### PR TITLE
Add tests for museum pages and delegation

### DIFF
--- a/__tests__/components/CollectionDelegationComponent.test.tsx
+++ b/__tests__/components/CollectionDelegationComponent.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import CollectionDelegationComponent from '../../components/delegation/CollectionDelegation';
+import { DelegationCenterSection } from '../../components/delegation/DelegationCenterMenu';
+
+jest.mock('wagmi', () => ({
+  useReadContract: jest.fn(() => ({})),
+  useReadContracts: jest.fn(() => ({ data: undefined, refetch: jest.fn() })),
+  useWriteContract: jest.fn(() => ({ writeContract: jest.fn(), reset: jest.fn(), data: undefined, error: undefined })),
+  useEnsName: jest.fn(() => ({ data: undefined })),
+  useWaitForTransactionReceipt: jest.fn(() => ({ isLoading: false })),
+  useChainId: jest.fn(() => 1),
+}));
+
+jest.mock('../../components/auth/SeizeConnectContext', () => ({
+  useSeizeConnectContext: () => ({ address: '0x0', isConnected: true }),
+}));
+
+describe('CollectionDelegationComponent', () => {
+  const collection = { title: 'Test Collection', display: 'Test', contract: '0x1', preview: '' };
+  const setSection = jest.fn();
+
+  it('renders collection title and back button works', () => {
+    render(<CollectionDelegationComponent collection={collection} setSection={setSection} />);
+    expect(screen.getByText('Test Collection')).toBeInTheDocument();
+
+    const back = screen.getAllByText(/Back to Delegation Center/i)[0];
+    fireEvent.click(back);
+    expect(setSection).toHaveBeenCalledWith(DelegationCenterSection.CENTER);
+  });
+
+  it('shows fetching messages initially', () => {
+    render(<CollectionDelegationComponent collection={collection} setSection={setSection} />);
+    expect(screen.getAllByText(/Fetching outgoing delegations/i)[0]).toBeInTheDocument();
+  });
+});

--- a/__tests__/hooks/useVirtualizedWaveMessages.test.ts
+++ b/__tests__/hooks/useVirtualizedWaveMessages.test.ts
@@ -1,0 +1,70 @@
+import { renderHook, act } from '@testing-library/react';
+import { useVirtualizedWaveMessages } from '../../hooks/useVirtualizedWaveMessages';
+import { Drop } from '../../helpers/waves/drop.helpers';
+
+jest.useFakeTimers();
+
+jest.mock('../../contexts/wave/MyStreamContext', () => ({
+  useMyStreamWaveMessages: jest.fn(),
+}));
+
+jest.mock('../../hooks/useDropMessages', () => ({
+  useDropMessages: jest.fn(),
+}));
+
+const { useMyStreamWaveMessages } = require('../../contexts/wave/MyStreamContext');
+const { useDropMessages } = require('../../hooks/useDropMessages');
+
+describe('useVirtualizedWaveMessages', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('returns undefined when no data available', () => {
+    useMyStreamWaveMessages.mockReturnValue(undefined);
+    useDropMessages.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useVirtualizedWaveMessages('wave1', null, 5));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('paginates locally and reveals drops', async () => {
+    const drops: Drop[] = [
+      { serial_no: 1 } as any,
+      { serial_no: 2 } as any,
+      { serial_no: 3 } as any,
+      { serial_no: 4 } as any,
+      { serial_no: 5 } as any,
+    ];
+    const waveData = {
+      id: 'wave1',
+      isLoading: false,
+      isLoadingNextPage: false,
+      hasNextPage: false,
+      drops,
+      latestFetchedSerialNo: 5,
+      fetchNextPage: jest.fn(),
+    };
+
+    useMyStreamWaveMessages.mockReturnValue(waveData);
+    useDropMessages.mockReturnValue(waveData);
+
+    const { result } = renderHook(() => useVirtualizedWaveMessages('wave1', null, 2));
+
+    expect(result.current?.drops.length).toBe(2);
+    expect(result.current?.hasMoreLocal).toBe(true);
+
+    act(() => {
+      result.current?.loadMoreLocally();
+    });
+
+    expect(result.current?.drops.length).toBe(4);
+
+    await act(async () => {
+      const p = result.current!.waitAndRevealDrop(5, 100, 10);
+      jest.runAllTimers();
+      const success = await p;
+      expect(success).toBe(true);
+    });
+
+    expect(result.current?.drops.length).toBe(5);
+  });
+});

--- a/__tests__/pages/museumPages7.test.tsx
+++ b/__tests__/pages/museumPages7.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import ArcheologyOfTheFuture from '../../pages/museum/6529-fund-szn1/archeology-of-the-future';
+import PhotoB from '../../pages/museum/6529-photo-b';
+import GeneralAssembly from '../../pages/museum/general-assembly';
+import Hyperhash from '../../pages/museum/genesis/hyperhash';
+import SecretSurprise from '../../pages/museum/genesis/secret-surprise';
+import SozetLounge from '../../pages/museum/sozet-lounge';
+import TheInstitutions from '../../pages/museum/the-institutions';
+import IntroducingOM from '../../pages/news/introducing-om';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+// Some of these pages rely on SeizeConnectContext, so provide a minimal mock
+jest.mock('../../components/auth/SeizeConnectContext', () => ({
+  useSeizeConnectContext: () => ({
+    address: '0x0',
+    seizeConnect: jest.fn(),
+    seizeDisconnect: jest.fn(),
+    seizeDisconnectAndLogout: jest.fn(),
+    seizeAcceptConnection: jest.fn(),
+    seizeConnectOpen: false,
+    isConnected: false,
+    isAuthenticated: false,
+  }),
+}));
+
+describe('additional museum pages render', () => {
+  it('renders Archeology Of The Future page', () => {
+    render(<ArcheologyOfTheFuture />);
+    expect(screen.getAllByText(/ARCHEOLOGY OF THE FUTURE/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders 6529 Photo B page', () => {
+    render(<PhotoB />);
+    expect(screen.getAllByText(/6529 PHOTO B/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders General Assembly page', () => {
+    render(<GeneralAssembly />);
+    expect(screen.getAllByText(/GENERAL ASSEMBLY/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Hyperhash page', () => {
+    render(<Hyperhash />);
+    expect(screen.getAllByText(/HYPERHASH/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Secret Surprise page', () => {
+    render(<SecretSurprise />);
+    expect(screen.getAllByText(/SECRET SURPRISE/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Sozet Lounge page', () => {
+    render(<SozetLounge />);
+    expect(screen.getAllByText(/SOZET LOUNGE/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders The Institutions page', () => {
+    render(<TheInstitutions />);
+    expect(screen.getAllByText(/THE INSTITUTIONS/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders Introducing OM news page', () => {
+    render(<IntroducingOM />);
+    expect(screen.getAllByText(/INTRODUCING OM/i).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add regression tests for static museum pages
- test CollectionDelegation component basic behavior
- add tests for useVirtualizedWaveMessages hook

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`