### PR TITLE
Add Nextgen component tests

### DIFF
--- a/__tests__/components/nextGen/collections/collectionParts/mint/NextgenCollectionMintingPlan.test.tsx
+++ b/__tests__/components/nextGen/collections/collectionParts/mint/NextgenCollectionMintingPlan.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import NextgenCollectionMintingPlan from '../../../../../../components/nextGen/collections/collectionParts/mint/NextgenCollectionMintingPlan';
+
+jest.mock('react-bootstrap', () => {
+  const React = require('react');
+  const Dropdown: any = (p: any) => <div {...p} />;
+  Dropdown.Toggle = (p: any) => <button {...p} />;
+  Dropdown.Menu = (p: any) => <div {...p} />;
+  Dropdown.Item = (p: any) => <button {...p} />;
+  const Table: any = (p: any) => <table>{p.children}</table>;
+  return {
+    Container: (p: any) => <div {...p} />,
+    Row: (p: any) => <div {...p} />,
+    Col: (p: any) => <div {...p} />,
+    Dropdown,
+    Table,
+    Form: { Control: (p: any) => <input {...p} /> },
+  };
+});
+
+jest.mock('next/dynamic', () => () => () => <div data-testid='pdf' />);
+
+jest.mock('../../../../../../services/api/common-api', () => ({
+  commonApiFetch: jest.fn(),
+}));
+
+jest.mock('../../../../../../components/nextGen/collections/collectionParts/NextGenCollectionHeader', () => () => <div data-testid='header' />);
+jest.mock('../../../../../../components/pagination/Pagination', () => (props: any) => (
+  <div data-testid='pagination'>
+    <button onClick={() => props.setPage(props.page + 1)}>next</button>
+  </div>
+));
+jest.mock('../../../../../../components/searchModal/SearchModal', () => ({
+  SearchModalDisplay: () => <div data-testid='search-modal' />,
+  SearchWalletsDisplay: () => <div data-testid='search-wallets' />,
+}));
+
+const { commonApiFetch } = require('../../../../../../services/api/common-api');
+
+const collection = { id: 1, name: 'COL', public_start: 0, public_end: 0, distribution_plan: 'plan.pdf' } as any;
+const phases = [{ phase: 'Phase1', start_time: 0, end_time: 0 }];
+const allowlist = [
+  { address: '0x1', keccak: 'k1', spots: 1, info: '{}', phase: 'Phase1', wallet_display: '' },
+  { address: '0x1', keccak: 'k2', spots: 3, info: '{}', phase: 'Phase1', wallet_display: '' },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (commonApiFetch as jest.Mock).mockImplementation(({ endpoint }: any) => {
+    if (endpoint.startsWith('nextgen/allowlist_phases')) return Promise.resolve(phases);
+    return Promise.resolve({ count: allowlist.length, page: 1, next: null, data: allowlist });
+  });
+});
+
+describe('NextgenCollectionMintingPlan', () => {
+  it('computes adjusted spots per address', async () => {
+    render(<NextgenCollectionMintingPlan collection={collection} />);
+    await screen.findAllByText('0x1');
+    const rows = screen.getAllByRole('row');
+    expect(rows.some(r => r.textContent?.includes("Phase1"))).toBe(true);
+    await waitFor(() => {
+      const cells = screen.getAllByText(/^[0-9]+$/);
+      expect(cells.map(c => c.textContent)).toEqual(expect.arrayContaining(['1', '2']));
+    });
+  });
+});

--- a/__tests__/components/nextGen/collections/nextgenToken/NextGenTokenPage.test.tsx
+++ b/__tests__/components/nextGen/collections/nextgenToken/NextGenTokenPage.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NextGenTokenPage from '../../../../../components/nextGen/collections/nextgenToken/NextGenToken';
+
+jest.mock('react-bootstrap', () => {
+  const React = require('react');
+  return {
+    Container: (p: any) => <div {...p} />,
+    Row: (p: any) => <div {...p} />,
+    Col: (p: any) => <div {...p} />,
+  };
+});
+
+jest.mock('../../../../../components/nextGen/collections/nextgenToken/NextGenTokenProvenance', () => () => <div data-testid="provenance" />);
+jest.mock('../../../../../components/nextGen/collections/nextgenToken/NextGenTokenProperties', () => ({
+  __esModule: true,
+  default: () => <div data-testid='rarity' />,
+  NextgenTokenTraits: () => <div data-testid='traits' />,
+}));
+jest.mock('../../../../../components/nextGen/collections/nextgenToken/NextGenTokenAbout', () => () => <div data-testid='about' />);
+jest.mock('../../../../../components/nextGen/collections/nextgenToken/NextGenTokenArt', () => () => <div data-testid='art' />);
+jest.mock('../../../../../components/nextGen/collections/nextgenToken/NextGenTokenRenderCenter', () => () => <div data-testid='render' />);
+jest.mock('../../../../../components/nextGen/collections/collectionParts/NextGenCollectionHeader', () => ({
+  NextGenBackToCollectionPageLink: () => <div data-testid='back' />,
+}));
+jest.mock('../../../../../components/nextGen/collections/collectionParts/NextGenCollection', () => ({
+  ContentView: { ABOUT: 'ABOUT', PROVENANCE: 'PROV', DISPLAY_CENTER: 'CENTER', RARITY: 'RARITY' },
+  printViewButton: (cur:any, v:any, setView:any) => <button onClick={() => setView(v)}>{v}</button>,
+}));
+
+jest.mock('@fortawesome/react-fontawesome', () => ({
+  FontAwesomeIcon: (props: any) => <svg data-testid={props.icon.iconName} style={props.style} onClick={props.onClick} />,
+}));
+
+jest.mock('@tippyjs/react', () => {
+  const React = require('react');
+  return { __esModule: true, default: ({ children }: any) => <span data-testid='tippy'>{children}</span> };
+});
+
+jest.mock('../../../../../helpers/Helpers', () => ({
+  isNullAddress: jest.fn(() => false),
+}));
+
+const baseProps = {
+  collection: { id: 1, name: 'COL' } as any,
+  token: { id: 1, normalised_id: 0, name: 'Token', owner: '0x1', burnt: false } as any,
+  traits: [] as any[],
+  tokenCount: 2,
+  view: 'ABOUT' as any,
+  setView: jest.fn(),
+};
+
+function renderComponent(props?: Partial<typeof baseProps>) {
+  return render(<NextGenTokenPage {...baseProps} {...props} />);
+}
+
+describe('NextGenTokenPage navigation', () => {
+  it('disables previous button on first token', () => {
+    renderComponent();
+    const prev = screen.getByTestId('circle-chevron-left');
+    expect(prev).toHaveStyle('color: #9a9a9a');
+    expect(prev.parentElement?.getAttribute('data-testid')).not.toBe('tippy');
+  });
+
+  it('enables previous button when not first token', () => {
+    renderComponent({ token: { ...baseProps.token, normalised_id: 1, id: 2 } });
+    const prev = screen.getByTestId('circle-chevron-left');
+    expect(prev).toHaveStyle('color: #fff');
+    expect(prev.parentElement?.getAttribute('data-testid')).toBe('tippy');
+  });
+
+  it('shows burnt icon when burnt', () => {
+    renderComponent({ token: { ...baseProps.token, burnt: true } });
+    expect(screen.getByTestId('fire')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for NextGenTokenPage navigation controls
- add tests for NextgenCollectionMintingPlan spot computations

## Testing
- `npm run test`
