### PR TITLE
Add tests for museum pages and utilities

### DIFF
--- a/__tests__/components/browserDetection.test.ts
+++ b/__tests__/components/browserDetection.test.ts
@@ -1,0 +1,20 @@
+import { detectBrowser, isBrowserSupported } from '../../components/waves/memes/file-upload/utils/browserDetection';
+
+describe('browser detection utilities', () => {
+  afterEach(() => {
+    Object.defineProperty(window, 'navigator', { value: { userAgent: '' }, writable: true });
+  });
+
+  it('detects chrome browser', () => {
+    Object.defineProperty(window, 'navigator', { value: { userAgent: 'Chrome' }, writable: true });
+    expect(detectBrowser()).toBe('Chrome');
+  });
+
+  it('detects unsupported File API', () => {
+    const original = { ...window } as any;
+    Object.defineProperty(window, 'File', { value: undefined });
+    const result = isBrowserSupported();
+    Object.assign(window, original);
+    expect(result.supported).toBe(false);
+  });
+});

--- a/__tests__/pages/museumPages.test.tsx
+++ b/__tests__/pages/museumPages.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import CryptoAdPunks from '../../pages/museum/6529-fund-szn1/cryptoad-punks';
+import CryptoPunks from '../../pages/museum/6529-fund-szn1/cryptopunks';
+import QueensKings from '../../pages/museum/6529-fund-szn1/queens-kings';
+import AckBar from '../../pages/museum/ack-bar';
+import EarlyNftArt from '../../pages/museum/early-nft-art';
+import Autology from '../../pages/museum/genesis/autology';
+import Cryptoblots from '../../pages/museum/genesis/cryptoblots';
+import Dreams from '../../pages/museum/genesis/dreams';
+import DynamicSlices from '../../pages/museum/genesis/dynamic-slices';
+import Edifice from '../../pages/museum/genesis/edifice';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+describe('museum static pages render', () => {
+  it('renders CryptoAdPunks page', () => {
+    render(<CryptoAdPunks />);
+    expect(screen.getAllByText(/CRYPTOAD PUNKS/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders CryptoPunks page', () => {
+    render(<CryptoPunks />);
+    expect(screen.getAllByText(/CRYPTOPUNKS/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Queens & Kings page', () => {
+    render(<QueensKings />);
+    expect(screen.getAllByText(/QUEENS \+ KINGS/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Ack Bar page', () => {
+    render(<AckBar />);
+    expect(screen.getAllByText(/ACK BAR/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Early NFT Art page', () => {
+    render(<EarlyNftArt />);
+    expect(screen.getAllByText(/EARLY NFT ART/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Autology page', () => {
+    render(<Autology />);
+    expect(screen.getAllByText(/AUTOLOGY/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Cryptoblots page', () => {
+    render(<Cryptoblots />);
+    expect(screen.getAllByText(/CRYPTOBLOTS/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Dreams page', () => {
+    render(<Dreams />);
+    expect(screen.getAllByText(/DREAMS/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Dynamic Slices page', () => {
+    render(<DynamicSlices />);
+    expect(screen.getAllByText(/DYNAMIC SLICES/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Edifice page', () => {
+    render(<Edifice />);
+    expect(screen.getAllByText(/EDIFICE/i).length).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/pages/museumPages2.test.tsx
+++ b/__tests__/pages/museumPages2.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import ElevatedDeconstructions from '../../pages/museum/genesis/elevated-deconstructions';
+import Ringers from '../../pages/museum/genesis/ringers';
+import Screens from '../../pages/museum/genesis/screens';
+import Skulptuur from '../../pages/museum/genesis/skulptuur';
+import Synapses from '../../pages/museum/genesis/synapses';
+import BlocksOfArt from '../../pages/museum/genesis/the-blocks-of-art';
+import Vortex from '../../pages/museum/genesis/vortex';
+import OMRedirect from '../../pages/om/OM';
+import TheMemesPage from '../../pages/the-memes';
+import { AuthContext } from '../../components/auth/Auth';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+const renderWithAuth = (ui: React.ReactElement, overrides = {}) => {
+  const value = { setTitle: jest.fn(), ...overrides } as any;
+  return {
+    ...render(<AuthContext.Provider value={value}>{ui}</AuthContext.Provider>),
+    setTitle: value.setTitle,
+  };
+};
+
+describe('additional museum and misc pages render', () => {
+  it('renders Elevated Deconstructions', () => {
+    render(<ElevatedDeconstructions />);
+    expect(screen.getAllByText(/ELEVATED DECONSTRUCTIONS/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Ringers', () => {
+    render(<Ringers />);
+    expect(screen.getAllByText(/RINGERS/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Screens', () => {
+    render(<Screens />);
+    expect(screen.getAllByText(/SCREENS/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Skulptuur', () => {
+    render(<Skulptuur />);
+    expect(screen.getAllByText(/SKULPTUUR/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Synapses', () => {
+    render(<Synapses />);
+    expect(screen.getAllByText(/SYNAPSES/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Blocks Of Art', () => {
+    render(<BlocksOfArt />);
+    expect(screen.getAllByText(/THE BLOCKS OF ART/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Vortex', () => {
+    render(<Vortex />);
+    expect(screen.getAllByText(/VORTEX/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders OM redirect page', () => {
+    render(<OMRedirect />);
+    expect(screen.getByText(/You are being redirected/i)).toBeInTheDocument();
+  });
+
+  it('renders The Memes page and sets title', () => {
+    const { setTitle } = renderWithAuth(<TheMemesPage />);
+    expect(setTitle).toHaveBeenCalledWith({ title: 'The Memes | Collections' });
+  });
+});

--- a/__tests__/pages/myStreamNotifications.test.tsx
+++ b/__tests__/pages/myStreamNotifications.test.tsx
@@ -1,0 +1,31 @@
+import { getServerSideProps } from '../../pages/my-stream/notifications';
+import { prefetchAuthenticatedNotifications } from '../../helpers/stream.helpers';
+import { QueryKey } from '../../components/react-query-wrapper/ReactQueryWrapper';
+import { Time } from '../../helpers/time';
+
+jest.mock('../../helpers/stream.helpers', () => ({
+  prefetchAuthenticatedNotifications: jest.fn(),
+}));
+
+describe('my-stream notifications getServerSideProps', () => {
+  const spy = jest.spyOn(Time, 'now');
+
+  afterEach(() => {
+    (prefetchAuthenticatedNotifications as jest.Mock).mockClear();
+    spy.mockReset();
+  });
+
+  it('prefetches when cookie timestamp is old', async () => {
+    spy.mockReturnValue(Time.millis(200000));
+    const context: any = { req: { cookies: { [QueryKey.IDENTITY_NOTIFICATIONS]: '100000' } } };
+    await getServerSideProps(context);
+    expect(prefetchAuthenticatedNotifications).toHaveBeenCalled();
+  });
+
+  it('does not prefetch when cookie is fresh', async () => {
+    spy.mockReturnValue(Time.millis(200000));
+    const context: any = { req: { cookies: { [QueryKey.IDENTITY_NOTIFICATIONS]: '199999' } } };
+    await getServerSideProps(context);
+    expect(prefetchAuthenticatedNotifications).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/pages/wavesPage.test.tsx
+++ b/__tests__/pages/wavesPage.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import WavesPage from '../../pages/waves';
+import { AuthContext } from '../../components/auth/Auth';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+describe('Waves page', () => {
+  it('sets title on mount', () => {
+    const setTitle = jest.fn();
+    render(
+      <AuthContext.Provider value={{ setTitle } as any}>
+        <WavesPage />
+      </AuthContext.Provider>
+    );
+    expect(setTitle).toHaveBeenCalledWith({ title: 'Waves | Brain' });
+  });
+});


### PR DESCRIPTION
## Summary
- add regression tests for static museum pages
- cover Om redirect and The Memes page behaviour
- test browser detection utility
- test server-side logic for notifications page
- ensure Waves page sets title

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
