### PR TITLE
Add tests for navigation helpers and collection filters

### DIFF
--- a/__tests__/components/navigation/isNavItemActive.test.ts
+++ b/__tests__/components/navigation/isNavItemActive.test.ts
@@ -1,0 +1,35 @@
+import { isNavItemActive } from '../../../components/navigation/isNavItemActive';
+import type { NavItem } from '../../../components/navigation/navTypes';
+import type { NextRouter } from 'next/router';
+
+function makeRouter(pathname: string, query: Record<string, any> = {}): NextRouter {
+  return { pathname, query } as NextRouter;
+}
+
+describe('isNavItemActive', () => {
+  it('returns true for Network item when on network routes with no active view', () => {
+    const item: NavItem = { kind: 'route', name: 'Network', href: '/network', icon: '' } as any;
+    const router = makeRouter('/network');
+    expect(isNavItemActive(item, router, null, false)).toBe(true);
+  });
+
+  it('handles Stream route based on wave query', () => {
+    const item: NavItem = { kind: 'route', name: 'Stream', href: '/my-stream', icon: '' } as any;
+    const routerNoWave = makeRouter('/my-stream');
+    expect(isNavItemActive(item, routerNoWave, null, false)).toBe(true);
+    const routerWave = makeRouter('/my-stream', { wave: 'w1' });
+    expect(isNavItemActive(item, routerWave, null, false)).toBe(false);
+  });
+
+  it('returns true for waves view when viewing non-DM wave sub route', () => {
+    const item: NavItem = { kind: 'view', name: 'Waves', viewKey: 'waves', icon: '' } as any;
+    const router = makeRouter('/my-stream', { wave: 'x1' });
+    expect(isNavItemActive(item, router, null, false)).toBe(true);
+  });
+
+  it('returns true for messages view when current wave is DM', () => {
+    const item: NavItem = { kind: 'view', name: 'Messages', viewKey: 'messages', icon: '' } as any;
+    const router = makeRouter('/my-stream', { wave: 'dm1' });
+    expect(isNavItemActive(item, router, null, true)).toBe(true);
+  });
+});

--- a/__tests__/components/nextGen/collections/collectionParts/printViewButton.test.tsx
+++ b/__tests__/components/nextGen/collections/collectionParts/printViewButton.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { printViewButton, ContentView } from '../../../../../components/nextGen/collections/collectionParts/NextGenCollection';
+
+describe('printViewButton', () => {
+  it('highlights current view and triggers setView on click', () => {
+    const setView = jest.fn();
+    render(printViewButton(ContentView.ABOUT, ContentView.ABOUT, setView));
+    const button = screen.getByRole('button');
+    expect(button.className).toMatch(/nextgenTokenDetailsLinkSelected/);
+    expect(screen.getByText('About')).toHaveClass('font-color');
+    fireEvent.click(button);
+    expect(setView).toHaveBeenCalledWith(ContentView.ABOUT);
+  });
+
+  it('renders unselected state and calls setView with provided value', () => {
+    const setView = jest.fn();
+    render(printViewButton(ContentView.ABOUT, ContentView.PROVENANCE, setView));
+    const button = screen.getByRole('button');
+    expect(button.className).not.toMatch(/nextgenTokenDetailsLinkSelected/);
+    expect(screen.getByText('Provenance')).toHaveClass('font-color-h cursor-pointer');
+    fireEvent.click(button);
+    expect(setView).toHaveBeenCalledWith(ContentView.PROVENANCE);
+  });
+});

--- a/__tests__/components/user/collected/filters/UserPageCollectedFiltersCollection.test.tsx
+++ b/__tests__/components/user/collected/filters/UserPageCollectedFiltersCollection.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+import UserPageCollectedFiltersCollection from '../../../../../components/user/collected/filters/UserPageCollectedFiltersCollection';
+import { CollectedCollectionType } from '../../../../../entities/IProfile';
+
+let capturedProps: any = null;
+jest.mock('../../../../../components/utils/select/CommonSelect', () => (props: any) => {
+  capturedProps = props;
+  return <div data-testid="select" />;
+});
+
+describe('UserPageCollectedFiltersCollection', () => {
+  beforeEach(() => { capturedProps = null; });
+
+  it('passes all collection options including "All"', () => {
+    render(<UserPageCollectedFiltersCollection selected={null} setSelected={jest.fn()} />);
+    const values = capturedProps.items.map((i: any) => i.value);
+    expect(values).toEqual([null, ...Object.values(CollectedCollectionType)]);
+    expect(capturedProps.activeItem).toBeNull();
+  });
+
+  it('sets activeItem from props', () => {
+    render(<UserPageCollectedFiltersCollection selected={CollectedCollectionType.MEMES} setSelected={jest.fn()} />);
+    expect(capturedProps.activeItem).toBe(CollectedCollectionType.MEMES);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `isNavItemActive`
- test `printViewButton` selection logic
- verify props for `UserPageCollectedFiltersCollection`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
