### PR TITLE
Improve accessible name for team login input

### DIFF
--- a/pages/access.tsx
+++ b/pages/access.tsx
@@ -60,6 +60,7 @@ export default function Access() {
       {image && <LoginImage image={image} alt="access" />}
       <div className={styles.loginPrompt}>
         <input
+          aria-label="Team access code"
           disabled={inputDisabled}
           type="text"
           className={inputDisabled ? "text-center" : ""}


### PR DESCRIPTION
## Summary
- add aria label to the team login input on `/access`

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm test` *(fails: `jest: not found`)*