### PR TITLE
Increase coverage for pages

### DIFF
--- a/__tests__/pages/acceptConnectionSharing.test.tsx
+++ b/__tests__/pages/acceptConnectionSharing.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import AcceptConnectionSharing, { getServerSideProps } from '../../pages/accept-connection-sharing';
+import { AuthContext } from '../../components/auth/Auth';
+import { useSeizeConnectContext } from '../../components/auth/SeizeConnectContext';
+import { useRouter } from 'next/router';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../components/auth/SeizeConnectContext', () => ({
+  useSeizeConnectContext: jest.fn(),
+}));
+
+const TestProvider: React.FC = ({ children }) => (
+  <AuthContext.Provider value={{ setTitle: jest.fn(), setToast: jest.fn() } as any}>
+    {children}
+  </AuthContext.Provider>
+);
+
+describe('AcceptConnectionSharing page', () => {
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({ push: jest.fn() });
+    (useSeizeConnectContext as jest.Mock).mockReturnValue({
+      address: undefined,
+      seizeDisconnectAndLogout: jest.fn(),
+      seizeAcceptConnection: jest.fn(),
+    });
+  });
+
+  it('shows missing parameters message when token or address missing', () => {
+    render(
+      <TestProvider>
+        <AcceptConnectionSharing pageProps={{ token: '', address: '' }} />
+      </TestProvider>
+    );
+    expect(screen.getByText(/Missing required parameters/)).toBeInTheDocument();
+  });
+
+  it('includes provided token and address in the page', () => {
+    render(
+      <TestProvider>
+        <AcceptConnectionSharing pageProps={{ token: 'abc12345', address: '0x123' }} />
+      </TestProvider>
+    );
+    expect(screen.getByText(/Incoming Connection/)).toBeInTheDocument();
+    expect(screen.getByText(/0x123/)).toBeInTheDocument();
+  });
+
+  it('getServerSideProps returns props from query', async () => {
+    const result = await getServerSideProps({ query: { token: 't', address: 'a', role: 'r' } } as any, null as any, null as any);
+    expect(result).toEqual({ props: { token: 't', address: 'a', role: 'r' } });
+  });
+});

--- a/__tests__/pages/consolidationMappingTool.test.tsx
+++ b/__tests__/pages/consolidationMappingTool.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import ConsolidationMappingToolPage from '../../pages/consolidation-mapping-tool';
+import { AuthContext } from '../../components/auth/Auth';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+const TestProvider: React.FC = ({ children }) => (
+  <AuthContext.Provider value={{ setTitle: jest.fn() } as any}>{children}</AuthContext.Provider>
+);
+
+describe('ConsolidationMappingTool page', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve('<p>hello</p>'),
+    }) as any;
+  });
+
+  it('renders fetched html content', async () => {
+    render(
+      <TestProvider>
+        <ConsolidationMappingToolPage />
+      </TestProvider>
+    );
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(screen.getByText('Overview')).toBeInTheDocument();
+    await waitFor(() => {
+      const container = document.querySelector('#how-to-use .htmlContainer') as HTMLElement;
+      expect(container.innerHTML).toContain('hello');
+    });
+  });
+});

--- a/__tests__/pages/restricted.test.tsx
+++ b/__tests__/pages/restricted.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import Restricted from '../../pages/restricted';
+import { AuthContext } from '../../components/auth/Auth';
+import { useRouter } from 'next/router';
+import { getStagingAuth } from '../../services/auth/auth.utils';
+
+jest.mock('next/image', () => (props: any) => <img {...props} />);
+jest.mock('../../pages/access', () => ({ LoginImage: (p: any) => <img {...p} /> }));
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../services/auth/auth.utils', () => ({ getStagingAuth: jest.fn() }));
+
+const TestProvider: React.FC = ({ children }) => (
+  <AuthContext.Provider value={{ setTitle: jest.fn() } as any}>{children}</AuthContext.Provider>
+);
+
+describe('Restricted page', () => {
+  beforeEach(() => {
+    (useRouter as jest.Mock).mockReturnValue({ isReady: true });
+    (getStagingAuth as jest.Mock).mockReturnValue('token');
+  });
+
+  it('shows restricted message when response status 403', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 403,
+      json: () => Promise.resolve({ image: 'img', country: 'US' }),
+    }) as any;
+    render(
+      <TestProvider>
+        <Restricted />
+      </TestProvider>
+    );
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(await screen.findByDisplayValue(/restricted/)).toBeInTheDocument();
+  });
+
+  it('shows go message when allowed', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 200,
+      json: () => Promise.resolve({ image: 'img' }),
+    }) as any;
+    render(
+      <TestProvider>
+        <Restricted />
+      </TestProvider>
+    );
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(await screen.findByDisplayValue('Go to 6529.io')).toBeInTheDocument();
+  });
+});

