### PR TITLE
Improve test coverage

### DIFF
--- a/__tests__/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable.test.tsx
+++ b/__tests__/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import UserPageStatsActivityWalletTable from '../../../../../../../components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable';
+import { ApiIdentity } from '../../../../../../../generated/models/ApiIdentity';
+import { Transaction } from '../../../../../../../entities/ITransaction';
+
+jest.mock('../../../../../../../components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRow', () => ({
+  __esModule: true,
+  default: jest.fn(() => <tr data-testid="row" />)
+}));
+
+const RowMock = require('../../../../../../../components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRow').default as jest.Mock;
+
+describe('UserPageStatsActivityWalletTable', () => {
+  it('renders a row for each transaction', () => {
+    const transactions: Transaction[] = [
+      { from_address: '0x1', to_address: '0x2', transaction: 'tx1', token_id: 1, block: 1, transaction_date: new Date(), created_at: new Date(), from_display: '', to_display: '', contract: '', token_count: 1, value: 0, royalties: 0, gas_gwei: 1, gas_price: 1, gas_price_gwei: 1, gas: 1 },
+      { from_address: '0x3', to_address: '0x4', transaction: 'tx2', token_id: 2, block: 2, transaction_date: new Date(), created_at: new Date(), from_display: '', to_display: '', contract: '', token_count: 1, value: 0, royalties: 0, gas_gwei: 1, gas_price: 1, gas_price_gwei: 1, gas: 1 }
+    ];
+    const profile = { handle: 'alice' } as ApiIdentity;
+    render(<UserPageStatsActivityWalletTable transactions={transactions} profile={profile} memes={[]} nextgenCollections={[]} />);
+    expect(RowMock).toHaveBeenCalledTimes(2);
+    expect(screen.getAllByTestId('row')).toHaveLength(2);
+  });
+});

--- a/__tests__/components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRowGas.test.tsx
+++ b/__tests__/components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRowGas.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import UserPageStatsActivityWalletTableRowGas from '../../../../../../../../components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRowGas';
+
+jest.mock('@tippyjs/react', () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div data-testid="tippy">
+      <div data-testid="tippy-content">{props.content}</div>
+      {props.children}
+    </div>
+  )
+}));
+
+describe('UserPageStatsActivityWalletTableRowGas', () => {
+  it('shows gas information in tooltip', () => {
+    render(<UserPageStatsActivityWalletTableRowGas gas={1.23456} gasGwei={123} gasPriceGwei={45.67} />);
+    expect(screen.getByLabelText('Gas Information')).toBeInTheDocument();
+    const content = screen.getByTestId('tippy-content');
+    expect(content.textContent).toContain('Gas:');
+    expect(content.textContent).toContain('1.23456');
+    expect(content.textContent).toContain('123');
+    expect(content.textContent).toContain('45.67');
+  });
+});

--- a/__tests__/components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRowIcon.test.tsx
+++ b/__tests__/components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRowIcon.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react';
+import UserPageStatsActivityWalletTableRowIcon from '../../../../../../../../components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRowIcon';
+import { TransactionType } from '../../../../../../../../components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRow';
+
+describe('UserPageStatsActivityWalletTableRowIcon', () => {
+  it('renders sale icon for sale transaction', () => {
+    const { container } = render(<UserPageStatsActivityWalletTableRowIcon type={TransactionType.SALE} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('viewBox', '0 0 27 27');
+  });
+
+  it('renders burn icon for burned transaction', () => {
+    const { container } = render(<UserPageStatsActivityWalletTableRowIcon type={TransactionType.BURNED} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+  });
+});

--- a/__tests__/components/utils/button/ClosedButton.test.tsx
+++ b/__tests__/components/utils/button/ClosedButton.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import ClosedButton from '../../../../components/utils/button/ClosedButton';
+
+jest.mock('../../../../components/distribution-plan-tool/common/CircleLoader', () => ({
+  __esModule: true,
+  default: () => <div data-testid="loader" />
+}));
+
+describe('ClosedButton', () => {
+  it('displays loader and disables button when loading', () => {
+    render(<ClosedButton loading title="closed">Done</ClosedButton>);
+    const button = screen.getByRole('button', { name: 'closed' });
+    expect(button).toBeDisabled();
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/utils/icons/OutsideLinkIcon.test.tsx
+++ b/__tests__/components/utils/icons/OutsideLinkIcon.test.tsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import OutsideLinkIcon from '../../../../components/utils/icons/OutsideLinkIcon';
+
+describe('OutsideLinkIcon', () => {
+  it('renders svg with expected attributes', () => {
+    const { container } = render(<OutsideLinkIcon />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+    const cls = svg?.getAttribute('class') || '';
+    expect(cls).toContain('tw-flex-shrink-0');
+  });
+});


### PR DESCRIPTION
## Summary
- add ClosedButton tests
- add OutsideLinkIcon tests
- add UserPageStatsActivityWallet table row tests
- add UserPageStatsActivityWallet table tests

## Testing
- `npx jest __tests__/components/utils/button/ClosedButton.test.tsx --coverage`
- `npx jest __tests__/components/utils/icons/OutsideLinkIcon.test.tsx --coverage`
- `npx jest __tests__/components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRowGas.test.tsx --coverage`
- `npx jest __tests__/components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRowIcon.test.tsx --coverage`
- `npx jest __tests__/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable.test.tsx --coverage`
- `npm run improve-coverage`