### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/components/app-wallets/AppWallet.test.tsx
+++ b/__tests__/components/app-wallets/AppWallet.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AppWallet from '../../../components/app-wallets/AppWallet';
+import { useAppWallets } from '../../../components/app-wallets/AppWalletsContext';
+import { useAuth } from '../../../components/auth/Auth';
+import { useSeizeConnectContext } from '../../../components/auth/SeizeConnectContext';
+import { useRouter } from 'next/router';
+import { useBalance, useChainId } from 'wagmi';
+import { sepolia } from 'viem/chains';
+
+jest.mock('next/image', () => ({ __esModule: true, default: (p:any)=> <img {...p}/> }));
+jest.mock('next/link', () => ({ __esModule: true, default: ({href, children}:any)=> <a href={href}>{children}</a> }));
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../../components/app-wallets/AppWalletsContext');
+jest.mock('../../../components/auth/Auth');
+jest.mock('../../../components/auth/SeizeConnectContext');
+jest.mock('@fortawesome/react-fontawesome', () => ({ FontAwesomeIcon: (props:any)=> <svg data-testid="icon" onClick={props.onClick}/> }));
+jest.mock('../../../components/app-wallets/AppWalletAvatar', () => ({__esModule:true,default: ({address}:any)=><div data-testid="avatar">{address}</div>}));
+jest.mock('../../../components/app-wallets/AppWalletsUnsupported', () => () => <div data-testid="unsupported"/>);
+jest.mock('../../../components/dotLoader/DotLoader', () => ({__esModule:true,default: ()=> <span data-testid="dotloader"/>, Spinner: ()=> <span data-testid="spinner"/> }));
+jest.mock('../../../components/app-wallets/AppWalletModal', () => ({ UnlockAppWalletModal: () => null }));
+jest.mock('../../../components/app-wallets/app-wallet-helpers', () => ({ decryptData: jest.fn(()=>Promise.resolve('decrypted')) }));
+jest.mock('wagmi', () => ({ useBalance: jest.fn(), useChainId: jest.fn() }));
+
+const mockedUseAppWallets = useAppWallets as jest.Mock;
+const mockedUseAuth = useAuth as jest.Mock;
+const mockedUseSeize = useSeizeConnectContext as jest.Mock;
+const mockedUseRouter = useRouter as jest.Mock;
+const mockedUseBalance = useBalance as jest.Mock;
+const mockedUseChainId = useChainId as jest.Mock;
+
+const wallet = {
+  name: 'Test',
+  created_at: 0,
+  address: '0xABC',
+  address_hashed: 'hash',
+  mnemonic: 'na',
+  private_key: 'pk',
+  imported: false
+};
+
+beforeEach(()=>{
+  jest.clearAllMocks();
+  mockedUseRouter.mockReturnValue({ push: jest.fn() });
+  mockedUseBalance.mockReturnValue({ isFetching:false, data:{ value: BigInt('1000000000000000000'), symbol:'ETH' }});
+  mockedUseChainId.mockReturnValue(sepolia.id);
+  mockedUseAuth.mockReturnValue({ setToast: jest.fn() });
+  mockedUseSeize.mockReturnValue({ address: '0xDEF' });
+  Object.assign(navigator, { clipboard: { writeText: jest.fn() } });
+});
+
+function renderComponent(ctx:any){
+  mockedUseAppWallets.mockReturnValue(ctx);
+  return render(<AppWallet address="0xABC"/>);
+}
+
+describe('AppWallet', () => {
+  it('shows spinner when fetching', () => {
+    renderComponent({fetchingAppWallets:true, appWalletsSupported:true, appWallets:[], deleteAppWallet:jest.fn()});
+    expect(screen.getByTestId('spinner')).toBeInTheDocument();
+  });
+
+  it('shows unsupported when not supported', () => {
+    renderComponent({fetchingAppWallets:false, appWalletsSupported:false, appWallets:[], deleteAppWallet:jest.fn()});
+    expect(screen.getByTestId('unsupported')).toBeInTheDocument();
+  });
+
+  it('shows not found when wallet missing', () => {
+    renderComponent({fetchingAppWallets:false, appWalletsSupported:true, appWallets:[], deleteAppWallet:jest.fn()});
+    expect(screen.getByText(/Wallet with address/i)).toBeInTheDocument();
+  });
+
+  it('prevents deleting connected wallet', async () => {
+    const deleteMock = jest.fn();
+    const toast = jest.fn();
+    mockedUseAuth.mockReturnValue({ setToast: toast });
+    mockedUseSeize.mockReturnValue({ address: '0xABC' });
+    const confirmSpy = jest.spyOn(window, 'confirm');
+    renderComponent({fetchingAppWallets:false, appWalletsSupported:true, appWallets:[wallet], deleteAppWallet:deleteMock});
+    await userEvent.click(screen.getByRole('button', { name: /delete/i }));
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it('deletes wallet on confirm', async () => {
+    const deleteMock = jest.fn().mockResolvedValue(true);
+    const toast = jest.fn();
+    const push = jest.fn();
+    mockedUseAuth.mockReturnValue({ setToast: toast });
+    mockedUseRouter.mockReturnValue({ push });
+    const confirmSpy = jest.spyOn(window, 'confirm').mockReturnValue(true);
+    renderComponent({fetchingAppWallets:false, appWalletsSupported:true, appWallets:[wallet], deleteAppWallet:deleteMock});
+    await userEvent.click(screen.getByRole('button', { name: /delete/i }));
+    expect(deleteMock).toHaveBeenCalledWith('0xABC');
+    expect(push).toHaveBeenCalledWith('/tools/app-wallets');
+    expect(toast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+    confirmSpy.mockRestore();
+  });
+
+  it('prints balance correctly', () => {
+    renderComponent({fetchingAppWallets:false, appWalletsSupported:true, appWallets:[wallet], deleteAppWallet:jest.fn()});
+    expect(screen.getByText(/1\s*ETH/)).toBeInTheDocument();
+    expect(screen.getByText(/sepolia/)).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/brain/BrainDesktop.test.tsx
+++ b/__tests__/components/brain/BrainDesktop.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { useRouter } from 'next/router';
+import { useQuery } from '@tanstack/react-query';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../../components/brain/left-sidebar/BrainLeftSidebar', () => ({ __esModule:true, default: () => <div data-testid="left"/> }));
+const rightMock = jest.fn(() => <div data-testid="right"/>);
+jest.mock('../../../components/brain/right-sidebar/BrainRightSidebar', () => ({ __esModule:true, default: rightMock, SidebarTab:{ ABOUT: 'ABOUT' } }));
+jest.mock('../../../components/brain/BrainDesktopDrop', () => jest.fn(({ onClose }) => <div data-testid="drop" onClick={onClose}/>));
+jest.mock('../../../components/brain/ContentTabContext', () => ({ ContentTabProvider: ({children}:any) => <div>{children}</div> }));
+jest.mock('../../../components/brain/my-stream/layout/LayoutContext', () => ({ useLayout: () => ({ contentContainerStyle:{} }) }));
+jest.mock('@tanstack/react-query', () => ({ useQuery: jest.fn(), keepPreviousData:{} }));
+
+import BrainDesktop from '../../../components/brain/BrainDesktop';
+
+const mockedRouter = useRouter as jest.Mock;
+const mockedUseQuery = useQuery as jest.Mock;
+const mockedDrop = require('../../../components/brain/BrainDesktopDrop');
+
+function setup(query:any){
+  const push = jest.fn();
+  mockedRouter.mockReturnValue({ query, push, pathname:'/brain' });
+  mockedUseQuery.mockReturnValue({ data: query.drop ? { id: query.drop } : null });
+  rightMock.mockClear();
+  (mockedDrop as jest.Mock).mockClear();
+  return { push, ...render(<BrainDesktop>child</BrainDesktop>) };
+}
+
+describe('BrainDesktop', () => {
+  it('shows right sidebar when wave present', () => {
+    setup({ wave:'1' });
+    expect(screen.getByTestId('right')).toBeInTheDocument();
+    expect(screen.queryByTestId('drop')).toBeNull();
+  });
+
+  it('shows drop overlay when drop param set', () => {
+    setup({ wave:'1', drop:'d1' });
+    expect(screen.getByTestId('drop')).toBeInTheDocument();
+    expect(screen.queryByTestId('right')).toBeNull();
+  });
+
+  it('removes drop param on close', () => {
+    const { push } = setup({ wave:'1', drop:'d1' });
+    screen.getByTestId('drop').click();
+    expect(push).toHaveBeenCalledWith({ pathname:'/brain', query:{ wave:'1' } }, undefined, { shallow:true });
+  });
+
+  it('handles drop click from sidebar', () => {
+    const { push } = setup({ wave:'1' });
+    const call = (rightMock.mock.calls[0] as any)[0];
+    call.onDropClick({ id:'new' });
+    expect(push).toHaveBeenCalledWith({ pathname:'/brain', query:{ wave:'1', drop:'new' } }, undefined, { shallow:true });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for AppWallet component behaviors
- add tests for BrainDesktop interactions

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
- `npm run improve-coverage`