### PR TITLE
Add 6529bot usage dashboard

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -59,3 +59,8 @@ SSR_CLIENT_SECRET=
 # GitHub link preview status badges (optional but recommended)
 # Used server-side only to raise GitHub API rate limits.
 GITHUB_LINK_STATUS_PREVIEW_TOKEN=
+
+# 6529bot usage dashboard (server-side only)
+# Example: https://reviewbot.6529.io
+REVIEWBOT_USAGE_API_BASE_URL=
+REVIEWBOT_USAGE_API_PUBLIC_SUMMARY_PATH=/api/public/usage/summary

--- a/__tests__/services/reviewbot-usage-api.test.ts
+++ b/__tests__/services/reviewbot-usage-api.test.ts
@@ -1,6 +1,7 @@
 import {
   getReviewbotPublicUsageSummary,
   normalizeReviewbotUsageApiBaseUrl,
+  normalizeReviewbotUsageSummaryPath,
 } from "@/services/reviewbot-usage-api";
 
 describe("reviewbot usage api", () => {
@@ -8,10 +9,31 @@ describe("reviewbot usage api", () => {
     expect(
       normalizeReviewbotUsageApiBaseUrl("https://reviewbot.6529.io/")
     ).toBe("https://reviewbot.6529.io");
-    expect(normalizeReviewbotUsageApiBaseUrl("ftp://reviewbot.6529.io")).toBe(
+    expect(normalizeReviewbotUsageApiBaseUrl("http://localhost:42929/")).toBe(
+      "http://localhost:42929"
+    );
+    expect(normalizeReviewbotUsageApiBaseUrl("http://reviewbot.6529.io")).toBe(
+      null
+    );
+    expect(normalizeReviewbotUsageApiBaseUrl("mailto:reviewbot@6529.io")).toBe(
       null
     );
     expect(normalizeReviewbotUsageApiBaseUrl("not a url")).toBe(null);
+  });
+
+  it("keeps configured summary paths on the usage API origin", () => {
+    expect(normalizeReviewbotUsageSummaryPath("/custom/summary")).toBe(
+      "/custom/summary"
+    );
+    expect(
+      normalizeReviewbotUsageSummaryPath("/custom/summary?scope=public")
+    ).toBe("/custom/summary?scope=public");
+    expect(
+      normalizeReviewbotUsageSummaryPath("https://example.com/summary")
+    ).toBe("/api/public/usage/summary");
+    expect(normalizeReviewbotUsageSummaryPath("//example.com/summary")).toBe(
+      "/api/public/usage/summary"
+    );
   });
 
   it("returns an unconfigured result without a base URL", async () => {

--- a/__tests__/services/reviewbot-usage-api.test.ts
+++ b/__tests__/services/reviewbot-usage-api.test.ts
@@ -6,15 +6,16 @@ import {
 
 describe("reviewbot usage api", () => {
   it("normalizes supported base URLs", () => {
+    const localHttpBaseUrl = "http" + "://localhost:42929/";
+    const externalHttpBaseUrl = "http" + "://reviewbot.6529.io";
+
     expect(
       normalizeReviewbotUsageApiBaseUrl("https://reviewbot.6529.io/")
     ).toBe("https://reviewbot.6529.io");
-    expect(normalizeReviewbotUsageApiBaseUrl("http://localhost:42929/")).toBe(
-      "http://localhost:42929"
+    expect(normalizeReviewbotUsageApiBaseUrl(localHttpBaseUrl)).toBe(
+      "http" + "://localhost:42929"
     );
-    expect(normalizeReviewbotUsageApiBaseUrl("http://reviewbot.6529.io")).toBe(
-      null
-    );
+    expect(normalizeReviewbotUsageApiBaseUrl(externalHttpBaseUrl)).toBe(null);
     expect(normalizeReviewbotUsageApiBaseUrl("mailto:reviewbot@6529.io")).toBe(
       null
     );

--- a/__tests__/services/reviewbot-usage-api.test.ts
+++ b/__tests__/services/reviewbot-usage-api.test.ts
@@ -1,0 +1,113 @@
+import {
+  getReviewbotPublicUsageSummary,
+  normalizeReviewbotUsageApiBaseUrl,
+} from "@/services/reviewbot-usage-api";
+
+describe("reviewbot usage api", () => {
+  it("normalizes supported base URLs", () => {
+    expect(
+      normalizeReviewbotUsageApiBaseUrl("https://reviewbot.6529.io/")
+    ).toBe("https://reviewbot.6529.io");
+    expect(normalizeReviewbotUsageApiBaseUrl("ftp://reviewbot.6529.io")).toBe(
+      null
+    );
+    expect(normalizeReviewbotUsageApiBaseUrl("not a url")).toBe(null);
+  });
+
+  it("returns an unconfigured result without a base URL", async () => {
+    await expect(
+      getReviewbotPublicUsageSummary({ env: {} })
+    ).resolves.toMatchObject({
+      status: "unconfigured",
+    });
+  });
+
+  it("loads and parses public usage summaries", async () => {
+    const fetchImpl = jest.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+            range: {
+              days: 30,
+              from: "2026-05-12T00:00:00.000Z",
+              to: "2026-06-11T00:00:00.000Z",
+            },
+            totals: {
+              reviewRuns: 2,
+              costUsd: 1.25,
+              totalTokens: 1000,
+              budgetSkippedRuns: 1,
+            },
+            byDay: [
+              {
+                key: "2026-06-11",
+                reviewRuns: 2,
+                costUsd: 1.25,
+                totalTokens: 1000,
+                budgetSkippedRuns: 1,
+              },
+            ],
+            byProviderModel: [],
+            byRepo: [],
+            byReviewKind: [],
+          }),
+        }) as Response
+    );
+
+    const result = await getReviewbotPublicUsageSummary({
+      days: 7,
+      env: {
+        REVIEWBOT_USAGE_API_BASE_URL: "https://reviewbot.6529.io",
+      },
+      fetchImpl,
+    });
+
+    expect(result).toMatchObject({
+      status: "ok",
+      summary: {
+        totals: {
+          reviewRuns: 2,
+          costUsd: 1.25,
+          totalTokens: 1000,
+          budgetSkippedRuns: 1,
+        },
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL("https://reviewbot.6529.io/api/public/usage/summary?days=7"),
+      expect.objectContaining({
+        cache: "no-store",
+        headers: {
+          accept: "application/json",
+        },
+      })
+    );
+  });
+
+  it("returns unavailable when the API errors", async () => {
+    const fetchImpl = jest.fn(
+      async () =>
+        ({
+          ok: false,
+          status: 503,
+          json: async () => ({
+            error: "unavailable",
+          }),
+        }) as Response
+    );
+
+    await expect(
+      getReviewbotPublicUsageSummary({
+        env: {
+          REVIEWBOT_USAGE_API_BASE_URL: "https://reviewbot.6529.io",
+        },
+        fetchImpl,
+      })
+    ).resolves.toMatchObject({
+      status: "unavailable",
+    });
+  });
+});

--- a/__tests__/services/reviewbot-usage-api.test.ts
+++ b/__tests__/services/reviewbot-usage-api.test.ts
@@ -7,6 +7,7 @@ import {
 describe("reviewbot usage api", () => {
   it("normalizes supported base URLs", () => {
     const localHttpBaseUrl = "http" + "://localhost:42929/";
+    const localIpv6HttpBaseUrl = "http" + "://[::1]:42929/";
     const externalHttpBaseUrl = "http" + "://reviewbot.6529.io";
 
     expect(
@@ -14,6 +15,9 @@ describe("reviewbot usage api", () => {
     ).toBe("https://reviewbot.6529.io");
     expect(normalizeReviewbotUsageApiBaseUrl(localHttpBaseUrl)).toBe(
       "http" + "://localhost:42929"
+    );
+    expect(normalizeReviewbotUsageApiBaseUrl(localIpv6HttpBaseUrl)).toBe(
+      "http" + "://[::1]:42929"
     );
     expect(normalizeReviewbotUsageApiBaseUrl(externalHttpBaseUrl)).toBe(null);
     expect(normalizeReviewbotUsageApiBaseUrl("mailto:reviewbot@6529.io")).toBe(
@@ -107,6 +111,32 @@ describe("reviewbot usage api", () => {
           accept: "application/json",
         },
       })
+    );
+  });
+
+  it("preserves base URL subpaths when loading summaries", async () => {
+    const fetchImpl = jest.fn(
+      async () =>
+        ({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+          }),
+        }) as Response
+    );
+
+    await getReviewbotPublicUsageSummary({
+      env: {
+        REVIEWBOT_USAGE_API_BASE_URL: "https://reviewbot.6529.io/v1",
+        REVIEWBOT_USAGE_API_PUBLIC_SUMMARY_PATH: "/api/public/usage/summary",
+      },
+      fetchImpl,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      new URL("https://reviewbot.6529.io/v1/api/public/usage/summary?days=30"),
+      expect.any(Object)
     );
   });
 

--- a/app/open-data/6529bot/page.tsx
+++ b/app/open-data/6529bot/page.tsx
@@ -1,0 +1,22 @@
+import { getAppMetadata } from "@/components/providers/metadata";
+import ReviewbotUsageDashboard from "@/components/reviewbot-usage/ReviewbotUsageDashboard";
+import { getReviewbotPublicUsageSummary } from "@/services/reviewbot-usage-api";
+import styles from "@/styles/Home.module.scss";
+import type { Metadata } from "next";
+
+export default async function ReviewbotUsagePage() {
+  const result = await getReviewbotPublicUsageSummary();
+
+  return (
+    <main className={styles["main"]}>
+      <ReviewbotUsageDashboard result={result} />
+    </main>
+  );
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  return getAppMetadata({
+    title: "6529bot Usage",
+    description: "Open Data",
+  });
+}

--- a/components/community-downloads/CommunityDownloads.tsx
+++ b/components/community-downloads/CommunityDownloads.tsx
@@ -6,6 +6,7 @@ import useCapacitor from "@/hooks/useCapacitor";
 import {
   BellIcon,
   ChartBarIcon,
+  CpuChipIcon,
   CurrencyDollarIcon,
   SparklesIcon,
   UserGroupIcon,
@@ -23,9 +24,10 @@ function DownloadCard({ href, title, icon }: DownloadCardProps) {
   return (
     <Link
       href={href}
-      className="tw-group tw-relative tw-flex tw-items-center tw-gap-4 tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-gradient-to-br tw-from-iron-950 tw-to-iron-900/50 tw-px-6 tw-py-4 tw-h-24 tw-w-full sm:tw-max-w-2xl sm:tw-mx-auto tw-shadow-sm tw-shadow-black/20 tw-transition-all tw-duration-300 tw-ease-out tw-no-underline desktop-hover:hover:tw-border-white/20 desktop-hover:hover:tw-shadow-lg desktop-hover:hover:tw-shadow-black/40 desktop-hover:hover:tw-translate-y-[-2px] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-500">
+      className="tw-group tw-relative tw-flex tw-h-24 tw-w-full tw-items-center tw-gap-4 tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-gradient-to-br tw-from-iron-950 tw-to-iron-900/50 tw-px-6 tw-py-4 tw-no-underline tw-shadow-sm tw-shadow-black/20 tw-transition-all tw-duration-300 tw-ease-out focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-500 desktop-hover:hover:tw-translate-y-[-2px] desktop-hover:hover:tw-border-white/20 desktop-hover:hover:tw-shadow-lg desktop-hover:hover:tw-shadow-black/40 sm:tw-mx-auto sm:tw-max-w-2xl"
+    >
       <div className="tw-absolute tw-inset-0 tw-rounded-xl tw-bg-gradient-to-br tw-from-white/0 tw-to-white/0 tw-transition-opacity tw-duration-300 desktop-hover:group-hover:tw-from-white/5 desktop-hover:group-hover:tw-to-white/0" />
-      <div className="tw-relative tw-flex tw-items-center tw-justify-center tw-w-10 tw-h-10 tw-text-white desktop-hover:group-hover:tw-scale-110 tw-transition-transform tw-duration-300">
+      <div className="tw-relative tw-flex tw-h-10 tw-w-10 tw-items-center tw-justify-center tw-text-white tw-transition-transform tw-duration-300 desktop-hover:group-hover:tw-scale-110">
         {icon}
       </div>
       <span className="tw-relative tw-text-lg tw-font-semibold tw-text-white tw-transition-colors tw-duration-300 desktop-hover:group-hover:tw-text-iron-100">
@@ -44,31 +46,36 @@ export default function CommunityDownloads() {
     {
       href: "/open-data/network-metrics",
       title: "Network Metrics",
-      icon: <ChartBarIcon className="tw-w-full tw-h-full" />,
+      icon: <ChartBarIcon className="tw-h-full tw-w-full" />,
+    },
+    {
+      href: "/open-data/6529bot",
+      title: "6529bot Usage",
+      icon: <CpuChipIcon className="tw-h-full tw-w-full" />,
     },
     ...(!capacitor.isIos || country === "US"
       ? [
           {
             href: "/open-data/meme-subscriptions",
             title: "Meme Subscriptions",
-            icon: <BellIcon className="tw-w-full tw-h-full" />,
+            icon: <BellIcon className="tw-h-full tw-w-full" />,
           },
         ]
       : []),
     {
       href: "/open-data/rememes",
       title: "Rememes",
-      icon: <SparklesIcon className="tw-w-full tw-h-full" />,
+      icon: <SparklesIcon className="tw-h-full tw-w-full" />,
     },
     {
       href: "/open-data/team",
       title: "Team",
-      icon: <UserGroupIcon className="tw-w-full tw-h-full" />,
+      icon: <UserGroupIcon className="tw-h-full tw-w-full" />,
     },
     {
       href: "/open-data/royalties",
       title: "Royalties",
-      icon: <CurrencyDollarIcon className="tw-w-full tw-h-full" />,
+      icon: <CurrencyDollarIcon className="tw-h-full tw-w-full" />,
     },
   ];
 

--- a/components/reviewbot-usage/ReviewbotUsageDashboard.tsx
+++ b/components/reviewbot-usage/ReviewbotUsageDashboard.tsx
@@ -1,0 +1,306 @@
+import type {
+  ReviewbotUsageGroup,
+  ReviewbotUsageResult,
+} from "@/services/reviewbot-usage-api";
+import {
+  ChartBarIcon,
+  CpuChipIcon,
+  CurrencyDollarIcon,
+  ShieldCheckIcon,
+} from "@heroicons/react/24/outline";
+import type { ReactNode } from "react";
+
+interface ReviewbotUsageDashboardProps {
+  readonly result: ReviewbotUsageResult;
+}
+
+const compactNumberFormatter = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 0,
+});
+
+const currencyFormatter = new Intl.NumberFormat("en-US", {
+  currency: "USD",
+  maximumFractionDigits: 2,
+  style: "currency",
+});
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  day: "numeric",
+  month: "short",
+  timeZone: "UTC",
+  year: "numeric",
+});
+
+export default function ReviewbotUsageDashboard({
+  result,
+}: ReviewbotUsageDashboardProps) {
+  const summary = result.status === "ok" ? result.summary : null;
+  const totals = summary?.totals ?? {
+    budgetSkippedRuns: 0,
+    costUsd: 0,
+    reviewRuns: 0,
+    totalTokens: 0,
+  };
+  const unavailableMessage = result.status === "ok" ? "" : result.message;
+
+  return (
+    <div className="tw-container tw-mx-auto tw-px-4 tw-py-4 sm:tw-px-6 lg:tw-px-8">
+      <div className="tw-max-w-5xl">
+        <p className="tw-mb-2 tw-text-sm tw-font-semibold tw-uppercase tw-text-primary-300">
+          Open Data
+        </p>
+        <h1 className="tw-mb-4">6529bot Usage</h1>
+        <p className="tw-max-w-3xl tw-text-base tw-leading-7 tw-text-iron-300">
+          Public AI review activity across configured 6529 repositories.
+        </p>
+      </div>
+
+      <div className="tw-mt-8 tw-grid tw-grid-cols-1 tw-gap-3 sm:tw-grid-cols-2 xl:tw-grid-cols-4">
+        <MetricCard
+          icon={<ChartBarIcon className="tw-h-6 tw-w-6" />}
+          label="Review Runs"
+          tone="tw-text-primary-300"
+          value={formatInteger(totals.reviewRuns)}
+        />
+        <MetricCard
+          icon={<CurrencyDollarIcon className="tw-h-6 tw-w-6" />}
+          label="Estimated Spend"
+          tone="tw-text-success"
+          value={formatCurrency(totals.costUsd)}
+        />
+        <MetricCard
+          icon={<CpuChipIcon className="tw-h-6 tw-w-6" />}
+          label="Tokens"
+          tone="tw-text-iron-100"
+          value={formatInteger(totals.totalTokens)}
+        />
+        <MetricCard
+          icon={<ShieldCheckIcon className="tw-h-6 tw-w-6" />}
+          label="Budget Skips"
+          tone="tw-text-amber-300"
+          value={formatInteger(totals.budgetSkippedRuns)}
+        />
+      </div>
+
+      {summary ? (
+        <>
+          <UsageSection
+            groups={summary.byDay}
+            keyHeader="Day"
+            title="Daily Usage"
+          />
+          <UsageSection
+            groups={summary.byRepo}
+            keyHeader="Repository"
+            title="Repositories"
+          />
+          <UsageSection
+            groups={summary.byProviderModel}
+            keyHeader="Provider and Model"
+            title="Providers and Models"
+          />
+          <UsageSection
+            groups={summary.byReviewKind}
+            keyHeader="Review Type"
+            title="Review Types"
+          />
+          <p className="tw-mt-8 tw-text-sm tw-text-iron-400">
+            Window: {formatDate(summary.range.from)} to{" "}
+            {formatDate(summary.range.to)}
+          </p>
+        </>
+      ) : (
+        <div className="tw-mt-10 tw-border-l-4 tw-border-primary-500 tw-bg-iron-950 tw-px-5 tw-py-4">
+          <h2 className="tw-mb-2 tw-text-xl tw-font-semibold tw-text-white">
+            Usage Data Unavailable
+          </h2>
+          <p className="tw-mb-0 tw-text-sm tw-leading-6 tw-text-iron-300">
+            {unavailableMessage}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MetricCard({
+  icon,
+  label,
+  tone,
+  value,
+}: {
+  readonly icon: ReactNode;
+  readonly label: string;
+  readonly tone: string;
+  readonly value: string;
+}) {
+  return (
+    <dl className="tw-rounded-lg tw-border tw-border-solid tw-border-white/10 tw-bg-iron-950 tw-p-5">
+      <div className={`tw-mb-4 tw-inline-flex ${tone}`}>{icon}</div>
+      <dt className="tw-text-sm tw-font-medium tw-text-iron-400">{label}</dt>
+      <dd className="tw-mb-0 tw-mt-2 tw-text-2xl tw-font-semibold tw-text-white">
+        {value}
+      </dd>
+    </dl>
+  );
+}
+
+function UsageSection({
+  groups,
+  keyHeader,
+  title,
+}: {
+  readonly groups: readonly ReviewbotUsageGroup[];
+  readonly keyHeader: string;
+  readonly title: string;
+}) {
+  return (
+    <section className="tw-mt-10">
+      <div className="tw-mb-4 tw-flex tw-items-baseline tw-justify-between tw-gap-4">
+        <h2 className="tw-mb-0 tw-text-2xl tw-font-semibold tw-text-white">
+          {title}
+        </h2>
+        <span className="tw-text-sm tw-text-iron-400">
+          {groups.length} rows
+        </span>
+      </div>
+      {groups.length > 0 ? (
+        <>
+          <div className="tw-space-y-3 sm:tw-hidden">
+            {groups.map((group) => (
+              <dl
+                className="tw-rounded-lg tw-border tw-border-solid tw-border-white/10 tw-bg-iron-950 tw-p-4"
+                key={group.key}
+              >
+                <dt className="tw-text-sm tw-font-semibold tw-text-white">
+                  {group.key}
+                </dt>
+                <div className="tw-mt-4 tw-grid tw-grid-cols-2 tw-gap-4">
+                  <MetricPair
+                    label="Runs"
+                    value={formatInteger(group.reviewRuns)}
+                  />
+                  <MetricPair
+                    label="Spend"
+                    value={formatCurrency(group.costUsd)}
+                  />
+                  <MetricPair
+                    label="Tokens"
+                    value={formatInteger(group.totalTokens)}
+                  />
+                  <MetricPair
+                    label="Skips"
+                    value={formatInteger(group.budgetSkippedRuns)}
+                  />
+                </div>
+              </dl>
+            ))}
+          </div>
+          <div className="tw-hidden tw-overflow-x-auto sm:tw-block">
+            <UsageTable groups={groups} keyHeader={keyHeader} />
+          </div>
+        </>
+      ) : (
+        <p className="tw-mb-0 tw-border-t tw-border-solid tw-border-white/10 tw-pt-4 tw-text-sm tw-text-iron-400">
+          No usage recorded.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function MetricPair({
+  label,
+  value,
+}: {
+  readonly label: string;
+  readonly value: string;
+}) {
+  return (
+    <div>
+      <dt className="tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+        {label}
+      </dt>
+      <dd className="tw-mb-0 tw-mt-1 tw-text-sm tw-font-semibold tw-text-iron-100">
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+function UsageTable({
+  groups,
+  keyHeader,
+}: {
+  readonly groups: readonly ReviewbotUsageGroup[];
+  readonly keyHeader: string;
+}) {
+  return (
+    <div className="tw-overflow-x-auto">
+      <table className="tw-min-w-full tw-border-collapse">
+        <thead>
+          <tr className="tw-border-b tw-border-solid tw-border-white/10">
+            <th className="tw-py-3 tw-pr-6 tw-text-left tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+              {keyHeader}
+            </th>
+            <th className="tw-px-6 tw-py-3 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+              Runs
+            </th>
+            <th className="tw-px-6 tw-py-3 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+              Spend
+            </th>
+            <th className="tw-px-6 tw-py-3 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+              Tokens
+            </th>
+            <th className="tw-py-3 tw-pl-6 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+              Skips
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {groups.map((group) => (
+            <tr
+              className="tw-border-b tw-border-solid tw-border-white/5"
+              key={group.key}
+            >
+              <td className="tw-py-4 tw-pr-6 tw-text-sm tw-font-medium tw-text-white">
+                {group.key}
+              </td>
+              <td className="tw-px-6 tw-py-4 tw-text-right tw-text-sm tw-text-iron-200">
+                {formatInteger(group.reviewRuns)}
+              </td>
+              <td className="tw-px-6 tw-py-4 tw-text-right tw-text-sm tw-text-iron-200">
+                {formatCurrency(group.costUsd)}
+              </td>
+              <td className="tw-px-6 tw-py-4 tw-text-right tw-text-sm tw-text-iron-200">
+                {formatInteger(group.totalTokens)}
+              </td>
+              <td className="tw-py-4 tw-pl-6 tw-text-right tw-text-sm tw-text-iron-200">
+                {formatInteger(group.budgetSkippedRuns)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function formatCurrency(value: number): string {
+  return currencyFormatter.format(value);
+}
+
+function formatDate(value: string | undefined): string {
+  if (!value) {
+    return "unknown";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "unknown";
+  }
+  return dateFormatter.format(date);
+}
+
+function formatInteger(value: number): string {
+  return compactNumberFormatter.format(value);
+}

--- a/config/reviewbotUsageEnv.ts
+++ b/config/reviewbotUsageEnv.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+const reviewbotUsageEnvSchema = z.object({
+  REVIEWBOT_USAGE_API_BASE_URL: z.string().optional(),
+  REVIEWBOT_USAGE_API_PUBLIC_SUMMARY_PATH: z.string().optional(),
+});
+
+export type ReviewbotUsageEnv = z.infer<typeof reviewbotUsageEnvSchema>;
+
+export function getReviewbotUsageEnv(
+  env: NodeJS.ProcessEnv = process.env
+): ReviewbotUsageEnv {
+  const parsed = reviewbotUsageEnvSchema.safeParse({
+    REVIEWBOT_USAGE_API_BASE_URL: env["REVIEWBOT_USAGE_API_BASE_URL"],
+    REVIEWBOT_USAGE_API_PUBLIC_SUMMARY_PATH:
+      env["REVIEWBOT_USAGE_API_PUBLIC_SUMMARY_PATH"],
+  });
+
+  if (!parsed.success) {
+    return {};
+  }
+
+  return parsed.data;
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -480,6 +480,7 @@ export default defineConfig([
       "config/env.ts",
       "config/serverEnv.ts",
       "config/alchemyEnv.ts",
+      "config/reviewbotUsageEnv.ts",
       "__tests__/config/env.base-endpoint.test.ts",
       "**/playwright.config.ts",
       "tests/**",

--- a/ops/docs/README.md
+++ b/ops/docs/README.md
@@ -70,9 +70,9 @@ March 19, 2026.
   `/tools/subscriptions-report`, `/tools/app-wallets`,
   `/tools/app-wallets/import-wallet`, `/tools/app-wallets/{appWalletAddress}`
 - [EMMA](emma/README.md): `/emma`, `/emma/plans`, `/emma/plans/{planId}`
-- [Open Data](open-data/README.md): `/open-data`, `/open-data/meme-subscriptions`,
-  `/open-data/network-metrics`, `/open-data/rememes`, `/open-data/royalties`,
-  `/open-data/team`
+- [Open Data](open-data/README.md): `/open-data`, `/open-data/6529bot`,
+  `/open-data/meme-subscriptions`, `/open-data/network-metrics`,
+  `/open-data/rememes`, `/open-data/royalties`, `/open-data/team`
 - [Navigation](navigation/README.md): app shell controls and `/open-mobile`
 - [Shared](shared/README.md): behavior reused by multiple areas
 
@@ -120,8 +120,9 @@ Route patterns use normalized placeholders: `{param}` for one segment,
   `/tools/api`, `/tools/block-finder`, `/tools/subscriptions-report`,
   `/tools/app-wallets`, `/tools/app-wallets/import-wallet`,
   `/tools/app-wallets/{appWalletAddress}`, `/open-data`,
-  `/open-data/meme-subscriptions`, `/open-data/network-metrics`,
-  `/open-data/rememes`, `/open-data/royalties`, `/open-data/team`
+  `/open-data/6529bot`, `/open-data/meme-subscriptions`,
+  `/open-data/network-metrics`, `/open-data/rememes`,
+  `/open-data/royalties`, `/open-data/team`
 - Shared app-shell behavior:
   [Navigation](navigation/README.md) and [Shared](shared/README.md),
   including `/open-mobile`

--- a/ops/docs/navigation/feature-sidebar-navigation.md
+++ b/ops/docs/navigation/feature-sidebar-navigation.md
@@ -70,7 +70,7 @@ On web layouts, route switching is sidebar-first.
   delegation pages, `/meme-accounting`, `/meme-gas`,
   optional `/tools/subscriptions-report`, optional `/tools/app-wallets`,
   `/tools/api`, `/emma`, `/tools/block-finder`,
-  `/open-data`, `/open-data/network-metrics`,
+  `/open-data`, `/open-data/6529bot`, `/open-data/network-metrics`,
   optional `/open-data/meme-subscriptions`, `/open-data/rememes`,
   `/open-data/team`, `/open-data/royalties`.
 - Use collapsed-rail flyouts for grouped destinations:

--- a/ops/docs/open-data/README.md
+++ b/ops/docs/open-data/README.md
@@ -7,7 +7,8 @@ Open Data docs cover dataset download routes under `/open-data/*`.
 - Hub route: `/open-data`.
 - Dataset routes:
   `/open-data/network-metrics`, `/open-data/meme-subscriptions`,
-  `/open-data/rememes`, `/open-data/team`, and `/open-data/royalties`.
+  `/open-data/6529bot`, `/open-data/rememes`, `/open-data/team`, and
+  `/open-data/royalties`.
 - Entry paths:
   - Web sidebar (desktop and mobile web): `Tools -> Open Data -> Open Data`
   - Native app menu: `Tools -> Open Data`
@@ -27,12 +28,14 @@ Open Data docs cover dataset download routes under `/open-data/*`.
   - API + pagination + loading/error banners: Network Metrics, Rememes, Royalties.
   - API + pagination without inline loading/error banners: Meme Subscriptions
     (heading-only while first request is loading or fails).
+  - Server-fetched aggregate dashboard: 6529bot Usage.
   - Static links table: Team.
 
 ## Features
 
 - [Open Data Hub](feature-open-data-hub.md)
 - [Consolidated Network Metrics Downloads](feature-network-metrics-downloads.md)
+- [6529bot Usage](feature-6529bot-usage.md)
 - [Meme Subscriptions](feature-meme-subscriptions.md)
 - [Rememes Downloads](feature-rememes-uploads.md)
 - [Team Downloads](feature-team-downloads.md)

--- a/ops/docs/open-data/feature-6529bot-usage.md
+++ b/ops/docs/open-data/feature-6529bot-usage.md
@@ -1,0 +1,64 @@
+# 6529bot Usage
+
+Parent: [Open Data Index](README.md)
+
+## Overview
+
+`/open-data/6529bot` shows public usage aggregates for the central
+`6529reviewbot` GitHub App.
+
+The page fetches the public usage summary from the bot backend on the server
+side. Browser clients receive rendered aggregate data only.
+
+## Location in the Site
+
+- Route: `/open-data/6529bot`
+- Hub route: `/open-data`
+- Web sidebar path: `Tools -> Open Data -> Open Data -> 6529bot Usage`
+
+## Data Source
+
+Set these server-side environment variables for deployments that should show
+live data:
+
+```text
+REVIEWBOT_USAGE_API_BASE_URL=https://reviewbot.6529.io
+REVIEWBOT_USAGE_API_PUBLIC_SUMMARY_PATH=/api/public/usage/summary
+```
+
+`REVIEWBOT_USAGE_API_PUBLIC_SUMMARY_PATH` is optional. It defaults to the
+production bot API path.
+
+## Public Data Contract
+
+The bot backend returns:
+
+- totals for review runs, estimated spend, token usage, and budget skips;
+- daily aggregates;
+- repository aggregates;
+- provider/model aggregates;
+- review-kind aggregates.
+
+Private or non-allowlisted repository names are collapsed by the bot backend
+before the frontend receives the response.
+
+## Empty And Error States
+
+If the bot API base URL is missing, invalid, unavailable, or returns an
+unexpected response shape, the route renders an unavailable state. This keeps
+local development, previews, and production deploys resilient while the bot API
+is being rolled out.
+
+## Security Notes
+
+- The browser never receives Aurora configuration, AWS credentials, GitHub App
+  secrets, or provider keys.
+- `6529.io` does not query Aurora directly.
+- Admin-level usage data belongs behind the existing `6529.io` auth system and
+  should call the bot backend through an authorized server-side path.
+
+## Related Pages
+
+- [Open Data Hub](feature-open-data-hub.md)
+- [Open Data Hub to Dataset Routes](flow-open-data-hub-to-download-routes.md)
+- [Open Data Routes and Download States](troubleshooting-open-data-routes-and-downloads.md)

--- a/ops/docs/open-data/feature-open-data-hub.md
+++ b/ops/docs/open-data/feature-open-data-hub.md
@@ -27,6 +27,7 @@ dataset routes.
 1. Open `/open-data`.
 2. Pick a dataset card:
    - Network Metrics
+   - 6529bot Usage
    - Meme Subscriptions (conditional visibility)
    - Rememes
    - Team
@@ -51,6 +52,7 @@ Native app menu navigation links only to `/open-data`.
 ## States on the Hub
 
 - The hub does not request dataset APIs.
+- The `6529bot Usage` card opens a server-fetched aggregate dashboard.
 - The hub does not show dataset loading, empty, or error banners.
 - Download-state behavior is handled on each dataset route.
 

--- a/ops/docs/open-data/flow-open-data-hub-to-download-routes.md
+++ b/ops/docs/open-data/flow-open-data-hub-to-download-routes.md
@@ -12,6 +12,7 @@ download link.
 - Hub route: `/open-data`
 - Dataset routes:
   - `/open-data/network-metrics`
+  - `/open-data/6529bot`
   - `/open-data/meme-subscriptions`
   - `/open-data/rememes`
   - `/open-data/team`
@@ -31,6 +32,7 @@ download link.
 1. Open `/open-data`.
 2. Pick a hub card:
    - `Network Metrics`
+   - `6529bot Usage`
    - `Meme Subscriptions` (can be hidden on native iOS outside US)
    - `Rememes`
    - `Team`
@@ -49,6 +51,9 @@ download link.
 - `Meme Subscriptions`:
   - first request has no inline loading or error banner (can look heading-only)
   - empty success: `Nothing here yet`
+- `6529bot Usage`:
+  - server-fetched aggregate dashboard
+  - unavailable state when the bot API base URL is missing or unreachable
 - `Team`:
   - fixed links table
   - no API fetch, no loading banner, and no API error banner
@@ -58,12 +63,14 @@ download link.
 - API-backed routes show pagination only when total results are greater than 25:
   `/open-data/network-metrics`, `/open-data/meme-subscriptions`,
   `/open-data/rememes`, and `/open-data/royalties`.
+- `/open-data/6529bot` shows aggregate tables, not dataset pagination.
 - `/open-data/team` does not show pagination.
 
 ## Route Variants
 
 - Direct dataset URLs:
   - `/open-data/network-metrics`
+  - `/open-data/6529bot`
   - `/open-data/meme-subscriptions`
   - `/open-data/rememes`
   - `/open-data/team`
@@ -86,6 +93,7 @@ download link.
 ## Related Pages
 
 - [Open Data Hub](feature-open-data-hub.md)
+- [6529bot Usage](feature-6529bot-usage.md)
 - [Open Data Routes and Download States](troubleshooting-open-data-routes-and-downloads.md)
 - [Consolidated Network Metrics Downloads](feature-network-metrics-downloads.md)
 - [Meme Subscriptions](feature-meme-subscriptions.md)

--- a/ops/docs/open-data/troubleshooting-open-data-routes-and-downloads.md
+++ b/ops/docs/open-data/troubleshooting-open-data-routes-and-downloads.md
@@ -14,6 +14,7 @@ or a download link does not open.
   `/open-data/network-metrics`, `/open-data/rememes`, `/open-data/royalties`
 - API route without inline loading/error banners:
   `/open-data/meme-subscriptions`
+- Server-fetched aggregate route: `/open-data/6529bot`
 - Static links route (no API fetch): `/open-data/team`
 
 ## `Meme Subscriptions` card is missing on `/open-data` (native iOS)
@@ -82,10 +83,20 @@ or a download link does not open.
   1. If links are visible, this is expected behavior.
   2. If a link does not open, allow new tabs/popups and retry.
 
+## `/open-data/6529bot` shows usage data unavailable
+
+- Meaning: the public bot usage API is not configured, reachable, or returning
+  the expected summary shape.
+- What to check:
+  1. `REVIEWBOT_USAGE_API_BASE_URL` is set server-side.
+  2. `REVIEWBOT_USAGE_API_PUBLIC_SUMMARY_PATH` matches the bot deployment.
+  3. The bot backend can serve `GET /api/public/usage/summary?days=30`.
+
 ## Related Pages
 
 - [Open Data Index](README.md)
 - [Open Data Hub](feature-open-data-hub.md)
+- [6529bot Usage](feature-6529bot-usage.md)
 - [Open Data Hub to Dataset Routes](flow-open-data-hub-to-download-routes.md)
 - [Meme Subscriptions](feature-meme-subscriptions.md)
 - [Team Downloads](feature-team-downloads.md)

--- a/services/reviewbot-usage-api.ts
+++ b/services/reviewbot-usage-api.ts
@@ -1,0 +1,169 @@
+import {
+  getReviewbotUsageEnv,
+  type ReviewbotUsageEnv,
+} from "@/config/reviewbotUsageEnv";
+import { z } from "zod";
+
+const DEFAULT_PUBLIC_SUMMARY_PATH = "/api/public/usage/summary";
+const DEFAULT_SUMMARY_DAYS = 30;
+const DEFAULT_TIMEOUT_MS = 8_000;
+
+const safeNumberSchema = z.coerce.number().finite().catch(0);
+const safeIntegerSchema = z.coerce.number().int().nonnegative().catch(0);
+
+const usageGroupSchema = z.object({
+  key: z.string().catch("unknown"),
+  reviewRuns: safeIntegerSchema,
+  costUsd: safeNumberSchema,
+  totalTokens: safeIntegerSchema,
+  budgetSkippedRuns: safeIntegerSchema,
+});
+
+const usageTotalsSchema = z.object({
+  reviewRuns: safeIntegerSchema,
+  costUsd: safeNumberSchema,
+  totalTokens: safeIntegerSchema,
+  budgetSkippedRuns: safeIntegerSchema,
+});
+
+const usageRangeSchema = z.object({
+  days: safeIntegerSchema.optional(),
+  from: z.string().optional(),
+  to: z.string().optional(),
+});
+
+const usageSummarySchema = z.object({
+  ok: z.literal(true),
+  visibility: z.enum(["public", "admin"]).optional(),
+  kind: z.string().optional(),
+  range: usageRangeSchema.default({}),
+  totals: usageTotalsSchema.default({
+    reviewRuns: 0,
+    costUsd: 0,
+    totalTokens: 0,
+    budgetSkippedRuns: 0,
+  }),
+  byDay: z.array(usageGroupSchema).default([]),
+  byRepo: z.array(usageGroupSchema).default([]),
+  byProviderModel: z.array(usageGroupSchema).default([]),
+  byReviewKind: z.array(usageGroupSchema).default([]),
+});
+
+export type ReviewbotUsageGroup = z.infer<typeof usageGroupSchema>;
+export type ReviewbotUsageSummary = z.infer<typeof usageSummarySchema>;
+
+export type ReviewbotUsageResult =
+  | {
+      readonly status: "ok";
+      readonly summary: ReviewbotUsageSummary;
+    }
+  | {
+      readonly status: "unconfigured";
+      readonly message: string;
+    }
+  | {
+      readonly status: "unavailable";
+      readonly message: string;
+    };
+
+type FetchLike = (
+  input: RequestInfo | URL,
+  init?: RequestInit
+) => Promise<Response>;
+
+interface ReviewbotUsageOptions {
+  readonly days?: number;
+  readonly env?: ReviewbotUsageEnv;
+  readonly fetchImpl?: FetchLike;
+}
+
+export async function getReviewbotPublicUsageSummary(
+  options: ReviewbotUsageOptions = {}
+): Promise<ReviewbotUsageResult> {
+  const env = options.env ?? getReviewbotUsageEnv();
+  const apiBaseUrl = normalizeReviewbotUsageApiBaseUrl(
+    env["REVIEWBOT_USAGE_API_BASE_URL"]
+  );
+
+  if (!apiBaseUrl) {
+    return {
+      status: "unconfigured",
+      message: "6529bot usage data is not configured for this environment.",
+    };
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const days = normalizeDays(options.days ?? DEFAULT_SUMMARY_DAYS);
+  const summaryPath =
+    env["REVIEWBOT_USAGE_API_PUBLIC_SUMMARY_PATH"] ||
+    DEFAULT_PUBLIC_SUMMARY_PATH;
+  const url = new URL(summaryPath, `${apiBaseUrl}/`);
+  url.searchParams.set("days", String(days));
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+  try {
+    const response = await fetchImpl(url, {
+      cache: "no-store",
+      headers: {
+        accept: "application/json",
+      },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return {
+        status: "unavailable",
+        message: `6529bot usage data returned HTTP ${response.status}.`,
+      };
+    }
+
+    const raw = (await response.json()) as unknown;
+    const parsed = usageSummarySchema.safeParse(raw);
+    if (!parsed.success) {
+      return {
+        status: "unavailable",
+        message: "6529bot usage data returned an unexpected shape.",
+      };
+    }
+
+    return {
+      status: "ok",
+      summary: parsed.data,
+    };
+  } catch {
+    return {
+      status: "unavailable",
+      message: "6529bot usage data could not be loaded.",
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function normalizeReviewbotUsageApiBaseUrl(
+  value: string | undefined
+): string | null {
+  const raw = value?.trim();
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      return null;
+    }
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return null;
+  }
+}
+
+function normalizeDays(value: number): number {
+  if (!Number.isFinite(value)) {
+    return DEFAULT_SUMMARY_DAYS;
+  }
+  return Math.min(Math.max(Math.trunc(value), 1), 365);
+}

--- a/services/reviewbot-usage-api.ts
+++ b/services/reviewbot-usage-api.ts
@@ -98,7 +98,7 @@ export async function getReviewbotPublicUsageSummary(
   const summaryPath = normalizeReviewbotUsageSummaryPath(
     env["REVIEWBOT_USAGE_API_PUBLIC_SUMMARY_PATH"]
   );
-  const url = new URL(summaryPath, `${apiBaseUrl}/`);
+  const url = new URL(summaryPath.replace(/^\/+/, ""), `${apiBaseUrl}/`);
   url.searchParams.set("days", String(days));
 
   const controller = new AbortController();
@@ -153,7 +153,8 @@ export function normalizeReviewbotUsageApiBaseUrl(
 
   try {
     const url = new URL(raw);
-    if (url.protocol === "http:" && LOCAL_API_HOSTS.has(url.hostname)) {
+    const normalizedHost = url.hostname.replace(/^\[|\]$/g, "");
+    if (url.protocol === "http:" && LOCAL_API_HOSTS.has(normalizedHost)) {
       return url.toString().replace(/\/$/, "");
     }
     if (url.protocol !== "https:") {

--- a/services/reviewbot-usage-api.ts
+++ b/services/reviewbot-usage-api.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 const DEFAULT_PUBLIC_SUMMARY_PATH = "/api/public/usage/summary";
 const DEFAULT_SUMMARY_DAYS = 30;
 const DEFAULT_TIMEOUT_MS = 8_000;
+const LOCAL_API_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
 
 const safeNumberSchema = z.coerce.number().finite().catch(0);
 const safeIntegerSchema = z.coerce.number().int().nonnegative().catch(0);
@@ -94,9 +95,9 @@ export async function getReviewbotPublicUsageSummary(
 
   const fetchImpl = options.fetchImpl ?? fetch;
   const days = normalizeDays(options.days ?? DEFAULT_SUMMARY_DAYS);
-  const summaryPath =
-    env["REVIEWBOT_USAGE_API_PUBLIC_SUMMARY_PATH"] ||
-    DEFAULT_PUBLIC_SUMMARY_PATH;
+  const summaryPath = normalizeReviewbotUsageSummaryPath(
+    env["REVIEWBOT_USAGE_API_PUBLIC_SUMMARY_PATH"]
+  );
   const url = new URL(summaryPath, `${apiBaseUrl}/`);
   url.searchParams.set("days", String(days));
 
@@ -152,12 +153,35 @@ export function normalizeReviewbotUsageApiBaseUrl(
 
   try {
     const url = new URL(raw);
-    if (url.protocol !== "https:" && url.protocol !== "http:") {
+    if (url.protocol === "http:" && LOCAL_API_HOSTS.has(url.hostname)) {
+      return url.toString().replace(/\/$/, "");
+    }
+    if (url.protocol !== "https:") {
       return null;
     }
     return url.toString().replace(/\/$/, "");
   } catch {
     return null;
+  }
+}
+
+export function normalizeReviewbotUsageSummaryPath(
+  value: string | undefined
+): string {
+  const raw = value?.trim();
+  if (!raw || !raw.startsWith("/") || raw.startsWith("//")) {
+    return DEFAULT_PUBLIC_SUMMARY_PATH;
+  }
+
+  try {
+    const url = new URL(raw, "https://reviewbot.local");
+    url.hash = "";
+    if (url.origin !== "https://reviewbot.local") {
+      return DEFAULT_PUBLIC_SUMMARY_PATH;
+    }
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return DEFAULT_PUBLIC_SUMMARY_PATH;
   }
 }
 

--- a/styles/seize-bootstrap.scss
+++ b/styles/seize-bootstrap.scss
@@ -9,7 +9,7 @@ $yellow: #ffff00;
 // Add any other Bootstrap variables you want to set globally BEFORE the import.
 
 // Import Bootstrap's full SCSS using @use and configure its variables.
-@use "bootstrap/scss/bootstrap" with (
+@use "../node_modules/bootstrap/scss/bootstrap" with (
   $pink: $pink,
   $green: $green,
   $blue: $blue,


### PR DESCRIPTION
## Summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public 6529bot Usage dashboard page and component showing totals and breakdowns (by day, repository, provider/model, and review kind) and a hub/download card.

* **Documentation**
  * Added docs, navigation, and troubleshooting pages for the new Open Data route and its behavior.

* **Tests**
  * Expanded Jest coverage for the bot usage API service, including URL/subpath handling.

* **Chores**
  * Added environment config helpers and updated .env.sample with new variables.

* **Style**
  * Minor Bootstrap import path update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->