### PR TITLE
fix: improve GroupCard accessibility

### DIFF
--- a/__tests__/components/groups/page/list/card/GroupCard.test.tsx
+++ b/__tests__/components/groups/page/list/card/GroupCard.test.tsx
@@ -30,6 +30,10 @@ jest.mock(
 const push = jest.fn();
 (useRouter as jest.Mock).mockReturnValue({ push });
 
+beforeEach(() => {
+  push.mockClear();
+});
+
 describe("GroupCard", () => {
   const group: any = {
     id: "g1",
@@ -61,8 +65,20 @@ describe("GroupCard", () => {
   }
 
   it("navigates to community view when idle", () => {
-    renderComp();
-    fireEvent.click(document.querySelector("div.tw-col-span-1")!);
+    const { getByRole } = renderComp();
+    fireEvent.click(getByRole("button"));
+    expect(push).toHaveBeenCalledWith(`/network?page=1&group=${group.id}`);
+  });
+
+  it("navigates to community view when pressing Enter", () => {
+    const { getByRole } = renderComp();
+    fireEvent.keyDown(getByRole("button"), { key: "Enter" });
+    expect(push).toHaveBeenCalledWith(`/network?page=1&group=${group.id}`);
+  });
+
+  it("navigates to community view when pressing Space", () => {
+    const { getByRole } = renderComp();
+    fireEvent.keyDown(getByRole("button"), { key: " " });
     expect(push).toHaveBeenCalledWith(`/network?page=1&group=${group.id}`);
   });
 

--- a/components/groups/page/list/card/GroupCard.tsx
+++ b/components/groups/page/list/card/GroupCard.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useContext, useEffect, useState, type JSX } from "react";
+import {
+  useContext,
+  useEffect,
+  useState,
+  type JSX,
+  type KeyboardEvent,
+} from "react";
 import { ApiGroupFull } from "@/generated/models/ApiGroupFull";
 import { getRandomColorWithSeed } from "@/helpers/Helpers";
 import GroupCardView from "./GroupCardView";
@@ -110,12 +116,25 @@ export default function GroupCard({
     router.push(`/network?page=1&group=${group?.id}`);
   };
 
+  const onCardKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      goToCommunityView();
+    }
+  };
+
+  const isIdle = state === GroupCardState.IDLE;
+
   return (
     <div
+      role="button"
+      tabIndex={isIdle ? 0 : -1}
+      aria-disabled={!isIdle}
       className={`${
-        state === GroupCardState.IDLE && "tw-group tw-cursor-pointer"
+        isIdle && "tw-group tw-cursor-pointer"
       } tw-col-span-1`}
-      onClick={goToCommunityView}>
+      onClick={goToCommunityView}
+      onKeyDown={onCardKeyDown}>
       <div
         className="tw-relative tw-w-full tw-h-9 tw-rounded-t-2xl"
         style={{


### PR DESCRIPTION
## Summary
- add keyboard and ARIA semantics to the GroupCard wrapper so the card is focusable and responds to keyboard activation
- update GroupCard unit tests to exercise keyboard interaction and reset router mocks between runs

## Testing
- npm run lint
- npm run type-check *(fails: existing TypeScript errors in unrelated test files)*
- npm run test *(fails: BASE_ENDPOINT env var required by unrelated suites)*
- BASE_ENDPOINT=https://example.com npm run test *(fails: BASE_ENDPOINT env var still required during suite startup)*

------
https://chatgpt.com/codex/tasks/task_e_68c942bfb4048321b152603f10636751