### PR TITLE
feat: add YouTube preview handling in markdown

### DIFF
--- a/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
+++ b/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
@@ -1,5 +1,10 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import DropPartMarkdown from "../../../../../components/drops/view/part/DropPartMarkdown";
+import {
+  fetchYoutubePreview,
+  type YoutubeOEmbedResponse,
+} from "@/services/api/youtube";
 
 jest.mock("../../../../../hooks/isMobileScreen", () => () => false);
 jest.mock("../../../../../contexts/EmojiContext", () => ({
@@ -8,8 +13,32 @@ jest.mock("../../../../../contexts/EmojiContext", () => ({
 jest.mock("react-tweet", () => ({
   Tweet: ({ id }: any) => <div>tweet:{id}</div>,
 }));
+jest.mock("@/services/api/youtube", () => ({
+  fetchYoutubePreview: jest.fn(),
+}));
+
+const mockFetchYoutubePreview =
+  fetchYoutubePreview as jest.MockedFunction<typeof fetchYoutubePreview>;
+const originalBaseEndpoint = process.env.BASE_ENDPOINT;
 
 describe("DropPartMarkdown", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    if (originalBaseEndpoint === undefined) {
+      delete process.env.BASE_ENDPOINT;
+    } else {
+      process.env.BASE_ENDPOINT = originalBaseEndpoint;
+    }
+  });
+
+  afterEach(() => {
+    if (originalBaseEndpoint === undefined) {
+      delete process.env.BASE_ENDPOINT;
+    } else {
+      process.env.BASE_ENDPOINT = originalBaseEndpoint;
+    }
+  });
+
   it("renders gif embeds", () => {
     const content = "Check this ![gif](https://media.tenor.com/test.gif)";
     render(
@@ -56,5 +85,74 @@ describe("DropPartMarkdown", () => {
     const a = screen.getByRole("link");
     expect(a).not.toHaveAttribute("target");
     expect(a).toHaveAttribute("href", "/page");
+  });
+
+  it("renders YouTube previews with thumbnail and iframe interaction", async () => {
+    const preview: YoutubeOEmbedResponse = {
+      title: "Sample Video",
+      author_name: "Sample Creator",
+      thumbnail_url: "https://img.youtube.com/vi/sample/hqdefault.jpg",
+      html: '<iframe title="Sample Video" src="https://www.youtube.com/embed/sample"></iframe>',
+    };
+    mockFetchYoutubePreview.mockResolvedValue(preview);
+
+    const content = "Watch this https://youtu.be/sample";
+    render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        referencedNfts={[]}
+        partContent={content}
+        onQuoteClick={jest.fn()}
+      />
+    );
+
+    const previewButton = await screen.findByRole("button", {
+      name: /sample video/i,
+    });
+    expect(
+      await screen.findByRole("img", { name: /sample video/i })
+    ).toHaveAttribute("src", preview.thumbnail_url);
+
+    await userEvent.click(previewButton);
+
+    expect(await screen.findByTitle("Sample Video")).toBeInTheDocument();
+    expect(mockFetchYoutubePreview).toHaveBeenCalled();
+    expect(mockFetchYoutubePreview.mock.calls[0]?.[0]).toBe(
+      "https://youtu.be/sample"
+    );
+  });
+
+  it("falls back to a link when YouTube preview rejects", async () => {
+    mockFetchYoutubePreview.mockRejectedValue(new Error("network"));
+
+    const url = "https://youtu.be/failure";
+    render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        referencedNfts={[]}
+        partContent={`Check ${url}`}
+        onQuoteClick={jest.fn()}
+      />
+    );
+
+    const fallbackLink = await screen.findByRole("link", { name: url });
+    expect(fallbackLink).toHaveAttribute("href", url);
+  });
+
+  it("falls back to a link when YouTube preview returns null", async () => {
+    mockFetchYoutubePreview.mockResolvedValue(null);
+
+    const url = "https://youtu.be/unknown";
+    render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        referencedNfts={[]}
+        partContent={`Check ${url}`}
+        onQuoteClick={jest.fn()}
+      />
+    );
+
+    const fallbackLink = await screen.findByRole("link", { name: url });
+    expect(fallbackLink).toHaveAttribute("href", url);
   });
 });

--- a/components/header/HeaderNavConfig.ts
+++ b/components/header/HeaderNavConfig.ts
@@ -80,6 +80,7 @@ export function getDesktopNavigation(_context: NavContext): NavDropdown[] {
       sections: [
         {
           name: "NFT Delegation",
+          hasDivider: true,
           items: [
             {
               name: "Delegation Center",

--- a/services/api/youtube.ts
+++ b/services/api/youtube.ts
@@ -1,0 +1,32 @@
+export interface YoutubeOEmbedResponse {
+  readonly title: string;
+  readonly author_name?: string;
+  readonly author_url?: string;
+  readonly provider_name?: string;
+  readonly provider_url?: string;
+  readonly thumbnail_url: string;
+  readonly thumbnail_width?: number;
+  readonly thumbnail_height?: number;
+  readonly html: string;
+  readonly width?: number;
+  readonly height?: number;
+  readonly type?: string;
+  readonly version?: string;
+}
+
+export const fetchYoutubePreview = async (
+  url: string,
+  signal?: AbortSignal
+): Promise<YoutubeOEmbedResponse | null> => {
+  const endpoint = new URL("https://www.youtube.com/oembed");
+  endpoint.searchParams.set("format", "json");
+  endpoint.searchParams.set("url", url);
+
+  const response = await fetch(endpoint.toString(), { signal });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  return (await response.json()) as YoutubeOEmbedResponse;
+};


### PR DESCRIPTION
## Summary
- support YouTube smart links in DropPartMarkdown, fetching oEmbed data and rendering a preview/iframe
- add Jest coverage for the new YouTube cases and restore BASE_ENDPOINT handling inside the tests
- mark the NFT Delegation tools section with a divider and expose a reusable fetchYoutubePreview helper

## Testing
- BASE_ENDPOINT=https://www.6529.io npx jest __tests__/components/drops/view/part/DropPartMarkdown.test.tsx __tests__/components/header/HeaderNavConfig.test.tsx
- npm run lint
- npm run type-check *(fails: existing type mismatches across NextGen tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c9421a05748321b73b78dd2764814a