### PR TITLE
Improve test coverage

### DIFF
--- a/__tests__/components/user/subscriptions/UserPageSubscriptionsUpcoming.test.tsx
+++ b/__tests__/components/user/subscriptions/UserPageSubscriptionsUpcoming.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserPageSubscriptionsUpcoming from '../../../../components/user/subscriptions/UserPageSubscriptionsUpcoming';
+import { AuthContext } from '../../../../components/auth/Auth';
+
+jest.mock('../../../../services/api/common-api', () => ({
+  commonApiFetch: jest.fn(),
+  commonApiPost: jest.fn(),
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: null }),
+}));
+
+jest.mock('react-toggle', () => (props: any) => (
+  <input type="checkbox" {...props} data-testid="toggle" />
+));
+
+function renderComponent(subscriptions: any[]) {
+  const requestAuth = jest.fn().mockResolvedValue({ success: true });
+  const setToast = jest.fn();
+  const refresh = jest.fn();
+  render(
+    <AuthContext.Provider value={{ requestAuth, setToast } as any}>
+      <UserPageSubscriptionsUpcoming
+        profileKey="p1"
+        details={undefined}
+        memes_subscriptions={subscriptions}
+        readonly={false}
+        refresh={refresh}
+      />
+    </AuthContext.Provider>
+  );
+  return { requestAuth, setToast, refresh };
+}
+
+describe('UserPageSubscriptionsUpcoming', () => {
+  const sample = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({
+      token_id: i + 1,
+      contract: '0x1',
+      subscribed: true,
+      consolidation_key: 'k',
+    }));
+
+  it('expands and collapses subscription list', async () => {
+    const user = userEvent.setup();
+    renderComponent(sample(4));
+    expect(screen.getAllByRole('checkbox').length).toBe(3);
+    await user.click(screen.getByRole('button'));
+    expect(screen.getAllByRole('checkbox').length).toBe(4);
+    await user.click(screen.getByRole('button'));
+    expect(screen.getAllByRole('checkbox').length).toBe(3);
+  });
+});

--- a/__tests__/components/waves/create-dm/CreateDirectMessage.test.tsx
+++ b/__tests__/components/waves/create-dm/CreateDirectMessage.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateDirectMessage from '../../../../components/waves/create-dm/CreateDirectMessage';
+import { useRouter } from 'next/router';
+import { useAuth } from '../../../../components/auth/Auth';
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+jest.mock('../../../../components/auth/Auth', () => ({
+  useAuth: jest.fn(),
+}));
+jest.mock('../../../../helpers/waves/waves.helpers', () => ({
+  createDirectMessageWave: jest.fn().mockResolvedValue({ id: 1 }),
+}));
+
+jest.mock(
+  '../../../../components/groups/page/create/config/identities/select/GroupCreateIdentitiesSelect',
+  () => (props: any) => (
+    <button onClick={() => props.onIdentitySelect({ wallet: '0x2' })}>add</button>
+  )
+);
+
+const push = jest.fn();
+(useRouter as jest.Mock).mockReturnValue({ push });
+
+function setup() {
+  (useAuth as jest.Mock).mockReturnValue({ setToast: jest.fn() });
+  render(
+    <CreateDirectMessage profile={{ primary_wallet: '0x1' } as any} onBack={() => {}} />
+  );
+}
+
+describe('CreateDirectMessage', () => {
+  it('creates direct message when button clicked', async () => {
+    const user = userEvent.setup();
+    setup();
+    await user.click(screen.getByText('add'));
+    await user.click(screen.getByRole('button', { name: /create/i }));
+    expect(push).toHaveBeenCalledWith('/my-stream?view=messages&wave=1', undefined, { shallow: true });
+  });
+});

