### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/components/groups/page/create/actions/GroupCreateTest.test.tsx
+++ b/__tests__/components/groups/page/create/actions/GroupCreateTest.test.tsx
@@ -25,6 +25,7 @@ const useQueryMock = jest.fn(() => ({ isFetching: false, data: undefined }));
 
 jest.mock('@tanstack/react-query', () => ({
   useMutation: (opts: any) => useMutationMock(opts),
+  // @ts-expect-error - test mock
   useQuery: (...args: any[]) => useQueryMock(...args),
   keepPreviousData: {},
 }));

--- a/__tests__/components/groups/page/create/config/GroupCreateLevel.test.tsx
+++ b/__tests__/components/groups/page/create/config/GroupCreateLevel.test.tsx
@@ -1,8 +1,8 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import GroupCreateLevel from '../../../../../../../components/groups/page/create/config/GroupCreateLevel';
+import GroupCreateLevel from '../../../../../../components/groups/page/create/config/GroupCreateLevel';
 
-jest.mock('../../../../../../../components/groups/page/create/config/common/GroupCreateNumericValue', () => ({
+jest.mock('../../../../../../components/groups/page/create/config/common/GroupCreateNumericValue', () => ({
   __esModule: true,
   default: (props: any) => {
     mockProps = props;

--- a/__tests__/components/groups/page/create/config/GroupCreateRep.test.tsx
+++ b/__tests__/components/groups/page/create/config/GroupCreateRep.test.tsx
@@ -1,0 +1,76 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import GroupCreateRep from '../../../../../../components/groups/page/create/config/GroupCreateRep';
+import { ApiGroupFilterDirection } from '../../../../../../generated/models/ApiGroupFilterDirection';
+import { ApiCreateGroupDescription } from '../../../../../../generated/models/ApiCreateGroupDescription';
+
+let identityProps: any = null;
+let repCategoryProps: any = null;
+let numericProps: any = null;
+let directionProps: any = null;
+let toggleProps: any = null;
+
+jest.mock('../../../../../../components/groups/page/create/config/common/GroupCreateDirection', () => ({
+  __esModule: true,
+  default: (props: any) => { directionProps = props; return <div data-testid="direction" />; }
+}));
+jest.mock('../../../../../../components/utils/input/identity/IdentitySearch', () => ({
+  __esModule: true,
+  IdentitySearchSize: { MD: 'md' },
+  default: (props: any) => { identityProps = props; return <div data-testid="identity" />; }
+}));
+jest.mock('../../../../../../components/utils/input/rep-category/RepCategorySearch', () => ({
+  __esModule: true,
+  RepCategorySearchSize: { MD: 'md' },
+  default: (props: any) => { repCategoryProps = props; return <div data-testid="category" />; }
+}));
+jest.mock('../../../../../../components/groups/page/create/config/common/GroupCreateNumericValue', () => ({
+  __esModule: true,
+  default: (props: any) => { numericProps = props; return <div data-testid="numeric" />; }
+}));
+jest.mock('../../../../../../components/groups/page/create/config/rep/PositiveOnlyToggle', () => ({
+  __esModule: true,
+  default: (props: any) => { toggleProps = props; return <div data-testid="toggle" />; }
+}));
+
+function renderComponent(rep: ApiCreateGroupDescription['rep'], setRep: jest.Mock) {
+  return render(<GroupCreateRep rep={rep} setRep={setRep} />);
+}
+
+
+describe('GroupCreateRep', () => {
+  beforeEach(() => {
+    identityProps = null;
+    repCategoryProps = null;
+    numericProps = null;
+    directionProps = null;
+    toggleProps = null;
+  });
+
+  it('renders identity search with default label when no direction', () => {
+    const setRep = jest.fn();
+    const rep: ApiCreateGroupDescription['rep'] = { user_identity: null, category: null, min: 1, direction: null } as any;
+    const { getByTestId } = renderComponent(rep, setRep);
+    expect(getByTestId('identity')).toBeInTheDocument();
+    expect(identityProps.label).toBe('Identity');
+    identityProps.setIdentity('alice');
+    expect(setRep).toHaveBeenCalledWith({ ...rep, user_identity: 'alice' });
+    numericProps.setValue(5);
+    expect(setRep).toHaveBeenCalledWith({ ...rep, min: 5 });
+  });
+
+  it('shows direction component when user_identity and direction present', () => {
+    const setRep = jest.fn();
+    const rep: ApiCreateGroupDescription['rep'] = { user_identity: 'u1', category: 'c1', min: 0, direction: ApiGroupFilterDirection.Sent } as any;
+    const { getByTestId } = renderComponent(rep, setRep);
+    expect(getByTestId('direction')).toBeInTheDocument();
+    expect(directionProps.direction).toBe(ApiGroupFilterDirection.Sent);
+    expect(identityProps.label).toBe('To Identity');
+    repCategoryProps.setCategory('new');
+    expect(setRep).toHaveBeenCalledWith({ ...rep, category: 'new' });
+    directionProps.setDirection(ApiGroupFilterDirection.Received);
+    expect(setRep).toHaveBeenCalledWith({ ...rep, direction: ApiGroupFilterDirection.Received });
+    expect(toggleProps).toBeDefined();
+  });
+});
+

--- a/__tests__/components/groups/page/create/config/nfts/GroupCreateNfts.test.tsx
+++ b/__tests__/components/groups/page/create/config/nfts/GroupCreateNfts.test.tsx
@@ -1,0 +1,57 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import GroupCreateNfts from '../../../../../../../components/groups/page/create/config/nfts/GroupCreateNfts';
+import { ApiGroupOwnsNftNameEnum } from '../../../../../../../generated/models/ApiGroupOwnsNft';
+import { MEMES_CONTRACT } from '../../../../../../../constants';
+
+let selectProps: any = null;
+let selectedProps: any = null;
+
+jest.mock('../../../../../../../components/groups/page/create/config/nfts/GroupCreateNftsSelect', () => ({
+  __esModule: true,
+  default: (props: any) => { selectProps = props; return <div data-testid="select" />; }
+}));
+jest.mock('../../../../../../../components/groups/page/create/config/nfts/GroupCreateNftsSelected', () => ({
+  __esModule: true,
+  default: (props: any) => { selectedProps = props; return <div data-testid="selected" />; }
+}));
+
+const gradients = {
+  name: ApiGroupOwnsNftNameEnum.Gradients,
+  tokens: ['1']
+};
+
+function renderComponent(nfts: any[], setNfts: jest.Mock) {
+  return render(<GroupCreateNfts nfts={nfts} setNfts={setNfts} />);
+}
+
+
+describe('GroupCreateNfts', () => {
+  beforeEach(() => {
+    selectProps = null;
+    selectedProps = null;
+  });
+
+  it('passes props to child components', () => {
+    const setNfts = jest.fn();
+    renderComponent([gradients], setNfts);
+    expect(selectProps.selected).toEqual([gradients]);
+    expect(selectedProps.selected).toEqual([gradients]);
+  });
+
+  it('handles selecting and removing tokens', () => {
+    const setNfts = jest.fn();
+    renderComponent([], setNfts);
+    const item = { id: '2', contract: '0x0000' } as any;
+    selectProps.onSelect(item);
+    expect(setNfts).not.toHaveBeenCalled();
+    const validItem = { id: '3', contract: MEMES_CONTRACT } as any;
+    selectProps.onSelect(validItem);
+    expect(setNfts).toHaveBeenCalledWith([{ name: ApiGroupOwnsNftNameEnum.Memes, tokens: ['3'] }]);
+
+    setNfts.mockClear();
+    selectedProps.onRemove({ name: ApiGroupOwnsNftNameEnum.Memes, token: '3' });
+    expect(setNfts).toHaveBeenCalledWith([]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for GroupCreateRep component
- add tests for GroupCreateNfts component
- fix relative paths in GroupCreateLevel tests
- add ts-expect-error for test query mock

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
