### PR TITLE
Fix failing type-check

### DIFF
--- a/__tests__/components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotFormTable.test.tsx
+++ b/__tests__/components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotFormTable.test.tsx
@@ -5,8 +5,8 @@ import CreateCustomSnapshotFormTable from '../../../../../components/distributio
 import { CustomTokenPoolParamsToken } from '../../../../../components/allowlist-tool/allowlist-tool.types';
 
 const tokens: CustomTokenPoolParamsToken[] = [
-  { owner: '0x1', amount: '1' },
-  { owner: '0x2', amount: '2' }
+  { owner: '0x1' },
+  { owner: '0x2' }
 ];
 
 describe('CreateCustomSnapshotFormTable', () => {

--- a/__tests__/components/distribution-plan-tool/create-custom-snapshots/table/CreateCustomSnapshotTable.test.tsx
+++ b/__tests__/components/distribution-plan-tool/create-custom-snapshots/table/CreateCustomSnapshotTable.test.tsx
@@ -4,8 +4,8 @@ import CreateCustomSnapshotTable from '../../../../../components/distribution-pl
 import { AllowlistCustomTokenPool } from '../../../../../components/allowlist-tool/allowlist-tool.types';
 
 const snapshots: AllowlistCustomTokenPool[] = [
-  { id: '1', name: 'snap1', walletsCount: 2, tokensCount: 5 },
-  { id: '2', name: 'snap2', walletsCount: 3, tokensCount: 7 },
+  { id: '1', allowlistId: 'a1', name: 'snap1', description: 'd1', walletsCount: 2, tokensCount: 5 },
+  { id: '2', allowlistId: 'a2', name: 'snap2', description: 'd2', walletsCount: 3, tokensCount: 7 },
 ];
 
 describe('CreateCustomSnapshotTable', () => {


### PR DESCRIPTION
## Summary
- fix custom snapshot table tests for `CustomTokenPoolParamsToken` and `AllowlistCustomTokenPool`

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
