### PR TITLE
Improve coverage

### DIFF
--- a/__tests__/components/allowlist-tool/AllowlistToolCsvIcon.test.tsx
+++ b/__tests__/components/allowlist-tool/AllowlistToolCsvIcon.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import AllowlistToolCsvIcon from '../../../components/allowlist-tool/icons/AllowlistToolCsvIcon';
+
+describe('AllowlistToolCsvIcon', () => {
+  it('renders svg with csv accent color', () => {
+    const { container } = render(<AllowlistToolCsvIcon />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('viewBox', '0 0 71 80');
+    expect(svg).toHaveClass('tw-h-auto tw-w-auto tw-text-[#76bc99]');
+  });
+});

--- a/__tests__/components/allowlist-tool/AllowlistToolSelectMenuMultipleListItem.test.tsx
+++ b/__tests__/components/allowlist-tool/AllowlistToolSelectMenuMultipleListItem.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AllowlistToolSelectMenuListItem from '../../../components/allowlist-tool/common/select-menu-multiple/AllowlistToolSelectMenuMultipleListItem';
+import { AllowlistToolSelectMenuMultipleOption } from '../../../components/allowlist-tool/common/select-menu-multiple/AllowlistToolSelectMenuMultiple';
+
+const option: AllowlistToolSelectMenuMultipleOption = {
+  title: 'Option 1',
+  value: 'opt1',
+  subTitle: 'Sub 1',
+};
+
+describe('AllowlistToolSelectMenuMultipleListItem', () => {
+  it('renders subtitle and checkmark when selected', () => {
+    const toggle = jest.fn();
+    const { container } = render(
+      <AllowlistToolSelectMenuListItem
+        option={option}
+        selectedOptions={[option]}
+        toggleSelectedOption={toggle}
+      />,
+    );
+    expect(screen.getByText('Sub 1')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('calls toggleSelectedOption on click', async () => {
+    const user = userEvent.setup();
+    const toggle = jest.fn();
+    render(
+      <AllowlistToolSelectMenuListItem
+        option={option}
+        selectedOptions={[]}
+        toggleSelectedOption={toggle}
+      />,
+    );
+    await user.click(screen.getByRole('option'));
+    expect(toggle).toHaveBeenCalledWith(option);
+  });
+});

--- a/__tests__/components/allowlist-tool/allowlist-tool.types.test.ts
+++ b/__tests__/components/allowlist-tool/allowlist-tool.types.test.ts
@@ -1,0 +1,32 @@
+import {
+  AllowlistOperationCode,
+  Pool,
+  AllowlistRunStatus,
+  DistributionPlanTokenPoolDownloadStatus,
+} from '../../../components/allowlist-tool/allowlist-tool.types';
+
+describe('allowlist-tool.types enums', () => {
+  it('has correct AllowlistOperationCode values', () => {
+    expect(AllowlistOperationCode.CREATE_ALLOWLIST).toBe('CREATE_ALLOWLIST');
+    expect(AllowlistOperationCode.ADD_ITEM).toBe('ADD_ITEM');
+    expect(AllowlistOperationCode.ITEM_REMOVE_FIRST_N_WALLETS).toBe('ITEM_REMOVE_FIRST_N_WALLETS');
+  });
+
+  it('has correct Pool enum values', () => {
+    expect(Pool.TOKEN_POOL).toBe('TOKEN_POOL');
+    expect(Pool.CUSTOM_TOKEN_POOL).toBe('CUSTOM_TOKEN_POOL');
+    expect(Pool.WALLET_POOL).toBe('WALLET_POOL');
+  });
+
+  it('has correct AllowlistRunStatus values', () => {
+    expect(AllowlistRunStatus.PENDING).toBe('PENDING');
+    expect(AllowlistRunStatus.CLAIMED).toBe('CLAIMED');
+    expect(AllowlistRunStatus.FAILED).toBe('FAILED');
+  });
+
+  it('has correct DistributionPlanTokenPoolDownloadStatus values', () => {
+    expect(DistributionPlanTokenPoolDownloadStatus.PENDING).toBe('PENDING');
+    expect(DistributionPlanTokenPoolDownloadStatus.CLAIMED).toBe('CLAIMED');
+    expect(DistributionPlanTokenPoolDownloadStatus.COMPLETED).toBe('COMPLETED');
+  });
+});

--- a/__tests__/components/block-picker/BlockPickerBlockNumberIncludes.test.tsx
+++ b/__tests__/components/block-picker/BlockPickerBlockNumberIncludes.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import BlockPickerBlockNumberIncludes from '../../../components/block-picker/BlockPickerBlockNumberIncludes';
+
+describe('BlockPickerBlockNumberIncludes', () => {
+  it('renders input and updates value', async () => {
+    function Wrapper() {
+      const [val, setVal] = useState('');
+      return (
+        <BlockPickerBlockNumberIncludes
+          blockNumberIncludes={val}
+          setBlockNumberIncludes={setVal}
+        />
+      );
+    }
+    render(<Wrapper />);
+    const input = screen.getByPlaceholderText('e.g. 42, 69, 42069, 6529');
+    await userEvent.type(input, '123');
+    expect((input as HTMLInputElement).value).toBe('123');
+  });
+});

--- a/__tests__/components/brain/content/BrainContentPinnedWave.test.tsx
+++ b/__tests__/components/brain/content/BrainContentPinnedWave.test.tsx
@@ -1,0 +1,55 @@
+import { render, fireEvent } from '@testing-library/react';
+import BrainContentPinnedWave from '../../../../components/brain/content/BrainContentPinnedWave';
+import { ApiWaveType } from '../../../../generated/models/ObjectSerializer';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    query: {},
+    push: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../../hooks/usePrefetchWaveData', () => ({
+  usePrefetchWaveData: () => jest.fn(),
+}));
+
+jest.mock('../../../../hooks/useWaveData', () => ({
+  useWaveData: () => ({
+    data: {
+      name: 'wave name',
+      picture: '',
+      wave: { type: ApiWaveType.Chat },
+      contributors_overview: [],
+    },
+  }),
+}));
+
+jest.mock('../../../../hooks/isMobileDevice', () => ({
+  __esModule: true,
+  default: () => false,
+}));
+
+jest.mock('../../../../contexts/wave/MyStreamContext', () => ({
+  useMyStream: () => ({ registerWave: jest.fn() }),
+}));
+
+describe('BrainContentPinnedWave', () => {
+  it('calls callbacks on hover and remove', () => {
+    const onMouseEnter = jest.fn();
+    const onMouseLeave = jest.fn();
+    const onRemove = jest.fn();
+    const { getByRole } = render(
+      <BrainContentPinnedWave
+        waveId="1"
+        active={false}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        onRemove={onRemove}
+      />,
+    );
+    fireEvent.mouseEnter(getByRole('link').parentElement!);
+    expect(onMouseEnter).toHaveBeenCalledWith('1');
+    fireEvent.click(getByRole('button', { name: 'Remove wave' }));
+    expect(onRemove).toHaveBeenCalledWith('1');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for enum values in allowlist-tool types
- test selection list item UI behavior
- add CSV icon test
- test block number includes input interactions
- cover pinned wave events

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run improve-coverage`