### PR TITLE
Add tests for CreateDropFull component

### DIFF
--- a/__tests__/components/drops/create/full/CreateDropFull.test.tsx
+++ b/__tests__/components/drops/create/full/CreateDropFull.test.tsx
@@ -1,0 +1,90 @@
+import React, { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import CreateDropFull, { CreateDropFullHandles } from '../../../../../components/drops/create/full/CreateDropFull';
+import { CreateDropScreenType } from '../../../../../components/drops/create/utils/CreateDropWrapper';
+import { CreateDropType } from '../../../../../components/drops/create/types';
+
+jest.mock('react-use', () => ({
+  createBreakpoint: () => () => 'LG',
+}));
+
+const desktopClearMock = jest.fn();
+const mobileClearMock = jest.fn();
+
+jest.mock('../../../../../components/drops/create/full/desktop/CreateDropFullDesktop', () => {
+  return React.forwardRef((props: any, ref) => {
+    React.useImperativeHandle(ref, () => ({ clearEditorState: desktopClearMock }));
+    return <div data-testid="desktop">{props.children}</div>;
+  });
+});
+
+jest.mock('../../../../../components/drops/create/full/mobile/CreateDropFullMobile', () => {
+  return React.forwardRef((props: any, ref) => {
+    React.useImperativeHandle(ref, () => ({ clearEditorState: mobileClearMock }));
+    return <div data-testid="mobile">{props.children}</div>;
+  });
+});
+
+function renderComponent(screenType: CreateDropScreenType) {
+  const ref = createRef<CreateDropFullHandles>();
+  render(
+    <CreateDropFull
+      ref={ref}
+      screenType={screenType}
+      profile={{} as any}
+      title={null}
+      metadata={[]}
+      editorState={null}
+      files={[]}
+      canSubmit={false}
+      canAddPart={false}
+      loading={false}
+      showSubmit={false}
+      type={CreateDropType.DROP}
+      drop={null}
+      showDropError={false}
+      missingMedia={[]}
+      missingMetadata={[]}
+      waveId={null}
+      onTitle={jest.fn()}
+      onMetadataEdit={jest.fn()}
+      onMetadataRemove={jest.fn()}
+      onViewChange={jest.fn()}
+      onEditorState={jest.fn()}
+      onMentionedUser={jest.fn()}
+      onReferencedNft={jest.fn()}
+      onFileRemove={jest.fn()}
+      setFiles={jest.fn()}
+      onDrop={jest.fn()}
+      onDropPart={jest.fn()}
+    >
+      child
+    </CreateDropFull>
+  );
+  return ref;
+}
+
+describe('CreateDropFull', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders desktop component and delegates clearEditorState', () => {
+    const ref = renderComponent(CreateDropScreenType.DESKTOP);
+    expect(screen.getByTestId('desktop')).toBeInTheDocument();
+    expect(screen.queryByTestId('mobile')).toBeNull();
+    ref.current?.clearEditorState();
+    expect(desktopClearMock).toHaveBeenCalled();
+    expect(mobileClearMock).not.toHaveBeenCalled();
+  });
+
+  it('renders mobile component and delegates clearEditorState', () => {
+    const ref = renderComponent(CreateDropScreenType.MOBILE);
+    expect(screen.getByTestId('mobile')).toBeInTheDocument();
+    expect(screen.queryByTestId('desktop')).toBeNull();
+    ref.current?.clearEditorState();
+    expect(mobileClearMock).toHaveBeenCalled();
+    expect(desktopClearMock).not.toHaveBeenCalled();
+  });
+});
+

--- a/__tests__/components/groups/header/GroupHeaderSelect.test.tsx
+++ b/__tests__/components/groups/header/GroupHeaderSelect.test.tsx
@@ -12,7 +12,7 @@ const GroupHeaderSelect = require('../../../../components/groups/header/GroupHea
 describe('GroupHeaderSelect', () => {
   const renderWithProfile = (profile: any) =>
     render(
-      <AuthContext.Provider value={{ connectedProfile: profile }} as any>
+      <AuthContext.Provider value={{ connectedProfile: profile } as any}>
         <GroupHeaderSelect />
       </AuthContext.Provider>
     );
@@ -31,7 +31,7 @@ describe('GroupHeaderSelect', () => {
     const { rerender } = renderWithProfile(null);
     expect(screen.getByText('Please connect a wallet')).toBeInTheDocument();
     rerender(
-      <AuthContext.Provider value={{ connectedProfile: { handle: 'user' } }} as any>
+      <AuthContext.Provider value={{ connectedProfile: { handle: 'user' } } as any}>
         <GroupHeaderSelect />
       </AuthContext.Provider>
     );


### PR DESCRIPTION
## Summary
- add tests verifying desktop/mobile rendering and ref behavior for `CreateDropFull`
- fix `GroupHeaderSelect.test` type casts to satisfy type-check

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`