### PR TITLE
Fix path errors in group tests

### DIFF
--- a/__tests__/components/groups/page/create/actions/GroupCreateTest.test.tsx
+++ b/__tests__/components/groups/page/create/actions/GroupCreateTest.test.tsx
@@ -21,7 +21,7 @@ const useMutationMock = jest.fn((options: any) => {
   return { mutateAsync: mutateAsyncMock };
 });
 
-const useQueryMock = jest.fn(() => ({ isFetching: false, data: undefined }));
+const useQueryMock = jest.fn((...args: any[]) => ({ isFetching: false, data: undefined }));
 
 jest.mock('@tanstack/react-query', () => ({
   useMutation: (opts: any) => useMutationMock(opts),

--- a/__tests__/components/groups/page/create/config/GroupCreateLevel.test.tsx
+++ b/__tests__/components/groups/page/create/config/GroupCreateLevel.test.tsx
@@ -1,8 +1,8 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import GroupCreateLevel from '../../../../../../../components/groups/page/create/config/GroupCreateLevel';
+import GroupCreateLevel from '../../../../../../components/groups/page/create/config/GroupCreateLevel';
 
-jest.mock('../../../../../../../components/groups/page/create/config/common/GroupCreateNumericValue', () => ({
+jest.mock('../../../../../../components/groups/page/create/config/common/GroupCreateNumericValue', () => ({
   __esModule: true,
   default: (props: any) => {
     mockProps = props;


### PR DESCRIPTION
## Summary
- adjust test paths for GroupCreateLevel mocks
- update query mock to avoid TypeScript errors

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
