### PR TITLE
Render OG metadata for crawlers

### DIFF
--- a/__tests__/components/providers/metadata.test.ts
+++ b/__tests__/components/providers/metadata.test.ts
@@ -54,6 +54,8 @@ describe("Metadata functionality (migrated from _document.tsx)", () => {
       const metadata = getAppMetadata();
 
       expect(metadata.openGraph).toBeDefined();
+      expect(metadata.openGraph?.type).toBe("website");
+      expect(metadata.openGraph?.siteName).toBe("6529.io");
       expect(metadata.openGraph?.images).toBeInstanceOf(Array);
       expect(metadata.openGraph?.images.length).toBeGreaterThan(0);
       expect(metadata.openGraph?.title).toBeDefined();
@@ -65,6 +67,7 @@ describe("Metadata functionality (migrated from _document.tsx)", () => {
 
       expect(metadata.twitter).toEqual({
         card: "summary",
+        site: "@6529Collections",
       });
     });
 
@@ -89,7 +92,12 @@ describe("Metadata functionality (migrated from _document.tsx)", () => {
       expect(metadata.openGraph?.images).toEqual([
         "https://custom.com/image.png",
       ]);
-      expect(metadata.twitter?.card).toBe("summary_large_image");
+      expect(metadata.openGraph?.type).toBe("website");
+      expect(metadata.openGraph?.siteName).toBe("6529.io");
+      expect(metadata.twitter).toEqual({
+        card: "summary_large_image",
+        site: "@6529Collections",
+      });
     });
 
     it("emits Open Graph image dimensions when provided", () => {

--- a/components/providers/metadata.ts
+++ b/components/providers/metadata.ts
@@ -29,12 +29,15 @@ export function getAppMetadata(
       icon: "/favicon.ico",
     },
     openGraph: {
+      type: "website",
+      siteName: "6529.io",
       images: openGraphImages,
       title,
       description: description ? `${description} | ${domain}` : domain,
     },
     twitter: {
       card: twitterCard,
+      site: "@6529Collections",
     },
     other: {
       version: publicEnv.VERSION ?? "",

--- a/config/nextConfig.ts
+++ b/config/nextConfig.ts
@@ -3,6 +3,9 @@ import { PublicEnv } from "./env.schema";
 import { NextConfig } from "next";
 import { ARWEAVE_GATEWAY_REMOTE_PATTERN_HOSTNAMES } from "../lib/media/arweave-gateways";
 
+const HTML_LIMITED_METADATA_BOTS =
+  /facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|TelegramBot|redditbot|Pinterestbot|opentweet/i;
+
 export function sharedConfig(
   publicEnv: PublicEnv,
   assetPrefix: string
@@ -11,7 +14,7 @@ export function sharedConfig(
     assetPrefix,
     reactCompiler: true,
     reactStrictMode: false,
-    htmlLimitedBots: /.*/,
+    htmlLimitedBots: HTML_LIMITED_METADATA_BOTS,
     compress: true,
     productionBrowserSourceMaps: true,
     sassOptions: { quietDeps: true },

--- a/config/nextConfig.ts
+++ b/config/nextConfig.ts
@@ -11,6 +11,7 @@ export function sharedConfig(
     assetPrefix,
     reactCompiler: true,
     reactStrictMode: false,
+    htmlLimitedBots: /.*/,
     compress: true,
     productionBrowserSourceMaps: true,
     sassOptions: { quietDeps: true },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced Open Graph metadata to include site name and type for richer social previews
  * Updated Twitter card metadata to include the site handle for proper attribution
  * Added HTML bot limiting configuration to control metadata exposure for certain bots
* **Tests**
  * Expanded metadata tests to assert the new Open Graph and Twitter fields
<!-- end of auto-generated comment: release notes by coderabbit.ai -->