### PR TITLE
Increase tests for proxy actions and user settings classification

### DIFF
--- a/__tests__/components/user/proxy/proxy/list/ProxyActions.test.tsx
+++ b/__tests__/components/user/proxy/proxy/list/ProxyActions.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import ProxyActions from '../../../../../../components/user/proxy/proxy/list/ProxyActions';
+import { Time } from '../../../../../../helpers/time';
+
+jest.mock('../../../../../../components/user/proxy/proxy/list/ProxyActionRow', () => (props: any) => (
+  <div data-testid="row">{props.action.id}</div>
+));
+
+const baseProfile = { id: 'p1' } as any;
+
+function buildAction(id: string, start: number, end: number | null) {
+  return {
+    id,
+    start_time: start,
+    end_time: end,
+  } as any;
+}
+
+describe('ProxyActions', () => {
+  beforeEach(() => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(1000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('sorts actions with active ones first and by start time', () => {
+    const actions = [
+      buildAction('a1', 100, null),
+      buildAction('a2', 200, null),
+      buildAction('a3', 300, 800),
+      buildAction('a4', 400, 700),
+    ];
+    render(
+      <ProxyActions profileProxy={{ actions } as any} profile={baseProfile} isSelf={false} />
+    );
+    const ids = screen.getAllByTestId('row').map((e) => e.textContent);
+    expect(ids).toEqual(['a2', 'a1', 'a3', 'a4']);
+  });
+
+  it('orders expired actions by descending end time', () => {
+    const actions = [
+      buildAction('a1', 100, 500),
+      buildAction('a2', 200, 800),
+      buildAction('a3', 300, 700),
+    ];
+    render(
+      <ProxyActions profileProxy={{ actions } as any} profile={baseProfile} isSelf={true} />
+    );
+    const ids = screen.getAllByTestId('row').map((e) => e.textContent);
+    expect(ids).toEqual(['a2', 'a3', 'a1']);
+  });
+});

--- a/__tests__/components/user/settings/UserSettingsClassificationItem.test.tsx
+++ b/__tests__/components/user/settings/UserSettingsClassificationItem.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserSettingsClassificationItem from '../../../../components/user/settings/UserSettingsClassificationItem';
+import { ApiProfileClassification } from '../../../../generated/models/ApiProfileClassification';
+
+const classification = ApiProfileClassification.Bot;
+
+function renderItem(selected: ApiProfileClassification | null, handler = jest.fn()) {
+  render(
+    <ul>
+      <UserSettingsClassificationItem
+        classification={classification}
+        selected={selected}
+        onClassification={handler}
+      />
+    </ul>
+  );
+  return handler;
+}
+
+describe('UserSettingsClassificationItem', () => {
+  it('calls onClassification when clicked', async () => {
+    const handler = renderItem(null);
+    const item = screen.getByText('Bot').closest('li') as HTMLElement;
+    await userEvent.click(item);
+    expect(handler).toHaveBeenCalledWith(classification);
+  });
+
+  it('shows check icon when selected', () => {
+    renderItem(classification);
+    const item = screen.getByText('Bot').closest('li') as HTMLElement;
+    expect(item.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('updates active state when selected prop changes', () => {
+    const { rerender } = render(
+      <ul>
+        <UserSettingsClassificationItem
+          classification={classification}
+          selected={null}
+          onClassification={() => {}}
+        />
+      </ul>
+    );
+    let item = screen.getByText('Bot').closest('li') as HTMLElement;
+    expect(item.querySelector('svg')).toBeNull();
+
+    rerender(
+      <ul>
+        <UserSettingsClassificationItem
+          classification={classification}
+          selected={classification}
+          onClassification={() => {}}
+        />
+      </ul>
+    );
+    item = screen.getByText('Bot').closest('li') as HTMLElement;
+    expect(item.querySelector('svg')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for sorting logic in ProxyActions component
- add tests for UserSettingsClassificationItem behavior

## Testing
- `npx jest __tests__/components/user/proxy/proxy/list/ProxyActions.test.tsx --coverage`
- `npx jest __tests__/components/user/settings/UserSettingsClassificationItem.test.tsx --coverage`
- `npm run lint`
- `npm run type-check`
