### PR TITLE
Add tests for museum pages and validation hook

### DIFF
--- a/__tests__/components/waves/memes/submission/validation/validationHooks.test.ts
+++ b/__tests__/components/waves/memes/submission/validation/validationHooks.test.ts
@@ -1,0 +1,170 @@
+import { renderHook, act } from '@testing-library/react';
+import { useTraitsValidation } from '../../../../../../components/waves/memes/submission/validation/validationHooks';
+import { validateTraitsData } from '../../../../../../components/waves/memes/submission/validation/traitsValidation';
+import { TraitsData } from '../../../../../../components/waves/memes/submission/types/TraitsData';
+
+jest.mock('../../../../../../components/waves/memes/submission/validation/traitsValidation');
+
+const mockValidate = validateTraitsData as jest.Mock;
+
+function createTraits(): TraitsData {
+  return {
+    title: 't',
+    description: 'd',
+    artist: '',
+    seizeArtistProfile: '',
+    palette: '',
+    style: '',
+    jewel: '',
+    superpower: '',
+    dharma: '',
+    gear: '',
+    clothing: '',
+    element: '',
+    mystery: '',
+    secrets: '',
+    weapon: '',
+    home: '',
+    parent: '',
+    sibling: '',
+    food: '',
+    drink: '',
+    bonus: '',
+    boost: '',
+    punk6529: false,
+    gradient: false,
+    movement: false,
+    dynamic: false,
+    interactive: false,
+    collab: false,
+    om: false,
+    threeD: false,
+    pepe: false,
+    gm: false,
+    summer: false,
+    tulip: false,
+    memeName: '',
+    pointsPower: 1,
+    pointsWisdom: 2,
+    pointsLoki: 3,
+    pointsSpeed: 4,
+  };
+}
+
+describe('useTraitsValidation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockValidate.mockReturnValue({ isValid: true, errors: {}, errorCount: 0 });
+  });
+
+  it('tracks touched fields and validates on change', () => {
+    const traits = createTraits();
+    const { result, rerender } = renderHook(({ t }) => useTraitsValidation(t, traits), {
+      initialProps: { t: traits },
+    });
+
+    expect(mockValidate).toHaveBeenLastCalledWith(traits, expect.objectContaining({
+      mode: 'touched',
+    }));
+
+    act(() => {
+      result.current.markFieldTouched('artist');
+    });
+    rerender({ t: traits });
+
+    const lastOptions = mockValidate.mock.calls[mockValidate.mock.calls.length - 1][1];
+    expect(lastOptions.touchedFields.has('artist')).toBe(true);
+    expect(result.current.touchedFields.has('artist')).toBe(true);
+  });
+
+  it('marks all fields touched', () => {
+    const traits = createTraits();
+    const { result } = renderHook(() => useTraitsValidation(traits, traits));
+    act(() => {
+      result.current.markAllFieldsTouched();
+    });
+    expect(result.current.touchedFields.size).toBe(Object.keys(traits).length);
+  });
+
+  it('validateAll switches to all mode and returns result', () => {
+    const traits = createTraits();
+    mockValidate.mockReturnValue({ isValid: true, errors: {}, errorCount: 0 });
+    const { result } = renderHook(() => useTraitsValidation(traits, traits));
+    mockValidate.mockReturnValue({ isValid: false, errors: {}, errorCount: 1 });
+    let validation: any;
+    act(() => {
+      validation = result.current.validateAll();
+    });
+    expect(validation).toEqual({ isValid: false, errors: {}, errorCount: 1 });
+    expect(result.current.submitAttempted).toBe(true);
+    expect(mockValidate).toHaveBeenCalledWith(traits, { mode: 'all' });
+  });
+
+  it('resets validation state', () => {
+    const traits = createTraits();
+    const { result } = renderHook(() => useTraitsValidation(traits, traits));
+    act(() => {
+      result.current.markFieldTouched('title');
+      result.current.validateAll();
+      result.current.resetValidation();
+    });
+    expect(result.current.touchedFields.size).toBe(0);
+    expect(result.current.submitAttempted).toBe(false);
+  });
+
+  it('focuses first invalid field when element exists', () => {
+    jest.useFakeTimers();
+    const traits = createTraits();
+    mockValidate.mockReturnValue({
+      isValid: false,
+      errors: { title: 'err' } as any,
+      errorCount: 1,
+      firstInvalidField: 'title',
+    });
+    const element = document.createElement('div');
+    element.focus = jest.fn();
+    element.scrollIntoView = jest.fn();
+    element.classList.add = jest.fn();
+    element.classList.remove = jest.fn();
+    element.getBoundingClientRect = jest.fn(() => ({ top: 0 } as any));
+    const querySpy = jest.spyOn(document, 'querySelector').mockReturnValue(element);
+    const scrollSpy = jest.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useTraitsValidation(traits, traits));
+    act(() => {
+      result.current.focusFirstInvalidField();
+    });
+    expect(querySpy).toHaveBeenCalled();
+    expect(element.focus).toHaveBeenCalled();
+    expect(element.scrollIntoView).toHaveBeenCalled();
+    expect(element.classList.add).toHaveBeenCalledWith('tw-highlight-focus');
+    jest.advanceTimersByTime(2000);
+    expect(element.classList.remove).toHaveBeenCalledWith('tw-highlight-focus');
+
+    querySpy.mockRestore();
+    scrollSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it('logs warning when element not found in development', () => {
+    const oldEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    mockValidate.mockReturnValue({
+      isValid: false,
+      errors: {},
+      errorCount: 1,
+      firstInvalidField: 'title',
+    });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(document, 'querySelector').mockReturnValue(null);
+
+    const traits = createTraits();
+    const { result } = renderHook(() => useTraitsValidation(traits, traits));
+    act(() => {
+      result.current.focusFirstInvalidField();
+    });
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+    process.env.NODE_ENV = oldEnv;
+  });
+});

