### PR TITLE
Increase coverage for wallet and brain components

### DIFF
--- a/__tests__/components/app-wallets/AppWalletCard.test.tsx
+++ b/__tests__/components/app-wallets/AppWalletCard.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import AppWalletCard from '../../../components/app-wallets/AppWalletCard';
+
+// Mock next/link to simply render an anchor
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children }: any) => <a href={href}>{children}</a>,
+}));
+
+// Mock AppWalletAvatar to avoid image complexities
+jest.mock('../../../components/app-wallets/AppWalletAvatar', () => ({
+  __esModule: true,
+  default: ({ address }: any) => <div data-testid="avatar">{address}</div>,
+}));
+
+describe('AppWalletCard', () => {
+  const wallet = {
+    name: 'Test Wallet',
+    created_at: 0,
+    address: '0xABCDEF',
+    address_hashed: '',
+    mnemonic: '',
+    private_key: '',
+    imported: false,
+  };
+
+  it('renders wallet info and link', () => {
+    render(<AppWalletCard wallet={wallet} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', `/tools/app-wallets/${wallet.address}`);
+    expect(screen.getByText(wallet.name)).toBeInTheDocument();
+    expect(screen.queryByText('(imported)')).not.toBeInTheDocument();
+    expect(screen.getByTestId('avatar')).toHaveTextContent(wallet.address);
+    expect(screen.getByText(wallet.address.toLowerCase())).toBeInTheDocument();
+  });
+
+  it('shows imported label when wallet is imported', () => {
+    render(<AppWalletCard wallet={{ ...wallet, imported: true }} />);
+    expect(screen.getByText('(imported)')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/block-picker/advanced/BlockPickerAdvancedItemBlock.test.tsx
+++ b/__tests__/components/block-picker/advanced/BlockPickerAdvancedItemBlock.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import BlockPickerAdvancedItemBlock from '../../../../components/block-picker/advanced/BlockPickerAdvancedItemBlock';
+
+jest.useFakeTimers();
+
+const mockCopy = jest.fn();
+
+jest.mock('react-use', () => ({
+  useCopyToClipboard: () => [null, mockCopy],
+}));
+
+describe('BlockPickerAdvancedItemBlock', () => {
+  beforeEach(() => {
+    mockCopy.mockClear();
+  });
+
+  it('renders link with highlighted parts', () => {
+    render(<BlockPickerAdvancedItemBlock block={12345} blockParts={34} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', 'https://etherscan.io/block/countdown/12345');
+    expect(link).toHaveTextContent('12345');
+    const highlight = screen.getByText('34');
+    expect(highlight).toHaveClass('tw-text-error');
+    expect(screen.queryByText('Copied')).not.toBeInTheDocument();
+  });
+
+  it('copies block number to clipboard on click', () => {
+    const { container } = render(<BlockPickerAdvancedItemBlock block={222} blockParts={2} />);
+    const svg = container.querySelector('svg') as SVGElement;
+    fireEvent.click(svg);
+    expect(mockCopy).toHaveBeenCalledWith('222');
+    expect(screen.getByText('Copied')).toBeInTheDocument();
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(screen.queryByText('Copied')).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/block-picker/result/BlockPickerResultTableHeader.test.tsx
+++ b/__tests__/components/block-picker/result/BlockPickerResultTableHeader.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import BlockPickerResultTableHeader from '../../../../components/block-picker/result/BlockPickerResultTableHeader';
+
+describe('BlockPickerResultTableHeader', () => {
+  it('renders three column headers', () => {
+    render(<table><BlockPickerResultTableHeader /></table>);
+    const headers = screen.getAllByRole('columnheader');
+    expect(headers).toHaveLength(3);
+    expect(headers[0]).toHaveTextContent('Block includes');
+    expect(headers[1]).toHaveTextContent('Count');
+    expect(headers[2]).toHaveTextContent('');
+  });
+});

--- a/__tests__/components/brain/Brain.test.tsx
+++ b/__tests__/components/brain/Brain.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+let useBreakpointMock = jest.fn();
+
+jest.mock('react-use', () => ({
+  createBreakpoint: () => useBreakpointMock,
+}));
+
+jest.mock('../../../components/brain/BrainMobile', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div data-testid="mobile">{children}</div>,
+}));
+
+jest.mock('../../../components/brain/BrainDesktop', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div data-testid="desktop">{children}</div>,
+}));
+
+import Brain from '../../../components/brain/Brain';
+
+describe('Brain', () => {
+  beforeEach(() => {
+    useBreakpointMock.mockReset();
+  });
+
+  it('renders mobile version when breakpoint is S', () => {
+    useBreakpointMock.mockReturnValue('S');
+    render(<Brain>child</Brain>);
+    expect(screen.getByTestId('mobile')).toBeInTheDocument();
+    expect(screen.getByText('child')).toBeInTheDocument();
+    expect(screen.queryByTestId('desktop')).not.toBeInTheDocument();
+  });
+
+  it('renders desktop version otherwise', () => {
+    useBreakpointMock.mockReturnValue('LG');
+    render(<Brain>desk</Brain>);
+    expect(screen.getByTestId('desktop')).toBeInTheDocument();
+    expect(screen.getByText('desk')).toBeInTheDocument();
+    expect(screen.queryByTestId('mobile')).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/brain/content/BrainContentPinnedWaves.test.tsx
+++ b/__tests__/components/brain/content/BrainContentPinnedWaves.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const addId = jest.fn();
+const removeId = jest.fn();
+
+jest.mock('../../../../hooks/usePinnedWaves', () => ({
+  usePinnedWaves: () => ({ pinnedIds: mockPinnedIds, addId, removeId }),
+}));
+
+let mockPinnedIds: string[] = [];
+
+const replace = jest.fn();
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: mockQuery, replace }),
+}));
+
+jest.mock('../../../../components/brain/content/BrainContentPinnedWave', () => ({
+  __esModule: true,
+  default: ({ waveId, onRemove }: any) => (
+    <div data-testid={`wave-${waveId}`} onClick={() => onRemove(waveId)}>wave {waveId}</div>
+  ),
+}));
+
+import BrainContentPinnedWaves from '../../../../components/brain/content/BrainContentPinnedWaves';
+
+beforeAll(() => {
+  (window as any).matchMedia = (window as any).matchMedia || (() => ({ matches: false, addListener: jest.fn(), removeListener: jest.fn() }));
+  (global as any).ResizeObserver = class { observe() {}; unobserve() {}; disconnect() {}; };
+});
+
+let mockQuery: any = {};
+
+describe('BrainContentPinnedWaves', () => {
+  beforeEach(() => {
+    addId.mockClear();
+    removeId.mockClear();
+    replace.mockClear();
+    mockPinnedIds = [];
+    mockQuery = {};
+  });
+
+  it('returns null when no pinned waves', () => {
+    const { container } = render(<BrainContentPinnedWaves />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders pinned waves and handles removal', async () => {
+    mockPinnedIds = ['1', '2'];
+    mockQuery = { wave: '1' };
+    const user = userEvent.setup();
+    render(<BrainContentPinnedWaves />);
+    await waitFor(() => expect(addId).toHaveBeenCalledWith('1'));
+    const wave1 = screen.getByTestId('wave-1');
+    const wave2 = screen.getByTestId('wave-2');
+    expect(wave1).toBeInTheDocument();
+    expect(wave2).toBeInTheDocument();
+    await user.click(wave1);
+    expect(removeId).toHaveBeenCalledWith('1');
+    expect(replace).toHaveBeenCalledWith('/my-stream', undefined, { shallow: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for AppWalletCard
- cover BlockPickerAdvancedItemBlock utilities
- test BlockPickerResultTableHeader rendering
- add Brain component responsive tests
- verify BrainContentPinnedWaves behavior

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run improve-coverage`