### PR TITLE
fix: replace meta refresh redirects

### DIFF
--- a/app/city/6529-museum-district/page.tsx
+++ b/app/city/6529-museum-district/page.tsx
@@ -1,17 +1,9 @@
+import { redirect } from "next/navigation";
 import { getAppMetadata } from "@/components/providers/metadata";
 import type { Metadata } from "next";
 
 export default function CityMuseumRedirectPage() {
-  return (
-    <div>
-      <title>Redirecting...</title>
-      <meta httpEquiv="refresh" content="0;url=/om/6529-museum-district/" />
-      <p>
-        You are being redirected to{" "}
-        <a href="/om/6529-museum-district/">/om/6529-museum-district/</a>
-      </p>
-    </div>
-  );
+  redirect("/om/6529-museum-district/");
 }
 
 export async function generateMetadata(): Promise<Metadata> {

--- a/app/element_category/columns/page.tsx
+++ b/app/element_category/columns/page.tsx
@@ -1,17 +1,9 @@
-import React from "react";
+import { redirect } from "next/navigation";
 import { getAppMetadata } from "@/components/providers/metadata";
 import type { Metadata } from "next";
 
 export default function ElementColumnsRedirectPage() {
-  return (
-    <div>
-      <title>Redirecting...</title>
-      <meta httpEquiv="refresh" content="0;url=/" />
-      <p>
-        You are being redirected to <a href="/">/</a>
-      </p>
-    </div>
-  );
+  redirect("/");
 }
 
 export async function generateMetadata(): Promise<Metadata> {

--- a/app/element_category/sections/page.tsx
+++ b/app/element_category/sections/page.tsx
@@ -1,17 +1,9 @@
-import React from "react";
+import { redirect } from "next/navigation";
 import { getAppMetadata } from "@/components/providers/metadata";
 import type { Metadata } from "next";
 
 export default function ElementSectionsRedirectPage() {
-  return (
-    <div>
-      <title>Redirecting...</title>
-      <meta httpEquiv="refresh" content="0;url=/" />
-      <p>
-        You are being redirected to <a href="/">/</a>
-      </p>
-    </div>
-  );
+  redirect("/");
 }
 
 export async function generateMetadata(): Promise<Metadata> {

--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -1,17 +1,9 @@
-import React from "react";
+import { redirect } from "next/navigation";
 import { getAppMetadata } from "@/components/providers/metadata";
 import type { Metadata } from "next";
 
 export default function FeedRedirectPage() {
-  return (
-    <div>
-      <title>Redirecting...</title>
-      <meta httpEquiv="refresh" content="0;url=index.xml" />
-      <p>
-        You are being redirected to <a href="index.xml">index.xml</a>
-      </p>
-    </div>
-  );
+  redirect("/index.xml");
 }
 
 export async function generateMetadata(): Promise<Metadata> {

--- a/app/gm-or-die-small-mp4/page.tsx
+++ b/app/gm-or-die-small-mp4/page.tsx
@@ -1,23 +1,9 @@
-import React from "react";
+import { redirect } from "next/navigation";
 import { getAppMetadata } from "@/components/providers/metadata";
 import type { Metadata } from "next";
 
 export default function GMRedirectPage() {
-  return (
-    <div>
-      <title>Redirecting...</title>
-      <meta
-        httpEquiv="refresh"
-        content="0;url=https://videos.files.wordpress.com/Pr49XLee/gm-or-die-small.mp4"
-      />
-      <p>
-        You are being redirected to{" "}
-        <a href="https://videos.files.wordpress.com/Pr49XLee/gm-or-die-small.mp4">
-          https://videos.files.wordpress.com/Pr49XLee/gm-or-die-small.mp4
-        </a>
-      </p>
-    </div>
-  );
+  redirect("https://videos.files.wordpress.com/Pr49XLee/gm-or-die-small.mp4");
 }
 
 export async function generateMetadata(): Promise<Metadata> {

--- a/app/om/OM/page.tsx
+++ b/app/om/OM/page.tsx
@@ -1,16 +1,10 @@
-import React from "react";
+import { redirect } from "next/navigation";
 import { getAppMetadata } from "@/components/providers/metadata";
 import type { Metadata } from "next";
 
-const IndexPage = () => (
-  <div>
-    <title>Redirecting...</title>
-    <meta httpEquiv="refresh" content="0;url=/om/" />
-    <p>
-      You are being redirected to <a href="/om/">/om/</a>
-    </p>
-  </div>
-);
+const IndexPage = () => {
+  redirect("/om/");
+};
 
 export default IndexPage;
 

--- a/app/om/partnership-request/page.tsx
+++ b/app/om/partnership-request/page.tsx
@@ -1,16 +1,10 @@
-import React from "react";
+import { redirect } from "next/navigation";
 import { getAppMetadata } from "@/components/providers/metadata";
 import type { Metadata } from "next";
 
-const IndexPage = () => (
-  <div>
-    <title>Redirecting...</title>
-    <meta httpEquiv="refresh" content="0;url=/om/join-om/" />
-    <p>
-      You are being redirected to <a href="/om/join-om/">/om/join-om/</a>
-    </p>
-  </div>
-);
+const IndexPage = () => {
+  redirect("/om/join-om/");
+};
 
 export default IndexPage;
 

--- a/app/slide-page/6529-initiatives/page.tsx
+++ b/app/slide-page/6529-initiatives/page.tsx
@@ -1,12 +1,9 @@
+import { redirect } from "next/navigation";
 import { getAppMetadata } from "@/components/providers/metadata";
-const IndexPage = () => (
-  <div>
-      <title>Redirecting...</title>
-      <meta httpEquiv="refresh" content="0;url=/" />
-      <p>
-        You are being redirected to <a href="/">/</a>
-      </p>
-    </div>);
+
+const IndexPage = () => {
+  redirect("/");
+};
 
 export default IndexPage;
 

--- a/app/slide-page/homepage-slider/page.tsx
+++ b/app/slide-page/homepage-slider/page.tsx
@@ -1,12 +1,9 @@
+import { redirect } from "next/navigation";
 import { getAppMetadata } from "@/components/providers/metadata";
-const IndexPage = () => (
-  <div>
-      <title>Redirecting...</title>
-      <meta httpEquiv="refresh" content="0;url=/" />
-      <p>
-        You are being redirected to <a href="/">/</a>
-      </p>
-    </div>);
+
+const IndexPage = () => {
+  redirect("/");
+};
 
 export default IndexPage;
 


### PR DESCRIPTION
## Summary
- replace app route redirect pages to use `next/navigation` redirects instead of meta refresh markup
- keep existing metadata generation while removing in-body `<title>` and `<meta>` tags on the redirect stubs

## Testing
- BASE_ENDPOINT=http://localhost npm run lint
- BASE_ENDPOINT=http://localhost npm run type-check *(fails: existing repository type errors in test fixtures)*
- BASE_ENDPOINT=http://localhost npm run test *(fails: HeaderNavConfig test expects NFT Delegation section divider)*

------
https://chatgpt.com/codex/tasks/task_e_68c942ba617c8321a80857fcb9c24505