### PR TITLE
Restore static preview-image fallback for html

### DIFF
--- a/__tests__/components/drops/view/item/content/media/MediaDisplay.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/MediaDisplay.test.tsx
@@ -100,6 +100,22 @@ describe("MediaDisplay", () => {
     );
   });
 
+  it("renders preview image instead of iframe for html when preview is provided", () => {
+    render(
+      <MediaDisplay
+        media_mime_type="text/html"
+        media_url="ipfs://hash"
+        previewImageUrl="preview.png"
+      />
+    );
+
+    expect(screen.getByTestId("image")).toHaveAttribute(
+      "data-src",
+      "preview.png"
+    );
+    expect(screen.queryByTestId("iframe")).not.toBeInTheDocument();
+  });
+
   it("renders gated html iframe with normalized ipfs url after activation", () => {
     render(
       <MediaDisplay
@@ -118,6 +134,29 @@ describe("MediaDisplay", () => {
     expect(screen.getByTestId("iframe")).toHaveAttribute(
       "data-title",
       "Interactive HTML media"
+    );
+  });
+
+  it("keeps gated html behavior when preview is provided", () => {
+    render(
+      <MediaDisplay
+        media_mime_type="text/html"
+        media_url="ipfs://hash"
+        previewImageUrl="preview.png"
+        requireInteractionToLoad
+      />
+    );
+
+    expect(screen.getByTestId("image")).toHaveAttribute(
+      "data-src",
+      "preview.png"
+    );
+
+    fireEvent.click(screen.getByTestId("load-gate"));
+
+    expect(screen.getByTestId("iframe")).toHaveAttribute(
+      "data-src",
+      "https://ipfs.io/ipfs/hash"
     );
   });
 

--- a/components/drops/view/item/content/media/MediaDisplay.tsx
+++ b/components/drops/view/item/content/media/MediaDisplay.tsx
@@ -167,6 +167,12 @@ export default function MediaDisplay({
   const mediaType = getMediaType();
 
   if (mediaType === MediaType.HTML) {
+    if (previewImageUrl && !requireInteractionToLoad) {
+      return (
+        <MediaDisplayImage src={previewImageUrl} imageScale={imageScale} />
+      );
+    }
+
     return (
       <InteractiveHtmlMediaDisplay
         key={`${media_mime_type}:${media_url}`}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTML media now displays preview images by default instead of loading interactive content immediately when preview images are available.

* **Tests**
  * Added test coverage for HTML media preview image rendering and interactive load behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->