### PR TITLE
Date fixes for TDH 1.4

### DIFF
--- a/app/network/tdh/historic-boosts/page.client.tsx
+++ b/app/network/tdh/historic-boosts/page.client.tsx
@@ -139,7 +139,7 @@ export default function TDHHistoricBoostsPage() {
 
           <div className="tw-space-y-6">
             {/* 1.3 */}
-            <DetailsCard title="TDH 1.3 (March 29, 2024 — October 8, 2025)">
+            <DetailsCard title="TDH 1.3 (March 29, 2024 — October 9, 2025)">
               <IntroLine>
                 Higher of <b>Category A</b> and <b>Category B</b> Boosters, plus{" "}
                 <b>Category C</b> Boosters

--- a/app/network/tdh/page.client.tsx
+++ b/app/network/tdh/page.client.tsx
@@ -53,7 +53,7 @@ export default function TDHMainPage() {
           <div
             id="tdh-1-4"
             className="tw-mt-10 tw-rounded-lg tw-bg-[#0c0c0d] tw-border-1 tw-border-solid tw-border-[#222] tw-p-6">
-            <h3>TDH 1.4 (October 8, 2025 — present)</h3>
+            <h3>TDH 1.4 (October 10, 2025 — present)</h3>
             <p className="tw-mt-4">
               Higher of <b>Category A</b> and <b>Category B</b> boosters, plus{" "}
               <b>Category C</b> boosters.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected the displayed date on the TDH 1.3 details card from October 8, 2025 to October 9, 2025 in the Historic Boosts view.
  - Updated the TDH 1.4 heading date from October 8, 2025 to October 10, 2025 in the TDH overview.
  - Ensures users see accurate event dates across TDH pages; no functional or behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->