### PR TITLE
UI for blocking links in chats

### DIFF
--- a/__tests__/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.test.ts
+++ b/__tests__/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.test.ts
@@ -1,0 +1,32 @@
+import { containsOpenGraphPreviewLink } from "@/components/drops/view/part/dropPartMarkdown/linkPreviewDetection";
+
+describe("linkPreviewDetection", () => {
+  it("detects markdown links and bare urls that become OpenGraph previews", () => {
+    expect(
+      containsOpenGraphPreviewLink("[article](https://example.com/post)")
+    ).toBe(true);
+    expect(containsOpenGraphPreviewLink("read https://example.com/post")).toBe(
+      true
+    );
+    expect(containsOpenGraphPreviewLink("read www.example.com/post")).toBe(
+      true
+    );
+  });
+
+  it("ignores urls in code and direct image urls", () => {
+    expect(containsOpenGraphPreviewLink("`https://example.com/post`")).toBe(
+      false
+    );
+    expect(containsOpenGraphPreviewLink("https://example.com/image.png")).toBe(
+      false
+    );
+  });
+
+  it("ignores urls handled by non-OpenGraph cards", () => {
+    expect(
+      containsOpenGraphPreviewLink(
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+      )
+    ).toBe(false);
+  });
+});

--- a/__tests__/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.test.ts
+++ b/__tests__/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.test.ts
@@ -5,6 +5,11 @@ describe("linkPreviewDetection", () => {
     expect(
       containsOpenGraphPreviewLink("[article](https://example.com/post)")
     ).toBe(true);
+    expect(
+      containsOpenGraphPreviewLink(
+        "[wiki](https://en.wikipedia.org/wiki/Function_(mathematics))"
+      )
+    ).toBe(true);
     expect(containsOpenGraphPreviewLink("read https://example.com/post")).toBe(
       true
     );
@@ -20,6 +25,9 @@ describe("linkPreviewDetection", () => {
     expect(containsOpenGraphPreviewLink("https://example.com/image.png")).toBe(
       false
     );
+    expect(
+      containsOpenGraphPreviewLink("![preview](https://example.com/post)")
+    ).toBe(false);
   });
 
   it("ignores urls handled by non-OpenGraph cards", () => {

--- a/__tests__/components/waves/CreateDropContent.refocus.test.tsx
+++ b/__tests__/components/waves/CreateDropContent.refocus.test.tsx
@@ -105,6 +105,7 @@ jest.mock("@/components/waves/CreateDropSubmit", () => ({
     <button
       type="button"
       disabled={!props.canSubmit || props.submitting}
+      title={props.disabledTooltip ?? undefined}
       onClick={() => void props.onDrop()}
     >
       submit
@@ -167,6 +168,7 @@ jest.mock("@/components/auth/SeizeConnectContext", () => ({
 
 const wave = {
   id: "wave-1",
+  author: { handle: "creator" },
   wave: {
     type: ApiWaveType.Rank,
     authenticated_user_eligible_for_admin: false,
@@ -202,10 +204,14 @@ const createStoredDrop = () =>
 const renderSubject = ({
   isDropMode = false,
   isChatBlockedBySlowMode = false,
+  drop = createStoredDrop(),
+  waveOverride = wave,
   submitDrop = jest.fn(() => true),
 }: {
   readonly isDropMode?: boolean;
   readonly isChatBlockedBySlowMode?: boolean;
+  readonly drop?: any;
+  readonly waveOverride?: any;
   readonly submitDrop?: jest.Mock;
 } = {}) => {
   render(
@@ -215,8 +221,8 @@ const renderSubject = ({
       <CreateDropContent
         activeDrop={null}
         onCancelReplyQuote={jest.fn()}
-        wave={wave}
-        drop={createStoredDrop()}
+        wave={waveOverride}
+        drop={drop}
         isStormMode={false}
         isDropMode={isDropMode}
         dropId={null}
@@ -300,6 +306,82 @@ describe("CreateDropContent chat refocus", () => {
     expect(submitDrop).not.toHaveBeenCalled();
     expect(mockInputClear).not.toHaveBeenCalled();
     expect(mockInputFocus).not.toHaveBeenCalled();
+  });
+
+  it("disables chat submit with tooltip while link restriction is active", async () => {
+    const submitDrop = jest.fn(() => true);
+    renderSubject({
+      isDropMode: false,
+      submitDrop,
+      waveOverride: {
+        ...wave,
+        chat: {
+          ...wave.chat,
+          links_disabled: true,
+        },
+      },
+      drop: {
+        ...createStoredDrop(),
+        parts: [
+          {
+            content: "https://example.com/article",
+            quoted_drop: null,
+            media: [],
+          },
+        ],
+      },
+    });
+
+    const submitButton = screen.getByText("submit");
+
+    expect(
+      screen.getByText("Links are not allowed in this wave")
+    ).toBeInTheDocument();
+    expect(submitButton).toBeDisabled();
+    expect(submitButton).toHaveAttribute(
+      "title",
+      "Links are not allowed in this wave"
+    );
+
+    await userEvent.click(submitButton);
+
+    expect(mockRequestAuth).not.toHaveBeenCalled();
+    expect(submitDrop).not.toHaveBeenCalled();
+  });
+
+  it("does not block participatory submit with a link", async () => {
+    const submitDrop = jest.fn(() => true);
+    renderSubject({
+      isDropMode: true,
+      submitDrop,
+      waveOverride: {
+        ...wave,
+        chat: {
+          ...wave.chat,
+          links_disabled: true,
+        },
+      },
+      drop: {
+        ...createStoredDrop(),
+        parts: [
+          {
+            content: "https://example.com/article",
+            quoted_drop: null,
+            media: [],
+          },
+        ],
+      },
+    });
+
+    await userEvent.click(screen.getByText("submit"));
+
+    expect(
+      screen.queryByText("Links are not allowed in this wave")
+    ).not.toBeInTheDocument();
+    await waitFor(() => expect(submitDrop).toHaveBeenCalledTimes(1));
+    expect(submitDrop.mock.calls[0]?.[0].drop.drop_type).toBe(
+      ApiDropType.Participatory
+    );
   });
 
   it("does not refocus after an accepted participatory submit", async () => {

--- a/__tests__/components/waves/drops/EditDropLexical.test.tsx
+++ b/__tests__/components/waves/drops/EditDropLexical.test.tsx
@@ -13,6 +13,7 @@ const useDeviceInfoMock = jest.fn(() => ({
   isApp: false,
   isMobileDevice: false,
 }));
+const mockContainsOpenGraphPreviewLink = jest.fn(() => false);
 
 const rootMock = {
   getChildren: jest.fn(() => [] as unknown[]),
@@ -222,6 +223,13 @@ const {
   exportDropMarkdown: jest.Mock;
 };
 jest.mock(
+  "@/components/drops/view/part/dropPartMarkdown/linkPreviewDetection",
+  () => ({
+    containsOpenGraphPreviewLink: (...args: unknown[]) =>
+      mockContainsOpenGraphPreviewLink(...args),
+  })
+);
+jest.mock(
   "@/components/drops/create/lexical/utils/groupMentionDetection",
   () => ({
     getMentionedGroupsFromEditorState: jest.fn(() => []),
@@ -280,6 +288,7 @@ describe("EditDropLexical", () => {
     rootMock.getChildren.mockReturnValue([]);
     rootMock.getAllTextNodes.mockReturnValue([]);
     mentionSelectHandler = null;
+    mockContainsOpenGraphPreviewLink.mockReturnValue(false);
     useDeviceInfoMock.mockReturnValue({
       isApp: false,
       isMobileDevice: false,
@@ -493,6 +502,36 @@ describe("EditDropLexical", () => {
     });
 
     expect(handled).toBe(true);
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("disables save while the link restriction matches current markdown", async () => {
+    const user = userEvent.setup();
+    const onSave = jest.fn();
+    const onCancel = jest.fn();
+    exportDropMarkdownMock.mockReturnValue("https://example.com/article");
+    mockContainsOpenGraphPreviewLink.mockReturnValue(true);
+
+    render(
+      <EditDropLexical
+        {...defaultProps}
+        linkRestrictionMessage="Links are not allowed in this wave"
+        onSave={onSave}
+        onCancel={onCancel}
+      />
+    );
+
+    const saveButton = screen.getByRole("button", { name: /save/i });
+
+    expect(saveButton).toBeDisabled();
+    expect(saveButton).toHaveAttribute(
+      "title",
+      "Links are not allowed in this wave"
+    );
+
+    await user.click(saveButton);
+
     expect(onSave).not.toHaveBeenCalled();
     expect(onCancel).not.toHaveBeenCalled();
   });

--- a/__tests__/components/waves/specs/WaveSpecs.test.tsx
+++ b/__tests__/components/waves/specs/WaveSpecs.test.tsx
@@ -27,6 +27,7 @@ const makeWave = (
     readonly slowModeCooldownMs?: number | undefined;
     readonly canAdmin?: boolean | undefined;
     readonly chatEnabled?: boolean | undefined;
+    readonly linksDisabled?: boolean | undefined;
     readonly waveType?: ApiWaveType | undefined;
   } = {}
 ): any => ({
@@ -48,6 +49,7 @@ const makeWave = (
     scope: { group: null },
     enabled: overrides.chatEnabled ?? true,
     authenticated_user_eligible: true,
+    links_disabled: overrides.linksDisabled ?? false,
     slow_mode_cooldown_ms: overrides.slowModeCooldownMs,
   },
   participation: {
@@ -115,7 +117,7 @@ describe("WaveSpecs", () => {
     renderWaveSpecs({ wave: makeWave() });
 
     expect(screen.getByText("Slow mode")).toBeInTheDocument();
-    expect(screen.getByText("Off")).toBeInTheDocument();
+    expect(screen.getAllByText("Off").length).toBeGreaterThan(0);
   });
 
   it("shows slow mode on with interval", () => {
@@ -137,6 +139,7 @@ describe("WaveSpecs", () => {
     renderWaveSpecs({ wave: makeWave({ chatEnabled: false }) });
 
     expect(screen.queryByText("Slow mode")).not.toBeInTheDocument();
+    expect(screen.queryByText("Disable links")).not.toBeInTheDocument();
   });
 
   it("shows edit icon only when user can edit wave", () => {
@@ -146,6 +149,9 @@ describe("WaveSpecs", () => {
 
     expect(
       screen.getByRole("button", { name: "Edit slow mode" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Edit disable links" })
     ).toBeInTheDocument();
 
     rerender(
@@ -169,6 +175,9 @@ describe("WaveSpecs", () => {
 
     expect(
       screen.queryByRole("button", { name: "Edit slow mode" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Edit disable links" })
     ).not.toBeInTheDocument();
   });
 
@@ -243,6 +252,7 @@ describe("WaveSpecs", () => {
 
     await waitFor(() => expect(commonApiPostMock).toHaveBeenCalled());
     expect(commonApiPostMock.mock.calls[0][0].body.chat).toMatchObject({
+      links_disabled: false,
       slow_mode_cooldown_ms: 300_000,
     });
   });
@@ -260,5 +270,31 @@ describe("WaveSpecs", () => {
     expect(commonApiPostMock.mock.calls[0][0].body.chat).not.toHaveProperty(
       "slow_mode_cooldown_ms"
     );
+    expect(commonApiPostMock.mock.calls[0][0].body.chat).toMatchObject({
+      links_disabled: false,
+    });
+  });
+
+  it("shows disable links state", () => {
+    renderWaveSpecs({ wave: makeWave({ linksDisabled: true }) });
+
+    expect(screen.getByText("Disable links")).toBeInTheDocument();
+    expect(screen.getByText("On")).toBeInTheDocument();
+  });
+
+  it("saves disable links setting", async () => {
+    const user = userEvent.setup();
+    renderWaveSpecs({ wave: makeWave({ canAdmin: true }) });
+
+    await user.click(
+      screen.getByRole("button", { name: "Edit disable links" })
+    );
+    await user.click(screen.getByLabelText("Disable links"));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(commonApiPostMock).toHaveBeenCalled());
+    expect(commonApiPostMock.mock.calls[0][0].body.chat).toMatchObject({
+      links_disabled: true,
+    });
   });
 });

--- a/__tests__/helpers/waves/waves.helpers.test.ts
+++ b/__tests__/helpers/waves/waves.helpers.test.ts
@@ -110,7 +110,11 @@ describe("waves.helpers", () => {
           forbid_negative_votes: true,
         },
         visibility: { scope: { group_id: "vis" } },
-        chat: { scope: { group_id: "chat" }, enabled: true },
+        chat: {
+          scope: { group_id: "chat" },
+          enabled: true,
+          links_disabled: false,
+        },
         participation: {
           scope: { group_id: "part" },
           no_of_applications_allowed_per_participant: 2,
@@ -142,6 +146,7 @@ describe("waves.helpers", () => {
       expect(result.chat).toEqual({
         scope: { group_id: "chat" },
         enabled: true,
+        links_disabled: false,
         slow_mode_cooldown_ms: 30_000,
       });
     });
@@ -152,6 +157,17 @@ describe("waves.helpers", () => {
       const result = convertWaveToUpdateWave(wave);
 
       expect(result.chat).not.toHaveProperty("slow_mode_cooldown_ms");
+    });
+
+    it("preserves disabled links", () => {
+      const wave = makeWave();
+      wave.chat.links_disabled = true;
+
+      const result = convertWaveToUpdateWave(wave);
+
+      expect(result.chat).toMatchObject({
+        links_disabled: true,
+      });
     });
 
     it.each([

--- a/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.ts
+++ b/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.ts
@@ -1,0 +1,176 @@
+import { ensureStableSeizeLink } from "@/helpers/SeizeLinkParser";
+
+import {
+  isDirectImageUrl,
+  parseUrl,
+  shouldUseOpenGraphPreview,
+} from "./linkUtils";
+
+const MARKDOWN_IMAGE_REGEX = /!\[[^\]\n]*\]\(\s*(?:<[^>\n]*>|[^)\n]*)\s*\)/g;
+const RAW_URL_REGEX = /\b(?:https?:\/\/|www\.)[^\s<>"'`]+/gi;
+
+const stripMarkdownCode = (content: string): string =>
+  content
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/~~~[\s\S]*?~~~/g, " ")
+    .replace(/`[^`\n]*(?:`|$)/g, " ");
+
+const trimTrailingUrlPunctuation = (href: string): string => {
+  let trimmed = href.trim();
+
+  while (/[.,!?;:'"\]]$/.test(trimmed)) {
+    trimmed = trimmed.slice(0, -1);
+  }
+
+  while (
+    trimmed.endsWith(")") &&
+    (trimmed.match(/\)/g)?.length ?? 0) > (trimmed.match(/\(/g)?.length ?? 0)
+  ) {
+    trimmed = trimmed.slice(0, -1);
+  }
+
+  return trimmed;
+};
+
+const normalizeHrefCandidate = (href: string): string => {
+  const withoutAngles =
+    href.startsWith("<") && href.endsWith(">") ? href.slice(1, -1) : href;
+  const trimmed = trimTrailingUrlPunctuation(withoutAngles);
+
+  if (/^www\./i.test(trimmed)) {
+    return `https://${trimmed}`;
+  }
+
+  return trimmed;
+};
+
+const isOpenGraphPreviewHref = (href: string): boolean => {
+  const normalizedHref = normalizeHrefCandidate(href);
+  if (!normalizedHref) {
+    return false;
+  }
+
+  const stableHref = ensureStableSeizeLink(normalizedHref);
+  const parsedUrl = parseUrl(stableHref);
+
+  if (isDirectImageUrl(stableHref, parsedUrl)) {
+    return false;
+  }
+
+  return shouldUseOpenGraphPreview(stableHref, parsedUrl);
+};
+
+const skipWhitespace = (content: string, startIndex: number): number => {
+  let index = startIndex;
+  while (content[index] === " " || content[index] === "\t") {
+    index += 1;
+  }
+
+  return index;
+};
+
+const readAngleWrappedHref = (
+  content: string,
+  hrefStart: number
+): string | null => {
+  const hrefEnd = content.indexOf(">", hrefStart + 1);
+  if (hrefEnd === -1) {
+    return null;
+  }
+
+  return content.slice(hrefStart, hrefEnd + 1);
+};
+
+const readPlainHref = (content: string, hrefStart: number): string | null => {
+  let hrefEnd = hrefStart;
+  while (
+    hrefEnd < content.length &&
+    content[hrefEnd] !== ")" &&
+    content[hrefEnd] !== " " &&
+    content[hrefEnd] !== "\t" &&
+    content[hrefEnd] !== "\n"
+  ) {
+    hrefEnd += 1;
+  }
+
+  if (hrefEnd <= hrefStart) {
+    return null;
+  }
+
+  return content.slice(hrefStart, hrefEnd);
+};
+
+const readMarkdownHref = (
+  content: string,
+  closeBracketIndex: number
+): string | null => {
+  const hrefStart = skipWhitespace(content, closeBracketIndex + 2);
+
+  return content[hrefStart] === "<"
+    ? readAngleWrappedHref(content, hrefStart)
+    : readPlainHref(content, hrefStart);
+};
+
+const isMarkdownImageLink = (
+  content: string,
+  openBracketIndex: number
+): boolean => openBracketIndex > 0 && content[openBracketIndex - 1] === "!";
+
+const extractMarkdownLinkHrefs = (content: string): string[] => {
+  const hrefs: string[] = [];
+  let searchIndex = 0;
+
+  while (searchIndex < content.length) {
+    const closeBracketIndex = content.indexOf("](", searchIndex);
+    if (closeBracketIndex === -1) {
+      break;
+    }
+
+    const openBracketIndex = content.lastIndexOf("[", closeBracketIndex);
+    if (
+      openBracketIndex === -1 ||
+      isMarkdownImageLink(content, openBracketIndex)
+    ) {
+      searchIndex = closeBracketIndex + 2;
+      continue;
+    }
+
+    const href = readMarkdownHref(content, closeBracketIndex);
+    if (href) {
+      hrefs.push(href);
+    }
+
+    searchIndex = closeBracketIndex + 2;
+  }
+
+  return hrefs;
+};
+
+export const containsOpenGraphPreviewLink = (
+  content: string | null | undefined
+): boolean => {
+  if (!content) {
+    return false;
+  }
+
+  const withoutCode = stripMarkdownCode(content);
+  let match: RegExpExecArray | null;
+
+  for (const href of extractMarkdownLinkHrefs(withoutCode)) {
+    if (isOpenGraphPreviewHref(href)) {
+      return true;
+    }
+  }
+
+  const withoutMarkdownImages = withoutCode.replace(MARKDOWN_IMAGE_REGEX, " ");
+
+  RAW_URL_REGEX.lastIndex = 0;
+  while ((match = RAW_URL_REGEX.exec(withoutMarkdownImages)) !== null) {
+    const href = match[0];
+    if (href && isOpenGraphPreviewHref(href)) {
+      return true;
+    }
+  }
+
+  return false;
+};

--- a/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.ts
+++ b/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.ts
@@ -6,7 +6,6 @@ import {
   shouldUseOpenGraphPreview,
 } from "./linkUtils";
 
-const MARKDOWN_IMAGE_REGEX = /!\[[^\]\n]*\]\(\s*(?:<[^>\n]*>|[^)\n]*)\s*\)/g;
 const RAW_URL_REGEX = /\b(?:https?:\/\/|www\.)[^\s<>"'`]+/gi;
 
 const stripMarkdownCode = (content: string): string =>
@@ -69,31 +68,62 @@ const skipWhitespace = (content: string, startIndex: number): number => {
   return index;
 };
 
+const getAngleWrappedHrefEnd = (
+  content: string,
+  hrefStart: number
+): number | null => {
+  const hrefEnd = content.indexOf(">", hrefStart + 1);
+  return hrefEnd === -1 ? null : hrefEnd + 1;
+};
+
 const readAngleWrappedHref = (
   content: string,
   hrefStart: number
 ): string | null => {
-  const hrefEnd = content.indexOf(">", hrefStart + 1);
-  if (hrefEnd === -1) {
+  const hrefEnd = getAngleWrappedHrefEnd(content, hrefStart);
+  if (hrefEnd === null) {
     return null;
   }
 
-  return content.slice(hrefStart, hrefEnd + 1);
+  return content.slice(hrefStart, hrefEnd);
 };
 
-const readPlainHref = (content: string, hrefStart: number): string | null => {
+const isPlainHrefBreak = (character: string | undefined): boolean =>
+  character === " " || character === "\t" || character === "\n";
+
+const getPlainHrefEnd = (content: string, hrefStart: number): number | null => {
   let hrefEnd = hrefStart;
-  while (
-    hrefEnd < content.length &&
-    content[hrefEnd] !== ")" &&
-    content[hrefEnd] !== " " &&
-    content[hrefEnd] !== "\t" &&
-    content[hrefEnd] !== "\n"
-  ) {
+  let parenthesisDepth = 0;
+
+  while (hrefEnd < content.length) {
+    const character = content[hrefEnd];
+    if (character === ")" && parenthesisDepth === 0) {
+      break;
+    }
+
+    if (isPlainHrefBreak(character)) {
+      break;
+    }
+
+    if (character === "(") {
+      parenthesisDepth += 1;
+    } else if (character === ")") {
+      parenthesisDepth -= 1;
+    }
+
     hrefEnd += 1;
   }
 
   if (hrefEnd <= hrefStart) {
+    return null;
+  }
+
+  return hrefEnd;
+};
+
+const readPlainHref = (content: string, hrefStart: number): string | null => {
+  const hrefEnd = getPlainHrefEnd(content, hrefStart);
+  if (hrefEnd === null) {
     return null;
   }
 
@@ -115,6 +145,60 @@ const isMarkdownImageLink = (
   content: string,
   openBracketIndex: number
 ): boolean => openBracketIndex > 0 && content[openBracketIndex - 1] === "!";
+
+const getMarkdownImageEnd = (
+  content: string,
+  imageStartIndex: number
+): number | null => {
+  const closeBracketIndex = content.indexOf("](", imageStartIndex + 2);
+  const newlineIndex = content.indexOf("\n", imageStartIndex + 2);
+
+  if (
+    closeBracketIndex === -1 ||
+    (newlineIndex !== -1 && newlineIndex < closeBracketIndex)
+  ) {
+    return null;
+  }
+
+  const hrefStart = skipWhitespace(content, closeBracketIndex + 2);
+  const hrefEnd =
+    content[hrefStart] === "<"
+      ? getAngleWrappedHrefEnd(content, hrefStart)
+      : getPlainHrefEnd(content, hrefStart);
+
+  if (hrefEnd === null) {
+    return null;
+  }
+
+  const closeParenIndex = skipWhitespace(content, hrefEnd);
+  return content[closeParenIndex] === ")" ? closeParenIndex + 1 : null;
+};
+
+const stripMarkdownImages = (content: string): string => {
+  let stripped = "";
+  let searchIndex = 0;
+
+  while (searchIndex < content.length) {
+    const imageStartIndex = content.indexOf("![", searchIndex);
+    if (imageStartIndex === -1) {
+      stripped += content.slice(searchIndex);
+      break;
+    }
+
+    stripped += content.slice(searchIndex, imageStartIndex);
+    const imageEndIndex = getMarkdownImageEnd(content, imageStartIndex);
+    if (imageEndIndex === null) {
+      stripped += content.slice(imageStartIndex, imageStartIndex + 2);
+      searchIndex = imageStartIndex + 2;
+      continue;
+    }
+
+    stripped += " ";
+    searchIndex = imageEndIndex;
+  }
+
+  return stripped;
+};
 
 const extractMarkdownLinkHrefs = (content: string): string[] => {
   const hrefs: string[] = [];
@@ -162,7 +246,7 @@ export const containsOpenGraphPreviewLink = (
     }
   }
 
-  const withoutMarkdownImages = withoutCode.replace(MARKDOWN_IMAGE_REGEX, " ");
+  const withoutMarkdownImages = stripMarkdownImages(withoutCode);
 
   RAW_URL_REGEX.lastIndex = 0;
   while ((match = RAW_URL_REGEX.exec(withoutMarkdownImages)) !== null) {

--- a/components/waves/CreateDrop.tsx
+++ b/components/waves/CreateDrop.tsx
@@ -18,7 +18,7 @@ import { commonApiPost } from "@/services/api/common-api";
 import type { ApiCreateDropRequest } from "@/generated/models/ApiCreateDropRequest";
 import type { ApiDrop } from "@/generated/models/ApiDrop";
 import { ApiDropType } from "@/generated/models/ApiDropType";
-import { AuthContext } from "../auth/Auth";
+import { useAuth } from "../auth/Auth";
 import { useKeyPressEvent } from "react-use";
 import type { ActiveDropState } from "@/types/dropInteractionTypes";
 import type {
@@ -112,7 +112,7 @@ export default function CreateDrop({
   termsSignatureFlowEnabled = true,
   identityPickerPlacement = "modal",
 }: CreateDropProps) {
-  const { setToast, connectedProfile } = useContext(AuthContext);
+  const { setToast, connectedProfile } = useAuth();
   const { waitAndInvalidateDrops } = useContext(ReactQueryWrapperContext);
   const queryClient = useQueryClient();
   const unreadDividerContext = useUnreadDividerOptional();

--- a/components/waves/CreateDropContent.tsx
+++ b/components/waves/CreateDropContent.tsx
@@ -54,6 +54,7 @@ import { CreateDropSubmit } from "./CreateDropSubmit";
 import SlowModeChatNotice from "./SlowModeChatNotice";
 
 import { exportDropMarkdown } from "@/components/waves/drops/normalizeDropMarkdown";
+import { containsOpenGraphPreviewLink } from "@/components/drops/view/part/dropPartMarkdown/linkPreviewDetection";
 import { getMentionedGroupsFromEditorState } from "@/components/drops/create/lexical/utils/groupMentionDetection";
 import { ProcessIncomingDropType } from "@/contexts/wave/hooks/useWaveRealtimeUpdater";
 import { useMyStream } from "@/contexts/wave/MyStreamContext";
@@ -103,6 +104,11 @@ import type { ApiDropGroupMention } from "@/generated/models/ApiDropGroupMention
 import { getMentionedGroupsFromParts } from "@/helpers/waves/drop-group-mentions";
 import type { IdentityPickerPlacement } from "./dropComposer.types";
 import { XMarkIcon } from "@heroicons/react/24/outline";
+import {
+  CHAT_LINK_RESTRICTION_MESSAGE,
+  areHandlesEqual,
+  isChatLinkRestrictionApplicable,
+} from "@/helpers/waves/chat-link-restriction.helpers";
 
 // Use next/dynamic for lazy loading with SSR support
 const TermsSignatureFlow = dynamic(
@@ -764,7 +770,30 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
 
   const getCanAddPart = () => getHaveMarkdownOrFile() && !getIsDropLimit();
   const isSlowModeSubmitBlocked = isChatBlockedBySlowMode && !isDropMode;
-  const canSubmit = getCanSubmit() && !isSlowModeSubmitBlocked;
+  const isChatLinksRestrictionActive = isChatLinkRestrictionApplicable({
+    dropType: ApiDropType.Chat,
+    linksDisabled: wave.chat.links_disabled === true,
+    isWaveAdmin: wave.wave.authenticated_user_eligible_for_admin === true,
+    isWaveCreator: areHandlesEqual(
+      connectedProfile?.handle,
+      wave.author.handle
+    ),
+  });
+  const hasChatContentWithLink = useMemo(() => {
+    if (!isChatLinksRestrictionActive || isDropMode) {
+      return false;
+    }
+
+    const contentParts = [
+      getMarkdown,
+      ...(drop?.parts.map((part) => part.content ?? null) ?? []),
+    ];
+
+    return contentParts.some(containsOpenGraphPreviewLink);
+  }, [drop?.parts, getMarkdown, isChatLinksRestrictionActive, isDropMode]);
+  const isLinksSubmitBlocked = hasChatContentWithLink;
+  const canSubmit =
+    getCanSubmit() && !isSlowModeSubmitBlocked && !isLinksSubmitBlocked;
   const canAddPart = getCanAddPart();
   const normalizedCurationDropUrl = useMemo(() => {
     if (!isCurationSubmissionExperience || isDropMode) {
@@ -1162,6 +1191,16 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
       return;
     }
 
+    if (
+      dropRequest.drop_type === ApiDropType.Chat &&
+      isChatLinksRestrictionActive &&
+      dropRequest.parts.some((part) =>
+        containsOpenGraphPreviewLink(part.content)
+      )
+    ) {
+      return;
+    }
+
     setSubmitting(true);
     const { success } = await requestAuth();
     if (!success) {
@@ -1304,6 +1343,10 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
     }
 
     if (isSlowModeSubmitBlocked) {
+      return;
+    }
+
+    if (isLinksSubmitBlocked) {
       return;
     }
 
@@ -1869,6 +1912,14 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
             >
               <div className="tw-col-start-2 tw-row-start-1 tw-min-w-0">
                 <SlowModeChatNotice wave={wave} isDropMode={isDropMode} />
+                {isLinksSubmitBlocked && (
+                  <p
+                    className="tw-mb-2 tw-mt-0 tw-text-[11px] tw-font-medium tw-leading-4 tw-text-iron-400"
+                    aria-live="polite"
+                  >
+                    {CHAT_LINK_RESTRICTION_MESSAGE}
+                  </p>
+                )}
               </div>
               <div className="tw-col-start-1 tw-row-start-2 tw-self-center">
                 <CreateDropActions
@@ -1936,6 +1987,9 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
                   canSubmit={canSubmit}
                   onDrop={onDrop}
                   isDropMode={isDropMode}
+                  disabledTooltip={
+                    isLinksSubmitBlocked ? CHAT_LINK_RESTRICTION_MESSAGE : null
+                  }
                 />
               </div>
             </div>

--- a/components/waves/CreateDropSubmit.tsx
+++ b/components/waves/CreateDropSubmit.tsx
@@ -4,6 +4,7 @@ import PrimaryButton from "../utils/button/PrimaryButton";
 interface CreateDropSubmitProps {
   readonly submitting: boolean;
   readonly canSubmit: boolean;
+  readonly disabledTooltip?: string | null | undefined;
   readonly isDropMode: boolean;
   readonly onDrop: () => void;
 }
@@ -11,16 +12,19 @@ interface CreateDropSubmitProps {
 export const CreateDropSubmit: React.FC<CreateDropSubmitProps> = ({
   submitting,
   canSubmit,
+  disabledTooltip = null,
   isDropMode,
   onDrop,
 }) => {
   const submitLabel = isDropMode ? "Drop" : "Post";
+  const title = !canSubmit && disabledTooltip ? disabledTooltip : undefined;
 
-  return (
+  const button = (
     <PrimaryButton
       onClicked={onDrop}
       loading={submitting}
       disabled={!canSubmit}
+      title={title}
       padding="tw-w-10 tw-px-2.5 tw-py-3 lg:tw-w-[3.875rem] lg:tw-px-3.5"
       ariaLabel={submitting ? `${submitLabel} in progress` : submitLabel}
       hideChildrenWhenLoading
@@ -36,5 +40,13 @@ export const CreateDropSubmit: React.FC<CreateDropSubmitProps> = ({
         <path d="M3.478 2.405a.75.75 0 00-.926.94l2.432 7.905H13.5a.75.75 0 010 1.5H4.984l-2.432 7.905a.75.75 0 00.926.94 60.519 60.519 0 0018.445-8.986.75.75 0 000-1.218A60.517 60.517 0 003.478 2.405z" />
       </svg>
     </PrimaryButton>
+  );
+
+  return title ? (
+    <span className="tw-inline-flex" title={title}>
+      {button}
+    </span>
+  ) : (
+    button
   );
 };

--- a/components/waves/drops/EditDropLexical.tsx
+++ b/components/waves/drops/EditDropLexical.tsx
@@ -81,6 +81,7 @@ import {
   normalizeDropMarkdown,
 } from "./normalizeDropMarkdown";
 import { areMentionedGroupsEqual } from "@/helpers/waves/drop-group-mentions";
+import { containsOpenGraphPreviewLink } from "@/components/drops/view/part/dropPartMarkdown/linkPreviewDetection";
 
 interface EditDropLexicalProps {
   readonly initialContent: string;
@@ -90,6 +91,7 @@ interface EditDropLexicalProps {
   readonly canMentionAll: boolean;
   readonly waveId: string | null;
   readonly isSaving: boolean;
+  readonly linkRestrictionMessage?: string | null | undefined;
   readonly onSave: (
     content: string,
     mentions: ApiDropMentionedUser[],
@@ -366,6 +368,7 @@ function KeyboardPlugin({
   onSave,
   onCancel,
   isSaving,
+  isSaveBlocked,
   isMobileOrApp,
   initialContent,
   initialGroupMentions,
@@ -377,6 +380,7 @@ function KeyboardPlugin({
   onSave: () => void;
   onCancel: () => void;
   isSaving: boolean;
+  isSaveBlocked: boolean;
   isMobileOrApp: boolean;
   initialContent: string;
   initialGroupMentions: ApiDropGroupMention[];
@@ -416,7 +420,7 @@ function KeyboardPlugin({
           return false;
         }
 
-        if (!isSaving) {
+        if (!isSaving && !isSaveBlocked) {
           const currentMarkdown = exportDropMarkdown(
             editor.getEditorState(),
             transformers
@@ -454,6 +458,7 @@ function KeyboardPlugin({
     onSave,
     onCancel,
     isSaving,
+    isSaveBlocked,
     isMobileOrApp,
     initialContent,
     initialGroupMentions,
@@ -475,6 +480,7 @@ const EditDropLexical: React.FC<EditDropLexicalProps> = ({
   canMentionAll,
   waveId,
   isSaving,
+  linkRestrictionMessage = null,
   onSave,
   onCancel,
 }) => {
@@ -542,6 +548,18 @@ const EditDropLexical: React.FC<EditDropLexicalProps> = ({
     setEditorState(editorState);
   }, []);
 
+  const currentMarkdown = useMemo(() => {
+    if (!editorState) {
+      return normalizedInitialContent;
+    }
+
+    return removeBlankLinePlaceholders(
+      exportDropMarkdown(editorState, exportMarkdownTransformers)
+    );
+  }, [editorState, exportMarkdownTransformers, normalizedInitialContent]);
+  const isSaveBlockedByLinks =
+    !!linkRestrictionMessage && containsOpenGraphPreviewLink(currentMarkdown);
+
   const handleMentionSelect = useCallback(
     (user: Omit<MentionedUser, "current_handle">) => {
       const newMention: ApiDropMentionedUser = {
@@ -579,13 +597,9 @@ const EditDropLexical: React.FC<EditDropLexicalProps> = ({
 
   const handleSave = useCallback(() => {
     if (!editorState) return;
+    if (isSaveBlockedByLinks) return;
 
-    const markdown = exportDropMarkdown(
-      editorState,
-      exportMarkdownTransformers
-    );
-
-    const sanitizedMarkdown = removeBlankLinePlaceholders(markdown);
+    const sanitizedMarkdown = currentMarkdown;
     const sanitizedMentionedGroups = getMentionedGroupsFromEditorState(
       editorState,
       canResolveAllGroupMention
@@ -612,6 +626,8 @@ const EditDropLexical: React.FC<EditDropLexicalProps> = ({
     mentionedWaves,
     canResolveAllGroupMention,
     initialGroupMentions,
+    currentMarkdown,
+    isSaveBlockedByLinks,
     onSave,
     normalizedInitialContent,
     onCancel,
@@ -669,6 +685,7 @@ const EditDropLexical: React.FC<EditDropLexicalProps> = ({
             onSave={handleSave}
             onCancel={onCancel}
             isSaving={isSaving}
+            isSaveBlocked={isSaveBlockedByLinks}
             isMobileOrApp={isMobileOrApp}
             initialContent={normalizedInitialContent}
             initialGroupMentions={initialGroupMentions}
@@ -692,7 +709,13 @@ const EditDropLexical: React.FC<EditDropLexicalProps> = ({
           {isMobileDevice ? "• " : "• enter to "}
           <button
             onClick={handleSave}
-            className="tw-cursor-pointer tw-rounded-md tw-border-0 tw-bg-transparent tw-px-[3px] tw-font-medium tw-text-primary-400 tw-transition focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-primary-400 desktop-hover:hover:tw-underline"
+            disabled={isSaveBlockedByLinks || isSaving}
+            title={isSaveBlockedByLinks ? linkRestrictionMessage : undefined}
+            className={`tw-rounded-md tw-border-0 tw-bg-transparent tw-px-[3px] tw-font-medium tw-text-primary-400 tw-transition focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-primary-400 ${
+              isSaveBlockedByLinks || isSaving
+                ? "tw-cursor-not-allowed tw-opacity-50"
+                : "tw-cursor-pointer desktop-hover:hover:tw-underline"
+            }`}
           >
             save
           </button>
@@ -711,7 +734,8 @@ const EditDropLexical: React.FC<EditDropLexicalProps> = ({
             </button>
             <button
               onClick={handleSave}
-              disabled={isSaving}
+              disabled={isSaving || isSaveBlockedByLinks}
+              title={isSaveBlockedByLinks ? linkRestrictionMessage : undefined}
               className="tw-rounded-lg tw-border-0 tw-bg-primary-500 tw-px-3 tw-py-1.5 tw-text-sm tw-font-medium tw-text-white tw-transition-colors tw-duration-150 active:tw-bg-primary-600 disabled:tw-opacity-50"
             >
               {isSaving ? "Saving..." : "Save"}

--- a/components/waves/drops/WaveDropPartContentMarkdown.tsx
+++ b/components/waves/drops/WaveDropPartContentMarkdown.tsx
@@ -8,11 +8,19 @@ import type { ApiDropReferencedNFT } from "@/generated/models/ApiDropReferencedN
 import type { ApiMentionedWave } from "@/generated/models/ApiMentionedWave";
 import type { ApiWaveMin } from "@/generated/models/ApiWaveMin";
 import React from "react";
+import { useAuth } from "@/components/auth/Auth";
 import QuorumProposalCompactContent from "@/components/waves/quorum/QuorumProposalCompactContent";
 import { parseQuorumProposalMarkdown } from "@/components/waves/quorum/quorumProposalMarkdown";
 import type { DropContentPresentation } from "./dropContentPresentation";
 import EditDropLexical from "./EditDropLexical";
 import WaveDropQuoteWithDropId from "./WaveDropQuoteWithDropId";
+import { ApiDropType } from "@/generated/models/ApiDropType";
+import type { ApiWaveMinWithChatLinkSettings } from "@/helpers/waves/wave.helpers";
+import {
+  CHAT_LINK_RESTRICTION_MESSAGE,
+  areHandlesEqual,
+  isChatLinkRestrictionApplicable,
+} from "@/helpers/waves/chat-link-restriction.helpers";
 
 interface WaveDropPartContentMarkdownProps {
   readonly mentionedUsers: Array<ApiDropMentionedUser>;
@@ -66,6 +74,7 @@ const WaveDropPartContentMarkdown: React.FC<
   embedDepth,
   maxEmbedDepth,
 }) => {
+  const { connectedProfile } = useAuth();
   const linkPreviewToggleControl = useDropLinkPreviewToggleControl(drop);
   const dropId = drop?.id;
   const dropSerialNo = drop?.serial_no;
@@ -95,6 +104,18 @@ const WaveDropPartContentMarkdown: React.FC<
     contentPresentation === "quorumCompact"
       ? parseQuorumProposalMarkdown(part.content)
       : null;
+  const waveWithLinkSettings = drop?.wave as
+    | ApiWaveMinWithChatLinkSettings
+    | undefined;
+  const editLinkRestrictionApplies = isChatLinkRestrictionApplicable({
+    dropType: drop?.drop_type ?? ApiDropType.Chat,
+    linksDisabled: waveWithLinkSettings?.links_disabled === true,
+    isWaveAdmin: drop?.wave.authenticated_user_admin === true,
+    isWaveCreator: areHandlesEqual(
+      connectedProfile?.handle,
+      waveWithLinkSettings?.wave_author_handle
+    ),
+  });
 
   if (isEditing) {
     return (
@@ -106,6 +127,9 @@ const WaveDropPartContentMarkdown: React.FC<
         canMentionAll={drop?.wave.authenticated_user_admin === true}
         waveId={wave.id}
         isSaving={isSaving}
+        linkRestrictionMessage={
+          editLinkRestrictionApplies ? CHAT_LINK_RESTRICTION_MESSAGE : null
+        }
         onSave={(
           content: string,
           mentions: ApiDropMentionedUser[],

--- a/components/waves/specs/WaveDisableLinks.tsx
+++ b/components/waves/specs/WaveDisableLinks.tsx
@@ -2,9 +2,6 @@
 
 import { useAuth } from "@/components/auth/Auth";
 import { ReactQueryWrapperContext } from "@/components/react-query-wrapper/ReactQueryWrapper";
-import PencilIcon, {
-  PencilIconSize,
-} from "@/components/utils/icons/PencilIcon";
 import type { ApiUpdateWaveRequest } from "@/generated/models/ApiUpdateWaveRequest";
 import type { ApiWave } from "@/generated/models/ApiWave";
 import {
@@ -12,197 +9,30 @@ import {
   convertWaveToUpdateWave,
 } from "@/helpers/waves/waves.helpers";
 import { commonApiPost } from "@/services/api/common-api";
-import {
-  useCallback,
-  useContext,
-  useEffect,
-  useId,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
-import { createPortal } from "react-dom";
+import { useCallback, useContext, useState } from "react";
+import WaveSettingRow from "./WaveSettingRow";
 
 interface WaveDisableLinksProps {
   readonly wave: ApiWave;
 }
 
-const VIEWPORT_PADDING_PX = 16;
-const POPOVER_GAP_PX = 8;
-const POPOVER_WIDTH_PX = 256;
-
-const shouldUseBottomSheet = () => {
-  if (typeof globalThis.matchMedia !== "function") {
-    return false;
-  }
-
-  return globalThis.matchMedia("(max-width: 767px), (pointer: coarse)").matches;
-};
-
-const isInsideElement = (
-  element: HTMLElement | null,
-  target: EventTarget | null
-) => {
-  if (!element || typeof globalThis.Node === "undefined") {
-    return false;
-  }
-
-  return target instanceof globalThis.Node && element.contains(target);
-};
-
 export default function WaveDisableLinks({ wave }: WaveDisableLinksProps) {
   const { connectedProfile, activeProfileProxy, requestAuth, setToast } =
     useAuth();
   const { onWaveCreated } = useContext(ReactQueryWrapperContext);
-  const editorId = useId();
   const canEdit = canEditWave({ connectedProfile, activeProfileProxy, wave });
   const linksDisabled = wave.chat.links_disabled === true;
-  const [isEditorOpen, setIsEditorOpen] = useState(false);
   const [draftLinksDisabled, setDraftLinksDisabled] = useState(linksDisabled);
   const [mutating, setMutating] = useState(false);
-  const [useBottomSheet, setUseBottomSheet] = useState(() =>
-    shouldUseBottomSheet()
-  );
-  const [popoverPosition, setPopoverPosition] = useState<{
-    readonly left: number;
-    readonly top: number;
-  } | null>(null);
-  const editButtonRef = useRef<HTMLButtonElement>(null);
-  const editorRef = useRef<HTMLDivElement>(null);
 
-  const closeEditor = useCallback(() => {
-    setIsEditorOpen(false);
-  }, []);
-
-  useEffect(() => {
-    if (!isEditorOpen) {
-      return;
-    }
-
-    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
-      if (
-        isInsideElement(editorRef.current, event.target) ||
-        isInsideElement(editButtonRef.current, event.target)
-      ) {
-        return;
-      }
-
-      closeEditor();
-    };
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        closeEditor();
-      }
-    };
-
-    globalThis.document.addEventListener("mousedown", handlePointerDown);
-    globalThis.document.addEventListener("touchstart", handlePointerDown);
-    globalThis.document.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      globalThis.document.removeEventListener("mousedown", handlePointerDown);
-      globalThis.document.removeEventListener("touchstart", handlePointerDown);
-      globalThis.document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [closeEditor, isEditorOpen]);
-
-  const openEditor = useCallback(() => {
+  const resetEditor = useCallback(() => {
     setDraftLinksDisabled(linksDisabled);
-    setPopoverPosition(null);
-    setIsEditorOpen(true);
   }, [linksDisabled]);
 
-  const toggleEditor = () => {
-    if (isEditorOpen) {
-      closeEditor();
-      return;
-    }
-
-    openEditor();
-  };
-
-  const updatePopoverPosition = useCallback(() => {
-    if (!isEditorOpen || useBottomSheet) {
-      return;
-    }
-
-    const button = editButtonRef.current;
-    const editor = editorRef.current;
-    if (!button || !editor) {
-      return;
-    }
-
-    const buttonRect = button.getBoundingClientRect();
-    const editorWidth = editor.offsetWidth || POPOVER_WIDTH_PX;
-    const editorHeight = editor.offsetHeight;
-    const viewportWidth =
-      globalThis.innerWidth ||
-      globalThis.document.documentElement.clientWidth ||
-      POPOVER_WIDTH_PX + VIEWPORT_PADDING_PX * 2;
-    const viewportHeight =
-      globalThis.innerHeight ||
-      globalThis.document.documentElement.clientHeight ||
-      editorHeight + VIEWPORT_PADDING_PX * 2;
-
-    const maxLeft = Math.max(
-      VIEWPORT_PADDING_PX,
-      viewportWidth - VIEWPORT_PADDING_PX - editorWidth
-    );
-    const left = Math.min(
-      Math.max(buttonRect.right - editorWidth, VIEWPORT_PADDING_PX),
-      maxLeft
-    );
-
-    const availableAbove = buttonRect.top - VIEWPORT_PADDING_PX;
-    const availableBelow =
-      viewportHeight - buttonRect.bottom - VIEWPORT_PADDING_PX;
-    const shouldOpenAbove =
-      editorHeight > 0 &&
-      availableBelow < editorHeight + POPOVER_GAP_PX &&
-      availableAbove > availableBelow;
-    const unclampedTop = shouldOpenAbove
-      ? buttonRect.top - editorHeight - POPOVER_GAP_PX
-      : buttonRect.bottom + POPOVER_GAP_PX;
-    const maxTop = Math.max(
-      VIEWPORT_PADDING_PX,
-      viewportHeight - VIEWPORT_PADDING_PX - editorHeight
-    );
-    const top = Math.min(Math.max(unclampedTop, VIEWPORT_PADDING_PX), maxTop);
-
-    setPopoverPosition({ left, top });
-  }, [isEditorOpen, useBottomSheet]);
-
-  useEffect(() => {
-    const updateSurfaceMode = () => {
-      setUseBottomSheet(shouldUseBottomSheet());
-    };
-
-    globalThis.addEventListener("resize", updateSurfaceMode);
-
-    return () => {
-      globalThis.removeEventListener("resize", updateSurfaceMode);
-    };
-  }, []);
-
-  useLayoutEffect(() => {
-    updatePopoverPosition();
-  }, [updatePopoverPosition]);
-
-  useEffect(() => {
-    if (!isEditorOpen || useBottomSheet) {
-      return;
-    }
-
-    globalThis.addEventListener("resize", updatePopoverPosition);
-    globalThis.addEventListener("scroll", updatePopoverPosition, true);
-
-    return () => {
-      globalThis.removeEventListener("resize", updatePopoverPosition);
-      globalThis.removeEventListener("scroll", updatePopoverPosition, true);
-    };
-  }, [isEditorOpen, updatePopoverPosition, useBottomSheet]);
-
-  const updateWave = async (body: ApiUpdateWaveRequest): Promise<void> => {
+  const updateWave = async (
+    body: ApiUpdateWaveRequest,
+    closeEditor: () => void
+  ): Promise<void> => {
     setMutating(true);
 
     try {
@@ -231,27 +61,34 @@ export default function WaveDisableLinks({ wave }: WaveDisableLinksProps) {
     }
   };
 
-  const handleSave = () => {
+  const handleSave = (closeEditor: () => void) => {
     if (mutating) {
       return;
     }
 
     const body = convertWaveToUpdateWave(wave);
-    void updateWave({
-      ...body,
-      chat: {
-        ...body.chat,
-        links_disabled: draftLinksDisabled,
+    void updateWave(
+      {
+        ...body,
+        chat: {
+          ...body.chat,
+          links_disabled: draftLinksDisabled,
+        },
       },
-    });
+      closeEditor
+    );
   };
 
-  const editorForm = (
+  const renderEditor = ({
+    closeEditor,
+  }: {
+    readonly closeEditor: () => void;
+  }) => (
     <form
       className="tw-flex tw-flex-col tw-gap-3"
       onSubmit={(event) => {
         event.preventDefault();
-        handleSave();
+        handleSave(closeEditor);
       }}
     >
       <label className="tw-flex tw-cursor-pointer tw-items-start tw-gap-2 tw-text-sm tw-text-iron-100">
@@ -287,75 +124,14 @@ export default function WaveDisableLinks({ wave }: WaveDisableLinksProps) {
     </form>
   );
 
-  const bottomSheetSurface = (
-    <div className="tailwind-scope tw-fixed tw-inset-0 tw-z-[1200] tw-flex tw-items-end tw-bg-black/60 tw-px-3 tw-pb-3 tw-pt-10">
-      <dialog
-        open
-        aria-modal="true"
-        aria-label="Edit disable links"
-        className="tw-relative tw-m-0 tw-w-full tw-max-w-none tw-border-0 tw-bg-transparent tw-p-0 tw-text-inherit"
-      >
-        <div
-          id={editorId}
-          ref={editorRef}
-          className="tw-w-full tw-rounded-t-xl tw-border tw-border-b-0 tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-p-4 tw-shadow-[0_-18px_50px_rgba(0,0,0,0.45)]"
-        >
-          {editorForm}
-        </div>
-      </dialog>
-    </div>
-  );
-  const popoverSurface = (
-    <div
-      className="tailwind-scope tw-fixed tw-z-[1200]"
-      style={{
-        left: popoverPosition?.left ?? 0,
-        top: popoverPosition?.top ?? 0,
-        visibility: popoverPosition ? "visible" : "hidden",
-        width: POPOVER_WIDTH_PX,
-      }}
-    >
-      <div
-        id={editorId}
-        ref={editorRef}
-        className="tw-w-64 tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-p-3 tw-shadow-xl"
-      >
-        {editorForm}
-      </div>
-    </div>
-  );
-  const selectedEditorSurface = useBottomSheet
-    ? bottomSheetSurface
-    : popoverSurface;
-  const editorSurface = isEditorOpen
-    ? createPortal(selectedEditorSurface, globalThis.document.body)
-    : null;
-
   return (
-    <div className="tw-group tw-flex tw-min-h-6 tw-w-full tw-items-center tw-justify-between tw-gap-1.5 tw-text-sm">
-      <span className="tw-font-medium tw-text-iron-400">Disable links</span>
-      <div className="tw-flex tw-items-center tw-gap-x-2">
-        <span className="tw-font-medium tw-text-iron-200">
-          {linksDisabled ? "On" : "Off"}
-        </span>
-        {canEdit && (
-          <button
-            ref={editButtonRef}
-            type="button"
-            aria-label="Edit disable links"
-            aria-controls={editorId}
-            aria-expanded={isEditorOpen}
-            aria-haspopup="dialog"
-            title="Edit disable links"
-            onClick={toggleEditor}
-            className="tw-border-none tw-bg-transparent tw-p-0 tw-text-iron-300 tw-transition-all tw-duration-300 tw-ease-out desktop-hover:hover:tw-text-iron-400"
-          >
-            <PencilIcon size={PencilIconSize.SMALL} />
-          </button>
-        )}
-      </div>
-
-      {editorSurface}
-    </div>
+    <WaveSettingRow
+      canEdit={canEdit}
+      editLabel="Edit disable links"
+      label="Disable links"
+      onOpen={resetEditor}
+      renderEditor={renderEditor}
+      valueLabel={linksDisabled ? "On" : "Off"}
+    />
   );
 }

--- a/components/waves/specs/WaveDisableLinks.tsx
+++ b/components/waves/specs/WaveDisableLinks.tsx
@@ -1,82 +1,29 @@
 "use client";
 
-import { useAuth } from "@/components/auth/Auth";
-import { ReactQueryWrapperContext } from "@/components/react-query-wrapper/ReactQueryWrapper";
-import type { ApiUpdateWaveRequest } from "@/generated/models/ApiUpdateWaveRequest";
 import type { ApiWave } from "@/generated/models/ApiWave";
-import {
-  canEditWave,
-  convertWaveToUpdateWave,
-} from "@/helpers/waves/waves.helpers";
-import { commonApiPost } from "@/services/api/common-api";
-import { useCallback, useContext, useState } from "react";
+import { useCallback, useState } from "react";
+import WaveDisableLinksEditorForm from "./WaveDisableLinksEditorForm";
 import WaveSettingRow from "./WaveSettingRow";
+import { useWaveSettingUpdater } from "./useWaveSettingUpdater";
 
 interface WaveDisableLinksProps {
   readonly wave: ApiWave;
 }
 
 export default function WaveDisableLinks({ wave }: WaveDisableLinksProps) {
-  const { connectedProfile, activeProfileProxy, requestAuth, setToast } =
-    useAuth();
-  const { onWaveCreated } = useContext(ReactQueryWrapperContext);
-  const canEdit = canEditWave({ connectedProfile, activeProfileProxy, wave });
+  const { canEdit, mutating, saveChatUpdate } = useWaveSettingUpdater(wave);
   const linksDisabled = wave.chat.links_disabled === true;
   const [draftLinksDisabled, setDraftLinksDisabled] = useState(linksDisabled);
-  const [mutating, setMutating] = useState(false);
 
   const resetEditor = useCallback(() => {
     setDraftLinksDisabled(linksDisabled);
   }, [linksDisabled]);
 
-  const updateWave = async (
-    body: ApiUpdateWaveRequest,
-    closeEditor: () => void
-  ): Promise<void> => {
-    setMutating(true);
-
-    try {
-      const { success } = await requestAuth();
-      if (!success) {
-        setToast({
-          type: "error",
-          message: "Failed to authenticate",
-        });
-        return;
-      }
-
-      await commonApiPost<ApiUpdateWaveRequest, ApiWave>({
-        endpoint: `waves/${wave.id}`,
-        body,
-      });
-      onWaveCreated();
-      closeEditor();
-    } catch (error) {
-      setToast({
-        message: error instanceof Error ? error.message : String(error),
-        type: "error",
-      });
-    } finally {
-      setMutating(false);
-    }
-  };
-
   const handleSave = (closeEditor: () => void) => {
-    if (mutating) {
-      return;
-    }
-
-    const body = convertWaveToUpdateWave(wave);
-    void updateWave(
-      {
-        ...body,
-        chat: {
-          ...body.chat,
-          links_disabled: draftLinksDisabled,
-        },
-      },
-      closeEditor
-    );
+    saveChatUpdate(closeEditor, (chat) => ({
+      ...chat,
+      links_disabled: draftLinksDisabled,
+    }));
   };
 
   const renderEditor = ({
@@ -84,44 +31,13 @@ export default function WaveDisableLinks({ wave }: WaveDisableLinksProps) {
   }: {
     readonly closeEditor: () => void;
   }) => (
-    <form
-      className="tw-flex tw-flex-col tw-gap-3"
-      onSubmit={(event) => {
-        event.preventDefault();
-        handleSave(closeEditor);
-      }}
-    >
-      <label className="tw-flex tw-cursor-pointer tw-items-start tw-gap-2 tw-text-sm tw-text-iron-100">
-        <input
-          type="checkbox"
-          aria-label="Disable links"
-          autoFocus
-          checked={draftLinksDisabled}
-          disabled={mutating}
-          onChange={(event) => setDraftLinksDisabled(event.target.checked)}
-          className="tw-mt-0.5 tw-h-4 tw-w-4 tw-rounded tw-border-iron-600 tw-bg-iron-900 tw-text-primary-500 focus:tw-ring-primary-400 disabled:tw-cursor-not-allowed disabled:tw-opacity-50"
-        />
-        <span>Disable links</span>
-      </label>
-
-      <div className="tw-flex tw-items-center tw-justify-end tw-gap-2">
-        <button
-          type="button"
-          disabled={mutating}
-          onClick={closeEditor}
-          className="tw-rounded-md tw-border tw-border-solid tw-border-iron-700 tw-bg-transparent tw-px-3 tw-py-2 tw-text-xs tw-font-semibold tw-text-iron-300 tw-transition disabled:tw-cursor-not-allowed disabled:tw-opacity-50 desktop-hover:hover:tw-border-iron-500 desktop-hover:hover:tw-text-iron-100"
-        >
-          Cancel
-        </button>
-        <button
-          type="submit"
-          disabled={mutating}
-          className="tw-rounded-md tw-border tw-border-solid tw-border-primary-500 tw-bg-primary-500 tw-px-3 tw-py-2 tw-text-xs tw-font-semibold tw-text-white tw-transition disabled:tw-cursor-not-allowed disabled:tw-opacity-50 desktop-hover:hover:tw-border-primary-600 desktop-hover:hover:tw-bg-primary-600"
-        >
-          Save
-        </button>
-      </div>
-    </form>
+    <WaveDisableLinksEditorForm
+      checked={draftLinksDisabled}
+      disabled={mutating}
+      onCancel={closeEditor}
+      onCheckedChange={setDraftLinksDisabled}
+      onSave={() => handleSave(closeEditor)}
+    />
   );
 
   return (

--- a/components/waves/specs/WaveDisableLinks.tsx
+++ b/components/waves/specs/WaveDisableLinks.tsx
@@ -8,13 +8,6 @@ import PencilIcon, {
 import type { ApiUpdateWaveRequest } from "@/generated/models/ApiUpdateWaveRequest";
 import type { ApiWave } from "@/generated/models/ApiWave";
 import {
-  SLOW_MODE_MIN_MS,
-  formatSlowModeInterval,
-  getSlowModeInputParts,
-  getSlowModeMs,
-  type SlowModeUnit,
-} from "@/helpers/waves/slow-mode.helpers";
-import {
   canEditWave,
   convertWaveToUpdateWave,
 } from "@/helpers/waves/waves.helpers";
@@ -29,9 +22,8 @@ import {
   useState,
 } from "react";
 import { createPortal } from "react-dom";
-import WaveSlowModeEditorForm from "./WaveSlowModeEditorForm";
 
-interface WaveSlowModeProps {
+interface WaveDisableLinksProps {
   readonly wave: ApiWave;
 }
 
@@ -58,32 +50,25 @@ const isInsideElement = (
   return target instanceof globalThis.Node && element.contains(target);
 };
 
-export default function WaveSlowMode({ wave }: WaveSlowModeProps) {
+export default function WaveDisableLinks({ wave }: WaveDisableLinksProps) {
   const { connectedProfile, activeProfileProxy, requestAuth, setToast } =
     useAuth();
   const { onWaveCreated } = useContext(ReactQueryWrapperContext);
   const editorId = useId();
   const canEdit = canEditWave({ connectedProfile, activeProfileProxy, wave });
-  const cooldownMs = wave.chat.slow_mode_cooldown_ms ?? null;
-  const isSlowModeEnabled =
-    typeof cooldownMs === "number" && cooldownMs >= SLOW_MODE_MIN_MS;
-  const slowModeLabel = isSlowModeEnabled
-    ? `On · ${formatSlowModeInterval(cooldownMs)}`
-    : "Off";
-  const initialParts = getSlowModeInputParts(cooldownMs);
+  const linksDisabled = wave.chat.links_disabled === true;
   const [isEditorOpen, setIsEditorOpen] = useState(false);
-  const [value, setValue] = useState(String(initialParts.value));
-  const [unit, setUnit] = useState<SlowModeUnit>(initialParts.unit);
+  const [draftLinksDisabled, setDraftLinksDisabled] = useState(linksDisabled);
   const [mutating, setMutating] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const [useBottomSheet, setUseBottomSheet] = useState(false);
+  const [useBottomSheet, setUseBottomSheet] = useState(() =>
+    shouldUseBottomSheet()
+  );
   const [popoverPosition, setPopoverPosition] = useState<{
     readonly left: number;
     readonly top: number;
   } | null>(null);
   const editButtonRef = useRef<HTMLButtonElement>(null);
   const editorRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
 
   const closeEditor = useCallback(() => {
     setIsEditorOpen(false);
@@ -122,12 +107,10 @@ export default function WaveSlowMode({ wave }: WaveSlowModeProps) {
   }, [closeEditor, isEditorOpen]);
 
   const openEditor = useCallback(() => {
-    const nextParts = getSlowModeInputParts(cooldownMs);
-    setValue(String(nextParts.value));
-    setUnit(nextParts.unit);
+    setDraftLinksDisabled(linksDisabled);
     setPopoverPosition(null);
     setIsEditorOpen(true);
-  }, [cooldownMs]);
+  }, [linksDisabled]);
 
   const toggleEditor = () => {
     if (isEditorOpen) {
@@ -154,11 +137,11 @@ export default function WaveSlowMode({ wave }: WaveSlowModeProps) {
     const editorHeight = editor.offsetHeight;
     const viewportWidth =
       globalThis.innerWidth ||
-      globalThis.document?.documentElement.clientWidth ||
+      globalThis.document.documentElement.clientWidth ||
       POPOVER_WIDTH_PX + VIEWPORT_PADDING_PX * 2;
     const viewportHeight =
       globalThis.innerHeight ||
-      globalThis.document?.documentElement.clientHeight ||
+      globalThis.document.documentElement.clientHeight ||
       editorHeight + VIEWPORT_PADDING_PX * 2;
 
     const maxLeft = Math.max(
@@ -190,12 +173,10 @@ export default function WaveSlowMode({ wave }: WaveSlowModeProps) {
   }, [isEditorOpen, useBottomSheet]);
 
   useEffect(() => {
-    setMounted(true);
     const updateSurfaceMode = () => {
       setUseBottomSheet(shouldUseBottomSheet());
     };
 
-    updateSurfaceMode();
     globalThis.addEventListener("resize", updateSurfaceMode);
 
     return () => {
@@ -220,15 +201,6 @@ export default function WaveSlowMode({ wave }: WaveSlowModeProps) {
       globalThis.removeEventListener("scroll", updatePopoverPosition, true);
     };
   }, [isEditorOpen, updatePopoverPosition, useBottomSheet]);
-
-  useEffect(() => {
-    if (!isEditorOpen) {
-      return;
-    }
-
-    inputRef.current?.focus();
-    inputRef.current?.select();
-  }, [isEditorOpen, useBottomSheet]);
 
   const updateWave = async (body: ApiUpdateWaveRequest): Promise<void> => {
     setMutating(true);
@@ -264,111 +236,117 @@ export default function WaveSlowMode({ wave }: WaveSlowModeProps) {
       return;
     }
 
-    const parsedValue = Number(value);
-    if (
-      !Number.isInteger(parsedValue) ||
-      parsedValue <= 0 ||
-      getSlowModeMs({ value: parsedValue, unit }) < SLOW_MODE_MIN_MS
-    ) {
-      setToast({
-        type: "error",
-        message: "Slow mode must be at least 1 second",
-      });
-      return;
-    }
-
     const body = convertWaveToUpdateWave(wave);
     void updateWave({
       ...body,
       chat: {
         ...body.chat,
-        slow_mode_cooldown_ms: getSlowModeMs({ value: parsedValue, unit }),
+        links_disabled: draftLinksDisabled,
       },
     });
   };
 
-  const handleDisable = () => {
-    if (mutating) {
-      return;
-    }
-
-    const body = convertWaveToUpdateWave(wave);
-    delete body.chat.slow_mode_cooldown_ms;
-    void updateWave(body);
-  };
-
   const editorForm = (
-    <WaveSlowModeEditorForm
-      disabled={mutating}
-      inputRef={inputRef}
-      isSlowModeEnabled={isSlowModeEnabled}
-      onCancel={closeEditor}
-      onDisable={handleDisable}
-      onSave={handleSave}
-      onUnitChange={setUnit}
-      onValueChange={setValue}
-      unit={unit}
-      value={value}
-    />
+    <form
+      className="tw-flex tw-flex-col tw-gap-3"
+      onSubmit={(event) => {
+        event.preventDefault();
+        handleSave();
+      }}
+    >
+      <label className="tw-flex tw-cursor-pointer tw-items-start tw-gap-2 tw-text-sm tw-text-iron-100">
+        <input
+          type="checkbox"
+          aria-label="Disable links"
+          autoFocus
+          checked={draftLinksDisabled}
+          disabled={mutating}
+          onChange={(event) => setDraftLinksDisabled(event.target.checked)}
+          className="tw-mt-0.5 tw-h-4 tw-w-4 tw-rounded tw-border-iron-600 tw-bg-iron-900 tw-text-primary-500 focus:tw-ring-primary-400 disabled:tw-cursor-not-allowed disabled:tw-opacity-50"
+        />
+        <span>Disable links</span>
+      </label>
+
+      <div className="tw-flex tw-items-center tw-justify-end tw-gap-2">
+        <button
+          type="button"
+          disabled={mutating}
+          onClick={closeEditor}
+          className="tw-rounded-md tw-border tw-border-solid tw-border-iron-700 tw-bg-transparent tw-px-3 tw-py-2 tw-text-xs tw-font-semibold tw-text-iron-300 tw-transition disabled:tw-cursor-not-allowed disabled:tw-opacity-50 desktop-hover:hover:tw-border-iron-500 desktop-hover:hover:tw-text-iron-100"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={mutating}
+          className="tw-rounded-md tw-border tw-border-solid tw-border-primary-500 tw-bg-primary-500 tw-px-3 tw-py-2 tw-text-xs tw-font-semibold tw-text-white tw-transition disabled:tw-cursor-not-allowed disabled:tw-opacity-50 desktop-hover:hover:tw-border-primary-600 desktop-hover:hover:tw-bg-primary-600"
+        >
+          Save
+        </button>
+      </div>
+    </form>
   );
 
-  const editorSurface =
-    mounted && isEditorOpen
-      ? createPortal(
-          useBottomSheet ? (
-            <div className="tailwind-scope tw-fixed tw-inset-0 tw-z-[1200] tw-flex tw-items-end tw-bg-black/60 tw-px-3 tw-pb-3 tw-pt-10">
-              <dialog
-                open
-                aria-modal="true"
-                aria-label="Edit slow mode"
-                className="tw-relative tw-m-0 tw-w-full tw-max-w-none tw-border-0 tw-bg-transparent tw-p-0 tw-text-inherit"
-              >
-                <div
-                  id={editorId}
-                  ref={editorRef}
-                  className="tw-w-full tw-rounded-t-xl tw-border tw-border-b-0 tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-p-4 tw-shadow-[0_-18px_50px_rgba(0,0,0,0.45)]"
-                >
-                  {editorForm}
-                </div>
-              </dialog>
-            </div>
-          ) : (
-            <div
-              className="tailwind-scope tw-fixed tw-z-[1200]"
-              style={{
-                left: popoverPosition?.left ?? 0,
-                top: popoverPosition?.top ?? 0,
-                visibility: popoverPosition ? "visible" : "hidden",
-                width: POPOVER_WIDTH_PX,
-              }}
-            >
-              <div
-                id={editorId}
-                ref={editorRef}
-                className="tw-w-64 tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-p-3 tw-shadow-xl"
-              >
-                {editorForm}
-              </div>
-            </div>
-          ),
-          globalThis.document.body
-        )
-      : null;
+  const bottomSheetSurface = (
+    <div className="tailwind-scope tw-fixed tw-inset-0 tw-z-[1200] tw-flex tw-items-end tw-bg-black/60 tw-px-3 tw-pb-3 tw-pt-10">
+      <dialog
+        open
+        aria-modal="true"
+        aria-label="Edit disable links"
+        className="tw-relative tw-m-0 tw-w-full tw-max-w-none tw-border-0 tw-bg-transparent tw-p-0 tw-text-inherit"
+      >
+        <div
+          id={editorId}
+          ref={editorRef}
+          className="tw-w-full tw-rounded-t-xl tw-border tw-border-b-0 tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-p-4 tw-shadow-[0_-18px_50px_rgba(0,0,0,0.45)]"
+        >
+          {editorForm}
+        </div>
+      </dialog>
+    </div>
+  );
+  const popoverSurface = (
+    <div
+      className="tailwind-scope tw-fixed tw-z-[1200]"
+      style={{
+        left: popoverPosition?.left ?? 0,
+        top: popoverPosition?.top ?? 0,
+        visibility: popoverPosition ? "visible" : "hidden",
+        width: POPOVER_WIDTH_PX,
+      }}
+    >
+      <div
+        id={editorId}
+        ref={editorRef}
+        className="tw-w-64 tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-p-3 tw-shadow-xl"
+      >
+        {editorForm}
+      </div>
+    </div>
+  );
+  const selectedEditorSurface = useBottomSheet
+    ? bottomSheetSurface
+    : popoverSurface;
+  const editorSurface = isEditorOpen
+    ? createPortal(selectedEditorSurface, globalThis.document.body)
+    : null;
 
   return (
     <div className="tw-group tw-flex tw-min-h-6 tw-w-full tw-items-center tw-justify-between tw-gap-1.5 tw-text-sm">
-      <span className="tw-font-medium tw-text-iron-400">Slow mode</span>
+      <span className="tw-font-medium tw-text-iron-400">Disable links</span>
       <div className="tw-flex tw-items-center tw-gap-x-2">
-        <span className="tw-font-medium tw-text-iron-200">{slowModeLabel}</span>
+        <span className="tw-font-medium tw-text-iron-200">
+          {linksDisabled ? "On" : "Off"}
+        </span>
         {canEdit && (
           <button
             ref={editButtonRef}
             type="button"
-            aria-label="Edit slow mode"
+            aria-label="Edit disable links"
             aria-controls={editorId}
             aria-expanded={isEditorOpen}
             aria-haspopup="dialog"
-            title="Edit slow mode"
+            title="Edit disable links"
             onClick={toggleEditor}
             className="tw-border-none tw-bg-transparent tw-p-0 tw-text-iron-300 tw-transition-all tw-duration-300 tw-ease-out desktop-hover:hover:tw-text-iron-400"
           >

--- a/components/waves/specs/WaveDisableLinksEditorForm.tsx
+++ b/components/waves/specs/WaveDisableLinksEditorForm.tsx
@@ -1,0 +1,42 @@
+import WaveSettingEditorActions from "./WaveSettingEditorActions";
+
+interface WaveDisableLinksEditorFormProps {
+  readonly checked: boolean;
+  readonly disabled: boolean;
+  readonly onCancel: () => void;
+  readonly onCheckedChange: (checked: boolean) => void;
+  readonly onSave: () => void;
+}
+
+export default function WaveDisableLinksEditorForm({
+  checked,
+  disabled,
+  onCancel,
+  onCheckedChange,
+  onSave,
+}: WaveDisableLinksEditorFormProps) {
+  return (
+    <form
+      className="tw-flex tw-flex-col tw-gap-3"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSave();
+      }}
+    >
+      <label className="tw-flex tw-cursor-pointer tw-items-start tw-gap-2 tw-text-sm tw-text-iron-100">
+        <input
+          type="checkbox"
+          aria-label="Disable links"
+          autoFocus
+          checked={checked}
+          disabled={disabled}
+          onChange={(event) => onCheckedChange(event.target.checked)}
+          className="tw-mt-0.5 tw-h-4 tw-w-4 tw-rounded tw-border-iron-600 tw-bg-iron-900 tw-text-primary-500 focus:tw-ring-primary-400 disabled:tw-cursor-not-allowed disabled:tw-opacity-50"
+        />
+        <span>Disable links</span>
+      </label>
+
+      <WaveSettingEditorActions disabled={disabled} onCancel={onCancel} />
+    </form>
+  );
+}

--- a/components/waves/specs/WaveSettingEditorActions.tsx
+++ b/components/waves/specs/WaveSettingEditorActions.tsx
@@ -1,0 +1,45 @@
+interface WaveSettingEditorActionsProps {
+  readonly disabled: boolean;
+  readonly secondaryAction?: {
+    readonly disabled: boolean;
+    readonly label: string;
+    readonly onClick: () => void;
+  } | null;
+  readonly onCancel: () => void;
+}
+
+export default function WaveSettingEditorActions({
+  disabled,
+  onCancel,
+  secondaryAction = null,
+}: WaveSettingEditorActionsProps) {
+  return (
+    <div className="tw-flex tw-items-center tw-justify-end tw-gap-2">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onCancel}
+        className="tw-rounded-md tw-border tw-border-solid tw-border-iron-700 tw-bg-transparent tw-px-3 tw-py-2 tw-text-xs tw-font-semibold tw-text-iron-300 tw-transition disabled:tw-cursor-not-allowed disabled:tw-opacity-50 desktop-hover:hover:tw-border-iron-500 desktop-hover:hover:tw-text-iron-100"
+      >
+        Cancel
+      </button>
+      {secondaryAction && (
+        <button
+          type="button"
+          disabled={disabled || secondaryAction.disabled}
+          onClick={secondaryAction.onClick}
+          className="tw-rounded-md tw-border tw-border-solid tw-border-red/40 tw-bg-transparent tw-px-3 tw-py-2 tw-text-xs tw-font-semibold tw-text-red tw-transition disabled:tw-cursor-not-allowed disabled:tw-opacity-50 desktop-hover:hover:tw-border-red desktop-hover:hover:tw-text-red"
+        >
+          {secondaryAction.label}
+        </button>
+      )}
+      <button
+        type="submit"
+        disabled={disabled}
+        className="tw-rounded-md tw-border tw-border-solid tw-border-primary-500 tw-bg-primary-500 tw-px-3 tw-py-2 tw-text-xs tw-font-semibold tw-text-white tw-transition disabled:tw-cursor-not-allowed disabled:tw-opacity-50 desktop-hover:hover:tw-border-primary-600 desktop-hover:hover:tw-bg-primary-600"
+      >
+        Save
+      </button>
+    </div>
+  );
+}

--- a/components/waves/specs/WaveSettingRow.tsx
+++ b/components/waves/specs/WaveSettingRow.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import PencilIcon, {
+  PencilIconSize,
+} from "@/components/utils/icons/PencilIcon";
+import type { ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+interface WaveSettingRowProps {
+  readonly canEdit: boolean;
+  readonly editLabel: string;
+  readonly label: string;
+  readonly onOpen: () => void;
+  readonly renderEditor: (controls: {
+    readonly closeEditor: () => void;
+  }) => ReactNode;
+  readonly valueLabel: ReactNode;
+}
+
+const VIEWPORT_PADDING_PX = 16;
+const POPOVER_GAP_PX = 8;
+const POPOVER_WIDTH_PX = 256;
+
+const shouldUseBottomSheet = () => {
+  if (typeof globalThis.matchMedia !== "function") {
+    return false;
+  }
+
+  return globalThis.matchMedia("(max-width: 767px), (pointer: coarse)").matches;
+};
+
+const isInsideElement = (
+  element: HTMLElement | null,
+  target: EventTarget | null
+) => {
+  if (!element || typeof globalThis.Node === "undefined") {
+    return false;
+  }
+
+  return target instanceof globalThis.Node && element.contains(target);
+};
+
+export default function WaveSettingRow({
+  canEdit,
+  editLabel,
+  label,
+  onOpen,
+  renderEditor,
+  valueLabel,
+}: WaveSettingRowProps) {
+  const editorId = useId();
+  const [isEditorOpen, setIsEditorOpen] = useState(false);
+  const [useBottomSheet, setUseBottomSheet] = useState(() =>
+    shouldUseBottomSheet()
+  );
+  const [popoverPosition, setPopoverPosition] = useState<{
+    readonly left: number;
+    readonly top: number;
+  } | null>(null);
+  const editButtonRef = useRef<HTMLButtonElement>(null);
+  const editorRef = useRef<HTMLDivElement>(null);
+
+  const closeEditor = useCallback(() => {
+    setIsEditorOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (!isEditorOpen) {
+      return;
+    }
+
+    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      if (
+        isInsideElement(editorRef.current, event.target) ||
+        isInsideElement(editButtonRef.current, event.target)
+      ) {
+        return;
+      }
+
+      closeEditor();
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeEditor();
+      }
+    };
+
+    globalThis.document.addEventListener("mousedown", handlePointerDown);
+    globalThis.document.addEventListener("touchstart", handlePointerDown);
+    globalThis.document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      globalThis.document.removeEventListener("mousedown", handlePointerDown);
+      globalThis.document.removeEventListener("touchstart", handlePointerDown);
+      globalThis.document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [closeEditor, isEditorOpen]);
+
+  const openEditor = useCallback(() => {
+    onOpen();
+    setPopoverPosition(null);
+    setIsEditorOpen(true);
+  }, [onOpen]);
+
+  const toggleEditor = () => {
+    if (isEditorOpen) {
+      closeEditor();
+      return;
+    }
+
+    openEditor();
+  };
+
+  const updatePopoverPosition = useCallback(() => {
+    if (!isEditorOpen || useBottomSheet) {
+      return;
+    }
+
+    const button = editButtonRef.current;
+    const editor = editorRef.current;
+    if (!button || !editor) {
+      return;
+    }
+
+    const buttonRect = button.getBoundingClientRect();
+    const editorWidth = editor.offsetWidth || POPOVER_WIDTH_PX;
+    const editorHeight = editor.offsetHeight;
+    const viewportWidth =
+      globalThis.innerWidth ||
+      globalThis.document.documentElement.clientWidth ||
+      POPOVER_WIDTH_PX + VIEWPORT_PADDING_PX * 2;
+    const viewportHeight =
+      globalThis.innerHeight ||
+      globalThis.document.documentElement.clientHeight ||
+      editorHeight + VIEWPORT_PADDING_PX * 2;
+
+    const maxLeft = Math.max(
+      VIEWPORT_PADDING_PX,
+      viewportWidth - VIEWPORT_PADDING_PX - editorWidth
+    );
+    const left = Math.min(
+      Math.max(buttonRect.right - editorWidth, VIEWPORT_PADDING_PX),
+      maxLeft
+    );
+
+    const availableAbove = buttonRect.top - VIEWPORT_PADDING_PX;
+    const availableBelow =
+      viewportHeight - buttonRect.bottom - VIEWPORT_PADDING_PX;
+    const shouldOpenAbove =
+      editorHeight > 0 &&
+      availableBelow < editorHeight + POPOVER_GAP_PX &&
+      availableAbove > availableBelow;
+    const unclampedTop = shouldOpenAbove
+      ? buttonRect.top - editorHeight - POPOVER_GAP_PX
+      : buttonRect.bottom + POPOVER_GAP_PX;
+    const maxTop = Math.max(
+      VIEWPORT_PADDING_PX,
+      viewportHeight - VIEWPORT_PADDING_PX - editorHeight
+    );
+    const top = Math.min(Math.max(unclampedTop, VIEWPORT_PADDING_PX), maxTop);
+
+    setPopoverPosition({ left, top });
+  }, [isEditorOpen, useBottomSheet]);
+
+  useEffect(() => {
+    const updateSurfaceMode = () => {
+      setUseBottomSheet(shouldUseBottomSheet());
+    };
+
+    globalThis.addEventListener("resize", updateSurfaceMode);
+
+    return () => {
+      globalThis.removeEventListener("resize", updateSurfaceMode);
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    updatePopoverPosition();
+  }, [updatePopoverPosition]);
+
+  useEffect(() => {
+    if (!isEditorOpen || useBottomSheet) {
+      return;
+    }
+
+    globalThis.addEventListener("resize", updatePopoverPosition);
+    globalThis.addEventListener("scroll", updatePopoverPosition, true);
+
+    return () => {
+      globalThis.removeEventListener("resize", updatePopoverPosition);
+      globalThis.removeEventListener("scroll", updatePopoverPosition, true);
+    };
+  }, [isEditorOpen, updatePopoverPosition, useBottomSheet]);
+
+  const editorForm = isEditorOpen ? renderEditor({ closeEditor }) : null;
+  const bottomSheetSurface = (
+    <div className="tailwind-scope tw-fixed tw-inset-0 tw-z-[1200] tw-flex tw-items-end tw-bg-black/60 tw-px-3 tw-pb-3 tw-pt-10">
+      <dialog
+        open
+        aria-modal="true"
+        aria-label={editLabel}
+        className="tw-relative tw-m-0 tw-w-full tw-max-w-none tw-border-0 tw-bg-transparent tw-p-0 tw-text-inherit"
+      >
+        <div
+          id={editorId}
+          ref={editorRef}
+          className="tw-w-full tw-rounded-t-xl tw-border tw-border-b-0 tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-p-4 tw-shadow-[0_-18px_50px_rgba(0,0,0,0.45)]"
+        >
+          {editorForm}
+        </div>
+      </dialog>
+    </div>
+  );
+  const popoverSurface = (
+    <div
+      className="tailwind-scope tw-fixed tw-z-[1200]"
+      style={{
+        left: popoverPosition?.left ?? 0,
+        top: popoverPosition?.top ?? 0,
+        visibility: popoverPosition ? "visible" : "hidden",
+        width: POPOVER_WIDTH_PX,
+      }}
+    >
+      <div
+        id={editorId}
+        ref={editorRef}
+        className="tw-w-64 tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-p-3 tw-shadow-xl"
+      >
+        {editorForm}
+      </div>
+    </div>
+  );
+  const selectedEditorSurface = useBottomSheet
+    ? bottomSheetSurface
+    : popoverSurface;
+  const editorSurface = isEditorOpen
+    ? createPortal(selectedEditorSurface, globalThis.document.body)
+    : null;
+
+  return (
+    <div className="tw-group tw-flex tw-min-h-6 tw-w-full tw-items-center tw-justify-between tw-gap-1.5 tw-text-sm">
+      <span className="tw-font-medium tw-text-iron-400">{label}</span>
+      <div className="tw-flex tw-items-center tw-gap-x-2">
+        <span className="tw-font-medium tw-text-iron-200">{valueLabel}</span>
+        {canEdit && (
+          <button
+            ref={editButtonRef}
+            type="button"
+            aria-label={editLabel}
+            aria-controls={editorId}
+            aria-expanded={isEditorOpen}
+            aria-haspopup="dialog"
+            title={editLabel}
+            onClick={toggleEditor}
+            className="tw-border-none tw-bg-transparent tw-p-0 tw-text-iron-300 tw-transition-all tw-duration-300 tw-ease-out desktop-hover:hover:tw-text-iron-400"
+          >
+            <PencilIcon size={PencilIconSize.SMALL} />
+          </button>
+        )}
+      </div>
+
+      {editorSurface}
+    </div>
+  );
+}

--- a/components/waves/specs/WaveSlowMode.tsx
+++ b/components/waves/specs/WaveSlowMode.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { useAuth } from "@/components/auth/Auth";
-import { ReactQueryWrapperContext } from "@/components/react-query-wrapper/ReactQueryWrapper";
-import type { ApiUpdateWaveRequest } from "@/generated/models/ApiUpdateWaveRequest";
 import type { ApiWave } from "@/generated/models/ApiWave";
 import {
   SLOW_MODE_MIN_MS,
@@ -11,24 +8,18 @@ import {
   getSlowModeMs,
   type SlowModeUnit,
 } from "@/helpers/waves/slow-mode.helpers";
-import {
-  canEditWave,
-  convertWaveToUpdateWave,
-} from "@/helpers/waves/waves.helpers";
-import { commonApiPost } from "@/services/api/common-api";
-import { useCallback, useContext, useRef, useState } from "react";
-import WaveSlowModeEditorForm from "./WaveSlowModeEditorForm";
+import { useCallback, useRef, useState } from "react";
 import WaveSettingRow from "./WaveSettingRow";
+import WaveSlowModeEditorForm from "./WaveSlowModeEditorForm";
+import { useWaveSettingUpdater } from "./useWaveSettingUpdater";
 
 interface WaveSlowModeProps {
   readonly wave: ApiWave;
 }
 
 export default function WaveSlowMode({ wave }: WaveSlowModeProps) {
-  const { connectedProfile, activeProfileProxy, requestAuth, setToast } =
-    useAuth();
-  const { onWaveCreated } = useContext(ReactQueryWrapperContext);
-  const canEdit = canEditWave({ connectedProfile, activeProfileProxy, wave });
+  const { canEdit, mutating, saveChatUpdate, setToast } =
+    useWaveSettingUpdater(wave);
   const cooldownMs = wave.chat.slow_mode_cooldown_ms ?? null;
   const isSlowModeEnabled =
     typeof cooldownMs === "number" && cooldownMs >= SLOW_MODE_MIN_MS;
@@ -38,7 +29,6 @@ export default function WaveSlowMode({ wave }: WaveSlowModeProps) {
   const initialParts = getSlowModeInputParts(cooldownMs);
   const [value, setValue] = useState(String(initialParts.value));
   const [unit, setUnit] = useState<SlowModeUnit>(initialParts.unit);
-  const [mutating, setMutating] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const resetEditor = useCallback(() => {
@@ -47,43 +37,7 @@ export default function WaveSlowMode({ wave }: WaveSlowModeProps) {
     setUnit(nextParts.unit);
   }, [cooldownMs]);
 
-  const updateWave = async (
-    body: ApiUpdateWaveRequest,
-    closeEditor: () => void
-  ): Promise<void> => {
-    setMutating(true);
-
-    try {
-      const { success } = await requestAuth();
-      if (!success) {
-        setToast({
-          type: "error",
-          message: "Failed to authenticate",
-        });
-        return;
-      }
-
-      await commonApiPost<ApiUpdateWaveRequest, ApiWave>({
-        endpoint: `waves/${wave.id}`,
-        body,
-      });
-      onWaveCreated();
-      closeEditor();
-    } catch (error) {
-      setToast({
-        message: error instanceof Error ? error.message : String(error),
-        type: "error",
-      });
-    } finally {
-      setMutating(false);
-    }
-  };
-
   const handleSave = (closeEditor: () => void) => {
-    if (mutating) {
-      return;
-    }
-
     const parsedValue = Number(value);
     if (
       !Number.isInteger(parsedValue) ||
@@ -97,28 +51,38 @@ export default function WaveSlowMode({ wave }: WaveSlowModeProps) {
       return;
     }
 
-    const body = convertWaveToUpdateWave(wave);
-    void updateWave(
-      {
-        ...body,
-        chat: {
-          ...body.chat,
-          slow_mode_cooldown_ms: getSlowModeMs({ value: parsedValue, unit }),
-        },
-      },
-      closeEditor
-    );
+    saveChatUpdate(closeEditor, (chat) => ({
+      ...chat,
+      slow_mode_cooldown_ms: getSlowModeMs({ value: parsedValue, unit }),
+    }));
   };
 
   const handleDisable = (closeEditor: () => void) => {
-    if (mutating) {
-      return;
-    }
-
-    const body = convertWaveToUpdateWave(wave);
-    delete body.chat.slow_mode_cooldown_ms;
-    void updateWave(body, closeEditor);
+    saveChatUpdate(closeEditor, (chat) => {
+      const nextChat = { ...chat };
+      delete nextChat.slow_mode_cooldown_ms;
+      return nextChat;
+    });
   };
+
+  const renderEditor = ({
+    closeEditor,
+  }: {
+    readonly closeEditor: () => void;
+  }) => (
+    <WaveSlowModeEditorForm
+      disabled={mutating}
+      inputRef={inputRef}
+      isSlowModeEnabled={isSlowModeEnabled}
+      onCancel={closeEditor}
+      onDisable={() => handleDisable(closeEditor)}
+      onSave={() => handleSave(closeEditor)}
+      onUnitChange={setUnit}
+      onValueChange={setValue}
+      unit={unit}
+      value={value}
+    />
+  );
 
   return (
     <WaveSettingRow
@@ -126,21 +90,8 @@ export default function WaveSlowMode({ wave }: WaveSlowModeProps) {
       editLabel="Edit slow mode"
       label="Slow mode"
       onOpen={resetEditor}
+      renderEditor={renderEditor}
       valueLabel={slowModeLabel}
-      renderEditor={({ closeEditor }) => (
-        <WaveSlowModeEditorForm
-          disabled={mutating}
-          inputRef={inputRef}
-          isSlowModeEnabled={isSlowModeEnabled}
-          onCancel={closeEditor}
-          onDisable={() => handleDisable(closeEditor)}
-          onSave={() => handleSave(closeEditor)}
-          onUnitChange={setUnit}
-          onValueChange={setValue}
-          unit={unit}
-          value={value}
-        />
-      )}
     />
   );
 }

--- a/components/waves/specs/WaveSlowMode.tsx
+++ b/components/waves/specs/WaveSlowMode.tsx
@@ -2,9 +2,6 @@
 
 import { useAuth } from "@/components/auth/Auth";
 import { ReactQueryWrapperContext } from "@/components/react-query-wrapper/ReactQueryWrapper";
-import PencilIcon, {
-  PencilIconSize,
-} from "@/components/utils/icons/PencilIcon";
 import type { ApiUpdateWaveRequest } from "@/generated/models/ApiUpdateWaveRequest";
 import type { ApiWave } from "@/generated/models/ApiWave";
 import {
@@ -19,50 +16,18 @@ import {
   convertWaveToUpdateWave,
 } from "@/helpers/waves/waves.helpers";
 import { commonApiPost } from "@/services/api/common-api";
-import {
-  useCallback,
-  useContext,
-  useEffect,
-  useId,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from "react";
-import { createPortal } from "react-dom";
+import { useCallback, useContext, useRef, useState } from "react";
 import WaveSlowModeEditorForm from "./WaveSlowModeEditorForm";
+import WaveSettingRow from "./WaveSettingRow";
 
 interface WaveSlowModeProps {
   readonly wave: ApiWave;
 }
 
-const VIEWPORT_PADDING_PX = 16;
-const POPOVER_GAP_PX = 8;
-const POPOVER_WIDTH_PX = 256;
-
-const shouldUseBottomSheet = () => {
-  if (typeof globalThis.matchMedia !== "function") {
-    return false;
-  }
-
-  return globalThis.matchMedia("(max-width: 767px), (pointer: coarse)").matches;
-};
-
-const isInsideElement = (
-  element: HTMLElement | null,
-  target: EventTarget | null
-) => {
-  if (!element || typeof globalThis.Node === "undefined") {
-    return false;
-  }
-
-  return target instanceof globalThis.Node && element.contains(target);
-};
-
 export default function WaveSlowMode({ wave }: WaveSlowModeProps) {
   const { connectedProfile, activeProfileProxy, requestAuth, setToast } =
     useAuth();
   const { onWaveCreated } = useContext(ReactQueryWrapperContext);
-  const editorId = useId();
   const canEdit = canEditWave({ connectedProfile, activeProfileProxy, wave });
   const cooldownMs = wave.chat.slow_mode_cooldown_ms ?? null;
   const isSlowModeEnabled =
@@ -71,166 +36,21 @@ export default function WaveSlowMode({ wave }: WaveSlowModeProps) {
     ? `On · ${formatSlowModeInterval(cooldownMs)}`
     : "Off";
   const initialParts = getSlowModeInputParts(cooldownMs);
-  const [isEditorOpen, setIsEditorOpen] = useState(false);
   const [value, setValue] = useState(String(initialParts.value));
   const [unit, setUnit] = useState<SlowModeUnit>(initialParts.unit);
   const [mutating, setMutating] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const [useBottomSheet, setUseBottomSheet] = useState(false);
-  const [popoverPosition, setPopoverPosition] = useState<{
-    readonly left: number;
-    readonly top: number;
-  } | null>(null);
-  const editButtonRef = useRef<HTMLButtonElement>(null);
-  const editorRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const closeEditor = useCallback(() => {
-    setIsEditorOpen(false);
-  }, []);
-
-  useEffect(() => {
-    if (!isEditorOpen) {
-      return;
-    }
-
-    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
-      if (
-        isInsideElement(editorRef.current, event.target) ||
-        isInsideElement(editButtonRef.current, event.target)
-      ) {
-        return;
-      }
-
-      closeEditor();
-    };
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        closeEditor();
-      }
-    };
-
-    globalThis.document.addEventListener("mousedown", handlePointerDown);
-    globalThis.document.addEventListener("touchstart", handlePointerDown);
-    globalThis.document.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      globalThis.document.removeEventListener("mousedown", handlePointerDown);
-      globalThis.document.removeEventListener("touchstart", handlePointerDown);
-      globalThis.document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [closeEditor, isEditorOpen]);
-
-  const openEditor = useCallback(() => {
+  const resetEditor = useCallback(() => {
     const nextParts = getSlowModeInputParts(cooldownMs);
     setValue(String(nextParts.value));
     setUnit(nextParts.unit);
-    setPopoverPosition(null);
-    setIsEditorOpen(true);
   }, [cooldownMs]);
 
-  const toggleEditor = () => {
-    if (isEditorOpen) {
-      closeEditor();
-      return;
-    }
-
-    openEditor();
-  };
-
-  const updatePopoverPosition = useCallback(() => {
-    if (!isEditorOpen || useBottomSheet) {
-      return;
-    }
-
-    const button = editButtonRef.current;
-    const editor = editorRef.current;
-    if (!button || !editor) {
-      return;
-    }
-
-    const buttonRect = button.getBoundingClientRect();
-    const editorWidth = editor.offsetWidth || POPOVER_WIDTH_PX;
-    const editorHeight = editor.offsetHeight;
-    const viewportWidth =
-      globalThis.innerWidth ||
-      globalThis.document?.documentElement.clientWidth ||
-      POPOVER_WIDTH_PX + VIEWPORT_PADDING_PX * 2;
-    const viewportHeight =
-      globalThis.innerHeight ||
-      globalThis.document?.documentElement.clientHeight ||
-      editorHeight + VIEWPORT_PADDING_PX * 2;
-
-    const maxLeft = Math.max(
-      VIEWPORT_PADDING_PX,
-      viewportWidth - VIEWPORT_PADDING_PX - editorWidth
-    );
-    const left = Math.min(
-      Math.max(buttonRect.right - editorWidth, VIEWPORT_PADDING_PX),
-      maxLeft
-    );
-
-    const availableAbove = buttonRect.top - VIEWPORT_PADDING_PX;
-    const availableBelow =
-      viewportHeight - buttonRect.bottom - VIEWPORT_PADDING_PX;
-    const shouldOpenAbove =
-      editorHeight > 0 &&
-      availableBelow < editorHeight + POPOVER_GAP_PX &&
-      availableAbove > availableBelow;
-    const unclampedTop = shouldOpenAbove
-      ? buttonRect.top - editorHeight - POPOVER_GAP_PX
-      : buttonRect.bottom + POPOVER_GAP_PX;
-    const maxTop = Math.max(
-      VIEWPORT_PADDING_PX,
-      viewportHeight - VIEWPORT_PADDING_PX - editorHeight
-    );
-    const top = Math.min(Math.max(unclampedTop, VIEWPORT_PADDING_PX), maxTop);
-
-    setPopoverPosition({ left, top });
-  }, [isEditorOpen, useBottomSheet]);
-
-  useEffect(() => {
-    setMounted(true);
-    const updateSurfaceMode = () => {
-      setUseBottomSheet(shouldUseBottomSheet());
-    };
-
-    updateSurfaceMode();
-    globalThis.addEventListener("resize", updateSurfaceMode);
-
-    return () => {
-      globalThis.removeEventListener("resize", updateSurfaceMode);
-    };
-  }, []);
-
-  useLayoutEffect(() => {
-    updatePopoverPosition();
-  }, [updatePopoverPosition]);
-
-  useEffect(() => {
-    if (!isEditorOpen || useBottomSheet) {
-      return;
-    }
-
-    globalThis.addEventListener("resize", updatePopoverPosition);
-    globalThis.addEventListener("scroll", updatePopoverPosition, true);
-
-    return () => {
-      globalThis.removeEventListener("resize", updatePopoverPosition);
-      globalThis.removeEventListener("scroll", updatePopoverPosition, true);
-    };
-  }, [isEditorOpen, updatePopoverPosition, useBottomSheet]);
-
-  useEffect(() => {
-    if (!isEditorOpen) {
-      return;
-    }
-
-    inputRef.current?.focus();
-    inputRef.current?.select();
-  }, [isEditorOpen, useBottomSheet]);
-
-  const updateWave = async (body: ApiUpdateWaveRequest): Promise<void> => {
+  const updateWave = async (
+    body: ApiUpdateWaveRequest,
+    closeEditor: () => void
+  ): Promise<void> => {
     setMutating(true);
 
     try {
@@ -259,7 +79,7 @@ export default function WaveSlowMode({ wave }: WaveSlowModeProps) {
     }
   };
 
-  const handleSave = () => {
+  const handleSave = (closeEditor: () => void) => {
     if (mutating) {
       return;
     }
@@ -278,106 +98,49 @@ export default function WaveSlowMode({ wave }: WaveSlowModeProps) {
     }
 
     const body = convertWaveToUpdateWave(wave);
-    void updateWave({
-      ...body,
-      chat: {
-        ...body.chat,
-        slow_mode_cooldown_ms: getSlowModeMs({ value: parsedValue, unit }),
+    void updateWave(
+      {
+        ...body,
+        chat: {
+          ...body.chat,
+          slow_mode_cooldown_ms: getSlowModeMs({ value: parsedValue, unit }),
+        },
       },
-    });
+      closeEditor
+    );
   };
 
-  const handleDisable = () => {
+  const handleDisable = (closeEditor: () => void) => {
     if (mutating) {
       return;
     }
 
     const body = convertWaveToUpdateWave(wave);
     delete body.chat.slow_mode_cooldown_ms;
-    void updateWave(body);
+    void updateWave(body, closeEditor);
   };
 
-  const editorForm = (
-    <WaveSlowModeEditorForm
-      disabled={mutating}
-      inputRef={inputRef}
-      isSlowModeEnabled={isSlowModeEnabled}
-      onCancel={closeEditor}
-      onDisable={handleDisable}
-      onSave={handleSave}
-      onUnitChange={setUnit}
-      onValueChange={setValue}
-      unit={unit}
-      value={value}
-    />
-  );
-
-  const editorSurface =
-    mounted && isEditorOpen
-      ? createPortal(
-          useBottomSheet ? (
-            <div className="tailwind-scope tw-fixed tw-inset-0 tw-z-[1200] tw-flex tw-items-end tw-bg-black/60 tw-px-3 tw-pb-3 tw-pt-10">
-              <dialog
-                open
-                aria-modal="true"
-                aria-label="Edit slow mode"
-                className="tw-relative tw-m-0 tw-w-full tw-max-w-none tw-border-0 tw-bg-transparent tw-p-0 tw-text-inherit"
-              >
-                <div
-                  id={editorId}
-                  ref={editorRef}
-                  className="tw-w-full tw-rounded-t-xl tw-border tw-border-b-0 tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-p-4 tw-shadow-[0_-18px_50px_rgba(0,0,0,0.45)]"
-                >
-                  {editorForm}
-                </div>
-              </dialog>
-            </div>
-          ) : (
-            <div
-              className="tailwind-scope tw-fixed tw-z-[1200]"
-              style={{
-                left: popoverPosition?.left ?? 0,
-                top: popoverPosition?.top ?? 0,
-                visibility: popoverPosition ? "visible" : "hidden",
-                width: POPOVER_WIDTH_PX,
-              }}
-            >
-              <div
-                id={editorId}
-                ref={editorRef}
-                className="tw-w-64 tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-p-3 tw-shadow-xl"
-              >
-                {editorForm}
-              </div>
-            </div>
-          ),
-          globalThis.document.body
-        )
-      : null;
-
   return (
-    <div className="tw-group tw-flex tw-min-h-6 tw-w-full tw-items-center tw-justify-between tw-gap-1.5 tw-text-sm">
-      <span className="tw-font-medium tw-text-iron-400">Slow mode</span>
-      <div className="tw-flex tw-items-center tw-gap-x-2">
-        <span className="tw-font-medium tw-text-iron-200">{slowModeLabel}</span>
-        {canEdit && (
-          <button
-            ref={editButtonRef}
-            type="button"
-            aria-label="Edit slow mode"
-            aria-controls={editorId}
-            aria-expanded={isEditorOpen}
-            aria-haspopup="dialog"
-            title="Edit slow mode"
-            onClick={toggleEditor}
-            className="tw-border-none tw-bg-transparent tw-p-0 tw-text-iron-300 tw-transition-all tw-duration-300 tw-ease-out desktop-hover:hover:tw-text-iron-400"
-          >
-            <PencilIcon size={PencilIconSize.SMALL} />
-          </button>
-        )}
-      </div>
-
-      {editorSurface}
-    </div>
+    <WaveSettingRow
+      canEdit={canEdit}
+      editLabel="Edit slow mode"
+      label="Slow mode"
+      onOpen={resetEditor}
+      valueLabel={slowModeLabel}
+      renderEditor={({ closeEditor }) => (
+        <WaveSlowModeEditorForm
+          disabled={mutating}
+          inputRef={inputRef}
+          isSlowModeEnabled={isSlowModeEnabled}
+          onCancel={closeEditor}
+          onDisable={() => handleDisable(closeEditor)}
+          onSave={() => handleSave(closeEditor)}
+          onUnitChange={setUnit}
+          onValueChange={setValue}
+          unit={unit}
+          value={value}
+        />
+      )}
+    />
   );
 }

--- a/components/waves/specs/WaveSlowModeEditorForm.tsx
+++ b/components/waves/specs/WaveSlowModeEditorForm.tsx
@@ -3,6 +3,7 @@ import {
   type SlowModeUnit,
 } from "@/helpers/waves/slow-mode.helpers";
 import type { RefObject } from "react";
+import WaveSettingEditorActions from "./WaveSettingEditorActions";
 
 interface WaveSlowModeEditorFormProps {
   readonly disabled: boolean;
@@ -73,31 +74,15 @@ export default function WaveSlowModeEditorForm({
         </select>
       </div>
 
-      <div className="tw-flex tw-items-center tw-justify-end tw-gap-2">
-        <button
-          type="button"
-          disabled={disabled}
-          onClick={onCancel}
-          className="tw-rounded-md tw-border tw-border-solid tw-border-iron-700 tw-bg-transparent tw-px-3 tw-py-2 tw-text-xs tw-font-semibold tw-text-iron-300 tw-transition disabled:tw-cursor-not-allowed disabled:tw-opacity-50 desktop-hover:hover:tw-border-iron-500 desktop-hover:hover:tw-text-iron-100"
-        >
-          Cancel
-        </button>
-        <button
-          type="button"
-          disabled={disabled || !isSlowModeEnabled}
-          onClick={onDisable}
-          className="tw-rounded-md tw-border tw-border-solid tw-border-red/40 tw-bg-transparent tw-px-3 tw-py-2 tw-text-xs tw-font-semibold tw-text-red tw-transition disabled:tw-cursor-not-allowed disabled:tw-opacity-50 desktop-hover:hover:tw-border-red desktop-hover:hover:tw-text-red"
-        >
-          Disable
-        </button>
-        <button
-          type="submit"
-          disabled={disabled}
-          className="tw-rounded-md tw-border tw-border-solid tw-border-primary-500 tw-bg-primary-500 tw-px-3 tw-py-2 tw-text-xs tw-font-semibold tw-text-white tw-transition disabled:tw-cursor-not-allowed disabled:tw-opacity-50 desktop-hover:hover:tw-border-primary-600 desktop-hover:hover:tw-bg-primary-600"
-        >
-          Save
-        </button>
-      </div>
+      <WaveSettingEditorActions
+        disabled={disabled}
+        onCancel={onCancel}
+        secondaryAction={{
+          disabled: !isSlowModeEnabled,
+          label: "Disable",
+          onClick: onDisable,
+        }}
+      />
     </form>
   );
 }

--- a/components/waves/specs/WaveSlowModeEditorForm.tsx
+++ b/components/waves/specs/WaveSlowModeEditorForm.tsx
@@ -44,12 +44,14 @@ export default function WaveSlowModeEditorForm({
         <input
           ref={inputRef}
           aria-label="Slow mode value"
+          autoFocus
           className="tw-min-w-0 tw-flex-1 tw-rounded-md tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900 tw-px-2.5 tw-py-2 tw-text-sm tw-text-iron-100 focus:tw-border-primary-400 focus:tw-outline-none"
           disabled={disabled}
           min={1}
           step={1}
           type="number"
           value={value}
+          onFocus={(event) => event.currentTarget.select()}
           onChange={(event) => onValueChange(event.target.value)}
         />
         <select

--- a/components/waves/specs/WaveSpecs.tsx
+++ b/components/waves/specs/WaveSpecs.tsx
@@ -4,6 +4,7 @@ import WaveAuthor from "./WaveAuthor";
 import WaveTypeIcon from "./WaveTypeIcon";
 import WaveRating from "./WaveRating";
 import WaveSlowMode from "./WaveSlowMode";
+import WaveDisableLinks from "./WaveDisableLinks";
 
 interface WaveSpecsProps {
   readonly wave: ApiWave;
@@ -52,7 +53,12 @@ export default function WaveSpecs({ wave, useRing = true }: WaveSpecsProps) {
             </div>
           </div>
 
-          {showSlowMode && <WaveSlowMode wave={wave} />}
+          {showSlowMode && (
+            <>
+              <WaveSlowMode wave={wave} />
+              <WaveDisableLinks wave={wave} />
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/components/waves/specs/useWaveSettingUpdater.ts
+++ b/components/waves/specs/useWaveSettingUpdater.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useAuth } from "@/components/auth/Auth";
+import { ReactQueryWrapperContext } from "@/components/react-query-wrapper/ReactQueryWrapper";
+import type { ApiUpdateWaveRequest } from "@/generated/models/ApiUpdateWaveRequest";
+import type { ApiWave } from "@/generated/models/ApiWave";
+import {
+  canEditWave,
+  convertWaveToUpdateWave,
+} from "@/helpers/waves/waves.helpers";
+import { commonApiPost } from "@/services/api/common-api";
+import { useCallback, useContext, useState } from "react";
+
+type WaveChatUpdate = ApiUpdateWaveRequest["chat"];
+
+export const useWaveSettingUpdater = (wave: ApiWave) => {
+  const { connectedProfile, activeProfileProxy, requestAuth, setToast } =
+    useAuth();
+  const { onWaveCreated } = useContext(ReactQueryWrapperContext);
+  const [mutating, setMutating] = useState(false);
+  const canEdit = canEditWave({ connectedProfile, activeProfileProxy, wave });
+
+  const updateWave = useCallback(
+    async (body: ApiUpdateWaveRequest, closeEditor: () => void) => {
+      setMutating(true);
+
+      try {
+        const { success } = await requestAuth();
+        if (!success) {
+          setToast({
+            type: "error",
+            message: "Failed to authenticate",
+          });
+          return;
+        }
+
+        await commonApiPost<ApiUpdateWaveRequest, ApiWave>({
+          endpoint: `waves/${wave.id}`,
+          body,
+        });
+        onWaveCreated();
+        closeEditor();
+      } catch (error) {
+        setToast({
+          message: error instanceof Error ? error.message : String(error),
+          type: "error",
+        });
+      } finally {
+        setMutating(false);
+      }
+    },
+    [onWaveCreated, requestAuth, setToast, wave.id]
+  );
+
+  const saveChatUpdate = useCallback(
+    (
+      closeEditor: () => void,
+      getChatUpdate: (chat: WaveChatUpdate) => WaveChatUpdate
+    ) => {
+      if (mutating) {
+        return;
+      }
+
+      const body = convertWaveToUpdateWave(wave);
+      void updateWave(
+        {
+          ...body,
+          chat: getChatUpdate(body.chat),
+        },
+        closeEditor
+      );
+    },
+    [mutating, updateWave, wave]
+  );
+
+  return {
+    canEdit,
+    mutating,
+    saveChatUpdate,
+    setToast,
+  };
+};

--- a/components/waves/utils/getOptimisticDrop.ts
+++ b/components/waves/utils/getOptimisticDrop.ts
@@ -7,6 +7,7 @@ import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import type { ApiReplyToDropResponse } from "@/generated/models/ApiReplyToDropResponse";
 import type { ApiWave } from "@/generated/models/ApiWave";
 import { getOptimisticDropId } from "@/helpers/waves/drop.helpers";
+import type { ApiWaveMinWithChatLinkSettings } from "@/helpers/waves/wave.helpers";
 import { getBannerColorValue } from "@/helpers/profile-banner.helpers";
 import type { ActiveDropState } from "@/types/dropInteractionTypes";
 import { ActiveDropAction } from "@/types/dropInteractionTypes";
@@ -68,7 +69,9 @@ export const getOptimisticDrop = (
       submission_type: wave.participation.submission_strategy?.type ?? null,
       identity_wave: wave.identity_wave,
       voting_credit_nfts: wave.voting.credit_nfts,
-    },
+      links_disabled: wave.chat.links_disabled,
+      wave_author_handle: wave.author.handle ?? null,
+    } as ApiWaveMinWithChatLinkSettings,
     author: {
       id: connectedProfile.id,
       handle: connectedProfile.handle,

--- a/generated/models/ApiCreateNewWaveChatConfig.ts
+++ b/generated/models/ApiCreateNewWaveChatConfig.ts
@@ -18,6 +18,7 @@ export class ApiCreateNewWaveChatConfig {
     'scope': ApiCreateNewWaveScope;
     'enabled': boolean;
     'slow_mode_cooldown_ms'?: number;
+    'links_disabled'?: boolean;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -41,6 +42,12 @@ export class ApiCreateNewWaveChatConfig {
             "baseName": "slow_mode_cooldown_ms",
             "type": "number",
             "format": "int64"
+        },
+        {
+            "name": "links_disabled",
+            "baseName": "links_disabled",
+            "type": "boolean",
+            "format": ""
         }    ];
 
     static getAttributeTypeMap() {

--- a/generated/models/ApiWaveChatConfig.ts
+++ b/generated/models/ApiWaveChatConfig.ts
@@ -17,6 +17,7 @@ import { HttpFile } from '../http/http';
 export class ApiWaveChatConfig {
     'scope': ApiWaveScope;
     'enabled': boolean;
+    'links_disabled': boolean;
     'authenticated_user_eligible': boolean;
     'next_drop_allowed'?: number;
     'slow_mode_cooldown_ms'?: number;
@@ -35,6 +36,12 @@ export class ApiWaveChatConfig {
         {
             "name": "enabled",
             "baseName": "enabled",
+            "type": "boolean",
+            "format": ""
+        },
+        {
+            "name": "links_disabled",
+            "baseName": "links_disabled",
             "type": "boolean",
             "format": ""
         },

--- a/generated/models/ApiWaveOverview.ts
+++ b/generated/models/ApiWaveOverview.ts
@@ -25,6 +25,7 @@ export class ApiWaveOverview {
     'subscribers_count': number;
     'has_competition': boolean;
     'is_dm_wave': boolean;
+    'links_disabled': boolean;
     'description_drop': ApiWaveOverviewDescriptionDrop;
     'total_drops_count': number;
     'is_private': boolean;
@@ -81,6 +82,12 @@ export class ApiWaveOverview {
         {
             "name": "is_dm_wave",
             "baseName": "is_dm_wave",
+            "type": "boolean",
+            "format": ""
+        },
+        {
+            "name": "links_disabled",
+            "baseName": "links_disabled",
             "type": "boolean",
             "format": ""
         },

--- a/helpers/waves/chat-link-restriction.helpers.ts
+++ b/helpers/waves/chat-link-restriction.helpers.ts
@@ -1,0 +1,31 @@
+import { ApiDropType } from "@/generated/models/ApiDropType";
+
+export const CHAT_LINK_RESTRICTION_MESSAGE =
+  "Links are not allowed in this wave";
+
+export const areHandlesEqual = (
+  left: string | null | undefined,
+  right: string | null | undefined
+): boolean => {
+  if (!left || !right) {
+    return false;
+  }
+
+  return left.toLowerCase() === right.toLowerCase();
+};
+
+export const isChatLinkRestrictionApplicable = ({
+  dropType,
+  isWaveAdmin,
+  isWaveCreator,
+  linksDisabled,
+}: {
+  readonly dropType: ApiDropType | null | undefined;
+  readonly isWaveAdmin: boolean;
+  readonly isWaveCreator: boolean;
+  readonly linksDisabled: boolean;
+}): boolean =>
+  linksDisabled &&
+  dropType === ApiDropType.Chat &&
+  !isWaveAdmin &&
+  !isWaveCreator;

--- a/helpers/waves/create-wave.helpers.ts
+++ b/helpers/waves/create-wave.helpers.ts
@@ -449,6 +449,7 @@ export const getCreateNewWaveBody = ({
         group_id: config.groups.canChat,
       },
       enabled: config.chat.enabled,
+      links_disabled: false,
     },
     wave: {
       admin_drop_deletion_enabled: config.drops.adminCanDeleteDrops,

--- a/helpers/waves/wave.helpers.ts
+++ b/helpers/waves/wave.helpers.ts
@@ -36,6 +36,11 @@ interface MinimalWaveLike {
   readonly id: string;
 }
 
+export interface ApiWaveMinWithChatLinkSettings extends ApiWaveMin {
+  readonly links_disabled?: boolean | undefined;
+  readonly wave_author_handle?: string | null | undefined;
+}
+
 export const normalizeOptionalWaveId = (
   waveId: string | null | undefined
 ): string | null => {
@@ -64,29 +69,36 @@ export const isPublicNonDirectMessageWave = (
     !wave.visibility?.scope?.group?.id
   );
 
-export const toApiWaveMin = (wave: ApiWave): ApiWaveMin => ({
-  id: wave.id,
-  name: wave.name,
-  picture: wave.picture,
-  description_drop_id: wave.description_drop.id,
-  last_drop_time: wave.last_drop_time,
-  authenticated_user_eligible_to_vote: wave.voting.authenticated_user_eligible,
-  authenticated_user_eligible_to_participate:
-    wave.participation.authenticated_user_eligible,
-  authenticated_user_eligible_to_chat: wave.chat.authenticated_user_eligible,
-  authenticated_user_admin: wave.wave.authenticated_user_eligible_for_admin,
-  visibility_group_id: wave.visibility.scope.group?.id ?? null,
-  participation_group_id: wave.participation.scope.group?.id ?? null,
-  chat_group_id: wave.chat.scope.group?.id ?? null,
-  voting_group_id: wave.voting.scope.group?.id ?? null,
-  admin_group_id: wave.wave.admin_group.group?.id ?? null,
-  voting_period_start: wave.voting.period?.min ?? null,
-  voting_period_end: wave.voting.period?.max ?? null,
-  voting_credit_type: wave.voting.credit_type,
-  admin_drop_deletion_enabled: wave.wave.admin_drop_deletion_enabled,
-  forbid_negative_votes: wave.voting.forbid_negative_votes,
-  pinned: wave.pinned,
-  identity_wave: wave.identity_wave,
-  submission_type: wave.participation.submission_strategy?.type ?? null,
-  voting_credit_nfts: wave.voting.credit_nfts,
-});
+export const toApiWaveMin = (wave: ApiWave): ApiWaveMin => {
+  const waveMin: ApiWaveMinWithChatLinkSettings = {
+    id: wave.id,
+    name: wave.name,
+    picture: wave.picture,
+    description_drop_id: wave.description_drop.id,
+    last_drop_time: wave.last_drop_time,
+    authenticated_user_eligible_to_vote:
+      wave.voting.authenticated_user_eligible,
+    authenticated_user_eligible_to_participate:
+      wave.participation.authenticated_user_eligible,
+    authenticated_user_eligible_to_chat: wave.chat.authenticated_user_eligible,
+    authenticated_user_admin: wave.wave.authenticated_user_eligible_for_admin,
+    visibility_group_id: wave.visibility.scope.group?.id ?? null,
+    participation_group_id: wave.participation.scope.group?.id ?? null,
+    chat_group_id: wave.chat.scope.group?.id ?? null,
+    voting_group_id: wave.voting.scope.group?.id ?? null,
+    admin_group_id: wave.wave.admin_group.group?.id ?? null,
+    voting_period_start: wave.voting.period?.min ?? null,
+    voting_period_end: wave.voting.period?.max ?? null,
+    voting_credit_type: wave.voting.credit_type,
+    admin_drop_deletion_enabled: wave.wave.admin_drop_deletion_enabled,
+    forbid_negative_votes: wave.voting.forbid_negative_votes,
+    pinned: wave.pinned,
+    identity_wave: wave.identity_wave,
+    submission_type: wave.participation.submission_strategy?.type ?? null,
+    voting_credit_nfts: wave.voting.credit_nfts,
+    links_disabled: wave.chat.links_disabled,
+    wave_author_handle: wave.author.handle ?? null,
+  };
+
+  return waveMin;
+};

--- a/helpers/waves/waves.helpers.ts
+++ b/helpers/waves/waves.helpers.ts
@@ -67,6 +67,7 @@ export const convertWaveToUpdateWave = (
       group_id: wave.chat.scope.group?.id ?? null,
     },
     enabled: wave.chat.enabled,
+    links_disabled: wave.chat.links_disabled === true,
     ...getSlowModeUpdate(wave.chat.slow_mode_cooldown_ms),
   },
   participation: {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9394,6 +9394,8 @@ components:
           type: integer
           format: int64
           minimum: 1000
+        links_disabled:
+          type: boolean
     ApiCreateNewWaveParticipationConfig:
       type: object
       required:
@@ -13497,11 +13499,14 @@ components:
       required:
         - scope
         - enabled
+        - links_disabled
         - authenticated_user_eligible
       properties:
         scope:
           $ref: "#/components/schemas/ApiWaveScope"
         enabled:
+          type: boolean
+        links_disabled:
           type: boolean
         authenticated_user_eligible:
           type: boolean
@@ -14124,6 +14129,7 @@ components:
         - subscribers_count
         - has_competition
         - is_dm_wave
+        - links_disabled
         - description_drop
         - total_drops_count
         - is_private
@@ -14146,6 +14152,8 @@ components:
         has_competition:
           type: boolean
         is_dm_wave:
+          type: boolean
+        links_disabled:
           type: boolean
         description_drop:
           $ref: "#/components/schemas/ApiWaveOverviewDescriptionDrop"

--- a/services/api/drop-v2-mappers.ts
+++ b/services/api/drop-v2-mappers.ts
@@ -18,7 +18,10 @@ import type { ApiWave } from "@/generated/models/ApiWave";
 import { ApiWaveCreditType } from "@/generated/models/ApiWaveCreditType";
 import type { ApiWaveMin } from "@/generated/models/ApiWaveMin";
 import type { ApiWaveOverview } from "@/generated/models/ApiWaveOverview";
-import { toApiWaveMin } from "@/helpers/waves/wave.helpers";
+import {
+  toApiWaveMin,
+  type ApiWaveMinWithChatLinkSettings,
+} from "@/helpers/waves/wave.helpers";
 
 type ApiProfileMinWithBadges = ApiProfileMin & {
   readonly badges?: ApiIdentityOverviewBadges;
@@ -73,7 +76,7 @@ export const mapPriorityMetadataV2ToDropMetadata = (
 
 export const mapApiWaveOverviewToApiWaveMin = (
   wave: ApiWaveOverview
-): ApiWaveMin => ({
+): ApiWaveMinWithChatLinkSettings => ({
   id: wave.id,
   name: wave.name,
   picture: wave.pfp ?? null,
@@ -98,6 +101,7 @@ export const mapApiWaveOverviewToApiWaveMin = (
   forbid_negative_votes: false,
   pinned: wave.context_profile_context?.pinned ?? false,
   identity_wave: false,
+  links_disabled: wave.links_disabled,
 });
 
 export const createFallbackWaveMin = (waveId: string): ApiWaveMin => ({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wave creators/admins can toggle a "Disable links" setting for chat-enabled waves via a new settings UI.
  * When link restrictions are active, submissions or edits containing preview-worthy links are blocked with a disabled state and explanatory tooltip; participatory drop submissions remain allowed.
  * Editors and save/submit controls show appropriate disabled styling and tooltips when links are blocked.

* **Tests**
  * Added coverage for link-preview detection and chat link restriction behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-frontend/pull/2424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->