### PR TITLE
Add tests for user components

### DIFF
--- a/__tests__/components/user/identity/statements/add/UserPageIdentityAddStatementsSelect.test.tsx
+++ b/__tests__/components/user/identity/statements/add/UserPageIdentityAddStatementsSelect.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import UserPageIdentityAddStatementsSelect from '../../../../../../components/user/identity/statements/add/UserPageIdentityAddStatementsSelect';
+import { STATEMENT_ADD_VIEW } from '../../../../../../components/user/identity/statements/add/UserPageIdentityAddStatements';
+
+describe('UserPageIdentityAddStatementsSelect', () => {
+  it('closes when close button clicked', async () => {
+    const onClose = jest.fn();
+    render(<UserPageIdentityAddStatementsSelect onClose={onClose} onViewChange={() => {}} />);
+    await userEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('selects social media accounts view', async () => {
+    const onViewChange = jest.fn();
+    render(<UserPageIdentityAddStatementsSelect onClose={() => {}} onViewChange={onViewChange} />);
+    await userEvent.click(screen.getByRole('button', { name: /social media accounts/i }));
+    expect(onViewChange).toHaveBeenCalledWith(STATEMENT_ADD_VIEW.SOCIAL_MEDIA_ACCOUNT);
+  });
+});

--- a/__tests__/components/user/proxy/proxy/create-action/config/ProxyCreateActionConfigRateWaveDrop.test.tsx
+++ b/__tests__/components/user/proxy/proxy/create-action/config/ProxyCreateActionConfigRateWaveDrop.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import ProxyCreateActionConfigRateWaveDrop from '../../../../../../../components/user/proxy/proxy/create-action/config/ProxyCreateActionConfigRateWaveDrop';
+import { ApiProfileProxyActionType } from '../../../../../../../generated/models/ApiProfileProxyActionType';
+
+describe('ProxyCreateActionConfigRateWaveDrop', () => {
+  it('submits rate wave drop action', async () => {
+    const onSubmit = jest.fn();
+    render(
+      <ProxyCreateActionConfigRateWaveDrop endTime={42} onSubmit={onSubmit} onCancel={() => {}} />
+    );
+    await userEvent.click(screen.getByRole('button', { name: /save/i }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      action_type: ApiProfileProxyActionType.RateWaveDrop,
+      end_time: 42,
+    });
+  });
+
+  it('handles cancel click', async () => {
+    const onCancel = jest.fn();
+    render(
+      <ProxyCreateActionConfigRateWaveDrop endTime={null} onSubmit={() => {}} onCancel={onCancel} />
+    );
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/user/proxy/proxy/create-action/select-type/ProxyCreateActionSelectTypeItem.test.tsx
+++ b/__tests__/components/user/proxy/proxy/create-action/select-type/ProxyCreateActionSelectTypeItem.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import ProxyCreateActionSelectTypeItem from '../../../../../../../components/user/proxy/proxy/create-action/select-type/ProxyCreateActionSelectTypeItem';
+import { ApiProfileProxyActionType } from '../../../../../../../generated/models/ApiProfileProxyActionType';
+import { PROFILE_PROXY_ACTION_LABELS } from '../../../../../../../entities/IProxy';
+
+describe('ProxyCreateActionSelectTypeItem', () => {
+  it('shows label and triggers selection', async () => {
+    const setSelectedActionType = jest.fn();
+    const actionType = ApiProfileProxyActionType.RateWaveDrop;
+    render(
+      <ProxyCreateActionSelectTypeItem
+        actionType={actionType}
+        setSelectedActionType={setSelectedActionType}
+      />
+    );
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent(PROFILE_PROXY_ACTION_LABELS[actionType]);
+    await userEvent.click(button);
+    expect(setSelectedActionType).toHaveBeenCalledWith(actionType);
+  });
+});

--- a/__tests__/components/user/settings/UserSettingsClassification.test.tsx
+++ b/__tests__/components/user/settings/UserSettingsClassification.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import UserSettingsClassification from '../../../../components/user/settings/UserSettingsClassification';
+import { ApiProfileClassification } from '../../../../generated/models/ApiProfileClassification';
+import { CLASSIFICATIONS } from '../../../../entities/IProfile';
+
+describe('UserSettingsClassification', () => {
+  it('opens menu and selects new classification', async () => {
+    const onSelect = jest.fn();
+    render(
+      <UserSettingsClassification
+        selected={ApiProfileClassification.Ai}
+        onSelect={onSelect}
+      />
+    );
+    const toggle = screen.getByRole('button');
+    expect(toggle).toHaveTextContent(CLASSIFICATIONS[ApiProfileClassification.Ai].title);
+    await userEvent.click(toggle);
+    const option = await screen.findByText(CLASSIFICATIONS[ApiProfileClassification.Pseudonym].title);
+    await userEvent.click(option);
+    expect(onSelect).toHaveBeenCalledWith(ApiProfileClassification.Pseudonym);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for ProxyCreateActionConfigRateWaveDrop component
- add unit tests for ProxyCreateActionSelectTypeItem component
- add tests for UserSettingsClassification dropdown behaviour
- test the AddStatementsSelect component interactions

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage`