### PR TITLE
feat: improve filter target accessibility

### DIFF
--- a/__tests__/components/utils/CommonFilterTargetSelect.test.tsx
+++ b/__tests__/components/utils/CommonFilterTargetSelect.test.tsx
@@ -4,13 +4,52 @@ import React from 'react';
 import CommonFilterTargetSelect, { FilterTargetType } from '../../../components/utils/CommonFilterTargetSelect';
 
 describe('CommonFilterTargetSelect', () => {
-  it('renders radio buttons and triggers change', async () => {
+  it('renders the filter target options and triggers change on click', async () => {
     const user = userEvent.setup();
     const onChange = jest.fn();
+
     render(<CommonFilterTargetSelect selected={FilterTargetType.ALL} onChange={onChange} />);
+
+    const group = screen.getByRole('group', { name: /filter target/i });
+    expect(group).toBeInTheDocument();
+
     const buttons = screen.getAllByRole('radio');
     expect(buttons).toHaveLength(3);
+
     await user.click(screen.getByLabelText('Outgoing'));
+
     expect(onChange).toHaveBeenCalledWith(FilterTargetType.OUTGOING);
+  });
+
+  it('supports keyboard navigation between targets', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    const { rerender } = render(
+      <CommonFilterTargetSelect selected={FilterTargetType.ALL} onChange={onChange} />,
+    );
+
+    await user.tab();
+
+    const allRadio = screen.getByRole('radio', { name: 'All' });
+    expect(allRadio).toHaveFocus();
+
+    await user.keyboard('{ArrowRight}');
+
+    expect(onChange).toHaveBeenCalledWith(FilterTargetType.OUTGOING);
+
+    onChange.mockClear();
+
+    rerender(
+      <CommonFilterTargetSelect selected={FilterTargetType.OUTGOING} onChange={onChange} />,
+    );
+
+    const outgoingRadio = screen.getByRole('radio', { name: 'Outgoing' });
+    expect(outgoingRadio).toHaveFocus();
+    expect(outgoingRadio).toBeChecked();
+
+    await user.keyboard('{ArrowLeft}');
+
+    expect(onChange).toHaveBeenCalledWith(FilterTargetType.ALL);
   });
 });

--- a/components/utils/CommonFilterTargetSelect.tsx
+++ b/components/utils/CommonFilterTargetSelect.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useId } from "react";
+
 export enum FilterTargetType {
   ALL = "ALL",
   INCOMING = "INCOMING",
@@ -17,30 +21,37 @@ export default function CommonFilterTargetSelect({
   readonly selected: FilterTargetType;
   readonly onChange: (filter: FilterTargetType) => void;
 }) {
+  const baseId = useId().replace(/:/g, "");
+  const groupName = `filter-target-${baseId}`;
+
   return (
     <fieldset className="tw-px-4 sm:tw-px-6 tw-mt-6 tw-max-w-sm">
+      <legend className="tw-mb-2 tw-text-sm sm:tw-text-md tw-font-medium tw-leading-6 tw-text-iron-300">
+        Filter target
+      </legend>
       <div className="tw-flex tw-items-center tw-space-x-6 tw-space-y-0">
-        {TARGETS.map((target) => (
-          <button
-            key={target.id}
-            onClick={() => onChange(target.id)}
-            className="tw-p-0 tw-flex tw-items-center tw-bg-iron-900 tw-border-none"
-          >
-            <input
-              id={target.id}
-              type="radio"
-              checked={selected === target.id}
-              onChange={() => onChange(target.id)}
-              className="tw-form-radio tw-h-4 tw-w-4 tw-bg-iron-700 tw-border-iron-600 tw-border tw-border-solid focus:tw-ring-2 tw-ring-offset-iron-800 tw-text-primary-400 focus:tw-ring-primary-400 tw-cursor-pointer"
-            />
-            <label
-              htmlFor={target.id}
-              className="tw-ml-2 tw-block tw-text-sm sm:tw-text-md tw-font-medium tw-leading-6 tw-text-iron-300 tw-cursor-pointer"
-            >
-              {target.name}
-            </label>
-          </button>
-        ))}
+        {TARGETS.map((target) => {
+          const inputId = `${groupName}-${target.id}`;
+
+          return (
+            <div key={target.id} className="tw-flex tw-items-center tw-bg-iron-900">
+              <input
+                id={inputId}
+                name={groupName}
+                type="radio"
+                checked={selected === target.id}
+                onChange={() => onChange(target.id)}
+                className="tw-form-radio tw-h-4 tw-w-4 tw-bg-iron-700 tw-border-iron-600 tw-border tw-border-solid focus:tw-ring-2 tw-ring-offset-iron-800 tw-text-primary-400 focus:tw-ring-primary-400 tw-cursor-pointer"
+              />
+              <label
+                htmlFor={inputId}
+                className="tw-ml-2 tw-block tw-text-sm sm:tw-text-md tw-font-medium tw-leading-6 tw-text-iron-300 tw-cursor-pointer"
+              >
+                {target.name}
+              </label>
+            </div>
+          );
+        })}
       </div>
     </fieldset>
   );


### PR DESCRIPTION
## Summary
- replace the button-wrapped radios with a semantic fieldset, legend and individual radio inputs to enable native keyboard support
- ensure each radio shares a unique group name generated per render so only the intended option can be selected at once
- update the CommonFilterTargetSelect tests to cover the new group label and keyboard navigation behaviour

## Testing
- npm run lint
- npm run type-check *(fails: repository contains pre-existing type errors in test fixtures)*
- npm run test *(fails: many suites require BASE_ENDPOINT env var that is not configured in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9430aa9a08321ab6907bf81932241