### PR TITLE
PRXT - fix: improve not found navigation

### DIFF
--- a/components/not-found/NotFound.tsx
+++ b/components/not-found/NotFound.tsx
@@ -1,11 +1,18 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { useTitle } from "@/contexts/TitleContext";
 
 export default function NotFound() {
   const { setTitle } = useTitle();
+  const router = useRouter();
+
+  const handleGoBack = () => {
+    router.back();
+  };
   useEffect(() => {
     setTitle("404 - NOT FOUND");
   }, []);
@@ -28,9 +35,16 @@ export default function NotFound() {
           className="tw-ml-0.5 tw-w-8 tw-h-8"
         />
       </div>
-      <a href="/" className="tw-mt-4 tw-text-md tw-font-semibold">
+      <Link href="/" className="tw-mt-4 tw-text-md tw-font-semibold">
         TAKE ME HOME
-      </a>
+      </Link>
+      <button
+        type="button"
+        onClick={handleGoBack}
+        className="tw-mt-2 tw-text-md tw-font-semibold"
+      >
+        BACK TO PREVIOUS PAGE
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- switch the not-found component to use Next.js `Link` and add a router-powered back button for smoother navigation
- extend the NotFound page test suite with a mocked router to cover the updated navigation options

## Testing
- npm run lint
- BASE_ENDPOINT=https://www.6529.io npm run test -- --runTestsByPath __tests__/moreStaticPages.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c940facd808321ba14362835d7a124