### PR TITLE
Add targeted tests for user components

### DIFF
--- a/__tests__/components/prenodes/PrenodesStatus.test.tsx
+++ b/__tests__/components/prenodes/PrenodesStatus.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import PrenodesStatus from '../../../components/prenodes/PrenodesStatus';
+import { useSeizeConnectContext } from '../../../components/auth/SeizeConnectContext';
+
+jest.mock('../../../components/auth/SeizeConnectContext');
+
+const mockUseContext = useSeizeConnectContext as jest.Mock;
+
+describe('PrenodesStatus', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (global as any).fetch = jest.fn();
+  });
+
+  it('links to address when user is connected', async () => {
+    const prenode = {
+      ip: '1.2.3.4',
+      domain: 'node.example',
+      city: 'NY',
+      country: 'US',
+      tdh_sync: true,
+      ping_status: 'green' as const,
+      block_sync: true,
+      created_at: '2020-01-01T00:00:00Z',
+      updated_at: '2020-01-02T00:00:00Z',
+    };
+    (fetch as jest.Mock).mockResolvedValue({
+      json: () => Promise.resolve({ data: [prenode], count: 1 }),
+    });
+    mockUseContext.mockReturnValue({ address: '0xabc' });
+
+    render(<PrenodesStatus />);
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    const link = await screen.findByRole('link');
+    expect(link).toHaveAttribute('href', 'https://node.example/oracle/address/0xabc');
+  });
+
+  it('shows Unknown location and default link when not connected', async () => {
+    const prenode = {
+      ip: '1.2.3.4',
+      domain: 'node.example',
+      city: '',
+      country: '',
+      tdh_sync: false,
+      ping_status: 'orange' as const,
+      block_sync: false,
+      created_at: '2020-01-01T00:00:00Z',
+      updated_at: '2020-01-02T00:00:00Z',
+    };
+    (fetch as jest.Mock).mockResolvedValue({
+      json: () => Promise.resolve({ data: [prenode], count: 1 }),
+    });
+    mockUseContext.mockReturnValue({ address: undefined });
+
+    render(<PrenodesStatus />);
+
+    await screen.findByText('Unknown');
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', 'https://node.example/oracle/tdh/total');
+  });
+});

--- a/__tests__/components/user/collected/filters/UserPageCollectedFiltersSortBy.test.tsx
+++ b/__tests__/components/user/collected/filters/UserPageCollectedFiltersSortBy.test.tsx
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/react';
+import UserPageCollectedFiltersSortBy from '../../../../../components/user/collected/filters/UserPageCollectedFiltersSortBy';
+import { CollectedCollectionType, CollectionSort } from '../../../../../entities/IProfile';
+import { SortDirection } from '../../../../../entities/ISort';
+
+let capturedProps: any = null;
+jest.mock('../../../../../components/utils/select/CommonSelect', () => (props: any) => {
+  capturedProps = props;
+  return <div data-testid="select" />;
+});
+
+describe('UserPageCollectedFiltersSortBy', () => {
+  beforeEach(() => {
+    capturedProps = null;
+  });
+
+  it('filters sort items based on collection', () => {
+    const { rerender } = render(
+      <UserPageCollectedFiltersSortBy
+        selected={CollectionSort.TOKEN_ID}
+        direction={SortDirection.ASC}
+        collection={CollectedCollectionType.MEMELAB}
+        setSelected={jest.fn()}
+      />
+    );
+    expect(capturedProps.items.map((i: any) => i.value)).toEqual([
+      CollectionSort.TOKEN_ID,
+    ]);
+
+    rerender(
+      <UserPageCollectedFiltersSortBy
+        selected={CollectionSort.TOKEN_ID}
+        direction={SortDirection.ASC}
+        collection={CollectedCollectionType.MEMES}
+        setSelected={jest.fn()}
+      />
+    );
+    expect(capturedProps.items.map((i: any) => i.value)).toEqual([
+      CollectionSort.TOKEN_ID,
+      CollectionSort.TDH,
+      CollectionSort.RANK,
+    ]);
+  });
+
+  it('shows all sorts when collection is null', () => {
+    render(
+      <UserPageCollectedFiltersSortBy
+        selected={CollectionSort.TOKEN_ID}
+        direction={SortDirection.DESC}
+        collection={null}
+        setSelected={jest.fn()}
+      />
+    );
+    expect(capturedProps.items.map((i: any) => i.value)).toEqual([
+      CollectionSort.TOKEN_ID,
+      CollectionSort.TDH,
+      CollectionSort.RANK,
+    ]);
+  });
+});

