### PR TITLE
fix(): Rarible URL

### DIFF
--- a/components/nft-marketplace-links/NFTMarketplaceLinks.tsx
+++ b/components/nft-marketplace-links/NFTMarketplaceLinks.tsx
@@ -65,7 +65,7 @@ export default function NFTMarketplaceLinks({
       <Link
         title="Rarible"
         className="hover:tw-opacity-75"
-        href={`https://rarible.com/token/${contract}:${id}`}
+        href={`https://rarible.com/ethereum/items/${contract}:${id}`}
         target="_blank"
         rel="noopener noreferrer"
       >


### PR DESCRIPTION
Rarible has moved to a new product, example url for items is now https://rarible.com/ethereum/items/0x33fd426905f149f8376e227d0c9d3340aad17af1:68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Rarible marketplace link for NFT items to use the current URL format, so “View on Rarible” now opens the exact item page.
  * Eliminates broken/redirected links and improves reliability when navigating to Rarible.
  * No visual or workflow changes; other marketplace links remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->