### PR TITLE
Add missing page tests

### DIFF
--- a/__tests__/pages/gradientPage.test.tsx
+++ b/__tests__/pages/gradientPage.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import GradientPage, { getServerSideProps } from '../../pages/6529-gradient/[id]';
+import { AuthContext } from '../../components/auth/Auth';
+import { fetchUrl } from '../../services/6529api';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+jest.mock('../../services/6529api');
+
+const TestProvider: React.FC<{children: React.ReactNode}> = ({ children }) => (
+  <AuthContext.Provider value={{ setTitle: jest.fn() } as any}>{children}</AuthContext.Provider>
+);
+
+describe('GradientPage', () => {
+  it('renders gradient component', () => {
+    render(
+      <TestProvider>
+        <GradientPage pageProps={{ id: '1', name: 'Gradient #1', image: 'img', metadata: {} }} />
+      </TestProvider>
+    );
+    expect(screen.getByTestId('dynamic')).toBeInTheDocument();
+  });
+});
+
+describe('GradientPage getServerSideProps', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns data from api', async () => {
+    (fetchUrl as jest.Mock).mockResolvedValue({ data: [{ name: 'G1', thumbnail: 't.png' }] });
+    const result = await getServerSideProps({ query: { id: '5' } } as any, null as any, null as any);
+    expect(result).toEqual({
+      props: {
+        id: '5',
+        name: 'G1',
+        image: 't.png',
+        metadata: { title: 'G1', ogImage: 't.png', description: '6529 Gradient' },
+      },
+    });
+  });
+
+  it('uses defaults when api empty', async () => {
+    (fetchUrl as jest.Mock).mockResolvedValue({ data: [] });
+    process.env.BASE_ENDPOINT = 'http://base';
+    const result = await getServerSideProps({ query: { id: '8' } } as any, null as any, null as any);
+    expect(result).toEqual({
+      props: {
+        id: '8',
+        name: 'Gradient #8',
+        image: 'http://base/6529io.png',
+        metadata: { title: 'Gradient #8', ogImage: 'http://base/6529io.png', description: '6529 Gradient' },
+      },
+    });
+  });
+});

