### PR TITLE
Search open data pages

### DIFF
--- a/hooks/useSidebarSections.ts
+++ b/hooks/useSidebarSections.ts
@@ -1,8 +1,12 @@
-import { useMemo, type ComponentType } from "react";
-import { UsersIcon, WrenchIcon, DocumentTextIcon } from "@heroicons/react/24/outline";
 import Squares2X2Icon from "@/components/common/icons/Squares2X2Icon";
 import { SidebarSection } from "@/components/navigation/navTypes";
 import { AboutSection } from "@/enums";
+import {
+  DocumentTextIcon,
+  UsersIcon,
+  WrenchIcon,
+} from "@heroicons/react/24/outline";
+import { useMemo, type ComponentType } from "react";
 
 export function useSidebarSections(
   appWalletsSupported: boolean,
@@ -98,12 +102,12 @@ export function useSidebarSections(
               { name: "API", href: "/tools/api" },
               { name: "EMMA", href: "/emma" },
               { name: "Block Finder", href: "/tools/block-finder" },
-              { name: "Open Data", href: "/open-data" },
             ],
           },
           {
             name: "Open Data",
             items: [
+              { name: "Open Data", href: "/open-data" },
               { name: "Network Metrics", href: "/open-data/network-metrics" },
               ...(!isIos || country?.toUpperCase() === "US"
                 ? [
@@ -200,7 +204,7 @@ export function useSidebarSections(
 
 export function useSectionMap(sections: SidebarSection[]) {
   return useMemo(
-    () => new Map(sections.map(section => [section.key, section])),
+    () => new Map(sections.map((section) => [section.key, section])),
     [sections]
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Open Data" subsection under Tools > Other Tools containing: Open Data, Network Metrics, Meme Subscriptions (shown conditionally based on device and country), Rememes, Team, and Royalties.
  * Meme Subscriptions now appears only when not on iOS or when the user's country is US.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->