### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/components/brain/content/BrainContent.test.tsx
+++ b/__tests__/components/brain/content/BrainContent.test.tsx
@@ -35,7 +35,7 @@ describe('BrainContent', () => {
   it('shows pinned waves on small breakpoint', () => {
     bpValue = 'S';
     render(
-      <BrainContent activeDrop={{ id: 'd' }} onCancelReplyQuote={jest.fn()}>
+      <BrainContent activeDrop={{ id: 'd' } as any} onCancelReplyQuote={jest.fn()}>
         child
       </BrainContent>
     );
@@ -57,7 +57,7 @@ describe('BrainContent', () => {
     bpValue = 'S';
     const onCancel = jest.fn();
     render(
-      <BrainContent activeDrop={{ id: 'x' }} onCancelReplyQuote={onCancel}>
+      <BrainContent activeDrop={{ id: 'x' } as any} onCancelReplyQuote={onCancel}>
         child
       </BrainContent>
     );

--- a/__tests__/components/brain/content/input/BrainContentInput.test.tsx
+++ b/__tests__/components/brain/content/input/BrainContentInput.test.tsx
@@ -70,7 +70,7 @@ describe('BrainContentInput', () => {
     expect(screen.getByTestId('creator').parentElement?.className).toContain(
       'tw-max-h-[calc(100vh-14.7rem)]'
     );
-    onWaveNotFound && onWaveNotFound();
+    if (onWaveNotFound) (onWaveNotFound as any)();
     expect(onCancel).toHaveBeenCalled();
   });
 });

--- a/__tests__/components/brain/feed/FeedScrollContainer.test.tsx
+++ b/__tests__/components/brain/feed/FeedScrollContainer.test.tsx
@@ -1,0 +1,71 @@
+import { render, fireEvent } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
+import React, { createRef } from 'react';
+import { FeedScrollContainer } from '../../../../components/brain/feed/FeedScrollContainer';
+
+jest.useFakeTimers();
+
+describe('FeedScrollContainer', () => {
+  function setup(childrenCount = 35) {
+    const onUp = jest.fn();
+    const onDown = jest.fn();
+    const ref = createRef<HTMLDivElement>();
+    const children = Array.from({ length: childrenCount }, (_, i) => (
+      <div key={i} id={`feed-item-${i}`}>item {i}</div>
+    ));
+    const { container } = render(
+      <FeedScrollContainer
+        ref={ref}
+        onScrollUpNearTop={onUp}
+        onScrollDownNearBottom={onDown}
+        className="test-container"
+      >
+        {children}
+      </FeedScrollContainer>
+    );
+    const wrapper = container.querySelector('.test-container') as HTMLDivElement;
+    if (!wrapper) throw new Error('wrapper not found');
+    Object.defineProperty(wrapper, 'clientHeight', { value: 300 });
+    Object.defineProperty(wrapper, 'scrollHeight', { value: 1000, writable: true });
+    Object.defineProperty(wrapper, 'getBoundingClientRect', {
+      value: () => ({ top: 100, bottom: 400 } as DOMRect)
+    });
+    const items = Array.from(wrapper.querySelectorAll('[id^="feed-item-"]')) as HTMLDivElement[];
+    items.forEach((el, idx) => {
+      Object.defineProperty(el, 'getBoundingClientRect', {
+        value: () => ({ top: idx * 20, bottom: idx * 20 + 10 } as DOMRect)
+      });
+    });
+    return { wrapper, onUp, onDown };
+  }
+
+  it('calls onScrollUpNearTop when scrolling up near the top', () => {
+    const { wrapper, onUp } = setup(31);
+    wrapper.scrollTop = 200;
+    act(() => {
+      fireEvent.scroll(wrapper, { currentTarget: wrapper });
+      jest.runAllTimers();
+    });
+    wrapper.scrollTop = 50;
+    act(() => {
+      fireEvent.scroll(wrapper, { currentTarget: wrapper });
+      jest.runAllTimers();
+    });
+    expect(onUp).toHaveBeenCalled();
+  });
+
+  it('calls onScrollDownNearBottom when scrolling down near the bottom', () => {
+    const { wrapper, onDown } = setup(10);
+    wrapper.scrollTop = 0;
+    act(() => {
+      fireEvent.scroll(wrapper, { currentTarget: wrapper });
+      jest.runAllTimers();
+    });
+    wrapper.scrollTop = 701;
+    act(() => {
+      fireEvent.scroll(wrapper, { currentTarget: wrapper });
+      jest.runAllTimers();
+    });
+    expect(onDown).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/brain/feed/items/drop-replied/FeedItemDropReplied.test.tsx
+++ b/__tests__/components/brain/feed/items/drop-replied/FeedItemDropReplied.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import FeedItemDropReplied from '../../../../../../components/brain/feed/items/drop-replied/FeedItemDropReplied';
+
+const push = jest.fn();
+jest.mock('next/router', () => ({ useRouter: () => ({ push }) }));
+
+jest.mock('../../../../../../components/waves/drops/Drop', () => ({
+  __esModule: true,
+  default: ({ onReplyClick, onQuoteClick }: any) => (
+    <div>
+      <button onClick={() => onReplyClick(1)}>reply</button>
+      <button onClick={() => onQuoteClick({ wave: { id: 'w2' }, serial_no: 8 })}>quote</button>
+    </div>
+  ),
+  DropLocation: { MY_STREAM: 'MY_STREAM' },
+  DropSize: { FULL: 'FULL' }
+}));
+
+describe('FeedItemDropReplied', () => {
+  const baseItem = {
+    item: { reply: { wave: { id: 'w1' } } }
+  } as any;
+
+  it('navigates to reply and quote targets', () => {
+    render(
+      <FeedItemDropReplied
+        item={baseItem}
+        showWaveInfo={false}
+        activeDrop={null}
+        onReply={jest.fn()}
+        onQuote={jest.fn()}
+      />
+    );
+    fireEvent.click(screen.getByText('reply'));
+    expect(push).toHaveBeenCalledWith('/my-stream?wave=w1&serialNo=1/');
+    fireEvent.click(screen.getByText('quote'));
+    expect(push).toHaveBeenCalledWith('/my-stream?wave=w2&serialNo=8/');
+  });
+});

--- a/__tests__/components/brain/left-sidebar/search-wave/BrainLeftSidebarSearchWaveDropdownContent.test.tsx
+++ b/__tests__/components/brain/left-sidebar/search-wave/BrainLeftSidebarSearchWaveDropdownContent.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import BrainLeftSidebarSearchWaveDropdownContent from '../../../../../components/brain/left-sidebar/search-wave/BrainLeftSidebarSearchWaveDropdownContent';
+
+jest.mock('../../../../../components/brain/left-sidebar/search-wave/BrainLeftSidebarSearchWaveItem', () => ({
+  __esModule: true,
+  default: ({ wave }: any) => <li data-testid="wave-item">{wave.name}</li>
+}));
+
+describe('BrainLeftSidebarSearchWaveDropdownContent', () => {
+  it('renders loading state', () => {
+    render(
+      <BrainLeftSidebarSearchWaveDropdownContent loading waves={[]} onClose={jest.fn()} listType="waves" />
+    );
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('renders list of waves when present', () => {
+    const waves = [{ id: '1', name: 'A' }, { id: '2', name: 'B' }];
+    render(
+      <BrainLeftSidebarSearchWaveDropdownContent loading={false} waves={waves as any} onClose={jest.fn()} listType="waves" />
+    );
+    expect(screen.getAllByTestId('wave-item')).toHaveLength(2);
+  });
+
+  it('renders no results message when list empty', () => {
+    render(
+      <BrainLeftSidebarSearchWaveDropdownContent loading={false} waves={[]} onClose={jest.fn()} listType="waves" />
+    );
+    expect(screen.getByText('No results')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/brain/left-sidebar/search-wave/BrainLeftSidebarSearchWaveItem.test.tsx
+++ b/__tests__/components/brain/left-sidebar/search-wave/BrainLeftSidebarSearchWaveItem.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import BrainLeftSidebarSearchWaveItem from '../../../../../components/brain/left-sidebar/search-wave/BrainLeftSidebarSearchWaveItem';
+
+const push = jest.fn();
+const registerWave = jest.fn();
+const prefetchWaveData = jest.fn();
+
+jest.mock('next/router', () => ({ useRouter: () => ({ push, query: {} }) }));
+jest.mock('../../../../../hooks/usePrefetchWaveData', () => ({ usePrefetchWaveData: () => prefetchWaveData }));
+jest.mock('../../../../../contexts/wave/MyStreamContext', () => ({ useMyStream: () => ({ registerWave }) }));
+jest.mock('../../../../../hooks/useWave', () => ({ useWave: () => ({ isDm: false }) }));
+jest.mock('../../../../../components/waves/WavePicture', () => ({ __esModule: true, default: () => <div data-testid="pic" /> }));
+
+describe('BrainLeftSidebarSearchWaveItem', () => {
+  const wave = { id: 'w1', name: 'Wave', picture: 'p', contributors_overview: [], author: { handle: 'user' }, wave: { type: 'CHAT' } } as any;
+  it('navigates on click and closes', () => {
+    const onClose = jest.fn();
+    render(<BrainLeftSidebarSearchWaveItem wave={wave} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('link'));
+    expect(push).toHaveBeenCalledWith('/my-stream?wave=w1', undefined, { shallow: true });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('prefetches on hover when not active', () => {
+    render(<BrainLeftSidebarSearchWaveItem wave={wave} onClose={jest.fn()} />);
+    fireEvent.mouseEnter(screen.getByRole('link'));
+    expect(registerWave).toHaveBeenCalledWith('w1');
+    expect(prefetchWaveData).toHaveBeenCalledWith('w1');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for FeedScrollContainer behaviors
- cover DropReplied item navigation
- test search wave dropdown content and item components
- fix type-check errors in existing tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run improve-coverage`