### PR TITLE
Preserve newlines in meme drop descriptions

### DIFF
--- a/components/memes/drops/MemeWinnerDescription.tsx
+++ b/components/memes/drops/MemeWinnerDescription.tsx
@@ -7,7 +7,9 @@ export default function MemeWinnerDescription({
 }: MemeWinnerDescriptionProps) {
   return (
     <div>
-      <p className="tw-text-iron-400 tw-mb-0 tw-text-md">{description}</p>
+      <p className="tw-mb-0 tw-whitespace-pre-line tw-text-md tw-text-iron-400">
+        {description}
+      </p>
     </div>
   );
 }

--- a/components/memes/drops/MemesLeaderboardDropDescription.tsx
+++ b/components/memes/drops/MemesLeaderboardDropDescription.tsx
@@ -4,12 +4,14 @@ interface MemesLeaderboardDropDescriptionProps {
   readonly description: string;
 }
 
-const MemesLeaderboardDropDescription: React.FC<MemesLeaderboardDropDescriptionProps> = ({
-  description,
-}) => {
+const MemesLeaderboardDropDescription: React.FC<
+  MemesLeaderboardDropDescriptionProps
+> = ({ description }) => {
   return (
     <div>
-      <p className="tw-text-sm tw-text-iron-500 tw-mb-0 tw-leading-relaxed">{description}</p>
+      <p className="tw-mb-0 tw-whitespace-pre-line tw-text-sm tw-leading-relaxed tw-text-iron-500">
+        {description}
+      </p>
     </div>
   );
 };

--- a/components/memes/drops/meme-participation-drop/MemeDropDescription.tsx
+++ b/components/memes/drops/meme-participation-drop/MemeDropDescription.tsx
@@ -7,7 +7,9 @@ export default function MemeDropDescription({
 }: MemeDropDescriptionProps) {
   return (
     <div>
-      <p className="tw-text-iron-400 tw-mb-0 tw-text-md">{description}</p>
+      <p className="tw-mb-0 tw-whitespace-pre-line tw-text-md tw-text-iron-400">
+        {description}
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
- Render meme drop descriptions with whitespace-preserving styling so user-entered line breaks show on participation, leaderboard, and winner cards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Meme drop descriptions now display with proper line break formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->