### PR TITLE
Add tests for pages and hooks

### DIFF
--- a/__tests__/components/user/rep/modify-rep/UserPageRepModifyModal.test.tsx
+++ b/__tests__/components/user/rep/modify-rep/UserPageRepModifyModal.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Modal from '../../../../../components/user/rep/modify-rep/UserPageRepModifyModal';
+import { AuthContext } from '../../../../../components/auth/Auth';
+import { ReactQueryWrapperContext } from '../../../../components/react-query-wrapper/ReactQueryWrapper';
+import { useQuery, useMutation } from '@tanstack/react-query';
+
+jest.mock('@tanstack/react-query');
+
+const useQueryMock = useQuery as jest.Mock;
+const useMutationMock = useMutation as jest.Mock;
+
+useQueryMock.mockReturnValue({});
+useMutationMock.mockReturnValue({ mutateAsync: jest.fn() });
+
+const defaultCtx = {
+  requestAuth: jest.fn().mockResolvedValue({ success: false }),
+  setToast: jest.fn(),
+  setTitle: jest.fn(),
+  connectedProfile: null,
+  activeProfileProxy: null,
+};
+
+describe('UserPageRepModifyModal', () => {
+  it('calls onClose when cancel clicked', async () => {
+    const onClose = jest.fn();
+    render(
+      <ReactQueryWrapperContext.Provider value={{ onProfileRepModify: jest.fn() }}>
+        <AuthContext.Provider value={defaultCtx as any}>
+          <Modal onClose={onClose} profile={{} as any} category="cat" />
+        </AuthContext.Provider>
+      </ReactQueryWrapperContext.Provider>
+    );
+
+    const cancel = screen.getByRole('button', { name: 'Cancel' });
+    await userEvent.click(cancel);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('disables save button initially', () => {
+    render(
+      <ReactQueryWrapperContext.Provider value={{ onProfileRepModify: jest.fn() }}>
+        <AuthContext.Provider value={defaultCtx as any}>
+          <Modal onClose={() => {}} profile={{} as any} category="cat" />
+        </AuthContext.Provider>
+      </ReactQueryWrapperContext.Provider>
+    );
+    const save = screen.getByRole('button', { name: 'Save' });
+    expect(save).toBeDisabled();
+  });
+});

--- a/__tests__/components/utils/input/rep-category/RepCategorySearchItem.test.tsx
+++ b/__tests__/components/utils/input/rep-category/RepCategorySearchItem.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RepCategorySearchItem from '../../../../../components/utils/input/rep-category/RepCategorySearchItem';
+
+describe('RepCategorySearchItem', () => {
+  it('calls onSelect when clicked', async () => {
+    const onSelect = jest.fn();
+    render(
+      <RepCategorySearchItem category="Art" selected={null} onSelect={onSelect} />
+    );
+    await userEvent.click(screen.getByRole('button'));
+    expect(onSelect).toHaveBeenCalledWith('Art');
+  });
+
+  it('shows check icon when selected and disables when disabled', () => {
+    const { container } = render(
+      <RepCategorySearchItem
+        category="Tech"
+        selected="Tech"
+        disabledCategories={["Tech"]}
+        onSelect={jest.fn()}
+      />
+    );
+    expect(container.querySelector('svg')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+});

--- a/__tests__/contexts/wave/hooks/useWaveMessagesStore.test.ts
+++ b/__tests__/contexts/wave/hooks/useWaveMessagesStore.test.ts
@@ -1,0 +1,59 @@
+import { renderHook, act } from '@testing-library/react';
+import useWaveMessagesStore from '../../../../contexts/wave/hooks/useWaveMessagesStore';
+
+describe('useWaveMessagesStore', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const baseDrop = {
+    id: 'd1',
+    wave: { id: 'wave1' },
+    author: { handle: 'a' },
+    parts: [],
+    metadata: [],
+    created_at: '2020',
+    title: '',
+    type: 'FULL',
+  } as any;
+
+  it('allows subscription and updates data', () => {
+    const { result } = renderHook(() => useWaveMessagesStore());
+    const listener = jest.fn();
+
+    act(() => result.current.subscribe('wave1', listener));
+    expect(listener).toHaveBeenCalledWith(undefined);
+
+    act(() => {
+      result.current.updateData({ key: 'wave1', drops: [baseDrop] } as any);
+    });
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    const data = result.current.getData('wave1');
+    expect(data?.drops[0].id).toBe('d1');
+    expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({ id: 'wave1' }));
+  });
+
+  it('removes drops and notifies listeners', () => {
+    const { result } = renderHook(() => useWaveMessagesStore());
+    const listener = jest.fn();
+
+    act(() => result.current.subscribe('wave1', listener));
+    act(() => {
+      result.current.updateData({ key: 'wave1', drops: [baseDrop] } as any);
+    });
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    listener.mockClear();
+
+    act(() => result.current.removeDrop('wave1', 'd1'));
+    expect(result.current.getData('wave1')?.drops).toHaveLength(0);
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({ drops: [] }));
+  });
+});

--- a/__tests__/hooks/useLocalPreference.test.ts
+++ b/__tests__/hooks/useLocalPreference.test.ts
@@ -1,0 +1,31 @@
+import { renderHook, act } from '@testing-library/react';
+import useLocalPreference from '../../hooks/useLocalPreference';
+
+describe('useLocalPreference', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('uses default value and updates localStorage', () => {
+    const { result } = renderHook(() => useLocalPreference('pref', 'def'));
+    expect(result.current[0]).toBe('def');
+
+    act(() => result.current[1]('new'));
+    expect(result.current[0]).toBe('new');
+    expect(localStorage.getItem('pref')).toBe(JSON.stringify('new'));
+  });
+
+  it('initializes from existing storage', () => {
+    localStorage.setItem('pref', JSON.stringify('stored'));
+    const { result } = renderHook(() => useLocalPreference('pref', 'def'));
+    expect(result.current[0]).toBe('stored');
+  });
+
+  it('responds to storage events', () => {
+    const { result } = renderHook(() => useLocalPreference('pref', 'def'));
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', { key: 'pref', newValue: JSON.stringify('other') }));
+    });
+    expect(result.current[0]).toBe('other');
+  });
+});

