### PR TITLE
Improve test coverage

### DIFF
--- a/__mocks__/react-use-downloader.js
+++ b/__mocks__/react-use-downloader.js
@@ -1,0 +1,9 @@
+module.exports = jest.fn(() => ({
+  size: 0,
+  elapsed: 0,
+  percentage: 0,
+  download: jest.fn(),
+  cancel: jest.fn(),
+  error: null,
+  isInProgress: false,
+}));

--- a/__tests__/components/distribution-plan-tool/common/DistributionPlanStepWrapper.test.tsx
+++ b/__tests__/components/distribution-plan-tool/common/DistributionPlanStepWrapper.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DistributionPlanStepWrapper from '../../../../components/distribution-plan-tool/common/DistributionPlanStepWrapper';
+
+describe('DistributionPlanStepWrapper', () => {
+  it('renders children inside wrapper with expected classes', () => {
+    render(
+      <DistributionPlanStepWrapper>
+        <span data-testid="child" />
+      </DistributionPlanStepWrapper>
+    );
+    const wrapper = screen.getByTestId('child').parentElement as HTMLElement;
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper).toHaveClass(
+      'tw-mt-8 tw-pt-8 tw-border-t tw-border-solid tw-border-l-0 tw-border-r-0 tw-border-b-0 tw-border-t-neutral-700/60 tw-mx-auto'
+    );
+  });
+});

