### PR TITLE
Add coverage for AppWalletImport and BlockPickerRow

### DIFF
--- a/__tests__/components/app-wallets/AppWalletImport.test.tsx
+++ b/__tests__/components/app-wallets/AppWalletImport.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AppWalletImport from '../../../components/app-wallets/AppWalletImport';
+import { useAppWallets } from '../../../components/app-wallets/AppWalletsContext';
+import { useAuth } from '../../../components/auth/Auth';
+import { ethers } from 'ethers';
+
+jest.mock('next/image', () => ({ __esModule: true, default: (props: any) => <img {...props} /> }));
+jest.mock('next/link', () => ({ __esModule: true, default: ({ href, children }: any) => <a href={href}>{children}</a> }));
+jest.mock('next/router', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock('../../../hooks/useCapacitor', () => ({ __esModule: true, default: () => ({ isCapacitor: false }) }));
+jest.mock('@fortawesome/react-fontawesome', () => ({ FontAwesomeIcon: () => <svg data-testid="icon" /> }));
+jest.mock('../../../components/app-wallets/AppWalletsContext');
+jest.mock('../../../components/auth/Auth');
+jest.mock('ethers', () => ({ ethers: { Wallet: jest.fn() } }));
+
+const mockedUseAppWallets = useAppWallets as jest.Mock;
+const mockedUseAuth = useAuth as jest.Mock;
+const walletMock = ethers.Wallet as unknown as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedUseAuth.mockReturnValue({ setToast: jest.fn() });
+  walletMock.mockReturnValue({ address: '0xabc', privateKey: '0x123' });
+});
+
+describe('AppWalletImport', () => {
+  it('renders unsupported message when app wallets are not supported', () => {
+    mockedUseAppWallets.mockReturnValue({ appWalletsSupported: false });
+    render(<AppWalletImport />);
+    expect(screen.getByText(/App Wallets are not supported on this platform/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /take me home/i })).toHaveAttribute('href', '/');
+  });
+
+  it('can switch between mnemonic and private key input', async () => {
+    mockedUseAppWallets.mockReturnValue({ appWalletsSupported: true });
+    const user = userEvent.setup();
+    render(<AppWalletImport />);
+    expect(screen.getByPlaceholderText('word 1')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /private key/i }));
+    expect(screen.getByPlaceholderText(/private key/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /mnemonic/i }));
+    expect(screen.getByPlaceholderText('word 1')).toBeInTheDocument();
+  });
+
+  it('shows error when validating invalid private key', async () => {
+    mockedUseAppWallets.mockReturnValue({ appWalletsSupported: true });
+    walletMock.mockImplementationOnce(() => { throw new Error('invalid'); });
+    const user = userEvent.setup();
+    render(<AppWalletImport />);
+    await user.click(screen.getByRole('button', { name: /private key/i }));
+    await user.type(screen.getByPlaceholderText(/private key/i), 'badkey');
+    await user.click(screen.getByRole('button', { name: /^validate$/i }));
+    expect(screen.getByText(/Error: invalid/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/block-picker/BlockPickerResultTableRow.test.tsx
+++ b/__tests__/components/block-picker/BlockPickerResultTableRow.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BlockPickerResultTableRow from '../../../components/block-picker/result/BlockPickerResultTableRow';
+
+jest.mock('../../../components/allowlist-tool/common/modals/AllowlistToolCommonModalWrapper', () => ({
+  __esModule: true,
+  default: ({ children, showModal, onClose }: any) => showModal ? (
+    <div data-testid="modal">
+      <button aria-label="Close" onClick={(e: any) => { e.stopPropagation(); onClose(); }}>Close</button>
+      {children}
+    </div>
+  ) : null,
+  AllowlistToolModalSize: { X_LARGE: 'X_LARGE' },
+}));
+
+jest.mock('../../../components/block-picker/result/BlockPickerResultTableRowModal', () => ({
+  __esModule: true,
+  default: ({ predictedBlock }: any) => <div>{`Blocks that include ${predictedBlock.blockNumberIncludes}`}</div>,
+}));
+
+describe('BlockPickerResultTableRow', () => {
+  const predictedBlock = {
+    blockNumberIncludes: 111,
+    count: 3,
+    blockNumbers: [100, 101, 102],
+  };
+
+  it('renders row data and toggles modal on click', async () => {
+    const user = userEvent.setup();
+    render(
+      <table><tbody>
+        <BlockPickerResultTableRow predictedBlock={predictedBlock} />
+      </tbody></table>
+    );
+
+    expect(screen.getByText('111')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('row'));
+    expect(screen.getByTestId('modal')).toBeInTheDocument();
+    expect(screen.getByText('Blocks that include 111')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /close/i }));
+    expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add test suite for AppWalletImport component
- add test suite for BlockPickerResultTableRow

## Testing
- `npm run test --silent`
- `npm run lint`
- `npm run type-check`
