### PR TITLE
Fix wave markdown data images

### DIFF
--- a/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
+++ b/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
@@ -254,8 +254,7 @@ describe("DropPartMarkdown", () => {
   });
 
   it("renders a markdown image with a safe base64 data URI", () => {
-    const dataUri =
-      "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2w==";
+    const dataUri = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2w==";
 
     render(
       <DropPartMarkdown

--- a/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
+++ b/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
@@ -253,6 +253,41 @@ describe("DropPartMarkdown", () => {
     ).not.toBeNull();
   });
 
+  it("renders a markdown image with a safe base64 data URI", () => {
+    const dataUri =
+      "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2w==";
+
+    render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        mentionedWaves={[]}
+        referencedNfts={[]}
+        partContent={`hello\n\n![Seize](${dataUri})`}
+        onQuoteClick={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText("hello")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Drop media" })).toHaveAttribute(
+      "src",
+      dataUri
+    );
+  });
+
+  it("does not render markdown images with non-image data URIs", () => {
+    render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        mentionedWaves={[]}
+        referencedNfts={[]}
+        partContent="![Seize](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)"
+        onQuoteClick={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByRole("img", { name: "Drop media" })).toBeNull();
+  });
+
   it("preserves whitespace between a markdown image and following text", () => {
     const { container } = render(
       <DropPartMarkdown

--- a/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
+++ b/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
@@ -287,6 +287,20 @@ describe("DropPartMarkdown", () => {
     expect(screen.queryByRole("img", { name: "Drop media" })).toBeNull();
   });
 
+  it("does not render markdown images with unsafe invalid sources", () => {
+    render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        mentionedWaves={[]}
+        referencedNfts={[]}
+        partContent="![Seize](javascript:alert(1)) ![Seize](//example.com/image.png)"
+        onQuoteClick={jest.fn()}
+      />
+    );
+
+    expect(screen.queryByRole("img", { name: "Drop media" })).toBeNull();
+  });
+
   it("preserves whitespace between a markdown image and following text", () => {
     const { container } = render(
       <DropPartMarkdown

--- a/components/drops/view/part/DropPartMarkdown.tsx
+++ b/components/drops/view/part/DropPartMarkdown.tsx
@@ -11,7 +11,11 @@ import {
   type ElementType,
   type ReactNode,
 } from "react";
-import Markdown, { type Components, type ExtraProps } from "react-markdown";
+import Markdown, {
+  defaultUrlTransform,
+  type Components,
+  type ExtraProps,
+} from "react-markdown";
 import rehypeExternalLinks from "rehype-external-links";
 import rehypeSanitize from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
@@ -41,6 +45,7 @@ import {
   createLinkRenderer,
   DEFAULT_MAX_EMBED_DEPTH,
 } from "./dropPartMarkdown/linkHandlers";
+import { isSafeMarkdownImageSrc } from "./dropPartMarkdown/linkUtils";
 
 const BreakComponent = () => <br />;
 
@@ -417,6 +422,12 @@ function DropPartMarkdown({
             code: ["className"],
             pre: ["className"],
           },
+          protocols: {
+            cite: ["http", "https"],
+            href: ["http", "https", "irc", "ircs", "mailto", "xmpp"],
+            longDesc: ["http", "https"],
+            src: ["http", "https", "data"],
+          },
         },
       ],
     ],
@@ -447,6 +458,17 @@ function DropPartMarkdown({
         remarkPlugins={remarkPlugins}
         className="tw-w-full"
         components={markdownComponents}
+        urlTransform={(url, key, node) => {
+          if (
+            key === "src" &&
+            node.tagName === "img" &&
+            isSafeMarkdownImageSrc(url)
+          ) {
+            return url;
+          }
+
+          return defaultUrlTransform(url);
+        }}
       >
         {processedContent}
       </Markdown>

--- a/components/drops/view/part/dropPartMarkdown/linkHandlers.tsx
+++ b/components/drops/view/part/dropPartMarkdown/linkHandlers.tsx
@@ -23,6 +23,7 @@ import { createLinkHandlers, createSeizeHandlers } from "./handlers";
 import type { LinkHandler } from "./linkTypes";
 import {
   isDirectImageUrl,
+  isSafeMarkdownImageSrc,
   isValidLink,
   parseUrl,
   renderExternalOrInternalLink,
@@ -140,6 +141,10 @@ export const createLinkRenderer = ({
 
   const renderImage: LinkRenderer["renderImage"] = ({ src, ...props }) => {
     if (typeof src !== "string") {
+      return null;
+    }
+
+    if (!isSafeMarkdownImageSrc(src)) {
       return null;
     }
 

--- a/components/drops/view/part/dropPartMarkdown/linkUtils.tsx
+++ b/components/drops/view/part/dropPartMarkdown/linkUtils.tsx
@@ -39,6 +39,14 @@ const isSafeDataImageUrl = (href: string): boolean => {
   return SAFE_DATA_IMAGE_REGEX.test(href.trim());
 };
 
+const isSafeRelativeImagePath = (href: string): boolean => {
+  return (
+    (href.startsWith("/") && !href.startsWith("//")) ||
+    href.startsWith("./") ||
+    href.startsWith("../")
+  );
+};
+
 const isSafeMarkdownImageSrc = (href: string): boolean => {
   const trimmedHref = href.trim();
 
@@ -52,7 +60,7 @@ const isSafeMarkdownImageSrc = (href: string): boolean => {
 
   const parsedUrl = parseUrl(trimmedHref);
   if (!parsedUrl) {
-    return true;
+    return isSafeRelativeImagePath(trimmedHref);
   }
 
   const protocol = parsedUrl.protocol.toLowerCase();

--- a/components/drops/view/part/dropPartMarkdown/linkUtils.tsx
+++ b/components/drops/view/part/dropPartMarkdown/linkUtils.tsx
@@ -32,6 +32,32 @@ const DIRECT_IMAGE_EXTENSIONS = [
   ".webp",
   ".avif",
 ] as const;
+const SAFE_DATA_IMAGE_REGEX =
+  /^data:image\/(?:gif|png|jpe?g|webp|avif);base64,[a-z0-9+/=\s]+$/i;
+
+const isSafeDataImageUrl = (href: string): boolean => {
+  return SAFE_DATA_IMAGE_REGEX.test(href.trim());
+};
+
+const isSafeMarkdownImageSrc = (href: string): boolean => {
+  const trimmedHref = href.trim();
+
+  if (trimmedHref.length === 0) {
+    return false;
+  }
+
+  if (isSafeDataImageUrl(trimmedHref)) {
+    return true;
+  }
+
+  const parsedUrl = parseUrl(trimmedHref);
+  if (!parsedUrl) {
+    return true;
+  }
+
+  const protocol = parsedUrl.protocol.toLowerCase();
+  return protocol === "http:" || protocol === "https:";
+};
 
 const isDirectImageUrl = (href: string, parsedUrl?: URL | null): boolean => {
   const url = parsedUrl ?? parseUrl(href);
@@ -139,6 +165,7 @@ const isValidLink = (href: string): boolean => {
 
 export {
   isDirectImageUrl,
+  isSafeMarkdownImageSrc,
   isValidLink,
   parseUrl,
   renderExternalOrInternalLink,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enable rendering of safe base64 data-URI images in markdown.

* **Bug Fixes**
  * Strengthened validation to prevent rendering of unsafe or disallowed image sources (e.g., javascript:, protocol-relative, non-image data URIs).

* **Tests**
  * Added tests covering allowed base64 image URIs and rejection of unsafe/non-image data URI image sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-frontend/pull/2422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->