### PR TITLE
Add waves tests

### DIFF
--- a/__tests__/components/waves/Waves.test.tsx
+++ b/__tests__/components/waves/Waves.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AuthContext } from "../../components/auth/Auth";
+import Waves from "../../components/waves/Waves";
+import { ProfileConnectedStatus } from "../../entities/IProfile";
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: jest.fn(),
+}));
+
+// Simplified dynamic loader returning stub components
+jest.mock("next/dynamic", () => (importFn: any) => {
+  const fnStr = importFn.toString();
+  if (fnStr.includes("create-wave/CreateWave")) {
+    return () => <div data-testid="create-wave">CreateWave</div>;
+  }
+  if (fnStr.includes("create-dm/CreateDirectMessage")) {
+    return () => <div data-testid="create-dm">CreateDM</div>;
+  }
+  return () => null;
+});
+
+jest.mock("../../components/waves/list/WavesList", () => {
+  return function MockWavesList(props: any) {
+    return (
+      <div>
+        <button onClick={props.onCreateNewWave}>open-create-wave</button>
+        <button onClick={props.onCreateNewDirectMessage}>open-create-dm</button>
+      </div>
+    );
+  };
+});
+
+const { useSearchParams } = jest.requireMock("next/navigation");
+
+const baseAuth = {
+  connectedProfile: { handle: "alice" },
+  fetchingProfile: false,
+  receivedProfileProxies: [],
+  activeProfileProxy: null,
+  connectionStatus: ProfileConnectedStatus.HAVE_PROFILE,
+  showWaves: true,
+  requestAuth: jest.fn().mockResolvedValue({ success: true }),
+  setToast: jest.fn(),
+  setActiveProfileProxy: jest.fn(),
+  setTitle: jest.fn(),
+  title: "",
+};
+
+function renderWaves(params: Map<string, string | null>) {
+  (useSearchParams as jest.Mock).mockReturnValue({
+    get: (key: string) => params.get(key) ?? null,
+  });
+  return render(
+    <AuthContext.Provider value={baseAuth as any}>
+      <Waves />
+    </AuthContext.Provider>
+  );
+}
+
+it("shows CreateWave when ?new is present", () => {
+  renderWaves(new Map([["new", "1"]]));
+  expect(screen.getByTestId("create-wave")).toBeInTheDocument();
+});
+
+it("shows CreateDM when ?new-dm is present", () => {
+  renderWaves(new Map([["new-dm", "1"]]));
+  expect(screen.getByTestId("create-dm")).toBeInTheDocument();
+});
+
+it("switches view modes on button clicks", async () => {
+  const user = userEvent.setup();
+  renderWaves(new Map());
+  await user.click(screen.getByText("open-create-wave"));
+  expect(screen.getByTestId("create-wave")).toBeInTheDocument();
+  await user.click(screen.getByText("open-create-dm"));
+  expect(screen.getByTestId("create-dm")).toBeInTheDocument();
+});

--- a/__tests__/components/waves/list/WavesList.test.tsx
+++ b/__tests__/components/waves/list/WavesList.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import WavesList from "../../../components/waves/list/WavesList";
+import { AuthContext } from "../../../components/auth/Auth";
+import { ProfileConnectedStatus } from "../../../entities/IProfile";
+import { ApiWavesOverviewType } from "../../../generated/models/ApiWavesOverviewType";
+import { useRouter } from "next/router";
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock("../../../components/waves/list/header/WavesListHeader", () => (props: any) => (
+  <div>
+    <button onClick={() => props.setIdentity("bob")} data-testid="set-id" />
+    <button onClick={() => props.setIdentity(null)} data-testid="clear-id" />
+  </div>
+));
+
+jest.mock("../../../components/waves/list/WavesListWrapper", () => (props: any) => (
+  <div data-testid={`wrapper-${props.overviewType}`}>
+    <span data-testid={`showall-${props.overviewType}`}>{String(props.showAllType)}</span>
+    <button
+      onClick={() =>
+        props.setShowAllType(
+          props.showAllType === props.overviewType ? null : props.overviewType
+        )
+      }
+      data-testid={`toggle-${props.overviewType}`}
+    />
+  </div>
+));
+
+jest.mock("../../../components/waves/list/WavesListSearchResults", () => (props: any) => (
+  <div data-testid="search-results">{props.identity ?? ""}</div>
+));
+
+const push = jest.fn((url: any, _as?: any, _opts?: any) => {
+  router.pathname = url.pathname;
+  router.query = url.query;
+});
+const router = { pathname: "/waves", query: {}, push } as any;
+(useRouter as jest.Mock).mockReturnValue(router);
+
+const baseAuth = {
+  connectedProfile: { handle: "alice" },
+  fetchingProfile: false,
+  receivedProfileProxies: [],
+  activeProfileProxy: null,
+  connectionStatus: ProfileConnectedStatus.HAVE_PROFILE,
+  showWaves: true,
+  requestAuth: jest.fn().mockResolvedValue({ success: true }),
+  setToast: jest.fn(),
+  setActiveProfileProxy: jest.fn(),
+  setTitle: jest.fn(),
+  title: "",
+};
+
+function setup() {
+  return render(
+    <AuthContext.Provider value={baseAuth as any}>
+      <WavesList
+        showCreateNewButton
+        onCreateNewWave={jest.fn()}
+        onCreateNewDirectMessage={jest.fn()}
+      />
+    </AuthContext.Provider>
+  );
+}
+
+it("updates router and shows search results when identity changes", async () => {
+  const user = userEvent.setup();
+  setup();
+  expect(screen.queryByTestId("search-results")).not.toBeInTheDocument();
+  await user.click(screen.getByTestId("set-id"));
+  expect(screen.getByTestId("search-results")).toHaveTextContent("bob");
+  expect(push).toHaveBeenLastCalledWith(
+    { pathname: "/waves", query: { identity: "bob" } },
+    undefined,
+    { shallow: true }
+  );
+  await user.click(screen.getByTestId("clear-id"));
+  expect(screen.queryByTestId("search-results")).not.toBeInTheDocument();
+  expect(push).toHaveBeenLastCalledWith(
+    { pathname: "/waves", query: {} },
+    undefined,
+    { shallow: true }
+  );
+});
+
+it("toggles show all state", async () => {
+  const user = userEvent.setup();
+  setup();
+  const type = Object.values(ApiWavesOverviewType)[0];
+  const toggle = screen.getByTestId(`toggle-${type}`);
+  const label = () => screen.getByTestId(`showall-${type}`);
+  expect(label().textContent).toBe("null");
+  await user.click(toggle);
+  expect(label().textContent).toBe(type);
+  await user.click(toggle);
+  expect(label().textContent).toBe("null");
+});


### PR DESCRIPTION
## Summary
- add tests for Waves view modes
- add tests for WavesList search and show-all behaviour

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*