### PR TITLE
Add icon and table row tests

### DIFF
--- a/__tests__/components/CsvIcon.test.tsx
+++ b/__tests__/components/CsvIcon.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import CsvIcon from '../../components/distribution-plan-tool/common/CsvIcon';
+
+describe('CsvIcon', () => {
+  it('renders svg with expected attributes', () => {
+    const { container } = render(<CsvIcon />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('viewBox', '0 0 71 80');
+    expect(svg).toHaveClass('tw-h-auto tw-w-auto tw-text-[#76bc99]');
+  });
+
+  it('contains a path element filled with currentColor', () => {
+    const { container } = render(<CsvIcon />);
+    const path = container.querySelector('path');
+    expect(path).toBeInTheDocument();
+    expect(path?.getAttribute('fill')).toBe('currentColor');
+    expect(path?.getAttribute('d')).toContain('66.37');
+  });
+});

--- a/__tests__/components/FinalizeSnapshotsTableSnapshotTooltipTableRow.test.tsx
+++ b/__tests__/components/FinalizeSnapshotsTableSnapshotTooltipTableRow.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import FinalizeSnapshotsTableSnapshotTooltipTableRow from '../../components/distribution-plan-tool/build-phases/build-phase/form/component-config/snapshots-table/FinalizeSnapshotsTableSnapshotTooltipTableRow';
+
+describe('FinalizeSnapshotsTableSnapshotTooltipTableRow', () => {
+  it('displays provided name and value', () => {
+    render(<FinalizeSnapshotsTableSnapshotTooltipTableRow name="Address" value="0xabc" />);
+    expect(screen.getByText('Address:')).toBeInTheDocument();
+    expect(screen.getByText('0xabc')).toBeInTheDocument();
+  });
+
+  it('handles long values gracefully', () => {
+    const long = 'x'.repeat(50);
+    render(<FinalizeSnapshotsTableSnapshotTooltipTableRow name="Long" value={long} />);
+    expect(screen.getByText(long)).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/brain/right-sidebar/BrainRightSidebar.test.tsx
+++ b/__tests__/components/brain/right-sidebar/BrainRightSidebar.test.tsx
@@ -4,10 +4,10 @@ import React from 'react';
 
 jest.mock('@tanstack/react-query', () => ({ useQuery: jest.fn(), keepPreviousData: {} }));
 
-const WaveContent = jest.fn(() => <div data-testid="content" />);
+const WaveContentMock = jest.fn((props: any) => <div data-testid="content" />);
 jest.mock('../../../../components/brain/right-sidebar/WaveContent', () => ({
   __esModule: true,
-  WaveContent: (props: any) => WaveContent(props),
+  WaveContent: (props: any) => WaveContentMock(props),
 }));
 
 import BrainRightSidebar, { Mode, SidebarTab } from '../../../../components/brain/right-sidebar/BrainRightSidebar';
@@ -37,7 +37,7 @@ describe('BrainRightSidebar', () => {
         setActiveTab={setActiveTab}
       />
     );
-    expect(WaveContent).toHaveBeenCalledWith(
+    expect(WaveContentMock).toHaveBeenCalledWith(
       expect.objectContaining({
         wave,
         mode: Mode.CONTENT,

--- a/__tests__/components/communityDownloads/CommunityDownloadsTDH.test.tsx
+++ b/__tests__/components/communityDownloads/CommunityDownloadsTDH.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react';
+import CommunityDownloadsTDH, { VIEW } from '../../../components/communityDownloads/CommunityDownloadsTDH';
+import CommunityDownloadsComponent from '../../../components/communityDownloads/CommunityDownloadsComponent';
+
+jest.mock('../../../components/communityDownloads/CommunityDownloadsComponent', () => ({
+  __esModule: true,
+  default: jest.fn(() => <div data-testid="mock" />)
+}));
+
+const ComponentMock = CommunityDownloadsComponent as jest.Mock;
+
+describe('CommunityDownloadsTDH', () => {
+  beforeEach(() => {
+    ComponentMock.mockClear();
+    process.env.API_ENDPOINT = 'https://api.test';
+  });
+
+  it('uses consolidated uploads for CONSOLIDATION view', () => {
+    render(<CommunityDownloadsTDH view={VIEW.CONSOLIDATION} />);
+    const props = ComponentMock.mock.calls[0][0];
+    expect(props).toEqual(
+      expect.objectContaining({
+        url: 'https://api.test/api/consolidated_uploads',
+        title: 'Consolidated  Network'
+      })
+    );
+  });
+
+  it('uses uploads for WALLET view', () => {
+    render(<CommunityDownloadsTDH view={VIEW.WALLET} />);
+    const props = ComponentMock.mock.calls[0][0];
+    expect(props).toEqual(
+      expect.objectContaining({
+        url: 'https://api.test/api/uploads',
+        title: ' Network'
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for CommunityDownloadsTDH props
- add tests for CsvIcon
- add tests for FinalizeSnapshotsTableSnapshotTooltipTableRow
- fix MyStream right sidebar test mock naming

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
