### PR TITLE
Add tests for time formatters and downloads

### DIFF
--- a/__tests__/components/community/members-table/CommunityMembersTableRow.test.tsx
+++ b/__tests__/components/community/members-table/CommunityMembersTableRow.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import CommunityMembersTableRow from '../../../../components/community/members-table/CommunityMembersTableRow';
+import { CommunityMemberOverview } from '../../../../entities/IProfile';
+
+jest.mock('../../../../helpers/Helpers', () => ({
+  formatNumberWithCommasOrDash: (n: number) => `#${n}`,
+  cicToType: (n: number) => n,
+}));
+
+jest.mock('../../../../helpers/AllowlistToolHelpers', () => ({
+  isEthereumAddress: (val: string) => val.startsWith('0x'),
+}));
+
+jest.mock('../../../../helpers/image.helpers', () => ({
+  ImageScale: { W_AUTO_H_50: 'AUTOx50' },
+  getScaledImageUri: (url: string) => `scaled-${url}`,
+}));
+
+jest.mock('../../../../components/user/utils/level/UserLevel', () => () => <div data-testid="level" />);
+jest.mock('../../../../components/user/utils/user-cic-type/UserCICTypeIcon', () => () => <div data-testid="icon" />);
+jest.mock('../../../../components/utils/CommonTimeAgo', () => () => <span data-testid="time" />);
+jest.mock('next/link', () => ({ __esModule: true, default: ({ children, href }: any) => <a href={href}>{children}</a> }));
+jest.mock('@tippyjs/react', () => ({ __esModule: true, default: ({ children }: any) => <>{children}</> }));
+
+const baseMember: CommunityMemberOverview = {
+  display: 'Alice',
+  detail_view_key: 'alice',
+  level: 1,
+  tdh: 10,
+  rep: 5,
+  cic: 2,
+  pfp: 'pfp.png',
+  last_activity: 123,
+  wallet: '0x123',
+};
+
+describe('CommunityMembersTableRow', () => {
+  it('renders profile member info', () => {
+    render(
+      <table>
+        <tbody>
+          <CommunityMembersTableRow member={baseMember} rank={1} />
+        </tbody>
+      </table>
+    );
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/alice');
+    expect(screen.getByRole('link')).toHaveTextContent('Alice');
+    expect(screen.getAllByText('#10')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('#5')[0]).toBeInTheDocument();
+    expect(screen.getByTestId('level')).toBeInTheDocument();
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+    expect(screen.getByTestId('time')).toBeInTheDocument();
+  });
+
+  it('applies address styles when detail_view_key is address', () => {
+    const member = { ...baseMember, detail_view_key: '0xabc', display: '0xabc' };
+    render(
+      <table>
+        <tbody>
+          <CommunityMembersTableRow member={member} rank={2} />
+        </tbody>
+      </table>
+    );
+    const rows = screen.getAllByRole('row');
+    expect(rows[0].querySelector('.tw-opacity-50')).not.toBeNull();
+  });
+});

