### PR TITLE
Add tests for network activity and other components

### DIFF
--- a/__tests__/components/brain/my-stream/layout/LayoutContext.test.tsx
+++ b/__tests__/components/brain/my-stream/layout/LayoutContext.test.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import { LayoutProvider, useLayout } from '../../../../components/brain/my-stream/layout/LayoutContext';
+
+jest.mock('../../../../../hooks/useCapacitor', () => ({ __esModule: true, default: () => ({ isCapacitor: false, isAndroid: false, isIos: false }) }));
+
+beforeAll(() => {
+  // run RAF callbacks immediately
+  global.requestAnimationFrame = (cb: any) => { cb(); return 0; };
+});
+
+afterAll(() => {
+  delete (global as any).requestAnimationFrame;
+});
+
+function TestComponent() {
+  const { registerRef, spaces, waveViewStyle } = useLayout();
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (ref.current) {
+      // mock height
+      (ref.current as any).getBoundingClientRect = () => ({ height: 100 });
+      registerRef('header', ref.current);
+    }
+  }, [registerRef]);
+  return (
+    <>
+      <div ref={ref} />
+      <div data-testid="content" style={waveViewStyle}>{spaces.contentSpace}</div>
+    </>
+  );
+}
+
+describe('LayoutProvider', () => {
+  it('calculates spaces and styles', () => {
+    Object.defineProperty(window, 'innerHeight', { value: 1000, configurable: true });
+    render(
+      <LayoutProvider>
+        <TestComponent />
+      </LayoutProvider>
+    );
+    const content = screen.getByTestId('content');
+    expect(content.textContent).toBe('900');
+    expect(content.style.height).toContain('calc(100vh - 100px');
+  });
+});

--- a/__tests__/components/groups/page/list/card/GroupCardConfigs.test.tsx
+++ b/__tests__/components/groups/page/list/card/GroupCardConfigs.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import GroupCardConfigs from '../../../../../../components/groups/page/list/card/GroupCardConfigs';
+import { ApiGroupFilterDirection } from '../../../../../../generated/models/ApiGroupFilterDirection';
+import { GroupDescriptionType } from '../../../../../../entities/IGroup';
+
+jest.mock('../../../../../../components/groups/page/list/card/GroupCardConfig', () => ({ config }: any) => <div data-testid={`config-${config.key}`}>{config.value}</div>);
+
+describe('GroupCardConfigs', () => {
+  it('shows default wallets when group undefined', () => {
+    const { getByTestId } = render(<GroupCardConfigs group={undefined as any} />);
+    expect(getByTestId(`config-${GroupDescriptionType.WALLETS}`)).toHaveTextContent('0');
+  });
+
+  it('creates configs from group data', () => {
+    const group: any = {
+      group: {
+        tdh: { min: 1, max: 2 },
+        rep: { min: 0, max: 10, category: 'c', user_identity: 'bob', direction: ApiGroupFilterDirection.Sent },
+        cic: { min: null, max: 5, user_identity: null, direction: null },
+        level: { min: 3, max: 4 },
+        identity_group_identities_count: 7,
+      },
+    };
+    const { getByTestId } = render(<GroupCardConfigs group={group} />);
+    expect(getByTestId(`config-${GroupDescriptionType.TDH}`)).toHaveTextContent('1 - 2');
+    expect(getByTestId(`config-${GroupDescriptionType.REP}`)).toHaveTextContent('0 - 10, category: c, to identity: bob');
+    expect(getByTestId(`config-${GroupDescriptionType.NIC}`)).toHaveTextContent('<= 5');
+    expect(getByTestId(`config-${GroupDescriptionType.LEVEL}`)).toHaveTextContent('3 - 4');
+    expect(getByTestId(`config-${GroupDescriptionType.WALLETS}`)).toHaveTextContent('7');
+  });
+});

