### PR TITLE
Increase coverage for user components

### DIFF
--- a/__tests__/components/nextGen/collections/NextGenArtists.test.tsx
+++ b/__tests__/components/nextGen/collections/NextGenArtists.test.tsx
@@ -1,0 +1,50 @@
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import NextGenArtists from '../../../../components/nextGen/collections/NextGenArtists';
+import { fetchUrl } from '../../../../services/6529api';
+
+jest.mock('../../../../services/6529api', () => ({ fetchUrl: jest.fn() }));
+
+const MockArtist = jest.fn(() => <div data-testid="artist" />);
+jest.mock('../../../../components/nextGen/collections/collectionParts/NextGenCollectionArtist', () => ({
+  __esModule: true,
+  default: (props: any) => MockArtist(props),
+}));
+
+describe('NextGenArtists', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fetches collections and groups by artist', async () => {
+    (fetchUrl as jest.Mock).mockResolvedValue({
+      data: [
+        { id: 1, artist_address: '0xa', artist: 'A' },
+        { id: 2, artist_address: '0xa', artist: 'A' },
+        { id: 3, artist_address: '0xb', artist: 'B' },
+      ],
+    });
+
+    render(<NextGenArtists />);
+
+    await waitFor(() => expect(MockArtist).toHaveBeenCalledTimes(2));
+
+    expect(MockArtist).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        collection: expect.objectContaining({ id: 1 }),
+        link_collections: [
+          expect.objectContaining({ id: 1 }),
+          expect.objectContaining({ id: 2 }),
+        ],
+      })
+    );
+    expect(MockArtist).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        collection: expect.objectContaining({ id: 3 }),
+        link_collections: [expect.objectContaining({ id: 3 })],
+      })
+    );
+  });
+});

