### PR TITLE
Add comprehensive tests

### DIFF
--- a/__tests__/components/distribution-plan-tool/build-phases/build-phase/form/component-config/snapshots-table/FinalizeSnapshotsTable.test.tsx
+++ b/__tests__/components/distribution-plan-tool/build-phases/build-phase/form/component-config/snapshots-table/FinalizeSnapshotsTable.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import FinalizeSnapshotsTable from '../../../../../../../../../components/distribution-plan-tool/build-phases/build-phase/form/component-config/snapshots-table/FinalizeSnapshotsTable';
+import { TopHolderType } from '../../../../../../../../../components/distribution-plan-tool/build-phases/build-phase/form/BuildPhaseFormConfigModal';
+
+const groupSnapshots = [
+  {
+    groupSnapshotId: 'g1',
+    snapshotId: 's1',
+    excludeSnapshots: [{ snapshotId: 's2', snapshotType: 'MINT' }],
+    excludeComponentWinners: [],
+    tokenIds: '1,2',
+    topHoldersFilter: { type: TopHolderType.TOTAL_TOKENS_COUNT, from: 1, to: null },
+    uniqueWalletsCount: 5,
+  },
+];
+
+const snapshots = [{ id: 's1', name: 'Snap1', poolType: 'MINT' }];
+
+describe('FinalizeSnapshotsTable', () => {
+  it('maps snapshots to rows and renders text', () => {
+    render(
+      <FinalizeSnapshotsTable
+        onRemoveGroupSnapshot={jest.fn()}
+        groupSnapshots={groupSnapshots as any}
+        snapshots={snapshots as any}
+        phases={[]}
+      />
+    );
+    expect(screen.getByText('Snap1')).toBeInTheDocument();
+    expect(screen.getByText('1 snapshot')).toBeInTheDocument();
+    expect(screen.getByText('Total Tokens Top 1+')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/drops/view/item/content/media/MediaDisplayVideo.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/MediaDisplayVideo.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import MediaDisplayVideo from '../../../../../../../components/drops/view/item/content/media/MediaDisplayVideo';
+
+// mock hooks used inside component
+jest.mock('../../../../../../../hooks/useInView', () => ({
+  useInView: () => [jest.fn(), true],
+}));
+
+const playMock = jest.fn().mockResolvedValue(undefined);
+const pauseMock = jest.fn();
+
+jest.mock('../../../../../../../hooks/useOptimizedVideo', () => ({
+  useOptimizedVideo: () => ({ playableUrl: 'video.mp4', isHls: false }),
+}));
+
+beforeAll(() => {
+  Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+    configurable: true,
+    value: playMock,
+  });
+  Object.defineProperty(HTMLMediaElement.prototype, 'pause', {
+    configurable: true,
+    value: pauseMock,
+  });
+});
+
+beforeEach(() => {
+  playMock.mockClear();
+  pauseMock.mockClear();
+});
+
+describe('MediaDisplayVideo', () => {
+  it('autoplays when in view', () => {
+    const { container } = render(<MediaDisplayVideo src="foo.mp4" />);
+    const video = container.querySelector('video') as HTMLVideoElement;
+    expect(video.autoplay).toBe(true);
+  });
+
+  it('toggles play state on click when controls hidden', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<MediaDisplayVideo src="foo.mp4" />);
+    const video = container.querySelector('video') as HTMLVideoElement;
+    Object.defineProperty(video, 'paused', { writable: true, value: true });
+    await user.click(video);
+    expect(playMock).toHaveBeenCalled();
+    (video as any).paused = false;
+    await user.click(video);
+    expect(pauseMock).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
+++ b/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import DropPartMarkdown from '../../../../components/drops/view/part/DropPartMarkdown';
+
+jest.mock('../../../../hooks/isMobileScreen', () => () => false);
+jest.mock('../../../../contexts/EmojiContext', () => ({ useEmoji: () => ({ emojiMap: [] }) }));
+jest.mock('react-tweet', () => ({ Tweet: ({ id }: any) => <div>tweet:{id}</div> }));
+
+describe('DropPartMarkdown', () => {
+  it('renders gif embeds', () => {
+    const content = 'Check this ![gif](https://media.tenor.com/test.gif)';
+    render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        referencedNfts={[]}
+        partContent={content}
+        onQuoteClick={jest.fn()}
+      />
+    );
+    expect(screen.getByRole('img')).toHaveAttribute('src', 'https://media.tenor.com/test.gif');
+  });
+
+  it('handles external links', () => {
+    process.env.BASE_ENDPOINT = 'http://example.com';
+    const content = '[link](https://google.com)';
+    render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        referencedNfts={[]}
+        partContent={content}
+        onQuoteClick={jest.fn()}
+      />
+    );
+    const a = screen.getByRole('link');
+    expect(a).toHaveAttribute('target', '_blank');
+    expect(a).toHaveAttribute('rel');
+  });
+
+  it('handles internal links', () => {
+    process.env.BASE_ENDPOINT = 'http://example.com';
+    const content = '[home](http://example.com/page)';
+    render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        referencedNfts={[]}
+        partContent={content}
+        onQuoteClick={jest.fn()}
+      />
+    );
+    const a = screen.getByRole('link');
+    expect(a).not.toHaveAttribute('target');
+    expect(a).toHaveAttribute('href', '/page');
+  });
+});

--- a/__tests__/components/nextGen/admin/NextGenAdminSetCosts.test.tsx
+++ b/__tests__/components/nextGen/admin/NextGenAdminSetCosts.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NextGenAdminSetCosts from '../../../../components/nextGen/admin/NextGenAdminSetCosts';
+
+jest.mock('../../../../components/nextGen/nextgen_helpers', () => ({
+  useGlobalAdmin: jest.fn(() => ({ data: true })),
+  useFunctionAdmin: jest.fn(() => ({ data: true })),
+  useCollectionIndex: jest.fn(() => ({ data: 2 })),
+  useCollectionAdmin: jest.fn(() => ({ data: [] })),
+  getCollectionIdsForAddress: jest.fn(() => ['1']),
+  useCollectionCosts: jest.fn(),
+  useMinterContractWrite: jest.fn(() => ({ writeContract: jest.fn(), reset: jest.fn(), params: {}, isSuccess:false, isError:false })),
+  useParsedCollectionIndex: jest.fn(() => 2),
+}));
+
+jest.mock('../../../../components/nextGen/admin/NextGenAdminShared', () => ({
+  NextGenCollectionIdFormGroup: ({ onChange }: any) => (
+    <input data-testid="collectionId" onChange={(e) => onChange(e.target.value)} />
+  ),
+  NextGenAdminHeadingRow: () => <div data-testid="heading" />,
+}));
+
+jest.mock('../../../../components/nextGen/NextGenContractWriteStatus', () => () => <div data-testid="status" />);
+
+jest.mock('../../../../components/auth/SeizeConnectContext', () => ({ useSeizeConnectContext: () => ({ address: '0x1' }) }));
+
+const helpers = require('../../../../components/nextGen/nextgen_helpers');
+
+function setup() {
+  return render(<NextGenAdminSetCosts close={() => {}} />);
+}
+
+describe('NextGenAdminSetCosts', () => {
+  it('shows validation errors when fields empty', () => {
+    setup();
+    fireEvent.click(screen.getByText('Submit'));
+    expect(screen.getByText('Collection id is required')).toBeInTheDocument();
+    expect(screen.getByText('Starting price is required')).toBeInTheDocument();
+  });
+
+  it('calls writeContract with provided values', async () => {
+    const user = userEvent.setup();
+    setup();
+    const contract = helpers.useMinterContractWrite.mock.results[0].value;
+    await user.type(screen.getByTestId('collectionId'), '1');
+    const inputs = screen.getAllByRole('textbox');
+    await user.type(inputs[0], '10');
+    await user.type(inputs[1], '20');
+    await user.type(inputs[2], '1');
+    await user.type(inputs[3], '2');
+    await user.type(inputs[4], '3');
+    await user.type(inputs[5], '0x2');
+    await user.click(screen.getByText('Submit'));
+    expect(contract.reset).toHaveBeenCalled();
+    await waitFor(() => expect(contract.writeContract).toHaveBeenCalledWith({
+      ...contract.params,
+      args: ['1', '10', '20', '1', '2', '3', '0x2'],
+    }));
+  });
+});

--- a/__tests__/components/user/utils/addresses-select/UserAddressesSelectDropdown.test.tsx
+++ b/__tests__/components/user/utils/addresses-select/UserAddressesSelectDropdown.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react';
+import UserAddressesSelectDropdown from '../../../../../components/user/utils/addresses-select/UserAddressesSelectDropdown';
+
+let capturedProps: any = null;
+
+jest.mock('../../../../../components/utils/select/dropdown/CommonDropdown', () => (props: any) => { capturedProps = props; return <div data-testid="dropdown" />; });
+
+const push = jest.fn();
+jest.mock('next/router', () => ({ useRouter: () => ({ query: { address: '0xabc' }, pathname: '/p', push }) }));
+
+describe('UserAddressesSelectDropdown', () => {
+  beforeEach(() => { capturedProps = null; push.mockClear(); });
+
+  it('initializes active item from query', () => {
+    render(<UserAddressesSelectDropdown wallets={[{ wallet: '0xabc', display: 'x' } as any]} onActiveAddress={jest.fn()} />);
+    expect(capturedProps.activeItem).toBe('0xabc');
+  });
+
+  it('updates query when selection changes', () => {
+    const onActive = jest.fn();
+    render(<UserAddressesSelectDropdown wallets={[{ wallet: '0xdef', display: 'd' } as any]} onActiveAddress={onActive} />);
+    capturedProps.setSelected('0xdef');
+    expect(push).toHaveBeenCalledWith({ pathname: '/p', query: { address: '0xdef' } }, undefined, { shallow: true });
+    expect(onActive).toHaveBeenCalledWith('0xdef');
+  });
+});

--- a/__tests__/components/waves/drops/DropContentWrapper.test.tsx
+++ b/__tests__/components/waves/drops/DropContentWrapper.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DropContentWrapper from '../../../components/waves/drops/DropContentWrapper';
+
+declare const ResizeObserver: any;
+
+beforeAll(() => {
+  (global as any).ResizeObserver = class { observe() {}; disconnect() {} };
+  Object.defineProperty(HTMLDivElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get() { return 1501; },
+  });
+});
+
+describe('DropContentWrapper', () => {
+  it('shows and hides expand button', async () => {
+    const user = userEvent.setup();
+    render(<DropContentWrapper>content</DropContentWrapper>);
+    expect(screen.getByText('Show full drop')).toBeInTheDocument();
+    await user.click(screen.getByText('Show full drop'));
+    expect(screen.queryByText('Show full drop')).toBeNull();
+  });
+});

--- a/__tests__/components/waves/memes/submission/validation/traitsValidation.test.ts
+++ b/__tests__/components/waves/memes/submission/validation/traitsValidation.test.ts
@@ -1,0 +1,80 @@
+import { validateTraitsData } from '../../../../../../components/waves/memes/submission/validation/traitsValidation';
+import { TraitsData } from '../../../../../../components/waves/memes/submission/types/TraitsData';
+
+function createTraits(): TraitsData {
+  return {
+    title: 'Title',
+    description: 'Desc',
+    artist: 'Artist',
+    seizeArtistProfile: '',
+    palette: '',
+    style: '',
+    jewel: '',
+    superpower: '',
+    dharma: '',
+    gear: '',
+    clothing: '',
+    element: '',
+    mystery: '',
+    secrets: '',
+    weapon: '',
+    home: '',
+    parent: '',
+    sibling: '',
+    food: '',
+    drink: '',
+    bonus: '',
+    boost: '',
+    punk6529: false,
+    gradient: false,
+    movement: false,
+    dynamic: false,
+    interactive: false,
+    collab: false,
+    om: false,
+    threeD: false,
+    pepe: false,
+    gm: false,
+    summer: false,
+    tulip: false,
+    memeName: 'Use a Hardware Wallet',
+    pointsPower: 1,
+    pointsWisdom: 2,
+    pointsLoki: 3,
+    pointsSpeed: 4,
+  };
+}
+
+describe('validateTraitsData', () => {
+  it('returns valid result for correct data', () => {
+    const traits = createTraits();
+    const result = validateTraitsData(traits);
+    expect(result.isValid).toBe(true);
+    expect(result.errorCount).toBe(0);
+  });
+
+  it('detects errors for empty required field', () => {
+    const traits = createTraits();
+    traits.artist = '';
+    const result = validateTraitsData(traits);
+    expect(result.isValid).toBe(false);
+    expect(result.errors.artist).toBeTruthy();
+  });
+
+  it('skips untouched fields in touched mode', () => {
+    const traits = createTraits();
+    traits.artist = '';
+    const result = validateTraitsData(traits, { mode: 'touched', touchedFields: new Set(['title']) });
+    expect(result.isValid).toBe(true);
+    expect(result.errorCount).toBe(0);
+  });
+
+  it('only validates changed fields in dirty mode', () => {
+    const initial = createTraits();
+    const traits = createTraits();
+    traits.artist = '';
+    const result = validateTraitsData(traits, { mode: 'dirty', initialValues: initial });
+    expect(result.isValid).toBe(false);
+    expect(result.errors.artist).toBeTruthy();
+  });
+});

--- a/__tests__/hooks/drops/useDropInteractionRules.test.ts
+++ b/__tests__/hooks/drops/useDropInteractionRules.test.ts
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { useDropInteractionRules } from '../../../hooks/drops/useDropInteractionRules';
+import { AuthContext } from '../../../components/auth/Auth';
+import { ApiDropType } from '../../../generated/models/ApiDropType';
+
+const wrapper = (value: any) => ({ children }: any) => (
+  <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+);
+
+describe('useDropInteractionRules', () => {
+  const baseDrop: any = {
+    id: 'd1',
+    drop_type: ApiDropType.Participatory,
+    author: { handle: 'me' },
+    context_profile_context: { max_rating: 1 },
+    wave: {
+      voting_period_start: 0,
+      voting_period_end: 3000,
+      authenticated_user_eligible_to_vote: true,
+      authenticated_user_admin: false,
+      admin_drop_deletion_enabled: false,
+    },
+  };
+
+  it('requires login to vote', () => {
+    const { result } = renderHook(() => useDropInteractionRules(baseDrop), { wrapper: wrapper({ connectedProfile: null, activeProfileProxy: null }) });
+    expect(result.current.canVote).toBe(false);
+    expect(result.current.voteState).toBe('NOT_LOGGED_IN');
+  });
+
+  it('handles winner drops', () => {
+    const drop = { ...baseDrop, drop_type: ApiDropType.Winner, winning_context: { place: 1 } };
+    const ctx = { connectedProfile: { handle: 'me' }, activeProfileProxy: null };
+    const { result } = renderHook(() => useDropInteractionRules(drop), { wrapper: wrapper(ctx) });
+    expect(result.current.isWinner).toBe(true);
+    expect(result.current.winningRank).toBe(1);
+    expect(result.current.canVote).toBe(false);
+  });
+
+  it('detects voting ended', () => {
+    const drop = { ...baseDrop, wave: { ...baseDrop.wave, voting_period_end: 1000 } };
+    jest.spyOn(Date, 'now').mockReturnValue(2000);
+    const ctx = { connectedProfile: { handle: 'me' }, activeProfileProxy: null };
+    const { result } = renderHook(() => useDropInteractionRules(drop), { wrapper: wrapper(ctx) });
+    expect(result.current.isVotingEnded).toBe(true);
+  });
+});

--- a/__tests__/hooks/useDeviceInfo.test.ts
+++ b/__tests__/hooks/useDeviceInfo.test.ts
@@ -1,0 +1,47 @@
+import { renderHook } from '@testing-library/react';
+import useDeviceInfo from '../../hooks/useDeviceInfo';
+
+jest.mock('../../hooks/useCapacitor', () => ({ __esModule: true, default: jest.fn(() => ({ isCapacitor: false })) }));
+const useCapacitorMock = require('../../hooks/useCapacitor').default as jest.Mock;
+
+defineMatchMedia();
+
+function defineMatchMedia(pointer = false, width = false) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn((query) => ({
+      matches: query.includes('pointer') ? pointer : width,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    })),
+  });
+}
+
+describe('useDeviceInfo', () => {
+  it('detects classic mobile user agent', () => {
+    Object.defineProperty(window.navigator, 'userAgent', { value: 'iPhone', configurable: true });
+    defineMatchMedia(true, false);
+    const { result } = renderHook(() => useDeviceInfo());
+    expect(result.current.isMobileDevice).toBe(true);
+    expect(result.current.hasTouchScreen).toBe(true);
+    expect(result.current.isApp).toBe(false);
+  });
+
+  it('detects capacitor mobile with desktop UA', () => {
+    useCapacitorMock.mockReturnValue({ isCapacitor: true });
+    Object.defineProperty(window.navigator, 'userAgent', { value: 'Macintosh', configurable: true });
+    defineMatchMedia(true, true);
+    const { result } = renderHook(() => useDeviceInfo());
+    expect(result.current.isMobileDevice).toBe(true);
+    expect(result.current.isApp).toBe(true);
+  });
+
+  it('returns false for desktop without touch', () => {
+    useCapacitorMock.mockReturnValue({ isCapacitor: false });
+    Object.defineProperty(window.navigator, 'userAgent', { value: 'Mozilla/5.0', configurable: true });
+    defineMatchMedia(false, false);
+    const { result } = renderHook(() => useDeviceInfo());
+    expect(result.current.isMobileDevice).toBe(false);
+    expect(result.current.hasTouchScreen).toBe(false);
+  });
+});

