### PR TITLE
Increase header component test coverage

### DIFF
--- a/__tests__/components/header/AppSidebarUserInfo.test.tsx
+++ b/__tests__/components/header/AppSidebarUserInfo.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import AppSidebarUserInfo from '../../../components/header/AppSidebarUserInfo';
+import React from 'react';
+
+jest.mock('../../../components/header/AppSidebarUserStats', () => (props: any) => {
+  return <div data-testid="stats">{JSON.stringify(props)}</div>;
+});
+
+jest.mock('../../../components/user/utils/level/UserLevel', () => (props: any) => {
+  return <div data-testid="level">{JSON.stringify(props)}</div>;
+});
+
+jest.mock('../../../components/auth/SeizeConnectContext', () => ({
+  useSeizeConnectContext: jest.fn(),
+}));
+
+jest.mock('../../../components/auth/Auth', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useIdentity', () => ({
+  useIdentity: jest.fn(),
+}));
+
+const { useSeizeConnectContext } = require('../../../components/auth/SeizeConnectContext');
+const { useAuth } = require('../../../components/auth/Auth');
+const { useIdentity } = require('../../../hooks/useIdentity');
+
+function setup(options: any) {
+  (useSeizeConnectContext as jest.Mock).mockReturnValue({ address: options.address });
+  (useAuth as jest.Mock).mockReturnValue({ activeProfileProxy: options.activeProfileProxy });
+  (useIdentity as jest.Mock).mockReturnValue({ profile: options.profile });
+  return render(<AppSidebarUserInfo />);
+}
+
+describe('AppSidebarUserInfo', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('uses active profile proxy data when available', () => {
+    const proxy = {
+      created_by: { handle: 'alice', pfp: 'alice.png', level: 5, tdh: 10, rep: 20 },
+    };
+    setup({ address: '0x123', activeProfileProxy: proxy, profile: null });
+
+    expect(screen.getByAltText('pfp')).toHaveAttribute('src', 'alice.png');
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByTestId('level')).toHaveTextContent('"level":5');
+    const stats = JSON.parse(screen.getByTestId('stats').textContent as string);
+    expect(stats.handle).toBe('alice');
+    expect(stats.tdh).toBe(10);
+    expect(stats.rep).toBe(20);
+    expect(stats.profileId).toBeNull();
+  });
+
+  it('falls back to profile when no active proxy', () => {
+    const profile = { id: 'p1', handle: 'bob', pfp: 'bob.png', level: 3, tdh: 4, rep: 5 };
+    setup({ address: '0xabc', activeProfileProxy: null, profile });
+
+    expect(screen.getByAltText('pfp')).toHaveAttribute('src', 'bob.png');
+    expect(screen.getByText('bob')).toBeInTheDocument();
+    expect(screen.getByTestId('level')).toHaveTextContent('"level":3');
+    const stats = JSON.parse(screen.getByTestId('stats').textContent as string);
+    expect(stats.handle).toBe('bob');
+    expect(stats.tdh).toBe(4);
+    expect(stats.rep).toBe(5);
+    expect(stats.profileId).toBe('p1');
+  });
+
+  it('uses address when no profile data', () => {
+    setup({ address: '0xabcdef1234', activeProfileProxy: null, profile: null });
+
+    expect(screen.queryByAltText('pfp')).not.toBeInTheDocument();
+    expect(screen.getByText('0xabcd')).toBeInTheDocument();
+    const stats = JSON.parse(screen.getByTestId('stats').textContent as string);
+    expect(stats.handle).toBe('0xabcdef1234');
+    expect(stats.tdh).toBe(0);
+    expect(stats.rep).toBe(0);
+    expect(stats.profileId).toBeNull();
+  });
+});

