### PR TITLE
react-tweet: Force dark theme

### DIFF
--- a/components/drops/view/part/DropPartMarkdown.tsx
+++ b/components/drops/view/part/DropPartMarkdown.tsx
@@ -294,7 +294,7 @@ function DropPartMarkdown({
 
   const renderTweetEmbed = (result: { href: string; tweetId: string }) => (
     <div className="tw-flex tw-items-stretch tw-w-full tw-gap-x-1">
-      <div className="tw-flex-1 tw-min-w-0">
+      <div className="tw-flex-1 tw-min-w-0" data-theme="dark">
         <Tweet id={result.tweetId} />
       </div>
       <ChatItemHrefButtons href={result.href} />


### PR DESCRIPTION
[react-tweet](https://react-tweet.vercel.app/#toggling-theme-manually) uses the `prefers-color-scheme` CSS media feature but the 6529 frontend doesn't. For aesthetics, tweets should therefore always use the dark theme.