### PR TITLE
Align HTML media actions in meme card viewer with drop view

### DIFF
--- a/__tests__/components/the-memes/MemePageArtViewer.test.tsx
+++ b/__tests__/components/the-memes/MemePageArtViewer.test.tsx
@@ -275,6 +275,35 @@ describe("MemePageArtViewer", () => {
     );
   });
 
+  it("renders only fullscreen for html artwork media actions", () => {
+    render(
+      <MemePageArtViewer
+        nft={
+          {
+            ...baseNft,
+            image: "",
+            animation: "https://media.example/interactive.html",
+            metadata: {
+              image: "",
+              animation_url: "https://media.example/interactive.html",
+              animation_details: { format: "HTML" },
+            },
+          } as any
+        }
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Full screen" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Open in new tab" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Download media" })
+    ).not.toBeInTheDocument();
+  });
+
   it("uses optimized media for the initial artwork render", () => {
     render(<MemePageArtViewer nft={baseNft as any} />);
 

--- a/components/the-memes/MemePage.tsx
+++ b/components/the-memes/MemePage.tsx
@@ -594,7 +594,7 @@ export default function MemePage({ nftId }: { readonly nftId: string }) {
 
   return (
     <div className="tailwind-scope tw-min-h-[calc(100vh-100px)] tw-border tw-border-y-0 tw-border-l-0 tw-border-solid tw-border-iron-800 tw-bg-[#0D0D0F] tw-pb-5 tw-text-white">
-      <div className="tw-px-4 tw-py-6 md:tw-px-6 md:tw-py-10 lg:tw-px-8">
+      <div className="tw-px-4 tw-py-4 md:tw-px-6 md:tw-pb-10 lg:tw-px-8">
         <header className="tw-pb-8">
           <div className="tw-flex tw-flex-col tw-gap-4">
             <div className="tw-flex tw-items-center tw-justify-between tw-gap-x-4 tw-gap-y-2 md:tw-justify-start">

--- a/components/the-memes/MemePageArtViewer.tsx
+++ b/components/the-memes/MemePageArtViewer.tsx
@@ -116,6 +116,7 @@ export function MemePageArtViewer({
       };
   const currentFormat = activeMedia.format ?? "";
   const activeMediaUrl = activeMedia.url ?? "";
+  const canUseBrowserMediaActions = activeMedia.variant !== "html";
   const showBalanceControl = showBalance && Boolean(connectedProfile);
   const { downloadMedia, isDownloading, openLabel, openMedia } =
     useMediaActions({
@@ -201,9 +202,9 @@ export function MemePageArtViewer({
     return (
       <InlineMediaActions
         variant={activeMedia.variant}
-        onDownload={downloadMedia}
-        onOpen={openMedia}
-        openLabel={openLabel}
+        onDownload={canUseBrowserMediaActions ? downloadMedia : undefined}
+        onOpen={canUseBrowserMediaActions ? openMedia : undefined}
+        openLabel={canUseBrowserMediaActions ? openLabel : undefined}
         isDownloading={isDownloading}
         onFullscreen={enterActiveMediaFullScreen}
         fullscreenTargetAvailable={Boolean(activeMedia.fullscreenElementId)}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined padding and spacing on the meme viewing page for better visual balance across different screen sizes.

* **Bug Fixes**
  * HTML-based artwork now displays only the "Full screen" action button, with "Download media" and "Open in new tab" options disabled as they are not supported.

* **Tests**
  * Added test verification for HTML-based artwork media action button rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-frontend/pull/2436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->