### PR TITLE
Add tests for static pages

### DIFF
--- a/__tests__/pages/memeAccounting.test.tsx
+++ b/__tests__/pages/memeAccounting.test.tsx
@@ -1,0 +1,40 @@
+// @ts-nocheck
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import MemeAccountingPage from '../../pages/meme-accounting';
+import { AuthContext } from '../../components/auth/Auth';
+
+jest.mock('../../components/gas-royalties/Royalties', () => () => <div data-testid="royalties" />);
+
+jest.mock('../../styles/Home.module.scss', () => ({
+  main: 'main-class',
+}));
+
+describe('MemeAccountingPage', () => {
+  const setTitle = jest.fn();
+
+  const renderPage = () =>
+    render(
+      <AuthContext.Provider value={{ setTitle } as any}>
+        <MemeAccountingPage />
+      </AuthContext.Provider>
+    );
+
+  it('renders royalties component inside main', async () => {
+    const { container } = renderPage();
+    expect(container.querySelector('main')).toHaveClass('main-class');
+    expect(await screen.findByTestId('royalties')).toBeInTheDocument();
+  });
+
+  it('sets the page title on mount', () => {
+    renderPage();
+    expect(setTitle).toHaveBeenCalledWith({ title: 'Meme Accounting | Tools' });
+  });
+
+  it('exposes correct metadata', () => {
+    expect(MemeAccountingPage.metadata).toEqual({
+      title: 'Meme Accounting',
+      description: 'Tools',
+    });
+  });
+});

--- a/__tests__/pages/miscPages3.test.tsx
+++ b/__tests__/pages/miscPages3.test.tsx
@@ -1,0 +1,94 @@
+// @ts-nocheck
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AuthorPage from '../../pages/author/6529er6529-io';
+import CompanyPortfolio from '../../pages/capital/company-portfolio';
+import EducationPage from '../../pages/education';
+import FakeRares from '../../pages/museum/6529-fund-szn1/fakerares';
+import Gazers from '../../pages/museum/6529-fund-szn1/gazers';
+import RarePepe from '../../pages/museum/6529-fund-szn1/rarepepe';
+import WildChild from '../../pages/museum/6529-fund-szn1/wild-child-2022';
+import Bonafidehan from '../../pages/museum/bonafidehan-museum';
+import AerialView from '../../pages/museum/genesis/aerial-view';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+jest.mock('../../components/header/Header', () => () => <div data-testid="header" />);
+jest.mock('../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder" />);
+
+describe('static content pages render meta tags and headings', () => {
+  const pages = [
+    {
+      Component: AuthorPage,
+      title: '6529er, Author at 6529.io',
+      canonical: '/author/6529er6529-io/',
+    },
+    {
+      Component: CompanyPortfolio,
+      title: 'COMPANY PORTFOLIO - 6529.io',
+      canonical: '/capital/company-portfolio/',
+      heading: /6529 NFT FUND/i,
+    },
+    {
+      Component: EducationPage,
+      title: 'EDUCATION - 6529.io',
+      canonical: '/education/',
+      heading: /EDUCATION/i,
+    },
+    {
+      Component: FakeRares,
+      title: 'FAKERARES - 6529.io',
+      canonical: '/museum/6529-fund-szn1/fakerares/',
+      heading: /FAKERARES/i,
+    },
+    {
+      Component: Gazers,
+      title: 'GAZERS - 6529.io',
+      canonical: '/museum/6529-fund-szn1/gazers/',
+      heading: /GAZERS/i,
+    },
+    {
+      Component: RarePepe,
+      title: 'RAREPEPE - 6529.io',
+      canonical: '/museum/6529-fund-szn1/rarepepe/',
+      heading: /RAREPEPE/i,
+    },
+    {
+      Component: WildChild,
+      title: 'WILD CHILD 2022 - 6529.io',
+      canonical: '/museum/6529-fund-szn1/wild-child-2022/',
+      heading: /WILD CHILD 2022/i,
+    },
+    {
+      Component: Bonafidehan,
+      title: 'BONAFIDEHAN GALLERY - 6529.io',
+      canonical: '/museum/bonafidehan-museum/',
+      heading: /BONAFIDEHAN GALLERY/i,
+    },
+    {
+      Component: AerialView,
+      title: 'AERIAL VIEW - 6529.io',
+      canonical: '/museum/genesis/aerial-view/',
+      heading: /AERIAL VIEW/i,
+    },
+  ];
+
+  pages.forEach(({ Component, title, canonical, heading }) => {
+    it(`renders ${title}`, () => {
+      render(<Component />);
+
+      const titleElement = document.querySelector('title');
+      expect(titleElement?.textContent).toBe(title);
+
+      const canonicalLink = document.querySelector('link[rel="canonical"]');
+      expect(canonicalLink?.getAttribute('href')).toBe(canonical);
+
+      const ogTitle = document.querySelector('meta[property="og:title"]');
+      expect(ogTitle?.getAttribute('content')).toBe(title);
+
+      if (heading) {
+        const h1 = document.querySelector('h1');
+        expect(h1?.textContent).toMatch(heading);
+      }
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "__tests__"
   ]
 }


### PR DESCRIPTION
## Summary
- add tests for Meme Accounting page
- add misc static page tests
- exclude test files from TypeScript build

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
