### PR TITLE
refactor: modularize drop part markdown

### DIFF
--- a/components/drops/view/part/DropPartMarkdown.tsx
+++ b/components/drops/view/part/DropPartMarkdown.tsx
@@ -1,56 +1,26 @@
-import {
-  AnchorHTMLAttributes,
-  Children,
-  ClassAttributes,
-  Fragment,
-  HTMLAttributes,
-  ImgHTMLAttributes,
-  isValidElement,
-  memo,
-  ReactNode,
-  useEffect,
-  useState,
-  type JSX,
-} from "react";
-import Markdown, { ExtraProps } from "react-markdown";
+import { memo, useMemo, type ComponentPropsWithoutRef } from "react";
+import Markdown, { type Components, type ExtraProps } from "react-markdown";
 import rehypeExternalLinks from "rehype-external-links";
 import rehypeSanitize from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
-import { ErrorBoundary } from "react-error-boundary";
+import type { PluggableList } from "unified";
 
-import { getRandomObjectId } from "../../../../helpers/AllowlistToolHelpers";
-
-// Component definitions moved outside for better performance
-const BreakComponent = () => <br />;
-import DropListItemContentPart, {
-  DropListItemContentPartProps,
-} from "../item/content/DropListItemContentPart";
+import { ApiDrop } from "../../../../generated/models/ApiDrop";
 import { ApiDropMentionedUser } from "../../../../generated/models/ApiDropMentionedUser";
 import { ApiDropReferencedNFT } from "../../../../generated/models/ApiDropReferencedNFT";
-import { Tweet, type TwitterComponents } from "react-tweet";
-
-import DropPartMarkdownImage from "./DropPartMarkdownImage";
-import WaveDropQuoteWithDropId from "../../../waves/drops/WaveDropQuoteWithDropId";
-import WaveDropQuoteWithSerialNo from "../../../waves/drops/WaveDropQuoteWithSerialNo";
-import { ApiDrop } from "../../../../generated/models/ApiDrop";
-import {
-  parseSeizeQueryLink,
-  parseSeizeQuoteLink,
-  SeizeQuoteLinkInfo,
-} from "../../../../helpers/SeizeLinkParser";
-import useIsMobileScreen from "../../../../hooks/isMobileScreen";
 import { useEmoji } from "../../../../contexts/EmojiContext";
-import GroupCardChat from "../../../groups/page/list/card/GroupCardChat";
-import WaveItemChat from "../../../waves/list/WaveItemChat";
-import DropItemChat from "../../../waves/drops/DropItemChat";
-import ChatItemHrefButtons from "../../../waves/ChatItemHrefButtons";
-import LinkPreviewCard from "../../../waves/LinkPreviewCard";
+import useIsMobileScreen from "../../../../hooks/isMobileScreen";
+
 import {
-  fetchYoutubePreview,
-  YoutubeOEmbedResponse,
-} from "@/services/api/youtube";
-import { parseArtBlocksLink } from "@/src/services/artblocks/url";
-import ArtBlocksTokenCard from "@/src/components/waves/ArtBlocksTokenCard";
+  DropContentPartType,
+  createMarkdownContentRenderers,
+} from "./dropPartMarkdown/content";
+import {
+  createLinkRenderer,
+  isArtBlocksFeatureEnabled,
+} from "./dropPartMarkdown/linkHandlers";
+
+const BreakComponent = () => <br />;
 
 export interface DropPartMarkdownProps {
   readonly mentionedUsers: Array<ApiDropMentionedUser>;
@@ -59,16 +29,6 @@ export interface DropPartMarkdownProps {
   readonly onQuoteClick: (drop: ApiDrop) => void;
   readonly textSize?: "sm" | "md";
 }
-
-export enum DropContentPartType {
-  MENTION = "MENTION",
-  HASHTAG = "HASHTAG",
-}
-
-type SmartLinkHandler<T> = {
-  parse: (href: string) => T | null;
-  render: (result: T, href: string) => JSX.Element | null;
-};
 
 function DropPartMarkdown({
   mentionedUsers,
@@ -79,904 +39,180 @@ function DropPartMarkdown({
 }: DropPartMarkdownProps) {
   const isMobile = useIsMobileScreen();
   const { emojiMap, findNativeEmoji } = useEmoji();
-  const textSizeClass = (() => {
+
+  const textSizeClass = useMemo(() => {
     switch (textSize) {
       case "sm":
         return isMobile ? "tw-text-xs" : "tw-text-sm";
       default:
-        return "tw-text-md"; // Always use medium text for both mobile and desktop
+        return "tw-text-md";
     }
-  })();
+  }, [isMobile, textSize]);
 
-  const customPartRenderer = ({
-    content,
-    mentionedUsers,
-    referencedNfts,
-  }: {
-    readonly content: ReactNode | undefined;
-    readonly mentionedUsers: Array<ApiDropMentionedUser>;
-    readonly referencedNfts: Array<ApiDropReferencedNFT>;
-  }) => {
-    if (typeof content !== "string") {
-      return content;
-    }
+  const isArtBlocksCardEnabled = useMemo(
+    () => isArtBlocksFeatureEnabled(),
+    []
+  );
 
-    const splitter = getRandomObjectId();
+  const { renderAnchor, isSmartLink, renderImage } = useMemo(
+    () =>
+      createLinkRenderer({
+        onQuoteClick,
+        isArtBlocksCardEnabled,
+      }),
+    [onQuoteClick, isArtBlocksCardEnabled]
+  );
 
-    const values: Record<string, DropListItemContentPartProps> = {
-      ...mentionedUsers.reduce(
-        (acc, user) => ({
-          ...acc,
-          [`@[${user.handle_in_content}]`]: {
-            type: DropContentPartType.MENTION,
-            value: user,
-            match: `@[${user.handle_in_content}]`,
-          },
-        }),
-        {}
-      ),
-      ...referencedNfts.reduce(
-        (acc, nft) => ({
-          ...acc,
-          [`#[${nft.name}]`]: {
-            type: DropContentPartType.HASHTAG,
-            value: nft,
-            match: `#[${nft.name}]`,
-          },
-        }),
-        {}
-      ),
-    };
-
-    const emojiRegex = /(:\w+:)/g;
-    const isEmoji = (str: string): boolean => {
-      const emojiTextRegex =
-        /^(?:\ud83c[\udffb-\udfff]|\ud83d[\udc00-\ude4f\ude80-\udfff]|\ud83e[\udd00-\uddff]|\u00a9|\u00ae|\u200d|\u203c|\u2049|\u2122|\u2139|\u2194-\u21aa|\u231a-\u23fa|\u24c2|\u25aa-\u25fe|\u2600-\u27bf|\u2934-\u2b55|\u3030|\u303d|\u3297|\u3299|\ufe0f)$/;
-      return emojiTextRegex.test(str.trim());
-    };
-    const areAllPartsEmojis = content
-      .split(emojiRegex)
-      .filter((p) => !!p)
-      .every((part) => part.match(emojiRegex) || isEmoji(part));
-
-    let currentContent = content;
-
-    for (const token of Object.values(values)) {
-      currentContent = currentContent.replaceAll(
-        token.match,
-        `${splitter}${token.match}${splitter}`
-      );
-    }
-    const parts = currentContent
-      .split(splitter)
-      .filter((part) => part !== "")
-      .map((part) => {
-        const partProps = values[part];
-        if (partProps) {
-          const randomId = getRandomObjectId();
-          return <DropListItemContentPart key={randomId} part={partProps} />;
-        } else {
-          const parts = part.split(emojiRegex);
-
-          return parts.map((part) =>
-            part.match(emojiRegex) ? (
-              <Fragment key={getRandomObjectId()}>
-                {renderEmoji(part, areAllPartsEmojis)}
-              </Fragment>
-            ) : (
-              <span
-                key={getRandomObjectId()}
-                className={`${areAllPartsEmojis ? "emoji-text-node" : "tw-align-middle"
-                  }`}
-              >
-                {part}
-              </span>
-            )
-          );
-        }
-      });
-
-    return parts;
-  };
-
-  const customRenderer = ({
-    content,
-    mentionedUsers,
-    referencedNfts,
-  }: {
-    readonly content: ReactNode | undefined;
-    readonly mentionedUsers: Array<ApiDropMentionedUser>;
-    readonly referencedNfts: Array<ApiDropReferencedNFT>;
-  }) => {
-    if (typeof content === "string") {
-      return customPartRenderer({
-        content,
+  const { customRenderer, renderParagraph, processContent } = useMemo(
+    () =>
+      createMarkdownContentRenderers({
+        textSizeClass,
         mentionedUsers,
         referencedNfts,
-      });
-    }
+        emojiMap,
+        findNativeEmoji,
+        isSmartLink,
+      }),
+    [
+      textSizeClass,
+      mentionedUsers,
+      referencedNfts,
+      emojiMap,
+      findNativeEmoji,
+      isSmartLink,
+    ]
+  );
 
-    if (Array.isArray(content)) {
-      return content.map((child) => {
-        if (typeof child === "string") {
-          return customPartRenderer({
-            content: child,
-            mentionedUsers,
-            referencedNfts,
-          });
-        }
+  const processedContent = useMemo(
+    () => processContent(partContent),
+    [processContent, partContent]
+  );
 
-        return child;
-      });
-    }
+  const rehypePlugins = useMemo<PluggableList>(
+    () => [
+      [
+        rehypeExternalLinks,
+        {
+          target: "_blank",
+          rel: ["noopener", "noreferrer", "nofollow"],
+          protocols: ["http", "https"],
+        },
+      ],
+      [
+        rehypeSanitize,
+        {
+          allowedTags: [
+            "p",
+            "br",
+            "strong",
+            "em",
+            "a",
+            "code",
+            "pre",
+            "blockquote",
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6",
+            "ul",
+            "ol",
+            "li",
+            "img",
+          ],
+          allowedAttributes: {
+            a: ["href", "title"],
+            img: ["src", "alt", "title"],
+          },
+        },
+      ],
+    ],
+    []
+  );
 
-    return content;
-  };
+  const remarkPlugins = useMemo<PluggableList>(() => [remarkGfm], []);
 
-  const renderEmoji = (emojiProps: string, bigEmoji: boolean) => {
-    const emojiId = emojiProps.replaceAll(":", "");
-    const emoji = emojiMap
-      .flatMap((cat) => cat.emojis)
-      .find((e) => e.id === emojiId);
+  const markdownComponents = useMemo<Components>(
+    () => {
+      const mergeClassNames = (
+        ...classes: Array<string | undefined>
+      ): string => classes.filter(Boolean).join(" ");
 
-    if (!emoji) {
-      const nativeEmoji = findNativeEmoji(emojiId);
-      if (nativeEmoji) {
-        return (
-          <span
-            className={`${bigEmoji ? "emoji-text-node" : "tw-align-middle"}`}
+      const headingClassName = "tw-text-iron-200 tw-break-words word-break";
+      const createHeadingRenderer = <T extends keyof JSX.IntrinsicElements>(
+        Tag: T
+      ) =>
+        ({ children, className, ...props }: ComponentPropsWithoutRef<T> & ExtraProps) => (
+          <Tag
+            {...props}
+            className={mergeClassNames(headingClassName, className)}
           >
-            {nativeEmoji.skins[0].native}
-          </span>
+            {customRenderer(children)}
+          </Tag>
         );
-      }
-      return <span>{`:${emojiId}:`}</span>;
-    }
 
-    return (
-      <img
-        src={emoji.skins[0].src}
-        alt={emojiId}
-        className={`${bigEmoji ? "emoji-node-big" : "emoji-node"}`}
-      />
-    );
-  };
-
-  const parseTwitterLink = (
-    href: string
-  ): { href: string; tweetId: string } | null => {
-    const twitterRegex =
-      /https:\/\/(?:twitter\.com|x\.com)\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)/;
-    const match = href.match(twitterRegex);
-    return match ? { href, tweetId: match[3] } : null;
-  };
-
-  const parseGifLink = (href: string): string | null => {
-    const gifRegex = /^https?:\/\/media\.tenor\.com\/[^\s]+\.gif$/i;
-    return gifRegex.test(href) ? href : null;
-  };
-
-  const matchesDomainOrSubdomain = (host: string, domain: string): boolean => {
-    return host === domain || host.endsWith(`.${domain}`);
-  };
-
-  const parseYoutubeLink = (
-    href: string
-  ): { readonly videoId: string; readonly url: string } | null => {
-    try {
-      const url = new URL(href);
-      const normalizedHost = url.hostname.replace(/^www\./i, "").toLowerCase();
-      const youtubeDomains = ["youtube.com", "youtube-nocookie.com"];
-      const isYoutubeDomain = youtubeDomains.some(
-        (domain) =>
-          normalizedHost === domain || normalizedHost.endsWith(`.${domain}`)
-      );
-
-      let videoId: string | null = null;
-
-      if (normalizedHost === "youtu.be") {
-        const pathSegments = url.pathname.split("/").filter(Boolean);
-        videoId = pathSegments[0] ?? null;
-      } else if (isYoutubeDomain) {
-        const pathSegments = url.pathname.split("/").filter(Boolean);
-
-        if (url.pathname === "/watch" || url.pathname === "/watch/") {
-          videoId = url.searchParams.get("v");
-        } else if (pathSegments[0] === "shorts") {
-          videoId = pathSegments[1] ?? null;
-        } else if (pathSegments[0] === "embed") {
-          videoId = pathSegments[1] ?? null;
-        } else if (pathSegments[0] === "live") {
-          videoId = pathSegments[1] ?? null;
-        } else if (pathSegments[0] === "v") {
-          videoId = pathSegments[1] ?? null;
-        }
-      }
-
-      if (!videoId) {
-        return null;
-      }
-
-      const trimmed = videoId.trim();
-      if (!trimmed.match(/^[A-Za-z0-9_-]{6,}$/)) {
-        return null;
-      }
-
-      return { videoId: trimmed, url: href };
-    } catch {
-      return null;
-    }
-  };
-
-  const getYoutubeFetchUrl = (href: string, videoId: string): string => {
-    try {
-      const url = new URL(href);
-      const canonical = new URL(`https://www.youtube.com/watch?v=${videoId}`);
-      const preservedParams = ["list", "index"] as const;
-
-      preservedParams.forEach((param) => {
-        const value = url.searchParams.get(param);
-        if (value) {
-          canonical.searchParams.set(param, value);
-        }
-      });
-
-      return canonical.toString();
-    } catch {
-      return `https://www.youtube.com/watch?v=${videoId}`;
-    }
-  };
-
-  const smartLinkHandlers: SmartLinkHandler<any>[] = [
-    {
-      parse: parseSeizeQuoteLink,
-      render: (result: SeizeQuoteLinkInfo, href: string) =>
-        renderSeizeQuote(result, onQuoteClick, href),
+      return {
+        h1: createHeadingRenderer("h1"),
+        h2: createHeadingRenderer("h2"),
+        h3: createHeadingRenderer("h3"),
+        h4: createHeadingRenderer("h4"),
+        h5: createHeadingRenderer("h5"),
+        p: renderParagraph,
+        li: ({ children, className, ...props }) => (
+          <li
+            {...props}
+            className={mergeClassNames(
+              "tw-text-md tw-text-iron-200 tw-break-words word-break",
+              className
+            )}
+          >
+            {customRenderer(children)}
+          </li>
+        ),
+        code: ({ children, className, style, ...props }) => (
+          <code
+            {...props}
+            style={{ ...style, textOverflow: "unset" }}
+            className={mergeClassNames(
+              "tw-text-iron-200 tw-whitespace-pre-wrap tw-break-words",
+              className
+            )}
+          >
+            {customRenderer(children)}
+          </code>
+        ),
+        a: renderAnchor,
+        img: renderImage,
+        br: BreakComponent,
+        blockquote: ({ children, className, ...props }) => (
+          <blockquote
+            {...props}
+            className={mergeClassNames(
+              "tw-text-iron-200 tw-break-words word-break tw-pl-4 tw-border-l-4 tw-border-l-iron-500 tw-border-solid tw-border-t-0 tw-border-r-0 tw-border-b-0",
+              className
+            )}
+          >
+            {customRenderer(children)}
+          </blockquote>
+        ),
+      } satisfies Components;
     },
-    {
-      parse: (href: string) => parseSeizeQueryLink(href, "/network", ["group"]),
-      render: (result: { group: string }, href: string) => (
-        <GroupCardChat href={href} groupId={result.group} />
-      ),
-    },
-    {
-      parse: (href: string) =>
-        parseSeizeQueryLink(href, "/my-stream", ["wave"], true),
-      render: (result: { wave: string }, href: string) => (
-        <WaveItemChat href={href} waveId={result.wave} />
-      ),
-    },
-    {
-      parse: (href: string) =>
-        parseSeizeQueryLink(href, "/my-stream", ["wave", "drop"], true),
-      render: (result: { drop: string }, href: string) => (
-        <DropItemChat href={href} dropId={result.drop} />
-      ),
-    },
-    {
-      parse: parseTwitterLink,
-      render: (result: { href: string; tweetId: string }) =>
-        renderTweetEmbed(result),
-    },
-    {
-      parse: parseGifLink,
-      render: (url: string) => renderGifEmbed(url),
-    },
-  ];
-
-  const artBlocksFeatureFlags = [
-    process.env.VITE_FEATURE_AB_CARD,
-    process.env.NEXT_PUBLIC_VITE_FEATURE_AB_CARD,
-    process.env.NEXT_PUBLIC_FEATURE_AB_CARD,
-    process.env.FEATURE_AB_CARD,
-  ];
-
-  const isArtBlocksCardEnabled = artBlocksFeatureFlags.some((flag) => flag === "true");
-
-  if (isArtBlocksCardEnabled) {
-    const parseArtBlocks = (href: string) => parseArtBlocksLink(href);
-    const renderArtBlocks = (
-      artBlocksId: { tokenId: string; contract?: string },
-      href: string
-    ) => (
-      <div className="tw-flex tw-items-stretch tw-w-full tw-gap-x-1">
-        <div className="tw-flex-1 tw-min-w-0">
-          <ArtBlocksTokenCard href={href} id={artBlocksId} />
-        </div>
-        <ChatItemHrefButtons href={href} />
-      </div>
-    );
-
-    smartLinkHandlers.push({
-      parse: parseArtBlocks,
-      render: (artBlocksId, href) => renderArtBlocks(artBlocksId, href),
-    });
-  }
-
-  const isSmartLink = (href: string): boolean => {
-    if (parseYoutubeLink(href)) {
-      return true;
-    }
-
-    if (smartLinkHandlers.some((handler) => !!handler.parse(href))) {
-      return true;
-    }
-
-    return shouldUseOpenGraphPreview(href);
-  };
-
-  const aHrefRenderer = ({
-    node,
-    ...props
-  }: ClassAttributes<HTMLAnchorElement> &
-    AnchorHTMLAttributes<HTMLAnchorElement> &
-    ExtraProps) => {
-    const { href } = props;
-    if (!href || !isValidLink(href)) {
-      return null;
-    }
-
-    const youtubeInfo = parseYoutubeLink(href);
-    if (youtubeInfo) {
-      return (
-        <YoutubePreview
-          href={youtubeInfo.url}
-          videoId={youtubeInfo.videoId}
-          fallbackProps={props}
-        />
-      );
-    }
-
-    for (const { parse, render } of smartLinkHandlers) {
-      const result = parse(href);
-      if (result) {
-        return render(result, href);
-      }
-    }
-
-    if (shouldUseOpenGraphPreview(href)) {
-      return (
-        <LinkPreviewCard
-          href={href}
-          renderFallback={() => renderExternalOrInternalLink(href, props)}
-        />
-      );
-    }
-
-    return renderExternalOrInternalLink(href, props);
-  };
-
-  const imgRenderer = ({
-    node,
-    ...props
-  }: ClassAttributes<HTMLImageElement> &
-    ImgHTMLAttributes<HTMLImageElement> &
-    ExtraProps) =>
-    typeof props.src === "string" ? (
-      <DropPartMarkdownImage src={props.src} />
-    ) : null;
-
-  const renderTweetFallback = (href: string) => (
-    <a
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="tw-flex tw-h-full tw-w-full tw-flex-col tw-justify-center tw-gap-y-1 tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900 tw-p-4 tw-text-left tw-no-underline tw-transition-colors tw-duration-200 hover:tw-border-iron-500 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400"
-    >
-      <span className="tw-text-sm tw-font-medium tw-text-iron-100">
-        Tweet unavailable
-      </span>
-      <span className="tw-text-xs tw-text-iron-400">Open on X</span>
-    </a>
+    [customRenderer, renderAnchor, renderImage, renderParagraph]
   );
-
-  const renderTweetEmbed = (result: { href: string; tweetId: string }) => {
-    const renderFallback = () => renderTweetFallback(result.href);
-    const TweetNotFound: TwitterComponents["TweetNotFound"] = () =>
-      renderFallback();
-
-    return (
-      <div className="tw-flex tw-items-stretch tw-w-full tw-gap-x-1">
-        <div className="tw-flex-1 tw-min-w-0" data-theme="dark">
-          <ErrorBoundary fallbackRender={() => renderFallback()}>
-            <Tweet
-              id={result.tweetId}
-              components={{ TweetNotFound }}
-            />
-          </ErrorBoundary>
-        </div>
-        <ChatItemHrefButtons href={result.href} />
-      </div>
-    );
-  };
-
-  const renderGifEmbed = (url: string) => (
-    <img
-      src={url}
-      alt={url}
-      className="tw-max-h-[25rem] tw-max-w-[100%] tw-h-auto"
-    />
-  );
-
-  const isValidLink = (href: string): boolean => {
-    try {
-      new URL(href);
-      return true;
-    } catch {
-      return false;
-    }
-  };
-
-  const shouldUseOpenGraphPreview = (href: string): boolean => {
-    const baseEndpoint = process.env.BASE_ENDPOINT;
-
-    try {
-      const parsed = new URL(href);
-      const protocol = parsed.protocol.toLowerCase();
-      if (protocol !== "http:" && protocol !== "https:") {
-        return false;
-      }
-
-      if (baseEndpoint) {
-        try {
-          const baseUrl = new URL(baseEndpoint);
-          if (parsed.host === baseUrl.host) {
-            return false;
-          }
-        } catch {
-          if (href.startsWith(baseEndpoint)) {
-            return false;
-          }
-        }
-      }
-
-      const hostname = parsed.hostname.toLowerCase();
-      const youtubeDomains = ["youtube.com", "youtube-nocookie.com"];
-      const twitterDomains = ["twitter.com", "x.com"];
-      const artBlocksDomains = [
-        "artblocks.io",
-        "live.artblocks.io",
-        "media.artblocks.io",
-        "media-proxy.artblocks.io",
-        "token.artblocks.io",
-      ];
-
-      if (
-        hostname === "youtu.be" ||
-        youtubeDomains.some((domain) => matchesDomainOrSubdomain(hostname, domain)) ||
-        twitterDomains.some((domain) => matchesDomainOrSubdomain(hostname, domain)) ||
-        artBlocksDomains.some((domain) => matchesDomainOrSubdomain(hostname, domain))
-      ) {
-        return false;
-      }
-
-      return true;
-    } catch {
-      return false;
-    }
-  };
-
-  const renderExternalOrInternalLink = (
-    href: string,
-    props: AnchorHTMLAttributes<HTMLAnchorElement> & ExtraProps
-  ) => {
-    const baseEndpoint = process.env.BASE_ENDPOINT ?? "";
-    const isExternalLink = baseEndpoint && !href.startsWith(baseEndpoint);
-    const { onClick, ...restProps } = props;
-    const anchorProps: AnchorHTMLAttributes<HTMLAnchorElement> & ExtraProps = {
-      ...restProps,
-      href,
-    };
-
-    if (isExternalLink) {
-      anchorProps.rel = "noopener noreferrer nofollow";
-      anchorProps.target = "_blank";
-    } else {
-      anchorProps.href = href.replace(baseEndpoint, "");
-    }
-
-    return (
-      <a
-        {...anchorProps}
-        onClick={(e) => {
-          e.stopPropagation();
-          if (typeof onClick === "function") {
-            onClick(e);
-          }
-        }}
-      />
-    );
-  };
-
-  const normalizeYoutubeHtml = (html: string): string => {
-    let normalized = html.replace(/width="[^"]*"/i, 'width="100%"');
-    normalized = normalized.replace(/height="[^"]*"/i, 'height="100%"');
-
-    if (/style="[^"]*"/i.test(normalized)) {
-      normalized = normalized.replace(
-        /style="([^"]*)"/i,
-        (_, styles: string) => {
-          const cleanedStyles = styles.replace(/;?\s*$/, "");
-          return `style="${cleanedStyles};width:100%;height:100%;"`;
-        }
-      );
-    } else {
-      normalized = normalized.replace(
-        /<iframe/i,
-        '<iframe style="width:100%;height:100%;"'
-      );
-    }
-
-    return normalized;
-  };
-
-  const YoutubePreview = ({
-    href,
-    videoId,
-    fallbackProps,
-  }: {
-    readonly href: string;
-    readonly videoId: string;
-    readonly fallbackProps: AnchorHTMLAttributes<HTMLAnchorElement> & ExtraProps;
-  }) => {
-    const [preview, setPreview] = useState<YoutubeOEmbedResponse | null>(null);
-    const [hasError, setHasError] = useState(false);
-    const [showEmbed, setShowEmbed] = useState(false);
-
-    useEffect(() => {
-      const abortController = new AbortController();
-      let isActive = true;
-
-      setPreview(null);
-      setHasError(false);
-      setShowEmbed(false);
-
-      const fetchUrl = getYoutubeFetchUrl(href, videoId);
-
-      fetchYoutubePreview(fetchUrl, abortController.signal)
-        .then((data) => {
-          if (!isActive) {
-            return;
-          }
-
-          if (data) {
-            setPreview({
-              ...data,
-              html: normalizeYoutubeHtml(data.html),
-            });
-          } else {
-            setHasError(true);
-          }
-        })
-        .catch((error) => {
-          if (!isActive) {
-            return;
-          }
-
-          if (error instanceof DOMException && error.name === "AbortError") {
-            return;
-          }
-
-          setHasError(true);
-        });
-
-      return () => {
-        isActive = false;
-        abortController.abort();
-      };
-    }, [href, videoId]);
-
-    const renderFallback = () =>
-      renderExternalOrInternalLink(href, { ...fallbackProps });
-
-    if (hasError) {
-      return renderFallback();
-    }
-
-    if (!preview) {
-      return (
-        <div className="tw-flex tw-items-stretch tw-w-full tw-gap-x-1">
-          <div className="tw-flex-1 tw-min-w-0">
-            <div className="tw-aspect-video tw-w-full tw-rounded-lg tw-bg-iron-800 tw-animate-pulse" />
-          </div>
-          <ChatItemHrefButtons href={href} />
-        </div>
-      );
-    }
-
-    const ariaLabel = preview.title
-      ? `Play YouTube video ${preview.title}`
-      : `Play YouTube video ${videoId}`;
-
-    return (
-      <div className="tw-flex tw-items-stretch tw-w-full tw-gap-x-1">
-        <div className="tw-flex-1 tw-min-w-0">
-          <div className="tw-relative tw-overflow-hidden tw-rounded-lg tw-bg-black">
-            {showEmbed ? (
-              <div
-                className="tw-relative tw-w-full tw-aspect-video tw-bg-black"
-                data-testid="youtube-embed"
-                dangerouslySetInnerHTML={{ __html: preview.html }}
-              />
-            ) : (
-              <button
-                type="button"
-                className="tw-relative tw-w-full tw-aspect-video tw-border-0 tw-bg-transparent tw-p-0 tw-cursor-pointer"
-                onClick={() => setShowEmbed(true)}
-                aria-label={ariaLabel}
-              >
-                <img
-                  src={preview.thumbnail_url}
-                  alt={preview.title ?? `YouTube video ${videoId}`}
-                  className="tw-h-full tw-w-full tw-object-cover"
-                />
-                <div className="tw-absolute tw-inset-0 tw-flex tw-items-center tw-justify-center tw-bg-black/40">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    className="tw-h-12 tw-w-12 tw-text-white tw-opacity-90"
-                    aria-hidden="true"
-                  >
-                    <path d="M8 5v14l11-7z" />
-                  </svg>
-                </div>
-              </button>
-            )}
-          </div>
-          <div className="tw-mt-2 tw-space-y-1">
-            {preview.title && (
-              <p className="tw-text-sm tw-font-semibold tw-text-iron-100 tw-mb-0">
-                {preview.title}
-              </p>
-            )}
-            {preview.author_name && (
-              <p className="tw-text-xs tw-text-iron-400 tw-mb-0">
-                {preview.author_name}
-              </p>
-            )}
-          </div>
-        </div>
-        <ChatItemHrefButtons href={href} />
-      </div>
-    );
-  };
-
-  const renderSeizeQuote = (
-    quoteLinkInfo: SeizeQuoteLinkInfo,
-    onQuoteClick: (drop: ApiDrop) => void,
-    href: string
-  ) => {
-    const { waveId, serialNo, dropId } = quoteLinkInfo;
-
-    if (serialNo) {
-      return (
-        <div className="tw-flex tw-items-stretch tw-w-full tw-gap-x-1">
-          <div className="tw-flex-1 tw-min-w-0">
-            <WaveDropQuoteWithSerialNo
-              serialNo={parseInt(serialNo)}
-              waveId={waveId}
-              onQuoteClick={onQuoteClick}
-            />
-          </div>
-          <ChatItemHrefButtons href={href} hideLink />
-        </div>
-      );
-    } else if (dropId) {
-      return (
-        <div className="tw-flex tw-items-stretch tw-w-full tw-gap-x-1">
-          <div className="tw-flex-1 tw-min-w-0">
-            <WaveDropQuoteWithDropId
-              dropId={dropId}
-              partId={1}
-              maybeDrop={null}
-              onQuoteClick={onQuoteClick}
-            />
-          </div>
-          <ChatItemHrefButtons
-            href={href}
-            relativeHref={`/my-stream?wave=${waveId}&drop=${dropId}`}
-          />
-        </div>
-      );
-    }
-
-    return null;
-  };
-
-  const renderParagraph = (
-    params: ClassAttributes<HTMLParagraphElement> &
-      HTMLAttributes<HTMLParagraphElement> &
-      ExtraProps
-  ) => {
-    const renderP = (
-      params: ClassAttributes<HTMLParagraphElement> &
-        HTMLAttributes<HTMLParagraphElement> &
-        ExtraProps
-    ) => (
-      <p
-        key={getRandomObjectId()}
-        className={`tw-mb-0 tw-leading-6 tw-text-iron-200 tw-font-normal tw-whitespace-pre-wrap tw-break-words word-break tw-transition tw-duration-300 tw-ease-out ${textSizeClass}`}
-      >
-        {customRenderer({
-          content: params.children,
-          mentionedUsers,
-          referencedNfts,
-        })}
-      </p>
-    );
-
-    const { children } = params;
-
-    // Flatten children (could be string, JSX, or array)
-    const flattened = Children.toArray(children);
-
-    const elements: React.ReactNode[] = [];
-    let currentTextChunk: React.ReactNode[] = [];
-
-    const flushTextChunk = () => {
-      if (currentTextChunk.length > 0) {
-        elements.push(renderP({ children: currentTextChunk }));
-        currentTextChunk = [];
-      }
-    };
-
-    for (const node of flattened) {
-      const isValid = isValidElement(node);
-      const src = isValid && (node.props as any)?.src;
-      const href = isValid && (node.props as any)?.href;
-      if (src || (href && isSmartLink(href))) {
-        flushTextChunk();
-        elements.push(node);
-      } else {
-        currentTextChunk.push(node);
-      }
-    }
-
-    flushTextChunk();
-
-    return <>{elements}</>;
-  };
-
-  let processedContent = partContent;
-  if (processedContent) {
-    processedContent = processedContent.replace(/\n{4,}/g, (match: string) => {
-      // Calculate how many empty paragraphs to create
-      const numParagraphs = Math.floor(match.length / 2) - 1;
-      // Create empty paragraphs with &nbsp; to ensure they render with height
-      const emptyParagraphs = Array(numParagraphs).fill("\n\n&nbsp;").join("");
-      return "\n\n" + emptyParagraphs + "\n\n";
-    });
-  }
 
   return (
     <Markdown
-      rehypePlugins={[
-        [
-          rehypeExternalLinks,
-          {
-            target: "_blank",
-            rel: ["noopener", "noreferrer", "nofollow"],
-            protocols: ["http", "https"],
-          },
-        ],
-        [
-          rehypeSanitize,
-          {
-            allowedTags: [
-              "p",
-              "br",
-              "strong",
-              "em",
-              "a",
-              "code",
-              "pre",
-              "blockquote",
-              "h1",
-              "h2",
-              "h3",
-              "h4",
-              "h5",
-              "h6",
-              "ul",
-              "ol",
-              "li",
-              "img",
-            ],
-            allowedAttributes: {
-              a: ["href", "title"],
-              img: ["src", "alt", "title"],
-            },
-          },
-        ],
-      ]}
-      remarkPlugins={[remarkGfm]}
+      rehypePlugins={rehypePlugins}
+      remarkPlugins={remarkPlugins}
       className="tw-w-full"
-      components={{
-        h5: (params) => (
-          <h5 className="tw-text-iron-200 tw-break-words word-break">
-            {customRenderer({
-              content: params.children,
-              mentionedUsers,
-              referencedNfts,
-            })}
-          </h5>
-        ),
-        h4: (params) => (
-          <h4 className="tw-text-iron-200 tw-break-words word-break">
-            {customRenderer({
-              content: params.children,
-              mentionedUsers,
-              referencedNfts,
-            })}
-          </h4>
-        ),
-        h3: (params) => (
-          <h3 className="tw-text-iron-200 tw-break-words word-break">
-            {customRenderer({
-              content: params.children,
-              mentionedUsers,
-              referencedNfts,
-            })}
-          </h3>
-        ),
-        h2: (params) => (
-          <h2 className="tw-text-iron-200 tw-break-words word-break">
-            {customRenderer({
-              content: params.children,
-              mentionedUsers,
-              referencedNfts,
-            })}
-          </h2>
-        ),
-        h1: (params) => (
-          <h1 className="tw-text-iron-200 tw-break-words word-break">
-            {customRenderer({
-              content: params.children,
-              mentionedUsers,
-              referencedNfts,
-            })}
-          </h1>
-        ),
-        p: renderParagraph,
-        li: (params) => (
-          <li className="tw-text-md tw-text-iron-200 tw-break-words word-break">
-            {customRenderer({
-              content: params.children,
-              mentionedUsers,
-              referencedNfts,
-            })}
-          </li>
-        ),
-        code: (params) => (
-          <code
-            style={{ textOverflow: "unset" }}
-            className="tw-text-iron-200 tw-whitespace-pre-wrap tw-break-words"
-          >
-            {customRenderer({
-              content: params.children,
-              mentionedUsers,
-              referencedNfts,
-            })}
-          </code>
-        ),
-        a: (params) => aHrefRenderer(params),
-        img: imgRenderer,
-        br: BreakComponent,
-        blockquote: (params) => (
-          <blockquote className="tw-text-iron-200 tw-break-words word-break tw-pl-4 tw-border-l-4 tw-border-l-iron-500 tw-border-solid tw-border-t-0 tw-border-r-0 tw-border-b-0">
-            {customRenderer({
-              content: params.children,
-              mentionedUsers,
-              referencedNfts,
-            })}
-          </blockquote>
-        ),
-      }}
+      components={markdownComponents}
     >
       {processedContent}
     </Markdown>
   );
 }
+
+export { DropContentPartType };
 
 export default memo(DropPartMarkdown);

--- a/components/drops/view/part/dropPartMarkdown/content.tsx
+++ b/components/drops/view/part/dropPartMarkdown/content.tsx
@@ -1,0 +1,260 @@
+import {
+  Children,
+  ClassAttributes,
+  Fragment,
+  HTMLAttributes,
+  ReactNode,
+  isValidElement,
+} from "react";
+import { ExtraProps } from "react-markdown";
+
+import { getRandomObjectId } from "../../../../../helpers/AllowlistToolHelpers";
+import type { DropListItemContentPartProps } from "../../item/content/DropListItemContentPart";
+import { ApiDropMentionedUser } from "../../../../../generated/models/ApiDropMentionedUser";
+import { ApiDropReferencedNFT } from "../../../../../generated/models/ApiDropReferencedNFT";
+
+export enum DropContentPartType {
+  MENTION = "MENTION",
+  HASHTAG = "HASHTAG",
+}
+
+interface EmojiCategory {
+  emojis: Array<{ id: string; skins: Array<{ src: string }> }>;
+}
+
+interface NativeEmojiSkin {
+  native: string;
+}
+
+type FindNativeEmoji = (
+  emojiId: string
+) => { skins: NativeEmojiSkin[] } | null;
+
+export interface MarkdownContentConfig {
+  readonly textSizeClass: string;
+  readonly mentionedUsers: Array<ApiDropMentionedUser>;
+  readonly referencedNfts: Array<ApiDropReferencedNFT>;
+  readonly emojiMap: EmojiCategory[];
+  readonly findNativeEmoji: FindNativeEmoji;
+  readonly isSmartLink: (href: string) => boolean;
+}
+
+export interface MarkdownContentRenderers {
+  readonly customRenderer: (content: ReactNode | undefined) => ReactNode;
+  readonly renderParagraph: (
+    params: ClassAttributes<HTMLParagraphElement> &
+      HTMLAttributes<HTMLParagraphElement> &
+      ExtraProps
+  ) => ReactNode;
+  readonly processContent: (content: string | null) => string | null;
+}
+
+type DropListItemContentPartComponent = typeof import("../../item/content/DropListItemContentPart").default;
+
+const getDropListItemContentPart = (): DropListItemContentPartComponent => {
+  const module = require("../../item/content/DropListItemContentPart");
+  return module.default as DropListItemContentPartComponent;
+};
+
+const emojiRegex = /(:\w+:)/g;
+
+export const createMarkdownContentRenderers = ({
+  textSizeClass,
+  mentionedUsers,
+  referencedNfts,
+  emojiMap,
+  findNativeEmoji,
+  isSmartLink,
+}: MarkdownContentConfig): MarkdownContentRenderers => {
+  const renderEmoji = (emojiProps: string, bigEmoji: boolean) => {
+    const emojiId = emojiProps.replaceAll(":", "");
+    const emoji = emojiMap
+      .flatMap((cat) => cat.emojis)
+      .find((e) => e.id === emojiId);
+
+    if (!emoji) {
+      const nativeEmoji = findNativeEmoji(emojiId);
+      if (nativeEmoji) {
+        return (
+          <span className={`${bigEmoji ? "emoji-text-node" : "tw-align-middle"}`}>
+            {nativeEmoji.skins[0]?.native}
+          </span>
+        );
+      }
+      return <span>{`:${emojiId}:`}</span>;
+    }
+
+    return (
+      <img
+        src={emoji.skins[0]?.src}
+        alt={emojiId}
+        className={`${bigEmoji ? "emoji-node-big" : "emoji-node"}`}
+      />
+    );
+  };
+
+  const customPartRenderer = (
+    content: string
+  ): Array<ReactNode> | ReactNode => {
+    const splitter = getRandomObjectId();
+
+    const values: Record<string, DropListItemContentPartProps> = {
+      ...mentionedUsers.reduce(
+        (acc, user) => ({
+          ...acc,
+          [`@[${user.handle_in_content}]`]: {
+            type: DropContentPartType.MENTION,
+            value: user,
+            match: `@[${user.handle_in_content}]`,
+          },
+        }),
+        {}
+      ),
+      ...referencedNfts.reduce(
+        (acc, nft) => ({
+          ...acc,
+          [`#[${nft.name}]`]: {
+            type: DropContentPartType.HASHTAG,
+            value: nft,
+            match: `#[${nft.name}]`,
+          },
+        }),
+        {}
+      ),
+    };
+
+    const isEmoji = (str: string): boolean => {
+      const emojiTextRegex = /^(?:\ud83c[\udffb-\udfff]|\ud83d[\udc00-\ude4f\ude80-\udfff]|\ud83e[\udd00-\uddff]|\u00a9|\u00ae|\u200d|\u203c|\u2049|\u2122|\u2139|\u2194-\u21aa|\u231a-\u23fa|\u24c2|\u25aa-\u25fe|\u2600-\u27bf|\u2934-\u2b55|\u3030|\u303d|\u3297|\u3299|\ufe0f)$/;
+      return emojiTextRegex.test(str.trim());
+    };
+
+    const areAllPartsEmojis = content
+      .split(emojiRegex)
+      .filter((part) => !!part)
+      .every((part) => part.match(emojiRegex) || isEmoji(part));
+
+    let currentContent = content;
+
+    for (const token of Object.values(values)) {
+      currentContent = currentContent.replaceAll(
+        token.match,
+        `${splitter}${token.match}${splitter}`
+      );
+    }
+
+    const parts = currentContent
+      .split(splitter)
+      .filter((part) => part !== "")
+      .map((part) => {
+        const partProps = values[part];
+        if (partProps) {
+          const randomId = getRandomObjectId();
+          const DropListItemContentPart = getDropListItemContentPart();
+          return <DropListItemContentPart key={randomId} part={partProps} />;
+        }
+
+        const segments = part.split(emojiRegex);
+        return segments.map((segment) =>
+          segment.match(emojiRegex) ? (
+            <Fragment key={getRandomObjectId()}>
+              {renderEmoji(segment, areAllPartsEmojis)}
+            </Fragment>
+          ) : (
+            <span
+              key={getRandomObjectId()}
+              className={
+                areAllPartsEmojis ? "emoji-text-node" : "tw-align-middle"
+              }
+            >
+              {segment}
+            </span>
+          )
+        );
+      });
+
+    return parts;
+  };
+
+  const customRenderer = (content: ReactNode | undefined): ReactNode => {
+    if (typeof content === "string") {
+      return customPartRenderer(content);
+    }
+
+    if (Array.isArray(content)) {
+      return content.map((child) => {
+        if (typeof child === "string") {
+          return customPartRenderer(child);
+        }
+        return child;
+      });
+    }
+
+    return content;
+  };
+
+  const renderParagraph = (
+    params: ClassAttributes<HTMLParagraphElement> &
+      HTMLAttributes<HTMLParagraphElement> &
+      ExtraProps
+  ) => {
+    const renderP = (
+      paragraphParams: ClassAttributes<HTMLParagraphElement> &
+        HTMLAttributes<HTMLParagraphElement> &
+        ExtraProps
+    ) => (
+      <p
+        key={getRandomObjectId()}
+        className={`tw-mb-0 tw-leading-6 tw-text-iron-200 tw-font-normal tw-whitespace-pre-wrap tw-break-words word-break tw-transition tw-duration-300 tw-ease-out ${textSizeClass}`}
+      >
+        {customRenderer(paragraphParams.children)}
+      </p>
+    );
+
+    const { children } = params;
+    const flattened = Children.toArray(children);
+
+    const elements: ReactNode[] = [];
+    let currentTextChunk: ReactNode[] = [];
+
+    const flushTextChunk = () => {
+      if (currentTextChunk.length > 0) {
+        elements.push(renderP({ children: currentTextChunk }));
+        currentTextChunk = [];
+      }
+    };
+
+    for (const node of flattened) {
+      const element = isValidElement(node);
+      const src = element && (node.props as any)?.src;
+      const href = element && (node.props as any)?.href;
+      if (src || (href && isSmartLink(href))) {
+        flushTextChunk();
+        elements.push(node);
+      } else {
+        currentTextChunk.push(node);
+      }
+    }
+
+    flushTextChunk();
+
+    return <>{elements}</>;
+  };
+
+  const processContent = (content: string | null) => {
+    if (!content) {
+      return content;
+    }
+
+    return content.replace(/\n{4,}/g, (match: string) => {
+      const numParagraphs = Math.floor(match.length / 2) - 1;
+      const emptyParagraphs = Array(numParagraphs).fill("\n\n&nbsp;").join("");
+      return "\n\n" + emptyParagraphs + "\n\n";
+    });
+  };
+
+  return {
+    customRenderer,
+    renderParagraph,
+    processContent,
+  };
+};

--- a/components/drops/view/part/dropPartMarkdown/linkHandlers.tsx
+++ b/components/drops/view/part/dropPartMarkdown/linkHandlers.tsx
@@ -1,0 +1,441 @@
+import {
+  AnchorHTMLAttributes,
+  ClassAttributes,
+  ImgHTMLAttributes,
+  type ReactElement,
+} from "react";
+import { ExtraProps } from "react-markdown";
+import { ErrorBoundary } from "react-error-boundary";
+import { Tweet, type TwitterComponents } from "react-tweet";
+
+import { ApiDrop } from "../../../../../generated/models/ApiDrop";
+import { SeizeQuoteLinkInfo, parseSeizeQuoteLink } from "../../../../../helpers/SeizeLinkParser";
+import { parseSeizeQueryLink } from "../../../../../helpers/SeizeLinkParser";
+import { parseArtBlocksLink } from "@/src/services/artblocks/url";
+import ArtBlocksTokenCard from "@/src/components/waves/ArtBlocksTokenCard";
+
+import { parseYoutubeLink } from "./youtube";
+import YoutubePreview from "./youtubePreview";
+
+type DropPartMarkdownImageComponent = typeof import("../DropPartMarkdownImage").default;
+type WaveDropQuoteWithSerialNoComponent = typeof import("../../../../waves/drops/WaveDropQuoteWithSerialNo").default;
+type WaveDropQuoteWithDropIdComponent = typeof import("../../../../waves/drops/WaveDropQuoteWithDropId").default;
+type GroupCardChatComponent = typeof import("../../../../groups/page/list/card/GroupCardChat").default;
+type WaveItemChatComponent = typeof import("../../../../waves/list/WaveItemChat").default;
+type DropItemChatComponent = typeof import("../../../../waves/drops/DropItemChat").default;
+type ChatItemHrefButtonsComponent = typeof import("../../../../waves/ChatItemHrefButtons").default;
+type LinkPreviewCardComponent = typeof import("../../../../waves/LinkPreviewCard").default;
+
+const getDropPartMarkdownImage = (): DropPartMarkdownImageComponent => {
+  const module = require("../DropPartMarkdownImage");
+  return module.default as DropPartMarkdownImageComponent;
+};
+
+const getWaveDropQuoteWithSerialNo = (): WaveDropQuoteWithSerialNoComponent => {
+  const module = require("../../../../waves/drops/WaveDropQuoteWithSerialNo");
+  return module.default as WaveDropQuoteWithSerialNoComponent;
+};
+
+const getWaveDropQuoteWithDropId = (): WaveDropQuoteWithDropIdComponent => {
+  const module = require("../../../../waves/drops/WaveDropQuoteWithDropId");
+  return module.default as WaveDropQuoteWithDropIdComponent;
+};
+
+const getGroupCardChat = (): GroupCardChatComponent => {
+  const module = require("../../../../groups/page/list/card/GroupCardChat");
+  return module.default as GroupCardChatComponent;
+};
+
+const getWaveItemChat = (): WaveItemChatComponent => {
+  const module = require("../../../../waves/list/WaveItemChat");
+  return module.default as WaveItemChatComponent;
+};
+
+const getDropItemChat = (): DropItemChatComponent => {
+  const module = require("../../../../waves/drops/DropItemChat");
+  return module.default as DropItemChatComponent;
+};
+
+const getChatItemHrefButtons = (): ChatItemHrefButtonsComponent => {
+  const module = require("../../../../waves/ChatItemHrefButtons");
+  return module.default as ChatItemHrefButtonsComponent;
+};
+
+const getLinkPreviewCard = (): LinkPreviewCardComponent => {
+  const module = require("../../../../waves/LinkPreviewCard");
+  return module.default as LinkPreviewCardComponent;
+};
+
+interface SmartLinkHandler<T> {
+  parse: (href: string) => T | null;
+  render: (result: T, href: string) => ReactElement | null;
+}
+
+const matchesDomainOrSubdomain = (host: string, domain: string): boolean => {
+  return host === domain || host.endsWith(`.${domain}`);
+};
+
+const parseTwitterLink = (
+  href: string
+): { href: string; tweetId: string } | null => {
+  const twitterRegex =
+    /https:\/\/(?:twitter\.com|x\.com)\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)/;
+  const match = href.match(twitterRegex);
+  return match ? { href, tweetId: match[3] } : null;
+};
+
+const parseGifLink = (href: string): string | null => {
+  const gifRegex = /^https?:\/\/media\.tenor\.com\/[^\s]+\.gif$/i;
+  return gifRegex.test(href) ? href : null;
+};
+
+const renderTweetFallback = (href: string) => (
+  <a
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="tw-flex tw-h-full tw-w-full tw-flex-col tw-justify-center tw-gap-y-1 tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900 tw-p-4 tw-text-left tw-no-underline tw-transition-colors tw-duration-200 hover:tw-border-iron-500 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400"
+  >
+    <span className="tw-text-sm tw-font-medium tw-text-iron-100">
+      Tweet unavailable
+    </span>
+    <span className="tw-text-xs tw-text-iron-400">Open on X</span>
+  </a>
+);
+
+const renderTweetEmbed = (result: { href: string; tweetId: string }) => {
+  const renderFallback = () => renderTweetFallback(result.href);
+  const TweetNotFound: TwitterComponents["TweetNotFound"] = () => renderFallback();
+  const ChatItemHrefButtons = getChatItemHrefButtons();
+
+  return (
+    <div className="tw-flex tw-items-stretch tw-w-full tw-gap-x-1">
+      <div className="tw-flex-1 tw-min-w-0" data-theme="dark">
+        <ErrorBoundary fallbackRender={() => renderFallback()}>
+          <Tweet id={result.tweetId} components={{ TweetNotFound }} />
+        </ErrorBoundary>
+      </div>
+      <ChatItemHrefButtons href={result.href} />
+    </div>
+  );
+};
+
+const renderGifEmbed = (url: string) => (
+  <img
+    src={url}
+    alt={url}
+    className="tw-max-h-[25rem] tw-max-w-[100%] tw-h-auto"
+  />
+);
+
+const renderSeizeQuote = (
+  quoteLinkInfo: SeizeQuoteLinkInfo,
+  onQuoteClick: (drop: ApiDrop) => void,
+  href: string
+) => {
+  const { waveId, serialNo, dropId } = quoteLinkInfo;
+  const ChatItemHrefButtons = getChatItemHrefButtons();
+
+  if (serialNo) {
+    const WaveDropQuoteWithSerialNo = getWaveDropQuoteWithSerialNo();
+    return (
+      <div className="tw-flex tw-items-stretch tw-w-full tw-gap-x-1">
+        <div className="tw-flex-1 tw-min-w-0">
+          <WaveDropQuoteWithSerialNo
+            serialNo={parseInt(serialNo)}
+            waveId={waveId}
+            onQuoteClick={onQuoteClick}
+          />
+        </div>
+        <ChatItemHrefButtons href={href} hideLink />
+      </div>
+    );
+  }
+
+  if (dropId) {
+    const WaveDropQuoteWithDropId = getWaveDropQuoteWithDropId();
+    return (
+      <div className="tw-flex tw-items-stretch tw-w-full tw-gap-x-1">
+        <div className="tw-flex-1 tw-min-w-0">
+          <WaveDropQuoteWithDropId
+            dropId={dropId}
+            partId={1}
+            maybeDrop={null}
+            onQuoteClick={onQuoteClick}
+          />
+        </div>
+        <ChatItemHrefButtons
+          href={href}
+          relativeHref={`/my-stream?wave=${waveId}&drop=${dropId}`}
+        />
+      </div>
+    );
+  }
+
+  return null;
+};
+
+const shouldUseOpenGraphPreview = (href: string): boolean => {
+  const baseEndpoint = process.env.BASE_ENDPOINT;
+
+  try {
+    const parsed = new URL(href);
+    const protocol = parsed.protocol.toLowerCase();
+    if (protocol !== "http:" && protocol !== "https:") {
+      return false;
+    }
+
+    if (baseEndpoint) {
+      try {
+        const baseUrl = new URL(baseEndpoint);
+        if (parsed.host === baseUrl.host) {
+          return false;
+        }
+      } catch {
+        if (href.startsWith(baseEndpoint)) {
+          return false;
+        }
+      }
+    }
+
+    const hostname = parsed.hostname.toLowerCase();
+    const youtubeDomains = ["youtube.com", "youtube-nocookie.com"];
+    const twitterDomains = ["twitter.com", "x.com"];
+    const artBlocksDomains = [
+      "artblocks.io",
+      "live.artblocks.io",
+      "media.artblocks.io",
+      "media-proxy.artblocks.io",
+      "token.artblocks.io",
+    ];
+
+    if (
+      hostname === "youtu.be" ||
+      youtubeDomains.some((domain) => matchesDomainOrSubdomain(hostname, domain)) ||
+      twitterDomains.some((domain) => matchesDomainOrSubdomain(hostname, domain)) ||
+      artBlocksDomains.some((domain) => matchesDomainOrSubdomain(hostname, domain))
+    ) {
+      return false;
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const renderExternalOrInternalLink = (
+  href: string,
+  props: AnchorHTMLAttributes<HTMLAnchorElement> & ExtraProps
+) => {
+  const baseEndpoint = process.env.BASE_ENDPOINT ?? "";
+  const isExternalLink = baseEndpoint && !href.startsWith(baseEndpoint);
+  const { onClick, ...restProps } = props;
+  const anchorProps: AnchorHTMLAttributes<HTMLAnchorElement> & ExtraProps = {
+    ...restProps,
+    href,
+  };
+
+  if (isExternalLink) {
+    anchorProps.rel = "noopener noreferrer nofollow";
+    anchorProps.target = "_blank";
+  } else {
+    anchorProps.href = href.replace(baseEndpoint, "");
+  }
+
+  return (
+    <a
+      {...anchorProps}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (typeof onClick === "function") {
+          onClick(e);
+        }
+      }}
+    />
+  );
+};
+
+const createSmartLinkHandlers = (
+  onQuoteClick: (drop: ApiDrop) => void,
+  isArtBlocksCardEnabled: boolean
+): SmartLinkHandler<any>[] => {
+  const handlers: SmartLinkHandler<any>[] = [
+    {
+      parse: parseSeizeQuoteLink,
+      render: (result: SeizeQuoteLinkInfo, href: string) =>
+        renderSeizeQuote(result, onQuoteClick, href),
+    },
+    {
+      parse: (href: string) => parseSeizeQueryLink(href, "/network", ["group"]),
+      render: (result: { group: string }, href: string) => {
+        const GroupCardChat = getGroupCardChat();
+        return <GroupCardChat href={href} groupId={result.group} />;
+      },
+    },
+    {
+      parse: (href: string) =>
+        parseSeizeQueryLink(href, "/my-stream", ["wave"], true),
+      render: (result: { wave: string }, href: string) => {
+        const WaveItemChat = getWaveItemChat();
+        return <WaveItemChat href={href} waveId={result.wave} />;
+      },
+    },
+    {
+      parse: (href: string) =>
+        parseSeizeQueryLink(href, "/my-stream", ["wave", "drop"], true),
+      render: (result: { drop: string }, href: string) => {
+        const DropItemChat = getDropItemChat();
+        return <DropItemChat href={href} dropId={result.drop} />;
+      },
+    },
+    {
+      parse: parseTwitterLink,
+      render: (result: { href: string; tweetId: string }) =>
+        renderTweetEmbed(result),
+    },
+    {
+      parse: parseGifLink,
+      render: (url: string) => renderGifEmbed(url),
+    },
+  ];
+
+  if (isArtBlocksCardEnabled) {
+    handlers.push({
+      parse: parseArtBlocksLink,
+      render: (
+        artBlocksId: { tokenId: string; contract?: string },
+        href: string
+      ) => {
+        const ChatItemHrefButtons = getChatItemHrefButtons();
+        return (
+          <div className="tw-flex tw-items-stretch tw-w-full tw-gap-x-1">
+            <div className="tw-flex-1 tw-min-w-0">
+              <ArtBlocksTokenCard href={href} id={artBlocksId} />
+            </div>
+            <ChatItemHrefButtons href={href} />
+          </div>
+        );
+      },
+    });
+  }
+
+  return handlers;
+};
+
+const isValidLink = (href: string): boolean => {
+  try {
+    new URL(href);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export interface LinkRendererConfig {
+  readonly onQuoteClick: (drop: ApiDrop) => void;
+  readonly isArtBlocksCardEnabled: boolean;
+}
+
+export interface LinkRenderer {
+  readonly renderAnchor: (
+    params: ClassAttributes<HTMLAnchorElement> &
+      AnchorHTMLAttributes<HTMLAnchorElement> &
+      ExtraProps
+  ) => ReactElement | null;
+  readonly isSmartLink: (href: string) => boolean;
+  readonly renderImage: (
+    params: ClassAttributes<HTMLImageElement> &
+      ImgHTMLAttributes<HTMLImageElement> &
+      ExtraProps
+  ) => ReactElement | null;
+}
+
+export const createLinkRenderer = ({
+  onQuoteClick,
+  isArtBlocksCardEnabled,
+}: LinkRendererConfig): LinkRenderer => {
+  const smartLinkHandlers = createSmartLinkHandlers(
+    onQuoteClick,
+    isArtBlocksCardEnabled
+  );
+
+  const renderImage: LinkRenderer["renderImage"] = ({
+    ...props
+  }) => {
+    if (typeof props.src !== "string") {
+      return null;
+    }
+
+    const DropPartMarkdownImage = getDropPartMarkdownImage();
+    return <DropPartMarkdownImage src={props.src} />;
+  };
+
+  const renderAnchor: LinkRenderer["renderAnchor"] = ({
+    ...props
+  }) => {
+    const { href } = props;
+    if (!href || !isValidLink(href)) {
+      return null;
+    }
+
+    const youtubeInfo = parseYoutubeLink(href);
+    if (youtubeInfo) {
+      return (
+        <YoutubePreview
+          href={youtubeInfo.url}
+          videoId={youtubeInfo.videoId}
+          renderFallback={() => renderExternalOrInternalLink(href, props)}
+        />
+      );
+    }
+
+    for (const { parse, render } of smartLinkHandlers) {
+      const result = parse(href);
+      if (result) {
+        return render(result, href);
+      }
+    }
+
+    if (shouldUseOpenGraphPreview(href)) {
+      const LinkPreviewCard = getLinkPreviewCard();
+      return (
+        <LinkPreviewCard
+          href={href}
+          renderFallback={() => renderExternalOrInternalLink(href, props)}
+        />
+      );
+    }
+
+    return renderExternalOrInternalLink(href, props);
+  };
+
+  const isSmartLink = (href: string): boolean => {
+    if (parseYoutubeLink(href)) {
+      return true;
+    }
+
+    if (smartLinkHandlers.some((handler) => !!handler.parse(href))) {
+      return true;
+    }
+
+    return shouldUseOpenGraphPreview(href);
+  };
+
+  return {
+    renderAnchor,
+    isSmartLink,
+    renderImage,
+  };
+};
+
+export const isArtBlocksFeatureEnabled = () => {
+  const artBlocksFeatureFlags = [
+    process.env.VITE_FEATURE_AB_CARD,
+    process.env.NEXT_PUBLIC_VITE_FEATURE_AB_CARD,
+    process.env.NEXT_PUBLIC_FEATURE_AB_CARD,
+    process.env.FEATURE_AB_CARD,
+  ];
+
+  return artBlocksFeatureFlags.some((flag) => flag === "true");
+};

--- a/components/drops/view/part/dropPartMarkdown/youtube.ts
+++ b/components/drops/view/part/dropPartMarkdown/youtube.ts
@@ -1,0 +1,72 @@
+export interface YoutubeLinkInfo {
+  readonly videoId: string;
+  readonly url: string;
+}
+
+const matchesDomainOrSubdomain = (host: string, domain: string): boolean => {
+  return host === domain || host.endsWith(`.${domain}`);
+};
+
+export const parseYoutubeLink = (href: string): YoutubeLinkInfo | null => {
+  try {
+    const url = new URL(href);
+    const normalizedHost = url.hostname.replace(/^www\./i, "").toLowerCase();
+    const youtubeDomains = ["youtube.com", "youtube-nocookie.com"];
+    const isYoutubeDomain = youtubeDomains.some((domain) =>
+      matchesDomainOrSubdomain(normalizedHost, domain)
+    );
+
+    let videoId: string | null = null;
+
+    if (normalizedHost === "youtu.be") {
+      const pathSegments = url.pathname.split("/").filter(Boolean);
+      videoId = pathSegments[0] ?? null;
+    } else if (isYoutubeDomain) {
+      const pathSegments = url.pathname.split("/").filter(Boolean);
+
+      if (url.pathname === "/watch" || url.pathname === "/watch/") {
+        videoId = url.searchParams.get("v");
+      } else if (pathSegments[0] === "shorts") {
+        videoId = pathSegments[1] ?? null;
+      } else if (pathSegments[0] === "embed") {
+        videoId = pathSegments[1] ?? null;
+      } else if (pathSegments[0] === "live") {
+        videoId = pathSegments[1] ?? null;
+      } else if (pathSegments[0] === "v") {
+        videoId = pathSegments[1] ?? null;
+      }
+    }
+
+    if (!videoId) {
+      return null;
+    }
+
+    const trimmed = videoId.trim();
+    if (!trimmed.match(/^[A-Za-z0-9_-]{6,}$/)) {
+      return null;
+    }
+
+    return { videoId: trimmed, url: href };
+  } catch {
+    return null;
+  }
+};
+
+export const getYoutubeFetchUrl = (href: string, videoId: string): string => {
+  try {
+    const url = new URL(href);
+    const canonical = new URL(`https://www.youtube.com/watch?v=${videoId}`);
+    const preservedParams = ["list", "index"] as const;
+
+    preservedParams.forEach((param) => {
+      const value = url.searchParams.get(param);
+      if (value) {
+        canonical.searchParams.set(param, value);
+      }
+    });
+
+    return canonical.toString();
+  } catch {
+    return `https://www.youtube.com/watch?v=${videoId}`;
+  }
+};

--- a/components/drops/view/part/dropPartMarkdown/youtubePreview.tsx
+++ b/components/drops/view/part/dropPartMarkdown/youtubePreview.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useState, type ReactElement } from "react";
+import {
+  fetchYoutubePreview,
+  YoutubeOEmbedResponse,
+} from "@/services/api/youtube";
+
+import { getYoutubeFetchUrl } from "./youtube";
+
+type ChatItemHrefButtonsComponent = typeof import("../../../../waves/ChatItemHrefButtons").default;
+
+const getChatItemHrefButtons = (): ChatItemHrefButtonsComponent => {
+  const module = require("../../../../waves/ChatItemHrefButtons");
+  return module.default as ChatItemHrefButtonsComponent;
+};
+
+const normalizeYoutubeHtml = (html: string): string => {
+  let normalized = html.replace(/width="[^"]*"/i, 'width="100%"');
+  normalized = normalized.replace(/height="[^"]*"/i, 'height="100%"');
+
+  if (/style="[^"]*"/i.test(normalized)) {
+    normalized = normalized.replace(
+      /style="([^"]*)"/i,
+      (_, styles: string) => {
+        const cleanedStyles = styles.replace(/;?\s*$/, "");
+        return `style="${cleanedStyles};width:100%;height:100%;"`;
+      }
+    );
+  } else {
+    normalized = normalized.replace(
+      /<iframe/i,
+      '<iframe style="width:100%;height:100%;"'
+    );
+  }
+
+  return normalized;
+};
+
+export interface YoutubePreviewProps {
+  readonly href: string;
+  readonly videoId: string;
+  readonly renderFallback: () => ReactElement | null;
+}
+
+const YoutubePreview = ({
+  href,
+  videoId,
+  renderFallback,
+}: YoutubePreviewProps) => {
+  const [preview, setPreview] = useState<YoutubeOEmbedResponse | null>(null);
+  const [hasError, setHasError] = useState(false);
+  const [showEmbed, setShowEmbed] = useState(false);
+
+  useEffect(() => {
+    const abortController = new AbortController();
+    let isActive = true;
+
+    setPreview(null);
+    setHasError(false);
+    setShowEmbed(false);
+
+    const fetchUrl = getYoutubeFetchUrl(href, videoId);
+
+    fetchYoutubePreview(fetchUrl, abortController.signal)
+      .then((data) => {
+        if (!isActive) {
+          return;
+        }
+
+        if (data) {
+          setPreview({
+            ...data,
+            html: normalizeYoutubeHtml(data.html),
+          });
+        } else {
+          setHasError(true);
+        }
+      })
+      .catch((error) => {
+        if (!isActive) {
+          return;
+        }
+
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+
+        setHasError(true);
+      });
+
+    return () => {
+      isActive = false;
+      abortController.abort();
+    };
+  }, [href, videoId]);
+
+  if (hasError) {
+    return renderFallback();
+  }
+
+  const ChatItemHrefButtons = getChatItemHrefButtons();
+
+  if (!preview) {
+    return (
+      <div className="tw-flex tw-items-stretch tw-w-full tw-gap-x-1">
+        <div className="tw-flex-1 tw-min-w-0">
+          <div className="tw-aspect-video tw-w-full tw-rounded-lg tw-bg-iron-800 tw-animate-pulse" />
+        </div>
+        <ChatItemHrefButtons href={href} />
+      </div>
+    );
+  }
+
+  const ariaLabel = preview.title
+    ? `Play YouTube video ${preview.title}`
+    : `Play YouTube video ${videoId}`;
+
+  return (
+    <div className="tw-flex tw-items-stretch tw-w-full tw-gap-x-1">
+      <div className="tw-flex-1 tw-min-w-0">
+        <div className="tw-relative tw-overflow-hidden tw-rounded-lg tw-bg-black">
+          {showEmbed ? (
+            <div
+              className="tw-relative tw-w-full tw-aspect-video tw-bg-black"
+              data-testid="youtube-embed"
+              dangerouslySetInnerHTML={{ __html: preview.html }}
+            />
+          ) : (
+            <button
+              type="button"
+              className="tw-relative tw-w-full tw-aspect-video tw-border-0 tw-bg-transparent tw-p-0 tw-cursor-pointer"
+              onClick={() => setShowEmbed(true)}
+              aria-label={ariaLabel}
+            >
+              <img
+                src={preview.thumbnail_url}
+                alt={preview.title ?? `YouTube video ${videoId}`}
+                className="tw-h-full tw-w-full tw-object-cover"
+              />
+              <div className="tw-absolute tw-inset-0 tw-flex tw-items-center tw-justify-center tw-bg-black/40">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  className="tw-h-12 tw-w-12 tw-text-white tw-opacity-90"
+                  aria-hidden="true"
+                >
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+              </div>
+            </button>
+          )}
+        </div>
+        <div className="tw-mt-2 tw-space-y-1">
+          {preview.title && (
+            <p className="tw-text-sm tw-font-semibold tw-text-iron-100 tw-mb-0">
+              {preview.title}
+            </p>
+          )}
+          {preview.author_name && (
+            <p className="tw-text-xs tw-text-iron-400 tw-mb-0">
+              {preview.author_name}
+            </p>
+          )}
+        </div>
+      </div>
+      <ChatItemHrefButtons href={href} />
+    </div>
+  );
+};
+
+export default YoutubePreview;


### PR DESCRIPTION
## Summary
- split the monolithic DropPartMarkdown into memoized renderer wiring that consumes dedicated helper modules
- add content renderer utilities that handle mentions, emoji parsing, and paragraph splitting while lazy-loading heavy dependencies
- introduce link handling and YouTube helper modules to manage smart embeds, previews, and feature flags without eager imports

## Testing
- npm run lint
- npm run test -- --runTestsByPath __tests__/components/drops/view/part/DropPartMarkdown.test.tsx
- npm run test *(fails: BASE_ENDPOINT environment variable is required in unrelated suites)*
- npm run type-check *(fails: pre-existing type errors across test fixtures and wagmi mocks)*

------
https://chatgpt.com/codex/tasks/task_e_68ca99f56f54832189408e488e687982