### PR TITLE
Add unit tests for wave creation components

### DIFF
--- a/__tests__/components/user/subscriptions/UserPageSubscriptionsBalance.test.tsx
+++ b/__tests__/components/user/subscriptions/UserPageSubscriptionsBalance.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserPageSubscriptionsBalance from '../../../../components/user/subscriptions/UserPageSubscriptionsBalance';
+
+jest.mock('../../../../components/dotLoader/DotLoader', () => ({
+  __esModule: true,
+  default: () => <div>Loading...</div>,
+  Spinner: () => <div>Spinner</div>,
+}));
+
+describe('UserPageSubscriptionsBalance', () => {
+  it('shows loader when fetching', () => {
+    render(
+      <UserPageSubscriptionsBalance
+        details={undefined}
+        show_refresh={false}
+        fetching={true}
+        refresh={jest.fn()}
+      />
+    );
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('calls refresh when icon clicked', async () => {
+    const user = userEvent.setup();
+    const refresh = jest.fn();
+    render(
+      <UserPageSubscriptionsBalance
+        details={{ balance: 2 } as any}
+        show_refresh={true}
+        fetching={false}
+        refresh={refresh}
+      />
+    );
+    await user.click(screen.getByLabelText('Refresh balance'));
+    expect(refresh).toHaveBeenCalled();
+    expect(screen.getByText((t) => t.includes('cards'))).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/user/utils/set-up-profile/UserPageSetUpProfile.test.tsx
+++ b/__tests__/components/user/utils/set-up-profile/UserPageSetUpProfile.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserPageSetUpProfile from '../../../../../components/user/utils/set-up-profile/UserPageSetUpProfile';
+import { AuthContext } from '../../../../../components/auth/Auth';
+import { ReactQueryWrapperContext } from '../../../../../components/react-query-wrapper/ReactQueryWrapper';
+
+jest.mock('../../../../../components/user/utils/set-up-profile/UserPageSetUpProfileHeader', () => () => <div data-testid="header" />);
+jest.mock('../../../../../components/user/settings/UserSettingsUsername', () => (props: any) => (
+  <button
+    data-testid="username"
+    onClick={() => {
+      props.setUserName('newname');
+      props.setIsAvailable(true);
+      props.setIsLoading(false);
+    }}
+  >
+    username
+  </button>
+));
+jest.mock('../../../../../components/user/settings/UserSettingsClassification', () => () => <div data-testid="classification" />);
+jest.mock('../../../../../components/user/settings/UserSettingsPrimaryWallet', () => () => <div data-testid="primary-wallet" />);
+jest.mock('../../../../../components/user/settings/UserSettingsSave', () => (props: any) => (
+  <button data-testid="save" disabled={props.disabled}>save</button>
+));
+jest.mock('../../../../../services/api/common-api', () => ({
+  commonApiPost: jest.fn(() => Promise.resolve({ handle: 'newname' })),
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ pathname: '/[user]', replace: jest.fn() }),
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  useMutation: () => ({ mutateAsync: jest.fn() }),
+}));
+
+describe('UserPageSetUpProfile', () => {
+  const profile: any = {
+    handle: 'user',
+    wallets: [
+      { wallet: '0x1', tdh: 1 },
+      { wallet: '0x2', tdh: 0 },
+    ],
+    primary_wallet: '0x1',
+  };
+
+  it('renders primary wallet selector when multiple wallets', () => {
+    render(
+      <AuthContext.Provider value={{ requestAuth: jest.fn(), setToast: jest.fn() } as any}>
+        <ReactQueryWrapperContext.Provider value={{ onProfileEdit: jest.fn() } as any}>
+          <UserPageSetUpProfile profile={profile} />
+        </ReactQueryWrapperContext.Provider>
+      </AuthContext.Provider>
+    );
+    expect(screen.getByTestId('primary-wallet')).toBeInTheDocument();
+  });
+
+  it('submits profile update on save', async () => {
+    const user = userEvent.setup();
+    const requestAuth = jest.fn().mockResolvedValue({ success: true });
+    const mutate = jest.fn();
+    jest.spyOn(require('@tanstack/react-query'), 'useMutation').mockReturnValue({ mutateAsync: mutate } as any);
+    render(
+      <AuthContext.Provider value={{ requestAuth, setToast: jest.fn() } as any}>
+        <ReactQueryWrapperContext.Provider value={{ onProfileEdit: jest.fn() } as any}>
+          <UserPageSetUpProfile profile={profile} />
+        </ReactQueryWrapperContext.Provider>
+      </AuthContext.Provider>
+    );
+    await user.click(screen.getByTestId('username'));
+    await user.click(screen.getByTestId('save'));
+    expect(requestAuth).toHaveBeenCalled();
+    expect(mutate).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/waves/create-wave/dates/Decisions.test.tsx
+++ b/__tests__/components/waves/create-wave/dates/Decisions.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Decisions from '../../../../../components/waves/create-wave/dates/Decisions';
+
+jest.mock('../../../../../components/waves/create-wave/dates/DecisionsFirst', () => () => <div data-testid="first" />);
+jest.mock('../../../../../components/waves/create-wave/dates/SubsequentDecisions', () => (props: any) => (
+  <button data-testid="sub" onClick={() => props.setSubsequentDecisions([1])}>add</button>
+));
+jest.mock('../../../../../components/waves/create-wave/services/waveDecisionService', () => ({
+  calculateDecisionTimes: jest.fn(() => [1, 2]),
+  calculateEndDateForCycles: jest.fn(() => 3),
+}));
+jest.mock('../../../../../components/common/DateAccordion', () => (props: any) => <div>{props.children}</div>);
+jest.mock('../../../../../components/common/TooltipIconButton', () => () => <div />);
+jest.mock('../../../../../components/utils/switch/CommonSwitch', () => (props: any) => (
+  <button role="switch" onClick={() => props.setIsOn(!props.isOn)}>{String(props.isOn)}</button>
+));
+
+describe('Decisions', () => {
+  const baseDates = { firstDecisionTime: 1, subsequentDecisions: [], votingStartDate: 0, isRolling: false, endDate: 0 } as any;
+
+  it('updates decisions when subsequent decisions added', async () => {
+    const user = userEvent.setup();
+    const setDates = jest.fn();
+    render(
+      <Decisions
+        dates={baseDates}
+        setDates={setDates}
+        isRollingMode={false}
+        setIsRollingMode={jest.fn()}
+        isExpanded={true}
+        setIsExpanded={jest.fn()}
+        onInteraction={jest.fn()}
+      />
+    );
+    await user.click(screen.getByTestId('sub'));
+    expect(setDates).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/waves/create-wave/drops/metadata/CreateWaveDropsMetadataRow.test.tsx
+++ b/__tests__/components/waves/create-wave/drops/metadata/CreateWaveDropsMetadataRow.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveDropsMetadataRow from '../../../../../../components/waves/create-wave/drops/metadata/CreateWaveDropsMetadataRow';
+import { ApiWaveMetadataType } from '../../../../../../generated/models/ApiWaveMetadataType';
+
+jest.mock('../../../../../../components/waves/create-wave/drops/metadata/CreateWaveDropsMetadataRowType', () => (props: any) => (
+  <div data-testid="type" onClick={() => props.onTypeChange(ApiWaveMetadataType.Number)} />
+));
+
+describe('CreateWaveDropsMetadataRow', () => {
+  it('calls onItemChange when input changes', async () => {
+    const user = userEvent.setup();
+    const onItemChange = jest.fn();
+    const onItemRemove = jest.fn();
+    render(
+      <CreateWaveDropsMetadataRow
+        item={{ key: 'name', type: ApiWaveMetadataType.String }}
+        index={0}
+        isNotUnique={true}
+        onItemChange={onItemChange}
+        onItemRemove={onItemRemove}
+      />
+    );
+    await user.type(screen.getByRole('textbox'), 'a');
+    expect(onItemChange).toHaveBeenCalledWith({ index: 0, key: 'namea', type: ApiWaveMetadataType.String });
+    await user.click(screen.getByTestId('type'));
+    expect(onItemChange).toHaveBeenLastCalledWith(expect.objectContaining({ type: ApiWaveMetadataType.Number }));
+    await user.click(screen.getByRole('button', { name: 'Remove item' }));
+    expect(onItemRemove).toHaveBeenCalledWith(0);
+    expect(screen.getByText('Metadata name must be unique')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/create-wave/groups/CreateWaveGroups.test.tsx
+++ b/__tests__/components/waves/create-wave/groups/CreateWaveGroups.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import CreateWaveGroups from '../../../../../components/waves/create-wave/groups/CreateWaveGroups';
+import { ApiWaveType } from '../../../../../generated/models/ApiWaveType';
+import { CREATE_WAVE_GROUPS } from '../../../../../helpers/waves/waves.constants';
+
+jest.mock('../../../../../components/waves/create-wave/groups/CreateWaveGroup', () => (props: any) => (
+  <div data-testid="group">{props.groupType}</div>
+));
+jest.mock('../../../../../components/waves/create-wave/utils/CreateWaveWarning', () => (props: any) => (
+  <div data-testid="warning">{props.title}</div>
+));
+
+describe('CreateWaveGroups', () => {
+  it('renders groups and warning when restricted', () => {
+    const groups = { admin: '1', canView: '2' } as any;
+    render(
+      <CreateWaveGroups
+        waveType={ApiWaveType.Rank}
+        groups={groups}
+        onGroupSelect={jest.fn()}
+        chatEnabled={false}
+        adminCanDeleteDrops={false}
+        groupsCache={{}} 
+        setChatEnabled={jest.fn()}
+        setDropsAdminCanDelete={jest.fn()}
+      />
+    );
+    expect(screen.getAllByTestId('group')).toHaveLength(CREATE_WAVE_GROUPS[ApiWaveType.Rank].length);
+    expect(screen.getByTestId('warning')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/create-wave/main-steps/CreateWavesMainStep.test.tsx
+++ b/__tests__/components/waves/create-wave/main-steps/CreateWavesMainStep.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWavesMainStep from '../../../../../components/waves/create-wave/main-steps/CreateWavesMainStep';
+import { CreateWaveStep, CreateWaveStepStatus } from '../../../../../types/waves.types';
+
+jest.mock('../../../../../components/waves/create-wave/main-steps/CreateWavesMainStepIcon', () => () => <div data-testid="icon" />);
+jest.mock('../../../../../components/waves/create-wave/main-steps/CreateWavesMainStepConnectionLine', () => () => <div data-testid="line" />);
+
+jest.mock('../../../../../helpers/waves/waves.helpers', () => ({
+  getCreateWaveStepStatus: jest.fn(() => CreateWaveStepStatus.DONE),
+}));
+
+describe('CreateWavesMainStep', () => {
+  it('calls onStep when step is done', async () => {
+    const user = userEvent.setup();
+    const onStep = jest.fn();
+    render(
+      <CreateWavesMainStep
+        isLast={false}
+        label="Step"
+        step={CreateWaveStep.OVERVIEW}
+        stepIndex={0}
+        activeStepIndex={1}
+        onStep={onStep}
+      />
+    );
+    await user.click(screen.getByRole('button'));
+    expect(onStep).toHaveBeenCalledWith(CreateWaveStep.OVERVIEW);
+  });
+
+  it('disables button when not done', () => {
+    const helpers = require('../../../../../helpers/waves/waves.helpers');
+    helpers.getCreateWaveStepStatus.mockReturnValue(CreateWaveStepStatus.ACTIVE);
+    render(
+      <CreateWavesMainStep
+        isLast={false}
+        label="Step"
+        step={CreateWaveStep.OVERVIEW}
+        stepIndex={0}
+        activeStepIndex={0}
+        onStep={jest.fn()}
+      />
+    );
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+});

--- a/__tests__/components/waves/create-wave/outcomes/CreateWaveOutcomeTypes.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/CreateWaveOutcomeTypes.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveOutcomeTypes from '../../../../../components/waves/create-wave/outcomes/CreateWaveOutcomeTypes';
+import { CreateWaveOutcomeType } from '../../../../../types/waves.types';
+
+jest.mock('../../../../../components/waves/create-wave/outcomes/CreateWaveOutcomeTypesItem', () => (props: any) => (
+  <button data-testid="item" onClick={() => props.setOutcomeType(props.outcomeType)}>{props.label}</button>
+));
+
+describe('CreateWaveOutcomeTypes', () => {
+  it('renders all outcome type items and handles click', async () => {
+    const user = userEvent.setup();
+    const setOutcomeType = jest.fn();
+    render(
+      <CreateWaveOutcomeTypes outcomeType={null} setOutcomeType={setOutcomeType} />
+    );
+    const items = screen.getAllByTestId('item');
+    expect(items).toHaveLength(Object.values(CreateWaveOutcomeType).length);
+    await user.click(items[0]);
+    expect(setOutcomeType).toHaveBeenCalledWith(Object.values(CreateWaveOutcomeType)[0]);
+  });
+});

--- a/__tests__/components/waves/create-wave/outcomes/cic/CreateWaveOutcomesCIC.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/cic/CreateWaveOutcomesCIC.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import CreateWaveOutcomesCIC from '../../../../../../components/waves/create-wave/outcomes/cic/CreateWaveOutcomesCIC';
+import { ApiWaveType } from '../../../../../../generated/models/ApiWaveType';
+
+jest.mock('../../../../../../components/waves/create-wave/outcomes/cic/CreateWaveOutcomesCICRank', () => () => <div data-testid="rank" />);
+jest.mock('../../../../../../components/waves/create-wave/outcomes/cic/CreateWaveOutcomesCICApprove', () => () => <div data-testid="approve" />);
+
+describe('CreateWaveOutcomesCIC', () => {
+  it('renders rank component for rank waves', () => {
+    render(
+      <CreateWaveOutcomesCIC waveType={ApiWaveType.Rank} dates={{} as any} onOutcome={jest.fn()} onCancel={jest.fn()} />
+    );
+    expect(screen.getByTestId('rank')).toBeInTheDocument();
+  });
+
+  it('renders approve component for approve waves', () => {
+    render(
+      <CreateWaveOutcomesCIC waveType={ApiWaveType.Approve} dates={{} as any} onOutcome={jest.fn()} onCancel={jest.fn()} />
+    );
+    expect(screen.getByTestId('approve')).toBeInTheDocument();
+  });
+
+  it('renders empty div for chat waves', () => {
+    const { container } = render(
+      <CreateWaveOutcomesCIC waveType={ApiWaveType.Chat} dates={{} as any} onOutcome={jest.fn()} onCancel={jest.fn()} />
+    );
+    expect(container.querySelector('div')).toBeEmptyDOMElement();
+  });
+});

--- a/__tests__/components/waves/create-wave/overview/type/CreateWaveType.test.tsx
+++ b/__tests__/components/waves/create-wave/overview/type/CreateWaveType.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveType from '../../../../../../components/waves/create-wave/overview/type/CreateWaveType';
+import { ApiWaveType } from '../../../../../../generated/models/ApiWaveType';
+
+jest.mock('../../../../../../components/waves/create-wave/overview/type/CreateWaveTypeInputs', () => (props: any) => (
+  <button data-testid="inputs" onClick={() => props.onChange(ApiWaveType.Rank)}>inputs</button>
+));
+
+describe('CreateWaveType', () => {
+  it('renders and handles selection', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<CreateWaveType selected={ApiWaveType.Chat} onChange={onChange} />);
+    await user.click(screen.getByTestId('inputs'));
+    expect(onChange).toHaveBeenCalledWith(ApiWaveType.Rank);
+    expect(screen.getByText('Wave Type')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/create-wave/utils/CreateWaveActions.test.tsx
+++ b/__tests__/components/waves/create-wave/utils/CreateWaveActions.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveActions from '../../../../../components/waves/create-wave/utils/CreateWaveActions';
+import { CreateWaveStep } from '../../../../../types/waves.types';
+
+jest.mock('../../../../../components/waves/create-wave/utils/CreateWaveBackStep', () => (props: any) => (
+  <button data-testid="back" onClick={props.onPreviousStep}>back</button>
+));
+jest.mock('../../../../../components/waves/create-wave/utils/CreateWaveNextStep', () => (props: any) => (
+  <button data-testid="next" onClick={props.onClick} disabled={props.disabled}>next</button>
+));
+
+jest.mock('../../../../../helpers/waves/create-wave.helpers', () => ({
+  getCreateWaveNextStep: jest.fn(() => CreateWaveStep.DATES),
+  getCreateWavePreviousStep: jest.fn(() => CreateWaveStep.OVERVIEW),
+}));
+
+describe('CreateWaveActions', () => {
+  const config: any = { overview: { type: 'Rank' } };
+
+  it('navigates to next step', async () => {
+    const user = userEvent.setup();
+    const setStep = jest.fn();
+    render(
+      <CreateWaveActions
+        config={config}
+        step={CreateWaveStep.GROUPS}
+        submitting={false}
+        setStep={setStep}
+        onComplete={jest.fn()}
+      />
+    );
+    await user.click(screen.getByTestId('next'));
+    expect(setStep).toHaveBeenCalledWith(CreateWaveStep.DATES, 'forward');
+  });
+
+  it('calls onComplete when no next step', async () => {
+    const helpers = require('../../../../../helpers/waves/create-wave.helpers');
+    helpers.getCreateWaveNextStep.mockReturnValue(null);
+    const user = userEvent.setup();
+    const onComplete = jest.fn();
+    render(
+      <CreateWaveActions
+        config={config}
+        step={CreateWaveStep.DESCRIPTION}
+        submitting={false}
+        setStep={jest.fn()}
+        onComplete={onComplete}
+      />
+    );
+    await user.click(screen.getByTestId('next'));
+    expect(onComplete).toHaveBeenCalled();
+  });
+
+  it('renders back step when previous exists', () => {
+    render(
+      <CreateWaveActions
+        config={config}
+        step={CreateWaveStep.GROUPS}
+        submitting={false}
+        setStep={jest.fn()}
+        onComplete={jest.fn()}
+      />
+    );
+    expect(screen.getByTestId('back')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for create wave helpers and user components
- ensure coverage for wave creation actions, types, groups, decisions, etc

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`