--- a/__tests__/pages/museum/sunshine-square/index.test.tsx
+++ b/__tests__/pages/museum/sunshine-square/index.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Page from '../../../../pages/museum/sunshine-square';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+jest.mock('../../../../components/header/Header', () => () => <div data-testid="header" />);
+jest.mock('../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder" />);
+
+const renderPage = () => render(<Page />);
+
+describe('Sunshine Square Page', () => {
+  it('renders title and canonical link', () => {
+    renderPage();
+    expect(document.querySelector('title')?.textContent).toBe('SUNSHINE SQUARE - 6529.io');
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical?.getAttribute('href')).toBe('/museum/sunshine-square/');
+  });
+
+  it('includes robots meta tag and top link', () => {
+    renderPage();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+    expect(document.querySelector('#toTop')).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/network/nerd/index.test.tsx
+++ b/__tests__/pages/network/nerd/index.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { AuthContext } from '../../../../components/auth/Auth';
+import { useRouter } from 'next/router';
+// Provide our own enum to avoid loading the real component
+enum LeaderboardFocus {
+  TDH = 'Cards Collected',
+  INTERACTIONS = 'Interactions',
+}
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+let capturedProps: any;
+jest.mock('../../../../components/leaderboard/Leaderboard', () => {
+  return {
+    __esModule: true,
+    LeaderboardFocus,
+    default: (props: any) => {
+      capturedProps = props;
+      return <div data-testid="leaderboard" />;
+    },
+  };
+});
+
+jest.mock('next/router');
+const useRouterMock = useRouter as jest.Mock;
+const { default: CommunityNerdPage, getServerSideProps } = require('../../../../pages/network/nerd/[[...focus]]');
+
+describe('CommunityNerdPage', () => {
+  beforeEach(() => {
+    capturedProps = undefined;
+    jest.clearAllMocks();
+  });
+
+  const renderPage = (focus: LeaderboardFocus) => {
+    const setTitle = jest.fn();
+    useRouterMock.mockReturnValue({ asPath: '/network/nerd', replace: jest.fn() });
+    render(
+      <AuthContext.Provider value={{ setTitle, title: '' } as any}>
+        <CommunityNerdPage pageProps={{ focus }} />
+      </AuthContext.Provider>
+    );
+    return { setTitle, router: useRouterMock.mock.results[0].value };
+  };
+
+  it('passes focus to leaderboard and sets title', () => {
+    const { setTitle } = renderPage(LeaderboardFocus.TDH);
+    expect(capturedProps.focus).toBe(LeaderboardFocus.TDH);
+    expect(setTitle).toHaveBeenCalledWith({ title: 'Network Nerd - Cards Collected' });
+  });
+
+  it('updates path when focus changes', () => {
+    const { router } = renderPage(LeaderboardFocus.TDH);
+    act(() => capturedProps.setFocus(LeaderboardFocus.INTERACTIONS));
+    expect(router.replace).toHaveBeenCalledWith('/network/nerd/interactions', undefined, { shallow: true });
+  });
+});
+
+describe('getServerSideProps', () => {
+  it('returns focus based on query', async () => {
+    const result = await getServerSideProps({ query: { focus: ['interactions'] } } as any);
+    expect(result).toEqual({
+      props: {
+        focus: LeaderboardFocus.INTERACTIONS,
+        metadata: { title: 'Network Nerd - Interactions', description: 'Network' },
+      },
+    });
+  });
+
+  it('defaults to TDH', async () => {
+    const result = await getServerSideProps({ query: {} } as any);
+    expect(result.props.focus).toBe(LeaderboardFocus.TDH);
+  });
+});

--- a/__tests__/pages/om/index.test.tsx
+++ b/__tests__/pages/om/index.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Page from '../../../pages/om';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+jest.mock('../../../components/header/Header', () => () => <div data-testid="header" />);
+jest.mock('../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder" />);
+
+describe('OM Index Page', () => {
+  const renderPage = () => render(<Page />);
+
+  it('renders page title and canonical link', () => {
+    renderPage();
+    expect(document.querySelector('title')?.textContent).toBe('OM - 6529.io');
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical?.getAttribute('href')).toBe('/om/');
+  });
+
+  it('contains robots meta and go to top link', () => {
+    renderPage();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+    expect(document.querySelector('#toTop')).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/theMemesDistribution.test.tsx
+++ b/__tests__/pages/theMemesDistribution.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Page, { getServerSideProps } from '../../pages/the-memes/[id]/distribution';
+import { getSharedServerSideProps } from '../../components/the-memes/MemeShared';
+import { MEMES_CONTRACT } from '../../constants';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+jest.mock('../../components/distribution/Distribution', () => (props: any) => <div data-testid="distribution" {...props} />);
+jest.mock('../../components/the-memes/MemeShared');
+
+const mockShared = getSharedServerSideProps as jest.Mock;
+
+describe('Meme Distribution Page', () => {
+  it('renders distribution component', () => {
+    render(<Page />);
+    expect(document.querySelector('[data-testid="distribution"]')).toBeInTheDocument();
+  });
+
+  it('delegates getServerSideProps', async () => {
+    mockShared.mockResolvedValue({ props: { foo: 'bar' } });
+    const res = await getServerSideProps({} as any, null as any, null as any);
+    expect(mockShared).toHaveBeenCalledWith({}, MEMES_CONTRACT, true);
+    expect(res).toEqual({ props: { foo: 'bar' } });
+  });
+});

--- a/__tests__/pages/tools/app-wallets/import-wallet.test.tsx
+++ b/__tests__/pages/tools/app-wallets/import-wallet.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Page from '../../../../pages/tools/app-wallets/import-wallet';
+import { AuthContext } from '../../../../components/auth/Auth';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="import" />);
+jest.mock('../../../../components/app-wallets/AppWalletImport', () => () => <div data-testid="import" />);
+
+const renderPage = (setTitle: jest.Mock) =>
+  render(
+    <AuthContext.Provider value={{ setTitle } as any}>
+      <Page />
+    </AuthContext.Provider>
+  );
+
+describe('Import App Wallet Page', () => {
+  it('sets title and renders import component', () => {
+    const setTitle = jest.fn();
+    renderPage(setTitle);
+    expect(setTitle).toHaveBeenCalledWith({ title: 'Import App Wallet | Tools' });
+    expect(document.querySelector('[data-testid="import"]')).toBeInTheDocument();
+  });
+
+  it('exports metadata', () => {
+    expect(Page.metadata).toEqual({ title: 'App Wallets | Import', description: 'Tools' });
+  });
+});

--- a/__tests__/wagmiConfigWeb.test.ts
+++ b/__tests__/wagmiConfigWeb.test.ts
@@ -1,0 +1,21 @@
+import { wagmiConfigWeb } from '../wagmiConfig/wagmiConfigWeb';
+import { mainnet } from 'viem/chains';
+
+jest.mock('@web3modal/wagmi', () => ({ defaultWagmiConfig: jest.fn(() => ({})) }));
+
+const mockDefault = require('@web3modal/wagmi').defaultWagmiConfig as jest.Mock;
+
+describe('wagmiConfigWeb', () => {
+  it('builds config with expected options', () => {
+    const metadata = { name: 'test' };
+    wagmiConfigWeb([mainnet], metadata);
+    expect(mockDefault).toHaveBeenCalledWith({
+      chains: [mainnet],
+      projectId: '0ba285cc179045bec37f7c9b9e7f9fbf',
+      metadata,
+      enableCoinbase: true,
+      coinbasePreference: 'all',
+      auth: { email: false, socials: [] },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add page tests for Sunshine Square, OM, Network Nerd, and more
- cover wagmi config web and local preference hook
- test wave message store hook behaviour
- test RepCategorySearchItem component
- basic tests for rep modify modal and import wallet page

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`