### PR TITLE
Add helper tests

### DIFF
--- a/__tests__/helpers/calendar/calendar.helpers.test.ts
+++ b/__tests__/helpers/calendar/calendar.helpers.test.ts
@@ -1,0 +1,20 @@
+import { generateCalendar } from '../../../helpers/calendar/calendar.helpers';
+
+describe('calendar.helpers', () => {
+  it('generates a month grid with previous and next month days', () => {
+    const result = generateCalendar({ year: 2024, month: 2 }); // March 2024
+    expect(result).toHaveLength(35);
+    // first days from previous month
+    expect(result[0]).toEqual(
+      expect.objectContaining({ date: 26, isActiveMonth: false })
+    );
+    // first active day
+    expect(result[4]).toEqual(
+      expect.objectContaining({ date: 1, isActiveMonth: true })
+    );
+    // last active day
+    expect(result[result.length - 1]).toEqual(
+      expect.objectContaining({ date: 31, isActiveMonth: true })
+    );
+  });
+});

--- a/__tests__/helpers/waves/create-wave.helpers.test.ts
+++ b/__tests__/helpers/waves/create-wave.helpers.test.ts
@@ -1,0 +1,56 @@
+import {
+  getCreateWaveNextStep,
+  getCreateWavePreviousStep,
+  calculateLastDecisionTime,
+} from '../../../helpers/waves/create-wave.helpers';
+import { ApiWaveType } from '../../../generated/models/ApiWaveType';
+import { CreateWaveStep } from '../../../types/waves.types';
+
+describe('create-wave.helpers', () => {
+  describe('getCreateWaveNextStep', () => {
+    it('returns expected next steps for various wave types', () => {
+      expect(
+        getCreateWaveNextStep({ step: CreateWaveStep.OVERVIEW, waveType: ApiWaveType.Rank })
+      ).toBe(CreateWaveStep.GROUPS);
+      expect(
+        getCreateWaveNextStep({ step: CreateWaveStep.GROUPS, waveType: ApiWaveType.Chat })
+      ).toBe(CreateWaveStep.DESCRIPTION);
+      expect(
+        getCreateWaveNextStep({ step: CreateWaveStep.VOTING, waveType: ApiWaveType.Approve })
+      ).toBe(CreateWaveStep.APPROVAL);
+      expect(
+        getCreateWaveNextStep({ step: CreateWaveStep.DESCRIPTION, waveType: ApiWaveType.Rank })
+      ).toBeNull();
+    });
+  });
+
+  describe('getCreateWavePreviousStep', () => {
+    it('returns expected previous steps based on wave type', () => {
+      expect(
+        getCreateWavePreviousStep({ step: CreateWaveStep.DESCRIPTION, waveType: ApiWaveType.Chat })
+      ).toBe(CreateWaveStep.GROUPS);
+      expect(
+        getCreateWavePreviousStep({ step: CreateWaveStep.OUTCOMES, waveType: ApiWaveType.Approve })
+      ).toBe(CreateWaveStep.APPROVAL);
+    });
+  });
+
+  describe('calculateLastDecisionTime', () => {
+    it('handles empty subsequent decisions', () => {
+      expect(calculateLastDecisionTime(1000, [], 5000)).toBe(1000);
+    });
+
+    it('handles end date before first decision', () => {
+      expect(calculateLastDecisionTime(5000, [1000], 4000)).toBe(5000);
+    });
+
+    it('handles multi-decision non-rolling waves', () => {
+      expect(calculateLastDecisionTime(0, [10, 20], 100)).toBe(100);
+      expect(calculateLastDecisionTime(0, [50, 60], 80)).toBe(50);
+    });
+
+    it('handles rolling waves correctly', () => {
+      expect(calculateLastDecisionTime(0, [10, 10], 35)).toBe(30);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for calendar helper and create-wave helpers

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
