### PR TITLE
Add component tests to increase coverage

### DIFF
--- a/__tests__/components/allowlist-tool/AllowlistToolAnimationHeightOpacity.test.tsx
+++ b/__tests__/components/allowlist-tool/AllowlistToolAnimationHeightOpacity.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import AllowlistToolAnimationHeightOpacity from '../../../components/allowlist-tool/common/animation/AllowlistToolAnimationHeightOpacity';
+
+// Mock framer-motion motion.div to inspect props
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: jest.fn((props: any) => <div data-testid="motion-div" {...props} />)
+  }
+}));
+
+const { motion } = require('framer-motion');
+
+describe('AllowlistToolAnimationHeightOpacity', () => {
+  it('renders children with provided role and class and handles click', () => {
+    const handleClick = jest.fn();
+    render(
+      <AllowlistToolAnimationHeightOpacity elementRole="row" elementClasses="my-class" onClicked={handleClick}>
+        <span>Content</span>
+      </AllowlistToolAnimationHeightOpacity>
+    );
+
+    const div = screen.getByTestId('motion-div');
+    expect(div).toHaveClass('my-class');
+    expect(div).toHaveAttribute('role', 'row');
+    expect(div).toHaveTextContent('Content');
+
+    fireEvent.click(div);
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('passes framer-motion props correctly', () => {
+    render(
+      <AllowlistToolAnimationHeightOpacity>
+        <span>child</span>
+      </AllowlistToolAnimationHeightOpacity>
+    );
+
+    const props = (motion.div as jest.Mock).mock.calls[0][0];
+    expect(props.initial).toEqual({ height: '0', opacity: 0 });
+    expect(props.animate).toEqual({
+      height: 'auto',
+      opacity: 1,
+      transition: {
+        height: { duration: 0.3 },
+        opacity: { duration: 0.3, delay: 0.3 },
+      },
+    });
+    expect(props.exit).toEqual({
+      height: '0',
+      opacity: 0,
+      transition: {
+        opacity: { duration: 0 },
+        height: { duration: 0.3 },
+      },
+    });
+  });
+});

--- a/__tests__/components/app-wallets/AppWalletCard.test.tsx
+++ b/__tests__/components/app-wallets/AppWalletCard.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import AppWalletCard from '../../../components/app-wallets/AppWalletCard';
+
+jest.mock('../../../components/app-wallets/AppWalletAvatar', () => (props: any) => (
+  <div data-testid="avatar" data-address={props.address} />
+));
+
+describe('AppWalletCard', () => {
+  const wallet = { address: '0xABC', name: 'Main Wallet', imported: false } as any;
+
+  it('renders wallet details and link', () => {
+    render(<AppWalletCard wallet={wallet} />);
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/tools/app-wallets/0xABC');
+    expect(screen.getByTestId('avatar')).toHaveAttribute('data-address', '0xABC');
+    expect(screen.getByText('Main Wallet')).toBeInTheDocument();
+    expect(screen.getByText('0xabc')).toBeInTheDocument();
+  });
+
+  it('shows imported label when wallet.imported is true', () => {
+    render(<AppWalletCard wallet={{ ...(wallet as any), imported: true }} />);
+    expect(screen.getByText('(imported)')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/block-picker/advanced/BlockPickerAdvancedItemBlock.test.tsx
+++ b/__tests__/components/block-picker/advanced/BlockPickerAdvancedItemBlock.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import React from 'react';
+
+const mockCopy = jest.fn();
+jest.mock('react-use', () => ({
+  useCopyToClipboard: () => [{}, mockCopy],
+}));
+
+import BlockPickerAdvancedItemBlock from '../../../../components/block-picker/advanced/BlockPickerAdvancedItemBlock';
+
+jest.useFakeTimers();
+
+describe('BlockPickerAdvancedItemBlock', () => {
+  it('highlights matching block parts', () => {
+    render(<BlockPickerAdvancedItemBlock block={12323} blockParts={23} />);
+    const spans = screen.getAllByText('23');
+    // should highlight each occurrence with span element
+    spans.forEach((span) => expect(span.tagName).toBe('SPAN'));
+  });
+
+  it('copies block number to clipboard and shows feedback', () => {
+    const { container } = render(
+      <BlockPickerAdvancedItemBlock block={42} blockParts={4} />
+    );
+    const svg = container.querySelector('svg') as Element;
+    fireEvent.click(svg);
+    expect(mockCopy).toHaveBeenCalledWith('42');
+    expect(screen.getByText('Copied')).toBeInTheDocument();
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(screen.queryByText('Copied')).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/block-picker/result/BlockPickerResultTableHeader.test.tsx
+++ b/__tests__/components/block-picker/result/BlockPickerResultTableHeader.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import BlockPickerResultTableHeader from '../../../../components/block-picker/result/BlockPickerResultTableHeader';
+
+describe('BlockPickerResultTableHeader', () => {
+  it('renders table header with expected columns', () => {
+    render(<table><BlockPickerResultTableHeader /></table>);
+    const headers = screen.getAllByRole('columnheader');
+    expect(headers).toHaveLength(3);
+    expect(headers[0]).toHaveTextContent('Block includes');
+    expect(headers[1]).toHaveTextContent('Count');
+  });
+});

--- a/__tests__/components/brain/Brain.test.tsx
+++ b/__tests__/components/brain/Brain.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+const mockBreakpointFn = jest.fn();
+
+jest.mock('react-use', () => ({
+  createBreakpoint: jest.fn(() => mockBreakpointFn),
+}));
+
+jest.mock('../../../components/brain/BrainMobile', () => (props: any) => (
+  <div data-testid="mobile">{props.children}</div>
+));
+
+jest.mock('../../../components/brain/BrainDesktop', () => (props: any) => (
+  <div data-testid="desktop">{props.children}</div>
+));
+
+import Brain from '../../../components/brain/Brain';
+
+describe('Brain', () => {
+  it('renders BrainMobile on small screens', () => {
+    mockBreakpointFn.mockReturnValue('S');
+    render(<Brain>child</Brain>);
+    expect(screen.getByTestId('mobile')).toHaveTextContent('child');
+    expect(screen.queryByTestId('desktop')).toBeNull();
+  });
+
+  it('renders BrainDesktop otherwise', () => {
+    mockBreakpointFn.mockReturnValue('LG');
+    render(<Brain>desk</Brain>);
+    expect(screen.getByTestId('desktop')).toHaveTextContent('desk');
+    expect(screen.queryByTestId('mobile')).toBeNull();
+  });
+});

--- a/__tests__/components/brain/content/BrainContentPinnedWaves.test.tsx
+++ b/__tests__/components/brain/content/BrainContentPinnedWaves.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const mockUsePinnedWaves = {
+  pinnedIds: [] as string[],
+  addId: jest.fn(),
+  removeId: jest.fn(),
+};
+
+jest.mock('../../../../hooks/usePinnedWaves', () => ({
+  usePinnedWaves: () => mockUsePinnedWaves,
+}));
+
+jest.mock('../../../../components/brain/content/BrainContentPinnedWave', () => (props: any) => (
+  <div data-testid="pinned-wave">{props.waveId}</div>
+));
+
+jest.mock('next/router', () => ({ useRouter: () => ({ query: {}, replace: jest.fn() }) }));
+
+// window.matchMedia stub
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(() => ({ matches: false, addListener: jest.fn(), removeListener: jest.fn() })),
+});
+
+(global as any).ResizeObserver = class {
+  observe() {}
+  disconnect() {}
+};
+
+import BrainContentPinnedWaves from '../../../../components/brain/content/BrainContentPinnedWaves';
+
+describe('BrainContentPinnedWaves', () => {
+  it('returns null when no pinned ids', () => {
+    mockUsePinnedWaves.pinnedIds = [];
+    const { container } = render(<BrainContentPinnedWaves />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders pinned waves and arrows respond to clicks', () => {
+    mockUsePinnedWaves.pinnedIds = ['a', 'b'];
+    const { container } = render(<BrainContentPinnedWaves />);
+    expect(screen.getAllByTestId('pinned-wave')).toHaveLength(2);
+    // simulate arrow elements existence
+    const buttons = container.querySelectorAll('button');
+    buttons.forEach((btn) => fireEvent.click(btn));
+  });
+});


### PR DESCRIPTION
## Summary
- add test for AllowlistToolAnimationHeightOpacity
- add AppWalletCard component test
- add BlockPickerAdvancedItemBlock test
- add BlockPickerResultTableHeader test
- add Brain component breakpoint tests
- add BrainContentPinnedWaves tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage`