### PR TITLE
Add tests for museum and stream pages

### DIFF
--- a/__tests__/pages/museumPages5.test.tsx
+++ b/__tests__/pages/museumPages5.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Clonex from '../../pages/museum/6529-fund-szn1/clonex';
+import Grifters from '../../pages/museum/6529-fund-szn1/grifters';
+import GenesisPage from '../../pages/museum/genesis';
+import Gazers from '../../pages/museum/genesis/gazers';
+import GlitchCrystalMonsters from '../../pages/museum/genesis/glitch-crystal-monsters';
+import KaiGen from '../../pages/museum/genesis/kai-gen';
+import Labios from '../../pages/museum/genesis/labios';
+import ImaginedWorlds from '../../pages/museum/imagined-worlds';
+import MuseumDistrict from '../../pages/om/6529-museum-district';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+const pages = [
+  {
+    Component: Clonex,
+    title: 'CLONEX - 6529.io',
+    canonical: '/museum/6529-fund-szn1/clonex/',
+    heading: /CLONEX/i,
+  },
+  {
+    Component: Grifters,
+    title: 'GRIFTERS - 6529.io',
+    canonical: '/museum/6529-fund-szn1/grifters/',
+    heading: /GRIFTERS/i,
+  },
+  {
+    Component: GenesisPage,
+    title: 'GENESIS - 6529.io',
+    canonical: '/museum/genesis/',
+    heading: /GENESIS/i,
+  },
+  {
+    Component: Gazers,
+    title: 'GAZERS - 6529.io',
+    canonical: '/museum/genesis/gazers/',
+    heading: /GAZERS/i,
+  },
+  {
+    Component: GlitchCrystalMonsters,
+    title: 'GLITCH CRYSTAL MONSTERS - 6529.io',
+    canonical: '/museum/genesis/glitch-crystal-monsters/',
+    heading: /GLITCH CRYSTAL MONSTERS/i,
+  },
+  {
+    Component: KaiGen,
+    title: 'KAI-GEN - 6529.io',
+    canonical: '/museum/genesis/kai-gen/',
+    heading: /KAI-GEN/i,
+  },
+  {
+    Component: Labios,
+    title: 'LABIOS - 6529.io',
+    canonical: '/museum/genesis/labios/',
+    heading: /LABIOS/i,
+  },
+  {
+    Component: ImaginedWorlds,
+    title: 'IMAGINED WORLDS - 6529.io',
+    canonical: '/museum/imagined-worlds/',
+    heading: /IMAGINED WORLDS/i,
+  },
+  {
+    Component: MuseumDistrict,
+    title: '6529 MUSEUM DISTRICT - 6529.io',
+    canonical: '/om/6529-museum-district/',
+    heading: /6529 MUSEUM DISTRICT/i,
+  },
+];
+
+describe('museum pages render correctly', () => {
+  pages.forEach(({ Component, title, canonical, heading }) => {
+    it(`renders ${title}`, () => {
+      render(<Component />);
+
+      const titleEl = document.querySelector('title');
+      expect(titleEl?.textContent).toBe(title);
+
+      const canonicalLink = document.querySelector('link[rel="canonical"]');
+      expect(canonicalLink?.getAttribute('href')).toBe(canonical);
+
+      const ogTitle = document.querySelector('meta[property="og:title"]');
+      expect(ogTitle?.getAttribute('content')).toBe(title);
+
+      const h1 = document.querySelector('h1');
+      expect(h1?.textContent).toMatch(heading);
+    });
+  });
+});

--- a/__tests__/pages/myStreamPage.test.tsx
+++ b/__tests__/pages/myStreamPage.test.tsx
@@ -1,0 +1,67 @@
+import { getServerSideProps } from '../../pages/my-stream';
+import { prefetchWavesOverview } from '../../helpers/stream.helpers';
+import { getCommonHeaders } from '../../helpers/server.helpers';
+import { commonApiFetch } from '../../services/api/common-api';
+import { Time } from '../../helpers/time';
+
+jest.mock('../../helpers/stream.helpers');
+jest.mock('../../helpers/server.helpers');
+jest.mock('../../services/api/common-api');
+
+(getCommonHeaders as jest.Mock).mockReturnValue({ Authorization: 'auth' });
+
+const createContext = (overrides: any = {}) => ({
+  query: {},
+  req: { cookies: {} },
+  ...overrides,
+});
+
+describe('my-stream getServerSideProps', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns default metadata without wave', async () => {
+    const result = await getServerSideProps(createContext());
+    expect(prefetchWavesOverview).not.toHaveBeenCalled();
+    expect(result.props.metadata.title).toBe('My Stream');
+    expect(result.props.metadata.description).toBe('Brain');
+  });
+
+  it('fetches wave data and prefetches when cookie stale', async () => {
+    (commonApiFetch as jest.Mock).mockResolvedValue({
+      name: 'WaveName',
+      picture: 'img.png',
+      author: { handle: 'alice' },
+      metrics: { subscribers_count: 1, drops_count: 2 },
+    });
+    const old = Time.now().toMillis() - 60001;
+    const context = createContext({
+      query: { wave: '1234' },
+      req: { cookies: { FEED_ITEMS: String(old) } },
+    });
+
+    const result = await getServerSideProps(context);
+
+    expect(prefetchWavesOverview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryClient: expect.anything(),
+        headers: { Authorization: 'auth' },
+        waveId: '1234',
+      })
+    );
+    expect(result.props.metadata.title).toBe('WaveName | My Stream');
+    expect(result.props.metadata.ogImage).toBe('img.png');
+    expect(result.props.metadata.description).toContain('@alice');
+  });
+
+  it('uses short id when wave fetch fails', async () => {
+    (commonApiFetch as jest.Mock).mockRejectedValue(new Error('fail'));
+    const old = Time.now().toMillis() - 60001;
+    const context = createContext({
+      query: { wave: 'abcdef1234567890' },
+      req: { cookies: { FEED_ITEMS: String(old) } },
+    });
+
+    const result = await getServerSideProps(context);
+    expect(result.props.metadata.title).toBe('Wave abcdef12...7890 | My Stream');
+  });
+});


### PR DESCRIPTION
## Summary
- add regression tests for various museum static pages
- test my-stream server side logic

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`