### PR TITLE
EvoCoder – Introduce /codex/: STATE.md board, tickets, plans, and agents.md

### DIFF
--- a/codex/STATE.md
+++ b/codex/STATE.md
@@ -1,0 +1,17 @@
+# Codex State Board
+
+This table is the single source of truth for active and historical tickets. Keep it alphabetically sorted by ticket ID and update it whenever any metadata changes.
+
+| Ticket ID | Title | Status | Priority | Owner | PRs | Last Updated |
+|-----------|-------|--------|----------|-------|-----|--------------|
+| — | — | — | — | — | — | — |
+
+## Usage Guidelines
+
+- **Status** must be one of `Backlog`, `In-Progress`, `Review`, or `Done`.
+- **Priority** codes follow the scale `P0` (blockers) through `P3` (nice-to-have).
+- **Owner** should be the GitHub handle responsible for delivery.
+- **PRs** should list merged or open pull requests as Markdown links (separate multiple entries with `<br>`).
+- **Last Updated** records the most recent date (`YYYY-MM-DD`) that any field changed.
+
+After a ticket is marked **Done**, leave the row in place for history but do not edit it further. If new work emerges, capture it as a fresh ticket with a unique ID.

--- a/codex/agents.md
+++ b/codex/agents.md
@@ -1,0 +1,64 @@
+# Codex Workspace Overview
+
+The `/codex` directory centralises planning artefacts so work can be tracked and audited without relying on external tools. Every ticket progresses through a shared lifecycle that keeps the board, ticket logs, and pull requests synchronised.
+
+## Workflow Fundamentals
+
+- **Open a ticket**: Create a new Markdown file under `codex/tickets/` using the ticket template. Assign a unique ID that matches the filename (`ticket-ID.md`) and choose an initial priority (P0–P3).
+- **Register the ticket**: Add a row to `codex/STATE.md` capturing the ticket metadata. The table is the authoritative board and must mirror the ticket front matter.
+- **Deliver incremental work**: Keep updates small, land pull requests frequently, and cross-reference the ticket in PR descriptions.
+- **Maintain the board**: Whenever the status, owner, linked PRs, or priority changes, update both the ticket front matter and the `STATE.md` row.
+- **Close the loop**: Before marking a ticket **Done**, verify the acceptance criteria, ensure linked PRs are merged, and capture the final log entry.
+
+## Directory Layout
+
+- `/codex/STATE.md`: Master board of tickets, tracked as a Markdown table. Every ticket ID listed here must have a matching file in `codex/tickets/`.
+- `/codex/tickets/`: Canonical ticket records with context, plan, acceptance checks, PR links, and chronological log entries.
+- `/codex/plans/`: Time-boxed planning documents (for example, sprint briefs) that roll tickets into broader initiatives and demos.
+
+> Tip: Avoid editing tickets marked **Done**—append follow-up work as a new ticket to keep historical artefacts immutable.
+
+## Ticket Status Lifecycle
+
+Tickets use one of the four Codex statuses:
+
+- **Backlog** – Defined work that is not yet being executed.
+- **In-Progress** – Active engineering work; log meaningful events daily.
+- **Review** – Waiting on pull request review, sign-off, or external validation.
+- **Done** – Ticket verified, acceptance criteria satisfied, no further work expected.
+
+Only move a ticket forward (never backwards) unless there is an explicit reset of scope. When rolling back, add a log entry explaining the decision.
+
+## Board Hygiene Expectations
+
+- Update the `Last Updated` column every time a ticket changes state, owner, or linked PRs.
+- Use GitHub handles for the **Owner** column to line up with PR mentions.
+- Track PR references as Markdown links (e.g. `[PR #123](https://github.com/org/repo/pull/123)`).
+- Leave placeholder rows out of the board—`STATE.md` should only list active or historical tickets.
+
+## Ticket Authoring Standards
+
+- Maintain the YAML front matter in alphabetical key order: `created`, `id`, `owner`, `priority`, `status`, `title`.
+- Use ISO 8601 dates (`YYYY-MM-DD`) for `created` and timestamps in the log.
+- Keep the **Plan** section as a living checklist; strike through or mark completed items with `[x]`.
+- Capture risks, external dependencies, and decisions in log entries so reviewers can audit the timeline.
+
+## Planning Documents
+
+Planning files in `codex/plans/` should:
+
+- Follow the naming convention `YYYYWW-name.md` (calendar week) or `YYYY-QN-name.md` for quarterly plans.
+- Document the planning window, goals, committed tickets, stretch objectives, demo notes, and retro actions.
+- Link back to ticket IDs and keep status snapshots so stakeholders can see progression across the time box.
+
+## Codex Agent Contract
+
+Codex agents working in this repository must:
+
+1. Read `codex/STATE.md` before beginning new work to avoid conflicts.
+2. Log every material action or decision in the ticket's **Log** section with timestamped bullet notes.
+3. Keep ticket files and `STATE.md` in sync for status, priority, ownership, and PR references.
+4. Never modify tickets marked **Done**—open a follow-up ticket instead.
+5. Ensure every merged PR references its ticket ID and that the ticket references the PR.
+
+By keeping the board, tickets, and plans tightly aligned, contributors maintain a single source of truth that scales across teams and long-running initiatives.

