### PR TITLE
Increase test coverage for nextgen components

### DIFF
--- a/__tests__/components/nextGen/collections/NextGenCollectionPreview.test.tsx
+++ b/__tests__/components/nextGen/collections/NextGenCollectionPreview.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import NextGenCollectionPreview from '../../../../components/nextGen/collections/NextGenCollectionPreview';
+import { formatNameForUrl } from '../../../../components/nextGen/nextgen_helpers';
+
+jest.mock('react-bootstrap', () => {
+  const React = require('react');
+  return {
+    Container: (p: any) => <div {...p} />,
+    Row: (p: any) => <div {...p} />,
+    Col: (p: any) => <div {...p} />,
+  };
+});
+
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => <img data-testid="img" {...props} />,
+}));
+
+jest.mock('../../../../components/nextGen/collections/collectionParts/NextGenCollectionHeader', () => ({
+  NextGenMintCounts: () => <span data-testid="mint-counts" />,
+}));
+
+const collection = {
+  id: 1,
+  name: 'Test Collection',
+  artist: 'Artist',
+  image: '/image.png',
+} as any;
+
+it('renders link, image and fallback on error', () => {
+  const { container } = render(<NextGenCollectionPreview collection={collection} />);
+  const link = container.querySelector('a');
+  expect(link).toHaveAttribute('href', `/nextgen/collection/${formatNameForUrl(collection.name)}`);
+
+  const img = screen.getByTestId('img') as HTMLImageElement;
+  expect(img).toHaveAttribute('src', collection.image);
+
+  fireEvent.error(img);
+  expect(img).toHaveAttribute('src', '/pebbles-loading.jpeg');
+
+  expect(screen.getByText(collection.name)).toBeInTheDocument();
+  expect(screen.getAllByText('Artist').length).toBeGreaterThan(0);
+  expect(screen.getByTestId('mint-counts')).toBeInTheDocument();
+});

--- a/__tests__/components/nextGen/collections/nextgenToken/NextGenTokenRenderCenter.test.tsx
+++ b/__tests__/components/nextGen/collections/nextgenToken/NextGenTokenRenderCenter.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NextGenTokenRenderCenter from '../../../../../components/nextGen/collections/nextgenToken/NextGenTokenRenderCenter';
+
+jest.mock('react-bootstrap', () => {
+  const React = require('react');
+  const RB: any = {
+    Container: (p: any) => <div {...p} />,
+    Row: (p: any) => <div {...p} />,
+    Col: (p: any) => <div {...p} />,
+  };
+  const Dropdown: any = (p: any) => <div {...p} />;
+  Dropdown.Toggle = (p: any) => <button {...p}>{p.children}</button>;
+  Dropdown.Menu = (p: any) => <div {...p} />;
+  Dropdown.Item = (p: any) => <button {...p}>{p.children}</button>;
+  RB.Dropdown = Dropdown;
+  return RB;
+});
+
+jest.mock('../../../../../components/nextGen/collections/nextgenToken/NextGenTokenDownload', () => ({
+  __esModule: true,
+  default: () => <div data-testid="download" />,
+  Resolution: { '1K':'1K','2K':'2K','4K':'4K','8K':'8K','16K':'16K','0.5K':'0.5K', Thumbnail:'Thumbnail' }
+}));
+
+jest.mock('../../../../../helpers/AllowlistToolHelpers', () => ({ getRandomObjectId: () => 'id' }));
+
+jest.mock('../../../../../helpers/Helpers', () => ({ numberWithCommas: (n:number) => n.toString() }));
+
+const token = { id: 42 } as any;
+
+function setup() {
+  return render(<NextGenTokenRenderCenter token={token} />);
+}
+
+describe('NextGenTokenRenderCenter', () => {
+  it('opens generator with default options', async () => {
+    const open = jest.fn();
+    const orig = window.open;
+    // @ts-ignore
+    window.open = open;
+    setup();
+    await userEvent.click(screen.getByText('GO!'));
+    expect(open).toHaveBeenCalledWith('https://generator.6529.io/mainnet/html/42', '_blank');
+    window.open = orig;
+  });
+
+  it('passes selected options to generator url', async () => {
+    const open = jest.fn();
+    // @ts-ignore
+    window.open = open;
+    setup();
+    await userEvent.click(screen.getByText('Static'));
+    await userEvent.click(screen.getByText('OG'));
+    const input = screen.getByPlaceholderText('enter height');
+    await userEvent.type(input, '400');
+    await userEvent.click(screen.getByText('GO!'));
+    expect(open).toHaveBeenCalledWith(
+      'https://generator.6529.io/mainnet/html/42?render_static=true&render_og=true&height=400',
+      '_blank'
+    );
+    window.open = undefined as any;
+  });
+});

--- a/__tests__/components/user/settings/UserSettingsImgSelectMeme.test.tsx
+++ b/__tests__/components/user/settings/UserSettingsImgSelectMeme.test.tsx
@@ -4,8 +4,8 @@ import UserSettingsImgSelectMeme, { MemeLite } from '../../../../components/user
 
 describe('UserSettingsImgSelectMeme', () => {
   const memes: MemeLite[] = [
-    { id: 1, name: 'First', animation: null, contract: '', icon: null, image: null, scaled: null, thumbnail: null, artist: null },
-    { id: 2, name: 'Second', animation: null, contract: '', icon: null, image: null, scaled: null, thumbnail: null, artist: null },
+    { id: 1, name: 'First', animation: null, contract: '', icon: null, image: null, scaled: null, thumbnail: null, artist: null } as unknown as MemeLite,
+    { id: 2, name: 'Second', animation: null, contract: '', icon: null, image: null, scaled: null, thumbnail: null, artist: null } as unknown as MemeLite,
   ];
 
   it('filters memes and selects one', async () => {


### PR DESCRIPTION
## Summary
- add tests for NextGenCollectionPreview rendering and fallback
- add tests for NextGenTokenRenderCenter url building
- fix type issue in UserSettingsImgSelectMeme test

## Testing
- `npx jest __tests__/components/nextGen/collections/NextGenCollectionPreview.test.tsx --coverage`
- `npx jest __tests__/components/nextGen/collections/nextgenToken/NextGenTokenRenderCenter.test.tsx --coverage`
- `npm run lint`
- `npm run type-check`
