### PR TITLE
Increase coverage for brain components

### DIFF
--- a/__tests__/components/brain/mobile/BrainMobileMessages.test.tsx
+++ b/__tests__/components/brain/mobile/BrainMobileMessages.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+const directMessagesListMock = jest.fn();
+
+jest.mock('../../../../components/brain/direct-messages/DirectMessagesList', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    directMessagesListMock(props);
+    return <div data-testid="direct-messages" />;
+  },
+}));
+
+const useLayoutMock = jest.fn();
+jest.mock('../../../../components/brain/my-stream/layout/LayoutContext', () => ({
+  useLayout: () => useLayoutMock(),
+}));
+
+import BrainMobileMessages from '../../../../components/brain/mobile/BrainMobileMessages';
+
+describe('BrainMobileMessages', () => {
+  beforeEach(() => {
+    directMessagesListMock.mockClear();
+    useLayoutMock.mockReturnValue({ mobileWavesViewStyle: { height: '42px' } });
+  });
+
+  it('renders and passes scrollContainerRef to DirectMessagesList', () => {
+    const { container } = render(<BrainMobileMessages />);
+
+    expect(directMessagesListMock).toHaveBeenCalledTimes(1);
+    const { scrollContainerRef } = directMessagesListMock.mock.calls[0][0];
+    const rootDiv = container.firstChild as HTMLElement;
+
+    // ref should point to the rendered div
+    expect(scrollContainerRef.current).toBe(rootDiv);
+    // style from useLayout should be applied
+    expect(rootDiv).toHaveStyle('height: 42px');
+  });
+});

