### PR TITLE
Increase test coverage for components

### DIFF
--- a/__tests__/components/block-picker/BlockPickerDateSelect.test.tsx
+++ b/__tests__/components/block-picker/BlockPickerDateSelect.test.tsx
@@ -31,7 +31,7 @@ describe('BlockPickerDateSelect', () => {
       expect(screen.getByText('Select time')).toBeInTheDocument();
       
       const dateInput = screen.getByDisplayValue('2024-01-15');
-      const timeInput = screen.getByDisplayValue('14:31:45');
+      const timeInput = screen.getByDisplayValue('14:30:45');
       
       expect(dateInput).toBeInTheDocument();
       expect(timeInput).toBeInTheDocument();

--- a/__tests__/components/distribution-plan-tool/create-phases/form/CreatePhasesForm.test.tsx
+++ b/__tests__/components/distribution-plan-tool/create-phases/form/CreatePhasesForm.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreatePhasesForm from '../../../../../components/distribution-plan-tool/create-phases/form/CreatePhasesForm';
+import { DistributionPlanToolContext } from '../../../../../components/distribution-plan-tool/DistributionPlanToolContext';
+import { distributionPlanApiPost } from '../../../../../services/distribution-plan-api';
+import { getRandomObjectId } from '../../../../../helpers/AllowlistToolHelpers';
+
+jest.mock('../../../../../components/distribution-plan-tool/common/DistributionPlanAddOperationBtn', () => ({ children }: any) => (
+  <button type="submit">{children}</button>
+));
+
+jest.mock('../../../../../services/distribution-plan-api');
+jest.mock('../../../../../helpers/AllowlistToolHelpers');
+
+const postMock = distributionPlanApiPost as jest.Mock;
+(getRandomObjectId as jest.Mock).mockReturnValue('phase-id');
+
+const ctx = {
+  distributionPlan: { id: 'd1' },
+  setToasts: jest.fn(),
+  fetchOperations: jest.fn(),
+};
+
+function renderForm() {
+  return render(
+    <DistributionPlanToolContext.Provider value={ctx as any}>
+      <CreatePhasesForm />
+    </DistributionPlanToolContext.Provider>
+  );
+}
+
+describe('CreatePhasesForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('submits and resets on success', async () => {
+    postMock.mockResolvedValue({ success: true, data: {} });
+    renderForm();
+    await userEvent.type(screen.getByPlaceholderText('Name of Phase'), 'Phase1');
+    await userEvent.click(screen.getByRole('button', { name: /add phase/i }));
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    expect(postMock).toHaveBeenCalledWith({
+      endpoint: '/allowlists/d1/operations',
+      body: {
+        code: 'ADD_PHASE',
+        params: { id: 'phase-id', name: 'Phase1', description: 'Phase1' },
+      },
+    });
+    expect(ctx.fetchOperations).toHaveBeenCalledWith('d1');
+    expect((screen.getByPlaceholderText('Name of Phase') as HTMLInputElement).value).toBe('');
+  });
+
+  it('does not reset when api fails', async () => {
+    postMock.mockResolvedValue({ success: false, data: null });
+    renderForm();
+    const input = screen.getByPlaceholderText('Name of Phase') as HTMLInputElement;
+    await userEvent.type(input, 'Fail');
+    await userEvent.click(screen.getByRole('button', { name: /add phase/i }));
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    expect(ctx.fetchOperations).not.toHaveBeenCalled();
+    expect(input.value).toBe('Fail');
+  });
+});

--- a/__tests__/components/nextGen/NextGenCollections.test.tsx
+++ b/__tests__/components/nextGen/NextGenCollections.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NextGenCollections from '../../../components/nextGen/collections/NextGenCollections';
+import { fetchUrl } from '../../../services/6529api';
+
+jest.mock('../../../services/6529api', () => ({
+  fetchUrl: jest.fn(),
+}));
+
+jest.mock('../../../components/nextGen/collections/NextGenCollectionPreview', () => (props: any) => (
+  <div data-testid="preview">{props.collection.name}</div>
+));
+
+jest.mock('../../../components/pagination/Pagination', () => (props: any) => (
+  <div data-testid="pagination" onClick={() => props.setPage(props.page + 1)}>
+    page {props.page}
+  </div>
+));
+
+const fetchUrlMock = fetchUrl as jest.Mock;
+
+function setup(mockData: any) {
+  process.env.API_ENDPOINT = 'https://api.test';
+  fetchUrlMock.mockResolvedValue(mockData);
+  render(<NextGenCollections />);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('NextGenCollections', () => {
+  it('displays returned collections', async () => {
+    setup({ count: 1, data: [{ id: 1, name: 'Col1', artist: 'Alice', image: 'img' }] });
+    await waitFor(() => expect(fetchUrlMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByTestId('preview')).toBeInTheDocument());
+    expect(screen.getByTestId('preview')).toHaveTextContent('Col1');
+  });
+
+  it('shows no collections message when none returned', async () => {
+    setup({ count: 0, data: [] });
+    await waitFor(() => expect(fetchUrlMock).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('No collections found')).toBeInTheDocument();
+  });
+
+  it('fetches new results when status filter changes', async () => {
+    // first two calls on mount return data
+    fetchUrlMock.mockResolvedValueOnce({ count: 1, data: [{ id: 1, name: 'First', artist: 'A', image: 'img' }] });
+    fetchUrlMock.mockResolvedValueOnce({ count: 1, data: [{ id: 1, name: 'First', artist: 'A', image: 'img' }] });
+    // call after filter change
+    fetchUrlMock.mockResolvedValueOnce({ count: 0, data: [] });
+
+    process.env.API_ENDPOINT = 'https://api.test';
+    render(<NextGenCollections />);
+
+    await waitFor(() => expect(fetchUrlMock).toHaveBeenCalledTimes(2));
+
+    await userEvent.click(screen.getByRole('button', { name: /Status:/i }));
+    await userEvent.click(screen.getByText('LIVE'));
+
+    await waitFor(() => expect(fetchUrlMock).toHaveBeenCalledTimes(3));
+    expect(fetchUrlMock).toHaveBeenLastCalledWith(
+      'https://api.test/api/nextgen/collections?page_size=25&page=1&status=LIVE'
+    );
+    expect(screen.getByText('Status: LIVE')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- fix BlockPickerDateSelect expectation
- add tests for NextGenCollections component
- add tests for CreatePhasesForm component

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
