### PR TITLE
Clarify README environment setup note

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Otherwise, open a new shell after running `./bin/6529 bootstrap`.
 
 ### Environment
 
-To run the project you need a .env file.
+To run the project, create a `.env` file.
 
 [Sample .env file](https://github.com/6529-Collections/6529seize-frontend/tree/main/.env.sample)
 


### PR DESCRIPTION
## Summary
- Clarifies the README environment setup sentence to refer to a `.env` file explicitly.

## Verification
- `git diff --check -- README.md`
- Targeted Prettier check attempted locally; current Windows shell cannot run the repo Bash wrapper directly, and `README.md` has pre-existing formatting/line-ending drift when checked in isolation.

Docs-only smoke-test PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Environment section wording in README regarding `.env` file setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->