### PR TITLE
Add tests for download components

### DIFF
--- a/__tests__/components/Download.test.tsx
+++ b/__tests__/components/Download.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Download from '../../components/download/Download';
+
+const mockDownload = jest.fn();
+const mockCancel = jest.fn();
+const mockUseDownloader = jest.fn(() => ({
+  size: 0,
+  elapsed: 0,
+  percentage: 42,
+  download: mockDownload,
+  cancel: mockCancel,
+  error: null,
+  isInProgress: false,
+}));
+
+jest.mock('react-use-downloader', () => ({
+  __esModule: true,
+  default: () => mockUseDownloader(),
+}));
+
+describe('Download', () => {
+  beforeEach(() => {
+    mockDownload.mockClear();
+    mockCancel.mockClear();
+    mockUseDownloader.mockClear();
+    mockUseDownloader.mockReturnValue({
+      size: 0,
+      elapsed: 0,
+      percentage: 42,
+      download: mockDownload,
+      cancel: mockCancel,
+      error: null,
+      isInProgress: false,
+    });
+  });
+
+  it('starts download on icon click when not in progress', async () => {
+    render(<Download href="/file" name="test" extension="txt" />);
+    const icon = screen.getByRole('img', { hidden: true });
+    await userEvent.click(icon);
+    expect(mockDownload).toHaveBeenCalledWith('/file', 'test.txt');
+  });
+
+  it('shows progress and cancels when in progress', async () => {
+    mockUseDownloader.mockReturnValueOnce({
+      size: 0,
+      elapsed: 0,
+      percentage: 55,
+      download: mockDownload,
+      cancel: mockCancel,
+      error: null,
+      isInProgress: true,
+    });
+    render(<Download href="/file" name="test" extension="txt" />);
+    expect(screen.getByText(/Downloading 55/)).toBeInTheDocument();
+    const cancel = screen.getByText('Cancel');
+    await userEvent.click(cancel);
+    expect(mockCancel).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/distribution-plan-tool/CreatePhases.test.tsx
+++ b/__tests__/components/distribution-plan-tool/CreatePhases.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CreatePhases from '../../../components/distribution-plan-tool/create-phases/CreatePhases';
+import { DistributionPlanToolContext, DistributionPlanToolStep } from '../../../components/distribution-plan-tool/DistributionPlanToolContext';
+import { AllowlistOperationCode } from '../../../components/allowlist-tool/allowlist-tool.types';
+
+jest.mock('../../../components/distribution-plan-tool/common/StepHeader', () => () => <div data-testid="header" />);
+jest.mock('../../../components/distribution-plan-tool/common/DistributionPlanStepWrapper', () => ({ children }: any) => <div>{children}</div>);
+jest.mock('../../../components/distribution-plan-tool/create-phases/form/CreatePhasesForm', () => () => <div data-testid="form" />);
+jest.mock('../../../components/distribution-plan-tool/create-phases/table/CreatePhasesTable', () => ({ phases }: any) => <div data-testid="table">{phases.length}</div>);
+jest.mock('../../../components/distribution-plan-tool/common/DistributionPlanNextStepBtn', () => ({ onNextStep, showNextBtn }: any) => (
+  <button data-testid="next" onClick={onNextStep}>{showNextBtn && 'next'}</button>
+));
+jest.mock('../../../components/distribution-plan-tool/common/DistributionPlanEmptyTablePlaceholder', () => ({ title }: any) => <div data-testid="empty">{title}</div>);
+
+describe('CreatePhases', () => {
+  function renderWithOps(operations: any[], setStep = jest.fn()) {
+    return {
+      setStep,
+      ...render(
+        <DistributionPlanToolContext.Provider value={{ operations, setStep } as any}>
+          <CreatePhases />
+        </DistributionPlanToolContext.Provider>
+      )
+    };
+  }
+
+  it('shows table and allows advancing when phases exist', () => {
+    const ops = [{
+      code: AllowlistOperationCode.ADD_PHASE,
+      params: { id: 'p1', name: 'Phase1', description: '' },
+      hasRan: false,
+      order: 1,
+      allowlistId: 'a'
+    }];
+    const { setStep } = renderWithOps(ops);
+    expect(screen.getByTestId('form')).toBeInTheDocument();
+    expect(screen.getByTestId('table')).toHaveTextContent('1');
+    const btn = screen.getByTestId('next');
+    expect(btn).toHaveTextContent('next');
+    fireEvent.click(btn);
+    expect(setStep).toHaveBeenCalledWith(DistributionPlanToolStep.BUILD_PHASES);
+  });
+
+  it('shows placeholder and hides next when no phases', () => {
+    renderWithOps([]);
+    expect(screen.getByTestId('empty')).toHaveTextContent('No Phases Added');
+    expect(screen.getByTestId('next')).toHaveTextContent('');
+  });
+});

--- a/__tests__/components/distribution-plan-tool/common/DistributionPlanStepWrapper.test.tsx
+++ b/__tests__/components/distribution-plan-tool/common/DistributionPlanStepWrapper.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DistributionPlanStepWrapper from '../../../../components/distribution-plan-tool/common/DistributionPlanStepWrapper';
+
+const CHILD_TEXT = 'wrapped content';
+
+function renderWrapper() {
+  return render(
+    <DistributionPlanStepWrapper>
+      <span>{CHILD_TEXT}</span>
+    </DistributionPlanStepWrapper>
+  );
+}
+
+describe('DistributionPlanStepWrapper', () => {
+  it('renders children inside wrapper', () => {
+    renderWrapper();
+    expect(screen.getByText(CHILD_TEXT)).toBeInTheDocument();
+  });
+
+  it('applies styling classes to wrapper', () => {
+    const { container } = renderWrapper();
+    const div = container.firstElementChild as HTMLElement;
+    expect(div.tagName).toBe('DIV');
+    expect(div.className).toContain('tw-mt-8');
+    expect(div.className).toContain('tw-pt-8');
+    expect(div.className).toContain('tw-border-t');
+    expect(div.className).toContain('tw-border-solid');
+    expect(div.className).toContain('tw-border-t-neutral-700/60');
+    expect(div.className).toContain('tw-mx-auto');
+  });
+});

--- a/__tests__/components/distribution-plan-tool/connect/DistributionPlanToolNotConnected.test.tsx
+++ b/__tests__/components/distribution-plan-tool/connect/DistributionPlanToolNotConnected.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import DistributionPlanToolNotConnected from '../../../../components/distribution-plan-tool/connect/distribution-plan-tool-not-connected';
+
+describe('DistributionPlanToolNotConnected', () => {
+  it('shows headings prompting user to connect', () => {
+    render(<DistributionPlanToolNotConnected />);
+    expect(screen.getByRole('heading', { level: 1, name: /EMMA/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /Connect Your Wallet/i })).toBeInTheDocument();
+  });
+
+  it('displays explanatory paragraphs', () => {
+    render(<DistributionPlanToolNotConnected />);
+    expect(screen.getByText(/Connect with an address/)).toBeInTheDocument();
+    expect(screen.getByText(/No gas is needed to sign in/)).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/downloadUrlWidget/DownloadUrlWidget.test.tsx
+++ b/__tests__/components/downloadUrlWidget/DownloadUrlWidget.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DownloadUrlWidget from '../../../components/downloadUrlWidget/DownloadUrlWidget';
+
+const mockDownload = jest.fn();
+const mockUseDownloader = jest.fn();
+
+jest.mock('react-use-downloader', () => ({
+  __esModule: true,
+  default: (...args: any[]) => mockUseDownloader(...args)
+}));
+
+jest.mock('../../../services/auth/auth.utils', () => ({
+  getStagingAuth: () => 'stag',
+  getAuthJwt: () => 'jwtToken'
+}));
+
+describe('DownloadUrlWidget', () => {
+  beforeEach(() => {
+    mockDownload.mockClear();
+    mockUseDownloader.mockClear();
+  });
+
+  it('passes headers and triggers download on click', async () => {
+    mockUseDownloader.mockReturnValue({ download: mockDownload, isInProgress: false });
+    render(<DownloadUrlWidget preview="Download" url="/file" name="file.pdf" />);
+    expect(mockUseDownloader).toHaveBeenCalledWith({ headers: { 'x-6529-auth': 'stag', Authorization: 'Bearer jwtToken' } });
+    const button = screen.getByRole('button');
+    await userEvent.click(button);
+    expect(mockDownload).toHaveBeenCalledWith('/file', 'file.pdf');
+  });
+
+  it('shows spinner and disables button when in progress', async () => {
+    mockUseDownloader.mockReturnValue({ download: mockDownload, isInProgress: true });
+    render(<DownloadUrlWidget preview="Download" url="/file" name="file.pdf" />);
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+    expect(screen.getByText('Downloading')).toBeInTheDocument();
+    await userEvent.click(button);
+    expect(mockDownload).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for DistributionPlanStepWrapper
- add tests for CreatePhases logic
- cover Download component behaviour
- cover DownloadUrlWidget and not-connected state

## Testing
- `npm run improve-coverage`