--- a/__tests__/components/header/AppUserConnect.test.tsx
+++ b/__tests__/components/header/AppUserConnect.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import AppUserConnect from '../../../components/header/AppUserConnect';
+import React from 'react';
+
+jest.mock('../../../components/header/share/HeaderQRScanner', () => () => (
+  <div data-testid="scanner" />
+));
+
+jest.mock('../../../components/auth/SeizeConnectContext', () => ({
+  useSeizeConnectContext: jest.fn(),
+}));
+
+const { useSeizeConnectContext } = require('../../../components/auth/SeizeConnectContext');
+
+function setup(address: string | undefined) {
+  const seizeConnect = jest.fn();
+  const seizeDisconnectAndLogout = jest.fn();
+  (useSeizeConnectContext as jest.Mock).mockReturnValue({
+    address,
+    seizeConnect,
+    seizeDisconnectAndLogout,
+  });
+  const onNavigate = jest.fn();
+  render(<AppUserConnect onNavigate={onNavigate} />);
+  return { seizeConnect, seizeDisconnectAndLogout, onNavigate };
+}
+
+describe('AppUserConnect', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders connect button when not connected', () => {
+    const { seizeConnect, onNavigate } = setup(undefined);
+    const btn = screen.getByRole('button', { name: 'Connect' });
+    expect(btn).toBeInTheDocument();
+    fireEvent.click(btn);
+    expect(seizeConnect).toHaveBeenCalled();
+    expect(onNavigate).toHaveBeenCalled();
+    expect(screen.getByTestId('scanner')).toBeInTheDocument();
+  });
+
+  it('renders disconnect options when connected', () => {
+    const { seizeDisconnectAndLogout, onNavigate } = setup('0xabc');
+    const switchBtn = screen.getByRole('button', { name: 'Switch Account' });
+    const disconnectBtn = screen.getByRole('button', { name: 'Disconnect & Logout' });
+
+    fireEvent.click(switchBtn);
+    expect(seizeDisconnectAndLogout).toHaveBeenCalledWith(true);
+    expect(onNavigate).toHaveBeenCalled();
+
+    fireEvent.click(disconnectBtn);
+    expect(seizeDisconnectAndLogout).toHaveBeenCalledWith();
+    expect(onNavigate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/components/header/HeaderNotifications.test.tsx
+++ b/__tests__/components/header/HeaderNotifications.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import HeaderNotifications from '../../../components/header/notifications/HeaderNotifications';
+import React from 'react';
+
+jest.mock('next/link', () => ({ __esModule: true, default: ({ href, children }: any) => <a href={href}>{children}</a> }));
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+
+jest.mock('../../../components/auth/Auth', () => ({
+  useAuth: jest.fn(),
+  TitleType: { NOTIFICATION: 'NOTIFICATION' },
+}));
+
+jest.mock('../../../hooks/useUnreadNotifications', () => ({
+  useUnreadNotifications: jest.fn(),
+}));
+
+jest.mock('../../../components/notifications/NotificationsContext', () => ({
+  useNotificationsContext: jest.fn(),
+}));
+
+const { useRouter } = require('next/router');
+const { useAuth, TitleType } = require('../../../components/auth/Auth');
+const { useUnreadNotifications } = require('../../../hooks/useUnreadNotifications');
+const { useNotificationsContext } = require('../../../components/notifications/NotificationsContext');
+
+describe('HeaderNotifications', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('shows unread badge and sets title', () => {
+    (useAuth as jest.Mock).mockReturnValue({ connectedProfile: { handle: 'alice' }, setTitle: jest.fn() });
+    (useRouter as jest.Mock).mockReturnValue({ pathname: '/home' });
+    const removeAll = jest.fn();
+    (useNotificationsContext as jest.Mock).mockReturnValue({ removeAllDeliveredNotifications: removeAll });
+    (useUnreadNotifications as jest.Mock).mockReturnValue({ notifications: { unread_count: 2 }, haveUnreadNotifications: true });
+
+    render(<HeaderNotifications />);
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/my-stream/notifications');
+    expect(screen.getByRole('link').querySelector('div')).toBeInTheDocument();
+    expect(removeAll).not.toHaveBeenCalled();
+    const { setTitle } = (useAuth as jest.Mock).mock.results[0].value;
+    expect(setTitle).toHaveBeenCalledWith({ title: '(2) Notifications | 6529.io', type: TitleType.NOTIFICATION });
+  });
+
+  it('removes delivered notifications when none unread and adjusts link', () => {
+    const setTitle = jest.fn();
+    (useAuth as jest.Mock).mockReturnValue({ connectedProfile: { handle: 'bob' }, setTitle });
+    (useRouter as jest.Mock).mockReturnValue({ pathname: '/my-stream/notifications' });
+    const removeAll = jest.fn();
+    (useNotificationsContext as jest.Mock).mockReturnValue({ removeAllDeliveredNotifications: removeAll });
+    (useUnreadNotifications as jest.Mock).mockReturnValue({ notifications: { unread_count: 0 }, haveUnreadNotifications: false });
+
+    render(<HeaderNotifications />);
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/my-stream/notifications?reload=true');
+    expect(screen.getByRole('link').querySelector('div')).toBeNull();
+    expect(removeAll).toHaveBeenCalled();
+    expect(setTitle).toHaveBeenCalledWith({ title: null, type: TitleType.NOTIFICATION });
+  });
+});

--- a/__tests__/components/header/HeaderOpenMobile.test.tsx
+++ b/__tests__/components/header/HeaderOpenMobile.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import HeaderOpenMobile from '../../../components/header/open-mobile/HeaderOpenMobile';
+import React from 'react';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../../hooks/useCapacitor', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('../../../hooks/isMobileDevice', () => ({ __esModule: true, default: jest.fn() }));
+
+const { useRouter } = require('next/router');
+const useCapacitor = require('../../../hooks/useCapacitor').default as jest.Mock;
+const useIsMobileDevice = require('../../../hooks/isMobileDevice').default as jest.Mock;
+
+describe('HeaderOpenMobile', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('does not render when running in capacitor', () => {
+    useCapacitor.mockReturnValue({ isCapacitor: true });
+    useIsMobileDevice.mockReturnValue(true);
+    const push = jest.fn();
+    (useRouter as jest.Mock).mockReturnValue({ asPath: '/path', push });
+    const { container } = render(<HeaderOpenMobile />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('opens mobile link when clicked', () => {
+    useCapacitor.mockReturnValue({ isCapacitor: false });
+    useIsMobileDevice.mockReturnValue(true);
+    (useRouter as jest.Mock).mockReturnValue({ asPath: '/foo' });
+    const open = jest.fn();
+    const original = window.open;
+    // @ts-ignore
+    window.open = open;
+
+    render(<HeaderOpenMobile />);
+    const btn = screen.getByRole('button', { name: 'Open Mobile' });
+    fireEvent.click(btn);
+    expect(open).toHaveBeenCalledWith(`${window.location.origin}/open-mobile?path=%2Ffoo`, '_blank');
+
+    window.open = original;
+  });
+});


### PR DESCRIPTION
## Summary
- add missing tests for sidebar info, user connect, notifications, and open mobile header components

## Testing
- `npx jest __tests__/components/header/HeaderOpenMobile.test.tsx --coverage --maxWorkers=2`
- `npx jest __tests__/components/header/AppUserConnect.test.tsx --coverage --maxWorkers=2`
- `npx jest __tests__/components/header/AppSidebarUserInfo.test.tsx --coverage --maxWorkers=2`
- `npx jest __tests__/components/header/HeaderNotifications.test.tsx --coverage --maxWorkers=2`
- `npm run improve-coverage` *(fails: Required environment variables not set)*
