### PR TITLE
Add accessible label to drop image container

### DIFF
--- a/components/drops/view/item/content/media/DropListItemContentMediaImage.tsx
+++ b/components/drops/view/item/content/media/DropListItemContentMediaImage.tsx
@@ -166,6 +166,7 @@ function DropListItemContentMediaImage({
                 className="tw-flex tw-flex-col tw-items-center"
                 onClick={(e) => e.stopPropagation()}
                 tabIndex={0}
+                aria-label="Full size drop media"
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
                     e.stopPropagation();


### PR DESCRIPTION
## Summary
- add `aria-label` to drop image container so it has an accessible name

## Testing
- `npm test` *(fails: jest not found)*