### PR TITLE
Added our cloudfront link bypass to link blocking

### DIFF
--- a/__tests__/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.test.ts
+++ b/__tests__/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.test.ts
@@ -37,4 +37,30 @@ describe("linkPreviewDetection", () => {
       )
     ).toBe(false);
   });
+
+  it("ignores exact CloudFront-origin links allowed by chat restrictions", () => {
+    expect(
+      containsOpenGraphPreviewLink(
+        "uploaded https://d3lqz0a4bldqgf.cloudfront.net/drops/asset.mp4"
+      )
+    ).toBe(false);
+    expect(
+      containsOpenGraphPreviewLink(
+        "[download](https://d3lqz0a4bldqgf.cloudfront.net/drops/asset.html)"
+      )
+    ).toBe(false);
+    expect(
+      containsOpenGraphPreviewLink(
+        "https://d3lqz0a4bldqgf.cloudfront.net/drops/asset"
+      )
+    ).toBe(false);
+  });
+
+  it("does not ignore CloudFront lookalike hosts", () => {
+    expect(
+      containsOpenGraphPreviewLink(
+        "https://d3lqz0a4bldqgf.cloudfront.net.evil/drops/asset.mp4"
+      )
+    ).toBe(true);
+  });
 });

--- a/__tests__/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.test.ts
+++ b/__tests__/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.test.ts
@@ -54,25 +54,37 @@ describe("linkPreviewDetection", () => {
     ).toBe(false);
   });
 
