### PR TITLE
Add component tests

### DIFF
--- a/__tests__/components/user/collected/cards/UserPageCollectedCard.test.tsx
+++ b/__tests__/components/user/collected/cards/UserPageCollectedCard.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import UserPageCollectedCard from '../../../../../components/user/collected/cards/UserPageCollectedCard';
+import { CollectedCollectionType } from '../../../../../entities/IProfile';
+
+const memeCard = {
+  collection: CollectedCollectionType.MEMES,
+  token_id: 1,
+  token_name: 'Card',
+  img: '/img.png',
+  tdh: 2,
+  rank: 3,
+  seized_count: 1,
+};
+
+describe('UserPageCollectedCard', () => {
+  it('shows data row and seized count for memes', () => {
+    render(<UserPageCollectedCard card={memeCard as any} showDataRow={true} />);
+    expect(screen.getByText('#1')).toBeInTheDocument();
+    expect(screen.getByText('TDH')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('Rank')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('1x')).toBeInTheDocument();
+  });
+
+  it('handles memelab collection', () => {
+    const card = { ...memeCard, collection: CollectedCollectionType.MEMELAB, seized_count: 0 };
+    render(<UserPageCollectedCard card={card as any} showDataRow={true} />);
+    expect(screen.getAllByText('N/A').length).toBe(2);
+  });
+});

