### PR TITLE
Add tests for CapacitorWidget, HeaderUserProxyDropdownItem and IPFSContext

### DIFF
--- a/__tests__/components/header/capacitor/CapacitorWidget.test.tsx
+++ b/__tests__/components/header/capacitor/CapacitorWidget.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CapacitorWidget from '../../../../components/header/capacitor/CapacitorWidget';
+
+jest.mock('../../../../hooks/useNavigationHistory', () => ({
+  useNavigationHistory: () => ({
+    canGoBack: true,
+    canGoForward: true,
+    isLoading: false,
+    goBack: jest.fn(),
+    goForward: jest.fn(),
+    refresh: jest.fn(),
+  }),
+}));
+
+const mockUseCapacitor = jest.fn();
+jest.mock('../../../../hooks/useCapacitor', () => ({
+  __esModule: true,
+  default: () => mockUseCapacitor(),
+}));
+
+jest.mock('../../../../hooks/useDeepLinkNavigation', () => ({
+  useDeepLinkNavigation: jest.fn(),
+}));
+
+const shareMock = jest.fn();
+jest.mock('@capacitor/share', () => ({
+  Share: { share: (...args: any[]) => shareMock(...args) },
+}));
+
+jest.mock('hammerjs', () => {
+  return jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    off: jest.fn(),
+  }));
+});
+
+describe('CapacitorWidget', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing when keyboard is visible', () => {
+    mockUseCapacitor.mockReturnValue({ keyboardVisible: true });
+    const { container } = render(<CapacitorWidget />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('opens share popup when Share API not implemented', async () => {
+    mockUseCapacitor.mockReturnValue({ keyboardVisible: false });
+    shareMock.mockRejectedValueOnce(new Error('not implemented'));
+
+    render(<CapacitorWidget />);
+    const buttons = screen.getAllByRole('button');
+    const shareButton = buttons[2];
+    await userEvent.click(shareButton);
+
+    const overlay = await screen.findByLabelText('Close overlay');
+    await waitFor(() => expect(overlay).toBeVisible());
+    expect(shareMock).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/header/user/proxy/HeaderUserProxyDropdownItem.test.tsx
+++ b/__tests__/components/header/user/proxy/HeaderUserProxyDropdownItem.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import HeaderUserProxyDropdownItem from '../../../../../components/header/user/proxy/HeaderUserProxyDropdownItem';
+
+const profile = {
+  id: 1,
+  created_by: { handle: 'alice', pfp: 'img.png' }
+};
+
+describe('HeaderUserProxyDropdownItem', () => {
+  it('activates proxy when not active', async () => {
+    const activate = jest.fn();
+    render(
+      <HeaderUserProxyDropdownItem
+        profileProxy={profile as any}
+        activeProfileProxy={null}
+        onActivateProfileProxy={activate}
+      />
+    );
+    const btn = screen.getByRole('button');
+    await userEvent.click(btn);
+    expect(activate).toHaveBeenCalledWith(profile);
+    expect(screen.getByText('alice')).toBeInTheDocument();
+  });
+
+  it('deactivates proxy when active', async () => {
+    const activate = jest.fn();
+    render(
+      <HeaderUserProxyDropdownItem
+        profileProxy={profile as any}
+        activeProfileProxy={profile as any}
+        onActivateProfileProxy={activate}
+      />
+    );
+    const btn = screen.getByRole('button');
+    await userEvent.click(btn);
+    expect(activate).toHaveBeenCalledWith(null);
+    expect(btn.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/ipfs/IPFSContext.test.tsx
+++ b/__tests__/components/ipfs/IPFSContext.test.tsx
@@ -1,0 +1,62 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { IpfsProvider, useIpfsService, resolveIpfsUrl } from '../../../components/ipfs/IPFSContext';
+import IpfsService from '../../../components/ipfs/IPFSService';
+
+jest.mock('../../../components/ipfs/IPFSService');
+
+const MockIpfsService = IpfsService as jest.MockedClass<typeof IpfsService>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.IPFS_API_ENDPOINT = 'http://api';
+  process.env.IPFS_GATEWAY_ENDPOINT = 'http://gateway';
+  process.env.IPFS_MFS_PATH = 'files';
+});
+
+afterAll(() => {
+  delete process.env.IPFS_API_ENDPOINT;
+  delete process.env.IPFS_GATEWAY_ENDPOINT;
+  delete process.env.IPFS_MFS_PATH;
+});
+
+describe('IpfsContext', () => {
+  it('initializes IpfsService on mount', async () => {
+    const init = jest.fn();
+    MockIpfsService.mockImplementation(() => ({ init } as any));
+
+    render(
+      <IpfsProvider>
+        <div>child</div>
+      </IpfsProvider>
+    );
+
+    await waitFor(() => expect(MockIpfsService).toHaveBeenCalled());
+    expect(MockIpfsService).toHaveBeenCalledWith({ apiEndpoint: 'http://api', mfsPath: 'files' });
+    expect(init).toHaveBeenCalled();
+  });
+
+  it('throws when used outside provider', () => {
+    expect(() => {
+      renderHook(() => {
+        return useIpfsService();
+      });
+    }).toThrow('useIpfsService must be used within an IpfsProvider');
+  });
+
+  it('resolves ipfs urls to gateway', async () => {
+    const url = await resolveIpfsUrl('ipfs://abc');
+    expect(url).toBe('http://gateway/ipfs/abc');
+  });
+
+  it('returns original url if env missing', async () => {
+    delete process.env.IPFS_API_ENDPOINT;
+    delete process.env.IPFS_GATEWAY_ENDPOINT;
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const url = await resolveIpfsUrl('ipfs://xyz');
+    expect(url).toBe('ipfs://xyz');
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for CapacitorWidget behaviour when keyboard shown and when sharing fails
- test HeaderUserProxyDropdownItem activation logic
- cover IPFSContext provider initialization and helpers

## Testing
- `npx jest __tests__/components/header/capacitor/CapacitorWidget.test.tsx --coverage`
- `npx jest __tests__/components/header/user/proxy/HeaderUserProxyDropdownItem.test.tsx --coverage`
- `npx jest __tests__/components/ipfs/IPFSContext.test.tsx --coverage`
- `npm run lint`
- `npm run type-check`
