### PR TITLE
Localize shared timeline labels

### DIFF
--- a/__tests__/components/Download.test.tsx
+++ b/__tests__/components/Download.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import Download from '@/components/download/Download';
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Download from "@/components/download/Download";
 
 const mockDownload = jest.fn();
 const mockCancel = jest.fn();
@@ -14,12 +14,12 @@ const mockUseDownloader = jest.fn(() => ({
   isInProgress: false,
 }));
 
-jest.mock('react-use-downloader', () => ({
+jest.mock("react-use-downloader", () => ({
   __esModule: true,
   default: () => mockUseDownloader(),
 }));
 
-describe('Download', () => {
+describe("Download", () => {
   beforeEach(() => {
     mockDownload.mockClear();
     mockCancel.mockClear();
@@ -35,14 +35,15 @@ describe('Download', () => {
     });
   });
 
-  it('starts download on icon click when not in progress', async () => {
+  it("starts download on button click when not in progress", async () => {
     render(<Download href="/file" name="test" extension="txt" />);
-    const icon = screen.getByRole('img', { hidden: true });
-    await userEvent.click(icon);
-    expect(mockDownload).toHaveBeenCalledWith('/file', 'test.txt');
+    await userEvent.click(
+      screen.getByRole("button", { name: "Download file" })
+    );
+    expect(mockDownload).toHaveBeenCalledWith("/file", "test.txt");
   });
 
-  it('shows progress and cancels when in progress', async () => {
+  it("shows progress and cancels when in progress", async () => {
     mockUseDownloader.mockReturnValueOnce({
       size: 0,
       elapsed: 0,
@@ -54,9 +55,42 @@ describe('Download', () => {
     });
     render(<Download href="/file" name="test" extension="txt" />);
     expect(screen.getByText(/Downloading 55/)).toBeInTheDocument();
-    // The cancel button is an X icon, not text
-    const cancelButton = screen.getByRole('img', { hidden: true });
-    await userEvent.click(cancelButton);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Cancel download" })
+    );
     expect(mockCancel).toHaveBeenCalled();
+  });
+
+  it("uses custom labels for visible and accessible download states", async () => {
+    mockUseDownloader.mockReturnValueOnce({
+      size: 0,
+      elapsed: 0,
+      percentage: 55,
+      download: mockDownload,
+      cancel: mockCancel,
+      error: null,
+      isInProgress: true,
+    });
+
+    render(
+      <Download
+        href="/file"
+        name="test"
+        extension="txt"
+        labels={{
+          cancelDownload: "Custom cancel",
+          downloadingFile: "Custom downloading file",
+          downloadingProgress: (percentage) => `Custom ${percentage}%`,
+        }}
+      />
+    );
+
+    expect(
+      screen.getByLabelText("Custom downloading file")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Custom 55%")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Custom cancel" })
+    ).toBeInTheDocument();
   });
 });

--- a/__tests__/components/UserPageStatsBoostBreakdown.test.tsx
+++ b/__tests__/components/UserPageStatsBoostBreakdown.test.tsx
@@ -1,5 +1,16 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import UserPageStatsBoostBreakdown from "@/components/user/stats/UserPageStatsBoostBreakdown";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
+
+jest.mock("@fortawesome/react-fontawesome", () => ({
+  FontAwesomeIcon: () => <svg data-testid="icon" />,
+}));
+
+const boostText = (
+  key: Parameters<typeof t>[1],
+  params?: Parameters<typeof t>[2]
+) => t(DEFAULT_LOCALE, key, params);
 
 function makeTDH() {
   return {
@@ -44,7 +55,17 @@ describe("UserPageStatsBoostBreakdown", () => {
 
   it("shows boost rows when data present", () => {
     render(<UserPageStatsBoostBreakdown tdh={makeTDH()} />);
-    expect(screen.getByText("Boost Breakdown")).toBeInTheDocument();
-    expect(screen.getByText("TOTAL BOOST")).toBeInTheDocument();
+    expect(
+      screen.getByText(boostText("user.collected.stats.boostBreakdown.title"))
+    ).toBeInTheDocument();
+
+    const table = screen.getByRole("table", {
+      name: boostText("user.collected.stats.boostBreakdown.tableCaption"),
+    });
+    expect(
+      within(table).getByRole("rowheader", {
+        name: boostText("user.collected.stats.boostBreakdown.rows.total"),
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/__tests__/components/meme-calendar/MemeCalendar.test.tsx
+++ b/__tests__/components/meme-calendar/MemeCalendar.test.tsx
@@ -1,0 +1,91 @@
+import MemeCalendar from "@/components/meme-calendar/MemeCalendar";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+jest.mock("@/hooks/isMobileScreen", () => ({
+  __esModule: true,
+  default: () => false,
+}));
+
+describe("MemeCalendar controls", () => {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date(Date.UTC(2026, 0, 1, 12)));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("exposes named zoom, guide, navigation, and jump controls", () => {
+    render(<MemeCalendar displayTz="utc" locale="de-DE" />);
+
+    const rangeGroup = screen.getByRole("group", { name: "Calendar range" });
+    expect(
+      within(rangeGroup).getByRole("button", { name: "SZN 14" })
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(
+      within(rangeGroup).getByRole("button", { name: "Year 4" })
+    ).toHaveAttribute("aria-pressed", "false");
+
+    expect(
+      screen.getByRole("button", { name: "Previous SZN" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Next SZN" })
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Show calendar guide" })
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Hide calendar guide" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "Calendar guide" })
+    ).toHaveTextContent("Minting Days");
+
+    expect(screen.getByRole("button", { name: "Jump to Today" })).toBeEnabled();
+    expect(screen.getByLabelText("Meme #")).toHaveAttribute("type", "number");
+    expect(screen.getByLabelText("Date")).toHaveAttribute("type", "month");
+  });
+
+  it("formats default SZN grid dates and mint day labels with the active locale", () => {
+    render(<MemeCalendar displayTz="utc" locale="de-DE" />);
+
+    expect(screen.getByText("Januar 2026")).toBeInTheDocument();
+    const mintButton = screen.getByRole("button", {
+      name: /Fr\., 2\. Jan\. 2026: #439 mint/i,
+    });
+    expect(mintButton).toHaveAttribute(
+      "data-tooltip-html",
+      expect.stringContaining("Meme #439")
+    );
+    expect(mintButton).toHaveAttribute(
+      "data-tooltip-html",
+      expect.stringContaining("Fr., 2. Jan. 2026")
+    );
+  });
+
+  it("names drilldown cards with titles, ranges, and mint counts", () => {
+    render(<MemeCalendar displayTz="utc" locale="de-DE" />);
+
+    const rangeGroup = screen.getByRole("group", { name: "Calendar range" });
+    fireEvent.click(within(rangeGroup).getByRole("button", { name: "Year 4" }));
+
+    expect(
+      screen.getByRole("button", {
+        name: /Open SZN #14: .+2026 - .+2026; Memes #/i,
+      })
+    ).toHaveTextContent("SZN #14");
+
+    fireEvent.click(
+      within(rangeGroup).getByRole("button", { name: "Epoch 1" })
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: /Open Year #4 \(2026\): .+2026 - .+2026; Memes #/i,
+      })
+    ).toHaveTextContent("Year #4 (2026)");
+  });
+});

--- a/__tests__/components/meme-calendar/MemeCalendarOverview.test.tsx
+++ b/__tests__/components/meme-calendar/MemeCalendarOverview.test.tsx
@@ -22,9 +22,45 @@ describe("MemeCalendarOverview upcoming mints card", () => {
   it("shows next season when current season has no upcoming mints", () => {
     jest.useFakeTimers().setSystemTime(new Date(Date.UTC(2025, 11, 31)));
     render(<MemeCalendarOverview displayTz="utc" />);
-    expect(screen.getByText(/Upcoming Mints for SZN 14/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("table", { name: /Upcoming Mints for SZN 14/ })
+    ).toBeInTheDocument();
     expect(
       screen.queryByText(/No upcoming mints in this season./)
     ).not.toBeInTheDocument();
+  });
+
+  it("uses locale-aware overview labels and preserves locale on the full calendar link", () => {
+    jest.useFakeTimers().setSystemTime(new Date(Date.UTC(2025, 11, 31)));
+    render(<MemeCalendarOverview displayTz="utc" locale="de-DE" showViewAll />);
+
+    expect(
+      screen.getByRole("heading", { name: "The Memes Minting Calendar" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "View full Memes minting calendar" })
+    ).toHaveAttribute("href", "/meme-calendar?locale=de-DE");
+    expect(
+      screen.getByRole("button", { name: "Next Mint" })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Meme #")).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("link", { name: "Add to Calendar" }).length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole("link", { name: "Add to Google Calendar" }).length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("columnheader", { name: "Meme number" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Mint time" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Calendar links" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Screenshot" })).toHaveClass(
+      "focus-visible:tw-outline"
+    );
   });
 });

--- a/__tests__/components/meme-calendar/MemesMintingCalendar.test.tsx
+++ b/__tests__/components/meme-calendar/MemesMintingCalendar.test.tsx
@@ -1,0 +1,51 @@
+import MemesMintingCalendar from "@/components/meme-calendar/MemesMintingCalendar";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("@/components/meme-calendar/MemeCalendarOverview", () => ({
+  __esModule: true,
+  default: ({ displayTz, locale }: { displayTz: string; locale: string }) => (
+    <div data-locale={locale} data-testid="overview" data-tz={displayTz} />
+  ),
+}));
+
+jest.mock("@/components/meme-calendar/MemeCalendar", () => ({
+  __esModule: true,
+  default: ({ displayTz, locale }: { displayTz: string; locale: string }) => (
+    <div data-locale={locale} data-testid="calendar" data-tz={displayTz} />
+  ),
+}));
+
+describe("MemesMintingCalendar timezone toggle", () => {
+  it("labels the timezone controls and passes locale to child views", async () => {
+    render(<MemesMintingCalendar locale="de-DE" />);
+
+    expect(
+      screen.getByRole("group", { name: "Calendar timezone" })
+    ).toBeInTheDocument();
+
+    const localButton = screen.getByRole("button", {
+      name: "Show local time",
+    });
+    const utcButton = screen.getByRole("button", { name: "Show UTC" });
+
+    expect(localButton).toHaveAttribute("aria-pressed", "true");
+    expect(utcButton).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByTestId("overview")).toHaveAttribute(
+      "data-locale",
+      "de-DE"
+    );
+    expect(screen.getByTestId("calendar")).toHaveAttribute(
+      "data-locale",
+      "de-DE"
+    );
+    expect(screen.getByTestId("overview")).toHaveAttribute("data-tz", "local");
+
+    await userEvent.click(utcButton);
+
+    expect(localButton).toHaveAttribute("aria-pressed", "false");
+    expect(utcButton).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("overview")).toHaveAttribute("data-tz", "utc");
+    expect(screen.getByTestId("calendar")).toHaveAttribute("data-tz", "utc");
+  });
+});

--- a/__tests__/components/meme-calendar/meme-calendar.helpers.test.ts
+++ b/__tests__/components/meme-calendar/meme-calendar.helpers.test.ts
@@ -4,6 +4,7 @@ import {
   getCardsRemainingUntilEndOf,
   getMintNumberForMintDate,
   getMintTimelineDetails,
+  getMonthWeeks,
   getNextMintStart,
   getRangeDatesByZoom,
   getSeasonIndexForDate,
@@ -86,6 +87,9 @@ describe("printCalendarInvites", () => {
 
     expect(html).toContain("dates=20240703T144000Z%2F20240704T140000Z");
     expect(html).toContain("DTEND%3A20240704T140000Z");
+    expect(html).toContain('aria-label="Add to Calendar"');
+    expect(html).toContain('aria-label="Add to Google Calendar"');
+    expect(html).toContain('alt="" aria-hidden="true"');
   });
 
   it("sets a 15:00 UTC end time for winter mints", () => {
@@ -106,6 +110,56 @@ describe("printCalendarInvites", () => {
 
     expect(html).toContain("dates=20231026T144000Z%2F20231027T140000Z");
     expect(html).toContain("DTEND%3A20231027T140000Z");
+  });
+
+  it("escapes generated calendar link attributes", () => {
+    const mintDay = nextMintDateOnOrAfter(new Date(Date.UTC(2024, 6, 3)));
+    const mintInstant = mintStartInstantUtcForMintDay(mintDay);
+    const mintNumber = getMintNumberForMintDate(mintDay);
+    const html = printCalendarInvites(
+      mintInstant,
+      mintNumber,
+      'red";background:url(test)',
+      22,
+      {
+        addToCalendar: `Add "ICS" calendar's event`,
+        addToGoogleCalendar: "Add <Google> calendar",
+      }
+    );
+
+    expect(html).toContain(
+      'aria-label="Add &quot;ICS&quot; calendar&#39;s event"'
+    );
+    expect(html).toContain('aria-label="Add &lt;Google&gt; calendar"');
+    expect(html).toContain("color:red&quot;;background:url(test);");
+  });
+
+  it("accepts escaped accessible labels for calendar links", () => {
+    const mintDay = nextMintDateOnOrAfter(new Date(Date.UTC(2024, 6, 3)));
+    const mintInstant = mintStartInstantUtcForMintDay(mintDay);
+    const mintNumber = getMintNumberForMintDate(mintDay);
+    const html = printCalendarInvites(mintInstant, mintNumber, "#fff", 22, {
+      addToCalendar: 'Add "ICS" calendar',
+      addToGoogleCalendar: "Add <Google> calendar",
+    });
+
+    expect(html).toContain('aria-label="Add &quot;ICS&quot; calendar"');
+    expect(html).toContain('aria-label="Add &lt;Google&gt; calendar"');
+  });
+
+  it("formats calendar event titles with the active locale", () => {
+    const mintDay = nextMintDateOnOrAfter(new Date(Date.UTC(2026, 0, 2)));
+    const mintInstant = mintStartInstantUtcForMintDay(mintDay);
+    const html = printCalendarInvites(
+      mintInstant,
+      1234,
+      "#fff",
+      22,
+      undefined,
+      "de-DE"
+    );
+
+    expect(decodeURIComponent(html)).toContain("SUMMARY:Meme #1.234 Minting");
   });
 });
 
@@ -254,5 +308,18 @@ describe("meme-calendar helpers", () => {
       new Date(Date.UTC(2023, 0, 2))
     );
     expect(yearRemaining).toBeGreaterThanOrEqual(earlySeason);
+  });
+
+  it("pads month grids for Monday-first weekday headers", () => {
+    expect(getMonthWeeks(2022, 5)[0]).toEqual([null, null, 1, 2, 3, 4, 5]);
+    expect(getMonthWeeks(2022, 4)[0]).toEqual([
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      1,
+    ]);
   });
 });

--- a/__tests__/components/memelab/MemeLabCollection.test.tsx
+++ b/__tests__/components/memelab/MemeLabCollection.test.tsx
@@ -1,9 +1,11 @@
 import { AuthContext } from "@/components/auth/Auth";
+import MemeLabComponent from "@/components/memelab/MemeLab";
 import LabCollection from "@/components/memelab/MemeLabCollection";
 import { fetchAllPages } from "@/services/6529api";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import { useRouter } from "next/navigation";
+import type { ComponentProps } from "react";
 
 jest.mock("next/navigation", () => ({
   useRouter: jest.fn(),
@@ -14,6 +16,16 @@ jest.mock("@/services/6529api", () => ({ fetchAllPages: jest.fn() }));
 jest.mock("@/components/nft-image/NFTImage", () => (props: any) => (
   <div data-testid={`nft-${props.nft.id}`}>{props.nft.name}</div>
 ));
+jest.mock("@/components/lfg-slideshow/LFGSlideshow", () => ({
+  LFGButton: () => <div data-testid="lfg-button" />,
+}));
+jest.mock("@/components/collections-dropdown/CollectionsDropdown", () => ({
+  __esModule: true,
+  default: () => <div data-testid="collections-dropdown" />,
+}));
+jest.mock("@/contexts/TitleContext", () => ({
+  useSetTitle: jest.fn(),
+}));
 jest.mock("@fortawesome/react-fontawesome", () => ({
   FontAwesomeIcon: (props: any) => (
     <svg data-testid="icon" onClick={props.onClick} />
@@ -34,7 +46,12 @@ beforeEach(() => {
 
 const collectionName = "Cool Collection";
 
-function renderComponent() {
+const DEFAULT_MEME_LAB_PROPS: ComponentProps<typeof MemeLabComponent> = {
+  initialSort: null,
+  initialSortDirection: null,
+};
+
+function renderComponent(locale?: "en-US" | "de-DE") {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -44,13 +61,65 @@ function renderComponent() {
   return render(
     <QueryClientProvider client={queryClient}>
       <AuthContext.Provider value={{ connectedProfile: null } as any}>
-        <LabCollection collectionName={collectionName} />
+        <LabCollection collectionName={collectionName} locale={locale} />
+      </AuthContext.Provider>
+    </QueryClientProvider>
+  );
+}
+
+function renderMemeLab(props?: ComponentProps<typeof MemeLabComponent>) {
+  const componentProps = props ?? DEFAULT_MEME_LAB_PROPS;
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuthContext.Provider value={{ connectedProfile: null } as any}>
+        <MemeLabComponent {...componentProps} />
       </AuthContext.Provider>
     </QueryClientProvider>
   );
 }
 
 describe("MemeLabCollection", () => {
+  it("renders grouped collection cards as a labelled list with locale-preserving collection links", async () => {
+    (fetchAllPages as jest.Mock)
+      .mockResolvedValueOnce([
+        { id: 1, metadata_collection: "Cool Collection" },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 1,
+          contract: "0x",
+          name: "NFT",
+          artist: "artist",
+          mint_date: "2024-01-01",
+        },
+      ]);
+
+    renderMemeLab({
+      initialSort: "collections",
+      initialSortDirection: null,
+      locale: "de-DE",
+    });
+
+    await waitFor(() => expect(fetchAllPages).toHaveBeenCalledTimes(2));
+    const resultsList = await screen.findByRole("list", {
+      name: "Meme Lab cards in Cool Collection",
+    });
+    expect(within(resultsList).getAllByRole("listitem")).toHaveLength(1);
+    expect(
+      screen.getByRole("link", { name: "View Cool Collection collection" })
+    ).toHaveAttribute(
+      "href",
+      "/meme-lab/collection/Cool-Collection?locale=de-DE"
+    );
+  });
+
   it("renders nft data and website links", async () => {
     (fetchAllPages as jest.Mock)
       .mockResolvedValueOnce([{ id: 1, website: "example.com", name: "meta" }])
@@ -61,6 +130,10 @@ describe("MemeLabCollection", () => {
     await waitFor(() => expect(fetchAllPages).toHaveBeenCalledTimes(2));
     expect(screen.getByText(collectionName)).toBeInTheDocument();
     expect(screen.getByTestId("nft-1")).toHaveTextContent("NFT");
+    const resultsList = screen.getByRole("list", {
+      name: "Meme Lab cards in Cool Collection",
+    });
+    expect(within(resultsList).getAllByRole("listitem")).toHaveLength(1);
     expect(
       screen.getByRole("link", { name: "View NFT, Meme Lab card #1" })
     ).toHaveAttribute("href", "/meme-lab/1");
@@ -70,6 +143,22 @@ describe("MemeLabCollection", () => {
       "href",
       "https://example.com"
     );
+  });
+
+  it("preserves locale on card links and falls back to source list labels", async () => {
+    (fetchAllPages as jest.Mock)
+      .mockResolvedValueOnce([{ id: 1, website: "", name: "meta" }])
+      .mockResolvedValueOnce([
+        { id: 1, contract: "0x", name: "NFT", artist: "artist" },
+      ]);
+    renderComponent("de-DE");
+    await waitFor(() => expect(fetchAllPages).toHaveBeenCalledTimes(2));
+    expect(
+      screen.getByRole("list", { name: "Meme Lab cards in Cool Collection" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "View NFT, Meme Lab card #1" })
+    ).toHaveAttribute("href", "/meme-lab/1?locale=de-DE");
   });
 
   it("shows placeholder when no nfts", async () => {

--- a/__tests__/components/memelab/memeLabRouteParams.test.ts
+++ b/__tests__/components/memelab/memeLabRouteParams.test.ts
@@ -1,4 +1,5 @@
 import {
+  getMemeLabCollectionHref,
   getMemeLabCollectionName,
   getMemeLabCollectionPath,
   getMemeLabDetailHref,
@@ -58,5 +59,17 @@ describe("Meme Lab route params", () => {
     expect(getMemeLabDetailHref({ id: "token#1", locale: "de-DE" })).toBe(
       "/meme-lab/token%231?locale=de-DE"
     );
+    expect(
+      getMemeLabCollectionHref({
+        collectionName: "6529 Intern JPGs",
+        locale: "en-US",
+      })
+    ).toBe("/meme-lab/collection/6529-Intern-JPGs");
+    expect(
+      getMemeLabCollectionHref({
+        collectionName: "6529 Intern JPGs",
+        locale: "de-DE",
+      })
+    ).toBe("/meme-lab/collection/6529-Intern-JPGs?locale=de-DE");
   });
 });

--- a/__tests__/components/nft-image/RememeImage.test.tsx
+++ b/__tests__/components/nft-image/RememeImage.test.tsx
@@ -1,43 +1,118 @@
-import { render, screen } from '@testing-library/react';
-import React from 'react';
-import RememeImage from '@/components/nft-image/RememeImage';
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import RememeImage from "@/components/nft-image/RememeImage";
 
-jest.mock('next/image', () => ({ __esModule: true, default: (p: any) => <img {...p} /> }));
-jest.mock('@/helpers/Helpers', () => ({
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (p: any) => React.createElement("img", p),
+}));
+jest.mock("@/helpers/Helpers", () => ({
   parseIpfsUrl: (url: string) => `parsed-${url}`,
   parseIpfsUrlToGateway: (url: string) => `gateway-${url}`,
 }));
 
-describe('RememeImage', () => {
+describe("RememeImage", () => {
   const nftBase = {
-    id: '1',
-    contract: '0xabc',
-    image: 'ipfs://image.jpg',
-    animation: '',
+    id: "1",
+    contract: "0xabc",
+    image: "ipfs://image.jpg",
+    animation: "",
     metadata: {
-      name: 'test',
-      image: 'ipfs://meta.jpg',
-      animation: 'ipfs://anim.mp4',
-      animation_details: { format: 'MP4' },
+      name: "test",
+      image: "ipfs://meta.jpg",
+      animation: "ipfs://anim.mp4",
+      animation_details: { format: "MP4" },
     },
-    contract_opensea_data: { imageUrl: 'opensea.jpg' },
-    s3_image_thumbnail: 'thumb.jpg',
-    s3_image_scaled: 'scaled.jpg',
-    s3_image_original: 'orig.jpg',
+    contract_opensea_data: { imageUrl: "opensea.jpg" },
+    s3_image_thumbnail: "thumb.jpg",
+    s3_image_scaled: "scaled.jpg",
+    s3_image_original: "orig.jpg",
   } as any;
 
-  it('renders video when mp4 animation requested', () => {
-    const nft = { ...nftBase, image: 'file.mp4', animation: 'file.mp4' };
-    const { container } = render(<RememeImage nft={nft} animation height={300} />);
-    const video = container.querySelector('video');
+  it("renders video when mp4 animation requested", () => {
+    const nft = { ...nftBase, image: "file.mp4", animation: "file.mp4" };
+    const { container } = render(
+      <RememeImage nft={nft} animation height={300} />
+    );
+    const video = container.querySelector("video");
     expect(video).toBeTruthy();
-    expect(video).toHaveAttribute('src', expect.stringContaining('parsed-'));
+    expect(video).toHaveAttribute("src", expect.stringContaining("parsed-"));
   });
 
-  it('renders still image with first fallback', () => {
+  it("uses top-level animation as a video fallback when metadata animation is empty", () => {
+    const nft = {
+      ...nftBase,
+      image: "ipfs://poster.jpg",
+      animation: "ipfs://top-level-animation.mp4",
+      metadata: {
+        ...nftBase.metadata,
+        animation: "",
+        animation_details: { format: "MP4" },
+      },
+    };
+
+    const { container } = render(
+      <RememeImage nft={nft} animation height={300} />
+    );
+
+    const video = container.querySelector("video");
+    expect(video).toHaveAttribute(
+      "src",
+      "parsed-ipfs://top-level-animation.mp4"
+    );
+  });
+
+  it("renders still image with first fallback", () => {
     const nft = { ...nftBase };
     render(<RememeImage nft={nft} animation={false} height={300} />);
-    const img = screen.getByRole('img');
-    expect(img).toHaveAttribute('src', 'thumb.jpg');
+    const img = screen.getByRole("img");
+    expect(img).toHaveAttribute("src", "thumb.jpg");
+  });
+
+  it("uses data image URLs when no hosted fallback exists", () => {
+    const nft = {
+      ...nftBase,
+      image: "data:image/png;base64,abc123",
+      metadata: {
+        ...nftBase.metadata,
+        image: "",
+      },
+      contract_opensea_data: { imageUrl: "" },
+      s3_image_thumbnail: "",
+      s3_image_scaled: "",
+      s3_image_original: "",
+    };
+
+    render(<RememeImage nft={nft} animation={false} height={300} />);
+
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "src",
+      "data:image/png;base64,abc123"
+    );
+  });
+
+  it("renders a named placeholder when no image fallback exists", () => {
+    const nft = {
+      ...nftBase,
+      image: "",
+      metadata: {
+        ...nftBase.metadata,
+        name: "Missing ReMeme",
+        image: "",
+        animation: "",
+      },
+      contract_opensea_data: { imageUrl: "" },
+      s3_image_thumbnail: "",
+      s3_image_scaled: "",
+      s3_image_original: "",
+    };
+
+    render(<RememeImage nft={nft} animation={false} height={300} />);
+
+    const placeholder = screen.getByRole("img", { name: "Missing ReMeme" });
+    expect(placeholder).toHaveAttribute(
+      "src",
+      expect.stringMatching(/^data:image\/gif;base64,/)
+    );
   });
 });

--- a/__tests__/components/rememes/Rememes.test.tsx
+++ b/__tests__/components/rememes/Rememes.test.tsx
@@ -1,7 +1,7 @@
 import Rememes, { RememeSort } from "@/components/rememes/Rememes";
 import { TitleProvider } from "@/contexts/TitleContext";
 import { fetchUrl } from "@/services/6529api";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 
@@ -98,6 +98,10 @@ describe("Rememes component", () => {
       expect.objectContaining({ signal: expect.any(Object) })
     );
     expect(screen.getByText("#1")).toBeInTheDocument();
+    const resultsList = screen.getByRole("list", {
+      name: "ReMemes results",
+    });
+    expect(within(resultsList).getAllByRole("listitem")).toHaveLength(1);
     expect(
       screen.getByRole("link", {
         name: "View Example ReMeme, ReMeme #1",
@@ -204,6 +208,10 @@ describe("Rememes component", () => {
       )
     );
     expect(screen.getAllByText("(x1.234)")).toHaveLength(2);
+    expect(screen.getByRole("link", { name: "Add ReMeme" })).toHaveAttribute(
+      "href",
+      "/rememes/add?locale=de-DE"
+    );
     expect(
       screen.getAllByText(
         (_, element) => element?.textContent?.includes("(x2)") ?? false

--- a/__tests__/components/rememes/rememesRouteParams.test.ts
+++ b/__tests__/components/rememes/rememesRouteParams.test.ts
@@ -1,6 +1,7 @@
 import {
   getInitialRememesMemeId,
   getRememeDetailHref,
+  getRememesAddHref,
   getRememesBrowseQuery,
   getRouteHrefWithLocale,
   getRememesRouteLocale,
@@ -50,6 +51,10 @@ describe("Rememes route params", () => {
     expect(
       getRememeDetailHref({ contract: "0xabc", id: 1, locale: "de-DE" })
     ).toBe("/rememes/0xabc/1?locale=de-DE");
+    expect(getRememesAddHref({ locale: "en-US" })).toBe("/rememes/add");
+    expect(getRememesAddHref({ locale: "de-DE" })).toBe(
+      "/rememes/add?locale=de-DE"
+    );
     expect(
       getRememeDetailHref({
         contract: "collection/alpha",

--- a/__tests__/components/the-memes/MemePage.test.tsx
+++ b/__tests__/components/the-memes/MemePage.test.tsx
@@ -54,7 +54,9 @@ jest.mock("@/components/the-memes/MemePageActivity", () => ({
 }));
 
 jest.mock("@/components/the-memes/MemePageArtViewer", () => ({
-  MemePageArtViewer: () => <div data-testid="art-viewer" />,
+  MemePageArtViewer: ({ locale }: { readonly locale?: string }) => (
+    <div data-locale={locale} data-testid="art-viewer" />
+  ),
 }));
 
 jest.mock("@/components/the-memes/MemePageArt", () => ({
@@ -97,12 +99,24 @@ const mockReplace = jest.fn(
   }
 );
 let currentFocus: string | null = null;
+let currentLocale: string | null = null;
 const mockSearchParams = {
-  get: jest.fn((key: string) => (key === "focus" ? currentFocus : null)),
+  get: jest.fn((key: string) => {
+    if (key === "focus") {
+      return currentFocus;
+    }
+    if (key === "locale") {
+      return currentLocale;
+    }
+    return null;
+  }),
   toString: jest.fn(() => {
     const params = new URLSearchParams();
     if (currentFocus) {
       params.set("focus", currentFocus);
+    }
+    if (currentLocale) {
+      params.set("locale", currentLocale);
     }
     return params.toString();
   }),
@@ -122,6 +136,7 @@ usePathnameMock.mockReturnValue("/the-memes/1");
 
 beforeEach(() => {
   currentFocus = null;
+  currentLocale = null;
   mockReplace.mockClear();
   mockSearchParams.get.mockClear();
   mockSearchParams.toString.mockClear();
@@ -262,6 +277,7 @@ jest.mock("@/contexts/TitleContext", () => ({
 describe("MemePage tab navigation", () => {
   beforeEach(() => {
     currentFocus = null;
+    currentLocale = null;
     mockReplace.mockClear();
   });
 
@@ -389,6 +405,18 @@ describe("MemePage search params handling", () => {
     expect(detailsColumn?.className).toContain("[&>*:first-child]:tw-order-1");
     expect(artworkColumn).toHaveClass("tw-order-2");
     expect(artworkColumn).toHaveClass("lg:tw-self-stretch");
+  });
+
+  it("passes active locale into the art viewer", async () => {
+    currentLocale = "de-DE";
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("art-viewer")).toHaveAttribute(
+        "data-locale",
+        "de-DE"
+      );
+    });
   });
 
   it("sets focus from valid search param", async () => {
@@ -654,6 +682,27 @@ describe("MemePage navigation integration", () => {
         expect(
           screen.getByRole("link", { name: "View SZN 1 cards" })
         ).toHaveAttribute("href", "/the-memes?szn=1&sort=age&sort_dir=ASC");
+      },
+      { timeout: 5000 }
+    );
+  });
+
+  it("preserves the active locale on the season link", async () => {
+    currentLocale = "de-DE";
+
+    renderPage();
+
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("link", { name: "View SZN 1 cards" })
+        ).toHaveAttribute(
+          "href",
+          "/the-memes?szn=1&sort=age&sort_dir=ASC&locale=de-DE"
+        );
+        expect(
+          screen.getByLabelText("Meme calendar position")
+        ).toBeInTheDocument();
       },
       { timeout: 5000 }
     );

--- a/__tests__/components/the-memes/MemePageArt.test.tsx
+++ b/__tests__/components/the-memes/MemePageArt.test.tsx
@@ -1,4 +1,6 @@
 import { MemePageArt } from "@/components/the-memes/MemePageArt";
+import { formatNumber, roundTo } from "@/i18n/format";
+import { t } from "@/i18n/messages";
 import { render, screen } from "@testing-library/react";
 
 jest.mock("next/link", () => ({
@@ -12,8 +14,21 @@ jest.mock("next/link", () => ({
 
 jest.mock("@/components/download/Download", () => ({
   __esModule: true,
-  default: ({ href }: { href: string }) => (
-    <div data-testid="download" data-href={href} />
+  default: ({
+    href,
+    labels,
+  }: {
+    href: string;
+    labels?: { downloadFile?: string; download?: string };
+  }) => (
+    <button
+      type="button"
+      data-testid="download"
+      data-href={href}
+      aria-label={labels?.downloadFile ?? "Download file"}
+    >
+      {labels?.download ?? "Download"}
+    </button>
   ),
 }));
 
@@ -60,7 +75,7 @@ const nft = {
       { trait_type: "Other", value: "val" },
       { trait_type: "Boost", value: 10, display_type: "boost_percentage" },
     ],
-    image: "img",
+    image: "https://media.example/img.png",
   },
 };
 const nftMeta = { season: 1, meme_name: "meme" };
@@ -100,7 +115,7 @@ describe("MemePageArt", () => {
     ).toHaveAttribute("href", "https://metadata.example/meme.json");
     expect(
       screen.getByRole("link", { name: "Open image in new tab" })
-    ).toHaveAttribute("href", "img");
+    ).toHaveAttribute("href", "https://media.example/img.png");
 
     expect(screen.getByText("Properties")).toBeInTheDocument();
     expect(screen.getByText("Other")).toBeInTheDocument();
@@ -118,6 +133,40 @@ describe("MemePageArt", () => {
     expect(screen.getByText("C1")).toBeInTheDocument();
     expect(screen.getByText("Boosts")).toBeInTheDocument();
     expect(screen.getByText("+10%")).toBeInTheDocument();
+  });
+
+  it("uses locale-backed labels and number formatting", () => {
+    render(
+      <MemePageArt
+        show={true}
+        nft={nft as any}
+        nftMeta={nftMeta as any}
+        locale="de-DE"
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: t("de-DE", "theMemes.detail.art.sections.arweaveLinks"),
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: t("de-DE", "theMemes.detail.art.links.openRawMetadata"),
+      })
+    ).toHaveAttribute("href", "https://metadata.example/meme.json");
+    expect(
+      screen.getByRole("button", {
+        name: t("de-DE", "theMemes.detail.art.download.downloadFile"),
+      })
+    ).toHaveTextContent(t("de-DE", "theMemes.detail.art.download.download"));
+    expect(
+      screen.getByText(
+        formatNumber("de-DE", roundTo(nft.boosted_tdh, 2), {
+          maximumFractionDigits: 2,
+        })
+      )
+    ).toBeInTheDocument();
   });
 
   it("renders text display_type attributes in Properties", () => {
@@ -294,7 +343,7 @@ describe("MemePageArt", () => {
         animation_details: { format: "gif", width: 1, height: 2 },
         animation_url: "https://metadata.example/animation.gif",
         attributes: nft.metadata.attributes,
-        image: "img",
+        image: "https://media.example/img.png",
       },
     };
 

--- a/__tests__/components/the-memes/MemePageArtViewer.test.tsx
+++ b/__tests__/components/the-memes/MemePageArtViewer.test.tsx
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import type React from "react";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { t } from "@/i18n/messages";
 
 const mockDownloadMediaUrl = jest.fn().mockResolvedValue(undefined);
 type MockNFTImageProps = {
@@ -273,6 +274,31 @@ describe("MemePageArtViewer", () => {
     expect(mockHelpers.enterArtFullScreen).toHaveBeenCalledWith(
       "the-art-fullscreen-animation"
     );
+  });
+
+  it("uses locale-backed labels for artwork media controls", () => {
+    render(<MemePageArtViewer nft={baseNft as any} locale="de-DE" />);
+
+    expect(
+      screen.getByRole("button", {
+        name: t("de-DE", "theMemes.detail.art.media.fullscreen"),
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: t("de-DE", "theMemes.detail.art.media.openInNewTab"),
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: t("de-DE", "theMemes.detail.art.media.download"),
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: t("de-DE", "theMemes.detail.art.media.next"),
+      })
+    ).toBeInTheDocument();
   });
 
   it("renders only fullscreen for html artwork media actions", () => {

--- a/__tests__/components/the-memes/MemePageLive.test.tsx
+++ b/__tests__/components/the-memes/MemePageLive.test.tsx
@@ -15,20 +15,23 @@ import {
 import { t } from "@/i18n/messages";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { createElement } from "react";
 
 let mockCountry = "US";
 let mockIsIos = false;
+const mockMemePageArt = jest.fn((..._args: unknown[]) => (
+  <div data-testid="meme-page-art" />
+));
 
 jest.mock("next/image", () => ({
   __esModule: true,
-  default: ({ unoptimized, priority, ...props }: any) => (
-    <img
-      alt={props.alt ?? ""}
-      {...props}
-      data-unoptimized={unoptimized}
-      data-priority={priority}
-    />
-  ),
+  default: ({ unoptimized, priority, ...props }: any) =>
+    createElement("img", {
+      ...props,
+      alt: props.alt ?? "",
+      "data-unoptimized": unoptimized,
+      "data-priority": priority,
+    }),
 }));
 jest.mock("next/link", () => ({
   __esModule: true,
@@ -40,7 +43,7 @@ jest.mock("next/link", () => ({
 }));
 jest.mock("@/components/the-memes/MemePageArt", () => ({
   __esModule: true,
-  MemePageArt: () => <div data-testid="meme-page-art" />,
+  MemePageArt: (...args: unknown[]) => mockMemePageArt(...args),
 }));
 jest.mock("@/components/nft-image/RememeImage", () => ({
   __esModule: true,
@@ -93,6 +96,7 @@ jest.mock("@/services/api/common-api", () => ({
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockMemePageArt.mockClear();
   mockCountry = "US";
   mockIsIos = false;
 });
@@ -166,7 +170,7 @@ function createMeta(): MemesExtendedData {
   } as MemesExtendedData;
 }
 
-function createRememe(name: string): Rememe {
+function createRememe(name: string, overrides: Partial<Rememe> = {}): Rememe {
   return {
     created_at: new Date(),
     updated_at: new Date(),
@@ -194,6 +198,7 @@ function createRememe(name: string): Rememe {
     replicas: [],
     source: "",
     added_by: "",
+    ...overrides,
   } as Rememe;
 }
 
@@ -242,20 +247,85 @@ describe("MemePageReferencesSubMenu sorting", () => {
       .mockResolvedValueOnce({ data: firstData, count: 21 })
       .mockResolvedValueOnce({ data: refreshed, count: 21 });
 
-    const { container } = render(<MemePageReferencesSubMenu show nft={nft} />);
+    render(<MemePageReferencesSubMenu show nft={nft} />);
 
     await waitFor(() =>
       expect(screen.getByText(/Random1/)).toBeInTheDocument()
     );
 
-    const refreshIcon = container.querySelector(
-      'svg[data-icon="arrows-rotate"]'
-    ) as Element;
-    expect(refreshIcon).toBeInTheDocument();
-    fireEvent.click(refreshIcon);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: t("en-US", "theMemes.detail.references.refresh.ariaLabel"),
+      })
+    );
 
     await waitFor(() =>
       expect(screen.getByText(/Random2/)).toBeInTheDocument()
+    );
+  });
+
+  it("renders references labels and links with the active locale", async () => {
+    const nft = createNft();
+    const firstData = [
+      createRememe("Locale Rememe", {
+        contract: "0xabc",
+        id: "42",
+        replicas: [1, 2],
+      }),
+    ];
+
+    mockFetchUrl
+      .mockResolvedValueOnce({ data: [], count: 0 })
+      .mockResolvedValueOnce({ data: firstData, count: 21 });
+
+    render(<MemePageReferencesSubMenu show nft={nft} locale="de-DE" />);
+
+    expect(
+      screen.getByAltText(
+        t("de-DE", "theMemes.detail.references.memeLab.logoAlt")
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        t("de-DE", "theMemes.detail.references.memeLab.description")
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByAltText(
+        t("de-DE", "theMemes.detail.references.rememes.logoAlt")
+      )
+    ).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByText("Locale Rememe")).toBeInTheDocument()
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: t("de-DE", "theMemes.detail.references.sort.trigger", {
+          sort: t("de-DE", "rememes.sort.random"),
+        }),
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: t("de-DE", "theMemes.detail.references.refresh.ariaLabel"),
+      })
+    ).toBeInTheDocument();
+    const rememeLink = screen.getByRole("link", {
+      name: t("de-DE", "rememes.card.linkAriaLabel", {
+        name: "Locale Rememe",
+        tokenId: "42",
+      }),
+    });
+    expect(rememeLink).toHaveAttribute(
+      "href",
+      "/rememes/0xabc/42?locale=de-DE"
+    );
+    expect(rememeLink).toHaveTextContent(
+      t("de-DE", "rememes.card.replicaCount", {
+        count: formatInteger("de-DE", 2),
+      })
     );
   });
 });
@@ -524,6 +594,23 @@ describe("MemePageLiveSubMenu details", () => {
       expect(
         screen.getByRole("button", { name: /additional details/i })
       ).toHaveAttribute("aria-expanded", "true")
+    );
+  });
+
+  it("passes locale into additional details content", () => {
+    render(
+      <MemePageLiveSubMenu
+        show
+        nft={createNft()}
+        nftMeta={createMeta()}
+        defaultAdditionalDetailsOpen={true}
+        locale="de-DE"
+      />
+    );
+
+    expect(mockMemePageArt).toHaveBeenCalledWith(
+      expect.objectContaining({ locale: "de-DE" }),
+      undefined
     );
   });
 });

--- a/__tests__/components/the-memes/MemePageTimeline.test.tsx
+++ b/__tests__/components/the-memes/MemePageTimeline.test.tsx
@@ -1,12 +1,22 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
-import { MemePageTimeline } from '@/components/the-memes/MemePageTimeline';
-import { fetchAllPages } from '@/services/6529api';
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { MemePageTimeline } from "@/components/the-memes/MemePageTimeline";
+import { t } from "@/i18n/messages";
+import { fetchAllPages } from "@/services/6529api";
 
-jest.mock('@/services/6529api');
-jest.mock('@/components/timeline/Timeline', () => ({ __esModule: true, default: ({ steps }: any) => (<div data-testid="timeline" data-count={steps.length} />) }));
+jest.mock("@/services/6529api");
+jest.mock("@/components/timeline/Timeline", () => ({
+  __esModule: true,
+  default: ({ steps, locale }: any) => (
+    <div
+      data-testid="timeline"
+      data-count={steps.length}
+      data-locale={locale}
+    />
+  ),
+}));
 
-describe('MemePageTimeline', () => {
+describe("MemePageTimeline", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (fetchAllPages as jest.Mock).mockResolvedValue([]);
@@ -14,16 +24,32 @@ describe('MemePageTimeline', () => {
 
   const nft = { id: 42 } as any;
 
-  it('does not render timeline when show is false but still fetches history', async () => {
+  it("does not render timeline when show is false but still fetches history", async () => {
     render(<MemePageTimeline show={false} nft={nft} />);
     await waitFor(() => expect(fetchAllPages).toHaveBeenCalledTimes(1));
-    expect(screen.queryByTestId('timeline')).toBeNull();
+    expect(screen.queryByTestId("timeline")).toBeNull();
   });
 
-  it('fetches history and renders timeline when show is true', async () => {
+  it("fetches history and renders timeline when show is true", async () => {
     (fetchAllPages as jest.Mock).mockResolvedValue([{ id: 1 }, { id: 2 }]);
     render(<MemePageTimeline show nft={nft} />);
     await waitFor(() => expect(fetchAllPages).toHaveBeenCalledTimes(1));
-    expect(screen.getByTestId('timeline')).toHaveAttribute('data-count', '2');
+    expect(screen.getByTestId("timeline")).toHaveAttribute("data-count", "2");
+  });
+
+  it("labels the timeline region and passes the selected locale", async () => {
+    (fetchAllPages as jest.Mock).mockResolvedValue([{ id: 1 }]);
+    render(<MemePageTimeline show nft={nft} locale="de-DE" />);
+
+    expect(
+      screen.getByRole("region", {
+        name: t("de-DE", "theMemes.detail.timeline.region"),
+      })
+    ).toBeInTheDocument();
+    await waitFor(() => expect(fetchAllPages).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId("timeline")).toHaveAttribute(
+      "data-locale",
+      "de-DE"
+    );
   });
 });

--- a/__tests__/components/timeline/Timeline.test.tsx
+++ b/__tests__/components/timeline/Timeline.test.tsx
@@ -99,6 +99,8 @@ describe("Timeline", () => {
       />
     );
     expect(mediaProps[0]).toMatchObject({
+      label: t("en-US", "timeline.fields.addedImage"),
+      locale: "en-US",
       type: MediaType.IMAGE,
       url: "img.png",
     });
@@ -112,6 +114,8 @@ describe("Timeline", () => {
       />
     );
     expect(mediaProps[0]).toMatchObject({
+      label: t("en-US", "timeline.fields.addedAnimation"),
+      locale: "en-US",
       type: MediaType.VIDEO,
       url: "vid.mp4",
     });

--- a/__tests__/components/timeline/Timeline.test.tsx
+++ b/__tests__/components/timeline/Timeline.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import Timeline from "@/components/timeline/Timeline";
 import { MediaType } from "@/components/timeline/TimelineMedia";
+import { t } from "@/i18n/messages";
 
 jest.mock("@/components/timeline/Timeline.module.scss", () => ({
   timeline: "timeline",
@@ -36,7 +37,7 @@ const makeStep = (changeKey: string, from: any, to: any) =>
       event: "Minted",
       changes: [{ key: changeKey, from, to }],
     },
-  } as any);
+  }) as any;
 
 beforeEach(() => {
   mediaProps = [];
@@ -45,8 +46,32 @@ beforeEach(() => {
 describe("Timeline", () => {
   it("formats date header and displays key label", () => {
     render(<Timeline nft={baseNft} steps={[makeStep("some_key", "a", "b")]} />);
-    expect(screen.getByText("2024/05/02 - 07:08 UTC")).toBeInTheDocument();
+    expect(screen.getByText("05/02/2024, 07:08 UTC")).toBeInTheDocument();
     expect(screen.getByText("Some Key")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: t("en-US", "timeline.links.uriAriaLabel"),
+      })
+    ).toHaveAttribute("href", "https://example.com");
+    expect(
+      screen.getByRole("link", {
+        name: t("en-US", "timeline.links.txnAriaLabel"),
+      })
+    ).toHaveAttribute("href", "https://etherscan.io/tx/0xabc");
+  });
+
+  it("formats timeline dates with the selected locale", () => {
+    render(
+      <Timeline
+        nft={baseNft}
+        steps={[makeStep("some_key", "a", undefined)]}
+        locale="de-DE"
+      />
+    );
+    expect(screen.getByText("02.05.2024, 07:08 UTC")).toBeInTheDocument();
+    expect(
+      screen.getByText(`${t("de-DE", "timeline.fields.removedValue")}:`)
+    ).toBeInTheDocument();
   });
 
   it("passes image type for image changes", () => {

--- a/__tests__/components/timeline/Timeline.test.tsx
+++ b/__tests__/components/timeline/Timeline.test.tsx
@@ -9,6 +9,7 @@ jest.mock("@/components/timeline/Timeline.module.scss", () => ({
   content: "content",
   linkIcon: "linkIcon",
   changesUl: "changesUl",
+  metadataValue: "metadataValue",
 }));
 
 let mediaProps: any[] = [];
@@ -72,6 +73,22 @@ describe("Timeline", () => {
     expect(
       screen.getByText(`${t("de-DE", "timeline.fields.removedValue")}:`)
     ).toBeInTheDocument();
+  });
+
+  it("renders timeline metadata values as text", () => {
+    const { container } = render(
+      <Timeline
+        nft={baseNft}
+        steps={[makeStep("some_key", undefined, "alpha\n<b>beta</b>")]}
+      />
+    );
+
+    expect(container.innerHTML).toContain("&lt;b&gt;beta&lt;/b&gt;");
+    expect(
+      Array.from(container.querySelectorAll("b")).some(
+        (node) => node.textContent === "beta"
+      )
+    ).toBe(false);
   });
 
   it("passes image type for image changes", () => {

--- a/__tests__/components/timeline/TimelineMedia.test.tsx
+++ b/__tests__/components/timeline/TimelineMedia.test.tsx
@@ -1,25 +1,64 @@
-import { render, screen } from '@testing-library/react';
-import TimelineMedia, { MediaType } from '@/components/timeline/TimelineMedia';
+import { render, screen } from "@testing-library/react";
+import TimelineMedia, { MediaType } from "@/components/timeline/TimelineMedia";
+import { t } from "@/i18n/messages";
 
-jest.mock('@/components/timeline/Timeline.module.scss', () => ({ timelineMediaImage: 'media' }));
+jest.mock("@/components/timeline/Timeline.module.scss", () => ({
+  timelineMediaImage: "media",
+}));
 
-describe('TimelineMedia', () => {
-  it('renders image element by default', () => {
-    render(<TimelineMedia url="img.png" type={MediaType.IMAGE} />);
-    const img = screen.getByRole('img');
-    expect(img).toHaveAttribute('src', 'img.png');
-    expect(img).toHaveClass('media');
+describe("TimelineMedia", () => {
+  it("renders native image with accessible preview text", () => {
+    render(
+      <TimelineMedia
+        url="https://arbitrary.example/media/non-square.png"
+        type={MediaType.IMAGE}
+        label="Added Image"
+      />
+    );
+    const img = screen.getByRole("img", {
+      name: t("en-US", "timeline.media.imageAlt", { label: "Added Image" }),
+    });
+    expect(img.tagName).toBe("IMG");
+    expect(img).toHaveAttribute(
+      "src",
+      "https://arbitrary.example/media/non-square.png"
+    );
+    expect(img).not.toHaveAttribute("width");
+    expect(img).not.toHaveAttribute("height");
+    expect(img).toHaveClass("media");
   });
 
-  it('renders video when type VIDEO', () => {
-    const { container } = render(<TimelineMedia url="video.mp4" type={MediaType.VIDEO} />);
-    const video = container.querySelector('video');
-    expect(video).toHaveAttribute('src', 'video.mp4');
+  it("renders video with an accessible label", () => {
+    const { container } = render(
+      <TimelineMedia
+        url="video.mp4"
+        type={MediaType.VIDEO}
+        label="Added Animation"
+      />
+    );
+    const video = container.querySelector("video");
+    expect(video).toHaveAttribute("src", "video.mp4");
+    expect(video).toHaveAttribute(
+      "aria-label",
+      t("en-US", "timeline.media.videoAriaLabel", {
+        label: "Added Animation",
+      })
+    );
   });
 
-  it('renders iframe when type HTML', () => {
-    const { container } = render(<TimelineMedia url="page.html" type={MediaType.HTML} />);
-    const frame = container.querySelector('iframe');
-    expect(frame).toHaveAttribute('src', 'page.html');
+  it("renders iframe with a title", () => {
+    const { container } = render(
+      <TimelineMedia
+        url="page.html"
+        type={MediaType.HTML}
+        label="Added Animation"
+      />
+    );
+    const frame = container.querySelector("iframe");
+    expect(frame).toHaveAttribute("src", "page.html");
+    expect(frame).toHaveAttribute(
+      "title",
+      t("en-US", "timeline.media.htmlTitle", { label: "Added Animation" })
+    );
   });
 });

--- a/__tests__/components/user/collected/CollectedStatsSeasonTile.test.tsx
+++ b/__tests__/components/user/collected/CollectedStatsSeasonTile.test.tsx
@@ -102,6 +102,7 @@ describe("CollectedStatsSeasonTile", () => {
 
     expect(container.querySelectorAll("circle")).toHaveLength(1);
     expect(container.querySelector("animate")).not.toBeInTheDocument();
+    expect(screen.getByText("0 sets")).toBeInTheDocument();
   });
 
   it("skips the entry animation when reduced motion is enabled", () => {
@@ -181,7 +182,7 @@ describe("CollectedStatsSeasonTile", () => {
     const button = screen.getByRole("button", { name: /szn2/i });
 
     expect(button).toHaveClass("tw-border-transparent", "tw-bg-transparent");
-    expect(button).toHaveClass("desktop-hover:hover:tw-scale-[1.03]");
+    expect(button).toHaveClass("desktop-hover:hover:tw-scale-105");
     expect(button).not.toHaveClass(
       "hover:tw-scale-[1.01]",
       "focus-visible:tw-scale-[1.01]"
@@ -234,5 +235,33 @@ describe("CollectedStatsSeasonTile", () => {
       "sm:tw-w-[88px]",
       "tw-px-2"
     );
+  });
+
+  it("uses source-locale set count labels", () => {
+    const { rerender } = render(
+      <CollectedStatsSeasonTile
+        season={buildSeason({ setsHeld: 1 })}
+        isSelected={false}
+        showDetailText={false}
+        hasTouchScreen={false}
+        shouldAnimateProgressOnMount
+        onPreview={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText("1 set")).toBeInTheDocument();
+
+    rerender(
+      <CollectedStatsSeasonTile
+        season={buildSeason({ setsHeld: 3 })}
+        isSelected={false}
+        showDetailText={false}
+        hasTouchScreen={false}
+        shouldAnimateProgressOnMount
+        onPreview={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText("3 sets")).toBeInTheDocument();
   });
 });

--- a/__tests__/components/user/collected/UserPageCollectedStats.test.tsx
+++ b/__tests__/components/user/collected/UserPageCollectedStats.test.tsx
@@ -640,6 +640,33 @@ describe("UserPageCollectedStats", () => {
     expect(screen.getByTestId("details")).toBeInTheDocument();
   });
 
+  it("uses source-locale copy when stats details are unavailable", async () => {
+    const user = userEvent.setup();
+
+    renderWithQueryClient(
+      <UserPageCollectedStats
+        profile={
+          {
+            handle: "",
+            wallets: [],
+            consolidation_key: "",
+          } as any
+        }
+        activeAddress={null}
+        initialStatsData={buildInitialStatsData({
+          initialCollectedStats: undefined,
+        })}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Details" }));
+
+    expect(
+      screen.getByText("Stats are unavailable for this profile.")
+    ).toBeInTheDocument();
+    expect(apiMock).not.toHaveBeenCalled();
+  });
+
   it("starts with details open when an activity query param is present", async () => {
     useSearchParamsMock.mockReturnValue({
       get: (key: string) => (key === "activity" ? "distributions" : null),
@@ -655,8 +682,54 @@ describe("UserPageCollectedStats", () => {
 
     await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(4));
 
-    expect(screen.getByRole("button", { name: "Hide Details" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Hide Details" })
+    ).toBeInTheDocument();
     expect(screen.getByTestId("details")).toBeInTheDocument();
+  });
+
+  it("uses non-undefined fallbacks when detail stats fetches fail", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    apiMock.mockRejectedValue(new Error("Network request failed"));
+    useSearchParamsMock.mockReturnValue({
+      get: (key: string) => (key === "activity" ? "tdh-history" : null),
+    });
+
+    try {
+      renderWithQueryClient(
+        <UserPageCollectedStats
+          profile={profile}
+          activeAddress={null}
+          initialStatsData={buildInitialStatsData()}
+        />
+      );
+
+      await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(4));
+
+      expect(screen.getByTestId("details")).toHaveAttribute(
+        "data-seasons",
+        "0"
+      );
+      expect(screen.getByTestId("details")).toHaveAttribute(
+        "data-has-tdh",
+        "false"
+      );
+      expect(screen.getByTestId("details")).toHaveAttribute(
+        "data-has-owner-balance",
+        "false"
+      );
+      expect(screen.getByTestId("details")).toHaveAttribute(
+        "data-balance-memes",
+        "0"
+      );
+      expect(consoleErrorSpy.mock.calls.join("\n")).not.toContain(
+        "Query data cannot be undefined"
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it("clears previous detail stats while the next address detail queries are in flight", async () => {

--- a/__tests__/components/user/collected/cards/UserPageCollectedCards.test.tsx
+++ b/__tests__/components/user/collected/cards/UserPageCollectedCards.test.tsx
@@ -6,7 +6,7 @@ import {
   CollectionSort,
 } from "@/entities/IProfile";
 import { SortDirection } from "@/entities/ISort";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import React from "react";
 
 jest.mock("@/components/user/collected/cards/UserPageCollectedCard", () => {
@@ -95,9 +95,12 @@ describe("UserPageCollectedCards", () => {
         showDataRow={true}
         filters={{ ...baseFilters, collection: null }}
         setPage={setPage}
+        dataTransfer={[]}
       />
     );
 
+    const cardsList = screen.getByRole("list", { name: "Collected cards" });
+    expect(within(cardsList).getAllByRole("listitem")).toHaveLength(2);
     expect(screen.getAllByTestId("card")).toHaveLength(2);
     expect(screen.getAllByTestId("card")[0]).toHaveAttribute(
       "data-show-data-row",
@@ -117,6 +120,7 @@ describe("UserPageCollectedCards", () => {
         showDataRow={false}
         filters={{ ...baseFilters, collection: null }}
         setPage={() => {}}
+        dataTransfer={[]}
       />
     );
 
@@ -132,10 +136,12 @@ describe("UserPageCollectedCards", () => {
         showDataRow={false}
         filters={{ ...baseFilters, collection: CollectedCollectionType.MEMES }}
         setPage={() => {}}
+        dataTransfer={[]}
       />
     );
 
     expect(screen.getByTestId("no-cards")).toHaveTextContent("MEMES");
+    expect(screen.queryByRole("list", { name: "Collected cards" })).toBeNull();
     expect(screen.queryByTestId("card")).toBeNull();
   });
 });

--- a/__tests__/components/user/collected/cards/UserPageCollectedCardsNoCards.test.tsx
+++ b/__tests__/components/user/collected/cards/UserPageCollectedCardsNoCards.test.tsx
@@ -23,6 +23,7 @@ describe("UserPageCollectedCardsNoCards messages", () => {
       collection: null,
       szn: null,
     });
+    expect(screen.getByRole("status")).toHaveTextContent("No cards to display");
     expect(screen.getByText("No cards to display")).toBeInTheDocument();
   });
 
@@ -32,6 +33,9 @@ describe("UserPageCollectedCardsNoCards messages", () => {
       collection: null,
       szn: null,
     });
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Congratulations, full setter!"
+    );
     expect(
       screen.getByText("Congratulations, full setter!")
     ).toBeInTheDocument();
@@ -46,6 +50,17 @@ describe("UserPageCollectedCardsNoCards messages", () => {
     expect(
       screen.getByText("Congratulations, SZN 4 full setter!")
     ).toBeInTheDocument();
+  });
+
+  it("shows source-locale network empty state", () => {
+    renderComponent({
+      seized: CollectionSeized.NOT_SEIZED,
+      collection: CollectedCollectionType.NETWORK,
+      szn: null,
+    });
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "No network tokens found"
+    );
   });
 
   it("shows gradient message", () => {

--- a/__tests__/components/user/collected/cards/UserPageCollectedNetworkCards.test.tsx
+++ b/__tests__/components/user/collected/cards/UserPageCollectedNetworkCards.test.tsx
@@ -1,0 +1,122 @@
+import UserPageCollectedNetworkCards from "@/components/user/collected/cards/UserPageCollectedNetworkCards";
+import { useTokenMetadataQuery } from "@/hooks/useAlchemyNftQueries";
+import { render, screen, within } from "@testing-library/react";
+import React from "react";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ alt, src }: { readonly alt: string; readonly src: string }) =>
+    React.createElement("img", { alt, src }),
+}));
+
+const paginationProps: any = {};
+jest.mock("@/components/utils/table/paginator/CommonTablePagination", () => {
+  const MockedPagination = (props: any) => {
+    Object.assign(paginationProps, props);
+    return (
+      <div data-testid="pagination">
+        Page {props.currentPage} of {props.totalPages}
+      </div>
+    );
+  };
+  MockedPagination.displayName = "CommonTablePagination";
+  return MockedPagination;
+});
+
+jest.mock("@/hooks/useAlchemyNftQueries", () => ({
+  useTokenMetadataQuery: jest.fn(),
+}));
+
+const useTokenMetadataQueryMock = useTokenMetadataQuery as jest.Mock;
+
+const cards = [
+  {
+    contract: "0xabc",
+    token: 101,
+    xtdh: 42.25,
+    xtdh_rate: 1.5,
+  },
+  {
+    contract: "0xdef",
+    token: 202,
+    xtdh: 7,
+    xtdh_rate: 0.25,
+  },
+] as any;
+
+describe("UserPageCollectedNetworkCards", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(paginationProps).forEach((key) => delete paginationProps[key]);
+    useTokenMetadataQueryMock.mockReturnValue({ data: [] });
+  });
+
+  it("renders network cards as a labelled list with localized labels", () => {
+    const setPage = jest.fn();
+    useTokenMetadataQueryMock.mockReturnValue({
+      data: [
+        {
+          tokenId: BigInt(101),
+          tokenIdRaw: "101",
+          contract: "0xabc",
+          name: "First Token",
+          imageUrl: "https://example.com/first.png",
+          collectionName: "Cool Collection",
+          isSpam: false,
+        },
+      ],
+    });
+
+    render(
+      <UserPageCollectedNetworkCards
+        cards={cards}
+        page={2}
+        setPage={setPage}
+        next={true}
+      />
+    );
+
+    expect(useTokenMetadataQueryMock).toHaveBeenCalledWith({
+      tokens: [
+        { contract: "0xabc", tokenId: "101" },
+        { contract: "0xdef", tokenId: "202" },
+      ],
+      enabled: true,
+    });
+    const cardsList = screen.getByRole("list", {
+      name: "Collected network cards",
+    });
+    expect(within(cardsList).getAllByRole("listitem")).toHaveLength(2);
+    expect(
+      screen.getByRole("img", { name: "Network token image for First Token" })
+    ).toHaveAttribute("src", "https://example.com/first.png");
+    expect(screen.getByText("Cool Collection")).toBeInTheDocument();
+    expect(screen.getByText("Token #202")).toBeInTheDocument();
+    expect(screen.getAllByText("xTDH")).toHaveLength(2);
+    expect(screen.getAllByText("xTDH/day")).toHaveLength(2);
+    expect(screen.getByTestId("pagination")).toHaveTextContent("Page 2 of 3");
+    expect(paginationProps.setCurrentPage).toBe(setPage);
+    expect(paginationProps.haveNextPage).toBe(true);
+  });
+
+  it("renders localized empty state and disables metadata fetching", () => {
+    render(
+      <UserPageCollectedNetworkCards
+        cards={[]}
+        page={1}
+        setPage={() => {}}
+        next={false}
+      />
+    );
+
+    expect(screen.getByText("No network tokens found")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("list", { name: "Collected network cards" })
+    ).toBeNull();
+    expect(screen.queryByTestId("pagination")).toBeNull();
+    expect(useTokenMetadataQueryMock).toHaveBeenCalledWith({
+      tokens: [],
+      enabled: false,
+    });
+  });
+});

--- a/__tests__/components/user/collected/filters/UserPageCollectedFilters.test.tsx
+++ b/__tests__/components/user/collected/filters/UserPageCollectedFilters.test.tsx
@@ -1,10 +1,6 @@
 import UserPageCollectedFilters from "@/components/user/collected/filters/UserPageCollectedFilters";
-import type {
-  CollectionSeized} from "@/entities/IProfile";
-import {
-  CollectedCollectionType,
-  CollectionSort,
-} from "@/entities/IProfile";
+import type { CollectionSeized } from "@/entities/IProfile";
+import { CollectedCollectionType, CollectionSort } from "@/entities/IProfile";
 import type { MemeSeason } from "@/entities/ISeason";
 import { SortDirection } from "@/entities/ISort";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
@@ -509,7 +505,8 @@ describe("UserPageCollectedFilters", () => {
     await waitFor(() => {
       expect(addEventListenerSpy).toHaveBeenCalledWith(
         "scroll",
-        expect.any(Function)
+        expect.any(Function),
+        { passive: true }
       );
       expect(windowAddEventListenerSpy).toHaveBeenCalledWith(
         "resize",

--- a/__tests__/components/user/collected/filters/UserPageCollectedFiltersNativeDropdown.test.tsx
+++ b/__tests__/components/user/collected/filters/UserPageCollectedFiltersNativeDropdown.test.tsx
@@ -1,0 +1,54 @@
+import UserPageCollectedFiltersNativeDropdown from "@/components/user/collected/filters/UserPageCollectedFiltersNativeDropdown";
+import { CollectedCollectionType } from "@/entities/IProfile";
+import { render } from "@testing-library/react";
+
+let capturedProps: any = null;
+
+jest.mock(
+  "@/components/utils/select/dropdown/CommonDropdown",
+  () => (props: any) => {
+    capturedProps = props;
+    return <div data-testid="dropdown" />;
+  }
+);
+
+describe("UserPageCollectedFiltersNativeDropdown", () => {
+  beforeEach(() => {
+    capturedProps = null;
+  });
+
+  it("passes source-locale collection labels to the dropdown", () => {
+    render(
+      <UserPageCollectedFiltersNativeDropdown
+        selected={CollectedCollectionType.MEMES}
+        setSelected={jest.fn()}
+      />
+    );
+
+    expect(capturedProps.filterLabel).toBe("Collection");
+    expect(capturedProps.activeItem).toBe(CollectedCollectionType.MEMES);
+    expect(capturedProps.items).toEqual([
+      expect.objectContaining({
+        label: "All",
+        mobileLabel: "All Collections",
+        value: null,
+      }),
+      expect.objectContaining({
+        label: "The Memes",
+        value: CollectedCollectionType.MEMES,
+      }),
+      expect.objectContaining({
+        label: "NextGen",
+        value: CollectedCollectionType.NEXTGEN,
+      }),
+      expect.objectContaining({
+        label: "Gradients",
+        value: CollectedCollectionType.GRADIENTS,
+      }),
+      expect.objectContaining({
+        label: "Meme Lab",
+        value: CollectedCollectionType.MEMELAB,
+      }),
+    ]);
+  });
+});

--- a/__tests__/components/user/collected/filters/UserPageCollectedFiltersNetworkCollection.test.tsx
+++ b/__tests__/components/user/collected/filters/UserPageCollectedFiltersNetworkCollection.test.tsx
@@ -1,0 +1,65 @@
+import UserPageCollectedFiltersNetworkCollection from "@/components/user/collected/filters/UserPageCollectedFiltersNetworkCollection";
+import { useXtdhCollectionsQuery } from "@/hooks/useXtdhCollectionsQuery";
+import { render } from "@testing-library/react";
+
+let capturedProps: any = null;
+
+jest.mock(
+  "@/components/utils/select/dropdown/CommonDropdown",
+  () => (props: any) => {
+    capturedProps = props;
+    return <div data-testid="dropdown" />;
+  }
+);
+
+jest.mock("@/hooks/useXtdhCollectionsQuery", () => ({
+  useXtdhCollectionsQuery: jest.fn(),
+}));
+
+describe("UserPageCollectedFiltersNetworkCollection", () => {
+  const useXtdhCollectionsQueryMock = useXtdhCollectionsQuery as jest.Mock;
+
+  beforeEach(() => {
+    capturedProps = null;
+    useXtdhCollectionsQueryMock.mockReturnValue({
+      collections: [
+        { collection_name: "6529 Network", contract: "0x123" },
+        { collection_name: null, contract: "0x456" },
+      ],
+    });
+  });
+
+  it("passes source-locale network collection labels to the dropdown", () => {
+    render(
+      <UserPageCollectedFiltersNetworkCollection
+        identity="punk6529"
+        selected="0x456"
+        setSelected={jest.fn()}
+      />
+    );
+
+    expect(useXtdhCollectionsQueryMock).toHaveBeenCalledWith({
+      identity: "punk6529",
+      pageSize: 100,
+      sortField: "xtdh",
+      order: "DESC",
+    });
+    expect(capturedProps.filterLabel).toBe("Collection");
+    expect(capturedProps.activeItem).toBe("0x456");
+    expect(capturedProps.items).toEqual([
+      expect.objectContaining({
+        label: "All",
+        mobileLabel: "All Collections",
+        value: null,
+      }),
+      expect.objectContaining({
+        label: "6529 Network",
+        value: "0x123",
+      }),
+      expect.objectContaining({
+        label: "Unknown Collection",
+        value: "0x456",
+      }),
+    ]);
+  });
+});

--- a/__tests__/components/user/collected/filters/UserPageCollectedFiltersSeized.test.tsx
+++ b/__tests__/components/user/collected/filters/UserPageCollectedFiltersSeized.test.tsx
@@ -1,21 +1,24 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import UserPageCollectedFiltersSeized from '@/components/user/collected/filters/UserPageCollectedFiltersSeized';
-import { CollectionSeized } from '@/entities/IProfile';
+import React from "react";
+import { render } from "@testing-library/react";
+import UserPageCollectedFiltersSeized from "@/components/user/collected/filters/UserPageCollectedFiltersSeized";
+import { CollectionSeized } from "@/entities/IProfile";
 
 let capturedProps: any = null;
 
-jest.mock('@/components/utils/select/dropdown/CommonDropdown', () => (props: any) => {
-  capturedProps = props;
-  return <div data-testid="dropdown" />;
-});
+jest.mock(
+  "@/components/utils/select/dropdown/CommonDropdown",
+  () => (props: any) => {
+    capturedProps = props;
+    return <div data-testid="dropdown" />;
+  }
+);
 
-describe('UserPageCollectedFiltersSeized', () => {
+describe("UserPageCollectedFiltersSeized", () => {
   beforeEach(() => {
     capturedProps = null;
   });
 
-  it('passes items and active selection to dropdown', () => {
+  it("passes items, labels, and active selection to dropdown", () => {
     const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
     render(
       <UserPageCollectedFiltersSeized
@@ -26,8 +29,23 @@ describe('UserPageCollectedFiltersSeized', () => {
     );
     const values = capturedProps.items.map((i: any) => i.value);
     expect(values).toEqual([null, ...Object.values(CollectionSeized)]);
+    expect(capturedProps.items).toEqual([
+      expect.objectContaining({
+        label: "All",
+        mobileLabel: "All Cards",
+        value: null,
+      }),
+      expect.objectContaining({
+        label: "Seized",
+        value: CollectionSeized.SEIZED,
+      }),
+      expect.objectContaining({
+        label: "Not Seized",
+        value: CollectionSeized.NOT_SEIZED,
+      }),
+    ]);
     expect(capturedProps.activeItem).toBe(CollectionSeized.NOT_SEIZED);
-    expect(capturedProps.filterLabel).toBe('Seized');
+    expect(capturedProps.filterLabel).toBe("Seized");
     expect(capturedProps.containerRef).toBe(ref);
   });
 });

--- a/__tests__/components/user/collected/filters/UserPageCollectedFiltersSortBy.test.tsx
+++ b/__tests__/components/user/collected/filters/UserPageCollectedFiltersSortBy.test.tsx
@@ -1,20 +1,20 @@
-import { render } from '@testing-library/react';
-import UserPageCollectedFiltersSortBy from '@/components/user/collected/filters/UserPageCollectedFiltersSortBy';
-import { CollectedCollectionType, CollectionSort } from '@/entities/IProfile';
-import { SortDirection } from '@/entities/ISort';
+import { render } from "@testing-library/react";
+import UserPageCollectedFiltersSortBy from "@/components/user/collected/filters/UserPageCollectedFiltersSortBy";
+import { CollectedCollectionType, CollectionSort } from "@/entities/IProfile";
+import { SortDirection } from "@/entities/ISort";
 
 let capturedProps: any = null;
-jest.mock('@/components/utils/select/CommonSelect', () => (props: any) => {
+jest.mock("@/components/utils/select/CommonSelect", () => (props: any) => {
   capturedProps = props;
   return <div data-testid="select" />;
 });
 
-describe('UserPageCollectedFiltersSortBy', () => {
+describe("UserPageCollectedFiltersSortBy", () => {
   beforeEach(() => {
     capturedProps = null;
   });
 
-  it('filters sort items based on collection', () => {
+  it("filters sort items based on collection", () => {
     const { rerender } = render(
       <UserPageCollectedFiltersSortBy
         selected={CollectionSort.TOKEN_ID}
@@ -42,7 +42,7 @@ describe('UserPageCollectedFiltersSortBy', () => {
     ]);
   });
 
-  it('shows all sorts when collection is null', () => {
+  it("shows all sorts when collection is null", () => {
     render(
       <UserPageCollectedFiltersSortBy
         selected={CollectionSort.TOKEN_ID}
@@ -55,6 +55,26 @@ describe('UserPageCollectedFiltersSortBy', () => {
       CollectionSort.TOKEN_ID,
       CollectionSort.TDH,
       CollectionSort.RANK,
+    ]);
+  });
+
+  it("passes source-locale labels to the select", () => {
+    render(
+      <UserPageCollectedFiltersSortBy
+        selected={CollectionSort.XTDH_DAY}
+        direction={SortDirection.DESC}
+        collection={CollectedCollectionType.NETWORK}
+        setSelected={jest.fn()}
+      />
+    );
+
+    expect(capturedProps.filterLabel).toBe("Sort By");
+    expect(capturedProps.items).toEqual([
+      expect.objectContaining({ label: "xTDH", value: CollectionSort.XTDH }),
+      expect.objectContaining({
+        label: "xTDH/day",
+        value: CollectionSort.XTDH_DAY,
+      }),
     ]);
   });
 });

--- a/__tests__/components/user/followers/UserPageFollowersModal.test.tsx
+++ b/__tests__/components/user/followers/UserPageFollowersModal.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { AuthContext } from "@/components/auth/Auth";
+import UserPageFollowersModal from "@/components/user/followers/UserPageFollowersModal";
+import useFollowersList from "@/hooks/useFollowersList";
+
+jest.mock("@/components/mobile-wrapper-dialog/MobileWrapperDialog", () => ({
+  __esModule: true,
+  default: ({ title, children }: any) => (
+    <section role="dialog" aria-label={title}>
+      {children}
+    </section>
+  ),
+}));
+
+jest.mock("@/components/utils/CommonIntersectionElement", () => ({
+  __esModule: true,
+  default: () => <div data-testid="intersection-sentinel" />,
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ alt, fill, sizes, unoptimized, ...props }: any) =>
+    React.createElement("img", { alt: alt ?? "", ...props }),
+}));
+
+jest.mock("@/components/user/utils/UserCICAndLevel", () => ({
+  __esModule: true,
+  default: (props: any) => <div data-testid="cic">{props.level}</div>,
+  UserCICAndLevelSize: { SMALL: "SMALL" },
+}));
+
+jest.mock("@/components/user/utils/UserFollowBtn", () => ({
+  __esModule: true,
+  default: ({ handle }: any) => <button type="button">Follow {handle}</button>,
+  UserFollowBtnSize: { SMALL: "SMALL" },
+}));
+
+jest.mock("@/hooks/useFollowersList");
+
+const mockedUseFollowersList = useFollowersList as jest.Mock;
+
+const renderModal = () =>
+  render(
+    <AuthContext.Provider
+      value={{
+        connectedProfile: null,
+        fetchingProfile: false,
+        receivedProfileProxies: [],
+        activeProfileProxy: null,
+        connectionStatus: "NOT_CONNECTED" as any,
+        showWaves: false,
+        requestAuth: async () => ({ success: false }),
+        setToast: jest.fn(),
+        setActiveProfileProxy: jest.fn(),
+      }}
+    >
+      <UserPageFollowersModal
+        profileId="profile-1"
+        isOpen={true}
+        onClose={jest.fn()}
+      />
+    </AuthContext.Provider>
+  );
+
+describe("UserPageFollowersModal", () => {
+  beforeEach(() => {
+    mockedUseFollowersList.mockReturnValue({
+      followers: [
+        {
+          identity: {
+            id: "1",
+            handle: "alice",
+            level: 5,
+            pfp: "alice.png",
+            primary_address: "0xalice",
+          },
+        },
+      ],
+      isFetching: false,
+      onBottomIntersection: jest.fn(),
+    });
+  });
+
+  it("uses the localized followers title and forwards list state", () => {
+    renderModal();
+
+    expect(
+      screen.getByRole("dialog", { name: "Followers" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("list", { name: "Followers" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "View alice's profile" })
+    ).toHaveAttribute("href", "/alice");
+    expect(mockedUseFollowersList).toHaveBeenCalledWith({
+      profileId: "profile-1",
+      enabled: true,
+    });
+  });
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+  ])(
+    "falls back to primary address when follower handle is %s",
+    (_label, missingHandle) => {
+      mockedUseFollowersList.mockReturnValue({
+        followers: [
+          {
+            identity: {
+              id: "2",
+              handle: missingHandle,
+              level: 2,
+              pfp: "fallback.png",
+              primary_address: "0xabc",
+            },
+          },
+        ],
+        isFetching: false,
+        onBottomIntersection: jest.fn(),
+      });
+
+      renderModal();
+
+      const profileLink = screen.getByRole("link", {
+        name: "View 0xabc's profile",
+      });
+      expect(profileLink).toHaveAttribute("href", "/0xabc");
+      expect(profileLink).toHaveAttribute("aria-label", "View 0xabc's profile");
+      expect(profileLink).toHaveTextContent("0xabc");
+      expect(screen.getByAltText("0xabc's profile image")).toBeInTheDocument();
+    }
+  );
+});

--- a/__tests__/components/user/layout/UserPageLayout.test.tsx
+++ b/__tests__/components/user/layout/UserPageLayout.test.tsx
@@ -5,12 +5,18 @@ import { TitleProvider } from "@/contexts/TitleContext";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
-import { useParams, usePathname, useSearchParams } from "next/navigation";
+import {
+  useParams,
+  usePathname,
+  useRouter,
+  useSearchParams,
+} from "next/navigation";
 
 jest.mock("next/navigation", () => ({
   useSearchParams: jest.fn(),
   useParams: jest.fn(),
   usePathname: jest.fn(),
+  useRouter: jest.fn(),
 }));
 jest.mock(
   "@/components/user/user-page-header/UserPageHeader",
@@ -35,12 +41,14 @@ const mockAuthContext = {} as any;
 const mockReactQueryContext = { setProfile: jest.fn() } as any;
 const mockUseParams = useParams as jest.Mock;
 const mockUsePathname = usePathname as jest.Mock;
+const mockUseRouter = useRouter as jest.Mock;
 const mockUseSearchParams = useSearchParams as jest.Mock;
 
 describe("UserPageLayout", () => {
   beforeEach(() => {
     mockUseParams.mockReturnValue({ user: "testuser" });
     mockUsePathname.mockReturnValue("/testuser");
+    mockUseRouter.mockReturnValue({ push: jest.fn(), replace: jest.fn() });
     mockUseSearchParams.mockReturnValue(new URLSearchParams());
   });
 
@@ -53,10 +61,7 @@ describe("UserPageLayout", () => {
         <QueryClientProvider client={queryClient}>
           <AuthContext.Provider value={mockAuthContext}>
             <ReactQueryWrapperContext.Provider value={mockReactQueryContext}>
-              <UserPageLayout
-                profile={mockProfile}
-                handleOrWallet="testuser"
-              >
+              <UserPageLayout profile={mockProfile} handleOrWallet="testuser">
                 <div>Content</div>
               </UserPageLayout>
             </ReactQueryWrapperContext.Provider>
@@ -76,9 +81,7 @@ describe("UserPageLayout", () => {
   it("sets profile in context when not cached", async () => {
     renderComponent();
     await waitFor(() =>
-      expect(mockReactQueryContext.setProfile).toHaveBeenCalledWith(
-        mockProfile
-      )
+      expect(mockReactQueryContext.setProfile).toHaveBeenCalledWith(mockProfile)
     );
   });
 });

--- a/__tests__/components/user/layout/UserPageTab.test.tsx
+++ b/__tests__/components/user/layout/UserPageTab.test.tsx
@@ -1,26 +1,39 @@
-import { render, screen } from '@testing-library/react';
-import UserPageTab from '@/components/user/layout/UserPageTab';
-import { USER_PAGE_TAB_IDS, USER_PAGE_TAB_MAP } from '@/components/user/layout/userTabs.config';
-import { useParams, useSearchParams } from 'next/navigation';
+import { render, screen } from "@testing-library/react";
+import UserPageTab from "@/components/user/layout/UserPageTab";
+import {
+  USER_PAGE_TAB_IDS,
+  USER_PAGE_TAB_MAP,
+} from "@/components/user/layout/userTabs.config";
+import { useParams, useSearchParams } from "next/navigation";
 
-jest.mock('next/navigation', () => ({
+jest.mock("next/navigation", () => ({
   useParams: jest.fn(),
   useSearchParams: jest.fn(),
 }));
-jest.mock('next/link', () => (props: any) => (
+jest.mock("next/link", () => (props: any) => (
   <a
     data-testid="link"
-    href={props.href.pathname + (props.href.query ? '?address=' + props.href.query.address : '')}
+    href={
+      props.href.pathname +
+      (props.href.query ? "?address=" + props.href.query.address : "")
+    }
     className={props.className}
+    aria-current={props["aria-current"]}
+    aria-label={props["aria-label"]}
   >
     {props.children}
   </a>
 ));
 
-describe('UserPageTab', () => {
-  it('renders active and inactive states', () => {
-    (useParams as jest.Mock).mockReturnValue({ user: 'bob' });
-    (useSearchParams as jest.Mock).mockReturnValue({ get: (k: string) => (k === 'address' ? '0x1' : null) });
+describe("UserPageTab", () => {
+  beforeEach(() => {
+    (useParams as jest.Mock).mockReturnValue({ user: "bob" });
+    (useSearchParams as jest.Mock).mockReturnValue({
+      get: (k: string) => (k === "address" ? "0x1" : null),
+    });
+  });
+
+  it("renders active and inactive states", () => {
     const repTab = USER_PAGE_TAB_MAP[USER_PAGE_TAB_IDS.REP];
     const { rerender } = render(
       <UserPageTab
@@ -29,9 +42,11 @@ describe('UserPageTab', () => {
         activeTabId={USER_PAGE_TAB_IDS.REP}
       />
     );
-    const link = screen.getByTestId('link');
-    expect(link).toHaveAttribute('href', '/bob/rep?address=0x1');
-    expect(link).toHaveClass('tw-pointer-events-none');
+    const link = screen.getByTestId("link");
+    expect(link).toHaveAttribute("href", "/bob/?address=0x1");
+    expect(link).toHaveAttribute("aria-label", "Identity");
+    expect(link).toHaveClass("tw-pointer-events-none");
+    expect(link).toHaveAttribute("aria-current", "page");
     rerender(
       <UserPageTab
         tab={repTab}
@@ -39,6 +54,19 @@ describe('UserPageTab', () => {
         activeTabId={USER_PAGE_TAB_IDS.BRAIN}
       />
     );
-    expect(link).not.toHaveClass('tw-pointer-events-none');
+    expect(link).not.toHaveClass("tw-pointer-events-none");
+    expect(link).not.toHaveAttribute("aria-current");
+  });
+
+  it("renders localized badges in the link name", () => {
+    render(
+      <UserPageTab
+        tab={USER_PAGE_TAB_MAP[USER_PAGE_TAB_IDS.XTDH]}
+        parentRef={{ current: null }}
+        activeTabId={USER_PAGE_TAB_IDS.REP}
+      />
+    );
+
+    expect(screen.getByRole("link", { name: "xTDH Beta" })).toBeInTheDocument();
   });
 });

--- a/__tests__/components/user/layout/UserPageTabs.test.tsx
+++ b/__tests__/components/user/layout/UserPageTabs.test.tsx
@@ -1,4 +1,5 @@
 import UserPageTabs from "@/components/user/layout/UserPageTabs";
+import { getUserProfileTabsMessage } from "@/components/user/layout/user-tabs.messages";
 import { USER_PAGE_TAB_IDS } from "@/components/user/layout/userTabs.config";
 import { render, screen, waitFor } from "@testing-library/react";
 import {
@@ -26,6 +27,10 @@ const capacitorMock = jest.fn();
 jest.mock("@/hooks/useCapacitor", () => ({
   __esModule: true,
   default: () => capacitorMock(),
+}));
+const useIdentityMock = jest.fn();
+jest.mock("@/hooks/useIdentity", () => ({
+  useIdentity: () => useIdentityMock(),
 }));
 jest.mock("@/components/user/layout/UserPageTab", () => ({
   __esModule: true,
@@ -96,6 +101,10 @@ const renderTabs = ({
     connectedProfile,
     fetchingProfile,
   });
+  useIdentityMock.mockReturnValue({
+    profile: { profile_wave_id: null },
+    isLoading: false,
+  });
   useSeizeConnectContextMock.mockReturnValue({
     address,
     connectionState,
@@ -109,6 +118,11 @@ const renderTabs = ({
 describe("UserPageTabs", () => {
   it("filters tabs based on context and platform", () => {
     renderTabs({ showWaves: false, isIos: false });
+    expect(
+      screen.getByRole("navigation", {
+        name: getUserProfileTabsMessage("user.profile.tabs.navigationLabel"),
+      })
+    ).toBeInTheDocument();
     const tabs = getTabIds();
     expect(tabs).not.toContain(USER_PAGE_TAB_IDS.BRAIN);
     expect(tabs).not.toContain("stats");

--- a/__tests__/components/user/stats/UserPageStatsActivityOverview.test.tsx
+++ b/__tests__/components/user/stats/UserPageStatsActivityOverview.test.tsx
@@ -1,18 +1,152 @@
-import { render, waitFor } from '@testing-library/react';
-import React from 'react';
-import UserPageStatsActivityOverview from '@/components/user/stats/UserPageStatsActivityOverview';
-import { commonApiFetch } from '@/services/api/common-api';
+import { render, screen, waitFor, within } from "@testing-library/react";
+import UserPageStatsActivityOverview from "@/components/user/stats/UserPageStatsActivityOverview";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
+import { commonApiFetch } from "@/services/api/common-api";
 
-jest.mock('@/services/api/common-api', () => ({
-  commonApiFetch: jest.fn(() => Promise.resolve({}))
+jest.mock("@/services/api/common-api", () => ({
+  commonApiFetch: jest.fn(),
 }));
 
-const profile: any = { wallets: [{ wallet: '0xabc' }] };
+const profile: any = { wallets: [{ wallet: "0xabc" }] };
 
-describe('UserPageStatsActivityOverview', () => {
-  it('calls API on mount', async () => {
-    render(<UserPageStatsActivityOverview profile={profile} activeAddress={null} />);
+const activityText = (
+  key: Parameters<typeof t>[1],
+  params?: Parameters<typeof t>[2]
+) => t(DEFAULT_LOCALE, key, params);
+
+function mockActivityResponses() {
+  (commonApiFetch as jest.Mock)
+    .mockResolvedValueOnce({
+      airdrops: 1000,
+      airdrops_memes: 800,
+      airdrops_nextgen: 100,
+      airdrops_gradients: 50,
+      airdrops_memelab: 50,
+      transfers_in: 25,
+      transfers_in_memes: 20,
+      transfers_in_nextgen: 2,
+      transfers_in_gradients: 2,
+      transfers_in_memelab: 1,
+      primary_purchases_count: 4,
+      primary_purchases_value: 1.234,
+      secondary_purchases_count: 3,
+      secondary_purchases_value: 2.345,
+      transfers_out: 2,
+      burns: 1,
+      sales_count: 5,
+      sales_value: 6.789,
+    })
+    .mockResolvedValueOnce([
+      {
+        consolidation_key: "wallet:0xabc",
+        season: 1,
+        transfers_in: 9,
+        airdrops: 8,
+        primary_purchases_count: 7,
+        primary_purchases_value: 1.23,
+        secondary_purchases_count: 6,
+        secondary_purchases_value: 2.34,
+        transfers_out: 5,
+        burns: 4,
+        sales_count: 3,
+        sales_value: 4.56,
+      },
+    ]);
+}
+
+describe("UserPageStatsActivityOverview", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockActivityResponses();
+  });
+
+  it("calls API on mount", async () => {
+    render(
+      <UserPageStatsActivityOverview profile={profile} activeAddress={null} />
+    );
     await waitFor(() => expect(commonApiFetch).toHaveBeenCalledTimes(2));
-    expect((commonApiFetch as jest.Mock).mock.calls[0][0].endpoint).toContain('aggregated-activity/wallet/0xabc');
+    expect((commonApiFetch as jest.Mock).mock.calls[0][0].endpoint).toContain(
+      "aggregated-activity/wallet/0xabc"
+    );
+  });
+
+  it("renders accessible activity overview tables", async () => {
+    render(
+      <UserPageStatsActivityOverview profile={profile} activeAddress={null} />
+    );
+
+    const overviewTable = await screen.findByRole("table", {
+      name: activityText(
+        "user.collected.stats.activityOverview.tables.overviewCaption"
+      ),
+    });
+    expect(
+      within(overviewTable).getByRole("rowheader", {
+        name: activityText(
+          "user.collected.stats.activityOverview.rows.airdrops"
+        ),
+      })
+    ).toBeInTheDocument();
+    expect(within(overviewTable).getByText("1,000")).toBeInTheDocument();
+    expect(within(overviewTable).getByText("1.23")).toBeInTheDocument();
+
+    const seasonTable = await screen.findByRole("table", {
+      name: activityText(
+        "user.collected.stats.activityOverview.tables.memesBySeasonCaption"
+      ),
+    });
+    expect(
+      await within(seasonTable).findByRole("rowheader", {
+        name: activityText(
+          "user.collected.stats.activityOverview.seasonLabel",
+          { seasonNumber: 1 }
+        ),
+      })
+    ).toBeInTheDocument();
+    expect(
+      within(seasonTable).getByRole("columnheader", {
+        name: activityText(
+          "user.collected.stats.activityOverview.rows.transfersIn"
+        ),
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("shows an empty state instead of an empty season table", async () => {
+    (commonApiFetch as jest.Mock)
+      .mockReset()
+      .mockResolvedValueOnce({
+        airdrops: 0,
+        transfers_in: 0,
+        primary_purchases_count: 0,
+        primary_purchases_value: 0,
+        secondary_purchases_count: 0,
+        secondary_purchases_value: 0,
+        transfers_out: 0,
+        burns: 0,
+        sales_count: 0,
+        sales_value: 0,
+      })
+      .mockResolvedValueOnce([]);
+
+    render(
+      <UserPageStatsActivityOverview profile={profile} activeAddress={null} />
+    );
+
+    expect(
+      await screen.findByText(
+        activityText(
+          "user.collected.stats.activityOverview.tables.memesBySeasonEmpty"
+        )
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("table", {
+        name: activityText(
+          "user.collected.stats.activityOverview.tables.memesBySeasonCaption"
+        ),
+      })
+    ).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/user/stats/UserPageStatsBoostBreakdown.test.tsx
+++ b/__tests__/components/user/stats/UserPageStatsBoostBreakdown.test.tsx
@@ -1,38 +1,169 @@
-import { render, screen } from '@testing-library/react';
-import UserPageStatsBoostBreakdown from '@/components/user/stats/UserPageStatsBoostBreakdown';
-import type { ConsolidatedTDH } from '@/entities/ITDH';
+import { render, screen, within } from "@testing-library/react";
+import UserPageStatsBoostBreakdown from "@/components/user/stats/UserPageStatsBoostBreakdown";
+import type { ConsolidatedTDH } from "@/entities/ITDH";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 
-jest.mock('@fortawesome/react-fontawesome', () => ({ FontAwesomeIcon: () => <svg data-testid="icon" /> }));
+jest.mock("@fortawesome/react-fontawesome", () => ({
+  FontAwesomeIcon: () => <svg data-testid="icon" />,
+}));
 
-describe('UserPageStatsBoostBreakdown', () => {
-  it('renders nothing when boost breakdown missing', () => {
-    const { container } = render(<UserPageStatsBoostBreakdown tdh={undefined} />);
+const boostText = (
+  key: Parameters<typeof t>[1],
+  params?: Parameters<typeof t>[2]
+) => t(DEFAULT_LOCALE, key, params);
+
+describe("UserPageStatsBoostBreakdown", () => {
+  it("renders nothing when boost breakdown missing", () => {
+    const { container } = render(
+      <UserPageStatsBoostBreakdown tdh={undefined} />
+    );
     expect(container.firstChild).toBeNull();
   });
 
-  it('shows table when data provided', () => {
+  it("shows the accessible boost table when data provided", () => {
     const tdh: ConsolidatedTDH = {
       boost: 2,
       boost_breakdown: {
-        memes_card_sets: { available: 1, acquired: 1, available_info: [], acquired_info: [] },
-        gradients: { available: 1, acquired: 1, available_info: [], acquired_info: [] },
+        memes_card_sets: {
+          available: 1,
+          acquired: 1,
+          available_info: ["Card set boost detail"],
+          acquired_info: [],
+        },
+        gradients: {
+          available: 1,
+          acquired: 1,
+          available_info: [],
+          acquired_info: [],
+        },
       },
     } as any;
     render(<UserPageStatsBoostBreakdown tdh={tdh} />);
-    expect(screen.getByText('Boost Breakdown')).toBeInTheDocument();
-    expect(screen.getByText('TOTAL BOOST')).toBeInTheDocument();
+    expect(
+      screen.getByText(boostText("user.collected.stats.boostBreakdown.title"))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: boostText("user.collected.stats.boostBreakdown.versionLink", {
+          version: "1.4",
+        }),
+      })
+    ).toBeInTheDocument();
+
+    const table = screen.getByRole("table", {
+      name: boostText("user.collected.stats.boostBreakdown.tableCaption"),
+    });
+    expect(
+      within(table).getByRole("columnheader", {
+        name: boostText("user.collected.stats.boostBreakdown.columns.type"),
+      })
+    ).toBeInTheDocument();
+    expect(
+      within(table).getByRole("columnheader", {
+        name: boostText(
+          "user.collected.stats.boostBreakdown.columns.potential"
+        ),
+      })
+    ).toBeInTheDocument();
+    expect(
+      within(table).getByRole("rowheader", {
+        name: boostText("user.collected.stats.boostBreakdown.rows.total"),
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("button", {
+        name: boostText("user.collected.stats.boostBreakdown.info.ariaLabel"),
+      }).length
+    ).toBeGreaterThan(0);
   });
 
-  it('shows season rows when card sets acquired is zero', () => {
+  it("shows season rows when card sets acquired is zero", () => {
     const tdh: ConsolidatedTDH = {
       boost: 2,
       boost_breakdown: {
-        memes_card_sets: { available: 1, acquired: 0, available_info: [], acquired_info: [] },
-        memes_szn1: { available: 1, acquired: 1, available_info: [], acquired_info: [] },
-        gradients: { available: 0, acquired: 0, available_info: [], acquired_info: [] },
+        memes_card_sets: {
+          available: 1,
+          acquired: 0,
+          available_info: [],
+          acquired_info: [],
+        },
+        memes_szn1: {
+          available: 1,
+          acquired: 1,
+          available_info: [],
+          acquired_info: [],
+        },
+        gradients: {
+          available: 0,
+          acquired: 0,
+          available_info: [],
+          acquired_info: [],
+        },
       },
     } as any;
     render(<UserPageStatsBoostBreakdown tdh={tdh} />);
-    expect(screen.getByText('SZN1')).toBeInTheDocument();
+    expect(
+      screen.getByRole("rowheader", {
+        name: boostText("user.collected.stats.boostBreakdown.seasonLabel", {
+          seasonNumber: 1,
+        }),
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("renders zero boost values and total row numbers", () => {
+    const tdh: ConsolidatedTDH = {
+      boost: 1.25,
+      boost_breakdown: {
+        memes_card_sets: {
+          available: 0,
+          acquired: 0,
+          available_info: [],
+          acquired_info: [],
+        },
+        gradients: {
+          available: 1.5,
+          acquired: 0,
+          available_info: [],
+          acquired_info: [],
+        },
+      },
+    } as any;
+
+    render(<UserPageStatsBoostBreakdown tdh={tdh} />);
+
+    const table = screen.getByRole("table", {
+      name: boostText("user.collected.stats.boostBreakdown.tableCaption"),
+    });
+    expect(within(table).getAllByText("0.00").length).toBeGreaterThanOrEqual(3);
+    expect(within(table).getAllByText("1.50").length).toBeGreaterThanOrEqual(2);
+    expect(within(table).getByText("0.25")).toBeInTheDocument();
+  });
+
+  it("does not throw when optional boost breakdown sections are absent", () => {
+    const tdh: ConsolidatedTDH = {
+      boost: 1,
+      boost_breakdown: {
+        memes_card_sets: {
+          available: 0,
+          acquired: 0,
+          available_info: [],
+          acquired_info: [],
+        },
+      },
+    } as any;
+
+    render(<UserPageStatsBoostBreakdown tdh={tdh} />);
+
+    const table = screen.getByRole("table", {
+      name: boostText("user.collected.stats.boostBreakdown.tableCaption"),
+    });
+    expect(
+      within(table).getByRole("rowheader", {
+        name: boostText("user.collected.stats.boostBreakdown.rows.total"),
+      })
+    ).toBeInTheDocument();
+    expect(within(table).getAllByText("0.00").length).toBeGreaterThan(0);
   });
 });

--- a/__tests__/components/user/stats/UserPageStatsCollected.test.tsx
+++ b/__tests__/components/user/stats/UserPageStatsCollected.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import UserPageStatsCollected from "@/components/user/stats/UserPageStatsCollected";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 
 const ownerBalance = {
   total_balance: 5,
@@ -35,16 +37,115 @@ const balanceMemes = [
   },
 ];
 
-const seasons = [{ id: 1, count: 2, start_index:1, end_index:2, name:"S1", display:"Season 1" }];
+const seasons = [
+  {
+    id: 1,
+    count: 2,
+    start_index: 1,
+    end_index: 2,
+    name: "S1",
+    display: "Season 1",
+  },
+];
 
 test("renders collected stats", () => {
   render(
-    <UserPageStatsCollected ownerBalance={ownerBalance} balanceMemes={balanceMemes} seasons={seasons} />
+    <UserPageStatsCollected
+      ownerBalance={ownerBalance}
+      balanceMemes={balanceMemes}
+      seasons={seasons}
+    />
   );
-  expect(screen.getByText("Collected")).toBeInTheDocument();
   expect(
-    screen.getByText((_, node) => node?.textContent?.replace(/\s+/g, " ").trim() === "1 / 2 (50%)")
+    screen.getByRole("heading", {
+      name: t(DEFAULT_LOCALE, "user.collected.stats.details.collected.title"),
+    })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", {
+      name: t(DEFAULT_LOCALE, "user.collected.stats.details.overview"),
+    })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("button", {
+      name: t(DEFAULT_LOCALE, "user.collected.stats.details.memesBySeason"),
+    })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("table", {
+      name: t(
+        DEFAULT_LOCALE,
+        "user.collected.stats.details.tables.overviewCaption"
+      ),
+    })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("table", {
+      name: t(
+        DEFAULT_LOCALE,
+        "user.collected.stats.details.tables.memesBySeasonCaption"
+      ),
+    })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("rowheader", {
+      name: t(DEFAULT_LOCALE, "user.collected.stats.details.rows.cards"),
+    })
+  ).toBeInTheDocument();
+  expect(
+    screen.getAllByRole("rowheader", {
+      name: t(DEFAULT_LOCALE, "user.collected.stats.details.rows.rank"),
+    }).length
+  ).toBeGreaterThan(0);
+  expect(
+    screen.getByRole("rowheader", {
+      name: t(DEFAULT_LOCALE, "user.collected.stats.details.seasonLabel", {
+        seasonNumber: 1,
+      }),
+    })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText(
+      (_, node) =>
+        node?.textContent?.replace(/\s+/g, " ").trim() === "1 / 2 (50%)"
+    )
   ).toBeInTheDocument();
   // check rank formatting
   expect(screen.getAllByText("#1").length).toBeGreaterThan(0);
+});
+
+test("renders placeholders for sparse collected stats without NaN", () => {
+  const sparseOwnerBalance = {
+    total_balance: 1,
+    total_balance_rank: 1,
+  } as any;
+  const sparseBalanceMemes = [
+    {
+      season: 1,
+      consolidation_key: "1",
+      balance: 1,
+      unique: 0,
+      sets: undefined,
+      rank: undefined,
+      boosted_tdh: undefined,
+      tdh_rank: undefined,
+    },
+  ] as any;
+
+  const { container } = render(
+    <UserPageStatsCollected
+      ownerBalance={sparseOwnerBalance}
+      balanceMemes={sparseBalanceMemes}
+      seasons={seasons}
+    />
+  );
+
+  expect(container).not.toHaveTextContent("NaN");
+  expect(screen.getAllByText("-").length).toBeGreaterThan(0);
+  expect(
+    screen.getByText(
+      (_, node) =>
+        node?.textContent?.replace(/\s+/g, " ").trim() === "0 / 2 (0%)"
+    )
+  ).toBeInTheDocument();
 });

--- a/__tests__/components/user/stats/UserPageStatsTableShared.test.tsx
+++ b/__tests__/components/user/stats/UserPageStatsTableShared.test.tsx
@@ -1,19 +1,50 @@
-import { render, screen } from '@testing-library/react';
-import React from 'react';
-import { UserPageStatsTableHead, UserPageStatsTableHr } from '@/components/user/stats/UserPageStatsTableShared';
+import {
+  UserPageStatsTableHead,
+  UserPageStatsTableHr,
+} from "@/components/user/stats/UserPageStatsTableShared";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
+import { render, screen } from "@testing-library/react";
+import React from "react";
 
-describe('UserPageStatsTableShared', () => {
-  it('renders table head with all columns', () => {
-    render(<table><UserPageStatsTableHead /></table>);
-    const headers = screen.getAllByRole('columnheader');
-    expect(headers).toHaveLength(6);
-    expect(headers[1]).toHaveTextContent('Total');
-    expect(headers[5]).toHaveTextContent('Meme Lab');
+describe("UserPageStatsTableShared", () => {
+  it("renders table head with all columns", () => {
+    const caption = t(
+      DEFAULT_LOCALE,
+      "user.collected.stats.details.tables.overviewCaption"
+    );
+
+    render(
+      <table>
+        <UserPageStatsTableHead caption={caption} />
+      </table>
+    );
+
+    expect(screen.getByRole("table", { name: caption })).toBeInTheDocument();
+    const headers = screen.getAllByRole("columnheader");
+    expect(headers).toHaveLength(5);
+    expect(headers[0]).toHaveTextContent(
+      t(DEFAULT_LOCALE, "user.collected.stats.details.tables.column.total")
+    );
+    expect(headers[0]).toHaveAttribute("scope", "col");
+    expect(headers[4]).toHaveTextContent(
+      t(DEFAULT_LOCALE, "user.collected.stats.details.tables.column.memeLab")
+    );
   });
 
-  it('renders hr row spanning specified columns', () => {
-    render(<table><tbody><UserPageStatsTableHr span={4} /></tbody></table>);
-    const cell = screen.getByRole('cell');
-    expect(cell).toHaveAttribute('colspan', '4');
+  it("renders hr row spanning specified columns", () => {
+    const { container } = render(
+      <table>
+        <tbody>
+          <UserPageStatsTableHr span={4} />
+        </tbody>
+      </table>
+    );
+    const separatorRow = container.querySelector('tr[aria-hidden="true"]');
+    const cell = separatorRow?.querySelector("td") ?? null;
+
+    expect(separatorRow).toBeInTheDocument();
+    expect(cell).not.toBeNull();
+    expect(cell!).toHaveAttribute("colspan", "4");
   });
 });

--- a/__tests__/components/user/stats/activity/UserPageActivityTab.test.tsx
+++ b/__tests__/components/user/stats/activity/UserPageActivityTab.test.tsx
@@ -2,6 +2,15 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import UserPageActivityTab from "@/components/user/stats/activity/tabs/UserPageActivityTab";
 import { USER_PAGE_ACTIVITY_TAB } from "@/components/user/stats/activity/activity.types";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
+import {
+  getActivityPanelId,
+  getActivityTabId,
+} from "@/components/user/stats/activity/tabs/activity-tabs.helpers";
+
+const activityTabText = (key: Parameters<typeof t>[1]) =>
+  t(DEFAULT_LOCALE, key);
 
 describe("UserPageActivityTab", () => {
   it("renders label and handles click", async () => {
@@ -12,10 +21,23 @@ describe("UserPageActivityTab", () => {
         tab={USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS}
         activeTab={USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY}
         setActiveTab={setActive}
+        onKeyDown={jest.fn()}
       />
     );
-    const btn = screen.getByRole("button", { name: "Distributions" });
+    const btn = screen.getByRole("tab", {
+      name: activityTabText("user.collected.stats.activityTabs.distributions"),
+    });
     expect(btn).toHaveClass("tw-bg-iron-950", { exact: false });
+    expect(btn).toHaveAttribute("aria-selected", "false");
+    expect(btn).toHaveAttribute(
+      "aria-controls",
+      getActivityPanelId(USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS)
+    );
+    expect(btn).toHaveAttribute(
+      "id",
+      getActivityTabId(USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS)
+    );
+    expect(btn).toHaveAttribute("tabIndex", "-1");
     await user.click(btn);
     expect(setActive).toHaveBeenCalledWith(
       USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS
@@ -28,9 +50,14 @@ describe("UserPageActivityTab", () => {
         tab={USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY}
         activeTab={USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY}
         setActiveTab={jest.fn()}
+        onKeyDown={jest.fn()}
       />
     );
-    const btn = screen.getByRole("button", { name: "Wallet Activity" });
+    const btn = screen.getByRole("tab", {
+      name: activityTabText("user.collected.stats.activityTabs.walletActivity"),
+    });
     expect(btn.className).toContain("tw-bg-iron-800");
+    expect(btn).toHaveAttribute("aria-selected", "true");
+    expect(btn).toHaveAttribute("tabIndex", "0");
   });
 });

--- a/__tests__/components/user/stats/activity/UserPageActivityWrapper.test.tsx
+++ b/__tests__/components/user/stats/activity/UserPageActivityWrapper.test.tsx
@@ -1,5 +1,9 @@
 import UserPageActivityWrapper from "@/components/user/stats/activity/UserPageActivityWrapper";
 import { USER_PAGE_ACTIVITY_TAB } from "@/components/user/stats/activity/activity.types";
+import {
+  getActivityPanelId,
+  getActivityTabId,
+} from "@/components/user/stats/activity/tabs/activity-tabs.helpers";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -60,6 +64,15 @@ test("hydrates the active tab from query params and updates the url on change", 
   render(<UserPageActivityWrapper profile={profile} activeAddress={null} />);
 
   expect(screen.getByTestId("tdh")).toBeInTheDocument();
+  const activePanel = screen.getByRole("tabpanel");
+  expect(activePanel).toHaveAttribute(
+    "id",
+    getActivityPanelId(USER_PAGE_ACTIVITY_TAB.TDH_HISTORY)
+  );
+  expect(activePanel).toHaveAttribute(
+    "aria-labelledby",
+    getActivityTabId(USER_PAGE_ACTIVITY_TAB.TDH_HISTORY)
+  );
 
   await user.click(screen.getByTestId("tab"));
 

--- a/__tests__/components/user/stats/activity/distributions/UserPageStatsActivityDistributions.test.tsx
+++ b/__tests__/components/user/stats/activity/distributions/UserPageStatsActivityDistributions.test.tsx
@@ -1,4 +1,5 @@
 import UserPageStatsActivityDistributions from "@/components/user/stats/activity/distributions/UserPageStatsActivityDistributions";
+import { getDistributionsMessage } from "@/components/user/stats/activity/distributions/distributions.messages";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -68,6 +69,11 @@ test("hydrates the page from query params and updates the url on page change", a
     />
   );
 
+  expect(
+    screen.getByRole("heading", {
+      name: getDistributionsMessage("user.collected.stats.distributions.title"),
+    })
+  ).toBeInTheDocument();
   expect(screen.getByTestId("wrapper")).toHaveAttribute("data-page", "2");
 
   await userEvent.click(screen.getByTestId("set-page"));

--- a/__tests__/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTable.test.tsx
+++ b/__tests__/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTable.test.tsx
@@ -1,46 +1,91 @@
-import { render, screen } from '@testing-library/react';
-import UserPageStatsActivityDistributionsTable from '@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTable';
+import { render, screen } from "@testing-library/react";
+import UserPageStatsActivityDistributionsTable from "@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTable";
+import { getDistributionsMessage } from "@/components/user/stats/activity/distributions/distributions.messages";
 
-jest.mock('@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableItem', () => (props: any) => (
-  <tr data-testid="item">{props.item.name}</tr>
-));
+jest.mock(
+  "@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableItem",
+  () => (props: any) => (
+    <tr data-testid="item">
+      <td>{props.item.name}</td>
+    </tr>
+  )
+);
 
 const items = [
   {
     card_id: 1,
-    contract: '0x33FD426905F149f8376e227d0C9D3340AaD17aF1',
-    wallet: '0x1',
-    wallet_display: 'A',
-    card_name: 'Card1',
-    mint_date: '2020-01-01',
+    contract: "0x33FD426905F149f8376e227d0C9D3340AaD17aF1",
+    wallet: "0x1",
+    wallet_display: "A",
+    card_name: "Card1",
+    mint_date: "2020-01-01",
     airdrops: 1,
     total_spots: 0,
     minted: 2,
-    allowlist: [{ phase: 'phase1', spots: 3 }],
+    allowlist: [{ phase: "phase1", spots: 3 }],
     total_count: 5,
-    phases: ['phase1', 'AIRDROP'],
+    phases: ["phase1", "AIRDROP"],
   },
   {
     card_id: 2,
-    contract: '0x0C58Ef43fF3032005e472cB5709f8908aCb00205',
-    wallet: '0x2',
-    wallet_display: 'B',
-    card_name: 'Card2',
-    mint_date: '2020-01-02',
+    contract: "0x0C58Ef43fF3032005e472cB5709f8908aCb00205",
+    wallet: "0x2",
+    wallet_display: "B",
+    card_name: "Card2",
+    mint_date: "2020-01-02",
     airdrops: 0,
     total_spots: 0,
     minted: 1,
     allowlist: [],
     total_count: 3,
-    phases: ['phase1'],
+    phases: ["phase1"],
   },
 ];
 
-const profile = { wallets: [{ wallet: '0x1', display: 'disp1' }] } as any;
+const profile = { wallets: [{ wallet: "0x1", display: "disp1" }] } as any;
 
-test('renders rows and phases', () => {
-  render(<UserPageStatsActivityDistributionsTable items={items} profile={profile} loading={false} />);
-  expect(screen.getAllByTestId('item')).toHaveLength(2);
-  expect(screen.getByText('Phase1')).toBeInTheDocument();
-  expect(screen.getByText('Airdrop')).toBeInTheDocument();
+test("renders rows, phase headers, and a named table", () => {
+  render(
+    <UserPageStatsActivityDistributionsTable
+      items={items}
+      profile={profile}
+      loading={false}
+    />
+  );
+  expect(
+    screen.getByRole("table", {
+      name: getDistributionsMessage(
+        "user.collected.stats.distributions.tableCaption"
+      ),
+    })
+  ).toBeInTheDocument();
+  expect(screen.getAllByTestId("item")).toHaveLength(2);
+  expect(screen.getByText("Phase1")).toBeInTheDocument();
+  expect(
+    screen.getByText(
+      getDistributionsMessage(
+        "user.collected.stats.distributions.phases.airdrop"
+      )
+    )
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByText(
+      getDistributionsMessage("user.collected.stats.distributions.loading")
+    )
+  ).not.toBeInTheDocument();
+});
+
+test("renders the loading label only while loading", () => {
+  render(
+    <UserPageStatsActivityDistributionsTable
+      items={items}
+      profile={profile}
+      loading={true}
+    />
+  );
+  expect(
+    screen.getByText(
+      getDistributionsMessage("user.collected.stats.distributions.loading")
+    )
+  ).toBeInTheDocument();
 });

--- a/__tests__/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableItem.test.tsx
+++ b/__tests__/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableItem.test.tsx
@@ -1,39 +1,54 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import UserPageStatsActivityDistributionsTableItem from '@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableItem';
-import { formatNumberWithCommasOrDash, getTimeAgo } from '@/helpers/Helpers';
-
-jest.mock('@/helpers/Helpers');
-const formatMock = formatNumberWithCommasOrDash as jest.Mock;
-const timeAgoMock = getTimeAgo as jest.Mock;
+import { render, screen } from "@testing-library/react";
+import UserPageStatsActivityDistributionsTableItem from "@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableItem";
+import { DistributionCollection } from "@/components/user/stats/activity/distributions/distributions.types";
 
 beforeEach(() => {
-  formatMock.mockImplementation((v) => v.toString());
-  timeAgoMock.mockReturnValue('1d ago');
+  jest
+    .spyOn(Date, "now")
+    .mockReturnValue(new Date("2020-01-02T00:00:00.000Z").getTime());
 });
 
-describe('UserPageStatsActivityDistributionsTableItem', () => {
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("UserPageStatsActivityDistributionsTableItem", () => {
   const item = {
-    collection: 'MEMES',
+    collection: DistributionCollection.MEMES,
     tokenId: 1,
-    name: 'Test',
-    wallet: '0x1',
-    phases: [1,2],
+    name: "Test",
+    wallet: "0x1",
+    phases: [
+      { phase: "phase1", amount: 1 },
+      { phase: "phase2", amount: 2 },
+    ],
     amountMinted: 3,
     amountTotal: 4,
-    date: '2020-01-01'
-  } as any;
+    date: "2020-01-01T00:00:00.000Z",
+  };
 
-  it('renders info', () => {
-    render(<table><tbody><UserPageStatsActivityDistributionsTableItem item={item} /></tbody></table>);
-    expect(screen.getByText('The Memes')).toBeInTheDocument();
-    expect(screen.getByText('# 1')).toBeInTheDocument();
-    expect(screen.getByText('Test')).toBeInTheDocument();
-    expect(screen.getByText('0x1')).toBeInTheDocument();
-    expect(screen.getByText('1')).toBeInTheDocument();
-    expect(screen.getByText('2')).toBeInTheDocument();
-    expect(screen.getByText('3')).toBeInTheDocument();
-    expect(screen.getByText('4')).toBeInTheDocument();
-    expect(screen.getByText('1d ago')).toBeInTheDocument();
+  it("renders info", () => {
+    render(
+      <table>
+        <tbody>
+          <UserPageStatsActivityDistributionsTableItem
+            item={item}
+            formatNumber={(value) => `n-${value}`}
+          />
+        </tbody>
+      </table>
+    );
+    expect(screen.getByText("The Memes")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "View The Memes token #1" })
+    ).toHaveAttribute("href", "/the-memes/1");
+    expect(screen.getByText("# 1")).toBeInTheDocument();
+    expect(screen.getByText("Test")).toBeInTheDocument();
+    expect(screen.getByText("0x1")).toBeInTheDocument();
+    expect(screen.getByText("n-1")).toBeInTheDocument();
+    expect(screen.getByText("n-2")).toBeInTheDocument();
+    expect(screen.getByText("n-3")).toBeInTheDocument();
+    expect(screen.getByText("n-4")).toBeInTheDocument();
+    expect(screen.getByText("yesterday")).toBeInTheDocument();
   });
 });

--- a/__tests__/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableWrapper.test.tsx
+++ b/__tests__/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableWrapper.test.tsx
@@ -1,16 +1,28 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import UserPageStatsActivityDistributionsTableWrapper from '@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableWrapper';
+import { render, screen } from "@testing-library/react";
+import UserPageStatsActivityDistributionsTableWrapper from "@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableWrapper";
+import { getDistributionsMessage } from "@/components/user/stats/activity/distributions/distributions.messages";
 
-jest.mock('@/components/utils/animation/CommonCardSkeleton', () => () => <div data-testid="skeleton" />);
-jest.mock('@/components/utils/table/paginator/CommonTablePagination', () => (props: any) => <div data-testid="pagination" data-page={props.currentPage} />);
-jest.mock('@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTable', () => (props: any) => <div data-testid="table" data-count={props.items.length} />);
+jest.mock("@/components/utils/animation/CommonCardSkeleton", () => () => (
+  <div data-testid="skeleton" />
+));
+jest.mock(
+  "@/components/utils/table/paginator/CommonTablePagination",
+  () => (props: any) => (
+    <div data-testid="pagination" data-page={props.currentPage} />
+  )
+);
+jest.mock(
+  "@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTable",
+  () => (props: any) => (
+    <div data-testid="table" data-count={props.items.length} />
+  )
+);
 
-describe('UserPageStatsActivityDistributionsTableWrapper', () => {
-  const profile = { id: 'p' } as any;
+describe("UserPageStatsActivityDistributionsTableWrapper", () => {
+  const profile = { id: "p" } as any;
   const item = { amount: 1 } as any;
 
-  it('shows skeleton during initial loading', () => {
+  it("shows skeleton during initial loading", () => {
     render(
       <UserPageStatsActivityDistributionsTableWrapper
         data={[]}
@@ -22,10 +34,10 @@ describe('UserPageStatsActivityDistributionsTableWrapper', () => {
         setPage={jest.fn()}
       />
     );
-    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument();
   });
 
-  it('renders table and pagination when data exists', () => {
+  it("renders table and pagination when data exists", () => {
     render(
       <UserPageStatsActivityDistributionsTableWrapper
         data={[item]}
@@ -37,11 +49,11 @@ describe('UserPageStatsActivityDistributionsTableWrapper', () => {
         setPage={jest.fn()}
       />
     );
-    expect(screen.getByTestId('table')).toHaveAttribute('data-count', '1');
-    expect(screen.getByTestId('pagination')).toHaveAttribute('data-page', '1');
+    expect(screen.getByTestId("table")).toHaveAttribute("data-count", "1");
+    expect(screen.getByTestId("pagination")).toHaveAttribute("data-page", "1");
   });
 
-  it('shows empty message when list empty', () => {
+  it("shows empty message when list empty", () => {
     render(
       <UserPageStatsActivityDistributionsTableWrapper
         data={[]}
@@ -53,6 +65,8 @@ describe('UserPageStatsActivityDistributionsTableWrapper', () => {
         setPage={jest.fn()}
       />
     );
-    expect(screen.getByText('No distributions found')).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      getDistributionsMessage("user.collected.stats.distributions.empty")
+    );
   });
 });

--- a/__tests__/components/user/stats/activity/tabs/UserPageActivityTabs.test.tsx
+++ b/__tests__/components/user/stats/activity/tabs/UserPageActivityTabs.test.tsx
@@ -2,18 +2,8 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import UserPageActivityTabs from "@/components/user/stats/activity/tabs/UserPageActivityTabs";
 import { USER_PAGE_ACTIVITY_TAB } from "@/components/user/stats/activity/activity.types";
-
-jest.mock("@/components/user/stats/activity/tabs/UserPageActivityTab", () => ({
-  __esModule: true,
-  default: (props: any) => (
-    <button
-      data-testid={props.tab}
-      onClick={() => props.setActiveTab(props.tab)}
-    >
-      {props.tab}
-    </button>
-  ),
-}));
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 
 describe("UserPageActivityTabs", () => {
   it("renders all tabs and handles click", async () => {
@@ -25,13 +15,44 @@ describe("UserPageActivityTabs", () => {
         setActiveTab={setActive}
       />
     );
-    const walletBtn = screen.getByTestId(
-      USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY
-    );
+    expect(
+      screen.getByRole("tablist", {
+        name: t(DEFAULT_LOCALE, "user.collected.stats.activityTabs.listLabel"),
+      })
+    ).toBeInTheDocument();
+    const walletBtn = screen.getByRole("tab", {
+      name: t(
+        DEFAULT_LOCALE,
+        "user.collected.stats.activityTabs.walletActivity"
+      ),
+    });
     expect(walletBtn).toBeInTheDocument();
     await user.click(walletBtn);
     expect(setActive).toHaveBeenCalledWith(
       USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY
     );
+  });
+
+  it("supports arrow-key tab switching", async () => {
+    const user = userEvent.setup();
+    const setActive = jest.fn();
+    render(
+      <UserPageActivityTabs
+        activeTab={USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS}
+        setActiveTab={setActive}
+      />
+    );
+    screen
+      .getByRole("tab", {
+        name: t(
+          DEFAULT_LOCALE,
+          "user.collected.stats.activityTabs.distributions"
+        ),
+      })
+      .focus();
+
+    await user.keyboard("{ArrowRight}");
+
+    expect(setActive).toHaveBeenCalledWith(USER_PAGE_ACTIVITY_TAB.TDH_HISTORY);
   });
 });

--- a/__tests__/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistory.test.tsx
+++ b/__tests__/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistory.test.tsx
@@ -1,31 +1,50 @@
-import { render, screen } from '@testing-library/react';
-import UserPageStatsActivityTDHHistory from '@/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistory';
-import { useQuery } from '@tanstack/react-query';
+import { render, screen } from "@testing-library/react";
+import UserPageStatsActivityTDHHistory from "@/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistory";
+import { getTdhHistoryMessage } from "@/components/user/stats/activity/tdh-history/tdh-history.messages";
+import { useQuery } from "@tanstack/react-query";
 
-jest.mock('@tanstack/react-query');
+jest.mock("@tanstack/react-query");
 
-jest.mock('@/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryCharts', () => ({ __esModule: true, default: () => <div data-testid="charts" /> }));
-jest.mock('@/components/utils/animation/CommonCardSkeleton', () => ({ __esModule: true, default: () => <div data-testid="skeleton" /> }));
+jest.mock(
+  "@/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryCharts",
+  () => ({ __esModule: true, default: () => <div data-testid="charts" /> })
+);
+jest.mock("@/components/utils/animation/CommonCardSkeleton", () => ({
+  __esModule: true,
+  default: () => <div data-testid="skeleton" />,
+}));
 
-describe('UserPageStatsActivityTDHHistory', () => {
+describe("UserPageStatsActivityTDHHistory", () => {
   const mockUseQuery = useQuery as jest.Mock;
-  const profile = { consolidation_key: 'key' } as any;
+  const profile = { consolidation_key: "key" } as any;
 
-  it('shows skeleton while fetching', () => {
+  it("shows skeleton while fetching", () => {
     mockUseQuery.mockReturnValue({ isFetching: true, data: undefined });
     render(<UserPageStatsActivityTDHHistory profile={profile} />);
-    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: getTdhHistoryMessage("user.collected.stats.tdhHistory.title"),
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        getTdhHistoryMessage("user.collected.stats.tdhHistory.loading")
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument();
   });
 
-  it('renders charts when data available', () => {
+  it("renders charts when data available", () => {
     mockUseQuery.mockReturnValue({ isFetching: false, data: [{}] });
     render(<UserPageStatsActivityTDHHistory profile={profile} />);
-    expect(screen.getByTestId('charts')).toBeInTheDocument();
+    expect(screen.getByTestId("charts")).toBeInTheDocument();
   });
 
-  it('renders fallback when no data', () => {
+  it("renders fallback when no data", () => {
     mockUseQuery.mockReturnValue({ isFetching: false, data: [] });
     render(<UserPageStatsActivityTDHHistory profile={profile} />);
-    expect(screen.getByText('No TDH history found')).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      getTdhHistoryMessage("user.collected.stats.tdhHistory.empty")
+    );
   });
 });

--- a/__tests__/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryCharts.test.tsx
+++ b/__tests__/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryCharts.test.tsx
@@ -1,29 +1,45 @@
-import { render, screen } from '@testing-library/react';
-import UserPageStatsActivityTDHHistoryCharts from '@/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryCharts';
-import type { TDHHistory } from '@/entities/ITDH';
+import { render, screen } from "@testing-library/react";
+import UserPageStatsActivityTDHHistoryCharts from "@/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryCharts";
+import { getTdhHistoryMessage } from "@/components/user/stats/activity/tdh-history/tdh-history.messages";
+import type { TDHHistory } from "@/entities/ITDH";
 
-jest.mock('@/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryChart', () => ({
-  __esModule: true,
-  default: (props: any) => <div data-testid="chart">{props.data.title}</div>,
-}));
+jest.mock(
+  "@/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryChart",
+  () => ({
+    __esModule: true,
+    default: (props: any) => (
+      <div aria-label={props.data.ariaLabel} data-testid="chart">
+        {props.data.title}:{props.data.datasets[0].label}:
+        {props.data.labels.join("|")}
+      </div>
+    ),
+  })
+);
 
-describe('UserPageStatsActivityTDHHistoryCharts', () => {
-  it('renders no charts when history is empty', () => {
+describe("UserPageStatsActivityTDHHistoryCharts", () => {
+  it("renders no charts when history is empty", () => {
     render(<UserPageStatsActivityTDHHistoryCharts tdhHistory={[]} />);
-    expect(screen.queryByTestId('chart')).toBeNull();
+    expect(
+      screen.getByRole("list", {
+        name: getTdhHistoryMessage(
+          "user.collected.stats.tdhHistory.chartListLabel"
+        ),
+      })
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("chart")).toBeNull();
   });
 
-  it('creates charts from history data', () => {
+  it("creates charts from history data", () => {
     const history: TDHHistory[] = [
       {
-        date: new Date('2024-01-01'),
+        date: new Date("2024-01-01T12:00:00.000Z"),
         boosted_tdh: 1,
         net_boosted_tdh: 2,
         created_boosted_tdh: 3,
         destroyed_boosted_tdh: 4,
       } as TDHHistory,
       {
-        date: new Date('2024-01-02'),
+        date: new Date("2024-01-02T12:00:00.000Z"),
         boosted_tdh: 2,
         net_boosted_tdh: 3,
         created_boosted_tdh: 4,
@@ -31,8 +47,25 @@ describe('UserPageStatsActivityTDHHistoryCharts', () => {
       } as TDHHistory,
     ];
     render(<UserPageStatsActivityTDHHistoryCharts tdhHistory={history} />);
-    const charts = screen.getAllByTestId('chart');
+    const charts = screen.getAllByTestId("chart");
     expect(charts).toHaveLength(4);
-    expect(charts[0]).toHaveTextContent('Total TDH');
+    expect(charts[0]).toHaveTextContent(
+      getTdhHistoryMessage(
+        "user.collected.stats.tdhHistory.charts.totalTdh.title"
+      )
+    );
+    expect(charts[0]).toHaveTextContent(
+      getTdhHistoryMessage(
+        "user.collected.stats.tdhHistory.charts.totalTdh.totalBoosted"
+      )
+    );
+    expect(charts[0]).toHaveAccessibleName(
+      getTdhHistoryMessage("user.collected.stats.tdhHistory.chartAriaLabel", {
+        title: getTdhHistoryMessage(
+          "user.collected.stats.tdhHistory.charts.totalTdh.title"
+        ),
+      })
+    );
+    expect(charts[0]).toHaveTextContent("Jan 2, 2024|Jan 1, 2024");
   });
 });

--- a/__tests__/components/user/stats/activity/wallet/UserPageStatsActivityWalletFilter.test.tsx
+++ b/__tests__/components/user/stats/activity/wallet/UserPageStatsActivityWalletFilter.test.tsx
@@ -1,12 +1,19 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import UserPageStatsActivityWalletFilter from "@/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilter";
-import { UserPageStatsActivityWalletFilterType } from "@/components/user/stats/activity/wallet/UserPageStatsActivityWallet";
+import { UserPageStatsActivityWalletFilterType } from "@/components/user/stats/activity/wallet/UserPageStatsActivityWallet.types";
+import {
+  getWalletActivityFilterLabel,
+  getWalletActivityFilterOptionLabel,
+  getWalletActivityMessage,
+} from "@/components/user/stats/activity/wallet/wallet-activity.messages";
 
 jest.mock("framer-motion", () => ({
   AnimatePresence: ({ children }: any) => <>{children}</>,
-  motion: { div: ({ children }: any) => <div>{children}</div> },
-  useAnimate: () => [ { current: null }, jest.fn() ],
+  LazyMotion: ({ children }: any) => <>{children}</>,
+  domAnimation: {},
+  m: { div: ({ children }: any) => <div>{children}</div> },
+  useAnimate: () => [{ current: null }, jest.fn()],
 }));
 
 jest.mock("react-use", () => ({
@@ -14,10 +21,6 @@ jest.mock("react-use", () => ({
   useKeyPressEvent: jest.fn(),
   useCss: jest.fn(() => ["", jest.fn()]),
 }));
-
-jest.mock("@/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilterItem", () => (props: any) => (
-  <li data-testid="filter-item" onClick={() => props.onFilter(props.filter)}>{props.title}</li>
-));
 
 describe("UserPageStatsActivityWalletFilter", () => {
   it("opens list and selects filter", async () => {
@@ -29,9 +32,38 @@ describe("UserPageStatsActivityWalletFilter", () => {
         setActiveFilter={setActive}
       />
     );
-    await user.click(screen.getByRole("button"));
-    const option = screen.getAllByTestId("filter-item")[1];
-    await user.click(option);
-    expect(setActive).toHaveBeenCalledWith(Object.values(UserPageStatsActivityWalletFilterType)[1]);
+    const trigger = screen.getByRole("button", {
+      name: getWalletActivityMessage(
+        "user.collected.stats.walletActivity.filterButtonLabel",
+        {
+          filter: getWalletActivityFilterLabel(
+            UserPageStatsActivityWalletFilterType.ALL
+          ),
+        }
+      ),
+    });
+
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(
+      screen.getByRole("list", {
+        name: getWalletActivityMessage(
+          "user.collected.stats.walletActivity.filterOptionsLabel"
+        ),
+      })
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: getWalletActivityFilterOptionLabel(
+          UserPageStatsActivityWalletFilterType.AIRDROPS
+        ),
+      })
+    );
+
+    expect(setActive).toHaveBeenCalledWith(
+      UserPageStatsActivityWalletFilterType.AIRDROPS
+    );
   });
 });

--- a/__tests__/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilterItem.test.tsx
+++ b/__tests__/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilterItem.test.tsx
@@ -1,33 +1,50 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import UserPageStatsActivityWalletFilterItem from '@/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilterItem';
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UserPageStatsActivityWalletFilterItem from "@/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilterItem";
+import { UserPageStatsActivityWalletFilterType } from "@/components/user/stats/activity/wallet/UserPageStatsActivityWallet.types";
+import {
+  getWalletActivityFilterLabel,
+  getWalletActivityFilterOptionLabel,
+} from "@/components/user/stats/activity/wallet/wallet-activity.messages";
 
-enum FilterType { ALL = 'ALL', SENT = 'SENT' }
-
-describe('UserPageStatsActivityWalletFilterItem', () => {
-  it('calls onFilter when clicked', async () => {
+describe("UserPageStatsActivityWalletFilterItem", () => {
+  it("calls onFilter when clicked", async () => {
     const onFilter = jest.fn();
+    const filter = UserPageStatsActivityWalletFilterType.ALL;
     render(
       <UserPageStatsActivityWalletFilterItem
-        filter={FilterType.ALL as any}
-        title="All"
-        activeFilter={FilterType.SENT as any}
+        filter={filter}
+        title={getWalletActivityFilterLabel(filter)}
+        ariaLabel={getWalletActivityFilterOptionLabel(filter)}
+        activeFilter={UserPageStatsActivityWalletFilterType.SALES}
         onFilter={onFilter}
       />
     );
-    await userEvent.click(screen.getByText('All'));
-    expect(onFilter).toHaveBeenCalledWith(FilterType.ALL);
+    const button = screen.getByRole("button", {
+      name: getWalletActivityFilterOptionLabel(filter),
+    });
+
+    expect(button).toHaveAttribute("aria-pressed", "false");
+    await userEvent.click(button);
+    expect(onFilter).toHaveBeenCalledWith(filter);
   });
 
-  it('shows check mark when active', () => {
+  it("shows check mark when active", () => {
+    const filter = UserPageStatsActivityWalletFilterType.ALL;
     const { container } = render(
       <UserPageStatsActivityWalletFilterItem
-        filter={FilterType.ALL as any}
-        title="All"
-        activeFilter={FilterType.ALL as any}
+        filter={filter}
+        title={getWalletActivityFilterLabel(filter)}
+        ariaLabel={getWalletActivityFilterOptionLabel(filter)}
+        activeFilter={filter}
         onFilter={jest.fn()}
       />
     );
-    expect(container.querySelector('svg')).not.toBeNull();
+    expect(
+      screen.getByRole("button", {
+        name: getWalletActivityFilterOptionLabel(filter),
+      })
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(container.querySelector("svg")).not.toBeNull();
   });
 });

--- a/__tests__/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable.test.tsx
+++ b/__tests__/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable.test.tsx
@@ -1,24 +1,86 @@
-import { render, screen } from '@testing-library/react';
-import UserPageStatsActivityWalletTable from '@/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable';
-import type { ApiIdentity } from '@/generated/models/ApiIdentity';
-import type { Transaction } from '@/entities/ITransaction';
+import { render, screen } from "@testing-library/react";
+import type { Transaction } from "@/entities/ITransaction";
+import type { ApiIdentity } from "@/generated/models/ApiIdentity";
+import UserPageStatsActivityWalletTable from "@/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable";
+import { getWalletActivityMessage } from "@/components/user/stats/activity/wallet/wallet-activity.messages";
 
-jest.mock('@/components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRow', () => ({
-  __esModule: true,
-  default: jest.fn(() => <tr data-testid="row" />)
-}));
+jest.mock(
+  "@/components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRow",
+  () => ({
+    __esModule: true,
+    default: jest.fn(() => (
+      <tr>
+        <td data-testid="row" />
+      </tr>
+    )),
+  })
+);
 
-const RowMock = require('@/components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRow').default as jest.Mock;
+const RowMock =
+  require("@/components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRow")
+    .default as jest.Mock;
 
-describe('UserPageStatsActivityWalletTable', () => {
-  it('renders a row for each transaction', () => {
+describe("UserPageStatsActivityWalletTable", () => {
+  it("renders a row for each transaction", () => {
     const transactions: Transaction[] = [
-      { from_address: '0x1', to_address: '0x2', transaction: 'tx1', token_id: 1, block: 1, transaction_date: new Date(), created_at: new Date(), from_display: '', to_display: '', contract: '', token_count: 1, value: 0, royalties: 0, gas_gwei: 1, gas_price: 1, gas_price_gwei: 1, gas: 1 },
-      { from_address: '0x3', to_address: '0x4', transaction: 'tx2', token_id: 2, block: 2, transaction_date: new Date(), created_at: new Date(), from_display: '', to_display: '', contract: '', token_count: 1, value: 0, royalties: 0, gas_gwei: 1, gas_price: 1, gas_price_gwei: 1, gas: 1 }
+      {
+        from_address: "0x1",
+        to_address: "0x2",
+        transaction: "tx1",
+        token_id: 1,
+        block: 1,
+        transaction_date: new Date(),
+        created_at: new Date(),
+        from_display: "",
+        to_display: "",
+        contract: "",
+        token_count: 1,
+        value: 0,
+        royalties: 0,
+        gas_gwei: 1,
+        gas_price: 1,
+        gas_price_gwei: 1,
+        gas: 1,
+      },
+      {
+        from_address: "0x3",
+        to_address: "0x4",
+        transaction: "tx2",
+        token_id: 2,
+        block: 2,
+        transaction_date: new Date(),
+        created_at: new Date(),
+        from_display: "",
+        to_display: "",
+        contract: "",
+        token_count: 1,
+        value: 0,
+        royalties: 0,
+        gas_gwei: 1,
+        gas_price: 1,
+        gas_price_gwei: 1,
+        gas: 1,
+      },
     ];
-    const profile = { handle: 'alice' } as ApiIdentity;
-    render(<UserPageStatsActivityWalletTable transactions={transactions} profile={profile} memes={[]} nextgenCollections={[]} />);
+    const profile = { handle: "alice" } as ApiIdentity;
+    render(
+      <UserPageStatsActivityWalletTable
+        transactions={transactions}
+        profile={profile}
+        memes={[]}
+        memeLab={[]}
+        nextgenCollections={[]}
+      />
+    );
+
+    expect(
+      screen.getByRole("table", {
+        name: getWalletActivityMessage(
+          "user.collected.stats.walletActivity.tableCaption"
+        ),
+      })
+    ).toBeInTheDocument();
     expect(RowMock).toHaveBeenCalledTimes(2);
-    expect(screen.getAllByTestId('row')).toHaveLength(2);
+    expect(screen.getAllByTestId("row")).toHaveLength(2);
   });
 });

--- a/__tests__/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper.test.tsx
+++ b/__tests__/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper.test.tsx
@@ -1,35 +1,54 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import UserPageStatsActivityWalletTableWrapper from '@/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper';
-import { UserPageStatsActivityWalletFilterType } from '@/components/user/stats/activity/wallet/UserPageStatsActivityWallet';
+import { render, screen } from "@testing-library/react";
+import UserPageStatsActivityWalletTableWrapper from "@/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper";
+import { UserPageStatsActivityWalletFilterType } from "@/components/user/stats/activity/wallet/UserPageStatsActivityWallet.types";
+import { getWalletActivityEmptyMessage } from "@/components/user/stats/activity/wallet/wallet-activity.messages";
 
-jest.mock('@/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilter', () => (props: any) => (
-  <div data-testid="filter" data-active={props.activeFilter} />
+jest.mock(
+  "@/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilter",
+  () => (props: any) => (
+    <div data-testid="filter" data-active={props.activeFilter} />
+  )
+);
+
+jest.mock(
+  "@/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable",
+  () => () => <div data-testid="table" />
+);
+
+jest.mock(
+  "@/components/utils/table/paginator/CommonTablePagination",
+  () => (props: any) => (
+    <div
+      data-testid="pagination"
+      data-page={props.currentPage}
+      data-total={props.totalPages}
+    />
+  )
+);
+
+jest.mock("@/components/utils/animation/CommonCardSkeleton", () => () => (
+  <div data-testid="skeleton" />
 ));
 
-jest.mock('@/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable', () => () => <div data-testid="table" />);
+jest.mock(
+  "@/components/distribution-plan-tool/common/CircleLoader",
+  () => () => <div data-testid="loader" />
+);
 
-jest.mock('@/components/utils/table/paginator/CommonTablePagination', () => (props: any) => (
-  <div data-testid="pagination" data-page={props.currentPage} data-total={props.totalPages} />
-));
-
-jest.mock('@/components/utils/animation/CommonCardSkeleton', () => () => <div data-testid="skeleton" />);
-
-jest.mock('@/components/distribution-plan-tool/common/CircleLoader', () => () => <div data-testid="loader" />);
-
-describe('UserPageStatsActivityWalletTableWrapper', () => {
-  const profile = { id: 'p' } as any;
+describe("UserPageStatsActivityWalletTableWrapper", () => {
+  const profile = { id: "p" } as any;
   const meme = { id: 1 } as any;
   const collection = { id: 1 } as any;
   const tx = { id: 1 } as any;
 
-  it('shows skeleton during initial load', () => {
+  it("shows skeleton during initial load", () => {
     render(
       <UserPageStatsActivityWalletTableWrapper
         filter={UserPageStatsActivityWalletFilterType.ALL}
         profile={profile}
         transactions={[]}
         memes={[]}
+        memeLab={[]}
         nextgenCollections={[]}
         totalPages={1}
         page={1}
@@ -39,16 +58,17 @@ describe('UserPageStatsActivityWalletTableWrapper', () => {
         onActiveFilter={jest.fn()}
       />
     );
-    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument();
   });
 
-  it('renders table and pagination when data available', () => {
+  it("renders table and pagination when data available", () => {
     render(
       <UserPageStatsActivityWalletTableWrapper
         filter={UserPageStatsActivityWalletFilterType.ALL}
         profile={profile}
         transactions={[tx]}
         memes={[meme]}
+        memeLab={[]}
         nextgenCollections={[collection]}
         totalPages={2}
         page={1}
@@ -58,19 +78,23 @@ describe('UserPageStatsActivityWalletTableWrapper', () => {
         onActiveFilter={jest.fn()}
       />
     );
-    expect(screen.getByTestId('filter')).toHaveAttribute('data-active', UserPageStatsActivityWalletFilterType.ALL);
-    expect(screen.getByTestId('loader')).toBeInTheDocument();
-    expect(screen.getByTestId('table')).toBeInTheDocument();
-    expect(screen.getByTestId('pagination')).toHaveAttribute('data-total', '2');
+    expect(screen.getByTestId("filter")).toHaveAttribute(
+      "data-active",
+      UserPageStatsActivityWalletFilterType.ALL
+    );
+    expect(screen.getByTestId("loader")).toBeInTheDocument();
+    expect(screen.getByTestId("table")).toBeInTheDocument();
+    expect(screen.getByTestId("pagination")).toHaveAttribute("data-total", "2");
   });
 
-  it('shows no data message when list empty', () => {
+  it("shows no data message when list empty", () => {
     render(
       <UserPageStatsActivityWalletTableWrapper
         filter={UserPageStatsActivityWalletFilterType.MINTS}
         profile={profile}
         transactions={[]}
         memes={[]}
+        memeLab={[]}
         nextgenCollections={[]}
         totalPages={1}
         page={1}
@@ -80,6 +104,8 @@ describe('UserPageStatsActivityWalletTableWrapper', () => {
         onActiveFilter={jest.fn()}
       />
     );
-    expect(screen.getByText('No mints')).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      getWalletActivityEmptyMessage(UserPageStatsActivityWalletFilterType.MINTS)
+    );
   });
 });

--- a/__tests__/components/utils/followers/Follower.test.tsx
+++ b/__tests__/components/utils/followers/Follower.test.tsx
@@ -1,11 +1,21 @@
-import type { ReactElement } from "react";
+import React, { type ReactElement } from "react";
 import { render, screen } from "@testing-library/react";
 import Follower from "@/components/utils/followers/Follower";
 import { AuthContext } from "@/components/auth/Auth";
 
 jest.mock("next/link", () => ({
   __esModule: true,
-  default: ({ href, children }: any) => <a href={href}>{children}</a>,
+  default: ({ href, children, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ alt, fill, sizes, unoptimized, ...props }: any) =>
+    React.createElement("img", { alt: alt ?? "", ...props }),
 }));
 
 jest.mock("@/helpers/Helpers", () => ({ cicToType: jest.fn(() => "UNKNOWN") }));
@@ -23,7 +33,14 @@ jest.mock("@/components/user/utils/UserFollowBtn", () => ({
 }));
 
 const baseFollower: any = {
-  identity: { handle: "alice", level: 5, cic: 0, pfp: "pic.png" },
+  identity: {
+    id: "1",
+    handle: "alice",
+    level: 5,
+    cic: 0,
+    pfp: "pic.png",
+    primary_address: "0xalice",
+  },
 };
 
 const renderWithAuth = (ui: ReactElement, connectedProfile: any = null) =>
@@ -47,14 +64,52 @@ const renderWithAuth = (ui: ReactElement, connectedProfile: any = null) =>
 
 test("renders follower info with image", () => {
   render(<Follower follower={baseFollower} />);
-  expect(screen.getByRole("link")).toHaveAttribute("href", "/alice");
-  expect(screen.getByAltText("alice's profile")).toBeInTheDocument();
+  expect(
+    screen.getByRole("link", { name: "View alice's profile" })
+  ).toHaveAttribute("href", "/alice");
+  expect(screen.getByAltText("alice's profile image")).toBeInTheDocument();
   expect(screen.getByTestId("cic")).toHaveTextContent("5");
 });
 
+test.each([
+  ["null", null],
+  ["undefined", undefined],
+])(
+  "falls back to primary address when follower handle is %s",
+  (_label, missingHandle) => {
+    const follower = {
+      identity: {
+        id: "3",
+        handle: missingHandle,
+        level: 2,
+        cic: 0,
+        pfp: "pic.png",
+        primary_address: "0xabc",
+      },
+    } as any;
+
+    render(<Follower follower={follower} />);
+
+    const profileLink = screen.getByRole("link", {
+      name: "View 0xabc's profile",
+    });
+    expect(profileLink).toHaveAttribute("href", "/0xabc");
+    expect(profileLink).toHaveAttribute("aria-label", "View 0xabc's profile");
+    expect(profileLink).toHaveTextContent("0xabc");
+    expect(screen.getByAltText("0xabc's profile image")).toBeInTheDocument();
+  }
+);
+
 test("shows placeholder when no pfp", () => {
   const follower = {
-    identity: { handle: "bob", level: 1, cic: 0, pfp: "" },
+    identity: {
+      id: "2",
+      handle: "bob",
+      level: 1,
+      cic: 0,
+      pfp: "",
+      primary_address: "0xbob",
+    },
   } as any;
   const { container } = render(<Follower follower={follower} />);
   expect(container.querySelector("img")).toBeNull();

--- a/__tests__/components/utils/followers/FollowersList.test.tsx
+++ b/__tests__/components/utils/followers/FollowersList.test.tsx
@@ -32,6 +32,7 @@ describe('FollowersList', () => {
       { identity: { id: '2', handle: 'b' } } as any,
     ];
     render(<FollowersList followers={followers} />);
+    expect(screen.getByRole('list', { name: 'Followers' })).toBeInTheDocument();
     expect(Follower).toHaveBeenCalledTimes(2);
     expect(screen.getAllByTestId('follower').length).toBe(2);
   });

--- a/__tests__/components/utils/followers/FollowersListWrapper.test.tsx
+++ b/__tests__/components/utils/followers/FollowersListWrapper.test.tsx
@@ -21,6 +21,7 @@ describe('FollowersListWrapper', () => {
     const cb = jest.fn();
     render(<FollowersListWrapper followers={[{ id: '1' } as any]} loading={true} onBottomIntersection={cb} />);
     expect(screen.getByTestId('list').textContent).toBe('1');
+    expect(screen.getByRole('status', { name: 'Loading followers' })).toBeInTheDocument();
     expect(screen.getByTestId('loader')).toBeInTheDocument();
     expect(cb).toHaveBeenCalledWith(true);
   });

--- a/__tests__/i18n/messages.test.ts
+++ b/__tests__/i18n/messages.test.ts
@@ -1,6 +1,7 @@
 import {
   compareLocalized,
   formatDate,
+  formatInteger,
   formatNumber,
   formatRelativeTime,
 } from "@/i18n/format";
@@ -52,13 +53,151 @@ describe("frontend i18n helpers", () => {
     ).toBe("View Meme Lab NFT, Meme Lab card #1");
     expect(t("de-DE", "memeLab.sorting.sortBy")).toBe("Sort by");
     expect(
+      t("fr-FR", "memeLab.results.collectionGridLabel", {
+        collectionName: "6529 Intern JPGs",
+      })
+    ).toBe(
+      t("en-US", "memeLab.results.collectionGridLabel", {
+        collectionName: "6529 Intern JPGs",
+      })
+    );
+    expect(
       t("en-US", "rememes.card.linkAriaLabel", {
         name: "ReMeme",
         tokenId: 1,
       })
     ).toBe("View ReMeme, ReMeme #1");
+    expect(t("es-ES", "rememes.results.gridLabel")).toBe(
+      t("en-US", "rememes.results.gridLabel")
+    );
     expect(t("de-DE", "rememes.refresh.ariaLabel")).toBe(
       "Refresh ReMemes results"
+    );
+    expect(t("fr-FR", "user.collected.cards.listLabel")).toBe(
+      t("en-US", "user.collected.cards.listLabel")
+    );
+    expect(t("de-DE", "user.collected.empty.noCards")).toBe(
+      t("en-US", "user.collected.empty.noCards")
+    );
+    expect(t("fr-FR", "user.collected.filters.sortBy")).toBe(
+      t("en-US", "user.collected.filters.sortBy")
+    );
+    expect(
+      t("de-DE", "user.collected.stats.seasons.startedCount", {
+        started: 2,
+        total: 3,
+      })
+    ).toBe(
+      t("en-US", "user.collected.stats.seasons.startedCount", {
+        started: 2,
+        total: 3,
+      })
+    );
+    expect(t("fr-FR", "user.collected.stats.details.unavailable")).toBe(
+      t("en-US", "user.collected.stats.details.unavailable")
+    );
+    expect(
+      t("es-ES", "user.collected.stats.metrics.unique", {
+        value: "465",
+      })
+    ).toBe(
+      t("en-US", "user.collected.stats.metrics.unique", {
+        value: "465",
+      })
+    );
+    expect(t("fr-FR", "user.collected.stats.details.overview")).toBe(
+      t("en-US", "user.collected.stats.details.overview")
+    );
+    expect(
+      t("de-DE", "user.collected.stats.details.tables.overviewCaption")
+    ).toBe(t("en-US", "user.collected.stats.details.tables.overviewCaption"));
+    expect(
+      t("es-ES", "user.collected.stats.details.seasonLabel", {
+        seasonNumber: 1,
+      })
+    ).toBe(
+      t("en-US", "user.collected.stats.details.seasonLabel", {
+        seasonNumber: 1,
+      })
+    );
+    expect(
+      t("fr-FR", "user.collected.stats.details.uniqueProgress", {
+        held: "1",
+        total: "2",
+      })
+    ).toBe("1 / 2");
+    expect(
+      t("de-DE", "user.collected.stats.boostBreakdown.versionLink", {
+        version: "1.4",
+      })
+    ).toBe(
+      t("en-US", "user.collected.stats.boostBreakdown.versionLink", {
+        version: "1.4",
+      })
+    );
+    expect(t("fr-FR", "user.collected.stats.boostBreakdown.tableCaption")).toBe(
+      t("en-US", "user.collected.stats.boostBreakdown.tableCaption")
+    );
+    expect(t("es-ES", "user.collected.stats.activityOverview.title")).toBe(
+      t("en-US", "user.collected.stats.activityOverview.title")
+    );
+    expect(
+      t("de-DE", "user.collected.stats.activityOverview.seasonLabel", {
+        seasonNumber: 1,
+      })
+    ).toBe(
+      t("en-US", "user.collected.stats.activityOverview.seasonLabel", {
+        seasonNumber: 1,
+      })
+    );
+    expect(t("fr-FR", "user.collected.stats.activityTabs.walletActivity")).toBe(
+      t("en-US", "user.collected.stats.activityTabs.walletActivity")
+    );
+    expect(t("de-DE", "user.collected.stats.activityTabs.listLabel")).toBe(
+      t("en-US", "user.collected.stats.activityTabs.listLabel")
+    );
+    expect(t("fr-FR", "user.collected.stats.walletActivity.title")).toBe(
+      t("en-US", "user.collected.stats.walletActivity.title")
+    );
+    expect(
+      t("de-DE", "user.collected.stats.walletActivity.filterButtonLabel", {
+        filter: "All",
+      })
+    ).toBe("Wallet activity filter: All");
+    expect(t("es-ES", "user.collected.stats.walletActivity.empty.mints")).toBe(
+      t("en-US", "user.collected.stats.walletActivity.empty.mints")
+    );
+    expect(t("fr-FR", "user.collected.stats.distributions.title")).toBe(
+      t("en-US", "user.collected.stats.distributions.title")
+    );
+    expect(
+      t("de-DE", "user.collected.stats.distributions.tokenLinkAriaLabel", {
+        collection: "The Memes",
+        tokenId: 1,
+      })
+    ).toBe("View The Memes token #1");
+    expect(t("fr-FR", "user.collected.stats.tdhHistory.title")).toBe(
+      t("en-US", "user.collected.stats.tdhHistory.title")
+    );
+    expect(
+      t("es-ES", "user.collected.stats.tdhHistory.chartAriaLabel", {
+        title: "Total TDH",
+      })
+    ).toBe("Total TDH chart");
+    expect(t("fr-FR", "user.profile.tabs.navigationLabel")).toBe(
+      t("en-US", "user.profile.tabs.navigationLabel")
+    );
+    expect(t("de-DE", "user.profile.tabs.badges.beta")).toBe("Beta");
+    expect(t("fr-FR", "followers.modal.title")).toBe(
+      t("en-US", "followers.modal.title")
+    );
+    expect(
+      t("de-DE", "followers.profile.linkAriaLabel", {
+        handle: "alice",
+      })
+    ).toBe("View alice's profile");
+    expect(t("es-ES", "user.collected.networkCards.empty")).toBe(
+      t("en-US", "user.collected.networkCards.empty")
     );
     expect(t("de-DE", "theMemes.detail.live.market.title")).toBe(
       t("en-US", "theMemes.detail.live.market.title")
@@ -80,8 +219,83 @@ describe("frontend i18n helpers", () => {
     expect(t("de-DE", "theMemes.detail.timeline.region")).toBe(
       t("en-US", "theMemes.detail.timeline.region")
     );
+    expect(t("fr-FR", "theMemes.detail.references.rememes.description")).toBe(
+      t("en-US", "theMemes.detail.references.rememes.description")
+    );
+    expect(
+      t("es-ES", "theMemes.detail.references.sort.trigger", {
+        sort: t("es-ES", "rememes.sort.random"),
+      })
+    ).toBe(`Sort: ${t("es-ES", "rememes.sort.random")}`);
+    expect(t("fr-FR", "theMemes.detail.art.media.fullscreen")).toBe(
+      t("en-US", "theMemes.detail.art.media.fullscreen")
+    );
+    expect(t("de-DE", "theMemes.detail.art.sections.arweaveLinks")).toBe(
+      t("en-US", "theMemes.detail.art.sections.arweaveLinks")
+    );
+    expect(
+      t("es-ES", "theMemes.detail.art.download.downloadingProgress", {
+        percentage: formatInteger("es-ES", 50),
+      })
+    ).toBe(
+      t("en-US", "theMemes.detail.art.download.downloadingProgress", {
+        percentage: formatInteger("en-US", 50),
+      })
+    );
     expect(t("fr-FR", "timeline.links.uriAriaLabel")).toBe(
       t("en-US", "timeline.links.uriAriaLabel")
+    );
+    expect(t("de-DE", "memeCalendar.periods.positionLabel")).toBe(
+      t("en-US", "memeCalendar.periods.positionLabel")
+    );
+    expect(
+      t("fr-FR", "memeCalendar.periods.seasonLinkAriaLabel", {
+        season: 1,
+      })
+    ).toBe(
+      t("en-US", "memeCalendar.periods.seasonLinkAriaLabel", {
+        season: 1,
+      })
+    );
+    expect(t("es-ES", "memeCalendar.timezone.showLocal")).toBe(
+      t("en-US", "memeCalendar.timezone.showLocal")
+    );
+    expect(
+      t("de-DE", "memeCalendar.overview.upcoming.currentSeason", {
+        season: 14,
+      })
+    ).toBe(
+      t("en-US", "memeCalendar.overview.upcoming.currentSeason", {
+        season: 14,
+      })
+    );
+    expect(t("fr-FR", "memeCalendar.invites.addToCalendar")).toBe(
+      t("en-US", "memeCalendar.invites.addToCalendar")
+    );
+    expect(t("es-ES", "memeCalendar.overview.upcoming.mintTime")).toBe(
+      t("en-US", "memeCalendar.overview.upcoming.mintTime")
+    );
+    expect(t("de-DE", "memeCalendar.grid.previous", { division: "SZN" })).toBe(
+      t("en-US", "memeCalendar.grid.previous", { division: "SZN" })
+    );
+    expect(
+      t("fr-FR", "memeCalendar.grid.cardAriaLabel", {
+        title: "SZN #14",
+        range: "Jan 2026 - Mar 2026",
+        mints: "Memes #123 - #456",
+      })
+    ).toBe(
+      t("en-US", "memeCalendar.grid.cardAriaLabel", {
+        title: "SZN #14",
+        range: "Jan 2026 - Mar 2026",
+        mints: "Memes #123 - #456",
+      })
+    );
+    const timelineMediaParams = {
+      label: t("en-US", "timeline.fields.addedImage"),
+    };
+    expect(t("es-ES", "timeline.media.imageAlt", timelineMediaParams)).toBe(
+      t("en-US", "timeline.media.imageAlt", timelineMediaParams)
     );
     expect(
       t("de-DE", "rememes.detail.documentTitle", {

--- a/__tests__/i18n/messages.test.ts
+++ b/__tests__/i18n/messages.test.ts
@@ -77,6 +77,12 @@ describe("frontend i18n helpers", () => {
     ).toBe(
       t("en-US", "theMemes.detail.activity.table.caption", { tokenId: 1 })
     );
+    expect(t("de-DE", "theMemes.detail.timeline.region")).toBe(
+      t("en-US", "theMemes.detail.timeline.region")
+    );
+    expect(t("fr-FR", "timeline.links.uriAriaLabel")).toBe(
+      t("en-US", "timeline.links.uriAriaLabel")
+    );
     expect(
       t("de-DE", "rememes.detail.documentTitle", {
         name: "Meme",

--- a/app/meme-calendar/page.tsx
+++ b/app/meme-calendar/page.tsx
@@ -1,18 +1,36 @@
 import MemesMintingCalendar from "@/components/meme-calendar/MemesMintingCalendar";
 import { getAppMetadata } from "@/components/providers/metadata";
+import { normalizeLocale } from "@/i18n/locales";
 import type { Metadata } from "next";
 import { Col, Container, Row } from "react-bootstrap";
+
+type MemeCalendarPageSearchParams = Promise<{
+  readonly locale?: string | string[] | undefined;
+}>;
 
 export async function generateMetadata(): Promise<Metadata> {
   return getAppMetadata({ title: "Memes Minting Calendar" });
 }
 
-export default function MemesMintingCalendarPage() {
+function getFirstSearchParamValue(
+  value: string | string[] | undefined
+): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export default async function MemesMintingCalendarPage({
+  searchParams,
+}: {
+  readonly searchParams: MemeCalendarPageSearchParams;
+}) {
+  const { locale } = await searchParams;
+  const resolvedLocale = normalizeLocale(getFirstSearchParamValue(locale));
+
   return (
-    <Container className="tw-pt-6 tw-pb-8">
+    <Container className="tw-pb-8 tw-pt-6">
       <Row>
         <Col>
-          <MemesMintingCalendar />
+          <MemesMintingCalendar locale={resolvedLocale} />
         </Col>
       </Row>
     </Container>

--- a/components/download/Download.tsx
+++ b/components/download/Download.tsx
@@ -8,7 +8,7 @@ import {
   faXmarkCircle,
   faCheckCircle,
 } from "@fortawesome/free-solid-svg-icons";
-import { useEffect, useRef, useState } from "react";
+import { type MouseEvent, useEffect, useReducer, useRef } from "react";
 import { ArrowDownTrayIcon } from "@heroicons/react/24/outline";
 
 interface Props {
@@ -19,20 +19,197 @@ interface Props {
   className?: string | undefined;
   variant?: "default" | "text" | undefined;
   alwaysShowText?: boolean | undefined;
+  labels?: Partial<DownloadLabels> | undefined;
+}
+
+export type DownloadLabels = {
+  readonly cancelDownload: string;
+  readonly complete: string;
+  readonly dismissComplete: string;
+  readonly download: string;
+  readonly downloadComplete: string;
+  readonly downloadFile: string;
+  readonly downloading: string;
+  readonly downloadingFile: string;
+  readonly downloadingProgress: (percentage: number) => string;
+};
+
+const DEFAULT_DOWNLOAD_LABELS: DownloadLabels = {
+  cancelDownload: "Cancel download",
+  complete: "Complete",
+  dismissComplete: "Dismiss download complete",
+  download: "Download",
+  downloadComplete: "Download complete",
+  downloadFile: "Download file",
+  downloading: "Downloading...",
+  downloadingFile: "Downloading file",
+  downloadingProgress: (percentage) => `Downloading ${percentage}%`,
+};
+
+function getDownloadLabels(
+  labels: Partial<DownloadLabels> | undefined
+): DownloadLabels {
+  return {
+    cancelDownload:
+      labels?.cancelDownload ?? DEFAULT_DOWNLOAD_LABELS.cancelDownload,
+    complete: labels?.complete ?? DEFAULT_DOWNLOAD_LABELS.complete,
+    dismissComplete:
+      labels?.dismissComplete ?? DEFAULT_DOWNLOAD_LABELS.dismissComplete,
+    download: labels?.download ?? DEFAULT_DOWNLOAD_LABELS.download,
+    downloadComplete:
+      labels?.downloadComplete ?? DEFAULT_DOWNLOAD_LABELS.downloadComplete,
+    downloadFile: labels?.downloadFile ?? DEFAULT_DOWNLOAD_LABELS.downloadFile,
+    downloading: labels?.downloading ?? DEFAULT_DOWNLOAD_LABELS.downloading,
+    downloadingFile:
+      labels?.downloadingFile ?? DEFAULT_DOWNLOAD_LABELS.downloadingFile,
+    downloadingProgress:
+      labels?.downloadingProgress ??
+      DEFAULT_DOWNLOAD_LABELS.downloadingProgress,
+  };
+}
+
+type CompletionAction = "show" | "hide";
+
+function completionReducer(
+  _isCompleted: boolean,
+  action: CompletionAction
+): boolean {
+  return action === "show";
+}
+
+type DownloadContentProps = {
+  readonly alwaysShowText?: boolean | undefined;
+  readonly isCompleted: boolean;
+  readonly isInProgress: boolean;
+  readonly labels: DownloadLabels;
+  readonly normalizedPercentage: number | null;
+  readonly onCancel: () => void;
+  readonly onDismissComplete: () => void;
+  readonly onStartDownload: () => void;
+  readonly showProgress: boolean;
+  readonly variant: "default" | "text";
+};
+
+function DownloadContent({
+  alwaysShowText,
+  isCompleted,
+  isInProgress,
+  labels,
+  normalizedPercentage,
+  onCancel,
+  onDismissComplete,
+  onStartDownload,
+  showProgress,
+  variant,
+}: DownloadContentProps) {
+  function handleDownloadClick(event: MouseEvent<HTMLButtonElement>) {
+    event.stopPropagation();
+    onStartDownload();
+  }
+
+  if (isCompleted) {
+    return (
+      <div
+        className="tw-inline-flex tw-h-9 tw-flex-shrink-0 tw-items-center tw-justify-center tw-gap-2 tw-rounded-full tw-border-0 tw-bg-iron-900 tw-px-3 tw-text-white tw-transition tw-duration-300 tw-ease-out"
+        aria-label={labels.downloadComplete}
+      >
+        <span className="tw-text-sm tw-font-medium tw-leading-[2.25rem]">
+          {labels.complete}
+        </span>
+        <button
+          aria-label={labels.dismissComplete}
+          type="button"
+          onClick={onDismissComplete}
+          className="tw-flex tw-cursor-pointer tw-items-center tw-justify-center tw-border-0 tw-bg-transparent tw-p-0 tw-text-white"
+        >
+          <FontAwesomeIcon
+            aria-hidden="true"
+            icon={faCheckCircle}
+            className="tw-h-5 tw-w-5 tw-flex-shrink-0"
+          />
+        </button>
+      </div>
+    );
+  }
+
+  if (!isInProgress || !showProgress) {
+    if (variant === "text") {
+      return (
+        <button
+          onClick={handleDownloadClick}
+          className="tw-flex tw-min-h-6 tw-cursor-pointer tw-items-center tw-gap-1.5 tw-border-0 tw-bg-transparent tw-text-xs tw-font-medium tw-text-iron-500 tw-transition-colors tw-duration-300 desktop-hover:hover:tw-text-iron-100"
+          aria-label={labels.downloadFile}
+          type="button"
+        >
+          <ArrowDownTrayIcon
+            aria-hidden="true"
+            className="tw-h-4 tw-w-4 tw-flex-shrink-0"
+          />
+          <span className={alwaysShowText ? "" : "tw-hidden sm:tw-inline"}>
+            {labels.download}
+          </span>
+        </button>
+      );
+    }
+
+    return (
+      <button
+        onClick={handleDownloadClick}
+        className="tw-inline-flex tw-size-9 tw-flex-shrink-0 tw-cursor-pointer tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-bg-iron-900 tw-transition tw-duration-300 tw-ease-out desktop-hover:hover:tw-bg-iron-800"
+        aria-label={labels.downloadFile}
+        type="button"
+      >
+        <FontAwesomeIcon
+          aria-hidden="true"
+          icon={faDownload}
+          className="tw-h-4 tw-w-4 tw-flex-shrink-0 tw-text-white"
+        />
+      </button>
+    );
+  }
+
+  return (
+    <div
+      className="tw-inline-flex tw-h-9 tw-flex-shrink-0 tw-items-center tw-justify-center tw-gap-2 tw-rounded-full tw-border-0 tw-bg-iron-900 tw-px-3 tw-text-white tw-transition tw-duration-300 tw-ease-out"
+      aria-label={labels.downloadingFile}
+    >
+      <span className="tw-text-sm tw-font-medium tw-leading-[2.25rem]">
+        {normalizedPercentage === null
+          ? labels.downloading
+          : labels.downloadingProgress(normalizedPercentage)}
+      </span>
+      <button
+        aria-label={labels.cancelDownload}
+        type="button"
+        onClick={onCancel}
+        className="tw-flex tw-cursor-pointer tw-items-center tw-justify-center tw-border-0 tw-bg-transparent tw-p-0 tw-text-white"
+      >
+        <FontAwesomeIcon
+          aria-hidden="true"
+          icon={faXmarkCircle}
+          className="tw-h-5 tw-w-5 tw-flex-shrink-0"
+        />
+      </button>
+    </div>
+  );
 }
 
 export default function Download(props: Readonly<Props>) {
   const { percentage, download, cancel, isInProgress } = useDownloader();
   const showProgress = props.showProgress ?? true;
   const variant = props.variant ?? "default";
+  const labels = getDownloadLabels(props.labels);
   const normalizedPercentage = Number.isFinite(percentage)
     ? Math.min(Math.max(percentage, 0), 100)
     : null;
 
-  const [isCompleted, setIsCompleted] = useState(false);
+  const [isCompleted, dispatchCompletion] = useReducer(
+    completionReducer,
+    false
+  );
   const completionTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  async function startDownload() {
+  function startDownload() {
     const filename = props.extension
       ? `${props.name}.${props.extension}`
       : props.name;
@@ -41,12 +218,12 @@ export default function Download(props: Readonly<Props>) {
 
   useEffect(() => {
     if (normalizedPercentage === 100 && showProgress) {
-      setIsCompleted(true);
+      dispatchCompletion("show");
       if (completionTimeoutRef.current) {
         clearTimeout(completionTimeoutRef.current);
       }
       completionTimeoutRef.current = setTimeout(() => {
-        setIsCompleted(false);
+        dispatchCompletion("hide");
         completionTimeoutRef.current = null;
       }, 1500);
     }
@@ -60,86 +237,20 @@ export default function Download(props: Readonly<Props>) {
     };
   }, []);
 
-  const renderContent = () => {
-    if (isCompleted) {
-      return (
-        <div
-          className="tw-inline-flex tw-h-9 tw-flex-shrink-0 tw-items-center tw-justify-center tw-gap-2 tw-rounded-full tw-border-0 tw-bg-iron-900 tw-px-3 tw-text-white tw-transition tw-duration-300 tw-ease-out"
-          aria-label="Download complete"
-        >
-          <span className="tw-text-sm tw-font-medium tw-leading-[2.25rem]">
-            Complete
-          </span>
-          <FontAwesomeIcon
-            icon={faCheckCircle}
-            className="tw-h-5 tw-w-5 tw-flex-shrink-0 tw-cursor-pointer tw-text-white"
-            onClick={() => setIsCompleted(false)}
-          />
-        </div>
-      );
-    }
-
-    if (!isInProgress || !showProgress) {
-      if (variant === "text") {
-        return (
-          <button
-            onClick={(e) => {
-              e.stopPropagation();
-              startDownload();
-            }}
-            className="tw-flex tw-cursor-pointer tw-items-center tw-gap-1.5 tw-border-0 tw-bg-transparent tw-text-xs tw-font-medium tw-text-iron-500 tw-transition-colors tw-duration-300 desktop-hover:hover:tw-text-iron-100"
-            aria-label="Download file"
-            type="button"
-          >
-            <ArrowDownTrayIcon className="tw-h-4 tw-w-4 tw-flex-shrink-0" />
-            <span
-              className={props.alwaysShowText ? "" : "tw-hidden sm:tw-inline"}
-            >
-              Download
-            </span>
-          </button>
-        );
-      }
-      return (
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            startDownload();
-          }}
-          className="tw-inline-flex tw-size-9 tw-flex-shrink-0 tw-cursor-pointer tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-bg-iron-900 tw-transition tw-duration-300 tw-ease-out desktop-hover:hover:tw-bg-iron-800"
-          aria-label="Download file"
-          type="button"
-        >
-          <FontAwesomeIcon
-            icon={faDownload}
-            className="tw-h-4 tw-w-4 tw-flex-shrink-0 tw-text-white"
-          />
-        </button>
-      );
-    }
-
-    return (
-      <div
-        className="tw-inline-flex tw-h-9 tw-flex-shrink-0 tw-items-center tw-justify-center tw-gap-2 tw-rounded-full tw-border-0 tw-bg-iron-900 tw-px-3 tw-text-white tw-transition tw-duration-300 tw-ease-out"
-        aria-label="Downloading file"
-      >
-        <span className="tw-text-sm tw-font-medium tw-leading-[2.25rem]">
-          {normalizedPercentage === null
-            ? "Downloading..."
-            : `Downloading ${normalizedPercentage}%`}
-        </span>
-        <FontAwesomeIcon
-          icon={faXmarkCircle}
-          className="tw-h-5 tw-w-5 tw-flex-shrink-0 tw-cursor-pointer tw-text-white"
-          onClick={() => cancel()}
-        />
-      </div>
-    );
-  };
-
   return (
     <div className={`${styles["download"]} ${props.className ?? ""}`}>
-      {renderContent()}
+      <DownloadContent
+        alwaysShowText={props.alwaysShowText}
+        isCompleted={isCompleted}
+        isInProgress={isInProgress}
+        labels={labels}
+        normalizedPercentage={normalizedPercentage}
+        onCancel={cancel}
+        onDismissComplete={() => dispatchCompletion("hide")}
+        onStartDownload={startDownload}
+        showProgress={showProgress}
+        variant={variant}
+      />
     </div>
   );
 }

--- a/components/drops/view/item/content/media/MediaActionToolbar.tsx
+++ b/components/drops/view/item/content/media/MediaActionToolbar.tsx
@@ -13,6 +13,20 @@ import type React from "react";
 const BASE_BUTTON_CLASS =
   "tw-inline-flex tw-size-9 tw-items-center tw-justify-center tw-border-0 tw-bg-transparent tw-text-iron-100 tw-transition tw-duration-200 desktop-hover:hover:tw-bg-iron-700 disabled:tw-cursor-default disabled:tw-opacity-60";
 
+export type MediaActionLabels = {
+  readonly close?: string | undefined;
+  readonly download?: string | undefined;
+  readonly downloading?: string | undefined;
+  readonly fullscreen?: string | undefined;
+};
+
+const DEFAULT_MEDIA_ACTION_LABELS = {
+  close: "Close media",
+  download: "Download media",
+  downloading: "Downloading media",
+  fullscreen: "Full screen",
+} satisfies Required<MediaActionLabels>;
+
 function ToolbarButton({
   label,
   onClick,
@@ -40,6 +54,15 @@ function ToolbarButton({
   );
 }
 
+function getMediaActionLabels(labels?: MediaActionLabels | undefined) {
+  return {
+    close: labels?.close ?? DEFAULT_MEDIA_ACTION_LABELS.close,
+    download: labels?.download ?? DEFAULT_MEDIA_ACTION_LABELS.download,
+    downloading: labels?.downloading ?? DEFAULT_MEDIA_ACTION_LABELS.downloading,
+    fullscreen: labels?.fullscreen ?? DEFAULT_MEDIA_ACTION_LABELS.fullscreen,
+  };
+}
+
 const stopAndRun =
   (handler: () => void) => (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -55,6 +78,7 @@ export function InlineMediaActions({
   fullscreenTargetAvailable,
   variant,
   position = "top-right",
+  labels,
 }: {
   readonly onDownload?: (() => void) | undefined;
   readonly onOpen?: (() => void) | undefined;
@@ -64,7 +88,9 @@ export function InlineMediaActions({
   readonly fullscreenTargetAvailable?: boolean | undefined;
   readonly variant: "image" | "video" | "html";
   readonly position?: "top-right" | "bottom-right" | undefined;
+  readonly labels?: MediaActionLabels | undefined;
 }) {
+  const actionLabels = getMediaActionLabels(labels);
   const canFullscreen =
     (variant === "image" || variant === "html") &&
     Boolean(onFullscreen) &&
@@ -83,7 +109,10 @@ export function InlineMediaActions({
       )}
     >
       {canFullscreen && (
-        <ToolbarButton label="Full screen" onClick={stopAndRun(onFullscreen!)}>
+        <ToolbarButton
+          label={actionLabels.fullscreen}
+          onClick={stopAndRun(onFullscreen!)}
+        >
           <ArrowsPointingOutIcon className="tw-size-4" aria-hidden="true" />
         </ToolbarButton>
       )}
@@ -94,7 +123,9 @@ export function InlineMediaActions({
       )}
       {onDownload && (
         <ToolbarButton
-          label={isDownloading ? "Downloading media" : "Download media"}
+          label={
+            isDownloading ? actionLabels.downloading : actionLabels.download
+          }
           onClick={stopAndRun(onDownload)}
           disabled={isDownloading}
         >
@@ -113,6 +144,7 @@ export function ExpandedMediaToolbar({
   openLabel,
   isDownloading,
   fullscreenTargetAvailable,
+  labels,
 }: {
   readonly onOpen?: (() => void) | undefined;
   readonly onDownload: () => void;
@@ -121,7 +153,9 @@ export function ExpandedMediaToolbar({
   readonly openLabel?: string | undefined;
   readonly isDownloading: boolean;
   readonly fullscreenTargetAvailable?: boolean | undefined;
+  readonly labels?: MediaActionLabels | undefined;
 }) {
+  const actionLabels = getMediaActionLabels(labels);
   const canFullscreen =
     Boolean(onFullscreen) &&
     Boolean(fullscreenTargetAvailable) &&
@@ -132,7 +166,7 @@ export function ExpandedMediaToolbar({
       <div className="tw-flex tw-overflow-hidden tw-rounded-xl tw-bg-iron-900/95 tw-shadow-lg tw-shadow-black/30 tw-ring-1 tw-ring-inset tw-ring-iron-700/70 tw-backdrop-blur">
         {canFullscreen && (
           <ToolbarButton
-            label="Full screen"
+            label={actionLabels.fullscreen}
             onClick={stopAndRun(onFullscreen!)}
           >
             <ArrowsPointingOutIcon className="tw-size-5" aria-hidden="true" />
@@ -147,7 +181,9 @@ export function ExpandedMediaToolbar({
           </ToolbarButton>
         )}
         <ToolbarButton
-          label={isDownloading ? "Downloading media" : "Download media"}
+          label={
+            isDownloading ? actionLabels.downloading : actionLabels.download
+          }
           onClick={stopAndRun(onDownload)}
           disabled={isDownloading}
         >
@@ -156,8 +192,8 @@ export function ExpandedMediaToolbar({
       </div>
       <button
         type="button"
-        aria-label="Close media"
-        title="Close media"
+        aria-label={actionLabels.close}
+        title={actionLabels.close}
         onClick={stopAndRun(onClose)}
         className="tw-inline-flex tw-size-9 tw-items-center tw-justify-center tw-rounded-xl tw-border-0 tw-bg-iron-900/95 tw-text-iron-100 tw-shadow-lg tw-shadow-black/30 tw-ring-1 tw-ring-inset tw-ring-iron-700/70 tw-backdrop-blur tw-transition tw-duration-200 desktop-hover:hover:tw-bg-iron-700"
       >

--- a/components/drops/view/item/content/media/useMediaActions.ts
+++ b/components/drops/view/item/content/media/useMediaActions.ts
@@ -11,6 +11,11 @@ import { useCallback, useState } from "react";
 const DIRECT_OPEN_UNSUPPORTED_EXTENSIONS = new Set(["mov", "qt"]);
 const DIRECT_OPEN_UNSUPPORTED_MIME_TYPES = new Set(["video/quicktime"]);
 
+export type MediaOpenLabels = {
+  readonly openInBrowser?: string | undefined;
+  readonly openInNewTab?: string | undefined;
+};
+
 function getUrlExtension(url: string): string | null {
   try {
     const pathname = new URL(url, globalThis.window.location.origin).pathname;
@@ -49,11 +54,13 @@ export function useMediaActions({
   fallbackFileName,
   dialogTitle = "Save file",
   mimeType,
+  labels,
 }: {
   readonly url: string;
   readonly fallbackFileName: string;
   readonly dialogTitle?: string | undefined;
   readonly mimeType?: string | undefined;
+  readonly labels?: MediaOpenLabels | undefined;
 }) {
   const { isCapacitor } = useCapacitor();
   const [isDownloading, setIsDownloading] = useState(false);
@@ -62,7 +69,9 @@ export function useMediaActions({
   let openLabel: string | undefined;
 
   if (canOpen) {
-    openLabel = isCapacitor ? "Open in browser" : "Open in new tab";
+    openLabel = isCapacitor
+      ? (labels?.openInBrowser ?? "Open in browser")
+      : (labels?.openInNewTab ?? "Open in new tab");
   }
 
   const openMedia = useCallback(() => {

--- a/components/meme-calendar/MemeCalendar.tsx
+++ b/components/meme-calendar/MemeCalendar.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import useIsMobileScreen from "@/hooks/isMobileScreen";
+import { formatInteger } from "@/i18n/format";
+import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
 import {
   faCaretLeft,
   faCaretRight,
@@ -10,8 +13,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useEffect, useState, type FormEvent } from "react";
 import { Tooltip } from "react-tooltip";
-import type { DisplayTz ,
-  ZoomLevel} from "./meme-calendar.helpers";
+import type { DisplayTz, ZoomLevel } from "./meme-calendar.helpers";
 import {
   addMonths,
   dateFromMintNumber,
@@ -43,7 +45,7 @@ import {
   SZN1_RANGE,
   SZN1_SEASON_INDEX,
   toISO,
-  ymd
+  ymd,
 } from "./meme-calendar.helpers";
 import { getMintOverrideNoteForUtcDay } from "./meme-calendar.overrides";
 import { getHistoricalMintsOnUtcDay } from "./meme-calendar.szn1";
@@ -68,31 +70,280 @@ function escapeHtml(value: string): string {
     .replaceAll("'", "&#39;");
 }
 
-function getZoomTitle(zoom: ZoomLevel, seasonIndex: number): string {
-  const seasonNumber =
-    displayedSeasonNumberFromIndex(seasonIndex).toLocaleString();
-  const yearNumber = displayedYearNumberFromIndex(seasonIndex).toLocaleString();
-  const epochNumber =
-    displayedEpochNumberFromIndex(seasonIndex).toLocaleString();
-  const periodNumber =
-    displayedPeriodNumberFromIndex(seasonIndex).toLocaleString();
-  const eraNumber = displayedEraNumberFromIndex(seasonIndex).toLocaleString();
-  const eonNumber = displayedEonNumberFromIndex(seasonIndex).toLocaleString();
+const ZOOM_LEVELS: readonly ZoomLevel[] = [
+  "szn",
+  "year",
+  "epoch",
+  "period",
+  "era",
+  "eon",
+];
 
+const ZOOM_MESSAGE_KEYS: Record<
+  ZoomLevel,
+  {
+    readonly division: MessageKey;
+    readonly title: MessageKey;
+    readonly zoom: MessageKey;
+  }
+> = {
+  szn: {
+    division: "memeCalendar.grid.division.szn",
+    title: "memeCalendar.grid.title.szn",
+    zoom: "memeCalendar.grid.zoom.szn",
+  },
+  year: {
+    division: "memeCalendar.grid.division.year",
+    title: "memeCalendar.grid.title.year",
+    zoom: "memeCalendar.grid.zoom.year",
+  },
+  epoch: {
+    division: "memeCalendar.grid.division.epoch",
+    title: "memeCalendar.grid.title.epoch",
+    zoom: "memeCalendar.grid.zoom.epoch",
+  },
+  period: {
+    division: "memeCalendar.grid.division.period",
+    title: "memeCalendar.grid.title.period",
+    zoom: "memeCalendar.grid.zoom.period",
+  },
+  era: {
+    division: "memeCalendar.grid.division.era",
+    title: "memeCalendar.grid.title.era",
+    zoom: "memeCalendar.grid.zoom.era",
+  },
+  eon: {
+    division: "memeCalendar.grid.division.eon",
+    title: "memeCalendar.grid.title.eon",
+    zoom: "memeCalendar.grid.zoom.eon",
+  },
+};
+
+const GRID_INFO_ITEMS: ReadonlyArray<{
+  readonly label: MessageKey;
+  readonly text: MessageKey;
+  readonly note?: MessageKey;
+}> = [
+  {
+    label: "memeCalendar.grid.info.mintingDays.label",
+    text: "memeCalendar.grid.info.mintingDays.text",
+  },
+  {
+    label: "memeCalendar.grid.info.szn.label",
+    text: "memeCalendar.grid.info.szn.text",
+    note: "memeCalendar.grid.info.szn.note",
+  },
+  {
+    label: "memeCalendar.grid.info.year.label",
+    text: "memeCalendar.grid.info.year.text",
+    note: "memeCalendar.grid.info.year.note",
+  },
+  {
+    label: "memeCalendar.grid.info.epoch.label",
+    text: "memeCalendar.grid.info.epoch.text",
+    note: "memeCalendar.grid.info.epoch.note",
+  },
+  {
+    label: "memeCalendar.grid.info.period.label",
+    text: "memeCalendar.grid.info.period.text",
+    note: "memeCalendar.grid.info.period.note",
+  },
+  {
+    label: "memeCalendar.grid.info.era.label",
+    text: "memeCalendar.grid.info.era.text",
+    note: "memeCalendar.grid.info.era.note",
+  },
+  {
+    label: "memeCalendar.grid.info.eon.label",
+    text: "memeCalendar.grid.info.eon.text",
+    note: "memeCalendar.grid.info.eon.note",
+  },
+  {
+    label: "memeCalendar.grid.info.yearZero.label",
+    text: "memeCalendar.grid.info.yearZero.text",
+    note: "memeCalendar.grid.info.yearZero.note",
+  },
+] as const;
+
+function getZoomNumber(zoom: ZoomLevel, seasonIndex: number): number {
   switch (zoom) {
     case "szn":
-      return `SZN #${seasonNumber}`;
+      return displayedSeasonNumberFromIndex(seasonIndex);
     case "year":
-      return `Year #${yearNumber}`;
+      return displayedYearNumberFromIndex(seasonIndex);
     case "epoch":
-      return `Epoch #${epochNumber}`;
+      return displayedEpochNumberFromIndex(seasonIndex);
     case "period":
-      return `Period #${periodNumber}`;
+      return displayedPeriodNumberFromIndex(seasonIndex);
     case "era":
-      return `Era #${eraNumber}`;
+      return displayedEraNumberFromIndex(seasonIndex);
     case "eon":
-      return `Eon #${eonNumber}`;
+      return displayedEonNumberFromIndex(seasonIndex);
   }
+}
+
+function getZoomLabel(
+  locale: SupportedLocale,
+  zoom: ZoomLevel,
+  value: number
+): string {
+  return t(locale, ZOOM_MESSAGE_KEYS[zoom].zoom, {
+    value: formatInteger(locale, value),
+  });
+}
+
+function getZoomTitle(
+  locale: SupportedLocale,
+  zoom: ZoomLevel,
+  seasonIndex: number
+): string {
+  const value = formatInteger(locale, getZoomNumber(zoom, seasonIndex));
+  return t(locale, ZOOM_MESSAGE_KEYS[zoom].title, { value });
+}
+
+function getDivisionName(locale: SupportedLocale, zoom: ZoomLevel): string {
+  return t(locale, ZOOM_MESSAGE_KEYS[zoom].division);
+}
+
+function getDivisionTitle(
+  locale: SupportedLocale,
+  zoom: ZoomLevel,
+  value: number
+): string {
+  return t(locale, ZOOM_MESSAGE_KEYS[zoom].title, {
+    value: formatInteger(locale, value),
+  });
+}
+
+function formatCalendarYear(locale: SupportedLocale, year: number): string {
+  return new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 0,
+    useGrouping: false,
+  }).format(year);
+}
+
+function getDivisionTitleWithGregorianYear(
+  locale: SupportedLocale,
+  zoom: ZoomLevel,
+  value: number,
+  year: number
+): string {
+  return t(locale, "memeCalendar.grid.titleWithGregorianYear", {
+    title: getDivisionTitle(locale, zoom, value),
+    year: formatCalendarYear(locale, year),
+  });
+}
+
+function getDateRangeLabel(
+  locale: SupportedLocale,
+  start: Date,
+  end: Date
+): string {
+  return t(locale, "memeCalendar.grid.dateRange", {
+    start: formatUtcMonthYear(start, "short", locale),
+    end: formatUtcMonthYear(end, "short", locale),
+  });
+}
+
+function getMemeRangeLabel(
+  locale: SupportedLocale,
+  start: number,
+  end: number
+): string {
+  return t(locale, "memeCalendar.grid.memeRange", {
+    start: formatInteger(locale, start),
+    end: formatInteger(locale, end),
+  });
+}
+
+function getDrilldownCardAriaLabel(
+  locale: SupportedLocale,
+  title: string,
+  range: string,
+  mints: string
+): string {
+  return t(locale, "memeCalendar.grid.cardAriaLabel", {
+    title,
+    range,
+    mints,
+  });
+}
+
+function getCalendarInviteLabels(locale: SupportedLocale) {
+  return {
+    addToCalendar: t(locale, "memeCalendar.invites.addToCalendar"),
+    addToGoogleCalendar: t(locale, "memeCalendar.invites.addToGoogleCalendar"),
+  };
+}
+
+const DRILLDOWN_CARD_CLASS =
+  "tw-cursor-pointer tw-rounded-md tw-border tw-border-solid tw-border-[#222222] tw-bg-black tw-p-3 hover:tw-bg-[#eee] hover:tw-text-black focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400";
+
+interface DrilldownCardProps {
+  readonly title: string;
+  readonly range: string;
+  readonly mints: string;
+  readonly isCurrent: boolean;
+  readonly onClick: () => void;
+  readonly locale: SupportedLocale;
+}
+
+function DrilldownCard({
+  title,
+  range,
+  mints,
+  isCurrent,
+  onClick,
+  locale,
+}: DrilldownCardProps) {
+  return (
+    <button
+      type="button"
+      aria-label={getDrilldownCardAriaLabel(locale, title, range, mints)}
+      className={DRILLDOWN_CARD_CLASS}
+      style={{
+        borderColor: isCurrent ? "#20fa59" : "#222222",
+        borderWidth: isCurrent ? "2px" : "1px",
+      }}
+      onClick={onClick}
+    >
+      <div className="tw-font-semibold">{title}</div>
+      <div className="tw-text-xs tw-text-gray-500">{range}</div>
+      <div className="tw-mt-1 tw-text-sm">{mints}</div>
+    </button>
+  );
+}
+
+interface HistoricalLaunchDrilldownCardProps {
+  readonly title: string;
+  readonly isCurrent: boolean;
+  readonly onClick: () => void;
+  readonly locale: SupportedLocale;
+}
+
+function HistoricalLaunchDrilldownCard({
+  title,
+  isCurrent,
+  onClick,
+  locale,
+}: HistoricalLaunchDrilldownCardProps) {
+  const start = new Date(SZN1_RANGE.start);
+  const end = new Date(SZN1_RANGE.end);
+  const range = getDateRangeLabel(locale, start, end);
+  const mints = getMemeRangeLabel(locale, 1, 47);
+
+  return (
+    <div className="tw-mt-4 tw-grid tw-grid-cols-1 tw-gap-4">
+      <DrilldownCard
+        title={title}
+        range={range}
+        mints={mints}
+        isCurrent={isCurrent}
+        locale={locale}
+        onClick={onClick}
+      />
+    </div>
+  );
 }
 
 // Props types
@@ -101,48 +352,367 @@ interface MonthProps {
   readonly onSelectDay?: ((date: Date) => void) | undefined;
   readonly autoOpenYmd?: string | undefined;
   readonly displayTz: DisplayTz;
+  readonly locale: SupportedLocale;
 }
 interface SeasonViewProps {
   readonly seasonIndex: number;
   readonly onSelectDay?: ((date: Date) => void) | undefined;
   readonly autoOpenYmd?: string | undefined;
   readonly displayTz: DisplayTz;
+  readonly locale: SupportedLocale;
 }
 interface YearViewProps {
   readonly seasonIndex: number;
   readonly onSelectSeason: (seasonIndex: number) => void;
   readonly onZoomToSeason: () => void;
+  readonly locale: SupportedLocale;
 }
 interface EpochViewProps {
   readonly seasonIndex: number;
   readonly onSelectSeason: (seasonIndex: number) => void;
   readonly onSelectYear: (yearNumber: number) => void;
   readonly onZoomToYear: () => void;
+  readonly locale: SupportedLocale;
 }
 interface PeriodViewProps {
   readonly seasonIndex: number;
   readonly onSelectEpoch: (epochNumber: number) => void;
   readonly onZoomToEpoch: () => void;
+  readonly locale: SupportedLocale;
 }
 interface EraViewProps {
   readonly seasonIndex: number;
   readonly onSelectPeriod: (periodNumber: number) => void;
   readonly onZoomToPeriod: () => void;
+  readonly locale: SupportedLocale;
 }
 interface EonViewProps {
   readonly seasonIndex: number;
   readonly onSelectEra: (eraNumber: number) => void;
   readonly onZoomToEra: () => void;
+  readonly locale: SupportedLocale;
+}
+
+type TooltipPlace = "top" | "bottom" | "right";
+type HistoricalMint = ReturnType<typeof getHistoricalMintsOnUtcDay>[number];
+
+interface MintCellDetails {
+  readonly historical: HistoricalMint[];
+  readonly isMintDay: boolean;
+  readonly mintInstantUtc: Date | undefined;
+  readonly mintLabel: string | undefined;
+  readonly mintNumber: number | undefined;
+}
+
+interface MintTooltip {
+  readonly className: string;
+  readonly html: string;
+}
+
+interface MonthDayCellProps {
+  readonly cellOffset: number;
+  readonly day: number;
+  readonly displayTz: DisplayTz;
+  readonly locale: SupportedLocale;
+  readonly month: number;
+  readonly onSelectDay?: ((date: Date) => void) | undefined;
+  readonly year: number;
+}
+
+function getTooltipPlace(cellOffset: number): TooltipPlace {
+  const col = cellOffset % 7;
+  const row = Math.floor(cellOffset / 7);
+
+  if (col <= 1) {
+    return "right";
+  }
+
+  return row <= 1 ? "bottom" : "top";
+}
+
+function formatHistoricalMintLabel(
+  historical: readonly HistoricalMint[],
+  locale: SupportedLocale
+): string | undefined {
+  const first = historical[0];
+  const last = historical[historical.length - 1];
+
+  if (!first || !last) {
+    return undefined;
+  }
+
+  if (historical.length === 1) {
+    return `#${formatInteger(locale, first.id)}`;
+  }
+
+  return `#${formatInteger(locale, first.id)}-#${formatInteger(locale, last.id)}`;
+}
+
+function getMintCellDetails(
+  cellDateUtcDay: Date,
+  locale: SupportedLocale
+): MintCellDetails {
+  const historical = getHistoricalMintsOnUtcDay(cellDateUtcDay);
+
+  if (historical.length > 0) {
+    return {
+      historical,
+      isMintDay: true,
+      mintInstantUtc: historical[0]?.instantUtc,
+      mintLabel: formatHistoricalMintLabel(historical, locale),
+      mintNumber: historical[0]?.id,
+    };
+  }
+
+  if (isMintEligibleUtcDay(cellDateUtcDay)) {
+    const mintNumber = getMintNumberForMintDate(cellDateUtcDay);
+
+    return {
+      historical,
+      isMintDay: true,
+      mintInstantUtc: mintStartInstantUtcForMintDay(cellDateUtcDay),
+      mintLabel: formatMint(mintNumber, locale),
+      mintNumber,
+    };
+  }
+
+  return {
+    historical,
+    isMintDay: false,
+    mintInstantUtc: undefined,
+    mintLabel: undefined,
+    mintNumber: undefined,
+  };
+}
+
+function getHistoricalTooltipHtml(
+  historical: readonly HistoricalMint[],
+  displayTz: DisplayTz,
+  locale: SupportedLocale
+): string {
+  const firstInstant = historical[0]?.instantUtc;
+
+  if (!firstInstant) {
+    return "";
+  }
+
+  const items = historical
+    .map((h) => `#${formatInteger(locale, h.id)}`)
+    .join(", ");
+  const tooltipTitle = t(
+    locale,
+    historical.length > 1
+      ? "memeCalendar.grid.tooltip.memes"
+      : "memeCalendar.grid.tooltip.meme",
+    historical.length > 1 ? { mints: items } : { mint: items }
+  );
+
+  return `<div style="min-width:220px">
+    <div style="font-weight:600; margin-bottom:3px; font-size:larger">
+      ${escapeHtml(tooltipTitle)}
+    </div>
+    <div style="margin-bottom:12px">${formatFullDate(
+      firstInstant,
+      displayTz,
+      locale
+    )}</div>
+  </div>`;
+}
+
+function getScheduledMintTooltip({
+  displayTz,
+  locale,
+  mintInstantUtc,
+  mintLabel,
+  mintNumber,
+  noteTooltipContent,
+}: {
+  readonly displayTz: DisplayTz;
+  readonly locale: SupportedLocale;
+  readonly mintInstantUtc: Date | undefined;
+  readonly mintLabel: string | undefined;
+  readonly mintNumber: number | undefined;
+  readonly noteTooltipContent: string;
+}): MintTooltip {
+  if (!mintInstantUtc || !mintNumber) {
+    return { className: "!tw-bg-[#dcc]", html: "" };
+  }
+
+  const now = new Date();
+  const isFutureMint = mintInstantUtc.getTime() > now.getTime();
+  const oneLine = isFutureMint
+    ? formatFullDateTime(mintInstantUtc, displayTz, locale)
+    : formatFullDate(mintInstantUtc, displayTz, locale);
+  const oneLineDivWithNote = noteTooltipContent
+    ? `<div style="margin-bottom:12px">${oneLine}<br />
+      <span style="font-size:11px; color: #666;">*${noteTooltipContent}</span></div>`
+    : `<div style="margin-bottom:12px">${oneLine}</div>`;
+  const invites = isFutureMint
+    ? printCalendarInvites(
+        mintInstantUtc,
+        mintNumber,
+        "#000",
+        22,
+        getCalendarInviteLabels(locale),
+        locale
+      )
+    : "";
+  const tooltipTitle = t(locale, "memeCalendar.grid.tooltip.meme", {
+    mint: mintLabel ?? "",
+  });
+
+  return {
+    className: isFutureMint ? "!tw-bg-[#eee]" : "!tw-bg-[#dcc]",
+    html: `
+      <div style="min-width:220px">
+        <div style="font-weight:600; margin-bottom:3px; font-size:larger">${escapeHtml(tooltipTitle)}</div>
+        ${oneLineDivWithNote}
+        ${invites}
+      </div>`,
+  };
+}
+
+function getMintTooltip(
+  cellDateUtcDay: Date,
+  details: MintCellDetails,
+  displayTz: DisplayTz,
+  locale: SupportedLocale
+): MintTooltip {
+  if (details.historical.length > 0) {
+    return {
+      className: "!tw-bg-[#dcc]",
+      html: getHistoricalTooltipHtml(details.historical, displayTz, locale),
+    };
+  }
+
+  const overrideNote = getMintOverrideNoteForUtcDay(cellDateUtcDay);
+
+  return getScheduledMintTooltip({
+    displayTz,
+    locale,
+    mintInstantUtc: details.mintInstantUtc,
+    mintLabel: details.mintLabel,
+    mintNumber: details.mintNumber,
+    noteTooltipContent: overrideNote
+      ? escapeHtml(overrideNote).replaceAll("\n", "<br />")
+      : "",
+  });
+}
+
+function EmptyMonthCell({ keyDate }: { readonly keyDate: Date }) {
+  return (
+    <div
+      key={`empty-${ymd(keyDate)}`}
+      className="tw-pointer-events-none tw-invisible"
+    ></div>
+  );
+}
+
+function MonthDayCell({
+  cellOffset,
+  day,
+  displayTz,
+  locale,
+  month,
+  onSelectDay,
+  year,
+}: MonthDayCellProps) {
+  const cellDateUtcDay = new Date(Date.UTC(year, month, day));
+  const isToday = ymd(cellDateUtcDay) === ymd(new Date());
+  const details = getMintCellDetails(cellDateUtcDay, locale);
+
+  if (!details.isMintDay) {
+    return (
+      <div
+        className="tw-flex tw-min-h-[2.5rem] tw-flex-col tw-items-center tw-justify-start tw-border-b-2 tw-py-2 tw-text-gray-400"
+        style={{ borderColor: "#222222", borderBottomStyle: "solid" }}
+      >
+        <span
+          className={`tw-flex tw-h-6 tw-w-6 tw-items-center tw-justify-center tw-rounded-full tw-text-xs ${
+            isToday
+              ? "tw-bg-[#20fa59] tw-font-semibold tw-text-black"
+              : "tw-text-gray-400"
+          }`}
+        >
+          {day}
+        </span>
+        <span className="tw-mt-0.5 tw-text-xs tw-font-medium">&nbsp;</span>
+      </div>
+    );
+  }
+
+  const tooltip = getMintTooltip(cellDateUtcDay, details, displayTz, locale);
+
+  return (
+    <button
+      type="button"
+      id={`meme-cell-${ymd(cellDateUtcDay)}`}
+      className="tw-flex tw-min-h-[2.5rem] tw-cursor-pointer tw-flex-col tw-items-center tw-justify-start tw-border-b-2 tw-border-none tw-bg-transparent tw-py-2 hover:tw-bg-[#eee] hover:tw-text-black focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400"
+      style={{
+        borderColor: "#222222",
+        borderBottomStyle: "solid",
+      }}
+      data-tooltip-id="meme-tooltip"
+      data-tooltip-html={tooltip.html}
+      data-tooltip-class-name={tooltip.className}
+      data-tooltip-place={getTooltipPlace(cellOffset)}
+      aria-label={t(locale, "memeCalendar.grid.dayMintAriaLabel", {
+        date: formatFullDate(cellDateUtcDay, "utc", locale),
+        mint: details.mintLabel ?? "",
+      })}
+      onClick={() => onSelectDay?.(cellDateUtcDay)}
+    >
+      <span
+        className={`tw-flex tw-h-6 tw-w-6 tw-items-center tw-justify-center tw-rounded-full tw-text-xs ${
+          isToday ? "tw-bg-[#20fa59] tw-font-semibold tw-text-black" : ""
+        }`}
+      >
+        {day}
+      </span>
+      {details.mintLabel && (
+        <span className="tw-mt-0.5 tw-text-xs tw-font-medium tw-text-blue-600">
+          {details.mintLabel}
+        </span>
+      )}
+    </button>
+  );
 }
 
 /**
  * Month component - renders a month grid with weekday headers.
  */
-function Month({ date, onSelectDay, autoOpenYmd, displayTz }: MonthProps) {
+function Month({
+  date,
+  onSelectDay,
+  autoOpenYmd,
+  displayTz,
+  locale,
+}: MonthProps) {
   const year = date.getUTCFullYear();
   const month = date.getUTCMonth();
-  const monthName = formatUtcMonth(new Date(Date.UTC(year, month, 1)), "long");
+  const monthName = formatUtcMonth(
+    new Date(Date.UTC(year, month, 1)),
+    "long",
+    locale
+  );
+  const weekdays: readonly MessageKey[] = [
+    "memeCalendar.grid.weekday.mon",
+    "memeCalendar.grid.weekday.tue",
+    "memeCalendar.grid.weekday.wed",
+    "memeCalendar.grid.weekday.thu",
+    "memeCalendar.grid.weekday.fri",
+    "memeCalendar.grid.weekday.sat",
+    "memeCalendar.grid.weekday.sun",
+  ];
   const weeks = getMonthWeeks(year, month);
+  const firstMonthDay = new Date(Date.UTC(year, month, 1));
+  const firstMonthDow = firstMonthDay.getUTCDay();
+  const gridStartOffset = firstMonthDow === 0 ? -6 : 1 - firstMonthDow;
+  const cells = weeks.flat().map((day, cellOffset) => ({
+    day,
+    cellOffset,
+    keyDate: new Date(Date.UTC(year, month, 1 + gridStartOffset + cellOffset)),
+  }));
   useEffect(() => {
     if (!autoOpenYmd) return;
     const el = document.getElementById(`meme-cell-${autoOpenYmd}`);
@@ -175,7 +745,7 @@ function Month({ date, onSelectDay, autoOpenYmd, displayTz }: MonthProps) {
       </div>
       {/* Weekday header */}
       <div className="tw-mt-1 tw-grid tw-grid-cols-7 tw-text-center tw-text-xs tw-font-medium">
-        {["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"].map((wd) => (
+        {weekdays.map((wd) => (
           <div
             key={wd}
             className="tw-border-b-2 tw-p-1"
@@ -184,162 +754,26 @@ function Month({ date, onSelectDay, autoOpenYmd, displayTz }: MonthProps) {
               borderBottomStyle: "solid",
             }}
           >
-            {wd}
+            {t(locale, wd)}
           </div>
         ))}
         {/* Day cells */}
-        {weeks.flat().map((day, idx) => {
-          if (day === null) {
-            return (
-              <div
-                key={`empty-${year}-${month}-${idx}`}
-                className="tw-pointer-events-none tw-invisible"
-              ></div>
-            );
-          }
-
-          const cellDateUtcDay = new Date(Date.UTC(year, month, day));
-          const col = idx % 7;
-          const row = Math.floor(idx / 7);
-          let tooltipPlace: "top" | "bottom" | "right";
-          if (col <= 1) tooltipPlace = "right";
-          else if (row <= 1) tooltipPlace = "bottom";
-          else tooltipPlace = "top";
-
-          const historical = getHistoricalMintsOnUtcDay(cellDateUtcDay);
-          const isHistoricalMintDay = historical.length > 0;
-
-          const isScheduledMintDay = isMintEligibleUtcDay(cellDateUtcDay);
-
-          const isMintDay = isHistoricalMintDay || isScheduledMintDay;
-          const overrideNote = getMintOverrideNoteForUtcDay(cellDateUtcDay);
-          const noteTooltipContent = overrideNote
-            ? escapeHtml(overrideNote).replaceAll("\n", "<br />")
-            : "";
-
-          // For label: if multiple historical mints, show a range (#1-#3). Otherwise single #.
-          let mintLabel: string | undefined;
-          let mintInstantUtc: Date | undefined;
-          let mintNumber: number | undefined;
-
-          if (isHistoricalMintDay) {
-            const first = historical[0];
-            const last = historical[historical.length - 1];
-            mintNumber = first?.id; // anchor for invites (unused for past)
-            mintInstantUtc = first?.instantUtc;
-            mintLabel =
-              historical.length === 1
-                ? `#${first?.id}`
-                : `#${first?.id}-#${last?.id}`;
-          } else if (isScheduledMintDay) {
-            mintNumber = getMintNumberForMintDate(cellDateUtcDay);
-            mintLabel = formatMint(mintNumber);
-            mintInstantUtc = mintStartInstantUtcForMintDay(cellDateUtcDay);
-          }
-
-          const isToday = ymd(cellDateUtcDay) === ymd(new Date());
-
-          if (!isMintDay) {
-            return (
-              <div
-                key={ymd(cellDateUtcDay)}
-                className="tw-flex tw-min-h-[2.5rem] tw-flex-col tw-items-center tw-justify-start tw-border-b-2 tw-py-2 tw-text-gray-400"
-                style={{ borderColor: "#222222", borderBottomStyle: "solid" }}
-              >
-                <span
-                  className={`tw-flex tw-h-6 tw-w-6 tw-items-center tw-justify-center tw-rounded-full tw-text-xs ${
-                    isToday
-                      ? "tw-bg-[#20fa59] tw-font-semibold tw-text-black"
-                      : "tw-text-gray-400"
-                  }`}
-                >
-                  {day}
-                </span>
-                <span className="tw-mt-0.5 tw-text-xs tw-font-medium">
-                  &nbsp;
-                </span>
-              </div>
-            );
-          }
-
-          // Tooltip HTML:
-          let tooltipHtml = "";
-          let tooltipClassName = "!tw-bg-[#dcc]";
-
-          if (isHistoricalMintDay) {
-            // list each historical mint with exact timestamps
-            const items = historical
-              .map((h) => {
-                return `#${h.id}`;
-              })
-              .join(", ");
-            tooltipHtml = `<div style="min-width:220px">
-              <div style="font-weight:600; margin-bottom:3px; font-size:larger">
-                Meme${historical.length > 1 ? "s" : ""} ${items}
-              </div>
-              <div style="margin-bottom:12px">${formatFullDate(
-                historical[0]?.instantUtc!,
-                displayTz
-              )}</div>
-            </div>`;
-          } else if (mintInstantUtc) {
-            const now = new Date();
-            const oneLine =
-              mintInstantUtc.getTime() > now.getTime()
-                ? formatFullDateTime(mintInstantUtc, displayTz)
-                : formatFullDate(mintInstantUtc, displayTz);
-            const oneLineDivWithNote = noteTooltipContent
-              ? `<div style="margin-bottom:12px">${oneLine}<br />
-                <span style="font-size:11px; color: #666;">*${noteTooltipContent}</span></div>`
-              : `<div style="margin-bottom:12px">${oneLine}</div>`;
-            const invites =
-              mintInstantUtc.getTime() > now.getTime()
-                ? printCalendarInvites(mintInstantUtc, mintNumber!, "#000")
-                : "";
-            tooltipHtml = `
-              <div style="min-width:220px">
-                <div style="font-weight:600; margin-bottom:3px; font-size:larger">Meme ${mintLabel}</div>
-                ${oneLineDivWithNote}
-                ${invites}
-              </div>`;
-            if (mintInstantUtc?.getTime() > now.getTime()) {
-              tooltipClassName = "!tw-bg-[#eee]";
-            }
-          }
-
-          return (
-            <button
-              type="button"
-              id={`meme-cell-${ymd(cellDateUtcDay)}`}
-              key={ymd(cellDateUtcDay)}
-              className="tw-flex tw-min-h-[2.5rem] tw-cursor-pointer tw-flex-col tw-items-center tw-justify-start tw-border-b-2 tw-border-none tw-bg-transparent tw-py-2 hover:tw-bg-[#eee] hover:tw-text-black"
-              style={{
-                borderColor: "#222222",
-                borderBottomStyle: "solid",
-              }}
-              data-tooltip-id="meme-tooltip"
-              data-tooltip-html={tooltipHtml}
-              data-tooltip-class-name={tooltipClassName}
-              data-tooltip-place={tooltipPlace}
-              onClick={() => onSelectDay?.(cellDateUtcDay)}
-            >
-              <span
-                className={`tw-flex tw-h-6 tw-w-6 tw-items-center tw-justify-center tw-rounded-full tw-text-xs ${
-                  isToday
-                    ? "tw-bg-[#20fa59] tw-font-semibold tw-text-black"
-                    : ""
-                }`}
-              >
-                {day}
-              </span>
-              {mintLabel && (
-                <span className="tw-mt-0.5 tw-text-xs tw-font-medium tw-text-blue-600">
-                  {mintLabel}
-                </span>
-              )}
-            </button>
-          );
-        })}
+        {cells.map(({ day, cellOffset, keyDate }) =>
+          day === null ? (
+            <EmptyMonthCell key={`empty-${ymd(keyDate)}`} keyDate={keyDate} />
+          ) : (
+            <MonthDayCell
+              key={ymd(new Date(Date.UTC(year, month, day)))}
+              cellOffset={cellOffset}
+              day={day}
+              displayTz={displayTz}
+              locale={locale}
+              month={month}
+              onSelectDay={onSelectDay}
+              year={year}
+            />
+          )
+        )}
       </div>
     </div>
   );
@@ -353,6 +787,7 @@ function SeasonView({
   onSelectDay,
   autoOpenYmd,
   displayTz,
+  locale,
 }: SeasonViewProps) {
   const seasonStart = getSeasonStartDate(seasonIndex);
 
@@ -381,6 +816,7 @@ function SeasonView({
           onSelectDay={onSelectDay}
           autoOpenYmd={autoOpenYmd}
           displayTz={displayTz}
+          locale={locale}
         />
       ))}
     </div>
@@ -394,6 +830,7 @@ function YearView({
   seasonIndex,
   onSelectSeason,
   onZoomToSeason,
+  locale,
 }: YearViewProps) {
   const yearIndex = Math.floor(seasonIndex / SEASONS_PER_YEAR);
   const firstSeasonIndexOfYear = yearIndex * SEASONS_PER_YEAR;
@@ -402,33 +839,18 @@ function YearView({
   // ⭐ Special case: Year 0 (2022) shows a single SZN1 card (Jun–Dec 2022)
   const displayedYear = displayedYearNumberFromIndex(seasonIndex);
   if (displayedYear === 0) {
-    const start = new Date(SZN1_RANGE.start); // Jun 1, 2022
-    const end = new Date(SZN1_RANGE.end); // Dec 31, 2022
-    const sIdx = SZN1_SEASON_INDEX; // our SZN1 bucket
-    const isCurrent = currentIdx === sIdx;
+    const title = getDivisionTitle(locale, "szn", 1);
 
     return (
-      <div className="tw-mt-4 tw-grid tw-grid-cols-1 tw-gap-4">
-        <button
-          type="button"
-          key={sIdx}
-          className="tw-cursor-pointer tw-rounded-md tw-border tw-border-solid tw-border-[#222222] tw-bg-black tw-p-3 hover:tw-text-black"
-          style={{
-            borderColor: isCurrent ? "#20fa59" : "#222222",
-            borderWidth: isCurrent ? "2px" : "1px",
-          }}
-          onClick={() => {
-            onSelectSeason(sIdx);
-            onZoomToSeason();
-          }}
-        >
-          <div className="tw-font-semibold">SZN #1</div>
-          <div className="tw-text-xs tw-text-gray-500">
-            {formatUtcMonthYear(start)} - {formatUtcMonthYear(end)}
-          </div>
-          <div className="tw-mt-1 tw-text-sm">Memes #1 - #47</div>
-        </button>
-      </div>
+      <HistoricalLaunchDrilldownCard
+        title={title}
+        isCurrent={currentIdx === SZN1_SEASON_INDEX}
+        locale={locale}
+        onClick={() => {
+          onSelectSeason(SZN1_SEASON_INDEX);
+          onZoomToSeason();
+        }}
+      />
     );
   }
   // 👇 existing code for other years stays the same
@@ -436,7 +858,14 @@ function YearView({
     const sIdx = firstSeasonIndexOfYear + s;
     const start = getSeasonStartDate(sIdx);
     const end = addMonths(start, 2);
-    return { sIdx, start, end, label: getRangeLabel(start, end) };
+    const title = getDivisionTitle(
+      locale,
+      "szn",
+      displayedSeasonNumberFromIndex(sIdx)
+    );
+    const range = getDateRangeLabel(locale, start, end);
+    const mints = getRangeLabel(start, end, locale);
+    return { sIdx, start, end, mints, range, title };
   });
 
   return (
@@ -444,27 +873,18 @@ function YearView({
       {seasons.map((s) => {
         const isCurrent = currentIdx === s.sIdx;
         return (
-          <button
-            type="button"
+          <DrilldownCard
             key={s.sIdx}
-            className="tw-cursor-pointer tw-rounded-md tw-border tw-border-solid tw-border-[#222222] tw-bg-black tw-p-3 hover:tw-bg-[#eee] hover:tw-text-black"
-            style={{
-              borderColor: isCurrent ? "#20fa59" : "#222222",
-              borderWidth: isCurrent ? "2px" : "1px",
-            }}
+            title={s.title}
+            range={s.range}
+            mints={s.mints}
+            isCurrent={isCurrent}
+            locale={locale}
             onClick={() => {
               onSelectSeason(s.sIdx);
               onZoomToSeason();
             }}
-          >
-            <div className="tw-font-semibold">
-              SZN #{displayedSeasonNumberFromIndex(s.sIdx)}
-            </div>
-            <div className="tw-text-xs tw-text-gray-500">
-              {formatUtcMonthYear(s.start)} - {formatUtcMonthYear(s.end)}
-            </div>
-            <div className="tw-mt-1 tw-text-sm">{s.label}</div>
-          </button>
+          />
         );
       })}
     </div>
@@ -479,36 +899,26 @@ function EpochView({
   onSelectYear,
   onSelectSeason,
   onZoomToYear,
+  locale,
 }: EpochViewProps) {
   const currentIdx = getSeasonIndexForDate(new Date());
   const epochNumber = displayedEpochNumberFromIndex(seasonIndex);
 
   if (epochNumber === 0) {
     // Special case: SZN1 epoch, single card for Year #0 (SZN1)
-    const sIdx = SZN1_SEASON_INDEX; // SZN1
-    // Highlight if currentIdx is within SZN1 range
-    const isCurrent = currentIdx === sIdx;
+    const title = getDivisionTitleWithGregorianYear(locale, "year", 0, 2022);
+
     return (
-      <div className="tw-mt-4 tw-grid tw-grid-cols-1 tw-gap-4">
-        <button
-          type="button"
-          key={sIdx}
-          className="tw-cursor-pointer tw-rounded-md tw-border tw-border-solid tw-border-[#222222] tw-bg-black tw-p-3 hover:tw-bg-[#eee] hover:tw-text-black"
-          style={{
-            borderColor: isCurrent ? "#20fa59" : "#222222",
-            borderWidth: isCurrent ? "2px" : "1px",
-          }}
-          onClick={() => {
-            onSelectSeason(sIdx);
-            onSelectYear(0);
-            onZoomToYear();
-          }}
-        >
-          <div className="tw-font-semibold">Year #0 (2022)</div>
-          <div className="tw-text-xs tw-text-gray-500">Jun 2022 - Dec 2022</div>
-          <div className="tw-mt-1 tw-text-sm">Memes #1 - #47</div>
-        </button>
-      </div>
+      <HistoricalLaunchDrilldownCard
+        title={title}
+        isCurrent={currentIdx === SZN1_SEASON_INDEX}
+        locale={locale}
+        onClick={() => {
+          onSelectSeason(SZN1_SEASON_INDEX);
+          onSelectYear(0);
+          onZoomToYear();
+        }}
+      />
     );
   } else {
     // For epochNumber >= 1, show 4 years, starting with Jan 1 of year 2023 + 4*(epochNumber-1)
@@ -526,7 +936,14 @@ function EpochView({
         start,
         end,
         seasonIndex: yearSeasonIndex,
-        label: getRangeLabel(start, end),
+        mints: getRangeLabel(start, end, locale),
+        range: getDateRangeLabel(locale, start, end),
+        title: getDivisionTitleWithGregorianYear(
+          locale,
+          "year",
+          yearNumber,
+          year
+        ),
       };
     });
     return (
@@ -536,27 +953,18 @@ function EpochView({
             currentIdx >= y.seasonIndex &&
             currentIdx < y.seasonIndex + SEASONS_PER_YEAR;
           return (
-            <button
-              type="button"
+            <DrilldownCard
               key={toISO(y.start)}
-              className="tw-cursor-pointer tw-rounded-md tw-border tw-border-solid tw-border-[#222222] tw-bg-black tw-p-3 hover:tw-bg-[#eee] hover:tw-text-black"
-              style={{
-                borderColor: isCurrent ? "#20fa59" : "#222222",
-                borderWidth: isCurrent ? "2px" : "1px",
-              }}
+              title={y.title}
+              range={y.range}
+              mints={y.mints}
+              isCurrent={isCurrent}
+              locale={locale}
               onClick={() => {
                 onSelectYear(y.yearNumber);
                 onZoomToYear();
               }}
-            >
-              <div className="tw-font-semibold">
-                Year #{y.yearNumber} ({y.start.getUTCFullYear()})
-              </div>
-              <div className="tw-text-xs tw-text-gray-500">
-                {formatUtcMonthYear(y.start)} - {formatUtcMonthYear(y.end)}
-              </div>
-              <div className="tw-mt-1 tw-text-sm">{y.label}</div>
-            </button>
+            />
           );
         })}
       </div>
@@ -571,33 +979,24 @@ function PeriodView({
   seasonIndex,
   onSelectEpoch,
   onZoomToEpoch,
+  locale,
 }: PeriodViewProps) {
   const currentIdx = getSeasonIndexForDate(new Date());
   const periodNumber = displayedPeriodNumberFromIndex(seasonIndex);
 
   if (periodNumber === 0) {
-    const sIdx = SZN1_SEASON_INDEX; // SZN1
-    const isCurrent = currentIdx === sIdx;
+    const title = getDivisionTitleWithGregorianYear(locale, "epoch", 0, 2022);
+
     return (
-      <div className="tw-mt-4 tw-grid tw-grid-cols-1 tw-gap-4">
-        <button
-          type="button"
-          key={sIdx}
-          className="tw-cursor-pointer tw-rounded-md tw-border tw-border-solid tw-border-[#222222] tw-bg-black tw-p-3 hover:tw-bg-[#eee] hover:tw-text-black"
-          style={{
-            borderColor: isCurrent ? "#20fa59" : "#222222",
-            borderWidth: isCurrent ? "2px" : "1px",
-          }}
-          onClick={() => {
-            onSelectEpoch(0);
-            onZoomToEpoch();
-          }}
-        >
-          <div className="tw-font-semibold">Epoch #0 (2022)</div>
-          <div className="tw-text-xs tw-text-gray-500">Jun 2022 - Dec 2022</div>
-          <div className="tw-mt-1 tw-text-sm">Memes #1 - #47</div>
-        </button>
-      </div>
+      <HistoricalLaunchDrilldownCard
+        title={title}
+        isCurrent={currentIdx === SZN1_SEASON_INDEX}
+        locale={locale}
+        onClick={() => {
+          onSelectEpoch(0);
+          onZoomToEpoch();
+        }}
+      />
     );
   } else {
     // For periodNumber >= 1, show 5 epochs, starting with epochNumber = 1 + 5*(periodNumber-1)
@@ -615,7 +1014,14 @@ function PeriodView({
         start,
         end,
         seasonIndex: seasonIndexForEpoch,
-        label: getRangeLabel(start, end),
+        mints: getRangeLabel(start, end, locale),
+        range: getDateRangeLabel(locale, start, end),
+        title: getDivisionTitleWithGregorianYear(
+          locale,
+          "epoch",
+          epochNumber,
+          startYear
+        ),
       };
     });
     return (
@@ -625,27 +1031,18 @@ function PeriodView({
             currentIdx >= ep.seasonIndex &&
             currentIdx < ep.seasonIndex + SEASONS_PER_EPOCH;
           return (
-            <button
-              type="button"
+            <DrilldownCard
               key={toISO(ep.start)}
-              className="tw-cursor-pointer tw-rounded-md tw-border tw-border-solid tw-border-[#222222] tw-bg-black tw-p-3 hover:tw-bg-[#eee] hover:tw-text-black"
-              style={{
-                borderColor: isCurrent ? "#20fa59" : "#222222",
-                borderWidth: isCurrent ? "2px" : "1px",
-              }}
+              title={ep.title}
+              range={ep.range}
+              mints={ep.mints}
+              isCurrent={isCurrent}
+              locale={locale}
               onClick={() => {
                 onSelectEpoch(ep.epochNumber);
                 onZoomToEpoch();
               }}
-            >
-              <div className="tw-font-semibold">
-                Epoch #{ep.epochNumber} ({ep.start.getUTCFullYear()})
-              </div>
-              <div className="tw-text-xs tw-text-gray-500">
-                {formatUtcMonthYear(ep.start)} - {formatUtcMonthYear(ep.end)}
-              </div>
-              <div className="tw-mt-1 tw-text-sm">{ep.label}</div>
-            </button>
+            />
           );
         })}
       </div>
@@ -660,34 +1057,24 @@ function EraView({
   seasonIndex,
   onSelectPeriod,
   onZoomToPeriod,
+  locale,
 }: EraViewProps) {
   const currentIdx = getSeasonIndexForDate(new Date());
   const eraNumber = displayedEraNumberFromIndex(seasonIndex);
 
   // Era #0 – special (SZN1 only)
   if (eraNumber === 0) {
-    const sIdx = SZN1_SEASON_INDEX; // SZN1 bucket
-    const isCurrent = currentIdx === sIdx;
+    const title = getDivisionTitleWithGregorianYear(locale, "period", 0, 2022);
     return (
-      <div className="tw-mt-4 tw-grid tw-grid-cols-1 tw-gap-4">
-        <button
-          type="button"
-          key={sIdx}
-          className="tw-cursor-pointer tw-rounded-md tw-border tw-border-solid tw-border-[#222222] tw-bg-black tw-p-3 hover:tw-bg-[#eee] hover:tw-text-black"
-          style={{
-            borderColor: isCurrent ? "#20fa59" : "#222222",
-            borderWidth: isCurrent ? "2px" : "1px",
-          }}
-          onClick={() => {
-            onSelectPeriod(0);
-            onZoomToPeriod();
-          }}
-        >
-          <div className="tw-font-semibold">Period #0 (2022)</div>
-          <div className="tw-text-xs tw-text-gray-500">Jun 2022 - Dec 2022</div>
-          <div className="tw-mt-1 tw-text-sm">Memes #1 - #47</div>
-        </button>
-      </div>
+      <HistoricalLaunchDrilldownCard
+        title={title}
+        isCurrent={currentIdx === SZN1_SEASON_INDEX}
+        locale={locale}
+        onClick={() => {
+          onSelectPeriod(0);
+          onZoomToPeriod();
+        }}
+      />
     );
   }
 
@@ -704,7 +1091,14 @@ function EraView({
       start,
       end,
       seasonIndex: seasonIndexForPeriod,
-      label: getRangeLabel(start, end),
+      mints: getRangeLabel(start, end, locale),
+      range: getDateRangeLabel(locale, start, end),
+      title: getDivisionTitleWithGregorianYear(
+        locale,
+        "period",
+        firstPeriodNumber + k,
+        py
+      ),
     };
   });
 
@@ -715,27 +1109,18 @@ function EraView({
           currentIdx >= p.seasonIndex &&
           currentIdx < p.seasonIndex + SEASONS_PER_PERIOD;
         return (
-          <button
-            type="button"
+          <DrilldownCard
             key={toISO(p.start)}
-            className="tw-cursor-pointer tw-rounded-md tw-border tw-border-solid tw-border-[#222222] tw-bg-black tw-p-3 hover:tw-bg-[#eee] hover:tw-text-black"
-            style={{
-              borderColor: isCurrent ? "#20fa59" : "#222222",
-              borderWidth: isCurrent ? "2px" : "1px",
-            }}
+            title={p.title}
+            range={p.range}
+            mints={p.mints}
+            isCurrent={isCurrent}
+            locale={locale}
             onClick={() => {
               onSelectPeriod(p.periodNumber);
               onZoomToPeriod();
             }}
-          >
-            <div className="tw-font-semibold">
-              Period #{p.periodNumber} ({p.start.getUTCFullYear()})
-            </div>
-            <div className="tw-text-xs tw-text-gray-500">
-              {formatUtcMonthYear(p.start)} - {formatUtcMonthYear(p.end)}
-            </div>
-            <div className="tw-mt-1 tw-text-sm">{p.label}</div>
-          </button>
+          />
         );
       })}
     </div>
@@ -745,34 +1130,28 @@ function EraView({
 /**
  * EonView - eras only, one per row, with ranges; drill into Era view.
  */
-function EonView({ seasonIndex, onSelectEra, onZoomToEra }: EonViewProps) {
+function EonView({
+  seasonIndex,
+  onSelectEra,
+  onZoomToEra,
+  locale,
+}: EonViewProps) {
   const currentIdx = getSeasonIndexForDate(new Date());
   const eonNumber = displayedEonNumberFromIndex(seasonIndex);
 
   // Eon #0 – special (SZN1 only)
   if (eonNumber === 0) {
-    const sIdx = SZN1_SEASON_INDEX;
-    const isCurrent = currentIdx === sIdx;
+    const title = getDivisionTitleWithGregorianYear(locale, "era", 0, 2022);
     return (
-      <div className="tw-mt-4 tw-grid tw-grid-cols-1 tw-gap-4">
-        <button
-          type="button"
-          key={sIdx}
-          className="tw-cursor-pointer tw-rounded-md tw-border tw-border-solid tw-border-[#222222] tw-bg-black tw-p-3 hover:tw-bg-[#eee] hover:tw-text-black"
-          style={{
-            borderColor: isCurrent ? "#20fa59" : "#222222",
-            borderWidth: isCurrent ? "2px" : "1px",
-          }}
-          onClick={() => {
-            onSelectEra(0);
-            onZoomToEra();
-          }}
-        >
-          <div className="tw-font-semibold">Era #0 (2022)</div>
-          <div className="tw-text-xs tw-text-gray-500">Jun 2022 - Dec 2022</div>
-          <div className="tw-mt-1 tw-text-sm">Memes #1 - #47</div>
-        </button>
-      </div>
+      <HistoricalLaunchDrilldownCard
+        title={title}
+        isCurrent={currentIdx === SZN1_SEASON_INDEX}
+        locale={locale}
+        onClick={() => {
+          onSelectEra(0);
+          onZoomToEra();
+        }}
+      />
     );
   }
 
@@ -789,7 +1168,14 @@ function EonView({ seasonIndex, onSelectEra, onZoomToEra }: EonViewProps) {
       start,
       end,
       seasonIndex: seasonIndexForEra,
-      label: getRangeLabel(start, end),
+      mints: getRangeLabel(start, end, locale),
+      range: getDateRangeLabel(locale, start, end),
+      title: getDivisionTitleWithGregorianYear(
+        locale,
+        "era",
+        firstEraNumber + k,
+        ey
+      ),
     };
   });
 
@@ -800,27 +1186,18 @@ function EonView({ seasonIndex, onSelectEra, onZoomToEra }: EonViewProps) {
           currentIdx >= er.seasonIndex &&
           currentIdx < er.seasonIndex + SEASONS_PER_ERA;
         return (
-          <button
-            type="button"
+          <DrilldownCard
             key={toISO(er.start)}
-            className="tw-cursor-pointer tw-rounded-md tw-border tw-border-solid tw-border-[#222222] tw-bg-black tw-p-3 hover:tw-bg-[#eee] hover:tw-text-black"
-            style={{
-              borderColor: isCurrent ? "#20fa59" : "#222222",
-              borderWidth: isCurrent ? "2px" : "1px",
-            }}
+            title={er.title}
+            range={er.range}
+            mints={er.mints}
+            isCurrent={isCurrent}
+            locale={locale}
             onClick={() => {
               onSelectEra(er.eraNumber);
               onZoomToEra();
             }}
-          >
-            <div className="tw-font-semibold">
-              Era #{er.eraNumber} ({er.start.getUTCFullYear()})
-            </div>
-            <div className="tw-text-xs tw-text-gray-500">
-              {formatUtcMonthYear(er.start)} - {formatUtcMonthYear(er.end)}
-            </div>
-            <div className="tw-mt-1 tw-text-sm">{er.label}</div>
-          </button>
+          />
         );
       })}
     </div>
@@ -833,9 +1210,13 @@ function EonView({ seasonIndex, onSelectEra, onZoomToEra }: EonViewProps) {
  */
 interface MemeCalendarProps {
   readonly displayTz: DisplayTz;
+  readonly locale?: SupportedLocale | undefined;
 }
 
-export default function MemeCalendar({ displayTz }: MemeCalendarProps) {
+export default function MemeCalendar({
+  displayTz,
+  locale = DEFAULT_LOCALE,
+}: MemeCalendarProps) {
   const isMobile = useIsMobileScreen();
   const [seasonIndex, setSeasonIndex] = useState<number>(() => {
     try {
@@ -855,6 +1236,14 @@ export default function MemeCalendar({ displayTz }: MemeCalendarProps) {
   const periodNumber = displayedPeriodNumberFromIndex(seasonIndex);
   const eraNumber = displayedEraNumberFromIndex(seasonIndex);
   const eonNumber = displayedEonNumberFromIndex(seasonIndex);
+  const zoomNumbers: Record<ZoomLevel, number> = {
+    szn: seasonNumber,
+    year: yearNumber,
+    epoch: epochNumber,
+    period: periodNumber,
+    era: eraNumber,
+    eon: eonNumber,
+  };
 
   // Jump to specific numbers (1‑based)
   const selectYear = (n: number) =>
@@ -874,6 +1263,7 @@ export default function MemeCalendar({ displayTz }: MemeCalendarProps) {
             seasonIndex={seasonIndex}
             autoOpenYmd={autoOpenYmd ?? undefined}
             displayTz={displayTz}
+            locale={locale}
           />
         );
       case "year":
@@ -882,6 +1272,7 @@ export default function MemeCalendar({ displayTz }: MemeCalendarProps) {
             seasonIndex={seasonIndex}
             onSelectSeason={setSeasonIndex}
             onZoomToSeason={() => setZoomLevel("szn")}
+            locale={locale}
           />
         );
       case "epoch":
@@ -891,6 +1282,7 @@ export default function MemeCalendar({ displayTz }: MemeCalendarProps) {
             onSelectSeason={setSeasonIndex}
             onSelectYear={selectYear}
             onZoomToYear={() => setZoomLevel("year")}
+            locale={locale}
           />
         );
       case "period":
@@ -899,6 +1291,7 @@ export default function MemeCalendar({ displayTz }: MemeCalendarProps) {
             seasonIndex={seasonIndex}
             onSelectEpoch={selectEpoch}
             onZoomToEpoch={() => setZoomLevel("epoch")}
+            locale={locale}
           />
         );
       case "era":
@@ -907,6 +1300,7 @@ export default function MemeCalendar({ displayTz }: MemeCalendarProps) {
             seasonIndex={seasonIndex}
             onSelectPeriod={selectPeriod}
             onZoomToPeriod={() => setZoomLevel("period")}
+            locale={locale}
           />
         );
       case "eon":
@@ -915,6 +1309,7 @@ export default function MemeCalendar({ displayTz }: MemeCalendarProps) {
             seasonIndex={seasonIndex}
             onSelectEra={selectEra}
             onZoomToEra={() => setZoomLevel("era")}
+            locale={locale}
           />
         );
       default:
@@ -996,43 +1391,68 @@ export default function MemeCalendar({ displayTz }: MemeCalendarProps) {
     jumpToMonthValue(jumpValue);
   };
 
+  const infoButtonLabel = t(
+    locale,
+    showInfo ? "memeCalendar.grid.info.hide" : "memeCalendar.grid.info.show"
+  );
+  const currentDivisionName = getDivisionName(locale, zoomLevel);
+  const previousDivisionLabel = t(locale, "memeCalendar.grid.previous", {
+    division: currentDivisionName,
+  });
+  const nextDivisionLabel = t(locale, "memeCalendar.grid.next", {
+    division: currentDivisionName,
+  });
+
   return (
     <div className="tw-rounded-md tw-border tw-border-solid tw-border-[#222222] tw-bg-[#0c0c0d] tw-p-4">
       {/* Division (zoom) selector buttons */}
       <div className="tw-mb-8 tw-grid tw-grid-cols-3 tw-gap-2 lg:tw-grid-cols-[repeat(6,minmax(0,1fr))_auto]">
-        {(
-          [
-            ["szn", `SZN ${seasonNumber.toLocaleString()}`],
-            ["year", `Year ${yearNumber.toLocaleString()}`],
-            ["epoch", `Epoch ${epochNumber.toLocaleString()}`],
-            ["period", `Period ${periodNumber.toLocaleString()}`],
-            ["era", `Era ${eraNumber.toLocaleString()}`],
-            ["eon", `Eon ${eonNumber.toLocaleString()}`],
-          ] as [ZoomLevel, string][]
-        ).map(([level, label]) => (
-          <button
-            key={level}
-            className={
-              "tw-w-full tw-rounded-md tw-border tw-px-3 tw-py-2 tw-text-sm tw-font-medium tw-transition-colors " +
-              (zoomLevel === level
-                ? "tw-border-blue-500 tw-bg-blue-600 tw-text-white tw-shadow"
-                : "tw-border-gray-300 tw-bg-gray-100 tw-text-gray-900 hover:tw-bg-gray-200 dark:tw-border-gray-700 dark:tw-bg-gray-800 dark:tw-text-gray-100 dark:hover:tw-bg-gray-700")
-            }
-            onClick={() => setZoomLevel(level)}
-          >
-            {label}
-          </button>
-        ))}
+        <fieldset className="tw-col-span-3 tw-grid tw-grid-cols-3 tw-gap-2 lg:tw-col-span-6 lg:tw-grid-cols-6">
+          <legend className="tw-sr-only">
+            {t(locale, "memeCalendar.grid.zoomGroup")}
+          </legend>
+          {ZOOM_LEVELS.map((level) => {
+            const label = getZoomLabel(locale, level, zoomNumbers[level]);
+            return (
+              <button
+                key={level}
+                type="button"
+                aria-pressed={zoomLevel === level}
+                className={
+                  "tw-w-full tw-rounded-md tw-border tw-px-3 tw-py-2 tw-text-sm tw-font-medium tw-transition-colors focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 " +
+                  (zoomLevel === level
+                    ? "tw-border-blue-500 tw-bg-blue-600 tw-text-white tw-shadow"
+                    : "tw-border-gray-300 tw-bg-gray-100 tw-text-gray-900 hover:tw-bg-gray-200 dark:tw-border-gray-700 dark:tw-bg-gray-800 dark:tw-text-gray-100 dark:hover:tw-bg-gray-700")
+                }
+                onClick={() => setZoomLevel(level)}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </fieldset>
         <div className="tw-col-span-3 tw-flex tw-items-center tw-justify-end lg:tw-col-span-1">
-          <FontAwesomeIcon
-            icon={showInfo ? faXmarkCircle : faInfoCircle}
-            className="tw-h-8 tw-w-8 tw-cursor-pointer"
+          <button
+            type="button"
+            aria-controls="meme-calendar-info"
+            aria-expanded={showInfo}
+            aria-label={infoButtonLabel}
+            title={infoButtonLabel}
+            className="tw-inline-flex tw-h-10 tw-w-10 tw-items-center tw-justify-center tw-rounded-md tw-border tw-border-transparent tw-bg-transparent tw-text-gray-100 hover:tw-bg-gray-800 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400"
             onClick={() => setShowInfo((v) => !v)}
-          />
+          >
+            <FontAwesomeIcon
+              aria-hidden="true"
+              icon={showInfo ? faXmarkCircle : faInfoCircle}
+              className="tw-h-8 tw-w-8"
+            />
+          </button>
         </div>
       </div>
 
-      <div
+      <section
+        id="meme-calendar-info"
+        aria-label={t(locale, "memeCalendar.grid.info.panelLabel")}
         className={
           "tw-rounded-md tw-border tw-border-solid tw-border-[#222222] tw-bg-black " +
           "tw-origin-top tw-overflow-hidden tw-transition-all tw-duration-300 tw-ease-out " +
@@ -1046,55 +1466,28 @@ export default function MemeCalendar({ displayTz }: MemeCalendarProps) {
         <div className="tw-flex tw-flex-col tw-gap-4 md:tw-flex-row md:tw-gap-6">
           {/* Left side grows on md+ */}
           <div className="md:tw-flex-1">
-            {[
-              { label: "Minting Days", text: "Monday / Wednesday / Friday" },
-              {
-                label: "SZN",
-                text: "Traditional calendar quarter system / 3 months each",
-                note: "~ 39 mints",
-              },
-              { label: "YEAR", text: "4 SZNs in 1 YEAR", note: "~ 156 mints" },
-              {
-                label: "EPOCH",
-                text: "4 YEARs / 16 SZNs",
-                note: "~ 626 mints",
-              },
-              {
-                label: "PERIOD",
-                text: "5 EPOCHs / 20 YEARs / 80 SZNs",
-                note: "~ 3,130 mints",
-              },
-              {
-                label: "ERA",
-                text: "5 PERIODs / 20 EPOCHs / 100 YEARs / 400 SZNs",
-                note: "~ 15,650 mints",
-              },
-              {
-                label: "EON",
-                text: "10 ERAs / 100 PERIODs / 1,000 YEARs / 4,000 SZNs",
-                note: "~ 156,500 mints",
-              },
-              {
-                label: "Year 0",
-                text: "Jun 2022 - Dec 2022 / SZN1 / Year 0 was our experimental launch period, not bound by the later structured minting schedule.",
-                note: "Memes #1 - #47",
-              },
-            ].map(({ label, text, note }) => (
+            {GRID_INFO_ITEMS.map(({ label, text, note }) => (
               <div key={label} className="tw-py-2">
-                <span className="tw-font-bold">{label}</span> - {text}{" "}
-                {note && <span className="tw-text-gray-500">{note}</span>}
+                <span className="tw-font-bold">{t(locale, label)}</span> -{" "}
+                {t(locale, text)}{" "}
+                {note && (
+                  <span className="tw-text-gray-500">{t(locale, note)}</span>
+                )}
               </div>
             ))}
           </div>
         </div>
-      </div>
+      </section>
 
       {/* Unified navigation + controls in one row on large, wrap on small */}
       <div className="tw-mb-6 tw-mt-2 tw-flex tw-flex-wrap tw-items-end tw-justify-between tw-gap-3">
         {/* Left half: Prev | Title+Range | Next */}
         <div className="tw-flex tw-w-full tw-min-w-0 tw-flex-1 tw-items-center tw-gap-2 lg:tw-max-w-[40%] lg:tw-basis-2/3">
           <button
-            className="tw-inline-flex tw-h-9 tw-w-9 tw-items-center tw-justify-center tw-gap-2 tw-rounded-md tw-border tw-border-gray-300 tw-px-3 tw-py-1.5 tw-text-gray-900 hover:tw-bg-gray-100 dark:tw-border-gray-700 dark:tw-text-gray-100 dark:hover:tw-bg-gray-700"
+            type="button"
+            aria-label={previousDivisionLabel}
+            title={previousDivisionLabel}
+            className="tw-inline-flex tw-h-9 tw-w-9 tw-items-center tw-justify-center tw-gap-2 tw-rounded-md tw-border tw-border-gray-300 tw-px-3 tw-py-1.5 tw-text-gray-900 hover:tw-bg-gray-100 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 dark:tw-border-gray-700 dark:tw-text-gray-100 dark:hover:tw-bg-gray-700"
             onClick={() => {
               let delta = 0;
               if (zoomLevel === "epoch") {
@@ -1128,23 +1521,27 @@ export default function MemeCalendar({ displayTz }: MemeCalendarProps) {
               setSeasonIndex((s) => clampIndex(s + delta));
             }}
           >
-            <FontAwesomeIcon icon={faCaretLeft} />
+            <FontAwesomeIcon aria-hidden="true" icon={faCaretLeft} />
           </button>
 
           {/* Label block: title and date range; wraps if needed */}
           <div className="tw-min-w-0 tw-flex-1 tw-text-center">
             <div className="tw-text-sm tw-font-semibold">
-              {getZoomTitle(zoomLevel, seasonIndex)}
+              {getZoomTitle(locale, zoomLevel, seasonIndex)}
             </div>
             {(() => {
               const { start, end } = getRangeDatesByZoom(
                 zoomLevel,
                 seasonIndex
               );
-              const range = `${formatUtcMonthYear(start)} - ${formatUtcMonthYear(end)}`;
+              const range = `${formatUtcMonthYear(
+                start,
+                "short",
+                locale
+              )} - ${formatUtcMonthYear(end, "short", locale)}`;
               const mintRange = isSznOneIndex(seasonIndex)
                 ? "Memes #1 - #47"
-                : getRangeLabel(start, end);
+                : getRangeLabel(start, end, locale);
               return (
                 <div className="tw-whitespace-normal tw-break-words tw-text-xs tw-text-gray-400">
                   {range} / {mintRange}
@@ -1154,7 +1551,10 @@ export default function MemeCalendar({ displayTz }: MemeCalendarProps) {
           </div>
 
           <button
-            className="tw-inline-flex tw-h-9 tw-w-9 tw-items-center tw-justify-center tw-gap-2 tw-rounded-md tw-border tw-border-gray-300 tw-px-3 tw-py-1.5 tw-text-gray-900 hover:tw-bg-gray-100 dark:tw-border-gray-700 dark:tw-text-gray-100 dark:hover:tw-bg-gray-700"
+            type="button"
+            aria-label={nextDivisionLabel}
+            title={nextDivisionLabel}
+            className="tw-inline-flex tw-h-9 tw-w-9 tw-items-center tw-justify-center tw-gap-2 tw-rounded-md tw-border tw-border-gray-300 tw-px-3 tw-py-1.5 tw-text-gray-900 hover:tw-bg-gray-100 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 dark:tw-border-gray-700 dark:tw-text-gray-100 dark:hover:tw-bg-gray-700"
             onClick={() => {
               let delta = 0;
               if (zoomLevel === "epoch") {
@@ -1188,7 +1588,7 @@ export default function MemeCalendar({ displayTz }: MemeCalendarProps) {
               setSeasonIndex((s) => clampIndex(s + delta));
             }}
           >
-            <FontAwesomeIcon icon={faCaretRight} />
+            <FontAwesomeIcon aria-hidden="true" icon={faCaretRight} />
           </button>
         </div>
         {/* Right: controls — Jump to Today, Mint #, and Date jump (date hidden on small screens) */}
@@ -1197,17 +1597,22 @@ export default function MemeCalendar({ displayTz }: MemeCalendarProps) {
           <div className="tw-flex tw-w-full tw-gap-3 sm:tw-w-auto sm:tw-gap-3">
             <button
               type="button"
-              className="tw-inline-flex tw-h-9 tw-flex-1 tw-shrink-0 tw-items-center tw-justify-center tw-whitespace-nowrap tw-rounded-md tw-border tw-border-[#d1d1d1] tw-bg-white tw-px-3 tw-text-sm tw-font-semibold tw-text-black hover:tw-bg-[#e9e9e9] sm:tw-w-auto sm:tw-flex-none"
+              className="tw-inline-flex tw-h-9 tw-flex-1 tw-shrink-0 tw-items-center tw-justify-center tw-whitespace-nowrap tw-rounded-md tw-border tw-border-[#d1d1d1] tw-bg-white tw-px-3 tw-text-sm tw-font-semibold tw-text-black hover:tw-bg-[#e9e9e9] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 sm:tw-w-auto sm:tw-flex-none"
               onClick={handleJumpToToday}
             >
-              Jump to Today
+              {t(locale, "memeCalendar.grid.jumpToday")}
             </button>
             <form
               onSubmit={handleMintJumpSubmit}
               className="tw-w-full tw-flex-1 tw-shrink-0 sm:tw-w-auto sm:tw-flex-none"
             >
-              <div className="tw-flex tw-h-9 tw-w-full tw-items-center tw-rounded-md tw-border tw-border-[#d1d1d1] tw-bg-[#e5e5e5] tw-bg-white tw-pl-3 tw-font-semibold tw-text-black">
-                <div className="tw-shrink-0 tw-select-none tw-pr-2">Meme #</div>
+              <div className="tw-flex tw-h-9 tw-w-full tw-items-center tw-rounded-md tw-border tw-border-[#d1d1d1] tw-bg-white tw-pl-3 tw-font-semibold tw-text-black">
+                <label
+                  htmlFor="meme-calendar-mint-input"
+                  className="tw-shrink-0 tw-select-none tw-pr-2"
+                >
+                  {t(locale, "memeCalendar.grid.memeNumber")}
+                </label>
                 <input
                   id="meme-calendar-mint-input"
                   type="number"
@@ -1218,7 +1623,7 @@ export default function MemeCalendar({ displayTz }: MemeCalendarProps) {
                     const v = event.target.value.replaceAll(/\D/g, "");
                     setJumpMint(v);
                   }}
-                  className="tw-h-9 tw-w-full tw-min-w-0 tw-rounded-r-md tw-border-none tw-px-2 tw-text-black placeholder:tw-text-gray-500 focus:tw-outline-none sm:tw-w-[8ch]"
+                  className="tw-h-9 tw-w-full tw-min-w-0 tw-rounded-r-md tw-border-none tw-px-2 tw-text-black placeholder:tw-text-gray-500 focus:tw-outline-none focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-0 focus-visible:tw-outline-primary-400 sm:tw-w-[8ch]"
                 />
               </div>
             </form>
@@ -1227,8 +1632,13 @@ export default function MemeCalendar({ displayTz }: MemeCalendarProps) {
             onSubmit={handleDateJumpSubmit}
             className="tw-hidden tw-min-w-0 tw-max-w-full sm:tw-block sm:tw-w-auto sm:tw-basis-auto lg:tw-flex-1"
           >
-            <div className="tw-flex tw-h-9 tw-w-full tw-max-w-full tw-items-center tw-rounded-md tw-border tw-border-[#d1d1d1] tw-bg-[#e5e5e5] tw-bg-white tw-pl-3 tw-font-semibold tw-text-black sm:tw-w-auto sm:tw-max-w-[28rem] lg:tw-w-full">
-              <div className="tw-shrink-0 tw-select-none tw-pr-2">Date</div>
+            <div className="tw-flex tw-h-9 tw-w-full tw-max-w-full tw-items-center tw-rounded-md tw-border tw-border-[#d1d1d1] tw-bg-white tw-pl-3 tw-font-semibold tw-text-black sm:tw-w-auto sm:tw-max-w-[28rem] lg:tw-w-full">
+              <label
+                htmlFor="meme-calendar-date-input"
+                className="tw-shrink-0 tw-select-none tw-pr-2"
+              >
+                {t(locale, "memeCalendar.grid.date")}
+              </label>
               <input
                 id="meme-calendar-date-input"
                 type="month"
@@ -1238,7 +1648,7 @@ export default function MemeCalendar({ displayTz }: MemeCalendarProps) {
                   setJumpValue(value);
                   jumpToMonthValue(value);
                 }}
-                className="tw-h-9 tw-w-full tw-min-w-0 tw-rounded-r-md tw-border-none tw-px-2 tw-text-black placeholder:tw-text-gray-500 focus:tw-outline-none sm:tw-w-[16rem] lg:tw-w-full lg:tw-max-w-[28rem]"
+                className="tw-h-9 tw-w-full tw-min-w-0 tw-rounded-r-md tw-border-none tw-px-2 tw-text-black placeholder:tw-text-gray-500 focus:tw-outline-none focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-0 focus-visible:tw-outline-primary-400 sm:tw-w-[16rem] lg:tw-w-full lg:tw-max-w-[28rem]"
               />
             </div>
           </form>

--- a/components/meme-calendar/MemeCalendarOverview.tsx
+++ b/components/meme-calendar/MemeCalendarOverview.tsx
@@ -1,6 +1,10 @@
 "use client";
 
+import { getRouteHrefWithLocale } from "@/components/rememes/rememesRouteParams";
 import useCapacitor from "@/hooks/useCapacitor";
+import { formatInteger } from "@/i18n/format";
+import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import { faCamera } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { toPng } from "html-to-image";
@@ -35,31 +39,39 @@ import {
  */
 interface MemeCalendarOverviewProps {
   readonly displayTz: DisplayTz;
+  readonly locale?: SupportedLocale | undefined;
   readonly showViewAll?: boolean | undefined;
 }
 
 export default function MemeCalendarOverview({
   displayTz,
+  locale = DEFAULT_LOCALE,
   showViewAll = false,
 }: MemeCalendarOverviewProps) {
   return (
     <div className="tw-flex tw-flex-col tw-gap-3">
       <div className="tw-flex tw-h-full tw-items-center tw-gap-3">
-        <h1 className="tw-mb-0">The Memes Minting Calendar</h1>
+        <h1 className="tw-mb-0">{t(locale, "memeCalendar.title")}</h1>
         {showViewAll && (
-          <Link href="/meme-calendar">
+          <Link
+            href={getRouteHrefWithLocale({ href: "/meme-calendar", locale })}
+            aria-label={t(locale, "memeCalendar.viewFullCalendarAriaLabel")}
+          >
             <span className="tw-whitespace-nowrap tw-text-sm tw-font-medium hover:tw-text-[#bbb] max-[800px]:tw-text-xs">
-              View Full Calendar
+              {t(locale, "memeCalendar.viewFullCalendar")}
             </span>
           </Link>
         )}
       </div>
       <div className="tw-grid tw-grid-cols-1 tw-gap-4 md:tw-grid-cols-2">
         <div className="tw-h-full">
-          <MemeCalendarOverviewNextMint displayTz={displayTz} />
+          <MemeCalendarOverviewNextMint displayTz={displayTz} locale={locale} />
         </div>
         <div className="tw-h-full">
-          <MemeCalendarOverviewUpcomingMints displayTz={displayTz} />
+          <MemeCalendarOverviewUpcomingMints
+            displayTz={displayTz}
+            locale={locale}
+          />
         </div>
       </div>
     </div>
@@ -73,6 +85,7 @@ export default function MemeCalendarOverview({
 interface MemeCalendarOverviewNextMintProps {
   readonly displayTz: DisplayTz;
   readonly id?: number | undefined;
+  readonly locale?: SupportedLocale | undefined;
 }
 
 const TopControls = memo(function TopControls(props: {
@@ -84,6 +97,7 @@ const TopControls = memo(function TopControls(props: {
   onMintInputSubmit: (event: FormEvent<HTMLFormElement>) => void;
   onScreenshot: () => void;
   isCapturing: boolean;
+  locale: SupportedLocale;
 }) {
   const { isCapacitor } = useCapacitor();
   const {
@@ -95,7 +109,9 @@ const TopControls = memo(function TopControls(props: {
     onMintInputSubmit,
     onScreenshot,
     isCapturing,
+    locale,
   } = props;
+  const mintInputId = "meme-overview-mint-input";
 
   return (
     <div
@@ -105,17 +121,23 @@ const TopControls = memo(function TopControls(props: {
       <button
         disabled={canonicalNextMintNumber === selectedMintNumber}
         type="button"
-        className="tw-inline-flex tw-h-8 tw-items-center tw-justify-center tw-rounded-md tw-border tw-border-[#d1d1d1] tw-bg-white tw-px-3 tw-text-sm tw-font-semibold tw-text-black hover:tw-bg-[#e9e9e9] disabled:tw-opacity-75 disabled:hover:tw-border-[#d1d1d1] disabled:hover:tw-bg-white disabled:hover:tw-text-black"
+        aria-label={t(locale, "memeCalendar.overview.controls.nextMint")}
+        className="tw-inline-flex tw-h-8 tw-items-center tw-justify-center tw-rounded-md tw-border tw-border-[#d1d1d1] tw-bg-white tw-px-3 tw-text-sm tw-font-semibold tw-text-black hover:tw-bg-[#e9e9e9] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 disabled:tw-opacity-75 disabled:hover:tw-border-[#d1d1d1] disabled:hover:tw-bg-white disabled:hover:tw-text-black"
         onClick={() => onSelect(canonicalNextMintNumber)}
       >
-        Next Mint
+        {t(locale, "memeCalendar.overview.controls.nextMint")}
       </button>
 
       <form onSubmit={onMintInputSubmit}>
-        <div className="tw-flex tw-h-8 tw-items-center tw-rounded-md tw-border tw-border-[#d1d1d1] tw-bg-[#e5e5e5] tw-pl-3 tw-font-semibold tw-text-black">
-          <div className="tw-shrink-0 tw-select-none tw-pr-2">Meme #</div>
+        <label
+          htmlFor={mintInputId}
+          className="tw-flex tw-h-8 tw-items-center tw-rounded-md tw-border tw-border-[#d1d1d1] tw-bg-[#e5e5e5] tw-pl-3 tw-font-semibold tw-text-black"
+        >
+          <span className="tw-shrink-0 tw-select-none tw-pr-2">
+            {t(locale, "memeCalendar.overview.controls.memeNumber")}
+          </span>
           <input
-            id="meme-overview-mint-input"
+            id={mintInputId}
             ref={mintInputRef}
             type="number"
             min={1}
@@ -125,9 +147,9 @@ const TopControls = memo(function TopControls(props: {
               const v = event.target.value.replace(/\D/g, "");
               onMintInputChange(v);
             }}
-            className="tw-h-8 tw-w-[8ch] tw-rounded-r-md tw-border-none tw-px-2 tw-text-black placeholder:tw-text-gray-500 focus:tw-outline-none"
+            className="tw-h-8 tw-w-[8ch] tw-rounded-r-md tw-border-none tw-px-2 tw-text-black placeholder:tw-text-gray-500 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400"
           />
-        </div>
+        </label>
       </form>
 
       {!isCapacitor && (
@@ -138,6 +160,7 @@ const TopControls = memo(function TopControls(props: {
           <ScreenshotCard
             onScreenshot={onScreenshot}
             isCapturing={isCapturing}
+            locale={locale}
           />
         </>
       )}
@@ -148,6 +171,7 @@ const TopControls = memo(function TopControls(props: {
 export function MemeCalendarOverviewNextMint({
   displayTz,
   id,
+  locale = DEFAULT_LOCALE,
 }: MemeCalendarOverviewNextMintProps) {
   const [now, setNow] = useState(new Date());
   const [isManualSelection, setIsManualSelection] = useState(false);
@@ -238,8 +262,22 @@ export function MemeCalendarOverviewNextMint({
   );
 
   const invitesHtml = useMemo(
-    () => printCalendarInvites(mintDetails.instantUtc, mintDetails.mintNumber),
-    [mintDetails]
+    () =>
+      printCalendarInvites(
+        mintDetails.instantUtc,
+        mintDetails.mintNumber,
+        "#fff",
+        22,
+        {
+          addToCalendar: t(locale, "memeCalendar.invites.addToCalendar"),
+          addToGoogleCalendar: t(
+            locale,
+            "memeCalendar.invites.addToGoogleCalendar"
+          ),
+        },
+        locale
+      ),
+    [locale, mintDetails]
   );
 
   const nowMs = now.getTime();
@@ -252,29 +290,29 @@ export function MemeCalendarOverviewNextMint({
   if (isUpcoming) {
     heading =
       mintDetails.mintNumber === canonicalNextMintNumber
-        ? "Next Mint"
-        : "Upcoming Mint";
+        ? t(locale, "memeCalendar.overview.nextMint.heading.next")
+        : t(locale, "memeCalendar.overview.nextMint.heading.upcoming");
   } else if (isPast) {
-    heading = "Past Mint";
+    heading = t(locale, "memeCalendar.overview.nextMint.heading.past");
   } else {
-    heading = "Mint Live";
+    heading = t(locale, "memeCalendar.overview.nextMint.heading.live");
   }
 
-  let countdownTitle = "Minting in";
+  let countdownTitle = t(locale, "memeCalendar.overview.countdown.mintingIn");
   let countdownSuffix: string | null = null;
   let countdownParts: ReturnType<typeof msToParts>;
   if (isUpcoming) {
     countdownParts = msToParts(startMs - nowMs);
   } else if (isPast) {
-    countdownTitle = "Minted";
-    countdownSuffix = "ago";
+    countdownTitle = t(locale, "memeCalendar.overview.countdown.minted");
+    countdownSuffix = t(locale, "memeCalendar.overview.countdown.ago");
     countdownParts = msToParts(nowMs - startMs);
   } else {
-    countdownTitle = "Mint ends in";
+    countdownTitle = t(locale, "memeCalendar.overview.countdown.mintEndsIn");
     countdownParts = msToParts(endMs - nowMs);
   }
 
-  const countdownText = formatDurationParts(countdownParts);
+  const countdownText = formatDurationParts(countdownParts, locale);
   const finalCountdown = countdownSuffix ? (
     <>
       {countdownText}{" "}
@@ -364,6 +402,7 @@ export function MemeCalendarOverviewNextMint({
               onMintInputSubmit={handleMintInputSubmit}
               onScreenshot={handleScreenshot}
               isCapturing={isCapturing}
+              locale={locale}
             />
           )}
           <div className="tw-flex tw-items-center tw-justify-between tw-gap-2">
@@ -372,16 +411,17 @@ export function MemeCalendarOverviewNextMint({
               <ScreenshotCard
                 onScreenshot={handleScreenshot}
                 isCapturing={isCapturing}
+                locale={locale}
               />
             )}
           </div>
           <div className="tw-flex tw-items-center tw-gap-2">
             <div className="!tw-text-3xl tw-font-bold md:!tw-text-4xl">
-              #{mintDetails.mintNumber.toLocaleString()}
+              #{formatInteger(locale, mintDetails.mintNumber)}
             </div>
           </div>
           <div className="tw-text-lg tw-font-semibold">
-            {formatFullDateTime(mintDetails.instantUtc, displayTz)}
+            {formatFullDateTime(mintDetails.instantUtc, displayTz, locale)}
           </div>
           <div className="tw-text-sm">
             {formatToFullDivision(mintDetails.instantUtc)}
@@ -409,10 +449,12 @@ export function MemeCalendarOverviewNextMint({
  */
 interface MemeCalendarOverviewUpcomingMintsProps {
   readonly displayTz: DisplayTz;
+  readonly locale?: SupportedLocale | undefined;
 }
 
 function MemeCalendarOverviewUpcomingMints({
   displayTz,
+  locale = DEFAULT_LOCALE,
 }: MemeCalendarOverviewUpcomingMintsProps) {
   const [now] = useState(new Date());
 
@@ -463,24 +505,45 @@ function MemeCalendarOverviewUpcomingMints({
     };
   }, [currentSeason, canonicalNextMintNumber, now]);
 
-  const emptyStateCopy = "No upcoming mints in this season.";
+  const formattedSeason = formatInteger(
+    locale,
+    displayedSeasonNumberFromIndex(seasonIndex)
+  );
+  const upcomingHeading = isNextSeason
+    ? t(locale, "memeCalendar.overview.upcoming.nextSeason", {
+        season: formattedSeason,
+      })
+    : t(locale, "memeCalendar.overview.upcoming.currentSeason", {
+        season: formattedSeason,
+      });
+  const emptyStateCopy = t(locale, "memeCalendar.overview.upcoming.empty");
 
   return (
     <div className="tw-flex tw-h-full tw-flex-col tw-rounded-md tw-border tw-border-solid tw-border-[#222222] tw-bg-[#0c0c0d] tw-p-4">
       <div className="tw-mb-3 tw-flex tw-items-center tw-justify-between">
-        <div className="tw-font-semibold">
-          {isNextSeason ? "Upcoming SZN" : "Upcoming Mints for SZN"}{" "}
-          {displayedSeasonNumberFromIndex(seasonIndex)}
-        </div>
+        <div className="tw-font-semibold">{upcomingHeading}</div>
         <div className="tw-text-sm tw-text-gray-400">
-          {formatFullDate(seasonStart, displayTz)} -{" "}
-          {formatFullDate(seasonEndInclusive, displayTz)}
+          {formatFullDate(seasonStart, displayTz, locale)} -{" "}
+          {formatFullDate(seasonEndInclusive, displayTz, locale)}
         </div>
       </div>
 
       <div className="tw-max-h-[390px] tw-flex-1 tw-overflow-x-auto tw-overflow-y-auto tw-transition-colors tw-duration-500 tw-scrollbar-thin tw-scrollbar-track-iron-800 tw-scrollbar-thumb-iron-500 desktop-hover:hover:tw-scrollbar-thumb-iron-300">
         <table className="tw-w-full tw-text-sm">
-          <thead></thead>
+          <caption className="tw-sr-only">{upcomingHeading}</caption>
+          <thead>
+            <tr className="tw-sr-only">
+              <th scope="col">
+                {t(locale, "memeCalendar.overview.upcoming.memeNumber")}
+              </th>
+              <th scope="col">
+                {t(locale, "memeCalendar.overview.upcoming.mintTime")}
+              </th>
+              <th scope="col">
+                {t(locale, "memeCalendar.overview.upcoming.calendarLinks")}
+              </th>
+            </tr>
+          </thead>
           <tbody>
             {filteredRows.length === 0 ? (
               <tr>
@@ -492,10 +555,10 @@ function MemeCalendarOverviewUpcomingMints({
               filteredRows.map(({ utcDay, instantUtc, meme }) => (
                 <tr key={ymd(utcDay)}>
                   <td className="tw-py-2 tw-font-semibold">
-                    #{meme.toLocaleString()}
+                    #{formatInteger(locale, meme)}
                   </td>
                   <td className="tw-py-2 tw-pr-4">
-                    {formatFullDateTime(instantUtc, displayTz)}
+                    {formatFullDateTime(instantUtc, displayTz, locale)}
                   </td>
                   <td
                     className="tw-flex tw-items-center tw-justify-end tw-py-2 tw-pr-6"
@@ -504,7 +567,18 @@ function MemeCalendarOverviewUpcomingMints({
                         instantUtc,
                         meme,
                         "#fff",
-                        18
+                        18,
+                        {
+                          addToCalendar: t(
+                            locale,
+                            "memeCalendar.invites.addToCalendar"
+                          ),
+                          addToGoogleCalendar: t(
+                            locale,
+                            "memeCalendar.invites.addToGoogleCalendar"
+                          ),
+                        },
+                        locale
                       ),
                     }}
                   ></td>
@@ -531,21 +605,40 @@ function msToParts(ms: number) {
 
 type DurationParts = ReturnType<typeof msToParts>;
 
-function formatDurationParts(parts: DurationParts): string {
+function formatDurationParts(
+  parts: DurationParts,
+  locale: SupportedLocale
+): string {
   const segments: string[] = [];
+  const segment = (
+    value: number,
+    unitKey:
+      | "memeCalendar.overview.duration.days"
+      | "memeCalendar.overview.duration.hours"
+      | "memeCalendar.overview.duration.minutes"
+      | "memeCalendar.overview.duration.seconds"
+  ) => `${formatInteger(locale, value)}${t(locale, unitKey)}`;
+
   if (parts.d > 0) {
     segments.push(
-      `${parts.d.toLocaleString()}d`,
-      `${parts.h}h`,
-      `${parts.m}m`,
-      `${parts.s}s`
+      segment(parts.d, "memeCalendar.overview.duration.days"),
+      segment(parts.h, "memeCalendar.overview.duration.hours"),
+      segment(parts.m, "memeCalendar.overview.duration.minutes"),
+      segment(parts.s, "memeCalendar.overview.duration.seconds")
     );
   } else if (parts.h > 0) {
-    segments.push(`${parts.h}h`, `${parts.m}m`, `${parts.s}s`);
+    segments.push(
+      segment(parts.h, "memeCalendar.overview.duration.hours"),
+      segment(parts.m, "memeCalendar.overview.duration.minutes"),
+      segment(parts.s, "memeCalendar.overview.duration.seconds")
+    );
   } else if (parts.m > 0) {
-    segments.push(`${parts.m}m`, `${parts.s}s`);
+    segments.push(
+      segment(parts.m, "memeCalendar.overview.duration.minutes"),
+      segment(parts.s, "memeCalendar.overview.duration.seconds")
+    );
   } else {
-    segments.push(`${parts.s}s`);
+    segments.push(segment(parts.s, "memeCalendar.overview.duration.seconds"));
   }
   return segments.join(" : ");
 }
@@ -553,19 +646,23 @@ function formatDurationParts(parts: DurationParts): string {
 function ScreenshotCard({
   onScreenshot,
   isCapturing,
+  locale,
 }: {
   readonly onScreenshot: () => void;
   readonly isCapturing: boolean;
+  readonly locale: SupportedLocale;
 }) {
+  const label = t(locale, "memeCalendar.overview.controls.screenshot");
+
   return (
     <button
       data-ignore-screenshot
       type="button"
       onClick={onScreenshot}
       disabled={isCapturing}
-      className="tw-inline-flex tw-h-8 tw-w-8 tw-items-center tw-justify-center tw-rounded-md tw-border tw-border-[#d1d1d1] tw-bg-white tw-text-black tw-transition hover:tw-bg-[#e9e9e9] focus:tw-outline-none disabled:tw-opacity-50"
-      aria-label="Screenshot"
-      title="Screenshot"
+      className="tw-inline-flex tw-h-8 tw-w-8 tw-items-center tw-justify-center tw-rounded-md tw-border tw-border-[#d1d1d1] tw-bg-white tw-text-black tw-transition hover:tw-bg-[#e9e9e9] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 disabled:tw-opacity-50"
+      aria-label={label}
+      title={label}
     >
       <FontAwesomeIcon icon={faCamera} className="tw-h-4 tw-w-4" />
     </button>

--- a/components/meme-calendar/MemesMintingCalendar.tsx
+++ b/components/meme-calendar/MemesMintingCalendar.tsx
@@ -1,14 +1,20 @@
 "use client";
+import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import { useState } from "react";
 import type { DisplayTz } from "./meme-calendar.helpers";
 import MemeCalendar from "./MemeCalendar";
 import MemeCalendarOverview from "./MemeCalendarOverview";
 
-export default function MemesMintingCalendar() {
+export default function MemesMintingCalendar({
+  locale = DEFAULT_LOCALE,
+}: {
+  readonly locale?: SupportedLocale | undefined;
+}) {
   const [displayTz, setDisplayTz] = useState<DisplayTz>("local");
 
   const baseBtn =
-    "tw-px-4 tw-py-1.5 tw-text-sm tw-font-medium tw-border tw-transition-colors tw-duration-200";
+    "tw-min-h-8 tw-px-4 tw-py-1.5 tw-text-sm tw-font-medium tw-border tw-transition-colors tw-duration-200 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400";
 
   const activeBtn =
     "tw-bg-blue-600 tw-text-white tw-border-blue-500 hover:tw-bg-blue-700";
@@ -20,32 +26,43 @@ export default function MemesMintingCalendar() {
     <div className="tw-flex tw-flex-col tw-gap-3">
       {/* Global Local/UTC toggle */}
       <div className="tw-flex tw-justify-end">
-        <div className="tw-inline-flex">
+        <fieldset className="tw-m-0 tw-inline-flex tw-border-0 tw-p-0">
+          <legend className="tw-sr-only">
+            {t(locale, "memeCalendar.timezone.regionLabel")}
+          </legend>
           <button
             className={`${baseBtn} ${
               displayTz === "local" ? activeBtn : inactiveBtn
             } tw-rounded-l-md tw-border-r-0`}
+            aria-label={t(locale, "memeCalendar.timezone.showLocal")}
+            aria-pressed={displayTz === "local"}
             onClick={() => setDisplayTz("local")}
-            title="Show local time">
-            Local
+            title={t(locale, "memeCalendar.timezone.showLocal")}
+            type="button"
+          >
+            {t(locale, "memeCalendar.timezone.local")}
           </button>
           <button
             className={`${baseBtn} ${
               displayTz === "utc" ? activeBtn : inactiveBtn
             } tw-rounded-r-md`}
+            aria-label={t(locale, "memeCalendar.timezone.showUtc")}
+            aria-pressed={displayTz === "utc"}
             onClick={() => setDisplayTz("utc")}
-            title="Show UTC">
-            UTC
+            title={t(locale, "memeCalendar.timezone.showUtc")}
+            type="button"
+          >
+            {t(locale, "memeCalendar.timezone.utc")}
           </button>
-        </div>
+        </fieldset>
       </div>
 
       <div className="tw-flex tw-flex-wrap tw-gap-8">
         <div className="tw-w-full">
-          <MemeCalendarOverview displayTz={displayTz} />
+          <MemeCalendarOverview displayTz={displayTz} locale={locale} />
         </div>
         <div className="tw-w-full">
-          <MemeCalendar displayTz={displayTz} />
+          <MemeCalendar displayTz={displayTz} locale={locale} />
         </div>
       </div>
     </div>

--- a/components/meme-calendar/README.md
+++ b/components/meme-calendar/README.md
@@ -15,7 +15,7 @@ The default mint cadence (Monday/Wednesday/Friday, plus a handful of historic ex
     {
       mintNumber: 415,
       from: "2025-10-20", // original Monday slot
-      to: "2025-10-21",   // new Tuesday slot
+      to: "2025-10-21", // new Tuesday slot
       note: "Delayed one day for artist schedule",
     },
   ];
@@ -25,18 +25,18 @@ These overrides feed into the eligibility logic used by all calendar utilities, 
 
 ## Mint Day & Window Calculations
 
-| Helper                                        | Summary                                                                                                                                 |
-| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `nextMintDateOnOrAfter(date: Date)`           | Scans forward from the provided day until it finds the next mintable UTC date, respecting historic skips and off-schedule mints.        |
-| `mintStartInstantUtcForMintDay(utcDay: Date)` | Converts a mintable UTC day into the precise UTC timestamp when the mint opens (10:40 ET with automatic DST handling).                  |
-| `getNextMintStart(now?: Date)`                | Returns the UTC timestamp for the very next mint start instant relative to `now`, including today if it has not started yet.            |
+| Helper                                        | Summary                                                                                                                          |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `nextMintDateOnOrAfter(date: Date)`           | Scans forward from the provided day until it finds the next mintable UTC date, respecting historic skips and off-schedule mints. |
+| `mintStartInstantUtcForMintDay(utcDay: Date)` | Converts a mintable UTC day into the precise UTC timestamp when the mint opens (10:40 ET with automatic DST handling).           |
+| `getNextMintStart(now?: Date)`                | Returns the UTC timestamp for the very next mint start instant relative to `now`, including today if it has not started yet.     |
 
 ## Mint Numbering & Identification
 
-| Helper                                 | Summary                                                                                                                                   |
-| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `getMintNumberForMintDate(date: Date)` | Calculates the ordinal mint number that occurs on the given mintable UTC day, accounting for historic breaks and the continuous schedule. |
-| `dateFromMintNumber(n: number)`        | Inverse lookup that returns the mint start timestamp for a specific mint number, including SZN1 historical data.                          |
+| Helper                                 | Summary                                                                                                                                       |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getMintNumberForMintDate(date: Date)` | Calculates the ordinal mint number that occurs on the given mintable UTC day, accounting for historic breaks and the continuous schedule.     |
+| `dateFromMintNumber(n: number)`        | Inverse lookup that returns the mint start timestamp for a specific mint number, including SZN1 historical data.                              |
 | `getMintTimelineDetails(n: number)`    | Bundles the mint's UTC start/end, season index, displayed SZN/Year/Epoch/Period/Era/Eon numbers, and the exact date ranges for each division. |
 
 ## Mint Activity & Remaining Supply
@@ -48,14 +48,14 @@ These overrides feed into the eligibility logic used by all calendar utilities, 
 
 ## Calendar Link Helpers
 
-| Helper                                                               | Summary                                                                                                           |
-| -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `printCalendarInvites(dateOrInstant, mintNumber, fontColor?, size?)` | Produces the HTML snippet that renders download links for both the ICS file and Google Calendar entry for a mint. |
+| Helper                                                                                 | Summary                                                                                                                                                                |
+| -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `printCalendarInvites(dateOrInstant, mintNumber, fontColor?, size?, labels?, locale?)` | Produces the HTML snippet that renders accessible download links for both the ICS file and Google Calendar entry for a mint, using the provided locale for event text. |
 
 ## Range & Display Utilities
 
-| Helper                                                      | Summary                                                                                                                         |
-| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `getRangeDatesByZoom(zoom: ZoomLevel, seasonIndex: number)` | Returns the UTC start and end bounds for the selected timeline division (season → eon) so views can share consistent date math. |
-| `getRangeLabel(start: Date, end: Date)`                     | Formats a human-friendly “Memes #X - #Y” label using mint numbers that fall inside the provided date range.                     |
-| `formatMint(n: number)` / `formatFullDateTime(date, mode)`  | Formatting helpers used across the calendar to keep mint numbers and timestamps consistent.                                     |
+| Helper                                                                       | Summary                                                                                                                         |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `getRangeDatesByZoom(zoom: ZoomLevel, seasonIndex: number)`                  | Returns the UTC start and end bounds for the selected timeline division (season → eon) so views can share consistent date math. |
+| `getRangeLabel(start: Date, end: Date, locale?)`                             | Formats a human-friendly “Memes #X - #Y” label using mint numbers that fall inside the provided date range.                     |
+| `formatMint(n: number, locale?)` / `formatFullDateTime(date, mode, locale?)` | Formatting helpers used across the calendar to keep mint numbers and timestamps consistent.                                     |

--- a/components/meme-calendar/meme-calendar.helpers.tsx
+++ b/components/meme-calendar/meme-calendar.helpers.tsx
@@ -3,6 +3,9 @@ import {
   SKIPPED_MINT_UTC_DAYS,
 } from "./meme-calendar.overrides";
 import { HISTORICAL_MINTS } from "./meme-calendar.szn1";
+import { formatInteger } from "@/i18n/format";
+import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 
 // Constants for division sizes
 export const SEASONS_PER_YEAR = 4;
@@ -573,7 +576,7 @@ export function getMonthWeeks(
   const weeks: (number | null)[][] = [];
   let week: (number | null)[] = [];
 
-  // ⭐ Monday-first: convert Sunday(0) to 7, then pad (dow-1) nulls
+  // Monday-first: convert Sunday(0) to 7, then pad (dow - 1) nulls.
   const dow = firstDay.getUTCDay();
   const monFirstIndex = dow === 0 ? 7 : dow; // 1..7 (Mon..Sun)
   for (let i = 1; i < monFirstIndex; i++) week.push(null);
@@ -609,8 +612,8 @@ export function ymd(d: Date): string {
 // Display timezone toggle type
 export type DisplayTz = "local" | "utc";
 
-export function formatMint(n: number): string {
-  return `#${n.toLocaleString()}`;
+export function formatMint(n: number, locale = "en-US"): string {
+  return `#${n.toLocaleString(locale)}`;
 }
 
 export function formatUtcMonth(
@@ -632,8 +635,12 @@ export function formatUtcMonthYear(
   return `${formatUtcMonth(d, style, locale)} ${d.getUTCFullYear()}`;
 }
 
-export function formatFullDate(d: Date, mode: DisplayTz = "local"): string {
-  return d.toLocaleDateString(undefined, {
+export function formatFullDate(
+  d: Date,
+  mode: DisplayTz = "local",
+  locale = "en-US"
+): string {
+  return d.toLocaleDateString(locale, {
     weekday: "short",
     year: "numeric",
     month: "short",
@@ -643,9 +650,10 @@ export function formatFullDate(d: Date, mode: DisplayTz = "local"): string {
 }
 export const formatFullDateTime = (
   d: Date,
-  mode: DisplayTz = "local"
+  mode: DisplayTz = "local",
+  locale = "en-US"
 ): string => {
-  const s = d.toLocaleString(undefined, {
+  const s = d.toLocaleString(locale, {
     weekday: "short",
     year: "numeric",
     month: "short",
@@ -707,12 +715,33 @@ function createIcsDataUrl(
   return `data:text/calendar;charset=utf-8,${encodeURIComponent(ics)}`;
 }
 
+type CalendarInviteLabels = {
+  readonly addToCalendar: string;
+  readonly addToGoogleCalendar: string;
+};
+
+const DEFAULT_CALENDAR_INVITE_LABELS: CalendarInviteLabels = {
+  addToCalendar: "Add to Calendar",
+  addToGoogleCalendar: "Add to Google Calendar",
+};
+
+function escapeHtmlAttribute(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+}
+
 // Accept either a UTC day (mint day) or an instant; always emit timed links at the correct mint instant
 export function printCalendarInvites(
   dateOrInstant: Date,
   mintNumber: number,
   fontColor: string = "#fff",
-  size: number = 22
+  size: number = 22,
+  labels: CalendarInviteLabels = DEFAULT_CALENDAR_INVITE_LABELS,
+  locale = "en-US"
 ): string {
   // Normalize to mint instant in UTC
   const utcDay = startOfUtcDay(dateOrInstant);
@@ -722,33 +751,45 @@ export function printCalendarInvites(
     : new Date(dateOrInstant);
   const mintEndUtc = mintEndInstantUtcForMintDay(utcDay);
 
-  const title = `Meme ${formatMint(mintNumber)}`;
-  const fullLocal = formatFullDateTime(mintStartUtc, "local");
-  const fullUtc = formatFullDateTime(mintStartUtc, "utc");
+  const title = `Meme ${formatMint(mintNumber, locale)}`;
+  const fullLocal = formatFullDateTime(mintStartUtc, "local", locale);
+  const fullUtc = formatFullDateTime(mintStartUtc, "utc", locale);
   const desc = `${title} — ${fullLocal} / ${fullUtc}\n\nhttps://6529.io/the-memes/mint`;
 
   const gUrl = createGoogleCalendarUrl(mintStartUtc, mintEndUtc, title, desc);
   const icsUrl = createIcsDataUrl(mintStartUtc, mintEndUtc, title, desc);
+  const addToCalendarLabel = escapeHtmlAttribute(labels.addToCalendar);
+  const addToGoogleCalendarLabel = escapeHtmlAttribute(
+    labels.addToGoogleCalendar
+  );
+  const safeFontColor = escapeHtmlAttribute(fontColor);
 
   return `
     <div style="display:flex; gap:15px; align-items:center;">
-      <a href="${icsUrl}" download="meme-${mintNumber}-minting.ics" title="Add to Calendar" style="display:flex; align-items:center; gap:5px; text-decoration:none; color:${fontColor};">
-        <img src="/calendar-ics.png" style="width:${size}px;height:${size}px" />
+      <a href="${icsUrl}" download="meme-${mintNumber}-minting.ics" aria-label="${addToCalendarLabel}" title="${addToCalendarLabel}" style="display:flex; align-items:center; gap:5px; text-decoration:none; color:${safeFontColor};">
+        <img src="/calendar-ics.png" alt="" aria-hidden="true" style="width:${size}px;height:${size}px" />
       </a>
-      <a href="${gUrl}" target="_blank" rel="noopener noreferrer" title="Add to Google Calendar" style="display:flex; align-items:center; gap:5px; text-decoration:none; color:${fontColor};">
-        <img src="/calendar-google.png" style="width:${size}px;height:${size}px" />
+      <a href="${gUrl}" target="_blank" rel="noopener noreferrer" aria-label="${addToGoogleCalendarLabel}" title="${addToGoogleCalendarLabel}" style="display:flex; align-items:center; gap:5px; text-decoration:none; color:${safeFontColor};">
+        <img src="/calendar-google.png" alt="" aria-hidden="true" style="width:${size}px;height:${size}px" />
       </a>
     </div>`;
 }
 
 // Helper: get label for a date range using mint numbers (locale formatted)
-export function getRangeLabel(start: Date, end: Date): string {
+export function getRangeLabel(
+  start: Date,
+  end: Date,
+  locale: SupportedLocale = DEFAULT_LOCALE
+): string {
   const startMintDate = nextMintDateOnOrAfter(start);
   const endMintDate = prevMintDateOnOrBefore(end);
   if (startMintDate.getTime() > endMintDate.getTime()) return "—";
-  const startMint = getMintNumberForMintDate(startMintDate).toLocaleString();
-  const endMint = getMintNumberForMintDate(endMintDate).toLocaleString();
-  return `Memes #${startMint} - #${endMint}`;
+  const startMint = getMintNumberForMintDate(startMintDate);
+  const endMint = getMintNumberForMintDate(endMintDate);
+  return t(locale, "memeCalendar.grid.memeRange", {
+    start: formatInteger(locale, startMint),
+    end: formatInteger(locale, endMint),
+  });
 }
 
 export function formatToFullDivision(d: Date): React.ReactNode {

--- a/components/memelab/MemeLab.tsx
+++ b/components/memelab/MemeLab.tsx
@@ -21,13 +21,16 @@ import { MemeLabSort } from "@/types/enums";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useContext, useEffect, useMemo, useState } from "react";
-import { getMemeLabCollectionPath } from "./memeLabRouteParams";
+import { getMemeLabCollectionHref } from "./memeLabRouteParams";
 import MemeLabNftCard from "./MemeLabNftCard";
 import MemeLabSortControls from "./MemeLabSortControls";
 export { printNftContent } from "./memeLabCardContent";
 
 const COLLECTION_GRID_CLASS =
   "tw-grid tw-grid-cols-2 tw-gap-3 tw-pt-2 sm:tw-grid-cols-3 sm:tw-gap-4 lg:tw-grid-cols-4 xl:tw-gap-5";
+const COLLECTION_GRID_LIST_CLASS = `${COLLECTION_GRID_CLASS} tw-m-0 tw-list-none tw-px-0 tw-pb-0`;
+const GROUP_GRID_LIST_CLASS =
+  "tw-grid tw-grid-cols-2 tw-gap-3 tw-m-0 tw-list-none tw-p-0 sm:tw-grid-cols-3 sm:tw-gap-4 lg:tw-grid-cols-4 xl:tw-gap-5";
 
 export function getInitialRouterValues(
   sortDir: string | null,
@@ -459,20 +462,28 @@ export default function MemeLabComponent({
 
   function printNft(nft: LabNFT) {
     return (
-      <MemeLabNftCard
-        key={`${nft.contract}-${nft.id}`}
-        nft={nft}
-        sort={sort}
-        nftMetas={nftMetas}
-        volumeType={volumeType}
-        hasConnectedProfile={isConnected}
-        locale={locale}
-      />
+      <li key={`${nft.contract}-${nft.id}`} className="tw-min-w-0">
+        <MemeLabNftCard
+          nft={nft}
+          sort={sort}
+          nftMetas={nftMetas}
+          volumeType={volumeType}
+          hasConnectedProfile={isConnected}
+          locale={locale}
+        />
+      </li>
     );
   }
 
   function printNfts() {
-    return <div className={COLLECTION_GRID_CLASS}>{nfts.map(printNft)}</div>;
+    return (
+      <ul
+        aria-label={t(locale, "memeLab.results.gridLabel")}
+        className={COLLECTION_GRID_LIST_CLASS}
+      >
+        {nfts.map(printNft)}
+      </ul>
+    );
   }
 
   function printArtists() {
@@ -483,11 +494,16 @@ export default function MemeLabComponent({
           <h2 className="tw-mb-4 tw-text-lg tw-font-semibold tw-leading-6 tw-text-iron-100">
             {artist}
           </h2>
-          <div className="tw-grid tw-grid-cols-2 tw-gap-3 sm:tw-grid-cols-3 sm:tw-gap-4 lg:tw-grid-cols-4 xl:tw-gap-5">
+          <ul
+            aria-label={t(locale, "memeLab.results.artistGridLabel", {
+              artistName: artist,
+            })}
+            className={GROUP_GRID_LIST_CLASS}
+          >
             {[...artistNfts]
               .sort((a, b) => a.id - b.id)
               .map((nft: LabNFT) => printNft(nft))}
-          </div>
+          </ul>
         </section>
       );
     });
@@ -509,7 +525,10 @@ export default function MemeLabComponent({
             </h2>
             <Link
               className="hover:tw-text-primary-200 tw-text-sm tw-font-medium tw-text-primary-300 tw-no-underline tw-transition"
-              href={getMemeLabCollectionPath(collection)}
+              href={getMemeLabCollectionHref({
+                collectionName: collection,
+                locale,
+              })}
               aria-label={t(locale, "memeLab.collection.viewAriaLabel", {
                 collectionName: collection,
               })}
@@ -517,11 +536,16 @@ export default function MemeLabComponent({
               {t(locale, "memeLab.collection.view")}
             </Link>
           </div>
-          <div className="tw-grid tw-grid-cols-2 tw-gap-3 sm:tw-grid-cols-3 sm:tw-gap-4 lg:tw-grid-cols-4 xl:tw-gap-5">
+          <ul
+            aria-label={t(locale, "memeLab.results.collectionGridLabel", {
+              collectionName: collection,
+            })}
+            className={GROUP_GRID_LIST_CLASS}
+          >
             {[...collectionNfts]
               .sort((a, b) => a.id - b.id)
               .map((nft: LabNFT) => printNft(nft))}
-          </div>
+          </ul>
         </section>
       );
     });

--- a/components/memelab/MemeLabCollection.tsx
+++ b/components/memelab/MemeLabCollection.tsx
@@ -28,6 +28,7 @@ const MEME_LAB_COLLECTION_SORT_OPTIONS = Object.values(MemeLabSort).filter(
 
 const COLLECTION_GRID_CLASS =
   "tw-grid tw-grid-cols-2 tw-gap-3 tw-pt-2 sm:tw-grid-cols-3 sm:tw-gap-4 lg:tw-grid-cols-4 xl:tw-gap-5";
+const COLLECTION_GRID_LIST_CLASS = `${COLLECTION_GRID_CLASS} tw-m-0 tw-list-none tw-px-0 tw-pb-0`;
 
 export default function LabCollection({
   collectionName,
@@ -120,21 +121,31 @@ export default function LabCollection({
 
   function printNft(nft: LabNFT) {
     return (
-      <MemeLabNftCard
-        key={`${nft.contract}-${nft.id}`}
-        nft={nft}
-        sort={sort}
-        nftMetas={nftMetas}
-        volumeType={volumeType}
-        hasConnectedProfile={connectedProfile !== null}
-        locale={locale}
-        showArtistMetric={true}
-      />
+      <li key={`${nft.contract}-${nft.id}`} className="tw-min-w-0">
+        <MemeLabNftCard
+          nft={nft}
+          sort={sort}
+          nftMetas={nftMetas}
+          volumeType={volumeType}
+          hasConnectedProfile={connectedProfile !== null}
+          locale={locale}
+          showArtistMetric={true}
+        />
+      </li>
     );
   }
 
   function printNfts() {
-    return <div className={COLLECTION_GRID_CLASS}>{nfts.map(printNft)}</div>;
+    return (
+      <ul
+        aria-label={t(locale, "memeLab.results.collectionGridLabel", {
+          collectionName,
+        })}
+        className={COLLECTION_GRID_LIST_CLASS}
+      >
+        {nfts.map(printNft)}
+      </ul>
+    );
   }
 
   function printNftsContent() {

--- a/components/memelab/MemeLabPage.tsx
+++ b/components/memelab/MemeLabPage.tsx
@@ -882,7 +882,7 @@ export default function MemeLabPageComponent({
         className="tw-pb-5 tw-pt-3"
       >
         <div className="tw-mx-auto tw-w-full md:tw-w-10/12">
-          {nft && <Timeline nft={nft} steps={nftHistory} />}
+          {nft && <Timeline nft={nft} steps={nftHistory} locale={locale} />}
         </div>
       </section>
     );

--- a/components/memelab/memeLabRouteParams.ts
+++ b/components/memelab/memeLabRouteParams.ts
@@ -76,6 +76,19 @@ export function getMemeLabDetailHref({
   });
 }
 
+export function getMemeLabCollectionHref({
+  collectionName,
+  locale,
+}: {
+  readonly collectionName: string;
+  readonly locale: SupportedLocale;
+}): string {
+  return getMemeLabRouteHrefWithLocale({
+    href: getMemeLabCollectionPath(collectionName),
+    locale,
+  });
+}
+
 export function getMemeLabCollectionName(collectionParam: string): string {
   try {
     return decodeURIComponent(collectionParam)

--- a/components/nft-image/RememeImage.tsx
+++ b/components/nft-image/RememeImage.tsx
@@ -10,60 +10,93 @@ interface Props {
   height: 300 | 650;
 }
 
+const TRANSPARENT_IMAGE_SRC =
+  "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+
+function getText(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function addFallbackUrl(urls: string[], value: unknown) {
+  const url = getText(value);
+  if (url) {
+    urls.push(url);
+  }
+}
+
+function addParsedFallbackUrls(
+  urls: string[],
+  value: unknown,
+  gatewayFirst = true
+) {
+  const url = getText(value);
+  if (!url) {
+    return;
+  }
+
+  const parsedUrl = parseIpfsUrl(url);
+  const gatewayUrl = parseIpfsUrlToGateway(url);
+  if (gatewayFirst) {
+    addFallbackUrl(urls, gatewayUrl);
+    addFallbackUrl(urls, parsedUrl);
+    return;
+  }
+
+  addFallbackUrl(urls, parsedUrl);
+  addFallbackUrl(urls, gatewayUrl);
+}
+
+function getImageAlt(nft: Rememe): string {
+  return getText(nft.metadata?.name) || `#${nft.id}`;
+}
+
 export default function RememeImage(props: Readonly<Props>) {
   const imageFallbackUrls = getImageFallbackUrls();
   const videoFallbackUrls = getVideoFallbackUrls();
+  const imageAlt = getImageAlt(props.nft);
 
   function getImageFallbackUrls() {
-    const urls = [];
-    if (props.height === 300 && props.nft.s3_image_thumbnail) {
-      urls.push(props.nft.s3_image_thumbnail);
+    const urls: string[] = [];
+    if (props.height === 300) {
+      addFallbackUrl(urls, props.nft.s3_image_thumbnail);
     }
-    if (props.nft.s3_image_scaled) {
-      urls.push(props.nft.s3_image_scaled);
-    }
-    if (props.nft.s3_image_original) {
-      urls.push(props.nft.s3_image_original);
-    }
-    if (!props.nft.image.toLowerCase().startsWith("data")) {
-      urls.push(parseIpfsUrlToGateway(props.nft.image));
-      urls.push(parseIpfsUrl(props.nft.image));
-      if (props.nft.metadata.image) {
-        urls.push(parseIpfsUrlToGateway(props.nft.metadata.image));
-        urls.push(parseIpfsUrl(props.nft.metadata.image));
-      }
-      urls.push(props.nft.contract_opensea_data.imageUrl);
+    addFallbackUrl(urls, props.nft.s3_image_scaled);
+    addFallbackUrl(urls, props.nft.s3_image_original);
+
+    const image = getText(props.nft.image);
+    if (image.toLowerCase().startsWith("data")) {
+      addFallbackUrl(urls, image);
+    } else {
+      addParsedFallbackUrls(urls, image);
+      addParsedFallbackUrls(urls, props.nft.metadata?.image);
+      addFallbackUrl(urls, props.nft.contract_opensea_data?.imageUrl);
     }
     return urls;
   }
 
   function getVideoFallbackUrls() {
-    const urls = [];
+    const urls: string[] = [];
+    const image = getText(props.nft.image);
 
-    if (props.nft.image.endsWith(".mp4")) {
-      urls.push(parseIpfsUrl(props.nft.image));
-      urls.push(parseIpfsUrlToGateway(props.nft.image));
+    if (image.toLowerCase().endsWith(".mp4")) {
+      addParsedFallbackUrls(urls, image, false);
     }
 
-    if (props.nft.metadata.animation) {
-      urls.push(parseIpfsUrl(props.nft.metadata.animation));
-      urls.push(parseIpfsUrlToGateway(props.nft.metadata.animation));
-    }
+    addParsedFallbackUrls(urls, props.nft.animation, false);
+    addParsedFallbackUrls(urls, props.nft.metadata?.animation, false);
 
     return urls;
   }
 
   function isMp4() {
     return (
-      props.nft.metadata.animation_details &&
-      props.nft.metadata.animation_details.format &&
-      props.nft.metadata.animation_details.format.toLowerCase() === "mp4"
+      props.nft.metadata?.animation_details?.format?.toLowerCase() === "mp4"
     );
   }
 
   if (
     (props.animation && props.nft.animation && isMp4()) ||
-    props.nft.image.endsWith(".mp4")
+    getText(props.nft.image).endsWith(".mp4")
   ) {
     return (
       <Col
@@ -90,6 +123,35 @@ export default function RememeImage(props: Readonly<Props>) {
     );
   }
 
+  if (!imageFallbackUrls[0]) {
+    return (
+      <Col
+        xs={12}
+        className={`mb-2 text-center d-flex align-items-center justify-content-center ${
+          styles["imageWrapper"]
+        } ${props.height === 300 ? styles["height300"] : ""}`}
+      >
+        <Image
+          unoptimized
+          loading="eager"
+          priority
+          width="0"
+          height="0"
+          style={{
+            height: "auto",
+            width: "auto",
+            maxWidth: "100%",
+            maxHeight: "100%",
+          }}
+          id={`${props.nft.contract}-${props.nft.id}`}
+          src={TRANSPARENT_IMAGE_SRC}
+          alt={imageAlt}
+          className={props.height === 650 ? styles["height650"] : ""}
+        />
+      </Col>
+    );
+  }
+
   return (
     <Col
       xs={12}
@@ -110,14 +172,14 @@ export default function RememeImage(props: Readonly<Props>) {
           maxHeight: "100%",
         }}
         id={`${props.nft.contract}-${props.nft.id}`}
-        src={imageFallbackUrls[0]!}
+        src={imageFallbackUrls[0]}
         onError={({ currentTarget }) => {
           const nextFallback = imageFallbackUrls.shift();
           if (nextFallback) {
             currentTarget.src = nextFallback;
           }
         }}
-        alt={props.nft.metadata.name}
+        alt={imageAlt}
         className={props.height === 650 ? styles["height650"] : ""}
       />
     </Col>

--- a/components/rememes/Rememes.tsx
+++ b/components/rememes/Rememes.tsx
@@ -26,6 +26,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Tooltip } from "react-tooltip";
 import { getRememeSortLabel, getRememeTokenTypeLabel } from "./rememesI18n";
 import {
+  getRememesAddHref,
   getRememeDetailHref,
   getRememesBrowseQuery,
 } from "./rememesRouteParams";
@@ -36,7 +37,7 @@ const PAGE_SIZE = 40;
 export { RememeSort, TokenType } from "./rememesTypes";
 
 const REMEMES_GRID_CLASS =
-  "tw-grid tw-grid-cols-2 tw-gap-3 tw-pt-2 sm:tw-grid-cols-3 sm:tw-gap-4 lg:tw-grid-cols-4 xl:tw-gap-5";
+  "tw-m-0 tw-grid tw-list-none tw-grid-cols-2 tw-gap-3 tw-p-0 tw-pt-2 sm:tw-grid-cols-3 sm:tw-gap-4 lg:tw-grid-cols-4 xl:tw-gap-5";
 const REMEMES_TOTAL_COUNT_CLASS =
   "tw-shrink-0 tw-text-sm tw-font-medium tw-leading-none tw-text-iron-500 sm:tw-text-base";
 const REMEME_SORTING = [RememeSort.RANDOM, RememeSort.CREATED_ASC] as const;
@@ -225,45 +226,46 @@ export default function Rememes({
     const title = getRememeTitle(rememe);
 
     return (
-      <Link
-        key={`${rememe.contract}-${rememe.id}`}
-        href={getRememeDetailHref({
-          contract: rememe.contract,
-          id: rememe.id,
-          locale,
-        })}
-        aria-label={t(locale, "rememes.card.linkAriaLabel", {
-          name: title,
-          tokenId,
-        })}
-        className="tw-group tw-flex tw-h-full tw-min-w-0 tw-flex-col tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-iron-950 tw-text-iron-100 tw-no-underline tw-transition tw-duration-200 hover:tw-border-white/20 hover:tw-bg-iron-900/50 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-primary-400"
-      >
-        <div className="tw-bg-iron-900">
-          <RememeImage nft={rememe} animation={false} height={300} />
-        </div>
-        <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-items-center tw-px-2 tw-pb-4 tw-pt-4 tw-text-center md:tw-px-4">
-          <div className="tw-line-clamp-2 tw-w-full tw-max-w-full tw-break-words tw-text-center tw-text-sm tw-font-semibold tw-leading-snug tw-text-iron-50 md:tw-text-md">
-            {title}
+      <li key={`${rememe.contract}-${rememe.id}`} className="tw-min-w-0">
+        <Link
+          href={getRememeDetailHref({
+            contract: rememe.contract,
+            id: rememe.id,
+            locale,
+          })}
+          aria-label={t(locale, "rememes.card.linkAriaLabel", {
+            name: title,
+            tokenId,
+          })}
+          className="tw-group tw-flex tw-h-full tw-min-w-0 tw-flex-col tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-iron-950 tw-text-iron-100 tw-no-underline tw-transition tw-duration-200 hover:tw-border-white/20 hover:tw-bg-iron-900/50 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-primary-400"
+        >
+          <div className="tw-bg-iron-900">
+            <RememeImage nft={rememe} animation={false} height={300} />
           </div>
-          <div className="tw-mt-2 tw-flex tw-min-h-5 tw-w-full tw-min-w-0 tw-flex-wrap tw-items-center tw-justify-center tw-gap-x-1.5 tw-gap-y-0.5 tw-text-center tw-text-xs tw-leading-5 tw-text-iron-500">
-            <span className="tw-break-words">
-              {collectionName}
-              {replicaCount > 1 && <>&nbsp;{replicaCountLabel}</>}
-            </span>
-            <span aria-hidden="true" className="tw-shrink-0 tw-text-iron-600">
-              &middot;
-            </span>
-            <span
-              aria-label={t(locale, "rememes.card.tokenAriaLabel", {
-                tokenId,
-              })}
-              className="tw-min-w-0 tw-truncate tw-font-medium"
-            >
-              #{rememe.id}
-            </span>
+          <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-items-center tw-px-2 tw-pb-4 tw-pt-4 tw-text-center md:tw-px-4">
+            <div className="tw-line-clamp-2 tw-w-full tw-max-w-full tw-break-words tw-text-center tw-text-sm tw-font-semibold tw-leading-snug tw-text-iron-50 md:tw-text-md">
+              {title}
+            </div>
+            <div className="tw-mt-2 tw-flex tw-min-h-5 tw-w-full tw-min-w-0 tw-flex-wrap tw-items-center tw-justify-center tw-gap-x-1.5 tw-gap-y-0.5 tw-text-center tw-text-xs tw-leading-5 tw-text-iron-500">
+              <span className="tw-break-words">
+                {collectionName}
+                {replicaCount > 1 && <>&nbsp;{replicaCountLabel}</>}
+              </span>
+              <span aria-hidden="true" className="tw-shrink-0 tw-text-iron-600">
+                &middot;
+              </span>
+              <span
+                aria-label={t(locale, "rememes.card.tokenAriaLabel", {
+                  tokenId,
+                })}
+                className="tw-min-w-0 tw-truncate tw-font-medium"
+              >
+                #{rememe.id}
+              </span>
+            </div>
           </div>
-        </div>
-      </Link>
+        </Link>
+      </li>
     );
   }
 
@@ -275,7 +277,14 @@ export default function Rememes({
         </div>
       );
     }
-    return <div className={REMEMES_GRID_CLASS}>{rememes.map(printRememe)}</div>;
+    return (
+      <ul
+        aria-label={t(locale, "rememes.results.gridLabel")}
+        className={REMEMES_GRID_CLASS}
+      >
+        {rememes.map(printRememe)}
+      </ul>
+    );
   }
 
   return (
@@ -336,7 +345,7 @@ export default function Rememes({
               <div className="tw-flex tw-w-full tw-items-center sm:tw-w-auto sm:tw-justify-end">
                 <div className="tw-w-full sm:tw-w-auto [&>a]:tw-w-full sm:[&>a]:tw-w-auto">
                   <Link
-                    href="/rememes/add"
+                    href={getRememesAddHref({ locale })}
                     aria-label={t(locale, "rememes.actions.add")}
                     className={ADD_REMEME_LINK_CLASS}
                   >

--- a/components/rememes/rememesRouteParams.ts
+++ b/components/rememes/rememesRouteParams.ts
@@ -112,3 +112,14 @@ export function getRememeDetailHref({
     locale,
   });
 }
+
+export function getRememesAddHref({
+  locale,
+}: {
+  readonly locale: SupportedLocale;
+}): string {
+  return getRouteHrefWithLocale({
+    href: "/rememes/add",
+    locale,
+  });
+}

--- a/components/the-memes/MemeCalendarPeriods.tsx
+++ b/components/the-memes/MemeCalendarPeriods.tsx
@@ -8,6 +8,10 @@ import {
   displayedYearNumberFromIndex,
   getSeasonIndexForDate,
 } from "@/components/meme-calendar/meme-calendar.helpers";
+import { getRouteHrefWithLocale } from "@/components/rememes/rememesRouteParams";
+import { formatInteger } from "@/i18n/format";
+import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import clsx from "clsx";
 import Link from "next/link";
 
@@ -17,10 +21,12 @@ const PERIOD_SEPARATOR_CLASS_NAME =
 
 export default function MemeCalendarPeriods({
   id,
+  locale = DEFAULT_LOCALE,
   seasonHref,
   showOnlySeasonOnMobile = false,
 }: {
   readonly id: number;
+  readonly locale?: SupportedLocale | undefined;
   readonly seasonHref?: string | undefined;
   readonly showOnlySeasonOnMobile?: boolean | undefined;
 }) {
@@ -32,38 +38,59 @@ export default function MemeCalendarPeriods({
   const epoch = displayedEpochNumberFromIndex(idx);
   const year = displayedYearNumberFromIndex(idx);
   const szn = displayedSeasonNumberFromIndex(idx);
+  const formattedSeason = formatInteger(locale, szn);
 
   const printSecondaryPeriod = (label: string, number: number) => (
     <span className="tw-inline-flex tw-items-center tw-gap-1 tw-px-1.5 tw-py-0.5 tw-text-[10.5px] tw-font-medium tw-uppercase tw-tracking-wider tw-text-iron-500">
       <span>{label}</span>
-      <span className="tw-font-semibold tw-text-iron-300">{number}</span>
+      <span className="tw-font-semibold tw-text-iron-300">
+        {formatInteger(locale, number)}
+      </span>
     </span>
   );
   const secondaryPeriods = [
-    { label: "YEAR", number: year },
-    { label: "EPOCH", number: epoch },
-    { label: "PERIOD", number: period },
-    { label: "ERA", number: era },
-    { label: "EON", number: eon },
+    {
+      key: "year",
+      label: t(locale, "memeCalendar.periods.year"),
+      number: year,
+    },
+    {
+      key: "epoch",
+      label: t(locale, "memeCalendar.periods.epoch"),
+      number: epoch,
+    },
+    {
+      key: "period",
+      label: t(locale, "memeCalendar.periods.period"),
+      number: period,
+    },
+    { key: "era", label: t(locale, "memeCalendar.periods.era"), number: era },
+    { key: "eon", label: t(locale, "memeCalendar.periods.eon"), number: eon },
   ];
   const seasonContent = (
     <>
-      <span>SZN</span>
-      <span>{szn}</span>
+      <span>{t(locale, "memeCalendar.periods.seasonShort")}</span>
+      <span>{formattedSeason}</span>
     </>
   );
 
   const secondaryPeriodClassName = showOnlySeasonOnMobile
     ? SECONDARY_PERIOD_CLASS_NAME
     : undefined;
+  const seasonLinkHref =
+    seasonHref === undefined
+      ? undefined
+      : getRouteHrefWithLocale({ href: seasonHref, locale });
 
   return (
     <span className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
       {seasonHref ? (
         <Link
-          href={seasonHref}
-          aria-label={`View SZN ${szn} cards`}
-          className="tw-inline-flex tw-items-center tw-gap-1 tw-rounded-md tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900 tw-px-2.5 tw-py-0.5 tw-text-xs tw-font-semibold tw-leading-4 tw-text-iron-100 tw-no-underline tw-transition-colors hover:tw-border-primary-400 hover:tw-text-primary-300"
+          href={seasonLinkHref ?? seasonHref}
+          aria-label={t(locale, "memeCalendar.periods.seasonLinkAriaLabel", {
+            season: formattedSeason,
+          })}
+          className="tw-inline-flex tw-min-h-6 tw-items-center tw-gap-1 tw-rounded-md tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900 tw-px-2.5 tw-py-0.5 tw-text-xs tw-font-semibold tw-leading-4 tw-text-iron-100 tw-no-underline tw-transition-colors hover:tw-border-primary-400 hover:tw-text-primary-300 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400"
         >
           {seasonContent}
         </Link>
@@ -79,17 +106,15 @@ export default function MemeCalendarPeriods({
         /
       </span>
       <span
-        aria-label="Meme calendar position"
+        aria-label={t(locale, "memeCalendar.periods.positionLabel")}
+        role="group"
         className={clsx(
           "tw-flex-wrap tw-items-center tw-gap-1.5",
           secondaryPeriodClassName
         )}
       >
-        {secondaryPeriods.map(({ label, number }, index) => (
-          <span
-            key={label}
-            className="tw-inline-flex tw-items-center tw-gap-1.5"
-          >
+        {secondaryPeriods.map(({ key, label, number }, index) => (
+          <span key={key} className="tw-inline-flex tw-items-center tw-gap-1.5">
             {index > 0 && (
               <span aria-hidden="true" className={PERIOD_SEPARATOR_CLASS_NAME}>
                 /

--- a/components/the-memes/MemePage.tsx
+++ b/components/the-memes/MemePage.tsx
@@ -548,7 +548,7 @@ export default function MemePage({ nftId }: { readonly nftId: string }) {
           )}
         {activeTab === MEME_FOCUS.HISTORY &&
           activeHistoryTab === MEME_HISTORY_TAB.TIMELINE && (
-            <MemePageTimeline show={true} nft={nft} />
+            <MemePageTimeline show={true} nft={nft} locale={locale} />
           )}
       </>
     );

--- a/components/the-memes/MemePage.tsx
+++ b/components/the-memes/MemePage.tsx
@@ -421,6 +421,7 @@ export default function MemePage({ nftId }: { readonly nftId: string }) {
               key={`${nft.contract}-${nft.id}`}
               nft={nft}
               showBalance={true}
+              locale={locale}
             />
           </div>
           {userLoaded && (
@@ -520,6 +521,7 @@ export default function MemePage({ nftId }: { readonly nftId: string }) {
           <MemePageReferencesSubMenu
             show={activeTab === MEME_FOCUS.REFERENCES}
             nft={nft}
+            locale={locale}
           />
           {userLoaded && (
             <MemePageYourCardsSubMenu
@@ -580,6 +582,7 @@ export default function MemePage({ nftId }: { readonly nftId: string }) {
                 <div className="tw-ml-auto tw-flex tw-min-w-0 tw-items-center md:tw-ml-0">
                   <MemeCalendarPeriods
                     id={nft.id}
+                    locale={locale}
                     seasonHref={`/the-memes?szn=${nftMeta.season}&sort=age&sort_dir=ASC`}
                     showOnlySeasonOnMobile
                   />

--- a/components/the-memes/MemePageAdditionalDetails.tsx
+++ b/components/the-memes/MemePageAdditionalDetails.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Download from "@/components/download/Download";
+import Download, { type DownloadLabels } from "@/components/download/Download";
 import { buildTooltipId, TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
 import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
 import Link from "next/link";
@@ -12,8 +12,10 @@ export type AdditionalDetailsMediaRow = {
   readonly title: string;
   readonly url: string;
   readonly openLabel: string;
+  readonly openText?: string | undefined;
   readonly extension?: string | undefined;
   readonly downloadName?: string | undefined;
+  readonly downloadLabels?: Partial<DownloadLabels> | undefined;
 };
 
 const SAFE_EXTERNAL_PROTOCOLS = new Set([
@@ -118,6 +120,7 @@ export function ArweaveLinkRow({
             extension={row.extension ?? ""}
             variant="text"
             alwaysShowText={true}
+            labels={row.downloadLabels}
           />
         )}
         {safeExternalUrl && (
@@ -126,9 +129,9 @@ export function ArweaveLinkRow({
             target="_blank"
             rel="noopener noreferrer"
             aria-label={row.openLabel}
-            className="tw-flex tw-items-center tw-gap-1.5 tw-text-xs tw-font-medium tw-text-iron-500 tw-no-underline tw-transition-colors tw-duration-300 desktop-hover:hover:tw-text-iron-100"
+            className="tw-flex tw-min-h-6 tw-items-center tw-gap-1.5 tw-text-xs tw-font-medium tw-text-iron-500 tw-no-underline tw-transition-colors tw-duration-300 desktop-hover:hover:tw-text-iron-100"
           >
-            Open
+            {row.openText ?? "Open"}
             <ArrowTopRightOnSquareIcon className="tw-h-4 tw-w-4 tw-flex-shrink-0" />
           </Link>
         )}

--- a/components/the-memes/MemePageArt.tsx
+++ b/components/the-memes/MemePageArt.tsx
@@ -10,13 +10,15 @@ import {
 } from "@/components/the-memes/MemePageAdditionalDetails";
 import { getResolvedAnimationSrc } from "@/components/nft-image/utils/animation-source";
 import type { IAttribute, MemesExtendedData, NFT } from "@/entities/INFT";
-import { numberWithCommas } from "@/helpers/Helpers";
 import {
   getAnimationDimensionsFromMetadata,
   getAnimationFileTypeFromMetadata,
   getImageDimensionsFromMetadata,
   getImageFileTypeFromMetadata,
 } from "@/helpers/nft.helpers";
+import { formatInteger, formatNumber, roundTo } from "@/i18n/format";
+import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import {
   BoltIcon,
   ChartBarIcon,
@@ -66,12 +68,32 @@ export function MemePageArt(props: {
   show: boolean;
   nft: NFT | undefined;
   nftMeta: MemesExtendedData | undefined;
+  locale?: SupportedLocale;
 }) {
   if (!props.show || !props.nft || !props.nftMeta) {
     return <></>;
   }
 
   const { nft, nftMeta } = props;
+  const locale = props.locale ?? DEFAULT_LOCALE;
+  const unavailableValue = t(locale, "theMemes.detail.art.values.notAvailable");
+  const downloadLabels = {
+    cancelDownload: t(locale, "theMemes.detail.art.download.cancelDownload"),
+    complete: t(locale, "theMemes.detail.art.download.complete"),
+    dismissComplete: t(locale, "theMemes.detail.art.download.dismissComplete"),
+    download: t(locale, "theMemes.detail.art.download.download"),
+    downloadComplete: t(
+      locale,
+      "theMemes.detail.art.download.downloadComplete"
+    ),
+    downloadFile: t(locale, "theMemes.detail.art.download.downloadFile"),
+    downloading: t(locale, "theMemes.detail.art.download.downloading"),
+    downloadingFile: t(locale, "theMemes.detail.art.download.downloadingFile"),
+    downloadingProgress: (percentage: number) =>
+      t(locale, "theMemes.detail.art.download.downloadingProgress", {
+        percentage: formatInteger(locale, percentage),
+      }),
+  };
   const animationHref = getResolvedAnimationSrc(nft);
   const hasAnimation = Boolean(animationHref);
   const rawMetadata: unknown = nft.metadata;
@@ -101,34 +123,43 @@ export function MemePageArt(props: {
     ...(metadataHref
       ? [
           {
-            label: "JSON",
-            title: "JSON Metadata",
+            label: t(locale, "theMemes.detail.art.links.jsonLabel"),
+            title: t(locale, "theMemes.detail.art.links.jsonTitle"),
             url: metadataHref,
-            openLabel: "Open raw metadata in new tab",
+            openLabel: t(locale, "theMemes.detail.art.links.openRawMetadata"),
+            openText: t(locale, "theMemes.detail.art.links.open"),
           },
         ]
       : []),
     ...(artImageHref
       ? [
           {
-            label: imageFormat?.toUpperCase() ?? "IMAGE",
-            title: "Image Asset",
+            label:
+              imageFormat?.toUpperCase() ??
+              t(locale, "theMemes.detail.art.links.imageFallbackLabel"),
+            title: t(locale, "theMemes.detail.art.links.imageTitle"),
             url: artImageHref,
-            openLabel: "Open image in new tab",
+            openLabel: t(locale, "theMemes.detail.art.links.openImage"),
+            openText: t(locale, "theMemes.detail.art.links.open"),
             extension: imageFormat ?? "",
             downloadName: nft.name,
+            downloadLabels,
           },
         ]
       : []),
     ...(artAnimationHref
       ? [
           {
-            label: animationFormat?.toUpperCase() ?? "ANIMATION",
-            title: "Animation Asset",
+            label:
+              animationFormat?.toUpperCase() ??
+              t(locale, "theMemes.detail.art.links.animationFallbackLabel"),
+            title: t(locale, "theMemes.detail.art.links.animationTitle"),
             url: artAnimationHref,
-            openLabel: "Open animation in new tab",
+            openLabel: t(locale, "theMemes.detail.art.links.openAnimation"),
+            openText: t(locale, "theMemes.detail.art.links.open"),
             extension: animationFormat ?? "",
             downloadName: nft.name,
+            downloadLabels,
           },
         ]
       : []),
@@ -137,18 +168,18 @@ export function MemePageArt(props: {
   const detailRows = [
     {
       key: "meme",
-      label: "Meme name",
+      label: t(locale, "theMemes.detail.art.fields.memeName"),
       value: nftMeta.meme_name,
     },
     {
       key: "collection",
-      label: "Collection",
+      label: t(locale, "theMemes.detail.art.fields.collection"),
       value: nft.collection,
     },
     {
       key: "dimensions",
-      label: "Dimensions",
-      value: dimensions ?? "N/A",
+      label: t(locale, "theMemes.detail.art.fields.dimensions"),
+      value: dimensions ?? unavailableValue,
     },
   ];
 
@@ -157,18 +188,18 @@ export function MemePageArt(props: {
     ...detailRows,
     {
       key: "season",
-      label: "Season",
-      value: getAttributeValue(attributes, "Type - Season"),
+      label: t(locale, "theMemes.detail.art.fields.season"),
+      value: getAttributeValue(attributes, "Type - Season", unavailableValue),
     },
     {
       key: "meme-number",
-      label: "Meme",
-      value: getAttributeValue(attributes, "Type - Meme"),
+      label: t(locale, "theMemes.detail.art.fields.meme"),
+      value: getAttributeValue(attributes, "Type - Meme", unavailableValue),
     },
     {
       key: "card-number",
-      label: "Card number",
-      value: getAttributeValue(attributes, "Type - Card"),
+      label: t(locale, "theMemes.detail.art.fields.cardNumber"),
+      value: getAttributeValue(attributes, "Type - Card", unavailableValue),
     },
   ];
   const boostRows = attributes.filter(
@@ -177,26 +208,37 @@ export function MemePageArt(props: {
   const tdhRows = [
     {
       key: "tdh",
-      label: "TDH",
-      value: numberWithCommas(Math.round(nft.boosted_tdh * 100) / 100),
+      label: t(locale, "theMemes.detail.art.fields.tdh"),
+      value: formatNumber(locale, roundTo(nft.boosted_tdh, 2), {
+        maximumFractionDigits: 2,
+      }),
       highlightedLabel: true,
     },
     {
       key: "unweighted-tdh",
-      label: "Unweighted TDH",
-      value: numberWithCommas(Math.round(nft.tdh__raw * 100) / 100),
+      label: t(locale, "theMemes.detail.art.fields.unweightedTdh"),
+      value: formatNumber(locale, roundTo(nft.tdh__raw, 2), {
+        maximumFractionDigits: 2,
+      }),
     },
     {
       key: "meme-rank",
-      label: "Meme Rank",
-      value: nft.tdh_rank ? `#${numberWithCommas(nft.tdh_rank)}` : "-",
+      label: t(locale, "theMemes.detail.art.fields.memeRank"),
+      value: nft.tdh_rank
+        ? t(locale, "theMemes.detail.art.values.rank", {
+            rank: formatInteger(locale, nft.tdh_rank),
+          })
+        : unavailableValue,
     },
   ];
 
   return (
     <div className="tw-space-y-14 tw-pb-8 tw-pt-8">
       {mediaRows.length > 0 && (
-        <AdditionalDetailsSection title="Arweave links" icon={LinkIcon}>
+        <AdditionalDetailsSection
+          title={t(locale, "theMemes.detail.art.sections.arweaveLinks")}
+          icon={LinkIcon}
+        >
           <div>
             {mediaRows.map((row) => (
               <ArweaveLinkRow row={row} key={`${row.label}-${row.url}`} />
@@ -205,7 +247,10 @@ export function MemePageArt(props: {
         </AdditionalDetailsSection>
       )}
 
-      <AdditionalDetailsSection title="Properties" icon={SwatchIcon}>
+      <AdditionalDetailsSection
+        title={t(locale, "theMemes.detail.art.sections.properties")}
+        icon={SwatchIcon}
+      >
         {propertyAttributes.length > 0 ? (
           <div className="tw-grid tw-grid-cols-2 tw-gap-3 sm:tw-grid-cols-3 lg:tw-grid-cols-4">
             {propertyAttributes.map((attribute) => (
@@ -217,11 +262,16 @@ export function MemePageArt(props: {
             ))}
           </div>
         ) : (
-          <EmptyDetailsState>No properties found.</EmptyDetailsState>
+          <EmptyDetailsState>
+            {t(locale, "theMemes.detail.art.empty.noProperties")}
+          </EmptyDetailsState>
         )}
       </AdditionalDetailsSection>
 
-      <AdditionalDetailsSection title="TDH breakdown" icon={ChartBarSquareIcon}>
+      <AdditionalDetailsSection
+        title={t(locale, "theMemes.detail.art.sections.tdhBreakdown")}
+        icon={ChartBarSquareIcon}
+      >
         <div className="tw-flex tw-flex-wrap tw-gap-x-6 tw-gap-y-6 sm:tw-gap-x-16">
           {tdhRows.map((row) => (
             <MetricBlock
@@ -235,7 +285,10 @@ export function MemePageArt(props: {
       </AdditionalDetailsSection>
 
       <div className="tw-grid tw-grid-cols-1 tw-gap-x-16 tw-gap-y-14 lg:tw-grid-cols-2">
-        <AdditionalDetailsSection title="Stats" icon={ChartBarIcon}>
+        <AdditionalDetailsSection
+          title={t(locale, "theMemes.detail.art.sections.stats")}
+          icon={ChartBarIcon}
+        >
           <div className="tw-grid tw-grid-cols-2 tw-gap-x-4 tw-gap-y-6 sm:tw-gap-x-12 sm:tw-gap-y-8">
             {statsRows.map((row) => (
               <MetricBlock key={row.key} label={row.label} value={row.value} />
@@ -243,22 +296,25 @@ export function MemePageArt(props: {
           </div>
         </AdditionalDetailsSection>
 
-        <AdditionalDetailsSection title="Boosts" icon={BoltIcon}>
+        <AdditionalDetailsSection
+          title={t(locale, "theMemes.detail.art.sections.boosts")}
+          icon={BoltIcon}
+        >
           {boostRows.length > 0 ? (
             <div className="tw-grid tw-grid-cols-2 tw-gap-x-4 tw-gap-y-6 sm:tw-gap-x-12 sm:tw-gap-y-8">
               {boostRows.map((attribute) => (
                 <MetricBlock
                   key={attribute.trait_type}
                   label={attribute.trait_type}
-                  value={`${Number(attribute.value) > 0 ? "+" : ""}${
-                    attribute.value
-                  }%`}
+                  value={formatBoostValue(locale, attribute.value)}
                   highlightedLabel={Number(attribute.value) > 0}
                 />
               ))}
             </div>
           ) : (
-            <EmptyDetailsState>No boosts found.</EmptyDetailsState>
+            <EmptyDetailsState>
+              {t(locale, "theMemes.detail.art.empty.noBoosts")}
+            </EmptyDetailsState>
           )}
         </AdditionalDetailsSection>
       </div>
@@ -268,12 +324,26 @@ export function MemePageArt(props: {
 
 function getAttributeValue(
   attributes: readonly IAttribute[],
-  traitType: string
+  traitType: string,
+  fallback: string
 ) {
   return (
     attributes.find((attribute) => attribute.trait_type === traitType)?.value ??
-    "N/A"
+    fallback
   );
+}
+
+function formatBoostValue(locale: SupportedLocale, value: string | number) {
+  const numericValue = Number(value);
+
+  if (!Number.isFinite(numericValue)) {
+    return String(value);
+  }
+
+  return t(locale, "theMemes.detail.art.values.boostPercent", {
+    sign: numericValue > 0 ? "+" : "",
+    value: formatNumber(locale, numericValue, { maximumFractionDigits: 2 }),
+  });
 }
 
 function isAttribute(value: unknown): value is IAttribute {

--- a/components/the-memes/MemePageArtViewer.tsx
+++ b/components/the-memes/MemePageArtViewer.tsx
@@ -9,6 +9,8 @@ import { getResolvedAnimationSrc } from "@/components/nft-image/utils/animation-
 import { getResolvedImageSrc } from "@/components/nft-image/utils/image-source";
 import type { BaseNFT } from "@/entities/INFT";
 import { enterArtFullScreen } from "@/helpers/Helpers";
+import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import {
   getAnimationFileTypeFromMetadata,
   getAnimationMimeTypeFromMetadata,
@@ -72,9 +74,11 @@ function getInlineMediaVariant(
 export function MemePageArtViewer({
   nft,
   showBalance = false,
+  locale = DEFAULT_LOCALE,
 }: {
   readonly nft: BaseNFT;
   readonly showBalance?: boolean;
+  readonly locale?: SupportedLocale;
 }) {
   const { connectedProfile } = useAuth();
   const [currentSlide, setCurrentSlide] = useState(0);
@@ -97,7 +101,7 @@ export function MemePageArtViewer({
   const hasMultipleSlides = hasAnimation && hasImage;
   const activeMedia = isShowingAnimation
     ? {
-        dialogTitle: "Save animation",
+        dialogTitle: t(locale, "theMemes.detail.art.media.saveAnimation"),
         fallbackFileName: "animation",
         format: animationFormat,
         fullscreenElementId: "the-art-fullscreen-animation",
@@ -106,7 +110,7 @@ export function MemePageArtViewer({
         variant: getInlineMediaVariant(animationMimeType),
       }
     : {
-        dialogTitle: "Save image",
+        dialogTitle: t(locale, "theMemes.detail.art.media.saveImage"),
         fallbackFileName: "image",
         format: imageFormat,
         fullscreenElementId: hasImage ? "the-art-fullscreen-img" : "",
@@ -117,6 +121,12 @@ export function MemePageArtViewer({
   const currentFormat = activeMedia.format ?? "";
   const activeMediaUrl = activeMedia.url ?? "";
   const canUseBrowserMediaActions = activeMedia.variant !== "html";
+  const mediaActionLabels = {
+    close: t(locale, "theMemes.detail.art.media.close"),
+    download: t(locale, "theMemes.detail.art.media.download"),
+    downloading: t(locale, "theMemes.detail.art.media.downloading"),
+    fullscreen: t(locale, "theMemes.detail.art.media.fullscreen"),
+  };
   const showBalanceControl = showBalance && Boolean(connectedProfile);
   const { downloadMedia, isDownloading, openLabel, openMedia } =
     useMediaActions({
@@ -124,6 +134,10 @@ export function MemePageArtViewer({
       fallbackFileName: activeMedia.fallbackFileName,
       dialogTitle: activeMedia.dialogTitle,
       mimeType: activeMedia.mimeType ?? undefined,
+      labels: {
+        openInBrowser: t(locale, "theMemes.detail.art.media.openInBrowser"),
+        openInNewTab: t(locale, "theMemes.detail.art.media.openInNewTab"),
+      },
     });
 
   useEffect(() => {
@@ -208,6 +222,7 @@ export function MemePageArtViewer({
         isDownloading={isDownloading}
         onFullscreen={enterActiveMediaFullScreen}
         fullscreenTargetAvailable={Boolean(activeMedia.fullscreenElementId)}
+        labels={mediaActionLabels}
       />
     );
   }
@@ -240,7 +255,7 @@ export function MemePageArtViewer({
             >
               <button
                 type="button"
-                aria-label="Show previous artwork media"
+                aria-label={t(locale, "theMemes.detail.art.media.previous")}
                 disabled={currentSlide === 0}
                 className={styles["artSlideButton"]}
                 onClick={goToPreviousSlide}
@@ -255,7 +270,7 @@ export function MemePageArtViewer({
               </div>
               <button
                 type="button"
-                aria-label="Show next artwork media"
+                aria-label={t(locale, "theMemes.detail.art.media.next")}
                 disabled={currentSlide === 1}
                 className={styles["artSlideButton"]}
                 onClick={goToNextSlide}

--- a/components/the-memes/MemePageLive.tsx
+++ b/components/the-memes/MemePageLive.tsx
@@ -151,7 +151,12 @@ function MemePageAdditionalDetailsAccordion({
           tabIndex={isOpen ? undefined : -1}
           className={isOpen ? "tw-overflow-visible" : "tw-overflow-hidden"}
         >
-          <MemePageArt show={true} nft={nft} nftMeta={nftMeta} />
+          <MemePageArt
+            show={true}
+            nft={nft}
+            nftMeta={nftMeta}
+            locale={locale}
+          />
         </div>
       </div>
     </section>

--- a/components/the-memes/MemePageReferences.tsx
+++ b/components/the-memes/MemePageReferences.tsx
@@ -3,27 +3,137 @@
 import RememeImage from "@/components/nft-image/RememeImage";
 import Pagination from "@/components/pagination/Pagination";
 import { printMemeReferences } from "@/components/rememes/RememePage";
-import { RememeSort } from "@/components/rememes/Rememes";
+import { RememeSort } from "@/components/rememes/rememesTypes";
 import { publicEnv } from "@/config/env";
 import { OPENSEA_STORE_FRONT_CONTRACT } from "@/constants/constants";
 import type { DBResponse } from "@/entities/IDBResponse";
 import type { NFT, Rememe } from "@/entities/INFT";
-import {
-  areEqualAddresses,
-  formatAddress,
-  numberWithCommas,
-} from "@/helpers/Helpers";
+import { areEqualAddresses, formatAddress } from "@/helpers/Helpers";
+import { formatInteger } from "@/i18n/format";
+import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import { fetchUrl } from "@/services/6529api";
 import { faRefresh } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useReducer, useRef } from "react";
 import { Col, Container, Dropdown, Row } from "react-bootstrap";
 import { Tooltip } from "react-tooltip";
+import { getRememeSortLabel } from "../rememes/rememesI18n";
+import { getRememeDetailHref } from "../rememes/rememesRouteParams";
 import styles from "./TheMemes.module.scss";
 
 const REMEMES_PAGE_SIZE = 20;
+const REMEME_SORTING = [RememeSort.RANDOM, RememeSort.CREATED_ASC] as const;
+
+type MemeLabReferencesState = {
+  readonly loaded: boolean;
+  readonly nfts: NFT[];
+};
+
+type MemeLabReferencesAction =
+  | { readonly type: "loadSuccess"; readonly nfts: NFT[] }
+  | { readonly type: "loadError" };
+
+type RememesReferencesState = {
+  readonly totalResults: number;
+  readonly page: number;
+  readonly items: Rememe[];
+  readonly showSort: boolean;
+  readonly loaded: boolean;
+  readonly selectedSorting: RememeSort;
+};
+
+type RememesReferencesAction =
+  | {
+      readonly type: "loadSuccess";
+      readonly totalResults: number;
+      readonly items: Rememe[];
+    }
+  | { readonly type: "loadError" }
+  | { readonly type: "setPage"; readonly page: number }
+  | { readonly type: "setSorting"; readonly sorting: RememeSort };
+
+const INITIAL_MEME_LAB_REFERENCES_STATE: MemeLabReferencesState = {
+  loaded: false,
+  nfts: [],
+};
+
+const INITIAL_REMEMES_REFERENCES_STATE: RememesReferencesState = {
+  totalResults: 0,
+  page: 1,
+  items: [],
+  showSort: false,
+  loaded: false,
+  selectedSorting: RememeSort.RANDOM,
+};
+
+function memeLabReferencesReducer(
+  _state: MemeLabReferencesState,
+  action: MemeLabReferencesAction
+): MemeLabReferencesState {
+  switch (action.type) {
+    case "loadSuccess":
+      return {
+        loaded: true,
+        nfts: action.nfts,
+      };
+    case "loadError":
+      return {
+        loaded: true,
+        nfts: [],
+      };
+    default: {
+      const unhandled: never = action;
+      throw new Error(
+        `Unhandled MemeLabReferencesAction: ${String(unhandled)}`
+      );
+    }
+  }
+}
+
+function rememesReferencesReducer(
+  state: RememesReferencesState,
+  action: RememesReferencesAction
+): RememesReferencesState {
+  switch (action.type) {
+    case "loadSuccess":
+      return {
+        ...state,
+        totalResults: action.totalResults,
+        items: action.items,
+        showSort: action.totalResults > REMEMES_PAGE_SIZE,
+        loaded: true,
+      };
+    case "loadError":
+      return {
+        ...state,
+        totalResults: 0,
+        items: [],
+        showSort: false,
+        loaded: true,
+      };
+    case "setPage":
+      return {
+        ...state,
+        page: action.page,
+      };
+    case "setSorting":
+      return {
+        ...state,
+        page: 1,
+        totalResults: 0,
+        selectedSorting: action.sorting,
+      };
+    default: {
+      const unhandled: never = action;
+      throw new Error(
+        `Unhandled RememesReferencesAction: ${String(unhandled)}`
+      );
+    }
+  }
+}
 
 function buildRememesUrl(memeId: number, page: number, sorting: RememeSort) {
   const sort =
@@ -51,35 +161,33 @@ function getRememeName(rememe: Rememe) {
 export function MemePageReferencesSubMenu(props: {
   show: boolean;
   nft: NFT | undefined;
+  locale?: SupportedLocale | undefined;
 }) {
-  const [memeLabNftsLoaded, setMemeLabNftsLoaded] = useState(false);
-  const [memeLabNfts, setMemeLabNfts] = useState<NFT[]>([]);
-
-  const [rememesTotalResults, setRememesTotalResults] = useState(0);
-  const [rememesPage, setRememesPage] = useState(1);
-  const [rememes, setRememes] = useState<Rememe[]>([]);
-  const [showRememesSort, setShowRememesSort] = useState(false);
-  const [rememesLoaded, setRememesLoaded] = useState(false);
+  const locale = props.locale ?? DEFAULT_LOCALE;
+  const [memeLabState, setMemeLabNfts] = useReducer(
+    memeLabReferencesReducer,
+    INITIAL_MEME_LAB_REFERENCES_STATE
+  );
+  const [rememesState, dispatchRememesState] = useReducer(
+    rememesReferencesReducer,
+    INITIAL_REMEMES_REFERENCES_STATE
+  );
 
   const rememesTarget = useRef<HTMLDivElement>(null);
 
-  const rememeSorting = [RememeSort.RANDOM, RememeSort.CREATED_ASC];
-  const [selectedRememeSorting, setSelectedRememeSorting] =
-    useState<RememeSort>(RememeSort.RANDOM);
-
   function refreshRememes(memeId: number) {
-    void fetchUrl(buildRememesUrl(memeId, rememesPage, selectedRememeSorting))
+    void fetchUrl(
+      buildRememesUrl(memeId, rememesState.page, rememesState.selectedSorting)
+    )
       .then((response: DBResponse) => {
-        setRememesTotalResults(response.count);
-        setRememes(response.data);
-        setShowRememesSort(response.count > REMEMES_PAGE_SIZE);
-        setRememesLoaded(true);
+        dispatchRememesState({
+          type: "loadSuccess",
+          totalResults: response.count,
+          items: response.data,
+        });
       })
       .catch(() => {
-        setRememesTotalResults(0);
-        setRememes([]);
-        setShowRememesSort(false);
-        setRememesLoaded(true);
+        dispatchRememesState({ type: "loadError" });
       });
   }
 
@@ -89,12 +197,13 @@ export function MemePageReferencesSubMenu(props: {
         `${publicEnv.API_ENDPOINT}/api/nfts_memelab?sort_direction=asc&meme_id=${props.nft.id}`
       )
         .then((response: DBResponse) => {
-          setMemeLabNfts(response.data);
-          setMemeLabNftsLoaded(true);
+          setMemeLabNfts({
+            type: "loadSuccess",
+            nfts: response.data,
+          });
         })
         .catch(() => {
-          setMemeLabNfts([]);
-          setMemeLabNftsLoaded(true);
+          setMemeLabNfts({ type: "loadError" });
         });
     }
   }, [props.show, props.nft]);
@@ -102,26 +211,33 @@ export function MemePageReferencesSubMenu(props: {
   useEffect(() => {
     if (props.show && props.nft) {
       void fetchUrl(
-        buildRememesUrl(props.nft.id, rememesPage, selectedRememeSorting)
+        buildRememesUrl(
+          props.nft.id,
+          rememesState.page,
+          rememesState.selectedSorting
+        )
       )
         .then((response: DBResponse) => {
-          setRememesTotalResults(response.count);
-          setRememes(response.data);
-          setShowRememesSort(response.count > REMEMES_PAGE_SIZE);
-          setRememesLoaded(true);
+          dispatchRememesState({
+            type: "loadSuccess",
+            totalResults: response.count,
+            items: response.data,
+          });
         })
         .catch(() => {
-          setRememesTotalResults(0);
-          setRememes([]);
-          setShowRememesSort(false);
-          setRememesLoaded(true);
+          dispatchRememesState({ type: "loadError" });
         });
     }
-  }, [props.show, props.nft, rememesPage, selectedRememeSorting]);
+  }, [props.show, props.nft, rememesState.page, rememesState.selectedSorting]);
 
   if (!props.show) {
     return <></>;
   }
+
+  const selectedRememeSortingLabel = getRememeSortLabel(
+    rememesState.selectedSorting,
+    locale
+  );
 
   return (
     <>
@@ -133,17 +249,20 @@ export function MemePageReferencesSubMenu(props: {
             height="0"
             style={{ width: "250px", height: "auto" }}
             src="/memelab.png"
-            alt="memelab"
+            alt={t(locale, "theMemes.detail.references.memeLab.logoAlt")}
           />
         </Col>
       </Row>
       <Row className="pt-4 pb-2">
-        <Col>
-          The Meme Lab is the lab for Meme Artists to release work that is
-          related to The Meme Cards.
-        </Col>
+        <Col>{t(locale, "theMemes.detail.references.memeLab.description")}</Col>
       </Row>
-      {printMemeReferences(memeLabNfts, "meme-lab", memeLabNftsLoaded, true)}
+      {printMemeReferences(
+        memeLabState.nfts,
+        "meme-lab",
+        memeLabState.loaded,
+        true,
+        locale
+      )}
       <Row className="pt-3" ref={rememesTarget}>
         <Col className="d-flex flex-wrap align-items-center justify-content-between">
           <h1 className="mb-0 pt-2">
@@ -153,43 +272,54 @@ export function MemePageReferencesSubMenu(props: {
               height="0"
               style={{ width: "250px", height: "auto", float: "left" }}
               src="/re-memes.png"
-              alt="re-memes"
+              alt={t(locale, "theMemes.detail.references.rememes.logoAlt")}
             />
           </h1>
-          {showRememesSort && (
+          {rememesState.showSort && (
             <span className="d-flex align-items-center gap-2 pt-2">
               <Dropdown
                 className={styles["rememesSortDropdown"]}
                 drop={"down-centered"}
               >
-                <Dropdown.Toggle>Sort: {selectedRememeSorting}</Dropdown.Toggle>
+                <Dropdown.Toggle>
+                  {t(locale, "theMemes.detail.references.sort.trigger", {
+                    sort: selectedRememeSortingLabel,
+                  })}
+                </Dropdown.Toggle>
                 <Dropdown.Menu>
-                  {rememeSorting.map((s) => (
+                  {REMEME_SORTING.map((s) => (
                     <Dropdown.Item
                       key={`sorting-${s}`}
                       onClick={() => {
-                        setRememesPage(1);
-                        setRememesTotalResults(0);
-                        setSelectedRememeSorting(s);
+                        dispatchRememesState({
+                          type: "setSorting",
+                          sorting: s,
+                        });
                       }}
                     >
-                      {s}
+                      {getRememeSortLabel(s, locale)}
                     </Dropdown.Item>
                   ))}
                 </Dropdown.Menu>
               </Dropdown>
-              {selectedRememeSorting === RememeSort.RANDOM && (
+              {rememesState.selectedSorting === RememeSort.RANDOM && (
                 <>
-                  <FontAwesomeIcon
-                    icon={faRefresh}
-                    className={styles["buttonIcon"]}
+                  <button
+                    type="button"
+                    aria-label={t(
+                      locale,
+                      "theMemes.detail.references.refresh.ariaLabel"
+                    )}
+                    className={`${styles["buttonIcon"]} tw-inline-flex tw-min-h-6 tw-min-w-6 tw-items-center tw-justify-center tw-rounded-sm tw-border-0 tw-bg-transparent tw-p-0 tw-text-white focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400`}
                     onClick={() => {
                       if (props.nft) {
                         refreshRememes(props.nft.id);
                       }
                     }}
                     data-tooltip-id="refresh-rememes"
-                  />
+                  >
+                    <FontAwesomeIcon icon={faRefresh} aria-hidden="true" />
+                  </button>
                   <Tooltip
                     id="refresh-rememes"
                     place="top"
@@ -200,7 +330,7 @@ export function MemePageReferencesSubMenu(props: {
                       padding: "4px 8px",
                     }}
                   >
-                    Refresh results
+                    {t(locale, "theMemes.detail.references.refresh.tooltip")}
                   </Tooltip>
                 </>
               )}
@@ -209,21 +339,17 @@ export function MemePageReferencesSubMenu(props: {
         </Col>
       </Row>
       <Row className="pt-4 pb-2">
-        <Col>
-          ReMemes are community-created and community-submitted NFTs inspired by
-          the Meme Cards. They are not created or &quot;authorized&quot; by 6529
-          Collections.
-        </Col>
+        <Col>{t(locale, "theMemes.detail.references.rememes.description")}</Col>
       </Row>
-      {rememesLoaded && rememes.length === 0 && (
+      {rememesState.loaded && rememesState.items.length === 0 && (
         <Row className="pt-2 pb-4">
-          <Col>ReMemes that reference this NFT will appear here.</Col>
+          <Col>{t(locale, "theMemes.detail.references.empty.rememes")}</Col>
         </Row>
       )}
-      {rememes.length > 0 && (
+      {rememesState.items.length > 0 && (
         <>
           <Row className="py-2">
-            {rememes.map((rememe) => {
+            {rememesState.items.map((rememe) => {
               return (
                 <Col
                   key={`${rememe.contract}-${rememe.id}`}
@@ -234,7 +360,15 @@ export function MemePageReferencesSubMenu(props: {
                   lg={{ span: 3 }}
                 >
                   <Link
-                    href={`/rememes/${rememe.contract}/${rememe.id}`}
+                    href={getRememeDetailHref({
+                      contract: rememe.contract,
+                      id: rememe.id,
+                      locale,
+                    })}
+                    aria-label={t(locale, "rememes.card.linkAriaLabel", {
+                      name: getRememeName(rememe),
+                      tokenId: rememe.id,
+                    })}
                     className="decoration-none scale-hover"
                   >
                     <Container fluid className="no-padding">
@@ -273,8 +407,13 @@ export function MemePageReferencesSubMenu(props: {
                                 )}
                                 {rememe.replicas.length > 1 && (
                                   <>
-                                    &nbsp;(x
-                                    {numberWithCommas(rememe.replicas.length)})
+                                    &nbsp;
+                                    {t(locale, "rememes.card.replicaCount", {
+                                      count: formatInteger(
+                                        locale,
+                                        rememe.replicas.length
+                                      ),
+                                    })}
                                   </>
                                 )}
                               </Col>
@@ -295,14 +434,17 @@ export function MemePageReferencesSubMenu(props: {
               );
             })}
           </Row>
-          {rememesTotalResults > REMEMES_PAGE_SIZE && (
+          {rememesState.totalResults > REMEMES_PAGE_SIZE && (
             <Row className="text-center pt-2 pb-3">
               <Pagination
-                page={rememesPage}
+                page={rememesState.page}
                 pageSize={REMEMES_PAGE_SIZE}
-                totalResults={rememesTotalResults}
+                totalResults={rememesState.totalResults}
                 setPage={function (newPage: number) {
-                  setRememesPage(newPage);
+                  dispatchRememesState({
+                    type: "setPage",
+                    page: newPage,
+                  });
                   if (rememesTarget.current) {
                     rememesTarget.current.scrollIntoView({
                       behavior: "smooth",

--- a/components/the-memes/MemePageTimeline.tsx
+++ b/components/the-memes/MemePageTimeline.tsx
@@ -3,6 +3,8 @@
 import { publicEnv } from "@/config/env";
 import { MEMES_CONTRACT } from "@/constants/constants";
 import type { NFT, NFTHistory } from "@/entities/INFT";
+import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import { fetchAllPages } from "@/services/6529api";
 import { useEffect, useState } from "react";
 import { Col, Container, Row } from "react-bootstrap";
@@ -11,8 +13,10 @@ import Timeline from "../timeline/Timeline";
 export function MemePageTimeline(props: {
   show: boolean;
   nft: NFT | undefined;
+  locale?: SupportedLocale;
 }) {
   const [nftHistory, setNftHistory] = useState<NFTHistory[]>([]);
+  const locale = props.locale ?? DEFAULT_LOCALE;
 
   useEffect(() => {
     async function fetchHistory(url: string) {
@@ -27,13 +31,17 @@ export function MemePageTimeline(props: {
 
   if (props.show && props.nft) {
     return (
-      <Container className="pt-3 pb-5 no-padding">
-        <Row>
-          <Col xs={12} md={{ span: 10, offset: 1 }}>
-            {props.nft && <Timeline nft={props.nft} steps={nftHistory} />}
-          </Col>
-        </Row>
-      </Container>
+      <section aria-label={t(locale, "theMemes.detail.timeline.region")}>
+        <Container className="pt-3 pb-5 no-padding">
+          <Row>
+            <Col xs={12} md={{ span: 10, offset: 1 }}>
+              {props.nft && (
+                <Timeline nft={props.nft} steps={nftHistory} locale={locale} />
+              )}
+            </Col>
+          </Row>
+        </Container>
+      </section>
     );
   } else {
     return <></>;

--- a/components/timeline/Timeline.module.scss
+++ b/components/timeline/Timeline.module.scss
@@ -169,3 +169,8 @@
   font-size: smaller;
   overflow-wrap: anywhere;
 }
+
+.metadataValue {
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+}

--- a/components/timeline/Timeline.module.scss
+++ b/components/timeline/Timeline.module.scss
@@ -154,6 +154,7 @@
 }
 
 .timelineMediaImage {
+  height: auto;
   width: 100%;
   min-width: 150px;
 }

--- a/components/timeline/Timeline.tsx
+++ b/components/timeline/Timeline.tsx
@@ -126,7 +126,12 @@ export default function Timeline(props: Readonly<Props>) {
     return (
       <Col className="d-flex align-items-start flex-column gap-1">
         <b>{label}:</b>
-        <TimelineMediaComponent type={MediaType.IMAGE} url={value} />
+        <TimelineMediaComponent
+          type={MediaType.IMAGE}
+          url={value}
+          label={label}
+          locale={locale}
+        />
       </Col>
     );
   }
@@ -152,7 +157,12 @@ export default function Timeline(props: Readonly<Props>) {
     return (
       <Col className="d-flex align-items-start flex-column gap-1">
         <b>{label}:</b>
-        <TimelineMediaComponent type={getType()} url={value} />
+        <TimelineMediaComponent
+          type={getType()}
+          url={value}
+          label={label}
+          locale={locale}
+        />
       </Col>
     );
   }

--- a/components/timeline/Timeline.tsx
+++ b/components/timeline/Timeline.tsx
@@ -5,24 +5,33 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { numberWithCommasFromString } from "@/helpers/Helpers";
 import TimelineMediaComponent, { MediaType } from "./TimelineMedia";
 import { faExternalLinkSquare } from "@fortawesome/free-solid-svg-icons";
+import { formatDate } from "@/i18n/format";
+import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 
 interface Props {
   nft: BaseNFT;
   steps: NFTHistory[];
+  locale?: SupportedLocale;
 }
 
+const TIMELINE_DATE_FORMAT = {
+  day: "2-digit",
+  hour: "2-digit",
+  hour12: false,
+  minute: "2-digit",
+  month: "2-digit",
+  timeZone: "UTC",
+  year: "numeric",
+} satisfies Intl.DateTimeFormatOptions;
+
 export default function Timeline(props: Readonly<Props>) {
+  const locale = props.locale ?? DEFAULT_LOCALE;
+
   const getDateDisplay = (date: Date) => {
-    date = new Date(date);
-    return `${date.getUTCFullYear()}/${(date.getUTCMonth() + 1)
-      .toString()
-      .padStart(2, "0")}/${date
-      .getUTCDate()
-      .toString()
-      .padStart(2, "0")} - ${date
-      .getUTCHours()
-      .toString()
-      .padStart(2, "0")}:${date.getUTCMinutes().toString().padStart(2, "0")}`;
+    return t(locale, "timeline.date.utc", {
+      date: formatDate(locale, date, TIMELINE_DATE_FORMAT),
+    });
   };
 
   const getType = () => {
@@ -64,7 +73,8 @@ export default function Timeline(props: Readonly<Props>) {
         <div
           dangerouslySetInnerHTML={{
             __html: numberWithCommasFromString(value).replaceAll("\n", "<br>"),
-          }}></div>
+          }}
+        ></div>
       </Col>
     );
   }
@@ -73,13 +83,15 @@ export default function Timeline(props: Readonly<Props>) {
     if (from && to) {
       return (
         <>
-          {printAttribute("From", from)}
-          {printAttribute("To", to)}
+          {printAttribute(t(locale, "timeline.fields.from"), from)}
+          {printAttribute(t(locale, "timeline.fields.to"), to)}
         </>
       );
     }
 
-    const label = from ? "Removed Value" : "Added Value";
+    const label = from
+      ? t(locale, "timeline.fields.removedValue")
+      : t(locale, "timeline.fields.addedValue");
     const nonUndefined = from || to;
     return printAttribute(label, nonUndefined, true);
   }
@@ -99,13 +111,15 @@ export default function Timeline(props: Readonly<Props>) {
     if (from && to) {
       return (
         <>
-          {printLink("From", from)}
-          {printLink("To", to)}
+          {printLink(t(locale, "timeline.fields.from"), from)}
+          {printLink(t(locale, "timeline.fields.to"), to)}
         </>
       );
     }
 
-    const label = from ? "Removed URL" : "Added URL";
+    const label = from
+      ? t(locale, "timeline.fields.removedUrl")
+      : t(locale, "timeline.fields.addedUrl");
     const nonUndefined = from || to;
     return printLink(label, nonUndefined);
   }
@@ -123,13 +137,15 @@ export default function Timeline(props: Readonly<Props>) {
     if (from && to) {
       return (
         <>
-          {printImage("From", from)}
-          {printImage("To", to)}
+          {printImage(t(locale, "timeline.fields.from"), from)}
+          {printImage(t(locale, "timeline.fields.to"), to)}
         </>
       );
     }
 
-    const label = from ? "Removed Image" : "Added Image";
+    const label = from
+      ? t(locale, "timeline.fields.removedImage")
+      : t(locale, "timeline.fields.addedImage");
     const nonUndefined = from || to;
     return printImage(label, nonUndefined);
   }
@@ -147,13 +163,15 @@ export default function Timeline(props: Readonly<Props>) {
     if (from && to) {
       return (
         <>
-          {printAnimation("From", from)}
-          {printAnimation("To", to)}
+          {printAnimation(t(locale, "timeline.fields.from"), from)}
+          {printAnimation(t(locale, "timeline.fields.to"), to)}
         </>
       );
     }
 
-    const label = from ? "Removed Animation" : "Added Animation";
+    const label = from
+      ? t(locale, "timeline.fields.removedAnimation")
+      : t(locale, "timeline.fields.addedAnimation");
     const nonUndefined = from || to;
     return printAnimation(label, nonUndefined);
   }
@@ -167,9 +185,17 @@ export default function Timeline(props: Readonly<Props>) {
     } else if (isUrlKey(change.key)) {
       content = printFromToUrls(change.from, change.to);
     } else if (change.key.endsWith("(Added)")) {
-      content = printAttribute("Value", change.to, true);
+      content = printAttribute(
+        t(locale, "timeline.fields.value"),
+        change.to,
+        true
+      );
     } else if (change.key.endsWith("(Removed)")) {
-      content = printAttribute("Value", change.from, true);
+      content = printAttribute(
+        t(locale, "timeline.fields.value"),
+        change.from,
+        true
+      );
     } else {
       content = printFromToFields(change.from, change.to);
     }
@@ -185,10 +211,11 @@ export default function Timeline(props: Readonly<Props>) {
             key={`timeline-${step.block}`}
             className={`${styles["timelineContainer"]} ${
               index % 2 === 0 ? styles["right"] : styles["left"]
-            }`}>
+            }`}
+          >
             <div className={styles["content"]}>
               <h5 className="m-0 mb-3">
-                {`${getDateDisplay(step.transaction_date)} UTC`}
+                {getDateDisplay(step.transaction_date)}
               </h5>
               <Container className="no-padding">
                 <Row className="pb-1">
@@ -199,10 +226,13 @@ export default function Timeline(props: Readonly<Props>) {
                         href={step.uri}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="d-flex align-items-center justify-content-center gap-2 decoration-none">
-                        URI
+                        aria-label={t(locale, "timeline.links.uriAriaLabel")}
+                        className="d-flex align-items-center justify-content-center gap-2 decoration-none"
+                      >
+                        {t(locale, "timeline.links.uri")}
                         <FontAwesomeIcon
                           icon={faExternalLinkSquare}
+                          aria-hidden="true"
                           className={styles["linkIcon"]}
                         />
                       </a>
@@ -210,10 +240,13 @@ export default function Timeline(props: Readonly<Props>) {
                         href={`https://etherscan.io/tx/${step.transaction_hash}`}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="d-flex align-items-center justify-content-center gap-2 decoration-none">
-                        TXN
+                        aria-label={t(locale, "timeline.links.txnAriaLabel")}
+                        className="d-flex align-items-center justify-content-center gap-2 decoration-none"
+                      >
+                        {t(locale, "timeline.links.txn")}
                         <FontAwesomeIcon
                           icon={faExternalLinkSquare}
+                          aria-hidden="true"
                           className={styles["linkIcon"]}
                         />
                       </a>

--- a/components/timeline/Timeline.tsx
+++ b/components/timeline/Timeline.tsx
@@ -67,14 +67,12 @@ export default function Timeline(props: Readonly<Props>) {
   };
 
   function printAttribute(label: string, value: any, fullWidth?: boolean) {
+    const displayValue = String(numberWithCommasFromString(value));
+
     return (
       <Col sm={12} md={fullWidth ? 12 : 6}>
         <b>{label}:</b>{" "}
-        <div
-          dangerouslySetInnerHTML={{
-            __html: numberWithCommasFromString(value).replaceAll("\n", "<br>"),
-          }}
-        ></div>
+        <div className={styles["metadataValue"]}>{displayValue}</div>
       </Col>
     );
   }

--- a/components/timeline/TimelineMedia.tsx
+++ b/components/timeline/TimelineMedia.tsx
@@ -1,8 +1,12 @@
 import styles from "./Timeline.module.scss";
+import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 
 interface Props {
   type: MediaType;
   url: string;
+  label?: string;
+  locale?: SupportedLocale;
 }
 
 export enum MediaType {
@@ -12,28 +16,38 @@ export enum MediaType {
 }
 
 export default function TimelineMediaComponent(props: Readonly<Props>) {
+  const locale = props.locale ?? DEFAULT_LOCALE;
+  const label = props.label ?? t(locale, "timeline.media.defaultLabel");
+
   if (props.type === MediaType.VIDEO) {
     return (
       <video
+        aria-label={t(locale, "timeline.media.videoAriaLabel", { label })}
         autoPlay
         muted
         controls
         loop
         playsInline
         className={styles["timelineMediaImage"]}
-        src={props.url}></video>
+        src={props.url}
+      ></video>
     );
   }
   if (props.type === MediaType.HTML) {
     return (
-      <iframe className={styles["timelineMediaImage"]} src={props.url}></iframe>
+      <iframe
+        className={styles["timelineMediaImage"]}
+        src={props.url}
+        title={t(locale, "timeline.media.htmlTitle", { label })}
+      ></iframe>
     );
   }
   return (
+    // Native img is intentional: timeline media hosts come from arbitrary NFT metadata.
     <img
       src={props.url}
       className={styles["timelineMediaImage"]}
-      alt={props.url}
+      alt={t(locale, "timeline.media.imageAlt", { label })}
     />
   );
 }

--- a/components/user/collected/cards/UserPageCollectedCards.tsx
+++ b/components/user/collected/cards/UserPageCollectedCards.tsx
@@ -12,7 +12,20 @@ import {
   buildTransferKey,
   useTransfer,
 } from "@/components/nft-transfer/TransferState";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t as translate } from "@/i18n/messages";
 import type { ContractType } from "@/types/enums";
+
+const COLLECTED_CARDS_LIST_CLASS =
+  "tw-m-0 tw-grid tw-grid-cols-2 tw-gap-4 tw-pb-2 tw-pl-0 sm:tw-grid-cols-3 md:tw-grid-cols-4 lg:tw-gap-6";
+const COLLECTED_CARDS_LIST_LABEL = translate(
+  DEFAULT_LOCALE,
+  "user.collected.cards.listLabel"
+);
+// CSS marker removal can cause Safari/VoiceOver to drop native list semantics.
+const COLLECTED_CARDS_LIST_COMPATIBILITY_PROPS = {
+  role: "list",
+} as const;
 
 export default function UserPageCollectedCards({
   cards,
@@ -33,22 +46,26 @@ export default function UserPageCollectedCards({
   readonly dataTransfer: CollectedCard[];
   readonly isTransferLoading?: boolean | undefined;
 }) {
-  const t = useTransfer();
-  const isTransferEnabled = t.enabled;
+  const transfer = useTransfer();
+  const isTransferEnabled = transfer.enabled;
 
   return (
     <div>
       {cards.length ? (
         <div className="tw-flow-root">
-          <div className="tw-grid tw-grid-cols-2 tw-gap-4 tw-pb-2 sm:tw-grid-cols-3 md:tw-grid-cols-4 lg:tw-gap-6">
+          <ul
+            {...COLLECTED_CARDS_LIST_COMPATIBILITY_PROPS}
+            aria-label={COLLECTED_CARDS_LIST_LABEL}
+            className={COLLECTED_CARDS_LIST_CLASS}
+          >
             {cards.map((card) => {
               const selKey = buildTransferKey({
                 collection: card.collection,
                 tokenId: card.token_id,
                 fallback: `${card.collection}-${card.token_id}`,
               });
-              const selected = t.isSelected(selKey);
-              const selectedItem = t.selected.get(selKey);
+              const selected = transfer.isSelected(selKey);
+              const selectedItem = transfer.selected.get(selKey);
               const dataTransferItem = dataTransfer?.find(
                 (item: CollectedCard) =>
                   item.token_id === card.token_id &&
@@ -61,34 +78,40 @@ export default function UserPageCollectedCards({
               ] as ContractType;
 
               return (
-                <UserPageCollectedCard
+                <li
                   key={`${card.collection}-${card.token_id}`}
-                  card={card}
-                  contractType={contractType}
-                  showDataRow={showDataRow}
-                  interactiveMode={isTransferEnabled ? "select" : "link"}
-                  selected={selected}
-                  copiesMax={max}
-                  qtySelected={qty}
-                  isTransferLoading={isTransferLoading}
-                  onToggle={() =>
-                    t.toggleSelect({
-                      key: selKey,
-                      contract:
-                        COLLECTED_COLLECTION_TYPE_TO_CONTRACT[card.collection],
-                      contractType,
-                      tokenId: card.token_id,
-                      title: card.token_name,
-                      thumbUrl: card.img,
-                      max,
-                    })
-                  }
-                  onIncQty={() => t.incQty(selKey)}
-                  onDecQty={() => t.decQty(selKey)}
-                />
+                  className="tw-min-w-0 tw-list-none"
+                >
+                  <UserPageCollectedCard
+                    card={card}
+                    contractType={contractType}
+                    showDataRow={showDataRow}
+                    interactiveMode={isTransferEnabled ? "select" : "link"}
+                    selected={selected}
+                    copiesMax={max}
+                    qtySelected={qty}
+                    isTransferLoading={isTransferLoading}
+                    onToggle={() =>
+                      transfer.toggleSelect({
+                        key: selKey,
+                        contract:
+                          COLLECTED_COLLECTION_TYPE_TO_CONTRACT[
+                            card.collection
+                          ],
+                        contractType,
+                        tokenId: card.token_id,
+                        title: card.token_name,
+                        thumbUrl: card.img,
+                        max,
+                      })
+                    }
+                    onIncQty={() => transfer.incQty(selKey)}
+                    onDecQty={() => transfer.decQty(selKey)}
+                  />
+                </li>
               );
             })}
-          </div>
+          </ul>
           {totalPages > 1 && (
             <CommonTablePagination
               currentPage={page}

--- a/components/user/collected/cards/UserPageCollectedCardsNoCards.tsx
+++ b/components/user/collected/cards/UserPageCollectedCardsNoCards.tsx
@@ -2,47 +2,62 @@
 
 import { CollectedCollectionType, CollectionSeized } from "@/entities/IProfile";
 import { assertUnreachable } from "@/helpers/AllowlistToolHelpers";
-import { useEffect, useState } from "react";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t as translate } from "@/i18n/messages";
 import type { ProfileCollectedFilters } from "../UserPageCollected";
+
+const getNoCardsMessage = (filters: ProfileCollectedFilters): string => {
+  if (filters.seized !== CollectionSeized.NOT_SEIZED) {
+    return translate(DEFAULT_LOCALE, "user.collected.empty.noCards");
+  }
+  switch (filters.collection) {
+    case null:
+      return translate(DEFAULT_LOCALE, "user.collected.empty.fullSetter");
+    case CollectedCollectionType.MEMES:
+      if (filters.szn === null) {
+        return translate(
+          DEFAULT_LOCALE,
+          "user.collected.empty.memesFullSetter"
+        );
+      }
+      return translate(
+        DEFAULT_LOCALE,
+        "user.collected.empty.seasonFullSetter",
+        { season: filters.szn.display }
+      );
+    case CollectedCollectionType.GRADIENTS:
+      return translate(
+        DEFAULT_LOCALE,
+        "user.collected.empty.gradientFullSetter"
+      );
+    case CollectedCollectionType.MEMELAB:
+      return translate(
+        DEFAULT_LOCALE,
+        "user.collected.empty.memeLabFullSetter"
+      );
+    case CollectedCollectionType.NEXTGEN:
+      return translate(
+        DEFAULT_LOCALE,
+        "user.collected.empty.nextGenFullSetter"
+      );
+    case CollectedCollectionType.NETWORK:
+      return translate(DEFAULT_LOCALE, "user.collected.networkCards.empty");
+    default:
+      assertUnreachable(filters.collection);
+      return "";
+  }
+};
 
 export default function UserPageCollectedCardsNoCards({
   filters,
 }: {
   readonly filters: ProfileCollectedFilters;
 }) {
-  const getMsg = (): string => {
-    if (filters.seized !== CollectionSeized.NOT_SEIZED) {
-      return "No cards to display";
-    }
-    switch (filters.collection) {
-      case null:
-        return "Congratulations, full setter!";
-      case CollectedCollectionType.MEMES:
-        if (filters.szn === null) {
-          return "Congratulations, The Memes full setter!";
-        }
-        return `Congratulations, ${filters.szn.display} full setter!`;
-      case CollectedCollectionType.GRADIENTS:
-        return "Congratulations, Gradient full setter!";
-      case CollectedCollectionType.MEMELAB:
-        return "Congratulations, Meme Lab full setter!";
-      case CollectedCollectionType.NEXTGEN:
-        return "Congratulations, Next Gen full setter!";
-      case CollectedCollectionType.NETWORK:
-        return "No network tokens found";
-      default:
-        assertUnreachable(filters.collection);
-        return "";
-    }
-  };
-
-  const [msg, setMsg] = useState(getMsg());
-
-  useEffect(() => {
-    setMsg(getMsg());
-  }, [filters]);
+  const msg = getNoCardsMessage(filters);
 
   return (
-    <div className="tw-py-4 tw-text-sm tw-italic tw-text-iron-500">{msg}</div>
+    <output className="tw-block tw-py-4 tw-text-sm tw-italic tw-text-iron-500">
+      {msg}
+    </output>
   );
 }

--- a/components/user/collected/cards/UserPageCollectedNetworkCards.tsx
+++ b/components/user/collected/cards/UserPageCollectedNetworkCards.tsx
@@ -2,9 +2,38 @@ import CommonTablePagination from "@/components/utils/table/paginator/CommonTabl
 import type { ApiXTdhToken } from "@/generated/models/ApiXTdhToken";
 import { formatStatFloor } from "@/helpers/Helpers";
 import { useTokenMetadataQuery } from "@/hooks/useAlchemyNftQueries";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t as translate } from "@/i18n/messages";
 import type { TokenMetadata } from "@/types/nft";
 import Image from "next/image";
 import { useMemo, useState } from "react";
+
+const NETWORK_CARDS_LIST_CLASS =
+  "tw-m-0 tw-grid tw-list-none tw-grid-cols-2 tw-gap-4 tw-pb-2 tw-pl-0 sm:tw-grid-cols-3 md:tw-grid-cols-4 lg:tw-gap-6";
+const NETWORK_CARDS_LIST_LABEL = translate(
+  DEFAULT_LOCALE,
+  "user.collected.networkCards.listLabel"
+);
+const NETWORK_CARDS_EMPTY_TEXT = translate(
+  DEFAULT_LOCALE,
+  "user.collected.networkCards.empty"
+);
+const NETWORK_CARDS_DEFAULT_COLLECTION = translate(
+  DEFAULT_LOCALE,
+  "user.collected.networkCards.defaultCollection"
+);
+const NETWORK_CARDS_XTDH_LABEL = translate(
+  DEFAULT_LOCALE,
+  "user.collected.networkCards.xtdh"
+);
+const NETWORK_CARDS_XTDH_RATE_LABEL = translate(
+  DEFAULT_LOCALE,
+  "user.collected.networkCards.xtdhPerDay"
+);
+// CSS marker removal can cause Safari/VoiceOver to drop native list semantics.
+const NETWORK_CARDS_LIST_COMPATIBILITY_PROPS = {
+  role: "list",
+} as const;
 
 export default function UserPageCollectedNetworkCards({
   cards,
@@ -34,21 +63,28 @@ export default function UserPageCollectedNetworkCards({
   if (cards.length === 0) {
     return (
       <div className="tw-w-full tw-py-10 tw-text-center tw-text-iron-400">
-        No tokens found
+        {NETWORK_CARDS_EMPTY_TEXT}
       </div>
     );
   }
 
   return (
-    <div className="tw-grid tw-grid-cols-2 tw-gap-4 tw-pb-2 sm:tw-grid-cols-3 md:tw-grid-cols-4 lg:tw-gap-6">
-      {cards.map((card) => (
-        <NetworkCard
-          key={`${card.contract}-${card.token}`}
-          card={card}
-          metadata={metadata}
-        />
-      ))}
-      <div className="tw-col-span-full tw-mt-4">
+    <>
+      <ul
+        {...NETWORK_CARDS_LIST_COMPATIBILITY_PROPS}
+        aria-label={NETWORK_CARDS_LIST_LABEL}
+        className={NETWORK_CARDS_LIST_CLASS}
+      >
+        {cards.map((card) => (
+          <li
+            key={`${card.contract}-${card.token}`}
+            className="tw-min-w-0 tw-list-none"
+          >
+            <NetworkCard card={card} metadata={metadata} />
+          </li>
+        ))}
+      </ul>
+      <div className="tw-mt-4">
         <CommonTablePagination
           currentPage={page}
           setCurrentPage={setPage}
@@ -58,7 +94,7 @@ export default function UserPageCollectedNetworkCards({
           loading={false}
         />
       </div>
-    </div>
+    </>
   );
 }
 
@@ -79,6 +115,23 @@ function NetworkCard({
 
   const imageUrl = tokenMetadata?.imageUrl;
   const hasImageUrl = typeof imageUrl === "string" && imageUrl.length > 0;
+  const tokenName =
+    tokenMetadata?.name ??
+    translate(DEFAULT_LOCALE, "user.collected.networkCards.defaultTokenName", {
+      tokenId: card.token,
+    });
+  const collectionName =
+    tokenMetadata?.collectionName ?? NETWORK_CARDS_DEFAULT_COLLECTION;
+  const imageAlt = translate(
+    DEFAULT_LOCALE,
+    "user.collected.networkCards.imageAlt",
+    { name: tokenName }
+  );
+  const tokenLabel = translate(
+    DEFAULT_LOCALE,
+    "user.collected.networkCards.tokenLabel",
+    { tokenId: card.token }
+  );
 
   return (
     <div className="tw-group tw-relative tw-flex tw-flex-col tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-white/[0.02] tw-shadow-xl tw-transition-all tw-duration-300 hover:tw-border-white/30">
@@ -91,7 +144,7 @@ function NetworkCard({
             {hasImageUrl && (
               <Image
                 src={imageUrl}
-                alt={tokenMetadata?.collectionName ?? "Network Token"}
+                alt={imageAlt}
                 fill
                 onLoad={() => setIsImageLoaded(true)}
                 sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 25vw"
@@ -108,10 +161,10 @@ function NetworkCard({
 
         <div className="tw-flex tw-w-full tw-items-center tw-justify-between tw-gap-2 tw-px-4 tw-pt-4">
           <span className="tw-mr-2 tw-truncate tw-text-[10px] tw-font-bold tw-uppercase tw-tracking-wider tw-text-white/40">
-            {tokenMetadata?.collectionName ?? "Network"}
+            {collectionName}
           </span>
           <span className="tw-font-mono tw-text-[11px] tw-font-medium tw-text-white/50">
-            #{card.token}
+            {tokenLabel}
           </span>
         </div>
       </div>
@@ -119,19 +172,23 @@ function NetworkCard({
       <div className="tw-flex tw-h-full tw-w-full tw-flex-col tw-gap-1.5 tw-self-end tw-px-4 tw-pb-4 tw-pt-1.5">
         <div className="tw-flex tw-justify-between tw-gap-x-2">
           <span className="tw-block tw-w-full tw-truncate tw-text-sm tw-font-semibold tw-leading-snug tw-text-white/90 tw-transition-colors group-hover:tw-text-white">
-            {tokenMetadata?.name ?? `Token #${card.token}`}
+            {tokenName}
           </span>
         </div>
 
         <div className="tw-mt-2 tw-grid tw-grid-cols-2 tw-gap-3 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/[0.08] tw-pt-2.5">
           <span className="tw-flex tw-items-baseline tw-gap-1.5 tw-text-[13px] tw-font-semibold">
-            <span className="tw-order-2 tw-text-white/30">xTDH</span>
+            <span className="tw-order-2 tw-text-white/30">
+              {NETWORK_CARDS_XTDH_LABEL}
+            </span>
             <span className="tw-order-1 tw-text-white/80">
               {formatStatFloor(card.xtdh, 1)}
             </span>
           </span>
           <span className="tw-flex tw-items-baseline tw-justify-end tw-gap-1.5 tw-text-[13px] tw-font-semibold">
-            <span className="tw-order-2 tw-text-white/30">xTDH/day</span>
+            <span className="tw-order-2 tw-text-white/30">
+              {NETWORK_CARDS_XTDH_RATE_LABEL}
+            </span>
             <span className="tw-order-1 tw-text-white/80">
               {formatStatFloor(card.xtdh_rate, 1)}
             </span>

--- a/components/user/collected/filters/UserPageCollectedFilters.tsx
+++ b/components/user/collected/filters/UserPageCollectedFilters.tsx
@@ -16,6 +16,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import type { RefObject } from "react";
 import { useEffect, useRef, useState } from "react";
 import type { ProfileCollectedFilters } from "../UserPageCollected";
+import { getCollectedFilterMessage } from "./user-page-collected-filter-labels";
 import { COLLECTED_COLLECTIONS_META } from "./user-page-collected-filters.helpers";
 import UserPageCollectedFiltersNativeDropdown from "./UserPageCollectedFiltersNativeDropdown";
 import UserPageCollectedFiltersNetworkCollection from "./UserPageCollectedFiltersNetworkCollection";
@@ -69,7 +70,7 @@ export default function UserPageCollectedFilters({
     if (!container) return;
 
     checkScroll();
-    container.addEventListener("scroll", checkScroll);
+    container.addEventListener("scroll", checkScroll, { passive: true });
     window.addEventListener("resize", checkScroll);
 
     const resizeObserver = new ResizeObserver(() => {
@@ -125,12 +126,12 @@ export default function UserPageCollectedFilters({
 
   const mainTabItems: CommonSelectItem<MainTab>[] = [
     {
-      label: "Native",
+      label: getCollectedFilterMessage("user.collected.filters.view.native"),
       value: MainTab.NATIVE,
       key: MainTab.NATIVE,
     },
     {
-      label: "Network",
+      label: getCollectedFilterMessage("user.collected.filters.view.network"),
       value: MainTab.NETWORK,
       key: MainTab.NETWORK,
     },
@@ -163,7 +164,9 @@ export default function UserPageCollectedFilters({
               items={mainTabItems}
               activeItem={activeMainTab}
               setSelected={handleMainTabChange}
-              filterLabel="View"
+              filterLabel={getCollectedFilterMessage(
+                "user.collected.filters.view"
+              )}
               size="sm"
             />
 
@@ -219,7 +222,9 @@ export default function UserPageCollectedFilters({
           <div className="tw-pointer-events-none tw-absolute tw-bottom-0 tw-left-0 tw-top-0 tw-z-10 tw-w-24 tw-bg-gradient-to-r tw-from-black tw-via-black/40 tw-to-black/0" />
           <button
             onClick={scrollLeft}
-            aria-label="Scroll filters left"
+            aria-label={getCollectedFilterMessage(
+              "user.collected.filters.scrollLeft"
+            )}
             className="tw-group tw-absolute tw-left-0 tw-top-1/2 tw-z-20 tw-inline-flex tw-h-10 tw-w-10 tw--translate-y-1/2 tw-items-center tw-justify-start tw-border-none tw-bg-transparent tw-p-0 tw-outline-none"
           >
             <FontAwesomeIcon
@@ -234,7 +239,9 @@ export default function UserPageCollectedFilters({
           <div className="tw-pointer-events-none tw-absolute tw-bottom-0 tw-right-0 tw-top-0 tw-z-10 tw-w-24 tw-bg-gradient-to-l tw-from-black tw-via-black/40 tw-to-black/0" />
           <button
             onClick={scrollRight}
-            aria-label="Scroll filters right"
+            aria-label={getCollectedFilterMessage(
+              "user.collected.filters.scrollRight"
+            )}
             className="tw-group tw-absolute tw-right-0 tw-top-1/2 tw-z-20 tw-inline-flex tw-h-10 tw-w-10 tw--translate-y-1/2 tw-items-center tw-justify-end tw-border-none tw-bg-transparent tw-p-0 tw-outline-none"
           >
             <FontAwesomeIcon

--- a/components/user/collected/filters/UserPageCollectedFiltersNativeDropdown.tsx
+++ b/components/user/collected/filters/UserPageCollectedFiltersNativeDropdown.tsx
@@ -1,7 +1,10 @@
 import CommonDropdown from "@/components/utils/select/dropdown/CommonDropdown";
 import type { CommonSelectItem } from "@/components/utils/select/CommonSelect";
 import { CollectedCollectionType } from "@/entities/IProfile";
-import { COLLECTED_COLLECTIONS_META } from "./user-page-collected-filters.helpers";
+import {
+  getCollectedCollectionLabel,
+  getCollectedFilterMessage,
+} from "./user-page-collected-filter-labels";
 
 type SelectedType = CollectedCollectionType | null;
 
@@ -14,15 +17,17 @@ export default function UserPageCollectedFiltersNativeDropdown({
 }) {
   const items: CommonSelectItem<SelectedType>[] = [
     {
-      label: "All",
-      mobileLabel: "All Collections",
+      label: getCollectedFilterMessage("user.collected.filters.collection.all"),
+      mobileLabel: getCollectedFilterMessage(
+        "user.collected.filters.collection.allCollections"
+      ),
       value: null,
       key: "all",
     },
     ...Object.values(CollectedCollectionType)
       .filter((collection) => collection !== CollectedCollectionType.NETWORK)
       .map((collection) => ({
-        label: COLLECTED_COLLECTIONS_META[collection].label,
+        label: getCollectedCollectionLabel(collection),
         value: collection,
         key: collection,
       })),
@@ -32,7 +37,9 @@ export default function UserPageCollectedFiltersNativeDropdown({
     <CommonDropdown
       items={items}
       activeItem={selected}
-      filterLabel="Collection"
+      filterLabel={getCollectedFilterMessage(
+        "user.collected.filters.collection"
+      )}
       setSelected={setSelected}
       size="sm"
     />

--- a/components/user/collected/filters/UserPageCollectedFiltersNetworkCollection.tsx
+++ b/components/user/collected/filters/UserPageCollectedFiltersNetworkCollection.tsx
@@ -2,6 +2,7 @@ import CommonDropdown from "@/components/utils/select/dropdown/CommonDropdown";
 import type { CommonSelectItem } from "@/components/utils/select/CommonSelect";
 import { useXtdhCollectionsQuery } from "@/hooks/useXtdhCollectionsQuery";
 import { useMemo } from "react";
+import { getCollectedFilterMessage } from "./user-page-collected-filter-labels";
 
 export default function UserPageCollectedFiltersNetworkCollection({
   identity,
@@ -21,14 +22,18 @@ export default function UserPageCollectedFiltersNetworkCollection({
 
   const items: CommonSelectItem<string | null>[] = useMemo(() => {
     const allOption: CommonSelectItem<string | null> = {
-      label: "All",
-      mobileLabel: "All Collections",
+      label: getCollectedFilterMessage("user.collected.filters.collection.all"),
+      mobileLabel: getCollectedFilterMessage(
+        "user.collected.filters.collection.allCollections"
+      ),
       value: null,
       key: "all",
     };
 
     const collectionOptions = collections.map((c) => ({
-      label: c.collection_name ?? "Unknown Collection",
+      label:
+        c.collection_name ??
+        getCollectedFilterMessage("user.collected.filters.collection.unknown"),
       value: c.contract,
       key: c.contract,
     }));
@@ -40,7 +45,9 @@ export default function UserPageCollectedFiltersNetworkCollection({
     <CommonDropdown
       items={items}
       activeItem={selected}
-      filterLabel="Collection"
+      filterLabel={getCollectedFilterMessage(
+        "user.collected.filters.collection"
+      )}
       setSelected={setSelected}
       size="sm"
     />

--- a/components/user/collected/filters/UserPageCollectedFiltersSeized.tsx
+++ b/components/user/collected/filters/UserPageCollectedFiltersSeized.tsx
@@ -2,6 +2,10 @@ import type { RefObject } from "react";
 import { CollectionSeized } from "@/entities/IProfile";
 import type { CommonSelectItem } from "@/components/utils/select/CommonSelect";
 import CommonDropdown from "@/components/utils/select/dropdown/CommonDropdown";
+import {
+  getCollectedFilterMessage,
+  getCollectedSeizedLabel,
+} from "./user-page-collected-filter-labels";
 
 type SelectedType = CollectionSeized | null;
 
@@ -14,20 +18,17 @@ export default function UserPageCollectedFiltersSeized({
   readonly containerRef: RefObject<HTMLDivElement | null>;
   readonly setSelected: (selected: SelectedType) => void;
 }) {
-  const labels: { [key in CollectionSeized]: string } = {
-    [CollectionSeized.SEIZED]: "Seized",
-    [CollectionSeized.NOT_SEIZED]: "Not Seized",
-  };
-
   const items: CommonSelectItem<SelectedType>[] = [
     {
-      label: "All",
-      mobileLabel: "All Cards",
+      label: getCollectedFilterMessage("user.collected.filters.seized.all"),
+      mobileLabel: getCollectedFilterMessage(
+        "user.collected.filters.seized.allCards"
+      ),
       value: null,
       key: "all",
     },
     ...Object.values(CollectionSeized).map((seized) => ({
-      label: labels[seized],
+      label: getCollectedSeizedLabel(seized),
       value: seized,
       key: seized,
     })),
@@ -37,7 +38,7 @@ export default function UserPageCollectedFiltersSeized({
     <CommonDropdown
       items={items}
       activeItem={selected}
-      filterLabel="Seized"
+      filterLabel={getCollectedFilterMessage("user.collected.filters.seized")}
       containerRef={containerRef}
       setSelected={setSelected}
       size="sm"

--- a/components/user/collected/filters/UserPageCollectedFiltersSortBy.tsx
+++ b/components/user/collected/filters/UserPageCollectedFiltersSortBy.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 import type { CollectedCollectionType } from "@/entities/IProfile";
 import { CollectionSort } from "@/entities/IProfile";
 import type { SortDirection } from "@/entities/ISort";
 import type { CommonSelectItem } from "@/components/utils/select/CommonSelect";
 import CommonSelect from "@/components/utils/select/CommonSelect";
+import {
+  getCollectedFilterMessage,
+  getCollectedSortLabel,
+} from "./user-page-collected-filter-labels";
 import { COLLECTED_COLLECTIONS_META } from "./user-page-collected-filters.helpers";
 
 export default function UserPageCollectedFiltersSortBy({
@@ -19,19 +23,11 @@ export default function UserPageCollectedFiltersSortBy({
   readonly collection: CollectedCollectionType | null;
   readonly setSelected: (sort: CollectionSort) => void;
 }) {
-  const labels: { [key in CollectionSort]: string } = {
-    [CollectionSort.TOKEN_ID]: "Token ID",
-    [CollectionSort.TDH]: "TDH",
-    [CollectionSort.RANK]: "Rank",
-    [CollectionSort.XTDH]: "xTDH",
-    [CollectionSort.XTDH_DAY]: "xTDH/day",
-  };
-
-  const getItems = () => {
+  const items = useMemo(() => {
     const items: CommonSelectItem<CollectionSort>[] = Object.values(
       CollectionSort
     ).map((sort) => ({
-      label: labels[sort],
+      label: getCollectedSortLabel(sort),
       value: sort,
       key: sort,
     }));
@@ -48,19 +44,13 @@ export default function UserPageCollectedFiltersSortBy({
         item.value !== CollectionSort.XTDH_DAY
       );
     });
-  };
-  const [items, setItems] =
-    useState<CommonSelectItem<CollectionSort>[]>(getItems());
-
-  useEffect(() => {
-    setItems(getItems());
   }, [collection]);
 
   return (
     <CommonSelect
       items={items}
       activeItem={selected}
-      filterLabel="Sort By"
+      filterLabel={getCollectedFilterMessage("user.collected.filters.sortBy")}
       setSelected={setSelected}
       sortDirection={direction}
       size="sm"

--- a/components/user/collected/filters/user-page-collected-filter-labels.ts
+++ b/components/user/collected/filters/user-page-collected-filter-labels.ts
@@ -1,0 +1,52 @@
+import {
+  CollectedCollectionType,
+  CollectionSeized,
+  CollectionSort,
+} from "@/entities/IProfile";
+import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+import { t as translate, type MessageKey } from "@/i18n/messages";
+
+const COLLECTION_LABEL_KEYS: Record<CollectedCollectionType, MessageKey> = {
+  [CollectedCollectionType.MEMES]: "user.collected.filters.collection.memes",
+  [CollectedCollectionType.NEXTGEN]:
+    "user.collected.filters.collection.nextgen",
+  [CollectedCollectionType.GRADIENTS]:
+    "user.collected.filters.collection.gradients",
+  [CollectedCollectionType.MEMELAB]:
+    "user.collected.filters.collection.memeLab",
+  [CollectedCollectionType.NETWORK]:
+    "user.collected.filters.collection.network",
+};
+
+const SORT_LABEL_KEYS: Record<CollectionSort, MessageKey> = {
+  [CollectionSort.TOKEN_ID]: "user.collected.filters.sort.tokenId",
+  [CollectionSort.TDH]: "user.collected.filters.sort.tdh",
+  [CollectionSort.RANK]: "user.collected.filters.sort.rank",
+  [CollectionSort.XTDH]: "user.collected.filters.sort.xtdh",
+  [CollectionSort.XTDH_DAY]: "user.collected.filters.sort.xtdhDay",
+};
+
+const SEIZED_LABEL_KEYS: Record<CollectionSeized, MessageKey> = {
+  [CollectionSeized.SEIZED]: "user.collected.filters.seized.seized",
+  [CollectionSeized.NOT_SEIZED]: "user.collected.filters.seized.notSeized",
+};
+
+export const getCollectedFilterMessage = (
+  key: MessageKey,
+  locale: SupportedLocale = DEFAULT_LOCALE
+): string => translate(locale, key);
+
+export const getCollectedCollectionLabel = (
+  collection: CollectedCollectionType,
+  locale: SupportedLocale = DEFAULT_LOCALE
+): string => translate(locale, COLLECTION_LABEL_KEYS[collection]);
+
+export const getCollectedSortLabel = (
+  sort: CollectionSort,
+  locale: SupportedLocale = DEFAULT_LOCALE
+): string => translate(locale, SORT_LABEL_KEYS[sort]);
+
+export const getCollectedSeizedLabel = (
+  seized: CollectionSeized,
+  locale: SupportedLocale = DEFAULT_LOCALE
+): string => translate(locale, SEIZED_LABEL_KEYS[seized]);

--- a/components/user/collected/stats/helpers.ts
+++ b/components/user/collected/stats/helpers.ts
@@ -7,6 +7,8 @@ import type { ApiCollectedStats } from "@/generated/models/ApiCollectedStats";
 import type { ApiCollectedStatsSeason } from "@/generated/models/ApiCollectedStatsSeason";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import { formatNumberWithCommasOrDash } from "@/helpers/Helpers";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t as translate } from "@/i18n/messages";
 import type {
   CollectedHeaderMetric,
   CollectedStatsViewModel,
@@ -39,7 +41,9 @@ export const getSafeCollectedStatsIdentityKey = (
 };
 
 const formatMetricValue = (value: number | undefined) =>
-  `x${formatNumberWithCommasOrDash(value ?? 0)}`;
+  translate(DEFAULT_LOCALE, "user.collected.stats.metric.value", {
+    value: formatNumberWithCommasOrDash(value ?? 0),
+  });
 
 const parseSeasonNumber = (season: string) => {
   const trimmed = season.trim();
@@ -77,7 +81,7 @@ const buildMainMetrics = (
   if (collectedStats.nextgen_balance) {
     metrics.push({
       id: "nextgen",
-      label: "NextGen",
+      label: translate(DEFAULT_LOCALE, "user.collected.stats.metrics.nextGen"),
       val: formatMetricValue(collectedStats.nextgen_balance),
       collection: CollectedCollectionType.NEXTGEN,
     });
@@ -86,7 +90,7 @@ const buildMainMetrics = (
   if (memeSets > 0) {
     metrics.push({
       id: "memes_sets",
-      label: "Meme Sets",
+      label: translate(DEFAULT_LOCALE, "user.collected.stats.metrics.memeSets"),
       val: formatMetricValue(memeSets),
       collection: CollectedCollectionType.MEMES,
     });
@@ -96,11 +100,13 @@ const buildMainMetrics = (
     const uniqueSub =
       collectedStats.unique_memes === collectedStats.memes_balance
         ? undefined
-        : `unique x${formatNumberWithCommasOrDash(collectedStats.unique_memes)}`;
+        : translate(DEFAULT_LOCALE, "user.collected.stats.metrics.unique", {
+            value: formatNumberWithCommasOrDash(collectedStats.unique_memes),
+          });
 
     metrics.push({
       id: "memes",
-      label: "Memes",
+      label: translate(DEFAULT_LOCALE, "user.collected.stats.metrics.memes"),
       val: formatMetricValue(collectedStats.memes_balance),
       collection: CollectedCollectionType.MEMES,
       ...(uniqueSub ? { sub: uniqueSub } : {}),
@@ -110,7 +116,10 @@ const buildMainMetrics = (
   if (collectedStats.gradients_balance) {
     metrics.push({
       id: "gradients",
-      label: "Gradients",
+      label: translate(
+        DEFAULT_LOCALE,
+        "user.collected.stats.metrics.gradients"
+      ),
       val: formatMetricValue(collectedStats.gradients_balance),
       collection: CollectedCollectionType.GRADIENTS,
     });
@@ -119,7 +128,7 @@ const buildMainMetrics = (
   if (collectedStats.boost) {
     metrics.push({
       id: "boost",
-      label: "Boost",
+      label: translate(DEFAULT_LOCALE, "user.collected.stats.metrics.boost"),
       val: formatMetricValue(
         Number.parseFloat(collectedStats.boost.toFixed(2))
       ),
@@ -150,17 +159,29 @@ const buildDisplaySeason = (
   let detailText: string | null = null;
   if (isStarted) {
     if (nextSetCards > 0) {
-      detailText = `${formatNumberWithCommasOrDash(
-        nextSetCards
-      )}/${formatNumberWithCommasOrDash(totalCards)} to set ${setsHeld + 1}`;
+      detailText = translate(
+        DEFAULT_LOCALE,
+        "user.collected.stats.seasonTile.toNextSet",
+        {
+          held: formatNumberWithCommasOrDash(nextSetCards),
+          total: formatNumberWithCommasOrDash(totalCards),
+          setNumber: setsHeld + 1,
+        }
+      );
     } else if (setsHeld > 0) {
-      detailText = `Set ${formatNumberWithCommasOrDash(setsHeld)} complete`;
+      detailText = translate(
+        DEFAULT_LOCALE,
+        "user.collected.stats.seasonTile.setComplete",
+        { count: formatNumberWithCommasOrDash(setsHeld) }
+      );
     }
   }
 
   return {
     id: season.season,
-    label: `SZN${seasonNumber}`,
+    label: translate(DEFAULT_LOCALE, "user.collected.stats.seasonTile.label", {
+      seasonNumber,
+    }),
     seasonNumber,
     totalCards,
     setsHeld,

--- a/components/user/collected/stats/subcomponents/CollectedStatsDetailsPanel.tsx
+++ b/components/user/collected/stats/subcomponents/CollectedStatsDetailsPanel.tsx
@@ -4,6 +4,8 @@ import type { OwnerBalance, OwnerBalanceMemes } from "@/entities/IBalances";
 import type { MemeSeason } from "@/entities/ISeason";
 import type { ConsolidatedTDH, TDH } from "@/entities/ITDH";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t as translate } from "@/i18n/messages";
 
 interface CollectedStatsDetailsPanelProps {
   readonly isOpen: boolean;
@@ -28,6 +30,11 @@ export function CollectedStatsDetailsPanel({
   ownerBalance,
   balanceMemes,
 }: Readonly<CollectedStatsDetailsPanelProps>) {
+  const unavailableMessage = translate(
+    DEFAULT_LOCALE,
+    "user.collected.stats.details.unavailable"
+  );
+
   return (
     <CommonAnimationHeight>
       <div id={detailsId}>
@@ -35,7 +42,7 @@ export function CollectedStatsDetailsPanel({
           <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800/90 tw-bg-gradient-to-b tw-from-iron-900/30 tw-to-transparent tw-px-4 tw-pb-5 sm:tw-px-6 sm:tw-pb-6">
             {statsPath === null ? (
               <div className="tw-py-2 tw-text-sm tw-text-iron-400">
-                Stats are unavailable for this profile.
+                {unavailableMessage}
               </div>
             ) : (
               <UserPageStatsDetailsContent

--- a/components/user/collected/stats/subcomponents/CollectedStatsHeader.tsx
+++ b/components/user/collected/stats/subcomponents/CollectedStatsHeader.tsx
@@ -1,5 +1,7 @@
 import { ChartBarIcon } from "@heroicons/react/24/outline";
 import type { CollectedCollectionType } from "@/entities/IProfile";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t as translate } from "@/i18n/messages";
 import type { CollectedHeaderMetric } from "../types";
 
 interface CollectedStatsHeaderProps {
@@ -21,6 +23,16 @@ export function CollectedStatsHeader({
   onToggleDetails,
   onCollectionShortcut,
 }: Readonly<CollectedStatsHeaderProps>) {
+  const detailsLabel = translate(
+    DEFAULT_LOCALE,
+    "user.collected.stats.details.show"
+  );
+  const hideDetailsLabel = translate(
+    DEFAULT_LOCALE,
+    "user.collected.stats.details.hide"
+  );
+  const detailsButtonLabel = isDetailsOpen ? hideDetailsLabel : detailsLabel;
+
   return (
     <div className="tw-flex tw-flex-col tw-gap-4 md:tw-flex-row md:tw-items-start md:tw-justify-between">
       <div className="tw-min-w-0 tw-flex-1">
@@ -133,9 +145,9 @@ export function CollectedStatsHeader({
         ].join(" ")}
       >
         <span className="-tw-ml-1 tw-inline-flex tw-h-3.5 tw-w-3.5 tw-flex-shrink-0">
-          <ChartBarIcon className="tw-h-full tw-w-full" />
+          <ChartBarIcon aria-hidden="true" className="tw-h-full tw-w-full" />
         </span>
-        <span>{isDetailsOpen ? "Hide Details" : "Details"}</span>
+        <span>{detailsButtonLabel}</span>
       </button>
     </div>
   );

--- a/components/user/collected/stats/subcomponents/CollectedStatsSeasonTile.tsx
+++ b/components/user/collected/stats/subcomponents/CollectedStatsSeasonTile.tsx
@@ -1,3 +1,5 @@
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t as translate } from "@/i18n/messages";
 import { useReducedMotion } from "framer-motion";
 import { useState } from "react";
 import type { DisplaySeason } from "../types";
@@ -84,10 +86,25 @@ const getButtonClassName = (isSelected: boolean): string =>
 
 const getSetsHeldLabel = (setsHeld: number): string => {
   if (setsHeld <= 0) {
-    return "0 sets";
+    return translate(
+      DEFAULT_LOCALE,
+      "user.collected.stats.seasonTile.sets.zero"
+    );
   }
 
-  return `${setsHeld} set${setsHeld > 1 ? "s" : ""}`;
+  if (setsHeld === 1) {
+    return translate(
+      DEFAULT_LOCALE,
+      "user.collected.stats.seasonTile.sets.one",
+      { count: setsHeld }
+    );
+  }
+
+  return translate(
+    DEFAULT_LOCALE,
+    "user.collected.stats.seasonTile.sets.many",
+    { count: setsHeld }
+  );
 };
 
 export function CollectedStatsSeasonTile({

--- a/components/user/collected/stats/subcomponents/CollectedStatsSeasons.tsx
+++ b/components/user/collected/stats/subcomponents/CollectedStatsSeasons.tsx
@@ -1,3 +1,5 @@
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t as translate } from "@/i18n/messages";
 import type { RefObject } from "react";
 import type { DisplaySeason } from "../types";
 import { CollectedStatsSeasonTile } from "./CollectedStatsSeasonTile";
@@ -17,6 +19,47 @@ interface CollectedStatsSeasonsProps {
   readonly onActivateSeason: (seasonId: string) => void;
   readonly onSeasonShortcut?: ((seasonNumber: number) => void) | undefined;
   readonly onToggleExpanded: () => void;
+}
+
+interface SeasonTilesProps {
+  readonly seasons: DisplaySeason[];
+  readonly activeSeasonId: string | null;
+  readonly activeSeasonNumber: number | null;
+  readonly hasTouchScreen: boolean;
+  readonly shouldAnimateProgressOnMount: boolean;
+  readonly onActivateSeason: (seasonId: string) => void;
+  readonly onSeasonShortcut?: ((seasonNumber: number) => void) | undefined;
+}
+
+function SeasonTiles({
+  seasons,
+  activeSeasonId,
+  activeSeasonNumber,
+  hasTouchScreen,
+  shouldAnimateProgressOnMount,
+  onActivateSeason,
+  onSeasonShortcut,
+}: Readonly<SeasonTilesProps>) {
+  return (
+    <>
+      {seasons.map((season) => (
+        <CollectedStatsSeasonTile
+          key={season.id}
+          season={season}
+          isSelected={season.seasonNumber === activeSeasonNumber}
+          showDetailText={hasTouchScreen || season.id === activeSeasonId}
+          hasTouchScreen={hasTouchScreen}
+          shouldAnimateProgressOnMount={shouldAnimateProgressOnMount}
+          onPreview={() => onActivateSeason(season.id)}
+          onSelect={
+            onSeasonShortcut
+              ? () => onSeasonShortcut(season.seasonNumber)
+              : undefined
+          }
+        />
+      ))}
+    </>
+  );
 }
 
 export function CollectedStatsSeasons({
@@ -44,32 +87,42 @@ export function CollectedStatsSeasons({
     return null;
   }
 
-  const renderTiles = (seasons: DisplaySeason[]) =>
-    seasons.map((season) => (
-      <CollectedStatsSeasonTile
-        key={season.id}
-        season={season}
-        isSelected={season.seasonNumber === activeSeasonNumber}
-        showDetailText={hasTouchScreen || season.id === activeSeasonId}
-        hasTouchScreen={hasTouchScreen}
-        shouldAnimateProgressOnMount={shouldAnimateProgressOnMount}
-        onPreview={() => onActivateSeason(season.id)}
-        onSelect={
-          onSeasonShortcut
-            ? () => onSeasonShortcut(season.seasonNumber)
-            : undefined
-        }
-      />
-    ));
+  const title = translate(DEFAULT_LOCALE, "user.collected.stats.seasons.title");
+  const startedCount = translate(
+    DEFAULT_LOCALE,
+    "user.collected.stats.seasons.startedCount",
+    {
+      started: startedSeasons.length,
+      total: allSeasonCount,
+    }
+  );
+  const showLess = translate(
+    DEFAULT_LOCALE,
+    "user.collected.stats.seasons.showLess"
+  );
+  const showMore = translate(
+    DEFAULT_LOCALE,
+    "user.collected.stats.seasons.showMore",
+    { count: hiddenStartedSeasonCount }
+  );
+  const showMoreAriaLabel = translate(
+    DEFAULT_LOCALE,
+    "user.collected.stats.seasons.showMoreAriaLabel",
+    { count: hiddenStartedSeasonCount }
+  );
+  const unseizedLabel = translate(
+    DEFAULT_LOCALE,
+    "user.collected.stats.seasons.unseized"
+  );
 
   return (
     <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800 tw-pt-4">
       <div className="tw-flex tw-items-baseline tw-gap-2 tw-px-1">
         <span className="tw-text-xs tw-font-semibold tw-tracking-tight tw-text-iron-400">
-          Seasons
+          {title}
         </span>
         <span className="tw-ml-auto tw-text-[10px] tw-font-medium tw-text-iron-500">
-          {startedSeasons.length}/{allSeasonCount} started
+          {startedCount}
         </span>
       </div>
 
@@ -78,31 +131,39 @@ export function CollectedStatsSeasons({
           <>
             <div className="tw-w-full tw-pt-3">
               <div className="tw-flex tw-w-full tw-flex-wrap tw-items-start tw-gap-x-1 tw-gap-y-2">
-                {renderTiles(visibleStartedSeasons)}
+                <SeasonTiles
+                  seasons={visibleStartedSeasons}
+                  activeSeasonId={activeSeasonId}
+                  activeSeasonNumber={activeSeasonNumber}
+                  hasTouchScreen={hasTouchScreen}
+                  shouldAnimateProgressOnMount={shouldAnimateProgressOnMount}
+                  onActivateSeason={onActivateSeason}
+                  onSeasonShortcut={onSeasonShortcut}
+                />
               </div>
             </div>
 
             {hiddenStartedSeasonCount > 0 && (
-              <div className="tw-flex tw-justify-center -tw-mb-2 tw-mt-1">
+              <div className="-tw-mb-2 tw-mt-1 tw-flex tw-justify-center">
                 {isDesktopSeasonListExpanded ? (
                   <button
                     type="button"
                     aria-expanded
-                    aria-label="Show less"
+                    aria-label={showLess}
                     onClick={onToggleExpanded}
                     className={desktopToggleClassName}
                   >
-                    Show less
+                    {showLess}
                   </button>
                 ) : (
                   <button
                     type="button"
                     aria-expanded={false}
-                    aria-label={`Show ${hiddenStartedSeasonCount} more started seasons`}
+                    aria-label={showMoreAriaLabel}
                     onClick={onToggleExpanded}
                     className={desktopToggleClassName}
                   >
-                    +{hiddenStartedSeasonCount} more
+                    {showMore}
                   </button>
                 )}
               </div>
@@ -111,7 +172,15 @@ export function CollectedStatsSeasons({
         ) : (
           <div className="tw-overflow-x-auto tw-overflow-y-hidden tw-pb-2 tw-scrollbar-thin tw-scrollbar-track-iron-800 tw-scrollbar-thumb-iron-500 desktop-hover:hover:tw-scrollbar-thumb-iron-300">
             <div className="tw-flex tw-w-max tw-flex-nowrap tw-items-start tw-gap-x-3 tw-gap-y-0 tw-pt-3">
-              {renderTiles(startedSeasons)}
+              <SeasonTiles
+                seasons={startedSeasons}
+                activeSeasonId={activeSeasonId}
+                activeSeasonNumber={activeSeasonNumber}
+                hasTouchScreen={hasTouchScreen}
+                shouldAnimateProgressOnMount={shouldAnimateProgressOnMount}
+                onActivateSeason={onActivateSeason}
+                onSeasonShortcut={onSeasonShortcut}
+              />
             </div>
           </div>
         )}
@@ -120,7 +189,7 @@ export function CollectedStatsSeasons({
       {notStartedSeasons.length > 0 && (
         <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-1.5 tw-px-1 tw-pt-2">
           <span className="tw-mr-0.5 tw-text-[8px] tw-font-medium tw-text-iron-500">
-            Unseized
+            {unseizedLabel}
           </span>
           {notStartedSeasons.map((season) => (
             <span

--- a/components/user/collected/stats/useCollectedStatsData.ts
+++ b/components/user/collected/stats/useCollectedStatsData.ts
@@ -23,7 +23,7 @@ type CollectedStatsFetchState = {
   readonly shouldFetchBalanceMemes: boolean;
 };
 
-type CollectedStatsTdh = ConsolidatedTDH | TDH | undefined;
+type CollectedStatsTdh = ConsolidatedTDH | TDH;
 
 const DETAILS_DATA_STALE_TIME = 60_000;
 
@@ -41,10 +41,11 @@ const fetchStatsQuery = async <T>({
   }
 
   try {
-    return await commonApiFetch<T>({
+    const result = await commonApiFetch<T | undefined>({
       endpoint,
       signal,
     });
+    return result ?? fallback;
   } catch (error: unknown) {
     if (isAbortError(error)) {
       throw error;
@@ -119,7 +120,7 @@ const buildCollectedStatsDataResult = ({
   readonly shouldFetchSeasons: boolean;
   readonly shouldFetchTdh: boolean;
   readonly statsPath: string | null;
-  readonly tdh: CollectedStatsTdh;
+  readonly tdh: CollectedStatsTdh | undefined;
 }): UseCollectedStatsDataResult => ({
   statsPath,
   collectedStats: shouldFetchCollectedStats
@@ -162,19 +163,17 @@ export function useCollectedStatsData({
     statsPath,
   });
 
-  const { data: fetchedCollectedStats } = useQuery<
-    ApiCollectedStats | undefined
-  >({
+  const { data: fetchedCollectedStats } = useQuery<ApiCollectedStats | null>({
     queryKey: [STATS_QUERY_KEY, "collected-stats", collectedStatsIdentityKey],
     enabled: shouldFetchCollectedStats,
     retry: false,
     queryFn: ({ signal }) =>
-      fetchStatsQuery<ApiCollectedStats | undefined>({
+      fetchStatsQuery<ApiCollectedStats | null>({
         endpoint:
           collectedStatsIdentityKey === null
             ? null
             : `collected-stats/${encodeURIComponent(collectedStatsIdentityKey)}`,
-        fallback: undefined,
+        fallback: null,
         signal,
       }),
   });
@@ -192,28 +191,28 @@ export function useCollectedStatsData({
       }),
   });
 
-  const { data: fetchedTdh } = useQuery<CollectedStatsTdh>({
+  const { data: fetchedTdh } = useQuery<CollectedStatsTdh | null>({
     queryKey: [STATS_QUERY_KEY, "tdh", statsPath],
     enabled: shouldFetchTdh,
     retry: false,
     staleTime: DETAILS_DATA_STALE_TIME,
     queryFn: ({ signal }) =>
-      fetchStatsQuery<ConsolidatedTDH | TDH | undefined>({
+      fetchStatsQuery<CollectedStatsTdh | null>({
         endpoint: statsPath === null ? null : `tdh/${statsPath}`,
-        fallback: undefined,
+        fallback: null,
         signal,
       }),
   });
 
-  const { data: fetchedOwnerBalance } = useQuery<OwnerBalance | undefined>({
+  const { data: fetchedOwnerBalance } = useQuery<OwnerBalance | null>({
     queryKey: [STATS_QUERY_KEY, "owner-balance", statsPath],
     enabled: shouldFetchOwnerBalance,
     retry: false,
     staleTime: DETAILS_DATA_STALE_TIME,
     queryFn: ({ signal }) =>
-      fetchStatsQuery<OwnerBalance | undefined>({
+      fetchStatsQuery<OwnerBalance | null>({
         endpoint: statsPath === null ? null : `owners-balances/${statsPath}`,
-        fallback: undefined,
+        fallback: null,
         signal,
       }),
   });
@@ -234,9 +233,9 @@ export function useCollectedStatsData({
 
   return buildCollectedStatsDataResult({
     balanceMemes: fetchedBalanceMemes,
-    collectedStats: fetchedCollectedStats,
+    collectedStats: fetchedCollectedStats ?? undefined,
     initialStatsData,
-    ownerBalance: fetchedOwnerBalance,
+    ownerBalance: fetchedOwnerBalance ?? undefined,
     seasons: fetchedSeasons,
     shouldFetchBalanceMemes,
     shouldFetchCollectedStats,
@@ -244,6 +243,6 @@ export function useCollectedStatsData({
     shouldFetchSeasons,
     shouldFetchTdh,
     statsPath,
-    tdh: fetchedTdh,
+    tdh: fetchedTdh ?? undefined,
   });
 }

--- a/components/user/followers/UserPageFollowersModal.tsx
+++ b/components/user/followers/UserPageFollowersModal.tsx
@@ -1,5 +1,6 @@
 import MobileWrapperDialog from "@/components/mobile-wrapper-dialog/MobileWrapperDialog";
 import FollowersListWrapper from "@/components/utils/followers/FollowersListWrapper";
+import { getFollowersMessage } from "@/components/utils/followers/followers.messages";
 import useFollowersList from "@/hooks/useFollowersList";
 
 export default function UserPageFollowersModal({
@@ -18,7 +19,7 @@ export default function UserPageFollowersModal({
 
   return (
     <MobileWrapperDialog
-      title="Followers"
+      title={getFollowersMessage("followers.modal.title")}
       isOpen={isOpen}
       onClose={onClose}
       tall

--- a/components/user/layout/UserPageLayout.tsx
+++ b/components/user/layout/UserPageLayout.tsx
@@ -1,9 +1,18 @@
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
-import type { ReactNode } from "react";
+import { Suspense, type ReactNode } from "react";
 import UserPageHeader from "../user-page-header/UserPageHeader";
 import UserPageClientHydrator from "./UserPageClientHydrator";
 import UserPageDropModal from "./UserPageDropModal";
 import UserPageTabs from "./UserPageTabs";
+
+function UserPageTabsFallback() {
+  return (
+    <div
+      aria-hidden="true"
+      className="tw-min-h-[3.5rem] tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-700"
+    />
+  );
+}
 
 export default function UserPageLayout({
   profile: initialProfile,
@@ -32,7 +41,9 @@ export default function UserPageLayout({
           fallbackMainAddress={mainAddress}
         />
         <div className="tw-mx-auto tw-px-4 sm:tw-px-6 md:tw-px-8">
-          <UserPageTabs initialProfile={initialProfile} />
+          <Suspense fallback={<UserPageTabsFallback />}>
+            <UserPageTabs initialProfile={initialProfile} />
+          </Suspense>
           <div className="tw-mt-6 lg:tw-mt-8">{children}</div>
         </div>
       </div>

--- a/components/user/layout/UserPageTab.tsx
+++ b/components/user/layout/UserPageTab.tsx
@@ -3,10 +3,7 @@
 import Link from "next/link";
 import { useParams, useSearchParams } from "next/navigation";
 import { useEffect, useRef } from "react";
-import type {
-  UserPageTabConfig,
-  UserPageTabKey,
-} from "./userTabs.config";
+import type { UserPageTabConfig, UserPageTabKey } from "./userTabs.config";
 
 interface UserPageTabProps {
   readonly tab: UserPageTabConfig;
@@ -35,6 +32,7 @@ export default function UserPageTab({
   const classes = isActive ? activeClasses : inActiveClasses;
 
   const ref = useRef<HTMLAnchorElement>(null);
+  const linkLabel = tab.badge ? `${tab.title} ${tab.badge}` : tab.title;
 
   const isVisibleInViewportSide = () => {
     if (!parentRef.current || !ref.current) {
@@ -70,11 +68,14 @@ export default function UserPageTab({
       }}
       className={`${
         isActive ? "tw-pointer-events-none" : ""
-      }  tw-no-underline tw-leading-4 tw-p-0 tw-text-base tw-font-semibold`}>
+      } tw-p-0 tw-text-base tw-font-semibold tw-leading-4 tw-no-underline`}
+      aria-current={isActive ? "page" : undefined}
+      aria-label={linkLabel}
+    >
       <div className={classes}>
         {tab.title}
         {tab.badge && (
-          <span className="tw-ml-1 tw-rounded-full tw-bg-primary-300/20 tw-px-1.5 tw-py-0.5 tw-text-[0.625rem] tw-font-bold tw-uppercase tw-leading-none tw-text-primary-400 tw-tracking-wider">
+          <span className="tw-ml-1 tw-rounded-full tw-bg-primary-300/20 tw-px-1.5 tw-py-0.5 tw-text-[0.625rem] tw-font-bold tw-uppercase tw-leading-none tw-tracking-wider tw-text-primary-400">
             {tab.badge}
           </span>
         )}

--- a/components/user/layout/UserPageTabs.tsx
+++ b/components/user/layout/UserPageTabs.tsx
@@ -37,6 +37,7 @@ import {
 } from "./userTabs.config";
 import { shouldHideSubscriptions } from "./userPageVisibility";
 import { shouldDelayUserPageBrainRedirect } from "./userPageBrainAccess";
+import { getUserProfileTabsMessage } from "./user-tabs.messages";
 
 const DEFAULT_TAB = DEFAULT_USER_PAGE_TAB;
 const subscribeToClientRender = () => () => undefined;
@@ -245,7 +246,7 @@ export default function UserPageTabs({
     if (!container) return;
 
     checkScroll();
-    container.addEventListener("scroll", checkScroll);
+    container.addEventListener("scroll", checkScroll, { passive: true });
     window.addEventListener("resize", checkScroll);
 
     let resizeObserver: ResizeObserver | null = null;
@@ -290,16 +291,19 @@ export default function UserPageTabs({
   };
 
   return (
-    <div className="tw-relative tw-overflow-hidden tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-700">
+    <nav
+      aria-label={getUserProfileTabsMessage(
+        "user.profile.tabs.navigationLabel"
+      )}
+      className="tw-relative tw-overflow-hidden tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-700"
+    >
       <div
         ref={scrollContainerRef}
         className="tw-w-full tw-overflow-x-auto tw-overflow-y-hidden [-ms-overflow-style:none] [scrollbar-width:none] [touch-action:pan-x] [&::-webkit-scrollbar]:tw-hidden"
-        aria-label="Tabs"
       >
         <div
           ref={contentContainerRef}
           className="-tw-mb-px tw-flex tw-min-w-max tw-gap-x-3 lg:tw-gap-x-4"
-          aria-label="Tabs"
         >
           {visibleTabs.map((tabConfig) => (
             <UserPageTab
@@ -316,7 +320,9 @@ export default function UserPageTabs({
           <div className="tw-pointer-events-none tw-absolute tw-bottom-0 tw-left-0 tw-top-0 tw-z-10 tw-w-24 tw-bg-gradient-to-r tw-from-black tw-via-black/40 tw-to-black/0" />
           <button
             onClick={scrollLeft}
-            aria-label="Scroll tabs left"
+            aria-label={getUserProfileTabsMessage(
+              "user.profile.tabs.scrollLeft"
+            )}
             className="tw-group tw-absolute tw-left-0 tw-top-1/2 tw-z-20 tw-inline-flex tw-h-10 tw-w-10 tw--translate-y-1/2 tw-items-center tw-justify-start tw-border-none tw-bg-transparent tw-p-0 tw-outline-none"
           >
             <FontAwesomeIcon
@@ -331,7 +337,9 @@ export default function UserPageTabs({
           <div className="tw-pointer-events-none tw-absolute tw-bottom-0 tw-right-0 tw-top-0 tw-z-10 tw-w-24 tw-bg-gradient-to-l tw-from-black tw-via-black/40 tw-to-black/0" />
           <button
             onClick={scrollRight}
-            aria-label="Scroll tabs right"
+            aria-label={getUserProfileTabsMessage(
+              "user.profile.tabs.scrollRight"
+            )}
             className="tw-group tw-absolute tw-right-0 tw-top-1/2 tw-z-20 tw-inline-flex tw-h-10 tw-w-10 tw--translate-y-1/2 tw-items-center tw-justify-end tw-border-none tw-bg-transparent tw-p-0 tw-outline-none"
           >
             <FontAwesomeIcon
@@ -341,6 +349,6 @@ export default function UserPageTabs({
           </button>
         </>
       )}
-    </div>
+    </nav>
   );
 }

--- a/components/user/layout/user-tabs.messages.ts
+++ b/components/user/layout/user-tabs.messages.ts
@@ -1,0 +1,16 @@
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
+
+type UserProfileTabsMessageKey = Extract<
+  MessageKey,
+  `user.profile.tabs.${string}`
+>;
+
+type MessageParams = Record<string, string | number>;
+
+export function getUserProfileTabsMessage(
+  key: UserProfileTabsMessageKey,
+  params: MessageParams = {}
+): string {
+  return t(DEFAULT_LOCALE, key, params);
+}

--- a/components/user/layout/userTabs.config.ts
+++ b/components/user/layout/userTabs.config.ts
@@ -1,3 +1,5 @@
+import { getUserProfileTabsMessage } from "./user-tabs.messages";
+
 export type UserPageVisibilityContext = {
   readonly showWaves: boolean;
   readonly hasProfileWave: boolean;
@@ -7,10 +9,10 @@ export type UserPageVisibilityContext = {
 
 type UserPageTabDefinition = {
   readonly id: string;
-  readonly title: string;
+  readonly titleKey: Parameters<typeof getUserProfileTabsMessage>[0];
   readonly route: string;
-  readonly metaLabel?: string | undefined;
-  readonly badge?: string | undefined;
+  readonly metaLabelKey?: Parameters<typeof getUserProfileTabsMessage>[0];
+  readonly badgeKey?: Parameters<typeof getUserProfileTabsMessage>[0];
   readonly isVisible?:
     | ((context: UserPageVisibilityContext) => boolean)
     | undefined;
@@ -19,41 +21,41 @@ type UserPageTabDefinition = {
 const TAB_DEFINITIONS = [
   {
     id: "rep",
-    title: "Identity",
+    titleKey: "user.profile.tabs.identity",
     route: "",
   },
   {
     id: "brain",
-    title: "Brain",
+    titleKey: "user.profile.tabs.brain",
     route: "brain",
     isVisible: ({ showWaves }: UserPageVisibilityContext) => showWaves,
   },
   {
     id: "waves",
-    title: "Curation",
+    titleKey: "user.profile.tabs.curation",
     route: "curations",
   },
   {
     id: "collected",
-    title: "Collected",
+    titleKey: "user.profile.tabs.collected",
     route: "collected",
   },
   {
     id: "xtdh",
-    title: "xTDH",
+    titleKey: "user.profile.tabs.xtdh",
     route: "xtdh",
-    badge: "Beta",
+    badgeKey: "user.profile.tabs.badges.beta",
   },
   {
     id: "subscriptions",
-    title: "Subscriptions",
+    titleKey: "user.profile.tabs.subscriptions",
     route: "subscriptions",
     isVisible: ({ hideSubscriptions }: UserPageVisibilityContext) =>
       !hideSubscriptions,
   },
   {
     id: "proxy",
-    title: "Proxy",
+    titleKey: "user.profile.tabs.proxy",
     route: "proxy",
     isVisible: ({ isOwnProfile }: UserPageVisibilityContext) => isOwnProfile,
   },
@@ -66,15 +68,19 @@ export type UserPageTabKey = (typeof TAB_DEFINITIONS)[number]["id"];
 
 export type UserPageTabConfig = Omit<
   UserPageTabDefinition,
-  "id" | "metaLabel"
+  "id" | "titleKey" | "metaLabelKey" | "badgeKey"
 > & {
   readonly id: UserPageTabKey;
+  readonly title: string;
   readonly metaLabel: string;
+  readonly badge?: string | undefined;
 };
 
 export const USER_PAGE_TABS = USER_PAGE_TAB_DEFINITIONS.map((tab) => ({
   ...tab,
-  metaLabel: tab.metaLabel ?? tab.title,
+  title: getUserProfileTabsMessage(tab.titleKey),
+  metaLabel: getUserProfileTabsMessage(tab.metaLabelKey ?? tab.titleKey),
+  badge: tab.badgeKey ? getUserProfileTabsMessage(tab.badgeKey) : undefined,
 })) as readonly UserPageTabConfig[];
 
 export const USER_PAGE_TAB_MAP: Record<UserPageTabKey, UserPageTabConfig> =

--- a/components/user/stats/UserPageStatsActivityOverview.tsx
+++ b/components/user/stats/UserPageStatsActivityOverview.tsx
@@ -1,26 +1,227 @@
 "use client";
 
 import type {
-    AggregatedActivity,
-    AggregatedActivityMemes,
+  AggregatedActivity,
+  AggregatedActivityMemes,
 } from "@/entities/IAggregatedActivity";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
-import { numberWithCommas } from "@/helpers/Helpers";
+import { formatInteger, formatNumber } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
 import { commonApiFetch } from "@/services/api/common-api";
 import { Fragment, useEffect, useState } from "react";
 import { Accordion, Col, Container, Row, Table } from "react-bootstrap";
 import { getStatsPath } from "./userPageStats.helpers";
 import styles from "./UserPageStats.module.scss";
 import {
-    UserPageStatsTableHead,
-    UserPageStatsTableHr,
+  UserPageStatsTableHead,
+  UserPageStatsTableHr,
 } from "./UserPageStatsTableShared";
 
-function printEthValue(value: number | undefined) {
-  if (value === undefined) {
-    return "-";
+type ActivityOverviewMessageKey = Extract<
+  MessageKey,
+  `user.collected.stats.activityOverview.${string}`
+>;
+
+type NumericAggregatedActivityField = {
+  [Field in keyof AggregatedActivity]: AggregatedActivity[Field] extends number
+    ? Field
+    : never;
+}[keyof AggregatedActivity];
+type NumericAggregatedActivityMemesField = {
+  [Field in keyof AggregatedActivityMemes]: AggregatedActivityMemes[Field] extends number
+    ? Field
+    : never;
+}[keyof AggregatedActivityMemes];
+type ActivityValueType = "integer" | "eth";
+type OverviewFieldRoot =
+  | "airdrops"
+  | "transfers_in"
+  | "primary_purchases_count"
+  | "primary_purchases_value"
+  | "secondary_purchases_count"
+  | "secondary_purchases_value"
+  | "transfers_out"
+  | "burns"
+  | "sales_count"
+  | "sales_value";
+
+interface OverviewRowConfig {
+  readonly labelKey: ActivityOverviewMessageKey;
+  readonly valueType: ActivityValueType;
+  readonly fields: readonly [
+    NumericAggregatedActivityField,
+    NumericAggregatedActivityField,
+    NumericAggregatedActivityField,
+    NumericAggregatedActivityField,
+    NumericAggregatedActivityField,
+  ];
+}
+
+interface SeasonColumnConfig {
+  readonly labelKey: ActivityOverviewMessageKey;
+  readonly valueType: ActivityValueType;
+  readonly field: NumericAggregatedActivityMemesField;
+}
+
+const COLLECTION_FIELD_SUFFIXES = [
+  "",
+  "_memes",
+  "_nextgen",
+  "_gradients",
+  "_memelab",
+] as const;
+
+function collectionFields(
+  root: OverviewFieldRoot
+): OverviewRowConfig["fields"] {
+  return COLLECTION_FIELD_SUFFIXES.map(
+    (suffix) => `${root}${suffix}`
+  ) as unknown as OverviewRowConfig["fields"];
+}
+
+function overviewRow(
+  labelKey: ActivityOverviewMessageKey,
+  valueType: ActivityValueType,
+  root: OverviewFieldRoot
+): OverviewRowConfig {
+  return { labelKey, valueType, fields: collectionFields(root) };
+}
+
+function seasonColumn(
+  labelKey: ActivityOverviewMessageKey,
+  valueType: ActivityValueType,
+  field: NumericAggregatedActivityMemesField
+): SeasonColumnConfig {
+  return { labelKey, valueType, field };
+}
+
+const OVERVIEW_ROW_GROUPS: readonly (readonly OverviewRowConfig[])[] = [
+  [
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.airdrops",
+      "integer",
+      "airdrops"
+    ),
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.transfersIn",
+      "integer",
+      "transfers_in"
+    ),
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.mints",
+      "integer",
+      "primary_purchases_count"
+    ),
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.mintsEth",
+      "eth",
+      "primary_purchases_value"
+    ),
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.purchases",
+      "integer",
+      "secondary_purchases_count"
+    ),
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.purchasesEth",
+      "eth",
+      "secondary_purchases_value"
+    ),
+  ],
+  [
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.transfersOut",
+      "integer",
+      "transfers_out"
+    ),
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.burns",
+      "integer",
+      "burns"
+    ),
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.sales",
+      "integer",
+      "sales_count"
+    ),
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.salesEth",
+      "eth",
+      "sales_value"
+    ),
+  ],
+];
+
+const SEASON_ACTIVITY_COLUMNS: readonly SeasonColumnConfig[] = [
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.transfersIn",
+    "integer",
+    "transfers_in"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.airdrops",
+    "integer",
+    "airdrops"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.mints",
+    "integer",
+    "primary_purchases_count"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.mintsEth",
+    "eth",
+    "primary_purchases_value"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.purchases",
+    "integer",
+    "secondary_purchases_count"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.purchasesEth",
+    "eth",
+    "secondary_purchases_value"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.transfersOut",
+    "integer",
+    "transfers_out"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.burns",
+    "integer",
+    "burns"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.sales",
+    "integer",
+    "sales_count"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.salesEth",
+    "eth",
+    "sales_value"
+  ),
+];
+
+function activityMessage(
+  key: ActivityOverviewMessageKey,
+  params: Record<string, string | number> = {}
+): string {
+  return t(DEFAULT_LOCALE, key, params);
+}
+
+function formatActivityValue(
+  value: number | undefined,
+  valueType: ActivityValueType
+): string {
+  if (valueType === "eth") {
+    return formatNumber(DEFAULT_LOCALE, value, { maximumFractionDigits: 2 });
   }
-  return numberWithCommas(Math.round(value * 100) / 100);
+
+  return formatInteger(DEFAULT_LOCALE, value);
 }
 
 export default function UserPageStatsActivityOverview({
@@ -70,9 +271,9 @@ export default function UserPageStatsActivityOverview({
 
   return (
     <div className="pt-2 pb-2">
-      <div className="tw-flex pt-2 pb-2">
+      <div className="pt-2 pb-2 tw-flex">
         <h3 className="tw-mb-0 tw-text-lg tw-font-semibold tw-text-iron-100">
-          Activity Overview
+          {activityMessage("user.collected.stats.activityOverview.title")}
         </h3>
       </div>
       <div className="pt-2 pb-2">
@@ -85,7 +286,6 @@ export default function UserPageStatsActivityOverview({
   );
 }
 
-
 function UserPageStatsActivityOverviewTotals({
   activity,
 }: {
@@ -95,247 +295,33 @@ function UserPageStatsActivityOverviewTotals({
     <Accordion>
       <Accordion.Item defaultChecked={true} eventKey={"0"}>
         <Accordion.Button className={styles["collectedAccordionButton"]}>
-          <b>Overview</b>
+          <b>
+            {activityMessage("user.collected.stats.activityOverview.overview")}
+          </b>
         </Accordion.Button>
         <Accordion.Body className={styles["collectedAccordionBody"]}>
           <Container>
             <Row className={`pt-2 pb-2 ${styles["scrollContainer"]}`}>
               <Col>
                 <Table className={styles["collectedAccordionTable"]}>
-                  <UserPageStatsTableHead />
+                  <UserPageStatsTableHead
+                    caption={activityMessage(
+                      "user.collected.stats.activityOverview.tables.overviewCaption"
+                    )}
+                  />
                   <tbody>
-                    <UserPageStatsTableHr span={6} />
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Airdrops</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.airdrops)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.airdrops_memes)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.airdrops_nextgen)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.airdrops_gradients)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.airdrops_memelab)}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Transfers In</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_in)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_in_memes)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_in_nextgen)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_in_gradients)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_in_memelab)}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Mints</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.primary_purchases_count)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(
-                          activity?.primary_purchases_count_memes
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(
-                          activity?.primary_purchases_count_nextgen
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(
-                          activity?.primary_purchases_count_gradients
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(
-                          activity?.primary_purchases_count_memelab
-                        )}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Mints (ETH)</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(activity?.primary_purchases_value)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(activity?.primary_purchases_value_memes)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(
-                          activity?.primary_purchases_value_nextgen
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(
-                          activity?.primary_purchases_value_gradients
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(
-                          activity?.primary_purchases_value_memelab
-                        )}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Purchases</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.secondary_purchases_count)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(
-                          activity?.secondary_purchases_count_memes
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(
-                          activity?.secondary_purchases_count_nextgen
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(
-                          activity?.secondary_purchases_count_gradients
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(
-                          activity?.secondary_purchases_count_memelab
-                        )}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Purchases (ETH)</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(activity?.secondary_purchases_value)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(
-                          activity?.secondary_purchases_value_memes
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(
-                          activity?.secondary_purchases_value_nextgen
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(
-                          activity?.secondary_purchases_value_gradients
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(
-                          activity?.secondary_purchases_value_memelab
-                        )}
-                      </td>
-                    </tr>
-                    <UserPageStatsTableHr span={6} />
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Transfers Out</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_out)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_out_memes)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_out_nextgen)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_out_gradients)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_out_memelab)}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Burns</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.burns)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.burns_memes)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.burns_nextgen)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.burns_gradients)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.burns_memelab)}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Sales</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.sales_count)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.sales_count_memes)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.sales_count_nextgen)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.sales_count_gradients)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.sales_count_memelab)}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Sales (ETH)</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(activity?.sales_value)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(activity?.sales_value_memes)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(activity?.sales_value_nextgen)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(activity?.sales_value_gradients)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(activity?.sales_value_memelab)}
-                      </td>
-                    </tr>
+                    {OVERVIEW_ROW_GROUPS.map((group, groupIndex) => (
+                      <Fragment key={`activity-overview-group-${groupIndex}`}>
+                        <UserPageStatsTableHr span={6} />
+                        {group.map((row) => (
+                          <ActivityOverviewRow
+                            key={row.labelKey}
+                            row={row}
+                            activity={activity}
+                          />
+                        ))}
+                      </Fragment>
+                    ))}
                   </tbody>
                 </Table>
               </Col>
@@ -344,6 +330,27 @@ function UserPageStatsActivityOverviewTotals({
         </Accordion.Body>
       </Accordion.Item>
     </Accordion>
+  );
+}
+
+function ActivityOverviewRow({
+  row,
+  activity,
+}: {
+  readonly row: OverviewRowConfig;
+  readonly activity: AggregatedActivity | undefined;
+}) {
+  return (
+    <tr>
+      <th scope="row" className="!tw-text-[#93939f]">
+        <b>{activityMessage(row.labelKey)}</b>
+      </th>
+      {row.fields.map((field) => (
+        <td key={field} className="tw-text-right !tw-text-[#fff]">
+          {formatActivityValue(activity?.[field], row.valueType)}
+        </td>
+      ))}
+    </tr>
   );
 }
 
@@ -356,93 +363,72 @@ function UserPageStatsActivityOverviewMemes({
     <Accordion>
       <Accordion.Item defaultChecked={true} eventKey={"0"}>
         <Accordion.Button className={styles["collectedAccordionButton"]}>
-          <b>Memes Breakdown By Season</b>
+          <b>
+            {activityMessage(
+              "user.collected.stats.activityOverview.memesBySeason"
+            )}
+          </b>
         </Accordion.Button>
         <Accordion.Body className={styles["collectedAccordionBody"]}>
           <Container>
             <Row className={`pt-2 pb-2 ${styles["scrollContainer"]}`}>
               <Col>
-                {activity && (
+                {activity.length > 0 ? (
                   <Table className={styles["collectedAccordionTable"]}>
+                    <caption className="tw-sr-only">
+                      {activityMessage(
+                        "user.collected.stats.activityOverview.tables.memesBySeasonCaption"
+                      )}
+                    </caption>
                     <thead>
                       <tr>
-                        <th colSpan={1}></th>
-                        <th className="text-right !tw-text-[#93939f]">
-                          Transfers In
-                        </th>
-                        <th className="text-right !tw-text-[#93939f]">
-                          Airdrops
-                        </th>
-                        <th className="text-right !tw-text-[#93939f]">Mints</th>
-                        <th className="text-right !tw-text-[#93939f]">
-                          Mints (ETH)
-                        </th>
-                        <th className="text-right !tw-text-[#93939f]">
-                          Purchases
-                        </th>
-                        <th className="text-right !tw-text-[#93939f]">
-                          Purchases (ETH)
-                        </th>
-                        <th className="text-right !tw-text-[#93939f]">
-                          Transfers Out
-                        </th>
-                        <th className="text-right !tw-text-[#93939f]">Burns</th>
-                        <th className="text-right !tw-text-[#93939f]">Sales</th>
-                        <th className="text-right !tw-text-[#93939f]">
-                          Sales (ETH)
-                        </th>
+                        <th aria-hidden="true"></th>
+                        {SEASON_ACTIVITY_COLUMNS.map((column) => (
+                          <th
+                            key={column.field}
+                            scope="col"
+                            className="text-right !tw-text-[#93939f]"
+                          >
+                            {activityMessage(column.labelKey)}
+                          </th>
+                        ))}
                       </tr>
                     </thead>
                     <tbody>
                       {activity.map((activity) => (
                         <Fragment
-                          key={`stats-activity-memes-${activity.season}`}>
+                          key={`stats-activity-memes-${activity.season}`}
+                        >
                           <UserPageStatsTableHr span={11} />
                           <tr>
-                            <td className="!tw-text-[#93939f]">
-                              Season {activity.season}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {numberWithCommas(activity.transfers_in)}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {numberWithCommas(activity.airdrops)}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {numberWithCommas(
-                                activity.primary_purchases_count
+                            <th scope="row" className="!tw-text-[#93939f]">
+                              {activityMessage(
+                                "user.collected.stats.activityOverview.seasonLabel",
+                                { seasonNumber: activity.season }
                               )}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {printEthValue(activity.primary_purchases_value)}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {numberWithCommas(
-                                activity.secondary_purchases_count
-                              )}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {printEthValue(
-                                activity.secondary_purchases_value
-                              )}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {numberWithCommas(activity.transfers_out)}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {numberWithCommas(activity.burns)}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {numberWithCommas(activity.sales_count)}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {printEthValue(activity.sales_value)}
-                            </td>
+                            </th>
+                            {SEASON_ACTIVITY_COLUMNS.map((column) => (
+                              <td
+                                key={column.field}
+                                className="tw-text-right !tw-text-[#fff]"
+                              >
+                                {formatActivityValue(
+                                  activity[column.field],
+                                  column.valueType
+                                )}
+                              </td>
+                            ))}
                           </tr>
                         </Fragment>
                       ))}
                     </tbody>
                   </Table>
+                ) : (
+                  <p className="tw-mb-0 tw-px-2 tw-py-3 tw-text-sm tw-text-iron-300">
+                    {activityMessage(
+                      "user.collected.stats.activityOverview.tables.memesBySeasonEmpty"
+                    )}
+                  </p>
                 )}
               </Col>
             </Row>

--- a/components/user/stats/UserPageStatsBoostBreakdown.tsx
+++ b/components/user/stats/UserPageStatsBoostBreakdown.tsx
@@ -2,8 +2,41 @@ import type { ConsolidatedTDH, TDH, TDHBoostBreakdown } from "@/entities/ITDH";
 import { getRandomObjectId } from "@/helpers/AllowlistToolHelpers";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { formatNumber, roundTo } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
 import Link from "next/link";
 import { Tooltip } from "react-tooltip";
+
+const BOOST_VERSION = "1.4";
+const BOOST_VALUE_FORMAT_OPTIONS = {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+} satisfies Intl.NumberFormatOptions;
+
+type BoostMessageKey = Extract<
+  MessageKey,
+  `user.collected.stats.boostBreakdown.${string}`
+>;
+
+function boostMessage(
+  key: BoostMessageKey,
+  params: Record<string, string | number> = {}
+): string {
+  return t(DEFAULT_LOCALE, key, params);
+}
+
+function formatBoostValue(value: number | undefined | null): string {
+  if (value == null) {
+    return "-";
+  }
+
+  return formatNumber(DEFAULT_LOCALE, value, BOOST_VALUE_FORMAT_OPTIONS);
+}
+
+function hasBoostValue(value: number | undefined | null): value is number {
+  return value != null;
+}
 
 export default function UserPageStatsBoostBreakdown({
   tdh,
@@ -17,23 +50,26 @@ export default function UserPageStatsBoostBreakdown({
   function getMemeRow(name: string, breakdown: TDHBoostBreakdown | undefined) {
     return (
       <tr key={getRandomObjectId()}>
-        <td className="tw-px-8 sm:tw-px-10 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-iron-400">
+        <th
+          scope="row"
+          className="tw-group tw-whitespace-nowrap tw-px-8 tw-py-3 tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-10 sm:tw-text-md lg:tw-pr-4"
+        >
           {name}
-        </td>
-        <td className="tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-white-400 tw-text-center">
-          {breakdown?.available ? (
+        </th>
+        <td className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4">
+          {hasBoostValue(breakdown?.available) ? (
             <span className="d-flex align-items-center justify-content-center gap-2">
-              {breakdown.available.toFixed(2)}
+              {formatBoostValue(breakdown.available)}
               <BoostBreakdownInfo info={breakdown.available_info} />
             </span>
           ) : (
             "-"
           )}
         </td>
-        <td className="tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-white-400 tw-text-center">
-          {breakdown?.acquired ? (
+        <td className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4">
+          {hasBoostValue(breakdown?.acquired) ? (
             <span className="d-flex align-items-center justify-content-center gap-2">
-              {breakdown.acquired.toFixed(2)}
+              {formatBoostValue(breakdown.acquired)}
               <BoostBreakdownInfo info={breakdown.acquired_info} />
             </span>
           ) : (
@@ -47,9 +83,13 @@ export default function UserPageStatsBoostBreakdown({
   function getMemesRows() {
     const headerRow = (
       <tr key={getRandomObjectId()}>
-        <td className="tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-pt-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-white-400">
-          Memes
-        </td>
+        <th
+          scope="rowgroup"
+          colSpan={3}
+          className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-px-4 tw-pt-3 tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4"
+        >
+          {boostMessage("user.collected.stats.boostBreakdown.groups.memes")}
+        </th>
       </tr>
     );
 
@@ -58,7 +98,12 @@ export default function UserPageStatsBoostBreakdown({
 
     const baseRows = [
       headerRow,
-      getMemeRow("Full Collection Set", bb.memes_card_sets),
+      getMemeRow(
+        boostMessage(
+          "user.collected.stats.boostBreakdown.rows.fullCollectionSet"
+        ),
+        bb.memes_card_sets
+      ),
     ];
 
     if (bb.memes_card_sets?.acquired !== 0) {
@@ -75,11 +120,24 @@ export default function UserPageStatsBoostBreakdown({
 
     const extraRows = seasonKeys.flatMap((key) => {
       const sznNum = key.replace("memes_szn", "");
-      const rows = [getMemeRow(`SZN${sznNum}`, bb[key])];
+      const rows = [
+        getMemeRow(
+          boostMessage("user.collected.stats.boostBreakdown.seasonLabel", {
+            seasonNumber: sznNum,
+          }),
+          bb[key]
+        ),
+      ];
       if (key === "memes_szn1" && !bb[key]?.acquired) {
         rows.push(
-          getMemeRow("Genesis Set", bb.memes_genesis),
-          getMemeRow("Nakamoto", bb.memes_nakamoto)
+          getMemeRow(
+            boostMessage("user.collected.stats.boostBreakdown.rows.genesisSet"),
+            bb.memes_genesis
+          ),
+          getMemeRow(
+            boostMessage("user.collected.stats.boostBreakdown.rows.nakamoto"),
+            bb.memes_nakamoto
+          )
         );
       }
       return rows;
@@ -92,23 +150,26 @@ export default function UserPageStatsBoostBreakdown({
     if (breakdown) {
       return (
         <tr key={getRandomObjectId()}>
-          <td className="tw-border-t tw-border-x-0 tw-border-b-0 tw-border-solid tw-border-iron-800 tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-white-400">
+          <th
+            scope="row"
+            className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800 tw-px-4 tw-py-3 tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4"
+          >
             {name}
-          </td>
-          <td className="tw-border-t tw-border-x-0 tw-border-b-0 tw-border-solid tw-border-iron-800 tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-white-400 tw-text-center">
-            {breakdown.available ? (
+          </th>
+          <td className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800 tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4">
+            {hasBoostValue(breakdown.available) ? (
               <span className="d-flex align-items-center justify-content-center gap-2">
-                {breakdown.available.toFixed(2)}
+                {formatBoostValue(breakdown.available)}
                 <BoostBreakdownInfo info={breakdown.available_info} />
               </span>
             ) : (
               "-"
             )}
           </td>
-          <td className="tw-border-t tw-border-x-0 tw-border-b-0 tw-border-solid tw-border-iron-800 tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-white-400 tw-text-center">
-            {breakdown.acquired ? (
+          <td className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800 tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4">
+            {hasBoostValue(breakdown.acquired) ? (
               <span className="d-flex align-items-center justify-content-center gap-2">
-                {breakdown.acquired.toFixed(2)}
+                {formatBoostValue(breakdown.acquired)}
                 <BoostBreakdownInfo info={breakdown.acquired_info} />
               </span>
             ) : (
@@ -126,36 +187,53 @@ export default function UserPageStatsBoostBreakdown({
     <div className="tw-mt-6 lg:tw-mt-8">
       <div className="tw-flex tw-items-center tw-justify-between">
         <h3 className="tw-mb-0 tw-text-lg tw-font-semibold tw-text-iron-100">
-          Boost Breakdown
+          {boostMessage("user.collected.stats.boostBreakdown.title")}
         </h3>
         <span>
           <Link
             href="/network/tdh#tdh-1-4"
-            className="decoration-hover-underline tw-text-sm">
-            TDH Version: 1.4
+            className="decoration-hover-underline tw-text-sm"
+          >
+            {boostMessage("user.collected.stats.boostBreakdown.versionLink", {
+              version: BOOST_VERSION,
+            })}
           </Link>
         </span>
       </div>
-      <div className="tw-mt-2 lg:tw-mt-4 tw-bg-iron-950 tw-border tw-border-iron-700 tw-border-solid tw-rounded-lg tw-overflow-x-auto">
+      <div className="tw-mt-2 tw-overflow-x-auto tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 lg:tw-mt-4">
         <div className="tw-flow-root">
           <div className="tw-inline-block tw-min-w-full tw-align-middle">
             <table className="tw-min-w-full">
-              <thead className="tw-bg-iron-900 tw-border-b tw-border-iron-700 tw-border-x-0 tw-border-t-0">
+              <caption className="tw-sr-only">
+                {boostMessage(
+                  "user.collected.stats.boostBreakdown.tableCaption"
+                )}
+              </caption>
+              <thead className="tw-border-x-0 tw-border-b tw-border-t-0 tw-border-iron-700 tw-bg-iron-900">
                 <tr key={getRandomObjectId()}>
                   <th
                     scope="col"
-                    className="tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-iron-400">
-                    Type
+                    className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pr-4"
+                  >
+                    {boostMessage(
+                      "user.collected.stats.boostBreakdown.columns.type"
+                    )}
                   </th>
                   <th
                     scope="col"
-                    className="tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-iron-400  tw-text-center">
-                    Potential Boost
+                    className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pr-4"
+                  >
+                    {boostMessage(
+                      "user.collected.stats.boostBreakdown.columns.potential"
+                    )}
                   </th>
                   <th
                     scope="col"
-                    className="tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-iron-400 tw-text-center">
-                    Actual Boost
+                    className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pr-4"
+                  >
+                    {boostMessage(
+                      "user.collected.stats.boostBreakdown.columns.actual"
+                    )}
                   </th>
                 </tr>
               </thead>
@@ -164,35 +242,51 @@ export default function UserPageStatsBoostBreakdown({
                   <>
                     {getMemesRows()}
                     {getBaseBoostRow(
-                      "Gradients",
+                      boostMessage(
+                        "user.collected.stats.boostBreakdown.rows.gradients"
+                      ),
                       tdh?.boost_breakdown.gradients
                     )}
                     <tr key={getRandomObjectId()}>
-                      <td className="tw-border-t tw-border-x-0 tw-border-b-0 tw-border-solid tw-border-iron-700 tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-semibold tw-text-white-400">
-                        TOTAL BOOST
-                      </td>
-                      <td className="tw-border-t tw-border-x-0 tw-border-b-0 tw-border-solid tw-border-iron-700 tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-white-400 tw-text-center">
+                      <th
+                        scope="row"
+                        className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700 tw-px-4 tw-py-3 tw-text-sm tw-font-semibold sm:tw-px-6 sm:tw-text-md lg:tw-pr-4"
+                      >
+                        {boostMessage(
+                          "user.collected.stats.boostBreakdown.rows.total"
+                        )}
+                      </th>
+                      <td className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700 tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4">
                         {tdh?.boost ? (
                           <span className="d-flex align-items-center justify-content-center gap-2">
-                            {(
-                              tdh.boost_breakdown.memes_card_sets.available +
-                              tdh.boost_breakdown.gradients.available
-                            ).toFixed(2)}
+                            {formatBoostValue(
+                              (tdh.boost_breakdown.memes_card_sets?.available ??
+                                0) +
+                                (tdh.boost_breakdown.gradients?.available ?? 0)
+                            )}
                             <BoostBreakdownInfo
-                              info={["Total Potential Boost"]}
+                              info={[
+                                boostMessage(
+                                  "user.collected.stats.boostBreakdown.info.totalPotential"
+                                ),
+                              ]}
                             />
                           </span>
                         ) : (
                           "-"
                         )}
                       </td>
-                      <td className="tw-border-t tw-border-x-0 tw-border-b-0 tw-border-solid tw-border-iron-700 tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-white-400 tw-text-center">
+                      <td className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700 tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4">
                         {tdh?.boost ? (
                           <span className="d-flex align-items-center justify-content-center gap-2">
-                            {(Math.round((tdh.boost - 1) * 100) / 100).toFixed(
-                              2
-                            )}
-                            <BoostBreakdownInfo info={["Total Actual Boost"]} />
+                            {formatBoostValue(roundTo(tdh.boost - 1, 2))}
+                            <BoostBreakdownInfo
+                              info={[
+                                boostMessage(
+                                  "user.collected.stats.boostBreakdown.info.totalActual"
+                                ),
+                              ]}
+                            />
                           </span>
                         ) : (
                           "-"
@@ -219,13 +313,21 @@ function BoostBreakdownInfo({ info }: { readonly info: string[] }) {
 
   return (
     <>
-      <FontAwesomeIcon
-        icon={faInfoCircle}
-        height={16}
-        color="lightgrey"
-        cursor={"pointer"}
+      <button
+        type="button"
+        className="tw-inline-flex tw-items-center tw-border-0 tw-bg-transparent tw-p-0 tw-text-iron-300 hover:tw-text-iron-100 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400"
+        aria-label={boostMessage(
+          "user.collected.stats.boostBreakdown.info.ariaLabel"
+        )}
         data-tooltip-id={tooltipId}
-      />
+      >
+        <FontAwesomeIcon
+          icon={faInfoCircle}
+          height={16}
+          color="lightgrey"
+          aria-hidden="true"
+        />
+      </button>
       <Tooltip
         id={tooltipId}
         place="top"
@@ -234,11 +336,13 @@ function BoostBreakdownInfo({ info }: { readonly info: string[] }) {
           color: "white",
           padding: "4px 8px",
           zIndex: 10,
-        }}>
+        }}
+      >
         {info.length > 1 ? (
           <ul
             className="mb-0"
-            style={{ paddingLeft: "1rem", textAlign: "left" }}>
+            style={{ paddingLeft: "1rem", textAlign: "left" }}
+          >
             {info.map((i) => (
               <li key={getRandomObjectId()} className="text-left">
                 {i}

--- a/components/user/stats/UserPageStatsCollected.tsx
+++ b/components/user/stats/UserPageStatsCollected.tsx
@@ -1,19 +1,105 @@
 import type { OwnerBalance, OwnerBalanceMemes } from "@/entities/IBalances";
 import type { MemeSeason } from "@/entities/ISeason";
-import { numberWithCommas } from "@/helpers/Helpers";
-import { Fragment } from "react";
+import { formatInteger, formatPercent } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
+import { Fragment, type ReactNode } from "react";
 import { Accordion, Col, Container, Row, Table } from "react-bootstrap";
 import styles from "./UserPageStats.module.scss";
 import {
-    UserPageStatsTableHead,
-    UserPageStatsTableHr,
+  UserPageStatsTableHead,
+  UserPageStatsTableHr,
 } from "./UserPageStatsTableShared";
 
 function getRankDisplay(balance: number | undefined, rank: number | undefined) {
   if (!balance || !rank) {
     return "-";
   }
-  return `#${numberWithCommas(rank)}`;
+  return `#${formatInteger(DEFAULT_LOCALE, rank)}`;
+}
+
+const VALUE_CELL_CLASS = "tw-text-right !tw-text-[#fff]";
+const MUTED_VALUE_CELL_CLASS = "text-right !tw-text-[#93939f]";
+const ROW_HEADER_CLASS = "!tw-text-[#93939f]";
+
+type TotalsColumnConfig = readonly [
+  key: string,
+  balanceKey: keyof OwnerBalance,
+  balanceRankKey: keyof OwnerBalance,
+  tdhKey: keyof OwnerBalance | undefined,
+  tdhRankKey: keyof OwnerBalance | undefined,
+];
+
+const TOTALS_COLUMN_CONFIG = [
+  [
+    "total",
+    "total_balance",
+    "total_balance_rank",
+    "boosted_tdh",
+    "boosted_tdh_rank",
+  ],
+  [
+    "memes",
+    "memes_balance",
+    "memes_balance_rank",
+    "boosted_memes_tdh",
+    "boosted_memes_tdh_rank",
+  ],
+  [
+    "nextgen",
+    "nextgen_balance",
+    "nextgen_balance_rank",
+    "boosted_nextgen_tdh",
+    "boosted_nextgen_tdh_rank",
+  ],
+  [
+    "gradients",
+    "gradients_balance",
+    "gradients_balance_rank",
+    "boosted_gradients_tdh",
+    "boosted_gradients_tdh_rank",
+  ],
+  ["memelab", "memelab_balance", "memelab_balance_rank", undefined, undefined],
+] as const satisfies readonly TotalsColumnConfig[];
+
+function getOwnerBalanceNumber(
+  ownerBalance: OwnerBalance | undefined,
+  key: keyof OwnerBalance | undefined
+) {
+  const value = key ? ownerBalance?.[key] : undefined;
+  return typeof value === "number" ? value : undefined;
+}
+
+function NumberCell({ value }: { readonly value: number | null | undefined }) {
+  return (
+    <td className={VALUE_CELL_CLASS}>{formatInteger(DEFAULT_LOCALE, value)}</td>
+  );
+}
+
+function RankCell({
+  balance,
+  rank,
+}: {
+  readonly balance: number | undefined;
+  readonly rank: number | undefined;
+}) {
+  return <td className={VALUE_CELL_CLASS}>{getRankDisplay(balance, rank)}</td>;
+}
+
+function MutedCell({ children }: { readonly children: ReactNode }) {
+  return <td className={MUTED_VALUE_CELL_CLASS}>{children}</td>;
+}
+
+function RowHeader({ children }: { readonly children: ReactNode }) {
+  return (
+    <th scope="row" className={ROW_HEADER_CLASS}>
+      <b>{children}</b>
+    </th>
+  );
+}
+
+function roundedTdhValue(value: number | undefined, hasOwnerBalance: boolean) {
+  return hasOwnerBalance && value !== undefined ? Math.round(value) : undefined;
 }
 
 export default function UserPageStatsCollected({
@@ -27,9 +113,9 @@ export default function UserPageStatsCollected({
 }) {
   return (
     <div className="pt-2 pb-2">
-      <div className="tw-flex pt-2 pb-2">
+      <div className="pt-2 pb-2 tw-flex">
         <h3 className="tw-mb-0 tw-text-lg tw-font-semibold tw-text-iron-100">
-          Collected
+          {t(DEFAULT_LOCALE, "user.collected.stats.details.collected.title")}
         </h3>
       </div>
       <div className="pt-2 pb-2">
@@ -50,141 +136,104 @@ function UserPageStatsCollectedTotals({
 }: {
   readonly ownerBalance: OwnerBalance | undefined;
 }) {
+  const totalColumns = TOTALS_COLUMN_CONFIG.map(
+    ([key, balanceKey, balanceRankKey, tdhKey, tdhRankKey]) => ({
+      key,
+      balance: getOwnerBalanceNumber(ownerBalance, balanceKey),
+      balanceRank: getOwnerBalanceNumber(ownerBalance, balanceRankKey),
+      tdh: getOwnerBalanceNumber(ownerBalance, tdhKey),
+      tdhRank: getOwnerBalanceNumber(ownerBalance, tdhRankKey),
+      hasTdh: tdhKey !== undefined,
+    })
+  );
+
   return (
     <Accordion>
       <Accordion.Item defaultChecked={true} eventKey={"0"}>
         <Accordion.Button className={styles["collectedAccordionButton"]}>
-          <b>Overview</b>
+          <b>{t(DEFAULT_LOCALE, "user.collected.stats.details.overview")}</b>
         </Accordion.Button>
         <Accordion.Body className={styles["collectedAccordionBody"]}>
           <Container>
             <Row className={`pt-2 pb-2 ${styles["scrollContainer"]}`}>
               <Col>
                 <Table className={styles["collectedAccordionTable"]}>
-                  <UserPageStatsTableHead />
+                  <UserPageStatsTableHead
+                    caption={t(
+                      DEFAULT_LOCALE,
+                      "user.collected.stats.details.tables.overviewCaption"
+                    )}
+                  />
                   <tbody>
                     <UserPageStatsTableHr span={6} />
                     <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Cards</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(ownerBalance?.total_balance)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(ownerBalance?.memes_balance)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(ownerBalance?.nextgen_balance)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(ownerBalance?.gradients_balance)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(ownerBalance?.memelab_balance)}
-                      </td>
+                      <RowHeader>
+                        {t(
+                          DEFAULT_LOCALE,
+                          "user.collected.stats.details.rows.cards"
+                        )}
+                      </RowHeader>
+                      {totalColumns.map((column) => (
+                        <NumberCell key={column.key} value={column.balance} />
+                      ))}
                     </tr>
                     <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Rank</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {getRankDisplay(
-                          ownerBalance?.total_balance,
-                          ownerBalance?.total_balance_rank
+                      <RowHeader>
+                        {t(
+                          DEFAULT_LOCALE,
+                          "user.collected.stats.details.rows.rank"
                         )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {getRankDisplay(
-                          ownerBalance?.memes_balance,
-                          ownerBalance?.memes_balance_rank
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {getRankDisplay(
-                          ownerBalance?.nextgen_balance,
-                          ownerBalance?.nextgen_balance_rank
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {getRankDisplay(
-                          ownerBalance?.gradients_balance,
-                          ownerBalance?.gradients_balance_rank
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {getRankDisplay(
-                          ownerBalance?.memelab_balance,
-                          ownerBalance?.memelab_balance_rank
-                        )}
-                      </td>
+                      </RowHeader>
+                      {totalColumns.map((column) => (
+                        <RankCell
+                          key={column.key}
+                          balance={column.balance}
+                          rank={column.balanceRank}
+                        />
+                      ))}
                     </tr>
                     <UserPageStatsTableHr span={6} />
                     <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>TDH</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {ownerBalance
-                          ? numberWithCommas(
-                              Math.round(ownerBalance.boosted_tdh)
-                            )
-                          : "-"}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {ownerBalance
-                          ? numberWithCommas(
-                              Math.round(ownerBalance?.boosted_memes_tdh)
-                            )
-                          : "-"}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {ownerBalance
-                          ? numberWithCommas(
-                              Math.round(ownerBalance?.boosted_nextgen_tdh)
-                            )
-                          : "-"}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {ownerBalance
-                          ? numberWithCommas(
-                              Math.round(ownerBalance?.boosted_gradients_tdh)
-                            )
-                          : "-"}
-                      </td>
-                      <td className="text-right !tw-text-[#93939f]">*</td>
+                      <RowHeader>
+                        {t(
+                          DEFAULT_LOCALE,
+                          "user.collected.stats.details.rows.tdh"
+                        )}
+                      </RowHeader>
+                      {totalColumns.map((column) =>
+                        column.hasTdh ? (
+                          <NumberCell
+                            key={column.key}
+                            value={roundedTdhValue(column.tdh, !!ownerBalance)}
+                          />
+                        ) : (
+                          <MutedCell key={column.key}>*</MutedCell>
+                        )
+                      )}
                     </tr>
                     <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Rank</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {getRankDisplay(
-                          ownerBalance?.boosted_tdh,
-                          ownerBalance?.boosted_tdh_rank
+                      <RowHeader>
+                        {t(
+                          DEFAULT_LOCALE,
+                          "user.collected.stats.details.rows.rank"
                         )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {getRankDisplay(
-                          ownerBalance?.boosted_memes_tdh,
-                          ownerBalance?.boosted_memes_tdh_rank
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {getRankDisplay(
-                          ownerBalance?.boosted_nextgen_tdh,
-                          ownerBalance?.boosted_nextgen_tdh_rank
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {getRankDisplay(
-                          ownerBalance?.boosted_gradients_tdh,
-                          ownerBalance?.boosted_gradients_tdh_rank
-                        )}
-                      </td>
-                      <td className="text-right !tw-text-[#93939f]">
-                        * No TDH
-                      </td>
+                      </RowHeader>
+                      {totalColumns.map((column) =>
+                        column.hasTdh ? (
+                          <RankCell
+                            key={column.key}
+                            balance={column.tdh}
+                            rank={column.tdhRank}
+                          />
+                        ) : (
+                          <MutedCell key={column.key}>
+                            {t(
+                              DEFAULT_LOCALE,
+                              "user.collected.stats.details.rows.noTdh"
+                            )}
+                          </MutedCell>
+                        )
+                      )}
                     </tr>
                   </tbody>
                 </Table>
@@ -204,18 +253,30 @@ function UserPageStatsCollectedMemes({
   readonly balanceMemes: OwnerBalanceMemes[];
   readonly seasons: MemeSeason[];
 }) {
-  function getDisplayWithValueAndRank(value: number, rank: number) {
-    if (!value) {
+  const memeColumns = [
+    t(DEFAULT_LOCALE, "user.collected.stats.details.tables.column.total"),
+    t(DEFAULT_LOCALE, "user.collected.stats.details.tables.column.unique"),
+    t(DEFAULT_LOCALE, "user.collected.stats.details.tables.column.sets"),
+    t(DEFAULT_LOCALE, "user.collected.stats.details.rows.tdh"),
+  ];
+
+  function getDisplayWithValueAndRank(
+    value: number | null | undefined,
+    rank: number | null | undefined
+  ) {
+    if (!value || !Number.isFinite(value)) {
       return "-";
     }
-    if (!rank) {
-      return numberWithCommas(value);
+    if (!rank || !Number.isFinite(rank)) {
+      return formatInteger(DEFAULT_LOCALE, value);
     }
 
     return (
       <>
-        {numberWithCommas(value)}{" "}
-        <span className="!tw-text-[#93939f]">(#{numberWithCommas(rank)})</span>
+        {formatInteger(DEFAULT_LOCALE, value)}{" "}
+        <span className="!tw-text-[#93939f]">
+          (#{formatInteger(DEFAULT_LOCALE, rank)})
+        </span>
       </>
     );
   }
@@ -225,14 +286,28 @@ function UserPageStatsCollectedMemes({
       (season) => season.id === balanceMemes.season
     );
     if (!seasonBalance) {
-      return numberWithCommas(balanceMemes.unique);
+      return formatInteger(DEFAULT_LOCALE, balanceMemes.unique);
     }
     return (
       <>
-        {balanceMemes.unique ? numberWithCommas(balanceMemes.unique) : `0`} /{" "}
-        {numberWithCommas(seasonBalance.count)}{" "}
+        {t(DEFAULT_LOCALE, "user.collected.stats.details.uniqueProgress", {
+          held: balanceMemes.unique
+            ? formatInteger(DEFAULT_LOCALE, balanceMemes.unique)
+            : "0",
+          total: formatInteger(DEFAULT_LOCALE, seasonBalance.count),
+        })}{" "}
         <span className="!tw-text-[#93939f]">
-          ({((balanceMemes.unique / seasonBalance.count) * 100).toFixed(0)}%)
+          {t(
+            DEFAULT_LOCALE,
+            "user.collected.stats.details.uniqueProgressPercent",
+            {
+              percent: formatPercent(
+                DEFAULT_LOCALE,
+                balanceMemes.unique / seasonBalance.count,
+                0
+              ),
+            }
+          )}
         </span>
       </>
     );
@@ -242,7 +317,9 @@ function UserPageStatsCollectedMemes({
     <Accordion>
       <Accordion.Item defaultChecked={true} eventKey={"0"}>
         <Accordion.Button className={styles["collectedAccordionButton"]}>
-          <b>Memes Breakdown By Season</b>
+          <b>
+            {t(DEFAULT_LOCALE, "user.collected.stats.details.memesBySeason")}
+          </b>
         </Accordion.Button>
         <Accordion.Body className={styles["collectedAccordionBody"]}>
           <Container>
@@ -250,26 +327,44 @@ function UserPageStatsCollectedMemes({
               <Col>
                 {balanceMemes && (
                   <Table className={styles["collectedAccordionTable"]}>
+                    <caption className="tw-sr-only">
+                      {t(
+                        DEFAULT_LOCALE,
+                        "user.collected.stats.details.tables.memesBySeasonCaption"
+                      )}
+                    </caption>
                     <thead>
                       <tr>
-                        <th colSpan={2}></th>
-                        <th className="text-right !tw-text-[#93939f]">Total</th>
-                        <th className="text-right !tw-text-[#93939f]">
-                          Unique
-                        </th>
-                        <th className="text-right !tw-text-[#93939f]">Sets</th>
-                        <th className="text-right !tw-text-[#93939f]">TDH</th>
+                        <th colSpan={2} aria-hidden="true"></th>
+                        {memeColumns.map((label) => (
+                          <th
+                            key={label}
+                            scope="col"
+                            className="text-right !tw-text-[#93939f]"
+                          >
+                            {label}
+                          </th>
+                        ))}
                       </tr>
                     </thead>
                     <tbody>
                       {balanceMemes.map((balanceMeme) => (
                         <Fragment
-                          key={`stats-collected-memes-${balanceMeme.season}`}>
+                          key={`stats-collected-memes-${balanceMeme.season}`}
+                        >
                           <UserPageStatsTableHr span={6} />
                           <tr>
-                            <td colSpan={2} className="!tw-text-[#93939f]">
-                              Season {balanceMeme.season}
-                            </td>
+                            <th
+                              scope="row"
+                              colSpan={2}
+                              className="!tw-text-[#93939f]"
+                            >
+                              {t(
+                                DEFAULT_LOCALE,
+                                "user.collected.stats.details.seasonLabel",
+                                { seasonNumber: balanceMeme.season }
+                              )}
+                            </th>
                             <td className="tw-text-right !tw-text-[#fff]">
                               {getDisplayWithValueAndRank(
                                 balanceMeme.balance,
@@ -280,7 +375,7 @@ function UserPageStatsCollectedMemes({
                               {getUniqueDisplay(balanceMeme)}
                             </td>
                             <td className="tw-text-right !tw-text-[#fff]">
-                              {numberWithCommas(balanceMeme.sets)}
+                              {formatInteger(DEFAULT_LOCALE, balanceMeme.sets)}
                             </td>
                             <td className="tw-text-right !tw-text-[#fff]">
                               {getDisplayWithValueAndRank(

--- a/components/user/stats/UserPageStatsTableShared.tsx
+++ b/components/user/stats/UserPageStatsTableShared.tsx
@@ -1,17 +1,64 @@
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import styles from "./UserPageStats.module.scss";
 
-export function UserPageStatsTableHead() {
+function getTableColumnLabels() {
+  return {
+    total: t(
+      DEFAULT_LOCALE,
+      "user.collected.stats.details.tables.column.total"
+    ),
+    memes: t(
+      DEFAULT_LOCALE,
+      "user.collected.stats.details.tables.column.memes"
+    ),
+    nextGen: t(
+      DEFAULT_LOCALE,
+      "user.collected.stats.details.tables.column.nextGen"
+    ),
+    gradient: t(
+      DEFAULT_LOCALE,
+      "user.collected.stats.details.tables.column.gradient"
+    ),
+    memeLab: t(
+      DEFAULT_LOCALE,
+      "user.collected.stats.details.tables.column.memeLab"
+    ),
+  };
+}
+
+export function UserPageStatsTableHead({
+  caption,
+}: Readonly<{
+  caption?: string;
+}> = {}) {
+  const labels = getTableColumnLabels();
+  const columns = [
+    labels.total,
+    labels.memes,
+    labels.nextGen,
+    labels.gradient,
+    labels.memeLab,
+  ];
+
   return (
-    <thead>
-      <tr>
-        <th></th>
-        <th className="text-right !tw-text-[#93939f]">Total</th>
-        <th className="text-right !tw-text-[#93939f]">Memes</th>
-        <th className="text-right !tw-text-[#93939f]">NextGen</th>
-        <th className="text-right !tw-text-[#93939f]">Gradient</th>
-        <th className="text-right !tw-text-[#93939f]">Meme Lab</th>
-      </tr>
-    </thead>
+    <>
+      {caption ? <caption className="tw-sr-only">{caption}</caption> : null}
+      <thead>
+        <tr>
+          <th aria-hidden="true"></th>
+          {columns.map((label) => (
+            <th
+              key={label}
+              scope="col"
+              className="text-right !tw-text-[#93939f]"
+            >
+              {label}
+            </th>
+          ))}
+        </tr>
+      </thead>
+    </>
   );
 }
 
@@ -21,7 +68,7 @@ export function UserPageStatsTableHr(
   }>
 ) {
   return (
-    <tr>
+    <tr aria-hidden="true">
       <td colSpan={props.span} className={styles["collectedAccordionTableHr"]}>
         <hr className="mb-1 mt-1 tw-border-[#93939f]" />
       </td>

--- a/components/user/stats/activity/UserPageActivityWrapper.tsx
+++ b/components/user/stats/activity/UserPageActivityWrapper.tsx
@@ -2,6 +2,7 @@
 
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Suspense } from "react";
 import {
   SEARCH_PARAM_ACTIVITY,
   WALLET_ACTIVITY_FILTER_PARAM,
@@ -10,6 +11,10 @@ import {
 } from "./activity.helpers";
 import { USER_PAGE_ACTIVITY_TAB } from "./activity.types";
 import UserPageStatsActivityDistributions from "./distributions/UserPageStatsActivityDistributions";
+import {
+  getActivityPanelId,
+  getActivityTabId,
+} from "./tabs/activity-tabs.helpers";
 import UserPageActivityTabs from "./tabs/UserPageActivityTabs";
 import UserPageStatsActivityTDHHistory from "./tdh-history/UserPageStatsActivityTDHHistory";
 import UserPageStatsActivityWallet from "./wallet/UserPageStatsActivityWallet";
@@ -31,6 +36,23 @@ const pathToEnum = (path: string): USER_PAGE_ACTIVITY_TAB => {
 };
 
 export default function UserPageActivityWrapper({
+  profile,
+  activeAddress,
+}: {
+  readonly profile: ApiIdentity;
+  readonly activeAddress: string | null;
+}) {
+  return (
+    <Suspense fallback={null}>
+      <UserPageActivityContent
+        profile={profile}
+        activeAddress={activeAddress}
+      />
+    </Suspense>
+  );
+}
+
+function UserPageActivityContent({
   profile,
   activeAddress,
 }: {
@@ -63,19 +85,44 @@ export default function UserPageActivityWrapper({
     <div className="tw-mt-7 lg:tw-mt-9">
       <UserPageActivityTabs activeTab={activeTab} setActiveTab={onActiveTab} />
       {activeTab === USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY && (
-        <UserPageStatsActivityWallet
-          profile={profile}
-          activeAddress={activeAddress}
-        />
+        <section
+          role="tabpanel"
+          id={getActivityPanelId(USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY)}
+          aria-labelledby={getActivityTabId(
+            USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY
+          )}
+          tabIndex={0}
+        >
+          <UserPageStatsActivityWallet
+            profile={profile}
+            activeAddress={activeAddress}
+          />
+        </section>
       )}
       {activeTab === USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS && (
-        <UserPageStatsActivityDistributions
-          profile={profile}
-          activeAddress={activeAddress}
-        />
+        <section
+          role="tabpanel"
+          id={getActivityPanelId(USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS)}
+          aria-labelledby={getActivityTabId(
+            USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS
+          )}
+          tabIndex={0}
+        >
+          <UserPageStatsActivityDistributions
+            profile={profile}
+            activeAddress={activeAddress}
+          />
+        </section>
       )}
       {activeTab === USER_PAGE_ACTIVITY_TAB.TDH_HISTORY && (
-        <UserPageStatsActivityTDHHistory profile={profile} />
+        <section
+          role="tabpanel"
+          id={getActivityPanelId(USER_PAGE_ACTIVITY_TAB.TDH_HISTORY)}
+          aria-labelledby={getActivityTabId(USER_PAGE_ACTIVITY_TAB.TDH_HISTORY)}
+          tabIndex={0}
+        >
+          <UserPageStatsActivityTDHHistory profile={profile} />
+        </section>
       )}
     </div>
   );

--- a/components/user/stats/activity/distributions/UserPageStatsActivityDistributions.tsx
+++ b/components/user/stats/activity/distributions/UserPageStatsActivityDistributions.tsx
@@ -15,6 +15,7 @@ import {
   getActivityWalletsParam,
   WALLET_DISTRIBUTION_PAGE_PARAM,
 } from "../activity.helpers";
+import { getDistributionsMessage } from "./distributions.messages";
 import UserPageStatsActivityDistributionsTableWrapper from "./UserPageStatsActivityDistributionsTableWrapper";
 
 export default function UserPageStatsActivityDistributions({
@@ -105,7 +106,7 @@ export default function UserPageStatsActivityDistributions({
     <div className="tw-mt-4 md:tw-mt-5">
       <div className="tw-flex">
         <h3 className="tw-mb-0 tw-text-lg tw-font-semibold tw-text-iron-100">
-          Distributions
+          {getDistributionsMessage("user.collected.stats.distributions.title")}
         </h3>
       </div>
       <UserPageStatsActivityDistributionsTableWrapper

--- a/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTable.tsx
+++ b/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTable.tsx
@@ -8,26 +8,59 @@ import {
 } from "@/constants/constants";
 import type { Distribution } from "@/entities/IDistribution";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
-import { getRandomObjectId } from "@/helpers/AllowlistToolHelpers";
-import { areEqualAddresses, capitalizeEveryWord } from "@/helpers/Helpers";
-import { useEffect, useState } from "react";
+import { formatInteger } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { areEqualAddresses } from "@/helpers/Helpers";
+import { useMemo } from "react";
+import {
+  getDistributionPhaseLabel,
+  getDistributionsMessage,
+} from "./distributions.messages";
+import {
+  DistributionCollection,
+  type DistributionTableItem,
+} from "./distributions.types";
 import UserPageStatsActivityDistributionsTableItem from "./UserPageStatsActivityDistributionsTableItem";
 
-export enum DistributionCollection {
-  MEMES = "MEMES",
-  GRADIENTS = "GRADIENTS",
-  MEMELAB = "MEMELAB",
+function getAvailablePhases(items: Distribution[]): string[] {
+  const phases: Set<string> = new Set();
+  for (const item of items) {
+    for (const phase of item.phases) {
+      phases.add(phase);
+    }
+  }
+  return Array.from(phases);
 }
 
-export interface DistributionTableItem {
-  readonly collection: DistributionCollection;
-  readonly tokenId: number;
-  readonly name: string;
-  readonly wallet: string;
-  readonly phases: number[];
-  readonly amountMinted: number;
-  readonly amountTotal: number;
-  readonly date: string;
+function getCollectionEnum(contract: string): DistributionCollection {
+  if (areEqualAddresses(contract, MEMES_CONTRACT)) {
+    return DistributionCollection.MEMES;
+  }
+  if (areEqualAddresses(contract, GRADIENT_CONTRACT)) {
+    return DistributionCollection.GRADIENTS;
+  }
+
+  if (areEqualAddresses(contract, MEMELAB_CONTRACT)) {
+    return DistributionCollection.MEMELAB;
+  }
+  throw new Error(`Unknown contract ${contract}`);
+}
+
+function getItemPhaseAmount({
+  phase,
+  item,
+}: {
+  readonly phase: string;
+  readonly item: Distribution;
+}): number {
+  if (phase.toUpperCase() === "AIRDROP") {
+    return item.airdrops ?? 0;
+  }
+
+  const allowlistPhase = item.allowlist.find(
+    (allowlistItem) => allowlistItem.phase === phase
+  );
+  return allowlistPhase?.spots ?? 0;
 }
 
 export default function UserPageStatsActivityDistributionsTable({
@@ -39,58 +72,9 @@ export default function UserPageStatsActivityDistributionsTable({
   readonly profile: ApiIdentity;
   readonly loading: boolean;
 }) {
-  const getAvailablePhases = (): string[] => {
-    const phases: Set<string> = new Set();
-    for (const item of items) {
-      for (const p of item.phases) {
-        phases.add(p);
-      }
-    }
-    return Array.from(phases);
-  };
-
-  const [availablePhases, setAvailablePhases] =
-    useState<string[]>(getAvailablePhases());
-
-  const [results, setResults] = useState<DistributionTableItem[]>([]);
-
-  const getCollectionEnum = (contract: string): DistributionCollection => {
-    if (areEqualAddresses(contract, MEMES_CONTRACT)) {
-      return DistributionCollection.MEMES;
-    }
-    if (areEqualAddresses(contract, GRADIENT_CONTRACT)) {
-      return DistributionCollection.GRADIENTS;
-    }
-
-    if (areEqualAddresses(contract, MEMELAB_CONTRACT)) {
-      return DistributionCollection.MEMELAB;
-    }
-    throw new Error(`Unknown contract ${contract}`);
-  };
-
-  const getItemPhaseAmount = ({
-    phase,
-    item,
-  }: {
-    readonly phase: string;
-    readonly item: Distribution;
-  }): number => {
-    let count = 0;
-
-    if (phase.toUpperCase() === "AIRDROP") {
-      count = item.airdrops;
-    } else {
-      const p = item.allowlist.find((a) => a.phase === phase);
-      count = p?.spots ?? 0;
-    }
-
-    return count ?? 0;
-  };
-
-  useEffect(() => {
-    const phases = getAvailablePhases();
-    setAvailablePhases(phases);
-    setResults(
+  const availablePhases = useMemo(() => getAvailablePhases(items), [items]);
+  const results = useMemo<DistributionTableItem[]>(
+    () =>
       items.map((item) => ({
         collection: getCollectionEnum(item.contract),
         tokenId: item.card_id,
@@ -101,71 +85,98 @@ export default function UserPageStatsActivityDistributionsTable({
           )?.display ??
           item.wallet_display ??
           item.wallet,
-        phases: phases.map((phase) => getItemPhaseAmount({ phase, item })),
+        phases: availablePhases.map((phase) => ({
+          phase,
+          amount: getItemPhaseAmount({ phase, item }),
+        })),
         amountMinted: item.minted,
         amountTotal: item.total_count,
         date: item.mint_date,
-      }))
-    );
-  }, [items]);
+      })),
+    [availablePhases, items, profile.wallets]
+  );
 
   return (
     <table className="tw-min-w-full tw-divide-y tw-divide-iron-700">
+      <caption className="tw-sr-only">
+        {getDistributionsMessage(
+          "user.collected.stats.distributions.tableCaption"
+        )}
+      </caption>
       <thead className="tw-bg-iron-900">
         <tr>
           <th
             scope="col"
             className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pr-4"
           >
-            Collection
+            {getDistributionsMessage(
+              "user.collected.stats.distributions.columns.collection"
+            )}
           </th>
           <th
             scope="col"
             className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-right tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pl-4"
           >
-            Token
+            {getDistributionsMessage(
+              "user.collected.stats.distributions.columns.token"
+            )}
           </th>
           <th
             scope="col"
             className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pl-4"
           >
-            Name
+            {getDistributionsMessage(
+              "user.collected.stats.distributions.columns.name"
+            )}
           </th>
 
           <th
             scope="col"
             className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pl-4"
           >
-            Wallet
+            {getDistributionsMessage(
+              "user.collected.stats.distributions.columns.wallet"
+            )}
           </th>
           {availablePhases.map((phase) => (
             <th
-              key={getRandomObjectId()}
+              key={phase}
               scope="col"
               className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-right tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pl-4"
             >
-              {capitalizeEveryWord(phase.replaceAll("_", " "))}
+              {getDistributionPhaseLabel(phase)}
             </th>
           ))}
           <th
             scope="col"
             className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-right tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pl-4"
           >
-            Minted
+            {getDistributionsMessage(
+              "user.collected.stats.distributions.columns.minted"
+            )}
           </th>
           <th
             scope="col"
             className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-right tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pl-4"
           >
-            Total
+            {getDistributionsMessage(
+              "user.collected.stats.distributions.columns.total"
+            )}
           </th>
           <th
             scope="col"
             className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-right tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pl-4"
           >
-            <div className={loading ? "tw-opacity-100" : "tw-opacity-0"}>
-              <CircleLoader />
-            </div>
+            {loading ? (
+              <div>
+                <span className="tw-sr-only">
+                  {getDistributionsMessage(
+                    "user.collected.stats.distributions.loading"
+                  )}
+                </span>
+                <CircleLoader />
+              </div>
+            ) : null}
           </th>
         </tr>
       </thead>
@@ -174,6 +185,7 @@ export default function UserPageStatsActivityDistributionsTable({
           <UserPageStatsActivityDistributionsTableItem
             key={`${item.collection}-${item.tokenId}-${item.wallet}`}
             item={item}
+            formatNumber={(value) => formatInteger(DEFAULT_LOCALE, value)}
           />
         ))}
       </tbody>

--- a/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableItem.tsx
+++ b/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableItem.tsx
@@ -1,74 +1,81 @@
 "use client";
 
 import Link from "next/link";
-import { getRandomObjectId } from "@/helpers/AllowlistToolHelpers";
 import {
-  formatNumberWithCommasOrDash,
-  getTimeAgo,
-} from "@/helpers/Helpers";
-import type {
-  DistributionTableItem} from "./UserPageStatsActivityDistributionsTable";
-import {
-  DistributionCollection
-} from "./UserPageStatsActivityDistributionsTable";
+  formatDistributionRelativeTime,
+  getDistributionCollectionLabel,
+  getDistributionTokenLinkLabel,
+} from "./distributions.messages";
+import type { DistributionTableItem } from "./distributions.types";
 import { useEffect, useState } from "react";
 
 export default function UserPageStatsActivityDistributionsTableItem({
   item,
+  formatNumber,
 }: {
   readonly item: DistributionTableItem;
+  readonly formatNumber: (value: number) => string;
 }) {
-  const COLLECTION_TO_TEXT: { [key in DistributionCollection]: string } = {
-    [DistributionCollection.MEMES]: "The Memes",
-    [DistributionCollection.GRADIENTS]: "6529Gradient",
-    [DistributionCollection.MEMELAB]: "Meme Lab",
-  };
-
-  const COLLECTION_TO_PATH: { [key in DistributionCollection]: string } = {
-    [DistributionCollection.MEMES]: "/the-memes",
-    [DistributionCollection.GRADIENTS]: "/6529-gradient",
-    [DistributionCollection.MEMELAB]: "/meme-lab",
-  };
-
   const [timeAgo, setTimeAgo] = useState<string>("");
   useEffect(() => {
-    setTimeAgo(getTimeAgo(new Date(item.date).getTime()));
-  }, []);
+    setTimeAgo(formatDistributionRelativeTime(item.date));
+  }, [item.date]);
+
+  const collectionLabel = getDistributionCollectionLabel(item.collection);
 
   return (
     <tr className="even:tw-bg-iron-900">
-      <td className="tw-text-iron-400 tw-py-3.5 tw-font-medium tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-text-sm sm:tw-text-base">
-        {COLLECTION_TO_TEXT[item.collection]}
+      <td className="tw-whitespace-nowrap tw-px-4 tw-py-3.5 tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-base lg:tw-pr-4">
+        {collectionLabel}
       </td>
-      <td className="tw-py-3.5 tw-font-medium tw-px-4 sm:tw-px-6 lg:tw-pl-4 tw-text-right tw-whitespace-nowrap tw-text-sm sm:tw-text-base">
+      <td className="tw-whitespace-nowrap tw-px-4 tw-py-3.5 tw-text-right tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-base lg:tw-pl-4">
         <Link
-          className="tw-no-underline hover:tw-underline tw-text-iron-50"
-          href={`${COLLECTION_TO_PATH[item.collection]}/${item.tokenId}`}>
+          aria-label={getDistributionTokenLinkLabel({
+            collection: item.collection,
+            tokenId: item.tokenId,
+          })}
+          className="tw-text-iron-50 tw-no-underline hover:tw-underline"
+          href={`${getCollectionPath(item.collection)}/${item.tokenId}`}
+        >
           # {item.tokenId}
         </Link>
       </td>
-      <td className="tw-text-iron-50 tw-py-3.5 tw-font-medium tw-px-4 sm:tw-px-6 lg:tw-pl-4 tw-whitespace-nowrap tw-text-sm sm:tw-text-base">
+      <td className="tw-whitespace-nowrap tw-px-4 tw-py-3.5 tw-text-sm tw-font-medium tw-text-iron-50 sm:tw-px-6 sm:tw-text-base lg:tw-pl-4">
         {item.name}
       </td>
-      <td className="tw-text-iron-400 tw-py-3.5 tw-font-normal tw-px-4 sm:tw-px-6 lg:tw-pl-4 tw-whitespace-nowrap tw-text-sm sm:tw-text-base">
+      <td className="tw-whitespace-nowrap tw-px-4 tw-py-3.5 tw-text-sm tw-font-normal tw-text-iron-400 sm:tw-px-6 sm:tw-text-base lg:tw-pl-4">
         {item.wallet}
       </td>
       {item.phases.map((phase) => (
         <td
-          key={getRandomObjectId()}
-          className="tw-text-iron-400 tw-py-3.5 tw-font-normal tw-px-4 tw-text-right sm:tw-px-6 lg:tw-pl-4 tw-whitespace-nowrap tw-text-sm sm:tw-text-base">
-          {formatNumberWithCommasOrDash(phase)}
+          key={`${item.collection}-${item.tokenId}-${item.wallet}-phase-${phase.phase}`}
+          className="tw-whitespace-nowrap tw-px-4 tw-py-3.5 tw-text-right tw-text-sm tw-font-normal tw-text-iron-400 sm:tw-px-6 sm:tw-text-base lg:tw-pl-4"
+        >
+          {formatNumber(phase.amount)}
         </td>
       ))}
-      <td className="tw-text-iron-400 tw-py-3.5 tw-font-normal tw-px-4 sm:tw-px-6 lg:tw-pl-4 tw-whitespace-nowrap tw-text-sm sm:tw-text-base tw-text-right">
-        {formatNumberWithCommasOrDash(item.amountMinted)}
+      <td className="tw-whitespace-nowrap tw-px-4 tw-py-3.5 tw-text-right tw-text-sm tw-font-normal tw-text-iron-400 sm:tw-px-6 sm:tw-text-base lg:tw-pl-4">
+        {formatNumber(item.amountMinted)}
       </td>
-      <td className="tw-text-iron-400 tw-py-3.5 tw-font-normal tw-px-4 sm:tw-px-6 lg:tw-pl-4 tw-whitespace-nowrap tw-text-sm sm:tw-text-base tw-text-right">
-        {formatNumberWithCommasOrDash(item.amountTotal)}
+      <td className="tw-whitespace-nowrap tw-px-4 tw-py-3.5 tw-text-right tw-text-sm tw-font-normal tw-text-iron-400 sm:tw-px-6 sm:tw-text-base lg:tw-pl-4">
+        {formatNumber(item.amountTotal)}
       </td>
-      <td className="tw-text-iron-500 tw-py-3.5 tw-font-normal tw-px-4 sm:tw-px-6 lg:tw-pl-4 tw-whitespace-nowrap tw-text-sm sm:tw-text-base tw-text-right">
+      <td className="tw-whitespace-nowrap tw-px-4 tw-py-3.5 tw-text-right tw-text-sm tw-font-normal tw-text-iron-500 sm:tw-px-6 sm:tw-text-base lg:tw-pl-4">
         {timeAgo}
       </td>
     </tr>
   );
+}
+
+function getCollectionPath(collection: DistributionTableItem["collection"]) {
+  const COLLECTION_TO_PATH: Record<
+    DistributionTableItem["collection"],
+    string
+  > = {
+    MEMES: "/the-memes",
+    GRADIENTS: "/6529-gradient",
+    MEMELAB: "/meme-lab",
+  };
+
+  return COLLECTION_TO_PATH[collection];
 }

--- a/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableWrapper.tsx
+++ b/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableWrapper.tsx
@@ -2,6 +2,7 @@ import type { Distribution } from "@/entities/IDistribution";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import CommonTablePagination from "@/components/utils/table/paginator/CommonTablePagination";
 import CommonCardSkeleton from "@/components/utils/animation/CommonCardSkeleton";
+import { getDistributionsMessage } from "./distributions.messages";
 import UserPageStatsActivityDistributionsTable from "./UserPageStatsActivityDistributionsTable";
 
 export default function UserPageStatsActivityDistributionsTableWrapper({
@@ -23,14 +24,14 @@ export default function UserPageStatsActivityDistributionsTableWrapper({
 }) {
   if (isFirstLoading) {
     return (
-      <div className="tw-mt-2 sm:tw-mt-4 tw-w-full tw-h-96">
+      <div className="tw-mt-2 tw-h-96 tw-w-full sm:tw-mt-4">
         <CommonCardSkeleton />
       </div>
     );
   }
 
   return (
-    <div className="tw-mt-2 lg:tw-mt-4 tw-bg-iron-950 tw-border tw-border-iron-700 tw-border-solid tw-rounded-lg tw-overflow-x-auto">
+    <div className="tw-mt-2 tw-overflow-x-auto tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 lg:tw-mt-4">
       {data.length ? (
         <div className="tw-flow-root">
           <UserPageStatsActivityDistributionsTable
@@ -50,9 +51,9 @@ export default function UserPageStatsActivityDistributionsTableWrapper({
           )}
         </div>
       ) : (
-        <div className="tw-p-4 sm:tw-px-6 tw-text-sm tw-italic tw-text-iron-500">
-          No distributions found
-        </div>
+        <output className="tw-p-4 tw-text-sm tw-italic tw-text-iron-500 sm:tw-px-6">
+          {getDistributionsMessage("user.collected.stats.distributions.empty")}
+        </output>
       )}
     </div>
   );

--- a/components/user/stats/activity/distributions/distributions.messages.ts
+++ b/components/user/stats/activity/distributions/distributions.messages.ts
@@ -1,0 +1,88 @@
+import { formatRelativeTime } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
+import { DistributionCollection } from "./distributions.types";
+
+type DistributionsMessageKey = `user.collected.stats.distributions.${string}`;
+
+const COLLECTION_LABEL_KEYS: Record<DistributionCollection, MessageKey> = {
+  [DistributionCollection.MEMES]:
+    "user.collected.stats.distributions.collections.memes",
+  [DistributionCollection.GRADIENTS]:
+    "user.collected.stats.distributions.collections.gradients",
+  [DistributionCollection.MEMELAB]:
+    "user.collected.stats.distributions.collections.memeLab",
+};
+
+const RELATIVE_TIME_UNITS = [
+  { unit: "year", milliseconds: 365 * 24 * 60 * 60 * 1000 },
+  { unit: "month", milliseconds: 30 * 24 * 60 * 60 * 1000 },
+  { unit: "week", milliseconds: 7 * 24 * 60 * 60 * 1000 },
+  { unit: "day", milliseconds: 24 * 60 * 60 * 1000 },
+  { unit: "hour", milliseconds: 60 * 60 * 1000 },
+  { unit: "minute", milliseconds: 60 * 1000 },
+] as const;
+
+export function getDistributionsMessage(
+  key: DistributionsMessageKey,
+  params?: Record<string, string | number>
+) {
+  return t(DEFAULT_LOCALE, key as MessageKey, params);
+}
+
+export function getDistributionCollectionLabel(
+  collection: DistributionCollection
+) {
+  return t(DEFAULT_LOCALE, COLLECTION_LABEL_KEYS[collection]);
+}
+
+export function getDistributionTokenLinkLabel({
+  collection,
+  tokenId,
+}: {
+  readonly collection: DistributionCollection;
+  readonly tokenId: number;
+}) {
+  return getDistributionsMessage(
+    "user.collected.stats.distributions.tokenLinkAriaLabel",
+    {
+      collection: getDistributionCollectionLabel(collection),
+      tokenId,
+    }
+  );
+}
+
+export function getDistributionPhaseLabel(phase: string) {
+  if (phase.toUpperCase() === "AIRDROP") {
+    return getDistributionsMessage(
+      "user.collected.stats.distributions.phases.airdrop"
+    );
+  }
+
+  return phase
+    .replaceAll("_", " ")
+    .toLowerCase()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function formatDistributionRelativeTime(date: string, now = Date.now()) {
+  const timestamp = new Date(date).getTime();
+  if (!Number.isFinite(timestamp)) {
+    return "-";
+  }
+
+  const elapsed = timestamp - now;
+  const absoluteElapsed = Math.abs(elapsed);
+
+  for (const { unit, milliseconds } of RELATIVE_TIME_UNITS) {
+    if (absoluteElapsed >= milliseconds) {
+      return formatRelativeTime(
+        DEFAULT_LOCALE,
+        Math.round(elapsed / milliseconds),
+        unit
+      );
+    }
+  }
+
+  return formatRelativeTime(DEFAULT_LOCALE, 0, "second");
+}

--- a/components/user/stats/activity/distributions/distributions.types.ts
+++ b/components/user/stats/activity/distributions/distributions.types.ts
@@ -1,0 +1,21 @@
+export enum DistributionCollection {
+  MEMES = "MEMES",
+  GRADIENTS = "GRADIENTS",
+  MEMELAB = "MEMELAB",
+}
+
+export interface DistributionTableItem {
+  readonly collection: DistributionCollection;
+  readonly tokenId: number;
+  readonly name: string;
+  readonly wallet: string;
+  readonly phases: DistributionTableItemPhase[];
+  readonly amountMinted: number;
+  readonly amountTotal: number;
+  readonly date: string;
+}
+
+export interface DistributionTableItemPhase {
+  readonly phase: string;
+  readonly amount: number;
+}

--- a/components/user/stats/activity/tabs/UserPageActivityTab.tsx
+++ b/components/user/stats/activity/tabs/UserPageActivityTab.tsx
@@ -1,32 +1,60 @@
+import type { KeyboardEventHandler } from "react";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
 import { USER_PAGE_ACTIVITY_TAB } from "../activity.types";
+import { getActivityPanelId, getActivityTabId } from "./activity-tabs.helpers";
+
+type ActivityTabMessageKey = Extract<
+  MessageKey,
+  `user.collected.stats.activityTabs.${string}`
+>;
+
+const TAB_TO_LABEL_KEY: Record<USER_PAGE_ACTIVITY_TAB, ActivityTabMessageKey> =
+  {
+    [USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY]:
+      "user.collected.stats.activityTabs.walletActivity",
+    [USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS]:
+      "user.collected.stats.activityTabs.distributions",
+    [USER_PAGE_ACTIVITY_TAB.TDH_HISTORY]:
+      "user.collected.stats.activityTabs.tdhHistory",
+  };
 
 export default function UserPageActivityTab({
   tab,
   activeTab,
   setActiveTab,
+  onKeyDown,
 }: {
   readonly tab: USER_PAGE_ACTIVITY_TAB;
   readonly activeTab: USER_PAGE_ACTIVITY_TAB;
   readonly setActiveTab: (tab: USER_PAGE_ACTIVITY_TAB) => void;
+  readonly onKeyDown: KeyboardEventHandler<HTMLButtonElement>;
 }) {
-  const TAB_TO_LABEL: Record<USER_PAGE_ACTIVITY_TAB, string> = {
-    [USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY]: "Wallet Activity",
-    [USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS]: "Distributions",
-    [USER_PAGE_ACTIVITY_TAB.TDH_HISTORY]: "TDH History",
-  };
+  const isActive = tab === activeTab;
+  const className = [
+    "tw-border tw-border-solid tw-border-iron-700 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-transition tw-duration-300 tw-ease-out",
+    isActive
+      ? "tw-bg-iron-800 tw-text-iron-100"
+      : "tw-bg-iron-950 tw-text-iron-500 hover:tw-bg-iron-900 hover:tw-text-iron-100",
+    tab === USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY ? "tw-rounded-l-lg" : "",
+    tab === USER_PAGE_ACTIVITY_TAB.TDH_HISTORY ? "tw-rounded-r-lg" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <button
       type="button"
-      className={`tw-border tw-border-solid tw-border-iron-700 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-transition tw-duration-300 tw-ease-out ${
-        tab === activeTab
-          ? "tw-bg-iron-800 tw-text-iron-100"
-          : "tw-bg-iron-950 tw-text-iron-500 hover:tw-bg-iron-900 hover:tw-text-iron-100"
-      } ${
-        tab === USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY && "tw-rounded-l-lg"
-      } ${tab === USER_PAGE_ACTIVITY_TAB.TDH_HISTORY && "tw-rounded-r-lg"}`}
+      role="tab"
+      id={getActivityTabId(tab)}
+      aria-selected={isActive}
+      aria-controls={getActivityPanelId(tab)}
+      tabIndex={isActive ? 0 : -1}
+      className={className}
       onClick={() => setActiveTab(tab)}
+      onKeyDown={onKeyDown}
     >
-      {TAB_TO_LABEL[tab]}
+      {t(DEFAULT_LOCALE, TAB_TO_LABEL_KEY[tab])}
     </button>
   );
 }

--- a/components/user/stats/activity/tabs/UserPageActivityTabs.tsx
+++ b/components/user/stats/activity/tabs/UserPageActivityTabs.tsx
@@ -1,5 +1,30 @@
+import type { KeyboardEvent } from "react";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import { USER_PAGE_ACTIVITY_TAB } from "../activity.types";
+import {
+  getActivityTabId,
+  getNextActivityTab,
+  USER_PAGE_ACTIVITY_TABS,
+} from "./activity-tabs.helpers";
 import UserPageActivityTab from "./UserPageActivityTab";
+
+const focusActivityTab = (tab: USER_PAGE_ACTIVITY_TAB) => {
+  if (typeof globalThis.document === "undefined") {
+    return;
+  }
+
+  const focusTab = () => {
+    globalThis.document.getElementById(getActivityTabId(tab))?.focus();
+  };
+
+  if (typeof globalThis.requestAnimationFrame === "function") {
+    globalThis.requestAnimationFrame(focusTab);
+    return;
+  }
+
+  globalThis.setTimeout(focusTab, 0);
+};
 
 export default function UserPageActivityTabs({
   activeTab,
@@ -8,14 +33,43 @@ export default function UserPageActivityTabs({
   readonly activeTab: USER_PAGE_ACTIVITY_TAB;
   readonly setActiveTab: (tab: USER_PAGE_ACTIVITY_TAB) => void;
 }) {
+  const selectTabFromKeyboard = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    tab: USER_PAGE_ACTIVITY_TAB
+  ) => {
+    const keyToTab: Partial<Record<string, USER_PAGE_ACTIVITY_TAB>> = {
+      ArrowLeft: getNextActivityTab(tab, -1),
+      ArrowRight: getNextActivityTab(tab, 1),
+      Home: USER_PAGE_ACTIVITY_TABS[0],
+      End: USER_PAGE_ACTIVITY_TABS[USER_PAGE_ACTIVITY_TABS.length - 1],
+    };
+    const nextTab = keyToTab[event.key];
+
+    if (!nextTab) {
+      return;
+    }
+
+    event.preventDefault();
+    setActiveTab(nextTab);
+    focusActivityTab(nextTab);
+  };
+
   return (
-    <div className="tw-inline-flex tw-overflow-hidden tw-rounded-lg">
-      {Object.values(USER_PAGE_ACTIVITY_TAB).map((tab) => (
+    <div
+      role="tablist"
+      aria-label={t(
+        DEFAULT_LOCALE,
+        "user.collected.stats.activityTabs.listLabel"
+      )}
+      className="tw-inline-flex tw-overflow-hidden tw-rounded-lg"
+    >
+      {USER_PAGE_ACTIVITY_TABS.map((tab) => (
         <UserPageActivityTab
           key={tab}
           tab={tab}
           activeTab={activeTab}
           setActiveTab={setActiveTab}
+          onKeyDown={(event) => selectTabFromKeyboard(event, tab)}
         />
       ))}
     </div>

--- a/components/user/stats/activity/tabs/activity-tabs.helpers.ts
+++ b/components/user/stats/activity/tabs/activity-tabs.helpers.ts
@@ -1,0 +1,24 @@
+import { USER_PAGE_ACTIVITY_TAB } from "../activity.types";
+
+export const USER_PAGE_ACTIVITY_TABS = Object.values(USER_PAGE_ACTIVITY_TAB);
+
+const toActivityTabSlug = (tab: USER_PAGE_ACTIVITY_TAB) =>
+  tab.toLowerCase().replaceAll("_", "-");
+
+export const getActivityTabId = (tab: USER_PAGE_ACTIVITY_TAB) =>
+  `user-collected-activity-tab-${toActivityTabSlug(tab)}`;
+
+export const getActivityPanelId = (tab: USER_PAGE_ACTIVITY_TAB) =>
+  `user-collected-activity-panel-${toActivityTabSlug(tab)}`;
+
+export const getNextActivityTab = (
+  tab: USER_PAGE_ACTIVITY_TAB,
+  offset: number
+) => {
+  const currentIndex = USER_PAGE_ACTIVITY_TABS.indexOf(tab);
+  const nextIndex =
+    (currentIndex + offset + USER_PAGE_ACTIVITY_TABS.length) %
+    USER_PAGE_ACTIVITY_TABS.length;
+
+  return USER_PAGE_ACTIVITY_TABS[nextIndex];
+};

--- a/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistory.tsx
+++ b/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistory.tsx
@@ -4,6 +4,7 @@ import type { TDHHistory } from "@/entities/ITDH";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import { commonApiFetch } from "@/services/api/common-api";
 import { useQuery } from "@tanstack/react-query";
+import { getTdhHistoryMessage } from "./tdh-history.messages";
 import UserPageStatsActivityTDHHistoryCharts from "./UserPageStatsActivityTDHHistoryCharts";
 
 export default function UserPageStatsActivityTDHHistory({
@@ -26,7 +27,10 @@ export default function UserPageStatsActivityTDHHistory({
 
   if (isFetching) {
     content = (
-      <div className="tw-mt-2 sm:tw-mt-4 tw-w-full tw-h-96">
+      <div className="tw-mt-2 tw-h-96 tw-w-full sm:tw-mt-4">
+        <span className="tw-sr-only">
+          {getTdhHistoryMessage("user.collected.stats.tdhHistory.loading")}
+        </span>
         <CommonCardSkeleton />
       </div>
     );
@@ -34,10 +38,10 @@ export default function UserPageStatsActivityTDHHistory({
     content = <UserPageStatsActivityTDHHistoryCharts tdhHistory={tdhHistory} />;
   } else {
     content = (
-      <div className="tw-mt-2 lg:tw-mt-4 tw-bg-iron-950 tw-border tw-border-iron-700 tw-border-solid tw-rounded-lg tw-overflow-x-auto">
-        <div className="tw-p-4 sm:tw-px-6 tw-text-sm tw-italic tw-text-iron-500">
-          No TDH history found
-        </div>
+      <div className="tw-mt-2 tw-overflow-x-auto tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 lg:tw-mt-4">
+        <output className="tw-block tw-p-4 tw-text-sm tw-italic tw-text-iron-500 sm:tw-px-6">
+          {getTdhHistoryMessage("user.collected.stats.tdhHistory.empty")}
+        </output>
       </div>
     );
   }
@@ -46,7 +50,7 @@ export default function UserPageStatsActivityTDHHistory({
     <div className="tw-mt-4 md:tw-mt-5">
       <div className="tw-flex">
         <h3 className="tw-mb-0 tw-text-lg tw-font-semibold tw-text-iron-100">
-          TDH History
+          {getTdhHistoryMessage("user.collected.stats.tdhHistory.title")}
         </h3>
       </div>
       {content}

--- a/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryChart.tsx
+++ b/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryChart.tsx
@@ -1,14 +1,15 @@
 import { Line } from "react-chartjs-2";
 
+import { formatTdhHistoryValue } from "./tdh-history.messages";
 import {
-    BarElement,
-    CategoryScale,
-    Chart as ChartJS,
-    Legend,
-    LinearScale,
-    LineElement,
-    PointElement,
-    Tooltip,
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  LineElement,
+  PointElement,
+  Tooltip,
 } from "chart.js";
 import type { ChartProps } from "./UserPageStatsActivityTDHHistoryCharts";
 
@@ -38,6 +39,8 @@ const GRAPH_OPTIONS = {
       },
       ticks: {
         color: "rgb(154, 154, 154)",
+        callback: (value: string | number) =>
+          typeof value === "number" ? formatTdhHistoryValue(value) : value,
       },
     },
   },
@@ -55,15 +58,29 @@ export default function UserPageStatsActivityTDHHistoryChart({
 }: {
   readonly data: ChartProps;
 }) {
+  const headingId = `tdh-history-chart-${data.id}`;
+
   return (
-    <div className="tw-bg-iron-950 tw-border tw-border-iron-800 tw-border-solid tw-rounded-xl">
-      <div className="tw-pt-6 tw-px-4 sm:tw-px-6 tw-flex">
-        <h3 className="tw-mb-0 tw-text-lg tw-font-semibold tw-text-iron-100">
+    <div
+      aria-labelledby={headingId}
+      className="tw-rounded-xl tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-950"
+      role="listitem"
+    >
+      <div className="tw-flex tw-px-4 tw-pt-6 sm:tw-px-6">
+        <h3
+          className="tw-mb-0 tw-text-lg tw-font-semibold tw-text-iron-100"
+          id={headingId}
+        >
           {data.title}
         </h3>
       </div>
       <div className="tw-p-6">
-        <Line data={data} options={GRAPH_OPTIONS} />
+        <Line
+          aria-label={data.ariaLabel}
+          data={data}
+          options={GRAPH_OPTIONS}
+          role="img"
+        />
       </div>
     </div>
   );

--- a/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryCharts.tsx
+++ b/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryCharts.tsx
@@ -3,7 +3,10 @@
 import { useEffect, useState } from "react";
 import type { TDHHistory } from "@/entities/ITDH";
 import UserPageStatsActivityTDHHistoryChart from "./UserPageStatsActivityTDHHistoryChart";
-import { getRandomObjectId } from "@/helpers/AllowlistToolHelpers";
+import {
+  formatTdhHistoryDate,
+  getTdhHistoryMessage,
+} from "./tdh-history.messages";
 
 interface ChartData {
   readonly label: string;
@@ -12,58 +15,70 @@ interface ChartData {
   readonly borderColor: string;
 }
 export interface ChartProps {
+  readonly id: string;
   readonly title: string;
-  readonly labels: Date[];
+  readonly ariaLabel: string;
+  readonly labels: string[];
   readonly datasets: ChartData[];
 }
 
 interface ChartConfigDataset {
-  readonly label: string;
+  readonly labelKey: Parameters<typeof getTdhHistoryMessage>[0];
   readonly field: keyof TDHHistory;
   readonly color: string;
 }
 
 interface ChartConfig {
-  readonly title: string;
+  readonly id: string;
+  readonly titleKey: Parameters<typeof getTdhHistoryMessage>[0];
   readonly datasets: ChartConfigDataset[];
 }
 
 const CHART_CONFIGS: ChartConfig[] = [
   {
-    title: "Total TDH",
+    id: "total-tdh",
+    titleKey: "user.collected.stats.tdhHistory.charts.totalTdh.title",
     datasets: [
       {
-        label: "Total Boosted TDH",
+        labelKey:
+          "user.collected.stats.tdhHistory.charts.totalTdh.totalBoosted",
         field: "boosted_tdh",
         color: "#00DC21",
       },
     ],
   },
   {
-    title: "Net TDH Daily Change",
+    id: "net-daily-change",
+    titleKey: "user.collected.stats.tdhHistory.charts.netDailyChange.title",
     datasets: [
       {
-        label: "Net Boosted TDH",
+        labelKey:
+          "user.collected.stats.tdhHistory.charts.netDailyChange.netBoosted",
         field: "net_boosted_tdh",
         color: "#00DC21",
       },
     ],
   },
   {
-    title: "Created TDH Daily Change",
+    id: "created-daily-change",
+    titleKey: "user.collected.stats.tdhHistory.charts.createdDailyChange.title",
     datasets: [
       {
-        label: "Created Boosted TDH",
+        labelKey:
+          "user.collected.stats.tdhHistory.charts.createdDailyChange.createdBoosted",
         field: "created_boosted_tdh",
         color: "#00DC21",
       },
     ],
   },
   {
-    title: "Destroyed TDH Daily Change",
+    id: "destroyed-daily-change",
+    titleKey:
+      "user.collected.stats.tdhHistory.charts.destroyedDailyChange.title",
     datasets: [
       {
-        label: "Destroyed Boosted TDH",
+        labelKey:
+          "user.collected.stats.tdhHistory.charts.destroyedDailyChange.destroyedBoosted",
         field: "destroyed_boosted_tdh",
         color: "#00DC21",
       },
@@ -82,15 +97,15 @@ export default function UserPageStatsActivityTDHHistoryCharts({
 
   const getData = ({
     tdh,
-    labels,
+    dates,
     field,
   }: {
     tdh: TDHHistory[];
-    labels: Date[];
+    dates: TDHHistory["date"][];
     field: keyof TDHHistory;
   }): number[] => {
-    return labels.map((l) => {
-      const tdhItem = tdh.find((t) => t.date === l);
+    return dates.map((date) => {
+      const tdhItem = tdh.find((t) => t.date === date);
       if (!tdhItem) {
         return 0;
       }
@@ -101,18 +116,26 @@ export default function UserPageStatsActivityTDHHistoryCharts({
 
   const getDataSets = ({
     tdh,
-    labels,
+    dates,
   }: {
     tdh: TDHHistory[];
-    labels: Date[];
+    dates: TDHHistory["date"][];
   }): ChartProps[] => {
+    const labels = dates.map(formatTdhHistoryDate);
+
     return CHART_CONFIGS.map((config) => {
+      const title = getTdhHistoryMessage(config.titleKey);
       return {
-        title: config.title,
+        id: config.id,
+        title,
+        ariaLabel: getTdhHistoryMessage(
+          "user.collected.stats.tdhHistory.chartAriaLabel",
+          { title }
+        ),
         labels,
         datasets: config.datasets.map((d) => ({
-          label: d.label,
-          data: getData({ tdh, labels, field: d.field }),
+          label: getTdhHistoryMessage(d.labelKey),
+          data: getData({ tdh, dates, field: d.field }),
           backgroundColor: d.color,
           borderColor: d.color,
         })),
@@ -127,17 +150,20 @@ export default function UserPageStatsActivityTDHHistoryCharts({
     }
 
     const tdhHistoryReversed = tdhHistory.toReversed();
-    const tdhLabels = tdhHistoryReversed.map((t) => t.date);
-    setDataSets(getDataSets({ tdh: tdhHistoryReversed, labels: tdhLabels }));
+    const tdhDates = tdhHistoryReversed.map((t) => t.date);
+    setDataSets(getDataSets({ tdh: tdhHistoryReversed, dates: tdhDates }));
   }, [tdhHistory]);
 
   return (
-    <div className="tw-mt-2 sm:tw-mt-4 tw-flex tw-flex-col tw-gap-y-6 md:tw-gap-y-8">
+    <div
+      aria-label={getTdhHistoryMessage(
+        "user.collected.stats.tdhHistory.chartListLabel"
+      )}
+      className="tw-mt-2 tw-flex tw-flex-col tw-gap-y-6 sm:tw-mt-4 md:tw-gap-y-8"
+      role="list"
+    >
       {dataSets.map((dataSet) => (
-        <UserPageStatsActivityTDHHistoryChart
-          key={getRandomObjectId()}
-          data={dataSet}
-        />
+        <UserPageStatsActivityTDHHistoryChart key={dataSet.id} data={dataSet} />
       ))}
     </div>
   );

--- a/components/user/stats/activity/tdh-history/tdh-history.messages.ts
+++ b/components/user/stats/activity/tdh-history/tdh-history.messages.ts
@@ -1,0 +1,27 @@
+import { formatDate, formatInteger } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
+
+type TdhHistoryMessageKey = Extract<
+  MessageKey,
+  `user.collected.stats.tdhHistory.${string}`
+>;
+
+type MessageParams = Record<string, string | number>;
+
+export function getTdhHistoryMessage(
+  key: TdhHistoryMessageKey,
+  params: MessageParams = {}
+): string {
+  return t(DEFAULT_LOCALE, key, params);
+}
+
+export function formatTdhHistoryDate(date: Date | string | number): string {
+  return formatDate(DEFAULT_LOCALE, date);
+}
+
+export function formatTdhHistoryValue(
+  value: number | null | undefined
+): string {
+  return formatInteger(DEFAULT_LOCALE, value);
+}

--- a/components/user/stats/activity/wallet/UserPageStatsActivityWallet.tsx
+++ b/components/user/stats/activity/wallet/UserPageStatsActivityWallet.tsx
@@ -21,6 +21,7 @@ import {
 } from "../activity.helpers";
 import { UserPageStatsActivityWalletFilterType } from "./UserPageStatsActivityWallet.types";
 import UserPageStatsActivityWalletTableWrapper from "./table/UserPageStatsActivityWalletTableWrapper";
+import { getWalletActivityMessage } from "./wallet-activity.messages";
 
 const ENUM_AND_PATH: {
   type: UserPageStatsActivityWalletFilterType;
@@ -212,7 +213,9 @@ export default function UserPageStatsActivityWallet({
     <div className="tw-mt-4 md:tw-mt-5">
       <div className="tw-flex">
         <h3 className="tw-mb-0 tw-text-lg tw-font-semibold tw-text-iron-100">
-          Wallet Activity
+          {getWalletActivityMessage(
+            "user.collected.stats.walletActivity.title"
+          )}
         </h3>
       </div>
       <UserPageStatsActivityWalletTableWrapper

--- a/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilter.tsx
+++ b/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilter.tsx
@@ -1,10 +1,23 @@
 "use client";
 
-import { AnimatePresence, motion, useAnimate } from "framer-motion";
+import {
+  AnimatePresence,
+  LazyMotion,
+  domAnimation,
+  m,
+  useAnimate,
+} from "framer-motion";
 import { useEffect, useRef, useState } from "react";
 import { useClickAway, useKeyPressEvent } from "react-use";
 import { UserPageStatsActivityWalletFilterType } from "../UserPageStatsActivityWallet.types";
+import {
+  getWalletActivityFilterLabel,
+  getWalletActivityFilterOptionLabel,
+  getWalletActivityMessage,
+} from "../wallet-activity.messages";
 import UserPageStatsActivityWalletFilterItem from "./UserPageStatsActivityWalletFilterItem";
+
+const FILTER_LIST_ID = "wallet-activity-filter-options";
 
 export default function UserPageStatsActivityWalletFilter({
   activeFilter,
@@ -15,19 +28,6 @@ export default function UserPageStatsActivityWalletFilter({
     filter: UserPageStatsActivityWalletFilterType
   ) => void;
 }) {
-  const ACTIVITY_WALLET_FILTER_TYPE_TO_TITLE: Record<
-    UserPageStatsActivityWalletFilterType,
-    string
-  > = {
-    [UserPageStatsActivityWalletFilterType.ALL]: "All",
-    [UserPageStatsActivityWalletFilterType.AIRDROPS]: "Airdrops",
-    [UserPageStatsActivityWalletFilterType.MINTS]: "Mints",
-    [UserPageStatsActivityWalletFilterType.SALES]: "Sales",
-    [UserPageStatsActivityWalletFilterType.PURCHASES]: "Purchases",
-    [UserPageStatsActivityWalletFilterType.TRANSFERS]: "Transfers",
-    [UserPageStatsActivityWalletFilterType.BURNS]: "Burns",
-  };
-
   const [isOpen, setIsOpen] = useState(false);
   const [iconScope, animateIcon] = useAnimate();
   const toggleOpen = () => setIsOpen(!isOpen);
@@ -46,6 +46,7 @@ export default function UserPageStatsActivityWalletFilter({
     setActiveFilter(filter);
     setIsOpen(false);
   };
+  const activeFilterLabel = getWalletActivityFilterLabel(activeFilter);
 
   return (
     <div className="tw-w-full sm:tw-max-w-xs" ref={listRef}>
@@ -53,9 +54,15 @@ export default function UserPageStatsActivityWalletFilter({
         <button
           type="button"
           onClick={toggleOpen}
+          aria-expanded={isOpen}
+          aria-controls={FILTER_LIST_ID}
+          aria-label={getWalletActivityMessage(
+            "user.collected.stats.walletActivity.filterButtonLabel",
+            { filter: activeFilterLabel }
+          )}
           className="tw-relative tw-flex tw-w-full tw-items-center tw-rounded-lg tw-border-0 tw-bg-iron-900 tw-px-3.5 tw-py-2.5 tw-text-base tw-font-medium tw-text-iron-50 tw-caret-primary-400 tw-shadow-sm tw-ring-1 tw-ring-inset tw-ring-iron-700 tw-transition tw-duration-300 tw-ease-out placeholder:tw-text-iron-500 hover:tw-ring-iron-600 focus:tw-bg-transparent focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-primary-400 sm:tw-leading-6"
         >
-          <span>{ACTIVITY_WALLET_FILTER_TYPE_TO_TITLE[activeFilter]}</span>
+          <span>{activeFilterLabel}</span>
         </button>
         <div className="tw-pointer-events-none tw-absolute tw-inset-y-0 tw-right-0 tw-flex tw-items-center tw-pr-3.5">
           <svg
@@ -75,35 +82,46 @@ export default function UserPageStatsActivityWalletFilter({
             />
           </svg>
         </div>
-        <AnimatePresence mode="wait" initial={false}>
-          {isOpen && (
-            <motion.div
-              className="tw-absolute tw-right-0 tw-z-10 tw-mt-1 tw-w-full tw-origin-top-right tw-rounded-lg tw-bg-iron-800 tw-shadow-xl tw-ring-1 tw-ring-black tw-ring-opacity-5"
-              initial={{ opacity: 0, y: -20 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -20 }}
-              transition={{ duration: 0.2 }}
-            >
-              <div className="tw-absolute tw-z-10 tw-mt-1 tw-w-full tw-overflow-hidden tw-rounded-md tw-bg-iron-800 tw-shadow-2xl tw-ring-1 tw-ring-white/10">
-                <div className="tw-flow-root tw-max-h-[calc(16rem+_-10svh)] tw-overflow-y-auto tw-overflow-x-hidden tw-py-1">
-                  <ul className="tw-mx-0 tw-mb-0 tw-flex tw-list-none tw-flex-col tw-px-2">
-                    {Object.values(UserPageStatsActivityWalletFilterType).map(
-                      (filter) => (
-                        <UserPageStatsActivityWalletFilterItem
-                          key={`nft-activity-${filter}`}
-                          filter={filter}
-                          title={ACTIVITY_WALLET_FILTER_TYPE_TO_TITLE[filter]}
-                          activeFilter={activeFilter}
-                          onFilter={onFilter}
-                        />
-                      )
-                    )}
-                  </ul>
+        <LazyMotion features={domAnimation}>
+          <AnimatePresence mode="wait" initial={false}>
+            {isOpen && (
+              <m.div
+                className="tw-absolute tw-right-0 tw-z-10 tw-mt-1 tw-w-full tw-origin-top-right tw-rounded-lg tw-bg-iron-800 tw-shadow-xl tw-ring-1 tw-ring-black tw-ring-opacity-5"
+                initial={{ opacity: 0, y: -20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -20 }}
+                transition={{ duration: 0.2 }}
+              >
+                <div className="tw-absolute tw-z-10 tw-mt-1 tw-w-full tw-overflow-hidden tw-rounded-md tw-bg-iron-800 tw-shadow-2xl tw-ring-1 tw-ring-white/10">
+                  <div className="tw-flow-root tw-max-h-[calc(16rem+_-10svh)] tw-overflow-y-auto tw-overflow-x-hidden tw-py-1">
+                    <ul
+                      id={FILTER_LIST_ID}
+                      aria-label={getWalletActivityMessage(
+                        "user.collected.stats.walletActivity.filterOptionsLabel"
+                      )}
+                      className="tw-mx-0 tw-mb-0 tw-flex tw-list-none tw-flex-col tw-px-2"
+                    >
+                      {Object.values(UserPageStatsActivityWalletFilterType).map(
+                        (filter) => (
+                          <UserPageStatsActivityWalletFilterItem
+                            key={`nft-activity-${filter}`}
+                            filter={filter}
+                            title={getWalletActivityFilterLabel(filter)}
+                            ariaLabel={getWalletActivityFilterOptionLabel(
+                              filter
+                            )}
+                            activeFilter={activeFilter}
+                            onFilter={onFilter}
+                          />
+                        )
+                      )}
+                    </ul>
+                  </div>
                 </div>
-              </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
+              </m.div>
+            )}
+          </AnimatePresence>
+        </LazyMotion>
       </div>
     </div>
   );

--- a/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilterItem.tsx
+++ b/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilterItem.tsx
@@ -3,17 +3,23 @@ import type { UserPageStatsActivityWalletFilterType } from "../UserPageStatsActi
 export default function UserPageStatsActivityWalletFilterItem({
   filter,
   title,
+  ariaLabel,
   activeFilter,
   onFilter,
 }: {
   readonly filter: UserPageStatsActivityWalletFilterType;
   readonly title: string;
+  readonly ariaLabel: string;
   readonly activeFilter: UserPageStatsActivityWalletFilterType;
   readonly onFilter: (filter: UserPageStatsActivityWalletFilterType) => void;
 }) {
+  const isActive = filter === activeFilter;
   return (
     <li>
       <button
+        type="button"
+        aria-label={ariaLabel}
+        aria-pressed={isActive}
         className="tw-relative tw-flex tw-h-full tw-w-full tw-cursor-pointer tw-select-none tw-items-center tw-justify-between tw-rounded-lg tw-border-none tw-bg-transparent tw-p-2 tw-text-left tw-text-white tw-transition tw-duration-300 tw-ease-out hover:tw-bg-iron-700"
         onClick={() => onFilter(filter)}
       >
@@ -21,8 +27,9 @@ export default function UserPageStatsActivityWalletFilterItem({
           <span className="tw-text-sm tw-font-medium tw-text-white">
             {title}
           </span>
-          {filter === activeFilter && (
+          {isActive && (
             <svg
+              aria-hidden="true"
               className="tw-ml-2 tw-h-5 tw-w-5 tw-text-primary-300 tw-transition tw-duration-300 tw-ease-out"
               viewBox="0 0 24 24"
               fill="none"

--- a/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable.tsx
+++ b/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable.tsx
@@ -2,6 +2,7 @@ import type { NFTLite } from "@/components/user/settings/UserSettingsImgSelectMe
 import type { NextGenCollection } from "@/entities/INextgen";
 import type { Transaction } from "@/entities/ITransaction";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
+import { getWalletActivityMessage } from "../wallet-activity.messages";
 import UserPageStatsActivityWalletTableRow from "./row/UserPageStatsActivityWalletTableRow";
 
 export default function UserPageStatsActivityWalletTable({
@@ -18,9 +19,14 @@ export default function UserPageStatsActivityWalletTable({
   readonly nextgenCollections: NextGenCollection[];
 }) {
   return (
-    <div className="tw-px-4 sm:tw-px-6 tw-mt-4 tw-pb-2 tw-inline-block tw-min-w-full tw-align-middle">
+    <div className="tw-mt-4 tw-inline-block tw-min-w-full tw-px-4 tw-pb-2 tw-align-middle sm:tw-px-6">
       <table className="tw-min-w-full">
-        <tbody className="tw-divide-y tw-divide-iron-800 tw-divide-solid tw-divide-x-0">
+        <caption className="tw-sr-only">
+          {getWalletActivityMessage(
+            "user.collected.stats.walletActivity.tableCaption"
+          )}
+        </caption>
+        <tbody className="tw-divide-x-0 tw-divide-y tw-divide-solid tw-divide-iron-800">
           {transactions.map((transaction) => (
             <UserPageStatsActivityWalletTableRow
               key={`${transaction.from_address}-${transaction.to_address}-${transaction.transaction}-${transaction.token_id}`}

--- a/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper.tsx
+++ b/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper.tsx
@@ -7,6 +7,7 @@ import type { Transaction } from "@/entities/ITransaction";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import UserPageStatsActivityWalletFilter from "../filter/UserPageStatsActivityWalletFilter";
 import { UserPageStatsActivityWalletFilterType } from "../UserPageStatsActivityWallet.types";
+import { getWalletActivityEmptyMessage } from "../wallet-activity.messages";
 import UserPageStatsActivityWalletTable from "./UserPageStatsActivityWalletTable";
 export default function UserPageStatsActivityWalletTableWrapper({
   filter,
@@ -37,19 +38,6 @@ export default function UserPageStatsActivityWalletTableWrapper({
     filter: UserPageStatsActivityWalletFilterType
   ) => void;
 }) {
-  const FILTER_TO_NO_DATA: Record<
-    UserPageStatsActivityWalletFilterType,
-    string
-  > = {
-    [UserPageStatsActivityWalletFilterType.ALL]: "No transactions",
-    [UserPageStatsActivityWalletFilterType.AIRDROPS]: "No airdrops",
-    [UserPageStatsActivityWalletFilterType.MINTS]: "No mints",
-    [UserPageStatsActivityWalletFilterType.SALES]: "No sales",
-    [UserPageStatsActivityWalletFilterType.PURCHASES]: "No purchases",
-    [UserPageStatsActivityWalletFilterType.TRANSFERS]: "No transfers",
-    [UserPageStatsActivityWalletFilterType.BURNS]: "No burns",
-  };
-
   if (isFirstLoading) {
     return (
       <div className="tw-mt-2 tw-h-96 tw-w-full sm:tw-mt-4">
@@ -89,9 +77,9 @@ export default function UserPageStatsActivityWalletTableWrapper({
             )}
           </div>
         ) : (
-          <div className="tw-px-4 tw-py-4 tw-text-sm tw-italic tw-text-iron-500 sm:tw-px-6 sm:tw-text-base">
-            {FILTER_TO_NO_DATA[filter]}
-          </div>
+          <output className="tw-px-4 tw-py-4 tw-text-sm tw-italic tw-text-iron-500 sm:tw-px-6 sm:tw-text-base">
+            {getWalletActivityEmptyMessage(filter)}
+          </output>
         )}
       </div>
     </div>

--- a/components/user/stats/activity/wallet/wallet-activity.messages.ts
+++ b/components/user/stats/activity/wallet/wallet-activity.messages.ts
@@ -1,0 +1,71 @@
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
+import { UserPageStatsActivityWalletFilterType } from "./UserPageStatsActivityWallet.types";
+
+type WalletActivityMessageKey = Extract<
+  MessageKey,
+  `user.collected.stats.walletActivity.${string}`
+>;
+
+const FILTER_LABEL_KEYS: Record<
+  UserPageStatsActivityWalletFilterType,
+  WalletActivityMessageKey
+> = {
+  [UserPageStatsActivityWalletFilterType.ALL]:
+    "user.collected.stats.walletActivity.filters.all",
+  [UserPageStatsActivityWalletFilterType.AIRDROPS]:
+    "user.collected.stats.walletActivity.filters.airdrops",
+  [UserPageStatsActivityWalletFilterType.MINTS]:
+    "user.collected.stats.walletActivity.filters.mints",
+  [UserPageStatsActivityWalletFilterType.SALES]:
+    "user.collected.stats.walletActivity.filters.sales",
+  [UserPageStatsActivityWalletFilterType.PURCHASES]:
+    "user.collected.stats.walletActivity.filters.purchases",
+  [UserPageStatsActivityWalletFilterType.TRANSFERS]:
+    "user.collected.stats.walletActivity.filters.transfers",
+  [UserPageStatsActivityWalletFilterType.BURNS]:
+    "user.collected.stats.walletActivity.filters.burns",
+};
+
+const EMPTY_MESSAGE_KEYS: Record<
+  UserPageStatsActivityWalletFilterType,
+  WalletActivityMessageKey
+> = {
+  [UserPageStatsActivityWalletFilterType.ALL]:
+    "user.collected.stats.walletActivity.empty.all",
+  [UserPageStatsActivityWalletFilterType.AIRDROPS]:
+    "user.collected.stats.walletActivity.empty.airdrops",
+  [UserPageStatsActivityWalletFilterType.MINTS]:
+    "user.collected.stats.walletActivity.empty.mints",
+  [UserPageStatsActivityWalletFilterType.SALES]:
+    "user.collected.stats.walletActivity.empty.sales",
+  [UserPageStatsActivityWalletFilterType.PURCHASES]:
+    "user.collected.stats.walletActivity.empty.purchases",
+  [UserPageStatsActivityWalletFilterType.TRANSFERS]:
+    "user.collected.stats.walletActivity.empty.transfers",
+  [UserPageStatsActivityWalletFilterType.BURNS]:
+    "user.collected.stats.walletActivity.empty.burns",
+};
+
+export const getWalletActivityMessage = (
+  key: WalletActivityMessageKey,
+  params?: Parameters<typeof t>[2]
+) => t(DEFAULT_LOCALE, key, params);
+
+export const getWalletActivityFilterLabel = (
+  filter: UserPageStatsActivityWalletFilterType
+) => getWalletActivityMessage(FILTER_LABEL_KEYS[filter]);
+
+export const getWalletActivityFilterOptionLabel = (
+  filter: UserPageStatsActivityWalletFilterType
+) =>
+  getWalletActivityMessage(
+    "user.collected.stats.walletActivity.optionAriaLabel",
+    {
+      filter: getWalletActivityFilterLabel(filter),
+    }
+  );
+
+export const getWalletActivityEmptyMessage = (
+  filter: UserPageStatsActivityWalletFilterType
+) => getWalletActivityMessage(EMPTY_MESSAGE_KEYS[filter]);

--- a/components/utils/followers/Follower.tsx
+++ b/components/utils/followers/Follower.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import Link from "next/link";
 import type { ApiIdentityAndSubscriptionActions } from "@/generated/models/ApiIdentityAndSubscriptionActions";
 import UserCICAndLevel, {
@@ -8,6 +9,7 @@ import { AuthContext } from "@/components/auth/Auth";
 import UserFollowBtn, {
   UserFollowBtnSize,
 } from "@/components/user/utils/UserFollowBtn";
+import { getFollowersMessage } from "./followers.messages";
 
 const FOLLOW_STATUS_PREFETCH_MARGIN = "360px";
 
@@ -20,10 +22,13 @@ export default function Follower({
   readonly showFollowButton?: boolean | undefined;
   readonly mutedBackground?: boolean | undefined;
 }) {
-  const rowRef = useRef<HTMLDivElement>(null);
+  const rowRef = useRef<HTMLLIElement>(null);
   const [shouldLoadFollowButton, setShouldLoadFollowButton] = useState(false);
   const { connectedProfile } = useContext(AuthContext);
   const followerHandle = follower.identity.handle;
+  const followerProfileRoute =
+    followerHandle ?? follower.identity.primary_address;
+  const followerProfileName = followerHandle ?? follower.identity.primary_address;
   const normalizedFollowerHandle = followerHandle?.toLowerCase() ?? null;
   const normalizedConnectedHandle =
     connectedProfile?.handle?.toLowerCase() ?? null;
@@ -34,6 +39,12 @@ export default function Follower({
       normalizedFollowerHandle !== normalizedConnectedHandle)
   );
   const backgroundClass = mutedBackground ? "tw-bg-white/[0.01]" : "";
+  const profileLabel = getFollowersMessage("followers.profile.linkAriaLabel", {
+    handle: followerProfileName,
+  });
+  const profileImageAlt = getFollowersMessage("followers.profile.avatarAlt", {
+    handle: followerProfileName,
+  });
 
   useEffect(() => {
     if (!shouldShowFollowButton || shouldLoadFollowButton) {
@@ -63,18 +74,22 @@ export default function Follower({
   }, [shouldShowFollowButton, shouldLoadFollowButton]);
 
   return (
-    <div ref={rowRef} className={`${backgroundClass} tw-py-3`}>
+    <li ref={rowRef} className={`${backgroundClass} tw-py-3`}>
       <div className="tw-flex tw-items-center tw-justify-between tw-gap-x-3 tw-px-4 sm:tw-px-6">
         <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-x-3">
           <div className="tw-relative tw-h-10 tw-w-10 tw-flex-shrink-0 tw-rounded-lg tw-bg-iron-800">
             <div className="tw-h-full tw-w-full tw-rounded-lg">
               <div className="tw-h-full tw-w-full tw-max-w-full tw-overflow-hidden tw-rounded-lg tw-bg-iron-800 tw-ring-1 tw-ring-inset tw-ring-white/5">
-                <div className="tw-flex tw-h-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-lg tw-text-center">
+                <div className="tw-relative tw-flex tw-h-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-lg tw-text-center">
                   {follower.identity.pfp ? (
-                    <img
+                    // Profile avatars can come from arbitrary remote hosts, so this stays unoptimized.
+                    <Image
                       src={follower.identity.pfp}
-                      alt={`${follower.identity.handle}'s profile`}
-                      className="tw-mx-auto tw-h-auto tw-max-h-full tw-w-auto tw-max-w-full tw-bg-transparent tw-object-contain"
+                      alt={profileImageAlt}
+                      fill
+                      unoptimized
+                      sizes="40px"
+                      className="tw-bg-transparent tw-object-contain"
                     />
                   ) : (
                     <div className="tw-mx-auto tw-h-auto tw-max-h-full tw-w-auto tw-max-w-full tw-bg-transparent tw-object-contain" />
@@ -88,10 +103,11 @@ export default function Follower({
               <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-x-2">
                 <p className="tw-mb-0 tw-min-w-0 tw-text-md tw-font-semibold tw-leading-none tw-text-iron-50">
                   <Link
-                    href={`/${follower.identity.handle}`}
+                    href={`/${followerProfileRoute}`}
+                    aria-label={profileLabel}
                     className="tw-block tw-truncate tw-no-underline tw-transition tw-duration-300 tw-ease-out hover:tw-text-iron-500 hover:tw-underline"
                   >
-                    {follower.identity.handle}
+                    {followerProfileName}
                   </Link>
                 </p>
                 <UserCICAndLevel
@@ -115,6 +131,6 @@ export default function Follower({
           </div>
         )}
       </div>
-    </div>
+    </li>
   );
 }

--- a/components/utils/followers/FollowersList.tsx
+++ b/components/utils/followers/FollowersList.tsx
@@ -1,5 +1,6 @@
 import type { ApiIdentityAndSubscriptionActions } from "@/generated/models/ApiIdentityAndSubscriptionActions";
 import Follower from "./Follower";
+import { getFollowersMessage } from "./followers.messages";
 
 export default function FollowersList({
   followers,
@@ -8,8 +9,13 @@ export default function FollowersList({
   readonly followers: ApiIdentityAndSubscriptionActions[];
   readonly showFollowButtons?: boolean | undefined;
 }) {
+  const listLabel = getFollowersMessage("followers.list.label");
+
   return (
-    <div className="tw-mt-4 tw-flex tw-h-full tw-flex-col tw-overflow-hidden">
+    <ul
+      aria-label={listLabel}
+      className="tw-mb-0 tw-mt-4 tw-flex tw-h-full tw-list-none tw-flex-col tw-overflow-hidden tw-p-0"
+    >
       {followers.map((follower, index) => (
         <Follower
           key={follower.identity.id}
@@ -18,6 +24,6 @@ export default function FollowersList({
           mutedBackground={index % 2 === 1}
         />
       ))}
-    </div>
+    </ul>
   );
 }

--- a/components/utils/followers/FollowersListWrapper.tsx
+++ b/components/utils/followers/FollowersListWrapper.tsx
@@ -4,6 +4,7 @@ import CircleLoader, {
 } from "@/components/distribution-plan-tool/common/CircleLoader";
 import CommonIntersectionElement from "../CommonIntersectionElement";
 import FollowersList from "./FollowersList";
+import { getFollowersMessage } from "./followers.messages";
 
 export default function FollowersListWrapper({
   followers,
@@ -16,14 +17,22 @@ export default function FollowersListWrapper({
   readonly onBottomIntersection: (state: boolean) => void;
   readonly showFollowButtons?: boolean | undefined;
 }) {
+  const loadingLabel = getFollowersMessage("followers.list.loading");
+
   return (
-    <div className="tw-h-full tw-overflow-hidden">
+    <div className="tw-h-full tw-overflow-hidden" aria-busy={loading}>
       <FollowersList
         followers={followers}
         showFollowButtons={showFollowButtons}
       />
       {loading && (
-        <div className="tw-mt-8 tw-w-full tw-text-center">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-label={loadingLabel}
+          className="tw-mt-8 tw-w-full tw-text-center"
+        >
+          <span className="tw-sr-only">{loadingLabel}</span>
           <CircleLoader size={CircleLoaderSize.XXLARGE} />
         </div>
       )}

--- a/components/utils/followers/followers.messages.ts
+++ b/components/utils/followers/followers.messages.ts
@@ -1,0 +1,13 @@
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
+
+type FollowersMessageKey = Extract<MessageKey, `followers.${string}`>;
+
+type MessageParams = Record<string, string | number>;
+
+export function getFollowersMessage(
+  key: FollowersMessageKey,
+  params: MessageParams = {}
+): string {
+  return t(DEFAULT_LOCALE, key, params);
+}

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -16,6 +16,21 @@ function namespaceMessages<
   ) as NamespacedMessages<Prefix, Entries>;
 }
 
+type MessageMap = Record<string, string>;
+
+type ObjectMessages<Prefix extends string, Entries extends MessageMap> = {
+  readonly [Entry in keyof Entries as `${Prefix}.${Entry & string}`]: Entries[Entry];
+};
+
+function objectMessages<Prefix extends string, Entries extends MessageMap>(
+  prefix: Prefix,
+  entries: Entries
+): ObjectMessages<Prefix, Entries> {
+  return Object.fromEntries(
+    Object.entries(entries).map(([key, value]) => [`${prefix}.${key}`, value])
+  ) as ObjectMessages<Prefix, Entries>;
+}
+
 const REMEMES_DETAIL_MESSAGES = namespaceMessages("rememes.detail", [
   ["documentTitle", "{name} | ReMemes"],
   ["browserTitle", "{name} | ReMemes | 6529.io"],
@@ -46,6 +61,202 @@ const REMEMES_DETAIL_MESSAGES = namespaceMessages("rememes.detail", [
   ["references.artistName", "Artist Name: {artist}"],
   ["references.artistProfile", "Artist Profile:"],
 ] as const);
+
+const USER_COLLECTED_STATS_MESSAGES = namespaceMessages(
+  "user.collected.stats",
+  [
+    ["metrics.nextGen", "NextGen"],
+    ["metrics.memeSets", "Meme Sets"],
+    ["metrics.memes", "Memes"],
+    ["metrics.gradients", "Gradients"],
+    ["metrics.boost", "Boost"],
+    ["metrics.unique", "unique x{value}"],
+    ["metric.value", "x{value}"],
+    ["details.show", "Details"],
+    ["details.hide", "Hide Details"],
+    ["details.unavailable", "Stats are unavailable for this profile."],
+    ["seasons.title", "Seasons"],
+    ["seasons.startedCount", "{started}/{total} started"],
+    ["seasons.showLess", "Show less"],
+    ["seasons.showMore", "+{count} more"],
+    ["seasons.showMoreAriaLabel", "Show {count} more started seasons"],
+    ["seasons.unseized", "Unseized"],
+    ["seasonTile.sets.zero", "0 sets"],
+    ["seasonTile.sets.one", "{count} set"],
+    ["seasonTile.sets.many", "{count} sets"],
+    ["seasonTile.label", "SZN{seasonNumber}"],
+    ["seasonTile.toNextSet", "{held}/{total} to set {setNumber}"],
+    ["seasonTile.setComplete", "Set {count} complete"],
+  ] as const
+);
+
+const USER_COLLECTED_STATS_DETAILS_MESSAGES = objectMessages(
+  "user.collected.stats.details",
+  {
+    "collected.title": "Collected",
+    overview: "Overview",
+    "tables.overviewCaption": "Collected holdings summary by collection",
+    "tables.column.total": "Total",
+    "tables.column.memes": "Memes",
+    "tables.column.nextGen": "NextGen",
+    "tables.column.gradient": "Gradient",
+    "tables.column.memeLab": "Meme Lab",
+    "rows.cards": "Cards",
+    "rows.rank": "Rank",
+    "rows.tdh": "TDH",
+    "rows.noTdh": "* No TDH",
+    memesBySeason: "Memes Breakdown By Season",
+    "tables.memesBySeasonCaption": "Collected Memes breakdown by season",
+    "tables.column.unique": "Unique",
+    "tables.column.sets": "Sets",
+    seasonLabel: "Season {seasonNumber}",
+    uniqueProgress: "{held} / {total}",
+    uniqueProgressPercent: "({percent})",
+  } as const
+);
+
+const USER_COLLECTED_STATS_BOOST_MESSAGES = objectMessages(
+  "user.collected.stats.boostBreakdown",
+  {
+    title: "Boost Breakdown",
+    versionLink: "TDH Version: {version}",
+    tableCaption: "TDH boost breakdown by source",
+    "columns.type": "Type",
+    "columns.potential": "Potential Boost",
+    "columns.actual": "Actual Boost",
+    "groups.memes": "Memes",
+    "rows.fullCollectionSet": "Full Collection Set",
+    "rows.genesisSet": "Genesis Set",
+    "rows.nakamoto": "Nakamoto",
+    "rows.gradients": "Gradients",
+    "rows.total": "TOTAL BOOST",
+    seasonLabel: "SZN{seasonNumber}",
+    "info.totalPotential": "Total Potential Boost",
+    "info.totalActual": "Total Actual Boost",
+    "info.ariaLabel": "Show boost detail",
+  } as const
+);
+
+const USER_COLLECTED_STATS_ACTIVITY_MESSAGES = objectMessages(
+  "user.collected.stats.activityOverview",
+  {
+    title: "Activity Overview",
+    overview: "Overview",
+    memesBySeason: "Memes Breakdown By Season",
+    "tables.overviewCaption": "Collected activity summary by collection",
+    "tables.memesBySeasonCaption":
+      "Collected Meme activity breakdown by season",
+    "tables.memesBySeasonEmpty": "No Meme activity by season yet.",
+    "rows.airdrops": "Airdrops",
+    "rows.transfersIn": "Transfers In",
+    "rows.mints": "Mints",
+    "rows.mintsEth": "Mints (ETH)",
+    "rows.purchases": "Purchases",
+    "rows.purchasesEth": "Purchases (ETH)",
+    "rows.transfersOut": "Transfers Out",
+    "rows.burns": "Burns",
+    "rows.sales": "Sales",
+    "rows.salesEth": "Sales (ETH)",
+    seasonLabel: "Season {seasonNumber}",
+  } as const
+);
+
+const USER_COLLECTED_STATS_ACTIVITY_TABS_MESSAGES = objectMessages(
+  "user.collected.stats.activityTabs",
+  {
+    listLabel: "Activity details sections",
+    walletActivity: "Wallet Activity",
+    distributions: "Distributions",
+    tdhHistory: "TDH History",
+  } as const
+);
+
+const USER_COLLECTED_STATS_WALLET_ACTIVITY_MESSAGES = objectMessages(
+  "user.collected.stats.walletActivity",
+  {
+    title: "Wallet Activity",
+    filterButtonLabel: "Wallet activity filter: {filter}",
+    filterOptionsLabel: "Wallet activity filter options",
+    optionAriaLabel: "Show {filter} wallet activity",
+    tableCaption: "Wallet activity transactions",
+    "filters.all": "All",
+    "filters.airdrops": "Airdrops",
+    "filters.mints": "Mints",
+    "filters.sales": "Sales",
+    "filters.purchases": "Purchases",
+    "filters.transfers": "Transfers",
+    "filters.burns": "Burns",
+    "empty.all": "No transactions",
+    "empty.airdrops": "No airdrops",
+    "empty.mints": "No mints",
+    "empty.sales": "No sales",
+    "empty.purchases": "No purchases",
+    "empty.transfers": "No transfers",
+    "empty.burns": "No burns",
+  } as const
+);
+
+const USER_COLLECTED_STATS_DISTRIBUTIONS_MESSAGES = objectMessages(
+  "user.collected.stats.distributions",
+  {
+    title: "Distributions",
+    empty: "No distributions found",
+    loading: "Loading distributions",
+    tableCaption: "Profile distribution claims",
+    tokenLinkAriaLabel: "View {collection} token #{tokenId}",
+    "columns.collection": "Collection",
+    "columns.token": "Token",
+    "columns.name": "Name",
+    "columns.wallet": "Wallet",
+    "columns.minted": "Minted",
+    "columns.total": "Total",
+    "collections.memes": "The Memes",
+    "collections.gradients": "6529Gradient",
+    "collections.memeLab": "Meme Lab",
+    "phases.airdrop": "Airdrop",
+  } as const
+);
+
+const USER_COLLECTED_STATS_TDH_HISTORY_MESSAGES = objectMessages(
+  "user.collected.stats.tdhHistory",
+  {
+    title: "TDH History",
+    empty: "No TDH history found",
+    loading: "Loading TDH history",
+    chartListLabel: "TDH history charts",
+    chartAriaLabel: "{title} chart",
+    "charts.totalTdh.title": "Total TDH",
+    "charts.totalTdh.totalBoosted": "Total Boosted TDH",
+    "charts.netDailyChange.title": "Net TDH Daily Change",
+    "charts.netDailyChange.netBoosted": "Net Boosted TDH",
+    "charts.createdDailyChange.title": "Created TDH Daily Change",
+    "charts.createdDailyChange.createdBoosted": "Created Boosted TDH",
+    "charts.destroyedDailyChange.title": "Destroyed TDH Daily Change",
+    "charts.destroyedDailyChange.destroyedBoosted": "Destroyed Boosted TDH",
+  } as const
+);
+
+const USER_PROFILE_TABS_MESSAGES = objectMessages("user.profile.tabs", {
+  navigationLabel: "Profile sections",
+  scrollLeft: "Scroll profile sections left",
+  scrollRight: "Scroll profile sections right",
+  identity: "Identity",
+  brain: "Brain",
+  curation: "Curation",
+  collected: "Collected",
+  xtdh: "xTDH",
+  subscriptions: "Subscriptions",
+  proxy: "Proxy",
+  "badges.beta": "Beta",
+} as const);
+
+const FOLLOWERS_MESSAGES = objectMessages("followers", {
+  "modal.title": "Followers",
+  "list.label": "Followers",
+  "list.loading": "Loading followers",
+  "profile.linkAriaLabel": "View {handle}'s profile",
+  "profile.avatarAlt": "{handle}'s profile image",
+} as const);
 
 const MEME_LAB_DETAIL_MESSAGES = namespaceMessages("memeLab.detail", [
   ["browserTitle", "{name} | Meme Lab #{tokenId}"],
@@ -95,6 +306,10 @@ const TIMELINE_MESSAGES = namespaceMessages("timeline", [
   ["fields.addedImage", "Added Image"],
   ["fields.removedAnimation", "Removed Animation"],
   ["fields.addedAnimation", "Added Animation"],
+  ["media.defaultLabel", "Timeline media"],
+  ["media.imageAlt", "{label} preview image"],
+  ["media.videoAriaLabel", "{label} preview video"],
+  ["media.htmlTitle", "{label} interactive preview"],
 ] as const);
 
 const DISTRIBUTION_MESSAGES = namespaceMessages("distribution", [
@@ -127,6 +342,115 @@ const DISTRIBUTION_MESSAGES = namespaceMessages("distribution", [
   ["empty.xLink.ariaLabel", "Open @6529Collections on X for drop updates"],
   ["empty.noResults", "No results found for the search criteria."],
   ["notFound.label", "DISTRIBUTION"],
+] as const);
+
+const MEME_CALENDAR_MESSAGES = namespaceMessages("memeCalendar", [
+  ["title", "The Memes Minting Calendar"],
+  ["viewFullCalendar", "View Full Calendar"],
+  ["viewFullCalendarAriaLabel", "View full Memes minting calendar"],
+  ["timezone.regionLabel", "Calendar timezone"],
+  ["timezone.local", "Local"],
+  ["timezone.utc", "UTC"],
+  ["timezone.showLocal", "Show local time"],
+  ["timezone.showUtc", "Show UTC"],
+  ["overview.controls.nextMint", "Next Mint"],
+  ["overview.controls.memeNumber", "Meme #"],
+  ["overview.controls.screenshot", "Screenshot"],
+  ["overview.nextMint.heading.next", "Next Mint"],
+  ["overview.nextMint.heading.upcoming", "Upcoming Mint"],
+  ["overview.nextMint.heading.past", "Past Mint"],
+  ["overview.nextMint.heading.live", "Mint Live"],
+  ["overview.countdown.mintingIn", "Minting in"],
+  ["overview.countdown.minted", "Minted"],
+  ["overview.countdown.ago", "ago"],
+  ["overview.countdown.mintEndsIn", "Mint ends in"],
+  ["overview.duration.days", "d"],
+  ["overview.duration.hours", "h"],
+  ["overview.duration.minutes", "m"],
+  ["overview.duration.seconds", "s"],
+  ["overview.upcoming.currentSeason", "Upcoming Mints for SZN {season}"],
+  ["overview.upcoming.nextSeason", "Upcoming SZN {season}"],
+  ["overview.upcoming.empty", "No upcoming mints in this season."],
+  ["overview.upcoming.memeNumber", "Meme number"],
+  ["overview.upcoming.mintTime", "Mint time"],
+  ["overview.upcoming.calendarLinks", "Calendar links"],
+  ["grid.zoomGroup", "Calendar range"],
+  ["grid.zoom.szn", "SZN {value}"],
+  ["grid.zoom.year", "Year {value}"],
+  ["grid.zoom.epoch", "Epoch {value}"],
+  ["grid.zoom.period", "Period {value}"],
+  ["grid.zoom.era", "Era {value}"],
+  ["grid.zoom.eon", "Eon {value}"],
+  ["grid.title.szn", "SZN #{value}"],
+  ["grid.title.year", "Year #{value}"],
+  ["grid.title.epoch", "Epoch #{value}"],
+  ["grid.title.period", "Period #{value}"],
+  ["grid.title.era", "Era #{value}"],
+  ["grid.title.eon", "Eon #{value}"],
+  ["grid.titleWithGregorianYear", "{title} ({year})"],
+  ["grid.dateRange", "{start} - {end}"],
+  ["grid.memeRange", "Memes #{start} - #{end}"],
+  ["grid.cardAriaLabel", "Open {title}: {range}; {mints}"],
+  ["grid.division.szn", "SZN"],
+  ["grid.division.year", "year"],
+  ["grid.division.epoch", "epoch"],
+  ["grid.division.period", "period"],
+  ["grid.division.era", "era"],
+  ["grid.division.eon", "eon"],
+  ["grid.previous", "Previous {division}"],
+  ["grid.next", "Next {division}"],
+  ["grid.info.show", "Show calendar guide"],
+  ["grid.info.hide", "Hide calendar guide"],
+  ["grid.info.panelLabel", "Calendar guide"],
+  ["grid.info.mintingDays.label", "Minting Days"],
+  ["grid.info.mintingDays.text", "Monday / Wednesday / Friday"],
+  ["grid.info.szn.label", "SZN"],
+  ["grid.info.szn.text", "Traditional calendar quarter system / 3 months each"],
+  ["grid.info.szn.note", "~ 39 mints"],
+  ["grid.info.year.label", "YEAR"],
+  ["grid.info.year.text", "4 SZNs in 1 YEAR"],
+  ["grid.info.year.note", "~ 156 mints"],
+  ["grid.info.epoch.label", "EPOCH"],
+  ["grid.info.epoch.text", "4 YEARs / 16 SZNs"],
+  ["grid.info.epoch.note", "~ 626 mints"],
+  ["grid.info.period.label", "PERIOD"],
+  ["grid.info.period.text", "5 EPOCHs / 20 YEARs / 80 SZNs"],
+  ["grid.info.period.note", "~ 3,130 mints"],
+  ["grid.info.era.label", "ERA"],
+  ["grid.info.era.text", "5 PERIODs / 20 EPOCHs / 100 YEARs / 400 SZNs"],
+  ["grid.info.era.note", "~ 15,650 mints"],
+  ["grid.info.eon.label", "EON"],
+  ["grid.info.eon.text", "10 ERAs / 100 PERIODs / 1,000 YEARs / 4,000 SZNs"],
+  ["grid.info.eon.note", "~ 156,500 mints"],
+  ["grid.info.yearZero.label", "Year 0"],
+  [
+    "grid.info.yearZero.text",
+    "Jun 2022 - Dec 2022 / SZN1 / Year 0 was our experimental launch period, not bound by the later structured minting schedule.",
+  ],
+  ["grid.info.yearZero.note", "Memes #1 - #47"],
+  ["grid.jumpToday", "Jump to Today"],
+  ["grid.memeNumber", "Meme #"],
+  ["grid.date", "Date"],
+  ["grid.weekday.mon", "Mon"],
+  ["grid.weekday.tue", "Tue"],
+  ["grid.weekday.wed", "Wed"],
+  ["grid.weekday.thu", "Thu"],
+  ["grid.weekday.fri", "Fri"],
+  ["grid.weekday.sat", "Sat"],
+  ["grid.weekday.sun", "Sun"],
+  ["grid.tooltip.meme", "Meme {mint}"],
+  ["grid.tooltip.memes", "Memes {mints}"],
+  ["grid.dayMintAriaLabel", "{date}: {mint} mint"],
+  ["invites.addToCalendar", "Add to Calendar"],
+  ["invites.addToGoogleCalendar", "Add to Google Calendar"],
+  ["periods.seasonShort", "SZN"],
+  ["periods.seasonLinkAriaLabel", "View SZN {season} cards"],
+  ["periods.positionLabel", "Meme calendar position"],
+  ["periods.year", "YEAR"],
+  ["periods.epoch", "EPOCH"],
+  ["periods.period", "PERIOD"],
+  ["periods.era", "ERA"],
+  ["periods.eon", "EON"],
 ] as const);
 
 const THE_MEMES_DETAIL_LIVE_MESSAGES = namespaceMessages(
@@ -193,6 +517,77 @@ const THE_MEMES_DETAIL_TIMELINE_MESSAGES = namespaceMessages(
   [["region", "The Memes card timeline"]] as const
 );
 
+const THE_MEMES_DETAIL_REFERENCES_MESSAGES = namespaceMessages(
+  "theMemes.detail.references",
+  [
+    ["empty.rememes", "ReMemes that reference this NFT will appear here."],
+    [
+      "memeLab.description",
+      "The Meme Lab is the lab for Meme Artists to release work that is related to The Meme Cards.",
+    ],
+    ["memeLab.logoAlt", "Meme Lab"],
+    ["refresh.ariaLabel", "Refresh ReMemes results"],
+    ["refresh.tooltip", "Refresh results"],
+    [
+      "rememes.description",
+      'ReMemes are community-created and community-submitted NFTs inspired by the Meme Cards. They are not created or "authorized" by 6529 Collections.',
+    ],
+    ["rememes.logoAlt", "ReMemes"],
+    ["sort.trigger", "Sort: {sort}"],
+  ] as const
+);
+
+const THE_MEMES_DETAIL_ART_MESSAGES = namespaceMessages("theMemes.detail.art", [
+  ["download.cancelDownload", "Cancel download"],
+  ["download.complete", "Complete"],
+  ["download.dismissComplete", "Dismiss download complete"],
+  ["download.download", "Download"],
+  ["download.downloadComplete", "Download complete"],
+  ["download.downloadFile", "Download file"],
+  ["download.downloading", "Downloading..."],
+  ["download.downloadingFile", "Downloading file"],
+  ["download.downloadingProgress", "Downloading {percentage}%"],
+  ["empty.noBoosts", "No boosts found."],
+  ["empty.noProperties", "No properties found."],
+  ["fields.cardNumber", "Card number"],
+  ["fields.collection", "Collection"],
+  ["fields.dimensions", "Dimensions"],
+  ["fields.meme", "Meme"],
+  ["fields.memeName", "Meme name"],
+  ["fields.memeRank", "Meme Rank"],
+  ["fields.season", "Season"],
+  ["fields.tdh", "TDH"],
+  ["fields.unweightedTdh", "Unweighted TDH"],
+  ["links.animationFallbackLabel", "ANIMATION"],
+  ["links.animationTitle", "Animation Asset"],
+  ["links.imageFallbackLabel", "IMAGE"],
+  ["links.imageTitle", "Image Asset"],
+  ["links.jsonLabel", "JSON"],
+  ["links.jsonTitle", "JSON Metadata"],
+  ["links.open", "Open"],
+  ["links.openAnimation", "Open animation in new tab"],
+  ["links.openImage", "Open image in new tab"],
+  ["links.openRawMetadata", "Open raw metadata in new tab"],
+  ["media.close", "Close media"],
+  ["media.download", "Download media"],
+  ["media.downloading", "Downloading media"],
+  ["media.fullscreen", "Full screen"],
+  ["media.next", "Show next artwork media"],
+  ["media.openInBrowser", "Open in browser"],
+  ["media.openInNewTab", "Open in new tab"],
+  ["media.previous", "Show previous artwork media"],
+  ["media.saveAnimation", "Save animation"],
+  ["media.saveImage", "Save image"],
+  ["sections.arweaveLinks", "Arweave links"],
+  ["sections.boosts", "Boosts"],
+  ["sections.properties", "Properties"],
+  ["sections.stats", "Stats"],
+  ["sections.tdhBreakdown", "TDH breakdown"],
+  ["values.boostPercent", "{sign}{value}%"],
+  ["values.notAvailable", "N/A"],
+  ["values.rank", "#{rank}"],
+] as const);
+
 export const EN_US_MESSAGES = {
   "theMemes.documentTitle": "The Memes | Collections",
   "theMemes.title": "The Memes",
@@ -238,7 +633,10 @@ export const EN_US_MESSAGES = {
   ...THE_MEMES_DETAIL_LIVE_MESSAGES,
   ...THE_MEMES_DETAIL_ACTIVITY_MESSAGES,
   ...THE_MEMES_DETAIL_TIMELINE_MESSAGES,
+  ...THE_MEMES_DETAIL_REFERENCES_MESSAGES,
+  ...THE_MEMES_DETAIL_ART_MESSAGES,
   ...TIMELINE_MESSAGES,
+  ...MEME_CALENDAR_MESSAGES,
   "theMemes.sort.age": "Age",
   "theMemes.sort.editionSize": "Edition Size",
   "theMemes.sort.meme": "Meme",
@@ -270,6 +668,9 @@ export const EN_US_MESSAGES = {
   "memeLab.sorting.descendingLabel": "Sort descending",
   "memeLab.sorting.sortButtonLabel": "Sort by {sort}",
   "memeLab.loading.fetching": "Fetching",
+  "memeLab.results.gridLabel": "Meme Lab cards",
+  "memeLab.results.artistGridLabel": "Meme Lab cards by {artistName}",
+  "memeLab.results.collectionGridLabel": "Meme Lab cards in {collectionName}",
   "memeLab.collection.view": "view",
   "memeLab.collection.viewAriaLabel": "View {collectionName} collection",
   "memeLab.card.linkAriaLabel": "View {name}, Meme Lab card #{tokenId}",
@@ -306,6 +707,7 @@ export const EN_US_MESSAGES = {
   "rememes.logoAlt": "ReMemes",
   "rememes.actions.add": "Add ReMeme",
   "rememes.results.count": "(x{count})",
+  "rememes.results.gridLabel": "ReMemes results",
   "rememes.sorting.filterLabel": "Sort",
   "rememes.sort.random": "Random",
   "rememes.sort.recentlyAdded": "Recently Added",
@@ -321,6 +723,62 @@ export const EN_US_MESSAGES = {
   "rememes.card.linkAriaLabel": "View {name}, ReMeme #{tokenId}",
   "rememes.card.tokenAriaLabel": "Token #{tokenId}",
   "rememes.card.replicaCount": "(x{count})",
+  "user.collected.cards.listLabel": "Collected cards",
+  "user.collected.empty.noCards": "No cards to display",
+  "user.collected.empty.fullSetter": "Congratulations, full setter!",
+  "user.collected.empty.memesFullSetter":
+    "Congratulations, The Memes full setter!",
+  "user.collected.empty.seasonFullSetter":
+    "Congratulations, {season} full setter!",
+  "user.collected.empty.gradientFullSetter":
+    "Congratulations, Gradient full setter!",
+  "user.collected.empty.memeLabFullSetter":
+    "Congratulations, Meme Lab full setter!",
+  "user.collected.empty.nextGenFullSetter":
+    "Congratulations, Next Gen full setter!",
+  "user.collected.filters.view": "View",
+  "user.collected.filters.view.native": "Native",
+  "user.collected.filters.view.network": "Network",
+  "user.collected.filters.collection": "Collection",
+  "user.collected.filters.collection.all": "All",
+  "user.collected.filters.collection.allCollections": "All Collections",
+  "user.collected.filters.collection.unknown": "Unknown Collection",
+  "user.collected.filters.collection.memes": "The Memes",
+  "user.collected.filters.collection.nextgen": "NextGen",
+  "user.collected.filters.collection.gradients": "Gradients",
+  "user.collected.filters.collection.memeLab": "Meme Lab",
+  "user.collected.filters.collection.network": "Network",
+  "user.collected.filters.sortBy": "Sort By",
+  "user.collected.filters.sort.tokenId": "Token ID",
+  "user.collected.filters.sort.tdh": "TDH",
+  "user.collected.filters.sort.rank": "Rank",
+  "user.collected.filters.sort.xtdh": "xTDH",
+  "user.collected.filters.sort.xtdhDay": "xTDH/day",
+  "user.collected.filters.seized": "Seized",
+  "user.collected.filters.seized.all": "All",
+  "user.collected.filters.seized.allCards": "All Cards",
+  "user.collected.filters.seized.seized": "Seized",
+  "user.collected.filters.seized.notSeized": "Not Seized",
+  "user.collected.filters.scrollLeft": "Scroll filters left",
+  "user.collected.filters.scrollRight": "Scroll filters right",
+  ...USER_COLLECTED_STATS_MESSAGES,
+  ...USER_COLLECTED_STATS_DETAILS_MESSAGES,
+  ...USER_COLLECTED_STATS_BOOST_MESSAGES,
+  ...USER_COLLECTED_STATS_ACTIVITY_MESSAGES,
+  ...USER_COLLECTED_STATS_ACTIVITY_TABS_MESSAGES,
+  ...USER_COLLECTED_STATS_WALLET_ACTIVITY_MESSAGES,
+  ...USER_COLLECTED_STATS_DISTRIBUTIONS_MESSAGES,
+  ...USER_COLLECTED_STATS_TDH_HISTORY_MESSAGES,
+  "user.collected.networkCards.listLabel": "Collected network cards",
+  "user.collected.networkCards.empty": "No network tokens found",
+  "user.collected.networkCards.defaultCollection": "Network",
+  "user.collected.networkCards.defaultTokenName": "Token #{tokenId}",
+  "user.collected.networkCards.imageAlt": "Network token image for {name}",
+  "user.collected.networkCards.tokenLabel": "#{tokenId}",
+  "user.collected.networkCards.xtdh": "xTDH",
+  "user.collected.networkCards.xtdhPerDay": "xTDH/day",
+  ...USER_PROFILE_TABS_MESSAGES,
+  ...FOLLOWERS_MESSAGES,
   ...REMEMES_DETAIL_MESSAGES,
 } as const;
 

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -78,6 +78,25 @@ const MEME_LAB_DETAIL_MESSAGES = namespaceMessages("memeLab.detail", [
   ["activity.transactionType", "Transaction Type"],
 ] as const);
 
+const TIMELINE_MESSAGES = namespaceMessages("timeline", [
+  ["date.utc", "{date} UTC"],
+  ["links.uri", "URI"],
+  ["links.uriAriaLabel", "Open metadata URI"],
+  ["links.txn", "TXN"],
+  ["links.txnAriaLabel", "Open transaction on Etherscan"],
+  ["fields.from", "From"],
+  ["fields.to", "To"],
+  ["fields.value", "Value"],
+  ["fields.removedValue", "Removed Value"],
+  ["fields.addedValue", "Added Value"],
+  ["fields.removedUrl", "Removed URL"],
+  ["fields.addedUrl", "Added URL"],
+  ["fields.removedImage", "Removed Image"],
+  ["fields.addedImage", "Added Image"],
+  ["fields.removedAnimation", "Removed Animation"],
+  ["fields.addedAnimation", "Added Animation"],
+] as const);
+
 const DISTRIBUTION_MESSAGES = namespaceMessages("distribution", [
   ["title", "Distribution"],
   ["documentTitle", "{collection} #{tokenId} | Distribution"],
@@ -169,6 +188,11 @@ const THE_MEMES_DETAIL_ACTIVITY_MESSAGES = namespaceMessages(
   ] as const
 );
 
+const THE_MEMES_DETAIL_TIMELINE_MESSAGES = namespaceMessages(
+  "theMemes.detail.timeline",
+  [["region", "The Memes card timeline"]] as const
+);
+
 export const EN_US_MESSAGES = {
   "theMemes.documentTitle": "The Memes | Collections",
   "theMemes.title": "The Memes",
@@ -213,6 +237,8 @@ export const EN_US_MESSAGES = {
   "theMemes.detail.tabs.yourTransactions": "Your Transactions",
   ...THE_MEMES_DETAIL_LIVE_MESSAGES,
   ...THE_MEMES_DETAIL_ACTIVITY_MESSAGES,
+  ...THE_MEMES_DETAIL_TIMELINE_MESSAGES,
+  ...TIMELINE_MESSAGES,
   "theMemes.sort.age": "Age",
   "theMemes.sort.editionSize": "Edition Size",
   "theMemes.sort.meme": "Meme",

--- a/ops/docs/media/collections/feature-meme-lab-list-and-collection-browsing.md
+++ b/ops/docs/media/collections/feature-meme-lab-list-and-collection-browsing.md
@@ -26,6 +26,8 @@
 - On `/meme-lab`, switch to `Collections`, then select `view` for a collection.
 - Open `/meme-lab/collection/{collection}` directly.
 - On mobile and tablet (`< xl`), use the collections dropdown on `/meme-lab`.
+- Browse and collection card grids render as labelled lists so assistive
+  technology can announce grouped card results.
 - Card tiles expose accessible names in the form
   `View {name}, Meme Lab card #{tokenId}`.
 
@@ -44,7 +46,8 @@
 7. If `Volume` is not active, picking a volume window also switches sort to
    `Volume`.
 8. In grouped `Collections`, select `view` to open
-   `/meme-lab/collection/{collection}`.
+   `/meme-lab/collection/{collection}`. During progressive i18n migration, a
+   supported non-default `locale` query is preserved on the collection link.
 9. Open any card tile to go to `/meme-lab/{id}`.
 
 ### Collection Route `/meme-lab/collection/{collection}`
@@ -73,6 +76,7 @@
 - Collection `view` links normalize spaces to hyphenated slugs and the
   collection page decodes older encoded-space URLs such as
   `/meme-lab/collection/6529-Intern%20JPGs`.
+- Collection `view` links preserve supported non-default `locale` query values.
 
 ## Loading, Empty, and Error States
 
@@ -117,10 +121,10 @@
   through each sort change.
 - Card tiles reuse shared NFT rendering, including wallet balance chips when
   signed in.
-- List, collection, sorting, card accessible names, and card metric labels are
-  message-backed for the progressive i18n path. Non-`en-US` dictionaries may
-  still fall back to `en-US` for Meme Lab-specific labels while reviewed
-  translations are pending.
+- List, grouped collection/artist list labels, sorting, card accessible names,
+  and card metric labels are message-backed for the progressive i18n path.
+  Non-`en-US` dictionaries may still fall back to `en-US` for Meme Lab-specific
+  labels while reviewed translations are pending.
 - Card metric dates, numbers, percentages, ETH values, and grouped label
   sorting use the repo `Intl` helpers.
 - Card-level tabs and navigation are documented in

--- a/ops/docs/media/collections/feature-rememes-browse-and-detail.md
+++ b/ops/docs/media/collections/feature-rememes-browse-and-detail.md
@@ -7,7 +7,8 @@
 - Browse supports sort/filter controls, random refresh, pagination, and detail
   handoff.
 - Browse is progressively i18n-ready for labels, accessible names, metadata,
-  logo alt text, loading text, and count formatting.
+  logo alt text, loading text, count formatting, locale-preserving card/detail
+  navigation, and the Add ReMeme action.
 - Detail is progressively i18n-ready for document metadata, labels, accessible
   names, tab labels, reference-card labels, and locale-preserving navigation.
 - Detail uses in-page tabs: `Overview`, `Metadata`, and `References`.
@@ -35,7 +36,7 @@
 3. Review the header actions:
    - Result count badge
    - `LFG: Start the Show!`
-   - `Add ReMeme` (`/rememes/add`)
+   - `Add ReMeme` (`/rememes/add`, preserving non-default `locale`)
 4. Apply filters:
    - `Sort`: `Random` or `Recently Added`
    - `Token Type`: `All`, `ERC-721`, `ERC-1155`
@@ -73,8 +74,10 @@
 - Non-numeric `meme_id` values are cleared back to `/rememes`.
 - Count formatting follows the active locale; visible token IDs remain stable
   identifiers.
-- Browse card, detail back, replica, and reference-card links preserve
-  non-default `locale` values.
+- Browse exposes the card grid as a labelled results list for assistive
+  technology.
+- Browse card, Add ReMeme, detail back, replica, and reference-card links
+  preserve non-default `locale` values.
 - Sort, token type, and page are in-memory state and reset on reload.
 - Changing sort/token type/meme filter resets pagination to page 1.
 - Detail tabs (`Overview`, `Metadata`, `References`) are in-page state only and

--- a/ops/docs/media/memes/feature-card-tabs-and-focus-links.md
+++ b/ops/docs/media/memes/feature-card-tabs-and-focus-links.md
@@ -54,10 +54,23 @@
    ETH numbers, activity headings, the transaction-type dropdown label/options,
    loading and empty states, and the hidden activity-table caption.
 9. `Timeline` uses the active supported `locale` for its region label, UTC date
-   formatting, URI/TXN link labels, and change field labels.
-10. `The Art`, `Activity`, and `Timeline` load on first open, then stay mounted
+   formatting, URI/TXN link labels, change field labels, and timeline media
+   accessible names.
+10. `References` uses the active supported `locale` for Meme Lab/ReMemes
+    descriptions, logo alt text, sort labels, refresh labels, ReMeme empty
+    state, ReMeme card accessible names, ReMeme link locale preservation, and
+    replica counts.
+11. The header calendar period strip uses the active supported `locale` for
+    period labels, season-link accessible text, locale-preserving season
+    links, and period number formatting.
+12. `The Art`, `Activity`, and `Timeline` load on first open, then stay mounted
     for later tab switches.
-11. If a numeric card id is unresolved, the route removes `focus`, hides tab
+13. The header Art Viewer uses the active supported `locale` for media action
+    accessible names and save dialog titles.
+14. The Art additional-details rows use the active supported `locale` for
+    section headings, metric labels, empty states, open/download labels, and
+    TDH/rank number formatting.
+15. If a numeric card id is unresolved, the route removes `focus`, hides tab
     content, and shows the shared next-mint fallback panel.
 
 ## Route States
@@ -116,10 +129,30 @@
   through the progressive i18n helpers.
 - Shared activity-row copy, pagination copy, and transaction-specific date and
   amount formatting remain deferred activity-surface debt.
+- Header Art Viewer fullscreen/open/download/downloading/close controls,
+  previous/next media buttons, and save dialog titles are routed through the
+  progressive i18n helpers.
+- The Art additional-details section headings, metric labels, empty states,
+  open/download labels, and TDH/rank number formatting are routed through the
+  progressive i18n helpers. Property trait names/values and media URLs remain
+  source-data copy.
+- References tab Meme Lab/ReMemes descriptions, logo alt text, sort labels,
+  refresh labels, ReMeme empty state, ReMeme card accessible names, ReMeme link
+  locale preservation, and replica counts are routed through the progressive
+  i18n helpers. ReMeme names, collection names, token IDs, and source NFT
+  metadata remain source-data copy.
+- The References refresh action is keyboard reachable with a semantic button.
+- The header calendar period strip has message-backed period labels and
+  accessible names, locale-aware number formatting, locale-preserving season
+  links, a labelled group for the secondary period cluster, and a 24px minimum
+  target on the season link.
 - Timeline region labels, UTC date formatting, URI/TXN link labels, and shared
   change field labels are routed through the progressive i18n helpers.
-- Timeline media alt text, iframe titles, raw metadata values, and event text
-  remain deferred shared-timeline debt.
+- Timeline image alt text, video accessible labels, and HTML iframe titles use
+  message-backed text based on the localized change label.
+- Timeline metadata values render as plain text with preserved line breaks;
+  event text remains source-data copy and deeper media semantics remain
+  deferred shared-timeline debt.
 - Non-source locales fall back to `en-US` for this detail surface until
   reviewed translations are added.
 - Primary tabs expose selected state with `aria-pressed`; History tabs use the

--- a/ops/docs/media/memes/feature-card-tabs-and-focus-links.md
+++ b/ops/docs/media/memes/feature-card-tabs-and-focus-links.md
@@ -53,9 +53,11 @@
 8. `Card Activity` uses the active supported `locale` for volume labels and
    ETH numbers, activity headings, the transaction-type dropdown label/options,
    loading and empty states, and the hidden activity-table caption.
-9. `The Art`, `Activity`, and `Timeline` load on first open, then stay mounted
-   for later tab switches.
-10. If a numeric card id is unresolved, the route removes `focus`, hides tab
+9. `Timeline` uses the active supported `locale` for its region label, UTC date
+   formatting, URI/TXN link labels, and change field labels.
+10. `The Art`, `Activity`, and `Timeline` load on first open, then stay mounted
+    for later tab switches.
+11. If a numeric card id is unresolved, the route removes `focus`, hides tab
     content, and shows the shared next-mint fallback panel.
 
 ## Route States
@@ -114,6 +116,10 @@
   through the progressive i18n helpers.
 - Shared activity-row copy, pagination copy, and transaction-specific date and
   amount formatting remain deferred activity-surface debt.
+- Timeline region labels, UTC date formatting, URI/TXN link labels, and shared
+  change field labels are routed through the progressive i18n helpers.
+- Timeline media alt text, iframe titles, raw metadata values, and event text
+  remain deferred shared-timeline debt.
 - Non-source locales fall back to `en-US` for this detail surface until
   reviewed translations are added.
 - Primary tabs expose selected state with `aria-pressed`; History tabs use the

--- a/ops/docs/media/memes/feature-minting-calendar.md
+++ b/ops/docs/media/memes/feature-minting-calendar.md
@@ -34,7 +34,8 @@ distribution routes.
 ## User Journey
 
 1. Open `/meme-calendar`.
-2. Switch between `Local` and `UTC`.
+2. Switch between `Local` and `UTC`; the timezone toggle exposes pressed
+   state and accessible names.
 3. Read the top panel:
    - Heading changes by state: `Next Mint`, `Upcoming Mint`, `Mint Live`, or
      `Past Mint`.
@@ -119,6 +120,18 @@ distribution routes.
 - Mint start/end are anchored to Europe/Athens wall-clock timing before
   rendering in local or UTC display modes.
 - Calendar/API output is schedule information, not wallet eligibility.
+- During progressive localization, `/meme-calendar?locale=<supported-locale>`
+  can be used to smoke-test the overview shell and the first lower-calendar
+  pass. The timezone toggle, overview heading/full-calendar link, top-panel
+  controls/headings/countdown labels, screenshot label, upcoming-card
+  heading/empty state, lower-calendar zoom/guide/navigation/jump controls,
+  default SZN month names, mint numbers, mint-day accessible names, and
+  calendar invite link/event labels are routed through the source-message and
+  formatting helpers. Higher-level lower-calendar drilldown cards (`Year`,
+  `Epoch`, `Period`, `Era`, `Eon`) now use message-backed titles, date ranges,
+  mint ranges, and accessible button names.
+- Reviewed non-English product translations and locale-prefixed routing remain
+  deferred.
 - `Date` jump is month-level only.
 - Compact fallback panels are intentionally limited to local-time next-mint
   context.

--- a/ops/docs/profiles/tabs/feature-collected-tab.md
+++ b/ops/docs/profiles/tabs/feature-collected-tab.md
@@ -6,6 +6,7 @@ The `Collected` tab at `/{user}/collected` combines profile holdings browsing
 with an integrated stats summary and an expandable details panel.
 
 It has two top-level views:
+
 - `Native`: profile card holdings for The Memes, Gradients, NextGen, and Meme Lab.
 - `Network`: xTDH token holdings by contract.
 
@@ -55,6 +56,8 @@ Transfer mode is part of the Native collected view (not a separate route).
 2. Review the top stats block:
    - headline metrics can include `NextGen`, `Meme Sets`, `Memes`,
      `Gradients`, and `Boost`
+   - headline metric labels, multiplier values, unique-count copy, and the
+     `Details` toggle are message-backed from the source locale
    - collection-backed metrics (`NextGen`, `Meme Sets`, `Memes`, `Gradients`)
      act as shortcuts into that collection; clicking the active metric clears
      that collection filter
@@ -63,15 +66,42 @@ Transfer mode is part of the Native collected view (not a separate route).
      full set; it shows the lowest full-set count across those seasons
    - `Seasons` tiles show started Meme seasons, complete-set counts, and
      progress toward the next set
+   - `Seasons` heading/count text, show more/less controls, unseized labels,
+     and tile set-count text are message-backed from the source locale
+   - season tile labels and progress detail copy are message-backed from the
+     source locale
    - hover/focus previews a season tile's progress text; click applies or
      clears the Memes season filter
    - unopened Meme seasons can appear as `Unseized` chips
 3. Click `Details` to expand the integrated stats panel.
 4. In `Details`, review:
    - `Collected` totals and per-season Meme tables
+     - collected details headings, table headers, row labels, and per-season
+       labels are message-backed from the source locale
+     - collected details tables include screen-reader captions and row headers
+       for assistive technologies
    - `Activity Overview`
+   - Activity Overview heading, table headings, row labels, and per-season
+     labels are message-backed from the source locale
+   - Activity Overview tables include screen-reader captions and row headers
+     for assistive technologies
    - lower section tabs: `Wallet Activity`, `Distributions`, `TDH History`
+     - lower Activity tab labels and the tab-list accessible name are
+       message-backed from the source locale
+     - lower Activity tabs expose tab/panel relationships and support keyboard
+       arrow, Home, and End navigation
+   - `Wallet Activity`
+     - Wallet Activity heading, filter labels, filter accessible names, empty
+       states, and transaction table caption are message-backed from the source
+       locale
+   - `Distributions`
+     - Distributions heading, empty state, table caption, table headings,
+       collection names, token link accessible names, and relative time display
+       are message-backed or locale-formatted from the source locale
    - `Boost Breakdown`
+   - Boost Breakdown static labels and table headings are message-backed from
+     the source locale; the table exposes a screen-reader caption, row
+     headers, and keyboard-focusable info triggers.
 5. Choose `View`:
    - `Native` for profile card holdings.
    - `Network` for xTDH token holdings.
@@ -80,14 +110,25 @@ Transfer mode is part of the Native collected view (not a separate route).
    - Network collection: contract list from current xTDH collections.
    - Memes-only filters: `Seized` and `Season`.
    - Address filter (`All Addresses` or one wallet) is available in native view.
+   - View, collection, sort, seized, and filter-scroll control names are
+     message-backed from the source locale.
 7. Apply sort and browse pages.
 8. In native view (outside transfer mode), open token routes from cards:
    - `/the-memes/{id}`, `/6529-gradient/{id}`, `/nextgen/token/{id}`, `/meme-lab/{id}`.
-9. If transfer is available, click `Transfer`:
-   - cards switch from links to selection controls
-   - ERC-1155 cards support quantity selection
-   - ERC-721 cards are single-select
-10. Use the sticky transfer panel to review selection and continue.
+   - Native card results render as a labelled `Collected cards` list with one
+     list item per card for assistive technologies.
+9. In network view, review xTDH token holdings:
+   - Network card results render as a labelled `Collected network cards` list
+     with one list item per token for assistive technologies.
+   - Network card copy and image alternatives are message-backed from the
+     source locale.
+10. If transfer is available, click `Transfer`:
+
+- cards switch from links to selection controls
+- ERC-1155 cards support quantity selection
+- ERC-721 cards are single-select
+
+11. Use the sticky transfer panel to review selection and continue.
 
 ## Common Scenarios
 
@@ -146,8 +187,11 @@ Transfer mode is part of the Native collected view (not a separate route).
 
 - Initial load shows skeleton placeholders.
 - If native collected data fails, the tab falls back to empty-state copy
-  (for example `No cards to display`).
-- If network token data fails, network cards can fall back to `No tokens found`.
+  (for example `No cards to display`). Empty-state copy is message-backed from
+  the source locale and announced as status text for assistive technologies.
+- If network token data fails, network cards can fall back to
+  `No network tokens found`. This copy follows the same message-backed status
+  pattern as the native collected view.
 - Inside `Details`:
   - Wallet Activity empty states are filter-specific (`No transactions`,
     `No sales`, `No burns`, and similar).

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -7,11 +7,12 @@ page migration PRs for safe media surfaces.
 
 ## Current Branch
 
-`codex/the-memes-timeline-a11y-i18n`
+`codex/user-followers-modal-a11y-i18n`
 
 ## Constraints
 
 - Preserve unrelated dirty files:
+  - `__tests__/components/nft-image/RememeImage.test.tsx`
   - `contexts/EmojiContext.tsx`
   - `__tests__/contexts/EmojiContext.test.tsx`
   - `styles/seize-bootstrap.scss`
@@ -25,20 +26,42 @@ page migration PRs for safe media surfaces.
 - WCAG target: WCAG 2.2 AA.
 - Source locale: `en-US`.
 - Initial supported locales: `en-US`, `en-GB`, `fr-FR`, `es-ES`, `de-DE`.
-- Current implementation surface: shared timeline labels/dates and The Memes
-  Timeline tab, stacked on PR #2614. PR #2614 is bot-happy on latest head
-  `45caff7`, review-ready only, and must not be merged without human approval.
-- Scope includes The Memes timeline region labeling, locale-aware UTC timeline
-  date formatting, message-backed URI/TXN link labels and accessible names, and
-  shared change field labels.
-- Timeline media alt text, iframe titles, raw metadata values, event text, and
-  deeper media semantics remain deferred shared-timeline debt.
+- PR #2623 is bot-happy on the latest head and remains review-ready only.
+- PR #2624 is open and review-ready only after the CodeRabbit video-fallback
+  fix; keep it unmerged.
+- PR #2625 is bot-happy on the latest head and remains review-ready only.
+- PR #2626 is bot-happy on the latest head and remains review-ready only.
+- PR #2627 remains review-ready only with a bot-happy latest head.
+- PR #2628 is bot-happy on the latest head and remains review-ready only.
+- PR #2629 is bot-happy on the latest head and remains review-ready only.
+- PR #2630 is bot-happy on the latest head and remains review-ready only.
+- PR #2631 is bot-happy on the latest head and remains review-ready only.
+- PR #2633 is bot-happy on the latest head and remains review-ready only.
+- PR #2634 is bot-happy on the latest head and remains review-ready only.
+- PR #2635 is bot-happy on the latest head and remains review-ready only.
+- PR #2636 is bot-happy on the latest head and remains review-ready only.
+- PR #2637 is bot-happy on the latest head and remains review-ready only.
+- PR #2638 is bot-happy on the latest head and remains review-ready only.
+- PR #2639 is bot-happy on the latest head and remains review-ready only.
+- PR #2640 is bot-happy on the latest head and remains review-ready only. It
+  covers profile shell tab titles, beta badge text, navigation landmark labels,
+  scroll button labels, and active-page semantics. It is stacked from PR #2639
+  and must not be merged.
+- PR #2641 is open and review-ready only. It covers the profile followers modal
+  title, follower list label, loading status, follower profile link names,
+  avatar alt text, and semantic list structure. It is stacked from PR #2640 and
+  must not be merged.
+- Non-source locales currently fall back to `en-US` until reviewed
+  translations are added.
 - Full locale-prefixed routing is deferred.
 
 ## Next Actions
 
-1. Open a review-ready PR stacked on PR #2614.
-2. Trigger available review bots and iterate on actionable feedback.
-3. Keep page implementation PRs review-ready only; do not merge without human
-   approval.
-4. Preserve the unrelated dirty EmojiContext and bootstrap style files.
+1. Iterate on PR #2641 with available bots/checks without
+   merging.
+2. Keep PR #2641 review-ready only; do not merge.
+3. Keep PR #2640 review-ready only; do not merge.
+4. Maintain PRs #2639, #2638, #2637, and earlier page PRs as review-ready only;
+   do not merge.
+5. Preserve the unrelated dirty EmojiContext, RememeImage test, and bootstrap
+   style files.

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -7,7 +7,7 @@ page migration PRs for safe media surfaces.
 
 ## Current Branch
 
-`codex/the-memes-activity-a11y-i18n`
+`codex/the-memes-timeline-a11y-i18n`
 
 ## Constraints
 
@@ -25,19 +25,19 @@ page migration PRs for safe media surfaces.
 - WCAG target: WCAG 2.2 AA.
 - Source locale: `en-US`.
 - Initial supported locales: `en-US`, `en-GB`, `fr-FR`, `es-ES`, `de-DE`.
-- Current implementation surface: The Memes Card Activity tab, stacked on PR
-  #2613. PR #2613 is bot-happy on latest head `0b79960`, review-ready only, and
-  must not be merged without human approval.
-- Scope includes message-backed activity headings, transaction-type dropdown
-  labels/options, volume labels, loading and empty states, a hidden activity
-  table caption, and locale-aware ETH volume formatting.
-- Shared `LatestActivityRow` transaction copy/date formatting and shared
-  pagination copy remain deferred activity-surface debt.
+- Current implementation surface: shared timeline labels/dates and The Memes
+  Timeline tab, stacked on PR #2614. PR #2614 is bot-happy on latest head
+  `45caff7`, review-ready only, and must not be merged without human approval.
+- Scope includes The Memes timeline region labeling, locale-aware UTC timeline
+  date formatting, message-backed URI/TXN link labels and accessible names, and
+  shared change field labels.
+- Timeline media alt text, iframe titles, raw metadata values, event text, and
+  deeper media semantics remain deferred shared-timeline debt.
 - Full locale-prefixed routing is deferred.
 
 ## Next Actions
 
-1. Open a review-ready PR stacked on PR #2613.
+1. Open a review-ready PR stacked on PR #2614.
 2. Trigger available review bots and iterate on actionable feedback.
 3. Keep page implementation PRs review-ready only; do not merge without human
    approval.

--- a/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
+++ b/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
@@ -2,17 +2,65 @@
 
 Record review-bot and CI decisions here for this workstream.
 
-| Date       | PR    | Bot or Check | Finding                                                                  | Decision                             |
-| ---------- | ----- | ------------ | ------------------------------------------------------------------------ | ------------------------------------ |
-| 2026-06-11 | #2603 | SonarCloud   | Quality Gate passed with 0 new issues                                    | Accept                               |
-| 2026-06-11 | #2603 | Snyk         | No manifest changes detected                                             | Accept                               |
-| 2026-06-11 | #2603 | Claude       | Review skipped because organization monthly code review cap was reached  | Treat as unavailable, not actionable |
-| 2026-06-11 | #2603 | CodeRabbit   | No actionable comments generated                                         | Accept                               |
-| 2026-06-11 | #2603 | Merge        | Branch protection allowed merge after green checks                       | Merged standards PR                  |
-| 2026-06-11 | #2604 | Claude       | Review skipped because organization monthly code review cap was reached  | Treat as unavailable, not actionable |
-| 2026-06-11 | #2604 | SonarCloud   | Flagged i18n default object parameters and interpolation character class | Fixed                                |
-| 2026-06-11 | #2604 | CodeRabbit   | Flagged Suspense, title i18n, locale matching, and exhaustive guards     | Fixed                                |
-| 2026-06-12 | #2607 | SonarCloud   | Quality Gate passed with 0 new issues                                    | Accept                               |
-| 2026-06-12 | #2607 | Snyk         | PR check passed                                                          | Accept                               |
-| 2026-06-12 | #2607 | CodeRabbit   | Flagged dead `MemeTab.title` and duplicate `MEME_FOCUS_VALUES` guards    | Fixed                                |
-| 2026-06-12 | #2607 | CodeRabbit   | Flagged hardcoded detail locale, metadata locale path, and focus docs    | Fixed                                |
+| Date       | PR    | Bot or Check | Finding                                                                   | Decision                             |
+| ---------- | ----- | ------------ | ------------------------------------------------------------------------- | ------------------------------------ |
+| 2026-06-11 | #2603 | SonarCloud   | Quality Gate passed with 0 new issues                                     | Accept                               |
+| 2026-06-11 | #2603 | Snyk         | No manifest changes detected                                              | Accept                               |
+| 2026-06-11 | #2603 | Claude       | Review skipped because organization monthly code review cap was reached   | Treat as unavailable, not actionable |
+| 2026-06-11 | #2603 | CodeRabbit   | No actionable comments generated                                          | Accept                               |
+| 2026-06-11 | #2603 | Merge        | Branch protection allowed merge after green checks                        | Merged standards PR                  |
+| 2026-06-11 | #2604 | Claude       | Review skipped because organization monthly code review cap was reached   | Treat as unavailable, not actionable |
+| 2026-06-11 | #2604 | SonarCloud   | Flagged i18n default object parameters and interpolation character class  | Fixed                                |
+| 2026-06-11 | #2604 | CodeRabbit   | Flagged Suspense, title i18n, locale matching, and exhaustive guards      | Fixed                                |
+| 2026-06-12 | #2607 | SonarCloud   | Quality Gate passed with 0 new issues                                     | Accept                               |
+| 2026-06-12 | #2607 | Snyk         | PR check passed                                                           | Accept                               |
+| 2026-06-12 | #2607 | CodeRabbit   | Flagged dead `MemeTab.title` and duplicate `MEME_FOCUS_VALUES` guards     | Fixed                                |
+| 2026-06-12 | #2607 | CodeRabbit   | Flagged hardcoded detail locale, metadata locale path, and focus docs     | Fixed                                |
+| 2026-06-12 | #2622 | SonarCloud   | Flagged guide `role="region"` and month-cell cognitive complexity         | Fixed                                |
+| 2026-06-12 | #2623 | SonarCloud   | Flagged 10.4% duplication on new code                                     | Fixed                                |
+| 2026-06-12 | #2623 | CodeRabbit   | Suggested consolidating mint formatting and renaming card mint range data | Fixed                                |
+| 2026-06-12 | #2624 | SonarCloud   | Flagged optional chaining, redundant list role, and placeholder img role  | Fixed                                |
+| 2026-06-12 | #2624 | CodeRabbit   | Flagged missing top-level `nft.animation` video fallback                  | Fixed                                |
+| 2026-06-13 | #2625 | CodeRabbit   | Manual review found no issues                                             | Accept                               |
+| 2026-06-13 | #2625 | SonarCloud   | Flagged object literal fallback in Meme Lab test helper                   | Fixed                                |
+| 2026-06-13 | #2625 | SonarCloud   | Quality Gate passed with 0 new issues after follow-up                     | Accept                               |
+| 2026-06-13 | #2625 | Snyk         | PR check passed                                                           | Accept                               |
+| 2026-06-13 | #2626 | CodeRabbit   | Flagged missing explicit list role for Safari/VoiceOver list semantics    | Fixed                                |
+| 2026-06-13 | #2626 | CodeRabbit   | Flagged outdated collected-surface tracker wording                        | Fixed                                |
+| 2026-06-13 | #2626 | SonarCloud   | Flagged explicit list role as redundant after CodeRabbit requested it     | Kept with Safari/VO prop rationale   |
+| 2026-06-13 | #2626 | SonarCloud   | Quality Gate passed with 0 new issues after follow-up                     | Accept                               |
+| 2026-06-13 | #2626 | Snyk         | PR check passed                                                           | Accept                               |
+| 2026-06-13 | #2626 | CodeRabbit   | Latest head passed with all review threads resolved                       | Accept                               |
+| 2026-06-13 | #2627 | SonarCloud   | Quality Gate passed with 0 new issues                                     | Accept                               |
+| 2026-06-13 | #2627 | Snyk         | PR check passed                                                           | Accept                               |
+| 2026-06-13 | #2627 | CodeRabbit   | Latest head passed with no review threads                                 | Accept                               |
+| 2026-06-13 | #2628 | SonarCloud   | Flagged explicit `status` role in favor of native `<output>`              | Fixed                                |
+| 2026-06-13 | #2628 | CodeRabbit   | Flagged repetitive active-context wording                                 | Fixed                                |
+| 2026-06-13 | #2628 | SonarCloud   | Quality Gate passed with 0 new issues after follow-up                     | Accept                               |
+| 2026-06-13 | #2628 | Snyk         | PR check passed                                                           | Accept                               |
+| 2026-06-13 | #2628 | CodeRabbit   | Latest head passed with no review threads                                 | Accept                               |
+| 2026-06-13 | #2629 | SonarCloud   | Quality Gate passed with 0 new issues                                     | Accept                               |
+| 2026-06-13 | #2629 | Snyk         | PR check passed                                                           | Accept                               |
+| 2026-06-13 | #2629 | CodeRabbit   | Latest head passed with no review threads                                 | Accept                               |
+| 2026-06-13 | #2630 | DCO          | Signed commits check passed                                               | Accept                               |
+| 2026-06-13 | #2630 | SonarCloud   | Quality Gate passed with 0 new issues                                     | Accept                               |
+| 2026-06-13 | #2630 | Snyk         | No manifest changes detected                                              | Accept                               |
+| 2026-06-13 | #2630 | CodeRabbit   | Manual review completed with no review threads                            | Accept                               |
+| 2026-06-13 | #2631 | SonarCloud   | Flagged 13.8% duplication on new message dictionary lines                 | Fixed                                |
+| 2026-06-13 | #2631 | DCO          | Signed commits check passed                                               | Accept                               |
+| 2026-06-13 | #2631 | SonarCloud   | Quality Gate passed with 0 new issues and 0.0% duplication after fix      | Accept                               |
+| 2026-06-13 | #2631 | Snyk         | No manifest changes detected                                              | Accept                               |
+| 2026-06-13 | #2631 | CodeRabbit   | Latest head passed with no review threads                                 | Accept                               |
+| 2026-06-13 | #2638 | CodeRabbit   | Flagged Distributions loading text remaining in the accessibility tree    | Fixed                                |
+| 2026-06-13 | #2638 | DCO          | Signed commits check passed                                               | Accept                               |
+| 2026-06-13 | #2638 | SonarCloud   | Quality Gate passed with 0 new issues after follow-up                     | Accept                               |
+| 2026-06-13 | #2638 | Snyk         | No manifest changes detected                                              | Accept                               |
+| 2026-06-13 | #2638 | CodeRabbit   | Latest head passed with the loading-label thread resolved                 | Accept                               |
+| 2026-06-13 | #2639 | DCO          | Signed commits check passed                                               | Accept                               |
+| 2026-06-13 | #2639 | SonarCloud   | Quality Gate passed with 0 new issues                                     | Accept                               |
+| 2026-06-13 | #2639 | Snyk         | No manifest changes detected                                              | Accept                               |
+| 2026-06-13 | #2639 | CodeRabbit   | Latest head passed with no review threads                                 | Accept                               |
+| 2026-06-13 | #2640 | DCO          | Signed commits check passed                                               | Accept                               |
+| 2026-06-13 | #2640 | SonarCloud   | Quality Gate passed with 0 new issues                                     | Accept                               |
+| 2026-06-13 | #2640 | Snyk         | No manifest changes detected                                              | Accept                               |
+| 2026-06-13 | #2640 | CodeRabbit   | Manual review completed with no review threads                            | Accept                               |

--- a/ops/workstreams/frontend-a11y-i18n/pr-links.md
+++ b/ops/workstreams/frontend-a11y-i18n/pr-links.md
@@ -12,3 +12,4 @@
 | Meme Lab distribution | `codex/meme-lab-distribution-a11y-i18n` | #2612 | Open, review-ready only |
 | The Memes live stats  | `codex/the-memes-live-stats-a11y-i18n`  | #2613 | Open, review-ready only |
 | The Memes activity    | `codex/the-memes-activity-a11y-i18n`    | #2614 | Open, review-ready only |
+| The Memes timeline    | `codex/the-memes-timeline-a11y-i18n`    | TBD   | In progress             |

--- a/ops/workstreams/frontend-a11y-i18n/pr-links.md
+++ b/ops/workstreams/frontend-a11y-i18n/pr-links.md
@@ -1,15 +1,40 @@
 # PR Links
 
-| Purpose               | Branch                                  | PR    | Status                  |
-| --------------------- | --------------------------------------- | ----- | ----------------------- |
-| Standards and skills  | `codex/frontend-a11y-i18n-standards`    | #2603 | Merged                  |
-| The Memes list card   | `codex/the-memes-card-a11y-i18n`        | #2604 | Open, review-ready only |
-| The Memes detail tabs | `codex/the-memes-detail-a11y-i18n`      | #2607 | Open, review-ready only |
-| Meme Lab browse cards | `codex/meme-lab-cards-a11y-i18n`        | #2608 | Open, review-ready only |
-| Rememes browse cards  | `codex/rememes-cards-a11y-i18n`         | #2609 | Open, review-ready only |
-| Rememe detail tabs    | `codex/rememe-detail-a11y-i18n`         | #2610 | Open, review-ready only |
-| Meme Lab detail tabs  | `codex/meme-lab-detail-a11y-i18n`       | #2611 | Open, review-ready only |
-| Meme Lab distribution | `codex/meme-lab-distribution-a11y-i18n` | #2612 | Open, review-ready only |
-| The Memes live stats  | `codex/the-memes-live-stats-a11y-i18n`  | #2613 | Open, review-ready only |
-| The Memes activity    | `codex/the-memes-activity-a11y-i18n`    | #2614 | Open, review-ready only |
-| The Memes timeline    | `codex/the-memes-timeline-a11y-i18n`    | #2615 | Open, review-ready only |
+| Purpose                   | Branch                                                  | PR    | Status                  |
+| ------------------------- | ------------------------------------------------------- | ----- | ----------------------- |
+| Standards and skills      | `codex/frontend-a11y-i18n-standards`                    | #2603 | Merged                  |
+| The Memes list card       | `codex/the-memes-card-a11y-i18n`                        | #2604 | Open, review-ready only |
+| The Memes detail tabs     | `codex/the-memes-detail-a11y-i18n`                      | #2607 | Open, review-ready only |
+| Meme Lab browse cards     | `codex/meme-lab-cards-a11y-i18n`                        | #2608 | Open, review-ready only |
+| Rememes browse cards      | `codex/rememes-cards-a11y-i18n`                         | #2609 | Open, review-ready only |
+| Rememe detail tabs        | `codex/rememe-detail-a11y-i18n`                         | #2610 | Open, review-ready only |
+| Meme Lab detail tabs      | `codex/meme-lab-detail-a11y-i18n`                       | #2611 | Open, review-ready only |
+| Meme Lab distribution     | `codex/meme-lab-distribution-a11y-i18n`                 | #2612 | Open, review-ready only |
+| The Memes live stats      | `codex/the-memes-live-stats-a11y-i18n`                  | #2613 | Open, review-ready only |
+| The Memes activity        | `codex/the-memes-activity-a11y-i18n`                    | #2614 | Open, review-ready only |
+| The Memes timeline        | `codex/the-memes-timeline-a11y-i18n`                    | #2615 | Open, review-ready only |
+| Timeline media            | `codex/timeline-media-a11y-i18n`                        | #2616 | Open, review-ready only |
+| The Memes art viewer      | `codex/the-memes-art-viewer-a11y-i18n`                  | #2617 | Open, review-ready only |
+| The Memes art details     | `codex/the-memes-art-details-a11y-i18n`                 | #2618 | Open, review-ready only |
+| The Memes references      | `codex/the-memes-references-a11y-i18n`                  | #2619 | Open, review-ready only |
+| Meme calendar periods     | `codex/meme-calendar-periods-a11y-i18n`                 | #2620 | Open, review-ready only |
+| Meme calendar overview    | `codex/meme-calendar-overview-a11y-i18n`                | #2621 | Open, review-ready only |
+| Meme calendar grid        | `codex/meme-calendar-grid-a11y-i18n`                    | #2622 | Open, review-ready only |
+| Meme calendar drilldowns  | `codex/meme-calendar-drilldown-a11y-i18n`               | #2623 | Open, review-ready only |
+| Rememes browse follow-up  | `codex/rememes-browse-card-followup-a11y-i18n`          | #2624 | Open, review-ready only |
+| Meme Lab browse follow-up | `codex/memelab-browse-card-a11y-i18n-followup`          | #2625 | Open, review-ready only |
+| Profile collected cards   | `codex/user-collected-cards-a11y-i18n`                  | #2626 | Open, review-ready only |
+| Profile network cards     | `codex/user-collected-network-cards-a11y-i18n`          | #2627 | Open, review-ready only |
+| Profile empty states      | `codex/user-collected-empty-states-a11y-i18n`           | #2628 | Open, review-ready only |
+| Profile filter controls   | `codex/user-collected-sort-controls-a11y-i18n`          | #2629 | Open, review-ready only |
+| Profile season strip      | `codex/user-collected-season-strip-a11y-i18n`           | #2630 | Open, review-ready only |
+| Profile stats summary     | `codex/user-collected-stats-summary-a11y-i18n`          | #2631 | Open, review-ready only |
+| Profile details tables    | `codex/user-collected-details-tables-a11y-i18n`         | #2633 | Open, review-ready only |
+| Profile boost breakdown   | `codex/user-collected-boost-breakdown-a11y-i18n`        | #2634 | Open, review-ready only |
+| Profile activity overview | `codex/user-collected-activity-overview-a11y-i18n`      | #2635 | Open, review-ready only |
+| Profile activity tabs     | `codex/user-collected-activity-tabs-a11y-i18n`          | #2636 | Open, review-ready only |
+| Profile wallet activity   | `codex/user-collected-wallet-activity-filter-a11y-i18n` | #2637 | Open, review-ready only |
+| Profile distributions     | `codex/user-collected-distributions-a11y-i18n`          | #2638 | Open, review-ready only |
+| Profile TDH history       | `codex/user-collected-tdh-history-a11y-i18n`            | #2639 | Open, review-ready only |
+| Profile tabs shell        | `codex/user-profile-tabs-a11y-i18n`                     | #2640 | Open, review-ready only |
+| Profile followers modal   | `codex/user-followers-modal-a11y-i18n`                  | #2641 | Open, review-ready only |

--- a/ops/workstreams/frontend-a11y-i18n/pr-links.md
+++ b/ops/workstreams/frontend-a11y-i18n/pr-links.md
@@ -12,4 +12,4 @@
 | Meme Lab distribution | `codex/meme-lab-distribution-a11y-i18n` | #2612 | Open, review-ready only |
 | The Memes live stats  | `codex/the-memes-live-stats-a11y-i18n`  | #2613 | Open, review-ready only |
 | The Memes activity    | `codex/the-memes-activity-a11y-i18n`    | #2614 | Open, review-ready only |
-| The Memes timeline    | `codex/the-memes-timeline-a11y-i18n`    | TBD   | In progress             |
+| The Memes timeline    | `codex/the-memes-timeline-a11y-i18n`    | #2615 | Open, review-ready only |

--- a/ops/workstreams/frontend-a11y-i18n/route-page-status.md
+++ b/ops/workstreams/frontend-a11y-i18n/route-page-status.md
@@ -13,4 +13,4 @@
 | `/the-memes/{id}/distribution`         | PR open              | PR open           | PR #2612; stacked on PR #2611; do not merge yet           |
 | `/the-memes/{id}` live stats           | PR open              | PR open           | PR #2613; stacked on PR #2612; do not merge yet           |
 | `/the-memes/{id}` card activity        | PR open              | PR open           | PR #2614; stacked on PR #2613; do not merge yet           |
-| `/the-memes/{id}` timeline             | In progress          | In progress       | Stacked on PR #2614; do not merge yet                     |
+| `/the-memes/{id}` timeline             | PR open              | PR open           | PR #2615; stacked on PR #2614; do not merge yet           |

--- a/ops/workstreams/frontend-a11y-i18n/route-page-status.md
+++ b/ops/workstreams/frontend-a11y-i18n/route-page-status.md
@@ -1,16 +1,41 @@
 # Route And Page Status
 
-| Surface                                | Accessibility Status | I18n Status       | Notes                                                     |
-| -------------------------------------- | -------------------- | ----------------- | --------------------------------------------------------- |
-| Standards and skills                   | Foundation merged    | Foundation merged | PR #2603 merged                                           |
-| `/the-memes` list cards                | PR open              | PR open           | PR #2604; default route remains `en-US`; do not merge yet |
-| `/the-memes/{id}` tabs and focus links | PR open              | PR open           | PR #2607; stacked on PR #2604; do not merge yet           |
-| Meme Lab browse and collection cards   | PR open              | PR open           | PR #2608; stacked on PR #2607; do not merge yet           |
-| Rememes browse cards                   | PR open              | PR open           | PR #2609; stacked on PR #2608; do not merge yet           |
-| `/rememes/{contract}/{id}` detail      | PR open              | PR open           | PR #2610; stacked on PR #2609; do not merge yet           |
-| `/meme-lab/{id}` detail                | PR open              | PR open           | PR #2611; stacked on PR #2610; do not merge yet           |
-| `/meme-lab/{id}/distribution`          | PR open              | PR open           | PR #2612; stacked on PR #2611; do not merge yet           |
-| `/the-memes/{id}/distribution`         | PR open              | PR open           | PR #2612; stacked on PR #2611; do not merge yet           |
-| `/the-memes/{id}` live stats           | PR open              | PR open           | PR #2613; stacked on PR #2612; do not merge yet           |
-| `/the-memes/{id}` card activity        | PR open              | PR open           | PR #2614; stacked on PR #2613; do not merge yet           |
-| `/the-memes/{id}` timeline             | PR open              | PR open           | PR #2615; stacked on PR #2614; do not merge yet           |
+| Surface                                | Accessibility Status | I18n Status       | Notes                                                              |
+| -------------------------------------- | -------------------- | ----------------- | ------------------------------------------------------------------ |
+| Standards and skills                   | Foundation merged    | Foundation merged | PR #2603 merged                                                    |
+| `/the-memes` list cards                | PR open              | PR open           | PR #2604; default route remains `en-US`; do not merge yet          |
+| `/the-memes/{id}` tabs and focus links | PR open              | PR open           | PR #2607; stacked on PR #2604; do not merge yet                    |
+| Meme Lab browse and collection cards   | PR open              | PR open           | PR #2608; stacked on PR #2607; do not merge yet                    |
+| Rememes browse cards                   | PR open              | PR open           | PR #2609; stacked on PR #2608; do not merge yet                    |
+| `/rememes/{contract}/{id}` detail      | PR open              | PR open           | PR #2610; stacked on PR #2609; do not merge yet                    |
+| `/meme-lab/{id}` detail                | PR open              | PR open           | PR #2611; stacked on PR #2610; do not merge yet                    |
+| `/meme-lab/{id}/distribution`          | PR open              | PR open           | PR #2612; stacked on PR #2611; do not merge yet                    |
+| `/the-memes/{id}/distribution`         | PR open              | PR open           | PR #2612; stacked on PR #2611; do not merge yet                    |
+| `/the-memes/{id}` live stats           | PR open              | PR open           | PR #2613; stacked on PR #2612; do not merge yet                    |
+| `/the-memes/{id}` card activity        | PR open              | PR open           | PR #2614; stacked on PR #2613; do not merge yet                    |
+| `/the-memes/{id}` timeline             | PR open              | PR open           | PR #2615; stacked on PR #2614; do not merge yet                    |
+| Shared Timeline media semantics        | PR open              | PR open           | PR #2616; stacked on PR #2615; do not merge yet                    |
+| `/the-memes/{id}` art viewer actions   | PR open              | PR open           | PR #2617; stacked on PR #2616; do not merge yet                    |
+| `/the-memes/{id}` art details rows     | PR open              | PR open           | PR #2618; review-ready only; stacked on PR #2617; do not merge yet |
+| `/the-memes/{id}` references tab       | PR open              | PR open           | PR #2619; review-ready only; stacked on PR #2618; do not merge yet |
+| `/the-memes/{id}` calendar periods     | PR open              | PR open           | PR #2620; review-ready only; stacked on PR #2619; do not merge yet |
+| `/meme-calendar` overview shell        | PR open              | PR open           | PR #2621; review-ready only; stacked on PR #2620; do not merge yet |
+| `/meme-calendar` lower grid controls   | PR open              | PR open           | PR #2622; review-ready only; stacked on PR #2621; do not merge yet |
+| `/meme-calendar` drilldown cards       | PR open              | PR open           | PR #2623; review-ready only; stacked on PR #2622; do not merge yet |
+| `/rememes` browse-card follow-up       | PR open              | PR open           | PR #2624; review-ready only; stacked on PR #2623; do not merge yet |
+| `/meme-lab` browse-card follow-up      | PR open              | PR open           | PR #2625; review-ready only; stacked on PR #2624; do not merge yet |
+| `/{user}/collected` native card list   | PR open              | PR open           | PR #2626; review-ready only; stacked on PR #2625; do not merge yet |
+| `/{user}/collected` network card list  | PR open              | PR open           | PR #2627; review-ready only; stacked on PR #2626; do not merge yet |
+| `/{user}/collected` empty states       | PR open              | PR open           | PR #2628; review-ready only; stacked on PR #2627; do not merge yet |
+| `/{user}/collected` filter controls    | PR open              | PR open           | PR #2629; review-ready only; stacked on PR #2628; do not merge yet |
+| `/{user}/collected` season strip       | PR open              | PR open           | PR #2630; review-ready only; stacked on PR #2629; do not merge yet |
+| `/{user}/collected` stats summary      | PR open              | PR open           | PR #2631; review-ready only; stacked on PR #2630; do not merge yet |
+| `/{user}/collected` details tables     | PR open              | PR open           | PR #2633; review-ready only; stacked on PR #2631; do not merge yet |
+| `/{user}/collected` boost breakdown    | PR open              | PR open           | PR #2634; review-ready only; stacked on PR #2633; do not merge yet |
+| `/{user}/collected` activity overview  | PR open              | PR open           | PR #2635; review-ready only; stacked on PR #2634; do not merge yet |
+| `/{user}/collected` activity tabs      | PR open              | PR open           | PR #2636; review-ready only; stacked on PR #2635; do not merge yet |
+| `/{user}/collected` wallet activity    | PR open              | PR open           | PR #2637; review-ready only; stacked on PR #2636; do not merge yet |
+| `/{user}/collected` distributions      | PR open              | PR open           | PR #2638; review-ready only; stacked on PR #2637; do not merge yet |
+| `/{user}/collected` TDH history        | PR open              | PR open           | PR #2639; review-ready only; stacked on PR #2638; do not merge yet |
+| User profile tabs shell                | PR open              | PR open           | PR #2640; review-ready only; stacked on PR #2639; do not merge yet |
+| User followers modal/list              | PR open              | PR open           | PR #2641; review-ready only; stacked on PR #2640; do not merge yet |

--- a/ops/workstreams/frontend-a11y-i18n/route-page-status.md
+++ b/ops/workstreams/frontend-a11y-i18n/route-page-status.md
@@ -13,3 +13,4 @@
 | `/the-memes/{id}/distribution`         | PR open              | PR open           | PR #2612; stacked on PR #2611; do not merge yet           |
 | `/the-memes/{id}` live stats           | PR open              | PR open           | PR #2613; stacked on PR #2612; do not merge yet           |
 | `/the-memes/{id}` card activity        | PR open              | PR open           | PR #2614; stacked on PR #2613; do not merge yet           |
+| `/the-memes/{id}` timeline             | In progress          | In progress       | Stacked on PR #2614; do not merge yet                     |

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -334,3 +334,5 @@
   selected Timeline tabs, locale-backed region labels, German UTC date
   formatting, URI/TXN accessible link labels, no horizontal overflow, no
   unexpected HTTP failures, and no Next.js runtime session errors.
+- Opened review-ready stacked PR #2615 against PR #2614. Per workstream policy,
+  do not merge PR #2615 without human approval.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -345,3 +345,729 @@
   focused Prettier, `lint:changed`, `typecheck:changed`, and
   `react-doctor:diff`. React Doctor exited 0 at 99/100 with only the unrelated
   dirty EmojiContext fetch-in-effect diagnostic.
+- Confirmed PR #2615 is bot-happy on latest head `bd8ba44`: CodeRabbit passed
+  with its prior thread marked resolved/outdated, SonarCloud passed, DCO
+  passed, Snyk passed, and Claude remained skipped by the organization monthly
+  code review spending cap. Per workstream policy, do not merge PR #2615
+  without human approval.
+- Started stacked branch `codex/timeline-media-a11y-i18n` from PR #2615 for the
+  next shared Timeline media semantics slice.
+- Implemented the shared Timeline media accessibility and i18n pass: Timeline
+  media previews now receive the active locale and localized change label,
+  images use message-backed alt text through `next/image`, videos use translated
+  accessible labels, and HTML timeline embeds use translated iframe titles.
+- Validation passed for the Timeline media slice: targeted shared Timeline,
+  Timeline media, The Memes Timeline, and i18n Jest suites (4 suites, 15 tests),
+  focused Prettier, `lint:changed`, `typecheck:changed`, and
+  `react-doctor:diff`. React Doctor exited 0 at 99/100 with only the unrelated
+  dirty EmojiContext fetch-in-effect diagnostic.
+- Browser smoke passed on the live local frontend for
+  `/meme-lab/1?focus=timeline&locale=de-DE` at desktop and a 390px mobile
+  viewport. Verified the Meme Lab timeline region, German UTC timeline dates,
+  timeline image alt text (`From preview image`, `To preview image`), no
+  horizontal overflow, and no Next.js runtime session errors. Shared local
+  API/resource requests still log unrelated browser console failures.
+- Opened review-ready stacked PR #2616 against PR #2615. Per workstream policy,
+  do not merge PR #2616 without human approval.
+- Confirmed PR #2616 is bot-happy on latest head `d1d146d`: CodeRabbit passed
+  with no review threads, SonarCloud passed, DCO passed, Snyk passed, and
+  Claude remained skipped by the organization monthly code review spending cap.
+  Per workstream policy, do not merge PR #2616 without human approval.
+- Started stacked branch `codex/the-memes-art-viewer-a11y-i18n` from PR #2616
+  for the next The Memes Art Viewer action-label slice.
+- Implemented the initial The Memes Art Viewer accessibility and i18n pass:
+  active detail-page locale now reaches the header Art Viewer, shared media
+  action toolbars accept optional localized labels with English defaults, and
+  the Art Viewer routes fullscreen/open/download/downloading/close controls,
+  previous/next media buttons, and save dialog titles through source messages.
+- Validation passed for the Art Viewer slice: targeted The Memes Art Viewer,
+  The Memes page, and i18n Jest suites (3 suites, 37 tests), focused Prettier,
+  `lint:changed`, `typecheck:changed`, and `react-doctor:diff`. React Doctor
+  exited 0 at 95/100 with only the unrelated dirty EmojiContext diagnostic and
+  existing `MemePage` size/state/useSearchParams warnings.
+- Browser smoke passed on the live local frontend for
+  `/the-memes/1?focus=the-art&locale=de-DE` at desktop and a 390px responsive
+  viewport. Verified Art media action accessible names, no horizontal overflow,
+  and no Next.js runtime session errors. A strict mobile-user-agent smoke only
+  rendered the compact route shell in this local setup, so target Art controls
+  were verified with the 390px viewport instead.
+- Opened review-ready stacked PR #2617 against PR #2616. Per workstream policy,
+  do not merge PR #2617 without human approval.
+- Confirmed PR #2617 is bot-happy on latest head `5987023`: CodeRabbit passed
+  with no actionable comments or review threads, DCO passed, SonarCloud passed,
+  Snyk passed, and Claude remained skipped by the organization monthly code
+  review spending cap. Per workstream policy, do not merge PR #2617 without
+  human approval.
+- Started stacked branch `codex/the-memes-art-details-a11y-i18n` from PR #2617
+  for the next The Memes Art details row/link-label slice.
+- Implemented the initial The Memes Art details accessibility and i18n pass:
+  the active detail-page locale now reaches the Art details component; section
+  headings, metric labels, empty states, Arweave open labels, visible open text,
+  and download progress/completion labels use source messages; and TDH/rank
+  values use locale-aware number formatting. Property trait names/values, media
+  URLs, and raw NFT metadata remain source-data copy.
+- While validating the Art details slice, tightened the shared text-style
+  `Download` action and Art Arweave `Open` links to 24px minimum target height,
+  and replaced Download's clickable status icons with semantic icon buttons.
+- Validation passed for the Art details slice: targeted Download, The Memes Art
+  details, The Memes live submenu, and i18n Jest suites (4 suites, 31 tests),
+  focused Prettier, `lint:changed`, `typecheck:changed`, and
+  `react-doctor:diff`. React Doctor exited 0 at 99/100 with only the unrelated
+  dirty `contexts/EmojiContext.tsx` fetch-in-effect diagnostic.
+- Browser smoke passed on the live local frontend for
+  `/the-memes/1?focus=the-art&locale=de-DE` at desktop and a 390px responsive
+  viewport. Verified additional details are expanded for the `the-art` focus
+  key, Art details section headings and Arweave open/download accessible names,
+  German number formatting in details, 24px row action targets, no horizontal
+  overflow, no page errors in the mobile smoke, and no Next.js runtime session
+  errors. Shared local API/resource requests still log unrelated browser console
+  failures in the desktop session.
+- Opened review-ready stacked PR #2618 against PR #2617. Per workstream policy,
+  do not merge PR #2618 without human approval.
+- Addressed CodeRabbit feedback on PR #2618 by marking the route-status row as
+  review-ready only and matching the download-progress fallback test to the
+  formatted string passed by production code.
+- Validation for the PR #2618 bot-feedback follow-up passed: focused i18n Jest
+  suite, focused Prettier, `lint:changed`, and `typecheck:changed`.
+- Started stacked branch `codex/the-memes-references-a11y-i18n` from PR #2618
+  for the next The Memes References tab accessibility and i18n slice.
+- Implemented the initial References tab pass: the active detail-page locale now
+  reaches the References tab; Meme Lab/ReMemes descriptions, logo alt text, sort
+  trigger/options, refresh labels, ReMeme empty state, ReMeme card accessible
+  names, locale-preserving ReMeme links, and replica counts use progressive
+  messages/formatters; and the refresh icon is now a semantic button with an
+  accessible name.
+- While validating the References slice, grouped the References tab's related
+  Meme Lab and ReMeme fetch/result state into reducers to remove the
+  component-specific React Doctor state warnings.
+- Validation passed for the References slice: targeted The Memes live submenu
+  and i18n Jest suites (2 suites, 19 tests), `lint:changed`,
+  `typecheck:changed`, and `react-doctor:diff`. React Doctor exited 0 at 95/100
+  with only the unrelated dirty `contexts/EmojiContext.tsx` fetch-in-effect
+  diagnostic and pre-existing broad `MemePage` warnings.
+- Browser smoke passed on the live local frontend for
+  `/the-memes/1?focus=references&locale=de-DE` at desktop and a 390px mobile
+  viewport. Verified selected References tab state, Meme Lab/ReMemes logo alt
+  text and descriptions, refresh button accessible name and 24px minimum target,
+  locale-preserving ReMeme links, no horizontal overflow, no mobile page errors,
+  and no Next.js runtime session errors.
+- Opened review-ready stacked PR #2619 against PR #2618. Per workstream policy,
+  do not merge PR #2619 without human approval.
+- Addressed CodeRabbit feedback on PR #2619 by aligning the Meme Lab reducer
+  with the action-object pattern used by the ReMeme reducer.
+- Validation for the PR #2619 bot-feedback follow-up passed: targeted The Memes
+  live submenu and i18n Jest suites (2 suites, 19 tests), `lint:changed`,
+  `typecheck:changed`, and `react-doctor:diff`. React Doctor exited 0 at
+  98/100 with the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic and the pre-existing long References component
+  warning.
+- Confirmed PR #2619 is bot-happy on latest head: CodeRabbit passed, DCO
+  passed, SonarCloud passed, and Snyk passed. Per workstream policy, do not
+  merge PR #2619 without human approval.
+- Started stacked branch `codex/meme-calendar-periods-a11y-i18n` from PR #2619
+  for the next The Memes header calendar period strip accessibility and i18n
+  slice.
+- Implemented the initial calendar period strip pass: the active detail-page
+  locale now reaches `MemeCalendarPeriods`; season/period labels and accessible
+  names use source messages; period numbers use locale-aware formatting; season
+  links preserve non-default locales; the secondary period cluster is a
+  labelled group; and the season link has visible focus plus a 24px minimum
+  target.
+- Validation passed for the calendar period strip slice: targeted The Memes
+  page and i18n Jest suites (2 suites, 24 tests), `lint:changed`, and
+  `typecheck:changed`. React Doctor exited 0 at 95/100 with the unrelated dirty
+  `contexts/EmojiContext.tsx` fetch-in-effect diagnostic and pre-existing broad
+  `MemePage` warnings from the stacked diff.
+- Browser smoke passed on the live local frontend for
+  `/the-memes/1?locale=de-DE` at desktop and a 390px mobile viewport. Verified
+  locale-preserving season link href, labelled period group, 24px season-link
+  target, no horizontal overflow, no mobile page errors, and no Next.js runtime
+  session errors.
+- Opened review-ready stacked PR #2620 against PR #2619. Per workstream policy,
+  do not merge PR #2620 without human approval.
+- Confirmed PR #2620 is bot-happy on latest head: CodeRabbit passed with no
+  actionable comments, DCO passed, SonarCloud passed, Snyk passed, and Claude
+  remained skipped by the organization monthly code review spending cap. Per
+  workstream policy, do not merge PR #2620 without human approval.
+- Started stacked branch `codex/meme-calendar-overview-a11y-i18n` from PR
+  #2620 for the next `/meme-calendar` overview shell accessibility and i18n
+  slice.
+- Implemented the initial Meme Calendar overview pass: `/meme-calendar` reads
+  the optional `locale` query, the timezone toggle exposes pressed state and
+  message-backed accessible names, the overview heading/full-calendar link,
+  next-mint controls/headings/countdown labels, screenshot label,
+  upcoming-card heading/empty state, mint numbers, and calendar invite link
+  accessible names use progressive messages/formatters. The lower custom
+  calendar grid remains deferred.
+- Added semantic, screen-reader-only headers to the upcoming-mints overview
+  table so the touched table surface exposes column meaning without changing
+  the visual layout.
+- Validation passed for the Meme Calendar overview shell slice: targeted
+  calendar and i18n Jest suites (4 suites, 23 tests), `lint:changed`,
+  `typecheck:changed`, and `react-doctor:diff` exit 0. React Doctor still
+  reports the unrelated dirty `contexts/EmojiContext.tsx` fetch-in-effect
+  diagnostic.
+- Browser smoke passed on the live local frontend for
+  `/meme-calendar?locale=de-DE` at desktop and
+  `/meme-calendar?locale=fr-FR` at a 390px mobile viewport. Verified timezone
+  pressed state, semantic table headers, calendar invite accessible names,
+  labelled Meme # input, no horizontal overflow, no mobile page errors, and no
+  Next.js runtime session errors. Local console resource errors were from the
+  shared backend/emoji feed.
+- Opened review-ready stacked PR #2621 against PR #2620. Per workstream policy,
+  do not merge PR #2621 without human approval.
+- Addressed SonarCloud issue `typescript:S6819` on PR #2621 by replacing the
+  timezone toggle's generic `role="group"` wrapper with native
+  `fieldset`/`legend` semantics. Re-ran targeted calendar/i18n tests,
+  `lint:changed`, `typecheck:changed`, `react-doctor:diff`, and a live browser
+  smoke on `/meme-calendar?locale=de-DE`; all passed except the unchanged
+  unrelated React Doctor diagnostic in `contexts/EmojiContext.tsx`.
+- Addressed CodeRabbit's defensive `printCalendarInvites` note by escaping the
+  generated `fontColor` style attribute and adding regression coverage for
+  quote/apostrophe/color escaping. Re-ran targeted calendar/i18n tests,
+  `lint:changed`, `typecheck:changed`, `react-doctor:diff`, and a live browser
+  smoke on `/meme-calendar?locale=de-DE`.
+- Confirmed PR #2621 is bot-happy on latest head: CodeRabbit completed with no
+  actionable comments, DCO passed, SonarCloud passed with 0 new issues, and
+  Snyk passed. Claude did not produce a code review after `@claude review once`
+  and left the repository-configured manual review instruction comment only.
+  Per workstream policy, do not merge PR #2621 without human approval.
+- Started stacked branch `codex/meme-calendar-grid-a11y-i18n` from PR #2621 for
+  the next `/meme-calendar` lower grid/control accessibility and i18n slice.
+- Implemented the first lower custom calendar pass: lower zoom controls now use
+  native `fieldset`/`legend` semantics and message-backed pressed-state
+  buttons; the guide toggle is a named icon button controlling a labelled
+  region; previous/next controls have accessible names; jump controls use real
+  labels; default SZN month names, mint-day accessible names, mint numbers,
+  ranges, and calendar invite event text use locale-aware helpers.
+- Validation passed for the lower grid/control slice: focused calendar/i18n
+  Jest suites (5 suites, 27 tests), `lint:changed`, `typecheck:changed`, and
+  `react-doctor:diff` exit 0. React Doctor still reports the unrelated dirty
+  `contexts/EmojiContext.tsx` fetch-in-effect diagnostic plus broad
+  `MemeCalendar` component-size/state/renderView warnings left as follow-up
+  refactor debt.
+- Browser smoke passed on the live local frontend for
+  `/meme-calendar?locale=de-DE` at desktop and
+  `/meme-calendar?locale=fr-FR` at a 390px mobile viewport. Verified guide
+  toggle state, labelled region, named previous/next controls, labelled
+  `Meme #` input, hidden mobile `Date` input, localized month/mint-day labels,
+  no horizontal overflow, and no Next.js runtime session errors. Local console
+  resource errors were from the shared backend/emoji feed.
+- Opened review-ready stacked PR #2622 against PR #2621. Per workstream policy,
+  do not merge PR #2622 without human approval.
+- Addressed SonarCloud feedback on PR #2622 by replacing the guide panel's
+  generic `role="region"` with a native labelled `section` and extracting the
+  lower-calendar month cell metadata/tooltip rendering from the inline map to
+  reduce cognitive complexity. Re-ran the focused calendar/i18n Jest suites,
+  `lint:changed`, `typecheck:changed`, `react-doctor:diff`, and a live browser
+  smoke on `/meme-calendar?locale=de-DE`.
+- Started stacked branch `codex/meme-calendar-drilldown-a11y-i18n` from PR
+  #2622 for the next `/meme-calendar` lower drilldown card accessibility and
+  i18n slice.
+- Implemented the lower drilldown card pass: `Year`, `Epoch`, `Period`, `Era`,
+  and `Eon` views now receive the active locale; card titles, date ranges, mint
+  ranges, and accessible button names are routed through message/format helpers;
+  drilldown cards also expose consistent focus-visible styling.
+- Validation passed for the lower drilldown card slice: focused calendar/i18n
+  Jest suites (5 suites, 28 tests), `lint:changed`, `typecheck:changed`, and
+  `react-doctor:diff` exit 0. React Doctor still reports the unrelated dirty
+  `contexts/EmojiContext.tsx` fetch-in-effect diagnostic plus the existing
+  broad `MemeCalendar` component-size/state/renderView warnings.
+- Browser smoke passed on the live local frontend for
+  `/meme-calendar?locale=de-DE` at desktop and
+  `/meme-calendar?locale=fr-FR` at a 390px mobile viewport. Verified
+  drilldown card accessible names, localized month labels, ungrouped calendar
+  years, hidden mobile `Date` input, no horizontal overflow, and no Next.js
+  runtime session errors. Local console resource errors were from the shared
+  backend waves endpoints and blocked emoji feed.
+- Opened review-ready stacked PR #2623 against PR #2622. Per workstream policy,
+  do not merge PR #2623 without human approval.
+- Addressed SonarCloud's new-code duplication gate on PR #2623 by extracting
+  the repeated lower-calendar drilldown button markup into a shared
+  `DrilldownCard` component and the repeated SZN1 launch-period branch into
+  `HistoricalLaunchDrilldownCard`. Re-ran the focused calendar/i18n Jest
+  suites, `lint:changed`, `typecheck:changed`, `react-doctor:diff`, and
+  desktop/mobile browser smoke on `/meme-calendar`; all remained green apart
+  from the known React Doctor follow-up diagnostics.
+- Addressed CodeRabbit's non-blocking cleanup notes on PR #2623 by
+  consolidating mint-range number formatting on `formatInteger` and renaming
+  drilldown card data from `label` to `mints`. Re-ran the focused
+  calendar/i18n Jest suites, `lint:changed`, `typecheck:changed`, and
+  `react-doctor:diff`; results remained green apart from the known React Doctor
+  follow-up diagnostics.
+- Confirmed PR #2623 is bot-happy on the latest head: Snyk passed, CodeRabbit
+  passed with no open review threads, and SonarCloud had already reported 0 new
+  issues and 0.0% duplication. Claude remained configured for manual review and
+  did not leave an actionable review. Per workstream policy, do not merge PR
+  #2623 without human approval.
+- Started stacked branch `codex/rememes-browse-card-followup-a11y-i18n` from
+  PR #2623 for a small `/rememes` browse-card follow-up.
+- Implemented the Rememes browse follow-up: card results now render as a
+  labelled list/listitem structure, the list label is message-backed, the Add
+  ReMeme header action preserves non-default `locale` query values via the
+  existing locale-aware href helper, and missing Rememe image fallbacks render a
+  named placeholder instead of handing `src=""` to `next/image`.
+- Focused validation passed for the Rememes browse follow-up:
+  `pnpm run test -- --runTestsByPath __tests__/components/rememes/Rememes.test.tsx __tests__/components/rememes/rememesRouteParams.test.ts __tests__/components/nft-image/RememeImage.test.tsx __tests__/i18n/messages.test.ts --coverage=false --runInBand --silent --verbose=false`
+  with `SEIZE_6529_COMMAND=1` (4 suites, 17 tests), `lint:changed`,
+  `typecheck:changed`, and `react-doctor:diff` exit 0. React Doctor still
+  reports the unrelated dirty `contexts/EmojiContext.tsx` fetch-in-effect
+  diagnostic plus pre-existing broad `Rememes` component-size/state warnings.
+  Direct `6529` wrapper invocation remains blocked in this shell by the local
+  Windows/WSL wrapper path/line-ending handoff, so the guarded script path was
+  used.
+- Browser smoke passed on the live local frontend for
+  `/rememes?locale=de-DE` at desktop and `/rememes?locale=fr-FR` at a 390px
+  mobile viewport. Verified labelled results list, 40 list items, Add ReMeme
+  locale-preserving href, no horizontal overflow, and no Next.js runtime
+  session errors. Remaining browser console errors were shared backend waves,
+  blocked emoji feed, or third-party media resource loads.
+- Opened review-ready stacked PR #2624 against PR #2623. Per workstream policy,
+  do not merge PR #2624 without human approval.
+- Addressed SonarCloud's PR #2624 issues by simplifying optional chaining,
+  removing the redundant explicit list role, and replacing the missing-image
+  placeholder `role="img"` with a real `next/image` placeholder carrying `alt`.
+  Re-ran the focused Rememes/image/i18n Jest suites, `lint:changed`,
+  `typecheck:changed`, `react-doctor:diff`, and a live browser smoke on
+  `/rememes?locale=de-DE`; results remained green apart from the known React
+  Doctor follow-up diagnostics.
+- Addressed CodeRabbit's PR #2624 video fallback finding by including the
+  top-level `nft.animation` URL in Rememe video fallback candidates and adding
+  regression coverage for top-level animation with empty metadata animation.
+  Re-ran the focused Rememes/image/i18n Jest suites (4 suites, 18 tests),
+  `lint:changed`, `typecheck:changed`, and `react-doctor:diff`; results
+  remained green apart from the unrelated dirty EmojiContext React Doctor
+  diagnostic.
+- Started stacked branch `codex/memelab-browse-card-a11y-i18n-followup` from
+  PR #2624 for a small Meme Lab browse/collection card follow-up.
+- Implemented labelled list/listitem semantics for Meme Lab ungrouped,
+  artist-grouped, collection-grouped, and collection-route card grids. Added
+  message-backed list labels, locale-preserving grouped collection `view`
+  links, and regression coverage for grouped list labels, list items, collection
+  href preservation, collection-route card href preservation, and fallback
+  messages.
+- Validation passed for the Meme Lab browse follow-up: focused Meme Lab,
+  Rememe image, and i18n Jest suites (4 suites, 15 tests), focused Prettier
+  check, `lint:changed`, `typecheck:changed`, and `react-doctor:diff`.
+  React Doctor still reports the unrelated dirty EmojiContext diagnostic plus
+  existing Meme Lab state/refactor warnings.
+- Browser smoke passed on the live local frontend for
+  `/meme-lab?sort=collections&locale=de-DE` at desktop and
+  `/meme-lab/collection/6529-Intern-JPGs?locale=fr-FR` at a 390px mobile
+  viewport. Verified labelled card lists, locale-preserving collection/card
+  links, no horizontal overflow, and no Next.js runtime session errors.
+- Opened review-ready stacked PR #2625 against PR #2624. Per workstream policy,
+  do not merge PR #2625 without human approval.
+- Addressed SonarCloud's PR #2625 test-helper issue by hoisting the default
+  Meme Lab props object into a stable module constant. Re-ran the focused Meme
+  Lab card-grid test, Prettier check, `lint:changed`, and
+  `typecheck:changed`; results remained green.
+- Confirmed PR #2625 is bot-happy on the latest head: Snyk passed,
+  CodeRabbit passed with no open review threads, and SonarCloud reported 0 new
+  issues. Claude remained configured for manual review and did not leave an
+  actionable review. Per workstream policy, do not merge PR #2625 without human
+  approval.
+- Started stacked branch `codex/user-collected-cards-a11y-i18n` from PR #2625
+  for a low-risk `/{user}/collected` native card list follow-up.
+- Implemented labelled list/listitem semantics for profile native collected
+  card results. Added source message key `user.collected.cards.listLabel`,
+  fallback coverage, component assertions for list semantics and empty-state
+  behavior, and Collected-tab feature docs.
+- Validation passed for the profile collected card list follow-up: focused
+  collected-card/i18n Jest suites (2 suites, 6 tests), focused Prettier check,
+  `lint:changed`, `typecheck:changed`, and `react-doctor:diff`. React Doctor
+  still reports only the unrelated dirty EmojiContext diagnostic.
+- Browser smoke passed on the live local frontend for `/punk6529/collected` at
+  desktop and a 390px mobile viewport. Verified one labelled `Collected cards`
+  list, 24 direct list items, no horizontal overflow, and no Next.js runtime
+  session errors. Console resource errors were shared backend/resource noise.
+- Opened review-ready stacked PR #2626 against PR #2625. Per workstream policy,
+  do not merge PR #2626 without human approval.
+- Addressed CodeRabbit's PR #2626 Safari/VoiceOver list-semantics finding by
+  adding an explicit `role="list"` to the collected cards `ul` and hoisting the
+  static list label. Re-ran the focused collected-card/i18n Jest suites,
+  Prettier check, `lint:changed`, and `typecheck:changed`; results remained
+  green.
+- Addressed CodeRabbit's PR #2626 tracker wording finding by updating the
+  outdated collected-surface status to collected card list wording.
+- Addressed the PR #2626 SonarCloud/CodeRabbit role conflict by keeping the
+  explicit `list` role for Safari/VoiceOver compatibility behind a small
+  compatibility prop object with a local rationale.
+- Confirmed PR #2626 is bot-happy on the latest head: Snyk passed, CodeRabbit
+  passed with all review threads resolved, and SonarCloud reported 0 new
+  issues. Claude remains configured for manual review and did not leave an
+  actionable review. Per workstream policy, do not merge PR #2626 without human
+  approval.
+- Started stacked branch `codex/user-collected-network-cards-a11y-i18n` from
+  PR #2626 for a low-risk `/{user}/collected` network card-list follow-up.
+- Implemented labelled list/listitem semantics for profile network collected
+  card results. Added source message keys for the list label, empty state,
+  fallback token/collection names, image alt text, token number label, and xTDH
+  labels, plus focused component and fallback-message coverage.
+- Validation passed for the profile collected network-card follow-up: focused
+  network-card/i18n Jest suites (2 suites, 5 tests), focused Prettier check,
+  `lint:changed`, `typecheck:changed`, and `react-doctor:diff`. React Doctor
+  still reports only the unrelated dirty EmojiContext diagnostic.
+- Browser smoke passed on the live local frontend for
+  `/punk6529/collected?collection=network`. The local seed data returns the
+  network empty state, so non-empty list semantics are covered by component
+  tests. Verified localized `No network tokens found` copy, no horizontal
+  overflow, and no Next.js runtime session errors. Console errors were shared
+  backend wave endpoints and blocked emoji feed noise.
+- Opened review-ready stacked PR #2627 against PR #2626. Per workstream policy,
+  do not merge PR #2627 without human approval.
+- Confirmed PR #2627 is bot-happy on the latest head: DCO passed, Snyk passed,
+  CodeRabbit passed with no review threads, and SonarCloud reported 0 new
+  issues. Claude remains configured for manual review and did not leave an
+  actionable review. Per workstream policy, do not merge PR #2627 without human
+  approval.
+- Started stacked branch `codex/user-collected-empty-states-a11y-i18n` from
+  PR #2627 for a low-risk `/{user}/collected` empty-state follow-up.
+- Implemented message-backed native collected empty-state copy and native
+  `<output>` status semantics while preserving existing filter and full-set
+  behavior. Reused the network empty-state message from PR #2627.
+- Validation passed for the empty-state follow-up: focused collected empty-state
+  and i18n Jest suites (2 suites, 8 tests), focused Prettier check,
+  `lint:changed`, `typecheck:changed`, and `react-doctor:diff`. React Doctor
+  still reports only the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic.
+- Browser smoke passed on the live local frontend for
+  `/punk6529/collected?collection=memes&seized=seized`. Local seed data returned
+  the non-empty collected list rather than the empty-state branch, so the status
+  region is covered by component tests. Verified no horizontal overflow and no
+  Next.js runtime session errors. Console errors were shared backend wave
+  endpoints and blocked emoji feed noise.
+- Opened review-ready stacked PR #2628 against PR #2627. Per workstream policy,
+  do not merge PR #2628 without human approval.
+- Addressed SonarCloud's PR #2628 native-status finding by replacing explicit
+  `role="status"` with `<output>`, then addressed CodeRabbit's active-context
+  wording nit. Re-ran focused empty-state/i18n tests, focused Prettier check,
+  `lint:changed`, `typecheck:changed`, `react-doctor:diff`, and
+  `git diff --check`; results remained green apart from the known unrelated
+  EmojiContext React Doctor diagnostic.
+- Confirmed PR #2628 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed with 0 new issues, CodeRabbit passed with no review threads,
+  and Claude remained configured for manual review only. Per workstream policy,
+  do not merge PR #2628 without human approval.
+- Started stacked branch `codex/user-collected-sort-controls-a11y-i18n` from
+  PR #2628 for a low-risk `/{user}/collected` filter-control follow-up.
+- Implemented message-backed collected filter labels for View, Native/Network,
+  Collection, All/All Collections, Unknown Collection, Sort By, collection sort
+  options, Seized filter options, and horizontal filter-scroll buttons. Removed
+  derived sort-item state in favor of memoized source-label items and made the
+  touched filter-strip scroll listener passive.
+- Focused validation passed for the filter-control follow-up: collected filter
+  and i18n Jest suites (6 suites, 17 tests), focused Prettier check,
+  `lint:changed`, `typecheck:changed`, and `react-doctor:diff`. React Doctor
+  still reports only the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic.
+- Browser smoke passed on the live local frontend for `/punk6529/collected` at
+  desktop and a 390px mobile viewport. Verified source-message filter labels,
+  filter accessible names, no horizontal overflow, no page errors, and no
+  Next.js runtime session errors. Console errors were shared backend wave
+  endpoints and blocked emoji feed noise.
+- Opened review-ready stacked PR #2629 against PR #2628. Per workstream policy,
+  do not merge PR #2629 without human approval.
+- Confirmed PR #2629 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed with 0 new issues, CodeRabbit passed with no review threads,
+  and Claude remained configured for manual review only. Per workstream policy,
+  do not merge PR #2629 without human approval.
+- Started stacked branch `codex/user-collected-season-strip-a11y-i18n` from PR
+  #2629 for a low-risk `/{user}/collected` season-strip follow-up.
+- Implemented message-backed source-locale labels for the collected season
+  strip: `Seasons`, started count, desktop show more/less controls, unseized
+  label, and season tile set-count plural labels. Extracted the tile renderer
+  into a stable `SeasonTiles` component to avoid React Doctor render-helper
+  warnings.
+- Validation passed for the season-strip follow-up: focused season/i18n Jest
+  suites (3 suites, 26 tests), focused Prettier check, `lint:changed`,
+  `typecheck:changed`, and `react-doctor:diff`. React Doctor still reports only
+  the unrelated dirty `contexts/EmojiContext.tsx` fetch-in-effect diagnostic.
+- Browser smoke passed on the live local frontend for `/punk6529/collected` at
+  desktop and a 390px mobile viewport. Verified message-backed season heading
+  and started count, button season tiles, no page errors, and no Next.js
+  runtime session errors. Mobile horizontal overflow came from existing
+  scrollable strips, including the season carousel. Console resource errors
+  were shared backend wave endpoints and blocked emoji feed noise.
+- Opened review-ready stacked PR #2630 against PR #2629. Per workstream policy,
+  do not merge PR #2630 without human approval.
+- Confirmed PR #2630 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed with 0 new issues, CodeRabbit manual review passed with no
+  review threads, and Claude remained configured for manual review only. Per
+  workstream policy, do not merge PR #2630 without human approval.
+- Started stacked branch `codex/user-collected-stats-summary-a11y-i18n` from
+  PR #2630 for a low-risk `/{user}/collected` stats-summary follow-up.
+- Implemented message-backed source-locale copy for collected header metric
+  labels, multiplier values, unique-count copy, the `Details`/`Hide Details`
+  toggle, the stats-unavailable message, and remaining season tile label/detail
+  copy. Marked the Details icon decorative for assistive technologies.
+- Validation passed for the stats-summary follow-up: focused stats/season/i18n
+  Jest suites (3 suites, 27 tests), focused Prettier write/check during the
+  edit loop, `lint:changed`, `typecheck:changed`, and `react-doctor:diff`.
+  React Doctor still reports only the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic.
+- Browser smoke passed on the live local frontend for `/punk6529/collected` at
+  desktop and a 390px mobile viewport. Verified source-message metric labels,
+  season tile detail text, Details/Hide Details toggle text, `aria-expanded`
+  state changes, no page errors, and no Next.js runtime session errors. Mobile
+  horizontal overflow came from existing scrollable strips. Console resource
+  errors were shared backend wave endpoints and blocked emoji feed noise.
+- Opened review-ready stacked PR #2631 against PR #2630. Per workstream policy,
+  do not merge PR #2631 without human approval.
+- Addressed SonarCloud's PR #2631 new-code duplication gate by moving the
+  collected stats message keys into a typed `namespaceMessages` block while
+  preserving the same public message keys. Re-ran focused stats/season/i18n
+  Jest suites, `lint:changed`, `typecheck:changed`, and `react-doctor:diff`;
+  results remained green apart from the known unrelated EmojiContext diagnostic.
+- Confirmed PR #2631 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed with 0 new issues and 0.0% duplication, CodeRabbit manual
+  review passed with no review threads, and Claude remained configured for
+  manual review only. Per workstream policy, do not merge PR #2631 without
+  human approval.
+- Started stacked branch `codex/user-collected-details-tables-a11y-i18n` from
+  PR #2631 for the next low-risk `/{user}/collected` Details-panel follow-up.
+- Implemented message-backed source-locale labels for the expanded collected
+  details tables, added screen-reader table captions, promoted touched row
+  labels to table row headers, added column scopes, and moved touched collected
+  table counts/percent copy through the repo i18n formatting helpers. Hid the
+  visual separator rows from assistive technologies.
+- Validation passed for the details-table follow-up: focused collected
+  stats/shared-table/i18n Jest suites (3 suites, 6 tests), focused Prettier
+  write/check during the edit loop, `lint:changed`, `typecheck:changed`,
+  `react-doctor:diff`, and `git diff --check`. React Doctor still reports only
+  the unrelated dirty `contexts/EmojiContext.tsx` fetch-in-effect diagnostic.
+- Browser smoke passed on the live local frontend for `/punk6529/collected` at
+  desktop and 390px mobile viewport. Verified `Details` opens, collected table
+  captions, scoped column headers, row headers, hidden separator rows, no
+  desktop or mobile page overflow, and no Next.js runtime session errors.
+  Console resource errors were shared backend wave endpoints and blocked emoji
+  feed noise.
+- Opened review-ready stacked PR #2633 against PR #2631. Per workstream policy,
+  do not merge PR #2633 without human approval.
+- Addressed SonarCloud's PR #2633 new-code duplication gate by refactoring the
+  collected details table headers/rows into mapped column definitions and
+  small reusable cells while preserving the rendered table semantics. Re-ran
+  focused collected stats/shared-table/i18n Jest suites, `lint:changed`,
+  `typecheck:changed`, `react-doctor:diff`, `git diff --check`, and a live
+  browser DOM smoke; results remained green apart from the known unrelated
+  EmojiContext diagnostic and shared backend/emoji console noise.
+- Narrowed the remaining PR #2633 SonarCloud duplication finding to the new
+  source-locale message entries and moved the collected details message group
+  to an object-backed helper while preserving all public message keys. Re-ran
+  focused collected stats/shared-table/i18n Jest suites, `lint:changed`,
+  `typecheck:changed`, `react-doctor:diff`, and `git diff --check`; results
+  remained green apart from the known unrelated EmojiContext diagnostic.
+- Confirmed PR #2633 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed, CodeRabbit manual review passed, there are no review
+  threads, and Claude remained configured for manual review only. Per
+  workstream policy, do not merge PR #2633 without human approval.
+- Started stacked branch `codex/user-collected-boost-breakdown-a11y-i18n` from
+  PR #2633 for the next low-risk `/{user}/collected` Details-panel follow-up.
+- Implemented message-backed source-locale labels for the Boost Breakdown
+  heading, TDH version link, table caption, columns, row labels, season labels,
+  and total boost tooltip copy. Added a screen-reader table caption, promoted
+  touched row labels to row headers, moved boost numeric values through the
+  repo i18n formatting helper, and made info tooltip triggers keyboard
+  focusable with accessible names.
+- Validation passed for the Boost Breakdown follow-up: focused boost
+  breakdown/i18n Jest suites (3 suites, 8 tests), `lint:changed`,
+  `typecheck:changed`, `react-doctor:diff`, and `git diff --check`. React
+  Doctor still reports only the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic.
+- Browser smoke passed on the live local frontend for `/punk6529/collected` at
+  desktop and a 390px mobile viewport. Verified `Details` opens, Boost
+  Breakdown renders with a screen-reader table caption, scoped column headers,
+  row headers, keyboard-focusable tooltip buttons with accessible names, no
+  page-level mobile overflow, and no Next.js runtime session errors. Console
+  resource errors were shared backend wave endpoints and blocked emoji feed
+  noise.
+- Opened review-ready stacked PR #2634 against PR #2633. Per workstream policy,
+  do not merge PR #2634 without human approval.
+- Confirmed PR #2634 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed, CodeRabbit manual review passed, there are no review
+  threads, and Claude remained configured for manual review only. Per
+  workstream policy, do not merge PR #2634 without human approval.
+- Started stacked branch `codex/user-collected-activity-overview-a11y-i18n`
+  from PR #2634 for the next low-risk `/{user}/collected` Details-panel
+  follow-up.
+- Implemented message-backed source-locale labels for the Activity Overview
+  heading, accordion headings, table captions, columns, row labels, season
+  labels, and numeric/ETH values. Refactored repeated overview and per-season
+  activity rows into typed row/column configs, added screen-reader table
+  captions, and promoted touched row labels to row headers.
+- Validation passed for the Activity Overview follow-up: focused activity
+  overview/i18n Jest suites (2 suites, 5 tests), `lint:changed`,
+  `typecheck:changed`, `react-doctor:diff`, and `git diff --check`. React
+  Doctor still reports only the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic.
+- Browser smoke passed on the live local frontend for `/punk6529/collected` at
+  desktop and a 390px mobile viewport. Verified `Details` opens, Activity
+  Overview tables render with screen-reader captions, scoped column headers,
+  row headers, message-backed labels, horizontal scrollers containing wide
+  tables on mobile, and no Next.js runtime session errors. Console resource
+  errors were shared backend wave endpoints and blocked emoji feed noise.
+- Opened review-ready stacked PR #2635 against PR #2634. Per workstream policy,
+  do not merge PR #2635.
+- Confirmed PR #2635 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed after reducing the row-config duplication, CodeRabbit
+  manual review passed after the async test assertion fix, the stale review
+  thread is resolved/outdated, and Claude remained configured for manual review
+  only. Per workstream policy, do not merge PR #2635.
+- Started stacked branch `codex/user-collected-activity-tabs-a11y-i18n` from
+  PR #2635 for the next low-risk `/{user}/collected` Details-panel follow-up.
+- Implemented message-backed source-locale labels for the lower Activity tab
+  list and tabs, added a tab-list accessible name, connected tabs to the active
+  tabpanel, added roving tab focus with Arrow/Home/End keyboard switching, and
+  exposed active state via `aria-selected` while preserving the existing
+  query-param tab switching.
+- Validation passed for the Activity tabs follow-up: focused activity
+  tab/wrapper/i18n Jest suites (4 suites, 8 tests), `lint:changed`,
+  `typecheck:changed`, and `git diff --check`. `react-doctor:diff` exits 0 and
+  still reports the unrelated dirty `contexts/EmojiContext.tsx` fetch-in-effect
+  diagnostic plus a `useSearchParams` Suspense warning for
+  `UserPageActivityWrapper.tsx`; the wrapper now owns a local Suspense boundary
+  around the hook content, and the remaining warning appears to be analyzer
+  follow-up rather than a missing local boundary.
+- Browser smoke passed on the live local frontend for
+  `/punk6529/collected?activity=wallet-activity`. Verified the lower Activity
+  tab group exposes a named tablist, tabs expose `role="tab"`,
+  `aria-selected`, roving tab indexes, `aria-controls`, and stable IDs, the
+  active panel exposes `role="tabpanel"` and `aria-labelledby`, ArrowRight moves
+  focus/selection from `Wallet Activity` to `Distributions`, the query string
+  updates, and Next.js runtime diagnostics reported no config or session
+  errors. Console resource errors were shared backend wave endpoints and blocked
+  emoji feed noise.
+- Opened review-ready stacked PR #2636 against PR #2635. Per workstream policy,
+  do not merge PR #2636.
+- Confirmed PR #2636 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed, CodeRabbit manual review passed after tightening the
+  page-PR merge policy wording, the prior review thread is resolved/outdated,
+  and Claude remained configured for manual review only. Per workstream policy,
+  do not merge PR #2636.
+- Started stacked branch
+  `codex/user-collected-wallet-activity-filter-a11y-i18n` from PR #2636 for the
+  next low-risk `/{user}/collected` Details-panel follow-up.
+- Implemented message-backed source-locale labels for the Wallet Activity
+  heading, filter trigger/options, empty states, and transaction table caption.
+  Added accessible filter trigger/option names, `aria-expanded`,
+  `aria-controls`, option pressed state, status semantics for empty states, and
+  a screen-reader table caption. Swapped the touched framer-motion dropdown
+  usage to `LazyMotion`/`m`.
+- Validation passed for the Wallet Activity filter follow-up so far: focused
+  wallet filter/table/i18n Jest suites (5 suites, 10 tests), `lint:changed`,
+  `typecheck:changed`, `react-doctor:diff`, and browser smoke on
+  `/punk6529/collected?activity=wallet-activity`. React Doctor still reports
+  the unrelated dirty `contexts/EmojiContext.tsx` fetch-in-effect diagnostic
+  and the `useSearchParams` Suspense warning for the touched wallet component,
+  which is rendered under the activity wrapper Suspense boundary from PR #2636.
+  Browser smoke verified the Wallet Activity heading, filter trigger accessible
+  name, option list labels, pressed state, Wallet Activity table caption,
+  `Mints` selection/query update, and no Next.js runtime session errors.
+- Opened review-ready stacked PR #2637 against PR #2636. Per workstream policy,
+  do not merge PR #2637.
+- SonarCloud reported one non-blocking accessibility code smell on PR #2637:
+  prefer native `<output>` over `role="status"` for the Wallet Activity empty
+  state. Updated the empty state wrapper to `<output>` and reran focused wallet
+  filter/table/i18n Jest suites, targeted eslint for the touched wrapper file,
+  `typecheck:changed`, and `git diff --check`.
+- Confirmed PR #2637 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed with zero open issues after the `<output>` fix, CodeRabbit
+  manual review passed, no review threads are open, and Claude remains
+  configured for manual review only. Per workstream policy, do not merge PR
+  #2637.
+- Started stacked branch `codex/user-collected-distributions-a11y-i18n` from
+  PR #2637 for the next low-risk `/{user}/collected` Details-panel follow-up.
+- Implemented message-backed source-locale labels for the Distributions
+  heading, empty state, table caption, table headings, collection labels,
+  token link accessible names, and a loading-only screen-reader label. Replaced
+  the empty state with native `<output>`, switched distribution row numbers to
+  default-locale `Intl` formatting, switched relative time to the repo i18n
+  helper, and replaced phase index keys with stable phase-name keys.
+- Validation passed for the Distributions follow-up so far: focused
+  distributions/i18n Jest suites (5 suites, 10 tests), targeted eslint for the
+  PR-specific TypeScript files, `typecheck:changed`, `react-doctor:diff`, and
+  browser smoke on `/punk6529/collected?activity=distributions`.
+  `lint:changed` was not rerun for this branch because the long stacked diff
+  expands beyond Windows' command-line limit; the PR-specific eslint run passed.
+  React Doctor still reports the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic and the `useSearchParams` Suspense warning for
+  the touched Distributions component, which is rendered under the activity
+  wrapper Suspense boundary from PR #2636. Browser smoke verified the
+  Distributions tab selection/panel relationship, message-backed heading,
+  native empty-state output, and no Next.js runtime session errors.
+- Opened review-ready stacked PR #2638 against PR #2637. Per workstream policy,
+  do not merge PR #2638.
+- CodeRabbit flagged that the Distributions loading label remained in the
+  accessibility tree when visually hidden by opacity. Fixed the loader subtree
+  to render only while loading and added a focused regression assertion.
+- Confirmed PR #2638 is bot-happy on the latest head after the loading-label
+  follow-up: DCO passed, Snyk passed, SonarCloud passed with zero new issues,
+  CodeRabbit manual review passed, and the prior loading-label review thread is
+  resolved/outdated. Per workstream policy, do not merge PR #2638.
+- Started stacked branch `codex/user-collected-tdh-history-a11y-i18n` from PR
+  #2638 for the next low-risk `/{user}/collected` Details-panel follow-up.
+- Implemented message-backed source-locale labels for the TDH History heading,
+  loading label, empty state, chart list label, chart titles, dataset labels,
+  and chart accessible names. Replaced the empty state with native `<output>`,
+  switched chart date and axis labels through the repo i18n helpers, and
+  replaced random chart keys with stable chart IDs.
+- Validation passed for the TDH History follow-up so far: focused TDH
+  History/i18n Jest suites (3 suites, 8 tests), targeted eslint for the
+  PR-specific TypeScript files, `typecheck:changed`, `react-doctor:diff`, and
+  browser smoke on `/punk6529/collected?activity=tdh-history`. React Doctor
+  still reports the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic and the pre-existing heavy Chart.js import warning
+  in the touched TDH chart component. Browser smoke verified the TDH History tab
+  selection/panel relationship, message-backed heading, chart list label, chart
+  headings, canvas accessible names, and no Next.js runtime session errors; the
+  remaining browser console errors were the known local shared API wave 500s and
+  blocked emoji-list request.
+- Opened review-ready stacked PR #2639 against PR #2638. Per workstream policy,
+  do not merge PR #2639.
+- Confirmed PR #2639 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed, CodeRabbit manual review passed, and no review threads are
+  open. Per workstream policy, do not merge PR #2639.
+- Started stacked branch `codex/user-profile-tabs-a11y-i18n` from PR #2639 for
+  the next low-risk profile shell follow-up.
+- Implemented message-backed source-locale labels for profile tab titles, beta
+  badge text, profile-section navigation landmark text, and tab-scroll button
+  labels. Added `aria-current="page"` to the active profile tab link, wrapped
+  the search-param-driven tab tree in a documented Suspense boundary, and made
+  the horizontal tab scroll listener passive.
+- Validation passed for the profile tabs follow-up so far: focused
+  layout-tabs/i18n Jest suites (4 suites, 20 tests), targeted eslint for the
+  PR-specific TypeScript files, `typecheck:changed`, `react-doctor:diff`, and
+  browser smoke on `/punk6529/collected?activity=tdh-history`. React Doctor
+  still reports the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic, still flags `useSearchParams` in the touched
+  profile tab files despite the `UserPageLayout` Suspense boundary, and still
+  flags the existing `router.replace()` redirect effect. Browser smoke verified
+  the `Profile sections` navigation landmark, message-backed tab labels, the
+  explicit `xTDH Beta` link name, `aria-current="page"` on Collected, and no
+  Next.js runtime session errors; remaining browser console errors were the
+  known local shared API wave 500s and blocked emoji-list request.
+- Opened review-ready stacked PR #2640 against PR #2639. Per workstream policy,
+  do not merge PR #2640.
+- Confirmed PR #2640 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed, CodeRabbit manual review passed, and no review threads are
+  open. Per workstream policy, do not merge PR #2640.
+- Started stacked branch `codex/user-followers-modal-a11y-i18n` from PR #2640
+  for the next low-risk profile modal/list follow-up.
+- Implemented message-backed source-locale labels for the profile followers
+  modal title, follower list label, loading status label, follower profile link
+  names, and follower avatar alt text. Converted the follower collection to a
+  semantic list/listitem structure, added `aria-busy` plus a polite loading
+  status, and switched follower avatars to `next/image` with `unoptimized` for
+  arbitrary remote profile hosts.
+- Validation passed for the followers modal/list follow-up so far: focused
+  followers/i18n Jest suites (5 suites, 11 tests), targeted eslint for the
+  PR-specific source files, `typecheck:changed`, `react-doctor:diff`, and live
+  browser smoke on `/punk6529` at desktop and 390px mobile widths. React Doctor
+  still reports only the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic. Browser smoke verified the `Followers` dialog
+  title, modal `aria-modal`, `Followers` list label, two list items, labeled
+  profile links, avatar alt text, close button on mobile, and no Next.js
+  runtime session errors; browser console errors were local API/resource
+  responses unrelated to the followers modal change.
+- Opened review-ready stacked PR #2641 against PR #2640. Per workstream policy,
+  do not merge PR #2641.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -308,3 +308,29 @@
   i18n Jest suites (2 suites, 22 tests), focused Prettier, `lint:changed`,
   `typecheck:changed`, and `react-doctor:diff`. React Doctor exited 0 at
   99/100 with only the unrelated dirty EmojiContext fetch-in-effect diagnostic.
+- Confirmed PR #2614 is bot-happy on latest head `45caff7`: CodeRabbit passed
+  with no actionable comments, SonarCloud passed with 0 new issues, DCO passed,
+  Snyk passed, and Claude remained skipped by the organization monthly code
+  review spending cap. Per workstream policy, do not merge PR #2614 without
+  human approval.
+- Started stacked branch `codex/the-memes-timeline-a11y-i18n` from PR #2614
+  for the next safe The Memes Timeline tab and shared timeline label surface.
+- Implemented the initial shared timeline accessibility and i18n pass:
+  The Memes Timeline now exposes a locale-backed region label, the shared
+  Timeline accepts an active locale, UTC dates use the progressive date
+  formatter, URI/TXN link labels and accessible names are message-backed, link
+  icons are hidden from assistive tech, and shared From/To/Value/add/remove
+  field labels are message-backed. Timeline media alt text, iframe titles, raw
+  metadata values, and event text remain deferred shared-timeline debt.
+- Validation passed for the timeline slice: targeted shared Timeline,
+  The Memes Timeline, and i18n Jest suites (3 suites, 11 tests), focused
+  Prettier, `lint:changed`, `typecheck:changed`, and `react-doctor:diff`.
+  React Doctor exited 0 at 95/100 with only the unrelated dirty EmojiContext
+  fetch-in-effect diagnostic and existing stacked detail-page
+  size/state/useSearchParams warnings.
+- Browser smoke passed on the live local frontend for
+  `/the-memes/1?focus=timeline&locale=de-DE` at desktop and 390px mobile
+  viewports, plus `/meme-lab/1?focus=timeline&locale=de-DE` at desktop. Verified
+  selected Timeline tabs, locale-backed region labels, German UTC date
+  formatting, URI/TXN accessible link labels, no horizontal overflow, no
+  unexpected HTTP failures, and no Next.js runtime session errors.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -336,3 +336,12 @@
   unexpected HTTP failures, and no Next.js runtime session errors.
 - Opened review-ready stacked PR #2615 against PR #2614. Per workstream policy,
   do not merge PR #2615 without human approval.
+- Addressed CodeRabbit feedback on PR #2615 by removing
+  `dangerouslySetInnerHTML` from shared Timeline metadata value rendering.
+  Timeline values now render as text with newline-preserving CSS, and a
+  regression test covers escaped markup in metadata values.
+- Validation for the PR #2615 CodeRabbit follow-up passed: targeted shared
+  Timeline, The Memes Timeline, and i18n Jest suites (3 suites, 12 tests),
+  focused Prettier, `lint:changed`, `typecheck:changed`, and
+  `react-doctor:diff`. React Doctor exited 0 at 99/100 with only the unrelated
+  dirty EmojiContext fetch-in-effect diagnostic.


### PR DESCRIPTION
## Summary
- Make the shared media `Timeline` component locale-aware for UTC date formatting, URI/TXN link labels and accessible names, and common change field labels.
- Add a labeled The Memes Timeline region and pass the active locale from The Memes and Meme Lab detail pages into the shared timeline.
- Add source messages and fallback tests for the shared timeline and The Memes timeline region.
- Update the media feature doc and frontend a11y/i18n workstream state for this stacked slice.

## Validation
- `pnpm exec prettier --write components/timeline/Timeline.tsx components/the-memes/MemePageTimeline.tsx components/the-memes/MemePage.tsx components/memelab/MemeLabPage.tsx i18n/messages/en-US.ts __tests__/components/timeline/Timeline.test.tsx __tests__/components/the-memes/MemePageTimeline.test.tsx __tests__/i18n/messages.test.ts ops/docs/media/memes/feature-card-tabs-and-focus-links.md ops/workstreams/frontend-a11y-i18n/active-context.md ops/workstreams/frontend-a11y-i18n/pr-links.md ops/workstreams/frontend-a11y-i18n/route-page-status.md ops/workstreams/frontend-a11y-i18n/run-log.md`
- `pnpm run test:no-coverage -- --runInBand --runTestsByPath __tests__/components/timeline/Timeline.test.tsx __tests__/components/the-memes/MemePageTimeline.test.tsx __tests__/i18n/messages.test.ts`
- `pnpm run lint:changed`
- `pnpm run typecheck:changed`
- `pnpm run react-doctor:diff` exited 0 at 95/100 with only the unrelated dirty EmojiContext diagnostic and existing stacked detail-page size/state/useSearchParams warnings.
- Local browser smoke on the live FE/BE: `/the-memes/1?focus=timeline&locale=de-DE` at desktop and 390px mobile, plus `/meme-lab/1?focus=timeline&locale=de-DE` at desktop. Verified selected Timeline tabs, labeled regions, German UTC date formatting, URI/TXN accessible link labels, no horizontal overflow, no unexpected HTTP failures, and no Next.js runtime session errors.

## Review Notes
- Stacked on PR #2614 via base branch `codex/the-memes-activity-a11y-i18n`.
- Review-ready only; do not merge this page-change PR without human approval.
- Timeline media alt text, iframe titles, raw metadata values, and event text remain deferred shared-timeline debt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timeline now respects the selected locale: dates, field labels, link text/accessible names are localized.
  * Timeline region receives an i18n-derived accessible name.
  * Metadata values render as plain text with preserved line breaks (no raw HTML injection).

* **Documentation**
  * Docs updated to clarify timeline localization and accessibility coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->