--- a/codex/plans/README.md
+++ b/codex/plans/README.md
@@ -1,0 +1,40 @@
+# Planning Document Guide
+
+Planning artefacts in this directory provide a lightweight structure for organising tickets into time-boxed initiatives (sprints, OKRs, releases).
+
+## Naming Convention
+
+- Weekly plans: `YYYYWW-name.md` (e.g., `2025W41-sprint.md`)
+- Quarterly plans: `YYYY-QN-name.md` (e.g., `2025-Q1-growth.md`)
+
+## Recommended Outline
+
+```markdown
+# 2025W41 – Acquisition Sprint
+
+**Window:** 2025-10-06 → 2025-10-17  
+**Facilitator:** github-handle  
+**Goals:** Bullet list of top-level objectives.
+
+## Committed Tickets
+
+- TKT-1234 – Short description and owner
+
+## Stretch Tickets
+
+- TKT-2345 – Optional goals if capacity allows
+
+## Milestones
+
+- 2025-10-08 – Mid-sprint review agenda, demo targets, or checkpoints.
+
+## Demo & Review Notes
+
+- Capture outcomes, learnings, and retro action items.
+```
+
+## Best Practices
+
+- Reference ticket IDs consistently so readers can jump to the source ticket record.
+- Note capacity or staffing risks early and keep this file updated after standups or planning meetings.
+- Archive completed plans in place—do not delete them. They serve as historical context for future planning cycles.

--- a/codex/tickets/README.md
+++ b/codex/tickets/README.md
@@ -1,0 +1,55 @@
+# Codex Ticket Authoring Guide
+
+Each ticket is stored as a Markdown file in this directory with the filename `<ticket-id>.md` (for example, `TKT-1234.md`). The file begins with YAML front matter followed by structured sections that capture context, plan, acceptance, links, and a running log.
+
+## Front Matter Template
+
+```yaml
+---
+created: 2024-01-15
+id: TKT-1234
+owner: octocat
+priority: P1
+status: In-Progress
+title: Upgrade authentication flow
+---
+```
+
+- Use ISO 8601 dates for `created`.
+- Keep keys in alphabetical order.
+- `status` must match the values used in `codex/STATE.md`.
+- `priority` is one of `P0`, `P1`, `P2`, or `P3`.
+
+## Body Outline
+
+```markdown
+## Context
+
+Briefly describe the problem space and why the work matters.
+
+## Plan
+
+- [ ] Step or milestone
+- [ ] Another step
+
+## Acceptance
+
+- [ ] Condition or test that confirms success
+
+## Links
+
+- Primary PR: _(add a Markdown link when created)_
+- Follow-ups: _(list future tickets or TODOs)_
+
+## Log
+
+- 2024-01-15T10:42:00Z – Initial draft created, awaiting estimation.
+```
+
+### Best Practices
+
+- Keep the plan checklist current; mark completed items with `[x]` and expand with sub-steps when scope changes.
+- Add timestamps to every log entry in UTC using the `YYYY-MM-DDThh:mm:ssZ` format.
+- Record notable decisions, blockers, escalations, and validations in the log to build an auditable history.
+- When opening a PR, link it in both the **Links** section and the corresponding row in `codex/STATE.md`.
+- If work is descoped or postponed, document the reasoning in the log before updating the status or priority.

