### PR TITLE
Standardize legacy OG metadata builders

### DIFF
--- a/__tests__/app/collectionMetadataPages.test.tsx
+++ b/__tests__/app/collectionMetadataPages.test.tsx
@@ -1,0 +1,66 @@
+import { generateMetadata as generateGradientMetadata } from "@/app/6529-gradient/page";
+import { generateMetadata as generateMemeLabMetadata } from "@/app/meme-lab/page";
+import { generateMetadata as generateTheMemesMetadata } from "@/app/the-memes/page";
+import type { Metadata } from "next";
+
+jest.mock("@/components/6529Gradient/6529Gradient", () => ({
+  __esModule: true,
+  default: () => <div data-testid="gradient" />,
+}));
+
+jest.mock("@/components/memelab/MemeLab", () => ({
+  __esModule: true,
+  default: () => <div data-testid="meme-lab" />,
+}));
+
+jest.mock("@/components/the-memes/TheMemes", () => ({
+  __esModule: true,
+  default: () => <div data-testid="the-memes" />,
+}));
+
+const getSocialImage = (metadata: Metadata) => {
+  const [image] = metadata.openGraph?.images as {
+    alt: string;
+    height: number;
+    url: string;
+    width: number;
+  }[];
+  return image;
+};
+
+describe("collection landing metadata", () => {
+  it.each([
+    {
+      alt: "The Memes collection social card",
+      generateMetadata: generateTheMemesMetadata,
+      slug: "the-memes",
+      title: "The Memes",
+    },
+    {
+      alt: "Meme Lab collection social card",
+      generateMetadata: generateMemeLabMetadata,
+      slug: "meme-lab",
+      title: "Meme Lab",
+    },
+    {
+      alt: "6529 Gradient collection social card",
+      generateMetadata: generateGradientMetadata,
+      slug: "6529-gradient",
+      title: "6529 Gradient",
+    },
+  ])("uses branded collection card metadata for $title", async (route) => {
+    const metadata = await route.generateMetadata();
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe(route.title);
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(image).toMatchObject({
+      alt: route.alt,
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe(`/api/og-metadata/collections/${route.slug}`);
+    expect(url.search).toBe("");
+  });
+});

--- a/__tests__/app/gradientPage.test.tsx
+++ b/__tests__/app/gradientPage.test.tsx
@@ -1,4 +1,5 @@
 import { generateMetadata } from "@/app/6529-gradient/[id]/page";
+import { GRADIENT_CONTRACT } from "@/constants/constants";
 import { fetchUrl } from "@/services/6529api";
 
 // === Mock Services & Dependencies ===
@@ -27,10 +28,6 @@ jest.mock("@/components/latest-activity/LatestActivityRow", () => ({
   __esModule: true,
   default: () => <tr data-testid="activity-row" />,
 }));
-jest.mock("@/components/nft-attributes/NftStats", () => ({
-  __esModule: true,
-  default: () => <></>,
-}));
 jest.mock("@/components/nft-navigation/NftNavigation", () => ({
   __esModule: true,
   default: () => <></>,
@@ -53,11 +50,26 @@ describe("generateMetadata", () => {
 
     expect(metadata.title).toBe("6529 Gradient #10");
 
-    const images = Array.isArray(metadata.openGraph?.images)
-      ? metadata.openGraph.images
-      : [metadata.openGraph?.images];
+    const [image] = metadata.openGraph?.images as {
+      alt: string;
+      height: number;
+      url: string;
+      width: number;
+    }[];
+    const url = new URL(image.url);
 
-    expect(images?.[0]).toBe("https://example.com/thumb.png");
+    expect(image).toMatchObject({
+      alt: "6529 Gradient #10 social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe(`/api/og-metadata/nfts/${GRADIENT_CONTRACT}/10`);
+    expect(url.searchParams.get("badge")).toBe("6529 Gradient");
+    expect(url.searchParams.get("collection")).toBe("6529 Gradient");
+    expect(url.searchParams.get("image")).toBe("https://example.com/thumb.png");
+    expect(url.searchParams.get("subtitle")).toBe("Collections");
+    expect(url.searchParams.get("title")).toBe("6529 Gradient #10");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
   });
 
   it("falls back to image if thumbnail is missing", async () => {
@@ -69,24 +81,28 @@ describe("generateMetadata", () => {
       params: Promise.resolve({ id: "20" }),
     });
 
-    const images = Array.isArray(metadata.openGraph?.images)
-      ? metadata.openGraph.images
-      : [metadata.openGraph?.images];
+    const [image] = metadata.openGraph?.images as {
+      url: string;
+    }[];
+    const url = new URL(image.url);
 
-    expect(images?.[0]).toBe("https://example.com/image.png");
+    expect(url.pathname).toBe(`/api/og-metadata/nfts/${GRADIENT_CONTRACT}/20`);
+    expect(url.searchParams.get("image")).toBe("https://example.com/image.png");
   });
 
-  it("uses default image if no data", async () => {
+  it("uses branded card without raw image if no data", async () => {
     (fetchUrl as jest.Mock).mockResolvedValue({ data: [] });
 
     const metadata = await generateMetadata({
       params: Promise.resolve({ id: "30" }),
     });
 
-    const images = Array.isArray(metadata.openGraph?.images)
-      ? metadata.openGraph.images
-      : [metadata.openGraph?.images];
+    const [image] = metadata.openGraph?.images as {
+      url: string;
+    }[];
+    const url = new URL(image.url);
 
-    expect(images?.[0]).toBe("https://test.6529.io/6529io.png");
+    expect(url.pathname).toBe(`/api/og-metadata/nfts/${GRADIENT_CONTRACT}/30`);
+    expect(url.searchParams.get("image")).toBeNull();
   });
 });

--- a/__tests__/app/nextgenMetadataPages.test.tsx
+++ b/__tests__/app/nextgenMetadataPages.test.tsx
@@ -1,0 +1,292 @@
+import { generateMetadata as generateNextGenCollectionMetadata } from "@/app/nextgen/collection/[collection]/[[...view]]/page";
+import { generateNextgenCollectionMetadata } from "@/app/nextgen/collection/[collection]/page-utils";
+import { generateMetadata as generateNextGenMetadata } from "@/app/nextgen/[[...view]]/page";
+import { generateMetadata as generateNextGenAdminMetadata } from "@/app/nextgen/manager/page";
+import { generateMetadata as generateNextGenTokenMetadata } from "@/app/nextgen/token/[token]/[[...view]]/page";
+import { NEXTGEN_CONTRACT } from "@/constants/constants";
+import { commonApiFetch } from "@/services/api/common-api";
+import type { NextGenCollection, NextGenToken } from "@/entities/INextgen";
+import type { Metadata } from "next";
+
+jest.mock("@/helpers/server.app.helpers", () => ({
+  getAppCommonHeaders: jest.fn().mockResolvedValue({ "x-test": "1" }),
+}));
+
+jest.mock("@/services/api/common-api", () => ({ commonApiFetch: jest.fn() }));
+
+jest.mock("@/app/nextgen/[[...view]]/NextGenPageClient", () => ({
+  __esModule: true,
+  default: () => <div data-testid="nextgen-page" />,
+}));
+
+jest.mock(
+  "@/app/nextgen/token/[token]/[[...view]]/NextGenTokenPageClient",
+  () => ({
+    __esModule: true,
+    default: () => <div data-testid="nextgen-token" />,
+  })
+);
+
+jest.mock(
+  "@/components/nextGen/collections/collectionParts/NextGenCollection",
+  () => ({
+    __esModule: true,
+    default: () => <div data-testid="nextgen-collection" />,
+  })
+);
+
+jest.mock("@/components/nextGen/admin/NextGenAdmin", () => ({
+  __esModule: true,
+  default: () => <div data-testid="nextgen-admin" />,
+}));
+
+const collection: NextGenCollection = {
+  allowlist_end: 0,
+  allowlist_start: 0,
+  artist: "6529er",
+  artist_address: "0xartist",
+  artist_signature: "0xsig",
+  banner: "https://cdn.test/pebbles-banner.png",
+  base_uri: "https://generator.test/",
+  created_at: "2024-01-01T00:00:00Z",
+  dependency_script: "",
+  description: "Pebbles description",
+  distribution_plan: "Random",
+  final_supply_after_mint: 100,
+  id: 1,
+  image: "https://cdn.test/pebbles.png",
+  library: "p5js",
+  licence: "CC0",
+  max_purchases: 1,
+  merkle_root: "0xroot",
+  mint_count: 10,
+  name: "Pebbles",
+  on_chain: true,
+  opensea_link: "https://opensea.test/pebbles",
+  public_end: 0,
+  public_start: 0,
+  total_supply: 100,
+  updated_at: "2024-01-01T00:00:00Z",
+  website: "https://pebbles.test",
+};
+
+const token: NextGenToken = {
+  animation_url: "https://cdn.test/animation.html",
+  blur_price: 0,
+  burnt: false,
+  collection_id: 1,
+  collection_name: "Pebbles",
+  created_at: "2024-01-01T00:00:00Z",
+  handle: "6529er",
+  hodl_rate: 0,
+  icon_url: "https://cdn.test/icon.png",
+  id: 123,
+  image_url: "https://cdn.test/token.png",
+  last_sale_date: new Date("2024-01-01T00:00:00Z"),
+  last_sale_value: 0,
+  level: 1,
+  max_sale_date: new Date("2024-01-01T00:00:00Z"),
+  max_sale_value: 0,
+  me_price: 0,
+  me_royalty: 0,
+  metadata_url: "https://cdn.test/token.json",
+  mint_data: "{}",
+  mint_date: new Date("2024-01-01T00:00:00Z"),
+  mint_price: 0,
+  name: "Pebble #123",
+  normalised_handle: "6529er",
+  normalised_id: 123,
+  opensea_price: 0,
+  opensea_royalty: 0,
+  owner: "0xowner",
+  pending: false,
+  price: 0,
+  rarity_score: 0,
+  rarity_score_normalised: 0,
+  rarity_score_normalised_rank: 0,
+  rarity_score_rank: 0,
+  rarity_score_trait_count: 0,
+  rarity_score_trait_count_normalised: 0,
+  rarity_score_trait_count_normalised_rank: 0,
+  rarity_score_trait_count_rank: 0,
+  rep_score: 0,
+  single_trait_rarity_score: 0,
+  single_trait_rarity_score_normalised: 0,
+  single_trait_rarity_score_normalised_rank: 0,
+  single_trait_rarity_score_rank: 0,
+  single_trait_rarity_score_trait_count: 0,
+  single_trait_rarity_score_trait_count_normalised: 0,
+  single_trait_rarity_score_trait_count_normalised_rank: 0,
+  single_trait_rarity_score_trait_count_rank: 0,
+  statistical_score: 0,
+  statistical_score_normalised: 0,
+  statistical_score_normalised_rank: 0,
+  statistical_score_rank: 0,
+  statistical_score_trait_count: 0,
+  statistical_score_trait_count_normalised: 0,
+  statistical_score_trait_count_normalised_rank: 0,
+  statistical_score_trait_count_rank: 0,
+  tdh: 0,
+  thumbnail_url: "https://cdn.test/thumb.png",
+  updated_at: "2024-01-01T00:00:00Z",
+};
+
+const getSocialImage = (metadata: Metadata) => {
+  const [image] = metadata.openGraph?.images as {
+    alt: string;
+    height: number;
+    url: string;
+    width: number;
+  }[];
+  return image;
+};
+
+const mockNextgenFetches = () => {
+  (commonApiFetch as jest.Mock).mockImplementation(
+    ({ endpoint }: { endpoint: string }) => {
+      if (endpoint === "nextgen/tokens/123") {
+        return Promise.resolve(token);
+      }
+      if (endpoint === "nextgen/tokens/123/traits") {
+        return Promise.resolve([{ token_count: 100 }]);
+      }
+      if (
+        endpoint === "nextgen/collections/1" ||
+        endpoint === "nextgen/collections/pebbles"
+      ) {
+        return Promise.resolve(collection);
+      }
+      return Promise.reject(new Error(`Unexpected endpoint ${endpoint}`));
+    }
+  );
+};
+
+describe("NextGen metadata", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("uses the branded NextGen collection card on view pages", async () => {
+    const metadata = await generateNextGenMetadata({
+      params: Promise.resolve({ view: ["collections"] }),
+    });
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("NextGen Collections");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(image).toMatchObject({
+      alt: "NextGen Collections social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe("/api/og-metadata/collections/nextgen");
+    expect(url.searchParams.get("subtitle")).toBe(
+      "Generative art collections from 6529"
+    );
+    expect(url.searchParams.get("title")).toBe("NextGen Collections");
+  });
+
+  it("uses a route-specific NextGen collection card for admin metadata", async () => {
+    const metadata = await generateNextGenAdminMetadata();
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("NextGen Admin");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(url.pathname).toBe("/api/og-metadata/collections/nextgen");
+    expect(url.searchParams.get("subtitle")).toBe("Manage NextGen collections");
+    expect(url.searchParams.get("title")).toBe("NextGen Admin");
+  });
+
+  it("uses collection facts in NextGen collection page cards", async () => {
+    mockNextgenFetches();
+
+    const metadata = await generateNextGenCollectionMetadata({
+      params: Promise.resolve({
+        collection: "pebbles",
+        view: ["rarity"],
+      }),
+    });
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("Pebbles | Rarity");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(image).toMatchObject({
+      alt: "Pebbles | Rarity social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe("/api/og-metadata/collections/nextgen");
+    expect(url.searchParams.get("image")).toBe(
+      "https://cdn.test/pebbles-banner.png"
+    );
+    expect(url.searchParams.get("subtitle")).toBe("Pebbles | NextGen");
+    expect(url.searchParams.get("title")).toBe("Pebbles | Rarity");
+  });
+
+  it("uses collection facts in NextGen collection subpage cards", async () => {
+    mockNextgenFetches();
+
+    const metadata = await generateNextgenCollectionMetadata({
+      collection: "pebbles",
+      headers: { "x-test": "1" },
+      page: "Mint",
+    });
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("Mint | Pebbles");
+    expect(url.pathname).toBe("/api/og-metadata/collections/nextgen");
+    expect(url.searchParams.get("image")).toBe(
+      "https://cdn.test/pebbles-banner.png"
+    );
+    expect(url.searchParams.get("title")).toBe("Mint | Pebbles");
+  });
+
+  it("uses branded NFT card metadata for NextGen token pages", async () => {
+    mockNextgenFetches();
+
+    const metadata = await generateNextGenTokenMetadata({
+      params: Promise.resolve({
+        token: "123",
+        view: ["provenance"],
+      }),
+    });
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("Pebble #123 | Provenance");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(image).toMatchObject({
+      alt: "Pebble #123 | Provenance social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe(`/api/og-metadata/nfts/${NEXTGEN_CONTRACT}/123`);
+    expect(url.searchParams.get("artist")).toBe("6529er");
+    expect(url.searchParams.get("badge")).toBe("NextGen");
+    expect(url.searchParams.get("collection")).toBe("Pebbles");
+    expect(url.searchParams.get("image")).toBe("https://cdn.test/thumb.png");
+    expect(url.searchParams.get("subtitle")).toBe("Pebbles #123 | NextGen");
+    expect(url.searchParams.get("title")).toBe("Pebble #123 | Provenance");
+  });
+
+  it("falls back to a branded NextGen token card when token data is missing", async () => {
+    (commonApiFetch as jest.Mock).mockRejectedValue(new Error("missing"));
+
+    const metadata = await generateNextGenTokenMetadata({
+      params: Promise.resolve({ token: "999" }),
+    });
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("NextGen Token");
+    expect(url.pathname).toBe(`/api/og-metadata/nfts/${NEXTGEN_CONTRACT}/999`);
+    expect(url.searchParams.get("badge")).toBe("NextGen");
+    expect(url.searchParams.get("collection")).toBe("NextGen");
+    expect(url.searchParams.get("image")).toBeNull();
+    expect(url.searchParams.get("title")).toBe("NextGen #999");
+  });
+});

--- a/__tests__/app/rememesMetadataPages.test.tsx
+++ b/__tests__/app/rememesMetadataPages.test.tsx
@@ -123,6 +123,50 @@ describe("ReMemes metadata", () => {
     expect(url.searchParams.get("title")).toBe("Community Remix");
   });
 
+  it("uses Alchemy-style media objects for ReMeme detail card images", async () => {
+    (fetchUrl as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          contract_opensea_data: {
+            collectionName: "SEIZING",
+            imageUrl: "https://cdn.test/collection.png",
+          },
+          image: "",
+          media: {
+            cachedUrl: "https://cdn.test/cached.gif",
+            contentType: "image/gif",
+            originalUrl: "https://arweave.test/original",
+            pngUrl: "https://cdn.test/converted.png",
+            size: 9908164,
+            thumbnailUrl: "https://cdn.test/thumb.gif",
+          },
+          metadata: { name: "GDRC #2" },
+          s3_image_original: "",
+          s3_image_scaled: "",
+        },
+      ],
+    });
+
+    const metadata = await generateRememeDetailMetadata({
+      params: Promise.resolve({
+        contract: "0x869a96493d64ed5bbbfc24d96c5e84f95e558cf2",
+        id: "39",
+      }),
+    });
+
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("GDRC #2");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(url.pathname).toBe(
+      "/api/og-metadata/nfts/0x869a96493d64ed5bbbfc24d96c5e84f95e558cf2/39"
+    );
+    expect(url.searchParams.get("collection")).toBe("SEIZING");
+    expect(url.searchParams.get("image")).toBe("https://cdn.test/thumb.gif");
+    expect(url.searchParams.get("title")).toBe("GDRC #2");
+  });
+
   it("falls back to a branded ReMeme NFT card when API data is missing", async () => {
     (fetchUrl as jest.Mock).mockResolvedValue({ data: [] });
 

--- a/__tests__/app/rememesMetadataPages.test.tsx
+++ b/__tests__/app/rememesMetadataPages.test.tsx
@@ -1,0 +1,149 @@
+import { generateMetadata as generateRememeDetailMetadata } from "@/app/rememes/[contract]/[id]/page";
+import { generateMetadata as generateRememesAddMetadata } from "@/app/rememes/add/page";
+import { generateMetadata as generateRememesMetadata } from "@/app/rememes/page";
+import { getAppCommonHeaders } from "@/helpers/server.app.helpers";
+import { fetchUrl } from "@/services/6529api";
+import type { Metadata } from "next";
+
+jest.mock("@/services/6529api", () => ({ fetchUrl: jest.fn() }));
+
+jest.mock("@/helpers/server.app.helpers", () => ({
+  getAppCommonHeaders: jest.fn().mockResolvedValue({ "x-test": "1" }),
+}));
+
+jest.mock("@/components/rememes/Rememes", () => ({
+  __esModule: true,
+  default: () => <div data-testid="rememes" />,
+}));
+
+jest.mock("@/components/rememes/RememeAddPage", () => ({
+  __esModule: true,
+  default: () => <div data-testid="rememe-add" />,
+}));
+
+jest.mock("@/components/rememes/RememePage", () => ({
+  __esModule: true,
+  default: () => <div data-testid="rememe-page" />,
+}));
+
+const getSocialImage = (metadata: Metadata) => {
+  const [image] = metadata.openGraph?.images as {
+    alt: string;
+    height: number;
+    url: string;
+    width: number;
+  }[];
+  return image;
+};
+
+describe("ReMemes metadata", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("uses the branded ReMemes collection card on the landing page", async () => {
+    const metadata = await generateRememesMetadata();
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("ReMemes");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(image).toMatchObject({
+      alt: "ReMemes collection social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe("/api/og-metadata/collections/rememes");
+    expect(url.search).toBe("");
+  });
+
+  it("uses a route-specific ReMemes card on the add page", async () => {
+    const metadata = await generateRememesAddMetadata();
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("ReMemes | Add");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(image).toMatchObject({
+      alt: "Add ReMeme social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe("/api/og-metadata/collections/rememes");
+    expect(url.searchParams.get("subtitle")).toBe(
+      "Submit a community remix or derivative"
+    );
+    expect(url.searchParams.get("title")).toBe("Add a ReMeme");
+  });
+
+  it("uses branded NFT card metadata for ReMeme detail pages", async () => {
+    (fetchUrl as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          contract_opensea_data: {
+            collectionName: "Remix Editions",
+            imageUrl: "https://cdn.test/collection.png",
+          },
+          image: "https://cdn.test/raw.png",
+          media: [{ gateway: "https://cdn.test/gateway.png" }],
+          metadata: { name: "Community Remix" },
+          s3_image_original: "https://cdn.test/original.png",
+          s3_image_scaled: "https://cdn.test/scaled.png",
+        },
+      ],
+    });
+
+    const metadata = await generateRememeDetailMetadata({
+      params: Promise.resolve({ contract: "0xabc", id: "7" }),
+    });
+
+    expect(getAppCommonHeaders).toHaveBeenCalled();
+    expect(fetchUrl).toHaveBeenCalledWith(
+      expect.stringContaining("/api/rememes?contract=0xabc&id=7"),
+      { headers: { "x-test": "1" } }
+    );
+
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("Community Remix");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(image).toMatchObject({
+      alt: "Community Remix ReMeme social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe("/api/og-metadata/nfts/0xabc/7");
+    expect(url.searchParams.get("badge")).toBe("ReMemes");
+    expect(url.searchParams.get("collection")).toBe("Remix Editions");
+    expect(url.searchParams.get("image")).toBe("https://cdn.test/scaled.png");
+    expect(url.searchParams.get("subtitle")).toBe(
+      "Remix Editions #7 | ReMemes"
+    );
+    expect(url.searchParams.get("title")).toBe("Community Remix");
+  });
+
+  it("falls back to a branded ReMeme NFT card when API data is missing", async () => {
+    (fetchUrl as jest.Mock).mockResolvedValue({ data: [] });
+
+    const metadata = await generateRememeDetailMetadata({
+      params: Promise.resolve({ contract: "0xabc", id: "8" }),
+    });
+
+    expect(getAppCommonHeaders).toHaveBeenCalled();
+    expect(fetchUrl).toHaveBeenCalledWith(
+      expect.stringContaining("/api/rememes?contract=0xabc&id=8"),
+      { headers: { "x-test": "1" } }
+    );
+
+    const image = getSocialImage(metadata);
+    const url = new URL(image.url);
+
+    expect(metadata.title).toBe("0xabc #8");
+    expect(url.pathname).toBe("/api/og-metadata/nfts/0xabc/8");
+    expect(url.searchParams.get("badge")).toBe("ReMemes");
+    expect(url.searchParams.get("collection")).toBe("ReMemes");
+    expect(url.searchParams.get("image")).toBeNull();
+    expect(url.searchParams.get("title")).toBe("0xabc #8");
+  });
+});

--- a/__tests__/app/the-memes/theMemesMint.test.tsx
+++ b/__tests__/app/the-memes/theMemesMint.test.tsx
@@ -9,6 +9,13 @@ jest.mock("next/dynamic", () => () => (props: any) => (
   <div data-testid="dynamic" {...props} />
 ));
 
+jest.mock("@/components/the-memes/TheMemesMint", () => ({
+  __esModule: true,
+  default: ({ nft }: { nft: { id: number } }) => (
+    <div data-testid="mint-component" data-nft-id={nft.id} />
+  ),
+}));
+
 jest.mock("@/helpers/server.app.helpers", () => ({
   getAppCommonHeaders: jest.fn(),
 }));
@@ -50,9 +57,10 @@ describe("TheMemesMintPage", () => {
       <AuthContext.Provider value={{} as any}>{jsx}</AuthContext.Provider>
     );
 
-    const dynamic = await screen.findByTestId("dynamic");
+    const mint = await screen.findByTestId("mint-component");
 
-    expect(dynamic).toBeInTheDocument();
+    expect(mint).toBeInTheDocument();
+    expect(mint).toHaveAttribute("data-nft-id", "1");
     expect(commonApiFetch).toHaveBeenCalledWith({
       endpoint: "memes_latest",
       headers: { h: "1" },
@@ -61,19 +69,39 @@ describe("TheMemesMintPage", () => {
 
   it("exports metadata", async () => {
     const metadata = await generateMetadata();
-    expect(metadata).toEqual({
+    const [image] = metadata.openGraph?.images as {
+      alt: string;
+      height: number;
+      url: string;
+      width: number;
+    }[];
+    const url = new URL(image.url);
+
+    expect(metadata).toMatchObject({
       title: "Mint | The Memes",
       description: "Collections | 6529.io",
       icons: { icon: "/favicon.ico" },
-      openGraph: {
-        images: ["https://test.6529.io/memes-preview.png"],
-        title: "Mint | The Memes",
-        description: "Collections | 6529.io",
-      },
       other: { version: "test-version" },
       twitter: {
         card: "summary_large_image",
+        site: "@6529Collections",
       },
     });
+    expect(metadata.openGraph).toMatchObject({
+      type: "website",
+      siteName: "6529.io",
+      title: "Mint | The Memes",
+      description: "Collections | 6529.io",
+    });
+    expect(image).toMatchObject({
+      alt: "The Memes mint social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe("/api/og-metadata/collections/the-memes");
+    expect(url.searchParams.get("subtitle")).toBe(
+      "Latest The Memes mint on 6529.io"
+    );
+    expect(url.searchParams.get("title")).toBe("Mint | The Memes");
   });
 });

--- a/__tests__/components/providers/metadata.test.ts
+++ b/__tests__/components/providers/metadata.test.ts
@@ -6,8 +6,10 @@ import {
   SOCIAL_CARD_IMAGE_WIDTH,
   getAbsoluteOgImageUrl,
   getAppMetadata,
+  getCollectionSocialCardImagePath,
   getDefaultOgImageUrl,
   getLargeSocialCardMetadata,
+  getNftSocialCardImagePath,
 } from "@/components/providers/metadata";
 
 describe("Metadata functionality (migrated from _document.tsx)", () => {
@@ -176,6 +178,40 @@ describe("Metadata functionality (migrated from _document.tsx)", () => {
         ogImageWidth: SOCIAL_CARD_IMAGE_WIDTH,
         twitterCard: LARGE_IMAGE_TWITTER_CARD,
       });
+    });
+
+    it("builds collection social-card image paths", () => {
+      expect(getCollectionSocialCardImagePath("the-memes")).toBe(
+        "/api/og-metadata/collections/the-memes"
+      );
+
+      expect(
+        getCollectionSocialCardImagePath("the memes", {
+          badge: "6529",
+          image: "/memes-preview.png",
+          subtitle: "The Memes by 6529",
+          title: "The Memes",
+        })
+      ).toBe(
+        "/api/og-metadata/collections/the%20memes?badge=6529&image=%2Fmemes-preview.png&subtitle=The+Memes+by+6529&title=The+Memes"
+      );
+    });
+
+    it("builds NFT social-card image paths", () => {
+      expect(
+        getNftSocialCardImagePath({
+          artist: "6529er",
+          badge: "The Memes",
+          collection: "The Memes",
+          contract: "0xabc/def",
+          id: "1/2",
+          image: "https://cdn.test/image.png",
+          subtitle: "The Memes #1 | Collections",
+          title: "Seize the Memes",
+        })
+      ).toBe(
+        "/api/og-metadata/nfts/0xabc%2Fdef/1%2F2?artist=6529er&badge=The+Memes&collection=The+Memes&image=https%3A%2F%2Fcdn.test%2Fimage.png&subtitle=The+Memes+%231+%7C+Collections&title=Seize+the+Memes"
+      );
     });
   });
 });

--- a/__tests__/components/providers/metadataSocialCardGuardrails.test.ts
+++ b/__tests__/components/providers/metadataSocialCardGuardrails.test.ts
@@ -1,0 +1,132 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+type MetadataSourceGuardrail = {
+  readonly requiredSnippets: readonly string[];
+  readonly routePath: string;
+};
+
+// Manually enrolled routes: add new standardized metadata surfaces here.
+const standardizedMetadataSources: readonly MetadataSourceGuardrail[] = [
+  {
+    routePath: "app/the-memes/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/the-memes/mint/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/meme-lab/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/6529-gradient/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/6529-gradient/[id]/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getNftSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/rememes/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/rememes/add/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/rememes/[contract]/[id]/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getNftSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/nextgen/[[...view]]/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/nextgen/manager/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/nextgen/collection/[collection]/page-utils.ts",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/nextgen/collection/[collection]/[[...view]]/page.tsx",
+    requiredSnippets: ["getNextgenCollectionMetadata("],
+  },
+  {
+    routePath: "app/nextgen/token/[token]/[[...view]]/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getNftSocialCardImagePath(",
+    ],
+  },
+];
+
+// Heuristics for the most common drift patterns, not exhaustive source parsing.
+const manualLargeTwitterCard = /twitterCard\s*:\s*["']summary_large_image["']/;
+const directBaseEndpointOgImage =
+  /ogImage\s*:\s*`[^`]*\$\{publicEnv\.BASE_ENDPOINT\}/;
+
+const readSource = (routePath: string): string => {
+  const absoluteRoutePath = path.join(process.cwd(), routePath);
+
+  if (!existsSync(absoluteRoutePath)) {
+    throw new Error(
+      `Expected guardrailed metadata route "${routePath}" to exist. ` +
+        "If this route moved or was renamed, update standardizedMetadataSources."
+    );
+  }
+
+  return readFileSync(absoluteRoutePath, "utf8");
+};
+
+describe("standardized social-card metadata route guardrails", () => {
+  it.each(standardizedMetadataSources)(
+    "$routePath keeps using shared social-card metadata helpers",
+    ({ requiredSnippets, routePath }) => {
+      const source = readSource(routePath);
+
+      requiredSnippets.forEach((snippet) => {
+        expect(source).toContain(snippet);
+      });
+      expect(source).not.toMatch(manualLargeTwitterCard);
+      expect(source).not.toMatch(directBaseEndpointOgImage);
+    }
+  );
+});

--- a/__tests__/components/the-memes/MemeShared.test.tsx
+++ b/__tests__/components/the-memes/MemeShared.test.tsx
@@ -1,4 +1,10 @@
-import { getMemeTabTitle, MEME_FOCUS } from "@/components/the-memes/MemeShared";
+import {
+  getMemeTabTitle,
+  getSharedAppServerSideProps,
+  MEME_FOCUS,
+} from "@/components/the-memes/MemeShared";
+import { MEMELAB_CONTRACT, MEMES_CONTRACT } from "@/constants/constants";
+import { fetchUrl } from "@/services/6529api";
 
 jest.mock("@/services/6529api", () => ({ fetchUrl: jest.fn() }));
 
@@ -11,5 +17,79 @@ describe("getMemeTabTitle", () => {
 
   it("returns original title when no extras", () => {
     expect(getMemeTabTitle("The Memes")).toBe("The Memes");
+  });
+});
+
+describe("getSharedAppServerSideProps", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("builds large branded social metadata for The Memes", async () => {
+    (fetchUrl as jest.Mock).mockResolvedValue({
+      data: [
+        {
+          artist: "6529er",
+          name: "Seize the Memes",
+          thumbnail: "https://cdn.test/seize.png",
+        },
+      ],
+    });
+
+    const metadata = await getSharedAppServerSideProps(
+      MEMES_CONTRACT,
+      "1",
+      MEME_FOCUS.COLLECTORS
+    );
+    const [image] = metadata.openGraph?.images as {
+      alt: string;
+      height: number;
+      url: string;
+      width: number;
+    }[];
+    const url = new URL(image.url);
+
+    expect(fetchUrl).toHaveBeenCalledWith(
+      `https://api.test.6529.io/api/nfts?contract=${MEMES_CONTRACT}&id=1`
+    );
+    expect(metadata.title).toBe("Seize the Memes | Collectors");
+    expect(metadata.twitter?.card).toBe("summary_large_image");
+    expect(image).toMatchObject({
+      alt: "Seize the Memes | Collectors social card",
+      height: 630,
+      width: 1200,
+    });
+    expect(url.pathname).toBe(`/api/og-metadata/nfts/${MEMES_CONTRACT}/1`);
+    expect(url.searchParams.get("artist")).toBe("6529er");
+    expect(url.searchParams.get("badge")).toBe("The Memes");
+    expect(url.searchParams.get("collection")).toBe("The Memes");
+    expect(url.searchParams.get("image")).toBe("https://cdn.test/seize.png");
+    expect(url.searchParams.get("subtitle")).toBe("The Memes #1 | Collections");
+    expect(url.searchParams.get("title")).toBe("Seize the Memes | Collectors");
+  });
+
+  it("builds Meme Lab social cards without raw media when data is missing", async () => {
+    (fetchUrl as jest.Mock).mockResolvedValue({ data: [] });
+
+    const metadata = await getSharedAppServerSideProps(
+      MEMELAB_CONTRACT,
+      "2",
+      MEME_FOCUS.LIVE,
+      true
+    );
+    const [image] = metadata.openGraph?.images as {
+      url: string;
+    }[];
+    const url = new URL(image.url);
+
+    expect(fetchUrl).toHaveBeenCalledWith(
+      `https://api.test.6529.io/api/nfts_memelab?contract=${MEMELAB_CONTRACT}&id=2`
+    );
+    expect(metadata.title).toBe("Meme Lab #2 | Distribution");
+    expect(url.pathname).toBe(`/api/og-metadata/nfts/${MEMELAB_CONTRACT}/2`);
+    expect(url.searchParams.get("badge")).toBe("Meme Lab");
+    expect(url.searchParams.get("collection")).toBe("Meme Lab");
+    expect(url.searchParams.get("image")).toBeNull();
+    expect(url.searchParams.get("title")).toBe("Meme Lab #2 | Distribution");
   });
 });

--- a/app/6529-gradient/[id]/page.tsx
+++ b/app/6529-gradient/[id]/page.tsx
@@ -1,5 +1,9 @@
 import GradientPageComponent from "@/components/6529Gradient/GradientPage";
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getLargeSocialCardMetadata,
+  getNftSocialCardImagePath,
+} from "@/components/providers/metadata";
 import { publicEnv } from "@/config/env";
 import { GRADIENT_CONTRACT } from "@/constants/constants";
 import { fetchUrl } from "@/services/6529api";
@@ -27,25 +31,36 @@ export async function generateMetadata({
   const { id } = await params;
 
   let title = `6529 Gradient #${id}`;
-  let ogImage = `${publicEnv.BASE_ENDPOINT}/6529io.png`;
+  let image: string | null = null;
   try {
     const response = await fetchUrl(
       `${publicEnv.API_ENDPOINT}/api/nfts?contract=${GRADIENT_CONTRACT}&id=${id}`
     );
     if (response?.data?.length > 0) {
-      if (response.data[0].thumbnail) {
-        ogImage = response.data[0].thumbnail;
-      } else if (response.data[0].image) {
-        ogImage = response.data[0].image;
+      const nft = response.data[0];
+      if (nft.thumbnail) {
+        image = nft.thumbnail;
+      } else if (nft.image) {
+        image = nft.image;
       }
     }
   } catch (error) {
     console.error(`Failed to load gradient metadata for id ${id}`, error);
   }
-  return getAppMetadata({
-    title,
-    description: "Collections | 6529.io",
-    ogImage,
-    twitterCard: "summary",
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title,
+      description: "Collections",
+      ogImage: getNftSocialCardImagePath({
+        badge: "6529 Gradient",
+        collection: "6529 Gradient",
+        contract: GRADIENT_CONTRACT,
+        id,
+        image,
+        subtitle: "Collections",
+        title,
+      }),
+      ogImageAlt: `${title} social card`,
+    })
+  );
 }

--- a/app/6529-gradient/page.tsx
+++ b/app/6529-gradient/page.tsx
@@ -1,6 +1,9 @@
 import GradientsComponent from "@/components/6529Gradient/6529Gradient";
-import { getAppMetadata } from "@/components/providers/metadata";
-import { publicEnv } from "@/config/env";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import styles from "@/styles/Home.module.scss";
 import type { Metadata } from "next";
 
@@ -13,10 +16,12 @@ export default function GradientsPage() {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({
-    title: "6529 Gradient",
-    description: "Collections",
-    ogImage: `${publicEnv.BASE_ENDPOINT}/gradients-preview.png`,
-    twitterCard: "summary_large_image",
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title: "6529 Gradient",
+      description: "Collections",
+      ogImage: getCollectionSocialCardImagePath("6529-gradient"),
+      ogImageAlt: "6529 Gradient collection social card",
+    })
+  );
 }

--- a/app/meme-lab/page.tsx
+++ b/app/meme-lab/page.tsx
@@ -1,6 +1,9 @@
 import MemeLabComponent from "@/components/memelab/MemeLab";
-import { getAppMetadata } from "@/components/providers/metadata";
-import { publicEnv } from "@/config/env";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import styles from "@/styles/Home.module.scss";
 import type { Metadata } from "next";
 
@@ -13,10 +16,12 @@ export default function MemeLab() {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({
-    title: "Meme Lab",
-    ogImage: `${publicEnv.BASE_ENDPOINT}/meme-lab.jpg`,
-    description: "Collections",
-    twitterCard: "summary_large_image",
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title: "Meme Lab",
+      ogImage: getCollectionSocialCardImagePath("meme-lab"),
+      ogImageAlt: "Meme Lab collection social card",
+      description: "Collections",
+    })
+  );
 }

--- a/app/nextgen/[[...view]]/page.tsx
+++ b/app/nextgen/[[...view]]/page.tsx
@@ -1,4 +1,8 @@
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import type { NextGenCollection } from "@/entities/INextgen";
 import { getAppCommonHeaders } from "@/helpers/server.app.helpers";
 import { commonApiFetch } from "@/services/api/common-api";
@@ -22,7 +26,19 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { view } = await params;
   const nextgenView = getNextGenView(view?.[0] ?? "");
-  return getAppMetadata({ title: "NextGen " + (nextgenView ?? "") });
+  const title = nextgenView ? `NextGen ${nextgenView}` : "NextGen";
+
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title,
+      description: "NextGen",
+      ogImage: getCollectionSocialCardImagePath("nextgen", {
+        subtitle: "Generative art collections from 6529",
+        title,
+      }),
+      ogImageAlt: `${title} social card`,
+    })
+  );
 }
 
 export default async function NextGenPage({

--- a/app/nextgen/collection/[collection]/[[...view]]/page.tsx
+++ b/app/nextgen/collection/[collection]/[[...view]]/page.tsx
@@ -1,12 +1,15 @@
 import NextGenCollectionComponent from "@/components/nextGen/collections/collectionParts/NextGenCollection";
 import { getAppMetadata } from "@/components/providers/metadata";
-import { publicEnv } from "@/config/env";
 import { getAppCommonHeaders } from "@/helpers/server.app.helpers";
 import styles from "@/styles/Home.module.scss";
 import { NextgenCollectionView } from "@/types/enums";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { fetchCollection, getCollectionView } from "../page-utils";
+import {
+  fetchCollection,
+  getCollectionView,
+  getNextgenCollectionMetadata,
+} from "../page-utils";
 
 export async function generateMetadata({
   params,
@@ -24,14 +27,9 @@ export async function generateMetadata({
   if (resolvedView !== NextgenCollectionView.OVERVIEW) {
     title += ` | ${resolvedView}`;
   }
-  return getAppMetadata({
+  return getNextgenCollectionMetadata({
+    collection: resolvedCollection,
     title,
-    ogImage:
-      resolvedCollection.banner ||
-      resolvedCollection.image ||
-      `${publicEnv.BASE_ENDPOINT}/nextgen.png`,
-    description: "NextGen",
-    twitterCard: "summary_large_image",
   });
 }
 

--- a/app/nextgen/collection/[collection]/page-utils.ts
+++ b/app/nextgen/collection/[collection]/page-utils.ts
@@ -1,4 +1,8 @@
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import type { NextGenCollection } from "@/entities/INextgen";
 import { isEmptyObject } from "@/helpers/Helpers";
 import { commonApiFetch } from "@/services/api/common-api";
@@ -46,6 +50,29 @@ export function getContentViewKeyByValue(value: string): string {
   return NextgenCollectionView.OVERVIEW;
 }
 
+export function getNextgenCollectionMetadata({
+  collection,
+  subtitle,
+  title,
+}: {
+  readonly collection: NextGenCollection;
+  readonly subtitle?: string | undefined;
+  readonly title: string;
+}): Metadata {
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title,
+      description: "NextGen",
+      ogImage: getCollectionSocialCardImagePath("nextgen", {
+        image: collection.banner || collection.image,
+        subtitle: subtitle ?? `${collection.name} | NextGen`,
+        title,
+      }),
+      ogImageAlt: `${title} social card`,
+    })
+  );
+}
+
 export async function generateNextgenCollectionMetadata({
   collection,
   headers,
@@ -59,10 +86,9 @@ export async function generateNextgenCollectionMetadata({
   if (!resolvedCollection) {
     return getAppMetadata({ title: page });
   }
-  return getAppMetadata({
+  return getNextgenCollectionMetadata({
+    collection: resolvedCollection,
+    subtitle: `${resolvedCollection.name} | NextGen`,
     title: `${page} | ${resolvedCollection.name}`,
-    ogImage: resolvedCollection.image,
-    description: "NextGen",
-    twitterCard: "summary_large_image",
   });
 }

--- a/app/nextgen/manager/page.tsx
+++ b/app/nextgen/manager/page.tsx
@@ -1,11 +1,25 @@
 import NextGenAdminComponent from "@/components/nextGen/admin/NextGenAdmin";
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import type { Metadata } from "next";
 import { Container, Row, Col } from "react-bootstrap";
 import styles from "@/styles/Home.module.scss";
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({ title: "NextGen Admin" });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title: "NextGen Admin",
+      description: "NextGen",
+      ogImage: getCollectionSocialCardImagePath("nextgen", {
+        subtitle: "Manage NextGen collections",
+        title: "NextGen Admin",
+      }),
+      ogImageAlt: "NextGen Admin social card",
+    })
+  );
 }
 
 export default function NextGenAdminPage() {

--- a/app/nextgen/token/[token]/[[...view]]/page.tsx
+++ b/app/nextgen/token/[token]/[[...view]]/page.tsx
@@ -1,5 +1,9 @@
-import { getAppMetadata } from "@/components/providers/metadata";
-import { publicEnv } from "@/config/env";
+import {
+  getAppMetadata,
+  getLargeSocialCardMetadata,
+  getNftSocialCardImagePath,
+} from "@/components/providers/metadata";
+import { NEXTGEN_CONTRACT } from "@/constants/constants";
 import { getAppCommonHeaders } from "@/helpers/server.app.helpers";
 import { NextgenCollectionView } from "@/types/enums";
 import type { Metadata } from "next";
@@ -16,7 +20,21 @@ export async function generateMetadata({
   const headers = await getAppCommonHeaders();
   const data = await fetchTokenData(token, headers);
   if (!data) {
-    return getAppMetadata({ title: "NextGen Token" });
+    return getAppMetadata(
+      getLargeSocialCardMetadata({
+        title: "NextGen Token",
+        description: "NextGen",
+        ogImage: getNftSocialCardImagePath({
+          badge: "NextGen",
+          collection: "NextGen",
+          contract: NEXTGEN_CONTRACT,
+          id: token,
+          subtitle: "NextGen",
+          title: `NextGen #${token}`,
+        }),
+        ogImageAlt: "NextGen Token social card",
+      })
+    );
   }
   const resolvedView = getContentView(view?.[0] ?? "");
   const viewDisplay =
@@ -24,15 +42,27 @@ export async function generateMetadata({
   const baseTitle =
     data.token?.name ?? `${data.collection.name} - #${data.tokenId}`;
   const title = viewDisplay ? `${baseTitle} | ${viewDisplay}` : baseTitle;
-  return getAppMetadata({
-    title,
-    ogImage:
-      data.token?.thumbnail_url ||
-      data.token?.image_url ||
-      data.collection.banner ||
-      `${publicEnv.BASE_ENDPOINT}/nextgen.png`,
-    description: "NextGen",
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title,
+      description: "NextGen",
+      ogImage: getNftSocialCardImagePath({
+        artist: data.collection.artist,
+        badge: "NextGen",
+        collection: data.collection.name,
+        contract: NEXTGEN_CONTRACT,
+        id: data.tokenId,
+        image:
+          data.token?.thumbnail_url ||
+          data.token?.image_url ||
+          data.collection.banner ||
+          data.collection.image,
+        subtitle: `${data.collection.name} #${data.tokenId} | NextGen`,
+        title,
+      }),
+      ogImageAlt: `${title} social card`,
+    })
+  );
 }
 
 export default async function NextGenTokenPage({

--- a/app/rememes/[contract]/[id]/page.tsx
+++ b/app/rememes/[contract]/[id]/page.tsx
@@ -28,20 +28,50 @@ const getRememeName = (rememe: Rememe): string | undefined => {
     : undefined;
 };
 
+const getNonEmptyRecordText = (
+  record: Record<string, unknown>,
+  key: string
+): string | undefined => {
+  const value = record[key];
+  return typeof value === "string" ? getNonEmptyText(value) : undefined;
+};
+
+const getRememeMediaImage = (media: unknown): string | undefined => {
+  if (Array.isArray(media)) {
+    return media.find((item): item is { gateway: string } => {
+      if (item === null || item === undefined || typeof item !== "object") {
+        return false;
+      }
+      const gateway = (item as Record<string, unknown>)["gateway"];
+      return typeof gateway === "string" && gateway.trim().length > 0;
+    })?.gateway;
+  }
+
+  if (media === null || media === undefined || typeof media !== "object") {
+    return undefined;
+  }
+
+  const mediaRecord = media as Record<string, unknown>;
+  return (
+    getNonEmptyRecordText(mediaRecord, "thumbnailUrl") ??
+    getNonEmptyRecordText(mediaRecord, "cachedUrl") ??
+    getNonEmptyRecordText(mediaRecord, "pngUrl") ??
+    getNonEmptyRecordText(mediaRecord, "originalUrl")
+  );
+};
+
 const getRememeImage = (rememe?: Rememe): string | undefined => {
   if (!rememe) {
     return undefined;
   }
 
-  const mediaGateway = rememe.media.find(
-    (media) => media.gateway.trim().length > 0
-  )?.gateway;
+  const mediaImage = getRememeMediaImage(rememe.media);
 
   return (
     getNonEmptyText(rememe.s3_image_scaled) ??
     getNonEmptyText(rememe.s3_image_original) ??
     getNonEmptyText(rememe.image) ??
-    getNonEmptyText(mediaGateway) ??
+    mediaImage ??
     getNonEmptyText(rememe.contract_opensea_data.imageUrl)
   );
 };

--- a/app/rememes/[contract]/[id]/page.tsx
+++ b/app/rememes/[contract]/[id]/page.tsx
@@ -1,12 +1,50 @@
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getLargeSocialCardMetadata,
+  getNftSocialCardImagePath,
+} from "@/components/providers/metadata";
 import RememePage from "@/components/rememes/RememePage";
 import { publicEnv } from "@/config/env";
 import { formatAddress } from "@/helpers/Helpers";
+import { getAppCommonHeaders } from "@/helpers/server.app.helpers";
 import { fetchUrl } from "@/services/6529api";
 import styles from "@/styles/Home.module.scss";
 import type { DBResponse } from "@/entities/IDBResponse";
 import type { Rememe } from "@/entities/INFT";
 import type { Metadata } from "next";
+
+const getNonEmptyText = (value: string | undefined): string | undefined => {
+  const normalized = value?.trim() ?? "";
+  return normalized.length > 0 ? normalized : undefined;
+};
+
+const getRememeCollectionName = (rememe?: Rememe): string =>
+  getNonEmptyText(rememe?.contract_opensea_data.collectionName) ?? "ReMemes";
+
+const getRememeName = (rememe: Rememe): string | undefined => {
+  const metadata = rememe.metadata as { name?: unknown };
+  return typeof metadata.name === "string"
+    ? getNonEmptyText(metadata.name)
+    : undefined;
+};
+
+const getRememeImage = (rememe?: Rememe): string | undefined => {
+  if (!rememe) {
+    return undefined;
+  }
+
+  const mediaGateway = rememe.media.find(
+    (media) => media.gateway.trim().length > 0
+  )?.gateway;
+
+  return (
+    getNonEmptyText(rememe.s3_image_scaled) ??
+    getNonEmptyText(rememe.s3_image_original) ??
+    getNonEmptyText(rememe.image) ??
+    getNonEmptyText(mediaGateway) ??
+    getNonEmptyText(rememe.contract_opensea_data.imageUrl)
+  );
+};
 
 export default async function ReMeme({
   params,
@@ -29,18 +67,21 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { contract, id } = await params;
   let name = `${formatAddress(contract)} #${id}`;
-  let image = `${publicEnv.BASE_ENDPOINT}/6529io.png`;
+  let rememe: Rememe | undefined;
+
   try {
+    const headers = await getAppCommonHeaders();
     const response = await fetchUrl<DBResponse<Rememe>>(
-      `${publicEnv.API_ENDPOINT}/api/rememes?contract=${contract}&id=${id}`
+      `${publicEnv.API_ENDPOINT}/api/rememes?contract=${contract}&id=${id}`,
+      { headers }
     );
 
-    if (response?.data?.length > 0) {
-      if (response.data[0]?.metadata?.name) {
-        name = response.data[0]?.metadata.name;
-      }
-      if (response.data[0]?.image) {
-        image = response.data[0]?.image;
+    const firstRememe = response.data[0];
+    if (firstRememe !== undefined) {
+      rememe = firstRememe;
+      const rememeName = getRememeName(rememe);
+      if (rememeName !== undefined) {
+        name = rememeName;
       }
     }
   } catch (error) {
@@ -50,10 +91,22 @@ export async function generateMetadata({
     );
   }
 
-  return getAppMetadata({
-    title: name,
-    ogImage: image ?? `${publicEnv.BASE_ENDPOINT}/re-memes-b.jpeg`,
-    description: `ReMemes`,
-    twitterCard: "summary",
-  });
+  const collectionName = getRememeCollectionName(rememe);
+
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title: name,
+      description: "ReMemes",
+      ogImage: getNftSocialCardImagePath({
+        badge: "ReMemes",
+        collection: collectionName,
+        contract,
+        id,
+        image: getRememeImage(rememe),
+        subtitle: `${collectionName} #${id} | ReMemes`,
+        title: name,
+      }),
+      ogImageAlt: `${name} ReMeme social card`,
+    })
+  );
 }

--- a/app/rememes/add/page.tsx
+++ b/app/rememes/add/page.tsx
@@ -1,6 +1,9 @@
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import RememeAddPage from "@/components/rememes/RememeAddPage";
-import { publicEnv } from "@/config/env";
 import styles from "@/styles/Home.module.scss";
 import type { Metadata } from "next";
 
@@ -13,9 +16,15 @@ export default function ReMemesAddPage() {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({
-    title: "ReMemes | Add",
-    description: "Collections",
-    ogImage: `${publicEnv.BASE_ENDPOINT}/re-memes-b.jpeg`,
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title: "ReMemes | Add",
+      description: "Collections",
+      ogImage: getCollectionSocialCardImagePath("rememes", {
+        subtitle: "Submit a community remix or derivative",
+        title: "Add a ReMeme",
+      }),
+      ogImageAlt: "Add ReMeme social card",
+    })
+  );
 }

--- a/app/rememes/page.tsx
+++ b/app/rememes/page.tsx
@@ -1,6 +1,9 @@
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import Rememes from "@/components/rememes/Rememes";
-import { publicEnv } from "@/config/env";
 import styles from "@/styles/Home.module.scss";
 import type { Metadata } from "next";
 
@@ -13,9 +16,12 @@ export default function ReMemesPage() {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({
-    title: "ReMemes",
-    description: "Collections",
-    ogImage: `${publicEnv.BASE_ENDPOINT}/re-memes-b.jpeg`,
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title: "ReMemes",
+      description: "Collections",
+      ogImage: getCollectionSocialCardImagePath("rememes"),
+      ogImageAlt: "ReMemes collection social card",
+    })
+  );
 }

--- a/app/the-memes/mint/page.tsx
+++ b/app/the-memes/mint/page.tsx
@@ -1,6 +1,9 @@
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import TheMemesMint from "@/components/the-memes/TheMemesMint";
-import { publicEnv } from "@/config/env";
 import type { NFTWithMemesExtendedData } from "@/entities/INFT";
 import { getAppCommonHeaders } from "@/helpers/server.app.helpers";
 import { commonApiFetch } from "@/services/api/common-api";
@@ -21,10 +24,15 @@ export default async function TheMemesMintPage() {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({
-    title: "Mint | The Memes",
-    ogImage: `${publicEnv.BASE_ENDPOINT}/memes-preview.png`,
-    description: "Collections",
-    twitterCard: "summary_large_image",
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title: "Mint | The Memes",
+      ogImage: getCollectionSocialCardImagePath("the-memes", {
+        title: "Mint | The Memes",
+        subtitle: "Latest The Memes mint on 6529.io",
+      }),
+      ogImageAlt: "The Memes mint social card",
+      description: "Collections",
+    })
+  );
 }

--- a/app/the-memes/page.tsx
+++ b/app/the-memes/page.tsx
@@ -1,8 +1,11 @@
 import styles from "@/styles/Home.module.scss";
 
-import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  getAppMetadata,
+  getCollectionSocialCardImagePath,
+  getLargeSocialCardMetadata,
+} from "@/components/providers/metadata";
 import TheMemesComponent from "@/components/the-memes/TheMemes";
-import { publicEnv } from "@/config/env";
 import type { Metadata } from "next";
 
 export default function TheMemesPage() {
@@ -14,10 +17,12 @@ export default function TheMemesPage() {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({
-    title: "The Memes",
-    ogImage: `${publicEnv.BASE_ENDPOINT}/memes-preview.png`,
-    description: "Collections",
-    twitterCard: "summary_large_image",
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title: "The Memes",
+      ogImage: getCollectionSocialCardImagePath("the-memes"),
+      ogImageAlt: "The Memes collection social card",
+      description: "Collections",
+    })
+  );
 }

--- a/components/providers/metadata.ts
+++ b/components/providers/metadata.ts
@@ -22,12 +22,42 @@ type LargeSocialCardMetadata = Omit<
   readonly ogImage: string;
 };
 
+type SocialCardQueryValue = string | number | null | undefined;
+
 const getBaseEndpointUrl = (baseEndpoint: string): URL => {
   try {
     return new URL(baseEndpoint);
   } catch {
     return new URL(publicEnv.BASE_ENDPOINT);
   }
+};
+
+const appendSocialCardQueryText = (
+  params: URLSearchParams,
+  key: string,
+  value: SocialCardQueryValue
+) => {
+  if (value === null || value === undefined) {
+    return;
+  }
+
+  const normalized = String(value).trim();
+  if (normalized) {
+    params.set(key, normalized);
+  }
+};
+
+const getSocialCardImagePath = (
+  path: string,
+  query: Record<string, SocialCardQueryValue>
+): string => {
+  const params = new URLSearchParams();
+  Object.entries(query).forEach(([key, value]) =>
+    appendSocialCardQueryText(params, key, value)
+  );
+
+  const queryString = params.toString();
+  return queryString ? `${path}?${queryString}` : path;
 };
 
 export function getAbsoluteOgImageUrl(
@@ -41,6 +71,55 @@ export function getDefaultOgImageUrl(
   baseEndpoint = publicEnv.BASE_ENDPOINT
 ): string {
   return getAbsoluteOgImageUrl(DEFAULT_OG_IMAGE_PATH, baseEndpoint);
+}
+
+export function getCollectionSocialCardImagePath(
+  collection: string,
+  options: {
+    readonly badge?: SocialCardQueryValue;
+    readonly image?: SocialCardQueryValue;
+    readonly subtitle?: SocialCardQueryValue;
+    readonly title?: SocialCardQueryValue;
+  } = {}
+): string {
+  return getSocialCardImagePath(
+    `/api/og-metadata/collections/${encodeURIComponent(collection)}`,
+    options
+  );
+}
+
+export function getNftSocialCardImagePath({
+  artist,
+  badge,
+  collection,
+  contract,
+  id,
+  image,
+  subtitle,
+  title,
+}: {
+  readonly artist?: SocialCardQueryValue;
+  readonly badge?: SocialCardQueryValue;
+  readonly collection?: SocialCardQueryValue;
+  readonly contract: string;
+  readonly id: string | number;
+  readonly image?: SocialCardQueryValue;
+  readonly subtitle?: SocialCardQueryValue;
+  readonly title?: SocialCardQueryValue;
+}): string {
+  return getSocialCardImagePath(
+    `/api/og-metadata/nfts/${encodeURIComponent(contract)}/${encodeURIComponent(
+      String(id)
+    )}`,
+    {
+      artist,
+      badge,
+      collection,
+      image,
+      subtitle,
+      title,
+    }
+  );
 }
 
 export function getLargeSocialCardMetadata<

--- a/components/the-memes/MemeShared.tsx
+++ b/components/the-memes/MemeShared.tsx
@@ -3,7 +3,11 @@ import { MEMELAB_CONTRACT } from "@/constants/constants";
 import type { BaseNFT } from "@/entities/INFT";
 import { areEqualAddresses, idStringToDisplay } from "@/helpers/Helpers";
 import { fetchUrl } from "@/services/6529api";
-import { getAppMetadata } from "../providers/metadata";
+import {
+  getAppMetadata,
+  getLargeSocialCardMetadata,
+  getNftSocialCardImagePath,
+} from "../providers/metadata";
 
 export enum MEME_FOCUS {
   LIVE = "live",
@@ -41,23 +45,28 @@ async function getMetadataProps(
 ) {
   let urlPath = "nfts";
   const idDisplay = idStringToDisplay(id);
+  let collection = "The Memes";
   let name = `The Memes #${idDisplay}`;
   let description = "Collections";
   if (areEqualAddresses(contract, MEMELAB_CONTRACT)) {
     urlPath = "nfts_memelab";
+    collection = "Meme Lab";
     name = `Meme Lab #${idDisplay}`;
   }
   const response = await fetchUrl(
     `${publicEnv.API_ENDPOINT}/api/${urlPath}?contract=${contract}&id=${id}`
   );
-  let image = `${publicEnv.BASE_ENDPOINT}/6529io.png`;
+  let artist: string | null = null;
+  let image: string | null = null;
   if (response?.data?.length > 0) {
+    const nft = response.data[0];
     description = `${name} | ${description}`;
-    name = `${response.data[0].name}`;
-    if (response.data[0].thumbnail) {
-      image = response.data[0].thumbnail;
-    } else if (response.data[0].image) {
-      image = response.data[0].image;
+    name = `${nft.name}`;
+    artist = nft.artist ?? null;
+    if (nft.thumbnail) {
+      image = nft.thumbnail;
+    } else if (nft.image) {
+      image = nft.image;
     }
   }
 
@@ -73,7 +82,17 @@ async function getMetadataProps(
   return {
     title: name,
     description: description,
-    ogImage: image,
+    ogImage: getNftSocialCardImagePath({
+      artist,
+      badge: collection,
+      collection,
+      contract,
+      id,
+      image,
+      subtitle: description,
+      title: name,
+    }),
+    ogImageAlt: `${name} social card`,
   };
 }
 
@@ -83,19 +102,21 @@ export async function getSharedAppServerSideProps(
   focus: string,
   isDistribution: boolean = false
 ) {
-  const { title, description, ogImage } = await getMetadataProps(
+  const { title, description, ogImage, ogImageAlt } = await getMetadataProps(
     contract,
     id,
     focus,
     isDistribution
   );
 
-  return getAppMetadata({
-    title,
-    description: description,
-    ogImage,
-    twitterCard: "summary",
-  });
+  return getAppMetadata(
+    getLargeSocialCardMetadata({
+      title,
+      description,
+      ogImage,
+      ogImageAlt,
+    })
+  );
 }
 
 export function getMemeTabTitle(

--- a/ops/docs/shared/README.md
+++ b/ops/docs/shared/README.md
@@ -36,6 +36,12 @@ Shared docs cover user-facing behavior reused across multiple product areas.
 - [Browser Zoom and Pinch Scaling](feature-browser-zoom-and-pinch-scaling.md):
   web zoom defaults plus native-wrapper zoom lock and text-entry safeguards.
 
+### Metadata and Sharing
+
+- [Social Card and Open Graph Metadata](feature-social-card-and-open-graph-metadata.md):
+  shared metadata helpers, dynamic OG endpoint families, standardized coverage,
+  and the expansion checklist for new share surfaces.
+
 ### Privacy and Consent
 
 - [Cookie Consent and Performance Analytics](feature-cookie-consent-and-performance-analytics.md):

--- a/ops/docs/shared/feature-social-card-and-open-graph-metadata.md
+++ b/ops/docs/shared/feature-social-card-and-open-graph-metadata.md
@@ -1,0 +1,109 @@
+# Social Card and Open Graph Metadata
+
+Parent: [Shared Index](README.md)
+
+## Overview
+
+6529 has mature dynamic Open Graph card rendering. New share surfaces should
+expand that coverage and standardize on the existing card families, not rebuild
+social-card infrastructure from scratch.
+
+The shared metadata contract lives in `components/providers/metadata.ts`.
+User-facing routes pass route metadata through `getAppMetadata`. Routes that
+need large social previews use `getLargeSocialCardMetadata`, which standardizes
+the `1200x630` image dimensions and `summary_large_image` Twitter card.
+
+## Location in the Site
+
+- Any public route with Next.js `generateMetadata`.
+- Dynamic social-card API routes under `/api/og-metadata`.
+- Server metadata helpers that build share metadata for profiles, waves, drops,
+  collections, NFTs, NextGen, ReMemes, Meme Lab, The Memes, and 6529 Gradient.
+
+## Dynamic Card Families
+
+- `/api/og-metadata/profiles/{identity}` renders identity/profile cards from
+  API-backed profile metadata.
+- `/api/og-metadata/waves/{id}` renders wave cards from API-backed wave
+  metadata.
+- `/api/og-metadata/drops/{id}` renders drop cards from API-backed drop
+  metadata.
+- `/api/og-metadata/collections/{collection}` renders branded collection cards.
+  It has built-in defaults for `the-memes`, `meme-lab`, `6529-gradient`,
+  `rememes`, and `nextgen`, plus query overrides for `badge`, `image`,
+  `subtitle`, and `title`.
+- `/api/og-metadata/nfts/{contract}/{id}` renders branded NFT cards with query
+  overrides for `artist`, `badge`, `collection`, `image`, `subtitle`, and
+  `title`.
+- `/api/og-metadata/image?url={url}&w={width}` safely normalizes allowed remote
+  images for card rendering.
+
+## Standard Route Contract
+
+- Use `getAppMetadata` for every App Router metadata response so title,
+  description, favicon, version, site name, default image, and Twitter site stay
+  consistent.
+- Use `getLargeSocialCardMetadata` when a route should render as a large social
+  card. Do not hand-code `twitterCard: "summary_large_image"` or hard-code
+  `1200x630` in route metadata.
+- Use `getCollectionSocialCardImagePath` for collection-like pages.
+- Use `getNftSocialCardImagePath` for token, NFT, and token-detail pages.
+- Keep API-backed entity details in query parameters on the collection/NFT card
+  paths instead of creating one-off static OG image URLs.
+- Profile, wave, and drop metadata can point directly at their dynamic endpoint
+  because those endpoint families already own the entity-specific rendering.
+
+## Current Standardized Coverage
+
+- Site default metadata and default image normalization through
+  `getAppMetadata`.
+- Profile cards through the profile OG endpoint.
+- Wave cards and drop cards through the wave/drop OG endpoints, including
+  wave-page entity-specific metadata in `waves-page.shared.tsx`.
+- Collection landing cards for The Memes, Meme Lab, 6529 Gradient, ReMemes, and
+  NextGen.
+- Detail cards for 6529 Gradient tokens, ReMemes, and NextGen tokens through
+  the NFT card endpoint.
+- NextGen collection, collection subpage, admin, and view metadata through the
+  shared collection card helpers.
+- The Memes mint metadata through the collection card endpoint.
+
+## Expansion Checklist
+
+1. Pick the existing card family first:
+   - profile identity -> profile endpoint
+   - wave -> wave endpoint
+   - drop -> drop endpoint
+   - collection/list/gallery -> collection endpoint
+   - NFT/token/detail -> NFT endpoint
+2. Add a new endpoint only when the entity model cannot fit an existing card
+   family.
+3. Route metadata should call `getAppMetadata` and, for large cards,
+   `getLargeSocialCardMetadata`.
+4. Collection/NFT cards should use the helper path builders instead of manual
+   `BASE_ENDPOINT` string interpolation.
+5. Provide useful fallback metadata when API data is missing: stable title,
+   collection/badge label, and no broken image query.
+6. Add focused tests that assert title, `twitter.card`, Open Graph image
+   dimensions, endpoint pathname, query parameters, and missing-data fallback.
+7. For new or changed render endpoints, verify the PNG response in a browser or
+   endpoint test and confirm dimensions remain `1200x630`.
+8. Update this page when a new route family becomes standardized.
+
+## Known Follow-Ups
+
+- Continue migrating older static collection and editorial pages that still
+  rely on bespoke image URLs or inline metadata tags.
+- Prefer helper-backed metadata for newly added public App Router pages before
+  adding route-specific card code.
+- Keep social-card route tests in sync with endpoint defaults so branded cards
+  do not silently lose titles, subtitles, image fallbacks, or dimensions.
+
+## Related Pages
+
+- [Shared Index](README.md)
+- [Media Collections Index](../media/collections/README.md)
+- [Media NFT Index](../media/nft/README.md)
+- [NextGen Index](../nextgen/README.md)
+- [Profiles Index](../profiles/README.md)
+- [Waves Index](../waves/README.md)


### PR DESCRIPTION
## Issue

Legacy collection and NFT metadata builders still used a mix of static absolute image URLs, raw NFT media URLs, and small Twitter cards after the shared OG metadata contract and branded card routes were introduced.

Depends on #2594.

## Fix

Wire the legacy collection landing pages and selected NFT detail metadata builders through the shared branded collection/NFT OG card endpoints and the large social card metadata helper.

## Changes

- Add shared URL builders for collection and NFT social card image routes.
- Migrate The Memes, Meme Lab, 6529 Gradient, and The Memes mint metadata to branded collection cards.
- Migrate The Memes/Meme Lab shared NFT metadata and 6529 Gradient NFT detail metadata to branded NFT cards.
- Add/refresh focused coverage for metadata helpers, collection landing metadata, MemeShared metadata, gradient metadata, and mint metadata.

## Validation

- `6529 run test -- __tests__/components/providers/metadata.test.ts __tests__/components/the-memes/MemeShared.test.tsx __tests__/app/gradientPage.test.tsx __tests__/app/the-memes/theMemesMint.test.tsx __tests__/app/collectionMetadataPages.test.tsx`
- `6529 exec prettier --check components/providers/metadata.ts components/the-memes/MemeShared.tsx app/the-memes/page.tsx app/meme-lab/page.tsx app/6529-gradient/page.tsx 'app/6529-gradient/[id]/page.tsx' app/the-memes/mint/page.tsx __tests__/components/providers/metadata.test.ts __tests__/components/the-memes/MemeShared.test.tsx __tests__/app/gradientPage.test.tsx __tests__/app/the-memes/theMemesMint.test.tsx __tests__/app/collectionMetadataPages.test.tsx`
- `6529 run lint:changed`
- `6529 run typecheck:changed`
- `git diff --check`
- Browser verified on `http://localhost:3116`:
  - `/api/og-metadata/collections/the-memes` rendered as a `1200x630` PNG.
  - `/api/og-metadata/nfts/0x33FD426905F149f8376e227d0C9D3340AaD17aF1/1?...` rendered as a `1200x630` PNG with no browser console errors.

## Risk

Low to moderate. This changes social preview URLs and Twitter card shape for migrated routes, but keeps existing page rendering and fetch behavior unchanged.

## Review Notes

This is PR 5 in the OG/social standardization stack. CodeRabbit may need a manual review trigger because the base branch is another feature branch, not the default branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Open Graph and Twitter card metadata for social sharing across collection and NFT pages
  * Customizable social card parameters including badges, subtitles, and custom images

* **Tests**
  * Added comprehensive test coverage for metadata generation across collection and NFT pages
  * Validation for social card image path generation with query parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->