### PR TITLE
Add unit tests for wave helpers

### DIFF
--- a/__tests__/helpers/waves/create-wave.validation.test.ts
+++ b/__tests__/helpers/waves/create-wave.validation.test.ts
@@ -1,0 +1,49 @@
+import { getCreateWaveValidationErrors, CREATE_WAVE_VALIDATION_ERROR } from '../../../helpers/waves/create-wave.validation';
+import { ApiWaveType } from '../../../generated/models/ApiWaveType';
+import { ApiWaveCreditType } from '../../../generated/models/ApiWaveCreditType';
+import { CreateWaveStep } from '../../../types/waves.types';
+
+describe('create-wave.validation', () => {
+  const baseConfig: any = {
+    overview: { type: ApiWaveType.Rank, name: 'name', image: null },
+    groups: { canView: null, canDrop: null, canVote: null, canChat: null, admin: null },
+    dates: { submissionStartDate: 1, votingStartDate: 1, endDate: 2, firstDecisionTime: 0, subsequentDecisions: [], isRolling: false },
+    drops: { noOfApplicationsAllowedPerParticipant: null, requiredTypes: [], requiredMetadata: [], terms: null, signatureRequired: false, adminCanDeleteDrops: false },
+    chat: { enabled: true },
+    voting: { type: ApiWaveCreditType.Rep, category: 'cat', profileId: 'id', timeWeighted: { enabled: false, averagingInterval: 10, averagingIntervalUnit: 'minutes' } },
+    outcomes: [{ id: 1 }],
+    approval: { threshold: 1, thresholdTimeMs: 1 },
+  };
+
+  it('validates overview name required', () => {
+    const config = { ...baseConfig, overview: { ...baseConfig.overview, name: '' } };
+    const errors = getCreateWaveValidationErrors({ step: CreateWaveStep.OVERVIEW, config });
+    expect(errors).toContain(CREATE_WAVE_VALIDATION_ERROR.NAME_REQUIRED);
+  });
+
+  it('requires end date for rank waves', () => {
+    const config = { ...baseConfig, dates: { ...baseConfig.dates, endDate: null } };
+    const errors = getCreateWaveValidationErrors({ step: CreateWaveStep.DATES, config });
+    expect(errors).toContain(CREATE_WAVE_VALIDATION_ERROR.END_DATE_REQUIRED);
+  });
+
+  it('chat waves cannot have voting', () => {
+    const chatConfig = { ...baseConfig, overview: { type: ApiWaveType.Chat, name: 'n', image: null }, voting: { type: ApiWaveCreditType.Rep, category: 'c', profileId: 'p', timeWeighted: { enabled: false, averagingInterval: 5, averagingIntervalUnit: 'minutes' } } };
+    const errors = getCreateWaveValidationErrors({ step: CreateWaveStep.VOTING, config: chatConfig });
+    expect(errors).toContain(CREATE_WAVE_VALIDATION_ERROR.CHAT_WAVE_CANNOT_HAVE_VOTING);
+  });
+
+  it('approval threshold required for approve waves', () => {
+    const approveConfig = { ...baseConfig, overview: { type: ApiWaveType.Approve, name: 'n', image: null }, approval: { threshold: null, thresholdTimeMs: null } };
+    const errors = getCreateWaveValidationErrors({ step: CreateWaveStep.APPROVAL, config: approveConfig });
+    expect(errors).toContain(CREATE_WAVE_VALIDATION_ERROR.APPROVAL_THRESHOLD_REQUIRED);
+  });
+
+  it('detects duplicate required metadata', () => {
+    const drops = { ...baseConfig.drops, requiredMetadata: [{ key: 'a', type: 't' }, { key: 'a', type: 't2' }] };
+    const config = { ...baseConfig, drops };
+    const errors = getCreateWaveValidationErrors({ step: CreateWaveStep.DROPS, config });
+    expect(errors).toContain(CREATE_WAVE_VALIDATION_ERROR.DROPS_REQUIRED_METADATA_NON_UNIQUE);
+  });
+});
+

