### PR TITLE
refactor: replace anchors with next/link

### DIFF
--- a/app/author/6529er6529-io/page.tsx
+++ b/app/author/6529er6529-io/page.tsx
@@ -1,4 +1,5 @@
 import { getAppMetadata } from "@/components/providers/metadata";
+import Link from "next/link";
 import { Metadata } from "next";
 
 export default function Author6529er6529IoPage() {
@@ -247,12 +248,12 @@ export default function Author6529er6529IoPage() {
                 <div className="fusion-page-title-wrapper">
                   <div className="fusion-page-title-captions">
                     <h1 className="entry-title">
-                      <a
+                      <Link
                         href="/cdn-cgi/l/email-protection"
                         className="__cf_email__"
                         data-cfemail="4177747378243301777473786f282e">
                         [email&nbsp;protected]
-                      </a>
+                      </Link>
                     </h1>
                     <div className="fusion-page-title-secondary"></div>
                   </div>
@@ -328,11 +329,11 @@ export default function Author6529er6529IoPage() {
                           />
                           <div className="fusion-rollover">
                             <div className="fusion-rollover-content">
-                              <a
+                              <Link
                                 className="fusion-rollover-link"
                                 href="/news/introducing-om/">
                                 INTRODUCING OM
-                              </a>
+                              </Link>
                               <div className="fusion-rollover-sep" />
                               <a
                                 className="fusion-rollover-gallery"
@@ -344,18 +345,18 @@ export default function Author6529er6529IoPage() {
                                 Gallery{" "}
                               </a>
                               <h4 className="fusion-rollover-title">
-                                <a
+                                <Link
                                   className="fusion-rollover-title-link"
                                   href="/news/introducing-om/">
                                   INTRODUCING OM{" "}
-                                </a>
+                                </Link>
                               </h4>
                               <div className="fusion-rollover-categories">
-                                <a href="/category/news/" rel="tag">
+                                <Link href="/category/news/" rel="tag">
                                   NEWS
-                                </a>
+                                </Link>
                               </div>
-                              <a
+                              <Link
                                 className="fusion-link-wrapper"
                                 href="/news/introducing-om/"
                                 aria-label="INTRODUCING OM"
@@ -366,16 +367,16 @@ export default function Author6529er6529IoPage() {
                         <div className="fusion-post-content-wrapper">
                           <div className="fusion-post-content post-content">
                             <h2 className="entry-title fusion-post-title">
-                              <a href="/news/introducing-om/">INTRODUCING OM</a>
+                              <Link href="/news/introducing-om/">INTRODUCING OM</Link>
                             </h2>
                             <span className="vcard rich-snippet-hidden">
                               <span className="fn">
-                                <a
+                                <Link
                                   href="/author/6529er6529-io/"
                                   title="Posts by 6529er"
                                   rel="author">
                                   6529er
-                                </a>
+                                </Link>
                               </span>
                             </span>
                             <span className="updated rich-snippet-hidden">
@@ -395,12 +396,12 @@ export default function Author6529er6529IoPage() {
                           </span>
                           <span className="vcard rich-snippet-hidden">
                             <span className="fn">
-                              <a
+                              <Link
                                 href="/author/6529er6529-io/"
                                 title="Posts by 6529er"
                                 rel="author">
                                 6529er
-                              </a>
+                              </Link>
                             </span>
                           </span>
                           <span className="updated rich-snippet-hidden">

--- a/app/author/ladysabrina/page.tsx
+++ b/app/author/ladysabrina/page.tsx
@@ -1,4 +1,5 @@
 import { getAppMetadata } from "@/components/providers/metadata";
+import Link from "next/link";
 import { Metadata } from "next";
 
 export default function AuthorLadysabrinaPage() {
@@ -324,13 +325,13 @@ export default function AuthorLadysabrinaPage() {
                           />
                           <div className="fusion-rollover">
                             <div className="fusion-rollover-content">
-                              <a
+                              <Link
                                 className="fusion-rollover-link"
                                 href="/blog/disney-deekay-their-secret-to-animation/"
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 Disney and DeeKay: Their Secret to Animation
-                              </a>
+                              </Link>
                               <div className="fusion-rollover-sep" />
                               <a
                                 className="fusion-rollover-gallery"
@@ -342,20 +343,20 @@ export default function AuthorLadysabrinaPage() {
                                 Gallery{" "}
                               </a>
                               <h4 className="fusion-rollover-title">
-                                <a
+                                <Link
                                   className="fusion-rollover-title-link"
                                   href="/blog/disney-deekay-their-secret-to-animation/"
                                   target="_blank"
                                   rel="noopener noreferrer">
                                   Disney and DeeKay: Their Secret to Animation{" "}
-                                </a>
+                                </Link>
                               </h4>
                               <div className="fusion-rollover-categories">
-                                <a href="/category/blog/" rel="tag">
+                                <Link href="/category/blog/" rel="tag">
                                   BLOG
-                                </a>
+                                </Link>
                               </div>
-                              <a
+                              <Link
                                 className="fusion-link-wrapper"
                                 href="/blog/disney-deekay-their-secret-to-animation/"
                                 target="_blank"
@@ -368,21 +369,21 @@ export default function AuthorLadysabrinaPage() {
                         <div className="fusion-post-content-wrapper">
                           <div className="fusion-post-content post-content">
                             <h2 className="entry-title fusion-post-title">
-                              <a
+                              <Link
                                 href="/blog/disney-deekay-their-secret-to-animation/"
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 Disney and DeeKay: Their Secret to Animation
-                              </a>
+                              </Link>
                             </h2>
                             <span className="vcard rich-snippet-hidden">
                               <span className="fn">
-                                <a
+                                <Link
                                   href="/author/ladysabrina/"
                                   title="Posts by Sabrina Khan"
                                   rel="author">
                                   Sabrina Khan
-                                </a>
+                                </Link>
                               </span>
                             </span>
                             <span className="updated rich-snippet-hidden">
@@ -402,12 +403,12 @@ export default function AuthorLadysabrinaPage() {
                           </span>
                           <span className="vcard rich-snippet-hidden">
                             <span className="fn">
-                              <a
+                              <Link
                                 href="/author/ladysabrina/"
                                 title="Posts by Sabrina Khan"
                                 rel="author">
                                 Sabrina Khan
-                              </a>
+                              </Link>
                             </span>
                           </span>
                           <span className="updated rich-snippet-hidden">
@@ -441,13 +442,13 @@ export default function AuthorLadysabrinaPage() {
                           />
                           <div className="fusion-rollover">
                             <div className="fusion-rollover-content">
-                              <a
+                              <Link
                                 className="fusion-rollover-link"
                                 href="/blog/from-fibonacci-to-fidenza/"
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 FROM FIBONACCI TO FIDENZA
-                              </a>
+                              </Link>
                               <div className="fusion-rollover-sep" />
                               <a
                                 className="fusion-rollover-gallery"
@@ -459,20 +460,20 @@ export default function AuthorLadysabrinaPage() {
                                 Gallery{" "}
                               </a>
                               <h4 className="fusion-rollover-title">
-                                <a
+                                <Link
                                   className="fusion-rollover-title-link"
                                   href="/blog/from-fibonacci-to-fidenza/"
                                   target="_blank"
                                   rel="noopener noreferrer">
                                   FROM FIBONACCI TO FIDENZA{" "}
-                                </a>
+                                </Link>
                               </h4>
                               <div className="fusion-rollover-categories">
-                                <a href="/category/blog/" rel="tag">
+                                <Link href="/category/blog/" rel="tag">
                                   BLOG
-                                </a>
+                                </Link>
                               </div>
-                              <a
+                              <Link
                                 className="fusion-link-wrapper"
                                 href="/blog/from-fibonacci-to-fidenza/"
                                 target="_blank"
@@ -485,21 +486,21 @@ export default function AuthorLadysabrinaPage() {
                         <div className="fusion-post-content-wrapper">
                           <div className="fusion-post-content post-content">
                             <h2 className="entry-title fusion-post-title">
-                              <a
+                              <Link
                                 href="/blog/from-fibonacci-to-fidenza/"
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 FROM FIBONACCI TO FIDENZA
-                              </a>
+                              </Link>
                             </h2>
                             <span className="vcard rich-snippet-hidden">
                               <span className="fn">
-                                <a
+                                <Link
                                   href="/author/ladysabrina/"
                                   title="Posts by Sabrina Khan"
                                   rel="author">
                                   Sabrina Khan
-                                </a>
+                                </Link>
                               </span>
                             </span>
                             <span className="updated rich-snippet-hidden">
@@ -520,12 +521,12 @@ export default function AuthorLadysabrinaPage() {
                           </span>
                           <span className="vcard rich-snippet-hidden">
                             <span className="fn">
-                              <a
+                              <Link
                                 href="/author/ladysabrina/"
                                 title="Posts by Sabrina Khan"
                                 rel="author">
                                 Sabrina Khan
-                              </a>
+                              </Link>
                             </span>
                           </span>
                           <span className="updated rich-snippet-hidden">
@@ -559,13 +560,13 @@ export default function AuthorLadysabrinaPage() {
                           />
                           <div className="fusion-rollover">
                             <div className="fusion-rollover-content">
-                              <a
+                              <Link
                                 className="fusion-rollover-link"
                                 href="/blog/a-tale-of-two-artists/"
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 A Tale of Two Artists – Van Gogh and XCOPY
-                              </a>
+                              </Link>
                               <div className="fusion-rollover-sep" />
                               <a
                                 className="fusion-rollover-gallery"
@@ -577,20 +578,20 @@ export default function AuthorLadysabrinaPage() {
                                 Gallery{" "}
                               </a>
                               <h4 className="fusion-rollover-title">
-                                <a
+                                <Link
                                   className="fusion-rollover-title-link"
                                   href="/blog/a-tale-of-two-artists/"
                                   target="_blank"
                                   rel="noopener noreferrer">
                                   A Tale of Two Artists – Van Gogh and XCOPY{" "}
-                                </a>
+                                </Link>
                               </h4>
                               <div className="fusion-rollover-categories">
-                                <a href="/category/blog/" rel="tag">
+                                <Link href="/category/blog/" rel="tag">
                                   BLOG
-                                </a>
+                                </Link>
                               </div>
-                              <a
+                              <Link
                                 className="fusion-link-wrapper"
                                 href="/blog/a-tale-of-two-artists/"
                                 target="_blank"
@@ -603,21 +604,21 @@ export default function AuthorLadysabrinaPage() {
                         <div className="fusion-post-content-wrapper">
                           <div className="fusion-post-content post-content">
                             <h2 className="entry-title fusion-post-title">
-                              <a
+                              <Link
                                 href="/blog/a-tale-of-two-artists/"
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 A Tale of Two Artists – Van Gogh and XCOPY
-                              </a>
+                              </Link>
                             </h2>
                             <span className="vcard rich-snippet-hidden">
                               <span className="fn">
-                                <a
+                                <Link
                                   href="/author/ladysabrina/"
                                   title="Posts by Sabrina Khan"
                                   rel="author">
                                   Sabrina Khan
-                                </a>
+                                </Link>
                               </span>
                             </span>
                             <span className="updated rich-snippet-hidden">
@@ -637,12 +638,12 @@ export default function AuthorLadysabrinaPage() {
                           </span>
                           <span className="vcard rich-snippet-hidden">
                             <span className="fn">
-                              <a
+                              <Link
                                 href="/author/ladysabrina/"
                                 title="Posts by Sabrina Khan"
                                 rel="author">
                                 Sabrina Khan
-                              </a>
+                              </Link>
                             </span>
                           </span>
                           <span className="updated rich-snippet-hidden">

--- a/app/capital/page.tsx
+++ b/app/capital/page.tsx
@@ -1,4 +1,5 @@
 import { getAppMetadata } from "@/components/providers/metadata";
+import Link from "next/link";
 import { Metadata } from "next";
 
 export default function CapitalPage() {
@@ -300,12 +301,12 @@ NFT investing is difficult specifically"
                   </span>
                   <span className="vcard rich-snippet-hidden">
                     <span className="fn">
-                      <a
+                      <Link
                         href="/author/6529er6529-io/"
                         title="Posts by 6529er"
                         rel="author">
                         6529er
-                      </a>
+                      </Link>
                     </span>
                   </span>
                   <span className="updated rich-snippet-hidden">
@@ -373,11 +374,11 @@ NFT investing is difficult specifically"
                               <p>
                                 A full list of companies in our portfolio can be
                                 found{" "}
-                                <a
+                                <Link
                                   href="/capital/company-portfolio/"
                                   className="decoration-underline">
                                   here
-                                </a>
+                                </Link>
                                 {"."}
                               </p>
                             </div>
@@ -797,9 +798,9 @@ NFT investing is difficult specifically"
                             <div className="fusion-text fusion-text-11">
                               <p>
                                 6529 Capital is currently investing through the{" "}
-                                <a href="/capital/fund/">
+                                <Link href="/capital/fund/">
                                   <u>6529 NFT Fund</u>
-                                </a>
+                                </Link>
                                 {"."}
                               </p>
                             </div>

--- a/app/category/blog/page.tsx
+++ b/app/category/blog/page.tsx
@@ -1,4 +1,5 @@
 import { getAppMetadata } from "@/components/providers/metadata";
+import Link from "next/link";
 import type { Metadata } from "next";
 
 export default function CategoryBlogPage() {
@@ -295,13 +296,13 @@ export default function CategoryBlogPage() {
                           />
                           <div className="fusion-rollover">
                             <div className="fusion-rollover-content">
-                              <a
+                              <Link
                                 className="fusion-rollover-link"
                                 href="/blog/disney-deekay-their-secret-to-animation/"
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 Disney and DeeKay: Their Secret to Animation
-                              </a>
+                              </Link>
                               <div className="fusion-rollover-sep" />
                               <a
                                 className="fusion-rollover-gallery"
@@ -313,20 +314,20 @@ export default function CategoryBlogPage() {
                                 Gallery{" "}
                               </a>
                               <h4 className="fusion-rollover-title">
-                                <a
+                                <Link
                                   className="fusion-rollover-title-link"
                                   href="/blog/disney-deekay-their-secret-to-animation/"
                                   target="_blank"
                                   rel="noopener noreferrer">
                                   Disney and DeeKay: Their Secret to Animation{" "}
-                                </a>
+                                </Link>
                               </h4>
                               <div className="fusion-rollover-categories">
-                                <a href="/category/blog/" rel="tag">
+                                <Link href="/category/blog/" rel="tag">
                                   BLOG
-                                </a>
+                                </Link>
                               </div>
-                              <a
+                              <Link
                                 className="fusion-link-wrapper"
                                 href="/blog/disney-deekay-their-secret-to-animation/"
                                 target="_blank"
@@ -339,21 +340,21 @@ export default function CategoryBlogPage() {
                         <div className="fusion-post-content-wrapper">
                           <div className="fusion-post-content post-content">
                             <h2 className="entry-title fusion-post-title">
-                              <a
+                              <Link
                                 href="/blog/disney-deekay-their-secret-to-animation/"
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 Disney and DeeKay: Their Secret to Animation
-                              </a>
+                              </Link>
                             </h2>
                             <span className="vcard rich-snippet-hidden">
                               <span className="fn">
-                                <a
+                                <Link
                                   href="/author/ladysabrina/"
                                   title="Posts by Sabrina Khan"
                                   rel="author">
                                   Sabrina Khan
-                                </a>
+                                </Link>
                               </span>
                             </span>
                             <span className="updated rich-snippet-hidden">
@@ -373,12 +374,12 @@ export default function CategoryBlogPage() {
                           </span>
                           <span className="vcard rich-snippet-hidden">
                             <span className="fn">
-                              <a
+                              <Link
                                 href="/author/ladysabrina/"
                                 title="Posts by Sabrina Khan"
                                 rel="author">
                                 Sabrina Khan
-                              </a>
+                              </Link>
                             </span>
                           </span>
                           <span className="updated rich-snippet-hidden">
@@ -412,13 +413,13 @@ export default function CategoryBlogPage() {
                           />
                           <div className="fusion-rollover">
                             <div className="fusion-rollover-content">
-                              <a
+                              <Link
                                 className="fusion-rollover-link"
                                 href="/blog/from-fibonacci-to-fidenza/"
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 FROM FIBONACCI TO FIDENZA
-                              </a>
+                              </Link>
                               <div className="fusion-rollover-sep" />
                               <a
                                 className="fusion-rollover-gallery"
@@ -430,20 +431,20 @@ export default function CategoryBlogPage() {
                                 Gallery{" "}
                               </a>
                               <h4 className="fusion-rollover-title">
-                                <a
+                                <Link
                                   className="fusion-rollover-title-link"
                                   href="/blog/from-fibonacci-to-fidenza/"
                                   target="_blank"
                                   rel="noopener noreferrer">
                                   FROM FIBONACCI TO FIDENZA{" "}
-                                </a>
+                                </Link>
                               </h4>
                               <div className="fusion-rollover-categories">
-                                <a href="/category/blog/" rel="tag">
+                                <Link href="/category/blog/" rel="tag">
                                   BLOG
-                                </a>
+                                </Link>
                               </div>
-                              <a
+                              <Link
                                 className="fusion-link-wrapper"
                                 href="/blog/from-fibonacci-to-fidenza/"
                                 target="_blank"
@@ -456,21 +457,21 @@ export default function CategoryBlogPage() {
                         <div className="fusion-post-content-wrapper">
                           <div className="fusion-post-content post-content">
                             <h2 className="entry-title fusion-post-title">
-                              <a
+                              <Link
                                 href="/blog/from-fibonacci-to-fidenza/"
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 FROM FIBONACCI TO FIDENZA
-                              </a>
+                              </Link>
                             </h2>
                             <span className="vcard rich-snippet-hidden">
                               <span className="fn">
-                                <a
+                                <Link
                                   href="/author/ladysabrina/"
                                   title="Posts by Sabrina Khan"
                                   rel="author">
                                   Sabrina Khan
-                                </a>
+                                </Link>
                               </span>
                             </span>
                             <span className="updated rich-snippet-hidden">
@@ -491,12 +492,12 @@ export default function CategoryBlogPage() {
                           </span>
                           <span className="vcard rich-snippet-hidden">
                             <span className="fn">
-                              <a
+                              <Link
                                 href="/author/ladysabrina/"
                                 title="Posts by Sabrina Khan"
                                 rel="author">
                                 Sabrina Khan
-                              </a>
+                              </Link>
                             </span>
                           </span>
                           <span className="updated rich-snippet-hidden">
@@ -530,13 +531,13 @@ export default function CategoryBlogPage() {
                           />
                           <div className="fusion-rollover">
                             <div className="fusion-rollover-content">
-                              <a
+                              <Link
                                 className="fusion-rollover-link"
                                 href="/blog/a-tale-of-two-artists/"
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 A Tale of Two Artists – Van Gogh and XCOPY
-                              </a>
+                              </Link>
                               <div className="fusion-rollover-sep" />
                               <a
                                 className="fusion-rollover-gallery"
@@ -548,20 +549,20 @@ export default function CategoryBlogPage() {
                                 Gallery{" "}
                               </a>
                               <h4 className="fusion-rollover-title">
-                                <a
+                                <Link
                                   className="fusion-rollover-title-link"
                                   href="/blog/a-tale-of-two-artists/"
                                   target="_blank"
                                   rel="noopener noreferrer">
                                   A Tale of Two Artists – Van Gogh and XCOPY{" "}
-                                </a>
+                                </Link>
                               </h4>
                               <div className="fusion-rollover-categories">
-                                <a href="/category/blog/" rel="tag">
+                                <Link href="/category/blog/" rel="tag">
                                   BLOG
-                                </a>
+                                </Link>
                               </div>
-                              <a
+                              <Link
                                 className="fusion-link-wrapper"
                                 href="/blog/a-tale-of-two-artists/"
                                 target="_blank"
@@ -574,21 +575,21 @@ export default function CategoryBlogPage() {
                         <div className="fusion-post-content-wrapper">
                           <div className="fusion-post-content post-content">
                             <h2 className="entry-title fusion-post-title">
-                              <a
+                              <Link
                                 href="/blog/a-tale-of-two-artists/"
                                 target="_blank"
                                 rel="noopener noreferrer">
                                 A Tale of Two Artists – Van Gogh and XCOPY
-                              </a>
+                              </Link>
                             </h2>
                             <span className="vcard rich-snippet-hidden">
                               <span className="fn">
-                                <a
+                                <Link
                                   href="/author/ladysabrina/"
                                   title="Posts by Sabrina Khan"
                                   rel="author">
                                   Sabrina Khan
-                                </a>
+                                </Link>
                               </span>
                             </span>
                             <span className="updated rich-snippet-hidden">
@@ -608,12 +609,12 @@ export default function CategoryBlogPage() {
                           </span>
                           <span className="vcard rich-snippet-hidden">
                             <span className="fn">
-                              <a
+                              <Link
                                 href="/author/ladysabrina/"
                                 title="Posts by Sabrina Khan"
                                 rel="author">
                                 Sabrina Khan
-                              </a>
+                              </Link>
                             </span>
                           </span>
                           <span className="updated rich-snippet-hidden">

--- a/app/category/news/page.tsx
+++ b/app/category/news/page.tsx
@@ -1,4 +1,5 @@
 import { getAppMetadata } from "@/components/providers/metadata";
+import Link from "next/link";
 import type { Metadata } from "next";
 
 export default function CategoryNewsPage() {
@@ -300,11 +301,11 @@ export default function CategoryNewsPage() {
                           />
                           <div className="fusion-rollover">
                             <div className="fusion-rollover-content">
-                              <a
+                              <Link
                                 className="fusion-rollover-link"
                                 href="/news/introducing-om/">
                                 INTRODUCING OM
-                              </a>
+                              </Link>
                               <div className="fusion-rollover-sep" />
                               <a
                                 className="fusion-rollover-gallery"
@@ -316,18 +317,18 @@ export default function CategoryNewsPage() {
                                 Gallery{" "}
                               </a>
                               <h4 className="fusion-rollover-title">
-                                <a
+                                <Link
                                   className="fusion-rollover-title-link"
                                   href="/news/introducing-om/">
                                   INTRODUCING OM{" "}
-                                </a>
+                                </Link>
                               </h4>
                               <div className="fusion-rollover-categories">
-                                <a href="/category/news/" rel="tag">
+                                <Link href="/category/news/" rel="tag">
                                   NEWS
-                                </a>
+                                </Link>
                               </div>
-                              <a
+                              <Link
                                 className="fusion-link-wrapper"
                                 href="/news/introducing-om/"
                                 aria-label="INTRODUCING OM"
@@ -338,16 +339,16 @@ export default function CategoryNewsPage() {
                         <div className="fusion-post-content-wrapper">
                           <div className="fusion-post-content post-content">
                             <h2 className="entry-title fusion-post-title">
-                              <a href="/news/introducing-om/">INTRODUCING OM</a>
+                              <Link href="/news/introducing-om/">INTRODUCING OM</Link>
                             </h2>
                             <span className="vcard rich-snippet-hidden">
                               <span className="fn">
-                                <a
+                                <Link
                                   href="/author/6529er6529-io/"
                                   title="Posts by 6529er"
                                   rel="author">
                                   6529er
-                                </a>
+                                </Link>
                               </span>
                             </span>
                             <span className="updated rich-snippet-hidden">
@@ -367,12 +368,12 @@ export default function CategoryNewsPage() {
                           </span>
                           <span className="vcard rich-snippet-hidden">
                             <span className="fn">
-                              <a
+                              <Link
                                 href="/author/6529er6529-io/"
                                 title="Posts by 6529er"
                                 rel="author">
                                 6529er
-                              </a>
+                              </Link>
                             </span>
                           </span>
                           <span className="updated rich-snippet-hidden">

--- a/app/dispute-resolution/page.client.tsx
+++ b/app/dispute-resolution/page.client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useSetTitle } from "@/contexts/TitleContext";
 import { AboutSection } from "@/enums";
 import styles from "@/styles/Home.module.scss";
@@ -78,9 +79,9 @@ export default function DisputeResolutionPage() {
             </ol>
             <br />
             <p>
-              <a href={`/about/${AboutSection.TERMS_OF_SERVICE}`}>
+              <Link href={`/about/${AboutSection.TERMS_OF_SERVICE}`}>
                 Back to Terms of Service
-              </a>{" "}
+              </Link>{" "}
             </p>
           </Col>
         </Row>

--- a/app/education/page.tsx
+++ b/app/education/page.tsx
@@ -1,4 +1,5 @@
 import { getAppMetadata } from "@/components/providers/metadata";
+import Link from "next/link";
 import type { Metadata } from "next";
 
 export default function EducationPage() {
@@ -299,12 +300,12 @@ Societies are made up of people – citizens, business leaders, public servants.
                   </span>
                   <span className="vcard rich-snippet-hidden">
                     <span className="fn">
-                      <a
+                      <Link
                         href="/author/6529er6529-io/"
                         title="Posts by 6529er"
                         rel="author">
                         6529er
-                      </a>
+                      </Link>
                     </span>
                   </span>
                   <span className="updated rich-snippet-hidden">
@@ -378,17 +379,17 @@ Societies are made up of people – citizens, business leaders, public servants.
                               <h3>WHAT IS THE PLAN IN EDUCATION?</h3>
                               <p>
                                 The 6529{" "}
-                                <a href="/education/tweetstorms/">
+                                <Link href="/education/tweetstorms/">
                                   <span style={{ textDecoration: "underline" }}>
                                     Tweetstorms
                                   </span>
-                                </a>{" "}
+                                </Link>{" "}
                                 and{" "}
-                                <a href="/education/podcasts/">
+                                <Link href="/education/podcasts/">
                                   <span style={{ textDecoration: "underline" }}>
                                     Podcasts
                                   </span>
-                                </a>{" "}
+                                </Link>{" "}
                                 are the start and will continue.
                               </p>
                               <p>
@@ -406,9 +407,9 @@ Societies are made up of people – citizens, business leaders, public servants.
                                 advocacy or policy in the cryptocurrency,
                                 digital rights, NFTs, Web3, metaverse, or
                                 related space, please get in touch{" "}
-                                <a href="/education/education-collaboration-form/">
+                                <Link href="/education/education-collaboration-form/">
                                   <u>here</u>
-                                </a>
+                                </Link>
                                 .
                               </p>
                               <p>

--- a/app/email-signatures/page.tsx
+++ b/app/email-signatures/page.tsx
@@ -1,4 +1,5 @@
 import { getAppMetadata } from "@/components/providers/metadata";
+import Link from "next/link";
 import { Metadata } from "next";
 
 export default function EmailSignaturesPage() {
@@ -305,12 +306,12 @@ Notes:
                   </span>
                   <span className="vcard rich-snippet-hidden">
                     <span className="fn">
-                      <a
+                      <Link
                         href="/author/6529er6529-io/"
                         title="Posts by 6529er"
                         rel="author">
                         6529er
-                      </a>
+                      </Link>
                     </span>
                   </span>
                   <span className="updated rich-snippet-hidden">
@@ -409,7 +410,7 @@ Notes:
                                 <tbody>
                                   <tr>
                                     <td>
-                                      <a href="/">
+                                      <Link href="/">
                                         <img
                                           loading="lazy"
                                           decoding="async"
@@ -422,7 +423,7 @@ Notes:
                                           width={96}
                                           height={96}
                                         />
-                                      </a>
+                                      </Link>
                                     </td>
                                     <td
                                       style={{
@@ -433,12 +434,12 @@ Notes:
                                       <strong>6529er</strong>
                                       <br />
                                       <strong>e</strong>{" "}
-                                      <a
+                                      <Link
                                         href="/cdn-cgi/l/email-protection"
                                         className="__cf_email__"
                                         data-cfemail="774142454e1205374142454e591e18">
                                         [email&nbsp;protected]
-                                      </a>
+                                      </Link>
                                       <br />
                                       <strong>t</strong> @6529er
                                       <br />
@@ -456,12 +457,12 @@ Notes:
                                 <strong>6529er</strong>
                                 <br />
                                 <strong>e</strong>{" "}
-                                <a
+                                <Link
                                   href="/cdn-cgi/l/email-protection"
                                   className="__cf_email__"
                                   data-cfemail="e2d4d7d0db8790a2d4d7d0dbcc8b8d">
                                   [email&nbsp;protected]
-                                </a>
+                                </Link>
                                 <br />
                                 <strong>t</strong> @6529er
                                 <br />
@@ -469,7 +470,7 @@ Notes:
                                 <br />
                                 <strong>w</strong> www.6529.io
                                 <br />
-                                <a href="/">
+                                <Link href="/">
                                   <img
                                     loading="lazy"
                                     decoding="async"
@@ -482,7 +483,7 @@ Notes:
                                     width={96}
                                     height={96}
                                   />
-                                </a>
+                                </Link>
                               </p>
                             </div>
                           </div>

--- a/app/museum/6529-fund-szn1/page.tsx
+++ b/app/museum/6529-fund-szn1/page.tsx
@@ -1,4 +1,5 @@
 import { getAppMetadata } from "@/components/providers/metadata";
+import Link from "next/link";
 const IndexPage = () => (
   <div>
     <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
@@ -347,12 +348,12 @@ Matt Kane"
                 </span>
                 <span className="vcard rich-snippet-hidden">
                   <span className="fn">
-                    <a
+                    <Link
                       href="/author/6529er6529-io/"
                       title="Posts by 6529er"
                       rel="author">
                       6529er
-                    </a>
+                    </Link>
                   </span>
                 </span>
                 <span className="updated rich-snippet-hidden">
@@ -500,24 +501,24 @@ Matt Kane"
                             className="fusion-text fusion-text-2"
                             style={{ color: "#000000" }}>
                             <p>
-                              <a href="/museum/6529-fund-szn1/fidenza/">
+                              <Link href="/museum/6529-fund-szn1/fidenza/">
                                 <strong>Fidenza</strong>
-                              </a>
+                              </Link>
                               <br />
                               Tyler Hobbs
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/xcopy/">
+                              <Link href="/museum/6529-fund-szn1/xcopy/">
                                 <strong>XCOPY</strong>
-                              </a>
+                              </Link>
                               <br />
                               XCOPYART
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/meridian/">
+                                <Link href="/museum/6529-fund-szn1/meridian/">
                                   Meridian
-                                </a>
+                                </Link>
                                 <br />
                                 <span style={{ fontWeight: 400 }}>
                                   Matt DesLauriers
@@ -526,74 +527,74 @@ Matt Kane"
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/ringers/">
+                                <Link href="/museum/6529-fund-szn1/ringers/">
                                   Ringers
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               Dmitri Cherniak
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/bored-ape-yacht-club/">
+                              <Link href="/museum/6529-fund-szn1/bored-ape-yacht-club/">
                                 <strong>Bored Ape Yacht Club</strong>
-                              </a>
+                              </Link>
                               <br />
                               Yuga Labs
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/cryptopunks/">
+                                <Link href="/museum/6529-fund-szn1/cryptopunks/">
                                   CryptoPunks
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               Yuga Labs
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/nouns/">
+                                <Link href="/museum/6529-fund-szn1/nouns/">
                                   Nouns
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               NounsDAO
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/gazers/">
+                                <Link href="/museum/6529-fund-szn1/gazers/">
                                   Gazers
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               Matt Kane
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/intensify-modeling/">
+                                <Link href="/museum/6529-fund-szn1/intensify-modeling/">
                                   Intensify Modeling
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               Botto
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/dead-ringers/">
+                              <Link href="/museum/6529-fund-szn1/dead-ringers/">
                                 <strong>Dead Ringers</strong>
-                              </a>
+                              </Link>
                               <br />
                               Dmitri Cherniak
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/azuki/">
+                              <Link href="/museum/6529-fund-szn1/azuki/">
                                 <strong>Azuki</strong>
-                              </a>
+                              </Link>
                               <br />
                               Chiru Labs
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/mfers/">
+                              <Link href="/museum/6529-fund-szn1/mfers/">
                                 <strong>mfers</strong>
-                              </a>
+                              </Link>
                               <br />
                               Sartoshi
                             </p>
@@ -616,34 +617,34 @@ Matt Kane"
                             style={{ color: "#000000" }}>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/where-my-vans-go/">
+                                <Link href="/museum/6529-fund-szn1/where-my-vans-go/">
                                   Where My Vans Go
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               DrifterShoots
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/archeology-of-the-future/">
+                                <Link href="/museum/6529-fund-szn1/archeology-of-the-future/">
                                   Archeology of the Future
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               Neurocolor
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/act-of-kindness/">
+                              <Link href="/museum/6529-fund-szn1/act-of-kindness/">
                                 <strong>Act of Kindness</strong>
-                              </a>
+                              </Link>
                               <br />
                               Danguiz
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/twin-flames/">
+                                <Link href="/museum/6529-fund-szn1/twin-flames/">
                                   Twin Flames
-                                </a>
+                                </Link>
                                 <br />
                                 <span style={{ fontWeight: 400 }}>
                                   Justin Aversano
@@ -652,9 +653,9 @@ Matt Kane"
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/conflicting-metaphysics/">
+                                <Link href="/museum/6529-fund-szn1/conflicting-metaphysics/">
                                   Conflicting Metaphysics
-                                </a>
+                                </Link>
                                 <br />
                                 <span style={{ fontWeight: 400 }}>
                                   Victor Fota
@@ -663,9 +664,9 @@ Matt Kane"
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/ballad-of-ghosts/">
+                                <Link href="/museum/6529-fund-szn1/ballad-of-ghosts/">
                                   Ballad of Ghosts
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               <span style={{ fontWeight: 400 }}>
@@ -674,18 +675,18 @@ Matt Kane"
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/image-with-arrow/">
+                                <Link href="/museum/6529-fund-szn1/image-with-arrow/">
                                   Image with Arrow
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               Coldie
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/an-incomparable-love/">
+                                <Link href="/museum/6529-fund-szn1/an-incomparable-love/">
                                   An Incomparable Love
-                                </a>
+                                </Link>
                                 <br />
                                 <span style={{ fontWeight: 400 }}>
                                   Kevin Abosch
@@ -694,35 +695,35 @@ Matt Kane"
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/faraway/">
+                                <Link href="/museum/6529-fund-szn1/faraway/">
                                   FARAWAY
-                                </a>
+                                </Link>
                               </strong>
                               <br />
                               CA Chou
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/wild-child-2022/">
+                                <Link href="/museum/6529-fund-szn1/wild-child-2022/">
                                   Wild Child 2022
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               Ali Sabet
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/primary-colors-of-neural-bricolage/">
+                                <Link href="/museum/6529-fund-szn1/primary-colors-of-neural-bricolage/">
                                   Primary Colors of Neural Bricolage
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               Helena Sarin
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/videodrome/">
+                              <Link href="/museum/6529-fund-szn1/videodrome/">
                                 <strong>Videodrome</strong>
-                              </a>
+                              </Link>
                               <br />
                               Robby Barrat
                             </p>
@@ -745,43 +746,43 @@ Matt Kane"
                             style={{ color: "#000000" }}>
                             <p>
                               <span style={{ fontWeight: 400 }}>
-                                <a href="/museum/6529-fund-szn1/incomplete-control/">
+                                <Link href="/museum/6529-fund-szn1/incomplete-control/">
                                   <strong>Incomplete Control</strong>
-                                </a>
+                                </Link>
                                 <br />
                                 Tyler Hobbs
                               </span>
                             </p>
                             <p>
                               <span style={{ fontWeight: 400 }}>
-                                <a href="/museum/6529-fund-szn1/cryptocubes/">
+                                <Link href="/museum/6529-fund-szn1/cryptocubes/">
                                   <strong>CryptoCubes</strong>
-                                </a>
+                                </Link>
                                 <br />
                                 HanRGB
                               </span>
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/proof-grails-wall/">
+                              <Link href="/museum/6529-fund-szn1/proof-grails-wall/">
                                 <strong>Wall</strong>
-                              </a>
+                              </Link>
                               <br />
                               Tyler Hobbs
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/proof-grails-protoglyph/">
+                                <Link href="/museum/6529-fund-szn1/proof-grails-protoglyph/">
                                   Protoglyph
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               Larva Labs
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/subscapes/">
+                                <Link href="/museum/6529-fund-szn1/subscapes/">
                                   Subscapes
-                                </a>
+                                </Link>
                               </strong>
                               <br />
                               Matt DesLauriers
@@ -791,27 +792,27 @@ Matt Kane"
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/chromie-squiggle/">
+                                <Link href="/museum/6529-fund-szn1/chromie-squiggle/">
                                   Chromie Squiggle
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               Snowfro
                             </p>
                             <p>
                               <span style={{ fontWeight: 400 }}>
-                                <a href="/museum/6529-fund-szn1/genesis/">
+                                <Link href="/museum/6529-fund-szn1/genesis/">
                                   <strong>Genesis</strong>
-                                </a>
+                                </Link>
                                 <br />
                                 Daniel Calderon
                               </span>
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/non-either/">
+                                <Link href="/museum/6529-fund-szn1/non-either/">
                                   Non Either
-                                </a>
+                                </Link>
                                 <br />
                                 <span style={{ fontWeight: 400 }}>
                                   Rafael Rozendaal
@@ -821,34 +822,34 @@ Matt Kane"
                             </p>
                             <p>
                               <span style={{ fontWeight: 400 }}>
-                                <a href="/museum/6529-fund-szn1/entretiempos/">
+                                <Link href="/museum/6529-fund-szn1/entretiempos/">
                                   <strong>Entretiempos</strong>
-                                </a>
+                                </Link>
                                 <br />
                                 Marcelo Soria-Rodriguez
                               </span>
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/construction-token/">
+                              <Link href="/museum/6529-fund-szn1/construction-token/">
                                 <strong>Construction Token</strong>
-                              </a>
+                              </Link>
                               <br />
                               Jeff Davis
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/jiometory-no-compute/">
+                                <Link href="/museum/6529-fund-szn1/jiometory-no-compute/">
                                   Jiometory No Compute
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               Samsy
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/screens/">
+                                <Link href="/museum/6529-fund-szn1/screens/">
                                   Screens
-                                </a>
+                                </Link>
                                 <br />
                                 <span style={{ fontWeight: 400 }}>
                                   Thomas Lin Pedersen
@@ -873,25 +874,25 @@ Matt Kane"
                             className="fusion-text fusion-text-5"
                             style={{ color: "#000000" }}>
                             <p>
-                              <a href="/museum/6529-fund-szn1/grifters/">
+                              <Link href="/museum/6529-fund-szn1/grifters/">
                                 <strong>Grifters</strong>
-                              </a>
+                              </Link>
                               <br />
                               XCOPY
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/cryptoadz/">
+                                <Link href="/museum/6529-fund-szn1/cryptoadz/">
                                   CrypToadz
-                                </a>
+                                </Link>
                               </strong>
                               <br />
                               gremplin
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/clonex/">
+                              <Link href="/museum/6529-fund-szn1/clonex/">
                                 <strong>CloneX</strong>
-                              </a>
+                              </Link>
                               <br />
                               RTFKT x{" "}
                               <span style={{ fontWeight: 400 }}>
@@ -900,9 +901,9 @@ Matt Kane"
                             </p>
                             <p>
                               <span style={{ fontWeight: 400 }}>
-                                <a href="/museum/6529-fund-szn1/rarepepe/">
+                                <Link href="/museum/6529-fund-szn1/rarepepe/">
                                   <strong>RAREPEPE</strong>
-                                </a>
+                                </Link>
                                 <br />
                               </span>
                               <span style={{ fontWeight: 400 }}>
@@ -910,58 +911,58 @@ Matt Kane"
                               </span>
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/fakerares/">
+                              <Link href="/museum/6529-fund-szn1/fakerares/">
                                 <strong>FARERARES</strong>
-                              </a>
+                              </Link>
                               <br />
                               Various Artists
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/capsule-house/">
+                              <Link href="/museum/6529-fund-szn1/capsule-house/">
                                 <strong>Capsule House</strong>
-                              </a>
+                              </Link>
                               <br />
                               SeerLight + Kaejunni
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/nuclear-nerds/">
+                              <Link href="/museum/6529-fund-szn1/nuclear-nerds/">
                                 <strong>Nuclear Nerds</strong>
-                              </a>
+                              </Link>
                               <br />
                               Bazooka Labs
                             </p>
                             <p>
                               <span style={{ fontWeight: 400 }}>
-                                <a href="/museum/6529-fund-szn1/invisible-friends/">
+                                <Link href="/museum/6529-fund-szn1/invisible-friends/">
                                   <strong>Invisible Friends</strong>
-                                </a>
+                                </Link>
                                 <br />
                                 Markus Magnusson{" "}
                               </span>
                             </p>
                             <p>
                               <span style={{ fontWeight: 400 }}>
-                                <a href="/museum/6529-fund-szn1/the-key-the-trial/">
+                                <Link href="/museum/6529-fund-szn1/the-key-the-trial/">
                                   <strong>The Trial</strong>
-                                </a>
+                                </Link>
                                 <br />
                                 k-art
                               </span>
                             </p>
                             <p>
                               <span style={{ fontWeight: 400 }}>
-                                <a href="/museum/6529-fund-szn1/madhouse/">
+                                <Link href="/museum/6529-fund-szn1/madhouse/">
                                   <strong>MAD</strong>
-                                </a>
+                                </Link>
                                 <br />
                               </span>
                               k-art
                             </p>
                             <p>
                               <span style={{ fontWeight: 400 }}>
-                                <a href="/museum/6529-fund-szn1/queens-kings/">
+                                <Link href="/museum/6529-fund-szn1/queens-kings/">
                                   <strong>Queens + Kings</strong>
-                                </a>
+                                </Link>
                                 <br />
                                 Hackatao
                                 <br />
@@ -970,18 +971,18 @@ Matt Kane"
                             <p>
                               <span style={{ fontWeight: 400 }}>
                                 <strong>
-                                  <a href="/museum/6529-fund-szn1/cod/">
+                                  <Link href="/museum/6529-fund-szn1/cod/">
                                     Async Blueprints cods
-                                  </a>
+                                  </Link>
                                 </strong>
                                 <br />
                               </span>
                               k-art
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/cryptoad-punks/">
+                              <Link href="/museum/6529-fund-szn1/cryptoad-punks/">
                                 <strong>CrypToad Punks</strong>
-                              </a>
+                              </Link>
                             </p>
                           </div>
                         </div>

--- a/app/museum/6529-fund-szn2/page.tsx
+++ b/app/museum/6529-fund-szn2/page.tsx
@@ -1,4 +1,5 @@
 import { getAppMetadata } from "@/components/providers/metadata";
+import Link from "next/link";
 const IndexPage = () => (
   <div>
     <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
@@ -347,12 +348,12 @@ Matt Kane"
                 </span>
                 <span className="vcard rich-snippet-hidden">
                   <span className="fn">
-                    <a
+                    <Link
                       href="/author/ladysabrina/"
                       title="Posts by Sabrina Khan"
                       rel="author">
                       Sabrina Khan
-                    </a>
+                    </Link>
                   </span>
                 </span>
                 <span className="updated rich-snippet-hidden">
@@ -500,24 +501,24 @@ Matt Kane"
                             className="fusion-text fusion-text-2"
                             style={{ color: "#000000" }}>
                             <p>
-                              <a href="/museum/6529-fund-szn1/fidenza/">
+                              <Link href="/museum/6529-fund-szn1/fidenza/">
                                 <strong>Fidenza</strong>
-                              </a>
+                              </Link>
                               <br />
                               Tyler Hobbs
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/xcopy/">
+                              <Link href="/museum/6529-fund-szn1/xcopy/">
                                 <strong>XCOPY</strong>
-                              </a>
+                              </Link>
                               <br />
                               XCOPYART
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/meridian/">
+                                <Link href="/museum/6529-fund-szn1/meridian/">
                                   Meridian
-                                </a>
+                                </Link>
                                 <br />
                                 <span style={{ fontWeight: 400 }}>
                                   Matt DesLauriers
@@ -526,74 +527,74 @@ Matt Kane"
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/ringers/">
+                                <Link href="/museum/6529-fund-szn1/ringers/">
                                   Ringers
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               Dmitri Cherniak
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/bored-ape-yacht-club/">
+                              <Link href="/museum/6529-fund-szn1/bored-ape-yacht-club/">
                                 <strong>Bored Ape Yacht Club</strong>
-                              </a>
+                              </Link>
                               <br />
                               Yuga Labs
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/cryptopunks/">
+                                <Link href="/museum/6529-fund-szn1/cryptopunks/">
                                   CryptoPunks
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               Yuga Labs
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/nouns/">
+                                <Link href="/museum/6529-fund-szn1/nouns/">
                                   Nouns
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               NounsDAO
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/gazers/">
+                                <Link href="/museum/6529-fund-szn1/gazers/">
                                   Gazers
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               Matt Kane
                             </p>
                             <p>
                               <strong>
-                                <a href="/museum/6529-fund-szn1/intensify-modeling/">
+                                <Link href="/museum/6529-fund-szn1/intensify-modeling/">
                                   Intensify Modeling
-                                </a>
+                                </Link>
                                 <br />
                               </strong>
                               Botto
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/dead-ringers/">
+                              <Link href="/museum/6529-fund-szn1/dead-ringers/">
                                 <strong>Dead Ringers</strong>
-                              </a>
+                              </Link>
                               <br />
                               Dmitri Cherniak
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/azuki/">
+                              <Link href="/museum/6529-fund-szn1/azuki/">
                                 <strong>Azuki</strong>
-                              </a>
+                              </Link>
                               <br />
                               Chiru Labs
                             </p>
                             <p>
-                              <a href="/museum/6529-fund-szn1/mfers/">
+                              <Link href="/museum/6529-fund-szn1/mfers/">
                                 <strong>mfers</strong>
-                              </a>
+                              </Link>
                               <br />
                               Sartoshi
                             </p>

--- a/app/museum/genesis/page.tsx
+++ b/app/museum/genesis/page.tsx
@@ -1,4 +1,5 @@
 import { getAppMetadata } from "@/components/providers/metadata";
+import Link from "next/link";
 const IndexPage = () => (
   <div>
     <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
@@ -301,12 +302,12 @@ EARLY ON-CHAIN GENERATIVE ART"
                 <span className="entry-title rich-snippet-hidden">GENESIS</span>
                 <span className="vcard rich-snippet-hidden">
                   <span className="fn">
-                    <a
+                    <Link
                       href="/author/6529er6529-io/"
                       title="Posts by 6529er"
                       rel="author">
                       6529er
-                    </a>
+                    </Link>
                   </span>
                 </span>
                 <span className="updated rich-snippet-hidden">
@@ -486,56 +487,56 @@ EARLY ON-CHAIN GENERATIVE ART"
                             className="fusion-text fusion-text-2"
                             style={{ color: "#000000" }}>
                             <p>
-                              <a href="/museum/genesis/autoglyphs/">
+                              <Link href="/museum/genesis/autoglyphs/">
                                 <span style={{ textDecoration: "underline" }}>
                                   <strong>Autoglyphs</strong>
                                 </span>
-                              </a>
+                              </Link>
                               <br />
                               Larva Labs
                             </p>
                             <p>
-                              <a href="/museum/genesis/squiggly-wtf/">
+                              <Link href="/museum/genesis/squiggly-wtf/">
                                 <span style={{ textDecoration: "underline" }}>
                                   <strong>Squiggly.wtf</strong>
                                 </span>
-                              </a>
+                              </Link>
                               <br />
                               natealex
                             </p>
                             <p>
-                              <a href="/museum/genesis/labios">
+                              <Link href="/museum/genesis/labios">
                                 <span style={{ textDecoration: "underline" }}>
                                   <strong>Labios</strong>
                                 </span>
-                              </a>
+                              </Link>
                               <br />
                               Manoloide
                             </p>
                             <p>
-                              <a href="/museum/genesis/cryptocube">
+                              <Link href="/museum/genesis/cryptocube">
                                 <span style={{ textDecoration: "underline" }}>
                                   <strong>Cryptocube</strong>
                                 </span>
-                              </a>
+                              </Link>
                               <br />
                               Han
                             </p>
                             <p>
-                              <a href="/museum/genesis/cryptoarte">
+                              <Link href="/museum/genesis/cryptoarte">
                                 <span style={{ textDecoration: "underline" }}>
                                   <strong>Cryptoarte</strong>
                                 </span>
-                              </a>
+                              </Link>
                               <br />
                               Sebastián Brocher
                             </p>
                             <p>
-                              <a href="/museum/genesis/lost-robbies">
+                              <Link href="/museum/genesis/lost-robbies">
                                 <span style={{ textDecoration: "underline" }}>
                                   <strong>The Lost Robbies</strong>
                                 </span>
-                              </a>
+                              </Link>
                               <br />
                               Robbie Barrat
                             </p>
@@ -570,44 +571,44 @@ EARLY ON-CHAIN GENERATIVE ART"
                             className="fusion-text fusion-text-3"
                             style={{ color: "#000000" }}>
                             <p>
-                              <a href="/museum/genesis/chromie-squiggle">
+                              <Link href="/museum/genesis/chromie-squiggle">
                                 <strong>Chromie Squiggle</strong>
-                              </a>
+                              </Link>
                               <br />
                               snowfro
                             </p>
                             <p>
-                              <a href="/museum/genesis/genesis-dca">
+                              <Link href="/museum/genesis/genesis-dca">
                                 <strong>Genesis</strong>
-                              </a>
+                              </Link>
                               <br />
                               DCA
                             </p>
                             <p>
-                              <a href="/museum/genesis/construction-token">
+                              <Link href="/museum/genesis/construction-token">
                                 <strong>Construction Token</strong>
-                              </a>
+                              </Link>
                               <br />
                               Jeff Davis
                             </p>
                             <p>
-                              <a href="/museum/genesis/cryptoblots">
+                              <Link href="/museum/genesis/cryptoblots">
                                 <strong>Cryptoblots</strong>
-                              </a>
+                              </Link>
                               <br />
                               Daïm Aggott-Hönsch
                             </p>
                             <p>
-                              <a href="/museum/genesis/dynamic-slices">
+                              <Link href="/museum/genesis/dynamic-slices">
                                 <strong>Dynamic Slices</strong>
-                              </a>
+                              </Link>
                               <br />
                               pxlq
                             </p>
                             <p>
-                              <a href="/museum/genesis/elevated-deconstructions">
+                              <Link href="/museum/genesis/elevated-deconstructions">
                                 <strong>Elevated Deconstructions</strong>
-                              </a>
+                              </Link>
                               <br />
                               luxpris
                             </p>
@@ -642,100 +643,100 @@ EARLY ON-CHAIN GENERATIVE ART"
                             className="fusion-text fusion-text-4"
                             style={{ color: "#000000" }}>
                             <p>
-                              <a href="/museum/genesis/singularity">
+                              <Link href="/museum/genesis/singularity">
                                 <strong>Singularity</strong>
-                              </a>
+                              </Link>
                               <br />
                               Hideki Tsukamoto
                             </p>
                             <p>
-                              <a href="/museum/genesis/ignition">
+                              <Link href="/museum/genesis/ignition">
                                 <strong>Ignition</strong>
-                              </a>
+                              </Link>
                               <br />
                               ge1doot
                             </p>
                             <p>
-                              <a href="/museum/genesis/nimbuds">
+                              <Link href="/museum/genesis/nimbuds">
                                 <strong>NimBuds</strong>
-                              </a>
+                              </Link>
                               <br />
                               Bryan Brinkman
                             </p>
                             <p>
-                              <a href="/museum/genesis/hyperhash">
+                              <Link href="/museum/genesis/hyperhash">
                                 <strong>HyperHash</strong>
-                              </a>
+                              </Link>
                               <br />
                               Beervangeer
                             </p>
                             <p>
-                              <a href="/museum/genesis/unigrids">
+                              <Link href="/museum/genesis/unigrids">
                                 <strong>Unigrids</strong>
-                              </a>
+                              </Link>
                               <br />
                               Zeblocks
                             </p>
                             <p>
-                              <a href="/museum/genesis/ringers">
+                              <Link href="/museum/genesis/ringers">
                                 <strong>Ringers</strong>
-                              </a>
+                              </Link>
                               <br />
                               Dmitri Cherniak
                             </p>
                             <p>
-                              <a href="/museum/genesis/spectron">
+                              <Link href="/museum/genesis/spectron">
                                 <strong>Spectron</strong>
-                              </a>
+                              </Link>
                               <br />
                               Simon De Mai
                             </p>
                             <p>
-                              <a href="/museum/genesis/27-bit-digital">
+                              <Link href="/museum/genesis/27-bit-digital">
                                 <strong>27-Bit Digital</strong>
-                              </a>
+                              </Link>
                               <br />
                               kai
                             </p>
                             <p>
-                              <a href="/museum/genesis/archetype">
+                              <Link href="/museum/genesis/archetype">
                                 <strong>Archetype</strong>
-                              </a>
+                              </Link>
                               <br />
                               Kjetil Golid
                             </p>
                             <p>
-                              <a href="/museum/genesis/720-minutes">
+                              <Link href="/museum/genesis/720-minutes">
                                 <strong>720 Minutes</strong>
-                              </a>
+                              </Link>
                               <br />
                               Alexis André
                             </p>
                             <p>
-                              <a href="/museum/genesis/aerial-view">
+                              <Link href="/museum/genesis/aerial-view">
                                 <strong>Aerial View</strong>
-                              </a>
+                              </Link>
                               <br />
                               daLenz
                             </p>
                             <p>
-                              <a href="/museum/genesis/apparitions">
+                              <Link href="/museum/genesis/apparitions">
                                 <strong>Apparitions</strong>
-                              </a>
+                              </Link>
                               <br />
                               Aaron Penne
                             </p>
                             <p>
-                              <a href="/museum/genesis/inspirals">
+                              <Link href="/museum/genesis/inspirals">
                                 <strong>Inspirals</strong>
-                              </a>
+                              </Link>
                               <br />
                               Radix
                             </p>
                             <p>
-                              <a href="/museum/genesis/secret-surprise">
+                              <Link href="/museum/genesis/secret-surprise">
                                 <strong>Secret Surprise</strong>
-                              </a>
+                              </Link>
                             </p>
                           </div>
                         </div>
@@ -768,86 +769,86 @@ EARLY ON-CHAIN GENERATIVE ART"
                             className="fusion-text fusion-text-5"
                             style={{ color: "#000000" }}>
                             <p>
-                              <a href="/museum/genesis/synapses">
+                              <Link href="/museum/genesis/synapses">
                                 <strong>Synapses</strong>
-                              </a>
+                              </Link>
                               <br />
                               Chaosconstruct
                             </p>
                             <p>
-                              <a href="/museum/genesis/algobots">
+                              <Link href="/museum/genesis/algobots">
                                 <strong>Algobots</strong>
-                              </a>
+                              </Link>
                               <br />
                               Stina Jones
                             </p>
                             <p>
-                              <a href="/museum/genesis/elementals">
+                              <Link href="/museum/genesis/elementals">
                                 <strong>Elementals</strong>
-                              </a>
+                              </Link>
                               <br />
                               Michael Connolly
                             </p>
                             <p>
-                              <a href="/museum/genesis/subscapes">
+                              <Link href="/museum/genesis/subscapes">
                                 <strong>Subscapes</strong>
-                              </a>
+                              </Link>
                               <br />
                               Matt DesLauriers
                             </p>
                             <p>
-                              <a href="/museum/genesis/watercolor-dreams">
+                              <Link href="/museum/genesis/watercolor-dreams">
                                 <strong>Watercolor Dreams</strong>
-                              </a>
+                              </Link>
                               <br />
                               NumbersInMotion
                             </p>
                             <p>
-                              <a href="/museum/genesis/bubble-bobbly">
+                              <Link href="/museum/genesis/bubble-bobbly">
                                 <strong>Bubble Bobbly</strong>
-                              </a>
+                              </Link>
                               <br />
                               Jason Ting
                             </p>
                             <p>
-                              <a href="/museum/genesis/frammenti">
+                              <Link href="/museum/genesis/frammenti">
                                 <strong>Frammenti</strong>
-                              </a>
+                              </Link>
                               <br />
                               Stefano Contiero
                             </p>
                             <p>
-                              <a href="/museum/genesis/algorhythms">
+                              <Link href="/museum/genesis/algorhythms">
                                 <strong>AlgoRhythms</strong>
-                              </a>
+                              </Link>
                               <br />
                               Han x Nicolas Daniel
                             </p>
                             <p>
-                              <a href="/museum/genesis/the-blocks-of-art">
+                              <Link href="/museum/genesis/the-blocks-of-art">
                                 <strong>The Blocks of Art</strong>
-                              </a>
+                              </Link>
                               <br />
                               Shvembldr
                             </p>
                             <p>
-                              <a href="/museum/genesis/century">
+                              <Link href="/museum/genesis/century">
                                 <strong>Century</strong>
-                              </a>
+                              </Link>
                               <br />
                               Casey REAS
                             </p>
                             <p>
-                              <a href="/museum/genesis/dreams">
+                              <Link href="/museum/genesis/dreams">
                                 <strong>Dreams</strong>
-                              </a>
+                              </Link>
                               <br />
                               Joshua Bagley
                             </p>
                             <p>
-                              <a href="/museum/genesis/fidenza">
+                              <Link href="/museum/genesis/fidenza">
                                 <strong>Fidenza</strong>
-                              </a>
+                              </Link>
                               <br />
                               Tyler Hobbs
                             </p>
@@ -882,65 +883,65 @@ EARLY ON-CHAIN GENERATIVE ART"
                             className="fusion-text fusion-text-6"
                             style={{ color: "#000000" }}>
                             <p>
-                              <a href="/museum/genesis/glitch-crystal-monsters">
+                              <Link href="/museum/genesis/glitch-crystal-monsters">
                                 <strong>Glitch Crystal Monsters</strong>
-                              </a>
+                              </Link>
                               <br />
                               Alida Sun
                             </p>
                             <p>
-                              <a href="/museum/genesis/endless-nameless">
+                              <Link href="/museum/genesis/endless-nameless">
                                 <strong>Endless Nameless</strong>
-                              </a>
+                              </Link>
                               <br />
                               Rafaël Rozendaal
                             </p>
                             <p>
-                              <a href="/museum/genesis/pigments">
+                              <Link href="/museum/genesis/pigments">
                                 <strong>Pigments</strong>
-                              </a>
+                              </Link>
                               <br />
                               Darien Brito
                             </p>
                             <p>
-                              <a href="/museum/genesis/phase">
+                              <Link href="/museum/genesis/phase">
                                 <strong>phase</strong>
-                              </a>
+                              </Link>
                               <br />
                               Loren Bednar
                             </p>
                             <p>
-                              <a href="/museum/genesis/scribbled-boundaries">
+                              <Link href="/museum/genesis/scribbled-boundaries">
                                 <strong>Scribbled Boundaries</strong>
-                              </a>
+                              </Link>
                               <br />
                               William Tan
                             </p>
                             <p>
-                              <a href="/museum/genesis/trossets">
+                              <Link href="/museum/genesis/trossets">
                                 <strong>Trossets</strong>
-                              </a>
+                              </Link>
                               <br />
                               Anna Carreras
                             </p>
                             <p>
-                              <a href="/museum/genesis/geometry-runners">
+                              <Link href="/museum/genesis/geometry-runners">
                                 <strong>Geometry Runners</strong>
-                              </a>
+                              </Link>
                               <br />
                               Rich Lord
                             </p>
                             <p>
-                              <a href="/museum/genesis/fragments-of-an-infinite-field">
+                              <Link href="/museum/genesis/fragments-of-an-infinite-field">
                                 <strong>Fragments of an Infinite Field</strong>
-                              </a>
+                              </Link>
                               <br />
                               Monica Rizzolli
                             </p>
                             <p>
-                              <a href="/museum/genesis/skulptuur">
+                              <Link href="/museum/genesis/skulptuur">
                                 <strong>Skulptuur</strong>
-                              </a>
+                              </Link>
                               <br />
                               Piter Pasma
                             </p>
@@ -975,51 +976,51 @@ EARLY ON-CHAIN GENERATIVE ART"
                             className="fusion-text fusion-text-7"
                             style={{ color: "#000000" }}>
                             <p>
-                              <a href="/museum/genesis/edifice">
+                              <Link href="/museum/genesis/edifice">
                                 <strong>Edifice</strong>
-                              </a>
+                              </Link>
                               <br />
                               Ben Kovach
                             </p>
                             <p>
-                              <a href="/museum/genesis/asemica">
+                              <Link href="/museum/genesis/asemica">
                                 <strong>Asemica</strong>
-                              </a>
+                              </Link>
                               <br />
                               Emily Edelman – Dima Ofman – Andrew Badr
                             </p>
                             <p>
-                              <a href="/museum/genesis/autology">
+                              <Link href="/museum/genesis/autology">
                                 <strong>Autology</strong>
-                              </a>
+                              </Link>
                               <br />
                               steganon
                             </p>
                             <p>
-                              <a href="/museum/genesis/bent">
+                              <Link href="/museum/genesis/bent">
                                 <strong>Bent</strong>
-                              </a>
+                              </Link>
                               <br />
                               ippsketch
                             </p>
                             <p>
-                              <a href="/museum/genesis/gazers">
+                              <Link href="/museum/genesis/gazers">
                                 <strong>Gazers</strong>
-                              </a>
+                              </Link>
                               <br />
                               Matt Kane
                             </p>
                             <p>
-                              <a href="/museum/genesis/vortex">
+                              <Link href="/museum/genesis/vortex">
                                 <strong>Vortex</strong>
-                              </a>
+                              </Link>
                               <br />
                               Jen Stark
                             </p>
                             <p>
-                              <a href="/museum/genesis/jiometory-no-compute">
+                              <Link href="/museum/genesis/jiometory-no-compute">
                                 <strong>Jiometory No Compute – </strong>
-                              </a>
+                              </Link>
                               <br />
                               <strong>ジオメトリ ハ ケイサンサレマセン</strong>
                               <br />
@@ -1056,37 +1057,37 @@ EARLY ON-CHAIN GENERATIVE ART"
                             className="fusion-text fusion-text-8"
                             style={{ color: "#000000" }}>
                             <p>
-                              <a href="/museum/genesis/chimera">
+                              <Link href="/museum/genesis/chimera">
                                 <strong>Chimera</strong>
-                              </a>
+                              </Link>
                               <br />
                               mpkoz
                             </p>
                             <p>
-                              <a href="/museum/genesis/cosmic-reef">
+                              <Link href="/museum/genesis/cosmic-reef">
                                 <strong>Cosmic Reef</strong>
-                              </a>
+                              </Link>
                               <br />
                               Leo Villareal
                             </p>
                             <p>
-                              <a href="/museum/genesis/screens">
+                              <Link href="/museum/genesis/screens">
                                 <strong>Screens</strong>
-                              </a>
+                              </Link>
                               <br />
                               Thomas Lin Pedersen
                             </p>
                             <p>
-                              <a href="/museum/genesis/para-bellum">
+                              <Link href="/museum/genesis/para-bellum">
                                 <strong>Para Bellum</strong>
-                              </a>
+                              </Link>
                               <br />
                               Matty Mariansky
                             </p>
                             <p>
-                              <a href="/museum/genesis/entretiempos">
+                              <Link href="/museum/genesis/entretiempos">
                                 <strong>entretiempos</strong>
-                              </a>
+                              </Link>
                               <br />
                               Marcelo Soria-Rodríguez
                             </p>
@@ -1124,37 +1125,37 @@ EARLY ON-CHAIN GENERATIVE ART"
                             className="fusion-text fusion-text-9"
                             style={{ color: "#000000" }}>
                             <p>
-                              <a href="/museum/genesis/incomplete-control">
+                              <Link href="/museum/genesis/incomplete-control">
                                 <strong>Incomplete Control</strong>
-                              </a>
+                              </Link>
                               <br />
                               Tyler Hobbs
                             </p>
                             <p>
-                              <a href="/museum/genesis/meridian">
+                              <Link href="/museum/genesis/meridian">
                                 <strong>Meridian</strong>
-                              </a>
+                              </Link>
                               <br />
                               Matt DesLauriers
                             </p>
                             <p>
-                              <a href="/museum/genesis/kai-gen">
+                              <Link href="/museum/genesis/kai-gen">
                                 <strong>Kai-Gen</strong>
-                              </a>
+                              </Link>
                               <br />
                               Takeshi Murata, Christopher Rutledge, J. Krispy
                             </p>
                             <p>
-                              <a href="/museum/genesis/willow-shield">
+                              <Link href="/museum/genesis/willow-shield">
                                 <strong>Willow Shield</strong>
-                              </a>
+                              </Link>
                               <br />
                               ixshells
                             </p>
                             <p>
-                              <a href="/museum/genesis/great-hall-of-generative-art">
+                              <Link href="/museum/genesis/great-hall-of-generative-art">
                                 <strong>Great Hall of Generative Art</strong>
-                              </a>
+                              </Link>
                               <br />
                               Various Artists
                             </p>

--- a/app/museum/page.tsx
+++ b/app/museum/page.tsx
@@ -1,4 +1,5 @@
 import { getAppMetadata } from "@/components/providers/metadata";
+import Link from "next/link";
 const IndexPage = () => (
   <div>
     <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
@@ -299,12 +300,12 @@ The museum also owns"
                 </span>
                 <span className="vcard rich-snippet-hidden">
                   <span className="fn">
-                    <a
+                    <Link
                       href="/author/6529er6529-io/"
                       title="Posts by 6529er"
                       rel="author">
                       6529er
-                    </a>
+                    </Link>
                   </span>
                 </span>
                 <span className="updated rich-snippet-hidden">
@@ -574,24 +575,24 @@ The museum also owns"
                                   style={{ color: "#000000" }}>
                                   <ul style={{ margin: 0, paddingLeft: 20 }}>
                                     <li>
-                                      <a href="/museum/imagined-worlds/">
+                                      <Link href="/museum/imagined-worlds/">
                                         <u>IMAGINED WORLDS</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                     <li>
-                                      <a href="/museum/early-nft-art/">
+                                      <Link href="/museum/early-nft-art/">
                                         <u>EARLY NFT ART</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                     <li>
-                                      <a href="/museum/yongoh-kim/">
+                                      <Link href="/museum/yongoh-kim/">
                                         Y<u>ONGOH KIM</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                     <li>
-                                      <a href="/museum/sozet-lounge/">
+                                      <Link href="/museum/sozet-lounge/">
                                         <u>SOZET LOUNGE</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                   </ul>
                                 </div>
@@ -675,9 +676,9 @@ The museum also owns"
                                   style={{ color: "#000000" }}>
                                   <ul style={{ margin: 0, paddingLeft: 20 }}>
                                     <li>
-                                      <a href="/museum/genesis/">
+                                      <Link href="/museum/genesis/">
                                         <u>GENESIS</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                   </ul>
                                 </div>
@@ -763,14 +764,14 @@ The museum also owns"
                                   style={{ color: "#000000" }}>
                                   <ul style={{ margin: 0, paddingLeft: 20 }}>
                                     <li>
-                                      <a href="/museum/6529-photo-a/">
+                                      <Link href="/museum/6529-photo-a/">
                                         <u>6529 PHOTO A</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                     <li>
-                                      <a href="/museum/6529-photo-b/">
+                                      <Link href="/museum/6529-photo-b/">
                                         <u>6529 PHOTO B</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                   </ul>
                                 </div>
@@ -856,9 +857,9 @@ The museum also owns"
                                   style={{ color: "#000000" }}>
                                   <ul style={{ margin: 0, paddingLeft: 20 }}>
                                     <li>
-                                      <a href="/museum/general-assembly/">
+                                      <Link href="/museum/general-assembly/">
                                         <u>GENERAL ASSEMBLY</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                   </ul>
                                 </div>
@@ -944,19 +945,19 @@ The museum also owns"
                                   style={{ color: "#000000" }}>
                                   <ul style={{ margin: 0, paddingLeft: 20 }}>
                                     <li>
-                                      <a href="/museum/6529-fam-2021/">
+                                      <Link href="/museum/6529-fam-2021/">
                                         <u>6529 FAM 2021</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                     <li>
-                                      <a href="/museum/6529-gradient-collector-curated/">
+                                      <Link href="/museum/6529-gradient-collector-curated/">
                                         <u>6529 GRADIENT COLLECTOR CURATED</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                     <li>
-                                      <a href="/museum/6529-public-domain/">
+                                      <Link href="/museum/6529-public-domain/">
                                         <u>6529 PUBLIC DOMAIN</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                   </ul>
                                 </div>
@@ -1042,9 +1043,9 @@ The museum also owns"
                                   style={{ color: "#000000" }}>
                                   <ul style={{ margin: 0, paddingLeft: 20 }}>
                                     <li>
-                                      <a href="/museum/6529-fund-szn1/">
+                                      <Link href="/museum/6529-fund-szn1/">
                                         <u>6529 FUND SZN1</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                   </ul>
                                 </div>
@@ -1122,9 +1123,9 @@ The museum also owns"
                                       lineHeight: 1,
                                       color: "#000000",
                                     }}>
-                                    <a href="/museum/sunshine-square/">
+                                    <Link href="/museum/sunshine-square/">
                                       <u>SUNSHINE SQUARE</u>
-                                    </a>
+                                    </Link>
                                   </h3>
                                 </div>
                               </div>
@@ -1199,9 +1200,9 @@ The museum also owns"
                                       lineHeight: 1,
                                       color: "#000000",
                                     }}>
-                                    <a href="/museum/temple-of-gm/">
+                                    <Link href="/museum/temple-of-gm/">
                                       <u>TEMPLE OF GM</u>
-                                    </a>
+                                    </Link>
                                   </h3>
                                 </div>
                               </div>
@@ -1278,9 +1279,9 @@ The museum also owns"
                                       lineHeight: 1,
                                       color: "#000000",
                                     }}>
-                                    <a href="/museum/ack-bar/">
+                                    <Link href="/museum/ack-bar/">
                                       <u>ACK BAR</u>
-                                    </a>
+                                    </Link>
                                   </h3>
                                 </div>
                               </div>
@@ -1389,19 +1390,19 @@ The museum also owns"
                                   style={{ color: "#000000" }}>
                                   <ul style={{ margin: 0, paddingLeft: 20 }}>
                                     <li>
-                                      <a href="/museum/bharat-krymo-museum-1/">
+                                      <Link href="/museum/bharat-krymo-museum-1/">
                                         <u>BHARAT KRYMO MUSEE D'ART 1</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                     <li>
-                                      <a href="/museum/bharat-krymo-museum-2/">
+                                      <Link href="/museum/bharat-krymo-museum-2/">
                                         <u>BHARAT KRYMO MUSEE D'ART 2</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                     <li>
-                                      <a href="/museum/bharat-krymo-museum-3/">
+                                      <Link href="/museum/bharat-krymo-museum-3/">
                                         <u>BHARAT KRYMO MUSEE D'ART 3</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                   </ul>
                                 </div>
@@ -1487,14 +1488,14 @@ The museum also owns"
                                   style={{ color: "#000000" }}>
                                   <ul style={{ margin: 0, paddingLeft: 20 }}>
                                     <li>
-                                      <a href="/museum/batsoupyum-museum-1/">
+                                      <Link href="/museum/batsoupyum-museum-1/">
                                         <u>BATSOUPCAVE</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                     <li>
-                                      <a href="/museum/batsoupyum-museum-2/">
+                                      <Link href="/museum/batsoupyum-museum-2/">
                                         <u>BATSOUPLOUNGE</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                   </ul>
                                 </div>
@@ -1580,9 +1581,9 @@ The museum also owns"
                                   style={{ color: "#000000" }}>
                                   <ul style={{ margin: 0, paddingLeft: 20 }}>
                                     <li>
-                                      <a href="/museum/ac-museum/">
+                                      <Link href="/museum/ac-museum/">
                                         <u>AC COLLECTION</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                   </ul>
                                 </div>
@@ -1668,9 +1669,9 @@ The museum also owns"
                                   style={{ color: "#000000" }}>
                                   <ul style={{ margin: 0, paddingLeft: 20 }}>
                                     <li>
-                                      <a href="/museum/bonafidehan-museum/">
+                                      <Link href="/museum/bonafidehan-museum/">
                                         <u>BONAFIDEHAN GALLERY</u>
-                                      </a>
+                                      </Link>
                                     </li>
                                   </ul>
                                 </div>

--- a/app/news/introducing-om/page.tsx
+++ b/app/news/introducing-om/page.tsx
@@ -1,4 +1,5 @@
 import { getAppMetadata } from "@/components/providers/metadata";
+import Link from "next/link";
 const IndexPage = () => (
   <div>
     <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
@@ -403,7 +404,7 @@ const IndexPage = () => (
                             </p>
                             <ul>
                               <li>
-                                <a href="/om/">/om/</a>
+                                <Link href="/om/">/om/</Link>
                               </li>
                               <li>
                                 <a
@@ -432,12 +433,12 @@ const IndexPage = () => (
                 </div>
                 <span className="vcard rich-snippet-hidden">
                   <span className="fn">
-                    <a
+                    <Link
                       href="/author/6529er6529-io/"
                       title="Posts by 6529er"
                       rel="author">
                       6529er
-                    </a>
+                    </Link>
                   </span>
                 </span>
                 <span className="updated rich-snippet-hidden">

--- a/app/om/page.tsx
+++ b/app/om/page.tsx
@@ -1,4 +1,5 @@
 import { getAppMetadata } from "@/components/providers/metadata";
+import Link from "next/link";
 import type { Metadata } from "next";
 
 const IndexPage = () => (
@@ -310,12 +311,12 @@ CITIES 1-10"
                 <span className="entry-title rich-snippet-hidden">OM</span>
                 <span className="vcard rich-snippet-hidden">
                   <span className="fn">
-                    <a
+                    <Link
                       href="/author/6529er6529-io/"
                       title="Posts by 6529er"
                       rel="author">
                       6529er
-                    </a>
+                    </Link>
                   </span>
                 </span>
                 <span className="updated rich-snippet-hidden">
@@ -784,27 +785,27 @@ CITIES 1-10"
                             <h1
                               className="fusion-title-heading title-heading-left fusion-responsive-typography-calculated"
                               style={{ margin: 0, lineHeight: 1 }}>
-                              <a href="/city/6529-museum-district/">
+                              <Link href="/city/6529-museum-district/">
                                 DISTRICT 1 – 6529 MUSEUM DISTRICT
-                              </a>
+                              </Link>
                             </h1>
                           </div>
                           <div className="fusion-title title fusion-title-6 fusion-sep-none fusion-title-text fusion-title-size-three">
                             <h3
                               className="fusion-title-heading title-heading-left fusion-responsive-typography-calculated"
                               style={{ margin: 0, lineHeight: 1 }}>
-                              <a href="/city/6529-museum-district/">
+                              <Link href="/city/6529-museum-district/">
                                 PHASE 1 – ALPHA VERSION – SPRING 2022
-                              </a>
+                              </Link>
                             </h3>
                           </div>
                           <div className="fusion-text fusion-text-6">
                             <p>
                               The{" "}
                               <span style={{ textDecoration: "underline" }}>
-                                <a href="/om/6529-museum-district/">
+                                <Link href="/om/6529-museum-district/">
                                   <strong>6529 Museum District</strong>
-                                </a>
+                                </Link>
                               </span>{" "}
                               is the first district of the first city –{" "}
                               <strong>Genesis City</strong> – in what we hope
@@ -815,14 +816,14 @@ CITIES 1-10"
                             </p>
                           </div>
                           <div>
-                            <a
+                            <Link
                               className="fusion-button button-flat fusion-button-default-size button-default fusion-button-default button-1 fusion-button-default-span fusion-button-default-type"
                               target="_self"
                               href="/om/6529-museum-district/">
                               <span className="fusion-button-text">
                                 EXPLORE 6529 MUSEUM DISTRICT
                               </span>
-                            </a>
+                            </Link>
                           </div>
                         </div>
                       </div>
@@ -841,7 +842,7 @@ CITIES 1-10"
                             className="fusion-image-element "
                             style={{ textAlign: "center" }}>
                             <span className=" fusion-imageframe imageframe-none imageframe-9 hover-type-none">
-                              <a
+                              <Link
                                 className="fusion-no-lightbox"
                                 href="/om/6529-museum-district/"
                                 target="_self"
@@ -857,7 +858,7 @@ CITIES 1-10"
                                   srcSet="https://dnclu2fna0b2b.cloudfront.net/wp-content/uploads/2022/04/Phase-0-Screenshot-200x93.jpg 200w, https://dnclu2fna0b2b.cloudfront.net/wp-content/uploads/2022/04/Phase-0-Screenshot-400x187.jpg 400w, https://dnclu2fna0b2b.cloudfront.net/wp-content/uploads/2022/04/Phase-0-Screenshot-600x280.jpg 600w, https://dnclu2fna0b2b.cloudfront.net/wp-content/uploads/2022/04/Phase-0-Screenshot-800x374.jpg 800w, https://dnclu2fna0b2b.cloudfront.net/wp-content/uploads/2022/04/Phase-0-Screenshot-1200x560.jpg 1200w, https://dnclu2fna0b2b.cloudfront.net/wp-content/uploads/2022/04/Phase-0-Screenshot.jpg 1300w"
                                   sizes="(max-width: 640px) 100vw, 1200px"
                                 />
-                              </a>
+                              </Link>
                             </span>
                           </div>
                         </div>
@@ -1113,9 +1114,9 @@ CITIES 1-10"
                               If you are an organization or individual who has
                               an idea about a space, a building or a district,
                               please contact us{" "}
-                              <a href="/om/partnership-request/">
+                              <Link href="/om/partnership-request/">
                                 <u>here</u>
-                              </a>
+                              </Link>
                               {"."}
                             </p>
                             <h3 style={{ color: "#000000" }}>

--- a/components/about/AboutDataDecentral.tsx
+++ b/components/about/AboutDataDecentral.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Col, Container, Row } from "react-bootstrap";
 
 export default function AboutDataDecentral() {
@@ -81,9 +82,9 @@ export default function AboutDataDecentral() {
               Every day, we post our complete set of on-chain and calculated
               values shown on the site to Arweave as a CSV. The specific links
               can be found{" "}
-              <a href={`/open-data`} target="_blank" rel="noopener noreferrer">
+              <Link href="/open-data" target="_blank" rel="noopener noreferrer">
                 here
-              </a>
+              </Link>
               .
             </li>
           </ul>

--- a/components/about/AboutMemes.tsx
+++ b/components/about/AboutMemes.tsx
@@ -76,25 +76,25 @@ export default function AboutMemes() {
           </p>
           <p>
             All The Memes:{" "}
-            <a href={`/the-memes`} target="_blank" rel="noopener noreferrer">
+            <Link href="/the-memes" target="_blank" rel="noopener noreferrer">
               6529.io/the-memes
-            </a>
+            </Link>
           </p>
           <p>
             The Memes Network:{" "}
-            <a href={`/network`} target="_blank" rel="noopener noreferrer">
+            <Link href="/network" target="_blank" rel="noopener noreferrer">
               6529.io/network
-            </a>
+            </Link>
           </p>
           <p>
             FAQs:{" "}
-            <a
+            <Link
               href={`/about/${AboutSection.FAQ}`}
               target="_blank"
               rel="noopener noreferrer"
             >
               6529.io/about/faq
-            </a>
+            </Link>
           </p>
           <p>
             The Memes chat on Brain:{" "}
@@ -104,13 +104,13 @@ export default function AboutMemes() {
           </p>
           <p>
             Minting Memes:{" "}
-            <a
+            <Link
               href={`/about/${AboutSection.MINTING}`}
               target="_blank"
               rel="noopener noreferrer"
             >
               6529.io/about/minting
-            </a>
+            </Link>
           </p>
         </Col>
       </Row>

--- a/components/about/AboutMinting.tsx
+++ b/components/about/AboutMinting.tsx
@@ -538,9 +538,9 @@ export default function AboutMinting() {
             <br />
             <li>
               For our full analysis of our Network Metrics, go here:{" "}
-              <a href="/network/metrics" target="_blank" rel="noopener noreferrer">
+              <Link href="/network/metrics" target="_blank" rel="noopener noreferrer">
                 6529.io/network/metrics
-              </a>
+              </Link>
             </li>
           </ul>
           <br />
@@ -569,9 +569,9 @@ export default function AboutMinting() {
             <li>
               On a daily basis, we publish to Arweave the statistics we use to
               create our own allowlists. You can find them here:{" "}
-              <a href="/open-data" target="_blank" rel="noopener noreferrer">
+              <Link href="/open-data" target="_blank" rel="noopener noreferrer">
                 6529.io/open-data
-              </a>
+              </Link>
             </li>
             <br />
             <li>

--- a/components/about/AboutNFTDelegation.tsx
+++ b/components/about/AboutNFTDelegation.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Col, Container, Row } from "react-bootstrap";
 
 export default function AboutNFTDelegation() {
@@ -13,8 +14,8 @@ export default function AboutNFTDelegation() {
       <Row className="pt-5">
         <Col>
           Visit our{" "}
-          <a href="/delegation/delegation-center">Delegation Center</a> to get
-          started
+          <Link href="/delegation/delegation-center">Delegation Center</Link> to
+          get started
         </Col>
       </Row>
     </Container>

--- a/components/about/AboutTermsOfService.tsx
+++ b/components/about/AboutTermsOfService.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import styles from "./About.module.scss";
 import { Col, Container, Row } from "react-bootstrap";
 import { AboutSection } from "@/enums";
@@ -617,9 +618,13 @@ export default function AboutTermsOfService() {
               incorporated by reference into these Terms.
               <br />
               <br />
-              <a href="/dispute-resolution" target="_blank" rel="noopener noreferrer">
+              <Link
+                href="/dispute-resolution"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 6529.io/dispute-resolution
-              </a>{" "}
+              </Link>{" "}
             </li>
             <br />
             <br />

--- a/components/community-downloads/CommunityDownloads.tsx
+++ b/components/community-downloads/CommunityDownloads.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { Col, Container, Row } from "react-bootstrap";
 import styles from "./CommunityDownloads.module.scss";
 import useCapacitor from "@/hooks/useCapacitor";
@@ -25,40 +26,40 @@ export default function CommunityDownloads() {
             </Row>
             <Row className="pt-4">
               <Col xs={12} sm={6} md={4} className="pt-2 pb-3">
-                <a href="/open-data/network-metrics">
+                <Link href="/open-data/network-metrics">
                   <span className={styles.downloadLink}>Network Metrics</span>
-                </a>
+                </Link>
               </Col>
               <Col xs={12} sm={6} md={4} className="pt-2 pb-3">
-                <a href="/open-data/consolidated-network-metrics">
+                <Link href="/open-data/consolidated-network-metrics">
                   <span className={styles.downloadLink}>
                     Consolidated Network Metrics
                   </span>
-                </a>
+                </Link>
               </Col>
               {(!capacitor.isIos || country === "US") && (
                 <Col xs={12} sm={6} md={4} className="pt-2 pb-3">
-                  <a href="/open-data/meme-subscriptions">
+                  <Link href="/open-data/meme-subscriptions">
                     <span className={styles.downloadLink}>
                       Meme Subscriptions
                     </span>
-                  </a>
+                  </Link>
                 </Col>
               )}
               <Col xs={12} sm={6} md={4} className="pt-2 pb-3">
-                <a href="/open-data/rememes">
+                <Link href="/open-data/rememes">
                   <span className={styles.downloadLink}>Rememes</span>
-                </a>
+                </Link>
               </Col>
               <Col xs={12} sm={6} md={4} className="pt-2 pb-3">
-                <a href="/open-data/team">
+                <Link href="/open-data/team">
                   <span className={styles.downloadLink}>Team</span>
-                </a>
+                </Link>
               </Col>
               <Col xs={12} sm={6} md={4} className="pt-2 pb-3">
-                <a href="/open-data/royalties">
+                <Link href="/open-data/royalties">
                   <span className={styles.downloadLink}>Royalties</span>
-                </a>
+                </Link>
               </Col>
             </Row>
           </Container>

--- a/components/delegation/CollectionDelegation.tsx
+++ b/components/delegation/CollectionDelegation.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Fragment, useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import {
   Accordion,
   Col,
@@ -1756,11 +1757,10 @@ export default function CollectionDelegationComponent(props: Readonly<Props>) {
                 </button>
               ) : (
                 <div>
-                  <span className={styles.hint}>* Note:</span> Unlock use case
-                  in{" "}
-                  <a href={`/delegation/${ANY_COLLECTION_PATH}`}>
+                  <span className={styles.hint}>* Note:</span> Unlock use case in{" "}
+                  <Link href={`/delegation/${ANY_COLLECTION_PATH}`}>
                     All Collections
-                  </a>
+                  </Link>
                 </div>
               )}
             </Col>
@@ -1778,7 +1778,9 @@ export default function CollectionDelegationComponent(props: Readonly<Props>) {
           <Row className="pb-3">
             <Col>
               <span className={styles.hint}>* Note:</span> Unlock Wallet on{" "}
-              <a href={`/delegation/${ANY_COLLECTION_PATH}`}>All Collections</a>{" "}
+              <Link href={`/delegation/${ANY_COLLECTION_PATH}`}>
+                All Collections
+              </Link>{" "}
               to lock/unlock specific collections and use cases
             </Col>
           </Row>

--- a/components/latest-activity/ActivityHeader.tsx
+++ b/components/latest-activity/ActivityHeader.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { Col } from "react-bootstrap";
 import homeStyles from "@/styles/Home.module.scss";
 import DotLoader from "../dotLoader/DotLoader";
@@ -24,9 +25,9 @@ export default function ActivityHeader({
           <span className="font-lightest">NFT</span> Activity{" "}
         </h1>
         {showViewAll ? (
-          <a href="/nft-activity" className={homeStyles.viewAllLink}>
+          <Link href="/nft-activity" className={homeStyles.viewAllLink}>
             <span>View All</span>
-          </a>
+          </Link>
         ) : (
           fetching && <DotLoader />
         )}

--- a/components/leaderboard/Leaderboard.tsx
+++ b/components/leaderboard/Leaderboard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { publicEnv } from "@/config/env";
 import { LeaderboardFocus } from "@/enums";
 import { useEffect, useState } from "react";
@@ -173,9 +174,9 @@ export default function Leaderboard(
           <h1>
             Network{" "}
             {showViewAll && (
-              <a href="/network/nerd">
+              <Link href="/network/nerd">
                 <span className={styles.viewAllLink}>View All</span>
-              </a>
+              </Link>
             )}
           </h1>
         </Col>

--- a/components/memelab/MemeLab.tsx
+++ b/components/memelab/MemeLab.tsx
@@ -28,6 +28,7 @@ import {
   faChevronCircleUp,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useContext, useEffect, useState } from "react";
 import { Col, Container, Row } from "react-bootstrap";
@@ -532,7 +533,10 @@ export default function MemeLabComponent() {
         sm={{ span: 4 }}
         md={{ span: 3 }}
         lg={{ span: 3 }}>
-        <a href={`/meme-lab/${nft.id}`} className="decoration-none scale-hover">
+        <Link
+          href={`/meme-lab/${nft.id}`}
+          className="decoration-none scale-hover"
+        >
           <Container fluid>
             <Row className={isConnected ? styles.nftImagePadding : ""}>
               <NFTImage
@@ -554,7 +558,7 @@ export default function MemeLabComponent() {
               </Col>
             </Row>
           </Container>
-        </a>
+        </Link>
       </Col>
     );
   }

--- a/components/rememes/RememeAddPage.tsx
+++ b/components/rememes/RememeAddPage.tsx
@@ -16,6 +16,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Image from "next/image";
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { Button, Col, Container, Row } from "react-bootstrap";
 import { useSignMessage } from "wagmi";
@@ -203,7 +204,7 @@ export default function RememeAddPage() {
             <Row className="pt-2">
               <Col>
                 Please use this page to only add ReMemes{" "}
-                <a href="#requirements">view requirements</a>
+                <Link href="#requirements">view requirements</Link>
               </Col>
             </Row>
             <Row className="pt-4">

--- a/components/rememes/RememePage.tsx
+++ b/components/rememes/RememePage.tsx
@@ -7,6 +7,7 @@ import { useTitle } from "@/contexts/TitleContext";
 import { faExternalLink, faGlobe } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Image from "next/image";
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { Col, Container, Row, Table } from "react-bootstrap";
 import { useEnsName } from "wagmi";
@@ -344,9 +345,9 @@ export default function RememePage(props: Readonly<Props>) {
                     .filter((rep) => rep != parseInt(rememe.id))
                     .map((rep) => (
                       <span className={styles.replica} key={`replica-rep`}>
-                        <a href={`/rememes/${rememe.contract}/${rep}`}>
+                        <Link href={`/rememes/${rememe.contract}/${rep}`}>
                           #{rep}
-                        </a>
+                        </Link>
                       </span>
                     ))}
                 </Col>


### PR DESCRIPTION
## Summary
- replace internal navigation anchors across static app pages with `next/link` for faster client-side routing
- update shared components to import and use `next/link` for internal URLs
- ensure delegation and ReMeme flows use `Link` elements for internal links while preserving external anchors

## Testing
- npm run lint *(fails: `next` command not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de2bb047448333b4c34d1630bef7bf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Smoother, faster in-app navigation via client-side routing across many pages (authors, categories, museum, education, news/OM, email signatures, dispute resolution) and components (about, downloads, delegation, activity, leaderboard, MemeLab, Rememes).
- Refactor
  - Standardized internal links to use the app’s native navigation component for consistent behavior across the site; external links remain unchanged.
- Performance
  - Reduced full page reloads and improved perceived speed when navigating between internal pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->