### PR TITLE
Add unit tests for pages, hooks and config

### DIFF
--- a/__tests__/components/NumberTrait.test.tsx
+++ b/__tests__/components/NumberTrait.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { NumberTrait } from '../../components/waves/memes/traits/NumberTrait';
+
+jest.mock('react-use', () => ({ useDebounce: (fn: any, _ms: number) => fn() }));
+
+describe('NumberTrait', () => {
+  const traits: any = { size: 0 };
+  it('clears zero on focus and restores on blur', () => {
+    const update = jest.fn();
+    render(
+      <NumberTrait label="Size" field="size" traits={traits} updateNumber={update} />
+    );
+    const input = screen.getByRole('spinbutton') as HTMLInputElement;
+    fireEvent.focus(input);
+    expect(input.value).toBe('');
+    fireEvent.blur(input);
+    // value returns to 0 but no update since value unchanged
+    expect(update).not.toHaveBeenCalled();
+    expect(input.value).toBe('0');
+  });
+
+  it('enforces min and max bounds', () => {
+    const update = jest.fn();
+    render(
+      <NumberTrait label="Size" field="size" traits={{ size: 5 }} updateNumber={update} min={1} max={10} />
+    );
+    const input = screen.getByRole('spinbutton');
+    fireEvent.change(input, { target: { value: '20' } });
+    fireEvent.blur(input);
+    expect(update).toHaveBeenLastCalledWith('size', 10);
+  });
+});

