### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/components/app-wallets/AppWalletAvatar.test.tsx
+++ b/__tests__/components/app-wallets/AppWalletAvatar.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import AppWalletAvatar from '../../../components/app-wallets/AppWalletAvatar';
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => <img {...props} />,
+}));
+
+describe('AppWalletAvatar', () => {
+  it('renders img with default size when no size prop is provided', () => {
+    render(<AppWalletAvatar address="0xabc" />);
+    const img = screen.getByRole('img', { name: '0xabc' });
+    expect(img).toHaveAttribute('src', 'https://robohash.org/0xabc.png');
+    expect(img).toHaveAttribute('width', '36');
+    expect(img).toHaveAttribute('height', '36');
+    expect(img).toHaveAttribute('loading', 'eager');
+    expect(img).toHaveAttribute('fetchPriority', 'high');
+  });
+
+  it('renders img with custom size', () => {
+    render(<AppWalletAvatar address="0xdef" size={50} />);
+    const img = screen.getByRole('img', { name: '0xdef' });
+    expect(img).toHaveAttribute('width', '50');
+    expect(img).toHaveAttribute('height', '50');
+  });
+});

--- a/__tests__/components/app-wallets/app-wallet-helpers.test.ts
+++ b/__tests__/components/app-wallets/app-wallet-helpers.test.ts
@@ -1,0 +1,17 @@
+import { encryptData, decryptData } from '../../../components/app-wallets/app-wallet-helpers';
+
+const salt = 'deadbeefcafebabe0001020304050607';
+
+describe('app-wallet-helpers', () => {
+  it('encrypts and decrypts data with same password', async () => {
+    const encrypted = await encryptData(salt, 'hello', 'pw');
+    expect(encrypted).not.toEqual('hello');
+    const decrypted = await decryptData(salt, encrypted, 'pw');
+    expect(decrypted).toBe('hello');
+  });
+
+  it('throws when password is incorrect', async () => {
+    const encrypted = await encryptData(salt, 'secret', 'pw');
+    await expect(decryptData(salt, encrypted, 'wrong')).rejects.toThrow();
+  });
+});

--- a/__tests__/components/block-picker/BlockPickerTimeWindowSelectList.test.tsx
+++ b/__tests__/components/block-picker/BlockPickerTimeWindowSelectList.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, fireEvent, within } from '@testing-library/react';
+jest.mock('../../../pages/meme-blocks', () => ({
+  BlockPickerTimeWindow: {
+    ONE_MINUTE: 'ONE_MINUTE',
+    FIVE_MINUTES: 'FIVE_MINUTES'
+  }
+}));
+
+import BlockPickerTimeWindowSelectList from '../../../components/block-picker/BlockPickerTimeWindowSelectList';
+import { BlockPickerTimeWindow } from '../../../pages/meme-blocks';
+
+describe('BlockPickerTimeWindowSelectList', () => {
+  const options = [
+    { title: '1m', value: BlockPickerTimeWindow.ONE_MINUTE },
+    { title: '5m', value: BlockPickerTimeWindow.FIVE_MINUTES },
+  ];
+
+  it('renders options and highlights the active one', () => {
+    const setTimeWindow = jest.fn();
+    const { container } = render(
+      <BlockPickerTimeWindowSelectList
+        options={options}
+        timeWindow={BlockPickerTimeWindow.ONE_MINUTE}
+        setTimeWindow={setTimeWindow}
+      />
+    );
+
+    const items = screen.getAllByRole('option');
+    expect(items).toHaveLength(2);
+    expect(within(items[0]).getByText('1m')).toBeInTheDocument();
+    expect(within(items[1]).getByText('5m')).toBeInTheDocument();
+    expect(items[0].querySelector('svg')).toBeInTheDocument();
+    expect(items[1].querySelector('svg')).toBeNull();
+  });
+
+  it('calls setTimeWindow when option clicked', () => {
+    const setTimeWindow = jest.fn();
+    render(
+      <BlockPickerTimeWindowSelectList
+        options={options}
+        timeWindow={BlockPickerTimeWindow.ONE_MINUTE}
+        setTimeWindow={setTimeWindow}
+      />
+    );
+    const items = screen.getAllByRole('option');
+    fireEvent.click(items[1]);
+    expect(setTimeWindow).toHaveBeenCalledWith(BlockPickerTimeWindow.FIVE_MINUTES);
+  });
+});

--- a/__tests__/components/block-picker/result/BlockPickerResultHeader.test.tsx
+++ b/__tests__/components/block-picker/result/BlockPickerResultHeader.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import BlockPickerResultHeader from '../../../../components/block-picker/result/BlockPickerResultHeader';
+
+jest.mock('../../../../components/distribution-plan-tool/common/Countdown', () => ({
+  __esModule: true,
+  default: ({ timestamp }: any) => <div data-testid="countdown">{`countdown-${timestamp}`}</div>,
+}));
+
+describe('BlockPickerResultHeader', () => {
+  it('renders block number, formatted date and countdown', () => {
+    const timestamp = Date.UTC(2023, 0, 2, 15, 30);
+    render(<BlockPickerResultHeader blocknumber={123} timestamp={timestamp} />);
+    expect(screen.getByText('123')).toBeInTheDocument();
+    const formatted = new Date(timestamp).toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      hour12: true,
+    });
+    expect(screen.getByText(new RegExp(formatted))).toBeInTheDocument();
+    expect(screen.getByTestId('countdown')).toHaveTextContent(`countdown-${timestamp}`);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for AppWalletAvatar
- add tests for app-wallet helpers
- add tests for BlockPickerTimeWindowSelectList
- add tests for BlockPickerResultHeader

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`