### PR TITLE
test: fix group create tests

### DIFF
--- a/__tests__/components/groups/page/create/actions/GroupCreateTest.test.tsx
+++ b/__tests__/components/groups/page/create/actions/GroupCreateTest.test.tsx
@@ -25,7 +25,8 @@ const useQueryMock = jest.fn(() => ({ isFetching: false, data: undefined }));
 
 jest.mock('@tanstack/react-query', () => ({
   useMutation: (opts: any) => useMutationMock(opts),
-  useQuery: (...args: any[]) => useQueryMock(...args),
+  // Cast to any to avoid tuple spread type issues
+  useQuery: (...args: any[]) => (useQueryMock as any)(...args),
   keepPreviousData: {},
 }));
 

--- a/__tests__/components/groups/page/create/config/GroupCreateLevel.test.tsx
+++ b/__tests__/components/groups/page/create/config/GroupCreateLevel.test.tsx
@@ -1,8 +1,8 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import GroupCreateLevel from '../../../../../../../components/groups/page/create/config/GroupCreateLevel';
+import GroupCreateLevel from '../../../../../../components/groups/page/create/config/GroupCreateLevel';
 
-jest.mock('../../../../../../../components/groups/page/create/config/common/GroupCreateNumericValue', () => ({
+jest.mock('../../../../../../components/groups/page/create/config/common/GroupCreateNumericValue', () => ({
   __esModule: true,
   default: (props: any) => {
     mockProps = props;


### PR DESCRIPTION
## Summary
- correct relative paths in GroupCreateLevel tests
- silence tuple spread issue in GroupCreateTest mocks

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
