### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/components/brain/BrainMobile.test.tsx
+++ b/__tests__/components/brain/BrainMobile.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import BrainMobile from '../../../components/brain/BrainMobile';
+
+jest.mock('next/image', () => ({ __esModule: true, default: (props:any) => <img {...props} /> }));
+
+let mockRouter: any = { query: {}, pathname: '/', push: jest.fn() };
+jest.mock('next/router', () => ({ useRouter: () => mockRouter }));
+
+let isApp = true;
+jest.mock('../../../hooks/useDeviceInfo', () => ({ __esModule: true, default: () => ({ isApp }) }));
+
+let dropData: any = null;
+let waveData: any = null;
+
+jest.mock('@tanstack/react-query', () => ({
+  keepPreviousData: {},
+  useQuery: jest.fn(() => ({ data: dropData })),
+}));
+
+jest.mock('../../../hooks/useWaveData', () => ({
+  useWaveData: () => ({ data: waveData })
+}));
+
+jest.mock('../../../hooks/useWave', () => ({
+  useWave: () => ({ isMemesWave: false, isRankWave: true })
+}));
+
+jest.mock('../../../hooks/useWaveTimers', () => ({
+  useWaveTimers: () => ({ voting: { isCompleted: false }, decisions: { firstDecisionDone: true } })
+}));
+
+jest.mock('../../../components/brain/BrainDesktopDrop', () => ({ __esModule: true, default: (props:any) => <div data-testid='drop' onClick={props.onClose}>drop</div> }));
+
+jest.mock('../../../components/brain/mobile/BrainMobileTabs', () => ({ __esModule: true, default: () => <div data-testid='tabs' /> }));
+
+jest.mock('../../../components/brain/mobile/BrainMobileAbout', () => ({ __esModule: true, default: () => <div data-testid='about' /> }));
+
+jest.mock('../../../components/brain/mobile/BrainMobileWaves', () => ({ __esModule: true, default: () => <div data-testid='waves' /> }));
+
+jest.mock('../../../components/brain/mobile/BrainMobileMessages', () => ({ __esModule: true, default: () => <div data-testid='messages' /> }));
+
+jest.mock('../../../components/brain/notifications/Notifications', () => ({ __esModule: true, default: () => <div data-testid='notifications' /> }));
+
+jest.mock('../../../components/brain/my-stream/MyStreamWaveLeaderboard', () => ({ __esModule: true, default: () => <div data-testid="leaderboard" /> }));
+
+jest.mock('../../../components/brain/my-stream/MyStreamWaveOutcome', () => ({ __esModule: true, default: () => <div data-testid="outcome" /> }));
+
+jest.mock('../../../components/waves/winners/WaveWinners', () => ({ __esModule: true, WaveWinners: () => <div data-testid="winners" /> }));
+
+jest.mock('../../../components/brain/my-stream/votes/MyStreamWaveMyVotes', () => ({ __esModule: true, default: () => <div data-testid="myvotes" /> }));
+
+jest.mock('../../../components/brain/my-stream/MyStreamWaveFAQ', () => ({ __esModule: true, default: () => <div data-testid="faq" /> }));
+
+// Tests
+
+describe('BrainMobile', () => {
+  beforeEach(() => {
+    mockRouter = { query: {}, pathname: '/', push: jest.fn() };
+    dropData = null;
+    waveData = null;
+    isApp = true;
+  });
+
+  it('renders BrainDesktopDrop when drop is open', () => {
+    mockRouter.query = { drop: 'd1' };
+    dropData = { id: 'd1' };
+    render(<BrainMobile>child</BrainMobile>);
+    expect(screen.getByTestId('drop')).toBeInTheDocument();
+  });
+
+  it('shows notifications view when path matches', async () => {
+    mockRouter.pathname = '/my-stream/notifications';
+    render(<BrainMobile>child</BrainMobile>);
+    await waitFor(() => {
+      expect(screen.getByTestId('notifications')).toBeInTheDocument();
+    });
+  });
+
+  it('shows tabs only when wave active or not in app', async () => {
+    isApp = true;
+    render(<BrainMobile>child</BrainMobile>);
+    expect(screen.queryByTestId('tabs')).toBeNull();
+
+    mockRouter.query = { wave: '1' };
+    const { rerender } = render(<BrainMobile>child</BrainMobile>);
+    await waitFor(() => expect(screen.getByTestId('tabs')).toBeInTheDocument());
+    rerender(<div />);
+  });
+});
+

