### PR TITLE
feat: add jitter to websocket reconnect delay

### DIFF
--- a/services/websocket/WebSocketProvider.tsx
+++ b/services/websocket/WebSocketProvider.tsx
@@ -27,16 +27,22 @@ const MAX_RECONNECT_DELAY = 30000; // Max 30 seconds
 const DEFAULT_MAX_RECONNECT_ATTEMPTS = 20; // Try up to 20 times before giving up
 
 /**
- * Calculate delay for exponential backoff
+ * Calculate delay for exponential backoff with jitter.
+ *
+ * Applies a random multiplier between 0.5x and 1.5x to stagger reconnect
+ * attempts while still respecting the configured maximum delay.
  */
-function calculateReconnectDelay(
+export function calculateReconnectDelay(
   attempt: number,
   initialDelay: number,
   maxDelay: number
 ): number {
-  // Exponential backoff formula: initialDelay * 2^attempt (capped at maxDelay)
-  const delay = initialDelay * Math.pow(1.5, attempt);
-  return Math.min(delay, maxDelay);
+  // Exponential backoff formula: initialDelay * 1.5^attempt (capped at maxDelay)
+  const exponentialDelay = initialDelay * Math.pow(1.5, attempt);
+  const jitterFactor = 0.5 + Math.random();
+  const jitteredDelay = exponentialDelay * jitterFactor;
+
+  return Math.min(jitteredDelay, maxDelay);
 }
 
 /**


### PR DESCRIPTION
## Summary
- add jitter to WebSocket reconnect delays and document the randomized backoff behaviour
- export calculateReconnectDelay for reuse and cover jitter boundaries in unit tests
- stabilize provider tests by mocking Math.random for deterministic scheduling

## Testing
- `npm run test` *(fails: existing HeaderNavConfig expectation requires NFT Delegation section hasDivider to be true)*
- `npm run lint`
- `npm run type-check` *(fails: existing TypeScript errors in numerous legacy tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c940c85674832181b5191b822a87a5