### PR TITLE
Fix GroupCreateLevel test path

### DIFF
--- a/__tests__/components/groups/page/create/config/GroupCreateLevel.test.tsx
+++ b/__tests__/components/groups/page/create/config/GroupCreateLevel.test.tsx
@@ -1,8 +1,8 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import GroupCreateLevel from '../../../../../../../components/groups/page/create/config/GroupCreateLevel';
+import GroupCreateLevel from '../../../../../../components/groups/page/create/config/GroupCreateLevel';
 
-jest.mock('../../../../../../../components/groups/page/create/config/common/GroupCreateNumericValue', () => ({
+jest.mock('../../../../../../components/groups/page/create/config/common/GroupCreateNumericValue', () => ({
   __esModule: true,
   default: (props: any) => {
     mockProps = props;


### PR DESCRIPTION
## Summary
- fix relative imports in GroupCreateLevel.test

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test __tests__/components/groups/page/create/config/GroupCreateLevel.test.tsx`
