### PR TITLE
Add tests for permission icon and wave flow

### DIFF
--- a/__tests__/components/utils/calendar/CommonCalendarDay.test.tsx
+++ b/__tests__/components/utils/calendar/CommonCalendarDay.test.tsx
@@ -1,0 +1,40 @@
+import { render, fireEvent } from '@testing-library/react';
+import CommonCalendarDay from '../../../../components/utils/calendar/CommonCalendarDay';
+import { CalendarDay } from '../../../../helpers/calendar/calendar.helpers';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('CommonCalendarDay', () => {
+  it('disables button for inactive month', () => {
+    const day: CalendarDay = { date: 1, isActiveMonth: false, startTimestamp: 0 };
+    const setSelected = jest.fn();
+    const { getByRole } = render(
+      <CommonCalendarDay
+        day={day}
+        selectedTimestamp={null}
+        minTimestamp={null}
+        maxTimestamp={null}
+        setSelectedTimestamp={setSelected}
+      />
+    );
+    const button = getByRole('button');
+    expect(button).toBeDisabled();
+  });
+
+  it('selects minTimestamp when start equals min', () => {
+    const min = 1000;
+    const day: CalendarDay = { date: 1, isActiveMonth: true, startTimestamp: min };
+    const setSelected = jest.fn();
+    const { getByRole } = render(
+      <CommonCalendarDay
+        day={day}
+        selectedTimestamp={null}
+        minTimestamp={min}
+        maxTimestamp={null}
+        setSelectedTimestamp={setSelected}
+      />
+    );
+    fireEvent.click(getByRole('button'));
+    expect(setSelected).toHaveBeenCalledWith(min);
+  });
+});

--- a/__tests__/components/utils/icons/PermissionIcon.test.tsx
+++ b/__tests__/components/utils/icons/PermissionIcon.test.tsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react';
+import PermissionIcon from '../../../../components/utils/icons/PermissionIcon';
+
+describe('PermissionIcon', () => {
+  it('renders svg with provided class', () => {
+    const { container } = render(<PermissionIcon className="test-class" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveClass('test-class');
+    expect(svg).toHaveAttribute('viewBox', '0 0 24 24');
+  });
+
+  it('renders default without class', () => {
+    const { container } = render(<PermissionIcon />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg?.getAttribute('class')).toBe('');
+  });
+});

--- a/__tests__/components/waves/create-wave/CreateWaveFlow.test.tsx
+++ b/__tests__/components/waves/create-wave/CreateWaveFlow.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import CreateWaveFlow from '../../../../components/waves/create-wave/CreateWaveFlow';
+
+jest.mock('../../../../hooks/isMobileScreen', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+import useIsMobileScreen from '../../../../hooks/isMobileScreen';
+const mockedUseIsMobileScreen = useIsMobileScreen as jest.Mock;
+
+describe('CreateWaveFlow', () => {
+  it('renders title size based on screen width', () => {
+    mockedUseIsMobileScreen.mockReturnValueOnce(true);
+    const { rerender } = render(
+      <CreateWaveFlow title="Test" onBack={() => {}}>
+        <div data-testid="child" />
+      </CreateWaveFlow>
+    );
+    expect(screen.getByText('Test')).toHaveClass('tw-text-3xl');
+
+    mockedUseIsMobileScreen.mockReturnValueOnce(false);
+    rerender(
+      <CreateWaveFlow title="Test" onBack={() => {}}>
+        <div data-testid="child" />
+      </CreateWaveFlow>
+    );
+    expect(screen.getByText('Test')).toHaveClass('tw-text-5xl');
+  });
+
+  it('invokes onBack when button clicked', () => {
+    mockedUseIsMobileScreen.mockReturnValue(false);
+    const onBack = jest.fn();
+    render(
+      <CreateWaveFlow title="BackTest" onBack={onBack}>
+        <span />
+      </CreateWaveFlow>
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(onBack).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for PermissionIcon component
- add tests for CreateWaveFlow mobile headings and back button
- add tests for CommonCalendarDay button behaviour

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
