### PR TITLE
Add tests for toggles and IPFSService

### DIFF
--- a/__tests__/components/groups/page/create/config/rep/PositiveOnlyToggle.test.tsx
+++ b/__tests__/components/groups/page/create/config/rep/PositiveOnlyToggle.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import PositiveOnlyToggle from '../../../../../../../components/groups/page/create/config/rep/PositiveOnlyToggle';
+
+describe('PositiveOnlyToggle', () => {
+  it('reflects unchecked state and toggles on click', async () => {
+    const setPositiveOnly = jest.fn();
+    render(<PositiveOnlyToggle positiveOnly={false} setPositiveOnly={setPositiveOnly} />);
+    const checkbox = screen.getByLabelText('Positive Only');
+    expect(checkbox).not.toBeChecked();
+    await userEvent.click(checkbox);
+    expect(setPositiveOnly).toHaveBeenCalledWith(true);
+  });
+
+  it('shows checked state and toggles off', async () => {
+    const setPositiveOnly = jest.fn();
+    render(<PositiveOnlyToggle positiveOnly={true} setPositiveOnly={setPositiveOnly} />);
+    const checkbox = screen.getByLabelText('Positive Only');
+    expect(checkbox).toBeChecked();
+    const switchEl = screen.getByRole('switch');
+    expect(switchEl).toHaveAttribute('aria-checked', 'true');
+    const knob = switchEl.querySelector('span[aria-hidden="true"]') as HTMLElement;
+    expect(knob.className).toContain('tw-translate-x-5');
+    await userEvent.click(checkbox);
+    expect(setPositiveOnly).toHaveBeenCalledWith(false);
+  });
+});

--- a/__tests__/components/groups/sidebar/GroupsSidebarAppToggle.test.tsx
+++ b/__tests__/components/groups/sidebar/GroupsSidebarAppToggle.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useSelector } from 'react-redux';
+import GroupsSidebarAppToggle from '../../../../components/groups/sidebar/GroupsSidebarAppToggle';
+
+jest.mock('react-redux', () => ({ useSelector: jest.fn() }));
+
+const { useSelector: useSelectorMock } = jest.requireMock('react-redux');
+
+describe('GroupsSidebarAppToggle', () => {
+  it('highlights button when group selected and closed', async () => {
+    (useSelectorMock as jest.Mock).mockReturnValue('g1');
+    const setOpen = jest.fn();
+    render(<GroupsSidebarAppToggle open={false} setOpen={setOpen} />);
+    const button = screen.getByLabelText('Toggle groups sidebar');
+    expect(button.className).toContain('tw-text-primary-400');
+    await userEvent.click(button);
+    expect(setOpen).toHaveBeenCalledWith(true);
+  });
+
+  it('shows default color when open or no group selected', () => {
+    (useSelectorMock as jest.Mock).mockReturnValue(null);
+    const { rerender } = render(<GroupsSidebarAppToggle open={false} setOpen={jest.fn()} />);
+    let button = screen.getByLabelText('Toggle groups sidebar');
+    expect(button.className).toContain('tw-bg-iron-950');
+    rerender(<GroupsSidebarAppToggle open={true} setOpen={jest.fn()} />);
+    button = screen.getByLabelText('Toggle groups sidebar');
+    expect(button.className).toContain('tw-bg-iron-950');
+  });
+});

--- a/__tests__/components/ipfs/IPFSService.test.ts
+++ b/__tests__/components/ipfs/IPFSService.test.ts
@@ -1,0 +1,42 @@
+import IpfsService from '../../../components/ipfs/IPFSService';
+jest.mock("form-data", () => { return class { append = jest.fn(); }; });
+import axios from 'axios';
+
+jest.mock('axios');
+const axiosPostMock = axios.post as jest.Mock;
+
+describe('IpfsService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('adds file to ipfs and returns cid', async () => {
+    const service = new IpfsService({ apiEndpoint: 'http://api' });
+    const file = new File(['a'], 'a.txt', { type: 'text/plain' });
+    axiosPostMock.mockResolvedValueOnce({ data: { Hash: 'cid123' } });
+    const cid = await service.addFile(file);
+    expect(cid).toBe('cid123');
+    expect(axiosPostMock).toHaveBeenCalledWith('http://api/api/v0/add?pin=true', expect.any(Object));
+  });
+
+  it('creates mfs directory on init', async () => {
+    const service = new IpfsService({ apiEndpoint: 'http://api', mfsPath: 'files' });
+    axiosPostMock.mockResolvedValueOnce(null);
+    await service.init();
+    expect(axiosPostMock).toHaveBeenCalledWith('http://api/api/v0/files/mkdir?arg=/files&parents=true');
+  });
+
+  it('copies file to mfs when not existing', async () => {
+    const service = new IpfsService({ apiEndpoint: 'http://api', mfsPath: 'files' });
+    const file = new File(['data'], 'img.png', { type: 'image/png' });
+    axiosPostMock
+      .mockResolvedValueOnce({ data: { Hash: 'cid456' } }) // add
+      .mockRejectedValueOnce(new Error('missing')) // stat
+      .mockResolvedValueOnce(null); // cp
+    const cid = await service.addFile(file);
+    expect(cid).toBe('cid456');
+    expect(axiosPostMock).toHaveBeenNthCalledWith(1, 'http://api/api/v0/add?pin=true', expect.any(Object));
+    expect(axiosPostMock).toHaveBeenNthCalledWith(2, 'http://api/api/v0/files/stat?arg=/files/cid456.png');
+    expect(axiosPostMock).toHaveBeenNthCalledWith(3, 'http://api/api/v0/files/cp?arg=/ipfs/cid456&arg=/files/cid456.png');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for PositiveOnlyToggle component
- cover GroupsSidebarAppToggle toggle behavior
- add service tests for IPFSService

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
