### PR TITLE
Add tests for several Next.js pages

### DIFF
--- a/__tests__/pages/additionalPages2.test.tsx
+++ b/__tests__/pages/additionalPages2.test.tsx
@@ -1,0 +1,26 @@
+// @ts-nocheck
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import Teexels from '../../pages/author/teexels/index';
+import Capital from '../../pages/capital/index';
+import Feed from '../../pages/feed/index';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+describe('additional static pages 2', () => {
+  it('renders Teexels author page', () => {
+    render(<Teexels />);
+    expect(screen.getAllByText(/Teexels/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Capital page', () => {
+    render(<Capital />);
+    expect(screen.getAllByText(/6529 CAPITAL/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Feed redirect page', () => {
+    render(<Feed />);
+    expect(screen.getByText(/You are being redirected/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /index.xml/i })).toHaveAttribute('href', 'index.xml');
+  });
+});

--- a/__tests__/pages/app.test.ts
+++ b/__tests__/pages/app.test.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+import { Chain, mainnet, sepolia, goerli } from 'wagmi/chains';
+
+describe('getChains', () => {
+  const loadGetChains = (mocks: {delegation?: Chain; nextgen?: Chain; subs?: Chain; manifold?: Chain}) => {
+    jest.isolateModules(() => {
+      jest.resetModules();
+      jest.doMock('@web3modal/wagmi/react', () => ({ createWeb3Modal: jest.fn() }));
+      jest.doMock('../../wagmiConfig/wagmiConfigWeb', () => ({ wagmiConfigWeb: jest.fn(() => ({})) }));
+      jest.doMock('../../wagmiConfig/wagmiConfigCapacitor', () => ({ wagmiConfigCapacitor: jest.fn(() => ({})) }));
+      jest.doMock('../../store/store', () => ({ wrapper: { useWrappedStore: jest.fn(() => ({store:{}, props:{}})) } }));
+      jest.doMock('../../components/nextGen/nextgen_contracts', () => ({ NEXTGEN_CHAIN_ID: mocks.nextgen?.id ?? mainnet.id }));
+      jest.doMock('../../hooks/useManifoldClaim', () => ({ MANIFOLD_NETWORK: mocks.manifold ?? mainnet }));
+      jest.doMock('../../constants', () => ({
+        CW_PROJECT_ID: '1',
+        DELEGATION_CONTRACT: { chain_id: mocks.delegation?.id ?? mainnet.id, contract: '0x0' },
+        SUBSCRIPTIONS_CHAIN: mocks.subs ?? mainnet,
+      }));
+      const mod = require('../../pages/_app');
+      chains = mod.getChains();
+    });
+    return chains;
+  };
+  let chains: Chain[] = [];
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it('returns mainnet when no test nets configured', () => {
+    const result = loadGetChains({});
+    expect(result.map(c => c.id)).toEqual([mainnet.id]);
+  });
+
+  it('includes sepolia when delegation contract uses sepolia', () => {
+    const result = loadGetChains({delegation: sepolia});
+    expect(result.map(c => c.id)).toEqual([mainnet.id, sepolia.id]);
+  });
+
+  it('includes goerli when NEXTGEN_CHAIN_ID is goerli', () => {
+    const result = loadGetChains({nextgen: goerli});
+    expect(result.map(c => c.id)).toEqual([mainnet.id, goerli.id]);
+  });
+});

--- a/__tests__/pages/museumPages4.test.tsx
+++ b/__tests__/pages/museumPages4.test.tsx
@@ -1,0 +1,37 @@
+// @ts-nocheck
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import Fam2021 from '../../pages/museum/6529-fam-2021';
+import ActOfKindness from '../../pages/museum/6529-fund-szn1/act-of-kindness';
+import Archeology from '../../pages/museum/6529-fund-szn1/archeology-of-the-future';
+import ChromieSquiggle from '../../pages/museum/6529-fund-szn1/chromie-squiggle';
+import ConflictingMetaphysics from '../../pages/museum/6529-fund-szn1/conflicting-metaphysics';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+describe('museum pages set 4', () => {
+  it('renders 6529 Fam 2021 page', () => {
+    render(<Fam2021 />);
+    expect(screen.getAllByText(/6529 FAM 2021/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Act of Kindness page', () => {
+    render(<ActOfKindness />);
+    expect(screen.getAllByText(/ACT OF KINDNESS/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Archeology of the Future page', () => {
+    render(<Archeology />);
+    expect(screen.getAllByText(/ARCHEOLOGY OF THE FUTURE/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Chromie Squiggle page', () => {
+    render(<ChromieSquiggle />);
+    expect(screen.getAllByText(/CHROMIE SQUIGGLE/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Conflicting Metaphysics page', () => {
+    render(<ConflictingMetaphysics />);
+    expect(screen.getAllByText(/CONFLICTING METAPHYSICS/i).length).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/pages/userFollowers.test.tsx
+++ b/__tests__/pages/userFollowers.test.tsx
@@ -1,0 +1,47 @@
+// @ts-nocheck
+import React from 'react';
+import { render } from '@testing-library/react';
+import Page, { getServerSideProps } from '../../pages/[user]/followers';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+jest.mock('../../components/user/followers/UserPageFollowers', () => () => <div data-testid="followers" />);
+jest.mock('../../components/user/layout/UserPageLayout', () => ({ children }: any) => <div data-testid="layout">{children}</div>);
+
+jest.mock('../../helpers/server.helpers', () => ({
+  getCommonHeaders: jest.fn(() => ({ h: '1' })),
+  getUserProfile: jest.fn(() => Promise.resolve({ handle: 'alice' })),
+  userPageNeedsRedirect: jest.fn(() => false),
+}));
+
+jest.mock('../../helpers/Helpers', () => ({
+  getMetadataForUserPage: jest.fn(() => 'meta'),
+}));
+
+const { getCommonHeaders, getUserProfile, userPageNeedsRedirect } = require('../../helpers/server.helpers');
+
+describe('followers page', () => {
+  it('renders followers component', () => {
+    const { getByTestId } = render(<Page pageProps={{ profile: { handle: 'alice' } as any }} />);
+    expect(getByTestId('followers')).toBeInTheDocument();
+  });
+
+  it('returns redirect when helpers request it', async () => {
+    (userPageNeedsRedirect as jest.Mock).mockReturnValue({ redirect: 'yes' });
+    const res = await getServerSideProps({ query: { user: 'alice' } } as any, null as any, null as any);
+    expect(res).toEqual({ redirect: 'yes' });
+  });
+
+  it('returns props when no redirect', async () => {
+    (userPageNeedsRedirect as jest.Mock).mockReturnValue(false);
+    const res = await getServerSideProps({ query: { user: 'alice' } } as any, null as any, null as any);
+    expect(res).toEqual({ props: { profile: { handle: 'alice' }, metadata: 'meta' } });
+    expect(getCommonHeaders).toHaveBeenCalled();
+    expect(getUserProfile).toHaveBeenCalled();
+  });
+
+  it('handles errors by redirecting to 404', async () => {
+    (getUserProfile as jest.Mock).mockRejectedValue(new Error('fail'));
+    const res = await getServerSideProps({ query: { user: 'alice' } } as any, null as any, null as any);
+    expect(res).toEqual({ redirect: { permanent: false, destination: '/404' }, props: {} });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests covering getChains from _app
- test [user] followers page component and server props
- add coverage for Teexels, Capital and Feed pages
- test additional museum pages

## Testing
- `npm run lint`
- `npm run test`
- `npm run type-check` *(fails: numerous existing TypeScript errors)*