### PR TITLE
EvoResolver - Gate “Thank you for participating” by login and minted card ownership

### DIFF
--- a/__tests__/components/mint-countdown-box/MemePageMintCountdown.test.tsx
+++ b/__tests__/components/mint-countdown-box/MemePageMintCountdown.test.tsx
@@ -2,6 +2,7 @@ import { useCookieConsent } from "@/components/cookies/CookieConsentContext";
 import MemePageMintCountdown from "@/components/mint-countdown-box/MemePageMintCountdown";
 import { Time } from "@/helpers/time";
 import useCapacitor from "@/hooks/useCapacitor";
+import { useShowThankYouForMint } from "@/hooks/useShowThankYouForMint";
 import type {
   ManifoldClaim} from "@/hooks/useManifoldClaim";
 import {
@@ -13,6 +14,7 @@ import { render, screen } from "@testing-library/react";
 
 jest.mock("@/hooks/useManifoldClaim");
 jest.mock("@/hooks/useCapacitor");
+jest.mock("@/hooks/useShowThankYouForMint");
 jest.mock("@/components/cookies/CookieConsentContext", () => ({
   useCookieConsent: jest.fn(),
 }));
@@ -57,6 +59,8 @@ const mockUseCapacitor = useCapacitor as jest.MockedFunction<
 const mockUseCookieConsent = useCookieConsent as jest.MockedFunction<
   typeof useCookieConsent
 >;
+const mockUseShowThankYouForMint =
+  useShowThankYouForMint as jest.MockedFunction<typeof useShowThankYouForMint>;
 
 const baseClaim: ManifoldClaim = {
   instanceId: 1,
@@ -71,6 +75,8 @@ const baseClaim: ManifoldClaim = {
   memePhase: undefined,
   isFetching: false,
   isFinalized: false,
+  isSoldOut: false,
+  isError: false,
 };
 
 beforeEach(() => {
@@ -80,6 +86,12 @@ beforeEach(() => {
     country: "US",
     consent: jest.fn(),
     reject: jest.fn(),
+  });
+  mockUseShowThankYouForMint.mockReturnValue({
+    showThankYou: false,
+    isLoading: false,
+    error: null as any,
+    balance: 0,
   });
 });
 

--- a/__tests__/components/mint-countdown-box/MintCountdownBox.test.tsx
+++ b/__tests__/components/mint-countdown-box/MintCountdownBox.test.tsx
@@ -144,6 +144,9 @@ describe("MintCountdownBox (new API)", () => {
       );
       expect(screen.getByText(/Mint Phase Complete/i)).toBeInTheDocument();
       expect(screen.queryByTestId("date-countdown")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/Thank you for participating/i)
+      ).not.toBeInTheDocument();
     });
 
     it("shows ended state (sold out) message", () => {
@@ -156,6 +159,21 @@ describe("MintCountdownBox (new API)", () => {
         screen.getByText(/Mint Complete - Sold Out!/i)
       ).toBeInTheDocument();
       expect(screen.queryByTestId("date-countdown")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/Thank you for participating/i)
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows thank-you text when explicitly enabled", () => {
+      render(
+        <MintCountdownBox
+          mintInfo={{ title: "X", date: 1640995200, isFinalized: true }}
+          showThankYou={true}
+        />
+      );
+      expect(
+        screen.getByText(/Thank you for participating/i)
+      ).toBeInTheDocument();
     });
   });
 

--- a/components/home/now-minting/NowMintingCountdown.tsx
+++ b/components/home/now-minting/NowMintingCountdown.tsx
@@ -2,6 +2,8 @@ import {
   type MintCountdownState,
   useMintCountdownState,
 } from "@/hooks/useMintCountdownState";
+import { MEMES_CONTRACT } from "@/constants/constants";
+import { useShowThankYouForMint } from "@/hooks/useShowThankYouForMint";
 import NowMintingCountdownActive from "./NowMintingCountdownActive";
 import NowMintingCountdownError from "./NowMintingCountdownError";
 import NowMintingCountdownFinalized from "./NowMintingCountdownFinalized";
@@ -16,18 +18,27 @@ export default function NowMintingCountdown({
   nftId,
 }: NowMintingCountdownProps) {
   const state = useMintCountdownState(nftId);
+  const shouldCheckParticipation =
+    state.type === "sold_out" || state.type === "finalized";
+  const { showThankYou } = useShowThankYouForMint({
+    contract: MEMES_CONTRACT,
+    tokenId: nftId,
+    enabled: shouldCheckParticipation,
+  });
 
   return (
     <div className="tw-group tw-relative tw-mt-auto">
-      <NowMintingCountdownContent state={state} />
+      <NowMintingCountdownContent state={state} showThankYou={showThankYou} />
     </div>
   );
 }
 
 function NowMintingCountdownContent({
   state,
+  showThankYou,
 }: {
   readonly state: MintCountdownState;
+  readonly showThankYou: boolean;
 }) {
   switch (state.type) {
     case "loading":
@@ -35,9 +46,9 @@ function NowMintingCountdownContent({
     case "error":
       return <NowMintingCountdownError />;
     case "sold_out":
-      return <NowMintingCountdownSoldOut />;
+      return <NowMintingCountdownSoldOut showThankYou={showThankYou} />;
     case "finalized":
-      return <NowMintingCountdownFinalized />;
+      return <NowMintingCountdownFinalized showThankYou={showThankYou} />;
     case "countdown":
       return <NowMintingCountdownActive countdown={state.countdown} />;
   }

--- a/components/home/now-minting/NowMintingCountdownFinalized.tsx
+++ b/components/home/now-minting/NowMintingCountdownFinalized.tsx
@@ -1,6 +1,10 @@
 import ClockIcon from "@/components/utils/icons/ClockIcon";
 
-export default function NowMintingCountdownFinalized() {
+export default function NowMintingCountdownFinalized({
+  showThankYou,
+}: {
+  readonly showThankYou: boolean;
+}) {
   return (
     <div className="tw-relative tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/5 tw-bg-iron-900/60 tw-p-3 tw-text-left tw-backdrop-blur-sm md:tw-p-4">
       <div className="tw-flex tw-items-start tw-gap-3">
@@ -14,9 +18,11 @@ export default function NowMintingCountdownFinalized() {
           <p className="tw-mb-0 tw-text-sm tw-leading-relaxed tw-text-iron-300">
             This mint phase has ended.
           </p>
-          <p className="tw-mb-0 tw-text-xs tw-text-iron-500">
-            Thank you for participating!
-          </p>
+          {showThankYou && (
+            <p className="tw-mb-0 tw-text-xs tw-text-iron-500">
+              Thank you for participating!
+            </p>
+          )}
         </div>
       </div>
     </div>

--- a/components/home/now-minting/NowMintingCountdownSoldOut.tsx
+++ b/components/home/now-minting/NowMintingCountdownSoldOut.tsx
@@ -1,6 +1,10 @@
 import { CheckCircleIcon } from "@heroicons/react/24/outline";
 
-export default function NowMintingCountdownSoldOut() {
+export default function NowMintingCountdownSoldOut({
+  showThankYou,
+}: {
+  readonly showThankYou: boolean;
+}) {
   return (
     <div className="tw-relative tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/5 tw-bg-iron-900/60 tw-p-3 tw-text-left tw-backdrop-blur-sm md:tw-p-4">
       <div className="tw-flex tw-items-start tw-gap-3">
@@ -14,9 +18,11 @@ export default function NowMintingCountdownSoldOut() {
           <span className="tw-text-sm tw-leading-relaxed tw-text-iron-300">
             All NFTs have been successfully minted.
           </span>
-          <span className="tw-text-xs tw-text-iron-500">
-            Thank you for participating.
-          </span>
+          {showThankYou && (
+            <span className="tw-text-xs tw-text-iron-500">
+              Thank you for participating.
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/components/mint-countdown-box/MemePageMintCountdown.tsx
+++ b/components/mint-countdown-box/MemePageMintCountdown.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useCookieConsent } from "@/components/cookies/CookieConsentContext";
+import { MEMES_CONTRACT } from "@/constants/constants";
 import useCapacitor from "@/hooks/useCapacitor";
 import {
   ManifoldClaimStatus,
   ManifoldPhase,
   useMemesManifoldClaim,
 } from "@/hooks/useManifoldClaim";
+import { useShowThankYouForMint } from "@/hooks/useShowThankYouForMint";
 import { useEffect, useState } from "react";
 import MintCountdownBox from "./MintCountdownBox";
 
@@ -66,10 +68,18 @@ export default function MemePageMintCountdown(
   };
 
   const hideMintBtn = props.hide_mint_btn || (isIos && country !== "US");
+  const mintInfo = getMintInfo();
+  const shouldCheckParticipation =
+    !!mintInfo?.isFinalized || !!mintInfo?.isSoldOut;
+  const { showThankYou } = useShowThankYouForMint({
+    contract: MEMES_CONTRACT,
+    tokenId: props.nft_id,
+    enabled: shouldCheckParticipation,
+  });
 
   return (
     <MintCountdownBox
-      mintInfo={getMintInfo()}
+      mintInfo={mintInfo}
       linkInfo={{
         href: "/the-memes/mint",
         target: "_self",
@@ -77,6 +87,7 @@ export default function MemePageMintCountdown(
       hideMintBtn={hideMintBtn}
       small={props.hide_mint_btn}
       isError={isError}
+      showThankYou={showThankYou}
     />
   );
 }

--- a/components/mint-countdown-box/MintCountdownBox.tsx
+++ b/components/mint-countdown-box/MintCountdownBox.tsx
@@ -24,10 +24,12 @@ interface Props {
   hideMintBtn?: boolean | undefined;
   small?: boolean | undefined;
   isError?: boolean | undefined;
+  showThankYou?: boolean | undefined;
 }
 
 export default function MintCountdownBox(props: Readonly<Props>) {
-  const { mintInfo, linkInfo, hideMintBtn, small, isError } = props;
+  const { mintInfo, linkInfo, hideMintBtn, small, isError, showThankYou } =
+    props;
 
   // Derived flags
   const hasMintInfo = Boolean(mintInfo);
@@ -71,7 +73,9 @@ export default function MintCountdownBox(props: Readonly<Props>) {
         <p className="mb-1 tw-font-medium">
           All NFTs have been successfully minted.
         </p>
-        <p className="mb-0 tw-text-md">Thank you for participating!</p>
+        {showThankYou && (
+          <p className="mb-0 tw-text-md">Thank you for participating!</p>
+        )}
       </div>
     );
   }
@@ -81,7 +85,9 @@ export default function MintCountdownBox(props: Readonly<Props>) {
       <div className={containerClasses}>
         <h4 className="mb-3">⌛️ Mint Phase Complete</h4>
         <p className="mb-1 tw-font-medium">This mint phase has ended.</p>
-        <p className="mb-0 tw-text-md">Thank you for participating!</p>
+        {showThankYou && (
+          <p className="mb-0 tw-text-md">Thank you for participating!</p>
+        )}
       </div>
     );
   }

--- a/hooks/useNftBalance.ts
+++ b/hooks/useNftBalance.ts
@@ -7,12 +7,14 @@ interface UseNftBalanceProps {
   consolidationKey: string | null;
   contract: string;
   tokenId: number;
+  enabled?: boolean;
 }
 
 export function useNftBalance({
   consolidationKey,
   contract,
   tokenId,
+  enabled = true,
 }: UseNftBalanceProps) {
   const { data, isLoading, error } = useQuery<DBResponse>({
     queryKey: ["nft-balance", consolidationKey, contract, tokenId],
@@ -20,7 +22,7 @@ export function useNftBalance({
       await commonApiFetch<DBResponse>({
         endpoint: `nft-owners/consolidation/${consolidationKey}?contract=${contract}&token_id=${tokenId}`,
       }),
-    enabled: !!consolidationKey,
+    enabled: !!consolidationKey && enabled,
   });
 
   const balanceObject: NftOwner | undefined = data?.data?.[0];

--- a/hooks/useShowThankYouForMint.ts
+++ b/hooks/useShowThankYouForMint.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useAuth } from "@/components/auth/Auth";
+import { useNftBalance } from "@/hooks/useNftBalance";
+
+export function useShowThankYouForMint({
+  contract,
+  tokenId,
+  enabled = true,
+}: {
+  readonly contract: string;
+  readonly tokenId: number;
+  readonly enabled?: boolean;
+}) {
+  const { connectedProfile } = useAuth();
+
+  const { balance, isLoading, error } = useNftBalance({
+    consolidationKey: connectedProfile?.consolidation_key ?? null,
+    contract,
+    tokenId,
+    enabled,
+  });
+
+  const showThankYou =
+    !!connectedProfile && enabled && !isLoading && !error && balance > 0;
+
+  return { showThankYou, isLoading, error, balance };
+}
+


### PR DESCRIPTION
Automated change generated by `evoticketresolver`.

- Execution ID: `81ffa996-1834-42f2-8476-ff84aeb88474`
- Provider: `openai`
- Model: `gpt-5.2-pro`
- Target branch: `main`

### Prompt
```
on the home page of 6529.io (and possibly on the memes detail page but I have not checked), once a mint is done, it has the text "thank you for participating" but this text is shown without any check on if the person has participated or not

I would like you to change the behavior as follows
- Logged out user: do not show the text
- Logged in user who has not minted the card: do not show the text
- Logged in user who has minted the card: show the text
```

### Engine output (last message)
```
Implemented conditional “Thank you for participating” so it only shows for users who are logged in *and* own (have a positive balance of) the minted card.

- Home page “Latest Drop” mint-complete states now gate the message via `components/home/now-minting/NowMintingCountdown.tsx:17` → `components/home/now-minting/NowMintingCountdownSoldOut.tsx:3` and `components/home/now-minting/NowMintingCountdownFinalized.tsx:3`.
- Memes detail countdown box now gates the same message via `components/mint-countdown-box/MemePageMintCountdown.tsx:15` → `components/mint-countdown-box/MintCountdownBox.tsx:30`.
- Added `hooks/useShowThankYouForMint.ts:1` (uses the logged-in profile’s `consolidation_key` + `useNftBalance`), and added an `enabled` option to `hooks/useNftBalance.ts:13` to only check once the mint is finalized/sold out.
```

_Generated at 2026-01-22 21:47:37Z._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a thank you acknowledgment message displayed for users who have participated in mints, appearing in sold-out and finalized mint states.

* **Tests**
  * Introduced tests to verify the thank you message displays correctly for participating users and is properly hidden in other scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->