### PR TITLE
Add tests for infinite scroll and wave metadata UI

### DIFF
--- a/__tests__/components/nextGen/collections/NextGenArtists.test.tsx
+++ b/__tests__/components/nextGen/collections/NextGenArtists.test.tsx
@@ -5,7 +5,7 @@ import { fetchUrl } from '../../../../services/6529api';
 
 jest.mock('../../../../services/6529api', () => ({ fetchUrl: jest.fn() }));
 
-const MockArtist = jest.fn(() => <div data-testid="artist" />);
+const MockArtist = jest.fn((props: any) => <div data-testid="artist" />);
 jest.mock('../../../../components/nextGen/collections/collectionParts/NextGenCollectionArtist', () => ({
   __esModule: true,
   default: (props: any) => MockArtist(props),

--- a/__tests__/components/user/identity/UserPageIdentityWrapper.test.tsx
+++ b/__tests__/components/user/identity/UserPageIdentityWrapper.test.tsx
@@ -20,7 +20,7 @@ describe('UserPageIdentityWrapper', () => {
 
   it('uses profile from hook when available', () => {
     routerMock.mockReturnValue({ query: { user: 'alice' } });
-    const profile = { handle: 'alice' };
+    const profile: any = { handle: 'alice' };
     useIdentityMock.mockReturnValue({ profile });
     render(
       <UserPageIdentityWrapper
@@ -37,7 +37,7 @@ describe('UserPageIdentityWrapper', () => {
 
   it('falls back to initial profile when hook returns null', () => {
     routerMock.mockReturnValue({ query: { user: 'bob' } });
-    const profile = { handle: 'bob' };
+    const profile: any = { handle: 'bob' };
     useIdentityMock.mockReturnValue({ profile: null });
     render(
       <UserPageIdentityWrapper

--- a/__tests__/components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltip.test.tsx
+++ b/__tests__/components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltip.test.tsx
@@ -1,7 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import UserCICTypeIconTooltip from '../../../../../../components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltip';
-import { CICType } from '../../../../../entities/IProfile';
-import { ApiIdentity } from '../../../../../generated/models/ApiIdentity';
 
 jest.mock('../../../../../../components/user/utils/user-cic-type/UserCICTypeIcon', () => () => <div data-testid="icon" />);
 jest.mock('../../../../../../components/user/utils/user-cic-type/tooltip/UserCICTypeIconTooltipHeaders', () => () => <div data-testid="headers" />);
@@ -23,7 +21,7 @@ jest.mock('@tanstack/react-query', () => ({ useQuery: () => ({ data: { count: 2 
 
 const { amIUser } = jest.requireMock('../../../../../../helpers/Helpers');
 
-const profile: ApiIdentity = { handle: 'alice', cic: -30 } as any;
+const profile: any = { handle: 'alice', cic: -30 };
 
 describe('UserCICTypeIconTooltip', () => {
   it('shows rate section when not my profile', () => {

--- a/__tests__/components/utils/infinite-scroll/CommonInfiniteScrollWrapper.test.tsx
+++ b/__tests__/components/utils/infinite-scroll/CommonInfiniteScrollWrapper.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import CommonInfiniteScrollWrapper from '../../../../components/utils/infinite-scroll/CommonInfiniteScrollWrapper';
+import userEvent from '@testing-library/user-event';
+
+const Trigger = jest.fn((props: any) => <button onClick={() => props.onIntersection(true)}>trigger</button>);
+const Loader = () => <div data-testid="loader" />;
+
+jest.mock('../../../../components/utils/infinite-scroll/InfiniteScrollTrigger', () => ({ __esModule: true, default: (props: any) => Trigger(props) }));
+jest.mock('../../../../components/distribution-plan-tool/common/CircleLoader', () => ({ __esModule: true, default: () => Loader(), CircleLoaderSize: { MEDIUM: 'MEDIUM' } }));
+
+describe('CommonInfiniteScrollWrapper', () => {
+  it('shows loader when loading', () => {
+    render(
+      <CommonInfiniteScrollWrapper loading={true} onBottomIntersection={jest.fn()}>
+        <div>child</div>
+      </CommonInfiniteScrollWrapper>
+    );
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+  });
+
+  it('calls onBottomIntersection when trigger fires', async () => {
+    const cb = jest.fn();
+    render(
+      <CommonInfiniteScrollWrapper loading={false} onBottomIntersection={cb}>
+        <div>child</div>
+      </CommonInfiniteScrollWrapper>
+    );
+    await userEvent.click(screen.getByText('trigger'));
+    expect(cb).toHaveBeenCalledWith(true);
+  });
+});

--- a/__tests__/components/utils/infinite-scroll/InfiniteScrollTrigger.test.tsx
+++ b/__tests__/components/utils/infinite-scroll/InfiniteScrollTrigger.test.tsx
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/react';
+import { waitFor } from '@testing-library/react';
+import InfiniteScrollTrigger from '../../../../components/utils/infinite-scroll/InfiniteScrollTrigger';
+
+const onIntersection = jest.fn();
+const useIntersectionMock = jest.fn();
+
+jest.mock('react-use', () => ({
+  useIntersection: (...args: any[]) => useIntersectionMock(...args)
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('InfiniteScrollTrigger', () => {
+  it('calls onIntersection with false when not intersecting', async () => {
+    useIntersectionMock.mockReturnValue({ isIntersecting: false });
+    render(<InfiniteScrollTrigger onIntersection={onIntersection} />);
+    await waitFor(() => {
+      expect(onIntersection).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it('calls onIntersection with true when intersecting', async () => {
+    useIntersectionMock.mockReturnValue({ isIntersecting: true });
+    render(<InfiniteScrollTrigger onIntersection={onIntersection} />);
+    await waitFor(() => {
+      expect(onIntersection).toHaveBeenCalledWith(true);
+    });
+  });
+});

--- a/__tests__/components/waves/create-wave/drops/metadata/CreateWaveDropsMetadataAddRowButton.test.tsx
+++ b/__tests__/components/waves/create-wave/drops/metadata/CreateWaveDropsMetadataAddRowButton.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveDropsMetadataAddRowButton from '../../../../../../components/waves/create-wave/drops/metadata/CreateWaveDropsMetadataAddRowButton';
+
+describe('CreateWaveDropsMetadataAddRowButton', () => {
+  it('renders "Add" when no items and calls handler', async () => {
+    const cb = jest.fn();
+    render(<CreateWaveDropsMetadataAddRowButton itemsCount={0} onAddNewRow={cb} />);
+    expect(screen.getByText('Add')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button'));
+    expect(cb).toHaveBeenCalled();
+  });
+
+  it('renders "Add more" when items exist', () => {
+    const cb = jest.fn();
+    render(<CreateWaveDropsMetadataAddRowButton itemsCount={2} onAddNewRow={cb} />);
+    expect(screen.getByText('Add more')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/create-wave/drops/metadata/CreateWaveDropsMetadataRowType.test.tsx
+++ b/__tests__/components/waves/create-wave/drops/metadata/CreateWaveDropsMetadataRowType.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveDropsMetadataRowType from '../../../../../../components/waves/create-wave/drops/metadata/CreateWaveDropsMetadataRowType';
+import { ApiWaveMetadataType } from '../../../../../../generated/models/ApiWaveMetadataType';
+
+describe('CreateWaveDropsMetadataRowType', () => {
+  it('calls onTypeChange when buttons clicked', async () => {
+    const cb = jest.fn();
+    render(<CreateWaveDropsMetadataRowType activeType={ApiWaveMetadataType.String} onTypeChange={cb} />);
+    await userEvent.click(screen.getByTitle('Number'));
+    expect(cb).toHaveBeenCalledWith(ApiWaveMetadataType.Number);
+  });
+
+  it('applies active classes based on activeType', () => {
+    render(<CreateWaveDropsMetadataRowType activeType={ApiWaveMetadataType.Number} onTypeChange={jest.fn()} />);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons[1].className).toContain('tw-ring-primary-400');
+    expect(buttons[0].className).not.toContain('tw-ring-primary-400');
+  });
+});


### PR DESCRIPTION
## Summary
- test InfiniteScrollTrigger intersection handling
- test CommonInfiniteScrollWrapper loader and trigger behaviour
- test CreateWaveDropsMetadata components
- adjust existing tests for type-check compliance

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
