### PR TITLE
Fix missing ARIA label

### DIFF
--- a/components/delegation/DelegationFormParts.tsx
+++ b/components/delegation/DelegationFormParts.tsx
@@ -483,6 +483,7 @@ export function DelegationCloseButton(
       placement={"top"}
       theme={"light"}>
       <FontAwesomeIcon
+        aria-label={`Cancel ${props.title}`}
         className={styles.closeNewDelegationForm}
         icon={faTimesCircle}
         onClick={() => props.onHide()}></FontAwesomeIcon>


### PR DESCRIPTION
## Summary
- add accessible label to interactive FontAwesome icon button in Delegation form

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*