### PR TITLE
Add tests for various components and hooks

### DIFF
--- a/__tests__/components/distribution-plan-tool/common/Countdown.test.tsx
+++ b/__tests__/components/distribution-plan-tool/common/Countdown.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import Countdown from '../../../../components/distribution-plan-tool/common/Countdown';
+
+jest.useFakeTimers();
+
+describe('Countdown component', () => {
+  it('counts down and stops', () => {
+    const now = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    const target = now + 5000; // 5 seconds later
+    render(<Countdown timestamp={target} />);
+    act(() => {
+      jest.advanceTimersByTime(1000); // first interval
+    });
+    expect(screen.getByText(/seconds/)).toBeInTheDocument();
+
+    // advance remaining time
+    act(() => {
+      jest.advanceTimersByTime(4000);
+    });
+    expect(screen.getByText('Countdown finished!')).toBeInTheDocument();
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/__tests__/components/nextGen/collections/nextgenToken/NextGenTokenProperties.test.tsx
+++ b/__tests__/components/nextGen/collections/nextgenToken/NextGenTokenProperties.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { NextgenTokenTraits, NextgenRarityToggle, displayScore } from '../../../../../components/nextGen/collections/nextgenToken/NextGenTokenProperties';
+
+jest.mock('react-bootstrap', () => {
+  const React = require('react');
+  return { Container: (p: any) => <div {...p} />, Row: (p: any) => <div>{p.children}</div>, Col: (p: any) => <div>{p.children}</div> };
+});
+
+jest.mock('react-toggle', () => (p: any) => <input type="checkbox" {...p} />);
+
+describe('displayScore', () => {
+  it('formats numbers based on size', () => {
+    expect(displayScore(1.2345)).toBe('1.235');
+    expect(displayScore(0.005)).toBe('0.00500');
+    expect(displayScore(0.0005)).toBe('5.000e-4');
+  });
+});
+
+describe('NextgenRarityToggle', () => {
+  it('toggles value when clicked', () => {
+    const setShow = jest.fn();
+    render(<NextgenRarityToggle title="Trait Count" show={false} setShow={setShow} />);
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+    checkbox.click();
+    expect(setShow).toHaveBeenCalledWith(true);
+  });
+
+  it('shows disabled style', () => {
+    render(<NextgenRarityToggle title="Trait Count" show disabled />);
+    expect(screen.getByRole('checkbox')).toBeDisabled();
+    const label = screen.getByText(/Trait Count/).closest('label');
+    expect(label).toHaveClass('font-color-h');
+  });
+});
+
+describe('NextgenTokenTraits', () => {
+  it('renders trait rows with links', () => {
+    const traits = [{ trait: 'Color', value: 'Red', value_count: 2, token_count: 10, trait_count: 1 } as any];
+    render(<NextgenTokenTraits collection={{ name: 'Cool Coll' } as any} token={{} as any} traits={traits} tokenCount={10} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/nextgen/collection/cool-coll/art?traits=Color:Red');
+    expect(link.textContent).toBe('Red');
+  });
+});

--- a/__tests__/contexts/wave/hooks/useWaveLoadingState.test.ts
+++ b/__tests__/contexts/wave/hooks/useWaveLoadingState.test.ts
@@ -1,0 +1,49 @@
+import { renderHook, act } from '@testing-library/react';
+import { useWaveLoadingState } from '../../../../contexts/wave/hooks/useWaveLoadingState';
+
+describe('useWaveLoadingState', () => {
+  it('initializes state and determines continuation', () => {
+    const { result } = renderHook(() => useWaveLoadingState());
+    const res = result.current.getLoadingState('w1');
+    expect(res.state).toEqual({ isLoading: false, promise: null });
+    expect(res.shouldContinue).toBe(true);
+  });
+
+  it('updates loading state and clears promise', () => {
+    const { result } = renderHook(() => useWaveLoadingState());
+    act(() => {
+      result.current.getLoadingState('w1');
+      result.current.setPromise('w1', Promise.resolve(null));
+      result.current.setLoadingState('w1', true);
+    });
+    expect(result.current.loadingStates.current['w1'].isLoading).toBe(true);
+    expect(result.current.loadingStates.current['w1'].promise).not.toBeNull();
+
+    act(() => {
+      result.current.setLoadingState('w1', false);
+    });
+    expect(result.current.loadingStates.current['w1']).toEqual({ isLoading: false, promise: null });
+  });
+
+  it('getLoadingState returns shouldContinue false when already loading', () => {
+    const { result } = renderHook(() => useWaveLoadingState());
+    act(() => {
+      result.current.getLoadingState('w1');
+      result.current.setPromise('w1', Promise.resolve(null));
+      result.current.setLoadingState('w1', true);
+    });
+    const res = result.current.getLoadingState('w1');
+    expect(res.shouldContinue).toBe(false);
+  });
+
+  it('clearLoadingState resets data', () => {
+    const { result } = renderHook(() => useWaveLoadingState());
+    act(() => {
+      result.current.getLoadingState('w1');
+      result.current.setPromise('w1', Promise.resolve(null));
+      result.current.setLoadingState('w1', true);
+      result.current.clearLoadingState('w1');
+    });
+    expect(result.current.loadingStates.current['w1']).toEqual({ isLoading: false, promise: null });
+  });
+});

--- a/__tests__/pages/nextgen/collection/[collection]/trait-sets.test.tsx
+++ b/__tests__/pages/nextgen/collection/[collection]/trait-sets.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Page, { getServerSideProps } from '../../../../../pages/nextgen/collection/[collection]/trait-sets';
+
+let headerProps: any = null;
+let setsProps: any = null;
+
+jest.mock('../../../../../components/nextGen/collections/collectionParts/NextGenCollectionHeader', () => ({
+  NextGenCollectionHead: (p: any) => { headerProps = p; return <div data-testid='head' />; },
+  getServerSideCollection: jest.fn(() => Promise.resolve({ props: { ok: true } })),
+}));
+
+jest.mock('../../../../../components/nextGen/collections/NextGenNavigationHeader', () => () => <div data-testid='nav' />);
+
+jest.mock('next/dynamic', () => () => (p: any) => { setsProps = p; return <div data-testid='dynamic' />; });
+
+const { getServerSideCollection } = require('../../../../../components/nextGen/collections/collectionParts/NextGenCollectionHeader');
+
+describe('NextGen trait sets page', () => {
+  beforeEach(() => { headerProps = null; setsProps = null; });
+
+  it('passes collection to components', () => {
+    const props = { pageProps: { collection: { id: 1 } } } as any;
+    render(<Page {...props} />);
+    expect(headerProps).toEqual({ collection: props.pageProps.collection });
+    expect(setsProps).toEqual({ collection: props.pageProps.collection });
+  });
+
+  it('delegates getServerSideProps', async () => {
+    const req = {} as any;
+    const res = await getServerSideProps(req, null as any, '/p');
+    expect(getServerSideCollection).toHaveBeenCalledWith(req, 'Trait Sets');
+    expect(res).toEqual(await getServerSideCollection.mock.results[0].value);
+  });
+});

--- a/__tests__/pages/nextgen/view-index.test.tsx
+++ b/__tests__/pages/nextgen/view-index.test.tsx
@@ -1,0 +1,48 @@
+import { getServerSideProps } from '../../../pages/nextgen/[[...view]]/index';
+import { NextGenView } from '../../../components/nextGen/collections/NextGenNavigationHeader';
+import { getCommonHeaders } from '../../../helpers/server.helpers';
+import { commonApiFetch } from '../../../services/api/common-api';
+
+jest.mock('../../../helpers/server.helpers', () => ({
+  getCommonHeaders: jest.fn(() => ({ h: 'h' })),
+}));
+
+jest.mock('../../../services/api/common-api', () => ({
+  commonApiFetch: jest.fn(),
+}));
+
+const mockedHeaders = getCommonHeaders as jest.Mock;
+const mockedFetch = commonApiFetch as jest.Mock;
+
+describe('NextGen [[...view]] getServerSideProps', () => {
+  beforeEach(() => {
+    mockedFetch.mockClear();
+    mockedHeaders.mockClear();
+    process.env.BASE_ENDPOINT = 'http://base';
+  });
+
+  it('returns collection and parsed view', async () => {
+    mockedFetch.mockResolvedValue({ id: 1 });
+    const res = await getServerSideProps({ query: { view: ['artists'] } } as any, null as any, '/p');
+    expect(mockedHeaders).toHaveBeenCalled();
+    expect(mockedFetch).toHaveBeenCalledWith({ endpoint: 'nextgen/featured', headers: { h: 'h' } });
+    expect(res).toEqual({
+      props: {
+        collection: { id: 1 },
+        view: NextGenView.ARTISTS,
+        metadata: {
+          title: 'NextGen Artists',
+          ogImage: 'http://base/nextgen.png',
+          description: 'NextGen',
+          twitterCard: 'summary_large_image',
+        },
+      },
+    });
+  });
+
+  it('handles missing view', async () => {
+    mockedFetch.mockResolvedValue({ id: 2 });
+    const res = await getServerSideProps({ query: {} } as any, null as any, '/p');
+    expect(res.props.view).toBeNull();
+  });
+});

--- a/__tests__/pages/om/community-galleries/index.test.tsx
+++ b/__tests__/pages/om/community-galleries/index.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Page from '../../../../pages/om/community-galleries';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="header" />);
+jest.mock('../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="placeholder" />);
+
+const renderPage = () => render(<Page />);
+
+describe('OM Community Galleries Page', () => {
+  it('renders meta tags', () => {
+    renderPage();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('OM COMMUNITY GALLERIES - 6529.io');
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical?.getAttribute('href')).toBe('/om/community-galleries/');
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+    expect(document.querySelector('#toTop')).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/om/discord/index.test.tsx
+++ b/__tests__/pages/om/discord/index.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Page from '../../../../pages/om/discord';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="header" />);
+jest.mock('../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="placeholder" />);
+
+const renderPage = () => render(<Page />);
+
+describe('OM Discord Page', () => {
+  it('renders meta tags', () => {
+    renderPage();
+    const title = document.querySelector('title');
+    expect(title?.textContent).toBe('DISCORD - 6529.io');
+    const canonical = document.querySelector('link[rel="canonical"]');
+    expect(canonical?.getAttribute('href')).toBe('/om/discord/');
+    const robots = document.querySelector('meta[name="robots"]');
+    expect(robots?.getAttribute('content')).toBe('index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1');
+    expect(document.querySelector('#toTop')).toHaveClass('fusion-top-top-link');
+  });
+});

--- a/__tests__/pages/open-data/rememes.test.tsx
+++ b/__tests__/pages/open-data/rememes.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import RememesDownloads from '../../../pages/open-data/rememes';
+import { AuthContext } from '../../../components/auth/Auth';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+describe('Open Data rememes page', () => {
+  it('renders component and sets title', () => {
+    const setTitle = jest.fn();
+    render(
+      <AuthContext.Provider value={{ setTitle } as any}>
+        <RememesDownloads />
+      </AuthContext.Provider>
+    );
+    expect(screen.getByTestId('dynamic')).toBeInTheDocument();
+    expect(setTitle).toHaveBeenCalledWith({ title: 'Rememes | Open Data' });
+  });
+
+  it('exposes metadata', () => {
+    expect(RememesDownloads.metadata).toEqual({ title: 'Rememes', description: 'Open Data' });
+  });
+});

--- a/__tests__/pages/open-data/team.test.tsx
+++ b/__tests__/pages/open-data/team.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import TeamDownloads from '../../../pages/open-data/team';
+import { AuthContext } from '../../../components/auth/Auth';
+
+jest.mock('next/dynamic', () => () => () => <div data-testid="dynamic" />);
+
+describe('Open Data team page', () => {
+  it('renders component and sets title', () => {
+    const setTitle = jest.fn();
+    render(
+      <AuthContext.Provider value={{ setTitle } as any}>
+        <TeamDownloads />
+      </AuthContext.Provider>
+    );
+    expect(screen.getByTestId('dynamic')).toBeInTheDocument();
+    expect(setTitle).toHaveBeenCalledWith({ title: 'Team | Open Data' });
+  });
+
+  it('exposes metadata', () => {
+    expect(TeamDownloads.metadata).toEqual({ title: 'Team', description: 'Open Data' });
+  });
+});

--- a/__tests__/pages/tools/app-wallets/address.test.tsx
+++ b/__tests__/pages/tools/app-wallets/address.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Page, { getServerSideProps } from '../../../../pages/tools/app-wallets/[app-wallet-address]';
+import { AuthContext } from '../../../../components/auth/Auth';
+import { formatAddress } from '../../../../helpers/Helpers';
+
+jest.mock('next/dynamic', () => () => (p: any) => <div data-testid="wallet" {...p} />);
+
+jest.mock('../../../../helpers/Helpers', () => ({
+  formatAddress: jest.fn((a: string) => `fmt-${a}`),
+}));
+
+const mockedFormat = formatAddress as jest.Mock;
+
+const renderPage = (address: string, setTitle: jest.Mock) =>
+  render(
+    <AuthContext.Provider value={{ setTitle } as any}>
+      <Page pageProps={{ address }} />
+    </AuthContext.Provider>
+  );
+
+describe('App Wallet page', () => {
+  it('sets title and passes address', () => {
+    const setTitle = jest.fn();
+    renderPage('0xabc', setTitle);
+    expect(screen.getByTestId('wallet')).toHaveAttribute('address', '0xabc');
+    expect(setTitle).toHaveBeenCalledWith({ title: 'fmt-0xabc | App Wallets | 6529.io' });
+  });
+
+  it('getServerSideProps returns metadata', async () => {
+    const ctx = { query: { 'app-wallet-address': '0xdef' } } as any;
+    const res = await getServerSideProps(ctx, null as any, '/p');
+    expect(res).toEqual({
+      props: {
+        address: '0xdef',
+        metadata: { title: 'fmt-0xdef | App Wallets' },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for nextgen view and trait pages
- add tests for OM pages and open-data downloads
- test app wallet page and countdown component
- cover nextgen token properties and wave loading state hook

## Testing
- `npx jest __tests__/pages/nextgen/view-index.test.tsx __tests__/pages/nextgen/collection/[collection]/trait-sets.test.tsx __tests__/pages/om/community-galleries/index.test.tsx __tests__/pages/om/discord/index.test.tsx __tests__/pages/open-data/rememes.test.tsx __tests__/pages/open-data/team.test.tsx __tests__/pages/tools/app-wallets/address.test.tsx __tests__/components/distribution-plan-tool/common/Countdown.test.tsx __tests__/components/nextGen/collections/nextgenToken/NextGenTokenProperties.test.tsx __tests__/contexts/wave/hooks/useWaveLoadingState.test.ts --runInBand --coverage=false`
- `npm run lint`
- `npm run type-check`
