### PR TITLE
fix link as  reply_to click (scroll to post instead open link)

### DIFF
--- a/__tests__/components/waves/drops/WaveDropReply.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropReply.test.tsx
@@ -16,7 +16,7 @@ jest.mock("@/components/waves/drops/ContentDisplay", () => (props: any) => {
 
 const hookData: any = {
   drop: null,
-  content: { segments: [] },
+  content: { segments: [], apiMedia: [] },
   isLoading: false,
 };
 
@@ -83,5 +83,6 @@ describe("WaveDropReply", () => {
         mockContentDisplaySpy.mock.calls.length - 1
       ][0];
     expect(lastCallProps.textClassName).not.toContain("tw-block");
+    expect(lastCallProps.linkify).toBe(false);
   });
 });

--- a/components/waves/drops/WaveDropReply.tsx
+++ b/components/waves/drops/WaveDropReply.tsx
@@ -91,6 +91,7 @@ export default function WaveDropReply({
               onClick={() => onReplyClick(drop.serial_no)}
               className="tw-min-w-0 tw-flex-1 tw-overflow-hidden"
               textClassName="tw-min-w-0 tw-overflow-hidden"
+              linkify={false}
             />
           </p>
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled automatic link processing in reply content to prevent unwanted link conversion.

* **Tests**
  * Extended test fixtures and added assertions to verify link processing is disabled for reply content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->