### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/components/GroupCreatePrivate.test.tsx
+++ b/__tests__/components/GroupCreatePrivate.test.tsx
@@ -1,0 +1,14 @@
+import { render, fireEvent } from '@testing-library/react';
+import GroupCreatePrivate from '../../components/groups/page/create/config/include-me-and-private/GroupCreatePrivate';
+
+describe('GroupCreatePrivate', () => {
+  it('toggles checkbox and calls callback', () => {
+    const mock = jest.fn();
+    const { getByRole } = render(
+      <GroupCreatePrivate isPrivate={false} setIsPrivate={mock} />
+    );
+    const toggle = getByRole('switch');
+    fireEvent.click(toggle);
+    expect(mock).toHaveBeenCalledWith(true);
+  });
+});

--- a/__tests__/components/groups/page/create/GroupCreateHeader.test.tsx
+++ b/__tests__/components/groups/page/create/GroupCreateHeader.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import GroupCreateHeader from '../../../../../components/groups/page/create/GroupCreateHeader';
+
+describe('GroupCreateHeader', () => {
+  it('renders icon and label with expected classes', () => {
+    const { container } = render(<GroupCreateHeader />);
+    const outer = container.firstElementChild as HTMLElement;
+    expect(outer).toHaveClass('tw-inline-flex');
+    expect(outer).toHaveClass('tw-items-center');
+
+    const icon = outer.querySelector('svg');
+    expect(icon).toBeInTheDocument();
+    expect(screen.getByText('Group configuration')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/groups/page/create/config/include-me-and-private/GroupCreateIncludeMeAndPrivate.test.tsx
+++ b/__tests__/components/groups/page/create/config/include-me-and-private/GroupCreateIncludeMeAndPrivate.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+let includeProps: any;
+let privateProps: any;
+
+jest.mock('../../../../../../../components/groups/page/create/config/include-me-and-private/GroupCreateIncludeMe', () => (props: any) => { includeProps = props; return <div data-testid="include" />; });
+jest.mock('../../../../../../../components/groups/page/create/config/include-me-and-private/GroupCreatePrivate', () => (props: any) => { privateProps = props; return <div data-testid="private" />; });
+
+import GroupCreateIncludeMeAndPrivate from '../../../../../../../components/groups/page/create/config/include-me-and-private/GroupCreateIncludeMeAndPrivate';
+
+describe('GroupCreateIncludeMeAndPrivate', () => {
+  it('passes props to child components', () => {
+    const setPrivate = jest.fn();
+    const setInclude = jest.fn();
+    const { container } = render(
+      <GroupCreateIncludeMeAndPrivate
+        isPrivate={true}
+        setIsPrivate={setPrivate}
+        iAmIncluded={false}
+        setIAmIncluded={setInclude}
+      />
+    );
+    expect(includeProps).toEqual({ iAmIncluded: false, setIAmIncluded: setInclude });
+    expect(privateProps).toEqual({ isPrivate: true, setIsPrivate: setPrivate });
+    const outer = container.firstElementChild as HTMLElement;
+    expect(outer).toHaveClass('tw-p-3');
+  });
+});

--- a/__tests__/components/layout/MainLayout.test.tsx
+++ b/__tests__/components/layout/MainLayout.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+const useRouter = jest.fn();
+const useDeviceInfo = jest.fn();
+const useAuth = jest.fn();
+
+jest.mock("next/router", () => ({ useRouter: () => useRouter() }));
+jest.mock("../../../hooks/useDeviceInfo", () => ({ __esModule: true, default: () => useDeviceInfo() }));
+jest.mock("../../../components/auth/Auth", () => ({ useAuth: () => useAuth() }));
+
+jest.mock("../../../components/layout/MobileLayout", () => ({ __esModule: true, default: ({ children }: any) => <div data-testid="mobile">{children}</div> }));
+jest.mock("../../../components/layout/DesktopLayout", () => ({ __esModule: true, default: ({ children, isSmall }: any) => <div data-testid="desktop" data-small={isSmall ? 'true' : 'false'}>{children}</div> }));
+
+jest.mock("../../../components/client-only/ClientOnly", () => ({ __esModule: true, default: ({ children }: any) => <>{children}</> }));
+jest.mock("../../../components/navigation/ViewContext", () => ({ ViewProvider: ({ children }: any) => <>{children}</> }));
+jest.mock("../../../contexts/NavigationHistoryContext", () => ({ NavigationHistoryProvider: ({ children }: any) => <>{children}</> }));
+jest.mock("../../../contexts/wave/MyStreamContext", () => ({ MyStreamProvider: ({ children }: any) => <>{children}</> }));
+jest.mock("../../../components/brain/my-stream/layout/LayoutContext", () => ({ LayoutProvider: ({ children }: any) => <>{children}</> }));
+jest.mock("../../../contexts/ScrollPositionContext", () => ({ ScrollPositionProvider: ({ children }: any) => <>{children}</> }));
+
+const MainLayout = require("../../../components/layout/MainLayout").default;
+
+const metadata = {
+  title: "Meta",
+  description: "desc",
+  ogImage: "image",
+  twitterCard: "summary" as const,
+};
+
+beforeEach(() => {
+  useAuth.mockReturnValue({ title: "Auth" });
+  process.env.BASE_ENDPOINT = "https://base";
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("MainLayout", () => {
+  it("returns children directly on /access routes", () => {
+    useRouter.mockReturnValue({ pathname: "/access/login", asPath: "/access/login" });
+    useDeviceInfo.mockReturnValue({ isMobileDevice: false, hasTouchScreen: false, isApp: false });
+    render(<MainLayout metadata={metadata}>child</MainLayout>);
+    expect(screen.getByText("child")).toBeInTheDocument();
+    expect(screen.queryByTestId("desktop")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("mobile")).not.toBeInTheDocument();
+  });
+
+  it("uses MobileLayout when device is mobile", () => {
+    useRouter.mockReturnValue({ pathname: "/", asPath: "/" });
+    useDeviceInfo.mockReturnValue({ isMobileDevice: true, hasTouchScreen: false, isApp: false });
+    render(<MainLayout metadata={metadata}>child</MainLayout>);
+    expect(screen.getByTestId("mobile")).toBeInTheDocument();
+    expect(screen.queryByTestId("desktop")).not.toBeInTheDocument();
+  });
+
+  it("passes isSmall=true for /my-stream routes", () => {
+    useRouter.mockReturnValue({ pathname: "/my-stream/page", asPath: "/my-stream/page" });
+    useDeviceInfo.mockReturnValue({ isMobileDevice: false, hasTouchScreen: false, isApp: false });
+    render(<MainLayout metadata={metadata}>child</MainLayout>);
+    const desktop = screen.getByTestId("desktop");
+    expect(desktop).toBeInTheDocument();
+    expect(desktop.getAttribute("data-small")).toBe("true");
+  });
+
+  it("passes isSmall=false on other routes", () => {
+    useRouter.mockReturnValue({ pathname: "/other", asPath: "/other" });
+    useDeviceInfo.mockReturnValue({ isMobileDevice: false, hasTouchScreen: false, isApp: false });
+    render(<MainLayout metadata={metadata}>child</MainLayout>);
+    const desktop = screen.getByTestId("desktop");
+    expect(desktop.getAttribute("data-small")).toBe("false");
+  });
+
+});


### PR DESCRIPTION
## Summary
- add tests for MainLayout
- add tests for group creation header component
- add tests for IncludeMeAndPrivate wrapper
- add tests for GroupCreatePrivate toggle

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage`