### PR TITLE
Disable link previews for temporary drops

### DIFF
--- a/__tests__/components/waves/drops/WaveDropActionsToggleLinkPreview.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropActionsToggleLinkPreview.test.tsx
@@ -1,7 +1,13 @@
-import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
-import WaveDropActionsToggleLinkPreview from "@/components/waves/drops/WaveDropActionsToggleLinkPreview";
 import { AuthContext } from "@/components/auth/Auth";
+import WaveDropActionsToggleLinkPreview from "@/components/waves/drops/WaveDropActionsToggleLinkPreview";
 import { commonApiPost } from "@/services/api/common-api";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 
 jest.mock("@/services/api/common-api", () => ({
   commonApiPost: jest.fn(),
@@ -9,7 +15,9 @@ jest.mock("@/services/api/common-api", () => ({
 
 jest.mock("@/contexts/wave/MyStreamContext", () => ({
   useMyStream: () => ({
-    applyOptimisticDropUpdate: jest.fn().mockReturnValue({ rollback: jest.fn() }),
+    applyOptimisticDropUpdate: jest
+      .fn()
+      .mockReturnValue({ rollback: jest.fn() }),
   }),
 }));
 
@@ -45,7 +53,9 @@ const renderWithAuth = (
     <AuthContext.Provider
       value={
         {
-          connectedProfile: connectedHandle ? { handle: connectedHandle } : null,
+          connectedProfile: connectedHandle
+            ? { handle: connectedHandle }
+            : null,
           activeProfileProxy,
           setToast: jest.fn(),
         } as any
@@ -68,10 +78,7 @@ describe("WaveDropActionsToggleLinkPreview", () => {
 
   it("renders nothing when user is not the author", () => {
     const drop = createDrop("bob");
-    renderWithAuth(
-      <WaveDropActionsToggleLinkPreview drop={drop} />,
-      "alice"
-    );
+    renderWithAuth(<WaveDropActionsToggleLinkPreview drop={drop} />, "alice");
     expect(screen.queryByRole("button")).toBeNull();
   });
 
@@ -83,56 +90,47 @@ describe("WaveDropActionsToggleLinkPreview", () => {
 
   it("renders nothing when using proxy profile", () => {
     const drop = createDrop("alice");
-    renderWithAuth(
-      <WaveDropActionsToggleLinkPreview drop={drop} />,
-      "alice",
-      { some: "proxy" }
-    );
+    renderWithAuth(<WaveDropActionsToggleLinkPreview drop={drop} />, "alice", {
+      some: "proxy",
+    });
     expect(screen.queryByRole("button")).toBeNull();
   });
 
   it("renders nothing when drop has no links", () => {
     const drop = createDrop("alice", false);
-    renderWithAuth(
-      <WaveDropActionsToggleLinkPreview drop={drop} />,
-      "alice"
-    );
+    renderWithAuth(<WaveDropActionsToggleLinkPreview drop={drop} />, "alice");
     expect(screen.queryByRole("button")).toBeNull();
   });
 
   it("renders button when user is the author and drop has links", () => {
     const drop = createDrop("alice", true);
-    renderWithAuth(
-      <WaveDropActionsToggleLinkPreview drop={drop} />,
-      "alice"
-    );
+    renderWithAuth(<WaveDropActionsToggleLinkPreview drop={drop} />, "alice");
     expect(screen.getByRole("button")).toBeInTheDocument();
   });
 
   it("shows hide icon when previews are visible (hide_link_preview is false)", () => {
     const drop = createDrop("alice", true, false);
-    renderWithAuth(
-      <WaveDropActionsToggleLinkPreview drop={drop} />,
-      "alice"
-    );
+    renderWithAuth(<WaveDropActionsToggleLinkPreview drop={drop} />, "alice");
     expect(screen.getByLabelText("Hide link previews")).toBeInTheDocument();
   });
 
   it("shows show icon when previews are hidden (hide_link_preview is true)", () => {
     const drop = createDrop("alice", true, true);
-    renderWithAuth(
-      <WaveDropActionsToggleLinkPreview drop={drop} />,
-      "alice"
-    );
+    renderWithAuth(<WaveDropActionsToggleLinkPreview drop={drop} />, "alice");
     expect(screen.getByLabelText("Show link previews")).toBeInTheDocument();
+  });
+
+  it("disables button for temporary (optimistic) drop", () => {
+    const drop = { ...createDrop("alice"), id: "temp-123" };
+    renderWithAuth(<WaveDropActionsToggleLinkPreview drop={drop} />, "alice");
+    const button = screen.getByRole("button");
+    expect(button).toBeDisabled();
+    expect(button).toHaveClass("tw-opacity-50");
   });
 
   it("calls API when clicked", async () => {
     const drop = createDrop("alice");
-    renderWithAuth(
-      <WaveDropActionsToggleLinkPreview drop={drop} />,
-      "alice"
-    );
+    renderWithAuth(<WaveDropActionsToggleLinkPreview drop={drop} />, "alice");
     fireEvent.click(screen.getByRole("button"));
     await waitFor(() => {
       expect(mockCommonApiPost).toHaveBeenCalledWith({

--- a/components/waves/drops/WaveDropActionsToggleLinkPreview.tsx
+++ b/components/waves/drops/WaveDropActionsToggleLinkPreview.tsx
@@ -140,17 +140,19 @@ export default function WaveDropActionsToggleLinkPreview({
 
   const hasLinks = useMemo(() => dropHasLinks(drop), [drop]);
 
+  const isTemporaryDrop = drop.id.startsWith("temp-");
   const isAuthor =
     connectedProfile?.handle === drop.author.handle && !activeProfileProxy;
 
   const previewsHidden = drop.hide_link_preview;
+  const canToggle = !isTemporaryDrop;
 
   const labelText = previewsHidden
     ? "Show Link Previews"
     : "Hide Link Previews";
 
   const handleToggle = useCallback(async () => {
-    if (loading) return;
+    if (loading || !canToggle) return;
 
     setLoading(true);
     setTooltipOpen(false);
@@ -185,6 +187,7 @@ export default function WaveDropActionsToggleLinkPreview({
     }
   }, [
     loading,
+    canToggle,
     applyOptimisticDropUpdate,
     drop.wave.id,
     drop.id,
@@ -202,15 +205,16 @@ export default function WaveDropActionsToggleLinkPreview({
     handleToggle();
   };
 
-  const buttonClassName = loading
-    ? "tw-opacity-50 tw-cursor-default"
-    : "active:tw-bg-iron-800";
+  const buttonClassName =
+    loading || !canToggle
+      ? "tw-opacity-50 tw-cursor-default"
+      : "active:tw-bg-iron-800";
 
   if (isMobile) {
     return (
       <button
         onClick={handleClick}
-        disabled={loading}
+        disabled={loading || !canToggle}
         className={`tw-flex tw-items-center tw-gap-x-4 tw-rounded-xl tw-border-0 tw-bg-iron-950 tw-p-4 ${buttonClassName} tw-transition-colors tw-duration-200`}
       >
         <ToggleIcon
@@ -230,12 +234,18 @@ export default function WaveDropActionsToggleLinkPreview({
       <button
         type="button"
         onClick={handleClick}
-        disabled={loading}
-        className="icon tw-group tw-flex tw-h-full tw-items-center tw-gap-x-2 tw-rounded-full tw-border-0 tw-bg-transparent tw-px-2 tw-text-[0.8125rem] tw-font-medium tw-leading-5 tw-text-iron-500 tw-transition tw-duration-300 tw-ease-out hover:tw-text-iron-300"
+        disabled={loading || !canToggle}
+        className={`icon tw-group tw-flex tw-h-full tw-items-center tw-gap-x-2 tw-rounded-full tw-border-0 tw-bg-transparent tw-px-2 tw-text-[0.8125rem] tw-font-medium tw-leading-5 tw-text-iron-500 tw-transition tw-duration-300 tw-ease-out ${
+          !canToggle
+            ? "tw-cursor-default tw-opacity-50"
+            : "hover:tw-text-iron-300"
+        }`}
         aria-label={
           previewsHidden ? "Show link previews" : "Hide link previews"
         }
-        data-tooltip-id={`toggle-link-preview-${drop.id}`}
+        {...(!isTemporaryDrop
+          ? { "data-tooltip-id": `toggle-link-preview-${drop.id}` }
+          : {})}
       >
         <ToggleIcon
           loading={loading}
@@ -243,27 +253,29 @@ export default function WaveDropActionsToggleLinkPreview({
           isMobile={false}
         />
       </button>
-      <Tooltip
-        id={`toggle-link-preview-${drop.id}`}
-        place="top"
-        offset={8}
-        opacity={1}
-        isOpen={tooltipOpen}
-        setIsOpen={setTooltipOpen}
-        style={{
-          padding: "4px 8px",
-          background: "#37373E",
-          color: "white",
-          fontSize: "13px",
-          fontWeight: 500,
-          borderRadius: "6px",
-          boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
-          zIndex: 99999,
-          pointerEvents: "none",
-        }}
-      >
-        <span className="tw-text-xs">{labelText}</span>
-      </Tooltip>
+      {!isTemporaryDrop && (
+        <Tooltip
+          id={`toggle-link-preview-${drop.id}`}
+          place="top"
+          offset={8}
+          opacity={1}
+          isOpen={tooltipOpen}
+          setIsOpen={setTooltipOpen}
+          style={{
+            padding: "4px 8px",
+            background: "#37373E",
+            color: "white",
+            fontSize: "13px",
+            fontWeight: 500,
+            borderRadius: "6px",
+            boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
+            zIndex: 99999,
+            pointerEvents: "none",
+          }}
+        >
+          <span className="tw-text-xs">{labelText}</span>
+        </Tooltip>
+      )}
     </>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimistic drops now have disabled action buttons to prevent toggle operations during updates
  * Disabled buttons display reduced opacity for improved visual feedback
  * Tooltips are hidden for temporary drops

<!-- end of auto-generated comment: release notes by coderabbit.ai -->