### PR TITLE
Add tests for drop components

### DIFF
--- a/__tests__/components/drops/create/utils/CreateDropActionsRow.test.tsx
+++ b/__tests__/components/drops/create/utils/CreateDropActionsRow.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CreateDropActionsRow from '../../../../../components/drops/create/utils/CreateDropActionsRow';
+import { AuthContext } from '../../../../../components/auth/Auth';
+import { MAX_DROP_UPLOAD_FILES } from '../../../../../helpers/Helpers';
+
+function renderComponent(props: any, ctx?: any) {
+  const value = { setToast: jest.fn(), ...(ctx || {}) } as any;
+  return {
+    ...render(
+      <AuthContext.Provider value={value}>
+        <CreateDropActionsRow {...props} />
+      </AuthContext.Provider>
+    ),
+    toast: value.setToast,
+  };
+}
+
+describe('CreateDropActionsRow', () => {
+  it('shows toast when uploading too many files', () => {
+    const setFiles = jest.fn();
+    const files = Array.from({ length: MAX_DROP_UPLOAD_FILES + 1 }, (_, i) => new File([''], `f${i}.png`, { type: 'image/png' }));
+    const { toast } = renderComponent({ canAddPart: false, isStormMode: false, setFiles, breakIntoStorm: jest.fn() });
+    const button = screen.getByRole('button', { name: /select audio file/i });
+    const input = button.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { files } });
+    expect(toast).toHaveBeenCalledWith({ message: 'You can only upload up to 4 files at a time', type: 'error' });
+    expect(setFiles).not.toHaveBeenCalled();
+  });
+
+  it('passes files to callback when under limit', () => {
+    const setFiles = jest.fn();
+    const files = [new File(['a'], 'a.png', { type: 'image/png' }), new File(['b'], 'b.png', { type: 'image/png' })];
+    const { toast } = renderComponent({ canAddPart: false, isStormMode: false, setFiles, breakIntoStorm: jest.fn() });
+    const button = screen.getByRole('button', { name: /select audio file/i });
+    const input = button.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { files } });
+    expect(setFiles).toHaveBeenCalledWith(files);
+    expect(toast).not.toHaveBeenCalled();
+  });
+
+  it('renders break into storm button when allowed and handles click', () => {
+    const handler = jest.fn();
+    renderComponent({ canAddPart: true, isStormMode: false, setFiles: jest.fn(), breakIntoStorm: handler });
+    const button = screen.getByRole('button', { name: /break into storm/i });
+    fireEvent.click(button);
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('shows continue storm text when in storm mode', () => {
+    renderComponent({ canAddPart: true, isStormMode: true, setFiles: jest.fn(), breakIntoStorm: jest.fn() });
+    expect(screen.getByText(/continue storm/i)).toBeInTheDocument();
+  });
+
+  it('hides storm button when cannot add part', () => {
+    renderComponent({ canAddPart: false, isStormMode: false, setFiles: jest.fn(), breakIntoStorm: jest.fn() });
+    expect(screen.queryByRole('button', { name: /break into storm/i })).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/drops/view/item/rate/give/clap/DropListItemRateGiveClap.test.tsx
+++ b/__tests__/components/drops/view/item/rate/give/clap/DropListItemRateGiveClap.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import DropListItemRateGiveClap from '../../../../../../../../components/drops/view/item/rate/give/clap/DropListItemRateGiveClap';
+import { DropVoteState } from '../../../../../../../../hooks/drops/types';
+
+const mockReplay = jest.fn();
+const mockAdd = jest.fn();
+
+jest.mock('@mojs/core', () => ({
+  __esModule: true,
+  default: {
+    Burst: jest.fn().mockImplementation(() => ({ tune: jest.fn() })),
+    Html: jest.fn().mockImplementation(() => ({ then: jest.fn().mockReturnThis(), tune: jest.fn() })),
+    Timeline: jest.fn().mockImplementation(() => ({ add: mockAdd, replay: mockReplay })),
+    easing: { bezier: jest.fn(), out: jest.fn() },
+  },
+}));
+
+jest.mock('../../../../../../../../helpers/AllowlistToolHelpers', () => ({
+  getRandomObjectId: () => 'id123',
+}));
+
+jest.mock('../../../../../../../../components/utils/tooltip/LazyTippy', () => ({ children }: any) => <div data-testid="tippy">{children}</div>);
+
+describe('DropListItemRateGiveClap', () => {
+  it('triggers animation and submit on click when voting positive', async () => {
+    const onSubmit = jest.fn();
+    render(
+      <DropListItemRateGiveClap rate={5} voteState={DropVoteState.CAN_VOTE} canVote onSubmit={onSubmit} />
+    );
+    await waitFor(() => expect(mockAdd).toHaveBeenCalled());
+    const button = screen.getByRole('button', { name: /clap for drop/i });
+    fireEvent.click(button);
+    expect(mockReplay).toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalled();
+    expect(button.className).toContain('clapPositive');
+  });
+
+  it('does not submit when user cannot vote', async () => {
+    const onSubmit = jest.fn();
+    render(
+      <DropListItemRateGiveClap rate={5} voteState={DropVoteState.NO_PROFILE} canVote={false} onSubmit={onSubmit} />
+    );
+    const button = await screen.findByRole('button', { name: /clap for drop/i });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(button.className).not.toContain('clapPositive');
+  });
+
+  it('formats large numbers and sets size classes', async () => {
+    render(
+      <DropListItemRateGiveClap rate={1500} voteState={DropVoteState.CAN_VOTE} canVote onSubmit={() => {}} />
+    );
+    const count = await screen.findByText('+1.5k');
+    expect(count.className).toContain('tw-w-9 tw-h-9 tw-left-[6px]');
+  });
+});


### PR DESCRIPTION
## Summary
- add CreateDropActionsRow tests
- add DropListItemRateGiveClap tests with mojs mock

## Testing
- `npm run test`
- `npm run improve-coverage` *(fails to show summary due to log length but tests pass)*