### PR TITLE
Add unit tests for coverage

### DIFF
--- a/__tests__/components/waves/create-wave/outcomes/rep/CreateWaveOutcomesRepApprove.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/rep/CreateWaveOutcomesRepApprove.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveOutcomesRepApprove from '../../../../../../components/waves/create-wave/outcomes/rep/CreateWaveOutcomesRepApprove';
+import { ApiWaveType } from '../../../../../../generated/models/ApiWaveType';
+
+jest.mock('../../../../../../components/utils/input/rep-category/RepCategorySearch', () => {
+  return function RepCategorySearch({ category, setCategory }: any) {
+    return <input data-testid="category" value={category || ''} onChange={e => setCategory(e.target.value)} />;
+  };
+});
+
+jest.mock('../../../../../../components/utils/button/PrimaryButton', () => {
+  return function PrimaryButton({ onClicked, children }: any) {
+    return <button onClick={onClicked}>{children}</button>;
+  };
+});
+
+describe('CreateWaveOutcomesRepApprove', () => {
+  const onOutcome = jest.fn();
+  const onCancel = jest.fn();
+
+  const setup = async () => {
+    const user = userEvent.setup();
+    render(
+      <CreateWaveOutcomesRepApprove
+        waveType={ApiWaveType.Approve}
+        dates={{} as any}
+        onOutcome={onOutcome}
+        onCancel={onCancel}
+      />
+    );
+    const categoryInput = screen.getByTestId('category');
+    const creditInput = screen.getByLabelText('Rep');
+    const maxWinnersInput = screen.getByLabelText('Max Winners');
+    const saveButton = screen.getByText('Save');
+    return { user, categoryInput, creditInput, maxWinnersInput, saveButton };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls onOutcome with entered values', async () => {
+    const { user, categoryInput, creditInput, maxWinnersInput, saveButton } = await setup();
+
+    await user.type(categoryInput, 'cat');
+    await user.type(creditInput, '5');
+    await user.type(maxWinnersInput, '3');
+    await user.click(saveButton);
+
+    expect(onOutcome).toHaveBeenCalledWith(
+      expect.objectContaining({ category: 'cat', credit: 5, maxWinners: 3 })
+    );
+  });
+
+  it('shows errors when required fields missing', async () => {
+    const { user, saveButton } = await setup();
+
+    await user.click(saveButton);
+    expect(onOutcome).not.toHaveBeenCalled();
+    expect(screen.getByText('Rep must be a positive number')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/create-wave/outcomes/winners/rows/CreateWaveOutcomesRow.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/winners/rows/CreateWaveOutcomesRow.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import CreateWaveOutcomesRow from '../../../../../../../components/waves/create-wave/outcomes/winners/rows/CreateWaveOutcomesRow';
+import { ApiWaveType } from '../../../../../../../generated/models/ApiWaveType';
+import { CreateWaveOutcomeType } from '../../../../../../../types/waves.types';
+
+jest.mock('../../../../../../../components/waves/create-wave/outcomes/winners/rows/manual/CreateWaveOutcomesRowManual', () => () => <div data-testid="manual" />);
+jest.mock('../../../../../../../components/waves/create-wave/outcomes/winners/rows/rep/CreateWaveOutcomesRowRep', () => () => <div data-testid="rep" />);
+jest.mock('../../../../../../../components/waves/create-wave/outcomes/winners/rows/cic/CreateWaveOutcomesRowCIC', () => () => <div data-testid="cic" />);
+
+describe('CreateWaveOutcomesRow', () => {
+  const outcome = { type: CreateWaveOutcomeType.MANUAL } as any;
+  const removeOutcome = jest.fn();
+
+  it('renders manual component', () => {
+    render(<CreateWaveOutcomesRow waveType={ApiWaveType.Rank} outcome={{ ...outcome, type: CreateWaveOutcomeType.MANUAL }} removeOutcome={removeOutcome} />);
+    expect(screen.getByTestId('manual')).toBeInTheDocument();
+  });
+
+  it('renders rep component', () => {
+    render(<CreateWaveOutcomesRow waveType={ApiWaveType.Rank} outcome={{ ...outcome, type: CreateWaveOutcomeType.REP }} removeOutcome={removeOutcome} />);
+    expect(screen.getByTestId('rep')).toBeInTheDocument();
+  });
+
+  it('renders cic component', () => {
+    render(<CreateWaveOutcomesRow waveType={ApiWaveType.Rank} outcome={{ ...outcome, type: CreateWaveOutcomeType.NIC }} removeOutcome={removeOutcome} />);
+    expect(screen.getByTestId('cic')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/create-wave/outcomes/winners/rows/rep/CreateWaveOutcomesRowRepApprove.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/winners/rows/rep/CreateWaveOutcomesRowRepApprove.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveOutcomesRowRepApprove from '../../../../../../../../components/waves/create-wave/outcomes/winners/rows/rep/CreateWaveOutcomesRowRepApprove';
+
+jest.mock('../../../../../../../../helpers/Helpers', () => ({
+  formatLargeNumber: (n: number) => n.toString(),
+}));
+
+describe('CreateWaveOutcomesRowRepApprove', () => {
+  const outcome = {
+    category: 'Cat',
+    credit: 10,
+    maxWinners: 2,
+  } as any;
+  const removeOutcome = jest.fn();
+
+  it('displays outcome data and handles remove', async () => {
+    const user = userEvent.setup();
+    render(
+      <CreateWaveOutcomesRowRepApprove outcome={outcome} removeOutcome={removeOutcome} />
+    );
+
+    expect(screen.getByText('Cat')).toBeInTheDocument();
+    expect(screen.getByText('10 Rep')).toBeInTheDocument();
+    expect(screen.getByText('Max winners: 2')).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Remove'));
+    expect(removeOutcome).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/waves/create-wave/outcomes/winners/rows/rep/CreateWaveOutcomesRowRepRank.test.tsx
+++ b/__tests__/components/waves/create-wave/outcomes/winners/rows/rep/CreateWaveOutcomesRowRepRank.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveOutcomesRowRepRank from '../../../../../../../../components/waves/create-wave/outcomes/winners/rows/rep/CreateWaveOutcomesRowRepRank';
+
+jest.mock('../../../../../../../../helpers/Helpers', () => ({
+  formatLargeNumber: (n: number) => n.toString(),
+}));
+
+describe('CreateWaveOutcomesRowRepRank', () => {
+  const outcome = {
+    category: 'Cat',
+    winnersConfig: { totalAmount: 100, winners: [{}, {}] },
+  } as any;
+  const removeOutcome = jest.fn();
+
+  it('renders data and handles remove click', async () => {
+    const user = userEvent.setup();
+    render(
+      <CreateWaveOutcomesRowRepRank outcome={outcome} removeOutcome={removeOutcome} />
+    );
+
+    expect(screen.getByText('Cat')).toBeInTheDocument();
+    expect(screen.getByText('Total: 100 Rep')).toBeInTheDocument();
+    expect(screen.getByText('Winners: 2')).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Remove'));
+    expect(removeOutcome).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/waves/create-wave/overview/CreateWaveNameInput.test.tsx
+++ b/__tests__/components/waves/create-wave/overview/CreateWaveNameInput.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveNameInput from '../../../../../components/waves/create-wave/overview/CreateWaveNameInput';
+import { CREATE_WAVE_VALIDATION_ERROR } from '../../../../../helpers/waves/create-wave.validation';
+
+beforeAll(() => {
+  // Mock ResizeObserver used in CommonAnimationHeight
+  // @ts-ignore
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe('CreateWaveNameInput', () => {
+  it('calls onChange when typing', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    render(<CreateWaveNameInput name="" errors={[]} onChange={onChange} />);
+    await user.type(screen.getByLabelText('Name'), 'Wave');
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('shows error message when name required', () => {
+    render(<CreateWaveNameInput name="" errors={[CREATE_WAVE_VALIDATION_ERROR.NAME_REQUIRED]} onChange={jest.fn()} />);
+    expect(screen.getByText('Name is required')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/create-wave/utils/CreateWaveNextStep.test.tsx
+++ b/__tests__/components/waves/create-wave/utils/CreateWaveNextStep.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveNextStep from '../../../../../components/waves/create-wave/utils/CreateWaveNextStep';
+import { CreateWaveStep } from '../../../../../types/waves.types';
+
+jest.mock('../../../../../components/utils/button/PrimaryButton', () => {
+  return function PrimaryButton({ onClicked, children, disabled }: any) {
+    return <button onClick={onClicked} disabled={disabled}>{children}</button>;
+  };
+});
+
+describe('CreateWaveNextStep', () => {
+  it('renders Next when step not description', async () => {
+    const user = userEvent.setup();
+    const onClick = jest.fn();
+    render(<CreateWaveNextStep disabled={false} submitting={false} step={CreateWaveStep.DATES} onClick={onClick} />);
+    await user.click(screen.getByText('Next'));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('renders Complete when step is description', () => {
+    render(<CreateWaveNextStep disabled={false} submitting={true} step={CreateWaveStep.DESCRIPTION} onClick={jest.fn()} />);
+    expect(screen.getByText('Complete')).toBeInTheDocument();
+    expect(screen.getByText('Complete')).toBeDisabled();
+  });
+});

--- a/__tests__/helpers/time.types.test.ts
+++ b/__tests__/helpers/time.types.test.ts
@@ -1,0 +1,5 @@
+import 'helpers/waves/time.types';
+
+test('module loads', () => {
+  expect(true).toBe(true);
+});

--- a/__tests__/hooks/useAppWalletPasswordModal.test.tsx
+++ b/__tests__/hooks/useAppWalletPasswordModal.test.tsx
@@ -1,0 +1,41 @@
+import { renderHook, act } from '@testing-library/react';
+import { useAppWalletPasswordModal } from '../../hooks/useAppWalletPasswordModal';
+
+jest.mock('../../components/app-wallets/AppWalletModal', () => ({
+  UnlockAppWalletModal: ({ show, onUnlock, onHide }: any) => (
+    <div data-testid="modal" data-show={show} onClick={() => onUnlock('pass')} onDoubleClick={onHide} />
+  ),
+}));
+
+describe('useAppWalletPasswordModal', () => {
+  it('resolves promise on unlock', async () => {
+    const { result } = renderHook(() => useAppWalletPasswordModal());
+
+    let resolved: string | undefined;
+    let promise: Promise<string> = Promise.resolve('');
+    await act(async () => {
+      promise = result.current.requestPassword('0x1', 'hash');
+    });
+
+    act(() => {
+      result.current.modal.props.onUnlock('pass');
+    });
+
+    await expect(promise).resolves.toBe('pass');
+  });
+
+  it('rejects promise on cancel', async () => {
+    const { result } = renderHook(() => useAppWalletPasswordModal());
+
+    let promise: Promise<string> = Promise.resolve('');
+    await act(async () => {
+      promise = result.current.requestPassword('0x1', 'hash');
+    });
+
+    act(() => {
+      result.current.modal.props.onHide();
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(Error);
+  });
+});

--- a/__tests__/pages/userPageIdentity.test.tsx
+++ b/__tests__/pages/userPageIdentity.test.tsx
@@ -1,0 +1,27 @@
+import { getServerSideProps } from '../../pages/[user]/identity';
+import { getCommonHeaders, getUserProfile, userPageNeedsRedirect } from '../../helpers/server.helpers';
+import { getMetadataForUserPage } from '../../helpers/Helpers';
+
+jest.mock('../../helpers/server.helpers');
+jest.mock('../../helpers/Helpers');
+
+const mockProfile = { handle: 'alice' } as any;
+(getCommonHeaders as jest.Mock).mockReturnValue({ head: '1' });
+(getUserProfile as jest.Mock).mockResolvedValue(mockProfile);
+(getMetadataForUserPage as jest.Mock).mockReturnValue('meta');
+
+describe('identity page getServerSideProps', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('redirects when helper returns redirect', async () => {
+    (userPageNeedsRedirect as jest.Mock).mockReturnValue({ redirect: 'yes' });
+    const result = await getServerSideProps({ query: { user: 'bob' }, req: {} } as any, null as any, null as any);
+    expect(result).toEqual({ redirect: 'yes' });
+  });
+
+  it('returns props when no redirect needed', async () => {
+    (userPageNeedsRedirect as jest.Mock).mockReturnValue(false);
+    const result = await getServerSideProps({ query: { user: 'bob' }, req: {} } as any, null as any, null as any);
+    expect(result).toEqual({ props: { profile: mockProfile, handleOrWallet: 'bob', metadata: 'meta' } });
+  });
+});

--- a/__tests__/pages/userPageSubscriptions.test.tsx
+++ b/__tests__/pages/userPageSubscriptions.test.tsx
@@ -1,0 +1,27 @@
+import { getServerSideProps } from '../../pages/[user]/subscriptions';
+import { getCommonHeaders, getUserProfile, userPageNeedsRedirect } from '../../helpers/server.helpers';
+import { getMetadataForUserPage } from '../../helpers/Helpers';
+
+jest.mock('../../helpers/server.helpers');
+jest.mock('../../helpers/Helpers');
+
+const mockProfile = { handle: 'alice' } as any;
+(getCommonHeaders as jest.Mock).mockReturnValue({ head: '1' });
+(getUserProfile as jest.Mock).mockResolvedValue(mockProfile);
+(getMetadataForUserPage as jest.Mock).mockReturnValue('meta');
+
+describe('subscriptions page getServerSideProps', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('redirects when helper returns redirect', async () => {
+    (userPageNeedsRedirect as jest.Mock).mockReturnValue({ redirect: 'yes' });
+    const result = await getServerSideProps({ query: { user: 'bob' }, req: {} } as any, null as any, null as any);
+    expect(result).toEqual({ redirect: 'yes' });
+  });
+
+  it('returns props when no redirect needed', async () => {
+    (userPageNeedsRedirect as jest.Mock).mockReturnValue(false);
+    const result = await getServerSideProps({ query: { user: 'bob' }, req: {} } as any, null as any, null as any);
+    expect(result).toEqual({ props: { profile: mockProfile, metadata: 'meta' } });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for create wave components and hooks
- add page getServerSideProps tests

## Testing
- `npx jest __tests__/components/waves/create-wave/outcomes/rep/CreateWaveOutcomesRepApprove.test.tsx --coverage`
- `npx jest __tests__/components/waves/create-wave/outcomes/winners/rows/CreateWaveOutcomesRow.test.tsx --coverage`
- `npx jest __tests__/components/waves/create-wave/outcomes/winners/rows/rep/CreateWaveOutcomesRowRepApprove.test.tsx --coverage`
- `npx jest __tests__/components/waves/create-wave/outcomes/winners/rows/rep/CreateWaveOutcomesRowRepRank.test.tsx --coverage`
- `npx jest __tests__/components/waves/create-wave/overview/CreateWaveNameInput.test.tsx --coverage`
- `npx jest __tests__/components/waves/create-wave/utils/CreateWaveNextStep.test.tsx --coverage`
- `npx jest __tests__/helpers/time.types.test.ts --coverage`
- `npx jest __tests__/hooks/useAppWalletPasswordModal.test.tsx --coverage`
- `npx jest __tests__/pages/userPageIdentity.test.tsx --coverage`
- `npx jest __tests__/pages/userPageSubscriptions.test.tsx --coverage`
