### PR TITLE
Add branded NFT and collection OG card routes

### DIFF
--- a/__tests__/app/api/og-metadata.brandedCards.test.tsx
+++ b/__tests__/app/api/og-metadata.brandedCards.test.tsx
@@ -53,6 +53,46 @@ const collectTextNodes = (node: React.ReactNode): string[] => {
   );
 };
 
+type ElementRecord = {
+  readonly childCount: number;
+  readonly props: {
+    readonly children?: React.ReactNode;
+    readonly style?: Record<string, unknown>;
+  };
+};
+
+const collectElementRecords = (node: React.ReactNode): ElementRecord[] => {
+  if (!React.isValidElement(node)) {
+    return [];
+  }
+
+  if (typeof node.type === "function") {
+    return collectElementRecords(node.type(node.props));
+  }
+
+  const props = node.props as ElementRecord["props"];
+  const current = {
+    childCount: React.Children.count(props.children),
+    props,
+  };
+  const children = React.Children.toArray(props.children).flatMap((child) =>
+    collectElementRecords(child)
+  );
+
+  return [current, ...children];
+};
+
+const getStyleNumber = (
+  style: Record<string, unknown>,
+  key: string
+): number => {
+  const value = style[key];
+  if (typeof value !== "number") {
+    throw new Error(`Expected numeric style ${key}.`);
+  }
+  return value;
+};
+
 describe("branded OG card renderers", () => {
   it("renders NFT card art through the OG image proxy", () => {
     const element = renderBrandedNftOgImage({
@@ -204,5 +244,71 @@ describe("branded OG card renderers", () => {
     });
 
     expect(collectTextNodes(element)).toEqual(expect.arrayContaining(["# 5 "]));
+  });
+
+  it("uses displayId for the visible NFT id label", () => {
+    const element = renderBrandedNftOgImage({
+      collection: "Pebbles",
+      contract: "0x45882f9bc325e14fbb298a1df930c43a874b83ae",
+      displayId: "42",
+      id: "10000000042",
+      title: "Pebbles #42",
+    });
+    const textNodes = collectTextNodes(element);
+
+    expect(textNodes).toContain("#42");
+    expect(textNodes).not.toContain("#10,000,000,042");
+  });
+
+  it("positions NFT metadata below long subtitles", () => {
+    const element = renderBrandedNftOgImage({
+      artist: "A Very Long Artist Name",
+      badge: "Long Text",
+      collection: "The Memes",
+      contract: "0xabc",
+      id: "999",
+      imageUrl: "/memes-preview.png",
+      subtitle:
+        "This subtitle is also intentionally long so QA can verify the generated image still returns successfully with wrapped text",
+      title:
+        "This is a very long NFT title that should wrap cleanly inside the branded social card without escaping its content column or causing the image route to fail",
+    });
+    const records = collectElementRecords(element);
+    const subtitleRecord = records.find(({ props }) => {
+      const style = props.style;
+      return (
+        style?.color === "#D5D5DC" &&
+        style.fontSize === 34 &&
+        style.lineHeight === 1.18
+      );
+    });
+    const metadataRecord = records.find(({ props }) => {
+      const style = props.style;
+      return (
+        style?.color === "#9A9AA5" && style.fontSize === 30 && style.gap === 16
+      );
+    });
+
+    expect(subtitleRecord).toBeDefined();
+    expect(metadataRecord).toBeDefined();
+    if (!subtitleRecord?.props.style || !metadataRecord?.props.style) {
+      throw new Error("Expected subtitle and metadata records.");
+    }
+
+    const subtitleTop = getStyleNumber(subtitleRecord.props.style, "top");
+    const subtitleFontSize = getStyleNumber(
+      subtitleRecord.props.style,
+      "fontSize"
+    );
+    const subtitleLineHeight = getStyleNumber(
+      subtitleRecord.props.style,
+      "lineHeight"
+    );
+    const subtitleBottom =
+      subtitleTop +
+      subtitleRecord.childCount * subtitleFontSize * subtitleLineHeight;
+    const metadataTop = getStyleNumber(metadataRecord.props.style, "top");
+
+    expect(metadataTop).toBeGreaterThanOrEqual(subtitleBottom + 18);
   });
 });

--- a/__tests__/app/api/og-metadata.brandedCards.test.tsx
+++ b/__tests__/app/api/og-metadata.brandedCards.test.tsx
@@ -1,0 +1,115 @@
+jest.mock("@/config/env", () => ({
+  publicEnv: {
+    BASE_ENDPOINT: "https://6529.test",
+  },
+}));
+
+import {
+  renderBrandedCollectionOgImage,
+  renderBrandedNftOgImage,
+} from "@/app/api/og-metadata/_lib/brandedCards";
+import React from "react";
+
+const collectImageSrcs = (node: React.ReactNode): string[] => {
+  if (!React.isValidElement(node)) {
+    return [];
+  }
+
+  if (typeof node.type === "function") {
+    return collectImageSrcs(node.type(node.props));
+  }
+
+  const props = node.props as {
+    readonly src?: string | undefined;
+    readonly children?: React.ReactNode;
+  };
+  const current = typeof props.src === "string" ? [props.src] : [];
+  const children = React.Children.toArray(props.children).flatMap((child) =>
+    collectImageSrcs(child)
+  );
+
+  return [...current, ...children];
+};
+
+const collectTextNodes = (node: React.ReactNode): string[] => {
+  if (typeof node === "string" || typeof node === "number") {
+    return [`${node}`];
+  }
+
+  if (!React.isValidElement(node)) {
+    return [];
+  }
+
+  if (typeof node.type === "function") {
+    return collectTextNodes(node.type(node.props));
+  }
+
+  const props = node.props as {
+    readonly children?: React.ReactNode;
+  };
+
+  return React.Children.toArray(props.children).flatMap((child) =>
+    collectTextNodes(child)
+  );
+};
+
+describe("branded OG card renderers", () => {
+  it("renders NFT card art through the OG image proxy", () => {
+    const element = renderBrandedNftOgImage({
+      artist: "6529er",
+      badge: "The Memes",
+      collection: "The Memes",
+      contract: "0x33FD426905F149f8376e227d0C9D3340AaD17aF1",
+      id: "6529",
+      imageUrl: "https://cdn.test/meme.png",
+      origin: "http://localhost:3001",
+      subtitle: "Card 6529 from The Memes collection",
+      title: "Seize the Memes of Production",
+    });
+
+    expect(collectImageSrcs(element)).toEqual(
+      expect.arrayContaining([
+        "http://localhost:3001/api/og-metadata/image?url=https%3A%2F%2Fcdn.test%2Fmeme.png&w=538",
+        "https://6529.test/6529.svg",
+      ])
+    );
+    expect(collectTextNodes(element)).toEqual(
+      expect.arrayContaining([
+        "The Memes",
+        "Seize the Memes",
+        "of Production",
+        "Card 6529 from The Memes",
+        "collection",
+        "#6,529",
+        "by",
+        "6529er",
+        "0x33FD...7aF1",
+      ])
+    );
+  });
+
+  it("renders collection card local images directly from the public base URL", () => {
+    const element = renderBrandedCollectionOgImage({
+      badge: "6529 Collections",
+      imageUrl: "/memes-preview.png",
+      slug: "the-memes",
+      subtitle: "The Memes by 6529",
+      title: "The Memes",
+    });
+
+    expect(collectImageSrcs(element)).toEqual(
+      expect.arrayContaining([
+        "https://6529.test/memes-preview.png",
+        "https://6529.test/6529.svg",
+      ])
+    );
+    expect(collectTextNodes(element)).toEqual(
+      expect.arrayContaining([
+        "6529 Collections",
+        "The Memes",
+        "The Memes by 6529",
+        "the-memes",
+      ])
+    );
+  });
+});

--- a/__tests__/app/api/og-metadata.brandedCards.test.tsx
+++ b/__tests__/app/api/og-metadata.brandedCards.test.tsx
@@ -112,4 +112,32 @@ describe("branded OG card renderers", () => {
       ])
     );
   });
+
+  it("proxies protocol-relative card art URLs", () => {
+    const element = renderBrandedNftOgImage({
+      contract: "0x33FD426905F149f8376e227d0C9D3340AaD17aF1",
+      id: "6529",
+      imageUrl: "//cdn.test/meme.png",
+      origin: "http://localhost:3001",
+      title: "Protocol-relative art",
+    });
+
+    expect(collectImageSrcs(element)).toEqual(
+      expect.arrayContaining([
+        "http://localhost:3001/api/og-metadata/image?url=https%3A%2F%2Fcdn.test%2Fmeme.png&w=538",
+      ])
+    );
+  });
+
+  it("does not treat bare relative card art URLs as local assets", () => {
+    const element = renderBrandedCollectionOgImage({
+      imageUrl: "memes-preview.png",
+      slug: "the-memes",
+      title: "The Memes",
+    });
+
+    expect(collectImageSrcs(element)).not.toContain(
+      "https://6529.test/memes-preview.png"
+    );
+  });
 });

--- a/__tests__/app/api/og-metadata.brandedCards.test.tsx
+++ b/__tests__/app/api/og-metadata.brandedCards.test.tsx
@@ -113,7 +113,7 @@ describe("branded OG card renderers", () => {
     );
   });
 
-  it("proxies protocol-relative card art URLs", () => {
+  it("proxies protocol-relative public HTTPS card art URLs", () => {
     const element = renderBrandedNftOgImage({
       contract: "0x33FD426905F149f8376e227d0C9D3340AaD17aF1",
       id: "6529",
@@ -129,6 +129,61 @@ describe("branded OG card renderers", () => {
     );
   });
 
+  it("renders the placeholder for non-HTTPS external card art URLs", () => {
+    const element = renderBrandedNftOgImage({
+      collection: "The Memes",
+      contract: "0x33FD426905F149f8376e227d0C9D3340AaD17aF1",
+      id: "6529",
+      imageUrl: "http://cdn.test/meme.png",
+      origin: "http://localhost:3001",
+      title: "HTTP art",
+    });
+
+    expect(collectImageSrcs(element)).not.toEqual(
+      expect.arrayContaining([
+        "http://localhost:3001/api/og-metadata/image?url=http%3A%2F%2Fcdn.test%2Fmeme.png&w=538",
+      ])
+    );
+    expect(collectTextNodes(element)).toEqual(
+      expect.arrayContaining(["6529", "The Memes"])
+    );
+  });
+
+  it("renders the placeholder for disallowed external card art hosts", () => {
+    const element = renderBrandedNftOgImage({
+      collection: "The Memes",
+      contract: "0x33FD426905F149f8376e227d0C9D3340AaD17aF1",
+      id: "6529",
+      imageUrl: "//localhost/secret.png",
+      origin: "http://localhost:3001",
+      title: "Localhost art",
+    });
+
+    expect(collectImageSrcs(element)).not.toEqual(
+      expect.arrayContaining([
+        "http://localhost:3001/api/og-metadata/image?url=https%3A%2F%2Flocalhost%2Fsecret.png&w=538",
+      ])
+    );
+    expect(collectTextNodes(element)).toEqual(
+      expect.arrayContaining(["6529", "The Memes"])
+    );
+  });
+
+  it("renders the placeholder for local paths that resolve off origin", () => {
+    const element = renderBrandedCollectionOgImage({
+      imageUrl: "/\\evil.test/meme.png",
+      slug: "the-memes",
+      title: "The Memes",
+    });
+
+    expect(collectImageSrcs(element)).not.toContain(
+      "https://evil.test/meme.png"
+    );
+    expect(collectTextNodes(element)).toEqual(
+      expect.arrayContaining(["6529", "The Memes"])
+    );
+  });
+
   it("does not treat bare relative card art URLs as local assets", () => {
     const element = renderBrandedCollectionOgImage({
       imageUrl: "memes-preview.png",
@@ -139,5 +194,15 @@ describe("branded OG card renderers", () => {
     expect(collectImageSrcs(element)).not.toContain(
       "https://6529.test/memes-preview.png"
     );
+  });
+
+  it("keeps non-decimal NFT ids unformatted", () => {
+    const element = renderBrandedNftOgImage({
+      contract: "0x33FD426905F149f8376e227d0C9D3340AaD17aF1",
+      id: " 5 ",
+      title: "Spaced id",
+    });
+
+    expect(collectTextNodes(element)).toEqual(expect.arrayContaining(["# 5 "]));
   });
 });

--- a/__tests__/app/api/og-metadata.collections.route.test.ts
+++ b/__tests__/app/api/og-metadata.collections.route.test.ts
@@ -32,6 +32,28 @@ jest.mock("@/app/api/og-metadata/profiles/[identity]/font", () => ({
 }));
 
 import { GET } from "@/app/api/og-metadata/collections/[collection]/route";
+import React from "react";
+
+const collectImageSrcs = (node: React.ReactNode): string[] => {
+  if (!React.isValidElement(node)) {
+    return [];
+  }
+
+  if (typeof node.type === "function") {
+    return collectImageSrcs(node.type(node.props));
+  }
+
+  const props = node.props as {
+    readonly src?: string | undefined;
+    readonly children?: React.ReactNode;
+  };
+  const current = typeof props.src === "string" ? [props.src] : [];
+  const children = React.Children.toArray(props.children).flatMap((child) =>
+    collectImageSrcs(child)
+  );
+
+  return [...current, ...children];
+};
 
 describe("/api/og-metadata/collections/[collection]", () => {
   beforeEach(() => {
@@ -68,6 +90,35 @@ describe("/api/og-metadata/collections/[collection]", () => {
       },
     });
     expect(response).toBe(mockImageResponse.mock.results[0]?.value);
+  });
+
+  it("preserves long image URLs without text truncation", async () => {
+    const imageUrl = `https://cdn.test/collections/${"preview-".repeat(
+      26
+    )}card.png?signature=${"signed-".repeat(35)}`;
+
+    await GET(
+      {
+        url:
+          "https://6529.test/api/og-metadata/collections/the-memes" +
+          `?image=${encodeURIComponent(imageUrl)}`,
+      } as Request,
+      {
+        params: Promise.resolve({ collection: "the-memes" }),
+      }
+    );
+
+    const element = mockImageResponse.mock.calls[0]?.[0] as React.ReactNode;
+    const proxiedSrc = collectImageSrcs(element).find((src) =>
+      src.includes("/api/og-metadata/image?")
+    );
+
+    expect(imageUrl.length).toBeGreaterThan(180);
+    expect(proxiedSrc).toBeDefined();
+    if (proxiedSrc === undefined) {
+      throw new Error("Expected long image URL to be proxied.");
+    }
+    expect(new URL(proxiedSrc).searchParams.get("url")).toBe(imageUrl);
   });
 
   it("returns 400 when the collection param is missing", async () => {

--- a/__tests__/app/api/og-metadata.collections.route.test.ts
+++ b/__tests__/app/api/og-metadata.collections.route.test.ts
@@ -1,0 +1,91 @@
+const mockImageResponse = jest.fn((element, init) => ({
+  element,
+  init,
+}));
+const mockNextResponseJson = jest.fn();
+const mockFonts = [
+  {
+    name: "Montserrat",
+    data: new ArrayBuffer(8),
+    weight: 700,
+    style: "normal",
+  },
+];
+const mockLoadMontserratFonts = jest.fn();
+
+jest.mock("next/og", () => ({
+  ImageResponse: mockImageResponse,
+}));
+
+jest.mock("next/server", () => ({
+  NextResponse: { json: mockNextResponseJson },
+}));
+
+jest.mock("@/config/env", () => ({
+  publicEnv: {
+    BASE_ENDPOINT: "https://6529.test",
+  },
+}));
+
+jest.mock("@/app/api/og-metadata/profiles/[identity]/font", () => ({
+  loadMontserratFonts: mockLoadMontserratFonts,
+}));
+
+import { GET } from "@/app/api/og-metadata/collections/[collection]/route";
+
+describe("/api/og-metadata/collections/[collection]", () => {
+  beforeEach(() => {
+    mockImageResponse.mockClear();
+    mockLoadMontserratFonts.mockReset();
+    mockLoadMontserratFonts.mockResolvedValue(mockFonts);
+    mockNextResponseJson.mockReset();
+    mockNextResponseJson.mockImplementation((body, init) => ({
+      body,
+      status: init?.status ?? 200,
+      json: async () => body,
+    }));
+  });
+
+  it("returns a default collection image response for known collections", async () => {
+    const response = await GET(
+      {
+        url: "https://6529.test/api/og-metadata/collections/the-memes",
+      } as Request,
+      {
+        params: Promise.resolve({ collection: "the-memes" }),
+      }
+    );
+
+    expect(mockLoadMontserratFonts).toHaveBeenCalledTimes(1);
+    expect(mockImageResponse).toHaveBeenCalledTimes(1);
+    expect(mockImageResponse.mock.calls[0]?.[1]).toEqual({
+      width: 1200,
+      height: 630,
+      fonts: mockFonts,
+      headers: {
+        "Cache-Control":
+          "public, max-age=1800, s-maxage=3600, stale-while-revalidate=86400",
+      },
+    });
+    expect(response).toBe(mockImageResponse.mock.results[0]?.value);
+  });
+
+  it("returns 400 when the collection param is missing", async () => {
+    const response = await GET(
+      { url: "https://6529.test/api/og-metadata/collections/" } as Request,
+      {
+        params: Promise.resolve({}),
+      }
+    );
+
+    expect(mockImageResponse).not.toHaveBeenCalled();
+    expect(mockNextResponseJson).toHaveBeenCalledWith(
+      {
+        error:
+          "Invalid collection. Use /api/og-metadata/collections/<collection>.",
+      },
+      { status: 400 }
+    );
+    expect(response.status).toBe(400);
+  });
+});

--- a/__tests__/app/api/og-metadata.nfts.route.test.ts
+++ b/__tests__/app/api/og-metadata.nfts.route.test.ts
@@ -32,6 +32,29 @@ jest.mock("@/app/api/og-metadata/profiles/[identity]/font", () => ({
 }));
 
 import { GET } from "@/app/api/og-metadata/nfts/[contract]/[id]/route";
+import React from "react";
+
+const collectTextNodes = (node: React.ReactNode): string[] => {
+  if (typeof node === "string" || typeof node === "number") {
+    return [`${node}`];
+  }
+
+  if (!React.isValidElement(node)) {
+    return [];
+  }
+
+  if (typeof node.type === "function") {
+    return collectTextNodes(node.type(node.props));
+  }
+
+  const props = node.props as {
+    readonly children?: React.ReactNode;
+  };
+
+  return React.Children.toArray(props.children).flatMap((child) =>
+    collectTextNodes(child)
+  );
+};
 
 describe("/api/og-metadata/nfts/[contract]/[id]", () => {
   beforeEach(() => {
@@ -49,12 +72,12 @@ describe("/api/og-metadata/nfts/[contract]/[id]", () => {
   it("returns an image response from path and query display metadata", async () => {
     const request = {
       url:
-        "https://6529.test/api/og-metadata/nfts/0xabc/42" +
-        "?title=Test%20Meme&collection=The%20Memes&artist=6529er&image=https%3A%2F%2Fcdn.test%2Fmeme.png",
+        "https://6529.test/api/og-metadata/nfts/0xabc/10000000042" +
+        "?title=Test%20Meme&collection=The%20Memes&artist=6529er&displayId=42&image=https%3A%2F%2Fcdn.test%2Fmeme.png",
     } as Request;
 
     const response = await GET(request, {
-      params: Promise.resolve({ contract: "0xabc", id: "42" }),
+      params: Promise.resolve({ contract: "0xabc", id: "10000000042" }),
     });
 
     expect(mockLoadMontserratFonts).toHaveBeenCalledTimes(1);
@@ -68,6 +91,10 @@ describe("/api/og-metadata/nfts/[contract]/[id]", () => {
           "public, max-age=1800, s-maxage=3600, stale-while-revalidate=86400",
       },
     });
+    const element = mockImageResponse.mock.calls[0]?.[0] as React.ReactNode;
+    const textNodes = collectTextNodes(element);
+    expect(textNodes).toContain("#42");
+    expect(textNodes).not.toContain("#10,000,000,042");
     expect(response).toBe(mockImageResponse.mock.results[0]?.value);
   });
 

--- a/__tests__/app/api/og-metadata.nfts.route.test.ts
+++ b/__tests__/app/api/og-metadata.nfts.route.test.ts
@@ -34,6 +34,27 @@ jest.mock("@/app/api/og-metadata/profiles/[identity]/font", () => ({
 import { GET } from "@/app/api/og-metadata/nfts/[contract]/[id]/route";
 import React from "react";
 
+const collectImageSrcs = (node: React.ReactNode): string[] => {
+  if (!React.isValidElement(node)) {
+    return [];
+  }
+
+  if (typeof node.type === "function") {
+    return collectImageSrcs(node.type(node.props));
+  }
+
+  const props = node.props as {
+    readonly src?: string | undefined;
+    readonly children?: React.ReactNode;
+  };
+  const current = typeof props.src === "string" ? [props.src] : [];
+  const children = React.Children.toArray(props.children).flatMap((child) =>
+    collectImageSrcs(child)
+  );
+
+  return [...current, ...children];
+};
+
 const collectTextNodes = (node: React.ReactNode): string[] => {
   if (typeof node === "string" || typeof node === "number") {
     return [`${node}`];
@@ -96,6 +117,33 @@ describe("/api/og-metadata/nfts/[contract]/[id]", () => {
     expect(textNodes).toContain("#42");
     expect(textNodes).not.toContain("#10,000,000,042");
     expect(response).toBe(mockImageResponse.mock.results[0]?.value);
+  });
+
+  it("preserves long image URLs without text truncation", async () => {
+    const imageUrl = `https://cdn.test/assets/${"card-path-".repeat(
+      24
+    )}image.png?signature=${"signed-".repeat(35)}`;
+    const request = {
+      url:
+        "https://6529.test/api/og-metadata/nfts/0xabc/42" +
+        `?title=Long%20Image&image=${encodeURIComponent(imageUrl)}`,
+    } as Request;
+
+    await GET(request, {
+      params: Promise.resolve({ contract: "0xabc", id: "42" }),
+    });
+
+    const element = mockImageResponse.mock.calls[0]?.[0] as React.ReactNode;
+    const proxiedSrc = collectImageSrcs(element).find((src) =>
+      src.includes("/api/og-metadata/image?")
+    );
+
+    expect(imageUrl.length).toBeGreaterThan(180);
+    expect(proxiedSrc).toBeDefined();
+    if (proxiedSrc === undefined) {
+      throw new Error("Expected long image URL to be proxied.");
+    }
+    expect(new URL(proxiedSrc).searchParams.get("url")).toBe(imageUrl);
   });
 
   it("returns 400 when the NFT identity is incomplete", async () => {

--- a/__tests__/app/api/og-metadata.nfts.route.test.ts
+++ b/__tests__/app/api/og-metadata.nfts.route.test.ts
@@ -1,0 +1,89 @@
+const mockImageResponse = jest.fn((element, init) => ({
+  element,
+  init,
+}));
+const mockNextResponseJson = jest.fn();
+const mockFonts = [
+  {
+    name: "Montserrat",
+    data: new ArrayBuffer(8),
+    weight: 700,
+    style: "normal",
+  },
+];
+const mockLoadMontserratFonts = jest.fn();
+
+jest.mock("next/og", () => ({
+  ImageResponse: mockImageResponse,
+}));
+
+jest.mock("next/server", () => ({
+  NextResponse: { json: mockNextResponseJson },
+}));
+
+jest.mock("@/config/env", () => ({
+  publicEnv: {
+    BASE_ENDPOINT: "https://6529.test",
+  },
+}));
+
+jest.mock("@/app/api/og-metadata/profiles/[identity]/font", () => ({
+  loadMontserratFonts: mockLoadMontserratFonts,
+}));
+
+import { GET } from "@/app/api/og-metadata/nfts/[contract]/[id]/route";
+
+describe("/api/og-metadata/nfts/[contract]/[id]", () => {
+  beforeEach(() => {
+    mockImageResponse.mockClear();
+    mockLoadMontserratFonts.mockReset();
+    mockLoadMontserratFonts.mockResolvedValue(mockFonts);
+    mockNextResponseJson.mockReset();
+    mockNextResponseJson.mockImplementation((body, init) => ({
+      body,
+      status: init?.status ?? 200,
+      json: async () => body,
+    }));
+  });
+
+  it("returns an image response from path and query display metadata", async () => {
+    const request = {
+      url:
+        "https://6529.test/api/og-metadata/nfts/0xabc/42" +
+        "?title=Test%20Meme&collection=The%20Memes&artist=6529er&image=https%3A%2F%2Fcdn.test%2Fmeme.png",
+    } as Request;
+
+    const response = await GET(request, {
+      params: Promise.resolve({ contract: "0xabc", id: "42" }),
+    });
+
+    expect(mockLoadMontserratFonts).toHaveBeenCalledTimes(1);
+    expect(mockImageResponse).toHaveBeenCalledTimes(1);
+    expect(mockImageResponse.mock.calls[0]?.[1]).toEqual({
+      width: 1200,
+      height: 630,
+      fonts: mockFonts,
+      headers: {
+        "Cache-Control":
+          "public, max-age=1800, s-maxage=3600, stale-while-revalidate=86400",
+      },
+    });
+    expect(response).toBe(mockImageResponse.mock.results[0]?.value);
+  });
+
+  it("returns 400 when the NFT identity is incomplete", async () => {
+    const response = await GET(
+      { url: "https://6529.test/api/og-metadata/nfts/0xabc/" } as Request,
+      {
+        params: Promise.resolve({ contract: "0xabc" }),
+      }
+    );
+
+    expect(mockImageResponse).not.toHaveBeenCalled();
+    expect(mockNextResponseJson).toHaveBeenCalledWith(
+      { error: "Invalid NFT. Use /api/og-metadata/nfts/<contract>/<id>." },
+      { status: 400 }
+    );
+    expect(response.status).toBe(400);
+  });
+});

--- a/__tests__/app/collectionMetadataPages.test.tsx
+++ b/__tests__/app/collectionMetadataPages.test.tsx
@@ -1,0 +1,66 @@
+import { generateMetadata as generateGradientMetadata } from "@/app/6529-gradient/page";
+import { generateMetadata as generateMemeLabMetadata } from "@/app/meme-lab/page";
+import { generateMetadata as generateTheMemesMetadata } from "@/app/the-memes/page";
+import type { Metadata } from "next";
+
+jest.mock("@/components/6529Gradient/6529Gradient", () => ({
+  __esModule: true,
+  default: () => <div data-testid="gradient" />,
+}));
+
+jest.mock("@/components/memelab/MemeLab", () => ({
+  __esModule: true,
+  default: () => <div data-testid="meme-lab" />,
+}));
+
+jest.mock("@/components/the-memes/TheMemes", () => ({
+  __esModule: true,
+  default: () => <div data-testid="the-memes" />,
+}));
+
+const getSocialImage = (metadata: Metadata) => {
+  const [image] = metadata.openGraph?.images as {
+    alt: string;
+    height: number;
+    url: string;
+    width: number;
+  }[];
+  return image;
+};
+
+describe("collection landing metadata", () => {
+  it.each([
+    {
+      alt: "The Memes collection social card",
+      generateMetadata: generateTheMemesMetadata,
+      slug: "the-memes",
+      title: "The Memes",
+    },
+    {
+      alt: "Meme Lab collection social card",
+      generateMetadata: generateMemeLabMetadata,
+      slug: "meme-lab",
+      title: "Meme Lab",
+    },
+    {
+      alt: "6529 Gradient collection social card",
+      generateMetadata: generateGradientMetadata,
+      slug: "6529-gradient",
+      title: "6529 Gradient",
+    },
+  ])("uses branded collection card metadata for $title", async (route) => {
+    const metadata = await route.generateMetadata();
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe(route.title);
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(image).toMatchObject({
+      alt: route.alt,
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe(`/api/og-metadata/collections/${route.slug}`);
+    expect(url.search).toBe("");
+  });
+});

--- a/__tests__/app/gradientPage.test.tsx
+++ b/__tests__/app/gradientPage.test.tsx
@@ -1,4 +1,5 @@
 import { generateMetadata } from "@/app/6529-gradient/[id]/page";
+import { GRADIENT_CONTRACT } from "@/constants/constants";
 import { fetchUrl } from "@/services/6529api";
 
 // === Mock Services & Dependencies ===
@@ -27,10 +28,6 @@ jest.mock("@/components/latest-activity/LatestActivityRow", () => ({
   __esModule: true,
   default: () => <tr data-testid="activity-row" />,
 }));
-jest.mock("@/components/nft-attributes/NftStats", () => ({
-  __esModule: true,
-  default: () => <></>,
-}));
 jest.mock("@/components/nft-navigation/NftNavigation", () => ({
   __esModule: true,
   default: () => <></>,
@@ -53,11 +50,26 @@ describe("generateMetadata", () => {
 
     expect(metadata.title).toBe("6529 Gradient #10");
 
-    const images = Array.isArray(metadata.openGraph?.images)
-      ? metadata.openGraph.images
-      : [metadata.openGraph?.images];
+    const [image] = metadata.openGraph?.images as {
+      alt: string;
+      height: number;
+      url: string;
+      width: number;
+    }[];
+    const url = new URL(image.url);
 
-    expect(images?.[0]).toBe("https://example.com/thumb.png");
+    expect(image).toMatchObject({
+      alt: "6529 Gradient #10 social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe(`/api/og-metadata/nfts/${GRADIENT_CONTRACT}/10`);
+    expect(url.searchParams.get("badge")).toBe("6529 Gradient");
+    expect(url.searchParams.get("collection")).toBe("6529 Gradient");
+    expect(url.searchParams.get("image")).toBe("https://example.com/thumb.png");
+    expect(url.searchParams.get("subtitle")).toBe("Collections");
+    expect(url.searchParams.get("title")).toBe("6529 Gradient #10");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
   });
 
   it("falls back to image if thumbnail is missing", async () => {
@@ -69,24 +81,28 @@ describe("generateMetadata", () => {
       params: Promise.resolve({ id: "20" }),
     });
 
-    const images = Array.isArray(metadata.openGraph?.images)
-      ? metadata.openGraph.images
-      : [metadata.openGraph?.images];
+    const [image] = metadata.openGraph?.images as {
+      url: string;
+    }[];
+    const url = new URL(image.url);
 
-    expect(images?.[0]).toBe("https://example.com/image.png");
+    expect(url.pathname).toBe(`/api/og-metadata/nfts/${GRADIENT_CONTRACT}/20`);
+    expect(url.searchParams.get("image")).toBe("https://example.com/image.png");
   });
 
-  it("uses default image if no data", async () => {
+  it("uses branded card without raw image if no data", async () => {
     (fetchUrl as jest.Mock).mockResolvedValue({ data: [] });
 
     const metadata = await generateMetadata({
       params: Promise.resolve({ id: "30" }),
     });
 
-    const images = Array.isArray(metadata.openGraph?.images)
-      ? metadata.openGraph.images
-      : [metadata.openGraph?.images];
+    const [image] = metadata.openGraph?.images as {
+      url: string;
+    }[];
+    const url = new URL(image.url);
 
-    expect(images?.[0]).toBe("https://test.6529.io/6529io.png");
+    expect(url.pathname).toBe(`/api/og-metadata/nfts/${GRADIENT_CONTRACT}/30`);
+    expect(url.searchParams.get("image")).toBeNull();
   });
 });

--- a/__tests__/app/nextgenMetadataPages.test.tsx
+++ b/__tests__/app/nextgenMetadataPages.test.tsx
@@ -80,7 +80,7 @@ const token: NextGenToken = {
   handle: "6529er",
   hodl_rate: 0,
   icon_url: "https://cdn.test/icon.png",
-  id: 123,
+  id: 10000000042,
   image_url: "https://cdn.test/token.png",
   last_sale_date: new Date("2024-01-01T00:00:00Z"),
   last_sale_value: 0,
@@ -93,9 +93,9 @@ const token: NextGenToken = {
   mint_data: "{}",
   mint_date: new Date("2024-01-01T00:00:00Z"),
   mint_price: 0,
-  name: "Pebble #123",
+  name: "Pebble #42",
   normalised_handle: "6529er",
-  normalised_id: 123,
+  normalised_id: 42,
   opensea_price: 0,
   opensea_royalty: 0,
   owner: "0xowner",
@@ -144,10 +144,10 @@ const getSocialImage = (metadata: Metadata) => {
 const mockNextgenFetches = () => {
   (commonApiFetch as jest.Mock).mockImplementation(
     ({ endpoint }: { endpoint: string }) => {
-      if (endpoint === "nextgen/tokens/123") {
+      if (endpoint === "nextgen/tokens/10000000042") {
         return Promise.resolve(token);
       }
-      if (endpoint === "nextgen/tokens/123/traits") {
+      if (endpoint === "nextgen/tokens/10000000042/traits") {
         return Promise.resolve([{ token_count: 100 }]);
       }
       if (
@@ -250,27 +250,30 @@ describe("NextGen metadata", () => {
 
     const metadata = await generateNextGenTokenMetadata({
       params: Promise.resolve({
-        token: "123",
+        token: "10000000042",
         view: ["provenance"],
       }),
     });
     const image = getSocialImage(metadata);
     const url = new URL(image.url);
 
-    expect(metadata.title).toBe("Pebble #123 | Provenance");
+    expect(metadata.title).toBe("Pebble #42 | Provenance");
     expect(metadata.twitter?.card).toBe("summary_large_image");
     expect(image).toMatchObject({
-      alt: "Pebble #123 | Provenance social card",
+      alt: "Pebble #42 | Provenance social card",
       height: 630,
       width: 1200,
     });
-    expect(url.pathname).toBe(`/api/og-metadata/nfts/${NEXTGEN_CONTRACT}/123`);
+    expect(url.pathname).toBe(
+      `/api/og-metadata/nfts/${NEXTGEN_CONTRACT}/10000000042`
+    );
     expect(url.searchParams.get("artist")).toBe("6529er");
     expect(url.searchParams.get("badge")).toBe("NextGen");
     expect(url.searchParams.get("collection")).toBe("Pebbles");
+    expect(url.searchParams.get("displayId")).toBe("42");
     expect(url.searchParams.get("image")).toBe("https://cdn.test/thumb.png");
-    expect(url.searchParams.get("subtitle")).toBe("Pebbles #123 | NextGen");
-    expect(url.searchParams.get("title")).toBe("Pebble #123 | Provenance");
+    expect(url.searchParams.get("subtitle")).toBe("Pebbles #42 | NextGen");
+    expect(url.searchParams.get("title")).toBe("Pebble #42 | Provenance");
   });
 
   it("falls back to a branded NextGen token card when token data is missing", async () => {

--- a/__tests__/app/nextgenMetadataPages.test.tsx
+++ b/__tests__/app/nextgenMetadataPages.test.tsx
@@ -1,0 +1,292 @@
+import { generateMetadata as generateNextGenCollectionMetadata } from "@/app/nextgen/collection/[collection]/[[...view]]/page";
+import { generateNextgenCollectionMetadata } from "@/app/nextgen/collection/[collection]/page-utils";
+import { generateMetadata as generateNextGenMetadata } from "@/app/nextgen/[[...view]]/page";
+import { generateMetadata as generateNextGenAdminMetadata } from "@/app/nextgen/manager/page";
+import { generateMetadata as generateNextGenTokenMetadata } from "@/app/nextgen/token/[token]/[[...view]]/page";
+import { NEXTGEN_CONTRACT } from "@/constants/constants";
+import { commonApiFetch } from "@/services/api/common-api";
+import type { NextGenCollection, NextGenToken } from "@/entities/INextgen";
+import type { Metadata } from "next";
+
+jest.mock("@/helpers/server.app.helpers", () => ({
+  getAppCommonHeaders: jest.fn().mockResolvedValue({ "x-test": "1" }),
+}));
+
+jest.mock("@/services/api/common-api", () => ({ commonApiFetch: jest.fn() }));
+
+jest.mock("@/app/nextgen/[[...view]]/NextGenPageClient", () => ({
+  __esModule: true,
+  default: () => <div data-testid="nextgen-page" />,
+}));
+
+jest.mock(
+  "@/app/nextgen/token/[token]/[[...view]]/NextGenTokenPageClient",
+  () => ({
+    __esModule: true,
+    default: () => <div data-testid="nextgen-token" />,
+  })
+);
+
+jest.mock(
+  "@/components/nextGen/collections/collectionParts/NextGenCollection",
+  () => ({
+    __esModule: true,
+    default: () => <div data-testid="nextgen-collection" />,
+  })
+);
+
+jest.mock("@/components/nextGen/admin/NextGenAdmin", () => ({
+  __esModule: true,
+  default: () => <div data-testid="nextgen-admin" />,
+}));
+
+const collection: NextGenCollection = {
+  allowlist_end: 0,
+  allowlist_start: 0,
+  artist: "6529er",
+  artist_address: "0xartist",
+  artist_signature: "0xsig",
+  banner: "https://cdn.test/pebbles-banner.png",
+  base_uri: "https://generator.test/",
+  created_at: "2024-01-01T00:00:00Z",
+  dependency_script: "",
+  description: "Pebbles description",
+  distribution_plan: "Random",
+  final_supply_after_mint: 100,
+  id: 1,
+  image: "https://cdn.test/pebbles.png",
+  library: "p5js",
+  licence: "CC0",
+  max_purchases: 1,
+  merkle_root: "0xroot",
+  mint_count: 10,
+  name: "Pebbles",
+  on_chain: true,
+  opensea_link: "https://opensea.test/pebbles",
+  public_end: 0,
+  public_start: 0,
+  total_supply: 100,
+  updated_at: "2024-01-01T00:00:00Z",
+  website: "https://pebbles.test",
+};
+
+const token: NextGenToken = {
+  animation_url: "https://cdn.test/animation.html",
+  blur_price: 0,
+  burnt: false,
+  collection_id: 1,
+  collection_name: "Pebbles",
+  created_at: "2024-01-01T00:00:00Z",
+  handle: "6529er",
+  hodl_rate: 0,
+  icon_url: "https://cdn.test/icon.png",
+  id: 123,
+  image_url: "https://cdn.test/token.png",
+  last_sale_date: new Date("2024-01-01T00:00:00Z"),
+  last_sale_value: 0,
+  level: 1,
+  max_sale_date: new Date("2024-01-01T00:00:00Z"),
+  max_sale_value: 0,
+  me_price: 0,
+  me_royalty: 0,
+  metadata_url: "https://cdn.test/token.json",
+  mint_data: "{}",
+  mint_date: new Date("2024-01-01T00:00:00Z"),
+  mint_price: 0,
+  name: "Pebble #123",
+  normalised_handle: "6529er",
+  normalised_id: 123,
+  opensea_price: 0,
+  opensea_royalty: 0,
+  owner: "0xowner",
+  pending: false,
+  price: 0,
+  rarity_score: 0,
+  rarity_score_normalised: 0,
+  rarity_score_normalised_rank: 0,
+  rarity_score_rank: 0,
+  rarity_score_trait_count: 0,
+  rarity_score_trait_count_normalised: 0,
+  rarity_score_trait_count_normalised_rank: 0,
+  rarity_score_trait_count_rank: 0,
+  rep_score: 0,
+  single_trait_rarity_score: 0,
+  single_trait_rarity_score_normalised: 0,
+  single_trait_rarity_score_normalised_rank: 0,
+  single_trait_rarity_score_rank: 0,
+  single_trait_rarity_score_trait_count: 0,
+  single_trait_rarity_score_trait_count_normalised: 0,
+  single_trait_rarity_score_trait_count_normalised_rank: 0,
+  single_trait_rarity_score_trait_count_rank: 0,
+  statistical_score: 0,
+  statistical_score_normalised: 0,
+  statistical_score_normalised_rank: 0,
+  statistical_score_rank: 0,
+  statistical_score_trait_count: 0,
+  statistical_score_trait_count_normalised: 0,
+  statistical_score_trait_count_normalised_rank: 0,
+  statistical_score_trait_count_rank: 0,
+  tdh: 0,
+  thumbnail_url: "https://cdn.test/thumb.png",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+const getSocialImage = (metadata: Metadata) => {
+  const [image] = metadata.openGraph?.images as {
+    alt: string;
+    height: number;
+    url: string;
+    width: number;
+  }[];
+  return image;
+};
+
+const mockNextgenFetches = () => {
+  (commonApiFetch as jest.Mock).mockImplementation(
+    ({ endpoint }: { endpoint: string }) => {
+      if (endpoint === "nextgen/tokens/123") {
+        return Promise.resolve(token);
+      }
+      if (endpoint === "nextgen/tokens/123/traits") {
+        return Promise.resolve([{ token_count: 100 }]);
+      }
+      if (
+        endpoint === "nextgen/collections/1" ||
+        endpoint === "nextgen/collections/pebbles"
+      ) {
+        return Promise.resolve(collection);
+      }
+      return Promise.reject(new Error(`Unexpected endpoint ${endpoint}`));
+    }
+  );
+};
+
+describe("NextGen metadata", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("uses the branded NextGen collection card on view pages", async () => {
+    const metadata = await generateNextGenMetadata({
+      params: Promise.resolve({ view: ["collections"] }),
+    });
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("NextGen Collections");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(image).toMatchObject({
+      alt: "NextGen Collections social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe("/api/og-metadata/collections/nextgen");
+    expect(url.searchParams.get("subtitle")).toBe(
+      "Generative art collections from 6529"
+    );
+    expect(url.searchParams.get("title")).toBe("NextGen Collections");
+  });
+
+  it("uses a route-specific NextGen collection card for admin metadata", async () => {
+    const metadata = await generateNextGenAdminMetadata();
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("NextGen Admin");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(url.pathname).toBe("/api/og-metadata/collections/nextgen");
+    expect(url.searchParams.get("subtitle")).toBe("Manage NextGen collections");
+    expect(url.searchParams.get("title")).toBe("NextGen Admin");
+  });
+
+  it("uses collection facts in NextGen collection page cards", async () => {
+    mockNextgenFetches();
+
+    const metadata = await generateNextGenCollectionMetadata({
+      params: Promise.resolve({
+        collection: "pebbles",
+        view: ["rarity"],
+      }),
+    });
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("Pebbles | Rarity");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(image).toMatchObject({
+      alt: "Pebbles | Rarity social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe("/api/og-metadata/collections/nextgen");
+    expect(url.searchParams.get("image")).toBe(
+      "https://cdn.test/pebbles-banner.png"
+    );
+    expect(url.searchParams.get("subtitle")).toBe("Pebbles | NextGen");
+    expect(url.searchParams.get("title")).toBe("Pebbles | Rarity");
+  });
+
+  it("uses collection facts in NextGen collection subpage cards", async () => {
+    mockNextgenFetches();
+
+    const metadata = await generateNextgenCollectionMetadata({
+      collection: "pebbles",
+      headers: { "x-test": "1" },
+      page: "Mint",
+    });
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("Mint | Pebbles");
+    expect(url.pathname).toBe("/api/og-metadata/collections/nextgen");
+    expect(url.searchParams.get("image")).toBe(
+      "https://cdn.test/pebbles-banner.png"
+    );
+    expect(url.searchParams.get("title")).toBe("Mint | Pebbles");
+  });
+
+  it("uses branded NFT card metadata for NextGen token pages", async () => {
+    mockNextgenFetches();
+
+    const metadata = await generateNextGenTokenMetadata({
+      params: Promise.resolve({
+        token: "123",
+        view: ["provenance"],
+      }),
+    });
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("Pebble #123 | Provenance");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(image).toMatchObject({
+      alt: "Pebble #123 | Provenance social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe(`/api/og-metadata/nfts/${NEXTGEN_CONTRACT}/123`);
+    expect(url.searchParams.get("artist")).toBe("6529er");
+    expect(url.searchParams.get("badge")).toBe("NextGen");
+    expect(url.searchParams.get("collection")).toBe("Pebbles");
+    expect(url.searchParams.get("image")).toBe("https://cdn.test/thumb.png");
+    expect(url.searchParams.get("subtitle")).toBe("Pebbles #123 | NextGen");
+    expect(url.searchParams.get("title")).toBe("Pebble #123 | Provenance");
+  });
+
+  it("falls back to a branded NextGen token card when token data is missing", async () => {
+    (commonApiFetch as jest.Mock).mockRejectedValue(new Error("missing"));
+
+    const metadata = await generateNextGenTokenMetadata({
+      params: Promise.resolve({ token: "999" }),
+    });
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("NextGen Token");
+    expect(url.pathname).toBe(`/api/og-metadata/nfts/${NEXTGEN_CONTRACT}/999`);
+    expect(url.searchParams.get("badge")).toBe("NextGen");
+    expect(url.searchParams.get("collection")).toBe("NextGen");
+    expect(url.searchParams.get("image")).toBeNull();
+    expect(url.searchParams.get("title")).toBe("NextGen #999");
+  });
+});

--- a/__tests__/app/rememesMetadataPages.test.tsx
+++ b/__tests__/app/rememesMetadataPages.test.tsx
@@ -1,0 +1,193 @@
+import { generateMetadata as generateRememeDetailMetadata } from "@/app/rememes/[contract]/[id]/page";
+import { generateMetadata as generateRememesAddMetadata } from "@/app/rememes/add/page";
+import { generateMetadata as generateRememesMetadata } from "@/app/rememes/page";
+import { getAppCommonHeaders } from "@/helpers/server.app.helpers";
+import { fetchUrl } from "@/services/6529api";
+import type { Metadata } from "next";
+
+jest.mock("@/services/6529api", () => ({ fetchUrl: jest.fn() }));
+
+jest.mock("@/helpers/server.app.helpers", () => ({
+  getAppCommonHeaders: jest.fn().mockResolvedValue({ "x-test": "1" }),
+}));
+
+jest.mock("@/components/rememes/Rememes", () => ({
+  __esModule: true,
+  default: () => <div data-testid="rememes" />,
+}));
+
+jest.mock("@/components/rememes/RememeAddPage", () => ({
+  __esModule: true,
+  default: () => <div data-testid="rememe-add" />,
+}));
+
+jest.mock("@/components/rememes/RememePage", () => ({
+  __esModule: true,
+  default: () => <div data-testid="rememe-page" />,
+}));
+
+const getSocialImage = (metadata: Metadata) => {
+  const [image] = metadata.openGraph?.images as {
+    alt: string;
+    height: number;
+    url: string;
+    width: number;
+  }[];
+  return image;
+};
+
+describe("ReMemes metadata", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("uses the branded ReMemes collection card on the landing page", async () => {
+    const metadata = await generateRememesMetadata();
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("ReMemes");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(image).toMatchObject({
+      alt: "ReMemes collection social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe("/api/og-metadata/collections/rememes");
+    expect(url.search).toBe("");
+  });
+
+  it("uses a route-specific ReMemes card on the add page", async () => {
+    const metadata = await generateRememesAddMetadata();
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("ReMemes | Add");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(image).toMatchObject({
+      alt: "Add ReMeme social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe("/api/og-metadata/collections/rememes");
+    expect(url.searchParams.get("subtitle")).toBe(
+      "Submit a community remix or derivative"
+    );
+    expect(url.searchParams.get("title")).toBe("Add a ReMeme");
+  });
+
+  it("uses branded NFT card metadata for ReMeme detail pages", async () => {
+    (fetchUrl as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          contract_opensea_data: {
+            collectionName: "Remix Editions",
+            imageUrl: "https://cdn.test/collection.png",
+          },
+          image: "https://cdn.test/raw.png",
+          media: [{ gateway: "https://cdn.test/gateway.png" }],
+          metadata: { name: "Community Remix" },
+          s3_image_original: "https://cdn.test/original.png",
+          s3_image_scaled: "https://cdn.test/scaled.png",
+        },
+      ],
+    });
+
+    const metadata = await generateRememeDetailMetadata({
+      params: Promise.resolve({ contract: "0xabc", id: "7" }),
+    });
+
+    expect(getAppCommonHeaders).toHaveBeenCalled();
+    expect(fetchUrl).toHaveBeenCalledWith(
+      expect.stringContaining("/api/rememes?contract=0xabc&id=7"),
+      { headers: { "x-test": "1" } }
+    );
+
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("Community Remix");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(image).toMatchObject({
+      alt: "Community Remix ReMeme social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe("/api/og-metadata/nfts/0xabc/7");
+    expect(url.searchParams.get("badge")).toBe("ReMemes");
+    expect(url.searchParams.get("collection")).toBe("Remix Editions");
+    expect(url.searchParams.get("image")).toBe("https://cdn.test/scaled.png");
+    expect(url.searchParams.get("subtitle")).toBe(
+      "Remix Editions #7 | ReMemes"
+    );
+    expect(url.searchParams.get("title")).toBe("Community Remix");
+  });
+
+  it("uses Alchemy-style media objects for ReMeme detail card images", async () => {
+    (fetchUrl as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          contract_opensea_data: {
+            collectionName: "SEIZING",
+            imageUrl: "https://cdn.test/collection.png",
+          },
+          image: "",
+          media: {
+            cachedUrl: "https://cdn.test/cached.gif",
+            contentType: "image/gif",
+            originalUrl: "https://arweave.test/original",
+            pngUrl: "https://cdn.test/converted.png",
+            size: 9908164,
+            thumbnailUrl: "https://cdn.test/thumb.gif",
+          },
+          metadata: { name: "GDRC #2" },
+          s3_image_original: "",
+          s3_image_scaled: "",
+        },
+      ],
+    });
+
+    const metadata = await generateRememeDetailMetadata({
+      params: Promise.resolve({
+        contract: "0x869a96493d64ed5bbbfc24d96c5e84f95e558cf2",
+        id: "39",
+      }),
+    });
+
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("GDRC #2");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(url.pathname).toBe(
+      "/api/og-metadata/nfts/0x869a96493d64ed5bbbfc24d96c5e84f95e558cf2/39"
+    );
+    expect(url.searchParams.get("collection")).toBe("SEIZING");
+    expect(url.searchParams.get("image")).toBe("https://cdn.test/thumb.gif");
+    expect(url.searchParams.get("title")).toBe("GDRC #2");
+  });
+
+  it("falls back to a branded ReMeme NFT card when API data is missing", async () => {
+    (fetchUrl as jest.Mock).mockResolvedValue({ data: [] });
+
+    const metadata = await generateRememeDetailMetadata({
+      params: Promise.resolve({ contract: "0xabc", id: "8" }),
+    });
+
+    expect(getAppCommonHeaders).toHaveBeenCalled();
+    expect(fetchUrl).toHaveBeenCalledWith(
+      expect.stringContaining("/api/rememes?contract=0xabc&id=8"),
+      { headers: { "x-test": "1" } }
+    );
+
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("0xabc #8");
+    expect(url.pathname).toBe("/api/og-metadata/nfts/0xabc/8");
+    expect(url.searchParams.get("badge")).toBe("ReMemes");
+    expect(url.searchParams.get("collection")).toBe("ReMemes");
+    expect(url.searchParams.get("image")).toBeNull();
+    expect(url.searchParams.get("title")).toBe("0xabc #8");
+  });
+});

--- a/__tests__/app/the-memes/theMemesMint.test.tsx
+++ b/__tests__/app/the-memes/theMemesMint.test.tsx
@@ -9,6 +9,13 @@ jest.mock("next/dynamic", () => () => (props: any) => (
   <div data-testid="dynamic" {...props} />
 ));
 
+jest.mock("@/components/the-memes/TheMemesMint", () => ({
+  __esModule: true,
+  default: ({ nft }: { nft: { id: number } }) => (
+    <div data-testid="mint-component" data-nft-id={nft.id} />
+  ),
+}));
+
 jest.mock("@/helpers/server.app.helpers", () => ({
   getAppCommonHeaders: jest.fn(),
 }));
@@ -50,9 +57,10 @@ describe("TheMemesMintPage", () => {
       <AuthContext.Provider value={{} as any}>{jsx}</AuthContext.Provider>
     );
 
-    const dynamic = await screen.findByTestId("dynamic");
+    const mint = await screen.findByTestId("mint-component");
 
-    expect(dynamic).toBeInTheDocument();
+    expect(mint).toBeInTheDocument();
+    expect(mint).toHaveAttribute("data-nft-id", "1");
     expect(commonApiFetch).toHaveBeenCalledWith({
       endpoint: "memes_latest",
       headers: { h: "1" },
@@ -61,19 +69,39 @@ describe("TheMemesMintPage", () => {
 
   it("exports metadata", async () => {
     const metadata = await generateMetadata();
-    expect(metadata).toEqual({
+    const [image] = metadata.openGraph?.images as {
+      alt: string;
+      height: number;
+      url: string;
+      width: number;
+    }[];
+    const url = new URL(image.url);
+
+    expect(metadata).toMatchObject({
       title: "Mint | The Memes",
       description: "Collections | 6529.io",
       icons: { icon: "/favicon.ico" },
-      openGraph: {
-        images: ["https://test.6529.io/memes-preview.png"],
-        title: "Mint | The Memes",
-        description: "Collections | 6529.io",
-      },
       other: { version: "test-version" },
       twitter: {
         card: "summary_large_image",
+        site: "@6529Collections",
       },
     });
+    expect(metadata.openGraph).toMatchObject({
+      type: "website",
+      siteName: "6529.io",
+      title: "Mint | The Memes",
+      description: "Collections | 6529.io",
+    });
+    expect(image).toMatchObject({
+      alt: "The Memes mint social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe("/api/og-metadata/collections/the-memes");
+    expect(url.searchParams.get("subtitle")).toBe(
+      "Latest The Memes mint on 6529.io"
+    );
+    expect(url.searchParams.get("title")).toBe("Mint | The Memes");
   });
 });

--- a/__tests__/components/providers/metadata.test.ts
+++ b/__tests__/components/providers/metadata.test.ts
@@ -6,8 +6,10 @@ import {
   SOCIAL_CARD_IMAGE_WIDTH,
   getAbsoluteOgImageUrl,
   getAppMetadata,
+  getCollectionSocialCardImagePath,
   getDefaultOgImageUrl,
   getLargeSocialCardMetadata,
+  getNftSocialCardImagePath,
 } from "@/components/providers/metadata";
 
 describe("Metadata functionality (migrated from _document.tsx)", () => {
@@ -176,6 +178,40 @@ describe("Metadata functionality (migrated from _document.tsx)", () => {
         ogImageWidth: SOCIAL_CARD_IMAGE_WIDTH,
         twitterCard: LARGE_IMAGE_TWITTER_CARD,
       });
+    });
+
+    it("builds collection social-card image paths", () => {
+      expect(getCollectionSocialCardImagePath("the-memes")).toBe(
+        "/api/og-metadata/collections/the-memes"
+      );
+
+      expect(
+        getCollectionSocialCardImagePath("the memes", {
+          badge: "6529",
+          image: "/memes-preview.png",
+          subtitle: "The Memes by 6529",
+          title: "The Memes",
+        })
+      ).toBe(
+        "/api/og-metadata/collections/the%20memes?badge=6529&image=%2Fmemes-preview.png&subtitle=The+Memes+by+6529&title=The+Memes"
+      );
+    });
+
+    it("builds NFT social-card image paths", () => {
+      expect(
+        getNftSocialCardImagePath({
+          artist: "6529er",
+          badge: "The Memes",
+          collection: "The Memes",
+          contract: "0xabc/def",
+          id: "1/2",
+          image: "https://cdn.test/image.png",
+          subtitle: "The Memes #1 | Collections",
+          title: "Seize the Memes",
+        })
+      ).toBe(
+        "/api/og-metadata/nfts/0xabc%2Fdef/1%2F2?artist=6529er&badge=The+Memes&collection=The+Memes&image=https%3A%2F%2Fcdn.test%2Fimage.png&subtitle=The+Memes+%231+%7C+Collections&title=Seize+the+Memes"
+      );
     });
   });
 });

--- a/__tests__/components/providers/metadata.test.ts
+++ b/__tests__/components/providers/metadata.test.ts
@@ -204,13 +204,14 @@ describe("Metadata functionality (migrated from _document.tsx)", () => {
           badge: "The Memes",
           collection: "The Memes",
           contract: "0xabc/def",
+          displayId: 42,
           id: "1/2",
           image: "https://cdn.test/image.png",
           subtitle: "The Memes #1 | Collections",
           title: "Seize the Memes",
         })
       ).toBe(
-        "/api/og-metadata/nfts/0xabc%2Fdef/1%2F2?artist=6529er&badge=The+Memes&collection=The+Memes&image=https%3A%2F%2Fcdn.test%2Fimage.png&subtitle=The+Memes+%231+%7C+Collections&title=Seize+the+Memes"
+        "/api/og-metadata/nfts/0xabc%2Fdef/1%2F2?artist=6529er&badge=The+Memes&collection=The+Memes&displayId=42&image=https%3A%2F%2Fcdn.test%2Fimage.png&subtitle=The+Memes+%231+%7C+Collections&title=Seize+the+Memes"
       );
     });
   });

--- a/__tests__/components/providers/metadataSocialCardGuardrails.test.ts
+++ b/__tests__/components/providers/metadataSocialCardGuardrails.test.ts
@@ -1,0 +1,132 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+type MetadataSourceGuardrail = {
+  readonly requiredSnippets: readonly string[];
+  readonly routePath: string;
+};
+
+// Manually enrolled routes: add new standardized metadata surfaces here.
+const standardizedMetadataSources: readonly MetadataSourceGuardrail[] = [
+  {
+    routePath: "app/the-memes/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/the-memes/mint/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/meme-lab/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/6529-gradient/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/6529-gradient/[id]/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getNftSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/rememes/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/rememes/add/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/rememes/[contract]/[id]/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getNftSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/nextgen/[[...view]]/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/nextgen/manager/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/nextgen/collection/[collection]/page-utils.ts",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/nextgen/collection/[collection]/[[...view]]/page.tsx",
+    requiredSnippets: ["getNextgenCollectionMetadata("],
+  },
+  {
+    routePath: "app/nextgen/token/[token]/[[...view]]/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getNftSocialCardImagePath(",
+    ],
+  },
+];
+
+// Heuristics for the most common drift patterns, not exhaustive source parsing.
+const manualLargeTwitterCard = /twitterCard\s*:\s*["']summary_large_image["']/;
+const directBaseEndpointOgImage =
+  /ogImage\s*:\s*`[^`]*\$\{publicEnv\.BASE_ENDPOINT\}/;
+
+const readSource = (routePath: string): string => {
+  const absoluteRoutePath = path.join(process.cwd(), routePath);
+
+  if (!existsSync(absoluteRoutePath)) {
+    throw new Error(
+      `Expected guardrailed metadata route "${routePath}" to exist. ` +
+        "If this route moved or was renamed, update standardizedMetadataSources."
+    );
+  }
+
+  return readFileSync(absoluteRoutePath, "utf8");
+};
+
+describe("standardized social-card metadata route guardrails", () => {
+  it.each(standardizedMetadataSources)(
+    "$routePath keeps using shared social-card metadata helpers",
+    ({ requiredSnippets, routePath }) => {
+      const source = readSource(routePath);
+
+      requiredSnippets.forEach((snippet) => {
+        expect(source).toContain(snippet);
+      });
+      expect(source).not.toMatch(manualLargeTwitterCard);
+      expect(source).not.toMatch(directBaseEndpointOgImage);
+    }
+  );
+});

--- a/__tests__/components/the-memes/MemeShared.test.tsx
+++ b/__tests__/components/the-memes/MemeShared.test.tsx
@@ -1,4 +1,10 @@
-import { getMemeTabTitle, MEME_FOCUS } from "@/components/the-memes/MemeShared";
+import {
+  getMemeTabTitle,
+  getSharedAppServerSideProps,
+  MEME_FOCUS,
+} from "@/components/the-memes/MemeShared";
+import { MEMELAB_CONTRACT, MEMES_CONTRACT } from "@/constants/constants";
+import { fetchUrl } from "@/services/6529api";
 
 jest.mock("@/services/6529api", () => ({ fetchUrl: jest.fn() }));
 
@@ -11,5 +17,79 @@ describe("getMemeTabTitle", () => {
 
   it("returns original title when no extras", () => {
     expect(getMemeTabTitle("The Memes")).toBe("The Memes");
+  });
+});
+
+describe("getSharedAppServerSideProps", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("builds large branded social metadata for The Memes", async () => {
+    (fetchUrl as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          artist: "6529er",
+          name: "Seize the Memes",
+          thumbnail: "https://cdn.test/seize.png",
+        },
+      ],
+    });
+
+    const metadata = await getSharedAppServerSideProps(
+      MEMES_CONTRACT,
+      "1",
+      MEME_FOCUS.COLLECTORS
+    );
+    const [image] = metadata.openGraph?.images as {
+      alt: string;
+      height: number;
+      url: string;
+      width: number;
+    }[];
+    const url = new URL(image.url);
+
+    expect(fetchUrl).toHaveBeenCalledWith(
+      `https://api.test.6529.io/api/nfts?contract=${MEMES_CONTRACT}&id=1`
+    );
+    expect(metadata.title).toBe("Seize the Memes | Collectors");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(image).toMatchObject({
+      alt: "Seize the Memes | Collectors social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe(`/api/og-metadata/nfts/${MEMES_CONTRACT}/1`);
+    expect(url.searchParams.get("artist")).toBe("6529er");
+    expect(url.searchParams.get("badge")).toBe("The Memes");
+    expect(url.searchParams.get("collection")).toBe("The Memes");
+    expect(url.searchParams.get("image")).toBe("https://cdn.test/seize.png");
+    expect(url.searchParams.get("subtitle")).toBe("The Memes #1 | Collections");
+    expect(url.searchParams.get("title")).toBe("Seize the Memes | Collectors");
+  });
+
+  it("builds Meme Lab social cards without raw media when data is missing", async () => {
+    (fetchUrl as jest.Mock).mockResolvedValue({ data: [] });
+
+    const metadata = await getSharedAppServerSideProps(
+      MEMELAB_CONTRACT,
+      "2",
+      MEME_FOCUS.LIVE,
+      true
+    );
+    const [image] = metadata.openGraph?.images as {
+      url: string;
+    }[];
+    const url = new URL(image.url);
+
+    expect(fetchUrl).toHaveBeenCalledWith(
+      `https://api.test.6529.io/api/nfts_memelab?contract=${MEMELAB_CONTRACT}&id=2`
+    );
+    expect(metadata.title).toBe("Meme Lab #2 | Distribution");
+    expect(url.pathname).toBe(`/api/og-metadata/nfts/${MEMELAB_CONTRACT}/2`);
+    expect(url.searchParams.get("badge")).toBe("Meme Lab");
+    expect(url.searchParams.get("collection")).toBe("Meme Lab");
+    expect(url.searchParams.get("image")).toBeNull();
+    expect(url.searchParams.get("title")).toBe("Meme Lab #2 | Distribution");
   });
 });

--- a/app/6529-gradient/[id]/page.tsx
+++ b/app/6529-gradient/[id]/page.tsx
@@ -1,5 +1,9 @@
 import GradientPageComponent from "@/components/6529Gradient/GradientPage";
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getLargeSocialCardMetadata,
+  getNftSocialCardImagePath,
+} from "@/components/providers/metadata";
 import { publicEnv } from "@/config/env";
 import { GRADIENT_CONTRACT } from "@/constants/constants";
 import { fetchUrl } from "@/services/6529api";
@@ -27,25 +31,36 @@ export async function generateMetadata({
   const { id } = await params;
 
   let title = `6529 Gradient #${id}`;
-  let ogImage = `${publicEnv.BASE_ENDPOINT}/6529io.png`;
+  let image: string | null = null;
   try {
     const response = await fetchUrl(
       `${publicEnv.API_ENDPOINT}/api/nfts?contract=${GRADIENT_CONTRACT}&id=${id}`
     );
     if (response?.data?.length > 0) {
-      if (response.data[0].thumbnail) {
-        ogImage = response.data[0].thumbnail;
-      } else if (response.data[0].image) {
-        ogImage = response.data[0].image;
+      const nft = response.data[0];
+      if (nft.thumbnail) {
+        image = nft.thumbnail;
+      } else if (nft.image) {
+        image = nft.image;
       }
     }
   } catch (error) {
     console.error(`Failed to load gradient metadata for id ${id}`, error);
   }
-  return getAppMetadata({
-    title,
-    description: "Collections | 6529.io",
-    ogImage,
-    twitterCard: "summary",
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title,
+      description: "Collections",
+      ogImage: getNftSocialCardImagePath({
+        badge: "6529 Gradient",
+        collection: "6529 Gradient",
+        contract: GRADIENT_CONTRACT,
+        id,
+        image,
+        subtitle: "Collections",
+        title,
+      }),
+      ogImageAlt: `${title} social card`,
+    })
+  );
 }

--- a/app/6529-gradient/page.tsx
+++ b/app/6529-gradient/page.tsx
@@ -1,6 +1,9 @@
 import GradientsComponent from "@/components/6529Gradient/6529Gradient";
-import { getAppMetadata } from "@/components/providers/metadata";
-import { publicEnv } from "@/config/env";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import styles from "@/styles/Home.module.scss";
 import type { Metadata } from "next";
 
@@ -13,10 +16,12 @@ export default function GradientsPage() {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({
-    title: "6529 Gradient",
-    description: "Collections",
-    ogImage: `${publicEnv.BASE_ENDPOINT}/gradients-preview.png`,
-    twitterCard: "summary_large_image",
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title: "6529 Gradient",
+      description: "Collections",
+      ogImage: getCollectionSocialCardImagePath("6529-gradient"),
+      ogImageAlt: "6529 Gradient collection social card",
+    })
+  );
 }

--- a/app/api/og-metadata/_lib/brandedCards.tsx
+++ b/app/api/og-metadata/_lib/brandedCards.tsx
@@ -35,14 +35,21 @@ const SUBTITLE_MAX_LINES = 3;
 const BADGE_TOP = 62;
 const NFT_TITLE_TOP = 154;
 const NFT_META_TOP = 404;
+const NFT_SUBTITLE_TOP = NFT_META_TOP - 78;
+const NFT_TITLE_SUBTITLE_GAP = 26;
+const NFT_SUBTITLE_META_GAP = 18;
 const COLLECTION_TITLE_TOP = 156;
 const COLLECTION_SUBTITLE_TOP = 338;
+
+// ImageResponse markup renders raw image elements; next/image is unavailable in generated OG image trees.
+const OgRawImage = "img";
 
 export type BrandedNftOgImageModel = {
   readonly artist?: string | null | undefined;
   readonly badge?: string | null | undefined;
   readonly collection?: string | null | undefined;
   readonly contract: string;
+  readonly displayId?: string | null | undefined;
   readonly id: string;
   readonly imageUrl?: string | null | undefined;
   readonly origin?: string | undefined;
@@ -131,6 +138,77 @@ const getSubtitleLines = (
     ellipsize: true,
   });
 
+const getKeyedLines = (
+  lines: readonly string[]
+): readonly {
+  readonly key: string;
+  readonly value: string;
+}[] => {
+  const seenCounts = new Map<string, number>();
+
+  return lines.map((value) => {
+    const count = seenCounts.get(value) ?? 0;
+    seenCounts.set(value, count + 1);
+
+    return {
+      key: count === 0 ? value : `${value}-${count}`,
+      value,
+    };
+  });
+};
+
+const getLineBlockHeight = ({
+  lineCount,
+  fontSize,
+  lineHeight,
+}: {
+  readonly lineCount: number;
+  readonly fontSize: number;
+  readonly lineHeight: number;
+}): number => lineCount * fontSize * lineHeight;
+
+const getNftLayout = ({
+  subtitleLines,
+  titleLines,
+}: {
+  readonly subtitleLines: readonly string[];
+  readonly titleLines: readonly string[];
+}): {
+  readonly metaTop: number;
+  readonly subtitleTop: number;
+} => {
+  const titleHeight = getLineBlockHeight({
+    lineCount: titleLines.length,
+    fontSize: TITLE_FONT_SIZE,
+    lineHeight: TITLE_LINE_HEIGHT,
+  });
+  const subtitleTop = Math.max(
+    NFT_SUBTITLE_TOP,
+    NFT_TITLE_TOP + titleHeight + NFT_TITLE_SUBTITLE_GAP
+  );
+
+  if (subtitleLines.length === 0) {
+    return {
+      metaTop: Math.max(NFT_META_TOP, subtitleTop),
+      subtitleTop,
+    };
+  }
+
+  const subtitleHeight = getLineBlockHeight({
+    lineCount: subtitleLines.length,
+    fontSize: SUBTITLE_FONT_SIZE,
+    lineHeight: SUBTITLE_LINE_HEIGHT,
+  });
+
+  return {
+    metaTop: Math.max(
+      NFT_META_TOP,
+      subtitleTop + subtitleHeight + NFT_SUBTITLE_META_GAP
+    ),
+    subtitleTop,
+  };
+};
+
 const CardLogo = () => (
   <div
     style={{
@@ -142,7 +220,7 @@ const CardLogo = () => (
       width: LOGO_SIZE,
     }}
   >
-    <img
+    <OgRawImage
       alt=""
       height={LOGO_SIZE}
       src={LOGO_URL}
@@ -181,7 +259,7 @@ const CardMedia = ({
     }}
   >
     {imageUrl ? (
-      <img
+      <OgRawImage
         alt=""
         height={MEDIA_SIZE}
         src={imageUrl}
@@ -272,9 +350,9 @@ const TitleLines = ({
       width: CONTENT_WIDTH,
     }}
   >
-    {lines.map((line, index) => (
+    {getKeyedLines(lines).map(({ key, value }) => (
       <div
-        key={`${line}-${index}`}
+        key={key}
         style={{
           display: "flex",
           overflow: "hidden",
@@ -282,7 +360,7 @@ const TitleLines = ({
           width: CONTENT_WIDTH,
         }}
       >
-        {line}
+        {value}
       </div>
     ))}
   </div>
@@ -310,9 +388,9 @@ const SubtitleLines = ({
       width: CONTENT_WIDTH,
     }}
   >
-    {lines.map((line, index) => (
+    {getKeyedLines(lines).map(({ key, value }) => (
       <div
-        key={`${line}-${index}`}
+        key={key}
         style={{
           display: "flex",
           overflow: "hidden",
@@ -320,7 +398,7 @@ const SubtitleLines = ({
           width: CONTENT_WIDTH,
         }}
       >
-        {line}
+        {value}
       </div>
     ))}
   </div>
@@ -331,6 +409,7 @@ export const renderBrandedNftOgImage = ({
   badge,
   collection,
   contract,
+  displayId,
   id,
   imageUrl,
   origin = publicEnv.BASE_ENDPOINT,
@@ -350,12 +429,14 @@ export const renderBrandedNftOgImage = ({
     origin,
     width: MEDIA_SIZE,
   });
+  const { metaTop, subtitleTop } = getNftLayout({ subtitleLines, titleLines });
   const artistLabel = getUsableText(artist);
-  const numericId = /^(0|[1-9]\d*)$/.test(id) ? Number(id) : null;
+  const visibleId = getUsableText(displayId) === null ? id : (displayId ?? id);
+  const numericId = /^(0|[1-9]\d*)$/.test(visibleId) ? Number(visibleId) : null;
   const idLabel =
     numericId !== null && Number.isSafeInteger(numericId)
-      ? `#${formatInteger(numericId) ?? id}`
-      : `#${id}`;
+      ? `#${formatInteger(numericId) ?? visibleId}`
+      : `#${visibleId}`;
 
   return (
     <div
@@ -378,7 +459,7 @@ export const renderBrandedNftOgImage = ({
         lines={titleLines}
         top={NFT_TITLE_TOP}
       />
-      <SubtitleLines lines={subtitleLines} top={NFT_META_TOP - 78} />
+      <SubtitleLines lines={subtitleLines} top={subtitleTop} />
       <div
         style={{
           color: MUTED_TEXT,
@@ -391,7 +472,7 @@ export const renderBrandedNftOgImage = ({
           letterSpacing: 0,
           lineHeight: 1,
           position: "absolute",
-          top: NFT_META_TOP,
+          top: metaTop,
           width: CONTENT_WIDTH,
         }}
       >

--- a/app/api/og-metadata/_lib/brandedCards.tsx
+++ b/app/api/og-metadata/_lib/brandedCards.tsx
@@ -1,0 +1,460 @@
+import { publicEnv } from "@/config/env";
+import {
+  formatInteger,
+  getMediaProxyUrl,
+  getUsableText,
+  getWrappedTextLines,
+  shortenAddress,
+  truncateText,
+} from "@/app/api/og-metadata/_lib/imageUtils";
+
+const CANVAS_WIDTH = 1200;
+const CANVAS_HEIGHT = 630;
+const LOGO_URL = `${publicEnv.BASE_ENDPOINT}/6529.svg`;
+const LOGO_SIZE = 42;
+const CARD_BACKGROUND = "#141418";
+const PANEL_BACKGROUND = "#0F1015";
+const PANEL_BORDER = "rgba(255,255,255,0.1)";
+const MUTED_TEXT = "#9A9AA5";
+const ACCENT_TEXT = "#7DD3FC";
+const HORIZONTAL_MARGIN = 46;
+const MEDIA_LEFT = 46;
+const MEDIA_TOP = 46;
+const MEDIA_SIZE = 538;
+const CONTENT_LEFT = 644;
+const CONTENT_WIDTH = CANVAS_WIDTH - CONTENT_LEFT - HORIZONTAL_MARGIN;
+const TITLE_FONT_SIZE = 58;
+const TITLE_LINE_HEIGHT = 1.08;
+const TITLE_MAX_LINES = 3;
+const COLLECTION_TITLE_FONT_SIZE = 64;
+const COLLECTION_TITLE_MAX_LINES = 2;
+const SUBTITLE_FONT_SIZE = 34;
+const SUBTITLE_LINE_HEIGHT = 1.18;
+const SUBTITLE_MAX_LINES = 3;
+const BADGE_TOP = 62;
+const NFT_TITLE_TOP = 154;
+const NFT_META_TOP = 404;
+const COLLECTION_TITLE_TOP = 156;
+const COLLECTION_SUBTITLE_TOP = 338;
+
+export type BrandedNftOgImageModel = {
+  readonly artist?: string | null | undefined;
+  readonly badge?: string | null | undefined;
+  readonly collection?: string | null | undefined;
+  readonly contract: string;
+  readonly id: string;
+  readonly imageUrl?: string | null | undefined;
+  readonly origin?: string | undefined;
+  readonly subtitle?: string | null | undefined;
+  readonly title: string;
+};
+
+export type BrandedCollectionOgImageModel = {
+  readonly badge?: string | null | undefined;
+  readonly imageUrl?: string | null | undefined;
+  readonly origin?: string | undefined;
+  readonly slug: string;
+  readonly subtitle?: string | null | undefined;
+  readonly title: string;
+};
+
+const getDisplayImageUrl = ({
+  imageUrl,
+  origin,
+  width,
+}: {
+  readonly imageUrl: string | null | undefined;
+  readonly origin: string;
+  readonly width: number;
+}): string | null => {
+  const normalizedImageUrl = getUsableText(imageUrl);
+  if (!normalizedImageUrl) {
+    return null;
+  }
+
+  try {
+    const url = new URL(normalizedImageUrl);
+    return url.protocol === "https:"
+      ? getMediaProxyUrl({
+          sourceUrl: url.toString(),
+          origin,
+          width,
+        })
+      : null;
+  } catch {
+    const localPath = normalizedImageUrl.startsWith("/")
+      ? normalizedImageUrl
+      : `/${normalizedImageUrl}`;
+    return new URL(localPath, publicEnv.BASE_ENDPOINT).toString();
+  }
+};
+
+const getTitleLines = ({
+  fontSize,
+  maxLines,
+  value,
+}: {
+  readonly fontSize: number;
+  readonly maxLines: number;
+  readonly value: string;
+}): readonly string[] =>
+  getWrappedTextLines({
+    value,
+    fontSize,
+    wrapWidth: CONTENT_WIDTH,
+    maxLines,
+    ellipsize: true,
+  });
+
+const getSubtitleLines = (
+  value: string | null | undefined
+): readonly string[] =>
+  getWrappedTextLines({
+    value,
+    fontSize: SUBTITLE_FONT_SIZE,
+    wrapWidth: CONTENT_WIDTH,
+    maxLines: SUBTITLE_MAX_LINES,
+    ellipsize: true,
+  });
+
+const CardLogo = () => (
+  <div
+    style={{
+      display: "flex",
+      height: LOGO_SIZE,
+      position: "absolute",
+      right: HORIZONTAL_MARGIN,
+      bottom: HORIZONTAL_MARGIN,
+      width: LOGO_SIZE,
+    }}
+  >
+    <img
+      alt=""
+      height={LOGO_SIZE}
+      src={LOGO_URL}
+      style={{
+        height: LOGO_SIZE,
+        objectFit: "contain",
+        opacity: 0.75,
+        width: LOGO_SIZE,
+      }}
+      width={LOGO_SIZE}
+    />
+  </div>
+);
+
+const CardMedia = ({
+  imageUrl,
+  label,
+}: {
+  readonly imageUrl: string | null;
+  readonly label: string;
+}) => (
+  <div
+    style={{
+      alignItems: "center",
+      background: PANEL_BACKGROUND,
+      border: `1px solid ${PANEL_BORDER}`,
+      borderRadius: 30,
+      display: "flex",
+      height: MEDIA_SIZE,
+      justifyContent: "center",
+      left: MEDIA_LEFT,
+      overflow: "hidden",
+      position: "absolute",
+      top: MEDIA_TOP,
+      width: MEDIA_SIZE,
+    }}
+  >
+    {imageUrl ? (
+      <img
+        alt=""
+        height={MEDIA_SIZE}
+        src={imageUrl}
+        style={{
+          height: MEDIA_SIZE,
+          objectFit: "contain",
+          width: MEDIA_SIZE,
+        }}
+        width={MEDIA_SIZE}
+      />
+    ) : (
+      <div
+        style={{
+          alignItems: "center",
+          color: "#FFFFFF",
+          display: "flex",
+          flexDirection: "column",
+          fontSize: 76,
+          fontWeight: 700,
+          gap: 18,
+          justifyContent: "center",
+          letterSpacing: 0,
+          lineHeight: 1,
+          width: MEDIA_SIZE,
+        }}
+      >
+        <span>6529</span>
+        <span
+          style={{
+            color: MUTED_TEXT,
+            fontSize: 28,
+            fontWeight: 600,
+          }}
+        >
+          {truncateText(label, 28)}
+        </span>
+      </div>
+    )}
+  </div>
+);
+
+const Badge = ({ value }: { readonly value: string }) => (
+  <div
+    style={{
+      alignItems: "center",
+      background: "rgba(125, 211, 252, 0.11)",
+      border: "1px solid rgba(125, 211, 252, 0.3)",
+      borderRadius: 999,
+      color: ACCENT_TEXT,
+      display: "flex",
+      fontSize: 24,
+      fontWeight: 700,
+      height: 42,
+      justifyContent: "center",
+      lineHeight: 1,
+      padding: "0 20px",
+      position: "absolute",
+      left: CONTENT_LEFT,
+      top: BADGE_TOP,
+      whiteSpace: "nowrap",
+    }}
+  >
+    {value}
+  </div>
+);
+
+const TitleLines = ({
+  lines,
+  top,
+  fontSize,
+}: {
+  readonly fontSize: number;
+  readonly lines: readonly string[];
+  readonly top: number;
+}) => (
+  <div
+    style={{
+      color: "#FFFFFF",
+      display: "flex",
+      flexDirection: "column",
+      fontSize,
+      fontWeight: 800,
+      left: CONTENT_LEFT,
+      letterSpacing: 0,
+      lineHeight: TITLE_LINE_HEIGHT,
+      position: "absolute",
+      top,
+      width: CONTENT_WIDTH,
+    }}
+  >
+    {lines.map((line, index) => (
+      <div
+        key={`${line}-${index}`}
+        style={{
+          display: "flex",
+          overflow: "hidden",
+          whiteSpace: "nowrap",
+          width: CONTENT_WIDTH,
+        }}
+      >
+        {line}
+      </div>
+    ))}
+  </div>
+);
+
+const SubtitleLines = ({
+  lines,
+  top,
+}: {
+  readonly lines: readonly string[];
+  readonly top: number;
+}) => (
+  <div
+    style={{
+      color: "#D5D5DC",
+      display: "flex",
+      flexDirection: "column",
+      fontSize: SUBTITLE_FONT_SIZE,
+      fontWeight: 500,
+      left: CONTENT_LEFT,
+      letterSpacing: 0,
+      lineHeight: SUBTITLE_LINE_HEIGHT,
+      position: "absolute",
+      top,
+      width: CONTENT_WIDTH,
+    }}
+  >
+    {lines.map((line, index) => (
+      <div
+        key={`${line}-${index}`}
+        style={{
+          display: "flex",
+          overflow: "hidden",
+          whiteSpace: "nowrap",
+          width: CONTENT_WIDTH,
+        }}
+      >
+        {line}
+      </div>
+    ))}
+  </div>
+);
+
+export const renderBrandedNftOgImage = ({
+  artist,
+  badge,
+  collection,
+  contract,
+  id,
+  imageUrl,
+  origin = publicEnv.BASE_ENDPOINT,
+  subtitle,
+  title,
+}: BrandedNftOgImageModel) => {
+  const resolvedCollection = getUsableText(collection) ?? "NFT";
+  const resolvedBadge = getUsableText(badge) ?? resolvedCollection;
+  const resolvedTitle = getUsableText(title) ?? `${resolvedCollection} #${id}`;
+  const titleLines = getTitleLines({
+    value: resolvedTitle,
+    fontSize: TITLE_FONT_SIZE,
+    maxLines: TITLE_MAX_LINES,
+  });
+  const subtitleLines = getSubtitleLines(subtitle);
+  const displayImageUrl = getDisplayImageUrl({
+    imageUrl,
+    origin,
+    width: MEDIA_SIZE,
+  });
+  const artistLabel = getUsableText(artist);
+  const idLabel = Number.isFinite(Number(id))
+    ? `#${formatInteger(Number(id)) ?? id}`
+    : `#${id}`;
+
+  return (
+    <div
+      style={{
+        background: CARD_BACKGROUND,
+        color: "#FFFFFF",
+        display: "flex",
+        fontFamily: "Montserrat, sans-serif",
+        height: CANVAS_HEIGHT,
+        overflow: "hidden",
+        position: "relative",
+        width: CANVAS_WIDTH,
+      }}
+    >
+      <CardMedia imageUrl={displayImageUrl} label={resolvedCollection} />
+      <CardLogo />
+      <Badge value={resolvedBadge} />
+      <TitleLines
+        fontSize={TITLE_FONT_SIZE}
+        lines={titleLines}
+        top={NFT_TITLE_TOP}
+      />
+      <SubtitleLines lines={subtitleLines} top={NFT_META_TOP - 78} />
+      <div
+        style={{
+          color: MUTED_TEXT,
+          display: "flex",
+          flexDirection: "column",
+          fontSize: 30,
+          fontWeight: 600,
+          gap: 16,
+          left: CONTENT_LEFT,
+          letterSpacing: 0,
+          lineHeight: 1,
+          position: "absolute",
+          top: NFT_META_TOP,
+          width: CONTENT_WIDTH,
+        }}
+      >
+        <div style={{ display: "flex", gap: 12 }}>
+          <span style={{ color: "#FFFFFF" }}>{idLabel}</span>
+          <span>{resolvedCollection}</span>
+        </div>
+        {artistLabel ? (
+          <div style={{ display: "flex", gap: 12 }}>
+            <span>by</span>
+            <span style={{ color: "#FFFFFF" }}>{artistLabel}</span>
+          </div>
+        ) : null}
+        <div style={{ display: "flex", fontSize: 24 }}>
+          {shortenAddress(contract)}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const renderBrandedCollectionOgImage = ({
+  badge,
+  imageUrl,
+  origin = publicEnv.BASE_ENDPOINT,
+  slug,
+  subtitle,
+  title,
+}: BrandedCollectionOgImageModel) => {
+  const resolvedBadge = getUsableText(badge) ?? "6529 Collections";
+  const titleLines = getTitleLines({
+    value: title,
+    fontSize: COLLECTION_TITLE_FONT_SIZE,
+    maxLines: COLLECTION_TITLE_MAX_LINES,
+  });
+  const subtitleLines = getSubtitleLines(subtitle);
+  const displayImageUrl = getDisplayImageUrl({
+    imageUrl,
+    origin,
+    width: MEDIA_SIZE,
+  });
+
+  return (
+    <div
+      style={{
+        background: CARD_BACKGROUND,
+        color: "#FFFFFF",
+        display: "flex",
+        fontFamily: "Montserrat, sans-serif",
+        height: CANVAS_HEIGHT,
+        overflow: "hidden",
+        position: "relative",
+        width: CANVAS_WIDTH,
+      }}
+    >
+      <CardMedia imageUrl={displayImageUrl} label={title} />
+      <CardLogo />
+      <Badge value={resolvedBadge} />
+      <TitleLines
+        fontSize={COLLECTION_TITLE_FONT_SIZE}
+        lines={titleLines}
+        top={COLLECTION_TITLE_TOP}
+      />
+      <SubtitleLines lines={subtitleLines} top={COLLECTION_SUBTITLE_TOP} />
+      <div
+        style={{
+          color: MUTED_TEXT,
+          display: "flex",
+          fontSize: 26,
+          fontWeight: 600,
+          left: CONTENT_LEFT,
+          letterSpacing: 0,
+          position: "absolute",
+          top: 508,
+        }}
+      >
+        {slug}
+      </div>
+    </div>
+  );
+};

--- a/app/api/og-metadata/_lib/brandedCards.tsx
+++ b/app/api/og-metadata/_lib/brandedCards.tsx
@@ -72,6 +72,14 @@ const getDisplayImageUrl = ({
     return null;
   }
 
+  if (normalizedImageUrl.startsWith("//")) {
+    return getMediaProxyUrl({
+      sourceUrl: `https:${normalizedImageUrl}`,
+      origin,
+      width,
+    });
+  }
+
   try {
     const url = new URL(normalizedImageUrl);
     return url.protocol === "https:"
@@ -82,10 +90,14 @@ const getDisplayImageUrl = ({
         })
       : null;
   } catch {
-    const localPath = normalizedImageUrl.startsWith("/")
-      ? normalizedImageUrl
-      : `/${normalizedImageUrl}`;
-    return new URL(localPath, publicEnv.BASE_ENDPOINT).toString();
+    if (!normalizedImageUrl.startsWith("/")) {
+      return null;
+    }
+
+    const resolvedUrl = new URL(normalizedImageUrl, publicEnv.BASE_ENDPOINT);
+    const baseOrigin = new URL(publicEnv.BASE_ENDPOINT).origin;
+
+    return resolvedUrl.origin === baseOrigin ? resolvedUrl.toString() : null;
   }
 };
 

--- a/app/api/og-metadata/_lib/brandedCards.tsx
+++ b/app/api/og-metadata/_lib/brandedCards.tsx
@@ -7,6 +7,7 @@ import {
   shortenAddress,
   truncateText,
 } from "@/app/api/og-metadata/_lib/imageUtils";
+import { isAllowedOgImageSourceUrl } from "@/app/api/og-metadata/_lib/imageProxyPolicy";
 
 const CANVAS_WIDTH = 1200;
 const CANVAS_HEIGHT = 630;
@@ -72,23 +73,24 @@ const getDisplayImageUrl = ({
     return null;
   }
 
-  if (normalizedImageUrl.startsWith("//")) {
-    return getMediaProxyUrl({
-      sourceUrl: `https:${normalizedImageUrl}`,
-      origin,
-      width,
-    });
-  }
-
-  try {
-    const url = new URL(normalizedImageUrl);
-    return url.protocol === "https:"
+  const getProxiedPublicHttpsUrl = (sourceUrl: string): string | null =>
+    isAllowedOgImageSourceUrl(sourceUrl)
       ? getMediaProxyUrl({
-          sourceUrl: url.toString(),
+          sourceUrl,
           origin,
           width,
         })
       : null;
+
+  // Query-supplied external media must be public HTTPS and go through the
+  // normal OG image proxy. Local static assets may only resolve to BASE_ENDPOINT.
+  if (normalizedImageUrl.startsWith("//")) {
+    return getProxiedPublicHttpsUrl(`https:${normalizedImageUrl}`);
+  }
+
+  try {
+    const url = new URL(normalizedImageUrl);
+    return getProxiedPublicHttpsUrl(url.toString());
   } catch {
     if (!normalizedImageUrl.startsWith("/")) {
       return null;
@@ -337,9 +339,8 @@ export const renderBrandedNftOgImage = ({
 }: BrandedNftOgImageModel) => {
   const resolvedCollection = getUsableText(collection) ?? "NFT";
   const resolvedBadge = getUsableText(badge) ?? resolvedCollection;
-  const resolvedTitle = getUsableText(title) ?? `${resolvedCollection} #${id}`;
   const titleLines = getTitleLines({
-    value: resolvedTitle,
+    value: title,
     fontSize: TITLE_FONT_SIZE,
     maxLines: TITLE_MAX_LINES,
   });
@@ -350,9 +351,11 @@ export const renderBrandedNftOgImage = ({
     width: MEDIA_SIZE,
   });
   const artistLabel = getUsableText(artist);
-  const idLabel = Number.isFinite(Number(id))
-    ? `#${formatInteger(Number(id)) ?? id}`
-    : `#${id}`;
+  const numericId = /^(0|[1-9]\d*)$/.test(id) ? Number(id) : null;
+  const idLabel =
+    numericId !== null && Number.isSafeInteger(numericId)
+      ? `#${formatInteger(numericId) ?? id}`
+      : `#${id}`;
 
   return (
     <div

--- a/app/api/og-metadata/_lib/routeUtils.ts
+++ b/app/api/og-metadata/_lib/routeUtils.ts
@@ -9,6 +9,7 @@ export const OG_CACHE_CONTROL =
   "public, max-age=1800, s-maxage=3600, stale-while-revalidate=86400";
 
 export const MAX_TEXT_LENGTH = 180;
+export const MAX_IMAGE_URL_LENGTH = 8192;
 
 export const getQueryText = (
   searchParams: URLSearchParams,
@@ -16,4 +17,16 @@ export const getQueryText = (
 ): string | null => {
   const normalized = getUsableText(searchParams.get(key));
   return normalized ? normalized.slice(0, MAX_TEXT_LENGTH) : null;
+};
+
+export const getQueryImageUrl = (
+  searchParams: URLSearchParams,
+  key: string
+): string | null => {
+  const normalized = getUsableText(searchParams.get(key));
+  if (normalized === null || normalized.length > MAX_IMAGE_URL_LENGTH) {
+    return null;
+  }
+
+  return normalized;
 };

--- a/app/api/og-metadata/_lib/routeUtils.ts
+++ b/app/api/og-metadata/_lib/routeUtils.ts
@@ -1,0 +1,19 @@
+import { getUsableText } from "@/app/api/og-metadata/_lib/imageUtils";
+
+export const OG_IMAGE_SIZE = {
+  width: 1200,
+  height: 630,
+} as const;
+
+export const OG_CACHE_CONTROL =
+  "public, max-age=1800, s-maxage=3600, stale-while-revalidate=86400";
+
+export const MAX_TEXT_LENGTH = 180;
+
+export const getQueryText = (
+  searchParams: URLSearchParams,
+  key: string
+): string | null => {
+  const normalized = getUsableText(searchParams.get(key));
+  return normalized ? normalized.slice(0, MAX_TEXT_LENGTH) : null;
+};

--- a/app/api/og-metadata/collections/[collection]/route.ts
+++ b/app/api/og-metadata/collections/[collection]/route.ts
@@ -4,6 +4,7 @@ import {
   type BrandedCollectionOgImageModel,
 } from "@/app/api/og-metadata/_lib/brandedCards";
 import {
+  getQueryImageUrl,
   getQueryText,
   OG_CACHE_CONTROL,
   OG_IMAGE_SIZE,
@@ -65,7 +66,7 @@ const getCollectionCardModel = ({
 
   return {
     badge: getQueryText(searchParams, "badge"),
-    imageUrl: getQueryText(searchParams, "image") ?? defaults?.imageUrl,
+    imageUrl: getQueryImageUrl(searchParams, "image") ?? defaults?.imageUrl,
     origin: getOgImageRequestOrigin(request),
     slug,
     subtitle:

--- a/app/api/og-metadata/collections/[collection]/route.ts
+++ b/app/api/og-metadata/collections/[collection]/route.ts
@@ -3,6 +3,11 @@ import {
   renderBrandedCollectionOgImage,
   type BrandedCollectionOgImageModel,
 } from "@/app/api/og-metadata/_lib/brandedCards";
+import {
+  getQueryText,
+  OG_CACHE_CONTROL,
+  OG_IMAGE_SIZE,
+} from "@/app/api/og-metadata/_lib/routeUtils";
 import { getUsableText } from "@/app/api/og-metadata/_lib/imageUtils";
 import { loadMontserratFonts } from "@/app/api/og-metadata/profiles/[identity]/font";
 import { ImageResponse } from "next/og";
@@ -10,14 +15,6 @@ import { NextResponse } from "next/server";
 
 export const runtime = "edge";
 export const revalidate = 3600;
-
-const OG_IMAGE_SIZE = {
-  width: 1200,
-  height: 630,
-} as const;
-const OG_CACHE_CONTROL =
-  "public, max-age=1800, s-maxage=3600, stale-while-revalidate=86400";
-const MAX_TEXT_LENGTH = 180;
 
 const COLLECTION_DEFAULTS: Record<
   string,
@@ -52,14 +49,6 @@ const COLLECTION_DEFAULTS: Record<
     subtitle: "The Memes by 6529",
     title: "The Memes",
   },
-};
-
-const getQueryText = (
-  searchParams: URLSearchParams,
-  key: string
-): string | null => {
-  const normalized = getUsableText(searchParams.get(key));
-  return normalized ? normalized.slice(0, MAX_TEXT_LENGTH) : null;
 };
 
 const getCollectionCardModel = ({

--- a/app/api/og-metadata/collections/[collection]/route.ts
+++ b/app/api/og-metadata/collections/[collection]/route.ts
@@ -1,0 +1,137 @@
+import { getOgImageRequestOrigin } from "@/app/api/og-metadata/_lib/requestOrigin";
+import {
+  renderBrandedCollectionOgImage,
+  type BrandedCollectionOgImageModel,
+} from "@/app/api/og-metadata/_lib/brandedCards";
+import { getUsableText } from "@/app/api/og-metadata/_lib/imageUtils";
+import { loadMontserratFonts } from "@/app/api/og-metadata/profiles/[identity]/font";
+import { ImageResponse } from "next/og";
+import { NextResponse } from "next/server";
+
+export const runtime = "edge";
+export const revalidate = 3600;
+
+const OG_IMAGE_SIZE = {
+  width: 1200,
+  height: 630,
+} as const;
+const OG_CACHE_CONTROL =
+  "public, max-age=1800, s-maxage=3600, stale-while-revalidate=86400";
+const MAX_TEXT_LENGTH = 180;
+
+const COLLECTION_DEFAULTS: Record<
+  string,
+  {
+    readonly imageUrl: string;
+    readonly subtitle: string;
+    readonly title: string;
+  }
+> = {
+  "6529-gradient": {
+    imageUrl: "/gradients-preview.png",
+    subtitle: "The official 6529 Gradient collection",
+    title: "6529 Gradient",
+  },
+  "meme-lab": {
+    imageUrl: "/meme-lab.jpg",
+    subtitle: "Experiments, editions, and collaborations from Meme Lab",
+    title: "Meme Lab",
+  },
+  nextgen: {
+    imageUrl: "/nextgen.png",
+    subtitle: "Generative art collections from 6529",
+    title: "NextGen",
+  },
+  rememes: {
+    imageUrl: "/re-memes-b.jpeg",
+    subtitle: "Community remixes and derivatives",
+    title: "ReMemes",
+  },
+  "the-memes": {
+    imageUrl: "/memes-preview.png",
+    subtitle: "The Memes by 6529",
+    title: "The Memes",
+  },
+};
+
+const getQueryText = (
+  searchParams: URLSearchParams,
+  key: string
+): string | null => {
+  const normalized = getUsableText(searchParams.get(key));
+  return normalized ? normalized.slice(0, MAX_TEXT_LENGTH) : null;
+};
+
+const getCollectionCardModel = ({
+  request,
+  slug,
+}: {
+  readonly request: Request;
+  readonly slug: string;
+}): BrandedCollectionOgImageModel => {
+  const searchParams = new URL(request.url).searchParams;
+  const defaults = COLLECTION_DEFAULTS[slug];
+  const title =
+    getQueryText(searchParams, "title") ?? defaults?.title ?? "6529 Collection";
+
+  return {
+    badge: getQueryText(searchParams, "badge"),
+    imageUrl: getQueryText(searchParams, "image") ?? defaults?.imageUrl,
+    origin: getOgImageRequestOrigin(request),
+    slug,
+    subtitle:
+      getQueryText(searchParams, "subtitle") ??
+      defaults?.subtitle ??
+      "Collections on 6529.io",
+    title,
+  };
+};
+
+export async function GET(
+  request: Request,
+  {
+    params,
+  }: {
+    readonly params: Promise<{
+      readonly collection?: string;
+    }>;
+  }
+) {
+  const { collection } = await params;
+  const normalizedCollection = getUsableText(collection)?.toLowerCase();
+
+  if (!normalizedCollection) {
+    return NextResponse.json(
+      {
+        error:
+          "Invalid collection. Use /api/og-metadata/collections/<collection>.",
+      },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const montserratFonts = await loadMontserratFonts();
+    return new ImageResponse(
+      renderBrandedCollectionOgImage(
+        getCollectionCardModel({
+          request,
+          slug: normalizedCollection,
+        })
+      ),
+      {
+        ...OG_IMAGE_SIZE,
+        fonts: montserratFonts,
+        headers: {
+          "Cache-Control": OG_CACHE_CONTROL,
+        },
+      }
+    );
+  } catch (error) {
+    console.error("Unable to generate collection OG metadata image.", error);
+    return NextResponse.json(
+      { error: "Unable to generate collection OG metadata image." },
+      { status: 502 }
+    );
+  }
+}

--- a/app/api/og-metadata/nfts/[contract]/[id]/route.ts
+++ b/app/api/og-metadata/nfts/[contract]/[id]/route.ts
@@ -4,6 +4,7 @@ import {
   type BrandedNftOgImageModel,
 } from "@/app/api/og-metadata/_lib/brandedCards";
 import {
+  getQueryImageUrl,
   getQueryText,
   OG_CACHE_CONTROL,
   OG_IMAGE_SIZE,
@@ -45,7 +46,7 @@ const getNftCardModel = ({
     contract,
     displayId: getQueryText(searchParams, "displayId"),
     id,
-    imageUrl: getQueryText(searchParams, "image"),
+    imageUrl: getQueryImageUrl(searchParams, "image"),
     origin: getOgImageRequestOrigin(request),
     subtitle: getQueryText(searchParams, "subtitle"),
     title,

--- a/app/api/og-metadata/nfts/[contract]/[id]/route.ts
+++ b/app/api/og-metadata/nfts/[contract]/[id]/route.ts
@@ -43,6 +43,7 @@ const getNftCardModel = ({
     badge: getQueryText(searchParams, "badge") ?? collection,
     collection,
     contract,
+    displayId: getQueryText(searchParams, "displayId"),
     id,
     imageUrl: getQueryText(searchParams, "image"),
     origin: getOgImageRequestOrigin(request),

--- a/app/api/og-metadata/nfts/[contract]/[id]/route.ts
+++ b/app/api/og-metadata/nfts/[contract]/[id]/route.ts
@@ -3,6 +3,11 @@ import {
   renderBrandedNftOgImage,
   type BrandedNftOgImageModel,
 } from "@/app/api/og-metadata/_lib/brandedCards";
+import {
+  getQueryText,
+  OG_CACHE_CONTROL,
+  OG_IMAGE_SIZE,
+} from "@/app/api/og-metadata/_lib/routeUtils";
 import { getUsableText } from "@/app/api/og-metadata/_lib/imageUtils";
 import { loadMontserratFonts } from "@/app/api/og-metadata/profiles/[identity]/font";
 import { ImageResponse } from "next/og";
@@ -10,22 +15,6 @@ import { NextResponse } from "next/server";
 
 export const runtime = "edge";
 export const revalidate = 3600;
-
-const OG_IMAGE_SIZE = {
-  width: 1200,
-  height: 630,
-} as const;
-const OG_CACHE_CONTROL =
-  "public, max-age=1800, s-maxage=3600, stale-while-revalidate=86400";
-const MAX_TEXT_LENGTH = 180;
-
-const getQueryText = (
-  searchParams: URLSearchParams,
-  key: string
-): string | null => {
-  const normalized = getUsableText(searchParams.get(key));
-  return normalized ? normalized.slice(0, MAX_TEXT_LENGTH) : null;
-};
 
 const getDefaultTitle = ({
   collection,

--- a/app/api/og-metadata/nfts/[contract]/[id]/route.ts
+++ b/app/api/og-metadata/nfts/[contract]/[id]/route.ts
@@ -1,0 +1,112 @@
+import { getOgImageRequestOrigin } from "@/app/api/og-metadata/_lib/requestOrigin";
+import {
+  renderBrandedNftOgImage,
+  type BrandedNftOgImageModel,
+} from "@/app/api/og-metadata/_lib/brandedCards";
+import { getUsableText } from "@/app/api/og-metadata/_lib/imageUtils";
+import { loadMontserratFonts } from "@/app/api/og-metadata/profiles/[identity]/font";
+import { ImageResponse } from "next/og";
+import { NextResponse } from "next/server";
+
+export const runtime = "edge";
+export const revalidate = 3600;
+
+const OG_IMAGE_SIZE = {
+  width: 1200,
+  height: 630,
+} as const;
+const OG_CACHE_CONTROL =
+  "public, max-age=1800, s-maxage=3600, stale-while-revalidate=86400";
+const MAX_TEXT_LENGTH = 180;
+
+const getQueryText = (
+  searchParams: URLSearchParams,
+  key: string
+): string | null => {
+  const normalized = getUsableText(searchParams.get(key));
+  return normalized ? normalized.slice(0, MAX_TEXT_LENGTH) : null;
+};
+
+const getDefaultTitle = ({
+  collection,
+  id,
+}: {
+  readonly collection: string | null;
+  readonly id: string;
+}): string => (collection ? `${collection} #${id}` : `NFT #${id}`);
+
+const getNftCardModel = ({
+  contract,
+  id,
+  request,
+}: {
+  readonly contract: string;
+  readonly id: string;
+  readonly request: Request;
+}): BrandedNftOgImageModel => {
+  const searchParams = new URL(request.url).searchParams;
+  const collection = getQueryText(searchParams, "collection");
+  const title =
+    getQueryText(searchParams, "title") ?? getDefaultTitle({ collection, id });
+
+  return {
+    artist: getQueryText(searchParams, "artist"),
+    badge: getQueryText(searchParams, "badge") ?? collection,
+    collection,
+    contract,
+    id,
+    imageUrl: getQueryText(searchParams, "image"),
+    origin: getOgImageRequestOrigin(request),
+    subtitle: getQueryText(searchParams, "subtitle"),
+    title,
+  };
+};
+
+export async function GET(
+  request: Request,
+  {
+    params,
+  }: {
+    readonly params: Promise<{
+      readonly contract?: string;
+      readonly id?: string;
+    }>;
+  }
+) {
+  const { contract, id } = await params;
+  const normalizedContract = getUsableText(contract);
+  const normalizedId = getUsableText(id);
+
+  if (!normalizedContract || !normalizedId) {
+    return NextResponse.json(
+      { error: "Invalid NFT. Use /api/og-metadata/nfts/<contract>/<id>." },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const montserratFonts = await loadMontserratFonts();
+    return new ImageResponse(
+      renderBrandedNftOgImage(
+        getNftCardModel({
+          contract: normalizedContract,
+          id: normalizedId,
+          request,
+        })
+      ),
+      {
+        ...OG_IMAGE_SIZE,
+        fonts: montserratFonts,
+        headers: {
+          "Cache-Control": OG_CACHE_CONTROL,
+        },
+      }
+    );
+  } catch (error) {
+    console.error("Unable to generate NFT OG metadata image.", error);
+    return NextResponse.json(
+      { error: "Unable to generate NFT OG metadata image." },
+      { status: 502 }
+    );
+  }
+}

--- a/app/meme-lab/page.tsx
+++ b/app/meme-lab/page.tsx
@@ -1,6 +1,9 @@
 import MemeLabComponent from "@/components/memelab/MemeLab";
-import { getAppMetadata } from "@/components/providers/metadata";
-import { publicEnv } from "@/config/env";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import styles from "@/styles/Home.module.scss";
 import type { Metadata } from "next";
 
@@ -13,10 +16,12 @@ export default function MemeLab() {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({
-    title: "Meme Lab",
-    ogImage: `${publicEnv.BASE_ENDPOINT}/meme-lab.jpg`,
-    description: "Collections",
-    twitterCard: "summary_large_image",
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title: "Meme Lab",
+      ogImage: getCollectionSocialCardImagePath("meme-lab"),
+      ogImageAlt: "Meme Lab collection social card",
+      description: "Collections",
+    })
+  );
 }

--- a/app/nextgen/[[...view]]/page.tsx
+++ b/app/nextgen/[[...view]]/page.tsx
@@ -1,4 +1,8 @@
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import type { NextGenCollection } from "@/entities/INextgen";
 import { getAppCommonHeaders } from "@/helpers/server.app.helpers";
 import { commonApiFetch } from "@/services/api/common-api";
@@ -22,7 +26,19 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { view } = await params;
   const nextgenView = getNextGenView(view?.[0] ?? "");
-  return getAppMetadata({ title: "NextGen " + (nextgenView ?? "") });
+  const title = nextgenView ? `NextGen ${nextgenView}` : "NextGen";
+
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title,
+      description: "NextGen",
+      ogImage: getCollectionSocialCardImagePath("nextgen", {
+        subtitle: "Generative art collections from 6529",
+        title,
+      }),
+      ogImageAlt: `${title} social card`,
+    })
+  );
 }
 
 export default async function NextGenPage({

--- a/app/nextgen/collection/[collection]/[[...view]]/page.tsx
+++ b/app/nextgen/collection/[collection]/[[...view]]/page.tsx
@@ -1,12 +1,15 @@
 import NextGenCollectionComponent from "@/components/nextGen/collections/collectionParts/NextGenCollection";
 import { getAppMetadata } from "@/components/providers/metadata";
-import { publicEnv } from "@/config/env";
 import { getAppCommonHeaders } from "@/helpers/server.app.helpers";
 import styles from "@/styles/Home.module.scss";
 import { NextgenCollectionView } from "@/types/enums";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { fetchCollection, getCollectionView } from "../page-utils";
+import {
+  fetchCollection,
+  getCollectionView,
+  getNextgenCollectionMetadata,
+} from "../page-utils";
 
 export async function generateMetadata({
   params,
@@ -24,14 +27,9 @@ export async function generateMetadata({
   if (resolvedView !== NextgenCollectionView.OVERVIEW) {
     title += ` | ${resolvedView}`;
   }
-  return getAppMetadata({
+  return getNextgenCollectionMetadata({
+    collection: resolvedCollection,
     title,
-    ogImage:
-      resolvedCollection.banner ||
-      resolvedCollection.image ||
-      `${publicEnv.BASE_ENDPOINT}/nextgen.png`,
-    description: "NextGen",
-    twitterCard: "summary_large_image",
   });
 }
 

--- a/app/nextgen/collection/[collection]/page-utils.ts
+++ b/app/nextgen/collection/[collection]/page-utils.ts
@@ -1,4 +1,8 @@
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import type { NextGenCollection } from "@/entities/INextgen";
 import { isEmptyObject } from "@/helpers/Helpers";
 import { commonApiFetch } from "@/services/api/common-api";
@@ -46,6 +50,29 @@ export function getContentViewKeyByValue(value: string): string {
   return NextgenCollectionView.OVERVIEW;
 }
 
+export function getNextgenCollectionMetadata({
+  collection,
+  subtitle,
+  title,
+}: {
+  readonly collection: NextGenCollection;
+  readonly subtitle?: string | undefined;
+  readonly title: string;
+}): Metadata {
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title,
+      description: "NextGen",
+      ogImage: getCollectionSocialCardImagePath("nextgen", {
+        image: collection.banner || collection.image,
+        subtitle: subtitle ?? `${collection.name} | NextGen`,
+        title,
+      }),
+      ogImageAlt: `${title} social card`,
+    })
+  );
+}
+
 export async function generateNextgenCollectionMetadata({
   collection,
   headers,
@@ -59,10 +86,9 @@ export async function generateNextgenCollectionMetadata({
   if (!resolvedCollection) {
     return getAppMetadata({ title: page });
   }
-  return getAppMetadata({
+  return getNextgenCollectionMetadata({
+    collection: resolvedCollection,
+    subtitle: `${resolvedCollection.name} | NextGen`,
     title: `${page} | ${resolvedCollection.name}`,
-    ogImage: resolvedCollection.image,
-    description: "NextGen",
-    twitterCard: "summary_large_image",
   });
 }

--- a/app/nextgen/manager/page.tsx
+++ b/app/nextgen/manager/page.tsx
@@ -1,11 +1,25 @@
 import NextGenAdminComponent from "@/components/nextGen/admin/NextGenAdmin";
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import type { Metadata } from "next";
 import { Container, Row, Col } from "react-bootstrap";
 import styles from "@/styles/Home.module.scss";
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({ title: "NextGen Admin" });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title: "NextGen Admin",
+      description: "NextGen",
+      ogImage: getCollectionSocialCardImagePath("nextgen", {
+        subtitle: "Manage NextGen collections",
+        title: "NextGen Admin",
+      }),
+      ogImageAlt: "NextGen Admin social card",
+    })
+  );
 }
 
 export default function NextGenAdminPage() {

--- a/app/nextgen/token/[token]/[[...view]]/page.tsx
+++ b/app/nextgen/token/[token]/[[...view]]/page.tsx
@@ -1,5 +1,9 @@
-import { getAppMetadata } from "@/components/providers/metadata";
-import { publicEnv } from "@/config/env";
+import {
+  getAppMetadata,
+  getLargeSocialCardMetadata,
+  getNftSocialCardImagePath,
+} from "@/components/providers/metadata";
+import { NEXTGEN_CONTRACT } from "@/constants/constants";
 import { getAppCommonHeaders } from "@/helpers/server.app.helpers";
 import { NextgenCollectionView } from "@/types/enums";
 import type { Metadata } from "next";
@@ -16,7 +20,21 @@ export async function generateMetadata({
   const headers = await getAppCommonHeaders();
   const data = await fetchTokenData(token, headers);
   if (!data) {
-    return getAppMetadata({ title: "NextGen Token" });
+    return getAppMetadata(
+      getLargeSocialCardMetadata({
+        title: "NextGen Token",
+        description: "NextGen",
+        ogImage: getNftSocialCardImagePath({
+          badge: "NextGen",
+          collection: "NextGen",
+          contract: NEXTGEN_CONTRACT,
+          id: token,
+          subtitle: "NextGen",
+          title: `NextGen #${token}`,
+        }),
+        ogImageAlt: "NextGen Token social card",
+      })
+    );
   }
   const resolvedView = getContentView(view?.[0] ?? "");
   const viewDisplay =
@@ -24,15 +42,27 @@ export async function generateMetadata({
   const baseTitle =
     data.token?.name ?? `${data.collection.name} - #${data.tokenId}`;
   const title = viewDisplay ? `${baseTitle} | ${viewDisplay}` : baseTitle;
-  return getAppMetadata({
-    title,
-    ogImage:
-      data.token?.thumbnail_url ||
-      data.token?.image_url ||
-      data.collection.banner ||
-      `${publicEnv.BASE_ENDPOINT}/nextgen.png`,
-    description: "NextGen",
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title,
+      description: "NextGen",
+      ogImage: getNftSocialCardImagePath({
+        artist: data.collection.artist,
+        badge: "NextGen",
+        collection: data.collection.name,
+        contract: NEXTGEN_CONTRACT,
+        id: data.tokenId,
+        image:
+          data.token?.thumbnail_url ||
+          data.token?.image_url ||
+          data.collection.banner ||
+          data.collection.image,
+        subtitle: `${data.collection.name} #${data.tokenId} | NextGen`,
+        title,
+      }),
+      ogImageAlt: `${title} social card`,
+    })
+  );
 }
 
 export default async function NextGenTokenPage({

--- a/app/nextgen/token/[token]/[[...view]]/page.tsx
+++ b/app/nextgen/token/[token]/[[...view]]/page.tsx
@@ -11,6 +11,15 @@ import { notFound } from "next/navigation";
 import NextGenTokenPageClient from "./NextGenTokenPageClient";
 import { fetchTokenData, getContentView } from "./page-utils";
 
+const isUsableImageSource = (
+  source: string | null | undefined
+): source is string =>
+  source !== null && source !== undefined && source.trim().length > 0;
+
+const getFirstUsableImage = (
+  ...sources: readonly (string | null | undefined)[]
+): string | undefined => sources.find(isUsableImageSource);
+
 export async function generateMetadata({
   params,
 }: {
@@ -39,9 +48,11 @@ export async function generateMetadata({
   const resolvedView = getContentView(view?.[0] ?? "");
   const viewDisplay =
     resolvedView !== NextgenCollectionView.ABOUT ? resolvedView : "";
+  const displayId = data.token?.normalised_id;
   const baseTitle =
     data.token?.name ?? `${data.collection.name} - #${data.tokenId}`;
-  const title = viewDisplay ? `${baseTitle} | ${viewDisplay}` : baseTitle;
+  const title =
+    viewDisplay.length > 0 ? `${baseTitle} | ${viewDisplay}` : baseTitle;
   return getAppMetadata(
     getLargeSocialCardMetadata({
       title,
@@ -51,13 +62,17 @@ export async function generateMetadata({
         badge: "NextGen",
         collection: data.collection.name,
         contract: NEXTGEN_CONTRACT,
+        displayId,
         id: data.tokenId,
-        image:
-          data.token?.thumbnail_url ||
-          data.token?.image_url ||
-          data.collection.banner ||
-          data.collection.image,
-        subtitle: `${data.collection.name} #${data.tokenId} | NextGen`,
+        image: getFirstUsableImage(
+          data.token?.thumbnail_url,
+          data.token?.image_url,
+          data.collection.banner,
+          data.collection.image
+        ),
+        subtitle: `${data.collection.name} #${
+          displayId ?? data.tokenId
+        } | NextGen`,
         title,
       }),
       ogImageAlt: `${title} social card`,

--- a/app/rememes/[contract]/[id]/page.tsx
+++ b/app/rememes/[contract]/[id]/page.tsx
@@ -1,12 +1,80 @@
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getLargeSocialCardMetadata,
+  getNftSocialCardImagePath,
+} from "@/components/providers/metadata";
 import RememePage from "@/components/rememes/RememePage";
 import { publicEnv } from "@/config/env";
 import { formatAddress } from "@/helpers/Helpers";
+import { getAppCommonHeaders } from "@/helpers/server.app.helpers";
 import { fetchUrl } from "@/services/6529api";
 import styles from "@/styles/Home.module.scss";
 import type { DBResponse } from "@/entities/IDBResponse";
 import type { Rememe } from "@/entities/INFT";
 import type { Metadata } from "next";
+
+const getNonEmptyText = (value: string | undefined): string | undefined => {
+  const normalized = value?.trim() ?? "";
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+const getRememeCollectionName = (rememe?: Rememe): string =>
+  getNonEmptyText(rememe?.contract_opensea_data.collectionName) ?? "ReMemes";
+
+const getRememeName = (rememe: Rememe): string | undefined => {
+  const metadata = rememe.metadata as { name?: unknown };
+  return typeof metadata.name === "string"
+    ? getNonEmptyText(metadata.name)
+    : undefined;
+};
+
+const getNonEmptyRecordText = (
+  record: Record<string, unknown>,
+  key: string
+): string | undefined => {
+  const value = record[key];
+  return typeof value === "string" ? getNonEmptyText(value) : undefined;
+};
+
+const getRememeMediaImage = (media: unknown): string | undefined => {
+  if (Array.isArray(media)) {
+    return media.find((item): item is { gateway: string } => {
+      if (item === null || item === undefined || typeof item !== "object") {
+        return false;
+      }
+      const gateway = (item as Record<string, unknown>)["gateway"];
+      return typeof gateway === "string" && gateway.trim().length > 0;
+    })?.gateway;
+  }
+
+  if (media === null || media === undefined || typeof media !== "object") {
+    return undefined;
+  }
+
+  const mediaRecord = media as Record<string, unknown>;
+  return (
+    getNonEmptyRecordText(mediaRecord, "thumbnailUrl") ??
+    getNonEmptyRecordText(mediaRecord, "cachedUrl") ??
+    getNonEmptyRecordText(mediaRecord, "pngUrl") ??
+    getNonEmptyRecordText(mediaRecord, "originalUrl")
+  );
+};
+
+const getRememeImage = (rememe?: Rememe): string | undefined => {
+  if (!rememe) {
+    return undefined;
+  }
+
+  const mediaImage = getRememeMediaImage(rememe.media);
+
+  return (
+    getNonEmptyText(rememe.s3_image_scaled) ??
+    getNonEmptyText(rememe.s3_image_original) ??
+    getNonEmptyText(rememe.image) ??
+    mediaImage ??
+    getNonEmptyText(rememe.contract_opensea_data.imageUrl)
+  );
+};
 
 export default async function ReMeme({
   params,
@@ -29,18 +97,21 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { contract, id } = await params;
   let name = `${formatAddress(contract)} #${id}`;
-  let image = `${publicEnv.BASE_ENDPOINT}/6529io.png`;
+  let rememe: Rememe | undefined;
+
   try {
+    const headers = await getAppCommonHeaders();
     const response = await fetchUrl<DBResponse<Rememe>>(
-      `${publicEnv.API_ENDPOINT}/api/rememes?contract=${contract}&id=${id}`
+      `${publicEnv.API_ENDPOINT}/api/rememes?contract=${contract}&id=${id}`,
+      { headers }
     );
 
-    if (response?.data?.length > 0) {
-      if (response.data[0]?.metadata?.name) {
-        name = response.data[0]?.metadata.name;
-      }
-      if (response.data[0]?.image) {
-        image = response.data[0]?.image;
+    const firstRememe = response.data[0];
+    if (firstRememe !== undefined) {
+      rememe = firstRememe;
+      const rememeName = getRememeName(rememe);
+      if (rememeName !== undefined) {
+        name = rememeName;
       }
     }
   } catch (error) {
@@ -50,10 +121,22 @@ export async function generateMetadata({
     );
   }
 
-  return getAppMetadata({
-    title: name,
-    ogImage: image ?? `${publicEnv.BASE_ENDPOINT}/re-memes-b.jpeg`,
-    description: `ReMemes`,
-    twitterCard: "summary",
-  });
+  const collectionName = getRememeCollectionName(rememe);
+
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title: name,
+      description: "ReMemes",
+      ogImage: getNftSocialCardImagePath({
+        badge: "ReMemes",
+        collection: collectionName,
+        contract,
+        id,
+        image: getRememeImage(rememe),
+        subtitle: `${collectionName} #${id} | ReMemes`,
+        title: name,
+      }),
+      ogImageAlt: `${name} ReMeme social card`,
+    })
+  );
 }

--- a/app/rememes/add/page.tsx
+++ b/app/rememes/add/page.tsx
@@ -1,6 +1,9 @@
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import RememeAddPage from "@/components/rememes/RememeAddPage";
-import { publicEnv } from "@/config/env";
 import styles from "@/styles/Home.module.scss";
 import type { Metadata } from "next";
 
@@ -13,9 +16,15 @@ export default function ReMemesAddPage() {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({
-    title: "ReMemes | Add",
-    description: "Collections",
-    ogImage: `${publicEnv.BASE_ENDPOINT}/re-memes-b.jpeg`,
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title: "ReMemes | Add",
+      description: "Collections",
+      ogImage: getCollectionSocialCardImagePath("rememes", {
+        subtitle: "Submit a community remix or derivative",
+        title: "Add a ReMeme",
+      }),
+      ogImageAlt: "Add ReMeme social card",
+    })
+  );
 }

--- a/app/rememes/page.tsx
+++ b/app/rememes/page.tsx
@@ -1,6 +1,9 @@
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import Rememes from "@/components/rememes/Rememes";
-import { publicEnv } from "@/config/env";
 import styles from "@/styles/Home.module.scss";
 import type { Metadata } from "next";
 
@@ -13,9 +16,12 @@ export default function ReMemesPage() {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({
-    title: "ReMemes",
-    description: "Collections",
-    ogImage: `${publicEnv.BASE_ENDPOINT}/re-memes-b.jpeg`,
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title: "ReMemes",
+      description: "Collections",
+      ogImage: getCollectionSocialCardImagePath("rememes"),
+      ogImageAlt: "ReMemes collection social card",
+    })
+  );
 }

--- a/app/the-memes/mint/page.tsx
+++ b/app/the-memes/mint/page.tsx
@@ -1,6 +1,9 @@
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import TheMemesMint from "@/components/the-memes/TheMemesMint";
-import { publicEnv } from "@/config/env";
 import type { NFTWithMemesExtendedData } from "@/entities/INFT";
 import { getAppCommonHeaders } from "@/helpers/server.app.helpers";
 import { commonApiFetch } from "@/services/api/common-api";
@@ -21,10 +24,15 @@ export default async function TheMemesMintPage() {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({
-    title: "Mint | The Memes",
-    ogImage: `${publicEnv.BASE_ENDPOINT}/memes-preview.png`,
-    description: "Collections",
-    twitterCard: "summary_large_image",
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title: "Mint | The Memes",
+      ogImage: getCollectionSocialCardImagePath("the-memes", {
+        title: "Mint | The Memes",
+        subtitle: "Latest The Memes mint on 6529.io",
+      }),
+      ogImageAlt: "The Memes mint social card",
+      description: "Collections",
+    })
+  );
 }

--- a/app/the-memes/page.tsx
+++ b/app/the-memes/page.tsx
@@ -1,8 +1,11 @@
 import styles from "@/styles/Home.module.scss";
 
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import TheMemesComponent from "@/components/the-memes/TheMemes";
-import { publicEnv } from "@/config/env";
 import type { Metadata } from "next";
 
 export default function TheMemesPage() {
@@ -14,10 +17,12 @@ export default function TheMemesPage() {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({
-    title: "The Memes",
-    ogImage: `${publicEnv.BASE_ENDPOINT}/memes-preview.png`,
-    description: "Collections",
-    twitterCard: "summary_large_image",
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title: "The Memes",
+      ogImage: getCollectionSocialCardImagePath("the-memes"),
+      ogImageAlt: "The Memes collection social card",
+      description: "Collections",
+    })
+  );
 }

--- a/components/providers/metadata.ts
+++ b/components/providers/metadata.ts
@@ -22,12 +22,42 @@ type LargeSocialCardMetadata = Omit<
   readonly ogImage: string;
 };
 
+type SocialCardQueryValue = string | number | null | undefined;
+
 const getBaseEndpointUrl = (baseEndpoint: string): URL => {
   try {
     return new URL(baseEndpoint);
   } catch {
     return new URL(publicEnv.BASE_ENDPOINT);
   }
+};
+
+const appendSocialCardQueryText = (
+  params: URLSearchParams,
+  key: string,
+  value: SocialCardQueryValue
+) => {
+  if (value === null || value === undefined) {
+    return;
+  }
+
+  const normalized = String(value).trim();
+  if (normalized) {
+    params.set(key, normalized);
+  }
+};
+
+const getSocialCardImagePath = (
+  path: string,
+  query: Record<string, SocialCardQueryValue>
+): string => {
+  const params = new URLSearchParams();
+  Object.entries(query).forEach(([key, value]) =>
+    appendSocialCardQueryText(params, key, value)
+  );
+
+  const queryString = params.toString();
+  return queryString ? `${path}?${queryString}` : path;
 };
 
 export function getAbsoluteOgImageUrl(
@@ -41,6 +71,55 @@ export function getDefaultOgImageUrl(
   baseEndpoint = publicEnv.BASE_ENDPOINT
 ): string {
   return getAbsoluteOgImageUrl(DEFAULT_OG_IMAGE_PATH, baseEndpoint);
+}
+
+export function getCollectionSocialCardImagePath(
+  collection: string,
+  options: {
+    readonly badge?: SocialCardQueryValue;
+    readonly image?: SocialCardQueryValue;
+    readonly subtitle?: SocialCardQueryValue;
+    readonly title?: SocialCardQueryValue;
+  } = {}
+): string {
+  return getSocialCardImagePath(
+    `/api/og-metadata/collections/${encodeURIComponent(collection)}`,
+    options
+  );
+}
+
+export function getNftSocialCardImagePath({
+  artist,
+  badge,
+  collection,
+  contract,
+  id,
+  image,
+  subtitle,
+  title,
+}: {
+  readonly artist?: SocialCardQueryValue;
+  readonly badge?: SocialCardQueryValue;
+  readonly collection?: SocialCardQueryValue;
+  readonly contract: string;
+  readonly id: string | number;
+  readonly image?: SocialCardQueryValue;
+  readonly subtitle?: SocialCardQueryValue;
+  readonly title?: SocialCardQueryValue;
+}): string {
+  return getSocialCardImagePath(
+    `/api/og-metadata/nfts/${encodeURIComponent(contract)}/${encodeURIComponent(
+      String(id)
+    )}`,
+    {
+      artist,
+      badge,
+      collection,
+      image,
+      subtitle,
+      title,
+    }
+  );
 }
 
 export function getLargeSocialCardMetadata<

--- a/components/providers/metadata.ts
+++ b/components/providers/metadata.ts
@@ -93,6 +93,7 @@ export function getNftSocialCardImagePath({
   badge,
   collection,
   contract,
+  displayId,
   id,
   image,
   subtitle,
@@ -102,6 +103,7 @@ export function getNftSocialCardImagePath({
   readonly badge?: SocialCardQueryValue;
   readonly collection?: SocialCardQueryValue;
   readonly contract: string;
+  readonly displayId?: SocialCardQueryValue;
   readonly id: string | number;
   readonly image?: SocialCardQueryValue;
   readonly subtitle?: SocialCardQueryValue;
@@ -115,6 +117,7 @@ export function getNftSocialCardImagePath({
       artist,
       badge,
       collection,
+      displayId,
       image,
       subtitle,
       title,
@@ -123,11 +126,11 @@ export function getNftSocialCardImagePath({
 }
 
 export function getLargeSocialCardMetadata<
-  Metadata extends LargeSocialCardMetadata,
+  SocialCardMetadata extends LargeSocialCardMetadata,
 >(
-  metadata: Metadata,
+  metadata: SocialCardMetadata,
   baseEndpoint = publicEnv.BASE_ENDPOINT
-): Omit<Metadata, "ogImage"> &
+): Omit<SocialCardMetadata, "ogImage"> &
   Pick<
     PageSSRMetadata,
     "ogImage" | "ogImageHeight" | "ogImageWidth" | "twitterCard"
@@ -152,7 +155,12 @@ const getOpenGraphImages = ({
   readonly ogImageWidth?: number | undefined;
   readonly ogImageAlt?: string | undefined;
 }): string[] | OgImageDescriptor[] => {
-  if (!ogImageHeight || !ogImageWidth) {
+  if (
+    ogImageHeight === undefined ||
+    ogImageWidth === undefined ||
+    ogImageHeight <= 0 ||
+    ogImageWidth <= 0
+  ) {
     return [ogImage];
   }
 
@@ -162,7 +170,7 @@ const getOpenGraphImages = ({
     height: ogImageHeight,
   };
 
-  if (ogImageAlt) {
+  if (ogImageAlt !== undefined && ogImageAlt.trim().length > 0) {
     return [{ ...image, alt: ogImageAlt }];
   }
 

--- a/components/the-memes/MemeShared.tsx
+++ b/components/the-memes/MemeShared.tsx
@@ -3,7 +3,11 @@ import { MEMELAB_CONTRACT } from "@/constants/constants";
 import type { BaseNFT } from "@/entities/INFT";
 import { areEqualAddresses, idStringToDisplay } from "@/helpers/Helpers";
 import { fetchUrl } from "@/services/6529api";
-import { getAppMetadata } from "../providers/metadata";
+import {
+  getAppMetadata,
+  getLargeSocialCardMetadata,
+  getNftSocialCardImagePath,
+} from "../providers/metadata";
 
 export enum MEME_FOCUS {
   LIVE = "live",
@@ -41,23 +45,28 @@ async function getMetadataProps(
 ) {
   let urlPath = "nfts";
   const idDisplay = idStringToDisplay(id);
+  let collection = "The Memes";
   let name = `The Memes #${idDisplay}`;
   let description = "Collections";
   if (areEqualAddresses(contract, MEMELAB_CONTRACT)) {
     urlPath = "nfts_memelab";
+    collection = "Meme Lab";
     name = `Meme Lab #${idDisplay}`;
   }
   const response = await fetchUrl(
     `${publicEnv.API_ENDPOINT}/api/${urlPath}?contract=${contract}&id=${id}`
   );
-  let image = `${publicEnv.BASE_ENDPOINT}/6529io.png`;
+  let artist: string | null = null;
+  let image: string | null = null;
   if (response?.data?.length > 0) {
+    const nft = response.data[0];
     description = `${name} | ${description}`;
-    name = `${response.data[0].name}`;
-    if (response.data[0].thumbnail) {
-      image = response.data[0].thumbnail;
-    } else if (response.data[0].image) {
-      image = response.data[0].image;
+    name = `${nft.name}`;
+    artist = nft.artist ?? null;
+    if (nft.thumbnail) {
+      image = nft.thumbnail;
+    } else if (nft.image) {
+      image = nft.image;
     }
   }
 
@@ -73,7 +82,17 @@ async function getMetadataProps(
   return {
     title: name,
     description: description,
-    ogImage: image,
+    ogImage: getNftSocialCardImagePath({
+      artist,
+      badge: collection,
+      collection,
+      contract,
+      id,
+      image,
+      subtitle: description,
+      title: name,
+    }),
+    ogImageAlt: `${name} social card`,
   };
 }
 
@@ -83,19 +102,21 @@ export async function getSharedAppServerSideProps(
   focus: string,
   isDistribution: boolean = false
 ) {
-  const { title, description, ogImage } = await getMetadataProps(
+  const { title, description, ogImage, ogImageAlt } = await getMetadataProps(
     contract,
     id,
     focus,
     isDistribution
   );
 
-  return getAppMetadata({
-    title,
-    description: description,
-    ogImage,
-    twitterCard: "summary",
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title,
+      description,
+      ogImage,
+      ogImageAlt,
+    })
+  );
 }
 
 export function getMemeTabTitle(

--- a/ops/docs/shared/README.md
+++ b/ops/docs/shared/README.md
@@ -36,6 +36,12 @@ Shared docs cover user-facing behavior reused across multiple product areas.
 - [Browser Zoom and Pinch Scaling](feature-browser-zoom-and-pinch-scaling.md):
   web zoom defaults plus native-wrapper zoom lock and text-entry safeguards.
 
+### Metadata and Sharing
+
+- [Social Card and Open Graph Metadata](feature-social-card-and-open-graph-metadata.md):
+  shared metadata helpers, dynamic OG endpoint families, standardized coverage,
+  and the expansion checklist for new share surfaces.
+
 ### Privacy and Consent
 
 - [Cookie Consent and Performance Analytics](feature-cookie-consent-and-performance-analytics.md):

--- a/ops/docs/shared/feature-social-card-and-open-graph-metadata.md
+++ b/ops/docs/shared/feature-social-card-and-open-graph-metadata.md
@@ -1,0 +1,109 @@
+# Social Card and Open Graph Metadata
+
+Parent: [Shared Index](README.md)
+
+## Overview
+
+6529 has mature dynamic Open Graph card rendering. New share surfaces should
+expand that coverage and standardize on the existing card families, not rebuild
+social-card infrastructure from scratch.
+
+The shared metadata contract lives in `components/providers/metadata.ts`.
+User-facing routes pass route metadata through `getAppMetadata`. Routes that
+need large social previews use `getLargeSocialCardMetadata`, which standardizes
+the `1200x630` image dimensions and `summary_large_image` Twitter card.
+
+## Location in the Site
+
+- Any public route with Next.js `generateMetadata`.
+- Dynamic social-card API routes under `/api/og-metadata`.
+- Server metadata helpers that build share metadata for profiles, waves, drops,
+  collections, NFTs, NextGen, ReMemes, Meme Lab, The Memes, and 6529 Gradient.
+
+## Dynamic Card Families
+
+- `/api/og-metadata/profiles/{identity}` renders identity/profile cards from
+  API-backed profile metadata.
+- `/api/og-metadata/waves/{id}` renders wave cards from API-backed wave
+  metadata.
+- `/api/og-metadata/drops/{id}` renders drop cards from API-backed drop
+  metadata.
+- `/api/og-metadata/collections/{collection}` renders branded collection cards.
+  It has built-in defaults for `the-memes`, `meme-lab`, `6529-gradient`,
+  `rememes`, and `nextgen`, plus query overrides for `badge`, `image`,
+  `subtitle`, and `title`.
+- `/api/og-metadata/nfts/{contract}/{id}` renders branded NFT cards with query
+  overrides for `artist`, `badge`, `collection`, `image`, `subtitle`, and
+  `title`.
+- `/api/og-metadata/image?url={url}&w={width}` safely normalizes allowed remote
+  images for card rendering.
+
+## Standard Route Contract
+
+- Use `getAppMetadata` for every App Router metadata response so title,
+  description, favicon, version, site name, default image, and Twitter site stay
+  consistent.
+- Use `getLargeSocialCardMetadata` when a route should render as a large social
+  card. Do not hand-code `twitterCard: "summary_large_image"` or hard-code
+  `1200x630` in route metadata.
+- Use `getCollectionSocialCardImagePath` for collection-like pages.
+- Use `getNftSocialCardImagePath` for token, NFT, and token-detail pages.
+- Keep API-backed entity details in query parameters on the collection/NFT card
+  paths instead of creating one-off static OG image URLs.
+- Profile, wave, and drop metadata can point directly at their dynamic endpoint
+  because those endpoint families already own the entity-specific rendering.
+
+## Current Standardized Coverage
+
+- Site default metadata and default image normalization through
+  `getAppMetadata`.
+- Profile cards through the profile OG endpoint.
+- Wave cards and drop cards through the wave/drop OG endpoints, including
+  wave-page entity-specific metadata in `waves-page.shared.tsx`.
+- Collection landing cards for The Memes, Meme Lab, 6529 Gradient, ReMemes, and
+  NextGen.
+- Detail cards for 6529 Gradient tokens, ReMemes, and NextGen tokens through
+  the NFT card endpoint.
+- NextGen collection, collection subpage, admin, and view metadata through the
+  shared collection card helpers.
+- The Memes mint metadata through the collection card endpoint.
+
+## Expansion Checklist
+
+1. Pick the existing card family first:
+   - profile identity -> profile endpoint
+   - wave -> wave endpoint
+   - drop -> drop endpoint
+   - collection/list/gallery -> collection endpoint
+   - NFT/token/detail -> NFT endpoint
+2. Add a new endpoint only when the entity model cannot fit an existing card
+   family.
+3. Route metadata should call `getAppMetadata` and, for large cards,
+   `getLargeSocialCardMetadata`.
+4. Collection/NFT cards should use the helper path builders instead of manual
+   `BASE_ENDPOINT` string interpolation.
+5. Provide useful fallback metadata when API data is missing: stable title,
+   collection/badge label, and no broken image query.
+6. Add focused tests that assert title, `twitter.card`, Open Graph image
+   dimensions, endpoint pathname, query parameters, and missing-data fallback.
+7. For new or changed render endpoints, verify the PNG response in a browser or
+   endpoint test and confirm dimensions remain `1200x630`.
+8. Update this page when a new route family becomes standardized.
+
+## Known Follow-Ups
+
+- Continue migrating older static collection and editorial pages that still
+  rely on bespoke image URLs or inline metadata tags.
+- Prefer helper-backed metadata for newly added public App Router pages before
+  adding route-specific card code.
+- Keep social-card route tests in sync with endpoint defaults so branded cards
+  do not silently lose titles, subtitles, image fallbacks, or dimensions.
+
+## Related Pages
+
+- [Shared Index](README.md)
+- [Media Collections Index](../media/collections/README.md)
+- [Media NFT Index](../media/nft/README.md)
+- [NextGen Index](../nextgen/README.md)
+- [Profiles Index](../profiles/README.md)
+- [Waves Index](../waves/README.md)


### PR DESCRIPTION
## Issue
- NFT and collection pages currently choose raw/static images in page metadata, but there is no reusable branded OG card surface for those entities.
- This PR is stacked on #2593 and adds the dynamic card routes that later metadata migrations can point at.

## Fix
- Add reusable branded 1200x630 OG card renderers for NFTs and collections.
- Add frontend-owned dynamic image routes that accept constrained display fields from page metadata builders and render them through the existing ImageResponse/font/proxy pattern.

## Changes
- Adds `/api/og-metadata/nfts/<contract>/<id>` for NFT social cards using path identity plus optional query display fields such as `title`, `collection`, `artist`, `subtitle`, `badge`, and `image`.
- Adds `/api/og-metadata/collections/<collection>` for collection social cards with defaults for `the-memes`, `meme-lab`, `6529-gradient`, `nextgen`, and `rememes`, plus optional query overrides.
- Adds shared branded-card renderers under `app/api/og-metadata/_lib`.
- Keeps remote media behind the existing `/api/og-metadata/image` proxy and uses public static assets directly for known local collection artwork.
- Adds renderer and route tests for both new card types.

## Validation
- `6529 run test -- __tests__/app/api/og-metadata.brandedCards.test.tsx __tests__/app/api/og-metadata.nfts.route.test.ts __tests__/app/api/og-metadata.collections.route.test.ts`
- `6529 exec prettier --check app/api/og-metadata/_lib/brandedCards.tsx app/api/og-metadata/nfts/[contract]/[id]/route.ts app/api/og-metadata/collections/[collection]/route.ts __tests__/app/api/og-metadata.brandedCards.test.tsx __tests__/app/api/og-metadata.nfts.route.test.ts __tests__/app/api/og-metadata.collections.route.test.ts`
- `6529 run lint:changed`
- `6529 run typecheck:changed`
- `git diff --cached --check`

## Risk
- Level: Low
- Why: The new routes are additive, covered by route and renderer tests, and do not change existing page metadata yet.
- Rollback: Revert this PR to remove the new card routes while leaving existing metadata behavior unchanged.

## Review Notes
- Review after #2593 or with the stack context. The next PR will start wiring page metadata builders to these new routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added API endpoints that generate branded Open Graph images for collections and individual NFTs, with customizable title, badge, subtitle, and image query parameters; images are produced at a fixed OG size and served with caching.
  * Introduced routing utilities for OG image size, cache control, and query text handling.

* **Tests**
  * Added comprehensive tests verifying image rendering, URL handling/proxying, font loading, cache headers, and error responses for missing/invalid params.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->