### PR TITLE
Improve test coverage

### DIFF
--- a/__tests__/components/common/TooltipIconButton.test.tsx
+++ b/__tests__/components/common/TooltipIconButton.test.tsx
@@ -1,0 +1,33 @@
+import { render, fireEvent } from '@testing-library/react';
+import TooltipIconButton from '../../../components/common/TooltipIconButton';
+import { faPlus } from '@fortawesome/free-solid-svg-icons';
+
+jest.mock('@fortawesome/react-fontawesome', () => ({ FontAwesomeIcon: (props: any) => <svg data-testid="icon" {...props} /> }));
+
+describe('TooltipIconButton', () => {
+  it('shows and hides tooltip on hover', () => {
+    const { container, queryByText, getByText } = render(
+      <TooltipIconButton icon={faPlus} tooltipText="Hint" />
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(queryByText('Hint')).toBeNull();
+    fireEvent.mouseEnter(root);
+    const tooltip = getByText('Hint');
+    expect(tooltip.className).toContain('tw-bottom-6'); // default top position
+    fireEvent.mouseLeave(root);
+    expect(queryByText('Hint')).toBeNull();
+  });
+
+  it('calls onClick and uses bottom position', () => {
+    const onClick = jest.fn();
+    const { container, getByText } = render(
+      <TooltipIconButton icon={faPlus} tooltipText="Tip" tooltipPosition="bottom" onClick={onClick} />
+    );
+    const root = container.firstChild as HTMLElement;
+    fireEvent.mouseEnter(root);
+    const tooltip = getByText('Tip');
+    expect(tooltip.className).toContain('tw-top-6');
+    fireEvent.click(root);
+    expect(onClick).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/common/icons/Squares2X2Icon.test.tsx
+++ b/__tests__/components/common/icons/Squares2X2Icon.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react';
+import Squares2X2Icon from '../../../../components/common/icons/Squares2X2Icon';
+
+describe('Squares2X2Icon', () => {
+  it('renders svg with provided class', () => {
+    const { container } = render(<Squares2X2Icon className="my-class" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveClass('my-class');
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+    expect(svg?.getAttribute('stroke-width')).toBe('1.65');
+  });
+
+  it('contains path with stroke attributes', () => {
+    const { container } = render(<Squares2X2Icon />);
+    const path = container.querySelector('path');
+    expect(path).toBeInTheDocument();
+    expect(path?.getAttribute('stroke-linecap')).toBe('round');
+    expect(path?.getAttribute('stroke-linejoin')).toBe('round');
+    expect(path?.getAttribute('d')).toContain('M16.5 8.25');
+  });
+});

--- a/__tests__/components/community/members-table/CommunityMembersMobileFilterBar.test.tsx
+++ b/__tests__/components/community/members-table/CommunityMembersMobileFilterBar.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CommunityMembersMobileFilterBar from '../../../../components/community/members-table/CommunityMembersMobileFilterBar';
+import { CommunityMembersSortOption } from '../../../../enums';
+import { SortDirection } from '../../../../entities/ISort';
+
+const sortIconMock = jest.fn();
+jest.mock('../../../../components/user/utils/icons/CommonTableSortIcon', () => ({
+  __esModule: true,
+  default: (props: any) => { sortIconMock(props); return <div data-testid="icon" />; }
+}));
+
+jest.mock('../../../../components/distribution-plan-tool/common/CircleLoader', () => ({
+  __esModule: true,
+  default: () => <div data-testid="loader" />,
+  CircleLoaderSize: { SMALL: 'SMALL' },
+}));
+
+describe('CommunityMembersMobileFilterBar', () => {
+  const baseProps = {
+    activeSort: CommunityMembersSortOption.LEVEL,
+    sortDirection: SortDirection.ASC,
+    isLoading: false,
+    onSort: jest.fn(),
+  };
+
+  beforeEach(() => {
+    sortIconMock.mockClear();
+    (baseProps.onSort as jest.Mock).mockClear();
+  });
+
+  it('renders options and handles click', async () => {
+    const user = userEvent.setup();
+    render(<CommunityMembersMobileFilterBar {...baseProps} />);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons).toHaveLength(4);
+    await user.click(buttons[1]);
+    expect(baseProps.onSort).toHaveBeenCalledWith(CommunityMembersSortOption.TDH);
+    expect(sortIconMock).toHaveBeenCalledWith(
+      expect.objectContaining({ direction: baseProps.sortDirection, isActive: true })
+    );
+  });
+
+  it('shows loader when active sort is loading', () => {
+    render(<CommunityMembersMobileFilterBar {...baseProps} isLoading={true} />);
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/community/members-table/CommunityMembersTable.test.tsx
+++ b/__tests__/components/community/members-table/CommunityMembersTable.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react';
+import CommunityMembersTable from '../../../../components/community/members-table/CommunityMembersTable';
+import { CommunityMembersSortOption } from '../../../../enums';
+import { SortDirection } from '../../../../entities/ISort';
+
+const headerMock = jest.fn(() => <thead data-testid="header" />);
+jest.mock('../../../../components/community/members-table/CommunityMembersTableHeader', () => ({ __esModule: true, default: (props: any) => headerMock(props) }));
+
+const rowMock = jest.fn((props: any) => <tr data-testid={`row-${props.rank}`} />);
+jest.mock('../../../../components/community/members-table/CommunityMembersTableRow', () => ({ __esModule: true, default: (props: any) => rowMock(props) }));
+
+const mobileFilterMock = jest.fn(() => <div data-testid="mobile-filter" />);
+jest.mock('../../../../components/community/members-table/CommunityMembersMobileFilterBar', () => ({ __esModule: true, default: (props: any) => mobileFilterMock(props) }));
+
+const mobileCardMock = jest.fn((props: any) => <div data-testid={`mobile-card-${props.rank}`} />);
+jest.mock('../../../../components/community/members-table/CommunityMembersMobileCard', () => ({ __esModule: true, default: (props: any) => mobileCardMock(props) }));
+
+const members = [
+  {
+    display: 'User One',
+    detail_view_key: 'user1',
+    level: 1,
+    tdh: 10,
+    rep: 20,
+    cic: 30,
+    pfp: null,
+    last_activity: null,
+    wallet: '0x1',
+  },
+  {
+    display: 'User Two',
+    detail_view_key: 'user2',
+    level: 2,
+    tdh: 15,
+    rep: 25,
+    cic: 35,
+    pfp: null,
+    last_activity: null,
+    wallet: '0x2',
+  },
+];
+
+const baseProps = {
+  members,
+  activeSort: CommunityMembersSortOption.LEVEL,
+  sortDirection: SortDirection.ASC,
+  page: 2,
+  pageSize: 10,
+  isLoading: false,
+  onSort: jest.fn(),
+};
+
+describe('CommunityMembersTable', () => {
+  beforeEach(() => {
+    headerMock.mockClear();
+    rowMock.mockClear();
+    mobileFilterMock.mockClear();
+    mobileCardMock.mockClear();
+    (baseProps.onSort as jest.Mock).mockClear();
+  });
+
+  it('renders rows and mobile cards with correct rank', () => {
+    render(<CommunityMembersTable {...baseProps} />);
+
+    expect(headerMock).toHaveBeenCalledWith(expect.objectContaining({
+      activeSort: baseProps.activeSort,
+      sortDirection: baseProps.sortDirection,
+      isLoading: baseProps.isLoading,
+      onSort: baseProps.onSort,
+    }));
+
+    expect(rowMock).toHaveBeenCalledTimes(2);
+    expect(rowMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ member: members[0], rank: 11 }));
+    expect(rowMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ member: members[1], rank: 12 }));
+
+    expect(mobileFilterMock).toHaveBeenCalledWith(expect.objectContaining({
+      activeSort: baseProps.activeSort,
+      sortDirection: baseProps.sortDirection,
+      isLoading: baseProps.isLoading,
+      onSort: baseProps.onSort,
+    }));
+
+    expect(mobileCardMock).toHaveBeenCalledTimes(2);
+    expect(mobileCardMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ member: members[0], rank: 11 }));
+    expect(mobileCardMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ member: members[1], rank: 12 }));
+
+    // ensure elements rendered
+    expect(screen.getByTestId('header')).toBeInTheDocument();
+    expect(screen.getByTestId('row-11')).toBeInTheDocument();
+    expect(screen.getByTestId('row-12')).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-filter')).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-card-11')).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-card-12')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/community/members-table/CommunityMembersTableHeader.test.tsx
+++ b/__tests__/components/community/members-table/CommunityMembersTableHeader.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CommunityMembersTableHeader from '../../../../components/community/members-table/CommunityMembersTableHeader';
+import { CommunityMembersSortOption } from '../../../../enums';
+import { SortDirection } from '../../../../entities/ISort';
+
+const sortableMock = jest.fn();
+jest.mock('../../../../components/community/members-table/CommunityMembersTableHeaderSortableContent', () => ({
+  __esModule: true,
+  default: (props: any) => { sortableMock(props); return <div data-testid={`content-${props.sort}`} />; }
+}));
+
+describe('CommunityMembersTableHeader', () => {
+  const onSort = jest.fn();
+  beforeEach(() => {
+    sortableMock.mockClear();
+    onSort.mockClear();
+  });
+
+  it('handles clicks and hover events', () => {
+    render(
+      <table>
+        <CommunityMembersTableHeader
+          activeSort={CommunityMembersSortOption.LEVEL}
+          sortDirection={SortDirection.ASC}
+          isLoading={false}
+          onSort={onSort}
+        />
+      </table>
+    );
+    const headers = screen.getAllByRole('columnheader');
+    expect(headers).toHaveLength(7);
+
+    // click on REP column (index 4)
+    fireEvent.click(headers[4]);
+    expect(onSort).toHaveBeenCalledWith(CommunityMembersSortOption.REP);
+
+    // hover over Level column triggers prop
+    fireEvent.mouseEnter(headers[2]);
+    expect(sortableMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sort: CommunityMembersSortOption.LEVEL, hoveringOption: CommunityMembersSortOption.LEVEL })
+    );
+    fireEvent.mouseLeave(headers[2]);
+    expect(sortableMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ hoveringOption: null })
+    );
+  });
+});

