### PR TITLE
Add tests for BackButton and MemePageCollectors

### DIFF
--- a/__tests__/components/navigation/BackButton.test.tsx
+++ b/__tests__/components/navigation/BackButton.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import BackButton from "../../../components/navigation/BackButton";
+
+jest.mock("../../../contexts/NavigationHistoryContext", () => ({
+  useNavigationHistoryContext: jest.fn(),
+}));
+jest.mock("../../../components/navigation/ViewContext", () => ({
+  useViewContext: jest.fn(),
+}));
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
+}));
+jest.mock("../../../hooks/useWaveData", () => ({
+  useWaveData: jest.fn(),
+}));
+jest.mock("../../../hooks/useWave", () => ({
+  useWave: jest.fn(),
+}));
+jest.mock("../../../components/utils/Spinner", () => ({
+  __esModule: true,
+  default: () => <div data-testid="spinner" />,
+}));
+
+const {
+  useNavigationHistoryContext,
+} = require("../../../contexts/NavigationHistoryContext");
+const { useViewContext } = require("../../../components/navigation/ViewContext");
+const { useRouter } = require("next/router");
+const { useWaveData } = require("../../../hooks/useWaveData");
+const { useWave } = require("../../../hooks/useWave");
+
+function setup(query: any = {}, opts: any = {}) {
+  const replace = jest.fn();
+  const router = {
+    query,
+    pathname: "/test",
+    events: { on: jest.fn(), off: jest.fn() },
+    replace,
+  } as any;
+  (useRouter as jest.Mock).mockReturnValue(router);
+  (useNavigationHistoryContext as jest.Mock).mockReturnValue({
+    canGoBack: opts.canGoBack ?? false,
+    goBack: jest.fn(),
+  });
+  (useViewContext as jest.Mock).mockReturnValue({ hardBack: jest.fn() });
+  (useWaveData as jest.Mock).mockReturnValue({ data: opts.wave });
+  (useWave as jest.Mock).mockReturnValue({ isDm: opts.isDm ?? false });
+  const utils = render(<BackButton />);
+  return { ...utils, router };
+}
+
+
+describe("BackButton", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("removes drop param and replaces route", async () => {
+    const { router } = setup({ drop: "123" });
+    await userEvent.click(screen.getByRole("button", { name: "Back" }));
+    expect(router.replace).toHaveBeenCalledWith(
+      { pathname: "/test", query: {} },
+      undefined,
+      { shallow: true }
+    );
+    expect(screen.getByTestId("spinner")).toBeInTheDocument();
+  });
+
+  it("navigates hard back to messages when wave is DM", async () => {
+    const { router } = setup({ wave: "w1" }, { wave: {}, isDm: true });
+    const hardBack = (useViewContext as jest.Mock).mock.results[0].value.hardBack;
+    await userEvent.click(screen.getByRole("button", { name: "Back" }));
+    expect(hardBack).toHaveBeenCalledWith("messages");
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it("navigates hard back to waves when wave is not DM", async () => {
+    const { router } = setup({ wave: "w1" }, { wave: {}, isDm: false });
+    const hardBack = (useViewContext as jest.Mock).mock.results[0].value.hardBack;
+    await userEvent.click(screen.getByRole("button", { name: "Back" }));
+    expect(hardBack).toHaveBeenCalledWith("waves");
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it("calls goBack when no params and canGoBack", async () => {
+    setup({}, { canGoBack: true });
+    const { goBack } = (useNavigationHistoryContext as jest.Mock).mock.results[0].value;
+    await userEvent.click(screen.getByRole("button", { name: "Back" }));
+    expect(goBack).toHaveBeenCalled();
+  });
+});
+

--- a/__tests__/components/the-memes/MemePageCollectors.test.tsx
+++ b/__tests__/components/the-memes/MemePageCollectors.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import {
+  MemePageCollectorsRightMenu,
+  MemePageCollectorsSubMenu,
+} from "../../../components/the-memes/MemePageCollectors";
+
+jest.mock("../../../helpers/Helpers", () => ({
+  numberWithCommas: jest.fn((n) => n.toString()),
+  printMintDate: jest.fn(() => "date"),
+}));
+
+let leaderboardProps: any;
+jest.mock("../../../components/leaderboard/NFTLeaderboard", () => (props: any) => {
+  leaderboardProps = props;
+  return <div data-testid="leaderboard" />;
+});
+
+jest.mock("../../../components/nftAttributes/NftStats", () => ({
+  NftPageStats: () => <tr data-testid="stats" />,
+}));
+
+const nft = {
+  id: 1,
+  contract: "0x123",
+  mint_date: "2020-01-01" as any,
+  boosted_tdh: 1.23,
+  tdh__raw: 4.56,
+  tdh_rank: 7,
+} as any;
+
+
+describe("MemePageCollectorsRightMenu", () => {
+  it("renders NFT details when shown", () => {
+    render(<MemePageCollectorsRightMenu show nft={nft} />);
+    expect(screen.getByText("NFT")).toBeInTheDocument();
+    expect(screen.getAllByText("TDH").length).toBeGreaterThan(0);
+    expect(screen.getByTestId("stats")).toBeInTheDocument();
+  });
+
+  it("returns null when not shown", () => {
+    const { container } = render(<MemePageCollectorsRightMenu show={false} nft={nft} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("MemePageCollectorsSubMenu", () => {
+  it("passes contract and id to leaderboard", () => {
+    render(<MemePageCollectorsSubMenu show nft={nft} />);
+    expect(screen.getByTestId("leaderboard")).toBeInTheDocument();
+    expect(leaderboardProps.contract).toBe("0x123");
+    expect(leaderboardProps.nftId).toBe(1);
+  });
+
+  it("returns null when nft missing", () => {
+    const { container } = render(<MemePageCollectorsSubMenu show nft={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for BackButton component
- add unit tests for MemePageCollectors helpers

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
