### PR TITLE
Add tests for NextGen components

### DIFF
--- a/__tests__/components/nextGen/collections/collectionParts/NextGenCollectionArt.test.tsx
+++ b/__tests__/components/nextGen/collections/collectionParts/NextGenCollectionArt.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import NextGenCollectionArt from '../../../../../components/nextGen/collections/collectionParts/NextGenCollectionArt';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ query: {}, push: jest.fn() }),
+}));
+
+jest.mock('../../../../../services/api/common-api', () => ({
+  commonApiFetch: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock('../../../../../components/nextGen/collections/NextGenTokenList', () => (props: any) => (
+  <div data-testid="token-list" data-limit={String(props.limit)} />
+));
+
+jest.mock('react-bootstrap', () => {
+  const React = require('react');
+  const RB: any = {
+    Container: (p: any) => <div {...p} />,
+    Row: (p: any) => <div {...p} />,
+    Col: (p: any) => <div {...p} />,
+    Form: (p: any) => <form {...p} />,
+    Dropdown: (p: any) => <div {...p} />,
+  };
+  const Accordion: any = (p: any) => <div {...p} />;
+  Accordion.Item = (p: any) => <div {...p} />;
+  Accordion.Button = (p: any) => <button {...p} />;
+  Accordion.Body = (p: any) => <div {...p} />;
+  RB.Accordion = Accordion;
+  return RB;
+});
+
+jest.mock('@fortawesome/react-fontawesome', () => ({
+  FontAwesomeIcon: (p: any) => <svg {...p} />,
+}));
+
+jest.mock('@tippyjs/react', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <span>{children}</span>,
+}));
+
+jest.mock('../../../../../helpers/AllowlistToolHelpers', () => ({
+  getRandomObjectId: () => 'id',
+}));
+
+jest.mock('../../../../../components/dotLoader/DotLoader', () => () => <div data-testid="loader" />);
+jest.mock("../../../../../components/nextGen/nextgen_helpers", () => ({
+  formatNameForUrl: (s: string) => s,
+  NextGenListFilters: { ID: "ID" },
+  NextGenTokenListedType: { ALL: "ALL", LISTED: "LISTED", NOT_LISTED: "NOT_LISTED" },
+}));
+
+const { commonApiFetch } = require('../../../../../services/api/common-api');
+
+const collection = { id: 1, name: 'Cool' } as any;
+
+describe('NextGenCollectionArt', () => {
+  beforeEach(() => {
+    (commonApiFetch as jest.Mock).mockClear();
+  });
+
+  it('shows view all link and renders token list with limit', async () => {
+    (commonApiFetch as jest.Mock).mockResolvedValue([]);
+    render(<NextGenCollectionArt collection={collection} show_view_all />);
+    await waitFor(() => expect(commonApiFetch).toHaveBeenCalled());
+    const link = screen.getByRole('link', { name: /View All/i });
+    expect(link).toHaveAttribute('href', '/nextgen/collection/Cool/art');
+    await screen.findByTestId('token-list');
+    expect(screen.getByTestId('token-list')).toHaveAttribute('data-limit', '6');
+  });
+});

--- a/__tests__/components/nextGen/collections/nextgenToken/Lightbulb.test.tsx
+++ b/__tests__/components/nextGen/collections/nextgenToken/Lightbulb.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Lightbulb from "../../../../../components/nextGen/collections/nextgenToken/Lightbulb";
+
+jest.mock('@tippyjs/react', () => ({
+  __esModule: true,
+  default: ({ content, children }: any) => (
+    <span data-testid="tippy" data-content={content}>{children}</span>
+  ),
+}));
+
+describe('Lightbulb', () => {
+  it('renders black mode tooltip and handles click', async () => {
+    const onClick = jest.fn();
+    const { container } = render(
+      <Lightbulb mode="black" className="cls" onClick={onClick} />
+    );
+    expect(screen.getByTestId('tippy')).toHaveAttribute('data-content', 'Blackbox');
+    const svg = container.querySelector('svg')!;
+    await userEvent.click(svg);
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('renders light mode tooltip', () => {
+    render(<Lightbulb mode="light" className="cls" />);
+    expect(screen.getByTestId('tippy')).toHaveAttribute('data-content', 'Lightbox');
+  });
+});

--- a/__tests__/components/nextGen/collections/nextgenToken/NextGenZoomableImage.test.tsx
+++ b/__tests__/components/nextGen/collections/nextgenToken/NextGenZoomableImage.test.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import NextGenZoomableImage, { MIN_ZOOM_SCALE } from '../../../../../components/nextGen/collections/nextgenToken/NextGenZoomableImage';
+import { get8KUrl, get16KUrl } from '../../../../../components/nextGen/collections/nextgenToken/NextGenTokenImage';
+import useIsMobileDevice from '../../../../../hooks/isMobileDevice';
+import useIsMobileScreen from '../../../../../hooks/isMobileScreen';
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: React.forwardRef((props: any, ref) => <img ref={ref} data-testid="img" {...props} />),
+}));
+
+jest.mock('../../../../../hooks/isMobileDevice');
+jest.mock('../../../../../hooks/isMobileScreen');
+
+jest.mock('../../../../../components/nextGen/collections/nextgenToken/NextGenTokenImage', () => ({
+  get8KUrl: jest.fn(() => '8k'),
+  get16KUrl: jest.fn(() => '16k'),
+}));
+
+jest.mock('../../../../../components/dotLoader/DotLoader', () => () => <div data-testid="loader" />);
+
+describe('NextGenZoomableImage', () => {
+  const token = { id: 1, name: 'Token' } as any;
+
+  it('uses 8k url on mobile devices and 16k otherwise', () => {
+    (useIsMobileDevice as jest.Mock).mockReturnValueOnce(true);
+    (useIsMobileScreen as jest.Mock).mockReturnValue(false);
+    const setZoomScale = jest.fn();
+    const onImageLoaded = jest.fn();
+    render(
+      <NextGenZoomableImage
+        token={token}
+        zoom_scale={1}
+        setZoomScale={setZoomScale}
+        maintain_aspect_ratio={false}
+        onImageLoaded={onImageLoaded}
+      />
+    );
+    expect(screen.getByTestId('img')).toHaveAttribute('src', '8k');
+
+    (useIsMobileDevice as jest.Mock).mockReturnValueOnce(false);
+    render(
+      <NextGenZoomableImage
+        token={token}
+        zoom_scale={1}
+        setZoomScale={setZoomScale}
+        maintain_aspect_ratio={false}
+        onImageLoaded={onImageLoaded}
+      />
+    );
+    expect(screen.getAllByTestId('img')[1]).toHaveAttribute('src', '16k');
+  });
+
+  it('handles wheel zoom events', () => {
+    (useIsMobileDevice as jest.Mock).mockReturnValue(false);
+    (useIsMobileScreen as jest.Mock).mockReturnValue(false);
+    const setZoomScale = jest.fn();
+    const onImageLoaded = jest.fn();
+    render(
+      <NextGenZoomableImage
+        token={token}
+        zoom_scale={5}
+        setZoomScale={setZoomScale}
+        maintain_aspect_ratio={false}
+        onImageLoaded={onImageLoaded}
+      />
+    );
+    const img = screen.getByTestId('img');
+    Object.defineProperty(img, 'getBoundingClientRect', {
+      value: () => ({ left: 0, top: 0, width: 100, height: 100 }),
+    });
+    fireEvent.wheel(img, { deltaY: -1, clientX: 50, clientY: 60 });
+    expect(setZoomScale).toHaveBeenCalledWith(4);
+    expect(img.style.transformOrigin).toBe('50% 60%');
+  });
+
+  it('runs image load workflow', () => {
+    jest.useFakeTimers();
+    (useIsMobileDevice as jest.Mock).mockReturnValue(false);
+    (useIsMobileScreen as jest.Mock).mockReturnValue(false);
+    const setZoomScale = jest.fn();
+    const onImageLoaded = jest.fn();
+    render(
+      <NextGenZoomableImage
+        token={token}
+        zoom_scale={2}
+        setZoomScale={setZoomScale}
+        maintain_aspect_ratio={false}
+        onImageLoaded={onImageLoaded}
+      />
+    );
+    const img = screen.getByTestId('img');
+    fireEvent.load(img);
+    expect(setZoomScale).toHaveBeenCalledWith(MIN_ZOOM_SCALE + 1);
+    jest.advanceTimersByTime(8000);
+    expect(setZoomScale).toHaveBeenCalledWith(MIN_ZOOM_SCALE);
+    jest.advanceTimersByTime(5000);
+    expect(onImageLoaded).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for Lightbulb rendering and tooltip behavior
- cover zoom and load logic in `NextGenZoomableImage`
- test `NextGenCollectionArt` view all mode

## Testing
- `npx jest __tests__/components/nextGen/collections/nextgenToken/Lightbulb.test.tsx --coverage`
- `npx jest __tests__/components/nextGen/collections/nextgenToken/NextGenZoomableImage.test.tsx --coverage`
- `npx jest __tests__/components/nextGen/collections/collectionParts/NextGenCollectionArt.test.tsx --coverage`
- `npm run lint`
- `npm run type-check`
