### PR TITLE
feat: trap header search modal focus

### DIFF
--- a/__tests__/components/header/header-search/HeaderSearchModalFocus.test.tsx
+++ b/__tests__/components/header/header-search/HeaderSearchModalFocus.test.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import HeaderSearchButton from "../../../../components/header/header-search/HeaderSearchButton";
+import { QueryKey } from "../../../../components/react-query-wrapper/ReactQueryWrapper";
+import useDeviceInfo from "../../../../hooks/useDeviceInfo";
+
+jest.mock("focus-trap-react", () => jest.requireActual("focus-trap-react"));
+
+const useQueryMock = jest.fn();
+const useRouterMock = jest.fn();
+const usePathnameMock = jest.fn();
+const useSearchParamsMock = jest.fn();
+const useWavesMock = jest.fn();
+const useLocalPreferenceMock = jest.fn();
+
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: (...args: any[]) => useQueryMock(...args),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => useRouterMock(),
+  usePathname: () => usePathnameMock(),
+  useSearchParams: () => useSearchParamsMock(),
+}));
+
+jest.mock("../../../../hooks/useWaves", () => ({
+  useWaves: (...args: any[]) => useWavesMock(...args),
+}));
+
+jest.mock("../../../../hooks/useLocalPreference", () => ({
+  __esModule: true,
+  default: (...args: any[]) => useLocalPreferenceMock(...args),
+}));
+
+jest.mock("../../../../components/utils/animation/CommonAnimationWrapper", () => ({
+  __esModule: true,
+  default: ({ children }: any) => <div>{children}</div>,
+}));
+
+jest.mock("../../../../components/utils/animation/CommonAnimationOpacity", () => ({
+  __esModule: true,
+  default: ({ children, elementRole }: any) => (
+    <div role={elementRole}>{children}</div>
+  ),
+}));
+
+jest.mock("react-use", () => {
+  const React = require("react");
+  return {
+    useKey: jest.fn(),
+    useClickAway: jest.fn(),
+    useKeyPressEvent: jest.fn(),
+    useDebounce: (fn: () => void, _delay: number, deps: any[]) => {
+      React.useEffect(fn, deps);
+    },
+  };
+});
+
+jest.mock("../../../../hooks/useDeviceInfo");
+
+const useDeviceInfoMock = useDeviceInfo as jest.MockedFunction<
+  typeof useDeviceInfo
+>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useQueryMock.mockImplementation(({ queryKey }) => {
+    switch (queryKey[0]) {
+      case QueryKey.PROFILE_SEARCH:
+      case QueryKey.NFTS_SEARCH:
+        return { isFetching: false, data: [] };
+      default:
+        return { isFetching: false, data: [] };
+    }
+  });
+  useRouterMock.mockReturnValue({ push: jest.fn() });
+  usePathnameMock.mockReturnValue("/");
+  useSearchParamsMock.mockReturnValue(new URLSearchParams());
+  useWavesMock.mockReturnValue({ waves: [], isFetching: false });
+  useLocalPreferenceMock.mockReturnValue(["PROFILES", jest.fn()]);
+  useDeviceInfoMock.mockReturnValue({ isApp: false } as any);
+});
+
+describe("HeaderSearchModal focus management", () => {
+  it("keeps focus trapped within the modal while it is open", async () => {
+    const user = userEvent.setup();
+    render(<HeaderSearchButton />);
+
+    const trigger = screen.getByRole("button", { name: /search/i });
+    await user.click(trigger);
+
+    const input = await screen.findByPlaceholderText("Search");
+    await waitFor(() => expect(input).toHaveFocus());
+
+    await screen.findByRole("dialog");
+    const modalRoot = document.body.querySelector(
+      ".tailwind-scope.tw-cursor-default.tw-relative.tw-z-1000"
+    ) as HTMLElement | null;
+    expect(modalRoot).not.toBeNull();
+
+    for (let i = 0; i < 6; i += 1) {
+      await user.tab();
+      const activeElement = document.activeElement as HTMLElement | null;
+      expect(activeElement).not.toBe(trigger);
+      expect(activeElement).not.toBe(document.body);
+      expect(activeElement && modalRoot?.contains(activeElement)).toBe(true);
+    }
+
+    await user.tab({ shift: true });
+    const activeElement = document.activeElement as HTMLElement | null;
+    expect(activeElement).not.toBe(trigger);
+    expect(activeElement).not.toBe(document.body);
+    expect(activeElement && modalRoot?.contains(activeElement)).toBe(true);
+  });
+
+  it("returns focus to the trigger button when the modal closes", async () => {
+    const user = userEvent.setup();
+    render(<HeaderSearchButton />);
+
+    const trigger = screen.getByRole("button", { name: /search/i });
+    await user.click(trigger);
+
+    const closeButton = await screen.findByRole("button", { name: /close/i });
+    await user.click(closeButton);
+
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText("Search")).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
+  });
+});
+

