### PR TITLE
Add tests for various components and hooks

### DIFF
--- a/__tests__/components/distribution-plan-tool/build-phases/build-phase/form/component-config/SnapshotSelectTopHolders.test.tsx
+++ b/__tests__/components/distribution-plan-tool/build-phases/build-phase/form/component-config/SnapshotSelectTopHolders.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SnapshotSelectTopHolders from '../../../../../../../components/distribution-plan-tool/build-phases/build-phase/form/component-config/SnapshotSelectTopHolders';
+import { DistributionPlanToolContext } from '../../../../../../../components/distribution-plan-tool/DistributionPlanToolContext';
+import { AllowlistOperationCode, Pool } from '../../../../../../../components/allowlist-tool/allowlist-tool.types';
+
+const operations = [
+  {
+    id: '1',
+    createdAt: 0,
+    order: 0,
+    allowlistId: 'a',
+    hasRan: false,
+    code: AllowlistOperationCode.CREATE_TOKEN_POOL,
+    params: {
+      id: 'tp1',
+      contract: '0x33fd426905f149f8376e227d0c9d3340aad17af1',
+      blockNo: 99
+    }
+  }
+] as any;
+
+const config = {
+  snapshotId: 'tp1',
+  snapshotType: Pool.TOKEN_POOL,
+  snapshotSchema: 'erc1155',
+  groupSnapshotId: null,
+  excludeComponentWinners: [],
+  excludeSnapshots: [],
+  topHoldersFilter: null,
+  tokenIds: null,
+  uniqueWalletsCount: 10
+} as any;
+
+const Wrapper: React.FC<{children: React.ReactNode}> = ({ children }) => (
+  <DistributionPlanToolContext.Provider value={{ operations } as any}>
+    {children}
+  </DistributionPlanToolContext.Provider>
+);
+
+describe('SnapshotSelectTopHolders', () => {
+  it('shows tdh and unique token options when conditions met', () => {
+    render(
+      <SnapshotSelectTopHolders
+        onSelectTopHoldersSkip={jest.fn()}
+        onSelectTopHoldersFilter={jest.fn()}
+        config={config}
+        title="title"
+        onClose={jest.fn()}
+      />,
+      { wrapper: Wrapper }
+    );
+    expect(screen.getByText('TDH')).toBeInTheDocument();
+    expect(screen.getByText('Unique tokens count')).toBeInTheDocument();
+  });
+
+  it('shows only total tokens option otherwise', () => {
+    const simpleConfig = { ...config, snapshotId: null, snapshotSchema: null };
+    render(
+      <SnapshotSelectTopHolders
+        onSelectTopHoldersSkip={jest.fn()}
+        onSelectTopHoldersFilter={jest.fn()}
+        config={simpleConfig as any}
+        title="title"
+        onClose={jest.fn()}
+      />,
+      { wrapper: ({ children }) => (
+        <DistributionPlanToolContext.Provider value={{ operations: [] } as any}>
+          {children}
+        </DistributionPlanToolContext.Provider>
+      ) }
+    );
+    expect(screen.queryByText('TDH')).toBeNull();
+    expect(screen.queryByText('Unique tokens count')).toBeNull();
+    expect(screen.getByText('Total tokens count')).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/distribution-plan-tool/create-snapshots/table/CreateSnapshotTableRowDownload.test.tsx
+++ b/__tests__/components/distribution-plan-tool/create-snapshots/table/CreateSnapshotTableRowDownload.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import CreateSnapshotTableRowDownload from '../../../../../components/distribution-plan-tool/create-snapshots/table/CreateSnapshotTableRowDownload';
+import { DistributionPlanToolContext } from '../../../../../components/distribution-plan-tool/DistributionPlanToolContext';
+import { distributionPlanApiFetch } from '../../../../../services/distribution-plan-api';
+
+jest.mock('../../../../../services/distribution-plan-api');
+
+const distPlan = { id: '1' } as any;
+
+const Wrapper: React.FC<{children: React.ReactNode}> = ({ children }) => (
+  <DistributionPlanToolContext.Provider value={{ distributionPlan: distPlan, setToasts: jest.fn() } as any}>
+    {children}
+  </DistributionPlanToolContext.Provider>
+);
+
+describe('CreateSnapshotTableRowDownload', () => {
+  beforeEach(() => {
+    (distributionPlanApiFetch as jest.Mock).mockResolvedValue({ success: true, data: [{ a: '1' }] });
+    jest.spyOn(document, 'createElement');
+    (global.URL as any).createObjectURL = jest.fn();
+  });
+
+  it('downloads json when button clicked', async () => {
+    const { container } = render(<CreateSnapshotTableRowDownload tokenPoolId="tp1" />, { wrapper: Wrapper });
+    const jsonBtn = container.querySelector('button');
+    fireEvent.click(jsonBtn!);
+    expect(distributionPlanApiFetch).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/drops/view/item/content/media/DropListItemContentMediaVideo.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/DropListItemContentMediaVideo.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import DropListItemContentMediaVideo from '../../../../../../components/drops/view/item/content/media/DropListItemContentMediaVideo';
+
+jest.mock('../../../../../../hooks/useDeviceInfo', () => () => ({ isApp: false }));
+jest.mock('../../../../../../hooks/useInView', () => ({ useInView: jest.fn() }));
+jest.mock('../../../../../../hooks/useOptimizedVideo', () => ({ useOptimizedVideo: jest.fn() }));
+
+const mockUseInView = require('../../../../../../hooks/useInView').useInView as jest.Mock;
+const mockUseOptimizedVideo = require('../../../../../../hooks/useOptimizedVideo').useOptimizedVideo as jest.Mock;
+
+describe('DropListItemContentMediaVideo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders video when in view', () => {
+    const ref = { current: document.createElement('div') } as React.RefObject<HTMLDivElement>;
+    mockUseInView.mockReturnValue([ref, true]);
+    mockUseOptimizedVideo.mockReturnValue({ playableUrl: 'foo.mp4', isHls: false });
+
+    render(<DropListItemContentMediaVideo src="foo.mp4" />);
+    expect(screen.getByText('Your browser does not support the video tag.')).toBeInTheDocument();
+    const vid = document.querySelector('video') as HTMLVideoElement;
+    expect(vid).toBeTruthy();
+    expect(vid.autoplay).toBe(true);
+  });
+
+  it('does not render video when not in view', () => {
+    const ref = { current: document.createElement('div') } as React.RefObject<HTMLDivElement>;
+    mockUseInView.mockReturnValue([ref, false]);
+    mockUseOptimizedVideo.mockReturnValue({ playableUrl: 'foo.mp4', isHls: false });
+
+    render(<DropListItemContentMediaVideo src="foo.mp4" />);
+    expect(document.querySelector('video')).toBeNull();
+  });
+});

--- a/__tests__/components/groups/page/list/card/vote-all/GroupCardVoteAll.test.tsx
+++ b/__tests__/components/groups/page/list/card/vote-all/GroupCardVoteAll.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, fireEvent, screen, act } from '@testing-library/react';
+import GroupCardVoteAll from '../../../../../../../components/groups/page/list/card/vote-all/GroupCardVoteAll';
+import { AuthContext } from '../../../../../../components/auth/Auth';
+import { ReactQueryWrapperContext } from '../../../../../../components/react-query-wrapper/ReactQueryWrapper';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { commonApiFetch, commonApiPost } from '../../../../../../../services/api/common-api';
+
+jest.mock('@tanstack/react-query');
+jest.mock('../../../../../../../services/api/common-api');
+
+jest.mock('../../../../../../../components/groups/page/list/card/vote-all/GroupCardVoteAllInputs', () => (props: any) => (
+  <input data-testid="amount" value={props.amountToAdd ?? ''} onChange={e => props.setAmountToAdd(Number(e.target.value))} />
+));
+
+jest.mock('../../../../../../../components/groups/page/list/card/GroupCardActionWrapper', () => (props: any) => (
+  <div>
+    {props.children}
+    <button onClick={props.onSave} disabled={props.disabled}>Grant</button>
+  </div>
+));
+
+describe('GroupCardVoteAll', () => {
+  const mockUseQuery = useQuery as jest.Mock;
+  const mockUseMutation = useMutation as jest.Mock;
+  const mockFetch = commonApiFetch as jest.Mock;
+  const mockPost = commonApiPost as jest.Mock;
+
+  const auth = { setToast: jest.fn(), requestAuth: jest.fn().mockResolvedValue({ success: true }) } as any;
+  const reactQueryCtx = { onIdentityBulkRate: jest.fn() } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseQuery.mockReturnValue({ data: { count: 1 }, isFetching: false });
+    mockUseMutation.mockReturnValue({ mutateAsync: jest.fn().mockResolvedValue({}) });
+    mockFetch.mockResolvedValue({ data: { count:1, next:null, data:[{ wallet:'0x1'}] }, success: true });
+    mockPost.mockResolvedValue({});
+  });
+
+  it('enables grant button when amount entered and performs save', async () => {
+    render(
+      <AuthContext.Provider value={auth}>
+        <ReactQueryWrapperContext.Provider value={reactQueryCtx}>
+          <GroupCardVoteAll matter="Cic" group={{ id: 'g1' } as any} onCancel={jest.fn()} />
+        </ReactQueryWrapperContext.Provider>
+      </AuthContext.Provider>
+    );
+
+    fireEvent.change(screen.getByTestId('amount'), { target: { value: '1' } });
+    const button = screen.getByText('Grant');
+    expect(button).not.toBeDisabled();
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    expect(auth.requestAuth).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/user/stats/tags/UserPageStatsTags.test.tsx
+++ b/__tests__/components/user/stats/tags/UserPageStatsTags.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import UserPageStatsTags from '../../../../components/user/stats/tags/UserPageStatsTags';
+
+const balance = {
+  nextgen_balance: 2,
+  memes_cards_sets: 3,
+  memes_balance: 4,
+  unique_memes: 3,
+  gradients_balance: 1,
+  boost: 5
+} as any;
+
+const balanceMemes = [{ season: 1, sets: 2 }];
+
+const seasons = [] as any;
+
+describe('UserPageStatsTags', () => {
+  it('renders tags based on balances', () => {
+    render(
+      <UserPageStatsTags ownerBalance={balance} balanceMemes={balanceMemes} seasons={seasons} />
+    );
+    expect(screen.getByText(/NextGen x2/)).toBeInTheDocument();
+    expect(screen.getByText(/Meme Sets x3/)).toBeInTheDocument();
+    expect(screen.getByText(/Memes x4 \(unique x3\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Gradients x1/)).toBeInTheDocument();
+    expect(screen.getByText(/Boost x5/)).toBeInTheDocument();
+    expect(screen.getByText(/SZN1 Sets x2/)).toBeInTheDocument();
+  });
+
+  it('renders empty div when no tags', () => {
+    const { container } = render(
+      <UserPageStatsTags ownerBalance={undefined} balanceMemes={[]} seasons={[]} />
+    );
+    expect(container.querySelector('div')?.textContent).toBe('');
+  });
+});

--- a/__tests__/components/waves/CreateDropContentRequirementsItem.test.tsx
+++ b/__tests__/components/waves/CreateDropContentRequirementsItem.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import CreateDropContentRequirementsItem from '../../../components/waves/CreateDropContentRequirementsItem';
+import { DropRequirementType } from '../../../components/waves/CreateDropContentRequirements';
+
+jest.mock('@tippyjs/react', () => ({ children }: any) => <div>{children}</div>);
+
+describe('CreateDropContentRequirementsItem', () => {
+  it('calls onOpenMetadata when requirement type is METADATA', () => {
+    const open = jest.fn();
+    const setFiles = jest.fn();
+    const { getByRole } = render(
+      <CreateDropContentRequirementsItem isValid={false} requirementType={DropRequirementType.METADATA} missingItems={[]} onOpenMetadata={open} setFiles={setFiles} disabled={false} />
+    );
+    fireEvent.click(getByRole('button'));
+    expect(open).toHaveBeenCalled();
+  });
+
+  it('opens file chooser when requirement type is MEDIA', () => {
+    const open = jest.fn();
+    const setFiles = jest.fn();
+    const input = document.createElement('input');
+    const clickSpy = jest.spyOn(input, 'click').mockImplementation(() => {});
+    jest.spyOn(document, 'createElement').mockReturnValue(input as any);
+    const { getByRole } = render(
+      <CreateDropContentRequirementsItem isValid={false} requirementType={DropRequirementType.MEDIA} missingItems={[]} onOpenMetadata={open} setFiles={setFiles} disabled={false} />
+    );
+    fireEvent.click(getByRole('button'));
+    expect(clickSpy).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/waves/header/name/WaveHeaderNameEditInput.test.tsx
+++ b/__tests__/components/waves/header/name/WaveHeaderNameEditInput.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import WaveHeaderNameEditInput from '../../../../../components/waves/header/name/WaveHeaderNameEditInput';
+
+const wave = { id: 'w1' } as any;
+
+describe('WaveHeaderNameEditInput', () => {
+  it('updates name on change', () => {
+    const setName = jest.fn();
+    const { getByPlaceholderText } = render(
+      <WaveHeaderNameEditInput wave={wave} name="abc" setName={setName} />
+    );
+    fireEvent.change(getByPlaceholderText('Please select a name'), { target: { value: 'new' } });
+    expect(setName).toHaveBeenCalledWith('new');
+  });
+});

--- a/__tests__/components/waves/leaderboard/time/HorizontalTimeline.test.tsx
+++ b/__tests__/components/waves/leaderboard/time/HorizontalTimeline.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { HorizontalTimeline } from '../../../../../components/waves/leaderboard/time/HorizontalTimeline';
+
+const decisions = [
+  { id: '1', timestamp: 1 },
+  { id: '2', timestamp: 2 },
+  { id: '3', timestamp: 3 },
+  { id: '4', timestamp: 4 },
+  { id: '5', timestamp: 5 },
+  { id: '6', timestamp: 6 }
+] as any;
+
+describe('HorizontalTimeline', () => {
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', { value: jest.fn(), writable: true });
+  });
+
+  it('scrolls to next decision when animation completed', () => {
+    render(
+      <HorizontalTimeline decisions={decisions} nextDecisionTime={3} animationComplete />
+    );
+    expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it('falls back to last decision when no next decision', () => {
+    render(
+      <HorizontalTimeline decisions={decisions} nextDecisionTime={null} animationComplete />
+    );
+    expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it('spreads items when few decisions', () => {
+    const { container } = render(
+      <HorizontalTimeline decisions={decisions.slice(0,3)} nextDecisionTime={null} animationComplete />
+    );
+    expect(container.querySelector('.tw-w-full')).toBeTruthy();
+  });
+});

--- a/__tests__/hooks/useVirtualizedWaves.test.tsx
+++ b/__tests__/hooks/useVirtualizedWaves.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { useVirtualizedWaves } from '../../hooks/useVirtualizedWaves';
+import { ScrollPositionProvider } from '../../contexts/ScrollPositionContext';
+
+const wrapper: React.FC<{children: React.ReactNode}> = ({ children }) => (
+  <ScrollPositionProvider>{children}</ScrollPositionProvider>
+);
+
+describe('useVirtualizedWaves', () => {
+  it('calculates virtual items and updates scroll position', () => {
+    const scrollContainer = document.createElement('div');
+    Object.defineProperty(scrollContainer, 'clientHeight', { value: 100 });
+    const listContainer = document.createElement('div');
+    Object.defineProperty(listContainer, 'offsetTop', { value: 0 });
+    const items = Array.from({ length: 10 }, (_, i) => i);
+    const scrollRef = { current: scrollContainer } as React.RefObject<HTMLDivElement>;
+    const listRef = { current: listContainer } as React.RefObject<HTMLDivElement>;
+
+    const { result } = renderHook(
+      () => useVirtualizedWaves(items, 'k', scrollRef, listRef, 50, 0),
+      { wrapper }
+    );
+    expect(result.current.totalHeight).toBe(10 * 50 + 40);
+    expect(result.current.virtualItems.length).toBe(3);
+
+    act(() => {
+      scrollContainer.scrollTop = 120;
+      scrollContainer.dispatchEvent(new Event('scroll'));
+    });
+    // subsequent call should read updated scroll offset
+    const { result: result2 } = renderHook(
+      () => useVirtualizedWaves(items, 'k', scrollRef, listRef, 50, 0),
+      { wrapper }
+    );
+    expect(result2.current.virtualItems[0].index).toBe(2); // start index advanced
+  });
+});

--- a/__tests__/hooks/useWaveWebSocket.test.ts
+++ b/__tests__/hooks/useWaveWebSocket.test.ts
@@ -1,0 +1,69 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useWaveWebSocket } from '../../hooks/useWaveWebSocket';
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  readyState = MockWebSocket.CONNECTING;
+  onopen = null as ((ev?: any) => any) | null;
+  onclose = null as ((ev?: any) => any) | null;
+  onerror = null as ((ev?: any) => any) | null;
+  send = jest.fn();
+  close = jest.fn(() => {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose && this.onclose({});
+  });
+  triggerOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen && this.onopen({});
+  }
+  constructor(public url: string) {}
+}
+
+describe('useWaveWebSocket', () => {
+  let originalWs: any;
+  beforeEach(() => {
+    originalWs = global.WebSocket;
+    (global as any).WebSocket = jest.fn((url: string) => new MockWebSocket(url));
+    process.env.WS_ENDPOINT = 'ws://test';
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+    (global as any).WebSocket = originalWs;
+    jest.clearAllMocks();
+  });
+
+  it('connects and sends subscribe message', async () => {
+    const { result } = renderHook(() => useWaveWebSocket('wave1'));
+    const instance = (global.WebSocket as jest.Mock).mock.results[0].value as MockWebSocket;
+    act(() => {
+      instance.triggerOpen();
+    });
+    await waitFor(() => expect(result.current.readyState).toBe(MockWebSocket.OPEN));
+    expect(instance.send).toHaveBeenCalledWith(
+      JSON.stringify({ type:  'SUBSCRIBE_TO_WAVE', wave_id: 'wave1' })
+    );
+  });
+
+  it('schedules reconnect on close', () => {
+    const spy = jest.spyOn(global, 'setTimeout');
+    renderHook(() => useWaveWebSocket('wave1'));
+    const instance = (global.WebSocket as jest.Mock).mock.results[0].value as MockWebSocket;
+    act(() => {
+      instance.onclose && instance.onclose({});
+    });
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('disconnect stops reconnecting', () => {
+    const { result } = renderHook(() => useWaveWebSocket('wave1'));
+    const instance = (global.WebSocket as jest.Mock).mock.results[0].value as MockWebSocket;
+    act(() => {
+      result.current.disconnect();
+    });
+    expect(instance.close).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for DropListItemContentMediaVideo
- add tests for UserPageStatsTags
- cover useWaveWebSocket hook behaviour
- add SnapshotSelectTopHolders side bar option tests
- test useVirtualizedWaves hook
- cover HorizontalTimeline behaviour
- test GroupCardVoteAll minimal flow
- cover snapshot download component
- test WaveHeaderNameEditInput
- add CreateDropContentRequirementsItem tests

## Testing
- `npm run test`
- `npx next lint`
- `npm run type-check`
