### PR TITLE
Add tests for leaderboard and navigation components

### DIFF
--- a/__tests__/components/leaderboard/NFTLeaderboard.test.ts
+++ b/__tests__/components/leaderboard/NFTLeaderboard.test.ts
@@ -1,0 +1,67 @@
+import { fetchNftTdhResults, setScrollPosition, PAGE_SIZE } from '../../../components/leaderboard/NFTLeaderboard';
+import { cicToType } from '../../../helpers/Helpers';
+import { commonApiFetch } from '../../../services/api/common-api';
+
+jest.mock('../../../helpers/Helpers', () => {
+  const original = jest.requireActual('../../../helpers/Helpers');
+  return { ...original, cicToType: jest.fn() };
+});
+
+jest.mock('../../../services/api/common-api', () => ({
+  commonApiFetch: jest.fn(),
+}));
+
+describe('fetchNftTdhResults', () => {
+  it('fetches data and converts cic_type', async () => {
+    (commonApiFetch as jest.Mock).mockResolvedValue({
+      count: 1,
+      page: 1,
+      next: null,
+      data: [
+        { id: 1, cic_score: 10 },
+      ],
+    });
+    (cicToType as jest.Mock).mockReturnValue('VIP');
+
+    const result = await fetchNftTdhResults('0xabc', 5, '', 2, 'balance', 'ASC');
+
+    expect(commonApiFetch).toHaveBeenCalledWith({
+      endpoint: `tdh/nft/0xabc/5?&page_size=${PAGE_SIZE}&page=2&sort=balance&sort_direction=ASC`,
+    });
+    expect(result.data[0].cic_type).toBe('VIP');
+  });
+});
+
+describe('setScrollPosition', () => {
+  it('scrolls to leaderboard when scrolled', () => {
+    const div = document.createElement('div');
+    div.id = 'nft-leaderboard';
+    Object.defineProperty(div, 'offsetTop', { value: 100 });
+    document.body.appendChild(div);
+    Object.defineProperty(window, 'scrollY', { value: 50, writable: true });
+    const scrollSpy = jest.spyOn(window, 'scrollTo').mockImplementation();
+
+    setScrollPosition();
+
+    expect(scrollSpy).toHaveBeenCalledWith({ top: 100, behavior: 'smooth' });
+
+    scrollSpy.mockRestore();
+    document.body.innerHTML = '';
+  });
+
+  it('does nothing when not scrolled', () => {
+    const div = document.createElement('div');
+    div.id = 'nft-leaderboard';
+    Object.defineProperty(div, 'offsetTop', { value: 50 });
+    document.body.appendChild(div);
+    Object.defineProperty(window, 'scrollY', { value: 0, writable: true });
+    const scrollSpy = jest.spyOn(window, 'scrollTo').mockImplementation();
+
+    setScrollPosition();
+
+    expect(scrollSpy).not.toHaveBeenCalled();
+
+    scrollSpy.mockRestore();
+    document.body.innerHTML = '';
+  });
+});

--- a/__tests__/components/mapping-tools/DelegationMappingTool.test.tsx
+++ b/__tests__/components/mapping-tools/DelegationMappingTool.test.tsx
@@ -1,0 +1,28 @@
+import { render, fireEvent } from '@testing-library/react';
+import DelegationMappingTool from '../../../components/mapping-tools/DelegationMappingTool';
+
+jest.mock('react-bootstrap', () => ({
+  Container: (props: any) => <div {...props} />,
+  Row: (props: any) => <div {...props} />,
+  Col: (props: any) => <div {...props} />,
+  Form: { Select: (props: any) => <select {...props} />, Control: (props: any) => <input {...props} /> },
+  Button: (props: any) => <button {...props} />,
+}));
+
+describe('DelegationMappingTool drag and drop', () => {
+  it('toggles active class on drag events and shows file name on drop', () => {
+    const { getByText } = render(<DelegationMappingTool />);
+    const textElement = getByText(/drag and drop/i);
+    const dropzone = textElement.parentElement as HTMLElement;
+
+    expect(dropzone.className).not.toMatch(/uploadAreaActive/);
+    fireEvent.dragEnter(dropzone);
+    expect(dropzone.className).toMatch(/uploadAreaActive/);
+    fireEvent.dragLeave(dropzone);
+    expect(dropzone.className).not.toMatch(/uploadAreaActive/);
+
+    const file = new File(['a'], 'test.csv', { type: 'text/csv' });
+    fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
+    expect(dropzone.textContent).toContain('test.csv');
+  });
+});

