### PR TITLE
Add tests for sidebar and layout

### DIFF
--- a/__tests__/components/groups/sidebar/GroupsSidebar.test.tsx
+++ b/__tests__/components/groups/sidebar/GroupsSidebar.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import GroupsSidebar from "../../../../components/groups/sidebar/GroupsSidebar";
+
+jest.mock("../../../../components/groups/header/GroupHeader", () => () => (
+  <div data-testid="group-header" />
+));
+
+jest.mock("../../../../components/groups/select/GroupSelect", () => () => (
+  <div data-testid="group-select" />
+));
+
+describe("GroupsSidebar", () => {
+  it("renders GroupHeader and GroupSelect", () => {
+    render(<GroupsSidebar />);
+    expect(screen.getByTestId("group-header")).toBeInTheDocument();
+    expect(screen.getByTestId("group-select")).toBeInTheDocument();
+  });
+
+  it("applies padding bottom container class", () => {
+    const { container } = render(<GroupsSidebar />);
+    expect(container.firstChild).toHaveClass("tw-pb-4");
+  });
+});

--- a/__tests__/components/header/user/HeaderUserConnecting.test.tsx
+++ b/__tests__/components/header/user/HeaderUserConnecting.test.tsx
@@ -1,0 +1,19 @@
+import { render } from "@testing-library/react";
+import HeaderUserConnecting from "../../../../components/header/user/HeaderUserConnecting";
+
+const mockLoader = jest.fn(() => <div data-testid="loader" />);
+
+jest.mock("../../../../components/distribution-plan-tool/common/CircleLoader", () => ({
+  __esModule: true,
+  default: (props: any) => mockLoader(props),
+  CircleLoaderSize: { MEDIUM: "MEDIUM" }
+}));
+
+describe("HeaderUserConnecting", () => {
+  it("renders a medium CircleLoader inside container", () => {
+    const { container, getByTestId } = render(<HeaderUserConnecting />);
+    expect(getByTestId("loader")).toBeInTheDocument();
+    expect(mockLoader).toHaveBeenCalledWith({ size: "MEDIUM" });
+    expect(container.firstChild).toHaveClass("tw-h-11", "tw-w-11", "tw-mr-4");
+  });
+});

--- a/__tests__/components/layout/AppLayout.test.tsx
+++ b/__tests__/components/layout/AppLayout.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+const useViewContext = jest.fn();
+const registerRef = jest.fn();
+const setHeaderRef = jest.fn();
+const useRouter = jest.fn();
+
+jest.mock("next/dynamic", () => () => () => <div data-testid="header" />);
+jest.mock("../../../components/navigation/ViewContext", () => ({
+  useViewContext: () => useViewContext(),
+}));
+jest.mock("../../../components/navigation/BottomNavigation", () => () => <div data-testid="bottom-nav" />);
+jest.mock("../../../components/brain/mobile/BrainMobileWaves", () => () => <div data-testid="waves" />);
+jest.mock("../../../components/brain/mobile/BrainMobileMessages", () => () => <div data-testid="messages" />);
+jest.mock("../../../components/brain/my-stream/layout/LayoutContext", () => ({ useLayout: () => ({ registerRef }) }));
+jest.mock("../../../contexts/HeaderContext", () => ({ useHeaderContext: () => ({ setHeaderRef }) }));
+jest.mock("../../../hooks/useDeepLinkNavigation", () => ({ useDeepLinkNavigation: jest.fn() }));
+jest.mock("next/router", () => ({ useRouter: () => useRouter() }));
+
+const AppLayout = require("../../components/layout/AppLayout").default;
+
+describe("AppLayout", () => {
+  beforeEach(() => {
+    useRouter.mockReturnValue({ pathname: "/", query: {}, push: jest.fn() });
+  });
+
+  it("renders main content when no active view", () => {
+    useViewContext.mockReturnValue({ activeView: null });
+    render(<AppLayout>child</AppLayout>);
+    expect(screen.getByTestId("header")).toBeInTheDocument();
+    expect(screen.getByText("child")).toBeInTheDocument();
+    expect(screen.getByTestId("bottom-nav")).toBeInTheDocument();
+  });
+
+  it("renders waves or messages view based on activeView", () => {
+    useViewContext.mockReturnValue({ activeView: "waves" });
+    const { rerender } = render(<AppLayout>child</AppLayout>);
+    expect(screen.getByTestId("waves")).toBeInTheDocument();
+
+    useViewContext.mockReturnValue({ activeView: "messages" });
+    rerender(<AppLayout>child</AppLayout>);
+    expect(screen.getByTestId("messages")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for GroupsSidebar component
- add tests for HeaderUserConnecting component
- add tests for AppLayout

## Testing
- `npm run improve-coverage` *(fails: coverage still below target)*