### PR TITLE
PRXT - fix: add accessible label to header search

### DIFF
--- a/__tests__/components/header/HeaderSearchModal.test.tsx
+++ b/__tests__/components/header/HeaderSearchModal.test.tsx
@@ -80,6 +80,15 @@ describe("HeaderSearchModal", () => {
     jest.clearAllMocks();
   });
 
+  it("associates the search input with an accessible label", () => {
+    setup();
+    expect(
+      screen.getByRole("textbox", {
+        name: "Search",
+      })
+    ).toBeInTheDocument();
+  });
+
   it("calls onClose when escape is pressed", () => {
     const { onClose } = setup();
     escapeCb();
@@ -88,7 +97,7 @@ describe("HeaderSearchModal", () => {
 
   it("renders search results when query returns items", () => {
     setup();
-    const input = screen.getByRole("textbox");
+    const input = screen.getByRole("textbox", { name: "Search" });
     fireEvent.change(input, { target: { value: "abc" } });
     expect(screen.getByTestId("item")).toBeInTheDocument();
   });
@@ -101,7 +110,7 @@ describe("HeaderSearchModal", () => {
 
   it("navigates on enter key", () => {
     const { push } = setup();
-    const input = screen.getByRole("textbox");
+    const input = screen.getByRole("textbox", { name: "Search" });
     fireEvent.change(input, { target: { value: "alice" } });
     enterCb();
     expect(push).toHaveBeenCalled();

--- a/components/header/header-search/HeaderSearchModal.tsx
+++ b/components/header/header-search/HeaderSearchModal.tsx
@@ -283,8 +283,12 @@ export default function HeaderSearchModal({
                     clipRule="evenodd"
                   />
                 </svg>
+                <label className="tw-sr-only" htmlFor="header-search-input">
+                  Search
+                </label>
                 <input
                   ref={inputRef}
+                  id="header-search-input"
                   type="text"
                   required
                   autoComplete="off"


### PR DESCRIPTION
## Summary
- add a visually hidden label for the header search input to keep the accessible name in sync with the placeholder
- update the HeaderSearchModal tests to cover the accessible label and use the labelled query helpers

## Testing
- CI=1 npm run test -- --runTestsByPath __tests__/components/header/HeaderSearchModal.test.tsx
- npm run lint
- npm run type-check *(fails due to pre-existing type errors in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c941044f1c8321b9051d7b2cf7f6cd