### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/components/UserCICProbablyAccurateIcon.test.tsx
+++ b/__tests__/components/UserCICProbablyAccurateIcon.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react';
+import UserCICProbablyAccurateIcon from '../../components/user/utils/user-cic-type/icons/UserCICProbablyAccurateIcon';
+
+describe('UserCICProbablyAccurateIcon', () => {
+  it('renders svg with expected elements', () => {
+    const { container } = render(<UserCICProbablyAccurateIcon />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('viewBox', '0 0 183 183');
+    // should contain an ellipse with specific fill
+    const ellipse = container.querySelector('ellipse');
+    expect(ellipse).toBeInTheDocument();
+    expect(ellipse).toHaveAttribute('fill', '#0A0A0A');
+    // there should be multiple path elements
+    const paths = container.querySelectorAll('path');
+    expect(paths.length).toBeGreaterThan(0);
+    expect(paths[0]).toHaveAttribute('fill', '#73E2A3');
+  });
+});

--- a/__tests__/components/UserPageStats.test.ts
+++ b/__tests__/components/UserPageStats.test.ts
@@ -1,0 +1,25 @@
+import { getStatsPath } from '../../components/user/stats/UserPageStats';
+import { ApiIdentity } from '../../generated/models/ApiIdentity';
+
+describe('getStatsPath', () => {
+  const baseProfile = {
+    wallets: [{ wallet: '0xabc' }],
+    consolidation_key: 'key123',
+  } as unknown as ApiIdentity;
+
+  it('returns wallet path when active address provided', () => {
+    const result = getStatsPath(baseProfile, '0xdef');
+    expect(result).toBe('wallet/0xdef');
+  });
+
+  it('returns consolidation path when no active address', () => {
+    const result = getStatsPath(baseProfile, null);
+    expect(result).toBe('consolidation/key123');
+  });
+
+  it('falls back to first wallet when no active address and no consolidation key', () => {
+    const profile = { wallets: [{ wallet: '0x999' }] } as unknown as ApiIdentity;
+    const result = getStatsPath(profile, null);
+    expect(result).toBe('wallet/0x999');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for UserCICProbablyAccurateIcon svg component
- cover getStatsPath helper logic

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
