### PR TITLE
Add tests for museum pages and CreateWave component

### DIFF
--- a/__tests__/components/waves/create-wave/CreateWave.test.tsx
+++ b/__tests__/components/waves/create-wave/CreateWave.test.tsx
@@ -1,0 +1,106 @@
+// @ts-nocheck
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWave from '../../../../components/waves/create-wave/CreateWave';
+import { AuthContext } from '../../../../components/auth/Auth';
+import { ReactQueryWrapperContext } from '../../../../components/react-query-wrapper/ReactQueryWrapper';
+import { ApiWaveType } from '../../../../generated/models/ApiWaveType';
+import { ApiWaveCreditType } from '../../../../generated/models/ApiWaveCreditType';
+import { ApiIdentity } from '../../../../generated/models/ApiIdentity';
+import { createMockAuthContext } from '../../../utils/testContexts';
+import { CreateWaveStep } from '../../../../types/waves.types';
+import { useWaveConfig } from '../../../../components/waves/create-wave/hooks/useWaveConfig';
+
+jest.mock('../../../../components/waves/create-wave/drops/CreateWaveDrops', () => () => <div data-testid='drops' />);
+jest.mock('../../../../components/waves/create-wave/main-steps/CreateWavesMainSteps', () => () => <div data-testid='steps' />);
+jest.mock('../../../../components/waves/create-wave/overview/CreateWaveOverview', () => () => <div data-testid='overview'>OVERVIEW</div>);
+jest.mock('../../../../components/waves/create-wave/groups/CreateWaveGroups', () => () => <div data-testid='groups'>GROUPS</div>);
+jest.mock('../../../../components/waves/create-wave/dates/CreateWaveDates', () => () => <div data-testid='dates'>DATES</div>);
+jest.mock('../../../../components/waves/create-wave/outcomes/CreateWaveOutcomes', () => () => <div data-testid='outcomes'>OUTCOMES</div>);
+jest.mock('../../../../components/waves/create-wave/voting/CreateWaveVoting', () => () => <div data-testid='voting'>VOTING</div>);
+jest.mock('../../../../components/waves/create-wave/approval/CreateWaveApproval', () => () => <div data-testid='approval'>APPROVAL</div>);
+
+jest.mock('../../../../components/waves/create-wave/description/CreateWaveDescription', () =>
+  React.forwardRef(() => {
+    return <div data-testid='description'>DESCRIPTION</div>;
+  })
+);
+
+jest.mock('../../../../hooks/useCapacitor', () => ({ __esModule: true, default: () => ({ isIos: false, keyboardVisible: false }) }));
+jest.mock('../../../../components/waves/create-wave/services/waveApiService', () => ({ useAddWaveMutation: () => ({ mutateAsync: jest.fn() }) }));
+jest.mock('next/router', () => ({ useRouter: () => ({ push: jest.fn() }) }));
+
+jest.mock('../../../../components/waves/create-wave/utils/CreateWaveActions', () => (props: any) => (
+  <button data-testid='next' onClick={() => props.setStep(CreateWaveStep.GROUPS, 'forward')}>next</button>
+));
+
+jest.mock('../../../../components/waves/create-wave/hooks/useWaveConfig');
+
+const mockedUseWaveConfig = useWaveConfig as jest.MockedFunction<typeof useWaveConfig>;
+
+function setup() {
+  mockedUseWaveConfig.mockImplementation(() => {
+    const [step, setStep] = React.useState(CreateWaveStep.OVERVIEW);
+    const config = {
+      overview: { type: ApiWaveType.Chat, name: '', image: null },
+      groups: { canView: null, canDrop: null, canVote: null, canChat: null, admin: '1' },
+      chat: { enabled: true },
+      dates: { submissionStartDate: 0, votingStartDate: 0, endDate: null, firstDecisionTime: 0, subsequentDecisions: [], isRolling: false },
+      drops: { noOfApplicationsAllowedPerParticipant: null, requiredTypes: [], requiredMetadata: [], terms: null, signatureRequired: false, adminCanDeleteDrops: false },
+      voting: { type: ApiWaveCreditType.Tdh, category: null, profileId: null, timeWeighted: { enabled: false, averagingInterval: 24, averagingIntervalUnit: 'hours' } },
+      outcomes: [],
+      approval: { threshold: null, thresholdTimeMs: null },
+    } as any;
+    return {
+      config,
+      step,
+      selectedOutcomeType: null,
+      errors: [],
+      groupsCache: {},
+      setOverview: jest.fn(),
+      setDates: jest.fn(),
+      setDrops: jest.fn(),
+      setOutcomes: jest.fn(),
+      setDropsAdminCanDelete: jest.fn(),
+      onStep: ({ step: s }: { step: CreateWaveStep; direction: 'forward' | 'backward' }) => setStep(s),
+      onOutcomeTypeChange: jest.fn(),
+      onGroupSelect: jest.fn(),
+      onVotingTypeChange: jest.fn(),
+      onCategoryChange: jest.fn(),
+      onProfileIdChange: jest.fn(),
+      onTimeWeightedVotingChange: jest.fn(),
+      onThresholdChange: jest.fn(),
+      onThresholdTimeChange: jest.fn(),
+      onChatEnabledChange: jest.fn(),
+    };
+  });
+
+  const auth = createMockAuthContext({ requestAuth: jest.fn(), connectedProfile: null });
+  const query = { waitAndInvalidateDrops: jest.fn(), onWaveCreated: jest.fn() } as any;
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <AuthContext.Provider value={auth}>
+      <ReactQueryWrapperContext.Provider value={query}>{children}</ReactQueryWrapperContext.Provider>
+    </AuthContext.Provider>
+  );
+  return { Wrapper };
+}
+
+describe('CreateWave', () => {
+  it('renders overview and navigates to groups', async () => {
+    const { Wrapper } = setup();
+    const user = userEvent.setup();
+    render(<CreateWave profile={{} as ApiIdentity} onBack={jest.fn()} />, { wrapper: Wrapper });
+    expect(screen.getByTestId('overview')).toBeInTheDocument();
+    await user.click(screen.getByTestId('next'));
+    expect(screen.getByTestId('groups')).toBeInTheDocument();
+  });
+
+  it('invokes onBack handler', async () => {
+    const { Wrapper } = setup();
+    const onBack = jest.fn();
+    render(<CreateWave profile={{} as ApiIdentity} onBack={onBack} />, { wrapper: Wrapper });
+    await userEvent.click(screen.getByRole('button', { name: /back/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/__tests__/pages/memeLabPage.test.tsx
+++ b/__tests__/pages/memeLabPage.test.tsx
@@ -1,0 +1,29 @@
+// @ts-nocheck
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import MemeLabPage, { getServerSideProps } from '../../pages/meme-lab/[id]';
+import { AuthContext } from '../../components/auth/Auth';
+import { createMockAuthContext } from '../utils/testContexts';
+import { getSharedServerSideProps } from '../../components/the-memes/MemeShared';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+jest.mock('../../components/memelab/MemeLabPage', () => () => <div data-testid="lab" />);
+jest.mock('../../components/the-memes/MemeShared', () => ({ getSharedServerSideProps: jest.fn(() => ({ props: {} })) }));
+
+const auth = createMockAuthContext({ connectedProfile: { wallets: [{ wallet: '0x1' }] } as any });
+
+describe('MemeLabPage', () => {
+  it('renders lab component with connected wallets', () => {
+    render(
+      <AuthContext.Provider value={auth}>
+        <MemeLabPage />
+      </AuthContext.Provider>
+    );
+    expect(screen.getByTestId('dynamic')).toBeInTheDocument();
+  });
+
+  it('calls shared server side props', async () => {
+    await getServerSideProps({}, {}, '/');
+    expect(getSharedServerSideProps).toHaveBeenCalled();
+  });
+});

--- a/__tests__/pages/museumPages3.test.tsx
+++ b/__tests__/pages/museumPages3.test.tsx
@@ -1,0 +1,55 @@
+// @ts-nocheck
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import Azuki from '../../pages/museum/6529-fund-szn1/azuki';
+import Cod from '../../pages/museum/6529-fund-szn1/cod';
+import InvisibleFriends from '../../pages/museum/6529-fund-szn1/invisible-friends';
+import Nouns from '../../pages/museum/6529-fund-szn1/nouns';
+import Screens from '../../pages/museum/6529-fund-szn1/screens';
+import TwinFlames from '../../pages/museum/6529-fund-szn1/twin-flames';
+import PhotoA from '../../pages/museum/6529-photo-a';
+import Batsoupyum from '../../pages/museum/batsoupyum-museum-2';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+describe('additional museum pages render', () => {
+  it('renders Azuki page', () => {
+    render(<Azuki />);
+    expect(screen.getAllByText(/AZUKI/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders COD page', () => {
+    render(<Cod />);
+    expect(screen.getAllByText(/COD/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Invisible Friends page', () => {
+    render(<InvisibleFriends />);
+    expect(screen.getAllByText(/INVISIBLE FRIENDS/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Nouns page', () => {
+    render(<Nouns />);
+    expect(screen.getAllByText(/NOUNS/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Screens page', () => {
+    render(<Screens />);
+    expect(screen.getAllByText(/SCREENS/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Twin Flames page', () => {
+    render(<TwinFlames />);
+    expect(screen.getAllByText(/TWIN FLAMES/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders 6529 Photo A page', () => {
+    render(<PhotoA />);
+    expect(screen.getAllByText(/6529 PHOTO A/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Batsoupyum museum page', () => {
+    render(<Batsoupyum />);
+    expect(screen.getAllByText(/BATSOUPLOUNGE/i).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for several museum static pages
- add tests for meme lab page
- test CreateWave component navigation

## Testing
- `npx jest __tests__/pages/museumPages3.test.tsx --coverage --silent`
- `npx jest __tests__/pages/memeLabPage.test.tsx --coverage --silent`
- `npx jest __tests__/components/waves/create-wave/CreateWave.test.tsx --coverage --silent`
- `npm run lint`
- `npm run type-check` *(fails: numerous existing TS errors)*