-  it("ignores official Tenor content links allowed by chat restrictions", () => {
+  it("ignores allowed Tenor media links", () => {
     expect(
       containsDisallowedLink("https://media.tenor.com/abc/tenor.gif")
     ).toBe(false);
     expect(
       containsDisallowedLink("https://media.tenor.com/abc/tenor.mp4")
     ).toBe(false);
-    expect(containsDisallowedLink("https://c.tenor.com/abc/tenor.webm")).toBe(
+    expect(containsDisallowedLink("https://c.tenor.com/abc/tenor.jpg")).toBe(
       false
     );
-    expect(containsDisallowedLink("https://tenor.com/view/funny-cat-123")).toBe(
+    expect(containsDisallowedLink("https://c.tenor.com/abc/tenor.webp")).toBe(
       false
     );
     expect(
-      containsDisallowedLink("https://www.tenor.com/view/funny-cat-123")
+      containsDisallowedLink("https://media.tenor.com/abc/tenor.gif?itemid=1")
     ).toBe(false);
     expect(
       containsDisallowedLink("![gif](https://media.tenor.com/abc/tenor.gif)")
     ).toBe(false);
+  });
+
+  it("blocks Tenor urls without allowed media extensions", () => {
+    expect(containsDisallowedLink("https://c.tenor.com/abc/tenor.webm")).toBe(
+      true
+    );
+    expect(containsDisallowedLink("https://tenor.com/view/funny-cat-123")).toBe(
+      true
+    );
+    expect(
+      containsDisallowedLink("https://www.tenor.com/view/funny-cat-123")
+    ).toBe(true);
   });
 
   it("does not ignore CloudFront or Tenor lookalike hosts", () => {

--- a/__tests__/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.test.ts
+++ b/__tests__/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.test.ts
@@ -1,66 +1,94 @@
-import { containsOpenGraphPreviewLink } from "@/components/drops/view/part/dropPartMarkdown/linkPreviewDetection";
+import { containsDisallowedLink } from "@/components/drops/view/part/dropPartMarkdown/linkPreviewDetection";
 
 describe("linkPreviewDetection", () => {
-  it("detects markdown links and bare urls that become OpenGraph previews", () => {
+  it("detects markdown links and bare urls blocked by chat restrictions", () => {
+    expect(containsDisallowedLink("[article](https://example.com/post)")).toBe(
+      true
+    );
     expect(
-      containsOpenGraphPreviewLink("[article](https://example.com/post)")
-    ).toBe(true);
-    expect(
-      containsOpenGraphPreviewLink(
+      containsDisallowedLink(
         "[wiki](https://en.wikipedia.org/wiki/Function_(mathematics))"
       )
     ).toBe(true);
-    expect(containsOpenGraphPreviewLink("read https://example.com/post")).toBe(
-      true
-    );
-    expect(containsOpenGraphPreviewLink("read www.example.com/post")).toBe(
-      true
-    );
+    expect(containsDisallowedLink("read https://example.com/post")).toBe(true);
+    expect(containsDisallowedLink("read www.example.com/post")).toBe(true);
   });
 
-  it("ignores urls in code and direct image urls", () => {
-    expect(containsOpenGraphPreviewLink("`https://example.com/post`")).toBe(
-      false
-    );
-    expect(containsOpenGraphPreviewLink("https://example.com/image.png")).toBe(
-      false
-    );
-    expect(
-      containsOpenGraphPreviewLink("![preview](https://example.com/post)")
-    ).toBe(false);
+  it("ignores urls in code", () => {
+    expect(containsDisallowedLink("`https://example.com/post`")).toBe(false);
   });
 
-  it("ignores urls handled by non-OpenGraph cards", () => {
+  it("ignores non-url markdown image placeholders", () => {
+    expect(containsDisallowedLink("![Seize](loading)")).toBe(false);
+  });
+
+  it("blocks non-allowed direct media urls", () => {
+    expect(containsDisallowedLink("https://example.com/image.png")).toBe(true);
+    expect(containsDisallowedLink("https://example.com/video.mp4")).toBe(true);
     expect(
-      containsOpenGraphPreviewLink(
-        "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-      )
-    ).toBe(false);
+      containsDisallowedLink("![preview](https://example.com/image.jpg)")
+    ).toBe(true);
+  });
+
+  it("blocks urls handled by non-OpenGraph cards", () => {
+    expect(
+      containsDisallowedLink("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+    ).toBe(true);
   });
 
   it("ignores exact CloudFront-origin links allowed by chat restrictions", () => {
     expect(
-      containsOpenGraphPreviewLink(
+      containsDisallowedLink(
         "uploaded https://d3lqz0a4bldqgf.cloudfront.net/drops/asset.mp4"
       )
     ).toBe(false);
     expect(
-      containsOpenGraphPreviewLink(
+      containsDisallowedLink(
         "[download](https://d3lqz0a4bldqgf.cloudfront.net/drops/asset.html)"
       )
     ).toBe(false);
     expect(
-      containsOpenGraphPreviewLink(
+      containsDisallowedLink(
         "https://d3lqz0a4bldqgf.cloudfront.net/drops/asset"
       )
     ).toBe(false);
   });
 
-  it("does not ignore CloudFront lookalike hosts", () => {
+  it("ignores official Tenor content links allowed by chat restrictions", () => {
     expect(
-      containsOpenGraphPreviewLink(
+      containsDisallowedLink("https://media.tenor.com/abc/tenor.gif")
+    ).toBe(false);
+    expect(
+      containsDisallowedLink("https://media.tenor.com/abc/tenor.mp4")
+    ).toBe(false);
+    expect(containsDisallowedLink("https://c.tenor.com/abc/tenor.webm")).toBe(
+      false
+    );
+    expect(containsDisallowedLink("https://tenor.com/view/funny-cat-123")).toBe(
+      false
+    );
+    expect(
+      containsDisallowedLink("https://www.tenor.com/view/funny-cat-123")
+    ).toBe(false);
+    expect(
+      containsDisallowedLink("![gif](https://media.tenor.com/abc/tenor.gif)")
+    ).toBe(false);
+  });
+
+  it("does not ignore CloudFront or Tenor lookalike hosts", () => {
+    expect(
+      containsDisallowedLink(
         "https://d3lqz0a4bldqgf.cloudfront.net.evil/drops/asset.mp4"
       )
+    ).toBe(true);
+    expect(
+      containsDisallowedLink("https://media.tenor.com.evil/abc/tenor.gif")
+    ).toBe(true);
+  });
+
+  it("blocks non-Tenor Google API urls", () => {
+    expect(
+      containsDisallowedLink("https://tenor.googleapis.com/v2/search?q=cat")
     ).toBe(true);
   });
 });

--- a/__tests__/components/waves/CreateDropContent.refocus.test.tsx
+++ b/__tests__/components/waves/CreateDropContent.refocus.test.tsx
@@ -349,6 +349,43 @@ describe("CreateDropContent chat refocus", () => {
     expect(submitDrop).not.toHaveBeenCalled();
   });
 
+  it("disables chat submit for non-allowed direct media links", async () => {
+    const submitDrop = jest.fn(() => true);
+    renderSubject({
+      isDropMode: false,
+      submitDrop,
+      waveOverride: {
+        ...wave,
+        chat: {
+          ...wave.chat,
+          links_disabled: true,
+        },
+      },
+      drop: {
+        ...createStoredDrop(),
+        parts: [
+          {
+            content: "https://example.com/image.jpg",
+            quoted_drop: null,
+            media: [],
+          },
+        ],
+      },
+    });
+
+    const submitButton = screen.getByText("submit");
+
+    expect(
+      screen.getByText("Links are not allowed in this wave")
+    ).toBeInTheDocument();
+    expect(submitButton).toBeDisabled();
+
+    await userEvent.click(submitButton);
+
+    expect(mockRequestAuth).not.toHaveBeenCalled();
+    expect(submitDrop).not.toHaveBeenCalled();
+  });
+
   it("does not disable chat submit for allowed CloudFront links", async () => {
     const submitDrop = jest.fn(() => true);
     renderSubject({
@@ -366,6 +403,43 @@ describe("CreateDropContent chat refocus", () => {
         parts: [
           {
             content: "https://d3lqz0a4bldqgf.cloudfront.net/drops/asset.mp4",
+            quoted_drop: null,
+            media: [],
+          },
+        ],
+      },
+    });
+
+    const submitButton = screen.getByText("submit");
+
+    expect(
+      screen.queryByText("Links are not allowed in this wave")
+    ).not.toBeInTheDocument();
+    expect(submitButton).not.toBeDisabled();
+
+    await userEvent.click(submitButton);
+
+    await waitFor(() => expect(submitDrop).toHaveBeenCalledTimes(1));
+    expect(submitDrop.mock.calls[0]?.[0].drop.drop_type).toBe(ApiDropType.Chat);
+  });
+
+  it("does not disable chat submit for allowed Tenor links", async () => {
+    const submitDrop = jest.fn(() => true);
+    renderSubject({
+      isDropMode: false,
+      submitDrop,
+      waveOverride: {
+        ...wave,
+        chat: {
+          ...wave.chat,
+          links_disabled: true,
+        },
+      },
+      drop: {
+        ...createStoredDrop(),
+        parts: [
+          {
+            content: "https://media.tenor.com/abc/tenor.mp4",
             quoted_drop: null,
             media: [],
           },

--- a/__tests__/components/waves/CreateDropContent.refocus.test.tsx
+++ b/__tests__/components/waves/CreateDropContent.refocus.test.tsx
@@ -349,6 +349,43 @@ describe("CreateDropContent chat refocus", () => {
     expect(submitDrop).not.toHaveBeenCalled();
   });
 
+  it("does not disable chat submit for allowed CloudFront links", async () => {
+    const submitDrop = jest.fn(() => true);
+    renderSubject({
+      isDropMode: false,
+      submitDrop,
+      waveOverride: {
+        ...wave,
+        chat: {
+          ...wave.chat,
+          links_disabled: true,
+        },
+      },
+      drop: {
+        ...createStoredDrop(),
+        parts: [
+          {
+            content: "https://d3lqz0a4bldqgf.cloudfront.net/drops/asset.mp4",
+            quoted_drop: null,
+            media: [],
+          },
+        ],
+      },
+    });
+
+    const submitButton = screen.getByText("submit");
+
+    expect(
+      screen.queryByText("Links are not allowed in this wave")
+    ).not.toBeInTheDocument();
+    expect(submitButton).not.toBeDisabled();
+
+    await userEvent.click(submitButton);
+
+    await waitFor(() => expect(submitDrop).toHaveBeenCalledTimes(1));
+    expect(submitDrop.mock.calls[0]?.[0].drop.drop_type).toBe(ApiDropType.Chat);
+  });
+
   it("does not block participatory submit with a link", async () => {
     const submitDrop = jest.fn(() => true);
     renderSubject({

--- a/__tests__/components/waves/drops/EditDropLexical.test.tsx
+++ b/__tests__/components/waves/drops/EditDropLexical.test.tsx
@@ -13,7 +13,7 @@ const useDeviceInfoMock = jest.fn(() => ({
   isApp: false,
   isMobileDevice: false,
 }));
-const mockContainsOpenGraphPreviewLink = jest.fn(() => false);
+const mockContainsDisallowedLink = jest.fn(() => false);
 
 const rootMock = {
   getChildren: jest.fn(() => [] as unknown[]),
@@ -225,8 +225,8 @@ const {
 jest.mock(
   "@/components/drops/view/part/dropPartMarkdown/linkPreviewDetection",
   () => ({
-    containsOpenGraphPreviewLink: (...args: unknown[]) =>
-      mockContainsOpenGraphPreviewLink(...args),
+    containsDisallowedLink: (...args: unknown[]) =>
+      mockContainsDisallowedLink(...args),
   })
 );
 jest.mock(
@@ -288,7 +288,7 @@ describe("EditDropLexical", () => {
     rootMock.getChildren.mockReturnValue([]);
     rootMock.getAllTextNodes.mockReturnValue([]);
     mentionSelectHandler = null;
-    mockContainsOpenGraphPreviewLink.mockReturnValue(false);
+    mockContainsDisallowedLink.mockReturnValue(false);
     useDeviceInfoMock.mockReturnValue({
       isApp: false,
       isMobileDevice: false,
@@ -511,7 +511,7 @@ describe("EditDropLexical", () => {
     const onSave = jest.fn();
     const onCancel = jest.fn();
     exportDropMarkdownMock.mockReturnValue("https://example.com/article");
-    mockContainsOpenGraphPreviewLink.mockReturnValue(true);
+    mockContainsDisallowedLink.mockReturnValue(true);
 
     render(
       <EditDropLexical

--- a/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.ts
+++ b/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.ts
@@ -1,4 +1,5 @@
 import { ensureStableSeizeLink } from "@/helpers/SeizeLinkParser";
+import { publicEnv } from "@/config/env";
 
 import {
   isDirectImageUrl,
@@ -6,6 +7,7 @@ import {
   shouldUseOpenGraphPreview,
 } from "./linkUtils";
 
+const DEFAULT_CLOUDFRONT_DOMAIN = "https://d3lqz0a4bldqgf.cloudfront.net";
 const RAW_URL_REGEX = /\b(?:https?:\/\/|www\.)[^\s<>"'`]+/gi;
 
 const stripMarkdownCode = (content: string): string =>
@@ -43,6 +45,23 @@ const normalizeHrefCandidate = (href: string): string => {
   return trimmed;
 };
 
+const getUrlOrigin = (href: string): string | null => {
+  try {
+    return new URL(href).origin;
+  } catch {
+    return null;
+  }
+};
+
+const getAllowedCloudfrontOrigin = (): string =>
+  getUrlOrigin(publicEnv.NEXT_PUBLIC_CLOUDFRONT_DOMAIN ?? "") ??
+  DEFAULT_CLOUDFRONT_DOMAIN;
+
+const isAllowedCloudfrontHref = (href: string): boolean => {
+  const hrefOrigin = getUrlOrigin(href);
+  return hrefOrigin !== null && hrefOrigin === getAllowedCloudfrontOrigin();
+};
+
 const isOpenGraphPreviewHref = (href: string): boolean => {
   const normalizedHref = normalizeHrefCandidate(href);
   if (!normalizedHref) {
@@ -51,6 +70,10 @@ const isOpenGraphPreviewHref = (href: string): boolean => {
 
   const stableHref = ensureStableSeizeLink(normalizedHref);
   const parsedUrl = parseUrl(stableHref);
+
+  if (isAllowedCloudfrontHref(stableHref)) {
+    return false;
+  }
 
   if (isDirectImageUrl(stableHref, parsedUrl)) {
     return false;

--- a/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.ts
+++ b/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.ts
@@ -1,13 +1,8 @@
 import { ensureStableSeizeLink } from "@/helpers/SeizeLinkParser";
 import { publicEnv } from "@/config/env";
 
-import {
-  isDirectImageUrl,
-  parseUrl,
-  shouldUseOpenGraphPreview,
-} from "./linkUtils";
-
 const DEFAULT_CLOUDFRONT_DOMAIN = "https://d3lqz0a4bldqgf.cloudfront.net";
+const TENOR_DOMAIN = "tenor.com";
 const RAW_URL_REGEX = /\b(?:https?:\/\/|www\.)[^\s<>"'`]+/gi;
 
 const stripMarkdownCode = (content: string): string =>
@@ -45,13 +40,16 @@ const normalizeHrefCandidate = (href: string): string => {
   return trimmed;
 };
 
-const getUrlOrigin = (href: string): string | null => {
+const parseUrl = (href: string): URL | null => {
   try {
-    return new URL(href).origin;
+    return new URL(href);
   } catch {
     return null;
   }
 };
+
+const getUrlOrigin = (href: string): string | null =>
+  parseUrl(href)?.origin ?? null;
 
 const getAllowedCloudfrontOrigin = (): string =>
   getUrlOrigin(publicEnv.NEXT_PUBLIC_CLOUDFRONT_DOMAIN ?? "") ??
@@ -62,24 +60,37 @@ const isAllowedCloudfrontHref = (href: string): boolean => {
   return hrefOrigin !== null && hrefOrigin === getAllowedCloudfrontOrigin();
 };
 
-const isOpenGraphPreviewHref = (href: string): boolean => {
+const isDomainOrSubdomain = (hostname: string, domain: string): boolean =>
+  hostname === domain || hostname.endsWith(`.${domain}`);
+
+const isAllowedTenorHref = (href: string): boolean => {
+  const url = parseUrl(href);
+  if (!url) {
+    return false;
+  }
+
+  const protocol = url.protocol.toLowerCase();
+  if (protocol !== "http:" && protocol !== "https:") {
+    return false;
+  }
+
+  return isDomainOrSubdomain(url.hostname.toLowerCase(), TENOR_DOMAIN);
+};
+
+const isDisallowedLinkHref = (href: string): boolean => {
   const normalizedHref = normalizeHrefCandidate(href);
   if (!normalizedHref) {
     return false;
   }
 
   const stableHref = ensureStableSeizeLink(normalizedHref);
-  const parsedUrl = parseUrl(stableHref);
-
-  if (isAllowedCloudfrontHref(stableHref)) {
+  if (!parseUrl(stableHref)) {
     return false;
   }
 
-  if (isDirectImageUrl(stableHref, parsedUrl)) {
-    return false;
-  }
-
-  return shouldUseOpenGraphPreview(stableHref, parsedUrl);
+  return (
+    !isAllowedCloudfrontHref(stableHref) && !isAllowedTenorHref(stableHref)
+  );
 };
 
 const skipWhitespace = (content: string, startIndex: number): number => {
@@ -164,65 +175,6 @@ const readMarkdownHref = (
     : readPlainHref(content, hrefStart);
 };
 
-const isMarkdownImageLink = (
-  content: string,
-  openBracketIndex: number
-): boolean => openBracketIndex > 0 && content[openBracketIndex - 1] === "!";
-
-const getMarkdownImageEnd = (
-  content: string,
-  imageStartIndex: number
-): number | null => {
-  const closeBracketIndex = content.indexOf("](", imageStartIndex + 2);
-  const newlineIndex = content.indexOf("\n", imageStartIndex + 2);
-
-  if (
-    closeBracketIndex === -1 ||
-    (newlineIndex !== -1 && newlineIndex < closeBracketIndex)
-  ) {
-    return null;
-  }
-
-  const hrefStart = skipWhitespace(content, closeBracketIndex + 2);
-  const hrefEnd =
-    content[hrefStart] === "<"
-      ? getAngleWrappedHrefEnd(content, hrefStart)
-      : getPlainHrefEnd(content, hrefStart);
-
-  if (hrefEnd === null) {
-    return null;
-  }
-
-  const closeParenIndex = skipWhitespace(content, hrefEnd);
-  return content[closeParenIndex] === ")" ? closeParenIndex + 1 : null;
-};
-
-const stripMarkdownImages = (content: string): string => {
-  let stripped = "";
-  let searchIndex = 0;
-
-  while (searchIndex < content.length) {
-    const imageStartIndex = content.indexOf("![", searchIndex);
-    if (imageStartIndex === -1) {
-      stripped += content.slice(searchIndex);
-      break;
-    }
-
-    stripped += content.slice(searchIndex, imageStartIndex);
-    const imageEndIndex = getMarkdownImageEnd(content, imageStartIndex);
-    if (imageEndIndex === null) {
-      stripped += content.slice(imageStartIndex, imageStartIndex + 2);
-      searchIndex = imageStartIndex + 2;
-      continue;
-    }
-
-    stripped += " ";
-    searchIndex = imageEndIndex;
-  }
-
-  return stripped;
-};
-
 const extractMarkdownLinkHrefs = (content: string): string[] => {
   const hrefs: string[] = [];
   let searchIndex = 0;
@@ -234,10 +186,7 @@ const extractMarkdownLinkHrefs = (content: string): string[] => {
     }
 
     const openBracketIndex = content.lastIndexOf("[", closeBracketIndex);
-    if (
-      openBracketIndex === -1 ||
-      isMarkdownImageLink(content, openBracketIndex)
-    ) {
+    if (openBracketIndex === -1) {
       searchIndex = closeBracketIndex + 2;
       continue;
     }
@@ -253,7 +202,7 @@ const extractMarkdownLinkHrefs = (content: string): string[] => {
   return hrefs;
 };
 
-export const containsOpenGraphPreviewLink = (
+export const containsDisallowedLink = (
   content: string | null | undefined
 ): boolean => {
   if (!content) {
@@ -264,17 +213,15 @@ export const containsOpenGraphPreviewLink = (
   let match: RegExpExecArray | null;
 
   for (const href of extractMarkdownLinkHrefs(withoutCode)) {
-    if (isOpenGraphPreviewHref(href)) {
+    if (isDisallowedLinkHref(href)) {
       return true;
     }
   }
 
-  const withoutMarkdownImages = stripMarkdownImages(withoutCode);
-
   RAW_URL_REGEX.lastIndex = 0;
-  while ((match = RAW_URL_REGEX.exec(withoutMarkdownImages)) !== null) {
+  while ((match = RAW_URL_REGEX.exec(withoutCode)) !== null) {
     const href = match[0];
-    if (href && isOpenGraphPreviewHref(href)) {
+    if (href && isDisallowedLinkHref(href)) {
       return true;
     }
   }

--- a/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.ts
+++ b/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.ts
@@ -3,6 +3,12 @@ import { publicEnv } from "@/config/env";
 
 const DEFAULT_CLOUDFRONT_DOMAIN = "https://d3lqz0a4bldqgf.cloudfront.net";
 const TENOR_DOMAIN = "tenor.com";
+const ALLOWED_TENOR_PATH_EXTENSIONS = [
+  ".mp4",
+  ".gif",
+  ".jpg",
+  ".webp",
+] as const;
 const RAW_URL_REGEX = /\b(?:https?:\/\/|www\.)[^\s<>"'`]+/gi;
 
 const stripMarkdownCode = (content: string): string =>
@@ -74,7 +80,14 @@ const isAllowedTenorHref = (href: string): boolean => {
     return false;
   }
 
-  return isDomainOrSubdomain(url.hostname.toLowerCase(), TENOR_DOMAIN);
+  if (!isDomainOrSubdomain(url.hostname.toLowerCase(), TENOR_DOMAIN)) {
+    return false;
+  }
+
+  const pathname = url.pathname.toLowerCase();
+  return ALLOWED_TENOR_PATH_EXTENSIONS.some((extension) =>
+    pathname.endsWith(extension)
+  );
 };
 
 const isDisallowedLinkHref = (href: string): boolean => {

--- a/components/waves/CreateDropContent.tsx
+++ b/components/waves/CreateDropContent.tsx
@@ -54,7 +54,7 @@ import { CreateDropSubmit } from "./CreateDropSubmit";
 import SlowModeChatNotice from "./SlowModeChatNotice";
 
 import { exportDropMarkdown } from "@/components/waves/drops/normalizeDropMarkdown";
-import { containsOpenGraphPreviewLink } from "@/components/drops/view/part/dropPartMarkdown/linkPreviewDetection";
+import { containsDisallowedLink } from "@/components/drops/view/part/dropPartMarkdown/linkPreviewDetection";
 import { getMentionedGroupsFromEditorState } from "@/components/drops/create/lexical/utils/groupMentionDetection";
 import { ProcessIncomingDropType } from "@/contexts/wave/hooks/useWaveRealtimeUpdater";
 import { useMyStream } from "@/contexts/wave/MyStreamContext";
@@ -789,7 +789,7 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
       ...(drop?.parts.map((part) => part.content ?? null) ?? []),
     ];
 
-    return contentParts.some(containsOpenGraphPreviewLink);
+    return contentParts.some(containsDisallowedLink);
   }, [drop?.parts, getMarkdown, isChatLinksRestrictionActive, isDropMode]);
   const isLinksSubmitBlocked = hasChatContentWithLink;
   const canSubmit =
@@ -1194,9 +1194,7 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
     if (
       dropRequest.drop_type === ApiDropType.Chat &&
       isChatLinksRestrictionActive &&
-      dropRequest.parts.some((part) =>
-        containsOpenGraphPreviewLink(part.content)
-      )
+      dropRequest.parts.some((part) => containsDisallowedLink(part.content))
     ) {
       return;
     }

--- a/components/waves/drops/EditDropLexical.tsx
+++ b/components/waves/drops/EditDropLexical.tsx
@@ -81,7 +81,7 @@ import {
   normalizeDropMarkdown,
 } from "./normalizeDropMarkdown";
 import { areMentionedGroupsEqual } from "@/helpers/waves/drop-group-mentions";
-import { containsOpenGraphPreviewLink } from "@/components/drops/view/part/dropPartMarkdown/linkPreviewDetection";
+import { containsDisallowedLink } from "@/components/drops/view/part/dropPartMarkdown/linkPreviewDetection";
 
 interface EditDropLexicalProps {
   readonly initialContent: string;
@@ -558,7 +558,7 @@ const EditDropLexical: React.FC<EditDropLexicalProps> = ({
     );
   }, [editorState, exportMarkdownTransformers, normalizedInitialContent]);
   const isSaveBlockedByLinks =
-    !!linkRestrictionMessage && containsOpenGraphPreviewLink(currentMarkdown);
+    !!linkRestrictionMessage && containsDisallowedLink(currentMarkdown);
 
   const handleMentionSelect = useCallback(
     (user: Omit<MentionedUser, "current_handle">) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened link-restriction behavior: direct image/video media URLs and some markdown preview links are now blocked; code-fenced URLs and non-URL markdown image placeholders remain ignored. Exact CloudFront and official Tenor hosts are allowed; lookalike/substring hosts and non-allowed Tenor/Google API variants are blocked. Composer/save/submit flows correctly show restriction notices and prevent submission when links are disabled.

* **Tests**
  * Added coverage for CloudFront, Tenor, lookalike hosts, media URL variants, and chat-specific blocking/submission scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-frontend/pull/2448?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->