### PR TITLE
Add tests for helpers and FooterWrapper

### DIFF
--- a/__tests__/FooterWrapper.test.tsx
+++ b/__tests__/FooterWrapper.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import FooterWrapper from '../FooterWrapper';
+import Footer from '../components/footer/Footer';
+import useDeviceInfo from '../hooks/useDeviceInfo';
+import { useRouter } from 'next/router';
+
+jest.mock('../hooks/useDeviceInfo');
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../components/footer/Footer', () => ({ __esModule: true, default: () => <div data-testid="footer" /> }));
+
+const useDeviceInfoMock = useDeviceInfo as jest.MockedFunction<typeof useDeviceInfo>;
+const useRouterMock = useRouter as jest.Mock;
+
+describe('FooterWrapper', () => {
+  beforeEach(() => {
+    useDeviceInfoMock.mockReturnValue({ isApp: false } as any);
+    useRouterMock.mockReturnValue({ pathname: '/' } as any);
+  });
+
+  it('hides footer when running in app', () => {
+    useDeviceInfoMock.mockReturnValue({ isApp: true } as any);
+    const { container } = render(<FooterWrapper />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('hides footer on specific routes', () => {
+    useRouterMock.mockReturnValue({ pathname: '/waves/123' } as any);
+    const { container } = render(<FooterWrapper />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders footer otherwise', () => {
+    useRouterMock.mockReturnValue({ pathname: '/other' } as any);
+    render(<FooterWrapper />);
+    expect(screen.getByTestId('footer')).toBeInTheDocument();
+  });
+});

--- a/__tests__/helpers/Helpers.test.ts
+++ b/__tests__/helpers/Helpers.test.ts
@@ -1,0 +1,99 @@
+import { addProtocol, parseIpfsUrl, parseIpfsUrlToGateway, numberWithCommas, numberWithCommasFromString, formatAddress, areEqualURLS, classNames } from '../../helpers/Helpers';
+
+describe('Helpers utility functions', () => {
+  test('addProtocol adds https scheme when missing', () => {
+    expect(addProtocol('example.com')).toBe('https://example.com');
+    expect(addProtocol('https://example.com')).toBe('https://example.com');
+    expect(addProtocol('')).toBe('');
+  });
+
+  test('parseIpfsUrl converts ipfs protocol to gateway url', () => {
+    expect(parseIpfsUrl('ipfs://hash')).toBe('https://ipfs.io/ipfs/hash');
+    expect(parseIpfsUrl('https://site')).toBe('https://site');
+  });
+
+  test('parseIpfsUrlToGateway converts ipfs protocol to cf-ipfs gateway', () => {
+    expect(parseIpfsUrlToGateway('ipfs://data')).toBe('https://cf-ipfs.com/ipfs/data');
+    expect(parseIpfsUrlToGateway('https://foo')).toBe('https://foo');
+  });
+
+  test('numberWithCommas formats numbers correctly', () => {
+    expect(numberWithCommas(1234.56)).toBe('1,234.56');
+    expect(numberWithCommas(-9876)).toBe('-9,876');
+    expect(numberWithCommas(undefined)).toBe('-');
+  });
+
+  test('numberWithCommasFromString cleans and formats string numbers', () => {
+    expect(numberWithCommasFromString('12345')).toBe('12,345');
+    expect(numberWithCommasFromString('abc')).toBe('abc');
+  });
+
+  test('formatAddress shortens valid long addresses', () => {
+    const addr = '0x1234567890abcdef1234567890abcdef12345678';
+    expect(formatAddress(addr)).toBe('0x1234...5678');
+    expect(formatAddress('example.eth')).toBe('example.eth');
+  });
+
+  test('areEqualURLS compares URLs safely', () => {
+    expect(areEqualURLS('https://example.com', 'https://example.com/')).toBe(true);
+    expect(areEqualURLS('https://example.com', 'not a url')).toBe(false);
+  });
+
+  test('classNames joins truthy strings', () => {
+    expect(classNames('a', '', 'b', undefined as any, 'c')).toBe('a b c');
+  });
+});
+import { parseNftDescriptionToHtml, getRandomColorWithSeed, getDateFilters } from '../../helpers/Helpers';
+import { DateIntervalsSelection } from '../../enums';
+
+describe('additional helper functions', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date(Date.UTC(2024, 0, 15)));
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('parseNftDescriptionToHtml replaces newlines and links', () => {
+    const input = 'line1\nhttps://example.com';
+    expect(parseNftDescriptionToHtml(input)).toBe(
+      "line1<br /><a href='https://example.com' target=\"blank\" rel=\"noreferrer\">https://example.com</a>"
+    );
+  });
+
+  test('getRandomColorWithSeed returns deterministic color', () => {
+    expect(getRandomColorWithSeed('seed')).toBe(getRandomColorWithSeed('seed'));
+  });
+
+  test('getDateFilters handles various selections', () => {
+    expect(getDateFilters(DateIntervalsSelection.TODAY, undefined, undefined)).toBe('&from_date=2024-01-15');
+    expect(getDateFilters(DateIntervalsSelection.LAST_7, undefined, undefined)).toBe('&from_date=2024-01-08');
+    const from = new Date(Date.UTC(2024, 0, 1));
+    const to = new Date(Date.UTC(2024, 0, 2));
+    expect(
+      getDateFilters(DateIntervalsSelection.CUSTOM_DATES, from, to)
+    ).toBe('&from_date=2024-01-01&to_date=2024-01-02');
+  });
+});
+import { formatNumberWithCommasOrDash, printMintDate, removeBaseEndpoint } from '../../helpers/Helpers';
+
+describe('more helper utilities', () => {
+  test('formatNumberWithCommasOrDash returns dash for invalid values', () => {
+    expect(formatNumberWithCommasOrDash(0)).toBe('-');
+    expect(formatNumberWithCommasOrDash(NaN as any)).toBe('-');
+    expect(formatNumberWithCommasOrDash(1000)).toBe('1,000');
+  });
+
+  test('printMintDate formats valid date or dash', () => {
+    const d = new Date(Date.UTC(2024, 0, 2));
+    const text = printMintDate(d);
+    expect(text).toContain('2024');
+    expect(text).toContain('Jan');
+    expect(printMintDate(undefined)).toBe('-');
+  });
+
+  test('removeBaseEndpoint strips prefix', () => {
+    process.env.BASE_ENDPOINT = 'https://api.example.com';
+    expect(removeBaseEndpoint('https://api.example.com/path')).toBe('/path');
+  });
+});

--- a/__tests__/services/api/common-api.test.ts
+++ b/__tests__/services/api/common-api.test.ts
@@ -1,0 +1,25 @@
+import * as api from '../../../services/api/common-api';
+
+describe('commonApiFetchWithRetry', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('retries once on failure then succeeds', async () => {
+    const spy = jest.spyOn(api as any, 'commonApiFetch');
+    spy.mockRejectedValueOnce(new Error('fail'));
+    spy.mockResolvedValueOnce('ok');
+    const result = await api.commonApiFetchWithRetry({ endpoint: 'a', retryOptions: { maxRetries: 1, initialDelayMs: 0 } });
+    expect(result).toBe('ok');
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws after exceeding retries', async () => {
+    const spy = jest.spyOn(api as any, 'commonApiFetch');
+    spy.mockRejectedValue(new Error('bad'));
+    await expect(
+      api.commonApiFetchWithRetry({ endpoint: 'a', retryOptions: { maxRetries: 1, initialDelayMs: 0 } })
+    ).rejects.toThrow('bad');
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for FooterWrapper component
- test various utility functions in Helpers
- cover retry logic in commonApiFetchWithRetry

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`