--- a/__tests__/components/community/members-table/CommunityMembersTableRow.test.tsx
+++ b/__tests__/components/community/members-table/CommunityMembersTableRow.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import CommunityMembersTableRow from '../../../../components/community/members-table/CommunityMembersTableRow';
+
+jest.mock('../../../../helpers/image.helpers', () => ({
+  ImageScale: { W_AUTO_H_50: 'W_AUTO_H_50' },
+  getScaledImageUri: () => '/scaled.png',
+}));
+
+jest.mock('../../../../components/user/utils/level/UserLevel', () => ({
+  __esModule: true,
+  default: () => <div data-testid="level" />,
+}));
+
+jest.mock('../../../../components/user/utils/user-cic-type/UserCICTypeIcon', () => ({
+  __esModule: true,
+  default: () => <div data-testid="cic-icon" />,
+}));
+
+jest.mock('../../../../components/utils/CommonTimeAgo', () => ({
+  __esModule: true,
+  default: () => <span data-testid="timeago">ago</span>,
+}));
+
+jest.mock('@tippyjs/react', () => ({ __esModule: true, default: ({ children }: any) => <div>{children}</div> }));
+
+describe('CommunityMembersTableRow', () => {
+  const member = {
+    display: 'User',
+    detail_view_key: 'userkey',
+    level: 2,
+    tdh: 10,
+    rep: 5,
+    cic: 1,
+    pfp: 'pfp.png',
+    last_activity: 123,
+    wallet: '0x1',
+  };
+
+  it('renders member info and link', () => {
+    render(<table><tbody><CommunityMembersTableRow member={member} rank={3} /></tbody></table>);
+    expect(screen.getByText('3')).toBeInTheDocument();
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/userkey');
+    expect(link).toHaveTextContent('User');
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByTestId('level')).toBeInTheDocument();
+    expect(screen.getByTestId('cic-icon')).toBeInTheDocument();
+    expect(screen.getByTestId('timeago')).toBeInTheDocument();
+    const img = screen.getByAltText('Network Table Profile Picture') as HTMLImageElement;
+    expect(img.src).toContain('/scaled.png');
+  });
+});


### PR DESCRIPTION
## Summary
- add TooltipIconButton tests covering hover and click
- add Squares2X2Icon rendering tests
- add community members table tests for rows and headers
- add mobile filter bar tests

## Testing
- `npm run improve-coverage`