### PR TITLE
Document OG metadata guardrails

### DIFF
--- a/__tests__/components/providers/metadataSocialCardGuardrails.test.ts
+++ b/__tests__/components/providers/metadataSocialCardGuardrails.test.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "fs";
-import path from "path";
+import { readFileSync } from "node:fs";
+import path from "node:path";
 
 type MetadataSourceGuardrail = {
   readonly requiredSnippets: readonly string[];

--- a/__tests__/components/providers/metadataSocialCardGuardrails.test.ts
+++ b/__tests__/components/providers/metadataSocialCardGuardrails.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 type MetadataSourceGuardrail = {
@@ -6,6 +6,7 @@ type MetadataSourceGuardrail = {
   readonly routePath: string;
 };
 
+// Manually enrolled routes: add new standardized metadata surfaces here.
 const standardizedMetadataSources: readonly MetadataSourceGuardrail[] = [
   {
     routePath: "app/the-memes/page.tsx",
@@ -97,12 +98,23 @@ const standardizedMetadataSources: readonly MetadataSourceGuardrail[] = [
   },
 ];
 
+// Heuristics for the most common drift patterns, not exhaustive source parsing.
 const manualLargeTwitterCard = /twitterCard\s*:\s*["']summary_large_image["']/;
 const directBaseEndpointOgImage =
   /ogImage\s*:\s*`[^`]*\$\{publicEnv\.BASE_ENDPOINT\}/;
 
-const readSource = (routePath: string): string =>
-  readFileSync(path.join(process.cwd(), routePath), "utf8");
+const readSource = (routePath: string): string => {
+  const absoluteRoutePath = path.join(process.cwd(), routePath);
+
+  if (!existsSync(absoluteRoutePath)) {
+    throw new Error(
+      `Expected guardrailed metadata route "${routePath}" to exist. ` +
+        "If this route moved or was renamed, update standardizedMetadataSources."
+    );
+  }
+
+  return readFileSync(absoluteRoutePath, "utf8");
+};
 
 describe("standardized social-card metadata route guardrails", () => {
   it.each(standardizedMetadataSources)(

--- a/__tests__/components/providers/metadataSocialCardGuardrails.test.ts
+++ b/__tests__/components/providers/metadataSocialCardGuardrails.test.ts
@@ -1,0 +1,120 @@
+import { readFileSync } from "fs";
+import path from "path";
+
+type MetadataSourceGuardrail = {
+  readonly requiredSnippets: readonly string[];
+  readonly routePath: string;
+};
+
+const standardizedMetadataSources: readonly MetadataSourceGuardrail[] = [
+  {
+    routePath: "app/the-memes/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/the-memes/mint/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/meme-lab/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/6529-gradient/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/6529-gradient/[id]/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getNftSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/rememes/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/rememes/add/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/rememes/[contract]/[id]/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getNftSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/nextgen/[[...view]]/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/nextgen/manager/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/nextgen/collection/[collection]/page-utils.ts",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getCollectionSocialCardImagePath(",
+    ],
+  },
+  {
+    routePath: "app/nextgen/collection/[collection]/[[...view]]/page.tsx",
+    requiredSnippets: ["getNextgenCollectionMetadata("],
+  },
+  {
+    routePath: "app/nextgen/token/[token]/[[...view]]/page.tsx",
+    requiredSnippets: [
+      "getLargeSocialCardMetadata(",
+      "getNftSocialCardImagePath(",
+    ],
+  },
+];
+
+const manualLargeTwitterCard = /twitterCard\s*:\s*["']summary_large_image["']/;
+const directBaseEndpointOgImage =
+  /ogImage\s*:\s*`[^`]*\$\{publicEnv\.BASE_ENDPOINT\}/;
+
+const readSource = (routePath: string): string =>
+  readFileSync(path.join(process.cwd(), routePath), "utf8");
+
+describe("standardized social-card metadata route guardrails", () => {
+  it.each(standardizedMetadataSources)(
+    "$routePath keeps using shared social-card metadata helpers",
+    ({ requiredSnippets, routePath }) => {
+      const source = readSource(routePath);
+
+      requiredSnippets.forEach((snippet) => {
+        expect(source).toContain(snippet);
+      });
+      expect(source).not.toMatch(manualLargeTwitterCard);
+      expect(source).not.toMatch(directBaseEndpointOgImage);
+    }
+  );
+});

--- a/ops/docs/shared/README.md
+++ b/ops/docs/shared/README.md
@@ -36,6 +36,12 @@ Shared docs cover user-facing behavior reused across multiple product areas.
 - [Browser Zoom and Pinch Scaling](feature-browser-zoom-and-pinch-scaling.md):
   web zoom defaults plus native-wrapper zoom lock and text-entry safeguards.
 
+### Metadata and Sharing
+
+- [Social Card and Open Graph Metadata](feature-social-card-and-open-graph-metadata.md):
+  shared metadata helpers, dynamic OG endpoint families, standardized coverage,
+  and the expansion checklist for new share surfaces.
+
 ### Privacy and Consent
 
 - [Cookie Consent and Performance Analytics](feature-cookie-consent-and-performance-analytics.md):

--- a/ops/docs/shared/feature-social-card-and-open-graph-metadata.md
+++ b/ops/docs/shared/feature-social-card-and-open-graph-metadata.md
@@ -1,0 +1,109 @@
+# Social Card and Open Graph Metadata
+
+Parent: [Shared Index](README.md)
+
+## Overview
+
+6529 has mature dynamic Open Graph card rendering. New share surfaces should
+expand that coverage and standardize on the existing card families, not rebuild
+social-card infrastructure from scratch.
+
+The shared metadata contract lives in `components/providers/metadata.ts`.
+User-facing routes pass route metadata through `getAppMetadata`. Routes that
+need large social previews use `getLargeSocialCardMetadata`, which standardizes
+the `1200x630` image dimensions and `summary_large_image` Twitter card.
+
+## Location in the Site
+
+- Any public route with Next.js `generateMetadata`.
+- Dynamic social-card API routes under `/api/og-metadata`.
+- Server metadata helpers that build share metadata for profiles, waves, drops,
+  collections, NFTs, NextGen, ReMemes, Meme Lab, The Memes, and 6529 Gradient.
+
+## Dynamic Card Families
+
+- `/api/og-metadata/profiles/{identity}` renders identity/profile cards from
+  API-backed profile metadata.
+- `/api/og-metadata/waves/{id}` renders wave cards from API-backed wave
+  metadata.
+- `/api/og-metadata/drops/{id}` renders drop cards from API-backed drop
+  metadata.
+- `/api/og-metadata/collections/{collection}` renders branded collection cards.
+  It has built-in defaults for `the-memes`, `meme-lab`, `6529-gradient`,
+  `rememes`, and `nextgen`, plus query overrides for `badge`, `image`,
+  `subtitle`, and `title`.
+- `/api/og-metadata/nfts/{contract}/{id}` renders branded NFT cards with query
+  overrides for `artist`, `badge`, `collection`, `image`, `subtitle`, and
+  `title`.
+- `/api/og-metadata/image?url={url}&w={width}` safely normalizes allowed remote
+  images for card rendering.
+
+## Standard Route Contract
+
+- Use `getAppMetadata` for every App Router metadata response so title,
+  description, favicon, version, site name, default image, and Twitter site stay
+  consistent.
+- Use `getLargeSocialCardMetadata` when a route should render as a large social
+  card. Do not hand-code `twitterCard: "summary_large_image"` or hard-code
+  `1200x630` in route metadata.
+- Use `getCollectionSocialCardImagePath` for collection-like pages.
+- Use `getNftSocialCardImagePath` for token, NFT, and token-detail pages.
+- Keep API-backed entity details in query parameters on the collection/NFT card
+  paths instead of creating one-off static OG image URLs.
+- Profile, wave, and drop metadata can point directly at their dynamic endpoint
+  because those endpoint families already own the entity-specific rendering.
+
+## Current Standardized Coverage
+
+- Site default metadata and default image normalization through
+  `getAppMetadata`.
+- Profile cards through the profile OG endpoint.
+- Wave cards and drop cards through the wave/drop OG endpoints, including
+  wave-page entity-specific metadata in `waves-page.shared.tsx`.
+- Collection landing cards for The Memes, Meme Lab, 6529 Gradient, ReMemes, and
+  NextGen.
+- Detail cards for 6529 Gradient tokens, ReMemes, and NextGen tokens through
+  the NFT card endpoint.
+- NextGen collection, collection subpage, admin, and view metadata through the
+  shared collection card helpers.
+- The Memes mint metadata through the collection card endpoint.
+
+## Expansion Checklist
+
+1. Pick the existing card family first:
+   - profile identity -> profile endpoint
+   - wave -> wave endpoint
+   - drop -> drop endpoint
+   - collection/list/gallery -> collection endpoint
+   - NFT/token/detail -> NFT endpoint
+2. Add a new endpoint only when the entity model cannot fit an existing card
+   family.
+3. Route metadata should call `getAppMetadata` and, for large cards,
+   `getLargeSocialCardMetadata`.
+4. Collection/NFT cards should use the helper path builders instead of manual
+   `BASE_ENDPOINT` string interpolation.
+5. Provide useful fallback metadata when API data is missing: stable title,
+   collection/badge label, and no broken image query.
+6. Add focused tests that assert title, `twitter.card`, Open Graph image
+   dimensions, endpoint pathname, query parameters, and missing-data fallback.
+7. For new or changed render endpoints, verify the PNG response in a browser or
+   endpoint test and confirm dimensions remain `1200x630`.
+8. Update this page when a new route family becomes standardized.
+
+## Known Follow-Ups
+
+- Continue migrating older static collection and editorial pages that still
+  rely on bespoke image URLs or inline metadata tags.
+- Prefer helper-backed metadata for newly added public App Router pages before
+  adding route-specific card code.
+- Keep social-card route tests in sync with endpoint defaults so branded cards
+  do not silently lose titles, subtitles, image fallbacks, or dimensions.
+
+## Related Pages
+
+- [Shared Index](README.md)
+- [Media Collections Index](../media/collections/README.md)
+- [Media NFT Index](../media/nft/README.md)
+- [NextGen Index](../nextgen/README.md)
+- [Profiles Index](../profiles/README.md)
+- [Waves Index](../waves/README.md)


### PR DESCRIPTION
## Issue
- The OG/social-card audit follow-up needs durable guidance that reflects the repo's existing mature dynamic OG endpoints and prevents future route metadata from drifting back to one-off implementations.

## Fix
- Adds a shared runbook for expanding and standardizing OG coverage around the existing profile, wave, drop, collection, NFT, and image-normalization endpoint families.
- Adds a focused Jest guardrail that keeps the standardized collection/NFT metadata routes on the shared large-card helpers instead of ad hoc `summary_large_image` or `BASE_ENDPOINT` image construction.

## Changes
- Documents the current dynamic card families, the standardized route metadata contract, current standardized coverage, and the expansion checklist for new share surfaces.
- Links the new runbook from the shared docs index.
- Adds `metadataSocialCardGuardrails.test.ts` covering The Memes, Meme Lab, 6529 Gradient, ReMemes, and NextGen standardized metadata sources.

## Validation
- `6529 run test -- __tests__/components/providers/metadata.test.ts __tests__/components/providers/metadataSocialCardGuardrails.test.ts __tests__/app/collectionMetadataPages.test.tsx __tests__/app/rememesMetadataPages.test.tsx __tests__/app/nextgenMetadataPages.test.tsx`
- `6529 exec prettier --check __tests__/components/providers/metadataSocialCardGuardrails.test.ts ops/docs/shared/feature-social-card-and-open-graph-metadata.md ops/docs/shared/README.md`
- `git diff --check`
- `6529 run lint:changed`
- `6529 run typecheck:changed`
- `python ops/scripts/docs-area-remediator-local/validate_docs_links.py --docs-root ops/docs`

## Risk
- Level: Low
- Why: Adds docs and a test-only guardrail; no runtime metadata behavior changes.
- Rollback: Revert this PR to remove the docs page, index link, and guardrail test.

## Review Notes
- This PR intentionally documents expansion/standardization rather than claiming OG cards were absent or rebuilding the infrastructure from scratch.
- The guardrail is source-level by design: it catches helper-contract drift even when a route might still produce a superficially valid social card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added parameterized tests to enforce standardized social-card metadata guardrails across app routes.

* **Documentation**
  * Added a “Social Card and Open Graph Metadata” guide detailing shared metadata helpers, standardized endpoint families, coverage, and migration checklist.
  * Expanded shared docs with a “Metadata and Sharing” subsection linking to the new guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->