### PR TITLE
Remove 'Add Metadata' icon when in chat mode

### DIFF
--- a/__tests__/components/waves/CreateDropActions.test.tsx
+++ b/__tests__/components/waves/CreateDropActions.test.tsx
@@ -26,10 +26,16 @@ jest.mock("framer-motion", () => {
   return {
     __esModule: true,
     motion: {
-      div: React.forwardRef(function Div({ children, ...props }: { children: React.ReactNode }, ref: React.Ref<HTMLDivElement>) {
+      div: React.forwardRef(function Div(
+        { children, ...props }: { children: React.ReactNode },
+        ref: React.Ref<HTMLDivElement>
+      ) {
         return React.createElement("div", { ...props, ref }, children);
       }),
-      button: React.forwardRef(function Btn({ children, ...props }: { children: React.ReactNode }, ref: React.Ref<HTMLButtonElement>) {
+      button: React.forwardRef(function Btn(
+        { children, ...props }: { children: React.ReactNode },
+        ref: React.Ref<HTMLButtonElement>
+      ) {
         return React.createElement("button", { ...props, ref }, children);
       }),
     },
@@ -51,7 +57,8 @@ jest.mock("@/components/waves/StormButton", () => {
       <button
         data-testid="storm-button"
         onClick={breakIntoStorm}
-        disabled={submitting || !canAddPart}>
+        disabled={submitting || !canAddPart}
+      >
         {isStormMode ? "Storm Mode" : "Storm"}
       </button>
     );
@@ -64,7 +71,8 @@ jest.mock("@/components/waves/CreateDropGifPicker", () => {
       <div data-testid="gif-picker">
         <button
           onClick={() => onSelect("test-gif.gif")}
-          data-testid="select-gif">
+          data-testid="select-gif"
+        >
           Select GIF
         </button>
         <button onClick={() => setShow(false)} data-testid="close-gif">
@@ -83,6 +91,7 @@ jest.mock("@/hooks/isMobileScreen", () => ({
 describe("CreateDropActions", () => {
   const defaultProps = {
     isStormMode: false,
+    isDropMode: true,
     canAddPart: true,
     submitting: false,
     isRequiredMetadataMissing: false,
@@ -109,8 +118,8 @@ describe("CreateDropActions", () => {
 
     // Find and click the chevron button (the one without aria-label in narrow container)
     const buttons = screen.getAllByRole("button");
-    const chevronButton = buttons.find(
-      (btn) => btn.querySelector('path[d="m8.25 4.5 7.5 7.5-7.5 7.5"]')
+    const chevronButton = buttons.find((btn) =>
+      btn.querySelector('path[d="m8.25 4.5 7.5 7.5-7.5 7.5"]')
     );
 
     if (chevronButton) {
@@ -131,24 +140,24 @@ describe("CreateDropActions", () => {
   it("calls onAddMetadataClick when metadata button is clicked", async () => {
     render(<CreateDropActions {...defaultProps} />);
 
-    // Find metadata buttons (the ones with the code icon, without aria-label)
-    const buttons = screen.getAllByRole("button");
-    const metadataButton = buttons.find(
-      (button) =>
-        button.querySelector('path[d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"]')
-    );
+    await userEvent.click(screen.getByLabelText("Add metadata"));
 
-    if (metadataButton) {
-      await userEvent.click(metadataButton);
-      expect(defaultProps.onAddMetadataClick).toHaveBeenCalled();
-    }
+    expect(defaultProps.onAddMetadataClick).toHaveBeenCalled();
+  });
+
+  it("does not render metadata button in chat mode", () => {
+    render(<CreateDropActions {...defaultProps} isDropMode={false} />);
+
+    expect(screen.queryByLabelText("Add metadata")).not.toBeInTheDocument();
   });
 
   it("handles file upload", async () => {
     render(<CreateDropActions {...defaultProps} />);
 
     const fileInputs = screen.getAllByLabelText("Upload a file");
-    const fileInput = fileInputs[0]?.querySelector('input[type="file"]') as HTMLInputElement;
+    const fileInput = fileInputs[0]?.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
     const file = new File(["test"], "test.jpg", { type: "image/jpeg" });
 
     await userEvent.upload(fileInput, file);
@@ -218,26 +227,16 @@ describe("CreateDropActions", () => {
 
   it("highlights metadata button when metadata is missing", () => {
     render(
-      <CreateDropActions
-        {...defaultProps}
-        isRequiredMetadataMissing={true}
-      />
+      <CreateDropActions {...defaultProps} isRequiredMetadataMissing={true} />
     );
 
-    const buttons = screen.getAllByRole("button");
-    const metadataButton = buttons.find(
-      (button) =>
-        button.querySelector('path[d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"]')
-    );
+    const metadataButton = screen.getByLabelText("Add metadata");
     expect(metadataButton).toHaveClass("tw-text-[#FEDF89]");
   });
 
   it("highlights upload button when media is missing", () => {
     render(
-      <CreateDropActions
-        {...defaultProps}
-        isRequiredMediaMissing={true}
-      />
+      <CreateDropActions {...defaultProps} isRequiredMediaMissing={true} />
     );
 
     const uploadLabels = screen.getAllByLabelText("Upload a file");
@@ -255,8 +254,8 @@ describe("CreateDropActions", () => {
     );
 
     const buttons = screen.getAllByRole("button");
-    const chevronButton = buttons.find(
-      (btn) => btn.querySelector('path[d="m8.25 4.5 7.5 7.5-7.5 7.5"]')
+    const chevronButton = buttons.find((btn) =>
+      btn.querySelector('path[d="m8.25 4.5 7.5 7.5-7.5 7.5"]')
     );
     expect(chevronButton).toHaveClass("tw-text-[#FEDF89]");
   });
@@ -298,7 +297,9 @@ describe("CreateDropActions", () => {
     render(<CreateDropActions {...defaultProps} />);
 
     const fileInputs = screen.getAllByLabelText("Upload a file");
-    const fileInput = fileInputs[0]?.querySelector('input[type="file"]') as HTMLInputElement;
+    const fileInput = fileInputs[0]?.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
     const files = [
       new File(["test1"], "test1.jpg", { type: "image/jpeg" }),
       new File(["test2"], "test2.png", { type: "image/png" }),
@@ -315,9 +316,7 @@ describe("CreateDropActions", () => {
       "removeEventListener"
     );
 
-    const { unmount } = render(
-      <CreateDropActions {...defaultProps} />
-    );
+    const { unmount } = render(<CreateDropActions {...defaultProps} />);
 
     const gifButtons = screen.getAllByLabelText("Add GIF");
     await userEvent.click(gifButtons[0]);
@@ -345,8 +344,8 @@ describe("CreateDropActions", () => {
 
     // When showOptions is false, only the chevron button should be visible
     const buttons = screen.getAllByRole("button");
-    const chevronButton = buttons.find(
-      (btn) => btn.querySelector('path[d="m8.25 4.5 7.5 7.5-7.5 7.5"]')
+    const chevronButton = buttons.find((btn) =>
+      btn.querySelector('path[d="m8.25 4.5 7.5 7.5-7.5 7.5"]')
     );
     expect(chevronButton).toBeInTheDocument();
   });

--- a/components/waves/CreateDropActions.tsx
+++ b/components/waves/CreateDropActions.tsx
@@ -10,6 +10,7 @@ import StormButton from "./StormButton";
 
 interface CreateDropActionsProps {
   readonly isStormMode: boolean;
+  readonly isDropMode: boolean;
   readonly canAddPart: boolean;
   readonly submitting: boolean;
   readonly showOptions: boolean;
@@ -26,6 +27,7 @@ interface CreateDropActionsProps {
 const CreateDropActions: React.FC<CreateDropActionsProps> = memo(
   ({
     isStormMode,
+    isDropMode,
     canAddPart,
     submitting,
     showOptions,
@@ -104,47 +106,49 @@ const CreateDropActions: React.FC<CreateDropActionsProps> = memo(
                 {...expandMotionProps}
                 className="tw-flex tw-items-center tw-gap-x-2 tw-overflow-hidden"
               >
-                <>
-                  <button
-                    onClick={onAddMetadataClick}
-                    className={`tw-flex-shrink-0 ${
-                      isRequiredMetadataMissing
-                        ? "tw-text-[#FEDF89]"
-                        : "tw-text-iron-300"
-                    } tw-flex tw-size-8 tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-bg-iron-700 tw-transition tw-duration-300 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 desktop-hover:hover:tw-bg-iron-700/80 lg:tw-size-7`}
-                    data-tooltip-id="add-metadata-tooltip"
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      strokeWidth="1.5"
-                      stroke="currentColor"
-                      className="tw-size-5 tw-flex-shrink-0 lg:tw-size-4"
-                      aria-hidden="true"
+                {isDropMode && (
+                  <>
+                    <button
+                      onClick={onAddMetadataClick}
+                      className={`tw-flex-shrink-0 ${
+                        isRequiredMetadataMissing
+                          ? "tw-text-[#FEDF89]"
+                          : "tw-text-iron-300"
+                      } tw-flex tw-size-8 tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-bg-iron-700 tw-transition tw-duration-300 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 desktop-hover:hover:tw-bg-iron-700/80 lg:tw-size-7`}
+                      data-tooltip-id="add-metadata-tooltip"
                     >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"
-                      />
-                    </svg>
-                  </button>
-                  {!isMobile && (
-                    <Tooltip
-                      id="add-metadata-tooltip"
-                      place="top"
-                      positionStrategy="fixed"
-                      style={{
-                        backgroundColor: "#1F2937",
-                        color: "white",
-                        padding: "4px 8px",
-                      }}
-                    >
-                      <span className="tw-text-xs">Add metadata</span>
-                    </Tooltip>
-                  )}
-                </>
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        strokeWidth="1.5"
+                        stroke="currentColor"
+                        className="tw-size-5 tw-flex-shrink-0 lg:tw-size-4"
+                        aria-hidden="true"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5"
+                        />
+                      </svg>
+                    </button>
+                    {!isMobile && (
+                      <Tooltip
+                        id="add-metadata-tooltip"
+                        place="top"
+                        positionStrategy="fixed"
+                        style={{
+                          backgroundColor: "#1F2937",
+                          color: "white",
+                          padding: "4px 8px",
+                        }}
+                      >
+                        <span className="tw-text-xs">Add metadata</span>
+                      </Tooltip>
+                    )}
+                  </>
+                )}
                 <motion.div
                   {...fadeMotionProps}
                   className="tw-flex tw-items-center tw-gap-x-2"
@@ -267,7 +271,8 @@ const CreateDropActions: React.FC<CreateDropActionsProps> = memo(
                 key="chevron-button"
                 onClick={onSetShowIconsClick}
                 className={`tw-flex-shrink-0 ${
-                  isRequiredMetadataMissing || isRequiredMediaMissing
+                  (isDropMode && isRequiredMetadataMissing) ||
+                  isRequiredMediaMissing
                     ? "tw-text-[#FEDF89]"
                     : "tw-text-iron-400"
                 } tw-flex tw-size-7 tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-bg-iron-700 tw-transition tw-duration-300 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-iron-500 focus-visible:tw-ring-offset-2 desktop-hover:hover:tw-bg-iron-700/70`}

--- a/components/waves/CreateDropActions.tsx
+++ b/components/waves/CreateDropActions.tsx
@@ -109,6 +109,7 @@ const CreateDropActions: React.FC<CreateDropActionsProps> = memo(
                 {isDropMode && (
                   <>
                     <button
+                      aria-label="Add metadata"
                       onClick={onAddMetadataClick}
                       className={`tw-flex-shrink-0 ${
                         isRequiredMetadataMissing

--- a/components/waves/CreateDropContent.tsx
+++ b/components/waves/CreateDropContent.tsx
@@ -35,7 +35,7 @@ import React, {
   useState,
 } from "react";
 import { useSelector } from "react-redux";
-import { AuthContext } from "../auth/Auth";
+import { useAuth } from "../auth/Auth";
 import { HASHTAG_TRANSFORMER } from "../drops/create/lexical/transformers/HastagTransformer";
 import { IMAGE_TRANSFORMER } from "../drops/create/lexical/transformers/ImageTransformer";
 import { MENTION_TRANSFORMER } from "../drops/create/lexical/transformers/MentionTransformer";
@@ -359,7 +359,7 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
   const prevWaveIdRef = useRef(wave.id);
   const [isWideContainer, setIsWideContainer] = useState(false);
   const editingDropId = useSelector(selectEditingDropId);
-  const { requestAuth, setToast, connectedProfile } = useContext(AuthContext);
+  const { requestAuth, setToast, connectedProfile } = useAuth();
   const { addOptimisticDrop } = useContext(ReactQueryWrapperContext);
   const { processIncomingDrop } = useMyStream();
   const { signDrop } = useDropSignature();
@@ -1069,6 +1069,16 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
     setIsMetadataOpen(false);
   };
 
+  const handleDropModeChange = useCallback(
+    (newIsDropMode: boolean) => {
+      if (!newIsDropMode) {
+        setIsMetadataOpen(false);
+      }
+      onDropModeChange(newIsDropMode);
+    },
+    [onDropModeChange]
+  );
+
   const onChangeKey = (params: { index: number; newKey: string }) => {
     setMetadata((prev) =>
       prev.map((item, i) =>
@@ -1166,6 +1176,7 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
         >
           <CreateDropActions
             isStormMode={isStormModeActive}
+            isDropMode={isDropMode}
             canAddPart={canAddPart}
             submitting={submitting}
             showOptions={showOptions}
@@ -1219,7 +1230,7 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
             {isParticipatory && !dropId && !isMemesWave && (
               <CreateDropDropModeToggle
                 isDropMode={isDropMode}
-                onDropModeChange={onDropModeChange}
+                onDropModeChange={handleDropModeChange}
                 privileges={privileges}
               />
             )}
@@ -1244,7 +1255,7 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
         />
       )}
       <AnimatePresence>
-        {isMetadataOpen && (
+        {isDropMode && isMetadataOpen && (
           <motion.div
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: "auto" }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metadata button and tooltip visibility to display only when drop mode is active
  * Metadata panel now automatically closes when exiting drop mode
  * Improved drop mode state management to ensure proper synchronization between UI controls and metadata visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->