### PR TITLE
Add tests for banner edit and leaderboard

### DIFF
--- a/__tests__/components/user/user-page-header/banner/UserPageHeaderEditBanner.test.tsx
+++ b/__tests__/components/user/user-page-header/banner/UserPageHeaderEditBanner.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { act } from 'react-dom/test-utils';
+import UserPageHeaderEditBanner from '../../../../../components/user/user-page-header/banner/UserPageHeaderEditBanner';
+import { ApiIdentity } from '../../../../../generated/models/ApiIdentity';
+import { AuthContext } from '../../../../../components/auth/Auth';
+import { ReactQueryWrapperContext } from '../../../../../components/react-query-wrapper/ReactQueryWrapper';
+
+let capturedBgProps: any;
+let capturedSaveProps: any;
+
+jest.mock('../../../../../components/user/settings/UserSettingsBackground', () => (props: any) => {
+  capturedBgProps = props;
+  return <div data-testid="background" />;
+});
+
+jest.mock('../../../../../components/user/settings/UserSettingsSave', () => (props: any) => {
+  capturedSaveProps = props;
+  return (
+    <button data-testid="save" type="submit" disabled={props.disabled}>
+      save
+    </button>
+  );
+});
+
+jest.mock('react-use', () => ({
+  useClickAway: jest.fn(),
+  useKeyPressEvent: jest.fn(),
+}));
+
+const mutateAsync = jest.fn();
+
+jest.mock('@tanstack/react-query', () => ({
+  useMutation: () => ({ mutateAsync }),
+}));
+
+const profile: ApiIdentity = {
+  handle: 'alice',
+  classification: 'Pseudonym' as any,
+  banner1: '#111111',
+  banner2: '#222222',
+  primary_wallet: '0xabc',
+  pfp: 'pfp',
+} as any;
+
+function renderComponent() {
+  return render(
+    <AuthContext.Provider value={{ setToast: jest.fn(), requestAuth: jest.fn().mockResolvedValue({ success: true }) } as any}>
+      <ReactQueryWrapperContext.Provider value={{ onProfileEdit: jest.fn() } as any}>
+        <UserPageHeaderEditBanner profile={profile} defaultBanner1="#000" defaultBanner2="#fff" onClose={jest.fn()} />
+      </ReactQueryWrapperContext.Provider>
+    </AuthContext.Provider>
+  );
+}
+
+describe('UserPageHeaderEditBanner', () => {
+  it('enables save when background changes and submits update', async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    expect(capturedSaveProps.disabled).toBe(true);
+
+    act(() => {
+      capturedBgProps.setBgColor1('#333333');
+    });
+    expect(capturedSaveProps.disabled).toBe(false);
+
+    await user.click(screen.getByTestId('save'));
+
+    expect(mutateAsync).toHaveBeenCalledWith({
+      handle: 'alice',
+      classification: 'Pseudonym',
+      banner_1: '#333333',
+      banner_2: '#222222',
+      pfp_url: 'pfp',
+    });
+  });
+});

--- a/__tests__/components/waves/small-leaderboard/WaveSmallLeaderboard.test.tsx
+++ b/__tests__/components/waves/small-leaderboard/WaveSmallLeaderboard.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { WaveSmallLeaderboard } from '../../../../components/waves/small-leaderboard/WaveSmallLeaderboard';
+import { AuthContext } from '../../../../components/auth/Auth';
+
+const mockHook = jest.fn();
+const mockDrop = jest.fn(() => <div data-testid="drop" />);
+const mockIntersection = jest.fn(() => ({ current: null }));
+
+jest.mock('../../../../hooks/useWaveDropsLeaderboard', () => ({
+  useWaveDropsLeaderboard: (...args: any) => mockHook(...args),
+}));
+
+jest.mock('../../../../hooks/useIntersectionObserver', () => ({
+  useIntersectionObserver: () => mockIntersection(),
+}));
+
+jest.mock('../../../../components/waves/small-leaderboard/WaveSmallLeaderboardDrop', () => ({
+  WaveSmallLeaderboardDrop: (props: any) => mockDrop(props),
+}));
+
+const wave = { id: '1' } as any;
+
+function renderComp(hookReturn: any) {
+  mockHook.mockReturnValue(hookReturn);
+  return render(
+    <AuthContext.Provider value={{ connectedProfile: null } as any}>
+      <WaveSmallLeaderboard wave={wave} onDropClick={jest.fn()} />
+    </AuthContext.Provider>
+  );
+}
+
+describe('WaveSmallLeaderboard', () => {
+  it('shows placeholder when no drops', () => {
+    renderComp({ drops: [], fetchNextPage: jest.fn(), hasNextPage: false, isFetching: false, isFetchingNextPage: false });
+    expect(screen.getByText('No drops have been made yet in this wave')).toBeInTheDocument();
+    expect(mockDrop).not.toHaveBeenCalled();
+  });
+
+  it('renders drops when available', () => {
+    renderComp({ drops: [{ id: 1 }, { id: 2 }], fetchNextPage: jest.fn(), hasNextPage: false, isFetching: false, isFetchingNextPage: false });
+    expect(screen.getAllByTestId('drop').length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add test covering UserPageHeaderEditBanner functionality
- add test for WaveSmallLeaderboard behaviour

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
