### PR TITLE
Increase coverage for user components

### DIFF
--- a/__tests__/components/user/settings/UserSettingsBackground.test.tsx
+++ b/__tests__/components/user/settings/UserSettingsBackground.test.tsx
@@ -1,0 +1,27 @@
+import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserSettingsBackground from '../../../../components/user/settings/UserSettingsBackground';
+
+describe('UserSettingsBackground', () => {
+  it('updates colors and handles icon clicks', async () => {
+    const setBgColor1 = jest.fn();
+    const setBgColor2 = jest.fn();
+    const { container } = render(
+      <UserSettingsBackground
+        bgColor1="#000000"
+        bgColor2="#ffffff"
+        setBgColor1={setBgColor1}
+        setBgColor2={setBgColor2}
+      />
+    );
+
+    const input1 = container.querySelector('input#bgColor1') as HTMLInputElement;
+    const input2 = container.querySelector('input#bgColor2') as HTMLInputElement;
+
+    fireEvent.change(input1, { target: { value: '#123456' } });
+    fireEvent.change(input2, { target: { value: '#654321' } });
+    expect(setBgColor1).toHaveBeenLastCalledWith('#123456');
+    expect(setBgColor2).toHaveBeenLastCalledWith('#654321');
+
+  });
+});

--- a/__tests__/components/user/settings/UserSettingsSave.test.tsx
+++ b/__tests__/components/user/settings/UserSettingsSave.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react';
+import UserSettingsSave from '../../../../components/user/settings/UserSettingsSave';
+
+describe('UserSettingsSave', () => {
+  it('disables button when loading or disabled', () => {
+    const { rerender, container } = render(
+      <UserSettingsSave loading={true} disabled={false} />
+    );
+    const button = container.querySelector('button') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+
+    rerender(<UserSettingsSave loading={false} disabled={true} />);
+    expect(button.disabled).toBe(true);
+
+    rerender(<UserSettingsSave loading={false} disabled={false} />);
+    expect(button.disabled).toBe(false);
+  });
+});

