### PR TITLE
Fix Drop Forge video preview sizing

### DIFF
--- a/__tests__/components/drops/view/item/content/media/MediaDisplay.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/MediaDisplay.test.tsx
@@ -17,6 +17,7 @@ jest.mock(
       data-src={props.src}
       data-controls={String(props.showControls)}
       data-disable={String(props.disableClickHandler)}
+      data-fill-container={String(props.fillContainer)}
     />
   )
 );
@@ -113,6 +114,22 @@ describe("MediaDisplay", () => {
     const node = screen.getByTestId("video");
     expect(node).toHaveAttribute("data-src", "vid.mp4");
     expect(node).toHaveAttribute("data-controls", "true");
+    expect(node).toHaveAttribute("data-fill-container", "false");
+  });
+
+  it("passes fill container sizing to videos", () => {
+    render(
+      <MediaDisplay
+        media_mime_type="video/mp4"
+        media_url="vid.mp4"
+        fillVideoContainer
+      />
+    );
+
+    expect(screen.getByTestId("video")).toHaveAttribute(
+      "data-fill-container",
+      "true"
+    );
   });
 
   it("renders audio", () => {

--- a/__tests__/components/drops/view/item/content/media/MediaDisplayVideo.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/MediaDisplayVideo.test.tsx
@@ -54,8 +54,24 @@ beforeEach(() => {
 describe("MediaDisplayVideo", () => {
   it("uses controlled playback instead of autoplay attribute", () => {
     const { container } = render(<MediaDisplayVideo src="foo.mp4" />);
+    const wrapper = container.firstElementChild;
     const video = container.querySelector("video") as HTMLVideoElement;
     expect(video.autoplay).toBe(false); // Component uses useEffect for controlled playback
+    expect(wrapper).toHaveClass("tw-max-h-64", "tw-min-h-[200px]");
+    expect(video).toHaveClass("tw-h-auto", "tw-max-h-64");
+  });
+
+  it("can fill its parent preview container", () => {
+    const { container } = render(
+      <MediaDisplayVideo src="foo.mp4" fillContainer />
+    );
+    const wrapper = container.firstElementChild;
+    const video = container.querySelector("video") as HTMLVideoElement;
+
+    expect(wrapper).toHaveClass("tw-h-full");
+    expect(wrapper).not.toHaveClass("tw-max-h-64", "tw-min-h-[200px]");
+    expect(video).toHaveClass("tw-h-full");
+    expect(video).not.toHaveClass("tw-h-auto", "tw-max-h-64");
   });
 
   it("keeps preferring HLS renditions when native controls are shown", () => {

--- a/components/drop-forge/craft/DropForgeCraftClaimPageClient.tsx
+++ b/components/drop-forge/craft/DropForgeCraftClaimPageClient.tsx
@@ -1142,6 +1142,7 @@ function AnimationSection({
                 <MediaDisplay
                   media_mime_type={animationPreviewMimeType}
                   media_url={animationDisplayUrl}
+                  fillVideoContainer
                 />
               </div>
             )}

--- a/components/drop-forge/launch/DropForgeLaunchClaimPageClient.view.tsx
+++ b/components/drop-forge/launch/DropForgeLaunchClaimPageClient.view.tsx
@@ -647,6 +647,7 @@ function DropForgeLaunchClaimMediaDisplayContent({
       <MediaDisplay
         media_mime_type={animationMimeType}
         media_url={claim.animation_url ?? ""}
+        fillVideoContainer
       />
     );
   }

--- a/components/drops/view/item/content/media/MediaDisplay.tsx
+++ b/components/drops/view/item/content/media/MediaDisplay.tsx
@@ -170,6 +170,7 @@ export default function MediaDisplay({
   previewImageUrl,
   requireInteractionToLoad = false,
   iframeContainerClassName,
+  fillVideoContainer = false,
   loadStrategy = "in-view",
 }: {
   readonly media_mime_type: string;
@@ -179,6 +180,7 @@ export default function MediaDisplay({
   readonly previewImageUrl?: string | null | undefined;
   readonly requireInteractionToLoad?: boolean | undefined;
   readonly iframeContainerClassName?: string | undefined;
+  readonly fillVideoContainer?: boolean | undefined;
   readonly loadStrategy?: MediaLoadStrategy | undefined;
 }) {
   const getMediaType = (): MediaType => {
@@ -265,6 +267,7 @@ export default function MediaDisplay({
           src={media_url}
           mimeType={media_mime_type}
           showControls={!disableMediaInteraction}
+          fillContainer={fillVideoContainer}
         />
       );
     case MediaType.AUDIO:

--- a/components/drops/view/item/content/media/MediaDisplayVideo.tsx
+++ b/components/drops/view/item/content/media/MediaDisplayVideo.tsx
@@ -6,6 +6,7 @@ import { useOptimizedVideo } from "@/hooks/useOptimizedVideo";
 import { useHlsPlayer } from "@/hooks/useHlsPlayer";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
 import { PlayIcon } from "@heroicons/react/24/solid";
+import clsx from "clsx";
 import { InlineMediaActions } from "./MediaActionToolbar";
 import { useMediaActions } from "./useMediaActions";
 
@@ -13,12 +14,14 @@ interface Props {
   readonly src: string;
   readonly mimeType?: string | undefined;
   readonly showControls?: boolean | undefined;
+  readonly fillContainer?: boolean | undefined;
 }
 
 const MediaDisplayVideo: React.FC<Props> = ({
   src,
   mimeType,
   showControls = false,
+  fillContainer = false,
 }) => {
   // Intersection observer for scroll-based triggers
   const [wrapperRef, inView] = useInView<HTMLDivElement>({ threshold: 0.1 });
@@ -123,7 +126,12 @@ const MediaDisplayVideo: React.FC<Props> = ({
   return (
     <div
       ref={wrapperRef}
-      className="tw-relative tw-max-h-64 tw-min-h-[200px] tw-w-full tw-overflow-hidden tw-rounded-xl tw-bg-black"
+      className={clsx(
+        "tw-relative tw-w-full tw-overflow-hidden tw-rounded-xl tw-bg-black",
+        fillContainer
+          ? "tw-flex tw-h-full tw-max-h-full tw-items-center tw-justify-center"
+          : "tw-max-h-64 tw-min-h-[200px]"
+      )}
     >
       <video
         ref={videoRef}
@@ -134,7 +142,10 @@ const MediaDisplayVideo: React.FC<Props> = ({
           }
           handleVideoClick();
         }}
-        className="tw-h-auto tw-max-h-64 tw-w-full tw-rounded-xl tw-object-contain"
+        className={clsx(
+          "tw-w-full tw-rounded-xl tw-object-contain",
+          fillContainer ? "tw-h-full tw-max-h-full" : "tw-h-auto tw-max-h-64"
+        )}
         muted
         loop
         controls={showNativeControls}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Video previews can now optionally expand to fill their parent container for improved visibility while preserving the original capped-height behavior by default.
* **Tests**
  * Updated and added tests to verify both capped-height and fill-to-container video layout behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->