### PR TITLE
Fix missing accessible name on login input

### DIFF
--- a/pages/access.tsx
+++ b/pages/access.tsx
@@ -64,6 +64,7 @@ export default function Access() {
           type="text"
           className={inputDisabled ? "text-center" : ""}
           defaultValue={inputDisabled ? "Go to 6529.io" : ""}
+          aria-label="Team Login"
           placeholder={inputDisabled ? "Go to 6529.io" : "Team Login"}
           onKeyDown={(event: React.KeyboardEvent<HTMLDivElement>): void => {
             if (event.key.toLowerCase() === "enter") {


### PR DESCRIPTION
## Summary
- add `aria-label` to the login input field

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*