### PR TITLE
Add frontend accessibility and i18n standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,14 @@ Fight entropy. Leave the codebase better than you found it.
 - Useful commands include `6529 run lint:changed`, `6529 run typecheck:changed`, `6529 run check:changed`, and targeted `6529 run test -- <pattern>` runs.
 - Use `6529 run build` when changes touch build-time behavior, generated API models, Next.js config, routing, or deployment-sensitive code.
 
+## Frontend Standards
+
+- New and touched user-facing UI should follow `ops/standards/frontend-accessibility-wcag-22-aa.md`.
+- New and touched user-facing copy, accessible names, dates, numbers, and locale-sensitive sorting should follow `ops/standards/frontend-i18n-localization.md`.
+- Use `ops/skills/wcag-22-aa/SKILL.md` for accessibility audits and fixes.
+- Use `ops/skills/i18n-localization/SKILL.md` for progressive localization work.
+- If a touched page is not fully migrated yet, make the touched UI compliant and record remaining debt.
+
 ## Next.js App Router
 
 - Before using `useSearchParams`, read `node_modules/next/dist/docs/01-app/03-api-reference/04-functions/use-search-params.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,10 @@ The default app port is `3001`.
 - Avoid editing generated files directly unless regenerating them from source.
 - Update user-facing documentation under `ops/docs/` when user-visible behavior
   changes.
+- For new or touched frontend UI, follow the accessibility and localization
+  standards in [ops/standards](ops/standards/README.md). Do not add new
+  accessibility or i18n debt when a touched surface can reasonably meet the
+  standard.
 
 Useful commands:
 

--- a/ops/skills/README.md
+++ b/ops/skills/README.md
@@ -10,10 +10,14 @@ This folder stores repo-local Codex skills and agent guidance.
   6529 frontend workstreams from instruction to validated closeout.
 - [Commit Docs Updater](commit-docs-updater/SKILL.md):
   maintains user-facing Markdown documentation under `ops/docs/`.
+- [I18n Localization](i18n-localization/SKILL.md): guides progressive
+  frontend message extraction, locale formatting, and fallback review.
 - [React Doctor](react-doctor/SKILL.md): provides React-focused review and
   troubleshooting guidance.
 - [Sonar Guardrails](sonar-guardrails/SKILL.md): captures Sonar-oriented
   quality guardrails.
+- [WCAG 2.2 AA](wcag-22-aa/SKILL.md): guides frontend accessibility audits,
+  remediations, and PR review against WCAG 2.2 AA.
 - [Write Skills](write-skills/SKILL.md): helps create, improve, or review
   Codex/OpenAI Agent Skills and `SKILL.md` files.
 - [Write PRs](write-prs/SKILL.md): helps create PR descriptions, iterate with

--- a/ops/skills/i18n-localization/SKILL.md
+++ b/ops/skills/i18n-localization/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: i18n-localization
+description: Implement, audit, or review progressive 6529 frontend internationalization and localization work. Use when extracting user-facing copy, adding message dictionaries, locale-aware date or number formatting, translated accessible names, locale fallbacks, or PR feedback about i18n/l10n.
+---
+
+# I18n Localization
+
+Use this skill for progressive internationalization work in this repository.
+
+## Workflow
+
+1. Read `ops/standards/frontend-i18n-localization.md`.
+2. Confirm the touched surface and whether an i18n path already exists nearby.
+3. Use `en-US` as the canonical source locale. Use `en-GB`, `fr-FR`, `es-ES`,
+   and `de-DE` as the initial supported locale set.
+4. Extract visible copy and accessible names together. Include button text,
+   tabs, labels, placeholders, tooltips, empty states, validation messages,
+   error text, and `aria-label` values.
+5. Use message keys based on product meaning. Avoid sentence fragments and
+   string concatenation.
+6. Route dates, numbers, percentages, relative time, and locale-sensitive
+   sorting through repo helpers when available.
+7. Keep untranslated locales functional by falling back to `en-US` and record
+   fallback debt when a page is not fully translated.
+8. Verify every supported locale for wrapping, formatting, missing-key behavior,
+   and accessible labels.
+
+## Migration Boundaries
+
+- Do not introduce a broad i18n dependency unless the task explicitly requires
+  it or the existing wrapper is no longer sufficient.
+- Do not move the full App Router tree under `app/[lang]` during component-level
+  migration work.
+- Do not translate user-generated content unless the feature explicitly calls
+  for it.
+
+## Validation
+
+Prefer focused checks:
+
+```bash
+6529 run lint:changed
+6529 run typecheck:changed
+6529 run check:changed
+```
+
+For visible UI, run browser checks for the affected route in `en-US`, `en-GB`,
+`fr-FR`, `es-ES`, and `de-DE` when locale switching is available for the touched
+surface.

--- a/ops/skills/i18n-localization/agents/openai.yaml
+++ b/ops/skills/i18n-localization/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "I18n Localization"
+  short_description: "Extract and verify frontend copy, locale formatting, and fallbacks."
+  default_prompt: "Use $i18n-localization to make the touched frontend UI translation-ready and locale-aware."

--- a/ops/skills/wcag-22-aa/SKILL.md
+++ b/ops/skills/wcag-22-aa/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: wcag-22-aa
+description: Audit, implement, or review 6529 frontend accessibility work against WCAG 2.2 AA. Use when changing user-facing React UI, forms, dialogs, navigation, cards, tables, focus behavior, keyboard interactions, accessible names, color contrast, or PR feedback about accessibility.
+---
+
+# WCAG 2.2 AA
+
+Use this skill for accessibility audits, remediations, and PR reviews in this
+repository.
+
+## Workflow
+
+1. Read `ops/standards/frontend-accessibility-wcag-22-aa.md`.
+2. Inspect the touched route, component, and nearby shared primitives.
+3. Prefer semantic HTML before ARIA. Use native controls, labels, links, form
+   fields, and dialogs where practical.
+4. Fix shared primitive issues before page-specific copies when the blast radius
+   is reasonable.
+5. Keep the change scoped. If the whole page is not being migrated, make the
+   touched UI compliant and record remaining debt.
+6. Verify with changed-file checks, browser review, keyboard-only navigation,
+   visible focus, labels, and relevant empty/error/loading states.
+7. In PR notes, state what was audited, what was fixed, what was not checked,
+   and any exceptions.
+
+## Review Checklist
+
+- Controls have semantic elements, keyboard support, and accessible names.
+- Focus order is predictable and focus remains visible.
+- Modals, menus, popovers, and overlays manage focus and dismissal.
+- Forms associate labels, descriptions, validation errors, and recovery text.
+- Color is not the only signal and contrast is adequate.
+- Touch targets are practical for mobile and WCAG 2.2 target-size expectations.
+- Motion respects reduced-motion preferences.
+- Dynamic status, loading, and error updates are announced when needed.
+
+## Validation
+
+Prefer focused checks:
+
+```bash
+6529 run lint:changed
+6529 run typecheck:changed
+6529 run check:changed
+```
+
+Use browser verification for visible UI changes. Automated checks support the
+review but do not replace manual keyboard and focus testing.

--- a/ops/skills/wcag-22-aa/agents/openai.yaml
+++ b/ops/skills/wcag-22-aa/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "WCAG 2.2 AA"
+  short_description: "Audit and improve 6529 frontend UI against WCAG 2.2 AA."
+  default_prompt: "Use $wcag-22-aa to review the touched frontend UI for accessibility issues and summarize required fixes."

--- a/ops/standards/README.md
+++ b/ops/standards/README.md
@@ -1,0 +1,25 @@
+# Frontend Standards
+
+This folder defines repo-wide frontend standards that apply across routes and
+components. These are operational standards for contributors and agents, not
+user-facing product docs.
+
+## New PR Quality Bar
+
+New frontend work must avoid adding accessibility or localization debt.
+
+- Follow [WCAG 2.2 AA](frontend-accessibility-wcag-22-aa.md) for user-facing UI,
+  including keyboard access, visible focus, semantic controls, labels, color
+  contrast, target size, error recovery, and modal behavior.
+- Follow [I18n and Localization](frontend-i18n-localization.md) for
+  user-facing copy, accessible names, dates, numbers, sorting, and locale
+  fallbacks.
+- If a touched page is not fully migrated yet, make the touched UI meet these
+  standards and record any remaining page-level debt.
+- Document exceptions with owner, reason, user impact, and a follow-up path.
+
+## Progressive Migration
+
+The frontend is migrating incrementally. Standards PRs may merge independently.
+Page and component migration PRs should stay focused, validate the touched
+surface, and move one area at a time toward the standards.

--- a/ops/standards/frontend-accessibility-wcag-22-aa.md
+++ b/ops/standards/frontend-accessibility-wcag-22-aa.md
@@ -1,0 +1,95 @@
+# Frontend Accessibility Standard: WCAG 2.2 AA
+
+## Target
+
+The frontend target is WCAG 2.2 AA for user-facing web UI. Migration is
+progressive: new work must not add accessibility debt, and touched UI should be
+moved toward this standard even when the whole page is not yet verified.
+
+WCAG 2.2 AA is the required baseline. AAA improvements are welcome when they
+fit the product, but they do not replace AA verification.
+
+## Applies To
+
+- App routes, layouts, modals, forms, navigation, cards, tables, dialogs,
+  toolbars, menus, overlays, toasts, loading states, empty states, and errors.
+- Visible text and non-visible accessible names such as `aria-label`,
+  `aria-labelledby`, `alt`, status messages, and validation copy.
+- Keyboard, pointer, touch, screen reader, zoom, reduced motion, and high
+  contrast use.
+
+User-generated content is not required to be rewritten, but the app shell that
+renders it must remain accessible.
+
+## New PR Requirements
+
+- Use semantic interactive elements: `button`, `a`, `Link`, native form fields,
+  and native `dialog` where practical.
+- Do not attach click or keyboard handlers to non-interactive elements unless
+  the element is given a valid role, focus behavior, keyboard behavior, and an
+  accessible name. Prefer replacing it with a semantic element.
+- Preserve keyboard access for every action. Tab order must match visual and
+  task order.
+- Provide visible focus indicators that are not removed or hidden by custom
+  styling.
+- Give every control a stable accessible name. Icon-only controls need labels.
+- Use headings, landmarks, lists, tables, and form labels according to meaning,
+  not visual appearance.
+- Meet contrast requirements for text, non-text UI, focus indicators, and
+  disabled or selected states where WCAG applies.
+- Make pointer targets large enough for normal touch use. Use WCAG 2.2 target
+  size guidance unless a documented exception applies.
+- Ensure errors are announced, associated with fields, and explain recovery.
+- Keep motion optional. Respect reduced-motion settings for animation that can
+  distract, disorient, or block task completion.
+- Avoid content that requires hover, precise pointer movement, or dragging when
+  a keyboard or touch alternative is not available.
+
+## Migration Checklist
+
+For each migrated page or component:
+
+- Can all meaningful actions be reached and operated with keyboard only?
+- Is focus visible and restored after dialogs, menus, route changes, and async
+  operations?
+- Do controls, links, tabs, inputs, menus, and dialogs expose correct roles and
+  names?
+- Are labels, descriptions, validation errors, status messages, and empty states
+  programmatically connected where needed?
+- Are heading order, landmarks, page title, and main content navigation usable?
+- Does text remain readable at 200% zoom and on mobile widths?
+- Do color, icon, and shape choices avoid color-only meaning?
+- Do loading, error, disabled, selected, and pressed states remain clear?
+- Are images, media, charts, and NFT previews given useful alt text or marked
+  decorative when appropriate?
+- Does automated a11y scanning show no new serious issues on the touched
+  surface?
+
+## Verification
+
+Use the strongest focused checks available for the touched surface:
+
+- `6529 run lint:changed`
+- `6529 run typecheck:changed`
+- Targeted unit or component tests when existing coverage is nearby
+- Browser verification for visible UI changes
+- Manual keyboard pass
+- Screen reader smoke check when labels, dialogs, forms, or dynamic status
+  messages change
+
+Automated tools do not prove WCAG conformance. They catch regressions and
+obvious defects; manual review is still required.
+
+## Exceptions
+
+Exceptions are allowed only when fixing the issue would be disproportionate for
+the current PR or blocked by third-party behavior. Record:
+
+- route or component
+- WCAG-related issue
+- user impact
+- reason for deferral
+- owner or follow-up issue
+- expected remediation path
+
+Do not use exceptions for new code when a compliant implementation is practical.

--- a/ops/standards/frontend-i18n-localization.md
+++ b/ops/standards/frontend-i18n-localization.md
@@ -1,0 +1,99 @@
+# Frontend I18n and Localization Standard
+
+## Target
+
+The frontend must become translation-ready and locale-aware progressively. New
+or touched user-facing UI should avoid hardcoded copy and should format
+locale-sensitive values through approved helpers.
+
+The initial locale set is:
+
+- `en-US`: canonical source locale and default
+- `en-GB`: English UK variant
+- `fr-FR`: French
+- `es-ES`: Spanish
+- `de-DE`: German
+
+Use BCP 47 locale identifiers. Treat "EN-UK" as `en-GB`.
+
+## Applies To
+
+- Visible app copy, headings, buttons, tabs, labels, placeholders, tooltips,
+  empty states, loading states, errors, validation messages, and metadata.
+- Non-visible accessible names and descriptions such as `aria-label`, `alt`,
+  screen-reader-only text, and status messages.
+- Dates, times, numbers, currencies, percentages, relative time, pluralization,
+  list formatting, and locale-sensitive sorting.
+
+User-generated content should remain in the user's authored language unless a
+specific translation feature is added.
+
+## New PR Requirements
+
+- Do not add new hardcoded user-facing strings in React components when an i18n
+  path exists for the touched area.
+- Store message source text under the app's approved i18n message structure.
+- Use stable message keys that describe product meaning, not English wording.
+- Use interpolation for dynamic values. Do not concatenate translated fragments
+  into sentences.
+- Keep accessible names in the same message system as visible labels.
+- Use locale-aware helpers for dates, times, numbers, percentages, relative
+  time, lists, and sorting.
+- Design for longer translated text. UI must wrap or resize without overlap.
+- Avoid text embedded in images unless the image is content and an accessible
+  text alternative is supplied.
+- Keep untranslated locales functional through documented fallback to `en-US`.
+
+## Progressive Routing Policy
+
+Do not move the full app under `app/[lang]` as part of the first migration wave.
+The first wave makes components message-backed and locale-format-ready.
+
+Localized route prefixes can be introduced later route by route when the page
+has message coverage, metadata policy, canonical links, and QA for supported
+locales.
+
+## Message And Fallback Policy
+
+- `en-US` is the complete source dictionary.
+- Other locale dictionaries may be partial during migration.
+- Missing keys fall back to `en-US`.
+- Missing fallback keys should fail loudly in development or tests when the
+  helper supports it.
+- Keep fallback debt visible in the page or workstream tracker.
+
+## Formatting Policy
+
+Use native `Intl` through repo helpers before adding a larger i18n dependency.
+Helpers should cover:
+
+- date and time
+- relative time
+- integers, decimals, compact numbers, and percentages
+- currency only when the product explicitly knows currency semantics
+- locale-sensitive compare and sorting
+
+Do not use `toLocaleString()` directly in newly touched UI when a repo helper is
+available.
+
+## Verification
+
+For each migrated page or component:
+
+- Render with `en-US`, `en-GB`, `fr-FR`, `es-ES`, and `de-DE`.
+- Check that long labels wrap without overlap or clipped buttons.
+- Check that accessible labels translate or fall back consistently.
+- Check that dates, numbers, and sorted labels follow the selected locale.
+- Confirm missing translations fall back to `en-US` without crashing.
+- Run focused changed-file checks and browser verification for visible UI.
+
+## Exceptions
+
+Record exceptions for untranslated or not-yet-localized areas with:
+
+- route or component
+- untranslated surface
+- current fallback behavior
+- user impact
+- owner or follow-up issue
+- expected remediation path

--- a/ops/workstreams/frontend-a11y-i18n/README.md
+++ b/ops/workstreams/frontend-a11y-i18n/README.md
@@ -1,0 +1,47 @@
+# Frontend Accessibility And I18n Workstream
+
+## Charter
+
+Progressively migrate the frontend toward WCAG 2.2 AA and locale-aware UI. The
+workstream starts with standards and repo-local skills, then moves through safe
+page surfaces one PR at a time.
+
+## Reload Order
+
+1. `AGENTS.md`
+2. `ops/skills/6529-autonomous-manager/SKILL.md`
+3. `ops/skills/write-prs/SKILL.md`
+4. `ops/standards/README.md`
+5. `active-context.md`
+6. `run-log.md`
+
+## Owned Paths
+
+- `ops/standards/`
+- `ops/skills/wcag-22-aa/`
+- `ops/skills/i18n-localization/`
+- `ops/workstreams/frontend-a11y-i18n/`
+- Future scoped implementation PRs for selected frontend surfaces.
+
+## Forbidden Paths Without Explicit Need
+
+- Generated files.
+- Environment files.
+- Minting or transaction flows during the first safe-page wave.
+- Unrelated user changes.
+
+## Evidence Standard
+
+Every PR must record:
+
+- changed surface
+- validation commands
+- browser or manual UI checks when visible behavior changes
+- bot feedback decisions
+- remaining risks or exceptions
+
+## Escalation Triggers
+
+Ask for human input only for secrets, production access, destructive actions,
+blocked merges that require approval, or product decisions not covered by the
+standards.

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -1,0 +1,37 @@
+# Active Context
+
+## Current Goal
+
+Deliver the standards and repo-local skill foundation, then start review-ready
+page migration PRs for safe media surfaces.
+
+## Current Branch
+
+`codex/frontend-a11y-i18n-standards`
+
+## Constraints
+
+- Preserve unrelated dirty files:
+  - `contexts/EmojiContext.tsx`
+  - `__tests__/contexts/EmojiContext.test.tsx`
+  - `styles/seize-bootstrap.scss`
+- Use `6529` wrapper commands for project checks.
+- Use signed commits with the configured Git identity.
+- Merge only the standards PR when bot-happy and branch protection allows.
+- Do not merge page implementation PRs.
+
+## Defaults
+
+- WCAG target: WCAG 2.2 AA.
+- Source locale: `en-US`.
+- Initial supported locales: `en-US`, `en-GB`, `fr-FR`, `es-ES`, `de-DE`.
+- First implementation surface: The Memes list card, then The Memes detail
+  tabs/focus links.
+- Full locale-prefixed routing is deferred.
+
+## Next Actions
+
+1. Publish and merge standards PR if allowed.
+2. Create first implementation branch for The Memes list card.
+3. Bootstrap local services before UI verification.
+4. Iterate implementation PRs with bots and leave them review-ready.

--- a/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
+++ b/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
@@ -4,4 +4,4 @@ Record review-bot and CI decisions here for this workstream.
 
 | Date | PR | Bot or Check | Finding | Decision |
 | --- | --- | --- | --- | --- |
-| 2026-06-11 | Standards and skills | TBD | No feedback yet | Pending |
+| 2026-06-11 | #2603 | TBD | No feedback yet | Pending |

--- a/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
+++ b/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
@@ -1,0 +1,7 @@
+# Bot Decisions
+
+Record review-bot and CI decisions here for this workstream.
+
+| Date | PR | Bot or Check | Finding | Decision |
+| --- | --- | --- | --- | --- |
+| 2026-06-11 | Standards and skills | TBD | No feedback yet | Pending |

--- a/ops/workstreams/frontend-a11y-i18n/pr-links.md
+++ b/ops/workstreams/frontend-a11y-i18n/pr-links.md
@@ -1,0 +1,7 @@
+# PR Links
+
+| Purpose | Branch | PR | Status |
+| --- | --- | --- | --- |
+| Standards and skills | `codex/frontend-a11y-i18n-standards` | TBD | In progress |
+| The Memes list card | TBD | TBD | Planned, review-ready only |
+| The Memes detail tabs | TBD | TBD | Planned, review-ready only |

--- a/ops/workstreams/frontend-a11y-i18n/pr-links.md
+++ b/ops/workstreams/frontend-a11y-i18n/pr-links.md
@@ -2,6 +2,6 @@
 
 | Purpose | Branch | PR | Status |
 | --- | --- | --- | --- |
-| Standards and skills | `codex/frontend-a11y-i18n-standards` | TBD | In progress |
+| Standards and skills | `codex/frontend-a11y-i18n-standards` | #2603 | Open |
 | The Memes list card | TBD | TBD | Planned, review-ready only |
 | The Memes detail tabs | TBD | TBD | Planned, review-ready only |

--- a/ops/workstreams/frontend-a11y-i18n/route-page-status.md
+++ b/ops/workstreams/frontend-a11y-i18n/route-page-status.md
@@ -1,0 +1,8 @@
+# Route And Page Status
+
+| Surface | Accessibility Status | I18n Status | Notes |
+| --- | --- | --- | --- |
+| Standards and skills | Foundation in progress | Foundation in progress | Merge allowed after bot feedback |
+| `/the-memes` list cards | Planned | Planned | First safe implementation PR |
+| `/the-memes/{id}` tabs and focus links | Planned | Planned | Second safe implementation PR |
+| Meme Lab or Rememes browse cards | Planned | Planned | Only after first two PRs are bot-happy |

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -5,3 +5,4 @@
 - Created the workstream scaffold for progressive WCAG 2.2 AA and i18n work.
 - Confirmed existing unrelated dirty files are outside this workstream.
 - Started standards branch `codex/frontend-a11y-i18n-standards`.
+- Opened standards PR #2603 for bot and CI review.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1,0 +1,7 @@
+# Run Log
+
+## 2026-06-11
+
+- Created the workstream scaffold for progressive WCAG 2.2 AA and i18n work.
+- Confirmed existing unrelated dirty files are outside this workstream.
+- Started standards branch `codex/frontend-a11y-i18n-standards`.


### PR DESCRIPTION
## Issue
- The frontend needs a progressive path to WCAG 2.2 AA and i18n readiness without forcing a single large migration.

## Fix
- Add repo-level standards, repo-local skills, and durable workstream memory so future PRs have a concrete quality bar and repeatable agent workflow.

## Changes
- Added frontend standards for WCAG 2.2 AA and i18n/localization under `ops/standards`.
- Added repo-local `wcag-22-aa` and `i18n-localization` skills.
- Linked the standards from `AGENTS.md`, `CONTRIBUTING.md`, and the skills index.
- Added workstream state for tracking PRs, route/page status, and bot decisions.

## Validation
- `git diff --cached --check`
- Custom staged Markdown link validation
- Custom skill frontmatter validation confirming each new skill has only `name` and `description`
- Did not run `6529 run lint:changed` because this PR changes Markdown/YAML guidance only and no linted TS/JS source.

## Risk
- Level: Low
- Why: Operational docs and skills only; no runtime app behavior changes.
- Rollback: Revert the documentation/skill commit.

## Review Notes
- Please focus on whether the standards are clear enough for future WCAG and i18n migration PRs, and whether the repo-local skill trigger descriptions are appropriately scoped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added frontend accessibility standards (WCAG 2.2 AA) and internationalization/localization standards to guide feature development.
  * Created comprehensive skill documentation for accessibility and localization work with agent configurations.

* **Chores**
  * Updated contribution guidelines to enforce accessibility and localization standards for new frontend UI.
  * Established a workstream for progressive frontend accessibility and localization migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->