### PR TITLE
Adjust coverage script workflow

### DIFF
--- a/scripts/coverage_prompt.md
+++ b/scripts/coverage_prompt.md
@@ -1,14 +1,12 @@
 ## Enhanced Test Coverage Prompt
 
 **Task:**
-Iteratively enhance the project's test suite to achieve both quantitative coverage targets (+0.2% above baseline) and qualitative testing excellence through comprehensive real-world scenarios, within a time-boxed constraint.
+Iteratively enhance the project's test suite with high-quality tests focused on real-world scenarios. Continue improving coverage until the time limit is nearly reached, then finalize your work and prepare a pull request.
 
 **Time Management:**
-- The coverage improvement task has a **20-minute time limit** (configurable via `TIME_LIMIT_MINUTES` environment variable)
-- The task will complete successfully when either:
-  - The coverage target is reached (+0.2% above baseline), OR
-  - The time limit is reached
-- This prevents endless iteration while encouraging focused, incremental improvements
+- The coverage improvement task has a **configurable time limit** (default 60 minutes via `TIME_LIMIT_MINUTES`).
+- The script will run until the time limit is nearly reached. When time is close to expiring, wrap up your current work and submit a pull request.
+- This allows for longer sessions while still preventing endless iteration.
 
 **Testing Philosophy:**
 - Coverage percentage is a metric, not the goal
@@ -22,7 +20,7 @@ Iteratively enhance the project's test suite to achieve both quantitative covera
    - The script will use the environment variables you set up
 
 2. **Parse Output:** Analyze the coverage report for:
-   - Current coverage percentage vs. target
+   - Current coverage percentage
    - Time elapsed and remaining
    - Specific files needing coverage
 
@@ -179,7 +177,7 @@ Iteratively enhance the project's test suite to achieve both quantitative covera
 - Ensure tests document expected behavior
 
 **Success Criteria:**
-- Coverage target is met (+0.2%) OR time limit is reached
+- Time limit is reached with meaningful tests added
 - No test is written solely for coverage
 - Each test adds value by preventing a potential bug
 - Test suite serves as living documentation
@@ -187,7 +185,7 @@ Iteratively enhance the project's test suite to achieve both quantitative covera
 - New developers can understand system behavior from tests
 
 **Time-Based Completion:**
-When the 20-minute limit is reached before the coverage target:
+When the time limit is reached:
 - The task is marked as complete (successful exit)
 - Progress is preserved for the next session
 - Focus on test quality over rushing to meet coverage
@@ -196,20 +194,14 @@ When the 20-minute limit is reached before the coverage target:
 
 **Example Output Scenarios:**
 
-1. **Target Reached:**
+1. **Time Limit Reached:**
    ```
-   current: 75.20%
-   Success: Current coverage has met or exceeded the target. Task completed.
-   ```
-
-2. **Time Limit Reached:**
-   ```
-   elapsed time: 20.1 minutes
-   Success: Time limit of 20 minutes has been reached. Task completed due to time constraint.
-   Final coverage: 75.15% (target was 75.20%)
+   elapsed time: 60.0 minutes
+   Success: Time limit reached. Task completed due to time constraint.
+   Final coverage: 75.15%
    ```
 
-3. **In Progress:**
+2. **In Progress:**
    ```
    elapsed time: 12.3 minutes
    Time remaining: 7.7 minutes until automatic completion.

--- a/scripts/improve-coverage.js
+++ b/scripts/improve-coverage.js
@@ -54,7 +54,7 @@ const COVERAGE_INCREMENT_PERCENT_ENV = parseFloat(
 );
 const COVERAGE_INCREMENT_PERCENT = !isNaN(COVERAGE_INCREMENT_PERCENT_ENV)
   ? COVERAGE_INCREMENT_PERCENT_ENV
-  : 0.2;
+  : 0;
 
 // Add time limit configuration
 const TIME_LIMIT_MINUTES_ENV = parseFloat(
@@ -62,7 +62,7 @@ const TIME_LIMIT_MINUTES_ENV = parseFloat(
 );
 const TIME_LIMIT_MINUTES = !isNaN(TIME_LIMIT_MINUTES_ENV)
   ? TIME_LIMIT_MINUTES_ENV
-  : 20;
+  : 60;
 
 function run(command) {
   execSync(command, { stdio: "inherit" });
@@ -309,30 +309,17 @@ function main() {
   }
 
   console.log(`initial: ${initialCoverage.toFixed(2)}%`);
-  console.log(`target: ${targetCoverage.toFixed(2)}%`);
   console.log(`current: ${currentCoverage.toFixed(2)}%`);
 
   // Check time constraint
   const elapsedMinutes = (Date.now() - startTime) / 1000 / 60;
   console.log(`elapsed time: ${elapsedMinutes.toFixed(1)} minutes`);
 
-  if (currentCoverage >= targetCoverage) {
-    console.log(
-      `\nSuccess: Current coverage of ${currentCoverage.toFixed(
-        2
-      )}% has met or exceeded the target of ${targetCoverage.toFixed(
-        2
-      )}%. Task completed.`
-    );
-  } else if (elapsedMinutes >= TIME_LIMIT_MINUTES) {
+  if (elapsedMinutes >= TIME_LIMIT_MINUTES) {
     console.log(
       `\nSuccess: Time limit of ${TIME_LIMIT_MINUTES} minutes has been reached. Task completed due to time constraint.`
     );
-    console.log(
-      `Final coverage: ${currentCoverage.toFixed(
-        2
-      )}% (target was ${targetCoverage.toFixed(2)}%)`
-    );
+    console.log(`Final coverage: ${currentCoverage.toFixed(2)}%`);
   } else {
     const remainingMinutes = TIME_LIMIT_MINUTES - elapsedMinutes;
     console.log(
@@ -358,11 +345,7 @@ function main() {
         );
       } else {
         console.log(
-          `\nInfo: All individual files meet the 80% threshold. However, current coverage of ${currentCoverage.toFixed(
-            2
-          )}% has not yet reached the target of ${targetCoverage.toFixed(
-            2
-          )}%. Please add more tests to any module to increase the overall percentage. Then re-run 'npm run improve-coverage'.`
+          `\nInfo: All individual files meet the 80% threshold. Please add more tests to increase the overall percentage and re-run 'npm run improve-coverage'.`
         );
       }
     }


### PR DESCRIPTION
## Summary
- relax coverage improvement instructions
- extend default time limit for improving coverage
- update the improve-coverage script to only stop on time limit

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
