### PR TITLE
Fix path and typing in tests

### DIFF
--- a/__tests__/components/header/user/HeaderUserConnecting.test.tsx
+++ b/__tests__/components/header/user/HeaderUserConnecting.test.tsx
@@ -1,7 +1,7 @@
 import { render } from "@testing-library/react";
 import HeaderUserConnecting from "../../../../components/header/user/HeaderUserConnecting";
 
-const mockLoader = jest.fn(() => <div data-testid="loader" />);
+const mockLoader = jest.fn((props: any) => <div data-testid="loader" />);
 
 jest.mock("../../../../components/distribution-plan-tool/common/CircleLoader", () => ({
   __esModule: true,

--- a/__tests__/components/layout/AppLayout.test.tsx
+++ b/__tests__/components/layout/AppLayout.test.tsx
@@ -18,7 +18,7 @@ jest.mock("../../../contexts/HeaderContext", () => ({ useHeaderContext: () => ({
 jest.mock("../../../hooks/useDeepLinkNavigation", () => ({ useDeepLinkNavigation: jest.fn() }));
 jest.mock("next/router", () => ({ useRouter: () => useRouter() }));
 
-const AppLayout = require("../../components/layout/AppLayout").default;
+const AppLayout = require("../../../components/layout/AppLayout").default;
 
 describe("AppLayout", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- fix relative import path in AppLayout test
- update mock function typing in HeaderUserConnecting test

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