--- a/__tests__/components/nextGen/admin/NextGenAdminCreateCollection.test.tsx
+++ b/__tests__/components/nextGen/admin/NextGenAdminCreateCollection.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NextGenAdminCreateCollection from '../../../../components/nextGen/admin/NextGenAdminCreateCollection';
+
+jest.mock('../../../../components/nextGen/admin/NextGenAdminShared', () => ({
+  NextGenAdminTextFormGroup: ({ title, value, setValue }: any) => (
+    <input data-testid={title} value={value} onChange={e => setValue(e.target.value)} />
+  ),
+  NextGenAdminScriptsFormGroup: ({ setScripts }: any) => (
+    <button data-testid="script" onClick={() => setScripts(['s'])} />
+  ),
+  NextGenAdminHeadingRow: () => <div data-testid="heading" />
+}));
+
+jest.mock('../../../../components/nextGen/nextgen_helpers', () => ({ useCoreContractWrite: jest.fn() }));
+jest.mock('../../../../components/nextGen/NextGenContractWriteStatus', () => () => <div data-testid="status" />);
+
+const helpers = require('../../../../components/nextGen/nextgen_helpers');
+
+describe('NextGenAdminCreateCollection', () => {
+  beforeEach(() => {
+    (helpers.useCoreContractWrite as jest.Mock).mockReturnValue({ writeContract: jest.fn(), reset: jest.fn(), params: {}, isSuccess:false,isError:false,isLoading:false });
+  });
+
+  it('shows validation errors', () => {
+    render(<NextGenAdminCreateCollection close={() => {}} />);
+    fireEvent.click(screen.getByText('Submit'));
+    expect(screen.getByText('Collection name is required')).toBeInTheDocument();
+  });
+
+  it('submits when valid', async () => {
+    const user = userEvent.setup();
+    render(<NextGenAdminCreateCollection close={() => {}} />);
+    const contract = (helpers.useCoreContractWrite as jest.Mock).mock.results[0].value;
+    const names = [
+      'Collection Name','Artist','Description','Website','License','Base URI','Library','Dependency Script'
+    ];
+    for (const name of names) {
+      await user.type(screen.getByTestId(name), 'x');
+    }
+    await user.click(screen.getByTestId('script'));
+    await user.click(screen.getByText('Submit'));
+  });
+});

--- a/__tests__/components/nextGen/admin/NextGenAdminPayArtist.test.tsx
+++ b/__tests__/components/nextGen/admin/NextGenAdminPayArtist.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NextGenAdminPayArtist from '../../../../components/nextGen/admin/NextGenAdminPayArtist';
+
+jest.mock('../../../../components/nextGen/admin/NextGenAdminShared', () => ({
+  NextGenCollectionIdFormGroup: ({ onChange }: any) => <input data-testid="col" onChange={e=>onChange(e.target.value)} />,
+  NextGenAdminHeadingRow: () => <div data-testid="heading" />,
+  NextGenAdminTextFormGroup: ({ title, value, setValue }: any) => <input data-testid={title} value={value} onChange={e=>setValue(e.target.value)} />
+}));
+
+jest.mock('../../../../components/nextGen/nextgen_helpers', () => ({
+  useGlobalAdmin: jest.fn(() => ({ data: true })),
+  useFunctionAdmin: jest.fn(() => ({ data: true })),
+  useCollectionIndex: jest.fn(() => ({ data: 1 })),
+  useCollectionAdmin: jest.fn(() => ({ data: [] })),
+  getCollectionIdsForAddress: jest.fn(() => ['1']),
+  useMinterContractWrite: jest.fn(),
+  useParsedCollectionIndex: jest.fn(() => 1)
+}));
+
+jest.mock('../../../../components/nextGen/NextGenContractWriteStatus', () => () => <div data-testid="status" />);
+jest.mock('../../../../components/auth/SeizeConnectContext', () => ({ useSeizeConnectContext: () => ({ address: '0x1' }) }));
+
+const helpers = require('../../../../components/nextGen/nextgen_helpers');
+
+describe('NextGenAdminPayArtist', () => {
+  beforeEach(() => {
+    (helpers.useMinterContractWrite as jest.Mock).mockReturnValue({ writeContract: jest.fn(), reset: jest.fn(), params:{}, isLoading:false,isError:false,isSuccess:false });
+  });
+
+  it('shows validation errors', () => {
+    render(<NextGenAdminPayArtist close={()=>{}} />);
+    fireEvent.click(screen.getByText('Submit'));
+    expect(screen.getByText('Collection id is required')).toBeInTheDocument();
+  });
+
+  it('calls writeContract when valid', async () => {
+    const user = userEvent.setup();
+    render(<NextGenAdminPayArtist close={()=>{}} />);
+    const contract = (helpers.useMinterContractWrite as jest.Mock).mock.results[0].value;
+    await user.type(screen.getByTestId('col'), '1');
+    const inputs = screen.getAllByTestId('Artist Address');
+    await user.type(inputs[0], 'a1');
+    await user.type(screen.getByTestId('Percentage for Address 1'), '1');
+    await user.type(inputs[1], 'a2');
+    await user.type(screen.getByTestId('Percentage for Address 2'), '2');
+    await user.click(screen.getByText('Submit'));
+  });
+});

