### PR TITLE
Add page tests

### DIFF
--- a/__tests__/pages/emmaPage.test.tsx
+++ b/__tests__/pages/emmaPage.test.tsx
@@ -2,7 +2,16 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import DistributionPlanTool from '../../pages/emma/index';
 
-jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+jest.mock('next/dynamic', () => {
+  return (importer: any) => {
+    const Component = (props: any) => {
+      const mod = require('../../components/distribution-plan-tool/wrapper/DistributionPlanToolWrapper');
+      const Actual = mod.default || mod;
+      return <Actual {...props} />;
+    };
+    return Component;
+  };
+});
 jest.mock('../../components/distribution-plan-tool/wrapper/DistributionPlanToolWrapper', () => ({ children }: any) => <div data-testid="wrapper">{children}</div>);
 jest.mock('../../components/distribution-plan-tool/connect/distributipn-plan-tool-connect', () => () => <div data-testid="connect" />);
 

--- a/__tests__/pages/museum/6529-fund-szn1/clonex/index.test.tsx
+++ b/__tests__/pages/museum/6529-fund-szn1/clonex/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../../pages/museum/6529-fund-szn1/clonex';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('CloneX Page', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('CLONEX - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/6529-fund-szn1/clonex/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('CLONEX - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/6529-fund-szn1/grifters/index.test.tsx
+++ b/__tests__/pages/museum/6529-fund-szn1/grifters/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../../pages/museum/6529-fund-szn1/grifters';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('Grifters Page', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('GRIFTERS - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/6529-fund-szn1/grifters/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('GRIFTERS - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/gazers/index.test.tsx
+++ b/__tests__/pages/museum/genesis/gazers/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../../pages/museum/genesis/gazers';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('Gazers Page', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('GAZERS - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/gazers/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('GAZERS - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/glitch-crystal-monsters/index.test.tsx
+++ b/__tests__/pages/museum/genesis/glitch-crystal-monsters/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../../pages/museum/genesis/glitch-crystal-monsters';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('Glitch Crystal Monsters Page', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('GLITCH CRYSTAL MONSTERS - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/glitch-crystal-monsters/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('GLITCH CRYSTAL MONSTERS - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/index.test.tsx
+++ b/__tests__/pages/museum/genesis/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../pages/museum/genesis';
+
+jest.mock('../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('Genesis Index Page', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('GENESIS - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('GENESIS - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/kai-gen/index.test.tsx
+++ b/__tests__/pages/museum/genesis/kai-gen/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../../pages/museum/genesis/kai-gen';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('Kai-Gen Page', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('KAI-GEN - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/kai-gen/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('KAI-GEN - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/genesis/labios/index.test.tsx
+++ b/__tests__/pages/museum/genesis/labios/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../../pages/museum/genesis/labios';
+
+jest.mock('../../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('Labios Page', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('LABIOS - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/genesis/labios/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('LABIOS - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/museum/imagined-worlds/index.test.tsx
+++ b/__tests__/pages/museum/imagined-worlds/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../pages/museum/imagined-worlds';
+
+jest.mock('../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('Imagined Worlds Page', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('IMAGINED WORLDS - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/museum/imagined-worlds/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('IMAGINED WORLDS - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/om/6529-museum-district/index.test.tsx
+++ b/__tests__/pages/om/6529-museum-district/index.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page from '../../../../pages/om/6529-museum-district';
+
+jest.mock('../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+
+describe('6529 Museum District Page', () => {
+  const renderComponent = () => render(<Page />);
+
+  it('renders the page title', () => {
+    renderComponent();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('6529 MUSEUM DISTRICT - 6529.io');
+  });
+
+  it('includes canonical link', () => {
+    renderComponent();
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical).toBeInTheDocument();
+    expect(canonical?.getAttribute('href')).toBe('/om/6529-museum-district/');
+  });
+
+  it('includes robots meta tag', () => {
+    renderComponent();
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+  });
+
+  it('includes Open Graph title', () => {
+    renderComponent();
+    const ogTitle = document.querySelector('meta[property="og:title"]');
+    expect(ogTitle?.getAttribute('content')).toBe('6529 MUSEUM DISTRICT - 6529.io');
+  });
+
+  it('has skip to content link', () => {
+    renderComponent();
+    const skip = screen.getByText('Skip to content');
+    expect(skip).toBeInTheDocument();
+    expect(skip).toHaveAttribute('href', '#content');
+  });
+
+  it('has go to top link', () => {
+    renderComponent();
+    const link = document.querySelector('#toTop');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/open-data/network-metrics.test.tsx
+++ b/__tests__/pages/open-data/network-metrics.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NetworkMetrics from '../../../pages/open-data/network-metrics';
+import { AuthContext } from '../../../components/auth/Auth';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+describe('Open Data network metrics page', () => {
+  it('renders metrics component and sets title', () => {
+    const setTitle = jest.fn();
+    render(
+      <AuthContext.Provider value={{ setTitle } as any}>
+        <NetworkMetrics />
+      </AuthContext.Provider>
+    );
+    expect(screen.getByTestId('dynamic')).toBeInTheDocument();
+    expect(setTitle).toHaveBeenCalledWith({ title: 'Network Metrics | Open Data' });
+  });
+
+  it('exposes metadata', () => {
+    expect(NetworkMetrics.metadata).toEqual({ title: 'Network Metrics', description: 'Open Data' });
+  });
+});


### PR DESCRIPTION
## Summary
- cover museum fund pages like CloneX, Grifters
- test Genesis landing and collections
- add imagined worlds and museum district tests
- cover open-data network metrics
- ensure EMMA page test loads wrapper correctly

## Testing
- `npx jest __tests__/pages/emmaPage.test.tsx`
- `npx jest __tests__/pages/open-data/network-metrics.test.tsx`
