### PR TITLE
Fix missing aria-label on Delegation close icon

### DIFF
--- a/components/delegation/DelegationFormParts.tsx
+++ b/components/delegation/DelegationFormParts.tsx
@@ -485,7 +485,8 @@ export function DelegationCloseButton(
       <FontAwesomeIcon
         className={styles.closeNewDelegationForm}
         icon={faTimesCircle}
-        onClick={() => props.onHide()}></FontAwesomeIcon>
+        onClick={() => props.onHide()}
+        aria-label={`Cancel ${props.title}`}></FontAwesomeIcon>
     </Tippy>
   );
 }


### PR DESCRIPTION
## Summary
- add aria-label to the close icon in DelegationFormParts

## Testing
- `npm test` *(fails: jest not found)*