### PR TITLE
fix: optimize meme page performance

### DIFF
--- a/__tests__/components/the-memes/MemePageActivity.test.tsx
+++ b/__tests__/components/the-memes/MemePageActivity.test.tsx
@@ -99,17 +99,23 @@ describe("MemePageActivity", () => {
   });
   
   describe("Activity Fetching", () => {
-  it("fetches activity with correct base url", async () => {
-    render(<MemePageActivity show nft={nft} pageSize={10} />);
+    it("skips fetching when tab is hidden", () => {
+      render(<MemePageActivity show={false} nft={nft} pageSize={10} />);
 
-    await waitFor(() => {
-      expect(fetchUrlMock).toHaveBeenCalledWith(
-        `https://api.test/api/transactions?contract=${MEMES_CONTRACT}&id=1&page_size=10&page=1`
+      expect(fetchUrlMock).not.toHaveBeenCalled();
+    });
+
+    it("fetches activity with correct base url", async () => {
+      render(<MemePageActivity show nft={nft} pageSize={10} />);
+
+      await waitFor(() => {
+        expect(fetchUrlMock).toHaveBeenCalledWith(
+          `https://api.test/api/transactions?contract=${MEMES_CONTRACT}&id=1&page_size=10&page=1`
       );
     });
   });
 
-  it("updates url when filter is changed", async () => {
+    it("updates url when filter is changed", async () => {
     render(<MemePageActivity show nft={nft} pageSize={5} />);
 
     await waitFor(() => expect(fetchUrlMock).toHaveBeenCalledTimes(1));
@@ -124,7 +130,7 @@ describe("MemePageActivity", () => {
     });
   });
 
-  it("requests new page when pagination changes", async () => {
+    it("requests new page when pagination changes", async () => {
     fetchUrlMock.mockResolvedValueOnce({ count: 20, data: [{} as any] });
     render(<MemePageActivity show nft={nft} pageSize={10} />);
     await waitFor(() => expect(fetchUrlMock).toHaveBeenCalledTimes(1));
@@ -142,7 +148,7 @@ describe("MemePageActivity", () => {
     });
   });
   
-  it("tests all TypeFilter values", async () => {
+    it("tests all TypeFilter values", async () => {
     render(<MemePageActivity show nft={nft} pageSize={5} />);
     await waitFor(() => expect(fetchUrlMock).toHaveBeenCalledTimes(1));
     
@@ -165,7 +171,7 @@ describe("MemePageActivity", () => {
     }
   });
   
-  it("resets page to 1 when filter changes", async () => {
+    it("resets page to 1 when filter changes", async () => {
     // Start with page 2
     fetchUrlMock.mockResolvedValue({ count: 20, data: [{} as any] });
     render(<MemePageActivity show nft={nft} pageSize={10} />);
@@ -195,10 +201,10 @@ describe("MemePageActivity", () => {
     });
   });
   
-  it("does not fetch when nft is undefined", () => {
-    render(<MemePageActivity show nft={undefined} pageSize={10} />);
-    expect(fetchUrlMock).not.toHaveBeenCalled();
-  });
+    it("does not fetch when nft is undefined", () => {
+      render(<MemePageActivity show nft={undefined} pageSize={10} />);
+      expect(fetchUrlMock).not.toHaveBeenCalled();
+    });
   });
   
   describe("Error Handling", () => {

--- a/components/the-memes/MemePageActivity.tsx
+++ b/components/the-memes/MemePageActivity.tsx
@@ -26,6 +26,11 @@ export function MemePageActivity(props: {
   );
 
   useEffect(() => {
+    if (!props.show || !props.nft) {
+      return;
+    }
+    let isMounted = true;
+
     if (props.nft) {
       let url = `${process.env.API_ENDPOINT}/api/transactions?contract=${MEMES_CONTRACT}&id=${props.nft.id}&page_size=${props.pageSize}&page=${activityPage}`;
       switch (activityTypeFilter) {
@@ -46,11 +51,24 @@ export function MemePageActivity(props: {
           break;
       }
       fetchUrl(url).then((response: DBResponse) => {
+        if (!isMounted) {
+          return;
+        }
         setActivityTotalResults(response.count);
         setActivity(response.data);
       });
     }
-  }, [props.nft, activityPage, activityTypeFilter]);
+
+    return () => {
+      isMounted = false;
+    };
+  }, [
+    props.show,
+    props.nft,
+    props.pageSize,
+    activityPage,
+    activityTypeFilter,
+  ]);
 
   if (props.show && props.nft) {
     return (


### PR DESCRIPTION
## Summary
- lazy load secondary meme tabs and synchronize focus search params without full navigation
- parallelize metadata and NFT fetches while guarding balances and tab rendering state
- skip hidden activity fetches and extend MemePage tests for new router behavior and fetch gating

## Testing
- `npm run lint`
- `npm run type-check` *(fails: existing type errors in unrelated test fixtures)*
- `npm run test` *(fails: enormous suite with unrelated HeaderNavConfig expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68c95d5b573c8321ac402ecab3691947