### PR TITLE
Add tests for wave config and components

### DIFF
--- a/__tests__/components/waves/create-wave/dates/end-date/CreateWaveDatesEndDateSelectPeriodItem.test.tsx
+++ b/__tests__/components/waves/create-wave/dates/end-date/CreateWaveDatesEndDateSelectPeriodItem.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveDatesEndDateSelectPeriodItem from '../../../../../../components/waves/create-wave/dates/end-date/CreateWaveDatesEndDateSelectPeriodItem';
+import { Period } from '../../../../../../helpers/Types';
+
+describe('CreateWaveDatesEndDateSelectPeriodItem', () => {
+  it('calls onPeriodSelect when clicked', async () => {
+    const onSelect = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <CreateWaveDatesEndDateSelectPeriodItem
+        period={Period.DAYS}
+        activePeriod={null}
+        onPeriodSelect={onSelect}
+      />
+    );
+    await user.click(screen.getByRole('listitem'));
+    expect(onSelect).toHaveBeenCalledWith(Period.DAYS);
+  });
+
+  it('shows active state when selected', () => {
+    const { container } = render(
+      <CreateWaveDatesEndDateSelectPeriodItem
+        period={Period.DAYS}
+        activePeriod={Period.DAYS}
+        onPeriodSelect={() => {}}
+      />
+    );
+    const li = screen.getByRole('listitem');
+    expect(li.querySelector('svg')).toBeInTheDocument();
+    const span = container.querySelector('span');
+    expect(span?.className).toContain('tw-font-semibold');
+  });
+});

--- a/__tests__/components/waves/create-wave/groups/CreateWaveGroupItem.test.tsx
+++ b/__tests__/components/waves/create-wave/groups/CreateWaveGroupItem.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveGroupItem from '../../../../../components/waves/create-wave/groups/CreateWaveGroupItem';
+import { CreateWaveGroupStatus } from '../../../../../types/waves.types';
+
+const sampleGroup = {
+  id: '1',
+  name: 'Group One',
+  group: {} as any,
+  created_at: 0,
+  created_by: { handle: 'alice', pfp: 'img.png' },
+  visible: true,
+  is_private: false,
+};
+
+describe('CreateWaveGroupItem', () => {
+  it('renders group info and triggers onSelectedClick', async () => {
+    const onSelectedClick = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <CreateWaveGroupItem
+        selectedGroup={sampleGroup as any}
+        switchSelected={jest.fn()}
+        onSelectedClick={onSelectedClick}
+      />
+    );
+    await user.click(screen.getByRole('radio'));
+    expect(onSelectedClick).toHaveBeenCalled();
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('Group One')).toBeInTheDocument();
+  });
+
+  it('shows placeholder label when no group selected', async () => {
+    const switchSelected = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <CreateWaveGroupItem
+        selectedGroup={null}
+        switchSelected={switchSelected}
+        onSelectedClick={jest.fn()}
+      />
+    );
+    await user.click(screen.getByRole('radio'));
+    expect(switchSelected).toHaveBeenCalledWith(CreateWaveGroupStatus.GROUP);
+    expect(screen.getByText('A Group')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/create-wave/main-steps/CreateWavesMainSteps.test.tsx
+++ b/__tests__/components/waves/create-wave/main-steps/CreateWavesMainSteps.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import CreateWavesMainSteps from '../../../../../components/waves/create-wave/main-steps/CreateWavesMainSteps';
+import { ApiWaveType } from '../../../../../generated/models/ApiWaveType';
+import { CREATE_WAVE_MAIN_STEPS } from '../../../../../helpers/waves/waves.constants';
+import { CreateWaveStep } from '../../../../../types/waves.types';
+
+jest.mock('../../../../../components/waves/create-wave/main-steps/CreateWavesMainStep', () => (props: any) => (
+  <div data-testid="step" data-step={props.step}>{props.label}</div>
+));
+
+describe('CreateWavesMainSteps', () => {
+  it('renders a step component for each configured step', () => {
+    render(
+      <CreateWavesMainSteps
+        waveType={ApiWaveType.Rank}
+        activeStep={CreateWaveStep.OVERVIEW}
+        onStep={jest.fn()}
+      />
+    );
+    const steps = screen.getAllByTestId('step');
+    expect(steps).toHaveLength(CREATE_WAVE_MAIN_STEPS[ApiWaveType.Rank].length);
+    expect(steps[0]).toHaveAttribute('data-step', CreateWaveStep.OVERVIEW);
+  });
+});

--- a/__tests__/components/waves/create-wave/outcomes/cic/CreateWaveOutcomesCICApprove.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/cic/CreateWaveOutcomesCICApprove.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveOutcomesCICApprove from '../../../../../../components/waves/create-wave/outcomes/cic/CreateWaveOutcomesCICApprove';
+import { ApiWaveType } from '../../../../../../generated/models/ApiWaveType';
+
+describe('CreateWaveOutcomesCICApprove', () => {
+  it('shows error when credit not provided', async () => {
+    const onOutcome = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <CreateWaveOutcomesCICApprove
+        waveType={ApiWaveType.Approve}
+        dates={{} as any}
+        onOutcome={onOutcome}
+        onCancel={() => {}}
+      />
+    );
+    await user.click(screen.getByText('Save'));
+    expect(onOutcome).not.toHaveBeenCalled();
+    expect(screen.getByText('NIC must be a positive number')).toBeInTheDocument();
+  });
+
+  it('submits valid outcome', async () => {
+    const onOutcome = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <CreateWaveOutcomesCICApprove
+        waveType={ApiWaveType.Approve}
+        dates={{} as any}
+        onOutcome={onOutcome}
+        onCancel={() => {}}
+      />
+    );
+    await user.type(screen.getByLabelText('NIC'), '10');
+    await user.type(screen.getByLabelText('Max Winners'), '2');
+    await user.click(screen.getByText('Save'));
+    expect(onOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({ credit: 10, maxWinners: 2 })
+    );
+  });
+});

