### PR TITLE
Add fallback wave icon for missing wave pictures

### DIFF
--- a/__tests__/components/waves/WavePicture.test.tsx
+++ b/__tests__/components/waves/WavePicture.test.tsx
@@ -11,12 +11,12 @@ describe("WavePicture", () => {
     expect(img).toHaveAttribute("alt", "wave");
   });
 
-  it("renders faded wave icon fallback when no picture and no contributors", () => {
+  it("renders default wave icon fallback when no picture and no contributors", () => {
     const { container } = render(
       <WavePicture name="wave" picture={null} contributors={[]} />
     );
     expect(container.firstChild).toBeInTheDocument();
-    expect(container.querySelector("svg")).toBeInTheDocument();
+    expect(screen.getByTestId("wave-fallback-icon")).toBeInTheDocument();
   });
 
   it("renders contributor images sliced", () => {

--- a/__tests__/components/waves/WavePicture.test.tsx
+++ b/__tests__/components/waves/WavePicture.test.tsx
@@ -16,7 +16,10 @@ describe("WavePicture", () => {
       <WavePicture name="wave" picture={null} contributors={[]} />
     );
     expect(container.firstChild).toBeInTheDocument();
-    expect(screen.getByTestId("wave-fallback-icon")).toBeInTheDocument();
+    const icon = screen.getByTestId("wave-fallback-icon");
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass("tw-text-white/60");
+    expect(icon.parentElement).toHaveClass("tw-bg-white/10");
   });
 
   it("renders contributor images sliced", () => {

--- a/__tests__/components/waves/WavePicture.test.tsx
+++ b/__tests__/components/waves/WavePicture.test.tsx
@@ -11,11 +11,12 @@ describe("WavePicture", () => {
     expect(img).toHaveAttribute("alt", "wave");
   });
 
-  it("renders gradient when no picture and no contributors", () => {
+  it("renders faded wave icon fallback when no picture and no contributors", () => {
     const { container } = render(
       <WavePicture name="wave" picture={null} contributors={[]} />
     );
     expect(container.firstChild).toBeInTheDocument();
+    expect(container.querySelector("svg")).toBeInTheDocument();
   });
 
   it("renders contributor images sliced", () => {

--- a/components/waves/WavePicture.tsx
+++ b/components/waves/WavePicture.tsx
@@ -3,6 +3,8 @@
 import { useMemo } from "react";
 import { FallbackImage } from "@/components/common/FallbackImage";
 import { useAuth } from "@/components/auth/Auth";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faWater } from "@fortawesome/free-solid-svg-icons";
 
 interface WavePictureProps {
   readonly name: string;
@@ -177,10 +179,15 @@ export default function WavePicture({
     })
     .map((contributor) => contributor.pfp);
 
-  // 3) If no PFPS, show fallback background
+  // 3) If no PFPS, show the default wave icon fallback
   if (pfps.length === 0) {
     return (
-      <div className="tw-h-full tw-w-full tw-rounded-full tw-bg-gradient-to-br tw-from-iron-800 tw-to-iron-700" />
+      <div className="tw-flex tw-h-full tw-w-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-full tw-bg-gradient-to-br tw-from-iron-800 tw-to-iron-700">
+        <FontAwesomeIcon
+          icon={faWater}
+          className="tw-size-[54%] tw-text-white/60"
+        />
+      </div>
     );
   }
 

--- a/components/waves/WavePicture.tsx
+++ b/components/waves/WavePicture.tsx
@@ -186,6 +186,9 @@ export default function WavePicture({
         <FontAwesomeIcon
           icon={faWater}
           className="tw-size-[54%] tw-text-white/60"
+          aria-hidden="true"
+          focusable={false}
+          data-testid="wave-fallback-icon"
         />
       </div>
     );

--- a/components/waves/WavePicture.tsx
+++ b/components/waves/WavePicture.tsx
@@ -182,7 +182,7 @@ export default function WavePicture({
   // 3) If no PFPS, show the default wave icon fallback
   if (pfps.length === 0) {
     return (
-      <div className="tw-flex tw-h-full tw-w-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-full tw-bg-gradient-to-br tw-from-iron-800 tw-to-iron-700">
+      <div className="tw-flex tw-h-full tw-w-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-full tw-bg-white/10">
         <FontAwesomeIcon
           icon={faWater}
           className="tw-size-[54%] tw-text-white/60"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wave visualization now displays a centered water icon inside a semi-transparent background when no profile pictures or contributors are present, giving clearer visual feedback.

* **Tests**
  * Unit test updated to verify the new fallback icon and its styling are rendered when no pictures or contributors exist.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-frontend/pull/2372)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->