### PR TITLE
Increase test coverage

### DIFF
--- a/__tests__/components/nextGen/collections/NextGenArtists.test.tsx
+++ b/__tests__/components/nextGen/collections/NextGenArtists.test.tsx
@@ -8,6 +8,7 @@ jest.mock('../../../../services/6529api', () => ({ fetchUrl: jest.fn() }));
 const MockArtist = jest.fn(() => <div data-testid="artist" />);
 jest.mock('../../../../components/nextGen/collections/collectionParts/NextGenCollectionArtist', () => ({
   __esModule: true,
+  // @ts-ignore
   default: (props: any) => MockArtist(props),
 }));
 

--- a/__tests__/components/user/identity/UserPageIdentityWrapper.test.tsx
+++ b/__tests__/components/user/identity/UserPageIdentityWrapper.test.tsx
@@ -20,7 +20,7 @@ describe('UserPageIdentityWrapper', () => {
 
   it('uses profile from hook when available', () => {
     routerMock.mockReturnValue({ query: { user: 'alice' } });
-    const profile = { handle: 'alice' };
+    const profile = { handle: 'alice' } as any;
     useIdentityMock.mockReturnValue({ profile });
     render(
       <UserPageIdentityWrapper
@@ -37,7 +37,7 @@ describe('UserPageIdentityWrapper', () => {
 
   it('falls back to initial profile when hook returns null', () => {
     routerMock.mockReturnValue({ query: { user: 'bob' } });
-    const profile = { handle: 'bob' };
+    const profile = { handle: 'bob' } as any;
     useIdentityMock.mockReturnValue({ profile: null });
     render(
       <UserPageIdentityWrapper

--- a/__tests__/components/user/subscriptions/UserPageSubscriptionsMode.test.tsx
+++ b/__tests__/components/user/subscriptions/UserPageSubscriptionsMode.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import UserPageSubscriptionsMode from '../../../../components/user/subscriptions/UserPageSubscriptionsMode';
+import { AuthContext } from '../../../../components/auth/Auth';
+import { commonApiPost } from '../../../../services/api/common-api';
+
+jest.mock('../../../../services/api/common-api', () => ({
+  commonApiPost: jest.fn(),
+}));
+
+jest.mock('../../../../components/dotLoader/DotLoader', () => ({ Spinner: () => <span data-testid="spinner" /> }));
+
+describe('UserPageSubscriptionsMode', () => {
+  const requestAuth = jest.fn();
+  const setToast = jest.fn();
+  const refresh = jest.fn();
+
+  const renderComponent = (auto = false) =>
+    render(
+      <AuthContext.Provider value={{ requestAuth, setToast } as any}>
+        <UserPageSubscriptionsMode
+          profileKey="p1"
+          details={{
+            automatic: auto,
+            consolidation_key: '',
+            last_update: 0,
+            balance: 0,
+          }}
+          readonly={false}
+          refresh={refresh}
+        />
+      </AuthContext.Provider>
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (commonApiPost as jest.Mock).mockResolvedValue({ automatic: true });
+    requestAuth.mockResolvedValue({ success: true });
+  });
+
+  it('initializes toggle state from props', () => {
+    renderComponent(true);
+    const toggle = screen.getByRole('checkbox');
+    expect(toggle).toBeChecked();
+  });
+
+  it('toggles subscription mode on click', async () => {
+    renderComponent(false);
+    const toggle = screen.getByRole('checkbox');
+    fireEvent.click(toggle);
+    expect(requestAuth).toHaveBeenCalled();
+    await screen.findByRole('checkbox');
+    expect(commonApiPost).toHaveBeenCalledWith({
+      endpoint: 'subscriptions/p1/subscription-mode',
+      body: { automatic: true },
+    });
+    expect(setToast).toHaveBeenCalled();
+    expect(refresh).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/user/utils/set-up-profile/UserPageSetUpProfileHeader.test.tsx
+++ b/__tests__/components/user/utils/set-up-profile/UserPageSetUpProfileHeader.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import UserPageSetUpProfileHeader from '../../../../../components/user/utils/set-up-profile/UserPageSetUpProfileHeader';
+
+describe('UserPageSetUpProfileHeader', () => {
+  it('renders the setup header text', () => {
+    render(<UserPageSetUpProfileHeader />);
+    expect(
+      screen.getByText('Set up your profile in 30 seconds or less')
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltip.test.tsx
+++ b/__tests__/components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltip.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import UserCICTypeIconTooltip from '../../../../../../components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltip';
-import { CICType } from '../../../../../entities/IProfile';
-import { ApiIdentity } from '../../../../../generated/models/ApiIdentity';
+import { CICType } from '../../../../../../entities/IProfile';
+import { ApiIdentity } from '../../../../../../generated/models/ApiIdentity';
 
 jest.mock('../../../../../../components/user/utils/user-cic-type/UserCICTypeIcon', () => () => <div data-testid="icon" />);
 jest.mock('../../../../../../components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltipHeaders', () => () => <div data-testid="headers" />);


### PR DESCRIPTION
## Summary
- add tests for UserPageSubscriptionsMode state transitions
- add tests for UserPageSetUpProfileHeader rendering
- fix type-check errors in existing tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