--- a/__tests__/components/user/identity/header/cic-rate/UserPageIdentityHeaderCICRate.test.tsx
+++ b/__tests__/components/user/identity/header/cic-rate/UserPageIdentityHeaderCICRate.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserPageIdentityHeaderCICRate from '../../../../../../components/user/identity/header/cic-rate/UserPageIdentityHeaderCICRate';
+import { AuthContext } from '../../../../../../components/auth/Auth';
+import { ReactQueryWrapperContext } from '../../../../../../components/react-query-wrapper/ReactQueryWrapper';
+import { useMutation, useQuery } from '@tanstack/react-query';
+
+jest.mock('../../../../../../components/user/identity/header/cic-rate/UserPageIdentityHeaderCICRateStats', () => () => <div data-testid="stats" />);
+jest.mock('../../../../../../components/auth/SeizeConnectContext', () => ({ useSeizeConnectContext: () => ({ address: '0x1' }) }));
+jest.mock('@tanstack/react-query');
+jest.mock('../../../../../../services/api/common-api', () => ({ commonApiFetch: jest.fn(), commonApiPost: jest.fn() }));
+jest.mock('react-use', () => ({ createBreakpoint: () => () => 'MD' }));
+
+const useQueryMock = useQuery as jest.Mock;
+const useMutationMock = useMutation as jest.Mock;
+
+describe('UserPageIdentityHeaderCICRate', () => {
+  beforeEach(() => {
+    useQueryMock.mockReturnValue({ data: { cic_rating_by_rater: 0, cic_ratings_left_to_give_by_rater: 5 } });
+    useMutationMock.mockImplementation((opts: any) => ({ mutateAsync: jest.fn(opts.mutationFn) }));
+  });
+
+  function setup(auth?: any) {
+    const authValue = {
+      requestAuth: jest.fn().mockResolvedValue({ success: true }),
+      setToast: jest.fn(),
+      connectedProfile: { handle: 'alice' },
+      activeProfileProxy: null,
+      ...auth,
+    } as any;
+    const queryCtx = { onProfileCICModify: jest.fn() } as any;
+    render(
+      <AuthContext.Provider value={authValue}>
+        <ReactQueryWrapperContext.Provider value={queryCtx}>
+          <UserPageIdentityHeaderCICRate profile={{ query: 'bob', handle: 'bob' } as any} isTooltip={false} />
+        </ReactQueryWrapperContext.Provider>
+      </AuthContext.Provider>
+    );
+    return { authValue, queryCtx };
+  }
+
+  it('submits rating when authenticated', async () => {
+    const user = userEvent.setup();
+    const { authValue } = setup();
+    await user.type(screen.getByLabelText(/Your total NIC Rating/), '3');
+    await user.click(screen.getByRole('button', { name: 'Rate' }));
+    expect(authValue.requestAuth).toHaveBeenCalled();
+  });
+
+  it('shows toast when auth fails', async () => {
+    const user = userEvent.setup();
+    const { authValue } = setup({ requestAuth: jest.fn().mockResolvedValue({ success: false }) });
+    await user.type(screen.getByLabelText(/Your total NIC Rating/), '1');
+    await user.click(screen.getByRole('button', { name: 'Rate' }));
+    expect(authValue.setToast).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/utils/switch/CommonSwitch.test.tsx
+++ b/__tests__/components/utils/switch/CommonSwitch.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CommonSwitch from '../../../../components/utils/switch/CommonSwitch';
+
+describe('CommonSwitch', () => {
+  it('renders and toggles', async () => {
+    const user = userEvent.setup();
+    const setIsOn = jest.fn();
+    render(<CommonSwitch label="Test" isOn={false} setIsOn={setIsOn} />);
+    const button = screen.getByRole('switch');
+    expect(button).toHaveClass('tw-bg-neutral-700');
+    await user.click(button);
+    expect(setIsOn).toHaveBeenCalledWith(true);
+  });
+});

--- a/__tests__/components/waves/create-wave/drops/metadata/CreateWaveDropsMetadata.test.tsx
+++ b/__tests__/components/waves/create-wave/drops/metadata/CreateWaveDropsMetadata.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CreateWaveDropsMetadata from '../../../../../../components/waves/create-wave/drops/metadata/CreateWaveDropsMetadata';
+import { ApiWaveMetadataType } from '../../../../../../generated/models/ApiWaveMetadataType';
+
+jest.mock('../../../../../../components/waves/create-wave/drops/metadata/CreateWaveDropsMetadataRow', () => ({ item, index, isNotUnique, onItemChange, onItemRemove }: any) => (
+  <div data-testid={`row-${index}`}>{item.key}-{isNotUnique ? 'bad' : 'ok'}<button onClick={()=>onItemRemove(index)}>rem</button></div>
+));
+
+jest.mock('../../../../../../components/waves/create-wave/drops/metadata/CreateWaveDropsMetadataAddRowButton', () => ({ onAddNewRow }: any) => (
+  <button data-testid="add" onClick={onAddNewRow}>add</button>
+));
+
+describe('CreateWaveDropsMetadata', () => {
+  it('adds rows and marks non unique', async () => {
+    const user = userEvent.setup();
+    const change = jest.fn();
+    const items = [{ key:'a', type:ApiWaveMetadataType.String },{ key:'a', type:ApiWaveMetadataType.String }];
+    render(<CreateWaveDropsMetadata requiredMetadata={items} errors={['DROPS_REQUIRED_METADATA_NON_UNIQUE'] as any} onRequiredMetadataChange={change} />);
+    expect(screen.getByTestId('row-0').textContent).toContain('bad');
+    await user.click(screen.getByTestId('add'));
+    expect(change).toHaveBeenCalledWith([...items, { key:'', type: ApiWaveMetadataType.String }]);
+    await user.click(screen.getAllByText('rem')[0]);
+    expect(change).toHaveBeenCalled();
+  });
+
+  it('shows placeholder when empty', () => {
+    render(<CreateWaveDropsMetadata requiredMetadata={[]} errors={[]} onRequiredMetadataChange={()=>{}} />);
+    expect(screen.getByText('No required metadata added')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/memes/submission/hooks/useArtworkSubmissionForm.test.ts
+++ b/__tests__/components/waves/memes/submission/hooks/useArtworkSubmissionForm.test.ts
@@ -1,0 +1,34 @@
+import { renderHook, act } from '@testing-library/react';
+import { useArtworkSubmissionForm } from '../../../../../../components/waves/memes/submission/hooks/useArtworkSubmissionForm';
+
+jest.mock('../../../../../../components/waves/memes/traits/schema', () => ({ initialTraits: { title: '', description: '', artist: '', seizeArtistProfile: '' } }));
+jest.mock('../../../../../../components/auth/Auth', () => ({ useAuth: jest.fn() }));
+
+const { useAuth } = require('../../../../../../components/auth/Auth');
+
+describe('useArtworkSubmissionForm', () => {
+  beforeEach(() => {
+    (useAuth as jest.Mock).mockReturnValue({ connectedProfile: { handle: 'alice' } });
+  });
+
+  it('initializes traits from profile and updates fields', () => {
+    const { result } = renderHook(() => useArtworkSubmissionForm());
+    expect(result.current.currentStep).toBe('agreement');
+    expect(result.current.traits.artist).toBe('alice');
+    act(() => { result.current.setTraits({ title: 't' }); });
+    expect(result.current.traits.title).toBe('t');
+    act(() => { result.current.updateTraitField('description', 'd'); });
+    expect(result.current.traits.description).toBe('d');
+  });
+
+  it('handles continue and file select', () => {
+    const { result } = renderHook(() => useArtworkSubmissionForm());
+    act(() => { result.current.handleContinueFromTerms(); });
+    expect(result.current.currentStep).toBe('artwork');
+    class MockFileReader { onloadend: any; readAsDataURL() { this.onloadend(); } result = 'url'; }
+    global.FileReader = MockFileReader as any;
+    act(() => { result.current.handleFileSelect(new File(['x'], 'a.png')); });
+    expect(result.current.artworkUploaded).toBe(true);
+    expect(result.current.artworkUrl).toBe('url');
+  });
+});

--- a/__tests__/hooks/waves/useDecisionPoints.test.ts
+++ b/__tests__/hooks/waves/useDecisionPoints.test.ts
@@ -1,0 +1,28 @@
+import { useDecisionPoints } from '../../hooks/waves/useDecisionPoints';
+
+const mockCalculate = require('../../../helpers/waves/time.utils').calculateLastDecisionTime;
+
+jest.mock('../../../helpers/waves/time.utils', () => ({
+  calculateLastDecisionTime: jest.fn(() => 20)
+}));
+
+describe('useDecisionPoints', () => {
+  it('returns empty array when first decision missing', () => {
+    const wave: any = { wave: { decisions_strategy: {} } };
+    expect(useDecisionPoints(wave).allDecisions).toEqual([]);
+  });
+
+  it('creates decision points until last time', () => {
+    const wave: any = {
+      wave: {
+        decisions_strategy: { first_decision_time: 10, subsequent_decisions: [5] },
+      },
+    };
+    const result = useDecisionPoints(wave).allDecisions;
+    expect(mockCalculate).toHaveBeenCalledWith(wave);
+    expect(result).toEqual([
+      { id: 0, name: 'First Decision', timestamp: 10 },
+      { id: 1, name: 'Decision 1', timestamp: 15 },
+    ]);
+  });
+});

--- a/__tests__/pages/network/activity.test.tsx
+++ b/__tests__/pages/network/activity.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { AuthContext } from '../../../components/auth/Auth';
+import { ReactQueryWrapperContext } from '../../../components/react-query-wrapper/ReactQueryWrapper';
+import { getCommonHeaders, getUserProfileActivityLogs } from '../../../helpers/server.helpers';
+
+jest.mock('../../../components/utils/sidebar/SidebarLayout', () => ({ children }: any) => <div data-testid="layout">{children}</div>);
+jest.mock('../../../components/profile-activity/ProfileActivityLogs', () => ({ children, ...props }: any) => { global.__profileProps = props; return <div data-testid="logs">{children}</div>; });
+
+jest.mock('../../../helpers/server.helpers');
+
+// Import after mocks so side effects run with mocks applied
+import CommunityActivityPage, { getServerSideProps } from '../../../pages/network/activity';
+
+const mockedGetCommonHeaders = getCommonHeaders as jest.Mock;
+const mockedGetLogs = getUserProfileActivityLogs as jest.Mock;
+
+describe('CommunityActivityPage', () => {
+  function renderPage() {
+    const setTitle = jest.fn();
+    const initCommunityActivityPage = jest.fn();
+    render(
+      <AuthContext.Provider value={{ setTitle } as any}>
+        <ReactQueryWrapperContext.Provider value={{ initCommunityActivityPage } as any}>
+          <CommunityActivityPage pageProps={{ logsPage: { items: [] } } as any} />
+        </ReactQueryWrapperContext.Provider>
+      </AuthContext.Provider>
+    );
+    return { setTitle, initCommunityActivityPage };
+  }
+
+  it('initializes page and sets title', () => {
+    const { setTitle, initCommunityActivityPage } = renderPage();
+    expect(setTitle).toHaveBeenCalledWith({ title: 'Activity | Network' });
+    expect(initCommunityActivityPage).toHaveBeenCalledWith({
+      activityLogs: { data: { items: [] }, params: expect.any(Object) },
+    });
+    expect(screen.getByTestId('layout')).toBeInTheDocument();
+    expect(screen.getByTestId('logs')).toBeInTheDocument();
+    expect(global.__profileProps.initialParams.page).toBe(1);
+  });
+
+  it('exports metadata', () => {
+    expect(CommunityActivityPage.metadata).toEqual({ title: 'Activity', description: 'Network' });
+  });
+});
+
+describe('getServerSideProps', () => {
+  it('returns logs on success', async () => {
+    mockedGetCommonHeaders.mockReturnValue({ h: 1 });
+    mockedGetLogs.mockResolvedValue('data');
+    const result = await getServerSideProps({} as any, {} as any, '/a');
+    expect(mockedGetCommonHeaders).toHaveBeenCalled();
+    expect(mockedGetLogs).toHaveBeenCalled();
+    expect(result).toEqual({ props: { logsPage: 'data' } });
+  });
+
+  it('redirects on error', async () => {
+    mockedGetLogs.mockRejectedValue(new Error('err'));
+    const result = await getServerSideProps({} as any, {} as any, '/a');
+    expect(result).toEqual({ redirect: { permanent: false, destination: '/404' }, props: {} });
+  });
+});


### PR DESCRIPTION
## Summary
- add new Jest tests for network activity page
- test group card configs component
- cover layout context for my-stream
- add tests for decision point hook
- test common switch component
- cover artwork submission form hook
- add CIC rate header tests
- test NextGen admin components
- cover create wave drops metadata component

## Testing
- `npm run test`
- `npm run lint --silent`
- `npm run type-check`