### PR TITLE
[SIMO] EvoResolver - Sanitize Sentry telemetry and make Session Replay opt-in

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -38,6 +38,11 @@ NEXT_PUBLIC_AWS_RUM_APP_ID=
 NEXT_PUBLIC_AWS_RUM_REGION=us-east-1
 NEXT_PUBLIC_AWS_RUM_IDENTITY_POOL_ID=
 
+# Sentry (optional)
+# Keep Session Replay disabled unless explicitly reviewed for PII risks.
+SENTRY_DSN=
+SENTRY_REPLAY_ENABLED=false
+
 # Pepe.wtf previews (optional overrides)
 PEPE_CACHE_TTL_MINUTES=10
 PEPE_CACHE_MAX_ITEMS=500

--- a/config/env.schema.ts
+++ b/config/env.schema.ts
@@ -116,6 +116,7 @@ export const publicEnvSchema = z.object({
   AWS_RUM_REGION: z.string().optional(),
   AWS_RUM_SAMPLE_RATE: z.string().optional(),
   SENTRY_DSN: z.string().optional(),
+  SENTRY_REPLAY_ENABLED: z.enum(["true", "false"]).optional(),
 
     /**
    * ────────────────

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -9,6 +9,10 @@ import {
   filterTunnelRouteErrors,
   tagSecurityProbes,
 } from "@/config/sentryProbes";
+import {
+  sanitizeSentryBreadcrumb,
+  sanitizeSentryEvent,
+} from "@/utils/sentry-sanitizer";
 import * as Sentry from "@sentry/nextjs";
 
 const dsn = publicEnv.SENTRY_DSN;
@@ -23,8 +27,13 @@ Sentry.init({
   // Enable logs to be sent to Sentry
   enableLogs: true,
 
-  // Enable sending user PII (Personally Identifiable Information)
-  sendDefaultPii: true,
+  // Default to NOT sending PII unless explicitly reviewed and required.
+  // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#sendDefaultPii
+  sendDefaultPii: false,
+
+  beforeBreadcrumb(breadcrumb) {
+    return sanitizeSentryBreadcrumb(breadcrumb);
+  },
 
   // ------------------------------------------------------------
   // Handle obvious bot / exploit probes more gently (edge)
@@ -34,6 +43,10 @@ Sentry.init({
     if (filtered === null) {
       return null;
     }
-    return tagSecurityProbes(filtered);
+    return sanitizeSentryEvent(tagSecurityProbes(filtered));
+  },
+
+  beforeSendTransaction(event) {
+    return sanitizeSentryEvent(tagSecurityProbes(event as any) as any);
   },
 });

--- a/utils/sentry-sanitizer.ts
+++ b/utils/sentry-sanitizer.ts
@@ -1,0 +1,212 @@
+import type { Breadcrumb, Event } from "@sentry/nextjs";
+
+const REDACTED = "[Filtered]";
+
+const JWT_PATTERN = /eyJ[A-Za-z0-9-_]+\.eyJ[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+/g;
+const STRIPE_KEY_PATTERN = /\b(sk|pk)_[a-zA-Z0-9]{16,}\b/g;
+const BEARER_PATTERN = /\bBearer\s+([A-Za-z0-9._~+/=-]+)\b/g;
+const BASIC_PATTERN = /\bBasic\s+([A-Za-z0-9+/=]+)\b/g;
+
+const SENSITIVE_KEY_FRAGMENT_PATTERN =
+  /(auth|authorization|cookie|set-cookie|token|secret|password|passwd|session|api[_-]?key|private[_-]?key|signature|body|payload)/i;
+
+const SENSITIVE_HEADER_NAME_PATTERN =
+  /^(authorization|cookie|set-cookie|x-api-key|x-auth-token|x-csrf-token|x-xsrf-token|proxy-authorization|x-forwarded-for|x-real-ip|cf-connecting-ip)$/i;
+
+function sanitizeString(value: string): string {
+  if (!value) return value;
+  let sanitized = value;
+  sanitized = sanitized.replace(JWT_PATTERN, REDACTED);
+  sanitized = sanitized.replace(STRIPE_KEY_PATTERN, REDACTED);
+  sanitized = sanitized.replace(BEARER_PATTERN, "Bearer " + REDACTED);
+  sanitized = sanitized.replace(BASIC_PATTERN, "Basic " + REDACTED);
+  return sanitized.length > 2048 ? sanitized.slice(0, 2048) : sanitized;
+}
+
+export function sanitizeUrlString(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+
+  // Fast-path: drop query / hash without needing URL parsing.
+  const noHash = value.split("#", 1)[0] ?? value;
+  const noQuery = noHash.split("?", 1)[0] ?? noHash;
+
+  // If it looks like a URL, keep only the pathname.
+  try {
+    const parsed = new URL(value, "http://localhost");
+    return parsed.pathname || "/";
+  } catch {
+    return noQuery;
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (Object.getPrototypeOf(value) === Object.prototype ||
+      Object.getPrototypeOf(value) === null)
+  );
+}
+
+function sanitizeUnknown(
+  value: unknown,
+  depth: number,
+  seen: WeakSet<object>
+): unknown {
+  if (depth > 8) return REDACTED;
+
+  if (typeof value === "string") {
+    return sanitizeString(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((v) => sanitizeUnknown(v, depth + 1, seen));
+  }
+
+  if (isPlainObject(value)) {
+    if (seen.has(value)) return REDACTED;
+    seen.add(value);
+
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      if (SENSITIVE_KEY_FRAGMENT_PATTERN.test(key)) {
+        result[key] = REDACTED;
+        continue;
+      }
+
+      if (key === "url" || key === "from" || key === "to") {
+        result[key] = sanitizeUrlString(val);
+        continue;
+      }
+
+      result[key] = sanitizeUnknown(val, depth + 1, seen);
+    }
+    return result;
+  }
+
+  return value;
+}
+
+function sanitizeHeaders(
+  headers: unknown
+): Record<string, unknown> | undefined {
+  if (!headers) return undefined;
+  if (!isPlainObject(headers)) return undefined;
+
+  const result: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(headers)) {
+    if (/^(referer|referrer)$/i.test(key)) {
+      result[key] = typeof val === "string" ? sanitizeUrlString(val) : REDACTED;
+      continue;
+    }
+
+    if (SENSITIVE_HEADER_NAME_PATTERN.test(key)) {
+      result[key] = REDACTED;
+      continue;
+    }
+
+    if (typeof val === "string") {
+      result[key] = sanitizeString(val);
+      continue;
+    }
+
+    result[key] = sanitizeUnknown(val, 0, new WeakSet<object>());
+  }
+  return result;
+}
+
+export function sanitizeSentryBreadcrumb(
+  breadcrumb: Breadcrumb | undefined | null
+): Breadcrumb | null {
+  if (!breadcrumb) return null;
+
+  const crumb = { ...breadcrumb };
+  if (typeof crumb.message === "string") {
+    crumb.message = sanitizeString(crumb.message);
+  }
+  if (typeof crumb.category === "string") {
+    crumb.category = sanitizeString(crumb.category);
+  }
+  if (typeof crumb.type === "string") {
+    crumb.type = sanitizeString(crumb.type);
+  }
+
+  if (crumb.data) {
+    const seen = new WeakSet<object>();
+    crumb.data = sanitizeUnknown(crumb.data, 0, seen) as NonNullable<
+      Breadcrumb["data"]
+    >;
+  }
+
+  return crumb;
+}
+
+export function sanitizeSentryEvent<T extends Event>(event: T): T {
+  // Avoid mutating the original reference in case Sentry reuses it.
+  const next = { ...event } as T;
+
+  // Do not send user-identifying fields by default.
+  delete (next as any).user;
+
+  if (next.request) {
+    const req: Record<string, unknown> = { ...(next.request as any) };
+
+    if (typeof req["url"] === "string") {
+      req["url"] = sanitizeUrlString(req["url"]);
+    }
+
+    const sanitizedHeaders = sanitizeHeaders(req["headers"]);
+    if (sanitizedHeaders) {
+      req["headers"] = sanitizedHeaders;
+    } else {
+      delete req["headers"];
+    }
+
+    // Request bodies and cookies can contain user content and credentials.
+    delete req["cookies"];
+    delete req["data"];
+    delete req["query_string"];
+
+    (next as any).request = req;
+  }
+
+  if (typeof next.message === "string") {
+    next.message = sanitizeString(next.message);
+  }
+
+  if (next.exception?.values) {
+    next.exception = {
+      ...next.exception,
+      values: next.exception.values.map((v) => {
+        const value = { ...v };
+        if (typeof value.value === "string") {
+          value.value = sanitizeString(value.value);
+        }
+        if (typeof value.type === "string") {
+          value.type = sanitizeString(value.type);
+        }
+        return value;
+      }),
+    };
+  }
+
+  if (Array.isArray(next.breadcrumbs)) {
+    next.breadcrumbs = next.breadcrumbs
+      .map((b) => sanitizeSentryBreadcrumb(b))
+      .filter(Boolean) as Breadcrumb[];
+  }
+
+  const seen = new WeakSet<object>();
+  if (next.extra) {
+    next.extra = sanitizeUnknown(next.extra, 0, seen) as NonNullable<
+      Event["extra"]
+    >;
+  }
+  if (next.contexts) {
+    next.contexts = sanitizeUnknown(next.contexts, 0, seen) as NonNullable<
+      Event["contexts"]
+    >;
+  }
+
+  return next;
+}


### PR DESCRIPTION
Automated change generated by `evoticketresolver`.

- Execution ID: `d68f8d56-daff-4f5a-9fc9-6236b5ca8e3c`
- Provider: `openai`
- Model: `gpt-5.2-pro`
- Target branch: `main`

### Prompt
```
Fix this issue in a way consistent with the approach of the rest of the site and not breaking any functionality

H-3 — Sentry configuration can capture PII and potentially sensitive data (plus session replay risk)
Impact: Potential leakage of identifiers, request context, and user content to a third party; privacy compliance risk.
Ease: Medium.

Evidence:

sendDefaultPii: true on client and server:
instrumentation-client.ts:143 → :181
sentry.server.config.ts:14 → :39
sentry.edge.config.ts:16 → :39
Replay enabled:
instrumentation-client.ts:147 → :157
Recommended remediation:

Default to sendDefaultPii: false unless there is a documented, reviewed need.
Add beforeSend and beforeBreadcrumb sanitizers to scrub tokens/headers/body fields.
Ensure session replay is opt-in and explicitly reviewed for PII (or disabled).

Note that you will not find the /ops/* control plane information you expect in this repo.  It is ok, read the existing documentation of the repo and proceed normally
```

### Engine output (last message)
```
**Fix**
- Defaulted `sendDefaultPii` to `false` on client/server/edge and added sanitizers for events + breadcrumbs (scrubs headers/cookies/body-like fields, strips URL query strings/fragments, redacts common token formats). See `instrumentation-client.ts:150`, `sentry.server.config.ts:18`, `sentry.edge.config.ts:20`, `utils/sentry-sanitizer.ts:1`.
- Made Session Replay opt-in via `SENTRY_REPLAY_ENABLED=true` (otherwise Replay integration is not added and sample rates are `0`). See `instrumentation-client.ts:21`, `config/env.schema.ts:118`, `.env.sample:41`.
- Added `beforeSendTransaction` sanitization so performance/transaction payloads don’t leak query params/headers either. See `instrumentation-client.ts:199`, `sentry.server.config.ts:49`, `sentry.edge.config.ts:49`.

**Validation**
- `npx tsc -p tsconfig.typecheck.json --noEmit` passes; `npm test` fails in this environment with `React.act is not a function` (appears unrelated to the Sentry changes).
```

_Generated at 2026-01-22 22:48:22Z._