### PR TITLE
Add YouTube smart link preview

### DIFF
--- a/components/drops/view/part/YouTubePreview.tsx
+++ b/components/drops/view/part/YouTubePreview.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import type { YoutubePreviewData } from "../../../../services/youtube-preview";
+import ChatItemHrefButtons from "../../../waves/ChatItemHrefButtons";
+
+interface YouTubePreviewProps {
+  readonly href: string;
+  readonly preview: YoutubePreviewData;
+}
+
+export default function YouTubePreview({
+  href,
+  preview,
+}: YouTubePreviewProps) {
+  const title = preview.title?.trim() || "YouTube Video";
+  const authorName = preview.authorName?.trim();
+  const providerLabel = preview.providerName || "YouTube";
+
+  return (
+    <div className="tw-flex tw-w-full tw-items-stretch tw-gap-x-1">
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer nofollow"
+        className="tw-flex-1 tw-min-w-0 tw-no-underline tw-text-current"
+      >
+        <div className="tw-flex tw-h-full tw-flex-col tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-transition tw-duration-300 tw-ease-out hover:tw-border-iron-500">
+          <div className="tw-relative tw-aspect-video tw-bg-iron-900">
+            {preview.thumbnailUrl ? (
+              <img
+                src={preview.thumbnailUrl}
+                alt={title}
+                loading="lazy"
+                className="tw-h-full tw-w-full tw-object-cover"
+              />
+            ) : (
+              <div className="tw-flex tw-h-full tw-w-full tw-items-center tw-justify-center tw-bg-iron-900">
+                <span className="tw-text-sm tw-font-medium tw-text-iron-400">
+                  {providerLabel}
+                </span>
+              </div>
+            )}
+            <div className="tw-absolute tw-inset-0 tw-flex tw-items-center tw-justify-center">
+              <div className="tw-flex tw-h-12 tw-w-12 tw-items-center tw-justify-center tw-rounded-full tw-bg-black/70">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  className="tw-h-6 tw-w-6 tw-text-iron-50"
+                  aria-hidden="true"
+                >
+                  <path d="M8.25 5.469a.75.75 0 0 1 1.125-.65l8 4.531a.75.75 0 0 1 0 1.3l-8 4.531a.75.75 0 0 1-1.125-.65V5.47Z" />
+                </svg>
+              </div>
+            </div>
+          </div>
+          <div className="tw-flex tw-flex-col tw-gap-y-1 tw-p-4">
+            <span className="tw-text-sm tw-font-semibold tw-leading-snug tw-text-iron-50 tw-break-words">
+              {title}
+            </span>
+            {authorName && (
+              <span className="tw-text-xs tw-text-iron-400 tw-truncate" title={authorName}>
+                {authorName}
+              </span>
+            )}
+          </div>
+        </div>
+      </a>
+      <ChatItemHrefButtons href={href} />
+    </div>
+  );
+}

--- a/services/youtube-preview.ts
+++ b/services/youtube-preview.ts
@@ -1,0 +1,65 @@
+export interface YoutubePreviewData {
+  readonly title: string;
+  readonly authorName?: string;
+  readonly authorUrl?: string;
+  readonly thumbnailUrl?: string;
+  readonly providerName?: string;
+}
+
+interface YoutubeOEmbedResponse {
+  readonly title: string;
+  readonly author_name?: string;
+  readonly author_url?: string;
+  readonly type?: string;
+  readonly height?: number;
+  readonly width?: number;
+  readonly version?: string;
+  readonly provider_name?: string;
+  readonly provider_url?: string;
+  readonly thumbnail_height?: number;
+  readonly thumbnail_width?: number;
+  readonly thumbnail_url?: string;
+  readonly html?: string;
+}
+
+export interface FetchYoutubePreviewParams {
+  readonly videoId: string;
+  readonly signal?: AbortSignal;
+}
+
+const YOUTUBE_OEMBED_ENDPOINT = "https://www.youtube.com/oembed";
+const YOUTUBE_WATCH_BASE_URL = "https://www.youtube.com/watch";
+
+export async function fetchYoutubePreview({
+  videoId,
+  signal,
+}: FetchYoutubePreviewParams): Promise<YoutubePreviewData> {
+  const sanitizedVideoId = videoId.trim();
+
+  if (!sanitizedVideoId) {
+    throw new Error("A valid YouTube video id is required");
+  }
+
+  const watchUrl = new URL(YOUTUBE_WATCH_BASE_URL);
+  watchUrl.searchParams.set("v", sanitizedVideoId);
+
+  const endpoint = new URL(YOUTUBE_OEMBED_ENDPOINT);
+  endpoint.searchParams.set("url", watchUrl.toString());
+  endpoint.searchParams.set("format", "json");
+
+  const response = await fetch(endpoint.toString(), { signal });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch YouTube preview (${response.status})`);
+  }
+
+  const data = (await response.json()) as YoutubeOEmbedResponse;
+
+  return {
+    title: data.title,
+    authorName: data.author_name,
+    authorUrl: data.author_url,
+    thumbnailUrl: data.thumbnail_url,
+    providerName: data.provider_name,
+  };
+}


### PR DESCRIPTION
## Summary
- add YouTube link parsing to DropPartMarkdown and integrate a smart-link handler
- create a YouTubePreview component that renders fetched metadata with share controls
- introduce a youtube-preview service that retrieves video details via the YouTube oEmbed API

## Testing
- npm run lint
- npm run type-check *(fails: existing TypeScript errors in test fixtures)*
- npm run test *(fails: BASE_ENDPOINT environment variable required by existing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68c942138578832197218eb6a91774a8