### PR TITLE
feat: add Compound link previews

### DIFF
--- a/__tests__/app/api/open-graph.route.test.ts
+++ b/__tests__/app/api/open-graph.route.test.ts
@@ -23,9 +23,17 @@ jest.mock("../../../app/api/open-graph/utils", () => {
   };
 });
 
+jest.mock("../../../app/api/open-graph/compound/service", () => ({
+  createCompoundPlan: jest.fn(() => null),
+}));
+
 const utils = jest.requireMock("../../../app/api/open-graph/utils") as {
   buildResponse: jest.Mock;
   ensureUrlIsPublic: jest.Mock;
+};
+
+const compound = jest.requireMock("../../../app/api/open-graph/compound/service") as {
+  createCompoundPlan: jest.Mock;
 };
 
 const originalFetch = global.fetch;
@@ -97,6 +105,7 @@ describe("open-graph API route", () => {
     expect(response.status).toBe(502);
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(utils.buildResponse).not.toHaveBeenCalled();
+    expect(compound.createCompoundPlan).toHaveBeenCalled();
   });
 
   it("follows safe redirects after validating each hop", async () => {
@@ -167,5 +176,6 @@ describe("open-graph API route", () => {
       html,
       "text/html"
     );
+    expect(compound.createCompoundPlan).toHaveBeenCalled();
   });
 });

--- a/__tests__/components/waves/LinkPreviewCard.test.tsx
+++ b/__tests__/components/waves/LinkPreviewCard.test.tsx
@@ -7,6 +7,17 @@ const mockOpenGraphPreview = jest.fn(({ href, preview }: any) => (
   <div data-testid="open-graph" data-href={href} data-preview={preview ? "ready" : "loading"} />
 ));
 
