### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/components/allowlist-tool/allowlist-tool.types.test.ts
+++ b/__tests__/components/allowlist-tool/allowlist-tool.types.test.ts
@@ -1,0 +1,22 @@
+import { AllowlistOperationCode, Pool, AllowlistRunStatus, DistributionPlanTokenPoolDownloadStatus } from '../../../components/allowlist-tool/allowlist-tool.types';
+
+describe('allowlist-tool.types enums', () => {
+  it('has expected AllowlistOperationCode values', () => {
+    expect(AllowlistOperationCode.CREATE_ALLOWLIST).toBe('CREATE_ALLOWLIST');
+    expect(AllowlistOperationCode.GET_COLLECTION_TRANSFERS).toBe('GET_COLLECTION_TRANSFERS');
+  });
+
+  it('Pool enum maps to string values', () => {
+    expect(Pool.TOKEN_POOL).toBe('TOKEN_POOL');
+    expect(Pool.CUSTOM_TOKEN_POOL).toBe('CUSTOM_TOKEN_POOL');
+    expect(Pool.WALLET_POOL).toBe('WALLET_POOL');
+  });
+
+  it('AllowlistRunStatus contains expected statuses', () => {
+    expect(Object.values(AllowlistRunStatus)).toEqual(['PENDING', 'CLAIMED', 'FAILED']);
+  });
+
+  it('DistributionPlanTokenPoolDownloadStatus includes COMPLETED', () => {
+    expect(DistributionPlanTokenPoolDownloadStatus.COMPLETED).toBe('COMPLETED');
+  });
+});

--- a/__tests__/components/allowlist-tool/common/AllowlistToolLoader.test.tsx
+++ b/__tests__/components/allowlist-tool/common/AllowlistToolLoader.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import AllowlistToolLoader, { AllowlistToolLoaderSize } from '../../../../components/allowlist-tool/common/AllowlistToolLoader';
+
+describe('AllowlistToolLoader', () => {
+  it('uses small size by default', () => {
+    render(<AllowlistToolLoader />);
+    const svg = screen.getByRole('status', { hidden: true });
+    expect(svg).toHaveClass('tw-w-5 tw-h-5');
+  });
+
+  it('applies large size class', () => {
+    render(<AllowlistToolLoader size={AllowlistToolLoaderSize.LARGE} />);
+    const svg = screen.getByRole('status', { hidden: true });
+    expect(svg).toHaveClass('tw-w-20 tw-h-20');
+  });
+});

--- a/__tests__/components/allowlist-tool/common/animation/AllowlistToolAnimationHeightOpacity.test.tsx
+++ b/__tests__/components/allowlist-tool/common/animation/AllowlistToolAnimationHeightOpacity.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import AllowlistToolAnimationHeightOpacity from '../../../../../components/allowlist-tool/common/animation/AllowlistToolAnimationHeightOpacity';
+
+jest.mock('framer-motion', () => ({ motion: { div: (props: any) => <div {...props}>{props.children}</div> } }));
+
+describe('AllowlistToolAnimationHeightOpacity', () => {
+  it('renders children with provided class and role', () => {
+    render(
+      <AllowlistToolAnimationHeightOpacity elementClasses="cls" elementRole="status">
+        <span>child</span>
+      </AllowlistToolAnimationHeightOpacity>
+    );
+    const div = screen.getByRole('status');
+    expect(div).toHaveClass('cls');
+    expect(div).toHaveTextContent('child');
+  });
+});

--- a/__tests__/components/allowlist-tool/common/modals/AllowlistToolCommonModalWrapper.test.tsx
+++ b/__tests__/components/allowlist-tool/common/modals/AllowlistToolCommonModalWrapper.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// Mock hooks from react-use before importing component
+const mockUseClickAway = jest.fn();
+const mockUseKeyPressEvent = jest.fn();
+jest.mock('react-use', () => ({
+  useClickAway: (...args: any[]) => mockUseClickAway(...args),
+  useKeyPressEvent: (...args: any[]) => mockUseKeyPressEvent(...args),
+}));
+
+import AllowlistToolCommonModalWrapper, { AllowlistToolModalSize } from '../../../../../components/allowlist-tool/common/modals/AllowlistToolCommonModalWrapper';
+
+// Simplify animation wrappers
+jest.mock(
+  '../../../../../components/allowlist-tool/common/animation/AllowlistToolAnimationWrapper',
+  () => ({
+    __esModule: true,
+    default: (props: any) => <div>{props.children}</div>,
+  })
+);
+jest.mock(
+  '../../../../../components/allowlist-tool/common/animation/AllowlistToolAnimationOpacity',
+  () => ({
+    __esModule: true,
+    default: (props: any) => (
+      <div role={props.elementRole} onClick={props.onClicked} className={props.elementClasses}>
+        {props.children}
+      </div>
+    ),
+  })
+);
+
+function setup(props: Partial<React.ComponentProps<typeof AllowlistToolCommonModalWrapper>> = {}) {
+  const onClose = jest.fn();
+  render(
+    <AllowlistToolCommonModalWrapper title="Modal title" showModal={true} onClose={onClose} {...props}>
+      <div>content</div>
+    </AllowlistToolCommonModalWrapper>
+  );
+  return { onClose };
+}
+
+describe('AllowlistToolCommonModalWrapper', () => {
+  it('does not render when showModal is false', () => {
+    render(
+      <AllowlistToolCommonModalWrapper title="title" showModal={false} onClose={() => {}}>
+        <div>child</div>
+      </AllowlistToolCommonModalWrapper>
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders small modal and closes via button', async () => {
+    const user = userEvent.setup();
+    const { onClose } = setup();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(screen.getByText('content')).toBeInTheDocument();
+    expect(dialog.firstChild).toHaveClass('tw-relative');
+    await user.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('applies custom size and hides title', () => {
+    setup({ modalSize: AllowlistToolModalSize.LARGE, showTitle: false });
+    const container = screen.getByRole('dialog').querySelector(
+      'div.tw-relative.tw-w-full.tw-transform.tw-rounded-lg.tw-bg-neutral-900.tw-text-left.tw-shadow-xl.tw-transition-all'
+    );
+    expect(container).toBeTruthy();
+    expect(screen.queryByText('Modal title')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for AllowlistToolCommonModalWrapper
- add tests for types and loader components
- add tests for animation wrapper

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage`