### PR TITLE
Add unit tests for allowlist tool utilities

### DIFF
--- a/__tests__/components/allowlist-tool/AllowlistToolTypes.test.ts
+++ b/__tests__/components/allowlist-tool/AllowlistToolTypes.test.ts
@@ -1,0 +1,29 @@
+import {
+  AllowlistOperationCode,
+  AllowlistRunStatus,
+  DistributionPlanTokenPoolDownloadStatus,
+  Pool,
+} from '../../../components/allowlist-tool/allowlist-tool.types';
+
+describe('allowlist-tool types', () => {
+  it('should expose correct AllowlistOperationCode values', () => {
+    expect(AllowlistOperationCode.CREATE_ALLOWLIST).toBe('CREATE_ALLOWLIST');
+    expect(AllowlistOperationCode.ADD_PHASE).toBe('ADD_PHASE');
+  });
+
+  it('should expose correct AllowlistRunStatus values', () => {
+    expect(AllowlistRunStatus.PENDING).toBe('PENDING');
+    expect(AllowlistRunStatus.CLAIMED).toBe('CLAIMED');
+    expect(AllowlistRunStatus.FAILED).toBe('FAILED');
+  });
+
+  it('should expose correct Pool enumeration values', () => {
+    expect(Pool.TOKEN_POOL).toBe('TOKEN_POOL');
+    expect(Pool.CUSTOM_TOKEN_POOL).toBe('CUSTOM_TOKEN_POOL');
+    expect(Pool.WALLET_POOL).toBe('WALLET_POOL');
+  });
+
+  it('should expose correct DistributionPlanTokenPoolDownloadStatus values', () => {
+    expect(DistributionPlanTokenPoolDownloadStatus.COMPLETED).toBe('COMPLETED');
+  });
+});

--- a/__tests__/components/allowlist-tool/common/select-menu-multiple/AllowlistToolSelectMenuMultipleListItem.test.tsx
+++ b/__tests__/components/allowlist-tool/common/select-menu-multiple/AllowlistToolSelectMenuMultipleListItem.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import AllowlistToolSelectMenuMultipleListItem from '../../../../../components/allowlist-tool/common/select-menu-multiple/AllowlistToolSelectMenuMultipleListItem';
+import { AllowlistToolSelectMenuMultipleOption } from '../../../../../components/allowlist-tool/common/select-menu-multiple/AllowlistToolSelectMenuMultiple';
+
+describe('AllowlistToolSelectMenuMultipleListItem', () => {
+  const option: AllowlistToolSelectMenuMultipleOption = { value: '1', title: 'Item 1', subTitle: 'Sub' };
+  const optionNoSub: AllowlistToolSelectMenuMultipleOption = { value: '2', title: 'Item 2', subTitle: null };
+  const toggle = jest.fn();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders title and subtitle when provided', () => {
+    render(
+      <AllowlistToolSelectMenuMultipleListItem option={option} selectedOptions={[]} toggleSelectedOption={toggle} />
+    );
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+    expect(screen.getByText('Sub')).toBeInTheDocument();
+  });
+
+  it('calls toggleSelectedOption on click', () => {
+    const { container } = render(
+      <AllowlistToolSelectMenuMultipleListItem option={optionNoSub} selectedOptions={[]} toggleSelectedOption={toggle} />
+    );
+    const li = container.querySelector('li') as HTMLElement;
+    fireEvent.click(li);
+    expect(toggle).toHaveBeenCalledWith(optionNoSub);
+  });
+
+  it('shows check icon when option is selected', () => {
+    const { container } = render(
+      <AllowlistToolSelectMenuMultipleListItem option={optionNoSub} selectedOptions={[optionNoSub]} toggleSelectedOption={toggle} />
+    );
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('does not show check icon when option is not selected', () => {
+    const { container } = render(
+      <AllowlistToolSelectMenuMultipleListItem option={optionNoSub} selectedOptions={[]} toggleSelectedOption={toggle} />
+    );
+    expect(container.querySelector('svg')).toBeNull();
+  });
+});

--- a/__tests__/components/allowlist-tool/icons/AllowlistToolCsvIcon.test.tsx
+++ b/__tests__/components/allowlist-tool/icons/AllowlistToolCsvIcon.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import AllowlistToolCsvIcon from '../../../../components/allowlist-tool/icons/AllowlistToolCsvIcon';
+
+describe('AllowlistToolCsvIcon', () => {
+  it('renders svg with expected attributes', () => {
+    const { container } = render(<AllowlistToolCsvIcon />);
+    const svg = container.querySelector('svg') as SVGElement;
+    expect(svg).toHaveAttribute('viewBox', '0 0 71 80');
+    expect(svg).toHaveClass('tw-h-auto tw-w-auto tw-text-[#76bc99]');
+  });
+});

--- a/__tests__/components/block-picker/BlockPickerBlockNumberIncludes.test.tsx
+++ b/__tests__/components/block-picker/BlockPickerBlockNumberIncludes.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import BlockPickerBlockNumberIncludes from '../../../components/block-picker/BlockPickerBlockNumberIncludes';
+
+describe('BlockPickerBlockNumberIncludes', () => {
+  it('renders with provided value', () => {
+    render(
+      <BlockPickerBlockNumberIncludes blockNumberIncludes="42" setBlockNumberIncludes={() => {}} />
+    );
+    const input = screen.getByPlaceholderText('e.g. 42, 69, 42069, 6529') as HTMLInputElement;
+    expect(input.value).toBe('42');
+  });
+
+  it('calls setBlockNumberIncludes on change', () => {
+    const setValue = jest.fn();
+    render(
+      <BlockPickerBlockNumberIncludes blockNumberIncludes="" setBlockNumberIncludes={setValue} />
+    );
+    const input = screen.getByPlaceholderText('e.g. 42, 69, 42069, 6529');
+    fireEvent.change(input, { target: { value: '69' } });
+    expect(setValue).toHaveBeenCalledWith('69');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for allowlist tool types
- add tests for SelectMenuMultiple list item
- add icon component test
- add block picker input test

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage` *(fails: coverage below target)*