### PR TITLE
Improve coverage for drop components

### DIFF
--- a/__tests__/components/drops/create/full/mobile/CreateDropFullMobileMetadata.test.tsx
+++ b/__tests__/components/drops/create/full/mobile/CreateDropFullMobileMetadata.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import CreateDropFullMobileMetadata from '../../../../../../components/drops/create/full/mobile/CreateDropFullMobileMetadata';
+import { DropMetadata } from '../../../../../../entities/IDrop';
+
+describe('CreateDropFullMobileMetadata', () => {
+  const metadata: DropMetadata[] = [
+    { data_key: 'Category', data_value: 'Art' },
+  ];
+  const onMetadataEdit = jest.fn();
+  const onMetadataRemove = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders existing metadata items', () => {
+    render(
+      <CreateDropFullMobileMetadata
+        metadata={metadata}
+        onMetadataEdit={onMetadataEdit}
+        onMetadataRemove={onMetadataRemove}
+      />
+    );
+    expect(screen.getByText(/category/i)).toBeInTheDocument();
+    expect(screen.getByText(/art/i)).toBeInTheDocument();
+  });
+
+  it('calls onMetadataEdit when form is submitted', () => {
+    render(
+      <CreateDropFullMobileMetadata
+        metadata={[]}
+        onMetadataEdit={onMetadataEdit}
+        onMetadataRemove={onMetadataRemove}
+      />
+    );
+    fireEvent.change(screen.getByPlaceholderText('Category'), { target: { value: 'Type' } });
+    fireEvent.change(screen.getByPlaceholderText('Value'), { target: { value: 'Value' } });
+    fireEvent.click(screen.getByRole('button', { name: /add/i }));
+    expect(onMetadataEdit).toHaveBeenCalledWith({ data_key: 'Type', data_value: 'Value' });
+    expect((screen.getByPlaceholderText('Category') as HTMLInputElement).value).toBe('');
+    expect((screen.getByPlaceholderText('Value') as HTMLInputElement).value).toBe('');
+  });
+});

--- a/__tests__/components/drops/create/utils/file/CreateDropSelectedFileIcon.test.tsx
+++ b/__tests__/components/drops/create/utils/file/CreateDropSelectedFileIcon.test.tsx
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react';
+import CreateDropSelectedFileIcon from '../../../../../../components/drops/create/utils/file/CreateDropSelectedFileIcon';
+
+describe('CreateDropSelectedFileIcon', () => {
+  function renderIcon(type: string) {
+    const file = new File([''], `test.${type}`, { type: `${type}/${type}` });
+    return render(<CreateDropSelectedFileIcon file={file} />);
+  }
+
+  it('renders image icon for image files', () => {
+    const { container } = renderIcon('image');
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders video icon for video files', () => {
+    const { container } = renderIcon('video');
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders audio icon for audio files', () => {
+    const { container } = renderIcon('audio');
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders nothing for unsupported files', () => {
+    const file = new File([''], 'test.txt', { type: 'text/plain' });
+    const { container } = render(<CreateDropSelectedFileIcon file={file} />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `CreateDropFullMobileMetadata`
- add tests for `CreateDropSelectedFileIcon`

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
