### PR TITLE
Remove PFP previews from collapsed polls

### DIFF
--- a/__tests__/components/waves/drops/poll/WaveDropPoll.test.tsx
+++ b/__tests__/components/waves/drops/poll/WaveDropPoll.test.tsx
@@ -36,6 +36,10 @@ jest.mock("@/components/utils/tooltip/UserProfileTooltipWrapper", () => ({
   ),
 }));
 
+jest.mock("@/components/ipfs/IPFSContext", () => ({
+  resolveIpfsUrlSync: (url: string) => url,
+}));
+
 jest.mock("@/services/api/wave-drops-v2-api", () => ({
   voteDropPollV2: jest.fn(),
   fetchDropPollOptionVotersV2: jest.fn(),
@@ -127,7 +131,7 @@ describe("WaveDropPoll", () => {
     expect(screen.queryByRole("button", { name: "Submit vote" })).toBeNull();
   });
 
-  it("shows results before voting and expands voters for an option", async () => {
+  it("shows results without fetching voters until an option expands", async () => {
     fetchDropPollOptionVotersV2Mock.mockResolvedValue({
       data: [
         {
@@ -137,6 +141,7 @@ describe("WaveDropPoll", () => {
           level: 1,
           classification: ApiProfileClassification.Pseudonym,
           badges: {},
+          pfp: "https://example.com/alice.png",
         },
       ],
       count: 1,
@@ -151,10 +156,24 @@ describe("WaveDropPoll", () => {
       })
     );
 
-    await userEvent.click(
-      screen.getByRole("button", { name: /View voters for First/ })
-    );
+    const firstOption = screen.getByRole("button", {
+      name: /View voters for First/,
+    });
 
+    expect(screen.getByText("2 votes")).toBeInTheDocument();
+    expect(screen.getByText("67%")).toBeInTheDocument();
+    expect(screen.getByText("1 vote")).toBeInTheDocument();
+    expect(screen.getByText("33%")).toBeInTheDocument();
+    expect(fetchDropPollOptionVotersV2Mock).not.toHaveBeenCalled();
+
+    await userEvent.hover(firstOption);
+    firstOption.focus();
+
+    expect(fetchDropPollOptionVotersV2Mock).not.toHaveBeenCalled();
+
+    await userEvent.click(firstOption);
+
+    expect(fetchDropPollOptionVotersV2Mock).toHaveBeenCalledTimes(1);
     expect(fetchDropPollOptionVotersV2Mock).toHaveBeenCalledWith(
       expect.objectContaining({
         dropId: "drop-1",
@@ -164,6 +183,7 @@ describe("WaveDropPoll", () => {
       })
     );
     expect(await screen.findByText("alice")).toBeInTheDocument();
+    expect(await screen.findByAltText("alice's avatar")).toBeInTheDocument();
   });
 
   it("submits a vote and switches to results", async () => {

--- a/components/waves/drops/poll/PollOptionVoters.tsx
+++ b/components/waves/drops/poll/PollOptionVoters.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import UserProfileTooltipWrapper from "@/components/utils/tooltip/UserProfileTooltipWrapper";
 import { resolveIpfsUrlSync } from "@/components/ipfs/IPFSContext";
+import UserProfileTooltipWrapper from "@/components/utils/tooltip/UserProfileTooltipWrapper";
 import type { ApiDropPollOption } from "@/generated/models/ApiDropPollOption";
 import type { ApiIdentityOverview } from "@/generated/models/ApiIdentityOverview";
-import {
-  DROP_POLL_OPTION_VOTER_PREVIEW_PAGE_SIZE,
-  useDropPollOptionVoters,
-} from "@/hooks/useDropPollOptionVoters";
+import { useDropPollOptionVoters } from "@/hooks/useDropPollOptionVoters";
 import Image from "next/image";
 import Link from "next/link";
 import {
@@ -67,66 +64,6 @@ function PollVoterRow({ voter }: { readonly voter: ApiIdentityOverview }) {
         </Link>
       </UserProfileTooltipWrapper>
     </div>
-  );
-}
-
-function PollOptionVoterPreviewAvatar({
-  identity,
-}: {
-  readonly identity: ApiIdentityOverview;
-}) {
-  const label = getIdentityLabel(identity);
-  const avatarClassName =
-    "tw-size-5 tw-flex-shrink-0 tw-rounded-full tw-border tw-border-solid tw-border-iron-900 tw-bg-iron-800 tw-object-cover";
-
-  if (!identity.pfp) {
-    return <span className={avatarClassName} aria-hidden="true" />;
-  }
-
-  return (
-    <Image
-      unoptimized
-      src={resolveIpfsUrlSync(identity.pfp)}
-      alt={`${label}'s avatar`}
-      width={20}
-      height={20}
-      className={avatarClassName}
-    />
-  );
-}
-
-export function PollOptionVoterPreviews({
-  dropId,
-  option,
-}: {
-  readonly dropId: string;
-  readonly option: ApiDropPollOption;
-}) {
-  const { voters } = useDropPollOptionVoters({
-    dropId,
-    optionNo: option.option_no,
-    enabled: option.votes > 0,
-    pageSize: DROP_POLL_OPTION_VOTER_PREVIEW_PAGE_SIZE,
-  });
-
-  const previewVoters = voters.slice(
-    0,
-    DROP_POLL_OPTION_VOTER_PREVIEW_PAGE_SIZE
-  );
-
-  if (previewVoters.length === 0) {
-    return null;
-  }
-
-  return (
-    <span
-      className="tw-flex tw-h-5 tw-flex-shrink-0 tw-items-center -tw-space-x-1.5 tw-opacity-80 tw-transition-opacity desktop-hover:group-hover/result:tw-opacity-100"
-      aria-hidden="true"
-    >
-      {previewVoters.map((voter) => (
-        <PollOptionVoterPreviewAvatar key={voter.id} identity={voter} />
-      ))}
-    </span>
   );
 }
 

--- a/components/waves/drops/poll/PollResultOption.tsx
+++ b/components/waves/drops/poll/PollResultOption.tsx
@@ -1,14 +1,11 @@
 "use client";
 
 import type { ApiDropPollOption } from "@/generated/models/ApiDropPollOption";
-import { usePrefetchDropPollOptionVoters } from "@/hooks/useDropPollOptionVoters";
 import { CheckIcon, ChevronDownIcon } from "@heroicons/react/24/outline";
 import type { CSSProperties, MouseEvent } from "react";
 import { getVoteCountLabel } from "./WaveDropPoll.helpers";
-import { PollOptionVoterPreviews } from "./PollOptionVoters";
 
 interface PollResultOptionProps {
-  readonly dropId: string;
   readonly option: ApiDropPollOption;
   readonly totalVotes: number;
   readonly isSelected: boolean;
@@ -152,14 +149,12 @@ const getPollResultPercentageClassName = ({
 
 function PollResultOptionStats({
   canShowVoters,
-  dropId,
   isExpanded,
   isSelected,
   option,
   percentage,
 }: {
   readonly canShowVoters: boolean;
-  readonly dropId: string;
   readonly isExpanded: boolean;
   readonly isSelected: boolean;
   readonly option: ApiDropPollOption;
@@ -178,9 +173,6 @@ function PollResultOptionStats({
   return (
     <div className="tw-ml-0 tw-flex tw-h-5 tw-flex-shrink-0 tw-translate-x-0 tw-animate-poll-result-stats-in tw-items-center tw-gap-2.5 tw-opacity-100 tw-transition-all tw-duration-500 motion-reduce:tw-animate-none sm:tw-ml-2">
       <span className="tw-flex tw-h-5 tw-items-center tw-gap-1.5">
-        {canShowVoters && (
-          <PollOptionVoterPreviews dropId={dropId} option={option} />
-        )}
         <span
           className={`tw-text-[11.5px] tw-font-medium tw-transition-colors ${voteCountClassName}`}
         >
@@ -221,7 +213,6 @@ const getPollResultFillClassName = ({
 };
 
 export function PollResultOption({
-  dropId,
   option,
   totalVotes,
   isSelected,
@@ -233,14 +224,7 @@ export function PollResultOption({
   const percentage =
     totalVotes > 0 ? Math.round((option.votes / totalVotes) * 100) : 0;
   const fillScale = Math.max(0, Math.min(100, percentage)) / 100;
-  const prefetchVoters = usePrefetchDropPollOptionVoters();
   const canShowVoters = option.votes > 0;
-  const handlePrefetchVoters = () =>
-    prefetchVoters({
-      dropId,
-      optionNo: option.option_no,
-      enabled: canShowVoters,
-    });
   const handleToggle = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
     onToggle(option.option_no);
@@ -277,7 +261,6 @@ export function PollResultOption({
         </div>
         <PollResultOptionStats
           canShowVoters={canShowVoters}
-          dropId={dropId}
           isExpanded={isExpanded}
           isSelected={isSelected}
           option={option}
@@ -299,8 +282,6 @@ export function PollResultOption({
             option.votes
           )}, ${percentage} percent.${selectedAriaLabel}`}
           onClick={handleToggle}
-          onFocus={handlePrefetchVoters}
-          onPointerEnter={handlePrefetchVoters}
           className={optionClassName}
         >
           {optionContent}

--- a/components/waves/drops/poll/WaveDropPoll.tsx
+++ b/components/waves/drops/poll/WaveDropPoll.tsx
@@ -478,7 +478,6 @@ export default function WaveDropPoll({ drop }: WaveDropPollProps) {
             return (
               <div key={option.option_no}>
                 <PollResultOption
-                  dropId={drop.id}
                   option={option}
                   totalVotes={totalVotes}
                   isSelected={votedOptionNos.has(option.option_no)}

--- a/hooks/useDropPollOptionVoters.ts
+++ b/hooks/useDropPollOptionVoters.ts
@@ -5,15 +5,10 @@ import { getDefaultQueryRetry } from "@/components/react-query-wrapper/utils/que
 import type { ApiDropPollVotersPage } from "@/generated/models/ApiDropPollVotersPage";
 import type { ApiIdentityOverview } from "@/generated/models/ApiIdentityOverview";
 import { fetchDropPollOptionVotersV2 } from "@/services/api/wave-drops-v2-api";
-import {
-  keepPreviousData,
-  useInfiniteQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
-import { useCallback, useMemo } from "react";
+import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 
 const DROP_POLL_OPTION_VOTERS_PAGE_SIZE = 20;
-export const DROP_POLL_OPTION_VOTER_PREVIEW_PAGE_SIZE = 3;
 const DROP_POLL_OPTION_VOTERS_STALE_TIME_MS = 60_000;
 
 interface UseDropPollOptionVotersProps {
@@ -77,58 +72,6 @@ const fetchDropPollOptionVotersPage = async ({
     signal,
   });
 };
-
-export function usePrefetchDropPollOptionVoters() {
-  const queryClient = useQueryClient();
-
-  return useCallback(
-    ({
-      dropId,
-      optionNo,
-      enabled = true,
-      pageSize = DROP_POLL_OPTION_VOTERS_PAGE_SIZE,
-    }: DropPollOptionVotersParams & {
-      readonly enabled?: boolean | undefined;
-    }) => {
-      const normalizedDropId = dropId.trim();
-      if (
-        !enabled ||
-        normalizedDropId.length === 0 ||
-        typeof optionNo !== "number"
-      ) {
-        return;
-      }
-
-      queryClient
-        .prefetchInfiniteQuery({
-          queryKey: getDropPollOptionVotersQueryKey({
-            dropId: normalizedDropId,
-            optionNo,
-          pageSize,}),
-          queryFn: ({
-            pageParam,
-            signal,
-          }: {
-            pageParam: number;
-            signal?: AbortSignal | undefined;
-          }) =>
-            fetchDropPollOptionVotersPage({
-              dropId: normalizedDropId,
-              optionNo,
-              pageParam,pageSize,
-              signal,
-            }),
-          initialPageParam: 1,
-          getNextPageParam: getNextDropPollOptionVotersPageParam,
-          pages: 1,
-          staleTime: DROP_POLL_OPTION_VOTERS_STALE_TIME_MS,
-          ...getDefaultQueryRetry(),
-        })
-        .catch(() => undefined);
-    },
-    [queryClient]
-  );
-}
 
 export function useDropPollOptionVoters({
   dropId,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed voter preview avatars feature that previously displayed truncated avatar lists in poll results
  * Voters now load on-demand when users interact with or expand poll options, replacing pre-fetch behavior
  * Removed prefetch utility hook and preview page size constant from voters module
  * Simplified poll option display and stats logic by eliminating prefetch-related event handlers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->