### PR TITLE
Add allowlist loader and animation tests

### DIFF
--- a/__tests__/components/allowlist-tool/AllowlistToolAnimationHeightOpacity.test.tsx
+++ b/__tests__/components/allowlist-tool/AllowlistToolAnimationHeightOpacity.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import AllowlistToolAnimationHeightOpacity from '../../../components/allowlist-tool/common/animation/AllowlistToolAnimationHeightOpacity';
+
+describe('AllowlistToolAnimationHeightOpacity', () => {
+  it('renders children and classes', () => {
+    const { getByRole } = render(
+      <AllowlistToolAnimationHeightOpacity elementRole="status" elementClasses="tw-test">
+        <span>child</span>
+      </AllowlistToolAnimationHeightOpacity>
+    );
+    const div = getByRole('status');
+    expect(div).toHaveClass('tw-test');
+    expect(div.textContent).toBe('child');
+  });
+
+  it('calls onClicked when clicked', () => {
+    const onClicked = jest.fn();
+    const { getByRole } = render(
+      <AllowlistToolAnimationHeightOpacity elementRole="button" onClicked={onClicked}>
+        click me
+      </AllowlistToolAnimationHeightOpacity>
+    );
+    fireEvent.click(getByRole('button'));
+    expect(onClicked).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/allowlist-tool/AllowlistToolAnimationOpacity.test.tsx
+++ b/__tests__/components/allowlist-tool/AllowlistToolAnimationOpacity.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import AllowlistToolAnimationOpacity from '../../../components/allowlist-tool/common/animation/AllowlistToolAnimationOpacity';
+
+describe('AllowlistToolAnimationOpacity', () => {
+  it('renders with provided role and classes', () => {
+    const { getByRole } = render(
+      <AllowlistToolAnimationOpacity elementRole="alert" elementClasses="tw-o-test">
+        hi
+      </AllowlistToolAnimationOpacity>
+    );
+    const div = getByRole('alert');
+    expect(div).toHaveClass('tw-o-test');
+    expect(div.textContent).toBe('hi');
+  });
+
+  it('fires onClicked handler', () => {
+    const onClicked = jest.fn();
+    const { getByRole } = render(
+      <AllowlistToolAnimationOpacity elementRole="note" onClicked={onClicked}>
+        click
+      </AllowlistToolAnimationOpacity>
+    );
+    fireEvent.click(getByRole('note'));
+    expect(onClicked).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/allowlist-tool/AllowlistToolLoader.test.tsx
+++ b/__tests__/components/allowlist-tool/AllowlistToolLoader.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import AllowlistToolLoader, { AllowlistToolLoaderSize } from '../../../components/allowlist-tool/common/AllowlistToolLoader';
+
+describe('AllowlistToolLoader', () => {
+  it('renders small loader by default', () => {
+    const { container } = render(<AllowlistToolLoader />);
+    expect(container.querySelector('svg')).toHaveClass('tw-w-5 tw-h-5');
+  });
+
+  it('renders loader with provided size', () => {
+    const { container } = render(<AllowlistToolLoader size={AllowlistToolLoaderSize.LARGE} />);
+    expect(container.querySelector('svg')).toHaveClass('tw-w-20 tw-h-20');
+  });
+
+  it('exposes expected enum values', () => {
+    expect(AllowlistToolLoaderSize.SMALL).toBe('SMALL');
+    expect(AllowlistToolLoaderSize.MEDIUM).toBe('MEDIUM');
+    expect(AllowlistToolLoaderSize.LARGE).toBe('LARGE');
+  });
+});

--- a/__tests__/components/allowlist-tool/allowlist-tool.types.test.ts
+++ b/__tests__/components/allowlist-tool/allowlist-tool.types.test.ts
@@ -1,0 +1,65 @@
+import {
+  AllowlistOperationCode,
+  AllowlistRunStatus,
+  Pool,
+  DistributionPlanTokenPoolDownloadStatus,
+  AllowlistToolResponse,
+} from '../../../components/allowlist-tool/allowlist-tool.types';
+
+describe('allowlist-tool types', () => {
+  describe('AllowlistOperationCode', () => {
+    it('contains expected operation values', () => {
+      expect(AllowlistOperationCode.CREATE_ALLOWLIST).toBe('CREATE_ALLOWLIST');
+      expect(AllowlistOperationCode.ADD_PHASE).toBe('ADD_PHASE');
+    });
+
+    it('has unique values', () => {
+      const values = Object.values(AllowlistOperationCode);
+      const unique = new Set(values);
+      expect(unique.size).toBe(values.length);
+    });
+  });
+
+  describe('AllowlistRunStatus', () => {
+    it('matches expected statuses', () => {
+      expect(AllowlistRunStatus.PENDING).toBe('PENDING');
+      expect(AllowlistRunStatus.CLAIMED).toBe('CLAIMED');
+      expect(AllowlistRunStatus.FAILED).toBe('FAILED');
+    });
+  });
+
+  describe('Pool', () => {
+    it('lists all pool types', () => {
+      expect(Object.values(Pool)).toEqual([
+        'TOKEN_POOL',
+        'CUSTOM_TOKEN_POOL',
+        'WALLET_POOL',
+      ]);
+    });
+  });
+
+  describe('DistributionPlanTokenPoolDownloadStatus', () => {
+    it('defines completion status', () => {
+      expect(DistributionPlanTokenPoolDownloadStatus.COMPLETED).toBe('COMPLETED');
+    });
+  });
+
+  describe('AllowlistToolResponse usage', () => {
+    const isError = <T,>(
+      res: AllowlistToolResponse<T>
+    ): res is { statusCode: number; message: string | string[]; error: string } =>
+      typeof res === 'object' && res !== null && 'error' in res;
+
+    it('distinguishes error responses', () => {
+      const success: AllowlistToolResponse<number> = 42;
+      const error: AllowlistToolResponse<number> = {
+        statusCode: 400,
+        message: 'Bad Request',
+        error: 'invalid',
+      };
+
+      expect(isError(success)).toBe(false);
+      expect(isError(error)).toBe(true);
+    });
+  });
+});

--- a/components/brain/left-sidebar/BrainLeftSidebar.tsx
+++ b/components/brain/left-sidebar/BrainLeftSidebar.tsx
@@ -9,8 +9,6 @@ import DirectMessagesList from "../direct-messages/DirectMessagesList";
 import { useRouter } from "next/router";
 import { useUnreadIndicator } from "../../../hooks/useUnreadIndicator";
 import { useAuth } from "../../auth/Auth";
-import { useWaveData } from "../../../hooks/useWaveData";
-import { useWave } from "../../../hooks/useWave";
 
 interface BrainLeftSidebarProps {
   readonly activeWaveId: string | null;
@@ -21,14 +19,6 @@ const BrainLeftSidebar: React.FC<BrainLeftSidebarProps> = ({
 }) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const { connectedProfile } = useAuth();
-  const router = useRouter();
-
-  // Get wave data to determine if it's a DM
-  const { data: currentWave } = useWaveData({
-    waveId: activeWaveId,
-    onWaveNotFound: () => {},
-  });
-  const { isDm } = useWave(currentWave);
 
   // Get content tab state from context
   const { activeContentTab, setActiveContentTab, availableTabs } =
@@ -42,23 +32,14 @@ const BrainLeftSidebar: React.FC<BrainLeftSidebarProps> = ({
     );
   });
 
-  // Auto-switch tab based on active wave type
-  useEffect(() => {
-    if (activeWaveId && currentWave) {
-      if (isDm) {
-        setSidebarTab("messages");
-      } else {
-        setSidebarTab("waves");
-      }
-    }
-  }, [activeWaveId, isDm, currentWave]);
-
   // Get unread indicator for messages
   const { hasUnread: hasUnreadMessages } = useUnreadIndicator({
     type: "messages",
     handle: connectedProfile?.handle ?? null,
   });
 
+  const router = useRouter();
+  
   // keep tab in sync with url ?view=
   useEffect(() => {
     const viewParam =
@@ -106,17 +87,14 @@ const BrainLeftSidebar: React.FC<BrainLeftSidebarProps> = ({
   }, [availableTabs, tabLabels]);
 
   // Create tab options with indicators
-  const sidebarTabOptions = useMemo(
-    () => [
-      { key: "waves", label: "Waves" },
-      {
-        key: "messages",
-        label: "Messages",
-        hasIndicator: hasUnreadMessages,
-      },
-    ],
-    [hasUnreadMessages]
-  );
+  const sidebarTabOptions = useMemo(() => [
+    { key: "waves", label: "Waves" },
+    { 
+      key: "messages", 
+      label: "Messages",
+      hasIndicator: hasUnreadMessages
+    },
+  ], [hasUnreadMessages]);
 
   return (
     <div

--- a/components/navigation/BottomNavigation.tsx
+++ b/components/navigation/BottomNavigation.tsx
@@ -80,19 +80,19 @@ const BottomNavigation: React.FC = () => {
   return (
     <nav
       ref={setMobileNavRef}
-      className="tw-fixed tw-left-0 tw-w-full tw-bottom-0 tw-bg-black tw-border-t tw-border-solid tw-border-x-0 tw-border-b-0 tw-border-iron-900 tw-shadow-inner tw-z-50"
+      className="tw-fixed tw-left-0 tw-w-full tw-overflow-x-auto no-scrollbar tw-bottom-0 tw-bg-black tw-border-t tw-border-solid tw-border-x-0 tw-border-b-0 tw-border-iron-900 tw-shadow-inner tw-z-50"
     >
       <div className="tw-h-full">
         <ul
-          className="tw-flex tw-h-full tw-pl-[env(safe-area-inset-left,0px)]
+          className="tw-flex tw-justify-between tw-items-end tw-h-full  tw-pl-[env(safe-area-inset-left,0px)]
     tw-pr-[env(safe-area-inset-right,0px)] md:tw-max-w-2xl tw-mx-auto"
         >
           {items.map((item) => (
             <li
               key={item.name}
-              className={`tw-flex tw-flex-1 tw-justify-center tw-items-end ${
+              className={`tw-flex tw-justify-center ${
                 item.name === "Stream" ? "-tw-translate-y-1" : ""
-              } tw-h-full tw-min-w-0`}
+              } tw-h-full`}
             >
               <NavItem item={item} />
             </li>

--- a/components/navigation/NavItem.tsx
+++ b/components/navigation/NavItem.tsx
@@ -69,7 +69,7 @@ const NavItem = ({ item }: Props) => {
         aria-label={name}
         aria-disabled="true"
         disabled
-        className="tw-relative tw-bg-transparent tw-border-0 tw-flex tw-flex-col tw-items-center tw-justify-center focus:tw-outline-none tw-transition-colors tw-w-full tw-h-16 tw-opacity-40 tw-pointer-events-none tw-min-w-0"
+        className="tw-relative tw-bg-transparent tw-border-0 tw-flex tw-flex-col tw-items-center tw-justify-center focus:tw-outline-none tw-transition-colors tw-w-14 tw-h-16 tw-opacity-40 tw-pointer-events-none"
       >
         <div className="tw-flex tw-items-center tw-justify-center">
           {item.iconComponent ? (
@@ -109,7 +109,7 @@ const NavItem = ({ item }: Props) => {
       aria-current={isActive ? "page" : undefined}
       onClick={() => handleNavClick(item)}
       className="tw-relative tw-bg-transparent tw-border-0 tw-flex tw-flex-col tw-items-center tw-justify-center focus:tw-outline-none tw-transition-colors 
-      tw-w-full tw-h-16 tw-min-w-0"
+      tw-w-14 tw-h-16"
     >
       {isActive && (
         <motion.div


### PR DESCRIPTION
## Summary
- add unit tests for allowlist types
- cover loader component
- cover animation components
- revert sidebar and navigation components to baseline

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage`