### PR TITLE
fix: normalize Art Blocks live viewer URL

### DIFF
--- a/__tests__/src/components/waves/ArtBlocksTokenCard.test.tsx
+++ b/__tests__/src/components/waves/ArtBlocksTokenCard.test.tsx
@@ -119,6 +119,10 @@ describe("ArtBlocksTokenCard", () => {
       "sandbox",
       "allow-scripts allow-same-origin allow-pointer-lock"
     );
+    expect(iframe).toHaveAttribute(
+      "src",
+      "https://live.artblocks.io/token/flagship-7"
+    );
     expect(iframe).toHaveAttribute("referrerpolicy", "no-referrer");
     expect(iframe).toHaveAttribute("allow", "autoplay; encrypted-media");
 

--- a/__tests__/src/services/artblocks/url.test.ts
+++ b/__tests__/src/services/artblocks/url.test.ts
@@ -93,8 +93,19 @@ describe("buildMediaUrl", () => {
 });
 
 describe("buildLiveUrl", () => {
-  it("builds live viewer URLs", () => {
-    expect(buildLiveUrl({contract: "0x1234567890abcdef1234567890abcdef12345678", tokenId: "99" })).toBe(
+  it("builds flagship live viewer URLs", () => {
+    expect(buildLiveUrl({ tokenId: "99" })).toBe(
+      "https://live.artblocks.io/token/flagship-99"
+    );
+  });
+
+  it("builds contract live viewer URLs", () => {
+    expect(
+      buildLiveUrl({
+        contract: "0x1234567890abcdef1234567890abcdef12345678",
+        tokenId: "99",
+      })
+    ).toBe(
       "https://live.artblocks.io/token/0x1234567890abcdef1234567890abcdef12345678-99"
     );
   });

--- a/src/services/artblocks/url.ts
+++ b/src/services/artblocks/url.ts
@@ -154,8 +154,16 @@ export const buildMediaUrl = ({
   return `https://media.artblocks.io/${tokenId}.png`;
 };
 
-export const buildLiveUrl = ({ contract, tokenId }: ArtBlocksTokenIdentifier): string => {
-  return `https://live.artblocks.io/token/${contract}-${tokenId}`;
+const FLAGSHIP_LIVE_SLUG = "flagship";
+
+export const buildLiveUrl = ({
+  contract,
+  tokenId,
+}: ArtBlocksTokenIdentifier): string => {
+  const normalizedContract = ensureValidContract(contract);
+
+  const prefix = normalizedContract ?? FLAGSHIP_LIVE_SLUG;
+  return `https://live.artblocks.io/token/${prefix}-${tokenId}`;
 };
 
 export const buildTokenApiUrl = ({


### PR DESCRIPTION
## Summary
- ensure the Art Blocks live viewer URL falls back to the flagship slug when no contract is provided
- extend service and component tests to cover flagship live viewer rendering

## Testing
- CI=1 npx jest --runTestsByPath __tests__/src/services/artblocks/url.test.ts __tests__/src/components/waves/ArtBlocksTokenCard.test.tsx
- npm run lint
- npm run type-check

------
https://chatgpt.com/codex/tasks/task_e_68cba24c65648321aa6844a826b6130f