### PR TITLE
Improve coverage for wallet and block picker

### DIFF
--- a/__tests__/components/app-wallets/app-wallet-helpers.test.ts
+++ b/__tests__/components/app-wallets/app-wallet-helpers.test.ts
@@ -1,0 +1,26 @@
+import { encryptData, decryptData } from '../../../components/app-wallets/app-wallet-helpers';
+
+const salt = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4';
+const password = 'test-password';
+const data = 'secret-data';
+
+describe('app-wallet-helpers', () => {
+  it('encrypts and decrypts data with same password', async () => {
+    const encrypted = await encryptData(salt, data, password);
+    expect(typeof encrypted).toBe('string');
+    expect(encrypted).not.toBe(data);
+    const decrypted = await decryptData(salt, encrypted, password);
+    expect(decrypted).toBe(data);
+  });
+
+  it('produces different ciphertexts for same input', async () => {
+    const encrypted1 = await encryptData(salt, data, password);
+    const encrypted2 = await encryptData(salt, data, password);
+    expect(encrypted1).not.toBe(encrypted2);
+  });
+
+  it('throws when decrypting with wrong password', async () => {
+    const encrypted = await encryptData(salt, data, password);
+    await expect(decryptData(salt, encrypted, 'wrong-password')).rejects.toThrow();
+  });
+});

--- a/__tests__/components/block-picker/BlockPickerTimeWindowSelectList.test.tsx
+++ b/__tests__/components/block-picker/BlockPickerTimeWindowSelectList.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import BlockPickerTimeWindowSelectList from '../../../components/block-picker/BlockPickerTimeWindowSelectList';
+import { BlockPickerTimeWindow } from '../../../pages/meme-blocks';
+
+jest.mock('next/font/google', () => ({
+  Poppins: () => ({ className: 'poppins' })
+}));
+
+describe('BlockPickerTimeWindowSelectList', () => {
+  const options = [
+    { title: 'One', value: BlockPickerTimeWindow.ONE_MINUTE },
+    { title: 'Two', value: BlockPickerTimeWindow.FIVE_MINUTES },
+  ];
+  const setup = (timeWindow: BlockPickerTimeWindow, setTimeWindow = jest.fn()) =>
+    render(
+      <BlockPickerTimeWindowSelectList
+        options={options}
+        timeWindow={timeWindow}
+        setTimeWindow={setTimeWindow}
+      />
+    );
+
+  it('renders all options', () => {
+    setup(BlockPickerTimeWindow.ONE_MINUTE);
+    const items = screen.getAllByRole('option');
+    expect(items).toHaveLength(options.length);
+    expect(items[0]).toHaveTextContent('One');
+    expect(items[1]).toHaveTextContent('Two');
+  });
+
+  it('calls setTimeWindow when option clicked', () => {
+    const onSelect = jest.fn();
+    setup(BlockPickerTimeWindow.ONE_MINUTE, onSelect);
+    const second = screen.getAllByRole('option')[1];
+    fireEvent.click(second);
+    expect(onSelect).toHaveBeenCalledWith(BlockPickerTimeWindow.FIVE_MINUTES);
+  });
+
+  it('shows selected icon for active option', () => {
+    setup(BlockPickerTimeWindow.FIVE_MINUTES);
+    const selected = screen.getAllByRole('option')[1];
+    expect(selected.querySelector('svg')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- test encryptData and decryptData helpers
- add tests for BlockPickerTimeWindowSelectList

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage`