### PR TITLE
Add tests for wave outcome components

### DIFF
--- a/__tests__/components/waves/create-wave/outcomes/winners/CreateWaveOutcomesWinnersRows.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/winners/CreateWaveOutcomesWinnersRows.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveOutcomesWinnersRows from '../../../../../../components/waves/create-wave/outcomes/winners/CreateWaveOutcomesWinnersRows';
+import { CreateWaveOutcomeConfigWinner, CreateWaveOutcomeConfigWinnersCreditValueType, CreateWaveOutcomeType } from '../../../../../../types/waves.types';
+
+const sampleWinners: CreateWaveOutcomeConfigWinner[] = [{ value: 1 }, { value: 2 }];
+
+function setup(props: Partial<{winners: CreateWaveOutcomeConfigWinner[]}> = {}) {
+  const setWinners = jest.fn();
+  const winners = props.winners ?? [...sampleWinners];
+  render(
+    <CreateWaveOutcomesWinnersRows
+      creditValueType={CreateWaveOutcomeConfigWinnersCreditValueType.ABSOLUTE_VALUE}
+      winners={winners}
+      isError={false}
+      outcomeType={CreateWaveOutcomeType.REP}
+      setWinners={setWinners}
+    />
+  );
+  return { setWinners, winners };
+}
+
+describe('CreateWaveOutcomesWinnersRows', () => {
+  it('updates winner value on input change', async () => {
+    const user = userEvent.setup();
+    const { setWinners, winners } = setup();
+    const inputs = screen.getAllByRole('textbox');
+    await user.clear(inputs[0]);
+    await user.type(inputs[0], '5');
+    expect(setWinners).toHaveBeenCalled();
+  });
+
+  it('removes winner when remove button clicked', async () => {
+    const user = userEvent.setup();
+    const { setWinners } = setup();
+    const removeButtons = screen.getAllByRole('button', { name: /remove/i });
+    await user.click(removeButtons[0]);
+    expect(setWinners).toHaveBeenCalledWith([{ value: 2 }]);
+  });
+});

--- a/__tests__/components/waves/create-wave/outcomes/winners/rows/CreateWaveOutcomesRows.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/winners/rows/CreateWaveOutcomesRows.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveOutcomesRows from '../../../../../../../components/waves/create-wave/outcomes/winners/rows/CreateWaveOutcomesRows';
+import { ApiWaveType } from '../../../../../../../generated/models/ApiWaveType';
+import { CREATE_WAVE_VALIDATION_ERROR } from '../../../../../../../helpers/waves/create-wave.validation';
+import { CreateWaveOutcomeConfig, CreateWaveOutcomeType } from '../../../../../../../types/waves.types';
+
+jest.mock('../../../../../../../components/waves/create-wave/outcomes/winners/rows/CreateWaveOutcomesRow', () => {
+  return function MockRow(props: any) {
+    return (
+      <div data-testid="row">
+        <button onClick={props.removeOutcome}>remove</button>
+      </div>
+    );
+  };
+});
+
+const sampleOutcomes: CreateWaveOutcomeConfig[] = [
+  { type: CreateWaveOutcomeType.REP, title: 'a', credit: null, category: null, maxWinners: null, winnersConfig: null },
+  { type: CreateWaveOutcomeType.NIC, title: 'b', credit: null, category: null, maxWinners: null, winnersConfig: null },
+];
+
+function setup(overrides: Partial<{ outcomes: CreateWaveOutcomeConfig[]; errors: CREATE_WAVE_VALIDATION_ERROR[] }> = {}) {
+  const setOutcomes = jest.fn();
+  const outcomes = overrides.outcomes ?? [...sampleOutcomes];
+  const errors = overrides.errors ?? [];
+  render(
+    <CreateWaveOutcomesRows
+      waveType={ApiWaveType.Rank}
+      errors={errors}
+      outcomes={outcomes}
+      setOutcomes={setOutcomes}
+    />
+  );
+  return { setOutcomes, outcomes };
+}
+
+describe('CreateWaveOutcomesRows', () => {
+  it('renders no outcomes message with optional error styling', () => {
+    setup({ outcomes: [], errors: [CREATE_WAVE_VALIDATION_ERROR.OUTCOMES_REQUIRED] });
+    const msg = screen.getByText('No outcomes added');
+    expect(msg).toHaveClass('tw-text-error');
+  });
+
+  it('removes outcome when child triggers remove', async () => {
+    const user = userEvent.setup();
+    const { setOutcomes, outcomes } = setup();
+    const buttons = screen.getAllByText('remove');
+    await user.click(buttons[0]);
+    expect(setOutcomes).toHaveBeenCalledWith([outcomes[1]]);
+  });
+});

