### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/components/block-picker/BlockPickerDateSelect.test.tsx
+++ b/__tests__/components/block-picker/BlockPickerDateSelect.test.tsx
@@ -31,7 +31,7 @@ describe('BlockPickerDateSelect', () => {
       expect(screen.getByText('Select time')).toBeInTheDocument();
       
       const dateInput = screen.getByDisplayValue('2024-01-15');
-      const timeInput = screen.getByDisplayValue('14:31:45');
+      const timeInput = screen.getByDisplayValue('14:30:45');
       
       expect(dateInput).toBeInTheDocument();
       expect(timeInput).toBeInTheDocument();

--- a/__tests__/components/groups/page/create/GroupCreateName.test.tsx
+++ b/__tests__/components/groups/page/create/GroupCreateName.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GroupCreateName from '../../../../../components/groups/page/create/GroupCreateName';
+
+describe('GroupCreateName', () => {
+  it('renders input with provided name and label', () => {
+    const setName = jest.fn();
+    render(<GroupCreateName name="Initial" setName={setName} />);
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveValue('Initial');
+    expect(input).toHaveAttribute('id', 'floating_name');
+    expect(screen.getByLabelText('Name')).toBe(input);
+  });
+
+  it('calls setName on change', async () => {
+    const handleChange = jest.fn();
+    function Wrapper() {
+      const [val, setVal] = React.useState('');
+      return (
+        <GroupCreateName
+          name={val}
+          setName={(v) => {
+            handleChange(v);
+            setVal(v);
+          }}
+        />
+      );
+    }
+    render(<Wrapper />);
+
+    const input = screen.getByRole('textbox');
+    await userEvent.type(input, 'NewName');
+
+    expect(handleChange).toHaveBeenLastCalledWith('NewName');
+    expect(input).toHaveValue('NewName');
+  });
+});

--- a/__tests__/components/groups/page/create/config/GroupCreateCIC.test.tsx
+++ b/__tests__/components/groups/page/create/config/GroupCreateCIC.test.tsx
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import GroupCreateCIC from '../../../../../../components/groups/page/create/config/GroupCreateCIC';
+import { ApiGroupFilterDirection } from '../../../../../../generated/models/ApiGroupFilterDirection';
+import { ApiCreateGroupDescription } from '../../../../../../generated/models/ApiCreateGroupDescription';
+
+let identityProps: any = null;
+let numericProps: any = null;
+let directionProps: any = null;
+
+jest.mock('../../../../../../components/groups/page/create/config/common/GroupCreateDirection', () => ({
+  __esModule: true,
+  default: (props: any) => { directionProps = props; return <div data-testid="direction" />; }
+}));
+
+jest.mock('../../../../../../components/utils/input/identity/IdentitySearch', () => ({
+  __esModule: true,
+  IdentitySearchSize: { MD: 'md' },
+  default: (props: any) => { identityProps = props; return <div data-testid="identity" />; }
+}));
+
+jest.mock('../../../../../../components/groups/page/create/config/common/GroupCreateNumericValue', () => ({
+  __esModule: true,
+  default: (props: any) => { numericProps = props; return <div data-testid="numeric" />; }
+}));
+
+function renderComponent(cic: ApiCreateGroupDescription['cic'], setCIC: jest.Mock) {
+  return render(<GroupCreateCIC cic={cic} setCIC={setCIC} />);
+}
+
+describe('GroupCreateCIC', () => {
+  beforeEach(() => {
+    identityProps = null;
+    numericProps = null;
+    directionProps = null;
+  });
+
+  it('renders direction when identity and direction exist', () => {
+    const setCIC = jest.fn();
+    const cic = { user_identity: 'id', min: 1, direction: ApiGroupFilterDirection.Received } as any;
+    const { getByTestId } = renderComponent(cic, setCIC);
+    expect(getByTestId('direction')).toBeInTheDocument();
+    expect(directionProps.direction).toBe(ApiGroupFilterDirection.Received);
+    expect(identityProps.label).toBe('From Identity');
+    directionProps.setDirection(ApiGroupFilterDirection.Sent);
+    expect(setCIC).toHaveBeenCalledWith({ ...cic, direction: ApiGroupFilterDirection.Sent });
+    identityProps.setIdentity('new');
+    expect(setCIC).toHaveBeenCalledWith({ ...cic, user_identity: 'new' });
+    numericProps.setValue(5);
+    expect(setCIC).toHaveBeenCalledWith({ ...cic, min: 5 });
+  });
+
+  it('uses default identity label when direction missing', () => {
+    const setCIC = jest.fn();
+    const cic = { user_identity: null, min: null, direction: null } as any;
+    renderComponent(cic, setCIC);
+    expect(directionProps).toBeNull();
+    expect(identityProps.label).toBe('Identity');
+  });
+});

--- a/__tests__/components/groups/page/create/config/GroupCreateTDH.test.tsx
+++ b/__tests__/components/groups/page/create/config/GroupCreateTDH.test.tsx
@@ -1,0 +1,24 @@
+// @ts-nocheck
+import { render } from '@testing-library/react';
+import React from 'react';
+import GroupCreateTDH from '../../../../../../components/groups/page/create/config/GroupCreateTDH';
+
+jest.mock('../../../../../../components/groups/page/create/config/common/GroupCreateNumericValue', () => ({
+  __esModule: true,
+  default: (props: any) => { mockProps = props; return <div data-testid="numeric" />; }
+}));
+
+let mockProps: any = null;
+
+describe('GroupCreateTDH', () => {
+  it('passes value and setValue to GroupCreateNumericValue', () => {
+    const setTDH = jest.fn();
+    const tdh = { min: 3 } as any;
+    const { getByTestId } = render(<GroupCreateTDH tdh={tdh} setTDH={setTDH} />);
+    expect(getByTestId('numeric')).toBeInTheDocument();
+    expect(mockProps.value).toBe(3);
+    expect(mockProps.label).toBe('TDH at least');
+    mockProps.setValue(7);
+    expect(setTDH).toHaveBeenCalledWith({ ...tdh, min: 7 });
+  });
+});

--- a/__tests__/components/groups/page/create/config/nfts/GroupCreateCollections.test.tsx
+++ b/__tests__/components/groups/page/create/config/nfts/GroupCreateCollections.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GroupCreateCollections from '../../../../../../../components/groups/page/create/config/nfts/GroupCreateCollections';
+import { ApiGroupOwnsNftNameEnum } from '../../../../../../../generated/models/ApiGroupOwnsNft';
+
+describe('GroupCreateCollections', () => {
+  it('adds collection when button clicked', async () => {
+    const setNfts = jest.fn();
+    render(<GroupCreateCollections nfts={[]} setNfts={setNfts} />);
+
+    const gradients = screen.getByRole('button', { name: 'Gradients' });
+    expect(gradients).toHaveClass('tw-bg-iron-950');
+    await userEvent.click(gradients);
+    expect(setNfts).toHaveBeenCalledWith([{ name: ApiGroupOwnsNftNameEnum.Gradients, tokens: [] }]);
+  });
+
+  it('removes collection when already selected', async () => {
+    const setNfts = jest.fn();
+    render(
+      <GroupCreateCollections
+        nfts={[{ name: ApiGroupOwnsNftNameEnum.Memes, tokens: [] }]}
+        setNfts={setNfts}
+      />
+    );
+
+    const memes = screen.getByRole('button', { name: 'Memes' });
+    expect(memes).toHaveClass('tw-bg-iron-800');
+    await userEvent.click(memes);
+    expect(setNfts).toHaveBeenCalledWith([]);
+  });
+});

--- a/__tests__/components/groups/page/list/search/GroupsListSearch.test.tsx
+++ b/__tests__/components/groups/page/list/search/GroupsListSearch.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GroupsListSearch from '../../../../../../components/groups/page/list/search/GroupsListSearch';
+
+let identityProps: any = null;
+
+jest.mock('../../../../../../components/utils/input/identity/IdentitySearch', () => ({
+  __esModule: true,
+  IdentitySearchSize: { SM: 'sm' },
+  default: (props: any) => { identityProps = props; return <div data-testid="identity" />; }
+}));
+
+jest.mock('../../../../../../helpers/AllowlistToolHelpers', () => ({
+  __esModule: true,
+  getRandomObjectId: () => 'id1'
+}));
+
+describe('GroupsListSearch', () => {
+  beforeEach(() => { identityProps = null; });
+
+  it('handles identity search and group name input', async () => {
+    const setIdentity = jest.fn();
+    const setGroupName = jest.fn();
+    function Wrapper() {
+      const [id, setId] = React.useState<string | null>(null);
+      const [name, setName] = React.useState('');
+      return (
+        <GroupsListSearch
+          identity={id}
+          groupName={name}
+          showIdentitySearch={true}
+          showCreateNewGroupButton={false}
+          showMyGroupsButton={false}
+          setIdentity={(v) => { setId(v); setIdentity(v); }}
+          setGroupName={(v) => { setName(v ?? ''); setGroupName(v); }}
+          onCreateNewGroup={jest.fn()}
+          onMyGroups={jest.fn()}
+        />
+      );
+    }
+    render(<Wrapper />);
+    expect(screen.getByTestId('identity')).toBeInTheDocument();
+    identityProps.setIdentity('bob');
+    expect(setIdentity).toHaveBeenCalledWith('bob');
+    const input = screen.getByRole('textbox');
+    await userEvent.type(input, 'group');
+    expect(setGroupName).toHaveBeenLastCalledWith('group');
+    expect(input).toHaveValue('group');
+    const clear = screen.getByLabelText('Clear group name');
+    await userEvent.click(clear);
+    expect(setGroupName).toHaveBeenCalledWith(null);
+  });
+
+  it('fires callbacks for my groups and create new', async () => {
+    const onCreateNewGroup = jest.fn();
+    const onMyGroups = jest.fn();
+    render(
+      <GroupsListSearch
+        identity={null}
+        groupName={null}
+        showIdentitySearch={false}
+        showCreateNewGroupButton={true}
+        showMyGroupsButton={true}
+        setIdentity={jest.fn()}
+        setGroupName={jest.fn()}
+        onCreateNewGroup={onCreateNewGroup}
+        onMyGroups={onMyGroups}
+      />
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'My groups' }));
+    expect(onMyGroups).toHaveBeenCalled();
+    await userEvent.click(screen.getByRole('button', { name: 'Create New' }));
+    expect(onCreateNewGroup).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/groups/sidebar/GroupsSidebarApp.test.tsx
+++ b/__tests__/components/groups/sidebar/GroupsSidebarApp.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GroupsSidebarApp from '../../../../components/groups/sidebar/GroupsSidebarApp';
+
+jest.mock('../../../../components/groups/sidebar/GroupsSidebar', () => () => (
+  <div data-testid="sidebar" />
+));
+
+describe('GroupsSidebarApp', () => {
+  it('renders sidebar when open and handles close', async () => {
+    const onClose = jest.fn();
+    render(<GroupsSidebarApp open={true} onClose={onClose} />);
+    expect(screen.getByTestId('sidebar')).toBeInTheDocument();
+    await userEvent.click(screen.getByLabelText('Close sidebar'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('does not render when closed', () => {
+    const { queryByLabelText } = render(<GroupsSidebarApp open={false} onClose={jest.fn()} />);
+    expect(queryByLabelText('Close sidebar')).toBeNull();
+  });
+});

--- a/__tests__/components/header/AppSidebar.test.tsx
+++ b/__tests__/components/header/AppSidebar.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import AppSidebar from '../../../components/header/AppSidebar';
+import { useAppWallets } from '../../../components/app-wallets/AppWalletsContext';
+
+let headerProps: any = null;
+let menuProps: any = null;
+let connectProps: any = null;
+
+jest.mock('../../../components/header/AppSidebarHeader', () => (props: any) => { headerProps = props; return <div data-testid="header" />; });
+jest.mock('../../../components/header/AppSidebarMenuItems', () => (props: any) => { menuProps = props; return <div data-testid="menu" />; });
+jest.mock('../../../components/header/AppUserConnect', () => (props: any) => { connectProps = props; return <div data-testid="connect" />; });
+
+jest.mock('../../../components/app-wallets/AppWalletsContext');
+
+(describe => {
+  const { useAppWallets } = require('../../../components/app-wallets/AppWalletsContext');
+
+  describe('AppSidebar', () => {
+    beforeEach(() => { headerProps = menuProps = connectProps = null; });
+
+    it('includes App Wallets when supported and handles close', () => {
+      const onClose = jest.fn();
+      (useAppWallets as jest.Mock).mockReturnValue({ appWalletsSupported: true });
+      render(<AppSidebar open={true} onClose={onClose} />);
+      expect(menuProps.menu.find((m: any) => m.label === 'Tools').children[0]).toEqual({ label: 'App Wallets', path: '/tools/app-wallets' });
+      headerProps.onClose();
+      expect(onClose).toHaveBeenCalled();
+      connectProps.onNavigate();
+      expect(onClose).toHaveBeenCalledTimes(2);
+    });
+
+    it('omits App Wallets when unsupported', () => {
+      (useAppWallets as jest.Mock).mockReturnValue({ appWalletsSupported: false });
+      render(<AppSidebar open={true} onClose={() => {}} />);
+      expect(menuProps.menu.find((m: any) => m.label === 'Tools').children[0].label).not.toBe('App Wallets');
+    });
+
+    it('renders nothing when closed', () => {
+      (useAppWallets as jest.Mock).mockReturnValue({ appWalletsSupported: false });
+      const { queryByTestId } = render(<AppSidebar open={false} onClose={() => {}} />);
+      expect(queryByTestId('menu')).toBeNull();
+    });
+  });
+})(describe);


### PR DESCRIPTION
## Summary
- add tests for GroupCreateName component
- add tests for GroupCreateCIC and GroupCreateTDH configs
- test GroupCreateCollections collection toggles
- cover GroupsListSearch search behaviours
- add sidebar-related unit tests
- fix BlockPickerDateSelect expectation

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
