### PR TITLE
fix mint date parsing

### DIFF
--- a/components/the-memes/MemePageLiveStats.tsx
+++ b/components/the-memes/MemePageLiveStats.tsx
@@ -39,6 +39,13 @@ const COLLECTOR_METRIC_VALUE_CLASS =
   "tw-text-sm tw-font-semibold tw-leading-5 tw-text-white md:tw-text-lg md:tw-leading-6";
 const INLINE_STATS_ROW_CLASS =
   "tw-flex tw-flex-wrap tw-gap-x-10 tw-gap-y-6 sm:tw-gap-x-14";
+const MEME_MINT_DATE_LOCALE = "en-US";
+const MEME_MINT_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  day: "numeric",
+  month: "short",
+  year: "numeric",
+  timeZone: "UTC",
+};
 
 export function MemeCollectorsStats({
   nftMeta,
@@ -327,11 +334,10 @@ function getMintDateParts(date?: Date) {
   }
 
   return {
-    date: mintDate.toLocaleString("default", {
-      day: "numeric",
-      month: "short",
-      year: "numeric",
-    }),
+    date: mintDate.toLocaleString(
+      MEME_MINT_DATE_LOCALE,
+      MEME_MINT_DATE_FORMAT
+    ),
     relative: `(${getDateDisplay(mintDate)})`,
   };
 }

--- a/components/the-memes/MemePageLiveStats.tsx
+++ b/components/the-memes/MemePageLiveStats.tsx
@@ -268,7 +268,7 @@ export function MemeArtworkDetails({ nft }: { readonly nft: NFT }) {
               {mintDate.date}
             </span>
             {mintDate.relative && (
-              <span className="tw-ml-1.5 tw-text-xs tw-font-medium tw-leading-none tw-text-iron-500">
+              <span className="tw-ml-1.5 tw-mt-1 tw-text-xs tw-font-medium tw-leading-none tw-text-iron-500">
                 {mintDate.relative}
               </span>
             )}
@@ -317,13 +317,20 @@ function CreatorProfileIdentity({
 
 function getMintDateParts(value: string) {
   const normalizedValue = value.replace(/\s+/g, " ").trim();
-  const match = normalizedValue.match(/^(.*?)\s*(\(.+\))$/);
+  const relativeStartIndex = normalizedValue.lastIndexOf("(");
 
-  if (!match) {
+  if (
+    relativeStartIndex <= 0 ||
+    !normalizedValue.endsWith(")") ||
+    relativeStartIndex === normalizedValue.length - 1
+  ) {
     return { date: normalizedValue };
   }
 
-  return { date: match[1], relative: match[2] };
+  return {
+    date: normalizedValue.slice(0, relativeStartIndex).trimEnd(),
+    relative: normalizedValue.slice(relativeStartIndex),
+  };
 }
 
 function getArtistHandles(value: string | undefined) {

--- a/components/the-memes/MemePageLiveStats.tsx
+++ b/components/the-memes/MemePageLiveStats.tsx
@@ -7,7 +7,7 @@ import ProfileAvatar, {
 import MediaTypeBadge from "@/components/drops/media/MediaTypeBadge";
 import NFTMarketplaceLinks from "@/components/nft-marketplace-links/NFTMarketplaceLinks";
 import type { MemesExtendedData, NFT } from "@/entities/INFT";
-import { numberWithCommas, printMintDate } from "@/helpers/Helpers";
+import { getDateDisplay, numberWithCommas } from "@/helpers/Helpers";
 import { buildTooltipId, TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
 import { getFileMimeTypeFromMetadata } from "@/helpers/nft.helpers";
 import { useIdentity } from "@/hooks/useIdentity";
@@ -206,7 +206,7 @@ function formatPercent(value: number) {
 }
 
 export function MemeArtworkDetails({ nft }: { readonly nft: NFT }) {
-  const mintDate = getMintDateParts(printMintDate(nft.mint_date));
+  const mintDate = getMintDateParts(nft.mint_date);
   const artistHandles = getArtistHandles(nft.artist_seize_handle);
   const artistNames = getArtistNames(nft.artist);
   const creatorCount = Math.max(artistNames.length, artistHandles.length);
@@ -315,21 +315,24 @@ function CreatorProfileIdentity({
   );
 }
 
-function getMintDateParts(value: string) {
-  const normalizedValue = value.replace(/\s+/g, " ").trim();
-  const relativeStartIndex = normalizedValue.lastIndexOf("(");
+function getMintDateParts(date?: Date) {
+  if (!date) {
+    return { date: "-" };
+  }
 
-  if (
-    relativeStartIndex <= 0 ||
-    !normalizedValue.endsWith(")") ||
-    relativeStartIndex === normalizedValue.length - 1
-  ) {
-    return { date: normalizedValue };
+  const mintDate = new Date(date);
+
+  if (Number.isNaN(mintDate.getTime())) {
+    return { date: "-" };
   }
 
   return {
-    date: normalizedValue.slice(0, relativeStartIndex).trimEnd(),
-    relative: normalizedValue.slice(relativeStartIndex),
+    date: mintDate.toLocaleString("default", {
+      day: "numeric",
+      month: "short",
+      year: "numeric",
+    }),
+    relative: `(${getDateDisplay(mintDate)})`,
   };
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted spacing for the mint-date relative suffix for clearer layout.

* **Bug Fixes**
  * More robust mint-date handling: missing/invalid dates now display "-".
  * Valid mint dates show a consistent, locale-aware absolute date (UTC-based) with a relative-time suffix wrapped in parentheses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-frontend/pull/2406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->