### PR TITLE
Add tests for various components and hooks

### DIFF
--- a/__tests__/components/distribution-plan-tool/build-phases/build-phase/form/BuildPhaseFormConfigModal.test.tsx
+++ b/__tests__/components/distribution-plan-tool/build-phases/build-phase/form/BuildPhaseFormConfigModal.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import BuildPhaseFormConfigModal from '../../../../../../components/distribution-plan-tool/build-phases/build-phase/form/BuildPhaseFormConfigModal';
+import { DistributionPlanToolContext } from '../../../../../../components/distribution-plan-tool/DistributionPlanToolContext';
+import { AllowlistOperationCode, Pool } from '../../../../../../components/allowlist-tool/allowlist-tool.types';
+
+jest.mock('../../../../../../components/distribution-plan-tool/build-phases/build-phase/form/component-config/select-snapshot/SelectSnapshot', () => ({
+  __esModule: true,
+  default: ({ onSelectSnapshot }: any) => <button onClick={() => onSelectSnapshot({ snapshotId: '1', snapshotType: Pool.TOKEN_POOL, uniqueWalletsCount: null })}>select</button>,
+}));
+
+jest.mock('../../../../../../components/distribution-plan-tool/build-phases/build-phase/form/component-config/SnapshotExcludeOtherSnapshots', () => ({
+  __esModule: true,
+  default: () => <div data-testid="exclude" />,
+}));
+
+const contextValue = {
+  operations: [
+    { code: AllowlistOperationCode.CREATE_TOKEN_POOL, params: { id: '1', name: 'A' } },
+    { code: AllowlistOperationCode.CREATE_TOKEN_POOL, params: { id: '2', name: 'B' } },
+  ],
+  distributionPlan: null,
+  tokenPools: [],
+  customTokenPools: [],
+  fetchOperations: jest.fn(),
+  runOperations: jest.fn(),
+  phases: [],
+  setToasts: jest.fn(),
+} as any;
+
+function renderModal() {
+  return render(
+    <DistributionPlanToolContext.Provider value={contextValue}>
+      <BuildPhaseFormConfigModal name="g" description="d" selectedPhase={{ id: 'p', components: [] }} phases={[{ id: 'p', components: [] }]} onClose={jest.fn()} />
+    </DistributionPlanToolContext.Provider>
+  );
+}
+
+test('initial step renders select snapshot', () => {
+  renderModal();
+  expect(screen.getByText('select')).toBeInTheDocument();
+});
+
+import { waitFor } from '@testing-library/react';
+
+test('moves to next step on select', async () => {
+  renderModal();
+  fireEvent.click(screen.getByText('select'));
+  await waitFor(() => expect(screen.getByTestId('exclude')).toBeInTheDocument());
+});

--- a/__tests__/components/drops/create/lexical/plugins/hashtags/HashtagsTypeaheadMenu.test.tsx
+++ b/__tests__/components/drops/create/lexical/plugins/hashtags/HashtagsTypeaheadMenu.test.tsx
@@ -1,0 +1,30 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+jest.mock("react-use");
+import HashtagsTypeaheadMenu from '../../../../../../../components/drops/create/lexical/plugins/hashtags/HashtagsTypeaheadMenu';
+import { useKeyPressEvent } from 'react-use';
+
+let keyCb: any;
+(useKeyPressEvent as jest.Mock).mockImplementation((_key, cb) => { keyCb = cb; });
+
+const option = { key: 'a', label: 'A' } as any;
+const setHighlightedIndex = jest.fn();
+const selectOptionAndCleanUp = jest.fn();
+
+let utils: any;
+beforeEach(() => {
+  utils = render(
+    <HashtagsTypeaheadMenu
+      selectedIndex={0}
+      options={[option]}
+      setHighlightedIndex={setHighlightedIndex}
+      selectOptionAndCleanUp={selectOptionAndCleanUp}
+    />
+  );
+});
+
+test('selects option on space press', () => {
+  keyCb();
+  expect(setHighlightedIndex).toHaveBeenCalledWith(0);
+  expect(selectOptionAndCleanUp).toHaveBeenCalledWith(option);
+});

--- a/__tests__/components/nextGen/admin/NextGenAdminSetSplits.test.tsx
+++ b/__tests__/components/nextGen/admin/NextGenAdminSetSplits.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import NextGenAdminSetSplits from '../../../../components/nextGen/admin/NextGenAdminSetSplits';
+
+jest.mock('../../../../components/nextGen/nextgen_helpers', () => ({
+  useGlobalAdmin: () => ({ data: true }),
+  useFunctionAdmin: () => ({ data: true }),
+  useCollectionIndex: () => ({ data: 1 }),
+  getCollectionIdsForAddress: () => ['1'],
+  useMinterContractWrite: () => ({ writeContract: jest.fn(), reset: jest.fn(), params: {}, isSuccess:false, isError:false }),
+  useParsedCollectionIndex: () => 1,
+}));
+
+jest.mock('../../../../components/nextGen/admin/NextGenAdminShared', () => ({
+  NextGenCollectionIdFormGroup: ({ onChange }: any) => <input data-testid="collection" onChange={e => onChange(e.target.value)} />,
+  NextGenAdminHeadingRow: () => <div />,
+  NextGenAdminTextFormGroup: ({ title, value, setValue }: any) => <input aria-label={title} value={value} onChange={e=>setValue(e.target.value)} />,
+}));
+
+jest.mock('../../../../components/nextGen/NextGenContractWriteStatus', () => () => <div />);
+
+jest.mock('../../../../components/auth/SeizeConnectContext', () => ({ useSeizeConnectContext: () => ({ address: '0x1' }) }));
+
+jest.mock('wagmi', () => ({ useReadContract: jest.fn(() => ({ data: [] })) }));
+
+function setup() {
+  return render(<NextGenAdminSetSplits close={() => {}} />);
+}
+
+test('shows validation errors when fields missing', () => {
+  setup();
+  fireEvent.click(screen.getByText('Submit'));
+  expect(screen.getByText('Collection id is required')).toBeInTheDocument();
+});

--- a/__tests__/components/waves/drops/DropMobileMenuHandler.test.tsx
+++ b/__tests__/components/waves/drops/DropMobileMenuHandler.test.tsx
@@ -1,0 +1,32 @@
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import DropMobileMenuHandler from '../../../../components/waves/drops/DropMobileMenuHandler';
+import { DropSize } from '../../../../helpers/waves/drop.helpers';
+
+jest.mock('../../../../hooks/isMobileDevice', () => () => true);
+
+jest.mock('../../../../components/waves/drops/WaveDropMobileMenu', () => ({
+  __esModule: true,
+  default: (props: any) => (
+    <div data-testid="menu" data-open={props.isOpen} onClick={() => props.onReply()} />
+  ),
+}));
+
+const drop = { id: 'drop', type: DropSize.FULL } as any;
+
+test('opens menu on long press', () => {
+  jest.useFakeTimers();
+  const { getByTestId } = render(
+    <DropMobileMenuHandler drop={drop} showReplyAndQuote onReply={jest.fn()} onQuote={jest.fn()}>
+      <div data-testid="child" />
+    </DropMobileMenuHandler>
+  );
+  fireEvent.touchStart(getByTestId('child'), { touches: [{ clientX:0, clientY:0 }] });
+  act(() => {
+    jest.advanceTimersByTime(600);
+  });
+  const menu = getByTestId('menu');
+  expect(menu.getAttribute('data-open')).toBe('true');
+  fireEvent.click(menu);
+  expect(menu.getAttribute('data-open')).toBe('false');
+});

--- a/__tests__/components/waves/drops/VirtualScrollWrapper.test.tsx
+++ b/__tests__/components/waves/drops/VirtualScrollWrapper.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import VirtualScrollWrapper from '../../../../components/waves/drops/VirtualScrollWrapper';
+import { DropSize } from '../../../../helpers/waves/drop.helpers';
+import { useMyStream } from "../../../../contexts/wave/MyStreamContext";
+
+jest.useFakeTimers();
+
+const observe = jest.fn();
+const unobserve = jest.fn();
+let intersectionCb: (entries: any[]) => void = () => {};
+
+beforeAll(() => {
+  (global as any).IntersectionObserver = class {
+    constructor(cb: any) {
+      intersectionCb = cb;
+    }
+    observe = observe;
+    unobserve = unobserve;
+    disconnect() {}
+  };
+});
+
+afterEach(() => {
+  observe.mockClear();
+  unobserve.mockClear();
+});
+
+jest.mock('../../../../contexts/wave/MyStreamContext', () => ({
+  useMyStream: jest.fn(() => ({ fetchAroundSerialNo: jest.fn() })),
+}));
+
+function setup(size: DropSize) {
+  const scrollRef = { current: document.createElement('div') };
+  const { container } = render(
+    <VirtualScrollWrapper
+      scrollContainerRef={scrollRef}
+      delay={1000}
+      dropSerialNo={1}
+      waveId="wave"
+      type={size}
+    >
+      <div data-testid="child">content</div>
+    </VirtualScrollWrapper>
+  );
+  return { container, scrollRef };
+}
+
+test('renders placeholder when out of view', () => {
+  const { container } = setup(DropSize.FULL);
+  const div = container.firstChild as HTMLElement;
+  Object.defineProperty(div, 'getBoundingClientRect', {
+    value: () => ({ height: 123 }),
+  });
+
+  act(() => {
+    jest.advanceTimersByTime(1000);
+  });
+
+  act(() => {
+    intersectionCb([{ isIntersecting: false } as any]);
+  });
+
+  const placeholder = div.firstChild as HTMLElement;
+  expect(placeholder.getAttribute('style')).toContain('height: 123');
+});
+
+test('fetches light drop when entering view', () => {
+  const fetchAroundSerialNo = jest.fn();
+  const module = require('../../../../contexts/wave/MyStreamContext');
+  (module.useMyStream as jest.Mock).mockReturnValue({ fetchAroundSerialNo });
+  setup(DropSize.LIGHT);
+  act(() => {
+    intersectionCb([{ isIntersecting: true } as any]);
+  });
+  expect(fetchAroundSerialNo).toHaveBeenCalledWith('wave', 1);
+});

--- a/__tests__/components/waves/drops/time/WaveDropTime.test.tsx
+++ b/__tests__/components/waves/drops/time/WaveDropTime.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import WaveDropTime from '../../../../../components/waves/drops/time/WaveDropTime';
+
+function renderWithTime(ts: number) {
+  render(<WaveDropTime timestamp={ts} />);
+}
+
+test('shows time for today', () => {
+  const now = Date.now();
+  renderWithTime(now);
+  const expected = new Date(now).toLocaleTimeString(undefined,{hour:'2-digit',minute:'2-digit'});
+  expect(screen.getByText(expected)).toBeInTheDocument();
+});
+
+test('shows yesterday prefix', () => {
+  const now = Date.now();
+  const yesterday = now - 24*60*60*1000;
+  renderWithTime(yesterday);
+  const timeStr = new Date(yesterday).toLocaleTimeString(undefined,{hour:'2-digit',minute:'2-digit'});
+  expect(screen.getByText(`Yesterday - ${timeStr}`)).toBeInTheDocument();
+});

--- a/__tests__/components/waves/memes/submission/hooks/useArtworkSubmissionMutation.test.tsx
+++ b/__tests__/components/waves/memes/submission/hooks/useArtworkSubmissionMutation.test.tsx
@@ -1,0 +1,45 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useArtworkSubmissionMutation } from '../../../../../../components/waves/memes/submission/hooks/useArtworkSubmissionMutation';
+
+jest.mock('../../../../../../hooks/drops/useDropSignature', () => ({
+  useDropSignature: () => ({ signDrop: jest.fn(() => Promise.resolve({ success: true, signature: 'sig' })), isLoading: false }),
+}));
+
+jest.mock('../../../../../../services/api/common-api', () => ({
+  commonApiPost: jest.fn(() => Promise.resolve({})),
+}));
+
+jest.mock('../../../../../../components/auth/Auth', () => ({
+  useAuth: () => ({ setToast: jest.fn(), requestAuth: jest.fn(() => Promise.resolve({ success: true })) }),
+}));
+
+jest.mock('../../../../../../components/waves/create-wave/services/multiPartUpload', () => ({
+  multiPartUpload: jest.fn(() => Promise.resolve({ url: 'media', mime_type: 'image/png' })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+const file = new File(['data'], 'test.png', { type: 'image/png' });
+
+it('validates required fields', async () => {
+  const { result } = renderHook(() => useArtworkSubmissionMutation(), { wrapper: createWrapper() });
+  const res = await result.current.submitArtwork({ imageFile: file, traits: { title: '' } as any, waveId: '1', termsOfService: null });
+  expect(res).toBeNull();
+});
+
+it('submits artwork successfully', async () => {
+  const { result } = renderHook(() => useArtworkSubmissionMutation(), { wrapper: createWrapper() });
+  const res = await result.current.submitArtwork({ imageFile: file, traits: { title: 't', description: 'd' } as any, waveId: '1', termsOfService: null });
+  await waitFor(() => expect(require('../../../../../components/waves/create-wave/services/multiPartUpload').multiPartUpload).toHaveBeenCalled());
+  expect(require('../../../../../services/api/common-api').commonApiPost).toHaveBeenCalled();
+  expect(res).not.toBeNull();
+});

--- a/__tests__/hooks/scroll/useIntersectionObserver.test.tsx
+++ b/__tests__/hooks/scroll/useIntersectionObserver.test.tsx
@@ -1,0 +1,23 @@
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { useIntersectionObserver } from '../../../hooks/scroll/useIntersectionObserver';
+
+let observeTarget: Element | null = null;
+let callback: any;
+
+beforeAll(() => {
+  (global as any).IntersectionObserver = class {
+    constructor(cb: any, public options: any) { callback = cb; }
+    observe(target: Element) { observeTarget = target; }
+    disconnect() {}
+  };
+});
+
+test('calls callback on intersection', () => {
+  const ref = { current: document.createElement('div') };
+  const cb = jest.fn();
+  renderHook(() => useIntersectionObserver(ref, { rootMargin: '0px', threshold: 0, freezeOnceVisible: false }, cb));
+  expect(observeTarget).toBe(ref.current);
+  callback([{ isIntersecting: true } as any]);
+  expect(cb).toHaveBeenCalled();
+});

--- a/__tests__/hooks/useWaveActivityLogs.test.tsx
+++ b/__tests__/hooks/useWaveActivityLogs.test.tsx
@@ -1,0 +1,25 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useWaveActivityLogs } from '../../hooks/useWaveActivityLogs';
+
+jest.mock('../../services/api/common-api', () => ({
+  commonApiFetch: jest.fn(() => Promise.resolve([{ id: '1' }, { id: '2' }])),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+test('fetches logs', async () => {
+  const { result } = renderHook(() => useWaveActivityLogs({ waveId: 'w', connectedProfileHandle: 'h', reverse: false, dropId: null, logTypes: [] }), { wrapper: createWrapper() });
+  await waitFor(() => expect(result.current.logs.length).toBe(2));
+});
+
+test('reverses logs when reverse true', async () => {
+  const { result } = renderHook(() => useWaveActivityLogs({ waveId: 'w', connectedProfileHandle: 'h', reverse: true, dropId: null, logTypes: [] }), { wrapper: createWrapper() });
+  await waitFor(() => expect(result.current.logs[0].id).toBe('2'));
+});

--- a/__tests__/hooks/useWaveIsTyping.test.tsx
+++ b/__tests__/hooks/useWaveIsTyping.test.tsx
@@ -1,0 +1,28 @@
+import { renderHook, act } from '@testing-library/react';
+import { useWaveIsTyping } from '../../hooks/useWaveIsTyping';
+import { WsMessageType } from '../../helpers/Types';
+
+const listeners: any[] = [];
+
+jest.mock('../../hooks/useWaveWebSocket', () => ({
+  useWaveWebSocket: () => ({
+    socket: {
+      addEventListener: (_: string, cb: any) => listeners.push(cb),
+      removeEventListener: jest.fn(),
+    },
+  }),
+}));
+
+test('reports typing status and clears after timeout', () => {
+  jest.useFakeTimers();
+  const { result } = renderHook(() => useWaveIsTyping('wave', null));
+
+  act(() => {
+    listeners[0]({ data: JSON.stringify({ type: WsMessageType.USER_IS_TYPING, data: { wave_id: 'wave', profile: { handle: 'A', level: 1 } } }) });
+  });
+  act(() => jest.advanceTimersByTime(1000));
+  expect(result.current).toContain('A is typing');
+
+  act(() => jest.advanceTimersByTime(6000));
+  expect(result.current).toBe('');
+});


### PR DESCRIPTION
## Summary
- add unit tests for VirtualScrollWrapper, WaveDropTime and related hooks
- test artwork submission hook workflow
- cover build phase form modal behaviour
- test mobile drop menu handler interactions
- add tests for intersection observer hook and wave activity logs
- cover hashtags typeahead menu and NextGen admin splits

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`