### PR TITLE
Fix about page tests for new app router

### DIFF
--- a/__tests__/app/about/media/index.test.tsx
+++ b/__tests__/app/about/media/index.test.tsx
@@ -1,24 +1,25 @@
 import React from 'react';
+/* eslint-disable react/display-name */
 import { render, screen } from '@testing-library/react';
-import PressPage from '../../../../pages/about/press/index';
+import MediaPage from '@/app/about/media/page';
 
-jest.mock('../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
-jest.mock('../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+jest.mock('@/components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('@/components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
 
-describe('PressPage', () => {
-  const renderComponent = () => render(<PressPage />);
+describe('MediaPage', () => {
+  const renderComponent = () => render(<MediaPage />);
 
   it('renders the page title', () => {
     renderComponent();
     const title = document.querySelector('title');
-    expect(title?.textContent).toBe('PRESS - 6529.io');
+    expect(title?.textContent).toBe('MEDIA CENTER - 6529.io');
   });
 
   it('includes canonical link', () => {
     renderComponent();
     const canonical = document.querySelector('link[rel="canonical"]');
     expect(canonical).toBeInTheDocument();
-    expect(canonical?.getAttribute('href')).toBe('/about/press/');
+    expect(canonical?.getAttribute('href')).toBe('/about/media/');
   });
 
   it('includes robots meta tag', () => {
@@ -30,7 +31,7 @@ describe('PressPage', () => {
   it('includes Open Graph title', () => {
     renderComponent();
     const ogTitle = document.querySelector('meta[property="og:title"]');
-    expect(ogTitle?.getAttribute('content')).toBe('PRESS - 6529.io');
+    expect(ogTitle?.getAttribute('content')).toBe('MEDIA CENTER - 6529.io');
   });
 
   it('has skip to content link', () => {

--- a/__tests__/app/about/mission/index.test.tsx
+++ b/__tests__/app/about/mission/index.test.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
+/* eslint-disable react/display-name */
 import { render, screen } from '@testing-library/react';
-import MissionPage from '../../../../pages/about/mission/index';
+import MissionPage from '@/app/about/mission/page';
 
 // Mock the Header component since it's dynamically imported
-jest.mock('../../../../components/header/Header', () => {
+jest.mock('@/components/header/Header', () => {
   return function MockHeader() {
     return <div data-testid="header">Header</div>;
   };
 });
 
 // Mock HeaderPlaceholder
-jest.mock('../../../../components/header/HeaderPlaceholder', () => {
+jest.mock('@/components/header/HeaderPlaceholder', () => {
   return function MockHeaderPlaceholder() {
     return <div data-testid="header-placeholder">Header Placeholder</div>;
   };

--- a/__tests__/app/about/press/index.test.tsx
+++ b/__tests__/app/about/press/index.test.tsx
@@ -1,24 +1,25 @@
 import React from 'react';
+/* eslint-disable react/display-name */
 import { render, screen } from '@testing-library/react';
-import MediaPage from '../../../../pages/about/media/index';
+import PressPage from '@/app/about/press/page';
 
-jest.mock('../../../../components/header/Header', () => () => <div data-testid="header">Header</div>);
-jest.mock('../../../../components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
+jest.mock('@/components/header/Header', () => () => <div data-testid="header">Header</div>);
+jest.mock('@/components/header/HeaderPlaceholder', () => () => <div data-testid="header-placeholder">Header Placeholder</div>);
 
-describe('MediaPage', () => {
-  const renderComponent = () => render(<MediaPage />);
+describe('PressPage', () => {
+  const renderComponent = () => render(<PressPage />);
 
   it('renders the page title', () => {
     renderComponent();
     const title = document.querySelector('title');
-    expect(title?.textContent).toBe('MEDIA CENTER - 6529.io');
+    expect(title?.textContent).toBe('PRESS - 6529.io');
   });
 
   it('includes canonical link', () => {
     renderComponent();
     const canonical = document.querySelector('link[rel="canonical"]');
     expect(canonical).toBeInTheDocument();
-    expect(canonical?.getAttribute('href')).toBe('/about/media/');
+    expect(canonical?.getAttribute('href')).toBe('/about/press/');
   });
 
   it('includes robots meta tag', () => {
@@ -30,7 +31,7 @@ describe('MediaPage', () => {
   it('includes Open Graph title', () => {
     renderComponent();
     const ogTitle = document.querySelector('meta[property="og:title"]');
-    expect(ogTitle?.getAttribute('content')).toBe('MEDIA CENTER - 6529.io');
+    expect(ogTitle?.getAttribute('content')).toBe('PRESS - 6529.io');
   });
 
   it('has skip to content link', () => {

--- a/__tests__/app/about/section.menu.test.tsx
+++ b/__tests__/app/about/section.menu.test.tsx
@@ -1,12 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { AuthContext } from '../../../components/auth/Auth';
+import { AuthContext } from '@/components/auth/Auth';
+/* eslint-disable react/display-name */
+import AboutPage from '@/app/about/[section]/page';
+import { AboutSection } from '@/enums';
 jest.mock('next/router', () => ({ useRouter: () => ({ asPath: '/', push: jest.fn() }) }));
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn() }) }));
 
-jest.mock('../../../hooks/useCapacitor', () => ({ __esModule: true, default: () => ({ isIos: true }) }));
+jest.mock('@/hooks/useCapacitor', () => ({ __esModule: true, default: () => ({ isIos: true }) }));
 
 let country = 'DE';
-jest.mock('../../../components/cookies/CookieConsentContext', () => ({ useCookieConsent: () => ({ country }) }));
+jest.mock('@/components/cookies/CookieConsentContext', () => ({ useCookieConsent: () => ({ country }) }));
 
 const setTitle = jest.fn();
 const Wrapper: React.FC<{children: React.ReactNode}> = ({ children }) => (
@@ -15,7 +19,7 @@ const Wrapper: React.FC<{children: React.ReactNode}> = ({ children }) => (
 
 
 // Mock TitleContext
-jest.mock('../../../contexts/TitleContext', () => ({
+jest.mock('@/contexts/TitleContext', () => ({
   useTitle: () => ({
     title: 'Test Title',
     setTitle: jest.fn(),
@@ -32,19 +36,24 @@ jest.mock('../../../contexts/TitleContext', () => ({
 }));
 
 describe('AboutMenu subscriptions row', () => {
-  beforeEach(() => { country = 'DE'; });
-  it('hides subscriptions row when not US', () => {
-    const AboutModule = require('../../../pages/about/[section]');
-    const Comp = AboutModule.default;
-    render(<Comp pageProps={{ section: AboutModule.AboutSection.MEMES, sectionTitle: 'THE MEMES' }} />, { wrapper: Wrapper });
+  beforeEach(() => {
+    country = 'DE';
+  });
+
+  it('hides subscriptions row when not US', async () => {
+    const element = await AboutPage({
+      params: Promise.resolve({ section: AboutSection.MEMES }),
+    } as any);
+    render(element, { wrapper: Wrapper });
     expect(screen.queryByText('Subscriptions')).toBeNull();
   });
 
-  it('shows subscriptions row in US', () => {
+  it('shows subscriptions row in US', async () => {
     country = 'US';
-    const AboutModule = require('../../../pages/about/[section]');
-    const Comp = AboutModule.default;
-    render(<Comp pageProps={{ section: AboutModule.AboutSection.MEMES, sectionTitle: 'THE MEMES' }} />, { wrapper: Wrapper });
+    const element = await AboutPage({
+      params: Promise.resolve({ section: AboutSection.MEMES }),
+    } as any);
+    render(element, { wrapper: Wrapper });
     expect(screen.getAllByText('Subscriptions').length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary
- migrate about path tests to `app/` folder
- adjust imports and mocks for new app router

## Testing
- `npm run lint`
- `npm run type-check`
- `npx jest __tests__/app/about/section.menu.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68628c05c8788333930a881f03f74dd0