### PR TITLE
Add tests for coverage

### DIFF
--- a/__tests__/components/waves/create-wave/dates/CreateWaveDates.test.tsx
+++ b/__tests__/components/waves/create-wave/dates/CreateWaveDates.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveDates from '../../../../../components/waves/create-wave/dates/CreateWaveDates';
+import { ApiWaveType } from '../../../../../generated/models/ApiWaveType';
+import { CreateWaveDatesConfig } from '../../../../../types/waves.types';
+
+jest.mock('../../../../../components/waves/create-wave/dates/StartDates', () => (props: any) => (
+  <button data-testid="start" onClick={() => props.setDates({ ...props.dates, submissionStartDate: 50 })}>start</button>
+));
+
+jest.mock('../../../../../components/waves/create-wave/dates/Decisions', () => (props: any) => (
+  <button data-testid="decisions" onClick={() => props.setIsRollingMode(true)}>decisions</button>
+));
+
+jest.mock('../../../../../components/waves/create-wave/dates/RollingEndDate', () => () => (
+  <div data-testid="rolling" />
+));
+
+jest.mock('../../../../../components/waves/create-wave/services/waveDecisionService', () => ({
+  adjustDatesAfterSubmissionChange: jest.fn((d, ts) => ({ ...d, submissionStartDate: ts })),
+  calculateEndDate: jest.fn(() => 123),
+  validateDateSequence: jest.fn(() => []),
+}));
+
+const baseDates: CreateWaveDatesConfig = {
+  submissionStartDate: 10,
+  votingStartDate: 20,
+  endDate: null,
+  firstDecisionTime: 30,
+  subsequentDecisions: [],
+  isRolling: false,
+};
+
+describe('CreateWaveDates', () => {
+  it('adjusts dates when submission start changes', async () => {
+    const setDates = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <CreateWaveDates waveType={ApiWaveType.Approve} dates={baseDates} setDates={setDates} />
+    );
+    await user.click(screen.getByTestId('start'));
+    expect(setDates).toHaveBeenCalledWith({ ...baseDates, submissionStartDate: 50 });
+  });
+
+  it('shows rolling section when rolling mode and decisions present', () => {
+    const dates = { ...baseDates, isRolling: true, subsequentDecisions: [1] };
+    render(
+      <CreateWaveDates waveType={ApiWaveType.Approve} dates={dates} setDates={jest.fn()} />
+    );
+    expect(screen.getByTestId('rolling')).toBeInTheDocument();
+  });
+});

--- a/__tests__/pages/museumPages3.test.tsx
+++ b/__tests__/pages/museumPages3.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import Art1of1 from '../../pages/museum/1-of-1-art';
+import Cryptocubes from '../../pages/museum/6529-fund-szn1/cryptocubes';
+import Faraway from '../../pages/museum/6529-fund-szn1/faraway';
+import NeuralBricolage from '../../pages/museum/6529-fund-szn1/primary-colors-of-neural-bricolage';
+import Subscapes from '../../pages/museum/6529-fund-szn1/subscapes';
+import Bonafidehan from '../../pages/museum/bonafidehan-museum';
+import GeneralAssembly from '../../pages/museum/general-assembly';
+import ChromieSquiggle from '../../pages/museum/genesis/chromie-squiggle';
+import GenesisDca from '../../pages/museum/genesis/genesis-dca';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+describe('additional museum pages render', () => {
+  it('renders 1 of 1 art page', () => {
+    render(<Art1of1 />);
+    expect(screen.getAllByText(/1 OF 1 ART/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Cryptocubes page', () => {
+    render(<Cryptocubes />);
+    expect(screen.getAllByText(/CRYPTOCUBES/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Faraway page', () => {
+    render(<Faraway />);
+    expect(screen.getAllByText(/FARAWAY/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Neural Bricolage page', () => {
+    render(<NeuralBricolage />);
+    expect(screen.getAllByText(/PRIMARY COLORS OF NEURAL BRICOLAGE/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Subscapes page', () => {
+    render(<Subscapes />);
+    expect(screen.getAllByText(/SUBSCAPES/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Bonafidehan page', () => {
+    render(<Bonafidehan />);
+    expect(screen.getAllByText(/BONAFIDEHAN GALLERY/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders General Assembly page', () => {
+    render(<GeneralAssembly />);
+    expect(screen.getAllByText(/GENERAL ASSEMBLY/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Chromie Squiggle page', () => {
+    render(<ChromieSquiggle />);
+    expect(screen.getAllByText(/CHROMIE SQUIGGLE/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Genesis DCA page', () => {
+    render(<GenesisDca />);
+    expect(screen.getAllByText(/GENESIS/i).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add CreateWaveDates component tests
- add museum pages test suite for additional static pages

## Testing
- `npx jest __tests__/components/waves/create-wave/dates/CreateWaveDates.test.tsx --coverage`
- `npx jest __tests__/pages/museumPages3.test.tsx --coverage`
- `npm run improve-coverage` *(fails: many existing test failures)*
- `npm run test` *(fails: 23 failed test suites)*