### PR TITLE
Harden NFT and NextGen HTML embeds

### DIFF
--- a/__tests__/components/common/SandboxedExternalIframe.test.tsx
+++ b/__tests__/components/common/SandboxedExternalIframe.test.tsx
@@ -64,4 +64,38 @@ describe("SandboxedExternalIframe", () => {
     expect(firstOnVisible).not.toHaveBeenCalled();
     expect(secondOnVisible).toHaveBeenCalledTimes(1);
   });
+
+  it("uses a caller-provided canonicalizer and forwards iframe options", () => {
+    render(
+      <SandboxedExternalIframe
+        id="media-frame"
+        src="https://example.com/media"
+        title="Media"
+        showBanner={false}
+        canonicalizeSrc={() => "https://canonical.example/media"}
+      />
+    );
+
+    act(() => {
+      observerCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        new MockIntersectionObserver(
+          jest.fn()
+        ) as unknown as IntersectionObserver
+      );
+    });
+
+    const iframe = document.querySelector("iframe");
+    expect(iframe).toHaveAttribute("id", "media-frame");
+    expect(iframe).toHaveAttribute("src", "https://canonical.example/media");
+    expect(iframe).toHaveAttribute(
+      "title",
+      "Media: https://canonical.example/media"
+    );
+    expect(iframe).toHaveAttribute("sandbox", "allow-scripts");
+    expect(iframe).toHaveAttribute("referrerpolicy", "no-referrer");
+    expect(document.body).not.toHaveTextContent(
+      "Untrusted interactive content"
+    );
+  });
 });

--- a/__tests__/components/common/sandboxed-external-iframe.helpers.test.ts
+++ b/__tests__/components/common/sandboxed-external-iframe.helpers.test.ts
@@ -58,30 +58,34 @@ describe("sandboxed external iframe URL helpers", () => {
   });
 
   it("opens canonical URLs with opener and referrer protections", () => {
-    const originalOpen = window.open;
-    const open = jest.fn();
-    window.open = open;
+    const openSpy = jest
+      .spyOn(globalThis.window, "open")
+      .mockImplementation(() => null);
 
-    openExternalMetadataUrl(" https://EXAMPLE.com/media/index.html ");
+    try {
+      openExternalMetadataUrl(" https://EXAMPLE.com/media/index.html ");
 
-    expect(open).toHaveBeenCalledWith(
-      "https://example.com/media/index.html",
-      "_blank",
-      "noopener,noreferrer"
-    );
-
-    window.open = originalOpen;
+      expect(openSpy).toHaveBeenCalledWith(
+        "https://example.com/media/index.html",
+        "_blank",
+        "noopener,noreferrer"
+      );
+    } finally {
+      openSpy.mockRestore();
+    }
   });
 
   it("does not open invalid URLs", () => {
-    const originalOpen = window.open;
-    const open = jest.fn();
-    window.open = open;
+    const openSpy = jest
+      .spyOn(globalThis.window, "open")
+      .mockImplementation(() => null);
 
-    openExternalMetadataUrl("javascript:alert(1)");
+    try {
+      openExternalMetadataUrl("javascript:alert(1)");
 
-    expect(open).not.toHaveBeenCalled();
-
-    window.open = originalOpen;
+      expect(openSpy).not.toHaveBeenCalled();
+    } finally {
+      openSpy.mockRestore();
+    }
   });
 });

--- a/__tests__/components/common/sandboxed-external-iframe.helpers.test.ts
+++ b/__tests__/components/common/sandboxed-external-iframe.helpers.test.ts
@@ -1,0 +1,87 @@
+import {
+  canonicalizeExternalMetadataHtmlUrl,
+  canonicalizeExternalMetadataUrl,
+  openExternalMetadataUrl,
+} from "@/components/common/sandboxed-external-iframe.helpers";
+
+const CID_V0 = "QmULf712pVAVBPDBenmE4PGQGA8EWY9uFRiiRmLksfu6Tn";
+
+jest.mock("@/lib/media/ipfs-gateways", () => ({
+  getConfiguredIpfsGatewayHost: () => "ipfs.6529.io",
+}));
+
+jest.mock("@/lib/media/arweave-gateways", () => ({
+  canonicalizeArweaveGatewayHostname: (hostname: string) =>
+    hostname.toLowerCase(),
+  isArweaveGatewayRuntimeHost: (hostname: string) =>
+    ["arweave.net", "ardrive.net", "gateway.arweave.net"].includes(
+      hostname.toLowerCase()
+    ),
+}));
+
+describe("sandboxed external iframe URL helpers", () => {
+  it("canonicalizes HTTPS metadata URLs", () => {
+    expect(
+      canonicalizeExternalMetadataUrl(
+        " https://EXAMPLE.com/media/index.html?seed=1 "
+      )
+    ).toBe("https://example.com/media/index.html?seed=1");
+  });
+
+  it("rejects unsafe external metadata URLs", () => {
+    expect(canonicalizeExternalMetadataUrl("")).toBeNull();
+    expect(canonicalizeExternalMetadataUrl("http://example.com")).toBeNull();
+    expect(canonicalizeExternalMetadataUrl("javascript:alert(1)")).toBeNull();
+    expect(
+      canonicalizeExternalMetadataUrl("https://user:pass@example.com")
+    ).toBeNull();
+    expect(
+      canonicalizeExternalMetadataUrl("https://example.com:444/index.html")
+    ).toBeNull();
+    expect(
+      canonicalizeExternalMetadataUrl("https://example.com/index.html#hash")
+    ).toBeNull();
+  });
+
+  it("keeps strict IPFS and Arweave validation for HTML embeds", () => {
+    expect(
+      canonicalizeExternalMetadataHtmlUrl(
+        `https://ipfs.io/ipfs/${CID_V0}/animation.html?seed=1`
+      )
+    ).toBe(`https://ipfs.io/ipfs/${CID_V0}/animation.html?seed=1`);
+
+    expect(
+      canonicalizeExternalMetadataHtmlUrl(
+        `https://ipfs.io/ipfs/${CID_V0}/image.png`
+      )
+    ).toBeNull();
+  });
+
+  it("opens canonical URLs with opener and referrer protections", () => {
+    const originalOpen = window.open;
+    const open = jest.fn();
+    window.open = open;
+
+    openExternalMetadataUrl(" https://EXAMPLE.com/media/index.html ");
+
+    expect(open).toHaveBeenCalledWith(
+      "https://example.com/media/index.html",
+      "_blank",
+      "noopener,noreferrer"
+    );
+
+    window.open = originalOpen;
+  });
+
+  it("does not open invalid URLs", () => {
+    const originalOpen = window.open;
+    const open = jest.fn();
+    window.open = open;
+
+    openExternalMetadataUrl("javascript:alert(1)");
+
+    expect(open).not.toHaveBeenCalled();
+
+    window.open = originalOpen;
+  });
+});

