### PR TITLE
PRXT - fix: add primary error callback to fallback image

### DIFF
--- a/__tests__/components/common/FallbackImage.test.tsx
+++ b/__tests__/components/common/FallbackImage.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import { FallbackImage } from '../../../components/common/FallbackImage';
+
+describe('FallbackImage', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('falls back without logging to the console', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    const onPrimaryError = jest.fn();
+
+    render(
+      <FallbackImage
+        primarySrc="primary.gif"
+        fallbackSrc="fallback.gif"
+        alt="fallback example"
+        onPrimaryError={onPrimaryError}
+      />
+    );
+
+    const image = screen.getByRole('img', { name: 'fallback example' });
+    expect(image.getAttribute('src')).toBe('primary.gif');
+
+    fireEvent.error(image);
+
+    await waitFor(() => {
+      expect(image.getAttribute('src')).toBe('fallback.gif');
+    });
+
+    expect(onPrimaryError).toHaveBeenCalledTimes(1);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});
+

--- a/components/common/FallbackImage.tsx
+++ b/components/common/FallbackImage.tsx
@@ -3,12 +3,13 @@
 import React from "react";
 
 type FallbackImageProps = React.ImgHTMLAttributes<HTMLImageElement> & {
-  primarySrc: string;   // try first (your downscaled gif)
-  fallbackSrc: string;  // use if primary fails (your original gif)
+  primarySrc: string; // try first (your downscaled gif)
+  fallbackSrc: string; // use if primary fails (your original gif)
+  onPrimaryError?: (event: React.SyntheticEvent<HTMLImageElement, Event>) => void;
 };
 
 export const FallbackImage = React.forwardRef<HTMLImageElement, FallbackImageProps>(
-  ({ primarySrc, fallbackSrc, alt = "", onError, ...rest }, ref) => {
+  ({ primarySrc, fallbackSrc, alt = "", onError, onPrimaryError, ...rest }, ref) => {
     const [src, setSrc] = React.useState(primarySrc);
     const [usedFallback, setUsedFallback] = React.useState(false);
 
@@ -20,7 +21,7 @@ export const FallbackImage = React.forwardRef<HTMLImageElement, FallbackImagePro
 
     const handleError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
       if (!usedFallback) {
-        console.log(`[FallbackImage] Primary failed: ${primarySrc}, falling back to: ${fallbackSrc}`);
+        onPrimaryError?.(e);
         setSrc(fallbackSrc);
         setUsedFallback(true);
       } else {


### PR DESCRIPTION
## Summary
- replace the FallbackImage console.log with a new optional `onPrimaryError` callback so consumers can react when the primary source fails without emitting console output
- ensure the component keeps working by resetting state on source changes and guard the fallback branch via the callback
- add a Jest test that confirms the component swaps to the fallback image and triggers the callback without logging to the console

## Testing
- BASE_ENDPOINT=https://www.6529.io npx jest __tests__/components/common/FallbackImage.test.tsx --runInBand --coverage=false
- npm run lint *(fails: repository already has numerous pre-existing lint warnings)*
- npm run type-check *(fails: repository already has many pre-existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c93fea8f008321887699a6795f3e0b