### PR TITLE
Improve frontend coverage

### DIFF
--- a/__tests__/components/drops/create/lexical/plugins/ToggleViewButtonPlugin.test.tsx
+++ b/__tests__/components/drops/create/lexical/plugins/ToggleViewButtonPlugin.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ToggleViewButtonPlugin from '../../../../../../components/drops/create/lexical/plugins/ToggleViewButtonPlugin';
+
+describe('ToggleViewButtonPlugin', () => {
+  it('calls onViewClick when button is clicked', () => {
+    const onViewClick = jest.fn();
+    render(<ToggleViewButtonPlugin onViewClick={onViewClick} />);
+    const button = screen.getByRole('button', { name: /cancel/i });
+    fireEvent.click(button);
+    expect(onViewClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders accessible button with cancel label', () => {
+    const onViewClick = jest.fn();
+    render(<ToggleViewButtonPlugin onViewClick={onViewClick} />);
+    const button = screen.getByRole('button', { name: /cancel/i });
+    expect(button).toHaveAttribute('type', 'button');
+    // ensure icon is present inside button
+    const svg = button.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/drops/create/utils/CreateDropDesktopFooter.test.tsx
+++ b/__tests__/components/drops/create/utils/CreateDropDesktopFooter.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CreateDropDesktopFooter from '../../../../../components/drops/create/utils/CreateDropDesktopFooter';
+import { CreateDropType } from '../../../../../components/drops/create/types';
+
+describe('CreateDropDesktopFooter', () => {
+  it('renders button text based on drop type', () => {
+    const onDrop = jest.fn();
+    const { rerender } = render(
+      <CreateDropDesktopFooter disabled={false} loading={false} type={CreateDropType.DROP} onDrop={onDrop} />
+    );
+    expect(screen.getByRole('button', { name: /drop/i })).toBeInTheDocument();
+
+    rerender(
+      <CreateDropDesktopFooter disabled={false} loading={false} type={CreateDropType.QUOTE} onDrop={onDrop} />
+    );
+    expect(screen.getByRole('button', { name: /quote/i })).toBeInTheDocument();
+  });
+
+  it('calls onDrop when button is clicked and not disabled', () => {
+    const onDrop = jest.fn();
+    render(
+      <CreateDropDesktopFooter disabled={false} loading={false} type={CreateDropType.DROP} onDrop={onDrop} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /drop/i }));
+    expect(onDrop).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables button when disabled prop is true', () => {
+    const onDrop = jest.fn();
+    render(
+      <CreateDropDesktopFooter disabled={true} loading={false} type={CreateDropType.DROP} onDrop={onDrop} />
+    );
+    const button = screen.getByRole('button', { name: /drop/i });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/drops/create/utils/storm/CreateDropStormView.test.tsx
+++ b/__tests__/components/drops/create/utils/storm/CreateDropStormView.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import CreateDropStormView from '../../../../../../components/drops/create/utils/storm/CreateDropStormView';
+import { CreateDropConfig } from '../../../../../../entities/IDrop';
+
+jest.mock('../../../../../../components/drops/create/utils/storm/CreateDropStormViewPart', () => {
+  return jest.fn(() => <div data-testid="part" />);
+});
+
+const MockPart = require('../../../../../../components/drops/create/utils/storm/CreateDropStormViewPart');
+
+describe('CreateDropStormView', () => {
+  const profile = { id: '1', handle: 'alice', pfp: null } as any;
+  const wave = { name: 'Wave', image: null, id: 'wave1' };
+
+  function createDropWithParts(count: number): CreateDropConfig {
+    return {
+      parts: Array.from({ length: count }, () => ({
+        content: 'content',
+        quoted_drop: null,
+        media: [new File([''], 'a.png', { type: 'image/png' })],
+      })),
+      referenced_nfts: [],
+      mentioned_users: [],
+      title: 'title',
+    } as any;
+  }
+
+  afterEach(() => {
+    (MockPart as jest.Mock).mockClear();
+  });
+
+  it('renders a part component for each drop part', () => {
+    const drop = createDropWithParts(2);
+    render(<CreateDropStormView drop={drop} profile={profile} wave={wave} removePart={jest.fn()} />);
+    expect(screen.getAllByTestId('part')).toHaveLength(2);
+    expect(MockPart).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders nothing when there are no parts', () => {
+    const drop = createDropWithParts(0);
+    render(<CreateDropStormView drop={drop} profile={profile} wave={wave} removePart={jest.fn()} />);
+    expect(screen.queryByTestId('part')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for drop desktop footer, toggle plugin, and storm view

## Testing
- `npm run test`
- `npm run improve-coverage`