### PR TITLE
Increase test coverage for user components

### DIFF
--- a/__tests__/components/user/collected/cards/UserPageCollectedCardsNoCards.test.tsx
+++ b/__tests__/components/user/collected/cards/UserPageCollectedCardsNoCards.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import UserPageCollectedCardsNoCards from '../../../../../components/user/collected/cards/UserPageCollectedCardsNoCards';
+import { CollectedCollectionType, CollectionSeized } from '../../../../../entities/IProfile';
+import { MEMES_SEASON } from '../../../../../enums';
+
+describe('UserPageCollectedCardsNoCards messages', () => {
+  function renderComponent(filters: any) {
+    return render(<UserPageCollectedCardsNoCards filters={filters} />);
+  }
+
+  it('shows generic message when seized filter active', () => {
+    renderComponent({ seized: CollectionSeized.SEIZED, collection: null, szn: null });
+    expect(screen.getByText('No cards to display')).toBeInTheDocument();
+  });
+
+  it('shows full setter when no collection selected', () => {
+    renderComponent({ seized: CollectionSeized.NOT_SEIZED, collection: null, szn: null });
+    expect(screen.getByText('Congratulations, full setter!')).toBeInTheDocument();
+  });
+
+  it('shows season specific message for memes season', () => {
+    renderComponent({ seized: CollectionSeized.NOT_SEIZED, collection: CollectedCollectionType.MEMES, szn: MEMES_SEASON.SZN4 });
+    expect(screen.getByText('Congratulations, SZN4 full setter!')).toBeInTheDocument();
+  });
+
+  it('shows gradient message', () => {
+    renderComponent({ seized: CollectionSeized.NOT_SEIZED, collection: CollectedCollectionType.GRADIENTS, szn: null });
+    expect(screen.getByText('Congratulations, Gradient full setter!')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/user/identity/statements/add/social-media/UserPageIdentityAddStatementsSocialMediaAccountItems.test.tsx
+++ b/__tests__/components/user/identity/statements/add/social-media/UserPageIdentityAddStatementsSocialMediaAccountItems.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SOCIAL_MEDIA_ACCOUNT_STATEMENT_TYPES, STATEMENT_TYPE } from '../../../../../../../helpers/Types';
+
+let buttonProps: any[] = [];
+
+jest.mock('../../../../../../../components/user/identity/statements/utils/UserPageIdentityAddStatementsTypeButton', () => (props: any) => {
+  buttonProps.push(props);
+  return <button data-testid={props.statementType} onClick={props.onClick} />;
+});
+
+const Component = require('../../../../../../../components/user/identity/statements/add/social-media/UserPageIdentityAddStatementsSocialMediaAccountItems').default;
+
+describe('UserPageIdentityAddStatementsSocialMediaAccountItems', () => {
+  beforeEach(() => { buttonProps = []; });
+
+  it('renders buttons and handles click', async () => {
+    const setType = jest.fn();
+    render(<Component activeType={STATEMENT_TYPE.X} setSocialType={setType} />);
+    expect(buttonProps).toHaveLength(SOCIAL_MEDIA_ACCOUNT_STATEMENT_TYPES.length);
+    await userEvent.click(screen.getByTestId(STATEMENT_TYPE.GITHUB));
+    expect(setType).toHaveBeenCalledWith(STATEMENT_TYPE.GITHUB);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for message logic in `UserPageCollectedCardsNoCards`
- add tests for `UserPageIdentityAddStatementsSocialMediaAccountItems`

## Testing
- `npx jest __tests__/components/user/collected/cards/UserPageCollectedCardsNoCards.test.tsx __tests__/components/user/identity/statements/add/social-media/UserPageIdentityAddStatementsSocialMediaAccountItems.test.tsx --coverage`
- `npm run lint`
- `npm run type-check`
- `npm run improve-coverage`