### PR TITLE
SIMO feat: add websocket heartbeat keepalive

### DIFF
--- a/helpers/Types.tsx
+++ b/helpers/Types.tsx
@@ -326,6 +326,7 @@ export enum WsMessageType {
   DROP_REACTION_UPDATE = "DROP_REACTION_UPDATE",
   USER_IS_TYPING = "USER_IS_TYPING",
   SUBSCRIBE_TO_WAVE = "SUBSCRIBE_TO_WAVE",
+  PING = "PING",
 }
 
 export interface WsTypingMessage {


### PR DESCRIPTION
## Summary
- add heartbeat timers and last-pong tracking to close stale sockets and send periodic pings
- extend `WsMessageType` with a `PING` entry so the provider can issue keepalive messages

## Testing
- `npm run lint`
- `npx jest __tests__/services/websocket/WebSocketProvider.test.tsx --runInBand --coverage=false`
- `npm run type-check` *(fails due to numerous existing type errors in test fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68c940c1b8c883219ef20901a985af70