### PR TITLE
Improve WebSocket test path

### DIFF
--- a/__tests__/services/websocket/useWebSocketMessage.test.ts
+++ b/__tests__/services/websocket/useWebSocketMessage.test.ts
@@ -2,11 +2,11 @@ import { renderHook } from '@testing-library/react';
 import { useWebSocketMessage } from '../../../services/websocket/useWebSocketMessage';
 import { WebSocketStatus } from '../../../services/websocket/WebSocketTypes';
 
-jest.mock('../../services/websocket/useWebSocket', () => ({
+jest.mock('../../../services/websocket/useWebSocket', () => ({
   useWebSocket: jest.fn(),
 }));
 
-const { useWebSocket } = require('../../services/websocket/useWebSocket');
+const { useWebSocket } = require('../../../services/websocket/useWebSocket');
 
 describe('useWebSocketMessage', () => {
   it('subscribes when connected and cleans up on unmount', () => {


### PR DESCRIPTION
## Summary
- fix test path in `useWebSocketMessage` unit test

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
