### PR TITLE
Improve coverage for header and nextgen components

### DIFF
--- a/__tests__/components/header/user/HeaderUserProfile.test.tsx
+++ b/__tests__/components/header/user/HeaderUserProfile.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import HeaderUserProfile from "../../../../components/header/user/HeaderUserProfile";
+import React from "react";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children }: any) => <a href={href}>{children}</a>,
+}));
+
+jest.mock("@tippyjs/react", () => (props: any) => (
+  <div data-testid="tippy" data-content={props.content}>
+    {props.children}
+  </div>
+));
+
+jest.mock("../../../../components/auth/Auth", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("../../../../components/auth/SeizeConnectContext", () => ({
+  useSeizeConnectContext: jest.fn(),
+}));
+
+const { useAuth } = require("../../../../components/auth/Auth");
+const {
+  useSeizeConnectContext,
+} = require("../../../../components/auth/SeizeConnectContext");
+
+function setup(options: any) {
+  (useAuth as jest.Mock).mockReturnValue({
+    activeProfileProxy: options.activeProfileProxy,
+  });
+  (useSeizeConnectContext as jest.Mock).mockReturnValue({
+    address: options.address,
+    isConnected: options.isConnected,
+  });
+  render(<HeaderUserProfile profile={options.profile} />);
+}
+
+describe("HeaderUserProfile", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("uses proxy information when active", () => {
+    const proxy = { created_by: { handle: "proxy", pfp: "proxy.png" } };
+    const profile = { handle: "alice", pfp: "alice.png" };
+    setup({
+      activeProfileProxy: proxy,
+      profile,
+      address: "0x1234",
+      isConnected: true,
+    });
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/proxy");
+    expect(screen.getByText("proxy")).toBeInTheDocument();
+    expect(screen.getByText("Proxy")).toBeInTheDocument();
+    expect(link.querySelector("img")!).toHaveAttribute("src", "proxy.png");
+    expect(screen.getByTestId("tippy")).toHaveAttribute(
+      "data-content",
+      "Connected and Authenticated",
+    );
+  });
+
+  it("falls back to profile when no proxy", () => {
+    const profile = { handle: "alice", pfp: "alice.png" };
+    setup({
+      activeProfileProxy: null,
+      profile,
+      address: "0x1234",
+      isConnected: false,
+    });
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/alice");
+    expect(screen.getByText("alice")).toBeInTheDocument();
+    expect(link.querySelector("img")!).toHaveAttribute("src", "alice.png");
+    expect(screen.queryByText("Proxy")).toBeNull();
+    expect(screen.getByTestId("tippy")).toHaveAttribute(
+      "data-content",
+      "Authenticated (wallet not connected)",
+    );
+  });
+
+  it("uses wallet display and address when no handle", () => {
+    const profile = { wallets: [{ wallet: "0xabcd", display: "Bob" }] };
+    setup({
+      activeProfileProxy: null,
+      profile,
+      address: "0xabcd",
+      isConnected: true,
+    });
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/Bob");
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+    expect(link.querySelector("img")).toBeNull();
+  });
+
+  it("falls back to address when no display", () => {
+    const profile = { wallets: [{ wallet: "0xabcde" }] };
+    setup({
+      activeProfileProxy: null,
+      profile,
+      address: "0xabcde",
+      isConnected: false,
+    });
+
+    const label = "0xabcde".slice(0, 6);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", `/0xabcde`);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/header/user/proxy/HeaderUserProxy.test.tsx
+++ b/__tests__/components/header/user/proxy/HeaderUserProxy.test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import HeaderUserProxy from "../../../../../components/header/user/proxy/HeaderUserProxy";
+
+let clickAwayCb: () => void;
+let keyPressCb: () => void;
+
+jest.mock("react-use", () => ({
+  useClickAway: (_ref: any, cb: () => void) => {
+    clickAwayCb = cb;
+  },
+  useKeyPressEvent: (_key: string, cb: () => void) => {
+    keyPressCb = cb;
+  },
+}));
+
+const dropdownMock = jest.fn();
+jest.mock(
+  "../../../../../components/header/user/proxy/HeaderUserProxyDropdown",
+  () => (props: any) => {
+    dropdownMock(props);
+    return <div data-testid="dropdown" />;
+  },
+);
+
+const profile = { handle: "alice" } as any;
+
+describe("HeaderUserProxy", () => {
+  beforeEach(() => dropdownMock.mockClear());
+
+  it("toggles dropdown when button clicked", () => {
+    render(<HeaderUserProxy profile={profile} />);
+    const btn = screen.getByRole("button", { name: /choose proxy/i });
+    expect(dropdownMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isOpen: false }),
+    );
+
+    fireEvent.click(btn);
+    expect(dropdownMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isOpen: true }),
+    );
+
+    fireEvent.click(btn);
+    expect(dropdownMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isOpen: false }),
+    );
+  });
+
+  it("closes when escape pressed and when clicking away", () => {
+    render(<HeaderUserProxy profile={profile} />);
+    const btn = screen.getByRole("button", { name: /choose proxy/i });
+
+    fireEvent.click(btn);
+    expect(dropdownMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isOpen: true }),
+    );
+
+    act(() => {
+      keyPressCb();
+    });
+    expect(dropdownMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isOpen: false }),
+    );
+
+    fireEvent.click(btn);
+    expect(dropdownMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isOpen: true }),
+    );
+
+    act(() => {
+      clickAwayCb();
+    });
+    expect(dropdownMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isOpen: false }),
+    );
+  });
+});