--- a/__tests__/components/distribution-plan-tool/connect/distribution-plan-tool-not-connected.test.tsx
+++ b/__tests__/components/distribution-plan-tool/connect/distribution-plan-tool-not-connected.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DistributionPlanToolNotConnected from '../../../../components/distribution-plan-tool/connect/distribution-plan-tool-not-connected';
+
+describe('DistributionPlanToolNotConnected', () => {
+  it('renders headings and explanatory text', () => {
+    render(<DistributionPlanToolNotConnected />);
+
+    expect(screen.getByRole('heading', { level: 1, name: 'EMMA' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /connect your wallet/i })).toBeInTheDocument();
+    expect(
+      screen.getByText(/connect with an address from within your consolidated account/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/no gas is needed to sign in/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotFormTable.test.tsx
+++ b/__tests__/components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotFormTable.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import CreateCustomSnapshotFormTable from '../../../../../components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotFormTable';
 import { CustomTokenPoolParamsToken } from '../../../../../components/allowlist-tool/allowlist-tool.types';
 
-const tokens: CustomTokenPoolParamsToken[] = [
+const tokens: any[] = [
   { owner: '0x1', amount: '1' },
   { owner: '0x2', amount: '2' }
 ];

--- a/__tests__/components/distribution-plan-tool/create-custom-snapshots/table/CreateCustomSnapshotTable.test.tsx
+++ b/__tests__/components/distribution-plan-tool/create-custom-snapshots/table/CreateCustomSnapshotTable.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import CreateCustomSnapshotTable from '../../../../../components/distribution-plan-tool/create-custom-snapshots/table/CreateCustomSnapshotTable';
 import { AllowlistCustomTokenPool } from '../../../../../components/allowlist-tool/allowlist-tool.types';
 
-const snapshots: AllowlistCustomTokenPool[] = [
+const snapshots: any[] = [
   { id: '1', name: 'snap1', walletsCount: 2, tokensCount: 5 },
   { id: '2', name: 'snap2', walletsCount: 3, tokensCount: 7 },
 ];

--- a/__tests__/components/distribution-plan-tool/create-phases/CreatePhases.test.tsx
+++ b/__tests__/components/distribution-plan-tool/create-phases/CreatePhases.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CreatePhases from '../../../../components/distribution-plan-tool/create-phases/CreatePhases';
+import { DistributionPlanToolContext, DistributionPlanToolStep } from '../../../../components/distribution-plan-tool/DistributionPlanToolContext';
+import { AllowlistOperationCode } from '../../../../components/allowlist-tool/allowlist-tool.types';
+
+const defaultContext = {
+  setStep: jest.fn(),
+  operations: [],
+} as any;
+
+function renderWithCtx(ctx?: Partial<typeof defaultContext>) {
+  return render(
+    <DistributionPlanToolContext.Provider value={{ ...defaultContext, ...ctx }}>
+      <CreatePhases />
+    </DistributionPlanToolContext.Provider>
+  );
+}
+
+describe('CreatePhases', () => {
+  it('shows placeholder and hides next button when no phases', () => {
+    renderWithCtx();
+    expect(screen.getByText('No Phases Added')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /next/i })).toBeNull();
+  });
+
+  it('lists phases from operations and enables next step', () => {
+    const operations = [
+      {
+        code: AllowlistOperationCode.ADD_PHASE,
+        params: { id: 'p1', name: 'Phase 1', description: '' },
+        allowlistId: '1',
+        order: 1,
+        createdAt: 0,
+        hasRan: false,
+      },
+    ];
+
+    renderWithCtx({ operations });
+
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getByText('Phase 1')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/download/Download.test.tsx
+++ b/__tests__/components/download/Download.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Download from '../../../components/download/Download';
+import useDownloader from 'react-use-downloader';
+
+jest.mock('react-use-downloader');
+
+const mockedUseDownloader = useDownloader as jest.MockedFunction<typeof useDownloader>;
+
+describe('Download', () => {
+  it('triggers download when not in progress', async () => {
+    const downloadMock = jest.fn();
+    mockedUseDownloader.mockReturnValue({
+      size: 0,
+      elapsed: 0,
+      percentage: 0,
+      download: downloadMock,
+      cancel: jest.fn(),
+      error: null,
+      isInProgress: false,
+    });
+
+    render(<Download href="/f" name="myfile" extension="txt" />);
+    await userEvent.click(screen.getByRole('img', { hidden: true }));
+    expect(downloadMock).toHaveBeenCalledWith('/f', 'myfile.txt');
+  });
+
+  it('shows progress and allows cancel', async () => {
+    const cancelMock = jest.fn();
+    mockedUseDownloader.mockReturnValue({
+      size: 0,
+      elapsed: 0,
+      percentage: 42,
+      download: jest.fn(),
+      cancel: cancelMock,
+      error: null,
+      isInProgress: true,
+    });
+
+    render(<Download href="/f" name="myfile" extension="txt" />);
+    expect(screen.getByText('Downloading 42 %')).toBeInTheDocument();
+    await userEvent.click(screen.getByText('Cancel'));
+    expect(cancelMock).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/downloadUrlWidget/DownloadUrlWidget.test.tsx
+++ b/__tests__/components/downloadUrlWidget/DownloadUrlWidget.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DownloadUrlWidget from '../../../components/downloadUrlWidget/DownloadUrlWidget';
+import useDownloader from 'react-use-downloader';
+
+jest.mock('react-use-downloader');
+jest.mock('../../../components/dotLoader/DotLoader', () => ({ Spinner: () => <span data-testid="spinner" /> }));
+jest.mock('../../../services/auth/auth.utils', () => ({ getAuthJwt: () => 'jwt', getStagingAuth: () => 'api' }));
+jest.mock('@fortawesome/react-fontawesome', () => ({ FontAwesomeIcon: (p:any) => <svg data-testid="icon" onClick={p.onClick} /> }));
+
+const mockedUseDownloader = useDownloader as jest.MockedFunction<typeof useDownloader>;
+
+describe('DownloadUrlWidget', () => {
+  it('starts download when button clicked', async () => {
+    const downloadMock = jest.fn();
+    mockedUseDownloader.mockReturnValue({
+      size: 0,
+      elapsed: 0,
+      percentage: 0,
+      download: downloadMock,
+      cancel: jest.fn(),
+      error: null,
+      isInProgress: false,
+    } as any);
+    render(<DownloadUrlWidget preview="Preview" url="/file" name="file.txt" />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(downloadMock).toHaveBeenCalledWith('/file', 'file.txt');
+    expect(screen.queryByTestId('spinner')).toBeNull();
+  });
+
+  it('shows spinner when in progress and disables button', () => {
+    const cancel = jest.fn();
+    mockedUseDownloader.mockReturnValue({
+      size: 0,
+      elapsed: 0,
+      percentage: 0,
+      download: jest.fn(),
+      cancel,
+      error: null,
+      isInProgress: true,
+    } as any);
+    render(<DownloadUrlWidget preview="Preview" url="/file" name="file.txt" />);
+    const btn = screen.getByRole('button');
+    expect(btn).toBeDisabled();
+    expect(screen.getByTestId('spinner')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- test DistributionPlanStepWrapper component
- add tests for DistributionPlanToolNotConnected and CreatePhases
- add download component tests and mock react-use-downloader
- update snapshot table tests to fix types
- add coverage for DownloadUrlWidget

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
