### PR TITLE
Add tests for group creation components

### DIFF
--- a/__tests__/components/groups/page/create/actions/GroupCreateActions.test.tsx
+++ b/__tests__/components/groups/page/create/actions/GroupCreateActions.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GroupCreateActions from '../../../../../../components/groups/page/create/actions/GroupCreateActions';
+import { AuthContext } from '../../../../../../components/auth/Auth';
+import { ReactQueryWrapperContext } from '../../../../../../components/react-query-wrapper/ReactQueryWrapper';
+
+jest.mock('../../../../../../components/groups/page/create/actions/GroupCreateTest', () => () => <div data-testid="test" />);
+jest.mock('../../../../../../components/distribution-plan-tool/common/CircleLoader', () => () => <div data-testid="loader" />);
+
+const commonApiPost = jest.fn();
+jest.mock('../../../../../../services/api/common-api', () => ({
+  commonApiPost: (...args: any[]) => commonApiPost(...args),
+}));
+
+// simple useMutation mock that executes mutationFn and callbacks
+const useMutationMock = jest.fn((options: any) => {
+  const mutateAsync = jest.fn(async (param?: any) => {
+    try {
+      const result = await options.mutationFn(param);
+      if (options.onSuccess) options.onSuccess(result, param, undefined);
+      if (options.onSettled) options.onSettled(result, undefined, param, undefined);
+      return result;
+    } catch (err) {
+      if (options.onError) options.onError(err, param, undefined);
+      if (options.onSettled) options.onSettled(undefined, err, param, undefined);
+      throw err;
+    }
+  });
+  return { mutateAsync };
+});
+
+jest.mock('@tanstack/react-query', () => ({ useMutation: (options: any) => useMutationMock(options) }));
+
+const defaultGroup = {
+  name: '',
+  group: {
+    tdh: { min: null, max: null },
+    rep: { min: null, max: null, user_identity: null, category: null },
+    cic: { min: null, max: null, user_identity: null },
+    level: { min: null, max: null },
+    owns_nfts: [],
+    identity_addresses: [],
+    excluded_identity_addresses: [],
+  },
+};
+
+function renderActions(props?: Partial<React.ComponentProps<typeof GroupCreateActions>>) {
+  const auth = {
+    requestAuth: jest.fn().mockResolvedValue({ success: true }),
+    setToast: jest.fn(),
+    connectedProfile: { handle: 'alice' },
+  } as any;
+  const queryCtx = { onGroupCreate: jest.fn() } as any;
+  const onCompleted = jest.fn();
+  render(
+    <AuthContext.Provider value={auth}>
+      <ReactQueryWrapperContext.Provider value={queryCtx}>
+        <GroupCreateActions
+          originalGroup={null}
+          groupConfig={defaultGroup as any}
+          onCompleted={onCompleted}
+          {...props}
+        />
+      </ReactQueryWrapperContext.Provider>
+    </AuthContext.Provider>
+  );
+  return { auth, queryCtx, onCompleted };
+}
+
+it('disables create button when no filters selected', () => {
+  renderActions();
+  expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+});
+
+it('creates group and marks visible on save', async () => {
+  const groupConfig = {
+    ...defaultGroup,
+    name: 'New Group',
+    group: { ...defaultGroup.group, identity_addresses: ['0x1'] },
+  };
+  const originalGroup = { id: 'old', created_by: { handle: 'Alice' } } as any;
+  commonApiPost.mockResolvedValueOnce({ id: '123' }).mockResolvedValueOnce({});
+
+  const { auth, queryCtx, onCompleted } = renderActions({ groupConfig, originalGroup });
+
+  await userEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+  await waitFor(() => expect(commonApiPost).toHaveBeenCalledTimes(2));
+  expect(auth.requestAuth).toHaveBeenCalled();
+  expect(commonApiPost).toHaveBeenNthCalledWith(1, { endpoint: 'groups', body: groupConfig });
+  expect(commonApiPost).toHaveBeenNthCalledWith(2, {
+    endpoint: 'groups/123/visible',
+    body: { visible: true, old_version_id: 'old' },
+  });
+  expect(auth.setToast).toHaveBeenCalledWith({ message: 'Group created.', type: 'success' });
+  expect(queryCtx.onGroupCreate).toHaveBeenCalled();
+  expect(onCompleted).toHaveBeenCalled();
+});

--- a/__tests__/components/groups/page/create/config/identities/select/GroupCreateIdentitiesSearchItems.test.tsx
+++ b/__tests__/components/groups/page/create/config/identities/select/GroupCreateIdentitiesSearchItems.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import GroupCreateIdentitiesSearchItems from '../../../../../../../../components/groups/page/create/config/identities/select/GroupCreateIdentitiesSearchItems';
+import { QueryKey } from '../../../../../../../../components/react-query-wrapper/ReactQueryWrapper';
+
+const useQueryMock = jest.fn();
+jest.mock('@tanstack/react-query', () => ({ useQuery: (...args: any[]) => useQueryMock(...args) }));
+
+const ContentMock = jest.fn(() => <div data-testid="content" />);
+jest.mock('../../../../../../../../components/groups/page/create/config/identities/select/GroupCreateIdentitiesSearchItemsContent', () => ({
+  __esModule: true,
+  default: (props: any) => ContentMock(props),
+}));
+
+const communityData = [{ wallet: '0x1', handle: 'alice', display: 'Alice' }];
+
+beforeEach(() => {
+  useQueryMock.mockReset();
+  ContentMock.mockClear();
+});
+
+test('queries and renders items when open and searchCriteria length >=3', () => {
+  useQueryMock.mockReturnValue({ data: communityData, isFetching: false });
+  render(
+    <GroupCreateIdentitiesSearchItems
+      open={true}
+      searchCriteria="alice"
+      selectedWallets={[]}
+      onSelect={jest.fn()}
+    />
+  );
+  expect(useQueryMock).toHaveBeenCalledWith({
+    queryKey: [QueryKey.PROFILE_SEARCH, { param: 'alice', only_profile_owners: 'true' }],
+    queryFn: expect.any(Function),
+    enabled: true,
+  });
+  expect(ContentMock).toHaveBeenCalledWith(
+    expect.objectContaining({ items: communityData, loading: false })
+  );
+  expect(screen.getByTestId('content')).toBeInTheDocument();
+});
+
+test('does not show list when open is false', () => {
+  useQueryMock.mockReturnValue({ data: communityData, isFetching: false });
+  render(
+    <GroupCreateIdentitiesSearchItems
+      open={false}
+      searchCriteria="alice"
+      selectedWallets={[]}
+      onSelect={jest.fn()}
+    />
+  );
+  expect(useQueryMock).toHaveBeenCalled();
+  expect(screen.queryByTestId('content')).toBeNull();
+});
+
+test('query disabled when searchCriteria too short', () => {
+  useQueryMock.mockReturnValue({ data: [], isFetching: false });
+  render(
+    <GroupCreateIdentitiesSearchItems
+      open={true}
+      searchCriteria="ab"
+      selectedWallets={[]}
+      onSelect={jest.fn()}
+    />
+  );
+  expect(useQueryMock).toHaveBeenCalledWith({
+    queryKey: [QueryKey.PROFILE_SEARCH, { param: 'ab', only_profile_owners: 'true' }],
+    queryFn: expect.any(Function),
+    enabled: false,
+  });
+  expect(ContentMock).toHaveBeenCalledWith(
+    expect.objectContaining({ items: [], loading: false })
+  );
+});

--- a/__tests__/components/groups/page/create/config/wallets/CreateGroupWalletsUpload.test.tsx
+++ b/__tests__/components/groups/page/create/config/wallets/CreateGroupWalletsUpload.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import CreateGroupWalletsUpload from '../../../../../../../components/groups/page/create/config/wallets/CreateGroupWalletsUpload';
+
+let mockContent = '';
+class MockFileReader {
+  onload: ((e: any) => void) | null = null;
+  readAsText() { if (this.onload) this.onload({ target: { result: mockContent } }); }
+}
+// @ts-ignore
+global.FileReader = MockFileReader;
+
+describe('CreateGroupWalletsUpload', () => {
+  it('parses uploaded csv and sets wallets', () => {
+    const setWallets = jest.fn();
+    mockContent = '0xAa00000000000000000000000000000000000000\n0xAA00000000000000000000000000000000000000,0xBb00000000000000000000000000000000000000';
+    const { container } = render(
+      <CreateGroupWalletsUpload type="a" wallets={null} setWallets={setWallets} />
+    );
+    const input = container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [new File(['x'], 'w.csv')] } });
+    expect(setWallets).toHaveBeenCalledWith([
+      '0xaa00000000000000000000000000000000000000',
+      '0xbb00000000000000000000000000000000000000',
+    ]);
+  });
+
+  it('removes wallets on button click', () => {
+    const setWallets = jest.fn();
+    const { getByLabelText } = render(
+      <CreateGroupWalletsUpload type="b" wallets={['0x1']} setWallets={setWallets} />
+    );
+    fireEvent.click(getByLabelText('Remove wallets'));
+    expect(setWallets).toHaveBeenCalledWith(null);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for GroupCreateActions
- add tests for identity search items and wallets upload components

## Testing
- `npm run test --silent __tests__/components/groups/page/create/actions/GroupCreateActions.test.tsx`
- `npm run test --silent __tests__/components/groups/page/create/config/identities/select/GroupCreateIdentitiesSearchItems.test.tsx`
- `npm run test --silent __tests__/components/groups/page/create/config/wallets/CreateGroupWalletsUpload.test.tsx`
- `npm run improve-coverage` *(fails: coverage below target)*