### PR TITLE
Add tests for delegation flows

### DIFF
--- a/__tests__/components/distribution-plan-tool/map-delegations/MapDelegations.test.tsx
+++ b/__tests__/components/distribution-plan-tool/map-delegations/MapDelegations.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MapDelegations from '../../../../components/distribution-plan-tool/map-delegations/MapDelegations';
+import { DistributionPlanToolContext, DistributionPlanToolStep } from '../../../../components/distribution-plan-tool/DistributionPlanToolContext';
+import { AllowlistOperationCode } from '../../../../components/allowlist-tool/allowlist-tool.types';
+
+jest.mock('../../../../components/distribution-plan-tool/common/StepHeader', () => ({ step }: any) => <div data-testid="header">{step}</div>);
+jest.mock('../../../../components/distribution-plan-tool/common/DistributionPlanStepWrapper', () => ({ children }: any) => <div data-testid="wrapper">{children}</div>);
+jest.mock('../../../../components/distribution-plan-tool/map-delegations/MapDelegationsForm', () => () => <div data-testid="form" />);
+jest.mock('../../../../components/distribution-plan-tool/map-delegations/MapDelegationsDone', () => ({ contract }: any) => <div data-testid="done">{contract}</div>);
+jest.mock('../../../../components/distribution-plan-tool/common/DistributionPlanNextStepBtn', () => ({ showRunAnalysisBtn, showNextBtn, showSkipBtn, onNextStep }: any) => (
+  <button data-testid="next" onClick={onNextStep}>
+    {showRunAnalysisBtn && 'run'}{showNextBtn && 'next'}{showSkipBtn && 'skip'}
+  </button>
+));
+
+function renderComponent(operations: any[]) {
+  const setStep = jest.fn();
+  return {
+    setStep,
+    ...render(
+      <DistributionPlanToolContext.Provider value={{ operations, setStep } as any}>
+        <MapDelegations />
+      </DistributionPlanToolContext.Provider>
+    )
+  };
+}
+
+describe('MapDelegations', () => {
+  it('shows done and next when contract exists and operations ran', () => {
+    const ops = [
+      { code: AllowlistOperationCode.MAP_RESULTS_TO_DELEGATED_WALLETS, params: { delegationContract: '0xABC' }, hasRan: true }
+    ];
+    const { setStep } = renderComponent(ops);
+    expect(screen.getByTestId('done')).toHaveTextContent('0xABC');
+    const btn = screen.getByTestId('next');
+    expect(btn).toHaveTextContent('next');
+    fireEvent.click(btn);
+    expect(setStep).toHaveBeenCalledWith(DistributionPlanToolStep.REVIEW);
+  });
+
+  it('shows run analysis when operations have not run', () => {
+    const ops = [
+      { code: AllowlistOperationCode.MAP_RESULTS_TO_DELEGATED_WALLETS, params: { delegationContract: '0xDEF' }, hasRan: false }
+    ];
+    renderComponent(ops);
+    expect(screen.getByTestId('done')).toHaveTextContent('0xDEF');
+    expect(screen.getByTestId('next')).toHaveTextContent('run');
+  });
+
+  it('shows form and skip when no contract', () => {
+    const ops: any[] = [];
+    renderComponent(ops);
+    expect(screen.getByTestId('form')).toBeInTheDocument();
+    expect(screen.getByTestId('next')).toHaveTextContent('skip');
+  });
+});

--- a/__tests__/components/distribution-plan-tool/review-distribution-plan/ReviewDistributionPlan.test.tsx
+++ b/__tests__/components/distribution-plan-tool/review-distribution-plan/ReviewDistributionPlan.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ReviewDistributionPlan from '../../../../components/distribution-plan-tool/review-distribution-plan/ReviewDistributionPlan';
+import { DistributionPlanToolStep } from '../../../../components/distribution-plan-tool/DistributionPlanToolContext';
+
+const mockHeader = jest.fn(() => <div data-testid="header" />);
+const mockWrapper = jest.fn(({ children }: any) => <div data-testid="wrapper">{children}</div>);
+const mockTable = jest.fn(() => <div data-testid="table" />);
+
+jest.mock('../../../../components/distribution-plan-tool/common/StepHeader', () => (props: any) => (mockHeader as any)(props));
+jest.mock('../../../../components/distribution-plan-tool/common/DistributionPlanStepWrapper', () => (props: any) => (mockWrapper as any)(props));
+jest.mock('../../../../components/distribution-plan-tool/review-distribution-plan/table/ReviewDistributionPlanTable', () => (props: any) => (mockTable as any)(props));
+
+describe('ReviewDistributionPlan', () => {
+  it('renders header, wrapper and table with review step', () => {
+    render(<ReviewDistributionPlan />);
+    expect(mockHeader).toHaveBeenCalledWith({ step: DistributionPlanToolStep.REVIEW });
+    expect(screen.getByTestId('wrapper')).toBeInTheDocument();
+    expect(screen.getByTestId('table')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/header/user/HeaderUserConnecting.test.tsx
+++ b/__tests__/components/header/user/HeaderUserConnecting.test.tsx
@@ -5,7 +5,7 @@ const mockLoader = jest.fn(() => <div data-testid="loader" />);
 
 jest.mock("../../../../components/distribution-plan-tool/common/CircleLoader", () => ({
   __esModule: true,
-  default: (props: any) => mockLoader(props),
+  default: (props: any) => (mockLoader as any)(props),
   CircleLoaderSize: { MEDIUM: "MEDIUM" }
 }));
 


### PR DESCRIPTION
## Summary
- add tests for MapDelegations component
- add tests for ReviewDistributionPlan
- adjust existing HeaderUserConnecting test for type safety

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage`