### PR TITLE
Improve test coverage

### DIFF
--- a/__tests__/components/user/collected/filters/user-page-collected-filters.helpers.test.ts
+++ b/__tests__/components/user/collected/filters/user-page-collected-filters.helpers.test.ts
@@ -1,0 +1,44 @@
+import { COLLECTED_COLLECTIONS_META, convertAddressToLowerCase } from "../../../../../components/user/collected/filters/user-page-collected-filters.helpers";
+import { CollectedCollectionType, CollectionSort } from "../../../../../entities/IProfile";
+
+describe("COLLECTED_COLLECTIONS_META", () => {
+  it("contains correct metadata for MEMES", () => {
+    const memes = COLLECTED_COLLECTIONS_META[CollectedCollectionType.MEMES];
+    expect(memes.label).toBe("The Memes");
+    expect(memes.showCardDataRow).toBe(true);
+    expect(memes.dataRows.seizedCount).toBe(true);
+    expect(memes.filters.seized).toBe(true);
+    expect(memes.filters.szn).toBe(true);
+    expect(memes.filters.sort).toEqual([
+      CollectionSort.TOKEN_ID,
+      CollectionSort.TDH,
+      CollectionSort.RANK,
+    ]);
+    expect(memes.cardPath).toBe("/the-memes");
+  });
+
+  it("contains correct metadata for MEMELAB", () => {
+    const memelab = COLLECTED_COLLECTIONS_META[CollectedCollectionType.MEMELAB];
+    expect(memelab.showCardDataRow).toBe(false);
+    expect(memelab.dataRows.seizedCount).toBe(true);
+    expect(memelab.filters.seized).toBe(false);
+    expect(memelab.filters.szn).toBe(false);
+    expect(memelab.filters.sort).toEqual([CollectionSort.TOKEN_ID]);
+    expect(memelab.cardPath).toBe("/meme-lab");
+  });
+});
+
+describe("convertAddressToLowerCase", () => {
+  it("lowercases valid address strings", () => {
+    expect(convertAddressToLowerCase("0xABCDEF")).toBe("0xabcdef");
+  });
+
+  it("returns null for non-string values", () => {
+    expect(convertAddressToLowerCase(undefined as any)).toBeNull();
+    expect(convertAddressToLowerCase(123 as any)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(convertAddressToLowerCase("")).toBeNull();
+  });
+});

--- a/__tests__/components/user/identity/header/cic-rate/UserPageIdentityHeaderCICRateStats.test.tsx
+++ b/__tests__/components/user/identity/header/cic-rate/UserPageIdentityHeaderCICRateStats.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import UserPageIdentityHeaderCICRateStats from "../../../../../../components/user/identity/header/cic-rate/UserPageIdentityHeaderCICRateStats";
+import { renderWithAuth } from "../../../../../utils/testContexts";
+import { ApiProfileProxyActionType } from "../../../../../../generated/models/ApiProfileProxyActionType";
+
+jest.mock("next/link", () => ({ __esModule: true, default: ({ href, children }: any) => <a href={href}>{children}</a> }));
+jest.mock("../../../../../../helpers/Helpers", () => ({
+  formatNumberWithCommas: (n: number) => `f${n}`,
+}));
+
+const profile = { handle: "bob" } as any;
+
+function setup(authOverrides: any, props: any) {
+  return renderWithAuth(
+    <UserPageIdentityHeaderCICRateStats isTooltip={false} profile={profile} {...props} />,
+    authOverrides
+  );
+}
+
+describe("UserPageIdentityHeaderCICRateStats", () => {
+  it("shows hero credit values without proxy", () => {
+    setup({ activeProfileProxy: null }, {
+      minMaxValues: { min: 1, max: 2 },
+      heroAvailableCredit: 50,
+    });
+
+    expect(screen.queryByText(/acting as proxy/)).toBeNull();
+    expect(screen.getByText("f50")).toBeInTheDocument();
+    expect(screen.getByText("\+/\- f2")).toBeInTheDocument();
+  });
+
+  it("renders proxy information when active", () => {
+    const proxy = {
+      created_by: { handle: "alice" },
+      actions: [
+        {
+          action_type: ApiProfileProxyActionType.AllocateCic,
+          credit_amount: 100,
+          credit_spent: 10,
+        },
+      ],
+    };
+
+    setup(
+      { activeProfileProxy: proxy },
+      { minMaxValues: { min: 3, max: 4 }, heroAvailableCredit: 50 }
+    );
+
+    expect(screen.getByText("alice").closest("a")).toHaveAttribute("href", "/alice");
+    expect(screen.getByText("f50")).toBeInTheDocument();
+    expect(screen.getByText("f4")).toBeInTheDocument();
+    expect(screen.getByText("f3")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/user/identity/statements/add/contact/UserPageIdentityAddStatementsContactHeader.test.tsx
+++ b/__tests__/components/user/identity/statements/add/contact/UserPageIdentityAddStatementsContactHeader.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import UserPageIdentityAddStatementsContactHeader from "../../../../../../../components/user/identity/statements/add/contact/UserPageIdentityAddStatementsContactHeader";
+
+describe("UserPageIdentityAddStatementsContactHeader", () => {
+  it("calls onClose when close button clicked", async () => {
+    const onClose = jest.fn();
+    render(<UserPageIdentityAddStatementsContactHeader onClose={onClose} />);
+    await userEvent.click(screen.getByRole("button", { name: /close/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("renders title", () => {
+    render(<UserPageIdentityAddStatementsContactHeader onClose={() => {}} />);
+    expect(screen.getByText("Add Contact")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for user page collection filters helpers
- add tests for identity header CIC rate stats
- add tests for add statements contact header

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
