### PR TITLE
Add tests for header components

### DIFF
--- a/__tests__/components/header/header-search/HeaderSearchModalItemMedia.test.tsx
+++ b/__tests__/components/header/header-search/HeaderSearchModalItemMedia.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import HeaderSearchModalItemMedia from '../../../../components/header/header-search/HeaderSearchModalItemMedia';
+
+jest.mock('next/image', () => ({ __esModule: true, default: (props: any) => <img {...props} /> }));
+
+describe('HeaderSearchModalItemMedia', () => {
+  it('renders placeholder with rounded style when no image available', () => {
+    const nft: any = { id: 1, name: 'NFT', icon_url: null, thumbnail_url: null, image_url: null };
+    const { container } = render(<HeaderSearchModalItemMedia nft={nft} roundedFull />);
+    const placeholder = container.querySelector('div');
+    expect(placeholder).toHaveClass('tw-rounded-full');
+    expect(placeholder).toHaveClass('tw-h-9');
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('renders provided src and alt', () => {
+    render(<HeaderSearchModalItemMedia src="/pic.png" alt="pic" />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('src', '/pic.png');
+    expect(img).toHaveAttribute('alt', 'pic');
+  });
+
+  it('uses nft image and name', () => {
+    const nft: any = { id: 2, name: 'Cool NFT', icon_url: 'icon.png', thumbnail_url: 'thumb.png', image_url: 'img.png' };
+    render(<HeaderSearchModalItemMedia nft={nft} />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('src', 'icon.png');
+    expect(img).toHaveAttribute('alt', 'Cool NFT');
+  });
+
+  it('falls back to id when name missing', () => {
+    const nft: any = { id: 42, name: null, icon_url: 'icon.png', thumbnail_url: null, image_url: null };
+    render(<HeaderSearchModalItemMedia nft={nft} />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('alt', '#42');
+  });
+});

--- a/__tests__/components/header/share/HeaderShareMobileApps.test.tsx
+++ b/__tests__/components/header/share/HeaderShareMobileApps.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ShareMobileApp } from '../../../../components/header/share/HeaderShareMobileApps';
+import { MOBILE_APP_IOS, MOBILE_APP_ANDROID } from '../../../../constants';
+
+jest.mock('next/image', () => ({ __esModule: true, default: (props: any) => <img {...props} /> }));
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children, target, onClick, className }: any) => (
+    <a href={href} target={target} onClick={onClick} className={className} data-testid="link">
+      {children}
+    </a>
+  ),
+}));
+
+describe('ShareMobileApp', () => {
+  it('renders iOS link with default target', () => {
+    render(<ShareMobileApp platform="ios" />);
+    const link = screen.getByTestId('link');
+    expect(link).toHaveAttribute('href', MOBILE_APP_IOS);
+    expect(link).toHaveAttribute('target', '_blank');
+    const img = link.querySelector('img')!;
+    expect(img).toHaveAttribute('src', '/app-store.png');
+    expect(img).toHaveAttribute('alt', '6529 Mobile iOS');
+  });
+
+  it('redirects at top level when target is _self', () => {
+    const top = { location: { href: '' } };
+    Object.defineProperty(window, 'top', { value: top });
+    render(<ShareMobileApp platform="android" target="_self" />);
+    const link = screen.getByTestId('link');
+    fireEvent.click(link);
+    expect(top.location.href).toBe(MOBILE_APP_ANDROID);
+  });
+});

--- a/__tests__/components/header/user/HeaderUserContext.test.tsx
+++ b/__tests__/components/header/user/HeaderUserContext.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import HeaderUserContext from '../../../../components/header/user/HeaderUserContext';
+
+const profileMock = jest.fn();
+const proxyMock = jest.fn();
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children, ...rest }: any) => (
+    <a href={href} {...rest}>{children}</a>
+  ),
+}));
+
+jest.mock('../../../../components/header/user/HeaderUserProfile', () => ({
+  __esModule: true,
+  default: (props: any) => { profileMock(props); return <div data-testid="profile" />; }
+}));
+
+jest.mock('../../../../components/header/user/proxy/HeaderUserProxy', () => ({
+  __esModule: true,
+  default: (props: any) => { proxyMock(props); return <div data-testid="proxy" />; }
+}));
+
+jest.mock('../../../../components/auth/SeizeConnectContext', () => ({
+  useSeizeConnectContext: jest.fn(),
+}));
+
+const { useSeizeConnectContext } = require('../../../../components/auth/SeizeConnectContext');
+
+describe('HeaderUserContext', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('shows create profile link when user has no handle', () => {
+    (useSeizeConnectContext as jest.Mock).mockReturnValue({ address: '0xabc' });
+    const profile: any = { handle: null };
+    render(<HeaderUserContext profile={profile} />);
+    expect(screen.getByRole('link', { name: /create profile/i })).toHaveAttribute('href', '/0xabc/identity');
+    expect(profileMock).toHaveBeenCalledWith({ profile });
+    expect(proxyMock).toHaveBeenCalledWith({ profile });
+  });
+
+  it('does not show create profile link when handle exists', () => {
+    (useSeizeConnectContext as jest.Mock).mockReturnValue({ address: '0xabc' });
+    const profile: any = { handle: 'alice' };
+    render(<HeaderUserContext profile={profile} />);
+    expect(screen.queryByRole('link', { name: /create profile/i })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `HeaderSearchModalItemMedia`
- test `ShareMobileApp` link behaviour
- verify conditional link in `HeaderUserContext`

## Testing
- `npx jest __tests__/components/header/header-search/HeaderSearchModalItemMedia.test.tsx --coverage --silent`
- `npx jest __tests__/components/header/share/HeaderShareMobileApps.test.tsx --coverage --silent`
- `npx jest __tests__/components/header/user/HeaderUserContext.test.tsx --coverage --silent`
