### PR TITLE
Increase coverage for group creation switches

### DIFF
--- a/__tests__/components/GroupCreateIncludeMeAndPrivate.test.tsx
+++ b/__tests__/components/GroupCreateIncludeMeAndPrivate.test.tsx
@@ -1,0 +1,24 @@
+import { render, fireEvent } from '@testing-library/react';
+import GroupCreateIncludeMeAndPrivate from '../../components/groups/page/create/config/include-me-and-private/GroupCreateIncludeMeAndPrivate';
+
+describe('GroupCreateIncludeMeAndPrivate', () => {
+  it('forwards state changes from both toggles', () => {
+    const onPrivate = jest.fn();
+    const onInclude = jest.fn();
+    const { getAllByRole } = render(
+      <GroupCreateIncludeMeAndPrivate
+        isPrivate={false}
+        setIsPrivate={onPrivate}
+        iAmIncluded={false}
+        setIAmIncluded={onInclude}
+      />
+    );
+
+    const switches = getAllByRole('switch');
+    fireEvent.click(switches[0]);
+    fireEvent.click(switches[1]);
+
+    expect(onInclude).toHaveBeenCalledWith(true);
+    expect(onPrivate).toHaveBeenCalledWith(true);
+  });
+});

--- a/__tests__/components/GroupCreatePrivate.test.tsx
+++ b/__tests__/components/GroupCreatePrivate.test.tsx
@@ -1,0 +1,14 @@
+import { render, fireEvent } from '@testing-library/react';
+import GroupCreatePrivate from '../../components/groups/page/create/config/include-me-and-private/GroupCreatePrivate';
+
+describe('GroupCreatePrivate', () => {
+  it('toggles checkbox and calls callback', () => {
+    const mock = jest.fn();
+    const { getByRole } = render(
+      <GroupCreatePrivate isPrivate={false} setIsPrivate={mock} />
+    );
+    const toggle = getByRole('switch');
+    fireEvent.click(toggle);
+    expect(mock).toHaveBeenCalledWith(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for GroupCreatePrivate component
- add tests for GroupCreateIncludeMeAndPrivate component

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
