### PR TITLE
Improve test coverage

### DIFF
--- a/__tests__/components/distribution-plan-tool/common/DistributionPlanAddOperationBtn.test.tsx
+++ b/__tests__/components/distribution-plan-tool/common/DistributionPlanAddOperationBtn.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DistributionPlanAddOperationBtn from '../../../../components/distribution-plan-tool/common/DistributionPlanAddOperationBtn';
+
+// helper to render component
+function renderBtn(loading: boolean) {
+  render(
+    <DistributionPlanAddOperationBtn loading={loading}>Add</DistributionPlanAddOperationBtn>
+  );
+}
+
+describe('DistributionPlanAddOperationBtn', () => {
+  it('shows children and no spinner when not loading', () => {
+    renderBtn(false);
+    const button = screen.getByRole('button');
+    expect(button).not.toBeDisabled();
+    expect(screen.getByText('Add')).toBeVisible();
+    // spinner should not be in the document
+    expect(button.querySelector('svg')).toBeNull();
+  });
+
+  it('disables button and shows spinner when loading', () => {
+    renderBtn(true);
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+    const spinner = button.querySelector('svg');
+    expect(spinner).toBeInTheDocument();
+    // children container should be hidden via style
+    const textDiv = screen.getByText('Add');
+    expect(textDiv).toHaveStyle('visibility: hidden');
+  });
+});

--- a/__tests__/components/distribution-plan-tool/common/StepHeader.test.tsx
+++ b/__tests__/components/distribution-plan-tool/common/StepHeader.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import StepHeader from '../../../../components/distribution-plan-tool/common/StepHeader';
+import { DistributionPlanToolStep, DistributionPlanToolContext } from '../../../../components/distribution-plan-tool/DistributionPlanToolContext';
+
+function renderComponent(step: DistributionPlanToolStep, ctx?: Partial<React.ContextType<typeof DistributionPlanToolContext>>) {
+  const defaultCtx = {
+    distributionPlan: { id: 'id1', name: 'Plan', description: 'Desc' },
+    operations: [{ code: 'OP', params: { foo: 'bar' } }] as any,
+    fetchOperations: jest.fn().mockResolvedValue(undefined),
+  } as any;
+  return {
+    ...render(
+      <DistributionPlanToolContext.Provider value={{ ...defaultCtx, ...ctx }}>
+        <StepHeader step={step} title="Extra" description="More" />
+      </DistributionPlanToolContext.Provider>
+    ),
+    fetchOperations: ctx?.fetchOperations || defaultCtx.fetchOperations,
+  };
+}
+
+describe('StepHeader', () => {
+  it('renders meta title and hides download when creating plan', () => {
+    renderComponent(DistributionPlanToolStep.CREATE_PLAN);
+    expect(screen.getByRole('heading', { name: /Distribution Plan Tool.*Extra/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /download operations/i })).toBeNull();
+  });
+
+  it('downloads operations when button clicked', async () => {
+    const createObjectURL = jest.fn().mockReturnValue('blob:url');
+    Object.defineProperty(window.URL, 'createObjectURL', { value: createObjectURL });
+    const fetchOperations = jest.fn().mockResolvedValue(undefined);
+    const { container } = renderComponent(DistributionPlanToolStep.REVIEW, { fetchOperations });
+    const link = document.createElement('a');
+    // replace click with mock
+    (link as any).click = jest.fn();
+    const originalCreate = document.createElement.bind(document);
+    jest.spyOn(document, 'createElement').mockImplementation((tag: any) => {
+      return tag === 'a' ? link : originalCreate(tag);
+    });
+    const btn = screen.getByRole('button', { name: /download operations/i });
+    await userEvent.click(btn);
+
+    expect(fetchOperations).toHaveBeenCalledWith('id1');
+    expect(link.click).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotFormTable.test.tsx
+++ b/__tests__/components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotFormTable.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateCustomSnapshotFormTable from '../../../../../components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotFormTable';
+import { CustomTokenPoolParamsToken } from '../../../../../components/allowlist-tool/allowlist-tool.types';
+
+const tokens: CustomTokenPoolParamsToken[] = [
+  { owner: '0x1', amount: '1' },
+  { owner: '0x2', amount: '2' }
+];
+
+describe('CreateCustomSnapshotFormTable', () => {
+  it('renders tokens with index', () => {
+    render(<CreateCustomSnapshotFormTable tokens={tokens} onRemoveToken={jest.fn()} />);
+    expect(screen.getByText('0x1')).toBeInTheDocument();
+    expect(screen.getByText('0x2')).toBeInTheDocument();
+    // indexes 1 and 2 should be shown
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('calls onRemoveToken when delete clicked', async () => {
+    const onRemoveToken = jest.fn();
+    render(<CreateCustomSnapshotFormTable tokens={tokens} onRemoveToken={onRemoveToken} />);
+    const buttons = screen.getAllByRole('button', { name: /delete/i });
+    await userEvent.click(buttons[1]);
+    expect(onRemoveToken).toHaveBeenCalledWith(1);
+  });
+});

--- a/__tests__/components/distribution-plan-tool/create-custom-snapshots/table/CreateCustomSnapshotTable.test.tsx
+++ b/__tests__/components/distribution-plan-tool/create-custom-snapshots/table/CreateCustomSnapshotTable.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CreateCustomSnapshotTable from '../../../../../components/distribution-plan-tool/create-custom-snapshots/table/CreateCustomSnapshotTable';
+import { AllowlistCustomTokenPool } from '../../../../../components/allowlist-tool/allowlist-tool.types';
+
+const snapshots: AllowlistCustomTokenPool[] = [
+  { id: '1', name: 'snap1', walletsCount: 2, tokensCount: 5 },
+  { id: '2', name: 'snap2', walletsCount: 3, tokensCount: 7 },
+];
+
+describe('CreateCustomSnapshotTable', () => {
+  it('renders header labels', () => {
+    render(<CreateCustomSnapshotTable customSnapshots={snapshots} />);
+    expect(screen.getByRole('columnheader', { name: /name/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /wallets/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /tokens/i })).toBeInTheDocument();
+  });
+
+  it('displays snapshot rows', () => {
+    render(<CreateCustomSnapshotTable customSnapshots={snapshots} />);
+    expect(screen.getByText('snap1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('snap2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add DistributionPlanAddOperationBtn tests
- add StepHeader tests for download behavior
- add tests for custom snapshot table components

## Testing
- `npm run lint`
- `npm run type-check`
- `npx jest __tests__/components/distribution-plan-tool/common/DistributionPlanAddOperationBtn.test.tsx`
- `npx jest __tests__/components/distribution-plan-tool/common/StepHeader.test.tsx`
- `npx jest __tests__/components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotFormTable.test.tsx`
- `npx jest __tests__/components/distribution-plan-tool/create-custom-snapshots/table/CreateCustomSnapshotTable.test.tsx`
- `npm run improve-coverage` *(fails: current coverage 18.02% < target 18.06%)*