### PR TITLE
Add frontend unit tests

### DIFF
--- a/__tests__/components/layout/DesktopLayout.test.tsx
+++ b/__tests__/components/layout/DesktopLayout.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+const registerRef = jest.fn();
+const setHeaderRef = jest.fn();
+let pathname = "/";
+
+jest.mock("next/dynamic", () => () => () => <div data-testid="header" />);
+jest.mock("../../../hooks/useBreadcrumbs", () => ({ useBreadcrumbs: () => [{ display: "Home", href: "/" }] }));
+jest.mock("../../../contexts/HeaderContext", () => ({ useHeaderContext: () => ({ setHeaderRef }) }));
+jest.mock("../../../components/brain/my-stream/layout/LayoutContext", () => ({ useLayout: () => ({ registerRef }) }));
+jest.mock("next/router", () => ({ useRouter: () => ({ pathname }) }));
+
+const DesktopLayout = require("../../../components/layout/DesktopLayout").default;
+
+describe("DesktopLayout", () => {
+  beforeEach(() => {
+    registerRef.mockClear();
+    setHeaderRef.mockClear();
+  });
+
+  it("renders header without breadcrumb on home page", () => {
+    pathname = "/";
+    render(<DesktopLayout>child</DesktopLayout>);
+    expect(screen.getByTestId("header")).toBeInTheDocument();
+    expect(screen.queryByText("Home")).not.toBeInTheDocument();
+    expect(registerRef).toHaveBeenCalledWith("header", expect.any(HTMLElement));
+    expect(setHeaderRef).toHaveBeenCalledWith(expect.any(HTMLElement));
+  });
+
+  it("shows breadcrumb when not on home page", () => {
+    pathname = "/page";
+    render(<DesktopLayout>child</DesktopLayout>);
+    expect(screen.getByText("Home")).toBeInTheDocument();
+    const wrapper = screen.getByTestId("header").parentElement as HTMLElement;
+    expect(wrapper.className).not.toContain("tw-sticky");
+  });
+
+  it("adds sticky classes for stream view", () => {
+    pathname = "/my-stream/test";
+    render(<DesktopLayout>child</DesktopLayout>);
+    const wrapper = screen.getByTestId("header").parentElement as HTMLElement;
+    expect(wrapper.className).toContain("tw-sticky");
+  });
+});

--- a/__tests__/components/levels/ProgressChart.test.tsx
+++ b/__tests__/components/levels/ProgressChart.test.tsx
@@ -1,0 +1,46 @@
+import { render, waitFor, screen } from "@testing-library/react";
+import React from "react";
+
+const lineMock = jest.fn((props: any) => {
+  if (props.options?.onHover) {
+    props.options.onHover({}, [{ index: 1 }]);
+  }
+  return <div data-testid="chart" />;
+});
+
+jest.mock("react-chartjs-2", () => ({ Line: (props: any) => lineMock(props) }));
+
+const originalMatchMedia = window.matchMedia;
+
+beforeEach(() => {
+  (window as any).matchMedia = jest.fn().mockReturnValue({ matches: false });
+  lineMock.mockClear();
+});
+
+afterAll(() => {
+  window.matchMedia = originalMatchMedia;
+});
+
+const ProgressChart = require("../../../components/levels/ProgressChart").default;
+
+describe("ProgressChart", () => {
+  it("dispatches level-hover event on hover", () => {
+    const spy = jest.spyOn(window, "dispatchEvent");
+    render(<ProgressChart />);
+    expect(screen.getByTestId("chart")).toBeInTheDocument();
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "level-hover", detail: { level: 1 } })
+    );
+    const options = lineMock.mock.calls[0][0].options;
+    expect(options.animation).toBeUndefined();
+    spy.mockRestore();
+  });
+
+  it("disables animation when prefers reduced motion", async () => {
+    (window as any).matchMedia = jest.fn().mockReturnValue({ matches: true });
+    render(<ProgressChart />);
+    await waitFor(() => expect(lineMock).toHaveBeenCalledTimes(2));
+    const options = lineMock.mock.calls[1][0].options;
+    expect(options.animation).toBe(false);
+  });
+});

--- a/__tests__/components/manifoldMinting/ManifoldMintingWidget.test.tsx
+++ b/__tests__/components/manifoldMinting/ManifoldMintingWidget.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { ManifoldClaimStatus, ManifoldPhase } from "../../../hooks/useManifoldClaim";
+
+jest.mock("react-bootstrap", () => {
+  const React = require("react");
+  return {
+    Container: (p: any) => <div {...p} />,
+    Row: (p: any) => <div {...p} />,
+    Col: (p: any) => <div {...p} />,
+    Form: { Select: (p: any) => <select {...p} />, Control: (p: any) => <input {...p} /> },
+    Table: (p: any) => <table {...p}>{p.children}</table>,
+  };
+});
+
+jest.mock("../../../components/dotLoader/DotLoader", () => () => <div data-testid="loader" />);
+jest.mock("../../../components/manifoldMinting/ManifoldMintingConnect", () => () => <div data-testid="connect" />);
+
+jest.mock("wagmi", () => ({
+  useReadContract: jest.fn(() => ({ data: 0 })),
+  useReadContracts: jest.fn(() => ({ data: [] })),
+  useWaitForTransactionReceipt: jest.fn(() => ({ isPending: false, isSuccess: false, error: null })),
+  useWriteContract: jest.fn(() => ({ writeContract: jest.fn(), reset: jest.fn(), data: undefined, isPending: false, error: null })),
+}));
+
+jest.mock("../../../components/auth/SeizeConnectContext", () => ({ useSeizeConnectContext: () => ({ address: "0x1" }) }));
+
+const ManifoldMintingWidget = require("../../../components/manifoldMinting/ManifoldMintingWidget").default;
+
+const baseProps = {
+  contract: "0x1",
+  proxy: "0x2",
+  abi: [],
+  claim: {
+    status: ManifoldClaimStatus.ENDED,
+    isFinalized: false,
+    phase: ManifoldPhase.ALLOWLIST,
+    instanceId: 1,
+    startDate: 0,
+    cost: 1,
+  } as any,
+  merkleTreeId: 1,
+  setFee: jest.fn(),
+  setMintForAddress: jest.fn(),
+};
+
+describe("ManifoldMintingWidget", () => {
+  it("shows ENDED when claim ended", () => {
+    render(<ManifoldMintingWidget {...baseProps} />);
+    const button = screen.getByRole("button");
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent("ENDED");
+  });
+
+  it("shows SOLD OUT when finalized", () => {
+    const props = { ...baseProps, claim: { ...baseProps.claim, status: ManifoldClaimStatus.ACTIVE, isFinalized: true } };
+    render(<ManifoldMintingWidget {...props} />);
+    const button = screen.getByRole("button");
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent("SOLD OUT");
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for DesktopLayout
- add tests for ProgressChart component
- test basic states of ManifoldMintingWidget

## Testing
- `npm run lint`
- `npm run type-check`
- ❌ `npm run test` *(fails: JavaScript heap out of memory)*