### PR TITLE
Centralize decentralized media resolution

### DIFF
--- a/__tests__/app/api/open-graph.opensea.service.test.ts
+++ b/__tests__/app/api/open-graph.opensea.service.test.ts
@@ -117,7 +117,7 @@ describe("createOpenSeaPlan", () => {
         description: "A clear sky",
         siteName: "OpenSea",
         image: expect.objectContaining({
-          url: "https://ipfs.io/ipfs/QmExampleHash/radar.png",
+          url: "https://media.6529.io/ipfs/QmExampleHash/radar.png",
           type: "image/png",
         }),
       })
@@ -268,7 +268,7 @@ describe("createOpenSeaPlan", () => {
         type: "opensea.nft",
         title: "Template token",
         image: expect.objectContaining({
-          url: "https://ipfs.io/ipfs/QmExampleHash/template.png",
+          url: "https://media.6529.io/ipfs/QmExampleHash/template.png",
         }),
       })
     );

--- a/__tests__/app/api/open-graph.transient.service.test.ts
+++ b/__tests__/app/api/open-graph.transient.service.test.ts
@@ -95,7 +95,7 @@ describe("createTransientPlan", () => {
         description: "Alchemy description",
         siteName: "Transient Labs",
         image: expect.objectContaining({
-          url: "https://ipfs.io/ipfs/QmExampleHash/stitched.png",
+          url: "https://media.6529.io/ipfs/QmExampleHash/stitched.png",
           type: "image/png",
         }),
       })
@@ -148,7 +148,7 @@ describe("createTransientPlan", () => {
         type: "transient.nft",
         title: "Token with token URI fallback",
         image: expect.objectContaining({
-          url: "https://ipfs.io/ipfs/QmExampleHash/token-uri-image.png",
+          url: "https://media.6529.io/ipfs/QmExampleHash/token-uri-image.png",
         }),
       })
     );

