### PR TITLE
Improve test coverage for brain sidebar components

### DIFF
--- a/__tests__/components/brain/left-sidebar/BrainLeftSidebarCreateADirectMessageButton.test.tsx
+++ b/__tests__/components/brain/left-sidebar/BrainLeftSidebarCreateADirectMessageButton.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import BrainLeftSidebarCreateADirectMessageButton from '../../../../components/brain/left-sidebar/BrainLeftSidebarCreateADirectMessageButton';
+import { useAuth } from '../../../../components/auth/Auth';
+
+jest.mock('next/link', () => ({ __esModule: true, default: ({ href, children }: any) => <a href={href}>{children}</a> }));
+jest.mock('../../../../components/auth/Auth');
+
+const mockedUseAuth = useAuth as jest.Mock;
+
+describe('BrainLeftSidebarCreateADirectMessageButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows "Create DM" when user is connected with no active proxy', () => {
+    mockedUseAuth.mockReturnValue({
+      connectedProfile: { handle: 'john' },
+      activeProfileProxy: null,
+    });
+    render(<BrainLeftSidebarCreateADirectMessageButton />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/waves?new-dm=true');
+    expect(screen.getByText('Create DM')).toBeInTheDocument();
+  });
+
+  it('shows "Direct Message" when no connected profile or active proxy present', () => {
+    mockedUseAuth.mockReturnValue({
+      connectedProfile: null,
+      activeProfileProxy: null,
+    });
+    render(<BrainLeftSidebarCreateADirectMessageButton />);
+    expect(screen.getByText('Direct Message')).toBeInTheDocument();
+  });
+
+  it('shows "Direct Message" when there is an active proxy', () => {
+    mockedUseAuth.mockReturnValue({
+      connectedProfile: { handle: 'john' },
+      activeProfileProxy: { id: '1' },
+    });
+    render(<BrainLeftSidebarCreateADirectMessageButton />);
+    expect(screen.getByText('Direct Message')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/brain/left-sidebar/BrainLeftSidebarViewChange.test.tsx
+++ b/__tests__/components/brain/left-sidebar/BrainLeftSidebarViewChange.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BrainLeftSidebarViewChange } from '../../../../components/brain/left-sidebar/BrainLeftSidebarViewChange';
+import { AuthContext } from '../../../../components/auth/Auth';
+import { useRouter } from 'next/router';
+import { useUnreadNotifications } from '../../../../hooks/useUnreadNotifications';
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children, onClick, className }: any) => (
+    <a href={href} onClick={onClick} className={className}>
+      {children}
+    </a>
+  ),
+}));
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../../../hooks/useUnreadNotifications');
+
+const mockedUseRouter = useRouter as jest.Mock;
+const mockedUseUnreadNotifications = useUnreadNotifications as jest.Mock;
+
+const baseAuth = { connectedProfile: { handle: 'alice' } } as any;
+
+function renderSidebar(route: string, unread = false) {
+  const push = jest.fn((path: string, _as?: any, _opts?: any) => {
+    router.pathname = path;
+  });
+  const router = { pathname: route, push } as any;
+  mockedUseRouter.mockReturnValue(router);
+  mockedUseUnreadNotifications.mockReturnValue({ haveUnreadNotifications: unread });
+
+  const utils = render(
+    <AuthContext.Provider value={baseAuth}>
+      <BrainLeftSidebarViewChange />
+    </AuthContext.Provider>
+  );
+  return { push, router, ...utils };
+}
+
+describe('BrainLeftSidebarViewChange', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('highlights "My Stream" link when on /my-stream', () => {
+    renderSidebar('/my-stream');
+    const links = screen.getAllByRole('link');
+    expect(links[0].className).toContain('tw-text-iron-300');
+    expect(links[1].className).toContain('tw-text-iron-400');
+  });
+
+  it('highlights "Notifications" link and shows unread dot', () => {
+    renderSidebar('/my-stream/notifications', true);
+    const links = screen.getAllByRole('link');
+    expect(links[1].className).toContain('tw-text-iron-300');
+    expect(links[0].className).toContain('tw-text-iron-400');
+    expect(document.querySelector('.tw-bg-red')).toBeInTheDocument();
+  });
+
+  it('navigates to notifications with shallow routing on click', async () => {
+    const user = userEvent.setup();
+    const { push } = renderSidebar('/my-stream');
+    await user.click(screen.getByRole('link', { name: /notifications/i }));
+    expect(push).toHaveBeenCalledWith('/my-stream/notifications', undefined, { shallow: true });
+  });
+});

