### PR TITLE
Add MediaDisplayGLB tests and fix type issues

### DIFF
--- a/__tests__/components/distribution-plan-tool/build-phases/build-phase/form/BuildPhaseForm.test.tsx
+++ b/__tests__/components/distribution-plan-tool/build-phases/build-phase/form/BuildPhaseForm.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import BuildPhaseForm from '../../../../../../components/distribution-plan-tool/build-phases/build-phase/form/BuildPhaseForm';
-import { DistributionPlanToolContext } from '../../../../../../components/distribution-plan-tool/DistributionPlanToolContext';
+import {
+  DistributionPlanToolContext,
+  DistributionPlanToolStep,
+} from '../../../../../../components/distribution-plan-tool/DistributionPlanToolContext';
 import { BuildPhasesPhase } from '../../../../../../components/distribution-plan-tool/build-phases/BuildPhases';
 
 // Mock sub components to keep test focused
@@ -33,7 +36,7 @@ jest.mock('../../../../../../components/allowlist-tool/common/modals/AllowlistTo
 jest.mock('@tippyjs/react', () => ({ children }: any) => <>{children}</>);
 
 const defaultContext = {
-  step: 0,
+  step: DistributionPlanToolStep.CREATE_PLAN,
   setStep: jest.fn(),
   fetching: false,
   distributionPlan: { id: 'id' } as any,

--- a/__tests__/components/distribution-plan-tool/common/DistributionPlanNextStepBtn.test.tsx
+++ b/__tests__/components/distribution-plan-tool/common/DistributionPlanNextStepBtn.test.tsx
@@ -4,7 +4,10 @@ import userEvent from '@testing-library/user-event';
 import DistributionPlanNextStepBtn from '../../../../components/distribution-plan-tool/common/DistributionPlanNextStepBtn';
 import { DistributionPlanToolContext } from '../../../../components/distribution-plan-tool/DistributionPlanToolContext';
 
-function renderBtn(props: React.ComponentProps<typeof DistributionPlanNextStepBtn>, ctx?: Partial<React.ContextType<typeof DistributionPlanToolContext>>) {
+function renderBtn(
+  props: any,
+  ctx?: Partial<React.ContextType<typeof DistributionPlanToolContext>>,
+) {
   const runOperations = jest.fn();
   const contextValue = { runOperations, ...(ctx || {}) } as any;
   const onNextStep = jest.fn();

--- a/__tests__/components/drops/create/full/mobile/CreateDropFullMobile.test.tsx
+++ b/__tests__/components/drops/create/full/mobile/CreateDropFullMobile.test.tsx
@@ -35,7 +35,6 @@ describe('CreateDropFullMobile', () => {
         showSubmit={props.showSubmit ?? false}
         type={props.type ?? CreateDropType.DROP}
         drop={null}
-        showDropError={false}
         missingMedia={[]}
         missingMetadata={[]}
         waveId={null}

--- a/__tests__/components/drops/view/item/content/media/MediaDisplayGLB.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/MediaDisplayGLB.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+jest.mock('@google/model-viewer', () => ({}));
+import MediaDisplayGLB from '../../../../../../../components/drops/view/item/content/media/MediaDisplayGLB';
+
+describe('MediaDisplayGLB', () => {
+  it('renders model-viewer with provided src', () => {
+    const { container } = render(<MediaDisplayGLB src="model.glb" />);
+    const el = container.querySelector('model-viewer');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveAttribute('src', 'model.glb');
+  });
+
+  it('includes AR, auto-rotate and camera controls', () => {
+    const { container } = render(<MediaDisplayGLB src="asset.glb" />);
+    const el = container.querySelector('model-viewer');
+    expect(el).toHaveAttribute('ar');
+    expect(el).toHaveAttribute('auto-rotate');
+    expect(el).toHaveAttribute('camera-controls');
+  });
+});

--- a/__tests__/components/leaderboard/LeaderboardCardsCollected.test.tsx
+++ b/__tests__/components/leaderboard/LeaderboardCardsCollected.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import LeaderboardCardsCollectedComponent from '../../../components/leaderboard/LeaderboardCardsCollected';
 import { SortDirection } from '../../../entities/ISort';
 import { LeaderboardCardsCollectedSort } from '../../../components/leaderboard/leaderboard_helpers';
+import { Content, Collector } from '../../../components/leaderboard/Leaderboard';
 
 jest.mock('../../../components/leaderboard/leaderboard_helpers', () => {
   const original = jest.requireActual('../../../components/leaderboard/leaderboard_helpers');
@@ -15,8 +16,8 @@ const useFetchLeaderboard = require('../../../components/leaderboard/leaderboard
 
 const baseProps = {
   block: 1,
-  content: 'all',
-  collector: 'all',
+  content: Content.ALL,
+  collector: Collector.ALL,
   selectedSeason: 1,
   searchWallets: [],
   seasons: [],


### PR DESCRIPTION
## Summary
- improve BuildPhaseForm tests and imports
- relax prop typing in DistributionPlanNextStepBtn tests
- remove unused prop in CreateDropFullMobile test
- use enums in LeaderboardCardsCollected test
- add new MediaDisplayGLB test

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`