--- a/__tests__/components/brain/notifications/subcomponents/NotificationHeader.test.tsx
+++ b/__tests__/components/brain/notifications/subcomponents/NotificationHeader.test.tsx
@@ -48,12 +48,12 @@ jest.mock("@/components/utils/tooltip/UserProfileTooltipWrapper", () => ({
 jest.mock("@/components/nft-image/utils/gateway-fallback", () => ({
   getMediaGatewayFallbackUrls: (url: string) =>
     url === "ipfs://gelato"
-      ? ["https://ipfs.6529.io/ipfs/gelato", "https://ipfs.io/ipfs/gelato"]
+      ? ["https://media.6529.io/ipfs/gelato", "https://ipfs.io/ipfs/gelato"]
       : [url],
 }));
 
 describe("NotificationHeader", () => {
-  it("prefers the configured ipfs gateway and falls back to ipfs.io on failure", () => {
+  it("prefers the 6529 resolver and falls back to ipfs.io on failure", () => {
     render(
       <NotificationHeader
         author={
@@ -73,7 +73,7 @@ describe("NotificationHeader", () => {
     });
     expect(firstAttempt).toHaveAttribute(
       "src",
-      "https://ipfs.6529.io/ipfs/gelato"
+      "https://media.6529.io/ipfs/gelato"
     );
     expect(firstAttempt).toHaveAttribute("data-unoptimized", "false");
 
@@ -84,7 +84,7 @@ describe("NotificationHeader", () => {
     });
     expect(secondAttempt).toHaveAttribute(
       "src",
-      "https://ipfs.6529.io/ipfs/gelato"
+      "https://media.6529.io/ipfs/gelato"
     );
     expect(secondAttempt).toHaveAttribute("data-unoptimized", "true");
 

--- a/__tests__/components/common/OverlappingAvatars.test.tsx
+++ b/__tests__/components/common/OverlappingAvatars.test.tsx
@@ -34,7 +34,7 @@ jest.mock("@/hooks/useIsTouchDevice", () => ({
 jest.mock("@/components/nft-image/utils/gateway-fallback", () => ({
   getMediaGatewayFallbackUrls: (url: string) =>
     url === "ipfs://gpebbles"
-      ? ["https://ipfs.6529.io/ipfs/gpebbles", "https://ipfs.io/ipfs/gpebbles"]
+      ? ["https://media.6529.io/ipfs/gpebbles", "https://ipfs.io/ipfs/gpebbles"]
       : [url],
 }));
 
@@ -69,7 +69,7 @@ describe("OverlappingAvatars", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("falls back from the configured ipfs gateway to ipfs.io", () => {
+  it("falls back from the 6529 resolver to ipfs.io", () => {
     render(
       <OverlappingAvatars
         items={[
@@ -86,7 +86,7 @@ describe("OverlappingAvatars", () => {
     const firstAttempt = screen.getByRole("img", { name: "View @gpebbles" });
     expect(firstAttempt).toHaveAttribute(
       "src",
-      "https://ipfs.6529.io/ipfs/gpebbles"
+      "https://media.6529.io/ipfs/gpebbles"
     );
     expect(firstAttempt).toHaveAttribute("data-unoptimized", "false");
 
@@ -95,7 +95,7 @@ describe("OverlappingAvatars", () => {
     const secondAttempt = screen.getByRole("img", { name: "View @gpebbles" });
     expect(secondAttempt).toHaveAttribute(
       "src",
-      "https://ipfs.6529.io/ipfs/gpebbles"
+      "https://media.6529.io/ipfs/gpebbles"
     );
     expect(secondAttempt).toHaveAttribute("data-unoptimized", "true");
 

--- a/__tests__/components/drop-forge/drop-forge-storage-location.helpers.test.ts
+++ b/__tests__/components/drop-forge/drop-forge-storage-location.helpers.test.ts
@@ -1,10 +1,3 @@
-jest.mock("@/components/ipfs/IPFSContext", () => ({
-  resolveIpfsUrlSync: (url: string) =>
-    url.startsWith("ipfs://")
-      ? `https://gateway.example/ipfs/${url.slice("ipfs://".length)}`
-      : url,
-}));
-
 import { getDropForgeStorageLocationInfo } from "@/components/drop-forge/drop-forge-storage-location.helpers";
 
 describe("getDropForgeStorageLocationInfo", () => {
@@ -27,9 +20,9 @@ describe("getDropForgeStorageLocationInfo", () => {
       provider: "arweave",
       providerBadgeLabel: null,
       openUrl:
-        "https://arweave.net/OI6-rpJ2C3Ab4HiZRWt5A1SumhjnYigmSPBPX0ICBj8",
+        "https://media.6529.io/arweave/OI6-rpJ2C3Ab4HiZRWt5A1SumhjnYigmSPBPX0ICBj8",
       copyValue:
-        "https://arweave.net/OI6-rpJ2C3Ab4HiZRWt5A1SumhjnYigmSPBPX0ICBj8",
+        "https://media.6529.io/arweave/OI6-rpJ2C3Ab4HiZRWt5A1SumhjnYigmSPBPX0ICBj8",
     });
   });
 
@@ -45,9 +38,9 @@ describe("getDropForgeStorageLocationInfo", () => {
       provider: "arweave",
       providerBadgeLabel: null,
       openUrl:
-        "https://arweave.net/OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc",
+        "https://media.6529.io/arweave/OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc",
       copyValue:
-        "https://arweave.net/OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc",
+        "https://media.6529.io/arweave/OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc",
     });
   });
 
@@ -66,9 +59,9 @@ describe("getDropForgeStorageLocationInfo", () => {
       provider: "ipfs",
       providerBadgeLabel: "IPFS",
       openUrl:
-        "https://gateway.example/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa",
+        "https://media.6529.io/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa",
       copyValue:
-        "https://gateway.example/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa",
+        "https://media.6529.io/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa",
     });
   });
 
@@ -87,9 +80,9 @@ describe("getDropForgeStorageLocationInfo", () => {
       provider: "ipfs",
       providerBadgeLabel: "IPFS",
       openUrl:
-        "https://gateway.example/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa/dir/file.png",
+        "https://media.6529.io/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa/dir/file.png",
       copyValue:
-        "https://gateway.example/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa/dir/file.png",
+        "https://media.6529.io/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa/dir/file.png",
     });
   });
 
@@ -107,9 +100,9 @@ describe("getDropForgeStorageLocationInfo", () => {
       provider: "ipfs",
       providerBadgeLabel: "IPFS",
       openUrl:
-        "https://gateway.example/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa",
+        "https://media.6529.io/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa",
       copyValue:
-        "https://gateway.example/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa",
+        "https://media.6529.io/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa",
     });
 
     expect(
@@ -123,9 +116,9 @@ describe("getDropForgeStorageLocationInfo", () => {
       provider: "ipfs",
       providerBadgeLabel: "IPFS",
       openUrl:
-        "https://gateway.example/ipfs/QmYwAPJzv5CZsnAzt8auVZRnG1R8n4wqxW48UUfZo59SyY",
+        "https://media.6529.io/ipfs/QmYwAPJzv5CZsnAzt8auVZRnG1R8n4wqxW48UUfZo59SyY",
       copyValue:
-        "https://gateway.example/ipfs/QmYwAPJzv5CZsnAzt8auVZRnG1R8n4wqxW48UUfZo59SyY",
+        "https://media.6529.io/ipfs/QmYwAPJzv5CZsnAzt8auVZRnG1R8n4wqxW48UUfZo59SyY",
     });
   });
 
@@ -144,9 +137,9 @@ describe("getDropForgeStorageLocationInfo", () => {
       provider: "ipfs",
       providerBadgeLabel: "IPFS",
       openUrl:
-        "https://gateway.example/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa",
+        "https://media.6529.io/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa",
       copyValue:
-        "https://gateway.example/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa",
+        "https://media.6529.io/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa",
     });
   });
 
@@ -165,9 +158,9 @@ describe("getDropForgeStorageLocationInfo", () => {
       provider: "ipfs",
       providerBadgeLabel: "IPFS",
       openUrl:
-        "https://gateway.example/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa/dir/file.png",
+        "https://media.6529.io/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa/dir/file.png",
       copyValue:
-        "https://gateway.example/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa/dir/file.png",
+        "https://media.6529.io/ipfs/bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa/dir/file.png",
     });
   });
 
@@ -185,9 +178,9 @@ describe("getDropForgeStorageLocationInfo", () => {
       provider: "arweave",
       providerBadgeLabel: null,
       openUrl:
-        "https://arweave.net/OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc",
+        "https://media.6529.io/arweave/OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc",
       copyValue:
-        "https://arweave.net/OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc",
+        "https://media.6529.io/arweave/OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc",
     });
   });
 });

--- a/__tests__/components/drop-forge/drop-forge-storage-location.helpers.test.ts
+++ b/__tests__/components/drop-forge/drop-forge-storage-location.helpers.test.ts
@@ -26,6 +26,18 @@ describe("getDropForgeStorageLocationInfo", () => {
     });
   });
 
+  it("does not fabricate arweave resolver URLs for unrecognized raw values", () => {
+    expect(getDropForgeStorageLocationInfo("not-a-valid-location")).toEqual({
+      rawValue: "not-a-valid-location",
+      displayValue: "not-a-valid-location",
+      displayTitle: "not-a-valid-location",
+      provider: null,
+      providerBadgeLabel: null,
+      openUrl: null,
+      copyValue: "not-a-valid-location",
+    });
+  });
+
   it("treats ar:// locations as arweave locations", () => {
     expect(
       getDropForgeStorageLocationInfo(

--- a/__tests__/components/drop-forge/drop-forge-storage-location.helpers.test.ts
+++ b/__tests__/components/drop-forge/drop-forge-storage-location.helpers.test.ts
@@ -134,6 +134,14 @@ describe("getDropForgeStorageLocationInfo", () => {
     });
   });
 
+  it("keeps bare CIDv1 values as IPFS even though they match the Arweave length range", () => {
+    expect(
+      getDropForgeStorageLocationInfo(
+        "bafybeifnoqgl2rnnredlcwqhujosdwbpufoqkvbgoeohcnepq5yexlt6wa"
+      )?.provider
+    ).toBe("ipfs");
+  });
+
   it("recognizes ipfs gateway urls and extracts the cid for display", () => {
     expect(
       getDropForgeStorageLocationInfo(

--- a/__tests__/components/drops/view/item/content/media/MediaDisplay.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/MediaDisplay.test.tsx
@@ -96,7 +96,7 @@ describe("MediaDisplay", () => {
     mockSandboxedExternalIframe.mockClear();
     mockGetArweaveGatewayFallbackUrls.mockImplementation((url: string) => {
       if (url === "ipfs://hash") {
-        return ["https://ipfs.io/ipfs/hash"];
+        return ["https://media.6529.io/ipfs/hash"];
       }
       return [url];
     });
@@ -140,7 +140,7 @@ describe("MediaDisplay", () => {
 
     expect(screen.getByTestId("iframe")).toHaveAttribute(
       "data-src",
-      "https://ipfs.io/ipfs/hash"
+      "https://media.6529.io/ipfs/hash"
     );
     expect(screen.getByTestId("iframe")).toHaveAttribute(
       "data-title",
@@ -199,7 +199,7 @@ describe("MediaDisplay", () => {
 
     expect(screen.getByTestId("iframe")).toHaveAttribute(
       "data-src",
-      "https://ipfs.io/ipfs/hash"
+      "https://media.6529.io/ipfs/hash"
     );
     expect(screen.getByTestId("iframe")).toHaveAttribute(
       "data-title",
@@ -226,7 +226,7 @@ describe("MediaDisplay", () => {
 
     expect(screen.getByTestId("iframe")).toHaveAttribute(
       "data-src",
-      "https://ipfs.io/ipfs/hash"
+      "https://media.6529.io/ipfs/hash"
     );
   });
 
@@ -255,7 +255,7 @@ describe("MediaDisplay", () => {
     jest.useFakeTimers();
     mockGetArweaveGatewayFallbackUrls.mockReturnValue([
       "https://ipfs.6529.io/ipfs/hash",
-      "https://ipfs.io/ipfs/hash",
+      "https://media.6529.io/ipfs/hash",
     ]);
     mockShouldUseIframeFallbackTimeout.mockReturnValue(false);
 

--- a/__tests__/components/ipfs/IPFSContext.test.tsx
+++ b/__tests__/components/ipfs/IPFSContext.test.tsx
@@ -47,8 +47,8 @@ describe("IpfsContext", () => {
     }).toThrow("useIpfsService must be used within an IpfsProvider");
   });
 
-  it("resolves ipfs urls to gateway", async () => {
-    const url = await resolveIpfsUrl(`ipfs://${CID}`);
+  it("resolves ipfs urls to gateway", () => {
+    const url = resolveIpfsUrl(`ipfs://${CID}`);
     expect(url).toBe(`https://media.6529.io/ipfs/${CID}`);
   });
 
@@ -72,10 +72,10 @@ describe("IpfsContext", () => {
     );
   });
 
-  it("does not require the legacy gateway endpoint to resolve media", async () => {
+  it("does not require the legacy gateway endpoint to resolve media", () => {
     publicEnv.IPFS_GATEWAY_ENDPOINT = undefined;
     publicEnv.IPFS_API_ENDPOINT = undefined;
-    const url = await resolveIpfsUrl(`ipfs://${CID}`);
+    const url = resolveIpfsUrl(`ipfs://${CID}`);
     expect(url).toBe(`https://media.6529.io/ipfs/${CID}`);
   });
 });

--- a/__tests__/components/ipfs/IPFSContext.test.tsx
+++ b/__tests__/components/ipfs/IPFSContext.test.tsx
@@ -48,39 +48,33 @@ describe("IpfsContext", () => {
 
   it("resolves ipfs urls to gateway", async () => {
     const url = await resolveIpfsUrl("ipfs://abc");
-    expect(url).toBe("https://ipfs.test.6529.io/ipfs/abc");
+    expect(url).toBe("https://media.6529.io/ipfs/abc");
   });
 
   it("resolves synchronously when needed", () => {
     expect(resolveIpfsUrlSync("ipfs://sync")).toBe(
-      "https://ipfs.test.6529.io/ipfs/sync"
+      "https://media.6529.io/ipfs/sync"
     );
   });
 
-  it("normalizes ipfs.io urls back to the configured gateway", () => {
+  it("normalizes ipfs.io urls back to the 6529 resolver", () => {
     expect(resolveIpfsUrlSync("https://ipfs.io/ipfs/sync")).toBe(
-      "https://ipfs.test.6529.io/ipfs/sync"
+      "https://media.6529.io/ipfs/sync"
     );
   });
 
-  it("preserves configured gateway port and base path when rewriting ipfs.io urls", () => {
-    publicEnv.IPFS_GATEWAY_ENDPOINT =
-      "https://ipfs.test.6529.io:8443/base/ipfs";
+  it("uses the configured media resolver endpoint when provided", () => {
+    publicEnv.MEDIA_RESOLVER_ENDPOINT = "https://media.test.6529.io/base";
 
     expect(resolveIpfsUrlSync("https://ipfs.io/ipfs/sync?x=1#hash")).toBe(
-      "https://ipfs.test.6529.io:8443/base/ipfs/sync?x=1#hash"
+      "https://media.test.6529.io/base/ipfs/sync"
     );
   });
 
-  it("returns original url if env missing", async () => {
+  it("does not require the legacy gateway endpoint to resolve media", async () => {
     publicEnv.IPFS_GATEWAY_ENDPOINT = undefined;
     publicEnv.IPFS_API_ENDPOINT = undefined;
-    const consoleSpy = jest
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
     const url = await resolveIpfsUrl("ipfs://xyz");
-    expect(url).toBe("ipfs://xyz");
-    expect(consoleSpy).toHaveBeenCalled();
-    consoleSpy.mockRestore();
+    expect(url).toBe("https://media.6529.io/ipfs/xyz");
   });
 });

--- a/__tests__/components/ipfs/IPFSContext.test.tsx
+++ b/__tests__/components/ipfs/IPFSContext.test.tsx
@@ -13,6 +13,7 @@ jest.mock("@/components/ipfs/IPFSService");
 const MockIpfsService = IpfsService as jest.MockedClass<typeof IpfsService>;
 
 const originalEnv = { ...publicEnv };
+const CID = "bafybeigdyrzt5sfp7udm7hu76mjts3sfb44oixwkw55rmpbc6g6wuigv3i";
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -47,34 +48,34 @@ describe("IpfsContext", () => {
   });
 
   it("resolves ipfs urls to gateway", async () => {
-    const url = await resolveIpfsUrl("ipfs://abc");
-    expect(url).toBe("https://media.6529.io/ipfs/abc");
+    const url = await resolveIpfsUrl(`ipfs://${CID}`);
+    expect(url).toBe(`https://media.6529.io/ipfs/${CID}`);
   });
 
   it("resolves synchronously when needed", () => {
-    expect(resolveIpfsUrlSync("ipfs://sync")).toBe(
-      "https://media.6529.io/ipfs/sync"
+    expect(resolveIpfsUrlSync(`ipfs://${CID}`)).toBe(
+      `https://media.6529.io/ipfs/${CID}`
     );
   });
 
   it("normalizes ipfs.io urls back to the 6529 resolver", () => {
-    expect(resolveIpfsUrlSync("https://ipfs.io/ipfs/sync")).toBe(
-      "https://media.6529.io/ipfs/sync"
+    expect(resolveIpfsUrlSync(`https://ipfs.io/ipfs/${CID}`)).toBe(
+      `https://media.6529.io/ipfs/${CID}`
     );
   });
 
   it("uses the configured media resolver endpoint when provided", () => {
     publicEnv.MEDIA_RESOLVER_ENDPOINT = "https://media.test.6529.io/base";
 
-    expect(resolveIpfsUrlSync("https://ipfs.io/ipfs/sync?x=1#hash")).toBe(
-      "https://media.test.6529.io/base/ipfs/sync"
+    expect(resolveIpfsUrlSync(`https://ipfs.io/ipfs/${CID}?x=1#hash`)).toBe(
+      `https://media.test.6529.io/base/ipfs/${CID}`
     );
   });
 
   it("does not require the legacy gateway endpoint to resolve media", async () => {
     publicEnv.IPFS_GATEWAY_ENDPOINT = undefined;
     publicEnv.IPFS_API_ENDPOINT = undefined;
-    const url = await resolveIpfsUrl("ipfs://xyz");
-    expect(url).toBe("https://media.6529.io/ipfs/xyz");
+    const url = await resolveIpfsUrl(`ipfs://${CID}`);
+    expect(url).toBe(`https://media.6529.io/ipfs/${CID}`);
   });
 });

--- a/__tests__/components/nft-image/utils/gateway-fallback.test.ts
+++ b/__tests__/components/nft-image/utils/gateway-fallback.test.ts
@@ -1,56 +1,37 @@
-jest.mock("@/components/ipfs/IPFSContext", () => ({
-  resolveIpfsUrlSync: (url: string) =>
-    url.startsWith("ipfs://")
-      ? `https://ipfs.6529.io/ipfs/${url.slice("ipfs://".length)}`
-      : url,
-}));
-
-jest.mock("@/helpers/Helpers", () => ({
-  parseIpfsUrl: (url: string) =>
-    url.startsWith("ipfs://")
-      ? `https://ipfs.io/ipfs/${url.slice("ipfs://".length)}`
-      : url,
-}));
-
-jest.mock("@/lib/media/ipfs-gateways", () => ({
-  getConfiguredIpfsGatewayHost: () => "ipfs.6529.io",
-}));
-
-jest.mock("@/lib/media/arweave-gateways", () => ({
-  ARWEAVE_FALLBACK_HOSTS: ["arweave.net", "ardrive.net", "gateway.arweave.net"],
-  canonicalizeArweaveGatewayHostname: (hostname: string) =>
-    hostname.toLowerCase(),
-  isArweaveGatewayRuntimeHost: (hostname: string) =>
-    ["arweave.net", "ardrive.net", "gateway.arweave.net"].includes(
-      hostname.toLowerCase()
-    ),
-}));
-
 import {
   getMediaGatewayFallbackUrls,
   shouldUseIframeFallbackTimeout,
 } from "@/components/nft-image/utils/gateway-fallback";
 
 describe("gateway fallback helpers", () => {
-  it("prefers the configured gateway for ipfs protocol urls", () => {
-    expect(getMediaGatewayFallbackUrls("ipfs://bafy-test")).toEqual([
-      "https://ipfs.6529.io/ipfs/bafy-test",
-      "https://ipfs.io/ipfs/bafy-test",
-    ]);
+  it("prefers the 6529 resolver for ipfs protocol urls", () => {
+    expect(getMediaGatewayFallbackUrls("ipfs://bafy-test").slice(0, 3)).toEqual(
+      [
+        "https://media.6529.io/ipfs/bafy-test",
+        "https://ipfs.io/ipfs/bafy-test",
+        "https://cf-ipfs.com/ipfs/bafy-test",
+      ]
+    );
   });
 
-  it("normalizes ipfs gateway urls back to configured gateway first", () => {
+  it("normalizes ipfs gateway urls back to the 6529 resolver first", () => {
     expect(
-      getMediaGatewayFallbackUrls("https://ipfs.io/ipfs/bafy-test")
+      getMediaGatewayFallbackUrls("https://ipfs.io/ipfs/bafy-test").slice(0, 3)
     ).toEqual([
-      "https://ipfs.6529.io/ipfs/bafy-test",
+      "https://media.6529.io/ipfs/bafy-test",
       "https://ipfs.io/ipfs/bafy-test",
+      "https://cf-ipfs.com/ipfs/bafy-test",
     ]);
   });
 
-  it("uses timeout fallback for approved arweave gateways", () => {
+  it("uses timeout fallback for approved arweave gateways and the 6529 resolver", () => {
     expect(
       shouldUseIframeFallbackTimeout("https://arweave.net/transaction-id")
+    ).toBe(true);
+    expect(
+      shouldUseIframeFallbackTimeout(
+        "https://media.6529.io/arweave/transaction-id"
+      )
     ).toBe(true);
   });
 

--- a/__tests__/components/providers/IpfsImageSetup.test.tsx
+++ b/__tests__/components/providers/IpfsImageSetup.test.tsx
@@ -1,0 +1,18 @@
+import { render, waitFor } from "@testing-library/react";
+import IpfsImageSetup from "@/components/providers/IpfsImageSetup";
+
+const CID = "bafybeigdyrzt5sfp7udm7hu76mjts3sfb44oixwkw55rmpbc6g6wuigv3i";
+
+describe("IpfsImageSetup", () => {
+  it("rewrites uppercase decentralized schemes in DOM attributes", async () => {
+    document.body.innerHTML = `<img src="IPFS://${CID}/image.png" />`;
+
+    render(<IpfsImageSetup />);
+
+    await waitFor(() => {
+      expect(document.querySelector("img")?.getAttribute("src")).toBe(
+        `https://media.6529.io/ipfs/${CID}/image.png`
+      );
+    });
+  });
+});

--- a/__tests__/components/providers/IpfsImageSetup.test.tsx
+++ b/__tests__/components/providers/IpfsImageSetup.test.tsx
@@ -5,6 +5,10 @@ const CID = "bafybeigdyrzt5sfp7udm7hu76mjts3sfb44oixwkw55rmpbc6g6wuigv3i";
 const TX_ID = "OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc";
 
 describe("IpfsImageSetup", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
   it("rewrites mixed-case decentralized schemes in DOM attributes", async () => {
     document.body.innerHTML = `
       <img src="IPFS://${CID}/image.png" />
@@ -23,6 +27,35 @@ describe("IpfsImageSetup", () => {
       );
       expect(document.querySelector("video")?.getAttribute("poster")).toBe(
         `https://media.6529.io/arweave/${TX_ID}`
+      );
+    });
+  });
+
+  it("rewrites mixed-case decentralized schemes added after mount", async () => {
+    render(<IpfsImageSetup />);
+
+    const image = document.createElement("img");
+    image.setAttribute("src", `IPFS://${CID}/late.png`);
+    document.body.appendChild(image);
+
+    await waitFor(() => {
+      expect(image.getAttribute("src")).toBe(
+        `https://media.6529.io/ipfs/${CID}/late.png`
+      );
+    });
+  });
+
+  it("rewrites mixed-case decentralized schemes in changed attributes", async () => {
+    document.body.innerHTML = `<a href="https://example.com">Example</a>`;
+
+    render(<IpfsImageSetup />);
+
+    const link = document.querySelector("a");
+    link?.setAttribute("href", `AR://${TX_ID}/index.html`);
+
+    await waitFor(() => {
+      expect(link?.getAttribute("href")).toBe(
+        `https://media.6529.io/arweave/${TX_ID}/index.html`
       );
     });
   });

--- a/__tests__/components/providers/IpfsImageSetup.test.tsx
+++ b/__tests__/components/providers/IpfsImageSetup.test.tsx
@@ -2,16 +2,27 @@ import { render, waitFor } from "@testing-library/react";
 import IpfsImageSetup from "@/components/providers/IpfsImageSetup";
 
 const CID = "bafybeigdyrzt5sfp7udm7hu76mjts3sfb44oixwkw55rmpbc6g6wuigv3i";
+const TX_ID = "OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc";
 
 describe("IpfsImageSetup", () => {
-  it("rewrites uppercase decentralized schemes in DOM attributes", async () => {
-    document.body.innerHTML = `<img src="IPFS://${CID}/image.png" />`;
+  it("rewrites mixed-case decentralized schemes in DOM attributes", async () => {
+    document.body.innerHTML = `
+      <img src="IPFS://${CID}/image.png" />
+      <a href="IpNs://collection-name/index.html">IPNS</a>
+      <video poster="AR://${TX_ID}"></video>
+    `;
 
     render(<IpfsImageSetup />);
 
     await waitFor(() => {
       expect(document.querySelector("img")?.getAttribute("src")).toBe(
         `https://media.6529.io/ipfs/${CID}/image.png`
+      );
+      expect(document.querySelector("a")?.getAttribute("href")).toBe(
+        "https://media.6529.io/ipns/collection-name/index.html"
+      );
+      expect(document.querySelector("video")?.getAttribute("poster")).toBe(
+        `https://media.6529.io/arweave/${TX_ID}`
       );
     });
   });

--- a/__tests__/components/waves/ens/EnsPreviewCard.test.tsx
+++ b/__tests__/components/waves/ens/EnsPreviewCard.test.tsx
@@ -25,7 +25,7 @@ describe("EnsPreviewCard", () => {
       contenthash: {
         protocol: "ipfs",
         decoded: "ipfs://bafy",
-        gatewayUrl: "https://cf-ipfs.com/ipfs/bafy",
+        gatewayUrl: "https://media.6529.io/ipfs/bafy",
       },
       ownership: {
         registryOwner: "0x0000000000000000000000000000000000000003",
@@ -36,8 +36,9 @@ describe("EnsPreviewCard", () => {
       },
       links: {
         app: "https://app.ens.domains/name/vitalik.eth",
-        etherscan: "https://etherscan.io/address/0x0000000000000000000000000000000000000001",
-        open: "https://cf-ipfs.com/ipfs/bafy",
+        etherscan:
+          "https://etherscan.io/address/0x0000000000000000000000000000000000000001",
+        open: "https://media.6529.io/ipfs/bafy",
       },
     };
 
@@ -50,7 +51,10 @@ describe("EnsPreviewCard", () => {
       "href",
       preview.links.etherscan
     );
-    expect(screen.getByText("Open content")).toHaveAttribute("href", preview.links.open);
+    expect(screen.getByText("Open content")).toHaveAttribute(
+      "href",
+      preview.links.open
+    );
   });
 
   it("renders ENS address information", () => {
@@ -63,7 +67,8 @@ describe("EnsPreviewCard", () => {
       avatarUrl: null,
       links: {
         app: "https://app.ens.domains/address/0x0000000000000000000000000000000000000001",
-        etherscan: "https://etherscan.io/address/0x0000000000000000000000000000000000000001",
+        etherscan:
+          "https://etherscan.io/address/0x0000000000000000000000000000000000000001",
       },
     };
 
@@ -82,10 +87,10 @@ describe("EnsPreviewCard", () => {
       contenthash: {
         protocol: "ipns",
         decoded: "ipns://example",
-        gatewayUrl: "https://cf-ipfs.com/ipns/example",
+        gatewayUrl: "https://media.6529.io/ipns/example",
       },
       links: {
-        open: "https://cf-ipfs.com/ipns/example",
+        open: "https://media.6529.io/ipns/example",
         app: "https://app.ens.domains/name/site.eth",
       },
     };

--- a/__tests__/components/waves/memes/submission/MemesArtSubmissionContainer.test.tsx
+++ b/__tests__/components/waves/memes/submission/MemesArtSubmissionContainer.test.tsx
@@ -162,11 +162,11 @@ describe("MemesArtSubmissionContainer", () => {
     formState.setExternalMediaHash = jest.fn((hash: string) => {
       formState.externalMediaHashInput = hash;
       if (hash) {
-        formState.externalMediaUrl = `${formState.externalMediaProvider === "arweave" ? "https://arweave.net/" : "ipfs://"}${hash}`;
+        formState.externalMediaUrl = `${formState.externalMediaProvider === "arweave" ? "ar://" : "ipfs://"}${hash}`;
         formState.externalMediaPreviewUrl =
           formState.externalMediaProvider === "arweave"
-            ? `https://arweave.net/${hash}`
-            : `https://ipfs.io/ipfs/${hash}`;
+            ? `https://media.6529.io/arweave/${hash}`
+            : `https://media.6529.io/ipfs/${hash}`;
         formState.isExternalMediaValid = true;
         formState.externalMediaValidationStatus = "valid";
         formState.externalMediaError = null;

--- a/__tests__/components/waves/memes/submission/actions/validateInteractivePreview.test.ts
+++ b/__tests__/components/waves/memes/submission/actions/validateInteractivePreview.test.ts
@@ -1,8 +1,8 @@
-import { validateInteractivePreview } from '@/components/waves/memes/submission/actions/validateInteractivePreview';
-import { INTERACTIVE_MEDIA_GATEWAY_BASE_URL } from '@/components/waves/memes/submission/constants/security';
+import { validateInteractivePreview } from "@/components/waves/memes/submission/actions/validateInteractivePreview";
+import { INTERACTIVE_MEDIA_GATEWAY_BASE_URL } from "@/components/waves/memes/submission/constants/security";
 
-const CID_V1 = 'bafybeigdyrztobg3tv6zj5n6xvztf4k5p3xf7r6xkqfq5jz3o5quftdjum';
-const ARWEAVE_TX_ID = 'QW_ArkGRZa0uSmLkH2ZAzU9xOQFfGqVsRyCrND3eOo8';
+const CID_V1 = "bafybeigdyrztobg3tv6zj5n6xvztf4k5p3xf7r6xkqfq5jz3o5quftdjum";
+const ARWEAVE_TX_ID = "QW_ArkGRZa0uSmLkH2ZAzU9xOQFfGqVsRyCrND3eOo8";
 
 const originalFetch = global.fetch;
 
@@ -21,7 +21,7 @@ type MockResponse = {
 const createResponse = (
   status: number,
   headers: Record<string, string>,
-  url = `https://ipfs.io/ipfs/${CID_V1}`
+  url = `https://media.6529.io/ipfs/${CID_V1}`
 ): MockResponse => {
   const headerStore = new Map(
     Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
@@ -44,7 +44,7 @@ const createResponse = (
   };
 };
 
-describe('validateInteractivePreview', () => {
+describe("validateInteractivePreview", () => {
   beforeEach(() => {
     global.fetch = jest.fn();
   });
@@ -54,34 +54,40 @@ describe('validateInteractivePreview', () => {
     jest.clearAllMocks();
   });
 
-  it('accepts HTML content served over an approved gateway', async () => {
+  it("accepts HTML content served over an approved gateway", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce(
-      createResponse(200, { 'content-type': 'text/html; charset=utf-8' })
+      createResponse(200, { "content-type": "text/html; charset=utf-8" })
     );
 
     const result = await validateInteractivePreview({
-      provider: 'ipfs',
+      provider: "ipfs",
       path: CID_V1,
     });
 
     expect(result.ok).toBe(true);
-    expect(result.contentType).toBe('text/html; charset=utf-8');
+    expect(result.contentType).toBe("text/html; charset=utf-8");
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(global.fetch).toHaveBeenLastCalledWith(
-      expect.stringContaining(`https://ipfs.io/ipfs/${CID_V1}`),
-      expect.objectContaining({ method: 'HEAD' })
+      expect.stringContaining(`https://media.6529.io/ipfs/${CID_V1}`),
+      expect.objectContaining({ method: "HEAD" })
     );
   });
 
-  it('falls back to a ranged GET when HEAD is unsupported', async () => {
+  it("falls back to a ranged GET when HEAD is unsupported", async () => {
     (global.fetch as jest.Mock)
-      .mockResolvedValueOnce(createResponse(405, { 'content-type': 'text/plain' }))
       .mockResolvedValueOnce(
-        createResponse(206, { 'content-type': 'text/html' }, `https://arweave.net/${ARWEAVE_TX_ID}`)
+        createResponse(405, { "content-type": "text/plain" })
+      )
+      .mockResolvedValueOnce(
+        createResponse(
+          206,
+          { "content-type": "text/html" },
+          `https://media.6529.io/arweave/${ARWEAVE_TX_ID}`
+        )
       );
 
     const result = await validateInteractivePreview({
-      provider: 'arweave',
+      provider: "arweave",
       path: ARWEAVE_TX_ID,
     });
 
@@ -89,22 +95,25 @@ describe('validateInteractivePreview', () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
     expect(global.fetch).toHaveBeenNthCalledWith(
       2,
-      expect.stringContaining(`https://arweave.net/${ARWEAVE_TX_ID}`),
-      expect.objectContaining({ method: 'GET', headers: { Range: 'bytes=0-1024' } })
+      expect.stringContaining(`https://media.6529.io/arweave/${ARWEAVE_TX_ID}`),
+      expect.objectContaining({
+        method: "GET",
+        headers: { Range: "bytes=0-1024" },
+      })
     );
   });
 
-  it('accepts HTML content served from an arweave subdomain', async () => {
+  it("accepts HTML content served from an arweave subdomain", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce(
       createResponse(
         200,
-        { 'content-type': 'text/html' },
+        { "content-type": "text/html" },
         `https://${ARWEAVE_TX_ID.toLowerCase()}.arweave.net/`
       )
     );
 
     const result = await validateInteractivePreview({
-      provider: 'arweave',
+      provider: "arweave",
       path: ARWEAVE_TX_ID,
     });
 
@@ -112,149 +121,157 @@ describe('validateInteractivePreview', () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects responses with disallowed content types', async () => {
+  it("rejects responses with disallowed content types", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce(
-      createResponse(200, { 'content-type': 'application/octet-stream' })
+      createResponse(200, { "content-type": "application/octet-stream" })
     );
 
     const result = await validateInteractivePreview({
-      provider: 'ipfs',
+      provider: "ipfs",
       path: CID_V1,
     });
 
     expect(result.ok).toBe(false);
-    expect(result.reason).toBe('Media must respond with an HTML document.');
+    expect(result.reason).toBe("Media must respond with an HTML document.");
   });
 
-  it('fails when the gateway redirects to an unapproved host', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce(
-      createResponse(200, { 'content-type': 'text/html' }, 'https://example.com/bad')
-    );
-
-    const result = await validateInteractivePreview({
-      provider: 'ipfs',
-      path: CID_V1,
-    });
-
-    expect(result.ok).toBe(false);
-    expect(result.reason).toBe('Gateway redirected to an unapproved host.');
-  });
-
-  it('propagates network failures as validation errors', async () => {
-    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('offline'));
-
-    const result = await validateInteractivePreview({
-      provider: 'ipfs',
-      path: CID_V1,
-    });
-
-    expect(result.ok).toBe(false);
-    expect(result.reason).toBe('Unable to reach the content gateway.');
-  });
-
-  it('fails fast when HEAD request returns 400 without retrying GET', async () => {
-    (global.fetch as jest.Mock).mockResolvedValueOnce(
-      createResponse(400, { 'content-type': 'text/plain' })
-    );
-
-    const result = await validateInteractivePreview({
-      provider: 'ipfs',
-      path: CID_V1,
-    });
-
-    expect(result.ok).toBe(false);
-    expect(result.reason).toBe('Gateway returned 400.');
-    expect(global.fetch).toHaveBeenCalledTimes(1);
-  });
-
-  it('accepts responses from trailing-dot hosts after canonicalization', async () => {
+  it("fails when the gateway redirects to an unapproved host", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce(
       createResponse(
         200,
-        { 'content-type': 'text/html' },
+        { "content-type": "text/html" },
+        "https://example.com/bad"
+      )
+    );
+
+    const result = await validateInteractivePreview({
+      provider: "ipfs",
+      path: CID_V1,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("Gateway redirected to an unapproved host.");
+  });
+
+  it("propagates network failures as validation errors", async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("offline"));
+
+    const result = await validateInteractivePreview({
+      provider: "ipfs",
+      path: CID_V1,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("Unable to reach the content gateway.");
+  });
+
+  it("fails fast when HEAD request returns 400 without retrying GET", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      createResponse(400, { "content-type": "text/plain" })
+    );
+
+    const result = await validateInteractivePreview({
+      provider: "ipfs",
+      path: CID_V1,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("Gateway returned 400.");
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts responses from trailing-dot hosts after canonicalization", async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce(
+      createResponse(
+        200,
+        { "content-type": "text/html" },
         `https://ipfs.io./ipfs/${CID_V1}`
       )
     );
 
     const result = await validateInteractivePreview({
-      provider: 'ipfs',
+      provider: "ipfs",
       path: CID_V1,
     });
 
     expect(result.ok).toBe(true);
   });
 
-  it('rejects responses that include credentials', async () => {
+  it("rejects responses that include credentials", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce(
       createResponse(
         200,
-        { 'content-type': 'text/html' },
+        { "content-type": "text/html" },
         `https://user:pass@ipfs.io/ipfs/${CID_V1}`
       )
     );
 
     const result = await validateInteractivePreview({
-      provider: 'ipfs',
+      provider: "ipfs",
       path: CID_V1,
     });
 
     expect(result.ok).toBe(false);
-    expect(result.reason).toBe('Gateway redirected to an unapproved host.');
+    expect(result.reason).toBe("Gateway redirected to an unapproved host.");
   });
 
-  it('rejects responses that use a non-default https port', async () => {
+  it("rejects responses that use a non-default https port", async () => {
     (global.fetch as jest.Mock).mockResolvedValueOnce(
       createResponse(
         200,
-        { 'content-type': 'text/html' },
+        { "content-type": "text/html" },
         `https://ipfs.io:444/ipfs/${CID_V1}`
       )
     );
 
     const result = await validateInteractivePreview({
-      provider: 'ipfs',
+      provider: "ipfs",
       path: CID_V1,
     });
 
     expect(result.ok).toBe(false);
-    expect(result.reason).toBe('Gateway redirected to an unapproved host.');
+    expect(result.reason).toBe("Gateway redirected to an unapproved host.");
   });
 
-  it('rejects identifiers containing path separators before requesting the gateway', async () => {
+  it("rejects identifiers containing path separators before requesting the gateway", async () => {
     const result = await validateInteractivePreview({
-      provider: 'ipfs',
+      provider: "ipfs",
       path: `${CID_V1}/index.html`,
     });
 
     expect(result.ok).toBe(false);
-    expect(result.reason).toBe('Invalid path: only relative paths under the gateway origin are allowed.');
+    expect(result.reason).toBe(
+      "Invalid path: only relative paths under the gateway origin are allowed."
+    );
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it('rejects identifiers that do not match provider expectations', async () => {
+  it("rejects identifiers that do not match provider expectations", async () => {
     const result = await validateInteractivePreview({
-      provider: 'ipfs',
-      path: 'not-a-valid-cid',
+      provider: "ipfs",
+      path: "not-a-valid-cid",
     });
 
     expect(result.ok).toBe(false);
-    expect(result.reason).toBe('Invalid path: expected a CIDv0 or CIDv1 root hash.');
+    expect(result.reason).toBe(
+      "Invalid path: expected a CIDv0 or CIDv1 root hash."
+    );
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it('rejects requests whose resolved target host is unapproved before making a network call', async () => {
+  it("rejects requests whose resolved target host is unapproved before making a network call", async () => {
     const originalBase = INTERACTIVE_MEDIA_GATEWAY_BASE_URL.ipfs;
-    INTERACTIVE_MEDIA_GATEWAY_BASE_URL.ipfs = 'https://example.com/';
+    INTERACTIVE_MEDIA_GATEWAY_BASE_URL.ipfs = "https://example.com/";
 
     try {
       const result = await validateInteractivePreview({
-        provider: 'ipfs',
+        provider: "ipfs",
         path: CID_V1,
       });
 
       expect(result.ok).toBe(false);
       expect(result.reason).toBe(
-        'Invalid path: resolved target is not permitted under allowed gateway hosts.'
+        "Invalid path: resolved target is not permitted under allowed gateway hosts."
       );
       expect(global.fetch).not.toHaveBeenCalled();
     } finally {

--- a/__tests__/components/waves/memes/submission/actions/validateInteractivePreview.test.ts
+++ b/__tests__/components/waves/memes/submission/actions/validateInteractivePreview.test.ts
@@ -154,7 +154,7 @@ describe("validateInteractivePreview", () => {
   });
 
   it("propagates network failures as validation errors", async () => {
-    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("offline"));
+    (globalThis.fetch as jest.Mock).mockRejectedValueOnce(new Error("offline"));
 
     const result = await validateInteractivePreview({
       provider: "ipfs",

--- a/__tests__/components/waves/memes/submission/actions/validateInteractivePreview.test.ts
+++ b/__tests__/components/waves/memes/submission/actions/validateInteractivePreview.test.ts
@@ -154,7 +154,7 @@ describe("validateInteractivePreview", () => {
   });
 
   it("propagates network failures as validation errors", async () => {
-    (globalThis.fetch as jest.Mock).mockRejectedValueOnce(new Error("offline"));
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error("offline"));
 
     const result = await validateInteractivePreview({
       provider: "ipfs",

--- a/__tests__/components/waves/memes/submission/constants/security.test.ts
+++ b/__tests__/components/waves/memes/submission/constants/security.test.ts
@@ -1,5 +1,6 @@
 import {
   canonicalizeInteractiveMediaUrl,
+  isInteractiveMediaAllowedHost,
   isInteractiveMediaContentPathAllowed,
 } from "@/components/waves/memes/submission/constants/security";
 
@@ -80,6 +81,36 @@ describe("interactive media security helpers", () => {
         `https://${CID_SUBDOMAIN}.ipfs.nftstorage.link/pendulums_mint_script.html`
       )
     ).toBeNull();
+  });
+
+  it("rejects recognized gateway paths when the host is outside the interactive allowlist", () => {
+    expect(isInteractiveMediaAllowedHost("cloudflare-ipfs.com")).toBe(false);
+    expect(
+      isInteractiveMediaContentPathAllowed(
+        "cloudflare-ipfs.com",
+        `/ipfs/${CID_V0}/pendulums_mint_script.html`
+      )
+    ).toBe(false);
+
+    expect(isInteractiveMediaAllowedHost("gateway.pinata.cloud")).toBe(false);
+    expect(
+      isInteractiveMediaContentPathAllowed(
+        "gateway.pinata.cloud",
+        `/ipfs/${CID_V0}/pendulums_mint_script.html`
+      )
+    ).toBe(false);
+  });
+
+  it("rejects recognized IPFS subdomain gateway paths in direct path validation", () => {
+    expect(
+      isInteractiveMediaAllowedHost(`${CID_SUBDOMAIN}.ipfs.nftstorage.link`)
+    ).toBe(false);
+    expect(
+      isInteractiveMediaContentPathAllowed(
+        `${CID_SUBDOMAIN}.ipfs.nftstorage.link`,
+        "/pendulums_mint_script.html"
+      )
+    ).toBe(false);
   });
 
   it("rejects nested non-HTML IPFS paths", () => {

--- a/__tests__/components/waves/memes/submission/constants/security.test.ts
+++ b/__tests__/components/waves/memes/submission/constants/security.test.ts
@@ -133,6 +133,12 @@ describe("interactive media security helpers", () => {
 
   it("rejects IPFS paths with encoded traversal", () => {
     expect(
+      isInteractiveMediaContentPathAllowed(
+        "ipfs.io",
+        `/ipfs/${CID_V0}/%2e%2e/index.html`
+      )
+    ).toBe(false);
+    expect(
       canonicalizeInteractiveMediaUrl(
         `https://ipfs.io/ipfs/${CID_V0}/%2e%2e/index.html`
       )
@@ -153,6 +159,18 @@ describe("interactive media security helpers", () => {
   });
 
   it("rejects gateway IPFS paths with encoded separators", () => {
+    expect(
+      isInteractiveMediaContentPathAllowed(
+        "ipfs.io",
+        `/ipfs/${CID_V0}/%2fsecret.html`
+      )
+    ).toBe(false);
+    expect(
+      isInteractiveMediaContentPathAllowed(
+        "ipfs.io",
+        `/ipfs/${CID_V0}/%5csecret.html`
+      )
+    ).toBe(false);
     expect(
       canonicalizeInteractiveMediaUrl(
         `https://ipfs.io/ipfs/${CID_V0}/%2fsecret.html`

--- a/__tests__/components/waves/memes/submission/constants/security.test.ts
+++ b/__tests__/components/waves/memes/submission/constants/security.test.ts
@@ -36,12 +36,34 @@ describe("interactive media security helpers", () => {
     ).toBe(true);
   });
 
-  it("strips query params when canonicalizing interactive media URLs", () => {
+  it("preserves query params when canonicalizing interactive media URLs", () => {
     expect(
       canonicalizeInteractiveMediaUrl(
         `https://ipfs.io/ipfs/${CID_V0}/pendulums_mint_script.html?seed=374131294`
       )
-    ).toBe(`https://media.6529.io/ipfs/${CID_V0}/pendulums_mint_script.html`);
+    ).toBe(
+      `https://media.6529.io/ipfs/${CID_V0}/pendulums_mint_script.html?seed=374131294`
+    );
+  });
+
+  it("preserves URL hashes when canonicalizing interactive media URLs", () => {
+    expect(
+      canonicalizeInteractiveMediaUrl(
+        `https://ipfs.io/ipfs/${CID_V0}/pendulums_mint_script.html?seed=374131294#preview`
+      )
+    ).toBe(
+      `https://media.6529.io/ipfs/${CID_V0}/pendulums_mint_script.html?seed=374131294#preview`
+    );
+  });
+
+  it("preserves query and hash for native interactive media URLs", () => {
+    expect(
+      canonicalizeInteractiveMediaUrl(
+        `ipfs://${CID_V0}/pendulums_mint_script.html?seed=374131294#preview`
+      )
+    ).toBe(
+      `https://media.6529.io/ipfs/${CID_V0}/pendulums_mint_script.html?seed=374131294#preview`
+    );
   });
 
   it("allows media resolver interactive URLs", () => {
@@ -88,9 +110,13 @@ describe("interactive media security helpers", () => {
     ).toBeNull();
   });
 
-  it("still rejects URL hashes", () => {
+  it("preserves URL hashes on media resolver interactive URLs", () => {
     expect(
-      canonicalizeInteractiveMediaUrl(`https://ipfs.io/ipfs/${CID_V0}#hash`)
-    ).toBeNull();
+      canonicalizeInteractiveMediaUrl(
+        `https://media.6529.io/ipfs/${CID_V0}/pendulums_mint_script.html#render`
+      )
+    ).toBe(
+      `https://media.6529.io/ipfs/${CID_V0}/pendulums_mint_script.html#render`
+    );
   });
 });

--- a/__tests__/components/waves/memes/submission/constants/security.test.ts
+++ b/__tests__/components/waves/memes/submission/constants/security.test.ts
@@ -110,6 +110,42 @@ describe("interactive media security helpers", () => {
     ).toBeNull();
   });
 
+  it("rejects gateway IPFS paths with encoded dot traversal before URL normalization", () => {
+    expect(
+      canonicalizeInteractiveMediaUrl(
+        `https://ipfs.io/ipfs/${CID_V0}/%2e%2e/secret`
+      )
+    ).toBeNull();
+    expect(
+      canonicalizeInteractiveMediaUrl(
+        `https://ipfs.io/ipfs/${CID_V0}/%2e%2e/${CID_V0}/pendulums_mint_script.html`
+      )
+    ).toBeNull();
+  });
+
+  it("rejects gateway IPFS paths with encoded separators", () => {
+    expect(
+      canonicalizeInteractiveMediaUrl(
+        `https://ipfs.io/ipfs/${CID_V0}/%2fsecret.html`
+      )
+    ).toBeNull();
+    expect(
+      canonicalizeInteractiveMediaUrl(
+        `https://ipfs.io/ipfs/${CID_V0}/%5csecret.html`
+      )
+    ).toBeNull();
+  });
+
+  it("allows encoded characters in interactive media query params", () => {
+    expect(
+      canonicalizeInteractiveMediaUrl(
+        `https://ipfs.io/ipfs/${CID_V0}/pendulums_mint_script.html?seed=a%2Fb%5Cc`
+      )
+    ).toBe(
+      `https://media.6529.io/ipfs/${CID_V0}/pendulums_mint_script.html?seed=a%2Fb%5Cc`
+    );
+  });
+
   it("preserves URL hashes on media resolver interactive URLs", () => {
     expect(
       canonicalizeInteractiveMediaUrl(

--- a/__tests__/components/waves/memes/submission/constants/security.test.ts
+++ b/__tests__/components/waves/memes/submission/constants/security.test.ts
@@ -74,14 +74,12 @@ describe("interactive media security helpers", () => {
     ).toBe(`https://media.6529.io/ipfs/${CID_V0}/pendulums_mint_script.html`);
   });
 
-  it("allows recognized IPFS subdomain gateways", () => {
+  it("rejects recognized IPFS subdomain gateways as interactive iframe sources", () => {
     expect(
       canonicalizeInteractiveMediaUrl(
         `https://${CID_SUBDOMAIN}.ipfs.nftstorage.link/pendulums_mint_script.html`
       )
-    ).toBe(
-      `https://media.6529.io/ipfs/${CID_SUBDOMAIN}/pendulums_mint_script.html`
-    );
+    ).toBeNull();
   });
 
   it("rejects nested non-HTML IPFS paths", () => {

--- a/__tests__/components/waves/memes/submission/constants/security.test.ts
+++ b/__tests__/components/waves/memes/submission/constants/security.test.ts
@@ -4,6 +4,8 @@ import {
 } from "@/components/waves/memes/submission/constants/security";
 
 const CID_V0 = "QmULf712pVAVBPDBenmE4PGQGA8EWY9uFRiiRmLksfu6Tn";
+const CID_SUBDOMAIN =
+  "bafybeigdyrztobg3tv6zj5n6xvztf4k5p3xf7r6xkqfq5jz3o5quftdjum";
 
 jest.mock("@/lib/media/ipfs-gateways", () => ({
   getConfiguredIpfsGatewayHost: () => "ipfs.6529.io",
@@ -34,13 +36,29 @@ describe("interactive media security helpers", () => {
     ).toBe(true);
   });
 
-  it("allows query params on canonical interactive media URLs", () => {
+  it("strips query params when canonicalizing interactive media URLs", () => {
     expect(
       canonicalizeInteractiveMediaUrl(
         `https://ipfs.io/ipfs/${CID_V0}/pendulums_mint_script.html?seed=374131294`
       )
+    ).toBe(`https://media.6529.io/ipfs/${CID_V0}/pendulums_mint_script.html`);
+  });
+
+  it("allows media resolver interactive URLs", () => {
+    expect(
+      canonicalizeInteractiveMediaUrl(
+        `https://media.6529.io/ipfs/${CID_V0}/pendulums_mint_script.html`
+      )
+    ).toBe(`https://media.6529.io/ipfs/${CID_V0}/pendulums_mint_script.html`);
+  });
+
+  it("allows recognized IPFS subdomain gateways", () => {
+    expect(
+      canonicalizeInteractiveMediaUrl(
+        `https://${CID_SUBDOMAIN}.ipfs.nftstorage.link/pendulums_mint_script.html`
+      )
     ).toBe(
-      `https://ipfs.io/ipfs/${CID_V0}/pendulums_mint_script.html?seed=374131294`
+      `https://media.6529.io/ipfs/${CID_SUBDOMAIN}/pendulums_mint_script.html`
     );
   });
 

--- a/__tests__/components/waves/memes/submission/hooks/useArtworkSubmissionForm.test.ts
+++ b/__tests__/components/waves/memes/submission/hooks/useArtworkSubmissionForm.test.ts
@@ -541,7 +541,7 @@ describe("useArtworkSubmissionForm", () => {
     });
     expect(result.current.externalMediaError).toBeNull();
     expect(result.current.externalMediaPreviewUrl).toBe(
-      `https://ipfs.io/ipfs/${CID_V1}`
+      `https://media.6529.io/ipfs/${CID_V1}`
     );
     expect(result.current.externalMediaValidationStatus).toBe("valid");
   });

--- a/__tests__/components/waves/memes/submission/hooks/useArtworkSubmissionForm.test.ts
+++ b/__tests__/components/waves/memes/submission/hooks/useArtworkSubmissionForm.test.ts
@@ -546,6 +546,32 @@ describe("useArtworkSubmissionForm", () => {
     expect(result.current.externalMediaValidationStatus).toBe("valid");
   });
 
+  it("normalizes parsed IPFS URLs with subpaths to the root CID", async () => {
+    const { result } = renderArtworkSubmissionForm();
+
+    act(() => {
+      result.current.setMediaSource("url");
+    });
+    act(() => {
+      result.current.setExternalMediaHash(`ipfs://${CID_V1}/index.html`);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isExternalMediaValid).toBe(true);
+    });
+
+    expect(validateInteractivePreview).toHaveBeenCalledWith({
+      provider: "ipfs",
+      path: CID_V1,
+    });
+    expect(result.current.externalMediaHashInput).toBe(
+      `ipfs://${CID_V1}/index.html`
+    );
+    expect(result.current.externalMediaPreviewUrl).toBe(
+      `https://media.6529.io/ipfs/${CID_V1}`
+    );
+  });
+
   it("surfaces gateway validation errors from server action", async () => {
     (validateInteractivePreview as jest.Mock).mockResolvedValue({
       ok: false,

--- a/__tests__/config/env.base-endpoint.test.ts
+++ b/__tests__/config/env.base-endpoint.test.ts
@@ -142,6 +142,26 @@ describe("publicEnvSchema BASE_ENDPOINT (Zod)", () => {
   it.each(validCases)("accepts valid BASE_ENDPOINT: %s", (value) => {
     expectParseToSucceed(value);
   });
+
+  it("requires MEDIA_RESOLVER_ENDPOINT to use HTTPS", () => {
+    const schema = freshImportPublicEnvSchema();
+
+    expect(() =>
+      schema.parse(
+        buildInput({ MEDIA_RESOLVER_ENDPOINT: "http://media.example.com" })
+      )
+    ).toThrow("MEDIA_RESOLVER_ENDPOINT must use HTTPS");
+  });
+
+  it("accepts HTTPS MEDIA_RESOLVER_ENDPOINT values", () => {
+    const schema = freshImportPublicEnvSchema();
+
+    expect(
+      schema.parse(
+        buildInput({ MEDIA_RESOLVER_ENDPOINT: "https://media.example.com" })
+      ).MEDIA_RESOLVER_ENDPOINT
+    ).toBe("https://media.example.com");
+  });
 });
 
 describe("config/env.ts publicEnv loader", () => {

--- a/__tests__/helpers/Helpers.test.ts
+++ b/__tests__/helpers/Helpers.test.ts
@@ -17,6 +17,8 @@ import {
 } from "@/helpers/Helpers";
 import { DateIntervalsSelection } from "@/types/enums";
 
+const CID_V0 = "QmYwAPJzv5CZsnAzt8auVZRnG1R8n4wqxW48UUfZo59SyY";
+
 type FullscreenRequestKey =
   | "requestFullscreen"
   | "mozRequestFullScreen"
@@ -50,15 +52,25 @@ describe("Helpers utility functions", () => {
   });
 
   test("parseIpfsUrl converts ipfs protocol to the 6529 resolver url", () => {
-    expect(parseIpfsUrl("ipfs://hash")).toBe("https://media.6529.io/ipfs/hash");
+    expect(parseIpfsUrl(`ipfs://${CID_V0}`)).toBe(
+      `https://media.6529.io/ipfs/${CID_V0}`
+    );
     expect(parseIpfsUrl("https://site")).toBe("https://site");
   });
 
   test("parseIpfsUrlToGateway converts ipfs protocol to cf-ipfs gateway", () => {
-    expect(parseIpfsUrlToGateway("ipfs://data")).toBe(
-      "https://cf-ipfs.com/ipfs/data"
+    expect(parseIpfsUrlToGateway(`ipfs://${CID_V0}`)).toBe(
+      `https://cf-ipfs.com/ipfs/${CID_V0}`
     );
     expect(parseIpfsUrlToGateway("https://foo")).toBe("https://foo");
+  });
+
+  test("parseIpfsUrlToGateway does not trust cf-ipfs host substrings", () => {
+    const spoofedGateway = `https://cf-ipfs.com.evil.tld/ipfs/${CID_V0}`;
+    const querySpoof = `https://example.com/?next=https://cf-ipfs.com/ipfs/${CID_V0}`;
+
+    expect(parseIpfsUrlToGateway(spoofedGateway)).toBe(spoofedGateway);
+    expect(parseIpfsUrlToGateway(querySpoof)).toBe(querySpoof);
   });
 
   test("numberWithCommas formats numbers correctly", () => {

--- a/__tests__/helpers/Helpers.test.ts
+++ b/__tests__/helpers/Helpers.test.ts
@@ -49,8 +49,8 @@ describe("Helpers utility functions", () => {
     expect(addProtocol("")).toBe("");
   });
 
-  test("parseIpfsUrl converts ipfs protocol to gateway url", () => {
-    expect(parseIpfsUrl("ipfs://hash")).toBe("https://ipfs.io/ipfs/hash");
+  test("parseIpfsUrl converts ipfs protocol to the 6529 resolver url", () => {
+    expect(parseIpfsUrl("ipfs://hash")).toBe("https://media.6529.io/ipfs/hash");
     expect(parseIpfsUrl("https://site")).toBe("https://site");
   });
 

--- a/__tests__/lib/media/decentralized-media.test.ts
+++ b/__tests__/lib/media/decentralized-media.test.ts
@@ -1,0 +1,136 @@
+import {
+  getDecentralizedMediaFetchUrls,
+  normalizeDecentralizedMediaUrl,
+  parseDecentralizedMediaRef,
+  resolveDecentralizedMediaInputs,
+  to6529ResolverUrl,
+  toExternalFallbackUrls,
+  toNativeUri,
+} from "@/lib/media/decentralized-media";
+
+const CID = "bafybeigdyrzt5sfp7udm7hu76mjts3sfb44oixwkw55rmpbc6g6wuigv3i";
+const CID_V0 = "QmYwAPJzv5CZsnAzt8auVZRnG1R8n4wqxW48UUfZo59SyY";
+const TX_ID = "OI6-rpJ2C3Ab4HiZRWt5A1SumhjnYigmSPBPX0ICBj8";
+
+describe("decentralized media resolver", () => {
+  it.each([
+    [`ipfs://${CID}/image.png`, "ipfs", CID, "image.png"],
+    [`ipfs://ipfs/${CID}/image.png`, "ipfs", CID, "image.png"],
+    [`ipns://example.eth/avatar.png`, "ipns", "example.eth", "avatar.png"],
+    [`ar://${TX_ID}/metadata.json`, "arweave", TX_ID, "metadata.json"],
+    [`https://media.6529.io/ipfs/${CID}/image.png`, "ipfs", CID, "image.png"],
+    [
+      `https://media.6529.io/arweave/${TX_ID}/metadata.json`,
+      "arweave",
+      TX_ID,
+      "metadata.json",
+    ],
+    [`https://ipfs.io/ipfs/${CID}/image.png`, "ipfs", CID, "image.png"],
+    [`https://cf-ipfs.com/ipfs/${CID}`, "ipfs", CID, ""],
+    [`https://${CID}.ipfs.nftstorage.link/image.png`, "ipfs", CID, "image.png"],
+    [
+      `https://arweave.net/${TX_ID}/metadata.json`,
+      "arweave",
+      TX_ID,
+      "metadata.json",
+    ],
+    [
+      `https://${TX_ID.toLowerCase()}.arweave.net`,
+      "arweave",
+      TX_ID.toLowerCase(),
+      "",
+    ],
+  ])("parses %s", (input, protocol, id, path) => {
+    expect(parseDecentralizedMediaRef(input)).toEqual({
+      protocol,
+      id,
+      path,
+    });
+  });
+
+  it("builds native, resolver, and external fallback urls", () => {
+    const ref = parseDecentralizedMediaRef(
+      `https://ipfs.io/ipfs/${CID}/image.png`
+    );
+
+    expect(ref).toEqual({ protocol: "ipfs", id: CID, path: "image.png" });
+    expect(toNativeUri(ref!)).toBe(`ipfs://${CID}/image.png`);
+    expect(to6529ResolverUrl(ref!)).toBe(
+      `https://media.6529.io/ipfs/${CID}/image.png`
+    );
+    expect(toExternalFallbackUrls(ref!)).toEqual(
+      expect.arrayContaining([
+        `https://ipfs.io/ipfs/${CID}/image.png`,
+        `https://cf-ipfs.com/ipfs/${CID}/image.png`,
+        `https://${CID}.ipfs.dweb.link/image.png`,
+      ])
+    );
+  });
+
+  it("supports bare IPFS CIDs for legacy inputs", () => {
+    expect(parseDecentralizedMediaRef(CID_V0)).toEqual({
+      protocol: "ipfs",
+      id: CID_V0,
+      path: "",
+    });
+  });
+
+  it("normalizes recognized gateway urls to the 6529 resolver", () => {
+    expect(normalizeDecentralizedMediaUrl(`https://arweave.net/${TX_ID}`)).toBe(
+      `https://media.6529.io/arweave/${TX_ID}`
+    );
+  });
+
+  it("returns fetch urls with the resolver first", () => {
+    expect(getDecentralizedMediaFetchUrls(`ar://${TX_ID}`).slice(0, 3)).toEqual(
+      [
+        `https://media.6529.io/arweave/${TX_ID}`,
+        `https://arweave.net/${TX_ID}`,
+        `https://gateway.arweave.net/${TX_ID}`,
+      ]
+    );
+  });
+
+  it("reports query or hash stripping per item", () => {
+    const [item] = resolveDecentralizedMediaInputs([
+      `https://ipfs.io/ipfs/${CID}/image.png?download=1#view`,
+    ]);
+
+    expect(item).toEqual(
+      expect.objectContaining({
+        recognized: true,
+        native_uri: `ipfs://${CID}/image.png`,
+        warnings: ["query_or_hash_stripped"],
+      })
+    );
+  });
+
+  it("keeps unrecognized http urls and invalid inputs item-scoped", () => {
+    expect(
+      resolveDecentralizedMediaInputs([
+        "https://example.com/image.png",
+        "nota://valid-media",
+        "",
+      ])
+    ).toEqual([
+      {
+        input: "https://example.com/image.png",
+        recognized: false,
+        external_fallback_urls: [],
+        warnings: [],
+      },
+      {
+        input: "nota://valid-media",
+        recognized: false,
+        external_fallback_urls: [],
+        warnings: ["unsupported_scheme"],
+      },
+      {
+        input: "",
+        recognized: false,
+        external_fallback_urls: [],
+        warnings: ["invalid_url"],
+      },
+    ]);
+  });
+});

--- a/__tests__/lib/media/decentralized-media.test.ts
+++ b/__tests__/lib/media/decentralized-media.test.ts
@@ -11,6 +11,7 @@ import {
 const CID = "bafybeigdyrzt5sfp7udm7hu76mjts3sfb44oixwkw55rmpbc6g6wuigv3i";
 const CID_V0 = "QmYwAPJzv5CZsnAzt8auVZRnG1R8n4wqxW48UUfZo59SyY";
 const TX_ID = "OI6-rpJ2C3Ab4HiZRWt5A1SumhjnYigmSPBPX0ICBj8";
+const DNS_SAFE_TX_ID = TX_ID.toLowerCase();
 
 describe("decentralized media resolver", () => {
   it.each([
@@ -34,12 +35,7 @@ describe("decentralized media resolver", () => {
       TX_ID,
       "metadata.json",
     ],
-    [
-      `https://${TX_ID.toLowerCase()}.arweave.net`,
-      "arweave",
-      TX_ID.toLowerCase(),
-      "",
-    ],
+    [`https://${DNS_SAFE_TX_ID}.arweave.net`, "arweave", DNS_SAFE_TX_ID, ""],
   ])("parses %s", (input, protocol, id, path) => {
     expect(parseDecentralizedMediaRef(input)).toEqual({
       protocol,
@@ -67,6 +63,35 @@ describe("decentralized media resolver", () => {
     );
   });
 
+  it("omits subdomain fallbacks for non-DNS-safe identifiers", () => {
+    const cidV0Ref = parseDecentralizedMediaRef(`ipfs://${CID_V0}/image.png`);
+    const arweaveRef = parseDecentralizedMediaRef(`ar://${TX_ID}`);
+
+    expect(toExternalFallbackUrls(cidV0Ref!)).toEqual(
+      expect.arrayContaining([`https://ipfs.io/ipfs/${CID_V0}/image.png`])
+    );
+    expect(toExternalFallbackUrls(cidV0Ref!)).not.toEqual(
+      expect.arrayContaining([`https://${CID_V0}.ipfs.dweb.link/image.png`])
+    );
+    expect(toExternalFallbackUrls(arweaveRef!)).toEqual(
+      expect.arrayContaining([`https://arweave.net/${TX_ID}`])
+    );
+    expect(toExternalFallbackUrls(arweaveRef!)).not.toEqual(
+      expect.arrayContaining([`https://${TX_ID}.arweave.net`])
+    );
+  });
+
+  it("emits tx subdomain fallbacks for DNS-safe Arweave txids", () => {
+    const ref = parseDecentralizedMediaRef(`ar://${DNS_SAFE_TX_ID}`);
+
+    expect(toExternalFallbackUrls(ref!)).toEqual(
+      expect.arrayContaining([
+        `https://${DNS_SAFE_TX_ID}.arweave.net`,
+        `https://${DNS_SAFE_TX_ID}.ar.io`,
+      ])
+    );
+  });
+
   it("supports bare IPFS CIDs for legacy inputs", () => {
     expect(parseDecentralizedMediaRef(CID_V0)).toEqual({
       protocol: "ipfs",
@@ -79,6 +104,17 @@ describe("decentralized media resolver", () => {
     expect(normalizeDecentralizedMediaUrl(`https://arweave.net/${TX_ID}`)).toBe(
       `https://media.6529.io/arweave/${TX_ID}`
     );
+  });
+
+  it("does not recognize invalid IPFS CIDs or Arweave txids", () => {
+    expect(
+      parseDecentralizedMediaRef("https://ipfs.io/ipfs/not-a-cid/a.png")
+    ).toBeNull();
+    expect(parseDecentralizedMediaRef("ipfs://not-a-cid/a.png")).toBeNull();
+    expect(
+      parseDecentralizedMediaRef("https://arweave.net/not-a-txid")
+    ).toBeNull();
+    expect(parseDecentralizedMediaRef("ar://not-a-txid")).toBeNull();
   });
 
   it("returns fetch urls with the resolver first", () => {
@@ -110,7 +146,9 @@ describe("decentralized media resolver", () => {
       resolveDecentralizedMediaInputs([
         "https://example.com/image.png",
         "nota://valid-media",
+        "ipfs://not-a-cid",
         "",
+        "   ",
       ])
     ).toEqual([
       {
@@ -126,7 +164,19 @@ describe("decentralized media resolver", () => {
         warnings: ["unsupported_scheme"],
       },
       {
+        input: "ipfs://not-a-cid",
+        recognized: false,
+        external_fallback_urls: [],
+        warnings: ["invalid_url"],
+      },
+      {
         input: "",
+        recognized: false,
+        external_fallback_urls: [],
+        warnings: ["invalid_url"],
+      },
+      {
+        input: "   ",
         recognized: false,
         external_fallback_urls: [],
         warnings: ["invalid_url"],

--- a/app/api/open-graph/ens.ts
+++ b/app/api/open-graph/ens.ts
@@ -5,13 +5,18 @@ import type {
   EnsNamePreview,
   EnsOwnership,
   EnsPreview,
-  TextRecordKey} from "@/components/waves/ens/types";
-import {
-  TEXT_RECORD_KEYS
+  TextRecordKey,
 } from "@/components/waves/ens/types";
+import { TEXT_RECORD_KEYS } from "@/components/waves/ens/types";
 import type { EnsTarget } from "@/lib/ens/detect";
 import { stripHtmlTags } from "@/lib/text/html";
 import LruTtlCache from "@/lib/cache/lruTtl";
+import { publicEnv } from "@/config/env";
+import {
+  normalizeDecentralizedMediaUrl,
+  parseDecentralizedMediaRef,
+  to6529ResolverUrl,
+} from "@/lib/media/decentralized-media";
 import { ens_normalize } from "@adraffy/ens-normalize";
 import * as contentHash from "@ensdomains/content-hash";
 import { toUnicode } from "punycode";
@@ -174,14 +179,12 @@ function sanitizeUrl(value: string | null): string | null {
     return null;
   }
 
-  if (trimmed.startsWith("ipfs://")) {
-    return `https://cf-ipfs.com/ipfs/${trimmed.slice(7)}`;
-  }
-  if (trimmed.startsWith("ipns://")) {
-    return `https://cf-ipfs.com/ipns/${trimmed.slice(7)}`;
-  }
-  if (trimmed.startsWith("ar://")) {
-    return `https://arweave.net/${trimmed.slice(5)}`;
+  const normalizedMediaUrl = normalizeDecentralizedMediaUrl(
+    trimmed,
+    publicEnv.MEDIA_RESOLVER_ENDPOINT
+  );
+  if (normalizedMediaUrl && normalizedMediaUrl !== trimmed) {
+    return normalizedMediaUrl;
   }
 
   try {
@@ -211,11 +214,13 @@ function buildGatewayUrl(
 
   switch (protocol) {
     case "ipfs":
-      return `https://cf-ipfs.com/ipfs/${value.replaceAll(/^ipfs:\/\//i, "")}`;
     case "ipns":
-      return `https://cf-ipfs.com/ipns/${value.replaceAll(/^ipns:\/\//i, "")}`;
-    case "arweave":
-      return `https://arweave.net/${value.replaceAll(/^ar:\/\//i, "")}`;
+    case "arweave": {
+      const parsed = parseDecentralizedMediaRef(value);
+      return parsed
+        ? to6529ResolverUrl(parsed, publicEnv.MEDIA_RESOLVER_ENDPOINT)
+        : null;
+    }
     default:
       return null;
   }
@@ -357,7 +362,7 @@ async function loadOwnership(
 
   isWrapped = Boolean(
     registryOwner &&
-      registryOwner.toLowerCase() === NAME_WRAPPER_ADDRESS.toLowerCase()
+    registryOwner.toLowerCase() === NAME_WRAPPER_ADDRESS.toLowerCase()
   );
 
   if (isEthSecondLevel(normalized)) {
@@ -493,7 +498,7 @@ async function fetchEnsName(input: string): Promise<EnsNamePreview> {
       string | null,
       Partial<Record<TextRecordKey, string | null>>,
       EnsContenthash | null,
-      EnsOwnership
+      EnsOwnership,
     ];
 
   const sanitizedRecords: Partial<Record<TextRecordKey, string | null>> = {};

--- a/app/api/open-graph/opensea/service.ts
+++ b/app/api/open-graph/opensea/service.ts
@@ -1,6 +1,8 @@
 import type { PreviewPlan } from "@/app/api/open-graph/compound/service";
 import { buildResponse } from "@/app/api/open-graph/utils";
 import { getAlchemyApiKey } from "@/config/alchemyEnv";
+import { publicEnv } from "@/config/env";
+import { normalizeDecentralizedMediaUrl } from "@/lib/media/decentralized-media";
 import { matchesDomainOrSubdomain } from "@/lib/url/domains";
 import type { LinkPreviewResponse } from "@/services/api/link-preview-api";
 import {
@@ -31,7 +33,6 @@ const OPENSEA_ITEM_PATH_PATTERN =
   /^\/item\/([^/]+)\/(0x[a-f0-9]{40})\/([^/?#]+)\/?$/i;
 const OPENSEA_ASSET_PATH_PATTERN =
   /^\/assets\/([^/]+)\/(0x[a-f0-9]{40})\/([^/?#]+)\/?$/i;
-const DEFAULT_IPFS_GATEWAY = "https://ipfs.io/ipfs/";
 const TOKEN_URI_PREFIXED_PLACEHOLDER_PATTERN = /0x(?:\{id\}|%7Bid%7D)/i;
 const TOKEN_URI_FETCH_TIMEOUT_MS = 4000;
 
@@ -174,20 +175,12 @@ const extractOpenSeaContext = (url: URL): OpenSeaContext | null => {
 
 const normalizeMediaUrl = (value: string): string => {
   const trimmed = value.trim();
-
-  if (trimmed.startsWith("ipfs://ipfs/")) {
-    return `${DEFAULT_IPFS_GATEWAY}${trimmed.slice("ipfs://ipfs/".length)}`;
-  }
-
-  if (trimmed.startsWith("ipfs://")) {
-    return `${DEFAULT_IPFS_GATEWAY}${trimmed.slice("ipfs://".length)}`;
-  }
-
-  if (trimmed.startsWith("ar://")) {
-    return `https://arweave.net/${trimmed.slice("ar://".length)}`;
-  }
-
-  return trimmed;
+  return (
+    normalizeDecentralizedMediaUrl(
+      trimmed,
+      publicEnv.MEDIA_RESOLVER_ENDPOINT
+    ) ?? trimmed
+  );
 };
 
 const isBlockedMarketplaceOverlayUrl = (value: string): boolean => {

--- a/app/api/open-graph/transient/service.ts
+++ b/app/api/open-graph/transient/service.ts
@@ -1,6 +1,8 @@
 import type { PreviewPlan } from "@/app/api/open-graph/compound/service";
 import { buildResponse } from "@/app/api/open-graph/utils";
 import { getAlchemyApiKey } from "@/config/alchemyEnv";
+import { publicEnv } from "@/config/env";
+import { normalizeDecentralizedMediaUrl } from "@/lib/media/decentralized-media";
 import { matchesDomainOrSubdomain } from "@/lib/url/domains";
 import type { LinkPreviewResponse } from "@/services/api/link-preview-api";
 import { fetchAlchemyMetadataCandidate } from "../opensea/alchemy";
@@ -18,7 +20,6 @@ const TRANSIENT_CACHE_TTL_MS = 5 * 60 * 1000;
 const TRANSIENT_HOST = "transient.xyz";
 const TRANSIENT_NFT_PATH_PATTERN =
   /^\/nfts\/([^/]+)\/(0x[a-f0-9]{40})\/([^/?#]+)\/?$/i;
-const DEFAULT_IPFS_GATEWAY = "https://ipfs.io/ipfs/";
 const TOKEN_URI_PREFIXED_PLACEHOLDER_PATTERN = /0x(?:\{id\}|%7Bid%7D)/i;
 
 const ALCHEMY_NETWORK_BY_TRANSIENT_CHAIN: Record<string, string> = {
@@ -199,20 +200,12 @@ const extractTransientContext = (url: URL): TransientContext | null => {
 
 const normalizeMediaUrl = (value: string): string => {
   const trimmed = value.trim();
-
-  if (trimmed.startsWith("ipfs://ipfs/")) {
-    return `${DEFAULT_IPFS_GATEWAY}${trimmed.slice("ipfs://ipfs/".length)}`;
-  }
-
-  if (trimmed.startsWith("ipfs://")) {
-    return `${DEFAULT_IPFS_GATEWAY}${trimmed.slice("ipfs://".length)}`;
-  }
-
-  if (trimmed.startsWith("ar://")) {
-    return `https://arweave.net/${trimmed.slice("ar://".length)}`;
-  }
-
-  return trimmed;
+  return (
+    normalizeDecentralizedMediaUrl(
+      trimmed,
+      publicEnv.MEDIA_RESOLVER_ENDPOINT
+    ) ?? trimmed
+  );
 };
 
 const resolveAlchemyImage = (

--- a/app/api/pepe/resolve/route.ts
+++ b/app/api/pepe/resolve/route.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 
 import { publicEnv } from "@/config/env";
+import { normalizeDecentralizedMediaUrl } from "@/lib/media/decentralized-media";
 import {
   assertContentType,
   isHtmlContentType,
@@ -124,18 +125,6 @@ const cache = new LruTtlCache<string, Preview>({
 
 const USER_AGENT =
   "6529seize-pepe-card/1.0 (+https://6529.io; fetching pepe.wtf previews)";
-const IPFS_GATEWAY = trimTrailingSlashes(
-  publicEnv.IPFS_GATEWAY_ENDPOINT || "https://ipfs.io/ipfs/"
-);
-
-function trimTrailingSlashes(value: string): string {
-  let end = value.length;
-  while (end > 0 && value.codePointAt(end - 1) === 47) {
-    end -= 1;
-  }
-  return end === value.length ? value : value.slice(0, end);
-}
-
 function isCounterpartyAssetCode(value: string): boolean {
   const upper = value.toUpperCase();
   return /^[A-Z0-9]{3,}$/.test(upper) || /^A[0-9]{6,}$/.test(upper);
@@ -211,14 +200,11 @@ async function fetchJson<T>(url: string, timeoutMs = 4000): Promise<T | null> {
   }
 }
 
-function ipfsToHttp(url: string): string {
-  const match = url.match(/^ipfs:\/\/(ipfs\/)?(.+)$/i);
-  if (!match) {
-    return url;
-  }
-
-  const [, , path] = match;
-  return `${IPFS_GATEWAY}/${path?.replace(/^\/+/, "")}`;
+function decentralizedMediaToHttp(url: string): string {
+  return (
+    normalizeDecentralizedMediaUrl(url, publicEnv.MEDIA_RESOLVER_ENDPOINT) ??
+    url
+  );
 }
 
 function absolutizeRelativeUrl(candidate: string, base: string): string {
@@ -244,7 +230,7 @@ function normalizeImageUrl(candidate: unknown, base: string): string | null {
   }
 
   if (trimmed.startsWith("ipfs://")) {
-    return ipfsToHttp(trimmed);
+    return decentralizedMediaToHttp(trimmed);
   }
 
   if (/^https?:\/\//i.test(trimmed)) {
@@ -379,7 +365,7 @@ async function tryExtractImageFromDescription(
     }
 
     if (trimmed.startsWith("ipfs://")) {
-      return ipfsToHttp(trimmed);
+      return decentralizedMediaToHttp(trimmed);
     }
 
     if (/\.(json|js)(?:\?.*)?$/i.test(trimmed) || /json/i.test(trimmed)) {
@@ -400,7 +386,7 @@ async function tryExtractImageFromDescription(
 
         if (candidate) {
           const normalized = candidate.startsWith("ipfs://")
-            ? ipfsToHttp(candidate)
+            ? decentralizedMediaToHttp(candidate)
             : absolutizeRelativeUrl(candidate, trimmed);
           return normalized;
         }
@@ -415,7 +401,7 @@ async function tryExtractImageFromDescription(
   if (/ipfs:\/\//i.test(description)) {
     const ipfsMatch = description.match(/ipfs:\/\/[^\s"'<>]+/i);
     if (ipfsMatch) {
-      return ipfsToHttp(ipfsMatch[0]);
+      return decentralizedMediaToHttp(ipfsMatch[0]);
     }
   }
 

--- a/app/api/pepe/resolve/route.ts
+++ b/app/api/pepe/resolve/route.ts
@@ -364,10 +364,6 @@ async function tryExtractImageFromDescription(
       continue;
     }
 
-    if (trimmed.startsWith("ipfs://")) {
-      return decentralizedMediaToHttp(trimmed);
-    }
-
     if (/\.(json|js)(?:\?.*)?$/i.test(trimmed) || /json/i.test(trimmed)) {
       const metadata = await fetchJson<Record<string, unknown>>(trimmed, 2500);
       if (metadata) {

--- a/components/about/AboutDataDecentral.tsx
+++ b/components/about/AboutDataDecentral.tsx
@@ -6,9 +6,7 @@ export default function AboutDataDecentral() {
     <Container>
       <Row>
         <Col>
-          <h1>
-            Data Decentralization
-          </h1>
+          <h1>Data Decentralization</h1>
         </Col>
       </Row>
       <Row className="pt-3 pb-3">
@@ -52,9 +50,10 @@ export default function AboutDataDecentral() {
             <li>
               6529 Team addresses. A record of these can be found on Arweave{" "}
               <Link
-                href={`https://arweave.net/fy83ffOGqR9cR2zooI7u9JxsG0oEWVJxH3B-bNxXKJg`}
+                href={`https://media.6529.io/arweave/fy83ffOGqR9cR2zooI7u9JxsG0oEWVJxH3B-bNxXKJg`}
                 target="_blank"
-                rel="noopener noreferrer">
+                rel="noopener noreferrer"
+              >
                 here
               </Link>
               . We will move this list 100% on-chain in the coming weeks.

--- a/components/about/AboutFAQ.tsx
+++ b/components/about/AboutFAQ.tsx
@@ -395,7 +395,7 @@ export default function AboutFAQ() {
             <p>
               The book is CC0 and you can download it here:{" "}
               <a
-                href="https://arweave.net/HRGsv6tXpKx-yUPD8j7zi8Vz8-ILZr378oNDYemST0E"
+                href="https://media.6529.io/arweave/HRGsv6tXpKx-yUPD8j7zi8Vz8-ILZr378oNDYemST0E"
                 target="_blank"
                 rel="noreferrer"
               >

--- a/components/community-downloads/CommunityDownloadsTeam.tsx
+++ b/components/community-downloads/CommunityDownloadsTeam.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 import { useSetTitle } from "@/contexts/TitleContext";
 import {
@@ -18,15 +18,15 @@ export default function CommunityDownloadsTeam() {
   const downloads: TeamDownload[] = [
     {
       created_at: "2023-05-10 11:44:03",
-      url: "https://arweave.net/lRR1YuRwnThzKVXNIuDCbA-LfyfyZYU6sezNtF9-Dn0",
+      url: "https://media.6529.io/arweave/lRR1YuRwnThzKVXNIuDCbA-LfyfyZYU6sezNtF9-Dn0",
     },
     {
       created_at: "2023-03-02 10:42:49",
-      url: "https://arweave.net/iDa7cvYLdS95XNnISou4h3Zzvt0qu6w7BUXJiGrCyVE",
+      url: "https://media.6529.io/arweave/iDa7cvYLdS95XNnISou4h3Zzvt0qu6w7BUXJiGrCyVE",
     },
     {
       created_at: "2024-04-11 16:02:56",
-      url: "https://arweave.net/Q1asRH7r36XAbAghCL_PbI0eZufThkMMnhYiD55KYc4",
+      url: "https://media.6529.io/arweave/Q1asRH7r36XAbAghCL_PbI0eZufThkMMnhYiD55KYc4",
     },
   ];
 

--- a/components/drop-forge/craft/DropForgeCraftClaimPageClient.tsx
+++ b/components/drop-forge/craft/DropForgeCraftClaimPageClient.tsx
@@ -963,11 +963,11 @@ function AnimationSection({
       setLinkError("Enter a link");
       return;
     }
-    const url = raw.startsWith("http") ? raw : `https://${raw}`;
+    const url = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw) ? raw : `https://${raw}`;
     const canonical = canonicalizeInteractiveMediaUrl(url);
     if (!canonical) {
       setLinkError(
-        "Link must be a valid IPFS or Arweave URL (e.g. https://ipfs.io/ipfs/… or https://arweave.net/…)"
+        "Link must be a valid IPFS or Arweave URL (e.g. ipfs://..., ar://..., or https://media.6529.io/...)"
       );
       return;
     }
@@ -1067,7 +1067,7 @@ function AnimationSection({
           setLinkInput(e.target.value);
           setLinkError(null);
         }}
-        placeholder="https://ipfs.io/ipfs/… or https://arweave.net/…"
+        placeholder="ipfs://... or ar://..."
         className="tw-w-full tw-rounded-lg tw-border tw-border-iron-700 tw-bg-iron-900 tw-px-3 tw-py-2 tw-text-iron-50 placeholder:tw-text-iron-500 focus:tw-border-iron-600 focus:tw-outline-none"
       />
       {linkError && (

--- a/components/drop-forge/drop-forge-storage-location.helpers.ts
+++ b/components/drop-forge/drop-forge-storage-location.helpers.ts
@@ -11,7 +11,7 @@ interface DropForgeStorageLocationInfo {
   readonly rawValue: string;
   readonly displayValue: string;
   readonly displayTitle: string;
-  readonly provider: DropForgeStorageProvider;
+  readonly provider: DropForgeStorageProvider | null;
   readonly providerBadgeLabel: string | null;
   readonly openUrl: string | null;
   readonly copyValue: string | null;
@@ -50,6 +50,18 @@ const buildLocationInfo = (
     copyValue: openUrl,
   };
 };
+
+const buildRawLocationInfo = (
+  rawValue: string
+): DropForgeStorageLocationInfo => ({
+  rawValue,
+  displayValue: rawValue,
+  displayTitle: rawValue,
+  provider: null,
+  providerBadgeLabel: null,
+  openUrl: null,
+  copyValue: rawValue,
+});
 
 export function getDropForgeStorageLocationInfo(
   location: string | null | undefined
@@ -93,9 +105,5 @@ export function getDropForgeStorageLocationInfo(
     };
   }
 
-  return buildLocationInfo(trimmedValue, {
-    protocol: "arweave",
-    id: trimmedValue,
-    path: "",
-  });
+  return buildRawLocationInfo(trimmedValue);
 }

--- a/components/drop-forge/drop-forge-storage-location.helpers.ts
+++ b/components/drop-forge/drop-forge-storage-location.helpers.ts
@@ -1,5 +1,9 @@
-import { resolveIpfsUrlSync } from "@/components/ipfs/IPFSContext";
-import { stripArweaveGatewayUrlPrefix } from "@/lib/media/arweave-gateways";
+import { publicEnv } from "@/config/env";
+import {
+  DecentralizedMediaRef,
+  parseDecentralizedMediaRef,
+  to6529ResolverUrl,
+} from "@/lib/media/decentralized-media";
 
 type DropForgeStorageProvider = "arweave" | "ipfs";
 
@@ -13,85 +17,35 @@ interface DropForgeStorageLocationInfo {
   readonly copyValue: string | null;
 }
 
-const IPFS_PROTOCOL_PREFIX = "ipfs://";
-const ARWEAVE_PROTOCOL_PREFIX = "ar://";
 const IPFS_CIDV0_PATTERN = /^Qm[1-9A-HJ-NP-Za-km-z]{44}$/;
 const IPFS_CIDV1_PATTERN = /^b[a-z2-7]{20,}$/;
+const ARWEAVE_TX_ID_PATTERN = /^[a-zA-Z0-9_-]{43,87}$/;
 
 const isHttpUrl = (value: string): boolean => /^https?:\/\//i.test(value);
 const isBareIpfsCid = (value: string): boolean =>
   IPFS_CIDV0_PATTERN.test(value) || IPFS_CIDV1_PATTERN.test(value);
+const isBareArweaveTxId = (value: string): boolean =>
+  ARWEAVE_TX_ID_PATTERN.test(value);
 
 const toRootIdentifier = (value: string): string => {
   const [identifier] = value.split("/");
   return identifier ?? value;
 };
 
-const normalizeIpfsPath = (value: string): string => {
-  let normalized = value.trim();
-
-  if (normalized.toLowerCase().startsWith(IPFS_PROTOCOL_PREFIX)) {
-    normalized = normalized.slice(IPFS_PROTOCOL_PREFIX.length);
-  }
-
-  normalized = normalized.replace(/^ipfs\/+/i, "");
-  normalized = normalized.replace(/^\/+/, "");
-
-  return normalized;
-};
-
-const getIpfsPathFromUrl = (value: string): string | null => {
-  try {
-    const parsedUrl = new URL(value);
-    const pathSegments = parsedUrl.pathname.split("/").filter(Boolean);
-
-    if (pathSegments[0]?.toLowerCase() !== "ipfs" || !pathSegments[1]) {
-      return null;
-    }
-
-    return pathSegments.slice(1).join("/");
-  } catch {
-    return null;
-  }
-};
-
-const buildIpfsLocationInfo = (
+const buildLocationInfo = (
   rawValue: string,
-  ipfsPath: string
+  ref: DecentralizedMediaRef
 ): DropForgeStorageLocationInfo => {
-  const normalizedPath = normalizeIpfsPath(ipfsPath);
-  const displayValue = toRootIdentifier(normalizedPath);
-  const openUrl = normalizedPath
-    ? resolveIpfsUrlSync(`${IPFS_PROTOCOL_PREFIX}${normalizedPath}`)
-    : null;
+  const displayValue = toRootIdentifier(ref.id);
+  const openUrl = to6529ResolverUrl(ref, publicEnv.MEDIA_RESOLVER_ENDPOINT);
 
   return {
     rawValue,
     displayValue: displayValue || rawValue,
     displayTitle: rawValue,
-    provider: "ipfs",
-    providerBadgeLabel: "IPFS",
-    openUrl,
-    copyValue: openUrl,
-  };
-};
-
-const buildArweaveLocationInfo = (
-  rawValue: string,
-  identifier: string
-): DropForgeStorageLocationInfo => {
-  const trimmedIdentifier = identifier.trim();
-  const rootIdentifier = toRootIdentifier(trimmedIdentifier);
-  const openUrl = rootIdentifier
-    ? `https://arweave.net/${rootIdentifier}`
-    : null;
-
-  return {
-    rawValue,
-    displayValue: rootIdentifier || rawValue,
-    displayTitle: rawValue,
-    provider: "arweave",
-    providerBadgeLabel: null,
+    provider: ref.protocol === "arweave" ? "arweave" : "ipfs",
+    providerBadgeLabel:
+      ref.protocol === "arweave" ? null : ref.protocol.toUpperCase(),
     openUrl,
     copyValue: openUrl,
   };
@@ -106,28 +60,28 @@ export function getDropForgeStorageLocationInfo(
     return null;
   }
 
-  if (trimmedValue.toLowerCase().startsWith(IPFS_PROTOCOL_PREFIX)) {
-    return buildIpfsLocationInfo(trimmedValue, trimmedValue);
+  const parsed = parseDecentralizedMediaRef(trimmedValue);
+  if (parsed) {
+    return buildLocationInfo(trimmedValue, parsed);
   }
 
-  if (trimmedValue.toLowerCase().startsWith(ARWEAVE_PROTOCOL_PREFIX)) {
-    return buildArweaveLocationInfo(
-      trimmedValue,
-      trimmedValue.slice(ARWEAVE_PROTOCOL_PREFIX.length)
-    );
+  if (isBareIpfsCid(trimmedValue)) {
+    return buildLocationInfo(trimmedValue, {
+      protocol: "ipfs",
+      id: trimmedValue,
+      path: "",
+    });
   }
 
-  const ipfsPath = getIpfsPathFromUrl(trimmedValue);
-  if (ipfsPath) {
-    return buildIpfsLocationInfo(trimmedValue, ipfsPath);
+  if (isBareArweaveTxId(trimmedValue)) {
+    return buildLocationInfo(trimmedValue, {
+      protocol: "arweave",
+      id: trimmedValue,
+      path: "",
+    });
   }
 
   if (isHttpUrl(trimmedValue)) {
-    const strippedArweavePath = stripArweaveGatewayUrlPrefix(trimmedValue);
-    if (strippedArweavePath !== trimmedValue) {
-      return buildArweaveLocationInfo(trimmedValue, strippedArweavePath);
-    }
-
     return {
       rawValue: trimmedValue,
       displayValue: trimmedValue,
@@ -139,9 +93,9 @@ export function getDropForgeStorageLocationInfo(
     };
   }
 
-  if (isBareIpfsCid(trimmedValue)) {
-    return buildIpfsLocationInfo(trimmedValue, trimmedValue);
-  }
-
-  return buildArweaveLocationInfo(trimmedValue, trimmedValue);
+  return buildLocationInfo(trimmedValue, {
+    protocol: "arweave",
+    id: trimmedValue,
+    path: "",
+  });
 }

--- a/components/drop-forge/drop-forge-storage-location.helpers.ts
+++ b/components/drop-forge/drop-forge-storage-location.helpers.ts
@@ -77,6 +77,8 @@ export function getDropForgeStorageLocationInfo(
     return buildLocationInfo(trimmedValue, parsed);
   }
 
+  // CIDv1 base32 strings also satisfy the broad Arweave tx-id shape below.
+  // Keep the bare IPFS CID check first so bare CIDs stay IPFS locations.
   if (isBareIpfsCid(trimmedValue)) {
     return buildLocationInfo(trimmedValue, {
       protocol: "ipfs",

--- a/components/drops/view/item/content/attachments/DropAttachmentDisplay.tsx
+++ b/components/drops/view/item/content/attachments/DropAttachmentDisplay.tsx
@@ -4,6 +4,10 @@ import { getFileInfoFromUrl } from "@/helpers/file.helpers";
 import { shareFetchedBlobInNativeApp } from "@/helpers/capacitorBlobDownload.helpers";
 import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
 import { resolveIpfsUrlSync } from "@/components/ipfs/IPFSContext";
+import {
+  parseDecentralizedMediaRef,
+  toNativeUri,
+} from "@/lib/media/decentralized-media";
 import CommonDropdownItemsDefaultWrapper from "@/components/utils/select/dropdown/CommonDropdownItemsDefaultWrapper";
 import JsonPreview from "@/components/drops/view/item/content/attachments/JsonPreview";
 import { faShieldHalved } from "@fortawesome/free-solid-svg-icons";
@@ -52,10 +56,13 @@ function getAttachmentMetadataUrl(rawUrl: string): string | null {
     return null;
   }
 
-  if (trimmedUrl.toLowerCase().startsWith("ipfs://")) {
-    const withoutProtocol = trimmedUrl.slice("ipfs://".length);
-    const rootCid = withoutProtocol.split(/[/?#]/)[0];
-    return rootCid ? `ipfs://${rootCid}/metadata.json` : null;
+  const parsedMedia = parseDecentralizedMediaRef(trimmedUrl);
+  if (parsedMedia?.protocol === "ipfs") {
+    return toNativeUri({
+      protocol: "ipfs",
+      id: parsedMedia.id,
+      path: "metadata.json",
+    });
   }
 
   try {

--- a/components/drops/view/item/content/media/UnsupportedMediaLink.tsx
+++ b/components/drops/view/item/content/media/UnsupportedMediaLink.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { publicEnv } from "@/config/env";
 import { getFileInfoFromUrl } from "@/helpers/file.helpers";
+import { normalizeDecentralizedMediaUrl } from "@/lib/media/decentralized-media";
 import {
   ArrowTopRightOnSquareIcon,
   ExclamationTriangleIcon,
@@ -12,7 +14,12 @@ const CONFIRM_RESET_MS = 2500;
 
 function getSafeUrl(rawUrl: string): string | null {
   try {
-    const parsed = new URL(rawUrl);
+    const resolvedUrl =
+      normalizeDecentralizedMediaUrl(
+        rawUrl,
+        publicEnv.MEDIA_RESOLVER_ENDPOINT
+      ) ?? rawUrl;
+    const parsed = new URL(resolvedUrl);
     if (SAFE_URL_PROTOCOLS.has(parsed.protocol)) {
       return parsed.toString();
     }

--- a/components/ipfs/IPFSContext.tsx
+++ b/components/ipfs/IPFSContext.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { publicEnv } from "@/config/env";
-import { getConfiguredIpfsGatewayHost } from "@/lib/media/ipfs-gateways";
+import {
+  normalizeDecentralizedMediaUrl,
+  parseDecentralizedMediaRef,
+  to6529ResolverUrl,
+} from "@/lib/media/decentralized-media";
 import React, {
   createContext,
   useContext,
@@ -19,26 +23,15 @@ const IpfsContext = createContext<IpfsContextType | undefined>(undefined);
 
 const readIpfsConfig = () => {
   const apiEndpoint = publicEnv.IPFS_API_ENDPOINT;
-  const gatewayEndpoint = publicEnv.IPFS_GATEWAY_ENDPOINT;
 
-  if (!apiEndpoint || !gatewayEndpoint) {
-    throw new Error("Missing IPFS_API_ENDPOINT or IPFS_GATEWAY_ENDPOINT");
+  if (!apiEndpoint) {
+    throw new Error("Missing IPFS_API_ENDPOINT");
   }
 
-  let trimmed = gatewayEndpoint;
-  while (trimmed.endsWith("/")) {
-    trimmed = trimmed.slice(0, -1);
-  }
-
-  const gatewayBase = trimmed.endsWith("/ipfs")
-    ? trimmed.slice(0, -5)
-    : trimmed;
   const mfsPath = publicEnv.IPFS_MFS_PATH;
 
   return {
     apiEndpoint,
-    gatewayEndpoint: trimmed,
-    gatewayBase,
     mfsPath,
   } as const;
 };
@@ -80,50 +73,14 @@ export const useIpfsService = (): IpfsService => {
   return context.ipfsService;
 };
 
-function joinUrlPaths(basePathname: string, pathName: string): string {
-  const normalizedBase = basePathname.endsWith("/")
-    ? basePathname.slice(0, -1)
-    : basePathname;
-  const normalizedPath = pathName.startsWith("/") ? pathName : `/${pathName}`;
-
-  if (!normalizedBase) {
-    return normalizedPath;
-  }
-
-  return `${normalizedBase}${normalizedPath}`;
-}
-
 export const resolveIpfsUrlSync = (url: string) => {
   try {
-    const { gatewayBase } = readIpfsConfig();
-    if (url.startsWith("ipfs://")) {
-      return `${gatewayBase}/ipfs/${url.slice(7)}`;
-    }
-
-    const configuredHost = getConfiguredIpfsGatewayHost();
-    if (!configuredHost) {
+    const parsed = parseDecentralizedMediaRef(url);
+    if (!parsed) {
       return url;
     }
 
-    const configuredGatewayBase = new URL(gatewayBase);
-    const parsedUrl = new URL(url);
-    const normalizedHost = parsedUrl.hostname.toLowerCase();
-    if (normalizedHost !== "ipfs.io" && normalizedHost !== "www.ipfs.io") {
-      return url;
-    }
-
-    if (!parsedUrl.pathname.startsWith("/ipfs/")) {
-      return url;
-    }
-
-    parsedUrl.protocol = configuredGatewayBase.protocol;
-    parsedUrl.hostname = configuredGatewayBase.hostname;
-    parsedUrl.port = configuredGatewayBase.port;
-    parsedUrl.pathname = joinUrlPaths(
-      configuredGatewayBase.pathname,
-      parsedUrl.pathname
-    );
-    return parsedUrl.toString();
+    return to6529ResolverUrl(parsed, publicEnv.MEDIA_RESOLVER_ENDPOINT);
   } catch (error) {
     console.error("Error resolving IPFS URL", error);
     return url;
@@ -133,3 +90,6 @@ export const resolveIpfsUrlSync = (url: string) => {
 export const resolveIpfsUrl = (url: string) => {
   return resolveIpfsUrlSync(url);
 };
+
+export const resolveDecentralizedMediaUrlSync = (url: string) =>
+  normalizeDecentralizedMediaUrl(url, publicEnv.MEDIA_RESOLVER_ENDPOINT) ?? url;

--- a/components/nft-image/utils/gateway-fallback.ts
+++ b/components/nft-image/utils/gateway-fallback.ts
@@ -1,92 +1,12 @@
 import type React from "react";
-import { resolveIpfsUrlSync } from "@/components/ipfs/IPFSContext";
+import { publicEnv } from "@/config/env";
 import {
-  ARWEAVE_FALLBACK_HOSTS,
-  canonicalizeArweaveGatewayHostname,
-  isArweaveGatewayRuntimeHost,
-} from "@/lib/media/arweave-gateways";
-import { getConfiguredIpfsGatewayHost } from "@/lib/media/ipfs-gateways";
-import { parseIpfsUrl } from "@/helpers/Helpers";
-
-const DEFAULT_IPFS_GATEWAY_HOSTS = new Set([
-  "ipfs.io",
-  "www.ipfs.io",
-  "cf-ipfs.com",
-]);
+  getDecentralizedMediaFetchUrls,
+  parseDecentralizedMediaRef,
+} from "@/lib/media/decentralized-media";
 
 function dedupe(list: readonly string[]): string[] {
   return Array.from(new Set(list));
-}
-
-function safeParseUrl(url: string): URL | null {
-  try {
-    return new URL(url);
-  } catch {
-    return null;
-  }
-}
-
-function normalizeHost(hostname: string): string {
-  return canonicalizeArweaveGatewayHostname(hostname);
-}
-
-function isArweaveGatewayHost(hostname: string): boolean {
-  return isArweaveGatewayRuntimeHost(hostname);
-}
-
-function isArweaveUrl(url: string): boolean {
-  const u = safeParseUrl(url);
-  return !!u && isArweaveGatewayHost(u.hostname);
-}
-
-function isIpfsProtocolUrl(url: string): boolean {
-  return url.trim().toLowerCase().startsWith("ipfs://");
-}
-
-function isKnownIpfsGatewayHost(hostname: string): boolean {
-  const normalizedHostname = canonicalizeArweaveGatewayHostname(hostname);
-  return (
-    DEFAULT_IPFS_GATEWAY_HOSTS.has(normalizedHostname) ||
-    normalizedHostname === getConfiguredIpfsGatewayHost()
-  );
-}
-
-function getIpfsProtocolUrlFromGatewayUrl(url: string): string | null {
-  const parsedUrl = safeParseUrl(url);
-  if (!parsedUrl || !isKnownIpfsGatewayHost(parsedUrl.hostname)) {
-    return null;
-  }
-
-  const pathMatch = /^\/ipfs\/(.+)$/.exec(parsedUrl.pathname);
-  if (!pathMatch) {
-    return null;
-  }
-
-  const identifierPath = pathMatch[1];
-  if (!identifierPath) {
-    return null;
-  }
-
-  return `ipfs://${identifierPath}${parsedUrl.search}${parsedUrl.hash}`;
-}
-
-function getIpfsFallbackUrls(url: string): string[] {
-  const primaryUrl = resolveIpfsUrlSync(url);
-  const fallbackUrl = parseIpfsUrl(url);
-
-  return dedupe([primaryUrl, fallbackUrl].filter(Boolean));
-}
-
-function buildUrlWithGateway(
-  originalUrl: string,
-  gatewayHost: string
-): string | null {
-  const u = safeParseUrl(originalUrl);
-  if (!u) return null;
-
-  u.hostname = gatewayHost;
-  u.host = gatewayHost + (u.port ? `:${u.port}` : "");
-  return u.toString();
 }
 
 type MediaErrorEvent = React.SyntheticEvent<
@@ -97,32 +17,29 @@ type MediaErrorEvent = React.SyntheticEvent<
   Event
 >;
 
-const DS_ORIGINAL = "arweaveOriginalSrc";
-const DS_LAST_HOST = "arweaveLastGatewayHost";
+const DS_ORIGINAL = "decentralizedMediaOriginalSrc";
+const DS_TRIED = "decentralizedMediaTriedSrcs";
 
-function classifyGatewayAssetUrl(
-  url: string
-):
+function classifyGatewayAssetUrl(url: string):
   | { kind: "empty" }
-  | { kind: "ipfs"; sourceUrl: string }
-  | { kind: "arweave"; sourceUrl: string }
+  | {
+      kind: "decentralized";
+      sourceUrl: string;
+      protocol: "ipfs" | "ipns" | "arweave";
+    }
   | { kind: "other"; sourceUrl: string } {
   const trimmed = url.trim();
   if (!trimmed) {
     return { kind: "empty" };
   }
 
-  if (isIpfsProtocolUrl(trimmed)) {
-    return { kind: "ipfs", sourceUrl: trimmed };
-  }
-
-  const ipfsProtocolUrl = getIpfsProtocolUrlFromGatewayUrl(trimmed);
-  if (ipfsProtocolUrl) {
-    return { kind: "ipfs", sourceUrl: ipfsProtocolUrl };
-  }
-
-  if (isArweaveUrl(trimmed)) {
-    return { kind: "arweave", sourceUrl: trimmed };
+  const parsed = parseDecentralizedMediaRef(trimmed);
+  if (parsed) {
+    return {
+      kind: "decentralized",
+      protocol: parsed.protocol,
+      sourceUrl: trimmed,
+    };
   }
 
   return { kind: "other", sourceUrl: trimmed };
@@ -134,39 +51,27 @@ export function getMediaGatewayFallbackUrls(url: string): string[] {
     return [];
   }
 
-  if (assetUrl.kind === "ipfs") {
-    return getIpfsFallbackUrls(assetUrl.sourceUrl);
-  }
-
   if (assetUrl.kind === "other") {
     return [assetUrl.sourceUrl];
   }
 
-  return getTryList(assetUrl.sourceUrl, assetUrl.sourceUrl);
+  return getDecentralizedMediaFetchUrls(assetUrl.sourceUrl, {
+    includeExternalFallbacks: true,
+    resolverEndpoint: publicEnv.MEDIA_RESOLVER_ENDPOINT,
+  });
 }
 
 export function shouldUseIframeFallbackTimeout(url: string): boolean {
-  return classifyGatewayAssetUrl(url).kind === "arweave";
+  const assetUrl = classifyGatewayAssetUrl(url);
+  return assetUrl.kind === "decentralized" && assetUrl.protocol === "arweave";
 }
 
-function getTryList(currentSrc: string, originalSrc: string): string[] {
-  const current = safeParseUrl(currentSrc);
-  const orig = safeParseUrl(originalSrc);
+function readTriedUrls(target: HTMLElement): string[] {
+  return target.dataset[DS_TRIED]?.split("|").filter(Boolean) ?? [];
+}
 
-  // Always try the exact originalSrc first.
-  const base: string[] = [originalSrc];
-
-  // If we can parse the host, skip it in fallbacks to avoid dumb retries.
-  const currentHost = current ? normalizeHost(current.hostname) : null;
-  const origHost = orig ? normalizeHost(orig.hostname) : null;
-
-  // Build gateway variants from originalSrc (preserves path/query exactly).
-  const variants = ARWEAVE_FALLBACK_HOSTS.filter((h) => h !== origHost) // original already first in base
-    .filter((h) => h !== currentHost) // skip current host too
-    .map((h) => buildUrlWithGateway(originalSrc, h))
-    .filter((u): u is string => !!u);
-
-  return dedupe([...base, ...variants]);
+function writeTriedUrls(target: HTMLElement, urls: readonly string[]): void {
+  target.dataset[DS_TRIED] = dedupe(urls).join("|");
 }
 
 export function withArweaveFallback(
@@ -176,64 +81,37 @@ export function withArweaveFallback(
     const target = event.currentTarget;
     const currentSrc = target.src;
 
-    if (!currentSrc || !isArweaveUrl(currentSrc)) {
+    if (!currentSrc) {
       onError?.(event);
       return;
     }
 
-    // Establish the "original" src once per media load.
-    // Only reset it if the app code changed `src` to a *non-gateway-swapped* URL.
     const storedOriginal = target.dataset[DS_ORIGINAL];
     const originalSrc = storedOriginal ?? currentSrc;
+    const original = classifyGatewayAssetUrl(originalSrc);
+
+    if (original.kind !== "decentralized" || original.protocol !== "arweave") {
+      onError?.(event);
+      return;
+    }
 
     if (!storedOriginal) {
       target.dataset[DS_ORIGINAL] = originalSrc;
     }
 
-    const tryList = getTryList(currentSrc, originalSrc);
-
-    // Track what we last tried so we can advance deterministically.
-    const lastHost = target.dataset[DS_LAST_HOST];
-    const currentHost = (() => {
-      const u = safeParseUrl(currentSrc);
-      return u ? normalizeHost(u.hostname) : null;
-    })();
-
-    // Find next URL to try:
-    // - If we have lastHost, advance from that in the tryList.
-    // - Otherwise, advance from currentSrc.
-    let nextUrl: string | null = null;
-
-    // Prefer stepping from the exact currentSrc position if present
-    const curIdx = tryList.indexOf(currentSrc);
-    if (curIdx >= 0 && curIdx + 1 < tryList.length) {
-      nextUrl = tryList[curIdx + 1] ?? null;
-    } else if (lastHost) {
-      // Fallback: step based on host
-      const lastIdx = tryList.findIndex((u) => {
-        const p = safeParseUrl(u);
-        return p ? normalizeHost(p.hostname) === lastHost : false;
-      });
-      if (lastIdx >= 0 && lastIdx + 1 < tryList.length) {
-        nextUrl = tryList[lastIdx + 1] ?? null;
-      }
-    } else {
-      // Final fallback: just try the second item
-      nextUrl = tryList[1] ?? null;
-    }
+    const triedUrls = dedupe([...readTriedUrls(target), currentSrc]);
+    const nextUrl =
+      getMediaGatewayFallbackUrls(original.sourceUrl).find(
+        (candidate) => !triedUrls.includes(candidate)
+      ) ?? null;
 
     if (!nextUrl) {
+      writeTriedUrls(target, triedUrls);
       onError?.(event);
       return;
     }
 
-    const nextParsed = safeParseUrl(nextUrl);
-    if (nextParsed) {
-      target.dataset[DS_LAST_HOST] = normalizeHost(nextParsed.hostname);
-    } else if (currentHost) {
-      target.dataset[DS_LAST_HOST] = currentHost;
-    }
-
+    writeTriedUrls(target, [...triedUrls, nextUrl]);
     target.src = nextUrl;
   };
 }

--- a/components/providers/IpfsImageSetup.tsx
+++ b/components/providers/IpfsImageSetup.tsx
@@ -3,7 +3,8 @@
 import { useEffect } from "react";
 import { resolveIpfsUrlSync } from "@/components/ipfs/IPFSContext";
 
-const DECENTRALIZED_URL_PATTERN = /(ipfs|ipns|ar):\/\/[^\s"'`]+/g;
+const DECENTRALIZED_URL_PATTERN = /(ipfs|ipns|ar):\/\/[^\s"'`]+/gi;
+const DECENTRALIZED_SCHEME_PATTERN = /(ipfs|ipns|ar):\/\//i;
 const ATTRIBUTES_TO_REWRITE = [
   "src",
   "srcset",
@@ -17,11 +18,7 @@ const ATTRIBUTES_SELECTOR = ATTRIBUTES_TO_REWRITE.map(
 ).join(",");
 
 const containsDecentralizedScheme = (value: string | null | undefined) =>
-  Boolean(
-    value?.includes("ipfs://") ||
-    value?.includes("ipns://") ||
-    value?.includes("ar://")
-  );
+  DECENTRALIZED_SCHEME_PATTERN.test(value ?? "");
 
 const replaceDecentralizedScheme = (value: string) =>
   value.replaceAll(DECENTRALIZED_URL_PATTERN, (match) =>

--- a/components/providers/IpfsImageSetup.tsx
+++ b/components/providers/IpfsImageSetup.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from "react";
 import { resolveIpfsUrlSync } from "@/components/ipfs/IPFSContext";
 
-const IPFS_URL_PATTERN = /ipfs:\/\/[^\s"'`]+/g;
+const DECENTRALIZED_URL_PATTERN = /(ipfs|ipns|ar):\/\/[^\s"'`]+/g;
 const ATTRIBUTES_TO_REWRITE = [
   "src",
   "srcset",
@@ -12,17 +12,28 @@ const ATTRIBUTES_TO_REWRITE = [
   "data-src",
   "data-srcset",
 ];
-const ATTRIBUTES_SELECTOR = ATTRIBUTES_TO_REWRITE.map((attr) => `[${attr}]`).join(",");
+const ATTRIBUTES_SELECTOR = ATTRIBUTES_TO_REWRITE.map(
+  (attr) => `[${attr}]`
+).join(",");
 
-const replaceIpfsScheme = (value: string) =>
-  value.replaceAll(IPFS_URL_PATTERN, (match) => resolveIpfsUrlSync(match));
+const containsDecentralizedScheme = (value: string | null | undefined) =>
+  Boolean(
+    value?.includes("ipfs://") ||
+    value?.includes("ipns://") ||
+    value?.includes("ar://")
+  );
+
+const replaceDecentralizedScheme = (value: string) =>
+  value.replaceAll(DECENTRALIZED_URL_PATTERN, (match) =>
+    resolveIpfsUrlSync(match)
+  );
 
 const rewriteAttributeValue = (value: string | null) => {
-  if (!value?.includes("ipfs://")) {
+  if (!value || !containsDecentralizedScheme(value)) {
     return value;
   }
 
-  return replaceIpfsScheme(value);
+  return replaceDecentralizedScheme(value);
 };
 
 export default function IpfsImageSetup() {
@@ -51,7 +62,7 @@ function useIpfsImageSetup() {
 
       applyToNode(node);
       for (const child of Array.from(
-        node.querySelectorAll(ATTRIBUTES_SELECTOR),
+        node.querySelectorAll(ATTRIBUTES_SELECTOR)
       )) {
         applyToNode(child);
       }
@@ -59,7 +70,7 @@ function useIpfsImageSetup() {
 
     const applyToTree = () => {
       for (const el of Array.from(
-        document.querySelectorAll(ATTRIBUTES_SELECTOR),
+        document.querySelectorAll(ATTRIBUTES_SELECTOR)
       )) {
         applyToNode(el);
       }
@@ -90,7 +101,7 @@ function useIpfsImageSetup() {
           const attrValue = target.getAttribute(attrName);
           if (
             attrValue === mutation.oldValue ||
-            !attrValue?.includes("ipfs://")
+            !containsDecentralizedScheme(attrValue)
           ) {
             continue;
           }
@@ -136,7 +147,7 @@ function useIpfsImageSetup() {
         }
 
         const attrValue = target.getAttribute(attrName);
-        return attrValue?.includes("ipfs://") ?? false;
+        return containsDecentralizedScheme(attrValue) ?? false;
       });
 
       if (relevantMutations.length === 0) {

--- a/components/the-memes/MemePageAdditionalDetails.tsx
+++ b/components/the-memes/MemePageAdditionalDetails.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import Download from "@/components/download/Download";
+import { publicEnv } from "@/config/env";
 import { buildTooltipId, TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
+import { normalizeDecentralizedMediaUrl } from "@/lib/media/decentralized-media";
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import type { ComponentType, ReactNode, SVGProps } from "react";
@@ -44,11 +46,17 @@ function getSafeUrl(
 }
 
 export function getSafeExternalUrl(url: string): string | null {
-  return getSafeUrl(url, SAFE_EXTERNAL_PROTOCOLS);
+  const resolvedUrl =
+    normalizeDecentralizedMediaUrl(url, publicEnv.MEDIA_RESOLVER_ENDPOINT) ??
+    url;
+  return getSafeUrl(resolvedUrl, SAFE_EXTERNAL_PROTOCOLS);
 }
 
 function getSafeDownloadUrl(url: string): string | null {
-  return getSafeUrl(url, SAFE_DOWNLOAD_PROTOCOLS);
+  const resolvedUrl =
+    normalizeDecentralizedMediaUrl(url, publicEnv.MEDIA_RESOLVER_ENDPOINT) ??
+    url;
+  return getSafeUrl(resolvedUrl, SAFE_DOWNLOAD_PROTOCOLS);
 }
 
 export function AdditionalDetailsSection({

--- a/components/waves/memes/submission/constants/security.ts
+++ b/components/waves/memes/submission/constants/security.ts
@@ -4,13 +4,20 @@ import {
   isArweaveGatewayRuntimeHost,
 } from "@/lib/media/arweave-gateways";
 import { getConfiguredIpfsGatewayHost } from "@/lib/media/ipfs-gateways";
+import {
+  DEFAULT_MEDIA_RESOLVER_ENDPOINT,
+  parseDecentralizedMediaRef,
+  to6529ResolverUrl,
+} from "@/lib/media/decentralized-media";
+import { publicEnv } from "@/config/env";
 
 const DEFAULT_INTERACTIVE_MEDIA_IPFS_HOSTS = ["ipfs.io", "www.ipfs.io"];
+const MEDIA_RESOLVER_HOST = "media.6529.io";
 
 const INTERACTIVE_MEDIA_IPFS_HOSTS = new Set<string>(
   [
     ...DEFAULT_INTERACTIVE_MEDIA_IPFS_HOSTS,
-    getConfiguredIpfsGatewayHost(),
+    getConfiguredIpfsGatewayHost(publicEnv.IPFS_GATEWAY_ENDPOINT),
   ].filter((value): value is string => Boolean(value))
 );
 
@@ -63,7 +70,11 @@ const getInteractiveMediaProviderForHost = (
 };
 
 export const isInteractiveMediaAllowedHost = (hostname: string): boolean =>
-  getInteractiveMediaProviderForHost(hostname) !== null;
+  canonicalizeInteractiveMediaHostname(hostname) === MEDIA_RESOLVER_HOST ||
+  getInteractiveMediaProviderForHost(hostname) !== null ||
+  parseDecentralizedMediaRef(
+    `https://${canonicalizeInteractiveMediaHostname(hostname)}`
+  ) !== null;
 
 const isValidIpfsCid = (cid: string): boolean =>
   CIDV0_PATTERN.test(cid) || CIDV1_PATTERN.test(cid);
@@ -128,6 +139,24 @@ export const isInteractiveMediaContentPathAllowed = (
   hostname: string,
   pathname: string
 ): boolean => {
+  const normalizedHostname = canonicalizeInteractiveMediaHostname(hostname);
+  const parsedMedia = parseDecentralizedMediaRef(
+    `https://${normalizedHostname}${pathname}`
+  );
+  if (parsedMedia?.protocol === "ipfs") {
+    if (!isInteractiveMediaContentIdentifier("ipfs", parsedMedia.id)) {
+      return false;
+    }
+    return isSafeIpfsNestedContentPath(parsedMedia.path || undefined);
+  }
+
+  if (parsedMedia?.protocol === "arweave") {
+    return (
+      !parsedMedia.path &&
+      isInteractiveMediaContentIdentifier("arweave", parsedMedia.id)
+    );
+  }
+
   const provider = getInteractiveMediaProviderForHost(hostname);
   if (!provider) {
     return false;
@@ -182,6 +211,20 @@ export const isInteractiveMediaContentPathAllowed = (
 };
 
 export const canonicalizeInteractiveMediaUrl = (src: string): string | null => {
+  if (/%2e|%2f|%5c/i.test(src)) {
+    return null;
+  }
+
+  if (/^(ipfs|ar):\/\//i.test(src)) {
+    const nativeRef = parseDecentralizedMediaRef(src);
+    if (
+      nativeRef &&
+      (nativeRef.protocol === "ipfs" || nativeRef.protocol === "arweave")
+    ) {
+      return to6529ResolverUrl(nativeRef, DEFAULT_MEDIA_RESOLVER_ENDPOINT);
+    }
+  }
+
   let parsedUrl: URL;
   try {
     parsedUrl = new URL(src);
@@ -237,6 +280,11 @@ export const canonicalizeInteractiveMediaUrl = (src: string): string | null => {
   parsedUrl.password = "";
   parsedUrl.hash = "";
 
+  const decentralizedRef = parseDecentralizedMediaRef(parsedUrl.toString());
+  if (decentralizedRef) {
+    return to6529ResolverUrl(decentralizedRef, DEFAULT_MEDIA_RESOLVER_ENDPOINT);
+  }
+
   return parsedUrl.toString();
 };
 
@@ -244,8 +292,8 @@ export const INTERACTIVE_MEDIA_GATEWAY_BASE_URL: Record<
   InteractiveMediaProvider,
   string
 > = {
-  ipfs: "https://ipfs.io/ipfs/",
-  arweave: "https://arweave.net/",
+  ipfs: `${DEFAULT_MEDIA_RESOLVER_ENDPOINT}/ipfs/`,
+  arweave: `${DEFAULT_MEDIA_RESOLVER_ENDPOINT}/arweave/`,
 };
 
 export const INTERACTIVE_MEDIA_ALLOWED_CONTENT_TYPES = [

--- a/components/waves/memes/submission/constants/security.ts
+++ b/components/waves/memes/submission/constants/security.ts
@@ -99,10 +99,7 @@ const getInteractiveMediaProviderForHost = (
 
 export const isInteractiveMediaAllowedHost = (hostname: string): boolean =>
   canonicalizeInteractiveMediaHostname(hostname) === MEDIA_RESOLVER_HOST ||
-  getInteractiveMediaProviderForHost(hostname) !== null ||
-  parseDecentralizedMediaRef(
-    `https://${canonicalizeInteractiveMediaHostname(hostname)}`
-  ) !== null;
+  getInteractiveMediaProviderForHost(hostname) !== null;
 
 const isValidIpfsCid = (cid: string): boolean =>
   CIDV0_PATTERN.test(cid) || CIDV1_PATTERN.test(cid);

--- a/components/waves/memes/submission/constants/security.ts
+++ b/components/waves/memes/submission/constants/security.ts
@@ -32,6 +32,23 @@ const IPFS_PATH_PATTERN = /^\/ipfs\/([^/]+)(?:\/(.*))?$/;
 const ARWEAVE_PATH_PATTERN = /^\/([^/]+)$/;
 const IPFS_HTML_PATH_PATTERN = /\.html?$/i;
 
+const getUrlSuffix = (value: string): string => {
+  const queryIndex = value.indexOf("?");
+  const hashIndex = value.indexOf("#");
+  const indexes = [queryIndex, hashIndex]
+    .filter((index) => index >= 0)
+    .sort((a, b) => a - b);
+  const suffixStart = indexes[0];
+
+  return suffixStart === undefined ? "" : value.slice(suffixStart);
+};
+
+const appendUrlSuffix = (
+  url: string,
+  search: string,
+  hash: string
+): string => `${url}${search}${hash}`;
+
 export const canonicalizeInteractiveMediaHostname = (
   hostname: string
 ): string => {
@@ -219,7 +236,10 @@ const canonicalizeNativeInteractiveMediaUrl = (
 
   const nativeRef = parseDecentralizedMediaRef(src);
   if (nativeRef?.protocol === "ipfs" || nativeRef?.protocol === "arweave") {
-    return to6529ResolverUrl(nativeRef, DEFAULT_MEDIA_RESOLVER_ENDPOINT);
+    return `${to6529ResolverUrl(
+      nativeRef,
+      DEFAULT_MEDIA_RESOLVER_ENDPOINT
+    )}${getUrlSuffix(src)}`;
   }
 
   return null;
@@ -271,7 +291,11 @@ const canonicalizeParsedInteractiveMediaUrl = (
 ): string | null => {
   const decentralizedRef = parseDecentralizedMediaRef(parsedUrl.toString());
   if (decentralizedRef) {
-    return to6529ResolverUrl(decentralizedRef, DEFAULT_MEDIA_RESOLVER_ENDPOINT);
+    return appendUrlSuffix(
+      to6529ResolverUrl(decentralizedRef, DEFAULT_MEDIA_RESOLVER_ENDPOINT),
+      parsedUrl.search,
+      parsedUrl.hash
+    );
   }
 
   return parsedUrl.toString();
@@ -289,10 +313,6 @@ export const canonicalizeInteractiveMediaUrl = (src: string): string | null => {
   if (!parsedUrl) return null;
 
   if (parsedUrl.username || parsedUrl.password) {
-    return null;
-  }
-
-  if (parsedUrl.hash) {
     return null;
   }
 
@@ -315,7 +335,6 @@ export const canonicalizeInteractiveMediaUrl = (src: string): string | null => {
 
   parsedUrl.username = "";
   parsedUrl.password = "";
-  parsedUrl.hash = "";
 
   return canonicalizeParsedInteractiveMediaUrl(parsedUrl);
 };

--- a/components/waves/memes/submission/constants/security.ts
+++ b/components/waves/memes/submission/constants/security.ts
@@ -164,6 +164,10 @@ export const isInteractiveMediaContentPathAllowed = (
   hostname: string,
   pathname: string
 ): boolean => {
+  if (hasEncodedPathEscape(pathname)) {
+    return false;
+  }
+
   const normalizedHostname = canonicalizeInteractiveMediaHostname(hostname);
   const provider = getInteractiveMediaProviderForHost(normalizedHostname);
   const isMediaResolverHost = normalizedHostname === MEDIA_RESOLVER_HOST;

--- a/components/waves/memes/submission/constants/security.ts
+++ b/components/waves/memes/submission/constants/security.ts
@@ -165,6 +165,12 @@ export const isInteractiveMediaContentPathAllowed = (
   pathname: string
 ): boolean => {
   const normalizedHostname = canonicalizeInteractiveMediaHostname(hostname);
+  const provider = getInteractiveMediaProviderForHost(normalizedHostname);
+  const isMediaResolverHost = normalizedHostname === MEDIA_RESOLVER_HOST;
+  if (!isMediaResolverHost && !provider) {
+    return false;
+  }
+
   const parsedMedia = parseDecentralizedMediaRef(
     `https://${normalizedHostname}${pathname}`
   );
@@ -182,7 +188,6 @@ export const isInteractiveMediaContentPathAllowed = (
     );
   }
 
-  const provider = getInteractiveMediaProviderForHost(hostname);
   if (!provider) {
     return false;
   }

--- a/components/waves/memes/submission/constants/security.ts
+++ b/components/waves/memes/submission/constants/security.ts
@@ -210,31 +210,83 @@ export const isInteractiveMediaContentPathAllowed = (
   return false;
 };
 
+const canonicalizeNativeInteractiveMediaUrl = (
+  src: string
+): string | null | undefined => {
+  if (!/^(ipfs|ar):\/\//i.test(src)) {
+    return undefined;
+  }
+
+  const nativeRef = parseDecentralizedMediaRef(src);
+  if (nativeRef?.protocol === "ipfs" || nativeRef?.protocol === "arweave") {
+    return to6529ResolverUrl(nativeRef, DEFAULT_MEDIA_RESOLVER_ENDPOINT);
+  }
+
+  return null;
+};
+
+const parseSecureInteractiveMediaUrl = (src: string): URL | null => {
+  try {
+    const parsedUrl = new URL(src);
+    if (parsedUrl.protocol !== "https:") {
+      return null;
+    }
+
+    return parsedUrl;
+  } catch {
+    return null;
+  }
+};
+
+const normalizeInteractiveMediaPort = (parsedUrl: URL): boolean => {
+  if (!parsedUrl.port) {
+    return true;
+  }
+
+  if (parsedUrl.port !== "443") {
+    return false;
+  }
+
+  parsedUrl.port = "";
+  return true;
+};
+
+const normalizeInteractiveMediaHostname = (parsedUrl: URL): boolean => {
+  const normalizedHostname = canonicalizeInteractiveMediaHostname(
+    parsedUrl.hostname
+  );
+  if (!normalizedHostname) {
+    return false;
+  }
+
+  if (normalizedHostname !== parsedUrl.hostname) {
+    parsedUrl.hostname = normalizedHostname;
+  }
+
+  return true;
+};
+
+const canonicalizeParsedInteractiveMediaUrl = (
+  parsedUrl: URL
+): string | null => {
+  const decentralizedRef = parseDecentralizedMediaRef(parsedUrl.toString());
+  if (decentralizedRef) {
+    return to6529ResolverUrl(decentralizedRef, DEFAULT_MEDIA_RESOLVER_ENDPOINT);
+  }
+
+  return parsedUrl.toString();
+};
+
 export const canonicalizeInteractiveMediaUrl = (src: string): string | null => {
   if (/%2e|%2f|%5c/i.test(src)) {
     return null;
   }
 
-  if (/^(ipfs|ar):\/\//i.test(src)) {
-    const nativeRef = parseDecentralizedMediaRef(src);
-    if (
-      nativeRef &&
-      (nativeRef.protocol === "ipfs" || nativeRef.protocol === "arweave")
-    ) {
-      return to6529ResolverUrl(nativeRef, DEFAULT_MEDIA_RESOLVER_ENDPOINT);
-    }
-  }
+  const nativeUrl = canonicalizeNativeInteractiveMediaUrl(src);
+  if (nativeUrl !== undefined) return nativeUrl;
 
-  let parsedUrl: URL;
-  try {
-    parsedUrl = new URL(src);
-  } catch {
-    return null;
-  }
-
-  if (parsedUrl.protocol !== "https:") {
-    return null;
-  }
+  const parsedUrl = parseSecureInteractiveMediaUrl(src);
+  if (!parsedUrl) return null;
 
   if (parsedUrl.username || parsedUrl.password) {
     return null;
@@ -244,24 +296,9 @@ export const canonicalizeInteractiveMediaUrl = (src: string): string | null => {
     return null;
   }
 
-  if (parsedUrl.port) {
-    if (parsedUrl.port === "443") {
-      parsedUrl.port = "";
-    } else {
-      return null;
-    }
-  }
+  if (!normalizeInteractiveMediaPort(parsedUrl)) return null;
 
-  const normalizedHostname = canonicalizeInteractiveMediaHostname(
-    parsedUrl.hostname
-  );
-  if (!normalizedHostname) {
-    return null;
-  }
-
-  if (normalizedHostname !== parsedUrl.hostname) {
-    parsedUrl.hostname = normalizedHostname;
-  }
+  if (!normalizeInteractiveMediaHostname(parsedUrl)) return null;
 
   if (!isInteractiveMediaAllowedHost(parsedUrl.hostname)) {
     return null;
@@ -280,12 +317,7 @@ export const canonicalizeInteractiveMediaUrl = (src: string): string | null => {
   parsedUrl.password = "";
   parsedUrl.hash = "";
 
-  const decentralizedRef = parseDecentralizedMediaRef(parsedUrl.toString());
-  if (decentralizedRef) {
-    return to6529ResolverUrl(decentralizedRef, DEFAULT_MEDIA_RESOLVER_ENDPOINT);
-  }
-
-  return parsedUrl.toString();
+  return canonicalizeParsedInteractiveMediaUrl(parsedUrl);
 };
 
 export const INTERACTIVE_MEDIA_GATEWAY_BASE_URL: Record<

--- a/components/waves/memes/submission/constants/security.ts
+++ b/components/waves/memes/submission/constants/security.ts
@@ -31,15 +31,20 @@ const ARWEAVE_TX_ID_PATTERN = /^[a-zA-Z0-9_-]{43,87}$/;
 const IPFS_PATH_PATTERN = /^\/ipfs\/([^/]+)(?:\/(.*))?$/;
 const ARWEAVE_PATH_PATTERN = /^\/([^/]+)$/;
 const IPFS_HTML_PATH_PATTERN = /\.html?$/i;
+const ENCODED_PATH_ESCAPE_PATTERN = /%(?:2e|2f|5c)/i;
 
-const getUrlSuffix = (value: string): string => {
+const getUrlSuffixStart = (value: string): number | undefined => {
   const queryIndex = value.indexOf("?");
   const hashIndex = value.indexOf("#");
   const indexes = [queryIndex, hashIndex]
     .filter((index) => index >= 0)
     .sort((a, b) => a - b);
-  const suffixStart = indexes[0];
 
+  return indexes[0];
+};
+
+const getUrlSuffix = (value: string): string => {
+  const suffixStart = getUrlSuffixStart(value);
   return suffixStart === undefined ? "" : value.slice(suffixStart);
 };
 
@@ -48,6 +53,14 @@ const appendUrlSuffix = (
   search: string,
   hash: string
 ): string => `${url}${search}${hash}`;
+
+const hasEncodedPathEscape = (value: string): boolean => {
+  const suffixStart = getUrlSuffixStart(value);
+  const pathValue =
+    suffixStart === undefined ? value : value.slice(0, suffixStart);
+
+  return ENCODED_PATH_ESCAPE_PATTERN.test(pathValue);
+};
 
 export const canonicalizeInteractiveMediaHostname = (
   hostname: string
@@ -302,7 +315,7 @@ const canonicalizeParsedInteractiveMediaUrl = (
 };
 
 export const canonicalizeInteractiveMediaUrl = (src: string): string | null => {
-  if (/%2e|%2f|%5c/i.test(src)) {
+  if (hasEncodedPathEscape(src)) {
     return null;
   }
 

--- a/components/waves/memes/submission/constants/security.ts
+++ b/components/waves/memes/submission/constants/security.ts
@@ -48,11 +48,9 @@ const getUrlSuffix = (value: string): string => {
   return suffixStart === undefined ? "" : value.slice(suffixStart);
 };
 
-const appendUrlSuffix = (
-  url: string,
-  search: string,
-  hash: string
-): string => `${url}${search}${hash}`;
+const appendUrlSuffix = (url: string, search: string, hash: string): string =>
+  // Preserve URL state for seeded generative scripts routed through the resolver.
+  `${url}${search}${hash}`;
 
 const hasEncodedPathEscape = (value: string): boolean => {
   const suffixStart = getUrlSuffixStart(value);

--- a/components/waves/memes/submission/hooks/artworkSubmissionFormState.ts
+++ b/components/waves/memes/submission/hooks/artworkSubmissionFormState.ts
@@ -113,6 +113,10 @@ const sanitizeInteractiveHash = (
     ((provider === "ipfs" && parsed.protocol === "ipfs") ||
       (provider === "arweave" && parsed.protocol === "arweave"))
   ) {
+    if (provider === "ipfs") {
+      return parsed.id;
+    }
+
     return parsed.path ? `${parsed.id}/${parsed.path}` : parsed.id;
   }
 

--- a/components/waves/memes/submission/hooks/artworkSubmissionFormState.ts
+++ b/components/waves/memes/submission/hooks/artworkSubmissionFormState.ts
@@ -1,4 +1,8 @@
 import { getInitialTraitsValues } from "@/components/waves/memes/traits/schema";
+import {
+  parseDecentralizedMediaRef,
+  toNativeUri,
+} from "@/lib/media/decentralized-media";
 import { stripArweaveGatewayUrlPrefix } from "@/lib/media/arweave-gateways";
 import type {
   InteractiveMediaMimeType,
@@ -103,6 +107,14 @@ const sanitizeInteractiveHash = (
   }
 
   let value = input.trim();
+  const parsed = parseDecentralizedMediaRef(value);
+  if (
+    parsed &&
+    ((provider === "ipfs" && parsed.protocol === "ipfs") ||
+      (provider === "arweave" && parsed.protocol === "arweave"))
+  ) {
+    return parsed.path ? `${parsed.id}/${parsed.path}` : parsed.id;
+  }
 
   if (provider === "ipfs") {
     value = value.replace(/^ipfs:\/\//i, "");
@@ -267,7 +279,11 @@ const buildExternalMediaUrls = (
   }
 
   const previewUrl = `${INTERACTIVE_MEDIA_GATEWAY_BASE_URL[provider]}${sanitizedHash}`;
-  const url = provider === "arweave" ? previewUrl : `ipfs://${sanitizedHash}`;
+  const url = toNativeUri({
+    protocol: provider === "arweave" ? "arweave" : "ipfs",
+    id: sanitizedHash,
+    path: "",
+  });
 
   return { previewUrl, url };
 };

--- a/config/env.schema.ts
+++ b/config/env.schema.ts
@@ -60,6 +60,11 @@ export const publicEnvSchema = z.object({
     .string()
     .url("IPFS_GATEWAY_ENDPOINT must be a valid URL"),
   // OPTIONAL
+  MEDIA_RESOLVER_ENDPOINT: z
+    .string()
+    .url("MEDIA_RESOLVER_ENDPOINT must be a valid URL")
+    .optional()
+    .default("https://media.6529.io"),
   IPFS_MFS_PATH: z.string().optional(),
 
   /**

--- a/config/env.schema.ts
+++ b/config/env.schema.ts
@@ -63,6 +63,9 @@ export const publicEnvSchema = z.object({
   MEDIA_RESOLVER_ENDPOINT: z
     .string()
     .url("MEDIA_RESOLVER_ENDPOINT must be a valid URL")
+    .refine((value) => new URL(value).protocol === "https:", {
+      message: "MEDIA_RESOLVER_ENDPOINT must use HTTPS",
+    })
     .optional()
     .default("https://media.6529.io"),
   IPFS_MFS_PATH: z.string().optional(),

--- a/config/nextConfig.ts
+++ b/config/nextConfig.ts
@@ -2,6 +2,8 @@ import { createSecurityHeaders } from "./securityHeaders";
 import { PublicEnv } from "./env.schema";
 import { NextConfig } from "next";
 import { ARWEAVE_GATEWAY_REMOTE_PATTERN_HOSTNAMES } from "../lib/media/arweave-gateways";
+import { getMediaResolverHostname } from "../lib/media/decentralized-media";
+import { IPFS_GATEWAY_REMOTE_PATTERN_HOSTNAMES } from "../lib/media/ipfs-gateways";
 import path from "node:path";
 
 import { fileURLToPath } from "node:url";
@@ -29,7 +31,15 @@ export function sharedConfig(
       remotePatterns: [
         { protocol: "https", hostname: "6529.io" },
         { protocol: "https", hostname: "staging.6529.io" },
+        {
+          protocol: "https",
+          hostname: getMediaResolverHostname(publicEnv.MEDIA_RESOLVER_ENDPOINT),
+        },
         ...ARWEAVE_GATEWAY_REMOTE_PATTERN_HOSTNAMES.map((hostname) => ({
+          protocol: "https" as const,
+          hostname,
+        })),
+        ...IPFS_GATEWAY_REMOTE_PATTERN_HOSTNAMES.map((hostname) => ({
           protocol: "https" as const,
           hostname,
         })),
@@ -60,6 +70,7 @@ export function sharedConfig(
           headers: createSecurityHeaders(
             publicEnv["API_ENDPOINT"],
             publicEnv["IPFS_GATEWAY_ENDPOINT"],
+              publicEnv["MEDIA_RESOLVER_ENDPOINT"],
             {
               allowInsecureLocalhostConnectSrc:
                 publicEnv.NODE_ENV === "development" ||

--- a/config/securityHeaders.ts
+++ b/config/securityHeaders.ts
@@ -1,4 +1,6 @@
 import { ARWEAVE_GATEWAY_CSP_SOURCES } from "../lib/media/arweave-gateways";
+import { getMediaResolverSource } from "../lib/media/decentralized-media";
+import { IPFS_GATEWAY_CSP_SOURCES } from "../lib/media/ipfs-gateways";
 
 function isLocalhostHostname(hostname: string): boolean {
   return (
@@ -63,6 +65,7 @@ interface SecurityHeaderOptions {
 export function createSecurityHeaders(
   apiEndpoint: string | undefined = "",
   ipfsGatewayEndpoint: string | undefined = "",
+  mediaResolverEndpoint: string | undefined = "",
   options: SecurityHeaderOptions = {}
 ) {
   const arweaveGatewaySources = ARWEAVE_GATEWAY_CSP_SOURCES;
@@ -74,6 +77,8 @@ export function createSecurityHeaders(
     options.webSocketEndpoint,
     options.allowInsecureLocalhostConnectSrc
   );
+  const ipfsGatewaySources = IPFS_GATEWAY_CSP_SOURCES.join(" ");
+  const mediaResolverSource = getMediaResolverSource(mediaResolverEndpoint);
   const configuredIpfsGatewaySource =
     getConfiguredIpfsGatewaySource(ipfsGatewayEndpoint);
   const connectSrc = [
@@ -93,7 +98,9 @@ export function createSecurityHeaders(
     "https://www.googletagmanager.com",
     "https://*.google-analytics.com",
     "https://cloudflare-eth.com/",
+    mediaResolverSource,
     ...arweaveGatewaySources,
+    ipfsGatewaySources,
     "https://rpc.walletconnect.com/v1/",
     "https://sts.us-east-1.amazonaws.com",
     "https://sts.us-west-2.amazonaws.com",
@@ -114,20 +121,23 @@ export function createSecurityHeaders(
     "blob:",
     "https://*.cloudfront.net",
     "https://videos.files.wordpress.com",
+    mediaResolverSource,
     ...arweaveGatewaySources,
+    ipfsGatewaySources,
     configuredIpfsGatewaySource,
-    "https://cf-ipfs.com/ipfs/*",
     "https://*.twimg.com",
     "https://artblocks.io",
     "https://*.artblocks.io",
   ];
   const frameSrc = [
     "'self'",
+    mediaResolverSource,
     "https://ipfs.io",
     "https://ipfs.io/ipfs/",
     configuredIpfsGatewaySource,
     "https://cf-ipfs.com",
     "https://cf-ipfs.com/ipfs/",
+    ipfsGatewaySources,
     "https://media.generator.seize.io",
     "https://media.generator.6529.io",
     "https://generator.seize.io",

--- a/helpers/Helpers.ts
+++ b/helpers/Helpers.ts
@@ -9,6 +9,7 @@ import {
 } from "@/components/user/layout/userTabs.config";
 import { publicEnv } from "@/config/env";
 import {
+  canonicalizeGatewayHostname,
   normalizeDecentralizedMediaUrl,
   parseDecentralizedMediaRef,
   toExternalFallbackUrls,
@@ -343,7 +344,16 @@ export function parseIpfsUrlToGateway(url: string) {
   }
   const fallbacks = toExternalFallbackUrls(parsed);
   return (
-    fallbacks.find((fallback) => fallback.includes("://cf-ipfs.com/")) ??
+    fallbacks.find((fallback) => {
+      try {
+        return (
+          canonicalizeGatewayHostname(new URL(fallback).hostname) ===
+          "cf-ipfs.com"
+        );
+      } catch {
+        return false;
+      }
+    }) ??
     fallbacks[0] ??
     parseIpfsUrl(url)
   );

--- a/helpers/Helpers.ts
+++ b/helpers/Helpers.ts
@@ -9,6 +9,11 @@ import {
 } from "@/components/user/layout/userTabs.config";
 import { publicEnv } from "@/config/env";
 import {
+  normalizeDecentralizedMediaUrl,
+  parseDecentralizedMediaRef,
+  toExternalFallbackUrls,
+} from "@/lib/media/decentralized-media";
+import {
   GRADIENT_CONTRACT,
   MEMELAB_CONTRACT,
   MEMES_CONTRACT,
@@ -322,20 +327,26 @@ export function parseIpfsUrl(url: string) {
   if (!url) {
     return url;
   }
-  if (url.startsWith("ipfs")) {
-    return `https://ipfs.io/ipfs/${url.split("://")[1]}`;
-  }
-  return url;
+  return (
+    normalizeDecentralizedMediaUrl(url, publicEnv.MEDIA_RESOLVER_ENDPOINT) ??
+    url
+  );
 }
 
 export function parseIpfsUrlToGateway(url: string) {
   if (!url) {
     return url;
   }
-  if (url.startsWith("ipfs")) {
-    return `https://cf-ipfs.com/ipfs/${url.split("://")[1]}`;
+  const parsed = parseDecentralizedMediaRef(url);
+  if (!parsed) {
+    return url;
   }
-  return url;
+  const fallbacks = toExternalFallbackUrls(parsed);
+  return (
+    fallbacks.find((fallback) => fallback.includes("://cf-ipfs.com/")) ??
+    fallbacks[0] ??
+    parseIpfsUrl(url)
+  );
 }
 
 export function isEmptyObject(obj: any) {

--- a/helpers/profile-banner.helpers.ts
+++ b/helpers/profile-banner.helpers.ts
@@ -1,4 +1,10 @@
-const BANNER_IMAGE_PREFIXES = ["http://", "https://", "ipfs://"];
+const BANNER_IMAGE_PREFIXES = [
+  "http://",
+  "https://",
+  "ipfs://",
+  "ipns://",
+  "ar://",
+];
 
 const isBannerImageUrl = (value?: string | null): value is string => {
   if (!value) {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -87,6 +87,7 @@ if (!process.env.PUBLIC_RUNTIME) {
     CORE_SCHEME: "testcore6529",
     IPFS_API_ENDPOINT: "https://api-ipfs.test.6529.io",
     IPFS_GATEWAY_ENDPOINT: "https://ipfs.test.6529.io",
+    MEDIA_RESOLVER_ENDPOINT: "https://media.6529.io",
     IPFS_MFS_PATH: "testfiles",
     TENOR_API_KEY: "test-tenor-api-key",
     WS_ENDPOINT: "wss://ws.test.6529.io",

--- a/lib/media/arweave-gateways.ts
+++ b/lib/media/arweave-gateways.ts
@@ -1,44 +1,41 @@
-// Ordered list: the array order defines the Arweave fallback retry order.
-const ARWEAVE_GATEWAY_HOSTS = [
-  "arweave.net",
-  "ardrive.net",
-  "gateway.arweave.net",
-  "gateway.ar.io",
-] as const;
+import {
+  ARWEAVE_GATEWAY_HOSTS,
+  ARWEAVE_TX_SUBDOMAIN_SUFFIXES,
+  DEFAULT_MEDIA_RESOLVER_ENDPOINT,
+  canonicalizeGatewayHostname,
+  parseDecentralizedMediaRef,
+} from "./decentralized-media";
 
-// gateway.ar.io redirects interactive content to <txid>.ar.io (not
-// <txid>.gateway.ar.io), so CSP / remote-pattern lists must also allow ar.io.
 const ADDITIONAL_CSP_HOSTS = ["ar.io"] as const;
 
 const dedupe = (values: readonly string[]): string[] =>
   Array.from(new Set(values));
 
-export const canonicalizeArweaveGatewayHostname = (
-  hostname: string
-): string => {
-  let normalized = hostname.trim().toLowerCase();
-  while (normalized.endsWith(".")) {
-    normalized = normalized.slice(0, -1);
-  }
-  return normalized;
-};
+export const canonicalizeArweaveGatewayHostname = (hostname: string): string =>
+  canonicalizeGatewayHostname(hostname);
 
 export const ARWEAVE_FALLBACK_HOSTS = [...ARWEAVE_GATEWAY_HOSTS];
 
 const ARWEAVE_GATEWAY_EXACT_HOSTS = dedupe(ARWEAVE_GATEWAY_HOSTS);
 
-const ARWEAVE_GATEWAY_WILDCARD_BASE_HOSTS = dedupe(ARWEAVE_GATEWAY_HOSTS);
+const ARWEAVE_GATEWAY_WILDCARD_BASE_HOSTS = dedupe([
+  ...ARWEAVE_GATEWAY_HOSTS,
+  ...ARWEAVE_TX_SUBDOMAIN_SUFFIXES.map((suffix) => suffix.slice(1)),
+]);
 
-export const ARWEAVE_GATEWAY_CSP_SOURCES = dedupe(
-  [...ARWEAVE_GATEWAY_HOSTS, ...ADDITIONAL_CSP_HOSTS].flatMap((hostname) => [
-    `https://${hostname}`,
-    `https://*.${hostname}`,
-  ])
-);
+export const ARWEAVE_GATEWAY_CSP_SOURCES = dedupe([
+  DEFAULT_MEDIA_RESOLVER_ENDPOINT,
+  ...ARWEAVE_GATEWAY_HOSTS.map((hostname) => `https://${hostname}`),
+  ...ARWEAVE_GATEWAY_HOSTS.map((hostname) => `https://*.${hostname}`),
+  ...ADDITIONAL_CSP_HOSTS.map((hostname) => `https://${hostname}`),
+  ...ADDITIONAL_CSP_HOSTS.map((hostname) => `https://*.${hostname}`),
+]);
 
-export const ARWEAVE_GATEWAY_REMOTE_PATTERN_HOSTNAMES = dedupe(
-  ARWEAVE_GATEWAY_HOSTS.flatMap((hostname) => [hostname, `**.${hostname}`])
-);
+export const ARWEAVE_GATEWAY_REMOTE_PATTERN_HOSTNAMES = dedupe([
+  "media.6529.io",
+  ...ARWEAVE_GATEWAY_HOSTS.flatMap((hostname) => [hostname, `**.${hostname}`]),
+  ...ADDITIONAL_CSP_HOSTS.flatMap((hostname) => [hostname, `**.${hostname}`]),
+]);
 
 export const isArweaveGatewayRuntimeHost = (hostname: string): boolean => {
   const normalized = canonicalizeArweaveGatewayHostname(hostname);
@@ -56,25 +53,10 @@ export const isArweaveGatewayRuntimeHost = (hostname: string): boolean => {
 };
 
 export const stripArweaveGatewayUrlPrefix = (value: string): string => {
-  try {
-    const parsed = new URL(value);
-    if (!/^https?:$/i.test(parsed.protocol)) {
-      return value;
-    }
-
-    if (!isArweaveGatewayRuntimeHost(parsed.hostname)) {
-      return value;
-    }
-
-    const strippedValue =
-      `${parsed.pathname}${parsed.search}${parsed.hash}`.replace(/^\/+/, "");
-
-    if (!strippedValue) {
-      return value;
-    }
-
-    return strippedValue;
-  } catch {
+  const parsed = parseDecentralizedMediaRef(value);
+  if (parsed?.protocol !== "arweave") {
     return value;
   }
+
+  return parsed.path ? `${parsed.id}/${parsed.path}` : parsed.id;
 };

--- a/lib/media/decentralized-media.ts
+++ b/lib/media/decentralized-media.ts
@@ -358,6 +358,8 @@ function parseArweaveTxSubdomainUrl(url: URL): ParsedDecentralizedMedia | null {
 
   const txid = hostname.slice(0, -suffix.length);
   const pathParts = splitPath(url.pathname);
+  // Tx subdomain hosts are canonicalized to lowercase; v1 keeps path casing
+  // exact, so only duplicate lowercase txid path prefixes are stripped.
   const normalizedPathParts =
     pathParts[0] === txid ? pathParts.slice(1) : pathParts;
   return makeParsed("arweave", txid, normalizedPathParts, getUrlWarnings(url));

--- a/lib/media/decentralized-media.ts
+++ b/lib/media/decentralized-media.ts
@@ -406,7 +406,7 @@ function buildSubdomainUrl(
 
 function normalizeOrigin(origin: string): string {
   let end = origin.length;
-  while (end > 0 && origin.charCodeAt(end - 1) === 47) {
+  while (end > 0 && origin.codePointAt(end - 1) === 47) {
     end -= 1;
   }
 

--- a/lib/media/decentralized-media.ts
+++ b/lib/media/decentralized-media.ts
@@ -405,7 +405,12 @@ function buildSubdomainUrl(
 }
 
 function normalizeOrigin(origin: string): string {
-  return origin.replace(/\/+$/, "");
+  let end = origin.length;
+  while (end > 0 && origin.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
+
+  return origin.slice(0, end);
 }
 
 function parseHttpUrl(input: string): URL | null {

--- a/lib/media/decentralized-media.ts
+++ b/lib/media/decentralized-media.ts
@@ -1,0 +1,476 @@
+export const DEFAULT_MEDIA_RESOLVER_ENDPOINT = "https://media.6529.io";
+
+export type DecentralizedMediaProtocol = "ipfs" | "ipns" | "arweave";
+
+export type DecentralizedMediaRef = {
+  readonly protocol: DecentralizedMediaProtocol;
+  readonly id: string;
+  readonly path: string;
+};
+
+export type DecentralizedMediaResolution = {
+  readonly input: string;
+  readonly recognized: boolean;
+  readonly protocol?: DecentralizedMediaProtocol;
+  readonly native_uri?: string;
+  readonly id?: string;
+  readonly path?: string;
+  readonly resolver_url?: string;
+  readonly external_fallback_urls: string[];
+  readonly warnings: string[];
+};
+
+export type ResolveDecentralizedMediaOptions = {
+  readonly includeExternalFallbacks?: boolean;
+  readonly resolverEndpoint?: string;
+};
+
+const MEDIA_RESOLVER_HOST = "media.6529.io";
+
+export const IPFS_PATH_GATEWAY_HOSTS = [
+  "ipfs.io",
+  "cf-ipfs.com",
+  "cloudflare-ipfs.com",
+  "gateway.pinata.cloud",
+  "ipfs.6529.io",
+] as const;
+
+export const IPFS_SUBDOMAIN_GATEWAY_SUFFIXES = [
+  ".ipfs.nftstorage.link",
+  ".ipfs.dweb.link",
+  ".ipfs.cf-ipfs.com",
+] as const;
+
+export const ARWEAVE_GATEWAY_HOSTS = [
+  "arweave.net",
+  "gateway.arweave.net",
+  "gateway.ar.io",
+  "ar-io.net",
+  "ardrive.net",
+] as const;
+
+export const ARWEAVE_TX_SUBDOMAIN_SUFFIXES = [
+  ".arweave.net",
+  ".ar.io",
+] as const;
+
+const IPFS_PATH_GATEWAY_SET = new Set<string>(IPFS_PATH_GATEWAY_HOSTS);
+const ARWEAVE_GATEWAY_SET = new Set<string>(ARWEAVE_GATEWAY_HOSTS);
+
+type ParsedDecentralizedMedia = {
+  readonly ref: DecentralizedMediaRef;
+  readonly warnings: string[];
+};
+
+export function parseDecentralizedMediaRef(
+  input: string | null | undefined
+): DecentralizedMediaRef | null {
+  return parseDecentralizedMedia(input)?.ref ?? null;
+}
+
+export function toNativeUri(ref: DecentralizedMediaRef): string {
+  const protocol = ref.protocol === "arweave" ? "ar" : ref.protocol;
+  return `${protocol}://${buildPath(ref.id, ref.path)}`;
+}
+
+export function to6529ResolverUrl(
+  ref: DecentralizedMediaRef,
+  resolverEndpoint = DEFAULT_MEDIA_RESOLVER_ENDPOINT
+): string {
+  const prefix = ref.protocol === "arweave" ? "arweave" : ref.protocol;
+  return `${normalizeOrigin(resolverEndpoint)}/${prefix}/${buildPath(
+    ref.id,
+    ref.path
+  )}`;
+}
+
+export function toExternalFallbackUrls(ref: DecentralizedMediaRef): string[] {
+  if (ref.protocol === "arweave") {
+    return [
+      ...ARWEAVE_GATEWAY_HOSTS.map(
+        (host) => `https://${host}/${buildPath(ref.id, ref.path)}`
+      ),
+      ...ARWEAVE_TX_SUBDOMAIN_SUFFIXES.map((suffix) =>
+        buildSubdomainUrl(ref.id, suffix.slice(1), ref.path)
+      ),
+    ];
+  }
+
+  const pathPrefix = ref.protocol === "ipns" ? "ipns" : "ipfs";
+  const pathGatewayUrls = IPFS_PATH_GATEWAY_HOSTS.map(
+    (host) => `https://${host}/${pathPrefix}/${buildPath(ref.id, ref.path)}`
+  );
+
+  if (ref.protocol === "ipns") {
+    return pathGatewayUrls;
+  }
+
+  return [
+    ...pathGatewayUrls,
+    ...IPFS_SUBDOMAIN_GATEWAY_SUFFIXES.map((suffix) =>
+      buildSubdomainUrl(ref.id, suffix.slice(1), ref.path)
+    ),
+  ];
+}
+
+export function resolveDecentralizedMediaInputs(
+  inputs: readonly string[],
+  options: ResolveDecentralizedMediaOptions = {}
+): DecentralizedMediaResolution[] {
+  return inputs.map((input) => resolveDecentralizedMediaInput(input, options));
+}
+
+export function normalizeDecentralizedMediaUrl(
+  input: string | null | undefined,
+  resolverEndpoint = DEFAULT_MEDIA_RESOLVER_ENDPOINT
+): string | undefined {
+  if (input == null) return undefined;
+  const trimmed = input.trim();
+  if (trimmed === "") return undefined;
+  const parsed = parseDecentralizedMediaRef(trimmed);
+  return parsed ? to6529ResolverUrl(parsed, resolverEndpoint) : trimmed;
+}
+
+export function getDecentralizedMediaFetchUrls(
+  input: string,
+  options: ResolveDecentralizedMediaOptions = {}
+): string[] {
+  const parsed = parseDecentralizedMediaRef(input);
+  if (!parsed) return [input];
+
+  return dedupe([
+    to6529ResolverUrl(parsed, options.resolverEndpoint),
+    ...(options.includeExternalFallbacks === false
+      ? []
+      : toExternalFallbackUrls(parsed)),
+  ]);
+}
+
+export function canonicalizeGatewayHostname(hostname: string): string {
+  let normalized = hostname.trim().toLowerCase();
+  while (normalized.endsWith(".")) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+export function getMediaResolverSource(
+  resolverEndpoint: string | undefined
+): string {
+  if (!resolverEndpoint) {
+    return DEFAULT_MEDIA_RESOLVER_ENDPOINT;
+  }
+
+  try {
+    const parsedUrl = new URL(resolverEndpoint);
+    if (parsedUrl.protocol !== "https:") {
+      return DEFAULT_MEDIA_RESOLVER_ENDPOINT;
+    }
+    return parsedUrl.origin;
+  } catch {
+    return DEFAULT_MEDIA_RESOLVER_ENDPOINT;
+  }
+}
+
+export function getMediaResolverHostname(
+  resolverEndpoint: string | undefined
+): string {
+  try {
+    return new URL(getMediaResolverSource(resolverEndpoint)).hostname;
+  } catch {
+    return MEDIA_RESOLVER_HOST;
+  }
+}
+
+export function isRecognizedDecentralizedMediaUrl(input: string): boolean {
+  return parseDecentralizedMediaRef(input) !== null;
+}
+
+function resolveDecentralizedMediaInput(
+  input: string,
+  options: ResolveDecentralizedMediaOptions
+): DecentralizedMediaResolution {
+  const parsed = parseDecentralizedMedia(input);
+  if (!parsed) {
+    return {
+      input,
+      recognized: false,
+      external_fallback_urls: [],
+      warnings: getUnrecognizedWarnings(input),
+    };
+  }
+
+  return {
+    input,
+    recognized: true,
+    protocol: parsed.ref.protocol,
+    native_uri: toNativeUri(parsed.ref),
+    id: parsed.ref.id,
+    path: parsed.ref.path,
+    resolver_url: to6529ResolverUrl(parsed.ref, options.resolverEndpoint),
+    external_fallback_urls:
+      options.includeExternalFallbacks === false
+        ? []
+        : toExternalFallbackUrls(parsed.ref),
+    warnings: parsed.warnings,
+  };
+}
+
+function parseDecentralizedMedia(
+  input: string | null | undefined
+): ParsedDecentralizedMedia | null {
+  if (input == null) return null;
+  const trimmed = input.trim();
+  if (trimmed === "") return null;
+
+  const native = parseNativeUri(trimmed);
+  if (native) return native;
+
+  const url = parseHttpUrl(trimmed);
+  if (!url) {
+    return looksLikeIpfsCid(trimmed)
+      ? { ref: { protocol: "ipfs", id: trimmed, path: "" }, warnings: [] }
+      : null;
+  }
+
+  return (
+    parse6529ResolverUrl(url) ??
+    parseIpfsPathGatewayUrl(url) ??
+    parseIpfsSubdomainGatewayUrl(url) ??
+    parseArweaveGatewayUrl(url) ??
+    parseArweaveTxSubdomainUrl(url)
+  );
+}
+
+function parseNativeUri(input: string): ParsedDecentralizedMedia | null {
+  const protocolMatch = /^(ipfs|ipns|ar):\/\/(.+)$/i.exec(input);
+  if (!protocolMatch?.[1] || !protocolMatch[2]) return null;
+
+  const protocol =
+    protocolMatch[1].toLowerCase() === "ar"
+      ? "arweave"
+      : (protocolMatch[1].toLowerCase() as DecentralizedMediaProtocol);
+  const { value, warnings } = stripQueryAndHash(protocolMatch[2]);
+  const parts = splitPath(value);
+  const maybeId = parts[0] ?? "";
+
+  if (
+    protocol === "ipfs" &&
+    maybeId.toLowerCase() === "ipfs" &&
+    parts.length > 1
+  ) {
+    return makeParsed(protocol, parts[1] ?? "", parts.slice(2), warnings);
+  }
+
+  if (
+    protocol === "ipns" &&
+    maybeId.toLowerCase() === "ipns" &&
+    parts.length > 1
+  ) {
+    return makeParsed(protocol, parts[1] ?? "", parts.slice(2), warnings);
+  }
+
+  return makeParsed(protocol, maybeId, parts.slice(1), warnings);
+}
+
+function parse6529ResolverUrl(url: URL): ParsedDecentralizedMedia | null {
+  if (canonicalizeGatewayHostname(url.hostname) !== MEDIA_RESOLVER_HOST) {
+    return null;
+  }
+
+  const parts = splitPath(url.pathname);
+  const prefix = (parts[0] ?? "").toLowerCase();
+  if (prefix !== "ipfs" && prefix !== "ipns" && prefix !== "arweave") {
+    return null;
+  }
+
+  const protocol = prefix === "arweave" ? "arweave" : prefix;
+  return makeParsed(
+    protocol,
+    parts[1] ?? "",
+    parts.slice(2),
+    getUrlWarnings(url)
+  );
+}
+
+function parseIpfsPathGatewayUrl(url: URL): ParsedDecentralizedMedia | null {
+  if (!IPFS_PATH_GATEWAY_SET.has(canonicalizeGatewayHostname(url.hostname))) {
+    return null;
+  }
+
+  const parts = splitPath(url.pathname);
+  const prefixIndex = parts.findIndex(
+    (part) => part.toLowerCase() === "ipfs" || part.toLowerCase() === "ipns"
+  );
+  if (prefixIndex < 0) return null;
+
+  const prefix = parts[prefixIndex];
+  if (!prefix) return null;
+
+  const protocol = prefix.toLowerCase() as "ipfs" | "ipns";
+  return makeParsed(
+    protocol,
+    parts[prefixIndex + 1] ?? "",
+    parts.slice(prefixIndex + 2),
+    getUrlWarnings(url)
+  );
+}
+
+function parseIpfsSubdomainGatewayUrl(
+  url: URL
+): ParsedDecentralizedMedia | null {
+  const hostname = canonicalizeGatewayHostname(url.hostname);
+  const suffix = IPFS_SUBDOMAIN_GATEWAY_SUFFIXES.find((candidate) =>
+    hostname.endsWith(candidate)
+  );
+  if (!suffix) return null;
+
+  const cid = hostname.slice(0, -suffix.length);
+  return makeParsed("ipfs", cid, splitPath(url.pathname), getUrlWarnings(url));
+}
+
+function parseArweaveGatewayUrl(url: URL): ParsedDecentralizedMedia | null {
+  if (!ARWEAVE_GATEWAY_SET.has(canonicalizeGatewayHostname(url.hostname))) {
+    return null;
+  }
+
+  const parts = splitPath(url.pathname);
+  return makeParsed(
+    "arweave",
+    parts[0] ?? "",
+    parts.slice(1),
+    getUrlWarnings(url)
+  );
+}
+
+function parseArweaveTxSubdomainUrl(url: URL): ParsedDecentralizedMedia | null {
+  const hostname = canonicalizeGatewayHostname(url.hostname);
+  const suffix = ARWEAVE_TX_SUBDOMAIN_SUFFIXES.find((candidate) =>
+    hostname.endsWith(candidate)
+  );
+  if (!suffix) return null;
+
+  const txid = hostname.slice(0, -suffix.length);
+  const pathParts = splitPath(url.pathname);
+  const normalizedPathParts =
+    pathParts[0] === txid ? pathParts.slice(1) : pathParts;
+  return makeParsed("arweave", txid, normalizedPathParts, getUrlWarnings(url));
+}
+
+function makeParsed(
+  protocol: DecentralizedMediaProtocol,
+  id: string,
+  pathParts: readonly string[],
+  warnings: readonly string[]
+): ParsedDecentralizedMedia | null {
+  const normalizedId = id.trim();
+  if (!isValidIdSegment(normalizedId)) return null;
+
+  return {
+    ref: {
+      protocol,
+      id: normalizedId,
+      path: normalizePath(pathParts),
+    },
+    warnings: [...warnings],
+  };
+}
+
+function splitPath(path: string): string[] {
+  return path
+    .split("/")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+}
+
+function normalizePath(pathParts: readonly string[]): string {
+  return pathParts.map(encodePathSegment).join("/");
+}
+
+function buildPath(id: string, path: string): string {
+  const normalizedPath = splitPath(path).map(encodePathSegment).join("/");
+  if (!normalizedPath) return encodePathSegment(id);
+  return `${encodePathSegment(id)}/${normalizedPath}`;
+}
+
+function buildSubdomainUrl(
+  id: string,
+  hostSuffix: string,
+  path: string
+): string {
+  const normalizedPath = splitPath(path).map(encodePathSegment).join("/");
+  return normalizedPath
+    ? `https://${encodePathSegment(id)}.${hostSuffix}/${normalizedPath}`
+    : `https://${encodePathSegment(id)}.${hostSuffix}`;
+}
+
+function normalizeOrigin(origin: string): string {
+  return origin.replace(/\/+$/, "");
+}
+
+function parseHttpUrl(input: string): URL | null {
+  try {
+    const url = new URL(input);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+function stripQueryAndHash(value: string): {
+  readonly value: string;
+  readonly warnings: string[];
+} {
+  const index = findFirstIndex(value, ["?", "#"]);
+  if (index < 0) return { value, warnings: [] };
+  return {
+    value: value.slice(0, index),
+    warnings: ["query_or_hash_stripped"],
+  };
+}
+
+function getUrlWarnings(url: URL): string[] {
+  return url.search || url.hash ? ["query_or_hash_stripped"] : [];
+}
+
+function getUnrecognizedWarnings(input: string): string[] {
+  const trimmed = input.trim();
+  if (trimmed === "") return ["invalid_url"];
+  if (/^https?:\/\//i.exec(trimmed)) {
+    return parseHttpUrl(trimmed) ? [] : ["invalid_url"];
+  }
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.exec(trimmed)) return ["unsupported_scheme"];
+  if (trimmed.includes("://")) return ["invalid_url"];
+  return [];
+}
+
+function findFirstIndex(value: string, needles: readonly string[]): number {
+  const indexes = needles
+    .map((needle) => value.indexOf(needle))
+    .filter((index) => index >= 0)
+    .sort((a, b) => a - b);
+  return indexes[0] ?? -1;
+}
+
+function encodePathSegment(segment: string): string {
+  try {
+    return encodeURIComponent(decodeURIComponent(segment));
+  } catch {
+    return encodeURIComponent(segment);
+  }
+}
+
+function isValidIdSegment(value: string): boolean {
+  return value.length > 0 && !/[\s/?#]/.exec(value);
+}
+
+function looksLikeIpfsCid(value: string): boolean {
+  return /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|[bB][aA][fF][a-zA-Z2-7]{20,})$/.test(
+    value
+  );
+}
+
+function dedupe(list: readonly string[]): string[] {
+  return Array.from(new Set(list));
+}

--- a/lib/media/decentralized-media.ts
+++ b/lib/media/decentralized-media.ts
@@ -496,6 +496,8 @@ function isValidProtocolId(
 }
 
 function looksLikeIpfsCid(value: string): boolean {
+  // Supports CIDv0 base58btc and CIDv1 base32; other CIDv1 multibase
+  // encodings are intentionally outside this resolver v1 allowlist.
   return /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|[bB][aA][fF][a-zA-Z2-7]{20,})$/.test(
     value
   );

--- a/lib/media/decentralized-media.ts
+++ b/lib/media/decentralized-media.ts
@@ -56,6 +56,8 @@ export const ARWEAVE_TX_SUBDOMAIN_SUFFIXES = [
 
 const IPFS_PATH_GATEWAY_SET = new Set<string>(IPFS_PATH_GATEWAY_HOSTS);
 const ARWEAVE_GATEWAY_SET = new Set<string>(ARWEAVE_GATEWAY_HOSTS);
+const ARWEAVE_TX_ID_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const DNS_SAFE_LABEL_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 
 type ParsedDecentralizedMedia = {
   readonly ref: DecentralizedMediaRef;
@@ -90,9 +92,11 @@ export function toExternalFallbackUrls(ref: DecentralizedMediaRef): string[] {
       ...ARWEAVE_GATEWAY_HOSTS.map(
         (host) => `https://${host}/${buildPath(ref.id, ref.path)}`
       ),
-      ...ARWEAVE_TX_SUBDOMAIN_SUFFIXES.map((suffix) =>
-        buildSubdomainUrl(ref.id, suffix.slice(1), ref.path)
-      ),
+      ...(isDnsSafeSubdomainId(ref.id)
+        ? ARWEAVE_TX_SUBDOMAIN_SUFFIXES.map((suffix) =>
+            buildSubdomainUrl(ref.id, suffix.slice(1), ref.path)
+          )
+        : []),
     ];
   }
 
@@ -107,9 +111,11 @@ export function toExternalFallbackUrls(ref: DecentralizedMediaRef): string[] {
 
   return [
     ...pathGatewayUrls,
-    ...IPFS_SUBDOMAIN_GATEWAY_SUFFIXES.map((suffix) =>
-      buildSubdomainUrl(ref.id, suffix.slice(1), ref.path)
-    ),
+    ...(isDnsSafeSubdomainId(ref.id)
+      ? IPFS_SUBDOMAIN_GATEWAY_SUFFIXES.map((suffix) =>
+          buildSubdomainUrl(ref.id, suffix.slice(1), ref.path)
+        )
+      : []),
   ];
 }
 
@@ -365,6 +371,7 @@ function makeParsed(
 ): ParsedDecentralizedMedia | null {
   const normalizedId = id.trim();
   if (!isValidIdSegment(normalizedId)) return null;
+  if (!isValidProtocolId(protocol, normalizedId)) return null;
 
   return {
     ref: {
@@ -445,7 +452,14 @@ function getUnrecognizedWarnings(input: string): string[] {
   if (/^https?:\/\//i.exec(trimmed)) {
     return parseHttpUrl(trimmed) ? [] : ["invalid_url"];
   }
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.exec(trimmed)) return ["unsupported_scheme"];
+  const schemeMatch = /^([a-z][a-z0-9+.-]*):\/\//i.exec(trimmed);
+  if (schemeMatch?.[1]) {
+    const scheme = schemeMatch[1].toLowerCase();
+    if (scheme === "ipfs" || scheme === "ipns" || scheme === "ar") {
+      return ["invalid_url"];
+    }
+    return ["unsupported_scheme"];
+  }
   if (trimmed.includes("://")) return ["invalid_url"];
   return [];
 }
@@ -470,10 +484,27 @@ function isValidIdSegment(value: string): boolean {
   return value.length > 0 && !/[\s/?#]/.exec(value);
 }
 
+function isValidProtocolId(
+  protocol: DecentralizedMediaProtocol,
+  value: string
+): boolean {
+  if (protocol === "ipfs") return looksLikeIpfsCid(value);
+  if (protocol === "arweave") return looksLikeArweaveTxId(value);
+  return true;
+}
+
 function looksLikeIpfsCid(value: string): boolean {
   return /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|[bB][aA][fF][a-zA-Z2-7]{20,})$/.test(
     value
   );
+}
+
+function looksLikeArweaveTxId(value: string): boolean {
+  return ARWEAVE_TX_ID_PATTERN.test(value);
+}
+
+function isDnsSafeSubdomainId(value: string): boolean {
+  return DNS_SAFE_LABEL_PATTERN.test(value);
 }
 
 function dedupe(list: readonly string[]): string[] {

--- a/lib/media/ipfs-gateways.ts
+++ b/lib/media/ipfs-gateways.ts
@@ -1,8 +1,26 @@
-import { publicEnv } from "@/config/env";
-import { canonicalizeArweaveGatewayHostname } from "@/lib/media/arweave-gateways";
+import {
+  IPFS_PATH_GATEWAY_HOSTS,
+  IPFS_SUBDOMAIN_GATEWAY_SUFFIXES,
+  canonicalizeGatewayHostname,
+} from "./decentralized-media";
+
+export const IPFS_GATEWAY_CSP_SOURCES = [
+  ...IPFS_PATH_GATEWAY_HOSTS.flatMap((hostname) => [
+    `https://${hostname}`,
+    `https://${hostname}/ipfs/*`,
+    `https://${hostname}/ipns/*`,
+  ]),
+  ...IPFS_SUBDOMAIN_GATEWAY_SUFFIXES.map((suffix) => `https://*${suffix}`),
+];
+
+export const IPFS_GATEWAY_REMOTE_PATTERN_HOSTNAMES = [
+  "media.6529.io",
+  ...IPFS_PATH_GATEWAY_HOSTS,
+  ...IPFS_SUBDOMAIN_GATEWAY_SUFFIXES.map((suffix) => `**${suffix}`),
+];
 
 export function getConfiguredIpfsGatewayHost(
-  gatewayEndpoint: string | undefined = publicEnv.IPFS_GATEWAY_ENDPOINT
+  gatewayEndpoint?: string
 ): string | null {
   if (!gatewayEndpoint) {
     return null;
@@ -14,7 +32,7 @@ export function getConfiguredIpfsGatewayHost(
       return null;
     }
 
-    return canonicalizeArweaveGatewayHostname(parsedUrl.hostname);
+    return canonicalizeGatewayHostname(parsedUrl.hostname);
   } catch {
     return null;
   }

--- a/next.config.ts
+++ b/next.config.ts
@@ -86,6 +86,7 @@ const nextConfigFactory = (phase: string): NextConfig => {
         CORE_SCHEME: publicEnv.CORE_SCHEME,
         IPFS_API_ENDPOINT: publicEnv.IPFS_API_ENDPOINT,
         IPFS_GATEWAY_ENDPOINT: publicEnv.IPFS_GATEWAY_ENDPOINT,
+        MEDIA_RESOLVER_ENDPOINT: publicEnv.MEDIA_RESOLVER_ENDPOINT,
         IPFS_MFS_PATH: publicEnv.IPFS_MFS_PATH,
         TENOR_API_KEY: publicEnv.TENOR_API_KEY,
         WS_ENDPOINT: publicEnv.WS_ENDPOINT,

--- a/ops/contracts/decentralized-media-resolver-review-and-rollout.md
+++ b/ops/contracts/decentralized-media-resolver-review-and-rollout.md
@@ -1,0 +1,406 @@
+# Decentralized Media Resolver Review and Rollout Plan
+
+Audience: 6529 frontend, backend, mobile, Electron, API, infra, QA, and release reviewers.
+
+This document covers both implementation branches for the decentralized media resolver work. The canonical contract files are in the frontend repository under `ops/contracts/`; this review and rollout document is intentionally mirrored in both PRs so each team has the same context.
+
+## Executive Summary
+
+The protocol goal is to stop treating third-party DNS gateways such as `ipfs.io`, `cf-ipfs.com`, `arweave.net`, and similar hosts as canonical media storage. The new default model is:
+
+1. Store and pass native decentralized identifiers where the surface can represent them:
+   - `ipfs://<cid>/<path?>`
+   - `ipns://<name>/<path?>`
+   - `ar://<txid>/<path?>`
+2. Resolve web-renderable URLs through the 6529 resolver layer:
+   - `https://media.6529.io/ipfs/<cid>/<path?>`
+   - `https://media.6529.io/ipns/<name>/<path?>`
+   - `https://media.6529.io/arweave/<txid>/<path?>`
+3. Keep public DNS gateways only as explicit fallback/debug/share options, never as new canonical storage.
+
+Version 1 does not proxy bytes inside these repos. It standardizes canonical parsing, normalization, resolver URL construction, fallback URL construction, frontend rendering defaults, backend API shape, and backend consumer behavior. The actual `media.6529.io` DNS/CDN/edge byte-serving infrastructure is assumed to be provisioned outside these PRs.
+
+## Why This Change Exists
+
+6529 wants to be a decentralized protocol, not a product whose protocol references silently depend on someone else's DNS gateway. Before this change, the frontend and backend both had scattered IPFS and Arweave handling with different defaults:
+
+- Some flows converted native `ipfs://` to `https://ipfs.io/ipfs/...`.
+- Some flows preferred `cf-ipfs.com`.
+- Arweave rendering and fallbacks commonly assumed `https://arweave.net/...`.
+- A few paths already knew about `ipfs.6529.io`, but it was mixed with third-party gateway behavior.
+- Parsing and fallback behavior lived in many small helpers with subtly different path, query, hash, and validation semantics.
+
+That creates protocol drift and makes it hard to reason about what is canonical. This work centralizes the rules so:
+
+- Native decentralized URIs are the first-class representation.
+- 6529 is the resolver layer for web contexts.
+- External DNS gateways remain available but are visibly secondary.
+- FE, BE, mobile, and Electron can share one mental model.
+
+## Non-Goals
+
+This PR pair intentionally does not:
+
+- Implement `media.6529.io` byte proxying.
+- Add database migrations.
+- Rewrite legacy IPFS upload/MFS flows.
+- Remove all third-party gateway allowlist entries.
+- Remove legacy `IPFS_GATEWAY_ENDPOINT`.
+- Require every copy/share UI in the app to change at once where no copy/debug surface exists yet.
+
+## Contract Summary
+
+Canonical native forms:
+
+- `ipfs://<cid>/<path?>`
+- `ipns://<name>/<path?>`
+- `ar://<txid>/<path?>`
+
+6529 resolver forms:
+
+- `https://media.6529.io/ipfs/<cid>/<path?>`
+- `https://media.6529.io/ipns/<name>/<path?>`
+- `https://media.6529.io/arweave/<txid>/<path?>`
+
+Recognized external fallback gateways:
+
+- IPFS path gateways: `ipfs.io`, `cf-ipfs.com`, `cloudflare-ipfs.com`, `gateway.pinata.cloud`, `ipfs.6529.io`
+- IPFS subdomain gateways: `<cid>.ipfs.nftstorage.link`, `<cid>.ipfs.dweb.link`, `<cid>.ipfs.cf-ipfs.com`
+- Arweave gateways: `arweave.net`, `gateway.arweave.net`, `gateway.ar.io`, `ar-io.net`, `ardrive.net`
+- Arweave transaction subdomains: `<txid>.arweave.net`, `<txid>.ar.io`
+
+Rules:
+
+- Recognized gateway URLs are parsed back to native form.
+- Query strings and hashes are stripped from recognized decentralized media references and surfaced as warnings in resolver responses.
+- Unrecognized HTTP(S) URLs remain unrecognized rather than being rewritten.
+- Invalid URLs produce item-level warnings instead of failing a whole batch request.
+- `ipfs.6529.io` remains accepted as legacy input/fallback-compatible output, but new default web URLs use `media.6529.io`.
+
+## Backend Changes
+
+Main new module:
+
+- `src/decentralized-media/decentralized-media.ts`
+
+Shared helper API:
+
+- `parseDecentralizedMediaRef(input)`
+- `toNativeUri(ref)`
+- `to6529ResolverUrl(ref)`
+- `toExternalFallbackUrls(ref)`
+- `resolveDecentralizedMediaInputs(inputs, options)`
+- Compatibility helpers for normalization and fetch fallback lists.
+
+New public API boundary:
+
+- `POST /api/media/resolve`
+
+OpenAPI request:
+
+```json
+{
+  "inputs": ["ipfs://...", "https://ipfs.io/ipfs/...", "ar://..."],
+  "include_external_fallbacks": true
+}
+```
+
+OpenAPI response item:
+
+```json
+{
+  "input": "https://ipfs.io/ipfs/<cid>/metadata.json",
+  "recognized": true,
+  "protocol": "ipfs",
+  "native_uri": "ipfs://<cid>/metadata.json",
+  "id": "<cid>",
+  "path": "metadata.json",
+  "resolver_url": "https://media.6529.io/ipfs/<cid>/metadata.json",
+  "external_fallback_urls": ["https://ipfs.io/ipfs/<cid>/metadata.json"],
+  "warnings": []
+}
+```
+
+Backend consumers updated:
+
+- NFT-link URI normalization now goes through the shared resolver module.
+- OG metadata media URLs now normalize recognized IPFS/Arweave inputs to 6529 resolver URLs.
+- Minting-claim Arweave upload fetch/location handling now uses central Arweave parsing/fallbacks.
+- Legacy IPFS helper/media checker now delegates parsing and fetch URL generation to the shared module.
+- Drop HTML media validation recognizes native and resolver-layer decentralized media references.
+- NFT metadata fetch normalization now recognizes native, 6529 resolver, legacy gateway, and fallback gateway forms.
+
+Backend generated/API files updated:
+
+- `src/api-serverless/openapi.yaml`
+- generated resolver request/response models
+- generated object serializer/route operation wiring
+
+Backend architecture docs updated:
+
+- `docs/architecture.md`
+
+## Frontend Changes
+
+Main new module:
+
+- `lib/media/decentralized-media.ts`
+
+Shared helper API:
+
+- `parseDecentralizedMediaRef(input)`
+- `toNativeUri(ref)`
+- `to6529ResolverUrl(ref, options?)`
+- `toExternalFallbackUrls(ref, options?)`
+- `resolveDecentralizedMediaInputs(inputs, options?)`
+- `normalizeDecentralizedMediaUrl(input, options?)`
+- `getDecentralizedMediaFetchUrls(input, options?)`
+- gateway recognition constants
+
+Contract files:
+
+- `ops/contracts/decentralized-media-resolver-v1.md`
+- `ops/contracts/decentralized-media-resolver-v1.openapi.yaml`
+
+Configuration:
+
+- Added optional public `MEDIA_RESOLVER_ENDPOINT`.
+- Default is `https://media.6529.io`.
+- Kept `IPFS_GATEWAY_ENDPOINT` for legacy upload/MFS flows.
+- Added `media.6529.io` to CSP and Next image remote patterns.
+- Retained third-party gateway allowlist entries as fallback compatibility entries.
+- Added IPFS subdomain gateway recognition where CSP/image handling already had gateway awareness.
+
+Frontend consumers updated:
+
+- IPFS context/rendering now defaults decentralized refs to the 6529 resolver URL.
+- Gateway fallback handling now tries resolver URL first, then explicit external fallbacks.
+- Drop Forge accepts native `ipfs://`, `ipns://`, `ar://`, 6529 resolver URLs, recognized external gateways, bare IPFS CIDs, and bare Arweave transaction IDs where previously supported.
+- Interactive memes submission stores native decentralized URIs where possible and previews via `media.6529.io`.
+- Attachment metadata URL construction uses native IPFS metadata roots.
+- OpenGraph, ENS, Pepe resolve, profile banner/avatar, unsupported media links, Meme additional details, and static Arweave references now normalize through the central module.
+- Public copy/share semantics are set up around native URI and 6529 web URL outputs, with third-party fallbacks staying limited to fallback/debug surfaces.
+
+## Review Map
+
+Backend reviewers should focus on:
+
+- Parser correctness for native URI forms, 6529 resolver forms, path gateways, subdomain gateways, nested paths, query/hash stripping, and invalid URLs.
+- OpenAPI shape and generated model compatibility.
+- API behavior for partial failures. One invalid input must not fail the whole request.
+- Whether `external_fallback_urls` should default to included or excluded for every caller. Current contract defaults inclusion to `true`.
+- Callers that fetch metadata/media. Confirm resolver-first plus fallback behavior is safe.
+- Any deployable loop that imports the changed helper modules.
+- Whether route naming and serverless wiring match backend conventions.
+
+Frontend reviewers should focus on:
+
+- The central resolver helper and whether it mirrors backend behavior closely enough for v1.
+- CSP and Next image remote patterns. We want `media.6529.io` first-class and third-party gateways retained only as fallback allowlist entries.
+- UX surfaces that copy/open links. Native URI and 6529 web URL should be the visible primary pair where such UI exists.
+- Interactive memes validation. Security constraints around HTML, path traversal, hashes, encoded path separators, and allowed hosts must remain strict.
+- Drop Forge storage link parsing. Native forms should work without regressing bare CID/txid behavior.
+- Mobile and Electron rendering. Confirm no runtime assumes only `http(s)` inputs before centralized normalization runs.
+
+Infra/release reviewers should focus on:
+
+- Whether `media.6529.io` is fully provisioned before frontend rollout.
+- Whether CDN/cache behavior for `media.6529.io` matches expected IPFS/IPNS/Arweave semantics.
+- Whether `MEDIA_RESOLVER_ENDPOINT` should be environment-overridden per deployment stage.
+- Whether old gateway egress patterns need monitoring during rollout.
+
+## Test Coverage Added Or Updated
+
+Backend:
+
+- Parser matrix for native IPFS/IPNS/Arweave, 6529 resolver URLs, path gateways, subdomain gateways, invalid URLs, nested paths, and query/hash stripping.
+- API route tests for batch success, invalid inputs, and external fallback inclusion.
+- NFT-link URI normalization tests.
+- OG metadata URL normalization tests.
+- Minting-claim Arweave upload/fetch handling tests.
+- Legacy IPFS helper tests.
+- Drop HTML validation tests.
+
+Frontend:
+
+- Parser/resolver matrix equivalent to backend.
+- IPFS context normalization tests.
+- Gateway fallback tests.
+- Interactive memes validation/submission tests.
+- Drop Forge storage link tests.
+- Attachment/media display tests.
+- ENS preview tests.
+- OpenGraph service tests.
+- Existing avatar/notification tests updated for resolver URL expectations.
+
+## Verification Notes From Implementation
+
+Backend verification completed:
+
+- Focused no-Docker Jest run passed.
+- Root TypeScript check passed.
+- ESLint equivalent passed in this Windows environment.
+- Standard `npm test` is blocked locally by Docker credential helper setup for Testcontainers.
+- Standard `npm run lint` has a PowerShell environment assignment issue locally; equivalent ESLint command was used.
+
+Frontend verification completed:
+
+- Focused Jest run passed.
+- Changed-surface ESLint equivalent passed.
+- Source TypeScript check passed.
+- The repo-local `6529` wrapper failed on this Windows worktree because the shell wrapper has CRLF/path handling issues; guarded equivalent commands were used with `SEIZE_6529_COMMAND=1`.
+- `pnpm run build` fails before app build in the frontend `generate` step because the script uses Unix `rm`/`mv` under PowerShell.
+- `pnpm run base-build` with required env values reaches Next build. Turbopack fails resolving Bootstrap Sass imports in this Windows/pnpm setup.
+- `next build --webpack` compiles, then fails existing generated Next route prop checks under `[user]` routes. That failure is not introduced by this resolver change, but it means a full local production build was not green on this machine.
+
+## Manual QA Plan
+
+Run these checks against an environment where `media.6529.io` is provisioned and the backend API branch is deployed.
+
+Backend API:
+
+1. `POST /api/media/resolve` with native IPFS, IPNS, and Arweave inputs.
+2. `POST /api/media/resolve` with `https://media.6529.io/ipfs/...`, `/ipns/...`, and `/arweave/...`.
+3. `POST /api/media/resolve` with every recognized external fallback gateway.
+4. Confirm unrecognized `https://example.com/foo` returns `recognized=false`.
+5. Confirm malformed input returns item-level warning and does not fail the whole request.
+6. Confirm query/hash stripping warnings appear for recognized gateway URLs with query/hash.
+7. Confirm `include_external_fallbacks=false` suppresses external fallback URL arrays.
+
+Frontend web:
+
+1. Render NFTs whose metadata image/animation fields contain `ipfs://`.
+2. Render NFTs whose metadata image/animation fields contain `ar://`.
+3. Render existing content that still stores `ipfs.io`, `cf-ipfs.com`, `ipfs.6529.io`, or `arweave.net` URLs.
+4. Confirm rendered web URL is `https://media.6529.io/...` before fallback.
+5. Simulate resolver failure and confirm explicit fallback logic still reaches recognized third-party gateways where fallback UI/path already exists.
+6. Upload/select Drop Forge storage links using native IPFS, native Arweave, 6529 resolver URLs, legacy gateway URLs, bare CID, and bare Arweave txid.
+7. Submit interactive meme content with safe IPFS HTML paths and confirm unsafe hash/traversal cases remain rejected.
+8. Confirm copy/open actions expose native URI and 6529 web URL where the UI has those actions.
+9. Confirm OpenGraph previews normalize decentralized media through `media.6529.io`.
+10. Confirm ENS avatar/contenthash previews normalize recognized decentralized refs.
+
+Mobile and Electron:
+
+1. Repeat media rendering checks for `ipfs://`, `ipns://`, `ar://`, and old gateway URLs.
+2. Confirm webviews or native shells do not reject native URI values before FE normalization runs.
+3. Confirm CSP/image allowlist changes are reflected in packaged runtime configuration.
+4. Confirm share sheets or copy flows do not expose third-party DNS gateways as the default link.
+
+## Deployment Plan
+
+Deploy backend first.
+
+1. Deploy the API service containing `/api/media/resolve`.
+2. Redeploy backend deployables that bundle changed resolver consumers. At minimum review and redeploy:
+   - API service
+   - `nftsLoop`
+   - NFT-link/media-preview related loop deployables that import `src/nft-links/lib/uri.ts`
+   - Any minting-claim deployable that imports `src/minting-claims/claims-media-arweave-upload.ts`
+   - Any media-checker deployable that imports `src/media-checker.ts`
+3. Confirm `/api/media/resolve` behavior in staging.
+4. Confirm `media.6529.io` byte resolution is available for IPFS, IPNS, and Arweave resolver paths.
+5. Deploy frontend web with `MEDIA_RESOLVER_ENDPOINT=https://media.6529.io`.
+6. Build and release mobile/Electron after web/API smoke tests pass.
+
+Important: if deploy tooling proves that some touched modules are API-only in practice, document that in the release ticket. The safe default is to redeploy every deployable that bundles touched shared modules.
+
+## Rollback Plan
+
+Backend rollback:
+
+- Revert the backend PR or roll back the API deployment to the previous version.
+- If frontend has already shipped, resolver URLs may still point at `media.6529.io`; ensure the resolver infrastructure remains available during backend rollback.
+
+Frontend rollback:
+
+- Revert the frontend PR or roll back the frontend deployment.
+- If only resolver infrastructure is unhealthy and the frontend code is otherwise sound, temporarily override `MEDIA_RESOLVER_ENDPOINT` only if infra has a vetted 6529-controlled replacement endpoint.
+- Do not switch canonical frontend defaults back to third-party gateways except as an emergency rollback decision.
+
+Data rollback:
+
+- No database migration is included in v1.
+- No data backfill is required for this PR pair.
+- Existing gateway URLs remain parseable as legacy inputs.
+
+## Monitoring And Observability
+
+Recommended rollout monitors:
+
+- `/api/media/resolve` request volume, latency, and 4xx/5xx rates.
+- Warning counts by warning code, especially invalid URL and query/hash stripping warnings.
+- `media.6529.io` CDN/cache hit rate and origin error rate.
+- Frontend image/media load failures grouped by host.
+- Fallback gateway usage after resolver-first attempts.
+- OpenGraph media fetch failures.
+- Minting-claim media upload/fetch failures.
+- NFT metadata fetch failures in `nftsLoop`.
+
+Expected healthy behavior:
+
+- `media.6529.io` usage should increase.
+- New third-party gateway URLs should stop appearing as canonical app-generated links.
+- External gateway traffic should still exist during fallback and legacy rendering but should trend lower over time.
+
+## Risks And Mitigations
+
+Risk: parser mismatch between FE and BE.
+
+- Mitigation: both repos now have parser matrix tests. Reviewers should compare fixtures and edge cases directly.
+
+Risk: `media.6529.io` not ready at frontend release time.
+
+- Mitigation: deploy backend/API first, verify resolver infrastructure separately, and keep external fallbacks available.
+
+Risk: IPNS behavior differs from IPFS/Arweave because names can resolve dynamically.
+
+- Mitigation: v1 only standardizes URL forms. Infra must define cache/TTL behavior for IPNS.
+
+Risk: hidden copy/share surfaces still expose third-party gateway URLs.
+
+- Mitigation: this PR covers known surfaces touched by current helpers. Reviewers should search for remaining direct `ipfs.io`, `cf-ipfs.com`, and `arweave.net` references before merge.
+
+Risk: mobile/Electron native URI handling differs from web.
+
+- Mitigation: native URIs should be normalized before webview/image rendering. QA must test package builds, not only browser dev.
+
+Risk: generated backend OpenAPI files drift.
+
+- Mitigation: generated models were updated for this endpoint. On Unix-like CI, run the repo generation commands and compare output.
+
+## Reviewer Search Checklist
+
+Before approval, run targeted searches in both repos:
+
+- `ipfs.io`
+- `cf-ipfs.com`
+- `cloudflare-ipfs.com`
+- `gateway.pinata.cloud`
+- `ipfs.6529.io`
+- `arweave.net`
+- `gateway.arweave.net`
+- `gateway.ar.io`
+- `ar-io.net`
+- `ardrive.net`
+- `ipfs://`
+- `ipns://`
+- `ar://`
+- `MEDIA_RESOLVER_ENDPOINT`
+- `media.6529.io`
+
+Remaining direct gateway references should be either:
+
+- central parser/fallback constants,
+- tests,
+- docs/contracts,
+- explicit legacy upload/MFS behavior,
+- explicit fallback/debug behavior.
+
+## Merge Order
+
+1. Backend PR: add shared resolver module and `/api/media/resolve`.
+2. Frontend PR: consume central FE resolver and contract files.
+
+The frontend PR should not be deployed before the backend API and `media.6529.io` infrastructure are verified.
+

--- a/ops/contracts/decentralized-media-resolver-v1.md
+++ b/ops/contracts/decentralized-media-resolver-v1.md
@@ -1,0 +1,118 @@
+# Decentralized Media Resolver Contract v1
+
+## Ownership
+
+Frontend owns this contract under `ops/contracts/`. Backend implements the API surface and shared parsing semantics. The resolver layer is `https://media.6529.io`.
+
+## Goals
+
+- Store and pass native decentralized references first.
+- Resolve native references through the 6529 resolver for web rendering.
+- Keep third-party DNS gateways as explicit external fallbacks for compatibility, copy/share, and debugging.
+- Never treat a third-party gateway URL as canonical storage when it can be parsed back to a native reference.
+
+## Canonical Native Forms
+
+The canonical stored and exchanged values are:
+
+- `ipfs://<cid>/<path?>`
+- `ipns://<name>/<path?>`
+- `ar://<txid>/<path?>`
+
+The optional `path` is slash-delimited. Query strings and fragments are not canonical and must be stripped during parsing with an item-level warning.
+
+## 6529 Resolver Forms
+
+The 6529 web resolver forms are:
+
+- `https://media.6529.io/ipfs/<cid>/<path?>`
+- `https://media.6529.io/ipns/<name>/<path?>`
+- `https://media.6529.io/arweave/<txid>/<path?>`
+
+Implementations may allow a configurable resolver origin for local and staged environments, but production defaults to `https://media.6529.io`.
+
+## Recognized External Fallback Gateways
+
+Recognized external gateway URLs must be parsed back to native form when possible.
+
+IPFS path gateways:
+
+- `ipfs.io`
+- `cf-ipfs.com`
+- `cloudflare-ipfs.com`
+- `gateway.pinata.cloud`
+- `ipfs.6529.io`
+
+IPFS subdomain gateways:
+
+- `<cid>.ipfs.nftstorage.link`
+- `<cid>.ipfs.dweb.link`
+- `<cid>.ipfs.cf-ipfs.com`
+
+Arweave gateways:
+
+- `arweave.net`
+- `gateway.arweave.net`
+- `gateway.ar.io`
+- `ar-io.net`
+- `ardrive.net`
+
+Arweave transaction subdomains:
+
+- `<txid>.arweave.net`
+- `<txid>.ar.io`
+
+## API
+
+`POST /api/media/resolve`
+
+Request:
+
+```json
+{
+  "inputs": [
+    "ipfs://bafybeigdyrzt5sfp7udm7hu76mjts3sfb44oixwkw55rmpbc6g6wuigv3i/image.png",
+    "https://ipfs.io/ipfs/bafybeigdyrzt5sfp7udm7hu76mjts3sfb44oixwkw55rmpbc6g6wuigv3i/image.png",
+    "ar://OI6-rpJ2C3Ab4HiZRWt5A1SumhjnYigmSPBPX0ICBj8"
+  ],
+  "include_external_fallbacks": true
+}
+```
+
+Response:
+
+```json
+{
+  "items": [
+    {
+      "input": "ipfs://bafybeigdyrzt5sfp7udm7hu76mjts3sfb44oixwkw55rmpbc6g6wuigv3i/image.png",
+      "recognized": true,
+      "protocol": "ipfs",
+      "native_uri": "ipfs://bafybeigdyrzt5sfp7udm7hu76mjts3sfb44oixwkw55rmpbc6g6wuigv3i/image.png",
+      "id": "bafybeigdyrzt5sfp7udm7hu76mjts3sfb44oixwkw55rmpbc6g6wuigv3i",
+      "path": "image.png",
+      "resolver_url": "https://media.6529.io/ipfs/bafybeigdyrzt5sfp7udm7hu76mjts3sfb44oixwkw55rmpbc6g6wuigv3i/image.png",
+      "external_fallback_urls": [
+        "https://ipfs.io/ipfs/bafybeigdyrzt5sfp7udm7hu76mjts3sfb44oixwkw55rmpbc6g6wuigv3i/image.png"
+      ],
+      "warnings": []
+    }
+  ]
+}
+```
+
+Unrecognized HTTP(S) URLs return `recognized=false` and preserve `input`. Invalid URLs return an item-level warning such as `invalid_url` or `unsupported_scheme`; one invalid item must not fail the whole batch.
+
+## UX Contract
+
+Copy/share surfaces should offer:
+
+- Native URI copy: `ipfs://...`, `ipns://...`, or `ar://...`
+- Web URL copy/open: `https://media.6529.io/...`
+- External fallback copy/open only where fallback or debug UI already exists.
+
+## v1 Non-Goals
+
+- This API does not proxy media bytes.
+- No database migration is required.
+- DNS/CDN/edge provisioning for `media.6529.io` is outside this repo work.

--- a/ops/contracts/decentralized-media-resolver-v1.openapi.yaml
+++ b/ops/contracts/decentralized-media-resolver-v1.openapi.yaml
@@ -55,6 +55,7 @@ components:
       properties:
         items:
           type: array
+          maxItems: 100
           items:
             $ref: "#/components/schemas/MediaResolution"
     MediaResolution:
@@ -89,6 +90,7 @@ components:
           description: 6529 resolver URL.
         external_fallback_urls:
           type: array
+          maxItems: 50
           items:
             type: string
             format: uri

--- a/ops/contracts/decentralized-media-resolver-v1.openapi.yaml
+++ b/ops/contracts/decentralized-media-resolver-v1.openapi.yaml
@@ -1,0 +1,108 @@
+openapi: 3.0.3
+info:
+  title: 6529 Decentralized Media Resolver Contract
+  version: 1.0.0
+  description: Canonical contract for native decentralized media resolution.
+paths:
+  /api/media/resolve:
+    post:
+      operationId: resolveDecentralizedMedia
+      summary: Resolve decentralized media references
+      description: Parses native and recognized gateway URLs into native references, 6529 resolver URLs, and optional external fallback URLs.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MediaResolveRequest"
+            examples:
+              mixed:
+                value:
+                  inputs:
+                    - ipfs://bafybeigdyrzt5sfp7udm7hu76mjts3sfb44oixwkw55rmpbc6g6wuigv3i/image.png
+                    - https://ipfs.io/ipfs/bafybeigdyrzt5sfp7udm7hu76mjts3sfb44oixwkw55rmpbc6g6wuigv3i/image.png
+                    - ar://OI6-rpJ2C3Ab4HiZRWt5A1SumhjnYigmSPBPX0ICBj8
+                  include_external_fallbacks: true
+      responses:
+        "200":
+          description: Resolution results. Invalid items are represented in the item warnings array.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MediaResolveResponse"
+        "400":
+          description: Request-level validation failure, such as missing inputs.
+components:
+  schemas:
+    MediaResolveRequest:
+      type: object
+      required:
+        - inputs
+      properties:
+        inputs:
+          type: array
+          minItems: 1
+          maxItems: 100
+          items:
+            type: string
+        include_external_fallbacks:
+          type: boolean
+          default: true
+    MediaResolveResponse:
+      type: object
+      required:
+        - items
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/MediaResolution"
+    MediaResolution:
+      type: object
+      required:
+        - input
+        - recognized
+        - external_fallback_urls
+        - warnings
+      properties:
+        input:
+          type: string
+        recognized:
+          type: boolean
+        protocol:
+          $ref: "#/components/schemas/DecentralizedMediaProtocol"
+        native_uri:
+          type: string
+          description: Canonical native decentralized URI.
+          examples:
+            - ipfs://bafybeigdyrzt5sfp7udm7hu76mjts3sfb44oixwkw55rmpbc6g6wuigv3i/image.png
+            - ar://OI6-rpJ2C3Ab4HiZRWt5A1SumhjnYigmSPBPX0ICBj8
+        id:
+          type: string
+          description: CID, IPNS name, or Arweave transaction ID.
+        path:
+          type: string
+          description: Optional slash-delimited path below the id.
+        resolver_url:
+          type: string
+          format: uri
+          description: 6529 resolver URL.
+        external_fallback_urls:
+          type: array
+          items:
+            type: string
+            format: uri
+        warnings:
+          type: array
+          items:
+            type: string
+            enum:
+              - query_or_hash_stripped
+              - invalid_url
+              - unsupported_scheme
+    DecentralizedMediaProtocol:
+      type: string
+      enum:
+        - ipfs
+        - ipns
+        - arweave


### PR DESCRIPTION
## Summary

Centralizes frontend IPFS/IPNS/Arweave parsing and rendering around native decentralized URIs and the 6529 resolver layer:

- Adds FE-owned v1 contract files under `ops/contracts/`.
- Adds one central frontend resolver module for native URI parsing, 6529 resolver URL construction, and explicit external fallback URL generation.
- Defaults web rendering/copy URLs to `https://media.6529.io` while preserving native `ipfs://`, `ipns://`, and `ar://` forms where appropriate.
- Keeps `IPFS_GATEWAY_ENDPOINT` for legacy upload/MFS flows and adds optional `MEDIA_RESOLVER_ENDPOINT` defaulting to `https://media.6529.io`.
- Updates media rendering, gateway fallback behavior, Drop Forge, interactive memes, attachment metadata, OpenGraph helpers, ENS/IPNS handling, profile/banner/avatar resolution, CSP, and Next image remote patterns.
- Adds a combined FE/BE review and rollout guide at `ops/contracts/decentralized-media-resolver-review-and-rollout.md`.

## Backend Companion

Backend PR: https://github.com/6529-Collections/6529seize-backend/pull/1617

The frontend should deploy after the backend API and `media.6529.io` resolver infrastructure are verified.

## Contract Files

- `ops/contracts/decentralized-media-resolver-v1.md`
- `ops/contracts/decentralized-media-resolver-v1.openapi.yaml`
- `ops/contracts/decentralized-media-resolver-review-and-rollout.md`

## Verification

Completed locally:

- Focused Jest run passed: 15 suites / 147 tests.
- Post-build-fix focused Jest run passed: 2 suites / 26 tests.
- Changed-surface ESLint equivalent passed.
- Source TypeScript check passed: `pnpm exec tsc --noEmit -p tsconfig.typecheck.json`.
- `git diff --check` passed before commit.

Local caveats:

- The repo-local `6529` wrapper failed on this Windows worktree because the shell wrapper has CRLF/path handling issues, so guarded equivalent commands were used with `SEIZE_6529_COMMAND=1`.
- `pnpm run build` fails before app build in the `generate` step because the script uses Unix `rm`/`mv` under PowerShell.
- `pnpm run base-build` with required env values reaches Next build; Turbopack then fails resolving Bootstrap Sass imports in this Windows/pnpm setup.
- `next build --webpack` compiles, then fails existing generated Next route prop checks under `[user]` routes. That failure is not introduced by this resolver change.

## Rollout Note

Deploy backend first, then frontend web, then mobile/Electron after staging smoke tests. The detailed manual QA, monitoring, and rollback plan is in `ops/contracts/decentralized-media-resolver-review-and-rollout.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized decentralized media resolver for `ipfs://`, `ipns://`, and `ar://` (defaults to `https://media.6529.io`), with consistent normalization for previews, attachments, downloads, and images.
* **Infrastructure**
  * Updated media URL rewriting, fallback ordering, and interactive media validation; improved handling for HTTPS/CSP/image remote patterns to match the resolver.
* **Bug Fixes**
  * Ensured IPFS gateway fallback behavior consistently prefers `media.6529.io` before reverting to legacy `ipfs.io` URLs.
* **Documentation**
  * Added resolver v1 contract, rollout plan, and OpenAPI specification for media resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->