### PR TITLE
Add icon and context tests

### DIFF
--- a/__tests__/components/common/icons/HomeIcon.test.tsx
+++ b/__tests__/components/common/icons/HomeIcon.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react';
+import HomeIcon from '../../../../components/common/icons/HomeIcon';
+
+describe('HomeIcon', () => {
+  it('renders svg with provided class and attributes', () => {
+    const { container } = render(<HomeIcon className="test-class" />);
+    const svg = container.querySelector('svg') as SVGElement;
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+    expect(svg).toHaveClass('test-class');
+    expect(svg.getAttribute('stroke-width')).toBe('1.65');
+  });
+
+  it('contains the expected path data', () => {
+    const { container } = render(<HomeIcon />);
+    const path = container.querySelector('path');
+    expect(path).toBeInTheDocument();
+    expect(path?.getAttribute('stroke-linecap')).toBe('round');
+    expect(path?.getAttribute('stroke-linejoin')).toBe('round');
+    expect(path?.getAttribute('d')).toContain('m2.25 12');
+  });
+});

--- a/__tests__/components/community/members-table/CommunityMembersTableHeaderSortableContent.test.tsx
+++ b/__tests__/components/community/members-table/CommunityMembersTableHeaderSortableContent.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, act } from '@testing-library/react';
+import CommunityMembersTableHeaderSortableContent from '../../../../components/community/members-table/CommunityMembersTableHeaderSortableContent';
+import { CommunityMembersSortOption } from '../../../../enums';
+import { SortDirection } from '../../../../entities/ISort';
+
+const sortIconMock = jest.fn();
+jest.mock('../../../../components/user/utils/icons/CommonTableSortIcon', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    sortIconMock(props);
+    return <div data-testid="sort-icon" />;
+  },
+}));
+
+jest.mock('../../../../components/distribution-plan-tool/common/CircleLoader', () => ({
+  __esModule: true,
+  default: () => <div data-testid="loader" />,
+  CircleLoaderSize: { SMALL: 'SMALL' },
+}));
+
+describe('CommunityMembersTableHeaderSortableContent', () => {
+  const baseProps = {
+    sort: CommunityMembersSortOption.LEVEL,
+    activeSort: CommunityMembersSortOption.DISPLAY,
+    sortDirection: SortDirection.ASC,
+    hoveringOption: null as CommunityMembersSortOption | null,
+    isLoading: false,
+  };
+
+  beforeEach(() => {
+    sortIconMock.mockClear();
+  });
+
+  it('renders title and sort icon when inactive', () => {
+    render(<CommunityMembersTableHeaderSortableContent {...baseProps} />);
+    expect(screen.getByText('Level')).toBeInTheDocument();
+    expect(screen.queryByTestId('loader')).not.toBeInTheDocument();
+    expect(sortIconMock).toHaveBeenCalledWith(
+      expect.objectContaining({ direction: SortDirection.DESC, isActive: false, shouldRotate: false })
+    );
+  });
+
+  it('shows loader when active and loading', () => {
+    render(
+      <CommunityMembersTableHeaderSortableContent
+        {...baseProps}
+        activeSort={CommunityMembersSortOption.LEVEL}
+        isLoading={true}
+      />
+    );
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+  });
+
+  it('rotates icon when hovering active option', () => {
+    const { rerender } = render(
+      <CommunityMembersTableHeaderSortableContent
+        {...baseProps}
+        activeSort={CommunityMembersSortOption.LEVEL}
+      />
+    );
+    expect(sortIconMock).toHaveBeenLastCalledWith(expect.objectContaining({ shouldRotate: false }));
+    act(() => {
+      rerender(
+        <CommunityMembersTableHeaderSortableContent
+          {...baseProps}
+          activeSort={CommunityMembersSortOption.LEVEL}
+          hoveringOption={CommunityMembersSortOption.LEVEL}
+        />
+      );
+    });
+    expect(sortIconMock).toHaveBeenLastCalledWith(expect.objectContaining({ shouldRotate: true }));
+  });
+});

