### PR TITLE
Add tests for museum and network pages

### DIFF
--- a/__tests__/pages/museum/6529-fund-szn1/act-of-kindness/index.test.tsx
+++ b/__tests__/pages/museum/6529-fund-szn1/act-of-kindness/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../../pages/museum/6529-fund-szn1/act-of-kindness/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('ActOfKindnessPage', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('ACT OF KINDNESS - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/6529-fund-szn1/act-of-kindness/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('ACT OF KINDNESS - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/6529-fund-szn1/capsule-house/index.test.tsx
+++ b/__tests__/pages/museum/6529-fund-szn1/capsule-house/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../../pages/museum/6529-fund-szn1/capsule-house/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('CapsuleHousePage', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('CAPSULE HOUSE - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/6529-fund-szn1/capsule-house/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('CAPSULE HOUSE - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/frammenti/index.test.tsx
+++ b/__tests__/pages/museum/genesis/frammenti/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../../pages/museum/genesis/frammenti/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('FrammentiPage', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('FRAMMENTI - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/frammenti/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('FRAMMENTI - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/phase/index.test.tsx
+++ b/__tests__/pages/museum/genesis/phase/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../../pages/museum/genesis/phase/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('PhasePage', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('PHASE - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/phase/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('PHASE - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/singularity/index.test.tsx
+++ b/__tests__/pages/museum/genesis/singularity/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../../pages/museum/genesis/singularity/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('SingularityPage', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('SINGULARITY - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/singularity/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('SINGULARITY - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/subscapes/index.test.tsx
+++ b/__tests__/pages/museum/genesis/subscapes/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../../pages/museum/genesis/subscapes/index';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('SubscapesGenesisPage', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('SUBSCAPES - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/subscapes/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('SUBSCAPES - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/temple-of-gm/index.test.tsx
+++ b/__tests__/pages/museum/temple-of-gm/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../pages/museum/temple-of-gm/index';
+
+jest.mock('../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('TempleOfGMPage', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('TEMPLE OF GM - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/temple-of-gm/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('TEMPLE OF GM - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/yongoh-kim/index.test.tsx
+++ b/__tests__/pages/museum/yongoh-kim/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../pages/museum/yongoh-kim/index';
+
+jest.mock('../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('YongohKimPage', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('YONGOH KIM - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/yongoh-kim/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('YONGOH KIM - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/network/index.test.tsx
+++ b/__tests__/pages/network/index.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CommunityPage from '../../../pages/network/index';
+import { AuthContext } from '../../../components/auth/Auth';
+import { useSelector } from 'react-redux';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import { QueryKey } from '../../../components/react-query-wrapper/ReactQueryWrapper';
+
+jest.mock('../../../components/utils/sidebar/SidebarLayout', () => ({ children }: any) => <div data-testid="layout">{children}</div>);
+jest.mock('../../../components/community/CommunityMembers', () => () => <div data-testid="members" />);
+
+jest.mock('react-redux', () => ({ useSelector: jest.fn() }));
+jest.mock('@tanstack/react-query', () => ({ useQuery: jest.fn(), keepPreviousData: 'keepPreviousData' }));
+jest.mock('../../../services/api/common-api', () => ({ commonApiFetch: jest.fn() }));
+
+describe('CommunityPage', () => {
+  const useQueryMock = useQuery as jest.Mock;
+  const useSelectorMock = useSelector as jest.Mock;
+
+  function renderComponent() {
+    const setTitle = jest.fn();
+    return {
+      setTitle,
+      ...render(
+        <AuthContext.Provider value={{ setTitle } as any}>
+          <CommunityPage />
+        </AuthContext.Provider>
+      ),
+    };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sets title and fetches group data', () => {
+    useSelectorMock.mockReturnValue('g1');
+    useQueryMock.mockReturnValue({});
+
+    const { setTitle } = renderComponent();
+
+    expect(setTitle).toHaveBeenCalledWith({ title: 'Network' });
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: [QueryKey.GROUP, 'g1'],
+        placeholderData: keepPreviousData,
+        enabled: true,
+      })
+    );
+    expect(screen.getByTestId('layout')).toBeInTheDocument();
+    expect(screen.getByTestId('members')).toBeInTheDocument();
+  });
+
+  it('exports metadata', () => {
+    expect(CommunityPage.metadata).toEqual({
+      title: 'Network',
+      description: 'Network',
+      twitterCard: 'summary_large_image',
+    });
+  });
+});

--- a/__tests__/pages/network/levels.test.tsx
+++ b/__tests__/pages/network/levels.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import LevelsPage from '../../../pages/network/levels';
+import { AuthContext } from '../../../components/auth/Auth';
+
+jest.mock('../../../components/levels/ProgressChart', () => () => <div data-testid="progress-chart" />);
+jest.mock('../../../components/levels/TableOfLevels', () => () => <div data-testid="table-of-levels" />);
+
+describe('LevelsPage', () => {
+  it('sets title and renders components', () => {
+    const setTitle = jest.fn();
+    render(
+      <AuthContext.Provider value={{ setTitle } as any}>
+        <LevelsPage />
+      </AuthContext.Provider>
+    );
+    expect(setTitle).toHaveBeenCalledWith({ title: 'Levels | Network' });
+    expect(screen.getByText('Levels')).toBeInTheDocument();
+    expect(screen.getByTestId('progress-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('table-of-levels')).toBeInTheDocument();
+  });
+
+  it('exports metadata', () => {
+    expect(LevelsPage.metadata).toEqual({ title: 'Levels', description: 'Network' });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for various museum pages with meta tags and navigation links
- test network pages for title setting, data fetching, and metadata

## Testing
- `npm run test`
- `npm run lint`
- `npm run type-check`
