### PR TITLE
Add tests for user components

### DIFF
--- a/__tests__/components/user/brain/UserPageBrainWrapper.test.tsx
+++ b/__tests__/components/user/brain/UserPageBrainWrapper.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import UserPageBrainWrapper from '../../../../components/user/brain/UserPageBrainWrapper';
+import { useRouter } from 'next/router';
+import { AuthContext } from '../../../../components/auth/Auth';
+import { useSeizeConnectContext } from '../../../../components/auth/SeizeConnectContext';
+import { useIdentity } from '../../../../hooks/useIdentity';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../../../components/auth/SeizeConnectContext', () => ({ useSeizeConnectContext: jest.fn() }));
+jest.mock('../../../../components/auth/Auth', () => ({ AuthContext: React.createContext({}), }));
+jest.mock('../../../../hooks/useIdentity', () => ({ useIdentity: jest.fn() }));
+jest.mock('../../../../components/user/brain/UserPageDrops', () => (props: any) => <div data-testid="drops" {...props} />);
+
+const routerPush = jest.fn();
+(useRouter as jest.Mock).mockReturnValue({ query: { user: 'alice' }, push: routerPush });
+
+function renderWithContext(ctx: any) {
+  (useSeizeConnectContext as jest.Mock).mockReturnValue({ address: ctx.address });
+  const AuthCtx = require('../../../../components/auth/Auth').AuthContext;
+  (useIdentity as jest.Mock).mockReturnValue({ profile: ctx.identity });
+  return render(
+    <AuthCtx.Provider value={ctx.auth as any}>
+      <UserPageBrainWrapper profile={ctx.identity} />
+    </AuthCtx.Provider>
+  );
+}
+
+describe('UserPageBrainWrapper', () => {
+  beforeEach(() => {
+    routerPush.mockClear();
+  });
+  it('redirects to rep when waves disabled', () => {
+    renderWithContext({ address: undefined, auth: { connectedProfile: null, activeProfileProxy: null, showWaves: false }, identity: { id: '1' } });
+    expect(routerPush).toHaveBeenCalledWith('/alice/rep');
+  });
+
+  it('shows drops when waves enabled', () => {
+    const { getByTestId } = renderWithContext({ address: '0x1', auth: { connectedProfile: null, activeProfileProxy: null, showWaves: true }, identity: { id: '1' } });
+    expect(getByTestId('drops')).toBeInTheDocument();
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/user/identity/statements/add/UserPageIdentityStatementsAddButton.test.tsx
+++ b/__tests__/components/user/identity/statements/add/UserPageIdentityStatementsAddButton.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import UserPageIdentityStatementsAddButton from '../../../../../../components/user/identity/statements/add/UserPageIdentityStatementsAddButton';
+
+let modalProps: any;
+
+jest.mock('../../../../../../components/utils/animation/CommonAnimationWrapper', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock('../../../../../../components/utils/animation/CommonAnimationOpacity', () => ({
+  __esModule: true,
+  default: ({ children, elementRole, elementClasses, ...rest }: any) => (
+    <div role={elementRole} className={elementClasses} {...rest}>{children}</div>
+  ),
+}));
+
+jest.mock('../../../../../../components/user/identity/statements/add/UserPageIdentityAddStatements', () => (props: any) => {
+  modalProps = props;
+  return <div data-testid="modal-content" />;
+});
+
+jest.mock('../../../../../../components/utils/button/PrimaryButton', () => (props: any) => (
+  <button onClick={props.onClicked}>{props.children}</button>
+));
+
+const profile = { id: '1' } as any;
+
+describe('UserPageIdentityStatementsAddButton', () => {
+  it('opens and closes the add statements modal', async () => {
+    render(<UserPageIdentityStatementsAddButton profile={profile} />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+
+    await userEvent.click(screen.getByRole('button', { name: /add/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(modalProps.profile).toBe(profile);
+
+    await act(async () => {
+      modalProps.onClose();
+    });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});

--- a/__tests__/components/user/identity/statements/add/contact/UserPageIdentityAddStatementsContact.test.tsx
+++ b/__tests__/components/user/identity/statements/add/contact/UserPageIdentityAddStatementsContact.test.tsx
@@ -1,0 +1,54 @@
+import { render } from '@testing-library/react';
+import { act } from '@testing-library/react';
+import React from 'react';
+import UserPageIdentityAddStatementsContact from '../../../../../../../components/user/identity/statements/add/contact/UserPageIdentityAddStatementsContact';
+import { STATEMENT_TYPE, STATEMENT_GROUP } from '../../../../../../../helpers/Types';
+
+let headerProps: any;
+let itemsProps: any;
+let formProps: any;
+
+jest.mock('../../../../../../../components/user/identity/statements/add/contact/UserPageIdentityAddStatementsContactHeader', () => (props: any) => {
+  headerProps = props;
+  return <div data-testid="header" />;
+});
+
+jest.mock('../../../../../../../components/user/identity/statements/add/contact/UserPageIdentityAddStatementsContactItems', () => (props: any) => {
+  itemsProps = props;
+  return <div data-testid="items" />;
+});
+
+jest.mock('../../../../../../../components/user/identity/statements/utils/UserPageIdentityAddStatementsForm', () => (props: any) => {
+  formProps = props;
+  return <div data-testid="form" />;
+});
+
+describe('UserPageIdentityAddStatementsContact', () => {
+  const profile = { id: 'p1' } as any;
+  const onClose = jest.fn();
+
+  beforeEach(() => {
+    headerProps = undefined;
+    itemsProps = undefined;
+    formProps = undefined;
+  });
+
+  it('passes props and updates active type', () => {
+    render(<UserPageIdentityAddStatementsContact profile={profile} onClose={onClose} />);
+
+    expect(headerProps.onClose).toBe(onClose);
+    expect(itemsProps.activeType).toBe(STATEMENT_TYPE.DISCORD);
+    expect(typeof itemsProps.setContactType).toBe('function');
+
+    expect(formProps.group).toBe(STATEMENT_GROUP.CONTACT);
+    expect(formProps.activeType).toBe(STATEMENT_TYPE.DISCORD);
+    expect(formProps.profile).toBe(profile);
+
+    act(() => {
+      itemsProps.setContactType(STATEMENT_TYPE.TELEGRAM);
+    });
+
+    expect(itemsProps.activeType).toBe(STATEMENT_TYPE.TELEGRAM);
+    expect(formProps.activeType).toBe(STATEMENT_TYPE.TELEGRAM);
+  });
+});

--- a/__tests__/components/user/identity/statements/add/nft-accounts/UserPageIdentityAddStatementsNFTAccountHeader.test.tsx
+++ b/__tests__/components/user/identity/statements/add/nft-accounts/UserPageIdentityAddStatementsNFTAccountHeader.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import UserPageIdentityAddStatementsNFTAccountHeader from '../../../../../../../components/user/identity/statements/add/nft-accounts/UserPageIdentityAddStatementsNFTAccountHeader';
+
+describe('UserPageIdentityAddStatementsNFTAccountHeader', () => {
+  it('renders title and handles close', async () => {
+    const onClose = jest.fn();
+    render(<UserPageIdentityAddStatementsNFTAccountHeader onClose={onClose} />);
+    expect(screen.getByText('Add NFT Account')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/user/identity/statements/nft-accounts/UserPageIdentityStatementsNFTAccounts.test.tsx
+++ b/__tests__/components/user/identity/statements/nft-accounts/UserPageIdentityStatementsNFTAccounts.test.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import UserPageIdentityStatementsNFTAccounts from '../../../../../../components/user/identity/statements/nft-accounts/UserPageIdentityStatementsNFTAccounts';
+
+let listProps: any;
+
+jest.mock('../../../../../../components/user/identity/statements/utils/UserPageIdentityStatementsStatementsList', () => (props: any) => {
+  listProps = props;
+  return <ul data-testid="list" />;
+});
+
+describe('UserPageIdentityStatementsNFTAccounts', () => {
+  it('passes statements to list', () => {
+    const statements = [{ id: 's1' } as any];
+    const profile = { id: 'p1' } as any;
+    render(
+      <UserPageIdentityStatementsNFTAccounts
+        statements={statements}
+        profile={profile}
+        loading={false}
+      />
+    );
+    expect(listProps.statements).toBe(statements);
+    expect(listProps.profile).toBe(profile);
+    expect(listProps.noItemsMessage).toBe('No NFT Account added yet');
+    expect(listProps.loading).toBe(false);
+  });
+});

--- a/__tests__/components/user/settings/UserSettingsImgSelectFile.test.tsx
+++ b/__tests__/components/user/settings/UserSettingsImgSelectFile.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import UserSettingsImgSelectFile from '../../../../components/user/settings/UserSettingsImgSelectFile';
+import { AuthContext } from '../../../../components/auth/Auth';
+
+const setToast = jest.fn();
+const setFile = jest.fn();
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <AuthContext.Provider value={{ setToast } as any}>{children}</AuthContext.Provider>
+);
+
+describe('UserSettingsImgSelectFile', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+
+  it('accepts valid file', async () => {
+    const { container } = render(<UserSettingsImgSelectFile imageToShow={null} setFile={setFile} />, { wrapper: Wrapper });
+    const input = container.querySelector('#pfp-upload-input') as HTMLInputElement;
+    const file = new File(['123'], 'file.png', { type: 'image/png' });
+    await userEvent.upload(input, file);
+    expect(setFile).toHaveBeenCalledWith(file);
+  });
+});


### PR DESCRIPTION
## Summary
- add modal toggle test for statements add button
- test contact statement add component logic
- test NFT account header and list wrappers
- test brain wrapper redirection logic
- test image selection file component

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`