### PR TITLE
refactor: remove wallet cookie migration

### DIFF
--- a/__tests__/components/auth/SeizeConnectContext.test.tsx
+++ b/__tests__/components/auth/SeizeConnectContext.test.tsx
@@ -41,7 +41,6 @@ jest.mock('viem', () => ({
 
 // Mock auth utils
 jest.mock('../../../services/auth/auth.utils', () => ({
-  migrateCookiesToLocalStorage: jest.fn(),
   getWalletAddress: jest.fn(() => null),
   removeAuthJwt: jest.fn(),
 }));

--- a/__tests__/components/header/share/HeaderShare.test.tsx
+++ b/__tests__/components/header/share/HeaderShare.test.tsx
@@ -105,14 +105,12 @@ const mockAuthUtils = {
   getRefreshToken: jest.fn(() => null),
   getWalletAddress: jest.fn(() => null),
   getWalletRole: jest.fn(() => null),
-  migrateCookiesToLocalStorage: jest.fn(),
   removeAuthJwt: jest.fn()
 };
 
 require("../../../../services/auth/auth.utils").getRefreshToken = mockAuthUtils.getRefreshToken;
 require("../../../../services/auth/auth.utils").getWalletAddress = mockAuthUtils.getWalletAddress;
 require("../../../../services/auth/auth.utils").getWalletRole = mockAuthUtils.getWalletRole;
-require("../../../../services/auth/auth.utils").migrateCookiesToLocalStorage = mockAuthUtils.migrateCookiesToLocalStorage;
 require("../../../../services/auth/auth.utils").removeAuthJwt = mockAuthUtils.removeAuthJwt;
 
 const mockUseCapacitor = useCapacitor as jest.MockedFunction<

--- a/__tests__/services/auth.utils.test.ts
+++ b/__tests__/services/auth.utils.test.ts
@@ -1,4 +1,4 @@
-import { setAuthJwt, getAuthJwt, getStagingAuth, removeAuthJwt, migrateCookiesToLocalStorage, getWalletAddress } from '../../services/auth/auth.utils';
+import { setAuthJwt, getAuthJwt, getStagingAuth, removeAuthJwt, getWalletAddress } from '../../services/auth/auth.utils';
 import Cookies from 'js-cookie';
 import { safeLocalStorage } from '../../helpers/safeLocalStorage';
 import { jwtDecode } from 'jwt-decode';
@@ -39,20 +39,6 @@ describe('auth.utils', () => {
     (Cookies.get as jest.Mock).mockReturnValueOnce(undefined);
     process.env.STAGING_API_KEY = 'e';
     expect(getStagingAuth()).toBe('e');
-  });
-
-  it('migrateCookiesToLocalStorage moves and removes cookies', () => {
-    (Cookies.get as jest.Mock)
-      .mockReturnValueOnce('addr')
-      .mockReturnValueOnce('refresh')
-      .mockReturnValueOnce('role');
-    migrateCookiesToLocalStorage();
-    expect(safeLocalStorage.setItem).toHaveBeenCalledWith('6529-wallet-address', 'addr');
-    expect(Cookies.remove).toHaveBeenCalledWith('wallet-address');
-    expect(safeLocalStorage.setItem).toHaveBeenCalledWith('6529-wallet-refresh-token', 'refresh');
-    expect(Cookies.remove).toHaveBeenCalledWith('wallet-refresh-token');
-    expect(safeLocalStorage.setItem).toHaveBeenCalledWith('6529-wallet-role', 'role');
-    expect(Cookies.remove).toHaveBeenCalledWith('wallet-role');
   });
 
   it('getWalletAddress respects dev mode and storage', () => {

--- a/components/auth/SeizeConnectContext.tsx
+++ b/components/auth/SeizeConnectContext.tsx
@@ -10,11 +10,7 @@ import React, {
   useRef,
 } from "react";
 
-import {
-  migrateCookiesToLocalStorage,
-  getWalletAddress,
-  removeAuthJwt,
-} from "../../services/auth/auth.utils";
+import { getWalletAddress, removeAuthJwt } from "../../services/auth/auth.utils";
 import { WalletInitializationError } from "../../src/errors/wallet";
 import { useAppKit, useAppKitAccount, useAppKitState, useDisconnect } from "@reown/appkit/react";
 import { isAddress, getAddress } from "viem";
@@ -341,10 +337,6 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     isInitialized
   } = useConsolidatedWalletState();
   const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-  useEffect(() => {
-    migrateCookiesToLocalStorage();
-  }, []);
 
   useEffect(() => {
     // Wait for initialization to complete before processing account changes

--- a/services/auth/auth.utils.ts
+++ b/services/auth/auth.utils.ts
@@ -5,11 +5,6 @@ import { API_AUTH_COOKIE } from "../../constants";
 
 export const WALLET_AUTH_COOKIE = "wallet-auth";
 
-// TODO: remove these cookies once migration is complete
-const WALLET_ADDRESS_COOKIE = "wallet-address";
-const WALLET_REFRESH_TOKEN_COOKIE = "wallet-refresh-token";
-const WALLET_ROLE_COOKIE = "wallet-role";
-
 const WALLET_ADDRESS_STORAGE_KEY = "6529-wallet-address";
 const WALLET_REFRESH_TOKEN_STORAGE_KEY = "6529-wallet-refresh-token";
 const WALLET_ROLE_STORAGE_KEY = "6529-wallet-role";
@@ -24,29 +19,6 @@ const getJwtExpiration = (jwt: string): number => {
     exp: number;
   }>(jwt);
   return decodedJwt.exp;
-};
-
-// TODO: remove these cookies once migration is complete
-export const migrateCookiesToLocalStorage = () => {
-  const walletAddress = Cookies.get(WALLET_ADDRESS_COOKIE);
-  const walletRefreshToken = Cookies.get(WALLET_REFRESH_TOKEN_COOKIE);
-  const walletRole = Cookies.get(WALLET_ROLE_COOKIE);
-
-  if (walletAddress) {
-    safeLocalStorage.setItem(WALLET_ADDRESS_STORAGE_KEY, walletAddress);
-    Cookies.remove(WALLET_ADDRESS_COOKIE);
-  }
-  if (walletRefreshToken) {
-    safeLocalStorage.setItem(
-      WALLET_REFRESH_TOKEN_STORAGE_KEY,
-      walletRefreshToken
-    );
-    Cookies.remove(WALLET_REFRESH_TOKEN_COOKIE);
-  }
-  if (walletRole) {
-    safeLocalStorage.setItem(WALLET_ROLE_STORAGE_KEY, walletRole);
-    Cookies.remove(WALLET_ROLE_COOKIE);
-  }
 };
 
 export const setAuthJwt = (


### PR DESCRIPTION
## Summary
- remove legacy wallet cookie constants and migration logic so auth utilities rely solely on localStorage
- stop SeizeConnectContext from invoking the deleted cookie migration
- align auth and header tests with the localStorage-only implementation

## Testing
- npm run lint
- BASE_ENDPOINT=http://localhost npx jest --runTestsByPath ./__tests__/services/auth.utils.test.ts ./__tests__/components/auth/SeizeConnectContext.test.tsx ./__tests__/components/header/share/HeaderShare.test.tsx --coverage=false --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c94027e0a08321a409134b4800e968