### PR TITLE
Fix missing ARIA label

### DIFF
--- a/components/searchModal/SearchModal.tsx
+++ b/components/searchModal/SearchModal.tsx
@@ -60,7 +60,11 @@ function SearchModal(props: Readonly<Props>) {
             className={`${styles.modalInput}`}
             placeholder="Search for address, ENS or username"
           />
-          <Button className={styles.modalButton} onClick={addSearchWallet}>
+          <Button
+            className={styles.modalButton}
+            onClick={addSearchWallet}
+            aria-label="Add search wallet"
+          >
             +
           </Button>
         </InputGroup>


### PR DESCRIPTION
## Summary
- ensure add-wallet button is labelled for assistive tech

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*