### PR TITLE
Improve test coverage

### DIFF
--- a/__tests__/components/waves/create-wave/outcomes/rep/CreateWaveOutcomesRep.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/rep/CreateWaveOutcomesRep.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import CreateWaveOutcomesRep from '../../../../../../components/waves/create-wave/outcomes/rep/CreateWaveOutcomesRep';
+import { ApiWaveType } from '../../../../../../generated/models/ApiWaveType';
+
+jest.mock('../../../../../../components/waves/create-wave/outcomes/rep/CreateWaveOutcomesRepApprove', () => () => <div data-testid="approve" />);
+jest.mock('../../../../../../components/waves/create-wave/outcomes/rep/CreateWaveOutcomesRepRank', () => () => <div data-testid="rank" />);
+
+describe('CreateWaveOutcomesRep', () => {
+  it('renders approve component when waveType is Approve', () => {
+    render(
+      <CreateWaveOutcomesRep
+        waveType={ApiWaveType.Approve}
+        dates={{} as any}
+        onOutcome={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    );
+    expect(screen.getByTestId('approve')).toBeInTheDocument();
+  });
+
+  it('renders rank component when waveType is Rank', () => {
+    render(
+      <CreateWaveOutcomesRep
+        waveType={ApiWaveType.Rank}
+        dates={{} as any}
+        onOutcome={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    );
+    expect(screen.getByTestId('rank')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/create-wave/outcomes/winners/rows/cic/CreateWaveOutcomesRowCICRank.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/winners/rows/cic/CreateWaveOutcomesRowCICRank.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveOutcomesRowCICRank from '../../../../../../../../components/waves/create-wave/outcomes/winners/rows/cic/CreateWaveOutcomesRowCICRank';
+
+const outcome = { winnersConfig: { totalAmount: 1500, winners: [] } } as any;
+
+describe('CreateWaveOutcomesRowCICRank', () => {
+  it('displays formatted total NIC', () => {
+    render(<CreateWaveOutcomesRowCICRank outcome={outcome} removeOutcome={jest.fn()} />);
+    expect(screen.getByText(/1\.5k/)).toBeInTheDocument();
+  });
+
+  it('renders remove button', () => {
+    render(<CreateWaveOutcomesRowCICRank outcome={outcome} removeOutcome={jest.fn()} />);
+    expect(screen.getByLabelText('Remove')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/create-wave/overview/type/CreateWaveTypeInputs.test.tsx
+++ b/__tests__/components/waves/create-wave/overview/type/CreateWaveTypeInputs.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveTypeInputs from '../../../../../../components/waves/create-wave/overview/type/CreateWaveTypeInputs';
+import { ApiWaveType } from '../../../../../../generated/models/ApiWaveType';
+
+jest.mock('../../../../../../components/utils/radio/CommonBorderedRadioButton', () => (props: any) => (
+  <button data-testid={props.type} disabled={props.disabled} onClick={() => props.onChange(props.type)}>{props.label}</button>
+));
+
+describe('CreateWaveTypeInputs', () => {
+  it('renders radio buttons and handles selection', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<CreateWaveTypeInputs selected={ApiWaveType.Chat} onChange={onChange} />);
+    const rankBtn = screen.getByTestId(ApiWaveType.Rank);
+    expect(screen.getByTestId(ApiWaveType.Approve)).toBeDisabled();
+    await user.click(rankBtn);
+    expect(onChange).toHaveBeenCalledWith(ApiWaveType.Rank);
+  });
+});

--- a/__tests__/components/waves/create-wave/types/period.test.ts
+++ b/__tests__/components/waves/create-wave/types/period.test.ts
@@ -1,0 +1,11 @@
+import { Period } from '../../../../../components/waves/create-wave/types/period';
+
+describe('Period enum', () => {
+  it('contains expected values', () => {
+    expect(Period.MINUTES).toBe('MINUTES');
+    expect(Period.HOURS).toBe('HOURS');
+    expect(Period.DAYS).toBe('DAYS');
+    expect(Period.WEEKS).toBe('WEEKS');
+    expect(Period.MONTHS).toBe('MONTHS');
+  });
+});

--- a/__tests__/components/waves/create-wave/utils/CreateWaveToggle.test.tsx
+++ b/__tests__/components/waves/create-wave/utils/CreateWaveToggle.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveToggle from '../../../../../components/waves/create-wave/utils/CreateWaveToggle';
+
+describe('CreateWaveToggle', () => {
+  it('renders label when displayLabel is true', () => {
+    render(<CreateWaveToggle enabled={false} onChange={jest.fn()} label="Enable" displayLabel />);
+    expect(screen.getByText('Enable')).toBeInTheDocument();
+  });
+
+  it('triggers onChange with new state', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<CreateWaveToggle enabled={false} onChange={onChange} label="Toggle" />);
+    await user.click(screen.getByRole('switch'));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for CreateWaveOutcomesRep component
- add tests for CreateWaveOutcomesRowCICRank component
- add tests for CreateWaveToggle component
- add tests for CreateWaveTypeInputs component
- add tests for Period enum

## Testing
- `npm run lint`
- `npm run type-check`
- `npx jest __tests__/components/waves/create-wave/outcomes/winners/rows/cic/CreateWaveOutcomesRowCICRank.test.tsx --coverage`
- `npx jest __tests__/components/waves/create-wave/outcomes/rep/CreateWaveOutcomesRep.test.tsx --coverage`
- `npx jest __tests__/components/waves/create-wave/utils/CreateWaveToggle.test.tsx --coverage`
- `npx jest __tests__/components/waves/create-wave/overview/type/CreateWaveTypeInputs.test.tsx --coverage`
- `npx jest __tests__/components/waves/create-wave/types/period.test.ts --coverage`
