### PR TITLE
Add unit tests for UI components

### DIFF
--- a/__tests__/components/user/brain/UserPageDrops.test.tsx
+++ b/__tests__/components/user/brain/UserPageDrops.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react';
+import UserPageDrops from '../../../../components/user/brain/UserPageDrops';
+
+jest.mock('../../../../components/drops/view/Drops', () => ({
+  __esModule: true,
+  default: () => <div data-testid="drops" />,
+}));
+
+describe('UserPageDrops', () => {
+  it('renders Drops when profile has handle', () => {
+    const { getByTestId } = render(<UserPageDrops profile={{ handle: 'test' } as any} />);
+    expect(getByTestId('drops')).toBeInTheDocument();
+  });
+
+  it('hides Drops when no profile handle', () => {
+    const { queryByTestId } = render(<UserPageDrops profile={null} />);
+    expect(queryByTestId('drops')).toBeNull();
+  });
+});

--- a/__tests__/components/user/identity/header/UserPageIdentityHeaderCIC.test.tsx
+++ b/__tests__/components/user/identity/header/UserPageIdentityHeaderCIC.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import UserPageIdentityHeaderCIC from '../../../../../components/user/identity/header/UserPageIdentityHeaderCIC';
+import { ApiIdentity } from '../../../../../generated/models/ApiIdentity';
+
+jest.mock('../../../../../components/user/utils/user-cic-type/UserCICTypeIconWrapper', () => ({
+  __esModule: true,
+  default: () => <div data-testid="icon" />,
+}));
+
+jest.mock('../../../../../components/user/utils/user-cic-status/UserCICStatus', () => ({
+  __esModule: true,
+  default: ({ cic }: { cic: number }) => <div data-testid="status">{cic}</div>,
+}));
+
+describe('UserPageIdentityHeaderCIC', () => {
+  const baseProfile: ApiIdentity = { cic: 1000 } as ApiIdentity;
+
+  it('displays NIC and status info', () => {
+    render(<UserPageIdentityHeaderCIC profile={baseProfile} />);
+    expect(screen.getByText('NIC:')).toBeInTheDocument();
+    expect(screen.getByText('1,000')).toBeInTheDocument();
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+    expect(screen.getByTestId('status')).toHaveTextContent('1000');
+  });
+
+  it('updates when profile prop changes', () => {
+    const { rerender } = render(<UserPageIdentityHeaderCIC profile={baseProfile} />);
+    rerender(<UserPageIdentityHeaderCIC profile={{ cic: 2000 } as ApiIdentity} />);
+    expect(screen.getByText('2,000')).toBeInTheDocument();
+    expect(screen.getByTestId('status')).toHaveTextContent('2000');
+  });
+});

--- a/__tests__/components/user/identity/statements/utils/UserPageIdentityAddStatementsTypeButton.test.tsx
+++ b/__tests__/components/user/identity/statements/utils/UserPageIdentityAddStatementsTypeButton.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserPageIdentityAddStatementsTypeButton from '../../../../../../components/user/identity/statements/utils/UserPageIdentityAddStatementsTypeButton';
+import { STATEMENT_TYPE } from '../../../../../../helpers/Types';
+
+jest.mock('../../../../../../components/user/utils/icons/SocialStatementIcon', () => ({
+  __esModule: true,
+  default: () => <div data-testid="icon" />,
+}));
+
+describe('UserPageIdentityAddStatementsTypeButton', () => {
+  it('applies correct classes based on props and handles click', async () => {
+    const onClick = jest.fn();
+    const { rerender, getByRole } = render(
+      <UserPageIdentityAddStatementsTypeButton
+        statementType={STATEMENT_TYPE.X}
+        isActive={false}
+        isFirst={true}
+        isLast={false}
+        onClick={onClick}
+      />
+    );
+    const button = getByRole('button');
+    expect(button.className).toContain('tw-bg-transparent');
+    expect(button.className).toContain('tw-rounded-l-md');
+    await userEvent.click(button);
+    expect(onClick).toHaveBeenCalled();
+
+    rerender(
+      <UserPageIdentityAddStatementsTypeButton
+        statementType={STATEMENT_TYPE.X}
+        isActive={true}
+        isFirst={false}
+        isLast={true}
+        onClick={onClick}
+      />
+    );
+    expect(button.className).toContain('tw-bg-iron-800');
+    expect(button.className).toContain('tw-rounded-r-md');
+  });
+});

