### PR TITLE
EvoResolver - Harden wallet encryption and password policy while preserving legacy unlock support

### DIFF
--- a/__tests__/components/app-wallets/app-wallet-helpers.test.ts
+++ b/__tests__/components/app-wallets/app-wallet-helpers.test.ts
@@ -1,14 +1,36 @@
 import { encryptData, decryptData } from '@/components/app-wallets/app-wallet-helpers';
+import crypto from 'crypto';
 
 const salt = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4';
 const password = 'test-password';
 const data = 'secret-data';
+
+async function encryptLegacy(saltValue: string, plaintext: string, pass: string) {
+  const saltBuffer = Buffer.from(saltValue, 'hex');
+  const key = await new Promise<Buffer>((resolve, reject) => {
+    crypto.pbkdf2(pass, saltBuffer, 100000, 32, 'sha256', (err, derivedKey) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(derivedKey);
+    });
+  });
+
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  let encrypted = cipher.update(plaintext, 'utf8', 'hex');
+  encrypted += cipher.final('hex');
+  const authTag = cipher.getAuthTag().toString('hex');
+  return `${iv.toString('hex')}:${authTag}:${encrypted}`;
+}
 
 describe('app-wallet-helpers', () => {
   it('encrypts and decrypts data with same password', async () => {
     const encrypted = await encryptData(salt, data, password);
     expect(typeof encrypted).toBe('string');
     expect(encrypted).not.toBe(data);
+    expect(encrypted.startsWith('v2:')).toBe(true);
     const decrypted = await decryptData(salt, encrypted, password);
     expect(decrypted).toBe(data);
   });
@@ -22,5 +44,18 @@ describe('app-wallet-helpers', () => {
   it('throws when decrypting with wrong password', async () => {
     const encrypted = await encryptData(salt, data, password);
     await expect(decryptData(salt, encrypted, 'wrong-password')).rejects.toThrow();
+  });
+
+  it('decrypts legacy payloads for backwards compatibility', async () => {
+    const legacyEncrypted = await encryptLegacy(salt, data, password);
+    const decrypted = await decryptData(salt, legacyEncrypted, password);
+    expect(decrypted).toBe(data);
+  });
+
+  it('decrypts legacy payloads created with 0x-prefixed salts', async () => {
+    const addressLikeSalt = '0x1234abcd';
+    const legacyEncrypted = await encryptLegacy(addressLikeSalt, data, password);
+    const decrypted = await decryptData(addressLikeSalt, legacyEncrypted, password);
+    expect(decrypted).toBe(data);
   });
 });

--- a/components/app-wallets/AppWallet.tsx
+++ b/components/app-wallets/AppWallet.tsx
@@ -79,6 +79,8 @@ export default function AppWalletComponent(
   const [addressCopied, setAddressCopied] = useState(false);
   const [mnemonicCopied, setMnemonicCopied] = useState(false);
   const [privateKeyCopied, setPrivateKeyCopied] = useState(false);
+  const [mnemonicCopyArmed, setMnemonicCopyArmed] = useState(false);
+  const [privateKeyCopyArmed, setPrivateKeyCopyArmed] = useState(false);
 
   function setEncryptedPhrase() {
     setPhrase(Array(12).fill("x".repeat(8)));
@@ -360,6 +362,7 @@ export default function AppWalletComponent(
                     if (revealPhrase) {
                       setRevealPhrase(false);
                       setEncryptedPhrase();
+                      setMnemonicCopyArmed(false);
                     } else {
                       setIsRevealingPhrase(true);
                     }
@@ -395,32 +398,44 @@ export default function AppWalletComponent(
                 <>
                   <FontAwesomeIcon
                     className="cursor-pointer unselectable"
-                    icon={faCopy}
-                    height={22}
-                    data-tooltip-id={`copy-mnemonic-${appWallet.address}`}
-                    onClick={() => {
-                      navigator.clipboard.writeText(phrase.join(" "));
-                      setMnemonicCopied(true);
+                  icon={faCopy}
+                  height={22}
+                  data-tooltip-id={`copy-mnemonic-${appWallet.address}`}
+                  onClick={() => {
+                    if (!mnemonicCopyArmed) {
+                      setMnemonicCopyArmed(true);
                       setTimeout(() => {
-                        setMnemonicCopied(false);
-                      }, 1500);
-                    }}
-                  />
-                  <Tooltip
-                    id={`copy-mnemonic-${appWallet.address}`}
-                    place="top"
+                        setMnemonicCopyArmed(false);
+                      }, 2500);
+                      return;
+                    }
+                    setMnemonicCopyArmed(false);
+                    navigator.clipboard.writeText(phrase.join(" "));
+                    setMnemonicCopied(true);
+                    setTimeout(() => {
+                      setMnemonicCopied(false);
+                    }, 1500);
+                  }}
+                />
+                <Tooltip
+                  id={`copy-mnemonic-${appWallet.address}`}
+                  place="top"
                     style={{
                       backgroundColor: "#1F2937",
                       color: "white",
                       padding: "4px 8px",
                     }}
-                  >
-                    {mnemonicCopied ? "Copied!" : "Copy to clipboard"}
-                  </Tooltip>
-                </>
-              )}
-            </span>
-          )}
+                >
+                  {mnemonicCopied
+                    ? "Copied!"
+                    : mnemonicCopyArmed
+                      ? "Click again to copy"
+                      : "Copy to clipboard"}
+                </Tooltip>
+              </>
+            )}
+          </span>
+        )}
         </Col>
       </Row>
       <Row className="pt-2">
@@ -453,6 +468,7 @@ export default function AppWalletComponent(
                   if (revealPrivateKey) {
                     setRevealPrivateKey(false);
                     setEncryptedPrivateKey();
+                    setPrivateKeyCopyArmed(false);
                   } else {
                     setIsRevealingPrivateKey(true);
                   }
@@ -494,6 +510,14 @@ export default function AppWalletComponent(
                   height={22}
                   data-tooltip-id={`copy-private-key-${appWallet.address}`}
                   onClick={() => {
+                    if (!privateKeyCopyArmed) {
+                      setPrivateKeyCopyArmed(true);
+                      setTimeout(() => {
+                        setPrivateKeyCopyArmed(false);
+                      }, 2500);
+                      return;
+                    }
+                    setPrivateKeyCopyArmed(false);
                     navigator.clipboard.writeText(privateKey);
                     setPrivateKeyCopied(true);
                     setTimeout(() => {
@@ -510,7 +534,11 @@ export default function AppWalletComponent(
                     padding: "4px 8px",
                   }}
                 >
-                  {privateKeyCopied ? "Copied!" : "Copy to clipboard"}
+                  {privateKeyCopied
+                    ? "Copied!"
+                    : privateKeyCopyArmed
+                      ? "Click again to copy"
+                      : "Copy to clipboard"}
                 </Tooltip>
               </>
             )}

--- a/components/app-wallets/app-wallet-helpers.ts
+++ b/components/app-wallets/app-wallet-helpers.ts
@@ -2,13 +2,20 @@ import crypto from "crypto";
 
 const ENCRYPTION_ALGORITHM = "aes-256-gcm";
 
-function deriveKey(password: string, salt: string): Promise<Buffer> {
+const LEGACY_PBKDF2_ITERATIONS = 100000;
+const PBKDF2_ITERATIONS_V2 = 310000;
+const SALT_BYTES_V2 = 16; // 128-bit salt
+
+function deriveKeyLegacy(password: string, salt: string): Promise<Buffer> {
+  // Legacy behavior intentionally preserves Buffer.from(salt, "hex") semantics.
+  // Notably, values like "0x..." produce an empty buffer, which is how existing
+  // wallets were encrypted historically and must remain decryptable.
   const saltBuffer = Buffer.from(salt, "hex");
   return new Promise((resolve, reject) => {
     crypto.pbkdf2(
       password,
       saltBuffer,
-      100000,
+      LEGACY_PBKDF2_ITERATIONS,
       32,
       "sha256",
       (err, derivedKey) => {
@@ -22,6 +29,26 @@ function deriveKey(password: string, salt: string): Promise<Buffer> {
   });
 }
 
+function deriveKeyV2(
+  password: string,
+  saltHex: string,
+  iterations: number
+): Promise<Buffer> {
+  if (!/^[0-9a-fA-F]+$/.test(saltHex) || saltHex.length % 2 !== 0) {
+    return Promise.reject(new Error("Invalid salt"));
+  }
+  const saltBuffer = Buffer.from(saltHex, "hex");
+  return new Promise((resolve, reject) => {
+    crypto.pbkdf2(password, saltBuffer, iterations, 32, "sha256", (err, key) => {
+      if (err) {
+        reject(new Error(err.message || "Error deriving key"));
+        return;
+      }
+      resolve(key);
+    });
+  });
+}
+
 function generateIv() {
   return crypto.randomBytes(12); // Use 12 bytes for GCM IV
 }
@@ -31,7 +58,12 @@ export async function encryptData(
   data: string,
   password: string
 ): Promise<string> {
-  const key = await deriveKey(password, salt);
+  // v2 format: v2:<iterations>:<saltHex>:<ivHex>:<authTagHex>:<ciphertextHex>
+  // Note: "salt" param is retained for API compatibility but is no longer used.
+  void salt;
+  const iterations = PBKDF2_ITERATIONS_V2;
+  const saltHex = crypto.randomBytes(SALT_BYTES_V2).toString("hex");
+  const key = await deriveKeyV2(password, saltHex, iterations);
   const iv = generateIv();
 
   const cipher = crypto.createCipheriv(ENCRYPTION_ALGORITHM, key, iv);
@@ -40,8 +72,7 @@ export async function encryptData(
 
   const authTag = cipher.getAuthTag().toString("hex"); // Retrieve the authentication tag
 
-  // Return IV, AuthTag, and Encrypted Data as a concatenated string
-  return `${iv.toString("hex")}:${authTag}:${encrypted}`;
+  return `v2:${iterations}:${saltHex}:${iv.toString("hex")}:${authTag}:${encrypted}`;
 }
 
 export async function decryptData(
@@ -49,17 +80,40 @@ export async function decryptData(
   encryptedData: string,
   password: string
 ): Promise<string> {
+  if (encryptedData.startsWith("v2:")) {
+    const parts = encryptedData.split(":");
+    if (parts.length !== 6) {
+      throw new Error("Invalid encrypted payload");
+    }
+    const [, iterationsRaw, saltHex, ivHex, authTagHex, encryptedHex] = parts;
+    const iterations = Number(iterationsRaw);
+    if (!Number.isFinite(iterations) || iterations <= 0) {
+      throw new Error("Invalid encrypted payload");
+    }
+
+    const iv = Buffer.from(ivHex ?? "", "hex");
+    const authTag = Buffer.from(authTagHex ?? "", "hex");
+
+    const key = await deriveKeyV2(password, saltHex ?? "", iterations);
+    const decipher = crypto.createDecipheriv(ENCRYPTION_ALGORITHM, key, iv);
+    decipher.setAuthTag(authTag);
+    let decrypted = decipher.update(encryptedHex ?? "", "hex", "utf8");
+    decrypted += decipher.final("utf8");
+    return decrypted;
+  }
+
+  // Legacy format: <ivHex>:<authTagHex>:<ciphertextHex>
   const [ivHex, authTagHex, encryptedHex] = encryptedData.split(":");
-  const iv = Buffer.from(ivHex!, "hex");
-  const authTag = Buffer.from(authTagHex!, "hex");
+  if (!ivHex || !authTagHex || !encryptedHex) {
+    throw new Error("Invalid encrypted payload");
+  }
+  const iv = Buffer.from(ivHex, "hex");
+  const authTag = Buffer.from(authTagHex, "hex");
 
-  const key = await deriveKey(password, salt);
-
+  const key = await deriveKeyLegacy(password, salt);
   const decipher = crypto.createDecipheriv(ENCRYPTION_ALGORITHM, key, iv);
-  decipher.setAuthTag(authTag); // Set the authentication tag
-
-  let decrypted = decipher.update(encryptedHex!, "hex", "utf8");
+  decipher.setAuthTag(authTag);
+  let decrypted = decipher.update(encryptedHex, "hex", "utf8");
   decrypted += decipher.final("utf8");
-
   return decrypted;
 }


### PR DESCRIPTION
Automated change generated by `evoticketresolver`.

- Execution ID: `77411542-cc39-4bd6-8206-698947459830`
- Provider: `openai`
- Model: `gpt-5.2-pro`
- Target branch: `main`

### Prompt
```
Fix this issue in a way consistent with the approach of the rest of the site and not breaking any functionality

X-2 — “App Wallet” feature: key custody and crypto hygiene
Impact: Handling mnemonics/private keys increases responsibility; compromise here is catastrophic for users.
Ease: Medium.

Evidence:

AES-256-GCM encryption + PBKDF2:
components/app-wallets/app-wallet-helpers.ts:1 → :65
Salt parsed as hex: Buffer.from(salt, "hex") (components/app-wallets/app-wallet-helpers.ts:5 → :13). Wallet addresses include 0x and are not valid hex strings unless normalized; this can weaken or break the intended salt usage.
Password minimum length is only 6:
components/app-wallets/AppWalletModal.tsx:13 → :71
Private key input uses type="text":
components/app-wallets/AppWalletImport.tsx:227 → :236
Recommended remediation:

Strongly consider removing or isolating in-app key custody unless absolutely required.
If kept:
Use a random per-wallet salt stored alongside ciphertext; normalize hex inputs (strip 0x).
Increase password requirements (length + strength meter; consider passphrases).
Use platform-native secure enclaves/keychains where possible; minimize key material exposure in JS memory; avoid copying secrets to clipboard by default.

We are keeping the app wallet for now, so make the suggested improvements to harden it

Note that you will not find the /ops/* control plane information you expect in this repo.  It is ok, read the existing documentation of the repo and proceed normally
```

### Engine output (last message)
```
**Changes**
- `components/app-wallets/app-wallet-helpers.ts:5`: switched to a versioned `v2:` encrypted payload with a random salt + higher PBKDF2 iterations; kept legacy decrypt support so existing wallets still unlock/decrypt.
- `components/app-wallets/AppWalletModal.tsx:13`: strengthened create/import password policy (min 12 + strength meter; passphrases allowed); unlock flow no longer blocks shorter legacy passwords.
- `components/app-wallets/AppWalletImport.tsx:195`: private key input is now masked by default with a reveal toggle and basic hex normalization; mnemonic inputs now disable autocomplete/spellcheck.
- `components/app-wallets/AppWallet.tsx:69`: copying mnemonic/private key now requires a second click (reduces accidental clipboard exposure).

**Checks**
- Ran `node node_modules/jest/bin/jest.js --runTestsByPath __tests__/components/app-wallets/app-wallet-helpers.test.ts --runInBand`
- Ran `node node_modules/typescript/bin/tsc -p tsconfig.typecheck.json --noEmit`
```

_Generated at 2026-01-22 22:55:13Z._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Password visibility toggle for private key input during wallet import.
  * Real-time password strength indicator with validation feedback during wallet creation.
  * Two-step copy confirmation for sensitive data (mnemonic and private key) for enhanced security.

* **Improvements**
  * Enhanced private key validation and input normalization.
  * Improved user input experience with accessibility enhancements.
  * Added backwards compatibility support for legacy encrypted wallets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->