--- a/__tests__/components/nextGen/NextGenTokenImage.test.tsx
+++ b/__tests__/components/nextGen/NextGenTokenImage.test.tsx
@@ -10,6 +10,30 @@ jest.mock("@/hooks/isMobileScreen", () => ({
   default: () => false,
 }));
 
+jest.mock("@/components/common/SandboxedExternalIframe", () => ({
+  __esModule: true,
+  default: function MockSandboxedExternalIframe({
+    canonicalizeSrc,
+    fallback,
+    src,
+    title,
+  }: any) {
+    const canonicalSrc = canonicalizeSrc ? canonicalizeSrc(src) : src;
+
+    if (!canonicalSrc) {
+      return fallback ? <>{fallback}</> : null;
+    }
+
+    return (
+      <iframe
+        data-testid="sandboxed-external-iframe"
+        src={canonicalSrc}
+        title={title}
+      />
+    );
+  },
+}));
+
 jest.mock("@/components/user/utils/UserCICAndLevel", () => ({
   __esModule: true,
   UserCICAndLevelSize: {
@@ -79,23 +103,36 @@ test("renders thumbnail image within link by default", () => {
 });
 
 test("renders iframe when animation shown and link hidden", () => {
-  const tokenWithAnimation = { ...token, animation_url: "anim.html" };
+  const tokenWithAnimation = {
+    ...token,
+    animation_url: "https://generator.6529.io/mainnet/html/1",
+  };
   render(
     <NextGenTokenImage token={tokenWithAnimation} show_animation hide_link />
   );
   const frame = screen.getByTitle("token");
   expect(frame).toBeInTheDocument();
-  expect(frame).toHaveAttribute("src", "anim.html");
+  expect(frame).toHaveAttribute(
+    "src",
+    "https://generator.6529.io/mainnet/html/1"
+  );
+  expect(frame).toHaveAttribute("data-testid", "sandboxed-external-iframe");
 });
 
 test("renders iframe within link when animation shown and link not hidden", () => {
-  const tokenWithAnimation = { ...token, animation_url: "anim.html" };
+  const tokenWithAnimation = {
+    ...token,
+    animation_url: "https://generator.6529.io/mainnet/html/1",
+  };
   render(<NextGenTokenImage token={tokenWithAnimation} show_animation />);
   const link = screen.getByRole("link");
   const frame = screen.getByTitle("token");
   expect(link).toBeInTheDocument();
   expect(frame).toBeInTheDocument();
-  expect(frame).toHaveAttribute("src", "anim.html");
+  expect(frame).toHaveAttribute(
+    "src",
+    "https://generator.6529.io/mainnet/html/1"
+  );
   expect(link).toContainElement(frame);
 });
 
@@ -284,17 +321,39 @@ test("renders owner info without normalised_handle", () => {
 });
 
 test("renders animation iframe when animation_url is available", () => {
-  const tokenWithAnimation = { ...token, animation_url: "anim.html" };
+  const tokenWithAnimation = {
+    ...token,
+    animation_url: "https://generator.6529.io/mainnet/html/1",
+  };
   render(
     <NextGenTokenImage token={tokenWithAnimation} show_animation hide_link />
   );
 
   const frame = screen.getByTitle("token");
-  expect(frame).toHaveAttribute("src", "anim.html");
+  expect(frame).toHaveAttribute(
+    "src",
+    "https://generator.6529.io/mainnet/html/1"
+  );
+});
+
+test("falls back to the image for unsafe animation URLs", () => {
+  const tokenWithAnimation = {
+    ...token,
+    animation_url: "javascript:alert(1)",
+  };
+  render(
+    <NextGenTokenImage token={tokenWithAnimation} show_animation hide_link />
+  );
+
+  expect(screen.queryByTitle("token")).not.toBeInTheDocument();
+  expect(screen.getByAltText("token")).toHaveAttribute("src", "thumb.png");
 });
 
 test("renders image when show_animation is false", () => {
-  const tokenWithAnimation = { ...token, animation_url: "anim.html" };
+  const tokenWithAnimation = {
+    ...token,
+    animation_url: "https://generator.6529.io/mainnet/html/1",
+  };
   render(
     <NextGenTokenImage
       token={tokenWithAnimation}

--- a/__tests__/components/nextGen/collections/nextgenToken/NextGenTokenArt.test.tsx
+++ b/__tests__/components/nextGen/collections/nextgenToken/NextGenTokenArt.test.tsx
@@ -1,95 +1,141 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import NextGenTokenArt from '@/components/nextGen/collections/nextgenToken/NextGenTokenArt';
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import NextGenTokenArt from "@/components/nextGen/collections/nextgenToken/NextGenTokenArt";
 
-jest.mock('react-bootstrap', () => {
-  const React = require('react');
+jest.mock("react-bootstrap", () => {
+  const React = require("react");
   const RB: any = {
-    Container: (p:any)=> <div {...p} />,
-    Row: (p:any)=> <div {...p} />,
-    Col: (p:any)=> <div {...p} />,
+    Container: (p: any) => <div {...p} />,
+    Row: (p: any) => <div {...p} />,
+    Col: (p: any) => <div {...p} />,
   };
-  const Dropdown: any = (p:any)=> <div {...p}/>;
-  Dropdown.Toggle = (p:any)=> <button {...p}/>;
-  Dropdown.Menu = (p:any)=> <div {...p}/>;
+  const Dropdown: any = (p: any) => <div {...p} />;
+  Dropdown.Toggle = (p: any) => <button {...p} />;
+  Dropdown.Menu = (p: any) => <div {...p} />;
   RB.Dropdown = Dropdown;
   return RB;
 });
 
-jest.mock('@/components/nextGen/collections/nextgenToken/NextGenTokenImage', () => ({
-  NextGenTokenImage: ({ onClick }: any) => (
-    <img data-testid="token-image" onClick={onClick} />
-  ),
-  get16KUrl: jest.fn((id:number)=>`https://test/16k/${id}`),
-  get8KUrl: jest.fn((id:number)=>`https://test/8k/${id}`)
-}));
+jest.mock(
+  "@/components/nextGen/collections/nextgenToken/NextGenTokenImage",
+  () => ({
+    NextGenTokenImage: ({ onClick }: any) => (
+      <img data-testid="token-image" onClick={onClick} />
+    ),
+    get16KUrl: jest.fn((id: number) => `https://test/16k/${id}`),
+    get8KUrl: jest.fn((id: number) => `https://test/8k/${id}`),
+  })
+);
 
-jest.mock('@/components/nextGen/collections/nextgenToken/NextGenZoomableImage', () => ({
+jest.mock(
+  "@/components/nextGen/collections/nextgenToken/NextGenZoomableImage",
+  () => ({
+    __esModule: true,
+    default: (props: any) => {
+      const React = require("react");
+      React.useEffect(() => {
+        props.onImageLoaded();
+      }, []);
+      return <img data-testid="zoom" />;
+    },
+  })
+);
+
+jest.mock(
+  "@/components/nextGen/collections/nextgenToken/Lightbulb",
+  () => (props: any) => (
+    <span data-testid={`light-${props.mode}`} onClick={props.onClick} />
+  )
+);
+
+jest.mock(
+  "@/components/nextGen/collections/nextgenToken/NextGenTokenDownload",
+  () => ({
+    NextGenTokenDownloadDropdownItem: (props: any) => (
+      <div data-testid={`download-${props.resolution}`} />
+    ),
+    Resolution: {
+      "0.5K": "0.5K",
+      Thumbnail: "Thumbnail",
+      "2K": "2K",
+      "16K": "16K",
+    },
+  })
+);
+
+jest.mock("@/hooks/isMobileDevice", () => ({
   __esModule: true,
-  default: (props:any) => {
-    const React = require('react');
-    React.useEffect(()=>{ props.onImageLoaded(); },[]);
-    return <img data-testid="zoom" />;
-  }
+  default: jest.fn(() => false),
+}));
+jest.mock("@/hooks/isMobileScreen", () => ({
+  __esModule: true,
+  default: jest.fn(() => false),
 }));
 
-jest.mock('@/components/nextGen/collections/nextgenToken/Lightbulb', () => (props:any) => <span data-testid={`light-${props.mode}`} onClick={props.onClick}/>);
-
-jest.mock('@/components/nextGen/collections/nextgenToken/NextGenTokenDownload', () => ({
-  NextGenTokenDownloadDropdownItem: (props:any) => <div data-testid={`download-${props.resolution}`}/>,
-  Resolution: { '0.5K':'0.5K', Thumbnail:'Thumbnail', '2K':'2K', '16K':'16K' }
+jest.mock("@fortawesome/react-fontawesome", () => ({
+  FontAwesomeIcon: (props: any) => (
+    <svg data-testid={props.icon.iconName} onClick={props.onClick} />
+  ),
 }));
 
-jest.mock('@/hooks/isMobileDevice', () => ({ __esModule: true, default: jest.fn(()=>false) }));
-jest.mock('@/hooks/isMobileScreen', () => ({ __esModule: true, default: jest.fn(()=>false) }));
-
-jest.mock('@fortawesome/react-fontawesome', () => ({
-  FontAwesomeIcon: (props:any) => <svg data-testid={props.icon.iconName} onClick={props.onClick} />
-}));
-
-const token = { id:7, image_url:'img', animation_url:'anim' } as any;
+const token = {
+  id: 7,
+  image_url: "https://media.generator.6529.io/mainnet/png/7",
+  animation_url: "https://generator.6529.io/mainnet/html/7",
+} as any;
 const collection = {} as any;
 
-function renderComponent(){
-  return render(<NextGenTokenArt token={token} collection={collection}/>);
+function renderComponent() {
+  return render(<NextGenTokenArt token={token} collection={collection} />);
 }
 
-describe('NextGenTokenArt', () => {
-  beforeEach(()=> jest.clearAllMocks());
+describe("NextGenTokenArt", () => {
+  beforeEach(() => jest.clearAllMocks());
 
-  it('opens image link by default', async () => {
+  it("opens image link by default", async () => {
     const open = jest.fn();
     const orig = window.open;
     // @ts-ignore
     window.open = open;
     renderComponent();
-    await userEvent.click(screen.getByTestId('arrow-up-right-from-square'));
-    expect(open).toHaveBeenCalledWith('img', '_blank');
+    await userEvent.click(screen.getByTestId("arrow-up-right-from-square"));
+    expect(open).toHaveBeenCalledWith(
+      "https://media.generator.6529.io/mainnet/png/7",
+      "_blank",
+      "noopener,noreferrer"
+    );
     window.open = orig;
   });
 
-  it('opens high res link and adjusts zoom', async () => {
+  it("opens high res link and adjusts zoom", async () => {
     const open = jest.fn();
     // @ts-ignore
     window.open = open;
     renderComponent();
-    await userEvent.click(screen.getByText('16K'));
-    await screen.findByTestId('zoom');
-    await userEvent.click(screen.getByTestId('arrow-up-right-from-square'));
-    expect(open).toHaveBeenCalledWith('https://test/16k/7', '_blank');
+    await userEvent.click(screen.getByText("16K"));
+    await screen.findByTestId("zoom");
+    await userEvent.click(screen.getByTestId("arrow-up-right-from-square"));
+    expect(open).toHaveBeenCalledWith(
+      "https://test/16k/7",
+      "_blank",
+      "noopener,noreferrer"
+    );
     window.open = undefined as any;
   });
 
-  it('opens animation link when live mode selected', async () => {
+  it("opens animation link when live mode selected", async () => {
     const open = jest.fn();
     // @ts-ignore
     window.open = open;
     renderComponent();
-    await userEvent.click(screen.getByTestId('circle-play'));
-    await userEvent.click(screen.getByTestId('arrow-up-right-from-square'));
-    expect(open).toHaveBeenCalledWith('anim', '_blank');
+    await userEvent.click(screen.getByTestId("circle-play"));
+    await userEvent.click(screen.getByTestId("arrow-up-right-from-square"));
+    expect(open).toHaveBeenCalledWith(
+      "https://generator.6529.io/mainnet/html/7",
+      "_blank",
+      "noopener,noreferrer"
+    );
     window.open = undefined as any;
   });
 });
-

--- a/__tests__/components/nextGen/collections/nextgenToken/NextGenTokenArt.test.tsx
+++ b/__tests__/components/nextGen/collections/nextgenToken/NextGenTokenArt.test.tsx
@@ -30,22 +30,26 @@ jest.mock(
 
 jest.mock(
   "@/components/nextGen/collections/nextgenToken/NextGenZoomableImage",
-  () => ({
-    __esModule: true,
-    default: (props: any) => {
+  () => {
+    function MockNextGenZoomableImage(props: any) {
       const React = require("react");
       React.useEffect(() => {
         props.onImageLoaded();
       }, []);
       return <img data-testid="zoom" />;
-    },
-  })
+    }
+
+    return {
+      __esModule: true,
+      default: MockNextGenZoomableImage,
+    };
+  }
 );
 
 jest.mock(
   "@/components/nextGen/collections/nextgenToken/Lightbulb",
   () => (props: any) => (
-    <span data-testid={`light-${props.mode}`} onClick={props.onClick} />
+    <button data-testid={`light-${props.mode}`} onClick={props.onClick} />
   )
 );
 

--- a/__tests__/components/nextGen/collections/nextgenToken/NextGenTokenDownload.test.tsx
+++ b/__tests__/components/nextGen/collections/nextgenToken/NextGenTokenDownload.test.tsx
@@ -106,7 +106,11 @@ it("opens link and downloads via button in main component", async () => {
   );
 
   await userEvent.click(icon!);
-  expect(open).toHaveBeenCalledWith("https://img.com/png4k/file.png", "_blank");
+  expect(open).toHaveBeenCalledWith(
+    "https://img.com/png4k/file.png",
+    "_blank",
+    "noopener,noreferrer"
+  );
 
   const download = container.querySelector(
     `[data-tooltip-id="download-${token.id}-${Resolution["4K"]}"]`

--- a/__tests__/components/nextGen/collections/nextgenToken/NextGenTokenRenderCenter.test.tsx
+++ b/__tests__/components/nextGen/collections/nextgenToken/NextGenTokenRenderCenter.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import NextGenTokenRenderCenter from '@/components/nextGen/collections/nextgenToken/NextGenTokenRenderCenter';
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import NextGenTokenRenderCenter from "@/components/nextGen/collections/nextgenToken/NextGenTokenRenderCenter";
 
-jest.mock('react-bootstrap', () => {
-  const React = require('react');
+jest.mock("react-bootstrap", () => {
+  const React = require("react");
   const RB: any = {
     Container: (p: any) => <div {...p} />,
     Row: (p: any) => <div {...p} />,
@@ -17,15 +17,30 @@ jest.mock('react-bootstrap', () => {
   return RB;
 });
 
-jest.mock('@/components/nextGen/collections/nextgenToken/NextGenTokenDownload', () => ({
-  __esModule: true,
-  default: () => <div data-testid="download" />,
-  Resolution: { '1K':'1K','2K':'2K','4K':'4K','8K':'8K','16K':'16K','0.5K':'0.5K', Thumbnail:'Thumbnail' }
+jest.mock(
+  "@/components/nextGen/collections/nextgenToken/NextGenTokenDownload",
+  () => ({
+    __esModule: true,
+    default: () => <div data-testid="download" />,
+    Resolution: {
+      "1K": "1K",
+      "2K": "2K",
+      "4K": "4K",
+      "8K": "8K",
+      "16K": "16K",
+      "0.5K": "0.5K",
+      Thumbnail: "Thumbnail",
+    },
+  })
+);
+
+jest.mock("@/helpers/AllowlistToolHelpers", () => ({
+  getRandomObjectId: () => "id",
 }));
 
-jest.mock('@/helpers/AllowlistToolHelpers', () => ({ getRandomObjectId: () => 'id' }));
-
-jest.mock('@/helpers/Helpers', () => ({ numberWithCommas: (n:number) => n.toString() }));
+jest.mock("@/helpers/Helpers", () => ({
+  numberWithCommas: (n: number) => n.toString(),
+}));
 
 const token = { id: 42 } as any;
 
@@ -33,31 +48,36 @@ function setup() {
   return render(<NextGenTokenRenderCenter token={token} />);
 }
 
-describe('NextGenTokenRenderCenter', () => {
-  it('opens generator with default options', async () => {
+describe("NextGenTokenRenderCenter", () => {
+  it("opens generator with default options", async () => {
     const open = jest.fn();
     const orig = window.open;
     // @ts-ignore
     window.open = open;
     setup();
-    await userEvent.click(screen.getByText('GO!'));
-    expect(open).toHaveBeenCalledWith('https://generator.6529.io/mainnet/html/42', '_blank');
+    await userEvent.click(screen.getByText("GO!"));
+    expect(open).toHaveBeenCalledWith(
+      "https://generator.6529.io/mainnet/html/42",
+      "_blank",
+      "noopener,noreferrer"
+    );
     window.open = orig;
   });
 
-  it('passes selected options to generator url', async () => {
+  it("passes selected options to generator url", async () => {
     const open = jest.fn();
     // @ts-ignore
     window.open = open;
     setup();
-    await userEvent.click(screen.getByText('Static'));
-    await userEvent.click(screen.getByText('OG'));
-    const input = screen.getByPlaceholderText('enter height');
-    await userEvent.type(input, '400');
-    await userEvent.click(screen.getByText('GO!'));
+    await userEvent.click(screen.getByText("Static"));
+    await userEvent.click(screen.getByText("OG"));
+    const input = screen.getByPlaceholderText("enter height");
+    await userEvent.type(input, "400");
+    await userEvent.click(screen.getByText("GO!"));
     expect(open).toHaveBeenCalledWith(
-      'https://generator.6529.io/mainnet/html/42?render_static=true&render_og=true&height=400',
-      '_blank'
+      "https://generator.6529.io/mainnet/html/42?render_static=true&render_og=true&height=400",
+      "_blank",
+      "noopener,noreferrer"
     );
     window.open = undefined as any;
   });

--- a/__tests__/components/nft-image/renderers/NFTHTMLRenderer.test.tsx
+++ b/__tests__/components/nft-image/renderers/NFTHTMLRenderer.test.tsx
@@ -25,6 +25,35 @@ jest.mock("@/components/nft-image/NFTImageBalance", () => {
   };
 });
 
+jest.mock("@/components/common/SandboxedExternalIframe", () => {
+  return function MockSandboxedExternalIframe({
+    canonicalizeSrc,
+    fallback,
+    id,
+    onError,
+    onLoad,
+    src,
+    title,
+  }: any) {
+    const canonicalSrc = canonicalizeSrc ? canonicalizeSrc(src) : src;
+
+    if (!canonicalSrc) {
+      return fallback ? <>{fallback}</> : null;
+    }
+
+    return (
+      <iframe
+        data-testid="sandboxed-external-iframe"
+        id={id}
+        onError={onError}
+        onLoad={onLoad}
+        src={canonicalSrc}
+        title={title}
+      />
+    );
+  };
+});
+
 const createMockNFT = (overrides: Partial<BaseNFT> = {}): BaseNFT =>
   ({
     id: 1,
@@ -203,9 +232,7 @@ describe("NFTHTMLRenderer", () => {
         render(<NFTHTMLRenderer {...props} />);
       }).not.toThrow();
 
-      const iframe = screen.getByTitle("test-iframe");
-      // When both are undefined, src becomes undefined and React removes the attribute
-      expect(iframe).not.toHaveAttribute("src");
+      expect(screen.queryByTitle("test-iframe")).not.toBeInTheDocument();
     });
 
     it("handles null animation sources gracefully", () => {
@@ -222,9 +249,7 @@ describe("NFTHTMLRenderer", () => {
         render(<NFTHTMLRenderer {...props} />);
       }).not.toThrow();
 
-      const iframe = screen.getByTitle("test-iframe");
-      // When both are null, src becomes null and React removes the attribute
-      expect(iframe).not.toHaveAttribute("src");
+      expect(screen.queryByTitle("test-iframe")).not.toBeInTheDocument();
     });
   });
 
@@ -241,7 +266,6 @@ describe("NFTHTMLRenderer", () => {
       const props = createDefaultProps();
       render(<NFTHTMLRenderer {...props} />);
 
-      // When no id is provided, title will be undefined
       const iframe = document.querySelector("iframe");
       expect(iframe).toBeInTheDocument();
       expect(iframe).toHaveAttribute("id", "iframe-1");
@@ -266,7 +290,7 @@ describe("NFTHTMLRenderer", () => {
 
       const iframe = document.querySelector("iframe");
       expect(iframe).toBeInTheDocument();
-      expect(iframe).not.toHaveAttribute("title");
+      expect(iframe).toHaveAttribute("title", "Test NFT");
     });
   });
 
@@ -310,32 +334,29 @@ describe("NFTHTMLRenderer", () => {
   });
 
   describe("Edge Cases and Error Handling", () => {
-    it("crashes when metadata is undefined (IMPLEMENTATION BUG)", () => {
+    it("handles undefined metadata gracefully", () => {
       const nft = createMockNFT({
-        ...(undefined !== undefined ? { metadata: undefined } : {}),
+        animation: undefined as any,
+        metadata: undefined as any,
       });
-      const props = createDefaultProps({ nft, id: "test-iframe" });
-
-      // The getSrc function has a bug - it checks "metadata" in nft but doesn't check if metadata is null/undefined
-      // Line 10: const hasAnimation = hasMetadata && nft.metadata.animation;
-      // This will crash when nft.metadata is undefined despite hasMetadata being true
-      expect(() => {
-        render(<NFTHTMLRenderer {...props} />);
-      }).toThrow("Cannot read properties of undefined (reading 'animation')");
-    });
-
-    it("handles empty metadata object gracefully", () => {
-      const nft = createMockNFT({ metadata: {} });
       const props = createDefaultProps({ nft, id: "test-iframe" });
 
       expect(() => {
         render(<NFTHTMLRenderer {...props} />);
       }).not.toThrow();
 
-      const iframe = screen.getByTitle("test-iframe");
-      expect(iframe).toBeInTheDocument();
-      // Empty metadata means animation_url is undefined, so no src attribute
-      expect(iframe).not.toHaveAttribute("src");
+      expect(screen.queryByTitle("test-iframe")).not.toBeInTheDocument();
+    });
+
+    it("handles empty metadata object gracefully", () => {
+      const nft = createMockNFT({ animation: undefined as any, metadata: {} });
+      const props = createDefaultProps({ nft, id: "test-iframe" });
+
+      expect(() => {
+        render(<NFTHTMLRenderer {...props} />);
+      }).not.toThrow();
+
+      expect(screen.queryByTitle("test-iframe")).not.toBeInTheDocument();
     });
 
     it("handles minimal NFT properties", () => {
@@ -394,12 +415,11 @@ describe("NFTHTMLRenderer", () => {
   });
 
   describe("Security Considerations", () => {
-    it("does not sanitize iframe src but passes it through as-is", () => {
-      // Note: In a real application, iframe src should be validated/sanitized
-      // This test documents current behavior
+    it("renders canonicalized HTTPS metadata URLs in a sandboxed iframe", () => {
       const nft = createMockNFT({
+        animation: "",
         metadata: {
-          animation: "https://untrusted-domain.com/content.html",
+          animation: " https://UNTRUSTED-DOMAIN.com/content.html ",
         },
       });
       const props = createDefaultProps({ nft, id: "test-iframe" });
@@ -407,24 +427,26 @@ describe("NFTHTMLRenderer", () => {
 
       const iframe = screen.getByTitle("test-iframe");
       expect(iframe).toHaveAttribute(
+        "data-testid",
+        "sandboxed-external-iframe"
+      );
+      expect(iframe).toHaveAttribute(
         "src",
         "https://untrusted-domain.com/content.html"
       );
     });
 
-    it("handles potentially malicious URLs but some crash in test environment", () => {
-      const safeUrls = [
+    it("rejects unsafe iframe metadata URLs", () => {
+      const unsafeUrls = [
         'data:text/html,<script>alert("xss")</script>',
         "file:///etc/passwd",
         "ftp://malicious.com/file",
-      ];
-      const crashingUrls = [
-        'javascript:alert("xss")', // JSDOM crashes on javascript: URLs
+        'javascript:alert("xss")',
       ];
 
-      // Test safe URLs that don't crash JSDOM
-      safeUrls.forEach((url, index) => {
+      unsafeUrls.forEach((url, index) => {
         const nft = createMockNFT({
+          animation: "",
           metadata: {
             animation: url,
           },
@@ -438,37 +460,17 @@ describe("NFTHTMLRenderer", () => {
           render(<NFTHTMLRenderer {...props} />);
         }).not.toThrow();
 
-        const iframe = screen.getByTitle(`test-iframe-safe-${index}`);
-        expect(iframe).toHaveAttribute("src", url);
+        expect(
+          screen.queryByTitle(`test-iframe-safe-${index}`)
+        ).not.toBeInTheDocument();
       });
-
-      // Document that javascript: URLs cause issues in test environment
-      // React itself doesn't block these at render time, but JSDOM throws an error
-      // when the iframe tries to load the javascript: URL
-      const nft = createMockNFT({
-        metadata: {
-          animation: 'javascript:alert("xss")',
-        },
-      });
-      const props = createDefaultProps({ nft, id: "test-iframe-js" });
-
-      // The component renders successfully but the iframe src causes JSDOM to error
-      expect(() => {
-        render(<NFTHTMLRenderer {...props} />);
-      }).not.toThrow();
-
-      // React actually transforms javascript: URLs to throw an error instead
-      const iframe = screen.getByTitle("test-iframe-js");
-      expect(iframe).toHaveAttribute(
-        "src",
-        "javascript:throw new Error('React has blocked a javascript: URL as a security precaution.')"
-      );
     });
 
     it("handles empty string URLs correctly", () => {
       const baseNft = createMockNFT();
       const nft = {
         ...baseNft,
+        animation: "",
         metadata: {
           ...baseNft.metadata,
           animation: "", // Empty string is falsy, so will use animation_url
@@ -481,9 +483,7 @@ describe("NFTHTMLRenderer", () => {
         render(<NFTHTMLRenderer {...props} />);
       }).not.toThrow();
 
-      const iframe = screen.getByTitle("test-iframe");
-      // React/DOM removes empty src attributes for security
-      expect(iframe).not.toHaveAttribute("src");
+      expect(screen.queryByTitle("test-iframe")).not.toBeInTheDocument();
     });
   });
 
@@ -532,7 +532,7 @@ describe("NFTHTMLRenderer", () => {
       const iframe = document.querySelector("iframe");
       expect(iframe).toBeInTheDocument();
       expect(iframe).toHaveAttribute("id", "iframe-1");
-      expect(iframe).not.toHaveAttribute("title");
+      expect(iframe).toHaveAttribute("title", "Test HTML NFT");
 
       // Since showBalance is false, balance element should not exist
       expect(screen.queryByTestId("nft-image-balance")).not.toBeInTheDocument();
@@ -542,6 +542,7 @@ describe("NFTHTMLRenderer", () => {
   describe("Animation Source Priority Logic", () => {
     it("prioritizes metadata.animation over animation_url when both exist", () => {
       const nft = createMockNFT({
+        animation: "",
         metadata: {
           animation: "https://priority.com/animation.html",
           animation_url: "https://fallback.com/animation.html",
@@ -562,6 +563,7 @@ describe("NFTHTMLRenderer", () => {
 
       falsyValues.forEach((falsyValue, index) => {
         const nft = createMockNFT({
+          animation: "",
           metadata: {
             animation: falsyValue,
             animation_url: "https://fallback.com/animation.html",
@@ -581,6 +583,7 @@ describe("NFTHTMLRenderer", () => {
 
     it("handles NFTLite type correctly (no metadata property check)", () => {
       const nftLite = createMockNFTLite({
+        animation: "",
         metadata: {
           animation_url: "https://nftlite.com/animation.html",
         },

--- a/components/common/SandboxedExternalIframe.tsx
+++ b/components/common/SandboxedExternalIframe.tsx
@@ -11,9 +11,14 @@ const DEFAULT_SANDBOX = "allow-scripts";
 interface SandboxedExternalIframeProps {
   readonly src: string;
   readonly title: string;
+  readonly id?: string | undefined;
   readonly className?: string | undefined;
+  readonly style?: React.CSSProperties | undefined;
   readonly fallback?: React.ReactNode | undefined;
   readonly containerClassName?: string | undefined;
+  readonly containerStyle?: React.CSSProperties | undefined;
+  readonly showBanner?: boolean | undefined;
+  readonly canonicalizeSrc?: ((src: string) => string | null) | undefined;
   readonly onLoad?:
     | React.IframeHTMLAttributes<HTMLIFrameElement>["onLoad"]
     | undefined;
@@ -37,9 +42,14 @@ interface SandboxedExternalIframeProps {
 const SandboxedExternalIframe: React.FC<SandboxedExternalIframeProps> = ({
   src,
   title,
+  id,
   className,
+  style,
   fallback = null,
   containerClassName,
+  containerStyle,
+  showBanner = true,
+  canonicalizeSrc = canonicalizeInteractiveMediaUrl,
   onLoad,
   onError,
   iframeRef,
@@ -49,8 +59,8 @@ const SandboxedExternalIframe: React.FC<SandboxedExternalIframeProps> = ({
   const [isVisible, setIsVisible] = useState(false);
 
   const canonicalSrc = useMemo(
-    () => canonicalizeInteractiveMediaUrl(src),
-    [src]
+    () => canonicalizeSrc(src),
+    [canonicalizeSrc, src]
   );
 
   const frameClassName = useMemo(() => {
@@ -140,9 +150,10 @@ const SandboxedExternalIframe: React.FC<SandboxedExternalIframeProps> = ({
     baseProps.fetchPriority = "low";
     baseProps.credentialless = "";
     baseProps.className = frameClassName;
+    baseProps.style = style;
 
     return baseProps;
-  }, [canonicalSrc, frameClassName]);
+  }, [canonicalSrc, frameClassName, style]);
 
   if (!canonicalSrc || !iframeProps) {
     return fallback ? <>{fallback}</> : null;
@@ -185,12 +196,13 @@ const SandboxedExternalIframe: React.FC<SandboxedExternalIframeProps> = ({
     .join(" ");
 
   return (
-    <div ref={containerRef} className={containerClasses}>
-      {banner}
+    <div ref={containerRef} className={containerClasses} style={containerStyle}>
+      {showBanner ? banner : null}
       <div className="tw-min-h-0 tw-flex-1 tw-overflow-hidden">
         {isVisible ? (
           <iframe
             {...iframeProps}
+            id={id}
             ref={iframeRef}
             title={iframeTitle}
             onLoad={onLoad}

--- a/components/common/sandboxed-external-iframe.helpers.ts
+++ b/components/common/sandboxed-external-iframe.helpers.ts
@@ -49,10 +49,16 @@ function parseHttpsMetadataUrl(src: string): URL | null {
   return parsedUrl;
 }
 
+/**
+ * Canonicalize metadata-provided external URLs before opening them in a new tab.
+ */
 export function canonicalizeExternalMetadataUrl(src: string): string | null {
   return parseHttpsMetadataUrl(src)?.toString() ?? null;
 }
 
+/**
+ * Canonicalize HTML embed URLs while preserving stricter IPFS and Arweave media rules.
+ */
 export function canonicalizeExternalMetadataHtmlUrl(
   src: string
 ): string | null {
@@ -69,6 +75,9 @@ export function canonicalizeExternalMetadataHtmlUrl(
   return parsedUrl.toString();
 }
 
+/**
+ * Open canonical metadata URLs without granting opener or referrer access.
+ */
 export function openExternalMetadataUrl(src: string | null | undefined): void {
   if (!src) {
     return;

--- a/components/common/sandboxed-external-iframe.helpers.ts
+++ b/components/common/sandboxed-external-iframe.helpers.ts
@@ -1,0 +1,84 @@
+import {
+  canonicalizeInteractiveMediaHostname,
+  canonicalizeInteractiveMediaUrl,
+  isInteractiveMediaAllowedHost,
+} from "@/components/waves/memes/submission/constants/security";
+
+const SAFE_EXTERNAL_PROTOCOL = "https:";
+const SAFE_EXTERNAL_OPEN_FEATURES = "noopener,noreferrer";
+
+function parseHttpsMetadataUrl(src: string): URL | null {
+  const trimmedSrc = src.trim();
+
+  if (!trimmedSrc) {
+    return null;
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(trimmedSrc);
+  } catch {
+    return null;
+  }
+
+  if (parsedUrl.protocol !== SAFE_EXTERNAL_PROTOCOL) {
+    return null;
+  }
+
+  if (parsedUrl.username || parsedUrl.password || parsedUrl.hash) {
+    return null;
+  }
+
+  if (parsedUrl.port && parsedUrl.port !== "443") {
+    return null;
+  }
+
+  const normalizedHostname = canonicalizeInteractiveMediaHostname(
+    parsedUrl.hostname
+  );
+  if (!normalizedHostname) {
+    return null;
+  }
+
+  parsedUrl.hostname = normalizedHostname;
+  parsedUrl.port = "";
+  parsedUrl.username = "";
+  parsedUrl.password = "";
+  parsedUrl.hash = "";
+
+  return parsedUrl;
+}
+
+export function canonicalizeExternalMetadataUrl(src: string): string | null {
+  return parseHttpsMetadataUrl(src)?.toString() ?? null;
+}
+
+export function canonicalizeExternalMetadataHtmlUrl(
+  src: string
+): string | null {
+  const parsedUrl = parseHttpsMetadataUrl(src);
+
+  if (!parsedUrl) {
+    return null;
+  }
+
+  if (isInteractiveMediaAllowedHost(parsedUrl.hostname)) {
+    return canonicalizeInteractiveMediaUrl(parsedUrl.toString());
+  }
+
+  return parsedUrl.toString();
+}
+
+export function openExternalMetadataUrl(src: string | null | undefined): void {
+  if (!src) {
+    return;
+  }
+
+  const canonicalUrl = canonicalizeExternalMetadataUrl(src);
+
+  if (!canonicalUrl || typeof window === "undefined") {
+    return;
+  }
+
+  window.open(canonicalUrl, "_blank", SAFE_EXTERNAL_OPEN_FEATURES);
+}

--- a/components/common/sandboxed-external-iframe.helpers.ts
+++ b/components/common/sandboxed-external-iframe.helpers.ts
@@ -75,10 +75,11 @@ export function openExternalMetadataUrl(src: string | null | undefined): void {
   }
 
   const canonicalUrl = canonicalizeExternalMetadataUrl(src);
+  const browserWindow = globalThis.window;
 
-  if (!canonicalUrl || typeof window === "undefined") {
+  if (!canonicalUrl || typeof browserWindow === "undefined") {
     return;
   }
 
-  window.open(canonicalUrl, "_blank", SAFE_EXTERNAL_OPEN_FEATURES);
+  browserWindow.open(canonicalUrl, "_blank", SAFE_EXTERNAL_OPEN_FEATURES);
 }

--- a/components/common/sandboxed-external-iframe.helpers.ts
+++ b/components/common/sandboxed-external-iframe.helpers.ts
@@ -75,9 +75,9 @@ export function openExternalMetadataUrl(src: string | null | undefined): void {
   }
 
   const canonicalUrl = canonicalizeExternalMetadataUrl(src);
-  const browserWindow = globalThis.window;
+  const browserWindow = Reflect.get(globalThis, "window") as Window | undefined;
 
-  if (!canonicalUrl || typeof browserWindow === "undefined") {
+  if (!canonicalUrl || browserWindow === undefined) {
     return;
   }
 

--- a/components/nextGen/collections/nextgenToken/NextGenTokenArt.tsx
+++ b/components/nextGen/collections/nextgenToken/NextGenTokenArt.tsx
@@ -14,6 +14,7 @@ import { useEffect, useRef, useState } from "react";
 import { Col, Container, Dropdown, Row } from "react-bootstrap";
 import { Tooltip } from "react-tooltip";
 import type { NextGenCollection, NextGenToken } from "@/entities/INextgen";
+import { openExternalMetadataUrl } from "@/components/common/sandboxed-external-iframe.helpers";
 import useIsMobileDevice from "@/hooks/isMobileDevice";
 import useIsMobileScreen from "@/hooks/isMobileScreen";
 import Lightbulb from "./Lightbulb";
@@ -61,7 +62,6 @@ function NextGenTokenArtImage(
       />
     );
   }
-  
 
   return (
     <NextGenTokenImage
@@ -157,19 +157,22 @@ export default function NextGenTokenArt(props: Readonly<Props>) {
           sm={mode === Mode.HIGH_RES ? 4 : 6}
           className={`pt-2 pb-2 d-flex gap-3 align-items-center ${
             isMobileScreen ? "justify-content-center" : "justify-content-start"
-          }`}>
+          }`}
+        >
           <button
             className={`unselectable ${styles["imageResolutionBtn"]} ${
               mode === Mode.IMAGE ? styles["imageResolutionBtnSelected"] : ""
             }`}
-            onClick={() => setMode(Mode.IMAGE)}>
+            onClick={() => setMode(Mode.IMAGE)}
+          >
             2K
           </button>
           <button
             className={`unselectable ${styles["imageResolutionBtn"]} ${
               mode === Mode.HIGH_RES ? styles["imageResolutionBtnSelected"] : ""
             }`}
-            onClick={() => setMode(Mode.HIGH_RES)}>
+            onClick={() => setMode(Mode.HIGH_RES)}
+          >
             {isMobileDevice ? "8K" : "16K"}
           </button>
           <FontAwesomeIcon
@@ -185,7 +188,8 @@ export default function NextGenTokenArt(props: Readonly<Props>) {
               backgroundColor: "#1F2937",
               color: "white",
               padding: "4px 8px",
-            }}>
+            }}
+          >
             Live
           </Tooltip>
         </Col>
@@ -193,7 +197,8 @@ export default function NextGenTokenArt(props: Readonly<Props>) {
           <Col
             xs={6}
             sm={4}
-            className="pt-2 pb-2 d-flex align-items-center gap-1 justify-content-center">
+            className="py-2 d-flex align-items-center gap-1 justify-content-center"
+          >
             {showZoomControls && (
               <>
                 <FontAwesomeIcon
@@ -231,7 +236,8 @@ export default function NextGenTokenArt(props: Readonly<Props>) {
           sm={mode === Mode.HIGH_RES ? 4 : 6}
           className={`pt-2 pb-2 d-flex gap-3 align-items-center ${
             isMobileScreen ? "justify-content-center" : "justify-content-end"
-          }`}>
+          }`}
+        >
           <Lightbulb
             mode="black"
             className={styles["modeIcon"]!}
@@ -256,7 +262,8 @@ export default function NextGenTokenArt(props: Readonly<Props>) {
                   backgroundColor: "#1F2937",
                   color: "white",
                   padding: "4px 8px",
-                }}>
+                }}
+              >
                 Download
               </Tooltip>
             </Dropdown.Toggle>
@@ -278,7 +285,7 @@ export default function NextGenTokenArt(props: Readonly<Props>) {
             className={styles["modeIcon"]}
             onClick={() => {
               const href = getCurrentHref();
-              window.open(href, "_blank");
+              openExternalMetadataUrl(href);
             }}
             icon={faExternalLink}
             data-tooltip-id={`external-tooltip-${props.token.id}`}
@@ -290,7 +297,8 @@ export default function NextGenTokenArt(props: Readonly<Props>) {
               backgroundColor: "#1F2937",
               color: "white",
               padding: "4px 8px",
-            }}>
+            }}
+          >
             Open in new tab
           </Tooltip>
           <FontAwesomeIcon
@@ -306,7 +314,8 @@ export default function NextGenTokenArt(props: Readonly<Props>) {
               backgroundColor: "#1F2937",
               color: "white",
               padding: "4px 8px",
-            }}>
+            }}
+          >
             Fullscreen
           </Tooltip>
         </Col>
@@ -356,7 +365,8 @@ export default function NextGenTokenArt(props: Readonly<Props>) {
                         ? styles["lightBoxContent"]
                         : "col pt-3"
                     }
-                    ref={tokenImageRef}>
+                    ref={tokenImageRef}
+                  >
                     <NextGenTokenArtImage
                       token={props.token}
                       mode={mode}

--- a/components/nextGen/collections/nextgenToken/NextGenTokenDownload.tsx
+++ b/components/nextGen/collections/nextgenToken/NextGenTokenDownload.tsx
@@ -9,6 +9,7 @@ import useDownloader from "@/hooks/useDownloader";
 import type { NextGenToken } from "@/entities/INextgen";
 import { numberWithCommas } from "@/helpers/Helpers";
 import DotLoader, { Spinner } from "@/components/dotLoader/DotLoader";
+import { openExternalMetadataUrl } from "@/components/common/sandboxed-external-iframe.helpers";
 
 export enum Resolution {
   "Thumbnail" = "Thumbnail",
@@ -115,7 +116,7 @@ export default function NextGenTokenDownload(
           style={{ cursor: "pointer", height: "20px", width: "20px" }}
           onClick={() => {
             const h = getUrl(props.token, quality);
-            window.open(h, "_blank");
+            openExternalMetadataUrl(h);
           }}
           icon={faExternalLink}
         />

--- a/components/nextGen/collections/nextgenToken/NextGenTokenImage.tsx
+++ b/components/nextGen/collections/nextgenToken/NextGenTokenImage.tsx
@@ -1,7 +1,9 @@
 import type { NextGenTokenRarityType } from "@/components/nextGen/nextgen_helpers";
+import SandboxedExternalIframe from "@/components/common/SandboxedExternalIframe";
 import ProfileAvatar, {
   ProfileBadgeSize,
 } from "@/components/common/profile/ProfileAvatar";
+import { canonicalizeExternalMetadataHtmlUrl } from "@/components/common/sandboxed-external-iframe.helpers";
 import UserCICAndLevel, {
   UserCICAndLevelSize,
 } from "@/components/user/utils/UserCICAndLevel";
@@ -52,8 +54,7 @@ export function NextGenTokenImage(
       const handleOrWallet =
         props.token.normalised_handle ?? formatAddress(props.token.owner);
       const profileHref = `/${props.token.normalised_handle ?? props.token.owner}`;
-      const initial =
-        handleOrWallet.trim().charAt(0) || "?";
+      const initial = handleOrWallet.trim().charAt(0) || "?";
       const ownerInfo = (
         <div className="tailwind-scope tw-inline-flex tw-min-w-0 tw-max-w-full tw-items-center tw-gap-2.5">
           <ProfileAvatar
@@ -311,10 +312,13 @@ export function NextGenTokenImage(
   }
 
   function getContent() {
-    if (props.show_animation && props.token.animation_url) {
+    const animationUrl =
+      props.token.animation_url || props.token.generator?.html;
+
+    if (props.show_animation && animationUrl) {
       return (
-        <iframe
-          style={{
+        <SandboxedExternalIframe
+          containerStyle={{
             width: "100%",
             height: props.is_fullscreen
               ? "100vh"
@@ -323,8 +327,12 @@ export function NextGenTokenImage(
                 : "85vh",
             marginBottom: "-8px",
           }}
-          src={props.token.animation_url ?? props.token.generator?.html}
+          src={animationUrl}
           title={props.token.name}
+          className="tw-bg-transparent"
+          showBanner={false}
+          canonicalizeSrc={canonicalizeExternalMetadataHtmlUrl}
+          fallback={getImage()}
         />
       );
     } else {

--- a/components/nextGen/collections/nextgenToken/NextGenTokenRenderCenter.tsx
+++ b/components/nextGen/collections/nextgenToken/NextGenTokenRenderCenter.tsx
@@ -5,6 +5,7 @@ import { NEXTGEN_GENERATOR_BASE_URL } from "@/constants/constants";
 import type { NextGenToken } from "@/entities/INextgen";
 import { getRandomObjectId } from "@/helpers/AllowlistToolHelpers";
 import { numberWithCommas } from "@/helpers/Helpers";
+import { openExternalMetadataUrl } from "@/components/common/sandboxed-external-iframe.helpers";
 import { useState } from "react";
 import { Col, Container, Dropdown, Row } from "react-bootstrap";
 import { mainnet } from "wagmi/chains";
@@ -99,7 +100,7 @@ function CustomRender(props: Readonly<{ token: NextGenToken }>) {
     if (params.toString()) {
       url += `?${params.toString()}`;
     }
-    window.open(url, "_blank");
+    openExternalMetadataUrl(url);
   }
 
   return (

--- a/components/nft-image/renderers/NFTHTMLRenderer.tsx
+++ b/components/nft-image/renderers/NFTHTMLRenderer.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import SandboxedExternalIframe from "@/components/common/SandboxedExternalIframe";
+import { canonicalizeExternalMetadataHtmlUrl } from "@/components/common/sandboxed-external-iframe.helpers";
 import NFTImageBalance from "@/components/nft-image/NFTImageBalance";
 import NFTMediaContainer from "@/components/nft-image/NFTMediaContainer";
 import styles from "@/components/nft-image/NFTImage.module.scss";
@@ -83,11 +85,15 @@ export default function NFTHTMLRenderer(props: Readonly<BaseRendererProps>) {
         />
       )}
       {activeUrl ? (
-        <iframe
-          title={props.id}
+        <SandboxedExternalIframe
+          title={props.id ?? props.nft.name}
           src={activeUrl}
           id={props.id ?? `iframe-${props.nft.id}`}
           key={`${props.nft.contract}-${props.nft.id}-${activeUrl}`}
+          className="tw-bg-transparent"
+          containerClassName="tw-h-full tw-w-full"
+          showBanner={false}
+          canonicalizeSrc={canonicalizeExternalMetadataHtmlUrl}
           onLoad={() => {
             setDidLoadCurrentUrl(true);
           }}


### PR DESCRIPTION
## Summary
- route NFT and NextGen HTML media through `SandboxedExternalIframe`
- add shared HTTPS metadata URL canonicalization and safe external-open helper
- add `noopener,noreferrer` to NextGen metadata-driven `window.open` paths
- cover sandbox/canonicalization behavior in focused tests

## Verification
- `bin/6529.cmd run test -- __tests__/components/common/SandboxedExternalIframe.test.tsx __tests__/components/common/sandboxed-external-iframe.helpers.test.ts __tests__/components/nft-image/renderers/NFTHTMLRenderer.test.tsx __tests__/components/nextGen/NextGenTokenImage.test.tsx __tests__/components/nextGen/collections/nextgenToken/NextGenTokenDownload.test.tsx __tests__/components/nextGen/collections/nextgenToken/NextGenTokenArt.test.tsx __tests__/components/nextGen/collections/nextgenToken/NextGenTokenRenderCenter.test.tsx`
- `bin/6529.cmd run lint:diff`
- `bin/6529.cmd exec tsc --noEmit -p tsconfig.typecheck.json`
- `bin/6529.cmd exec prettier --check <touched files>`

Note: `bin/6529.cmd run check:changed` is blocked on this Windows host because `scripts/quality.js` calls `spawnSync()` directly on `bin/6529.cmd`, which returns `EINVAL`; the underlying format/lint/typecheck steps above were run through the repo wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox-based rendering for external NFT HTML/animation with optional banner control and improved iframe accessibility.

* **Improvements**
  * Safer canonicalization and handling of external metadata URLs; external links open with noopener,noreferrer protection.
  * Iframe attributes (id, title, styling) and container styling are forwarded for better layout and accessibility.

* **Tests**
  * Expanded tests covering URL canonicalization, sandbox/iframe security behavior, and unsafe URL handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->