### PR TITLE
Improve test coverage

### DIFF
--- a/__tests__/components/DistributionPlanToolWrapper.test.tsx
+++ b/__tests__/components/DistributionPlanToolWrapper.test.tsx
@@ -1,0 +1,46 @@
+import { render, act } from '@testing-library/react';
+import DistributionPlanToolWrapper from '../../components/distribution-plan-tool/wrapper/DistributionPlanToolWrapper';
+import { AuthContext } from '../../components/auth/Auth';
+import { useSeizeConnectContext } from '../../components/auth/SeizeConnectContext';
+import { useRouter } from 'next/router';
+import { Poppins } from 'next/font/google';
+
+jest.mock('next/font/google', () => ({ Poppins: () => ({ className: 'poppins' }) }));
+jest.mock('../../components/auth/SeizeConnectContext');
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+
+const useSeizeConnectContextMock = useSeizeConnectContext as jest.MockedFunction<typeof useSeizeConnectContext>;
+const useRouterMock = useRouter as jest.Mock;
+
+describe('DistributionPlanToolWrapper', () => {
+  it('sets title on mount and navigates on address change', () => {
+    const setTitle = jest.fn();
+    const push = jest.fn();
+    useRouterMock.mockReturnValue({ push, pathname: '/' });
+    useSeizeConnectContextMock.mockReturnValue({ address: undefined } as any);
+
+    const { rerender } = render(
+      <AuthContext.Provider value={{ setTitle } as any}>
+        <DistributionPlanToolWrapper>
+          <div>child</div>
+        </DistributionPlanToolWrapper>
+      </AuthContext.Provider>
+    );
+
+    expect(setTitle).toHaveBeenCalledWith({ title: 'EMMA | Tools' });
+    expect(push).not.toHaveBeenCalled();
+
+    useSeizeConnectContextMock.mockReturnValue({ address: '0x1' } as any);
+    act(() => {
+      rerender(
+        <AuthContext.Provider value={{ setTitle } as any}>
+          <DistributionPlanToolWrapper>
+            <div>child</div>
+          </DistributionPlanToolWrapper>
+        </AuthContext.Provider>
+      );
+    });
+
+    expect(push).toHaveBeenCalledWith('/emma');
+  });
+});

--- a/__tests__/components/GroupCreateIncludeMe.test.tsx
+++ b/__tests__/components/GroupCreateIncludeMe.test.tsx
@@ -1,0 +1,14 @@
+import { render, fireEvent } from '@testing-library/react';
+import GroupCreateIncludeMe from '../../components/groups/page/create/config/include-me-and-private/GroupCreateIncludeMe';
+
+describe('GroupCreateIncludeMe', () => {
+  it('toggles checkbox and calls callback', () => {
+    const mock = jest.fn();
+    const { getByRole } = render(
+      <GroupCreateIncludeMe iAmIncluded={false} setIAmIncluded={mock} />
+    );
+    const toggle = getByRole('switch');
+    fireEvent.click(toggle);
+    expect(mock).toHaveBeenCalledWith(true);
+  });
+});

--- a/__tests__/components/MapDelegationsDone.test.tsx
+++ b/__tests__/components/MapDelegationsDone.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import MapDelegationsDone from '../../components/distribution-plan-tool/map-delegations/MapDelegationsDone';
+
+describe('MapDelegationsDone', () => {
+  it('renders the contract address', () => {
+    render(<MapDelegationsDone contract="0x123" />);
+    expect(screen.getByText(/contract/)).toHaveTextContent('0x123');
+  });
+});


### PR DESCRIPTION
## Summary
- add simple UI tests for DistributionPlanToolWrapper
- test GroupCreateIncludeMe toggle behavior
- test MapDelegationsDone text rendering

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`