### PR TITLE
Increase coverage for user components

### DIFF
--- a/__tests__/components/user/collected/filters/UserPageCollectedFiltersSzn.test.tsx
+++ b/__tests__/components/user/collected/filters/UserPageCollectedFiltersSzn.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import UserPageCollectedFiltersSzn from '../../../../../components/user/collected/filters/UserPageCollectedFiltersSzn';
+import { MEMES_SEASON } from '../../../../../enums';
+
+let capturedProps: any = null;
+
+jest.mock('../../../../../components/utils/select/dropdown/CommonDropdown', () => (props: any) => {
+  capturedProps = props;
+  return <div data-testid="dropdown" />;
+});
+
+describe('UserPageCollectedFiltersSzn', () => {
+  beforeEach(() => {
+    capturedProps = null;
+  });
+
+  it('passes items and active selection to dropdown', () => {
+    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    render(
+      <UserPageCollectedFiltersSzn selected={MEMES_SEASON.SZN1} containerRef={ref} setSelected={jest.fn()} />
+    );
+    const values = capturedProps.items.map((i: any) => i.value);
+    expect(values).toEqual([null, ...Object.values(MEMES_SEASON)]);
+    expect(capturedProps.activeItem).toBe(MEMES_SEASON.SZN1);
+    expect(capturedProps.filterLabel).toBe('Season');
+    expect(capturedProps.containerRef).toBe(ref);
+  });
+});

--- a/__tests__/components/user/groups/UserPageGroupsWrapper.test.tsx
+++ b/__tests__/components/user/groups/UserPageGroupsWrapper.test.tsx
@@ -34,7 +34,7 @@ describe('UserPageGroupsWrapper', () => {
 
   it('passes profile from hook when available', () => {
     useRouterMock.mockReturnValue({ query: { user: 'alice' } });
-    const profile = { handle: 'alice' };
+    const profile = { handle: 'alice' } as any;
     useIdentityMock.mockReturnValue({ profile });
     render(<UserPageGroupsWrapper profile={profile} />);
     expect(useIdentityMock).toHaveBeenCalledWith({ handleOrWallet: 'alice', initialProfile: profile });
@@ -44,7 +44,7 @@ describe('UserPageGroupsWrapper', () => {
 
   it('falls back to initial profile when hook returns null', () => {
     useRouterMock.mockReturnValue({ query: { user: 'bob' } });
-    const initialProfile = { handle: 'bob' };
+    const initialProfile = { handle: 'bob' } as any;
     useIdentityMock.mockReturnValue({ profile: null });
     render(<UserPageGroupsWrapper profile={initialProfile} />);
     expect(capturedWrapperProfile).toBe(initialProfile);

--- a/__tests__/components/user/identity/statements/UserPageIdentityStatementsSocialMediaVerificationPosts.test.tsx
+++ b/__tests__/components/user/identity/statements/UserPageIdentityStatementsSocialMediaVerificationPosts.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import UserPageIdentityStatementsSocialMediaVerificationPosts from '../../../../../components/user/identity/statements/social-media-verification-posts/UserPageIdentityStatementsSocialMediaVerificationPosts';
+import { CicStatement } from '../../../../../entities/IProfile';
+import { ApiIdentity } from '../../../../../generated/models/ApiIdentity';
+
+let capturedProps: any = null;
+
+jest.mock('../../../../../components/user/identity/statements/utils/UserPageIdentityStatementsStatementsList', () => (props: any) => {
+  capturedProps = props;
+  return <div data-testid="list" />;
+});
+
+describe('UserPageIdentityStatementsSocialMediaVerificationPosts', () => {
+  it('forwards props to statements list', () => {
+    const statements: CicStatement[] = [{ statement_value: 'a' }] as any;
+    const profile: ApiIdentity = { handle: 'bob' } as any;
+    render(
+      <UserPageIdentityStatementsSocialMediaVerificationPosts statements={statements} profile={profile} loading={true} />
+    );
+    expect(capturedProps.statements).toBe(statements);
+    expect(capturedProps.profile).toBe(profile);
+    expect(capturedProps.loading).toBe(true);
+    expect(capturedProps.noItemsMessage).toMatch('No Social Media Verification Post added yet');
+    expect(screen.getByTestId('list')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/user/settings/UserSettingsPrimaryWalletItem.test.tsx
+++ b/__tests__/components/user/settings/UserSettingsPrimaryWalletItem.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserSettingsPrimaryWalletItem from '../../../../components/user/settings/UserSettingsPrimaryWalletItem';
+import { ApiWallet } from '../../../../generated/models/ApiWallet';
+
+const wallet: ApiWallet = {
+  wallet: '0xabc',
+  display: '0xabc',
+  tdh: 10,
+} as any;
+
+describe('UserSettingsPrimaryWalletItem', () => {
+  it('displays check icon when selected and handles click', async () => {
+    const onSelect = jest.fn();
+    const { rerender } = render(
+      <UserSettingsPrimaryWalletItem wallet={wallet} selected='0xabc' onSelect={onSelect} />
+    );
+    const item = screen.getByRole('listitem');
+    expect(item.querySelector('svg')).toBeInTheDocument();
+
+    await userEvent.click(item);
+    expect(onSelect).toHaveBeenCalledWith('0xabc');
+
+    rerender(
+      <UserSettingsPrimaryWalletItem wallet={wallet} selected='0xdef' onSelect={onSelect} />
+    );
+    expect(screen.getByRole('listitem').querySelector('svg')).toBeNull();
+  });
+});

--- a/__tests__/components/user/user-page-header/UserPageHeaderAboutEditError.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeaderAboutEditError.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserPageHeaderAboutEditError from '../../../../components/user/user-page-header/about/UserPageHeaderAboutEditError';
+
+describe('UserPageHeaderAboutEditError', () => {
+  it('detects known error types', () => {
+    render(
+      <UserPageHeaderAboutEditError
+        msg="contains personal insults"
+        closeError={jest.fn()}
+      />
+    );
+    expect(screen.getByText('Error: Personal Insults')).toBeInTheDocument();
+  });
+
+  it('handles unknown errors and close click', async () => {
+    const close = jest.fn();
+    render(<UserPageHeaderAboutEditError msg="something" closeError={close} />);
+    expect(screen.getByText('Unknown Error')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button'));
+    expect(close).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/user/user-page-header/UserPageHeaderAboutStatement.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeaderAboutStatement.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import UserPageHeaderAboutStatement from '../../../../components/user/user-page-header/about/UserPageHeaderAboutStatement';
+import { CicStatement } from '../../../../entities/IProfile';
+
+describe('UserPageHeaderAboutStatement', () => {
+  it('shows placeholder when statement is null', () => {
+    render(<UserPageHeaderAboutStatement statement={null} />);
+    expect(screen.getByText('Click to add an About statement')).toBeInTheDocument();
+  });
+
+  it('renders statement value when provided', () => {
+    const statement: CicStatement = { statement_value: 'Hello there' } as any;
+    render(<UserPageHeaderAboutStatement statement={statement} />);
+    expect(screen.getByText('Hello there')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add test for UserSettingsPrimaryWalletItem
- add tests for user page header about components
- add test for season filter dropdown
- add test for social media verification posts list
- fix group wrapper tests for type checking

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
