### PR TITLE
SIMO fix: support additional twitter urls

### DIFF
--- a/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
+++ b/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
@@ -26,6 +26,36 @@ describe("DropPartMarkdown", () => {
     );
   });
 
+  it.each([
+    [
+      "standard status link with query params",
+      "https://twitter.com/test/status/1234567890?s=20&t=abc",
+      "1234567890",
+    ],
+    [
+      "i/web status link",
+      "https://twitter.com/i/web/status/9876543210",
+      "9876543210",
+    ],
+    [
+      "mobile subdomain link",
+      "https://mobile.twitter.com/test/status/1122334455",
+      "1122334455",
+    ],
+  ])("renders tweet embeds for %s", (_, url, expectedId) => {
+    const content = `[tweet](${url})`;
+    render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        referencedNfts={[]}
+        partContent={content}
+        onQuoteClick={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText(`tweet:${expectedId}`)).toBeInTheDocument();
+  });
+
   it("handles external links", () => {
     process.env.BASE_ENDPOINT = "https://example.com";
     const content = "[link](https://google.com)";


### PR DESCRIPTION
## Summary
- update the DropPartMarkdown Twitter parser to use the URL API and recognise mobile and i/web tweet URLs (including query strings)
- extend DropPartMarkdown tests to cover the new Twitter URL formats

## Testing
- npx jest __tests__/components/drops/view/part/DropPartMarkdown.test.tsx --runTestsByPath --coverage=false --watchAll=false
- npm run lint
- npm run type-check *(fails: pre-existing type errors in unrelated test fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68c9404ffecc8321bc8eb875e4bbcea4