### PR TITLE
Add extensive unit tests

### DIFF
--- a/__tests__/components/distribution-plan-tool/FinalizeSnapshotsTable.test.tsx
+++ b/__tests__/components/distribution-plan-tool/FinalizeSnapshotsTable.test.tsx
@@ -50,4 +50,30 @@ describe('FinalizeSnapshotsTable', () => {
     expect(row.snapshot?.name).toBe('Snap1');
     expect(row.requiredTokens).toBe('1,2');
   });
+
+  it('handles empty top holder filter', () => {
+    rows.length = 0;
+    const groupSnapshots = [
+      {
+        groupSnapshotId: 'gs2',
+        snapshotId: 's2',
+        snapshotType: Pool.TOKEN_POOL,
+        snapshotSchema: null,
+        excludeComponentWinners: [],
+        excludeSnapshots: [],
+        topHoldersFilter: { type: null, from: null, to: null },
+        tokenIds: null,
+        uniqueWalletsCount: null,
+      },
+    ];
+    render(
+      <FinalizeSnapshotsTable
+        groupSnapshots={groupSnapshots as any}
+        snapshots={[] as any}
+        phases={[]}
+        onRemoveGroupSnapshot={() => {}}
+      />
+    );
+    expect(rows[0].topHoldersFilter).toBe('');
+  });
 });

--- a/__tests__/components/distribution-plan-tool/create-snapshots/table/CreateSnapshotTableRowDownload.test.tsx
+++ b/__tests__/components/distribution-plan-tool/create-snapshots/table/CreateSnapshotTableRowDownload.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import CreateSnapshotTableRowDownload from '../../../../../components/distribution-plan-tool/create-snapshots/table/CreateSnapshotTableRowDownload';
 import { DistributionPlanToolContext } from '../../../../../components/distribution-plan-tool/DistributionPlanToolContext';
 import { distributionPlanApiFetch } from '../../../../../services/distribution-plan-api';
@@ -24,7 +24,18 @@ describe('CreateSnapshotTableRowDownload', () => {
   it('downloads json when button clicked', async () => {
     const { container } = render(<CreateSnapshotTableRowDownload tokenPoolId="tp1" />, { wrapper: Wrapper });
     const jsonBtn = container.querySelector('button');
-    fireEvent.click(jsonBtn!);
+    await act(async () => {
+      fireEvent.click(jsonBtn!);
+    });
+    expect(distributionPlanApiFetch).toHaveBeenCalled();
+  });
+
+  it('downloads csv when csv button clicked', async () => {
+    const { container } = render(<CreateSnapshotTableRowDownload tokenPoolId="tp1" />, { wrapper: Wrapper });
+    const buttons = container.querySelectorAll('button');
+    await act(async () => {
+      fireEvent.click(buttons[1]);
+    });
     expect(distributionPlanApiFetch).toHaveBeenCalled();
   });
 });

--- a/__tests__/components/latest-activity/LatestActivity.test.tsx
+++ b/__tests__/components/latest-activity/LatestActivity.test.tsx
@@ -29,4 +29,15 @@ describe('LatestActivity', () => {
     await userEvent.click(screen.getByText('Memes'));
     await waitFor(() => expect(fetchUrl).toHaveBeenLastCalledWith('http://api/api/transactions?page_size=10&page=1&contract=0x33FD426905F149f8376e227d0C9D3340AaD17aF1'));
   });
+
+  it('hides View All link on nft-activity page', async () => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { pathname: '/nft-activity' },
+    });
+    render(<LatestActivity page={1} pageSize={10} showMore />);
+    // Wait for fetch
+    await waitFor(() => expect(fetchUrl).toHaveBeenCalled());
+    expect(screen.queryByText('View All')).toBeNull();
+  });
 });

--- a/__tests__/components/waves/create-wave/dates/CreateWaveDates.test.tsx
+++ b/__tests__/components/waves/create-wave/dates/CreateWaveDates.test.tsx
@@ -81,4 +81,11 @@ describe('CreateWaveDates', () => {
     await user.click(screen.getByTestId('decisions'));
     expect(screen.getByTestId('start')).toHaveAttribute('data-expanded', 'false');
   });
+
+  it('updates end date when calculateEndDate differs', () => {
+    const setDates = jest.fn();
+    const dates = { ...baseDates, endDate: 0 };
+    render(<CreateWaveDates waveType={ApiWaveType.Approve} dates={dates} setDates={setDates} />);
+    expect(setDates).toHaveBeenCalledWith({ ...dates, endDate: 123 });
+  });
 });

--- a/__tests__/components/waves/create-wave/dates/DecisionsFirst.test.tsx
+++ b/__tests__/components/waves/create-wave/dates/DecisionsFirst.test.tsx
@@ -32,4 +32,17 @@ describe('DecisionsFirst', () => {
     await user.click(screen.getByText('time'));
     expect(setFirstDecisionTime).toHaveBeenCalledWith(expect.any(Number));
   });
