### PR TITLE
Add tests for select menu and app wallets

### DIFF
--- a/__tests__/components/allowlist-tool/common/select-menu-multiple/AllowlistToolSelectMenuMultiple.test.tsx
+++ b/__tests__/components/allowlist-tool/common/select-menu-multiple/AllowlistToolSelectMenuMultiple.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AllowlistToolSelectMenuMultiple, { AllowlistToolSelectMenuMultipleOption } from '../../../../../components/allowlist-tool/common/select-menu-multiple/AllowlistToolSelectMenuMultiple';
+jest.mock('../../../../../components/allowlist-tool/common/animation/AllowlistToolAnimationWrapper', () => (props: any) => <div data-testid="wrapper">{props.children}</div>);
+
+// Mock framer-motion to avoid animations and capture useAnimate
+const animateMock = jest.fn();
+const iconScope = { current: {} };
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: jest.fn(({ children, ...props }) => <div {...props}>{children}</div>),
+  },
+  useAnimate: () => [iconScope, animateMock],
+}));
+
+// Capture callbacks provided to react-use hooks
+let clickAwayCb: () => void;
+let keyPressCb: () => void;
+jest.mock('react-use', () => ({
+  useClickAway: (_ref: any, cb: () => void) => {
+    clickAwayCb = cb;
+  },
+  useKeyPressEvent: (_key: string, cb: () => void) => {
+    keyPressCb = cb;
+  },
+}));
+
+const options: AllowlistToolSelectMenuMultipleOption[] = [
+  { title: 'First', subTitle: null, value: '1' },
+  { title: 'Second', subTitle: null, value: '2' },
+  { title: 'Third', subTitle: null, value: '3' },
+];
+
+function renderComponent(selected: AllowlistToolSelectMenuMultipleOption[] = [], toggle = jest.fn()) {
+  return render(
+    <AllowlistToolSelectMenuMultiple
+      label="Label"
+      placeholder="Choose"
+      selectedOptions={selected}
+      toggleSelectedOption={toggle}
+      options={options}
+      allSelectedTitle="All"
+      someSelectedTitleSuffix="selected"
+    />
+  );
+}
+
+describe('AllowlistToolSelectMenuMultiple', () => {
+  beforeEach(() => {
+    animateMock.mockClear();
+  });
+
+  it('shows label and placeholder initially', () => {
+    renderComponent();
+    expect(screen.getByText('Label')).toBeInTheDocument();
+    expect(screen.getByText('Choose')).toBeInTheDocument();
+    expect(animateMock).toHaveBeenCalled();
+    expect(animateMock.mock.calls[0][1]).toEqual({ rotate: -90 });
+  });
+
+  it('opens and closes dropdown via click and clickAway', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    await user.click(screen.getByRole('button'));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    expect(animateMock).toHaveBeenLastCalledWith(iconScope.current, { rotate: 0 });
+
+    act(() => {
+      clickAwayCb();
+    });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('closes dropdown on escape key', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    await user.click(screen.getByRole('button'));
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    act(() => {
+      keyPressCb();
+    });
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('updates title based on selections', () => {
+    const first = renderComponent([options[0]]);
+    expect(screen.getByText('First')).toBeInTheDocument();
+    first.unmount();
+
+    const all = renderComponent(options);
+    expect(screen.getByText('All')).toBeInTheDocument();
+    all.unmount();
+
+    renderComponent([options[0], options[1]]);
+    expect(screen.getByText('2 selected')).toBeInTheDocument();
+  });
+
+  it('calls toggleSelectedOption when option clicked', async () => {
+    const user = userEvent.setup();
+    const toggle = jest.fn();
+    renderComponent([], toggle);
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByText('First'));
+    expect(toggle).toHaveBeenCalledWith(options[0]);
+  });
+});

--- a/__tests__/components/app-wallets/AppWallets.test.tsx
+++ b/__tests__/components/app-wallets/AppWallets.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AppWallets from '../../../components/app-wallets/AppWallets';
+import { useAppWallets } from '../../../components/app-wallets/AppWalletsContext';
+import { useRouter } from 'next/router';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+
+jest.mock('../../../components/app-wallets/AppWalletsContext');
+jest.mock('../../../components/app-wallets/AppWalletCard', () => (props: any) => <div data-testid="card">{props.wallet.address}</div>);
+jest.mock('../../../components/app-wallets/AppWalletsUnsupported', () => () => <div data-testid="unsupported" />);
+jest.mock('../../../components/app-wallets/AppWalletModal', () => ({ CreateAppWalletModal: (props: any) => <div data-testid="modal">{props.show ? 'open' : 'closed'}</div> }));
+
+const push = jest.fn();
+(useRouter as jest.Mock).mockReturnValue({ push });
+
+const mockUseAppWallets = useAppWallets as jest.Mock;
+
+function setup(value: any) {
+  mockUseAppWallets.mockReturnValue(value);
+  return render(<AppWallets />);
+}
+
+describe('AppWallets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows unsupported message when not supported', () => {
+    setup({ appWalletsSupported: false, fetchingAppWallets: false, appWallets: [] });
+    expect(screen.getByTestId('unsupported')).toBeInTheDocument();
+  });
+
+  it('shows loading state when fetching', () => {
+    setup({ appWalletsSupported: true, fetchingAppWallets: true, appWallets: [] });
+    expect(screen.getByText(/Fetching wallets/)).toBeInTheDocument();
+  });
+
+  it('shows no wallets message when list empty', () => {
+    setup({ appWalletsSupported: true, fetchingAppWallets: false, appWallets: [] });
+    expect(screen.getByText('No wallets found')).toBeInTheDocument();
+  });
+
+  it('renders wallets and handles buttons', async () => {
+    const user = userEvent.setup();
+    setup({ appWalletsSupported: true, fetchingAppWallets: false, appWallets: [{ address: '0x1' }] });
+    expect(screen.getByTestId('card')).toHaveTextContent('0x1');
+    expect(screen.getByTestId('modal')).toHaveTextContent('closed');
+    await user.click(screen.getByRole('button', { name: /Create Wallet/i }));
+    expect(screen.getByTestId('modal')).toHaveTextContent('open');
+    await user.click(screen.getByRole('button', { name: /Import Wallet/i }));
+    expect(push).toHaveBeenCalledWith('/tools/app-wallets/import-wallet');
+  });
+});


### PR DESCRIPTION
## Summary
- add comprehensive tests for AllowlistToolSelectMenuMultiple
- add test suite for AppWallets component

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage` *(fails to reach target: current 5.12%)*