### PR TITLE
Improve test coverage for BrainMobileTabs

### DIFF
--- a/__tests__/components/brain/content/BrainContent.test.tsx
+++ b/__tests__/components/brain/content/BrainContent.test.tsx
@@ -35,7 +35,7 @@ describe('BrainContent', () => {
   it('shows pinned waves on small breakpoint', () => {
     bpValue = 'S';
     render(
-      <BrainContent activeDrop={{ id: 'd' }} onCancelReplyQuote={jest.fn()}>
+      <BrainContent activeDrop={{ id: 'd' } as any} onCancelReplyQuote={jest.fn()}>
         child
       </BrainContent>
     );
@@ -57,7 +57,7 @@ describe('BrainContent', () => {
     bpValue = 'S';
     const onCancel = jest.fn();
     render(
-      <BrainContent activeDrop={{ id: 'x' }} onCancelReplyQuote={onCancel}>
+      <BrainContent activeDrop={{ id: 'x' } as any} onCancelReplyQuote={onCancel}>
         child
       </BrainContent>
     );

--- a/__tests__/components/brain/content/input/BrainContentInput.test.tsx
+++ b/__tests__/components/brain/content/input/BrainContentInput.test.tsx
@@ -55,7 +55,7 @@ describe('BrainContentInput', () => {
 
   it('uses capacitor height and triggers onWaveNotFound', () => {
     const onCancel = jest.fn();
-    let onWaveNotFound: Function | null = null;
+    let onWaveNotFound: (() => void) | null = null;
     useCapacitorMock.mockReturnValue({ isCapacitor: true });
     useWaveDataMock.mockImplementation((args: any) => {
       onWaveNotFound = args.onWaveNotFound;
@@ -70,7 +70,7 @@ describe('BrainContentInput', () => {
     expect(screen.getByTestId('creator').parentElement?.className).toContain(
       'tw-max-h-[calc(100vh-14.7rem)]'
     );
-    onWaveNotFound && onWaveNotFound();
+    (onWaveNotFound as any)?.();
     expect(onCancel).toHaveBeenCalled();
   });
 });

--- a/__tests__/components/brain/mobile/BrainMobileTabs.test.tsx
+++ b/__tests__/components/brain/mobile/BrainMobileTabs.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import BrainMobileTabs from '../../../../components/brain/mobile/BrainMobileTabs';
+
+enum BrainView {
+  DEFAULT = 'DEFAULT',
+  ABOUT = 'ABOUT',
+  LEADERBOARD = 'LEADERBOARD',
+  WINNERS = 'WINNERS',
+  OUTCOME = 'OUTCOME',
+  MY_VOTES = 'MY_VOTES',
+  FAQ = 'FAQ',
+  WAVES = 'WAVES',
+  MESSAGES = 'MESSAGES',
+  NOTIFICATIONS = 'NOTIFICATIONS',
+}
+
+const push = jest.fn();
+
+jest.mock('next/router', () => ({ useRouter: () => ({ push }) }));
+
+jest.mock('react-use', () => ({
+  createBreakpoint: () => () => 'S',
+}));
+
+const registerRef = jest.fn();
+jest.mock('../../../../components/brain/my-stream/layout/LayoutContext', () => ({
+  useLayout: () => ({ registerRef })
+}));
+
+jest.mock('../../../../hooks/useWave', () => ({
+  useWave: jest.fn()
+}));
+
+jest.mock('../../../../hooks/useUnreadIndicator', () => ({
+  useUnreadIndicator: jest.fn()
+}));
+
+jest.mock('../../../../hooks/useUnreadNotifications', () => ({
+  useUnreadNotifications: jest.fn()
+}));
+
+jest.mock('../../../../components/auth/Auth', () => ({
+  useAuth: () => ({ connectedProfile: { handle: 'alice' } })
+}));
+
+const leaderboardMock = jest.fn();
+jest.mock('../../../../components/brain/my-stream/MyStreamWaveTabsLeaderboard', () => ({
+  __esModule: true,
+  default: (props: any) => { leaderboardMock(props); return <div data-testid="leaderboard"/>; }
+}));
+
+(HTMLElement.prototype as any).scrollIntoView = jest.fn();
+
+const { useWave } = require('../../../../hooks/useWave');
+const { useUnreadIndicator } = require('../../../../hooks/useUnreadIndicator');
+const { useUnreadNotifications } = require('../../../../hooks/useUnreadNotifications');
+
+describe('BrainMobileTabs', () => {
+  const onViewChange = jest.fn();
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useWave as jest.Mock).mockReturnValue({ isMemesWave: false, isRankWave: false });
+    (useUnreadIndicator as jest.Mock).mockReturnValue({ hasUnread: false });
+    (useUnreadNotifications as jest.Mock).mockReturnValue({ haveUnreadNotifications: false });
+  });
+
+  it('renders back button and navigates to My Stream', async () => {
+    (useWave as jest.Mock).mockReturnValue({ isMemesWave: false, isRankWave: false });
+    render(
+      <BrainMobileTabs
+        activeView={BrainView.DEFAULT}
+        onViewChange={onViewChange}
+        waveActive={true}
+        showWavesTab={false}
+        showStreamBack={true}
+        isApp={false}
+      />
+    );
+
+    const button = screen.getByRole('button', { name: /my stream/i });
+    expect(button).toBeInTheDocument();
+    await userEvent.click(button);
+    expect(push).toHaveBeenCalledWith('/my-stream', undefined, { shallow: true });
+    expect(onViewChange).toHaveBeenCalledWith(BrainView.DEFAULT);
+  });
+
+  it('shows unread indicators and handles message/notification clicks', async () => {
+    (useWave as jest.Mock).mockReturnValue({ isMemesWave: false, isRankWave: false });
+    (useUnreadIndicator as jest.Mock).mockReturnValue({ hasUnread: true });
+    (useUnreadNotifications as jest.Mock).mockReturnValue({ haveUnreadNotifications: true });
+
+    render(
+      <BrainMobileTabs
+        activeView={BrainView.DEFAULT}
+        onViewChange={onViewChange}
+        waveActive={false}
+        showWavesTab={true}
+        showStreamBack={false}
+        isApp={false}
+      />
+    );
+
+    expect(screen.getByText('Waves')).toBeInTheDocument();
+    const messages = screen.getByRole('button', { name: /messages/i });
+    const notifications = screen.getByRole('button', { name: /notifications/i });
+    expect(messages.querySelector('.tw-bg-red')).toBeInTheDocument();
+    expect(notifications.querySelector('.tw-bg-red')).toBeInTheDocument();
+
+    await userEvent.click(messages);
+    expect(onViewChange).toHaveBeenCalledWith(BrainView.MESSAGES);
+    await userEvent.click(notifications);
+    expect(onViewChange).toHaveBeenCalledWith(BrainView.NOTIFICATIONS);
+  });
+
+  it('renders leaderboard and extra tabs for memes rank wave', () => {
+    (useWave as jest.Mock).mockReturnValue({ isMemesWave: true, isRankWave: true });
+
+    render(
+      <BrainMobileTabs
+        activeView={BrainView.ABOUT}
+        onViewChange={onViewChange}
+        waveActive={true}
+        showWavesTab={false}
+        showStreamBack={false}
+        isApp={false}
+        wave={{ id: '1' } as any}
+      />
+    );
+
+    expect(screen.getByTestId('leaderboard')).toBeInTheDocument();
+    expect(leaderboardMock).toHaveBeenCalledWith(
+      expect.objectContaining({ wave: { id: '1' }, activeView: BrainView.ABOUT, onViewChange })
+    );
+    expect(screen.getByText('My Votes')).toBeInTheDocument();
+    expect(screen.getByText('Outcome')).toBeInTheDocument();
+    expect(screen.getByText('FAQ')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for BrainMobileTabs and adjust existing tests for types
- ensure type-check passes by updating tests

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
- `npm run improve-coverage`