### PR TITLE
PRXT - fix: allow pinch zoom in app viewport

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,8 +21,6 @@ export const metadata = getAppMetadata();
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
   viewportFit: "cover",
 };
 


### PR DESCRIPTION
## Summary
- remove the maximumScale and userScalable restrictions from the global viewport configuration to re-enable pinch zoom support
- verified the home page in a mobile viewport, noting that the runtime currently blocks loading without the BASE_ENDPOINT environment variable

## Testing
- `npm run test` *(fails: requires BASE_ENDPOINT and other app-specific environment variables)*
- `npm run lint`
- `npm run type-check` *(fails: existing typing issues across numerous test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c940f295288321b7ce3207567c57da