### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/components/distribution-plan-tool/common/DistributionPlanNextStepBtn.test.tsx
+++ b/__tests__/components/distribution-plan-tool/common/DistributionPlanNextStepBtn.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DistributionPlanNextStepBtn from '../../../../components/distribution-plan-tool/common/DistributionPlanNextStepBtn';
+import { DistributionPlanToolContext } from '../../../../components/distribution-plan-tool/DistributionPlanToolContext';
+
+function renderBtn(props: React.ComponentProps<typeof DistributionPlanNextStepBtn>, ctx?: Partial<React.ContextType<typeof DistributionPlanToolContext>>) {
+  const runOperations = jest.fn();
+  const contextValue = { runOperations, ...(ctx || {}) } as any;
+  const onNextStep = jest.fn();
+  render(
+    <DistributionPlanToolContext.Provider value={contextValue}>
+      <DistributionPlanNextStepBtn {...props} onNextStep={onNextStep} />
+    </DistributionPlanToolContext.Provider>
+  );
+  return { runOperations, onNextStep };
+}
+
+describe('DistributionPlanNextStepBtn', () => {
+  it('triggers onNextStep when Skip button clicked', async () => {
+    const { onNextStep } = renderBtn({ showRunAnalysisBtn: false, showNextBtn: false, showSkipBtn: true, loading: false });
+    await userEvent.click(screen.getByRole('button', { name: 'Skip' }));
+    expect(onNextStep).toHaveBeenCalled();
+  });
+
+  it('calls runOperations from context when Run analysis clicked', async () => {
+    const { runOperations } = renderBtn({ showRunAnalysisBtn: true, showNextBtn: false, showSkipBtn: false, loading: false });
+    await userEvent.click(screen.getByRole('button', { name: 'Run analysis' }));
+    expect(runOperations).toHaveBeenCalled();
+  });
+
+  it('renders Next button using primary button and triggers onNextStep', async () => {
+    const { onNextStep } = renderBtn({ showRunAnalysisBtn: false, showNextBtn: true, showSkipBtn: false, loading: false });
+    const button = screen.getByRole('button', { name: 'Next' });
+    expect(button).toBeInTheDocument();
+    await userEvent.click(button);
+    expect(onNextStep).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/distribution-plan-tool/connect/distribution-plan-tool-connected.test.tsx
+++ b/__tests__/components/distribution-plan-tool/connect/distribution-plan-tool-connected.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DistributionPlanToolConnected from '../../../../components/distribution-plan-tool/connect/distribution-plan-tool-connected';
+import { renderWithAuth } from '../../../utils/testContexts';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+
+const { useRouter } = require('next/router');
+
+describe('DistributionPlanToolConnected', () => {
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+  });
+
+  it('calls requestAuth and redirects on success', async () => {
+    const requestAuth = jest.fn(async () => ({ success: true }));
+    renderWithAuth(<DistributionPlanToolConnected />, { requestAuth });
+    await userEvent.click(screen.getByRole('button', { name: /sign in with web3/i }));
+    expect(requestAuth).toHaveBeenCalled();
+    expect(useRouter().push).toHaveBeenCalledWith('/emma/plans');
+  });
+
+  it('does not redirect when auth fails', async () => {
+    const requestAuth = jest.fn(async () => ({ success: false }));
+    renderWithAuth(<DistributionPlanToolConnected />, { requestAuth });
+    await userEvent.click(screen.getByRole('button', { name: /sign in with web3/i }));
+    expect(useRouter().push).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/distribution-plan-tool/connect/distributipn-plan-tool-connect.test.tsx
+++ b/__tests__/components/distribution-plan-tool/connect/distributipn-plan-tool-connect.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, act } from '@testing-library/react';
+import DistributionPlanToolConnect from '../../../../components/distribution-plan-tool/connect/distributipn-plan-tool-connect';
+
+jest.mock('../../../../components/distribution-plan-tool/connect/distribution-plan-tool-not-connected', () => () => <div data-testid="not-connected" />);
+jest.mock('../../../../components/distribution-plan-tool/connect/distribution-plan-tool-connected', () => () => <div data-testid="connected" />);
+jest.mock('../../../../components/auth/SeizeConnectContext', () => ({ useSeizeConnectContext: jest.fn() }));
+
+import { useSeizeConnectContext } from '../../../../components/auth/SeizeConnectContext';
+import * as helpers from '../../../../helpers/AllowlistToolHelpers';
+
+describe('DistributionPlanToolConnect', () => {
+  it('renders not connected view when address invalid', async () => {
+    (useSeizeConnectContext as jest.Mock).mockReturnValue({ address: null });
+    jest.spyOn(helpers, 'isEthereumAddress').mockReturnValue(false);
+    await act(async () => { render(<DistributionPlanToolConnect />); });
+    expect(screen.getByTestId('not-connected')).toBeInTheDocument();
+  });
+
+  it('renders connected view when address valid', async () => {
+    (useSeizeConnectContext as jest.Mock).mockReturnValue({ address: '0x1' });
+    jest.spyOn(helpers, 'isEthereumAddress').mockReturnValue(true);
+    await act(async () => { render(<DistributionPlanToolConnect />); });
+    expect(screen.getByTestId('connected')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotForm.test.tsx
+++ b/__tests__/components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotForm.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateCustomSnapshotForm from '../../../../../components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotForm';
+import { DistributionPlanToolContext } from '../../../../../components/distribution-plan-tool/DistributionPlanToolContext';
+import { distributionPlanApiPost } from '../../../../../services/distribution-plan-api';
+
+jest.mock('../../../../../components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotFormUpload', () => () => <div data-testid="upload" />);
+jest.mock('../../../../../components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotFormTable', () => ({ tokens }: any) => <div data-testid="table">{tokens.length}</div>);
+jest.mock('../../../../../components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotFormAddWalletsModal', () => ({ addUploadedTokens, onClose, tokens }: any) => (
+  <div data-testid="modal">
+    <span data-testid="count">{tokens.length}</span>
+    <button onClick={() => { addUploadedTokens([{ owner: '0x1' }]); onClose(); }}>upload</button>
+  </div>
+));
+jest.mock('../../../../../components/allowlist-tool/common/modals/AllowlistToolCommonModalWrapper', () => ({ __esModule: true, AllowlistToolModalSize: { X_LARGE: 'X_LARGE' }, default: ({ children }: any) => <div data-testid="wrapper">{children}</div> }));
+
+jest.mock('../../../../../services/distribution-plan-api');
+
+const ctx = {
+  distributionPlan: { id: 'd1' },
+  setToasts: jest.fn(),
+  fetchOperations: jest.fn(),
+};
+
+describe('CreateCustomSnapshotForm', () => {
+  beforeEach(() => {
+    (distributionPlanApiPost as jest.Mock).mockResolvedValue({ success: true, data: null });
+  });
+
+  it('adds uploaded tokens and submits form', async () => {
+    render(
+      <DistributionPlanToolContext.Provider value={ctx as any}>
+        <CreateCustomSnapshotForm />
+      </DistributionPlanToolContext.Provider>
+    );
+    await userEvent.click(screen.getByRole('button', { name: /add wallets/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'upload' }));
+    expect(screen.queryByTestId('modal')).not.toBeInTheDocument();
+    // table should now show 1 token
+    expect(screen.getByTestId('table')).toHaveTextContent('1');
+
+    const input = screen.getByRole('textbox');
+    await userEvent.type(input, 'Snap');
+    await userEvent.click(screen.getByRole('button', { name: /add custom snapshot/i }));
+
+    expect(distributionPlanApiPost).toHaveBeenCalled();
+    expect(ctx.fetchOperations).toHaveBeenCalledWith('d1');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for DistributionPlanNextStepBtn
- test connected state for DistributionPlanToolConnect components
- cover CreateCustomSnapshotForm flow with mocks

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run improve-coverage`