### PR TITLE
Add tests for user page wrapper components

### DIFF
--- a/__tests__/components/user/groups/UserPageGroupsWrapper.test.tsx
+++ b/__tests__/components/user/groups/UserPageGroupsWrapper.test.tsx
@@ -1,0 +1,53 @@
+import { render } from '@testing-library/react';
+import UserPageGroupsWrapper from '../../../../components/user/groups/UserPageGroupsWrapper';
+import { useRouter } from 'next/router';
+import { useIdentity } from '../../../../hooks/useIdentity';
+
+let capturedWrapperProfile: any = null;
+let capturedGroupsProfile: any = null;
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../../../hooks/useIdentity', () => ({ useIdentity: jest.fn() }));
+
+jest.mock('../../../../components/user/utils/set-up-profile/UserPageSetUpProfileWrapper', () =>
+  function MockWrapper({ profile, children }: any) {
+    capturedWrapperProfile = profile;
+    return <div data-testid="wrapper">{children}</div>;
+  }
+);
+
+jest.mock('../../../../components/user/groups/UserPageGroups', () =>
+  function MockGroups(props: any) {
+    capturedGroupsProfile = props.profile;
+    return <div data-testid="groups" />;
+  }
+);
+
+describe('UserPageGroupsWrapper', () => {
+  const useRouterMock = useRouter as jest.Mock;
+  const useIdentityMock = useIdentity as jest.Mock;
+
+  beforeEach(() => {
+    capturedWrapperProfile = null;
+    capturedGroupsProfile = null;
+  });
+
+  it('passes profile from hook when available', () => {
+    useRouterMock.mockReturnValue({ query: { user: 'alice' } });
+    const profile = { handle: 'alice' };
+    useIdentityMock.mockReturnValue({ profile });
+    render(<UserPageGroupsWrapper profile={profile} />);
+    expect(useIdentityMock).toHaveBeenCalledWith({ handleOrWallet: 'alice', initialProfile: profile });
+    expect(capturedWrapperProfile).toBe(profile);
+    expect(capturedGroupsProfile).toBe(profile);
+  });
+
+  it('falls back to initial profile when hook returns null', () => {
+    useRouterMock.mockReturnValue({ query: { user: 'bob' } });
+    const initialProfile = { handle: 'bob' };
+    useIdentityMock.mockReturnValue({ profile: null });
+    render(<UserPageGroupsWrapper profile={initialProfile} />);
+    expect(capturedWrapperProfile).toBe(initialProfile);
+    expect(capturedGroupsProfile).toBeNull();
+  });
+});

--- a/__tests__/components/user/proxy/list/filters/ProxyListFilters.test.tsx
+++ b/__tests__/components/user/proxy/list/filters/ProxyListFilters.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ProxyListFilters from '../../../../../../components/user/proxy/list/filters/ProxyListFilters';
+import { ProfileProxyListType } from '../../../../../../components/user/proxy/list/ProxyList';
+
+jest.mock('../../../../../../components/utils/select/CommonSelect', () => ({
+  __esModule: true,
+  default: ({ items, activeItem, setSelected }: any) => (
+    <div data-testid="select">
+      {items.map((i: any) => (
+        <button key={i.key} onClick={() => setSelected(i.value)}>
+          {i.label}
+        </button>
+      ))}
+      <span data-testid="active">{activeItem}</span>
+    </div>
+  ),
+}));
+
+describe('ProxyListFilters', () => {
+  it('renders options and handles selection', async () => {
+    const setSelected = jest.fn();
+    render(
+      <ProxyListFilters
+        selected={ProfileProxyListType.ALL}
+        setSelected={setSelected}
+      />
+    );
+    const buttons = screen.getAllByRole('button');
+    expect(buttons.map((b) => b.textContent)).toEqual(['All', 'Received', 'Granted']);
+    await userEvent.click(screen.getByText('Granted'));
+    expect(setSelected).toHaveBeenCalledWith(ProfileProxyListType.GRANTED);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for ProxyListFilters component
- add tests for UserPageGroupsWrapper

## Testing
- `npx jest __tests__/components/user/proxy/list/filters/ProxyListFilters.test.tsx --coverage --coverageReporters=text-summary --runTestsByPath`
- `npx jest __tests__/components/user/groups/UserPageGroupsWrapper.test.tsx --coverage --coverageReporters=text-summary --runTestsByPath`
- `npm run improve-coverage`