### PR TITLE
make last 50 mints as default and only option at metrics mints section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ AGENTS.md
 .codex
 .gemini
 .windsurfrules
+.agent

--- a/app/metrics/components/MintMetricsCard.tsx
+++ b/app/metrics/components/MintMetricsCard.tsx
@@ -3,13 +3,9 @@ import CustomTooltip from "@/components/utils/tooltip/CustomTooltip";
 import type { ApiMintMetrics } from "@/generated/models/ApiMintMetrics";
 import { formatNumberWithCommas } from "../utils/formatNumbers";
 
-const PAGE_SIZE_OPTIONS = [10, 50] as const;
-
 interface MintMetricsCardProps {
   readonly data: ApiMintMetrics[];
   readonly icon: ReactNode;
-  readonly pageSize: number;
-  readonly onPageSizeChange: (size: number) => void;
 }
 
 function MintBarChart({ data }: { readonly data: ApiMintMetrics[] }) {
@@ -99,12 +95,7 @@ function MintBarChart({ data }: { readonly data: ApiMintMetrics[] }) {
   );
 }
 
-export default function MintMetricsCard({
-  data,
-  icon,
-  pageSize,
-  onPageSizeChange,
-}: MintMetricsCardProps) {
+export default function MintMetricsCard({ data, icon }: MintMetricsCardProps) {
   const latestMint = data[0];
 
   if (data.length === 0) {
@@ -122,28 +113,7 @@ export default function MintMetricsCard({
           <h3 className="tw-text-base tw-font-semibold tw-text-white">
             Mint Stats
           </h3>
-          <div className="tw-flex tw-gap-1">
-            {PAGE_SIZE_OPTIONS.map((size) => (
-              <span
-                key={size}
-                role="button"
-                tabIndex={0}
-                onClick={() => onPageSizeChange(size)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    onPageSizeChange(size);
-                  }
-                }}
-                className={`tw-cursor-pointer tw-select-none tw-rounded tw-px-2 tw-py-0.5 tw-text-xs tw-font-medium tw-transition-colors ${
-                  pageSize === size
-                    ? "tw-bg-emerald-500 tw-text-white"
-                    : "tw-text-neutral-400 hover:tw-bg-neutral-800 hover:tw-text-white"
-                }`}
-              >
-                {size}
-              </span>
-            ))}
-          </div>
+          <div className="tw-flex tw-gap-1"></div>
         </div>
         <div className="tw-flex tw-size-10 tw-items-center tw-justify-center tw-rounded-lg tw-bg-emerald-500">
           {icon}

--- a/app/metrics/page.client.tsx
+++ b/app/metrics/page.client.tsx
@@ -1,19 +1,16 @@
 "use client";
 
-import { useState } from "react";
 import { useSetTitle } from "@/contexts/TitleContext";
 import { useCommunityMetrics } from "@/hooks/useCommunityMetrics";
 import { useMintMetrics } from "@/hooks/useMintMetrics";
+import CumulativeMetricCard from "./components/CumulativeMetricCard";
 import MetricCard from "./components/MetricCard";
 import MetricsError from "./components/MetricsError";
-import MintMetricsCard from "./components/MintMetricsCard";
-import MetricsSkeleton from "./components/MetricsSkeleton";
-import CumulativeMetricCard from "./components/CumulativeMetricCard";
 import {
   ActiveIdentitiesIcon,
   ConsolidationsIcon,
-  DropsIcon,
   DroppersIcon,
+  DropsIcon,
   MintIcon,
   NetworkTdhIcon,
   PercentageIcon,
@@ -24,15 +21,15 @@ import {
   VotesIcon,
   XtdhIcon,
 } from "./components/MetricsIcons";
+import MetricsSkeleton from "./components/MetricsSkeleton";
+import MintMetricsCard from "./components/MintMetricsCard";
 
 export default function MetricsPageClient() {
   useSetTitle("Metrics");
 
-  const [mintPageSize, setMintPageSize] = useState(10);
-
   const dailyQuery = useCommunityMetrics("DAY");
   const weeklyQuery = useCommunityMetrics("WEEK");
-  const mintQuery = useMintMetrics(mintPageSize);
+  const mintQuery = useMintMetrics(50);
 
   const isLoading =
     dailyQuery.isLoading || weeklyQuery.isLoading || mintQuery.isLoading;
@@ -65,8 +62,6 @@ export default function MetricsPageClient() {
               <MintMetricsCard
                 data={mintQuery.data.items}
                 icon={<MintIcon />}
-                pageSize={mintPageSize}
-                onPageSizeChange={setMintPageSize}
               />
               <MetricCard
                 title="Distinct Droppers"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified the metrics display by removing customizable pagination controls in favor of a fixed page size.

* **Chores**
  * Updated git configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->