### PR TITLE
PRXT fix: replace error link with Next.js Link

### DIFF
--- a/__tests__/components/error/Error.test.tsx
+++ b/__tests__/components/error/Error.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+
+import ErrorComponent from "@/components/error/Error";
+
+const setTitleMock = jest.fn();
+
+jest.mock("@/contexts/TitleContext", () => ({
+  __esModule: true,
+  useTitle: () => ({
+    setTitle: setTitleMock,
+  }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: any) => (
+    <a href={typeof href === "string" ? href : href?.toString()} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ unoptimized, ...props }: any) => {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img {...props} />;
+  },
+}));
+
+describe("ErrorComponent", () => {
+  beforeEach(() => {
+    setTitleMock.mockClear();
+  });
+
+  it("sets the error page title and shows contact email", () => {
+    render(<ErrorComponent />);
+
+    expect(setTitleMock).toHaveBeenCalledWith("6529 Error");
+
+    const supportLink = screen.getByRole("link", { name: "support@6529.io" });
+    expect(supportLink).toHaveAttribute("href", "mailto:support@6529.io");
+  });
+
+  it("renders a styled link back to the home page", () => {
+    render(<ErrorComponent />);
+
+    const homeLink = screen.getByRole("link", { name: "TAKE ME HOME" });
+    expect(homeLink).toHaveAttribute("href", "/");
+    expect(homeLink).toHaveClass("tw-mt-4", "tw-text-md", "tw-font-semibold");
+  });
+});

--- a/components/error/Error.tsx
+++ b/components/error/Error.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { useEffect } from "react";
 import { useTitle } from "@/contexts/TitleContext";
 
@@ -32,9 +33,9 @@ export default function ErrorComponent() {
         Looks like something went wrong. Try again or reach out to us at{" "}
         <a href="mailto:support@6529.io">support@6529.io</a>
       </p>
-      <a href="/" className="tw-mt-4 tw-text-md tw-font-semibold">
+      <Link href="/" className="tw-mt-4 tw-text-md tw-font-semibold">
         TAKE ME HOME
-      </a>
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- import Next.js `Link` in the error component and wrap the home navigation CTA with it while keeping the existing styling
- add a focused test suite for the error page to verify the contact link, home navigation link and title setter behaviour

## Testing
- npm run lint
- npm run type-check *(fails: pre-existing type errors in other test fixtures)*
- npm run test *(fails: requires BASE_ENDPOINT environment variable for numerous suites)*
- BASE_ENDPOINT=https://example.com npx jest __tests__/components/error/Error.test.tsx --coverage=false

------
https://chatgpt.com/codex/tasks/task_e_68c942b303c0832188487d4664138700