--- a/__tests__/components/nextGen/admin/NextGenAdminArtistSignCollection.test.tsx
+++ b/__tests__/components/nextGen/admin/NextGenAdminArtistSignCollection.test.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import NextGenAdminArtistSignCollection from "../../../../components/nextGen/admin/NextGenAdminArtistSignCollection";
+
+jest.mock("../../../../components/nextGen/nextgen_helpers", () => ({
+  useCollectionIndex: jest.fn(() => ({ data: 1 })),
+  useCollectionArtist: jest.fn(() => ({ data: [{ result: "0xabc" }] })),
+  useParsedCollectionIndex: jest.fn(() => 1),
+  isCollectionArtist: jest.fn(),
+  useCoreContractWrite: jest.fn(),
+}));
+
+jest.mock("../../../../components/nextGen/admin/NextGenAdminShared", () => ({
+  NextGenCollectionIdFormGroup: ({ onChange }: any) => (
+    <input
+      data-testid="collectionId"
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+  NextGenAdminHeadingRow: () => <div data-testid="heading" />,
+}));
+
+jest.mock(
+  "../../../../components/nextGen/NextGenContractWriteStatus",
+  () => () => <div data-testid="status" />,
+);
+
+jest.mock("../../../../components/auth/SeizeConnectContext", () => ({
+  useSeizeConnectContext: jest.fn(),
+}));
+
+const {
+  useSeizeConnectContext,
+} = require("../../../../components/auth/SeizeConnectContext");
+const {
+  isCollectionArtist,
+  useCoreContractWrite,
+} = require("../../../../components/nextGen/nextgen_helpers");
+
+function setup(isArtist: boolean) {
+  (useSeizeConnectContext as jest.Mock).mockReturnValue({ address: "0xabc" });
+  (isCollectionArtist as jest.Mock).mockReturnValue(isArtist);
+  (useCoreContractWrite as jest.Mock).mockReturnValue({
+    reset: jest.fn(),
+    writeContract: jest.fn(),
+    params: {},
+    isSuccess: false,
+    isError: false,
+    isLoading: false,
+    data: null,
+    error: null,
+  });
+  render(<NextGenAdminArtistSignCollection close={jest.fn()} />);
+}
+
+describe("NextGenAdminArtistSignCollection", () => {
+  it("shows warning when not an artist", () => {
+    setup(false);
+    expect(
+      screen.getByText(/only collection artists can use this section/i),
+    ).toBeInTheDocument();
+  });
+
+  it("validates required fields on submit", () => {
+    setup(true);
+    fireEvent.click(screen.getByText("Submit"));
+    expect(screen.getByText("Collection id is required")).toBeInTheDocument();
+    expect(screen.getByText("Signature is required")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage tests for `HeaderUserProfile`
- add coverage tests for `HeaderUserProxy`
- cover `NextGenAdminArtistSignCollection`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run improve-coverage`
