### PR TITLE
Raise pinned waves limit to 20

### DIFF
--- a/__tests__/hooks/usePinnedWaves.test.tsx
+++ b/__tests__/hooks/usePinnedWaves.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, act } from "@testing-library/react";
 import { usePinnedWaves } from "@/hooks/usePinnedWaves";
 
-const MAX_PINNED_WAVES = 10;
+const MAX_PINNED_WAVES = 20;
 
 it("adds and removes ids and persists to localStorage", () => {
   const { result } = renderHook(() => usePinnedWaves());

--- a/hooks/usePinnedWaves.tsx
+++ b/hooks/usePinnedWaves.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 
-const MAX_PINNED_WAVES = 10;
+const MAX_PINNED_WAVES = 20;
 const STORAGE_KEY = "pinnedWave";
 
 export function usePinnedWaves() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Increased the maximum number of waves that can be pinned from 10 to 20, enabling broader content curation
  * Enhanced pinned waves feature with improved data management and lifecycle handling for greater stability
  * Pinned waves are now properly cleared upon logout to maintain data consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->