### PR TITLE
SIMO fix: improve pagination accessibility

### DIFF
--- a/__tests__/components/pagination/Pagination.test.tsx
+++ b/__tests__/components/pagination/Pagination.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Pagination from '@/components/pagination/Pagination';
+
+describe('Pagination', () => {
+  it('advances to the next page when activated with the Enter key', async () => {
+    const setPage = jest.fn();
+    const user = userEvent.setup();
+
+    render(<Pagination page={1} pageSize={10} totalResults={30} setPage={setPage} />);
+
+    const nextButton = screen.getByRole('button', { name: /next page/i });
+    nextButton.focus();
+    expect(nextButton).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+
+    expect(setPage).toHaveBeenCalledTimes(1);
+    expect(setPage).toHaveBeenCalledWith(2);
+  });
+
+  it('returns to the previous page when activated with the Space key', async () => {
+    const setPage = jest.fn();
+    const user = userEvent.setup();
+
+    render(<Pagination page={2} pageSize={10} totalResults={30} setPage={setPage} />);
+
+    const previousButton = screen.getByRole('button', { name: /previous page/i });
+    previousButton.focus();
+    expect(previousButton).toHaveFocus();
+
+    await user.keyboard(' ');
+
+    expect(setPage).toHaveBeenCalledTimes(1);
+    expect(setPage).toHaveBeenCalledWith(1);
+  });
+});

--- a/components/pagination/Pagination.module.scss
+++ b/components/pagination/Pagination.module.scss
@@ -1,21 +1,48 @@
 @use 'sass:color';
 @use "../../styles/variables.scss";
 
-.iconEnabled {
+.iconButton {
+  border: none;
+  background: transparent;
+  color: inherit;
+  padding: 0;
   width: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font: inherit;
+
+  &:disabled {
+    cursor: default;
+  }
+}
+
+.iconEnabled {
   cursor: pointer;
 }
 
 .iconDisabled {
-  width: 14px;
   opacity: 0.6;
+  cursor: default;
 }
 
 .goToLast {
+  border: none;
+  background: transparent;
+  color: inherit;
+  padding: 0;
   cursor: pointer;
+  font: inherit;
+
   &:hover {
     text-decoration: underline;
     color: color.scale(variables.$font-color, $lightness: -(variables.$darken-percentage));
+  }
+
+  &:disabled {
+    cursor: default;
+    text-decoration: none;
+    color: inherit;
   }
 }
 

--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -3,7 +3,7 @@
 import { faCaretLeft, faCaretRight } from "@fortawesome/free-solid-svg-icons";
 import styles from "./Pagination.module.scss";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useEffect, useState } from "react";
+import { type ChangeEvent, type KeyboardEvent, useEffect, useState } from "react";
 
 interface Props {
   page: number;
@@ -53,7 +53,7 @@ export default function Pagination(props: Readonly<Props>) {
     return props.page >= getLastPage();
   }
 
-  function enterValue(event: any) {
+  function enterValue(event: KeyboardEvent<HTMLInputElement>) {
     if (event.key === "Enter") {
       const newValue = parseInt(inputPage);
       if (!isNaN(newValue) && newValue >= 1 && newValue <= getLastPage()) {
@@ -64,7 +64,7 @@ export default function Pagination(props: Readonly<Props>) {
     }
   }
 
-  function setValue(event: any) {
+  function setValue(event: ChangeEvent<HTMLInputElement>) {
     const newValue = event.target.value;
     setInputPage(newValue);
   }
@@ -73,18 +73,16 @@ export default function Pagination(props: Readonly<Props>) {
     <>
       {props.totalResults > props.pageSize && (
         <span>
-          <FontAwesomeIcon
-            icon={faCaretLeft}
+          <button
+            type="button"
             onClick={pagePrevious}
-            className={
-              props.page > 1
-                ? `${styles.iconEnabled}`
-                : `${styles.iconDisabled}`
-            }
-            role="button"
+            className={`${styles.iconButton} ${
+              props.page > 1 ? styles.iconEnabled : styles.iconDisabled
+            }`}
             aria-label="Previous page"
-            tabIndex={0}
-          />{" "}
+            disabled={props.page <= 1}>
+            <FontAwesomeIcon icon={faCaretLeft} />
+          </button>{" "}
           <input
             id="page-number"
             type="text"
@@ -95,24 +93,24 @@ export default function Pagination(props: Readonly<Props>) {
             aria-label="Page number"
           />
           {" of "}
-          <span
+          <button
+            type="button"
             onClick={goToLast}
-            className={isLastPage() ? styles.goToLast : ""}
-            role="button"
+            className={styles.goToLast}
             aria-label="Go to last page"
-            tabIndex={0}>
+            disabled={isLastPage()}>
             {Math.ceil(props.totalResults / props.pageSize).toLocaleString()}
-          </span>{" "}
-          <FontAwesomeIcon
-            icon={faCaretRight}
+          </button>{" "}
+          <button
+            type="button"
             onClick={pageNext}
-            className={
-              isLastPage() ? `${styles.iconDisabled}` : `${styles.iconEnabled}`
-            }
-            role="button"
+            className={`${styles.iconButton} ${
+              isLastPage() ? styles.iconDisabled : styles.iconEnabled
+            }`}
             aria-label="Next page"
-            tabIndex={0}
-          />
+            disabled={isLastPage()}>
+            <FontAwesomeIcon icon={faCaretRight} />
+          </button>
         </span>
       )}
     </>


### PR DESCRIPTION
## Summary
- replace pagination icons and spans with button elements for native keyboard support
- adjust pagination styles to preserve visual treatment on the new buttons
- add tests verifying next/previous pagination can be activated via keyboard input

## Testing
- BASE_ENDPOINT=http://localhost npx jest __tests__/components/pagination/Pagination.test.tsx
- npm run lint *(warnings about existing lint rules remain)*
- npm run type-check *(fails due to pre-existing type issues in unrelated files)*
- npm run test *(aborted after encountering failing suites unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c93fd2617c83219c62ee6647360092