--- a/__tests__/components/user/settings/UserSettingsUsername.test.tsx
+++ b/__tests__/components/user/settings/UserSettingsUsername.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserSettingsUsername from '../../../../components/user/settings/UserSettingsUsername';
+
+jest.mock('react-use', () => {
+  const React = require('react');
+  return {
+    useDebounce: (fn: () => void, _delay: number, deps: any[]) => React.useEffect(fn, deps),
+  };
+});
+
+jest.mock('../../../../services/api/common-api', () => ({
+  commonApiFetch: jest.fn(),
+}));
+
+const { commonApiFetch } = require('../../../../services/api/common-api');
+
+describe('UserSettingsUsername', () => {
+  it('checks username availability on change', async () => {
+    (commonApiFetch as jest.Mock).mockResolvedValue({ available: true, message: 'ok' });
+    const setUserName = jest.fn();
+    const setIsAvailable = jest.fn();
+    const setIsLoading = jest.fn();
+    render(
+      <UserSettingsUsername
+        userName="alice"
+        originalUsername="bob"
+        setUserName={setUserName}
+        setIsAvailable={setIsAvailable}
+        setIsLoading={setIsLoading}
+      />
+    );
+
+    await userEvent.type(screen.getByRole('textbox'), '1');
+    expect(setUserName).toHaveBeenLastCalledWith('alice1');
+
+    await waitFor(() => expect(commonApiFetch).toHaveBeenCalled());
+    expect(setIsAvailable).toHaveBeenCalledWith(true);
+    expect(screen.getByText('ok')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/user/stats/activity/wallet/UserPageStatsActivityWallet.test.tsx
+++ b/__tests__/components/user/stats/activity/wallet/UserPageStatsActivityWallet.test.tsx
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react';
+import UserPageStatsActivityWallet from '../../../../../../components/user/stats/activity/wallet/UserPageStatsActivityWallet';
+import { UserPageStatsActivityWalletFilterType } from '../../../../../../components/user/stats/activity/wallet/UserPageStatsActivityWallet';
+
+const replace = jest.fn();
+
+jest.mock('next/router', () => ({ useRouter: () => ({ replace }) }));
+
+const searchParams = new Map<string, string | null>();
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/path',
+  useSearchParams: () => ({ get: (key: string) => searchParams.get(key) }),
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ isFetching: false, isLoading: false, data: { count: 0, data: [] } }),
+  keepPreviousData: jest.fn(),
+}));
+
+jest.mock('../../../../../../components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper', () => (props: any) => {
+  props.onActiveFilter(UserPageStatsActivityWalletFilterType.MINTS);
+  return <div data-testid="wrapper">{JSON.stringify(props)}</div>;
+});
+
+jest.mock('../../../../../../services/api/common-api', () => ({
+  commonApiFetch: jest.fn(),
+}));
+
+describe('UserPageStatsActivityWallet', () => {
+  it('uses query params and navigates on filter change', () => {
+    searchParams.set('wallet_activity_filter', 'airdrops');
+    render(<UserPageStatsActivityWallet profile={{ wallets: [] } as any} activeAddress={null} />);
+    expect(replace).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/user/subscriptions/UserPageSubscriptionsTopUp.test.tsx
+++ b/__tests__/components/user/subscriptions/UserPageSubscriptionsTopUp.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { parseEther } from 'viem';
+import UserPageSubscriptionsTopUp from '../../../../components/user/subscriptions/UserPageSubscriptionsTopUp';
+import { SUBSCRIPTIONS_CHAIN, SUBSCRIPTIONS_ADDRESS, MEMES_MINT_PRICE } from '../../../../constants';
+
+const sendTransaction = {
+  data: undefined,
+  sendTransaction: jest.fn(),
+  reset: jest.fn(),
+  isPending: false,
+  error: undefined,
+};
+const waitSendTransaction = {
+  isLoading: false,
+  isSuccess: false,
+};
+
+jest.mock('wagmi', () => ({
+  useSendTransaction: () => sendTransaction,
+  useWaitForTransactionReceipt: () => waitSendTransaction,
+}));
+
+jest.mock('../../../../helpers/meme_calendar.helpers', () => ({
+  numberOfCardsForCalendarEnd: () => ({ count: 0, year: 2024 }),
+  numberOfCardsForSeasonEnd: () => ({ count: 0, szn: 1 }),
+}));
+
+jest.mock('../../../../components/dotLoader/DotLoader', () => () => <span data-testid="loader" />);
+
+jest.mock('@tippyjs/react', () => ({ __esModule: true, default: (props: any) => <span>{props.children}</span> }));
+
+describe('UserPageSubscriptionsTopUp', () => {
+  it('sends transaction on card button click', async () => {
+    render(<UserPageSubscriptionsTopUp />);
+    await userEvent.click(screen.getByRole('button', { name: /Send top up for 1 Card/i }));
+    expect(sendTransaction.sendTransaction).toHaveBeenCalledWith({
+      chainId: SUBSCRIPTIONS_CHAIN.id,
+      to: SUBSCRIPTIONS_ADDRESS,
+      value: parseEther((MEMES_MINT_PRICE).toString()),
+    });
+  });
+
+  it('shows success message when transaction succeeded', () => {
+    sendTransaction.data = '0x123' as any;
+    waitSendTransaction.isSuccess = true;
+    const { container } = render(<UserPageSubscriptionsTopUp />);
+    expect(container.textContent).toContain('Top Up Successful!');
+  });
+});

--- a/__tests__/components/user/user-page-header/UserPageHeaderAbout.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeaderAbout.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserPageHeaderAbout from '../../../../components/user/user-page-header/about/UserPageHeaderAbout';
+import { ApiIdentity } from '../../../../generated/models/ApiIdentity';
+
+jest.mock('../../../../components/user/user-page-header/about/UserPageHeaderAboutStatement', () => (props: any) => (
+  <div data-testid="statement">{JSON.stringify(props)}</div>
+));
+
+jest.mock('../../../../components/user/user-page-header/about/UserPageHeaderAboutEdit', () => (props: any) => (
+  <div data-testid="edit" onClick={() => props.onClose()} />
+));
+
+const profile: ApiIdentity = { handle: 'alice' } as any;
+
+describe('UserPageHeaderAbout', () => {
+  it('toggles view on edit click', async () => {
+    render(<UserPageHeaderAbout profile={profile} statement={null} canEdit={true} />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(screen.getByTestId('edit')).toBeInTheDocument();
+  });
+
+  it('resets view when props change', () => {
+    const { rerender } = render(
+      <UserPageHeaderAbout profile={profile} statement={null} canEdit={true} />
+    );
+    rerender(
+      <UserPageHeaderAbout profile={{ handle: 'bob' } as any} statement={null} canEdit={true} />
+    );
+    expect(screen.getByTestId('statement')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/user/user-page-header/UserPageHeaderEditClassification.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeaderEditClassification.test.tsx
@@ -1,0 +1,43 @@
+import { render, act } from '@testing-library/react';
+import UserPageHeaderEditClassification from '../../../../components/user/user-page-header/name/classification/UserPageHeaderEditClassification';
+import { ApiIdentity } from '../../../../generated/models/ApiIdentity';
+import { ApiProfileClassification } from '../../../../generated/models/ApiProfileClassification';
+import { AuthContext } from '../../../../components/auth/Auth';
+import { ReactQueryWrapperContext } from '../../../../components/react-query-wrapper/ReactQueryWrapper';
+
+let capturedSaveProps: any;
+let capturedClassificationProps: any;
+
+jest.mock('../../../../components/user/settings/UserSettingsSave', () => (props: any) => {
+  capturedSaveProps = props;
+  return <button disabled={props.disabled}>save</button>;
+});
+
+jest.mock('../../../../components/user/settings/UserSettingsClassification', () => (props: any) => {
+  capturedClassificationProps = props;
+  return <div data-testid="classification" onClick={() => props.onSelect(ApiProfileClassification.Bot)} />;
+});
+
+jest.mock('@tanstack/react-query', () => ({
+  useMutation: () => ({ mutateAsync: jest.fn() }),
+}));
+
+const profile: ApiIdentity = { handle: 'alice', classification: ApiProfileClassification.Pseudonym } as any;
+
+describe('UserPageHeaderEditClassification', () => {
+  it('enables save button when classification changes', () => {
+    render(
+      <AuthContext.Provider value={{ setToast: jest.fn(), requestAuth: jest.fn() } as any}>
+        <ReactQueryWrapperContext.Provider value={{ onProfileEdit: jest.fn() } as any}>
+          <UserPageHeaderEditClassification profile={profile} onClose={jest.fn()} />
+        </ReactQueryWrapperContext.Provider>
+      </AuthContext.Provider>
+    );
+    expect(capturedSaveProps.disabled).toBe(true);
+
+    act(() => {
+      capturedClassificationProps.onSelect(ApiProfileClassification.Bot);
+    });
+    expect(capturedSaveProps.disabled).toBe(false);
+  });
+});

--- a/__tests__/components/user/user-page-header/UserPageHeaderPfp.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeaderPfp.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react';
+import UserPageHeaderPfp from '../../../../components/user/user-page-header/pfp/UserPageHeaderPfp';
+
+jest.mock('next/image', () => ({ __esModule: true, default: (props: any) => <img {...props} /> }));
+
+describe('UserPageHeaderPfp', () => {
+  it('renders image when profile has pfp', () => {
+    const { container } = render(
+      <UserPageHeaderPfp profile={{ pfp: 'url' } as any} defaultBanner1="#000" defaultBanner2="#fff" />
+    );
+    const img = container.querySelector('img');
+    expect(img).toBeInTheDocument();
+    expect(img?.getAttribute('src')).toContain('url');
+  });
+
+  it('renders placeholder when no pfp', () => {
+    const { container } = render(
+      <UserPageHeaderPfp profile={{} as any} defaultBanner1="#000" defaultBanner2="#fff" />
+    );
+    expect(container.querySelector('img')).toBeNull();
+  });
+});

--- a/__tests__/components/user/user-page-header/UserPageHeaderPfpWrapper.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeaderPfpWrapper.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserPageHeaderPfpWrapper from '../../../../components/user/user-page-header/pfp/UserPageHeaderPfpWrapper';
+
+jest.mock('../../../../components/utils/icons/PencilIcon', () => () => <span data-testid="pencil" />);
+jest.mock('../../../../components/user/user-page-header/pfp/UserPageHeaderEditPfp', () => (props: any) => (
+  <div data-testid="edit" onClick={props.onClose} />
+));
+
+jest.mock('../../../../components/utils/animation/CommonAnimationWrapper', () => ({ children }: any) => <div>{children}</div>);
+jest.mock('../../../../components/utils/animation/CommonAnimationOpacity', () => ({ children, onClicked }: any) => (
+  <div data-testid="opacity" onClick={onClicked}>{children}</div>
+));
+
+describe('UserPageHeaderPfpWrapper', () => {
+  it('opens and closes edit modal when button clicked', async () => {
+    render(
+      <UserPageHeaderPfpWrapper profile={{} as any} canEdit={true}>
+        <span data-testid="child" />
+      </UserPageHeaderPfpWrapper>
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+    expect(screen.getByTestId('edit')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('edit'));
+    expect(screen.queryByTestId('edit')).toBeNull();
+  });
+});

--- a/__tests__/components/user/user-page-header/UserPageHeaderProfileEnabledAt.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeaderProfileEnabledAt.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import UserPageHeaderProfileEnabledAt from '../../../../components/user/user-page-header/UserPageHeaderProfileEnabledAt';
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: jest.fn(),
+}));
+
+jest.mock('../../../../services/api/common-api', () => ({
+  commonApiFetch: jest.fn(),
+}));
+
+const { useQuery } = require('@tanstack/react-query');
+const { commonApiFetch } = require('../../../../services/api/common-api');
+
+describe('UserPageHeaderProfileEnabledAt', () => {
+  it('renders formatted date when data present', () => {
+    (useQuery as jest.Mock).mockImplementation(({ queryFn }) => {
+      (commonApiFetch as jest.Mock).mockResolvedValue({ data: [{ created_at: '2024-01-01T00:00:00Z' }] });
+      queryFn();
+      return { data: { data: [{ created_at: '2024-01-01T00:00:00Z' }] } };
+    });
+
+    render(<UserPageHeaderProfileEnabledAt handleOrWallet="alice" />);
+
+    expect(commonApiFetch).toHaveBeenCalled();
+    expect(screen.getByText('Profile Enabled: January 2024')).toBeInTheDocument();
+  });
+
+});


### PR DESCRIPTION
## Summary
- add tests covering user settings components
- add tests for user page header pieces and subscriptions top up
- add minimal wallet activity component test

## Testing
- `npx jest __tests__/components/user/settings/UserSettingsBackground.test.tsx --coverage --color`
- `npx jest __tests__/components/user/settings/UserSettingsSave.test.tsx __tests__/components/user/settings/UserSettingsUsername.test.tsx --coverage --color`
- `npx jest __tests__/components/user/user-page-header/UserPageHeaderProfileEnabledAt.test.tsx --coverage --color`
- `npx jest __tests__/components/user/user-page-header/UserPageHeaderAbout.test.tsx --coverage --color`
- `npx jest __tests__/components/user/user-page-header/UserPageHeaderEditClassification.test.tsx --coverage --color`
- `npx jest __tests__/components/user/user-page-header/UserPageHeaderPfp.test.tsx --coverage --color`
- `npx jest __tests__/components/user/user-page-header/UserPageHeaderPfpWrapper.test.tsx --coverage --color`
- `npx jest __tests__/components/user/subscriptions/UserPageSubscriptionsTopUp.test.tsx --coverage --color`
- `npx jest __tests__/components/user/stats/activity/wallet/UserPageStatsActivityWallet.test.tsx --coverage --color`
- `npm run lint`
- `npm run type-check`