--- a/__tests__/components/brain/content/BrainContent.test.tsx
+++ b/__tests__/components/brain/content/BrainContent.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import BrainContent from '../../../../components/brain/content/BrainContent';
+
+let bpValue = 'S';
+const registerRef = jest.fn();
+
+jest.mock('react-use', () => ({
+  createBreakpoint: () => () => bpValue,
+}));
+
+jest.mock('../../../../components/brain/my-stream/layout/LayoutContext', () => ({
+  useLayout: () => ({ registerRef }),
+}));
+
+jest.mock('../../../../components/brain/content/BrainContentPinnedWaves', () => ({
+  __esModule: true,
+  default: () => <div data-testid="pinned" />,
+}));
+
+jest.mock('../../../../components/brain/content/input/BrainContentInput', () => ({
+  __esModule: true,
+  default: ({ activeDrop, onCancelReplyQuote }: any) => (
+    <div data-testid="input">
+      {activeDrop?.id ?? 'no-drop'}
+      <button onClick={onCancelReplyQuote}>cancel</button>
+    </div>
+  ),
+}));
+
+describe('BrainContent', () => {
+  beforeEach(() => {
+    registerRef.mockClear();
+  });
+
+  it('shows pinned waves on small breakpoint', () => {
+    bpValue = 'S';
+    render(
+      <BrainContent activeDrop={{ id: 'd' }} onCancelReplyQuote={jest.fn()}>
+        child
+      </BrainContent>
+    );
+    expect(screen.getByTestId('pinned')).toBeInTheDocument();
+    expect(registerRef).toHaveBeenCalledWith('pinned', expect.any(HTMLElement));
+  });
+
+  it('hides pinned waves on large breakpoint', () => {
+    bpValue = 'LG';
+    render(
+      <BrainContent activeDrop={null} onCancelReplyQuote={jest.fn()}>
+        child
+      </BrainContent>
+    );
+    expect(screen.queryByTestId('pinned')).toBeNull();
+  });
+
+  it('passes props to BrainContentInput', () => {
+    bpValue = 'S';
+    const onCancel = jest.fn();
+    render(
+      <BrainContent activeDrop={{ id: 'x' }} onCancelReplyQuote={onCancel}>
+        child
+      </BrainContent>
+    );
+    expect(screen.getByTestId('input')).toHaveTextContent('x');
+    fireEvent.click(screen.getByText('cancel'));
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/brain/content/input/BrainContentInput.test.tsx
+++ b/__tests__/components/brain/content/input/BrainContentInput.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import BrainContentInput from '../../../../../components/brain/content/input/BrainContentInput';
+
+const useWaveDataMock = jest.fn();
+const useCapacitorMock = jest.fn();
+
+jest.mock('../../../../../hooks/useWaveData', () => ({
+  useWaveData: (args: any) => useWaveDataMock(args),
+}));
+
+jest.mock('../../../../../hooks/useCapacitor', () => ({
+  __esModule: true,
+  default: () => useCapacitorMock(),
+}));
+
+jest.mock('../../../../../components/waves/PrivilegedDropCreator', () => ({
+  __esModule: true,
+  default: ({ wave }: any) => <div data-testid="creator">{wave.id}</div>,
+  DropMode: { BOTH: 'BOTH' },
+}));
+
+describe('BrainContentInput', () => {
+  beforeEach(() => {
+    useWaveDataMock.mockReset();
+    useCapacitorMock.mockReset();
+  });
+
+  it('returns null when wave is missing', () => {
+    useCapacitorMock.mockReturnValue({ isCapacitor: false });
+    useWaveDataMock.mockReturnValue({ data: null });
+    const { container } = render(
+      <BrainContentInput activeDrop={null} onCancelReplyQuote={jest.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders creator and passes wave id', () => {
+    useCapacitorMock.mockReturnValue({ isCapacitor: false });
+    useWaveDataMock.mockReturnValue({ data: { id: 'w1' } });
+    render(
+      <BrainContentInput
+        activeDrop={{ drop: { wave: { id: 'w1' } } } as any}
+        onCancelReplyQuote={jest.fn()}
+      />
+    );
+    expect(useWaveDataMock).toHaveBeenCalledWith({
+      waveId: 'w1',
+      onWaveNotFound: expect.any(Function),
+    });
+    expect(screen.getByTestId('creator')).toHaveTextContent('w1');
+    expect(screen.getByTestId('creator').parentElement?.className).toContain(
+      'tw-max-h-[calc(100vh-20rem)]'
+    );
+  });
+
+  it('uses capacitor height and triggers onWaveNotFound', () => {
+    const onCancel = jest.fn();
+    let onWaveNotFound: Function | null = null;
+    useCapacitorMock.mockReturnValue({ isCapacitor: true });
+    useWaveDataMock.mockImplementation((args: any) => {
+      onWaveNotFound = args.onWaveNotFound;
+      return { data: { id: 'w2' } };
+    });
+    render(
+      <BrainContentInput
+        activeDrop={{ drop: { wave: { id: 'w2' } } } as any}
+        onCancelReplyQuote={onCancel}
+      />
+    );
+    expect(screen.getByTestId('creator').parentElement?.className).toContain(
+      'tw-max-h-[calc(100vh-14.7rem)]'
+    );
+    onWaveNotFound && onWaveNotFound();
+    expect(onCancel).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `BrainMobile` mobile view behaviors
- cover `BrainContent` rendering logic
- test `BrainContentInput` with mocked hooks

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage`