### PR TITLE
Add tests for modal and context components

### DIFF
--- a/__tests__/components/allowlist-tool/common/modals/AllowlistToolCommonModalWrapper.test.tsx
+++ b/__tests__/components/allowlist-tool/common/modals/AllowlistToolCommonModalWrapper.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AllowlistToolCommonModalWrapper, { AllowlistToolModalSize } from '../../../../../components/allowlist-tool/common/modals/AllowlistToolCommonModalWrapper';
+jest.mock("react-use", () => ({
+  useClickAway: (ref: React.RefObject<HTMLElement>, onClick: (e: MouseEvent) => void) => {
+    React.useEffect(() => {
+      const handler = (e: MouseEvent) => {
+        if (!ref.current || !ref.current.contains(e.target as Node)) onClick(e);
+      };
+      document.addEventListener("click", handler);
+      return () => document.removeEventListener("click", handler);
+    }, [ref, onClick]);
+  },
+  useKeyPressEvent: (key: string, onKey: (e: KeyboardEvent) => void) => {
+    React.useEffect(() => {
+      const handler = (e: KeyboardEvent) => { if (e.key === key) onKey(e); };
+      document.addEventListener("keydown", handler);
+      return () => document.removeEventListener("keydown", handler);
+    }, [key, onKey]);
+  },
+}));
+
+
+function renderModal(props: any) {
+  return render(
+    <AllowlistToolCommonModalWrapper {...props}>
+      <div data-testid="content" />
+    </AllowlistToolCommonModalWrapper>
+  );
+}
+
+describe('AllowlistToolCommonModalWrapper', () => {
+  it('does not render when showModal is false', () => {
+    renderModal({ showModal: false, title: 'Title', onClose: jest.fn() });
+    expect(screen.queryByTestId('content')).toBeNull();
+  });
+
+  it('renders title and calls onClose when close button clicked', async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+    renderModal({ showModal: true, title: 'My Modal', onClose });
+    expect(screen.getByText('My Modal')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose on Escape key and outside click', async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+    renderModal({ showModal: true, title: 'Esc', onClose });
+    await user.keyboard('{Escape}');
+    await user.click(document.body);
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('applies modal size class', () => {
+    renderModal({ showModal: true, title: 'size', onClose: jest.fn(), modalSize: AllowlistToolModalSize.LARGE });
+    const dialog = screen.getByRole("dialog");
+    const sized = Array.from(dialog.querySelectorAll("div")).find(el => el.classList.contains("sm:tw-max-w-xl"));
+    expect(sized).toBeTruthy();
+  });
+});

--- a/__tests__/components/allowlist-tool/common/select-menu-multiple/AllowlistToolSelectMenuMultipleList.test.tsx
+++ b/__tests__/components/allowlist-tool/common/select-menu-multiple/AllowlistToolSelectMenuMultipleList.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AllowlistToolSelectMenuMultipleList from '../../../../../components/allowlist-tool/common/select-menu-multiple/AllowlistToolSelectMenuMultipleList';
+
+jest.mock('../../../../../components/allowlist-tool/common/select-menu-multiple/AllowlistToolSelectMenuMultipleListItem', () => (props: any) => (
+  <li data-testid="item" data-option={props.option.value} />
+));
+
+describe('AllowlistToolSelectMenuMultipleList', () => {
+  const baseProps = {
+    selectedOptions: [],
+    toggleSelectedOption: jest.fn(),
+  };
+
+  it('renders list items for options', () => {
+    const options = [
+      { value: 'a', title: 'A', subTitle: null },
+      { value: 'b', title: 'B', subTitle: null },
+    ];
+    render(<AllowlistToolSelectMenuMultipleList {...baseProps} options={options} />);
+    const items = screen.getAllByTestId('item');
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveAttribute('data-option', 'a');
+    expect(items[1]).toHaveAttribute('data-option', 'b');
+  });
+
+  it('shows fallback text when no options', () => {
+    render(<AllowlistToolSelectMenuMultipleList {...baseProps} options={[]} />);
+    expect(screen.getByText('No options found')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/app-wallets/AppWalletsContext.test.tsx
+++ b/__tests__/components/app-wallets/AppWalletsContext.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { AppWalletsProvider, useAppWallets } from '../../../components/app-wallets/AppWalletsContext';
+
+jest.mock('../../../hooks/useCapacitor', () => () => ({ isCapacitor: false }));
+jest.mock('../../../components/app-wallets/app-wallet-helpers', () => ({ encryptData: jest.fn(() => Promise.resolve('enc')) }));
+jest.mock('capacitor-secure-storage-plugin', () => ({ SecureStoragePlugin: { keys: jest.fn(), set: jest.fn(), get: jest.fn(), remove: jest.fn() } }));
+
+const { SecureStoragePlugin } = require('capacitor-secure-storage-plugin');
+
+describe('AppWalletsContext', () => {
+  it('throws when used outside provider', () => {
+    const { result } = renderHook(() => {
+      try { useAppWallets(); } catch (e) { return e; }
+    });
+    expect(result.current).toBeInstanceOf(Error);
+  });
+
+  it('initializes unsupported when not running in capacitor', async () => {
+    const { result } = renderHook(() => useAppWallets(), { wrapper: AppWalletsProvider });
+    expect(result.current.appWalletsSupported).toBe(false);
+    expect(SecureStoragePlugin.keys).not.toHaveBeenCalled();
+  });
+
+  it('createAppWallet returns false when unsupported', async () => {
+    const { result } = renderHook(() => useAppWallets(), { wrapper: AppWalletsProvider });
+    const ok = await act(() => result.current.createAppWallet('name', 'pass'));
+    expect(ok).toBe(false);
+    expect(SecureStoragePlugin.set).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/brain/feed/FeedItem.test.tsx
+++ b/__tests__/components/brain/feed/FeedItem.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import FeedItem from '../../../../components/brain/feed/FeedItem';
+import { ApiFeedItemType } from '../../../../generated/models/ApiFeedItemType';
+
+jest.mock('../../../../components/brain/feed/items/wave-created/FeedItemWaveCreated', () => (props: any) => <div data-testid="wave" {...props} />);
+jest.mock('../../../../components/brain/feed/items/drop-created/FeedItemDropCreated', () => (props: any) => <div data-testid="drop-created" {...props} />);
+jest.mock('../../../../components/brain/feed/items/drop-replied/FeedItemDropReplied', () => (props: any) => <div data-testid="drop-replied" {...props} />);
+
+describe('FeedItem', () => {
+  const base = { showWaveInfo: false, activeDrop: null, onReply: jest.fn(), onQuote: jest.fn() };
+
+  it('renders wave created item', () => {
+    render(<FeedItem {...base} item={{ type: ApiFeedItemType.WaveCreated } as any } />);
+    expect(screen.getByTestId('wave')).toBeInTheDocument();
+  });
+
+  it('renders drop created item', () => {
+    render(<FeedItem {...base} item={{ type: ApiFeedItemType.DropCreated } as any } />);
+    expect(screen.getByTestId('drop-created')).toBeInTheDocument();
+  });
+
+  it('renders drop replied item', () => {
+    render(<FeedItem {...base} item={{ type: ApiFeedItemType.DropReplied } as any } />);
+    expect(screen.getByTestId('drop-replied')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for allowlist tool modal wrapper
- add tests for select menu list component
- add tests for AppWalletsContext and FeedItem

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage`