### PR TITLE
Increase coverage for radio and wave helpers

### DIFF
--- a/__tests__/components/user/groups/UserPageGroupsWrapper.test.tsx
+++ b/__tests__/components/user/groups/UserPageGroupsWrapper.test.tsx
@@ -34,7 +34,7 @@ describe('UserPageGroupsWrapper', () => {
 
   it('passes profile from hook when available', () => {
     useRouterMock.mockReturnValue({ query: { user: 'alice' } });
-    const profile = { handle: 'alice' };
+    const profile = { handle: 'alice' } as any;
     useIdentityMock.mockReturnValue({ profile });
     render(<UserPageGroupsWrapper profile={profile} />);
     expect(useIdentityMock).toHaveBeenCalledWith({ handleOrWallet: 'alice', initialProfile: profile });
@@ -44,7 +44,7 @@ describe('UserPageGroupsWrapper', () => {
 
   it('falls back to initial profile when hook returns null', () => {
     useRouterMock.mockReturnValue({ query: { user: 'bob' } });
-    const initialProfile = { handle: 'bob' };
+    const initialProfile = { handle: 'bob' } as any;
     useIdentityMock.mockReturnValue({ profile: null });
     render(<UserPageGroupsWrapper profile={initialProfile} />);
     expect(capturedWrapperProfile).toBe(initialProfile);

--- a/__tests__/components/user/identity/activity/UserPageIdentityActivityLog.test.tsx
+++ b/__tests__/components/user/identity/activity/UserPageIdentityActivityLog.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import UserPageIdentityActivityLog from '../../../../../components/user/identity/activity/UserPageIdentityActivityLog';
+
+jest.mock('../../../../../components/profile-activity/ProfileActivityLogs', () => (props: any) => (
+  <div data-testid="activity" data-props={JSON.stringify(props)} />
+));
+
+jest.mock('../../../../../components/profile-activity/ProfileName', () => ({
+  __esModule: true,
+  ProfileNameType: { POSSESSION: 'POSSESSION', DEFAULT: 'DEFAULT' },
+  default: (props: any) => <span data-testid="name">{props.type}</span>,
+}));
+
+jest.mock('../../../../../components/user/utils/UserTableHeaderWrapper', () => (props: any) => (
+  <div data-testid="wrapper">{props.children}</div>
+));
+
+describe('UserPageIdentityActivityLog', () => {
+  it('passes initial params to activity logs', () => {
+    const params = { limit: 5 } as any;
+    render(<UserPageIdentityActivityLog initialActivityLogParams={params} />);
+    const activity = screen.getByTestId('activity');
+    const props = JSON.parse(activity.getAttribute('data-props') || '{}');
+    expect(props.initialParams).toEqual(params);
+    expect(props.withFilters).toBe(true);
+    expect(screen.getByText('NIC Activity Log')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/utils/radio/CommonBorderedRadioButton.test.tsx
+++ b/__tests__/components/utils/radio/CommonBorderedRadioButton.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CommonBorderedRadioButton from '../../../../components/utils/radio/CommonBorderedRadioButton';
+
+
+describe('CommonBorderedRadioButton', () => {
+  it('calls onChange when clicked if not disabled', async () => {
+    const onChange = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <CommonBorderedRadioButton
+        type="A"
+        selected="B"
+        label="Option A"
+        onChange={onChange}
+      />
+    );
+    await user.click(screen.getByRole('radio'));
+    expect(onChange).toHaveBeenCalledWith('A');
+  });
+
+  it('does not call onChange when disabled', async () => {
+    const onChange = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <CommonBorderedRadioButton
+        type="A"
+        selected="B"
+        label="Option A"
+        onChange={onChange}
+        disabled
+      />
+    );
+    await user.click(screen.getByRole('radio'));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('renders children when label not provided', () => {
+    render(
+      <CommonBorderedRadioButton type="A" selected="A" onChange={() => {}}>
+        <span data-testid="child" />
+      </CommonBorderedRadioButton>
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+    expect(screen.getByRole('radio')).toBeChecked();
+  });
+});

--- a/__tests__/components/waves/create-wave/approval/CreateWaveApprovalThresholdTime.test.tsx
+++ b/__tests__/components/waves/create-wave/approval/CreateWaveApprovalThresholdTime.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveApprovalThresholdTime from '../../../../../components/waves/create-wave/approval/CreateWaveApprovalThresholdTime';
+import { Period } from '../../../../../helpers/Types';
+
+jest.mock('../../../../../components/waves/create-wave/dates/end-date/CreateWaveDatesEndDateSelectPeriod', () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <button onClick={() => props.onPeriodSelect(Period.HOURS)}>select-period</button>
+  ),
+}));
+
+describe('CreateWaveApprovalThresholdTime', () => {
+  it('calculates milliseconds when time and period set', async () => {
+    const setThresholdTimeMs = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <CreateWaveApprovalThresholdTime
+        thresholdTimeMs={null}
+        thresholdTimeError={false}
+        thresholdDurationError={false}
+        setThresholdTimeMs={setThresholdTimeMs}
+      />
+    );
+    await user.type(screen.getByLabelText('Set time'), '2');
+    await user.click(screen.getByText('select-period'));
+    const twoHoursMs = 2 * 60 * 60 * 1000;
+    expect(setThresholdTimeMs).toHaveBeenLastCalledWith(twoHoursMs);
+  });
+
+  it('shows error message when time missing', () => {
+    render(
+      <CreateWaveApprovalThresholdTime
+        thresholdTimeMs={null}
+        thresholdTimeError={true}
+        thresholdDurationError={false}
+        setThresholdTimeMs={jest.fn()}
+      />
+    );
+    expect(screen.getByText('Please set time')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/create-wave/drops/CreateWaveDrops.test.tsx
+++ b/__tests__/components/waves/create-wave/drops/CreateWaveDrops.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveDrops from '../../../../../components/waves/create-wave/drops/CreateWaveDrops';
+import { ApiWaveType } from '../../../../../generated/models/ApiWaveType';
+
+jest.mock('../../../../../components/waves/create-wave/drops/types/CreateWaveDropsTypes', () => (props: any) => (
+  <div data-testid="types" onClick={() => props.onRequiredTypeChange(['A'])} />
+));
+
+jest.mock('../../../../../components/waves/create-wave/drops/metadata/CreateWaveDropsMetadata', () => (props: any) => (
+  <div data-testid="metadata" onClick={() => props.onRequiredMetadataChange([{foo:'bar'}])} />
+));
+
+jest.mock('../../../../../components/waves/create-wave/drops/terms/CreateWaveTermsOfService', () => (props: any) => (
+  <button onClick={() => props.setTerms('terms')} data-testid="terms" />
+));
+
+describe('CreateWaveDrops', () => {
+  it('updates drops config based on user input', async () => {
+    const user = userEvent.setup();
+    const setDrops = jest.fn();
+    render(
+      <CreateWaveDrops
+        waveType={ApiWaveType.Rank}
+        drops={{
+          noOfApplicationsAllowedPerParticipant: null,
+          requiredTypes: [],
+          requiredMetadata: [],
+          terms: null,
+          signatureRequired: false,
+          adminCanDeleteDrops: false,
+        }}
+        errors={[]}
+        setDrops={setDrops}
+      />
+    );
+    await user.type(screen.getByLabelText(/Number of applications/i), '3');
+    expect(setDrops).toHaveBeenLastCalledWith(expect.objectContaining({ noOfApplicationsAllowedPerParticipant: 3 }));
+
+    await user.click(screen.getByTestId('types'));
+    expect(setDrops).toHaveBeenLastCalledWith(expect.objectContaining({ requiredTypes: ['A'] }));
+
+    await user.click(screen.getByTestId('metadata'));
+    expect(setDrops).toHaveBeenLastCalledWith(expect.objectContaining({ requiredMetadata: [{foo:'bar'}] }));
+
+    await user.click(screen.getByTestId('terms'));
+    expect(setDrops).toHaveBeenLastCalledWith(expect.objectContaining({ terms: 'terms', signatureRequired: true }));
+  });
+});

--- a/__tests__/components/waves/create-wave/services/waveGroupService.test.ts
+++ b/__tests__/components/waves/create-wave/services/waveGroupService.test.ts
@@ -1,0 +1,51 @@
+import { getAdminGroupId } from '../../../../../components/waves/create-wave/services/waveGroupService';
+import { commonApiPost } from '../../../../../services/api/common-api';
+
+jest.mock('../../../../../services/api/common-api', () => ({
+  commonApiPost: jest.fn(),
+}));
+
+const mockedCommonApiPost = commonApiPost as jest.Mock;
+
+describe('waveGroupService', () => {
+  beforeEach(() => {
+    mockedCommonApiPost.mockReset();
+  });
+
+  it('returns existing admin group id if provided', async () => {
+    const result = await getAdminGroupId({
+      adminGroupId: '123',
+      primaryWallet: '0x1',
+      handle: 'alice',
+      onError: jest.fn(),
+    });
+    expect(result).toBe('123');
+    expect(mockedCommonApiPost).not.toHaveBeenCalled();
+  });
+
+  it('returns null and calls onError when no primary wallet', async () => {
+    const onError = jest.fn();
+    const result = await getAdminGroupId({
+      adminGroupId: null,
+      primaryWallet: null,
+      handle: 'alice',
+      onError,
+    });
+    expect(result).toBeNull();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('creates group when no admin group id', async () => {
+    mockedCommonApiPost
+      .mockResolvedValueOnce({ id: 'new' }) // create group
+      .mockResolvedValueOnce({}); // set visible
+    const result = await getAdminGroupId({
+      adminGroupId: null,
+      primaryWallet: '0x1',
+      handle: 'alice',
+      onError: jest.fn(),
+    });
+    expect(result).toBe('new');
+    expect(mockedCommonApiPost).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `CommonBorderedRadioButton`
- add tests for wave creation helper components
- add test for `UserPageIdentityActivityLog`
- update existing group wrapper test to satisfy type check

## Testing
- `npm run lint`
- `npm run type-check`
