### PR TITLE
Add tests for pages and wave data hook

### DIFF
--- a/__tests__/contexts/wave/hooks/useWaveDataFetching.test.ts
+++ b/__tests__/contexts/wave/hooks/useWaveDataFetching.test.ts
@@ -1,0 +1,102 @@
+import { renderHook, act } from '@testing-library/react';
+import { useWaveDataFetching } from '../../../../contexts/wave/hooks/useWaveDataFetching';
+
+const getLoadingState = jest.fn(() => ({ state: { isLoading: false, promise: null }, shouldContinue: true }));
+const setLoadingState = jest.fn();
+const setPromise = jest.fn();
+const clearLoadingState = jest.fn();
+
+jest.mock('../../../../contexts/wave/hooks/useWaveLoadingState', () => ({
+  useWaveLoadingState: () => ({ getLoadingState, setLoadingState, setPromise, clearLoadingState }),
+}));
+
+const cancelFetch = jest.fn();
+const createController = jest.fn(() => ({ signal: {} } as AbortController));
+const cleanupController = jest.fn();
+
+jest.mock('../../../../contexts/wave/hooks/useWaveAbortController', () => ({
+  useWaveAbortController: () => ({ cancelFetch, createController, cleanupController }),
+}));
+
+export const fetchWaveMessages = jest.fn();
+export const formatWaveMessages = jest.fn();
+export const createEmptyWaveMessages = jest.fn();
+export const fetchNewestWaveMessages = jest.fn();
+
+jest.mock('../../../../contexts/wave/utils/wave-messages-utils', () => ({
+  fetchWaveMessages: (...args: any[]) => fetchWaveMessages(...args),
+  formatWaveMessages: (...args: any[]) => formatWaveMessages(...args),
+  createEmptyWaveMessages: (...args: any[]) => createEmptyWaveMessages(...args),
+  fetchNewestWaveMessages: (...args: any[]) => fetchNewestWaveMessages(...args),
+}));
+
+describe('useWaveDataFetching', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function setup(initial: Record<string, any>) {
+    const store = { ...initial };
+    const updateData = jest.fn((u: any) => { store[u.key] = { ...store[u.key], ...u }; });
+    const getData = jest.fn((key: string) => store[key]);
+    const { result } = renderHook(() => useWaveDataFetching({ updateData, getData }));
+    return { result, updateData, getData, store };
+  }
+
+  it('fetches wave data and updates store', async () => {
+    fetchWaveMessages.mockResolvedValue([{ id: 'd1', serial_no: 1 }]);
+    formatWaveMessages.mockReturnValue({ key: 'wave1', drops: [{ id: 'd1' }] });
+    createEmptyWaveMessages.mockReturnValue({ key: 'wave1', drops: [] });
+    const { result, updateData } = setup({ wave1: { drops: [] } });
+
+    await act(async () => {
+      result.current.registerWave('wave1');
+      await Promise.resolve();
+    });
+
+    expect(setLoadingState).toHaveBeenCalledWith('wave1', true);
+    expect(createController).toHaveBeenCalledWith('wave1');
+    expect(fetchWaveMessages).toHaveBeenCalledWith('wave1', null, expect.any(Object));
+    expect(updateData).toHaveBeenNthCalledWith(1, { key: 'wave1', drops: [] });
+    expect(updateData).toHaveBeenLastCalledWith({ key: 'wave1', drops: [{ id: 'd1' }] });
+  });
+
+  it('ignores abort errors', async () => {
+    const abortError = new DOMException('aborted', 'AbortError');
+    fetchWaveMessages.mockRejectedValue(abortError);
+    createEmptyWaveMessages.mockReturnValue({ key: 'wave1', drops: [] });
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { result, updateData } = setup({ wave1: { drops: [] } });
+
+    await act(async () => {
+      result.current.registerWave('wave1');
+      await Promise.resolve();
+    });
+
+    expect(updateData).toHaveBeenCalledTimes(1); // only initial empty state
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('syncNewestMessages updates data and returns result', async () => {
+    fetchNewestWaveMessages.mockResolvedValue({ drops: [{ id: 'd', serial_no: 11 }], highestSerialNo: 11 });
+    formatWaveMessages.mockReturnValue({ key: 'wave1', drops: [{ id: 'd' }] });
+    const { result, updateData } = setup({ wave1: { drops: [] } });
+
+    const res = await result.current.syncNewestMessages('wave1', 10, new AbortController().signal);
+    expect(fetchNewestWaveMessages).toHaveBeenCalledWith('wave1', 10, 50, expect.any(Object));
+    expect(updateData).toHaveBeenCalledWith({ key: 'wave1', drops: [{ id: 'd' }] });
+    expect(res).toEqual({ drops: [{ id: 'd', serial_no: 11 }], highestSerialNo: 11 });
+  });
+
+  it('syncNewestMessages handles error', async () => {
+    fetchNewestWaveMessages.mockResolvedValue({ drops: null, highestSerialNo: null });
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { result, updateData } = setup({ wave1: { drops: [] } });
+    const res = await result.current.syncNewestMessages('wave1', 10, new AbortController().signal);
+    expect(updateData).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(res).toEqual({ drops: null, highestSerialNo: null });
+    consoleSpy.mockRestore();
+  });
+});

--- a/__tests__/pages/museum/6529-fund-szn1/non-either/index.test.tsx
+++ b/__tests__/pages/museum/6529-fund-szn1/non-either/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NonEitherPage from '../../../../../pages/museum/6529-fund-szn1/non-either/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('NonEitherPage', () => {
+  const renderComponent = () => render(<NonEitherPage />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('NON EITHER - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/6529-fund-szn1/non-either/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('NON EITHER - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/geometry-runners/index.test.tsx
+++ b/__tests__/pages/museum/genesis/geometry-runners/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import GeometryRunnersPage from '../../../../../pages/museum/genesis/geometry-runners/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('GeometryRunnersPage', () => {
+  const renderComponent = () => render(<GeometryRunnersPage />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('GEOMETRY RUNNERS - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/geometry-runners/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('GEOMETRY RUNNERS - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/incomplete-control/index.test.tsx
+++ b/__tests__/pages/museum/genesis/incomplete-control/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import IncompleteControlPage from '../../../../../pages/museum/genesis/incomplete-control/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('IncompleteControlPage', () => {
+  const renderComponent = () => render(<IncompleteControlPage />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('INCOMPLETE CONTROL - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/incomplete-control/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('INCOMPLETE CONTROL - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/lost-robbies/index.test.tsx
+++ b/__tests__/pages/museum/genesis/lost-robbies/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import LostRobbiesPage from '../../../../../pages/museum/genesis/lost-robbies/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('LostRobbiesPage', () => {
+  const renderComponent = () => render(<LostRobbiesPage />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('THE LOST ROBBIES - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/lost-robbies/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('THE LOST ROBBIES - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/nextgen/collection/[collection]/art.test.tsx
+++ b/__tests__/pages/nextgen/collection/[collection]/art.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Page, { getServerSideProps } from '../../../../../pages/nextgen/collection/[collection]/art';
+
+let headerProps: any = null;
+let listProps: any = null;
+
+jest.mock('../../../../../components/nextGen/collections/collectionParts/NextGenCollectionHeader', () => ({
+  NextGenCollectionHead: (props: any) => {
+    headerProps = props;
+    return <div data-testid="header" />;
+  },
+  getServerSideCollection: jest.fn(() => Promise.resolve({ props: { collection: { name: 'c' } } })),
+}));
+
+jest.mock('next/dynamic', () => () => (props: any) => {
+  listProps = props;
+  return <div data-testid="dynamic" />;
+});
+
+const { getServerSideCollection } = require('../../../../../components/nextGen/collections/collectionParts/NextGenCollectionHeader');
+
+describe('NextGen collection art page', () => {
+  beforeEach(() => {
+    headerProps = null;
+    listProps = null;
+  });
+
+  it('passes collection to child components', () => {
+    const props = { pageProps: { collection: { id: 1, name: 'Cool' } } } as any;
+    render(<Page {...props} />);
+    expect(headerProps).toEqual({ collection: props.pageProps.collection });
+    expect(listProps).toEqual({ collection: props.pageProps.collection });
+  });
+
+  it('delegates getServerSideProps', async () => {
+    const req = {} as any;
+    const res = {} as any;
+    const result = await getServerSideProps(req, res, '/p');
+    expect(getServerSideCollection).toHaveBeenCalledWith(req, 'Art');
+    expect(result).toEqual(await getServerSideCollection.mock.results[0].value);
+  });
+});

--- a/__tests__/pages/open-data/index.test.tsx
+++ b/__tests__/pages/open-data/index.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Downloads from '../../../pages/open-data/index';
+import { AuthContext } from '../../../components/auth/Auth';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+describe('Open Data page', () => {
+  it('renders downloads component and sets title', () => {
+    const setTitle = jest.fn();
+    render(
+      <AuthContext.Provider value={{ setTitle } as any}>
+        <Downloads />
+      </AuthContext.Provider>
+    );
+    expect(screen.getByTestId('dynamic')).toBeInTheDocument();
+    expect(setTitle).toHaveBeenCalledWith({ title: 'Open Data' });
+  });
+
+  it('exposes metadata', () => {
+    expect(Downloads.metadata).toEqual({ title: 'Open Data' });
+  });
+});

--- a/__tests__/pages/open-data/royalties.test.tsx
+++ b/__tests__/pages/open-data/royalties.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import RoyaltiesDownloads from '../../../pages/open-data/royalties';
+import { AuthContext } from '../../../components/auth/Auth';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+describe('Open Data royalties page', () => {
+  it('renders royalties component and sets title', () => {
+    const setTitle = jest.fn();
+    render(
+      <AuthContext.Provider value={{ setTitle } as any}>
+        <RoyaltiesDownloads />
+      </AuthContext.Provider>
+    );
+    expect(screen.getByTestId('dynamic')).toBeInTheDocument();
+    expect(setTitle).toHaveBeenCalledWith({ title: 'Royalties | Open Data' });
+  });
+
+  it('exposes metadata', () => {
+    expect(RoyaltiesDownloads.metadata).toEqual({ title: 'Royalties', description: 'Open Data' });
+  });
+});

--- a/__tests__/pages/rememes/index.test.tsx
+++ b/__tests__/pages/rememes/index.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ReMemes from '../../../pages/rememes/index';
+import { AuthContext } from '../../../components/auth/Auth';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+describe('ReMemes page', () => {
+  it('renders component and sets title', () => {
+    const setTitle = jest.fn();
+    render(
+      <AuthContext.Provider value={{ setTitle } as any}>
+        <ReMemes />
+      </AuthContext.Provider>
+    );
+    expect(screen.getByTestId('dynamic')).toBeInTheDocument();
+    expect(setTitle).toHaveBeenCalledWith({ title: 'ReMemes | Collections' });
+  });
+
+  it('exposes metadata', () => {
+    expect(ReMemes.metadata).toEqual({ title: 'ReMemes', description: 'Collections', ogImage: `${process.env.BASE_ENDPOINT}/re-memes-b.jpeg` });
+  });
+});

--- a/__tests__/pages/tools/subscriptions-report.test.tsx
+++ b/__tests__/pages/tools/subscriptions-report.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Page, { getServerSideProps } from '../../../pages/tools/subscriptions-report';
+import { AuthContext } from '../../../components/auth/Auth';
+
+jest.mock('../../../helpers/meme_calendar.helpers', () => ({
+  getMintingDates: jest.fn(() => []),
+  numberOfCardsForSeasonEnd: jest.fn(() => ({ count: 2, szn: 1 })),
+}));
+
+jest.mock('../../../services/api/common-api', () => ({
+  commonApiFetch: jest.fn(() => Promise.resolve([])),
+}));
+
+jest.mock('../../../helpers/server.helpers', () => ({
+  getCommonHeaders: jest.fn(() => ({ h: '1' })),
+}));
+
+const { getCommonHeaders } = require('../../../helpers/server.helpers');
+const { commonApiFetch } = require('../../../services/api/common-api');
+const { numberOfCardsForSeasonEnd } = require('../../../helpers/meme_calendar.helpers');
+
+describe('Subscriptions report page', () => {
+  it('sets title and renders component', () => {
+    const setTitle = jest.fn();
+    const props = { pageProps: { szn: 1, upcoming: [], redeemed: [] } } as any;
+    const { container } = render(
+      <AuthContext.Provider value={{ setTitle } as any}>
+        <Page {...props} />
+      </AuthContext.Provider>
+    );
+    expect(container.querySelector('main')).toBeInTheDocument();
+    expect(setTitle).toHaveBeenCalledWith({ title: 'Subscriptions Report | Tools' });
+  });
+
+  it('fetches data on server side', async () => {
+    const res = await getServerSideProps({} as any, null as any, '/p');
+    expect(numberOfCardsForSeasonEnd).toHaveBeenCalled();
+    expect(getCommonHeaders).toHaveBeenCalled();
+    expect(commonApiFetch).toHaveBeenCalledTimes(2);
+    expect(res).toEqual({ props: { szn: 1, upcoming: [], redeemed: [] } });
+  });
+
+  it('exposes metadata', () => {
+    expect(Page.metadata).toEqual({ title: 'Subscriptions Report', description: 'Tools' });
+  });
+});


### PR DESCRIPTION
## Summary
- add rendering tests for several static pages
- add tests for NextGen collection art page
- add tests for Open Data, Royalties, Rememes, and Subscriptions Report pages
- cover useWaveDataFetching hook behavior

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test -- --runTestsByPath __tests__/pages/nextgen/collection/[collection]/art.test.tsx __tests__/pages/open-data/index.test.tsx __tests__/pages/open-data/royalties.test.tsx __tests__/pages/rememes/index.test.tsx __tests__/pages/tools/subscriptions-report.test.tsx __tests__/contexts/wave/hooks/useWaveDataFetching.test.ts __tests__/pages/museum/6529-fund-szn1/non-either/index.test.tsx __tests__/pages/museum/genesis/geometry-runners/index.test.tsx __tests__/pages/museum/genesis/incomplete-control/index.test.tsx __tests__/pages/museum/genesis/lost-robbies/index.test.tsx`