### PR TITLE
Add tests for group create components

### DIFF
--- a/__tests__/components/groups/page/create/GroupCreateWrapper.test.tsx
+++ b/__tests__/components/groups/page/create/GroupCreateWrapper.test.tsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import GroupCreateWrapper from '../../../../../components/groups/page/create/GroupCreateWrapper';
+
+describe('GroupCreateWrapper', () => {
+  it('renders children inside wrapper with correct classes', () => {
+    const { container } = render(
+      <GroupCreateWrapper>
+        <span>content</span>
+      </GroupCreateWrapper>
+    );
+
+    const outer = container.firstElementChild as HTMLElement;
+    expect(outer.tagName).toBe('DIV');
+    expect(outer.className).toContain('tw-mt-4');
+    expect(outer.className).toContain('lg:tw-mt-6');
+    expect(outer.className).toContain('tailwind-scope');
+    expect(outer.className).toContain('tw-relative');
+
+    const inner = outer.firstElementChild as HTMLElement;
+    expect(inner.tagName).toBe('DIV');
+    expect(inner.textContent).toBe('content');
+  });
+});

--- a/__tests__/components/groups/page/create/actions/GroupCreateTest.test.tsx
+++ b/__tests__/components/groups/page/create/actions/GroupCreateTest.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import GroupCreateTest from '../../../../../../components/groups/page/create/actions/GroupCreateTest';
+import { AuthContext } from '../../../../../../components/auth/Auth';
+
+const commonApiPost = jest.fn();
+const commonApiFetch = jest.fn();
+
+jest.mock('../../../../../../services/api/common-api', () => ({
+  commonApiPost: (...args: any[]) => commonApiPost(...args),
+  commonApiFetch: (...args: any[]) => commonApiFetch(...args),
+}));
+
+const mutateAsyncMock = jest.fn();
+
+const useMutationMock = jest.fn((options: any) => {
+  const mutateAsync = async (param?: any) => {
+    return options.mutationFn(param);
+  };
+  mutateAsyncMock.mockImplementation(mutateAsync);
+  return { mutateAsync: mutateAsyncMock };
+});
+
+const useQueryMock = jest.fn(() => ({ isFetching: false, data: undefined }));
+
+jest.mock('@tanstack/react-query', () => ({
+  useMutation: (opts: any) => useMutationMock(opts),
+  useQuery: (...args: any[]) => useQueryMock(...args),
+  keepPreviousData: {},
+}));
+
+function renderComponent(props?: Partial<React.ComponentProps<typeof GroupCreateTest>>) {
+  const auth = {
+    requestAuth: jest.fn().mockResolvedValue({ success: true }),
+    setToast: jest.fn(),
+    connectedProfile: { handle: 'alice' },
+  } as any;
+  render(
+    <AuthContext.Provider value={auth}>
+      <GroupCreateTest
+        groupConfig={{ name: 'name', group: {} } as any}
+        disabled={false}
+        {...props}
+      />
+    </AuthContext.Provider>
+  );
+  return { auth };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('disables button when disabled prop true', () => {
+  render(
+    <AuthContext.Provider value={{} as any}>
+      <GroupCreateTest groupConfig={{} as any} disabled={true} />
+    </AuthContext.Provider>
+  );
+  expect(screen.getByRole('button', { name: 'Test' })).toBeDisabled();
+});
+
+test('calls mutation and displays loader on click', async () => {
+  const { auth } = renderComponent();
+  const button = screen.getByRole('button', { name: 'Test' });
+
+  await fireEvent.click(button);
+
+  await waitFor(() => expect(auth.requestAuth).toHaveBeenCalled());
+  expect(mutateAsyncMock).toHaveBeenCalledWith({
+    name: 'name',
+    group: {},
+  });
+});

--- a/__tests__/components/groups/page/create/config/GroupCreateLevel.test.tsx
+++ b/__tests__/components/groups/page/create/config/GroupCreateLevel.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import GroupCreateLevel from '../../../../../../../components/groups/page/create/config/GroupCreateLevel';
+
+jest.mock('../../../../../../../components/groups/page/create/config/common/GroupCreateNumericValue', () => ({
+  __esModule: true,
+  default: (props: any) => {
+    mockProps = props;
+    return <div data-testid="numeric" />;
+  }
+}));
+
+let mockProps: any = null;
+
+describe('GroupCreateLevel', () => {
+  it('passes value and setValue to GroupCreateNumericValue', () => {
+    const setLevel = jest.fn();
+    const level = { min: 2 } as any;
+    const { getByTestId } = render(<GroupCreateLevel level={level} setLevel={setLevel} />);
+    expect(getByTestId('numeric')).toBeInTheDocument();
+    expect(mockProps.value).toBe(2);
+    expect(mockProps.label).toBe('Level at least');
+    mockProps.setValue(5);
+    expect(setLevel).toHaveBeenCalledWith({ ...level, min: 5 });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for GroupCreateWrapper
- add tests for GroupCreateTest button behavior
- add tests for GroupCreateLevel config component

## Testing
- `npm run improve-coverage` *(fails: Script didn't finish due to environment)*