### PR TITLE
Replaced generic wave badges in chats with profile wave pfps

### DIFF
--- a/__tests__/components/tweets/ExpandableTweetPreview.test.tsx
+++ b/__tests__/components/tweets/ExpandableTweetPreview.test.tsx
@@ -3,9 +3,7 @@ import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import type { Tweet } from "react-tweet/api";
 
-import ExpandableTweetPreview, {
-  normalizeTweetForEnrichment,
-} from "@/components/tweets/ExpandableTweetPreview";
+import ExpandableTweetPreview from "@/components/tweets/ExpandableTweetPreview";
 import { enrichTweet, useTweet } from "react-tweet";
 
 jest.mock("react-tweet", () => ({
@@ -86,15 +84,33 @@ describe("ExpandableTweetPreview", () => {
       quoted_tweet: quotedTweet,
     } as unknown as Tweet;
 
-    const normalized = normalizeTweetForEnrichment(tweet);
+    const href = "https://x.com/6529/status/123";
+    mockUseTweet.mockReturnValue({
+      data: tweet,
+      isLoading: false,
+      error: undefined,
+    });
+    mockEnrichTweet.mockReturnValue(null as never);
 
-    expect(normalized.entities).toEqual({
+    render(
+      <ExpandableTweetPreview
+        href={href}
+        tweetId="123"
+        renderFallback={(fallbackHref) => (
+          <a href={fallbackHref}>Open fallback tweet</a>
+        )}
+      />
+    );
+
+    const normalizedTweet = mockEnrichTweet.mock.calls[0]?.[0];
+
+    expect(normalizedTweet?.entities).toEqual({
       hashtags: [],
       urls: [],
       user_mentions: [],
       symbols: [],
     });
-    expect(normalized.quoted_tweet?.entities).toEqual({
+    expect(normalizedTweet?.quoted_tweet?.entities).toEqual({
       hashtags: [],
       urls: [],
       user_mentions: [],

--- a/__tests__/components/waves/drops/DropAuthorBadges.test.tsx
+++ b/__tests__/components/waves/drops/DropAuthorBadges.test.tsx
@@ -10,6 +10,7 @@ const mockArtistHandleBadgeClick = jest.fn();
 const mockArtistHandleModalClose = jest.fn();
 const mockWaveCreatorHandleBadgeClick = jest.fn();
 const mockWaveCreatorHandleModalClose = jest.fn();
+const mockRouterPush = jest.fn();
 
 const mockUseArtistPreviewModal = jest.fn();
 const mockUseWaveCreatorPreviewModal = jest.fn();
@@ -24,6 +25,9 @@ type ArtistActivityBadgeProps = {
 type WaveCreatorBadgeProps = {
   readonly tooltipId?: string;
   readonly onBadgeClick?: () => void;
+  readonly showWaveDetails?: boolean;
+  readonly waveName?: string | null;
+  readonly wavePfp?: string | null;
 };
 
 type ArtistPreviewModalProps = {
@@ -46,6 +50,12 @@ jest.mock("@/hooks/useArtistPreviewModal", () => ({
 
 jest.mock("@/hooks/useWaveCreatorPreviewModal", () => ({
   useWaveCreatorPreviewModal: () => mockUseWaveCreatorPreviewModal(),
+}));
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+  }),
 }));
 
 jest.mock("@/helpers/tooltip.helpers", () => ({
@@ -74,11 +84,20 @@ jest.mock("@/components/waves/drops/ArtistActivityBadge", () => ({
 }));
 
 jest.mock("@/components/waves/drops/WaveCreatorBadge", () => ({
-  WaveCreatorBadge: ({ tooltipId, onBadgeClick }: WaveCreatorBadgeProps) => (
+  WaveCreatorBadge: ({
+    tooltipId,
+    onBadgeClick,
+    showWaveDetails,
+    waveName,
+    wavePfp,
+  }: WaveCreatorBadgeProps) => (
     <button
       type="button"
       data-testid="wave-creator-badge"
       data-tooltip-id={tooltipId}
+      data-show-wave-details={String(showWaveDetails)}
+      data-wave-name={waveName ?? ""}
+      data-wave-pfp={wavePfp ?? ""}
       onClick={onBadgeClick}
     >
       Wave Creator
@@ -125,6 +144,7 @@ const baseProfile = {
 describe("DropAuthorBadges", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockRouterPush.mockClear();
     mockUseArtistPreviewModal.mockReturnValue({
       isModalOpen: false,
       activeTab: "active",
@@ -175,6 +195,8 @@ describe("DropAuthorBadges", () => {
             artist_of_main_stage_submissions: 1,
             artist_of_memes: 1,
             profile_wave_id: "profile-wave-1",
+            profile_wave_name: "Profile Wave",
+            profile_wave_pfp: "https://example.com/wave.png",
           },
         }}
         onArtistPreviewOpen={onArtistPreviewOpen}
@@ -196,6 +218,8 @@ describe("DropAuthorBadges", () => {
           artist_of_main_stage_submissions: 1,
           artist_of_memes: 1,
           profile_wave_id: "profile-wave-1",
+          profile_wave_name: "Profile Wave",
+          profile_wave_pfp: "https://example.com/wave.png",
         },
         is_wave_creator: true,
         profile_wave_id: "profile-wave-1",
@@ -216,6 +240,38 @@ describe("DropAuthorBadges", () => {
 
     expect(screen.getByTestId("wave-creator-badge")).toBeInTheDocument();
     expect(screen.queryByTestId("artist-activity-badge")).toBeNull();
+  });
+
+  it("passes profile wave details to the chat feed badge and opens the wave", () => {
+    render(
+      <DropAuthorBadges
+        profile={{
+          ...baseProfile,
+          badges: {
+            artist_of_main_stage_submissions: 0,
+            artist_of_memes: 0,
+            profile_wave_id: "profile-wave-1",
+            profile_wave_name: "Profile Wave",
+            profile_wave_pfp: "https://example.com/wave.png",
+          },
+        }}
+        showProfileWaveDetails
+      />
+    );
+
+    const badge = screen.getByTestId("wave-creator-badge");
+    expect(badge).toHaveAttribute("data-show-wave-details", "true");
+    expect(badge).toHaveAttribute("data-wave-name", "Profile Wave");
+    expect(badge).toHaveAttribute(
+      "data-wave-pfp",
+      "https://example.com/wave.png"
+    );
+
+    fireEvent.click(badge);
+
+    expect(mockCloseAllCustomTooltips).toHaveBeenCalledTimes(1);
+    expect(mockRouterPush).toHaveBeenCalledWith("/waves/profile-wave-1");
+    expect(mockWaveCreatorHandleBadgeClick).not.toHaveBeenCalled();
   });
 
   it("renders both badges and forwards tooltip id prefix", () => {

--- a/__tests__/services/api/wave-drops-v2-api.test.ts
+++ b/__tests__/services/api/wave-drops-v2-api.test.ts
@@ -169,6 +169,8 @@ describe("fetchWaveDropsFeedV2", () => {
       artist_of_main_stage_submissions: 1,
       artist_of_memes: 1,
       profile_wave_id: "profile-wave-1",
+      profile_wave_name: "Profile Wave",
+      profile_wave_pfp: "https://example.com/wave.png",
     };
 
     commonApiFetchMock.mockResolvedValueOnce({

--- a/components/tweets/ExpandableTweetPreview.tsx
+++ b/components/tweets/ExpandableTweetPreview.tsx
@@ -42,7 +42,7 @@ const normalizeTweetEntities = (
   ...(Array.isArray(entities?.media) ? { media: entities.media } : {}),
 });
 
-export const normalizeTweetForEnrichment = (tweet: Tweet): Tweet => {
+const normalizeTweetForEnrichment = (tweet: Tweet): Tweet => {
   const normalizedTweet = {
     ...tweet,
     entities: normalizeTweetEntities(tweet.entities),

--- a/components/waves/drops/DropAuthorBadges.tsx
+++ b/components/waves/drops/DropAuthorBadges.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import type { ApiProfileMin } from "@/generated/models/ApiProfileMin";
+import { getWaveRoute } from "@/helpers/navigation.helpers";
 import {
   getSubmissionCount,
   getTrophyArtworkCount,
@@ -17,6 +18,7 @@ import { ArtistPreviewModal } from "./ArtistPreviewModal";
 import { WaveCreatorBadge } from "./WaveCreatorBadge";
 import { WaveCreatorPreviewModal } from "./WaveCreatorPreviewModal";
 import type { ApiProfileClassification } from "@/generated/models/ApiProfileClassification";
+import { useRouter } from "next/navigation";
 
 interface DropAuthorBadgesProfile {
   readonly id?: string | null;
@@ -38,11 +40,15 @@ interface DropAuthorBadgesProfile {
   readonly winner_main_stage_drop_ids?: readonly string[] | null;
   readonly artist_of_prevote_cards?: readonly number[] | null;
   readonly profile_wave_id?: string | null;
+  readonly profile_wave_name?: string | null;
+  readonly profile_wave_pfp?: string | null;
   readonly is_wave_creator?: boolean | null;
   readonly badges?: {
     readonly artist_of_main_stage_submissions?: number | null;
     readonly artist_of_memes?: number | null;
     readonly profile_wave_id?: string | null;
+    readonly profile_wave_name?: string | null;
+    readonly profile_wave_pfp?: string | null;
   } | null;
   readonly classification: ApiProfileClassification;
   readonly sub_classification: string | null;
@@ -57,6 +63,7 @@ interface DropAuthorBadgesProps {
   readonly tooltipIdPrefix?: string | undefined;
   readonly className?: string | undefined;
   readonly size?: "default" | "compact" | undefined;
+  readonly showProfileWaveDetails?: boolean | undefined;
   readonly onArtistPreviewOpen?:
     | ((params: {
         readonly user: ApiProfileMin;
@@ -72,6 +79,12 @@ const DEFAULT_CONTAINER_CLASS = "tw-inline-flex tw-items-center tw-gap-x-1.5";
 
 const getProfileWaveId = (profile: DropAuthorBadgesProfile): string | null =>
   profile.profile_wave_id ?? profile.badges?.profile_wave_id ?? null;
+
+const getProfileWaveName = (profile: DropAuthorBadgesProfile): string | null =>
+  profile.profile_wave_name ?? profile.badges?.profile_wave_name ?? null;
+
+const getProfileWavePfp = (profile: DropAuthorBadgesProfile): string | null =>
+  profile.profile_wave_pfp ?? profile.badges?.profile_wave_pfp ?? null;
 
 const toApiProfileMin = (
   profile: DropAuthorBadgesProfile
@@ -125,14 +138,19 @@ export const DropAuthorBadges: React.FC<DropAuthorBadgesProps> = ({
   tooltipIdPrefix = "author-badges",
   className = DEFAULT_CONTAINER_CLASS,
   size = "default",
+  showProfileWaveDetails = false,
   onArtistPreviewOpen,
   onWaveCreatorPreviewOpen,
 }) => {
+  const router = useRouter();
+  const profileWaveId = getProfileWaveId(profile);
   const submissionCount = getSubmissionCount(profile);
   const trophyCount = getTrophyArtworkCount(profile);
   const hasActivityBadge = submissionCount > 0 || trophyCount > 0;
   const isWaveCreator =
-    profile.is_wave_creator === true || getProfileWaveId(profile) !== null;
+    profile.is_wave_creator === true || profileWaveId !== null;
+  const profileWaveName = getProfileWaveName(profile);
+  const profileWavePfp = getProfileWavePfp(profile);
 
   const modalUser = React.useMemo(() => toApiProfileMin(profile), [profile]);
 
@@ -164,12 +182,29 @@ export const DropAuthorBadges: React.FC<DropAuthorBadgesProps> = ({
 
   const onWaveCreatorBadgeClick = React.useCallback(() => {
     closeAllCustomTooltips();
+    if (showProfileWaveDetails && profileWaveId) {
+      router.push(
+        getWaveRoute({
+          waveId: profileWaveId,
+          isDirectMessage: false,
+          isApp: false,
+        })
+      );
+      return;
+    }
     if (onWaveCreatorPreviewOpen) {
       onWaveCreatorPreviewOpen(modalUser);
       return;
     }
     handleWaveCreatorBadgeClick();
-  }, [handleWaveCreatorBadgeClick, modalUser, onWaveCreatorPreviewOpen]);
+  }, [
+    handleWaveCreatorBadgeClick,
+    modalUser,
+    onWaveCreatorPreviewOpen,
+    profileWaveId,
+    router,
+    showProfileWaveDetails,
+  ]);
 
   if (!hasActivityBadge && !isWaveCreator) {
     return null;
@@ -192,6 +227,9 @@ export const DropAuthorBadges: React.FC<DropAuthorBadgesProps> = ({
             tooltipId={`${tooltipIdPrefix}-wave-creator`}
             onBadgeClick={onWaveCreatorBadgeClick}
             size={size}
+            showWaveDetails={showProfileWaveDetails && profileWaveId !== null}
+            waveName={profileWaveName}
+            wavePfp={profileWavePfp}
           />
         )}
       </div>

--- a/components/waves/drops/WaveCreatorBadge.tsx
+++ b/components/waves/drops/WaveCreatorBadge.tsx
@@ -7,7 +7,7 @@ import { faWater } from "@fortawesome/free-solid-svg-icons";
 import { Tooltip } from "react-tooltip";
 import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
 import useIsMobileDevice from "@/hooks/isMobileDevice";
-import { resolveIpfsUrlSync } from "@/components/ipfs/IPFSContext";
+import { getScaledImageUri, ImageScale } from "@/helpers/image.helpers";
 
 interface WaveCreatorBadgeProps {
   readonly tooltipId?: string | undefined;
@@ -45,7 +45,7 @@ export const WaveCreatorBadge: React.FC<WaveCreatorBadgeProps> = ({
   const normalizedWaveName = getTrimmedText(waveName);
   const normalizedWavePfp = getTrimmedText(wavePfp);
   const waveImageSrc = normalizedWavePfp
-    ? resolveIpfsUrlSync(normalizedWavePfp)
+    ? getScaledImageUri(normalizedWavePfp, ImageScale.W_AUTO_H_50)
     : null;
   const shouldShowWaveDetails = showWaveDetails && size !== "compact";
   const displayWaveName = normalizedWaveName ?? "profile wave";

--- a/components/waves/drops/WaveCreatorBadge.tsx
+++ b/components/waves/drops/WaveCreatorBadge.tsx
@@ -1,33 +1,101 @@
 "use client";
 
-import React, { useId } from "react";
+import React, { useId, useState } from "react";
+import Image from "next/image";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faWater } from "@fortawesome/free-solid-svg-icons";
 import { Tooltip } from "react-tooltip";
 import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
 import useIsMobileDevice from "@/hooks/isMobileDevice";
+import { resolveIpfsUrlSync } from "@/components/ipfs/IPFSContext";
 
 interface WaveCreatorBadgeProps {
   readonly tooltipId?: string | undefined;
   readonly onBadgeClick?: (() => void) | undefined;
   readonly size?: "default" | "compact" | undefined;
+  readonly waveName?: string | null | undefined;
+  readonly wavePfp?: string | null | undefined;
+  readonly showWaveDetails?: boolean | undefined;
 }
+
+const getTrimmedText = (value?: string | null): string | null => {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed;
+};
 
 export const WaveCreatorBadge: React.FC<WaveCreatorBadgeProps> = ({
   tooltipId = "wave-creator-badge",
   onBadgeClick,
   size = "default",
+  waveName,
+  wavePfp,
+  showWaveDetails = false,
 }) => {
   const isMobile = useIsMobileDevice();
   const id = useId();
   const uniqueTooltipId = `${tooltipId}-${id}`;
   const [isTooltipOpen, setIsTooltipOpen] = React.useState(false);
+  const [failedImageSrc, setFailedImageSrc] = useState<string | null>(null);
   const showTooltip = isMobile === false;
   const dataTooltipId = showTooltip ? uniqueTooltipId : undefined;
+  const normalizedWaveName = getTrimmedText(waveName);
+  const normalizedWavePfp = getTrimmedText(wavePfp);
+  const waveImageSrc = normalizedWavePfp
+    ? resolveIpfsUrlSync(normalizedWavePfp)
+    : null;
+  const shouldShowWaveDetails = showWaveDetails && size !== "compact";
+  const displayWaveName = normalizedWaveName ?? "profile wave";
+  const tooltipContent = shouldShowWaveDetails
+    ? displayWaveName
+    : "View created waves";
+  const ariaLabel = shouldShowWaveDetails
+    ? `Open ${displayWaveName}`
+    : "View created waves";
   const buttonSizeClassName =
     size === "compact" ? "tw-h-[18px] tw-w-[18px]" : "tw-h-5 tw-w-5";
   const iconSizeClassName =
     size === "compact" ? "tw-h-[9px] tw-w-[9px]" : "tw-h-2.5 tw-w-2.5";
+  const buttonClassName = shouldShowWaveDetails
+    ? `tw-inline-flex ${buttonSizeClassName} tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-md tw-border tw-border-solid tw-border-white/15 tw-bg-white/5 tw-text-iron-200 tw-outline-none tw-ring-0 tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-white/20 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950 desktop-hover:hover:tw-border-white/25 desktop-hover:hover:tw-bg-white/10 desktop-hover:hover:tw-text-iron-100`
+    : `tw-inline-flex ${buttonSizeClassName} tw-items-center tw-justify-center tw-rounded-md tw-border tw-border-solid tw-border-white/15 tw-bg-white/5 tw-text-white/60 tw-outline-none tw-ring-0 tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-white/20 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950 desktop-hover:hover:tw-border-white/20 desktop-hover:hover:tw-bg-white/10 desktop-hover:hover:tw-text-white/70`;
+  const badgeContent = (() => {
+    if (!shouldShowWaveDetails) {
+      return (
+        <FontAwesomeIcon
+          icon={faWater}
+          className={`${iconSizeClassName} tw-flex-shrink-0 tw-text-current`}
+        />
+      );
+    }
+
+    const imageSrc = waveImageSrc;
+
+    if (!imageSrc || failedImageSrc === imageSrc) {
+      return (
+        <FontAwesomeIcon
+          icon={faWater}
+          className={`${iconSizeClassName} tw-flex-shrink-0 tw-text-current`}
+          aria-hidden="true"
+        />
+      );
+    }
+
+    return (
+      <Image
+        src={imageSrc}
+        alt=""
+        width={20}
+        height={20}
+        unoptimized
+        className="tw-block tw-object-cover"
+        onError={() => setFailedImageSrc(imageSrc)}
+      />
+    );
+  })();
 
   return (
     <>
@@ -41,14 +109,11 @@ export const WaveCreatorBadge: React.FC<WaveCreatorBadgeProps> = ({
         }}
         onMouseEnter={() => setIsTooltipOpen(true)}
         onMouseLeave={() => setIsTooltipOpen(false)}
-        className={`tw-inline-flex ${buttonSizeClassName} tw-items-center tw-justify-center tw-rounded-md tw-border tw-border-solid tw-border-white/15 tw-bg-white/5 tw-text-white/60 tw-outline-none tw-ring-0 tw-transition-colors tw-duration-200 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-white/20 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950 desktop-hover:hover:tw-border-white/20 desktop-hover:hover:tw-bg-white/10 desktop-hover:hover:tw-text-white/70`}
-        aria-label="View created waves"
+        className={buttonClassName}
+        aria-label={ariaLabel}
         {...(dataTooltipId && { "data-tooltip-id": dataTooltipId })}
       >
-        <FontAwesomeIcon
-          icon={faWater}
-          className={`${iconSizeClassName} tw-flex-shrink-0 tw-text-current`}
-        />
+        {badgeContent}
       </button>
       {showTooltip && (
         <Tooltip
@@ -60,7 +125,7 @@ export const WaveCreatorBadge: React.FC<WaveCreatorBadgeProps> = ({
           style={TOOLTIP_STYLES}
           isOpen={isTooltipOpen}
         >
-          <span className="tw-text-xs">View created waves</span>
+          <span className="tw-text-xs">{tooltipContent}</span>
         </Tooltip>
       )}
     </>

--- a/components/waves/drops/WaveDropHeader.tsx
+++ b/components/waves/drops/WaveDropHeader.tsx
@@ -92,6 +92,7 @@ const WaveDropHeader: React.FC<WaveDropHeaderProps> = ({
               <DropAuthorBadges
                 profile={drop.author}
                 tooltipIdPrefix={`header-author-badges-${drop.id}`}
+                showProfileWaveDetails
               />
               {!isStackedTimestamp && (
                 <div className="tw-size-[3px] tw-flex-shrink-0 tw-rounded-full tw-bg-iron-600"></div>

--- a/docs/waves/drop-actions/feature-wave-creator-badge.md
+++ b/docs/waves/drop-actions/feature-wave-creator-badge.md
@@ -2,11 +2,14 @@
 
 ## Overview
 
-The wave creator badge is a compact water-drop button shown beside an author's
-identity when that profile is marked as a wave creator.
+The wave creator badge is shown beside an author's identity when that profile is
+marked as a wave creator. In the chat feed, V2 author badge data can render this
+as a square profile-wave picture badge.
 
-Selecting it opens the shared created-waves viewer (`Waves by {profile}`), so
-users can jump into waves that author created.
+Selecting the compact water-drop button opens the shared created-waves viewer
+(`Waves by {profile}`), so users can jump into waves that author created.
+Selecting the chat-feed profile-wave badge opens that author's profile wave
+directly.
 
 ## Location in the Site
 
@@ -23,17 +26,19 @@ users can jump into waves that author created.
 
 - Find the creator badge beside the author's handle, level badge, and other
   author-status badges.
-- Select the water-drop button.
-- On non-mobile layouts, hover tooltip text is `View created waves`.
+- Select the water-drop button, or the profile-wave badge in the chat feed.
+- On non-mobile layouts, hover tooltip text is `View created waves` for the
+  compact button and `{wave}` for the chat-feed profile-wave badge.
 
 ## User Journey
 
 1. Open a profile header, wave drop, direct-message drop, or supported author
    hover card.
-2. If the author is a wave creator, the water-drop badge appears in the author
-   identity row.
+2. If the author is a wave creator, the water-drop badge or profile-wave badge
+   appears in the author identity row.
 3. Select the badge.
-4. The shared `Waves by {profile}` viewer opens.
+4. The shared `Waves by {profile}` viewer opens, or the profile wave opens
+   directly from the chat-feed badge.
 5. Review created-wave rows, then select a row to open that wave at
    `/waves/{waveId}`.
 
@@ -51,7 +56,10 @@ users can jump into waves that author created.
 
 ## Edge Cases
 
-- If `is_wave_creator` is false or missing, the badge is hidden.
+- If `is_wave_creator` is false or missing and no `profile_wave_id` is present,
+  the badge is hidden.
+- If chat-feed profile-wave picture data is missing or fails to load, the badge
+  falls back to the water-drop icon.
 - Touch/mobile layouts do not rely on hover tooltip copy; tapping the badge
   still opens the viewer.
 - The created-waves viewer excludes direct-message threads from authored-wave

--- a/docs/waves/drop-actions/feature-wave-creator-badge.md
+++ b/docs/waves/drop-actions/feature-wave-creator-badge.md
@@ -39,8 +39,9 @@ directly.
 3. Select the badge.
 4. The shared `Waves by {profile}` viewer opens, or the profile wave opens
    directly from the chat-feed badge.
-5. Review created-wave rows, then select a row to open that wave at
-   `/waves/{waveId}`.
+5. If the viewer opened, review created-wave rows, then select a row to open
+   that wave at `/waves/{waveId}`; if the profile wave opened directly, skip
+   this step.
 
 ## Common Scenarios
 

--- a/generated/models/ApiIdentityOverviewBadges.ts
+++ b/generated/models/ApiIdentityOverviewBadges.ts
@@ -17,6 +17,8 @@ export class ApiIdentityOverviewBadges {
     'artist_of_main_stage_submissions': number;
     'artist_of_memes': number;
     'profile_wave_id'?: string;
+    'profile_wave_name'?: string;
+    'profile_wave_pfp'?: string | null;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -38,6 +40,18 @@ export class ApiIdentityOverviewBadges {
         {
             "name": "profile_wave_id",
             "baseName": "profile_wave_id",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "profile_wave_name",
+            "baseName": "profile_wave_name",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "profile_wave_pfp",
+            "baseName": "profile_wave_pfp",
             "type": "string",
             "format": ""
         }    ];

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11089,6 +11089,11 @@ components:
           format: int64
         profile_wave_id:
           type: string
+        profile_wave_name:
+          type: string
+        profile_wave_pfp:
+          type: string
+          nullable: true
     ApiIdentityOverviewContextProfileContext:
       type: object
       required:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wave creator badges can show a creator’s profile wave name and picture when available.
  * Tapping/clicking a profile-wave badge from the feed navigates directly to that wave’s profile.

* **Documentation**
  * Updated docs describing new badge behavior, entry points, tooltip text, and edge-case fallbacks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-frontend/pull/2454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->