--- a/__tests__/components/waves/create-wave/dates/RollingEndDate.test.tsx
+++ b/__tests__/components/waves/create-wave/dates/RollingEndDate.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RollingEndDate from '../../../../../components/waves/create-wave/dates/RollingEndDate';
+
+jest.mock('../../../../../components/utils/calendar/CommonCalendar', () => (props: any) => (
+  <button onClick={() => props.setSelectedTimestamp(1000)}>calendar</button>
+));
+
+type Config = {
+  submissionStartDate: number;
+  votingStartDate: number;
+  endDate: number | null;
+  firstDecisionTime: number;
+  subsequentDecisions: number[];
+  isRolling: boolean;
+};
+
+jest.mock('../../../../../components/common/DateAccordion', () => (props: any) => (
+  <div>
+    <button onClick={props.onToggle}>toggle</button>
+    {props.isExpanded && props.children}
+    {props.collapsedContent}
+  </div>
+));
+
+jest.mock('../../../../../components/common/TimePicker', () => (props: any) => (
+  <button onClick={() => props.onTimeChange(1, 2)}>time</button>
+));
+
+jest.mock('../../../../../helpers/waves/create-wave.helpers', () => ({
+  calculateLastDecisionTime: () => 1234,
+}));
+
+jest.mock('../../../../../components/waves/create-wave/services/waveDecisionService', () => ({
+  calculateDecisionTimes: jest.fn(() => []),
+  countTotalDecisions: jest.fn(() => 1),
+  formatDate: (n: number) => `date-${n}`,
+}));
+
+describe('RollingEndDate', () => {
+  const baseConfig: Config = {
+    submissionStartDate: 0,
+    votingStartDate: 0,
+    endDate: Date.now(),
+    firstDecisionTime: 0,
+    subsequentDecisions: [],
+    isRolling: true,
+  };
+
+  it('updates date on calendar selection', async () => {
+    const setDates = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <RollingEndDate
+        dates={baseConfig}
+        setDates={setDates}
+        isRollingMode
+        setIsRollingMode={() => {}}
+        isExpanded
+        setIsExpanded={() => {}}
+      />
+    );
+    await user.click(screen.getByText('calendar'));
+    expect(setDates).toHaveBeenCalled();
+  });
+
+  it('updates time when time picker changes', async () => {
+    const setDates = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <RollingEndDate
+        dates={baseConfig}
+        setDates={setDates}
+        isRollingMode
+        setIsRollingMode={() => {}}
+        isExpanded
+        setIsExpanded={() => {}}
+      />
+    );
+    await user.click(screen.getByText('time'));
+    expect(setDates).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/waves/create-wave/outcomes/winners/CreateWaveOutcomesWinners.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/winners/CreateWaveOutcomesWinners.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveOutcomesWinners from '../../../../../../components/waves/create-wave/outcomes/winners/CreateWaveOutcomesWinners';
+import { CreateWaveOutcomeConfigWinnersCreditValueType, CreateWaveOutcomeType } from '../../../../../../types/waves.types';
+
+jest.mock('../../../../../../components/waves/create-wave/outcomes/winners/CreateWaveOutcomesWinnersRows', () => (props: any) => (
+  <div data-testid="rows">{props.winners.length}</div>
+));
+
+jest.mock('../../../../../../components/waves/create-wave/outcomes/winners/CreateWaveOutcomesWinnersAddWinner', () => (props: any) => (
+  <button onClick={props.addWinner}>add</button>
+));
+
+describe('CreateWaveOutcomesWinners', () => {
+  const baseConfig = {
+    creditValueType: CreateWaveOutcomeConfigWinnersCreditValueType.ABSOLUTE_VALUE,
+    totalAmount: 0,
+    winners: [{ value: 1 }],
+  };
+
+  it('updates winners when add button clicked', async () => {
+    const setWinnersConfig = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <CreateWaveOutcomesWinners
+        winnersConfig={baseConfig}
+        totalValueError={false}
+        percentageError={false}
+        outcomeType={CreateWaveOutcomeType.REP}
+        setWinnersConfig={setWinnersConfig}
+      />
+    );
+    await user.click(screen.getByText('add'));
+    expect(setWinnersConfig).toHaveBeenCalled();
+  });
+});

--- a/__tests__/pages/staticPages.test.tsx
+++ b/__tests__/pages/staticPages.test.tsx
@@ -5,6 +5,31 @@ import CasaBatllo from '../../pages/casabatllo';
 import Museum from '../../pages/museum';
 import ElementColumns from '../../pages/element_category/columns';
 import MemeLabDistribution from '../../pages/meme-lab/[id]/distribution';
+import AuthorNft6529 from '../../pages/author/nft6529';
+import BlogArtists from '../../pages/blog/a-tale-of-two-artists';
+import CapitalFund from '../../pages/capital/fund';
+import ElementSections from '../../pages/element_category/sections';
+import EmmaPlan from '../../pages/emma/plans/[id]';
+
+jest.mock('next/font/google', () => ({ Poppins: () => ({ className: 'poppins' }) }));
+jest.mock('../../components/auth/SeizeConnectContext', () => ({
+  useSeizeConnectContext: () => ({
+    address: '0x0',
+    seizeConnect: jest.fn(),
+    seizeDisconnect: jest.fn(),
+    seizeDisconnectAndLogout: jest.fn(),
+    seizeAcceptConnection: jest.fn(),
+    seizeConnectOpen: false,
+    isConnected: false,
+    isAuthenticated: false,
+  }),
+}));
+jest.mock('next/router', () => ({ useRouter: () => ({ push: jest.fn(), replace: jest.fn(), query: { id: '1' } }) }));
+jest.mock('react-use', () => ({ useInterval: jest.fn() }));
+
+jest.mock('../../components/distribution-plan-tool/distribution-plan-tool-sidebar/DistributionPlanToolSidebar', () => () => (
+  <div data-testid="sidebar" />
+));
 
 jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
 
@@ -32,5 +57,30 @@ describe('static pages render', () => {
   it('meme lab distribution page loads', () => {
     render(<MemeLabDistribution />);
     expect(screen.getByTestId('dynamic')).toBeInTheDocument();
+  });
+
+  it('renders author page', () => {
+    const { container } = render(<AuthorNft6529 />);
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders blog page', () => {
+    render(<BlogArtists />);
+    expect(screen.getAllByText(/Tale of Two Artists/i)[0]).toBeInTheDocument();
+  });
+
+  it('renders capital fund page', () => {
+    render(<CapitalFund />);
+    expect(screen.getByText(/6529 FUND/i)).toBeInTheDocument();
+  });
+
+  it('sections page redirects', () => {
+    render(<ElementSections />);
+    expect(screen.getByText(/redirected/i)).toBeInTheDocument();
+  });
+
+  it('emma plan page renders', () => {
+    render(<EmmaPlan />);
+    expect(screen.getByTestId('sidebar')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add tests for upcoming subscriptions list
- add tests for direct message creation
- test rolling end date interaction
- cover wave outcomes winner configuration
- expand static page tests with mocks

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
- `npm run improve-coverage`