--- a/__tests__/components/user/groups/UserPageGroups.test.tsx
+++ b/__tests__/components/user/groups/UserPageGroups.test.tsx
@@ -1,0 +1,75 @@
+import { render, act } from '@testing-library/react';
+import UserPageGroups from '../../../../components/user/groups/UserPageGroups';
+import { AuthContext } from '../../../../components/auth/Auth';
+import { useRouter } from 'next/router';
+
+let routerPush = jest.fn();
+let capturedProps: any = null;
+
+jest.mock('../../../../components/groups/page/list/GroupsList', () => (props: any) => {
+  capturedProps = props;
+  return <div data-testid="list" />;
+});
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+
+const { useRouter: useRouterMock } = jest.requireMock('next/router');
+
+function renderComponent(context: any, profile: any) {
+  routerPush = jest.fn();
+  useRouterMock.mockReturnValue({ push: routerPush });
+  return render(
+    <AuthContext.Provider value={context}>
+      <UserPageGroups profile={profile} />
+    </AuthContext.Provider>
+  );
+}
+
+describe('UserPageGroups', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedProps = null;
+  });
+
+  it('determines visibility of create button based on context', () => {
+    renderComponent(
+      { connectedProfile: { handle: 'alice' }, activeProfileProxy: null, requestAuth: jest.fn() },
+      { handle: 'alice' }
+    );
+    expect(capturedProps.showCreateNewGroupButton).toBe(true);
+
+    renderComponent(
+      { connectedProfile: { handle: 'alice' }, activeProfileProxy: { id: 1 }, requestAuth: jest.fn() },
+      { handle: 'alice' }
+    );
+    expect(capturedProps.showCreateNewGroupButton).toBe(false);
+  });
+
+  it('updates filters when callbacks invoked', () => {
+    renderComponent(
+      { connectedProfile: { handle: 'bob' }, activeProfileProxy: null, requestAuth: jest.fn() },
+      { handle: 'bob' }
+    );
+    expect(capturedProps.filters).toEqual({ group_name: null, author_identity: 'bob' });
+
+    act(() => capturedProps.setGroupName('group'));
+    expect(capturedProps.filters.group_name).toBe('group');
+
+    act(() => capturedProps.setAuthorIdentity('alice'));
+    expect(capturedProps.filters.author_identity).toBe('alice');
+  });
+
+  it('navigates to create page after successful auth', async () => {
+    const requestAuth = jest.fn().mockResolvedValue({ success: true });
+    renderComponent(
+      { connectedProfile: { handle: 'bob' }, activeProfileProxy: null, requestAuth },
+      { handle: 'bob' }
+    );
+
+    await act(async () => {
+      await capturedProps.onCreateNewGroup();
+    });
+    expect(requestAuth).toHaveBeenCalled();
+    expect(routerPush).toHaveBeenCalledWith('/network/groups?edit=new');
+  });
+});


### PR DESCRIPTION
## Summary
- test PrenodesStatus render logic for logged in/out users
- test UserPageCollectedFiltersSortBy filtering
- test UserPageGroups interactions

## Testing
- `npx jest __tests__/components/prenodes/PrenodesStatus.test.tsx --coverage`
- `npx jest __tests__/components/user/collected/filters/UserPageCollectedFiltersSortBy.test.tsx --coverage`
- `npx jest __tests__/components/user/groups/UserPageGroups.test.tsx --coverage`
- `npm run lint`
- `npm run type-check`
