### PR TITLE
Improve test coverage

### DIFF
--- a/__mocks__/focus-trap-react.js
+++ b/__mocks__/focus-trap-react.js
@@ -1,0 +1,3 @@
+const FocusTrap = ({ children }) => <div>{children}</div>;
+export { FocusTrap };
+export default FocusTrap;

--- a/__tests__/components/NextGenAbout.test.tsx
+++ b/__tests__/components/NextGenAbout.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import NextGenAbout from '../../components/nextGen/collections/NextGenAbout';
+
+describe('NextGenAbout', () => {
+  it('renders heading and paragraph content', () => {
+    render(<NextGenAbout />);
+    expect(screen.getByRole('heading', { name: /about nextgen/i })).toBeInTheDocument();
+    expect(screen.getByText(/generative art NFT contract/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/TermsSignatureFlow.test.tsx
+++ b/__tests__/components/TermsSignatureFlow.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TermsSignatureFlow from '../../components/terms/TermsSignatureFlow';
+
+const mockSignDrop = jest.fn(async () => ({ success: true, signature: 'sig' }));
+
+jest.mock('../../hooks/drops/useDropSignature', () => ({
+  useDropSignature: () => ({ signDrop: mockSignDrop, isLoading: false })
+}));
+
+describe('TermsSignatureFlow', () => {
+  beforeEach(() => {
+    mockSignDrop.mockClear();
+  });
+
+  it('opens modal on event and resolves signature', async () => {
+    const onComplete = jest.fn();
+    render(<TermsSignatureFlow />);
+
+    await waitFor(() => {}); // allow effect to attach listener
+
+    const event = new CustomEvent('showTermsModal', {
+      detail: { drop: { id: 1 }, termsOfService: 'My Terms', onComplete }
+    });
+    await act(async () => {
+      document.dispatchEvent(event);
+    });
+
+    expect(await screen.findByText('Terms of Service')).toBeInTheDocument();
+
+    const checkbox = screen.getByRole('checkbox');
+    await userEvent.click(checkbox);
+    const button = screen.getByRole('button', { name: /agree & continue/i });
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalledWith({ success: true, signature: 'sig' });
+    });
+  });
+
+  it('calls failure callback when rejected', async () => {
+    const onComplete = jest.fn();
+    render(<TermsSignatureFlow />);
+
+    await waitFor(() => {});
+
+    const event = new CustomEvent('showTermsModal', {
+      detail: { drop: { id: 2 }, termsOfService: 'My Terms', onComplete }
+    });
+    await act(async () => {
+      document.dispatchEvent(event);
+    });
+
+    expect(await screen.findByText('Terms of Service')).toBeInTheDocument();
+    const close = screen.getByLabelText('Close modal');
+    await userEvent.click(close);
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalledWith({ success: false });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add mock for focus-trap-react to simplify modal tests
- test TermsSignatureFlow component
- test static NextGenAbout component

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
