### PR TITLE
test: cover drop link preview rendering

### DIFF
--- a/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
+++ b/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import DropPartMarkdown from "../../../../../components/drops/view/part/DropPartMarkdown";
+import { fetchLinkPreview } from "../../../../../services/api/link-preview";
 
 jest.mock("../../../../../hooks/isMobileScreen", () => () => false);
 jest.mock("../../../../../contexts/EmojiContext", () => ({
@@ -8,6 +9,19 @@ jest.mock("../../../../../contexts/EmojiContext", () => ({
 jest.mock("react-tweet", () => ({
   Tweet: ({ id }: any) => <div>tweet:{id}</div>,
 }));
+jest.mock("../../../../../services/api/link-preview", () => ({
+  fetchLinkPreview: jest.fn(),
+}));
+
+const mockFetchLinkPreview =
+  fetchLinkPreview as jest.MockedFunction<typeof fetchLinkPreview>;
+
+const originalBaseEndpoint = process.env.BASE_ENDPOINT;
+
+beforeEach(() => {
+  mockFetchLinkPreview.mockReset();
+  process.env.BASE_ENDPOINT = originalBaseEndpoint;
+});
 
 describe("DropPartMarkdown", () => {
   it("renders gif embeds", () => {
@@ -56,5 +70,59 @@ describe("DropPartMarkdown", () => {
     const a = screen.getByRole("link");
     expect(a).not.toHaveAttribute("target");
     expect(a).toHaveAttribute("href", "/page");
+  });
+
+  it("renders link preview metadata for external links", async () => {
+    process.env.BASE_ENDPOINT = "https://6529.io";
+    mockFetchLinkPreview.mockResolvedValue({
+      title: "Example Article",
+      description: "An example description.",
+      image: "https://example.com/og.png",
+      siteName: "Example.com",
+      url: "https://example.com/article",
+    });
+
+    render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        referencedNfts={[]}
+        partContent="https://example.com/article"
+        onQuoteClick={jest.fn()}
+      />
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("link-preview-card")).toBeInTheDocument()
+    );
+
+    expect(screen.getByText("Example Article")).toBeInTheDocument();
+    const previewImage = screen.getByRole("img", {
+      name: /example article/i,
+    });
+    expect(previewImage).toHaveAttribute("src", "https://example.com/og.png");
+    expect(
+      screen.queryByRole("link", { name: "https://example.com/article" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to a standard link when preview fetch fails", async () => {
+    process.env.BASE_ENDPOINT = "https://6529.io";
+    mockFetchLinkPreview.mockRejectedValue(new Error("network error"));
+
+    render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        referencedNfts={[]}
+        partContent="https://example.com/article"
+        onQuoteClick={jest.fn()}
+      />
+    );
+
+    await waitFor(() => expect(mockFetchLinkPreview).toHaveBeenCalled());
+
+    expect(
+      screen.getByRole("link", { name: "https://example.com/article" })
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("link-preview-card")).not.toBeInTheDocument();
   });
 });

--- a/services/api/link-preview.ts
+++ b/services/api/link-preview.ts
@@ -1,0 +1,20 @@
+import { commonApiFetch } from "./common-api";
+
+export interface LinkPreviewMetadata {
+  readonly title?: string;
+  readonly description?: string;
+  readonly image?: string;
+  readonly siteName?: string;
+  readonly url?: string;
+}
+
+export const fetchLinkPreview = async (
+  url: string,
+  options?: { readonly signal?: AbortSignal }
+): Promise<LinkPreviewMetadata> => {
+  return commonApiFetch<LinkPreviewMetadata, { url: string }>({
+    endpoint: "link-preview",
+    params: { url },
+    signal: options?.signal,
+  });
+};


### PR DESCRIPTION
## Summary
- add a link-preview API helper and teach DropPartMarkdown to render preview cards for eligible external links
- keep external links functional by falling back to the existing anchor when the preview request fails or lacks metadata
- extend DropPartMarkdown tests to cover both successful metadata rendering and the fallback path when the preview service rejects

## Testing
- BASE_ENDPOINT=https://6529.io API_ENDPOINT=https://6529.io npm run test *(fails: existing HeaderNavConfig test expects NFT Delegation section divider)*
- BASE_ENDPOINT=https://6529.io API_ENDPOINT=https://6529.io npx jest __tests__/components/drops/view/part/DropPartMarkdown.test.tsx
- BASE_ENDPOINT=https://6529.io API_ENDPOINT=https://6529.io npm run lint
- BASE_ENDPOINT=https://6529.io API_ENDPOINT=https://6529.io npm run type-check *(fails: pre-existing type errors in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c94150ee3c8321b216c16a7ce48160