### PR TITLE
Improve coverage for HeaderProxyNewModal

### DIFF
--- a/__tests__/components/distribution-plan-tool/create-snapshots/form/CreateSnapshotFormSearchCollectionDropdownItem.test.tsx
+++ b/__tests__/components/distribution-plan-tool/create-snapshots/form/CreateSnapshotFormSearchCollectionDropdownItem.test.tsx
@@ -50,7 +50,8 @@ describe('CreateSnapshotFormSearchCollectionDropdownItem', () => {
   it('renders collection info', () => {
     renderItem({ openseaVerified: true });
     expect(screen.getByText('Collection')).toBeInTheDocument();
-    expect(screen.getByRole('img')).toBeInTheDocument();
+    // image has empty alt so it has presentation role
+    expect(screen.getByRole('presentation')).toBeInTheDocument();
     expect(screen.getAllByText('f2')).toHaveLength(1); // volume
   });
 
@@ -62,9 +63,14 @@ describe('CreateSnapshotFormSearchCollectionDropdownItem', () => {
 
   it('fetches token ids and passes them for sub collection', async () => {
     fetchMock.mockResolvedValueOnce({ success: true, data: { tokenIds: '1,2' } });
-    const { onCollection, collection } = renderItem({ id: '0xabc:sub' });
+    const subId = `0x${'a'.repeat(40)}:sub`;
+    const { onCollection, collection } = renderItem({ id: subId });
     await userEvent.click(screen.getByRole('row'));
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith('/other/contract-token-ids-as-string/0xabc:sub'));
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/other/contract-token-ids-as-string/${subId}`
+      )
+    );
     expect(onCollection).toHaveBeenCalledWith({ name: collection.name, address: collection.address, tokenIds: '1,2' });
   });
 });

--- a/__tests__/components/header/proxy/HeaderProxyNewModal.test.tsx
+++ b/__tests__/components/header/proxy/HeaderProxyNewModal.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import HeaderProxyNewModal from '../../../../components/header/proxy/HeaderProxyNewModal';
+
+let clickAwayCb: () => void;
+let keyPressCb: () => void;
+
+jest.mock('react-use', () => ({
+  useClickAway: (_ref: any, cb: () => void) => {
+    clickAwayCb = cb;
+  },
+  useKeyPressEvent: (_key: string, cb: () => void) => {
+    keyPressCb = cb;
+  },
+}));
+
+const connectedProfile = { handle: 'user', pfp: 'user.png' } as any;
+const proxyGrantor = { handle: 'grantor', pfp: 'grantor.png' } as any;
+
+describe('HeaderProxyNewModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls onClose when escape is pressed', () => {
+    const onClose = jest.fn();
+    render(
+      <HeaderProxyNewModal
+        connectedProfile={connectedProfile}
+        proxyGrantor={proxyGrantor}
+        onClose={onClose}
+      />
+    );
+    fireEvent.keyDown(window, { key: 'Escape' });
+    keyPressCb();
+    expect(onClose).toHaveBeenCalledWith(false);
+  });
+
+  it('toggles dontShowAgain and passes value on close', () => {
+    const onClose = jest.fn();
+    render(
+      <HeaderProxyNewModal
+        connectedProfile={connectedProfile}
+        proxyGrantor={proxyGrantor}
+        onClose={onClose}
+      />
+    );
+    fireEvent.click(screen.getByLabelText("Don't show again"));
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalledWith(true);
+  });
+
+  it('calls onClose when clicking outside', () => {
+    const onClose = jest.fn();
+    render(
+      <HeaderProxyNewModal
+        connectedProfile={connectedProfile}
+        proxyGrantor={proxyGrantor}
+        onClose={onClose}
+      />
+    );
+    clickAwayCb();
+    expect(onClose).toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
## Summary
- fix `CreateSnapshotFormSearchCollectionDropdownItem` test to use proper sub collection id and presentation role
- add tests for `HeaderProxyNewModal`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage`