### PR TITLE
Restore notification chat drop navigation

### DIFF
--- a/__tests__/components/waves/drops/Drop.test.tsx
+++ b/__tests__/components/waves/drops/Drop.test.tsx
@@ -62,6 +62,31 @@ it("renders chat drop", () => {
   expect(waveProps.onDropContentClick).toBeUndefined();
 });
 
+it("keeps chat drops clickable outside wave context", () => {
+  const onDropContentClick = jest.fn();
+
+  render(
+    <Drop
+      drop={base}
+      previousDrop={null}
+      nextDrop={null}
+      showWaveInfo={false}
+      activeDrop={null}
+      location={DropLocation.MY_STREAM}
+      dropViewDropId={null}
+      onReply={jest.fn()}
+      onQuote={jest.fn()}
+      onReplyClick={jest.fn()}
+      onQuoteClick={jest.fn()}
+      onDropContentClick={onDropContentClick}
+      showReplyAndQuote={false}
+    />
+  );
+
+  expect(screen.getByTestId("wave")).toBeInTheDocument();
+  expect(waveProps.onDropContentClick).toBe(onDropContentClick);
+});
+
 it("renders winner drop", () => {
   const drop = { ...base, drop_type: ApiDropType.Winner };
   const onDropContentClick = jest.fn();

--- a/components/waves/drops/Drop.tsx
+++ b/components/waves/drops/Drop.tsx
@@ -10,10 +10,10 @@ import { DropSize } from "@/helpers/waves/drop.helpers";
 import type { ActiveDropState } from "@/types/dropInteractionTypes";
 import { useMemo } from "react";
 import DropContext from "./DropContext";
+import { DropLocation } from "./drop.types";
 import type {
   DropIdentityMode,
   DropInteractionParams,
-  DropLocation,
   DropTimestampLayout,
 } from "./drop.types";
 import ParticipationDrop from "./participation/ParticipationDrop";
@@ -77,7 +77,8 @@ export default function Drop({
   embedDepth,
   maxEmbedDepth,
 }: DropProps) {
-  const canOpenDrop = drop.drop_type !== ApiDropType.Chat;
+  const canOpenDrop =
+    drop.drop_type !== ApiDropType.Chat || location !== DropLocation.WAVE;
   const openDropContentClick = canOpenDrop ? onDropContentClick : undefined;
 
   const components: Record<ApiDropType, React.ReactNode> = {

--- a/utils/monitoring/dropReactionMonitoring.ts
+++ b/utils/monitoring/dropReactionMonitoring.ts
@@ -47,12 +47,12 @@ interface ReactionMutationContext {
   supersededByMutationId?: string | null;
 }
 
-export interface ReactionMutationResult {
+interface ReactionMutationResult {
   readonly isLatestMutation: boolean;
   readonly supersededByMutationId: string | null;
 }
 
-export interface ReactionRealtimeReconciliationResult {
+interface ReactionRealtimeReconciliationResult {
   readonly shouldApplyCanonicalDrop: boolean;
   readonly expectedReaction: string | null;
   readonly serverReaction: string | null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed drop interaction behavior — chat drops remain interactive when displayed outside wave contexts and keep expected (non-openable) behavior inside wave contexts.
  * Added test coverage — new test verifies drop interactivity and click handling across display contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-frontend/pull/2447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->