### PR TITLE
Add tests for BrainContentPinnedWave and DirectMessagesList

### DIFF
--- a/__tests__/components/brain/content/BrainContentPinnedWave.test.tsx
+++ b/__tests__/components/brain/content/BrainContentPinnedWave.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ApiWaveType } from '../../../../generated/models/ApiWaveType';
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children, onClick, className }: any) => (
+    <a href={href} onClick={onClick} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+const push = jest.fn();
+let routerQuery: any = {};
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: routerQuery, push }),
+}));
+
+const prefetch = jest.fn();
+jest.mock('../../../../hooks/usePrefetchWaveData', () => ({
+  usePrefetchWaveData: () => prefetch,
+}));
+
+const registerWave = jest.fn();
+jest.mock('../../../../contexts/wave/MyStreamContext', () => ({
+  useMyStream: () => ({ registerWave }),
+}));
+
+jest.mock('../../../../hooks/isMobileDevice', () => jest.fn(() => false));
+
+const waveData: any = {
+  id: '1',
+  name: 'Wave 1',
+  picture: 'pic.png',
+  contributors_overview: [{ contributor_pfp: 'pfp1.png' }],
+  wave: { type: ApiWaveType.Rank },
+};
+
+let useWaveDataMock: any;
+
+jest.mock('../../../../hooks/useWaveData', () => ({
+  useWaveData: (...args: any[]) => useWaveDataMock(...args),
+}));
+
+jest.mock('../../../../components/waves/WavePicture', () => ({
+  __esModule: true,
+  default: ({ name }: any) => <div data-testid="picture">{name}</div>,
+}));
+
+import BrainContentPinnedWave from '../../../../components/brain/content/BrainContentPinnedWave';
+import useIsMobileDevice from '../../../../hooks/isMobileDevice';
+import { useWaveData } from '../../../../hooks/useWaveData';
+
+describe('BrainContentPinnedWave', () => {
+  const onMouseEnter = jest.fn();
+  const onMouseLeave = jest.fn();
+  const onRemove = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    routerQuery = { wave: '2' };
+    (useIsMobileDevice as jest.Mock).mockReturnValue(false);
+    useWaveDataMock = jest.fn(() => ({ data: waveData }));
+  });
+
+  function renderComponent(active = false, id = '1') {
+    return render(
+      <BrainContentPinnedWave
+        waveId={id}
+        active={active}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        onRemove={onRemove}
+      />
+    );
+  }
+
+  it('renders wave info and handles interactions', async () => {
+    const user = userEvent.setup();
+    const { container } = renderComponent();
+
+    expect(screen.getAllByText('Wave 1').length).toBeGreaterThan(0);
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/my-stream?wave=1');
+
+    await user.hover(container.firstChild as HTMLElement);
+    expect(onMouseEnter).toHaveBeenCalledWith('1');
+    expect(registerWave).toHaveBeenCalledWith('1');
+    expect(prefetch).toHaveBeenCalledWith('1');
+
+    await user.click(screen.getByRole('button', { name: /Remove wave/i }));
+    expect(onRemove).toHaveBeenCalledWith('1');
+
+    await user.click(screen.getByRole('link'));
+    expect(onMouseLeave).toHaveBeenCalled();
+    expect(push).toHaveBeenCalledWith('/my-stream?wave=1', undefined, { shallow: true });
+  });
+
+  it('uses /my-stream when viewing active wave and skips prefetch', async () => {
+    routerQuery = { wave: '1' };
+    const user = userEvent.setup();
+    const { container } = renderComponent();
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/my-stream');
+
+    await user.hover(container.firstChild as HTMLElement);
+    expect(onMouseEnter).toHaveBeenCalledWith('1');
+    expect(registerWave).not.toHaveBeenCalled();
+    expect(prefetch).not.toHaveBeenCalled();
+  });
+
+  it('calls onRemove when wave not found', () => {
+    useWaveDataMock = jest.fn(({ onWaveNotFound }) => {
+      onWaveNotFound();
+      return { data: undefined };
+    });
+    renderComponent();
+    expect(onRemove).toHaveBeenCalledWith('1');
+  });
+});