--- a/__tests__/components/the-memes/MemePageArt.test.tsx
+++ b/__tests__/components/the-memes/MemePageArt.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemePageArt } from '../../../components/the-memes/MemePageArt';
+import { useRouter } from 'next/router';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('next/link', () => ({ __esModule: true, default: ({ href, children }: any) => <a href={href}>{children}</a> }));
+
+jest.mock('../../../components/nft-image/NFTImage', () => ({ __esModule: true, default: () => <div data-testid="nft" /> }));
+jest.mock('../../../components/download/Download', () => ({ __esModule: true, default: () => <div data-testid="download" /> }));
+jest.mock('../../../components/the-memes/ArtistProfileHandle', () => ({ __esModule: true, default: () => <div data-testid="artist-handle" /> }));
+jest.mock('../../../helpers/Helpers', () => ({
+  enterArtFullScreen: jest.fn(),
+  fullScreenSupported: () => true,
+  numberWithCommas: (n: number) => String(n),
+  parseNftDescriptionToHtml: (d: string) => d,
+  printMintDate: (d: string) => d,
+}));
+jest.mock('../../../helpers/nft.helpers', () => ({
+  getFileTypeFromMetadata: () => 'png',
+  getDimensionsFromMetadata: () => '100x100',
+}));
+jest.mock('../../../components/nftAttributes/NFTAttributes', () => ({ __esModule: true, default: () => <div data-testid="attrs" /> }));
+
+const nft = {
+  id: 5,
+  has_distribution: false,
+  mint_price: 1,
+  supply: 10,
+  collection: 'c',
+  artist: 'a',
+  mint_date: '2023',
+  description: 'desc',
+  metadata: {
+    image_details: { format: 'png', width: 1, height: 2 },
+    animation_details: { format: 'gif', width: 1, height: 2 },
+    attributes: [
+      { trait_type: 'Type - Season', value: 'S1' },
+      { trait_type: 'Type - Meme', value: 'M1' },
+      { trait_type: 'Type - Card', value: 'C1' },
+      { trait_type: 'Other', value: 'val' },
+      { trait_type: 'Boost', value: 10, display_type: 'boost_percentage' },
+    ],
+    image: 'img',
+  },
+};
+const nftMeta = { season: 1, meme_name: 'meme' };
+
+describe('MemePageArt', () => {
+  const routerMock = useRouter as jest.Mock;
+  beforeEach(() => {
+    routerMock.mockReturnValue({ isReady: true });
+  });
+  it('returns empty when missing data', () => {
+    const { container } = render(<MemePageArt show={false} nft={undefined} nftMeta={undefined} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders details when data present', () => {
+    render(<MemePageArt show={true} nft={nft as any} nftMeta={nftMeta as any} />);
+    expect(screen.getByText('Arweave Links')).toBeInTheDocument();
+    expect(screen.getByText('Card Details')).toBeInTheDocument();
+    expect(screen.getByText('Minting Approach')).toBeInTheDocument();
+    expect(screen.getByText('Card Description')).toBeInTheDocument();
+    expect(screen.getByText('Properties')).toBeInTheDocument();
+    expect(screen.getByText('Stats')).toBeInTheDocument();
+    expect(screen.getByText('Boosts')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/user/collected/UserPageCollectedFirstLoading.test.tsx
+++ b/__tests__/components/user/collected/UserPageCollectedFirstLoading.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import UserPageCollectedFirstLoading from '../../../../components/user/collected/UserPageCollectedFirstLoading';
+
+jest.mock('../../../../components/utils/animation/CommonSkeletonLoader', () => ({ __esModule: true, default: () => <div data-testid="loader" /> }));
+jest.mock('../../../../components/utils/animation/CommonCardSkeleton', () => ({ __esModule: true, default: () => <div data-testid="card" /> }));
+
+describe('UserPageCollectedFirstLoading', () => {
+  it('renders skeleton loaders and cards', () => {
+    render(<UserPageCollectedFirstLoading />);
+    expect(screen.getAllByTestId('loader')).toHaveLength(2);
+    expect(screen.getAllByTestId('card')).toHaveLength(20);
+  });
+});

--- a/__tests__/components/user/identity/UserPageIdentity.test.tsx
+++ b/__tests__/components/user/identity/UserPageIdentity.test.tsx
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import UserPageIdentity from '../../../../components/user/identity/UserPageIdentity';
+
+let headerProps: any;
+let statementsProps: any;
+let tableParams: any[] = [];
+let activityProps: any;
+
+jest.mock('../../../../components/user/identity/header/UserPageIdentityHeader', () => (props: any) => { headerProps = props; return <div data-testid="header" />; });
+jest.mock('../../../../components/user/identity/statements/UserPageIdentityStatements', () => (props: any) => { statementsProps = props; return <div data-testid="statements" />; });
+jest.mock('../../../../components/user/utils/raters-table/wrapper/ProfileRatersTableWrapper', () => (props: any) => { tableParams.push(props.initialParams); return <div data-testid="table" />; });
+jest.mock('../../../../components/user/identity/activity/UserPageIdentityActivityLog', () => (props: any) => { activityProps = props; return <div data-testid="activity" />; });
+
+describe('UserPageIdentity', () => {
+  beforeEach(() => { headerProps = undefined; statementsProps = undefined; tableParams = []; activityProps = undefined; });
+  it('passes props to children', () => {
+    const profile = { id: '1' } as any;
+    const params = { p: 1 } as any;
+    render(
+      <UserPageIdentity
+        profile={profile}
+        initialCICReceivedParams={params}
+        initialCICGivenParams={params}
+        initialActivityLogParams={params}
+      />
+    );
+    expect(headerProps.profile).toBe(profile);
+    expect(statementsProps.profile).toBe(profile);
+    expect(tableParams).toEqual([params, params]);
+    expect(activityProps.initialActivityLogParams).toBe(params);
+  });
+});

--- a/__tests__/components/user/identity/UserPageIdentityWrapper.test.tsx
+++ b/__tests__/components/user/identity/UserPageIdentityWrapper.test.tsx
@@ -1,0 +1,53 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import UserPageIdentityWrapper from '../../../../components/user/identity/UserPageIdentityWrapper';
+import { useRouter } from 'next/router';
+import { useIdentity } from '../../../../hooks/useIdentity';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../../../hooks/useIdentity', () => ({ useIdentity: jest.fn() }));
+
+let wrapperProfile: any;
+let identityProps: any;
+
+jest.mock('../../../../components/user/utils/set-up-profile/UserPageSetUpProfileWrapper', () => (props: any) => { wrapperProfile = props.profile; return <div data-testid="wrapper">{props.children}</div>; });
+jest.mock('../../../../components/user/identity/UserPageIdentity', () => (props: any) => { identityProps = props; return <div data-testid="identity" />; });
+
+describe('UserPageIdentityWrapper', () => {
+  const routerMock = useRouter as jest.Mock;
+  const useIdentityMock = useIdentity as jest.Mock;
+  beforeEach(() => { wrapperProfile = null; identityProps = null; });
+
+  it('uses profile from hook when available', () => {
+    routerMock.mockReturnValue({ query: { user: 'alice' } });
+    const profile = { handle: 'alice' };
+    useIdentityMock.mockReturnValue({ profile });
+    render(
+      <UserPageIdentityWrapper
+        profile={profile}
+        initialCICReceivedParams={{} as any}
+        initialCICGivenParams={{} as any}
+        initialActivityLogParams={{} as any}
+      />
+    );
+    expect(useIdentityMock).toHaveBeenCalledWith({ handleOrWallet: 'alice', initialProfile: profile });
+    expect(wrapperProfile).toBe(profile);
+    expect(identityProps.profile).toBe(profile);
+  });
+
+  it('falls back to initial profile when hook returns null', () => {
+    routerMock.mockReturnValue({ query: { user: 'bob' } });
+    const profile = { handle: 'bob' };
+    useIdentityMock.mockReturnValue({ profile: null });
+    render(
+      <UserPageIdentityWrapper
+        profile={profile}
+        initialCICReceivedParams={{} as any}
+        initialCICGivenParams={{} as any}
+        initialActivityLogParams={{} as any}
+      />
+    );
+    expect(wrapperProfile).toBe(profile);
+    expect(identityProps.profile).toBe(profile);
+  });
+});

--- a/__tests__/components/user/identity/statements/contacts/UserPageIdentityStatementsContacts.test.tsx
+++ b/__tests__/components/user/identity/statements/contacts/UserPageIdentityStatementsContacts.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import UserPageIdentityStatementsContacts from '../../../../../../components/user/identity/statements/contacts/UserPageIdentityStatementsContacts';
+
+let listProps: any;
+jest.mock('../../../../../../components/user/identity/statements/utils/UserPageIdentityStatementsStatementsList', () => (props: any) => { listProps = props; return <ul data-testid="list" />; });
+
+describe('UserPageIdentityStatementsContacts', () => {
+  it('passes props to list', () => {
+    const statements = [{ id: '1' } as any];
+    const profile = { id: 'p1' } as any;
+    render(<UserPageIdentityStatementsContacts statements={statements} profile={profile} loading={false} />);
+    expect(listProps.statements).toBe(statements);
+    expect(listProps.profile).toBe(profile);
+    expect(listProps.noItemsMessage).toBe('No Contact added yet');
+    expect(listProps.loading).toBe(false);
+  });
+});

--- a/__tests__/components/user/identity/statements/social-media-accounts/UserPageIdentityStatementsSocialMediaAccounts.test.tsx
+++ b/__tests__/components/user/identity/statements/social-media-accounts/UserPageIdentityStatementsSocialMediaAccounts.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import UserPageIdentityStatementsSocialMediaAccounts from '../../../../../../components/user/identity/statements/social-media-accounts/UserPageIdentityStatementsSocialMediaAccounts';
+
+let listProps: any;
+jest.mock('../../../../../../components/user/identity/statements/utils/UserPageIdentityStatementsStatementsList', () => (props: any) => { listProps = props; return <ul data-testid="list" />; });
+
+describe('UserPageIdentityStatementsSocialMediaAccounts', () => {
+  it('passes props to list', () => {
+    const statements = [{ id: '1' } as any];
+    const profile = { id: 'p1' } as any;
+    render(<UserPageIdentityStatementsSocialMediaAccounts statements={statements} profile={profile} loading={false} />);
+    expect(listProps.statements).toBe(statements);
+    expect(listProps.profile).toBe(profile);
+    expect(listProps.noItemsMessage).toBe('No Social Media Account added yet');
+    expect(listProps.loading).toBe(false);
+  });
+});

--- a/__tests__/components/user/identity/statements/utils/UserPageIdentityStatementsStatementsList.test.tsx
+++ b/__tests__/components/user/identity/statements/utils/UserPageIdentityStatementsStatementsList.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import UserPageIdentityStatementsStatementsList from '../../../../../../components/user/identity/statements/utils/UserPageIdentityStatementsStatementsList';
+import { AuthContext } from '../../../../../../components/auth/Auth';
+import { useSeizeConnectContext } from '../../../../../../components/auth/SeizeConnectContext';
+import { amIUser } from '../../../../../../helpers/Helpers';
+
+jest.mock('../../../../../../components/auth/SeizeConnectContext', () => ({ useSeizeConnectContext: jest.fn() }));
+jest.mock('../../../../../../helpers/Helpers', () => ({
+  amIUser: jest.fn(() => true),
+}));
+
+let statementProps: any[] = [];
+jest.mock('../../../../../../components/user/identity/statements/utils/UserPageIdentityStatementsStatement', () => (props: any) => { statementProps.push(props); return <li data-testid="statement" />; });
+jest.mock('../../../../../../components/utils/animation/CommonSkeletonLoader', () => ({ __esModule: true, default: () => <div data-testid="loader" /> }));
+
+describe('UserPageIdentityStatementsStatementsList', () => {
+  const addressContext = { address: '0x1' };
+  const authContext = { activeProfileProxy: null };
+
+  beforeEach(() => { (useSeizeConnectContext as jest.Mock).mockReturnValue(addressContext); statementProps = []; });
+
+  it('shows loader when loading', () => {
+    render(
+      <AuthContext.Provider value={authContext as any}>
+        <UserPageIdentityStatementsStatementsList statements={[]} profile={{} as any} noItemsMessage="none" loading={true} />
+      </AuthContext.Provider>
+    );
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+  });
+
+  it('passes canEdit to statements when not loading', async () => {
+    render(
+      <AuthContext.Provider value={authContext as any}>
+        <UserPageIdentityStatementsStatementsList statements={[{ id: 's' } as any]} profile={{} as any} noItemsMessage="none" loading={false} />
+      </AuthContext.Provider>
+    );
+    await waitFor(() => {
+      const last = statementProps[statementProps.length - 1];
+      expect(last.canEdit).toBe(true);
+    });
+  });
+});

--- a/__tests__/components/user/rep/UserPageRep.test.tsx
+++ b/__tests__/components/user/rep/UserPageRep.test.tsx
@@ -1,0 +1,58 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import UserPageRep from '../../../../components/user/rep/UserPageRep';
+import { useRouter } from 'next/router';
+import { useQuery } from '@tanstack/react-query';
+import { AuthContext } from '../../../../components/auth/Auth';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('@tanstack/react-query', () => ({ useQuery: jest.fn() }));
+
+let headerProps: any;
+let newRepProps: any;
+let repsProps: any;
+let tableParams: any[] = [];
+let activityProps: any;
+let rateWrapperProps: any;
+
+jest.mock('../../../../components/user/rep/header/UserPageRepHeader', () => (props: any) => { headerProps = props; return <div data-testid="header" />; });
+jest.mock('../../../../components/user/rep/new-rep/UserPageRepNewRep', () => (props: any) => { newRepProps = props; return <div data-testid="newrep" />; });
+jest.mock('../../../../components/user/rep/reps/UserPageRepReps', () => (props: any) => { repsProps = props; return <div data-testid="reps" />; });
+jest.mock('../../../../components/user/utils/raters-table/wrapper/ProfileRatersTableWrapper', () => (props: any) => { tableParams.push(props.initialParams); return <div data-testid="table" />; });
+jest.mock('../../../../components/user/rep/UserPageRepActivityLog', () => (props: any) => { activityProps = props; return <div data-testid="activity" />; });
+jest.mock('../../../../components/user/utils/rate/UserPageRateWrapper', () => (props: any) => { rateWrapperProps = props; return <div data-testid="ratewrapper">{props.children}</div>; });
+
+describe('UserPageRep', () => {
+  const routerMock = useRouter as jest.Mock;
+  const queryMock = useQuery as jest.Mock;
+
+  beforeEach(() => {
+    headerProps = newRepProps = repsProps = activityProps = rateWrapperProps = undefined;
+    tableParams = [];
+    routerMock.mockReturnValue({ query: { user: 'alice' } });
+    queryMock.mockReturnValue({ data: { score: 1 } });
+  });
+
+  it('passes repRates and params to children', () => {
+    const profile = { handle: 'alice' } as any;
+    const params = { p: 1 } as any;
+    render(
+      <AuthContext.Provider value={{ connectedProfile: { handle: 'charlie' } } as any}>
+        <UserPageRep
+          profile={profile}
+          initialRepReceivedParams={params}
+          initialRepGivenParams={params}
+          initialActivityLogParams={params}
+        />
+      </AuthContext.Provider>
+    );
+    expect(headerProps.repRates).toEqual({ score: 1 });
+    expect(newRepProps.profile).toBe(profile);
+    expect(newRepProps.repRates).toEqual({ score: 1 });
+    expect(repsProps.profile).toBe(profile);
+    expect(repsProps.repRates).toEqual({ score: 1 });
+    expect(tableParams.slice(0, 2)).toEqual([params, params]);
+    expect(activityProps.initialActivityLogParams).toBe(params);
+    expect(rateWrapperProps.profile).toBe(profile);
+  });
+});

--- a/__tests__/components/user/settings/UserSettingsPrimaryWallet.test.tsx
+++ b/__tests__/components/user/settings/UserSettingsPrimaryWallet.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import UserSettingsPrimaryWallet from '../../../../components/user/settings/UserSettingsPrimaryWallet';
+
+let clickAway: () => void;
+let escapeCb: () => void;
+
+jest.mock('react-use', () => ({
+  useClickAway: (_ref: any, cb: () => void) => { clickAway = cb; },
+  useKeyPressEvent: (key: string, cb: () => void) => { if (key === 'Escape') escapeCb = cb; },
+}));
+
+jest.mock('framer-motion', () => ({
+  motion: { div: (p: any) => <div {...p} /> },
+  AnimatePresence: ({ children }: any) => <div>{children}</div>,
+  useAnimate: () => [{ current: document.createElement('div') }, jest.fn()],
+}));
+
+let items: any[] = [];
+jest.mock('../../../../components/user/settings/UserSettingsPrimaryWalletItem', () => (props: any) => { items.push(props); return <li data-testid="item" onClick={() => props.onSelect(props.wallet.wallet)}>{props.wallet.display}</li>; });
+
+describe('UserSettingsPrimaryWallet', () => {
+  const wallets = [
+    { wallet: '0x1', display: 'One', tdh: 0 },
+    { wallet: '0x2', display: 'Two', tdh: 0 },
+  ];
+  beforeEach(() => { items = []; });
+
+  it('opens dropdown and selects wallet', async () => {
+    const onSelect = jest.fn();
+    render(<UserSettingsPrimaryWallet wallets={wallets as any} selected="0x1" onSelect={onSelect} />);
+    const btn = screen.getByRole('button');
+    await userEvent.click(btn);
+    expect(screen.getAllByTestId('item')).toHaveLength(2);
+    await userEvent.click(screen.getAllByTestId('item')[1]);
+    expect(onSelect).toHaveBeenCalledWith('0x2');
+    expect(screen.queryAllByTestId('item')).toHaveLength(0);
+  });
+
+  it('closes on escape and click away', async () => {
+    render(<UserSettingsPrimaryWallet wallets={wallets as any} selected="0x1" onSelect={() => {}} />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(screen.getAllByTestId('item')).toHaveLength(2);
+    escapeCb();
+    await waitFor(() => expect(screen.queryAllByTestId('item')).toHaveLength(0));
+    await userEvent.click(screen.getByRole('button'));
+    clickAway();
+    await waitFor(() => expect(screen.queryAllByTestId('item')).toHaveLength(0));
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for NextGenArtists list
- test MemePageArt display logic
- cover user identity and rep components
- test wallet dropdown interactions

## Testing
- `npx jest __tests__/components/nextGen/collections/NextGenArtists.test.tsx --coverage`
- `npx jest __tests__/components/the-memes/MemePageArt.test.tsx --coverage`
- `npx jest __tests__/components/user/collected/UserPageCollectedFirstLoading.test.tsx --coverage`
- `npx jest __tests__/components/user/identity/UserPageIdentity.test.tsx --coverage`
- `npx jest __tests__/components/user/identity/UserPageIdentityWrapper.test.tsx --coverage`
- `npx jest __tests__/components/user/identity/statements/contacts/UserPageIdentityStatementsContacts.test.tsx --coverage`
- `npx jest __tests__/components/user/identity/statements/social-media-accounts/UserPageIdentityStatementsSocialMediaAccounts.test.tsx --coverage`
- `npx jest __tests__/components/user/identity/statements/utils/UserPageIdentityStatementsStatementsList.test.tsx --coverage`
- `npx jest __tests__/components/user/rep/UserPageRep.test.tsx --coverage`
- `npx jest __tests__/components/user/settings/UserSettingsPrimaryWallet.test.tsx --coverage`
- `npm run improve-coverage`