### PR TITLE
Add tests for distribution plan components

### DIFF
--- a/__tests__/components/distribution-plan-tool/CreateCustomSnapshots.test.tsx
+++ b/__tests__/components/distribution-plan-tool/CreateCustomSnapshots.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CreateCustomSnapshots from '../../../components/distribution-plan-tool/create-custom-snapshots/CreateCustomSnapshots';
+import { DistributionPlanToolContext, DistributionPlanToolStep } from '../../../components/distribution-plan-tool/DistributionPlanToolContext';
+import { AllowlistOperationCode } from '../../../components/allowlist-tool/allowlist-tool.types';
+
+jest.mock('../../../components/distribution-plan-tool/create-custom-snapshots/table/CreateCustomSnapshotTable', () => ({ customSnapshots }: any) => <div data-testid="table">{customSnapshots.length}</div>);
+jest.mock('../../../components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotForm', () => () => <div data-testid="form" />);
+jest.mock('../../../components/distribution-plan-tool/common/StepHeader', () => () => <div data-testid="header" />);
+jest.mock('../../../components/distribution-plan-tool/common/DistributionPlanNextStepBtn', () => ({ showNextBtn, showSkipBtn }: any) => <div data-testid="next">{showNextBtn && 'next'}{showSkipBtn && 'skip'}</div>);
+jest.mock('../../../components/distribution-plan-tool/common/DistributionPlanStepWrapper', () => ({ children }: any) => <div>{children}</div>);
+jest.mock('../../../components/distribution-plan-tool/common/DistributionPlanEmptyTablePlaceholder', () => ({ title }: any) => <div data-testid="empty">{title}</div>);
+jest.mock('../../../components/allowlist-tool/icons/AllowlistToolCsvIcon', () => () => <svg data-testid="csv" />);
+
+describe('CreateCustomSnapshots', () => {
+  it('redirects to create plan when distribution plan is missing', () => {
+    const setStep = jest.fn();
+    render(
+      <DistributionPlanToolContext.Provider value={{ distributionPlan: null, setStep, operations: [] } as any}>
+        <CreateCustomSnapshots />
+      </DistributionPlanToolContext.Provider>
+    );
+    expect(setStep).toHaveBeenCalledWith(DistributionPlanToolStep.CREATE_PLAN);
+  });
+
+  it('renders table when custom snapshot operations exist', () => {
+    const ops = [
+      {
+        code: AllowlistOperationCode.CREATE_CUSTOM_TOKEN_POOL,
+        params: { id: 'c1', name: 'snap', description: '', tokens: [{ owner: '0x1' }] },
+      },
+    ];
+    render(
+      <DistributionPlanToolContext.Provider value={{ distributionPlan: { id: '1' }, setStep: jest.fn(), operations: ops } as any}>
+        <CreateCustomSnapshots />
+      </DistributionPlanToolContext.Provider>
+    );
+    expect(screen.getByTestId('table')).toHaveTextContent('1');
+    expect(screen.getByTestId('next')).toHaveTextContent('next');
+  });
+});