--- a/__tests__/components/brain/direct-messages/DirectMessagesList.test.tsx
+++ b/__tests__/components/brain/direct-messages/DirectMessagesList.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    const { priority, ...rest } = props;
+    return <img {...rest} />;
+  },
+}));
+
+jest.mock('../../../../components/brain/left-sidebar/waves/UnifiedWavesListWaves', () => ({
+  __esModule: true,
+  default: React.forwardRef((props: any, ref) => {
+    const handle = {
+      containerRef: { current: document.createElement('div') },
+      sentinelRef: { current: document.createElement('div') },
+    };
+    if (typeof ref === 'function') ref(handle);
+    else if (ref) (ref as any).current = handle;
+    return <div data-testid="waves-list">{props.waves.length}</div>;
+  }),
+}));
+
+jest.mock('../../../../components/brain/left-sidebar/waves/UnifiedWavesListLoader', () => ({
+  __esModule: true,
+  UnifiedWavesListLoader: (props: any) => <div data-testid="loader">{String(props.isFetchingNextPage)}</div>,
+}));
+
+jest.mock('../../../../components/brain/left-sidebar/waves/UnifiedWavesListEmpty', () => ({
+  __esModule: true,
+  default: (props: any) => <div data-testid="empty">{props.emptyMessage}</div>,
+}));
+
+jest.mock('../../../../components/brain/left-sidebar/BrainLeftSidebarCreateADirectMessageButton', () => ({
+  __esModule: true,
+  default: () => <div data-testid="create-dm-btn" />,
+}));
+
+jest.mock('../../../../contexts/wave/MyStreamContext', () => ({
+  useMyStream: () => ({
+    directMessages: mockDMs,
+    registerWave: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../../components/auth/SeizeConnectContext', () => ({
+  useSeizeConnectContext: () => ({ isAuthenticated: mockAuth }),
+}));
+
+jest.mock('../../../../hooks/useDeviceInfo', () => jest.fn(() => ({ isApp: mockIsApp })));
+
+jest.mock('../../../../components/header/user/HeaderUserConnect', () => ({ __esModule: true, default: () => <div data-testid="connect" /> }));
+jest.mock('../../../../components/user/utils/set-up-profile/UserSetUpProfileCta', () => ({ __esModule: true, default: () => <div data-testid="setup-profile" /> }));
+
+import DirectMessagesList from '../../../../components/brain/direct-messages/DirectMessagesList';
+import { AuthContext } from '../../../../components/auth/Auth';
+import useDeviceInfo from '../../../../hooks/useDeviceInfo';
+
+let mockAuth = false;
+let mockIsApp = false;
+const mockDMs = {
+  list: [{ id: '1', name: 'dm' }],
+  hasNextPage: false,
+  isFetchingNextPage: false,
+  fetchNextPage: jest.fn(),
+};
+
+function renderWithAuth(profile: any) {
+  return render(
+    <AuthContext.Provider value={{ connectedProfile: profile } as any}>
+      <DirectMessagesList scrollContainerRef={React.createRef()} />
+    </AuthContext.Provider>
+  );
+}
+
+describe('DirectMessagesList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuth = false;
+    mockIsApp = false;
+  });
+
+  it('shows connect wallet placeholder when not authenticated', () => {
+    const { container } = renderWithAuth(null);
+    expect(container.querySelector('#my-stream-connect')).toBeInTheDocument();
+    expect(screen.getByTestId('connect')).toBeInTheDocument();
+  });
+
+  it('shows profile setup placeholder when no profile handle', () => {
+    mockAuth = true;
+    renderWithAuth({ handle: null });
+    expect(screen.getByTestId('setup-profile')).toBeInTheDocument();
+  });
+
+  it('renders direct messages list and button when authenticated with profile', () => {
+    mockAuth = true;
+    const { getByTestId } = renderWithAuth({ handle: 'alice' });
+    expect(getByTestId('waves-list')).toHaveTextContent('1');
+    expect(screen.getByTestId('create-dm-btn')).toBeInTheDocument();
+    expect((useDeviceInfo as jest.Mock).mock.calls.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for BrainContentPinnedWave
- add unit tests for DirectMessagesList

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
