### PR TITLE
use only backend-scaled cloudfront image

### DIFF
--- a/components/drops/view/item/content/media/DropListItemContentMediaImage.tsx
+++ b/components/drops/view/item/content/media/DropListItemContentMediaImage.tsx
@@ -312,6 +312,7 @@ function DropListItemContentMediaImage({
             primarySrc={getScaledImageUri(src, imageScale)}
             fallbackSrc={src}
             alt="Drop media"
+            optimize={false}
             fill
             loading={loadStrategy === "eager" ? "eager" : undefined}
             sizes="(max-width: 768px) 100vw, 768px"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image optimization behavior for media thumbnails in drop list items to ensure proper rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->