### PR TITLE
Add test coverage for utilities and hooks

### DIFF
--- a/__tests__/components/distribution-plan-tool/review-distribution-plan/table/ReviewDistributionPlanTableHeader.test.tsx
+++ b/__tests__/components/distribution-plan-tool/review-distribution-plan/table/ReviewDistributionPlanTableHeader.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ReviewDistributionPlanTableHeader from '../../../../../components/distribution-plan-tool/review-distribution-plan/table/ReviewDistributionPlanTableHeader';
+import { DistributionPlanToolContext } from '../../../../../components/distribution-plan-tool/DistributionPlanToolContext';
+import { distributionPlanApiFetch } from '../../../../../services/distribution-plan-api';
+
+jest.mock('../../../../../services/distribution-plan-api', () => ({ distributionPlanApiFetch: jest.fn(async () => ({ success: true, data: [{ wallet: '0x', amount: 1, phaseId: 'p1', phaseComponentId: 'c1' }] })) }));
+
+describe('ReviewDistributionPlanTableHeader', () => {
+  const rows = [
+    { phase: { id: 'p1', name: 'Phase' }, components: [{ id: 'c1', name: 'Comp' }] },
+  ];
+  const distributionPlan = { id: '123' } as any;
+
+  it('fetches results on json button click', async () => {
+    const createElement = jest.spyOn(document, 'createElement').mockReturnValue({ click: jest.fn() } as any);
+
+    render(
+      <DistributionPlanToolContext.Provider value={{ distributionPlan, setToasts: jest.fn() } as any}>
+        <table><tbody><ReviewDistributionPlanTableHeader rows={rows} /></tbody></table>
+      </DistributionPlanToolContext.Provider>
+    );
+
+    await userEvent.click(screen.getAllByRole('button')[0]);
+    await waitFor(() => expect(distributionPlanApiFetch).toHaveBeenCalled());
+    expect(createElement).toHaveBeenCalled();
+    createElement.mockRestore();
+  });
+});

