### PR TITLE
Improve test coverage for header and activity components

### DIFF
--- a/__tests__/components/header/user/HeaderUserConnected.test.tsx
+++ b/__tests__/components/header/user/HeaderUserConnected.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import HeaderUserConnected from "../../../../components/header/user/HeaderUserConnected";
+
+const connectingMock = jest.fn((props: any) => <div data-testid="connecting" />);
+const contextMock = jest.fn((props: any) => <div data-testid="context">{JSON.stringify(props)}</div>);
+
+jest.mock("../../../../components/header/user/HeaderUserConnecting", () => ({
+  __esModule: true,
+  default: (props: any) => connectingMock(props),
+}));
+
+jest.mock("../../../../components/header/user/HeaderUserContext", () => ({
+  __esModule: true,
+  default: (props: any) => contextMock(props),
+}));
+
+jest.mock("../../../../hooks/useIdentity", () => ({
+  useIdentity: jest.fn(),
+}));
+
+const { useIdentity } = require("../../../../hooks/useIdentity");
+
+function setup(result: { profile: any; isLoading: boolean }) {
+  (useIdentity as jest.Mock).mockReturnValue(result);
+  return render(<HeaderUserConnected connectedAddress="0xabc" />);
+}
+
+afterEach(() => jest.clearAllMocks());
+
+describe("HeaderUserConnected", () => {
+  it("shows connecting component while loading", () => {
+    setup({ profile: null, isLoading: true });
+    expect(screen.getByTestId("connecting")).toBeInTheDocument();
+    expect(connectingMock).toHaveBeenCalled();
+    expect(contextMock).not.toHaveBeenCalled();
+    expect(useIdentity).toHaveBeenCalledWith({ handleOrWallet: "0xabc", initialProfile: null });
+  });
+
+  it("shows connecting component when profile missing", () => {
+    setup({ profile: null, isLoading: false });
+    expect(screen.getByTestId("connecting")).toBeInTheDocument();
+    expect(contextMock).not.toHaveBeenCalled();
+  });
+
+  it("renders context when profile available", () => {
+    const profile = { handle: "alice" };
+    setup({ profile, isLoading: false });
+    expect(screen.getByTestId("context")).toBeInTheDocument();
+    expect(contextMock).toHaveBeenCalledWith({ profile });
+  });
+});

--- a/__tests__/components/latest-activity/LatestActivityRow.test.tsx
+++ b/__tests__/components/latest-activity/LatestActivityRow.test.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { faFire, faCartPlus } from "@fortawesome/free-solid-svg-icons";
+import LatestActivityRow, { printRoyalties } from "../../../components/latest-activity/LatestActivityRow";
+import { MANIFOLD } from "../../../constants";
+
+jest.mock('next/image', () => ({ __esModule: true, default: (p:any) => <img {...p}/> }));
+jest.mock('@tippyjs/react', () => (p:any) => <div data-testid="tippy">{p.children}</div>);
+const iconMock = jest.fn();
+jest.mock('@fortawesome/react-fontawesome', () => ({ FontAwesomeIcon: (p:any) => { iconMock(p); return <svg data-testid="icon" />; } }));
+jest.mock('react-bootstrap', () => ({ Container:(p:any)=><div data-testid="container">{p.children}</div>, Row:(p:any)=><div>{p.children}</div>, Col:(p:any)=><div>{p.children}</div> }));
+jest.mock("../../../components/address/Address", () => (p:any) => <span>{p.display}</span>);
+
+jest.mock("../../../helpers/Helpers", () => ({
+  areEqualAddresses: (a:string,b:string)=>a.toLowerCase()===b.toLowerCase(),
+  areEqualURLS: (a:string,b:string)=>a===b,
+  displayDecimal: (n:number)=>String(n),
+  getDateDisplay: () => 'now',
+  isNextgenContract: () => false,
+  isGradientsContract: () => false,
+  isMemeLabContract: () => false,
+  isMemesContract: () => true,
+  isNullAddress: (a:string)=>a==="0x0",
+  numberWithCommas: (n:number)=>String(n),
+  getRoyaltyImage: () => 'royal.png',
+}));
+
+afterEach(() => jest.clearAllMocks());
+
+describe('printRoyalties', () => {
+  it('returns empty fragment when value is zero', () => {
+    const { container } = render(<>{printRoyalties(0,1,'0x1')}</>);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders image with royalty tooltip when applicable', () => {
+    const { container } = render(<>{printRoyalties(10,2,'0x1')}</>);
+    const img = container.querySelector('img') as HTMLImageElement;
+    expect(img).toHaveAttribute('src','/royal.png');
+    expect(img).toHaveAttribute('alt','royal.png');
+  });
+});
+
+describe('LatestActivityRow', () => {
+  const baseTr = {
+    contract: '0xcontract',
+    from_address: '0xfrom',
+    from_display: 'From',
+    to_address: '0xto',
+    to_display: 'To',
+    token_id: 1,
+    token_count: 1,
+    value: 0,
+    gas: 1,
+    gas_gwei: 1,
+    gas_price_gwei: 1,
+    transaction: 'tx',
+    transaction_date: '2020-01-01',
+    royalties: 0,
+  } as any;
+
+  it('uses burn icon when to address is null', () => {
+    render(<table><tbody><LatestActivityRow tr={{...baseTr, to_address: "0x0"}} /></tbody></table>);
+    expect(iconMock).toHaveBeenCalledWith(expect.objectContaining({ icon: faFire, className: 'iconRed' }));
+  });
+
+  it('uses mint icon when from address is MANIFOLD and value > 0', () => {
+    render(<table><tbody><LatestActivityRow tr={{...baseTr, from_address: MANIFOLD, value: 1}} /></tbody></table>);
+    expect(iconMock).toHaveBeenCalledWith(expect.objectContaining({ icon: faCartPlus, className: 'iconWhite' }));
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for HeaderUserConnected component
- add tests for LatestActivityRow helpers and icon logic

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
