### PR TITLE
fix: stabilize link preview fallback layout

### DIFF
--- a/components/waves/LinkPreviewCard.tsx
+++ b/components/waves/LinkPreviewCard.tsx
@@ -4,6 +4,8 @@ import { type ReactElement, useEffect, useState } from "react";
 
 import OpenGraphPreview, {
   hasOpenGraphContent,
+  LinkPreviewCardLayout,
+  LINK_PREVIEW_CARD_MIN_HEIGHT_CLASS,
   type OpenGraphPreviewData,
 } from "./OpenGraphPreview";
 import { fetchLinkPreview } from "../../services/api/link-preview-api";
@@ -75,7 +77,18 @@ export default function LinkPreviewCard({
   }, [href]);
 
   if (state.type === "fallback") {
-    return renderFallback();
+    const fallbackContent = renderFallback();
+
+    return (
+      <LinkPreviewCardLayout href={href}>
+        <div
+          className={`tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/40 tw-p-4 ${LINK_PREVIEW_CARD_MIN_HEIGHT_CLASS}`}>
+          <div className="tw-flex tw-h-full tw-w-full tw-items-center tw-justify-start">
+            {fallbackContent}
+          </div>
+        </div>
+      </LinkPreviewCardLayout>
+    );
   }
 
   const preview = state.type === "success" ? state.data : undefined;

--- a/components/waves/OpenGraphPreview.tsx
+++ b/components/waves/OpenGraphPreview.tsx
@@ -1,3 +1,5 @@
+import { type ReactNode } from "react";
+
 import Image from "next/image";
 import Link from "next/link";
 
@@ -49,7 +51,7 @@ const IMAGE_KEYS = [
   "secureUrl",
 ];
 const IMAGE_COLLECTION_KEYS = ["images", "ogImages", "og_images", "thumbnails"];
