### PR TITLE
Increase test coverage for navigation and MemeLab components

### DIFF
--- a/__tests__/components/memelab/MemeLabCollection.test.tsx
+++ b/__tests__/components/memelab/MemeLabCollection.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import LabCollection from '../../../components/memelab/MemeLabCollection';
+import { useRouter } from 'next/router';
+import { fetchAllPages } from '../../../services/6529api';
+import { AuthContext } from '../../../components/auth/Auth';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../../services/6529api', () => ({ fetchAllPages: jest.fn() }));
+
+jest.mock('../../../components/nft-image/NFTImage', () => (props: any) => <div data-testid={`nft-${props.nft.id}`}>{props.nft.name}</div>);
+jest.mock('@fortawesome/react-fontawesome', () => ({ FontAwesomeIcon: (props: any) => <svg data-testid="icon" onClick={props.onClick} /> }));
+jest.mock('../../../components/nothingHereYet/NothingHereYetSummer', () => () => <div data-testid="nothing" />);
+
+const routerReplace = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useRouter as jest.Mock).mockReturnValue({ isReady: true, query: { collection: 'cool-collection' }, replace: routerReplace });
+  process.env.API_ENDPOINT = 'https://api.test';
+});
+
+function renderComponent() {
+  return render(
+    <AuthContext.Provider value={{ connectedProfile: null } as any}>
+      <LabCollection wallets={[]} />
+    </AuthContext.Provider>
+  );
+}
+
+describe('MemeLabCollection', () => {
+  it('renders nft data and website links', async () => {
+    (fetchAllPages as jest.Mock)
+      .mockResolvedValueOnce([{ id: 1, website: 'example.com', name: 'meta' }])
+      .mockResolvedValueOnce([{ id: 1, contract: '0x', name: 'NFT', artist: 'artist' }]);
+    renderComponent();
+    await waitFor(() => expect(fetchAllPages).toHaveBeenCalledTimes(2));
+    expect(screen.getByText('cool collection')).toBeInTheDocument();
+    expect(screen.getByTestId('nft-1')).toHaveTextContent('NFT');
+    expect(screen.getByRole('link', { name: 'example.com' })).toHaveAttribute('href', 'https://example.com');
+  });
+
+  it('shows placeholder when no nfts', async () => {
+    (fetchAllPages as jest.Mock).mockResolvedValueOnce([]);
+    renderComponent();
+    await waitFor(() => expect(fetchAllPages).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId('nothing')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/navigation/BottomNavigation.test.tsx
+++ b/__tests__/components/navigation/BottomNavigation.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react';
+import BottomNavigation, { items } from '../../../components/navigation/BottomNavigation';
+import NavItem from '../../../components/navigation/NavItem';
+import { useLayout } from '../../../components/brain/my-stream/layout/LayoutContext';
+
+jest.mock('../../../components/navigation/NavItem', () => ({ __esModule: true, default: jest.fn(() => <div data-testid="nav-item" />) }));
+jest.mock('../../../components/brain/my-stream/layout/LayoutContext', () => ({ useLayout: jest.fn() }));
+
+const registerRef = jest.fn();
+(useLayout as jest.Mock).mockReturnValue({ registerRef });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useLayout as jest.Mock).mockReturnValue({ registerRef });
+});
+
+describe('BottomNavigation', () => {
+  it('registers mobileNav ref and renders nav items', () => {
+    const { container } = render(<BottomNavigation />);
+    expect(registerRef).toHaveBeenCalledWith('mobileNav', expect.any(HTMLElement));
+    // Expect one nav item per item definition
+    const rendered = container.querySelectorAll('[data-testid="nav-item"]');
+    expect(rendered).toHaveLength(items.length);
+    // Ensure NavItem called with each item
+    items.forEach((item, index) => {
+      expect((NavItem as jest.Mock).mock.calls[index][0]).toEqual({ item });
+    });
+  });
+});

--- a/__tests__/components/navigation/ViewContext.test.tsx
+++ b/__tests__/components/navigation/ViewContext.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, act, renderHook } from '@testing-library/react';
+import { ViewProvider, useViewContext } from '../../../components/navigation/ViewContext';
+import { useRouter } from 'next/router';
+import { commonApiFetch } from '../../../services/api/common-api';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../../services/api/common-api', () => ({ commonApiFetch: jest.fn() }));
+
+const push = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useRouter as jest.Mock).mockReturnValue({ query: {}, push, pathname: '/my-stream', asPath: '/my-stream' });
+});
+
+describe('ViewContext', () => {
+  it('throws when used outside provider', () => {
+    expect(() => renderHook(() => useViewContext())).toThrow('useViewContext must be used within a ViewProvider');
+  });
+
+  it('handles route navigation', () => {
+    function Test() {
+      const { handleNavClick } = useViewContext();
+      React.useEffect(() => {
+        handleNavClick({ kind: 'route', name: 'Home', href: '/home', icon: 'h' });
+      }, []);
+      return null;
+    }
+    render(
+      <ViewProvider>
+        <Test />
+      </ViewProvider>
+    );
+    expect(push).toHaveBeenCalledWith('/home', undefined, { shallow: true });
+  });
+
+  it('navigates to waves view when no last visited wave', () => {
+    function Test() {
+      const { handleNavClick, hardBack } = useViewContext();
+      React.useEffect(() => {
+        handleNavClick({ kind: 'view', name: 'Waves', viewKey: 'waves', icon: 'w' });
+        hardBack('waves');
+      }, []);
+      return null;
+    }
+    render(
+      <ViewProvider>
+        <Test />
+      </ViewProvider>
+    );
+    expect(push).toHaveBeenCalledWith('/my-stream?view=waves', undefined, { shallow: true });
+    expect(push).toHaveBeenLastCalledWith('/my-stream?view=waves', undefined, { shallow: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for BottomNavigation component to ensure NavItems render and layout ref registered
- cover navigation ViewContext hook behavior for route handling and default waves view
- test MemeLabCollection data loading and empty state handling

## Testing
- `npx jest __tests__/components/navigation/BottomNavigation.test.tsx --coverage`
- `npx jest __tests__/components/navigation/ViewContext.test.tsx --coverage`
- `npx jest __tests__/components/memelab/MemeLabCollection.test.tsx --coverage`
