### PR TITLE
Added reaction and copy icons to the curation drop

### DIFF
--- a/components/community-curations/CommunityCurations.tsx
+++ b/components/community-curations/CommunityCurations.tsx
@@ -6,15 +6,33 @@ import { useLayout } from "@/components/brain/my-stream/layout/LayoutContext";
 import { useCommunityCurationsDrops } from "@/hooks/useCommunityCurationsDrops";
 import { useCallback, useState } from "react";
 
-const COMMUNITY_CURATIONS_SKELETON_CARDS = [
-  { id: "compact", mediaHeight: 210, lines: 2 },
-  { id: "tall", mediaHeight: 320, lines: 4 },
-  { id: "mid", mediaHeight: 250, lines: 3 },
-  { id: "feature", mediaHeight: 390, lines: 2 },
-  { id: "balanced", mediaHeight: 280, lines: 4 },
-  { id: "short", mediaHeight: 220, lines: 3 },
-  { id: "portrait", mediaHeight: 350, lines: 3 },
-  { id: "wide", mediaHeight: 260, lines: 2 },
+const COMMUNITY_CURATIONS_SKELETON_COLUMNS = [
+  {
+    id: "left",
+    className: "tw-flex",
+    cards: [
+      { id: "compact", mediaHeight: 210, lines: 2 },
+      { id: "feature", mediaHeight: 390, lines: 2 },
+      { id: "portrait", mediaHeight: 350, lines: 3 },
+    ],
+  },
+  {
+    id: "middle",
+    className: "tw-hidden md:tw-flex",
+    cards: [
+      { id: "tall", mediaHeight: 320, lines: 4 },
+      { id: "balanced", mediaHeight: 280, lines: 4 },
+      { id: "wide", mediaHeight: 260, lines: 2 },
+    ],
+  },
+  {
+    id: "right",
+    className: "tw-hidden xl:tw-flex",
+    cards: [
+      { id: "mid", mediaHeight: 250, lines: 3 },
+      { id: "short", mediaHeight: 220, lines: 3 },
+    ],
+  },
 ] as const;
 
 const COMMUNITY_CURATIONS_SKELETON_LINE_IDS = [
@@ -32,7 +50,7 @@ function CommunityCurationsSkeletonCard({
   readonly mediaHeight: number;
 }) {
   return (
-    <div className="tw-mb-4 tw-break-inside-avoid tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-white/10 tw-bg-iron-950/75">
+    <div className="tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-iron-950/75">
       <div
         className="tw-animate-pulse tw-bg-iron-900"
         style={{ height: mediaHeight }}
@@ -58,6 +76,14 @@ function CommunityCurationsSkeletonCard({
             )
           )}
         </div>
+        <div className="tw-mt-5 tw-flex tw-items-center tw-justify-between tw-gap-3">
+          <div className="tw-flex tw-items-center tw-gap-2">
+            <div className="tw-h-9 tw-w-20 tw-animate-pulse tw-rounded-lg tw-bg-iron-900" />
+            <div className="tw-h-9 tw-w-14 tw-animate-pulse tw-rounded-lg tw-bg-iron-900" />
+            <div className="tw-size-9 tw-animate-pulse tw-rounded-lg tw-border tw-border-dashed tw-border-iron-700/80 tw-bg-iron-900/30" />
+          </div>
+          <div className="tw-size-9 tw-animate-pulse tw-rounded-lg tw-bg-iron-900/60" />
+        </div>
       </div>
     </div>
   );
@@ -65,13 +91,20 @@ function CommunityCurationsSkeletonCard({
 
 function CommunityCurationsSkeletonGrid() {
   return (
-    <div className="tw-[column-gap:1rem] tw-[column-width:300px]">
-      {COMMUNITY_CURATIONS_SKELETON_CARDS.map((card) => (
-        <CommunityCurationsSkeletonCard
-          key={`community-curations-skeleton-${card.id}`}
-          lines={card.lines}
-          mediaHeight={card.mediaHeight}
-        />
+    <div className="tw-grid tw-grid-cols-1 tw-gap-4 md:tw-grid-cols-2 xl:tw-grid-cols-3">
+      {COMMUNITY_CURATIONS_SKELETON_COLUMNS.map((column) => (
+        <div
+          key={`community-curations-skeleton-column-${column.id}`}
+          className={`${column.className} tw-flex-col tw-gap-4`}
+        >
+          {column.cards.map((card) => (
+            <CommunityCurationsSkeletonCard
+              key={`community-curations-skeleton-${column.id}-${card.id}`}
+              lines={card.lines}
+              mediaHeight={card.mediaHeight}
+            />
+          ))}
+        </div>
       ))}
     </div>
   );

--- a/components/community-curations/CommunityCurationsMasonry.tsx
+++ b/components/community-curations/CommunityCurationsMasonry.tsx
@@ -4,6 +4,7 @@ import CircleLoader, {
   CircleLoaderSize,
 } from "@/components/distribution-plan-tool/common/CircleLoader";
 import { TweetPreviewModeProvider } from "@/components/tweets/TweetPreviewModeContext";
+import CurationDropFooter from "@/components/waves/drops/CurationDropFooter";
 import Drop, { DropLocation } from "@/components/waves/drops/Drop";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import { useNavigateToDropWave } from "@/hooks/useNavigateToDropWave";
@@ -29,6 +30,10 @@ const MASONRY_COLUMN_WIDTH = 300;
 const MASONRY_GUTTER = 16;
 const INFINITE_SCROLL_ROOT_MARGIN = "1200px 0px";
 const SCROLL_IDLE_DELAY_MS = 120;
+const CURATION_CARD_CLASS_NAME =
+  "tw-group tw-relative tw-isolate tw-rounded-xl";
+const CURATION_CARD_HOVER_FRAME_CLASS_NAME =
+  "tw-pointer-events-none tw-absolute tw-inset-0 tw-z-10 tw-rounded-xl tw-border tw-border-solid tw-border-transparent tw-transition-colors tw-duration-200 tw-ease-out desktop-hover:group-hover:tw-border-white/10 motion-reduce:tw-transition-none";
 
 type PanelViewport = {
   readonly height: number;
@@ -243,7 +248,7 @@ function CommunityCurationsMasonryItem({
   const navigateToDropWave = useNavigateToDropWave();
 
   return (
-    <article className="tw-group tw-relative tw-isolate">
+    <article className={CURATION_CARD_CLASS_NAME}>
       <Drop
         drop={drop}
         previousDrop={null}
@@ -257,8 +262,14 @@ function CommunityCurationsMasonryItem({
         onReplyClick={noop}
         onQuoteClick={navigateToDropWave}
         onDropContentClick={navigateToDropWave}
+        footer={<CurationDropFooter drop={drop} />}
         identityMode="default"
+        timestampLayout="stacked"
         showInteractions={false}
+      />
+      <div
+        aria-hidden="true"
+        className={CURATION_CARD_HOVER_FRAME_CLASS_NAME}
       />
     </article>
   );
@@ -334,7 +345,7 @@ export default function CommunityCurationsMasonry({
 
   return (
     <TweetPreviewModeProvider mode="never">
-      <div className="tw-overflow-hidden tw-rounded-2xl">
+      <div>
         <CommunityCurationsVirtualMasonry
           drops={drops}
           scrollContainer={scrollContainer}

--- a/components/memes/drops/MemeParticipationDrop.tsx
+++ b/components/memes/drops/MemeParticipationDrop.tsx
@@ -7,7 +7,10 @@ import DropMobileMenuHandler from "@/components/waves/drops/DropMobileMenuHandle
 import { getRankHoverBorderClass } from "@/components/waves/drops/dropRankStyles";
 import WaveDropReactions from "@/components/waves/drops/WaveDropReactions";
 import type { DropInteractionParams } from "@/components/waves/drops/drop.types";
-import { DropLocation } from "@/components/waves/drops/drop.types";
+import {
+  DropLocation,
+  hasDropFooter,
+} from "@/components/waves/drops/drop.types";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import { useDropInteractionRules } from "@/hooks/drops/useDropInteractionRules";
 import useIsMobileDevice from "@/hooks/isMobileDevice";
@@ -175,7 +178,7 @@ export default function MemeParticipationDrop({
               <WaveDropReactions drop={drop} />
             </div>
           )}
-          {footer !== undefined && footer !== null && (
+          {hasDropFooter(footer) && (
             <div className="tw-px-4 tw-pb-4 tw-pt-2">{footer}</div>
           )}
 

--- a/components/memes/drops/MemeParticipationDrop.tsx
+++ b/components/memes/drops/MemeParticipationDrop.tsx
@@ -13,7 +13,7 @@ import { useDropInteractionRules } from "@/hooks/drops/useDropInteractionRules";
 import useIsMobileDevice from "@/hooks/isMobileDevice";
 import useIsMobileScreen from "@/hooks/isMobileScreen";
 import type { ActiveDropState } from "@/types/dropInteractionTypes";
-import { useCallback, useState } from "react";
+import { useCallback, useState, type ReactNode } from "react";
 import MemeDropActions from "./meme-participation-drop/MemeDropActions";
 import MemeDropArtistInfo from "./meme-participation-drop/MemeDropArtistInfo";
 import MemeDropDescription from "./meme-participation-drop/MemeDropDescription";
@@ -27,6 +27,7 @@ interface MemeParticipationDropProps {
   readonly showReplyAndQuote: boolean;
   readonly location: DropLocation;
   readonly onReply: (param: DropInteractionParams) => void;
+  readonly footer?: ReactNode;
   readonly showInteractions?: boolean | undefined;
 }
 
@@ -63,6 +64,7 @@ export default function MemeParticipationDrop({
   showReplyAndQuote,
   location,
   onReply,
+  footer,
   showInteractions = true,
 }: MemeParticipationDropProps) {
   const [isVotingModalOpen, setIsVotingModalOpen] = useState(false);
@@ -172,6 +174,9 @@ export default function MemeParticipationDrop({
             <div className="tw-flex tw-w-full tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-1 tw-px-4 tw-pb-4">
               <WaveDropReactions drop={drop} />
             </div>
+          )}
+          {footer !== undefined && footer !== null && (
+            <div className="tw-px-4 tw-pb-4 tw-pt-2">{footer}</div>
           )}
 
           {showInteractions && (

--- a/components/memes/drops/MemeWinnerDrop.tsx
+++ b/components/memes/drops/MemeWinnerDrop.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, type ReactNode } from "react";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import {
   getRankHoverBorderClass,
@@ -23,6 +23,7 @@ interface MemeWinnerDropProps {
   readonly drop: ExtendedDrop;
   readonly showReplyAndQuote: boolean;
   readonly onReply: (param: DropInteractionParams) => void;
+  readonly footer?: ReactNode;
   readonly showInteractions?: boolean | undefined;
 }
 
@@ -34,6 +35,7 @@ export default function MemeWinnerDrop({
   drop,
   showReplyAndQuote,
   onReply,
+  footer,
   showInteractions = true,
 }: MemeWinnerDropProps) {
   const isMobile = useIsMobileDevice();
@@ -116,6 +118,9 @@ export default function MemeWinnerDrop({
             </DropMobileMenuHandler>
           ) : (
             content
+          )}
+          {footer !== undefined && footer !== null && (
+            <div className="tw-px-4 tw-pb-4 tw-pt-2">{footer}</div>
           )}
           {!isMobile && showInteractions && showReplyAndQuote && (
             <div className="tw-absolute tw-right-4 tw-top-2">

--- a/components/memes/drops/MemeWinnerDrop.tsx
+++ b/components/memes/drops/MemeWinnerDrop.tsx
@@ -7,7 +7,10 @@ import {
   getRankStaticBorderClass,
 } from "@/components/waves/drops/dropRankStyles";
 import type { DropInteractionParams } from "@/components/waves/drops/drop.types";
-import { DropLocation } from "@/components/waves/drops/drop.types";
+import {
+  DropLocation,
+  hasDropFooter,
+} from "@/components/waves/drops/drop.types";
 import useIsMobileDevice from "@/hooks/isMobileDevice";
 import WaveDropActions from "@/components/waves/drops/WaveDropActions";
 import MemeWinnerHeader from "./MemeWinnerHeader";
@@ -119,7 +122,7 @@ export default function MemeWinnerDrop({
           ) : (
             content
           )}
-          {footer !== undefined && footer !== null && (
+          {hasDropFooter(footer) && (
             <div className="tw-px-4 tw-pb-4 tw-pt-2">{footer}</div>
           )}
           {!isMobile && showInteractions && showReplyAndQuote && (

--- a/components/user/waves/UserPageProfileWaveMasonry.tsx
+++ b/components/user/waves/UserPageProfileWaveMasonry.tsx
@@ -8,6 +8,7 @@ import { Spinner } from "@/components/dotLoader/DotLoader";
 import { TweetPreviewModeProvider } from "@/components/tweets/TweetPreviewModeContext";
 import CommonIntersectionElement from "@/components/utils/CommonIntersectionElement";
 import { ApiDropType } from "@/generated/models/ApiDropType";
+import CurationDropFooter from "@/components/waves/drops/CurationDropFooter";
 import Drop, { DropLocation } from "@/components/waves/drops/Drop";
 import DropMinimalIdentityRow from "@/components/waves/drops/DropMinimalIdentityRow";
 import WaveDropContent from "@/components/waves/drops/WaveDropContent";
@@ -40,6 +41,11 @@ interface UserPageProfileWaveMasonryProps {
 
 const MASONRY_COLUMN_WIDTH = 300;
 const MASONRY_GUTTER = 16;
+const noop = () => {};
+const CURATION_CARD_CLASS_NAME =
+  "tw-group tw-relative tw-isolate tw-rounded-xl";
+const CURATION_CARD_HOVER_FRAME_CLASS_NAME =
+  "tw-pointer-events-none tw-absolute tw-inset-0 tw-z-10 tw-rounded-xl tw-border tw-border-solid tw-border-transparent tw-transition-colors tw-duration-200 tw-ease-out desktop-hover:group-hover:tw-border-white/10 motion-reduce:tw-transition-none";
 
 export type ProfileIdentitySummary = {
   readonly id?: string | null | undefined;
@@ -249,7 +255,7 @@ function UserPageProfileWaveMasonryCard({
 
   if (layout.usesDefaultDropRenderer) {
     return (
-      <article className="tw-group tw-relative tw-isolate">
+      <article className={CURATION_CARD_CLASS_NAME}>
         {removeButton}
 
         <Drop
@@ -261,19 +267,25 @@ function UserPageProfileWaveMasonryCard({
           showReplyAndQuote={false}
           location={DropLocation.MY_STREAM}
           dropViewDropId={null}
-          onReply={() => {}}
-          onReplyClick={() => {}}
+          onReply={noop}
+          onReplyClick={noop}
           onQuoteClick={navigateToDropWave}
           onDropContentClick={navigateToDropWave}
+          footer={<CurationDropFooter drop={drop} />}
           identityMode={layout.identityMode}
+          timestampLayout="stacked"
           showInteractions={false}
+        />
+        <div
+          aria-hidden="true"
+          className={CURATION_CARD_HOVER_FRAME_CLASS_NAME}
         />
       </article>
     );
   }
 
   return (
-    <article className="tw-group tw-relative tw-isolate">
+    <article className={CURATION_CARD_CLASS_NAME}>
       {removeButton}
 
       <div className="tw-overflow-hidden tw-rounded-xl tw-bg-black/70 tw-ring-1 tw-ring-inset tw-ring-white/10">
@@ -281,11 +293,12 @@ function UserPageProfileWaveMasonryCard({
           <div className="tw-flex tw-items-start tw-gap-x-3 tw-px-4 tw-pb-4 tw-pt-4">
             <WaveDropAuthorPfp drop={drop} />
             <div className="tw-min-w-0 tw-flex-1">
-              <DropMinimalIdentityRow drop={drop} />
+              <DropMinimalIdentityRow drop={drop} timestampLayout="stacked" />
               <div className="tw-mt-2">{dropContent}</div>
               {drop.metadata.length > 0 && (
                 <WaveDropMetadata metadata={drop.metadata} />
               )}
+              <CurationDropFooter drop={drop} className="tw-mt-3" />
             </div>
           </div>
         ) : (
@@ -294,7 +307,10 @@ function UserPageProfileWaveMasonryCard({
               <div className="tw-flex tw-items-start tw-gap-x-3 tw-px-4 tw-pt-4">
                 <WaveDropAuthorPfp drop={drop} />
                 <div className="tw-min-w-0 tw-flex-1">
-                  <DropMinimalIdentityRow drop={drop} />
+                  <DropMinimalIdentityRow
+                    drop={drop}
+                    timestampLayout="stacked"
+                  />
                 </div>
               </div>
             )}
@@ -321,9 +337,17 @@ function UserPageProfileWaveMasonryCard({
                 <WaveDropMetadata metadata={drop.metadata} />
               </div>
             )}
+            <CurationDropFooter
+              drop={drop}
+              className="tw-px-4 tw-pb-4 tw-pt-2"
+            />
           </>
         )}
       </div>
+      <div
+        aria-hidden="true"
+        className={CURATION_CARD_HOVER_FRAME_CLASS_NAME}
+      />
     </article>
   );
 }

--- a/components/waves/drops/CurationDropFooter.tsx
+++ b/components/waves/drops/CurationDropFooter.tsx
@@ -20,6 +20,10 @@ export default function CurationDropFooter({
   drop,
   className,
 }: CurationDropFooterProps) {
+  const hasVisibleReactions = drop.reactions.some(
+    (reaction) => reaction.profiles.length > 0
+  );
+
   return (
     <div
       className={clsx(
@@ -31,10 +35,12 @@ export default function CurationDropFooter({
       data-text-selection-exclude="true"
     >
       <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-1">
-        <div className="-tw-mt-1 tw-flex tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-1">
-          <WaveDropReactions drop={drop} />
-        </div>
-        <div className="tw-flex tw-size-8 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-dashed tw-border-iron-700/80 tw-bg-iron-900/20 tw-transition-colors tw-duration-200 desktop-hover:hover:tw-border-iron-500 desktop-hover:hover:tw-bg-iron-900/40">
+        {hasVisibleReactions && (
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-1">
+            <WaveDropReactions drop={drop} />
+          </div>
+        )}
+        <div className="tw-mt-1 tw-flex tw-size-8 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-dashed tw-border-iron-700/80 tw-bg-iron-900/20 tw-transition-colors tw-duration-200 desktop-hover:hover:tw-border-iron-500 desktop-hover:hover:tw-bg-iron-900/40">
           <WaveDropActionsAddReaction
             drop={drop}
             size="compact"
@@ -42,7 +48,7 @@ export default function CurationDropFooter({
           />
         </div>
       </div>
-      <div className="tw-ml-2 tw-flex tw-size-9 tw-flex-shrink-0 tw-items-center tw-justify-center tw-text-iron-500 desktop-hover:hover:tw-text-iron-300">
+      <div className="tw-ml-2 tw-mt-1 tw-flex tw-size-9 tw-flex-shrink-0 tw-items-center tw-justify-center tw-text-iron-500 desktop-hover:hover:tw-text-iron-300">
         <WaveDropActionsCopyLink drop={drop} size="compact" />
       </div>
     </div>

--- a/components/waves/drops/CurationDropFooter.tsx
+++ b/components/waves/drops/CurationDropFooter.tsx
@@ -2,7 +2,6 @@
 
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import clsx from "clsx";
-import type { SyntheticEvent } from "react";
 import WaveDropActionsAddReaction from "./WaveDropActionsAddReaction";
 import WaveDropActionsCopyLink from "./WaveDropActionsCopyLink";
 import WaveDropReactions from "./WaveDropReactions";
@@ -11,10 +10,6 @@ interface CurationDropFooterProps {
   readonly drop: ExtendedDrop;
   readonly className?: string | undefined;
 }
-
-const stopFooterPropagation = (event: SyntheticEvent) => {
-  event.stopPropagation();
-};
 
 export default function CurationDropFooter({
   drop,
@@ -30,8 +25,6 @@ export default function CurationDropFooter({
         "tw-relative tw-z-20 tw-flex tw-w-full tw-items-center tw-justify-between tw-gap-x-3 tw-gap-y-2",
         className
       )}
-      onClick={stopFooterPropagation}
-      onMouseDown={stopFooterPropagation}
       data-text-selection-exclude="true"
     >
       <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-1">

--- a/components/waves/drops/CurationDropFooter.tsx
+++ b/components/waves/drops/CurationDropFooter.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
+import clsx from "clsx";
+import type { SyntheticEvent } from "react";
+import WaveDropActionsAddReaction from "./WaveDropActionsAddReaction";
+import WaveDropActionsCopyLink from "./WaveDropActionsCopyLink";
+import WaveDropReactions from "./WaveDropReactions";
+
+interface CurationDropFooterProps {
+  readonly drop: ExtendedDrop;
+  readonly className?: string | undefined;
+}
+
+const stopFooterPropagation = (event: SyntheticEvent) => {
+  event.stopPropagation();
+};
+
+export default function CurationDropFooter({
+  drop,
+  className,
+}: CurationDropFooterProps) {
+  return (
+    <div
+      className={clsx(
+        "tw-relative tw-z-20 tw-flex tw-w-full tw-items-center tw-justify-between tw-gap-x-3 tw-gap-y-2",
+        className
+      )}
+      onClick={stopFooterPropagation}
+      onMouseDown={stopFooterPropagation}
+      data-text-selection-exclude="true"
+    >
+      <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-1">
+        <div className="-tw-mt-1 tw-flex tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-1">
+          <WaveDropReactions drop={drop} />
+        </div>
+        <div className="tw-flex tw-size-8 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-dashed tw-border-iron-700/80 tw-bg-iron-900/20 tw-transition-colors tw-duration-200 desktop-hover:hover:tw-border-iron-500 desktop-hover:hover:tw-bg-iron-900/40">
+          <WaveDropActionsAddReaction
+            drop={drop}
+            size="compact"
+            updateCurationCache
+          />
+        </div>
+      </div>
+      <div className="tw-ml-2 tw-flex tw-size-9 tw-flex-shrink-0 tw-items-center tw-justify-center tw-text-iron-500 desktop-hover:hover:tw-text-iron-300">
+        <WaveDropActionsCopyLink drop={drop} size="compact" />
+      </div>
+    </div>
+  );
+}

--- a/components/waves/drops/Drop.tsx
+++ b/components/waves/drops/Drop.tsx
@@ -14,6 +14,7 @@ import type {
   DropIdentityMode,
   DropInteractionParams,
   DropLocation,
+  DropTimestampLayout,
 } from "./drop.types";
 import ParticipationDrop from "./participation/ParticipationDrop";
 import WaveDrop from "./WaveDrop";
@@ -36,7 +37,9 @@ interface DropProps {
   readonly onDropContentClick?: ((drop: ExtendedDrop) => void) | undefined;
   readonly parentContainerRef?: React.RefObject<HTMLElement | null> | undefined;
   readonly wrapContentOnly?: (content: React.ReactNode) => React.ReactNode;
+  readonly footer?: React.ReactNode;
   readonly identityMode?: DropIdentityMode | undefined;
+  readonly timestampLayout?: DropTimestampLayout | undefined;
   readonly showInteractions?: boolean | undefined;
 }
 
@@ -55,7 +58,9 @@ export default function Drop({
   showReplyAndQuote,
   parentContainerRef,
   wrapContentOnly,
+  footer,
   identityMode,
+  timestampLayout,
   showInteractions = true,
 }: DropProps) {
   const components: Record<ApiDropType, React.ReactNode> = {
@@ -70,7 +75,9 @@ export default function Drop({
         onDropContentClick={onDropContentClick}
         showReplyAndQuote={showReplyAndQuote}
         parentContainerRef={parentContainerRef}
+        footer={footer}
         identityMode={identityMode}
+        timestampLayout={timestampLayout}
         showInteractions={showInteractions}
       />
     ),
@@ -89,7 +96,9 @@ export default function Drop({
         onDropContentClick={onDropContentClick}
         showReplyAndQuote={showReplyAndQuote}
         parentContainerRef={parentContainerRef}
+        footer={footer}
         identityMode={identityMode}
+        timestampLayout={timestampLayout}
         showInteractions={showInteractions}
       />
     ),
@@ -110,7 +119,9 @@ export default function Drop({
         onDropContentClick={onDropContentClick}
         showReplyAndQuote={showReplyAndQuote}
         wrapContentOnly={wrapContentOnly}
+        footer={footer}
         identityMode={identityMode}
+        timestampLayout={timestampLayout}
         showInteractions={showInteractions}
       />
     ),

--- a/components/waves/drops/DropMinimalIdentityRow.tsx
+++ b/components/waves/drops/DropMinimalIdentityRow.tsx
@@ -6,17 +6,21 @@ import type { ApiDrop } from "@/generated/models/ApiDrop";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback } from "react";
+import type { DropTimestampLayout } from "./drop.types";
 import WaveDropTime from "./time/WaveDropTime";
 
 interface DropMinimalIdentityRowProps {
   readonly drop: ApiDrop;
+  readonly timestampLayout?: DropTimestampLayout | undefined;
 }
 
 export default function DropMinimalIdentityRow({
   drop,
+  timestampLayout = "inline",
 }: DropMinimalIdentityRowProps) {
   const router = useRouter();
   const authorIdentity = drop.author.handle ?? drop.author.primary_address;
+  const isStackedTimestamp = timestampLayout === "stacked";
 
   const handleNavigation = useCallback(
     (event: React.MouseEvent, path: string) => {
@@ -28,7 +32,13 @@ export default function DropMinimalIdentityRow({
   );
 
   return (
-    <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-x-1.5 tw-gap-y-1">
+    <div
+      className={
+        isStackedTimestamp
+          ? "tw-flex tw-min-w-0 tw-flex-col tw-items-start tw-gap-y-1"
+          : "tw-flex tw-flex-wrap tw-items-center tw-gap-x-1.5 tw-gap-y-1"
+      }
+    >
       <p className="tw-mb-0 tw-text-sm tw-font-semibold tw-leading-none">
         <UserProfileTooltipWrapper user={authorIdentity}>
           <Link
@@ -44,7 +54,9 @@ export default function DropMinimalIdentityRow({
           </Link>
         </UserProfileTooltipWrapper>
       </p>
-      <div className="tw-size-[3px] tw-flex-shrink-0 tw-rounded-full tw-bg-iron-600" />
+      {!isStackedTimestamp && (
+        <div className="tw-size-[3px] tw-flex-shrink-0 tw-rounded-full tw-bg-iron-600" />
+      )}
       <WaveDropTime timestamp={drop.created_at} />
     </div>
   );

--- a/components/waves/drops/WaveDrop.tsx
+++ b/components/waves/drops/WaveDrop.tsx
@@ -21,7 +21,7 @@ import type {
   DropInteractionParams,
   DropTimestampLayout,
 } from "./drop.types";
-import { DropLocation } from "./drop.types";
+import { DropLocation, hasDropFooter } from "./drop.types";
 import { getRankHoverRingClass } from "./dropRankStyles";
 import type { BoostAnimationState } from "./DropBoostAnimation";
 import DropBoostAnimation from "./DropBoostAnimation";
@@ -746,10 +746,12 @@ const WaveDrop = ({
       {showInteractions && <WaveDropReactions drop={drop} />}
     </div>
   );
-  const footerOffsetClass = showAuthorInfo
+  const shouldOffsetFooter =
+    showAuthorInfo || (shouldGroupWithPreviousDrop && !isProfileView);
+  const footerOffsetClass = shouldOffsetFooter
     ? getContentOffsetClass(compact)
     : "";
-  const footerRow = footer !== undefined && footer !== null && (
+  const footerRow = hasDropFooter(footer) && (
     <div className={`tw-mx-2 tw-mt-2 ${footerOffsetClass}`}>{footer}</div>
   );
 

--- a/components/waves/drops/WaveDrop.tsx
+++ b/components/waves/drops/WaveDrop.tsx
@@ -16,7 +16,11 @@ import type { ActiveDropState } from "@/types/dropInteractionTypes";
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { createBreakpoint } from "react-use";
-import type { DropIdentityMode, DropInteractionParams } from "./drop.types";
+import type {
+  DropIdentityMode,
+  DropInteractionParams,
+  DropTimestampLayout,
+} from "./drop.types";
 import { DropLocation } from "./drop.types";
 import { getRankHoverRingClass } from "./dropRankStyles";
 import type { BoostAnimationState } from "./DropBoostAnimation";
@@ -122,6 +126,14 @@ const getDropClasses = (
       : chatDropClasses;
 
   return `${baseClasses} ${groupingClass} ${locationClasses} ${rankClasses}`.trim();
+};
+
+const getContentOffsetClass = (compact: boolean): string => {
+  if (compact) {
+    return "tw-ml-11 tw-w-[calc(100%-2.5rem)]";
+  }
+
+  return "tw-ml-[3.25rem] tw-w-[calc(100%-3.25rem)]";
 };
 
 const shouldShowAuthorInfo = ({
@@ -239,6 +251,7 @@ const getAuthorHeader = ({
   activePartIndex,
   showActionsButton,
   handleOpenTouchActions,
+  timestampLayout,
 }: {
   readonly showAuthorInfo: boolean;
   readonly identityMode: DropIdentityMode;
@@ -250,6 +263,7 @@ const getAuthorHeader = ({
   readonly handleOpenTouchActions: (
     e: React.MouseEvent<HTMLButtonElement>
   ) => void;
+  readonly timestampLayout: DropTimestampLayout;
 }): React.ReactNode => {
   if (!showAuthorInfo) {
     return null;
@@ -265,11 +279,14 @@ const getAuthorHeader = ({
         partsCount={drop.parts.length}
         showActionsButton={showActionsButton}
         onOpenActions={handleOpenTouchActions}
+        timestampLayout={timestampLayout}
       />
     );
   }
 
-  return <DropMinimalIdentityRow drop={drop} />;
+  return (
+    <DropMinimalIdentityRow drop={drop} timestampLayout={timestampLayout} />
+  );
 };
 
 const getContentBlock = ({
@@ -406,7 +423,9 @@ interface WaveDropProps {
   readonly wrapContentOnly?:
     | ((content: React.ReactNode) => React.ReactNode)
     | undefined;
+  readonly footer?: React.ReactNode;
   readonly identityMode?: DropIdentityMode | undefined;
+  readonly timestampLayout?: DropTimestampLayout | undefined;
   readonly showInteractions?: boolean | undefined;
 }
 
@@ -424,7 +443,9 @@ const WaveDrop = ({
   onDropContentClick,
   showReplyAndQuote,
   wrapContentOnly,
+  footer,
   identityMode = "default",
+  timestampLayout = "inline",
   showInteractions = true,
 }: WaveDropProps) => {
   const [activePartIndex, setActivePartIndex] = useState<number>(0);
@@ -566,6 +587,7 @@ const WaveDrop = ({
     activePartIndex,
     showActionsButton,
     handleOpenTouchActions,
+    timestampLayout,
   });
 
   const handleOnEdit = useCallback(() => {
@@ -713,11 +735,7 @@ const WaveDrop = ({
 
   const reactionsRow = (drop.metadata.length > 0 || showInteractions) && (
     <div
-      className={`tw-mx-2 tw-flex tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-1 ${
-        compact
-          ? "tw-ml-11 tw-w-[calc(100%-2.5rem)]"
-          : "tw-ml-[3.25rem] tw-w-[calc(100%-3.25rem)]"
-      }`}
+      className={`tw-mx-2 tw-flex tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-1 ${getContentOffsetClass(compact)}`}
     >
       {drop.metadata.length > 0 && (
         <WaveDropMetadata metadata={drop.metadata} />
@@ -727,6 +745,12 @@ const WaveDrop = ({
       )}
       {showInteractions && <WaveDropReactions drop={drop} />}
     </div>
+  );
+  const footerOffsetClass = showAuthorInfo
+    ? getContentOffsetClass(compact)
+    : "";
+  const footerRow = footer !== undefined && footer !== null && (
+    <div className={`tw-mx-2 tw-mt-2 ${footerOffsetClass}`}>{footer}</div>
   );
 
   return (
@@ -746,6 +770,7 @@ const WaveDrop = ({
       >
         {wrapContentOnly ? wrapContentOnly(contentBlock) : contentBlock}
         {reactionsRow}
+        {footerRow}
         {showInteractions && (
           <WaveDropMobileMenu
             drop={drop}

--- a/components/waves/drops/WaveDropActionsAddReaction.tsx
+++ b/components/waves/drops/WaveDropActionsAddReaction.tsx
@@ -15,15 +15,26 @@ const WaveDropActionsAddReaction: React.FC<{
   readonly isMobile?: boolean | undefined;
   readonly onAddReaction?: (() => void) | undefined;
   readonly dialogZIndexClassName?: string | undefined;
-}> = ({ drop, isMobile = false, onAddReaction, dialogZIndexClassName }) => {
+  readonly size?: "default" | "compact" | undefined;
+  readonly updateCurationCache?: boolean | undefined;
+}> = ({
+  drop,
+  isMobile = false,
+  onAddReaction,
+  dialogZIndexClassName,
+  size = "default",
+  updateCurationCache = false,
+}) => {
   const { react, canReact } = useDropReaction(drop, {
     source: "picker",
     onSuccess: onAddReaction,
+    updateCurationCache,
   });
   const [showPicker, setShowPicker] = useState(false);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const pickerContainerRef = useRef<HTMLDivElement | null>(null);
   const { emojiMap, categories, categoryIcons } = useEmoji();
+  const desktopIconSizeClass = size === "compact" ? "tw-size-4" : "tw-size-5";
 
   const handleEmojiSelect = (emoji: {
     native?: string | undefined;
@@ -31,7 +42,7 @@ const WaveDropActionsAddReaction: React.FC<{
   }) => {
     const emojiText = `:${emoji.id ?? ""}:`;
     setShowPicker(false);
-    react(emojiText);
+    void react(emojiText);
   };
 
   useEffect(() => {
@@ -112,7 +123,7 @@ const WaveDropActionsAddReaction: React.FC<{
         {...(canReact ? { "data-tooltip-id": `add-reaction-${drop.id}` } : {})}
       >
         <svg
-          className={`tw-size-5 tw-flex-shrink-0 tw-transition tw-duration-300 tw-ease-out ${
+          className={`${desktopIconSizeClass} tw-flex-shrink-0 tw-transition tw-duration-300 tw-ease-out ${
             !canReact && "tw-opacity-50"
           }`}
           xmlns="http://www.w3.org/2000/svg"

--- a/components/waves/drops/WaveDropActionsCopyLink.tsx
+++ b/components/waves/drops/WaveDropActionsCopyLink.tsx
@@ -12,39 +12,40 @@ interface WaveDropActionsCopyLinkProps {
   readonly drop: ApiDrop;
   readonly isDropdownItem?: boolean | undefined;
   readonly onCopy?: (() => void) | undefined;
+  readonly size?: "default" | "compact" | undefined;
 }
 
 const WaveDropActionsCopyLink: React.FC<WaveDropActionsCopyLinkProps> = ({
   drop,
   isDropdownItem = false,
   onCopy,
+  size = "default",
 }) => {
   const [copied, setCopied] = useState(false);
   const { isMemesWave, isQuorumWave } = useSeizeSettings();
   const myStream = useMyStreamOptional();
   const directMessageWaves = myStream?.directMessages.list ?? [];
 
-  const isTemporaryDrop = (drop: ApiDrop): boolean => {
-    return drop.id.startsWith("temp-");
+  const isTemporaryDrop = (targetDrop: ApiDrop): boolean => {
+    return targetDrop.id.startsWith("temp-");
   };
 
   const copyToClipboard = () => {
     if (isTemporaryDrop(drop)) return;
 
-    const waveDetails =
-      (drop.wave as unknown as {
-        chat?:
-          | {
-              scope?:
-                | {
-                    group?:
-                      | { is_direct_message?: boolean | undefined }
-                      | undefined;
-                  }
-                | undefined;
-            }
-          | undefined;
-      }) ?? undefined;
+    const waveDetails = drop.wave as unknown as {
+      chat?:
+        | {
+            scope?:
+              | {
+                  group?:
+                    | { is_direct_message?: boolean | undefined }
+                    | undefined;
+                }
+              | undefined;
+          }
+        | undefined;
+    };
     const isDirectMessage = isWaveDirectMessage(
       drop.wave.id,
       waveDetails,
@@ -56,14 +57,18 @@ const WaveDropActionsCopyLink: React.FC<WaveDropActionsCopyLinkProps> = ({
       isMemesWave,
       isQuorumWave,
     });
-    navigator.clipboard.writeText(dropLink).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-      onCopy?.();
-    });
+    void navigator.clipboard
+      .writeText(dropLink)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+        onCopy?.();
+      })
+      .catch(() => undefined);
   };
 
   const isDisabled = isTemporaryDrop(drop);
+  const iconSizeClass = size === "compact" ? "tw-h-4 tw-w-4" : "tw-h-5 tw-w-5";
 
   const getLinkText = () => {
     if (isDisabled) return "Unavailable";
@@ -113,7 +118,7 @@ const WaveDropActionsCopyLink: React.FC<WaveDropActionsCopyLinkProps> = ({
         {...(!isDisabled ? { "data-tooltip-id": `copy-link-${drop.id}` } : {})}
       >
         <svg
-          className="tw-h-5 tw-w-5 tw-flex-shrink-0 tw-transition tw-duration-300 tw-ease-out"
+          className={`${iconSizeClass} tw-flex-shrink-0 tw-transition tw-duration-300 tw-ease-out`}
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"

--- a/components/waves/drops/WaveDropHeader.tsx
+++ b/components/waves/drops/WaveDropHeader.tsx
@@ -14,6 +14,7 @@ import { DropAuthorBadges } from "./DropAuthorBadges";
 import { useCallback } from "react";
 import { EllipsisVerticalIcon } from "@heroicons/react/24/outline";
 import { useCompactMode } from "@/contexts/CompactModeContext";
+import type { DropTimestampLayout } from "./drop.types";
 
 interface WaveDropHeaderProps {
   readonly drop: ApiDrop;
@@ -26,6 +27,7 @@ interface WaveDropHeaderProps {
   readonly onOpenActions?:
     | ((e: React.MouseEvent<HTMLButtonElement>) => void)
     | undefined;
+  readonly timestampLayout?: DropTimestampLayout | undefined;
 }
 
 const WaveDropHeader: React.FC<WaveDropHeaderProps> = ({
@@ -37,10 +39,12 @@ const WaveDropHeader: React.FC<WaveDropHeaderProps> = ({
   badge,
   showActionsButton = false,
   onOpenActions,
+  timestampLayout = "inline",
 }) => {
   const router = useRouter();
   const compact = useCompactMode();
   const authorIdentity = drop.author.handle ?? drop.author.primary_address;
+  const isStackedTimestamp = timestampLayout === "stacked";
 
   // Memoize event handlers to prevent unnecessary re-renders
   const handleNavigation = useCallback(
@@ -56,38 +60,53 @@ const WaveDropHeader: React.FC<WaveDropHeaderProps> = ({
     <>
       <div className="tw-flex tw-items-center tw-justify-between tw-gap-x-2">
         <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-x-1.5 tw-gap-y-1">
-          <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-x-1.5 tw-gap-y-1">
-            <p
-              className={`tw-mb-0 tw-font-semibold tw-leading-none ${compact ? "tw-text-sm" : "tw-text-md"}`}
-            >
-              <UserProfileTooltipWrapper user={authorIdentity}>
-                <Link
-                  onClick={(e) => handleNavigation(e, `/${authorIdentity}`)}
-                  href={`/${authorIdentity}`}
-                  className="tw-text-iron-200 tw-no-underline tw-transition tw-duration-300 tw-ease-out desktop-hover:hover:tw-text-opacity-80 desktop-hover:hover:tw-underline"
-                >
-                  <ProfileNameWithAiMarker
-                    classification={drop.author.classification}
+          <div
+            className={
+              isStackedTimestamp
+                ? "tw-flex tw-min-w-0 tw-flex-col tw-items-start tw-gap-y-1.5"
+                : "tw-flex tw-flex-wrap tw-items-center tw-gap-x-1.5 tw-gap-y-1"
+            }
+          >
+            <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-x-1.5 tw-gap-y-1">
+              <p
+                className={`tw-mb-0 tw-font-semibold tw-leading-none ${compact ? "tw-text-sm" : "tw-text-md"}`}
+              >
+                <UserProfileTooltipWrapper user={authorIdentity}>
+                  <Link
+                    onClick={(e) => handleNavigation(e, `/${authorIdentity}`)}
+                    href={`/${authorIdentity}`}
+                    className="tw-text-iron-200 tw-no-underline tw-transition tw-duration-300 tw-ease-out desktop-hover:hover:tw-text-opacity-80 desktop-hover:hover:tw-underline"
                   >
-                    {authorIdentity}
-                  </ProfileNameWithAiMarker>
-                </Link>
-              </UserProfileTooltipWrapper>
-            </p>
-            <UserCICAndLevel
-              level={drop.author.level}
-              size={UserCICAndLevelSize.SMALL}
-            />
-            <DropAuthorBadges
-              profile={drop.author}
-              tooltipIdPrefix={`header-author-badges-${drop.id}`}
-            />
-            <div className="tw-size-[3px] tw-flex-shrink-0 tw-rounded-full tw-bg-iron-600"></div>
-            <WaveDropTime timestamp={drop.created_at} />
+                    <ProfileNameWithAiMarker
+                      classification={drop.author.classification}
+                    >
+                      {authorIdentity}
+                    </ProfileNameWithAiMarker>
+                  </Link>
+                </UserProfileTooltipWrapper>
+              </p>
+              <UserCICAndLevel
+                level={drop.author.level}
+                size={UserCICAndLevelSize.SMALL}
+              />
+              <DropAuthorBadges
+                profile={drop.author}
+                tooltipIdPrefix={`header-author-badges-${drop.id}`}
+              />
+              {!isStackedTimestamp && (
+                <div className="tw-size-[3px] tw-flex-shrink-0 tw-rounded-full tw-bg-iron-600"></div>
+              )}
+              {!isStackedTimestamp && (
+                <WaveDropTime timestamp={drop.created_at} />
+              )}
+            </div>
+            {isStackedTimestamp && <WaveDropTime timestamp={drop.created_at} />}
           </div>
-          {!!badge && <div className="tw-ml-2">{badge}</div>}
+          {badge !== undefined && badge !== null && (
+            <div className="tw-ml-2">{badge}</div>
+          )}
         </div>
-        {showActionsButton && onOpenActions && (
+        {showActionsButton && onOpenActions !== undefined && (
           <button
             type="button"
             aria-label="Open drop actions"

--- a/components/waves/drops/WaveDropHeader.tsx
+++ b/components/waves/drops/WaveDropHeader.tsx
@@ -102,9 +102,7 @@ const WaveDropHeader: React.FC<WaveDropHeaderProps> = ({
             </div>
             {isStackedTimestamp && <WaveDropTime timestamp={drop.created_at} />}
           </div>
-          {badge !== undefined && badge !== null && (
-            <div className="tw-ml-2">{badge}</div>
-          )}
+          {Boolean(badge) && <div className="tw-ml-2">{badge}</div>}
         </div>
         {showActionsButton && onOpenActions !== undefined && (
           <button

--- a/components/waves/drops/drop.types.ts
+++ b/components/waves/drops/drop.types.ts
@@ -6,6 +6,7 @@ export interface DropInteractionParams {
 }
 
 export type DropIdentityMode = "default" | "minimal" | "hidden";
+export type DropTimestampLayout = "inline" | "stacked";
 
 export enum DropLocation {
   MY_STREAM = "MY_STREAM",

--- a/components/waves/drops/drop.types.ts
+++ b/components/waves/drops/drop.types.ts
@@ -1,4 +1,5 @@
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
+import type { ReactNode } from "react";
 
 export interface DropInteractionParams {
   drop: ExtendedDrop;
@@ -7,6 +8,11 @@ export interface DropInteractionParams {
 
 export type DropIdentityMode = "default" | "minimal" | "hidden";
 export type DropTimestampLayout = "inline" | "stacked";
+
+export const hasDropFooter = (
+  footer: ReactNode | undefined
+): footer is Exclude<ReactNode, boolean | null | undefined> =>
+  footer !== undefined && footer !== null && footer !== false;
 
 export enum DropLocation {
   MY_STREAM = "MY_STREAM",

--- a/components/waves/drops/participation/DefaultParticipationDrop.tsx
+++ b/components/waves/drops/participation/DefaultParticipationDrop.tsx
@@ -9,6 +9,7 @@ import type {
   DropIdentityMode,
   DropInteractionParams,
   DropLocation,
+  DropTimestampLayout,
 } from "../drop.types";
 
 interface DefaultParticipationDropProps {
@@ -21,7 +22,9 @@ interface DefaultParticipationDropProps {
   readonly onQuoteClick: (drop: ApiDrop) => void;
   readonly onDropContentClick?: ((drop: ExtendedDrop) => void) | undefined;
   readonly parentContainerRef?: React.RefObject<HTMLElement | null> | undefined;
+  readonly footer?: React.ReactNode;
   readonly identityMode?: DropIdentityMode | undefined;
+  readonly timestampLayout?: DropTimestampLayout | undefined;
   readonly showInteractions?: boolean | undefined;
 }
 

--- a/components/waves/drops/participation/EndedParticipationDrop.tsx
+++ b/components/waves/drops/participation/EndedParticipationDrop.tsx
@@ -28,7 +28,11 @@ import {
   getParticipationVisibleMetadata,
 } from "./participationIdentityProfile.helpers";
 import type { DropContentPresentation } from "../dropContentPresentation";
-import type { DropIdentityMode, DropInteractionParams } from "../drop.types";
+import type {
+  DropIdentityMode,
+  DropInteractionParams,
+  DropTimestampLayout,
+} from "../drop.types";
 import { DropLocation } from "../drop.types";
 
 interface EndedParticipationDropProps {
@@ -40,7 +44,9 @@ interface EndedParticipationDropProps {
   readonly onReply: (param: DropInteractionParams) => void;
   readonly onQuoteClick: (drop: ApiDrop) => void;
   readonly onDropContentClick?: ((drop: ExtendedDrop) => void) | undefined;
+  readonly footer?: React.ReactNode;
   readonly identityMode?: DropIdentityMode | undefined;
+  readonly timestampLayout?: DropTimestampLayout | undefined;
   readonly showInteractions?: boolean | undefined;
   readonly contentPresentation?: DropContentPresentation | undefined;
   readonly embedPath?: readonly string[] | undefined;
@@ -58,7 +64,9 @@ export default function EndedParticipationDrop({
   onReply,
   onQuoteClick,
   onDropContentClick,
+  footer,
   identityMode = "default",
+  timestampLayout = "inline",
   showInteractions = true,
   contentPresentation = "default",
   embedPath,
@@ -89,6 +97,7 @@ export default function EndedParticipationDrop({
   const isMobile = useIsMobileDevice();
   const hasTouch = useIsTouchDevice() || isMobile;
   const showIdentity = identityMode !== "hidden";
+  const isStackedTimestamp = timestampLayout === "stacked";
 
   const handleNavigation = (e: React.MouseEvent, path: string) => {
     e.preventDefault();
@@ -143,35 +152,55 @@ export default function EndedParticipationDrop({
           <div className="tw-flex tw-w-full tw-flex-col tw-gap-y-2">
             {showIdentity &&
               (identityMode === "minimal" ? (
-                <DropMinimalIdentityRow drop={drop} />
+                <DropMinimalIdentityRow
+                  drop={drop}
+                  timestampLayout={timestampLayout}
+                />
               ) : (
                 <div className="tw-flex tw-flex-col tw-gap-y-2">
-                  <div className="tw-flex tw-items-center tw-gap-x-2">
-                    <UserCICAndLevel
-                      level={drop.author.level}
-                      size={UserCICAndLevelSize.SMALL}
-                    />
+                  <div
+                    className={
+                      isStackedTimestamp
+                        ? "tw-flex tw-min-w-0 tw-flex-col tw-items-start tw-gap-y-1"
+                        : "tw-flex tw-items-center tw-gap-x-2"
+                    }
+                  >
+                    <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-1">
+                      <UserCICAndLevel
+                        level={drop.author.level}
+                        size={UserCICAndLevelSize.SMALL}
+                      />
 
-                    <p className="tw-mb-0 tw-text-md tw-font-semibold tw-leading-none">
-                      <Link
-                        onClick={(e) =>
-                          handleNavigation(
-                            e,
-                            `/${drop.author.handle ?? drop.author.primary_address}`
-                          )
-                        }
-                        href={`/${drop.author.handle ?? drop.author.primary_address}`}
-                        className="tw-text-iron-200 tw-no-underline tw-transition tw-duration-300 tw-ease-out hover:tw-text-iron-500"
-                      >
-                        {drop.author.handle ?? drop.author.primary_address}
-                      </Link>
-                    </p>
+                      <p className="tw-mb-0 tw-text-md tw-font-semibold tw-leading-none">
+                        <Link
+                          onClick={(e) =>
+                            handleNavigation(
+                              e,
+                              `/${drop.author.handle ?? drop.author.primary_address}`
+                            )
+                          }
+                          href={`/${drop.author.handle ?? drop.author.primary_address}`}
+                          className="tw-text-iron-200 tw-no-underline tw-transition tw-duration-300 tw-ease-out hover:tw-text-iron-500"
+                        >
+                          {drop.author.handle ?? drop.author.primary_address}
+                        </Link>
+                      </p>
 
-                    <div className="tw-size-[3px] tw-flex-shrink-0 tw-rounded-full tw-bg-iron-600"></div>
+                      {!isStackedTimestamp && (
+                        <div className="tw-size-[3px] tw-flex-shrink-0 tw-rounded-full tw-bg-iron-600"></div>
+                      )}
 
-                    <p className="tw-mb-0 tw-whitespace-nowrap tw-text-xs tw-font-normal tw-leading-none tw-text-iron-500">
-                      {getTimeAgoShort(drop.created_at)}
-                    </p>
+                      {!isStackedTimestamp && (
+                        <p className="tw-mb-0 tw-whitespace-nowrap tw-text-xs tw-font-normal tw-leading-none tw-text-iron-500">
+                          {getTimeAgoShort(drop.created_at)}
+                        </p>
+                      )}
+                    </div>
+                    {isStackedTimestamp && (
+                      <p className="tw-mb-0 tw-whitespace-nowrap tw-text-xs tw-font-normal tw-leading-none tw-text-iron-500">
+                        {getTimeAgoShort(drop.created_at)}
+                      </p>
+                    )}
                   </div>
                   <div className="tw-flex tw-w-fit tw-items-center tw-whitespace-nowrap tw-rounded-md tw-border tw-border-solid tw-border-iron-500/25 tw-bg-iron-600/10 tw-px-2 tw-py-0.5 tw-font-medium tw-text-iron-500">
                     <span className="tw-text-xs">Participant</span>
@@ -259,6 +288,13 @@ export default function EndedParticipationDrop({
               isCurated={drop.context_profile_context?.curated ?? false}
             />
             <WaveDropReactions drop={drop} />
+          </div>
+        )}
+        {footer !== undefined && footer !== null && (
+          <div
+            className={`${showIdentity ? "tw-ml-[3.25rem]" : ""} tw-pb-1 tw-pt-2`}
+          >
+            {footer}
           </div>
         )}
 

--- a/components/waves/drops/participation/EndedParticipationDrop.tsx
+++ b/components/waves/drops/participation/EndedParticipationDrop.tsx
@@ -33,7 +33,7 @@ import type {
   DropInteractionParams,
   DropTimestampLayout,
 } from "../drop.types";
-import { DropLocation } from "../drop.types";
+import { DropLocation, hasDropFooter } from "../drop.types";
 
 interface EndedParticipationDropProps {
   readonly drop: ExtendedDrop;
@@ -290,7 +290,7 @@ export default function EndedParticipationDrop({
             <WaveDropReactions drop={drop} />
           </div>
         )}
-        {footer !== undefined && footer !== null && (
+        {hasDropFooter(footer) && (
           <div
             className={`${showIdentity ? "tw-ml-[3.25rem]" : ""} tw-pb-1 tw-pt-2`}
           >

--- a/components/waves/drops/participation/OngoingParticipationDrop.tsx
+++ b/components/waves/drops/participation/OngoingParticipationDrop.tsx
@@ -30,6 +30,7 @@ import type {
   DropIdentityMode,
   DropInteractionParams,
   DropLocation,
+  DropTimestampLayout,
 } from "../drop.types";
 
 interface OngoingParticipationDropProps {
@@ -41,7 +42,9 @@ interface OngoingParticipationDropProps {
   readonly onReply: (param: DropInteractionParams) => void;
   readonly onQuoteClick: (drop: ApiDrop) => void;
   readonly onDropContentClick?: ((drop: ExtendedDrop) => void) | undefined;
+  readonly footer?: React.ReactNode;
   readonly identityMode?: DropIdentityMode | undefined;
+  readonly timestampLayout?: DropTimestampLayout | undefined;
   readonly showInteractions?: boolean | undefined;
   readonly contentPresentation?: DropContentPresentation | undefined;
   readonly embedPath?: readonly string[] | undefined;
@@ -59,7 +62,9 @@ export default function OngoingParticipationDrop({
   onReply,
   onQuoteClick,
   onDropContentClick,
+  footer,
   identityMode = "default",
+  timestampLayout = "inline",
   showInteractions = true,
   contentPresentation = "default",
   embedPath,
@@ -135,11 +140,15 @@ export default function OngoingParticipationDrop({
         <div className="tw-flex tw-w-full tw-flex-col">
           {showIdentity &&
             (identityMode === "minimal" ? (
-              <DropMinimalIdentityRow drop={drop} />
+              <DropMinimalIdentityRow
+                drop={drop}
+                timestampLayout={timestampLayout}
+              />
             ) : (
               <ParticipationDropHeader
                 drop={drop}
                 showWaveInfo={showWaveInfo}
+                timestampLayout={timestampLayout}
               />
             ))}
           <ParticipationDropContent
@@ -175,11 +184,20 @@ export default function OngoingParticipationDrop({
           metadata={visibleMetadata}
           contextId={drop.id}
         />
-        <ParticipationDropFooter
-          drop={drop}
-          voteAction={voteAction}
-          showInteractions={showInteractions}
-        />
+        {(showInteractions || footer === undefined || footer === null) && (
+          <ParticipationDropFooter
+            drop={drop}
+            voteAction={voteAction}
+            showInteractions={showInteractions}
+          />
+        )}
+        {footer !== undefined && footer !== null && (
+          <div
+            className={`${showIdentity ? "tw-ml-[3.25rem]" : ""} tw-px-4 tw-pb-4 tw-pt-2`}
+          >
+            {footer}
+          </div>
+        )}
       </div>
 
       {showInteractions &&

--- a/components/waves/drops/participation/OngoingParticipationDrop.tsx
+++ b/components/waves/drops/participation/OngoingParticipationDrop.tsx
@@ -32,6 +32,7 @@ import type {
   DropLocation,
   DropTimestampLayout,
 } from "../drop.types";
+import { hasDropFooter } from "../drop.types";
 
 interface OngoingParticipationDropProps {
   readonly drop: ExtendedDrop;
@@ -184,14 +185,14 @@ export default function OngoingParticipationDrop({
           metadata={visibleMetadata}
           contextId={drop.id}
         />
-        {(showInteractions || footer === undefined || footer === null) && (
+        {(showInteractions || !hasDropFooter(footer)) && (
           <ParticipationDropFooter
             drop={drop}
             voteAction={voteAction}
             showInteractions={showInteractions}
           />
         )}
-        {footer !== undefined && footer !== null && (
+        {hasDropFooter(footer) && (
           <div
             className={`${showIdentity ? "tw-ml-[3.25rem]" : ""} tw-px-4 tw-pb-4 tw-pt-2`}
           >

--- a/components/waves/drops/participation/ParticipationDropHeader.tsx
+++ b/components/waves/drops/participation/ParticipationDropHeader.tsx
@@ -6,61 +6,93 @@ import UserCICAndLevel, {
 } from "@/components/user/utils/UserCICAndLevel";
 import WinnerDropBadge from "../winner/WinnerDropBadge";
 import WaveDropTime from "../time/WaveDropTime";
+import type { DropTimestampLayout } from "../drop.types";
 
 interface ParticipationDropHeaderProps {
   readonly drop: ExtendedDrop;
   readonly showWaveInfo: boolean;
+  readonly timestampLayout?: DropTimestampLayout | undefined;
 }
 
 export default function ParticipationDropHeader({
   drop,
   showWaveInfo,
+  timestampLayout = "inline",
 }: ParticipationDropHeaderProps) {
+  const isStackedTimestamp = timestampLayout === "stacked";
+  const authorIdentity = drop.author.handle ?? drop.author.primary_address;
+  const hasRank = drop.rank !== null;
+
   return (
     <>
-      <div className="tw-flex tw-items-center tw-gap-x-2 tw-flex-wrap">
-        <p className="tw-text-md tw-mb-0 tw-leading-none tw-font-semibold">
-          <Link
-            onClick={(e) => e.stopPropagation()}
-            href={`/${drop.author.handle}`}
-            className="tw-no-underline tw-text-iron-200 hover:tw-text-iron-500 tw-transition tw-duration-300 tw-ease-out"
-          >
-            {drop.author.handle}
-          </Link>
-        </p>
-        <UserCICAndLevel
-          level={drop.author.level}
-          size={UserCICAndLevelSize.SMALL}
-        />
-        {drop.rank && (
-          <WinnerDropBadge
-            rank={drop.rank}
-            decisionTime={drop.winning_context?.decision_time ?? null}
+      <div
+        className={
+          isStackedTimestamp
+            ? "tw-flex tw-min-w-0 tw-flex-col tw-items-start tw-gap-y-1"
+            : "tw-flex tw-flex-wrap tw-items-center tw-gap-x-2"
+        }
+      >
+        <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-1">
+          <p className="tw-mb-0 tw-text-md tw-font-semibold tw-leading-none">
+            <Link
+              onClick={(e) => e.stopPropagation()}
+              href={`/${authorIdentity}`}
+              className="tw-text-iron-200 tw-no-underline tw-transition tw-duration-300 tw-ease-out hover:tw-text-iron-500"
+            >
+              {authorIdentity}
+            </Link>
+          </p>
+          <UserCICAndLevel
+            level={drop.author.level}
+            size={UserCICAndLevelSize.SMALL}
           />
-        )}
-        <div className="tw-size-[3px] tw-bg-iron-600 tw-rounded-full tw-flex-shrink-0"></div>
-        <WaveDropTime timestamp={drop.created_at} />
+          {hasRank && (
+            <WinnerDropBadge
+              rank={drop.rank}
+              decisionTime={drop.winning_context?.decision_time ?? null}
+            />
+          )}
+          {!isStackedTimestamp && (
+            <div className="tw-size-[3px] tw-flex-shrink-0 tw-rounded-full tw-bg-iron-600"></div>
+          )}
+          {!isStackedTimestamp && <WaveDropTime timestamp={drop.created_at} />}
+        </div>
+        {isStackedTimestamp && <WaveDropTime timestamp={drop.created_at} />}
       </div>
-      {showWaveInfo && drop.wave && (() => {
-        const waveMeta = (drop.wave as unknown as {
-          chat?: { scope?: { group?: { is_direct_message?: boolean | undefined } | undefined } | undefined } | undefined;
-        })?.chat;
-        const isDirectMessage = waveMeta?.scope?.group?.is_direct_message ?? false;
-        const waveHref = getWaveRoute({
-          waveId: drop.wave.id,
-          isDirectMessage,
-          isApp: false,
-        });
-        return (
-          <Link
-            onClick={(e) => e.stopPropagation()}
-            href={waveHref}
-            className="tw-mb-0 tw-text-[11px] tw-leading-0 tw-text-iron-500 hover:tw-text-iron-300 tw-transition tw-duration-300 tw-ease-out tw-no-underline"
-          >
-            {drop.wave.name}
-          </Link>
-        );
-      })()}
+      {showWaveInfo &&
+        (() => {
+          const waveMeta = (
+            drop.wave as unknown as {
+              chat?:
+                | {
+                    scope?:
+                      | {
+                          group?:
+                            | { is_direct_message?: boolean | undefined }
+                            | undefined;
+                        }
+                      | undefined;
+                  }
+                | undefined;
+            }
+          ).chat;
+          const isDirectMessage =
+            waveMeta?.scope?.group?.is_direct_message ?? false;
+          const waveHref = getWaveRoute({
+            waveId: drop.wave.id,
+            isDirectMessage,
+            isApp: false,
+          });
+          return (
+            <Link
+              onClick={(e) => e.stopPropagation()}
+              href={waveHref}
+              className="tw-leading-0 tw-mb-0 tw-text-[11px] tw-text-iron-500 tw-no-underline tw-transition tw-duration-300 tw-ease-out hover:tw-text-iron-300"
+            >
+              {drop.wave.name}
+            </Link>
+          );
+        })()}
     </>
   );
 }

--- a/components/waves/drops/participation/participationRenderer.types.ts
+++ b/components/waves/drops/participation/participationRenderer.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentType, RefObject } from "react";
+import type { ComponentType, ReactNode, RefObject } from "react";
 import type { ApiDrop } from "@/generated/models/ApiDrop";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import type { WaveParticipationVariant } from "@/helpers/waves/wave-participation-presentation.helpers";
@@ -7,6 +7,7 @@ import type {
   DropIdentityMode,
   DropInteractionParams,
   DropLocation,
+  DropTimestampLayout,
 } from "../drop.types";
 
 export interface ParticipationDropProps {
@@ -19,7 +20,9 @@ export interface ParticipationDropProps {
   readonly onQuoteClick: (drop: ApiDrop) => void;
   readonly onDropContentClick?: ((drop: ExtendedDrop) => void) | undefined;
   readonly parentContainerRef?: RefObject<HTMLElement | null> | undefined;
+  readonly footer?: ReactNode;
   readonly identityMode?: DropIdentityMode | undefined;
+  readonly timestampLayout?: DropTimestampLayout | undefined;
   readonly showInteractions?: boolean | undefined;
   readonly embedPath?: readonly string[] | undefined;
   readonly quotePath?: readonly string[] | undefined;

--- a/components/waves/drops/winner/DefaultWinnerDrop.tsx
+++ b/components/waves/drops/winner/DefaultWinnerDrop.tsx
@@ -8,7 +8,11 @@ import useIsTouchDevice from "@/hooks/useIsTouchDevice";
 import type { ActiveDropState } from "@/types/dropInteractionTypes";
 import Link from "next/link";
 import { memo, useCallback, useState } from "react";
-import type { DropIdentityMode, DropInteractionParams } from "../drop.types";
+import type {
+  DropIdentityMode,
+  DropInteractionParams,
+  DropTimestampLayout,
+} from "../drop.types";
 import { DropLocation } from "../drop.types";
 import {
   getRankHoverBorderClass,
@@ -55,7 +59,9 @@ interface DefautWinnerDropProps {
   readonly onReplyClick: (serialNo: number) => void;
   readonly onQuoteClick: (drop: ApiDrop) => void;
   readonly onDropContentClick?: ((drop: ExtendedDrop) => void) | undefined;
+  readonly footer?: React.ReactNode;
   readonly identityMode?: DropIdentityMode | undefined;
+  readonly timestampLayout?: DropTimestampLayout | undefined;
   readonly showInteractions?: boolean | undefined;
 }
 
@@ -69,8 +75,10 @@ const DefaultWinnerDrop = ({
   onReplyClick,
   onQuoteClick,
   onDropContentClick,
+  footer,
   showReplyAndQuote,
   identityMode = "default",
+  timestampLayout = "inline",
   showInteractions = true,
 }: DefautWinnerDropProps) => {
   const [activePartIndex, setActivePartIndex] = useState<number>(0);
@@ -147,7 +155,10 @@ const DefaultWinnerDrop = ({
             <div className="tw-flex tw-flex-col tw-items-start">
               {showIdentity &&
                 (identityMode === "minimal" ? (
-                  <DropMinimalIdentityRow drop={drop} />
+                  <DropMinimalIdentityRow
+                    drop={drop}
+                    timestampLayout={timestampLayout}
+                  />
                 ) : (
                   <WaveDropHeader
                     drop={drop}
@@ -161,6 +172,7 @@ const DefaultWinnerDrop = ({
                         decisionTime={decisionTime ?? null}
                       />
                     }
+                    timestampLayout={timestampLayout}
                   />
                 ))}
               {identityMode === "default" &&
@@ -237,6 +249,13 @@ const DefaultWinnerDrop = ({
             </div>
           )}
         </div>
+        {footer !== undefined && footer !== null && (
+          <div
+            className={`${showIdentity ? "tw-ml-[3.25rem]" : ""} tw-pb-1 tw-pt-2`}
+          >
+            {footer}
+          </div>
+        )}
       </div>
       {showInteractions && (
         <WaveDropMobileMenu

--- a/components/waves/drops/winner/DefaultWinnerDrop.tsx
+++ b/components/waves/drops/winner/DefaultWinnerDrop.tsx
@@ -13,7 +13,7 @@ import type {
   DropInteractionParams,
   DropTimestampLayout,
 } from "../drop.types";
-import { DropLocation } from "../drop.types";
+import { DropLocation, hasDropFooter } from "../drop.types";
 import {
   getRankHoverBorderClass,
   getRankStaticBorderClass,
@@ -249,7 +249,7 @@ const DefaultWinnerDrop = ({
             </div>
           )}
         </div>
-        {footer !== undefined && footer !== null && (
+        {hasDropFooter(footer) && (
           <div
             className={`${showIdentity ? "tw-ml-[3.25rem]" : ""} tw-pb-1 tw-pt-2`}
           >

--- a/components/waves/drops/winner/WinnerDrop.tsx
+++ b/components/waves/drops/winner/WinnerDrop.tsx
@@ -9,6 +9,7 @@ import type {
   DropIdentityMode,
   DropInteractionParams,
   DropLocation,
+  DropTimestampLayout,
 } from "../drop.types";
 
 interface WinnerDropProps {
@@ -25,7 +26,9 @@ interface WinnerDropProps {
   readonly onQuoteClick: (drop: ApiDrop) => void;
   readonly onDropContentClick?: ((drop: ExtendedDrop) => void) | undefined;
   readonly parentContainerRef?: React.RefObject<HTMLElement | null> | undefined;
+  readonly footer?: React.ReactNode;
   readonly identityMode?: DropIdentityMode | undefined;
+  readonly timestampLayout?: DropTimestampLayout | undefined;
   readonly showInteractions?: boolean | undefined;
 }
 

--- a/hooks/drops/useDropReaction.ts
+++ b/hooks/drops/useDropReaction.ts
@@ -1,15 +1,20 @@
 "use client";
 
 import { useAuth } from "@/components/auth/Auth";
+import { QueryKey as AppQueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import { useMyStream } from "@/contexts/wave/MyStreamContext";
+import type { ApiDropReaction } from "@/generated/models/ApiDropReaction";
 import type { ApiAddReactionToDropRequest } from "@/generated/models/ApiAddReactionToDropRequest";
 import type { ApiDrop } from "@/generated/models/ApiDrop";
 import type { ApiDropContextProfileContext } from "@/generated/models/ApiDropContextProfileContext";
 import { recordReaction } from "@/helpers/reactions/reactionHistory";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import { DropSize } from "@/helpers/waves/drop.helpers";
+import { COMMUNITY_CURATIONS_DROPS_QUERY_KEY } from "@/hooks/useCommunityCurationsDrops";
 import { commonApiDelete, commonApiPost } from "@/services/api/common-api";
 import { useWebsocketStatus } from "@/services/websocket/useWebSocketMessage";
+import type { InfiniteData } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useRef } from "react";
 import {
   cloneReactionEntries,
@@ -37,88 +42,241 @@ interface UseDropReactionResult {
 interface UseDropReactionOptions {
   readonly source?: ReactionSource | undefined;
   readonly onSuccess?: (() => void) | undefined;
+  readonly updateCurationCache?: boolean | undefined;
 }
 
-export function useDropReaction(
-  drop: ExtendedDrop,
-  options?: UseDropReactionOptions
-): UseDropReactionResult {
-  const { setToast, connectedProfile } = useAuth();
-  const { applyOptimisticDropUpdate } = useMyStream();
-  const websocketStatus = useWebsocketStatus();
-  const rollbackRef = useRef<(() => void) | null>(null);
-  const source = options?.source ?? "picker";
-  const onSuccess = options?.onSuccess;
+type OptimisticRollback = (() => void) | null;
 
-  const canReact = !drop.id.startsWith("temp-");
+type ReactionCacheDrop = {
+  readonly id: string;
+  readonly reactions: readonly ApiDropReaction[];
+  readonly context_profile_context?: ApiDropContextProfileContext | null;
+};
 
-  const waveId = drop.wave.id;
-  const dropId = drop.id;
-  const contextProfileContext = drop.context_profile_context;
+type ReactionCachePage = {
+  readonly data: readonly ReactionCacheDrop[];
+};
 
-  const applyOptimisticReaction = useCallback(
+type ReactionCacheData = InfiniteData<ReactionCachePage>;
+
+const EMPTY_CONTEXT_PROFILE_CONTEXT: ApiDropContextProfileContext = {
+  rating: 0,
+  min_rating: 0,
+  max_rating: 0,
+  reaction: null,
+  boosted: false,
+  bookmarked: false,
+  curatable: false,
+  curated: false,
+};
+
+const combineRollbacks = (
+  rollbacks: readonly OptimisticRollback[]
+): OptimisticRollback => {
+  const activeRollbacks = rollbacks.filter(
+    (rollback): rollback is () => void => rollback !== null
+  );
+
+  if (activeRollbacks.length === 0) {
+    return null;
+  }
+
+  return () => {
+    for (const rollback of activeRollbacks) {
+      rollback();
+    }
+  };
+};
+
+const isReactionCacheDrop = (value: unknown): value is ReactionCacheDrop => {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as {
+    readonly id?: unknown;
+    readonly reactions?: unknown;
+  };
+
+  return typeof candidate.id === "string" && Array.isArray(candidate.reactions);
+};
+
+const isReactionCacheData = (data: unknown): data is ReactionCacheData => {
+  if (data === null || typeof data !== "object") {
+    return false;
+  }
+
+  const pages = (data as { readonly pages?: unknown }).pages;
+  if (!Array.isArray(pages)) {
+    return false;
+  }
+
+  return pages.every((page) => {
+    if (page === null || typeof page !== "object") {
+      return false;
+    }
+
+    const pageData = (page as { readonly data?: unknown }).data;
+    return Array.isArray(pageData) && pageData.every(isReactionCacheDrop);
+  });
+};
+
+const isReactionCurationQueryKey = (queryKey: readonly unknown[]): boolean => {
+  if (queryKey[0] === COMMUNITY_CURATIONS_DROPS_QUERY_KEY) {
+    return true;
+  }
+
+  if (queryKey[0] !== AppQueryKey.DROPS) {
+    return false;
+  }
+
+  const params = queryKey[1];
+  return (
+    params !== null &&
+    typeof params === "object" &&
+    (params as { readonly context?: unknown }).context === "wave-curation-drops"
+  );
+};
+
+const applyReactionToCacheDrop = ({
+  baseContext,
+  drop,
+  profileMin,
+  reactionCode,
+}: {
+  readonly baseContext: ApiDropContextProfileContext | null | undefined;
+  readonly drop: ReactionCacheDrop;
+  readonly profileMin: ReturnType<typeof toProfileMin>;
+  readonly reactionCode: string | null;
+}): ReactionCacheDrop => {
+  if (!profileMin) {
+    return drop;
+  }
+
+  const reactionsWithoutUser = removeUserFromReactions(
+    cloneReactionEntries(drop.reactions),
+    profileMin.id
+  );
+
+  if (reactionCode !== null) {
+    const targetIndex = findReactionIndex(reactionsWithoutUser, reactionCode);
+
+    if (targetIndex >= 0) {
+      const target = reactionsWithoutUser[targetIndex]!;
+      reactionsWithoutUser[targetIndex] = {
+        ...target,
+        profiles: [...target.profiles, profileMin],
+      };
+    } else {
+      reactionsWithoutUser.push({
+        reaction: reactionCode,
+        profiles: [profileMin],
+      });
+    }
+  }
+
+  return {
+    ...drop,
+    reactions: reactionsWithoutUser,
+    context_profile_context: {
+      ...(drop.context_profile_context ??
+        baseContext ??
+        EMPTY_CONTEXT_PROFILE_CONTEXT),
+      reaction: reactionCode,
+    },
+  };
+};
+
+const updateReactionCacheData = ({
+  baseContext,
+  data,
+  dropId,
+  profileMin,
+  reactionCode,
+}: {
+  readonly baseContext: ApiDropContextProfileContext | null | undefined;
+  readonly data: unknown;
+  readonly dropId: string;
+  readonly profileMin: ReturnType<typeof toProfileMin>;
+  readonly reactionCode: string | null;
+}): unknown => {
+  if (!isReactionCacheData(data)) {
+    return data;
+  }
+
+  let changed = false;
+  const pages: ReactionCachePage[] = [];
+
+  for (const page of data.pages) {
+    let pageChanged = false;
+    const nextData: ReactionCacheDrop[] = [];
+
+    for (const cacheDrop of page.data) {
+      if (cacheDrop.id !== dropId) {
+        nextData.push(cacheDrop);
+        continue;
+      }
+
+      changed = true;
+      pageChanged = true;
+      nextData.push(
+        applyReactionToCacheDrop({
+          baseContext,
+          drop: cacheDrop,
+          profileMin,
+          reactionCode,
+        })
+      );
+    }
+
+    pages.push(pageChanged ? { ...page, data: nextData } : page);
+  }
+
+  return changed ? { ...data, pages } : data;
+};
+
+const useOptimisticStreamDropReaction = ({
+  applyOptimisticDropUpdate,
+  connectedProfile,
+  contextProfileContext,
+  dropId,
+  waveId,
+}: {
+  readonly applyOptimisticDropUpdate: ReturnType<
+    typeof useMyStream
+  >["applyOptimisticDropUpdate"];
+  readonly connectedProfile: ReturnType<typeof useAuth>["connectedProfile"];
+  readonly contextProfileContext:
+    | ApiDropContextProfileContext
+    | null
+    | undefined;
+  readonly dropId: string;
+  readonly waveId: string;
+}) =>
+  useCallback(
     (reactionCode: string | null) => {
       const profileMin = toProfileMin(connectedProfile);
       if (!profileMin) {
         return null;
       }
 
-      const userId = profileMin.id;
-
       const handle = applyOptimisticDropUpdate({
-        waveId: waveId,
-        dropId: dropId,
+        waveId,
+        dropId,
         update: (draft) => {
           if (draft.type !== DropSize.FULL) {
             return draft;
           }
 
-          const reactions = cloneReactionEntries(draft.reactions);
-          const reactionsWithoutUser = removeUserFromReactions(
-            reactions,
-            userId
-          );
-
-          if (reactionCode !== null) {
-            const targetIndex = findReactionIndex(
-              reactionsWithoutUser,
-              reactionCode
-            );
-
-            if (targetIndex >= 0) {
-              const profiles =
-                reactionsWithoutUser[targetIndex]?.profiles ?? [];
-              reactionsWithoutUser[targetIndex] = {
-                ...reactionsWithoutUser[targetIndex]!,
-                profiles: [...profiles, profileMin],
-              };
-            } else {
-              reactionsWithoutUser.push({
-                reaction: reactionCode,
-                profiles: [profileMin],
-              });
-            }
-          }
-
-          draft.reactions = reactionsWithoutUser;
-
-          const baseContext: ApiDropContextProfileContext =
-            draft.context_profile_context ??
-              contextProfileContext ?? {
-                rating: 0,
-                min_rating: 0,
-                max_rating: 0,
-                reaction: null,
-                boosted: false,
-                bookmarked: false,
-                curatable: false,
-                curated: false,
-              };
-
-          draft.context_profile_context = {
-            ...baseContext,
-            reaction: reactionCode,
-          };
+          const nextDrop = applyReactionToCacheDrop({
+            baseContext: contextProfileContext,
+            drop: draft,
+            profileMin,
+            reactionCode,
+          });
+          draft.reactions = [...nextDrop.reactions];
+          draft.context_profile_context =
+            nextDrop.context_profile_context ?? EMPTY_CONTEXT_PROFILE_CONTEXT;
 
           return draft;
         },
@@ -134,6 +292,113 @@ export function useDropReaction(
       waveId,
     ]
   );
+
+const useOptimisticCurationDropReaction = ({
+  connectedProfile,
+  contextProfileContext,
+  dropId,
+  enabled,
+}: {
+  readonly connectedProfile: ReturnType<typeof useAuth>["connectedProfile"];
+  readonly contextProfileContext:
+    | ApiDropContextProfileContext
+    | null
+    | undefined;
+  readonly dropId: string;
+  readonly enabled: boolean;
+}) => {
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    (reactionCode: string | null): OptimisticRollback => {
+      if (!enabled) {
+        return null;
+      }
+
+      const profileMin = toProfileMin(connectedProfile);
+      if (!profileMin) {
+        return null;
+      }
+
+      const matchingQueries = queryClient.getQueryCache().findAll({
+        predicate: (query) => isReactionCurationQueryKey(query.queryKey),
+      });
+
+      if (matchingQueries.length === 0) {
+        return null;
+      }
+
+      const snapshots: Array<{
+        readonly queryKey: (typeof matchingQueries)[number]["queryKey"];
+        readonly data: unknown;
+      }> = [];
+
+      for (const query of matchingQueries) {
+        const currentData = query.state.data;
+        const nextData = updateReactionCacheData({
+          baseContext: contextProfileContext,
+          data: currentData,
+          dropId,
+          profileMin,
+          reactionCode,
+        });
+
+        if (nextData === currentData) {
+          continue;
+        }
+
+        snapshots.push({
+          queryKey: query.queryKey,
+          data: currentData,
+        });
+        queryClient.setQueryData(query.queryKey, nextData);
+      }
+
+      if (snapshots.length === 0) {
+        return null;
+      }
+
+      return () => {
+        for (const snapshot of snapshots) {
+          queryClient.setQueryData(snapshot.queryKey, snapshot.data);
+        }
+      };
+    },
+    [connectedProfile, contextProfileContext, dropId, enabled, queryClient]
+  );
+};
+
+export function useDropReaction(
+  drop: ExtendedDrop,
+  options?: UseDropReactionOptions
+): UseDropReactionResult {
+  const { setToast, connectedProfile } = useAuth();
+  const { applyOptimisticDropUpdate } = useMyStream();
+  const websocketStatus = useWebsocketStatus();
+  const rollbackRef = useRef<(() => void) | null>(null);
+  const source = options?.source ?? "picker";
+  const onSuccess = options?.onSuccess;
+  const updateCurationCache = options?.updateCurationCache ?? false;
+
+  const canReact = !drop.id.startsWith("temp-");
+
+  const waveId = drop.wave.id;
+  const dropId = drop.id;
+  const contextProfileContext = drop.context_profile_context;
+  const applyOptimisticReaction = useOptimisticStreamDropReaction({
+    applyOptimisticDropUpdate,
+    connectedProfile,
+    contextProfileContext,
+    dropId,
+    waveId,
+  });
+  const applyOptimisticReactionToCurationQueries =
+    useOptimisticCurationDropReaction({
+      connectedProfile,
+      contextProfileContext,
+      dropId,
+      enabled: updateCurationCache,
+    });
 
   const react = useCallback(
     async (reactionCode: string) => {
@@ -157,7 +422,10 @@ export function useDropReaction(
       });
 
       rollbackRef.current?.();
-      rollbackRef.current = applyOptimisticReaction(intendedReaction);
+      rollbackRef.current = combineRollbacks([
+        applyOptimisticReaction(intendedReaction),
+        applyOptimisticReactionToCurationQueries(intendedReaction),
+      ]);
       recordReactionOptimisticApplied(mutation);
 
       if (!isRemoving) {
@@ -214,6 +482,7 @@ export function useDropReaction(
     [
       canReact,
       applyOptimisticReaction,
+      applyOptimisticReactionToCurationQueries,
       connectedProfile?.id,
       contextProfileContext?.reaction,
       drop.id,

--- a/hooks/useCommunityCurationsDrops.ts
+++ b/hooks/useCommunityCurationsDrops.ts
@@ -6,7 +6,7 @@ import { commonApiFetch } from "@/services/api/common-api";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 
-const COMMUNITY_CURATIONS_DROPS_QUERY_KEY = "COMMUNITY_CURATIONS_DROPS";
+export const COMMUNITY_CURATIONS_DROPS_QUERY_KEY = "COMMUNITY_CURATIONS_DROPS";
 
 interface UseCommunityCurationsDropsProps {
   readonly limit: number;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drop timestamps now support flexible layout modes (inline or stacked formatting).
  * Drop cards now display customizable footer sections with reactions and link-copy actions.
  * Reaction and link-copy action buttons support compact sizing options.

* **Refactor**
  * Enhanced event propagation handling for drop footer interactive elements.
  * Improved community curations card visual layout and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->