--- a/__tests__/components/user/identity/header/UserPageIdentityHeader.test.tsx
+++ b/__tests__/components/user/identity/header/UserPageIdentityHeader.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import UserPageIdentityHeader from '../../../../../components/user/identity/header/UserPageIdentityHeader';
+import { ApiIdentity } from '../../../../../generated/models/ApiIdentity';
+
+jest.mock('../../../../../components/user/identity/header/UserPageIdentityHeaderCIC', () => () => <div data-testid="cic" />);
+jest.mock('../../../../../components/user/utils/rate/UserPageRateWrapper', () => (props: any) => <div data-testid="rate-wrapper">{props.children}</div>);
+jest.mock('../../../../../components/user/identity/header/cic-rate/UserPageIdentityHeaderCICRate', () => () => <div data-testid="cic-rate" />);
+
+const profile = { cic: 1 } as ApiIdentity;
+
+describe('UserPageIdentityHeader', () => {
+  it('renders header and child components', () => {
+    render(<UserPageIdentityHeader profile={profile} />);
+    expect(screen.getByText('Network Identity Check (NIC)')).toBeInTheDocument();
+    expect(screen.getByTestId('cic')).toBeInTheDocument();
+    expect(screen.getByTestId('cic-rate')).toBeInTheDocument();
+    expect(screen.getByTestId('rate-wrapper')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddresses.test.tsx
+++ b/__tests__/components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddresses.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import UserPageIdentityStatementsConsolidatedAddresses from '../../../../../../components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddresses';
+import { AuthContext } from '../../../../../../components/auth/Auth';
+import { ApiIdentity } from '../../../../../../generated/models/ApiIdentity';
+
+jest.mock('../../../../../../components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddressesItem', () => (props: any) => <li data-testid="item">{props.address.wallet}</li>);
+jest.mock('../../../../../../components/user/utils/icons/EthereumIcon', () => () => <div />);
+jest.mock('next/link', () => ({ __esModule: true, default: (props: any) => <a {...props}>{props.children}</a> }));
+jest.mock('@tanstack/react-query', () => ({ useQueries: () => [] }));
+jest.mock('../../../../../../helpers/Helpers', () => ({ amIUser: () => true, formatNumberWithCommasOrDash: (x: number) => String(x) }));
+jest.mock('../../../../../../components/auth/SeizeConnectContext', () => ({ useSeizeConnectContext: () => ({ address: '0x2' }) }));
+
+describe('UserPageIdentityStatementsConsolidatedAddresses', () => {
+  const profile: ApiIdentity = {
+    primary_wallet: null,
+    wallets: [
+      { wallet: '0x1', tdh: 1 } as any,
+      { wallet: '0x2', tdh: 2 } as any,
+    ],
+  } as any;
+
+  it('sorts wallets and sets wallet checker link', () => {
+    render(
+      <AuthContext.Provider value={{ activeProfileProxy: null } as any}>
+        <UserPageIdentityStatementsConsolidatedAddresses profile={profile} />
+      </AuthContext.Provider>
+    );
+    const items = screen.getAllByTestId('item');
+    expect(items[0]).toHaveTextContent('0x2');
+    expect(screen.getByRole('link', { name: 'Wallet Checker' })).toHaveAttribute('href', '/delegation/wallet-checker?address=0x2');
+  });
+});

--- a/__tests__/components/user/rep/UserPageRepActivityLog.test.tsx
+++ b/__tests__/components/user/rep/UserPageRepActivityLog.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import UserPageRepActivityLog from '../../../../components/user/rep/UserPageRepActivityLog';
+
+jest.mock('../../../../components/profile-activity/ProfileActivityLogs', () => (props: any) => (
+  <div data-testid="logs">{JSON.stringify(props.initialParams)}</div>
+));
+jest.mock('../../../../components/profile-activity/ProfileName', () => ({
+  __esModule: true,
+  default: () => <span>ProfileName</span>,
+  ProfileNameType: { POSSESSION: 'POSSESSION' }
+}));
+
+const params = { page: 1 } as any;
+
+describe('UserPageRepActivityLog', () => {
+  it('renders activity log component', () => {
+    render(<UserPageRepActivityLog initialActivityLogParams={params} />);
+    expect(screen.getByText('Rep Activity Log')).toBeInTheDocument();
+    expect(screen.getByTestId('logs')).toHaveTextContent('page');
+  });
+});

--- a/__tests__/components/user/subscriptions/UserPageSubscriptionsHistory.test.tsx
+++ b/__tests__/components/user/subscriptions/UserPageSubscriptionsHistory.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import UserPageSubscriptionsHistory from '../../../../components/user/subscriptions/UserPageSubscriptionsHistory';
+import { Page } from '../../../../helpers/Types';
+
+const page = <T,>(data: T[]): Page<T> => ({ count: data.length, page: 1, next: false, data });
+
+describe('UserPageSubscriptionsHistory', () => {
+  it('renders accordions with entries', () => {
+    render(
+      <UserPageSubscriptionsHistory
+        topups={page([{ hash: 'h', amount: 1, from_wallet: 'a', transaction_date: '2020-01-01' } as any])}
+        redeemed={page([{ transaction: 'tx', token_id: 1, contract: '0x1', address: 'b', balance_after: 1, created_at: '2020-01-01' } as any])}
+        logs={page([{ id: 1, log: 'log', created_at: '2020-01-01' } as any])}
+        setRedeemedPage={() => {}}
+        setTopUpPage={() => {}}
+        setLogsPage={() => {}}
+      />
+    );
+    expect(screen.getByText('Subscription History')).toBeInTheDocument();
+    expect(screen.getByText('Redeemed Subscriptions')).toBeInTheDocument();
+    expect(screen.getByText('Log History')).toBeInTheDocument();
+    expect(screen.getByText('Top Up History')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/utils/icons/CalendarClosedIcon.test.tsx
+++ b/__tests__/components/utils/icons/CalendarClosedIcon.test.tsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import CalendarClosedIcon from '../../../../components/utils/icons/CalendarClosedIcon';
+
+describe('CalendarClosedIcon', () => {
+  it('renders svg paths and forwards className', () => {
+    const { container } = render(<CalendarClosedIcon className="text-red" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+    expect(svg).toHaveClass('text-red');
+    const rect = container.querySelector('rect');
+    const paths = container.querySelectorAll('path');
+    expect(rect).not.toBeNull();
+    expect(paths.length).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/components/waves/create-wave/approval/CreateWaveApproval.test.tsx
+++ b/__tests__/components/waves/create-wave/approval/CreateWaveApproval.test.tsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react';
+import CreateWaveApproval from '../../../../../components/waves/create-wave/approval/CreateWaveApproval';
+import { CREATE_WAVE_VALIDATION_ERROR } from '../../../../../helpers/waves/create-wave.validation';
+
+jest.mock('../../../../../components/waves/create-wave/approval/CreateWaveApprovalThreshold', () => (props: any) => (
+  <div data-testid="threshold" data-error={props.error}></div>
+));
+jest.mock('../../../../../components/waves/create-wave/approval/CreateWaveApprovalThresholdTime', () => (props: any) => (
+  <div data-testid="threshold-time" data-error={props.thresholdTimeError} data-duration-error={props.thresholdDurationError}></div>
+));
+
+describe('CreateWaveApproval', () => {
+  it('forwards error flags to child components', () => {
+    const errors = [
+      CREATE_WAVE_VALIDATION_ERROR.APPROVAL_THRESHOLD_REQUIRED,
+      CREATE_WAVE_VALIDATION_ERROR.APPROVAL_THRESHOLD_TIME_REQUIRED,
+    ];
+    const { getByTestId } = render(
+      <CreateWaveApproval
+        threshold={null}
+        thresholdTimeMs={null}
+        errors={errors}
+        setThreshold={() => {}}
+        setThresholdTimeMs={() => {}}
+      />
+    );
+    expect(getByTestId('threshold')).toHaveAttribute('data-error', 'true');
+    expect(getByTestId('threshold-time')).toHaveAttribute('data-error', 'true');
+    expect(getByTestId('threshold-time')).toHaveAttribute('data-duration-error', 'false');
+  });
+});

--- a/__tests__/components/waves/create-wave/dates/StartDates.test.tsx
+++ b/__tests__/components/waves/create-wave/dates/StartDates.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import StartDates from '../../../../../components/waves/create-wave/dates/StartDates';
+import { ApiWaveType } from '../../../../../generated/models/ApiWaveType';
+import { CreateWaveDatesConfig } from '../../../../../types/waves.types';
+
+jest.mock('../../../../../components/utils/calendar/CommonCalendar', () => (props: any) => (
+  <button onClick={() => props.setSelectedTimestamp(123)}>calendar</button>
+));
+jest.mock('../../../../../components/common/DateAccordion', () => (props: any) => (
+  <div>
+    <div onClick={props.onToggle}>{props.title}</div>
+    {props.isExpanded ? props.children : props.collapsedContent}
+  </div>
+));
+
+const baseDates: CreateWaveDatesConfig = {
+  submissionStartDate: Date.now(),
+  votingStartDate: Date.now(),
+  endDate: null,
+  firstDecisionTime: 0,
+  subsequentDecisions: [],
+  isRolling: false,
+};
+
+describe('StartDates', () => {
+  it('renders both calendars for rank waves', () => {
+    const { container } = render(
+      <StartDates waveType={ApiWaveType.Rank} dates={baseDates} setDates={jest.fn()} isExpanded={true} setIsExpanded={() => {}} />
+    );
+    expect(container.querySelectorAll('button').length).toBe(2);
+  });
+
+  it('calls setDates when calendar clicked', () => {
+    const setDates = jest.fn();
+    render(
+      <StartDates waveType={ApiWaveType.Approve} dates={baseDates} setDates={setDates} isExpanded={true} setIsExpanded={() => {}} />
+    );
+    fireEvent.click(screen.getByText('calendar'));
+    expect(setDates).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/waves/create-wave/drops/terms/CreateWaveTermsOfService.test.tsx
+++ b/__tests__/components/waves/create-wave/drops/terms/CreateWaveTermsOfService.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CreateWaveTermsOfService from '../../../../../../components/waves/create-wave/drops/terms/CreateWaveTermsOfService';
+import { ApiWaveType } from '../../../../../../generated/models/ApiWaveType';
+
+describe('CreateWaveTermsOfService', () => {
+  it('renders toggle and textarea when enabled', () => {
+    const setTerms = jest.fn();
+    render(
+      <CreateWaveTermsOfService
+        waveType={ApiWaveType.Rank}
+        terms="abc"
+        setTerms={setTerms}
+      />
+    );
+    const toggle = screen.getByRole('checkbox');
+    expect(toggle).toBeChecked();
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'xyz' } });
+    expect(setTerms).toHaveBeenCalledWith('xyz');
+  });
+
+  it('does not render for Chat waves', () => {
+    const { container } = render(
+      <CreateWaveTermsOfService waveType={ApiWaveType.Chat} terms={null} setTerms={() => {}} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/__tests__/components/waves/create-wave/drops/types/CreateWaveDropsType.test.tsx
+++ b/__tests__/components/waves/create-wave/drops/types/CreateWaveDropsType.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CreateWaveDropsType from '../../../../../../components/waves/create-wave/drops/types/CreateWaveDropsType';
+import { ExtendedWaveParticipationRequirement } from '../../../../../../components/waves/create-wave/drops/types/CreateWaveDropsTypes';
+
+describe('CreateWaveDropsType', () => {
+  it('calls change handler when clicked', () => {
+    const onChange = jest.fn();
+    render(
+      <CreateWaveDropsType
+        isChecked={false}
+        type={ExtendedWaveParticipationRequirement.IMAGE}
+        onRequiredTypeChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalledWith(ExtendedWaveParticipationRequirement.IMAGE);
+  });
+
+  it('displays label and checked state', () => {
+    const { container } = render(
+      <CreateWaveDropsType
+        isChecked={true}
+        type={ExtendedWaveParticipationRequirement.AUDIO}
+        onRequiredTypeChange={() => {}}
+      />
+    );
+    const checkbox = container.querySelector('input[type="checkbox"]');
+    expect(checkbox).toBeChecked();
+    expect(screen.getByText('Audio')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for CalendarClosedIcon
- test CreateWaveDropsType interactions
- cover CreateWaveTermsOfService component
- verify CreateWaveApproval error props
- test StartDates calendars
- add tests for several UserPage components

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
