### PR TITLE
EvoResolver - Harden TimelineMedia iframe embeds with URL validation and sandboxing

### DIFF
--- a/__tests__/components/timeline/TimelineMedia.test.tsx
+++ b/__tests__/components/timeline/TimelineMedia.test.tsx
@@ -18,8 +18,13 @@ describe('TimelineMedia', () => {
   });
 
   it('renders iframe when type HTML', () => {
-    const { container } = render(<TimelineMedia url="page.html" type={MediaType.HTML} />);
+    const { container } = render(
+      <TimelineMedia url="https://example.com/page.html" type={MediaType.HTML} />
+    );
     const frame = container.querySelector('iframe');
-    expect(frame).toHaveAttribute('src', 'page.html');
+    expect(frame).toHaveAttribute('src', 'https://example.com/page.html');
+    expect(frame).toHaveAttribute('sandbox', 'allow-scripts');
+    expect(frame).toHaveAttribute('allow', '');
+    expect(frame).toHaveAttribute('referrerpolicy', 'no-referrer');
   });
 });

--- a/components/timeline/TimelineMedia.tsx
+++ b/components/timeline/TimelineMedia.tsx
@@ -11,6 +11,64 @@ export enum MediaType {
   HTML,
 }
 
+const DEFAULT_UNTRUSTED_IFRAME_SANDBOX = "allow-scripts";
+
+const canonicalizeUntrustedHtmlMediaUrl = (rawUrl: string): string | null => {
+  if (!rawUrl) {
+    return null;
+  }
+
+  const trimmed = rawUrl.trim();
+  if (trimmed !== rawUrl) {
+    return null;
+  }
+
+  const normalized =
+    trimmed.startsWith("ipfs://") &&
+    trimmed.length > "ipfs://".length &&
+    !trimmed.slice("ipfs://".length).startsWith("/")
+      ? `https://ipfs.io/ipfs/${trimmed.slice("ipfs://".length)}`
+      : trimmed;
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(normalized);
+  } catch {
+    return null;
+  }
+
+  if (parsedUrl.protocol !== "https:") {
+    return null;
+  }
+
+  if (parsedUrl.username || parsedUrl.password) {
+    return null;
+  }
+
+  if (parsedUrl.port) {
+    if (parsedUrl.port === "443") {
+      parsedUrl.port = "";
+    } else {
+      return null;
+    }
+  }
+
+  let normalizedHostname = parsedUrl.hostname.toLowerCase();
+  while (normalizedHostname.endsWith(".")) {
+    normalizedHostname = normalizedHostname.slice(0, -1);
+  }
+
+  if (!normalizedHostname) {
+    return null;
+  }
+
+  if (parsedUrl.hostname !== normalizedHostname) {
+    parsedUrl.hostname = normalizedHostname;
+  }
+
+  return parsedUrl.toString();
+};
+
 export default function TimelineMediaComponent(props: Readonly<Props>) {
   if (props.type === MediaType.VIDEO) {
     return (
@@ -25,8 +83,25 @@ export default function TimelineMediaComponent(props: Readonly<Props>) {
     );
   }
   if (props.type === MediaType.HTML) {
+    const safeSrc = canonicalizeUntrustedHtmlMediaUrl(props.url);
+    if (!safeSrc) {
+      return (
+        <div className={styles["timelineMediaImage"]}>
+          Unsupported interactive media
+        </div>
+      );
+    }
+
     return (
-      <iframe className={styles["timelineMediaImage"]} src={props.url}></iframe>
+      <iframe
+        className={styles["timelineMediaImage"]}
+        src={safeSrc}
+        title="Untrusted interactive content"
+        sandbox={DEFAULT_UNTRUSTED_IFRAME_SANDBOX}
+        allow=""
+        referrerPolicy="no-referrer"
+        loading="lazy"
+      />
     );
   }
   return (


### PR DESCRIPTION
Automated change generated by `evoticketresolver`.

- Execution ID: `94c5685e-76ec-4cfb-b4ee-3410e3393d88`
- Provider: `openai`
- Model: `gpt-5.2-pro`
- Target branch: `main`

### Prompt
```
Fix this issue in a way consistent with the approach of the rest of the site and not breaking any functionality

H-1 — Untrusted HTML rendered in iframes without sandbox
Impact: Untrusted content can attempt top-level navigations/phishing overlays; increases user risk.
Ease: Easy → Medium.

Evidence:

components/timeline/TimelineMedia.tsx:27 → :31 renders an <iframe src={props.url}> for HTML animations with no sandbox or URL validation.
A safer pattern exists elsewhere:
components/common/SandboxedExternalIframe.tsx:6 → :172 (strong sandbox + URL canonicalization)
Recommended remediation:

Use SandboxedExternalIframe (or equivalent) for any user/metadata-sourced HTML.
Validate src scheme/host (disallow javascript:, credentials, non-HTTPS).

Note that you will not find the /ops/* control plane information you expect in this repo.  It is ok, read the existing documentation of the repo and proceed normally
```

### Engine output (last message)
```
- Fixed the unsafe HTML iframe in `components/timeline/TimelineMedia.tsx:85` by validating/canonicalizing the URL (HTTPS only, no credentials, no non-443 ports) and adding a restrictive iframe sandbox (`sandbox="allow-scripts"`, `allow=""`, `referrerPolicy="no-referrer"`). `ipfs://…` is normalized to `https://ipfs.io/ipfs/…`.  
- If the URL is invalid/unsafe, Timeline now renders a safe placeholder instead of embedding it (`components/timeline/TimelineMedia.tsx:87`).
- Updated the unit test to use an HTTPS URL and assert the sandboxing attributes (`__tests__/components/timeline/TimelineMedia.test.tsx:20`).

Commands I ran:
- `npx tsc -p tsconfig.typecheck.json --noEmit --pretty false`
- `NODE_ENV=test npx jest --runTestsByPath __tests__/components/timeline/TimelineMedia.test.tsx --forceExit`
```

_Generated at 2026-01-22 22:30:24Z._