### PR TITLE
Add test for GroupCreateConfigHeader

### DIFF
--- a/__tests__/components/groups/page/create/GroupCreateConfigHeader.test.tsx
+++ b/__tests__/components/groups/page/create/GroupCreateConfigHeader.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import GroupCreateConfigHeader from '../../../../../components/groups/page/create/GroupCreateConfigHeader';
+
+describe('GroupCreateConfigHeader', () => {
+  it('renders header with icon and label', () => {
+    const { container } = render(<GroupCreateConfigHeader />);
+
+    const outerDiv = container.firstElementChild as HTMLElement;
+    expect(outerDiv.tagName).toBe('DIV');
+    expect(outerDiv).toHaveClass('tw-inline-flex');
+    expect(outerDiv).toHaveClass('tw-items-center');
+
+    const icon = outerDiv.querySelector('svg');
+    expect(icon).toBeInTheDocument();
+
+    expect(screen.getByText('Types')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add test for GroupCreateConfigHeader component

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run test:cov`
- `npm run improve-coverage`