### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/components/common/icons/BellIcon.test.tsx
+++ b/__tests__/components/common/icons/BellIcon.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react';
+import BellIcon from '../../../../components/common/icons/BellIcon';
+
+describe('BellIcon', () => {
+  it('renders svg with given class and attributes', () => {
+    const { container } = render(<BellIcon className="ring" />);
+    const svg = container.querySelector('svg') as SVGElement;
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+    expect(svg).toHaveClass('ring');
+    expect(svg.getAttribute('stroke-width')).toBe('1.65');
+  });
+
+  it('contains correct path definition', () => {
+    const { container } = render(<BellIcon />);
+    const path = container.querySelector('path');
+    expect(path).toBeInTheDocument();
+    expect(path?.getAttribute('stroke-linecap')).toBe('round');
+    expect(path?.getAttribute('stroke-linejoin')).toBe('round');
+    expect(path?.getAttribute('d')).toContain('17.082');
+  });
+});

--- a/__tests__/components/common/icons/WavesIcon.test.tsx
+++ b/__tests__/components/common/icons/WavesIcon.test.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react';
+import WavesIcon from '../../../../components/common/icons/WavesIcon';
+
+describe('WavesIcon', () => {
+  it('renders svg with class and viewBox', () => {
+    const { container } = render(<WavesIcon className="wave" />);
+    const svg = container.querySelector('svg') as SVGElement;
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('viewBox', '0 0 512 512');
+    expect(svg).toHaveClass('wave');
+  });
+
+  it('renders three path elements with expected attributes', () => {
+    const { container } = render(<WavesIcon />);
+    const paths = container.querySelectorAll('path');
+    expect(paths.length).toBe(3);
+    expect(paths[0]).toHaveAttribute('fill', 'none');
+    expect(paths[0].getAttribute('d')).toContain('M397.9');
+    expect(paths[1]).toHaveAttribute('fill', 'none');
+    expect(paths[1].getAttribute('d')).toContain('M436.9');
+    expect(paths[2]).toHaveAttribute('fill', 'currentColor');
+  });
+});

--- a/__tests__/components/community/CommunityMembers.test.tsx
+++ b/__tests__/components/community/CommunityMembers.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CommunityMembers from '../../../components/community/CommunityMembers';
+import { useRouter } from 'next/router';
+import { useSearchParams, usePathname } from 'next/navigation';
+import { useSelector } from 'react-redux';
+import { useQuery } from '@tanstack/react-query';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+  useSearchParams: jest.fn()
+}));
+jest.mock('react-redux', () => ({ useSelector: jest.fn() }));
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: jest.fn(),
+  keepPreviousData: jest.fn()
+}));
+
+jest.mock('react-use', () => ({ useDebounce: () => {} }));
+
+jest.mock('../../../components/community/members-table/CommunityMembersTable', () => (props: any) => (
+  <div data-testid="table">{props.members.length}</div>
+));
+
+jest.mock('../../../components/utils/table/paginator/CommonTablePagination', () => (props: any) => (
+  <div data-testid="pagination">{props.totalPages}</div>
+));
+
+jest.mock('../../../components/utils/animation/CommonCardSkeleton', () => () => <div data-testid="skeleton" />);
+
+const push = jest.fn();
+const replace = jest.fn();
+
+const searchParamsMock = new Map<string, string | null>();
+(usePathname as jest.Mock).mockReturnValue('/network');
+(useSearchParams as jest.Mock).mockReturnValue({
+  get: (key: string) => searchParamsMock.get(key) ?? null
+});
+(useRouter as jest.Mock).mockReturnValue({ push, replace });
+(useSelector as jest.Mock).mockReturnValue('1');
+
+function renderComponent() {
+  return render(<CommunityMembers />);
+}
+
+describe('CommunityMembers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    searchParamsMock.clear();
+    (usePathname as jest.Mock).mockReturnValue('/network');
+    (useSearchParams as jest.Mock).mockReturnValue({
+      get: (key: string) => searchParamsMock.get(key) ?? null
+    });
+    (useRouter as jest.Mock).mockReturnValue({ push, replace });
+    (useSelector as jest.Mock).mockReturnValue('1');
+  });
+
+  it('shows skeleton while no members', () => {
+    (useQuery as jest.Mock).mockReturnValue({ isLoading: false, isFetching: false, data: null });
+    renderComponent();
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+  });
+
+  it('renders table and pagination when members loaded', () => {
+    (useQuery as jest.Mock).mockReturnValue({
+      isLoading: false,
+      isFetching: false,
+      data: { page: 1, next: 2, count: 100, data: [{ id: 1 }, { id: 2 }] }
+    });
+    renderComponent();
+    expect(screen.getByTestId('table')).toHaveTextContent('2');
+    expect(screen.getByTestId('pagination')).toHaveTextContent('2');
+  });
+
+  it('navigates to nerd view on button click', () => {
+    (useQuery as jest.Mock).mockReturnValue({
+      isLoading: false,
+      isFetching: false,
+      data: { page: 1, next: null, count: 2, data: [] }
+    });
+    renderComponent();
+    fireEvent.click(screen.getByText('Nerd view'));
+    expect(push).toHaveBeenCalledWith('/network/nerd');
+  });
+});