+const mockCompoundCard = jest.fn(({ href, response }: any) => (
+  <div data-testid="compound-card" data-href={href} data-type={response?.type} />
+));
+
+const mockToCompoundResponse = jest.fn((value: any) => {
+  if (value && typeof value === "object" && typeof value.type === "string" && value.type.startsWith("compound.")) {
+    return value;
+  }
+  return undefined;
+});
+
 jest.mock("../../../components/waves/OpenGraphPreview", () => {
   const actual = jest.requireActual("../../../components/waves/OpenGraphPreview");
   return {
@@ -15,6 +26,12 @@ jest.mock("../../../components/waves/OpenGraphPreview", () => {
     default: (props: any) => mockOpenGraphPreview(props),
   };
 });
+
+jest.mock("../../../components/waves/compound/CompoundCard", () => ({
+  __esModule: true,
+  default: (props: any) => mockCompoundCard(props),
+  toCompoundResponse: (value: unknown) => mockToCompoundResponse(value),
+}));
 
 jest.mock("../../../services/api/link-preview-api", () => ({
   fetchLinkPreview: jest.fn(),
@@ -58,6 +75,51 @@ describe("LinkPreviewCard", () => {
     );
 
     expect(fetchLinkPreview).toHaveBeenCalledWith("https://example.com/article");
+    expect(screen.queryByTestId("fallback")).toBeNull();
+  });
+
+  it("renders compound card when compound data is returned", async () => {
+    const compoundResponse = {
+      type: "compound.market",
+      version: "v2",
+      chainId: 1,
+      market: {
+        cToken: "0xToken",
+        symbol: "cUSDC",
+        underlying: { address: "0xUnderlying", symbol: "USDC", decimals: 6 },
+      },
+      metrics: {
+        supplyApy: "0.01",
+        borrowApy: "0.02",
+        utilization: "0.5",
+        tvlUnderlying: "1000",
+        tvlUsd: "1000",
+        collateralFactor: "0.5",
+        reserveFactor: "0.1",
+        exchangeRate: "0.02",
+      },
+      links: {},
+    };
+
+    fetchLinkPreview.mockResolvedValue(compoundResponse);
+
+    render(
+      <LinkPreviewCard
+        href="https://example.com/compound"
+        renderFallback={() => <div data-testid="fallback">fallback</div>}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockCompoundCard).toHaveBeenCalledWith(
+        expect.objectContaining({
+          href: "https://example.com/compound",
+          response: compoundResponse,
+        })
+      );
+    });
+
+    expect(mockToCompoundResponse).toHaveBeenCalledWith(compoundResponse);
     expect(screen.queryByTestId("fallback")).toBeNull();
   });
 

--- a/app/api/open-graph/compound/abis.ts
+++ b/app/api/open-graph/compound/abis.ts
@@ -1,0 +1,61 @@
+import { parseAbi } from "viem";
+
+export const cTokenAbi = parseAbi([
+  "function symbol() view returns (string)",
+  "function name() view returns (string)",
+  "function decimals() view returns (uint8)",
+  "function exchangeRateStored() view returns (uint256)",
+  "function totalBorrows() view returns (uint256)",
+  "function totalReserves() view returns (uint256)",
+  "function totalSupply() view returns (uint256)",
+  "function cash() view returns (uint256)",
+  "function reserveFactorMantissa() view returns (uint256)",
+  "function supplyRatePerBlock() view returns (uint256)",
+  "function borrowRatePerBlock() view returns (uint256)",
+  "function underlying() view returns (address)",
+  "function balanceOf(address) view returns (uint256)",
+  "function borrowBalanceStored(address) view returns (uint256)",
+  "event Mint(address indexed minter, uint256 mintAmount, uint256 mintTokens)",
+  "event Redeem(address indexed redeemer, uint256 redeemAmount, uint256 redeemTokens)",
+  "event Borrow(address indexed borrower, uint256 borrowAmount, uint256 accountBorrows, uint256 totalBorrows)",
+  "event RepayBorrow(address indexed payer, address indexed borrower, uint256 repayAmount, uint256 accountBorrows, uint256 totalBorrows)",
+  "event LiquidateBorrow(address indexed liquidator, address indexed borrower, uint256 repayAmount, address indexed cTokenCollateral, uint256 seizeTokens)",
+]);
+
+export const comptrollerAbi = parseAbi([
+  "function markets(address) view returns (bool isListed, uint256 collateralFactorMantissa, bool isComped)",
+  "function getAccountLiquidity(address) view returns (uint256, uint256, uint256)",
+  "function compAccrued(address) view returns (uint256)",
+  "function oracle() view returns (address)",
+]);
+
+export const priceOracleAbi = parseAbi([
+  "function getUnderlyingPrice(address) view returns (uint256)",
+]);
+
+export const cometAbi = parseAbi([
+  "function name() view returns (string)",
+  "function symbol() view returns (string)",
+  "function decimals() view returns (uint8)",
+  "function baseToken() view returns (address)",
+  "function totalsBasic() view returns (uint64 baseSupplyIndex, uint64 baseBorrowIndex, uint64 trackingSupplyIndex, uint64 trackingBorrowIndex, uint128 totalSupplyBase, uint128 totalBorrowBase, uint64 lastAccrualTime)",
+  "function getUtilization() view returns (uint256)",
+  "function getSupplyRate(uint256 utilization) view returns (uint64)",
+  "function getBorrowRate(uint256 utilization) view returns (uint64)",
+  "function numAssets() view returns (uint8)",
+  "function getAssetInfo(uint8) view returns (uint8 offset, address asset, address priceFeed, uint64 scale, uint64 borrowCollateralFactor, uint64 liquidateCollateralFactor, uint64 liquidationFactor, uint128 supplyCap)",
+  "function priceFeed() view returns (address)",
+  "function balanceOf(address) view returns (uint256)",
+  "function borrowBalanceOf(address) view returns (uint256)",
+  "function collateralBalanceOf(address, address) view returns (uint128)",
+  "event Supply(address indexed from, address indexed dst, uint256 amount)",
+  "event Withdraw(address indexed src, address indexed to, uint256 amount)",
+  "event AbsorbCollateral(address indexed absorber, address indexed borrower, address indexed asset, uint256 collateralAbsorbed, uint256 usdValue)",
+  "event AbsorbDebt(address indexed absorber, address indexed borrower, uint256 basePaidOut, uint256 usdValue)",
+  "event BuyCollateral(address indexed buyer, address indexed asset, uint256 baseAmount, uint256 collateralAmount)",
+]);
+
+export const priceFeedAbi = parseAbi([
+  "function getPrice(address) view returns (uint256)",
+  "function decimals() view returns (uint8)",
+]);

--- a/app/api/open-graph/compound/client.ts
+++ b/app/api/open-graph/compound/client.ts
@@ -1,0 +1,7 @@
+import { createPublicClient, fallback, http } from "viem";
+import { mainnet } from "viem/chains";
+
+export const publicClient = createPublicClient({
+  chain: mainnet,
+  transport: fallback([http(), http("https://rpc1.6529.io")]),
+});

--- a/app/api/open-graph/compound/registry.json
+++ b/app/api/open-graph/compound/registry.json
@@ -1,0 +1,79 @@
+{
+  "comptroller": "0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B",
+  "v2Markets": [
+    {
+      "address": "0x39AA39c021dfbaE8faC545936693aC917d5E7563",
+      "symbol": "cUSDC",
+      "name": "Compound USD Coin",
+      "appPath": "/markets/usdc",
+      "marketUrl": "https://app.compound.finance/markets/usdc",
+      "underlying": {
+        "address": "0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "decimals": 6
+      }
+    },
+    {
+      "address": "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643",
+      "symbol": "cDAI",
+      "name": "Compound Dai",
+      "appPath": "/markets/dai",
+      "marketUrl": "https://app.compound.finance/markets/dai",
+      "underlying": {
+        "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+        "symbol": "DAI",
+        "decimals": 18
+      }
+    },
+    {
+      "address": "0x4ddc2D193948926d02f9B1fE9e1daa0718270ED5",
+      "symbol": "cETH",
+      "name": "Compound Ether",
+      "appPath": "/markets/eth",
+      "marketUrl": "https://app.compound.finance/markets/eth",
+      "underlying": {
+        "address": "0x0000000000000000000000000000000000000000",
+        "symbol": "ETH",
+        "decimals": 18
+      }
+    },
+    {
+      "address": "0xccF4429DB6322D5C611ee964527D42E5d685DD6a",
+      "symbol": "cWBTC",
+      "name": "Compound Wrapped BTC",
+      "appPath": "/markets/wbtc",
+      "marketUrl": "https://app.compound.finance/markets/wbtc",
+      "underlying": {
+        "address": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        "symbol": "WBTC",
+        "decimals": 8
+      }
+    }
+  ],
+  "v3Markets": [
+    {
+      "address": "0xc3d688B66703497DAA19211EEdff47f25384cdc3",
+      "symbol": "USDC",
+      "name": "Compound USDC Comet",
+      "appPath": "/comet/usdc",
+      "marketUrl": "https://app.compound.finance/comet/usdc",
+      "base": {
+        "address": "0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "symbol": "USDC",
+        "decimals": 6
+      }
+    },
+    {
+      "address": "0xA17581A9E3356d785e831eC38ef7617dCece098a",
+      "symbol": "WETH",
+      "name": "Compound WETH Comet",
+      "appPath": "/comet/eth",
+      "marketUrl": "https://app.compound.finance/comet/eth",
+      "base": {
+        "address": "0xC02aaA39b223FE8D0A0E5C4F27eAD9083C756Cc2",
+        "symbol": "WETH",
+        "decimals": 18
+      }
+    }
+  ]
+}

--- a/app/api/open-graph/compound/registry.ts
+++ b/app/api/open-graph/compound/registry.ts
@@ -1,0 +1,53 @@
+import registry from "./registry.json";
+
+export type CompoundV2MarketConfig = {
+  readonly address: `0x${string}`;
+  readonly symbol: string;
+  readonly name: string;
+  readonly appPath: string;
+  readonly marketUrl: string;
+  readonly underlying: {
+    readonly address: `0x${string}`;
+    readonly symbol: string;
+    readonly decimals: number;
+  };
+};
+
+export type CompoundV3MarketConfig = {
+  readonly address: `0x${string}`;
+  readonly symbol: string;
+  readonly name: string;
+  readonly appPath: string;
+  readonly marketUrl: string;
+  readonly base: {
+    readonly address: `0x${string}`;
+    readonly symbol: string;
+    readonly decimals: number;
+  };
+};
+
+export type CompoundRegistry = {
+  readonly comptroller: `0x${string}`;
+  readonly v2Markets: readonly CompoundV2MarketConfig[];
+  readonly v3Markets: readonly CompoundV3MarketConfig[];
+};
+
+const parsedRegistry = registry as CompoundRegistry;
+
+export const compoundRegistry: CompoundRegistry = parsedRegistry;
+
+export const v2MarketsByAddress = new Map<`0x${string}`, CompoundV2MarketConfig>(
+  parsedRegistry.v2Markets.map((market) => [market.address.toLowerCase() as `0x${string}`, market])
+);
+
+export const v3MarketsByAddress = new Map<`0x${string}`, CompoundV3MarketConfig>(
+  parsedRegistry.v3Markets.map((market) => [market.address.toLowerCase() as `0x${string}`, market])
+);
+
+export const v2MarketsByPath = new Map<string, CompoundV2MarketConfig>(
+  parsedRegistry.v2Markets.map((market) => [market.appPath.toLowerCase(), market])
+);
+
+export const v3MarketsByPath = new Map<string, CompoundV3MarketConfig>(
+  parsedRegistry.v3Markets.map((market) => [market.appPath.toLowerCase(), market])
+);

--- a/app/api/open-graph/compound/service.ts
+++ b/app/api/open-graph/compound/service.ts
@@ -1,0 +1,1158 @@
+import type { LinkPreviewResponse } from "@/services/api/link-preview-api";
+import {
+  decodeEventLog,
+  erc20Abi,
+  formatUnits,
+  getAddress,
+  isAddress,
+  isHex,
+  zeroAddress,
+  type Address,
+  type Hash,
+} from "viem";
+
+import {
+  cTokenAbi,
+  cometAbi,
+  comptrollerAbi,
+  priceFeedAbi,
+  priceOracleAbi,
+} from "./abis";
+import { publicClient } from "./client";
+import {
+  compoundRegistry,
+  v2MarketsByAddress,
+  v2MarketsByPath,
+  v3MarketsByAddress,
+  v3MarketsByPath,
+  type CompoundV2MarketConfig,
+  type CompoundV3MarketConfig,
+} from "./registry";
+
+const BLOCKS_PER_YEAR = 2_365_200;
+const SECONDS_PER_YEAR = 31_536_000;
+
+const V2_MARKET_TTL_MS = 90_000;
+const V3_MARKET_TTL_MS = 90_000;
+const ACCOUNT_TTL_MS = 45_000;
+const TX_TTL_SUCCESS_MS = 24 * 60 * 60 * 1000;
+const TX_TTL_PENDING_MS = 30_000;
+
+const BIGINT_ZERO = BigInt(0);
+const BIGINT_ONE = BigInt(1);
+const BIGINT_TEN = BigInt(10);
+
+function pow10BigInt(exponent: number): bigint {
+  let result = BIGINT_ONE;
+  for (let index = 0; index < exponent; index += 1) {
+    result *= BIGINT_TEN;
+  }
+  return result;
+}
+
+const MANTISSA_1E18 = pow10BigInt(18);
+
+export type PreviewPlan = {
+  readonly cacheKey: string;
+  readonly execute: () => Promise<{ data: LinkPreviewResponse; ttl: number }>;
+};
+
+type CompoundTarget =
+  | { kind: "market"; version: "v2"; market: CompoundV2MarketConfig }
+  | { kind: "market"; version: "v3"; market: CompoundV3MarketConfig }
+  | { kind: "account"; address: Address }
+  | { kind: "tx"; hash: Hash };
+
+const TX_HASH_LENGTH = 66;
+
+function isPossibleTxHash(value: string): value is Hash {
+  return value.startsWith("0x") && value.length === TX_HASH_LENGTH && isHex(value);
+}
+
+function normalizeAddress(value: string): Address | null {
+  if (!isAddress(value)) {
+    return null;
+  }
+  return getAddress(value);
+}
+
+function formatMantissa(value: bigint, precision = 6): string {
+  const asNumber = Number(value) / Number(MANTISSA_1E18);
+  return formatNumber(asNumber, precision);
+}
+
+function formatNumber(value: number, precision = 6): string {
+  if (!Number.isFinite(value)) {
+    return "0";
+  }
+  const fixed = value.toFixed(precision);
+  return trimTrailingZeros(fixed);
+}
+
+function trimTrailingZeros(value: string): string {
+  if (!value.includes(".")) {
+    return value;
+  }
+  return value.replace(/\.0+$/, "").replace(/(\.\d*?)0+$/, "$1");
+}
+
+function formatUnitsWithPrecision(
+  value: bigint,
+  decimals: number,
+  precision = 6
+): string {
+  const formatted = formatUnits(value, decimals);
+  if (formatted.includes(".")) {
+    const [intPart, fracPart] = formatted.split(".");
+    const trimmed = `${intPart}.${fracPart.slice(0, precision)}`;
+    return trimTrailingZeros(trimmed);
+  }
+  return formatted;
+}
+
+function calculateApyFromRatePerBlock(ratePerBlock: bigint): string {
+  if (ratePerBlock === BIGINT_ZERO) {
+    return "0";
+  }
+  const rate = Number(ratePerBlock) / Number(MANTISSA_1E18);
+  const apy = Math.pow(1 + rate, BLOCKS_PER_YEAR) - 1;
+  return formatNumber(apy, 6);
+}
+
+function calculateApyFromRatePerSecond(rate: bigint): string {
+  if (rate === BIGINT_ZERO) {
+    return "0";
+  }
+  const perSecond = Number(rate) / Number(MANTISSA_1E18);
+  const apy = Math.pow(1 + perSecond, SECONDS_PER_YEAR) - 1;
+  return formatNumber(apy, 6);
+}
+
+function calculateUtilization(numerator: bigint, denominator: bigint): string {
+  if (denominator === BIGINT_ZERO) {
+    return "0";
+  }
+  const ratio = Number(numerator) / Number(denominator);
+  return formatNumber(ratio, 6);
+}
+
+function getExchangeRateScale(
+  underlyingDecimals: number,
+  cTokenDecimals: number
+): number {
+  return 18 + underlyingDecimals - cTokenDecimals;
+}
+
+type V2MarketState = {
+  readonly config: CompoundV2MarketConfig;
+  readonly cTokenDecimals: number;
+  readonly exchangeRateStored: bigint;
+  readonly supplyRatePerBlock: bigint;
+  readonly borrowRatePerBlock: bigint;
+  readonly totalBorrows: bigint;
+  readonly totalReserves: bigint;
+  readonly totalSupply: bigint;
+  readonly cash: bigint;
+  readonly reserveFactorMantissa: bigint;
+  readonly collateralFactorMantissa: bigint;
+  readonly underlyingPrice: bigint | null;
+  readonly metrics: {
+    readonly supplyApy: string;
+    readonly borrowApy: string;
+    readonly utilization: string;
+    readonly tvlUnderlying: string;
+    readonly tvlUsd?: string;
+    readonly collateralFactor: string;
+    readonly reserveFactor: string;
+    readonly exchangeRate: string;
+  };
+};
+
+type V3CollateralInfo = {
+  readonly asset: Address;
+  readonly symbol: string;
+  readonly decimals: number;
+  readonly scale: bigint;
+  readonly collateralFactor: string;
+  readonly priceFeed: Address | null;
+  readonly usdPrice?: string;
+};
+
+type V3MarketState = {
+  readonly config: CompoundV3MarketConfig;
+  readonly decimals: number;
+  readonly supplyRate: bigint;
+  readonly borrowRate: bigint;
+  readonly utilization: bigint;
+  readonly totalSupplyBase: bigint;
+  readonly totalBorrowBase: bigint;
+  readonly basePrice: bigint | null;
+  readonly basePriceDecimals: number | null;
+  readonly collaterals: readonly V3CollateralInfo[];
+  readonly metrics: {
+    readonly supplyApy: string;
+    readonly borrowApy: string;
+    readonly utilization: string;
+    readonly totalSupplyBase: string;
+    readonly totalBorrowBase: string;
+    readonly tvlUsd?: string;
+  };
+};
+
+async function fetchV2MarketState(
+  market: CompoundV2MarketConfig
+): Promise<V2MarketState> {
+  const cToken = market.address as Address;
+  const marketResults = await publicClient.multicall({
+    allowFailure: false,
+    contracts: [
+      { address: cToken, abi: cTokenAbi, functionName: "decimals" },
+      { address: cToken, abi: cTokenAbi, functionName: "exchangeRateStored" },
+      { address: cToken, abi: cTokenAbi, functionName: "totalBorrows" },
+      { address: cToken, abi: cTokenAbi, functionName: "totalReserves" },
+      { address: cToken, abi: cTokenAbi, functionName: "totalSupply" },
+      { address: cToken, abi: cTokenAbi, functionName: "cash" },
+      { address: cToken, abi: cTokenAbi, functionName: "reserveFactorMantissa" },
+      { address: cToken, abi: cTokenAbi, functionName: "supplyRatePerBlock" },
+      { address: cToken, abi: cTokenAbi, functionName: "borrowRatePerBlock" },
+    ],
+  });
+
+  const cTokenDecimalsRaw = marketResults[0] as number;
+  const exchangeRateStored = marketResults[1] as bigint;
+  const totalBorrows = marketResults[2] as bigint;
+  const totalReserves = marketResults[3] as bigint;
+  const totalSupply = marketResults[4] as bigint;
+  const cash = marketResults[5] as bigint;
+  const reserveFactorMantissa = marketResults[6] as bigint;
+  const supplyRatePerBlock = marketResults[7] as bigint;
+  const borrowRatePerBlock = marketResults[8] as bigint;
+
+  const [_, collateralFactorMantissa] = await publicClient.readContract({
+    address: compoundRegistry.comptroller as Address,
+    abi: comptrollerAbi,
+    functionName: "markets",
+    args: [cToken],
+  });
+
+  let underlyingPrice: bigint | null = null;
+  try {
+    const oracleAddress = await publicClient.readContract({
+      address: compoundRegistry.comptroller as Address,
+      abi: comptrollerAbi,
+      functionName: "oracle",
+    });
+    if (oracleAddress && oracleAddress !== zeroAddress) {
+      underlyingPrice = await publicClient.readContract({
+        address: oracleAddress,
+        abi: priceOracleAbi,
+        functionName: "getUnderlyingPrice",
+        args: [cToken],
+      });
+    }
+  } catch {
+    underlyingPrice = null;
+  }
+
+  const cTokenDecimals = Number(cTokenDecimalsRaw ?? 0);
+  const underlyingDecimals = market.underlying.decimals;
+  const exchangeRateScale = getExchangeRateScale(underlyingDecimals, cTokenDecimals);
+  const tvlUnderlying = (cash ?? BIGINT_ZERO) + (totalBorrows ?? BIGINT_ZERO) - (totalReserves ?? BIGINT_ZERO);
+
+  const supplyApy = calculateApyFromRatePerBlock(supplyRatePerBlock as bigint);
+  const borrowApy = calculateApyFromRatePerBlock(borrowRatePerBlock as bigint);
+  const utilization = calculateUtilization(
+    totalBorrows ?? BIGINT_ZERO,
+    tvlUnderlying
+  );
+  const collateralFactor = formatMantissa(collateralFactorMantissa as bigint);
+  const reserveFactor = formatMantissa(reserveFactorMantissa as bigint);
+  const exchangeRate = formatUnitsWithPrecision(
+    exchangeRateStored ?? BIGINT_ZERO,
+    exchangeRateScale,
+    10
+  );
+  const tvlUnderlyingDisplay = formatUnitsWithPrecision(
+    tvlUnderlying,
+    underlyingDecimals,
+    6
+  );
+
+  let tvlUsd: string | undefined;
+
+  if (underlyingPrice && underlyingPrice > BIGINT_ZERO) {
+    const tvlUsdScaled =
+      (tvlUnderlying * underlyingPrice) / pow10BigInt(18);
+    tvlUsd = formatUnitsWithPrecision(tvlUsdScaled, 18, 2);
+  }
+
+  return {
+    config: market,
+    cTokenDecimals,
+    exchangeRateStored: exchangeRateStored ?? BIGINT_ZERO,
+    supplyRatePerBlock: supplyRatePerBlock ?? BIGINT_ZERO,
+    borrowRatePerBlock: borrowRatePerBlock ?? BIGINT_ZERO,
+    totalBorrows: totalBorrows ?? BIGINT_ZERO,
+    totalReserves: totalReserves ?? BIGINT_ZERO,
+    totalSupply: totalSupply ?? BIGINT_ZERO,
+    cash: cash ?? BIGINT_ZERO,
+    reserveFactorMantissa: reserveFactorMantissa ?? BIGINT_ZERO,
+    collateralFactorMantissa: collateralFactorMantissa as bigint,
+    underlyingPrice: underlyingPrice ?? null,
+    metrics: {
+      supplyApy,
+      borrowApy,
+      utilization,
+      tvlUnderlying: tvlUnderlyingDisplay,
+      tvlUsd,
+      collateralFactor,
+      reserveFactor,
+      exchangeRate,
+    },
+  };
+}
+
+async function fetchV3MarketState(
+  market: CompoundV3MarketConfig
+): Promise<V3MarketState> {
+  const comet = market.address as Address;
+  const marketCoreResults = await publicClient.multicall({
+    allowFailure: false,
+    contracts: [
+      { address: comet, abi: cometAbi, functionName: "decimals" },
+      { address: comet, abi: cometAbi, functionName: "totalsBasic" },
+      { address: comet, abi: cometAbi, functionName: "getUtilization" },
+      { address: comet, abi: cometAbi, functionName: "numAssets" },
+      { address: comet, abi: cometAbi, functionName: "priceFeed" },
+    ],
+  });
+
+  const decimalsRaw = marketCoreResults[0] as number;
+  const totalsBasic = marketCoreResults[1] as unknown;
+  const utilizationRaw = marketCoreResults[2] as bigint;
+  const numAssetsRaw = marketCoreResults[3] as number;
+  const priceFeedAddress = marketCoreResults[4] as Address;
+
+  const utilizationValue = utilizationRaw ?? BIGINT_ZERO;
+
+  const [supplyRate, borrowRate] = await publicClient.multicall({
+    allowFailure: false,
+    contracts: [
+      {
+        address: comet,
+        abi: cometAbi,
+        functionName: "getSupplyRate",
+        args: [utilizationValue],
+      },
+      {
+        address: comet,
+        abi: cometAbi,
+        functionName: "getBorrowRate",
+        args: [utilizationValue],
+      },
+    ],
+  });
+
+  const decimals = Number(decimalsRaw ?? 0);
+  const {
+    totalSupplyBase,
+    totalBorrowBase,
+  } = totalsBasic as {
+    totalSupplyBase: bigint;
+    totalBorrowBase: bigint;
+  };
+
+  const numAssets = Number(numAssetsRaw ?? 0);
+  const collaterals: V3CollateralInfo[] = [];
+  const collateralCalls = Array.from({ length: numAssets }, (_, index) => ({
+    address: comet,
+    abi: cometAbi,
+    functionName: "getAssetInfo",
+    args: [BigInt(index)],
+  } as const));
+
+  if (collateralCalls.length > 0) {
+    const collateralResults = await publicClient.multicall({
+      allowFailure: false,
+      contracts: collateralCalls,
+    });
+
+    for (const result of collateralResults) {
+      const info = result as unknown as {
+        offset: bigint;
+        asset: Address;
+        priceFeed: Address;
+        scale: bigint;
+        borrowCollateralFactor: bigint;
+      };
+
+      const assetAddress = info.asset;
+      try {
+        const symbolAndDecimals = await publicClient.multicall({
+          allowFailure: false,
+          contracts: [
+            { address: assetAddress, abi: erc20Abi, functionName: "symbol" },
+            { address: assetAddress, abi: erc20Abi, functionName: "decimals" },
+          ],
+        });
+
+        const symbolResult = symbolAndDecimals[0];
+        const decimalsResult = symbolAndDecimals[1];
+
+        let usdPrice: string | undefined;
+
+        if (priceFeedAddress && priceFeedAddress !== zeroAddress) {
+          try {
+            const priceResults = await publicClient.multicall({
+              allowFailure: false,
+              contracts: [
+                {
+                  address: priceFeedAddress as Address,
+                  abi: priceFeedAbi,
+                  functionName: "getPrice",
+                  args: [assetAddress],
+                },
+                {
+                  address: priceFeedAddress as Address,
+                  abi: priceFeedAbi,
+                  functionName: "decimals",
+                },
+              ],
+            });
+
+            const priceValue = priceResults[0] as bigint;
+            const priceDecimals = Number(priceResults[1] ?? 8);
+            if (priceValue && priceValue > BIGINT_ZERO) {
+              usdPrice = formatUnitsWithPrecision(priceValue, priceDecimals, 6);
+            }
+          } catch {
+            usdPrice = undefined;
+          }
+        }
+
+        collaterals.push({
+          asset: assetAddress,
+          symbol: String(symbolResult),
+          decimals: Number(decimalsResult ?? 18),
+          scale: info.scale,
+          collateralFactor: formatMantissa(info.borrowCollateralFactor),
+          priceFeed: info.priceFeed,
+          usdPrice,
+        });
+      } catch {
+        collaterals.push({
+          asset: assetAddress,
+          symbol: assetAddress,
+          decimals: 18,
+          scale: info.scale,
+          collateralFactor: formatMantissa(info.borrowCollateralFactor),
+          priceFeed: info.priceFeed,
+        });
+      }
+    }
+  }
+
+  let basePrice: bigint | null = null;
+  let basePriceDecimals: number | null = null;
+
+  if (priceFeedAddress && priceFeedAddress !== zeroAddress) {
+    try {
+      const basePriceResults = await publicClient.multicall({
+        allowFailure: false,
+        contracts: [
+          {
+            address: priceFeedAddress as Address,
+            abi: priceFeedAbi,
+            functionName: "getPrice",
+            args: [market.base.address as Address],
+          },
+          {
+            address: priceFeedAddress as Address,
+            abi: priceFeedAbi,
+            functionName: "decimals",
+          },
+        ],
+      });
+      basePrice = basePriceResults[0] as bigint;
+      basePriceDecimals = Number(basePriceResults[1] ?? 8);
+    } catch {
+      basePrice = null;
+      basePriceDecimals = null;
+    }
+  }
+
+  const supplyApy = calculateApyFromRatePerSecond(supplyRate as bigint);
+  const borrowApy = calculateApyFromRatePerSecond(borrowRate as bigint);
+  const utilization = formatMantissa(utilizationValue);
+  const totalSupplyBaseDisplay = formatUnitsWithPrecision(
+    totalSupplyBase,
+    market.base.decimals,
+    6
+  );
+  const totalBorrowBaseDisplay = formatUnitsWithPrecision(
+    totalBorrowBase,
+    market.base.decimals,
+    6
+  );
+  let tvlUsd: string | undefined;
+
+  if (basePrice && basePrice > BIGINT_ZERO && basePriceDecimals !== null) {
+    const tvlUsdScaled =
+      (totalSupplyBase * basePrice) / pow10BigInt(basePriceDecimals);
+    tvlUsd = formatUnitsWithPrecision(tvlUsdScaled, market.base.decimals, 2);
+  }
+
+  return {
+    config: market,
+    decimals,
+    supplyRate: supplyRate as bigint,
+    borrowRate: borrowRate as bigint,
+    utilization: utilizationRaw as bigint,
+    totalSupplyBase,
+    totalBorrowBase,
+    basePrice,
+    basePriceDecimals,
+    collaterals,
+    metrics: {
+      supplyApy,
+      borrowApy,
+      utilization,
+      totalSupplyBase: totalSupplyBaseDisplay,
+      totalBorrowBase: totalBorrowBaseDisplay,
+      tvlUsd,
+    },
+  };
+}
+
+function buildV2MarketResponse(state: V2MarketState): LinkPreviewResponse {
+  const { config, metrics } = state;
+  return {
+    type: "compound.market",
+    version: "v2",
+    chainId: 1,
+    market: {
+      cToken: getAddress(config.address),
+      symbol: config.symbol,
+      underlying: {
+        address: getAddress(config.underlying.address),
+        symbol: config.underlying.symbol,
+        decimals: config.underlying.decimals,
+      },
+    },
+    metrics,
+    links: {
+      marketUrl: config.marketUrl,
+      etherscan: `https://etherscan.io/address/${getAddress(config.address)}`,
+    },
+  } as LinkPreviewResponse;
+}
+
+function buildV3MarketResponse(state: V3MarketState): LinkPreviewResponse {
+  const { config, metrics } = state;
+  return {
+    type: "compound.market",
+    version: "v3",
+    chainId: 1,
+    market: {
+      comet: getAddress(config.address),
+      base: {
+        address: getAddress(config.base.address),
+        symbol: config.base.symbol,
+        decimals: config.base.decimals,
+      },
+      collaterals: state.collaterals.map((collateral) => ({
+        address: getAddress(collateral.asset),
+        symbol: collateral.symbol,
+        decimals: collateral.decimals,
+        collateralFactor: collateral.collateralFactor,
+      })),
+    },
+    metrics,
+    links: {
+      marketUrl: config.marketUrl,
+      etherscan: `https://etherscan.io/address/${getAddress(config.address)}`,
+    },
+  } as LinkPreviewResponse;
+}
+
+async function fetchV2Account(address: Address): Promise<LinkPreviewResponse> {
+  const markets = Array.from(v2MarketsByAddress.values());
+  const states = await Promise.all(markets.map((market) => fetchV2MarketState(market)));
+
+  const positionsRaw = await Promise.all(
+    states.map(async (state) => {
+      const cToken = state.config.address as Address;
+      const [balanceResult, borrowResult] = await publicClient.multicall({
+        allowFailure: false,
+        contracts: [
+          { address: cToken, abi: cTokenAbi, functionName: "balanceOf", args: [address] },
+          {
+            address: cToken,
+            abi: cTokenAbi,
+            functionName: "borrowBalanceStored",
+            args: [address],
+          },
+        ],
+      });
+
+      const balance = balanceResult as bigint;
+      const borrowBalance = borrowResult as bigint;
+      const exchangeRateScale = getExchangeRateScale(
+        state.config.underlying.decimals,
+        state.cTokenDecimals
+      );
+
+      const supplyUnderlyingRaw =
+        (balance * state.exchangeRateStored) /
+        pow10BigInt(exchangeRateScale);
+      const supplyDisplay = formatUnitsWithPrecision(
+        supplyUnderlyingRaw,
+        state.config.underlying.decimals,
+        6
+      );
+      const borrowDisplay = formatUnitsWithPrecision(
+        borrowBalance,
+        state.config.underlying.decimals,
+        6
+      );
+
+      const priceDecimals = Math.max(0, 36 - state.config.underlying.decimals);
+      const usdPrice = state.underlyingPrice
+        ? formatUnitsWithPrecision(state.underlyingPrice, priceDecimals, 6)
+        : undefined;
+
+      return {
+        cToken: getAddress(state.config.address),
+        symbol: state.config.symbol,
+        supplyUnderlying: supplyDisplay,
+        borrowUnderlying: borrowDisplay,
+        supplyApy: state.metrics.supplyApy,
+        borrowApy: state.metrics.borrowApy,
+        collateralFactor: state.metrics.collateralFactor,
+        usdPrice: usdPrice ?? undefined,
+        hasPosition: supplyUnderlyingRaw > BIGINT_ZERO || borrowBalance > BIGINT_ZERO,
+      };
+    })
+  );
+
+  const positions = positionsRaw
+    .filter((position) => position.hasPosition)
+    .map(({ hasPosition: _ignored, ...rest }) => rest);
+
+  const [liquidityRaw, shortfallRaw] = await publicClient.readContract({
+    address: compoundRegistry.comptroller as Address,
+    abi: comptrollerAbi,
+    functionName: "getAccountLiquidity",
+    args: [address],
+  });
+
+  const liquidityUsd = formatUnitsWithPrecision(liquidityRaw as bigint, 18, 2);
+  const shortfallUsd = formatUnitsWithPrecision(shortfallRaw as bigint, 18, 2);
+  const liquidityValue = liquidityRaw as bigint;
+  const shortfallValue = shortfallRaw as bigint;
+
+  let healthLabel = "safe";
+  if (shortfallValue > BIGINT_ZERO) {
+    healthLabel = "liquidation";
+  } else if (liquidityValue < BigInt(500) * MANTISSA_1E18) {
+    healthLabel = "warning";
+  }
+
+  let compAccrued: bigint | null = null;
+  try {
+    compAccrued = await publicClient.readContract({
+      address: compoundRegistry.comptroller as Address,
+      abi: comptrollerAbi,
+      functionName: "compAccrued",
+      args: [address],
+    });
+  } catch {
+    compAccrued = null;
+  }
+
+  const rewards = {
+    v2CompAccrued: compAccrued
+      ? formatUnitsWithPrecision(compAccrued, 18, 6)
+      : "0",
+  };
+
+  return {
+    type: "compound.account",
+    chainId: 1,
+    address: getAddress(address),
+    positions: {
+      v2: positions,
+      v3: [],
+    },
+    risk: {
+      liquidityUsd,
+      shortfallUsd,
+      healthLabel,
+    },
+    rewards,
+    links: {
+      etherscan: `https://etherscan.io/address/${getAddress(address)}`,
+    },
+  } as LinkPreviewResponse;
+}
+
+async function fetchV3Account(address: Address): Promise<{
+  readonly v3Positions: any[];
+  readonly v3Rewards?: string;
+}> {
+  const markets = Array.from(v3MarketsByAddress.values());
+  const states = await Promise.all(markets.map((market) => fetchV3MarketState(market)));
+
+  const v3Positions = await Promise.all(
+    states.map(async (state) => {
+      const comet = state.config.address as Address;
+      const [balanceResult, borrowResult] = await publicClient.multicall({
+        allowFailure: false,
+        contracts: [
+          { address: comet, abi: cometAbi, functionName: "balanceOf", args: [address] },
+          { address: comet, abi: cometAbi, functionName: "borrowBalanceOf", args: [address] },
+        ],
+      });
+
+      const baseSupplyRaw = balanceResult as bigint;
+      const baseSupply = formatUnitsWithPrecision(
+        baseSupplyRaw,
+        state.config.base.decimals,
+        6
+      );
+      let baseBorrow = "0";
+      let baseBorrowRaw = BIGINT_ZERO;
+      try {
+        baseBorrowRaw = borrowResult as bigint;
+        baseBorrow = formatUnitsWithPrecision(
+          baseBorrowRaw,
+          state.config.base.decimals,
+          6
+        );
+      } catch {
+        baseBorrow = "0";
+        baseBorrowRaw = BIGINT_ZERO;
+      }
+
+      const collateralEntriesRaw = await Promise.all(
+        state.collaterals.map(async (collateral) => {
+          let balance = BIGINT_ZERO;
+          try {
+            balance = await publicClient.readContract({
+              address: comet,
+              abi: cometAbi,
+              functionName: "collateralBalanceOf",
+              args: [address, collateral.asset],
+            });
+          } catch {
+            balance = BIGINT_ZERO;
+          }
+
+          return {
+            asset: collateral.symbol,
+            amountRaw: balance,
+            decimals: collateral.decimals,
+            usdPrice: collateral.usdPrice,
+            collateralFactor: collateral.collateralFactor,
+          };
+        })
+      );
+
+      const collateralEntries = collateralEntriesRaw
+        .filter((entry) => entry.amountRaw > BIGINT_ZERO)
+        .map((entry) => ({
+          asset: entry.asset,
+          amount: formatUnitsWithPrecision(entry.amountRaw, entry.decimals, 6),
+          usdPrice: entry.usdPrice,
+          collateralFactor: entry.collateralFactor,
+        }));
+
+      const hasPosition =
+        baseSupplyRaw > BIGINT_ZERO || baseBorrowRaw > BIGINT_ZERO || collateralEntries.length > 0;
+
+      return {
+        comet: getAddress(state.config.address),
+        baseSymbol: state.config.base.symbol,
+        supplyBase: baseSupply,
+        borrowBase: baseBorrow,
+        collateral: collateralEntries,
+        supplyApy: state.metrics.supplyApy,
+        borrowApy: state.metrics.borrowApy,
+        hasPosition,
+      };
+    })
+  );
+
+  return {
+    v3Positions: v3Positions
+      .filter((position) => position.hasPosition)
+      .map(({ hasPosition, ...rest }) => rest),
+  };
+}
+
+async function fetchCompoundAccount(address: Address): Promise<LinkPreviewResponse> {
+  const [v2Response, v3Response] = await Promise.all([
+    fetchV2Account(address),
+    fetchV3Account(address),
+  ]);
+
+  const combined = v2Response as any;
+  combined.positions.v3 = v3Response.v3Positions;
+  if (!combined.rewards) {
+    combined.rewards = {};
+  }
+  combined.rewards.v3Claimable = v3Response.v3Rewards ?? "0";
+  return combined;
+}
+
+function decodeV2Event(log: { address: Address; data: `0x${string}`; topics: readonly `0x${string}`[] }) {
+  try {
+    const topics =
+      (log.topics.length === 0
+        ? ([] as [])
+        : ([...log.topics] as [`0x${string}`, ...`0x${string}`[]])) as
+      [] | [`0x${string}`, ...`0x${string}`[]];
+    return decodeEventLog({
+      abi: cTokenAbi,
+      data: log.data,
+      topics,
+    });
+  } catch {
+    return null;
+  }
+}
+
+function decodeV3Event(log: { address: Address; data: `0x${string}`; topics: readonly `0x${string}`[] }) {
+  try {
+    const topics =
+      (log.topics.length === 0
+        ? ([] as [])
+        : ([...log.topics] as [`0x${string}`, ...`0x${string}`[]])) as
+      [] | [`0x${string}`, ...`0x${string}`[]];
+    return decodeEventLog({
+      abi: cometAbi,
+      data: log.data,
+      topics,
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function decodeCompoundTx(hash: Hash): Promise<LinkPreviewResponse> {
+  const transaction = await publicClient.getTransaction({ hash });
+
+  let receipt;
+  let status: "success" | "reverted" | "pending" = "pending";
+  let blockNumber: number | null = null;
+
+  try {
+    receipt = await publicClient.getTransactionReceipt({ hash });
+    status = receipt.status;
+    blockNumber = Number(receipt.blockNumber ?? BIGINT_ZERO);
+  } catch {
+    receipt = null;
+    status = "pending";
+  }
+
+  let summary: any = null;
+
+  const logs = receipt?.logs ?? [];
+
+  for (const log of logs) {
+    const address = getAddress(log.address);
+    if (v2MarketsByAddress.has(address.toLowerCase() as Address)) {
+      const decoded = decodeV2Event(log);
+      if (!decoded) {
+        continue;
+      }
+      const market = v2MarketsByAddress.get(address.toLowerCase() as Address)!;
+      const underlyingDecimals = market.underlying.decimals;
+      switch (decoded.eventName) {
+        case "Mint": {
+          const amount = formatUnitsWithPrecision(
+            decoded.args.mintAmount as bigint,
+            underlyingDecimals,
+            6
+          );
+          summary = {
+            version: "v2",
+            action: "supply",
+            market: {
+              address: address,
+              symbol: market.symbol,
+            },
+            amount,
+            token: market.underlying.symbol,
+            from: transaction.from ? getAddress(transaction.from) : undefined,
+            to: transaction.to ? getAddress(transaction.to) : undefined,
+          };
+          break;
+        }
+        case "Redeem": {
+          const amount = formatUnitsWithPrecision(
+            decoded.args.redeemAmount as bigint,
+            underlyingDecimals,
+            6
+          );
+          summary = {
+            version: "v2",
+            action: "redeem",
+            market: {
+              address: address,
+              symbol: market.symbol,
+            },
+            amount,
+            token: market.underlying.symbol,
+            from: transaction.from ? getAddress(transaction.from) : undefined,
+            to: transaction.to ? getAddress(transaction.to) : undefined,
+          };
+          break;
+        }
+        case "Borrow": {
+          const amount = formatUnitsWithPrecision(
+            decoded.args.borrowAmount as bigint,
+            underlyingDecimals,
+            6
+          );
+          summary = {
+            version: "v2",
+            action: "borrow",
+            market: {
+              address: address,
+              symbol: market.symbol,
+            },
+            amount,
+            token: market.underlying.symbol,
+            from: transaction.from ? getAddress(transaction.from) : undefined,
+            to: transaction.to ? getAddress(transaction.to) : undefined,
+          };
+          break;
+        }
+        case "RepayBorrow": {
+          const amount = formatUnitsWithPrecision(
+            decoded.args.repayAmount as bigint,
+            underlyingDecimals,
+            6
+          );
+          summary = {
+            version: "v2",
+            action: "repay",
+            market: {
+              address: address,
+              symbol: market.symbol,
+            },
+            amount,
+            token: market.underlying.symbol,
+            from: transaction.from ? getAddress(transaction.from) : undefined,
+            to: transaction.to ? getAddress(transaction.to) : undefined,
+          };
+          break;
+        }
+        case "LiquidateBorrow": {
+          const amount = formatUnitsWithPrecision(
+            decoded.args.repayAmount as bigint,
+            underlyingDecimals,
+            6
+          );
+          summary = {
+            version: "v2",
+            action: "liquidate",
+            market: {
+              address: address,
+              symbol: market.symbol,
+            },
+            amount,
+            token: market.underlying.symbol,
+            from: transaction.from ? getAddress(transaction.from) : undefined,
+            to: transaction.to ? getAddress(transaction.to) : undefined,
+          };
+          break;
+        }
+      }
+    } else if (v3MarketsByAddress.has(address.toLowerCase() as Address)) {
+      const decoded = decodeV3Event(log);
+      if (!decoded) {
+        continue;
+      }
+      const market = v3MarketsByAddress.get(address.toLowerCase() as Address)!;
+      switch (decoded.eventName) {
+        case "Supply": {
+          const amount = formatUnitsWithPrecision(
+            decoded.args.amount as bigint,
+            market.base.decimals,
+            6
+          );
+          summary = {
+            version: "v3",
+            action: "supply",
+            market: {
+              address: address,
+              symbol: `${market.base.symbol}(Comet)`,
+            },
+            amount,
+            token: market.base.symbol,
+            from: transaction.from ? getAddress(transaction.from) : undefined,
+            to: transaction.to ? getAddress(transaction.to) : undefined,
+          };
+          break;
+        }
+        case "Withdraw": {
+          const amount = formatUnitsWithPrecision(
+            decoded.args.amount as bigint,
+            market.base.decimals,
+            6
+          );
+          summary = {
+            version: "v3",
+            action: "withdraw",
+            market: {
+              address: address,
+              symbol: `${market.base.symbol}(Comet)`,
+            },
+            amount,
+            token: market.base.symbol,
+            from: transaction.from ? getAddress(transaction.from) : undefined,
+            to: transaction.to ? getAddress(transaction.to) : undefined,
+          };
+          break;
+        }
+        case "AbsorbCollateral": {
+          const amount = formatUnitsWithPrecision(
+            decoded.args.collateralAbsorbed as bigint,
+            market.base.decimals,
+            6
+          );
+          summary = {
+            version: "v3",
+            action: "liquidate",
+            market: {
+              address: address,
+              symbol: `${market.base.symbol}(Comet)`,
+            },
+            amount,
+            token: market.base.symbol,
+            from: transaction.from ? getAddress(transaction.from) : undefined,
+            to: transaction.to ? getAddress(transaction.to) : undefined,
+          };
+          break;
+        }
+      }
+    }
+    if (summary) {
+      break;
+    }
+  }
+
+  return {
+    type: "compound.tx",
+    chainId: 1,
+    hash: hash,
+    status,
+    blockNumber: blockNumber ?? undefined,
+    summary: summary ?? undefined,
+    links: {
+      etherscan: `https://etherscan.io/tx/${hash}`,
+    },
+  } as LinkPreviewResponse;
+}
+
+function detectCompoundTarget(url: URL): CompoundTarget | null {
+  const hostname = url.hostname.toLowerCase();
+  const pathname = url.pathname.replace(/\/+$/, "").toLowerCase() || "/";
+
+  if (hostname.endsWith("app.compound.finance")) {
+    if (pathname.startsWith("/account")) {
+      const addressParam = url.searchParams.get("address");
+      const normalized = addressParam ? normalizeAddress(addressParam) : null;
+      if (normalized) {
+        return { kind: "account", address: normalized };
+      }
+    }
+
+    const v2 = v2MarketsByPath.get(pathname);
+    if (v2) {
+      return { kind: "market", version: "v2", market: v2 };
+    }
+
+    const v3 = v3MarketsByPath.get(pathname);
+    if (v3) {
+      return { kind: "market", version: "v3", market: v3 };
+    }
+  }
+
+  if (hostname.endsWith("etherscan.io")) {
+    if (pathname.startsWith("/tx/")) {
+      const hash = pathname.split("/")[2];
+      if (hash && isPossibleTxHash(hash)) {
+        return { kind: "tx", hash: hash as Address };
+      }
+    }
+
+    if (pathname.startsWith("/address/")) {
+      const raw = pathname.split("/")[2];
+      const normalized = raw ? normalizeAddress(raw) : null;
+      if (normalized) {
+        const lower = normalized.toLowerCase() as Address;
+        if (v2MarketsByAddress.has(lower)) {
+          return { kind: "market", version: "v2", market: v2MarketsByAddress.get(lower)! };
+        }
+        if (v3MarketsByAddress.has(lower)) {
+          return { kind: "market", version: "v3", market: v3MarketsByAddress.get(lower)! };
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+export function createCompoundPlan(url: URL): PreviewPlan | null {
+  const target = detectCompoundTarget(url);
+  if (!target) {
+    return null;
+  }
+
+  if (target.kind === "market" && target.version === "v2") {
+    return {
+      cacheKey: `compound:market:v2:${target.market.address.toLowerCase()}`,
+      execute: async () => {
+        const state = await fetchV2MarketState(target.market);
+        return { data: buildV2MarketResponse(state), ttl: V2_MARKET_TTL_MS };
+      },
+    };
+  }
+
+  if (target.kind === "market" && target.version === "v3") {
+    return {
+      cacheKey: `compound:market:v3:${target.market.address.toLowerCase()}`,
+      execute: async () => {
+        const state = await fetchV3MarketState(target.market);
+        return { data: buildV3MarketResponse(state), ttl: V3_MARKET_TTL_MS };
+      },
+    };
+  }
+
+  if (target.kind === "account") {
+    return {
+      cacheKey: `compound:account:${target.address.toLowerCase()}`,
+      execute: async () => {
+        const data = await fetchCompoundAccount(target.address);
+        return { data, ttl: ACCOUNT_TTL_MS };
+      },
+    };
+  }
+
+  if (target.kind === "tx") {
+    return {
+      cacheKey: `compound:tx:${target.hash.toLowerCase()}`,
+      execute: async () => {
+        const data = await decodeCompoundTx(target.hash);
+        const ttl = data.status === "pending" ? TX_TTL_PENDING_MS : TX_TTL_SUCCESS_MS;
+        return { data, ttl };
+      },
+    };
+  }
+
+  return null;
+}

--- a/components/waves/compound/CompoundCard.tsx
+++ b/components/waves/compound/CompoundCard.tsx
@@ -1,0 +1,420 @@
+import Link from "next/link";
+import type { ReactElement } from "react";
+
+import { LinkPreviewCardLayout } from "../OpenGraphPreview";
+import {
+  type CompoundAccountResponse,
+  type CompoundMarketV2Response,
+  type CompoundMarketV3Response,
+  type CompoundResponse,
+  type CompoundTxResponse,
+  isCompoundAccount,
+  isCompoundMarket,
+  isCompoundResponse,
+  isCompoundTx,
+} from "./types";
+
+interface CompoundCardProps {
+  readonly href: string;
+  readonly response: CompoundResponse;
+}
+
+const cardContainerClass =
+  "tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/40 tw-p-4 tw-flex tw-flex-col tw-gap-y-4";
+
+function formatPercent(value?: string): string {
+  if (!value) {
+    return "-";
+  }
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return value;
+  }
+  const percent = (numeric * 100).toFixed(2);
+  return `${percent.replace(/\.00$/, "").replace(/(\.\d*?)0+$/, "$1")}%`;
+}
+
+function formatNumber(value?: string): string {
+  if (!value) {
+    return "-";
+  }
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return value;
+  }
+  return numeric.toLocaleString(undefined, {
+    maximumFractionDigits: 6,
+  });
+}
+
+function formatCurrency(value?: string): string {
+  if (!value) {
+    return "-";
+  }
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return `$${value}`;
+  }
+  return numeric.toLocaleString(undefined, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+}
+
+function MarketStatsRow({
+  label,
+  value,
+}: {
+  readonly label: string;
+  readonly value: string;
+}) {
+  return (
+    <div className="tw-flex tw-flex-col tw-gap-1">
+      <span className="tw-text-xs tw-uppercase tw-tracking-wide tw-text-iron-400">{label}</span>
+      <span className="tw-text-base tw-font-semibold tw-text-iron-50">{value}</span>
+    </div>
+  );
+}
+
+function renderMarketV2(response: CompoundMarketV2Response) {
+  const { metrics, market, links } = response;
+  return (
+    <div className={cardContainerClass}>
+      <div className="tw-flex tw-flex-col tw-gap-y-1">
+        <span className="tw-text-xs tw-font-semibold tw-uppercase tw-text-primary-300">Compound v2 Market</span>
+        <h3 className="tw-text-xl tw-font-semibold tw-text-white">
+          {market.symbol}
+          <span className="tw-ml-2 tw-text-sm tw-font-normal tw-text-iron-400">
+            {market.underlying.symbol}
+          </span>
+        </h3>
+        <div className="tw-flex tw-flex-wrap tw-gap-x-4 tw-text-xs tw-text-iron-400">
+          <span>cToken: {market.cToken}</span>
+          <span>Underlying: {market.underlying.address}</span>
+        </div>
+      </div>
+      <div className="tw-grid tw-grid-cols-1 tw-gap-4 md:tw-grid-cols-2">
+        <MarketStatsRow label="Supply APY" value={formatPercent(metrics.supplyApy)} />
+        <MarketStatsRow label="Borrow APY" value={formatPercent(metrics.borrowApy)} />
+        <MarketStatsRow label="Utilization" value={formatPercent(metrics.utilization)} />
+        <MarketStatsRow label="Exchange Rate" value={formatNumber(metrics.exchangeRate)} />
+        <MarketStatsRow
+          label={`TVL (${market.underlying.symbol})`}
+          value={formatNumber(metrics.tvlUnderlying)}
+        />
+        <MarketStatsRow label="TVL (USD)" value={formatCurrency(metrics.tvlUsd)} />
+        <MarketStatsRow label="Collateral Factor" value={formatPercent(metrics.collateralFactor)} />
+        <MarketStatsRow label="Reserve Factor" value={formatPercent(metrics.reserveFactor)} />
+      </div>
+      <div className="tw-flex tw-flex-wrap tw-gap-4">
+        {links.marketUrl && (
+          <Link
+            href={links.marketUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="tw-text-sm tw-font-semibold tw-text-primary-300 hover:tw-text-primary-200"
+          >
+            View on Compound
+          </Link>
+        )}
+        {links.etherscan && (
+          <Link
+            href={links.etherscan}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="tw-text-sm tw-font-semibold tw-text-primary-300 hover:tw-text-primary-200"
+          >
+            View on Etherscan
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function renderMarketV3(response: CompoundMarketV3Response) {
+  const { metrics, market, links } = response;
+  return (
+    <div className={cardContainerClass}>
+      <div className="tw-flex tw-flex-col tw-gap-y-1">
+        <span className="tw-text-xs tw-font-semibold tw-uppercase tw-text-primary-300">Compound v3 Market</span>
+        <h3 className="tw-text-xl tw-font-semibold tw-text-white">
+          {market.base.symbol}
+          <span className="tw-ml-2 tw-text-sm tw-font-normal tw-text-iron-400">Base Asset</span>
+        </h3>
+        <div className="tw-flex tw-flex-wrap tw-gap-x-4 tw-text-xs tw-text-iron-400">
+          <span>Comet: {market.comet}</span>
+          <span>Base: {market.base.address}</span>
+        </div>
+      </div>
+      <div className="tw-grid tw-grid-cols-1 tw-gap-4 md:tw-grid-cols-2">
+        <MarketStatsRow label="Supply APY" value={formatPercent(metrics.supplyApy)} />
+        <MarketStatsRow label="Borrow APY" value={formatPercent(metrics.borrowApy)} />
+        <MarketStatsRow label="Utilization" value={formatPercent(metrics.utilization)} />
+        <MarketStatsRow
+          label={`Total Supply (${market.base.symbol})`}
+          value={formatNumber(metrics.totalSupplyBase)}
+        />
+        <MarketStatsRow
+          label={`Total Borrow (${market.base.symbol})`}
+          value={formatNumber(metrics.totalBorrowBase)}
+        />
+        <MarketStatsRow label="TVL (USD)" value={formatCurrency(metrics.tvlUsd)} />
+      </div>
+      {market.collaterals.length > 0 && (
+        <div className="tw-flex tw-flex-col tw-gap-y-2">
+          <span className="tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+            Collateral Assets
+          </span>
+          <div className="tw-flex tw-flex-wrap tw-gap-3">
+            {market.collaterals.map((collateral) => (
+              <div
+                key={collateral.address}
+                className="tw-rounded-lg tw-border tw-border-iron-700 tw-bg-iron-900/60 tw-px-3 tw-py-2"
+              >
+                <div className="tw-text-sm tw-font-semibold tw-text-iron-100">
+                  {collateral.symbol}
+                </div>
+                <div className="tw-text-xs tw-text-iron-400">
+                  CF: {formatPercent(collateral.collateralFactor)}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      <div className="tw-flex tw-flex-wrap tw-gap-4">
+        {links.marketUrl && (
+          <Link
+            href={links.marketUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="tw-text-sm tw-font-semibold tw-text-primary-300 hover:tw-text-primary-200"
+          >
+            View on Compound
+          </Link>
+        )}
+        {links.etherscan && (
+          <Link
+            href={links.etherscan}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="tw-text-sm tw-font-semibold tw-text-primary-300 hover:tw-text-primary-200"
+          >
+            View on Etherscan
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function renderAccount(response: CompoundAccountResponse) {
+  const { positions, risk, rewards, address, links } = response;
+  const hasV2 = positions.v2.length > 0;
+  const hasV3 = positions.v3.length > 0;
+  return (
+    <div className={cardContainerClass}>
+      <div className="tw-flex tw-flex-col tw-gap-y-1">
+        <span className="tw-text-xs tw-font-semibold tw-uppercase tw-text-primary-300">Compound Account</span>
+        <h3 className="tw-text-xl tw-font-semibold tw-text-white">{address}</h3>
+      </div>
+      {risk && (
+        <div className="tw-grid tw-grid-cols-1 tw-gap-4 md:tw-grid-cols-3">
+          <MarketStatsRow label="Liquidity" value={formatCurrency(risk.liquidityUsd)} />
+          <MarketStatsRow label="Shortfall" value={formatCurrency(risk.shortfallUsd)} />
+          <MarketStatsRow label="Health" value={risk.healthLabel ?? "-"} />
+        </div>
+      )}
+      {hasV2 && (
+        <div className="tw-flex tw-flex-col tw-gap-y-2">
+          <h4 className="tw-text-lg tw-font-semibold tw-text-iron-50">Compound v2 Positions</h4>
+          <div className="tw-flex tw-flex-col tw-gap-2">
+            {positions.v2.map((position) => (
+              <div
+                key={position.cToken}
+                className="tw-rounded-lg tw-border tw-border-iron-700 tw-bg-iron-900/60 tw-p-3 tw-flex tw-flex-col tw-gap-2"
+              >
+                <div className="tw-flex tw-justify-between tw-text-sm tw-text-iron-100 tw-font-semibold">
+                  <span>{position.symbol}</span>
+                  <span>Price: {position.usdPrice ? formatCurrency(position.usdPrice) : "-"}</span>
+                </div>
+                <div className="tw-grid tw-grid-cols-1 tw-gap-3 md:tw-grid-cols-3">
+                  <MarketStatsRow
+                    label="Supplied"
+                    value={`${formatNumber(position.supplyUnderlying)} ${position.symbol}`}
+                  />
+                  <MarketStatsRow
+                    label="Borrowed"
+                    value={`${formatNumber(position.borrowUnderlying)} ${position.symbol}`}
+                  />
+                  <MarketStatsRow
+                    label="Collateral Factor"
+                    value={formatPercent(position.collateralFactor)}
+                  />
+                  <MarketStatsRow label="Supply APY" value={formatPercent(position.supplyApy)} />
+                  <MarketStatsRow label="Borrow APY" value={formatPercent(position.borrowApy)} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {hasV3 && (
+        <div className="tw-flex tw-flex-col tw-gap-y-2">
+          <h4 className="tw-text-lg tw-font-semibold tw-text-iron-50">Compound v3 Positions</h4>
+          <div className="tw-flex tw-flex-col tw-gap-2">
+            {positions.v3.map((position) => (
+              <div
+                key={position.comet}
+                className="tw-rounded-lg tw-border tw-border-iron-700 tw-bg-iron-900/60 tw-p-3 tw-flex tw-flex-col tw-gap-2"
+              >
+                <div className="tw-flex tw-justify-between tw-text-sm tw-text-iron-100 tw-font-semibold">
+                  <span>{position.baseSymbol}</span>
+                </div>
+                <div className="tw-grid tw-grid-cols-1 tw-gap-3 md:tw-grid-cols-3">
+                  <MarketStatsRow
+                    label="Supplied"
+                    value={`${formatNumber(position.supplyBase)} ${position.baseSymbol}`}
+                  />
+                  <MarketStatsRow
+                    label="Borrowed"
+                    value={`${formatNumber(position.borrowBase)} ${position.baseSymbol}`}
+                  />
+                  <MarketStatsRow label="Supply APY" value={formatPercent(position.supplyApy)} />
+                  <MarketStatsRow label="Borrow APY" value={formatPercent(position.borrowApy)} />
+                </div>
+                {position.collateral.length > 0 && (
+                  <div className="tw-flex tw-flex-col tw-gap-y-2">
+                    <span className="tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+                      Collateral
+                    </span>
+                    <div className="tw-flex tw-flex-wrap tw-gap-3">
+                      {position.collateral.map((collateral) => (
+                        <div
+                          key={`${position.comet}-${collateral.asset}`}
+                          className="tw-rounded-lg tw-border tw-border-iron-700 tw-bg-iron-900/80 tw-px-3 tw-py-2"
+                        >
+                          <div className="tw-text-sm tw-font-semibold tw-text-iron-100">
+                            {collateral.asset}
+                          </div>
+                          <div className="tw-text-xs tw-text-iron-400">
+                            {formatNumber(collateral.amount)}
+                          </div>
+                          <div className="tw-text-xs tw-text-iron-400">
+                            CF: {formatPercent(collateral.collateralFactor)}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {rewards && (
+        <div className="tw-flex tw-flex-wrap tw-gap-4">
+          {rewards.v2CompAccrued && (
+            <span className="tw-text-sm tw-text-iron-300">
+              COMP accrued: {formatNumber(rewards.v2CompAccrued)}
+            </span>
+          )}
+          {rewards.v3Claimable && (
+            <span className="tw-text-sm tw-text-iron-300">
+              v3 rewards: {formatNumber(rewards.v3Claimable)}
+            </span>
+          )}
+        </div>
+      )}
+      <div className="tw-flex tw-flex-wrap tw-gap-4">
+        {links?.etherscan && (
+          <Link
+            href={links.etherscan}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="tw-text-sm tw-font-semibold tw-text-primary-300 hover:tw-text-primary-200"
+          >
+            View on Etherscan
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function renderTx(response: CompoundTxResponse) {
+  const { summary, status, blockNumber, links, hash } = response;
+  return (
+    <div className={cardContainerClass}>
+      <div className="tw-flex tw-flex-col tw-gap-y-1">
+        <span className="tw-text-xs tw-font-semibold tw-uppercase tw-text-primary-300">
+          Compound Transaction
+        </span>
+        <h3 className="tw-text-lg tw-font-semibold tw-text-white">{hash}</h3>
+      </div>
+      <div className="tw-grid tw-grid-cols-1 tw-gap-4 md:tw-grid-cols-2">
+        <MarketStatsRow label="Status" value={status} />
+        {blockNumber !== undefined && (
+          <MarketStatsRow label="Block" value={blockNumber.toString()} />
+        )}
+        {summary?.action && (
+          <MarketStatsRow label="Action" value={summary.action} />
+        )}
+        {summary?.token && (
+          <MarketStatsRow label="Token" value={summary.token} />
+        )}
+        {summary?.amount && (
+          <MarketStatsRow label="Amount" value={formatNumber(summary.amount)} />
+        )}
+        {summary?.market?.symbol && (
+          <MarketStatsRow label="Market" value={summary.market.symbol} />
+        )}
+      </div>
+      <div className="tw-flex tw-flex-wrap tw-gap-4">
+        {links?.etherscan && (
+          <Link
+            href={links.etherscan}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="tw-text-sm tw-font-semibold tw-text-primary-300 hover:tw-text-primary-200"
+          >
+            View on Etherscan
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function CompoundCard({ href, response }: CompoundCardProps) {
+  let content: ReactElement | null = null;
+
+  if (isCompoundMarket(response)) {
+    content =
+      response.version === "v2"
+        ? renderMarketV2(response as CompoundMarketV2Response)
+        : renderMarketV3(response as CompoundMarketV3Response);
+  } else if (isCompoundAccount(response)) {
+    content = renderAccount(response as CompoundAccountResponse);
+  } else if (isCompoundTx(response)) {
+    content = renderTx(response as CompoundTxResponse);
+  }
+
+  if (!content) {
+    return null;
+  }
+
+  return <LinkPreviewCardLayout href={href}>{content}</LinkPreviewCardLayout>;
+}
+
+export function toCompoundResponse(
+  response: unknown
+): CompoundResponse | undefined {
+  if (!isCompoundResponse(response)) {
+    return undefined;
+  }
+  return response;
+}

--- a/components/waves/compound/types.ts
+++ b/components/waves/compound/types.ts
@@ -1,0 +1,174 @@
+export interface CompoundLinkGroup {
+  readonly marketUrl?: string;
+  readonly etherscan?: string;
+}
+
+export interface CompoundMarketV2Metrics {
+  readonly supplyApy: string;
+  readonly borrowApy: string;
+  readonly utilization: string;
+  readonly tvlUnderlying: string;
+  readonly tvlUsd?: string;
+  readonly collateralFactor: string;
+  readonly reserveFactor: string;
+  readonly exchangeRate: string;
+}
+
+export interface CompoundMarketV3Metrics {
+  readonly supplyApy: string;
+  readonly borrowApy: string;
+  readonly utilization: string;
+  readonly totalSupplyBase: string;
+  readonly totalBorrowBase: string;
+  readonly tvlUsd?: string;
+}
+
+export interface CompoundMarketV2Response {
+  readonly type: "compound.market";
+  readonly version: "v2";
+  readonly chainId: number;
+  readonly market: {
+    readonly cToken: string;
+    readonly symbol: string;
+    readonly underlying: {
+      readonly address: string;
+      readonly symbol: string;
+      readonly decimals: number;
+    };
+  };
+  readonly metrics: CompoundMarketV2Metrics;
+  readonly links: CompoundLinkGroup;
+}
+
+export interface CompoundCollateralConfig {
+  readonly address: string;
+  readonly symbol: string;
+  readonly decimals: number;
+  readonly collateralFactor: string;
+}
+
+export interface CompoundMarketV3Response {
+  readonly type: "compound.market";
+  readonly version: "v3";
+  readonly chainId: number;
+  readonly market: {
+    readonly comet: string;
+    readonly base: {
+      readonly address: string;
+      readonly symbol: string;
+      readonly decimals: number;
+    };
+    readonly collaterals: readonly CompoundCollateralConfig[];
+  };
+  readonly metrics: CompoundMarketV3Metrics;
+  readonly links: CompoundLinkGroup;
+}
+
+export interface CompoundAccountV2Position {
+  readonly cToken: string;
+  readonly symbol: string;
+  readonly supplyUnderlying: string;
+  readonly borrowUnderlying: string;
+  readonly supplyApy: string;
+  readonly borrowApy: string;
+  readonly collateralFactor: string;
+  readonly usdPrice?: string;
+}
+
+export interface CompoundAccountV3CollateralPosition {
+  readonly asset: string;
+  readonly amount: string;
+  readonly usdPrice?: string;
+  readonly collateralFactor: string;
+}
+
+export interface CompoundAccountV3Position {
+  readonly comet: string;
+  readonly baseSymbol: string;
+  readonly supplyBase: string;
+  readonly borrowBase: string;
+  readonly collateral: readonly CompoundAccountV3CollateralPosition[];
+  readonly supplyApy: string;
+  readonly borrowApy: string;
+}
+
+export interface CompoundAccountResponse {
+  readonly type: "compound.account";
+  readonly chainId: number;
+  readonly address: string;
+  readonly positions: {
+    readonly v2: readonly CompoundAccountV2Position[];
+    readonly v3: readonly CompoundAccountV3Position[];
+  };
+  readonly risk?: {
+    readonly liquidityUsd?: string;
+    readonly shortfallUsd?: string;
+    readonly healthLabel?: string;
+  };
+  readonly rewards?: {
+    readonly v2CompAccrued?: string;
+    readonly v3Claimable?: string;
+  };
+  readonly links?: CompoundLinkGroup;
+}
+
+export interface CompoundTxSummary {
+  readonly version?: "v2" | "v3";
+  readonly action?: string;
+  readonly market?: {
+    readonly address: string;
+    readonly symbol: string;
+  };
+  readonly amount?: string;
+  readonly token?: string;
+  readonly from?: string;
+  readonly to?: string;
+}
+
+export interface CompoundTxResponse {
+  readonly type: "compound.tx";
+  readonly chainId: number;
+  readonly hash: string;
+  readonly status: "success" | "reverted" | "pending";
+  readonly blockNumber?: number;
+  readonly summary?: CompoundTxSummary;
+  readonly links?: CompoundLinkGroup;
+}
+
+export type CompoundMarketResponse =
+  | CompoundMarketV2Response
+  | CompoundMarketV3Response;
+
+export type CompoundResponse =
+  | CompoundMarketResponse
+  | CompoundAccountResponse
+  | CompoundTxResponse;
+
+export function isCompoundResponse(value: unknown): value is CompoundResponse {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.type !== "string") {
+    return false;
+  }
+  return record.type.startsWith("compound.");
+}
+
+export function isCompoundMarket(
+  value: CompoundResponse
+): value is CompoundMarketResponse {
+  return value.type === "compound.market";
+}
+
+export function isCompoundAccount(
+  value: CompoundResponse
+): value is CompoundAccountResponse {
+  return value.type === "compound.account";
+}
+
+export function isCompoundTx(
+  value: CompoundResponse
+): value is CompoundTxResponse {
+  return value.type === "compound.tx";
+}

--- a/types/cheerio.d.ts
+++ b/types/cheerio.d.ts
@@ -1,0 +1,1 @@
+declare module "cheerio";


### PR DESCRIPTION
## Summary
- add Compound-specific plan handling in the open graph API route and share caching with existing flows
- introduce server-side Compound service with registry, viem client, market/account/tx decoding logic, and presentational components for new cards
- extend link preview card tests and UI to render compound cards, and add ambient type declarations for cheerio

## Testing
- npm run test *(fails: __tests__/security/UserAgentSanitizer.test.ts duration threshold)*
- npm run lint
- npm run type-check
- npx jest __tests__/components/waves/LinkPreviewCard.test.tsx *(stopped after coverage startup)*

------
https://chatgpt.com/codex/tasks/task_e_68cb35566ecc8321b11bdb4b9b9004e5