### PR TITLE
Add tests for ImageComponent and Groups page

### DIFF
--- a/__tests__/components/drops/create/lexical/nodes/ImageComponent.test.tsx
+++ b/__tests__/components/drops/create/lexical/nodes/ImageComponent.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import ImageComponent from '../../../../../../components/drops/create/lexical/nodes/ImageComponent';
+import CircleLoader, { CircleLoaderSize } from '../../../../../../components/distribution-plan-tool/common/CircleLoader';
+
+jest.mock('../../../../../../components/distribution-plan-tool/common/CircleLoader', () => ({
+  __esModule: true,
+  default: jest.fn(() => <div data-testid="loader" />),
+  CircleLoaderSize: { MEDIUM: 'MEDIUM' }
+}));
+
+describe('ImageComponent', () => {
+  it('renders loader when src is "loading"', () => {
+    render(<ImageComponent src="loading" />);
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+  });
+
+  it('calculates dimensions when width and height are not provided', () => {
+    render(<ImageComponent src="img.png" altText="img" />);
+    const img = screen.getByRole('img', { name: 'img' }) as HTMLImageElement;
+
+    Object.defineProperty(img, 'naturalWidth', { value: 1200 });
+    Object.defineProperty(img, 'naturalHeight', { value: 600 });
+    fireEvent.load(img);
+
+    expect(img).toHaveAttribute('width', '800');
+    expect(img).toHaveAttribute('height', '400');
+  });
+
+  it('respects provided width and computes height', () => {
+    render(<ImageComponent src="foo.jpg" altText="foo" width={200} />);
+    const img = screen.getByRole('img', { name: 'foo' }) as HTMLImageElement;
+
+    Object.defineProperty(img, 'naturalWidth', { value: 600 });
+    Object.defineProperty(img, 'naturalHeight', { value: 300 });
+    fireEvent.load(img);
+
+    expect(img).toHaveAttribute('width', '200');
+    expect(img).toHaveAttribute('height', '100');
+  });
+});

--- a/__tests__/components/groups/page/Groups.test.tsx
+++ b/__tests__/components/groups/page/Groups.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Groups from '../../../../components/groups/page/Groups';
+import { AuthContext } from '../../../../components/auth/Auth';
+import React from 'react';
+
+jest.mock('next/router', () => ({ useRouter: () => ({ replace: jest.fn() }) }));
+
+const searchParams = new Map<string, string | null>();
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => ({ get: (key: string) => searchParams.get(key) ?? null }),
+  usePathname: () => '/groups'
+}));
+
+jest.mock('../../../../components/groups/page/create/GroupCreate', () => (props: any) => (
+  <div data-testid="group-create" {...props} />
+));
+
+jest.mock('../../../../components/groups/page/GroupsPageListWrapper', () => (props: any) => (
+  <div data-testid="list-wrapper" {...props} />
+));
+
+function renderGroups(context: any) {
+  return render(
+    <AuthContext.Provider value={context}>
+      <Groups />
+    </AuthContext.Provider>
+  );
+}
+
+describe('Groups page', () => {
+  const baseContext = {
+    connectedProfile: { handle: 'alice' },
+    activeProfileProxy: null,
+    requestAuth: jest.fn().mockResolvedValue({ success: true })
+  } as any;
+
+  it('opens create mode when edit param is present', async () => {
+    searchParams.set('edit', '123');
+    renderGroups(baseContext);
+    await screen.findByTestId('group-create');
+  });
+
+  it('switches back to list on back button click', async () => {
+    searchParams.set('edit', '123');
+    const user = userEvent.setup();
+    renderGroups(baseContext);
+    await screen.findByTestId('group-create');
+    await user.click(screen.getByRole('button', { name: /back/i }));
+    expect(screen.getByTestId('list-wrapper')).toBeInTheDocument();
+  });
+
+  it('shows list when not authenticated', () => {
+    searchParams.set('edit', '123');
+    renderGroups({ connectedProfile: null, activeProfileProxy: null, requestAuth: jest.fn() });
+    expect(screen.getByTestId('list-wrapper')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for drops ImageComponent logic
- add tests for Groups page view mode switching

## Testing
- `npx jest __tests__/components/groups/page/Groups.test.tsx --runInBand --coverage --coverageReporters=text-summary`
