### PR TITLE
Increase test coverage for leaderboard and minting components

### DIFF
--- a/__tests__/components/leaderboard/MemeLabLeaderboard.test.tsx
+++ b/__tests__/components/leaderboard/MemeLabLeaderboard.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MemeLabLeaderboard from '../../../components/leaderboard/MemeLabLeaderboard';
+import { SortDirection } from '../../../entities/ISort';
+
+jest.mock('../../../components/leaderboard/NFTLeaderboard', () => ({
+  fetchNftTdhResults: jest.fn(),
+  PAGE_SIZE: 25,
+  setScrollPosition: jest.fn(),
+}));
+
+jest.mock('../../../components/leaderboard/LeaderboardCollector', () => ({
+  LeaderboardCollector: (p: any) => <div data-testid="collector">{p.handle}</div>,
+}));
+
+jest.mock('../../../components/pagination/Pagination', () => (props: any) => (
+  <div data-testid="pagination" onClick={() => props.setPage(props.page + 1)}>next</div>
+));
+
+jest.mock('react-bootstrap', () => {
+  const React = require('react');
+  return {
+    Container: (p: any) => <div data-testid="container">{p.children}</div>,
+    Row: (p: any) => <div data-testid="row">{p.children}</div>,
+    Col: (p: any) => <div data-testid="col">{p.children}</div>,
+    Table: (p: any) => <table>{p.children}</table>,
+  };
+});
+
+const { fetchNftTdhResults, setScrollPosition } = require('../../../components/leaderboard/NFTLeaderboard');
+
+const baseData = [
+  {
+    consolidation_key: '0x1',
+    handle: 'alice',
+    consolidation_display: 'Alice',
+    pfp_url: '',
+    cic_type: undefined,
+    level: 1,
+    balance: 5,
+  },
+  {
+    consolidation_key: '0x2',
+    handle: 'bob',
+    consolidation_display: 'Bob',
+    pfp_url: '',
+    cic_type: undefined,
+    level: 1,
+    balance: 2,
+  },
+];
+
+function setup() {
+  (fetchNftTdhResults as jest.Mock)
+    .mockResolvedValueOnce({ count: baseData.length, data: baseData })
+    .mockResolvedValueOnce({ count: baseData.length, data: baseData })
+    .mockResolvedValueOnce({ count: baseData.length, data: baseData });
+
+  return render(<MemeLabLeaderboard contract="0x1" nftId={1} />);
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+test('renders leaderboard and sorts when caret clicked', async () => {
+  const { container } = setup();
+
+  await waitFor(() => expect(fetchNftTdhResults).toHaveBeenCalled());
+  expect(setScrollPosition).toHaveBeenCalledTimes(2);
+  await screen.findByText('alice');
+  await screen.findByText('bob');
+
+  const icons = container.querySelectorAll('svg');
+  await userEvent.click(icons[0]);
+
+  await waitFor(() => expect(fetchNftTdhResults).toHaveBeenCalledTimes(3));
+  expect(fetchNftTdhResults.mock.calls[2][5]).toBe(SortDirection.ASC);
+  expect(setScrollPosition).toHaveBeenCalledTimes(3);
+});
+
+
+test('shows message when no results', async () => {
+  (fetchNftTdhResults as jest.Mock)
+    .mockResolvedValueOnce({ count: 0, data: [] })
+    .mockResolvedValueOnce({ count: 0, data: [] });
+  render(<MemeLabLeaderboard contract="0x1" nftId={1} />);
+  await screen.findByText('No Results found');
+});

--- a/__tests__/components/manifoldMinting/ManifoldMinting.test.tsx
+++ b/__tests__/components/manifoldMinting/ManifoldMinting.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import ManifoldMinting from '../../../components/manifoldMinting/ManifoldMinting';
+import { Time } from '../../../helpers/time';
+
+jest.mock('next/link', () => ({ __esModule: true, default: ({href, children}:any) => <a href={href}>{children}</a> }));
+
+jest.mock('react-bootstrap', () => {
+  const React = require('react');
+  return {
+    Container: (p:any) => <div>{p.children}</div>,
+    Row: (p:any) => <div>{p.children}</div>,
+    Col: (p:any) => <div>{p.children}</div>,
+    Table: (p:any) => <table>{p.children}</table>,
+  };
+});
+
+jest.mock('../../../components/nft-image/NFTImage', () => () => <div data-testid="image" />);
+jest.mock('../../../components/nftAttributes/NFTAttributes', () => () => <div data-testid="attrs" />);
+jest.mock('../../../components/manifoldMinting/ManifoldMintingWidget', () => () => <div data-testid="widget" />);
+jest.mock('../../../components/the-memes/MemePageMintCountdown', () => () => <div data-testid="countdown" />);
+
+jest.mock('../../../hooks/useManifoldClaim', () => ({
+  __esModule: true,
+  default: jest.fn(),
+  ManifoldClaimStatus: { ACTIVE: 'active' },
+  buildMemesPhases: () => [
+    { id: 'public', name: 'Public', type: 'public', start: Time.now(), end: Time.now() },
+  ],
+}));
+
+jest.mock('../../../helpers/Helpers', () => ({
+  areEqualAddresses: () => true,
+  capitalizeEveryWord: (s: string) => s,
+  fromGWEI: (n: number) => n,
+  getNameForContract: () => 'Contract',
+  getPathForContract: () => 'path',
+  numberWithCommas: (n: number) => String(n),
+  parseNftDescriptionToHtml: (d: string) => d,
+}));
+
+const useManifoldClaim = require('../../../hooks/useManifoldClaim').default as jest.Mock;
+
+afterEach(() => jest.clearAllMocks());
+
+test('shows error message when hook reports error', async () => {
+  let called = false;
+  useManifoldClaim.mockImplementation((c,p,a,t,onError) => {
+    if (!called) {
+      called = true;
+      onError();
+    }
+    return undefined;
+  });
+  render(
+    <ManifoldMinting title="Title" contract="0x1" proxy="0x2" abi={{}} token_id={1} mint_date={Time.now()} />
+  );
+  await screen.findByText('Error fetching mint information');
+});
+
+test('renders nft info after successful fetch', async () => {
+  global.fetch = jest.fn().mockResolvedValue({ json: () => Promise.resolve({ id:1, publicData: { asset: { name: 'NFT', description:'', attributes: [] }, instanceAllowlist:{ merkleTreeId:1 } } }) });
+  useManifoldClaim.mockReturnValue({
+    instanceId: 1,
+    total: 1,
+    totalMax: 1,
+    remaining: 0,
+    cost: 1,
+    startDate: 1,
+    endDate: 2,
+    status: 'active',
+    phase: 'public',
+    isFetching: false,
+    isFinalized: false,
+  });
+  render(
+    <ManifoldMinting title="Title" contract="0x1" proxy="0x2" abi={{}} token_id={1} mint_date={Time.now()} />
+  );
+  await screen.findByText('NFT');
+});

--- a/__tests__/components/mapping-tools/MappingToolPlaceholder.test.tsx
+++ b/__tests__/components/mapping-tools/MappingToolPlaceholder.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import MappingToolPlaceholder from '../../../components/mapping-tools/MappingToolPlaceholder';
+
+jest.mock('react-bootstrap', () => ({ Container: (p:any)=> <div>{p.children}</div> }));
+
+it('renders placeholder div with correct class', () => {
+  const { container } = render(<MappingToolPlaceholder />);
+  const div = container.querySelector('div');
+  expect(div).toHaveClass('placeholder');
+});


### PR DESCRIPTION
## Summary
- add unit tests for MemeLabLeaderboard component
- add unit tests for ManifoldMinting component
- add MappingToolPlaceholder test

## Testing
- `npm run test --silent`
- `npm run lint`
- `npm run type-check`