--- a/__tests__/components/distribution-plan-tool/CreateDistributionPlan.test.tsx
+++ b/__tests__/components/distribution-plan-tool/CreateDistributionPlan.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateDistributionPlan from '../../../components/distribution-plan-tool/create-plan/CreateDistributionPlan';
+import { distributionPlanApiPost } from '../../../services/distribution-plan-api';
+
+jest.mock('../../../services/distribution-plan-api');
+
+const mockedPost = distributionPlanApiPost as jest.Mock;
+
+describe('CreateDistributionPlan', () => {
+  beforeEach(() => {
+    mockedPost.mockReset();
+  });
+
+  it('submits form and calls onSuccess on success', async () => {
+    mockedPost.mockResolvedValue({ success: true, data: { id: '123' } });
+    const onSuccess = jest.fn();
+    render(<CreateDistributionPlan onSuccess={onSuccess} />);
+    await userEvent.type(screen.getByPlaceholderText('Make a name for your distribution'), 'name');
+    await userEvent.type(screen.getByPlaceholderText('Description of your drop'), 'desc');
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(mockedPost).toHaveBeenCalled();
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith('123'));
+  });
+
+  it('does not submit when fields are empty', async () => {
+    const onSuccess = jest.fn();
+    render(<CreateDistributionPlan onSuccess={onSuccess} />);
+    await userEvent.click(screen.getByRole('button', { name: /create/i }));
+    expect(mockedPost).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/distribution-plan-tool/CreatePhasesTableBody.test.tsx
+++ b/__tests__/components/distribution-plan-tool/CreatePhasesTableBody.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CreatePhasesTableBody from '../../../components/distribution-plan-tool/create-phases/table/CreatePhasesTableBody';
+
+jest.mock('../../../components/distribution-plan-tool/create-phases/table/CreateTablePhasesRow', () => ({ phase }: any) => (
+  <tr data-testid="row">
+    <td>{phase.name}</td>
+  </tr>
+));
+jest.mock('../../../components/distribution-plan-tool/common/DistributionPlanTableBodyWrapper', () => ({ children }: any) => <tbody data-testid="wrapper">{children}</tbody>);
+
+describe('CreatePhasesTableBody', () => {
+  it('renders a row for each phase', () => {
+    const phases = [
+      { id: '1', allowlistId: 'a', name: 'p1', order: 1 },
+      { id: '2', allowlistId: 'a', name: 'p2', order: 2 },
+    ] as any[];
+    render(<table><CreatePhasesTableBody phases={phases} /></table>);
+    const rows = screen.getAllByTestId('row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveTextContent('p1');
+    expect(rows[1]).toHaveTextContent('p2');
+    expect(screen.getByTestId('wrapper')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/distribution-plan-tool/build-phases/BuildPhaseTableHeader.test.tsx
+++ b/__tests__/components/distribution-plan-tool/build-phases/BuildPhaseTableHeader.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import BuildPhaseTableHeader from '../../../../components/distribution-plan-tool/build-phases/build-phase/table/BuildPhaseTableHeader';
+
+describe('BuildPhaseTableHeader', () => {
+  it('renders the expected column headers', () => {
+    render(
+      <table>
+        <BuildPhaseTableHeader />
+      </table>
+    );
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Description')).toBeInTheDocument();
+    expect(screen.getByText('Spots')).toBeInTheDocument();
+    expect(screen.getAllByRole('columnheader')).toHaveLength(4);
+  });
+
+  it('wrapper has table head styles', () => {
+    const { container } = render(
+      <table>
+        <BuildPhaseTableHeader />
+      </table>
+    );
+    const thead = container.querySelector('thead');
+    expect(thead).toHaveClass('tw-bg-neutral-800');
+  });
+});

--- a/__tests__/components/distribution-plan-tool/build-phases/component-config/ComponentConfigMeta.test.tsx
+++ b/__tests__/components/distribution-plan-tool/build-phases/component-config/ComponentConfigMeta.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import ComponentConfigMeta from '../../../../../components/distribution-plan-tool/build-phases/build-phase/form/component-config/ComponentConfigMeta';
+
+describe('ComponentConfigMeta', () => {
+  it('renders container with expected classes', () => {
+    const { container } = render(
+      <ComponentConfigMeta tags={[{ id: '1', name: 'tag' }]} walletsCount={10} isLoading={false} />
+    );
+    const div = container.firstChild as HTMLElement;
+    expect(div).toHaveClass('tw-space-y-1 tw-self-center');
+  });
+
+  it('renders without crashing when loading', () => {
+    const { container } = render(
+      <ComponentConfigMeta tags={[]} walletsCount={null} isLoading={true} />
+    );
+    const div = container.querySelector('div');
+    expect(div).toBeTruthy();
+  });
+});

--- a/__tests__/components/distribution-plan-tool/common/DistributionPlanDeleteOperationButton.test.tsx
+++ b/__tests__/components/distribution-plan-tool/common/DistributionPlanDeleteOperationButton.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DistributionPlanDeleteOperationButton from '../../../../components/distribution-plan-tool/common/DistributionPlanDeleteOperationButton';
+import { DistributionPlanToolContext } from '../../../../components/distribution-plan-tool/DistributionPlanToolContext';
+import { distributionPlanApiDelete } from '../../../../services/distribution-plan-api';
+
+jest.mock('../../../../services/distribution-plan-api');
+
+const mockedDelete = distributionPlanApiDelete as jest.Mock;
+
+function renderButton(ctx?: Partial<React.ContextType<typeof DistributionPlanToolContext>>) {
+  const runOperations = jest.fn();
+  const contextValue = { runOperations, ...(ctx || {}) } as any;
+  render(
+    <DistributionPlanToolContext.Provider value={contextValue}>
+      <DistributionPlanDeleteOperationButton allowlistId="a1" order={2} />
+    </DistributionPlanToolContext.Provider>
+  );
+  return { runOperations };
+}
+
+describe('DistributionPlanDeleteOperationButton', () => {
+  beforeEach(() => {
+    mockedDelete.mockReset();
+  });
+
+  it('calls api and runOperations on success', async () => {
+    mockedDelete.mockResolvedValue({ success: true });
+    const { runOperations } = renderButton();
+    await userEvent.click(screen.getByRole('button'));
+    expect(mockedDelete).toHaveBeenCalledWith({ endpoint: '/allowlists/a1/operations/2' });
+    await waitFor(() => expect(runOperations).toHaveBeenCalled());
+    expect(screen.getByRole('button')).not.toBeDisabled();
+  });
+
+  it('does not run operations on failure', async () => {
+    mockedDelete.mockResolvedValue({ success: false });
+    const { runOperations } = renderButton();
+    await userEvent.click(screen.getByRole('button'));
+    expect(mockedDelete).toHaveBeenCalled();
+    await waitFor(() => expect(runOperations).not.toHaveBeenCalled());
+  });
+});

--- a/__tests__/components/distribution-plan-tool/common/RoundedJsonIconButton.test.tsx
+++ b/__tests__/components/distribution-plan-tool/common/RoundedJsonIconButton.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RoundedJsonIconButton from '../../../../components/distribution-plan-tool/common/RoundedJsonIconButton';
+
+jest.mock('../../../../components/distribution-plan-tool/common/JsonIcon', () => () => <svg data-testid="json-icon" />);
+jest.mock('../../../../components/distribution-plan-tool/common/CircleLoader', () => () => <div data-testid="loader" />);
+
+describe('RoundedJsonIconButton', () => {
+  it('renders json icon when not loading and handles click', async () => {
+    const onClick = jest.fn();
+    render(<RoundedJsonIconButton loading={false} onClick={onClick} />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalled();
+    expect(screen.getByTestId('json-icon')).toBeInTheDocument();
+  });
+
+  it('shows loader when loading', () => {
+    render(<RoundedJsonIconButton loading={true} onClick={() => {}} />);
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for distribution plan creation and tables
- cover delete operation button and JSON button
- verify custom snapshot logic

## Testing
- `npm run improve-coverage`