### PR TITLE
Add missing tests for wave components

### DIFF
--- a/__tests__/components/user/utils/user-cic-type/UserCICTypeIcon.test.tsx
+++ b/__tests__/components/user/utils/user-cic-type/UserCICTypeIcon.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import UserCICTypeIcon from '../../../../../components/user/utils/user-cic-type/UserCICTypeIcon';
+
+jest.mock('../../../../../components/user/utils/user-cic-type/icons/UserCICInaccurateIcon', () => () => <div data-testid="inaccurate" />);
+jest.mock('../../../../../components/user/utils/user-cic-type/icons/UserCICUnknownIcon', () => () => <div data-testid="unknown" />);
+jest.mock('../../../../../components/user/utils/user-cic-type/icons/UserCICProbablyAccurateIcon', () => () => <div data-testid="probably" />);
+jest.mock('../../../../../components/user/utils/user-cic-type/icons/UserCICAccurateIcon', () => () => <div data-testid="accurate" />);
+jest.mock('../../../../../components/user/utils/user-cic-type/icons/UserCICHighlyAccurateIcon', () => () => <div data-testid="highly" />);
+
+describe('UserCICTypeIcon', () => {
+  it('renders inaccurate icon for negative CIC', () => {
+    render(<UserCICTypeIcon cic={-30} />);
+    expect(screen.getByTestId('inaccurate')).toBeInTheDocument();
+  });
+
+  it('renders probably accurate icon for mid CIC', () => {
+    render(<UserCICTypeIcon cic={1500} />);
+    expect(screen.getByTestId('probably')).toBeInTheDocument();
+  });
+
+  it('renders highly accurate icon for high CIC', () => {
+    render(<UserCICTypeIcon cic={30000} />);
+    expect(screen.getByTestId('highly')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltip.test.tsx
+++ b/__tests__/components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltip.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import UserCICTypeIconTooltip from '../../../../../../components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltip';
+import { CICType } from '../../../../../entities/IProfile';
+import { ApiIdentity } from '../../../../../generated/models/ApiIdentity';
+
+jest.mock('../../../../../../components/user/utils/user-cic-type/UserCICTypeIcon', () => () => <div data-testid="icon" />);
+jest.mock('../../../../../../components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltipHeaders', () => () => <div data-testid="headers" />);
+jest.mock('../../../../../../components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltipRate', () => ({ profile }: any) => <div data-testid="rate">{profile.handle}</div>);
+
+jest.mock('../../../../../../helpers/Helpers', () => ({
+  amIUser: jest.fn(),
+  cicToType: jest.fn().mockReturnValue('INACCURATE'),
+  formatNumberWithCommas: (v: number) => String(v),
+}));
+
+jest.mock('../../../../../../components/react-query-wrapper/ReactQueryWrapper', () => ({ QueryKey: {} }));
+
+jest.mock('../../../../../../services/api/common-api', () => ({ commonApiFetch: jest.fn() }));
+
+jest.mock('../../../../../../components/auth/SeizeConnectContext', () => ({ useSeizeConnectContext: () => ({ address: '0x1' }) }));
+
+jest.mock('@tanstack/react-query', () => ({ useQuery: () => ({ data: { count: 2 } }) }));
+
+const { amIUser } = jest.requireMock('../../../../../../helpers/Helpers');
+
+const profile: ApiIdentity = { handle: 'alice', cic: -30 } as any;
+
+describe('UserCICTypeIconTooltip', () => {
+  it('shows rate section when not my profile', () => {
+    amIUser.mockReturnValue(false);
+    render(<UserCICTypeIconTooltip profile={profile} />);
+    expect(screen.getByTestId('headers')).toBeInTheDocument();
+    expect(screen.getByTestId('rate')).toHaveTextContent('alice');
+  });
+
+  it('hides rate section for my profile and shows warning text for inaccurate', () => {
+    amIUser.mockReturnValue(true);
+    render(<UserCICTypeIconTooltip profile={profile} />);
+    expect(screen.queryByTestId('rate')).toBeNull();
+    expect(screen.getByText(/at risk of losing/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/create-wave/outcomes/CreateWaveOutcomeTypesItem.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/CreateWaveOutcomeTypesItem.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveOutcomeTypesItem from '../../../../../components/waves/create-wave/outcomes/CreateWaveOutcomeTypesItem';
+import { CreateWaveOutcomeType } from '../../../../../types/waves.types';
+
+describe('CreateWaveOutcomeTypesItem', () => {
+  it('applies active classes when selected', () => {
+    render(
+      <CreateWaveOutcomeTypesItem
+        outcomeType={CreateWaveOutcomeType.MANUAL}
+        label="Manual"
+        selectedOutcomeType={CreateWaveOutcomeType.MANUAL}
+        setOutcomeType={jest.fn()}
+      />
+    );
+    const btn = screen.getByRole('button');
+    expect(btn.className).toContain('tw-ring-primary-400');
+  });
+
+  it('calls setOutcomeType on click', async () => {
+    const user = userEvent.setup();
+    const setOutcomeType = jest.fn();
+    render(
+      <CreateWaveOutcomeTypesItem
+        outcomeType={CreateWaveOutcomeType.REP}
+        label="Rep"
+        selectedOutcomeType={null}
+        setOutcomeType={setOutcomeType}
+      />
+    );
+    await user.click(screen.getByRole('button'));
+    expect(setOutcomeType).toHaveBeenCalledWith(CreateWaveOutcomeType.REP);
+  });
+});

--- a/__tests__/components/waves/create-wave/outcomes/CreateWaveOutcomes.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/CreateWaveOutcomes.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import CreateWaveOutcomes from '../../../../../components/waves/create-wave/outcomes/CreateWaveOutcomes';
+import { CreateWaveOutcomeType } from '../../../../../types/waves.types';
+import { ApiWaveType } from '../../../../../generated/models/ApiWaveType';
+
+jest.mock('../../../../../components/waves/create-wave/outcomes/CreateWaveOutcomeTypes', () => ({
+  __esModule: true,
+  default: () => <div data-testid="types" />,
+}));
+
+jest.mock('../../../../../components/waves/create-wave/outcomes/manual/CreateWaveOutcomesManual', () => ({
+  __esModule: true,
+  default: () => <div data-testid="manual" />,
+}));
+
+jest.mock('../../../../../components/waves/create-wave/outcomes/rep/CreateWaveOutcomesRep', () => ({
+  __esModule: true,
+  default: () => <div data-testid="rep" />,
+}));
+
+jest.mock('../../../../../components/waves/create-wave/outcomes/cic/CreateWaveOutcomesCIC', () => ({
+  __esModule: true,
+  default: () => <div data-testid="cic" />,
+}));
+
+jest.mock('../../../../../components/waves/create-wave/outcomes/winners/rows/CreateWaveOutcomesRows', () => ({
+  __esModule: true,
+  default: () => <div data-testid="rows" />,
+}));
+
+jest.mock('../../../../../components/utils/animation/CommonAnimationHeight', () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+describe('CreateWaveOutcomes', () => {
+  const baseProps = {
+    outcomes: [],
+    outcomeType: null as CreateWaveOutcomeType | null,
+    waveType: ApiWaveType.Approve,
+    errors: [],
+    dates: {} as any,
+    setOutcomeType: jest.fn(),
+    setOutcomes: jest.fn(),
+  };
+
+  it('shows rows list when no outcome type selected', () => {
+    render(<CreateWaveOutcomes {...baseProps} />);
+    expect(screen.getByTestId('rows')).toBeInTheDocument();
+  });
+
+  it('renders manual component when selected', () => {
+    render(<CreateWaveOutcomes {...baseProps} outcomeType={CreateWaveOutcomeType.MANUAL} />);
+    expect(screen.getByTestId('manual')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/create-wave/outcomes/winners/rows/cic/CreateWaveOutcomesRowCICApprove.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/winners/rows/cic/CreateWaveOutcomesRowCICApprove.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveOutcomesRowCICApprove from '../../../../../../../../components/waves/create-wave/outcomes/winners/rows/cic/CreateWaveOutcomesRowCICApprove';
+
+const outcome = { credit: 1000, maxWinners: 2 } as any;
+
+describe('CreateWaveOutcomesRowCICApprove', () => {
+  it('displays formatted credit and max winners', () => {
+    render(<CreateWaveOutcomesRowCICApprove outcome={outcome} removeOutcome={jest.fn()} />);
+    expect(screen.getByText('1.0k NIC')).toBeInTheDocument();
+    expect(screen.getByText(/Max winners: 2/)).toBeInTheDocument();
+  });
+
+  it('renders remove button', () => {
+    render(<CreateWaveOutcomesRowCICApprove outcome={outcome} removeOutcome={jest.fn()} />);
+    expect(screen.getByLabelText('Remove')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/create-wave/outcomes/winners/rows/manual/CreateWaveOutcomesRowManualRank.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/winners/rows/manual/CreateWaveOutcomesRowManualRank.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveOutcomesRowManualRank from '../../../../../../../../components/waves/create-wave/outcomes/winners/rows/manual/CreateWaveOutcomesRowManualRank';
+
+const outcome = { title: 'Winner' } as any;
+
+describe('CreateWaveOutcomesRowManualRank', () => {
+  it('shows outcome title', () => {
+    render(<CreateWaveOutcomesRowManualRank outcome={outcome} removeOutcome={jest.fn()} />);
+    expect(screen.getByText('Winner')).toBeInTheDocument();
+  });
+
+  it('calls removeOutcome on click', async () => {
+    const user = userEvent.setup();
+    const removeOutcome = jest.fn();
+    render(<CreateWaveOutcomesRowManualRank outcome={outcome} removeOutcome={removeOutcome} />);
+    await user.click(screen.getByLabelText('Remove'));
+    expect(removeOutcome).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/waves/create-wave/outcomes/winners/rows/rep/CreateWaveOutcomesRowRep.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/winners/rows/rep/CreateWaveOutcomesRowRep.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import CreateWaveOutcomesRowRep from '../../../../../../../../components/waves/create-wave/outcomes/winners/rows/rep/CreateWaveOutcomesRowRep';
+import { ApiWaveType } from '../../../../../../../../generated/models/ApiWaveType';
+
+jest.mock('../../../../../../../../components/waves/create-wave/outcomes/winners/rows/rep/CreateWaveOutcomesRowRepApprove', () => ({
+  __esModule: true,
+  default: () => <div data-testid="approve" />,
+}));
+
+jest.mock('../../../../../../../../components/waves/create-wave/outcomes/winners/rows/rep/CreateWaveOutcomesRowRepRank', () => ({
+  __esModule: true,
+  default: () => <div data-testid="rank" />,
+}));
+
+describe('CreateWaveOutcomesRowRep', () => {
+  const outcome = {} as any;
+  const removeOutcome = jest.fn();
+  it('renders approve component for approve wave', () => {
+    render(<CreateWaveOutcomesRowRep waveType={ApiWaveType.Approve} outcome={outcome} removeOutcome={removeOutcome} />);
+    expect(screen.getByTestId('approve')).toBeInTheDocument();
+  });
+
+  it('renders rank component for rank wave', () => {
+    render(<CreateWaveOutcomesRowRep waveType={ApiWaveType.Rank} outcome={outcome} removeOutcome={removeOutcome} />);
+    expect(screen.getByTestId('rank')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/create-wave/services/waveDecisionService.test.ts
+++ b/__tests__/components/waves/create-wave/services/waveDecisionService.test.ts
@@ -1,0 +1,46 @@
+import {
+  calculateDecisionTimes,
+  calculateEndDate,
+  validateDateSequence,
+  adjustDatesAfterSubmissionChange,
+  formatDate,
+  countTotalDecisions,
+  calculateEndDateForCycles,
+} from '../../../../../components/waves/create-wave/services/waveDecisionService';
+
+describe('waveDecisionService', () => {
+  it('calculates decision times list', () => {
+    expect(calculateDecisionTimes(10, [5, 5])).toEqual([10, 15, 20]);
+  });
+
+  it('calculates end date for non rolling', () => {
+    const dates = { firstDecisionTime: 10, subsequentDecisions: [5, 5], isRolling: false } as any;
+    expect(calculateEndDate(dates)).toBe(20);
+  });
+
+  it('validates date sequence', () => {
+    const errs = validateDateSequence({ submissionStartDate: 5, votingStartDate: 4, firstDecisionTime: 3, isRolling: false, subsequentDecisions: [], endDate: null } as any);
+    expect(errs).toContain('Voting start date must be after submission start date');
+    expect(errs).toContain('First decision time must be after voting start date');
+  });
+
+  it('adjusts dates after submission change', () => {
+    const result = adjustDatesAfterSubmissionChange({ submissionStartDate: 1, votingStartDate: 2, firstDecisionTime: 3 } as any, 5);
+    expect(result.votingStartDate).toBe(5);
+    expect(result.firstDecisionTime).toBe(5);
+  });
+
+  it('formats date', () => {
+    const ts = Date.UTC(2020, 0, 1, 12, 0, 0);
+    expect(formatDate(ts)).toMatch(/Jan/);
+  });
+
+  it('counts total decisions in rolling mode', () => {
+    const total = countTotalDecisions(0, [10, 20], 80);
+    expect(total).toBe(6);
+  });
+
+  it('calculates end date for cycles', () => {
+    expect(calculateEndDateForCycles(0, [10, 20], 2)).toBe(60);
+  });
+});

--- a/__tests__/components/waves/create-wave/utils/CreateWaveWarning.test.tsx
+++ b/__tests__/components/waves/create-wave/utils/CreateWaveWarning.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import CreateWaveWarning from '../../../../../components/waves/create-wave/utils/CreateWaveWarning';
+
+describe('CreateWaveWarning', () => {
+  it('renders provided title and description', () => {
+    render(<CreateWaveWarning title="Heads up" description="Be careful" />);
+    expect(screen.getByText('Heads up')).toBeInTheDocument();
+    expect(screen.getByText('Be careful')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/create-wave/voting/CreateWaveVotingRep.test.tsx
+++ b/__tests__/components/waves/create-wave/voting/CreateWaveVotingRep.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import CreateWaveVotingRep from '../../../../../components/waves/create-wave/voting/CreateWaveVotingRep';
+import { CREATE_WAVE_VALIDATION_ERROR } from '../../../../../helpers/waves/create-wave.validation';
+
+jest.mock('../../../../../components/utils/input/identity/IdentitySearch', () => ({
+  __esModule: true,
+  default: (props: any) => <div data-testid="identity" data-error={props.error} />,
+}));
+
+jest.mock('../../../../../components/utils/input/rep-category/RepCategorySearch', () => ({
+  __esModule: true,
+  default: (props: any) => <div data-testid="category" data-error={props.error} />,
+}));
+
+describe('CreateWaveVotingRep', () => {
+  const baseProps = {
+    category: null,
+    profileId: null,
+    errors: [] as CREATE_WAVE_VALIDATION_ERROR[],
+    setCategory: jest.fn(),
+    setProfileId: jest.fn(),
+  };
+
+  it('passes error props based on errors array', () => {
+    render(<CreateWaveVotingRep {...baseProps} errors={[CREATE_WAVE_VALIDATION_ERROR.VOTING_CATEGORY_CANNOT_BE_EMPTY, CREATE_WAVE_VALIDATION_ERROR.VOTING_PROFILE_ID_CANNOT_BE_EMPTY]} />);
+    expect(screen.getByTestId('category').getAttribute('data-error')).toBe('true');
+    expect(screen.getByTestId('identity').getAttribute('data-error')).toBe('true');
+  });
+
+  it('does not set error when array empty', () => {
+    render(<CreateWaveVotingRep {...baseProps} />);
+    expect(screen.getByTestId('category').getAttribute('data-error')).toBe('false');
+    expect(screen.getByTestId('identity').getAttribute('data-error')).toBe('false');
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for CIC type icon components and tooltip
- test outcome selection helpers
- cover wave service calculations and warning component
- add tests for create wave voting and winners rows

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`