### PR TITLE
Fix typo in styles comment

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -14,7 +14,7 @@
   }
 }
 
-// add the code bellow
+// add the code below
 @layer utilities {
   /* Hide scrollbar for Chrome, Safari and Opera */
   .no-scrollbar::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- fix a misspelled comment in `globals.scss`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test` *(fails: `jest` not found)*
- `npm run type-check` *(execution stalled / no output)*


------
https://chatgpt.com/codex/tasks/task_e_6847e1948308833399abe17aa4668dd5