--- a/__tests__/pages/home.test.tsx
+++ b/__tests__/pages/home.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Home, { getServerSideProps } from '../../pages/index';
+import { AuthContext } from '../../components/auth/Auth';
+import { commonApiFetch } from '../../services/api/common-api';
+import { getCommonHeaders } from '../../helpers/server.helpers';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+jest.mock('next/image', () => ({ __esModule: true, default: (p:any) => <img {...p} /> }));
+jest.mock('../../components/nextGen/collections/collectionParts/NextGenCollectionSlideshow', () => () => <div data-testid="slideshow" />);
+jest.mock('../../services/api/common-api');
+jest.mock('../../helpers/server.helpers');
+jest.mock('../../hooks/useCapacitor', () => ({ __esModule: true, default: jest.fn(() => ({ platform: 'web' })) }));
+
+const mockNft = {
+  id: 1,
+  name: 'Mock NFT',
+  contract: '0x1',
+  collection: 'COL',
+  season: 1,
+  meme_name: 'Meme',
+  artist: 'Artist',
+  mint_date: '2020-01-01',
+  metadata: { image_details: { format: 'png', width: 1, height: 1 } }
+} as any;
+const mockCollection = { name: 'Collection' } as any;
+
+const TestProvider: React.FC<{children: React.ReactNode}> = ({ children }) => (
+  <AuthContext.Provider value={{ setTitle: jest.fn(), connectedProfile: null } as any}>
+    {children}
+  </AuthContext.Provider>
+);
+
+describe('Home page', () => {
+  it('renders main sections', () => {
+    render(
+      <TestProvider>
+        <Home pageProps={{ nft: mockNft, nextGenFeatured: mockCollection }} />
+      </TestProvider>
+    );
+    expect(screen.getByText(/Latest/i)).toBeInTheDocument();
+    expect(screen.getByText(/Drop/i)).toBeInTheDocument();
+    expect(screen.getByText(`Card ${mockNft.id} - ${mockNft.name}`)).toBeInTheDocument();
+    expect(screen.getByText(/Discover/i)).toBeInTheDocument();
+  });
+});
+
+describe('Home getServerSideProps', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getCommonHeaders as jest.Mock).mockReturnValue({});
+  });
+
+  it('returns props on success', async () => {
+    (commonApiFetch as jest.Mock)
+      .mockResolvedValueOnce(mockNft)
+      .mockResolvedValueOnce(mockCollection);
+    const result = await getServerSideProps({} as any, null as any, null as any);
+    expect(result).toEqual({ props: { nft: mockNft, nextGenFeatured: mockCollection } });
+    expect(commonApiFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('redirects to 404 on error', async () => {
+    (commonApiFetch as jest.Mock).mockRejectedValue(new Error('fail'));
+    const result = await getServerSideProps({} as any, null as any, null as any);
+    expect(result).toEqual({ redirect: { permanent: false, destination: '/404' }, props: {} });
+  });
+});

--- a/__tests__/pages/newStaticPages.test.tsx
+++ b/__tests__/pages/newStaticPages.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import About100M from '../../pages/about/100m-project';
+import FromFibonacciToFidenza from '../../pages/blog/from-fibonacci-to-fidenza';
+import EmailProtection from '../../pages/cdn-cgi/l/email-protection';
+import EmailSignatures from '../../pages/email-signatures';
+import MuseumFund from '../../pages/museum/6529-fund-szn1';
+import ConstructionToken from '../../pages/museum/6529-fund-szn1/construction-token';
+import ImageWithArrow from '../../pages/museum/6529-fund-szn1/image-with-arrow';
+import { AuthContext } from '../../components/auth/Auth';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+const TestProvider: React.FC<{children: React.ReactNode}> = ({ children }) => (
+  <AuthContext.Provider value={{ setTitle: jest.fn() } as any}>{children}</AuthContext.Provider>
+);
+
+describe('additional static pages render', () => {
+  it('renders 100m project page', () => {
+    render(<TestProvider><About100M /></TestProvider>);
+    expect(screen.getAllByText(/100M PROJECT/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders blog fibonacci page', () => {
+    render(<TestProvider><FromFibonacciToFidenza /></TestProvider>);
+    expect(screen.getAllByText(/FROM FIBONACCI TO FIDENZA/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders email protection page', () => {
+    render(<TestProvider><EmailProtection /></TestProvider>);
+    expect(screen.getAllByText(/Email Protection/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders email signatures page', () => {
+    render(<TestProvider><EmailSignatures /></TestProvider>);
+    expect(screen.getAllByText(/EMAIL SIGNATURES/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders fund szn1 page', () => {
+    render(<TestProvider><MuseumFund /></TestProvider>);
+    expect(screen.getAllByText(/6529 FUND SZN1/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders construction token page', () => {
+    render(<TestProvider><ConstructionToken /></TestProvider>);
+    expect(screen.getAllByText(/CONSTRUCTION TOKEN/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders image with arrow page', () => {
+    render(<TestProvider><ImageWithArrow /></TestProvider>);
+    expect(screen.getAllByText(/IMAGE WITH ARROW/i).length).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/pages/userPageCollected.test.tsx
+++ b/__tests__/pages/userPageCollected.test.tsx
@@ -1,0 +1,34 @@
+import { getServerSideProps } from '../../pages/[user]/collected';
+import { getCommonHeaders, getUserProfile, userPageNeedsRedirect } from '../../helpers/server.helpers';
+import { getMetadataForUserPage } from '../../helpers/Helpers';
+
+jest.mock('../../helpers/server.helpers');
+jest.mock('../../helpers/Helpers');
+
+const mockProfile = { handle: 'alice' } as any;
+(getCommonHeaders as jest.Mock).mockReturnValue({ head: '1' });
+(getUserProfile as jest.Mock).mockResolvedValue(mockProfile);
+(getMetadataForUserPage as jest.Mock).mockReturnValue('meta');
+
+describe('collected page getServerSideProps', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('redirects when helper returns redirect', async () => {
+    (userPageNeedsRedirect as jest.Mock).mockReturnValue({ redirect: 'yes' });
+    const result = await getServerSideProps({ query: { user: 'bob' }, req: {} } as any, null as any, null as any);
+    expect(result).toEqual({ redirect: 'yes' });
+  });
+
+  it('returns props when no redirect needed', async () => {
+    (userPageNeedsRedirect as jest.Mock).mockReturnValue(false);
+    const result = await getServerSideProps({ query: { user: 'bob' }, req: {} } as any, null as any, null as any);
+    expect(result).toEqual({ props: { profile: mockProfile, metadata: 'meta' } });
+  });
+
+  it('returns 404 redirect on error', async () => {
+    (userPageNeedsRedirect as jest.Mock).mockReturnValue(false);
+    (getUserProfile as jest.Mock).mockRejectedValue(new Error('fail'));
+    const result = await getServerSideProps({ query: { user: 'bob' }, req: {} } as any, null as any, null as any);
+    expect(result).toEqual({ redirect: { permanent: false, destination: '/404' }, props: {} });
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for Home page component and server props
- test Gradient page and getServerSideProps
- verify collected page server side logic
- ensure several static pages render as expected

## Testing
- `npm run test -- -t "Home page"`
- `npm run lint`
- `npm run type-check`
