### PR TITLE
Increase coverage for mobile hooks

### DIFF
--- a/__tests__/hooks/useIsMobileDevice.test.ts
+++ b/__tests__/hooks/useIsMobileDevice.test.ts
@@ -1,0 +1,22 @@
+import { renderHook } from '@testing-library/react';
+import useIsMobileDevice from '../../hooks/isMobileDevice';
+
+describe('useIsMobileDevice', () => {
+  const originalUserAgent = navigator.userAgent;
+
+  afterEach(() => {
+    Object.defineProperty(window.navigator, 'userAgent', { value: originalUserAgent, configurable: true });
+  });
+
+  it('detects mobile user agent', () => {
+    Object.defineProperty(window.navigator, 'userAgent', { value: 'iPhone', configurable: true });
+    const { result } = renderHook(() => useIsMobileDevice());
+    expect(result.current).toBe(true);
+  });
+
+  it('detects desktop user agent', () => {
+    Object.defineProperty(window.navigator, 'userAgent', { value: 'Mozilla/5.0 (X11; Linux x86_64)', configurable: true });
+    const { result } = renderHook(() => useIsMobileDevice());
+    expect(result.current).toBe(false);
+  });
+});

--- a/__tests__/hooks/useIsMobileScreen.test.ts
+++ b/__tests__/hooks/useIsMobileScreen.test.ts
@@ -1,0 +1,27 @@
+import { renderHook, act } from '@testing-library/react';
+import useIsMobileScreen from '../../hooks/isMobileScreen';
+
+describe('useIsMobileScreen', () => {
+  const originalWidth = window.innerWidth;
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', { value: originalWidth, writable: true, configurable: true });
+  });
+
+  it('returns true when screen is small', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 500, writable: true, configurable: true });
+    const { result } = renderHook(() => useIsMobileScreen());
+    expect(result.current).toBe(true);
+  });
+
+  it('updates when resized', () => {
+    Object.defineProperty(window, 'innerWidth', { value: 1000, writable: true, configurable: true });
+    const { result } = renderHook(() => useIsMobileScreen());
+    expect(result.current).toBe(false);
+    act(() => {
+      window.innerWidth = 700 as number;
+      window.dispatchEvent(new Event('resize'));
+    });
+    expect(result.current).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for useIsMobileDevice hook
- add tests for useIsMobileScreen hook

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test` *(fails: output truncated)*