--- a/__tests__/components/drops/create/lexical/plugins/emoji/EmojiPlugin.test.tsx
+++ b/__tests__/components/drops/create/lexical/plugins/emoji/EmojiPlugin.test.tsx
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react';
+import EmojiPlugin from '../../../../../../../components/drops/create/lexical/plugins/emoji/EmojiPlugin';
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
+
+jest.mock('@lexical/react/LexicalComposerContext', () => ({ useLexicalComposerContext: jest.fn() }));
+jest.mock('../../../../../../../components/drops/create/lexical/nodes/EmojiNode', () => class {});
+
+jest.mock('lexical', () => ({
+  $getRoot: jest.fn(() => ({ getAllTextNodes: () => [] })),
+  $getSelection: jest.fn(() => null),
+  $isRangeSelection: jest.fn(() => false),
+  $createRangeSelection: jest.fn(() => ({ anchor: { set: jest.fn() }, focus: { set: jest.fn() } })),
+  $setSelection: jest.fn(),
+  TextNode: class {},
+}));
+
+describe('EmojiPlugin', () => {
+  it('registers listener and triggers update', () => {
+    const update = jest.fn((fn) => fn());
+    const register = jest.fn();
+    (useLexicalComposerContext as jest.Mock).mockReturnValue([{ update, registerTextContentListener: register }]);
+
+    render(<EmojiPlugin />);
+    expect(update).toHaveBeenCalled();
+
+    const cb = register.mock.calls[0][0];
+    cb(':smile:');
+    expect(update).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/components/groups/select/item/GroupItemWrapper.test.tsx
+++ b/__tests__/components/groups/select/item/GroupItemWrapper.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import GroupItemWrapper from '../../../../../components/groups/select/item/GroupItemWrapper';
+import { getRandomColorWithSeed } from '../../../../../helpers/Helpers';
+
+jest.mock('../../../../../helpers/Helpers', () => ({
+  getRandomColorWithSeed: jest.fn(() => '#123456'),
+}));
+
+describe('GroupItemWrapper', () => {
+  const group: any = {
+    id: 'g1',
+    created_by: { handle: 'john', banner1_color: '#111', banner2_color: '#222' },
+  };
+
+  it('invokes onActiveGroupId when inactive', async () => {
+    const onActive = jest.fn();
+    render(
+      <GroupItemWrapper group={group} isActive={false} deactivateHover={false} onActiveGroupId={onActive}>
+        <span>child</span>
+      </GroupItemWrapper>
+    );
+    await userEvent.click(screen.getByText('child'));
+    expect(onActive).toHaveBeenCalledWith('g1');
+  });
+
+  it('does not invoke onActiveGroupId when active', async () => {
+    const onActive = jest.fn();
+    render(
+      <GroupItemWrapper group={group} isActive={true} deactivateHover={false} onActiveGroupId={onActive}>
+        <span>child</span>
+      </GroupItemWrapper>
+    );
+    await userEvent.click(screen.getByText('child'));
+    expect(onActive).not.toHaveBeenCalled();
+  });
+
+  it('uses banner colors for gradient', () => {
+    render(
+      <GroupItemWrapper group={group} isActive={false} deactivateHover={false}>
+        <span>child</span>
+      </GroupItemWrapper>
+    );
+    const div = screen.getByText('child').closest('div')!.previousSibling as HTMLElement;
+    expect(div).toHaveStyle(`background: linear-gradient(45deg, #111 0%, #222 100%)`);
+  });
+});

--- a/__tests__/components/mapping-tools/ConsolidationMappingTool.test.tsx
+++ b/__tests__/components/mapping-tools/ConsolidationMappingTool.test.tsx
@@ -1,158 +1,38 @@
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import ConsolidationMappingTool from '../../../components/mapping-tools/ConsolidationMappingTool';
+import { fetchAllPages } from '../../../services/6529api';
 
-jest.mock('react-bootstrap', () => ({
-  Container: (props: any) => <div {...props} />,
-  Row: (props: any) => <div {...props} />,
-  Col: (props: any) => <div {...props} />,
-  Form: { Control: (props: any) => <input {...props} /> },
-  Button: (props: any) => <button {...props} />,
-}));
+jest.mock('../../../services/6529api', () => ({ fetchAllPages: jest.fn(() => Promise.resolve([])) }));
 
-jest.mock('../../../services/6529api');
-
-// Mock FileReader
-const mockFileReader = {
-  onload: null as any,
-  result: 'address,token_id,balance,contract,name\ntest-address,1,100,test-contract,test-name',
-  readAsText: jest.fn(),
-};
-
-Object.defineProperty(window, 'FileReader', {
-  writable: true,
-  value: jest.fn(() => mockFileReader),
+jest.mock('csv-parser', () => () => {
+  const handlers: Record<string, any> = {};
+  const obj = {
+    on: (event: string, cb: any) => { handlers[event] = cb; return obj; },
+    write: jest.fn(),
+    end: () => handlers['end'] && handlers['end'](),
+  };
+  return obj;
 });
 
-// Mock URL.createObjectURL and document methods for CSV download
-Object.defineProperty(window.URL, 'createObjectURL', {
-  writable: true,
-  value: jest.fn(() => 'mock-url'),
-});
-
-Object.defineProperty(document, 'createElement', {
-  writable: true,
-  value: jest.fn((tagName) => {
-    const element = {
-      setAttribute: jest.fn(),
-      click: jest.fn(),
-    };
-    return element;
-  }),
-});
-
-Object.defineProperty(document.body, 'appendChild', {
-  writable: true,
-  value: jest.fn(),
-});
-
-Object.defineProperty(document.body, 'removeChild', {
-  writable: true,
-  value: jest.fn(),
-});
+class MockFileReader {
+  result: any;
+  onload: ((ev: any) => void) | null = null;
+  readAsText() { this.result = ''; this.onload && this.onload({}); }
+}
+Object.defineProperty(window, 'FileReader', { writable: true, value: MockFileReader });
 
 describe('ConsolidationMappingTool', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+  it('shows selected file and triggers processing', async () => {
+    render(<ConsolidationMappingTool />);
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['a'], 'test.csv', { type: 'text/csv' });
+    await userEvent.upload(input, file);
+    expect(screen.getByText('test.csv')).toBeInTheDocument();
 
-  it.skip('renders upload area with correct initial state', () => {
-    const { getByText } = render(<ConsolidationMappingTool />);
-    
-    expect(getByText(/Upload File/)).toBeInTheDocument();
-    expect(getByText(/Drag and drop your file here/)).toBeInTheDocument();
-    expect(getByText('Submit')).toBeInTheDocument();
-  });
-
-  it.skip('toggles active class on drag events', () => {
-    const { getByText } = render(<ConsolidationMappingTool />);
-    const dropzone = getByText(/Drag and drop your file here/).parentElement as HTMLElement;
-
-    expect(dropzone.className).not.toMatch(/uploadAreaActive/);
-    
-    fireEvent.dragEnter(dropzone);
-    expect(dropzone.className).toMatch(/uploadAreaActive/);
-    
-    fireEvent.dragLeave(dropzone);
-    expect(dropzone.className).not.toMatch(/uploadAreaActive/);
-  });
-
-  it.skip('shows file name when file is dropped', () => {
-    const { getByText } = render(<ConsolidationMappingTool />);
-    const dropzone = getByText(/Drag and drop your file here/).parentElement as HTMLElement;
-
-    const file = new File(['test content'], 'test.csv', { type: 'text/csv' });
-    fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
-
-    expect(getByText('test.csv')).toBeInTheDocument();
-  });
-
-  it.skip('shows file name when file is selected via input', () => {
-    const { getByDisplayValue } = render(<ConsolidationMappingTool />);
-    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
-
-    const file = new File(['test content'], 'selected.csv', { type: 'text/csv' });
-    Object.defineProperty(fileInput, 'files', {
-      value: [file],
-      writable: false,
-    });
-
-    fireEvent.change(fileInput);
-    expect(document.body.textContent).toContain('selected.csv');
-  });
-
-  it.skip('disables submit button when no file is selected', () => {
-    const { getByText } = render(<ConsolidationMappingTool />);
-    const submitButton = getByText('Submit');
-
-    expect(submitButton.className).toMatch(/submitBtnDisabled/);
-  });
-
-  it.skip('enables submit button when file is selected', () => {
-    const { getByText } = render(<ConsolidationMappingTool />);
-    const dropzone = getByText(/Drag and drop your file here/).parentElement as HTMLElement;
-    const submitButton = getByText('Submit');
-
-    const file = new File(['test content'], 'test.csv', { type: 'text/csv' });
-    fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
-
-    expect(submitButton.className).not.toMatch(/submitBtnDisabled/);
-  });
-
-  it.skip('shows processing state when submit is clicked', () => {
-    const { getByText } = render(<ConsolidationMappingTool />);
-    const dropzone = getByText(/Drag and drop your file here/).parentElement as HTMLElement;
-
-    const file = new File(['test content'], 'test.csv', { type: 'text/csv' });
-    fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
-
-    const submitButton = getByText('Submit');
-    fireEvent.click(submitButton);
-
-    expect(getByText('Processing')).toBeInTheDocument();
-    expect(submitButton.className).toMatch(/submitBtnDisabled/);
-  });
-
-  it.skip('prevents default on drag events', () => {
-    const { getByText } = render(<ConsolidationMappingTool />);
-    const dropzone = getByText(/Drag and drop your file here/).parentElement as HTMLElement;
-
-    const dragEvent = { preventDefault: jest.fn(), stopPropagation: jest.fn(), type: 'dragenter' };
-    fireEvent.dragEnter(dropzone, dragEvent);
-
-    expect(dragEvent.preventDefault).toHaveBeenCalled();
-    expect(dragEvent.stopPropagation).toHaveBeenCalled();
-  });
-
-  it.skip('calls handleUpload when dropzone is clicked', () => {
-    const { getByText } = render(<ConsolidationMappingTool />);
-    const dropzone = getByText(/Drag and drop your file here/).parentElement as HTMLElement;
-
-    // Mock the input ref click
-    const mockClick = jest.fn();
-    const fileInput = document.querySelector('input[type="file"]') as any;
-    fileInput.click = mockClick;
-
-    fireEvent.click(dropzone);
-    expect(mockClick).toHaveBeenCalled();
+    const button = screen.getByRole('button', { name: /submit/i });
+    await userEvent.click(button);
+    expect(button).toHaveTextContent(/processing/i);
+    await waitFor(() => expect(fetchAllPages).toHaveBeenCalled());
   });
 });

--- a/__tests__/components/react-query-wrapper/utils/increaseWavesOverviewDropsCount.test.ts
+++ b/__tests__/components/react-query-wrapper/utils/increaseWavesOverviewDropsCount.test.ts
@@ -1,0 +1,30 @@
+import { QueryClient } from '@tanstack/react-query';
+import { increaseWavesOverviewDropsCount } from '../../../../components/react-query-wrapper/utils/increaseWavesOverviewDropsCount';
+import { ApiWavesOverviewType } from '../../../../generated/models/ApiWavesOverviewType';
+import { QueryKey } from '../../../../components/react-query-wrapper/ReactQueryWrapper';
+
+function createWave(id: string) {
+  return { id, metrics: { drops_count: 0, your_drops_count: 0 } } as any;
+}
+
+describe('increaseWavesOverviewDropsCount', () => {
+  it('increments drops count for all overview types', async () => {
+    const client = new QueryClient();
+    const wave = createWave('w1');
+    const data = { pages: [[wave]] };
+
+    for (const type of Object.values(ApiWavesOverviewType)) {
+      const key = [QueryKey.WAVES_OVERVIEW, { limit: 20, type, only_waves_followed_by_authenticated_user: true }];
+      client.setQueryData(key, data);
+    }
+
+    await increaseWavesOverviewDropsCount(client, 'w1');
+
+    for (const type of Object.values(ApiWavesOverviewType)) {
+      const key = [QueryKey.WAVES_OVERVIEW, { limit: 20, type, only_waves_followed_by_authenticated_user: true }];
+      const result: any = client.getQueryData(key);
+      expect(result?.pages?.[0][0].metrics.drops_count).toBe(1);
+      expect(result?.pages?.[0][0].metrics.your_drops_count).toBe(1);
+    }
+  });
+});

--- a/__tests__/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilterItem.test.tsx
+++ b/__tests__/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilterItem.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserPageStatsActivityWalletFilterItem from '../../../../../../../components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilterItem';
+
+enum FilterType { ALL = 'ALL', SENT = 'SENT' }
+
+describe('UserPageStatsActivityWalletFilterItem', () => {
+  it('calls onFilter when clicked', async () => {
+    const onFilter = jest.fn();
+    render(
+      <UserPageStatsActivityWalletFilterItem
+        filter={FilterType.ALL as any}
+        title="All"
+        activeFilter={FilterType.SENT as any}
+        onFilter={onFilter}
+      />
+    );
+    await userEvent.click(screen.getByText('All'));
+    expect(onFilter).toHaveBeenCalledWith(FilterType.ALL);
+  });
+
+  it('shows check mark when active', () => {
+    const { container } = render(
+      <UserPageStatsActivityWalletFilterItem
+        filter={FilterType.ALL as any}
+        title="All"
+        activeFilter={FilterType.ALL as any}
+        onFilter={jest.fn()}
+      />
+    );
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+});

--- a/__tests__/components/utils/table/paginator/CommonTablePagination.test.tsx
+++ b/__tests__/components/utils/table/paginator/CommonTablePagination.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CommonTablePagination from '../../../../../components/utils/table/paginator/CommonTablePagination';
+
+describe('CommonTablePagination', () => {
+  it('handles previous and next clicks', async () => {
+    const setPage = jest.fn();
+    render(
+      <CommonTablePagination
+        small={false}
+        currentPage={2}
+        setCurrentPage={setPage}
+        totalPages={3}
+        haveNextPage={true}
+      />
+    );
+    await userEvent.click(screen.getByText('Previous'));
+    expect(setPage).toHaveBeenCalledWith(1);
+    await userEvent.click(screen.getByText('Next'));
+    expect(setPage).toHaveBeenCalledWith(3);
+    expect(screen.getByText('Page 2 of 3')).toBeInTheDocument();
+  });
+
+  it('disables buttons when loading', () => {
+    const setPage = jest.fn();
+    render(
+      <CommonTablePagination
+        small={false}
+        currentPage={1}
+        setCurrentPage={setPage}
+        totalPages={2}
+        haveNextPage={true}
+        loading
+      />
+    );
+    expect(screen.getByText('Next')).toBeDisabled();
+  });
+});

--- a/__tests__/components/waves/CreateDropContent.test.tsx
+++ b/__tests__/components/waves/CreateDropContent.test.tsx
@@ -1,0 +1,7 @@
+import CreateDropContent from '../../../components/waves/CreateDropContent';
+
+describe('CreateDropContent', () => {
+  it('should be defined', () => {
+    expect(CreateDropContent).toBeTruthy();
+  });
+});

--- a/__tests__/contexts/wave/hooks/useWaveAbortController.test.ts
+++ b/__tests__/contexts/wave/hooks/useWaveAbortController.test.ts
@@ -1,0 +1,36 @@
+import { renderHook, act } from '@testing-library/react';
+import { useWaveAbortController } from '../../../../contexts/wave/hooks/useWaveAbortController';
+
+describe('useWaveAbortController', () => {
+  it('creates, cancels and cleans up controllers', () => {
+    const { result, unmount } = renderHook(() => useWaveAbortController());
+
+    const controller = result.current.createController('w1');
+    const abortSpy = jest.spyOn(controller, 'abort');
+
+    act(() => {
+      result.current.cancelFetch('w1');
+    });
+    expect(abortSpy).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.cleanupController('w1', controller);
+    });
+
+    act(() => {
+      result.current.cancelFetch('w1');
+    });
+    expect(abortSpy).toHaveBeenCalledTimes(1);
+
+    const controller2 = result.current.createController('w2');
+    const abortSpy2 = jest.spyOn(controller2, 'abort');
+    act(() => {
+      result.current.cancelAllFetches();
+    });
+    expect(abortSpy2).toHaveBeenCalled();
+
+    const abortSpy3 = jest.spyOn(controller2, 'abort');
+    unmount();
+    expect(abortSpy3).toHaveBeenCalled();
+  });
+});

--- a/__tests__/hooks/useWaveDropsLeaderboard.test.ts
+++ b/__tests__/hooks/useWaveDropsLeaderboard.test.ts
@@ -1,0 +1,55 @@
+import { renderHook, act } from '@testing-library/react';
+import { useWaveDropsLeaderboard } from '../../hooks/useWaveDropsLeaderboard';
+import { useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useDebounce } from 'react-use';
+
+jest.mock('@tanstack/react-query', () => ({
+  useInfiniteQuery: jest.fn(),
+  useQuery: jest.fn(),
+  useQueryClient: jest.fn(),
+  keepPreviousData: {},
+}));
+jest.mock('react-use', () => ({ useDebounce: jest.fn() }));
+jest.mock('../../services/api/common-api', () => ({ commonApiFetch: jest.fn() }));
+jest.mock('../../hooks/useCapacitor', () => () => ({ isCapacitor: false }));
+jest.mock('../../helpers/waves/wave-drops.helpers', () => ({
+  generateUniqueKeys: jest.fn((a) => a),
+  mapToExtendedDrops: jest.fn((pages) => pages.flatMap((p: any) => p.drops)),
+}));
+
+const queryClientMock = { prefetchInfiniteQuery: jest.fn(), removeQueries: jest.fn() };
+(useQueryClient as jest.Mock).mockReturnValue(queryClientMock);
+(useInfiniteQuery as jest.Mock).mockReturnValue({
+  data: { pages: [] },
+  fetchNextPage: jest.fn(),
+  hasNextPage: true,
+  isFetching: false,
+  isFetchingNextPage: false,
+  refetch: jest.fn(),
+});
+(useQuery as jest.Mock).mockReturnValue({});
+
+describe('useWaveDropsLeaderboard', () => {
+  it('calls fetchNextPage via manualFetch when more pages', async () => {
+    const fetchNext = jest.fn();
+    (useInfiniteQuery as jest.Mock).mockReturnValue({
+      data: { pages: [] },
+      fetchNextPage: fetchNext,
+      hasNextPage: true,
+      isFetching: false,
+      isFetchingNextPage: false,
+      refetch: jest.fn(),
+    });
+    const { result } = renderHook(() => useWaveDropsLeaderboard({ waveId: '1', connectedProfileHandle: 'h' }));
+    await act(async () => {
+      await result.current.manualFetch();
+    });
+    expect(fetchNext).toHaveBeenCalled();
+  });
+
+  it('removes queries on unmount', () => {
+    const { unmount } = renderHook(() => useWaveDropsLeaderboard({ waveId: '2', connectedProfileHandle: 'h' }));
+    unmount();
+    expect(queryClientMock.removeQueries).toHaveBeenCalledWith({ queryKey: ['DROPS', { waveId: '2' }] });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for react-query waves count updater
- add tests for abort controller hook
- add tests for consolidation mapping tool
- add tests for pagination component
- add tests for group item wrapper
- add emoji plugin tests
- add distribution plan table header tests
- add wallet filter item tests
- add simple CreateDropContent export test
- add tests for wave drops leaderboard hook

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`