### PR TITLE
Fix DropHasher test import path

### DIFF
--- a/__tests__/utils/drop-hasher.test.ts
+++ b/__tests__/utils/drop-hasher.test.ts
@@ -1,4 +1,4 @@
-import { DropHasher } from '../..//utils/drop-hasher';
+import { DropHasher } from '../../utils/drop-hasher';
 import { sha256 } from 'js-sha256';
 
 describe('DropHasher', () => {


### PR DESCRIPTION
## Summary
- correct DropHasher import path in tests

## Testing
- `npm run test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e10ac5688333a0abd6dc76d1c1b1