--- a/__tests__/components/waves/create-wave/outcomes/winners/rows/manual/CreateWaveOutcomesRowManualApprove.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/winners/rows/manual/CreateWaveOutcomesRowManualApprove.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveOutcomesRowManualApprove from '../../../../../../../../components/waves/create-wave/outcomes/winners/rows/manual/CreateWaveOutcomesRowManualApprove';
+import { CreateWaveOutcomeConfig } from '../../../../../../../../types/waves.types';
+
+jest.mock('@tippyjs/react', () => ({ __esModule: true, default: ({ children }: any) => <div>{children}</div> }));
+
+jest.mock('../../../../../../../../helpers/Helpers', () => ({
+  formatLargeNumber: (n: number) => `formatted-${n}`,
+}));
+
+describe('CreateWaveOutcomesRowManualApprove', () => {
+  const outcome: CreateWaveOutcomeConfig = {
+    type: 0 as any,
+    title: 'Winner',
+    credit: null,
+    category: null,
+    maxWinners: 3,
+    winnersConfig: null,
+  };
+
+  it('displays formatted max winners and title', () => {
+    render(<CreateWaveOutcomesRowManualApprove outcome={outcome} removeOutcome={jest.fn()} />);
+    expect(screen.getByText('Max winners: formatted-3')).toBeInTheDocument();
+    expect(screen.getByText('Winner')).toBeInTheDocument();
+  });
+
+  it('calls removeOutcome on button click', async () => {
+    const user = userEvent.setup();
+    const remove = jest.fn();
+    render(<CreateWaveOutcomesRowManualApprove outcome={outcome} removeOutcome={remove} />);
+    await user.click(screen.getByRole('button', { name: /remove/i }));
+    expect(remove).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/waves/leaderboard/sidebar/WaveLeaderboardRightSidebarVoter.test.tsx
+++ b/__tests__/components/waves/leaderboard/sidebar/WaveLeaderboardRightSidebarVoter.test.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import { WaveLeaderboardRightSidebarVoter } from '../../../../../components/waves/leaderboard/sidebar/WaveLeaderboardRightSidebarVoter';
+import { ApiWaveCreditType } from '../../../../../generated/models/ApiWaveCreditType';
+
+const baseVoter = {
+  voter: { handle: 'alice', pfp: '' },
+  positive_votes_summed: 2,
+  negative_votes_summed: 0,
+  absolute_votes_summed: 2,
+};
+
+describe('WaveLeaderboardRightSidebarVoter', () => {
+  it('shows positive indicator when positive votes exist', () => {
+    const { container } = render(
+      <WaveLeaderboardRightSidebarVoter voter={baseVoter as any} position={1} creditType={ApiWaveCreditType.Rep} />
+    );
+    expect(container.querySelectorAll('.tw-bg-green').length).toBe(1);
+    expect(container.querySelectorAll('.tw-bg-red').length).toBe(0);
+  });
+
+  it('shows negative indicator when negative votes exist', () => {
+    const voter = { ...baseVoter, negative_votes_summed: 1 };
+    const { container } = render(
+      <WaveLeaderboardRightSidebarVoter voter={voter as any} position={1} creditType={ApiWaveCreditType.Rep} />
+    );
+    expect(container.querySelectorAll('.tw-bg-red').length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for CreateWaveOutcomesWinnersRows
- add tests for CreateWaveOutcomesRows
- add tests for manual approve row component
- add test for leaderboard voter component

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
