### PR TITLE
Add initial coverage tests

### DIFF
--- a/__tests__/components/waves/create-wave/voting/CreateWaveVoting.test.tsx
+++ b/__tests__/components/waves/create-wave/voting/CreateWaveVoting.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveVoting from '../../../../../components/waves/create-wave/voting/CreateWaveVoting';
+import { ApiWaveType } from '../../../../../generated/models/ApiWaveType';
+import { ApiWaveCreditType } from '../../../../../generated/models/ApiWaveCreditType';
+
+jest.mock('../../../../../components/utils/radio/CommonBorderedRadioButton', () => (props: any) => (
+  <button data-testid={`radio-${props.type}`} onClick={() => props.onChange(props.type)}>{props.label}</button>
+));
+
+jest.mock('../../../../../components/waves/create-wave/voting/CreateWaveVotingRep', () => () => <div data-testid="rep" />);
+jest.mock('../../../../../components/waves/create-wave/voting/NegativeVotingToggle', () => () => <div data-testid="negative" />);
+jest.mock('../../../../../components/waves/create-wave/voting/TimeWeightedVoting', () => () => <div data-testid="time-weighted" />);
+
+describe('CreateWaveVoting', () => {
+  const baseProps = {
+    waveType: ApiWaveType.Rank,
+    selectedType: ApiWaveCreditType.Rep,
+    category: null,
+    profileId: null,
+    errors: [],
+    onTypeChange: jest.fn(),
+    setCategory: jest.fn(),
+    setProfileId: jest.fn(),
+    timeWeighted: { enabled: false, averagingInterval: 0, averagingIntervalUnit: 'minutes' } as any,
+    onTimeWeightedChange: jest.fn(),
+  };
+
+  it('returns null when no selected type', () => {
+    const { container } = render(<CreateWaveVoting {...baseProps} selectedType={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders rep voting options for rank waves', () => {
+    render(<CreateWaveVoting {...baseProps} />);
+    expect(screen.getByTestId('rep')).toBeInTheDocument();
+    expect(screen.getByTestId('negative')).toBeInTheDocument();
+    expect(screen.getByTestId('time-weighted')).toBeInTheDocument();
+  });
+
+  it('invokes onTypeChange when radio clicked', async () => {
+    const user = userEvent.setup();
+    render(<CreateWaveVoting {...baseProps} />);
+    await user.click(screen.getByTestId(`radio-${ApiWaveCreditType.Tdh}`));
+    expect(baseProps.onTypeChange).toHaveBeenCalledWith(ApiWaveCreditType.Tdh);
+  });
+
+  it('omits negative voting for chat waves', () => {
+    render(<CreateWaveVoting {...baseProps} waveType={ApiWaveType.Chat} />);
+    expect(screen.queryByTestId('negative')).toBeNull();
+  });
+});

--- a/__tests__/components/waves/drop/SingleWaveDropVoteStats.test.tsx
+++ b/__tests__/components/waves/drop/SingleWaveDropVoteStats.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import { SingleWaveDropVoteStats } from '../../../../components/waves/drop/SingleWaveDropVoteStats';
+import { ApiWaveCreditType } from '../../../../generated/models/ApiWaveCreditType';
+
+describe('SingleWaveDropVoteStats', () => {
+  it('displays current and max rating with credit type', () => {
+    render(
+      <SingleWaveDropVoteStats currentRating={1234} maxRating={5678} creditType={ApiWaveCreditType.Rep} />
+    );
+    expect(screen.getByText('Your votes:')).toBeInTheDocument();
+    expect(screen.getByText(/1,234\s*REP/i)).toBeInTheDocument();
+    expect(screen.getByText(/5,678\s*REP/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/leaderboard/sidebar/WaveLeaderboardRightSidebarActivityLogs.test.tsx
+++ b/__tests__/components/waves/leaderboard/sidebar/WaveLeaderboardRightSidebarActivityLogs.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import { WaveLeaderboardRightSidebarActivityLogs } from '../../../../../components/waves/leaderboard/sidebar/WaveLeaderboardRightSidebarActivityLogs';
+import { ApiWave } from '../../../../../generated/models/ApiWave';
+import { useAuth } from '../../../../../components/auth/Auth';
+
+const hook = jest.fn();
+let intersectionCb: any;
+
+jest.mock('../../../../../hooks/useWaveActivityLogs', () => ({
+  useWaveActivityLogs: (...args: any[]) => hook(...args),
+}));
+
+jest.mock('../../../../../hooks/useIntersectionObserver', () => ({
+  useIntersectionObserver: (cb: any) => {
+    intersectionCb = cb;
+    return { current: null };
+  },
+}));
+
+jest.mock('../../../../../components/waves/leaderboard/sidebar/WaveLeaderboardRightSidebarActivityLog', () => ({
+  WaveLeaderboardRightSidebarActivityLog: (props: any) => <div data-testid="log" >{props.log.id}</div>,
+}));
+
+jest.mock('../../../../../components/auth/Auth', () => ({
+  useAuth: jest.fn(),
+}));
+
+(useAuth as jest.Mock).mockReturnValue({ connectedProfile: null });
+
+describe('WaveLeaderboardRightSidebarActivityLogs', () => {
+  const wave = { id: '1', voting: { credit_type: 'REP' } } as unknown as ApiWave;
+
+  it('shows placeholder when no logs', () => {
+    hook.mockReturnValue({ logs: [], isFetchingNextPage: false, fetchNextPage: jest.fn(), hasNextPage: false, isLoading: false });
+    render(<WaveLeaderboardRightSidebarActivityLogs wave={wave} onDropClick={jest.fn()} />);
+    expect(screen.getByText('Be the First to Make a Vote')).toBeInTheDocument();
+  });
+
+  it('fetches next page on intersection', () => {
+    const fetchNextPage = jest.fn();
+    hook.mockReturnValue({ logs: [{ id: 'a' }], isFetchingNextPage: false, fetchNextPage, hasNextPage: true, isLoading: false });
+    render(<WaveLeaderboardRightSidebarActivityLogs wave={wave} onDropClick={jest.fn()} />);
+    expect(screen.getByTestId('log')).toHaveTextContent('a');
+    intersectionCb();
+    expect(fetchNextPage).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/waves/list/header/WavesListHeader.test.tsx
+++ b/__tests__/components/waves/list/header/WavesListHeader.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import WavesListHeader from '../../../../../components/waves/list/header/WavesListHeader';
+import { AuthContext } from '../../../../../components/auth/Auth';
+
+jest.mock('../../../../../components/waves/list/header/WavesListSearch', () => (props: any) => <div data-testid="search" />);
+
+const baseAuth = { connectedProfile: { handle: 'bob' }, activeProfileProxy: null } as any;
+
+describe('WavesListHeader', () => {
+  it('sets identity when my waves clicked', async () => {
+    const setIdentity = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <AuthContext.Provider value={baseAuth}>
+        <WavesListHeader identity={null} waveName={null} onCreateNewWave={jest.fn()} onCreateNewDirectMessage={jest.fn()} setIdentity={setIdentity} setWaveName={jest.fn()} showCreateNewButton={false} />
+      </AuthContext.Provider>
+    );
+    await user.click(screen.getByText('My Waves'));
+    expect(setIdentity).toHaveBeenCalledWith('bob');
+  });
+
+  it('shows create buttons when enabled', () => {
+    render(
+      <AuthContext.Provider value={baseAuth}>
+        <WavesListHeader identity={null} waveName={null} onCreateNewWave={jest.fn()} onCreateNewDirectMessage={jest.fn()} setIdentity={jest.fn()} setWaveName={jest.fn()} showCreateNewButton={true} />
+      </AuthContext.Provider>
+    );
+    expect(screen.getByText('Create Wave')).toBeInTheDocument();
+    expect(screen.getByText('Create DM')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/small-leaderboard/WaveSmallLeaderboardItemContent.test.tsx
+++ b/__tests__/components/waves/small-leaderboard/WaveSmallLeaderboardItemContent.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WaveSmallLeaderboardItemContent } from '../../../../components/waves/small-leaderboard/WaveSmallLeaderboardItemContent';
+
+jest.mock('../../../../components/waves/drops/WaveDropPartContentMedias', () => () => <div data-testid="medias" />);
+jest.mock('../../../../components/waves/drops/WaveDropPartContentMarkdown', () => () => <div data-testid="markdown" />);
+
+describe('WaveSmallLeaderboardItemContent', () => {
+  const baseDrop = { parts: [{ media: [], id: 1 }], metadata: [], mentioned_users: [], referenced_nfts: [], wave: {}, rank: 1 } as any;
+
+  it('calls onDropClick when content clicked', async () => {
+    const onDropClick = jest.fn();
+    const user = userEvent.setup();
+    render(<WaveSmallLeaderboardItemContent drop={baseDrop} onDropClick={onDropClick} />);
+    await user.click(screen.getByTestId('markdown').parentElement as HTMLElement);
+    expect(onDropClick).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/waves/winners/DefaultWaveWinnerDropSmall.test.tsx
+++ b/__tests__/components/waves/winners/DefaultWaveWinnerDropSmall.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DefaultWaveWinnerDropSmall } from '../../../../components/waves/winners/DefaultWaveWinnerDropSmall';
+
+jest.mock('../../../../components/waves/winners/drops/DropContentSmall', () => ({ DropContentSmall: () => <div data-testid="content" /> }));
+jest.mock('../../../../components/waves/winners/WaveWinnersSmallOutcome', () => ({ WaveWinnersSmallOutcome: () => <div data-testid="outcome" /> }));
+jest.mock('../../../../components/waves/drops/winner/WinnerDropBadge', () => ({ __esModule: true, default: (props: any) => <div data-testid="badge">{props.rank}</div> }));
+
+const baseDrop = { rating: 5, raters_count: 1, author: { handle: 'alice', pfp: null }, wave: { voting_credit_type: 'REP' }, parts: [{}], context_profile_context: { rating: 2 }, metadata: [], mentioned_users: [], referenced_nfts: [], created_at: 0 } as any;
+const wave = {} as any;
+
+describe('DefaultWaveWinnerDropSmall', () => {
+  it('handles click and shows user vote', async () => {
+    const onDropClick = jest.fn();
+    const user = userEvent.setup();
+    const { container } = render(<DefaultWaveWinnerDropSmall drop={baseDrop} wave={wave} onDropClick={onDropClick} />);
+    await user.click(container.firstElementChild as HTMLElement);
+    expect(onDropClick).toHaveBeenCalled();
+  });
+});

--- a/__tests__/helpers/stream.helpers.test.ts
+++ b/__tests__/helpers/stream.helpers.test.ts
@@ -1,0 +1,15 @@
+import { prefetchWavesOverview } from '../../helpers/stream.helpers';
+
+jest.mock('jwt-decode', () => ({ jwtDecode: () => ({ sub: 'wallet' }) }));
+jest.mock('../../helpers/server.helpers', () => ({ getUserProfile: jest.fn(() => Promise.resolve({ handle: 'bob' })) }));
+jest.mock('../../services/api/common-api', () => ({ commonApiFetch: jest.fn(() => Promise.resolve([])) }));
+
+const createClient = () => ({ prefetchInfiniteQuery: jest.fn(), prefetchQuery: jest.fn() });
+
+describe('prefetchWavesOverview', () => {
+  it('prefetches data when jwt present', async () => {
+    const queryClient = createClient();
+    await prefetchWavesOverview({ queryClient: queryClient as any, headers: { Authorization: 'Bearer token' }, waveId: '1' });
+    expect(queryClient.prefetchInfiniteQuery).toHaveBeenCalled();
+  });
+});

--- a/__tests__/hooks/useMyStreamQuery.test.ts
+++ b/__tests__/hooks/useMyStreamQuery.test.ts
@@ -1,0 +1,38 @@
+import { renderHook } from '@testing-library/react';
+import { useMyStreamQuery, usePollingQuery } from '../../hooks/useMyStreamQuery';
+
+jest.mock('@tanstack/react-query', () => ({
+  useInfiniteQuery: jest.fn(),
+  useQuery: jest.fn(),
+  useQueryClient: () => ({ prefetchInfiniteQuery: jest.fn() }),
+}));
+
+jest.mock('../../services/api/common-api', () => ({ commonApiFetch: jest.fn(() => Promise.resolve([])) }));
+
+const { useInfiniteQuery, useQuery } = require('@tanstack/react-query');
+
+describe('useMyStreamQuery', () => {
+  it('reverses items when reverse true', () => {
+    (useInfiniteQuery as jest.Mock).mockReturnValue({
+      data: { pages: [[{ serial_no: 1 }, { serial_no: 2 }]] },
+      fetchNextPage: jest.fn(),
+      hasNextPage: true,
+      isFetching: false,
+      isFetchingNextPage: false,
+      status: 'success',
+    });
+    const { result } = renderHook(() => useMyStreamQuery({ reverse: true }));
+    expect(result.current.items.map((i) => i.serial_no)).toEqual([2, 1]);
+  });
+});
+
+describe('usePollingQuery', () => {
+  it('detects new items appearing', () => {
+    (useQuery as jest.Mock).mockReturnValue({ data: [{ serial_no: 3 }], refetch: jest.fn() });
+    const { result, rerender } = renderHook((props: any) => usePollingQuery(props.initial, props.items, false), {
+      initialProps: { initial: true, items: [{ serial_no: 1 }], },
+    });
+    rerender({ initial: true, items: [{ serial_no: 1 }], });
+    expect(result.current.haveNewItems).toBe(true);
+  });
+});

--- a/__tests__/pages/buidl.test.tsx
+++ b/__tests__/pages/buidl.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import Buidl from '../../pages/buidl';
+import { AuthContext } from '../../components/auth/Auth';
+
+describe('Buidl page', () => {
+  it('sets title on mount', () => {
+    const setTitle = jest.fn();
+    render(
+      <AuthContext.Provider value={{ setTitle } as any}>
+        <Buidl />
+      </AuthContext.Provider>
+    );
+    expect(setTitle).toHaveBeenCalledWith({ title: 'BUIDL' });
+  });
+});


### PR DESCRIPTION
## Notes
- Added tests for wave voting, vote stats, leaderboard activity logs and more
- Simplified small leaderboard and winner item tests
- Created helper and hook tests
- Stopped after helper requested additional files which could not be completed in time