--- a/__tests__/pages/staticPages.test.tsx
+++ b/__tests__/pages/staticPages.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import AboutRules from '../../pages/about/rules';
+import CasaBatllo from '../../pages/casabatllo';
+import Museum from '../../pages/museum';
+import ElementColumns from '../../pages/element_category/columns';
+import MemeLabDistribution from '../../pages/meme-lab/[id]/distribution';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+describe('static pages render', () => {
+  it('renders about rules page', () => {
+    render(<AboutRules />);
+    expect(screen.getAllByText(/6529 FAM RULES/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders casa batllo page', () => {
+    render(<CasaBatllo />);
+    expect(screen.getAllByText(/CASA BATLLO/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders museum page', () => {
+    render(<Museum />);
+    expect(screen.getAllByText(/MUSEUM OF ART/i).length).toBeGreaterThan(0);
+  });
+
+  it('element columns page redirects', () => {
+    render(<ElementColumns />);
+    expect(screen.getByText(/You are being redirected/i)).toBeInTheDocument();
+  });
+
+  it('meme lab distribution page loads', () => {
+    render(<MemeLabDistribution />);
+    expect(screen.getByTestId('dynamic')).toBeInTheDocument();
+  });
+});

--- a/__tests__/pages/userPages.test.tsx
+++ b/__tests__/pages/userPages.test.tsx
@@ -1,0 +1,38 @@
+import { getServerSideProps as getUserProps } from '../../pages/[user]/index';
+import { getServerSideProps as getProxyProps } from '../../pages/[user]/proxy/index';
+import { getCommonHeaders, getUserProfile, userPageNeedsRedirect } from '../../helpers/server.helpers';
+import { getMetadataForUserPage } from '../../helpers/Helpers';
+
+jest.mock('../../helpers/server.helpers');
+jest.mock('../../helpers/Helpers');
+
+const mockProfile = { handle: 'alice' } as any;
+
+(getMetadataForUserPage as jest.Mock).mockReturnValue('meta');
+
+(getCommonHeaders as jest.Mock).mockReturnValue({ head: '1' });
+(getUserProfile as jest.Mock).mockResolvedValue(mockProfile);
+
+describe('user pages getServerSideProps', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redirects when helper returns redirect object', async () => {
+    (userPageNeedsRedirect as jest.Mock).mockReturnValue({ redirect: 'yes' });
+    const result = await getUserProps({ query: { user: 'bob' } } as any, null as any, null as any);
+    expect(result).toEqual({ redirect: 'yes' });
+  });
+
+  it('returns props when no redirect needed', async () => {
+    (userPageNeedsRedirect as jest.Mock).mockReturnValue(false);
+    const result = await getUserProps({ query: { user: 'bob' } } as any, null as any, null as any);
+    expect(result).toEqual({ props: { profile: mockProfile, metadata: 'meta' } });
+  });
+
+  it('proxy page returns props', async () => {
+    (userPageNeedsRedirect as jest.Mock).mockReturnValue(false);
+    const result = await getProxyProps({ query: { user: 'bob' } } as any, null as any, null as any);
+    expect(result).toEqual({ props: { profile: mockProfile, metadata: 'meta' } });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for AcceptConnectionSharing page and server-side props
- add tests for Consolidation Mapping Tool page
- add tests for Restricted page behavior
- add tests for server-side logic of user pages
- add smoke tests for several static pages

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
