### PR TITLE
Add tests for banner and terms hooks

### DIFF
--- a/__tests__/components/user/user-page-header/banner/UserPageHeaderBanner.test.tsx
+++ b/__tests__/components/user/user-page-header/banner/UserPageHeaderBanner.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserPageHeaderBanner from '../../../../../components/user/user-page-header/banner/UserPageHeaderBanner';
+import { ApiIdentity } from '../../../../../generated/models/ApiIdentity';
+
+jest.mock('../../../../../components/utils/icons/PencilIcon', () => () => <span data-testid="pencil" />);
+jest.mock('../../../../../components/utils/animation/CommonAnimationWrapper', () => ({ children }: any) => <div>{children}</div>);
+jest.mock('../../../../../components/utils/animation/CommonAnimationOpacity', () => ({ children, onClicked }: any) => (
+  <div data-testid="opacity" onClick={onClicked}>{children}</div>
+));
+
+jest.mock('../../../../../components/user/user-page-header/banner/UserPageHeaderEditBanner', () => (props: any) => (
+  <div data-testid="edit" onClick={props.onClose} />
+));
+
+describe('UserPageHeaderBanner', () => {
+  const baseProfile: ApiIdentity = {
+    id: '1',
+    handle: 'alice',
+    normalised_handle: null,
+    pfp: null,
+    cic: 0,
+    rep: 0,
+    level: 0,
+    tdh: 0,
+    consolidation_key: '',
+    display: 'alice',
+    primary_wallet: '0xabc',
+    banner1: null,
+    banner2: null,
+    classification: 0 as any,
+    sub_classification: null,
+  };
+
+  it('opens and closes edit modal when button clicked', async () => {
+    render(
+      <UserPageHeaderBanner profile={baseProfile} defaultBanner1="#000" defaultBanner2="#fff" canEdit={true} />
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+    expect(screen.getByTestId('edit')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('edit'));
+    expect(screen.queryByTestId('edit')).toBeNull();
+  });
+
+  it('hides edit button when cannot edit', () => {
+    render(
+      <UserPageHeaderBanner profile={baseProfile} defaultBanner1="#000" defaultBanner2="#fff" canEdit={false} />
+    );
+
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+});

--- a/__tests__/components/waves/list/WavesListSearchResults.test.tsx
+++ b/__tests__/components/waves/list/WavesListSearchResults.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import React from "react";
 import WavesListSearchResults from '../../../../components/waves/list/WavesListSearchResults';
 import { useWaves } from '../../../../hooks/useWaves';
 import { ApiWave } from '../../../../generated/models/ApiWave';

--- a/__tests__/hooks/drops/useTermsSignatureFlow.test.ts
+++ b/__tests__/hooks/drops/useTermsSignatureFlow.test.ts
@@ -1,0 +1,87 @@
+import { renderHook, act } from '@testing-library/react';
+import { useTermsSignatureFlow } from '../../../hooks/drops/useTermsSignatureFlow';
+import { useDropSignature } from '../../../hooks/drops/useDropSignature';
+
+jest.mock('../../../hooks/drops/useDropSignature');
+
+const mockSignDrop = jest.fn().mockResolvedValue({ success: true, signature: 'sig' });
+(useDropSignature as jest.Mock).mockReturnValue({ signDrop: mockSignDrop, isLoading: false });
+
+describe('useTermsSignatureFlow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('opens modal when terms require acknowledgment', async () => {
+    const { result } = renderHook(() => useTermsSignatureFlow());
+    const callback = jest.fn();
+
+    await act(async () => {
+      await result.current.prepareAndSignDrop({
+        drop: { id: 1 } as any,
+        termsOfService: 'Terms here',
+        onSigningComplete: callback,
+      });
+    });
+
+    expect(result.current.isTermsModalOpen).toBe(true);
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('signs immediately when no terms provided', async () => {
+    const { result } = renderHook(() => useTermsSignatureFlow());
+    const callback = jest.fn();
+
+    await act(async () => {
+      await result.current.prepareAndSignDrop({
+        drop: { id: 2 } as any,
+        termsOfService: null,
+        onSigningComplete: callback,
+      });
+    });
+
+    expect(mockSignDrop).toHaveBeenCalledWith({ drop: { id: 2 }, termsOfService: null });
+    expect(callback).toHaveBeenCalledWith({ success: true, signature: 'sig' });
+  });
+
+  it('completes signing after terms accepted', async () => {
+    const { result } = renderHook(() => useTermsSignatureFlow());
+    const callback = jest.fn();
+
+    await act(async () => {
+      await result.current.prepareAndSignDrop({
+        drop: { id: 3 } as any,
+        termsOfService: 'Terms',
+        onSigningComplete: callback,
+      });
+    });
+
+    await act(async () => {
+      await result.current.onTermsAccepted();
+    });
+
+    expect(mockSignDrop).toHaveBeenCalledWith({ drop: { id: 3 }, termsOfService: 'Terms' });
+    expect(callback).toHaveBeenCalledWith({ success: true, signature: 'sig' });
+    expect(result.current.isTermsModalOpen).toBe(false);
+  });
+
+  it('handles rejection correctly', async () => {
+    const { result } = renderHook(() => useTermsSignatureFlow());
+    const callback = jest.fn();
+
+    await act(async () => {
+      await result.current.prepareAndSignDrop({
+        drop: { id: 4 } as any,
+        termsOfService: 'Terms',
+        onSigningComplete: callback,
+      });
+    });
+
+    act(() => {
+      result.current.onTermsRejected();
+    });
+
+    expect(callback).toHaveBeenCalledWith({ success: false });
+    expect(result.current.isTermsModalOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for `UserPageHeaderBanner` component
- test `useTermsSignatureFlow` hook behaviour
- fix WavesListSearchResults test setup

## Testing
- `npx jest __tests__/components/user/user-page-header/banner/UserPageHeaderBanner.test.tsx __tests__/hooks/drops/useTermsSignatureFlow.test.ts --coverage`