### PR TITLE
Add tests for levels and NFT stats

### DIFF
--- a/__tests__/components/NftStats.test.tsx
+++ b/__tests__/components/NftStats.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, within } from '@testing-library/react';
+import { NftPageStats } from '../../components/nftAttributes/NftStats';
+
+describe('NftPageStats', () => {
+  const nft = {
+    mint_price: 0.123456,
+    hodl_rate: 0.456,
+    floor_price: 1.2345,
+    market_cap: 987.654,
+    highest_offer: 2.345,
+  } as any;
+
+  it('renders formatted stats rows', () => {
+    render(
+      <table><tbody><NftPageStats nft={nft} /></tbody></table>
+    );
+
+    const rows = screen.getAllByRole('row');
+    expect(within(rows[0]).getByText('Mint Price')).toBeInTheDocument();
+    expect(within(rows[0]).getByText('0.12346 ETH')).toBeInTheDocument();
+
+    expect(within(rows[1]).getByText('TDH Rate')).toBeInTheDocument();
+    expect(within(rows[1]).getByText('0.46')).toBeInTheDocument();
+
+    expect(within(rows[2]).getByText('Floor Price')).toBeInTheDocument();
+    expect(within(rows[2]).getByText('1.235 ETH')).toBeInTheDocument();
+
+    expect(within(rows[3]).getByText('Market Cap')).toBeInTheDocument();
+    expect(within(rows[3]).getByText('987.65 ETH')).toBeInTheDocument();
+
+    expect(within(rows[4]).getByText('Highest Offer')).toBeInTheDocument();
+    expect(within(rows[4]).getByText('2.345 ETH')).toBeInTheDocument();
+  });
+
+  it('shows N/A when value is zero', () => {
+    render(
+      <table><tbody><NftPageStats nft={{ ...nft, highest_offer: 0 }} /></tbody></table>
+    );
+    const lastRow = screen.getAllByRole('row')[4];
+    expect(within(lastRow).getByText('N/A')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/TableOfLevels.test.tsx
+++ b/__tests__/components/TableOfLevels.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen, within } from '@testing-library/react';
+import TableOfLevels from '../../components/levels/TableOfLevels';
+import levels from '../../levels.json';
+
+describe('TableOfLevels', () => {
+  it('renders a row for each level with the correct values', () => {
+    render(<TableOfLevels />);
+    const table = screen.getByRole('table');
+    const rows = within(table).getAllByRole('row');
+    // header row + one row per level
+    expect(rows).toHaveLength(levels.length + 1);
+
+    // check first and last rows
+    const firstRowCells = within(rows[1]).getAllByRole('cell');
+    expect(firstRowCells[0]).toHaveTextContent('0');
+    expect(firstRowCells[1]).toHaveTextContent('0');
+
+    const lastRowCells = within(rows[rows.length - 1]).getAllByRole('cell');
+    const last = levels[levels.length - 1];
+    expect(lastRowCells[0]).toHaveTextContent(last.level.toString());
+    expect(lastRowCells[1]).toHaveTextContent(last.threshold.toLocaleString());
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for TableOfLevels component
- add coverage for NftPageStats component

## Testing
- `npx jest __tests__/components/TableOfLevels.test.tsx --coverage --runTestsByPath`
- `npx jest __tests__/components/NftStats.test.tsx --coverage --runTestsByPath`
- `npm run lint`
- `npm run type-check`
