### PR TITLE
Fix profile wave hovercard loading state

### DIFF
--- a/__tests__/components/waves/drops/CurationWavePreviewCard.test.tsx
+++ b/__tests__/components/waves/drops/CurationWavePreviewCard.test.tsx
@@ -1,0 +1,176 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { CurationWavePreviewCard } from "@/components/waves/drops/CurationWavePreviewCard";
+import type { ApiWave } from "@/generated/models/ApiWave";
+import { useProfileWave } from "@/hooks/useProfileWave";
+import { useWaveById } from "@/hooks/useWaveById";
+import { useWaveCurationPreviewDrops } from "@/hooks/useWaveCurationPreviewDrops";
+import { useWaveCurations } from "@/hooks/waves/useWaveCurations";
+
+jest.mock("@/hooks/useProfileWave", () => ({
+  useProfileWave: jest.fn(),
+}));
+
+jest.mock("@/hooks/useWaveById", () => ({
+  useWaveById: jest.fn(),
+}));
+
+jest.mock("@/hooks/useWaveCurationPreviewDrops", () => ({
+  useWaveCurationPreviewDrops: jest.fn(),
+}));
+
+jest.mock("@/hooks/waves/useWaveCurations", () => ({
+  useWaveCurations: jest.fn(),
+}));
+
+jest.mock("@/components/common/FallbackImage", () => ({
+  FallbackImage: ({
+    alt,
+    fallbackSrc,
+    primarySrc,
+  }: {
+    readonly alt: string;
+    readonly fallbackSrc: string;
+    readonly primarySrc: string;
+  }) => <img alt={alt} src={primarySrc || fallbackSrc} />,
+}));
+
+jest.mock("@/helpers/image.helpers", () => ({
+  ImageScale: {
+    W_200_H_200: "W_200_H_200",
+  },
+  getScaledImageUri: (url: string) => `scaled:${url}`,
+}));
+
+jest.mock("@fortawesome/react-fontawesome", () => ({
+  FontAwesomeIcon: () => <span data-testid="wave-fallback-icon" />,
+}));
+
+jest.mock("@heroicons/react/24/outline", () => ({
+  ArrowRightIcon: () => <span aria-hidden="true" />,
+  LinkIcon: () => <span aria-hidden="true" />,
+  PlayIcon: () => <span aria-hidden="true" />,
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    prefetch: _prefetch,
+    ...props
+  }: {
+    readonly children: React.ReactNode;
+    readonly href: string;
+    readonly prefetch?: boolean;
+    readonly className?: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const useProfileWaveMock = useProfileWave as jest.Mock;
+const useWaveByIdMock = useWaveById as jest.Mock;
+const useWaveCurationPreviewDropsMock =
+  useWaveCurationPreviewDrops as jest.Mock;
+const useWaveCurationsMock = useWaveCurations as jest.Mock;
+
+const createWave = (): ApiWave =>
+  ({
+    id: "wave-1",
+    name: "Profile Wave",
+    picture: null,
+    author: {
+      banner1_color: null,
+      banner2_color: null,
+      handle: "alice",
+      primary_address: "0xabc",
+    },
+    chat: {
+      scope: {
+        group: {
+          is_direct_message: false,
+        },
+      },
+    },
+    description_drop: {
+      parts: [],
+    },
+  }) as ApiWave;
+
+describe("CurationWavePreviewCard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useWaveByIdMock.mockReturnValue({
+      isError: false,
+      wave: createWave(),
+    });
+    useProfileWaveMock.mockReturnValue({
+      data: undefined,
+      isError: false,
+    });
+    useWaveCurationsMock.mockReturnValue({
+      data: [],
+      isError: false,
+      isFetched: true,
+    });
+    useWaveCurationPreviewDropsMock.mockReturnValue({
+      drops: [],
+      isError: false,
+      isFetched: false,
+    });
+  });
+
+  it("keeps loading visible while fallback curations have not resolved", () => {
+    useWaveCurationsMock.mockReturnValue({
+      data: undefined,
+      isError: false,
+      isFetched: false,
+    });
+
+    render(<CurationWavePreviewCard waveId="wave-1" />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Loading...");
+    expect(screen.queryByText("No curated drops yet.")).not.toBeInTheDocument();
+  });
+
+  it("keeps loading visible while preview drops have not resolved", () => {
+    useProfileWaveMock.mockReturnValue({
+      data: {
+        profile_curation_id: "curation-1",
+        profile_wave_id: "wave-1",
+      },
+      isError: false,
+    });
+
+    render(<CurationWavePreviewCard waveId="wave-1" profileIdentity="alice" />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Loading...");
+    expect(screen.queryByText("No curated drops yet.")).not.toBeInTheDocument();
+  });
+
+  it("omits empty copy after preview drops resolve with no items", () => {
+    useProfileWaveMock.mockReturnValue({
+      data: {
+        profile_curation_id: "curation-1",
+        profile_wave_id: "wave-1",
+      },
+      isError: false,
+    });
+    useWaveCurationPreviewDropsMock.mockReturnValue({
+      drops: [],
+      isError: false,
+      isFetched: true,
+    });
+
+    render(<CurationWavePreviewCard waveId="wave-1" profileIdentity="alice" />);
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.queryByText("No curated drops yet.")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open wave/i })).toBeVisible();
+  });
+});