--- a/__tests__/components/communityDownloads/CommunityDownloadsComponent.test.tsx
+++ b/__tests__/components/communityDownloads/CommunityDownloadsComponent.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { CommunityDownloadsComponentRow } from '../../../components/communityDownloads/CommunityDownloadsComponent';
+
+function renderRow(date: string) {
+  return render(
+    <table>
+      <tbody>
+        <CommunityDownloadsComponentRow date={date} url="http://x" />
+      </tbody>
+    </table>
+  );
+}
+
+describe('CommunityDownloadsComponentRow', () => {
+  it('formats YYYYMMDD dates', () => {
+    renderRow('20230102');
+    expect(screen.getByText(new Date(2023,0,2).toDateString())).toBeInTheDocument();
+  });
+
+  it('formats ISO dates', () => {
+    const d = new Date('2023-02-03T00:00:00Z');
+    renderRow(d.toISOString());
+    expect(screen.getByText(d.toDateString())).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/communityDownloads/CommunityDownloadsTeam.test.tsx
+++ b/__tests__/components/communityDownloads/CommunityDownloadsTeam.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import CommunityDownloadsTeam from '../../../components/communityDownloads/CommunityDownloadsTeam';
+
+jest.mock('../../../components/communityDownloads/CommunityDownloadsComponent', () => ({
+  __esModule: true,
+  CommunityDownloadsComponentRow: ({ date, url }: any) => (
+    <tr data-testid="row"><td>{date}</td><td>{url}</td></tr>
+  ),
+}));
+
+describe('CommunityDownloadsTeam', () => {
+  it('lists static downloads', () => {
+    render(<CommunityDownloadsTeam />);
+    const rows = screen.getAllByTestId('row');
+    expect(rows).toHaveLength(3);
+    expect(screen.queryByText('Nothing here yet')).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/hooks/useCountdown.test.ts
+++ b/__tests__/hooks/useCountdown.test.ts
@@ -1,0 +1,44 @@
+import { renderHook, act } from '@testing-library/react';
+import { useCountdown } from '../../hooks/useCountdown';
+
+jest.useFakeTimers();
+
+describe('useCountdown', () => {
+  let now: number;
+  let nowSpy: jest.SpyInstance<number, []>;
+
+  beforeEach(() => {
+    now = 1600000000000;
+    nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => now);
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    nowSpy.mockRestore();
+  });
+
+  it('returns empty string when target is null', () => {
+    const { result } = renderHook(() => useCountdown(null));
+    expect(result.current).toBe('');
+  });
+
+  it('updates countdown over time and ends at "Now"', () => {
+    const target = now + 2 * 60 * 60 * 1000; // 2 hours
+    const { result } = renderHook(() => useCountdown(target));
+    expect(result.current).toBe('in 2h 0m');
+
+    // advance 5 minutes (interval < 1 day -> 5 minutes)
+    act(() => {
+      now += 5 * 60 * 1000;
+      jest.advanceTimersByTime(5 * 60 * 1000);
+    });
+    expect(result.current).toBe('in 1h 55m');
+
+    // advance past target time
+    act(() => {
+      now = target + 1000;
+      jest.advanceTimersByTime(5 * 60 * 1000);
+    });
+    expect(result.current).toBe('Now');
+  });
+});

--- a/__tests__/utils/timeFormatters.test.ts
+++ b/__tests__/utils/timeFormatters.test.ts
@@ -1,0 +1,45 @@
+import { formatCountdown } from '../../utils/timeFormatters';
+
+describe('formatCountdown', () => {
+  const realDateNow = Date.now;
+  let now: number;
+
+  beforeEach(() => {
+    now = 1600000000000; // fixed timestamp
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+  });
+
+  afterEach(() => {
+    (Date.now as jest.Mock).mockRestore();
+  });
+
+  it('returns empty string for null timestamp', () => {
+    expect(formatCountdown(null)).toBe('');
+  });
+
+  it('returns "Now" when timestamp has passed', () => {
+    expect(formatCountdown(now - 1000)).toBe('Now');
+  });
+
+  it('formats times less than a day', () => {
+    const thirtyMinutes = now + 30 * 60 * 1000;
+    expect(formatCountdown(thirtyMinutes)).toBe('in 30m');
+
+    const twoHoursFifteen = now + 2 * 60 * 60 * 1000 + 15 * 60 * 1000;
+    expect(formatCountdown(twoHoursFifteen)).toBe('in 2h 15m');
+  });
+
+  it('formats times less than a week', () => {
+    const twoDaysThreeHours = now + 2 * 24 * 60 * 60 * 1000 + 3 * 60 * 60 * 1000;
+    expect(formatCountdown(twoDaysThreeHours)).toBe('in 2d 3h');
+  });
+
+  it('formats distant future dates', () => {
+    const inTenDays = now + 10 * 24 * 60 * 60 * 1000;
+    const expected = new Date(inTenDays).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+    });
+    expect(formatCountdown(inTenDays)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- add new tests for `formatCountdown` utility
- add tests for `useCountdown` hook
- add table row tests for community members
- cover community downloads row and team components

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`