--- a/codex/tickets/TICKET_TEMPLATE.md
+++ b/codex/tickets/TICKET_TEMPLATE.md
@@ -1,0 +1,31 @@
+---
+created: YYYY-MM-DD
+id: TKT-XXXX
+owner: github-handle
+priority: P1
+status: Backlog
+title: Concise, action-oriented title
+---
+
+## Context
+
+> Summarise the problem space, business justification, and any relevant background links.
+
+## Plan
+
+- [ ] Outline the primary milestones or implementation steps.
+- [ ] Add additional tasks as the plan evolves.
+
+## Acceptance
+
+- [ ] Condition that proves the work is complete.
+- [ ] Include verification steps, test coverage expectations, or sign-off requirements.
+
+## Links
+
+- Primary PR: _(add when available)_
+- Follow-ups: _(reference additional tickets or TODO items)_
+
+## Log
+
+- YYYY-MM-DDThh:mm:ssZ – First update recorded here.


### PR DESCRIPTION
Automated EvoCoder agent submission. Please review the proposed changes.

> Execution mode: Code mode.

        ---

        ### Summary of Changes

        This round did not push a new commit; EvoCoder is aligning on the next set of updates.

        ### Testing & Validation

        Validation will run once a new commit is available.

Outstanding follow-ups:
- GitHub checks are failing.
- DCO: action_required — There is one commit incorrectly signed off.  This means that the author of this commit failed to include a Signed-off-by line in the commit message.  To avoid having PRs blocked in the future, always include `Signed-off-by: Author Name <authoremail@example.com>` in *every* commit message. You can also do this automatically by using the -s flag (i.e., `git commit -s`).  Here is how to fix the problem so that this code can be merged.   ---  ### Rebase the branch  If you have a local git environment and meet the criteria below, one option is to rebase the branch and add your Signed-off-by lines in the new commits.  Please note that if others have already begun work based upon the commits in this branch, this solution will rewrite history and may cause serious issues for collaborators ([described in the git documentation](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) under "The Perils of Rebasing").  You should only do this if:  * You are the only author of the commits in this branch * You are absolutely certain nobody else is doing any work based upon this branch * There are no empty commits in the branch (for example, a DCO Remediation Commit which was added using `--allow-empty`)  To add your Signed-off-by line to every commit in this branch:  1. Ensure you have a local copy of your branch by [checking out the pull request locally via command line](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally). 1. In your local branch, run: `git rebase HEAD~1 --signoff` 1. Force push your changes to overwrite the branch: `git push --force-with-lease origin evolvecoder-auto/I-want-to-add-this-codex-folder-structur-20251013-202432`  ---    ### Summary  Commit sha: [f6f5b85](https://github.com/6529-Collections/6529seize-frontend/pull/1534/commits/f6f5b85ddfc9c49512ede50a9c6148f10ae88352), Author: codex-agent, Committer: codex-agent; The sign-off is missing. | https://github.com/6529-Collections/6529seize-frontend/runs/52645010155
- [Blocker] codex/STATE.md line ~7: remove the placeholder table row to comply with board hygiene. Keep header and real rows aligned and valid Markdown.
- Remove exactly:
- codex/agents.md lines 7–9: make the ticket ID and filename pattern explicit and consistent. Use a canonical format and mirror it in front matter.
- Example revision: filename TKT-1234.md and front matter id: TKT-1234 (uppercase, TKT- prefix, digits).
- codex/agents.md lines 62–63: optionally require the ticket ID in PR titles for traceability, for example “TKT-1234: short description”.
- codex/tickets/README.md lines 18–22: state that owner must be the GitHub handle responsible for delivery.
- codex/plans/README.md lines 7–9: clarify weekly plan naming uses ISO week numbers, for example YYYYWww-name.md such as 2025W41-sprint.md.
- codex/tickets/TICKET_TEMPLATE.md lines 1–31: optionally add a note under Links to include the ticket ID in the PR title for consistency.
- codex/STATE.md lines 11–17: add a CI lint that synchronizes codex/STATE.md with ticket front matter in codex/tickets/*.md.
- CI job should:
- Ignore non-ticket files such as README.md and templates.
- Parse id, title, status, priority, owner from ticket front matter.
- Verify matching rows in STATE.md and flag missing rows, orphan rows, or drifted values.
- Current issues to catch include the orphan placeholder row and template IDs that should be ignored.
- Quality Gate passed for this PR.
- Technical findings:
- 0 new issues.
- 0 security hotspots.
- 0% coverage on new code.
- 0% duplication on new code.

        ### Latest EvoCoder Update

        **Round 2 – Ticket 1: Primary Ticket**

- Outcome: No commit was produced in this round.
- Outstanding items:
  - GitHub checks are failing.
  - DCO: action_required — There is one commit incorrectly signed off.  This means that the author of this commit failed to include a Signed-off-by line in the commit message.  To avoid having PRs blocked in the future, always include `Signed-off-by: Author Name <authoremail@example.com>` in *every* commit message. You can also do this automatically by using the -s flag (i.e., `git commit -s`).  Here is how to fix the problem so that this code can be merged.   ---  ### Rebase the branch  If you have a local git environment and meet the criteria below, one option is to rebase the branch and add your Signed-off-by lines in the new commits.  Please note that if others have already begun work based upon the commits in this branch, this solution will rewrite history and may cause serious issues for collaborators ([described in the git documentation](https://git-scm.com/book/en/v2/Git-Branching-Rebasing) under "The Perils of Rebasing").  You should only do this if:  * You are the only author of the commits in this branch * You are absolutely certain nobody else is doing any work based upon this branch * There are no empty commits in the branch (for example, a DCO Remediation Commit which was added using `--allow-empty`)  To add your Signed-off-by line to every commit in this branch:  1. Ensure you have a local copy of your branch by [checking out the pull request locally via command line](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/checking-out-pull-requests-locally). 1. In your local branch, run: `git rebase HEAD~1 --signoff` 1. Force push your changes to overwrite the branch: `git push --force-with-lease origin evolvecoder-auto/I-want-to-add-this-codex-folder-structur-20251013-202432`  ---    ### Summary  Commit sha: [f6f5b85](https://github.com/6529-Collections/6529seize-frontend/pull/1534/commits/f6f5b85ddfc9c49512ede50a9c6148f10ae88352), Author: codex-agent, Committer: codex-agent; The sign-off is missing. | https://github.com/6529-Collections/6529seize-frontend/runs/52645010155
  - [Blocker] codex/STATE.md line ~7: remove the placeholder table row to comply with board hygiene. Keep header and real rows aligned and valid Markdown.
  - Remove exactly:
  - codex/agents.md lines 7–9: make the ticket ID and filename pattern explicit and consistent. Use a canonical format and mirror it in front matter.
  - Example revision: filename TKT-1234.md and front matter id: TKT-1234 (uppercase, TKT- prefix, digits).
  - codex/agents.md lines 62–63: optionally require the ticket ID in PR titles for traceability, for example “TKT-1234: short description”.
  - codex/tickets/README.md lines 18–22: state that owner must be the GitHub handle responsible for delivery.
  - codex/plans/README.md lines 7–9: clarify weekly plan naming uses ISO week numbers, for example YYYYWww-name.md such as 2025W41-sprint.md.
  - codex/tickets/TICKET_TEMPLATE.md lines 1–31: optionally add a note under Links to include the ticket ID in the PR title for consistency.
  - codex/STATE.md lines 11–17: add a CI lint that synchronizes codex/STATE.md with ticket front matter in codex/tickets/*.md.
  - CI job should:
  - Ignore non-ticket files such as README.md and templates.
  - Parse id, title, status, priority, owner from ticket front matter.
  - Verify matching rows in STATE.md and flag missing rows, orphan rows, or drifted values.
  - Current issues to catch include the orphan placeholder row and template IDs that should be ignored.
  - Quality Gate passed for this PR.
  - Technical findings:
  - 0 new issues.
  - 0 security hotspots.
  - 0% coverage on new code.
  - 0% duplication on new code.
- Notes: Round 2: no changes produced; stopping ticket 1.

        ---

        ### Process Telemetry

        | Field | Value |
| --- | --- |
| Execution ID | `a2cfea80-d486-4461-9c78-a8781538ca86` |
| Latest Round | 2 |
| Ticket | 1 |
| Ticket Title | Primary Ticket |
| Last Push | 2025-10-13 20:27:19 UTC |