### PR TITLE
Fix threshold prop typo

### DIFF
--- a/components/distribution/Distribution.tsx
+++ b/components/distribution/Distribution.tsx
@@ -158,7 +158,7 @@ export default function DistributionPage(props: Readonly<Props>) {
   function printDistribution() {
     return (
       <>
-        <ScrollToButton threshhold={500} to="distribution-table" offset={0} />
+        <ScrollToButton threshold={500} to="distribution-table" offset={0} />
         <Container className="pt-5 pb-3" id={`distribution-table`}>
           <Row>
             <Col className={`d-flex justify-content-end align-items-center`}>

--- a/components/scrollTo/ScrollToButton.tsx
+++ b/components/scrollTo/ScrollToButton.tsx
@@ -6,7 +6,7 @@ import { faChevronUp } from "@fortawesome/free-solid-svg-icons";
 
 interface Props {
   to: string;
-  threshhold: number;
+  threshold: number;
   offset: number;
 }
 
@@ -16,9 +16,9 @@ export default function ScrollToButton(props: Readonly<Props>) {
   useEffect(() => {
     const target = document.getElementById(props.to);
     function handleScroll() {
-      const threshhold = props.threshhold + (target ? target.offsetTop : 0);
+      const threshold = props.threshold + (target ? target.offsetTop : 0);
 
-      if (window.pageYOffset > threshhold) {
+      if (window.pageYOffset > threshold) {
         setShowButton(true);
       } else {
         setShowButton(false);


### PR DESCRIPTION
## Summary
- rename `threshhold` prop in `ScrollToButton` to `threshold`
- update use of the prop and update calling component

## Testing
- `npm test` *(fails: jest not found)*