### PR TITLE
Increase BuildPhase table tests

### DIFF
--- a/__tests__/components/distribution-plan-tool/build-phases/build-phase/table/BuildPhaseTableBody.test.tsx
+++ b/__tests__/components/distribution-plan-tool/build-phases/build-phase/table/BuildPhaseTableBody.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import BuildPhaseTableBody from '../../../../../../components/distribution-plan-tool/build-phases/build-phase/table/BuildPhaseTableBody';
+import { BuildPhasesPhase } from '../../../../../../components/distribution-plan-tool/build-phases/BuildPhases';
+
+jest.mock('../../../../../../components/distribution-plan-tool/build-phases/build-phase/table/BuildPhaseTableRow', () => ({ component }: any) => (
+  <tr data-testid="mock-row">
+    <td>{component.name}</td>
+  </tr>
+));
+
+jest.mock('../../../../../../components/distribution-plan-tool/common/DistributionPlanTableBodyWrapper', () => ({ children }: any) => (
+  <tbody data-testid="wrapper">{children}</tbody>
+));
+
+const phase: BuildPhasesPhase = {
+  id: 'phase1',
+  allowlistId: '1',
+  name: 'Phase 1',
+  description: 'desc',
+  hasRan: false,
+  order: 1,
+  components: [
+    {
+      id: 'comp1',
+      allowlistId: '1',
+      name: 'Component 1',
+      description: 'c1',
+      spotsNotRan: false,
+      spots: 5,
+      order: 1,
+    },
+    {
+      id: 'comp2',
+      allowlistId: '1',
+      name: 'Component 2',
+      description: 'c2',
+      spotsNotRan: true,
+      spots: null,
+      order: 2,
+    },
+  ],
+};
+
+describe('BuildPhaseTableBody', () => {
+  it('renders a table row for each component', () => {
+    render(
+      <table>
+        <BuildPhaseTableBody phase={phase} />
+      </table>
+    );
+    const rows = screen.getAllByTestId('mock-row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveTextContent('Component 1');
+    expect(rows[1]).toHaveTextContent('Component 2');
+  });
+});

--- a/__tests__/components/distribution-plan-tool/build-phases/build-phase/table/BuildPhaseTableRow.test.tsx
+++ b/__tests__/components/distribution-plan-tool/build-phases/build-phase/table/BuildPhaseTableRow.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import BuildPhaseTableRow from '../../../../../../components/distribution-plan-tool/build-phases/build-phase/table/BuildPhaseTableRow';
+import { BuildPhasesPhaseComponent } from '../../../../../../components/distribution-plan-tool/build-phases/BuildPhases';
+
+jest.mock('../../../../../../components/distribution-plan-tool/common/DistributionPlanTableRowWrapper', () => ({ children }: any) => (
+  <tr data-testid="wrapper">{children}</tr>
+));
+
+jest.mock('../../../../../../components/distribution-plan-tool/common/DistributionPlanDeleteOperationButton', () => ({ allowlistId, order }: any) => (
+  <button data-testid="delete-btn">{allowlistId}-{order}</button>
+));
+
+describe('BuildPhaseTableRow', () => {
+  const component: BuildPhasesPhaseComponent = {
+    id: 'c1',
+    allowlistId: 'a1',
+    name: 'Comp',
+    description: 'Desc',
+    spotsNotRan: false,
+    spots: 3,
+    order: 2,
+  };
+
+  it('renders component info and delete button', () => {
+    render(
+      <table>
+        <tbody>
+          <BuildPhaseTableRow component={component} />
+        </tbody>
+      </table>
+    );
+
+    expect(screen.getByText('Comp')).toBeInTheDocument();
+    expect(screen.getByText('Desc')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByTestId('delete-btn')).toHaveTextContent('a1-2');
+  });
+
+  it('shows N/A when spotsNotRan is true', () => {
+    const modified = { ...component, spotsNotRan: true, spots: null };
+    render(
+      <table>
+        <tbody>
+          <BuildPhaseTableRow component={modified} />
+        </tbody>
+      </table>
+    );
+
+    expect(screen.getByText('N/A')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for BuildPhaseTableBody to verify row rendering
- add tests for BuildPhaseTableRow to check display and delete button

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*