--- a/__tests__/components/communityDownloads/CommunityDownloadsSubscriptions.test.tsx
+++ b/__tests__/components/communityDownloads/CommunityDownloadsSubscriptions.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, act } from '@testing-library/react';
+import CommunityDownloadsSubscriptions from '../../../components/communityDownloads/CommunityDownloadsSubscriptions';
+import { MEMES_CONTRACT } from '../../../constants';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../../services/api/common-api', () => ({ commonApiFetch: jest.fn() }));
+
+const { useRouter } = require('next/router');
+const { commonApiFetch } = require('../../../services/api/common-api');
+
+describe('CommunityDownloadsSubscriptions', () => {
+  beforeEach(() => {
+    useRouter.mockReturnValue({ isReady: true });
+    jest.clearAllMocks();
+  });
+
+  it('fetches and displays subscriptions', async () => {
+    commonApiFetch.mockResolvedValue({
+      count: 1,
+      data: [
+        { date: '2023', contract: MEMES_CONTRACT, token_id: 1, upload_url: 'http://example.com' },
+      ],
+    });
+    await act(async () => {
+      render(<CommunityDownloadsSubscriptions />);
+    });
+    expect(commonApiFetch).toHaveBeenCalledWith({
+      endpoint: `subscriptions/uploads?contract=${MEMES_CONTRACT}&page_size=25&page=1`,
+    });
+    expect(screen.getByText('2023')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'http://example.com' })).toHaveAttribute('href', 'http://example.com');
+  });
+
+  it('shows placeholder when no downloads', async () => {
+    commonApiFetch.mockResolvedValue({ count: 0, data: [] });
+    await act(async () => {
+      render(<CommunityDownloadsSubscriptions />);
+    });
+    expect(screen.getByText('Nothing here yet')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/cookies/CookieConsentContext.test.tsx
+++ b/__tests__/components/cookies/CookieConsentContext.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, act } from '@testing-library/react';
+import React from 'react';
+import {
+  CookieConsentProvider,
+  getCookieConsentByName,
+  useCookieConsent,
+} from '../../../components/cookies/CookieConsentContext';
+
+jest.mock('js-cookie', () => ({
+  get: jest.fn(),
+  set: jest.fn(),
+}));
+
+jest.mock('../../../components/cookies/CookiesBanner', () => () => <div data-testid="banner" />);
+
+jest.mock('../../../services/api/common-api', () => ({
+  commonApiFetch: jest.fn(() => Promise.resolve({ is_eu: true, is_consent: false })),
+  commonApiPost: jest.fn(() => Promise.resolve()),
+  commonApiDelete: jest.fn(() => Promise.resolve()),
+}));
+
+const { get } = require('js-cookie');
+const { commonApiFetch } = require('../../../services/api/common-api');
+
+const flushPromises = () => new Promise(resolve => setTimeout(resolve, 0));
+
+describe('CookieConsentContext', () => {
+  it('getCookieConsentByName parses values', () => {
+    get.mockReturnValueOnce('true');
+    expect(getCookieConsentByName('a')).toBe(true);
+    get.mockReturnValueOnce('false');
+    expect(getCookieConsentByName('b')).toBe(false);
+    get.mockReturnValueOnce(undefined);
+    expect(getCookieConsentByName('c')).toBeUndefined();
+  });
+
+  it('loads cookie consent on mount and shows banner', async () => {
+    render(
+      <CookieConsentProvider>
+        <div>child</div>
+      </CookieConsentProvider>
+    );
+    await act(flushPromises);
+    expect(commonApiFetch).toHaveBeenCalled();
+    expect(screen.getByTestId('banner')).toBeInTheDocument();
+  });
+
+  it('useCookieConsent throws outside provider', () => {
+    function Wrapper() {
+      useCookieConsent();
+      return null;
+    }
+    expect(() => render(<Wrapper />)).toThrow('useCookieConsent must be used within a CookieConsentProvider');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for HomeIcon component
- add tests for CommunityMembersTableHeaderSortableContent
- test CommunityDownloadsSubscriptions loading logic
- cover CookieConsentContext utilities

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage`