### PR TITLE
Add tests for various components and services

### DIFF
--- a/__tests__/components/ChatItemHrefButtons.test.tsx
+++ b/__tests__/components/ChatItemHrefButtons.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ChatItemHrefButtons from "../../components/waves/ChatItemHrefButtons";
+
+const writeText = jest.fn().mockResolvedValue(undefined);
+Object.assign(navigator, {
+  clipboard: { writeText },
+});
+
+describe("ChatItemHrefButtons", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("copies link to clipboard", () => {
+    render(<ChatItemHrefButtons href="https://a" />);
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    expect(writeText).toHaveBeenCalledWith("https://a");
+  });
+
+  it("renders external link when no relative href", () => {
+    render(<ChatItemHrefButtons href="https://a" />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "https://a");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("uses relative href when provided", () => {
+    render(<ChatItemHrefButtons href="https://a" relativeHref="/local" />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/local");
+    expect(link).not.toHaveAttribute("target");
+  });
+});

--- a/__tests__/components/DefaultWinnerDrop.test.tsx
+++ b/__tests__/components/DefaultWinnerDrop.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DefaultWinnerDrop from "../../components/waves/drops/winner/DefaultWinnerDrop";
+import React from "react";
+
+jest.mock("next/router", () => ({ useRouter: () => ({ push: jest.fn(), prefetch: jest.fn() }) }));
+
+jest.mock("../../components/waves/drops/WaveDropAuthorPfp", () => () => <div />);
+jest.mock("../../components/waves/drops/WaveDropReply", () => () => <div />);
+jest.mock("../../components/waves/drops/WaveDropContent", () => (props: any) => (
+  <button data-testid="content" onClick={() => props.setActivePartIndex(0)} />
+));
+jest.mock("../../components/waves/drops/WaveDropActions", () => (props: any) => (
+  <button data-testid="reply" onClick={props.onReply} />
+));
+jest.mock("../../components/waves/drops/WaveDropRatings", () => () => <div />);
+jest.mock("../../components/waves/drops/WaveDropMetadata", () => () => <div data-testid="metadata" />);
+jest.mock("../../components/waves/drops/WaveDropMobileMenu", () => () => <div />);
+jest.mock("../../hooks/isMobileDevice", () => () => false);
+
+describe("DefaultWinnerDrop", () => {
+  const drop: any = { id: "1", rank: 1, wave: { id: "w", name: "wave" }, parts: [{ part_id: 1 }], metadata: [], author: { cic: "g" } };
+
+  it("calls reply handler", async () => {
+    const user = userEvent.setup();
+    const onReply = jest.fn();
+    render(
+      <DefaultWinnerDrop
+        drop={drop}
+        previousDrop={null}
+        nextDrop={null}
+        showWaveInfo={false}
+        activeDrop={null}
+        showReplyAndQuote={true}
+        dropViewDropId={null}
+        location={0 as any}
+        onReply={onReply}
+        onQuote={jest.fn()}
+        onReplyClick={jest.fn()}
+        onQuoteClick={jest.fn()}
+      />
+    );
+    await user.click(screen.getByTestId("reply"));
+    expect(onReply).toHaveBeenCalled();
+  });
+
+  it("renders metadata when provided", () => {
+    const { container } = render(
+      <DefaultWinnerDrop
+        drop={{ ...drop, rank: 1, metadata: [{ data_key: 'k', data_value: 'v' }] }}
+        previousDrop={null}
+        nextDrop={null}
+        showWaveInfo={false}
+        activeDrop={{ drop } as any}
+        showReplyAndQuote={false}
+        dropViewDropId={null}
+        location={0 as any}
+        onReply={jest.fn()}
+        onQuote={jest.fn()}
+        onReplyClick={jest.fn()}
+        onQuoteClick={jest.fn()}
+      />
+    );
+    const meta = container.querySelector('[data-testid="metadata"]');
+    expect(meta).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/GroupCreateIdentitySelectedItems.test.tsx
+++ b/__tests__/components/GroupCreateIdentitySelectedItems.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import GroupCreateIdentitySelectedItems from "../../components/groups/page/create/config/GroupCreateIdentitySelectedItems";
+
+const identities = [
+  { wallet: "1", handle: "alice", pfp: undefined },
+  { wallet: "2", handle: "bob", pfp: "img" },
+];
+
+describe("GroupCreateIdentitySelectedItems", () => {
+  it("renders and removes", async () => {
+    const user = userEvent.setup();
+    const onRemove = jest.fn();
+    render(
+      <GroupCreateIdentitySelectedItems selectedIdentities={identities as any} onRemove={onRemove} />
+    );
+    const buttons = screen.getAllByRole("button");
+    await user.click(buttons[0]);
+    expect(onRemove).toHaveBeenCalledWith("1");
+  });
+});

--- a/__tests__/components/ProfileRatersTableHeader.test.tsx
+++ b/__tests__/components/ProfileRatersTableHeader.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ProfileRatersTableHeader from "../../components/user/utils/raters-table/ProfileRatersTableHeader";
+import { ProfileRatersTableType, ProfileRatersParamsOrderBy } from "../../components/user/utils/raters-table/wrapper/ProfileRatersTableWrapper";
+import { SortDirection } from "../../entities/ISort";
+
+describe("ProfileRatersTableHeader", () => {
+  it("shows correct title based on table type", () => {
+    const { rerender } = render(
+      <table>
+        <ProfileRatersTableHeader
+          type={ProfileRatersTableType.CIC_RECEIVED}
+          sortDirection={SortDirection.ASC}
+          sortOrderBy={ProfileRatersParamsOrderBy.RATING}
+          isLoading={false}
+          onSortTypeClick={jest.fn()}
+        />
+      </table>
+    );
+    expect(screen.getByText("Total NIC")).toBeInTheDocument();
+
+    rerender(
+      <table>
+        <ProfileRatersTableHeader
+          type={ProfileRatersTableType.REP_GIVEN}
+          sortDirection={SortDirection.ASC}
+          sortOrderBy={ProfileRatersParamsOrderBy.RATING}
+          isLoading={false}
+          onSortTypeClick={jest.fn()}
+        />
+      </table>
+    );
+    expect(screen.getByText("Total Rep")).toBeInTheDocument();
+  });
+
+  it("invokes onSortTypeClick when sortable column clicked", async () => {
+    const user = userEvent.setup();
+    const onClick = jest.fn();
+    render(
+      <table>
+        <ProfileRatersTableHeader
+          type={ProfileRatersTableType.CIC_RECEIVED}
+          sortDirection={SortDirection.ASC}
+          sortOrderBy={ProfileRatersParamsOrderBy.RATING}
+          isLoading={false}
+          onSortTypeClick={onClick}
+        />
+      </table>
+    );
+
+    const sortable = screen.getAllByRole("columnheader")[1];
+    await user.click(sortable);
+    expect(onClick).toHaveBeenCalledWith(ProfileRatersParamsOrderBy.RATING);
+  });
+});

--- a/__tests__/components/RevokeDelegationWithSub.test.tsx
+++ b/__tests__/components/RevokeDelegationWithSub.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import RevokeDelegationWithSub from "../../components/delegation/RevokeDelegationWithSub";
+import React from "react";
+
+jest.mock("../../components/delegation/DelegationFormParts", () => ({
+  DelegationCloseButton: (props: any) => <button onClick={props.onHide}>close</button>,
+  DelegationFormLabel: () => <div>label</div>,
+  DelegationAddressDisabledInput: () => <div />,
+  DelegationFormCollectionFormGroup: () => <div />,
+  DelegationFormDelegateAddressFormGroup: () => <div />,
+  DelegationSubmitGroups: (props: any) => (
+    <button data-testid="validate" onClick={() => props.validate()} />
+  ),
+}));
+
+jest.mock("wagmi", () => ({ useEnsName: () => ({ data: null }) }));
+
+jest.mock("../../pages/delegation/[...section]", () => ({
+  __esModule: true,
+  ALL_USE_CASES: [{ use_case: 1, display: "One" }],
+  DelegationCollection: {} as any,
+}));
+
+describe("RevokeDelegationWithSub", () => {
+  it("validates inputs", async () => {
+    const user = userEvent.setup();
+    render(
+      <RevokeDelegationWithSub
+        address="0x1"
+        ens={null}
+        originalDelegator="0x2"
+        collection={{} as any}
+        showAddMore={false}
+        onHide={jest.fn()}
+        onSetToast={jest.fn()}
+      />
+    );
+    await user.click(screen.getByTestId("validate"));
+    // errors due to empty form values
+    expect(screen.queryByTestId("validate")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/WaveDropFollowAuthor.test.tsx
+++ b/__tests__/components/WaveDropFollowAuthor.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import WaveDropFollowAuthor from "../../components/waves/drops/WaveDropFollowAuthor";
+import { AuthContext } from "../../components/auth/Auth";
+import { ReactQueryWrapperContext } from "../../components/react-query-wrapper/ReactQueryWrapper";
+import React from "react";
+
+jest.mock("@tanstack/react-query", () => ({
+  __esModule: true,
+  useMutation: jest.fn(),
+}));
+jest.mock("@tippyjs/react", () => ({ __esModule: true, default: (props: any) => <div>{props.children}</div> }));
+
+jest.mock("../../components/distribution-plan-tool/common/CircleLoader", () => ({ __esModule: true,
+  CircleLoaderSize: { SMALL: "SMALL" },
+  default: () => <div data-testid="loader" />,
+}));
+
+const { useMutation } = jest.requireMock("@tanstack/react-query");
+
+function setup(subscribed: boolean) {
+  const mutateAsyncFollow = jest.fn().mockResolvedValue(undefined);
+  const mutateAsyncUnfollow = jest.fn().mockResolvedValue(undefined);
+  (useMutation as jest.Mock).mockReturnValueOnce({ mutateAsync: mutateAsyncFollow }).mockReturnValueOnce({ mutateAsync: mutateAsyncUnfollow });
+  const requestAuth = jest.fn().mockResolvedValue({ success: true });
+  const invalidateDrops = jest.fn();
+  render(
+    <AuthContext.Provider value={{ setToast: jest.fn(), requestAuth } as any}>
+      <ReactQueryWrapperContext.Provider value={{ invalidateDrops } as any}>
+        <WaveDropFollowAuthor drop={{ author: { id: "1", handle: "bob", subscribed_actions: subscribed ? [1] : [] } } as any} />
+      </ReactQueryWrapperContext.Provider>
+    </AuthContext.Provider>
+  );
+  return { mutateAsyncFollow, mutateAsyncUnfollow, requestAuth, invalidateDrops };
+}
+
+describe("WaveDropFollowAuthor", () => {
+  it("follows when not following", async () => {
+    const user = userEvent.setup();
+    const { mutateAsyncFollow, requestAuth } = setup(false);
+    await user.click(screen.getByRole("button"));
+    expect(requestAuth).toHaveBeenCalled();
+    expect(mutateAsyncFollow).toHaveBeenCalled();
+  });
+
+  it("unfollows when currently following", async () => {
+    const user = userEvent.setup();
+    const { mutateAsyncUnfollow } = setup(true);
+    await user.click(screen.getByRole("button"));
+    expect(mutateAsyncUnfollow).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/WaveDropMetadata.test.tsx
+++ b/__tests__/components/WaveDropMetadata.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import WaveDropMetadata from "../../components/waves/drops/WaveDropMetadata";
+
+jest.mock("../../hooks/isMobileDevice", () => () => false);
+
+describe("WaveDropMetadata", () => {
+  const metadata = [
+    { data_key: "a", data_value: "1" },
+    { data_key: "b", data_value: "2" },
+    { data_key: "c", data_value: "3" },
+  ];
+
+  it("shows show all button and toggles", async () => {
+    const user = userEvent.setup();
+    render(<WaveDropMetadata metadata={metadata as any} />);
+    expect(screen.getByText("Show all")).toBeInTheDocument();
+    await user.click(screen.getByText("Show all"));
+    expect(screen.getByText("Show less")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/WaveGroupRemoveButton.test.tsx
+++ b/__tests__/components/WaveGroupRemoveButton.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import WaveGroupRemoveButton from "../../components/waves/specs/groups/group/edit/WaveGroupRemoveButton";
+import { WaveGroupType } from "../../components/waves/specs/groups/group/WaveGroup";
+import React from "react";
+
+jest.mock("../../components/waves/specs/groups/group/edit/WaveGroupRemove", () =>
+  function MockRemove(props: any) {
+    return (
+      <div data-testid="modal" onClick={() => props.onEdit({})}>
+        remove
+      </div>
+    );
+  }
+);
+
+describe("WaveGroupRemoveButton", () => {
+  it("opens modal and triggers edit", async () => {
+    const user = userEvent.setup();
+    const onEdit = jest.fn().mockResolvedValue(undefined);
+    render(
+      <WaveGroupRemoveButton wave={{} as any} type={WaveGroupType.VIEW} onEdit={onEdit} />
+    );
+    await user.click(screen.getByTitle("Remove"));
+    expect(screen.getByTestId("modal")).toBeInTheDocument();
+    await user.click(screen.getByTestId("modal"));
+    expect(onEdit).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/nextGen/NextGenTokenProperties.test.tsx
+++ b/__tests__/components/nextGen/NextGenTokenProperties.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { displayScore, NextgenRarityToggle } from "../../../components/nextGen/collections/nextgenToken/NextGenTokenProperties";
+
+describe("displayScore", () => {
+  it("formats numbers >= 0.01 with three decimals", () => {
+    expect(displayScore(0.1234)).toBe("0.123");
+  });
+
+  it("formats very small numbers using exponential", () => {
+    expect(displayScore(0.0005)).toBe("5.000e-4");
+  });
+
+  it("formats between 0.001 and 0.01 using precision", () => {
+    expect(displayScore(0.005)).toBe("0.00500");
+  });
+});
+
+describe("NextgenRarityToggle", () => {
+  it("calls setShow when toggled", async () => {
+    const user = userEvent.setup();
+    const setShow = jest.fn();
+    render(<NextgenRarityToggle title="Test" show={false} setShow={setShow} />);
+    const checkbox = screen.getByRole("checkbox");
+    await user.click(checkbox);
+    expect(setShow).toHaveBeenCalledWith(true);
+  });
+
+  it("respects disabled state", () => {
+    render(
+      <NextgenRarityToggle title="Dis" show={true} disabled={true} setShow={jest.fn()} />
+    );
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox).toBeDisabled();
+    const label = screen.getByText("Dis");
+    expect(label.parentElement).toHaveClass("font-color-h");
+  });
+});

--- a/__tests__/services/distribution-plan-api.test.ts
+++ b/__tests__/services/distribution-plan-api.test.ts
@@ -1,0 +1,42 @@
+import { distributionPlanApiFetch, distributionPlanApiPost, distributionPlanApiDelete } from "../../services/distribution-plan-api";
+
+jest.mock("../../services/distribution-plan.utils", () => ({ makeErrorToast: jest.fn() }));
+jest.mock("../../services/auth/auth.utils", () => ({ getAuthJwt: jest.fn(), removeAuthJwt: jest.fn() }));
+
+const { makeErrorToast } = jest.requireMock("../../services/distribution-plan.utils");
+const { getAuthJwt, removeAuthJwt } = jest.requireMock("../../services/auth/auth.utils");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (getAuthJwt as jest.Mock).mockReturnValue(null);
+});
+
+describe("distribution-plan-api", () => {
+  it("handles successful fetch", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ status: 200, json: () => Promise.resolve({ foo: "bar" }) }) as any;
+    const result = await distributionPlanApiFetch<any>("/path");
+    expect(result).toEqual({ success: true, data: { foo: "bar" } });
+  });
+
+  it("handles unauthorized", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ status: 401, json: jest.fn() }) as any;
+    const res = await distributionPlanApiFetch<any>("/x");
+    expect(removeAuthJwt).toHaveBeenCalled();
+    expect(makeErrorToast).toHaveBeenCalledWith("Unauthorized");
+    expect(res.success).toBe(false);
+  });
+
+  it("posts data with auth header", async () => {
+    (getAuthJwt as jest.Mock).mockReturnValue("jwt");
+    global.fetch = jest.fn().mockResolvedValue({ status: 200, json: () => Promise.resolve({ a: 1 }) }) as any;
+    await distributionPlanApiPost<any>({ endpoint: "/p", body: { x: 1 } });
+    const call = (fetch as jest.Mock).mock.calls[0];
+    expect(call[1].headers["Authorization"]).toBe("Bearer jwt");
+  });
+
+  it("deletes and handles plain ok response", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ status: 200, statusText: "OK", json: () => { throw new Error("no json") } }) as any;
+    const res = await distributionPlanApiDelete<any>({ endpoint: "/d" });
+    expect(res).toEqual({ success: true, data: null });
+  });
+});


### PR DESCRIPTION
## Summary
- add test coverage for NextGenTokenProperties utilities
- test profile raters table header behaviour
- cover copy-link logic in chat buttons
- ensure wave group remove button triggers editing
- test follow author drop behaviour
- cover distribution plan API utilities
- validate revoke delegation component
- test wave drop metadata display
- test default winner drop interactions
- test group identity selected items display

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run test`
