### PR TITLE
Fix large OG media previews

### DIFF
--- a/__tests__/app/api/og-metadata.drops.route.test.ts
+++ b/__tests__/app/api/og-metadata.drops.route.test.ts
@@ -75,19 +75,20 @@ describe("/api/og-metadata/drops/[id]", () => {
 
     expect(globalThis.fetch).toHaveBeenCalledWith(
       "https://api.test/api/og-metadata/drops/6411",
-      { next: { revalidate: 86400 } }
+      { next: { revalidate: 300 } }
     );
     expect(mockLoadMontserratFonts).toHaveBeenCalledTimes(1);
     expect(mockImageResponse).toHaveBeenCalledTimes(1);
-    expect(mockImageResponse.mock.calls[0]?.[1]).toEqual({
+    const imageResponseInit = mockImageResponse.mock.calls[0]?.[1];
+    expect(imageResponseInit).toMatchObject({
       width: 1200,
       height: 630,
-      fonts: mockFonts,
       headers: {
         "Cache-Control":
-          "public, max-age=86400, s-maxage=604800, stale-while-revalidate=2592000",
+          "public, max-age=300, s-maxage=300, stale-while-revalidate=600",
       },
     });
+    expect(imageResponseInit?.fonts).toBe(mockFonts);
     expect(response).toBe(mockImageResponse.mock.results[0]?.value);
   });
 

--- a/__tests__/app/api/og-metadata.image.route.test.ts
+++ b/__tests__/app/api/og-metadata.image.route.test.ts
@@ -36,7 +36,7 @@ class MockNextResponse {
 
   async json(): Promise<unknown> {
     if (typeof this.body !== "string") {
-      throw new Error("Mock JSON response body must be a string.");
+      throw new TypeError("Mock JSON response body must be a string.");
     }
 
     return JSON.parse(this.body);

--- a/__tests__/app/api/og-metadata.image.route.test.ts
+++ b/__tests__/app/api/og-metadata.image.route.test.ts
@@ -24,17 +24,22 @@ class MockNextResponse {
   }
 
   static json(body: unknown, init?: ResponseInit): MockNextResponse {
+    const headers = init?.headers
+      ? { ...init.headers, "Content-Type": "application/json" }
+      : { "Content-Type": "application/json" };
+
     return new MockNextResponse(JSON.stringify(body), {
       ...init,
-      headers: {
-        "Content-Type": "application/json",
-        ...(init?.headers ?? {}),
-      },
+      headers,
     });
   }
 
   async json(): Promise<unknown> {
-    return JSON.parse(`${this.body}`);
+    if (typeof this.body !== "string") {
+      throw new Error("Mock JSON response body must be a string.");
+    }
+
+    return JSON.parse(this.body);
   }
 }
 

--- a/__tests__/app/api/og-metadata.image.route.test.ts
+++ b/__tests__/app/api/og-metadata.image.route.test.ts
@@ -88,19 +88,17 @@ const createHeaders = (values: Record<string, string>) => ({
 });
 
 const mockImageResponse = (contentLength: number): void => {
-  mockFetchPublicUrl.mockResolvedValue(
-    {
-      body: createReadableBody(PNG_1X1),
-      headers: {
-        get: createHeaders({
-          "content-length": `${contentLength}`,
-          "content-type": "image/png",
-        }).get,
-      },
-      ok: true,
-      status: 200,
-    }
-  );
+  mockFetchPublicUrl.mockResolvedValue({
+    body: createReadableBody(PNG_1X1),
+    headers: {
+      get: createHeaders({
+        "content-length": `${contentLength}`,
+        "content-type": "image/png",
+      }).get,
+    },
+    ok: true,
+    status: 200,
+  });
 };
 
 describe("/api/og-metadata/image", () => {

--- a/__tests__/app/api/og-metadata.image.route.test.ts
+++ b/__tests__/app/api/og-metadata.image.route.test.ts
@@ -1,0 +1,139 @@
+jest.mock("@/lib/security/urlGuard", () => {
+  const actual = jest.requireActual("@/lib/security/urlGuard");
+  return {
+    ...actual,
+    fetchPublicUrl: jest.fn(),
+  };
+});
+
+class MockNextResponse {
+  readonly body: BodyInit | null;
+  readonly headers: { get: (name: string) => string | null };
+  readonly status: number;
+
+  constructor(body: BodyInit | null, init?: ResponseInit) {
+    const headerValues = new Map<string, string>();
+    Object.entries(init?.headers ?? {}).forEach(([key, value]) => {
+      headerValues.set(key.toLowerCase(), `${value}`);
+    });
+    this.body = body;
+    this.headers = {
+      get: (name: string) => headerValues.get(name.toLowerCase()) ?? null,
+    };
+    this.status = init?.status ?? 200;
+  }
+
+  static json(body: unknown, init?: ResponseInit): MockNextResponse {
+    return new MockNextResponse(JSON.stringify(body), {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        ...(init?.headers ?? {}),
+      },
+    });
+  }
+
+  async json(): Promise<unknown> {
+    return JSON.parse(`${this.body}`);
+  }
+}
+
+jest.mock("next/server", () => ({
+  NextResponse: MockNextResponse,
+}));
+
+import { GET } from "@/app/api/og-metadata/image/route";
+import { fetchPublicUrl } from "@/lib/security/urlGuard";
+import type { NextRequest } from "next/server";
+
+const mockFetchPublicUrl = fetchPublicUrl as jest.Mock;
+const PNG_1X1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+  "base64"
+);
+
+const createRequest = (sourceUrl: string): NextRequest =>
+  ({
+    nextUrl: new URL(
+      `http://localhost:3001/api/og-metadata/image?url=${encodeURIComponent(
+        sourceUrl
+      )}&w=1108`
+    ),
+  }) as NextRequest;
+
+const createReadableBody = (buffer: Buffer) => {
+  let hasRead = false;
+  return {
+    getReader: () => ({
+      cancel: jest.fn(),
+      read: jest.fn(async () => {
+        if (hasRead) {
+          return { done: true, value: undefined };
+        }
+        hasRead = true;
+        return { done: false, value: new Uint8Array(buffer) };
+      }),
+      releaseLock: jest.fn(),
+    }),
+  };
+};
+
+const createHeaders = (values: Record<string, string>) => ({
+  get: (name: string) => values[name.toLowerCase()] ?? null,
+});
+
+const mockImageResponse = (contentLength: number): void => {
+  mockFetchPublicUrl.mockResolvedValue(
+    {
+      body: createReadableBody(PNG_1X1),
+      headers: {
+        get: createHeaders({
+          "content-length": `${contentLength}`,
+          "content-type": "image/png",
+        }).get,
+      },
+      ok: true,
+      status: 200,
+    }
+  );
+};
+
+describe("/api/og-metadata/image", () => {
+  beforeEach(() => {
+    mockFetchPublicUrl.mockReset();
+  });
+
+  it("normalizes source images up to 50 MiB for drop OG previews", async () => {
+    mockImageResponse(50 * 1024 * 1024);
+
+    const response = await GET(
+      createRequest("https://d3lqz0a4bldqgf.cloudfront.net/drop.png")
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+  });
+
+  it("still rejects source images above the proxy cap", async () => {
+    mockImageResponse(51 * 1024 * 1024);
+
+    const response = await GET(
+      createRequest("https://d3lqz0a4bldqgf.cloudfront.net/huge.png")
+    );
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to normalize image",
+    });
+  });
+
+  it("keeps invalid media urls as JSON errors", async () => {
+    const response = await GET(createRequest("http://localhost/secret.png"));
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    await expect(response.json()).resolves.toEqual({
+      error: "Invalid image url",
+    });
+  });
+});

--- a/app/api/og-metadata/_lib/imageProxyPolicy.ts
+++ b/app/api/og-metadata/_lib/imageProxyPolicy.ts
@@ -1,3 +1,5 @@
+export const OG_IMAGE_PROXY_MAX_BYTES = 50 * 1024 * 1024;
+
 const normalizeHostname = (hostname: string): string => {
   let normalized = hostname.trim().toLowerCase();
   while (normalized.endsWith(".")) {

--- a/app/api/og-metadata/image/route.ts
+++ b/app/api/og-metadata/image/route.ts
@@ -4,6 +4,7 @@ import {
   UrlGuardError,
   type FetchPublicUrlOptions,
 } from "@/lib/security/urlGuard";
+import { OG_IMAGE_PROXY_MAX_BYTES } from "@/app/api/og-metadata/_lib/imageProxyPolicy";
 import { NextResponse, type NextRequest } from "next/server";
 import sharp from "sharp";
 
@@ -12,7 +13,6 @@ export const revalidate = 604800;
 
 const DEFAULT_WIDTH = 1200;
 const MAX_WIDTH = 1200;
-const MAX_IMAGE_BYTES = 15 * 1024 * 1024;
 const PNG_CONTENT_TYPE = "image/png";
 const CACHE_CONTROL =
   "public, max-age=604800, s-maxage=2592000, stale-while-revalidate=2592000";
@@ -107,7 +107,7 @@ const getContentLength = (response: Response): number | null => {
 };
 
 const ensureAllowedImageSize = (byteLength: number): void => {
-  if (byteLength > MAX_IMAGE_BYTES) {
+  if (byteLength > OG_IMAGE_PROXY_MAX_BYTES) {
     throw new Error("Image response exceeded maximum size.");
   }
 };
@@ -151,7 +151,7 @@ const readImageResponseBuffer = async (response: Response): Promise<Buffer> => {
 
       const chunk = Buffer.from(value);
       totalBytes += chunk.byteLength;
-      if (totalBytes > MAX_IMAGE_BYTES) {
+      if (totalBytes > OG_IMAGE_PROXY_MAX_BYTES) {
         await reader.cancel("Image response exceeded maximum size.");
         ensureAllowedImageSize(totalBytes);
       }
@@ -217,6 +217,7 @@ const normalizeImageToPng = async ({
 
   return sharp(buffer, {
     limitInputPixels: false,
+    pages: 1,
     sequentialRead: true,
   })
     .timeout({ seconds: 7 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image proxy now enforces a 50 MB maximum and rejects oversized inputs.

* **Improvements**
  * OG metadata now revalidates every 5 minutes.
  * Image normalization updated to ensure single-page PNG output and to stop processing once size limits are exceeded.

* **Tests**
  * Added and refined tests for image handling, size limits, error responses, and cache headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->