### PR TITLE
Add tests for museum pages

### DIFF
--- a/__tests__/pages/museum/6529-fund-szn1/madhouse/index.test.tsx
+++ b/__tests__/pages/museum/6529-fund-szn1/madhouse/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import MadhousePage from '../../../../../pages/museum/6529-fund-szn1/madhouse/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('MadhousePage', () => {
+  const renderComponent = () => render(<MadhousePage />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('MADHOUSE - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/6529-fund-szn1/madhouse/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('MADHOUSE - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/6529-fund-szn1/nuclear-nerds/index.test.tsx
+++ b/__tests__/pages/museum/6529-fund-szn1/nuclear-nerds/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NuclearNerdsPage from '../../../../../pages/museum/6529-fund-szn1/nuclear-nerds/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('NuclearNerdsPage', () => {
+  const renderComponent = () => render(<NuclearNerdsPage />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('NUCLEAR NERDS OF THE ACCIDENTAL APOCALYPSE - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/6529-fund-szn1/nuclear-nerds/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('NUCLEAR NERDS OF THE ACCIDENTAL APOCALYPSE - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/bharat-krymo-museum-2/index.test.tsx
+++ b/__tests__/pages/museum/bharat-krymo-museum-2/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import BharatKrymoMuseum2Page from '../../../../pages/museum/bharat-krymo-museum-2/index';
+
+jest.mock('../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe("BharatKrymoMuseum2Page", () => {
+  const renderComponent = () => render(<BharatKrymoMuseum2Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe("BHARAT KRYMO MUSEE D'ART 2 - 6529.io");
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/bharat-krymo-museum-2/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe("BHARAT KRYMO MUSEE D'ART 2 - 6529.io");
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/bubble-bobbly/index.test.tsx
+++ b/__tests__/pages/museum/genesis/bubble-bobbly/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import BubbleBobblyPage from '../../../../../pages/museum/genesis/bubble-bobbly/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('BubbleBobblyPage', () => {
+  const renderComponent = () => render(<BubbleBobblyPage />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('BUBBLE BOBBLY - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/bubble-bobbly/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('BUBBLE BOBBLY - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/cryptocube/index.test.tsx
+++ b/__tests__/pages/museum/genesis/cryptocube/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CryptocubePage from '../../../../../pages/museum/genesis/cryptocube/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('CryptocubePage', () => {
+  const renderComponent = () => render(<CryptocubePage />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('CRYPTOCUBE - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/cryptocube/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('CRYPTOCUBE - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/endless-nameless/index.test.tsx
+++ b/__tests__/pages/museum/genesis/endless-nameless/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import EndlessNamelessPage from '../../../../../pages/museum/genesis/endless-nameless/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('EndlessNamelessPage', () => {
+  const renderComponent = () => render(<EndlessNamelessPage />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('ENDLESS NAMELESS - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/endless-nameless/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('ENDLESS NAMELESS - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/fidenza/index.test.tsx
+++ b/__tests__/pages/museum/genesis/fidenza/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import FidenzaGenesisPage from '../../../../../pages/museum/genesis/fidenza/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('FidenzaGenesisPage', () => {
+  const renderComponent = () => render(<FidenzaGenesisPage />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('FIDENZA - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/fidenza/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('FIDENZA - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/pigments/index.test.tsx
+++ b/__tests__/pages/museum/genesis/pigments/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import PigmentsPage from '../../../../../pages/museum/genesis/pigments/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('PigmentsPage', () => {
+  const renderComponent = () => render(<PigmentsPage />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('PIGMENTS - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/pigments/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('PIGMENTS - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/squiggly-wtf/index.test.tsx
+++ b/__tests__/pages/museum/genesis/squiggly-wtf/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SquigglyWtfPage from '../../../../../pages/museum/genesis/squiggly-wtf/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('SquigglyWtfPage', () => {
+  const renderComponent = () => render(<SquigglyWtfPage />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('SQUIGGLY.WTF - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/squiggly-wtf/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('SQUIGGLY.WTF - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/trossets/index.test.tsx
+++ b/__tests__/pages/museum/genesis/trossets/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TrossetsPage from '../../../../../pages/museum/genesis/trossets/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('TrossetsPage', () => {
+  const renderComponent = () => render(<TrossetsPage />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('TROSSETS - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/trossets/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('TROSSETS - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});


### PR DESCRIPTION
## Summary
- add regression tests for several museum pages ensuring SEO tags and navigation elements

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
