### PR TITLE
Add tests for CreatePhasesForm

### DIFF
--- a/__tests__/components/block-picker/BlockPickerDateSelect.test.tsx
+++ b/__tests__/components/block-picker/BlockPickerDateSelect.test.tsx
@@ -31,7 +31,7 @@ describe('BlockPickerDateSelect', () => {
       expect(screen.getByText('Select time')).toBeInTheDocument();
       
       const dateInput = screen.getByDisplayValue('2024-01-15');
-      const timeInput = screen.getByDisplayValue('14:31:45');
+      const timeInput = screen.getByDisplayValue('14:30:45');
       
       expect(dateInput).toBeInTheDocument();
       expect(timeInput).toBeInTheDocument();

--- a/__tests__/components/distribution-plan-tool/create-phases/form/CreatePhasesForm.test.tsx
+++ b/__tests__/components/distribution-plan-tool/create-phases/form/CreatePhasesForm.test.tsx
@@ -1,0 +1,60 @@
+jest.mock('../../../../../services/distribution-plan-api');
+jest.mock('../../../../../helpers/AllowlistToolHelpers', () => {
+  const actual = jest.requireActual('../../../../../helpers/AllowlistToolHelpers');
+  return { __esModule: true, ...actual, getRandomObjectId: jest.fn(() => 'phase-1') };
+});
+jest.mock('../../../../../components/distribution-plan-tool/common/DistributionPlanAddOperationBtn', () => ({ children, loading }: any) => (
+  <button type="submit" disabled={loading}>{children}</button>
+));
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreatePhasesForm from '../../../../../components/distribution-plan-tool/create-phases/form/CreatePhasesForm';
+import { DistributionPlanToolContext } from '../../../../../components/distribution-plan-tool/DistributionPlanToolContext';
+import { distributionPlanApiPost } from '../../../../../services/distribution-plan-api';
+import { AllowlistOperationCode } from '../../../../../components/allowlist-tool/allowlist-tool.types';
+
+function renderForm(ctx?: Partial<React.ContextType<typeof DistributionPlanToolContext>>) {
+  const defaultCtx = { distributionPlan: { id: 'dp1' }, fetchOperations: jest.fn(), setToasts: jest.fn() } as any;
+  return {
+    ctx: { ...defaultCtx, ...ctx },
+    ...render(
+      <DistributionPlanToolContext.Provider value={{ ...defaultCtx, ...ctx }}>
+        <CreatePhasesForm />
+      </DistributionPlanToolContext.Provider>
+    )
+  };
+}
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('CreatePhasesForm', () => {
+  it('submits phase and resets input on success', async () => {
+    (distributionPlanApiPost as jest.Mock).mockResolvedValue({ success: true, data: {} });
+    const { ctx } = renderForm();
+    const input = screen.getByPlaceholderText('Name of Phase');
+    await userEvent.type(input, 'Phase 1');
+    await userEvent.click(screen.getByRole('button', { name: /add phase/i }));
+    await waitFor(() => expect(distributionPlanApiPost).toHaveBeenCalled());
+    const call = (distributionPlanApiPost as jest.Mock).mock.calls[0][0];
+    expect(call).toEqual(expect.objectContaining({
+      endpoint: '/allowlists/dp1/operations'
+    }));
+    expect(call.body.code).toBe(AllowlistOperationCode.ADD_PHASE);
+    await waitFor(() => expect(ctx.fetchOperations).toHaveBeenCalledWith('dp1'));
+    expect(input).toHaveValue('');
+  });
+
+  it('keeps input when request fails', async () => {
+    (distributionPlanApiPost as jest.Mock).mockResolvedValue({ success: false });
+    const { ctx } = renderForm();
+    const input = screen.getByPlaceholderText('Name of Phase');
+    await userEvent.type(input, 'Phase 1');
+    await userEvent.click(screen.getByRole('button', { name: /add phase/i }));
+    await waitFor(() => expect(distributionPlanApiPost).toHaveBeenCalled());
+    expect(ctx.fetchOperations).not.toHaveBeenCalled();
+    expect(input).toHaveValue('Phase 1');
+  });
+});


### PR DESCRIPTION
## Summary
- fix incorrect expected time value in BlockPickerDateSelect test
- add tests for CreatePhasesForm functionality

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test -- --runTestsByPath __tests__/components/distribution-plan-tool/create-phases/form/CreatePhasesForm.test.tsx __tests__/components/block-picker/BlockPickerDateSelect.test.tsx`