### PR TITLE
Add tests for profile credit and statements components

### DIFF
--- a/__tests__/components/user/identity/statements/utils/UserPageIdentityAddStatementsInput.test.tsx
+++ b/__tests__/components/user/identity/statements/utils/UserPageIdentityAddStatementsInput.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import UserPageIdentityAddStatementsContactInput from "../../../../../../components/user/identity/statements/utils/UserPageIdentityAddStatementsInput";
+import { STATEMENT_META, STATEMENT_TYPE } from "../../../../../../helpers/Types";
+
+describe("UserPageIdentityAddStatementsContactInput", () => {
+  it("focuses input and calls onChange when typing", async () => {
+    const onChange = jest.fn();
+    const { rerender } = render(
+      <UserPageIdentityAddStatementsContactInput
+        activeType={STATEMENT_TYPE.EMAIL}
+        value=""
+        onChange={onChange}
+      />
+    );
+    const input = screen.getByRole("textbox");
+    expect(input).toHaveAttribute("placeholder", STATEMENT_META[STATEMENT_TYPE.EMAIL].inputPlaceholder);
+    await waitFor(() => expect(input).toHaveFocus());
+    await userEvent.type(input, "abc");
+    expect(onChange).toHaveBeenCalled();
+
+    rerender(
+      <UserPageIdentityAddStatementsContactInput
+        activeType={STATEMENT_TYPE.DISCORD}
+        value=""
+        onChange={onChange}
+      />
+    );
+    const newInput = screen.getByRole("textbox");
+    expect(newInput).toHaveAttribute("placeholder", STATEMENT_META[STATEMENT_TYPE.DISCORD].inputPlaceholder);
+    await waitFor(() => expect(newInput).toHaveFocus());
+  });
+});

--- a/__tests__/components/user/identity/statements/utils/UserPageIdentityDeleteStatementButton.test.tsx
+++ b/__tests__/components/user/identity/statements/utils/UserPageIdentityDeleteStatementButton.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import UserPageIdentityDeleteStatementButton from "../../../../../../components/user/identity/statements/utils/UserPageIdentityDeleteStatementButton";
+import { useRouter } from "next/router";
+
+jest.mock("next/router", () => ({ useRouter: jest.fn() }));
+
+jest.mock("../../../../../../components/user/identity/statements/utils/UserPageIdentityDeleteStatementModal", () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div data-testid="modal">
+      <button onClick={props.onClose}>close</button>
+    </div>
+  ),
+}));
+
+jest.mock("@tippyjs/react", () => ({
+  __esModule: true,
+  default: (props: any) => <div data-testid="tippy" data-disabled={props.disabled}>{props.children}</div>,
+}));
+
+const statement = { id: "1" } as any;
+const profile = { id: "p" } as any;
+
+function setMatchMedia(matches: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: jest.fn().mockReturnValue({ matches, addListener: jest.fn(), removeListener: jest.fn() }),
+  });
+}
+
+describe("UserPageIdentityDeleteStatementButton", () => {
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({ isReady: true });
+    setMatchMedia(false);
+  });
+
+  it("opens and closes modal when button clicked", async () => {
+    render(
+      <UserPageIdentityDeleteStatementButton statement={statement} profile={profile} />
+    );
+    expect(screen.queryByTestId("modal")).toBeNull();
+    await userEvent.click(screen.getByRole("button", { name: /delete statement/i }));
+    expect(screen.getByTestId("modal")).toBeInTheDocument();
+    await userEvent.click(screen.getByText("close"));
+    expect(screen.queryByTestId("modal")).toBeNull();
+  });
+
+  it("shows button when touchscreen", () => {
+    setMatchMedia(true);
+    render(
+      <UserPageIdentityDeleteStatementButton statement={statement} profile={profile} />
+    );
+    const button = screen.getByRole("button", { name: /delete statement/i });
+    expect(button.className).toContain("tw-block");
+  });
+});

--- a/__tests__/components/user/proxy/proxy/action/utils/credit/ProfileProxyCredit.test.tsx
+++ b/__tests__/components/user/proxy/proxy/action/utils/credit/ProfileProxyCredit.test.tsx
@@ -1,0 +1,36 @@
+import { renderWithAuth } from "../../../../../../../utils/testContexts";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import ProfileProxyCredit from "../../../../../../../../components/user/proxy/proxy/action/utils/credit/ProfileProxyCredit";
+
+jest.mock("../../../../../../../../components/utils/icons/PencilIcon", () => ({
+  __esModule: true,
+  default: () => <svg data-testid="pencil" />,
+  PencilIconSize: { SMALL: 'sm' },
+}));
+
+const profileProxy = { created_by: { id: "owner" } } as any;
+const action = { credit_amount: 1000 } as any;
+
+describe("ProfileProxyCredit", () => {
+  it("shows edit button for owner and triggers callback", async () => {
+    const onEdit = jest.fn();
+    renderWithAuth(
+      <ProfileProxyCredit profileProxy={profileProxy} profileProxyAction={action} onCreditEdit={onEdit} />,
+      { connectedProfile: { id: "owner" } as any }
+    );
+    expect(screen.getByText("1,000")).toBeInTheDocument();
+    const button = screen.getByRole("button", { name: /edit credit/i });
+    await userEvent.click(button);
+    expect(onEdit).toHaveBeenCalled();
+  });
+
+  it("hides edit button when not owner", () => {
+    renderWithAuth(
+      <ProfileProxyCredit profileProxy={profileProxy} profileProxyAction={action} onCreditEdit={() => {}} />,
+      { connectedProfile: { id: "other" } as any }
+    );
+    expect(screen.queryByRole("button", { name: /edit credit/i })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `UserPageIdentityAddStatementsInput`
- test delete statements button behaviour
- cover owner logic for `ProfileProxyCredit`

## Testing
- `npx jest __tests__/components/user/identity/statements/utils/UserPageIdentityAddStatementsInput.test.tsx --runInBand`
- `npm run test` *(partial output due to long runtime)*
