### PR TITLE
Fix drop dates display

### DIFF
--- a/__tests__/components/DropListItemContentMediaImage.test.tsx
+++ b/__tests__/components/DropListItemContentMediaImage.test.tsx
@@ -61,6 +61,72 @@ describe("DropListItemContentMediaImage", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("closes the modal when the expanded image letterbox area is clicked", () => {
+    render(<DropListItemContentMediaImage src="img" maxRetries={1} />);
+    const img = screen.getByAltText("Drop media");
+    fireEvent.load(img);
+    fireEvent.click(img);
+
+    const modalImage = screen.getByAltText("Full size drop media");
+    Object.defineProperty(modalImage, "naturalWidth", {
+      configurable: true,
+      value: 100,
+    });
+    Object.defineProperty(modalImage, "naturalHeight", {
+      configurable: true,
+      value: 50,
+    });
+    modalImage.getBoundingClientRect = jest.fn(() => ({
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      right: 100,
+      bottom: 100,
+      toJSON: jest.fn(),
+    }));
+
+    fireEvent.click(modalImage, { clientX: 50, clientY: 10 });
+
+    expect(
+      screen.queryByAltText("Full size drop media")
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the modal open when the rendered image area is clicked", () => {
+    render(<DropListItemContentMediaImage src="img" maxRetries={1} />);
+    const img = screen.getByAltText("Drop media");
+    fireEvent.load(img);
+    fireEvent.click(img);
+
+    const modalImage = screen.getByAltText("Full size drop media");
+    Object.defineProperty(modalImage, "naturalWidth", {
+      configurable: true,
+      value: 100,
+    });
+    Object.defineProperty(modalImage, "naturalHeight", {
+      configurable: true,
+      value: 50,
+    });
+    modalImage.getBoundingClientRect = jest.fn(() => ({
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      top: 0,
+      left: 0,
+      right: 100,
+      bottom: 100,
+      toJSON: jest.fn(),
+    }));
+
+    fireEvent.click(modalImage, { clientX: 50, clientY: 50 });
+
+    expect(screen.getByAltText("Full size drop media")).toBeInTheDocument();
+  });
+
   it("does not open modal when disableModal is true", () => {
     render(<DropListItemContentMediaImage src="img" disableModal />);
     const img = screen.getByAltText("Drop media");
@@ -99,6 +165,7 @@ describe("DropListItemContentMediaImage", () => {
     expect(wrapper).toHaveClass("tw-w-full", "tw-min-h-40");
     expect(wrapper).not.toHaveClass("tw-h-full");
     expect(img).toHaveClass("tw-h-auto", "tw-w-full", "tw-max-h-64");
+    expect(img).not.toHaveClass("tw-max-h-full");
     expect(img).not.toHaveAttribute("data-nimg", "fill");
   });
 

--- a/__tests__/components/meme-calendar/meme-calendar.helpers.timezone.test.ts
+++ b/__tests__/components/meme-calendar/meme-calendar.helpers.timezone.test.ts
@@ -1,6 +1,7 @@
 import {
   formatUtcMonth,
   formatUtcMonthYear,
+  formatFullDate,
   mintStartInstantUtcForMintDay,
   nextMintDateOnOrAfter,
   wallTimeToUtcInstantInZone,
@@ -142,5 +143,19 @@ describe("meme calendar timezone handling", () => {
 
     expect(formatUtcMonth(seasonStart, "long")).toBe("January");
     expect(formatUtcMonthYear(seasonStart)).toBe("Jan 2026");
+  });
+
+  it("formats UTC mint days without shifting to the viewer's previous local day", () => {
+    const fridayMintDay = isoDate(2026, 4, 15);
+    const losAngelesLabel = fridayMintDay.toLocaleDateString("en-US", {
+      weekday: "short",
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      timeZone: "America/Los_Angeles",
+    });
+
+    expect(losAngelesLabel).toBe("Thu, May 14, 2026");
+    expect(formatFullDate(fridayMintDay, "utc")).toBe("Fri, May 15, 2026");
   });
 });

--- a/__tests__/components/meme-calendar/meme-calendar.helpers.timezone.test.ts
+++ b/__tests__/components/meme-calendar/meme-calendar.helpers.timezone.test.ts
@@ -83,7 +83,8 @@ describe("meme calendar timezone handling", () => {
     const beforeRollbackMint = nextMintDateOnOrAfter(isoDate(2024, 9, 24)); // Fri, 25 Oct 2024
     expect(beforeRollbackMint.toISOString()).toBe("2024-10-25T00:00:00.000Z");
 
-    const beforeRollbackStart = mintStartInstantUtcForMintDay(beforeRollbackMint);
+    const beforeRollbackStart =
+      mintStartInstantUtcForMintDay(beforeRollbackMint);
     const beforeRollbackEnd = mintEndInstantUtcForMintDay(beforeRollbackMint);
 
     expect(beforeRollbackStart.toISOString()).toBe("2024-10-25T14:40:00.000Z");

--- a/__tests__/components/user/subscriptions/UserPageSubscriptionsUpcoming.test.tsx
+++ b/__tests__/components/user/subscriptions/UserPageSubscriptionsUpcoming.test.tsx
@@ -211,6 +211,23 @@ describe("UserPageSubscriptionsUpcoming", () => {
     expect(screen.getByText("2024-01-02 / Tuesday")).toBeInTheDocument();
   });
 
+  it("formats upcoming mint days as UTC calendar days", () => {
+    const {
+      formatFullDate,
+    } = require("@/components/meme-calendar/meme-calendar.helpers");
+
+    renderComponent();
+
+    expect(formatFullDate).toHaveBeenCalledWith(
+      mockUpcomingRows[0].utcDay,
+      "utc"
+    );
+    expect(formatFullDate).toHaveBeenCalledWith(
+      mockUpcomingRows[1].utcDay,
+      "utc"
+    );
+  });
+
   it("shows minting today message when applicable", () => {
     const {
       isMintingToday,

--- a/components/drops/view/item/content/media/DropListItemContentMediaImage.tsx
+++ b/components/drops/view/item/content/media/DropListItemContentMediaImage.tsx
@@ -110,7 +110,9 @@ function DropImageContent({
   readonly handleIntrinsicImageError: () => void;
   readonly handleError: () => void;
 }) {
-  const imageClassName = `tw-max-h-full tw-max-w-full ${
+  const imageClassName = `${
+    intrinsicHeight ? "tw-max-w-full" : "tw-max-h-full tw-max-w-full"
+  } ${
     loaded ? "tw-opacity-100" : "tw-opacity-0"
   } ${disableModal ? "" : "tw-cursor-pointer"}`;
 

--- a/components/drops/view/item/content/media/ImageMediaModal.tsx
+++ b/components/drops/view/item/content/media/ImageMediaModal.tsx
@@ -55,6 +55,61 @@ export function ImageMediaModal({
 
   useKeyPressEvent("Escape", onClose);
 
+  const isPointInsideRenderedImage = (
+    image: HTMLImageElement,
+    clientX: number,
+    clientY: number
+  ) => {
+    const rect = image.getBoundingClientRect();
+    const naturalWidth = image.naturalWidth;
+    const naturalHeight = image.naturalHeight;
+
+    if (
+      rect.width <= 0 ||
+      rect.height <= 0 ||
+      naturalWidth <= 0 ||
+      naturalHeight <= 0
+    ) {
+      return true;
+    }
+
+    const imageAspectRatio = naturalWidth / naturalHeight;
+    const containerAspectRatio = rect.width / rect.height;
+    const renderedWidth =
+      imageAspectRatio > containerAspectRatio
+        ? rect.width
+        : rect.height * imageAspectRatio;
+    const renderedHeight =
+      imageAspectRatio > containerAspectRatio
+        ? rect.width / imageAspectRatio
+        : rect.height;
+    const renderedLeft = rect.left + (rect.width - renderedWidth) / 2;
+    const renderedTop = rect.top + (rect.height - renderedHeight) / 2;
+
+    return (
+      clientX >= renderedLeft &&
+      clientX <= renderedLeft + renderedWidth &&
+      clientY >= renderedTop &&
+      clientY <= renderedTop + renderedHeight
+    );
+  };
+
+  const handleExpandedImageClick = (
+    event: React.MouseEvent<HTMLImageElement>
+  ) => {
+    event.stopPropagation();
+
+    if (
+      !isPointInsideRenderedImage(
+        event.currentTarget,
+        event.clientX,
+        event.clientY
+      )
+    ) {
+      onClose();
+    }
+  };
+
   return createPortal(
     <div
       className="tailwind-scope tw-relative tw-z-1000 tw-cursor-default"
@@ -78,7 +133,10 @@ export function ImageMediaModal({
         {() => (
           <div className="tw-pointer-events-none tw-fixed tw-inset-0 tw-z-[1001] tw-flex tw-items-center tw-justify-center tw-overflow-hidden">
             <div className="tw-pointer-events-auto tw-relative tw-flex tw-h-[90dvh] tw-w-[95vw] tw-flex-col">
-              <div className="tw-flex tw-min-h-0 tw-min-w-0 tw-flex-1 tw-flex-col tw-items-center tw-justify-center">
+              <div
+                className="tw-flex tw-min-h-0 tw-min-w-0 tw-flex-1 tw-flex-col tw-items-center tw-justify-center"
+                onClick={onClose}
+              >
                 <TransformComponent
                   wrapperClass="tw-w-full tw-h-full tw-flex tw-items-center tw-justify-center"
                   contentClass="tw-w-full tw-h-full tw-flex tw-items-center tw-justify-center"
@@ -100,6 +158,7 @@ export function ImageMediaModal({
                         objectPosition: "center",
                         pointerEvents: "auto",
                       }}
+                      onClick={handleExpandedImageClick}
                     />
                   </div>
                 </TransformComponent>

--- a/components/drops/view/item/content/media/ImageMediaModal.tsx
+++ b/components/drops/view/item/content/media/ImageMediaModal.tsx
@@ -94,14 +94,20 @@ export function ImageMediaModal({
     );
   };
 
-  const handleExpandedImageClick = (
-    event: React.MouseEvent<HTMLImageElement>
+  const handleExpandedImageButtonClick = (
+    event: React.MouseEvent<HTMLButtonElement>
   ) => {
     event.stopPropagation();
 
+    const image = imageRef.current;
+    if (!image || event.detail === 0) {
+      onClose();
+      return;
+    }
+
     if (
       !isPointInsideRenderedImage(
-        event.currentTarget,
+        image,
         event.clientX,
         event.clientY
       )
@@ -133,17 +139,19 @@ export function ImageMediaModal({
         {() => (
           <div className="tw-pointer-events-none tw-fixed tw-inset-0 tw-z-[1001] tw-flex tw-items-center tw-justify-center tw-overflow-hidden">
             <div className="tw-pointer-events-auto tw-relative tw-flex tw-h-[90dvh] tw-w-[95vw] tw-flex-col">
-              <div
-                className="tw-flex tw-min-h-0 tw-min-w-0 tw-flex-1 tw-flex-col tw-items-center tw-justify-center"
-                onClick={onClose}
-              >
+              <div className="tw-flex tw-min-h-0 tw-min-w-0 tw-flex-1 tw-flex-col tw-items-center tw-justify-center">
                 <TransformComponent
                   wrapperClass="tw-w-full tw-h-full tw-flex tw-items-center tw-justify-center"
                   contentClass="tw-w-full tw-h-full tw-flex tw-items-center tw-justify-center"
                   wrapperStyle={{ width: "95vw", height: "90dvh" }}
                   contentStyle={{ width: "95vw", height: "90dvh" }}
                 >
-                  <div className="tw-relative tw-h-full tw-w-full">
+                  <button
+                    type="button"
+                    aria-label="Close modal"
+                    className="tw-relative tw-h-full tw-w-full tw-border-0 tw-bg-transparent tw-p-0"
+                    onClick={handleExpandedImageButtonClick}
+                  >
                     {/* Drop media can come from arbitrary hosts outside Next image config. */}
                     <FallbackImage
                       ref={imageRef}
@@ -158,9 +166,8 @@ export function ImageMediaModal({
                         objectPosition: "center",
                         pointerEvents: "auto",
                       }}
-                      onClick={handleExpandedImageClick}
                     />
-                  </div>
+                  </button>
                 </TransformComponent>
               </div>
             </div>

--- a/components/subscriptions-report/SubscriptionsReport.tsx
+++ b/components/subscriptions-report/SubscriptionsReport.tsx
@@ -523,7 +523,7 @@ function SubscriptionDayDetails(
           <span className="tw-text-sm tw-text-gray-400">
             SZN {displayedSeasonNumberFromIndex(props.date.seasonIndex)}
             {" / "}
-            {formatFullDate(props.date.utcDay)}
+            {formatFullDate(props.date.utcDay, "utc")}
           </span>
         </div>
       </td>

--- a/components/user/subscriptions/MemeSubscriptionRow.tsx
+++ b/components/user/subscriptions/MemeSubscriptionRow.tsx
@@ -383,7 +383,7 @@ export default function MemeSubscriptionRow(
                       </Tooltip>
                     </>
                   ) : (
-                    <span>{formatFullDate(props.date.utcDay)}</span>
+                    <span>{formatFullDate(props.date.utcDay, "utc")}</span>
                   )}
                 </>
               )}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image modal now closes only when clicking outside the image’s rendered area (e.g., letterbox), preventing unintended closes when clicking within the visible image.
  * Dates in subscription and upcoming drop views are now rendered explicitly in UTC to avoid local timezone shifts.

* **Tests**
  * Added tests covering image modal click behavior and UTC date formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-frontend/pull/2385)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->