### PR TITLE
Add tests for UI components

### DIFF
--- a/__tests__/components/nextGen/collections/collectionParts/art/NextGenCollectionArtPage.test.tsx
+++ b/__tests__/components/nextGen/collections/collectionParts/art/NextGenCollectionArtPage.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import NextGenCollectionArtPage from '../../../../../../components/nextGen/collections/collectionParts/art/NextGenCollectionArtPage';
+import { NextGenCollection } from '../../../../../../entities/INextgen';
+
+let headerProps: any = null;
+let artProps: any = null;
+
+jest.mock('../../../../../../components/nextGen/collections/collectionParts/NextGenCollectionHeader', () => (props: any) => {
+  headerProps = props;
+  return <div data-testid="header" />;
+});
+
+jest.mock('../../../../../../components/nextGen/collections/collectionParts/NextGenCollectionArt', () => (props: any) => {
+  artProps = props;
+  return <div data-testid="art" />;
+});
+
+jest.mock('../../../../../../components/nextGen/collections/NextGenNavigationHeader', () => () => <div data-testid="nav" />);
+
+describe('NextGenCollectionArtPage', () => {
+  beforeEach(() => {
+    headerProps = null;
+    artProps = null;
+  });
+
+  it('renders navigation header and passes collection to child components', () => {
+    const collection = { id: 1, name: 'Cool' } as NextGenCollection;
+    render(<NextGenCollectionArtPage collection={collection} />);
+    expect(headerProps).toEqual({ collection, collection_link: true });
+    expect(artProps).toEqual({ collection });
+  });
+});

--- a/__tests__/components/user/collected/filters/UserPageCollectedFiltersSeized.test.tsx
+++ b/__tests__/components/user/collected/filters/UserPageCollectedFiltersSeized.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import UserPageCollectedFiltersSeized from '../../../../../components/user/collected/filters/UserPageCollectedFiltersSeized';
+import { CollectionSeized } from '../../../../../entities/IProfile';
+
+let capturedProps: any = null;
+
+jest.mock('../../../../../components/utils/select/dropdown/CommonDropdown', () => (props: any) => {
+  capturedProps = props;
+  return <div data-testid="dropdown" />;
+});
+
+describe('UserPageCollectedFiltersSeized', () => {
+  beforeEach(() => {
+    capturedProps = null;
+  });
+
+  it('passes items and active selection to dropdown', () => {
+    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    render(
+      <UserPageCollectedFiltersSeized
+        selected={CollectionSeized.NOT_SEIZED}
+        containerRef={ref}
+        setSelected={jest.fn()}
+      />
+    );
+    const values = capturedProps.items.map((i: any) => i.value);
+    expect(values).toEqual([null, ...Object.values(CollectionSeized)]);
+    expect(capturedProps.activeItem).toBe(CollectionSeized.NOT_SEIZED);
+    expect(capturedProps.filterLabel).toBe('Seized');
+    expect(capturedProps.containerRef).toBe(ref);
+  });
+});

