### PR TITLE
PRXT - perf: optimize memes listing performance

### DIFF
--- a/__tests__/components/nft-image/renderers/NFTImageRenderer.test.tsx
+++ b/__tests__/components/nft-image/renderers/NFTImageRenderer.test.tsx
@@ -398,10 +398,20 @@ describe('NFTImageRenderer', () => {
   });
 
   describe('Performance Attributes', () => {
-    it('sets correct loading and priority attributes', () => {
+    it('uses lazy loading for grid-sized images', () => {
       const props = createDefaultProps();
       render(<NFTImageRenderer {...props} />);
-      
+
+      const image = screen.getByRole('img');
+      expect(image).toHaveAttribute('data-loading', 'lazy');
+      expect(image).toHaveAttribute('data-priority', 'false');
+      expect(image).toHaveAttribute('data-fetch-priority', 'auto');
+    });
+
+    it('prioritizes larger feature images', () => {
+      const props = createDefaultProps({ height: 650, heightStyle: 'height-650' });
+      render(<NFTImageRenderer {...props} />);
+
       const image = screen.getByRole('img');
       expect(image).toHaveAttribute('data-loading', 'eager');
       expect(image).toHaveAttribute('data-priority', 'true');

--- a/components/nft-image/renderers/NFTImageRenderer.tsx
+++ b/components/nft-image/renderers/NFTImageRenderer.tsx
@@ -22,17 +22,18 @@ function getSrc(
 
 export default function NFTImageRenderer(props: Readonly<BaseRendererProps>) {
   const src = getSrc(props.nft, !!props.showThumbnail, !!props.showOriginal);
+  const shouldLazyLoad = !!props.showThumbnail || props.height === 300;
 
   return (
     <Col
       xs={12}
       className={`mb-2 text-center d-flex align-items-center justify-content-center ${styles.imageWrapper} ${props.heightStyle} ${props.bgStyle}`}>
       <Image
-        loading="eager"
-        priority
+        loading={shouldLazyLoad ? "lazy" : "eager"}
+        priority={!shouldLazyLoad}
         width="0"
         height="0"
-        fetchPriority="high"
+        fetchPriority={shouldLazyLoad ? "auto" : "high"}
         unoptimized
         className={props.imageStyle}
         style={{


### PR DESCRIPTION
## Summary
- replace linear NFT balance lookups with cached maps and throttle infinite scroll fetching
- pre-compute meme groupings to avoid repeated scans and enable lazy loading for grid images
- align NFTImageRenderer tests with the new loading strategy

## Testing
- npm run lint
- npm run type-check *(fails: existing type errors under __tests__)*
- npm run test *(fails: missing BASE_ENDPOINT env and numerous unrelated suites)*
- BASE_ENDPOINT=http://localhost npm run test:cov:changed *(fails: repository lacks `main` ref in this context)*

------
https://chatgpt.com/codex/tasks/task_e_68c95e5175848321b0f1773f0b67693d