### PR TITLE
Fronpage boosted drops to v2 and filter to 3 boosts minimum to avoid self-shilling

### DIFF
--- a/__tests__/hooks/useBoostedDrops.test.ts
+++ b/__tests__/hooks/useBoostedDrops.test.ts
@@ -1,0 +1,68 @@
+import { renderHook } from "@testing-library/react";
+import { useQuery } from "@tanstack/react-query";
+import { useBoostedDrops } from "@/hooks/useBoostedDrops";
+import { fetchGlobalBoostedDropsV2 } from "@/services/api/wave-drops-v2-api";
+import { TIME_WINDOW_MS, TimeWindow } from "@/types/boosted-drops.types";
+
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: jest.fn(),
+}));
+
+jest.mock("@/services/api/wave-drops-v2-api", () => ({
+  fetchGlobalBoostedDropsV2: jest.fn(),
+}));
+
+const useQueryMock = useQuery as jest.Mock;
+const fetchGlobalBoostedDropsV2Mock =
+  fetchGlobalBoostedDropsV2 as jest.MockedFunction<
+    typeof fetchGlobalBoostedDropsV2
+  >;
+
+type QueryOptions = {
+  readonly queryKey: readonly unknown[];
+  readonly queryFn: (context: { readonly signal?: AbortSignal }) => unknown;
+};
+
+describe("useBoostedDrops", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(Date, "now").mockReturnValue(1_000_000);
+    useQueryMock.mockImplementation((options: QueryOptions) => {
+      return { data: [] };
+    });
+    fetchGlobalBoostedDropsV2Mock.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("uses the global v2 boosted drops fetch with a minimum boost filter", async () => {
+    let capturedOptions: QueryOptions | undefined;
+    useQueryMock.mockImplementation((options: QueryOptions) => {
+      capturedOptions = options;
+      return { data: [] };
+    });
+
+    renderHook(() => useBoostedDrops({ limit: 50 }));
+
+    expect(capturedOptions?.queryKey).toEqual([
+      expect.any(String),
+      {
+        global: true,
+        limit: 50,
+        minBoosts: 3,
+        timeWindow: TimeWindow.DAY,
+      },
+    ]);
+
+    await capturedOptions?.queryFn({});
+
+    expect(fetchGlobalBoostedDropsV2Mock).toHaveBeenCalledWith({
+      limit: 50,
+      countOnlyBoostsAfter: 1_000_000 - TIME_WINDOW_MS[TimeWindow.DAY],
+      minBoosts: 3,
+      signal: undefined,
+    });
+  });
+});

--- a/__tests__/services/api/wave-drops-v2-api.test.ts
+++ b/__tests__/services/api/wave-drops-v2-api.test.ts
@@ -10,6 +10,7 @@ import {
   fetchDropRepliesV2,
   fetchDropsV2ByIds,
   fetchDropV2ById,
+  fetchGlobalBoostedDropsV2,
   fetchWaveDropsFeedV2,
   mapLeaderboardDropV2,
 } from "@/services/api/wave-drops-v2-api";
@@ -464,6 +465,48 @@ describe("fetchBoostedDropsV2", () => {
     expectNoListEnrichmentCalls();
     expect(result[0]?.metadata).toEqual(priorityMetadata);
     expect(result[0]?.top_raters).toEqual([]);
+  });
+});
+
+describe("fetchGlobalBoostedDropsV2", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("fetches global boosted drops through v2 with the minimum boosts filter", async () => {
+    commonApiFetchMock.mockResolvedValueOnce({
+      data: [createEnrichableDrop({ wave })],
+      count: 1,
+      page: 1,
+      next: false,
+    });
+
+    const result = await fetchGlobalBoostedDropsV2({
+      limit: 50,
+      countOnlyBoostsAfter: 123,
+      minBoosts: 3,
+    });
+
+    expect(commonApiFetchMock).toHaveBeenCalledTimes(1);
+    expect(commonApiFetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: "v2/boosted-drops",
+        params: expect.objectContaining({
+          sort: "boosts",
+          sort_direction: "DESC",
+          page_size: "50",
+          count_only_boosts_after: "123",
+          min_boosts: "3",
+        }),
+      })
+    );
+    expectNoListEnrichmentCalls();
+    expect(result[0]?.wave).toEqual(
+      expect.objectContaining({
+        id: "wave-1",
+        name: "Wave 1",
+      })
+    );
   });
 });
 

--- a/hooks/useBoostedDrops.ts
+++ b/hooks/useBoostedDrops.ts
@@ -2,10 +2,9 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
-import { commonApiFetch } from "@/services/api/common-api";
 import type { ApiDrop } from "@/generated/models/ApiDrop";
