### PR TITLE
Follow all button in notifications only if there is someone to follow

### DIFF
--- a/__tests__/components/brain/notifications/NotificationsFollowAllBtn.test.tsx
+++ b/__tests__/components/brain/notifications/NotificationsFollowAllBtn.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AuthContext } from "@/components/auth/Auth";
+import NotificationsFollowAllBtn from "@/components/brain/notifications/NotificationsFollowAllBtn";
+import { ReactQueryWrapperContext } from "@/components/react-query-wrapper/ReactQueryWrapper";
+import { ApiIdentitySubscriptionTargetAction } from "@/generated/models/ApiIdentitySubscriptionTargetAction";
+import type { ApiProfileMin } from "@/generated/models/ApiProfileMin";
+import { commonApiPost } from "@/services/api/common-api";
+import type { ComponentProps } from "react";
+
+jest.mock("@/services/api/common-api", () => ({
+  commonApiPost: jest.fn(),
+}));
+
+const createProfile = ({
+  handle,
+  subscribed = false,
+}: {
+  readonly handle: string | null;
+  readonly subscribed?: boolean;
+}): ApiProfileMin =>
+  ({
+    id: handle ?? "unknown-profile",
+    handle,
+    pfp: null,
+    primary_address: "",
+    subscribed_actions: subscribed
+      ? [ApiIdentitySubscriptionTargetAction.WaveCreated]
+      : [],
+  }) as ApiProfileMin;
+
+const renderButton = (profiles: readonly ApiProfileMin[]) => {
+  const requestAuth = jest.fn().mockResolvedValue({ success: true });
+  const setToast = jest.fn();
+  const onIdentityFollowChange = jest.fn();
+  const auth = {
+    requestAuth,
+    setToast,
+  } as unknown as ComponentProps<typeof AuthContext.Provider>["value"];
+  const reactQuery = {
+    onIdentityFollowChange,
+  } as unknown as ComponentProps<
+    typeof ReactQueryWrapperContext.Provider
+  >["value"];
+
+  render(
+    <AuthContext.Provider value={auth}>
+      <ReactQueryWrapperContext.Provider value={reactQuery}>
+        <NotificationsFollowAllBtn profiles={profiles} />
+      </ReactQueryWrapperContext.Provider>
+    </AuthContext.Provider>
+  );
+
+  return {
+    onIdentityFollowChange,
+    requestAuth,
+  };
+};
+
+describe("NotificationsFollowAllBtn", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (commonApiPost as jest.Mock).mockResolvedValue({ actions: [] });
+  });
+
+  it("subscribes only reactors that are not already followed", async () => {
+    const user = userEvent.setup();
+    const { onIdentityFollowChange, requestAuth } = renderButton([
+      createProfile({ handle: "alice", subscribed: true }),
+      createProfile({ handle: "bob" }),
+      createProfile({ handle: "BOB" }),
+      createProfile({ handle: null }),
+    ]);
+
+    await user.click(screen.getByRole("button", { name: /follow all/i }));
+
+    await waitFor(() => {
+      expect(commonApiPost).toHaveBeenCalledTimes(1);
+    });
+    expect(commonApiPost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: "identities/bob/subscriptions",
+      })
+    );
+    expect(requestAuth).toHaveBeenCalledTimes(1);
+    expect(onIdentityFollowChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("is disabled when every reactor with a handle is already followed", () => {
+    const { requestAuth } = renderButton([
+      createProfile({ handle: "alice", subscribed: true }),
+      createProfile({ handle: "bob", subscribed: true }),
+      createProfile({ handle: null }),
+    ]);
+
+    expect(
+      screen.getByRole("button", { name: /following all/i })
+    ).toBeDisabled();
+    expect(commonApiPost).not.toHaveBeenCalled();
+    expect(requestAuth).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/services/api/notifications-v2-api.test.ts
+++ b/__tests__/services/api/notifications-v2-api.test.ts
@@ -1,4 +1,5 @@
 import { ApiDropMainType } from "@/generated/models/ApiDropMainType";
+import { ApiIdentitySubscriptionTargetAction } from "@/generated/models/ApiIdentitySubscriptionTargetAction";
 import { ApiNotificationCause } from "@/generated/models/ApiNotificationCause";
 import { ApiProfileClassification } from "@/generated/models/ApiProfileClassification";
 import { commonApiFetch } from "@/services/api/common-api";
@@ -97,8 +98,8 @@ describe("fetchNotificationsV2", () => {
           additional_context: {
             reaction: ":green_circle:",
             reactors: [
-              { handle: "alice", pfp: "alice.png" },
-              { handle: "bob", pfp: "bob.png" },
+              { handle: "alice", pfp: "alice.png", subscribed: true },
+              { handle: "bob", pfp: "bob.png", subscribed: false },
             ],
           },
         },
@@ -127,6 +128,9 @@ describe("fetchNotificationsV2", () => {
     expect(
       response.notifications.map((n) => n.related_identity.handle)
     ).toEqual(["alice", "bob"]);
+    expect(
+      response.notifications.map((n) => n.related_identity.subscribed_actions)
+    ).toEqual([[ApiIdentitySubscriptionTargetAction.WaveCreated], []]);
     const [firstNotification] = response.notifications;
     if (
       firstNotification?.cause === ApiNotificationCause.DropReacted &&
@@ -156,7 +160,9 @@ describe("fetchNotificationsV2", () => {
           related_drops: [drop],
           additional_context: {
             reaction: ":green_circle:",
-            reactors: [{ handle: "alice", pfp: "alice-new.png" }],
+            reactors: [
+              { handle: "alice", pfp: "alice-new.png", subscribed: true },
+            ],
           },
         },
       ],

--- a/components/brain/notifications/NotificationsFollowAllBtn.tsx
+++ b/components/brain/notifications/NotificationsFollowAllBtn.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AuthContext } from "@/components/auth/Auth";
+import { useAuth } from "@/components/auth/Auth";
 import CircleLoader from "@/components/distribution-plan-tool/common/CircleLoader";
 import { ReactQueryWrapperContext } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import {
@@ -12,7 +12,7 @@ import type { ApiIdentitySubscriptionActions } from "@/generated/models/ApiIdent
 import type { ApiProfileMin } from "@/generated/models/ApiProfileMin";
 import { commonApiPost } from "@/services/api/common-api";
 import type { FC } from "react";
-import { useContext, useState } from "react";
+import { useContext, useMemo, useState } from "react";
 import {
   DEFAULT_SUBSCRIPTION_BODY,
   FollowBtnCheckIcon,
@@ -29,13 +29,31 @@ const NotificationsFollowAllBtn: FC<NotificationsFollowAllBtnProps> = ({
   size = UserFollowBtnSize.SMALL,
 }) => {
   const { onIdentityFollowChange } = useContext(ReactQueryWrapperContext);
-  const { setToast, requestAuth } = useContext(AuthContext);
+  const { setToast, requestAuth } = useAuth();
   const [mutating, setMutating] = useState(false);
 
-  const toFollow = profiles.filter(
-    (p) => p.handle && (p.subscribed_actions?.length ?? 0) === 0
-  );
-  const allFollowed = toFollow.length === 0;
+  const handlesToFollow = useMemo(() => {
+    const seenHandles = new Set<string>();
+    const handles: string[] = [];
+
+    for (const profile of profiles) {
+      const handle = profile.handle?.trim();
+      if (!handle || profile.subscribed_actions.length > 0) {
+        continue;
+      }
+
+      const normalizedHandle = handle.toLowerCase();
+      if (seenHandles.has(normalizedHandle)) {
+        continue;
+      }
+
+      seenHandles.add(normalizedHandle);
+      handles.push(handle);
+    }
+
+    return handles;
+  }, [profiles]);
+  const allFollowed = handlesToFollow.length === 0;
   const label = allFollowed ? "Following All" : "Follow All";
 
   const onFollowAll = async (): Promise<void> => {
@@ -48,12 +66,12 @@ const NotificationsFollowAllBtn: FC<NotificationsFollowAllBtnProps> = ({
     }
     try {
       const results = await Promise.allSettled(
-        toFollow.map((profile) =>
+        handlesToFollow.map((handle) =>
           commonApiPost<
             ApiIdentitySubscriptionActions,
             ApiIdentitySubscriptionActions
           >({
-            endpoint: `identities/${profile.handle}/subscriptions`,
+            endpoint: `identities/${handle}/subscriptions`,
             body: DEFAULT_SUBSCRIPTION_BODY,
           })
         )

--- a/generated/models/ApiNotificationAdditionalContextV2.ts
+++ b/generated/models/ApiNotificationAdditionalContextV2.ts
@@ -15,7 +15,7 @@ import { ApiNotificationDropReactedReactor } from '../models/ApiNotificationDrop
 import { HttpFile } from '../http/http';
 
 /**
-* Notification-specific additional context. For DROP_REACTED notifications this includes reaction and reactors, where each reactor only has handle and pfp.
+* Notification-specific additional context. For DROP_REACTED notifications this includes reaction and reactors, where each reactor only has handle, pfp, and subscribed.
 */
 export class ApiNotificationAdditionalContextV2 {
     'amount'?: number;

--- a/generated/models/ApiNotificationDropReactedReactor.ts
+++ b/generated/models/ApiNotificationDropReactedReactor.ts
@@ -16,6 +16,7 @@ import { HttpFile } from '../http/http';
 export class ApiNotificationDropReactedReactor {
     'handle'?: string;
     'pfp'?: string;
+    'subscribed': boolean;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -32,6 +33,12 @@ export class ApiNotificationDropReactedReactor {
             "name": "pfp",
             "baseName": "pfp",
             "type": "string",
+            "format": ""
+        },
+        {
+            "name": "subscribed",
+            "baseName": "subscribed",
+            "type": "boolean",
             "format": ""
         }    ];
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11921,8 +11921,8 @@ components:
           type: string
       description: >-
         Notification-specific additional context. For DROP_REACTED notifications
-        this includes reaction and reactors, where each reactor only has handle
-        and pfp.
+        this includes reaction and reactors, where each reactor only has handle,
+        pfp, and subscribed.
     ApiNotificationCause:
       type: string
       enum:
@@ -11940,11 +11940,15 @@ components:
         - PRIORITY_ALERT
     ApiNotificationDropReactedReactor:
       type: object
+      required:
+        - subscribed
       properties:
         handle:
           type: string
         pfp:
           type: string
+        subscribed:
+          type: boolean
     ApiNotificationsResponse:
       type: object
       required:

--- a/services/api/notifications-v2-api.ts
+++ b/services/api/notifications-v2-api.ts
@@ -1,5 +1,6 @@
 import type { ApiDrop } from "@/generated/models/ApiDrop";
 import type { ApiDropV2 } from "@/generated/models/ApiDropV2";
+import { ApiIdentitySubscriptionTargetAction } from "@/generated/models/ApiIdentitySubscriptionTargetAction";
 import type { ApiNotificationAdditionalContextV2 } from "@/generated/models/ApiNotificationAdditionalContextV2";
 import { ApiNotificationCause } from "@/generated/models/ApiNotificationCause";
 import type { ApiNotificationDropReactedReactor } from "@/generated/models/ApiNotificationDropReactedReactor";
@@ -81,10 +82,12 @@ const emptyProfile = ({
   id,
   handle,
   pfp,
+  subscribedActions = [],
 }: {
   readonly id: string;
   readonly handle: string | null;
   readonly pfp: string | null;
+  readonly subscribedActions?: ApiProfileMin["subscribed_actions"];
 }): ApiProfileMin => ({
   id,
   handle,
@@ -101,7 +104,7 @@ const emptyProfile = ({
   classification: ApiProfileClassification.Pseudonym,
   sub_classification: null,
   primary_address: "",
-  subscribed_actions: [],
+  subscribed_actions: subscribedActions,
   archived: false,
   active_main_stage_submission_ids: [],
   winner_main_stage_drop_ids: [],
@@ -109,6 +112,17 @@ const emptyProfile = ({
   profile_wave_id: null,
   is_wave_creator: false,
 });
+
+const getReactorSubscribedActions = (
+  subscribed: boolean | undefined,
+  fallback: ApiProfileMin["subscribed_actions"] = []
+): ApiProfileMin["subscribed_actions"] => {
+  if (subscribed === undefined) {
+    return fallback;
+  }
+
+  return subscribed ? [ApiIdentitySubscriptionTargetAction.WaveCreated] : [];
+};
 
 const mapReactorToProfileMin = (
   reactor: ApiNotificationDropReactedReactor,
@@ -126,6 +140,10 @@ const mapReactorToProfileMin = (
     return {
       ...fallbackProfile,
       pfp: reactor.pfp ?? fallbackProfile.pfp,
+      subscribed_actions: getReactorSubscribedActions(
+        reactor.subscribed,
+        fallbackProfile.subscribed_actions
+      ),
     };
   }
 
@@ -133,6 +151,7 @@ const mapReactorToProfileMin = (
     id: handle ?? `reactor-${fallbackIndex}`,
     handle,
     pfp: reactor.pfp ?? null,
+    subscribedActions: getReactorSubscribedActions(reactor.subscribed),
   });
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification "Follow All" button now properly tracks subscription states; displays "following all" and disables itself when all reactor profiles are already followed.

* **Tests**
  * Added comprehensive test coverage for notification follow-all button functionality and subscription state handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-frontend/pull/2391)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->