--- a/__tests__/components/waves/drops/CurationWavePreviewCard.test.tsx
+++ b/__tests__/components/waves/drops/CurationWavePreviewCard.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { CurationWavePreviewCard } from "@/components/waves/drops/CurationWavePreviewCard";
 import type { ApiWave } from "@/generated/models/ApiWave";
+import { getScaledImageUri, ImageScale } from "@/helpers/image.helpers";
 import { useProfileWave } from "@/hooks/useProfileWave";
 import { useWaveById } from "@/hooks/useWaveById";
 import { useWaveCurationPreviewDrops } from "@/hooks/useWaveCurationPreviewDrops";
@@ -38,9 +39,10 @@ jest.mock("@/components/common/FallbackImage", () => ({
 
 jest.mock("@/helpers/image.helpers", () => ({
   ImageScale: {
+    W_AUTO_H_50: "W_AUTO_H_50",
     W_200_H_200: "W_200_H_200",
   },
-  getScaledImageUri: (url: string) => `scaled:${url}`,
+  getScaledImageUri: jest.fn((url: string) => `scaled:${url}`),
 }));
 
 jest.mock("@fortawesome/react-fontawesome", () => ({
@@ -77,12 +79,13 @@ const useWaveByIdMock = useWaveById as jest.Mock;
 const useWaveCurationPreviewDropsMock =
   useWaveCurationPreviewDrops as jest.Mock;
 const useWaveCurationsMock = useWaveCurations as jest.Mock;
+const getScaledImageUriMock = getScaledImageUri as jest.Mock;
 
 const createWave = (): ApiWave =>
   ({
     id: "wave-1",
     name: "Profile Wave",
-    picture: null,
+    picture: "https://example.com/wave.png",
     author: {
       banner1_color: null,
       banner2_color: null,
@@ -171,6 +174,10 @@ describe("CurationWavePreviewCard", () => {
 
     expect(screen.queryByRole("status")).not.toBeInTheDocument();
     expect(screen.queryByText("No curated drops yet.")).not.toBeInTheDocument();
+    expect(getScaledImageUriMock).toHaveBeenCalledWith(
+      "https://example.com/wave.png",
+      ImageScale.W_AUTO_H_50
+    );
     expect(screen.getByRole("link", { name: /open wave/i })).toBeVisible();
   });
 });

--- a/components/waves/drops/CurationWavePreviewCard.tsx
+++ b/components/waves/drops/CurationWavePreviewCard.tsx
@@ -103,12 +103,9 @@ export const CurationWavePreviewCard: React.FC<
   variant = "hovercard",
 }) => {
   const normalizedProfileIdentity = getTrimmedText(profileIdentity);
-  const { wave } = useWaveById(waveId);
-  const {
-    data: profileWave,
-    isError: isProfileWaveError,
-    isFetching: isProfileWaveFetching,
-  } = useProfileWave({
+  const { wave, isError: isWaveError } = useWaveById(waveId);
+  const resolvedWave = wave?.id === waveId ? wave : undefined;
+  const { data: profileWave, isError: isProfileWaveError } = useProfileWave({
     identity: normalizedProfileIdentity,
     enabled: normalizedProfileIdentity !== null,
   });
@@ -122,41 +119,63 @@ export const CurationWavePreviewCard: React.FC<
       : null;
   const shouldLoadFallbackCurations =
     hasResolvedProfileWave && selectedProfileCurationId === null;
-  const { data: curations = [], isFetching: areCurationsFetching } =
-    useWaveCurations({
-      waveId,
-      enabled: shouldLoadFallbackCurations,
-    });
+  const {
+    data: curations = [],
+    isError: isCurationsError,
+    isFetched: areCurationsFetched,
+  } = useWaveCurations({
+    waveId,
+    enabled: shouldLoadFallbackCurations,
+  });
   const fallbackCurationId = shouldLoadFallbackCurations
     ? (curations.at(0)?.id ?? null)
     : null;
   const curationId = selectedProfileCurationId ?? fallbackCurationId;
-  const { drops, isFetching: areDropsFetching } = useWaveCurationPreviewDrops({
-    wave: wave ?? null,
+  const canFetchPreviewDrops =
+    hasResolvedProfileWave && curationId !== null && resolvedWave !== undefined;
+  const {
+    drops,
+    isError: isDropsError,
+    isFetched: areDropsFetched,
+  } = useWaveCurationPreviewDrops({
+    wave: resolvedWave ?? null,
     curationId,
     pageSize: PREVIEW_DROPS_FETCH_LIMIT,
-    enabled: hasResolvedProfileWave && curationId !== null,
+    enabled: canFetchPreviewDrops,
   });
 
-  const isFetching =
-    isProfileWaveFetching || areCurationsFetching || areDropsFetching;
+  const isProfileWaveUnresolved =
+    normalizedProfileIdentity !== null &&
+    profileWave === undefined &&
+    !isProfileWaveError;
+  const areFallbackCurationsUnresolved =
+    shouldLoadFallbackCurations && !areCurationsFetched && !isCurationsError;
+  const areWaveDetailsUnresolved =
+    curationId !== null && resolvedWave === undefined && !isWaveError;
+  const arePreviewDropsUnresolved =
+    canFetchPreviewDrops && !areDropsFetched && !isDropsError;
+  const isPreviewPending =
+    isProfileWaveUnresolved ||
+    areFallbackCurationsUnresolved ||
+    areWaveDetailsUnresolved ||
+    arePreviewDropsUnresolved;
   const firstDropWave = drops.at(0)?.wave;
   const waveName =
-    getTrimmedText(wave?.name) ??
+    getTrimmedText(resolvedWave?.name) ??
     getTrimmedText(fallbackName) ??
     getTrimmedText(firstDropWave?.name) ??
     "Featured wave";
   const wavePicture =
-    getTrimmedText(wave?.picture) ??
+    getTrimmedText(resolvedWave?.picture) ??
     getTrimmedText(fallbackPfp) ??
     getTrimmedText(firstDropWave?.picture);
-  const author = getWaveAuthor(wave);
-  const description = getWaveDescriptionPreviewText(wave);
+  const author = getWaveAuthor(resolvedWave);
+  const description = getWaveDescriptionPreviewText(resolvedWave);
   const previewItems = getPreviewItems(drops);
-  const waveHref = getWaveHref({ waveId, wave, curationId });
+  const waveHref = getWaveHref({ waveId, wave: resolvedWave, curationId });
   const bannerBackground = getBannerBackground({
-    banner1: wave?.author.banner1_color,
-    banner2: wave?.author.banner2_color,
+    banner1: resolvedWave?.author.banner1_color,
+    banner2: resolvedWave?.author.banner2_color,
   });
   const hasBannerCover = bannerBackground !== null;
 
@@ -224,10 +243,13 @@ export const CurationWavePreviewCard: React.FC<
           </p>
         )}
 
-        <PreviewContent isFetching={isFetching} previewItems={previewItems} />
+        <PreviewContent
+          isPending={isPreviewPending}
+          previewItems={previewItems}
+        />
       </CurationPreviewBody>
 
-      <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/[0.06] tw-px-4 tw-py-3">
+      <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/[0.06] tw-px-5 tw-py-3">
         <Link
           href={waveHref}
           prefetch={false}
@@ -245,9 +267,9 @@ export const CurationWavePreviewCard: React.FC<
 };
 
 const PreviewContent: React.FC<{
-  readonly isFetching: boolean;
+  readonly isPending: boolean;
   readonly previewItems: ReturnType<typeof getPreviewItems>;
-}> = ({ isFetching, previewItems }) => {
+}> = ({ isPending, previewItems }) => {
   if (previewItems.length > 0) {
     return (
       <div className="tw-mt-4 tw-columns-2 tw-gap-2">
@@ -258,7 +280,7 @@ const PreviewContent: React.FC<{
     );
   }
 
-  if (isFetching) {
+  if (isPending) {
     return (
       <div
         className="tw-mt-4 tw-flex tw-w-full tw-items-center tw-justify-start tw-gap-2 tw-py-1.5 tw-text-left tw-text-xs tw-text-iron-400"
@@ -286,14 +308,10 @@ const PreviewContent: React.FC<{
             d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
           />
         </svg>
-        <span>Loading curated drops...</span>
+        <span>Loading...</span>
       </div>
     );
   }
 
-  return (
-    <p className="tw-mb-0 tw-mt-4 tw-text-xs tw-font-semibold tw-text-iron-400">
-      No curated drops yet.
-    </p>
-  );
+  return null;
 };

--- a/components/waves/drops/CurationWavePreviewCard.tsx
+++ b/components/waves/drops/CurationWavePreviewCard.tsx
@@ -54,7 +54,7 @@ const WavePreviewPicture: React.FC<{
   >
     {picture ? (
       <FallbackImage
-        primarySrc={getScaledImageUri(picture, ImageScale.W_200_H_200)}
+        primarySrc={getScaledImageUri(picture, ImageScale.W_AUTO_H_50)}
         fallbackSrc={picture}
         alt=""
         fill

--- a/hooks/useWaveCurationPreviewDrops.ts
+++ b/hooks/useWaveCurationPreviewDrops.ts
@@ -41,7 +41,7 @@ export function useWaveCurationPreviewDrops({
     [normalizedCurationId, pageSize, waveId]
   );
 
-  const { data, error, isError, isFetching } = useQuery({
+  const { data, error, isError, isFetched, isFetching } = useQuery({
     queryKey,
     queryFn: async ({ signal }) => {
       if (!wave || !normalizedCurationId) {
@@ -88,6 +88,7 @@ export function useWaveCurationPreviewDrops({
     drops,
     error,
     isError,
+    isFetched,
     isFetching,
   };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading-state handling for wave curation previews: shows consistent “Loading...” while data is being fetched, suppresses empty-state messages until resolution, ensures preview/open link appears when previews are available, and adjusts preview image sizing for better display.

* **Tests**
  * Added test coverage validating loading, empty, and resolved preview behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-frontend/pull/2482?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->