### PR TITLE
Add tests for additional distribution plan components

### DIFF
--- a/__tests__/components/distribution-plan-tool/create-snapshots/form/CreateSnapshotFormSearchCollectionDropdownTable.test.tsx
+++ b/__tests__/components/distribution-plan-tool/create-snapshots/form/CreateSnapshotFormSearchCollectionDropdownTable.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CreateSnapshotFormSearchCollectionDropdownTable from '../../../../../components/distribution-plan-tool/create-snapshots/form/CreateSnapshotFormSearchCollectionDropdownTable';
+
+const itemMock = jest.fn(({ collection }: any) => <tr data-testid="row">{collection.name}</tr>);
+
+jest.mock(
+  '../../../../../components/distribution-plan-tool/create-snapshots/form/CreateSnapshotFormSearchCollectionDropdownItem',
+  () => (props: any) => itemMock(props)
+);
+
+describe('CreateSnapshotFormSearchCollectionDropdownTable', () => {
+  const sample = {
+    id: '1',
+    address: '0xabc',
+    name: 'One',
+    tokenType: 'erc721',
+    floorPrice: 1,
+    imageUrl: null,
+    description: null,
+    allTimeVolume: 2,
+    openseaVerified: false,
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders table headers', () => {
+    render(
+      <CreateSnapshotFormSearchCollectionDropdownTable collections={[sample]} onCollection={jest.fn()} />
+    );
+    expect(screen.getByText('Collection')).toBeInTheDocument();
+    expect(screen.getByText('All time volume')).toBeInTheDocument();
+    expect(screen.getByText('Floor')).toBeInTheDocument();
+  });
+
+  it('renders an item row for each collection', () => {
+    const collections = [sample, { ...sample, id: '2', name: 'Two' }];
+    const onCollection = jest.fn();
+    render(
+      <CreateSnapshotFormSearchCollectionDropdownTable collections={collections} onCollection={onCollection} />
+    );
+    expect(screen.getAllByTestId('row')).toHaveLength(2);
+    expect(itemMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ collection: collections[0], onCollection }));
+    expect(itemMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ collection: collections[1], onCollection }));
+  });
+});

--- a/__tests__/components/distribution-plan-tool/map-delegations/MapDelegationsDone.test.tsx
+++ b/__tests__/components/distribution-plan-tool/map-delegations/MapDelegationsDone.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import MapDelegationsDone from '../../../../components/distribution-plan-tool/map-delegations/MapDelegationsDone';
+
+describe('MapDelegationsDone', () => {
+  it('displays contract with bold highlight', () => {
+    render(<MapDelegationsDone contract="0xABC" />);
+    expect(screen.getByText(/Delegations are done using contract/i)).toBeInTheDocument();
+    const bold = screen.getByText('0xABC');
+    expect(bold).toBeInTheDocument();
+    expect(bold).toHaveClass('tw-font-bold');
+  });
+});

--- a/__tests__/components/distribution-plan-tool/wrapper/DistributionPlanToolWrapper.test.tsx
+++ b/__tests__/components/distribution-plan-tool/wrapper/DistributionPlanToolWrapper.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import DistributionPlanToolWrapper from '../../../../components/distribution-plan-tool/wrapper/DistributionPlanToolWrapper';
+import { AuthContext } from '../../../../components/auth/Auth';
+
+jest.mock('next/font/google', () => ({ Poppins: () => ({ className: 'poppins' }) }));
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../../../components/auth/SeizeConnectContext', () => ({ useSeizeConnectContext: jest.fn() }));
+
+const { useRouter } = require('next/router');
+const { useSeizeConnectContext } = require('../../../../components/auth/SeizeConnectContext');
+
+function renderWrapper(address?: string) {
+  const push = jest.fn();
+  (useRouter as jest.Mock).mockReturnValue({ push });
+  (useSeizeConnectContext as jest.Mock).mockReturnValue({ address });
+  const setTitle = jest.fn();
+  const result = render(
+    <AuthContext.Provider value={{ setTitle } as any}>
+      <DistributionPlanToolWrapper>
+        <div data-testid="child" />
+      </DistributionPlanToolWrapper>
+    </AuthContext.Provider>
+  );
+  return { push, setTitle, ...result };
+}
+
+describe('DistributionPlanToolWrapper', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('sets title on mount', () => {
+    const { setTitle } = renderWrapper();
+    expect(setTitle).toHaveBeenCalledWith({ title: 'EMMA | Tools' });
+  });
+
+  it('redirects to /emma when address changes', () => {
+    const { rerender, push } = renderWrapper();
+    (useSeizeConnectContext as jest.Mock).mockReturnValue({ address: '0xabc' });
+    rerender(
+      <AuthContext.Provider value={{ setTitle: jest.fn() } as any}>
+        <DistributionPlanToolWrapper>
+          <div />
+        </DistributionPlanToolWrapper>
+      </AuthContext.Provider>
+    );
+    expect(push).toHaveBeenCalledWith('/emma');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for CreateSnapshotFormSearchCollectionDropdownTable
- add tests for MapDelegationsDone
- add tests for DistributionPlanToolWrapper

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