--- a/__tests__/components/distribution-plan-tool/DistributionPlanToolPage.test.tsx
+++ b/__tests__/components/distribution-plan-tool/DistributionPlanToolPage.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import DistributionPlanToolPage from '../../../components/distribution-plan-tool/DistributionPlanToolPage';
+import { DistributionPlanToolContext, DistributionPlanToolStep } from '../../../components/distribution-plan-tool/DistributionPlanToolContext';
+
+jest.mock('../../../components/distribution-plan-tool/create-plan/CreatePlan', () => () => <div data-testid="CreatePlan" />);
+jest.mock('../../../components/distribution-plan-tool/create-snapshots/CreateSnapshots', () => () => <div data-testid="CreateSnapshots" />);
+jest.mock('../../../components/distribution-plan-tool/create-custom-snapshots/CreateCustomSnapshots', () => () => <div data-testid="CreateCustomSnapshots" />);
+jest.mock('../../../components/distribution-plan-tool/create-phases/CreatePhases', () => () => <div data-testid="CreatePhases" />);
+jest.mock('../../../components/distribution-plan-tool/build-phases/BuildPhases', () => () => <div data-testid="BuildPhases" />);
+jest.mock('../../../components/distribution-plan-tool/map-delegations/MapDelegations', () => () => <div data-testid="MapDelegations" />);
+jest.mock('../../../components/distribution-plan-tool/review-distribution-plan/ReviewDistributionPlan', () => () => <div data-testid="ReviewDistributionPlan" />);
+
+function renderWithStep(step: DistributionPlanToolStep) {
+  return render(
+    <DistributionPlanToolContext.Provider value={{ step } as any}>
+      <DistributionPlanToolPage />
+    </DistributionPlanToolContext.Provider>
+  );
+}
+
+describe('DistributionPlanToolPage', () => {
+  it('renders create plan step', () => {
+    renderWithStep(DistributionPlanToolStep.CREATE_PLAN);
+    expect(screen.getByTestId('CreatePlan')).toBeInTheDocument();
+  });
+
+  it('renders create snapshots step', () => {
+    renderWithStep(DistributionPlanToolStep.CREATE_SNAPSHOTS);
+    expect(screen.getByTestId('CreateSnapshots')).toBeInTheDocument();
+  });
+
+  it('renders review step', () => {
+    renderWithStep(DistributionPlanToolStep.REVIEW);
+    expect(screen.getByTestId('ReviewDistributionPlan')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for BellIcon and WavesIcon components
- add tests for CommunityMembers and DistributionPlanToolPage

## Testing
- `npm run improve-coverage`