### PR TITLE
Increase test coverage for Distribution Plan components

### DIFF
--- a/__tests__/components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotFormAddWalletsModal.test.tsx
+++ b/__tests__/components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotFormAddWalletsModal.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import CreateCustomSnapshotFormAddWalletsModal from '../../../../../components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotFormAddWalletsModal';
+
+jest.mock(
+  '../../../../../components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotFormUpload',
+  () => ({ fileName, setFileName, setTokens }: any) => (
+    <div data-testid="upload" onClick={() => setFileName('file.csv')} />
+  )
+);
+
+const tableMock = jest.fn((props: any) => <div data-testid="table" />);
+jest.mock(
+  '../../../../../components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotFormTable',
+  () => ({
+    __esModule: true,
+    default: (props: any) => tableMock(props),
+  })
+);
+
+describe('CreateCustomSnapshotFormAddWalletsModal', () => {
+  const defaultProps = {
+    fileName: null,
+    setFileName: jest.fn(),
+    tokens: [],
+    addUploadedTokens: jest.fn(),
+    setManualWallet: jest.fn(),
+    addManualWallet: jest.fn(),
+    onRemoveToken: jest.fn(),
+    onClose: jest.fn(),
+  };
+
+  it('updates manual wallet and adds it', () => {
+    render(<CreateCustomSnapshotFormAddWalletsModal {...defaultProps} />);
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '0xabc' } });
+    expect(defaultProps.setManualWallet).toHaveBeenCalledWith('0xabc');
+    const addButton = screen.getByRole('button', { name: 'Add' });
+    fireEvent.click(addButton);
+    expect(defaultProps.addManualWallet).toHaveBeenCalled();
+  });
+
+
+  it('passes tokens to table and handles close', () => {
+    const onClose = jest.fn();
+    const props = { ...defaultProps, tokens: [{ owner: '0x1' } as any], onClose };
+    render(<CreateCustomSnapshotFormAddWalletsModal {...props} />);
+    expect(tableMock).toHaveBeenCalledWith(
+      expect.objectContaining({ tokens: props.tokens, onRemoveToken: props.onRemoveToken })
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/distribution-plan-tool/distribution-plan-tool-sidebar/DistributionPlanStepCurrent.test.tsx
+++ b/__tests__/components/distribution-plan-tool/distribution-plan-tool-sidebar/DistributionPlanStepCurrent.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import DistributionPlanStepCurrent from '../../../../components/distribution-plan-tool/distribution-plan-tool-sidebar/DistributionPlanStepCurrent';
+
+describe('DistributionPlanStepCurrent', () => {
+  const baseStep = {
+    label: 'Step Label',
+    description: 'Step Description',
+    key: 'ANY',
+    order: 1,
+  } as any;
+
+  it('renders connector line when not last step', () => {
+    render(<DistributionPlanStepCurrent step={baseStep} />);
+    expect(screen.getByText('Step Label')).toBeInTheDocument();
+    expect(screen.getByText('Step Description')).toBeInTheDocument();
+    // line div is present
+    expect(document.querySelector('div.tw-absolute')).not.toBeNull();
+  });
+
+  it('omits connector line for last step', () => {
+    const lastStep = { ...baseStep, order: 6 };
+    render(<DistributionPlanStepCurrent step={lastStep} />);
+    // line div should not be present
+    expect(document.querySelector('div.tw-absolute')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for CreateCustomSnapshotFormAddWalletsModal
- cover DistributionPlanStepCurrent component

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
