### PR TITLE
Add tests for header user components

### DIFF
--- a/__tests__/components/header/user/HeaderUser.test.tsx
+++ b/__tests__/components/header/user/HeaderUser.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import HeaderUser from '../../../../components/header/user/HeaderUser';
+
+jest.mock('../../../../components/header/user/HeaderUserConnected', () => ({ __esModule: true, default: (props: any) => <div data-testid="connected">{props.connectedAddress}</div> }));
+jest.mock('../../../../components/header/user/HeaderUserConnect', () => ({ __esModule: true, default: () => <div data-testid="connect" /> }));
+
+jest.mock('../../../../components/auth/SeizeConnectContext', () => ({ useSeizeConnectContext: jest.fn() }));
+jest.mock('../../../../components/notifications/NotificationsContext', () => ({ useNotificationsContext: jest.fn() }));
+
+const { useSeizeConnectContext } = require('../../../../components/auth/SeizeConnectContext');
+const { useNotificationsContext } = require('../../../../components/notifications/NotificationsContext');
+
+describe('HeaderUser', () => {
+  const removeAllDeliveredNotifications = jest.fn();
+
+  beforeEach(() => {
+    (useNotificationsContext as jest.Mock).mockReturnValue({ removeAllDeliveredNotifications });
+    jest.clearAllMocks();
+  });
+
+  it('renders connected state when address present', () => {
+    (useSeizeConnectContext as jest.Mock).mockReturnValue({ address: '0xabc' });
+    render(<HeaderUser />);
+    expect(screen.getByTestId('connected')).toHaveTextContent('0xabc');
+    expect(removeAllDeliveredNotifications).not.toHaveBeenCalled();
+  });
+
+  it('renders connect state and clears notifications when not connected', () => {
+    (useSeizeConnectContext as jest.Mock).mockReturnValue({ address: undefined });
+    render(<HeaderUser />);
+    expect(screen.getByTestId('connect')).toBeInTheDocument();
+    expect(removeAllDeliveredNotifications).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/components/header/user/proxy/HeaderUserProxyDropdownChains.test.tsx
+++ b/__tests__/components/header/user/proxy/HeaderUserProxyDropdownChains.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import HeaderUserProxyDropdownChains from '../../../../../components/header/user/proxy/HeaderUserProxyDropdownChains';
+
+jest.mock('wagmi', () => ({
+  useSwitchChain: jest.fn(),
+  useConnections: jest.fn(),
+}));
+jest.mock('../../../../../pages/_app', () => ({ getChains: jest.fn() }));
+
+const { useSwitchChain, useConnections } = require('wagmi');
+const { getChains } = require('../../../../../pages/_app');
+
+describe('HeaderUserProxyDropdownChains', () => {
+  const switchChain = jest.fn();
+  const onSwitchChain = jest.fn();
+
+  beforeEach(() => {
+    (useSwitchChain as jest.Mock).mockReturnValue({ switchChain });
+    (useConnections as jest.Mock).mockReturnValue([{ chainId: 1 }]);
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing when only one chain is available', () => {
+    (getChains as jest.Mock).mockReturnValue([{ id: 1, name: 'Main' }]);
+    const { container } = render(<HeaderUserProxyDropdownChains onSwitchChain={onSwitchChain} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('switches chain when button clicked', () => {
+    (getChains as jest.Mock).mockReturnValue([
+      { id: 1, name: 'Main' },
+      { id: 2, name: 'Goerli' },
+    ]);
+
+    render(<HeaderUserProxyDropdownChains onSwitchChain={onSwitchChain} />);
+    const button = screen.getByRole('button', { name: /switch to goerli/i });
+    fireEvent.click(button);
+    expect(onSwitchChain).toHaveBeenCalled();
+    expect(switchChain).toHaveBeenCalledWith({ chainId: 2 });
+  });
+
+  it('handles switch errors gracefully', () => {
+    switchChain.mockImplementation(() => { throw new Error('oops'); });
+    (getChains as jest.Mock).mockReturnValue([
+      { id: 1, name: 'Main' },
+      { id: 2, name: 'Goerli' },
+    ]);
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    render(<HeaderUserProxyDropdownChains onSwitchChain={onSwitchChain} />);
+    fireEvent.click(screen.getByRole('button', { name: /switch to goerli/i }));
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `HeaderUser` component
- add tests for `HeaderUserProxyDropdownChains` component

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
