### PR TITLE
Add tests for user utility components

### DIFF
--- a/__tests__/components/user/followers/UserPageFollowers.test.tsx
+++ b/__tests__/components/user/followers/UserPageFollowers.test.tsx
@@ -1,0 +1,45 @@
+import { render } from '@testing-library/react';
+import UserPageFollowers from '../../../../components/user/followers/UserPageFollowers';
+import { ApiIdentity } from '../../../../generated/models/ApiIdentity';
+
+let wrapperProps: any;
+const fetchNextPage = jest.fn();
+
+jest.mock('@tanstack/react-query', () => ({
+  useInfiniteQuery: jest.fn(),
+}));
+
+jest.mock('../../../../components/utils/followers/FollowersListWrapper', () => (props: any) => { wrapperProps = props; return <div data-testid="wrapper" />; });
+
+const { useInfiniteQuery } = require('@tanstack/react-query');
+
+describe('UserPageFollowers', () => {
+  beforeEach(() => {
+    wrapperProps = null;
+    fetchNextPage.mockReset();
+  });
+
+  function renderComponent(count: number) {
+    (useInfiniteQuery as jest.Mock).mockReturnValue({
+      data: { pages: [{ data: Array.from({ length: count }) }] },
+      fetchNextPage,
+      hasNextPage: true,
+      isFetching: false,
+      isFetchingNextPage: false,
+      status: 'success',
+    });
+    render(<UserPageFollowers profile={{ id: '1' } as ApiIdentity} />);
+  }
+
+  it('fetches next page when bottom reached with enough followers', () => {
+    renderComponent(100);
+    wrapperProps.onBottomIntersection(true);
+    expect(fetchNextPage).toHaveBeenCalled();
+  });
+
+  it('does not fetch next page when not enough followers', () => {
+    renderComponent(1);
+    wrapperProps.onBottomIntersection(true);
+    expect(fetchNextPage).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/user/user-page-header/name/classification/UserPageClassificationWrapper.test.tsx
+++ b/__tests__/components/user/user-page-header/name/classification/UserPageClassificationWrapper.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserPageClassificationWrapper from '../../../../../../components/user/user-page-header/name/classification/UserPageClassificationWrapper';
+
+jest.mock('../../../../../../components/utils/icons/PencilIcon', () => ({
+  __esModule: true,
+  PencilIconSize: { SMALL: 'SMALL' },
+  default: () => <span data-testid="pencil" />,
+}));
+
+jest.mock('../../../../../../components/user/user-page-header/name/classification/UserPageHeaderEditClassification', () => (props: any) => (
+  <div data-testid="edit" onClick={props.onClose} />
+));
+
+jest.mock('../../../../../../components/utils/animation/CommonAnimationWrapper', () => ({ children }: any) => <div>{children}</div>);
+
+jest.mock('../../../../../../components/utils/animation/CommonAnimationOpacity', () => ({ children, onClicked }: any) => (
+  <div data-testid="opacity" onClick={onClicked}>{children}</div>
+));
+
+describe('UserPageClassificationWrapper', () => {
+  it('opens and closes edit modal when button clicked', async () => {
+    render(
+      <UserPageClassificationWrapper profile={{} as any} canEdit={true}>
+        <span data-testid="child" />
+      </UserPageClassificationWrapper>
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+    expect(screen.getByTestId('edit')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('edit'));
+    expect(screen.queryByTestId('edit')).toBeNull();
+  });
+});

--- a/__tests__/components/user/utils/set-up-profile/UserPageSetUpProfileWrapper.test.tsx
+++ b/__tests__/components/user/utils/set-up-profile/UserPageSetUpProfileWrapper.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import UserPageSetUpProfileWrapper from '../../../../../components/user/utils/set-up-profile/UserPageSetUpProfileWrapper';
+import { ApiIdentity } from '../../../../../generated/models/ApiIdentity';
+import { ApiProfileClassification } from '../../../../../generated/models/ApiProfileClassification';
+
+jest.mock('../../../../../components/user/utils/set-up-profile/UserPageSetUpProfile', () => ({
+  __esModule: true,
+  default: () => <div data-testid="setup" />,
+}));
+
+jest.mock('../../../../../components/auth/SeizeConnectContext', () => ({
+  useSeizeConnectContext: jest.fn(),
+}));
+
+const { useSeizeConnectContext } = require('../../../../../components/auth/SeizeConnectContext');
+
+describe('UserPageSetUpProfileWrapper', () => {
+  const baseProfile: ApiIdentity = {
+    id: '1',
+    handle: null,
+    normalised_handle: null,
+    pfp: null,
+    cic: 0,
+    rep: 0,
+    level: 0,
+    tdh: 0,
+    consolidation_key: '',
+    display: '',
+    primary_wallet: '',
+    banner1: null,
+    banner2: null,
+    classification: ApiProfileClassification.Bot,
+    sub_classification: null,
+    wallets: [{ wallet: '0xabc', display: '0xabc', tdh: 0 }],
+  } as any;
+
+  it('shows setup component when connected wallet matches and handle missing', () => {
+    (useSeizeConnectContext as jest.Mock).mockReturnValue({ address: '0xabc' });
+    render(
+      <UserPageSetUpProfileWrapper profile={baseProfile}>
+        <div data-testid="child" />
+      </UserPageSetUpProfileWrapper>
+    );
+    expect(screen.getByTestId('setup')).toBeInTheDocument();
+  });
+
+  it('shows children when no wallet match', () => {
+    (useSeizeConnectContext as jest.Mock).mockReturnValue({ address: '0xdef' });
+    render(
+      <UserPageSetUpProfileWrapper profile={baseProfile}>
+        <div data-testid="child" />
+      </UserPageSetUpProfileWrapper>
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltipHeaders.test.tsx
+++ b/__tests__/components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltipHeaders.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import UserCICTypeIconTooltipHeaders from '../../../../../../components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltipHeaders';
+
+describe('UserCICTypeIconTooltipHeaders', () => {
+  it('displays tooltip header text', () => {
+    render(<UserCICTypeIconTooltipHeaders />);
+    expect(screen.getByText('Community ID Check')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Does the community believe this profile/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltipRate.test.tsx
+++ b/__tests__/components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltipRate.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { ApiIdentity } from '../../../../../../generated/models/ApiIdentity';
+import { ApiProfileClassification } from '../../../../../../generated/models/ApiProfileClassification';
+import UserCICTypeIconTooltipRate from '../../../../../../components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltipRate';
+
+jest.mock('../../../../../../components/user/utils/rate/UserPageRateWrapper', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div data-testid="wrapper">{children}</div>,
+}));
+
+jest.mock('../../../../../../components/user/identity/header/cic-rate/UserPageIdentityHeaderCICRate', () => ({
+  __esModule: true,
+  default: () => <div data-testid="rate" />,
+}));
+
+describe('UserCICTypeIconTooltipRate', () => {
+  const profile: ApiIdentity = {
+    id: '1',
+    handle: null,
+    normalised_handle: null,
+    pfp: null,
+    cic: 0,
+    rep: 0,
+    level: 0,
+    tdh: 0,
+    consolidation_key: '',
+    display: '',
+    primary_wallet: '',
+    banner1: null,
+    banner2: null,
+    classification: ApiProfileClassification.Bot,
+    sub_classification: null,
+  } as any;
+
+  it('renders cic rate inside wrapper', () => {
+    render(<UserCICTypeIconTooltipRate profile={profile} />);
+    expect(screen.getByTestId('wrapper')).toBeInTheDocument();
+    expect(screen.getByTestId('rate')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/utils/icons/ClockIcon.test.tsx
+++ b/__tests__/components/utils/icons/ClockIcon.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@testing-library/react';
+import ClockIcon from '../../../../components/utils/icons/ClockIcon';
+
+describe('ClockIcon', () => {
+  it('renders svg with viewBox and class', () => {
+    const { container } = render(<ClockIcon className="text-blue" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+    expect(svg).toHaveClass('text-blue');
+    const paths = container.querySelectorAll('path');
+    expect(paths.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for ClockIcon
- test tooltip header and rate components for CIC type
- cover profile setup wrapper logic
- test classification wrapper interactions
- ensure followers pagination triggers correctly

## Testing
- `npx jest __tests__/components/utils/icons/ClockIcon.test.tsx --coverage`
- `npx jest __tests__/components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltipHeaders.test.tsx --coverage`
- `npx jest __tests__/components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltipRate.test.tsx --coverage`
- `npx jest __tests__/components/user/utils/set-up-profile/UserPageSetUpProfileWrapper.test.tsx --coverage`
- `npx jest __tests__/components/user/user-page-header/name/classification/UserPageClassificationWrapper.test.tsx --coverage`
- `npx jest __tests__/components/user/followers/UserPageFollowers.test.tsx --coverage`
