### PR TITLE
Increase page and context test coverage

### DIFF
--- a/__tests__/contexts/navigationHistory.test.tsx
+++ b/__tests__/contexts/navigationHistory.test.tsx
@@ -1,0 +1,30 @@
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import { NavigationHistoryProvider, useNavigationHistoryContext } from '../../contexts/NavigationHistoryContext';
+import { useRouter } from 'next/router';
+import { useViewContext } from '../../components/navigation/ViewContext';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../components/navigation/ViewContext', () => ({ useViewContext: jest.fn() }));
+
+const routerMock = { asPath: '/', push: jest.fn(), back: jest.fn(), events: { on: jest.fn(), off: jest.fn() } };
+const hardBack = jest.fn();
+(useRouter as jest.Mock).mockReturnValue(routerMock);
+(useViewContext as jest.Mock).mockReturnValue({ hardBack });
+
+const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <NavigationHistoryProvider>{children}</NavigationHistoryProvider>
+);
+
+describe('NavigationHistoryContext', () => {
+  it('pushes view and navigates back to previous route', () => {
+    const { result } = renderHook(() => useNavigationHistoryContext(), { wrapper });
+    act(() => {
+      result.current.pushView('test' as any);
+    });
+    act(() => {
+      result.current.goBack();
+    });
+    expect(routerMock.push).toHaveBeenCalledWith('/');
+  });
+});

--- a/__tests__/pages/access.test.tsx
+++ b/__tests__/pages/access.test.tsx
@@ -1,0 +1,38 @@
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import Access from '../../pages/access';
+import { AuthContext } from '../../components/auth/Auth';
+import { useRouter } from 'next/router';
+
+jest.mock('next/image', () => ({ __esModule: true, default: (p: any) => <img {...p} /> }));
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+
+const useRouterMock = useRouter as jest.Mock;
+
+const TestProvider: React.FC = ({ children }) => (
+  <AuthContext.Provider value={{ setTitle: jest.fn() } as any}>{children}</AuthContext.Provider>
+);
+
+describe('Access page', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 401,
+      json: () => Promise.resolve({ image: 'img.jpg' }),
+    }) as any;
+    useRouterMock.mockReturnValue({ isReady: true, push: jest.fn() });
+    // Avoid "alert is not implemented" errors from jsdom
+    global.alert = jest.fn();
+  });
+
+  it('fetches image and triggers login on enter', async () => {
+    const { getByPlaceholderText } = render(
+      <TestProvider>
+        <Access />
+      </TestProvider>
+    );
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    const input = getByPlaceholderText('Team Login') as HTMLInputElement;
+    fireEvent.keyDown(input, { key: 'enter', target: input });
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+  });
+});

--- a/__tests__/pages/delegationMappingToolPage.test.tsx
+++ b/__tests__/pages/delegationMappingToolPage.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import DelegationMappingToolPage from '../../pages/delegation-mapping-tool';
+import { AuthContext } from '../../components/auth/Auth';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+const TestProvider: React.FC = ({ children }) => (
+  <AuthContext.Provider value={{ setTitle: jest.fn() } as any}>{children}</AuthContext.Provider>
+);
+
+describe('DelegationMappingTool page', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve('<p>hello</p>'),
+    }) as any;
+  });
+
+  it('renders fetched html content', async () => {
+    render(
+      <TestProvider>
+        <DelegationMappingToolPage />
+      </TestProvider>
+    );
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(screen.getByText('Overview')).toBeInTheDocument();
+    await waitFor(() => {
+      const container = document.querySelector('#how-to-use .htmlContainer') as HTMLElement;
+      expect(container.innerHTML).toContain('hello');
+    });
+  });
+});

--- a/__tests__/pages/openMobile.test.tsx
+++ b/__tests__/pages/openMobile.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import OpenMobilePage from '../../pages/open-mobile';
+import { useRouter } from 'next/router';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+
+const useRouterMock = useRouter as jest.Mock;
+
+describe('OpenMobilePage', () => {
+  beforeEach(() => {
+    delete (window as any).location;
+    (window as any).location = { href: 'http://example.com', origin: 'http://example.com' } as any;
+    process.env.MOBILE_APP_SCHEME = 'app';
+    useRouterMock.mockReturnValue({ query: { path: '/foo%20bar' } });
+  });
+
+  it('deep links and allows going back', async () => {
+    render(<OpenMobilePage />);
+    await waitFor(() => {
+      expect(window.location.href).toBe('app://navigate/foo bar');
+    });
+
+    await userEvent.click(screen.getByText('Back to 6529.io'));
+    expect(window.location.href).toBe('http://example.com/foo bar');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for OpenMobile page
- add tests for DelegationMappingTool page
- test login flow in Access page
- cover NavigationHistoryContext actions

## Testing
- `npm run lint`
- `npm run type-check`
- `npx jest __tests__/pages/openMobile.test.tsx --coverage`
- `npx jest __tests__/pages/delegationMappingToolPage.test.tsx --coverage`
- `npx jest __tests__/pages/access.test.tsx --coverage`
- `npx jest __tests__/contexts/navigationHistory.test.tsx --coverage`
- `npm run improve-coverage`