### PR TITLE
Add service tests

### DIFF
--- a/__tests__/services/6529api.test.ts
+++ b/__tests__/services/6529api.test.ts
@@ -1,0 +1,73 @@
+import * as api from '../../services/6529api';
+import Cookies from 'js-cookie';
+import { getStagingAuth } from '../../services/auth/auth.utils';
+import { API_AUTH_COOKIE } from '../../constants';
+
+jest.mock('js-cookie', () => ({ remove: jest.fn() }));
+jest.mock('../../services/auth/auth.utils', () => ({ getStagingAuth: jest.fn() }));
+
+const { fetchUrl, fetchAllPages, postData, postFormData } = api;
+
+describe('6529api service', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    (global as any).fetch = jest.fn();
+  });
+
+  it('fetchUrl removes cookie on 401 and returns json', async () => {
+    (getStagingAuth as jest.Mock).mockReturnValue('token');
+    const json = jest.fn().mockResolvedValue({ ok: true });
+    (global.fetch as jest.Mock).mockResolvedValue({ status: 401, json });
+
+    const result = await fetchUrl('/foo');
+
+    expect(global.fetch).toHaveBeenCalledWith('/foo', { headers: { 'x-6529-auth': 'token' } });
+    expect(Cookies.remove).toHaveBeenCalledWith(API_AUTH_COOKIE);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('fetchAllPages concatenates pages', async () => {
+    (getStagingAuth as jest.Mock).mockReturnValue(null);
+    (global.fetch as jest.Mock)
+      .mockResolvedValueOnce({ status: 200, json: async () => ({ data: ['a'], next: '/next' }) })
+      .mockResolvedValueOnce({ status: 200, json: async () => ({ data: ['b'] }) });
+
+    const result = await fetchAllPages('/start');
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(global.fetch).toHaveBeenNthCalledWith(1, '/start', { headers: {} });
+    expect(global.fetch).toHaveBeenNthCalledWith(2, '/next', { headers: {} });
+    expect(result).toEqual(['a', 'b']);
+  });
+
+  it('postData sends JSON body and returns status/response', async () => {
+    (getStagingAuth as jest.Mock).mockReturnValue(null);
+    const json = jest.fn().mockResolvedValue({ done: true });
+    (global.fetch as jest.Mock).mockResolvedValue({ status: 201, json });
+
+    const result = await postData('/bar', { foo: 'bar' });
+
+    expect(global.fetch).toHaveBeenCalledWith('/bar', {
+      method: 'POST',
+      body: JSON.stringify({ foo: 'bar' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(result).toEqual({ status: 201, response: { done: true } });
+  });
+
+  it('postFormData sends FormData body with auth header', async () => {
+    (getStagingAuth as jest.Mock).mockReturnValue('tok');
+    const formData = new FormData();
+    const json = jest.fn().mockResolvedValue({ ok: true });
+    (global.fetch as jest.Mock).mockResolvedValue({ status: 200, json });
+
+    const result = await postFormData('/fd', formData);
+
+    expect(global.fetch).toHaveBeenCalledWith('/fd', {
+      method: 'POST',
+      body: formData,
+      headers: { 'x-6529-auth': 'tok' },
+    });
+    expect(result).toEqual({ status: 200, response: { ok: true } });
+  });
+});

--- a/__tests__/services/auth.utils.test.ts
+++ b/__tests__/services/auth.utils.test.ts
@@ -1,0 +1,74 @@
+import { setAuthJwt, getAuthJwt, getStagingAuth, removeAuthJwt, migrateCookiesToLocalStorage, getWalletAddress } from '../../services/auth/auth.utils';
+import Cookies from 'js-cookie';
+import { safeLocalStorage } from '../../helpers/safeLocalStorage';
+import { jwtDecode } from 'jwt-decode';
+
+jest.mock('js-cookie', () => ({ get: jest.fn(), set: jest.fn(), remove: jest.fn() }));
+jest.mock('jwt-decode', () => ({ jwtDecode: jest.fn() }));
+jest.mock('../../helpers/safeLocalStorage', () => ({
+  safeLocalStorage: { getItem: jest.fn(), setItem: jest.fn(), removeItem: jest.fn() },
+}));
+
+describe('auth.utils', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('setAuthJwt stores tokens and cookie', () => {
+    (jwtDecode as jest.Mock).mockReturnValue({ exp: 86400 * 2 });
+    jest.spyOn(Date, 'now').mockReturnValue(0);
+    setAuthJwt('addr', 'jwt', 'refresh', 'role');
+    expect(Cookies.set).toHaveBeenCalledWith('wallet-auth', 'jwt', { secure: true, sameSite: 'strict', expires: 2 });
+    expect(safeLocalStorage.setItem).toHaveBeenCalledWith('6529-wallet-address', 'addr');
+    expect(safeLocalStorage.setItem).toHaveBeenCalledWith('6529-wallet-refresh-token', 'refresh');
+    expect(safeLocalStorage.setItem).toHaveBeenCalledWith('6529-wallet-role', 'role');
+  });
+
+  it('getAuthJwt prefers dev mode', () => {
+    process.env.USE_DEV_AUTH = 'true';
+    process.env.DEV_MODE_AUTH_JWT = 'dev';
+    expect(getAuthJwt()).toBe('dev');
+    process.env.USE_DEV_AUTH = 'false';
+    (Cookies.get as jest.Mock).mockReturnValue('cookie');
+    expect(getAuthJwt()).toBe('cookie');
+  });
+
+  it('getStagingAuth returns cookie or env', () => {
+    (Cookies.get as jest.Mock).mockReturnValueOnce('c');
+    expect(getStagingAuth()).toBe('c');
+    (Cookies.get as jest.Mock).mockReturnValueOnce(undefined);
+    process.env.STAGING_API_KEY = 'e';
+    expect(getStagingAuth()).toBe('e');
+  });
+
+  it('migrateCookiesToLocalStorage moves and removes cookies', () => {
+    (Cookies.get as jest.Mock)
+      .mockReturnValueOnce('addr')
+      .mockReturnValueOnce('refresh')
+      .mockReturnValueOnce('role');
+    migrateCookiesToLocalStorage();
+    expect(safeLocalStorage.setItem).toHaveBeenCalledWith('6529-wallet-address', 'addr');
+    expect(Cookies.remove).toHaveBeenCalledWith('wallet-address');
+    expect(safeLocalStorage.setItem).toHaveBeenCalledWith('6529-wallet-refresh-token', 'refresh');
+    expect(Cookies.remove).toHaveBeenCalledWith('wallet-refresh-token');
+    expect(safeLocalStorage.setItem).toHaveBeenCalledWith('6529-wallet-role', 'role');
+    expect(Cookies.remove).toHaveBeenCalledWith('wallet-role');
+  });
+
+  it('getWalletAddress respects dev mode and storage', () => {
+    process.env.USE_DEV_AUTH = 'true';
+    process.env.DEV_MODE_WALLET_ADDRESS = 'devaddr';
+    expect(getWalletAddress()).toBe('devaddr');
+    process.env.USE_DEV_AUTH = 'false';
+    (safeLocalStorage.getItem as jest.Mock).mockReturnValue('stored');
+    expect(getWalletAddress()).toBe('stored');
+  });
+
+  it('removeAuthJwt clears storage and cookie', () => {
+    removeAuthJwt();
+    expect(Cookies.remove).toHaveBeenCalledWith('wallet-auth', { secure: true, sameSite: 'strict' });
+    expect(safeLocalStorage.removeItem).toHaveBeenCalledWith('6529-wallet-address');
+    expect(safeLocalStorage.removeItem).toHaveBeenCalledWith('6529-wallet-refresh-token');
+    expect(safeLocalStorage.removeItem).toHaveBeenCalledWith('6529-wallet-role');
+  });
+});

--- a/__tests__/services/common-api.test.ts
+++ b/__tests__/services/common-api.test.ts
@@ -1,0 +1,70 @@
+import { commonApiFetch } from '../../services/api/common-api';
+import { getStagingAuth, getAuthJwt } from '../../services/auth/auth.utils';
+
+jest.mock('../../services/auth/auth.utils', () => ({
+  getStagingAuth: jest.fn(),
+  getAuthJwt: jest.fn(),
+}));
+
+describe('commonApiFetch', () => {
+  const originalEndpoint = process.env.API_ENDPOINT;
+  beforeEach(() => {
+    (global as any).fetch = jest.fn();
+    jest.resetAllMocks();
+    process.env.API_ENDPOINT = 'http://example.com';
+  });
+  afterAll(() => {
+    process.env.API_ENDPOINT = originalEndpoint;
+  });
+
+  it('builds url with params and headers', async () => {
+    (getStagingAuth as jest.Mock).mockReturnValue('s');
+    (getAuthJwt as jest.Mock).mockReturnValue('jwt');
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({ result: 1 }) });
+
+    const result = await commonApiFetch<{ result: number }>({
+      endpoint: 'test',
+      params: { foo: 'bar', typ: 'nic' },
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://example.com/api/test?foo=bar&typ=cic',
+      { headers: { 'Content-Type': 'application/json', 'x-6529-auth': 's', Authorization: 'Bearer jwt' }, signal: undefined }
+    );
+    expect(result).toEqual({ result: 1 });
+  });
+
+  it('rejects with error body when not ok', async () => {
+    (getStagingAuth as jest.Mock).mockReturnValue(null);
+    (getAuthJwt as jest.Mock).mockReturnValue(null);
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, statusText: 'Bad', json: async () => ({ error: 'err' }) });
+
+    await expect(
+      commonApiFetch({ endpoint: 'bad' })
+    ).rejects.toBe('err');
+  });
+});
+
+describe('commonApiPost', () => {
+  beforeEach(() => {
+    (global as any).fetch = jest.fn();
+  });
+
+  it('posts data and returns json', async () => {
+    (getStagingAuth as jest.Mock).mockReturnValue('a');
+    (getAuthJwt as jest.Mock).mockReturnValue(null);
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({ res: 1 }) });
+    const { commonApiPost } = await import('../../services/api/common-api');
+    const result = await commonApiPost<{v:number},{res:number}>({ endpoint:'e', body:{v:1} });
+    expect(global.fetch).toHaveBeenCalledWith('http://example.com/api/e', { method:'POST', headers:{ 'Content-Type':'application/json','x-6529-auth':'a'}, body: JSON.stringify({v:1}) });
+    expect(result).toEqual({ res:1 });
+  });
+
+  it('rejects on error', async () => {
+    (getStagingAuth as jest.Mock).mockReturnValue(null);
+    (getAuthJwt as jest.Mock).mockReturnValue(null);
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false, statusText:'B', json: async () => ({ error:'err' }) });
+    const { commonApiPost } = await import('../../services/api/common-api');
+    await expect(commonApiPost({ endpoint:'e', body:{} })).rejects.toBe('err');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for 6529api service
- add tests for common-api service functions
- add tests for auth utilities

## Testing
- `npm run test`
- `npm run test:cov` (fails: coverage did not reach target)