### PR TITLE
Improve test coverage

### DIFF
--- a/__tests__/components/allowlist-tool/common/AllowlistToolLoader.test.tsx
+++ b/__tests__/components/allowlist-tool/common/AllowlistToolLoader.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import AllowlistToolLoader, { AllowlistToolLoaderSize } from '../../../../components/allowlist-tool/common/AllowlistToolLoader';
+
+describe('AllowlistToolLoader', () => {
+  it('renders with default small size', () => {
+    render(<AllowlistToolLoader />);
+    const svg = screen.getByRole('status', { hidden: true });
+    expect(svg).toHaveClass('tw-w-5 tw-h-5');
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('renders with medium size', () => {
+    render(<AllowlistToolLoader size={AllowlistToolLoaderSize.MEDIUM} />);
+    const svg = screen.getByRole('status', { hidden: true });
+    expect(svg).toHaveClass('tw-w-10 tw-h-10');
+  });
+
+  it('renders with large size', () => {
+    render(<AllowlistToolLoader size={AllowlistToolLoaderSize.LARGE} />);
+    const svg = screen.getByRole('status', { hidden: true });
+    expect(svg).toHaveClass('tw-w-20 tw-h-20');
+  });
+});

--- a/__tests__/components/allowlist-tool/icons/AllowlistToolJsonIcon.test.tsx
+++ b/__tests__/components/allowlist-tool/icons/AllowlistToolJsonIcon.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import AllowlistToolJsonIcon from '../../../../components/allowlist-tool/icons/AllowlistToolJsonIcon';
+
+describe('AllowlistToolJsonIcon', () => {
+  it('renders svg with correct classes', () => {
+    const { container } = render(<AllowlistToolJsonIcon />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveClass('tw-h-auto tw-w-auto tw-text-[#e8c250]');
+  });
+});

--- a/__tests__/components/block-picker/result/BlockPickerResult.test.tsx
+++ b/__tests__/components/block-picker/result/BlockPickerResult.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import BlockPickerResult from '../../../../components/block-picker/result/BlockPickerResult';
+
+jest.mock('../../../../components/block-picker/result/BlockPickerResultHeader', () => (props: any) => (
+  <div data-testid="header">{`${props.blocknumber}-${props.timestamp}`}</div>
+));
+
+jest.mock('../../../../components/block-picker/result/BlockPickerResultTable', () => (props: any) => (
+  <div data-testid="table">{props.predictedBlocks.length}</div>
+));
+
+describe('BlockPickerResult', () => {
+  const blocknumber = 123;
+  const timestamp = 456;
+
+  it('renders header and no table for empty results', () => {
+    render(
+      <BlockPickerResult blocknumber={blocknumber} timestamp={timestamp} predictedBlocks={[]} />
+    );
+    expect(screen.getByTestId('header')).toHaveTextContent(`${blocknumber}-${timestamp}`);
+    expect(screen.queryByTestId('table')).not.toBeInTheDocument();
+  });
+
+  it('renders table when predicted blocks exist', () => {
+    const predictedBlocks = [{ blockNumberIncludes: 1, count: 2, blockNumbers: [1, 2] }];
+    render(
+      <BlockPickerResult
+        blocknumber={blocknumber}
+        timestamp={timestamp}
+        predictedBlocks={predictedBlocks}
+      />
+    );
+    expect(screen.getByTestId('table')).toHaveTextContent('1');
+  });
+});

--- a/__tests__/components/brain/BrainDesktopDrop.test.tsx
+++ b/__tests__/components/brain/BrainDesktopDrop.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react';
+import BrainDesktopDrop from '../../../components/brain/BrainDesktopDrop';
+
+const mockSingleWaveDrop = jest.fn<any, any[]>(() => <div data-testid="single-drop" />);
+
+jest.mock('../../../components/waves/drop/SingleWaveDrop', () => ({
+  SingleWaveDrop: (props: any) => mockSingleWaveDrop(props)
+}));
+
+describe('BrainDesktopDrop', () => {
+  const drop = { wave: { id: '1' } } as any;
+  const onClose = jest.fn();
+
+  beforeEach(() => {
+    mockSingleWaveDrop.mockClear();
+  });
+
+  it('renders SingleWaveDrop with provided props', () => {
+    render(<BrainDesktopDrop drop={drop} onClose={onClose} />);
+    expect(mockSingleWaveDrop).toHaveBeenCalledWith({ drop, onClose });
+  });
+});

--- a/__tests__/components/brain/ContentTabContext.test.tsx
+++ b/__tests__/components/brain/ContentTabContext.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ContentTabProvider, useContentTab, WaveVotingState } from '../../../components/brain/ContentTabContext';
+import { MyStreamWaveTab } from '../../../types/waves.types';
+
+function TestComponent() {
+  const { activeContentTab, setActiveContentTab, availableTabs, updateAvailableTabs } = useContentTab();
+  return (
+    <div>
+      <span data-testid="active">{activeContentTab}</span>
+      <span data-testid="available">{availableTabs.join(',')}</span>
+      <button onClick={() => setActiveContentTab(MyStreamWaveTab.LEADERBOARD)}>setLB</button>
+      <button onClick={() => updateAvailableTabs(null)}>reset</button>
+      <button
+        onClick={() =>
+          updateAvailableTabs({
+            isChatWave: false,
+            isMemesWave: false,
+            votingState: WaveVotingState.NOT_STARTED,
+            hasFirstDecisionPassed: false,
+          })
+        }
+      >
+        standard
+      </button>
+    </div>
+  );
+}
+
+describe('ContentTabContext', () => {
+  it('updates tabs based on wave state', async () => {
+    render(
+      <ContentTabProvider>
+        <TestComponent />
+      </ContentTabProvider>
+    );
+
+    // initial state
+    expect(screen.getByTestId('active')).toHaveTextContent(MyStreamWaveTab.CHAT);
+    expect(screen.getByTestId('available')).toHaveTextContent(MyStreamWaveTab.CHAT);
+
+    // attempt to set unavailable tab
+    await userEvent.click(screen.getByText('setLB'));
+    expect(screen.getByTestId('active')).toHaveTextContent(MyStreamWaveTab.CHAT);
+
+    // update to standard wave (adds leaderboard)
+    await userEvent.click(screen.getByText('standard'));
+    expect(screen.getByTestId('available').textContent).toContain(MyStreamWaveTab.LEADERBOARD);
+
+    // now setting leaderboard should work
+    await userEvent.click(screen.getByText('setLB'));
+    expect(screen.getByTestId('active')).toHaveTextContent(MyStreamWaveTab.LEADERBOARD);
+
+    // reset tabs, should revert to chat only and switch active tab back
+    await userEvent.click(screen.getByText('reset'));
+    expect(screen.getByTestId('active')).toHaveTextContent(MyStreamWaveTab.CHAT);
+    expect(screen.getByTestId('available')).toHaveTextContent(MyStreamWaveTab.CHAT);
+  });
+});

--- a/__tests__/components/brain/feed/items/drop-created/FeedItemDropCreated.test.tsx
+++ b/__tests__/components/brain/feed/items/drop-created/FeedItemDropCreated.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react';
+import FeedItemDropCreated from '../../../../../../components/brain/feed/items/drop-created/FeedItemDropCreated';
+
+const push = jest.fn();
+jest.mock('next/router', () => ({ useRouter: () => ({ push }) }));
+
+let capturedProps: any;
+jest.mock('../../../../../../components/waves/drops/Drop', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    capturedProps = props;
+    return <div data-testid="drop" />;
+  },
+  DropLocation: { MY_STREAM: 'MY_STREAM' }
+}));
+
+describe('FeedItemDropCreated', () => {
+  const item = { item: { wave: { id: '1' }, serial_no: 1 } } as any;
+
+  it('navigates on reply and quote clicks', () => {
+    render(
+      <FeedItemDropCreated
+        item={item}
+        showWaveInfo={true}
+        activeDrop={null}
+        onReply={jest.fn()}
+        onQuote={jest.fn()}
+      />
+    );
+
+    capturedProps.onReplyClick(5);
+    expect(push).toHaveBeenCalledWith('/my-stream?wave=1&serialNo=5/');
+
+    capturedProps.onQuoteClick({ wave: { id: '2' }, serial_no: 3 } as any);
+    expect(push).toHaveBeenCalledWith('/my-stream?wave=2&serialNo=3/');
+  });
+});


### PR DESCRIPTION
## Summary
- add test cases for AllowlistTool components and BlockPickerResult
- test desktop drop and content tab context
- cover FeedItemDropCreated router logic

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage` (time limit reached)