### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/components/brain/feed/items/drop-created/FeedItemDropCreated.test.tsx
+++ b/__tests__/components/brain/feed/items/drop-created/FeedItemDropCreated.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import FeedItemDropCreated from '../../../../../../components/brain/feed/items/drop-created/FeedItemDropCreated';
+
+const push = jest.fn();
+jest.mock('next/router', () => ({ useRouter: () => ({ push }) }));
+
+jest.mock('../../../../../../components/waves/drops/Drop', () => ({
+  __esModule: true,
+  default: ({ onReplyClick, onQuoteClick }: any) => (
+    <div>
+      <button onClick={() => onReplyClick(5)}>reply</button>
+      <button onClick={() => onQuoteClick({ wave: { id: 'wave1' }, serial_no: 3 })}>quote</button>
+    </div>
+  ),
+  DropLocation: { MY_STREAM: 'MY_STREAM' },
+  DropSize: { FULL: 'FULL' }
+}));
+
+describe('FeedItemDropCreated', () => {
+  const baseItem = {
+    item: { wave: { id: 'wave1' } },
+    serial_no: 2,
+    type: 'DROP_CREATED'
+  } as any;
+
+  it('navigates to reply and quote targets', () => {
+    render(
+      <FeedItemDropCreated
+        item={baseItem}
+        showWaveInfo={false}
+        activeDrop={null}
+        onReply={jest.fn()}
+        onQuote={jest.fn()}
+      />
+    );
+    fireEvent.click(screen.getByText('reply'));
+    expect(push).toHaveBeenCalledWith('/my-stream?wave=wave1&serialNo=5/');
+    fireEvent.click(screen.getByText('quote'));
+    expect(push).toHaveBeenCalledWith('/my-stream?wave=wave1&serialNo=3/');
+  });
+});

--- a/__tests__/components/brain/left-sidebar/search-wave/BrainLeftSidebarSearchWaveDropdown.test.tsx
+++ b/__tests__/components/brain/left-sidebar/search-wave/BrainLeftSidebarSearchWaveDropdown.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import BrainLeftSidebarSearchWaveDropdown from '../../../../../components/brain/left-sidebar/search-wave/BrainLeftSidebarSearchWaveDropdown';
+
+const useWaves = jest.fn();
+
+jest.mock('../../../../../hooks/useWaves', () => ({ useWaves: (...args: any[]) => useWaves(...args) }));
+
+jest.mock('../../../../../components/brain/left-sidebar/search-wave/BrainLeftSidebarSearchWaveDropdownContent', () => ({
+  __esModule: true,
+  default: ({ waves, loading }: any) => (
+    <div data-testid="content">{loading ? 'loading' : waves.map((w: any) => w.name).join(',')}</div>
+  )
+}));
+
+describe('BrainLeftSidebarSearchWaveDropdown', () => {
+  it('does not render when closed', () => {
+    useWaves.mockReturnValue({ waves: [], isFetching: false });
+    const { container } = render(
+      <BrainLeftSidebarSearchWaveDropdown open={false} searchCriteria={null} onClose={jest.fn()} listType="waves" />
+    );
+    expect(container.querySelector('[data-testid="content"]')).toBeNull();
+  });
+
+  it('shows waves when open', () => {
+    useWaves.mockReturnValue({ waves: [{ id: '1', name: 'Wave1' }], isFetching: false });
+    render(
+      <BrainLeftSidebarSearchWaveDropdown open searchCriteria="wave" onClose={jest.fn()} listType="waves" />
+    );
+    expect(screen.getByTestId('content')).toHaveTextContent('Wave1');
+  });
+});

--- a/__tests__/components/brain/my-stream/tabs/MyStreamWaveTabsDefault.test.tsx
+++ b/__tests__/components/brain/my-stream/tabs/MyStreamWaveTabsDefault.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import MyStreamWaveTabsDefault from '../../../../../components/brain/my-stream/tabs/MyStreamWaveTabsDefault';
+
+const useContentTab = jest.fn();
+
+jest.mock('../../../../../components/brain/my-stream/MyStreamWaveDesktopTabs', () => ({
+  __esModule: true,
+  default: ({ activeTab, setActiveTab }: any) => (
+    <div>
+      <span data-testid="active">{activeTab}</span>
+      <button onClick={() => setActiveTab('NEW')}>change</button>
+    </div>
+  )
+}));
+
+jest.mock('../../../../../components/brain/ContentTabContext', () => ({
+  useContentTab: (...args: any[]) => useContentTab(...args)
+}));
+
+describe('MyStreamWaveTabsDefault', () => {
+  it('passes active tab and handles tab change', () => {
+    const setActiveContentTab = jest.fn();
+    useContentTab.mockReturnValue({ activeContentTab: 'CHAT', setActiveContentTab });
+    const wave = { id: 'w1' } as any;
+    render(<MyStreamWaveTabsDefault wave={wave} />);
+    expect(screen.getByTestId('active')).toHaveTextContent('CHAT');
+    fireEvent.click(screen.getByText('change'));
+    expect(setActiveContentTab).toHaveBeenCalledWith('NEW');
+  });
+});

--- a/__tests__/components/brain/my-stream/tabs/MyStreamWaveTabsMeme.test.tsx
+++ b/__tests__/components/brain/my-stream/tabs/MyStreamWaveTabsMeme.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import MyStreamWaveTabsMeme from '../../../../../components/brain/my-stream/tabs/MyStreamWaveTabsMeme';
+
+const useContentTab = jest.fn();
+
+jest.mock('../../../../../components/brain/my-stream/MyStreamWaveDesktopTabs', () => ({
+  __esModule: true,
+  default: ({ activeTab }: any) => <div data-testid="desktop">{activeTab}</div>
+}));
+
+jest.mock('../../../../../components/brain/ContentTabContext', () => ({
+  useContentTab: (...args: any[]) => useContentTab(...args)
+}));
+
+jest.mock('../../../../../components/waves/memes/MemesArtSubmissionModal', () => ({
+  __esModule: true,
+  default: ({ isOpen }: any) => isOpen ? <div data-testid="modal">open</div> : null
+}));
+
+jest.mock('../../../../../components/brain/my-stream/tabs/MyStreamWaveTabsMemeSubmit', () => ({
+  __esModule: true,
+  default: ({ handleMemesSubmit }: any) => <button onClick={handleMemesSubmit}>submit</button>
+}));
+
+describe('MyStreamWaveTabsMeme', () => {
+  it('opens modal when submit clicked and passes active tab', () => {
+    const setActiveContentTab = jest.fn();
+    useContentTab.mockReturnValue({ activeContentTab: 'CHAT', setActiveContentTab });
+    const wave = { id: 'w1', name: 'Wave' } as any;
+    render(<MyStreamWaveTabsMeme wave={wave} />);
+    expect(screen.getByTestId('desktop')).toHaveTextContent('CHAT');
+    fireEvent.click(screen.getByText('submit'));
+    expect(screen.getByTestId('modal')).toHaveTextContent('open');
+  });
+});

--- a/__tests__/components/brain/right-sidebar/WaveContent.test.tsx
+++ b/__tests__/components/brain/right-sidebar/WaveContent.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { ApiWaveType } from '../../../../generated/models/ApiWaveType';
+import { Mode, SidebarTab } from '../../../../components/brain/right-sidebar/BrainRightSidebar';
+import { WaveContent } from '../../../../components/brain/right-sidebar/WaveContent';
+
+const useWaveTimers = jest.fn();
+
+jest.mock('../../../../hooks/useWaveTimers', () => ({ useWaveTimers: (...args: any[]) => useWaveTimers(...args) }));
+
+jest.mock('../../../../components/waves/header/WaveHeader', () => ({
+  __esModule: true,
+  default: () => <div data-testid="header">header</div>,
+  WaveHeaderPinnedSide: { LEFT: 'LEFT' }
+}));
+
+jest.mock('../../../../components/common/TabToggleWithOverflow', () => ({
+  __esModule: true,
+  TabToggleWithOverflow: ({ options, activeKey }: any) => (
+    <div data-testid="tabs">{activeKey}-{options.length}</div>
+  )
+}));
+
+jest.mock('../../../../components/waves/winners/WaveWinnersSmall', () => ({ __esModule: true, WaveWinnersSmall: () => <div>winners</div> }));
+jest.mock('../../../../components/waves/small-leaderboard/WaveSmallLeaderboard', () => ({ __esModule: true, WaveSmallLeaderboard: () => <div>leaderboard</div> }));
+jest.mock('../../../../components/waves/leaderboard/sidebar/WaveLeaderboardRightSidebarVoters', () => ({ __esModule: true, WaveLeaderboardRightSidebarVoters: () => <div>voters</div> }));
+jest.mock('../../../../components/waves/leaderboard/sidebar/WaveLeaderboardRightSidebarActivityLogs', () => ({ __esModule: true, WaveLeaderboardRightSidebarActivityLogs: () => <div>logs</div> }));
+jest.mock('../../../../components/brain/right-sidebar/BrainRightSidebarContent', () => ({ __esModule: true, default: () => <div>content</div> }));
+jest.mock('../../../../components/brain/right-sidebar/BrainRightSidebarFollowers', () => ({ __esModule: true, default: () => <div>followers</div> }));
+
+describe('WaveContent', () => {
+  const wave = { wave: { type: ApiWaveType.Chat }, name: 'Wave' } as any;
+
+  it('renders non-rank wave without tabs', () => {
+    useWaveTimers.mockReturnValue({ voting: { isCompleted: false }, decisions: { firstDecisionDone: false } });
+    render(
+      <WaveContent wave={wave} mode={Mode.CONTENT} setMode={jest.fn()} activeTab={SidebarTab.ABOUT} setActiveTab={jest.fn()} onDropClick={jest.fn()} />
+    );
+    expect(screen.getByTestId('header')).toBeInTheDocument();
+    expect(screen.queryByTestId('tabs')).toBeNull();
+    expect(screen.getByText('content')).toBeInTheDocument();
+  });
+
+  it('switches tab to about when voting completed', () => {
+    const setActiveTab = jest.fn();
+    useWaveTimers.mockReturnValue({ voting: { isCompleted: true }, decisions: { firstDecisionDone: true } });
+    render(
+      <WaveContent wave={{ wave: { type: ApiWaveType.Rank }, name: 'Wave' } as any} mode={Mode.CONTENT} setMode={jest.fn()} activeTab={SidebarTab.LEADERBOARD} setActiveTab={setActiveTab} onDropClick={jest.fn()} />
+    );
+    expect(setActiveTab).toHaveBeenCalledWith(SidebarTab.ABOUT);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for FeedItemDropCreated and dropdown components
- cover my-stream tabs and wave content behaviors

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