--- a/__tests__/components/user/proxy/proxy/create-action/config/ProxyCreateActionConfigCreateDropToWave.test.tsx
+++ b/__tests__/components/user/proxy/proxy/create-action/config/ProxyCreateActionConfigCreateDropToWave.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ProxyCreateActionConfigCreateDropToWave from '../../../../../../../components/user/proxy/proxy/create-action/config/ProxyCreateActionConfigCreateDropToWave';
+import { ApiProfileProxyActionType } from '../../../../../../../generated/models/ApiProfileProxyActionType';
+
+describe('ProxyCreateActionConfigCreateDropToWave', () => {
+  it('calls callbacks on buttons', async () => {
+    const onSubmit = jest.fn();
+    const onCancel = jest.fn();
+    render(
+      <ProxyCreateActionConfigCreateDropToWave endTime={123} onSubmit={onSubmit} onCancel={onCancel} />
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalled();
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      action_type: ApiProfileProxyActionType.CreateDropToWave,
+      end_time: 123,
+    });
+  });
+});

--- a/__tests__/components/user/rep/header/UserPageRepHeader.test.tsx
+++ b/__tests__/components/user/rep/header/UserPageRepHeader.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import UserPageRepHeader from '../../../../../components/user/rep/header/UserPageRepHeader';
+
+describe('UserPageRepHeader', () => {
+  it('shows rep totals when provided', () => {
+    const repRates = {
+      total_rep_rating: 1500,
+      number_of_raters: 25,
+    } as any;
+    render(<UserPageRepHeader repRates={repRates} />);
+    expect(screen.getByText('1,500')).toBeInTheDocument();
+    expect(screen.getByText('25')).toBeInTheDocument();
+  });
+
+  it('renders empty values without repRates', () => {
+    const { container } = render(<UserPageRepHeader repRates={null} />);
+    expect(container).toHaveTextContent('Rep:');
+  });
+});

