### PR TITLE
Add community downloads and cookie banner tests

### DIFF
--- a/__tests__/components/communityDownloads/CommunityDownloads.test.tsx
+++ b/__tests__/components/communityDownloads/CommunityDownloads.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import CommunityDownloads from '../../../components/communityDownloads/CommunityDownloads';
+import useCapacitor from '../../../hooks/useCapacitor';
+
+jest.mock('../../../hooks/useCapacitor');
+
+const mockUseCapacitor = useCapacitor as jest.MockedFunction<typeof useCapacitor>;
+
+describe('CommunityDownloads', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows Meme Subscriptions link when platform is not ios', () => {
+    mockUseCapacitor.mockReturnValue({ platform: 'web' } as any);
+    render(<CommunityDownloads />);
+    expect(screen.getByRole('link', { name: /Meme Subscriptions/i })).toBeInTheDocument();
+  });
+
+  it('hides Meme Subscriptions link on ios platform', () => {
+    mockUseCapacitor.mockReturnValue({ platform: 'ios' } as any);
+    render(<CommunityDownloads />);
+    expect(screen.queryByRole('link', { name: /Meme Subscriptions/i })).not.toBeInTheDocument();
+  });
+
+  it('renders other download links with correct hrefs', () => {
+    mockUseCapacitor.mockReturnValue({ platform: 'web' } as any);
+    render(<CommunityDownloads />);
+    expect(screen.getByRole('link', { name: 'Network Metrics' })).toHaveAttribute('href', '/open-data/network-metrics');
+    expect(screen.getByRole('link', { name: 'Consolidated Network Metrics' })).toHaveAttribute('href', '/open-data/consolidated-network-metrics');
+    expect(screen.getByRole('link', { name: 'Rememes' })).toHaveAttribute('href', '/open-data/rememes');
+    expect(screen.getByRole('link', { name: 'Team' })).toHaveAttribute('href', '/open-data/team');
+    expect(screen.getByRole('link', { name: 'Royalties' })).toHaveAttribute('href', '/open-data/royalties');
+  });
+});

--- a/__tests__/components/communityDownloads/CommunityDownloadsRememes.test.tsx
+++ b/__tests__/components/communityDownloads/CommunityDownloadsRememes.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react';
+import CommunityDownloadsRememes from '../../../components/communityDownloads/CommunityDownloadsRememes';
+import CommunityDownloadsComponent from '../../../components/communityDownloads/CommunityDownloadsComponent';
+
+jest.mock('../../../components/communityDownloads/CommunityDownloadsComponent');
+
+const mockComponent = CommunityDownloadsComponent as jest.MockedFunction<typeof CommunityDownloadsComponent>;
+
+describe('CommunityDownloadsRememes', () => {
+  const originalEnv = process.env.API_ENDPOINT;
+  beforeEach(() => {
+    mockComponent.mockClear();
+    process.env.API_ENDPOINT = 'http://api.test';
+  });
+  afterAll(() => {
+    process.env.API_ENDPOINT = originalEnv;
+  });
+
+  it('renders CommunityDownloadsComponent with rememe data', () => {
+    render(<CommunityDownloadsRememes />);
+    expect(mockComponent).toHaveBeenCalledTimes(1);
+    expect(mockComponent.mock.calls[0][0]).toEqual({
+      title: 'Rememes',
+      url: 'http://api.test/api/rememes_uploads',
+    });
+  });
+});

--- a/__tests__/components/communityDownloads/CommunityDownloadsRoyalties.test.tsx
+++ b/__tests__/components/communityDownloads/CommunityDownloadsRoyalties.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react';
+import CommunityDownloadsRoyalties from '../../../components/communityDownloads/CommunityDownloadsRoyalties';
+import CommunityDownloadsComponent from '../../../components/communityDownloads/CommunityDownloadsComponent';
+
+jest.mock('../../../components/communityDownloads/CommunityDownloadsComponent');
+
+const mockComponent = CommunityDownloadsComponent as jest.MockedFunction<typeof CommunityDownloadsComponent>;
+
+describe('CommunityDownloadsRoyalties', () => {
+  const originalEnv = process.env.API_ENDPOINT;
+  beforeEach(() => {
+    mockComponent.mockClear();
+    process.env.API_ENDPOINT = 'http://api.test';
+  });
+  afterAll(() => {
+    process.env.API_ENDPOINT = originalEnv;
+  });
+
+  it('renders CommunityDownloadsComponent with royalties data', () => {
+    render(<CommunityDownloadsRoyalties />);
+    expect(mockComponent).toHaveBeenCalledTimes(1);
+    expect(mockComponent.mock.calls[0][0]).toEqual({
+      title: 'Royalties',
+      url: 'http://api.test/api/royalties/uploads',
+    });
+  });
+});

--- a/__tests__/components/cookies/CookiesBanner.test.tsx
+++ b/__tests__/components/cookies/CookiesBanner.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CookiesBanner from '../../../components/cookies/CookiesBanner';
+import { useCookieConsent } from '../../../components/cookies/CookieConsentContext';
+import useIsMobileDevice from '../../../hooks/isMobileDevice';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../../components/cookies/CookieConsentContext', () => ({ useCookieConsent: jest.fn() }));
+jest.mock('../../../hooks/isMobileDevice');
+jest.mock('next/image', () => (props: any) => <img {...props} />);
+
+const { useRouter } = require('next/router');
+const mockUseCookieConsent = useCookieConsent as jest.MockedFunction<typeof useCookieConsent>;
+const mockUseIsMobileDevice = useIsMobileDevice as jest.MockedFunction<typeof useIsMobileDevice>;
+
+describe('CookiesBanner', () => {
+  beforeEach(() => {
+    useRouter.mockReturnValue({ pathname: '/' });
+    mockUseCookieConsent.mockReturnValue({ consent: jest.fn(), reject: jest.fn() } as any);
+    mockUseIsMobileDevice.mockReturnValue(false as any);
+  });
+
+  it('does not render on restricted routes', () => {
+    useRouter.mockReturnValue({ pathname: '/restricted' });
+    const { container } = render(<CookiesBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('calls consent when Accept clicked', () => {
+    const consent = jest.fn();
+    mockUseCookieConsent.mockReturnValue({ consent, reject: jest.fn() } as any);
+    render(<CookiesBanner />);
+    fireEvent.click(screen.getByRole('button', { name: /Accept/i }));
+    expect(consent).toHaveBeenCalled();
+  });
+
+  it('calls reject when Reject clicked', () => {
+    const reject = jest.fn();
+    mockUseCookieConsent.mockReturnValue({ consent: jest.fn(), reject } as any);
+    render(<CookiesBanner />);
+    fireEvent.click(screen.getByRole('button', { name: /Reject Non-Essential/i }));
+    expect(reject).toHaveBeenCalled();
+  });
+
+  it('links to cookie policy', () => {
+    render(<CookiesBanner />);
+    expect(screen.getByRole('link', { name: /Learn more/i })).toHaveAttribute('href', '/about/cookie-policy');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for CommunityDownloads links and platform logic
- add tests for Rememes and Royalties components
- add tests for CookiesBanner interactions

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