--- a/__tests__/components/walletChecker.test.tsx
+++ b/__tests__/components/walletChecker.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import WalletChecker from '../../components/delegation/walletChecker/WalletChecker';
+import { fetchUrl } from '../../services/6529api';
+
+jest.mock('react-bootstrap', () => ({
+  __esModule: true,
+  Container: (p: any) => <div>{p.children}</div>,
+  Row: (p: any) => <div>{p.children}</div>,
+  Col: (p: any) => <div>{p.children}</div>,
+  Form: Object.assign((p: any) => <form onSubmit={p.onSubmit}>{p.children}</form>, {
+    Group: (p: any) => <div>{p.children}</div>,
+    Label: (p: any) => <label>{p.children}</label>,
+    Control: (p: any) => <input {...p} />,
+    Text: (p: any) => <span>{p.children}</span>,
+  }),
+  Button: (p: any) => <button onClick={p.onClick} disabled={p.disabled}>{p.children}</button>,
+  Table: (p: any) => <table>{p.children}</table>,
+}));
+
+jest.mock('wagmi', () => ({ useEnsName: () => ({ data: undefined, isLoading: false }), useEnsAddress: () => ({ data: undefined, isLoading: false }) }));
+
+jest.mock('../../services/6529api');
+
+const mockFetchUrl = fetchUrl as jest.Mock;
+
+describe('WalletChecker', () => {
+  it('does not fetch when address invalid', () => {
+    const setAddressQuery = jest.fn();
+    render(<WalletChecker address_query="" setAddressQuery={setAddressQuery} />);
+    fireEvent.change(screen.getByPlaceholderText('0x... or ENS'), { target: { value: 'bad' } });
+    fireEvent.click(screen.getByText('Check'));
+    expect(setAddressQuery).not.toHaveBeenCalled();
+    expect(mockFetchUrl).not.toHaveBeenCalled();
+  });
+
+  it('fetches data for valid address', async () => {
+    mockFetchUrl.mockResolvedValue({ data: [] });
+    const setAddressQuery = jest.fn();
+    render(<WalletChecker address_query="" setAddressQuery={setAddressQuery} />);
+    fireEvent.change(screen.getByPlaceholderText('0x... or ENS'), { target: { value: '0x1111111111111111111111111111111111111111' } });
+    fireEvent.click(screen.getByText('Check'));
+    expect(setAddressQuery).toHaveBeenCalledWith('0x1111111111111111111111111111111111111111');
+    expect(mockFetchUrl).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/api/delegations/0x1111111111111111111111111111111111111111`);
+    expect(mockFetchUrl).toHaveBeenCalledWith(`${process.env.API_ENDPOINT}/api/consolidations/0x1111111111111111111111111111111111111111?show_incomplete=true`);
+  });
+});

--- a/__tests__/hooks/useOptimizedVideo.test.ts
+++ b/__tests__/hooks/useOptimizedVideo.test.ts
@@ -1,0 +1,34 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useOptimizedVideo } from '../../hooks/useOptimizedVideo';
+import { isVideoUrl, getVideoConversions, checkVideoAvailability } from '../../helpers/video.helpers';
+
+jest.mock('../../helpers/video.helpers');
+
+const mockIsVideoUrl = isVideoUrl as jest.Mock;
+const mockGetConversions = getVideoConversions as jest.Mock;
+const mockCheckAvailability = checkVideoAvailability as jest.Mock;
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useOptimizedVideo', () => {
+  it('returns original url for non video', () => {
+    mockIsVideoUrl.mockReturnValue(false);
+    const { result } = renderHook(() => useOptimizedVideo('file.txt'));
+    expect(result.current.playableUrl).toBe('file.txt');
+    expect(result.current.isOptimized).toBe(false);
+    expect(result.current.isChecking).toBe(false);
+  });
+
+  it('picks optimized hls url when available', async () => {
+    mockIsVideoUrl.mockReturnValue(true);
+    mockGetConversions.mockReturnValue({ HLS: 'hls.m3u8', MP4_1080P: '1080.mp4', MP4_720P: '720.mp4' });
+    mockCheckAvailability.mockResolvedValue(true);
+
+    const { result } = renderHook(() => useOptimizedVideo('video.mp4'));
+    await waitFor(() => expect(result.current.isOptimized).toBe(true));
+    expect(result.current.playableUrl).toBe('hls.m3u8');
+    expect(result.current.isHls).toBe(true);
+  });
+});

--- a/__tests__/hooks/useWaveTimers.test.ts
+++ b/__tests__/hooks/useWaveTimers.test.ts
@@ -1,0 +1,35 @@
+import { renderHook, act } from '@testing-library/react';
+import { useWaveTimers } from '../../hooks/useWaveTimers';
+
+describe('useWaveTimers', () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date(0));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const baseWave = {
+    participation: { period: { min: 1000, max: 2000 } },
+    voting: { period: { min: 3000, max: 4000 } },
+    wave: { decisions_strategy: { first_decision_time: 3100, subsequent_decisions: [], is_rolling: false } },
+  } as any;
+
+  it('computes initial upcoming phases', () => {
+    const { result } = renderHook(() => useWaveTimers(baseWave));
+    expect(result.current.participation.isUpcoming).toBe(true);
+    expect(result.current.voting.isUpcoming).toBe(true);
+    expect(result.current.decisions.firstDecisionDone).toBe(false);
+  });
+
+  it('updates phases over time', () => {
+    const { result } = renderHook(() => useWaveTimers(baseWave));
+    act(() => {
+      jest.setSystemTime(new Date(5000));
+      jest.advanceTimersByTime(5000);
+    });
+    expect(result.current.participation.isCompleted).toBe(true);
+    expect(result.current.voting.isCompleted).toBe(true);
+  });
+});

--- a/__tests__/pages/homepageSlider.test.tsx
+++ b/__tests__/pages/homepageSlider.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import HomeSlider from '../../pages/slide-page/homepage-slider';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+describe('homepage slider redirect', () => {
+  it('shows redirect message', () => {
+    render(<HomeSlider />);
+    expect(screen.getByText(/You are being redirected/i)).toBeInTheDocument();
+  });
+});

--- a/__tests__/pages/memePage.test.tsx
+++ b/__tests__/pages/memePage.test.tsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import MemePage, { getServerSideProps } from '../../pages/the-memes/[id]';
+import { getSharedServerSideProps } from '../../components/the-memes/MemeShared';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+jest.mock('../../components/the-memes/MemeShared');
+
+const mockGetShared = getSharedServerSideProps as jest.Mock;
+
+describe('MemePage', () => {
+  it('renders component', () => {
+    render(<MemePage />);
+  });
+});
+
+describe('MemePage getServerSideProps', () => {
+  it('delegates to getSharedServerSideProps', async () => {
+    mockGetShared.mockResolvedValue({ props: { id: '1' } });
+    const result = await getServerSideProps({ query: { id: '1' } } as any, null as any, null as any);
+    expect(mockGetShared).toHaveBeenCalledWith({ query: { id: '1' } }, '0x33FD426905F149f8376e227d0C9D3340AaD17aF1');
+    expect(result).toEqual({ props: { id: '1' } });
+  });
+});

--- a/__tests__/pages/museumGenesisPages5.test.tsx
+++ b/__tests__/pages/museumGenesisPages5.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import Century from '../../pages/museum/genesis/century';
+import Meridian from '../../pages/museum/genesis/meridian';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+describe('museum genesis pages', () => {
+  it('renders Century page', () => {
+    render(<Century />);
+    expect(screen.getAllByText(/CENTURY/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Meridian page', () => {
+    render(<Meridian />);
+    expect(screen.getAllByText(/MERIDIAN/i).length).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/pages/nextgenManager.test.tsx
+++ b/__tests__/pages/nextgenManager.test.tsx
@@ -1,0 +1,18 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import NextGenAdmin from '../../pages/nextgen/manager';
+import { AuthContext } from '../../components/auth/Auth';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+describe('NextGen admin page', () => {
+  it('sets page title and renders admin component', () => {
+    const setTitle = jest.fn();
+    render(
+      <AuthContext.Provider value={{ setTitle } as any}>
+        <NextGenAdmin />
+      </AuthContext.Provider>
+    );
+    expect(setTitle).toHaveBeenCalledWith({ title: 'NextGen Admin' });
+  });
+});

--- a/__tests__/wagmiConfigCapacitor.test.ts
+++ b/__tests__/wagmiConfigCapacitor.test.ts
@@ -1,0 +1,24 @@
+import { wagmiConfigCapacitor } from '../wagmiConfig/wagmiConfigCapacitor';
+import { mainnet } from 'viem/chains';
+import { createConfig } from 'wagmi';
+import { walletConnect, coinbaseWallet, injected } from 'wagmi/connectors';
+
+jest.mock('wagmi', () => ({ createConfig: jest.fn(() => ({})) }));
+jest.mock('wagmi/connectors', () => ({
+  walletConnect: jest.fn(() => 'wc'),
+  coinbaseWallet: jest.fn(() => 'cb'),
+  injected: jest.fn(() => 'inj'),
+}));
+
+const mockCreateConfig = createConfig as jest.Mock;
+
+describe('wagmiConfigCapacitor', () => {
+  it('builds config with connectors', () => {
+    const metadata = { name: 'test' };
+    wagmiConfigCapacitor([mainnet], metadata);
+    expect(walletConnect).toHaveBeenCalledWith({ projectId: '0ba285cc179045bec37f7c9b9e7f9fbf', metadata, showQrModal: false });
+    expect(coinbaseWallet).toHaveBeenCalled();
+    expect(injected).toHaveBeenCalled();
+    expect(mockCreateConfig).toHaveBeenCalledWith(expect.objectContaining({ connectors: ['wc', 'cb', 'inj'] }));
+  });
+});


### PR DESCRIPTION
## Summary
- cover museum genesis pages for Century and Meridian
- test NextGen admin manager page
- ensure homepage slider redirect page works
- add test for The Memes page and its server props
- validate wagmi capacitor configuration
- test optimized video polling hook
- test wave timer calculations
- test wallet checker basic behaviour
- test number trait component

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
