### PR TITLE
Add tests for distribution plan components

### DIFF
--- a/__tests__/components/distribution-plan-tool/plans/DistributionPlanToolPlansNoPlans.test.tsx
+++ b/__tests__/components/distribution-plan-tool/plans/DistributionPlanToolPlansNoPlans.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DistributionPlanToolPlansNoPlans from '../../../../components/distribution-plan-tool/plans/DistributionPlanToolPlansNoPlans';
+
+describe('DistributionPlanToolPlansNoPlans', () => {
+  it('renders the no plans message', () => {
+    render(<DistributionPlanToolPlansNoPlans />);
+    expect(screen.getByText('No plan')).toBeInTheDocument();
+    expect(
+      screen.getByText('Get started by creating a new distribution plan.')
+    ).toBeInTheDocument();
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/distribution-plan-tool/plans/DistributionPlanToolPlansTable.test.tsx
+++ b/__tests__/components/distribution-plan-tool/plans/DistributionPlanToolPlansTable.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DistributionPlanToolPlansTable from '../../../../components/distribution-plan-tool/plans/DistributionPlanToolPlansTable';
+
+const captured: any[] = [];
+jest.mock('../../../../components/distribution-plan-tool/plans/DistributionPlanToolPlansTableItem', () => (props: any) => {
+  captured.push(props);
+  return <tr data-testid={`row-${props.plan.id}`} />;
+});
+
+describe('DistributionPlanToolPlansTable', () => {
+  beforeEach(() => {
+    captured.length = 0;
+  });
+
+  it('renders rows for each plan and forwards onDeleted', () => {
+    const onDeleted = jest.fn();
+    const plans = [
+      { id: '1', name: 'P1', description: '', createdAt: 0 },
+      { id: '2', name: 'P2', description: '', createdAt: 0 },
+    ] as any;
+
+    render(<DistributionPlanToolPlansTable plans={plans} onDeleted={onDeleted} />);
+
+    expect(screen.getByTestId('row-1')).toBeInTheDocument();
+    expect(screen.getByTestId('row-2')).toBeInTheDocument();
+    expect(captured).toHaveLength(2);
+    captured[0].onDeleted('1');
+    expect(onDeleted).toHaveBeenCalledWith('1');
+  });
+});

--- a/__tests__/components/groups/page/list/GroupsList.test.tsx
+++ b/__tests__/components/groups/page/list/GroupsList.test.tsx
@@ -44,7 +44,7 @@ describe('GroupsList', () => {
     });
     render(
       <GroupsList
-        filters={{}}
+        filters={{ group_name: null, author_identity: null }}
         showIdentitySearch={true}
         showCreateNewGroupButton={false}
         showMyGroupsButton={false}


### PR DESCRIPTION
## Summary
- add tests for DistributionPlanToolPlansNoPlans component
- add tests for DistributionPlanToolPlansTable component
- fix GroupsList test typing

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`