### PR TITLE
EvoResolver - Add per-request nonce-based CSP and tighten security header allowlists

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,3 @@
-export const fetchCache = "force-no-store";
-
 // Side effect: Overrides globalThis.fetch on server-side to automatically
 // add auth headers (x-6529-internal-*) for rate limiter/WAF bypass
 import "@/lib/fetch/ssrFetch";
@@ -19,6 +17,9 @@ import StoreSetup from "@/components/providers/StoreSetup";
 import { getAppMetadata } from "@/components/providers/metadata";
 import { publicEnv } from "@/config/env";
 import type { Viewport } from "next";
+import { headers } from "next/headers";
+
+export const fetchCache = "force-no-store";
 
 export const metadata = getAppMetadata();
 export const viewport: Viewport = {
@@ -35,10 +36,15 @@ export default function RootLayout({
   readonly children: React.ReactNode;
 }) {
   const isUsingStaticAssets = publicEnv.ASSETS_FROM_S3 === "true";
+  const getHeaders = headers as unknown as () => {
+    get(name: string): string | null;
+  };
+  const nonce = getHeaders().get("x-nonce") ?? undefined;
 
   return (
     <html lang="en" data-scroll-behavior="smooth">
       <head>
+        {nonce && <meta name="csp-nonce" content={nonce} />}
         <link rel="preconnect" href={publicEnv.API_ENDPOINT} crossOrigin="" />
         <link rel="preconnect" href="https://d3lqz0a4bldqgf.cloudfront.net" />
         <link rel="preconnect" href="https://media.artblocks.io" />

--- a/config/nextConfig.ts
+++ b/config/nextConfig.ts
@@ -39,7 +39,7 @@ export function sharedConfig(
       return [
         {
           source: "/:path*",
-          headers: createSecurityHeaders(publicEnv["API_ENDPOINT"]),
+          headers: createSecurityHeaders(),
         },
       ];
     },

--- a/config/securityHeaders.ts
+++ b/config/securityHeaders.ts
@@ -1,12 +1,207 @@
-export function createSecurityHeaders(apiEndpoint: string | undefined = "") {
+import type { PublicEnv } from "./env.schema";
+
+function tryGetOrigin(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    return new URL(url).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+function uniq(values: readonly string[]): string[] {
+  const set = new Set<string>();
+  for (const v of values) {
+    const trimmed = v.trim();
+    if (trimmed) set.add(trimmed);
+  }
+  return Array.from(set);
+}
+
+export function createContentSecurityPolicyValue({
+  nonce,
+  publicEnv,
+}: {
+  nonce: string;
+  publicEnv: PublicEnv;
+}): string {
+  const nodeEnv = process.env.NODE_ENV;
+  const effectiveEnv = publicEnv.NODE_ENV ?? nodeEnv;
+  const isProd =
+    effectiveEnv !== "development" &&
+    effectiveEnv !== "test" &&
+    effectiveEnv !== "local";
+
+  const apiOrigin = tryGetOrigin(publicEnv.API_ENDPOINT);
+  const allowlistApiOrigin = tryGetOrigin(publicEnv.ALLOWLIST_API_ENDPOINT);
+  const ipfsApiOrigin = tryGetOrigin(publicEnv.IPFS_API_ENDPOINT);
+  const ipfsGatewayOrigin = tryGetOrigin(publicEnv.IPFS_GATEWAY_ENDPOINT);
+  const wsOrigin = tryGetOrigin(publicEnv.WS_ENDPOINT);
+  const derivedWsOrigin = apiOrigin
+    ? tryGetOrigin(apiOrigin.replace("https://api", "wss://ws"))
+    : undefined;
+
+  const awsRumRegion = publicEnv.AWS_RUM_REGION || "us-east-1";
+  const awsRumDataplane = `https://dataplane.rum.${awsRumRegion}.amazonaws.com`;
+  const awsSts = `https://sts.${awsRumRegion}.amazonaws.com`;
+  const awsCognitoIdentity = `https://cognito-identity.${awsRumRegion}.amazonaws.com`;
+
+  const scriptSrc = uniq([
+    "'self'",
+    `'nonce-${nonce}'`,
+    // Static assets (S3/CloudFront builds)
+    "https://dnclu2fna0b2b.cloudfront.net",
+    // Analytics (loaded after cookie consent)
+    "https://www.googletagmanager.com",
+    "https://www.google-analytics.com",
+    ...(isProd ? [] : ["'unsafe-eval'"]),
+  ]);
+
+  const connectSrc = uniq([
+    "'self'",
+    "blob:",
+    apiOrigin ?? "",
+    allowlistApiOrigin ?? "",
+    ipfsApiOrigin ?? "",
+    ipfsGatewayOrigin ?? "",
+    wsOrigin ?? "",
+    derivedWsOrigin ?? "",
+    // Wallet / Web3
+    "https://registry.walletconnect.com",
+    "https://explorer-api.walletconnect.com",
+    "https://rpc.walletconnect.com",
+    "https://*.walletconnect.com",
+    "https://*.walletconnect.org",
+    "https://cloudflare-eth.com",
+    "https://rpc1.6529.io",
+    "wss://*.bridge.walletconnect.org",
+    "wss://*.walletconnect.com",
+    "wss://www.walletlink.org",
+    // Analytics / monitoring
+    "https://www.google-analytics.com",
+    "https://stats.g.doubleclick.net",
+    "https://www.googletagmanager.com",
+    "https://*.google-analytics.com",
+    awsRumDataplane,
+    awsSts,
+    awsCognitoIdentity,
+    "https://sts.us-east-1.amazonaws.com",
+    "https://sts.us-west-2.amazonaws.com",
+    // Content networks
+    "https://arweave.net",
+    // GIF picker
+    "https://tenor.googleapis.com",
+    "https://g.tenor.com",
+  ]);
+
+  const fontSrc = uniq([
+    "'self'",
+    "data:",
+    "https://fonts.gstatic.com",
+    "https://fonts.reown.com",
+    "https://dnclu2fna0b2b.cloudfront.net",
+    "https://cdnjs.cloudflare.com",
+  ]);
+
+  const imgSrc = uniq([
+    "'self'",
+    "https:",
+    "data:",
+    "blob:",
+    "ipfs:",
+  ]);
+
+  const mediaSrc = uniq([
+    "'self'",
+    "blob:",
+    "https://*.cloudfront.net",
+    "https://videos.files.wordpress.com",
+    "https://arweave.net",
+    "https://*.arweave.net",
+    "https://cf-ipfs.com",
+    "https://*.twimg.com",
+    "https://artblocks.io",
+    "https://*.artblocks.io",
+  ]);
+
+  const frameSrc = uniq([
+    "'self'",
+    "https://ipfs.io",
+    "https://cf-ipfs.com",
+    "https://media.generator.seize.io",
+    "https://media.generator.6529.io",
+    "https://generator.seize.io",
+    "https://arweave.net",
+    "https://*.arweave.net",
+    "https://nftstorage.link",
+    "https://*.ipfs.nftstorage.link",
+    "https://verify.walletconnect.com",
+    "https://verify.walletconnect.org",
+    "https://secure.walletconnect.com",
+    "https://d3lqz0a4bldqgf.cloudfront.net",
+    "https://www.youtube.com",
+    "https://www.youtube-nocookie.com",
+    "https://*.youtube.com",
+    "https://artblocks.io",
+    "https://*.artblocks.io",
+    "https://docs.google.com",
+    "https://drive.google.com",
+    "https://*.google.com",
+  ]);
+
+  const styleSrc = uniq([
+    "'self'",
+    // TODO: remove once all inline styles are migrated to nonced styles.
+    "'unsafe-inline'",
+    "https://fonts.googleapis.com",
+    "https://dnclu2fna0b2b.cloudfront.net",
+    "https://cdnjs.cloudflare.com",
+    "https://cdn.jsdelivr.net",
+  ]);
+
+  const maybeDevOnly = isProd
+    ? []
+    : (["http://localhost:*", "http://127.0.0.1:*", "ws://localhost:*"] as const);
+
+  const prodOnlyFiltered = (values: readonly string[]) =>
+    isProd
+      ? values.filter(
+          (v) =>
+            !v.startsWith("http://") &&
+            !v.startsWith("ws://") &&
+            v !== "http:" &&
+            v !== "ws:"
+        )
+      : values;
+
+  const connectSrcFinal = prodOnlyFiltered([...connectSrc, ...maybeDevOnly]);
+  const imgSrcFinal = prodOnlyFiltered([...imgSrc, ...maybeDevOnly]);
+  const styleSrcFinal = prodOnlyFiltered(styleSrc);
+  const fontSrcFinal = prodOnlyFiltered(fontSrc);
+  const scriptSrcFinal = prodOnlyFiltered(scriptSrc);
+  const mediaSrcFinal = prodOnlyFiltered(mediaSrc);
+  const frameSrcFinal = prodOnlyFiltered(frameSrc);
+
+  return [
+    `default-src 'none'`,
+    `base-uri 'none'`,
+    `frame-ancestors 'self'`,
+    `script-src ${scriptSrcFinal.join(" ")}`,
+    `connect-src ${connectSrcFinal.join(" ")}`,
+    `font-src ${fontSrcFinal.join(" ")}`,
+    `img-src ${imgSrcFinal.join(" ")}`,
+    `media-src ${mediaSrcFinal.join(" ")}`,
+    `frame-src ${frameSrcFinal.join(" ")}`,
+    `style-src ${styleSrcFinal.join(" ")}`,
+    `object-src 'none'`,
+  ].join("; ");
+}
+
+export function createSecurityHeaders() {
   return [
     {
       key: "Strict-Transport-Security",
       value: "max-age=31536000; includeSubDomains; preload",
-    },
-    {
-      key: "Content-Security-Policy",
-      value: `default-src 'none'; script-src 'self' 'unsafe-inline' https://dnclu2fna0b2b.cloudfront.net https://www.google-analytics.com https://www.googletagmanager.com/ https://dataplane.rum.us-east-1.amazonaws.com 'unsafe-eval'; connect-src * 'self' blob: ${apiEndpoint} https://registry.walletconnect.com/api/v2/wallets wss://*.bridge.walletconnect.org wss://*.walletconnect.com wss://www.walletlink.org/rpc https://explorer-api.walletconnect.com/v3/wallets https://www.googletagmanager.com https://*.google-analytics.com https://cloudflare-eth.com/ https://arweave.net/* https://rpc.walletconnect.com/v1/ https://sts.us-east-1.amazonaws.com https://sts.us-west-2.amazonaws.com; font-src 'self' data: https://fonts.gstatic.com https://fonts.reown.com https://dnclu2fna0b2b.cloudfront.net https://cdnjs.cloudflare.com; img-src 'self' data: blob: ipfs: https://artblocks.io https://*.artblocks.io *; media-src 'self' blob: https://*.cloudfront.net https://videos.files.wordpress.com https://arweave.net https://*.arweave.net https://cf-ipfs.com/ipfs/* https://*.twimg.com https://artblocks.io https://*.artblocks.io; frame-src 'self' https://ipfs.io https://ipfs.io/ipfs/ https://cf-ipfs.com https://cf-ipfs.com/ipfs/ https://media.generator.seize.io https://media.generator.6529.io https://generator.seize.io https://arweave.net https://*.arweave.net https://nftstorage.link https://*.ipfs.nftstorage.link https://verify.walletconnect.com https://verify.walletconnect.org https://secure.walletconnect.com https://d3lqz0a4bldqgf.cloudfront.net https://www.youtube.com https://www.youtube-nocookie.com https://*.youtube.com https://artblocks.io https://*.artblocks.io https://docs.google.com https://drive.google.com https://*.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/css2 https://dnclu2fna0b2b.cloudfront.net https://cdnjs.cloudflare.com http://cdnjs.cloudflare.com https://cdn.jsdelivr.net; object-src data:;`,
     },
     { key: "X-Frame-Options", value: "SAMEORIGIN" },
     { key: "X-Content-Type-Options", value: "nosniff" },


### PR DESCRIPTION
Automated change generated by `evoticketresolver`.

- Execution ID: `2d64531b-40b3-48cb-ad3f-200a911e88b7`
- Provider: `openai`
- Model: `gpt-5.2-pro`
- Target branch: `main`

### Prompt
```
Fix this issue in a way consistent with the approach of the rest of the site and not breaking any functionality

C-2 — CSP is overly permissive, enabling XSS and post-exploitation
Impact: Reduces XSS difficulty and increases post-XSS capabilities (e.g., arbitrary script execution, data exfil).
Ease: Hard (requires removing inline scripts/styles and third-party sprawl).

Evidence:

config/securityHeaders.ts:1 → :46:
script-src 'unsafe-inline' ... 'unsafe-eval'
connect-src *
img-src ... *
object-src data:
style-src ... 'unsafe-inline' ... http://cdnjs.cloudflare.com ...
Recommended remediation (target state):

Remove 'unsafe-eval' and 'unsafe-inline' for script-src using nonces/hashes and next/script.
Replace connect-src * with explicit allowlists (include API_ENDPOINT, WalletConnect endpoints, etc.).
Replace img-src ... * with scheme/host allowlists (at minimum: https: data: blob: ipfs:).
Set object-src 'none', add base-uri 'none', and add frame-ancestors 'self' (in addition to X-Frame-Options).
Ensure no http: sources are allowed.

Note that you will not find the /ops/* control plane information you expect in this repo.  It is ok, read the existing documentation of the repo and proceed normally
```

### Engine output (last message)
```
**What I changed**
- Tightened CSP to a per-request, nonce-based policy (no more `script-src 'unsafe-inline'` / `script-src 'unsafe-eval'` in production), while keeping existing app behavior working with Next’s inline/runtime scripts.
- Replaced `connect-src *` and `img-src *` with explicit allowlists (plus `https: data: blob: ipfs:` for images), set `object-src 'none'`, added `base-uri 'none'` and `frame-ancestors 'self'`, and removed `http:` sources.

**Key files**
- `config/securityHeaders.ts:1` now exports `createContentSecurityPolicyValue()` (nonce-based CSP) and `createSecurityHeaders()` (static headers; no CSP).
- `config/nextConfig.ts:1` stops sending a static CSP header (prevents duplicate/overlapping CSP).
- `proxy.ts:1` now generates a nonce per request, injects it via `x-nonce`, and sets the CSP header on responses.
- `app/layout.tsx:1` exposes the nonce via a `<meta name="csp-nonce" ...>` tag.
- `components/cookies/CookieConsentContext.tsx:1` attaches the CSP nonce to the GA init inline script so it still works without `unsafe-inline`.

**Notes**
- `npm run lint:diff` passes.
- `npm test` fails due to an existing React/testing-library incompatibility (`React.act is not a function`) and then OOM; this isn’t caused by the CSP changes.
```

_Generated at 2026-01-22 23:37:13Z._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security Enhancements**
  * Implemented improved security policies across the application to enhance protection of user data and overall application integrity.
  * Enhanced server-side security configuration with updated security headers and robust security protocols.
  * Strengthened security controls for consistent protection across all application routes and features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->