-import type { Page } from "@/helpers/Types";
 import { TimeWindow, TIME_WINDOW_MS } from "@/types/boosted-drops.types";
+import { fetchGlobalBoostedDropsV2 } from "@/services/api/wave-drops-v2-api";
 
 interface UseBoostedDropsProps {
   readonly limit?: number;
@@ -13,6 +12,7 @@ interface UseBoostedDropsProps {
 }
 
 const DEFAULT_LIMIT = 10;
+const MIN_BOOSTS = 3;
 const STALE_TIME = 60000; // 1 minute
 const REFETCH_INTERVAL = 30000; // 30 seconds
 
@@ -21,19 +21,18 @@ export function useBoostedDrops({
   timeWindow = TimeWindow.DAY,
 }: UseBoostedDropsProps = {}) {
   return useQuery<ApiDrop[]>({
-    queryKey: [QueryKey.BOOSTED_DROPS, { global: true, limit, timeWindow }],
-    queryFn: async () => {
+    queryKey: [
+      QueryKey.BOOSTED_DROPS,
+      { global: true, limit, minBoosts: MIN_BOOSTS, timeWindow },
+    ],
+    queryFn: async ({ signal }) => {
       const countOnlyBoostsAfter = Date.now() - TIME_WINDOW_MS[timeWindow];
-      const response = await commonApiFetch<Page<ApiDrop>>({
-        endpoint: "boosted-drops",
-        params: {
-          sort: "boosts",
-          sort_direction: "DESC",
-          page_size: limit.toString(),
-          count_only_boosts_after: countOnlyBoostsAfter.toString(),
-        },
+      return fetchGlobalBoostedDropsV2({
+        limit,
+        countOnlyBoostsAfter,
+        minBoosts: MIN_BOOSTS,
+        signal,
       });
-      return response.data;
     },
     staleTime: STALE_TIME,
     refetchInterval: REFETCH_INTERVAL,

--- a/services/api/wave-drops-v2-api.ts
+++ b/services/api/wave-drops-v2-api.ts
@@ -70,6 +70,15 @@ interface FetchBoostedDropsV2Props {
   readonly countOnlyBoostsAfter?: number | undefined;
 }
 
+interface FetchGlobalBoostedDropsV2Props {
+  readonly limit: number;
+  readonly sortDirection?: string | undefined;
+  readonly sort?: string | undefined;
+  readonly countOnlyBoostsAfter?: number | undefined;
+  readonly minBoosts?: number | undefined;
+  readonly signal?: AbortSignal | undefined;
+}
+
 interface FetchDropRepliesV2Props {
   readonly parentDropId: string;
   readonly page: number;
@@ -729,5 +738,40 @@ export async function fetchBoostedDropsV2({
   return hydrateDropsV2({
     drops: response.data,
     wave: normalizeWaveMin(wave),
+  });
+}
+
+export async function fetchGlobalBoostedDropsV2({
+  limit,
+  sortDirection = "DESC",
+  sort = "boosts",
+  countOnlyBoostsAfter,
+  minBoosts,
+  signal,
+}: FetchGlobalBoostedDropsV2Props): Promise<ApiDrop[]> {
+  const params: Record<string, string> = {
+    sort,
+    sort_direction: sortDirection,
+    page_size: limit.toString(),
+  };
+
+  if (countOnlyBoostsAfter !== undefined) {
+    params["count_only_boosts_after"] = countOnlyBoostsAfter.toString();
+  }
+
+  if (minBoosts !== undefined) {
+    params["min_boosts"] = minBoosts.toString();
+  }
+
+  const response = await commonApiFetch<ApiDropV2Page>({
+    endpoint: "v2/boosted-drops",
+    params,
+    signal,
+  });
+  console.log(response)
+
+  return hydrateDropsWithEmbeddedWavesV2({
+    drops: response.data,
+    signal,
   });
 }

--- a/services/api/wave-drops-v2-api.ts
+++ b/services/api/wave-drops-v2-api.ts
@@ -768,7 +768,6 @@ export async function fetchGlobalBoostedDropsV2({
     params,
     signal,
   });
-  console.log(response)
 
   return hydrateDropsWithEmbeddedWavesV2({
     drops: response.data,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering boosted-drops retrieval, filtering, and API integration.

* **Refactor**
  * Improved boosted-drops filtering by minimum boost count and time window.
  * Streamlined boosted-drops request handling and enhanced wave data enrichment in results.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-frontend/pull/2485?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->