### PR TITLE
Add tests for additional user utilities

### DIFF
--- a/__tests__/components/user/UserLevel.test.tsx
+++ b/__tests__/components/user/UserLevel.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserLevel from '../../../components/user/utils/level/UserLevel';
+
+describe('UserLevel', () => {
+  it('applies color and size classes', () => {
+    const { container } = render(<UserLevel level={50} size="sm" />);
+    expect(container.firstChild).toHaveClass('tw-text-[#DAC660]');
+    expect(container.firstChild).toHaveClass('tw-text-sm');
+  });
+
+  it('opens levels page in new tab when clicked', async () => {
+    const open = jest.spyOn(window, 'open').mockImplementation();
+    render(<UserLevel level={10} />);
+    await userEvent.click(screen.getByRole('button'));
+    expect(open).toHaveBeenCalledWith('/network/levels', '_blank');
+    open.mockRestore();
+  });
+});

--- a/__tests__/components/user/UserPageWavesSearch.test.tsx
+++ b/__tests__/components/user/UserPageWavesSearch.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserPageWavesSearch from '../../../components/user/waves/UserPageWavesSearch';
+
+jest.mock('../../../components/utils/button/PrimaryButton', () => ({
+  __esModule: true,
+  default: ({ onClicked, children }: any) => (
+    <button data-testid="primary" onClick={onClicked}>{children}</button>
+  ),
+}));
+
+describe('UserPageWavesSearch', () => {
+  it('updates wave name on input change', async () => {
+    const setWaveName = jest.fn();
+    render(
+      <UserPageWavesSearch
+        waveName={''}
+        showCreateNewWaveButton={false}
+        setWaveName={setWaveName}
+        onCreateNewWave={jest.fn()}
+      />
+    );
+
+    await userEvent.type(screen.getByRole('textbox'), 'test');
+    expect(setWaveName).toHaveBeenCalled();
+    expect(setWaveName.mock.calls[setWaveName.mock.calls.length - 1][0]).toBe('t');
+  });
+
+  it('clears wave name when clear icon clicked', async () => {
+    const setWaveName = jest.fn();
+    render(
+      <UserPageWavesSearch
+        waveName={'abc'}
+        showCreateNewWaveButton={false}
+        setWaveName={setWaveName}
+        onCreateNewWave={jest.fn()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Clear wave name' }));
+    expect(setWaveName).toHaveBeenLastCalledWith(null);
+  });
+
+  it('calls onCreateNewWave when button clicked', async () => {
+    const onCreateNewWave = jest.fn();
+    render(
+      <UserPageWavesSearch
+        waveName={null}
+        showCreateNewWaveButton={true}
+        setWaveName={jest.fn()}
+        onCreateNewWave={onCreateNewWave}
+      />
+    );
+
+    await userEvent.click(screen.getByTestId('primary'));
+    expect(onCreateNewWave).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/utils/NewVersionToast.test.tsx
+++ b/__tests__/components/utils/NewVersionToast.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NewVersionToast from '../../../components/utils/NewVersionToast';
+import { useIsStale } from '../../../hooks/useVersion';
+import { useRouter } from 'next/router';
+import useDeviceInfo from '../../../hooks/useDeviceInfo';
+
+jest.mock('../../../hooks/useVersion', () => ({ useIsStale: jest.fn() }));
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../../hooks/useDeviceInfo', () => ({ __esModule: true, default: jest.fn() }));
+
+const mockedUseIsStale = useIsStale as jest.Mock;
+const mockedUseRouter = useRouter as jest.Mock;
+const mockedUseDeviceInfo = useDeviceInfo as jest.Mock;
+
+describe('NewVersionToast', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns null when not stale', () => {
+    mockedUseIsStale.mockReturnValue(false);
+    mockedUseRouter.mockReturnValue({ reload: jest.fn() });
+    mockedUseDeviceInfo.mockReturnValue({ isApp: false });
+    const { container } = render(<NewVersionToast />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders toast and reloads on click', async () => {
+    const reload = jest.fn();
+    mockedUseIsStale.mockReturnValue(true);
+    mockedUseRouter.mockReturnValue({ reload });
+    mockedUseDeviceInfo.mockReturnValue({ isApp: true });
+
+    const { container } = render(<NewVersionToast />);
+    expect(screen.getByText(/new version/i)).toBeInTheDocument();
+    expect(container.firstChild).toHaveClass('tw-bottom-24');
+    await userEvent.click(screen.getByRole('button'));
+    expect(reload).toHaveBeenCalled();
+  });
+
+  it('uses bottom-6 class when not in app', () => {
+    mockedUseIsStale.mockReturnValue(true);
+    mockedUseRouter.mockReturnValue({ reload: jest.fn() });
+    mockedUseDeviceInfo.mockReturnValue({ isApp: false });
+
+    const { container } = render(<NewVersionToast />);
+    expect(container.firstChild).toHaveClass('tw-bottom-6');
+  });
+});


### PR DESCRIPTION
## Summary
- add a test suite for `NewVersionToast`
- add a test suite for `UserPageWavesSearch`
- add a test suite for `UserLevel`

## Testing
- `npx jest __tests__/components/user/UserPageWavesSearch.test.tsx --coverage`
- `npx jest __tests__/components/user/UserLevel.test.tsx --coverage`
- `npx jest __tests__/components/utils/NewVersionToast.test.tsx --coverage`
- `npm run improve-coverage`