### PR TITLE
Keep chat drop titles non-clickable

### DIFF
--- a/__tests__/components/waves/drops/Drop.test.tsx
+++ b/__tests__/components/waves/drops/Drop.test.tsx
@@ -39,6 +39,8 @@ beforeEach(() => {
 });
 
 it("renders chat drop", () => {
+  const onDropContentClick = jest.fn();
+
   render(
     <Drop
       drop={base}
@@ -52,14 +54,18 @@ it("renders chat drop", () => {
       onQuote={jest.fn()}
       onReplyClick={jest.fn()}
       onQuoteClick={jest.fn()}
+      onDropContentClick={onDropContentClick}
       showReplyAndQuote={false}
     />
   );
   expect(screen.getByTestId("wave")).toBeInTheDocument();
+  expect(waveProps.onDropContentClick).toBeUndefined();
 });
 
 it("renders winner drop", () => {
   const drop = { ...base, drop_type: ApiDropType.Winner };
+  const onDropContentClick = jest.fn();
+
   render(
     <Drop
       drop={drop}
@@ -73,14 +79,18 @@ it("renders winner drop", () => {
       onQuote={jest.fn()}
       onReplyClick={jest.fn()}
       onQuoteClick={jest.fn()}
+      onDropContentClick={onDropContentClick}
       showReplyAndQuote={false}
     />
   );
   expect(screen.getByTestId("winner")).toBeInTheDocument();
+  expect(winnerProps.onDropContentClick).toBe(onDropContentClick);
 });
 
 it("passes approve wave state to participation drop", () => {
   const drop = { ...base, drop_type: ApiDropType.Participatory };
+  const onDropContentClick = jest.fn();
+
   render(
     <Drop
       drop={drop}
@@ -94,6 +104,7 @@ it("passes approve wave state to participation drop", () => {
       onQuote={jest.fn()}
       onReplyClick={jest.fn()}
       onQuoteClick={jest.fn()}
+      onDropContentClick={onDropContentClick}
       showReplyAndQuote={false}
       winningThreshold={15}
       isVotingClosed={true}
@@ -104,6 +115,7 @@ it("passes approve wave state to participation drop", () => {
   expect(participationProps.winningThreshold).toBe(15);
   expect(participationProps.isVotingClosed).toBe(true);
   expect(participationProps.isVotingControlsLocked).toBe(true);
+  expect(participationProps.onDropContentClick).toBe(onDropContentClick);
 });
 
 it("passes embed guard props to rendered drop variants", () => {

--- a/__tests__/components/waves/drops/DropItemChat.test.tsx
+++ b/__tests__/components/waves/drops/DropItemChat.test.tsx
@@ -7,6 +7,9 @@ jest.mock('next/link', () => ({ __esModule: true, default: ({ href, children }: 
 
 jest.mock('@/hooks/useDrop', () => ({ useDrop: jest.fn() }));
 jest.mock('@/helpers/Helpers', () => ({ removeBaseEndpoint: jest.fn((l: string) => l.replace('https://base.com', '')) }));
+jest.mock('@/contexts/SeizeSettingsContext', () => ({
+  useSeizeSettings: () => ({ isMemesSubmission: () => false }),
+}));
 jest.mock('@/components/drops/view/item/content/media/DropListItemContentMedia', () => (props: any) => <div data-testid="media" {...props} />);
 jest.mock('@/components/waves/drop/SingleWaveDropPosition', () => ({ SingleWaveDropPosition: (p: any) => <div data-testid="position">{p.rank}</div> }));
 jest.mock('@/components/waves/drop/SingleWaveDropVotes', () => ({ SingleWaveDropVotes: () => <div data-testid="votes" /> }));
@@ -43,5 +46,26 @@ describe('DropItemChat', () => {
     expect(screen.getByTestId('position')).toHaveTextContent('2');
     expect(screen.getByTestId('media')).toHaveAttribute('media_url', 'img');
     expect(screen.getByTestId('href-buttons')).toHaveTextContent('/p');
+  });
+
+  it('renders chat drop title as plain text when loaded', () => {
+    (useDrop as jest.Mock).mockReturnValue({
+      drop: {
+        drop_type: ApiDropType.Chat,
+        parts: [{ media: [] }],
+        metadata: [{ data_key: 'title', data_value: 'Chat Title' }],
+        title: 'Fallback',
+        wave: { id: 'w', name: 'Wave' },
+        rank: null,
+      },
+    });
+
+    render(<DropItemChat href="https://base.com/p" dropId="d1" />);
+
+    expect(screen.getByText('Chat Title').closest('a')).toBeNull();
+    expect(screen.getByRole('link', { name: 'Wave' })).toHaveAttribute(
+      'href',
+      '/p'
+    );
   });
 });

--- a/__tests__/components/waves/drops/DropItemChat.test.tsx
+++ b/__tests__/components/waves/drops/DropItemChat.test.tsx
@@ -1,71 +1,89 @@
-import { render, screen } from '@testing-library/react';
-import React from 'react';
-import DropItemChat from '@/components/waves/drops/DropItemChat';
-import { ApiDropType } from '@/generated/models/ApiDropType';
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import DropItemChat from "@/components/waves/drops/DropItemChat";
+import { ApiDropType } from "@/generated/models/ApiDropType";
 
-jest.mock('next/link', () => ({ __esModule: true, default: ({ href, children }: any) => <a href={href}>{children}</a> }));
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children }: any) => <a href={href}>{children}</a>,
+}));
 
-jest.mock('@/hooks/useDrop', () => ({ useDrop: jest.fn() }));
-jest.mock('@/helpers/Helpers', () => ({ removeBaseEndpoint: jest.fn((l: string) => l.replace('https://base.com', '')) }));
-jest.mock('@/contexts/SeizeSettingsContext', () => ({
+jest.mock("@/hooks/useDrop", () => ({ useDrop: jest.fn() }));
+jest.mock("@/helpers/Helpers", () => ({
+  removeBaseEndpoint: jest.fn((l: string) => l.replace("https://base.com", "")),
+}));
+jest.mock("@/contexts/SeizeSettingsContext", () => ({
   useSeizeSettings: () => ({ isMemesSubmission: () => false }),
 }));
-jest.mock('@/components/drops/view/item/content/media/DropListItemContentMedia', () => (props: any) => <div data-testid="media" {...props} />);
-jest.mock('@/components/waves/drop/SingleWaveDropPosition', () => ({ SingleWaveDropPosition: (p: any) => <div data-testid="position">{p.rank}</div> }));
-jest.mock('@/components/waves/drop/SingleWaveDropVotes', () => ({ SingleWaveDropVotes: () => <div data-testid="votes" /> }));
-jest.mock('@/components/waves/ChatItemHrefButtons', () => (p: any) => <div data-testid="href-buttons">{p.relativeHref}</div>);
+jest.mock(
+  "@/components/drops/view/item/content/media/DropListItemContentMedia",
+  () => (props: any) => <div data-testid="media" {...props} />
+);
+jest.mock("@/components/waves/drop/SingleWaveDropPosition", () => ({
+  SingleWaveDropPosition: (p: any) => (
+    <div data-testid="position">{p.rank}</div>
+  ),
+}));
+jest.mock("@/components/waves/drop/SingleWaveDropVotes", () => ({
+  SingleWaveDropVotes: () => <div data-testid="votes" />,
+}));
+jest.mock("@/components/waves/ChatItemHrefButtons", () => (p: any) => (
+  <div data-testid="href-buttons">{p.relativeHref}</div>
+));
 
-const { useDrop } = require('@/hooks/useDrop');
-const { removeBaseEndpoint } = require('@/helpers/Helpers');
+const { useDrop } = require("@/hooks/useDrop");
+const { removeBaseEndpoint } = require("@/helpers/Helpers");
 
-describe('DropItemChat', () => {
-  it('renders fallback link when drop not loaded', () => {
+describe("DropItemChat", () => {
+  it("renders fallback link when drop not loaded", () => {
     (useDrop as jest.Mock).mockReturnValue({ drop: null });
-    const { container } = render(<DropItemChat href="https://base.com/path" dropId="d1" />);
-    const link = container.querySelector('a');
-    expect(link).toHaveAttribute('href', '/path');
-    expect(link).toHaveTextContent('https://base.com/path');
-    expect(removeBaseEndpoint).toHaveBeenCalledWith('https://base.com/path');
+    const { container } = render(
+      <DropItemChat href="https://base.com/path" dropId="d1" />
+    );
+    const link = container.querySelector("a");
+    expect(link).toHaveAttribute("href", "/path");
+    expect(link).toHaveTextContent("https://base.com/path");
+    expect(removeBaseEndpoint).toHaveBeenCalledWith("https://base.com/path");
   });
 
-  it('shows drop details when loaded', () => {
+  it("shows drop details when loaded", () => {
     (useDrop as jest.Mock).mockReturnValue({
       drop: {
         drop_type: ApiDropType.Participatory,
-        parts: [{ media: [{ mime_type: 'image/png', url: 'img' }] }],
-        metadata: [{ data_key: 'title', data_value: 'Title' }],
-        title: 'T',
-        wave: { id: 'w', name: 'Wave' },
+        parts: [{ media: [{ mime_type: "image/png", url: "img" }] }],
+        metadata: [{ data_key: "title", data_value: "Title" }],
+        title: "T",
+        wave: { id: "w", name: "Wave" },
         rank: 2,
       },
     });
     render(<DropItemChat href="https://base.com/p" dropId="d1" />);
-    const links = screen.getAllByRole('link');
-    expect(links[0]).toHaveAttribute('href', '/p');
-    expect(screen.getByText('Title')).toBeInTheDocument();
-    expect(screen.getByTestId('position')).toHaveTextContent('2');
-    expect(screen.getByTestId('media')).toHaveAttribute('media_url', 'img');
-    expect(screen.getByTestId('href-buttons')).toHaveTextContent('/p');
+    const links = screen.getAllByRole("link");
+    expect(links[0]).toHaveAttribute("href", "/p");
+    expect(screen.getByText("Title")).toBeInTheDocument();
+    expect(screen.getByTestId("position")).toHaveTextContent("2");
+    expect(screen.getByTestId("media")).toHaveAttribute("media_url", "img");
+    expect(screen.getByTestId("href-buttons")).toHaveTextContent("/p");
   });
 
-  it('renders chat drop title as plain text when loaded', () => {
+  it("renders chat drop title as plain text when loaded", () => {
     (useDrop as jest.Mock).mockReturnValue({
       drop: {
         drop_type: ApiDropType.Chat,
         parts: [{ media: [] }],
-        metadata: [{ data_key: 'title', data_value: 'Chat Title' }],
-        title: 'Fallback',
-        wave: { id: 'w', name: 'Wave' },
+        metadata: [{ data_key: "title", data_value: "Chat Title" }],
+        title: "Fallback",
+        wave: { id: "w", name: "Wave" },
         rank: null,
       },
     });
 
     render(<DropItemChat href="https://base.com/p" dropId="d1" />);
 
-    expect(screen.getByText('Chat Title').closest('a')).toBeNull();
-    expect(screen.getByRole('link', { name: 'Wave' })).toHaveAttribute(
-      'href',
-      '/p'
+    expect(screen.getByText("Chat Title").closest("a")).toBeNull();
+    expect(screen.getByRole("link", { name: "Wave" })).toHaveAttribute(
+      "href",
+      "/p"
     );
   });
 });

--- a/components/waves/drops/Drop.tsx
+++ b/components/waves/drops/Drop.tsx
@@ -77,6 +77,9 @@ export default function Drop({
   embedDepth,
   maxEmbedDepth,
 }: DropProps) {
+  const canOpenDrop = drop.drop_type !== ApiDropType.Chat;
+  const openDropContentClick = canOpenDrop ? onDropContentClick : undefined;
+
   const components: Record<ApiDropType, React.ReactNode> = {
     [ApiDropType.Participatory]: (
       <ParticipationDrop
@@ -86,7 +89,7 @@ export default function Drop({
         location={location}
         onReply={onReply}
         onQuoteClick={onQuoteClick}
-        onDropContentClick={onDropContentClick}
+        onDropContentClick={openDropContentClick}
         showReplyAndQuote={showReplyAndQuote}
         parentContainerRef={parentContainerRef}
         footer={footer}
@@ -114,7 +117,7 @@ export default function Drop({
         onReply={onReply}
         onReplyClick={onReplyClick}
         onQuoteClick={onQuoteClick}
-        onDropContentClick={onDropContentClick}
+        onDropContentClick={openDropContentClick}
         showReplyAndQuote={showReplyAndQuote}
         parentContainerRef={parentContainerRef}
         footer={footer}
@@ -141,7 +144,7 @@ export default function Drop({
         onReply={onReply}
         onReplyClick={onReplyClick}
         onQuoteClick={onQuoteClick}
-        onDropContentClick={undefined}
+        onDropContentClick={openDropContentClick}
         showReplyAndQuote={showReplyAndQuote}
         wrapContentOnly={wrapContentOnly}
         footer={footer}

--- a/components/waves/drops/Drop.tsx
+++ b/components/waves/drops/Drop.tsx
@@ -141,7 +141,7 @@ export default function Drop({
         onReply={onReply}
         onReplyClick={onReplyClick}
         onQuoteClick={onQuoteClick}
-        onDropContentClick={onDropContentClick}
+        onDropContentClick={undefined}
         showReplyAndQuote={showReplyAndQuote}
         wrapContentOnly={wrapContentOnly}
         footer={footer}

--- a/components/waves/drops/DropItemChat.tsx
+++ b/components/waves/drops/DropItemChat.tsx
@@ -24,6 +24,7 @@ export default function DropItemChat({
   const title =
     drop?.metadata?.find((m) => m.data_key === "title")?.data_value ||
     drop?.title;
+  const canOpenDrop = drop?.drop_type !== ApiDropType.Chat;
 
   if (!drop) {
     return <Link href={relativeLink}>{href}</Link>;
@@ -43,9 +44,13 @@ export default function DropItemChat({
                 />
               )}
               <h3 className="tw-mb-0 tw-text-base tw-font-semibold tw-text-iron-100 sm:tw-text-lg">
-                <Link className="tw-no-underline" href={relativeLink}>
-                  {title}
-                </Link>
+                {canOpenDrop ? (
+                  <Link className="tw-no-underline" href={relativeLink}>
+                    {title}
+                  </Link>
+                ) : (
+                  title
+                )}
               </h3>
             </div>
             {drop?.drop_type === ApiDropType.Participatory && (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded drop component test coverage to validate callback propagation across different drop variants.
  * Added tests for chat drop metadata rendering and link handling behavior.

* **Bug Fixes**
  * Fixed chat drop title interaction: titles now display as plain text instead of clickable links, while maintaining separate wave-related navigation links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-frontend/pull/2444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->