### PR TITLE
Improve test coverage

### DIFF
--- a/__tests__/components/user/proxy/proxy/create-action/config/ProxyCreateActionConfigAllocateRep.test.tsx
+++ b/__tests__/components/user/proxy/proxy/create-action/config/ProxyCreateActionConfigAllocateRep.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import ProxyCreateActionConfigAllocateRep from "../../../../../../../components/user/proxy/proxy/create-action/config/ProxyCreateActionConfigAllocateRep";
+
+jest.mock("../../../../../../../components/distribution-plan-tool/common/CircleLoader", () => ({
+  __esModule: true,
+  default: ({ size }: any) => <div data-testid="loader" data-size={size} />,
+  CircleLoaderSize: { SMALL: "SMALL" },
+}));
+
+describe("ProxyCreateActionConfigAllocateRep", () => {
+  it("enables save button and submits value", async () => {
+    const onSubmit = jest.fn();
+    const onCancel = jest.fn();
+    render(
+      <ProxyCreateActionConfigAllocateRep endTime={123} submitting={false} onSubmit={onSubmit} onCancel={onCancel} />
+    );
+
+    const saveButton = screen.getByRole("button", { name: /save/i });
+    expect(saveButton).toBeDisabled();
+
+    const input = screen.getByPlaceholderText("Credit Amount");
+    await userEvent.clear(input);
+    await userEvent.type(input, "42");
+    expect(saveButton).toBeEnabled();
+
+    await userEvent.click(saveButton);
+    expect(onSubmit).toHaveBeenCalledWith({
+      action_type: 'ALLOCATE_REP',
+      end_time: 123,
+      credit_amount: 42,
+    });
+  });
+
+  it("shows loader when submitting and disables cancel", async () => {
+    const onSubmit = jest.fn();
+    const onCancel = jest.fn();
+    render(
+      <ProxyCreateActionConfigAllocateRep endTime={null} submitting={true} onSubmit={onSubmit} onCancel={onCancel} />
+    );
+
+    expect(screen.getByTestId("loader")).toBeInTheDocument();
+
+    const cancelButton = screen.getByRole("button", { name: /cancel/i });
+    expect(cancelButton).toBeDisabled();
+    await userEvent.click(cancelButton);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/user/rep/new-rep/UserPageRepNewRepSearchDropdown.test.tsx
+++ b/__tests__/components/user/rep/new-rep/UserPageRepNewRepSearchDropdown.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import UserPageRepNewRepSearchDropdown from "../../../../../components/user/rep/new-rep/UserPageRepNewRepSearchDropdown";
+import { RepSearchState } from "../../../../../components/user/rep/new-rep/UserPageRepNewRepSearch";
+
+describe("UserPageRepNewRepSearchDropdown", () => {
+  it("renders categories and handles selection", async () => {
+    const onSelect = jest.fn();
+    render(
+      <UserPageRepNewRepSearchDropdown
+        categories={["Art", "NFT"]}
+        onRepSelect={onSelect}
+        state={RepSearchState.HAVE_RESULTS}
+        minSearchLength={3}
+        maxSearchLength={100}
+      />
+    );
+
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(2);
+    await userEvent.click(buttons[1]);
+    expect(onSelect).toHaveBeenCalledWith("NFT");
+  });
+
+  it("shows error messages for min and max length", () => {
+    const { rerender } = render(
+      <UserPageRepNewRepSearchDropdown
+        categories={[]}
+        onRepSelect={() => {}}
+        state={RepSearchState.MIN_LENGTH_ERROR}
+        minSearchLength={3}
+        maxSearchLength={10}
+      />
+    );
+    expect(screen.getByText("Type at least 3 characters")).toBeInTheDocument();
+
+    rerender(
+      <UserPageRepNewRepSearchDropdown
+        categories={[]}
+        onRepSelect={() => {}}
+        state={RepSearchState.MAX_LENGTH_ERROR}
+        minSearchLength={3}
+        maxSearchLength={10}
+      />
+    );
+    expect(screen.getByText("Type at most 10 characters")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/user/rep/reps/UserPageRepReps.test.tsx
+++ b/__tests__/components/user/rep/reps/UserPageRepReps.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import UserPageRepReps from "../../../../../components/user/rep/reps/UserPageRepReps";
+import { AuthContext } from "../../../../../components/auth/Auth";
+import { ApiProfileProxyActionType } from "../../../../../generated/models/ApiProfileProxyActionType";
+
+jest.mock("next/router", () => ({ useRouter: () => ({ isReady: true }) }));
+
+function setMatchMedia(matches: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: jest.fn().mockReturnValue({ matches, addListener: jest.fn(), removeListener: jest.fn() }),
+  });
+}
+
+const sampleReps = [
+  { category: "a", rating: 5, contributor_count: 2, rater_contribution: 1 },
+  { category: "b", rating: 5, contributor_count: 3, rater_contribution: 0 },
+  { category: "c", rating: 10, contributor_count: 1, rater_contribution: 0 },
+];
+
+const profile = { handle: "target" } as any;
+
+function renderComponent(authValue: any) {
+  return render(
+    <AuthContext.Provider value={{ ...authValue }}>
+      <UserPageRepReps repRates={{ rating_stats: sampleReps } as any} profile={profile} />
+    </AuthContext.Provider>
+  );
+}
+
+describe("UserPageRepReps", () => {
+  beforeEach(() => {
+    setMatchMedia(false);
+  });
+  it("sorts reps by rating and contributor count", () => {
+    renderComponent({ connectedProfile: null, activeProfileProxy: null });
+
+    const items = screen.getAllByRole("button");
+    // first top rep should be rating 10 (category c)
+    expect(items[0]).toHaveTextContent("c");
+  });
+
+  it("disables editing when viewing own profile", () => {
+    renderComponent({ connectedProfile: { handle: "target" }, activeProfileProxy: null });
+    const button = screen.getAllByRole("button")[0];
+    expect(button).toBeDisabled();
+  });
+
+  it("allows editing when proxy has allocate rep action", () => {
+    renderComponent({
+      connectedProfile: { handle: "me" },
+      activeProfileProxy: {
+        created_by: { handle: "other" },
+        actions: [{ action_type: ApiProfileProxyActionType.AllocateRep }],
+      },
+    });
+    const button = screen.getAllByRole("button")[0];
+    expect(button).toBeEnabled();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for ProxyCreateActionConfigAllocateRep
- add tests for Rep search dropdown
- add tests for user rep listing behavior

## Testing
- `npx jest __tests__/components/user/proxy/proxy/create-action/config/ProxyCreateActionConfigAllocateRep.test.tsx --coverage`
- `npx jest __tests__/components/user/rep/new-rep/UserPageRepNewRepSearchDropdown.test.tsx --coverage`
- `npx jest __tests__/components/user/rep/reps/UserPageRepReps.test.tsx --coverage`