--- a/__tests__/pages/museum/6529-fund-szn1/incomplete-control/index.test.tsx
+++ b/__tests__/pages/museum/6529-fund-szn1/incomplete-control/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../../pages/museum/6529-fund-szn1/incomplete-control';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('Incomplete Control Page', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('INCOMPLETE CONTROL - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/6529-fund-szn1/incomplete-control/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('INCOMPLETE CONTROL - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/6529-fund-szn1/ringers/index.test.tsx
+++ b/__tests__/pages/museum/6529-fund-szn1/ringers/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../../pages/museum/6529-fund-szn1/ringers';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('Ringers Page', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('RINGERS - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/6529-fund-szn1/ringers/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('RINGERS - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/6529-general-assembly/index.test.tsx
+++ b/__tests__/pages/museum/6529-general-assembly/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../pages/museum/6529-general-assembly';
+
+jest.mock('../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('6529 General Assembly Page', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('6529 GENERAL ASSEMBLY - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/6529-general-assembly/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('6529 GENERAL ASSEMBLY - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/6529-gradient-collector-curated/index.test.tsx
+++ b/__tests__/pages/museum/6529-gradient-collector-curated/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../pages/museum/6529-gradient-collector-curated';
+
+jest.mock('../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('6529 Gradient Collector Curated Page', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('6529 GRADIENT COLLECTOR CURATED - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/6529-gradient-collector-curated/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('6529 GRADIENT COLLECTOR CURATED - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/bharat-krymo-museum-3/index.test.tsx
+++ b/__tests__/pages/museum/bharat-krymo-museum-3/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../pages/museum/bharat-krymo-museum-3';
+
+jest.mock('../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe("Bharat Krymo Musee d'Art 3 Page", () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe("BHARAT KRYMO MUSEE D'ART 3 - 6529.io");
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/bharat-krymo-museum-3/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe("BHARAT KRYMO MUSEE D'ART 3 - 6529.io");
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/apparitions/index.test.tsx
+++ b/__tests__/pages/museum/genesis/apparitions/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../../pages/museum/genesis/apparitions';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('Apparitions Page', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('APPARITIONS - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/apparitions/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('APPARITIONS - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/chromie-squiggle/index.test.tsx
+++ b/__tests__/pages/museum/genesis/chromie-squiggle/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../../pages/museum/genesis/chromie-squiggle';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('Chromie Squiggle Page', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('CHROMIE SQUIGGLE - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/chromie-squiggle/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('CHROMIE SQUIGGLE - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/cryptoarte/index.test.tsx
+++ b/__tests__/pages/museum/genesis/cryptoarte/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../../pages/museum/genesis/cryptoarte';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('CryptoArte Page', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('CRYPTOARTE - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/cryptoarte/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('CRYPTOARTE - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/om/instruction-manual/index.test.tsx
+++ b/__tests__/pages/om/instruction-manual/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../pages/om/instruction-manual';
+
+jest.mock('../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('OM Instruction Manual Page', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('OM INSTRUCTION MANUAL - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/om/instruction-manual/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('OM INSTRUCTION MANUAL - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for several museum pages
- add tests for `useTraitsValidation` hook

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test -- -i` *(fails to complete in provided environment)*