-const CARD_MIN_HEIGHT_CLASS = "tw-min-h-[12rem]";
+export const LINK_PREVIEW_CARD_MIN_HEIGHT_CLASS = "tw-min-h-[12rem]";
 
 function readFirstString(
   data: OpenGraphPreviewData | null | undefined,
@@ -186,6 +188,23 @@ function getRelativeHref(href: string): string | undefined {
   return relative.startsWith("/") ? relative : undefined;
 }
 
+export function LinkPreviewCardLayout({
+  href,
+  children,
+}: {
+  readonly href: string;
+  readonly children: ReactNode;
+}) {
+  const relativeHref = getRelativeHref(href);
+
+  return (
+    <div className="tw-flex tw-w-full tw-items-stretch tw-gap-x-1">
+      <div className="tw-flex-1 tw-min-w-0">{children}</div>
+      <ChatItemHrefButtons href={href} relativeHref={relativeHref} />
+    </div>
+  );
+}
+
 export function hasOpenGraphContent(
   preview: OpenGraphPreviewData | null | undefined
 ): boolean {
@@ -212,22 +231,19 @@ export default function OpenGraphPreview({
 
   if (typeof preview === "undefined") {
     return (
-      <div className="tw-flex tw-w-full tw-items-stretch tw-gap-x-1">
-        <div className="tw-flex-1 tw-min-w-0">
+      <LinkPreviewCardLayout href={href}>
+        <div
+          className={`tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/40 tw-p-4 ${LINK_PREVIEW_CARD_MIN_HEIGHT_CLASS}`}>
           <div
-            className={`tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/40 tw-p-4 ${CARD_MIN_HEIGHT_CLASS}`}>
-            <div
-              className="tw-animate-pulse tw-flex tw-flex-col tw-gap-y-3"
-              data-testid="og-preview-skeleton">
-              <div className="tw-aspect-video tw-w-full tw-rounded-lg tw-bg-iron-800/60" />
-              <div className="tw-h-4 tw-w-3/4 tw-rounded tw-bg-iron-800/40" />
-              <div className="tw-h-3 tw-w-full tw-rounded tw-bg-iron-800/30" />
-              <div className="tw-h-3 tw-w-2/3 tw-rounded tw-bg-iron-800/20" />
-            </div>
+            className="tw-animate-pulse tw-flex tw-flex-col tw-gap-y-3"
+            data-testid="og-preview-skeleton">
+            <div className="tw-aspect-video tw-w-full tw-rounded-lg tw-bg-iron-800/60" />
+            <div className="tw-h-4 tw-w-3/4 tw-rounded tw-bg-iron-800/40" />
+            <div className="tw-h-3 tw-w-full tw-rounded tw-bg-iron-800/30" />
+            <div className="tw-h-3 tw-w-2/3 tw-rounded tw-bg-iron-800/20" />
           </div>
         </div>
-        <ChatItemHrefButtons href={href} relativeHref={relativeHref} />
-      </div>
+      </LinkPreviewCardLayout>
     );
   }
 
@@ -239,80 +255,74 @@ export default function OpenGraphPreview({
 
   if (!hasContent) {
     return (
-      <div className="tw-flex tw-w-full tw-items-stretch tw-gap-x-1">
-        <div className="tw-flex-1 tw-min-w-0">
-          <div
-            className={`tw-flex tw-h-full tw-items-center tw-justify-center tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/40 tw-p-6 ${CARD_MIN_HEIGHT_CLASS}`}
-            data-testid="og-preview-unavailable">
-            <div className="tw-text-center tw-space-y-2">
-              <p className="tw-m-0 tw-text-sm tw-font-medium tw-text-iron-400">
-                Link unavailable
-              </p>
-              <Link
-                href={effectiveHref}
-                target={linkTarget}
-                rel={linkRel}
-                className="tw-text-sm tw-font-semibold tw-text-iron-100 tw-no-underline tw-transition tw-duration-200 hover:tw-text-white">
-                {domain ?? href}
-              </Link>
-            </div>
+      <LinkPreviewCardLayout href={href}>
+        <div
+          className={`tw-flex tw-h-full tw-items-center tw-justify-center tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/40 tw-p-6 ${LINK_PREVIEW_CARD_MIN_HEIGHT_CLASS}`}
+          data-testid="og-preview-unavailable">
+          <div className="tw-text-center tw-space-y-2">
+            <p className="tw-m-0 tw-text-sm tw-font-medium tw-text-iron-400">
+              Link unavailable
+            </p>
+            <Link
+              href={effectiveHref}
+              target={linkTarget}
+              rel={linkRel}
+              className="tw-text-sm tw-font-semibold tw-text-iron-100 tw-no-underline tw-transition tw-duration-200 hover:tw-text-white">
+              {domain ?? href}
+            </Link>
           </div>
         </div>
-        <ChatItemHrefButtons href={href} relativeHref={relativeHref} />
-      </div>
+      </LinkPreviewCardLayout>
     );
   }
 
   return (
-    <div className="tw-flex tw-w-full tw-items-stretch tw-gap-x-1">
-      <div className="tw-flex-1 tw-min-w-0">
-        <div
-          className={`tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/40 tw-p-4 ${CARD_MIN_HEIGHT_CLASS}`}
-          data-testid="og-preview-card">
-          <div className="tw-flex tw-flex-col tw-gap-4 md:tw-flex-row">
-            {imageUrl && (
-              <Link
-                href={effectiveHref}
-                target={linkTarget}
-                rel={linkRel}
-                className="tw-block md:tw-w-60 md:tw-flex-shrink-0">
-                <div className="tw-overflow-hidden tw-rounded-lg tw-bg-iron-900/60">
-                  <Image
-                    src={imageUrl}
-                    alt={title ?? domain ?? "Link preview"}
-                    width={1200}
-                    height={630}
-                    className="tw-h-full tw-w-full tw-object-cover"
-                    loading="lazy"
-                    sizes="(max-width: 768px) 100vw, 240px"
-                    unoptimized
-                  />
-                </div>
-              </Link>
+    <LinkPreviewCardLayout href={href}>
+      <div
+        className={`tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/40 tw-p-4 ${LINK_PREVIEW_CARD_MIN_HEIGHT_CLASS}`}
+        data-testid="og-preview-card">
+        <div className="tw-flex tw-flex-col tw-gap-4 md:tw-flex-row">
+          {imageUrl && (
+            <Link
+              href={effectiveHref}
+              target={linkTarget}
+              rel={linkRel}
+              className="tw-block md:tw-w-60 md:tw-flex-shrink-0">
+              <div className="tw-overflow-hidden tw-rounded-lg tw-bg-iron-900/60">
+                <Image
+                  src={imageUrl}
+                  alt={title ?? domain ?? "Link preview"}
+                  width={1200}
+                  height={630}
+                  className="tw-h-full tw-w-full tw-object-cover"
+                  loading="lazy"
+                  sizes="(max-width: 768px) 100vw, 240px"
+                  unoptimized
+                />
+              </div>
+            </Link>
+          )}
+          <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-y-2">
+            {domain && (
+              <span className="tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-iron-400">
+                {domain}
+              </span>
             )}
-            <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-y-2">
-              {domain && (
-                <span className="tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-iron-400">
-                  {domain}
-                </span>
-              )}
-              <Link
-                href={effectiveHref}
-                target={linkTarget}
-                rel={linkRel}
-                className="tw-text-lg tw-font-semibold tw-leading-snug tw-text-iron-100 tw-no-underline tw-transition tw-duration-200 hover:tw-text-white">
-                {title ?? domain ?? href}
-              </Link>
-              {description && (
-                <p className="tw-m-0 tw-text-sm tw-text-iron-300 tw-line-clamp-3 tw-break-words tw-whitespace-pre-line">
-                  {description}
-                </p>
-              )}
-            </div>
+            <Link
+              href={effectiveHref}
+              target={linkTarget}
+              rel={linkRel}
+              className="tw-text-lg tw-font-semibold tw-leading-snug tw-text-iron-100 tw-no-underline tw-transition tw-duration-200 hover:tw-text-white">
+              {title ?? domain ?? href}
+            </Link>
+            {description && (
+              <p className="tw-m-0 tw-text-sm tw-text-iron-300 tw-line-clamp-3 tw-break-words tw-whitespace-pre-line">
+                {description}
+              </p>
+            )}
           </div>
         </div>
       </div>
-      <ChatItemHrefButtons href={href} relativeHref={relativeHref} />
-    </div>
+    </LinkPreviewCardLayout>
   );
 }


### PR DESCRIPTION
## Summary
- share a dedicated link preview layout helper to keep skeleton, empty state, and rich previews at a consistent height
- wrap link preview fallback content in the shared layout so card space does not collapse when Open Graph data is unavailable

## Testing
- `npm run lint`
- `CI=1 BASE_ENDPOINT=http://localhost npx jest __tests__/components/waves/LinkPreviewCard.test.tsx __tests__/components/waves/OpenGraphPreview.test.tsx --runInBand --watchAll=false --forceExit`
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_68caa296f0c88321af93e22e428f8779