--- a/__tests__/components/waves/create-wave/outcomes/cic/CreateWaveOutcomesCICRank.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/cic/CreateWaveOutcomesCICRank.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveOutcomesCICRank from '../../../../../../components/waves/create-wave/outcomes/cic/CreateWaveOutcomesCICRank';
+import { CreateWaveOutcomeConfigWinnersCreditValueType } from '../../../../../../types/waves.types';
+
+jest.mock('../../../../../../components/waves/create-wave/outcomes/winners/CreateWaveOutcomesWinners', () => (props: any) => (
+  <button data-testid="winners" onClick={() => props.setWinnersConfig({ creditValueType: CreateWaveOutcomeConfigWinnersCreditValueType.ABSOLUTE_VALUE, totalAmount: 10, winners: [{ value: 10 }] })}>set</button>
+));
+
+describe('CreateWaveOutcomesCICRank', () => {
+  it('requires valid winners configuration before submit', async () => {
+    const onOutcome = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <CreateWaveOutcomesCICRank onOutcome={onOutcome} onCancel={() => {}} />
+    );
+    await user.click(screen.getByText('Save'));
+    expect(onOutcome).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId('winners')); // set valid config
+    await user.click(screen.getByText('Save'));
+    expect(onOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({
+        winnersConfig: expect.objectContaining({ totalAmount: 10 }),
+      })
+    );
+  });
+});

--- a/__tests__/hooks/useWaveConfig.test.ts
+++ b/__tests__/hooks/useWaveConfig.test.ts
@@ -1,0 +1,23 @@
+import { renderHook, act } from '@testing-library/react';
+import { useWaveConfig } from '../../components/waves/create-wave/hooks/useWaveConfig';
+import { CreateWaveStep } from '../../types/waves.types';
+
+
+describe('useWaveConfig', () => {
+  it('prevents step change when validation fails', () => {
+    const { result } = renderHook(() => useWaveConfig());
+    act(() => {
+      result.current.onStep({ step: CreateWaveStep.GROUPS, direction: 'forward' });
+    });
+    expect(result.current.step).toBe(CreateWaveStep.OVERVIEW);
+    expect(result.current.errors.length).toBeGreaterThan(0);
+  });
+
+  it('updates drops admin delete flag', () => {
+    const { result } = renderHook(() => useWaveConfig());
+    act(() => {
+      result.current.setDropsAdminCanDelete(true);
+    });
+    expect(result.current.config.drops.adminCanDeleteDrops).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add CreateWaveDatesEndDateSelectPeriodItem tests
- test CreateWaveGroupItem interactions
- test CreateWavesMainSteps renders
- cover CIC approve and rank outcome components
- test useWaveConfig hook

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