+
+  it('initializes to end of day when minTimestamp provided', async () => {
+    const user = userEvent.setup();
+    const setFirstDecisionTime = jest.fn();
+    const minTs = new Date('2023-01-01T12:00:00Z').getTime();
+    render(
+      <DecisionsFirst firstDecisionTime={0} setFirstDecisionTime={setFirstDecisionTime} minTimestamp={minTs} />
+    );
+    const expected = new Date(minTs);
+    expected.setHours(23, 59, 0, 0);
+    await screen.findByText('calendar'); // wait for render
+    expect(setFirstDecisionTime).toHaveBeenCalledWith(expected.getTime());
+  });
 });

--- a/__tests__/contexts/navigationHistory.test.tsx
+++ b/__tests__/contexts/navigationHistory.test.tsx
@@ -27,4 +27,16 @@ describe('NavigationHistoryContext', () => {
     });
     expect(routerMock.push).toHaveBeenCalledWith('/');
   });
+
+  it('navigates back through stacked views', () => {
+    const { result } = renderHook(() => useNavigationHistoryContext(), { wrapper });
+    act(() => {
+      result.current.pushView('v1' as any);
+      result.current.pushView('v2' as any);
+    });
+    act(() => {
+      result.current.goBack();
+    });
+    expect(hardBack).toHaveBeenCalledWith('v1');
+  });
 });

--- a/__tests__/helpers/SeizeLinkParser.test.ts
+++ b/__tests__/helpers/SeizeLinkParser.test.ts
@@ -26,4 +26,19 @@ describe('parseSeizeQueryLink', () => {
     const res = parseSeizeQueryLink('https://site.com/other?foo=1', '/path', ['foo']);
     expect(res).toBeNull();
   });
+
+  it('returns null when host does not match', () => {
+    const res = parseSeizeQueryLink('https://example.com/path?foo=1', '/path', ['foo']);
+    expect(res).toBeNull();
+  });
+
+  it('respects exact parameter when extra query present', () => {
+    const res = parseSeizeQueryLink(
+      'https://site.com/path?foo=1&bar=2',
+      '/path',
+      ['foo'],
+      true
+    );
+    expect(res).toBeNull();
+  });
 });

--- a/__tests__/helpers/stream.helpers.notifications.test.ts
+++ b/__tests__/helpers/stream.helpers.notifications.test.ts
@@ -18,4 +18,27 @@ describe('prefetchAuthenticatedNotifications', () => {
     await prefetchAuthenticatedNotifications({ queryClient: queryClient as any, headers: {}, context: {} as any });
     expect(queryClient.prefetchInfiniteQuery).not.toHaveBeenCalled();
   });
+
+  it('calls getUserProfile with provided headers', async () => {
+    const queryClient = createClient();
+    const { getUserProfile } = require('../../helpers/server.helpers');
+    await prefetchAuthenticatedNotifications({
+      queryClient: queryClient as any,
+      headers: { Authorization: 'Bearer t' },
+      context: {} as any,
+    });
+    expect(getUserProfile).toHaveBeenCalledWith({ user: 'wallet', headers: { Authorization: 'Bearer t' } });
+  });
+
+  it('does not prefetch when handle missing', async () => {
+    const queryClient = createClient();
+    const helpers = require('../../helpers/server.helpers');
+    helpers.getUserProfile.mockResolvedValueOnce({ handle: null });
+    await prefetchAuthenticatedNotifications({
+      queryClient: queryClient as any,
+      headers: { Authorization: 'Bearer t' },
+      context: {} as any,
+    });
+    expect(queryClient.prefetchInfiniteQuery).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/helpers/stream.helpers.test.ts
+++ b/__tests__/helpers/stream.helpers.test.ts
@@ -18,4 +18,14 @@ describe('prefetchWavesOverview', () => {
     await prefetchWavesOverview({ queryClient: queryClient as any, headers: {}, waveId: null });
     expect(queryClient.prefetchInfiniteQuery).not.toHaveBeenCalled();
   });
+
+  it('skips when Authorization header is malformed', async () => {
+    const queryClient = createClient();
+    await prefetchWavesOverview({
+      queryClient: queryClient as any,
+      headers: { Authorization: 'token' },
+      waveId: null,
+    });
+    expect(queryClient.prefetchInfiniteQuery).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- expand coverage for SeizeLinkParser helpers
- extend stream helpers notification tests
- add invalid auth scenario tests
- test LatestActivity showViewAll toggle
- improve NavigationHistoryContext tests
- add min timestamp test for DecisionsFirst
- verify CreateWaveDates end date update
- cover CSV download flow
- test FinalizeSnapshotsTable edge case

## Testing
- `npx jest __tests__/helpers/SeizeLinkParser.test.ts __tests__/helpers/stream.helpers.notifications.test.ts __tests__/helpers/stream.helpers.test.ts __tests__/components/latest-activity/LatestActivity.test.tsx __tests__/contexts/navigationHistory.test.tsx __tests__/components/waves/create-wave/dates/DecisionsFirst.test.tsx __tests__/components/waves/create-wave/dates/CreateWaveDates.test.tsx __tests__/components/distribution-plan-tool/create-snapshots/table/CreateSnapshotTableRowDownload.test.tsx __tests__/components/distribution-plan-tool/FinalizeSnapshotsTable.test.tsx --runInBand`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_683eb322b49c8330980ea497670a47c5