### PR TITLE
Fix typos in meme block components

### DIFF
--- a/components/block-picker/BlockPickerBlockNumberIncludes.tsx
+++ b/components/block-picker/BlockPickerBlockNumberIncludes.tsx
@@ -10,7 +10,7 @@ export default function BlockPickerBlockNumberIncludes({
   return (
     <div className="tw-w-full">
       <label className="tw-block tw-text-sm tw-font-normal tw-leading-5 tw-text-neutral-100">
-        Block no includes 
+        Block number includes
       </label>
       <div className="tw-mt-1 5">
         <input

--- a/components/block-picker/result/BlockPickerResultTableHeader.tsx
+++ b/components/block-picker/result/BlockPickerResultTableHeader.tsx
@@ -6,7 +6,7 @@ export default function BlockPickerResultTableHeader() {
           scope="col"
           className="tw-py-3 tw-pl-4 tw-pr-3 tw-whitespace-nowrap tw-text-left tw-text-[0.6875rem] tw-leading-[1.125rem] tw-font-medium tw-text-neutral-400 tw-uppercase tw-tracking-[0.25px] sm:tw-pl-6"
         >
-          Block inlcudes
+          Block includes
         </th>
         <th
           scope="col"


### PR DESCRIPTION
## Summary
- correct typo in table header text
- clarify block number includes label

## Testing
- `npm test --silent` *(fails: jest not found)*