--- a/__tests__/helpers/waves/waves.helpers.test.ts
+++ b/__tests__/helpers/waves/waves.helpers.test.ts
@@ -1,0 +1,143 @@
+import { canEditWave, createDirectMessageWave, convertWaveToUpdateWave, getCreateWaveStepStatus } from '../../../helpers/waves/waves.helpers';
+import { CreateWaveStepStatus } from '../../../types/waves.types';
+
+jest.mock('../../../services/api/common-api', () => ({
+  commonApiPost: jest.fn(() => Promise.resolve('wave')),
+}));
+
+import { commonApiPost } from '../../../services/api/common-api';
+
+describe('waves.helpers', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getCreateWaveStepStatus', () => {
+    it('returns DONE when step index is less than active', () => {
+      expect(getCreateWaveStepStatus({ stepIndex: 0, activeStepIndex: 2 })).toBe(CreateWaveStepStatus.DONE);
+    });
+
+    it('returns ACTIVE when step index equals active', () => {
+      expect(getCreateWaveStepStatus({ stepIndex: 2, activeStepIndex: 2 })).toBe(CreateWaveStepStatus.ACTIVE);
+    });
+
+    it('returns PENDING when step index is greater than active', () => {
+      expect(getCreateWaveStepStatus({ stepIndex: 3, activeStepIndex: 2 })).toBe(CreateWaveStepStatus.PENDING);
+    });
+  });
+
+  describe('convertWaveToUpdateWave', () => {
+    it('maps fields correctly', () => {
+      const wave: any = {
+        name: 'wave1',
+        picture: 'pic.png',
+        voting: {
+          scope: { group: { id: 'vgroup' } },
+          credit_type: 'credit',
+          credit_category: 'cat',
+          creditor: { id: 'cred1' },
+          signature_required: false,
+          period: 10,
+          forbid_negative_votes: true,
+        },
+        visibility: { scope: { group: { id: 'vis' } } },
+        chat: { scope: { group: { id: 'chat' } }, enabled: true },
+        participation: {
+          scope: { group: { id: 'part' } },
+          no_of_applications_allowed_per_participant: 2,
+          required_media: null,
+          required_metadata: [],
+          signature_required: true,
+          period: 5,
+          terms: 'terms',
+        },
+        wave: {
+          admin_drop_deletion_enabled: true,
+          type: 'TYPE',
+          winning_thresholds: { min: 1, max: 3 },
+          max_winners: 2,
+          time_lock_ms: 100,
+          admin_group: { group: { id: 'admin' } },
+          decisions_strategy: 'strategy',
+        },
+        outcomes: [{ foo: 'bar' }],
+      };
+
+      const result = convertWaveToUpdateWave(wave);
+      expect(result).toEqual({
+        name: 'wave1',
+        picture: 'pic.png',
+        voting: {
+          scope: { group_id: 'vgroup' },
+          credit_type: 'credit',
+          credit_category: 'cat',
+          creditor_id: 'cred1',
+          signature_required: false,
+          period: 10,
+          forbid_negative_votes: true,
+        },
+        visibility: { scope: { group_id: 'vis' } },
+        chat: { scope: { group_id: 'chat' }, enabled: true },
+        participation: {
+          scope: { group_id: 'part' },
+          no_of_applications_allowed_per_participant: 2,
+          required_media: null,
+          required_metadata: [],
+          signature_required: true,
+          period: 5,
+          terms: 'terms',
+        },
+        wave: {
+          admin_drop_deletion_enabled: true,
+          type: 'TYPE',
+          winning_thresholds: { min: 1, max: 3 },
+          max_winners: 2,
+          time_lock_ms: 100,
+          admin_group: { group_id: 'admin' },
+          decisions_strategy: 'strategy',
+        },
+        outcomes: [{ foo: 'bar' }],
+      });
+    });
+  });
+
+  describe('canEditWave', () => {
+    const baseWave: any = {
+      author: { handle: 'author' },
+      wave: { authenticated_user_eligible_for_admin: false },
+    };
+
+    it('returns false without connected profile', () => {
+      expect(canEditWave({ connectedProfile: null, activeProfileProxy: null, wave: baseWave })).toBe(false);
+    });
+
+    it('returns false when proxy active', () => {
+      expect(canEditWave({ connectedProfile: { handle: 'author' } as any, activeProfileProxy: {} as any, wave: baseWave })).toBe(false);
+    });
+
+    it('returns true when user is author', () => {
+      expect(canEditWave({ connectedProfile: { handle: 'author' } as any, activeProfileProxy: null, wave: baseWave })).toBe(true);
+    });
+
+    it('returns true when eligible for admin', () => {
+      const wave = { ...baseWave, wave: { authenticated_user_eligible_for_admin: true } };
+      expect(canEditWave({ connectedProfile: { handle: 'other' } as any, activeProfileProxy: null, wave })).toBe(true);
+    });
+
+    it('returns false otherwise', () => {
+      expect(canEditWave({ connectedProfile: { handle: 'other' } as any, activeProfileProxy: null, wave: baseWave })).toBe(false);
+    });
+  });
+
+  describe('createDirectMessageWave', () => {
+    it('posts to API with addresses', async () => {
+      const result = await createDirectMessageWave({ addresses: ['a', 'b'] });
+      expect(commonApiPost).toHaveBeenCalledWith({
+        endpoint: 'waves/direct-message/new',
+        body: { identity_addresses: ['a', 'b'] },
+      });
+      expect(result).toBe('wave');
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add coverage for create-wave validation helpers
- test waves.helpers utilities including API call

## Testing
- `npm test --silent` *(fails: jest not found)*