### PR TITLE
render LFG slideshow media in viewport portal

### DIFF
--- a/__tests__/components/lfg-slideshow/LFGSlideshow.test.tsx
+++ b/__tests__/components/lfg-slideshow/LFGSlideshow.test.tsx
@@ -20,6 +20,11 @@ describe("LFGSlideshow", () => {
     mockFetch.mockResolvedValue([{ id: "1", image: "img.png", animation: "" }]);
   });
 
+  afterEach(() => {
+    document.body.style.overflow = "";
+    mockFetch.mockReset();
+  });
+
   it("opens slideshow on button click", async () => {
     const { container } = render(<LFGButton contract="c" />);
     await waitFor(() => expect(mockFetch).toHaveBeenCalled());
@@ -29,6 +34,24 @@ describe("LFGSlideshow", () => {
     expect(screen.getByAltText("LFG Slide 1")).toBeInTheDocument();
     expect(container.querySelector("#lfg-slideshow")).not.toBeInTheDocument();
     expect(document.getElementById("lfg-slideshow")).toBeInTheDocument();
+  });
+
+  it("locks body scroll only while the slideshow is open", async () => {
+    document.body.style.overflow = "scroll";
+
+    render(<LFGButton contract="c" />);
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    fireEvent.click(
+      screen.getByRole("button", { name: "LFG: Start the Show!" })
+    );
+
+    expect(document.body.style.overflow).toBe("hidden");
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(document.body.style.overflow).toBe("scroll");
+    });
   });
 
   it("falls back to the image when video loading fails", async () => {

--- a/__tests__/components/lfg-slideshow/LFGSlideshow.test.tsx
+++ b/__tests__/components/lfg-slideshow/LFGSlideshow.test.tsx
@@ -78,6 +78,73 @@ describe("LFGSlideshow", () => {
     );
   });
 
+  it("tries the full video before falling back to the image", async () => {
+    mockFetch.mockResolvedValue([
+      {
+        id: "1",
+        image: "fallback.png",
+        animation_compact: "compact.mp4",
+        animation: "full.mp4",
+      },
+    ]);
+    render(<LFGButton contract="c" />);
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    fireEvent.click(
+      screen.getByRole("button", { name: "LFG: Start the Show!" })
+    );
+
+    const compactVideo = document.querySelector("video");
+    expect(compactVideo).toHaveAttribute("src", "compact.mp4");
+
+    fireEvent.error(compactVideo);
+
+    await waitFor(() => {
+      expect(document.querySelector("video")).toHaveAttribute(
+        "src",
+        "full.mp4"
+      );
+    });
+
+    fireEvent.error(document.querySelector("video"));
+
+    expect(screen.getByAltText("LFG Slide 1")).toHaveAttribute(
+      "src",
+      "fallback.png"
+    );
+  });
+
+  it("clears media fallback state when reopening", async () => {
+    mockFetch.mockResolvedValue([
+      {
+        id: "1",
+        image: "fallback.png",
+        animation: "video.mp4",
+      },
+    ]);
+    render(<LFGButton contract="c" />);
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    fireEvent.click(
+      screen.getByRole("button", { name: "LFG: Start the Show!" })
+    );
+
+    fireEvent.error(document.querySelector("video"));
+    expect(screen.getByAltText("LFG Slide 1")).toHaveAttribute(
+      "src",
+      "fallback.png"
+    );
+
+    fireEvent.keyDown(globalThis, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByAltText("LFG Slide 1")).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "LFG: Start the Show!" })
+    );
+
+    expect(document.querySelector("video")).toHaveAttribute("src", "video.mp4");
+  });
+
   it("opens when API media omits optional fields", async () => {
     mockFetch.mockResolvedValue([{ image: "img.png" }]);
     render(<LFGButton contract="c" />);

--- a/__tests__/components/lfg-slideshow/LFGSlideshow.test.tsx
+++ b/__tests__/components/lfg-slideshow/LFGSlideshow.test.tsx
@@ -1,27 +1,101 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import React from 'react';
-import { LFGButton } from '@/components/lfg-slideshow/LFGSlideshow';
-import { commonApiFetch } from '@/services/api/common-api';
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+import { LFGButton } from "@/components/lfg-slideshow/LFGSlideshow";
+import { commonApiFetch } from "@/services/api/common-api";
 
-jest.mock('@/services/api/common-api');
-jest.mock('@/helpers/Helpers', () => ({
+jest.mock("@/services/api/common-api");
+jest.mock("@/helpers/Helpers", () => ({
   enterArtFullScreen: jest.fn(),
   fullScreenSupported: () => true,
 }));
-jest.mock('react-bootstrap', () => ({ Button: (p: any) => <button onClick={p.onClick}>{p.children}</button> }));
-jest.mock('@/components/lfg-slideshow/LFGSlideshow.module.scss', () => ({}));
+jest.mock("react-bootstrap", () => ({
+  Button: (p: any) => <button onClick={p.onClick}>{p.children}</button>,
+}));
+jest.mock("@/components/lfg-slideshow/LFGSlideshow.module.scss", () => ({}));
 
 const mockFetch = commonApiFetch as jest.Mock;
 
-describe('LFGSlideshow', () => {
+describe("LFGSlideshow", () => {
   beforeEach(() => {
-    mockFetch.mockResolvedValue([{ image: 'img.png', animation: '' }]);
+    mockFetch.mockResolvedValue([{ id: "1", image: "img.png", animation: "" }]);
   });
 
-  it('opens slideshow on button click', async () => {
+  it("opens slideshow on button click", async () => {
+    const { container } = render(<LFGButton contract="c" />);
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    fireEvent.click(
+      screen.getByRole("button", { name: "LFG: Start the Show!" })
+    );
+    expect(screen.getByAltText("LFG Slide 1")).toBeInTheDocument();
+    expect(container.querySelector("#lfg-slideshow")).not.toBeInTheDocument();
+    expect(document.getElementById("lfg-slideshow")).toBeInTheDocument();
+  });
+
+  it("falls back to the image when video loading fails", async () => {
+    mockFetch.mockResolvedValue([
+      { id: "1", image: "fallback.png", animation: "video.mp4" },
+    ]);
     render(<LFGButton contract="c" />);
     await waitFor(() => expect(mockFetch).toHaveBeenCalled());
-    fireEvent.click(screen.getByRole('button', { name: 'LFG: Start the Show!' }));
-    expect(screen.getByAltText('LFG Slide 1')).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "LFG: Start the Show!" })
+    );
+
+    const video = document.querySelector("video");
+    expect(video).toBeInTheDocument();
+    expect(video?.querySelector("track")).not.toBeInTheDocument();
+
+    fireEvent.error(video as HTMLVideoElement);
+    expect(screen.getByAltText("LFG Slide 1")).toHaveAttribute(
+      "src",
+      "fallback.png"
+    );
+  });
+
+  it("opens when API media omits optional fields", async () => {
+    mockFetch.mockResolvedValue([{ image: "img.png" }]);
+    render(<LFGButton contract="c" />);
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    fireEvent.click(
+      screen.getByRole("button", { name: "LFG: Start the Show!" })
+    );
+    expect(screen.getByAltText("LFG Slide 1")).toHaveAttribute(
+      "src",
+      "img.png"
+    );
+  });
+
+  it("tries image variants and advances when they fail", async () => {
+    mockFetch.mockResolvedValue([
+      {
+        id: 1,
+        image: "original.png",
+        image_compact: "compact.png",
+        animation: null,
+      },
+      { id: 2, image: "next.png", animation: null },
+    ]);
+    render(<LFGButton contract="c" />);
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    fireEvent.click(
+      screen.getByRole("button", { name: "LFG: Start the Show!" })
+    );
+
+    expect(screen.getByAltText("LFG Slide 1")).toHaveAttribute(
+      "src",
+      "compact.png"
+    );
+
+    fireEvent.error(screen.getByAltText("LFG Slide 1"));
+    expect(screen.getByAltText("LFG Slide 1")).toHaveAttribute(
+      "src",
+      "original.png"
+    );
+
+    fireEvent.error(screen.getByAltText("LFG Slide 1"));
+    expect(screen.getByAltText("LFG Slide 2")).toHaveAttribute(
+      "src",
+      "next.png"
+    );
   });
 });

--- a/__tests__/components/lfg-slideshow/LFGSlideshow.test.tsx
+++ b/__tests__/components/lfg-slideshow/LFGSlideshow.test.tsx
@@ -47,7 +47,7 @@ describe("LFGSlideshow", () => {
 
     expect(document.body.style.overflow).toBe("hidden");
 
-    fireEvent.keyDown(window, { key: "Escape" });
+    fireEvent.keyDown(globalThis, { key: "Escape" });
 
     await waitFor(() => {
       expect(document.body.style.overflow).toBe("scroll");
@@ -66,9 +66,12 @@ describe("LFGSlideshow", () => {
 
     const video = document.querySelector("video");
     expect(video).toBeInTheDocument();
-    expect(video?.querySelector("track")).not.toBeInTheDocument();
+    expect(video?.querySelector("track")).toHaveAttribute(
+      "src",
+      expect.stringContaining("data:text/vtt")
+    );
 
-    fireEvent.error(video as HTMLVideoElement);
+    fireEvent.error(video);
     expect(screen.getByAltText("LFG Slide 1")).toHaveAttribute(
       "src",
       "fallback.png"

--- a/components/lfg-slideshow/LFGSlideshow.module.scss
+++ b/components/lfg-slideshow/LFGSlideshow.module.scss
@@ -3,10 +3,9 @@
 
 .slideshowContainer {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  inset: 0;
+  width: 100vw;
+  height: 100dvh;
   background-color: rgba(0, 0, 0, 0.95);
   display: flex;
   align-items: center;
@@ -40,14 +39,15 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  max-width: 90%;
-  max-height: 90%;
+  width: 100vw;
+  height: 100dvh;
   position: relative;
 }
 
 .slide img,
 .slide video {
-  width: 100%;
+  display: block;
+  width: auto;
   height: auto;
   max-width: 85vw;
   max-height: 85vh;

--- a/components/lfg-slideshow/LFGSlideshow.tsx
+++ b/components/lfg-slideshow/LFGSlideshow.tsx
@@ -13,6 +13,7 @@ import { createPortal } from "react-dom";
 
 const DEFAULT_TIMEOUT = 10000;
 const SLIDESHOW_ID = "lfg-slideshow";
+const EMPTY_CAPTIONS_SRC = "data:text/vtt,WEBVTT%0A%0A";
 
 type LFGMedia = ApiNftMedia & {
   image_compact?: string | null;
@@ -309,6 +310,12 @@ const LFGSlideshow: React.FC<{
               }
             }}
           >
+            <track
+              kind="captions"
+              src={EMPTY_CAPTIONS_SRC}
+              srcLang="en"
+              label="No captions available"
+            />
             Your browser does not support the video tag.
           </video>
         ) : (

--- a/components/lfg-slideshow/LFGSlideshow.tsx
+++ b/components/lfg-slideshow/LFGSlideshow.tsx
@@ -13,7 +13,6 @@ import { createPortal } from "react-dom";
 
 const DEFAULT_TIMEOUT = 10000;
 const SLIDESHOW_ID = "lfg-slideshow";
-const VIDEO_ID = "lfg-slideshow-video";
 
 type LFGMedia = ApiNftMedia & {
   image_compact?: string | null;
@@ -40,10 +39,10 @@ const uniqueSources = (...sources: unknown[]) =>
 const getImageCandidates = (mediaItem: LFGMedia) =>
   uniqueSources(mediaItem.image_compact, mediaItem.image);
 
-const getVideoCandidates = (mediaItem: LFGMedia) =>
-  uniqueSources(mediaItem.animation_compact, mediaItem.animation).filter(
+const getVideoSource = (mediaItem: LFGMedia) =>
+  uniqueSources(mediaItem.animation_compact, mediaItem.animation).find(
     isVideo
-  );
+  ) ?? "";
 
 const getCurrentSource = (
   candidates: string[],
@@ -52,7 +51,7 @@ const getCurrentSource = (
 ) => candidates[sourceIndexes[mediaKey] ?? 0] ?? "";
 
 const preloadMedia = (mediaItem: LFGMedia) => {
-  const animation = getVideoCandidates(mediaItem)[0] ?? "";
+  const animation = getVideoSource(mediaItem);
   const image = getImageCandidates(mediaItem)[0] ?? "";
 
   if (animation.length > 0) {
@@ -101,7 +100,7 @@ const shouldShowVideo = (
   index: number,
   videoLoadErrors: Record<string, boolean>
 ) =>
-  getVideoCandidates(mediaItem).length > 0 &&
+  getVideoSource(mediaItem).length > 0 &&
   videoLoadErrors[getMediaKey(mediaItem, index)] !== true;
 
 const LFGSlideshow: React.FC<{
@@ -117,19 +116,13 @@ const LFGSlideshow: React.FC<{
   const [imageSourceIndexes, setImageSourceIndexes] = useState<
     Record<string, number>
   >({});
-  const [videoSourceIndexes, setVideoSourceIndexes] = useState<
-    Record<string, number>
-  >({});
-  const bodyOverflow = useRef<string | undefined>(undefined);
   const slideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
 
   const [media, setMedia] = useState<LFGMedia[]>([]);
 
-  const toggleSlideshow = () => {
-    setIsOpen(!isOpen);
-    if (!isOpen) {
-      setCurrentIndex(0);
-    }
+  const closeSlideshow = () => {
+    setIsOpen(false);
   };
 
   const nextSlide = useCallback(() => {
@@ -143,6 +136,8 @@ const LFGSlideshow: React.FC<{
   }, [media.length]);
 
   useEffect(() => {
+    if (!isOpen) return;
+
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         setIsOpen(false);
@@ -153,18 +148,16 @@ const LFGSlideshow: React.FC<{
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [setIsOpen]);
+  }, [isOpen, setIsOpen]);
 
   useEffect(() => {
-    if (isOpen) {
-      bodyOverflow.current = document.body.style.overflow;
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = bodyOverflow.current ?? "unset";
-    }
+    if (!isOpen) return;
+
+    const previousBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
 
     return () => {
-      document.body.style.overflow = bodyOverflow.current ?? "unset";
+      document.body.style.overflow = previousBodyOverflow;
     };
   }, [isOpen]);
 
@@ -181,6 +174,8 @@ const LFGSlideshow: React.FC<{
 
         setMedia(loadedMedia);
         setCurrentIndex(0);
+        setVideoLoadErrors({});
+        setImageSourceIndexes({});
         const firstMedia = loadedMedia[0];
         if (firstMedia) {
           preloadMedia(firstMedia);
@@ -207,9 +202,7 @@ const LFGSlideshow: React.FC<{
     preloadNext(media, currentIndex);
 
     if (shouldShowVideo(currentMedia, currentIndex, videoLoadErrors)) {
-      const videoElement = document.getElementById(
-        VIDEO_ID
-      ) as HTMLVideoElement | null;
+      const videoElement = videoRef.current;
       if (videoElement !== null) {
         const handleEnded = () => {
           nextSlide();
@@ -250,13 +243,8 @@ const LFGSlideshow: React.FC<{
     currentIndex,
     videoLoadErrors
   );
-  const videoCandidates = getVideoCandidates(currentMedia);
   const imageCandidates = getImageCandidates(currentMedia);
-  const currentAnimation = getCurrentSource(
-    videoCandidates,
-    videoSourceIndexes,
-    currentMediaKey
-  );
+  const currentAnimation = getVideoSource(currentMedia);
   const currentImage = getCurrentSource(
     imageCandidates,
     imageSourceIndexes,
@@ -264,15 +252,6 @@ const LFGSlideshow: React.FC<{
   );
 
   const handleVideoUnavailable = () => {
-    const nextVideoIndex = (videoSourceIndexes[currentMediaKey] ?? 0) + 1;
-    if (nextVideoIndex < videoCandidates.length) {
-      setVideoSourceIndexes((indexes) => ({
-        ...indexes,
-        [currentMediaKey]: nextVideoIndex,
-      }));
-      return;
-    }
-
     setVideoLoadErrors((errors) => ({
       ...errors,
       [currentMediaKey]: true,
@@ -307,13 +286,13 @@ const LFGSlideshow: React.FC<{
         <FontAwesomeIcon
           icon={faXmarkCircle}
           className={styles["slideButton"]}
-          onClick={toggleSlideshow}
+          onClick={closeSlideshow}
         />
       </span>
       <div className={styles["slide"]} id={SLIDESHOW_ID}>
         {showVideo ? (
           <video
-            id={VIDEO_ID}
+            ref={videoRef}
             autoPlay
             controls
             playsInline

--- a/components/lfg-slideshow/LFGSlideshow.tsx
+++ b/components/lfg-slideshow/LFGSlideshow.tsx
@@ -40,10 +40,10 @@ const uniqueSources = (...sources: unknown[]) =>
 const getImageCandidates = (mediaItem: LFGMedia) =>
   uniqueSources(mediaItem.image_compact, mediaItem.image);
 
-const getVideoSource = (mediaItem: LFGMedia) =>
-  uniqueSources(mediaItem.animation_compact, mediaItem.animation).find(
+const getVideoCandidates = (mediaItem: LFGMedia) =>
+  uniqueSources(mediaItem.animation_compact, mediaItem.animation).filter(
     isVideo
-  ) ?? "";
+  );
 
 const getCurrentSource = (
   candidates: string[],
@@ -52,7 +52,7 @@ const getCurrentSource = (
 ) => candidates[sourceIndexes[mediaKey] ?? 0] ?? "";
 
 const preloadMedia = (mediaItem: LFGMedia) => {
-  const animation = getVideoSource(mediaItem);
+  const animation = getVideoCandidates(mediaItem)[0] ?? "";
   const image = getImageCandidates(mediaItem)[0] ?? "";
 
   if (animation.length > 0) {
@@ -99,10 +99,14 @@ const getMediaKey = (mediaItem: LFGMedia, index: number) => {
 const shouldShowVideo = (
   mediaItem: LFGMedia,
   index: number,
-  videoLoadErrors: Record<string, boolean>
+  videoLoadErrors: Record<string, boolean>,
+  videoSourceIndexes: Record<string, number>
 ) =>
-  getVideoSource(mediaItem).length > 0 &&
-  videoLoadErrors[getMediaKey(mediaItem, index)] !== true;
+  getCurrentSource(
+    getVideoCandidates(mediaItem),
+    videoSourceIndexes,
+    getMediaKey(mediaItem, index)
+  ).length > 0 && videoLoadErrors[getMediaKey(mediaItem, index)] !== true;
 
 const LFGSlideshow: React.FC<{
   isOpen: boolean;
@@ -117,14 +121,13 @@ const LFGSlideshow: React.FC<{
   const [imageSourceIndexes, setImageSourceIndexes] = useState<
     Record<string, number>
   >({});
+  const [videoSourceIndexes, setVideoSourceIndexes] = useState<
+    Record<string, number>
+  >({});
   const slideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const videoRef = useRef<HTMLVideoElement | null>(null);
 
   const [media, setMedia] = useState<LFGMedia[]>([]);
-
-  const closeSlideshow = () => {
-    setIsOpen(false);
-  };
 
   const nextSlide = useCallback(() => {
     if (slideTimer.current !== null) {
@@ -136,12 +139,29 @@ const LFGSlideshow: React.FC<{
     );
   }, [media.length]);
 
+  const resetSession = useCallback(() => {
+    if (slideTimer.current !== null) {
+      clearTimeout(slideTimer.current);
+      slideTimer.current = null;
+    }
+    setCurrentIndex(0);
+    setIsMuted(false);
+    setVideoLoadErrors({});
+    setImageSourceIndexes({});
+    setVideoSourceIndexes({});
+  }, []);
+
+  const closeSlideshow = useCallback(() => {
+    resetSession();
+    setIsOpen(false);
+  }, [resetSession, setIsOpen]);
+
   useEffect(() => {
     if (!isOpen) return;
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        setIsOpen(false);
+        closeSlideshow();
       }
     };
 
@@ -149,7 +169,7 @@ const LFGSlideshow: React.FC<{
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [isOpen, setIsOpen]);
+  }, [closeSlideshow, isOpen]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -177,6 +197,7 @@ const LFGSlideshow: React.FC<{
         setCurrentIndex(0);
         setVideoLoadErrors({});
         setImageSourceIndexes({});
+        setVideoSourceIndexes({});
         const firstMedia = loadedMedia[0];
         if (firstMedia) {
           preloadMedia(firstMedia);
@@ -202,7 +223,14 @@ const LFGSlideshow: React.FC<{
 
     preloadNext(media, currentIndex);
 
-    if (shouldShowVideo(currentMedia, currentIndex, videoLoadErrors)) {
+    if (
+      shouldShowVideo(
+        currentMedia,
+        currentIndex,
+        videoLoadErrors,
+        videoSourceIndexes
+      )
+    ) {
       const videoElement = videoRef.current;
       if (videoElement !== null) {
         const handleEnded = () => {
@@ -230,7 +258,14 @@ const LFGSlideshow: React.FC<{
         slideTimer.current = null;
       }
     };
-  }, [currentIndex, isOpen, media, nextSlide, videoLoadErrors]);
+  }, [
+    currentIndex,
+    isOpen,
+    media,
+    nextSlide,
+    videoLoadErrors,
+    videoSourceIndexes,
+  ]);
 
   const currentMedia = media[currentIndex];
 
@@ -242,10 +277,16 @@ const LFGSlideshow: React.FC<{
   const showVideo = shouldShowVideo(
     currentMedia,
     currentIndex,
-    videoLoadErrors
+    videoLoadErrors,
+    videoSourceIndexes
   );
+  const videoCandidates = getVideoCandidates(currentMedia);
   const imageCandidates = getImageCandidates(currentMedia);
-  const currentAnimation = getVideoSource(currentMedia);
+  const currentAnimation = getCurrentSource(
+    videoCandidates,
+    videoSourceIndexes,
+    currentMediaKey
+  );
   const currentImage = getCurrentSource(
     imageCandidates,
     imageSourceIndexes,
@@ -253,6 +294,15 @@ const LFGSlideshow: React.FC<{
   );
 
   const handleVideoUnavailable = () => {
+    const nextVideoIndex = (videoSourceIndexes[currentMediaKey] ?? 0) + 1;
+    if (nextVideoIndex < videoCandidates.length) {
+      setVideoSourceIndexes((indexes) => ({
+        ...indexes,
+        [currentMediaKey]: nextVideoIndex,
+      }));
+      return;
+    }
+
     setVideoLoadErrors((errors) => ({
       ...errors,
       [currentMediaKey]: true,

--- a/components/lfg-slideshow/LFGSlideshow.tsx
+++ b/components/lfg-slideshow/LFGSlideshow.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import styles from "./LFGSlideshow.module.scss";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faExpand, faXmarkCircle } from "@fortawesome/free-solid-svg-icons";
@@ -8,10 +8,101 @@ import { commonApiFetch } from "@/services/api/common-api";
 import type { ApiNftMedia } from "@/generated/models/ApiNftMedia";
 import { enterArtFullScreen, fullScreenSupported } from "@/helpers/Helpers";
 import { Button } from "react-bootstrap";
+import clsx from "clsx";
+import { createPortal } from "react-dom";
 
 const DEFAULT_TIMEOUT = 10000;
 const SLIDESHOW_ID = "lfg-slideshow";
 const VIDEO_ID = "lfg-slideshow-video";
+
+type LFGMedia = ApiNftMedia & {
+  image_compact?: string | null;
+  animation_compact?: string | null;
+};
+
+const getMediaField = (value: unknown) =>
+  typeof value === "string" ? value : "";
+
+const getMediaIdentityField = (value: unknown) =>
+  typeof value === "string" || typeof value === "number" ? `${value}` : "";
+
+const isVideo = (url: string | null | undefined) =>
+  getMediaField(url).toLowerCase().endsWith(".mp4");
+
+const uniqueSources = (...sources: unknown[]) =>
+  sources
+    .map(getMediaField)
+    .filter((source) => source.length > 0)
+    .filter(
+      (source, index, allSources) => allSources.indexOf(source) === index
+    );
+
+const getImageCandidates = (mediaItem: LFGMedia) =>
+  uniqueSources(mediaItem.image_compact, mediaItem.image);
+
+const getVideoCandidates = (mediaItem: LFGMedia) =>
+  uniqueSources(mediaItem.animation_compact, mediaItem.animation).filter(
+    isVideo
+  );
+
+const getCurrentSource = (
+  candidates: string[],
+  sourceIndexes: Record<string, number>,
+  mediaKey: string
+) => candidates[sourceIndexes[mediaKey] ?? 0] ?? "";
+
+const preloadMedia = (mediaItem: LFGMedia) => {
+  const animation = getVideoCandidates(mediaItem)[0] ?? "";
+  const image = getImageCandidates(mediaItem)[0] ?? "";
+
+  if (animation.length > 0) {
+    const video = document.createElement("video");
+    video.src = animation;
+    video.load();
+  } else if (image.length > 0) {
+    const img = new Image();
+    img.src = image;
+  }
+};
+
+const preloadNext = (mediaItems: LFGMedia[], index: number) => {
+  const nextIndex = (index + 1) % mediaItems.length;
+  const nextMedia = mediaItems[nextIndex];
+
+  if (!nextMedia) {
+    return;
+  }
+
+  preloadMedia(nextMedia);
+};
+
+const getMediaKey = (mediaItem: LFGMedia, index: number) => {
+  const id = getMediaIdentityField(mediaItem.id);
+  const animation = getMediaField(mediaItem.animation);
+  const image = getMediaField(mediaItem.image);
+
+  if (id.length > 0) {
+    return id;
+  }
+
+  if (animation.length > 0) {
+    return animation;
+  }
+
+  if (image.length > 0) {
+    return image;
+  }
+
+  return `media-${index}`;
+};
+
+const shouldShowVideo = (
+  mediaItem: LFGMedia,
+  index: number,
+  videoLoadErrors: Record<string, boolean>
+) =>
+  getVideoCandidates(mediaItem).length > 0 &&
+  videoLoadErrors[getMediaKey(mediaItem, index)] !== true;
 
 const LFGSlideshow: React.FC<{
   isOpen: boolean;
@@ -19,39 +110,20 @@ const LFGSlideshow: React.FC<{
   setIsOpen: (isOpen: boolean) => void;
 }> = ({ isOpen, contract, setIsOpen }) => {
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [bodyOverflow, setBodyOverflow] = useState<string>();
   const [isMuted, setIsMuted] = useState(false);
+  const [videoLoadErrors, setVideoLoadErrors] = useState<
+    Record<string, boolean>
+  >({});
+  const [imageSourceIndexes, setImageSourceIndexes] = useState<
+    Record<string, number>
+  >({});
+  const [videoSourceIndexes, setVideoSourceIndexes] = useState<
+    Record<string, number>
+  >({});
+  const bodyOverflow = useRef<string | undefined>(undefined);
+  const slideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const [media, setMedia] = useState<ApiNftMedia[]>([]);
-
-  let slideTimer: NodeJS.Timeout | null = null;
-
-  const isVideo = (url: string) => {
-    return url?.toLowerCase().endsWith(".mp4");
-  };
-
-  const preloadNext = (index: number) => {
-    const nextIndex = (index + 1) % media.length;
-    const nextMedia = media[nextIndex];
-
-    if (!nextMedia) {
-      return;
-    }
-
-    preloadMedia(nextMedia);
-  };
-
-  const preloadMedia = (media: ApiNftMedia) => {
-    if (!media) return;
-    if (isVideo(media.animation)) {
-      const video = document.createElement("video");
-      video.src = media.animation;
-      video.load();
-    } else {
-      const img = new Image();
-      img.src = media.image;
-    }
-  };
+  const [media, setMedia] = useState<LFGMedia[]>([]);
 
   const toggleSlideshow = () => {
     setIsOpen(!isOpen);
@@ -60,12 +132,15 @@ const LFGSlideshow: React.FC<{
     }
   };
 
-  const nextSlide = () => {
-    if (slideTimer) {
-      clearTimeout(slideTimer);
+  const nextSlide = useCallback(() => {
+    if (slideTimer.current !== null) {
+      clearTimeout(slideTimer.current);
+      slideTimer.current = null;
     }
-    setCurrentIndex((prevIndex) => (prevIndex + 1) % media.length);
-  };
+    setCurrentIndex((prevIndex) =>
+      media.length > 0 ? (prevIndex + 1) % media.length : prevIndex
+    );
+  }, [media.length]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -78,44 +153,64 @@ const LFGSlideshow: React.FC<{
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, []);
+  }, [setIsOpen]);
 
   useEffect(() => {
     if (isOpen) {
-      setBodyOverflow(document.body.style.overflow);
+      bodyOverflow.current = document.body.style.overflow;
       document.body.style.overflow = "hidden";
     } else {
-      document.body.style.overflow = bodyOverflow ?? "unset";
+      document.body.style.overflow = bodyOverflow.current ?? "unset";
     }
 
     return () => {
-      document.body.style.overflow = bodyOverflow ?? "unset";
+      document.body.style.overflow = bodyOverflow.current ?? "unset";
     };
   }, [isOpen]);
 
   useEffect(() => {
-    commonApiFetch<ApiNftMedia[]>({
+    let canceled = false;
+
+    void commonApiFetch<LFGMedia[]>({
       endpoint: `nfts/${contract}/media`,
-    }).then((media) => {
-      setMedia(media);
-      setCurrentIndex(0);
-      if (media[0]) {
-        preloadMedia(media[0]);
-      }
-    });
-  }, []);
+    })
+      .then((loadedMedia) => {
+        if (canceled) {
+          return;
+        }
+
+        setMedia(loadedMedia);
+        setCurrentIndex(0);
+        const firstMedia = loadedMedia[0];
+        if (firstMedia) {
+          preloadMedia(firstMedia);
+        }
+      })
+      .catch(() => {
+        if (!canceled) {
+          setMedia([]);
+          setCurrentIndex(0);
+        }
+      });
+
+    return () => {
+      canceled = true;
+    };
+  }, [contract]);
 
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen || media.length === 0) return;
 
     const currentMedia = media[currentIndex];
-    preloadNext(currentIndex);
+    if (!currentMedia) return;
 
-    if (currentMedia?.animation && isVideo(currentMedia.animation)) {
+    preloadNext(media, currentIndex);
+
+    if (shouldShowVideo(currentMedia, currentIndex, videoLoadErrors)) {
       const videoElement = document.getElementById(
         VIDEO_ID
-      ) as HTMLVideoElement;
-      if (videoElement) {
+      ) as HTMLVideoElement | null;
+      if (videoElement !== null) {
         const handleEnded = () => {
           nextSlide();
         };
@@ -128,24 +223,78 @@ const LFGSlideshow: React.FC<{
         videoElement.addEventListener("volumechange", handleVolumeChange);
         return () => {
           videoElement.removeEventListener("ended", handleEnded);
+          videoElement.removeEventListener("volumechange", handleVolumeChange);
         };
       }
     } else {
-      slideTimer = setTimeout(nextSlide, DEFAULT_TIMEOUT);
+      slideTimer.current = setTimeout(nextSlide, DEFAULT_TIMEOUT);
     }
 
     return () => {
-      if (slideTimer) {
-        clearTimeout(slideTimer);
+      if (slideTimer.current !== null) {
+        clearTimeout(slideTimer.current);
+        slideTimer.current = null;
       }
     };
-  }, [isOpen, currentIndex, media]);
+  }, [currentIndex, isOpen, media, nextSlide, videoLoadErrors]);
 
-  if (!isOpen || media.length === 0) {
+  const currentMedia = media[currentIndex];
+
+  if (!isOpen || !currentMedia) {
     return <></>;
   }
 
-  return (
+  const currentMediaKey = getMediaKey(currentMedia, currentIndex);
+  const showVideo = shouldShowVideo(
+    currentMedia,
+    currentIndex,
+    videoLoadErrors
+  );
+  const videoCandidates = getVideoCandidates(currentMedia);
+  const imageCandidates = getImageCandidates(currentMedia);
+  const currentAnimation = getCurrentSource(
+    videoCandidates,
+    videoSourceIndexes,
+    currentMediaKey
+  );
+  const currentImage = getCurrentSource(
+    imageCandidates,
+    imageSourceIndexes,
+    currentMediaKey
+  );
+
+  const handleVideoUnavailable = () => {
+    const nextVideoIndex = (videoSourceIndexes[currentMediaKey] ?? 0) + 1;
+    if (nextVideoIndex < videoCandidates.length) {
+      setVideoSourceIndexes((indexes) => ({
+        ...indexes,
+        [currentMediaKey]: nextVideoIndex,
+      }));
+      return;
+    }
+
+    setVideoLoadErrors((errors) => ({
+      ...errors,
+      [currentMediaKey]: true,
+    }));
+  };
+
+  const handleImageUnavailable = () => {
+    const nextImageIndex = (imageSourceIndexes[currentMediaKey] ?? 0) + 1;
+    if (nextImageIndex < imageCandidates.length) {
+      setImageSourceIndexes((indexes) => ({
+        ...indexes,
+        [currentMediaKey]: nextImageIndex,
+      }));
+      return;
+    }
+
+    if (media.length > 1) {
+      nextSlide();
+    }
+  };
+
+  const slideshow = (
     <div className={styles["slideshowContainer"]}>
       <span className={styles["slideButtons"]}>
         {fullScreenSupported() && (
@@ -162,28 +311,46 @@ const LFGSlideshow: React.FC<{
         />
       </span>
       <div className={styles["slide"]} id={SLIDESHOW_ID}>
-        {media[currentIndex]?.animation &&
-        isVideo(media[currentIndex].animation) ? (
+        {showVideo ? (
           <video
             id={VIDEO_ID}
             autoPlay
             controls
+            playsInline
             muted={isMuted}
-            src={media[currentIndex]?.animation}
-            poster={media[currentIndex]?.image}
+            src={currentAnimation}
+            poster={currentImage.length > 0 ? currentImage : undefined}
+            onError={handleVideoUnavailable}
+            onLoadedMetadata={({ currentTarget }) => {
+              if (
+                currentTarget.videoWidth === 0 ||
+                currentTarget.videoHeight === 0
+              ) {
+                handleVideoUnavailable();
+              }
+            }}
           >
-            <track kind="captions" src="" srcLang="en" label="English" />
             Your browser does not support the video tag.
           </video>
         ) : (
-          <img
-            src={media[currentIndex]?.image}
-            alt={`LFG Slide ${currentIndex + 1}`}
-          />
+          currentImage.length > 0 && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={currentImage}
+              alt={`LFG Slide ${currentIndex + 1}`}
+              onError={handleImageUnavailable}
+            />
+          )
         )}
       </div>
     </div>
   );
+
+  if (typeof document === "undefined") {
+    return <></>;
+  }
+
+  return createPortal(slideshow, document.body);
 };
 
 export const LFGButton: React.FC<{
@@ -196,7 +363,7 @@ export const LFGButton: React.FC<{
       <LFGSlideshow contract={contract} isOpen={isOpen} setIsOpen={setIsOpen} />
       <Button
         onClick={() => setIsOpen(true)}
-        className={`${styles["lfgButton"]} no-wrap`}
+        className={clsx(styles["lfgButton"], "no-wrap")}
       >
         LFG: Start the Show!
       </Button>

--- a/components/the-memes/MemePageLiveStats.tsx
+++ b/components/the-memes/MemePageLiveStats.tsx
@@ -229,8 +229,8 @@ export function MemeArtworkDetails({ nft }: { readonly nft: NFT }) {
       : [{ handle: null, display: "not available" }];
 
   return (
-    <section className="tw-border-0 tw-border-b tw-border-solid tw-border-iron-800 tw-pb-6 md:tw-pb-8">
-      <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-x-8 tw-gap-y-6">
+    <section className="tw-border-0 tw-border-b tw-border-solid tw-border-iron-800 tw-pb-6 tw-pt-8 md:tw-pb-8 lg:tw-pt-0">
+      <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-x-6 tw-gap-y-6">
         <div className="tw-min-w-0">
           <div className={TOP_LABEL_CLASS}>Created by</div>
           <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-y-2">
@@ -334,10 +334,7 @@ function getMintDateParts(date?: Date) {
   }
 
   return {
-    date: mintDate.toLocaleString(
-      MEME_MINT_DATE_LOCALE,
-      MEME_MINT_DATE_FORMAT
-    ),
+    date: mintDate.toLocaleString(MEME_MINT_DATE_LOCALE, MEME_MINT_DATE_FORMAT),
     relative: `(${getDateDisplay(mintDate)})`,
   };
 }

--- a/components/the-memes/TheMemesCard.tsx
+++ b/components/the-memes/TheMemesCard.tsx
@@ -96,7 +96,7 @@ export default function TheMemesCard({
       href={`/the-memes/${nft.id}`}
       className="tw-group tw-block tw-min-w-0 tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-iron-950 tw-text-iron-100 tw-no-underline tw-transition tw-duration-200 hover:tw-border-white/20 hover:tw-bg-iron-900/50 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-primary-400"
     >
-      <div className="tw-relative tw-mb-2 tw-bg-iron-950">
+      <div className="tw-relative tw-mb-2 tw-bg-iron-900">
         <NFTImage
           nft={nft}
           animation={false}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More resilient media handling: videos/images now auto-fallback and retry, with compact→full image fallback and progression when media fails. Slideshow restores page scroll when closed (including via Escape).

* **Refactor**
  * Reworked media selection, load/error tracking, and slide timing for more reliable playback and progression.

* **Style**
  * Slideshow updated to use full-viewport sizing; minor card/background and page spacing tweaks.

* **Tests**
  * Expanded tests covering open/close, overflow locking, media fallbacks, subtitle/track handling, and slide progression.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-frontend/pull/2415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->