--- a/__tests__/components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddressesItemPrimary.test.tsx
+++ b/__tests__/components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddressesItemPrimary.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Component from '../../../../../../components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddressesItemPrimary';
+
+let loaderRendered = false;
+jest.mock('../../../../../../components/distribution-plan-tool/common/CircleLoader', () => () => {
+  loaderRendered = true;
+  return <div data-testid="loader" />;
+});
+
+describe('UserPageIdentityStatementsConsolidatedAddressesItemPrimary', () => {
+  const wallet = { wallet: '0xabc' } as any;
+
+  beforeEach(() => {
+    loaderRendered = false;
+  });
+
+  it('displays Primary label when address is primary', () => {
+    render(
+      <Component
+        isPrimary
+        canEdit={false}
+        address={wallet}
+        assignPrimary={jest.fn()}
+        isAssigningPrimary={false}
+      />
+    );
+    expect(screen.getByText('Primary')).toBeInTheDocument();
+  });
+
+  it('calls assignPrimary when button clicked', () => {
+    const fn = jest.fn();
+    render(
+      <Component
+        isPrimary={false}
+        canEdit
+        address={wallet}
+        assignPrimary={fn}
+        isAssigningPrimary={false}
+      />
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(fn).toHaveBeenCalled();
+  });
+
+  it('shows loader when assigning primary', () => {
+    render(
+      <Component
+        isPrimary={false}
+        canEdit
+        address={wallet}
+        assignPrimary={jest.fn()}
+        isAssigningPrimary
+      />
+    );
+    expect(loaderRendered).toBe(true);
+  });
+
+  it('renders nothing when not editable and not primary', () => {
+    const { container } = render(
+      <Component
+        isPrimary={false}
+        canEdit={false}
+        address={wallet}
+        assignPrimary={jest.fn()}
+        isAssigningPrimary={false}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/__tests__/components/user/proxy/proxy/create-action/config/ProxyCreateActionConfigAllocateCic.test.tsx
+++ b/__tests__/components/user/proxy/proxy/create-action/config/ProxyCreateActionConfigAllocateCic.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import ProxyCreateActionConfigAllocateCic from '../../../../../../../components/user/proxy/proxy/create-action/config/ProxyCreateActionConfigAllocateCic';
+import { ApiProfileProxyActionType } from '../../../../../../../generated/models/ApiProfileProxyActionType';
+
+jest.mock('../../../../../../../components/distribution-plan-tool/common/CircleLoader', () => ({
+  __esModule: true,
+  default: ({ size }: any) => <div data-testid="loader" data-size={size} />,
+  CircleLoaderSize: { SMALL: 'SMALL' },
+}));
+
+describe('ProxyCreateActionConfigAllocateCic', () => {
+  it('enables save button and submits value', async () => {
+    const onSubmit = jest.fn();
+    const onCancel = jest.fn();
+    render(
+      <ProxyCreateActionConfigAllocateCic endTime={123} submitting={false} onSubmit={onSubmit} onCancel={onCancel} />
+    );
+    const saveButton = screen.getByRole('button', { name: /save/i });
+    expect(saveButton).toBeDisabled();
+    const input = screen.getByPlaceholderText('Credit Amount');
+    await userEvent.clear(input);
+    await userEvent.type(input, '42');
+    expect(saveButton).toBeEnabled();
+    await userEvent.click(saveButton);
+    expect(onSubmit).toHaveBeenCalledWith({
+      action_type: ApiProfileProxyActionType.AllocateCic,
+      end_time: 123,
+      credit_amount: 42,
+    });
+  });
+
+  it('shows loader when submitting and disables cancel', async () => {
+    const onSubmit = jest.fn();
+    const onCancel = jest.fn();
+    render(
+      <ProxyCreateActionConfigAllocateCic endTime={null} submitting={true} onSubmit={onSubmit} onCancel={onCancel} />
+    );
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+    expect(cancelButton).toBeDisabled();
+    await userEvent.click(cancelButton);
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/user/settings/UserSettingsImgSelectMeme.test.tsx
+++ b/__tests__/components/user/settings/UserSettingsImgSelectMeme.test.tsx
@@ -4,8 +4,8 @@ import UserSettingsImgSelectMeme, { MemeLite } from '../../../../components/user
 
 describe('UserSettingsImgSelectMeme', () => {
   const memes: MemeLite[] = [
-    { id: 1, name: 'First', animation: null, contract: '', icon: null, image: null, scaled: null, thumbnail: null, artist: null },
-    { id: 2, name: 'Second', animation: null, contract: '', icon: null, image: null, scaled: null, thumbnail: null, artist: null },
+    { id: 1, name: 'First', animation: null, contract: '', icon: null, image: null, scaled: null, thumbnail: null, artist: null } as unknown as MemeLite,
+    { id: 2, name: 'Second', animation: null, contract: '', icon: null, image: null, scaled: null, thumbnail: null, artist: null } as unknown as MemeLite,
   ];
 
   it('filters memes and selects one', async () => {

--- a/__tests__/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper.test.tsx
+++ b/__tests__/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import UserPageStatsActivityWalletTableWrapper from '../../../../../../../components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper';
+import { UserPageStatsActivityWalletFilterType } from '../../../../../../../components/user/stats/activity/wallet/UserPageStatsActivityWallet';
+
+jest.mock('../../../../../../../components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilter', () => (props: any) => (
+  <div data-testid="filter" data-active={props.activeFilter} />
+));
+
+jest.mock('../../../../../../../components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable', () => () => <div data-testid="table" />);
+
+jest.mock('../../../../../../../components/utils/table/paginator/CommonTablePagination', () => (props: any) => (
+  <div data-testid="pagination" data-page={props.currentPage} data-total={props.totalPages} />
+));
+
+jest.mock('../../../../../../../components/utils/animation/CommonCardSkeleton', () => () => <div data-testid="skeleton" />);
+
+jest.mock('../../../../../../../components/distribution-plan-tool/common/CircleLoader', () => () => <div data-testid="loader" />);
+
+describe('UserPageStatsActivityWalletTableWrapper', () => {
+  const profile = { id: 'p' } as any;
+  const meme = { id: 1 } as any;
+  const collection = { id: 1 } as any;
+  const tx = { id: 1 } as any;
+
+  it('shows skeleton during initial load', () => {
+    render(
+      <UserPageStatsActivityWalletTableWrapper
+        filter={UserPageStatsActivityWalletFilterType.ALL}
+        profile={profile}
+        transactions={[]}
+        memes={[]}
+        nextgenCollections={[]}
+        totalPages={1}
+        page={1}
+        isFirstLoading={true}
+        loading={false}
+        setPage={jest.fn()}
+        onActiveFilter={jest.fn()}
+      />
+    );
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+  });
+
+  it('renders table and pagination when data available', () => {
+    render(
+      <UserPageStatsActivityWalletTableWrapper
+        filter={UserPageStatsActivityWalletFilterType.ALL}
+        profile={profile}
+        transactions={[tx]}
+        memes={[meme]}
+        nextgenCollections={[collection]}
+        totalPages={2}
+        page={1}
+        isFirstLoading={false}
+        loading={true}
+        setPage={jest.fn()}
+        onActiveFilter={jest.fn()}
+      />
+    );
+    expect(screen.getByTestId('filter')).toHaveAttribute('data-active', UserPageStatsActivityWalletFilterType.ALL);
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+    expect(screen.getByTestId('table')).toBeInTheDocument();
+    expect(screen.getByTestId('pagination')).toHaveAttribute('data-total', '2');
+  });
+
+  it('shows no data message when list empty', () => {
+    render(
+      <UserPageStatsActivityWalletTableWrapper
+        filter={UserPageStatsActivityWalletFilterType.MINTS}
+        profile={profile}
+        transactions={[]}
+        memes={[]}
+        nextgenCollections={[]}
+        totalPages={1}
+        page={1}
+        isFirstLoading={false}
+        loading={false}
+        setPage={jest.fn()}
+        onActiveFilter={jest.fn()}
+      />
+    );
+    expect(screen.getByText('No mints')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for NextGenCollectionArtPage
- cover collected filters for seized state
- test consolidated addresses primary component
- add allocate CIC config tests
- test stats activity wallet table wrapper

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
