### PR TITLE
Add tests for distribution plan components

### DIFF
--- a/__tests__/components/community/members-table/CommunityMembersTable.test.tsx
+++ b/__tests__/components/community/members-table/CommunityMembersTable.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import CommunityMembersTable from '../../../../components/community/members-table/CommunityMembersTable';
+import { CommunityMemberOverview } from '../../../../entities/IProfile';
+import { CommunityMembersSortOption } from '../../../../enums';
+import { SortDirection } from '../../../../entities/ISort';
+
+jest.mock('../../../../components/community/members-table/CommunityMembersTableHeader', () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <thead data-testid="header">
+      <tr>
+        <td>{`header-${props.activeSort}-${props.sortDirection}-${String(props.isLoading)}`}</td>
+      </tr>
+    </thead>
+  ),
+}));
+
+jest.mock('../../../../components/community/members-table/CommunityMembersTableRow', () => ({
+  __esModule: true,
+  default: ({ rank, member }: any) => (
+    <tr data-testid="row">
+      <td>{`${rank}-${member.display}`}</td>
+    </tr>
+  ),
+}));
+
+jest.mock('../../../../components/community/members-table/CommunityMembersMobileFilterBar', () => ({
+  __esModule: true,
+  default: (props: any) => <div data-testid="filter">filter-{props.activeSort}-{props.sortDirection}-{String(props.isLoading)}</div>,
+}));
+
+jest.mock('../../../../components/community/members-table/CommunityMembersMobileCard', () => ({
+  __esModule: true,
+  default: ({ rank, member }: any) => <div data-testid="mobile-card">{rank}-{member.display}</div>,
+}));
+
+const members: CommunityMemberOverview[] = [
+  {
+    display: 'Alice',
+    detail_view_key: 'alice',
+    level: 1,
+    tdh: 10,
+    rep: 5,
+    cic: 2,
+    pfp: null,
+    last_activity: null,
+    wallet: '0x1',
+  },
+  {
+    display: 'Bob',
+    detail_view_key: 'bob',
+    level: 2,
+    tdh: 20,
+    rep: 15,
+    cic: 3,
+    pfp: null,
+    last_activity: null,
+    wallet: '0x2',
+  },
+];
+
+const baseProps = {
+  members,
+  activeSort: CommunityMembersSortOption.REP,
+  sortDirection: SortDirection.ASC,
+  page: 2,
+  pageSize: 5,
+  isLoading: false,
+  onSort: jest.fn(),
+};
+
+describe('CommunityMembersTable', () => {
+  it('renders rows and passes props to header and filter bar', () => {
+    render(<CommunityMembersTable {...baseProps} />);
+
+    const rows = screen.getAllByTestId('row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveTextContent('6-Alice');
+    expect(rows[1]).toHaveTextContent('7-Bob');
+
+    const cards = screen.getAllByTestId('mobile-card');
+    expect(cards).toHaveLength(2);
+    expect(cards[0]).toHaveTextContent('6-Alice');
+    expect(cards[1]).toHaveTextContent('7-Bob');
+
+    expect(screen.getByTestId('header')).toHaveTextContent('header-rep-ASC-false');
+    expect(screen.getByTestId('filter')).toHaveTextContent('filter-rep-ASC-false');
+  });
+});

--- a/__tests__/components/distribution-plan-tool/common/DistributionPlanErrorWarning.test.tsx
+++ b/__tests__/components/distribution-plan-tool/common/DistributionPlanErrorWarning.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import DistributionPlanErrorWarning from '../../../../components/distribution-plan-tool/common/DistributionPlanErrorWarning';
+import { DistributionPlanToolContext } from '../../../../components/distribution-plan-tool/DistributionPlanToolContext';
+
+describe('DistributionPlanErrorWarning', () => {
+  it('displays error reason and reruns analysis when button clicked', () => {
+    const runOperations = jest.fn();
+    const value = {
+      distributionPlan: { activeRun: { errorReason: 'Something went wrong' } },
+      runOperations,
+    } as any;
+    render(
+      <DistributionPlanToolContext.Provider value={value}>
+        <DistributionPlanErrorWarning />
+      </DistributionPlanToolContext.Provider>
+    );
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Run Analysis'));
+    expect(runOperations).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/distribution-plan-tool/common/DistributionPlanVerifiedIcon.test.tsx
+++ b/__tests__/components/distribution-plan-tool/common/DistributionPlanVerifiedIcon.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import DistributionPlanVerifiedIcon from '../../../../components/distribution-plan-tool/common/DistributionPlanVerifiedIcon';
+
+describe('DistributionPlanVerifiedIcon', () => {
+  it('renders SVG with two paths', () => {
+    const { container } = render(<DistributionPlanVerifiedIcon />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveClass('tw-h-4 tw-w-4');
+    expect(svg?.querySelectorAll('path')).toHaveLength(2);
+  });
+});

--- a/__tests__/components/distribution-plan-tool/common/DistributionPlanWarnings.test.tsx
+++ b/__tests__/components/distribution-plan-tool/common/DistributionPlanWarnings.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import DistributionPlanWarnings from '../../../../components/distribution-plan-tool/common/DistributionPlanWarnings';
+import { DistributionPlanToolContext } from '../../../../components/distribution-plan-tool/DistributionPlanToolContext';
+import { AllowlistRunStatus } from '../../../../components/allowlist-tool/allowlist-tool.types';
+
+jest.mock('../../../../components/distribution-plan-tool/common/DistributionPlanErrorWarning', () => ({
+  __esModule: true,
+  default: () => <div data-testid="error-warning" />,
+}));
+
+describe('DistributionPlanWarnings', () => {
+  function renderWith(status: AllowlistRunStatus | undefined) {
+    const value = {
+      operations: [],
+      distributionPlan: status ? { activeRun: { status } } : null,
+    } as any;
+    return render(
+      <DistributionPlanToolContext.Provider value={value}>
+        <DistributionPlanWarnings />
+      </DistributionPlanToolContext.Provider>
+    );
+  }
+
+  it('shows error warning when run failed', () => {
+    renderWith(AllowlistRunStatus.FAILED);
+    expect(screen.getByTestId('error-warning')).toBeInTheDocument();
+  });
+
+  it('does not show warning when run succeeded', () => {
+    renderWith(AllowlistRunStatus.CLAIMED);
+    expect(screen.queryByTestId('error-warning')).toBeNull();
+  });
+});

--- a/__tests__/components/distribution-plan-tool/common/RoundedManifoldIconButton.test.tsx
+++ b/__tests__/components/distribution-plan-tool/common/RoundedManifoldIconButton.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import RoundedManifoldIconButton from '../../../../components/distribution-plan-tool/common/RoundedManifoldIconButton';
+
+jest.mock('../../../../components/distribution-plan-tool/common/CircleLoader', () => ({
+  __esModule: true,
+  default: () => <div data-testid="loader" />,
+}));
+
+jest.mock('../../../../components/distribution-plan-tool/common/ManifoldIcon', () => ({
+  __esModule: true,
+  default: () => <div data-testid="icon" />,
+}));
+
+describe('RoundedManifoldIconButton', () => {
+  it('renders loader when loading and handles click', () => {
+    const onClick = jest.fn();
+    render(<RoundedManifoldIconButton loading={true} onClick={onClick} />);
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('shows icon when not loading', () => {
+    render(<RoundedManifoldIconButton loading={false} onClick={() => {}} />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for CommunityMembersTable component
- add tests for DistributionPlanErrorWarning
- add tests for DistributionPlanWarnings
- add tests for DistributionPlanVerifiedIcon and RoundedManifoldIconButton

## Testing
- `npx jest __tests__/components/distribution-plan-tool/common/DistributionPlanWarnings.test.tsx`
- `npx jest __tests__/components/distribution-plan-tool/common/RoundedManifoldIconButton.test.tsx`
