### PR TITLE
Fix path in websocket message test

### DIFF
--- a/__tests__/services/websocket/useWebSocketMessage.test.ts
+++ b/__tests__/services/websocket/useWebSocketMessage.test.ts
@@ -2,11 +2,11 @@ import { renderHook } from '@testing-library/react';
 import { useWebSocketMessage } from '../../../services/websocket/useWebSocketMessage';
 import { WebSocketStatus } from '../../../services/websocket/WebSocketTypes';
 
-jest.mock('../../services/websocket/useWebSocket', () => ({
+jest.mock('../../../services/websocket/useWebSocket', () => ({
   useWebSocket: jest.fn(),
 }));
 
-const { useWebSocket } = require('../../services/websocket/useWebSocket');
+const { useWebSocket } = require('../../../services/websocket/useWebSocket');
 
 describe('useWebSocketMessage', () => {
   it('subscribes when connected and cleans up on unmount', () => {


### PR DESCRIPTION
## Summary
- correct relative import paths in useWebSocketMessage test so mocks resolve

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`