--- a/components/header/header-search/HeaderSearchButton.tsx
+++ b/components/header/header-search/HeaderSearchButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import clsx from "clsx";
 import useDeviceInfo from "../../../hooks/useDeviceInfo";
 import CommonAnimationWrapper from "../../utils/animation/CommonAnimationWrapper";
@@ -11,11 +11,24 @@ import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
 
 export default function HeaderSearchButton() {
   const [isOpen, setIsOpen] = useState<boolean>(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const wasOpenRef = useRef(false);
   const { isApp } = useDeviceInfo();
+
+  useEffect(() => {
+    if (wasOpenRef.current && !isOpen) {
+      buttonRef.current?.focus();
+    }
+
+    wasOpenRef.current = isOpen;
+  }, [isOpen]);
+
+  const handleOpen = () => setIsOpen(true);
+  const handleClose = () => setIsOpen(false);
 
   useKey(
     (event) => event.metaKey && event.key === "k",
-    () => setIsOpen(true),
+    handleOpen,
     { event: "keydown" }
   );
 
@@ -24,10 +37,11 @@ export default function HeaderSearchButton() {
   return (
     <div className="tailwind-scope tw-self-center">
       <button
+        ref={buttonRef}
         type="button"
         aria-label="Search"
         title="Search"
-        onClick={() => setIsOpen(true)}
+        onClick={handleOpen}
         className={clsx(
           "tw-flex tw-items-center tw-justify-center tw-rounded-lg tw-h-10 tw-w-10 tw-border-0 tw-text-iron-300 hover:tw-text-iron-50 tw-shadow-sm focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-primary-400 tw-transition tw-duration-300 tw-ease-out",
           isApp
@@ -45,7 +59,7 @@ export default function HeaderSearchButton() {
             elementClasses="tw-absolute tw-z-10"
             elementRole="dialog"
             onClicked={(e) => e.stopPropagation()}>
-            <HeaderSearchModal onClose={() => setIsOpen(false)} />
+            <HeaderSearchModal onClose={handleClose} />
           </CommonAnimationOpacity>
         )}
       </CommonAnimationWrapper>

--- a/components/header/header-search/HeaderSearchModal.tsx
+++ b/components/header/header-search/HeaderSearchModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import FocusTrap from "focus-trap-react";
 import { useEffect, useRef, useState } from "react";
 import { useClickAway, useDebounce, useKeyPressEvent } from "react-use";
 import { CommunityMemberMinimal } from "../../../entities/IProfile";
@@ -255,85 +256,98 @@ export default function HeaderSearchModal({
     });
 
   return createPortal(
-    <div className="tailwind-scope tw-cursor-default tw-relative tw-z-1000">
-      <div className="tw-fixed tw-inset-0 tw-bg-gray-500 tw-bg-opacity-75"></div>
-      <div className="tw-fixed tw-inset-0 tw-z-1000 tw-overflow-y-auto">
-        <div className="tw-flex tw-min-h-full tw-items-start tw-justify-center tw-p-2 tw-text-center sm:tw-items-center sm:tw-p-0">
-          <div
-            ref={modalRef}
-            className="sm:tw-max-w-xl tw-relative tw-w-full tw-transform tw-rounded-xl tw-bg-iron-950 tw-text-left tw-shadow-xl tw-transition-all tw-duration-500 sm:tw-w-full tw-overflow-hidden inset-safe-area">
-            <div className="tw-border-b tw-border-x-0 tw-border-t-0 tw-border-solid tw-border-white/10 tw-pb-4 tw-px-4 tw-mt-4 tw-flex tw-items-center tw-gap-2">
-              {/* Back arrow mobile */}
-              <button
-                onClick={onClose}
-                aria-label="Close"
-                className="tw-flex sm:tw-hidden tw-size-6 tw-bg-transparent -tw-ml-1 tw-mr-1 tw-border-none tw-rounded-full tw-items-center tw-justify-center tw-text-iron-300 hover:tw-text-iron-50 tw-transition tw-duration-200">
-                <ChevronLeftIcon className="tw-size-6 tw-flex-shrink-0" />
-              </button>
+    <FocusTrap
+      focusTrapOptions={{
+        allowOutsideClick: true,
+        fallbackFocus: () =>
+          (modalRef.current as HTMLElement | null) ??
+          (inputRef.current as HTMLElement | null) ??
+          document.body,
+        initialFocus: () =>
+          (inputRef.current as HTMLElement | null) ??
+          (modalRef.current as HTMLElement | null) ??
+          document.body,
+      }}>
+      <div className="tailwind-scope tw-cursor-default tw-relative tw-z-1000">
+        <div className="tw-fixed tw-inset-0 tw-bg-gray-500 tw-bg-opacity-75"></div>
+        <div className="tw-fixed tw-inset-0 tw-z-1000 tw-overflow-y-auto">
+          <div className="tw-flex tw-min-h-full tw-items-start tw-justify-center tw-p-2 tw-text-center sm:tw-items-center sm:tw-p-0">
+            <div
+              ref={modalRef}
+              className="sm:tw-max-w-xl tw-relative tw-w-full tw-transform tw-rounded-xl tw-bg-iron-950 tw-text-left tw-shadow-xl tw-transition-all tw-duration-500 sm:tw-w-full tw-overflow-hidden inset-safe-area">
+              <div className="tw-border-b tw-border-x-0 tw-border-t-0 tw-border-solid tw-border-white/10 tw-pb-4 tw-px-4 tw-mt-4 tw-flex tw-items-center tw-gap-2">
+                {/* Back arrow mobile */}
+                <button
+                  onClick={onClose}
+                  aria-label="Close"
+                  className="tw-flex sm:tw-hidden tw-size-6 tw-bg-transparent -tw-ml-1 tw-mr-1 tw-border-none tw-rounded-full tw-items-center tw-justify-center tw-text-iron-300 hover:tw-text-iron-50 tw-transition tw-duration-200">
+                  <ChevronLeftIcon className="tw-size-6 tw-flex-shrink-0" />
+                </button>
 
-              <div className="tw-relative tw-flex-1">
-                <svg
-                  className="tw-pointer-events-none tw-absolute tw-left-4 tw-top-3.5 tw-h-5 tw-w-5 tw-text-iron-300"
-                  viewBox="0 0 20 20"
-                  fill="currentColor"
-                  aria-hidden="true">
-                  <path
-                    fillRule="evenodd"
-                    d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
-                    clipRule="evenodd"
+                <div className="tw-relative tw-flex-1">
+                  <svg
+                    className="tw-pointer-events-none tw-absolute tw-left-4 tw-top-3.5 tw-h-5 tw-w-5 tw-text-iron-300"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    aria-hidden="true">
+                    <path
+                      fillRule="evenodd"
+                      d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                  <input
+                    ref={inputRef}
+                    type="text"
+                    required
+                    autoComplete="off"
+                    value={searchValue}
+                    onChange={handleInputChange}
+                    className="tw-form-input tw-block tw-w-full tw-rounded-lg tw-border-0 tw-py-3 tw-pl-11 tw-pr-4 tw-bg-iron-900 tw-text-iron-50 tw-font-normal tw-caret-primary-300 tw-shadow-sm tw-ring-1 tw-ring-inset tw-ring-iron-700 hover:tw-ring-iron-600 placeholder:tw-text-iron-500 focus:tw-outline-none focus:tw-bg-transparent focus:tw-ring-1 focus:tw-ring-inset  focus:tw-ring-primary-300 tw-text-base sm:text-sm tw-transition tw-duration-300 tw-ease-out"
+                    placeholder="Search"
                   />
-                </svg>
-                <input
-                  ref={inputRef}
-                  type="text"
-                  required
-                  autoComplete="off"
-                  value={searchValue}
-                  onChange={handleInputChange}
-                  className="tw-form-input tw-block tw-w-full tw-rounded-lg tw-border-0 tw-py-3 tw-pl-11 tw-pr-4 tw-bg-iron-900 tw-text-iron-50 tw-font-normal tw-caret-primary-300 tw-shadow-sm tw-ring-1 tw-ring-inset tw-ring-iron-700 hover:tw-ring-iron-600 placeholder:tw-text-iron-500 focus:tw-outline-none focus:tw-bg-transparent focus:tw-ring-1 focus:tw-ring-inset  focus:tw-ring-primary-300 tw-text-base sm:text-sm tw-transition tw-duration-300 tw-ease-out"
-                  placeholder="Search"
+                </div>
+              </div>
+              <div className="tw-pt-3 tw-px-4">
+                <TabToggle
+                  options={Object.values(CATEGORY).map((c) => ({
+                    key: c,
+                    label: c.charAt(0) + c.slice(1).toLowerCase(),
+                  }))}
+                  activeKey={selectedCategory}
+                  onSelect={(k) => setSelectedCategory(k as CATEGORY)}
                 />
               </div>
-            </div>
-            <div className="tw-pt-3 tw-px-4">
-              <TabToggle
-                options={Object.values(CATEGORY).map((c) => ({
-                  key: c,
-                  label: c.charAt(0) + c.slice(1).toLowerCase(),
-                }))}
-                activeKey={selectedCategory}
-                onSelect={(k) => setSelectedCategory(k as CATEGORY)}
-              />
-            </div>
 
-            {state === STATE.SUCCESS && (
-              <div className="tw-h-72 tw-scroll-py-2 tw-px-4 tw-py-2 tw-overflow-y-auto tw-scrollbar-thin tw-scrollbar-thumb-iron-500 tw-scrollbar-track-iron-800 desktop-hover:hover:tw-scrollbar-thumb-iron-300 tw-text-sm tw-text-iron-200">
-                {renderItems(getCurrentItems())}
-              </div>
-            )}
-            {state === STATE.LOADING && (
-              <div className="tw-h-72 tw-flex tw-items-center tw-justify-center">
-                <p className="tw-text-iron-300 tw-font-normal tw-text-sm">
-                  Loading...
-                </p>
-              </div>
-            )}
-            {state === STATE.NO_RESULTS && (
-              <div className="tw-h-72 tw-flex tw-items-center tw-justify-center">
-                <p className="tw-text-iron-300 tw-text-sm">No results found</p>
-              </div>
-            )}
-            {state === STATE.INITIAL && (
-              <div className="tw-h-72 tw-flex tw-items-center tw-justify-center">
-                <p className="tw-text-iron-300 tw-font-normal tw-text-sm tw-text-center">
-                  Search for NFTs (by ID or name), Profiles and Waves
-                </p>
-              </div>
-            )}
+              {state === STATE.SUCCESS && (
+                <div className="tw-h-72 tw-scroll-py-2 tw-px-4 tw-py-2 tw-overflow-y-auto tw-scrollbar-thin tw-scrollbar-thumb-iron-500 tw-scrollbar-track-iron-800 desktop-hover:hover:tw-scrollbar-thumb-iron-300 tw-text-sm tw-text-iron-200">
+                  {renderItems(getCurrentItems())}
+                </div>
+              )}
+              {state === STATE.LOADING && (
+                <div className="tw-h-72 tw-flex tw-items-center tw-justify-center">
+                  <p className="tw-text-iron-300 tw-font-normal tw-text-sm">
+                    Loading...
+                  </p>
+                </div>
+              )}
+              {state === STATE.NO_RESULTS && (
+                <div className="tw-h-72 tw-flex tw-items-center tw-justify-center">
+                  <p className="tw-text-iron-300 tw-text-sm">No results found</p>
+                </div>
+              )}
+              {state === STATE.INITIAL && (
+                <div className="tw-h-72 tw-flex tw-items-center tw-justify-center">
+                  <p className="tw-text-iron-300 tw-font-normal tw-text-sm tw-text-center">
+                    Search for NFTs (by ID or name), Profiles and Waves
+                  </p>
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </div>
-    </div>,
+    </FocusTrap>,
     document.body
   );
 }


### PR DESCRIPTION
## Summary
- wrap the header search modal content in a focus trap with sensible initial and fallback focus targets
- ensure the header search trigger button regains focus after the modal closes
- add a focus management test suite covering trapping and trigger refocus behaviour

## Testing
- BASE_ENDPOINT=http://localhost npx jest __tests__/components/header/header-search/HeaderSearchModalFocus.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68c942cf73808321baf0a514726d8749