### PR TITLE
Add comprehensive tests

### DIFF
--- a/__tests__/components/brain/notifications/NotificationsCauseFilter.test.tsx
+++ b/__tests__/components/brain/notifications/NotificationsCauseFilter.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NotificationsCauseFilter from '../../../../components/brain/notifications/NotificationsCauseFilter';
+import { AuthContext } from '../../../../components/auth/Auth';
+import { usePrefetchNotifications } from '../../../../hooks/useNotificationsQuery';
+
+jest.mock('../../../../hooks/useNotificationsQuery');
+const prefetch = jest.fn();
+(usePrefetchNotifications as jest.Mock).mockReturnValue(prefetch);
+
+const connectedProfile = { handle: 'tester' } as any;
+const Wrapper: React.FC<{children: React.ReactNode}> = ({ children }) => (
+  <AuthContext.Provider value={{ connectedProfile } as any}>{children}</AuthContext.Provider>
+);
+
+beforeAll(() => {
+  HTMLElement.prototype.scrollTo = jest.fn();
+});
+
+describe('NotificationsCauseFilter', () => {
+  it('calls setActiveFilter on click and prefetch on hover', async () => {
+    const setActive = jest.fn();
+    render(<NotificationsCauseFilter activeFilter={null} setActiveFilter={setActive} />, { wrapper: Wrapper });
+
+    const buttons = screen.getAllByRole('button');
+    await userEvent.hover(buttons[1]);
+    expect(prefetch).toHaveBeenCalledWith({ identity: 'tester', cause: expect.any(Array) });
+
+    await userEvent.click(buttons[2]);
+    expect(setActive).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/nextGen/admin/NextGenAdminAirdropTokens.test.tsx
+++ b/__tests__/components/nextGen/admin/NextGenAdminAirdropTokens.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NextGenAdminAirdropTokens from '../../../../components/nextGen/admin/NextGenAdminAirdropTokens';
+
+jest.mock('../../../../components/auth/SeizeConnectContext', () => ({ useSeizeConnectContext: () => ({ address: '0x1' }) }));
+
+jest.mock('../../../../components/nextGen/nextgen_helpers', () => ({
+  useGlobalAdmin: () => ({ data: true }),
+  useFunctionAdmin: () => ({ data: true }),
+  useCollectionIndex: () => ({ data: 1 }),
+  useParsedCollectionIndex: () => 1,
+  useCollectionAdmin: () => ({ data: [] }),
+  getCollectionIdsForAddress: () => ['1'],
+  useMinterContractWrite: () => ({ writeContract: jest.fn(), reset: jest.fn(), params: {} , isLoading:false,isSuccess:false,isError:false,data:null,error:null }),
+}));
+
+jest.mock('../../../../components/nextGen/admin/NextGenAdminShared', () => ({
+  NextGenCollectionIdFormGroup: ({ collection_id, onChange }: any) => (
+    <input data-testid="collection" value={collection_id} onChange={e=>onChange(e.target.value)} />
+  ),
+  NextGenAdminHeadingRow: () => <div data-testid="heading" />,
+}));
+
+jest.mock('../../../../components/nextGen/NextGenContractWriteStatus', () => () => <div />);
+jest.mock('../../../../components/nextGen/admin/NextGenAdmin', () => ({ printAdminErrors: (errs: string[]) => <ul>{errs.map(e=> <li key={e}>{e}</li>)}</ul> }));
+
+describe('NextGenAdminAirdropTokens', () => {
+  it('shows validation errors when submitting empty form', async () => {
+    render(<NextGenAdminAirdropTokens close={() => {}} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(screen.getByText('At least one recipient is required')).toBeInTheDocument();
+    expect(screen.getByText('At least one token data is required')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/nextGen/collections/collectionParts/mint/NextGenMint.test.tsx
+++ b/__tests__/components/nextGen/collections/collectionParts/mint/NextGenMint.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NextGenMint, { Spinner } from '../../../../../../components/nextGen/collections/collectionParts/mint/NextGenMint';
+
+jest.mock('react-bootstrap', () => ({
+  Container: (p: any) => <div data-testid="container" {...p} />,
+  Row: (p: any) => <div {...p} />,
+  Col: (p: any) => <div {...p} />,
+}));
+
+jest.mock('../../../../../../components/nextGen/collections/collectionParts/mint/NextGenMintWidget', () => () => <div data-testid="widget" />);
+jest.mock('../../../../../../components/nextGen/collections/collectionParts/mint/NextGenMintBurnWidget', () => () => <div data-testid="burn-widget" />);
+jest.mock('../../../../../../components/nextGen/collections/collectionParts/NextGenCollectionHeader', () => ({ NextGenCountdown: () => <div data-testid="count" />, NextGenMintCounts: () => <div />, NextGenPhases: () => <div /> }));
+jest.mock('../../../../../../components/nextGen/nextgen_helpers', () => ({
+  useSharedState: () => ({ mintingDetails: null, setMintingDetails: jest.fn() }),
+  useCollectionCostsHook: jest.fn(),
+  useMintSharedState: () => ({
+    available: 0,
+    setAvailable: jest.fn(),
+    delegators: [],
+    setDelegators: jest.fn(),
+    mintForAddress: '',
+    setMintForAddress: jest.fn(),
+    addressMintCounts: { airdrop:0, allowlist:0, public:0, total:0 },
+    setAddressMintCounts: jest.fn(),
+    fetchingMintCounts: false,
+    setFetchingMintCounts: jest.fn(),
+  }),
+  getStatusFromDates: () => 'PAUSED',
+  formatNameForUrl: (n: string) => n,
+}));
+
+jest.mock('../../../../../../services/6529api', () => ({ fetchUrl: jest.fn() }));
+jest.mock('../../../../../../components/auth/SeizeConnectContext', () => ({ useSeizeConnectContext: () => ({ address: '0x0', isConnected: true }) }));
+jest.mock('wagmi', () => ({
+  useReadContract: () => ({ data: null, refetch: jest.fn(), isFetching: false }),
+  useReadContracts: () => ({ data: [] })
+}));
+jest.mock('next/image', () => (props: any) => <img {...props} />);
+jest.mock('../../../../../../components/dotLoader/DotLoader', () => () => <div data-testid="loader" />);
+
+describe('NextGenMint', () => {
+  it('renders loader when allowlist not loaded', () => {
+    render(<NextGenMint collection={{ id:1, name:'C', artist:'A', artist_address:'0x', image:'', public_start: '', public_end: '', merkle_root: '' } as any} mint_price={1} burn_amount={1} />);
+    expect(screen.getByTestId('loader')).toBeInTheDocument();
+  });
+
+  it('Spinner renders output element', () => {
+    const {container}=render(<Spinner />);
+    expect(container.querySelector("output")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/notifications/NotificationsContext.test.tsx
+++ b/__tests__/components/notifications/NotificationsContext.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { NotificationsProvider, useNotificationsContext } from '../../../components/notifications/NotificationsContext';
+
+jest.mock('../../../hooks/useCapacitor', () => () => ({ isCapacitor: false, isIos: false }));
+jest.mock('next/router', () => ({ __esModule: true, useRouter: jest.fn(() => ({ push: jest.fn() })) }));
+jest.mock('../../../components/auth/Auth', () => ({ useAuth: () => ({ connectedProfile: null }) }));
+
+const wrapper: React.FC<{children: React.ReactNode}> = ({ children }) => (
+  <NotificationsProvider>{children}</NotificationsProvider>
+);
+
+describe('NotificationsContext', () => {
+  it('provides context functions', () => {
+    const { result } = renderHook(() => useNotificationsContext(), { wrapper });
+    expect(typeof result.current.removeAllDeliveredNotifications).toBe('function');
+  });
+
+  it('throws when used outside provider', () => {
+    const { result } = renderHook(() => {
+      try {
+        return useNotificationsContext();
+      } catch (e) {
+        return e;
+      }
+    });
+    expect(result.current).toBeInstanceOf(Error);
+  });
+});

--- a/__tests__/components/user/rep/modify-rep/UserPageRepModifyModal.new.test.tsx
+++ b/__tests__/components/user/rep/modify-rep/UserPageRepModifyModal.new.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Modal from '../../../../../components/user/rep/modify-rep/UserPageRepModifyModal';
+import { AuthContext } from '../../../../../components/auth/Auth';
+import { ReactQueryWrapperContext } from '../../../../../components/react-query-wrapper/ReactQueryWrapper';
+import { useQuery, useMutation } from '@tanstack/react-query';
+
+jest.mock('@tanstack/react-query');
+
+const useQueryMock = useQuery as jest.Mock;
+const useMutationMock = useMutation as jest.Mock;
+
+useQueryMock.mockReturnValue({});
+useMutationMock.mockReturnValue({ mutateAsync: jest.fn() });
+
+const defaultCtx = {
+  requestAuth: jest.fn().mockResolvedValue({ success: false }),
+  setToast: jest.fn(),
+  setTitle: jest.fn(),
+  connectedProfile: null,
+  activeProfileProxy: null,
+};
+
+describe('UserPageRepModifyModal', () => {
+  it('calls onClose when cancel clicked', async () => {
+    const onClose = jest.fn();
+    render(
+      <ReactQueryWrapperContext.Provider value={{ onProfileRepModify: jest.fn() }}>
+        <AuthContext.Provider value={defaultCtx as any}>
+          <Modal onClose={onClose} profile={{} as any} category="cat" />
+        </AuthContext.Provider>
+      </ReactQueryWrapperContext.Provider>
+    );
+
+    const cancel = screen.getByRole('button', { name: 'Cancel' });
+    await userEvent.click(cancel);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('disables save button initially', () => {
+    render(
+      <ReactQueryWrapperContext.Provider value={{ onProfileRepModify: jest.fn() }}>
+        <AuthContext.Provider value={defaultCtx as any}>
+          <Modal onClose={() => {}} profile={{} as any} category="cat" />
+        </AuthContext.Provider>
+      </ReactQueryWrapperContext.Provider>
+    );
+    const save = screen.getByRole('button', { name: 'Save' });
+    expect(save).toBeDisabled();
+  });
+});

--- a/__tests__/components/waves/WavePicture.test.tsx
+++ b/__tests__/components/waves/WavePicture.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import WavePicture from '../../../components/waves/WavePicture';
+
+describe('WavePicture', () => {
+  it('renders picture image when provided', () => {
+    render(<WavePicture name="wave" picture="pic.jpg" contributors={[]} />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('src', 'pic.jpg');
+    expect(img).toHaveAttribute('alt', 'wave');
+  });
+
+  it('renders gradient when no picture and no contributors', () => {
+    const { container } = render(<WavePicture name="wave" picture={null} contributors={[]} />);
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it('renders contributor images sliced', () => {
+    const contributors = [
+      { pfp: 'a.png' },
+      { pfp: 'b.png' },
+      { pfp: 'c.png' },
+    ];
+    render(<WavePicture name="wave" picture={null} contributors={contributors} />);
+    expect(screen.getAllByRole('img').length).toBe(3);
+  });
+});

--- a/__tests__/components/waves/memes/file-upload/hooks/useDragAndDrop.test.ts
+++ b/__tests__/components/waves/memes/file-upload/hooks/useDragAndDrop.test.ts
@@ -1,0 +1,57 @@
+import { renderHook, act } from '@testing-library/react';
+import useDragAndDrop from '../../../../../../components/waves/memes/file-upload/hooks/useDragAndDrop';
+
+function setup(enabled = true) {
+  const onFileDrop = jest.fn();
+  const setVisualState = jest.fn();
+  const { result } = renderHook(() =>
+    useDragAndDrop({ enabled, onFileDrop, setVisualState })
+  );
+  return { result, onFileDrop, setVisualState };
+}
+
+describe('useDragAndDrop', () => {
+  it('handles drag events when enabled', () => {
+  const { result, setVisualState } = setup(true);
+    result.current.dropAreaRef.current = document.createElement('div');
+    act(() => {
+      result.current.handleDragEnter({ preventDefault: jest.fn(), stopPropagation: jest.fn() } as any);
+    });
+    expect(setVisualState).toHaveBeenCalledWith('dragging');
+
+    act(() => {
+      result.current.handleDragOver({ preventDefault: jest.fn(), stopPropagation: jest.fn() } as any);
+    });
+    expect(setVisualState).toHaveBeenCalledTimes(2);
+
+    const related = document.createElement('div');
+    act(() => {
+      result.current.handleDragLeave({ preventDefault: jest.fn(), stopPropagation: jest.fn(), relatedTarget: null } as any);
+    });
+    expect(setVisualState).toHaveBeenCalledWith('idle');
+  });
+
+  it('drops file and resets visual state', () => {
+    const file = new File(['a'], 'a.txt');
+    const { result, onFileDrop, setVisualState } = setup(true);
+    act(() => {
+      result.current.handleDrop({
+        preventDefault: jest.fn(),
+        stopPropagation: jest.fn(),
+        dataTransfer: { files: [file] }
+      } as any);
+    });
+    expect(onFileDrop).toHaveBeenCalledWith(file);
+    expect(setVisualState).not.toHaveBeenCalledWith('idle');
+  });
+
+  it('ignores events when disabled', () => {
+    const { result, setVisualState, onFileDrop } = setup(false);
+    act(() => {
+      result.current.handleDragEnter({ preventDefault: jest.fn(), stopPropagation: jest.fn() } as any);
+      result.current.handleDrop({ preventDefault: jest.fn(), stopPropagation: jest.fn(), dataTransfer: { files: [new File([], 'x')] } } as any);
+    });
+    expect(setVisualState).not.toHaveBeenCalled();
+    expect(onFileDrop).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/waves/memes/file-upload/reducers/fileUploadReducer.test.ts
+++ b/__tests__/components/waves/memes/file-upload/reducers/fileUploadReducer.test.ts
@@ -1,0 +1,29 @@
+import { fileUploaderReducer, initialFileUploaderState } from '../../../../../../components/waves/memes/file-upload/reducers/fileUploadReducer';
+
+const sampleFile = new File(['a'], 'a.txt', { type: 'text/plain' });
+
+beforeAll(() => {
+  (global as any).URL.revokeObjectURL = jest.fn();
+  (global as any).clearTimeout = jest.fn();
+});
+
+describe('fileUploaderReducer', () => {
+  it('sets visual state', () => {
+    const state = fileUploaderReducer(initialFileUploaderState, { type: 'SET_VISUAL_STATE', payload: 'dragging' });
+    expect(state.visualState).toBe('dragging');
+  });
+
+  it('handles processing success', () => {
+    const action = { type: 'PROCESSING_SUCCESS', payload: { objectUrl: 'url', file: sampleFile } } as any;
+    const state = fileUploaderReducer(initialFileUploaderState, action);
+    expect(state.objectUrl).toBe('url');
+    expect(state.currentFile).toBe(sampleFile);
+    expect(state.visualState).toBe('idle');
+  });
+
+  it('resets state', () => {
+    const modified = { ...initialFileUploaderState, visualState: 'dragging', objectUrl: 'url', processingTimeout: 1 };
+    const state = fileUploaderReducer(modified, { type: 'RESET_STATE' } as any);
+    expect(state).toEqual(initialFileUploaderState);
+  });
+});

--- a/__tests__/components/waves/memes/submission/steps/ArtworkStep.test.tsx
+++ b/__tests__/components/waves/memes/submission/steps/ArtworkStep.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ArtworkStep from '../../../../../../components/waves/memes/submission/steps/ArtworkStep';
+import { TraitsData } from '../../../../../../components/waves/memes/submission/types/TraitsData';
+
+jest.mock('../../../../../../components/waves/memes/MemesArtSubmissionFile', () => () => <div data-testid="file" />);
+jest.mock('../../../../../../components/waves/memes/submission/details/ArtworkDetails', () => (props: any) => (
+  <div data-testid="details" onClick={() => props.onTitleChange('t')} />
+));
+jest.mock('../../../../../../components/waves/memes/MemesArtSubmissionTraits', () => () => <div data-testid="traits" />);
+jest.mock('../../../../../../components/waves/memes/submission/ui/SubmissionProgress', () => () => <div data-testid="progress" />);
+jest.mock('../../../../../../components/utils/button/PrimaryButton', () => (props: any) => (
+  <button data-testid="submit" disabled={props.disabled} title={props.title} onClick={props.onClicked}>{props.children}</button>
+));
+jest.mock('../../../../../../components/waves/memes/submission/validation', () => ({
+  useTraitsValidation: () => ({
+    errors: {},
+    validateAll: () => ({ isValid: true }),
+    focusFirstInvalidField: jest.fn(),
+    markFieldTouched: jest.fn(),
+    isValid: true,
+    submitAttempted: false,
+  })
+}));
+
+function createTraits(): TraitsData {
+  return {
+    title: '',
+    description: '',
+    artist: 'a',
+    seizeArtistProfile: '',
+    palette: 'p',
+    style: '',
+    jewel: '',
+    superpower: '',
+    dharma: '',
+    gear: '',
+    clothing: '',
+    element: '',
+    mystery: '',
+    secrets: '',
+    weapon: '',
+    home: '',
+    parent: '',
+    sibling: '',
+    food: '',
+    drink: '',
+    bonus: '',
+    boost: '',
+    punk6529: false,
+    gradient: false,
+    movement: false,
+    dynamic: false,
+    interactive: false,
+    collab: false,
+    om: false,
+    threeD: false,
+    pepe: false,
+    gm: false,
+    summer: false,
+    tulip: false,
+    memeName: 'Use a Hardware Wallet',
+    pointsPower: 1,
+    pointsWisdom: 2,
+    pointsLoki: 3,
+    pointsSpeed: 4,
+  };
+}
+
+describe('ArtworkStep', () => {
+  it('shows upload tooltip when artwork missing', () => {
+    render(
+      <ArtworkStep
+        traits={createTraits()}
+        artworkUploaded={false}
+        artworkUrl=""
+        setArtworkUploaded={() => {}}
+        handleFileSelect={() => {}}
+        onSubmit={() => {}}
+        updateTraitField={() => {}}
+        setTraits={() => {}}
+      />
+    );
+    expect(screen.getByTestId('submit')).toBeDisabled();
+    expect(screen.getByTestId('submit').getAttribute('title')).toMatch('Please upload artwork');
+  });
+
+  it('enables submit when complete', () => {
+    const traits = createTraits();
+    traits.title = 't';
+    traits.description = 'd';
+    render(
+      <ArtworkStep
+        traits={traits}
+        artworkUploaded={true}
+        artworkUrl="url"
+        setArtworkUploaded={() => {}}
+        handleFileSelect={() => {}}
+        onSubmit={() => {}}
+        updateTraitField={() => {}}
+        setTraits={() => {}}
+      />
+    );
+    expect(screen.getByTestId('submit')).not.toBeDisabled();
+  });
+});

--- a/__tests__/hooks/useAppWalletPasswordModal.new.test.tsx
+++ b/__tests__/hooks/useAppWalletPasswordModal.new.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { useAppWalletPasswordModal } from '../..//hooks/useAppWalletPasswordModal';
+
+const MockUnlockAppWalletModal = jest.fn(({ show, onHide, onUnlock }) => (
+  show ? (
+    <div>
+      <button onClick={() => onUnlock('pass')} data-testid="unlock" />
+      <button onClick={onHide} data-testid="cancel" />
+    </div>
+  ) : null
+));
+
+jest.mock('../../components/app-wallets/AppWalletModal', () => ({
+  UnlockAppWalletModal: MockUnlockAppWalletModal,
+}));
+
+describe('useAppWalletPasswordModal hook', () => {
+  it('resolves password through modal', async () => {
+    const { result } = renderHook(() => useAppWalletPasswordModal());
+    let promise: Promise<string>;
+    act(() => {
+      promise = result.current.requestPassword('0x1', 'hash');
+    });
+    act(() => {
+      result.current.modal.props.onUnlock('secret');
+    });
+    await expect(promise!).resolves.toBe('secret');
+  });
+
+  it('rejects when cancelled', async () => {
+    const { result } = renderHook(() => useAppWalletPasswordModal());
+    let promise: Promise<string>;
+    act(() => {
+      promise = result.current.requestPassword('0x1', 'hash');
+    });
+    act(() => {
+      result.current.modal.props.onHide();
+    });
+    await expect(promise!).rejects.toThrow('Password entry canceled.');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for drag and drop hook
- test wallet password modal hook
- cover Artwork submission step logic
- add notifications filter and context tests
- test nextgen admin airdrop tokens page
- add reducer tests and wave picture tests
- test nextgen mint component
- test reputation modify modal

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`