### PR TITLE
increase error toast time

### DIFF
--- a/__tests__/components/auth/Auth.test.tsx
+++ b/__tests__/components/auth/Auth.test.tsx
@@ -988,7 +988,10 @@ describe("Auth component", () => {
 
       expect(toast).toHaveBeenCalledWith(
         "Test error message",
-        expect.objectContaining({ type: "error" })
+        expect.objectContaining({
+          type: "error",
+          autoClose: 8000,
+        })
       );
     });
 
@@ -1030,7 +1033,10 @@ describe("Auth component", () => {
 
       expect(toast).toHaveBeenCalledWith(
         "Test success message",
-        expect.objectContaining({ type: "success" })
+        expect.objectContaining({
+          type: "success",
+          autoClose: 3000,
+        })
       );
     });
   });

--- a/__tests__/components/distribution-plan-tool/DistributionPlanToolContext.test.tsx
+++ b/__tests__/components/distribution-plan-tool/DistributionPlanToolContext.test.tsx
@@ -37,6 +37,7 @@ function ContextReader() {
       <button data-testid="set-null" onClick={() => context.setState(null)} />
       <button data-testid="set-plan" onClick={() => context.setState(plan)} />
       <button data-testid="toast" onClick={() => context.setToasts({ messages: ['a', 'b'], type: 'info' as TypeOptions })} />
+      <button data-testid="error-toast" onClick={() => context.setToasts({ messages: ['error'], type: 'error' as TypeOptions })} />
     </>
   );
 }
@@ -89,5 +90,24 @@ describe('DistributionPlanToolContext', () => {
     setup();
     screen.getByTestId('toast').click();
     expect(toast).toHaveBeenCalledTimes(2);
+    expect(toast).toHaveBeenCalledWith(
+      'a',
+      expect.objectContaining({
+        type: 'info',
+        autoClose: 3000,
+      })
+    );
+  });
+
+  it('keeps error toasts visible longer', () => {
+    setup();
+    screen.getByTestId('error-toast').click();
+    expect(toast).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({
+        type: 'error',
+        autoClose: 8000,
+      })
+    );
   });
 });

--- a/__tests__/services/distribution-plan.utils.test.ts
+++ b/__tests__/services/distribution-plan.utils.test.ts
@@ -1,0 +1,25 @@
+import { makeErrorToast } from "@/services/distribution-plan.utils";
+import { toast } from "react-toastify";
+
+jest.mock("react-toastify", () => ({
+  toast: jest.fn(),
+  Slide: jest.fn(),
+}));
+
+describe("makeErrorToast", () => {
+  beforeEach(() => {
+    (toast as unknown as jest.Mock).mockClear();
+  });
+
+  it("shows error toasts for 8 seconds", () => {
+    makeErrorToast("Something went wrong");
+
+    expect(toast).toHaveBeenCalledWith(
+      "Something went wrong",
+      expect.objectContaining({
+        type: "error",
+        autoClose: 8000,
+      })
+    );
+  });
+});

--- a/components/auth/Auth.tsx
+++ b/components/auth/Auth.tsx
@@ -28,6 +28,7 @@ import type { ApiProfileProxy } from "@/generated/models/ApiProfileProxy";
 import { getActiveWaveIdFromUrl } from "@/helpers/navigation.helpers";
 import { groupProfileProxies } from "@/helpers/profile-proxy.helpers";
 import { getProfileConnectedStatus } from "@/helpers/ProfileHelpers";
+import { getToastAutoClose } from "@/helpers/toast.helpers";
 import { useIdentity } from "@/hooks/useIdentity";
 import {
   ConnectionMismatchError,
@@ -484,7 +485,7 @@ export default function Auth({
   }) => {
     toast(message, {
       position: "top-right",
-      autoClose: 3000,
+      autoClose: getToastAutoClose(type),
       hideProgressBar: false,
       draggable: false,
       closeOnClick: true,

--- a/components/distribution-plan-tool/DistributionPlanToolContext.tsx
+++ b/components/distribution-plan-tool/DistributionPlanToolContext.tsx
@@ -14,6 +14,7 @@ import type {
   AllowlistTransferPool,
 } from "../allowlist-tool/allowlist-tool.types";
 import RunOperations from "./run-operations/RunOperations";
+import { getToastAutoClose } from "@/helpers/toast.helpers";
 import {
   distributionPlanApiFetch,
   distributionPlanApiPost,
@@ -66,7 +67,7 @@ const setToast = ({
 }) => {
   toast(message, {
     position: "top-right",
-    autoClose: 3000,
+    autoClose: getToastAutoClose(type),
     hideProgressBar: false,
     draggable: false,
     closeOnClick: true,

--- a/helpers/toast.helpers.ts
+++ b/helpers/toast.helpers.ts
@@ -1,0 +1,7 @@
+import type { TypeOptions } from "react-toastify";
+
+export const DEFAULT_TOAST_AUTO_CLOSE_MS = 3000;
+export const ERROR_TOAST_AUTO_CLOSE_MS = 8000;
+
+export const getToastAutoClose = (type: TypeOptions): number =>
+  type === "error" ? ERROR_TOAST_AUTO_CLOSE_MS : DEFAULT_TOAST_AUTO_CLOSE_MS;

--- a/services/distribution-plan.utils.ts
+++ b/services/distribution-plan.utils.ts
@@ -1,8 +1,10 @@
+import { getToastAutoClose } from "@/helpers/toast.helpers";
 import { Slide, toast } from "react-toastify";
+
 export const makeErrorToast = (message: string) =>
   toast(message, {
     position: "top-right",
-    autoClose: 3000,
+    autoClose: getToastAutoClose("error"),
     hideProgressBar: false,
     draggable: false,
     closeOnClick: true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for toast notification auto-close timing behavior across all message types.

Toast notifications have been enhanced with type-specific display durations: error messages now remain visible for 8 seconds (previously 3 seconds), providing more time to read critical information, while success and info messages continue to close after 3 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->