### PR TITLE
Increase test coverage for utility components

### DIFF
--- a/__tests__/components/user/utils/addresses-select/UserAddressesSelectDropdownItem.test.tsx
+++ b/__tests__/components/user/utils/addresses-select/UserAddressesSelectDropdownItem.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UserAddressesSelectDropdownItem from "../../../../../components/user/utils/addresses-select/UserAddressesSelectDropdownItem";
+
+const mockCopy = jest.fn();
+
+jest.mock("react-use", () => ({
+  useCopyToClipboard: () => [null, mockCopy],
+}));
+
+describe("UserAddressesSelectDropdownItem", () => {
+  beforeEach(() => {
+    mockCopy.mockClear();
+    (window as any).open = jest.fn();
+  });
+
+  it("copies display address and calls onCopy", async () => {
+    const onCopy = jest.fn();
+    render(
+      <UserAddressesSelectDropdownItem
+        wallet={{ wallet: "0xabc", display: "ens.eth" } as any}
+        onCopy={onCopy}
+      />
+    );
+    await userEvent.click(screen.getByLabelText("Copy address"));
+    expect(mockCopy).toHaveBeenCalledWith("ens.eth");
+    expect(onCopy).toHaveBeenCalled();
+  });
+
+  it("opens opensea with wallet when no display", async () => {
+    render(
+      <UserAddressesSelectDropdownItem
+        wallet={{ wallet: "0x123" } as any}
+      />
+    );
+    await userEvent.click(screen.getByLabelText("Open in OpenSea"));
+    expect(window.open).toHaveBeenCalledWith(
+      "https://opensea.io/0x123",
+      "_blank"
+    );
+  });
+});

--- a/__tests__/components/utils/CommonTimeAgo.test.tsx
+++ b/__tests__/components/utils/CommonTimeAgo.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import CommonTimeAgo from "../../../components/utils/CommonTimeAgo";
+
+jest.mock("../../../helpers/Helpers", () => ({
+  getTimeAgo: jest.fn(),
+  getTimeAgoShort: jest.fn(),
+}));
+
+const helpers = jest.requireMock("../../../helpers/Helpers");
+
+describe("CommonTimeAgo", () => {
+  it("uses long format by default", () => {
+    helpers.getTimeAgo.mockReturnValue("long");
+    render(<CommonTimeAgo timestamp={1} />);
+    expect(helpers.getTimeAgo).toHaveBeenCalledWith(1);
+    const span = screen.getByText("long");
+    expect(span).toHaveClass(
+      "tw-whitespace-nowrap tw-font-normal tw-text-iron-500 tw-text-sm sm:tw-text-base"
+    );
+  });
+
+  it("uses short format when short prop set", () => {
+    helpers.getTimeAgoShort.mockReturnValue("short");
+    render(<CommonTimeAgo timestamp={2} short className="extra" />);
+    expect(helpers.getTimeAgoShort).toHaveBeenCalledWith(2);
+    const span = screen.getByText("short");
+    expect(span).toHaveClass(
+      "tw-whitespace-nowrap tw-font-normal tw-text-iron-500 extra"
+    );
+  });
+});

--- a/__tests__/components/waves/create-wave/outcomes/CreateWaveOutcomeWarning.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/CreateWaveOutcomeWarning.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import CreateWaveOutcomeWarning from "../../../../../components/waves/create-wave/outcomes/CreateWaveOutcomeWarning";
+import { ApiWaveType } from "../../../../../generated/models/ApiWaveType";
+
+jest.mock(
+  "../../../../../components/waves/create-wave/utils/CreateWaveWarning",
+  () => ({
+    __esModule: true,
+    default: ({ title, description }: any) => (
+      <div data-testid="warning">{title} - {description}</div>
+    ),
+  })
+);
+
+describe("CreateWaveOutcomeWarning", () => {
+  it("returns null for non-approve waves", () => {
+    const { container } = render(
+      <CreateWaveOutcomeWarning
+        waveType={ApiWaveType.Rank}
+        dates={{} as any}
+        maxWinners={null}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows indefinite warning when no endDate", () => {
+    render(
+      <CreateWaveOutcomeWarning
+        waveType={ApiWaveType.Approve}
+        dates={{} as any}
+        maxWinners={null}
+      />
+    );
+    expect(screen.getByTestId("warning")).toHaveTextContent(
+      "Warning: Challenge Will Run Indefinitely"
+    );
+  });
+
+  it("shows unlimited warning when endDate present", () => {
+    render(
+      <CreateWaveOutcomeWarning
+        waveType={ApiWaveType.Approve}
+        dates={{ endDate: 1 } as any}
+        maxWinners={null}
+      />
+    );
+    expect(screen.getByTestId("warning")).toHaveTextContent(
+      "Warning: Unlimited Awards"
+    );
+  });
+
+  it("returns null when maxWinners set", () => {
+    const { container } = render(
+      <CreateWaveOutcomeWarning
+        waveType={ApiWaveType.Approve}
+        dates={{ endDate: 1 } as any}
+        maxWinners={5}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `UserAddressesSelectDropdownItem`
- add tests for `CommonTimeAgo`
- add tests for `CreateWaveOutcomeWarning`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
