### PR TITLE
Add tests to improve frontend coverage

### DIFF
--- a/__tests__/components/allowlist-tool/common/modals/AllowlistToolCommonModalWrapper.test.tsx
+++ b/__tests__/components/allowlist-tool/common/modals/AllowlistToolCommonModalWrapper.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import AllowlistToolCommonModalWrapper, { AllowlistToolModalSize } from '../../../../../components/allowlist-tool/common/modals/AllowlistToolCommonModalWrapper';
+
+jest.mock('react-use', () => ({
+  useClickAway: (ref: React.RefObject<HTMLElement>, handler: () => void) => {
+    React.useEffect(() => {
+      const listener = (e: MouseEvent) => {
+        if (ref.current && !ref.current.contains(e.target as Node)) {
+          handler();
+        }
+      };
+      document.addEventListener('mousedown', listener);
+      return () => document.removeEventListener('mousedown', listener);
+    }, [ref, handler]);
+  },
+  useKeyPressEvent: (key: string, handler: () => void) => {
+    React.useEffect(() => {
+      const listener = (e: KeyboardEvent) => {
+        if (e.key === key) {
+          handler();
+        }
+      };
+      window.addEventListener('keydown', listener);
+      return () => window.removeEventListener('keydown', listener);
+    }, [key, handler]);
+  },
+}));
+
+describe('AllowlistToolCommonModalWrapper', () => {
+  it('does not render when showModal is false', () => {
+    const handleClose = jest.fn();
+    render(
+      <AllowlistToolCommonModalWrapper showModal={false} onClose={handleClose} title="Hidden">
+        <div>content</div>
+      </AllowlistToolCommonModalWrapper>
+    );
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(handleClose).not.toHaveBeenCalled();
+  });
+
+  it('renders with title and children when showModal is true', () => {
+    const handleClose = jest.fn();
+    render(
+      <AllowlistToolCommonModalWrapper showModal={true} onClose={handleClose} title="My Modal">
+        <div data-testid="child">content</div>
+      </AllowlistToolCommonModalWrapper>
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('My Modal')).toBeInTheDocument();
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('hides the title when showTitle is false', () => {
+    const handleClose = jest.fn();
+    render(
+      <AllowlistToolCommonModalWrapper showModal={true} onClose={handleClose} title="Title" showTitle={false}>
+        <div>content</div>
+      </AllowlistToolCommonModalWrapper>
+    );
+    expect(screen.queryByText('Title')).toBeNull();
+  });
+
+  it('calls onClose when close button is clicked', () => {
+    const handleClose = jest.fn();
+    render(
+      <AllowlistToolCommonModalWrapper showModal={true} onClose={handleClose} title="Close Test">
+        <div>content</div>
+      </AllowlistToolCommonModalWrapper>
+    );
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when Escape key is pressed', () => {
+    const handleClose = jest.fn();
+    render(
+      <AllowlistToolCommonModalWrapper showModal={true} onClose={handleClose} title="Key Test">
+        <div>content</div>
+      </AllowlistToolCommonModalWrapper>
+    );
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when clicking outside the modal', () => {
+    const handleClose = jest.fn();
+    render(
+      <AllowlistToolCommonModalWrapper showModal={true} onClose={handleClose} title="Outside Test">
+        <div>content</div>
+      </AllowlistToolCommonModalWrapper>
+    );
+    const overlay = document.querySelector('.tw-bg-opacity-75') as HTMLElement;
+    fireEvent.mouseDown(overlay);
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies correct size class for X_LARGE', () => {
+    const handleClose = jest.fn();
+    render(
+      <AllowlistToolCommonModalWrapper showModal={true} onClose={handleClose} title="Size Test" modalSize={AllowlistToolModalSize.X_LARGE}>
+        <div>content</div>
+      </AllowlistToolCommonModalWrapper>
+    );
+    const container = screen.getByRole('dialog').querySelector('div[class*="sm:tw-max-w-2xl"]') as HTMLElement | null;
+    expect(container).not.toBeNull();
+  });
+});

--- a/__tests__/components/allowlist-tool/common/select-menu-multiple/AllowlistToolSelectMenuMultipleList.test.tsx
+++ b/__tests__/components/allowlist-tool/common/select-menu-multiple/AllowlistToolSelectMenuMultipleList.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import AllowlistToolSelectMenuMultipleList from '../../../../../components/allowlist-tool/common/select-menu-multiple/AllowlistToolSelectMenuMultipleList';
+
+jest.mock('../../../../../components/allowlist-tool/common/select-menu-multiple/AllowlistToolSelectMenuMultipleListItem', () => ({
+  __esModule: true,
+  default: ({ option, toggleSelectedOption }: any) => (
+    <li data-testid="item" onClick={() => toggleSelectedOption(option)}>{option.title}</li>
+  )
+}));
+
+describe('AllowlistToolSelectMenuMultipleList', () => {
+  const options = [
+    { title: 'One', subTitle: null, value: '1' },
+    { title: 'Two', subTitle: null, value: '2' },
+  ];
+
+  it('renders list items and handles selection', () => {
+    const toggle = jest.fn();
+    render(
+      <AllowlistToolSelectMenuMultipleList options={options} selectedOptions={[]} toggleSelectedOption={toggle} />
+    );
+
+    const items = screen.getAllByTestId('item');
+    expect(items).toHaveLength(2);
+    expect(screen.queryByText('No options found')).toBeNull();
+
+    fireEvent.click(items[0]);
+    expect(toggle).toHaveBeenCalledWith(options[0]);
+  });
+
+  it('shows message when there are no options', () => {
+    const toggle = jest.fn();
+    render(
+      <AllowlistToolSelectMenuMultipleList options={[]} selectedOptions={[]} toggleSelectedOption={toggle} />
+    );
+    expect(screen.getByText('No options found')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/brain/feed/FeedItem.test.tsx
+++ b/__tests__/components/brain/feed/FeedItem.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import FeedItem from '../../../../components/brain/feed/FeedItem';
+import { ApiFeedItemType } from '../../../../generated/models/ApiFeedItemType';
+
+jest.mock('../../../../components/brain/feed/items/drop-created/FeedItemDropCreated', () => ({
+  __esModule: true,
+  default: () => <div data-testid="drop-created" />
+}));
+
+jest.mock('../../../../components/brain/feed/items/drop-replied/FeedItemDropReplied', () => ({
+  __esModule: true,
+  default: () => <div data-testid="drop-replied" />
+}));
+
+jest.mock('../../../../components/brain/feed/items/wave-created/FeedItemWaveCreated', () => ({
+  __esModule: true,
+  default: () => <div data-testid="wave-created" />
+}));
+
+jest.mock('../../../../helpers/AllowlistToolHelpers', () => ({
+  assertUnreachable: jest.fn(() => { throw new Error('unreachable'); })
+}));
+
+const baseProps = {
+  showWaveInfo: true,
+  activeDrop: null,
+  onReply: jest.fn(),
+  onQuote: jest.fn(),
+  onDropContentClick: jest.fn(),
+};
+
+describe('FeedItem', () => {
+  it('renders wave created item', () => {
+    const item = { type: ApiFeedItemType.WaveCreated } as any;
+    render(<FeedItem {...baseProps} item={item} />);
+    expect(screen.getByTestId('wave-created')).toBeInTheDocument();
+  });
+
+  it('renders drop created item', () => {
+    const item = { type: ApiFeedItemType.DropCreated } as any;
+    render(<FeedItem {...baseProps} item={item} />);
+    expect(screen.getByTestId('drop-created')).toBeInTheDocument();
+  });
+
+  it('renders drop replied item', () => {
+    const item = { type: ApiFeedItemType.DropReplied } as any;
+    render(<FeedItem {...baseProps} item={item} />);
+    expect(screen.getByTestId('drop-replied')).toBeInTheDocument();
+  });
+
+  it('calls assertUnreachable for unknown item', () => {
+    const { assertUnreachable } = require('../../../../helpers/AllowlistToolHelpers');
+    const item = { type: 'OTHER' } as any;
+    expect(() => render(<FeedItem {...baseProps} item={item} />)).toThrow('unreachable');
+    expect(assertUnreachable).toHaveBeenCalledWith(item);
+  });
+});

--- a/__tests__/components/brain/feed/FeedItems.test.tsx
+++ b/__tests__/components/brain/feed/FeedItems.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import FeedItems from '../../../../components/brain/feed/FeedItems';
+import { ApiFeedItemType } from '../../../../generated/models/ApiFeedItemType';
+
+jest.mock('../../../../components/brain/feed/FeedItem', () => ({
+  __esModule: true,
+  default: ({ item }: any) => <div data-testid="feed-item" data-type={item.type} />
+}));
+
+jest.mock('../../../../helpers/waves/drop.helpers', () => ({
+  getFeedItemKey: jest.fn(({ item, index }) => `${item.type}-${index}`),
+}));
+
+jest.mock('../../../../components/utils/animation/CommonChangeAnimation', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div data-testid="anim">{children}</div>
+}));
+
+describe('FeedItems', () => {
+  const items = [
+    { type: ApiFeedItemType.DropCreated, serial_no: 1, item: {} },
+    { type: ApiFeedItemType.WaveCreated, serial_no: 2, item: {} },
+  ] as any[];
+
+  it('renders each feed item with wrapper and id', () => {
+    render(
+      <FeedItems
+        items={items}
+        showWaveInfo={false}
+        activeDrop={null}
+        onReply={jest.fn()}
+        onQuote={jest.fn()}
+      />
+    );
+    const rendered = screen.getAllByTestId('feed-item');
+    expect(rendered).toHaveLength(2);
+    expect(rendered[0]).toHaveAttribute('data-type', items[0].type);
+    const divWrapper = document.getElementById(`feed-item-${items[0].serial_no}`);
+    expect(divWrapper).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/brain/feed/items/wave-created/FeedItemWaveCreated.test.tsx
+++ b/__tests__/components/brain/feed/items/wave-created/FeedItemWaveCreated.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import FeedItemWaveCreated from '../../../../../../components/brain/feed/items/wave-created/FeedItemWaveCreated';
+
+const push = jest.fn();
+jest.mock('next/router', () => ({ useRouter: () => ({ push }) }));
+
+jest.mock('../../../../../../components/waves/drops/Drop', () => ({
+  __esModule: true,
+  default: ({ onReplyClick, onQuoteClick }: any) => (
+    <div>
+      <button onClick={() => onReplyClick(42)}>reply</button>
+      <button onClick={() => onQuoteClick({ wave: { id: 'w' }, serial_no: 7 })}>quote</button>
+    </div>
+  ),
+  DropLocation: { MY_STREAM: 'MY_STREAM' },
+}));
+
+describe('FeedItemWaveCreated', () => {
+  const baseItem = {
+    item: {
+      id: 'w',
+      author: { handle: 'user' },
+      description_drop: { id: 'd' },
+    },
+    serial_no: 1,
+    type: 'WAVE_CREATED',
+  } as any;
+
+  it('renders author handle and calls router on interactions', () => {
+    render(
+      <FeedItemWaveCreated
+        item={baseItem}
+        showWaveInfo={false}
+        activeDrop={null}
+        onReply={jest.fn()}
+        onQuote={jest.fn()}
+      />
+    );
+    expect(screen.getByText(/user/)).toBeInTheDocument();
+    fireEvent.click(screen.getByText('reply'));
+    expect(push).toHaveBeenCalledWith('/my-stream?wave=w&serialNo=42/');
+    fireEvent.click(screen.getByText('quote'));
+    expect(push).toHaveBeenCalledWith('/my-stream?wave=w&serialNo=7/');
+  });
+});


### PR DESCRIPTION
## Summary
- add comprehensive tests for AllowlistTool modals and select menus
- test FeedItem and FeedItems rendering logic
- test FeedItemWaveCreated interactions

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
