### PR TITLE
feat: add jitter to websocket reconnect backoff

### DIFF
--- a/__tests__/services/websocket/WebSocketProvider.test.tsx
+++ b/__tests__/services/websocket/WebSocketProvider.test.tsx
@@ -64,6 +64,7 @@ class MockWebSocket {
 describe('WebSocketProvider', () => {
   let originalWs: any;
   let mockGetAuthJwt: jest.MockedFunction<typeof authUtils.getAuthJwt>;
+  let mathRandomSpy: jest.SpyInstance<number, []>;
   
   beforeEach(() => {
     originalWs = global.WebSocket;
@@ -76,11 +77,13 @@ describe('WebSocketProvider', () => {
     mockGetAuthJwt = authUtils.getAuthJwt as jest.MockedFunction<typeof authUtils.getAuthJwt>;
     mockGetAuthJwt.mockReturnValue('fresh-token');
     
+    mathRandomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
     jest.clearAllMocks();
   });
   
   afterEach(() => {
     (global as any).WebSocket = originalWs;
+    mathRandomSpy.mockRestore();
     jest.useRealTimers();
   });
 

--- a/__tests__/services/websocket/calculateReconnectDelay.test.ts
+++ b/__tests__/services/websocket/calculateReconnectDelay.test.ts
@@ -1,0 +1,36 @@
+import { calculateReconnectDelay } from '@/services/websocket/WebSocketProvider';
+
+describe('calculateReconnectDelay', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns exponential backoff without jitter when jitterFactor is zero', () => {
+    const delay = calculateReconnectDelay(2, 1000, 30000, 0);
+    expect(delay).toBe(2250);
+  });
+
+  it('applies positive jitter up to the configured factor', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(1);
+    const delay = calculateReconnectDelay(0, 1000, 30000, 0.2);
+    expect(delay).toBe(1200);
+  });
+
+  it('applies negative jitter down to the configured factor', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    const delay = calculateReconnectDelay(0, 1000, 30000, 0.2);
+    expect(delay).toBe(800);
+  });
+
+  it('never exceeds maxDelay even with jitter', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(1);
+    const delay = calculateReconnectDelay(10, 1000, 1500, 0.5);
+    expect(delay).toBeLessThanOrEqual(1500);
+  });
+
+  it('ignores jitter factors below zero', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(1);
+    const delay = calculateReconnectDelay(1, 1000, 30000, -0.5);
+    expect(delay).toBe(1500);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -299,7 +299,6 @@
       "version": "7.28.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -945,7 +944,6 @@
     "node_modules/@capacitor/core": {
       "version": "7.4.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -1844,7 +1842,6 @@
     "node_modules/@fortawesome/fontawesome-svg-core": {
       "version": "6.7.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },
@@ -3277,7 +3274,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.6.tgz",
       "integrity": "sha512-krKwLLcFmeuKDqngG2N/RuZHCs2ycsKcxWIDgcm7i1lf3sQ0iG03ci+DsP/r3FcT/eJDFsIHnKtNta2LIi7PzQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.0.0",
         "iterare": "1.2.1",
@@ -3498,7 +3494,6 @@
     "node_modules/@noble/ciphers": {
       "version": "1.2.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3795,7 +3790,6 @@
       "version": "1.53.2",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.53.2"
       },
@@ -3814,7 +3808,6 @@
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -5880,7 +5873,6 @@
     "node_modules/@tanstack/react-query": {
       "version": "5.82.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.82.0"
       },
@@ -6071,7 +6063,8 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6256,7 +6249,6 @@
       "version": "20.19.6",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -6282,7 +6274,6 @@
     "node_modules/@types/react": {
       "version": "19.1.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -6290,7 +6281,6 @@
     "node_modules/@types/react-dom": {
       "version": "19.1.5",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -6412,7 +6402,6 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -6815,7 +6804,6 @@
       "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-2.21.2.tgz",
       "integrity": "sha512-Rp4waam2z0FQUDINkJ91jq38PI5wFUHCv1YBL2LXzAQswaEk1ZY8d6+WG3vYGhFHQ22DXy2AlQ8IWmj+2EG3zQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventemitter3": "5.0.1",
         "mipd": "0.0.7",
@@ -7667,7 +7655,6 @@
     "node_modules/@walletconnect/ethereum-provider/node_modules/ws": {
       "version": "8.18.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -8087,7 +8074,6 @@
     "node_modules/@walletconnect/utils/node_modules/ws": {
       "version": "8.18.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -8161,7 +8147,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8585,7 +8570,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
       "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -8895,7 +8879,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -8966,7 +8949,6 @@
       "version": "4.0.9",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -9156,7 +9138,6 @@
     "node_modules/chart.js": {
       "version": "4.5.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -9554,7 +9535,6 @@
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
       "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
@@ -10030,7 +10010,8 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -10172,7 +10153,6 @@
       "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.15.tgz",
       "integrity": "sha512-r6kEJXDKecVOCj2nLMuXK/FCPeurW33+3JRpfXVbjLja3XUYFfD9I/JBreH6sUyzcm3G/YQboBjMla6poKeSdA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ecies/ciphers": "^0.2.3",
         "@noble/ciphers": "^1.3.0",
@@ -10244,8 +10224,7 @@
     },
     "node_modules/emoji-mart": {
       "version": "5.6.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -10620,7 +10599,6 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -10776,7 +10754,6 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -11237,8 +11214,7 @@
       "version": "6.4.9",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
       "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
@@ -12510,8 +12486,7 @@
     },
     "node_modules/idb-keyval": {
       "version": "6.2.2",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/identity-obj-proxy": {
       "version": "3.0.0",
@@ -13242,6 +13217,7 @@
     "node_modules/isomorphic.js": {
       "version": "0.2.5",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -13378,7 +13354,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -14608,6 +14583,7 @@
     "node_modules/lib0": {
       "version": "0.2.109",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -14772,6 +14748,7 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -15797,7 +15774,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.2.tgz",
       "integrity": "sha512-H8Otr7abj1glFhbGnvUt3gz++0AF1+QoCXEBmd/6aKbfdFwrn0LpA836Ed5+00va/7HQSDD+mOoVhn3tNy3e/Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.5.2",
         "@swc/helpers": "0.5.15",
@@ -16924,6 +16900,7 @@
     },
     "node_modules/playwright/node_modules/fsevents": {
       "version": "2.3.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17138,7 +17115,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -17271,6 +17247,7 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -17284,6 +17261,7 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -17339,7 +17317,6 @@
     "node_modules/prop-types": {
       "version": "15.8.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -17646,7 +17623,6 @@
     "node_modules/react": {
       "version": "19.1.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17691,7 +17667,6 @@
     "node_modules/react-dom": {
       "version": "19.1.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -17712,7 +17687,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -17746,7 +17722,6 @@
     "node_modules/react-redux": {
       "version": "9.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -17918,7 +17893,6 @@
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -17959,8 +17933,7 @@
     },
     "node_modules/redux": {
       "version": "5.0.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -17971,8 +17944,7 @@
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -18499,7 +18471,6 @@
     "node_modules/rxjs": {
       "version": "7.8.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -18584,7 +18555,6 @@
     "node_modules/sass": {
       "version": "1.89.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -18965,7 +18935,6 @@
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
       "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
@@ -19643,7 +19612,6 @@
     "node_modules/tailwindcss": {
       "version": "3.4.17",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -19770,8 +19738,7 @@
     },
     "node_modules/three": {
       "version": "0.163.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/throttle-debounce": {
       "version": "3.0.1",
@@ -19818,7 +19785,6 @@
       "version": "4.0.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20070,8 +20036,7 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.20.6",
@@ -20198,7 +20163,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20636,7 +20600,6 @@
       "version": "5.0.10",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -20690,7 +20653,6 @@
       "resolved": "https://registry.npmjs.org/valtio/-/valtio-2.1.7.tgz",
       "integrity": "sha512-DwJhCDpujuQuKdJ2H84VbTjEJJteaSmqsuUltsfbfdbotVfNeTE4K/qc/Wi57I9x8/2ed4JNdjEna7O6PfavRg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "proxy-compare": "^3.0.1"
       },
@@ -20759,7 +20721,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -20923,7 +20884,6 @@
       "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-2.17.5.tgz",
       "integrity": "sha512-Sk2e40gfo68gbJ6lHkpIwCMkH76rO0+toCPjf3PzdQX37rZo9042DdNTYcSg3zhnx8abFJtrk/5vAWfR8APTDw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@wagmi/connectors": "5.11.2",
         "@wagmi/core": "2.21.2",
@@ -21233,7 +21193,6 @@
     "node_modules/ws": {
       "version": "7.5.10",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -21358,7 +21317,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/services/websocket/WebSocketTypes.ts
+++ b/services/websocket/WebSocketTypes.ts
@@ -33,4 +33,9 @@ export interface WebSocketConfig {
   url: string;
   reconnectDelay?: number;
   maxReconnectAttempts?: number;
+  /**
+   * Optional jitter factor (0-1) applied to each reconnect delay to avoid herd behaviour.
+   * Represents the maximum percentage variance applied around the base delay.
+   */
+  reconnectJitter?: number;
 }

--- a/services/websocket/index.ts
+++ b/services/websocket/index.ts
@@ -24,6 +24,7 @@ export const DEFAULT_WEBSOCKET_CONFIG = {
     "wss://default-fallback-url",
   reconnectDelay: 2000,
   maxReconnectAttempts: 20,
+  reconnectJitter: 0.2,
 };
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configurable reconnect jitter to WebSocket reconnections (default: 0.2) for smoother, less synchronized retries.
  - Reconnect delays now include bounded variance while respecting maximum limits.

- Tests
  - Added comprehensive tests for reconnect delay logic, covering exponential backoff, jitter behavior, upper bounds, and negative jitter handling.
  - Introduced deterministic randomness in tests to ensure stable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->