--- a/__tests__/components/navigation/NavItem.test.tsx
+++ b/__tests__/components/navigation/NavItem.test.tsx
@@ -1,0 +1,68 @@
+import { render } from '@testing-library/react';
+import NavItem from '../../../components/navigation/NavItem';
+import { useViewContext } from '../../../components/navigation/ViewContext';
+import { useAuth, TitleType } from '../../../components/auth/Auth';
+import { useUnreadNotifications } from '../../../hooks/useUnreadNotifications';
+import { useUnreadIndicator } from '../../../hooks/useUnreadIndicator';
+import { useNotificationsContext } from '../../../components/notifications/NotificationsContext';
+import { isNavItemActive } from '../../../components/navigation/isNavItemActive';
+import { useWaveData } from '../../../hooks/useWaveData';
+import { useWave } from '../../../hooks/useWave';
+import { useRouter } from 'next/router';
+
+jest.mock('../../../components/navigation/ViewContext', () => ({ useViewContext: jest.fn() }));
+jest.mock('../../../components/auth/Auth', () => ({ useAuth: jest.fn(), TitleType: { NOTIFICATION: 'NOTIFICATION' } }));
+jest.mock('../../../hooks/useUnreadNotifications', () => ({ useUnreadNotifications: jest.fn() }));
+jest.mock('../../../hooks/useUnreadIndicator', () => ({ useUnreadIndicator: jest.fn() }));
+jest.mock('../../../components/notifications/NotificationsContext', () => ({ useNotificationsContext: jest.fn() }));
+jest.mock('../../../components/navigation/isNavItemActive', () => ({ isNavItemActive: jest.fn() }));
+jest.mock('../../../hooks/useWaveData', () => ({ useWaveData: jest.fn() }));
+jest.mock('../../../hooks/useWave', () => ({ useWave: jest.fn() }));
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+
+describe('NavItem notifications', () => {
+  const handleNavClick = jest.fn();
+  const removeAllDeliveredNotifications = jest.fn();
+  const setTitle = jest.fn();
+
+  beforeEach(() => {
+    (useViewContext as jest.Mock).mockReturnValue({ activeView: 'home', handleNavClick });
+    (useRouter as jest.Mock).mockReturnValue({ query: {}, pathname: '/' });
+    (isNavItemActive as jest.Mock).mockReturnValue(false);
+    (useUnreadIndicator as jest.Mock).mockReturnValue({ hasUnread: false });
+    (useNotificationsContext as jest.Mock).mockReturnValue({ removeAllDeliveredNotifications });
+    (useAuth as jest.Mock).mockReturnValue({ connectedProfile: { handle: 'user' }, setTitle });
+    (useWaveData as jest.Mock).mockReturnValue({ data: null });
+    (useWave as jest.Mock).mockReturnValue({ isDm: false });
+  });
+
+  it('sets title and shows badge when there are unread notifications', () => {
+    (useUnreadNotifications as jest.Mock).mockReturnValue({ notifications: { unread_count: 3 }, haveUnreadNotifications: true });
+    const item = { name: 'Notifications', icon: '/n' } as any;
+
+    const { container } = render(<NavItem item={item} />);
+
+    expect(setTitle).toHaveBeenCalledWith({ title: '(3) Notifications | 6529.io', type: 'NOTIFICATION' });
+    expect(container.querySelector('.tw-bg-red')).not.toBeNull();
+    expect(removeAllDeliveredNotifications).not.toHaveBeenCalled();
+  });
+
+  it('clears delivered notifications when none unread', () => {
+    (useUnreadNotifications as jest.Mock).mockReturnValue({ notifications: { unread_count: 0 }, haveUnreadNotifications: false });
+    const item = { name: 'Notifications', icon: '/n' } as any;
+
+    const { container } = render(<NavItem item={item} />);
+
+    expect(setTitle).toHaveBeenCalledWith({ title: null, type: 'NOTIFICATION' });
+    expect(removeAllDeliveredNotifications).toHaveBeenCalled();
+    expect(container.querySelector('.tw-bg-red')).toBeNull();
+  });
+});
+
+it('renders disabled item when disabled flag set', () => {
+  (useUnreadNotifications as jest.Mock).mockReturnValue({});
+  const item = { name: 'Feed', icon: '/i', disabled: true } as any;
+  const { getByRole } = render(<NavItem item={item} />);
+  const button = getByRole('button');
+  expect(button).toBeDisabled();
+});


### PR DESCRIPTION
## Summary
- add utilities tests for NFT leaderboard
- test drag and drop behaviour for DelegationMappingTool
- cover NavItem notification badge logic

## Testing
- `npx jest __tests__/components/leaderboard/NFTLeaderboard.test.ts --coverage`
- `npx jest __tests__/components/mapping-tools/DelegationMappingTool.test.tsx --coverage`
- `npx jest __tests__/components/navigation/NavItem.test.tsx --coverage`
- `npm run improve-coverage`