--- a/__tests__/components/brain/my-stream/MyStreamWaveFAQ.test.tsx
+++ b/__tests__/components/brain/my-stream/MyStreamWaveFAQ.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MyStreamWaveTab } from '../../../../types/waves.types';
+
+const setActiveContentTab = jest.fn();
+
+jest.mock('../../../../components/brain/ContentTabContext', () => ({
+  useContentTab: () => ({ setActiveContentTab }),
+}));
+
+const useLayoutMock = jest.fn();
+jest.mock('../../../../components/brain/my-stream/layout/LayoutContext', () => ({
+  useLayout: () => useLayoutMock(),
+}));
+
+import MyStreamWaveFAQ from '../../../../components/brain/my-stream/MyStreamWaveFAQ';
+
+describe('MyStreamWaveFAQ', () => {
+  beforeEach(() => {
+    setActiveContentTab.mockClear();
+    useLayoutMock.mockReturnValue({ faqViewStyle: { height: '21px' } });
+  });
+
+  it('sets active tab to FAQ and applies style', () => {
+    const { container } = render(<MyStreamWaveFAQ wave={{} as any} />);
+
+    expect(setActiveContentTab).toHaveBeenCalledWith(MyStreamWaveTab.FAQ);
+    const rootDiv = container.firstChild as HTMLElement;
+    expect(rootDiv).toHaveStyle('height: 21px');
+    expect(screen.getByText('The Memes - Main Stage FAQ')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/brain/notifications/Notifications.test.tsx
+++ b/__tests__/components/brain/notifications/Notifications.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+const mutateAsyncMock = jest.fn();
+
+jest.mock('@tanstack/react-query', () => ({
+  useMutation: () => ({ mutateAsync: mutateAsyncMock }),
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: {}, replace: jest.fn() }),
+}));
+
+const setTitleMock = jest.fn();
+
+jest.mock('../../../../components/auth/Auth', () => {
+  const React = require('react');
+  return {
+    AuthContext: React.createContext({
+      connectedProfile: { handle: 'bob' },
+      activeProfileProxy: false,
+      setToast: jest.fn(),
+    }),
+    useAuth: () => ({ setTitle: setTitleMock }),
+  };
+});
+
+const invalidateNotifications = jest.fn();
+jest.mock('../../../../components/react-query-wrapper/ReactQueryWrapper', () => {
+  const React = require('react');
+  return { ReactQueryWrapperContext: React.createContext({ invalidateNotifications }) };
+});
+
+jest.mock('../../../../components/brain/notifications/NotificationsWrapper', () => ({
+  __esModule: true,
+  default: () => <div data-testid="wrapper" />,
+}));
+
+jest.mock('../../../../components/brain/notifications/NotificationsCauseFilter', () => ({
+  __esModule: true,
+  default: () => <div data-testid="filter" />,
+}));
+
+jest.mock('../../../../components/brain/feed/FeedScrollContainer', () => ({
+  FeedScrollContainer: React.forwardRef((props: any, ref) => (
+    <div data-testid="scroll" ref={ref} {...props} />
+  )),
+}));
+
+jest.mock('../../../../components/brain/content/input/BrainContentInput', () => ({
+  __esModule: true,
+  default: () => <div data-testid="input" />,
+}));
+
+jest.mock('../../../../components/brain/my-stream/layout/MyStreamNoItems', () => ({
+  __esModule: true,
+  default: () => <div data-testid="no-items" />,
+}));
+
+const useNotificationsQueryMock = jest.fn();
+jest.mock('../../../../hooks/useNotificationsQuery', () => ({
+  useNotificationsQuery: () => useNotificationsQueryMock(),
+}));
+
+jest.mock('../../../../components/notifications/NotificationsContext', () => ({
+  useNotificationsContext: () => ({ removeAllDeliveredNotifications: jest.fn() }),
+}));
+
+jest.mock('../../../../components/brain/my-stream/layout/LayoutContext', () => ({
+  useLayout: () => ({ notificationsViewStyle: { height: '10px' } }),
+}));
+
+import Notifications from '../../../../components/brain/notifications/Notifications';
+
+describe('Notifications component', () => {
+  beforeEach(() => {
+    mutateAsyncMock.mockClear();
+    useNotificationsQueryMock.mockReset();
+    setTitleMock.mockClear();
+  });
+
+  it('shows loader when fetching and no items', () => {
+    useNotificationsQueryMock.mockReturnValue({
+      items: [],
+      isFetching: true,
+      isFetchingNextPage: false,
+      hasNextPage: false,
+      fetchNextPage: jest.fn(),
+      refetch: jest.fn(),
+      isInitialQueryDone: false,
+    });
+
+    render(<Notifications />);
+
+    expect(screen.getByText('Loading notifications...')).toBeInTheDocument();
+    expect(mutateAsyncMock).toHaveBeenCalled();
+    expect(setTitleMock).toHaveBeenCalled();
+  });
+
+  it('renders wrapper with items', () => {
+    useNotificationsQueryMock.mockReturnValue({
+      items: ['a'],
+      isFetching: false,
+      isFetchingNextPage: false,
+      hasNextPage: false,
+      fetchNextPage: jest.fn(),
+      refetch: jest.fn(),
+      isInitialQueryDone: true,
+    });
+
+    render(<Notifications />);
+
+    expect(screen.getByTestId('wrapper')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/common/DateAccordion.test.tsx
+++ b/__tests__/components/common/DateAccordion.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  },
+  AnimatePresence: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('@fortawesome/react-fontawesome', () => ({
+  FontAwesomeIcon: () => <span data-testid="icon" />,
+}));
+
+import DateAccordion from '../../../components/common/DateAccordion';
+
+describe('DateAccordion', () => {
+  it('shows collapsed content when not expanded and triggers toggle', () => {
+    const toggle = jest.fn();
+    render(
+      <DateAccordion title="Title" isExpanded={false} onToggle={toggle} collapsedContent={<span>info</span>}>
+        <div data-testid="child" />
+      </DateAccordion>
+    );
+    expect(screen.getByText('info')).toBeInTheDocument();
+    expect(screen.queryByTestId('child')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Title'));
+    expect(toggle).toHaveBeenCalled();
+  });
+
+  it('renders children when expanded', () => {
+    render(
+      <DateAccordion title="Title" isExpanded={true} onToggle={() => {}} collapsedContent={<span>info</span>}>
+        <div data-testid="child" />
+      </DateAccordion>
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+    expect(screen.queryByText('info')).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/common/TabToggleWithOverflow.test.tsx
+++ b/__tests__/components/common/TabToggleWithOverflow.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { TabToggleWithOverflow } from '../../../components/common/TabToggleWithOverflow';
+
+describe('TabToggleWithOverflow', () => {
+  const options = [
+    { key: 'a', label: 'A' },
+    { key: 'b', label: 'B' },
+    { key: 'c', label: 'C' },
+    { key: 'd', label: 'D' },
+  ];
+
+  it('shows overflow items and handles selection', () => {
+    const onSelect = jest.fn();
+    render(
+      <TabToggleWithOverflow
+        options={options}
+        activeKey="a"
+        onSelect={onSelect}
+        maxVisibleTabs={2}
+      />
+    );
+
+    // visible tabs
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+
+    // open overflow dropdown
+    fireEvent.click(screen.getByText('More'));
+    const optionC = screen.getByText('C');
+    expect(optionC).toBeInTheDocument();
+
+    fireEvent.click(optionC);
+    expect(onSelect).toHaveBeenCalledWith('c');
+    expect(screen.queryByText('C')).not.toBeInTheDocument();
+  });
+
+  it('shows active label when active tab is in overflow', () => {
+    render(
+      <TabToggleWithOverflow
+        options={options}
+        activeKey="d"
+        onSelect={() => {}}
+        maxVisibleTabs={2}
+      />
+    );
+
+    // Button label should show active label
+    expect(screen.getByText('D')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for BrainMobileMessages
- add tests for MyStreamWaveFAQ
- add tests for Notifications component
- add tests for DateAccordion and TabToggleWithOverflow

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
