### PR TITLE
feat: add optimistic drop reactions and ratings

### DIFF
--- a/__tests__/components/drops/view/item/rate/give/DropListItemRateGiveSubmit.test.tsx
+++ b/__tests__/components/drops/view/item/rate/give/DropListItemRateGiveSubmit.test.tsx
@@ -6,6 +6,7 @@ import { ReactQueryWrapperContext } from '../../../../../../../components/react-
 import { useMutation } from '@tanstack/react-query';
 import { useDropInteractionRules } from '../../../../../../../hooks/drops/useDropInteractionRules';
 import { DropVoteState } from '../../../../../../../hooks/drops/types';
+import { useMyStream } from '../../../../../../../contexts/wave/MyStreamContext';
 
 jest.useFakeTimers();
 
@@ -28,9 +29,18 @@ jest.mock('../../../../../../../hooks/drops/useDropInteractionRules', () => ({ u
 
 jest.mock('@tanstack/react-query', () => ({ useMutation: jest.fn() }));
 
+jest.mock('../../../../../../../contexts/wave/MyStreamContext', () => ({
+  useMyStream: jest.fn(() => ({
+    applyOptimisticDropUpdate: jest.fn(() => ({ rollback: jest.fn() })),
+  })),
+}));
+
 const mutateAsync = jest.fn();
 (useMutation as jest.Mock).mockReturnValue({ mutateAsync });
 (useDropInteractionRules as jest.Mock).mockReturnValue({ voteState: DropVoteState.CAN_VOTE });
+(useMyStream as jest.Mock).mockReturnValue({
+  applyOptimisticDropUpdate: jest.fn(() => ({ rollback: jest.fn() })),
+});
 
 const auth = { requestAuth: jest.fn().mockResolvedValue({ success: true }), setToast: jest.fn(), connectedProfile: { handle: 'me' } } as any;
 const wrapper = ({ children }: any) => (

--- a/__tests__/components/waves/drops/WaveDropActionsAddReaction.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropActionsAddReaction.test.tsx
@@ -2,6 +2,40 @@ import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import WaveDropActionsAddReaction from "../../../../components/waves/drops/WaveDropActionsAddReaction";
 
+const applyOptimisticDropUpdateMock = jest.fn(() => ({ rollback: jest.fn() }));
+const setToastMock = jest.fn();
+
+jest.mock("../../../../contexts/wave/MyStreamContext", () => ({
+  useMyStream: jest.fn(() => ({
+    applyOptimisticDropUpdate: applyOptimisticDropUpdateMock,
+  })),
+}));
+
+jest.mock("../../../../components/auth/Auth", () => ({
+  useAuth: jest.fn(() => ({
+    setToast: setToastMock,
+    connectedProfile: {
+      id: "identity-1",
+      handle: "user",
+      pfp: null,
+      banner1: null,
+      banner2: null,
+      cic: 0,
+      rep: 0,
+      tdh: 0,
+      tdh_rate: 0,
+      level: 0,
+      primary_wallet: "0xuser",
+      active_main_stage_submission_ids: [],
+      winner_main_stage_drop_ids: [],
+    },
+  })),
+}));
+
+jest.mock("../../../../services/api/common-api", () => ({
+  commonApiPost: jest.fn(() => Promise.resolve({})),
+}));
+
 // Mock emoji-mart/react Picker and emoji-mart/data
 jest.mock("@emoji-mart/react", () => ({
   __esModule: true,
@@ -27,10 +61,22 @@ jest.mock("../../../../contexts/EmojiContext", () => ({
 }));
 
 // Mock drop object
-const mockDrop = { id: "12345" } as any;
-const tempDrop = { id: "temp-001" } as any;
+const mockDrop = {
+  id: "12345",
+  wave: { id: "wave-1" },
+  context_profile_context: { reaction: null },
+} as any;
+const tempDrop = {
+  id: "temp-001",
+  wave: { id: "wave-1" },
+  context_profile_context: { reaction: null },
+} as any;
 
 describe("WaveDropActionsAddReaction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("renders desktop button", () => {
     render(<WaveDropActionsAddReaction drop={mockDrop} />);
     expect(

--- a/__tests__/components/waves/drops/WaveDropReactions.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropReactions.test.tsx
@@ -4,6 +4,12 @@ import WaveDropReactions from "../../../../components/waves/drops/WaveDropReacti
 import { useEmoji } from "../../../../contexts/EmojiContext";
 import * as commonApi from "../../../../services/api/common-api"; // Import directly to mock methods
 
+jest.mock("../../../../contexts/wave/MyStreamContext", () => ({
+  useMyStream: jest.fn(() => ({
+    applyOptimisticDropUpdate: jest.fn(() => ({ rollback: jest.fn() })),
+  })),
+}));
+
 // Mock useEmoji with sample emojiMap and findNativeEmoji
 jest.mock("../../../../contexts/EmojiContext", () => ({
   useEmoji: jest.fn(),

--- a/components/drops/view/item/rate/give/DropListItemRateGiveSubmit.tsx
+++ b/components/drops/view/item/rate/give/DropListItemRateGiveSubmit.tsx
@@ -9,6 +9,8 @@ import dynamic from "next/dynamic";
 import { ApiDrop } from "../../../../../../generated/models/ApiDrop";
 import { useDropInteractionRules } from "../../../../../../hooks/drops/useDropInteractionRules";
 import { DropVoteState } from "../../../../../../hooks/drops/types";
+import { DropSize } from "../../../../../../helpers/waves/drop.helpers";
+import { useMyStream } from "../../../../../../contexts/wave/MyStreamContext";
 
 export const VOTE_STATE_ERRORS: Record<DropVoteState, string | null> = {
   [DropVoteState.NOT_LOGGED_IN]: "Connect your wallet to rate",
@@ -48,6 +50,8 @@ export default function DropListItemRateGiveSubmit({
   const [clickCount, setClickCount] = useState<number>(0);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const { voteState } = useDropInteractionRules(drop);
+  const { applyOptimisticDropUpdate } = useMyStream();
+  const optimisticRollbackRef = useRef<(() => void) | null>(null);
 
   const rateChangeMutation = useMutation({
     mutationFn: async (param: { rate: number; category: string }) =>
@@ -60,8 +64,11 @@ export default function DropListItemRateGiveSubmit({
       }),
     onSuccess: (response: ApiDrop) => {
       onSuccessfulRateChange();
+      optimisticRollbackRef.current = null;
     },
     onError: (error) => {
+      optimisticRollbackRef.current?.();
+      optimisticRollbackRef.current = null;
       setToast({
         message: error as unknown as string,
         type: "error",
@@ -93,6 +100,59 @@ export default function DropListItemRateGiveSubmit({
     const rateIncrement = rate * clickCount;
     const newRate = previousRate + rateIncrement;
 
+    if (applyOptimisticDropUpdate && drop.wave?.id) {
+      const previousHasRating = previousRate !== 0;
+      const newHasRating = newRate !== 0;
+      const ratersCountDelta = previousHasRating
+        ? newHasRating
+          ? 0
+          : -1
+        : newHasRating
+          ? 1
+          : 0;
+      const ratingDelta = newRate - previousRate;
+
+      optimisticRollbackRef.current?.();
+      const handle = applyOptimisticDropUpdate({
+        waveId: drop.wave.id,
+        dropId: drop.id,
+        update: (draft) => {
+          if (draft.type !== DropSize.FULL) {
+            return draft;
+          }
+          const baseContext =
+            draft.context_profile_context ??
+            drop.context_profile_context ?? {
+              rating: 0,
+              min_rating: 0,
+              max_rating: 0,
+              reaction: null,
+            };
+
+          draft.context_profile_context = {
+            ...baseContext,
+            rating: newRate,
+          };
+
+          const currentRating =
+            typeof draft.rating === "number" ? draft.rating : 0;
+          draft.rating = currentRating + ratingDelta;
+
+          if (typeof draft.realtime_rating === "number") {
+            draft.realtime_rating = draft.realtime_rating + ratingDelta;
+          }
+
+          const currentRaters =
+            typeof draft.raters_count === "number" ? draft.raters_count : 0;
+          draft.raters_count = Math.max(0, currentRaters + ratersCountDelta);
+
+          return draft;
+        },
+      });
+
+      optimisticRollbackRef.current = handle?.rollback ?? null;
+    }
+
     await rateChangeMutation.mutateAsync({
       rate: newRate,
       category: DEFAULT_DROP_RATE_CATEGORY,
@@ -107,6 +167,7 @@ export default function DropListItemRateGiveSubmit({
     rateChangeMutation,
     voteState,
     setToast,
+    applyOptimisticDropUpdate,
   ]);
 
   useEffect(() => {

--- a/contexts/wave/MyStreamContext.tsx
+++ b/contexts/wave/MyStreamContext.tsx
@@ -20,6 +20,7 @@ import {
   ProcessIncomingDropType,
   useWaveRealtimeUpdater,
 } from "./hooks/useWaveRealtimeUpdater";
+import { Drop } from "../../helpers/waves/drop.helpers";
 import { WaveMessages } from "./hooks/types";
 import { useWebsocketStatus } from "../../services/websocket/useWebSocketMessage";
 import useCapacitor from "../../hooks/useCapacitor";
@@ -69,6 +70,15 @@ interface MyStreamContextType {
     type: ProcessIncomingDropType
   ) => void;
   readonly processDropRemoved: (waveId: string, dropId: string) => void;
+  readonly applyOptimisticDropUpdate: ({
+    waveId,
+    dropId,
+    update,
+  }: {
+    waveId: string;
+    dropId: string;
+    update: (draft: Drop) => Drop | void;
+  }) => { rollback: () => void } | null;
 }
 
 interface MyStreamProviderProps {
@@ -191,6 +201,7 @@ export const MyStreamProvider: React.FC<MyStreamProviderProps> = ({
       fetchAroundSerialNo: waveDataManager.fetchAroundSerialNo,
       processIncomingDrop,
       processDropRemoved,
+      applyOptimisticDropUpdate: waveMessagesStore.optimisticUpdateDrop,
     };
   }, [
     wavesHookData.waves,
@@ -217,6 +228,7 @@ export const MyStreamProvider: React.FC<MyStreamProviderProps> = ({
     waveDataManager.fetchAroundSerialNo,
     processIncomingDrop,
     processDropRemoved,
+    waveMessagesStore.optimisticUpdateDrop,
   ]);
 
   return (


### PR DESCRIPTION
  - add rollback-capable optimistic drop updates to the wave messages store and
  context
  - update drop reaction actions to optimistically inject the current user and
  reset on failure
  - sync reaction display state with optimistic changes and guard against
  duplicate handles
  - optimistically adjust drop rating, realtime rating, and raters count during
  submissions with tests updated to match