### PR TITLE
Improve accessible labels on user page

### DIFF
--- a/components/drops/view/item/rate/give/clap/DropListItemRateGiveClap.tsx
+++ b/components/drops/view/item/rate/give/clap/DropListItemRateGiveClap.tsx
@@ -231,6 +231,7 @@ export default function DropListItemRateGiveClap({
         <button
           disabled={!rate || !canVote}
           id={`clap-${randomID}`}
+          aria-label="Clap for drop"
           className={`${clapClasses} tw-border-none tw-flex-shrink-0 tw-flex tw-items-center tw-justify-center tw-relative tw-z-10 tw-outline-1 tw-outline-transparent tw-bg-current tw-transition tw-duration-300 tw-ease-out ${styles.clap}`}
           onClick={(e) => {
             e.stopPropagation();

--- a/components/user/user-page-header/about/UserPageHeaderAbout.tsx
+++ b/components/user/user-page-header/about/UserPageHeaderAbout.tsx
@@ -49,7 +49,7 @@ export default function UserPageHeaderAbout({
             onClick={onEditClick}
             disabled={!canEdit}
             type="button"
-            aria-label="Add an About statement"
+            aria-label={statement ? "Edit About statement" : "Add About statement"}
             className="tw-flex tw-items-center tw-gap-x-2 tw-text-iron-500 hover:tw-text-iron-200 tw-text-left tw-group tw-bg-transparent tw-border-none tw-m-0 tw-p-0 tw-relative tw-transition tw-duration-300 tw-ease-out"
           >
             <UserPageHeaderAboutStatement statement={statement} />

--- a/components/user/user-page-header/banner/UserPageHeaderBanner.tsx
+++ b/components/user/user-page-header/banner/UserPageHeaderBanner.tsx
@@ -31,6 +31,7 @@ export default function UserPageHeaderBanner({
         <div className="">
           <button
             onClick={() => setIsEditOpen(true)}
+            aria-label="Edit banner image"
             className="tw-w-full tw-h-full tw-bg-transparent tw-border-none tw-p-0"
           >
             <div className="edit-profile tw-absolute tw-inset-0 tw-bg-black/30">

--- a/components/user/user-page-header/name/UserPageHeaderNameWrapper.tsx
+++ b/components/user/user-page-header/name/UserPageHeaderNameWrapper.tsx
@@ -21,6 +21,7 @@ export default function UserPageHeaderNameWrapper({
       <button
         onClick={() => setIsEditNameOpen(true)}
         disabled={!canEdit}
+        aria-label="Edit display name"
         className={`${
           canEdit ? "hover:tw-text-neutral-400" : ""
         } tw-group tw-bg-transparent tw-border-none tw-m-0 tw-p-0 tw-relative tw-transition tw-duration-300 tw-ease-out`}

--- a/components/user/user-page-header/name/classification/UserPageClassificationWrapper.tsx
+++ b/components/user/user-page-header/name/classification/UserPageClassificationWrapper.tsx
@@ -21,6 +21,7 @@ export default function UserPageClassificationWrapper({
       <button
         onClick={() => setIsEditOpen(true)}
         disabled={!canEdit}
+        aria-label="Edit classification"
         className={`${
           canEdit ? "hover:tw-text-neutral-400" : ""
         } tw-group tw-bg-transparent tw-border-none tw-m-0 tw-p-0 tw-relative tw-transition tw-duration-300 tw-ease-out`}>

--- a/components/user/user-page-header/pfp/UserPageHeaderPfpWrapper.tsx
+++ b/components/user/user-page-header/pfp/UserPageHeaderPfpWrapper.tsx
@@ -21,6 +21,7 @@ export default function UserPageHeaderPfpWrapper({
       <button
         onClick={() => setIsEditPfpOpen(true)}
         disabled={!canEdit}
+        aria-label="Edit profile picture"
         className="tw-group tw-bg-transparent tw-border-none tw-relative tw-p-1 tw-rounded-lg"
       >
         {children}

--- a/components/user/utils/UserFollowBtn.tsx
+++ b/components/user/utils/UserFollowBtn.tsx
@@ -153,6 +153,7 @@ export default function UserFollowBtn({
           delay={250}>
           <button
             onClick={onDirectMessage}
+            aria-label="Send direct message"
             className={`${BUTTON_CLASSES[size]} tw-bg-iron-800 tw-ring-iron-800 tw-text-iron-300 hover:tw-bg-iron-700 hover:tw-ring-iron-700 tw-flex tw-items-center tw-cursor-pointer tw-rounded-lg tw-font-semibold tw-border-0 tw-ring-1 tw-ring-inset tw-transition tw-duration-300 tw-ease-out`}>
             {directMessageLoading ? (
               <CircleLoader size={CircleLoaderSize.SMALL} />

--- a/components/waves/drops/WaveDropActionsCopyLink.tsx
+++ b/components/waves/drops/WaveDropActionsCopyLink.tsx
@@ -53,7 +53,8 @@ const WaveDropActionsCopyLink: React.FC<WaveDropActionsCopyLinkProps> = ({
             isDisabled ? "tw-opacity-50 tw-cursor-default" : "tw-cursor-pointer"
           }`}
           onClick={copyToClipboard}
-          disabled={isDisabled}>
+          disabled={isDisabled}
+          aria-label="Copy drop link">
           <svg
             className={`tw-flex-shrink-0 tw-w-5 tw-h-5 tw-transition tw-ease-out tw-duration-300`}
             xmlns="http://www.w3.org/2000/svg"

--- a/components/waves/drops/WaveDropActionsOpen.tsx
+++ b/components/waves/drops/WaveDropActionsOpen.tsx
@@ -46,6 +46,7 @@ const WaveDropActionsOpen: React.FC<WaveDropActionsOpenProps> = ({ drop }) => {
       <button
         className="tw-text-iron-400 tw-px-2 desktop-hover:hover:tw-text-iron-50 tw-h-full tw-group tw-bg-transparent tw-rounded-full tw-border-0 tw-flex tw-items-center tw-gap-x-2 tw-text-[0.8125rem] tw-leading-5 tw-font-medium tw-transition tw-ease-out tw-duration-300"
         onClick={() => onDropClick(drop)}
+        aria-label="Open drop"
       >
         <svg
           width="24"

--- a/components/waves/drops/WaveDropActionsOptions.tsx
+++ b/components/waves/drops/WaveDropActionsOptions.tsx
@@ -23,6 +23,7 @@ const WaveDropActionsOptions: React.FC<WaveDropActionsOptionsProps> = ({
             setIsDeleteModalOpen(true);
           }}
           className="tw-text-iron-500 icon tw-px-2 tw-h-full tw-group tw-bg-transparent tw-rounded-full tw-border-0 tw-flex tw-items-center tw-gap-x-2 tw-text-[0.8125rem] tw-leading-5 tw-font-medium tw-transition tw-ease-out tw-duration-300"
+          aria-label="Delete drop"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/components/waves/drops/WaveDropActionsQuote.tsx
+++ b/components/waves/drops/WaveDropActionsQuote.tsx
@@ -38,6 +38,7 @@ const WaveDropActionsQuote: React.FC<WaveDropActionsQuoteProps> = ({
           }`}
           onClick={isQuoteAllowed ? onQuote : undefined}
           disabled={!isQuoteAllowed}
+          aria-label="Quote drop"
         >
           <svg
             className={`tw-flex-shrink-0 tw-w-5 tw-h-5 tw-transition tw-ease-out tw-duration-300 ${

--- a/components/waves/drops/WaveDropActionsReply.tsx
+++ b/components/waves/drops/WaveDropActionsReply.tsx
@@ -38,6 +38,7 @@ const WaveDropActionsReply: React.FC<WaveDropActionsReplyProps> = ({
           }`}
           onClick={canReply ? onReply : undefined}
           disabled={!canReply}
+          aria-label="Reply to drop"
         >
           <svg
             className={`tw-flex-shrink-0 tw-w-5 tw-h-5 tw-transition tw-ease-out tw-duration-300 ${

--- a/components/waves/drops/WaveDropFollowAuthor.tsx
+++ b/components/waves/drops/WaveDropFollowAuthor.tsx
@@ -160,6 +160,7 @@ export default function WaveDropFollowAuthor({
         }}
         disabled={mutating}
         className={`${classes[followState]} tw-text-iron-500 icon tw-px-2 tw-h-full tw-group tw-bg-transparent tw-rounded-full tw-border-0 tw-inline-flex tw-items-center tw-gap-x-1.5 tw-text-xs tw-leading-5 tw-font-medium tw-transition tw-ease-out tw-duration-300`}
+        aria-label={followState === FOLLOW_STATE.FOLLOWING ? `Unfollow ${drop.author.handle}` : `Follow ${drop.author.handle}`}
       >
         {mutating ? (
           <CircleLoader size={CircleLoaderSize.SMALL} />


### PR DESCRIPTION
## Summary
- add aria labels for editing controls in user header
- ensure direct message and drop action buttons have names
- add label for about statement button
- label clap button

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*