### PR TITLE
Add tests for PdfViewer, TermsOfServiceModal and NextGenTokenProvenance

### DIFF
--- a/__tests__/components/nextGen/collections/nextgenToken/NextGenTokenProvenance.test.tsx
+++ b/__tests__/components/nextGen/collections/nextgenToken/NextGenTokenProvenance.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NextGenTokenProvenance from '../../../../../components/nextGen/collections/nextgenToken/NextGenTokenProvenance';
+import { NextGenCollection } from '../../../../../entities/INextgen';
+
+jest.mock('../../../../../services/api/common-api', () => ({
+  commonApiFetch: jest.fn(),
+}));
+
+jest.mock('../../../../../components/latest-activity/LatestActivityRow', () => (props: any) => (
+  <tr data-testid="activity-row">{props.tr.id}</tr>
+));
+
+jest.mock('../../../../../components/nextGen/collections/collectionParts/NextGenCollectionProvenance', () => ({
+  NextGenCollectionProvenanceRow: (props: any) => (
+    <div data-testid="log-row">{props.log.id}</div>
+  ),
+}));
+
+jest.mock('../../../../../components/pagination/Pagination', () => (props: any) => (
+  <div data-testid="pagination">
+    <button onClick={() => props.setPage(props.page + 1)}>next</button>
+  </div>
+));
+
+jest.mock('react-bootstrap', () => {
+  const React = require('react');
+  return {
+    Container: (p: any) => <div {...p} />,
+    Row: (p: any) => <div {...p} />,
+    Col: (p: any) => <div {...p} />,
+    Table: (p: any) => <table {...p} />,
+  };
+});
+
+const { commonApiFetch } = require('../../../../../services/api/common-api');
+
+const collection: NextGenCollection = { id: 1 } as any;
+const transaction = { id: 't1', from_address: 'a', to_address: 'b', transaction: 'tx', token_id: 7 } as any;
+const log = { id: 'l1', block: 1 } as any;
+
+function setup() {
+  (commonApiFetch as jest.Mock).mockResolvedValue({ count: 26, data: [transaction] });
+  return render(<NextGenTokenProvenance collection={collection} token_id={7} />);
+}
+
+describe('NextGenTokenProvenance', () => {
+  beforeEach(() => jest.clearAllMocks());
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      value: jest.fn(),
+      configurable: true,
+    });
+  });
+
+  it('fetches provenance data and paginates', async () => {
+    setup();
+    expect(commonApiFetch.mock.calls[0][0]).toEqual({
+      endpoint: `nextgen/tokens/7/transactions?page_size=25&page=1`,
+    });
+    expect(
+      commonApiFetch.mock.calls.some(
+        (c: any) => c[0].endpoint ===
+        `nextgen/collections/1/logs/7?page_size=25&page=1`
+      )
+    ).toBe(true);
+
+    await screen.findByTestId('activity-row');
+    await screen.findByTestId('log-row');
+
+    await userEvent.click(screen.getAllByText('next')[0]);
+    await userEvent.click(screen.getAllByText('next')[1]);
+
+    await waitFor(() => {
+      expect(
+        commonApiFetch.mock.calls.some(
+          (c: any) => c[0].endpoint ===
+          `nextgen/tokens/7/transactions?page_size=25&page=2`
+        )
+      ).toBe(true);
+      expect(
+        commonApiFetch.mock.calls.some(
+          (c: any) => c[0].endpoint ===
+          `nextgen/collections/1/logs/7?page_size=25&page=2`
+        )
+      ).toBe(true);
+    });
+  });
+});

--- a/__tests__/components/pdfViewer/PdfViewer.test.tsx
+++ b/__tests__/components/pdfViewer/PdfViewer.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import PdfViewer from '../../../components/pdfViewer/PdfViewer';
+
+jest.mock('../../../hooks/isMobileScreen', () => ({ __esModule: true, default: jest.fn() }));
+
+const useIsMobileScreen = require('../../../hooks/isMobileScreen').default;
+
+describe('PdfViewer', () => {
+  it('renders a link on mobile', () => {
+    useIsMobileScreen.mockReturnValue(true);
+    render(<PdfViewer file="/test.pdf" name="Doc" />);
+    const link = screen.getByRole('link', { name: 'Doc' });
+    expect(link).toHaveAttribute('href', '/test.pdf');
+  });
+
+  it('renders an iframe on desktop', () => {
+    useIsMobileScreen.mockReturnValue(false);
+    render(<PdfViewer file="/test.pdf" name="Doc" />);
+    const iframe = screen.getByTitle('Doc');
+    expect(iframe).toHaveAttribute('src', '/test.pdf');
+  });
+});

--- a/__tests__/components/terms/TermsOfServiceModal.test.tsx
+++ b/__tests__/components/terms/TermsOfServiceModal.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TermsOfServiceModal from '../../../components/terms/TermsOfServiceModal';
+
+jest.mock('../../../components/waves/memes/submission/layout/ModalLayout', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div data-testid="layout">{children}</div>,
+}));
+
+jest.mock('focus-trap-react', () => ({ FocusTrap: ({ children }: any) => <div>{children}</div> }));
+
+jest.mock('../../../components/utils/button/PrimaryButton', () => ({
+  __esModule: true,
+  default: ({ children, onClicked, ...props }: any) => (
+    <button data-testid="primary" onClick={onClicked} {...props}>{children}</button>
+  ),
+}));
+
+describe('TermsOfServiceModal', () => {
+  it('returns null when closed', () => {
+    const { container } = render(
+      <TermsOfServiceModal isOpen={false} onClose={jest.fn()} onAccept={jest.fn()} termsContent={''} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('displays content and allows acceptance', async () => {
+    const onAccept = jest.fn();
+    render(
+      <TermsOfServiceModal isOpen onClose={jest.fn()} onAccept={onAccept} termsContent="terms" />
+    );
+    const checkbox = screen.getByRole('checkbox');
+    const button = screen.getByTestId('primary');
+    expect(button).toBeDisabled();
+    await userEvent.click(checkbox);
+    expect(button).toBeEnabled();
+    await userEvent.click(button);
+    expect(onAccept).toHaveBeenCalled();
+  });
+
+  it('shows placeholder when no terms', () => {
+    render(
+      <TermsOfServiceModal isOpen onClose={jest.fn()} onAccept={jest.fn()} termsContent={null} />
+    );
+    expect(screen.getByText('No terms of service found.')).toBeInTheDocument();
+  });
+
+  it('closes on Escape', async () => {
+    const onClose = jest.fn();
+    render(
+      <TermsOfServiceModal isOpen onClose={onClose} onAccept={jest.fn()} termsContent="t" />
+    );
+    await userEvent.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('toggles via Enter key', async () => {
+    render(
+      <TermsOfServiceModal isOpen onClose={jest.fn()} onAccept={jest.fn()} termsContent="t" />
+    );
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toHaveAttribute('aria-checked', 'false');
+    checkbox.focus();
+    await userEvent.keyboard('{Enter}');
+    expect(checkbox).toHaveAttribute('aria-checked', 'true');
+  });
+});


### PR DESCRIPTION
## Summary
- add PdfViewer tests covering mobile and desktop view
- add TermsOfServiceModal tests for acknowledge flow, escape key, and accessibility
- add NextGenTokenProvenance tests with mocked API and pagination

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