--- a/__tests__/hooks/useWave.test.ts
+++ b/__tests__/hooks/useWave.test.ts
@@ -1,0 +1,36 @@
+import { renderHook } from '@testing-library/react';
+import { useWave, SubmissionStatus } from '../../hooks/useWave';
+
+jest.mock('../../contexts/SeizeSettingsContext', () => ({ useSeizeSettings: () => ({ isMemesWave: (id: string) => id === 'memes' }) }));
+jest.mock('../../helpers/time', () => ({ Time: { currentMillis: jest.fn(() => 2000) } }));
+
+describe('useWave', () => {
+  const baseWave: any = {
+    id: 'wave1',
+    participation: {
+      no_of_applications_allowed_per_participant: 2,
+      period: { min: 1000, max: 3000 },
+      authenticated_user_eligible: true,
+    },
+    voting: { period: { min: 1000, max: 3000 } },
+    chat: { authenticated_user_eligible: true, enabled: true, scope: { group: { is_direct_message: false } } },
+    metrics: { your_participation_drops_count: 1 },
+    wave: { decisions_strategy: { subsequent_decisions: [] }, type: 'RANK' },
+  };
+
+  it('determines submission status based on time', () => {
+    const { result } = renderHook(() => useWave(baseWave));
+    expect(result.current.participation.status).toBe(SubmissionStatus.ACTIVE);
+    expect(result.current.participation.remainingSubmissions).toBe(1);
+    const time = require('../../helpers/time');
+    time.Time.currentMillis.mockReturnValue(4000);
+    const { result: ended } = renderHook(() => useWave(baseWave));
+    expect(ended.current.participation.status).toBe(SubmissionStatus.ENDED);
+  });
+
+  it('flags memes wave', () => {
+    const wave = { ...baseWave, id: 'memes' };
+    const { result } = renderHook(() => useWave(wave));
+    expect(result.current.isMemesWave).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for MediaDisplayVideo and DropContentWrapper
- cover traitsValidation utilities
- test FinalizeSnapshotsTable row mapping
- add markdown link and gif tests
- test NextGenAdminSetCosts form behaviour
- test user addresses dropdown logic
- cover useDeviceInfo, useWave and drop interaction rules hooks

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`