--- a/__tests__/components/user/rep/new-rep/UserPageRepNewRep.test.tsx
+++ b/__tests__/components/user/rep/new-rep/UserPageRepNewRep.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserPageRepNewRep from '../../../../../components/user/rep/new-rep/UserPageRepNewRep';
+import { ApiIdentity } from '../../../../../generated/models/ApiIdentity';
+
+jest.mock('../../../../../components/user/rep/new-rep/UserPageRepNewRepSearch', () => ({
+  __esModule: true,
+  default: ({ onRepSearch }: { onRepSearch: (v: string) => void }) => (
+    <button onClick={() => onRepSearch('Art')}>search</button>
+  ),
+}));
+
+jest.mock('../../../../../components/user/rep/modify-rep/UserPageRepModifyModal', () => ({
+  __esModule: true,
+  default: () => <div data-testid="modal" />,
+}));
+
+describe('UserPageRepNewRep', () => {
+  const profile = { id: '1' } as ApiIdentity;
+  const repRates = { rating_stats: [] } as any;
+
+  it('opens modal when search selects rep', async () => {
+    render(<UserPageRepNewRep profile={profile} repRates={repRates} />);
+    await userEvent.click(screen.getByRole('button', { name: 'search' }));
+    expect(screen.getByTestId('modal')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/user/settings/UserSettingsImgSelectMeme.test.tsx
+++ b/__tests__/components/user/settings/UserSettingsImgSelectMeme.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserSettingsImgSelectMeme, { MemeLite } from '../../../../components/user/settings/UserSettingsImgSelectMeme';
+
+describe('UserSettingsImgSelectMeme', () => {
+  const memes: MemeLite[] = [
+    { id: 1, name: 'First', animation: null, contract: '', icon: null, image: null, scaled: null, thumbnail: null, artist: null },
+    { id: 2, name: 'Second', animation: null, contract: '', icon: null, image: null, scaled: null, thumbnail: null, artist: null },
+  ];
+
+  it('filters memes and selects one', async () => {
+    const onMeme = jest.fn();
+    render(<UserSettingsImgSelectMeme memes={memes} onMeme={onMeme} />);
+    const input = screen.getByPlaceholderText('Search');
+    await userEvent.click(input);
+    await userEvent.type(input, 'Second');
+    const option = await screen.findByText('#2 Second');
+    await userEvent.click(option);
+    expect(onMeme).toHaveBeenCalledWith(memes[1]);
+  });
+});

--- a/__tests__/components/user/stats/UserPageStatsBoostBreakdown.test.tsx
+++ b/__tests__/components/user/stats/UserPageStatsBoostBreakdown.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import UserPageStatsBoostBreakdown from '../../../../components/user/stats/UserPageStatsBoostBreakdown';
+import { ConsolidatedTDH } from '../../../../entities/ITDH';
+
+jest.mock('@fortawesome/react-fontawesome', () => ({ FontAwesomeIcon: () => <svg data-testid="icon" /> }));
+jest.mock('@tippyjs/react', () => ({ __esModule: true, default: ({ children }: any) => <span>{children}</span> }));
+
+describe('UserPageStatsBoostBreakdown', () => {
+  it('renders nothing when boost breakdown missing', () => {
+    const { container } = render(<UserPageStatsBoostBreakdown tdh={undefined} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows table when data provided', () => {
+    const tdh: ConsolidatedTDH = {
+      boost: 2,
+      boost_breakdown: {
+        memes_card_sets: { available: 1, acquired: 1, available_info: [], acquired_info: [] },
+        gradients: { available: 1, acquired: 1, available_info: [], acquired_info: [] },
+      },
+    } as any;
+    render(<UserPageStatsBoostBreakdown tdh={tdh} />);
+    expect(screen.getByText('Boost Breakdown')).toBeInTheDocument();
+    expect(screen.getByText('TOTAL BOOST')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/utils/Spinner.test.tsx
+++ b/__tests__/components/utils/Spinner.test.tsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react';
+import Spinner from '../../../components/utils/Spinner';
+
+describe('Spinner', () => {
+  it('renders svg with expected class', () => {
+    const { container } = render(<Spinner />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('class', expect.stringContaining('tw-animate-spin'));
+  });
+});

--- a/__tests__/components/utils/button/InfoButton.test.tsx
+++ b/__tests__/components/utils/button/InfoButton.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import InfoButton from '../../../../components/utils/button/InfoButton';
+
+jest.mock('../../../../components/distribution-plan-tool/common/CircleLoader', () => ({
+  __esModule: true,
+  default: () => <div data-testid="loader" />,
+}));
+
+describe('InfoButton', () => {
+  it('renders children and fires click handler', async () => {
+    const onClick = jest.fn();
+    render(<InfoButton onClicked={onClick}>Text</InfoButton>);
+    await userEvent.click(screen.getByRole('button', { name: 'Text' }));
+    expect(onClick).toHaveBeenCalled();
+    expect(screen.getByText('Text')).toBeInTheDocument();
+  });
+
+  it('shows loader and disables when loading', () => {
+    render(<InfoButton loading>Text</InfoButton>);
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+});

--- a/__tests__/components/utils/icons/RateClapOutlineIcon.test.tsx
+++ b/__tests__/components/utils/icons/RateClapOutlineIcon.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import RateClapOutlineIcon from '../../../../components/utils/icons/RateClapOutlineIcon';
+
+describe('RateClapOutlineIcon', () => {
+  it('renders svg element', () => {
+    const { container } = render(<RateClapOutlineIcon />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('viewBox', '0 0 350 364');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `UserPageDrops`
- add tests for CIC header and statement type button components
- cover proxy drop creation, rep header and new rep flows
- test user settings meme selector and stats breakdown
- add utility component tests for spinner, info button and icons

## Testing
- `npx jest __tests__/components/user/brain/UserPageDrops.test.tsx --coverage --runInBand`
- `npx jest __tests__/components/user/identity/header/UserPageIdentityHeaderCIC.test.tsx --coverage --runInBand`
- `npx jest __tests__/components/user/identity/statements/utils/UserPageIdentityAddStatementsTypeButton.test.tsx --coverage --runInBand`
- `npx jest __tests__/components/user/proxy/proxy/create-action/config/ProxyCreateActionConfigCreateDropToWave.test.tsx --coverage --runInBand`
- `npx jest __tests__/components/user/rep/header/UserPageRepHeader.test.tsx --coverage --runInBand`
- `npx jest __tests__/components/user/rep/new-rep/UserPageRepNewRep.test.tsx --coverage --runInBand`
- `npx jest __tests__/components/user/settings/UserSettingsImgSelectMeme.test.tsx --coverage --runInBand`
- `npx jest __tests__/components/user/stats/UserPageStatsBoostBreakdown.test.tsx --coverage --runInBand`
- `npx jest __tests__/components/utils/button/InfoButton.test.tsx --coverage --runInBand`
- `npx jest __tests__/components/utils/Spinner.test.tsx --coverage --runInBand`
- `npx jest __tests__/components/utils/icons/RateClapOutlineIcon.test.tsx --coverage --runInBand`
- `npm run improve-coverage`