### PR TITLE
Improve coverage for group create nft components

### DIFF
--- a/__tests__/components/groups/page/create/config/nfts/GroupCreateNftSearch.test.tsx
+++ b/__tests__/components/groups/page/create/config/nfts/GroupCreateNftSearch.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GroupCreateNftSearch from '../../../../../../../components/groups/page/create/config/nfts/GroupCreateNftSearch';
+
+let capturedProps: any = null;
+let clickAwayCb: () => void = () => {};
+let keyPressCb: () => void = () => {};
+
+jest.mock('../../../../../../../components/groups/page/create/config/nfts/GroupCreateNftSearchItems', () => ({
+  __esModule: true,
+  default: (props: any) => { capturedProps = props; return <div data-testid="items" />; }
+}));
+
+jest.mock('react-use', () => ({
+  useClickAway: (_ref: any, cb: () => void) => { clickAwayCb = cb; },
+  useKeyPressEvent: (_key: string, cb: () => void) => { keyPressCb = cb; },
+}));
+
+function renderComponent(selected: any[] = [], onSelect = jest.fn()) {
+  return render(<GroupCreateNftSearch selected={selected} onSelect={onSelect} />);
+}
+
+const sampleItem = { id: '1', contract: '0xabc', name: 'NFT', image_url: 'img' } as any;
+
+describe('GroupCreateNftSearch', () => {
+  beforeEach(() => {
+    capturedProps = null;
+  });
+
+  it('opens on focus and closes via click away', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    const input = screen.getByRole('textbox');
+
+    expect(capturedProps.open).toBe(false);
+    await user.click(input);
+    expect(capturedProps.open).toBe(true);
+
+    act(() => {
+      clickAwayCb();
+    });
+    expect(capturedProps.open).toBe(false);
+  });
+
+  it('updates search criteria and handles external close events', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'abc');
+    expect(capturedProps.searchCriteria).toBe('abc');
+
+    act(() => {
+      clickAwayCb();
+    });
+    expect(capturedProps.open).toBe(false);
+
+    await user.click(input);
+    act(() => {
+      keyPressCb();
+    });
+    expect(capturedProps.open).toBe(false);
+  });
+
+  it('resets search criteria and propagates selection', async () => {
+    const onSelect = jest.fn();
+    renderComponent([], onSelect);
+    const input = screen.getByRole('textbox');
+    await userEvent.type(input, '123');
+
+    act(() => {
+      capturedProps.onSelect(sampleItem);
+    });
+
+    expect(onSelect).toHaveBeenCalledWith(sampleItem);
+    expect(capturedProps.searchCriteria).toBe(null);
+    expect(capturedProps.open).toBe(false);
+  });
+});

--- a/__tests__/components/groups/page/create/config/nfts/GroupCreateNftSearchItem.test.tsx
+++ b/__tests__/components/groups/page/create/config/nfts/GroupCreateNftSearchItem.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GroupCreateNftSearchItem from '../../../../../../../components/groups/page/create/config/nfts/GroupCreateNftSearchItem';
+import { MEMES_CONTRACT } from '../../../../../../../constants';
+import { ApiGroupOwnsNftNameEnum } from '../../../../../../../generated/models/ApiGroupOwnsNft';
+
+jest.mock('../../../../../../../helpers/image.helpers');
+const imageHelpers = jest.requireMock('../../../../../../../helpers/image.helpers');
+const getScaledImageUriMock = imageHelpers.getScaledImageUri as jest.Mock;
+imageHelpers.ImageScale = { W_AUTO_H_50: 'scale' };
+getScaledImageUriMock.mockReturnValue('scaled-url');
+
+describe('GroupCreateNftSearchItem', () => {
+  const item = {
+    id: '1',
+    contract: MEMES_CONTRACT,
+    name: 'Cool NFT',
+    image_url: 'img-url',
+  } as any;
+
+  it('renders item info and handles selection', async () => {
+    const user = userEvent.setup();
+    const onSelect = jest.fn();
+    const { container } = render(<GroupCreateNftSearchItem item={item} selected={[]} onSelect={onSelect} />);
+
+    expect(screen.getByText('Cool NFT')).toBeInTheDocument();
+    expect(screen.getByText('The Memes')).toBeInTheDocument();
+    expect(getScaledImageUriMock).toHaveBeenCalledWith('img-url', 'scale');
+
+    await user.click(screen.getByRole('button'));
+    expect(onSelect).toHaveBeenCalledWith(item);
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('shows check icon when token already selected', () => {
+    const selected = [{ name: ApiGroupOwnsNftNameEnum.Memes, tokens: ['1'] }];
+    const { container } = render(
+      <GroupCreateNftSearchItem item={item} selected={selected} onSelect={jest.fn()} />
+    );
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/groups/page/list/GroupsList.test.tsx
+++ b/__tests__/components/groups/page/list/GroupsList.test.tsx
@@ -44,7 +44,7 @@ describe('GroupsList', () => {
     });
     render(
       <GroupsList
-        filters={{}}
+        filters={{} as any}
         showIdentitySearch={true}
         showCreateNewGroupButton={false}
         showMyGroupsButton={false}


### PR DESCRIPTION
## Summary
- add tests for GroupCreateNftSearch and GroupCreateNftSearchItem components
- fix type issue in GroupsList tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage`