### PR TITLE
Fix EMMA page test

### DIFF
--- a/__tests__/pages/emmaPage.test.tsx
+++ b/__tests__/pages/emmaPage.test.tsx
@@ -2,14 +2,16 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import DistributionPlanTool from '../../pages/emma/index';
 
-jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+jest.mock('next/dynamic', () => () => (props: any) => (
+  <div data-testid="dynamic">{props.children}</div>
+));
 jest.mock('../../components/distribution-plan-tool/wrapper/DistributionPlanToolWrapper', () => ({ children }: any) => <div data-testid="wrapper">{children}</div>);
 jest.mock('../../components/distribution-plan-tool/connect/distributipn-plan-tool-connect', () => () => <div data-testid="connect" />);
 
 describe('EMMA page', () => {
-  it('renders wrapper and connect components', () => {
+  it('renders dynamic wrapper and connect components', () => {
     render(<DistributionPlanTool />);
-    expect(screen.getByTestId('wrapper')).toBeInTheDocument();
+    expect(screen.getByTestId('dynamic')).toBeInTheDocument();
     expect(screen.getByTestId('connect')).toBeInTheDocument();
     expect(screen.getByText(/Meet EMMA/i)).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- update EMMA page test to render mocked dynamic component correctly

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
