### PR TITLE
Add tests for group page logic

### DIFF
--- a/__tests__/components/drops/view/item/content/media/DropListItemContentMediaGLB.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/DropListItemContentMediaGLB.test.tsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import DropListItemContentMediaGLB from '../../../../../../../components/drops/view/item/content/media/DropListItemContentMediaGLB';
+
+describe('DropListItemContentMediaGLB', () => {
+  it('renders an empty div for any src', () => {
+    const { container } = render(<DropListItemContentMediaGLB src="model.glb" />);
+    const div = container.querySelector('div');
+    expect(div).toBeInTheDocument();
+    expect(div?.childElementCount).toBe(0);
+  });
+
+  it('ignores the src prop but does not throw', () => {
+    const { container } = render(<DropListItemContentMediaGLB src="anything.glb" />);
+    expect(container.firstChild).toBeInstanceOf(HTMLDivElement);
+  });
+});

--- a/__tests__/components/groups/page/GroupsPageListWrapper.test.tsx
+++ b/__tests__/components/groups/page/GroupsPageListWrapper.test.tsx
@@ -1,0 +1,71 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import GroupsPageListWrapper from '../../../../components/groups/page/GroupsPageListWrapper';
+import { AuthContext } from '../../../../components/auth/Auth';
+import { useRouter } from 'next/router';
+import { useSearchParams, usePathname } from 'next/navigation';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn(),
+  usePathname: jest.fn()
+}));
+
+let listProps: any;
+jest.mock('../../../../components/groups/page/list/GroupsList', () => (props: any) => {
+  listProps = props;
+  return <div data-testid="list" />;
+});
+
+const replace = jest.fn();
+const searchMap = new Map<string, string | null>();
+
+function setupContext(context: any) {
+  (useRouter as jest.Mock).mockReturnValue({ replace });
+  (usePathname as jest.Mock).mockReturnValue('/groups');
+  (useSearchParams as jest.Mock).mockReturnValue({
+    get: (k: string) => searchMap.get(k) ?? null,
+    toString: () => {
+      const params = new URLSearchParams();
+      for (const [key, val] of Array.from(searchMap.entries())) {
+        if (val !== null) params.set(key, val);
+      }
+      return params.toString();
+    }
+  });
+  listProps = null;
+  replace.mockReset();
+  return render(
+    <AuthContext.Provider value={context}>
+      <GroupsPageListWrapper onCreateNewGroup={jest.fn()} />
+    </AuthContext.Provider>
+  );
+}
+
+describe('GroupsPageListWrapper', () => {
+  beforeEach(() => {
+    searchMap.clear();
+  });
+
+  it('initializes filters and buttons from context and params', () => {
+    searchMap.set('group', 'test');
+    searchMap.set('identity', 'bob');
+    setupContext({ connectedProfile: { handle: 'alice' }, activeProfileProxy: null });
+    expect(listProps.filters).toEqual({ group_name: 'test', author_identity: 'bob' });
+    expect(listProps.showCreateNewGroupButton).toBe(true);
+    expect(listProps.showMyGroupsButton).toBe(true);
+  });
+
+  it('updates query string when setting group name', () => {
+    searchMap.set('identity', 'bob');
+    setupContext({ connectedProfile: { handle: 'alice' }, activeProfileProxy: null });
+    listProps.setGroupName('new');
+    expect(replace).toHaveBeenCalledWith('/groups?identity=bob&group=new', undefined, { shallow: true });
+  });
+
+  it('uses proxy handle when available in onMyGroups', () => {
+    setupContext({ connectedProfile: { handle: 'alice' }, activeProfileProxy: { created_by: { handle: 'proxy' } } });
+    listProps.onMyGroups();
+    expect(replace).toHaveBeenCalledWith('/groups?identity=proxy', undefined, { shallow: true });
+  });
+});

--- a/__tests__/components/groups/page/create/GroupCreate.test.tsx
+++ b/__tests__/components/groups/page/create/GroupCreate.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import GroupCreate from '../../../../../components/groups/page/create/GroupCreate';
+import { AuthContext } from '../../../../../components/auth/Auth';
+import { useQuery } from '@tanstack/react-query';
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: jest.fn(),
+  keepPreviousData: 'keepPreviousData'
+}));
+
+let includeProps: any;
+let nameProps: any;
+
+jest.mock('../../../../../components/groups/page/create/GroupCreateWrapper', () => (props: any) => <div data-testid="wrapper">{props.children}</div>);
+jest.mock('../../../../../components/groups/page/create/GroupCreateHeader', () => () => <div data-testid="header" />);
+jest.mock('../../../../../components/groups/page/create/GroupCreateName', () => (props: any) => { nameProps = props; return <div data-testid="name" />; });
+jest.mock('../../../../../components/groups/page/create/config/include-me-and-private/GroupCreateIncludeMeAndPrivate', () => (props: any) => { includeProps = props; return <div data-testid="include" />; });
+jest.mock('../../../../../components/groups/page/create/config/GroupCreateConfig', () => () => <div data-testid="config" />);
+jest.mock('../../../../../components/groups/page/create/actions/GroupCreateActions', () => () => <div data-testid="actions" />);
+
+const mockedUseQuery = useQuery as jest.Mock;
+mockedUseQuery.mockReturnValue({ isFetching: false, data: null });
+
+function renderComponent(ctx: any) {
+  mockedUseQuery.mockReturnValueOnce({ isFetching: false, data: null })
+                .mockReturnValueOnce({ isFetching: false, data: null });
+  return render(
+    <AuthContext.Provider value={ctx}>
+      <GroupCreate edit="new" onCompleted={jest.fn()} />
+    </AuthContext.Provider>
+  );
+}
+
+describe('GroupCreate', () => {
+  it('shows loading indicator when fetching', () => {
+    mockedUseQuery.mockReturnValueOnce({ isFetching: true, data: null })
+                  .mockReturnValueOnce({ isFetching: true, data: null });
+    const { getByText } = renderComponent({ connectedProfile: null });
+    expect(getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('allows including primary wallet', () => {
+    const ctx = { connectedProfile: { primary_wallet: '0xA', wallets: [{wallet:'0xA'}] } } as any;
+    const { rerender } = renderComponent(ctx);
+    expect(includeProps.iAmIncluded).toBe(false);
+    act(() => { includeProps.setIAmIncluded(true); });
+    rerender(
+      <AuthContext.Provider value={ctx}>
+        <GroupCreate edit="new" onCompleted={jest.fn()} />
+      </AuthContext.Provider>
+    );
+    expect(includeProps.iAmIncluded).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- test DropListItemContentMediaGLB component
- cover GroupsPageListWrapper interactions with router and context
- add GroupCreate component tests for loading state and wallet inclusion

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage`