### PR TITLE
Increase coverage with additional tests

### DIFF
--- a/__tests__/components/CompactTimeCountdown.test.tsx
+++ b/__tests__/components/CompactTimeCountdown.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { CompactTimeCountdown } from '../../components/waves/leaderboard/time/CompactTimeCountdown';
+
+const baseTime = { days: 0, hours: 1, minutes: 2, seconds: 3 };
+
+describe('CompactTimeCountdown', () => {
+  it('renders hours, minutes and seconds', () => {
+    render(<CompactTimeCountdown timeLeft={baseTime} />);
+    expect(screen.queryByText('days')).not.toBeInTheDocument();
+    expect(screen.getByText('hrs')).toBeInTheDocument();
+    expect(screen.getByText('min')).toBeInTheDocument();
+    expect(screen.getByText('sec')).toBeInTheDocument();
+  });
+
+  it('includes days when value greater than zero', () => {
+    render(<CompactTimeCountdown timeLeft={{ ...baseTime, days: 1 }} />);
+    expect(screen.getByText('days')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/WaveSmallLeaderboardDrop.test.tsx
+++ b/__tests__/components/WaveSmallLeaderboardDrop.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+jest.mock('../../components/waves/small-leaderboard/MemesWaveSmallLeaderboardDrop', () => ({
+  MemesWaveSmallLeaderboardDrop: () => <div>memes</div>,
+}));
+jest.mock('../../components/waves/small-leaderboard/DefaultWaveSmallLeaderboardDrop', () => ({
+  DefaultWaveSmallLeaderboardDrop: () => <div>default</div>,
+}));
+jest.mock('../../hooks/useWave', () => ({ useWave: jest.fn() }));
+
+const { useWave } = require('../../hooks/useWave');
+
+const { WaveSmallLeaderboardDrop } = require('../../components/waves/small-leaderboard/WaveSmallLeaderboardDrop');
+
+describe('WaveSmallLeaderboardDrop', () => {
+  const drop = {} as any;
+  const wave = {} as any;
+  const onDropClick = jest.fn();
+
+  it('renders Memes component when wave is memes', () => {
+    useWave.mockReturnValue({ isMemesWave: true });
+    render(<WaveSmallLeaderboardDrop drop={drop} wave={wave} onDropClick={onDropClick} />);
+    expect(screen.getByText('memes')).toBeInTheDocument();
+  });
+
+  it('renders Default component when wave is not memes', () => {
+    useWave.mockReturnValue({ isMemesWave: false });
+    render(<WaveSmallLeaderboardDrop drop={drop} wave={wave} onDropClick={onDropClick} />);
+    expect(screen.getByText('default')).toBeInTheDocument();
+  });
+});

--- a/__tests__/hooks/useVersion.test.tsx
+++ b/__tests__/hooks/useVersion.test.tsx
@@ -1,0 +1,37 @@
+import { render, act } from '@testing-library/react';
+
+const ORIGINAL_ENV_VERSION = process.env.VERSION;
+
+describe('useIsStale', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    (global as any).fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    process.env.VERSION = ORIGINAL_ENV_VERSION;
+  });
+
+  function TestComponent({ interval }: { interval?: number }) {
+    const { useIsStale } = require('../../hooks/useVersion');
+    const stale = useIsStale(interval);
+    return <span>{stale ? 'stale' : 'fresh'}</span>;
+  }
+
+  it('shows fresh when versions match', async () => {
+    process.env.VERSION = '1.0.0';
+    (global.fetch as jest.Mock).mockResolvedValue({ json: async () => ({ version: '1.0.0' }) });
+    const { findByText } = render(<TestComponent interval={1000} />);
+    await act(async () => { jest.runOnlyPendingTimers(); });
+    expect(await findByText('fresh')).toBeInTheDocument();
+  });
+
+  it('shows stale when versions differ', async () => {
+    process.env.VERSION = '1.0.0';
+    (global.fetch as jest.Mock).mockResolvedValue({ json: async () => ({ version: '2.0.0' }) });
+    const { findByText } = render(<TestComponent interval={1000} />);
+    await act(async () => { jest.runOnlyPendingTimers(); });
+    expect(await findByText('stale')).toBeInTheDocument();
+  });
+});

--- a/__tests__/pages/document.test.tsx
+++ b/__tests__/pages/document.test.tsx
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+jest.mock('next/document', () => ({
+  Html: (props: any) => <html {...props} />,
+  Head: (props: any) => <head {...props} />,
+  Main: () => <main />,
+  NextScript: () => <script />,
+}));
+
+import Document from '../../pages/_document';
+
+describe('Document', () => {
+  it('renders meta version and preconnect links', () => {
+    process.env.VERSION = 'test-version';
+    render(<Document />);
+    const meta = document.head.querySelector('meta[name="version"]');
+    expect(meta).toHaveAttribute('content', 'test-version');
+    const links = document.head.querySelectorAll('link[rel="preconnect"]');
+    expect(links.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `useVersion` hook
- cover `WaveSmallLeaderboardDrop` logic
- check countdown and document page behaviors

## Testing
- `npx jest __tests__/hooks/useVersion.test.tsx --coverage --silent`
- `npx jest __tests__/components/WaveSmallLeaderboardDrop.test.tsx --coverage --silent`
- `npx jest __tests__/components/CompactTimeCountdown.test.tsx --coverage --silent`
- `npx jest __tests__/pages/document.test.tsx --coverage --silent`
- `npm run lint`
- `npm run type-check`