--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BrainLeftSidebarWave from '../../../../../components/brain/left-sidebar/waves/BrainLeftSidebarWave';
+import { ApiWaveType } from '../../../../../generated/models/ApiWaveType';
+import { useRouter } from 'next/router';
+import { usePrefetchWaveData } from '../../../../../hooks/usePrefetchWaveData';
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children, onMouseEnter, onClick, className }: any) => (
+    <a href={href} onMouseEnter={onMouseEnter} onClick={onClick} className={className}>{children}</a>
+  ),
+}));
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../../../../hooks/usePrefetchWaveData');
+jest.mock('../../../../../components/waves/WavePicture', () => (props: any) => <img data-testid="wave-picture" alt={props.name} />);
+jest.mock('../../../../../components/brain/left-sidebar/waves/BrainLeftSidebarWaveDropTime', () => (props: any) => <span data-testid="drop-time">{props.time}</span>);
+jest.mock('../../../../../components/brain/left-sidebar/waves/BrainLeftSidebarWavePin', () => (props: any) => <div data-testid="pin">{String(props.isPinned)}</div>);
+
+const mockedUseRouter = useRouter as jest.Mock;
+const mockedPrefetch = usePrefetchWaveData as jest.Mock;
+
+describe('BrainLeftSidebarWave', () => {
+  const prefetch = jest.fn();
+  const onHover = jest.fn();
+  const router = { query: {}, push: jest.fn() } as any;
+
+  const baseWave = {
+    id: '1',
+    type: ApiWaveType.Chat,
+    name: 'Chat Wave',
+    picture: '',
+    contributors: [],
+    newDropsCount: { count: 2, latestDropTimestamp: 123 },
+    isPinned: false,
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseRouter.mockReturnValue(router);
+    mockedPrefetch.mockReturnValue(prefetch);
+    router.query = {};
+  });
+
+  it('prefetches wave data on hover when not active', async () => {
+    render(<BrainLeftSidebarWave wave={baseWave} onHover={onHover} />);
+    const link = screen.getByRole('link');
+    await userEvent.hover(link);
+    expect(onHover).toHaveBeenCalledWith('1');
+    expect(prefetch).toHaveBeenCalledWith('1');
+  });
+
+  it('does not prefetch when hovering active wave', async () => {
+    router.query = { wave: '1' };
+    render(<BrainLeftSidebarWave wave={baseWave} onHover={onHover} />);
+    await userEvent.hover(screen.getByRole('link'));
+    expect(onHover).not.toHaveBeenCalled();
+    expect(prefetch).not.toHaveBeenCalled();
+  });
+
+  it('computes href based on current wave', () => {
+    const { rerender } = render(<BrainLeftSidebarWave wave={baseWave} onHover={onHover} />);
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/my-stream?wave=1');
+    router.query = { wave: '1' };
+    rerender(<BrainLeftSidebarWave wave={baseWave} onHover={onHover} />);
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/my-stream');
+  });
+
+  it('pushes shallow route on click', async () => {
+    render(<BrainLeftSidebarWave wave={baseWave} onHover={onHover} />);
+    const link = screen.getByRole('link');
+    await userEvent.click(link);
+    expect(router.push).toHaveBeenCalledWith('/my-stream?wave=1', undefined, { shallow: true });
+  });
+
+  it('shows drop indicators for non-chat waves', () => {
+    const dropWave = { ...baseWave, id: '2', type: ApiWaveType.Approve };
+    render(<BrainLeftSidebarWave wave={dropWave} onHover={onHover} />);
+    expect(screen.getByTestId('drop-time')).toHaveTextContent('123');
+  });
+});

--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWaveClose.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWaveClose.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BrainLeftSidebarWaveClose from '../../../../../components/brain/left-sidebar/waves/BrainLeftSidebarWaveClose';
+import { useRouter } from 'next/router';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('@tippyjs/react', () => (props: any) => <div data-testid="tippy">{props.children}</div>);
+jest.mock('@fortawesome/react-fontawesome', () => ({ FontAwesomeIcon: () => <svg data-testid="icon" /> }));
+
+const mockedUseRouter = useRouter as jest.Mock;
+
+describe('BrainLeftSidebarWaveClose', () => {
+  const push = jest.fn();
+  beforeEach(() => {
+    mockedUseRouter.mockReturnValue({ push });
+    jest.clearAllMocks();
+  });
+
+  it('renders button with icon', () => {
+    render(<BrainLeftSidebarWaveClose waveId="1" />);
+    expect(screen.getByRole('button', { name: /close wave/i })).toBeInTheDocument();
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+    expect(screen.getByTestId('tippy')).toBeInTheDocument();
+  });
+
+  it('navigates to /my-stream on click', async () => {
+    render(<BrainLeftSidebarWaveClose waveId="1" />);
+    const button = screen.getByRole('button');
+    await userEvent.click(button);
+    expect(push).toHaveBeenCalledWith('/my-stream', undefined, { shallow: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for BrainLeftSidebarCreateADirectMessageButton
- cover BrainLeftSidebarViewChange component interactions
- test BrainLeftSidebarWave and its helper components
- add BrainLeftSidebarWaveClose behavior tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
