### PR TITLE
Default rank wave my votes

### DIFF
--- a/__tests__/components/brain/ContentTabContext.test.tsx
+++ b/__tests__/components/brain/ContentTabContext.test.tsx
@@ -118,6 +118,49 @@ describe("ContentTabContext", () => {
     expect(result.current.activeContentTab).toBe(MyStreamWaveTab.CHAT);
   });
 
+  it("adds My Votes for authenticated normal rank waves", () => {
+    const { result } = setup();
+    act(() =>
+      result.current.updateAvailableTabs({
+        waveId: "rank-wave",
+        isChatWave: false,
+        hasAuthenticatedProfile: true,
+        isMemesWave: false,
+        isCurationWave: false,
+        votingState: WaveVotingState.NOT_STARTED,
+        hasFirstDecisionPassed: false,
+      })
+    );
+
+    expect(result.current.availableTabs).toEqual([
+      MyStreamWaveTab.CHAT,
+      MyStreamWaveTab.LEADERBOARD,
+      MyStreamWaveTab.OUTCOME,
+      MyStreamWaveTab.MY_VOTES,
+    ]);
+  });
+
+  it("omits My Votes for guests on normal rank waves", () => {
+    const { result } = setup();
+    act(() =>
+      result.current.updateAvailableTabs({
+        waveId: "rank-wave",
+        isChatWave: false,
+        hasAuthenticatedProfile: false,
+        isMemesWave: false,
+        isCurationWave: false,
+        votingState: WaveVotingState.NOT_STARTED,
+        hasFirstDecisionPassed: false,
+      })
+    );
+
+    expect(result.current.availableTabs).toEqual([
+      MyStreamWaveTab.CHAT,
+      MyStreamWaveTab.LEADERBOARD,
+      MyStreamWaveTab.OUTCOME,
+    ]);
+  });
+
   it("forces CHAT for chat waves", () => {
     const { result } = setup();
     act(() =>
@@ -195,7 +238,7 @@ describe("ContentTabContext", () => {
     expect(result.current.activeContentTab).toBe(MyStreamWaveTab.SUBMISSIONS);
   });
 
-  it("keeps approve waves on approvals and always shows approved tab", () => {
+  it("adds My Votes for authenticated normal approve waves", () => {
     const { result } = setup();
     act(() =>
       result.current.updateAvailableTabs({
@@ -215,8 +258,32 @@ describe("ContentTabContext", () => {
       MyStreamWaveTab.LEADERBOARD,
       MyStreamWaveTab.WINNERS,
       MyStreamWaveTab.OUTCOME,
+      MyStreamWaveTab.MY_VOTES,
     ]);
     expect(result.current.activeContentTab).toBe(MyStreamWaveTab.CHAT);
+  });
+
+  it("omits My Votes for guests on normal approve waves", () => {
+    const { result } = setup();
+    act(() =>
+      result.current.updateAvailableTabs({
+        waveId: "approve-wave",
+        isChatWave: false,
+        hasAuthenticatedProfile: false,
+        isMemesWave: false,
+        isCurationWave: false,
+        isApproveWave: true,
+        votingState: WaveVotingState.ENDED,
+        hasFirstDecisionPassed: false,
+      })
+    );
+
+    expect(result.current.availableTabs).toEqual([
+      MyStreamWaveTab.CHAT,
+      MyStreamWaveTab.LEADERBOARD,
+      MyStreamWaveTab.WINNERS,
+      MyStreamWaveTab.OUTCOME,
+    ]);
   });
 
   it("normalizes stored LEADERBOARD to SUBMISSIONS once voting ends", () => {

--- a/__tests__/components/brain/mobile/BrainMobileTabs.test.tsx
+++ b/__tests__/components/brain/mobile/BrainMobileTabs.test.tsx
@@ -19,9 +19,10 @@ enum BrainView {
 }
 
 const push = jest.fn();
+const replace = jest.fn();
 
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({ push }),
+  useRouter: () => ({ push, replace }),
   useSearchParams: () => ({
     get: jest.fn().mockReturnValue(null),
   }),
@@ -77,6 +78,12 @@ const { useWave } = require("@/hooks/useWave");
 const { useUnreadIndicator } = require("@/hooks/useUnreadIndicator");
 const { useUnreadNotifications } = require("@/hooks/useUnreadNotifications");
 const { useAuth } = require("@/components/auth/Auth");
+
+const createWave = () =>
+  ({
+    id: "1",
+    wave: { authenticated_user_eligible_for_admin: false },
+  }) as any;
 
 describe("BrainMobileTabs", () => {
   const onViewChange = jest.fn();
@@ -174,14 +181,14 @@ describe("BrainMobileTabs", () => {
         showWavesTab={false}
         showStreamBack={false}
         isApp={false}
-        wave={{ id: "1" } as any}
+        wave={createWave()}
       />
     );
 
     expect(screen.getByTestId("leaderboard")).toBeInTheDocument();
     expect(leaderboardMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        wave: { id: "1" },
+        wave: expect.objectContaining({ id: "1" }),
         activeView: BrainView.ABOUT,
         onViewChange: expect.any(Function),
       })
@@ -206,7 +213,7 @@ describe("BrainMobileTabs", () => {
         showWavesTab={false}
         showStreamBack={false}
         isApp={false}
-        wave={{ id: "1" } as any}
+        wave={createWave()}
       />
     );
 
@@ -215,6 +222,59 @@ describe("BrainMobileTabs", () => {
     expect(screen.getByText("My Votes")).toBeInTheDocument();
     expect(screen.queryByText("Outcome")).toBeNull();
     expect(screen.queryByText("FAQ")).toBeNull();
+  });
+
+  it("renders My Votes for authenticated normal rank wave", () => {
+    (useWave as jest.Mock).mockReturnValue({
+      isMemesWave: false,
+      isCurationWave: false,
+      isRankWave: true,
+      isApproveWave: false,
+    });
+
+    render(
+      <BrainMobileTabs
+        activeView={BrainView.ABOUT}
+        onViewChange={onViewChange}
+        waveActive={true}
+        showWavesTab={false}
+        showStreamBack={false}
+        isApp={false}
+        wave={createWave()}
+      />
+    );
+
+    expect(screen.getByTestId("leaderboard")).toBeInTheDocument();
+    expect(screen.getByText("My Votes")).toBeInTheDocument();
+    expect(screen.getByText("Outcome")).toBeInTheDocument();
+  });
+
+  it("hides My Votes for guests on normal rank waves", () => {
+    (useWave as jest.Mock).mockReturnValue({
+      isMemesWave: false,
+      isCurationWave: false,
+      isRankWave: true,
+      isApproveWave: false,
+    });
+    (useAuth as jest.Mock).mockReturnValue({
+      connectedProfile: null,
+    });
+
+    render(
+      <BrainMobileTabs
+        activeView={BrainView.ABOUT}
+        onViewChange={onViewChange}
+        waveActive={true}
+        showWavesTab={false}
+        showStreamBack={false}
+        isApp={false}
+        wave={createWave()}
+      />
+    );
+
+    expect(screen.getByTestId("leaderboard")).toBeInTheDocument();
+    expect(screen.queryByText("My Votes")).toBeNull();
+    expect(screen.getByText("Outcome")).toBeInTheDocument();
   });
 
   it("hides My Votes for guests on memes rank wave", () => {
@@ -235,7 +295,7 @@ describe("BrainMobileTabs", () => {
         showWavesTab={false}
         showStreamBack={false}
         isApp={false}
-        wave={{ id: "1" } as any}
+        wave={createWave()}
       />
     );
 
@@ -260,7 +320,7 @@ describe("BrainMobileTabs", () => {
         showWavesTab={false}
         showStreamBack={false}
         isApp={false}
-        wave={{ id: "1" } as any}
+        wave={createWave()}
       />
     );
 
@@ -284,18 +344,47 @@ describe("BrainMobileTabs", () => {
         showWavesTab={false}
         showStreamBack={false}
         isApp={false}
-        wave={{ id: "1" } as any}
+        wave={createWave()}
       />
     );
 
     expect(screen.getByTestId("leaderboard")).toBeInTheDocument();
     expect(screen.getByText("Outcome")).toBeInTheDocument();
+    expect(screen.getByText("My Votes")).toBeInTheDocument();
     expect(leaderboardMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        wave: { id: "1" },
+        wave: expect.objectContaining({ id: "1" }),
         activeView: BrainView.ABOUT,
       })
     );
+  });
+
+  it("hides My Votes for guests on normal approve waves", () => {
+    (useWave as jest.Mock).mockReturnValue({
+      isMemesWave: false,
+      isCurationWave: false,
+      isRankWave: false,
+      isApproveWave: true,
+    });
+    (useAuth as jest.Mock).mockReturnValue({
+      connectedProfile: null,
+    });
+
+    render(
+      <BrainMobileTabs
+        activeView={BrainView.ABOUT}
+        onViewChange={onViewChange}
+        waveActive={true}
+        showWavesTab={false}
+        showStreamBack={false}
+        isApp={false}
+        wave={createWave()}
+      />
+    );
+
+    expect(screen.getByTestId("leaderboard")).toBeInTheDocument();
+    expect(screen.queryByText("My Votes")).toBeNull();
+    expect(screen.getByText("Outcome")).toBeInTheDocument();
   });
 
   it("renders curation tabs without Outcome for approve curation waves", () => {
@@ -314,7 +403,7 @@ describe("BrainMobileTabs", () => {
         showWavesTab={false}
         showStreamBack={false}
         isApp={false}
-        wave={{ id: "1" } as any}
+        wave={createWave()}
       />
     );
 

--- a/__tests__/components/brain/mobile/useBrainMobileActiveView.test.ts
+++ b/__tests__/components/brain/mobile/useBrainMobileActiveView.test.ts
@@ -97,4 +97,93 @@ describe("useBrainMobileActiveView", () => {
 
     expect(result.current.activeView).toBe(BrainView.SUBMISSIONS);
   });
+
+  it("keeps My Votes for authenticated normal rank waves", () => {
+    const { result } = renderHook(() =>
+      useBrainMobileActiveView(
+        createProps({
+          hasAuthenticatedProfile: true,
+          wave: { id: "wave-1" } as UseBrainMobileActiveViewProps["wave"],
+        })
+      )
+    );
+
+    act(() => {
+      result.current.onViewChange(BrainView.MY_VOTES);
+    });
+
+    expect(result.current.activeView).toBe(BrainView.MY_VOTES);
+  });
+
+  it("resets My Votes for guests on normal rank waves", () => {
+    const { result } = renderHook(() =>
+      useBrainMobileActiveView(
+        createProps({
+          hasAuthenticatedProfile: false,
+          wave: { id: "wave-1" } as UseBrainMobileActiveViewProps["wave"],
+        })
+      )
+    );
+
+    act(() => {
+      result.current.onViewChange(BrainView.MY_VOTES);
+    });
+
+    expect(result.current.activeView).toBe(BrainView.SUBMISSIONS);
+  });
+
+  it("keeps My Votes for curation rank waves without requiring login", () => {
+    const { result } = renderHook(() =>
+      useBrainMobileActiveView(
+        createProps({
+          hasAuthenticatedProfile: false,
+          isCurationWave: true,
+          wave: { id: "wave-1" } as UseBrainMobileActiveViewProps["wave"],
+        })
+      )
+    );
+
+    act(() => {
+      result.current.onViewChange(BrainView.MY_VOTES);
+    });
+
+    expect(result.current.activeView).toBe(BrainView.MY_VOTES);
+  });
+
+  it("keeps My Votes for authenticated normal approve waves", () => {
+    const { result } = renderHook(() =>
+      useBrainMobileActiveView(
+        createProps({
+          hasAuthenticatedProfile: true,
+          isApproveWave: true,
+          isRankWave: false,
+          wave: { id: "wave-1" } as UseBrainMobileActiveViewProps["wave"],
+        })
+      )
+    );
+
+    act(() => {
+      result.current.onViewChange(BrainView.MY_VOTES);
+    });
+
+    expect(result.current.activeView).toBe(BrainView.MY_VOTES);
+  });
+
+  it("resets My Votes for guests on normal approve waves", () => {
+    const { result } = renderHook(() =>
+      useBrainMobileActiveView(
+        createProps({
+          isApproveWave: true,
+          isRankWave: false,
+          wave: { id: "wave-1" } as UseBrainMobileActiveViewProps["wave"],
+        })
+      )
+    );
+
+    act(() => {
+      result.current.onViewChange(BrainView.MY_VOTES);
+    });
+
+    expect(result.current.activeView).toBe(BrainView.DEFAULT);
+  });
 });

--- a/__tests__/components/brain/my-stream/MyStreamWaveDesktopTabs.test.tsx
+++ b/__tests__/components/brain/my-stream/MyStreamWaveDesktopTabs.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { MyStreamWaveTab } from "@/types/waves.types";
 import { ApiWaveType } from "@/generated/models/ApiWaveType";
@@ -151,17 +151,17 @@ describe("MyStreamWaveDesktopTabs", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("filters options and corrects invalid active tab", () => {
+  it("filters hidden My Votes without correcting the active tab", () => {
     mockAvailableTabs = [
       MyStreamWaveTab.CHAT,
       MyStreamWaveTab.MY_VOTES,
       MyStreamWaveTab.LEADERBOARD,
     ];
     renderComponent(MyStreamWaveTab.MY_VOTES);
-    expect(setActiveTab).toHaveBeenCalledWith(MyStreamWaveTab.CHAT);
-    expect(screen.getByText("Chat")).toBeInTheDocument();
-    expect(screen.getByText("Leaderboard")).toBeInTheDocument();
+    expect(screen.getAllByText("Chat").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Leaderboard").length).toBeGreaterThan(0);
     expect(screen.queryByText("My Votes")).toBeNull();
+    expect(setActiveTab).not.toHaveBeenCalled();
   });
 
   it("shows My Votes for curation waves", () => {
@@ -180,14 +180,54 @@ describe("MyStreamWaveDesktopTabs", () => {
     ];
     renderComponent(MyStreamWaveTab.MY_VOTES);
 
-    expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
-      "Chat",
-      "Leaderboard",
-      "Sales",
-      "My Votes",
-    ]);
-    expect(screen.getByText("Sales")).toBeInTheDocument();
-    expect(screen.getByText("My Votes")).toBeInTheDocument();
+    expect(screen.getAllByText("Sales").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("My Votes").length).toBeGreaterThan(0);
+    expect(setActiveTab).not.toHaveBeenCalled();
+  });
+
+  it("shows My Votes for authenticated normal rank waves", () => {
+    mockWaveInfo = {
+      isChatWave: false,
+      isApproveWave: false,
+      isMemesWave: false,
+      isCurationWave: false,
+      isRankWave: true,
+    };
+    mockAvailableTabs = [
+      MyStreamWaveTab.CHAT,
+      MyStreamWaveTab.LEADERBOARD,
+      MyStreamWaveTab.OUTCOME,
+      MyStreamWaveTab.MY_VOTES,
+    ];
+
+    renderComponent(MyStreamWaveTab.MY_VOTES);
+
+    expect(screen.getAllByText("My Votes").length).toBeGreaterThan(0);
+  });
+
+  it("hides My Votes for guests on normal rank waves", () => {
+    mockWaveInfo = {
+      isChatWave: false,
+      isApproveWave: false,
+      isMemesWave: false,
+      isCurationWave: false,
+      isRankWave: true,
+    };
+    mockAvailableTabs = [
+      MyStreamWaveTab.CHAT,
+      MyStreamWaveTab.LEADERBOARD,
+      MyStreamWaveTab.OUTCOME,
+      MyStreamWaveTab.MY_VOTES,
+    ];
+    (useAuth as jest.Mock).mockReturnValue({
+      connectedProfile: null,
+    });
+
+    renderComponent(MyStreamWaveTab.MY_VOTES);
+
+    expect(screen.getAllByText("Chat").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Leaderboard").length).toBeGreaterThan(0);
+    expect(screen.queryByText("My Votes")).toBeNull();
     expect(setActiveTab).not.toHaveBeenCalled();
   });
 
@@ -212,9 +252,66 @@ describe("MyStreamWaveDesktopTabs", () => {
 
     renderComponent(MyStreamWaveTab.MY_VOTES);
 
-    expect(screen.getByText("Leaderboard")).toBeInTheDocument();
-    expect(screen.getByText("Chat")).toBeInTheDocument();
+    expect(screen.getAllByText("Leaderboard").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Chat").length).toBeGreaterThan(0);
     expect(screen.queryByText("My Votes")).toBeNull();
+    expect(setActiveTab).not.toHaveBeenCalled();
+  });
+
+  it("shows My Votes for authenticated normal approve waves", () => {
+    mockWaveInfo = {
+      isChatWave: false,
+      isApproveWave: true,
+      isMemesWave: false,
+      isCurationWave: false,
+      isRankWave: false,
+    };
+    mockAvailableTabs = [
+      MyStreamWaveTab.CHAT,
+      MyStreamWaveTab.LEADERBOARD,
+      MyStreamWaveTab.WINNERS,
+      MyStreamWaveTab.OUTCOME,
+      MyStreamWaveTab.MY_VOTES,
+    ];
+
+    renderComponent(MyStreamWaveTab.MY_VOTES);
+
+    expect(screen.getAllByText("My Votes").length).toBeGreaterThan(0);
+  });
+
+  it("hides My Votes for guests on normal approve waves", () => {
+    mockWaveInfo = {
+      isChatWave: false,
+      isApproveWave: true,
+      isMemesWave: false,
+      isCurationWave: false,
+      isRankWave: false,
+    };
+    mockAvailableTabs = [
+      MyStreamWaveTab.CHAT,
+      MyStreamWaveTab.LEADERBOARD,
+      MyStreamWaveTab.WINNERS,
+      MyStreamWaveTab.OUTCOME,
+      MyStreamWaveTab.MY_VOTES,
+    ];
+    (useAuth as jest.Mock).mockReturnValue({
+      connectedProfile: null,
+    });
+
+    renderComponent(MyStreamWaveTab.MY_VOTES);
+
+    expect(screen.getAllByText("Chat").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Approvals").length).toBeGreaterThan(0);
+    expect(screen.queryByText("My Votes")).toBeNull();
+    expect(setActiveTab).not.toHaveBeenCalled();
+  });
+
+  it("sets the active tab when a visible standard tab is clicked", () => {
+    mockAvailableTabs = [MyStreamWaveTab.CHAT, MyStreamWaveTab.LEADERBOARD];
+    renderComponent(MyStreamWaveTab.CHAT);
+
+    fireEvent.click(screen.getAllByRole("tab", { name: "Leaderboard" })[0]);
+
     expect(setActiveTab).toHaveBeenCalledWith(MyStreamWaveTab.LEADERBOARD);
   });
 
@@ -229,8 +326,9 @@ describe("MyStreamWaveDesktopTabs", () => {
     mockAvailableTabs = [MyStreamWaveTab.CHAT, MyStreamWaveTab.SALES];
     renderComponent(MyStreamWaveTab.SALES);
 
+    expect(screen.getAllByText("Chat").length).toBeGreaterThan(0);
     expect(screen.queryByText("Sales")).toBeNull();
-    expect(setActiveTab).toHaveBeenCalledWith(MyStreamWaveTab.CHAT);
+    expect(setActiveTab).not.toHaveBeenCalled();
   });
 
   it("keeps FAQ hidden outside memes waves", () => {
@@ -244,8 +342,9 @@ describe("MyStreamWaveDesktopTabs", () => {
     mockAvailableTabs = [MyStreamWaveTab.CHAT, MyStreamWaveTab.FAQ];
     renderComponent(MyStreamWaveTab.FAQ);
 
+    expect(screen.getAllByText("Chat").length).toBeGreaterThan(0);
     expect(screen.queryByText("FAQ")).toBeNull();
-    expect(setActiveTab).toHaveBeenCalledWith(MyStreamWaveTab.CHAT);
+    expect(setActiveTab).not.toHaveBeenCalled();
   });
 
   it("does not render countdown; parent header handles it", () => {
@@ -302,9 +401,9 @@ describe("MyStreamWaveDesktopTabs", () => {
 
     renderComponent(MyStreamWaveTab.LEADERBOARD);
 
-    expect(screen.getByText("Chat")).toBeInTheDocument();
-    expect(screen.getByText("Approvals")).toBeInTheDocument();
-    expect(screen.getByText("Approved")).toBeInTheDocument();
+    expect(screen.getAllByText("Chat").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Approvals").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Approved").length).toBeGreaterThan(0);
     expect(screen.queryByText("Leaderboard")).toBeNull();
     expect(screen.queryByText("Winners")).toBeNull();
   });

--- a/__tests__/components/brain/my-stream/votes/MyStreamWaveMyVoteInput.test.tsx
+++ b/__tests__/components/brain/my-stream/votes/MyStreamWaveMyVoteInput.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
 import MyStreamWaveMyVoteInput from "@/components/brain/my-stream/votes/MyStreamWaveMyVoteInput";
 import { AuthContext } from "@/components/auth/Auth";
+import { ApiWaveCreditType } from "@/generated/models/ApiWaveCreditType";
 import {
   QueryKey,
   ReactQueryWrapperContext,
@@ -33,7 +34,7 @@ const wrapper = ({ children }: any) => (
 
 const drop: any = {
   id: "d1",
-  wave: { id: "wave-1" },
+  wave: { id: "wave-1", voting_credit_type: ApiWaveCreditType.Tdh },
   context_profile_context: { rating: 0, min_rating: 0, max_rating: 10 },
 };
 
@@ -77,6 +78,21 @@ describe("MyStreamWaveMyVoteInput", () => {
     render(<MyStreamWaveMyVoteInput drop={dropWithRating} />, { wrapper });
     expectMaxVotes("10");
     expect(screen.queryByText(/^Available/)).not.toBeInTheDocument();
+  });
+
+  it("uses the wave voting credit label in the input", () => {
+    render(
+      <MyStreamWaveMyVoteInput
+        drop={{
+          ...drop,
+          wave: { id: "wave-1", voting_credit_type: ApiWaveCreditType.Rep },
+        }}
+      />,
+      { wrapper }
+    );
+
+    expect(screen.getByText("Rep")).toBeInTheDocument();
+    expect(screen.queryByText("TDH")).not.toBeInTheDocument();
   });
 
   it("keeps max visible with negative current rating", () => {

--- a/components/brain/ContentTabContext.tsx
+++ b/components/brain/ContentTabContext.tsx
@@ -89,7 +89,8 @@ const buildMemesTabs = (
 const buildDefaultTabs = (
   votingState: WaveVotingState,
   hasFirstDecisionPassed: boolean,
-  isCurationWave: boolean
+  isCurationWave: boolean,
+  hasAuthenticatedProfile: boolean
 ) => {
   const tabs: MyStreamWaveTab[] = [MyStreamWaveTab.CHAT];
   if (votingState === WaveVotingState.ENDED) {
@@ -106,13 +107,16 @@ const buildDefaultTabs = (
   if (!isCurationWave) {
     tabs.push(MyStreamWaveTab.OUTCOME);
   }
-  if (isCurationWave) {
+  if (isCurationWave || hasAuthenticatedProfile) {
     tabs.push(MyStreamWaveTab.MY_VOTES);
   }
   return tabs;
 };
 
-const buildApproveTabs = (isCurationWave: boolean) => {
+const buildApproveTabs = (
+  isCurationWave: boolean,
+  hasAuthenticatedProfile: boolean
+) => {
   const tabs: MyStreamWaveTab[] = [
     MyStreamWaveTab.CHAT,
     MyStreamWaveTab.LEADERBOARD,
@@ -127,6 +131,10 @@ const buildApproveTabs = (isCurationWave: boolean) => {
   if (!isCurationWave) {
     tabs.push(MyStreamWaveTab.OUTCOME);
   } else {
+    tabs.push(MyStreamWaveTab.MY_VOTES);
+  }
+
+  if (!isCurationWave && hasAuthenticatedProfile) {
     tabs.push(MyStreamWaveTab.MY_VOTES);
   }
 
@@ -196,7 +204,7 @@ export const ContentTabProvider: React.FC<{ children: ReactNode }> = ({
       if (isChatWave) {
         tabs = [MyStreamWaveTab.CHAT];
       } else if (isApproveWave) {
-        tabs = buildApproveTabs(isCurationWave);
+        tabs = buildApproveTabs(isCurationWave, hasAuthenticatedProfile);
       } else if (isMemesWave) {
         tabs = buildMemesTabs(
           hasAuthenticatedProfile,
@@ -207,7 +215,8 @@ export const ContentTabProvider: React.FC<{ children: ReactNode }> = ({
         tabs = buildDefaultTabs(
           votingState,
           hasFirstDecisionPassed,
-          isCurationWave
+          isCurationWave,
+          hasAuthenticatedProfile
         );
       }
 

--- a/components/brain/mobile/BrainMobileTabs.tsx
+++ b/components/brain/mobile/BrainMobileTabs.tsx
@@ -98,6 +98,7 @@ const BrainMobileTabs: React.FC<BrainMobileTabsProps> = ({
     useWave(wave);
   const isCompetitionWave = isRankWave || isApproveWave;
   const supportsOutcomeView = isCompetitionWave && !isCurationWave;
+  const canShowMyVotesTab = isCurationWave || hasAuthenticatedProfile;
 
   // Get unread indicator for messages
   const { hasUnread: hasUnreadMessages } = useUnreadIndicator({
@@ -309,7 +310,7 @@ const BrainMobileTabs: React.FC<BrainMobileTabsProps> = ({
               onViewChange={handleWaveViewChange}
               renderAfterLeaderboard={salesTabButton}
             />
-            {(isCurationWave || (isMemesWave && hasAuthenticatedProfile)) && (
+            {canShowMyVotesTab && (
               <>
                 <button
                   ref={getActiveButtonRef(activeView === BrainView.MY_VOTES)}

--- a/components/brain/mobile/useBrainMobileActiveView.ts
+++ b/components/brain/mobile/useBrainMobileActiveView.ts
@@ -108,6 +108,8 @@ function normalizeActiveView({
   const hasLoadedWave = wave !== null && wave !== undefined;
   const isCompetitionWave = isRankWave || isApproveWave;
   const supportsOutcomeView = isCompetitionWave && !isCurationWave;
+  const canUseMyVotesView =
+    isCompetitionWave && (isCurationWave || hasAuthenticatedProfile);
   const waveDefaultView =
     hasLoadedWave && isRankWave && !isApproveWave && isCompleted
       ? BrainView.SUBMISSIONS
@@ -146,9 +148,7 @@ function normalizeActiveView({
     (activeView === BrainView.WINNERS &&
       (!isCompetitionWave || (!isApproveWave && !firstDecisionDone))) ||
     (activeView === BrainView.OUTCOME && !supportsOutcomeView) ||
-    (activeView === BrainView.MY_VOTES &&
-      ((isMemesWave && !hasAuthenticatedProfile) ||
-        (!isMemesWave && !isCurationWave))) ||
+    (activeView === BrainView.MY_VOTES && !canUseMyVotesView) ||
     (activeView === BrainView.FAQ && !isMemesWave);
 
   return shouldResetToDefault ? waveDefaultView : activeView;

--- a/components/brain/my-stream/MyStreamWaveDesktopTabs.tsx
+++ b/components/brain/my-stream/MyStreamWaveDesktopTabs.tsx
@@ -322,8 +322,10 @@ const MyStreamWaveDesktopTabs: React.FC<MyStreamWaveDesktopTabsProps> = ({
     isApproveWave,
     isMemesWave,
     isCurationWave,
+    isRankWave,
     pauses: { filterDecisionsDuringPauses },
   } = useWave(wave);
+  const isCompetitionWave = isRankWave || isApproveWave;
   const {
     voting: { isUpcoming, isCompleted },
     decisions: { firstDecisionDone },
@@ -455,7 +457,10 @@ const MyStreamWaveDesktopTabs: React.FC<MyStreamWaveDesktopTabsProps> = ({
       availableTabs
         .filter((tab) => {
           if (tab === MyStreamWaveTab.MY_VOTES) {
-            return isCurationWave || (isMemesWave && hasAuthenticatedProfile);
+            return (
+              isCurationWave ||
+              (hasAuthenticatedProfile && (isMemesWave || isCompetitionWave))
+            );
           }
           if (tab === MyStreamWaveTab.SALES) {
             return isCurationWave;
@@ -474,6 +479,7 @@ const MyStreamWaveDesktopTabs: React.FC<MyStreamWaveDesktopTabsProps> = ({
       availableTabs,
       hasAuthenticatedProfile,
       isApproveWave,
+      isCompetitionWave,
       isMemesWave,
       isCurationWave,
     ]

--- a/components/brain/my-stream/votes/MyStreamWaveMyVoteInput.tsx
+++ b/components/brain/my-stream/votes/MyStreamWaveMyVoteInput.tsx
@@ -10,6 +10,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import type { ApiDrop } from "@/generated/models/ApiDrop";
 import { commonApiPost } from "@/services/api/common-api";
 import { invalidateWaveApprovalStatusQueries } from "@/hooks/waves/invalidateWaveApprovalStatusQueries";
+import { WAVE_VOTING_LABELS } from "@/helpers/waves/waves.constants";
 
 interface MyStreamWaveMyVoteInputProps {
   readonly drop: ExtendedDrop;
@@ -68,6 +69,7 @@ const MyStreamWaveMyVoteInput: React.FC<MyStreamWaveMyVoteInputProps> = ({
   const hasValidVoteValue = !Number.isNaN(parsedVoteValue);
   const isEditing =
     hasValidVoteValue && parsedVoteValue !== liveCurrentVoteValue;
+  const voteLabel = WAVE_VOTING_LABELS[drop.wave.voting_credit_type];
 
   const setVoteDraftValue = (nextValue: string) => {
     setVoteDraftState({
@@ -238,7 +240,7 @@ const MyStreamWaveMyVoteInput: React.FC<MyStreamWaveMyVoteInputProps> = ({
             className="tw-h-8 tw-w-full tw-rounded-lg tw-border-0 tw-bg-iron-900 tw-px-3 tw-text-base tw-font-medium tw-text-iron-50 tw-placeholder-iron-400 tw-outline-none tw-ring-1 tw-ring-iron-700 tw-transition-all focus:tw-bg-iron-950/80 focus:tw-ring-primary-400 desktop-hover:hover:tw-bg-iron-950/60 desktop-hover:hover:tw-ring-primary-400"
           />
           <div className="tw-pointer-events-none tw-absolute tw-right-3 tw-top-1/2 -tw-translate-y-1/2 tw-text-xs tw-text-iron-400">
-            TDH
+            {voteLabel}
           </div>
         </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * "My Votes" tab now displays for authenticated users on all wave types (rank and approve waves), not just curation waves.
  * Voting credit type labels are now dynamically displayed based on wave configuration instead of hardcoded values.

* **Tests**
  * Extended test coverage for "My Votes" tab visibility across different authentication states and wave types.
  * Updated test assertions to reflect revised tab availability rules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-frontend/pull/2367)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->