### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/components/brain/content/BrainContent.test.tsx
+++ b/__tests__/components/brain/content/BrainContent.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import BrainContent from '../../../../components/brain/content/BrainContent';
+import { ActiveDropAction } from '../../../../types/dropInteractionTypes';
 
 let bpValue = 'S';
 const registerRef = jest.fn();
@@ -34,11 +35,18 @@ describe('BrainContent', () => {
 
   it('shows pinned waves on small breakpoint', () => {
     bpValue = 'S';
-    render(
-      <BrainContent activeDrop={{ id: 'd' }} onCancelReplyQuote={jest.fn()}>
-        child
-      </BrainContent>
-    );
+      render(
+        <BrainContent
+          activeDrop={{
+            action: ActiveDropAction.REPLY,
+            drop: { id: 'd', wave: { id: 'w' } } as any,
+            partId: 0,
+          }}
+          onCancelReplyQuote={jest.fn()}
+        >
+          child
+        </BrainContent>
+      );
     expect(screen.getByTestId('pinned')).toBeInTheDocument();
     expect(registerRef).toHaveBeenCalledWith('pinned', expect.any(HTMLElement));
   });
@@ -56,11 +64,19 @@ describe('BrainContent', () => {
   it('passes props to BrainContentInput', () => {
     bpValue = 'S';
     const onCancel = jest.fn();
-    render(
-      <BrainContent activeDrop={{ id: 'x' }} onCancelReplyQuote={onCancel}>
-        child
-      </BrainContent>
-    );
+      render(
+        <BrainContent
+          activeDrop={{
+            id: 'x',
+            action: ActiveDropAction.REPLY,
+            drop: { id: 'x', wave: { id: 'w' } } as any,
+            partId: 0,
+          } as any}
+          onCancelReplyQuote={onCancel}
+        >
+          child
+        </BrainContent>
+      );
     expect(screen.getByTestId('input')).toHaveTextContent('x');
     fireEvent.click(screen.getByText('cancel'));
     expect(onCancel).toHaveBeenCalled();

--- a/__tests__/components/brain/content/input/BrainContentInput.test.tsx
+++ b/__tests__/components/brain/content/input/BrainContentInput.test.tsx
@@ -55,7 +55,7 @@ describe('BrainContentInput', () => {
 
   it('uses capacitor height and triggers onWaveNotFound', () => {
     const onCancel = jest.fn();
-    let onWaveNotFound: Function | null = null;
+    let onWaveNotFound: (() => void) | null = null;
     useCapacitorMock.mockReturnValue({ isCapacitor: true });
     useWaveDataMock.mockImplementation((args: any) => {
       onWaveNotFound = args.onWaveNotFound;
@@ -70,7 +70,9 @@ describe('BrainContentInput', () => {
     expect(screen.getByTestId('creator').parentElement?.className).toContain(
       'tw-max-h-[calc(100vh-14.7rem)]'
     );
-    onWaveNotFound && onWaveNotFound();
+    if (onWaveNotFound) {
+      (onWaveNotFound as any)();
+    }
     expect(onCancel).toHaveBeenCalled();
   });
 });

--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BrainLeftSidebarWavePin from '../../../../../components/brain/left-sidebar/waves/BrainLeftSidebarWavePin';
+import { MAX_PINNED_WAVES } from '../../../../../hooks/usePinnedWaves';
+import { useMyStream } from '../../../../../contexts/wave/MyStreamContext';
+import { usePinnedWaves } from '../../../../../hooks/usePinnedWaves';
+
+jest.mock('@tippyjs/react', () => (props: any) => <div data-testid="tippy" data-content={props.content}>{props.children}</div>);
+jest.mock('@fortawesome/react-fontawesome', () => ({ FontAwesomeIcon: () => <svg data-testid="icon" /> }));
+jest.mock('../../../../../contexts/wave/MyStreamContext');
+jest.mock('../../../../../hooks/usePinnedWaves');
+
+const addPinnedWave = jest.fn();
+const removePinnedWave = jest.fn();
+const mockedUseMyStream = useMyStream as jest.Mock;
+const mockedUsePinnedWaves = usePinnedWaves as jest.Mock;
+
+function setup(isPinned = false, storedPinned: string[] = []) {
+  mockedUseMyStream.mockReturnValue({ waves: { addPinnedWave, removePinnedWave } });
+  mockedUsePinnedWaves.mockReturnValue({ pinnedIds: [] });
+  localStorage.setItem('pinnedWave', JSON.stringify(storedPinned));
+  return render(<BrainLeftSidebarWavePin waveId="1" isPinned={isPinned} />);
+}
+
+describe('BrainLeftSidebarWavePin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('unpins wave when already pinned', async () => {
+    const user = userEvent.setup();
+    setup(true, ['1']);
+    await user.click(screen.getByRole('button', { name: /unpin wave/i }));
+    expect(removePinnedWave).toHaveBeenCalledWith('1');
+    expect(addPinnedWave).not.toHaveBeenCalled();
+  });
+
+  it('pins wave when under max limit', async () => {
+    const user = userEvent.setup();
+    setup(false, []);
+    await user.click(screen.getByRole('button', { name: /pin wave/i }));
+    expect(addPinnedWave).toHaveBeenCalledWith('1');
+    expect(removePinnedWave).not.toHaveBeenCalled();
+  });
+
+  it('shows tooltip and does not pin when max limit reached', async () => {
+    const user = userEvent.setup();
+    const maxList = Array(MAX_PINNED_WAVES).fill('x');
+    setup(false, maxList);
+    await user.click(screen.getByRole('button', { name: /pin wave/i }));
+    expect(addPinnedWave).not.toHaveBeenCalled();
+    const tippy = screen.getByTestId('tippy');
+    expect(tippy).toHaveAttribute('data-content', `Max ${MAX_PINNED_WAVES} pinned waves. Unpin another wave first.`);
+  });
+});


### PR DESCRIPTION
## Summary
- improve coverage for BrainLeftSidebarWavePin
- fix type errors in BrainContent tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage`