### PR TITLE
refactor: centralize hover/long-press detection into useInteractionMode hook

### DIFF
--- a/__tests__/components/profile-activity/ProfileActivityLogItemValueWithCopy.test.tsx
+++ b/__tests__/components/profile-activity/ProfileActivityLogItemValueWithCopy.test.tsx
@@ -1,15 +1,33 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { useCopyToClipboard } from "react-use";
 import ProfileActivityLogItemValueWithCopy from "@/components/profile-activity/list/items/utils/ProfileActivityLogItemValueWithCopy";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
+import { createInteractionMode } from "@/__tests__/utils/interactionMode";
 
 jest.mock("react-use", () => ({ useCopyToClipboard: jest.fn() }));
+jest.mock("@/src/interaction/useInteractionMode");
+
+const useInteractionModeMock = useInteractionMode as jest.Mock;
+
+function setInteractionMode(
+  overrides: Parameters<typeof createInteractionMode>[0] = {}
+) {
+  useInteractionModeMock.mockReturnValue(createInteractionMode(overrides));
+}
+
 describe("ProfileActivityLogItemValueWithCopy", () => {
   const copy = jest.fn();
   beforeEach(() => {
     (useCopyToClipboard as jest.Mock).mockReturnValue([null, copy]);
-    Object.defineProperty(window, "matchMedia", {
-      value: () => ({ matches: false }),
+    setInteractionMode({
+      canHover: true,
+      hasFinePointer: true,
+      enableHoverUI: true,
     });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it("copies value on click and shows feedback", async () => {
@@ -21,5 +39,74 @@ describe("ProfileActivityLogItemValueWithCopy", () => {
     await fireEvent.click(screen.getByRole("button"));
     expect(copy).toHaveBeenCalledWith("0x1");
     expect(screen.getByText("Copied!")).toBeInTheDocument();
+  });
+
+  it("ignores browser touch primitives when centralized mode is hover-only", () => {
+    const touchStartDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "ontouchstart"
+    );
+    const maxTouchPointsDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis.navigator,
+      "maxTouchPoints"
+    );
+    const globalWithTouchStart = globalThis as typeof globalThis & {
+      ontouchstart?: unknown;
+    };
+    const navigatorWithTouchPoints = globalThis.navigator as Navigator & {
+      maxTouchPoints?: number;
+    };
+
+    Object.defineProperty(globalThis.navigator, "maxTouchPoints", {
+      value: 5,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, "ontouchstart", {
+      value: jest.fn(),
+      configurable: true,
+    });
+
+    try {
+      render(
+        <ProfileActivityLogItemValueWithCopy title="Address" value="0x1" />
+      );
+
+      const copyButton = screen.getByRole("button");
+
+      expect(copyButton).toHaveClass("tw-opacity-0");
+      expect(copyButton).toHaveClass("group-hover:tw-opacity-100");
+      expect(copyButton).not.toHaveClass("tw-block");
+    } finally {
+      if (maxTouchPointsDescriptor) {
+        Object.defineProperty(
+          globalThis.navigator,
+          "maxTouchPoints",
+          maxTouchPointsDescriptor
+        );
+      } else {
+        delete navigatorWithTouchPoints.maxTouchPoints;
+      }
+
+      if (touchStartDescriptor) {
+        Object.defineProperty(globalThis, "ontouchstart", touchStartDescriptor);
+      } else {
+        delete globalWithTouchStart.ontouchstart;
+      }
+    }
+  });
+
+  it("shows copy affordance when centralized touch activation is active", () => {
+    setInteractionMode({
+      canHover: true,
+      hasFinePointer: true,
+      hasCoarsePointer: true,
+      lastPointerType: "touch",
+      enableHoverUI: true,
+      enableLongPress: true,
+    });
+
+    render(<ProfileActivityLogItemValueWithCopy title="Address" value="0x1" />);
+
+    expect(screen.getByRole("button")).toHaveClass("tw-block");
   });
 });

--- a/__tests__/components/waves/outcome/useWaveOutcomeTooltipInteraction.test.ts
+++ b/__tests__/components/waves/outcome/useWaveOutcomeTooltipInteraction.test.ts
@@ -1,27 +1,16 @@
 import { renderHook } from "@testing-library/react";
 import useWaveOutcomeTooltipInteraction from "@/components/waves/outcome/useWaveOutcomeTooltipInteraction";
 import useInteractionMode from "@/src/interaction/useInteractionMode";
-import type { InteractionMode } from "@/src/interaction/useInteractionMode";
+import { createInteractionMode } from "@/__tests__/utils/interactionMode";
 
 jest.mock("@/src/interaction/useInteractionMode");
 
 const useInteractionModeMock = useInteractionMode as jest.Mock;
 
-const DEFAULT_INTERACTION_MODE: InteractionMode = {
-  canHover: false,
-  hasFinePointer: false,
-  hasCoarsePointer: false,
-  hoverNone: false,
-  lastPointerType: null,
-  enableHoverUI: false,
-  enableLongPress: false,
-};
-
-function setInteractionMode(overrides: Partial<InteractionMode> = {}) {
-  useInteractionModeMock.mockReturnValue({
-    ...DEFAULT_INTERACTION_MODE,
-    ...overrides,
-  });
+function setInteractionMode(
+  overrides: Parameters<typeof createInteractionMode>[0] = {}
+) {
+  useInteractionModeMock.mockReturnValue(createInteractionMode(overrides));
 }
 
 describe("useWaveOutcomeTooltipInteraction", () => {

--- a/__tests__/components/waves/outcome/useWaveOutcomeTooltipInteraction.test.ts
+++ b/__tests__/components/waves/outcome/useWaveOutcomeTooltipInteraction.test.ts
@@ -1,0 +1,79 @@
+import { renderHook } from "@testing-library/react";
+import useWaveOutcomeTooltipInteraction from "@/components/waves/outcome/useWaveOutcomeTooltipInteraction";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
+import type { InteractionMode } from "@/src/interaction/useInteractionMode";
+
+jest.mock("@/src/interaction/useInteractionMode");
+
+const useInteractionModeMock = useInteractionMode as jest.Mock;
+
+const DEFAULT_INTERACTION_MODE: InteractionMode = {
+  canHover: false,
+  hasFinePointer: false,
+  hasCoarsePointer: false,
+  hoverNone: false,
+  lastPointerType: null,
+  enableHoverUI: false,
+  enableLongPress: false,
+};
+
+function setInteractionMode(overrides: Partial<InteractionMode> = {}) {
+  useInteractionModeMock.mockReturnValue({
+    ...DEFAULT_INTERACTION_MODE,
+    ...overrides,
+  });
+}
+
+describe("useWaveOutcomeTooltipInteraction", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("keeps mouseleave close policy when a hybrid hover tooltip flips to touch activation", () => {
+    setInteractionMode({
+      canHover: true,
+      hasFinePointer: true,
+      enableHoverUI: true,
+    });
+
+    const { result, rerender } = renderHook(() =>
+      useWaveOutcomeTooltipInteraction()
+    );
+
+    expect(result.current.useClickActivation).toBe(false);
+    expect(result.current.tooltipOpenEvents).toEqual({
+      mouseenter: true,
+      focus: true,
+    });
+    expect(result.current.tooltipCloseEvents).toEqual({
+      mouseleave: true,
+      blur: true,
+    });
+
+    setInteractionMode({
+      canHover: true,
+      hasFinePointer: true,
+      hasCoarsePointer: true,
+      lastPointerType: "touch",
+      enableHoverUI: true,
+      enableLongPress: true,
+    });
+
+    rerender();
+
+    expect(result.current.useClickActivation).toBe(true);
+    expect(result.current.tooltipOpenEvents).toEqual({
+      mouseenter: true,
+      focus: true,
+      click: true,
+    });
+    expect(result.current.tooltipCloseEvents).toEqual({
+      mouseleave: true,
+      blur: true,
+      click: true,
+    });
+    expect(result.current.tooltipGlobalCloseEvents).toEqual({
+      clickOutsideAnchor: true,
+    });
+  });
+});

--- a/__tests__/components/waves/outcome/useWaveOutcomeTooltipInteraction.test.ts
+++ b/__tests__/components/waves/outcome/useWaveOutcomeTooltipInteraction.test.ts
@@ -1,4 +1,5 @@
-import { renderHook } from "@testing-library/react";
+import { fireEvent, render, renderHook, screen } from "@testing-library/react";
+import { createElement, useState } from "react";
 import useWaveOutcomeTooltipInteraction from "@/components/waves/outcome/useWaveOutcomeTooltipInteraction";
 import useInteractionMode from "@/src/interaction/useInteractionMode";
 import { createInteractionMode } from "@/__tests__/utils/interactionMode";
@@ -11,6 +12,48 @@ function setInteractionMode(
   overrides: Parameters<typeof createInteractionMode>[0] = {}
 ) {
   useInteractionModeMock.mockReturnValue(createInteractionMode(overrides));
+}
+
+function TooltipVisibilityHarness() {
+  const { tooltipOpenEvents, tooltipCloseEvents } =
+    useWaveOutcomeTooltipInteraction();
+  const [isVisible, setIsVisible] = useState(false);
+
+  const handleClick = () => {
+    if (isVisible && tooltipCloseEvents.click) {
+      setIsVisible(false);
+      return;
+    }
+    if (tooltipOpenEvents.click) {
+      setIsVisible(true);
+    }
+  };
+
+  return createElement(
+    "div",
+    null,
+    createElement(
+      "button",
+      {
+        onBlur: tooltipCloseEvents.blur
+          ? () => setIsVisible(false)
+          : undefined,
+        onClick: handleClick,
+        onFocus: tooltipOpenEvents.focus ? () => setIsVisible(true) : undefined,
+        onMouseEnter: tooltipOpenEvents.mouseenter
+          ? () => setIsVisible(true)
+          : undefined,
+        onMouseLeave: tooltipCloseEvents.mouseleave
+          ? () => setIsVisible(false)
+          : undefined,
+        type: "button",
+      },
+      "Outcome"
+    ),
+    isVisible
+      ? createElement("div", { role: "tooltip" }, "Outcome details")
+      : null
+  );
 }
 
 describe("useWaveOutcomeTooltipInteraction", () => {
@@ -64,5 +107,38 @@ describe("useWaveOutcomeTooltipInteraction", () => {
     expect(result.current.tooltipGlobalCloseEvents).toEqual({
       clickOutsideAnchor: true,
     });
+  });
+
+  it("dismisses a hover-opened tooltip on first tap after touch activation", () => {
+    setInteractionMode({
+      canHover: true,
+      hasFinePointer: true,
+      enableHoverUI: true,
+    });
+
+    const { rerender } = render(createElement(TooltipVisibilityHarness));
+    const button = screen.getByRole("button", { name: "Outcome" });
+
+    fireEvent.mouseEnter(button);
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Outcome details");
+
+    setInteractionMode({
+      canHover: true,
+      hasFinePointer: true,
+      hasCoarsePointer: true,
+      lastPointerType: "touch",
+      enableHoverUI: true,
+      enableLongPress: true,
+    });
+
+    rerender(createElement(TooltipVisibilityHarness));
+    fireEvent.click(button);
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    fireEvent.click(button);
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Outcome details");
   });
 });

--- a/__tests__/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes.test.tsx
+++ b/__tests__/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes.test.tsx
@@ -1,53 +1,139 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { WaveSmallLeaderboardItemOutcomes } from '@/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes';
+import { fireEvent, render, screen } from "@testing-library/react";
+import { WaveSmallLeaderboardItemOutcomes } from "@/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes";
+import useWaveOutcomeTooltipInteraction from "@/components/waves/outcome/useWaveOutcomeTooltipInteraction";
 
 const mockUseWaveRankReward = jest.fn();
 
-jest.mock('@/hooks/waves/useWaveRankReward', () => ({
+jest.mock("react-tooltip", () => ({
+  Tooltip: ({
+    children,
+    id,
+    openEvents,
+    closeEvents,
+    globalCloseEvents,
+  }: any) => (
+    <div
+      data-testid={`tooltip-${id}`}
+      data-open-events={JSON.stringify(openEvents)}
+      data-close-events={JSON.stringify(closeEvents)}
+      data-global-close-events={JSON.stringify(globalCloseEvents)}
+    >
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock("@/components/waves/outcome/useWaveOutcomeTooltipInteraction");
+
+jest.mock("@/hooks/waves/useWaveRankReward", () => ({
   useWaveRankReward: (args: any) => mockUseWaveRankReward(args),
 }));
 
-describe('WaveSmallLeaderboardItemOutcomes', () => {
-  const drop: any = { rank: 1, wave: { id: 'w1' } };
+const useWaveOutcomeTooltipInteractionMock =
+  useWaveOutcomeTooltipInteraction as jest.Mock;
+
+function mockTooltipInteraction(useClickActivation = false) {
+  useWaveOutcomeTooltipInteractionMock.mockReturnValue({
+    useClickActivation,
+    tooltipOpenEvents: useClickActivation
+      ? { click: true, focus: true }
+      : { mouseenter: true, focus: true },
+    tooltipCloseEvents: useClickActivation
+      ? { click: true, blur: true }
+      : { mouseleave: true, blur: true },
+    tooltipGlobalCloseEvents: useClickActivation
+      ? { clickOutsideAnchor: true }
+      : {},
+  });
+}
+
+describe("WaveSmallLeaderboardItemOutcomes", () => {
+  const drop: any = { id: "drop-1", rank: 1, wave: { id: "w1" } };
 
   beforeEach(() => {
     mockUseWaveRankReward.mockReset();
+    mockTooltipInteraction();
   });
 
-  it('renders button when outcomes exist', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders button when outcomes exist", () => {
     mockUseWaveRankReward.mockReturnValue({
       nicTotal: 10,
       repTotal: 20,
-      manualOutcomes: ['Award'],
-      isLoading: false
+      manualOutcomes: ["Award"],
+      isLoading: false,
     });
 
     render(<WaveSmallLeaderboardItemOutcomes drop={drop} />);
-    expect(screen.getByRole('button')).toBeInTheDocument();
-    expect(screen.getByText('Outcome')).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Outcome" })).toBeInTheDocument();
   });
 
-  it('hides when no outcomes and not loading', () => {
+  it("hides when no outcomes and not loading", () => {
     mockUseWaveRankReward.mockReturnValue({
       nicTotal: 0,
       repTotal: 0,
       manualOutcomes: [],
-      isLoading: false
+      isLoading: false,
     });
 
-    const { container } = render(<WaveSmallLeaderboardItemOutcomes drop={drop} />);
+    const { container } = render(
+      <WaveSmallLeaderboardItemOutcomes drop={drop} />
+    );
     expect(container.firstChild).toBeNull();
   });
 
-  it('shows loading state', () => {
+  it("shows loading state", () => {
     mockUseWaveRankReward.mockReturnValue({
       nicTotal: 0,
       repTotal: 0,
       manualOutcomes: [],
-      isLoading: true
+      isLoading: true,
     });
-    const { container } = render(<WaveSmallLeaderboardItemOutcomes drop={drop} />);
-    expect(container.querySelector('.tw-animate-pulse')).toBeInTheDocument();
+    const { container } = render(
+      <WaveSmallLeaderboardItemOutcomes drop={drop} />
+    );
+    expect(container.querySelector(".tw-animate-pulse")).toBeInTheDocument();
+  });
+
+  it("passes shared tooltip events through to the tooltip", () => {
+    const parentClickHandler = jest.fn();
+    mockTooltipInteraction(true);
+    mockUseWaveRankReward.mockReturnValue({
+      nicTotal: 10,
+      repTotal: 0,
+      manualOutcomes: [],
+      isLoading: false,
+    });
+
+    render(
+      <div onClick={parentClickHandler}>
+        <WaveSmallLeaderboardItemOutcomes drop={drop} />
+      </div>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Outcome" }));
+
+    expect(parentClickHandler).not.toHaveBeenCalled();
+    expect(
+      screen.getByTestId("tooltip-wave-outcomes-drop-1")
+    ).toHaveAttribute(
+      "data-open-events",
+      JSON.stringify({ click: true, focus: true })
+    );
+    expect(
+      screen.getByTestId("tooltip-wave-outcomes-drop-1")
+    ).toHaveAttribute(
+      "data-close-events",
+      JSON.stringify({ click: true, blur: true })
+    );
+    expect(
+      screen.getByTestId("tooltip-wave-outcomes-drop-1")
+    ).toHaveAttribute(
+      "data-global-close-events",
+      JSON.stringify({ clickOutsideAnchor: true })
+    );
   });
 });

--- a/__tests__/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes.test.tsx
+++ b/__tests__/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes.test.tsx
@@ -136,4 +136,24 @@ describe("WaveSmallLeaderboardItemOutcomes", () => {
       JSON.stringify({ clickOutsideAnchor: true })
     );
   });
+
+  it("lets clicks bubble when hover tooltip mode is active", () => {
+    const parentClickHandler = jest.fn();
+    mockUseWaveRankReward.mockReturnValue({
+      nicTotal: 10,
+      repTotal: 0,
+      manualOutcomes: [],
+      isLoading: false,
+    });
+
+    render(
+      <div onClick={parentClickHandler}>
+        <WaveSmallLeaderboardItemOutcomes drop={drop} />
+      </div>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Outcome" }));
+
+    expect(parentClickHandler).toHaveBeenCalledTimes(1);
+  });
 });

--- a/__tests__/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes.test.tsx
+++ b/__tests__/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes.test.tsx
@@ -25,7 +25,7 @@ describe('WaveSmallLeaderboardItemOutcomes', () => {
 
     render(<WaveSmallLeaderboardItemOutcomes drop={drop} />);
     expect(screen.getByRole('button')).toBeInTheDocument();
-    expect(screen.getByText('Outcome:')).toBeInTheDocument();
+    expect(screen.getByText('Outcome')).toBeInTheDocument();
   });
 
   it('hides when no outcomes and not loading', () => {

--- a/__tests__/components/waves/winners/WaveWinnersSmallOutcome.test.tsx
+++ b/__tests__/components/waves/winners/WaveWinnersSmallOutcome.test.tsx
@@ -1,416 +1,159 @@
-import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { WaveWinnersSmallOutcome } from '@/components/waves/winners/WaveWinnersSmallOutcome';
-import type { ApiWave } from '@/generated/models/ApiWave';
-import type { ExtendedDrop } from '@/helpers/waves/drop.helpers';
+import { fireEvent, render, screen } from "@testing-library/react";
+import { WaveWinnersSmallOutcome } from "@/components/waves/winners/WaveWinnersSmallOutcome";
+import useWaveOutcomeTooltipInteraction from "@/components/waves/outcome/useWaveOutcomeTooltipInteraction";
+import { useWaveRankReward } from "@/hooks/waves/useWaveRankReward";
+import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 
-// Mock external dependencies
-jest.mock('react-tooltip', () => ({
-  Tooltip: ({ children, id }: any) => (
-    <div data-testid={`tooltip-${id}`}>
+jest.mock("react-tooltip", () => ({
+  Tooltip: ({
+    children,
+    id,
+    openEvents,
+    closeEvents,
+    globalCloseEvents,
+  }: any) => (
+    <div
+      data-testid={`tooltip-${id}`}
+      data-open-events={JSON.stringify(openEvents)}
+      data-close-events={JSON.stringify(closeEvents)}
+      data-global-close-events={JSON.stringify(globalCloseEvents)}
+    >
       {children}
     </div>
   ),
 }));
 
-jest.mock('@/hooks/drops/useDropOutcomes', () => ({
-  useDropOutcomes: jest.fn(),
+jest.mock("@/components/waves/outcome/useWaveOutcomeTooltipInteraction");
+jest.mock("@/hooks/waves/useWaveRankReward");
+jest.mock("@/helpers/Helpers", () => ({
+  formatNumberWithCommas: jest.fn((num: number) => num.toLocaleString("en-US")),
 }));
 
-jest.mock('@/helpers/Helpers', () => ({
-  formatNumberWithCommas: jest.fn((num) => num.toLocaleString('en-US')),
-}));
+const useWaveOutcomeTooltipInteractionMock =
+  useWaveOutcomeTooltipInteraction as jest.Mock;
+const useWaveRankRewardMock = useWaveRankReward as jest.Mock;
 
-import { useDropOutcomes } from '@/hooks/drops/useDropOutcomes';
+const drop = {
+  id: "drop-123",
+  rank: 7,
+  wave: { id: "wave-123" },
+} as ExtendedDrop;
 
-const mockedUseDropOutcomes = useDropOutcomes as jest.Mock;
+function mockTooltipInteraction(useClickActivation = false) {
+  useWaveOutcomeTooltipInteractionMock.mockReturnValue({
+    useClickActivation,
+    tooltipOpenEvents: useClickActivation
+      ? { click: true, focus: true }
+      : { mouseenter: true, focus: true },
+    tooltipCloseEvents: useClickActivation
+      ? { click: true, blur: true }
+      : { mouseleave: true, blur: true },
+    tooltipGlobalCloseEvents: useClickActivation
+      ? { clickOutsideAnchor: true }
+      : {},
+  });
+}
 
-describe('WaveWinnersSmallOutcome', () => {
-  const mockWave: ApiWave = {
-    id: 'wave-123',
-    name: 'Test Wave',
-    description_drop: null,
-    outcomes: [],
-    voting_credit_type: 'TDH',
-    created_at: Date.now(),
-    updated_at: Date.now(),
-  };
-
-  const mockDrop: ExtendedDrop = {
-    id: 'drop-123',
-    serial_no: 1,
-    wave: mockWave,
-    author: {
-      id: 'author-123',
-      handle: 'testauthor',
-      normalised_handle: 'testauthor',
-      primary_wallet: '0x123',
-      pfp: null,
-      cic: { rating: 100, contributor_count: 5 },
-      rep: { rating: 200, contributor_count: 10 },
-      tdh: 1000,
-      level: 5,
-      classification: 'HUMAN',
-      sub_classification: null,
-      created_at: Date.now(),
-    },
-    parts: [],
-    referenced_nfts: [],
-    mentioned_users: [],
-    metadata: [],
-    created_at: Date.now(),
-    updated_at: Date.now(),
-  };
-
-  const mockOutcomesWithNIC = {
-    nicOutcomes: [{ value: 1000 }, { value: 500 }],
-    repOutcomes: [],
-    manualOutcomes: [],
-  };
-
-  const mockOutcomesWithRep = {
-    nicOutcomes: [],
-    repOutcomes: [
-      { value: 200, category: 'Art' },
-      { value: 150, category: 'Music' },
-    ],
-    manualOutcomes: [],
-  };
-
-  const mockOutcomesWithManual = {
-    nicOutcomes: [],
-    repOutcomes: [],
-    manualOutcomes: [
-      { description: 'Special Award' },
-      { description: 'Community Choice' },
-    ],
-  };
-
-  const mockMixedOutcomes = {
-    nicOutcomes: [{ value: 750 }],
-    repOutcomes: [{ value: 100, category: 'Innovation' }],
-    manualOutcomes: [{ description: 'Breakthrough' }],
-  };
-
+describe("WaveWinnersSmallOutcome", () => {
   beforeEach(() => {
-    jest.clearAllMocks();
-    
-    // Mock touch detection
-    Object.defineProperty(window, 'ontouchstart', {
-      writable: true,
-      value: undefined,
+    mockTooltipInteraction();
+    useWaveRankRewardMock.mockReturnValue({
+      nicTotal: 0,
+      repTotal: 0,
+      manualOutcomes: [],
     });
   });
 
-  it('returns null when there are no outcomes', () => {
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: {
-        nicOutcomes: [],
-        repOutcomes: [],
-        manualOutcomes: [],
-      },
-      haveOutcomes: false,
-    });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
-    const { container } = render(
-      <WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />
-    );
+  it("returns null when there are no outcomes", () => {
+    const { container } = render(<WaveWinnersSmallOutcome drop={drop} />);
 
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders outcome button when outcomes exist', () => {
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: mockOutcomesWithNIC,
-      haveOutcomes: true,
+  it("renders outcome details from rank rewards", () => {
+    useWaveRankRewardMock.mockReturnValue({
+      nicTotal: 1234,
+      repTotal: 56,
+      manualOutcomes: ["Special Award"],
     });
 
-    render(<WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />);
+    render(<WaveWinnersSmallOutcome drop={drop} />);
 
-    expect(screen.getByRole('button')).toBeInTheDocument();
-    expect(screen.getByText('Outcome:')).toBeInTheDocument();
+    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(screen.getByText("Outcome:")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("tooltip-outcome-small-drop-123")
+    ).toHaveAttribute(
+      "data-open-events",
+      JSON.stringify({ mouseenter: true, focus: true })
+    );
+    expect(screen.getByText("Outcome Details")).toBeInTheDocument();
+    expect(screen.getByText("1,234")).toBeInTheDocument();
+    expect(screen.getByText("56")).toBeInTheDocument();
+    expect(screen.getByText("Special Award")).toBeInTheDocument();
   });
 
-  it('displays NIC icon when NIC outcomes exist', () => {
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: mockOutcomesWithNIC,
-      haveOutcomes: true,
-    });
-
-    render(<WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />);
-
-    // Check for NIC icon (should have specific path for document icon)
-    const nicIcon = document.querySelector('svg[class*="tw-text-[#A4C2DB]"]');
-    expect(nicIcon).toBeInTheDocument();
-  });
-
-  it('displays Rep icon when Rep outcomes exist', () => {
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: mockOutcomesWithRep,
-      haveOutcomes: true,
-    });
-
-    render(<WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />);
-
-    // Check for Rep icon (should have specific path for star icon)
-    const repIcon = document.querySelector('svg[class*="tw-text-[#C3B5D9]"]');
-    expect(repIcon).toBeInTheDocument();
-  });
-
-  it('displays Manual icon when manual outcomes exist', () => {
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: mockOutcomesWithManual,
-      haveOutcomes: true,
-    });
-
-    render(<WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />);
-
-    // Check for Manual icon (should have specific path for badge icon)
-    const manualIcon = document.querySelector('svg[class*="tw-text-[#D4C5AA]"]');
-    expect(manualIcon).toBeInTheDocument();
-  });
-
-  it('displays multiple icons when multiple outcome types exist', () => {
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: mockMixedOutcomes,
-      haveOutcomes: true,
-    });
-
-    render(<WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />);
-
-    const nicIcon = document.querySelector('svg[class*="tw-text-[#A4C2DB]"]');
-    const repIcon = document.querySelector('svg[class*="tw-text-[#C3B5D9]"]');
-    const manualIcon = document.querySelector('svg[class*="tw-text-[#D4C5AA]"]');
-
-    expect(nicIcon).toBeInTheDocument();
-    expect(repIcon).toBeInTheDocument();
-    expect(manualIcon).toBeInTheDocument();
-  });
-
-  it('shows tooltip content with NIC outcomes', () => {
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: mockOutcomesWithNIC,
-      haveOutcomes: true,
-    });
-
-    render(<WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />);
-
-    expect(screen.getByTestId('tooltip-outcome-small-drop-123')).toBeInTheDocument();
-    expect(screen.getByText('Outcome Details')).toBeInTheDocument();
-    expect(screen.getAllByText('NIC')).toHaveLength(2);
-    expect(screen.getByText('1,000')).toBeInTheDocument();
-    expect(screen.getByText('500')).toBeInTheDocument();
-  });
-
-  it('shows tooltip content with Rep outcomes', () => {
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: mockOutcomesWithRep,
-      haveOutcomes: true,
-    });
-
-    render(<WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />);
-
-    expect(screen.getByTestId('tooltip-outcome-small-drop-123')).toBeInTheDocument();
-    expect(screen.getAllByText('Rep')).toHaveLength(2);
-    expect(screen.getByText('200')).toBeInTheDocument();
-    expect(screen.getByText('150')).toBeInTheDocument();
-    expect(screen.getByText('Art')).toBeInTheDocument();
-    expect(screen.getByText('Music')).toBeInTheDocument();
-  });
-
-  it('shows tooltip content with manual outcomes', () => {
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: mockOutcomesWithManual,
-      haveOutcomes: true,
-    });
-
-    render(<WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />);
-
-    expect(screen.getByTestId('tooltip-outcome-small-drop-123')).toBeInTheDocument();
-    expect(screen.getByText('Special Award')).toBeInTheDocument();
-    expect(screen.getByText('Community Choice')).toBeInTheDocument();
-  });
-
-  it('detects touch device and handles touch interactions', () => {
-    // Mock touch device
-    Object.defineProperty(window, 'ontouchstart', {
-      writable: true,
-      value: true,
-    });
-
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: mockOutcomesWithNIC,
-      haveOutcomes: true,
-    });
-
-    render(<WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />);
-
-    const button = screen.getByRole('button');
-    
-    // Button should be rendered (tooltip is always rendered with react-tooltip)
-    expect(button).toBeInTheDocument();
-    expect(screen.getByTestId('tooltip-outcome-small-drop-123')).toBeInTheDocument();
-  });
-
-  it('stops event propagation on button click', () => {
+  it("uses click activation without bubbling when touch-style tooltip mode is active", () => {
     const parentClickHandler = jest.fn();
-    
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: mockOutcomesWithNIC,
-      haveOutcomes: true,
+    mockTooltipInteraction(true);
+    useWaveRankRewardMock.mockReturnValue({
+      nicTotal: 1,
+      repTotal: 0,
+      manualOutcomes: [],
     });
 
     render(
       <div onClick={parentClickHandler}>
-        <WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />
+        <WaveWinnersSmallOutcome drop={drop} />
       </div>
     );
 
-    const button = screen.getByRole('button');
-    fireEvent.click(button);
+    fireEvent.click(screen.getByRole("button"));
 
     expect(parentClickHandler).not.toHaveBeenCalled();
-  });
-
-  it('handles onClickOutside for tooltip', () => {
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: mockOutcomesWithNIC,
-      haveOutcomes: true,
-    });
-
-    render(<WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />);
-
-    const button = screen.getByRole('button');
-    fireEvent.click(button);
-
-    expect(screen.getByTestId('tooltip-outcome-small-drop-123')).toBeInTheDocument();
-
-    // With react-tooltip, the tooltip is always rendered
-    expect(screen.getByTestId('tooltip-outcome-small-drop-123')).toBeInTheDocument();
-  });
-
-  it('passes correct props to useDropOutcomes hook', () => {
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: mockOutcomesWithNIC,
-      haveOutcomes: true,
-    });
-
-    render(<WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />);
-
-    expect(mockedUseDropOutcomes).toHaveBeenCalledWith({
-      drop: mockDrop,
-      wave: mockWave,
-    });
-  });
-
-  it('formats numbers correctly in tooltip', () => {
-    const formatNumberWithCommas = require('@/helpers/Helpers').formatNumberWithCommas;
-    formatNumberWithCommas.mockImplementation((num: number) => num.toLocaleString('en-US'));
-
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: {
-        nicOutcomes: [{ value: 1234567 }],
-        repOutcomes: [],
-        manualOutcomes: [],
-      },
-      haveOutcomes: true,
-    });
-
-    render(<WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />);
-
-    expect(formatNumberWithCommas).toHaveBeenCalledWith(1234567);
-    expect(screen.getByText('1,234,567')).toBeInTheDocument();
-  });
-
-  it('handles mixed outcomes correctly in tooltip', () => {
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: mockMixedOutcomes,
-      haveOutcomes: true,
-    });
-
-    render(<WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />);
-
-    // Should show all outcome types in tooltip
-    expect(screen.getByText('NIC')).toBeInTheDocument();
-    expect(screen.getByText('Rep')).toBeInTheDocument();
-    expect(screen.getByText('Innovation')).toBeInTheDocument();
-    expect(screen.getByText('Breakthrough')).toBeInTheDocument();
-    expect(screen.getByText('750')).toBeInTheDocument();
-    expect(screen.getByText('100')).toBeInTheDocument();
-  });
-
-  it('has correct CSS classes for styling', () => {
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: mockOutcomesWithNIC,
-      haveOutcomes: true,
-    });
-
-    render(<WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />);
-
-    const button = screen.getByRole('button');
-    expect(button).toHaveClass(
-      'tw-border-0',
-      'tw-rounded-lg',
-      'tw-flex',
-      'tw-items-center',
-      'tw-gap-2',
-      'tw-min-w-6',
-      'tw-py-1.5',
-      'tw-px-2',
-      'tw-bg-iron-800',
-      'tw-ring-1',
-      'tw-ring-iron-700'
+    expect(
+      screen.getByTestId("tooltip-outcome-small-drop-123")
+    ).toHaveAttribute(
+      "data-open-events",
+      JSON.stringify({ click: true, focus: true })
     );
   });
 
-  it('updates touch state on component mount', async () => {
-    // Test with touch device
-    Object.defineProperty(window, 'ontouchstart', {
-      writable: true,
-      value: true,
+  it("lets clicks bubble when hover tooltip mode is active", () => {
+    const parentClickHandler = jest.fn();
+    useWaveRankRewardMock.mockReturnValue({
+      nicTotal: 1,
+      repTotal: 0,
+      manualOutcomes: [],
     });
 
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: mockOutcomesWithNIC,
-      haveOutcomes: true,
-    });
+    render(
+      <div onClick={parentClickHandler}>
+        <WaveWinnersSmallOutcome drop={drop} />
+      </div>
+    );
 
-    render(<WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />);
+    fireEvent.click(screen.getByRole("button"));
 
-    // The component should detect touch and handle interactions accordingly
-    const button = screen.getByRole('button');
-    fireEvent.click(button);
-    
-    // On touch devices, clicking should toggle tooltip visibility
-    expect(screen.getByTestId('tooltip-outcome-small-drop-123')).toBeInTheDocument();
+    expect(parentClickHandler).toHaveBeenCalledTimes(1);
   });
 
-  it('renders unique keys for outcome items', () => {
-    mockedUseDropOutcomes.mockReturnValue({
-      outcomes: {
-        nicOutcomes: [{ value: 100 }, { value: 200 }],
-        repOutcomes: [
-          { value: 50, category: 'Art' },
-          { value: 75, category: 'Music' },
-        ],
-        manualOutcomes: [
-          { description: 'Award 1' },
-          { description: 'Award 2' },
-        ],
-      },
-      haveOutcomes: true,
+  it("loads rewards for the drop wave and rank", () => {
+    useWaveRankRewardMock.mockReturnValue({
+      nicTotal: 1,
+      repTotal: 0,
+      manualOutcomes: [],
     });
 
-    render(<WaveWinnersSmallOutcome drop={mockDrop} wave={mockWave} />);
+    render(<WaveWinnersSmallOutcome drop={drop} />);
 
-    // All items should render without key conflicts
-    expect(screen.getByText('100')).toBeInTheDocument();
-    expect(screen.getByText('200')).toBeInTheDocument();
-    expect(screen.getByText('50')).toBeInTheDocument();
-    expect(screen.getByText('75')).toBeInTheDocument();
-    expect(screen.getByText('Art')).toBeInTheDocument();
-    expect(screen.getByText('Music')).toBeInTheDocument();
-    expect(screen.getByText('Award 1')).toBeInTheDocument();
-    expect(screen.getByText('Award 2')).toBeInTheDocument();
+    expect(useWaveRankRewardMock).toHaveBeenCalledWith({
+      waveId: "wave-123",
+      rank: 7,
+    });
   });
 });

--- a/__tests__/hooks/useDeviceInfo.test.ts
+++ b/__tests__/hooks/useDeviceInfo.test.ts
@@ -1,6 +1,6 @@
 import useDeviceInfo from "@/hooks/useDeviceInfo";
 import useInteractionMode from "@/src/interaction/useInteractionMode";
-import type { InteractionMode } from "@/src/interaction/useInteractionMode";
+import { createInteractionMode } from "@/__tests__/utils/interactionMode";
 import { act, renderHook } from "@testing-library/react";
 
 jest.mock("@/hooks/useCapacitor", () => ({
@@ -13,21 +13,10 @@ jest.mock("@/src/interaction/useInteractionMode");
 const capacitorMock = require("@/hooks/useCapacitor").default as jest.Mock;
 const useInteractionModeMock = useInteractionMode as jest.Mock;
 
-const DEFAULT_INTERACTION_MODE: InteractionMode = {
-  canHover: false,
-  hasFinePointer: false,
-  hasCoarsePointer: false,
-  hoverNone: false,
-  lastPointerType: null,
-  enableHoverUI: false,
-  enableLongPress: false,
-};
-
-function setInteractionMode(overrides: Partial<InteractionMode> = {}) {
-  useInteractionModeMock.mockReturnValue({
-    ...DEFAULT_INTERACTION_MODE,
-    ...overrides,
-  });
+function setInteractionMode(
+  overrides: Parameters<typeof createInteractionMode>[0] = {}
+) {
+  useInteractionModeMock.mockReturnValue(createInteractionMode(overrides));
 }
 
 function defineMatchMedia(width = false) {
@@ -121,7 +110,14 @@ describe("useDeviceInfo", () => {
     expect(result.current.hasTouchScreen).toBe(true);
   });
 
-  it("ignores navigator maxTouchPoints in favor of centralized interaction mode", () => {
+  it("ignores browser touch primitives in favor of centralized interaction mode", () => {
+    const touchStartDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "ontouchstart"
+    );
+    const globalWithTouchStart = globalThis as typeof globalThis & {
+      ontouchstart?: unknown;
+    };
     capacitorMock.mockReturnValue({ isCapacitor: false });
     Object.defineProperty(globalThis.navigator, "userAgent", {
       value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
@@ -131,13 +127,25 @@ describe("useDeviceInfo", () => {
       value: 5,
       configurable: true,
     });
+    Object.defineProperty(globalThis, "ontouchstart", {
+      value: jest.fn(),
+      configurable: true,
+    });
     setInteractionMode({ enableLongPress: false, hasCoarsePointer: false });
     defineMatchMedia(false);
 
-    const { result } = renderHook(() => useDeviceInfo());
+    try {
+      const { result } = renderHook(() => useDeviceInfo());
 
-    expect(result.current.hasTouchScreen).toBe(false);
-    expect(result.current.isAppleMobile).toBe(false);
-    expect(result.current.isMobileDevice).toBe(false);
+      expect(result.current.hasTouchScreen).toBe(false);
+      expect(result.current.isAppleMobile).toBe(false);
+      expect(result.current.isMobileDevice).toBe(false);
+    } finally {
+      if (touchStartDescriptor) {
+        Object.defineProperty(globalThis, "ontouchstart", touchStartDescriptor);
+      } else {
+        delete globalWithTouchStart.ontouchstart;
+      }
+    }
   });
 });

--- a/__tests__/hooks/useDeviceInfo.test.ts
+++ b/__tests__/hooks/useDeviceInfo.test.ts
@@ -1,5 +1,6 @@
 import useDeviceInfo from "@/hooks/useDeviceInfo";
 import useInteractionMode from "@/src/interaction/useInteractionMode";
+import type { InteractionMode } from "@/src/interaction/useInteractionMode";
 import { act, renderHook } from "@testing-library/react";
 
 jest.mock("@/hooks/useCapacitor", () => ({
@@ -12,16 +13,20 @@ jest.mock("@/src/interaction/useInteractionMode");
 const capacitorMock = require("@/hooks/useCapacitor").default as jest.Mock;
 const useInteractionModeMock = useInteractionMode as jest.Mock;
 
-function setInteractionMode({
-  enableLongPress = false,
-  hasCoarsePointer = false,
-}: {
-  readonly enableLongPress?: boolean | undefined;
-  readonly hasCoarsePointer?: boolean | undefined;
-} = {}) {
+const DEFAULT_INTERACTION_MODE: InteractionMode = {
+  canHover: false,
+  hasFinePointer: false,
+  hasCoarsePointer: false,
+  hoverNone: false,
+  lastPointerType: null,
+  enableHoverUI: false,
+  enableLongPress: false,
+};
+
+function setInteractionMode(overrides: Partial<InteractionMode> = {}) {
   useInteractionModeMock.mockReturnValue({
-    enableLongPress,
-    hasCoarsePointer,
+    ...DEFAULT_INTERACTION_MODE,
+    ...overrides,
   });
 }
 
@@ -114,5 +119,25 @@ describe("useDeviceInfo", () => {
     });
 
     expect(result.current.hasTouchScreen).toBe(true);
+  });
+
+  it("ignores navigator maxTouchPoints in favor of centralized interaction mode", () => {
+    capacitorMock.mockReturnValue({ isCapacitor: false });
+    Object.defineProperty(globalThis.navigator, "userAgent", {
+      value: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+      configurable: true,
+    });
+    Object.defineProperty(globalThis.navigator, "maxTouchPoints", {
+      value: 5,
+      configurable: true,
+    });
+    setInteractionMode({ enableLongPress: false, hasCoarsePointer: false });
+    defineMatchMedia(false);
+
+    const { result } = renderHook(() => useDeviceInfo());
+
+    expect(result.current.hasTouchScreen).toBe(false);
+    expect(result.current.isAppleMobile).toBe(false);
+    expect(result.current.isMobileDevice).toBe(false);
   });
 });

--- a/__tests__/hooks/useDeviceInfo.test.ts
+++ b/__tests__/hooks/useDeviceInfo.test.ts
@@ -1,55 +1,49 @@
 import useDeviceInfo from "@/hooks/useDeviceInfo";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 import { act, renderHook } from "@testing-library/react";
 
 jest.mock("@/hooks/useCapacitor", () => ({
   __esModule: true,
   default: jest.fn(() => ({ isCapacitor: false })),
 }));
+
+jest.mock("@/src/interaction/useInteractionMode");
+
 const capacitorMock = require("@/hooks/useCapacitor").default as jest.Mock;
+const useInteractionModeMock = useInteractionMode as jest.Mock;
 
-let touchStartHandler: EventListener | null = null;
+function setInteractionMode({
+  enableLongPress = false,
+  hasCoarsePointer = false,
+}: {
+  readonly enableLongPress?: boolean | undefined;
+  readonly hasCoarsePointer?: boolean | undefined;
+} = {}) {
+  useInteractionModeMock.mockReturnValue({
+    enableLongPress,
+    hasCoarsePointer,
+  });
+}
 
-function defineMatchMedia(pointerFine = true, width = false) {
+function defineMatchMedia(width = false) {
   Object.defineProperty(globalThis, "matchMedia", {
     writable: true,
-    value: jest.fn((query: string) => {
-      if (query === "(pointer: fine)") {
-        return {
-          matches: pointerFine,
-          addEventListener: jest.fn(),
-          removeEventListener: jest.fn(),
-        };
-      }
-      if (query === "(max-width: 768px)") {
-        return {
-          matches: width,
-          addEventListener: jest.fn(),
-          removeEventListener: jest.fn(),
-        };
-      }
-      return {
-        matches: false,
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-      };
-    }),
+    value: jest.fn((query: string) => ({
+      matches: query === "(max-width: 768px)" ? width : false,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    })),
   });
 }
 
 describe("useDeviceInfo", () => {
   beforeEach(() => {
-    jest
-      .spyOn(globalThis, "addEventListener")
-      .mockImplementation((event, handler) => {
-        if (event === "touchstart") {
-          touchStartHandler = handler as EventListener;
-        }
-      });
-    jest.spyOn(globalThis, "removeEventListener");
+    setInteractionMode();
+    jest.spyOn(globalThis, "addEventListener").mockImplementation(jest.fn());
+    jest.spyOn(globalThis, "removeEventListener").mockImplementation(jest.fn());
   });
 
   afterEach(() => {
-    touchStartHandler = null;
     jest.restoreAllMocks();
     capacitorMock.mockReturnValue({ isCapacitor: false });
   });
@@ -59,12 +53,11 @@ describe("useDeviceInfo", () => {
       value: "iPhone",
       configurable: true,
     });
-    Object.defineProperty(globalThis.navigator, "maxTouchPoints", {
-      value: 5,
-      configurable: true,
-    });
-    defineMatchMedia(false, false);
+    setInteractionMode({ enableLongPress: true, hasCoarsePointer: true });
+    defineMatchMedia(false);
+
     const { result } = renderHook(() => useDeviceInfo());
+
     expect(result.current.isMobileDevice).toBe(true);
     expect(result.current.isAppleMobile).toBe(true);
     expect(result.current.isApp).toBe(false);
@@ -77,71 +70,49 @@ describe("useDeviceInfo", () => {
       value: "Macintosh",
       configurable: true,
     });
-    Object.defineProperty(globalThis.navigator, "maxTouchPoints", {
-      value: 5,
-      configurable: true,
-    });
-    defineMatchMedia(false, true);
+    setInteractionMode({ enableLongPress: true, hasCoarsePointer: true });
+    defineMatchMedia(true);
+
     const { result } = renderHook(() => useDeviceInfo());
+
     expect(result.current.isMobileDevice).toBe(true);
     expect(result.current.isApp).toBe(true);
     expect(result.current.isAppleMobile).toBe(true);
     expect(result.current.hasTouchScreen).toBe(true);
   });
 
-  it("returns false for desktop without touch", () => {
+  it("returns false for desktop without touch activation", () => {
     capacitorMock.mockReturnValue({ isCapacitor: false });
     Object.defineProperty(globalThis.navigator, "userAgent", {
       value: "Mozilla/5.0",
       configurable: true,
     });
-    Object.defineProperty(globalThis.navigator, "maxTouchPoints", {
-      value: 0,
-      configurable: true,
-    });
-    defineMatchMedia(true, false);
+    setInteractionMode({ enableLongPress: false, hasCoarsePointer: false });
+    defineMatchMedia(false);
+
     const { result } = renderHook(() => useDeviceInfo());
+
     expect(result.current.isMobileDevice).toBe(false);
     expect(result.current.hasTouchScreen).toBe(false);
     expect(result.current.isAppleMobile).toBe(false);
   });
 
-  it("hasTouchScreen becomes true on hybrid device after touch even with fine pointer", () => {
-    capacitorMock.mockReturnValue({ isCapacitor: false });
+  it("updates hasTouchScreen from centralized interaction mode", () => {
     Object.defineProperty(globalThis.navigator, "userAgent", {
       value: "Mozilla/5.0",
       configurable: true,
     });
-    Object.defineProperty(globalThis.navigator, "maxTouchPoints", {
-      value: 0,
-      configurable: true,
-    });
-    defineMatchMedia(true, false);
-    const { result } = renderHook(() => useDeviceInfo());
+    setInteractionMode({ enableLongPress: false, hasCoarsePointer: true });
+    defineMatchMedia(false);
 
+    const { result, rerender } = renderHook(() => useDeviceInfo());
     expect(result.current.hasTouchScreen).toBe(false);
 
     act(() => {
-      if (touchStartHandler) {
-        touchStartHandler(new Event("touchstart"));
-      }
+      setInteractionMode({ enableLongPress: true, hasCoarsePointer: true });
+      rerender();
     });
 
-    expect(result.current.hasTouchScreen).toBe(true);
-  });
-
-  it("hasTouchScreen is true when maxTouchPoints > 0 even without touch event", () => {
-    capacitorMock.mockReturnValue({ isCapacitor: false });
-    Object.defineProperty(globalThis.navigator, "userAgent", {
-      value: "Mozilla/5.0",
-      configurable: true,
-    });
-    Object.defineProperty(globalThis.navigator, "maxTouchPoints", {
-      value: 5,
-      configurable: true,
-    });
-    defineMatchMedia(true, false);
-    const { result } = renderHook(() => useDeviceInfo());
     expect(result.current.hasTouchScreen).toBe(true);
   });
 });

--- a/__tests__/hooks/useIsTouchDevice.test.ts
+++ b/__tests__/hooks/useIsTouchDevice.test.ts
@@ -1,27 +1,16 @@
 import { renderHook } from "@testing-library/react";
 import useIsTouchDevice from "@/hooks/useIsTouchDevice";
 import useInteractionMode from "@/src/interaction/useInteractionMode";
-import type { InteractionMode } from "@/src/interaction/useInteractionMode";
+import { createInteractionMode } from "@/__tests__/utils/interactionMode";
 
 jest.mock("@/src/interaction/useInteractionMode");
 
 const useInteractionModeMock = useInteractionMode as jest.Mock;
 
-const DEFAULT_INTERACTION_MODE: InteractionMode = {
-  canHover: false,
-  hasFinePointer: false,
-  hasCoarsePointer: false,
-  hoverNone: false,
-  lastPointerType: null,
-  enableHoverUI: false,
-  enableLongPress: false,
-};
-
-function setInteractionMode(overrides: Partial<InteractionMode> = {}) {
-  useInteractionModeMock.mockReturnValue({
-    ...DEFAULT_INTERACTION_MODE,
-    ...overrides,
-  });
+function setInteractionMode(
+  overrides: Parameters<typeof createInteractionMode>[0] = {}
+) {
+  useInteractionModeMock.mockReturnValue(createInteractionMode(overrides));
 }
 
 describe("useIsTouchDevice", () => {

--- a/__tests__/hooks/useIsTouchDevice.test.ts
+++ b/__tests__/hooks/useIsTouchDevice.test.ts
@@ -1,14 +1,32 @@
 import { renderHook } from "@testing-library/react";
 import useIsTouchDevice from "@/hooks/useIsTouchDevice";
 import useInteractionMode from "@/src/interaction/useInteractionMode";
+import type { InteractionMode } from "@/src/interaction/useInteractionMode";
 
 jest.mock("@/src/interaction/useInteractionMode");
 
 const useInteractionModeMock = useInteractionMode as jest.Mock;
 
+const DEFAULT_INTERACTION_MODE: InteractionMode = {
+  canHover: false,
+  hasFinePointer: false,
+  hasCoarsePointer: false,
+  hoverNone: false,
+  lastPointerType: null,
+  enableHoverUI: false,
+  enableLongPress: false,
+};
+
+function setInteractionMode(overrides: Partial<InteractionMode> = {}) {
+  useInteractionModeMock.mockReturnValue({
+    ...DEFAULT_INTERACTION_MODE,
+    ...overrides,
+  });
+}
+
 describe("useIsTouchDevice", () => {
   beforeEach(() => {
-    useInteractionModeMock.mockReturnValue({ enableLongPress: false });
+    setInteractionMode();
   });
 
   afterEach(() => {
@@ -22,7 +40,10 @@ describe("useIsTouchDevice", () => {
   });
 
   it("returns true when touch activation is enabled", () => {
-    useInteractionModeMock.mockReturnValue({ enableLongPress: true });
+    setInteractionMode({
+      enableLongPress: true,
+      hasCoarsePointer: true,
+    });
 
     const { result } = renderHook(() => useIsTouchDevice());
 

--- a/__tests__/hooks/useIsTouchDevice.test.ts
+++ b/__tests__/hooks/useIsTouchDevice.test.ts
@@ -1,137 +1,31 @@
-import { renderHook, act } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
 import useIsTouchDevice from "@/hooks/useIsTouchDevice";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
+
+jest.mock("@/src/interaction/useInteractionMode");
+
+const useInteractionModeMock = useInteractionMode as jest.Mock;
 
 describe("useIsTouchDevice", () => {
-  let addEventListenerSpy: jest.SpyInstance;
-  let removeEventListenerSpy: jest.SpyInstance;
-  let touchStartHandler: EventListener | null = null;
-  let originalMaxTouchPoints: number | undefined;
-
   beforeEach(() => {
-    originalMaxTouchPoints = (globalThis.navigator as Navigator | undefined)?.maxTouchPoints;
-    addEventListenerSpy = jest.spyOn(globalThis, "addEventListener").mockImplementation((event, handler) => {
-      if (event === "touchstart") {
-        touchStartHandler = handler as EventListener;
-      }
-    });
-    removeEventListenerSpy = jest.spyOn(globalThis, "removeEventListener");
+    useInteractionModeMock.mockReturnValue({ enableLongPress: false });
   });
 
   afterEach(() => {
-    addEventListenerSpy.mockRestore();
-    removeEventListenerSpy.mockRestore();
-    touchStartHandler = null;
-    if (typeof originalMaxTouchPoints === "number") {
-      Object.defineProperty(globalThis.navigator, "maxTouchPoints", {
-        value: originalMaxTouchPoints,
-        configurable: true,
-      });
-    } else {
-      // Ensure tests don't leak touch points across cases.
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-        delete (globalThis.navigator as any).maxTouchPoints;
-      } catch {
-        // ignore
-      }
-    }
-    jest.restoreAllMocks();
+    jest.resetAllMocks();
   });
 
-  it("returns false initially when fine pointer is detected", () => {
-    Object.defineProperty(globalThis, "matchMedia", {
-      writable: true,
-      value: jest.fn((query: string) => ({
-        matches: query === "(pointer: fine)",
-      })),
-    });
-
+  it("returns false when touch activation is disabled", () => {
     const { result } = renderHook(() => useIsTouchDevice());
+
     expect(result.current).toBe(false);
   });
 
-  it("returns false initially and does not listen for touch when fine pointer exists", () => {
-    Object.defineProperty(globalThis, "matchMedia", {
-      writable: true,
-      value: jest.fn((query: string) => ({
-        matches: query === "(pointer: fine)",
-      })),
-    });
-
-    renderHook(() => useIsTouchDevice());
-    expect(addEventListenerSpy).not.toHaveBeenCalledWith("touchstart", expect.any(Function), expect.any(Object));
-  });
-
-  it("returns true initially when maxTouchPoints > 0 and no fine pointer", () => {
-    Object.defineProperty(globalThis.navigator, "maxTouchPoints", { value: 10, configurable: true });
-    Object.defineProperty(globalThis, "matchMedia", {
-      writable: true,
-      value: jest.fn(() => ({ matches: false })),
-    });
+  it("returns true when touch activation is enabled", () => {
+    useInteractionModeMock.mockReturnValue({ enableLongPress: true });
 
     const { result } = renderHook(() => useIsTouchDevice());
-    expect(result.current).toBe(true);
-    expect(addEventListenerSpy).not.toHaveBeenCalledWith("touchstart", expect.any(Function), expect.any(Object));
-  });
-
-  it("returns false when a fine pointer exists even if maxTouchPoints > 0", () => {
-    Object.defineProperty(globalThis.navigator, "maxTouchPoints", { value: 10, configurable: true });
-    Object.defineProperty(globalThis, "matchMedia", {
-      writable: true,
-      value: jest.fn((query: string) => ({
-        matches: query === "(any-pointer: fine)",
-      })),
-    });
-
-    const { result } = renderHook(() => useIsTouchDevice());
-    expect(result.current).toBe(false);
-    expect(addEventListenerSpy).not.toHaveBeenCalledWith("touchstart", expect.any(Function), expect.any(Object));
-  });
-
-  it("returns false initially but switches to true after touchstart when no fine pointer", () => {
-    Object.defineProperty(globalThis, "matchMedia", {
-      writable: true,
-      value: jest.fn(() => ({ matches: false })),
-    });
-
-    const { result } = renderHook(() => useIsTouchDevice());
-    expect(result.current).toBe(false);
-
-    act(() => {
-      if (touchStartHandler) {
-        touchStartHandler(new Event("touchstart"));
-      }
-    });
 
     expect(result.current).toBe(true);
-  });
-
-  it("removes touchstart listener after first touch", () => {
-    Object.defineProperty(globalThis, "matchMedia", {
-      writable: true,
-      value: jest.fn(() => ({ matches: false })),
-    });
-
-    renderHook(() => useIsTouchDevice());
-
-    act(() => {
-      if (touchStartHandler) {
-        touchStartHandler(new Event("touchstart"));
-      }
-    });
-
-    expect(removeEventListenerSpy).toHaveBeenCalledWith("touchstart", expect.any(Function));
-  });
-
-  it("cleans up event listener on unmount", () => {
-    Object.defineProperty(globalThis, "matchMedia", {
-      writable: true,
-      value: jest.fn(() => ({ matches: false })),
-    });
-
-    const { unmount } = renderHook(() => useIsTouchDevice());
-    unmount();
-
-    expect(removeEventListenerSpy).toHaveBeenCalledWith("touchstart", expect.any(Function));
   });
 });

--- a/__tests__/src/interaction/useInteractionMode.test.ts
+++ b/__tests__/src/interaction/useInteractionMode.test.ts
@@ -1,0 +1,214 @@
+import { act, renderHook } from "@testing-library/react";
+import useInteractionMode, {
+  deriveInteractionMode,
+  type InteractionModeState,
+} from "@/src/interaction/useInteractionMode";
+
+const DEFAULT_STATE: InteractionModeState = {
+  canHover: false,
+  hasFinePointer: false,
+  hasCoarsePointer: false,
+  hoverNone: false,
+  lastPointerType: null,
+};
+
+type ChangeListener = (event: MediaQueryListEvent) => void;
+
+function createPointerEvent(pointerType: string): Event {
+  const event = new Event("pointerdown");
+  Object.defineProperty(event, "pointerType", { value: pointerType });
+  return event;
+}
+
+function installMatchMedia(initialMatches: Record<string, boolean>) {
+  const matches = new Map(Object.entries(initialMatches));
+  const listeners = new Map<string, Set<ChangeListener>>();
+  const mediaQueries: Array<
+    MediaQueryList & {
+      addEventListener: jest.Mock;
+      removeEventListener: jest.Mock;
+    }
+  > = [];
+
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: jest.fn((query: string) => {
+      const queryListeners = listeners.get(query) ?? new Set<ChangeListener>();
+      listeners.set(query, queryListeners);
+
+      const mediaQuery = {
+        media: query,
+        get matches() {
+          return matches.get(query) ?? false;
+        },
+        addEventListener: jest.fn((event: string, listener: ChangeListener) => {
+          if (event === "change") {
+            queryListeners.add(listener);
+          }
+        }),
+        removeEventListener: jest.fn(
+          (event: string, listener: ChangeListener) => {
+            if (event === "change") {
+              queryListeners.delete(listener);
+            }
+          }
+        ),
+      } as unknown as MediaQueryList & {
+        addEventListener: jest.Mock;
+        removeEventListener: jest.Mock;
+      };
+
+      mediaQueries.push(mediaQuery);
+      return mediaQuery;
+    }),
+  });
+
+  const setMatches = (query: string, value: boolean) => {
+    matches.set(query, value);
+    const event = { matches: value, media: query } as MediaQueryListEvent;
+    listeners.get(query)?.forEach((listener) => listener(event));
+  };
+
+  return { mediaQueries, setMatches };
+}
+
+describe("deriveInteractionMode", () => {
+  it("keeps hover UI and long-press activation independent on hybrid devices", () => {
+    expect(
+      deriveInteractionMode({
+        ...DEFAULT_STATE,
+        canHover: true,
+        hasFinePointer: true,
+      })
+    ).toMatchObject({
+      enableHoverUI: true,
+      enableLongPress: false,
+    });
+
+    expect(
+      deriveInteractionMode({
+        ...DEFAULT_STATE,
+        canHover: true,
+        hasFinePointer: true,
+        lastPointerType: "touch",
+      })
+    ).toMatchObject({
+      enableHoverUI: true,
+      enableLongPress: true,
+    });
+  });
+
+  it("enables touch activation when the primary input cannot hover", () => {
+    expect(
+      deriveInteractionMode({
+        ...DEFAULT_STATE,
+        hoverNone: true,
+        hasCoarsePointer: true,
+      })
+    ).toMatchObject({
+      enableHoverUI: false,
+      enableLongPress: true,
+      hasCoarsePointer: true,
+    });
+  });
+});
+
+describe("useInteractionMode", () => {
+  let addEventListenerSpy: jest.SpyInstance;
+  let removeEventListenerSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    addEventListenerSpy = jest.spyOn(window, "addEventListener");
+    removeEventListenerSpy = jest.spyOn(window, "removeEventListener");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("updates derivations from media query and pointer events", () => {
+    const { setMatches } = installMatchMedia({
+      "(any-hover: hover)": true,
+      "(any-pointer: fine)": true,
+      "(pointer: coarse)": false,
+      "(hover: none)": false,
+    });
+
+    const { result, unmount } = renderHook(() => useInteractionMode());
+
+    expect(result.current.enableHoverUI).toBe(true);
+    expect(result.current.enableLongPress).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(createPointerEvent("touch"));
+    });
+
+    expect(result.current.lastPointerType).toBe("touch");
+    expect(result.current.enableHoverUI).toBe(true);
+    expect(result.current.enableLongPress).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(createPointerEvent("mouse"));
+    });
+
+    expect(result.current.lastPointerType).toBe("mouse");
+    expect(result.current.enableLongPress).toBe(false);
+
+    act(() => {
+      setMatches("(hover: none)", true);
+      setMatches("(pointer: coarse)", true);
+    });
+
+    expect(result.current.hoverNone).toBe(true);
+    expect(result.current.hasCoarsePointer).toBe(true);
+    expect(result.current.enableLongPress).toBe(true);
+
+    unmount();
+  });
+
+  it("tears down and re-initializes after the last subscriber unmounts", () => {
+    const firstMedia = installMatchMedia({
+      "(any-hover: hover)": true,
+      "(any-pointer: fine)": true,
+      "(pointer: coarse)": false,
+      "(hover: none)": false,
+    });
+
+    const first = renderHook(() => useInteractionMode());
+    expect(first.result.current.enableHoverUI).toBe(true);
+
+    first.unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "pointerdown",
+      expect.any(Function),
+      expect.any(Object)
+    );
+    expect(
+      firstMedia.mediaQueries.filter(
+        (query) => query.removeEventListener.mock.calls.length > 0
+      )
+    ).toHaveLength(4);
+
+    const secondMedia = installMatchMedia({
+      "(any-hover: hover)": false,
+      "(any-pointer: fine)": false,
+      "(pointer: coarse)": true,
+      "(hover: none)": true,
+    });
+
+    const second = renderHook(() => useInteractionMode());
+
+    expect(second.result.current.enableHoverUI).toBe(false);
+    expect(second.result.current.enableLongPress).toBe(true);
+    expect(second.result.current.hasCoarsePointer).toBe(true);
+    expect(secondMedia.mediaQueries).toHaveLength(8);
+    expect(addEventListenerSpy).toHaveBeenCalledWith(
+      "pointerdown",
+      expect.any(Function),
+      expect.any(Object)
+    );
+
+    second.unmount();
+  });
+});

--- a/__tests__/src/interaction/useInteractionMode.test.ts
+++ b/__tests__/src/interaction/useInteractionMode.test.ts
@@ -12,6 +12,13 @@ const DEFAULT_STATE: InteractionModeState = {
   lastPointerType: null,
 };
 
+const INTERACTION_MEDIA_QUERIES = [
+  "(any-hover: hover)",
+  "(any-pointer: fine)",
+  "(pointer: coarse)",
+  "(hover: none)",
+];
+
 type ChangeListener = (event: MediaQueryListEvent) => void;
 
 function createPointerEvent(pointerType: string): Event {
@@ -179,16 +186,23 @@ describe("useInteractionMode", () => {
 
     first.unmount();
 
-    expect(removeEventListenerSpy).toHaveBeenCalledWith(
-      "pointerdown",
-      expect.any(Function),
-      expect.any(Object)
-    );
     expect(
-      firstMedia.mediaQueries.filter(
-        (query) => query.removeEventListener.mock.calls.length > 0
+      removeEventListenerSpy.mock.calls.some(
+        ([eventName]) => eventName === "pointerdown"
       )
-    ).toHaveLength(4);
+    ).toBe(true);
+    expect(
+      removeEventListenerSpy.mock.calls.some(
+        ([eventName]) => eventName === "pointermove"
+      )
+    ).toBe(true);
+    expect(
+      new Set(
+        firstMedia.mediaQueries
+          .filter((query) => query.removeEventListener.mock.calls.length > 0)
+          .map((query) => query.media)
+      )
+    ).toEqual(new Set(INTERACTION_MEDIA_QUERIES));
 
     const secondMedia = installMatchMedia({
       "(any-hover: hover)": false,
@@ -202,12 +216,23 @@ describe("useInteractionMode", () => {
     expect(second.result.current.enableHoverUI).toBe(false);
     expect(second.result.current.enableLongPress).toBe(true);
     expect(second.result.current.hasCoarsePointer).toBe(true);
-    expect(secondMedia.mediaQueries).toHaveLength(8);
-    expect(addEventListenerSpy).toHaveBeenCalledWith(
-      "pointerdown",
-      expect.any(Function),
-      expect.any(Object)
-    );
+    expect(
+      new Set(
+        secondMedia.mediaQueries
+          .filter((query) => query.addEventListener.mock.calls.length > 0)
+          .map((query) => query.media)
+      )
+    ).toEqual(new Set(INTERACTION_MEDIA_QUERIES));
+    expect(
+      addEventListenerSpy.mock.calls.some(
+        ([eventName]) => eventName === "pointerdown"
+      )
+    ).toBe(true);
+    expect(
+      addEventListenerSpy.mock.calls.some(
+        ([eventName]) => eventName === "pointermove"
+      )
+    ).toBe(true);
 
     second.unmount();
   });

--- a/__tests__/utils/interactionMode.ts
+++ b/__tests__/utils/interactionMode.ts
@@ -1,0 +1,20 @@
+import type { InteractionMode } from "@/src/interaction/useInteractionMode";
+
+export const DEFAULT_INTERACTION_MODE: InteractionMode = {
+  canHover: false,
+  hasFinePointer: false,
+  hasCoarsePointer: false,
+  hoverNone: false,
+  lastPointerType: null,
+  enableHoverUI: false,
+  enableLongPress: false,
+};
+
+export function createInteractionMode(
+  overrides: Partial<InteractionMode> = {}
+): InteractionMode {
+  return {
+    ...DEFAULT_INTERACTION_MODE,
+    ...overrides,
+  };
+}

--- a/components/brain/content/BrainContentPinnedWaves.tsx
+++ b/components/brain/content/BrainContentPinnedWaves.tsx
@@ -5,6 +5,7 @@ import BrainContentPinnedWave from "./BrainContentPinnedWave";
 import { usePinnedWaves } from "@/hooks/usePinnedWaves";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 import {
   getActiveWaveIdFromUrl,
   getWaveHomeRoute,
@@ -25,6 +26,7 @@ const BrainContentPinnedWaves: React.FC = () => {
   const rightArrowRef = useRef<HTMLButtonElement>(null);
   const [showLeftArrow, setShowLeftArrow] = useState(false);
   const [showRightArrow, setShowRightArrow] = useState(false);
+  const { enableHoverUI } = useInteractionMode();
 
   const scrollHorizontally = (direction: "left" | "right") => {
     const container = containerRef.current;
@@ -38,7 +40,7 @@ const BrainContentPinnedWaves: React.FC = () => {
   };
 
   const checkScrollArrows = () => {
-    if (window.matchMedia("(pointer: coarse)").matches) {
+    if (!enableHoverUI) {
       setShowLeftArrow(false);
       setShowRightArrow(false);
       return;
@@ -94,7 +96,7 @@ const BrainContentPinnedWaves: React.FC = () => {
         img.removeEventListener("load", checkScrollArrows);
       });
     };
-  }, [pinnedIds]);
+  }, [enableHoverUI, pinnedIds]);
 
   useEffect(() => {
     const wave =

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 import React, { useEffect, useState, useCallback } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faThumbtack } from "@fortawesome/free-solid-svg-icons";
@@ -23,7 +24,7 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
   const { waves } = useMyStream();
   const { pinnedIds, isOperationInProgress } = usePinnedWavesServer();
   const { setToast } = useAuth();
-  const [isTouchDevice, setIsTouchDevice] = useState(false);
+  const { enableHoverUI } = useInteractionMode();
   const [showMaxLimitTooltip, setShowMaxLimitTooltip] = useState(false);
 
   // Check if this specific wave operation is in progress
@@ -57,25 +58,7 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
     return () => clearTimeout(timer);
   }, [showMaxLimitTooltip]);
 
-  // Detect touch device on component mount
-  useEffect(() => {
-    const checkTouch = () => {
-      // Check if device supports touch events
-      setIsTouchDevice(
-        "ontouchstart" in window ||
-          navigator.maxTouchPoints > 0 ||
-          // @ts-ignore: matchMedia may not be available in all environments
-          (window.matchMedia && window.matchMedia("(pointer: coarse)").matches)
-      );
-    };
 
-    checkTouch();
-    window.addEventListener("resize", checkTouch);
-
-    return () => {
-      window.removeEventListener("resize", checkTouch);
-    };
-  }, []);
 
   const handleClick = async (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
@@ -25,6 +25,7 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
   const { pinnedIds, isOperationInProgress } = usePinnedWavesServer();
   const { setToast } = useAuth();
   const { enableHoverUI } = useInteractionMode();
+  const isTouchDevice = !enableHoverUI;
   const [showMaxLimitTooltip, setShowMaxLimitTooltip] = useState(false);
 
   // Check if this specific wave operation is in progress

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
@@ -25,7 +25,7 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
   const { pinnedIds, isOperationInProgress } = usePinnedWavesServer();
   const { setToast } = useAuth();
   const { enableHoverUI } = useInteractionMode();
-  const isTouchDevice = !enableHoverUI;
+  const shouldRevealWithoutHover = !enableHoverUI;
   const [showMaxLimitTooltip, setShowMaxLimitTooltip] = useState(false);
 
   // Check if this specific wave operation is in progress
@@ -58,8 +58,6 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
     const timer = setTimeout(() => setShowMaxLimitTooltip(false), 3000);
     return () => clearTimeout(timer);
   }, [showMaxLimitTooltip]);
-
-
 
   const handleClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -98,7 +96,7 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
 
   // Apply visibility logic: always show pinned waves on desktop, hide unpinned until hover
   const getOpacityClass = () => {
-    if (isTouchDevice) return "tw-opacity-100";
+    if (shouldRevealWithoutHover) return "tw-opacity-100";
     if (isPinned) return "tw-opacity-100";
     return "tw-opacity-0 group-hover:tw-opacity-100";
   };

--- a/components/brain/left-sidebar/web/WebDirectMessagesList.tsx
+++ b/components/brain/left-sidebar/web/WebDirectMessagesList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import useCreateModalState from "@/hooks/useCreateModalState";
-import useIsTouchDevice from "@/hooks/useIsTouchDevice";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 import { faPaperPlane } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Image from "next/image";
@@ -33,7 +33,7 @@ const WebDirectMessagesList: React.FC<WebDirectMessagesListProps> = ({
   const { connectedProfile } = useContext(AuthContext);
   const { isDirectMessageModalOpen, openDirectMessage, close, isApp } =
     useCreateModalState();
-  const isTouchDevice = useIsTouchDevice();
+  const { enableLongPress: isTouchDevice } = useInteractionMode();
 
   const shouldRenderCreateDirectMessage = !isApp;
 

--- a/components/brain/left-sidebar/web/WebDirectMessagesList.tsx
+++ b/components/brain/left-sidebar/web/WebDirectMessagesList.tsx
@@ -33,7 +33,8 @@ const WebDirectMessagesList: React.FC<WebDirectMessagesListProps> = ({
   const { connectedProfile } = useContext(AuthContext);
   const { isDirectMessageModalOpen, openDirectMessage, close, isApp } =
     useCreateModalState();
-  const { enableLongPress: isTouchDevice } = useInteractionMode();
+  const { enableHoverUI } = useInteractionMode();
+  const isHoverSupported = enableHoverUI;
 
   const shouldRenderCreateDirectMessage = !isApp;
 
@@ -184,7 +185,7 @@ const WebDirectMessagesList: React.FC<WebDirectMessagesListProps> = ({
         </div>
       </div>
 
-      {!isTouchDevice && shouldRenderCreateDirectMessage && (
+      {isHoverSupported && shouldRenderCreateDirectMessage && (
         <ReactTooltip
           id="create-dm-tooltip"
           place="bottom"

--- a/components/brain/left-sidebar/web/WebDirectMessagesList.tsx
+++ b/components/brain/left-sidebar/web/WebDirectMessagesList.tsx
@@ -34,7 +34,6 @@ const WebDirectMessagesList: React.FC<WebDirectMessagesListProps> = ({
   const { isDirectMessageModalOpen, openDirectMessage, close, isApp } =
     useCreateModalState();
   const { enableHoverUI } = useInteractionMode();
-  const isHoverSupported = enableHoverUI;
 
   const shouldRenderCreateDirectMessage = !isApp;
 
@@ -185,7 +184,7 @@ const WebDirectMessagesList: React.FC<WebDirectMessagesListProps> = ({
         </div>
       </div>
 
-      {isHoverSupported && shouldRenderCreateDirectMessage && (
+      {enableHoverUI && shouldRenderCreateDirectMessage && (
         <ReactTooltip
           id="create-dm-tooltip"
           place="bottom"

--- a/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.tsx
+++ b/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.tsx
@@ -2,7 +2,7 @@
 
 import PrimaryButton from "@/components/utils/button/PrimaryButton";
 import useCreateModalState from "@/hooks/useCreateModalState";
-import useIsTouchDevice from "@/hooks/useIsTouchDevice";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
@@ -70,7 +70,7 @@ const WebUnifiedWavesListWaves = forwardRef<
     const sentinelRef = useRef<HTMLDivElement>(null);
     const { connectedProfile } = useAuth();
     const { openWave, isApp } = useCreateModalState();
-    const isTouchDevice = useIsTouchDevice();
+    const { enableLongPress: isTouchDevice } = useInteractionMode();
 
     useImperativeHandle(ref, () => ({
       sentinelRef,

--- a/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.tsx
+++ b/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.tsx
@@ -70,7 +70,7 @@ const WebUnifiedWavesListWaves = forwardRef<
     const sentinelRef = useRef<HTMLDivElement>(null);
     const { connectedProfile } = useAuth();
     const { openWave, isApp } = useCreateModalState();
-    const { enableLongPress: isTouchDevice } = useInteractionMode();
+    const { enableHoverUI } = useInteractionMode();
 
     useImperativeHandle(ref, () => ({
       sentinelRef,
@@ -255,7 +255,7 @@ const WebUnifiedWavesListWaves = forwardRef<
           </div>
         </div>
 
-        {!isTouchDevice && (
+        {enableHoverUI && (
           <ReactTooltip
             id="create-wave-tooltip"
             place="bottom"

--- a/components/common/OverlappingAvatars.tsx
+++ b/components/common/OverlappingAvatars.tsx
@@ -79,7 +79,8 @@ export default function OverlappingAvatars({
   onItemClick,
 }: OverlappingAvatarsProps) {
   const baseId = useId();
-  const { enableLongPress: isTouchDevice } = useInteractionMode();
+  const { enableHoverUI } = useInteractionMode();
+  const showTooltip = enableHoverUI;
   const slice = items.slice(0, maxCount);
   const sizeClass = SIZE_CLASS[size];
   const avatarRing =
@@ -106,9 +107,9 @@ export default function OverlappingAvatars({
           />
         );
 
-        const showTooltip =
-          !isTouchDevice && item.title !== undefined && item.title !== "";
-        const tooltipId = showTooltip ? `${baseId}-${index}` : undefined;
+        const showTooltipForItem =
+          showTooltip && item.title !== undefined && item.title !== "";
+        const tooltipId = showTooltipForItem ? `${baseId}-${index}` : undefined;
         const wrapper = (
           <div
             key={item.key}
@@ -137,7 +138,7 @@ export default function OverlappingAvatars({
           wrapper
         );
 
-        if (showTooltip && tooltipId !== undefined) {
+        if (showTooltipForItem && tooltipId !== undefined) {
           return (
             <span key={item.key} className="tw-inline-flex">
               {anchor}

--- a/components/common/OverlappingAvatars.tsx
+++ b/components/common/OverlappingAvatars.tsx
@@ -2,7 +2,7 @@
 
 import { getScaledImageUri, ImageScale } from "@/helpers/image.helpers";
 import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
-import useIsTouchDevice from "@/hooks/useIsTouchDevice";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 import Image from "next/image";
 import Link from "next/link";
 import type { MouseEvent, ReactNode } from "react";
@@ -79,7 +79,7 @@ export default function OverlappingAvatars({
   onItemClick,
 }: OverlappingAvatarsProps) {
   const baseId = useId();
-  const isTouchDevice = useIsTouchDevice();
+  const { enableLongPress: isTouchDevice } = useInteractionMode();
   const slice = items.slice(0, maxCount);
   const sizeClass = SIZE_CLASS[size];
   const avatarRing =

--- a/components/common/OverlappingAvatars.tsx
+++ b/components/common/OverlappingAvatars.tsx
@@ -66,7 +66,7 @@ function AvatarContent({
       sizes="28px"
       unoptimized
       onError={() => setImgError(true)}
-      className={`tw-object-cover tw-rounded-full ${avatarRing}`}
+      className={`tw-rounded-full tw-object-cover ${avatarRing}`}
     />
   );
 }
@@ -107,8 +107,13 @@ export default function OverlappingAvatars({
           />
         );
 
+        const hasTooltipContent =
+          item.tooltipContent !== undefined &&
+          item.tooltipContent !== null &&
+          item.tooltipContent !== "";
+        const hasTitle = item.title !== undefined && item.title !== "";
         const showTooltipForItem =
-          showTooltip && item.title !== undefined && item.title !== "";
+          showTooltip && (hasTooltipContent || hasTitle);
         const tooltipId = showTooltipForItem ? `${baseId}-${index}` : undefined;
         const wrapper = (
           <div

--- a/components/header/header-search/HeaderSearchModalItem.tsx
+++ b/components/header/header-search/HeaderSearchModalItem.tsx
@@ -21,6 +21,7 @@ import {
   getWaveRoute,
 } from "@/helpers/navigation.helpers";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 import { DocumentTextIcon } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
@@ -91,11 +92,7 @@ export default function HeaderSearchModalItem({
   const ref = useRef<HTMLDivElement>(null);
   const isHovering = useHoverDirty(ref as React.RefObject<HTMLDivElement>);
   const { isApp } = useDeviceInfo();
-
-  const supportsHover =
-    typeof window !== "undefined" &&
-    window.matchMedia &&
-    window.matchMedia("(hover: hover)").matches;
+  const { enableHoverUI: supportsHover } = useInteractionMode();
 
   const isPage = () => (content as PageSearchResult).type === "PAGE";
   const isProfile = () => Object.hasOwn(content, "handle");

--- a/components/layout/sidebar/WebSidebar.tsx
+++ b/components/layout/sidebar/WebSidebar.tsx
@@ -2,7 +2,7 @@
 
 import useInteractionMode from "@/src/interaction/useInteractionMode";
 import { usePathname } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { Tooltip as ReactTooltip } from "react-tooltip";
 import { useIdentity } from "../../../hooks/useIdentity";
 import { useAuth } from "../../auth/Auth";

--- a/components/layout/sidebar/WebSidebar.tsx
+++ b/components/layout/sidebar/WebSidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Tooltip as ReactTooltip } from "react-tooltip";
@@ -46,43 +47,8 @@ function WebSidebar({
     return null;
   }, [connectedProfile?.handle, address]);
 
-  const [isTouchScreen, setIsTouchScreen] = useState(false);
-  useEffect(() => {
-    const { window: browserWindow } = globalThis as typeof globalThis & {
-      window?: Window | undefined;
-    };
-    if (
-      browserWindow === undefined ||
-      typeof browserWindow.matchMedia !== "function"
-    ) {
-      setIsTouchScreen(false);
-      return;
-    }
-
-    const coarsePointerQuery = browserWindow.matchMedia("(pointer: coarse)");
-    const handlePointerChange = (event: MediaQueryListEvent) => {
-      setIsTouchScreen(event.matches);
-    };
-
-    setIsTouchScreen(coarsePointerQuery.matches);
-
-    if (typeof coarsePointerQuery.addEventListener === "function") {
-      coarsePointerQuery.addEventListener("change", handlePointerChange);
-      return () =>
-        coarsePointerQuery.removeEventListener("change", handlePointerChange);
-    }
-
-    if ("onchange" in coarsePointerQuery) {
-      const originalHandler = coarsePointerQuery.onchange;
-      coarsePointerQuery.onchange = handlePointerChange;
-      return () => {
-        if (coarsePointerQuery.onchange === handlePointerChange) {
-          coarsePointerQuery.onchange = originalHandler ?? null;
-        }
-      };
-    }
-    return;
-  }, []);
+  const { enableHoverUI } = useInteractionMode();
+  const isTouchScreen = !enableHoverUI;
 
   // Close sidebar on route change when on mobile
   const prevPathnameRef = useRef(pathname);

--- a/components/layout/sidebar/WebSidebar.tsx
+++ b/components/layout/sidebar/WebSidebar.tsx
@@ -48,7 +48,6 @@ function WebSidebar({
   }, [connectedProfile?.handle, address]);
 
   const { enableHoverUI } = useInteractionMode();
-  const isTouchScreen = !enableHoverUI;
 
   // Close sidebar on route change when on mobile
   const prevPathnameRef = useRef(pathname);
@@ -164,7 +163,7 @@ function WebSidebar({
           </div>
         </div>
       </div>
-      {!isTouchScreen && (
+      {enableHoverUI && (
         <ReactTooltip
           id="sidebar-tooltip"
           place="right"

--- a/components/profile-activity/list/items/utils/ProfileActivityLogItemValueWithCopy.tsx
+++ b/components/profile-activity/list/items/utils/ProfileActivityLogItemValueWithCopy.tsx
@@ -15,7 +15,11 @@ export default function ProfileActivityLogItemValueWithCopy({
   readonly value: string;
 }) {
   const { enableHoverUI } = useInteractionMode();
-  const isTouchScreen = !enableHoverUI;
+  const hasTouchCapability =
+    typeof navigator !== "undefined" &&
+    (navigator.maxTouchPoints > 0 ||
+      "ontouchstart" in (typeof window !== "undefined" ? window : ({} as Window)));
+  const isTouchScreen = !enableHoverUI || hasTouchCapability;
 
   const [_, copyToClipboard] = useCopyToClipboard();
 

--- a/components/profile-activity/list/items/utils/ProfileActivityLogItemValueWithCopy.tsx
+++ b/components/profile-activity/list/items/utils/ProfileActivityLogItemValueWithCopy.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Tooltip } from "react-tooltip";
-import { useEffect, useState } from "react";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
+import { useState } from "react";
 import { useCopyToClipboard } from "react-use";
 import CopyIcon from "@/components/utils/icons/CopyIcon";
 import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
@@ -13,10 +14,8 @@ export default function ProfileActivityLogItemValueWithCopy({
   readonly title: string;
   readonly value: string;
 }) {
-  const [isTouchScreen, setIsTouchScreen] = useState(false);
-  useEffect(() => {
-    setIsTouchScreen(window.matchMedia("(pointer: coarse)").matches);
-  }, []);
+  const { enableHoverUI } = useInteractionMode();
+  const isTouchScreen = !enableHoverUI;
 
   const [_, copyToClipboard] = useCopyToClipboard();
 

--- a/components/profile-activity/list/items/utils/ProfileActivityLogItemValueWithCopy.tsx
+++ b/components/profile-activity/list/items/utils/ProfileActivityLogItemValueWithCopy.tsx
@@ -14,12 +14,9 @@ export default function ProfileActivityLogItemValueWithCopy({
   readonly title: string;
   readonly value: string;
 }) {
-  const { enableHoverUI } = useInteractionMode();
-  const hasTouchCapability =
-    typeof navigator !== "undefined" &&
-    (navigator.maxTouchPoints > 0 ||
-      "ontouchstart" in (typeof window !== "undefined" ? window : ({} as Window)));
-  const isTouchScreen = !enableHoverUI || hasTouchCapability;
+  const { enableHoverUI, enableLongPress } = useInteractionMode();
+  const shouldShowCopyButton = !enableHoverUI || enableLongPress;
+  const shouldShowCopyTooltip = enableHoverUI;
 
   const [_, copyToClipboard] = useCopyToClipboard();
 
@@ -41,7 +38,7 @@ export default function ProfileActivityLogItemValueWithCopy({
         <button
           onClick={handleCopy}
           className={`${
-            isTouchScreen
+            shouldShowCopyButton
               ? "tw-block"
               : "tw-opacity-0 group-hover:tw-opacity-100"
           } tw-mx-1 tw-cursor-pointer tw-border-0 tw-bg-transparent tw-text-sm tw-font-semibold tw-text-iron-500 tw-transition tw-duration-300 tw-ease-out hover:tw-text-iron-200 focus:tw-outline-none`}
@@ -51,7 +48,7 @@ export default function ProfileActivityLogItemValueWithCopy({
             <CopyIcon />
           </div>
         </button>
-        {!isTouchScreen && (
+        {shouldShowCopyTooltip && (
           <Tooltip
             id={`copy-activity-${value}`}
             place="top"

--- a/components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddressesItem.tsx
+++ b/components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddressesItem.tsx
@@ -99,10 +99,8 @@ export default function UserPageIdentityStatementsConsolidatedAddressesItem({
     };
   }, []);
 
-  const [isTouchScreen, setIsTouchScreen] = useState(false);
-  useEffect(() => {
-    setIsTouchScreen(window.matchMedia("(pointer: coarse)").matches);
-  }, []);
+  const { enableHoverUI } = useInteractionMode();
+  const isTouchScreen = !enableHoverUI;
 
   const [assigningPrimary, setAssigningPrimary] = useState(false);
   const [statusMessage, setStatusMessage] = useState<any>();

--- a/components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddressesItem.tsx
+++ b/components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddressesItem.tsx
@@ -19,6 +19,7 @@ import { useEffect, useRef, useState } from "react";
 import { Tooltip } from "react-tooltip";
 import { useCopyToClipboard } from "react-use";
 import { useWaitForTransactionReceipt, useWriteContract } from "wagmi";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 import UserPageIdentityStatementsConsolidatedAddressesItemPrimary from "./UserPageIdentityStatementsConsolidatedAddressesItemPrimary";
 
 export default function UserPageIdentityStatementsConsolidatedAddressesItem({

--- a/components/user/identity/statements/utils/UserPageIdentityDeleteStatementButton.tsx
+++ b/components/user/identity/statements/utils/UserPageIdentityDeleteStatementButton.tsx
@@ -5,7 +5,8 @@ import CommonAnimationWrapper from "@/components/utils/animation/CommonAnimation
 import type { CicStatement } from "@/entities/IProfile";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
-import { useEffect, useState } from "react";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
+import { useState } from "react";
 import { Tooltip } from "react-tooltip";
 import UserPageIdentityDeleteStatementModal from "./UserPageIdentityDeleteStatementModal";
 export default function UserPageIdentityDeleteStatementButton({
@@ -17,10 +18,8 @@ export default function UserPageIdentityDeleteStatementButton({
 }) {
   const [isDeleteStatementOpen, setIsDeleteStatementOpen] =
     useState<boolean>(false);
-  const [isTouchScreen, setIsTouchScreen] = useState(false);
-  useEffect(() => {
-    setIsTouchScreen(window.matchMedia("(pointer: coarse)").matches);
-  }, []);
+  const { enableHoverUI } = useInteractionMode();
+  const isTouchScreen = !enableHoverUI;
   const tooltipId = `delete-statement-${statement.statement_group}-${statement.statement_type}`;
   const showTooltip = !isTouchScreen && !isDeleteStatementOpen;
 

--- a/components/user/identity/statements/utils/UserPageIdentityStatementsStatement.tsx
+++ b/components/user/identity/statements/utils/UserPageIdentityStatementsStatement.tsx
@@ -7,7 +7,8 @@ import type { CicStatement } from "@/entities/IProfile";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
 import { STATEMENT_META } from "@/helpers/Types";
-import { useEffect, useState } from "react";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
+import { useState } from "react";
 import { Tooltip } from "react-tooltip";
 import { useCopyToClipboard } from "react-use";
 import UserPageIdentityDeleteStatementButton from "./UserPageIdentityDeleteStatementButton";
@@ -33,10 +34,8 @@ export default function UserPageIdentityStatementsStatement({
   };
 
   const canOpen = STATEMENT_META[statement.statement_type].canOpenStatement;
-  const [isTouchScreen, setIsTouchScreen] = useState(false);
-  useEffect(() => {
-    setIsTouchScreen(window.matchMedia("(pointer: coarse)").matches);
-  }, []);
+  const { enableHoverUI } = useInteractionMode();
+  const isTouchScreen = !enableHoverUI;
 
   return (
     <li className="tw-group hover:tw-bg-white/[0.02] tw-pl-0.5 tw-py-4 tw-transition-colors tw-duration-200 tw-ease-out tw-border-b tw-border-solid tw-border-white/[0.06] tw-border-t-0 tw-border-x-0 last:tw-border-b-0">

--- a/components/utils/select/dropdown/CommonDropdownItemsMobileWrapper.tsx
+++ b/components/utils/select/dropdown/CommonDropdownItemsMobileWrapper.tsx
@@ -9,7 +9,7 @@ import {
 } from "@headlessui/react";
 import type { ReactNode } from "react";
 import { Fragment } from "react";
-import useHasTouchInput from "@/hooks/useHasTouchInput";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 
 export default function CommonDropdownItemsMobileWrapper({
   isOpen,
@@ -24,7 +24,7 @@ export default function CommonDropdownItemsMobileWrapper({
   readonly hideOnDesktopHover?: boolean | undefined;
   readonly children: ReactNode;
 }) {
-  const hasTouchInput = useHasTouchInput();
+  const { enableLongPress: hasTouchInput } = useInteractionMode();
   const shouldHideOnDesktopHover = hideOnDesktopHover && !hasTouchInput;
 
   return (

--- a/components/waves/drops/DropMobileMenuHandler.tsx
+++ b/components/waves/drops/DropMobileMenuHandler.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useRef, useState } from "react";
 import WaveDropMobileMenu from "./WaveDropMobileMenu";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import useIsMobileDevice from "@/hooks/isMobileDevice";
-import useIsTouchDevice from "@/hooks/useIsTouchDevice";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 
 interface DropMobileMenuHandlerProps {
   readonly drop: ExtendedDrop;
@@ -26,7 +26,8 @@ export default function DropMobileMenuHandler({
   const [longPressTriggered, setLongPressTriggered] = useState(false);
   const [isSlideUp, setIsSlideUp] = useState(false);
   const isMobile = useIsMobileDevice();
-  const hasTouch = useIsTouchDevice() || isMobile;
+  const { enableLongPress } = useInteractionMode();
+  const hasTouch = enableLongPress || isMobile;
 
   const longPressTimeout = useRef<NodeJS.Timeout | null>(null);
   const touchStartX = useRef(0);

--- a/components/waves/drops/WaveDrop.tsx
+++ b/components/waves/drops/WaveDrop.tsx
@@ -9,7 +9,7 @@ import type { ApiUpdateDropRequest } from "@/generated/models/ApiUpdateDropReque
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import { useDropUpdateMutation } from "@/hooks/drops/useDropUpdateMutation";
 import useIsMobileDevice from "@/hooks/isMobileDevice";
-import useHasTouchInput from "@/hooks/useHasTouchInput";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 import { selectEditingDropId, setEditingDropId } from "@/store/editSlice";
 import type { ActiveDropState } from "@/types/dropInteractionTypes";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
@@ -178,7 +178,8 @@ const WaveDrop = ({
     !isDrop && shouldGroupWithDrop(drop, nextDrop);
 
   const isMobile = useIsMobileDevice();
-  const hasTouch = useHasTouchInput() || isMobile;
+  const { enableLongPress } = useInteractionMode();
+  const hasTouch = enableLongPress || isMobile;
   const breakpoint = useBreakpoint();
   const isMdUp = breakpoint === "MD";
   const allowLongPress = hasTouch && !isMdUp;

--- a/components/waves/drops/WaveDropContent.tsx
+++ b/components/waves/drops/WaveDropContent.tsx
@@ -5,7 +5,7 @@ import type { ApiMentionedWave } from "@/generated/models/ApiMentionedWave";
 import WaveDropPart from "./WaveDropPart";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import { ImageScale } from "@/helpers/image.helpers";
-import useIsTouchDevice from "@/hooks/useIsTouchDevice";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 
 interface WaveDropContentProps {
   readonly drop: ExtendedDrop;
@@ -46,7 +46,7 @@ const WaveDropContent: React.FC<WaveDropContentProps> = ({
   mediaImageScale = ImageScale.AUTOx450,
   hasTouch,
 }) => {
-  const isTouchDevice = useIsTouchDevice();
+  const { enableLongPress: isTouchDevice } = useInteractionMode();
   const effectiveHasTouch = hasTouch ?? isTouchDevice;
 
   return (

--- a/components/waves/drops/WaveDropReactions.tsx
+++ b/components/waves/drops/WaveDropReactions.tsx
@@ -11,7 +11,7 @@ import { formatLargeNumber } from "@/helpers/Helpers";
 import { recordReaction } from "@/helpers/reactions/reactionHistory";
 import { buildTooltipId } from "@/helpers/tooltip.helpers";
 import { DropSize } from "@/helpers/waves/drop.helpers";
-import useIsTouchDevice from "@/hooks/useIsTouchDevice";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 import useLongPressInteraction from "@/hooks/useLongPressInteraction";
 import { commonApiDelete, commonApiPost } from "@/services/api/common-api";
 import clsx from "clsx";
@@ -40,7 +40,7 @@ interface WaveDropReactionsProps {
 
 const WaveDropReactions: React.FC<WaveDropReactionsProps> = ({ drop }) => {
   const [dialogReaction, setDialogReaction] = useState<string | null>(null);
-  const isTouchDevice = useIsTouchDevice();
+  const { enableLongPress: isTouchDevice } = useInteractionMode();
 
   const handleOpenDialog = useCallback((reactionKey: string) => {
     setDialogReaction(reactionKey);

--- a/components/waves/drops/WaveDropReactions.tsx
+++ b/components/waves/drops/WaveDropReactions.tsx
@@ -40,7 +40,9 @@ interface WaveDropReactionsProps {
 
 const WaveDropReactions: React.FC<WaveDropReactionsProps> = ({ drop }) => {
   const [dialogReaction, setDialogReaction] = useState<string | null>(null);
-  const { enableLongPress: isTouchDevice } = useInteractionMode();
+  const { enableLongPress, enableHoverUI } = useInteractionMode();
+  const isTouchDevice = enableLongPress;
+  const showHoverTooltip = enableHoverUI;
 
   const handleOpenDialog = useCallback((reactionKey: string) => {
     setDialogReaction(reactionKey);
@@ -59,6 +61,7 @@ const WaveDropReactions: React.FC<WaveDropReactionsProps> = ({ drop }) => {
           reaction={reaction}
           onOpenDetailDialog={handleOpenDialog}
           isTouchDevice={isTouchDevice}
+          showHoverTooltip={showHoverTooltip}
         />
       ))}
       <WaveDropReactionsDetailDialog
@@ -76,11 +79,13 @@ function WaveDropReaction({
   reaction,
   onOpenDetailDialog,
   isTouchDevice,
+  showHoverTooltip,
 }: {
   readonly drop: ApiDrop;
   readonly reaction: ApiDropReaction;
   readonly onOpenDetailDialog: (reactionKey: string) => void;
   readonly isTouchDevice: boolean;
+  readonly showHoverTooltip: boolean;
 }) {
   const { setToast, connectedProfile } = useAuth();
   const { emojiMap, findNativeEmoji } = useEmoji();
@@ -401,7 +406,7 @@ function WaveDropReaction({
     <>
       <button
         onClick={handleClick}
-        {...(!isTouchDevice && { "data-tooltip-id": tooltipId })}
+        {...(showHoverTooltip && { "data-tooltip-id": tooltipId })}
         data-text-selection-exclude="true"
         className={clsx(
           "tw-mt-1 tw-inline-flex tw-items-center tw-gap-x-2 tw-rounded-lg tw-border tw-border-solid tw-px-2 tw-py-1 tw-shadow-sm hover:tw-text-iron-100",
@@ -425,7 +430,7 @@ function WaveDropReaction({
           </span>
         </div>
       </button>
-      {!isTouchDevice && (
+      {showHoverTooltip && (
         <Tooltip
           id={tooltipId}
           delayShow={250}

--- a/components/waves/drops/WaveDropReactions.tsx
+++ b/components/waves/drops/WaveDropReactions.tsx
@@ -41,8 +41,6 @@ interface WaveDropReactionsProps {
 const WaveDropReactions: React.FC<WaveDropReactionsProps> = ({ drop }) => {
   const [dialogReaction, setDialogReaction] = useState<string | null>(null);
   const { enableLongPress, enableHoverUI } = useInteractionMode();
-  const isTouchDevice = enableLongPress;
-  const showHoverTooltip = enableHoverUI;
 
   const handleOpenDialog = useCallback((reactionKey: string) => {
     setDialogReaction(reactionKey);
@@ -60,8 +58,8 @@ const WaveDropReactions: React.FC<WaveDropReactionsProps> = ({ drop }) => {
           drop={drop}
           reaction={reaction}
           onOpenDetailDialog={handleOpenDialog}
-          isTouchDevice={isTouchDevice}
-          showHoverTooltip={showHoverTooltip}
+          enableLongPress={enableLongPress}
+          showHoverTooltip={enableHoverUI}
         />
       ))}
       <WaveDropReactionsDetailDialog
@@ -78,13 +76,13 @@ function WaveDropReaction({
   drop,
   reaction,
   onOpenDetailDialog,
-  isTouchDevice,
+  enableLongPress,
   showHoverTooltip,
 }: {
   readonly drop: ApiDrop;
   readonly reaction: ApiDropReaction;
   readonly onOpenDetailDialog: (reactionKey: string) => void;
-  readonly isTouchDevice: boolean;
+  readonly enableLongPress: boolean;
   readonly showHoverTooltip: boolean;
 }) {
   const { setToast, connectedProfile } = useAuth();
@@ -97,7 +95,7 @@ function WaveDropReaction({
   }, [onOpenDetailDialog, reaction.reaction]);
 
   const { longPressTriggered, touchHandlers } = useLongPressInteraction({
-    hasTouchScreen: isTouchDevice,
+    hasTouchScreen: enableLongPress,
     onInteractionStart: handleLongPressStart,
     longPressDuration: 400,
     // Allow the native click to fire on tap; we only need preventDefault when the long press actually triggers

--- a/components/waves/drops/participation/EndedParticipationDrop.tsx
+++ b/components/waves/drops/participation/EndedParticipationDrop.tsx
@@ -8,7 +8,7 @@ import { getTimeAgoShort } from "@/helpers/Helpers";
 import { getWaveRoute } from "@/helpers/navigation.helpers";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import useIsMobileDevice from "@/hooks/isMobileDevice";
-import useIsTouchDevice from "@/hooks/useIsTouchDevice";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 import type { ActiveDropState } from "@/types/dropInteractionTypes";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -51,7 +51,8 @@ export default function EndedParticipationDrop({
   const [longPressTriggered, setLongPressTriggered] = useState(false);
   const [isSlideUp, setIsSlideUp] = useState(false);
   const isMobile = useIsMobileDevice();
-  const hasTouch = useIsTouchDevice() || isMobile;
+  const { enableLongPress } = useInteractionMode();
+  const hasTouch = enableLongPress || isMobile;
 
   const handleNavigation = (e: React.MouseEvent, path: string) => {
     e.preventDefault();

--- a/components/waves/drops/participation/OngoingParticipationDrop.tsx
+++ b/components/waves/drops/participation/OngoingParticipationDrop.tsx
@@ -14,7 +14,7 @@ import ParticipationDropHeader from "./ParticipationDropHeader";
 import ParticipationDropContent from "./ParticipationDropContent";
 import ParticipationDropMetadata from "./ParticipationDropMetadata";
 import ParticipationDropFooter from "./ParticipationDropFooter";
-import useIsTouchDevice from "@/hooks/useIsTouchDevice";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 
 interface OngoingParticipationDropProps {
   readonly drop: ExtendedDrop;
@@ -39,7 +39,8 @@ export default function OngoingParticipationDrop({
 }: OngoingParticipationDropProps) {
   const isActiveDrop = activeDrop?.drop.id === drop.id;
   const isMobile = useIsMobileDevice();
-  const hasTouch = useIsTouchDevice() || isMobile;
+  const { enableLongPress } = useInteractionMode();
+  const hasTouch = enableLongPress || isMobile;
 
   const [activePartIndex, setActivePartIndex] = useState(0);
   const [longPressTriggered, setLongPressTriggered] = useState(false);

--- a/components/waves/drops/participation/ParticipationDropContent.tsx
+++ b/components/waves/drops/participation/ParticipationDropContent.tsx
@@ -1,7 +1,7 @@
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import type { ApiDrop } from "@/generated/models/ApiDrop";
 import WaveDropContent from "../WaveDropContent";
-import useIsTouchDevice from "@/hooks/useIsTouchDevice";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 
 interface ParticipationDropContentProps {
   readonly drop: ExtendedDrop;
@@ -24,7 +24,7 @@ export default function ParticipationDropContent({
   setLongPressTriggered,
   isCompetitionDrop = false,
 }: ParticipationDropContentProps) {
-  const hasTouch = useIsTouchDevice();
+  const { enableLongPress: hasTouch } = useInteractionMode();
 
   return (
     <div className="tw-mt-1">

--- a/components/waves/drops/winner/DefaultWinnerDrop.tsx
+++ b/components/waves/drops/winner/DefaultWinnerDrop.tsx
@@ -4,7 +4,7 @@ import type { ApiDrop } from "@/generated/models/ApiDrop";
 import { getWaveRoute } from "@/helpers/navigation.helpers";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import useIsMobileDevice from "@/hooks/isMobileDevice";
-import useIsTouchDevice from "@/hooks/useIsTouchDevice";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 import type { ActiveDropState } from "@/types/dropInteractionTypes";
 import Link from "next/link";
 import { memo, useCallback, useState } from "react";
@@ -104,7 +104,8 @@ const DefaultWinnerDrop = ({
   const isActiveDrop = activeDrop?.drop.id === drop.id;
   const isStorm = drop.parts.length > 1;
   const isMobile = useIsMobileDevice();
-  const hasTouch = useIsTouchDevice() || isMobile;
+  const { enableLongPress } = useInteractionMode();
+  const hasTouch = enableLongPress || isMobile;
 
   const effectiveRank = drop.winning_context?.place ?? drop.rank;
 

--- a/components/waves/outcome/useWaveOutcomeTooltipInteraction.ts
+++ b/components/waves/outcome/useWaveOutcomeTooltipInteraction.ts
@@ -8,16 +8,27 @@ const CLICK_GLOBAL_CLOSE_EVENTS = { clickOutsideAnchor: true };
 const HOVER_OPEN_EVENTS = { mouseenter: true, focus: true };
 const HOVER_CLOSE_EVENTS = { mouseleave: true, blur: true };
 const HOVER_GLOBAL_CLOSE_EVENTS = {};
+const HYBRID_OPEN_EVENTS = { ...HOVER_OPEN_EVENTS, ...CLICK_OPEN_EVENTS };
+const HYBRID_CLOSE_EVENTS = { ...HOVER_CLOSE_EVENTS, ...CLICK_CLOSE_EVENTS };
 
 export default function useWaveOutcomeTooltipInteraction() {
-  const { enableLongPress } = useInteractionMode();
+  const { enableHoverUI, enableLongPress } = useInteractionMode();
+  const enableHybridActivation = enableHoverUI && enableLongPress;
+  let tooltipOpenEvents = HOVER_OPEN_EVENTS;
+  let tooltipCloseEvents = HOVER_CLOSE_EVENTS;
+
+  if (enableHybridActivation) {
+    tooltipOpenEvents = HYBRID_OPEN_EVENTS;
+    tooltipCloseEvents = HYBRID_CLOSE_EVENTS;
+  } else if (enableLongPress) {
+    tooltipOpenEvents = CLICK_OPEN_EVENTS;
+    tooltipCloseEvents = CLICK_CLOSE_EVENTS;
+  }
 
   return {
     useClickActivation: enableLongPress,
-    tooltipOpenEvents: enableLongPress ? CLICK_OPEN_EVENTS : HOVER_OPEN_EVENTS,
-    tooltipCloseEvents: enableLongPress
-      ? CLICK_CLOSE_EVENTS
-      : HOVER_CLOSE_EVENTS,
+    tooltipOpenEvents,
+    tooltipCloseEvents,
     tooltipGlobalCloseEvents: enableLongPress
       ? CLICK_GLOBAL_CLOSE_EVENTS
       : HOVER_GLOBAL_CLOSE_EVENTS,

--- a/components/waves/outcome/useWaveOutcomeTooltipInteraction.ts
+++ b/components/waves/outcome/useWaveOutcomeTooltipInteraction.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import useInteractionMode from "@/src/interaction/useInteractionMode";
+
+const CLICK_OPEN_EVENTS = { click: true, focus: true };
+const CLICK_CLOSE_EVENTS = { click: true, blur: true };
+const CLICK_GLOBAL_CLOSE_EVENTS = { clickOutsideAnchor: true };
+const HOVER_OPEN_EVENTS = { mouseenter: true, focus: true };
+const HOVER_CLOSE_EVENTS = { mouseleave: true, blur: true };
+const HOVER_GLOBAL_CLOSE_EVENTS = {};
+
+export default function useWaveOutcomeTooltipInteraction() {
+  const { enableLongPress } = useInteractionMode();
+
+  return {
+    useClickActivation: enableLongPress,
+    tooltipOpenEvents: enableLongPress ? CLICK_OPEN_EVENTS : HOVER_OPEN_EVENTS,
+    tooltipCloseEvents: enableLongPress
+      ? CLICK_CLOSE_EVENTS
+      : HOVER_CLOSE_EVENTS,
+    tooltipGlobalCloseEvents: enableLongPress
+      ? CLICK_GLOBAL_CLOSE_EVENTS
+      : HOVER_GLOBAL_CLOSE_EVENTS,
+  };
+}

--- a/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes.tsx
+++ b/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes.tsx
@@ -17,10 +17,10 @@ interface WaveSmallLeaderboardItemOutcomesProps {
 export const WaveSmallLeaderboardItemOutcomes: React.FC<
   WaveSmallLeaderboardItemOutcomesProps
 > = ({ drop, isMobile: _isMobile = false }) => {
-  const { enableLongPress: isTouch } = useInteractionMode();
+  const { enableHoverUI: isHoverEnabled } = useInteractionMode();
 
   const handleClick = (e: React.MouseEvent) => {
-    if (isTouch) {
+    if (!isHoverEnabled) {
       e.stopPropagation();
     }
   };
@@ -109,7 +109,7 @@ export const WaveSmallLeaderboardItemOutcomes: React.FC<
     <>
       <button
         onClick={handleClick}
-        className={`tw-flex tw-items-center tw-rounded-lg tw-border tw-border-solid tw-border-iron-700/50 tw-bg-iron-900/60 tw-px-3 tw-py-1.5 tw-backdrop-blur-sm tw-transition-colors tw-duration-200 desktop-hover:hover:tw-border-iron-600/50 desktop-hover:hover:tw-bg-iron-800/60 ${isTouch ? "tw-cursor-pointer" : ""}`}
+        className={`tw-flex tw-items-center tw-rounded-lg tw-border tw-border-solid tw-border-iron-700/50 tw-bg-iron-900/60 tw-px-3 tw-py-1.5 tw-backdrop-blur-sm tw-transition-colors tw-duration-200 desktop-hover:hover:tw-border-iron-600/50 desktop-hover:hover:tw-bg-iron-800/60 ${!isHoverEnabled ? "tw-cursor-pointer" : ""}`}
         data-tooltip-id={`wave-outcomes-${drop.id}`}
       >
         <span className="tw-text-xs tw-font-medium tw-text-iron-400">
@@ -130,9 +130,9 @@ export const WaveSmallLeaderboardItemOutcomes: React.FC<
           zIndex: 50,
         }}
         clickable={true}
-        openEvents={isTouch ? { click: true } : { mouseenter: true }}
-        closeEvents={isTouch ? { click: true } : { mouseleave: true }}
-        globalCloseEvents={isTouch ? { clickOutsideAnchor: true } : {}}
+        openEvents={isHoverEnabled ? { mouseenter: true } : { click: true }}
+        closeEvents={isHoverEnabled ? { mouseleave: true } : { click: true }}
+        globalCloseEvents={isHoverEnabled ? {} : { clickOutsideAnchor: true }}
       >
         {tooltipContent}
       </Tooltip>

--- a/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes.tsx
+++ b/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useState } from "react";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
+import React from "react";
 import { Tooltip } from "react-tooltip";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAddressCard, faStar } from "@fortawesome/free-regular-svg-icons";
@@ -16,15 +17,11 @@ interface WaveSmallLeaderboardItemOutcomesProps {
 export const WaveSmallLeaderboardItemOutcomes: React.FC<
   WaveSmallLeaderboardItemOutcomesProps
 > = ({ drop, isMobile: _isMobile = false }) => {
-  const [isTouch] = useState(
-    () => typeof globalThis !== "undefined" && "ontouchstart" in globalThis
-  );
-  const [isOpen, setIsOpen] = useState(false);
+  const { enableLongPress: isTouch } = useInteractionMode();
 
   const handleClick = (e: React.MouseEvent) => {
     if (isTouch) {
       e.stopPropagation();
-      setIsOpen(!isOpen);
     }
   };
 

--- a/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes.tsx
+++ b/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import useInteractionMode from "@/src/interaction/useInteractionMode";
+import useWaveOutcomeTooltipInteraction from "@/components/waves/outcome/useWaveOutcomeTooltipInteraction";
 import React from "react";
 import { Tooltip } from "react-tooltip";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -17,10 +17,15 @@ interface WaveSmallLeaderboardItemOutcomesProps {
 export const WaveSmallLeaderboardItemOutcomes: React.FC<
   WaveSmallLeaderboardItemOutcomesProps
 > = ({ drop, isMobile: _isMobile = false }) => {
-  const { enableHoverUI: isHoverEnabled } = useInteractionMode();
+  const {
+    useClickActivation,
+    tooltipOpenEvents,
+    tooltipCloseEvents,
+    tooltipGlobalCloseEvents,
+  } = useWaveOutcomeTooltipInteraction();
 
   const handleClick = (e: React.MouseEvent) => {
-    if (!isHoverEnabled) {
+    if (useClickActivation) {
       e.stopPropagation();
     }
   };
@@ -109,7 +114,7 @@ export const WaveSmallLeaderboardItemOutcomes: React.FC<
     <>
       <button
         onClick={handleClick}
-        className={`tw-flex tw-items-center tw-rounded-lg tw-border tw-border-solid tw-border-iron-700/50 tw-bg-iron-900/60 tw-px-3 tw-py-1.5 tw-backdrop-blur-sm tw-transition-colors tw-duration-200 desktop-hover:hover:tw-border-iron-600/50 desktop-hover:hover:tw-bg-iron-800/60 ${!isHoverEnabled ? "tw-cursor-pointer" : ""}`}
+        className={`tw-flex tw-items-center tw-rounded-lg tw-border tw-border-solid tw-border-iron-700/50 tw-bg-iron-900/60 tw-px-3 tw-py-1.5 tw-backdrop-blur-sm tw-transition-colors tw-duration-200 desktop-hover:hover:tw-border-iron-600/50 desktop-hover:hover:tw-bg-iron-800/60 ${useClickActivation ? "tw-cursor-pointer" : ""}`}
         data-tooltip-id={`wave-outcomes-${drop.id}`}
       >
         <span className="tw-text-xs tw-font-medium tw-text-iron-400">
@@ -130,9 +135,9 @@ export const WaveSmallLeaderboardItemOutcomes: React.FC<
           zIndex: 50,
         }}
         clickable={true}
-        openEvents={isHoverEnabled ? { mouseenter: true } : { click: true }}
-        closeEvents={isHoverEnabled ? { mouseleave: true } : { click: true }}
-        globalCloseEvents={isHoverEnabled ? {} : { clickOutsideAnchor: true }}
+        openEvents={tooltipOpenEvents}
+        closeEvents={tooltipCloseEvents}
+        globalCloseEvents={tooltipGlobalCloseEvents}
       >
         {tooltipContent}
       </Tooltip>

--- a/components/waves/winners/WaveWinnersSmallOutcome.tsx
+++ b/components/waves/winners/WaveWinnersSmallOutcome.tsx
@@ -21,6 +21,9 @@ export const WaveWinnersSmallOutcome: React.FC<
       e.stopPropagation();
     }
   };
+  const tooltipOpenEvents = isTouch ? { click: true } : { mouseenter: true };
+  const tooltipCloseEvents = isTouch ? { click: true } : { mouseleave: true };
+  const tooltipGlobalCloseEvents = isTouch ? { clickOutsideAnchor: true } : {};
 
   const { nicTotal, repTotal, manualOutcomes } = useWaveRankReward({
     waveId: drop.wave.id,
@@ -185,6 +188,9 @@ export const WaveWinnersSmallOutcome: React.FC<
         id={`outcome-small-${drop.id}`}
         place="top"
         delayShow={200}
+        openEvents={tooltipOpenEvents}
+        closeEvents={tooltipCloseEvents}
+        globalCloseEvents={tooltipGlobalCloseEvents}
         style={{
           backgroundColor: "#1F2937",
           color: "white",

--- a/components/waves/winners/WaveWinnersSmallOutcome.tsx
+++ b/components/waves/winners/WaveWinnersSmallOutcome.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
+import React from "react";
 import { Tooltip } from "react-tooltip";
 import { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import { formatNumberWithCommas } from "@/helpers/Helpers";
@@ -13,17 +14,11 @@ interface WaveWinnersSmallOutcomeProps {
 export const WaveWinnersSmallOutcome: React.FC<
   WaveWinnersSmallOutcomeProps
 > = ({ drop }) => {
-  const [isTouch, setIsTouch] = useState(false);
-  const [isOpen, setIsOpen] = useState(false);
-
-  useEffect(() => {
-    setIsTouch("ontouchstart" in window);
-  }, []);
+  const { enableLongPress: isTouch } = useInteractionMode();
 
   const handleClick = (e: React.MouseEvent) => {
     if (isTouch) {
       e.stopPropagation();
-      setIsOpen(!isOpen);
     }
   };
 

--- a/components/waves/winners/WaveWinnersSmallOutcome.tsx
+++ b/components/waves/winners/WaveWinnersSmallOutcome.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import useInteractionMode from "@/src/interaction/useInteractionMode";
+import useWaveOutcomeTooltipInteraction from "@/components/waves/outcome/useWaveOutcomeTooltipInteraction";
 import React from "react";
 import { Tooltip } from "react-tooltip";
 import { ExtendedDrop } from "@/helpers/waves/drop.helpers";
@@ -14,16 +14,18 @@ interface WaveWinnersSmallOutcomeProps {
 export const WaveWinnersSmallOutcome: React.FC<
   WaveWinnersSmallOutcomeProps
 > = ({ drop }) => {
-  const { enableLongPress: isTouch } = useInteractionMode();
+  const {
+    useClickActivation,
+    tooltipOpenEvents,
+    tooltipCloseEvents,
+    tooltipGlobalCloseEvents,
+  } = useWaveOutcomeTooltipInteraction();
 
   const handleClick = (e: React.MouseEvent) => {
-    if (isTouch) {
+    if (useClickActivation) {
       e.stopPropagation();
     }
   };
-  const tooltipOpenEvents = isTouch ? { click: true } : { mouseenter: true };
-  const tooltipCloseEvents = isTouch ? { click: true } : { mouseleave: true };
-  const tooltipGlobalCloseEvents = isTouch ? { clickOutsideAnchor: true } : {};
 
   const { nicTotal, repTotal, manualOutcomes } = useWaveRankReward({
     waveId: drop.wave.id,
@@ -125,10 +127,7 @@ export const WaveWinnersSmallOutcome: React.FC<
   return (
     <>
       <button
-        onClick={(e) => {
-          e.stopPropagation();
-          handleClick(e);
-        }}
+        onClick={handleClick}
         className="tw-flex tw-min-w-6 tw-items-center tw-gap-2 tw-rounded-lg tw-border-0 tw-bg-iron-800 tw-px-2 tw-py-1.5 tw-ring-1 tw-ring-iron-700"
         data-tooltip-id={`outcome-small-${drop.id}`}
       >

--- a/components/waves/winners/podium/WavePodiumItemContentOutcomes.tsx
+++ b/components/waves/winners/podium/WavePodiumItemContentOutcomes.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useState, useEffect, useMemo } from "react";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
+import React, { useMemo } from "react";
 import { Tooltip } from "react-tooltip";
 import type { ApiWaveDecisionWinner } from "@/generated/models/ApiWaveDecisionWinner";
 import { ApiWaveOutcomeCredit } from "@/generated/models/ApiWaveOutcomeCredit";
@@ -14,17 +15,11 @@ interface WavePodiumItemContentOutcomesProps {
 export const WavePodiumItemContentOutcomes: React.FC<
   WavePodiumItemContentOutcomesProps
 > = ({ winner }) => {
-  const [isTouch, setIsTouch] = useState(false);
-  const [isOpen, setIsOpen] = useState(false);
-
-  useEffect(() => {
-    setIsTouch("ontouchstart" in window);
-  }, []);
+  const { enableLongPress: isTouch } = useInteractionMode();
 
   const handleClick = (e: React.MouseEvent) => {
     if (isTouch) {
       e.stopPropagation();
-      setIsOpen(!isOpen);
     }
   };
 

--- a/components/waves/winners/podium/WavePodiumItemContentOutcomes.tsx
+++ b/components/waves/winners/podium/WavePodiumItemContentOutcomes.tsx
@@ -15,10 +15,10 @@ interface WavePodiumItemContentOutcomesProps {
 export const WavePodiumItemContentOutcomes: React.FC<
   WavePodiumItemContentOutcomesProps
 > = ({ winner }) => {
-  const { enableLongPress: isTouch } = useInteractionMode();
+  const { enableLongPress: isTouchInteraction } = useInteractionMode();
 
   const handleClick = (e: React.MouseEvent) => {
-    if (isTouch) {
+    if (isTouchInteraction) {
       e.stopPropagation();
     }
   };

--- a/components/waves/winners/podium/WavePodiumItemContentOutcomes.tsx
+++ b/components/waves/winners/podium/WavePodiumItemContentOutcomes.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import useInteractionMode from "@/src/interaction/useInteractionMode";
+import useWaveOutcomeTooltipInteraction from "@/components/waves/outcome/useWaveOutcomeTooltipInteraction";
 import React, { useMemo } from "react";
 import { Tooltip } from "react-tooltip";
 import type { ApiWaveDecisionWinner } from "@/generated/models/ApiWaveDecisionWinner";
@@ -15,10 +15,16 @@ interface WavePodiumItemContentOutcomesProps {
 export const WavePodiumItemContentOutcomes: React.FC<
   WavePodiumItemContentOutcomesProps
 > = ({ winner }) => {
-  const { enableLongPress: isTouchInteraction } = useInteractionMode();
+  const {
+    useClickActivation,
+    tooltipOpenEvents,
+    tooltipCloseEvents,
+    tooltipGlobalCloseEvents,
+  } = useWaveOutcomeTooltipInteraction();
 
   const handleClick = (e: React.MouseEvent) => {
-    if (isTouchInteraction) {
+    if (useClickActivation) {
+      e.preventDefault();
       e.stopPropagation();
     }
   };
@@ -173,11 +179,7 @@ export const WavePodiumItemContentOutcomes: React.FC<
   return (
     <>
       <button
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          handleClick(e);
-        }}
+        onClick={handleClick}
         className="tw-flex tw-items-center tw-gap-2 tw-rounded-xl tw-border tw-border-solid tw-border-iron-700/20 tw-bg-iron-800/40 tw-px-3 tw-py-1.5 tw-backdrop-blur-sm tw-transition-all tw-duration-200 hover:tw-border-iron-700/40 hover:tw-bg-iron-800/60 hover:tw-shadow-lg"
         data-tooltip-id={`outcome-${winner.place}-${winner.drop.id}`}
       >
@@ -243,6 +245,9 @@ export const WavePodiumItemContentOutcomes: React.FC<
         id={`outcome-${winner.place}-${winner.drop.id}`}
         place="left"
         delayShow={200}
+        openEvents={tooltipOpenEvents}
+        closeEvents={tooltipCloseEvents}
+        globalCloseEvents={tooltipGlobalCloseEvents}
         style={{
           backgroundColor: "#1F2937",
           color: "white",

--- a/hooks/useDeviceInfo.ts
+++ b/hooks/useDeviceInfo.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect } from "react";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 import useCapacitor from "./useCapacitor";
 
 interface DeviceInfo {
@@ -12,10 +13,10 @@ interface DeviceInfo {
 
 export default function useDeviceInfo(): DeviceInfo {
   const { isCapacitor } = useCapacitor();
-  const touchDetectedRef = useRef(false);
+  const { enableLongPress } = useInteractionMode();
 
   const getInfo = useCallback(
-    (touchDetected: boolean): DeviceInfo => {
+    (): DeviceInfo => {
       if (
         typeof globalThis === "undefined" ||
         typeof navigator === "undefined"
@@ -32,13 +33,11 @@ export default function useDeviceInfo(): DeviceInfo {
         matchMedia: (query: string) => MediaQueryList;
       };
       const nav = navigator as Navigator & {
-        msMaxTouchPoints?: number | undefined;
         userAgentData?: { mobile?: boolean | undefined } | undefined;
         standalone?: boolean | undefined;
       };
 
-      const maxTouchPoints = nav.maxTouchPoints ?? nav.msMaxTouchPoints ?? 0;
-      const hasTouchScreen = touchDetected || maxTouchPoints > 0;
+      const hasTouchScreen = enableLongPress;
 
       const ua = nav.userAgent;
       const uaDataMobile = nav.userAgentData?.mobile;
@@ -60,10 +59,10 @@ export default function useDeviceInfo(): DeviceInfo {
         isAppleMobile: appleMobile,
       };
     },
-    [isCapacitor]
+    [enableLongPress, isCapacitor]
   );
 
-  const [info, setInfo] = useState<DeviceInfo>(() => getInfo(false));
+  const [info, setInfo] = useState<DeviceInfo>(() => getInfo());
 
   useEffect(() => {
     const hasEventListenerApi =
@@ -72,7 +71,7 @@ export default function useDeviceInfo(): DeviceInfo {
 
     const update = () =>
       setInfo((prev) => {
-        const next = getInfo(touchDetectedRef.current);
+        const next = getInfo();
         if (
           prev.isMobileDevice === next.isMobileDevice &&
           prev.hasTouchScreen === next.hasTouchScreen &&
@@ -84,23 +83,13 @@ export default function useDeviceInfo(): DeviceInfo {
         return next;
       });
 
-    const onceTouch = () => {
-      touchDetectedRef.current = true;
-      update();
-      if (hasEventListenerApi) {
-        globalThis.removeEventListener("touchstart", onceTouch);
-      }
-    };
-
     if (hasEventListenerApi) {
       globalThis.addEventListener("resize", update);
-      globalThis.addEventListener("touchstart", onceTouch, { passive: true });
     }
 
     return () => {
       if (hasEventListenerApi) {
         globalThis.removeEventListener("resize", update);
-        globalThis.removeEventListener("touchstart", onceTouch);
       }
     };
   }, [getInfo]);

--- a/hooks/useDeviceInfo.ts
+++ b/hooks/useDeviceInfo.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useCallback, useEffect } from "react";
-import useInteractionMode from "@/src/interaction/useInteractionMode";
 import useCapacitor from "./useCapacitor";
 
 interface DeviceInfo {
@@ -13,7 +12,6 @@ interface DeviceInfo {
 
 export default function useDeviceInfo(): DeviceInfo {
   const { isCapacitor } = useCapacitor();
-  const { enableLongPress } = useInteractionMode();
 
   const getInfo = useCallback(
     (): DeviceInfo => {
@@ -37,13 +35,15 @@ export default function useDeviceInfo(): DeviceInfo {
         standalone?: boolean | undefined;
       };
 
-      const hasTouchScreen = enableLongPress;
+      const hasTouchCapability =
+        nav.maxTouchPoints > 0 ||
+        "ontouchstart" in (typeof window !== "undefined" ? window : ({} as Window));
 
       const ua = nav.userAgent;
       const uaDataMobile = nav.userAgentData?.mobile;
       const classicMobile =
         /Android|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(ua);
-      const iPadDesktopUA = ua.includes("Macintosh") && hasTouchScreen;
+      const iPadDesktopUA = ua.includes("Macintosh") && hasTouchCapability;
       const appleMobile = /(iPhone|iPad|iPod)/i.test(ua) || iPadDesktopUA;
       const widthMobile =
         win.matchMedia?.("(max-width: 768px)")?.matches ?? false;
@@ -54,12 +54,12 @@ export default function useDeviceInfo(): DeviceInfo {
 
       return {
         isMobileDevice,
-        hasTouchScreen,
+        hasTouchScreen: hasTouchCapability,
         isApp: isCapacitor,
         isAppleMobile: appleMobile,
       };
     },
-    [enableLongPress, isCapacitor]
+    [isCapacitor]
   );
 
   const [info, setInfo] = useState<DeviceInfo>(() => getInfo());
@@ -83,6 +83,7 @@ export default function useDeviceInfo(): DeviceInfo {
         return next;
       });
 
+    update();
     if (hasEventListenerApi) {
       globalThis.addEventListener("resize", update);
     }

--- a/hooks/useDeviceInfo.ts
+++ b/hooks/useDeviceInfo.ts
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useEffect } from "react";
 import useCapacitor from "./useCapacitor";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 
 interface DeviceInfo {
   readonly isMobileDevice: boolean;
@@ -12,55 +13,45 @@ interface DeviceInfo {
 
 export default function useDeviceInfo(): DeviceInfo {
   const { isCapacitor } = useCapacitor();
+  const { enableLongPress, hasCoarsePointer } = useInteractionMode();
 
-  const getInfo = useCallback(
-    (): DeviceInfo => {
-      if (
-        typeof globalThis === "undefined" ||
-        typeof navigator === "undefined"
-      ) {
-        return {
-          isMobileDevice: false,
-          hasTouchScreen: false,
-          isApp: false,
-          isAppleMobile: false,
-        };
-      }
-
-      const win = globalThis as typeof globalThis & {
-        matchMedia: (query: string) => MediaQueryList;
-      };
-      const nav = navigator as Navigator & {
-        userAgentData?: { mobile?: boolean | undefined } | undefined;
-        standalone?: boolean | undefined;
-      };
-
-      const hasTouchCapability =
-        nav.maxTouchPoints > 0 ||
-        "ontouchstart" in (typeof window !== "undefined" ? window : ({} as Window));
-
-      const ua = nav.userAgent;
-      const uaDataMobile = nav.userAgentData?.mobile;
-      const classicMobile =
-        /Android|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(ua);
-      const iPadDesktopUA = ua.includes("Macintosh") && hasTouchCapability;
-      const appleMobile = /(iPhone|iPad|iPod)/i.test(ua) || iPadDesktopUA;
-      const widthMobile =
-        win.matchMedia?.("(max-width: 768px)")?.matches ?? false;
-
-      const isMobileDevice =
-        uaDataMobile ??
-        (classicMobile || (isCapacitor && (iPadDesktopUA || widthMobile)));
-
+  const getInfo = useCallback((): DeviceInfo => {
+    if (typeof globalThis === "undefined" || typeof navigator === "undefined") {
       return {
-        isMobileDevice,
-        hasTouchScreen: hasTouchCapability,
-        isApp: isCapacitor,
-        isAppleMobile: appleMobile,
+        isMobileDevice: false,
+        hasTouchScreen: false,
+        isApp: false,
+        isAppleMobile: false,
       };
-    },
-    [isCapacitor]
-  );
+    }
+
+    const win = globalThis as typeof globalThis & {
+      matchMedia: (query: string) => MediaQueryList;
+    };
+    const nav = navigator as Navigator & {
+      userAgentData?: { mobile?: boolean | undefined } | undefined;
+    };
+
+    const ua = nav.userAgent;
+    const uaDataMobile = nav.userAgentData?.mobile;
+    const classicMobile =
+      /Android|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(ua);
+    const iPadDesktopUA = ua.includes("Macintosh") && hasCoarsePointer;
+    const appleMobile = /(iPhone|iPad|iPod)/i.test(ua) || iPadDesktopUA;
+    const widthMobile =
+      win.matchMedia?.("(max-width: 768px)")?.matches ?? false;
+
+    const isMobileDevice =
+      uaDataMobile ??
+      (classicMobile || (isCapacitor && (iPadDesktopUA || widthMobile)));
+
+    return {
+      isMobileDevice,
+      hasTouchScreen: enableLongPress,
+      isApp: isCapacitor,
+      isAppleMobile: appleMobile,
+    };
+  }, [enableLongPress, hasCoarsePointer, isCapacitor]);
 
   const [info, setInfo] = useState<DeviceInfo>(() => getInfo());
 

--- a/hooks/useDeviceInfo.ts
+++ b/hooks/useDeviceInfo.ts
@@ -13,7 +13,10 @@ interface DeviceInfo {
 
 export default function useDeviceInfo(): DeviceInfo {
   const { isCapacitor } = useCapacitor();
-  const { enableLongPress, hasCoarsePointer } = useInteractionMode();
+  const {
+    enableLongPress: hasTouchScreen,
+    hasCoarsePointer,
+  } = useInteractionMode();
 
   const getInfo = useCallback((): DeviceInfo => {
     if (typeof globalThis === "undefined" || typeof navigator === "undefined") {
@@ -47,11 +50,11 @@ export default function useDeviceInfo(): DeviceInfo {
 
     return {
       isMobileDevice,
-      hasTouchScreen: enableLongPress,
+      hasTouchScreen,
       isApp: isCapacitor,
       isAppleMobile: appleMobile,
     };
-  }, [enableLongPress, hasCoarsePointer, isCapacitor]);
+  }, [hasTouchScreen, hasCoarsePointer, isCapacitor]);
 
   const [info, setInfo] = useState<DeviceInfo>(() => getInfo());
 

--- a/hooks/useDeviceInfo.ts
+++ b/hooks/useDeviceInfo.ts
@@ -13,10 +13,8 @@ interface DeviceInfo {
 
 export default function useDeviceInfo(): DeviceInfo {
   const { isCapacitor } = useCapacitor();
-  const {
-    enableLongPress: hasTouchScreen,
-    hasCoarsePointer,
-  } = useInteractionMode();
+  const { enableLongPress, hasCoarsePointer } = useInteractionMode();
+  const hasTouchScreen = enableLongPress;
 
   const getInfo = useCallback((): DeviceInfo => {
     if (typeof globalThis === "undefined" || typeof navigator === "undefined") {

--- a/hooks/useHasTouchInput.ts
+++ b/hooks/useHasTouchInput.ts
@@ -1,37 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 
+/** @deprecated Use useInteractionMode().enableLongPress instead. */
 export default function useHasTouchInput(): boolean {
-  const [hasTouchInput, setHasTouchInput] = useState(() => {
-    if (typeof globalThis === "undefined") {
-      return false;
-    }
-
-    const nav = globalThis.navigator as Navigator | undefined;
-    return (nav?.maxTouchPoints ?? 0) > 0;
-  });
-
-  useEffect(() => {
-    if (typeof globalThis === "undefined") {
-      return;
-    }
-
-    if (hasTouchInput) {
-      return;
-    }
-
-    const onTouchStart = () => {
-      setHasTouchInput(true);
-      globalThis.removeEventListener("touchstart", onTouchStart);
-    };
-
-    globalThis.addEventListener("touchstart", onTouchStart, { passive: true });
-
-    return () => {
-      globalThis.removeEventListener("touchstart", onTouchStart);
-    };
-  }, [hasTouchInput]);
-
-  return hasTouchInput;
+  const { enableLongPress } = useInteractionMode();
+  return enableLongPress;
 }

--- a/hooks/useIsTouchDevice.ts
+++ b/hooks/useIsTouchDevice.ts
@@ -1,55 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 
+/** @deprecated Use useInteractionMode().enableLongPress instead. */
 export default function useIsTouchDevice(): boolean {
-  const [isTouchDevice, setIsTouchDevice] = useState(false);
-
-  useEffect(() => {
-    if (typeof globalThis === "undefined") {
-      return;
-    }
-
-    const win = globalThis as typeof globalThis & {
-      matchMedia?: (query: string) => MediaQueryList;
-    };
-
-    const nav = globalThis.navigator as Navigator | undefined;
-    const maxTouchPoints = nav?.maxTouchPoints ?? 0;
-
-    // Prefer "any-*" media queries so hybrid devices (touchscreen + trackpad/mouse)
-    // aren't misclassified as touch-only when the primary pointer is coarse.
-    const hasAnyFinePointer = win.matchMedia?.("(any-pointer: fine)")?.matches ?? false;
-    const hasPrimaryFinePointer = win.matchMedia?.("(pointer: fine)")?.matches ?? false;
-    const hasFinePointer = hasAnyFinePointer || hasPrimaryFinePointer;
-
-    const hasAnyHover = win.matchMedia?.("(any-hover: hover)")?.matches ?? false;
-    const hasPrimaryHover = win.matchMedia?.("(hover: hover)")?.matches ?? false;
-    const hasHover = hasAnyHover || hasPrimaryHover;
-
-    if (hasFinePointer || hasHover) {
-      setIsTouchDevice(false);
-      return;
-    }
-
-    // If there's no fine pointer and the device advertises touch points, treat it
-    // as touch (important for first-touch interactions like long-press menus).
-    if (maxTouchPoints > 0) {
-      setIsTouchDevice(true);
-      return;
-    }
-
-    const onTouchStart = () => {
-      setIsTouchDevice(true);
-      globalThis.removeEventListener("touchstart", onTouchStart);
-    };
-
-    globalThis.addEventListener("touchstart", onTouchStart, { passive: true });
-
-    return () => {
-      globalThis.removeEventListener("touchstart", onTouchStart);
-    };
-  }, []);
-
-  return isTouchDevice;
+  const { enableLongPress } = useInteractionMode();
+  return enableLongPress;
 }

--- a/hooks/useSidebarController.ts
+++ b/hooks/useSidebarController.ts
@@ -7,6 +7,7 @@ import {
   SIDEBAR_MOBILE_BREAKPOINT,
 } from "../constants/sidebar";
 import { safeSessionStorage } from "../helpers/safeSessionStorage";
+import useInteractionMode from "@/src/interaction/useInteractionMode";
 
 const getBrowserWindow = () => {
   const { window: browserWindow } = globalThis as typeof globalThis & {
@@ -44,15 +45,14 @@ export function useSidebarController() {
     () => createMediaQuery(`(max-width: ${SIDEBAR_BREAKPOINT - 0.02}px)`),
     [createMediaQuery]
   );
-  const coarseMql = useMemo(() => createMediaQuery("(pointer: coarse)"), [createMediaQuery]);
   const mobileWidthMql = useMemo(
     () => createMediaQuery(`(max-width: ${SIDEBAR_MOBILE_BREAKPOINT - 0.02}px)`),
     [createMediaQuery]
   );
 
   const [isNarrow, setIsNarrow] = useState(() => narrowMql?.matches ?? false);
-  const [isTouchScreen, setIsTouchScreen] = useState(() => coarseMql?.matches ?? false);
   const [isMobileWidth, setIsMobileWidth] = useState(() => mobileWidthMql?.matches ?? false);
+  const { enableLongPress: isTouchScreen } = useInteractionMode();
 
   const lastIsNarrowRef = useRef(isNarrow);
 
@@ -112,16 +112,6 @@ export function useSidebarController() {
     narrowMql.addEventListener("change", handleChange);
     return () => narrowMql.removeEventListener("change", handleChange);
   }, [narrowMql]);
-
-  useEffect(() => {
-    if (!coarseMql) {
-      return;
-    }
-    const handleChange = (event: MediaQueryListEvent) => setIsTouchScreen(event.matches);
-    setIsTouchScreen(coarseMql.matches);
-    coarseMql.addEventListener("change", handleChange);
-    return () => coarseMql.removeEventListener("change", handleChange);
-  }, [coarseMql]);
 
   useEffect(() => {
     if (!mobileWidthMql) {

--- a/hooks/useSidebarController.ts
+++ b/hooks/useSidebarController.ts
@@ -52,7 +52,8 @@ export function useSidebarController() {
 
   const [isNarrow, setIsNarrow] = useState(() => narrowMql?.matches ?? false);
   const [isMobileWidth, setIsMobileWidth] = useState(() => mobileWidthMql?.matches ?? false);
-  const { enableLongPress: isTouchScreen } = useInteractionMode();
+  const { enableHoverUI } = useInteractionMode();
+  const isTouchScreen = !enableHoverUI;
 
   const lastIsNarrowRef = useRef(isNarrow);
 

--- a/hooks/useSidebarController.ts
+++ b/hooks/useSidebarController.ts
@@ -33,27 +33,35 @@ const getBrowserWindow = () => {
  *   by the sidebar component, not this hook.
  */
 export function useSidebarController() {
-  const createMediaQuery = useCallback((query: string): MediaQueryList | null => {
-    const browserWindow = getBrowserWindow();
-    if (browserWindow === undefined || typeof browserWindow.matchMedia !== "function") {
-      return null;
-    }
-    return browserWindow.matchMedia(query);
-  }, []);
+  const createMediaQuery = useCallback(
+    (query: string): MediaQueryList | null => {
+      const browserWindow = getBrowserWindow();
+      if (
+        browserWindow === undefined ||
+        typeof browserWindow.matchMedia !== "function"
+      ) {
+        return null;
+      }
+      return browserWindow.matchMedia(query);
+    },
+    []
+  );
 
   const narrowMql = useMemo(
     () => createMediaQuery(`(max-width: ${SIDEBAR_BREAKPOINT - 0.02}px)`),
     [createMediaQuery]
   );
   const mobileWidthMql = useMemo(
-    () => createMediaQuery(`(max-width: ${SIDEBAR_MOBILE_BREAKPOINT - 0.02}px)`),
+    () =>
+      createMediaQuery(`(max-width: ${SIDEBAR_MOBILE_BREAKPOINT - 0.02}px)`),
     [createMediaQuery]
   );
 
   const [isNarrow, setIsNarrow] = useState(() => narrowMql?.matches ?? false);
-  const [isMobileWidth, setIsMobileWidth] = useState(() => mobileWidthMql?.matches ?? false);
-  const { enableHoverUI } = useInteractionMode();
-  const isTouchScreen = !enableHoverUI;
+  const [isMobileWidth, setIsMobileWidth] = useState(
+    () => mobileWidthMql?.matches ?? false
+  );
+  const { hasCoarsePointer } = useInteractionMode();
 
   const lastIsNarrowRef = useRef(isNarrow);
 
@@ -70,23 +78,29 @@ export function useSidebarController() {
     }
   });
 
-  const persistDesktopCollapsed = useCallback((value: boolean | ((prev: boolean) => boolean)) => {
-    setIsDesktopCollapsed((prev: boolean) => {
-      const newValue = typeof value === "function" ? value(prev) : value;
-      try {
-        safeSessionStorage.setItem("sidebarCollapsed", JSON.stringify(newValue));
-      } catch (e) {
-        console.warn("Failed to save sidebar preference:", e);
-      }
-      return newValue;
-    });
-  }, []);
+  const persistDesktopCollapsed = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) => {
+      setIsDesktopCollapsed((prev: boolean) => {
+        const newValue = typeof value === "function" ? value(prev) : value;
+        try {
+          safeSessionStorage.setItem(
+            "sidebarCollapsed",
+            JSON.stringify(newValue)
+          );
+        } catch (e) {
+          console.warn("Failed to save sidebar preference:", e);
+        }
+        return newValue;
+      });
+    },
+    []
+  );
 
   const [isOffcanvasOpen, setIsOffcanvasOpen] = useState(false);
 
   const isMobile = useMemo(
-    () => isMobileWidth && isTouchScreen,
-    [isMobileWidth, isTouchScreen]
+    () => isMobileWidth && hasCoarsePointer,
+    [isMobileWidth, hasCoarsePointer]
   );
 
   const isOffcanvasMode = useMemo(
@@ -108,7 +122,8 @@ export function useSidebarController() {
     if (!narrowMql) {
       return;
     }
-    const handleChange = (event: MediaQueryListEvent) => setIsNarrow(event.matches);
+    const handleChange = (event: MediaQueryListEvent) =>
+      setIsNarrow(event.matches);
     setIsNarrow(narrowMql.matches);
     narrowMql.addEventListener("change", handleChange);
     return () => narrowMql.removeEventListener("change", handleChange);
@@ -118,7 +133,8 @@ export function useSidebarController() {
     if (!mobileWidthMql) {
       return;
     }
-    const handleChange = (event: MediaQueryListEvent) => setIsMobileWidth(event.matches);
+    const handleChange = (event: MediaQueryListEvent) =>
+      setIsMobileWidth(event.matches);
     setIsMobileWidth(mobileWidthMql.matches);
     mobileWidthMql.addEventListener("change", handleChange);
     return () => mobileWidthMql.removeEventListener("change", handleChange);
@@ -147,9 +163,9 @@ export function useSidebarController() {
 
   const toggleCollapsed = useCallback(() => {
     if (isOffcanvasMode) {
-      setIsOffcanvasOpen(prev => !prev);
+      setIsOffcanvasOpen((prev) => !prev);
     } else {
-      persistDesktopCollapsed(prev => !prev);
+      persistDesktopCollapsed((prev) => !prev);
     }
   }, [isOffcanvasMode, persistDesktopCollapsed]);
 

--- a/src/interaction/useInteractionMode.ts
+++ b/src/interaction/useInteractionMode.ts
@@ -21,6 +21,9 @@ const DEFAULT_STATE: InteractionModeState = {
 let cachedState: InteractionModeState = DEFAULT_STATE;
 let initialized = false;
 const subscribers = new Set<(state: InteractionModeState) => void>();
+let mediaQueriesRef: MediaQueryList[] | null = null;
+let handlePointerDownRef: ((event: PointerEvent) => void) | null = null;
+let handlePointerMoveRef: ((event: PointerEvent) => void) | null = null;
 
 const getMediaMatch = (query: string): boolean => {
   if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
@@ -37,7 +40,9 @@ const getCapabilityState = (): Pick<InteractionModeState, "canHover" | "hasFineP
 
 const emit = (nextState: InteractionModeState) => {
   cachedState = nextState;
-  subscribers.forEach((subscriber) => subscriber(cachedState));
+  subscribers.forEach((subscriber) => {
+    subscriber(cachedState);
+  });
 };
 
 const updateCapabilities = () => {
@@ -54,6 +59,21 @@ const updatePointerType = (pointerType: string) => {
   emit({ ...cachedState, lastPointerType: pointerType });
 };
 
+function teardown() {
+  if (typeof window === "undefined" || !mediaQueriesRef || !handlePointerDownRef || !handlePointerMoveRef) {
+    return;
+  }
+  mediaQueriesRef.forEach((query) => {
+    query.removeEventListener("change", updateCapabilities);
+  });
+  window.removeEventListener("pointerdown", handlePointerDownRef, { passive: true } as EventListenerOptions);
+  window.removeEventListener("pointermove", handlePointerMoveRef, { passive: true } as EventListenerOptions);
+  mediaQueriesRef = null;
+  handlePointerDownRef = null;
+  handlePointerMoveRef = null;
+  initialized = false;
+}
+
 const init = () => {
   if (initialized || typeof window === "undefined") {
     return;
@@ -67,9 +87,12 @@ const init = () => {
     window.matchMedia("(any-pointer: fine)"),
     window.matchMedia("(hover: none)"),
   ];
+  mediaQueriesRef = mediaQueries;
 
   const handlePointerDown = (event: PointerEvent) => updatePointerType(event.pointerType);
   const handlePointerMove = (event: PointerEvent) => updatePointerType(event.pointerType);
+  handlePointerDownRef = handlePointerDown;
+  handlePointerMoveRef = handlePointerMove;
 
   mediaQueries.forEach((query) => {
     query.addEventListener("change", updateCapabilities);
@@ -90,6 +113,9 @@ export default function useInteractionMode() {
 
     return () => {
       subscribers.delete(onChange);
+      if (subscribers.size === 0) {
+        teardown();
+      }
     };
   }, []);
 

--- a/src/interaction/useInteractionMode.ts
+++ b/src/interaction/useInteractionMode.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type PointerType = "mouse" | "touch" | "pen" | null;
+
+interface InteractionModeState {
+  readonly canHover: boolean;
+  readonly hasFinePointer: boolean;
+  readonly hoverNone: boolean;
+  readonly lastPointerType: PointerType;
+}
+
+const DEFAULT_STATE: InteractionModeState = {
+  canHover: false,
+  hasFinePointer: false,
+  hoverNone: false,
+  lastPointerType: null,
+};
+
+let cachedState: InteractionModeState = DEFAULT_STATE;
+let initialized = false;
+const subscribers = new Set<(state: InteractionModeState) => void>();
+
+const getMediaMatch = (query: string): boolean => {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  return window.matchMedia(query).matches;
+};
+
+const getCapabilityState = (): Pick<InteractionModeState, "canHover" | "hasFinePointer" | "hoverNone"> => ({
+  canHover: getMediaMatch("(any-hover: hover)"),
+  hasFinePointer: getMediaMatch("(any-pointer: fine)"),
+  hoverNone: getMediaMatch("(hover: none)"),
+});
+
+const emit = (nextState: InteractionModeState) => {
+  cachedState = nextState;
+  subscribers.forEach((subscriber) => subscriber(cachedState));
+};
+
+const updateCapabilities = () => {
+  emit({ ...cachedState, ...getCapabilityState() });
+};
+
+const updatePointerType = (pointerType: string) => {
+  if (pointerType !== "mouse" && pointerType !== "touch" && pointerType !== "pen") {
+    return;
+  }
+  if (cachedState.lastPointerType === pointerType) {
+    return;
+  }
+  emit({ ...cachedState, lastPointerType: pointerType });
+};
+
+const init = () => {
+  if (initialized || typeof window === "undefined") {
+    return;
+  }
+
+  initialized = true;
+  cachedState = { ...cachedState, ...getCapabilityState() };
+
+  const mediaQueries = [
+    window.matchMedia("(any-hover: hover)"),
+    window.matchMedia("(any-pointer: fine)"),
+    window.matchMedia("(hover: none)"),
+  ];
+
+  const handlePointerDown = (event: PointerEvent) => updatePointerType(event.pointerType);
+  const handlePointerMove = (event: PointerEvent) => updatePointerType(event.pointerType);
+
+  mediaQueries.forEach((query) => {
+    query.addEventListener("change", updateCapabilities);
+  });
+
+  window.addEventListener("pointerdown", handlePointerDown, { passive: true });
+  window.addEventListener("pointermove", handlePointerMove, { passive: true });
+};
+
+export default function useInteractionMode() {
+  const [state, setState] = useState<InteractionModeState>(() => cachedState);
+
+  useEffect(() => {
+    init();
+    const onChange = (nextState: InteractionModeState) => setState(nextState);
+    subscribers.add(onChange);
+    onChange(cachedState);
+
+    return () => {
+      subscribers.delete(onChange);
+    };
+  }, []);
+
+  const { canHover, hasFinePointer, hoverNone, lastPointerType } = state;
+
+  return {
+    canHover,
+    hasFinePointer,
+    hoverNone,
+    lastPointerType,
+    enableHoverUI: canHover || hasFinePointer,
+    enableLongPress: hoverNone || lastPointerType === "touch",
+  };
+}

--- a/src/interaction/useInteractionMode.ts
+++ b/src/interaction/useInteractionMode.ts
@@ -4,16 +4,31 @@ import { useEffect, useState } from "react";
 
 export type PointerType = "mouse" | "touch" | "pen" | null;
 
-interface InteractionModeState {
+export interface InteractionModeState {
   readonly canHover: boolean;
   readonly hasFinePointer: boolean;
+  readonly hasCoarsePointer: boolean;
   readonly hoverNone: boolean;
   readonly lastPointerType: PointerType;
+}
+
+export interface InteractionMode extends InteractionModeState {
+  /**
+   * Use for hover-revealed UI and desktop hover tooltips. This can stay true
+   * on hybrid devices even after touch input is observed.
+   */
+  readonly enableHoverUI: boolean;
+  /**
+   * Use for touch/tap/long-press activation paths. This can overlap with
+   * enableHoverUI on hybrid devices when the last pointer was touch.
+   */
+  readonly enableLongPress: boolean;
 }
 
 const DEFAULT_STATE: InteractionModeState = {
   canHover: false,
   hasFinePointer: false,
+  hasCoarsePointer: false,
   hoverNone: false,
   lastPointerType: null,
 };
@@ -26,15 +41,22 @@ let handlePointerDownRef: ((event: PointerEvent) => void) | null = null;
 let handlePointerMoveRef: ((event: PointerEvent) => void) | null = null;
 
 const getMediaMatch = (query: string): boolean => {
-  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
     return false;
   }
   return window.matchMedia(query).matches;
 };
 
-const getCapabilityState = (): Pick<InteractionModeState, "canHover" | "hasFinePointer" | "hoverNone"> => ({
+const getCapabilityState = (): Pick<
+  InteractionModeState,
+  "canHover" | "hasFinePointer" | "hasCoarsePointer" | "hoverNone"
+> => ({
   canHover: getMediaMatch("(any-hover: hover)"),
   hasFinePointer: getMediaMatch("(any-pointer: fine)"),
+  hasCoarsePointer: getMediaMatch("(pointer: coarse)"),
   hoverNone: getMediaMatch("(hover: none)"),
 });
 
@@ -50,7 +72,11 @@ const updateCapabilities = () => {
 };
 
 const updatePointerType = (pointerType: string) => {
-  if (pointerType !== "mouse" && pointerType !== "touch" && pointerType !== "pen") {
+  if (
+    pointerType !== "mouse" &&
+    pointerType !== "touch" &&
+    pointerType !== "pen"
+  ) {
     return;
   }
   if (cachedState.lastPointerType === pointerType) {
@@ -60,17 +86,27 @@ const updatePointerType = (pointerType: string) => {
 };
 
 function teardown() {
-  if (typeof window === "undefined" || !mediaQueriesRef || !handlePointerDownRef || !handlePointerMoveRef) {
+  if (
+    typeof window === "undefined" ||
+    !mediaQueriesRef ||
+    !handlePointerDownRef ||
+    !handlePointerMoveRef
+  ) {
     return;
   }
   mediaQueriesRef.forEach((query) => {
     query.removeEventListener("change", updateCapabilities);
   });
-  window.removeEventListener("pointerdown", handlePointerDownRef, { passive: true } as EventListenerOptions);
-  window.removeEventListener("pointermove", handlePointerMoveRef, { passive: true } as EventListenerOptions);
+  window.removeEventListener("pointerdown", handlePointerDownRef, {
+    passive: true,
+  } as EventListenerOptions);
+  window.removeEventListener("pointermove", handlePointerMoveRef, {
+    passive: true,
+  } as EventListenerOptions);
   mediaQueriesRef = null;
   handlePointerDownRef = null;
   handlePointerMoveRef = null;
+  cachedState = DEFAULT_STATE;
   initialized = false;
 }
 
@@ -82,15 +118,21 @@ const init = () => {
   initialized = true;
   cachedState = { ...cachedState, ...getCapabilityState() };
 
-  const mediaQueries = [
-    window.matchMedia("(any-hover: hover)"),
-    window.matchMedia("(any-pointer: fine)"),
-    window.matchMedia("(hover: none)"),
-  ];
+  const mediaQueries =
+    typeof window.matchMedia === "function"
+      ? [
+          window.matchMedia("(any-hover: hover)"),
+          window.matchMedia("(any-pointer: fine)"),
+          window.matchMedia("(pointer: coarse)"),
+          window.matchMedia("(hover: none)"),
+        ]
+      : [];
   mediaQueriesRef = mediaQueries;
 
-  const handlePointerDown = (event: PointerEvent) => updatePointerType(event.pointerType);
-  const handlePointerMove = (event: PointerEvent) => updatePointerType(event.pointerType);
+  const handlePointerDown = (event: PointerEvent) =>
+    updatePointerType(event.pointerType);
+  const handlePointerMove = (event: PointerEvent) =>
+    updatePointerType(event.pointerType);
   handlePointerDownRef = handlePointerDown;
   handlePointerMoveRef = handlePointerMove;
 
@@ -102,7 +144,19 @@ const init = () => {
   window.addEventListener("pointermove", handlePointerMove, { passive: true });
 };
 
-export default function useInteractionMode() {
+export const deriveInteractionMode = (
+  state: InteractionModeState
+): InteractionMode => {
+  const { canHover, hasFinePointer, hoverNone, lastPointerType } = state;
+
+  return {
+    ...state,
+    enableHoverUI: canHover || hasFinePointer,
+    enableLongPress: hoverNone || lastPointerType === "touch",
+  };
+};
+
+export default function useInteractionMode(): InteractionMode {
   const [state, setState] = useState<InteractionModeState>(() => cachedState);
 
   useEffect(() => {
@@ -119,14 +173,5 @@ export default function useInteractionMode() {
     };
   }, []);
 
-  const { canHover, hasFinePointer, hoverNone, lastPointerType } = state;
-
-  return {
-    canHover,
-    hasFinePointer,
-    hoverNone,
-    lastPointerType,
-    enableHoverUI: canHover || hasFinePointer,
-    enableLongPress: hoverNone || lastPointerType === "touch",
-  };
+  return deriveInteractionMode(state);
 }


### PR DESCRIPTION
### Motivation

- Unify hover / touch / long-press decisions so hybrid devices can support cursor hover and touch long-press simultaneously without one disabling the other. 
- Remove scattered heuristics (`maxTouchPoints`, `ontouchstart`, ad-hoc `matchMedia` checks) and consolidate logic in one SSR-safe client module. 
- Provide a single API consumers can use for both hover-equivalent UI and long-press behavior to make future rules changes trivial.

### Description

- Added a new client hook at `src/interaction/useInteractionMode.ts` which computes capabilities via media queries and tracks `lastPointerType` globally using `pointerdown`/`pointermove`, and exposes `enableHoverUI`, `enableLongPress`, `lastPointerType` and raw fields (`canHover`, `hasFinePointer`, `hoverNone`).
- Replaced direct uses of `useHasTouchInput`, `useIsTouchDevice`, `navigator.maxTouchPoints`, `ontouchstart`, and ad-hoc `matchMedia` logic across multiple components to consume the new hook instead (notable files updated include drops/waves, sidebars, header search, profile activity copy, and a number of UI helpers). 
- Kept `hooks/useHasTouchInput.ts` and `hooks/useIsTouchDevice.ts` as thin deprecated wrappers that delegate to `useInteractionMode()` to preserve backward compatibility while preventing direct low-level logic usage. 
- Adjusted sidebar controller and hover-only UI gating to depend on `enableHoverUI` and `enableLongPress`, and ensured long-press gating follows the new rules (enable when `hover: none` or last pointer was `touch`).

### Testing

- Ran repository scans to confirm input-mode checks were centralized and no remaining ad-hoc usage of `maxTouchPoints`/`ontouchstart`/`matchMedia("(hover`|"(pointer`)` remain outside the new module; scan validated the centralization. (succeeded)
- Attempted full TypeScript typecheck (`npm run typecheck` / `npx tsc`) but environment lacked some type-definition dependencies (`@testing-library/jest-dom`, `node` types), preventing a complete typecheck (failed due to missing deps). 
- Attempted lint/format checks (`npx eslint`, `npx prettier`) but local environment resolution for tooling/config made them fail in this environment (failed due to missing local dev-tool resolution). 
- Verified code changes compiled locally enough to run the repository search and applied updates; no runtime tests were executed here due to environment constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a563fa1fc883338815bea28c637d1e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized interaction-mode hook to standardize hover UI and long-press behavior across the app.
  * Added a dedicated hook to control outcome tooltip open/close behavior for hover, click, and hybrid modes.

* **Refactor**
  * Replaced scattered touch/hover detection logic with the interaction-mode flag in multiple UI components (tooltips, copy controls, pins, sidebar, dropdowns, and wave drops).

* **Bug Fixes**
  * Improved tooltip and scroll-arrow visibility so UI behavior correctly matches the active interaction mode.

* **Tests**
  * Updated and expanded interaction/tooltip test coverage using the centralized mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->