### PR TITLE
fix: show consistent styling for quote blocks in composer

### DIFF
--- a/components/drops/create/lexical/lexical.styles.scss
+++ b/components/drops/create/lexical/lexical.styles.scss
@@ -30,6 +30,23 @@
   margin-bottom: 0;
 }
 
+.editor-quote {
+  position: relative;
+  margin: 0 0 8px;
+  padding-left: 16px;
+  border-left: 4px solid #848490;
+  color: #e5e7eb;
+}
+
+.editor-quote::before {
+  content: ">";
+  position: absolute;
+  left: 4px;
+  top: 0;
+  color: #93939f;
+  font-weight: 600;
+}
+
 .editor-input-one-liner {
   overflow-x: auto;
   min-height: 45px;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual styling for block quotes in the editor. Block quotes now feature distinctive left borders, optimized padding, refined text colors, and clear visual indicators to enhance readability and content distinction within the editor, providing better visual hierarchy when working with quoted content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->