### PR TITLE
Improve coverage

### DIFF
--- a/__tests__/components/user/utils/user-cic-type/icons/UserCICIcons.test.tsx
+++ b/__tests__/components/user/utils/user-cic-type/icons/UserCICIcons.test.tsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react';
+import UserCICInaccurateIcon from '../../../../../../components/user/utils/user-cic-type/icons/UserCICInaccurateIcon';
+import UserCICUnknownIcon from '../../../../../../components/user/utils/user-cic-type/icons/UserCICUnknownIcon';
+
+describe('User CIC Icons', () => {
+  it('renders the inaccurate icon svg correctly', () => {
+    const { container } = render(<UserCICInaccurateIcon />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('viewBox', '0 0 187 187');
+    expect(container.querySelectorAll('path').length).toBeGreaterThan(0);
+  });
+
+  it('renders the unknown icon svg correctly', () => {
+    const { container } = render(<UserCICUnknownIcon />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('viewBox', '0 0 183 183');
+    expect(container.querySelectorAll('path').length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for User CIC icon components

## Testing
- `npx jest __tests__/components/user/utils/user-cic-type/icons/UserCICIcons.test.tsx --coverage`
- `npm run lint`
- `npm run type-check`
- `npm run test`
