### PR TITLE
Localize collected boost breakdown

### DIFF
--- a/__tests__/components/UserPageStatsBoostBreakdown.test.tsx
+++ b/__tests__/components/UserPageStatsBoostBreakdown.test.tsx
@@ -1,5 +1,16 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import UserPageStatsBoostBreakdown from "@/components/user/stats/UserPageStatsBoostBreakdown";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
+
+jest.mock("@fortawesome/react-fontawesome", () => ({
+  FontAwesomeIcon: () => <svg data-testid="icon" />,
+}));
+
+const boostText = (
+  key: Parameters<typeof t>[1],
+  params?: Parameters<typeof t>[2]
+) => t(DEFAULT_LOCALE, key, params);
 
 function makeTDH() {
   return {
@@ -44,7 +55,17 @@ describe("UserPageStatsBoostBreakdown", () => {
 
   it("shows boost rows when data present", () => {
     render(<UserPageStatsBoostBreakdown tdh={makeTDH()} />);
-    expect(screen.getByText("Boost Breakdown")).toBeInTheDocument();
-    expect(screen.getByText("TOTAL BOOST")).toBeInTheDocument();
+    expect(
+      screen.getByText(boostText("user.collected.stats.boostBreakdown.title"))
+    ).toBeInTheDocument();
+
+    const table = screen.getByRole("table", {
+      name: boostText("user.collected.stats.boostBreakdown.tableCaption"),
+    });
+    expect(
+      within(table).getByRole("rowheader", {
+        name: boostText("user.collected.stats.boostBreakdown.rows.total"),
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/__tests__/components/user/collected/UserPageCollectedStats.test.tsx
+++ b/__tests__/components/user/collected/UserPageCollectedStats.test.tsx
@@ -688,6 +688,50 @@ describe("UserPageCollectedStats", () => {
     expect(screen.getByTestId("details")).toBeInTheDocument();
   });
 
+  it("uses non-undefined fallbacks when detail stats fetches fail", async () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    apiMock.mockRejectedValue(new Error("Network request failed"));
+    useSearchParamsMock.mockReturnValue({
+      get: (key: string) => (key === "activity" ? "tdh-history" : null),
+    });
+
+    try {
+      renderWithQueryClient(
+        <UserPageCollectedStats
+          profile={profile}
+          activeAddress={null}
+          initialStatsData={buildInitialStatsData()}
+        />
+      );
+
+      await waitFor(() => expect(apiMock).toHaveBeenCalledTimes(4));
+
+      expect(screen.getByTestId("details")).toHaveAttribute(
+        "data-seasons",
+        "0"
+      );
+      expect(screen.getByTestId("details")).toHaveAttribute(
+        "data-has-tdh",
+        "false"
+      );
+      expect(screen.getByTestId("details")).toHaveAttribute(
+        "data-has-owner-balance",
+        "false"
+      );
+      expect(screen.getByTestId("details")).toHaveAttribute(
+        "data-balance-memes",
+        "0"
+      );
+      expect(consoleErrorSpy.mock.calls.join("\n")).not.toContain(
+        "Query data cannot be undefined"
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
   it("clears previous detail stats while the next address detail queries are in flight", async () => {
     const user = userEvent.setup();
     const nextCollectedStatsDeferred = createDeferred<Record<string, never>>();

--- a/__tests__/components/user/followers/UserPageFollowersModal.test.tsx
+++ b/__tests__/components/user/followers/UserPageFollowersModal.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { AuthContext } from "@/components/auth/Auth";
+import UserPageFollowersModal from "@/components/user/followers/UserPageFollowersModal";
+import useFollowersList from "@/hooks/useFollowersList";
+
+jest.mock("@/components/mobile-wrapper-dialog/MobileWrapperDialog", () => ({
+  __esModule: true,
+  default: ({ title, children }: any) => (
+    <section role="dialog" aria-label={title}>
+      {children}
+    </section>
+  ),
+}));
+
+jest.mock("@/components/utils/CommonIntersectionElement", () => ({
+  __esModule: true,
+  default: () => <div data-testid="intersection-sentinel" />,
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ alt, fill, sizes, unoptimized, ...props }: any) =>
+    React.createElement("img", { alt: alt ?? "", ...props }),
+}));
+
+jest.mock("@/components/user/utils/UserCICAndLevel", () => ({
+  __esModule: true,
+  default: (props: any) => <div data-testid="cic">{props.level}</div>,
+  UserCICAndLevelSize: { SMALL: "SMALL" },
+}));
+
+jest.mock("@/components/user/utils/UserFollowBtn", () => ({
+  __esModule: true,
+  default: ({ handle }: any) => <button type="button">Follow {handle}</button>,
+  UserFollowBtnSize: { SMALL: "SMALL" },
+}));
+
+jest.mock("@/hooks/useFollowersList");
+
+const mockedUseFollowersList = useFollowersList as jest.Mock;
+
+const renderModal = () =>
+  render(
+    <AuthContext.Provider
+      value={{
+        connectedProfile: null,
+        fetchingProfile: false,
+        receivedProfileProxies: [],
+        activeProfileProxy: null,
+        connectionStatus: "NOT_CONNECTED" as any,
+        showWaves: false,
+        requestAuth: async () => ({ success: false }),
+        setToast: jest.fn(),
+        setActiveProfileProxy: jest.fn(),
+      }}
+    >
+      <UserPageFollowersModal
+        profileId="profile-1"
+        isOpen={true}
+        onClose={jest.fn()}
+      />
+    </AuthContext.Provider>
+  );
+
+describe("UserPageFollowersModal", () => {
+  beforeEach(() => {
+    mockedUseFollowersList.mockReturnValue({
+      followers: [
+        {
+          identity: {
+            id: "1",
+            handle: "alice",
+            level: 5,
+            pfp: "alice.png",
+            primary_address: "0xalice",
+          },
+        },
+      ],
+      isFetching: false,
+      onBottomIntersection: jest.fn(),
+    });
+  });
+
+  it("uses the localized followers title and forwards list state", () => {
+    renderModal();
+
+    expect(
+      screen.getByRole("dialog", { name: "Followers" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("list", { name: "Followers" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "View alice's profile" })
+    ).toHaveAttribute("href", "/alice");
+    expect(mockedUseFollowersList).toHaveBeenCalledWith({
+      profileId: "profile-1",
+      enabled: true,
+    });
+  });
+
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+  ])(
+    "falls back to primary address when follower handle is %s",
+    (_label, missingHandle) => {
+      mockedUseFollowersList.mockReturnValue({
+        followers: [
+          {
+            identity: {
+              id: "2",
+              handle: missingHandle,
+              level: 2,
+              pfp: "fallback.png",
+              primary_address: "0xabc",
+            },
+          },
+        ],
+        isFetching: false,
+        onBottomIntersection: jest.fn(),
+      });
+
+      renderModal();
+
+      const profileLink = screen.getByRole("link", {
+        name: "View 0xabc's profile",
+      });
+      expect(profileLink).toHaveAttribute("href", "/0xabc");
+      expect(profileLink).toHaveAttribute("aria-label", "View 0xabc's profile");
+      expect(profileLink).toHaveTextContent("0xabc");
+      expect(screen.getByAltText("0xabc's profile image")).toBeInTheDocument();
+    }
+  );
+});

--- a/__tests__/components/user/layout/UserPageLayout.test.tsx
+++ b/__tests__/components/user/layout/UserPageLayout.test.tsx
@@ -5,12 +5,18 @@ import { TitleProvider } from "@/contexts/TitleContext";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
-import { useParams, usePathname, useSearchParams } from "next/navigation";
+import {
+  useParams,
+  usePathname,
+  useRouter,
+  useSearchParams,
+} from "next/navigation";
 
 jest.mock("next/navigation", () => ({
   useSearchParams: jest.fn(),
   useParams: jest.fn(),
   usePathname: jest.fn(),
+  useRouter: jest.fn(),
 }));
 jest.mock(
   "@/components/user/user-page-header/UserPageHeader",
@@ -35,12 +41,14 @@ const mockAuthContext = {} as any;
 const mockReactQueryContext = { setProfile: jest.fn() } as any;
 const mockUseParams = useParams as jest.Mock;
 const mockUsePathname = usePathname as jest.Mock;
+const mockUseRouter = useRouter as jest.Mock;
 const mockUseSearchParams = useSearchParams as jest.Mock;
 
 describe("UserPageLayout", () => {
   beforeEach(() => {
     mockUseParams.mockReturnValue({ user: "testuser" });
     mockUsePathname.mockReturnValue("/testuser");
+    mockUseRouter.mockReturnValue({ push: jest.fn(), replace: jest.fn() });
     mockUseSearchParams.mockReturnValue(new URLSearchParams());
   });
 
@@ -53,10 +61,7 @@ describe("UserPageLayout", () => {
         <QueryClientProvider client={queryClient}>
           <AuthContext.Provider value={mockAuthContext}>
             <ReactQueryWrapperContext.Provider value={mockReactQueryContext}>
-              <UserPageLayout
-                profile={mockProfile}
-                handleOrWallet="testuser"
-              >
+              <UserPageLayout profile={mockProfile} handleOrWallet="testuser">
                 <div>Content</div>
               </UserPageLayout>
             </ReactQueryWrapperContext.Provider>
@@ -76,9 +81,7 @@ describe("UserPageLayout", () => {
   it("sets profile in context when not cached", async () => {
     renderComponent();
     await waitFor(() =>
-      expect(mockReactQueryContext.setProfile).toHaveBeenCalledWith(
-        mockProfile
-      )
+      expect(mockReactQueryContext.setProfile).toHaveBeenCalledWith(mockProfile)
     );
   });
 });

--- a/__tests__/components/user/layout/UserPageTab.test.tsx
+++ b/__tests__/components/user/layout/UserPageTab.test.tsx
@@ -1,26 +1,39 @@
-import { render, screen } from '@testing-library/react';
-import UserPageTab from '@/components/user/layout/UserPageTab';
-import { USER_PAGE_TAB_IDS, USER_PAGE_TAB_MAP } from '@/components/user/layout/userTabs.config';
-import { useParams, useSearchParams } from 'next/navigation';
+import { render, screen } from "@testing-library/react";
+import UserPageTab from "@/components/user/layout/UserPageTab";
+import {
+  USER_PAGE_TAB_IDS,
+  USER_PAGE_TAB_MAP,
+} from "@/components/user/layout/userTabs.config";
+import { useParams, useSearchParams } from "next/navigation";
 
-jest.mock('next/navigation', () => ({
+jest.mock("next/navigation", () => ({
   useParams: jest.fn(),
   useSearchParams: jest.fn(),
 }));
-jest.mock('next/link', () => (props: any) => (
+jest.mock("next/link", () => (props: any) => (
   <a
     data-testid="link"
-    href={props.href.pathname + (props.href.query ? '?address=' + props.href.query.address : '')}
+    href={
+      props.href.pathname +
+      (props.href.query ? "?address=" + props.href.query.address : "")
+    }
     className={props.className}
+    aria-current={props["aria-current"]}
+    aria-label={props["aria-label"]}
   >
     {props.children}
   </a>
 ));
 
-describe('UserPageTab', () => {
-  it('renders active and inactive states', () => {
-    (useParams as jest.Mock).mockReturnValue({ user: 'bob' });
-    (useSearchParams as jest.Mock).mockReturnValue({ get: (k: string) => (k === 'address' ? '0x1' : null) });
+describe("UserPageTab", () => {
+  beforeEach(() => {
+    (useParams as jest.Mock).mockReturnValue({ user: "bob" });
+    (useSearchParams as jest.Mock).mockReturnValue({
+      get: (k: string) => (k === "address" ? "0x1" : null),
+    });
+  });
+
+  it("renders active and inactive states", () => {
     const repTab = USER_PAGE_TAB_MAP[USER_PAGE_TAB_IDS.REP];
     const { rerender } = render(
       <UserPageTab
@@ -29,9 +42,11 @@ describe('UserPageTab', () => {
         activeTabId={USER_PAGE_TAB_IDS.REP}
       />
     );
-    const link = screen.getByTestId('link');
-    expect(link).toHaveAttribute('href', '/bob/rep?address=0x1');
-    expect(link).toHaveClass('tw-pointer-events-none');
+    const link = screen.getByTestId("link");
+    expect(link).toHaveAttribute("href", "/bob/?address=0x1");
+    expect(link).toHaveAttribute("aria-label", "Identity");
+    expect(link).toHaveClass("tw-pointer-events-none");
+    expect(link).toHaveAttribute("aria-current", "page");
     rerender(
       <UserPageTab
         tab={repTab}
@@ -39,6 +54,19 @@ describe('UserPageTab', () => {
         activeTabId={USER_PAGE_TAB_IDS.BRAIN}
       />
     );
-    expect(link).not.toHaveClass('tw-pointer-events-none');
+    expect(link).not.toHaveClass("tw-pointer-events-none");
+    expect(link).not.toHaveAttribute("aria-current");
+  });
+
+  it("renders localized badges in the link name", () => {
+    render(
+      <UserPageTab
+        tab={USER_PAGE_TAB_MAP[USER_PAGE_TAB_IDS.XTDH]}
+        parentRef={{ current: null }}
+        activeTabId={USER_PAGE_TAB_IDS.REP}
+      />
+    );
+
+    expect(screen.getByRole("link", { name: "xTDH Beta" })).toBeInTheDocument();
   });
 });

--- a/__tests__/components/user/layout/UserPageTabs.test.tsx
+++ b/__tests__/components/user/layout/UserPageTabs.test.tsx
@@ -1,4 +1,5 @@
 import UserPageTabs from "@/components/user/layout/UserPageTabs";
+import { getUserProfileTabsMessage } from "@/components/user/layout/user-tabs.messages";
 import { USER_PAGE_TAB_IDS } from "@/components/user/layout/userTabs.config";
 import { render, screen, waitFor } from "@testing-library/react";
 import {
@@ -26,6 +27,10 @@ const capacitorMock = jest.fn();
 jest.mock("@/hooks/useCapacitor", () => ({
   __esModule: true,
   default: () => capacitorMock(),
+}));
+const useIdentityMock = jest.fn();
+jest.mock("@/hooks/useIdentity", () => ({
+  useIdentity: () => useIdentityMock(),
 }));
 jest.mock("@/components/user/layout/UserPageTab", () => ({
   __esModule: true,
@@ -96,6 +101,10 @@ const renderTabs = ({
     connectedProfile,
     fetchingProfile,
   });
+  useIdentityMock.mockReturnValue({
+    profile: { profile_wave_id: null },
+    isLoading: false,
+  });
   useSeizeConnectContextMock.mockReturnValue({
     address,
     connectionState,
@@ -109,6 +118,11 @@ const renderTabs = ({
 describe("UserPageTabs", () => {
   it("filters tabs based on context and platform", () => {
     renderTabs({ showWaves: false, isIos: false });
+    expect(
+      screen.getByRole("navigation", {
+        name: getUserProfileTabsMessage("user.profile.tabs.navigationLabel"),
+      })
+    ).toBeInTheDocument();
     const tabs = getTabIds();
     expect(tabs).not.toContain(USER_PAGE_TAB_IDS.BRAIN);
     expect(tabs).not.toContain("stats");

--- a/__tests__/components/user/stats/UserPageStatsActivityOverview.test.tsx
+++ b/__tests__/components/user/stats/UserPageStatsActivityOverview.test.tsx
@@ -1,18 +1,152 @@
-import { render, waitFor } from '@testing-library/react';
-import React from 'react';
-import UserPageStatsActivityOverview from '@/components/user/stats/UserPageStatsActivityOverview';
-import { commonApiFetch } from '@/services/api/common-api';
+import { render, screen, waitFor, within } from "@testing-library/react";
+import UserPageStatsActivityOverview from "@/components/user/stats/UserPageStatsActivityOverview";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
+import { commonApiFetch } from "@/services/api/common-api";
 
-jest.mock('@/services/api/common-api', () => ({
-  commonApiFetch: jest.fn(() => Promise.resolve({}))
+jest.mock("@/services/api/common-api", () => ({
+  commonApiFetch: jest.fn(),
 }));
 
-const profile: any = { wallets: [{ wallet: '0xabc' }] };
+const profile: any = { wallets: [{ wallet: "0xabc" }] };
 
-describe('UserPageStatsActivityOverview', () => {
-  it('calls API on mount', async () => {
-    render(<UserPageStatsActivityOverview profile={profile} activeAddress={null} />);
+const activityText = (
+  key: Parameters<typeof t>[1],
+  params?: Parameters<typeof t>[2]
+) => t(DEFAULT_LOCALE, key, params);
+
+function mockActivityResponses() {
+  (commonApiFetch as jest.Mock)
+    .mockResolvedValueOnce({
+      airdrops: 1000,
+      airdrops_memes: 800,
+      airdrops_nextgen: 100,
+      airdrops_gradients: 50,
+      airdrops_memelab: 50,
+      transfers_in: 25,
+      transfers_in_memes: 20,
+      transfers_in_nextgen: 2,
+      transfers_in_gradients: 2,
+      transfers_in_memelab: 1,
+      primary_purchases_count: 4,
+      primary_purchases_value: 1.234,
+      secondary_purchases_count: 3,
+      secondary_purchases_value: 2.345,
+      transfers_out: 2,
+      burns: 1,
+      sales_count: 5,
+      sales_value: 6.789,
+    })
+    .mockResolvedValueOnce([
+      {
+        consolidation_key: "wallet:0xabc",
+        season: 1,
+        transfers_in: 9,
+        airdrops: 8,
+        primary_purchases_count: 7,
+        primary_purchases_value: 1.23,
+        secondary_purchases_count: 6,
+        secondary_purchases_value: 2.34,
+        transfers_out: 5,
+        burns: 4,
+        sales_count: 3,
+        sales_value: 4.56,
+      },
+    ]);
+}
+
+describe("UserPageStatsActivityOverview", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockActivityResponses();
+  });
+
+  it("calls API on mount", async () => {
+    render(
+      <UserPageStatsActivityOverview profile={profile} activeAddress={null} />
+    );
     await waitFor(() => expect(commonApiFetch).toHaveBeenCalledTimes(2));
-    expect((commonApiFetch as jest.Mock).mock.calls[0][0].endpoint).toContain('aggregated-activity/wallet/0xabc');
+    expect((commonApiFetch as jest.Mock).mock.calls[0][0].endpoint).toContain(
+      "aggregated-activity/wallet/0xabc"
+    );
+  });
+
+  it("renders accessible activity overview tables", async () => {
+    render(
+      <UserPageStatsActivityOverview profile={profile} activeAddress={null} />
+    );
+
+    const overviewTable = await screen.findByRole("table", {
+      name: activityText(
+        "user.collected.stats.activityOverview.tables.overviewCaption"
+      ),
+    });
+    expect(
+      within(overviewTable).getByRole("rowheader", {
+        name: activityText(
+          "user.collected.stats.activityOverview.rows.airdrops"
+        ),
+      })
+    ).toBeInTheDocument();
+    expect(within(overviewTable).getByText("1,000")).toBeInTheDocument();
+    expect(within(overviewTable).getByText("1.23")).toBeInTheDocument();
+
+    const seasonTable = await screen.findByRole("table", {
+      name: activityText(
+        "user.collected.stats.activityOverview.tables.memesBySeasonCaption"
+      ),
+    });
+    expect(
+      await within(seasonTable).findByRole("rowheader", {
+        name: activityText(
+          "user.collected.stats.activityOverview.seasonLabel",
+          { seasonNumber: 1 }
+        ),
+      })
+    ).toBeInTheDocument();
+    expect(
+      within(seasonTable).getByRole("columnheader", {
+        name: activityText(
+          "user.collected.stats.activityOverview.rows.transfersIn"
+        ),
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("shows an empty state instead of an empty season table", async () => {
+    (commonApiFetch as jest.Mock)
+      .mockReset()
+      .mockResolvedValueOnce({
+        airdrops: 0,
+        transfers_in: 0,
+        primary_purchases_count: 0,
+        primary_purchases_value: 0,
+        secondary_purchases_count: 0,
+        secondary_purchases_value: 0,
+        transfers_out: 0,
+        burns: 0,
+        sales_count: 0,
+        sales_value: 0,
+      })
+      .mockResolvedValueOnce([]);
+
+    render(
+      <UserPageStatsActivityOverview profile={profile} activeAddress={null} />
+    );
+
+    expect(
+      await screen.findByText(
+        activityText(
+          "user.collected.stats.activityOverview.tables.memesBySeasonEmpty"
+        )
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("table", {
+        name: activityText(
+          "user.collected.stats.activityOverview.tables.memesBySeasonCaption"
+        ),
+      })
+    ).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/user/stats/UserPageStatsBoostBreakdown.test.tsx
+++ b/__tests__/components/user/stats/UserPageStatsBoostBreakdown.test.tsx
@@ -1,38 +1,114 @@
-import { render, screen } from '@testing-library/react';
-import UserPageStatsBoostBreakdown from '@/components/user/stats/UserPageStatsBoostBreakdown';
-import type { ConsolidatedTDH } from '@/entities/ITDH';
+import { render, screen, within } from "@testing-library/react";
+import UserPageStatsBoostBreakdown from "@/components/user/stats/UserPageStatsBoostBreakdown";
+import type { ConsolidatedTDH } from "@/entities/ITDH";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 
-jest.mock('@fortawesome/react-fontawesome', () => ({ FontAwesomeIcon: () => <svg data-testid="icon" /> }));
+jest.mock("@fortawesome/react-fontawesome", () => ({
+  FontAwesomeIcon: () => <svg data-testid="icon" />,
+}));
 
-describe('UserPageStatsBoostBreakdown', () => {
-  it('renders nothing when boost breakdown missing', () => {
-    const { container } = render(<UserPageStatsBoostBreakdown tdh={undefined} />);
+const boostText = (
+  key: Parameters<typeof t>[1],
+  params?: Parameters<typeof t>[2]
+) => t(DEFAULT_LOCALE, key, params);
+
+describe("UserPageStatsBoostBreakdown", () => {
+  it("renders nothing when boost breakdown missing", () => {
+    const { container } = render(
+      <UserPageStatsBoostBreakdown tdh={undefined} />
+    );
     expect(container.firstChild).toBeNull();
   });
 
-  it('shows table when data provided', () => {
+  it("shows the accessible boost table when data provided", () => {
     const tdh: ConsolidatedTDH = {
       boost: 2,
       boost_breakdown: {
-        memes_card_sets: { available: 1, acquired: 1, available_info: [], acquired_info: [] },
-        gradients: { available: 1, acquired: 1, available_info: [], acquired_info: [] },
+        memes_card_sets: {
+          available: 1,
+          acquired: 1,
+          available_info: ["Card set boost detail"],
+          acquired_info: [],
+        },
+        gradients: {
+          available: 1,
+          acquired: 1,
+          available_info: [],
+          acquired_info: [],
+        },
       },
     } as any;
     render(<UserPageStatsBoostBreakdown tdh={tdh} />);
-    expect(screen.getByText('Boost Breakdown')).toBeInTheDocument();
-    expect(screen.getByText('TOTAL BOOST')).toBeInTheDocument();
+    expect(
+      screen.getByText(boostText("user.collected.stats.boostBreakdown.title"))
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: boostText("user.collected.stats.boostBreakdown.versionLink", {
+          version: "1.4",
+        }),
+      })
+    ).toBeInTheDocument();
+
+    const table = screen.getByRole("table", {
+      name: boostText("user.collected.stats.boostBreakdown.tableCaption"),
+    });
+    expect(
+      within(table).getByRole("columnheader", {
+        name: boostText("user.collected.stats.boostBreakdown.columns.type"),
+      })
+    ).toBeInTheDocument();
+    expect(
+      within(table).getByRole("columnheader", {
+        name: boostText(
+          "user.collected.stats.boostBreakdown.columns.potential"
+        ),
+      })
+    ).toBeInTheDocument();
+    expect(
+      within(table).getByRole("rowheader", {
+        name: boostText("user.collected.stats.boostBreakdown.rows.total"),
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("button", {
+        name: boostText("user.collected.stats.boostBreakdown.info.ariaLabel"),
+      }).length
+    ).toBeGreaterThan(0);
   });
 
-  it('shows season rows when card sets acquired is zero', () => {
+  it("shows season rows when card sets acquired is zero", () => {
     const tdh: ConsolidatedTDH = {
       boost: 2,
       boost_breakdown: {
-        memes_card_sets: { available: 1, acquired: 0, available_info: [], acquired_info: [] },
-        memes_szn1: { available: 1, acquired: 1, available_info: [], acquired_info: [] },
-        gradients: { available: 0, acquired: 0, available_info: [], acquired_info: [] },
+        memes_card_sets: {
+          available: 1,
+          acquired: 0,
+          available_info: [],
+          acquired_info: [],
+        },
+        memes_szn1: {
+          available: 1,
+          acquired: 1,
+          available_info: [],
+          acquired_info: [],
+        },
+        gradients: {
+          available: 0,
+          acquired: 0,
+          available_info: [],
+          acquired_info: [],
+        },
       },
     } as any;
     render(<UserPageStatsBoostBreakdown tdh={tdh} />);
-    expect(screen.getByText('SZN1')).toBeInTheDocument();
+    expect(
+      screen.getByRole("rowheader", {
+        name: boostText("user.collected.stats.boostBreakdown.seasonLabel", {
+          seasonNumber: 1,
+        }),
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/__tests__/components/user/stats/UserPageStatsBoostBreakdown.test.tsx
+++ b/__tests__/components/user/stats/UserPageStatsBoostBreakdown.test.tsx
@@ -111,4 +111,59 @@ describe("UserPageStatsBoostBreakdown", () => {
       })
     ).toBeInTheDocument();
   });
+
+  it("renders zero boost values and total row numbers", () => {
+    const tdh: ConsolidatedTDH = {
+      boost: 1.25,
+      boost_breakdown: {
+        memes_card_sets: {
+          available: 0,
+          acquired: 0,
+          available_info: [],
+          acquired_info: [],
+        },
+        gradients: {
+          available: 1.5,
+          acquired: 0,
+          available_info: [],
+          acquired_info: [],
+        },
+      },
+    } as any;
+
+    render(<UserPageStatsBoostBreakdown tdh={tdh} />);
+
+    const table = screen.getByRole("table", {
+      name: boostText("user.collected.stats.boostBreakdown.tableCaption"),
+    });
+    expect(within(table).getAllByText("0.00").length).toBeGreaterThanOrEqual(3);
+    expect(within(table).getAllByText("1.50").length).toBeGreaterThanOrEqual(2);
+    expect(within(table).getByText("0.25")).toBeInTheDocument();
+  });
+
+  it("does not throw when optional boost breakdown sections are absent", () => {
+    const tdh: ConsolidatedTDH = {
+      boost: 1,
+      boost_breakdown: {
+        memes_card_sets: {
+          available: 0,
+          acquired: 0,
+          available_info: [],
+          acquired_info: [],
+        },
+      },
+    } as any;
+
+    render(<UserPageStatsBoostBreakdown tdh={tdh} />);
+
+    const table = screen.getByRole("table", {
+      name: boostText("user.collected.stats.boostBreakdown.tableCaption"),
+    });
+    expect(
+      within(table).getByRole("rowheader", {
+        name: boostText("user.collected.stats.boostBreakdown.rows.total"),
+      })
+    ).toBeInTheDocument();
+    expect(within(table).getAllByText("0.00").length).toBeGreaterThan(0);
+  });
 });

--- a/__tests__/components/user/stats/activity/UserPageActivityTab.test.tsx
+++ b/__tests__/components/user/stats/activity/UserPageActivityTab.test.tsx
@@ -2,6 +2,15 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import UserPageActivityTab from "@/components/user/stats/activity/tabs/UserPageActivityTab";
 import { USER_PAGE_ACTIVITY_TAB } from "@/components/user/stats/activity/activity.types";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
+import {
+  getActivityPanelId,
+  getActivityTabId,
+} from "@/components/user/stats/activity/tabs/activity-tabs.helpers";
+
+const activityTabText = (key: Parameters<typeof t>[1]) =>
+  t(DEFAULT_LOCALE, key);
 
 describe("UserPageActivityTab", () => {
   it("renders label and handles click", async () => {
@@ -12,10 +21,23 @@ describe("UserPageActivityTab", () => {
         tab={USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS}
         activeTab={USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY}
         setActiveTab={setActive}
+        onKeyDown={jest.fn()}
       />
     );
-    const btn = screen.getByRole("button", { name: "Distributions" });
+    const btn = screen.getByRole("tab", {
+      name: activityTabText("user.collected.stats.activityTabs.distributions"),
+    });
     expect(btn).toHaveClass("tw-bg-iron-950", { exact: false });
+    expect(btn).toHaveAttribute("aria-selected", "false");
+    expect(btn).toHaveAttribute(
+      "aria-controls",
+      getActivityPanelId(USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS)
+    );
+    expect(btn).toHaveAttribute(
+      "id",
+      getActivityTabId(USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS)
+    );
+    expect(btn).toHaveAttribute("tabIndex", "-1");
     await user.click(btn);
     expect(setActive).toHaveBeenCalledWith(
       USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS
@@ -28,9 +50,14 @@ describe("UserPageActivityTab", () => {
         tab={USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY}
         activeTab={USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY}
         setActiveTab={jest.fn()}
+        onKeyDown={jest.fn()}
       />
     );
-    const btn = screen.getByRole("button", { name: "Wallet Activity" });
+    const btn = screen.getByRole("tab", {
+      name: activityTabText("user.collected.stats.activityTabs.walletActivity"),
+    });
     expect(btn.className).toContain("tw-bg-iron-800");
+    expect(btn).toHaveAttribute("aria-selected", "true");
+    expect(btn).toHaveAttribute("tabIndex", "0");
   });
 });

--- a/__tests__/components/user/stats/activity/UserPageActivityWrapper.test.tsx
+++ b/__tests__/components/user/stats/activity/UserPageActivityWrapper.test.tsx
@@ -1,5 +1,9 @@
 import UserPageActivityWrapper from "@/components/user/stats/activity/UserPageActivityWrapper";
 import { USER_PAGE_ACTIVITY_TAB } from "@/components/user/stats/activity/activity.types";
+import {
+  getActivityPanelId,
+  getActivityTabId,
+} from "@/components/user/stats/activity/tabs/activity-tabs.helpers";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -60,6 +64,15 @@ test("hydrates the active tab from query params and updates the url on change", 
   render(<UserPageActivityWrapper profile={profile} activeAddress={null} />);
 
   expect(screen.getByTestId("tdh")).toBeInTheDocument();
+  const activePanel = screen.getByRole("tabpanel");
+  expect(activePanel).toHaveAttribute(
+    "id",
+    getActivityPanelId(USER_PAGE_ACTIVITY_TAB.TDH_HISTORY)
+  );
+  expect(activePanel).toHaveAttribute(
+    "aria-labelledby",
+    getActivityTabId(USER_PAGE_ACTIVITY_TAB.TDH_HISTORY)
+  );
 
   await user.click(screen.getByTestId("tab"));
 

--- a/__tests__/components/user/stats/activity/distributions/UserPageStatsActivityDistributions.test.tsx
+++ b/__tests__/components/user/stats/activity/distributions/UserPageStatsActivityDistributions.test.tsx
@@ -1,4 +1,5 @@
 import UserPageStatsActivityDistributions from "@/components/user/stats/activity/distributions/UserPageStatsActivityDistributions";
+import { getDistributionsMessage } from "@/components/user/stats/activity/distributions/distributions.messages";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -68,6 +69,11 @@ test("hydrates the page from query params and updates the url on page change", a
     />
   );
 
+  expect(
+    screen.getByRole("heading", {
+      name: getDistributionsMessage("user.collected.stats.distributions.title"),
+    })
+  ).toBeInTheDocument();
   expect(screen.getByTestId("wrapper")).toHaveAttribute("data-page", "2");
 
   await userEvent.click(screen.getByTestId("set-page"));

--- a/__tests__/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTable.test.tsx
+++ b/__tests__/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTable.test.tsx
@@ -1,46 +1,91 @@
-import { render, screen } from '@testing-library/react';
-import UserPageStatsActivityDistributionsTable from '@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTable';
+import { render, screen } from "@testing-library/react";
+import UserPageStatsActivityDistributionsTable from "@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTable";
+import { getDistributionsMessage } from "@/components/user/stats/activity/distributions/distributions.messages";
 
-jest.mock('@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableItem', () => (props: any) => (
-  <tr data-testid="item">{props.item.name}</tr>
-));
+jest.mock(
+  "@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableItem",
+  () => (props: any) => (
+    <tr data-testid="item">
+      <td>{props.item.name}</td>
+    </tr>
+  )
+);
 
 const items = [
   {
     card_id: 1,
-    contract: '0x33FD426905F149f8376e227d0C9D3340AaD17aF1',
-    wallet: '0x1',
-    wallet_display: 'A',
-    card_name: 'Card1',
-    mint_date: '2020-01-01',
+    contract: "0x33FD426905F149f8376e227d0C9D3340AaD17aF1",
+    wallet: "0x1",
+    wallet_display: "A",
+    card_name: "Card1",
+    mint_date: "2020-01-01",
     airdrops: 1,
     total_spots: 0,
     minted: 2,
-    allowlist: [{ phase: 'phase1', spots: 3 }],
+    allowlist: [{ phase: "phase1", spots: 3 }],
     total_count: 5,
-    phases: ['phase1', 'AIRDROP'],
+    phases: ["phase1", "AIRDROP"],
   },
   {
     card_id: 2,
-    contract: '0x0C58Ef43fF3032005e472cB5709f8908aCb00205',
-    wallet: '0x2',
-    wallet_display: 'B',
-    card_name: 'Card2',
-    mint_date: '2020-01-02',
+    contract: "0x0C58Ef43fF3032005e472cB5709f8908aCb00205",
+    wallet: "0x2",
+    wallet_display: "B",
+    card_name: "Card2",
+    mint_date: "2020-01-02",
     airdrops: 0,
     total_spots: 0,
     minted: 1,
     allowlist: [],
     total_count: 3,
-    phases: ['phase1'],
+    phases: ["phase1"],
   },
 ];
 
-const profile = { wallets: [{ wallet: '0x1', display: 'disp1' }] } as any;
+const profile = { wallets: [{ wallet: "0x1", display: "disp1" }] } as any;
 
-test('renders rows and phases', () => {
-  render(<UserPageStatsActivityDistributionsTable items={items} profile={profile} loading={false} />);
-  expect(screen.getAllByTestId('item')).toHaveLength(2);
-  expect(screen.getByText('Phase1')).toBeInTheDocument();
-  expect(screen.getByText('Airdrop')).toBeInTheDocument();
+test("renders rows, phase headers, and a named table", () => {
+  render(
+    <UserPageStatsActivityDistributionsTable
+      items={items}
+      profile={profile}
+      loading={false}
+    />
+  );
+  expect(
+    screen.getByRole("table", {
+      name: getDistributionsMessage(
+        "user.collected.stats.distributions.tableCaption"
+      ),
+    })
+  ).toBeInTheDocument();
+  expect(screen.getAllByTestId("item")).toHaveLength(2);
+  expect(screen.getByText("Phase1")).toBeInTheDocument();
+  expect(
+    screen.getByText(
+      getDistributionsMessage(
+        "user.collected.stats.distributions.phases.airdrop"
+      )
+    )
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByText(
+      getDistributionsMessage("user.collected.stats.distributions.loading")
+    )
+  ).not.toBeInTheDocument();
+});
+
+test("renders the loading label only while loading", () => {
+  render(
+    <UserPageStatsActivityDistributionsTable
+      items={items}
+      profile={profile}
+      loading={true}
+    />
+  );
+  expect(
+    screen.getByText(
+      getDistributionsMessage("user.collected.stats.distributions.loading")
+    )
+  ).toBeInTheDocument();
 });

--- a/__tests__/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableItem.test.tsx
+++ b/__tests__/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableItem.test.tsx
@@ -1,39 +1,54 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import UserPageStatsActivityDistributionsTableItem from '@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableItem';
-import { formatNumberWithCommasOrDash, getTimeAgo } from '@/helpers/Helpers';
-
-jest.mock('@/helpers/Helpers');
-const formatMock = formatNumberWithCommasOrDash as jest.Mock;
-const timeAgoMock = getTimeAgo as jest.Mock;
+import { render, screen } from "@testing-library/react";
+import UserPageStatsActivityDistributionsTableItem from "@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableItem";
+import { DistributionCollection } from "@/components/user/stats/activity/distributions/distributions.types";
 
 beforeEach(() => {
-  formatMock.mockImplementation((v) => v.toString());
-  timeAgoMock.mockReturnValue('1d ago');
+  jest
+    .spyOn(Date, "now")
+    .mockReturnValue(new Date("2020-01-02T00:00:00.000Z").getTime());
 });
 
-describe('UserPageStatsActivityDistributionsTableItem', () => {
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("UserPageStatsActivityDistributionsTableItem", () => {
   const item = {
-    collection: 'MEMES',
+    collection: DistributionCollection.MEMES,
     tokenId: 1,
-    name: 'Test',
-    wallet: '0x1',
-    phases: [1,2],
+    name: "Test",
+    wallet: "0x1",
+    phases: [
+      { phase: "phase1", amount: 1 },
+      { phase: "phase2", amount: 2 },
+    ],
     amountMinted: 3,
     amountTotal: 4,
-    date: '2020-01-01'
-  } as any;
+    date: "2020-01-01T00:00:00.000Z",
+  };
 
-  it('renders info', () => {
-    render(<table><tbody><UserPageStatsActivityDistributionsTableItem item={item} /></tbody></table>);
-    expect(screen.getByText('The Memes')).toBeInTheDocument();
-    expect(screen.getByText('# 1')).toBeInTheDocument();
-    expect(screen.getByText('Test')).toBeInTheDocument();
-    expect(screen.getByText('0x1')).toBeInTheDocument();
-    expect(screen.getByText('1')).toBeInTheDocument();
-    expect(screen.getByText('2')).toBeInTheDocument();
-    expect(screen.getByText('3')).toBeInTheDocument();
-    expect(screen.getByText('4')).toBeInTheDocument();
-    expect(screen.getByText('1d ago')).toBeInTheDocument();
+  it("renders info", () => {
+    render(
+      <table>
+        <tbody>
+          <UserPageStatsActivityDistributionsTableItem
+            item={item}
+            formatNumber={(value) => `n-${value}`}
+          />
+        </tbody>
+      </table>
+    );
+    expect(screen.getByText("The Memes")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "View The Memes token #1" })
+    ).toHaveAttribute("href", "/the-memes/1");
+    expect(screen.getByText("# 1")).toBeInTheDocument();
+    expect(screen.getByText("Test")).toBeInTheDocument();
+    expect(screen.getByText("0x1")).toBeInTheDocument();
+    expect(screen.getByText("n-1")).toBeInTheDocument();
+    expect(screen.getByText("n-2")).toBeInTheDocument();
+    expect(screen.getByText("n-3")).toBeInTheDocument();
+    expect(screen.getByText("n-4")).toBeInTheDocument();
+    expect(screen.getByText("yesterday")).toBeInTheDocument();
   });
 });

--- a/__tests__/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableWrapper.test.tsx
+++ b/__tests__/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableWrapper.test.tsx
@@ -1,16 +1,28 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import UserPageStatsActivityDistributionsTableWrapper from '@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableWrapper';
+import { render, screen } from "@testing-library/react";
+import UserPageStatsActivityDistributionsTableWrapper from "@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableWrapper";
+import { getDistributionsMessage } from "@/components/user/stats/activity/distributions/distributions.messages";
 
-jest.mock('@/components/utils/animation/CommonCardSkeleton', () => () => <div data-testid="skeleton" />);
-jest.mock('@/components/utils/table/paginator/CommonTablePagination', () => (props: any) => <div data-testid="pagination" data-page={props.currentPage} />);
-jest.mock('@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTable', () => (props: any) => <div data-testid="table" data-count={props.items.length} />);
+jest.mock("@/components/utils/animation/CommonCardSkeleton", () => () => (
+  <div data-testid="skeleton" />
+));
+jest.mock(
+  "@/components/utils/table/paginator/CommonTablePagination",
+  () => (props: any) => (
+    <div data-testid="pagination" data-page={props.currentPage} />
+  )
+);
+jest.mock(
+  "@/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTable",
+  () => (props: any) => (
+    <div data-testid="table" data-count={props.items.length} />
+  )
+);
 
-describe('UserPageStatsActivityDistributionsTableWrapper', () => {
-  const profile = { id: 'p' } as any;
+describe("UserPageStatsActivityDistributionsTableWrapper", () => {
+  const profile = { id: "p" } as any;
   const item = { amount: 1 } as any;
 
-  it('shows skeleton during initial loading', () => {
+  it("shows skeleton during initial loading", () => {
     render(
       <UserPageStatsActivityDistributionsTableWrapper
         data={[]}
@@ -22,10 +34,10 @@ describe('UserPageStatsActivityDistributionsTableWrapper', () => {
         setPage={jest.fn()}
       />
     );
-    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument();
   });
 
-  it('renders table and pagination when data exists', () => {
+  it("renders table and pagination when data exists", () => {
     render(
       <UserPageStatsActivityDistributionsTableWrapper
         data={[item]}
@@ -37,11 +49,11 @@ describe('UserPageStatsActivityDistributionsTableWrapper', () => {
         setPage={jest.fn()}
       />
     );
-    expect(screen.getByTestId('table')).toHaveAttribute('data-count', '1');
-    expect(screen.getByTestId('pagination')).toHaveAttribute('data-page', '1');
+    expect(screen.getByTestId("table")).toHaveAttribute("data-count", "1");
+    expect(screen.getByTestId("pagination")).toHaveAttribute("data-page", "1");
   });
 
-  it('shows empty message when list empty', () => {
+  it("shows empty message when list empty", () => {
     render(
       <UserPageStatsActivityDistributionsTableWrapper
         data={[]}
@@ -53,6 +65,8 @@ describe('UserPageStatsActivityDistributionsTableWrapper', () => {
         setPage={jest.fn()}
       />
     );
-    expect(screen.getByText('No distributions found')).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      getDistributionsMessage("user.collected.stats.distributions.empty")
+    );
   });
 });

--- a/__tests__/components/user/stats/activity/tabs/UserPageActivityTabs.test.tsx
+++ b/__tests__/components/user/stats/activity/tabs/UserPageActivityTabs.test.tsx
@@ -2,18 +2,8 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import UserPageActivityTabs from "@/components/user/stats/activity/tabs/UserPageActivityTabs";
 import { USER_PAGE_ACTIVITY_TAB } from "@/components/user/stats/activity/activity.types";
-
-jest.mock("@/components/user/stats/activity/tabs/UserPageActivityTab", () => ({
-  __esModule: true,
-  default: (props: any) => (
-    <button
-      data-testid={props.tab}
-      onClick={() => props.setActiveTab(props.tab)}
-    >
-      {props.tab}
-    </button>
-  ),
-}));
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 
 describe("UserPageActivityTabs", () => {
   it("renders all tabs and handles click", async () => {
@@ -25,13 +15,44 @@ describe("UserPageActivityTabs", () => {
         setActiveTab={setActive}
       />
     );
-    const walletBtn = screen.getByTestId(
-      USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY
-    );
+    expect(
+      screen.getByRole("tablist", {
+        name: t(DEFAULT_LOCALE, "user.collected.stats.activityTabs.listLabel"),
+      })
+    ).toBeInTheDocument();
+    const walletBtn = screen.getByRole("tab", {
+      name: t(
+        DEFAULT_LOCALE,
+        "user.collected.stats.activityTabs.walletActivity"
+      ),
+    });
     expect(walletBtn).toBeInTheDocument();
     await user.click(walletBtn);
     expect(setActive).toHaveBeenCalledWith(
       USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY
     );
+  });
+
+  it("supports arrow-key tab switching", async () => {
+    const user = userEvent.setup();
+    const setActive = jest.fn();
+    render(
+      <UserPageActivityTabs
+        activeTab={USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS}
+        setActiveTab={setActive}
+      />
+    );
+    screen
+      .getByRole("tab", {
+        name: t(
+          DEFAULT_LOCALE,
+          "user.collected.stats.activityTabs.distributions"
+        ),
+      })
+      .focus();
+
+    await user.keyboard("{ArrowRight}");
+
+    expect(setActive).toHaveBeenCalledWith(USER_PAGE_ACTIVITY_TAB.TDH_HISTORY);
   });
 });

--- a/__tests__/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistory.test.tsx
+++ b/__tests__/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistory.test.tsx
@@ -1,31 +1,50 @@
-import { render, screen } from '@testing-library/react';
-import UserPageStatsActivityTDHHistory from '@/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistory';
-import { useQuery } from '@tanstack/react-query';
+import { render, screen } from "@testing-library/react";
+import UserPageStatsActivityTDHHistory from "@/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistory";
+import { getTdhHistoryMessage } from "@/components/user/stats/activity/tdh-history/tdh-history.messages";
+import { useQuery } from "@tanstack/react-query";
 
-jest.mock('@tanstack/react-query');
+jest.mock("@tanstack/react-query");
 
-jest.mock('@/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryCharts', () => ({ __esModule: true, default: () => <div data-testid="charts" /> }));
-jest.mock('@/components/utils/animation/CommonCardSkeleton', () => ({ __esModule: true, default: () => <div data-testid="skeleton" /> }));
+jest.mock(
+  "@/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryCharts",
+  () => ({ __esModule: true, default: () => <div data-testid="charts" /> })
+);
+jest.mock("@/components/utils/animation/CommonCardSkeleton", () => ({
+  __esModule: true,
+  default: () => <div data-testid="skeleton" />,
+}));
 
-describe('UserPageStatsActivityTDHHistory', () => {
+describe("UserPageStatsActivityTDHHistory", () => {
   const mockUseQuery = useQuery as jest.Mock;
-  const profile = { consolidation_key: 'key' } as any;
+  const profile = { consolidation_key: "key" } as any;
 
-  it('shows skeleton while fetching', () => {
+  it("shows skeleton while fetching", () => {
     mockUseQuery.mockReturnValue({ isFetching: true, data: undefined });
     render(<UserPageStatsActivityTDHHistory profile={profile} />);
-    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: getTdhHistoryMessage("user.collected.stats.tdhHistory.title"),
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        getTdhHistoryMessage("user.collected.stats.tdhHistory.loading")
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument();
   });
 
-  it('renders charts when data available', () => {
+  it("renders charts when data available", () => {
     mockUseQuery.mockReturnValue({ isFetching: false, data: [{}] });
     render(<UserPageStatsActivityTDHHistory profile={profile} />);
-    expect(screen.getByTestId('charts')).toBeInTheDocument();
+    expect(screen.getByTestId("charts")).toBeInTheDocument();
   });
 
-  it('renders fallback when no data', () => {
+  it("renders fallback when no data", () => {
     mockUseQuery.mockReturnValue({ isFetching: false, data: [] });
     render(<UserPageStatsActivityTDHHistory profile={profile} />);
-    expect(screen.getByText('No TDH history found')).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      getTdhHistoryMessage("user.collected.stats.tdhHistory.empty")
+    );
   });
 });

--- a/__tests__/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryCharts.test.tsx
+++ b/__tests__/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryCharts.test.tsx
@@ -1,29 +1,45 @@
-import { render, screen } from '@testing-library/react';
-import UserPageStatsActivityTDHHistoryCharts from '@/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryCharts';
-import type { TDHHistory } from '@/entities/ITDH';
+import { render, screen } from "@testing-library/react";
+import UserPageStatsActivityTDHHistoryCharts from "@/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryCharts";
+import { getTdhHistoryMessage } from "@/components/user/stats/activity/tdh-history/tdh-history.messages";
+import type { TDHHistory } from "@/entities/ITDH";
 
-jest.mock('@/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryChart', () => ({
-  __esModule: true,
-  default: (props: any) => <div data-testid="chart">{props.data.title}</div>,
-}));
+jest.mock(
+  "@/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryChart",
+  () => ({
+    __esModule: true,
+    default: (props: any) => (
+      <div aria-label={props.data.ariaLabel} data-testid="chart">
+        {props.data.title}:{props.data.datasets[0].label}:
+        {props.data.labels.join("|")}
+      </div>
+    ),
+  })
+);
 
-describe('UserPageStatsActivityTDHHistoryCharts', () => {
-  it('renders no charts when history is empty', () => {
+describe("UserPageStatsActivityTDHHistoryCharts", () => {
+  it("renders no charts when history is empty", () => {
     render(<UserPageStatsActivityTDHHistoryCharts tdhHistory={[]} />);
-    expect(screen.queryByTestId('chart')).toBeNull();
+    expect(
+      screen.getByRole("list", {
+        name: getTdhHistoryMessage(
+          "user.collected.stats.tdhHistory.chartListLabel"
+        ),
+      })
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("chart")).toBeNull();
   });
 
-  it('creates charts from history data', () => {
+  it("creates charts from history data", () => {
     const history: TDHHistory[] = [
       {
-        date: new Date('2024-01-01'),
+        date: new Date("2024-01-01T12:00:00.000Z"),
         boosted_tdh: 1,
         net_boosted_tdh: 2,
         created_boosted_tdh: 3,
         destroyed_boosted_tdh: 4,
       } as TDHHistory,
       {
-        date: new Date('2024-01-02'),
+        date: new Date("2024-01-02T12:00:00.000Z"),
         boosted_tdh: 2,
         net_boosted_tdh: 3,
         created_boosted_tdh: 4,
@@ -31,8 +47,25 @@ describe('UserPageStatsActivityTDHHistoryCharts', () => {
       } as TDHHistory,
     ];
     render(<UserPageStatsActivityTDHHistoryCharts tdhHistory={history} />);
-    const charts = screen.getAllByTestId('chart');
+    const charts = screen.getAllByTestId("chart");
     expect(charts).toHaveLength(4);
-    expect(charts[0]).toHaveTextContent('Total TDH');
+    expect(charts[0]).toHaveTextContent(
+      getTdhHistoryMessage(
+        "user.collected.stats.tdhHistory.charts.totalTdh.title"
+      )
+    );
+    expect(charts[0]).toHaveTextContent(
+      getTdhHistoryMessage(
+        "user.collected.stats.tdhHistory.charts.totalTdh.totalBoosted"
+      )
+    );
+    expect(charts[0]).toHaveAccessibleName(
+      getTdhHistoryMessage("user.collected.stats.tdhHistory.chartAriaLabel", {
+        title: getTdhHistoryMessage(
+          "user.collected.stats.tdhHistory.charts.totalTdh.title"
+        ),
+      })
+    );
+    expect(charts[0]).toHaveTextContent("Jan 2, 2024|Jan 1, 2024");
   });
 });

--- a/__tests__/components/user/stats/activity/wallet/UserPageStatsActivityWalletFilter.test.tsx
+++ b/__tests__/components/user/stats/activity/wallet/UserPageStatsActivityWalletFilter.test.tsx
@@ -1,12 +1,19 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import UserPageStatsActivityWalletFilter from "@/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilter";
-import { UserPageStatsActivityWalletFilterType } from "@/components/user/stats/activity/wallet/UserPageStatsActivityWallet";
+import { UserPageStatsActivityWalletFilterType } from "@/components/user/stats/activity/wallet/UserPageStatsActivityWallet.types";
+import {
+  getWalletActivityFilterLabel,
+  getWalletActivityFilterOptionLabel,
+  getWalletActivityMessage,
+} from "@/components/user/stats/activity/wallet/wallet-activity.messages";
 
 jest.mock("framer-motion", () => ({
   AnimatePresence: ({ children }: any) => <>{children}</>,
-  motion: { div: ({ children }: any) => <div>{children}</div> },
-  useAnimate: () => [ { current: null }, jest.fn() ],
+  LazyMotion: ({ children }: any) => <>{children}</>,
+  domAnimation: {},
+  m: { div: ({ children }: any) => <div>{children}</div> },
+  useAnimate: () => [{ current: null }, jest.fn()],
 }));
 
 jest.mock("react-use", () => ({
@@ -14,10 +21,6 @@ jest.mock("react-use", () => ({
   useKeyPressEvent: jest.fn(),
   useCss: jest.fn(() => ["", jest.fn()]),
 }));
-
-jest.mock("@/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilterItem", () => (props: any) => (
-  <li data-testid="filter-item" onClick={() => props.onFilter(props.filter)}>{props.title}</li>
-));
 
 describe("UserPageStatsActivityWalletFilter", () => {
   it("opens list and selects filter", async () => {
@@ -29,9 +32,38 @@ describe("UserPageStatsActivityWalletFilter", () => {
         setActiveFilter={setActive}
       />
     );
-    await user.click(screen.getByRole("button"));
-    const option = screen.getAllByTestId("filter-item")[1];
-    await user.click(option);
-    expect(setActive).toHaveBeenCalledWith(Object.values(UserPageStatsActivityWalletFilterType)[1]);
+    const trigger = screen.getByRole("button", {
+      name: getWalletActivityMessage(
+        "user.collected.stats.walletActivity.filterButtonLabel",
+        {
+          filter: getWalletActivityFilterLabel(
+            UserPageStatsActivityWalletFilterType.ALL
+          ),
+        }
+      ),
+    });
+
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(
+      screen.getByRole("list", {
+        name: getWalletActivityMessage(
+          "user.collected.stats.walletActivity.filterOptionsLabel"
+        ),
+      })
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: getWalletActivityFilterOptionLabel(
+          UserPageStatsActivityWalletFilterType.AIRDROPS
+        ),
+      })
+    );
+
+    expect(setActive).toHaveBeenCalledWith(
+      UserPageStatsActivityWalletFilterType.AIRDROPS
+    );
   });
 });

--- a/__tests__/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilterItem.test.tsx
+++ b/__tests__/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilterItem.test.tsx
@@ -1,33 +1,50 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import UserPageStatsActivityWalletFilterItem from '@/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilterItem';
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UserPageStatsActivityWalletFilterItem from "@/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilterItem";
+import { UserPageStatsActivityWalletFilterType } from "@/components/user/stats/activity/wallet/UserPageStatsActivityWallet.types";
+import {
+  getWalletActivityFilterLabel,
+  getWalletActivityFilterOptionLabel,
+} from "@/components/user/stats/activity/wallet/wallet-activity.messages";
 
-enum FilterType { ALL = 'ALL', SENT = 'SENT' }
-
-describe('UserPageStatsActivityWalletFilterItem', () => {
-  it('calls onFilter when clicked', async () => {
+describe("UserPageStatsActivityWalletFilterItem", () => {
+  it("calls onFilter when clicked", async () => {
     const onFilter = jest.fn();
+    const filter = UserPageStatsActivityWalletFilterType.ALL;
     render(
       <UserPageStatsActivityWalletFilterItem
-        filter={FilterType.ALL as any}
-        title="All"
-        activeFilter={FilterType.SENT as any}
+        filter={filter}
+        title={getWalletActivityFilterLabel(filter)}
+        ariaLabel={getWalletActivityFilterOptionLabel(filter)}
+        activeFilter={UserPageStatsActivityWalletFilterType.SALES}
         onFilter={onFilter}
       />
     );
-    await userEvent.click(screen.getByText('All'));
-    expect(onFilter).toHaveBeenCalledWith(FilterType.ALL);
+    const button = screen.getByRole("button", {
+      name: getWalletActivityFilterOptionLabel(filter),
+    });
+
+    expect(button).toHaveAttribute("aria-pressed", "false");
+    await userEvent.click(button);
+    expect(onFilter).toHaveBeenCalledWith(filter);
   });
 
-  it('shows check mark when active', () => {
+  it("shows check mark when active", () => {
+    const filter = UserPageStatsActivityWalletFilterType.ALL;
     const { container } = render(
       <UserPageStatsActivityWalletFilterItem
-        filter={FilterType.ALL as any}
-        title="All"
-        activeFilter={FilterType.ALL as any}
+        filter={filter}
+        title={getWalletActivityFilterLabel(filter)}
+        ariaLabel={getWalletActivityFilterOptionLabel(filter)}
+        activeFilter={filter}
         onFilter={jest.fn()}
       />
     );
-    expect(container.querySelector('svg')).not.toBeNull();
+    expect(
+      screen.getByRole("button", {
+        name: getWalletActivityFilterOptionLabel(filter),
+      })
+    ).toHaveAttribute("aria-pressed", "true");
+    expect(container.querySelector("svg")).not.toBeNull();
   });
 });

--- a/__tests__/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable.test.tsx
+++ b/__tests__/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable.test.tsx
@@ -1,24 +1,86 @@
-import { render, screen } from '@testing-library/react';
-import UserPageStatsActivityWalletTable from '@/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable';
-import type { ApiIdentity } from '@/generated/models/ApiIdentity';
-import type { Transaction } from '@/entities/ITransaction';
+import { render, screen } from "@testing-library/react";
+import type { Transaction } from "@/entities/ITransaction";
+import type { ApiIdentity } from "@/generated/models/ApiIdentity";
+import UserPageStatsActivityWalletTable from "@/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable";
+import { getWalletActivityMessage } from "@/components/user/stats/activity/wallet/wallet-activity.messages";
 
-jest.mock('@/components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRow', () => ({
-  __esModule: true,
-  default: jest.fn(() => <tr data-testid="row" />)
-}));
+jest.mock(
+  "@/components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRow",
+  () => ({
+    __esModule: true,
+    default: jest.fn(() => (
+      <tr>
+        <td data-testid="row" />
+      </tr>
+    )),
+  })
+);
 
-const RowMock = require('@/components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRow').default as jest.Mock;
+const RowMock =
+  require("@/components/user/stats/activity/wallet/table/row/UserPageStatsActivityWalletTableRow")
+    .default as jest.Mock;
 
-describe('UserPageStatsActivityWalletTable', () => {
-  it('renders a row for each transaction', () => {
+describe("UserPageStatsActivityWalletTable", () => {
+  it("renders a row for each transaction", () => {
     const transactions: Transaction[] = [
-      { from_address: '0x1', to_address: '0x2', transaction: 'tx1', token_id: 1, block: 1, transaction_date: new Date(), created_at: new Date(), from_display: '', to_display: '', contract: '', token_count: 1, value: 0, royalties: 0, gas_gwei: 1, gas_price: 1, gas_price_gwei: 1, gas: 1 },
-      { from_address: '0x3', to_address: '0x4', transaction: 'tx2', token_id: 2, block: 2, transaction_date: new Date(), created_at: new Date(), from_display: '', to_display: '', contract: '', token_count: 1, value: 0, royalties: 0, gas_gwei: 1, gas_price: 1, gas_price_gwei: 1, gas: 1 }
+      {
+        from_address: "0x1",
+        to_address: "0x2",
+        transaction: "tx1",
+        token_id: 1,
+        block: 1,
+        transaction_date: new Date(),
+        created_at: new Date(),
+        from_display: "",
+        to_display: "",
+        contract: "",
+        token_count: 1,
+        value: 0,
+        royalties: 0,
+        gas_gwei: 1,
+        gas_price: 1,
+        gas_price_gwei: 1,
+        gas: 1,
+      },
+      {
+        from_address: "0x3",
+        to_address: "0x4",
+        transaction: "tx2",
+        token_id: 2,
+        block: 2,
+        transaction_date: new Date(),
+        created_at: new Date(),
+        from_display: "",
+        to_display: "",
+        contract: "",
+        token_count: 1,
+        value: 0,
+        royalties: 0,
+        gas_gwei: 1,
+        gas_price: 1,
+        gas_price_gwei: 1,
+        gas: 1,
+      },
     ];
-    const profile = { handle: 'alice' } as ApiIdentity;
-    render(<UserPageStatsActivityWalletTable transactions={transactions} profile={profile} memes={[]} nextgenCollections={[]} />);
+    const profile = { handle: "alice" } as ApiIdentity;
+    render(
+      <UserPageStatsActivityWalletTable
+        transactions={transactions}
+        profile={profile}
+        memes={[]}
+        memeLab={[]}
+        nextgenCollections={[]}
+      />
+    );
+
+    expect(
+      screen.getByRole("table", {
+        name: getWalletActivityMessage(
+          "user.collected.stats.walletActivity.tableCaption"
+        ),
+      })
+    ).toBeInTheDocument();
     expect(RowMock).toHaveBeenCalledTimes(2);
-    expect(screen.getAllByTestId('row')).toHaveLength(2);
+    expect(screen.getAllByTestId("row")).toHaveLength(2);
   });
 });

--- a/__tests__/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper.test.tsx
+++ b/__tests__/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper.test.tsx
@@ -1,35 +1,54 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import UserPageStatsActivityWalletTableWrapper from '@/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper';
-import { UserPageStatsActivityWalletFilterType } from '@/components/user/stats/activity/wallet/UserPageStatsActivityWallet';
+import { render, screen } from "@testing-library/react";
+import UserPageStatsActivityWalletTableWrapper from "@/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper";
+import { UserPageStatsActivityWalletFilterType } from "@/components/user/stats/activity/wallet/UserPageStatsActivityWallet.types";
+import { getWalletActivityEmptyMessage } from "@/components/user/stats/activity/wallet/wallet-activity.messages";
 
-jest.mock('@/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilter', () => (props: any) => (
-  <div data-testid="filter" data-active={props.activeFilter} />
+jest.mock(
+  "@/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilter",
+  () => (props: any) => (
+    <div data-testid="filter" data-active={props.activeFilter} />
+  )
+);
+
+jest.mock(
+  "@/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable",
+  () => () => <div data-testid="table" />
+);
+
+jest.mock(
+  "@/components/utils/table/paginator/CommonTablePagination",
+  () => (props: any) => (
+    <div
+      data-testid="pagination"
+      data-page={props.currentPage}
+      data-total={props.totalPages}
+    />
+  )
+);
+
+jest.mock("@/components/utils/animation/CommonCardSkeleton", () => () => (
+  <div data-testid="skeleton" />
 ));
 
-jest.mock('@/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable', () => () => <div data-testid="table" />);
+jest.mock(
+  "@/components/distribution-plan-tool/common/CircleLoader",
+  () => () => <div data-testid="loader" />
+);
 
-jest.mock('@/components/utils/table/paginator/CommonTablePagination', () => (props: any) => (
-  <div data-testid="pagination" data-page={props.currentPage} data-total={props.totalPages} />
-));
-
-jest.mock('@/components/utils/animation/CommonCardSkeleton', () => () => <div data-testid="skeleton" />);
-
-jest.mock('@/components/distribution-plan-tool/common/CircleLoader', () => () => <div data-testid="loader" />);
-
-describe('UserPageStatsActivityWalletTableWrapper', () => {
-  const profile = { id: 'p' } as any;
+describe("UserPageStatsActivityWalletTableWrapper", () => {
+  const profile = { id: "p" } as any;
   const meme = { id: 1 } as any;
   const collection = { id: 1 } as any;
   const tx = { id: 1 } as any;
 
-  it('shows skeleton during initial load', () => {
+  it("shows skeleton during initial load", () => {
     render(
       <UserPageStatsActivityWalletTableWrapper
         filter={UserPageStatsActivityWalletFilterType.ALL}
         profile={profile}
         transactions={[]}
         memes={[]}
+        memeLab={[]}
         nextgenCollections={[]}
         totalPages={1}
         page={1}
@@ -39,16 +58,17 @@ describe('UserPageStatsActivityWalletTableWrapper', () => {
         onActiveFilter={jest.fn()}
       />
     );
-    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument();
   });
 
-  it('renders table and pagination when data available', () => {
+  it("renders table and pagination when data available", () => {
     render(
       <UserPageStatsActivityWalletTableWrapper
         filter={UserPageStatsActivityWalletFilterType.ALL}
         profile={profile}
         transactions={[tx]}
         memes={[meme]}
+        memeLab={[]}
         nextgenCollections={[collection]}
         totalPages={2}
         page={1}
@@ -58,19 +78,23 @@ describe('UserPageStatsActivityWalletTableWrapper', () => {
         onActiveFilter={jest.fn()}
       />
     );
-    expect(screen.getByTestId('filter')).toHaveAttribute('data-active', UserPageStatsActivityWalletFilterType.ALL);
-    expect(screen.getByTestId('loader')).toBeInTheDocument();
-    expect(screen.getByTestId('table')).toBeInTheDocument();
-    expect(screen.getByTestId('pagination')).toHaveAttribute('data-total', '2');
+    expect(screen.getByTestId("filter")).toHaveAttribute(
+      "data-active",
+      UserPageStatsActivityWalletFilterType.ALL
+    );
+    expect(screen.getByTestId("loader")).toBeInTheDocument();
+    expect(screen.getByTestId("table")).toBeInTheDocument();
+    expect(screen.getByTestId("pagination")).toHaveAttribute("data-total", "2");
   });
 
-  it('shows no data message when list empty', () => {
+  it("shows no data message when list empty", () => {
     render(
       <UserPageStatsActivityWalletTableWrapper
         filter={UserPageStatsActivityWalletFilterType.MINTS}
         profile={profile}
         transactions={[]}
         memes={[]}
+        memeLab={[]}
         nextgenCollections={[]}
         totalPages={1}
         page={1}
@@ -80,6 +104,8 @@ describe('UserPageStatsActivityWalletTableWrapper', () => {
         onActiveFilter={jest.fn()}
       />
     );
-    expect(screen.getByText('No mints')).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      getWalletActivityEmptyMessage(UserPageStatsActivityWalletFilterType.MINTS)
+    );
   });
 });

--- a/__tests__/components/utils/followers/Follower.test.tsx
+++ b/__tests__/components/utils/followers/Follower.test.tsx
@@ -1,11 +1,21 @@
-import type { ReactElement } from "react";
+import React, { type ReactElement } from "react";
 import { render, screen } from "@testing-library/react";
 import Follower from "@/components/utils/followers/Follower";
 import { AuthContext } from "@/components/auth/Auth";
 
 jest.mock("next/link", () => ({
   __esModule: true,
-  default: ({ href, children }: any) => <a href={href}>{children}</a>,
+  default: ({ href, children, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ alt, fill, sizes, unoptimized, ...props }: any) =>
+    React.createElement("img", { alt: alt ?? "", ...props }),
 }));
 
 jest.mock("@/helpers/Helpers", () => ({ cicToType: jest.fn(() => "UNKNOWN") }));
@@ -23,7 +33,14 @@ jest.mock("@/components/user/utils/UserFollowBtn", () => ({
 }));
 
 const baseFollower: any = {
-  identity: { handle: "alice", level: 5, cic: 0, pfp: "pic.png" },
+  identity: {
+    id: "1",
+    handle: "alice",
+    level: 5,
+    cic: 0,
+    pfp: "pic.png",
+    primary_address: "0xalice",
+  },
 };
 
 const renderWithAuth = (ui: ReactElement, connectedProfile: any = null) =>
@@ -47,14 +64,52 @@ const renderWithAuth = (ui: ReactElement, connectedProfile: any = null) =>
 
 test("renders follower info with image", () => {
   render(<Follower follower={baseFollower} />);
-  expect(screen.getByRole("link")).toHaveAttribute("href", "/alice");
-  expect(screen.getByAltText("alice's profile")).toBeInTheDocument();
+  expect(
+    screen.getByRole("link", { name: "View alice's profile" })
+  ).toHaveAttribute("href", "/alice");
+  expect(screen.getByAltText("alice's profile image")).toBeInTheDocument();
   expect(screen.getByTestId("cic")).toHaveTextContent("5");
 });
 
+test.each([
+  ["null", null],
+  ["undefined", undefined],
+])(
+  "falls back to primary address when follower handle is %s",
+  (_label, missingHandle) => {
+    const follower = {
+      identity: {
+        id: "3",
+        handle: missingHandle,
+        level: 2,
+        cic: 0,
+        pfp: "pic.png",
+        primary_address: "0xabc",
+      },
+    } as any;
+
+    render(<Follower follower={follower} />);
+
+    const profileLink = screen.getByRole("link", {
+      name: "View 0xabc's profile",
+    });
+    expect(profileLink).toHaveAttribute("href", "/0xabc");
+    expect(profileLink).toHaveAttribute("aria-label", "View 0xabc's profile");
+    expect(profileLink).toHaveTextContent("0xabc");
+    expect(screen.getByAltText("0xabc's profile image")).toBeInTheDocument();
+  }
+);
+
 test("shows placeholder when no pfp", () => {
   const follower = {
-    identity: { handle: "bob", level: 1, cic: 0, pfp: "" },
+    identity: {
+      id: "2",
+      handle: "bob",
+      level: 1,
+      cic: 0,
+      pfp: "",
+      primary_address: "0xbob",
+    },
   } as any;
   const { container } = render(<Follower follower={follower} />);
   expect(container.querySelector("img")).toBeNull();

--- a/__tests__/components/utils/followers/FollowersList.test.tsx
+++ b/__tests__/components/utils/followers/FollowersList.test.tsx
@@ -32,6 +32,7 @@ describe('FollowersList', () => {
       { identity: { id: '2', handle: 'b' } } as any,
     ];
     render(<FollowersList followers={followers} />);
+    expect(screen.getByRole('list', { name: 'Followers' })).toBeInTheDocument();
     expect(Follower).toHaveBeenCalledTimes(2);
     expect(screen.getAllByTestId('follower').length).toBe(2);
   });

--- a/__tests__/components/utils/followers/FollowersListWrapper.test.tsx
+++ b/__tests__/components/utils/followers/FollowersListWrapper.test.tsx
@@ -21,6 +21,7 @@ describe('FollowersListWrapper', () => {
     const cb = jest.fn();
     render(<FollowersListWrapper followers={[{ id: '1' } as any]} loading={true} onBottomIntersection={cb} />);
     expect(screen.getByTestId('list').textContent).toBe('1');
+    expect(screen.getByRole('status', { name: 'Loading followers' })).toBeInTheDocument();
     expect(screen.getByTestId('loader')).toBeInTheDocument();
     expect(cb).toHaveBeenCalledWith(true);
   });

--- a/__tests__/i18n/messages.test.ts
+++ b/__tests__/i18n/messages.test.ts
@@ -138,6 +138,64 @@ describe("frontend i18n helpers", () => {
     expect(t("fr-FR", "user.collected.stats.boostBreakdown.tableCaption")).toBe(
       t("en-US", "user.collected.stats.boostBreakdown.tableCaption")
     );
+    expect(t("es-ES", "user.collected.stats.activityOverview.title")).toBe(
+      t("en-US", "user.collected.stats.activityOverview.title")
+    );
+    expect(
+      t("de-DE", "user.collected.stats.activityOverview.seasonLabel", {
+        seasonNumber: 1,
+      })
+    ).toBe(
+      t("en-US", "user.collected.stats.activityOverview.seasonLabel", {
+        seasonNumber: 1,
+      })
+    );
+    expect(t("fr-FR", "user.collected.stats.activityTabs.walletActivity")).toBe(
+      t("en-US", "user.collected.stats.activityTabs.walletActivity")
+    );
+    expect(t("de-DE", "user.collected.stats.activityTabs.listLabel")).toBe(
+      t("en-US", "user.collected.stats.activityTabs.listLabel")
+    );
+    expect(t("fr-FR", "user.collected.stats.walletActivity.title")).toBe(
+      t("en-US", "user.collected.stats.walletActivity.title")
+    );
+    expect(
+      t("de-DE", "user.collected.stats.walletActivity.filterButtonLabel", {
+        filter: "All",
+      })
+    ).toBe("Wallet activity filter: All");
+    expect(t("es-ES", "user.collected.stats.walletActivity.empty.mints")).toBe(
+      t("en-US", "user.collected.stats.walletActivity.empty.mints")
+    );
+    expect(t("fr-FR", "user.collected.stats.distributions.title")).toBe(
+      t("en-US", "user.collected.stats.distributions.title")
+    );
+    expect(
+      t("de-DE", "user.collected.stats.distributions.tokenLinkAriaLabel", {
+        collection: "The Memes",
+        tokenId: 1,
+      })
+    ).toBe("View The Memes token #1");
+    expect(t("fr-FR", "user.collected.stats.tdhHistory.title")).toBe(
+      t("en-US", "user.collected.stats.tdhHistory.title")
+    );
+    expect(
+      t("es-ES", "user.collected.stats.tdhHistory.chartAriaLabel", {
+        title: "Total TDH",
+      })
+    ).toBe("Total TDH chart");
+    expect(t("fr-FR", "user.profile.tabs.navigationLabel")).toBe(
+      t("en-US", "user.profile.tabs.navigationLabel")
+    );
+    expect(t("de-DE", "user.profile.tabs.badges.beta")).toBe("Beta");
+    expect(t("fr-FR", "followers.modal.title")).toBe(
+      t("en-US", "followers.modal.title")
+    );
+    expect(
+      t("de-DE", "followers.profile.linkAriaLabel", {
+        handle: "alice",
+      })
+    ).toBe("View alice's profile");
     expect(t("es-ES", "user.collected.networkCards.empty")).toBe(
       t("en-US", "user.collected.networkCards.empty")
     );

--- a/__tests__/i18n/messages.test.ts
+++ b/__tests__/i18n/messages.test.ts
@@ -126,6 +126,18 @@ describe("frontend i18n helpers", () => {
         total: "2",
       })
     ).toBe("1 / 2");
+    expect(
+      t("de-DE", "user.collected.stats.boostBreakdown.versionLink", {
+        version: "1.4",
+      })
+    ).toBe(
+      t("en-US", "user.collected.stats.boostBreakdown.versionLink", {
+        version: "1.4",
+      })
+    );
+    expect(t("fr-FR", "user.collected.stats.boostBreakdown.tableCaption")).toBe(
+      t("en-US", "user.collected.stats.boostBreakdown.tableCaption")
+    );
     expect(t("es-ES", "user.collected.networkCards.empty")).toBe(
       t("en-US", "user.collected.networkCards.empty")
     );

--- a/components/user/collected/stats/useCollectedStatsData.ts
+++ b/components/user/collected/stats/useCollectedStatsData.ts
@@ -23,7 +23,7 @@ type CollectedStatsFetchState = {
   readonly shouldFetchBalanceMemes: boolean;
 };
 
-type CollectedStatsTdh = ConsolidatedTDH | TDH | undefined;
+type CollectedStatsTdh = ConsolidatedTDH | TDH;
 
 const DETAILS_DATA_STALE_TIME = 60_000;
 
@@ -41,10 +41,11 @@ const fetchStatsQuery = async <T>({
   }
 
   try {
-    return await commonApiFetch<T>({
+    const result = await commonApiFetch<T | undefined>({
       endpoint,
       signal,
     });
+    return result ?? fallback;
   } catch (error: unknown) {
     if (isAbortError(error)) {
       throw error;
@@ -119,7 +120,7 @@ const buildCollectedStatsDataResult = ({
   readonly shouldFetchSeasons: boolean;
   readonly shouldFetchTdh: boolean;
   readonly statsPath: string | null;
-  readonly tdh: CollectedStatsTdh;
+  readonly tdh: CollectedStatsTdh | undefined;
 }): UseCollectedStatsDataResult => ({
   statsPath,
   collectedStats: shouldFetchCollectedStats
@@ -162,19 +163,17 @@ export function useCollectedStatsData({
     statsPath,
   });
 
-  const { data: fetchedCollectedStats } = useQuery<
-    ApiCollectedStats | undefined
-  >({
+  const { data: fetchedCollectedStats } = useQuery<ApiCollectedStats | null>({
     queryKey: [STATS_QUERY_KEY, "collected-stats", collectedStatsIdentityKey],
     enabled: shouldFetchCollectedStats,
     retry: false,
     queryFn: ({ signal }) =>
-      fetchStatsQuery<ApiCollectedStats | undefined>({
+      fetchStatsQuery<ApiCollectedStats | null>({
         endpoint:
           collectedStatsIdentityKey === null
             ? null
             : `collected-stats/${encodeURIComponent(collectedStatsIdentityKey)}`,
-        fallback: undefined,
+        fallback: null,
         signal,
       }),
   });
@@ -192,28 +191,28 @@ export function useCollectedStatsData({
       }),
   });
 
-  const { data: fetchedTdh } = useQuery<CollectedStatsTdh>({
+  const { data: fetchedTdh } = useQuery<CollectedStatsTdh | null>({
     queryKey: [STATS_QUERY_KEY, "tdh", statsPath],
     enabled: shouldFetchTdh,
     retry: false,
     staleTime: DETAILS_DATA_STALE_TIME,
     queryFn: ({ signal }) =>
-      fetchStatsQuery<ConsolidatedTDH | TDH | undefined>({
+      fetchStatsQuery<CollectedStatsTdh | null>({
         endpoint: statsPath === null ? null : `tdh/${statsPath}`,
-        fallback: undefined,
+        fallback: null,
         signal,
       }),
   });
 
-  const { data: fetchedOwnerBalance } = useQuery<OwnerBalance | undefined>({
+  const { data: fetchedOwnerBalance } = useQuery<OwnerBalance | null>({
     queryKey: [STATS_QUERY_KEY, "owner-balance", statsPath],
     enabled: shouldFetchOwnerBalance,
     retry: false,
     staleTime: DETAILS_DATA_STALE_TIME,
     queryFn: ({ signal }) =>
-      fetchStatsQuery<OwnerBalance | undefined>({
+      fetchStatsQuery<OwnerBalance | null>({
         endpoint: statsPath === null ? null : `owners-balances/${statsPath}`,
-        fallback: undefined,
+        fallback: null,
         signal,
       }),
   });
@@ -234,9 +233,9 @@ export function useCollectedStatsData({
 
   return buildCollectedStatsDataResult({
     balanceMemes: fetchedBalanceMemes,
-    collectedStats: fetchedCollectedStats,
+    collectedStats: fetchedCollectedStats ?? undefined,
     initialStatsData,
-    ownerBalance: fetchedOwnerBalance,
+    ownerBalance: fetchedOwnerBalance ?? undefined,
     seasons: fetchedSeasons,
     shouldFetchBalanceMemes,
     shouldFetchCollectedStats,
@@ -244,6 +243,6 @@ export function useCollectedStatsData({
     shouldFetchSeasons,
     shouldFetchTdh,
     statsPath,
-    tdh: fetchedTdh,
+    tdh: fetchedTdh ?? undefined,
   });
 }

--- a/components/user/followers/UserPageFollowersModal.tsx
+++ b/components/user/followers/UserPageFollowersModal.tsx
@@ -1,5 +1,6 @@
 import MobileWrapperDialog from "@/components/mobile-wrapper-dialog/MobileWrapperDialog";
 import FollowersListWrapper from "@/components/utils/followers/FollowersListWrapper";
+import { getFollowersMessage } from "@/components/utils/followers/followers.messages";
 import useFollowersList from "@/hooks/useFollowersList";
 
 export default function UserPageFollowersModal({
@@ -18,7 +19,7 @@ export default function UserPageFollowersModal({
 
   return (
     <MobileWrapperDialog
-      title="Followers"
+      title={getFollowersMessage("followers.modal.title")}
       isOpen={isOpen}
       onClose={onClose}
       tall

--- a/components/user/layout/UserPageLayout.tsx
+++ b/components/user/layout/UserPageLayout.tsx
@@ -1,9 +1,18 @@
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
-import type { ReactNode } from "react";
+import { Suspense, type ReactNode } from "react";
 import UserPageHeader from "../user-page-header/UserPageHeader";
 import UserPageClientHydrator from "./UserPageClientHydrator";
 import UserPageDropModal from "./UserPageDropModal";
 import UserPageTabs from "./UserPageTabs";
+
+function UserPageTabsFallback() {
+  return (
+    <div
+      aria-hidden="true"
+      className="tw-min-h-[3.5rem] tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-700"
+    />
+  );
+}
 
 export default function UserPageLayout({
   profile: initialProfile,
@@ -32,7 +41,9 @@ export default function UserPageLayout({
           fallbackMainAddress={mainAddress}
         />
         <div className="tw-mx-auto tw-px-4 sm:tw-px-6 md:tw-px-8">
-          <UserPageTabs initialProfile={initialProfile} />
+          <Suspense fallback={<UserPageTabsFallback />}>
+            <UserPageTabs initialProfile={initialProfile} />
+          </Suspense>
           <div className="tw-mt-6 lg:tw-mt-8">{children}</div>
         </div>
       </div>

--- a/components/user/layout/UserPageTab.tsx
+++ b/components/user/layout/UserPageTab.tsx
@@ -3,10 +3,7 @@
 import Link from "next/link";
 import { useParams, useSearchParams } from "next/navigation";
 import { useEffect, useRef } from "react";
-import type {
-  UserPageTabConfig,
-  UserPageTabKey,
-} from "./userTabs.config";
+import type { UserPageTabConfig, UserPageTabKey } from "./userTabs.config";
 
 interface UserPageTabProps {
   readonly tab: UserPageTabConfig;
@@ -35,6 +32,7 @@ export default function UserPageTab({
   const classes = isActive ? activeClasses : inActiveClasses;
 
   const ref = useRef<HTMLAnchorElement>(null);
+  const linkLabel = tab.badge ? `${tab.title} ${tab.badge}` : tab.title;
 
   const isVisibleInViewportSide = () => {
     if (!parentRef.current || !ref.current) {
@@ -70,11 +68,14 @@ export default function UserPageTab({
       }}
       className={`${
         isActive ? "tw-pointer-events-none" : ""
-      }  tw-no-underline tw-leading-4 tw-p-0 tw-text-base tw-font-semibold`}>
+      } tw-p-0 tw-text-base tw-font-semibold tw-leading-4 tw-no-underline`}
+      aria-current={isActive ? "page" : undefined}
+      aria-label={linkLabel}
+    >
       <div className={classes}>
         {tab.title}
         {tab.badge && (
-          <span className="tw-ml-1 tw-rounded-full tw-bg-primary-300/20 tw-px-1.5 tw-py-0.5 tw-text-[0.625rem] tw-font-bold tw-uppercase tw-leading-none tw-text-primary-400 tw-tracking-wider">
+          <span className="tw-ml-1 tw-rounded-full tw-bg-primary-300/20 tw-px-1.5 tw-py-0.5 tw-text-[0.625rem] tw-font-bold tw-uppercase tw-leading-none tw-tracking-wider tw-text-primary-400">
             {tab.badge}
           </span>
         )}

--- a/components/user/layout/UserPageTabs.tsx
+++ b/components/user/layout/UserPageTabs.tsx
@@ -37,6 +37,7 @@ import {
 } from "./userTabs.config";
 import { shouldHideSubscriptions } from "./userPageVisibility";
 import { shouldDelayUserPageBrainRedirect } from "./userPageBrainAccess";
+import { getUserProfileTabsMessage } from "./user-tabs.messages";
 
 const DEFAULT_TAB = DEFAULT_USER_PAGE_TAB;
 const subscribeToClientRender = () => () => undefined;
@@ -245,7 +246,7 @@ export default function UserPageTabs({
     if (!container) return;
 
     checkScroll();
-    container.addEventListener("scroll", checkScroll);
+    container.addEventListener("scroll", checkScroll, { passive: true });
     window.addEventListener("resize", checkScroll);
 
     let resizeObserver: ResizeObserver | null = null;
@@ -290,16 +291,19 @@ export default function UserPageTabs({
   };
 
   return (
-    <div className="tw-relative tw-overflow-hidden tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-700">
+    <nav
+      aria-label={getUserProfileTabsMessage(
+        "user.profile.tabs.navigationLabel"
+      )}
+      className="tw-relative tw-overflow-hidden tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-700"
+    >
       <div
         ref={scrollContainerRef}
         className="tw-w-full tw-overflow-x-auto tw-overflow-y-hidden [-ms-overflow-style:none] [scrollbar-width:none] [touch-action:pan-x] [&::-webkit-scrollbar]:tw-hidden"
-        aria-label="Tabs"
       >
         <div
           ref={contentContainerRef}
           className="-tw-mb-px tw-flex tw-min-w-max tw-gap-x-3 lg:tw-gap-x-4"
-          aria-label="Tabs"
         >
           {visibleTabs.map((tabConfig) => (
             <UserPageTab
@@ -316,7 +320,9 @@ export default function UserPageTabs({
           <div className="tw-pointer-events-none tw-absolute tw-bottom-0 tw-left-0 tw-top-0 tw-z-10 tw-w-24 tw-bg-gradient-to-r tw-from-black tw-via-black/40 tw-to-black/0" />
           <button
             onClick={scrollLeft}
-            aria-label="Scroll tabs left"
+            aria-label={getUserProfileTabsMessage(
+              "user.profile.tabs.scrollLeft"
+            )}
             className="tw-group tw-absolute tw-left-0 tw-top-1/2 tw-z-20 tw-inline-flex tw-h-10 tw-w-10 tw--translate-y-1/2 tw-items-center tw-justify-start tw-border-none tw-bg-transparent tw-p-0 tw-outline-none"
           >
             <FontAwesomeIcon
@@ -331,7 +337,9 @@ export default function UserPageTabs({
           <div className="tw-pointer-events-none tw-absolute tw-bottom-0 tw-right-0 tw-top-0 tw-z-10 tw-w-24 tw-bg-gradient-to-l tw-from-black tw-via-black/40 tw-to-black/0" />
           <button
             onClick={scrollRight}
-            aria-label="Scroll tabs right"
+            aria-label={getUserProfileTabsMessage(
+              "user.profile.tabs.scrollRight"
+            )}
             className="tw-group tw-absolute tw-right-0 tw-top-1/2 tw-z-20 tw-inline-flex tw-h-10 tw-w-10 tw--translate-y-1/2 tw-items-center tw-justify-end tw-border-none tw-bg-transparent tw-p-0 tw-outline-none"
           >
             <FontAwesomeIcon
@@ -341,6 +349,6 @@ export default function UserPageTabs({
           </button>
         </>
       )}
-    </div>
+    </nav>
   );
 }

--- a/components/user/layout/user-tabs.messages.ts
+++ b/components/user/layout/user-tabs.messages.ts
@@ -1,0 +1,16 @@
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
+
+type UserProfileTabsMessageKey = Extract<
+  MessageKey,
+  `user.profile.tabs.${string}`
+>;
+
+type MessageParams = Record<string, string | number>;
+
+export function getUserProfileTabsMessage(
+  key: UserProfileTabsMessageKey,
+  params: MessageParams = {}
+): string {
+  return t(DEFAULT_LOCALE, key, params);
+}

--- a/components/user/layout/userTabs.config.ts
+++ b/components/user/layout/userTabs.config.ts
@@ -1,3 +1,5 @@
+import { getUserProfileTabsMessage } from "./user-tabs.messages";
+
 export type UserPageVisibilityContext = {
   readonly showWaves: boolean;
   readonly hasProfileWave: boolean;
@@ -7,10 +9,10 @@ export type UserPageVisibilityContext = {
 
 type UserPageTabDefinition = {
   readonly id: string;
-  readonly title: string;
+  readonly titleKey: Parameters<typeof getUserProfileTabsMessage>[0];
   readonly route: string;
-  readonly metaLabel?: string | undefined;
-  readonly badge?: string | undefined;
+  readonly metaLabelKey?: Parameters<typeof getUserProfileTabsMessage>[0];
+  readonly badgeKey?: Parameters<typeof getUserProfileTabsMessage>[0];
   readonly isVisible?:
     | ((context: UserPageVisibilityContext) => boolean)
     | undefined;
@@ -19,41 +21,41 @@ type UserPageTabDefinition = {
 const TAB_DEFINITIONS = [
   {
     id: "rep",
-    title: "Identity",
+    titleKey: "user.profile.tabs.identity",
     route: "",
   },
   {
     id: "brain",
-    title: "Brain",
+    titleKey: "user.profile.tabs.brain",
     route: "brain",
     isVisible: ({ showWaves }: UserPageVisibilityContext) => showWaves,
   },
   {
     id: "waves",
-    title: "Curation",
+    titleKey: "user.profile.tabs.curation",
     route: "curations",
   },
   {
     id: "collected",
-    title: "Collected",
+    titleKey: "user.profile.tabs.collected",
     route: "collected",
   },
   {
     id: "xtdh",
-    title: "xTDH",
+    titleKey: "user.profile.tabs.xtdh",
     route: "xtdh",
-    badge: "Beta",
+    badgeKey: "user.profile.tabs.badges.beta",
   },
   {
     id: "subscriptions",
-    title: "Subscriptions",
+    titleKey: "user.profile.tabs.subscriptions",
     route: "subscriptions",
     isVisible: ({ hideSubscriptions }: UserPageVisibilityContext) =>
       !hideSubscriptions,
   },
   {
     id: "proxy",
-    title: "Proxy",
+    titleKey: "user.profile.tabs.proxy",
     route: "proxy",
     isVisible: ({ isOwnProfile }: UserPageVisibilityContext) => isOwnProfile,
   },
@@ -66,15 +68,19 @@ export type UserPageTabKey = (typeof TAB_DEFINITIONS)[number]["id"];
 
 export type UserPageTabConfig = Omit<
   UserPageTabDefinition,
-  "id" | "metaLabel"
+  "id" | "titleKey" | "metaLabelKey" | "badgeKey"
 > & {
   readonly id: UserPageTabKey;
+  readonly title: string;
   readonly metaLabel: string;
+  readonly badge?: string | undefined;
 };
 
 export const USER_PAGE_TABS = USER_PAGE_TAB_DEFINITIONS.map((tab) => ({
   ...tab,
-  metaLabel: tab.metaLabel ?? tab.title,
+  title: getUserProfileTabsMessage(tab.titleKey),
+  metaLabel: getUserProfileTabsMessage(tab.metaLabelKey ?? tab.titleKey),
+  badge: tab.badgeKey ? getUserProfileTabsMessage(tab.badgeKey) : undefined,
 })) as readonly UserPageTabConfig[];
 
 export const USER_PAGE_TAB_MAP: Record<UserPageTabKey, UserPageTabConfig> =

--- a/components/user/stats/UserPageStatsActivityOverview.tsx
+++ b/components/user/stats/UserPageStatsActivityOverview.tsx
@@ -1,26 +1,227 @@
 "use client";
 
 import type {
-    AggregatedActivity,
-    AggregatedActivityMemes,
+  AggregatedActivity,
+  AggregatedActivityMemes,
 } from "@/entities/IAggregatedActivity";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
-import { numberWithCommas } from "@/helpers/Helpers";
+import { formatInteger, formatNumber } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
 import { commonApiFetch } from "@/services/api/common-api";
 import { Fragment, useEffect, useState } from "react";
 import { Accordion, Col, Container, Row, Table } from "react-bootstrap";
 import { getStatsPath } from "./userPageStats.helpers";
 import styles from "./UserPageStats.module.scss";
 import {
-    UserPageStatsTableHead,
-    UserPageStatsTableHr,
+  UserPageStatsTableHead,
+  UserPageStatsTableHr,
 } from "./UserPageStatsTableShared";
 
-function printEthValue(value: number | undefined) {
-  if (value === undefined) {
-    return "-";
+type ActivityOverviewMessageKey = Extract<
+  MessageKey,
+  `user.collected.stats.activityOverview.${string}`
+>;
+
+type NumericAggregatedActivityField = {
+  [Field in keyof AggregatedActivity]: AggregatedActivity[Field] extends number
+    ? Field
+    : never;
+}[keyof AggregatedActivity];
+type NumericAggregatedActivityMemesField = {
+  [Field in keyof AggregatedActivityMemes]: AggregatedActivityMemes[Field] extends number
+    ? Field
+    : never;
+}[keyof AggregatedActivityMemes];
+type ActivityValueType = "integer" | "eth";
+type OverviewFieldRoot =
+  | "airdrops"
+  | "transfers_in"
+  | "primary_purchases_count"
+  | "primary_purchases_value"
+  | "secondary_purchases_count"
+  | "secondary_purchases_value"
+  | "transfers_out"
+  | "burns"
+  | "sales_count"
+  | "sales_value";
+
+interface OverviewRowConfig {
+  readonly labelKey: ActivityOverviewMessageKey;
+  readonly valueType: ActivityValueType;
+  readonly fields: readonly [
+    NumericAggregatedActivityField,
+    NumericAggregatedActivityField,
+    NumericAggregatedActivityField,
+    NumericAggregatedActivityField,
+    NumericAggregatedActivityField,
+  ];
+}
+
+interface SeasonColumnConfig {
+  readonly labelKey: ActivityOverviewMessageKey;
+  readonly valueType: ActivityValueType;
+  readonly field: NumericAggregatedActivityMemesField;
+}
+
+const COLLECTION_FIELD_SUFFIXES = [
+  "",
+  "_memes",
+  "_nextgen",
+  "_gradients",
+  "_memelab",
+] as const;
+
+function collectionFields(
+  root: OverviewFieldRoot
+): OverviewRowConfig["fields"] {
+  return COLLECTION_FIELD_SUFFIXES.map(
+    (suffix) => `${root}${suffix}`
+  ) as unknown as OverviewRowConfig["fields"];
+}
+
+function overviewRow(
+  labelKey: ActivityOverviewMessageKey,
+  valueType: ActivityValueType,
+  root: OverviewFieldRoot
+): OverviewRowConfig {
+  return { labelKey, valueType, fields: collectionFields(root) };
+}
+
+function seasonColumn(
+  labelKey: ActivityOverviewMessageKey,
+  valueType: ActivityValueType,
+  field: NumericAggregatedActivityMemesField
+): SeasonColumnConfig {
+  return { labelKey, valueType, field };
+}
+
+const OVERVIEW_ROW_GROUPS: readonly (readonly OverviewRowConfig[])[] = [
+  [
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.airdrops",
+      "integer",
+      "airdrops"
+    ),
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.transfersIn",
+      "integer",
+      "transfers_in"
+    ),
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.mints",
+      "integer",
+      "primary_purchases_count"
+    ),
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.mintsEth",
+      "eth",
+      "primary_purchases_value"
+    ),
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.purchases",
+      "integer",
+      "secondary_purchases_count"
+    ),
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.purchasesEth",
+      "eth",
+      "secondary_purchases_value"
+    ),
+  ],
+  [
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.transfersOut",
+      "integer",
+      "transfers_out"
+    ),
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.burns",
+      "integer",
+      "burns"
+    ),
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.sales",
+      "integer",
+      "sales_count"
+    ),
+    overviewRow(
+      "user.collected.stats.activityOverview.rows.salesEth",
+      "eth",
+      "sales_value"
+    ),
+  ],
+];
+
+const SEASON_ACTIVITY_COLUMNS: readonly SeasonColumnConfig[] = [
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.transfersIn",
+    "integer",
+    "transfers_in"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.airdrops",
+    "integer",
+    "airdrops"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.mints",
+    "integer",
+    "primary_purchases_count"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.mintsEth",
+    "eth",
+    "primary_purchases_value"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.purchases",
+    "integer",
+    "secondary_purchases_count"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.purchasesEth",
+    "eth",
+    "secondary_purchases_value"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.transfersOut",
+    "integer",
+    "transfers_out"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.burns",
+    "integer",
+    "burns"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.sales",
+    "integer",
+    "sales_count"
+  ),
+  seasonColumn(
+    "user.collected.stats.activityOverview.rows.salesEth",
+    "eth",
+    "sales_value"
+  ),
+];
+
+function activityMessage(
+  key: ActivityOverviewMessageKey,
+  params: Record<string, string | number> = {}
+): string {
+  return t(DEFAULT_LOCALE, key, params);
+}
+
+function formatActivityValue(
+  value: number | undefined,
+  valueType: ActivityValueType
+): string {
+  if (valueType === "eth") {
+    return formatNumber(DEFAULT_LOCALE, value, { maximumFractionDigits: 2 });
   }
-  return numberWithCommas(Math.round(value * 100) / 100);
+
+  return formatInteger(DEFAULT_LOCALE, value);
 }
 
 export default function UserPageStatsActivityOverview({
@@ -70,9 +271,9 @@ export default function UserPageStatsActivityOverview({
 
   return (
     <div className="pt-2 pb-2">
-      <div className="tw-flex pt-2 pb-2">
+      <div className="pt-2 pb-2 tw-flex">
         <h3 className="tw-mb-0 tw-text-lg tw-font-semibold tw-text-iron-100">
-          Activity Overview
+          {activityMessage("user.collected.stats.activityOverview.title")}
         </h3>
       </div>
       <div className="pt-2 pb-2">
@@ -85,7 +286,6 @@ export default function UserPageStatsActivityOverview({
   );
 }
 
-
 function UserPageStatsActivityOverviewTotals({
   activity,
 }: {
@@ -95,247 +295,33 @@ function UserPageStatsActivityOverviewTotals({
     <Accordion>
       <Accordion.Item defaultChecked={true} eventKey={"0"}>
         <Accordion.Button className={styles["collectedAccordionButton"]}>
-          <b>Overview</b>
+          <b>
+            {activityMessage("user.collected.stats.activityOverview.overview")}
+          </b>
         </Accordion.Button>
         <Accordion.Body className={styles["collectedAccordionBody"]}>
           <Container>
             <Row className={`pt-2 pb-2 ${styles["scrollContainer"]}`}>
               <Col>
                 <Table className={styles["collectedAccordionTable"]}>
-                  <UserPageStatsTableHead />
+                  <UserPageStatsTableHead
+                    caption={activityMessage(
+                      "user.collected.stats.activityOverview.tables.overviewCaption"
+                    )}
+                  />
                   <tbody>
-                    <UserPageStatsTableHr span={6} />
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Airdrops</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.airdrops)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.airdrops_memes)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.airdrops_nextgen)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.airdrops_gradients)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.airdrops_memelab)}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Transfers In</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_in)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_in_memes)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_in_nextgen)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_in_gradients)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_in_memelab)}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Mints</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.primary_purchases_count)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(
-                          activity?.primary_purchases_count_memes
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(
-                          activity?.primary_purchases_count_nextgen
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(
-                          activity?.primary_purchases_count_gradients
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(
-                          activity?.primary_purchases_count_memelab
-                        )}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Mints (ETH)</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(activity?.primary_purchases_value)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(activity?.primary_purchases_value_memes)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(
-                          activity?.primary_purchases_value_nextgen
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(
-                          activity?.primary_purchases_value_gradients
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(
-                          activity?.primary_purchases_value_memelab
-                        )}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Purchases</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.secondary_purchases_count)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(
-                          activity?.secondary_purchases_count_memes
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(
-                          activity?.secondary_purchases_count_nextgen
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(
-                          activity?.secondary_purchases_count_gradients
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(
-                          activity?.secondary_purchases_count_memelab
-                        )}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Purchases (ETH)</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(activity?.secondary_purchases_value)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(
-                          activity?.secondary_purchases_value_memes
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(
-                          activity?.secondary_purchases_value_nextgen
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(
-                          activity?.secondary_purchases_value_gradients
-                        )}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(
-                          activity?.secondary_purchases_value_memelab
-                        )}
-                      </td>
-                    </tr>
-                    <UserPageStatsTableHr span={6} />
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Transfers Out</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_out)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_out_memes)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_out_nextgen)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_out_gradients)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.transfers_out_memelab)}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Burns</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.burns)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.burns_memes)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.burns_nextgen)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.burns_gradients)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.burns_memelab)}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Sales</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.sales_count)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.sales_count_memes)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.sales_count_nextgen)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.sales_count_gradients)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {numberWithCommas(activity?.sales_count_memelab)}
-                      </td>
-                    </tr>
-                    <tr>
-                      <td className="!tw-text-[#93939f]">
-                        <b>Sales (ETH)</b>
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(activity?.sales_value)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(activity?.sales_value_memes)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(activity?.sales_value_nextgen)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(activity?.sales_value_gradients)}
-                      </td>
-                      <td className="tw-text-right !tw-text-[#fff]">
-                        {printEthValue(activity?.sales_value_memelab)}
-                      </td>
-                    </tr>
+                    {OVERVIEW_ROW_GROUPS.map((group, groupIndex) => (
+                      <Fragment key={`activity-overview-group-${groupIndex}`}>
+                        <UserPageStatsTableHr span={6} />
+                        {group.map((row) => (
+                          <ActivityOverviewRow
+                            key={row.labelKey}
+                            row={row}
+                            activity={activity}
+                          />
+                        ))}
+                      </Fragment>
+                    ))}
                   </tbody>
                 </Table>
               </Col>
@@ -344,6 +330,27 @@ function UserPageStatsActivityOverviewTotals({
         </Accordion.Body>
       </Accordion.Item>
     </Accordion>
+  );
+}
+
+function ActivityOverviewRow({
+  row,
+  activity,
+}: {
+  readonly row: OverviewRowConfig;
+  readonly activity: AggregatedActivity | undefined;
+}) {
+  return (
+    <tr>
+      <th scope="row" className="!tw-text-[#93939f]">
+        <b>{activityMessage(row.labelKey)}</b>
+      </th>
+      {row.fields.map((field) => (
+        <td key={field} className="tw-text-right !tw-text-[#fff]">
+          {formatActivityValue(activity?.[field], row.valueType)}
+        </td>
+      ))}
+    </tr>
   );
 }
 
@@ -356,93 +363,72 @@ function UserPageStatsActivityOverviewMemes({
     <Accordion>
       <Accordion.Item defaultChecked={true} eventKey={"0"}>
         <Accordion.Button className={styles["collectedAccordionButton"]}>
-          <b>Memes Breakdown By Season</b>
+          <b>
+            {activityMessage(
+              "user.collected.stats.activityOverview.memesBySeason"
+            )}
+          </b>
         </Accordion.Button>
         <Accordion.Body className={styles["collectedAccordionBody"]}>
           <Container>
             <Row className={`pt-2 pb-2 ${styles["scrollContainer"]}`}>
               <Col>
-                {activity && (
+                {activity.length > 0 ? (
                   <Table className={styles["collectedAccordionTable"]}>
+                    <caption className="tw-sr-only">
+                      {activityMessage(
+                        "user.collected.stats.activityOverview.tables.memesBySeasonCaption"
+                      )}
+                    </caption>
                     <thead>
                       <tr>
-                        <th colSpan={1}></th>
-                        <th className="text-right !tw-text-[#93939f]">
-                          Transfers In
-                        </th>
-                        <th className="text-right !tw-text-[#93939f]">
-                          Airdrops
-                        </th>
-                        <th className="text-right !tw-text-[#93939f]">Mints</th>
-                        <th className="text-right !tw-text-[#93939f]">
-                          Mints (ETH)
-                        </th>
-                        <th className="text-right !tw-text-[#93939f]">
-                          Purchases
-                        </th>
-                        <th className="text-right !tw-text-[#93939f]">
-                          Purchases (ETH)
-                        </th>
-                        <th className="text-right !tw-text-[#93939f]">
-                          Transfers Out
-                        </th>
-                        <th className="text-right !tw-text-[#93939f]">Burns</th>
-                        <th className="text-right !tw-text-[#93939f]">Sales</th>
-                        <th className="text-right !tw-text-[#93939f]">
-                          Sales (ETH)
-                        </th>
+                        <th aria-hidden="true"></th>
+                        {SEASON_ACTIVITY_COLUMNS.map((column) => (
+                          <th
+                            key={column.field}
+                            scope="col"
+                            className="text-right !tw-text-[#93939f]"
+                          >
+                            {activityMessage(column.labelKey)}
+                          </th>
+                        ))}
                       </tr>
                     </thead>
                     <tbody>
                       {activity.map((activity) => (
                         <Fragment
-                          key={`stats-activity-memes-${activity.season}`}>
+                          key={`stats-activity-memes-${activity.season}`}
+                        >
                           <UserPageStatsTableHr span={11} />
                           <tr>
-                            <td className="!tw-text-[#93939f]">
-                              Season {activity.season}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {numberWithCommas(activity.transfers_in)}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {numberWithCommas(activity.airdrops)}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {numberWithCommas(
-                                activity.primary_purchases_count
+                            <th scope="row" className="!tw-text-[#93939f]">
+                              {activityMessage(
+                                "user.collected.stats.activityOverview.seasonLabel",
+                                { seasonNumber: activity.season }
                               )}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {printEthValue(activity.primary_purchases_value)}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {numberWithCommas(
-                                activity.secondary_purchases_count
-                              )}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {printEthValue(
-                                activity.secondary_purchases_value
-                              )}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {numberWithCommas(activity.transfers_out)}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {numberWithCommas(activity.burns)}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {numberWithCommas(activity.sales_count)}
-                            </td>
-                            <td className="tw-text-right !tw-text-[#fff]">
-                              {printEthValue(activity.sales_value)}
-                            </td>
+                            </th>
+                            {SEASON_ACTIVITY_COLUMNS.map((column) => (
+                              <td
+                                key={column.field}
+                                className="tw-text-right !tw-text-[#fff]"
+                              >
+                                {formatActivityValue(
+                                  activity[column.field],
+                                  column.valueType
+                                )}
+                              </td>
+                            ))}
                           </tr>
                         </Fragment>
                       ))}
                     </tbody>
                   </Table>
+                ) : (
+                  <p className="tw-mb-0 tw-px-2 tw-py-3 tw-text-sm tw-text-iron-300">
+                    {activityMessage(
+                      "user.collected.stats.activityOverview.tables.memesBySeasonEmpty"
+                    )}
+                  </p>
                 )}
               </Col>
             </Row>

--- a/components/user/stats/UserPageStatsBoostBreakdown.tsx
+++ b/components/user/stats/UserPageStatsBoostBreakdown.tsx
@@ -26,12 +26,16 @@ function boostMessage(
   return t(DEFAULT_LOCALE, key, params);
 }
 
-function formatBoostValue(value: number | undefined): string {
-  if (!value) {
+function formatBoostValue(value: number | undefined | null): string {
+  if (value == null) {
     return "-";
   }
 
   return formatNumber(DEFAULT_LOCALE, value, BOOST_VALUE_FORMAT_OPTIONS);
+}
+
+function hasBoostValue(value: number | undefined | null): value is number {
+  return value != null;
 }
 
 export default function UserPageStatsBoostBreakdown({
@@ -53,7 +57,7 @@ export default function UserPageStatsBoostBreakdown({
           {name}
         </th>
         <td className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4">
-          {breakdown?.available ? (
+          {hasBoostValue(breakdown?.available) ? (
             <span className="d-flex align-items-center justify-content-center gap-2">
               {formatBoostValue(breakdown.available)}
               <BoostBreakdownInfo info={breakdown.available_info} />
@@ -63,7 +67,7 @@ export default function UserPageStatsBoostBreakdown({
           )}
         </td>
         <td className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4">
-          {breakdown?.acquired ? (
+          {hasBoostValue(breakdown?.acquired) ? (
             <span className="d-flex align-items-center justify-content-center gap-2">
               {formatBoostValue(breakdown.acquired)}
               <BoostBreakdownInfo info={breakdown.acquired_info} />
@@ -153,7 +157,7 @@ export default function UserPageStatsBoostBreakdown({
             {name}
           </th>
           <td className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800 tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4">
-            {breakdown.available ? (
+            {hasBoostValue(breakdown.available) ? (
               <span className="d-flex align-items-center justify-content-center gap-2">
                 {formatBoostValue(breakdown.available)}
                 <BoostBreakdownInfo info={breakdown.available_info} />
@@ -163,7 +167,7 @@ export default function UserPageStatsBoostBreakdown({
             )}
           </td>
           <td className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800 tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4">
-            {breakdown.acquired ? (
+            {hasBoostValue(breakdown.acquired) ? (
               <span className="d-flex align-items-center justify-content-center gap-2">
                 {formatBoostValue(breakdown.acquired)}
                 <BoostBreakdownInfo info={breakdown.acquired_info} />
@@ -256,8 +260,9 @@ export default function UserPageStatsBoostBreakdown({
                         {tdh?.boost ? (
                           <span className="d-flex align-items-center justify-content-center gap-2">
                             {formatBoostValue(
-                              tdh.boost_breakdown.memes_card_sets.available +
-                                tdh.boost_breakdown.gradients.available
+                              (tdh.boost_breakdown.memes_card_sets?.available ??
+                                0) +
+                                (tdh.boost_breakdown.gradients?.available ?? 0)
                             )}
                             <BoostBreakdownInfo
                               info={[

--- a/components/user/stats/UserPageStatsBoostBreakdown.tsx
+++ b/components/user/stats/UserPageStatsBoostBreakdown.tsx
@@ -2,8 +2,37 @@ import type { ConsolidatedTDH, TDH, TDHBoostBreakdown } from "@/entities/ITDH";
 import { getRandomObjectId } from "@/helpers/AllowlistToolHelpers";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { formatNumber, roundTo } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
 import Link from "next/link";
 import { Tooltip } from "react-tooltip";
+
+const BOOST_VERSION = "1.4";
+const BOOST_VALUE_FORMAT_OPTIONS = {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+} satisfies Intl.NumberFormatOptions;
+
+type BoostMessageKey = Extract<
+  MessageKey,
+  `user.collected.stats.boostBreakdown.${string}`
+>;
+
+function boostMessage(
+  key: BoostMessageKey,
+  params: Record<string, string | number> = {}
+): string {
+  return t(DEFAULT_LOCALE, key, params);
+}
+
+function formatBoostValue(value: number | undefined): string {
+  if (!value) {
+    return "-";
+  }
+
+  return formatNumber(DEFAULT_LOCALE, value, BOOST_VALUE_FORMAT_OPTIONS);
+}
 
 export default function UserPageStatsBoostBreakdown({
   tdh,
@@ -17,23 +46,26 @@ export default function UserPageStatsBoostBreakdown({
   function getMemeRow(name: string, breakdown: TDHBoostBreakdown | undefined) {
     return (
       <tr key={getRandomObjectId()}>
-        <td className="tw-px-8 sm:tw-px-10 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-iron-400">
+        <th
+          scope="row"
+          className="tw-group tw-whitespace-nowrap tw-px-8 tw-py-3 tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-10 sm:tw-text-md lg:tw-pr-4"
+        >
           {name}
-        </td>
-        <td className="tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-white-400 tw-text-center">
+        </th>
+        <td className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4">
           {breakdown?.available ? (
             <span className="d-flex align-items-center justify-content-center gap-2">
-              {breakdown.available.toFixed(2)}
+              {formatBoostValue(breakdown.available)}
               <BoostBreakdownInfo info={breakdown.available_info} />
             </span>
           ) : (
             "-"
           )}
         </td>
-        <td className="tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-white-400 tw-text-center">
+        <td className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4">
           {breakdown?.acquired ? (
             <span className="d-flex align-items-center justify-content-center gap-2">
-              {breakdown.acquired.toFixed(2)}
+              {formatBoostValue(breakdown.acquired)}
               <BoostBreakdownInfo info={breakdown.acquired_info} />
             </span>
           ) : (
@@ -47,9 +79,13 @@ export default function UserPageStatsBoostBreakdown({
   function getMemesRows() {
     const headerRow = (
       <tr key={getRandomObjectId()}>
-        <td className="tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-pt-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-white-400">
-          Memes
-        </td>
+        <th
+          scope="rowgroup"
+          colSpan={3}
+          className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-px-4 tw-pt-3 tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4"
+        >
+          {boostMessage("user.collected.stats.boostBreakdown.groups.memes")}
+        </th>
       </tr>
     );
 
@@ -58,7 +94,12 @@ export default function UserPageStatsBoostBreakdown({
 
     const baseRows = [
       headerRow,
-      getMemeRow("Full Collection Set", bb.memes_card_sets),
+      getMemeRow(
+        boostMessage(
+          "user.collected.stats.boostBreakdown.rows.fullCollectionSet"
+        ),
+        bb.memes_card_sets
+      ),
     ];
 
     if (bb.memes_card_sets?.acquired !== 0) {
@@ -75,11 +116,24 @@ export default function UserPageStatsBoostBreakdown({
 
     const extraRows = seasonKeys.flatMap((key) => {
       const sznNum = key.replace("memes_szn", "");
-      const rows = [getMemeRow(`SZN${sznNum}`, bb[key])];
+      const rows = [
+        getMemeRow(
+          boostMessage("user.collected.stats.boostBreakdown.seasonLabel", {
+            seasonNumber: sznNum,
+          }),
+          bb[key]
+        ),
+      ];
       if (key === "memes_szn1" && !bb[key]?.acquired) {
         rows.push(
-          getMemeRow("Genesis Set", bb.memes_genesis),
-          getMemeRow("Nakamoto", bb.memes_nakamoto)
+          getMemeRow(
+            boostMessage("user.collected.stats.boostBreakdown.rows.genesisSet"),
+            bb.memes_genesis
+          ),
+          getMemeRow(
+            boostMessage("user.collected.stats.boostBreakdown.rows.nakamoto"),
+            bb.memes_nakamoto
+          )
         );
       }
       return rows;
@@ -92,23 +146,26 @@ export default function UserPageStatsBoostBreakdown({
     if (breakdown) {
       return (
         <tr key={getRandomObjectId()}>
-          <td className="tw-border-t tw-border-x-0 tw-border-b-0 tw-border-solid tw-border-iron-800 tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-white-400">
+          <th
+            scope="row"
+            className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800 tw-px-4 tw-py-3 tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4"
+          >
             {name}
-          </td>
-          <td className="tw-border-t tw-border-x-0 tw-border-b-0 tw-border-solid tw-border-iron-800 tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-white-400 tw-text-center">
+          </th>
+          <td className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800 tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4">
             {breakdown.available ? (
               <span className="d-flex align-items-center justify-content-center gap-2">
-                {breakdown.available.toFixed(2)}
+                {formatBoostValue(breakdown.available)}
                 <BoostBreakdownInfo info={breakdown.available_info} />
               </span>
             ) : (
               "-"
             )}
           </td>
-          <td className="tw-border-t tw-border-x-0 tw-border-b-0 tw-border-solid tw-border-iron-800 tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-white-400 tw-text-center">
+          <td className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800 tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4">
             {breakdown.acquired ? (
               <span className="d-flex align-items-center justify-content-center gap-2">
-                {breakdown.acquired.toFixed(2)}
+                {formatBoostValue(breakdown.acquired)}
                 <BoostBreakdownInfo info={breakdown.acquired_info} />
               </span>
             ) : (
@@ -126,36 +183,53 @@ export default function UserPageStatsBoostBreakdown({
     <div className="tw-mt-6 lg:tw-mt-8">
       <div className="tw-flex tw-items-center tw-justify-between">
         <h3 className="tw-mb-0 tw-text-lg tw-font-semibold tw-text-iron-100">
-          Boost Breakdown
+          {boostMessage("user.collected.stats.boostBreakdown.title")}
         </h3>
         <span>
           <Link
             href="/network/tdh#tdh-1-4"
-            className="decoration-hover-underline tw-text-sm">
-            TDH Version: 1.4
+            className="decoration-hover-underline tw-text-sm"
+          >
+            {boostMessage("user.collected.stats.boostBreakdown.versionLink", {
+              version: BOOST_VERSION,
+            })}
           </Link>
         </span>
       </div>
-      <div className="tw-mt-2 lg:tw-mt-4 tw-bg-iron-950 tw-border tw-border-iron-700 tw-border-solid tw-rounded-lg tw-overflow-x-auto">
+      <div className="tw-mt-2 tw-overflow-x-auto tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 lg:tw-mt-4">
         <div className="tw-flow-root">
           <div className="tw-inline-block tw-min-w-full tw-align-middle">
             <table className="tw-min-w-full">
-              <thead className="tw-bg-iron-900 tw-border-b tw-border-iron-700 tw-border-x-0 tw-border-t-0">
+              <caption className="tw-sr-only">
+                {boostMessage(
+                  "user.collected.stats.boostBreakdown.tableCaption"
+                )}
+              </caption>
+              <thead className="tw-border-x-0 tw-border-b tw-border-t-0 tw-border-iron-700 tw-bg-iron-900">
                 <tr key={getRandomObjectId()}>
                   <th
                     scope="col"
-                    className="tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-iron-400">
-                    Type
+                    className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pr-4"
+                  >
+                    {boostMessage(
+                      "user.collected.stats.boostBreakdown.columns.type"
+                    )}
                   </th>
                   <th
                     scope="col"
-                    className="tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-iron-400  tw-text-center">
-                    Potential Boost
+                    className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pr-4"
+                  >
+                    {boostMessage(
+                      "user.collected.stats.boostBreakdown.columns.potential"
+                    )}
                   </th>
                   <th
                     scope="col"
-                    className="tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-iron-400 tw-text-center">
-                    Actual Boost
+                    className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pr-4"
+                  >
+                    {boostMessage(
+                      "user.collected.stats.boostBreakdown.columns.actual"
+                    )}
                   </th>
                 </tr>
               </thead>
@@ -164,35 +238,50 @@ export default function UserPageStatsBoostBreakdown({
                   <>
                     {getMemesRows()}
                     {getBaseBoostRow(
-                      "Gradients",
+                      boostMessage(
+                        "user.collected.stats.boostBreakdown.rows.gradients"
+                      ),
                       tdh?.boost_breakdown.gradients
                     )}
                     <tr key={getRandomObjectId()}>
-                      <td className="tw-border-t tw-border-x-0 tw-border-b-0 tw-border-solid tw-border-iron-700 tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-semibold tw-text-white-400">
-                        TOTAL BOOST
-                      </td>
-                      <td className="tw-border-t tw-border-x-0 tw-border-b-0 tw-border-solid tw-border-iron-700 tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-white-400 tw-text-center">
+                      <th
+                        scope="row"
+                        className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700 tw-px-4 tw-py-3 tw-text-sm tw-font-semibold sm:tw-px-6 sm:tw-text-md lg:tw-pr-4"
+                      >
+                        {boostMessage(
+                          "user.collected.stats.boostBreakdown.rows.total"
+                        )}
+                      </th>
+                      <td className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700 tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4">
                         {tdh?.boost ? (
                           <span className="d-flex align-items-center justify-content-center gap-2">
-                            {(
+                            {formatBoostValue(
                               tdh.boost_breakdown.memes_card_sets.available +
-                              tdh.boost_breakdown.gradients.available
-                            ).toFixed(2)}
+                                tdh.boost_breakdown.gradients.available
+                            )}
                             <BoostBreakdownInfo
-                              info={["Total Potential Boost"]}
+                              info={[
+                                boostMessage(
+                                  "user.collected.stats.boostBreakdown.info.totalPotential"
+                                ),
+                              ]}
                             />
                           </span>
                         ) : (
                           "-"
                         )}
                       </td>
-                      <td className="tw-border-t tw-border-x-0 tw-border-b-0 tw-border-solid tw-border-iron-700 tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-group tw-py-3 tw-text-sm sm:tw-text-md tw-font-medium tw-text-white-400 tw-text-center">
+                      <td className="tw-text-white-400 tw-group tw-whitespace-nowrap tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700 tw-px-4 tw-py-3 tw-text-center tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-md lg:tw-pr-4">
                         {tdh?.boost ? (
                           <span className="d-flex align-items-center justify-content-center gap-2">
-                            {(Math.round((tdh.boost - 1) * 100) / 100).toFixed(
-                              2
-                            )}
-                            <BoostBreakdownInfo info={["Total Actual Boost"]} />
+                            {formatBoostValue(roundTo(tdh.boost - 1, 2))}
+                            <BoostBreakdownInfo
+                              info={[
+                                boostMessage(
+                                  "user.collected.stats.boostBreakdown.info.totalActual"
+                                ),
+                              ]}
+                            />
                           </span>
                         ) : (
                           "-"
@@ -219,13 +308,21 @@ function BoostBreakdownInfo({ info }: { readonly info: string[] }) {
 
   return (
     <>
-      <FontAwesomeIcon
-        icon={faInfoCircle}
-        height={16}
-        color="lightgrey"
-        cursor={"pointer"}
+      <button
+        type="button"
+        className="tw-inline-flex tw-items-center tw-border-0 tw-bg-transparent tw-p-0 tw-text-iron-300 hover:tw-text-iron-100 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400"
+        aria-label={boostMessage(
+          "user.collected.stats.boostBreakdown.info.ariaLabel"
+        )}
         data-tooltip-id={tooltipId}
-      />
+      >
+        <FontAwesomeIcon
+          icon={faInfoCircle}
+          height={16}
+          color="lightgrey"
+          aria-hidden="true"
+        />
+      </button>
       <Tooltip
         id={tooltipId}
         place="top"
@@ -234,11 +331,13 @@ function BoostBreakdownInfo({ info }: { readonly info: string[] }) {
           color: "white",
           padding: "4px 8px",
           zIndex: 10,
-        }}>
+        }}
+      >
         {info.length > 1 ? (
           <ul
             className="mb-0"
-            style={{ paddingLeft: "1rem", textAlign: "left" }}>
+            style={{ paddingLeft: "1rem", textAlign: "left" }}
+          >
             {info.map((i) => (
               <li key={getRandomObjectId()} className="text-left">
                 {i}

--- a/components/user/stats/activity/UserPageActivityWrapper.tsx
+++ b/components/user/stats/activity/UserPageActivityWrapper.tsx
@@ -2,6 +2,7 @@
 
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Suspense } from "react";
 import {
   SEARCH_PARAM_ACTIVITY,
   WALLET_ACTIVITY_FILTER_PARAM,
@@ -10,6 +11,10 @@ import {
 } from "./activity.helpers";
 import { USER_PAGE_ACTIVITY_TAB } from "./activity.types";
 import UserPageStatsActivityDistributions from "./distributions/UserPageStatsActivityDistributions";
+import {
+  getActivityPanelId,
+  getActivityTabId,
+} from "./tabs/activity-tabs.helpers";
 import UserPageActivityTabs from "./tabs/UserPageActivityTabs";
 import UserPageStatsActivityTDHHistory from "./tdh-history/UserPageStatsActivityTDHHistory";
 import UserPageStatsActivityWallet from "./wallet/UserPageStatsActivityWallet";
@@ -31,6 +36,23 @@ const pathToEnum = (path: string): USER_PAGE_ACTIVITY_TAB => {
 };
 
 export default function UserPageActivityWrapper({
+  profile,
+  activeAddress,
+}: {
+  readonly profile: ApiIdentity;
+  readonly activeAddress: string | null;
+}) {
+  return (
+    <Suspense fallback={null}>
+      <UserPageActivityContent
+        profile={profile}
+        activeAddress={activeAddress}
+      />
+    </Suspense>
+  );
+}
+
+function UserPageActivityContent({
   profile,
   activeAddress,
 }: {
@@ -63,19 +85,44 @@ export default function UserPageActivityWrapper({
     <div className="tw-mt-7 lg:tw-mt-9">
       <UserPageActivityTabs activeTab={activeTab} setActiveTab={onActiveTab} />
       {activeTab === USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY && (
-        <UserPageStatsActivityWallet
-          profile={profile}
-          activeAddress={activeAddress}
-        />
+        <section
+          role="tabpanel"
+          id={getActivityPanelId(USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY)}
+          aria-labelledby={getActivityTabId(
+            USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY
+          )}
+          tabIndex={0}
+        >
+          <UserPageStatsActivityWallet
+            profile={profile}
+            activeAddress={activeAddress}
+          />
+        </section>
       )}
       {activeTab === USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS && (
-        <UserPageStatsActivityDistributions
-          profile={profile}
-          activeAddress={activeAddress}
-        />
+        <section
+          role="tabpanel"
+          id={getActivityPanelId(USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS)}
+          aria-labelledby={getActivityTabId(
+            USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS
+          )}
+          tabIndex={0}
+        >
+          <UserPageStatsActivityDistributions
+            profile={profile}
+            activeAddress={activeAddress}
+          />
+        </section>
       )}
       {activeTab === USER_PAGE_ACTIVITY_TAB.TDH_HISTORY && (
-        <UserPageStatsActivityTDHHistory profile={profile} />
+        <section
+          role="tabpanel"
+          id={getActivityPanelId(USER_PAGE_ACTIVITY_TAB.TDH_HISTORY)}
+          aria-labelledby={getActivityTabId(USER_PAGE_ACTIVITY_TAB.TDH_HISTORY)}
+          tabIndex={0}
+        >
+          <UserPageStatsActivityTDHHistory profile={profile} />
+        </section>
       )}
     </div>
   );

--- a/components/user/stats/activity/distributions/UserPageStatsActivityDistributions.tsx
+++ b/components/user/stats/activity/distributions/UserPageStatsActivityDistributions.tsx
@@ -15,6 +15,7 @@ import {
   getActivityWalletsParam,
   WALLET_DISTRIBUTION_PAGE_PARAM,
 } from "../activity.helpers";
+import { getDistributionsMessage } from "./distributions.messages";
 import UserPageStatsActivityDistributionsTableWrapper from "./UserPageStatsActivityDistributionsTableWrapper";
 
 export default function UserPageStatsActivityDistributions({
@@ -105,7 +106,7 @@ export default function UserPageStatsActivityDistributions({
     <div className="tw-mt-4 md:tw-mt-5">
       <div className="tw-flex">
         <h3 className="tw-mb-0 tw-text-lg tw-font-semibold tw-text-iron-100">
-          Distributions
+          {getDistributionsMessage("user.collected.stats.distributions.title")}
         </h3>
       </div>
       <UserPageStatsActivityDistributionsTableWrapper

--- a/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTable.tsx
+++ b/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTable.tsx
@@ -8,26 +8,59 @@ import {
 } from "@/constants/constants";
 import type { Distribution } from "@/entities/IDistribution";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
-import { getRandomObjectId } from "@/helpers/AllowlistToolHelpers";
-import { areEqualAddresses, capitalizeEveryWord } from "@/helpers/Helpers";
-import { useEffect, useState } from "react";
+import { formatInteger } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { areEqualAddresses } from "@/helpers/Helpers";
+import { useMemo } from "react";
+import {
+  getDistributionPhaseLabel,
+  getDistributionsMessage,
+} from "./distributions.messages";
+import {
+  DistributionCollection,
+  type DistributionTableItem,
+} from "./distributions.types";
 import UserPageStatsActivityDistributionsTableItem from "./UserPageStatsActivityDistributionsTableItem";
 
-export enum DistributionCollection {
-  MEMES = "MEMES",
-  GRADIENTS = "GRADIENTS",
-  MEMELAB = "MEMELAB",
+function getAvailablePhases(items: Distribution[]): string[] {
+  const phases: Set<string> = new Set();
+  for (const item of items) {
+    for (const phase of item.phases) {
+      phases.add(phase);
+    }
+  }
+  return Array.from(phases);
 }
 
-export interface DistributionTableItem {
-  readonly collection: DistributionCollection;
-  readonly tokenId: number;
-  readonly name: string;
-  readonly wallet: string;
-  readonly phases: number[];
-  readonly amountMinted: number;
-  readonly amountTotal: number;
-  readonly date: string;
+function getCollectionEnum(contract: string): DistributionCollection {
+  if (areEqualAddresses(contract, MEMES_CONTRACT)) {
+    return DistributionCollection.MEMES;
+  }
+  if (areEqualAddresses(contract, GRADIENT_CONTRACT)) {
+    return DistributionCollection.GRADIENTS;
+  }
+
+  if (areEqualAddresses(contract, MEMELAB_CONTRACT)) {
+    return DistributionCollection.MEMELAB;
+  }
+  throw new Error(`Unknown contract ${contract}`);
+}
+
+function getItemPhaseAmount({
+  phase,
+  item,
+}: {
+  readonly phase: string;
+  readonly item: Distribution;
+}): number {
+  if (phase.toUpperCase() === "AIRDROP") {
+    return item.airdrops ?? 0;
+  }
+
+  const allowlistPhase = item.allowlist.find(
+    (allowlistItem) => allowlistItem.phase === phase
+  );
+  return allowlistPhase?.spots ?? 0;
 }
 
 export default function UserPageStatsActivityDistributionsTable({
@@ -39,58 +72,9 @@ export default function UserPageStatsActivityDistributionsTable({
   readonly profile: ApiIdentity;
   readonly loading: boolean;
 }) {
-  const getAvailablePhases = (): string[] => {
-    const phases: Set<string> = new Set();
-    for (const item of items) {
-      for (const p of item.phases) {
-        phases.add(p);
-      }
-    }
-    return Array.from(phases);
-  };
-
-  const [availablePhases, setAvailablePhases] =
-    useState<string[]>(getAvailablePhases());
-
-  const [results, setResults] = useState<DistributionTableItem[]>([]);
-
-  const getCollectionEnum = (contract: string): DistributionCollection => {
-    if (areEqualAddresses(contract, MEMES_CONTRACT)) {
-      return DistributionCollection.MEMES;
-    }
-    if (areEqualAddresses(contract, GRADIENT_CONTRACT)) {
-      return DistributionCollection.GRADIENTS;
-    }
-
-    if (areEqualAddresses(contract, MEMELAB_CONTRACT)) {
-      return DistributionCollection.MEMELAB;
-    }
-    throw new Error(`Unknown contract ${contract}`);
-  };
-
-  const getItemPhaseAmount = ({
-    phase,
-    item,
-  }: {
-    readonly phase: string;
-    readonly item: Distribution;
-  }): number => {
-    let count = 0;
-
-    if (phase.toUpperCase() === "AIRDROP") {
-      count = item.airdrops;
-    } else {
-      const p = item.allowlist.find((a) => a.phase === phase);
-      count = p?.spots ?? 0;
-    }
-
-    return count ?? 0;
-  };
-
-  useEffect(() => {
-    const phases = getAvailablePhases();
-    setAvailablePhases(phases);
-    setResults(
+  const availablePhases = useMemo(() => getAvailablePhases(items), [items]);
+  const results = useMemo<DistributionTableItem[]>(
+    () =>
       items.map((item) => ({
         collection: getCollectionEnum(item.contract),
         tokenId: item.card_id,
@@ -101,71 +85,98 @@ export default function UserPageStatsActivityDistributionsTable({
           )?.display ??
           item.wallet_display ??
           item.wallet,
-        phases: phases.map((phase) => getItemPhaseAmount({ phase, item })),
+        phases: availablePhases.map((phase) => ({
+          phase,
+          amount: getItemPhaseAmount({ phase, item }),
+        })),
         amountMinted: item.minted,
         amountTotal: item.total_count,
         date: item.mint_date,
-      }))
-    );
-  }, [items]);
+      })),
+    [availablePhases, items, profile.wallets]
+  );
 
   return (
     <table className="tw-min-w-full tw-divide-y tw-divide-iron-700">
+      <caption className="tw-sr-only">
+        {getDistributionsMessage(
+          "user.collected.stats.distributions.tableCaption"
+        )}
+      </caption>
       <thead className="tw-bg-iron-900">
         <tr>
           <th
             scope="col"
             className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pr-4"
           >
-            Collection
+            {getDistributionsMessage(
+              "user.collected.stats.distributions.columns.collection"
+            )}
           </th>
           <th
             scope="col"
             className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-right tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pl-4"
           >
-            Token
+            {getDistributionsMessage(
+              "user.collected.stats.distributions.columns.token"
+            )}
           </th>
           <th
             scope="col"
             className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pl-4"
           >
-            Name
+            {getDistributionsMessage(
+              "user.collected.stats.distributions.columns.name"
+            )}
           </th>
 
           <th
             scope="col"
             className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pl-4"
           >
-            Wallet
+            {getDistributionsMessage(
+              "user.collected.stats.distributions.columns.wallet"
+            )}
           </th>
           {availablePhases.map((phase) => (
             <th
-              key={getRandomObjectId()}
+              key={phase}
               scope="col"
               className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-right tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pl-4"
             >
-              {capitalizeEveryWord(phase.replaceAll("_", " "))}
+              {getDistributionPhaseLabel(phase)}
             </th>
           ))}
           <th
             scope="col"
             className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-right tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pl-4"
           >
-            Minted
+            {getDistributionsMessage(
+              "user.collected.stats.distributions.columns.minted"
+            )}
           </th>
           <th
             scope="col"
             className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-right tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pl-4"
           >
-            Total
+            {getDistributionsMessage(
+              "user.collected.stats.distributions.columns.total"
+            )}
           </th>
           <th
             scope="col"
             className="tw-group tw-whitespace-nowrap tw-px-4 tw-py-3 tw-text-right tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-md lg:tw-pl-4"
           >
-            <div className={loading ? "tw-opacity-100" : "tw-opacity-0"}>
-              <CircleLoader />
-            </div>
+            {loading ? (
+              <div>
+                <span className="tw-sr-only">
+                  {getDistributionsMessage(
+                    "user.collected.stats.distributions.loading"
+                  )}
+                </span>
+                <CircleLoader />
+              </div>
+            ) : null}
           </th>
         </tr>
       </thead>
@@ -174,6 +185,7 @@ export default function UserPageStatsActivityDistributionsTable({
           <UserPageStatsActivityDistributionsTableItem
             key={`${item.collection}-${item.tokenId}-${item.wallet}`}
             item={item}
+            formatNumber={(value) => formatInteger(DEFAULT_LOCALE, value)}
           />
         ))}
       </tbody>

--- a/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableItem.tsx
+++ b/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableItem.tsx
@@ -1,74 +1,81 @@
 "use client";
 
 import Link from "next/link";
-import { getRandomObjectId } from "@/helpers/AllowlistToolHelpers";
 import {
-  formatNumberWithCommasOrDash,
-  getTimeAgo,
-} from "@/helpers/Helpers";
-import type {
-  DistributionTableItem} from "./UserPageStatsActivityDistributionsTable";
-import {
-  DistributionCollection
-} from "./UserPageStatsActivityDistributionsTable";
+  formatDistributionRelativeTime,
+  getDistributionCollectionLabel,
+  getDistributionTokenLinkLabel,
+} from "./distributions.messages";
+import type { DistributionTableItem } from "./distributions.types";
 import { useEffect, useState } from "react";
 
 export default function UserPageStatsActivityDistributionsTableItem({
   item,
+  formatNumber,
 }: {
   readonly item: DistributionTableItem;
+  readonly formatNumber: (value: number) => string;
 }) {
-  const COLLECTION_TO_TEXT: { [key in DistributionCollection]: string } = {
-    [DistributionCollection.MEMES]: "The Memes",
-    [DistributionCollection.GRADIENTS]: "6529Gradient",
-    [DistributionCollection.MEMELAB]: "Meme Lab",
-  };
-
-  const COLLECTION_TO_PATH: { [key in DistributionCollection]: string } = {
-    [DistributionCollection.MEMES]: "/the-memes",
-    [DistributionCollection.GRADIENTS]: "/6529-gradient",
-    [DistributionCollection.MEMELAB]: "/meme-lab",
-  };
-
   const [timeAgo, setTimeAgo] = useState<string>("");
   useEffect(() => {
-    setTimeAgo(getTimeAgo(new Date(item.date).getTime()));
-  }, []);
+    setTimeAgo(formatDistributionRelativeTime(item.date));
+  }, [item.date]);
+
+  const collectionLabel = getDistributionCollectionLabel(item.collection);
 
   return (
     <tr className="even:tw-bg-iron-900">
-      <td className="tw-text-iron-400 tw-py-3.5 tw-font-medium tw-px-4 sm:tw-px-6 lg:tw-pr-4 tw-whitespace-nowrap tw-text-sm sm:tw-text-base">
-        {COLLECTION_TO_TEXT[item.collection]}
+      <td className="tw-whitespace-nowrap tw-px-4 tw-py-3.5 tw-text-sm tw-font-medium tw-text-iron-400 sm:tw-px-6 sm:tw-text-base lg:tw-pr-4">
+        {collectionLabel}
       </td>
-      <td className="tw-py-3.5 tw-font-medium tw-px-4 sm:tw-px-6 lg:tw-pl-4 tw-text-right tw-whitespace-nowrap tw-text-sm sm:tw-text-base">
+      <td className="tw-whitespace-nowrap tw-px-4 tw-py-3.5 tw-text-right tw-text-sm tw-font-medium sm:tw-px-6 sm:tw-text-base lg:tw-pl-4">
         <Link
-          className="tw-no-underline hover:tw-underline tw-text-iron-50"
-          href={`${COLLECTION_TO_PATH[item.collection]}/${item.tokenId}`}>
+          aria-label={getDistributionTokenLinkLabel({
+            collection: item.collection,
+            tokenId: item.tokenId,
+          })}
+          className="tw-text-iron-50 tw-no-underline hover:tw-underline"
+          href={`${getCollectionPath(item.collection)}/${item.tokenId}`}
+        >
           # {item.tokenId}
         </Link>
       </td>
-      <td className="tw-text-iron-50 tw-py-3.5 tw-font-medium tw-px-4 sm:tw-px-6 lg:tw-pl-4 tw-whitespace-nowrap tw-text-sm sm:tw-text-base">
+      <td className="tw-whitespace-nowrap tw-px-4 tw-py-3.5 tw-text-sm tw-font-medium tw-text-iron-50 sm:tw-px-6 sm:tw-text-base lg:tw-pl-4">
         {item.name}
       </td>
-      <td className="tw-text-iron-400 tw-py-3.5 tw-font-normal tw-px-4 sm:tw-px-6 lg:tw-pl-4 tw-whitespace-nowrap tw-text-sm sm:tw-text-base">
+      <td className="tw-whitespace-nowrap tw-px-4 tw-py-3.5 tw-text-sm tw-font-normal tw-text-iron-400 sm:tw-px-6 sm:tw-text-base lg:tw-pl-4">
         {item.wallet}
       </td>
       {item.phases.map((phase) => (
         <td
-          key={getRandomObjectId()}
-          className="tw-text-iron-400 tw-py-3.5 tw-font-normal tw-px-4 tw-text-right sm:tw-px-6 lg:tw-pl-4 tw-whitespace-nowrap tw-text-sm sm:tw-text-base">
-          {formatNumberWithCommasOrDash(phase)}
+          key={`${item.collection}-${item.tokenId}-${item.wallet}-phase-${phase.phase}`}
+          className="tw-whitespace-nowrap tw-px-4 tw-py-3.5 tw-text-right tw-text-sm tw-font-normal tw-text-iron-400 sm:tw-px-6 sm:tw-text-base lg:tw-pl-4"
+        >
+          {formatNumber(phase.amount)}
         </td>
       ))}
-      <td className="tw-text-iron-400 tw-py-3.5 tw-font-normal tw-px-4 sm:tw-px-6 lg:tw-pl-4 tw-whitespace-nowrap tw-text-sm sm:tw-text-base tw-text-right">
-        {formatNumberWithCommasOrDash(item.amountMinted)}
+      <td className="tw-whitespace-nowrap tw-px-4 tw-py-3.5 tw-text-right tw-text-sm tw-font-normal tw-text-iron-400 sm:tw-px-6 sm:tw-text-base lg:tw-pl-4">
+        {formatNumber(item.amountMinted)}
       </td>
-      <td className="tw-text-iron-400 tw-py-3.5 tw-font-normal tw-px-4 sm:tw-px-6 lg:tw-pl-4 tw-whitespace-nowrap tw-text-sm sm:tw-text-base tw-text-right">
-        {formatNumberWithCommasOrDash(item.amountTotal)}
+      <td className="tw-whitespace-nowrap tw-px-4 tw-py-3.5 tw-text-right tw-text-sm tw-font-normal tw-text-iron-400 sm:tw-px-6 sm:tw-text-base lg:tw-pl-4">
+        {formatNumber(item.amountTotal)}
       </td>
-      <td className="tw-text-iron-500 tw-py-3.5 tw-font-normal tw-px-4 sm:tw-px-6 lg:tw-pl-4 tw-whitespace-nowrap tw-text-sm sm:tw-text-base tw-text-right">
+      <td className="tw-whitespace-nowrap tw-px-4 tw-py-3.5 tw-text-right tw-text-sm tw-font-normal tw-text-iron-500 sm:tw-px-6 sm:tw-text-base lg:tw-pl-4">
         {timeAgo}
       </td>
     </tr>
   );
+}
+
+function getCollectionPath(collection: DistributionTableItem["collection"]) {
+  const COLLECTION_TO_PATH: Record<
+    DistributionTableItem["collection"],
+    string
+  > = {
+    MEMES: "/the-memes",
+    GRADIENTS: "/6529-gradient",
+    MEMELAB: "/meme-lab",
+  };
+
+  return COLLECTION_TO_PATH[collection];
 }

--- a/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableWrapper.tsx
+++ b/components/user/stats/activity/distributions/UserPageStatsActivityDistributionsTableWrapper.tsx
@@ -2,6 +2,7 @@ import type { Distribution } from "@/entities/IDistribution";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import CommonTablePagination from "@/components/utils/table/paginator/CommonTablePagination";
 import CommonCardSkeleton from "@/components/utils/animation/CommonCardSkeleton";
+import { getDistributionsMessage } from "./distributions.messages";
 import UserPageStatsActivityDistributionsTable from "./UserPageStatsActivityDistributionsTable";
 
 export default function UserPageStatsActivityDistributionsTableWrapper({
@@ -23,14 +24,14 @@ export default function UserPageStatsActivityDistributionsTableWrapper({
 }) {
   if (isFirstLoading) {
     return (
-      <div className="tw-mt-2 sm:tw-mt-4 tw-w-full tw-h-96">
+      <div className="tw-mt-2 tw-h-96 tw-w-full sm:tw-mt-4">
         <CommonCardSkeleton />
       </div>
     );
   }
 
   return (
-    <div className="tw-mt-2 lg:tw-mt-4 tw-bg-iron-950 tw-border tw-border-iron-700 tw-border-solid tw-rounded-lg tw-overflow-x-auto">
+    <div className="tw-mt-2 tw-overflow-x-auto tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 lg:tw-mt-4">
       {data.length ? (
         <div className="tw-flow-root">
           <UserPageStatsActivityDistributionsTable
@@ -50,9 +51,9 @@ export default function UserPageStatsActivityDistributionsTableWrapper({
           )}
         </div>
       ) : (
-        <div className="tw-p-4 sm:tw-px-6 tw-text-sm tw-italic tw-text-iron-500">
-          No distributions found
-        </div>
+        <output className="tw-p-4 tw-text-sm tw-italic tw-text-iron-500 sm:tw-px-6">
+          {getDistributionsMessage("user.collected.stats.distributions.empty")}
+        </output>
       )}
     </div>
   );

--- a/components/user/stats/activity/distributions/distributions.messages.ts
+++ b/components/user/stats/activity/distributions/distributions.messages.ts
@@ -1,0 +1,88 @@
+import { formatRelativeTime } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
+import { DistributionCollection } from "./distributions.types";
+
+type DistributionsMessageKey = `user.collected.stats.distributions.${string}`;
+
+const COLLECTION_LABEL_KEYS: Record<DistributionCollection, MessageKey> = {
+  [DistributionCollection.MEMES]:
+    "user.collected.stats.distributions.collections.memes",
+  [DistributionCollection.GRADIENTS]:
+    "user.collected.stats.distributions.collections.gradients",
+  [DistributionCollection.MEMELAB]:
+    "user.collected.stats.distributions.collections.memeLab",
+};
+
+const RELATIVE_TIME_UNITS = [
+  { unit: "year", milliseconds: 365 * 24 * 60 * 60 * 1000 },
+  { unit: "month", milliseconds: 30 * 24 * 60 * 60 * 1000 },
+  { unit: "week", milliseconds: 7 * 24 * 60 * 60 * 1000 },
+  { unit: "day", milliseconds: 24 * 60 * 60 * 1000 },
+  { unit: "hour", milliseconds: 60 * 60 * 1000 },
+  { unit: "minute", milliseconds: 60 * 1000 },
+] as const;
+
+export function getDistributionsMessage(
+  key: DistributionsMessageKey,
+  params?: Record<string, string | number>
+) {
+  return t(DEFAULT_LOCALE, key as MessageKey, params);
+}
+
+export function getDistributionCollectionLabel(
+  collection: DistributionCollection
+) {
+  return t(DEFAULT_LOCALE, COLLECTION_LABEL_KEYS[collection]);
+}
+
+export function getDistributionTokenLinkLabel({
+  collection,
+  tokenId,
+}: {
+  readonly collection: DistributionCollection;
+  readonly tokenId: number;
+}) {
+  return getDistributionsMessage(
+    "user.collected.stats.distributions.tokenLinkAriaLabel",
+    {
+      collection: getDistributionCollectionLabel(collection),
+      tokenId,
+    }
+  );
+}
+
+export function getDistributionPhaseLabel(phase: string) {
+  if (phase.toUpperCase() === "AIRDROP") {
+    return getDistributionsMessage(
+      "user.collected.stats.distributions.phases.airdrop"
+    );
+  }
+
+  return phase
+    .replaceAll("_", " ")
+    .toLowerCase()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function formatDistributionRelativeTime(date: string, now = Date.now()) {
+  const timestamp = new Date(date).getTime();
+  if (!Number.isFinite(timestamp)) {
+    return "-";
+  }
+
+  const elapsed = timestamp - now;
+  const absoluteElapsed = Math.abs(elapsed);
+
+  for (const { unit, milliseconds } of RELATIVE_TIME_UNITS) {
+    if (absoluteElapsed >= milliseconds) {
+      return formatRelativeTime(
+        DEFAULT_LOCALE,
+        Math.round(elapsed / milliseconds),
+        unit
+      );
+    }
+  }
+
+  return formatRelativeTime(DEFAULT_LOCALE, 0, "second");
+}

--- a/components/user/stats/activity/distributions/distributions.types.ts
+++ b/components/user/stats/activity/distributions/distributions.types.ts
@@ -1,0 +1,21 @@
+export enum DistributionCollection {
+  MEMES = "MEMES",
+  GRADIENTS = "GRADIENTS",
+  MEMELAB = "MEMELAB",
+}
+
+export interface DistributionTableItem {
+  readonly collection: DistributionCollection;
+  readonly tokenId: number;
+  readonly name: string;
+  readonly wallet: string;
+  readonly phases: DistributionTableItemPhase[];
+  readonly amountMinted: number;
+  readonly amountTotal: number;
+  readonly date: string;
+}
+
+export interface DistributionTableItemPhase {
+  readonly phase: string;
+  readonly amount: number;
+}

--- a/components/user/stats/activity/tabs/UserPageActivityTab.tsx
+++ b/components/user/stats/activity/tabs/UserPageActivityTab.tsx
@@ -1,32 +1,60 @@
+import type { KeyboardEventHandler } from "react";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
 import { USER_PAGE_ACTIVITY_TAB } from "../activity.types";
+import { getActivityPanelId, getActivityTabId } from "./activity-tabs.helpers";
+
+type ActivityTabMessageKey = Extract<
+  MessageKey,
+  `user.collected.stats.activityTabs.${string}`
+>;
+
+const TAB_TO_LABEL_KEY: Record<USER_PAGE_ACTIVITY_TAB, ActivityTabMessageKey> =
+  {
+    [USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY]:
+      "user.collected.stats.activityTabs.walletActivity",
+    [USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS]:
+      "user.collected.stats.activityTabs.distributions",
+    [USER_PAGE_ACTIVITY_TAB.TDH_HISTORY]:
+      "user.collected.stats.activityTabs.tdhHistory",
+  };
 
 export default function UserPageActivityTab({
   tab,
   activeTab,
   setActiveTab,
+  onKeyDown,
 }: {
   readonly tab: USER_PAGE_ACTIVITY_TAB;
   readonly activeTab: USER_PAGE_ACTIVITY_TAB;
   readonly setActiveTab: (tab: USER_PAGE_ACTIVITY_TAB) => void;
+  readonly onKeyDown: KeyboardEventHandler<HTMLButtonElement>;
 }) {
-  const TAB_TO_LABEL: Record<USER_PAGE_ACTIVITY_TAB, string> = {
-    [USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY]: "Wallet Activity",
-    [USER_PAGE_ACTIVITY_TAB.DISTRIBUTIONS]: "Distributions",
-    [USER_PAGE_ACTIVITY_TAB.TDH_HISTORY]: "TDH History",
-  };
+  const isActive = tab === activeTab;
+  const className = [
+    "tw-border tw-border-solid tw-border-iron-700 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-transition tw-duration-300 tw-ease-out",
+    isActive
+      ? "tw-bg-iron-800 tw-text-iron-100"
+      : "tw-bg-iron-950 tw-text-iron-500 hover:tw-bg-iron-900 hover:tw-text-iron-100",
+    tab === USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY ? "tw-rounded-l-lg" : "",
+    tab === USER_PAGE_ACTIVITY_TAB.TDH_HISTORY ? "tw-rounded-r-lg" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <button
       type="button"
-      className={`tw-border tw-border-solid tw-border-iron-700 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-transition tw-duration-300 tw-ease-out ${
-        tab === activeTab
-          ? "tw-bg-iron-800 tw-text-iron-100"
-          : "tw-bg-iron-950 tw-text-iron-500 hover:tw-bg-iron-900 hover:tw-text-iron-100"
-      } ${
-        tab === USER_PAGE_ACTIVITY_TAB.WALLET_ACTIVITY && "tw-rounded-l-lg"
-      } ${tab === USER_PAGE_ACTIVITY_TAB.TDH_HISTORY && "tw-rounded-r-lg"}`}
+      role="tab"
+      id={getActivityTabId(tab)}
+      aria-selected={isActive}
+      aria-controls={getActivityPanelId(tab)}
+      tabIndex={isActive ? 0 : -1}
+      className={className}
       onClick={() => setActiveTab(tab)}
+      onKeyDown={onKeyDown}
     >
-      {TAB_TO_LABEL[tab]}
+      {t(DEFAULT_LOCALE, TAB_TO_LABEL_KEY[tab])}
     </button>
   );
 }

--- a/components/user/stats/activity/tabs/UserPageActivityTabs.tsx
+++ b/components/user/stats/activity/tabs/UserPageActivityTabs.tsx
@@ -1,5 +1,30 @@
+import type { KeyboardEvent } from "react";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import { USER_PAGE_ACTIVITY_TAB } from "../activity.types";
+import {
+  getActivityTabId,
+  getNextActivityTab,
+  USER_PAGE_ACTIVITY_TABS,
+} from "./activity-tabs.helpers";
 import UserPageActivityTab from "./UserPageActivityTab";
+
+const focusActivityTab = (tab: USER_PAGE_ACTIVITY_TAB) => {
+  if (typeof globalThis.document === "undefined") {
+    return;
+  }
+
+  const focusTab = () => {
+    globalThis.document.getElementById(getActivityTabId(tab))?.focus();
+  };
+
+  if (typeof globalThis.requestAnimationFrame === "function") {
+    globalThis.requestAnimationFrame(focusTab);
+    return;
+  }
+
+  globalThis.setTimeout(focusTab, 0);
+};
 
 export default function UserPageActivityTabs({
   activeTab,
@@ -8,14 +33,43 @@ export default function UserPageActivityTabs({
   readonly activeTab: USER_PAGE_ACTIVITY_TAB;
   readonly setActiveTab: (tab: USER_PAGE_ACTIVITY_TAB) => void;
 }) {
+  const selectTabFromKeyboard = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    tab: USER_PAGE_ACTIVITY_TAB
+  ) => {
+    const keyToTab: Partial<Record<string, USER_PAGE_ACTIVITY_TAB>> = {
+      ArrowLeft: getNextActivityTab(tab, -1),
+      ArrowRight: getNextActivityTab(tab, 1),
+      Home: USER_PAGE_ACTIVITY_TABS[0],
+      End: USER_PAGE_ACTIVITY_TABS[USER_PAGE_ACTIVITY_TABS.length - 1],
+    };
+    const nextTab = keyToTab[event.key];
+
+    if (!nextTab) {
+      return;
+    }
+
+    event.preventDefault();
+    setActiveTab(nextTab);
+    focusActivityTab(nextTab);
+  };
+
   return (
-    <div className="tw-inline-flex tw-overflow-hidden tw-rounded-lg">
-      {Object.values(USER_PAGE_ACTIVITY_TAB).map((tab) => (
+    <div
+      role="tablist"
+      aria-label={t(
+        DEFAULT_LOCALE,
+        "user.collected.stats.activityTabs.listLabel"
+      )}
+      className="tw-inline-flex tw-overflow-hidden tw-rounded-lg"
+    >
+      {USER_PAGE_ACTIVITY_TABS.map((tab) => (
         <UserPageActivityTab
           key={tab}
           tab={tab}
           activeTab={activeTab}
           setActiveTab={setActiveTab}
+          onKeyDown={(event) => selectTabFromKeyboard(event, tab)}
         />
       ))}
     </div>

--- a/components/user/stats/activity/tabs/activity-tabs.helpers.ts
+++ b/components/user/stats/activity/tabs/activity-tabs.helpers.ts
@@ -1,0 +1,24 @@
+import { USER_PAGE_ACTIVITY_TAB } from "../activity.types";
+
+export const USER_PAGE_ACTIVITY_TABS = Object.values(USER_PAGE_ACTIVITY_TAB);
+
+const toActivityTabSlug = (tab: USER_PAGE_ACTIVITY_TAB) =>
+  tab.toLowerCase().replaceAll("_", "-");
+
+export const getActivityTabId = (tab: USER_PAGE_ACTIVITY_TAB) =>
+  `user-collected-activity-tab-${toActivityTabSlug(tab)}`;
+
+export const getActivityPanelId = (tab: USER_PAGE_ACTIVITY_TAB) =>
+  `user-collected-activity-panel-${toActivityTabSlug(tab)}`;
+
+export const getNextActivityTab = (
+  tab: USER_PAGE_ACTIVITY_TAB,
+  offset: number
+) => {
+  const currentIndex = USER_PAGE_ACTIVITY_TABS.indexOf(tab);
+  const nextIndex =
+    (currentIndex + offset + USER_PAGE_ACTIVITY_TABS.length) %
+    USER_PAGE_ACTIVITY_TABS.length;
+
+  return USER_PAGE_ACTIVITY_TABS[nextIndex];
+};

--- a/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistory.tsx
+++ b/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistory.tsx
@@ -4,6 +4,7 @@ import type { TDHHistory } from "@/entities/ITDH";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import { commonApiFetch } from "@/services/api/common-api";
 import { useQuery } from "@tanstack/react-query";
+import { getTdhHistoryMessage } from "./tdh-history.messages";
 import UserPageStatsActivityTDHHistoryCharts from "./UserPageStatsActivityTDHHistoryCharts";
 
 export default function UserPageStatsActivityTDHHistory({
@@ -26,7 +27,10 @@ export default function UserPageStatsActivityTDHHistory({
 
   if (isFetching) {
     content = (
-      <div className="tw-mt-2 sm:tw-mt-4 tw-w-full tw-h-96">
+      <div className="tw-mt-2 tw-h-96 tw-w-full sm:tw-mt-4">
+        <span className="tw-sr-only">
+          {getTdhHistoryMessage("user.collected.stats.tdhHistory.loading")}
+        </span>
         <CommonCardSkeleton />
       </div>
     );
@@ -34,10 +38,10 @@ export default function UserPageStatsActivityTDHHistory({
     content = <UserPageStatsActivityTDHHistoryCharts tdhHistory={tdhHistory} />;
   } else {
     content = (
-      <div className="tw-mt-2 lg:tw-mt-4 tw-bg-iron-950 tw-border tw-border-iron-700 tw-border-solid tw-rounded-lg tw-overflow-x-auto">
-        <div className="tw-p-4 sm:tw-px-6 tw-text-sm tw-italic tw-text-iron-500">
-          No TDH history found
-        </div>
+      <div className="tw-mt-2 tw-overflow-x-auto tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 lg:tw-mt-4">
+        <output className="tw-block tw-p-4 tw-text-sm tw-italic tw-text-iron-500 sm:tw-px-6">
+          {getTdhHistoryMessage("user.collected.stats.tdhHistory.empty")}
+        </output>
       </div>
     );
   }
@@ -46,7 +50,7 @@ export default function UserPageStatsActivityTDHHistory({
     <div className="tw-mt-4 md:tw-mt-5">
       <div className="tw-flex">
         <h3 className="tw-mb-0 tw-text-lg tw-font-semibold tw-text-iron-100">
-          TDH History
+          {getTdhHistoryMessage("user.collected.stats.tdhHistory.title")}
         </h3>
       </div>
       {content}

--- a/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryChart.tsx
+++ b/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryChart.tsx
@@ -1,14 +1,15 @@
 import { Line } from "react-chartjs-2";
 
+import { formatTdhHistoryValue } from "./tdh-history.messages";
 import {
-    BarElement,
-    CategoryScale,
-    Chart as ChartJS,
-    Legend,
-    LinearScale,
-    LineElement,
-    PointElement,
-    Tooltip,
+  BarElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LinearScale,
+  LineElement,
+  PointElement,
+  Tooltip,
 } from "chart.js";
 import type { ChartProps } from "./UserPageStatsActivityTDHHistoryCharts";
 
@@ -38,6 +39,8 @@ const GRAPH_OPTIONS = {
       },
       ticks: {
         color: "rgb(154, 154, 154)",
+        callback: (value: string | number) =>
+          typeof value === "number" ? formatTdhHistoryValue(value) : value,
       },
     },
   },
@@ -55,15 +58,29 @@ export default function UserPageStatsActivityTDHHistoryChart({
 }: {
   readonly data: ChartProps;
 }) {
+  const headingId = `tdh-history-chart-${data.id}`;
+
   return (
-    <div className="tw-bg-iron-950 tw-border tw-border-iron-800 tw-border-solid tw-rounded-xl">
-      <div className="tw-pt-6 tw-px-4 sm:tw-px-6 tw-flex">
-        <h3 className="tw-mb-0 tw-text-lg tw-font-semibold tw-text-iron-100">
+    <div
+      aria-labelledby={headingId}
+      className="tw-rounded-xl tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-950"
+      role="listitem"
+    >
+      <div className="tw-flex tw-px-4 tw-pt-6 sm:tw-px-6">
+        <h3
+          className="tw-mb-0 tw-text-lg tw-font-semibold tw-text-iron-100"
+          id={headingId}
+        >
           {data.title}
         </h3>
       </div>
       <div className="tw-p-6">
-        <Line data={data} options={GRAPH_OPTIONS} />
+        <Line
+          aria-label={data.ariaLabel}
+          data={data}
+          options={GRAPH_OPTIONS}
+          role="img"
+        />
       </div>
     </div>
   );

--- a/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryCharts.tsx
+++ b/components/user/stats/activity/tdh-history/UserPageStatsActivityTDHHistoryCharts.tsx
@@ -3,7 +3,10 @@
 import { useEffect, useState } from "react";
 import type { TDHHistory } from "@/entities/ITDH";
 import UserPageStatsActivityTDHHistoryChart from "./UserPageStatsActivityTDHHistoryChart";
-import { getRandomObjectId } from "@/helpers/AllowlistToolHelpers";
+import {
+  formatTdhHistoryDate,
+  getTdhHistoryMessage,
+} from "./tdh-history.messages";
 
 interface ChartData {
   readonly label: string;
@@ -12,58 +15,70 @@ interface ChartData {
   readonly borderColor: string;
 }
 export interface ChartProps {
+  readonly id: string;
   readonly title: string;
-  readonly labels: Date[];
+  readonly ariaLabel: string;
+  readonly labels: string[];
   readonly datasets: ChartData[];
 }
 
 interface ChartConfigDataset {
-  readonly label: string;
+  readonly labelKey: Parameters<typeof getTdhHistoryMessage>[0];
   readonly field: keyof TDHHistory;
   readonly color: string;
 }
 
 interface ChartConfig {
-  readonly title: string;
+  readonly id: string;
+  readonly titleKey: Parameters<typeof getTdhHistoryMessage>[0];
   readonly datasets: ChartConfigDataset[];
 }
 
 const CHART_CONFIGS: ChartConfig[] = [
   {
-    title: "Total TDH",
+    id: "total-tdh",
+    titleKey: "user.collected.stats.tdhHistory.charts.totalTdh.title",
     datasets: [
       {
-        label: "Total Boosted TDH",
+        labelKey:
+          "user.collected.stats.tdhHistory.charts.totalTdh.totalBoosted",
         field: "boosted_tdh",
         color: "#00DC21",
       },
     ],
   },
   {
-    title: "Net TDH Daily Change",
+    id: "net-daily-change",
+    titleKey: "user.collected.stats.tdhHistory.charts.netDailyChange.title",
     datasets: [
       {
-        label: "Net Boosted TDH",
+        labelKey:
+          "user.collected.stats.tdhHistory.charts.netDailyChange.netBoosted",
         field: "net_boosted_tdh",
         color: "#00DC21",
       },
     ],
   },
   {
-    title: "Created TDH Daily Change",
+    id: "created-daily-change",
+    titleKey: "user.collected.stats.tdhHistory.charts.createdDailyChange.title",
     datasets: [
       {
-        label: "Created Boosted TDH",
+        labelKey:
+          "user.collected.stats.tdhHistory.charts.createdDailyChange.createdBoosted",
         field: "created_boosted_tdh",
         color: "#00DC21",
       },
     ],
   },
   {
-    title: "Destroyed TDH Daily Change",
+    id: "destroyed-daily-change",
+    titleKey:
+      "user.collected.stats.tdhHistory.charts.destroyedDailyChange.title",
     datasets: [
       {
-        label: "Destroyed Boosted TDH",
+        labelKey:
+          "user.collected.stats.tdhHistory.charts.destroyedDailyChange.destroyedBoosted",
         field: "destroyed_boosted_tdh",
         color: "#00DC21",
       },
@@ -82,15 +97,15 @@ export default function UserPageStatsActivityTDHHistoryCharts({
 
   const getData = ({
     tdh,
-    labels,
+    dates,
     field,
   }: {
     tdh: TDHHistory[];
-    labels: Date[];
+    dates: TDHHistory["date"][];
     field: keyof TDHHistory;
   }): number[] => {
-    return labels.map((l) => {
-      const tdhItem = tdh.find((t) => t.date === l);
+    return dates.map((date) => {
+      const tdhItem = tdh.find((t) => t.date === date);
       if (!tdhItem) {
         return 0;
       }
@@ -101,18 +116,26 @@ export default function UserPageStatsActivityTDHHistoryCharts({
 
   const getDataSets = ({
     tdh,
-    labels,
+    dates,
   }: {
     tdh: TDHHistory[];
-    labels: Date[];
+    dates: TDHHistory["date"][];
   }): ChartProps[] => {
+    const labels = dates.map(formatTdhHistoryDate);
+
     return CHART_CONFIGS.map((config) => {
+      const title = getTdhHistoryMessage(config.titleKey);
       return {
-        title: config.title,
+        id: config.id,
+        title,
+        ariaLabel: getTdhHistoryMessage(
+          "user.collected.stats.tdhHistory.chartAriaLabel",
+          { title }
+        ),
         labels,
         datasets: config.datasets.map((d) => ({
-          label: d.label,
-          data: getData({ tdh, labels, field: d.field }),
+          label: getTdhHistoryMessage(d.labelKey),
+          data: getData({ tdh, dates, field: d.field }),
           backgroundColor: d.color,
           borderColor: d.color,
         })),
@@ -127,17 +150,20 @@ export default function UserPageStatsActivityTDHHistoryCharts({
     }
 
     const tdhHistoryReversed = tdhHistory.toReversed();
-    const tdhLabels = tdhHistoryReversed.map((t) => t.date);
-    setDataSets(getDataSets({ tdh: tdhHistoryReversed, labels: tdhLabels }));
+    const tdhDates = tdhHistoryReversed.map((t) => t.date);
+    setDataSets(getDataSets({ tdh: tdhHistoryReversed, dates: tdhDates }));
   }, [tdhHistory]);
 
   return (
-    <div className="tw-mt-2 sm:tw-mt-4 tw-flex tw-flex-col tw-gap-y-6 md:tw-gap-y-8">
+    <div
+      aria-label={getTdhHistoryMessage(
+        "user.collected.stats.tdhHistory.chartListLabel"
+      )}
+      className="tw-mt-2 tw-flex tw-flex-col tw-gap-y-6 sm:tw-mt-4 md:tw-gap-y-8"
+      role="list"
+    >
       {dataSets.map((dataSet) => (
-        <UserPageStatsActivityTDHHistoryChart
-          key={getRandomObjectId()}
-          data={dataSet}
-        />
+        <UserPageStatsActivityTDHHistoryChart key={dataSet.id} data={dataSet} />
       ))}
     </div>
   );

--- a/components/user/stats/activity/tdh-history/tdh-history.messages.ts
+++ b/components/user/stats/activity/tdh-history/tdh-history.messages.ts
@@ -1,0 +1,27 @@
+import { formatDate, formatInteger } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
+
+type TdhHistoryMessageKey = Extract<
+  MessageKey,
+  `user.collected.stats.tdhHistory.${string}`
+>;
+
+type MessageParams = Record<string, string | number>;
+
+export function getTdhHistoryMessage(
+  key: TdhHistoryMessageKey,
+  params: MessageParams = {}
+): string {
+  return t(DEFAULT_LOCALE, key, params);
+}
+
+export function formatTdhHistoryDate(date: Date | string | number): string {
+  return formatDate(DEFAULT_LOCALE, date);
+}
+
+export function formatTdhHistoryValue(
+  value: number | null | undefined
+): string {
+  return formatInteger(DEFAULT_LOCALE, value);
+}

--- a/components/user/stats/activity/wallet/UserPageStatsActivityWallet.tsx
+++ b/components/user/stats/activity/wallet/UserPageStatsActivityWallet.tsx
@@ -21,6 +21,7 @@ import {
 } from "../activity.helpers";
 import { UserPageStatsActivityWalletFilterType } from "./UserPageStatsActivityWallet.types";
 import UserPageStatsActivityWalletTableWrapper from "./table/UserPageStatsActivityWalletTableWrapper";
+import { getWalletActivityMessage } from "./wallet-activity.messages";
 
 const ENUM_AND_PATH: {
   type: UserPageStatsActivityWalletFilterType;
@@ -212,7 +213,9 @@ export default function UserPageStatsActivityWallet({
     <div className="tw-mt-4 md:tw-mt-5">
       <div className="tw-flex">
         <h3 className="tw-mb-0 tw-text-lg tw-font-semibold tw-text-iron-100">
-          Wallet Activity
+          {getWalletActivityMessage(
+            "user.collected.stats.walletActivity.title"
+          )}
         </h3>
       </div>
       <UserPageStatsActivityWalletTableWrapper

--- a/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilter.tsx
+++ b/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilter.tsx
@@ -1,10 +1,23 @@
 "use client";
 
-import { AnimatePresence, motion, useAnimate } from "framer-motion";
+import {
+  AnimatePresence,
+  LazyMotion,
+  domAnimation,
+  m,
+  useAnimate,
+} from "framer-motion";
 import { useEffect, useRef, useState } from "react";
 import { useClickAway, useKeyPressEvent } from "react-use";
 import { UserPageStatsActivityWalletFilterType } from "../UserPageStatsActivityWallet.types";
+import {
+  getWalletActivityFilterLabel,
+  getWalletActivityFilterOptionLabel,
+  getWalletActivityMessage,
+} from "../wallet-activity.messages";
 import UserPageStatsActivityWalletFilterItem from "./UserPageStatsActivityWalletFilterItem";
+
+const FILTER_LIST_ID = "wallet-activity-filter-options";
 
 export default function UserPageStatsActivityWalletFilter({
   activeFilter,
@@ -15,19 +28,6 @@ export default function UserPageStatsActivityWalletFilter({
     filter: UserPageStatsActivityWalletFilterType
   ) => void;
 }) {
-  const ACTIVITY_WALLET_FILTER_TYPE_TO_TITLE: Record<
-    UserPageStatsActivityWalletFilterType,
-    string
-  > = {
-    [UserPageStatsActivityWalletFilterType.ALL]: "All",
-    [UserPageStatsActivityWalletFilterType.AIRDROPS]: "Airdrops",
-    [UserPageStatsActivityWalletFilterType.MINTS]: "Mints",
-    [UserPageStatsActivityWalletFilterType.SALES]: "Sales",
-    [UserPageStatsActivityWalletFilterType.PURCHASES]: "Purchases",
-    [UserPageStatsActivityWalletFilterType.TRANSFERS]: "Transfers",
-    [UserPageStatsActivityWalletFilterType.BURNS]: "Burns",
-  };
-
   const [isOpen, setIsOpen] = useState(false);
   const [iconScope, animateIcon] = useAnimate();
   const toggleOpen = () => setIsOpen(!isOpen);
@@ -46,6 +46,7 @@ export default function UserPageStatsActivityWalletFilter({
     setActiveFilter(filter);
     setIsOpen(false);
   };
+  const activeFilterLabel = getWalletActivityFilterLabel(activeFilter);
 
   return (
     <div className="tw-w-full sm:tw-max-w-xs" ref={listRef}>
@@ -53,9 +54,15 @@ export default function UserPageStatsActivityWalletFilter({
         <button
           type="button"
           onClick={toggleOpen}
+          aria-expanded={isOpen}
+          aria-controls={FILTER_LIST_ID}
+          aria-label={getWalletActivityMessage(
+            "user.collected.stats.walletActivity.filterButtonLabel",
+            { filter: activeFilterLabel }
+          )}
           className="tw-relative tw-flex tw-w-full tw-items-center tw-rounded-lg tw-border-0 tw-bg-iron-900 tw-px-3.5 tw-py-2.5 tw-text-base tw-font-medium tw-text-iron-50 tw-caret-primary-400 tw-shadow-sm tw-ring-1 tw-ring-inset tw-ring-iron-700 tw-transition tw-duration-300 tw-ease-out placeholder:tw-text-iron-500 hover:tw-ring-iron-600 focus:tw-bg-transparent focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-primary-400 sm:tw-leading-6"
         >
-          <span>{ACTIVITY_WALLET_FILTER_TYPE_TO_TITLE[activeFilter]}</span>
+          <span>{activeFilterLabel}</span>
         </button>
         <div className="tw-pointer-events-none tw-absolute tw-inset-y-0 tw-right-0 tw-flex tw-items-center tw-pr-3.5">
           <svg
@@ -75,35 +82,46 @@ export default function UserPageStatsActivityWalletFilter({
             />
           </svg>
         </div>
-        <AnimatePresence mode="wait" initial={false}>
-          {isOpen && (
-            <motion.div
-              className="tw-absolute tw-right-0 tw-z-10 tw-mt-1 tw-w-full tw-origin-top-right tw-rounded-lg tw-bg-iron-800 tw-shadow-xl tw-ring-1 tw-ring-black tw-ring-opacity-5"
-              initial={{ opacity: 0, y: -20 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -20 }}
-              transition={{ duration: 0.2 }}
-            >
-              <div className="tw-absolute tw-z-10 tw-mt-1 tw-w-full tw-overflow-hidden tw-rounded-md tw-bg-iron-800 tw-shadow-2xl tw-ring-1 tw-ring-white/10">
-                <div className="tw-flow-root tw-max-h-[calc(16rem+_-10svh)] tw-overflow-y-auto tw-overflow-x-hidden tw-py-1">
-                  <ul className="tw-mx-0 tw-mb-0 tw-flex tw-list-none tw-flex-col tw-px-2">
-                    {Object.values(UserPageStatsActivityWalletFilterType).map(
-                      (filter) => (
-                        <UserPageStatsActivityWalletFilterItem
-                          key={`nft-activity-${filter}`}
-                          filter={filter}
-                          title={ACTIVITY_WALLET_FILTER_TYPE_TO_TITLE[filter]}
-                          activeFilter={activeFilter}
-                          onFilter={onFilter}
-                        />
-                      )
-                    )}
-                  </ul>
+        <LazyMotion features={domAnimation}>
+          <AnimatePresence mode="wait" initial={false}>
+            {isOpen && (
+              <m.div
+                className="tw-absolute tw-right-0 tw-z-10 tw-mt-1 tw-w-full tw-origin-top-right tw-rounded-lg tw-bg-iron-800 tw-shadow-xl tw-ring-1 tw-ring-black tw-ring-opacity-5"
+                initial={{ opacity: 0, y: -20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -20 }}
+                transition={{ duration: 0.2 }}
+              >
+                <div className="tw-absolute tw-z-10 tw-mt-1 tw-w-full tw-overflow-hidden tw-rounded-md tw-bg-iron-800 tw-shadow-2xl tw-ring-1 tw-ring-white/10">
+                  <div className="tw-flow-root tw-max-h-[calc(16rem+_-10svh)] tw-overflow-y-auto tw-overflow-x-hidden tw-py-1">
+                    <ul
+                      id={FILTER_LIST_ID}
+                      aria-label={getWalletActivityMessage(
+                        "user.collected.stats.walletActivity.filterOptionsLabel"
+                      )}
+                      className="tw-mx-0 tw-mb-0 tw-flex tw-list-none tw-flex-col tw-px-2"
+                    >
+                      {Object.values(UserPageStatsActivityWalletFilterType).map(
+                        (filter) => (
+                          <UserPageStatsActivityWalletFilterItem
+                            key={`nft-activity-${filter}`}
+                            filter={filter}
+                            title={getWalletActivityFilterLabel(filter)}
+                            ariaLabel={getWalletActivityFilterOptionLabel(
+                              filter
+                            )}
+                            activeFilter={activeFilter}
+                            onFilter={onFilter}
+                          />
+                        )
+                      )}
+                    </ul>
+                  </div>
                 </div>
-              </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
+              </m.div>
+            )}
+          </AnimatePresence>
+        </LazyMotion>
       </div>
     </div>
   );

--- a/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilterItem.tsx
+++ b/components/user/stats/activity/wallet/filter/UserPageStatsActivityWalletFilterItem.tsx
@@ -3,17 +3,23 @@ import type { UserPageStatsActivityWalletFilterType } from "../UserPageStatsActi
 export default function UserPageStatsActivityWalletFilterItem({
   filter,
   title,
+  ariaLabel,
   activeFilter,
   onFilter,
 }: {
   readonly filter: UserPageStatsActivityWalletFilterType;
   readonly title: string;
+  readonly ariaLabel: string;
   readonly activeFilter: UserPageStatsActivityWalletFilterType;
   readonly onFilter: (filter: UserPageStatsActivityWalletFilterType) => void;
 }) {
+  const isActive = filter === activeFilter;
   return (
     <li>
       <button
+        type="button"
+        aria-label={ariaLabel}
+        aria-pressed={isActive}
         className="tw-relative tw-flex tw-h-full tw-w-full tw-cursor-pointer tw-select-none tw-items-center tw-justify-between tw-rounded-lg tw-border-none tw-bg-transparent tw-p-2 tw-text-left tw-text-white tw-transition tw-duration-300 tw-ease-out hover:tw-bg-iron-700"
         onClick={() => onFilter(filter)}
       >
@@ -21,8 +27,9 @@ export default function UserPageStatsActivityWalletFilterItem({
           <span className="tw-text-sm tw-font-medium tw-text-white">
             {title}
           </span>
-          {filter === activeFilter && (
+          {isActive && (
             <svg
+              aria-hidden="true"
               className="tw-ml-2 tw-h-5 tw-w-5 tw-text-primary-300 tw-transition tw-duration-300 tw-ease-out"
               viewBox="0 0 24 24"
               fill="none"

--- a/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable.tsx
+++ b/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTable.tsx
@@ -2,6 +2,7 @@ import type { NFTLite } from "@/components/user/settings/UserSettingsImgSelectMe
 import type { NextGenCollection } from "@/entities/INextgen";
 import type { Transaction } from "@/entities/ITransaction";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
+import { getWalletActivityMessage } from "../wallet-activity.messages";
 import UserPageStatsActivityWalletTableRow from "./row/UserPageStatsActivityWalletTableRow";
 
 export default function UserPageStatsActivityWalletTable({
@@ -18,9 +19,14 @@ export default function UserPageStatsActivityWalletTable({
   readonly nextgenCollections: NextGenCollection[];
 }) {
   return (
-    <div className="tw-px-4 sm:tw-px-6 tw-mt-4 tw-pb-2 tw-inline-block tw-min-w-full tw-align-middle">
+    <div className="tw-mt-4 tw-inline-block tw-min-w-full tw-px-4 tw-pb-2 tw-align-middle sm:tw-px-6">
       <table className="tw-min-w-full">
-        <tbody className="tw-divide-y tw-divide-iron-800 tw-divide-solid tw-divide-x-0">
+        <caption className="tw-sr-only">
+          {getWalletActivityMessage(
+            "user.collected.stats.walletActivity.tableCaption"
+          )}
+        </caption>
+        <tbody className="tw-divide-x-0 tw-divide-y tw-divide-solid tw-divide-iron-800">
           {transactions.map((transaction) => (
             <UserPageStatsActivityWalletTableRow
               key={`${transaction.from_address}-${transaction.to_address}-${transaction.transaction}-${transaction.token_id}`}

--- a/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper.tsx
+++ b/components/user/stats/activity/wallet/table/UserPageStatsActivityWalletTableWrapper.tsx
@@ -7,6 +7,7 @@ import type { Transaction } from "@/entities/ITransaction";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import UserPageStatsActivityWalletFilter from "../filter/UserPageStatsActivityWalletFilter";
 import { UserPageStatsActivityWalletFilterType } from "../UserPageStatsActivityWallet.types";
+import { getWalletActivityEmptyMessage } from "../wallet-activity.messages";
 import UserPageStatsActivityWalletTable from "./UserPageStatsActivityWalletTable";
 export default function UserPageStatsActivityWalletTableWrapper({
   filter,
@@ -37,19 +38,6 @@ export default function UserPageStatsActivityWalletTableWrapper({
     filter: UserPageStatsActivityWalletFilterType
   ) => void;
 }) {
-  const FILTER_TO_NO_DATA: Record<
-    UserPageStatsActivityWalletFilterType,
-    string
-  > = {
-    [UserPageStatsActivityWalletFilterType.ALL]: "No transactions",
-    [UserPageStatsActivityWalletFilterType.AIRDROPS]: "No airdrops",
-    [UserPageStatsActivityWalletFilterType.MINTS]: "No mints",
-    [UserPageStatsActivityWalletFilterType.SALES]: "No sales",
-    [UserPageStatsActivityWalletFilterType.PURCHASES]: "No purchases",
-    [UserPageStatsActivityWalletFilterType.TRANSFERS]: "No transfers",
-    [UserPageStatsActivityWalletFilterType.BURNS]: "No burns",
-  };
-
   if (isFirstLoading) {
     return (
       <div className="tw-mt-2 tw-h-96 tw-w-full sm:tw-mt-4">
@@ -89,9 +77,9 @@ export default function UserPageStatsActivityWalletTableWrapper({
             )}
           </div>
         ) : (
-          <div className="tw-px-4 tw-py-4 tw-text-sm tw-italic tw-text-iron-500 sm:tw-px-6 sm:tw-text-base">
-            {FILTER_TO_NO_DATA[filter]}
-          </div>
+          <output className="tw-px-4 tw-py-4 tw-text-sm tw-italic tw-text-iron-500 sm:tw-px-6 sm:tw-text-base">
+            {getWalletActivityEmptyMessage(filter)}
+          </output>
         )}
       </div>
     </div>

--- a/components/user/stats/activity/wallet/wallet-activity.messages.ts
+++ b/components/user/stats/activity/wallet/wallet-activity.messages.ts
@@ -1,0 +1,71 @@
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
+import { UserPageStatsActivityWalletFilterType } from "./UserPageStatsActivityWallet.types";
+
+type WalletActivityMessageKey = Extract<
+  MessageKey,
+  `user.collected.stats.walletActivity.${string}`
+>;
+
+const FILTER_LABEL_KEYS: Record<
+  UserPageStatsActivityWalletFilterType,
+  WalletActivityMessageKey
+> = {
+  [UserPageStatsActivityWalletFilterType.ALL]:
+    "user.collected.stats.walletActivity.filters.all",
+  [UserPageStatsActivityWalletFilterType.AIRDROPS]:
+    "user.collected.stats.walletActivity.filters.airdrops",
+  [UserPageStatsActivityWalletFilterType.MINTS]:
+    "user.collected.stats.walletActivity.filters.mints",
+  [UserPageStatsActivityWalletFilterType.SALES]:
+    "user.collected.stats.walletActivity.filters.sales",
+  [UserPageStatsActivityWalletFilterType.PURCHASES]:
+    "user.collected.stats.walletActivity.filters.purchases",
+  [UserPageStatsActivityWalletFilterType.TRANSFERS]:
+    "user.collected.stats.walletActivity.filters.transfers",
+  [UserPageStatsActivityWalletFilterType.BURNS]:
+    "user.collected.stats.walletActivity.filters.burns",
+};
+
+const EMPTY_MESSAGE_KEYS: Record<
+  UserPageStatsActivityWalletFilterType,
+  WalletActivityMessageKey
+> = {
+  [UserPageStatsActivityWalletFilterType.ALL]:
+    "user.collected.stats.walletActivity.empty.all",
+  [UserPageStatsActivityWalletFilterType.AIRDROPS]:
+    "user.collected.stats.walletActivity.empty.airdrops",
+  [UserPageStatsActivityWalletFilterType.MINTS]:
+    "user.collected.stats.walletActivity.empty.mints",
+  [UserPageStatsActivityWalletFilterType.SALES]:
+    "user.collected.stats.walletActivity.empty.sales",
+  [UserPageStatsActivityWalletFilterType.PURCHASES]:
+    "user.collected.stats.walletActivity.empty.purchases",
+  [UserPageStatsActivityWalletFilterType.TRANSFERS]:
+    "user.collected.stats.walletActivity.empty.transfers",
+  [UserPageStatsActivityWalletFilterType.BURNS]:
+    "user.collected.stats.walletActivity.empty.burns",
+};
+
+export const getWalletActivityMessage = (
+  key: WalletActivityMessageKey,
+  params?: Parameters<typeof t>[2]
+) => t(DEFAULT_LOCALE, key, params);
+
+export const getWalletActivityFilterLabel = (
+  filter: UserPageStatsActivityWalletFilterType
+) => getWalletActivityMessage(FILTER_LABEL_KEYS[filter]);
+
+export const getWalletActivityFilterOptionLabel = (
+  filter: UserPageStatsActivityWalletFilterType
+) =>
+  getWalletActivityMessage(
+    "user.collected.stats.walletActivity.optionAriaLabel",
+    {
+      filter: getWalletActivityFilterLabel(filter),
+    }
+  );
+
+export const getWalletActivityEmptyMessage = (
+  filter: UserPageStatsActivityWalletFilterType
+) => getWalletActivityMessage(EMPTY_MESSAGE_KEYS[filter]);

--- a/components/utils/followers/Follower.tsx
+++ b/components/utils/followers/Follower.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import Link from "next/link";
 import type { ApiIdentityAndSubscriptionActions } from "@/generated/models/ApiIdentityAndSubscriptionActions";
 import UserCICAndLevel, {
@@ -8,6 +9,7 @@ import { AuthContext } from "@/components/auth/Auth";
 import UserFollowBtn, {
   UserFollowBtnSize,
 } from "@/components/user/utils/UserFollowBtn";
+import { getFollowersMessage } from "./followers.messages";
 
 const FOLLOW_STATUS_PREFETCH_MARGIN = "360px";
 
@@ -20,10 +22,13 @@ export default function Follower({
   readonly showFollowButton?: boolean | undefined;
   readonly mutedBackground?: boolean | undefined;
 }) {
-  const rowRef = useRef<HTMLDivElement>(null);
+  const rowRef = useRef<HTMLLIElement>(null);
   const [shouldLoadFollowButton, setShouldLoadFollowButton] = useState(false);
   const { connectedProfile } = useContext(AuthContext);
   const followerHandle = follower.identity.handle;
+  const followerProfileRoute =
+    followerHandle ?? follower.identity.primary_address;
+  const followerProfileName = followerHandle ?? follower.identity.primary_address;
   const normalizedFollowerHandle = followerHandle?.toLowerCase() ?? null;
   const normalizedConnectedHandle =
     connectedProfile?.handle?.toLowerCase() ?? null;
@@ -34,6 +39,12 @@ export default function Follower({
       normalizedFollowerHandle !== normalizedConnectedHandle)
   );
   const backgroundClass = mutedBackground ? "tw-bg-white/[0.01]" : "";
+  const profileLabel = getFollowersMessage("followers.profile.linkAriaLabel", {
+    handle: followerProfileName,
+  });
+  const profileImageAlt = getFollowersMessage("followers.profile.avatarAlt", {
+    handle: followerProfileName,
+  });
 
   useEffect(() => {
     if (!shouldShowFollowButton || shouldLoadFollowButton) {
@@ -63,18 +74,22 @@ export default function Follower({
   }, [shouldShowFollowButton, shouldLoadFollowButton]);
 
   return (
-    <div ref={rowRef} className={`${backgroundClass} tw-py-3`}>
+    <li ref={rowRef} className={`${backgroundClass} tw-py-3`}>
       <div className="tw-flex tw-items-center tw-justify-between tw-gap-x-3 tw-px-4 sm:tw-px-6">
         <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-x-3">
           <div className="tw-relative tw-h-10 tw-w-10 tw-flex-shrink-0 tw-rounded-lg tw-bg-iron-800">
             <div className="tw-h-full tw-w-full tw-rounded-lg">
               <div className="tw-h-full tw-w-full tw-max-w-full tw-overflow-hidden tw-rounded-lg tw-bg-iron-800 tw-ring-1 tw-ring-inset tw-ring-white/5">
-                <div className="tw-flex tw-h-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-lg tw-text-center">
+                <div className="tw-relative tw-flex tw-h-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-lg tw-text-center">
                   {follower.identity.pfp ? (
-                    <img
+                    // Profile avatars can come from arbitrary remote hosts, so this stays unoptimized.
+                    <Image
                       src={follower.identity.pfp}
-                      alt={`${follower.identity.handle}'s profile`}
-                      className="tw-mx-auto tw-h-auto tw-max-h-full tw-w-auto tw-max-w-full tw-bg-transparent tw-object-contain"
+                      alt={profileImageAlt}
+                      fill
+                      unoptimized
+                      sizes="40px"
+                      className="tw-bg-transparent tw-object-contain"
                     />
                   ) : (
                     <div className="tw-mx-auto tw-h-auto tw-max-h-full tw-w-auto tw-max-w-full tw-bg-transparent tw-object-contain" />
@@ -88,10 +103,11 @@ export default function Follower({
               <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-x-2">
                 <p className="tw-mb-0 tw-min-w-0 tw-text-md tw-font-semibold tw-leading-none tw-text-iron-50">
                   <Link
-                    href={`/${follower.identity.handle}`}
+                    href={`/${followerProfileRoute}`}
+                    aria-label={profileLabel}
                     className="tw-block tw-truncate tw-no-underline tw-transition tw-duration-300 tw-ease-out hover:tw-text-iron-500 hover:tw-underline"
                   >
-                    {follower.identity.handle}
+                    {followerProfileName}
                   </Link>
                 </p>
                 <UserCICAndLevel
@@ -115,6 +131,6 @@ export default function Follower({
           </div>
         )}
       </div>
-    </div>
+    </li>
   );
 }

--- a/components/utils/followers/FollowersList.tsx
+++ b/components/utils/followers/FollowersList.tsx
@@ -1,5 +1,6 @@
 import type { ApiIdentityAndSubscriptionActions } from "@/generated/models/ApiIdentityAndSubscriptionActions";
 import Follower from "./Follower";
+import { getFollowersMessage } from "./followers.messages";
 
 export default function FollowersList({
   followers,
@@ -8,8 +9,13 @@ export default function FollowersList({
   readonly followers: ApiIdentityAndSubscriptionActions[];
   readonly showFollowButtons?: boolean | undefined;
 }) {
+  const listLabel = getFollowersMessage("followers.list.label");
+
   return (
-    <div className="tw-mt-4 tw-flex tw-h-full tw-flex-col tw-overflow-hidden">
+    <ul
+      aria-label={listLabel}
+      className="tw-mb-0 tw-mt-4 tw-flex tw-h-full tw-list-none tw-flex-col tw-overflow-hidden tw-p-0"
+    >
       {followers.map((follower, index) => (
         <Follower
           key={follower.identity.id}
@@ -18,6 +24,6 @@ export default function FollowersList({
           mutedBackground={index % 2 === 1}
         />
       ))}
-    </div>
+    </ul>
   );
 }

--- a/components/utils/followers/FollowersListWrapper.tsx
+++ b/components/utils/followers/FollowersListWrapper.tsx
@@ -4,6 +4,7 @@ import CircleLoader, {
 } from "@/components/distribution-plan-tool/common/CircleLoader";
 import CommonIntersectionElement from "../CommonIntersectionElement";
 import FollowersList from "./FollowersList";
+import { getFollowersMessage } from "./followers.messages";
 
 export default function FollowersListWrapper({
   followers,
@@ -16,14 +17,22 @@ export default function FollowersListWrapper({
   readonly onBottomIntersection: (state: boolean) => void;
   readonly showFollowButtons?: boolean | undefined;
 }) {
+  const loadingLabel = getFollowersMessage("followers.list.loading");
+
   return (
-    <div className="tw-h-full tw-overflow-hidden">
+    <div className="tw-h-full tw-overflow-hidden" aria-busy={loading}>
       <FollowersList
         followers={followers}
         showFollowButtons={showFollowButtons}
       />
       {loading && (
-        <div className="tw-mt-8 tw-w-full tw-text-center">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-label={loadingLabel}
+          className="tw-mt-8 tw-w-full tw-text-center"
+        >
+          <span className="tw-sr-only">{loadingLabel}</span>
           <CircleLoader size={CircleLoaderSize.XXLARGE} />
         </div>
       )}

--- a/components/utils/followers/followers.messages.ts
+++ b/components/utils/followers/followers.messages.ts
@@ -1,0 +1,13 @@
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
+
+type FollowersMessageKey = Extract<MessageKey, `followers.${string}`>;
+
+type MessageParams = Record<string, string | number>;
+
+export function getFollowersMessage(
+  key: FollowersMessageKey,
+  params: MessageParams = {}
+): string {
+  return t(DEFAULT_LOCALE, key, params);
+}

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -115,6 +115,28 @@ const USER_COLLECTED_STATS_DETAILS_MESSAGES = objectMessages(
   } as const
 );
 
+const USER_COLLECTED_STATS_BOOST_MESSAGES = objectMessages(
+  "user.collected.stats.boostBreakdown",
+  {
+    title: "Boost Breakdown",
+    versionLink: "TDH Version: {version}",
+    tableCaption: "TDH boost breakdown by source",
+    "columns.type": "Type",
+    "columns.potential": "Potential Boost",
+    "columns.actual": "Actual Boost",
+    "groups.memes": "Memes",
+    "rows.fullCollectionSet": "Full Collection Set",
+    "rows.genesisSet": "Genesis Set",
+    "rows.nakamoto": "Nakamoto",
+    "rows.gradients": "Gradients",
+    "rows.total": "TOTAL BOOST",
+    seasonLabel: "SZN{seasonNumber}",
+    "info.totalPotential": "Total Potential Boost",
+    "info.totalActual": "Total Actual Boost",
+    "info.ariaLabel": "Show boost detail",
+  } as const
+);
+
 const MEME_LAB_DETAIL_MESSAGES = namespaceMessages("memeLab.detail", [
   ["browserTitle", "{name} | Meme Lab #{tokenId}"],
   ["browserTitleWithTab", "{title} | {tab}"],
@@ -620,6 +642,7 @@ export const EN_US_MESSAGES = {
   "user.collected.filters.scrollRight": "Scroll filters right",
   ...USER_COLLECTED_STATS_MESSAGES,
   ...USER_COLLECTED_STATS_DETAILS_MESSAGES,
+  ...USER_COLLECTED_STATS_BOOST_MESSAGES,
   "user.collected.networkCards.listLabel": "Collected network cards",
   "user.collected.networkCards.empty": "No network tokens found",
   "user.collected.networkCards.defaultCollection": "Network",

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -137,6 +137,127 @@ const USER_COLLECTED_STATS_BOOST_MESSAGES = objectMessages(
   } as const
 );
 
+const USER_COLLECTED_STATS_ACTIVITY_MESSAGES = objectMessages(
+  "user.collected.stats.activityOverview",
+  {
+    title: "Activity Overview",
+    overview: "Overview",
+    memesBySeason: "Memes Breakdown By Season",
+    "tables.overviewCaption": "Collected activity summary by collection",
+    "tables.memesBySeasonCaption":
+      "Collected Meme activity breakdown by season",
+    "tables.memesBySeasonEmpty": "No Meme activity by season yet.",
+    "rows.airdrops": "Airdrops",
+    "rows.transfersIn": "Transfers In",
+    "rows.mints": "Mints",
+    "rows.mintsEth": "Mints (ETH)",
+    "rows.purchases": "Purchases",
+    "rows.purchasesEth": "Purchases (ETH)",
+    "rows.transfersOut": "Transfers Out",
+    "rows.burns": "Burns",
+    "rows.sales": "Sales",
+    "rows.salesEth": "Sales (ETH)",
+    seasonLabel: "Season {seasonNumber}",
+  } as const
+);
+
+const USER_COLLECTED_STATS_ACTIVITY_TABS_MESSAGES = objectMessages(
+  "user.collected.stats.activityTabs",
+  {
+    listLabel: "Activity details sections",
+    walletActivity: "Wallet Activity",
+    distributions: "Distributions",
+    tdhHistory: "TDH History",
+  } as const
+);
+
+const USER_COLLECTED_STATS_WALLET_ACTIVITY_MESSAGES = objectMessages(
+  "user.collected.stats.walletActivity",
+  {
+    title: "Wallet Activity",
+    filterButtonLabel: "Wallet activity filter: {filter}",
+    filterOptionsLabel: "Wallet activity filter options",
+    optionAriaLabel: "Show {filter} wallet activity",
+    tableCaption: "Wallet activity transactions",
+    "filters.all": "All",
+    "filters.airdrops": "Airdrops",
+    "filters.mints": "Mints",
+    "filters.sales": "Sales",
+    "filters.purchases": "Purchases",
+    "filters.transfers": "Transfers",
+    "filters.burns": "Burns",
+    "empty.all": "No transactions",
+    "empty.airdrops": "No airdrops",
+    "empty.mints": "No mints",
+    "empty.sales": "No sales",
+    "empty.purchases": "No purchases",
+    "empty.transfers": "No transfers",
+    "empty.burns": "No burns",
+  } as const
+);
+
+const USER_COLLECTED_STATS_DISTRIBUTIONS_MESSAGES = objectMessages(
+  "user.collected.stats.distributions",
+  {
+    title: "Distributions",
+    empty: "No distributions found",
+    loading: "Loading distributions",
+    tableCaption: "Profile distribution claims",
+    tokenLinkAriaLabel: "View {collection} token #{tokenId}",
+    "columns.collection": "Collection",
+    "columns.token": "Token",
+    "columns.name": "Name",
+    "columns.wallet": "Wallet",
+    "columns.minted": "Minted",
+    "columns.total": "Total",
+    "collections.memes": "The Memes",
+    "collections.gradients": "6529Gradient",
+    "collections.memeLab": "Meme Lab",
+    "phases.airdrop": "Airdrop",
+  } as const
+);
+
+const USER_COLLECTED_STATS_TDH_HISTORY_MESSAGES = objectMessages(
+  "user.collected.stats.tdhHistory",
+  {
+    title: "TDH History",
+    empty: "No TDH history found",
+    loading: "Loading TDH history",
+    chartListLabel: "TDH history charts",
+    chartAriaLabel: "{title} chart",
+    "charts.totalTdh.title": "Total TDH",
+    "charts.totalTdh.totalBoosted": "Total Boosted TDH",
+    "charts.netDailyChange.title": "Net TDH Daily Change",
+    "charts.netDailyChange.netBoosted": "Net Boosted TDH",
+    "charts.createdDailyChange.title": "Created TDH Daily Change",
+    "charts.createdDailyChange.createdBoosted": "Created Boosted TDH",
+    "charts.destroyedDailyChange.title": "Destroyed TDH Daily Change",
+    "charts.destroyedDailyChange.destroyedBoosted": "Destroyed Boosted TDH",
+  } as const
+);
+
+const USER_PROFILE_TABS_MESSAGES = objectMessages("user.profile.tabs", {
+  navigationLabel: "Profile sections",
+  scrollLeft: "Scroll profile sections left",
+  scrollRight: "Scroll profile sections right",
+  identity: "Identity",
+  brain: "Brain",
+  curation: "Curation",
+  collected: "Collected",
+  xtdh: "xTDH",
+  subscriptions: "Subscriptions",
+  proxy: "Proxy",
+  "badges.beta": "Beta",
+} as const);
+
+const FOLLOWERS_MESSAGES = objectMessages("followers", {
+  "modal.title": "Followers",
+  "list.label": "Followers",
+  "list.loading": "Loading followers",
+  "profile.linkAriaLabel": "View {handle}'s profile",
+  "profile.avatarAlt": "{handle}'s profile image",
+} as const);
+
 const MEME_LAB_DETAIL_MESSAGES = namespaceMessages("memeLab.detail", [
   ["browserTitle", "{name} | Meme Lab #{tokenId}"],
   ["browserTitleWithTab", "{title} | {tab}"],
@@ -643,6 +764,11 @@ export const EN_US_MESSAGES = {
   ...USER_COLLECTED_STATS_MESSAGES,
   ...USER_COLLECTED_STATS_DETAILS_MESSAGES,
   ...USER_COLLECTED_STATS_BOOST_MESSAGES,
+  ...USER_COLLECTED_STATS_ACTIVITY_MESSAGES,
+  ...USER_COLLECTED_STATS_ACTIVITY_TABS_MESSAGES,
+  ...USER_COLLECTED_STATS_WALLET_ACTIVITY_MESSAGES,
+  ...USER_COLLECTED_STATS_DISTRIBUTIONS_MESSAGES,
+  ...USER_COLLECTED_STATS_TDH_HISTORY_MESSAGES,
   "user.collected.networkCards.listLabel": "Collected network cards",
   "user.collected.networkCards.empty": "No network tokens found",
   "user.collected.networkCards.defaultCollection": "Network",
@@ -651,6 +777,8 @@ export const EN_US_MESSAGES = {
   "user.collected.networkCards.tokenLabel": "#{tokenId}",
   "user.collected.networkCards.xtdh": "xTDH",
   "user.collected.networkCards.xtdhPerDay": "xTDH/day",
+  ...USER_PROFILE_TABS_MESSAGES,
+  ...FOLLOWERS_MESSAGES,
   ...REMEMES_DETAIL_MESSAGES,
 } as const;
 

--- a/ops/docs/profiles/tabs/feature-collected-tab.md
+++ b/ops/docs/profiles/tabs/feature-collected-tab.md
@@ -81,7 +81,23 @@ Transfer mode is part of the Native collected view (not a separate route).
      - collected details tables include screen-reader captions and row headers
        for assistive technologies
    - `Activity Overview`
+   - Activity Overview heading, table headings, row labels, and per-season
+     labels are message-backed from the source locale
+   - Activity Overview tables include screen-reader captions and row headers
+     for assistive technologies
    - lower section tabs: `Wallet Activity`, `Distributions`, `TDH History`
+     - lower Activity tab labels and the tab-list accessible name are
+       message-backed from the source locale
+     - lower Activity tabs expose tab/panel relationships and support keyboard
+       arrow, Home, and End navigation
+   - `Wallet Activity`
+     - Wallet Activity heading, filter labels, filter accessible names, empty
+       states, and transaction table caption are message-backed from the source
+       locale
+   - `Distributions`
+     - Distributions heading, empty state, table caption, table headings,
+       collection names, token link accessible names, and relative time display
+       are message-backed or locale-formatted from the source locale
    - `Boost Breakdown`
    - Boost Breakdown static labels and table headings are message-backed from
      the source locale; the table exposes a screen-reader caption, row

--- a/ops/docs/profiles/tabs/feature-collected-tab.md
+++ b/ops/docs/profiles/tabs/feature-collected-tab.md
@@ -83,6 +83,9 @@ Transfer mode is part of the Native collected view (not a separate route).
    - `Activity Overview`
    - lower section tabs: `Wallet Activity`, `Distributions`, `TDH History`
    - `Boost Breakdown`
+   - Boost Breakdown static labels and table headings are message-backed from
+     the source locale; the table exposes a screen-reader caption, row
+     headers, and keyboard-focusable info triggers.
 5. Choose `View`:
    - `Native` for profile card holdings.
    - `Network` for xTDH token holdings.

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -37,8 +37,10 @@ page migration PRs for safe media surfaces.
 - PR #2630 is bot-happy on the latest head and remains review-ready only.
 - PR #2631 is bot-happy on the latest head and remains review-ready only.
 - PR #2633 is bot-happy on the latest head and remains review-ready only.
+- PR #2634 is open for the profile collected Boost Breakdown table and remains
+  review-ready only.
 - Current implementation surface: profile collected Boost Breakdown table under
-  the expanded stats panel is in progress. The branch is
+  the expanded stats panel is complete in PR #2634. The branch is
   `codex/user-collected-boost-breakdown-a11y-i18n`, stacked from PR #2633.
 - Non-source locales currently fall back to `en-US` until reviewed
   translations are added.
@@ -46,9 +48,9 @@ page migration PRs for safe media surfaces.
 
 ## Next Actions
 
-1. Open the Boost Breakdown branch as a review-ready stacked PR, then iterate
-   with available bots/checks without merging.
-2. Maintain PRs #2633, #2631, #2630, #2629, and #2628 as review-ready only;
+1. Iterate PR #2634 with available bots/checks, but do not merge without human
+   approval.
+2. Maintain PRs #2634, #2633, #2631, #2630, #2629, and #2628 as review-ready only;
    do not merge without human approval.
 3. Maintain PRs #2626 and #2627 as review-ready only; do not merge without
    human approval.

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -7,7 +7,7 @@ page migration PRs for safe media surfaces.
 
 ## Current Branch
 
-`codex/user-collected-details-tables-a11y-i18n`
+`codex/user-collected-boost-breakdown-a11y-i18n`
 
 ## Constraints
 
@@ -37,17 +37,17 @@ page migration PRs for safe media surfaces.
 - PR #2630 is bot-happy on the latest head and remains review-ready only.
 - PR #2631 is bot-happy on the latest head and remains review-ready only.
 - PR #2633 is bot-happy on the latest head and remains review-ready only.
-- Current implementation surface: profile collected details tables under the
-  expanded stats panel are complete in PR #2633. The branch is
-  `codex/user-collected-details-tables-a11y-i18n`, stacked from PR #2631.
+- Current implementation surface: profile collected Boost Breakdown table under
+  the expanded stats panel is in progress. The branch is
+  `codex/user-collected-boost-breakdown-a11y-i18n`, stacked from PR #2633.
 - Non-source locales currently fall back to `en-US` until reviewed
   translations are added.
 - Full locale-prefixed routing is deferred.
 
 ## Next Actions
 
-1. Start the next low-risk profile/media surface from PR #2633 after confirming
-   the target component boundaries.
+1. Open the Boost Breakdown branch as a review-ready stacked PR, then iterate
+   with available bots/checks without merging.
 2. Maintain PRs #2633, #2631, #2630, #2629, and #2628 as review-ready only;
    do not merge without human approval.
 3. Maintain PRs #2626 and #2627 as review-ready only; do not merge without

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -7,7 +7,7 @@ page migration PRs for safe media surfaces.
 
 ## Current Branch
 
-`codex/user-collected-boost-breakdown-a11y-i18n`
+`codex/user-followers-modal-a11y-i18n`
 
 ## Constraints
 
@@ -28,7 +28,7 @@ page migration PRs for safe media surfaces.
 - Initial supported locales: `en-US`, `en-GB`, `fr-FR`, `es-ES`, `de-DE`.
 - PR #2623 is bot-happy on the latest head and remains review-ready only.
 - PR #2624 is open and review-ready only after the CodeRabbit video-fallback
-  fix; keep it unmerged without human approval.
+  fix; keep it unmerged.
 - PR #2625 is bot-happy on the latest head and remains review-ready only.
 - PR #2626 is bot-happy on the latest head and remains review-ready only.
 - PR #2627 remains review-ready only with a bot-happy latest head.
@@ -37,23 +37,31 @@ page migration PRs for safe media surfaces.
 - PR #2630 is bot-happy on the latest head and remains review-ready only.
 - PR #2631 is bot-happy on the latest head and remains review-ready only.
 - PR #2633 is bot-happy on the latest head and remains review-ready only.
-- PR #2634 is open for the profile collected Boost Breakdown table and remains
-  review-ready only.
-- Current implementation surface: profile collected Boost Breakdown table under
-  the expanded stats panel is complete in PR #2634. The branch is
-  `codex/user-collected-boost-breakdown-a11y-i18n`, stacked from PR #2633.
+- PR #2634 is bot-happy on the latest head and remains review-ready only.
+- PR #2635 is bot-happy on the latest head and remains review-ready only.
+- PR #2636 is bot-happy on the latest head and remains review-ready only.
+- PR #2637 is bot-happy on the latest head and remains review-ready only.
+- PR #2638 is bot-happy on the latest head and remains review-ready only.
+- PR #2639 is bot-happy on the latest head and remains review-ready only.
+- PR #2640 is bot-happy on the latest head and remains review-ready only. It
+  covers profile shell tab titles, beta badge text, navigation landmark labels,
+  scroll button labels, and active-page semantics. It is stacked from PR #2639
+  and must not be merged.
+- PR #2641 is open and review-ready only. It covers the profile followers modal
+  title, follower list label, loading status, follower profile link names,
+  avatar alt text, and semantic list structure. It is stacked from PR #2640 and
+  must not be merged.
 - Non-source locales currently fall back to `en-US` until reviewed
   translations are added.
 - Full locale-prefixed routing is deferred.
 
 ## Next Actions
 
-1. Iterate PR #2634 with available bots/checks, but do not merge without human
-   approval.
-2. Maintain PRs #2634, #2633, #2631, #2630, #2629, and #2628 as review-ready only;
-   do not merge without human approval.
-3. Maintain PRs #2626 and #2627 as review-ready only; do not merge without
-   human approval.
-4. Keep all page implementation PRs review-ready only; do not merge without
-   human approval.
-5. Preserve the unrelated dirty EmojiContext and bootstrap style files.
+1. Iterate on PR #2641 with available bots/checks without
+   merging.
+2. Keep PR #2641 review-ready only; do not merge.
+3. Keep PR #2640 review-ready only; do not merge.
+4. Maintain PRs #2639, #2638, #2637, and earlier page PRs as review-ready only;
+   do not merge.
+5. Preserve the unrelated dirty EmojiContext, RememeImage test, and bootstrap
+   style files.

--- a/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
+++ b/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
@@ -51,3 +51,16 @@ Record review-bot and CI decisions here for this workstream.
 | 2026-06-13 | #2631 | SonarCloud   | Quality Gate passed with 0 new issues and 0.0% duplication after fix      | Accept                               |
 | 2026-06-13 | #2631 | Snyk         | No manifest changes detected                                              | Accept                               |
 | 2026-06-13 | #2631 | CodeRabbit   | Latest head passed with no review threads                                 | Accept                               |
+| 2026-06-13 | #2638 | CodeRabbit   | Flagged Distributions loading text remaining in the accessibility tree    | Fixed                                |
+| 2026-06-13 | #2638 | DCO          | Signed commits check passed                                               | Accept                               |
+| 2026-06-13 | #2638 | SonarCloud   | Quality Gate passed with 0 new issues after follow-up                     | Accept                               |
+| 2026-06-13 | #2638 | Snyk         | No manifest changes detected                                              | Accept                               |
+| 2026-06-13 | #2638 | CodeRabbit   | Latest head passed with the loading-label thread resolved                 | Accept                               |
+| 2026-06-13 | #2639 | DCO          | Signed commits check passed                                               | Accept                               |
+| 2026-06-13 | #2639 | SonarCloud   | Quality Gate passed with 0 new issues                                     | Accept                               |
+| 2026-06-13 | #2639 | Snyk         | No manifest changes detected                                              | Accept                               |
+| 2026-06-13 | #2639 | CodeRabbit   | Latest head passed with no review threads                                 | Accept                               |
+| 2026-06-13 | #2640 | DCO          | Signed commits check passed                                               | Accept                               |
+| 2026-06-13 | #2640 | SonarCloud   | Quality Gate passed with 0 new issues                                     | Accept                               |
+| 2026-06-13 | #2640 | Snyk         | No manifest changes detected                                              | Accept                               |
+| 2026-06-13 | #2640 | CodeRabbit   | Manual review completed with no review threads                            | Accept                               |

--- a/ops/workstreams/frontend-a11y-i18n/pr-links.md
+++ b/ops/workstreams/frontend-a11y-i18n/pr-links.md
@@ -1,33 +1,40 @@
 # PR Links
 
-| Purpose                   | Branch                                           | PR    | Status                  |
-| ------------------------- | ------------------------------------------------ | ----- | ----------------------- |
-| Standards and skills      | `codex/frontend-a11y-i18n-standards`             | #2603 | Merged                  |
-| The Memes list card       | `codex/the-memes-card-a11y-i18n`                 | #2604 | Open, review-ready only |
-| The Memes detail tabs     | `codex/the-memes-detail-a11y-i18n`               | #2607 | Open, review-ready only |
-| Meme Lab browse cards     | `codex/meme-lab-cards-a11y-i18n`                 | #2608 | Open, review-ready only |
-| Rememes browse cards      | `codex/rememes-cards-a11y-i18n`                  | #2609 | Open, review-ready only |
-| Rememe detail tabs        | `codex/rememe-detail-a11y-i18n`                  | #2610 | Open, review-ready only |
-| Meme Lab detail tabs      | `codex/meme-lab-detail-a11y-i18n`                | #2611 | Open, review-ready only |
-| Meme Lab distribution     | `codex/meme-lab-distribution-a11y-i18n`          | #2612 | Open, review-ready only |
-| The Memes live stats      | `codex/the-memes-live-stats-a11y-i18n`           | #2613 | Open, review-ready only |
-| The Memes activity        | `codex/the-memes-activity-a11y-i18n`             | #2614 | Open, review-ready only |
-| The Memes timeline        | `codex/the-memes-timeline-a11y-i18n`             | #2615 | Open, review-ready only |
-| Timeline media            | `codex/timeline-media-a11y-i18n`                 | #2616 | Open, review-ready only |
-| The Memes art viewer      | `codex/the-memes-art-viewer-a11y-i18n`           | #2617 | Open, review-ready only |
-| The Memes art details     | `codex/the-memes-art-details-a11y-i18n`          | #2618 | Open, review-ready only |
-| The Memes references      | `codex/the-memes-references-a11y-i18n`           | #2619 | Open, review-ready only |
-| Meme calendar periods     | `codex/meme-calendar-periods-a11y-i18n`          | #2620 | Open, review-ready only |
-| Meme calendar overview    | `codex/meme-calendar-overview-a11y-i18n`         | #2621 | Open, review-ready only |
-| Meme calendar grid        | `codex/meme-calendar-grid-a11y-i18n`             | #2622 | Open, review-ready only |
-| Meme calendar drilldowns  | `codex/meme-calendar-drilldown-a11y-i18n`        | #2623 | Open, review-ready only |
-| Rememes browse follow-up  | `codex/rememes-browse-card-followup-a11y-i18n`   | #2624 | Open, review-ready only |
-| Meme Lab browse follow-up | `codex/memelab-browse-card-a11y-i18n-followup`   | #2625 | Open, review-ready only |
-| Profile collected cards   | `codex/user-collected-cards-a11y-i18n`           | #2626 | Open, review-ready only |
-| Profile network cards     | `codex/user-collected-network-cards-a11y-i18n`   | #2627 | Open, review-ready only |
-| Profile empty states      | `codex/user-collected-empty-states-a11y-i18n`    | #2628 | Open, review-ready only |
-| Profile filter controls   | `codex/user-collected-sort-controls-a11y-i18n`   | #2629 | Open, review-ready only |
-| Profile season strip      | `codex/user-collected-season-strip-a11y-i18n`    | #2630 | Open, review-ready only |
-| Profile stats summary     | `codex/user-collected-stats-summary-a11y-i18n`   | #2631 | Open, review-ready only |
-| Profile details tables    | `codex/user-collected-details-tables-a11y-i18n`  | #2633 | Open, review-ready only |
-| Profile boost breakdown   | `codex/user-collected-boost-breakdown-a11y-i18n` | #2634 | Open, review-ready only |
+| Purpose                   | Branch                                                  | PR    | Status                  |
+| ------------------------- | ------------------------------------------------------- | ----- | ----------------------- |
+| Standards and skills      | `codex/frontend-a11y-i18n-standards`                    | #2603 | Merged                  |
+| The Memes list card       | `codex/the-memes-card-a11y-i18n`                        | #2604 | Open, review-ready only |
+| The Memes detail tabs     | `codex/the-memes-detail-a11y-i18n`                      | #2607 | Open, review-ready only |
+| Meme Lab browse cards     | `codex/meme-lab-cards-a11y-i18n`                        | #2608 | Open, review-ready only |
+| Rememes browse cards      | `codex/rememes-cards-a11y-i18n`                         | #2609 | Open, review-ready only |
+| Rememe detail tabs        | `codex/rememe-detail-a11y-i18n`                         | #2610 | Open, review-ready only |
+| Meme Lab detail tabs      | `codex/meme-lab-detail-a11y-i18n`                       | #2611 | Open, review-ready only |
+| Meme Lab distribution     | `codex/meme-lab-distribution-a11y-i18n`                 | #2612 | Open, review-ready only |
+| The Memes live stats      | `codex/the-memes-live-stats-a11y-i18n`                  | #2613 | Open, review-ready only |
+| The Memes activity        | `codex/the-memes-activity-a11y-i18n`                    | #2614 | Open, review-ready only |
+| The Memes timeline        | `codex/the-memes-timeline-a11y-i18n`                    | #2615 | Open, review-ready only |
+| Timeline media            | `codex/timeline-media-a11y-i18n`                        | #2616 | Open, review-ready only |
+| The Memes art viewer      | `codex/the-memes-art-viewer-a11y-i18n`                  | #2617 | Open, review-ready only |
+| The Memes art details     | `codex/the-memes-art-details-a11y-i18n`                 | #2618 | Open, review-ready only |
+| The Memes references      | `codex/the-memes-references-a11y-i18n`                  | #2619 | Open, review-ready only |
+| Meme calendar periods     | `codex/meme-calendar-periods-a11y-i18n`                 | #2620 | Open, review-ready only |
+| Meme calendar overview    | `codex/meme-calendar-overview-a11y-i18n`                | #2621 | Open, review-ready only |
+| Meme calendar grid        | `codex/meme-calendar-grid-a11y-i18n`                    | #2622 | Open, review-ready only |
+| Meme calendar drilldowns  | `codex/meme-calendar-drilldown-a11y-i18n`               | #2623 | Open, review-ready only |
+| Rememes browse follow-up  | `codex/rememes-browse-card-followup-a11y-i18n`          | #2624 | Open, review-ready only |
+| Meme Lab browse follow-up | `codex/memelab-browse-card-a11y-i18n-followup`          | #2625 | Open, review-ready only |
+| Profile collected cards   | `codex/user-collected-cards-a11y-i18n`                  | #2626 | Open, review-ready only |
+| Profile network cards     | `codex/user-collected-network-cards-a11y-i18n`          | #2627 | Open, review-ready only |
+| Profile empty states      | `codex/user-collected-empty-states-a11y-i18n`           | #2628 | Open, review-ready only |
+| Profile filter controls   | `codex/user-collected-sort-controls-a11y-i18n`          | #2629 | Open, review-ready only |
+| Profile season strip      | `codex/user-collected-season-strip-a11y-i18n`           | #2630 | Open, review-ready only |
+| Profile stats summary     | `codex/user-collected-stats-summary-a11y-i18n`          | #2631 | Open, review-ready only |
+| Profile details tables    | `codex/user-collected-details-tables-a11y-i18n`         | #2633 | Open, review-ready only |
+| Profile boost breakdown   | `codex/user-collected-boost-breakdown-a11y-i18n`        | #2634 | Open, review-ready only |
+| Profile activity overview | `codex/user-collected-activity-overview-a11y-i18n`      | #2635 | Open, review-ready only |
+| Profile activity tabs     | `codex/user-collected-activity-tabs-a11y-i18n`          | #2636 | Open, review-ready only |
+| Profile wallet activity   | `codex/user-collected-wallet-activity-filter-a11y-i18n` | #2637 | Open, review-ready only |
+| Profile distributions     | `codex/user-collected-distributions-a11y-i18n`          | #2638 | Open, review-ready only |
+| Profile TDH history       | `codex/user-collected-tdh-history-a11y-i18n`            | #2639 | Open, review-ready only |
+| Profile tabs shell        | `codex/user-profile-tabs-a11y-i18n`                     | #2640 | Open, review-ready only |
+| Profile followers modal   | `codex/user-followers-modal-a11y-i18n`                  | #2641 | Open, review-ready only |

--- a/ops/workstreams/frontend-a11y-i18n/pr-links.md
+++ b/ops/workstreams/frontend-a11y-i18n/pr-links.md
@@ -1,32 +1,33 @@
 # PR Links
 
-| Purpose                   | Branch                                          | PR    | Status                  |
-| ------------------------- | ----------------------------------------------- | ----- | ----------------------- |
-| Standards and skills      | `codex/frontend-a11y-i18n-standards`            | #2603 | Merged                  |
-| The Memes list card       | `codex/the-memes-card-a11y-i18n`                | #2604 | Open, review-ready only |
-| The Memes detail tabs     | `codex/the-memes-detail-a11y-i18n`              | #2607 | Open, review-ready only |
-| Meme Lab browse cards     | `codex/meme-lab-cards-a11y-i18n`                | #2608 | Open, review-ready only |
-| Rememes browse cards      | `codex/rememes-cards-a11y-i18n`                 | #2609 | Open, review-ready only |
-| Rememe detail tabs        | `codex/rememe-detail-a11y-i18n`                 | #2610 | Open, review-ready only |
-| Meme Lab detail tabs      | `codex/meme-lab-detail-a11y-i18n`               | #2611 | Open, review-ready only |
-| Meme Lab distribution     | `codex/meme-lab-distribution-a11y-i18n`         | #2612 | Open, review-ready only |
-| The Memes live stats      | `codex/the-memes-live-stats-a11y-i18n`          | #2613 | Open, review-ready only |
-| The Memes activity        | `codex/the-memes-activity-a11y-i18n`            | #2614 | Open, review-ready only |
-| The Memes timeline        | `codex/the-memes-timeline-a11y-i18n`            | #2615 | Open, review-ready only |
-| Timeline media            | `codex/timeline-media-a11y-i18n`                | #2616 | Open, review-ready only |
-| The Memes art viewer      | `codex/the-memes-art-viewer-a11y-i18n`          | #2617 | Open, review-ready only |
-| The Memes art details     | `codex/the-memes-art-details-a11y-i18n`         | #2618 | Open, review-ready only |
-| The Memes references      | `codex/the-memes-references-a11y-i18n`          | #2619 | Open, review-ready only |
-| Meme calendar periods     | `codex/meme-calendar-periods-a11y-i18n`         | #2620 | Open, review-ready only |
-| Meme calendar overview    | `codex/meme-calendar-overview-a11y-i18n`        | #2621 | Open, review-ready only |
-| Meme calendar grid        | `codex/meme-calendar-grid-a11y-i18n`            | #2622 | Open, review-ready only |
-| Meme calendar drilldowns  | `codex/meme-calendar-drilldown-a11y-i18n`       | #2623 | Open, review-ready only |
-| Rememes browse follow-up  | `codex/rememes-browse-card-followup-a11y-i18n`  | #2624 | Open, review-ready only |
-| Meme Lab browse follow-up | `codex/memelab-browse-card-a11y-i18n-followup`  | #2625 | Open, review-ready only |
-| Profile collected cards   | `codex/user-collected-cards-a11y-i18n`          | #2626 | Open, review-ready only |
-| Profile network cards     | `codex/user-collected-network-cards-a11y-i18n`  | #2627 | Open, review-ready only |
-| Profile empty states      | `codex/user-collected-empty-states-a11y-i18n`   | #2628 | Open, review-ready only |
-| Profile filter controls   | `codex/user-collected-sort-controls-a11y-i18n`  | #2629 | Open, review-ready only |
-| Profile season strip      | `codex/user-collected-season-strip-a11y-i18n`   | #2630 | Open, review-ready only |
-| Profile stats summary     | `codex/user-collected-stats-summary-a11y-i18n`  | #2631 | Open, review-ready only |
-| Profile details tables    | `codex/user-collected-details-tables-a11y-i18n` | #2633 | Open, review-ready only |
+| Purpose                   | Branch                                           | PR    | Status                  |
+| ------------------------- | ------------------------------------------------ | ----- | ----------------------- |
+| Standards and skills      | `codex/frontend-a11y-i18n-standards`             | #2603 | Merged                  |
+| The Memes list card       | `codex/the-memes-card-a11y-i18n`                 | #2604 | Open, review-ready only |
+| The Memes detail tabs     | `codex/the-memes-detail-a11y-i18n`               | #2607 | Open, review-ready only |
+| Meme Lab browse cards     | `codex/meme-lab-cards-a11y-i18n`                 | #2608 | Open, review-ready only |
+| Rememes browse cards      | `codex/rememes-cards-a11y-i18n`                  | #2609 | Open, review-ready only |
+| Rememe detail tabs        | `codex/rememe-detail-a11y-i18n`                  | #2610 | Open, review-ready only |
+| Meme Lab detail tabs      | `codex/meme-lab-detail-a11y-i18n`                | #2611 | Open, review-ready only |
+| Meme Lab distribution     | `codex/meme-lab-distribution-a11y-i18n`          | #2612 | Open, review-ready only |
+| The Memes live stats      | `codex/the-memes-live-stats-a11y-i18n`           | #2613 | Open, review-ready only |
+| The Memes activity        | `codex/the-memes-activity-a11y-i18n`             | #2614 | Open, review-ready only |
+| The Memes timeline        | `codex/the-memes-timeline-a11y-i18n`             | #2615 | Open, review-ready only |
+| Timeline media            | `codex/timeline-media-a11y-i18n`                 | #2616 | Open, review-ready only |
+| The Memes art viewer      | `codex/the-memes-art-viewer-a11y-i18n`           | #2617 | Open, review-ready only |
+| The Memes art details     | `codex/the-memes-art-details-a11y-i18n`          | #2618 | Open, review-ready only |
+| The Memes references      | `codex/the-memes-references-a11y-i18n`           | #2619 | Open, review-ready only |
+| Meme calendar periods     | `codex/meme-calendar-periods-a11y-i18n`          | #2620 | Open, review-ready only |
+| Meme calendar overview    | `codex/meme-calendar-overview-a11y-i18n`         | #2621 | Open, review-ready only |
+| Meme calendar grid        | `codex/meme-calendar-grid-a11y-i18n`             | #2622 | Open, review-ready only |
+| Meme calendar drilldowns  | `codex/meme-calendar-drilldown-a11y-i18n`        | #2623 | Open, review-ready only |
+| Rememes browse follow-up  | `codex/rememes-browse-card-followup-a11y-i18n`   | #2624 | Open, review-ready only |
+| Meme Lab browse follow-up | `codex/memelab-browse-card-a11y-i18n-followup`   | #2625 | Open, review-ready only |
+| Profile collected cards   | `codex/user-collected-cards-a11y-i18n`           | #2626 | Open, review-ready only |
+| Profile network cards     | `codex/user-collected-network-cards-a11y-i18n`   | #2627 | Open, review-ready only |
+| Profile empty states      | `codex/user-collected-empty-states-a11y-i18n`    | #2628 | Open, review-ready only |
+| Profile filter controls   | `codex/user-collected-sort-controls-a11y-i18n`   | #2629 | Open, review-ready only |
+| Profile season strip      | `codex/user-collected-season-strip-a11y-i18n`    | #2630 | Open, review-ready only |
+| Profile stats summary     | `codex/user-collected-stats-summary-a11y-i18n`   | #2631 | Open, review-ready only |
+| Profile details tables    | `codex/user-collected-details-tables-a11y-i18n`  | #2633 | Open, review-ready only |
+| Profile boost breakdown   | `codex/user-collected-boost-breakdown-a11y-i18n` | TBD   | In progress             |

--- a/ops/workstreams/frontend-a11y-i18n/pr-links.md
+++ b/ops/workstreams/frontend-a11y-i18n/pr-links.md
@@ -30,4 +30,4 @@
 | Profile season strip      | `codex/user-collected-season-strip-a11y-i18n`    | #2630 | Open, review-ready only |
 | Profile stats summary     | `codex/user-collected-stats-summary-a11y-i18n`   | #2631 | Open, review-ready only |
 | Profile details tables    | `codex/user-collected-details-tables-a11y-i18n`  | #2633 | Open, review-ready only |
-| Profile boost breakdown   | `codex/user-collected-boost-breakdown-a11y-i18n` | TBD   | In progress             |
+| Profile boost breakdown   | `codex/user-collected-boost-breakdown-a11y-i18n` | #2634 | Open, review-ready only |

--- a/ops/workstreams/frontend-a11y-i18n/route-page-status.md
+++ b/ops/workstreams/frontend-a11y-i18n/route-page-status.md
@@ -31,4 +31,4 @@
 | `/{user}/collected` season strip       | PR open              | PR open           | PR #2630; review-ready only; stacked on PR #2629; do not merge yet |
 | `/{user}/collected` stats summary      | PR open              | PR open           | PR #2631; review-ready only; stacked on PR #2630; do not merge yet |
 | `/{user}/collected` details tables     | PR open              | PR open           | PR #2633; review-ready only; stacked on PR #2631; do not merge yet |
-| `/{user}/collected` boost breakdown    | In progress          | In progress       | PR TBD; stacked on PR #2633; do not merge yet                      |
+| `/{user}/collected` boost breakdown    | PR open              | PR open           | PR #2634; review-ready only; stacked on PR #2633; do not merge yet |

--- a/ops/workstreams/frontend-a11y-i18n/route-page-status.md
+++ b/ops/workstreams/frontend-a11y-i18n/route-page-status.md
@@ -31,3 +31,4 @@
 | `/{user}/collected` season strip       | PR open              | PR open           | PR #2630; review-ready only; stacked on PR #2629; do not merge yet |
 | `/{user}/collected` stats summary      | PR open              | PR open           | PR #2631; review-ready only; stacked on PR #2630; do not merge yet |
 | `/{user}/collected` details tables     | PR open              | PR open           | PR #2633; review-ready only; stacked on PR #2631; do not merge yet |
+| `/{user}/collected` boost breakdown    | In progress          | In progress       | PR TBD; stacked on PR #2633; do not merge yet                      |

--- a/ops/workstreams/frontend-a11y-i18n/route-page-status.md
+++ b/ops/workstreams/frontend-a11y-i18n/route-page-status.md
@@ -32,3 +32,10 @@
 | `/{user}/collected` stats summary      | PR open              | PR open           | PR #2631; review-ready only; stacked on PR #2630; do not merge yet |
 | `/{user}/collected` details tables     | PR open              | PR open           | PR #2633; review-ready only; stacked on PR #2631; do not merge yet |
 | `/{user}/collected` boost breakdown    | PR open              | PR open           | PR #2634; review-ready only; stacked on PR #2633; do not merge yet |
+| `/{user}/collected` activity overview  | PR open              | PR open           | PR #2635; review-ready only; stacked on PR #2634; do not merge yet |
+| `/{user}/collected` activity tabs      | PR open              | PR open           | PR #2636; review-ready only; stacked on PR #2635; do not merge yet |
+| `/{user}/collected` wallet activity    | PR open              | PR open           | PR #2637; review-ready only; stacked on PR #2636; do not merge yet |
+| `/{user}/collected` distributions      | PR open              | PR open           | PR #2638; review-ready only; stacked on PR #2637; do not merge yet |
+| `/{user}/collected` TDH history        | PR open              | PR open           | PR #2639; review-ready only; stacked on PR #2638; do not merge yet |
+| User profile tabs shell                | PR open              | PR open           | PR #2640; review-ready only; stacked on PR #2639; do not merge yet |
+| User followers modal/list              | PR open              | PR open           | PR #2641; review-ready only; stacked on PR #2640; do not merge yet |

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -861,3 +861,23 @@
   SonarCloud passed, CodeRabbit manual review passed, there are no review
   threads, and Claude remained configured for manual review only. Per
   workstream policy, do not merge PR #2633 without human approval.
+- Started stacked branch `codex/user-collected-boost-breakdown-a11y-i18n` from
+  PR #2633 for the next low-risk `/{user}/collected` Details-panel follow-up.
+- Implemented message-backed source-locale labels for the Boost Breakdown
+  heading, TDH version link, table caption, columns, row labels, season labels,
+  and total boost tooltip copy. Added a screen-reader table caption, promoted
+  touched row labels to row headers, moved boost numeric values through the
+  repo i18n formatting helper, and made info tooltip triggers keyboard
+  focusable with accessible names.
+- Validation passed for the Boost Breakdown follow-up: focused boost
+  breakdown/i18n Jest suites (3 suites, 8 tests), `lint:changed`,
+  `typecheck:changed`, `react-doctor:diff`, and `git diff --check`. React
+  Doctor still reports only the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic.
+- Browser smoke passed on the live local frontend for `/punk6529/collected` at
+  desktop and a 390px mobile viewport. Verified `Details` opens, Boost
+  Breakdown renders with a screen-reader table caption, scoped column headers,
+  row headers, keyboard-focusable tooltip buttons with accessible names, no
+  page-level mobile overflow, and no Next.js runtime session errors. Console
+  resource errors were shared backend wave endpoints and blocked emoji feed
+  noise.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -883,3 +883,191 @@
   noise.
 - Opened review-ready stacked PR #2634 against PR #2633. Per workstream policy,
   do not merge PR #2634 without human approval.
+- Confirmed PR #2634 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed, CodeRabbit manual review passed, there are no review
+  threads, and Claude remained configured for manual review only. Per
+  workstream policy, do not merge PR #2634 without human approval.
+- Started stacked branch `codex/user-collected-activity-overview-a11y-i18n`
+  from PR #2634 for the next low-risk `/{user}/collected` Details-panel
+  follow-up.
+- Implemented message-backed source-locale labels for the Activity Overview
+  heading, accordion headings, table captions, columns, row labels, season
+  labels, and numeric/ETH values. Refactored repeated overview and per-season
+  activity rows into typed row/column configs, added screen-reader table
+  captions, and promoted touched row labels to row headers.
+- Validation passed for the Activity Overview follow-up: focused activity
+  overview/i18n Jest suites (2 suites, 5 tests), `lint:changed`,
+  `typecheck:changed`, `react-doctor:diff`, and `git diff --check`. React
+  Doctor still reports only the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic.
+- Browser smoke passed on the live local frontend for `/punk6529/collected` at
+  desktop and a 390px mobile viewport. Verified `Details` opens, Activity
+  Overview tables render with screen-reader captions, scoped column headers,
+  row headers, message-backed labels, horizontal scrollers containing wide
+  tables on mobile, and no Next.js runtime session errors. Console resource
+  errors were shared backend wave endpoints and blocked emoji feed noise.
+- Opened review-ready stacked PR #2635 against PR #2634. Per workstream policy,
+  do not merge PR #2635.
+- Confirmed PR #2635 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed after reducing the row-config duplication, CodeRabbit
+  manual review passed after the async test assertion fix, the stale review
+  thread is resolved/outdated, and Claude remained configured for manual review
+  only. Per workstream policy, do not merge PR #2635.
+- Started stacked branch `codex/user-collected-activity-tabs-a11y-i18n` from
+  PR #2635 for the next low-risk `/{user}/collected` Details-panel follow-up.
+- Implemented message-backed source-locale labels for the lower Activity tab
+  list and tabs, added a tab-list accessible name, connected tabs to the active
+  tabpanel, added roving tab focus with Arrow/Home/End keyboard switching, and
+  exposed active state via `aria-selected` while preserving the existing
+  query-param tab switching.
+- Validation passed for the Activity tabs follow-up: focused activity
+  tab/wrapper/i18n Jest suites (4 suites, 8 tests), `lint:changed`,
+  `typecheck:changed`, and `git diff --check`. `react-doctor:diff` exits 0 and
+  still reports the unrelated dirty `contexts/EmojiContext.tsx` fetch-in-effect
+  diagnostic plus a `useSearchParams` Suspense warning for
+  `UserPageActivityWrapper.tsx`; the wrapper now owns a local Suspense boundary
+  around the hook content, and the remaining warning appears to be analyzer
+  follow-up rather than a missing local boundary.
+- Browser smoke passed on the live local frontend for
+  `/punk6529/collected?activity=wallet-activity`. Verified the lower Activity
+  tab group exposes a named tablist, tabs expose `role="tab"`,
+  `aria-selected`, roving tab indexes, `aria-controls`, and stable IDs, the
+  active panel exposes `role="tabpanel"` and `aria-labelledby`, ArrowRight moves
+  focus/selection from `Wallet Activity` to `Distributions`, the query string
+  updates, and Next.js runtime diagnostics reported no config or session
+  errors. Console resource errors were shared backend wave endpoints and blocked
+  emoji feed noise.
+- Opened review-ready stacked PR #2636 against PR #2635. Per workstream policy,
+  do not merge PR #2636.
+- Confirmed PR #2636 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed, CodeRabbit manual review passed after tightening the
+  page-PR merge policy wording, the prior review thread is resolved/outdated,
+  and Claude remained configured for manual review only. Per workstream policy,
+  do not merge PR #2636.
+- Started stacked branch
+  `codex/user-collected-wallet-activity-filter-a11y-i18n` from PR #2636 for the
+  next low-risk `/{user}/collected` Details-panel follow-up.
+- Implemented message-backed source-locale labels for the Wallet Activity
+  heading, filter trigger/options, empty states, and transaction table caption.
+  Added accessible filter trigger/option names, `aria-expanded`,
+  `aria-controls`, option pressed state, status semantics for empty states, and
+  a screen-reader table caption. Swapped the touched framer-motion dropdown
+  usage to `LazyMotion`/`m`.
+- Validation passed for the Wallet Activity filter follow-up so far: focused
+  wallet filter/table/i18n Jest suites (5 suites, 10 tests), `lint:changed`,
+  `typecheck:changed`, `react-doctor:diff`, and browser smoke on
+  `/punk6529/collected?activity=wallet-activity`. React Doctor still reports
+  the unrelated dirty `contexts/EmojiContext.tsx` fetch-in-effect diagnostic
+  and the `useSearchParams` Suspense warning for the touched wallet component,
+  which is rendered under the activity wrapper Suspense boundary from PR #2636.
+  Browser smoke verified the Wallet Activity heading, filter trigger accessible
+  name, option list labels, pressed state, Wallet Activity table caption,
+  `Mints` selection/query update, and no Next.js runtime session errors.
+- Opened review-ready stacked PR #2637 against PR #2636. Per workstream policy,
+  do not merge PR #2637.
+- SonarCloud reported one non-blocking accessibility code smell on PR #2637:
+  prefer native `<output>` over `role="status"` for the Wallet Activity empty
+  state. Updated the empty state wrapper to `<output>` and reran focused wallet
+  filter/table/i18n Jest suites, targeted eslint for the touched wrapper file,
+  `typecheck:changed`, and `git diff --check`.
+- Confirmed PR #2637 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed with zero open issues after the `<output>` fix, CodeRabbit
+  manual review passed, no review threads are open, and Claude remains
+  configured for manual review only. Per workstream policy, do not merge PR
+  #2637.
+- Started stacked branch `codex/user-collected-distributions-a11y-i18n` from
+  PR #2637 for the next low-risk `/{user}/collected` Details-panel follow-up.
+- Implemented message-backed source-locale labels for the Distributions
+  heading, empty state, table caption, table headings, collection labels,
+  token link accessible names, and a loading-only screen-reader label. Replaced
+  the empty state with native `<output>`, switched distribution row numbers to
+  default-locale `Intl` formatting, switched relative time to the repo i18n
+  helper, and replaced phase index keys with stable phase-name keys.
+- Validation passed for the Distributions follow-up so far: focused
+  distributions/i18n Jest suites (5 suites, 10 tests), targeted eslint for the
+  PR-specific TypeScript files, `typecheck:changed`, `react-doctor:diff`, and
+  browser smoke on `/punk6529/collected?activity=distributions`.
+  `lint:changed` was not rerun for this branch because the long stacked diff
+  expands beyond Windows' command-line limit; the PR-specific eslint run passed.
+  React Doctor still reports the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic and the `useSearchParams` Suspense warning for
+  the touched Distributions component, which is rendered under the activity
+  wrapper Suspense boundary from PR #2636. Browser smoke verified the
+  Distributions tab selection/panel relationship, message-backed heading,
+  native empty-state output, and no Next.js runtime session errors.
+- Opened review-ready stacked PR #2638 against PR #2637. Per workstream policy,
+  do not merge PR #2638.
+- CodeRabbit flagged that the Distributions loading label remained in the
+  accessibility tree when visually hidden by opacity. Fixed the loader subtree
+  to render only while loading and added a focused regression assertion.
+- Confirmed PR #2638 is bot-happy on the latest head after the loading-label
+  follow-up: DCO passed, Snyk passed, SonarCloud passed with zero new issues,
+  CodeRabbit manual review passed, and the prior loading-label review thread is
+  resolved/outdated. Per workstream policy, do not merge PR #2638.
+- Started stacked branch `codex/user-collected-tdh-history-a11y-i18n` from PR
+  #2638 for the next low-risk `/{user}/collected` Details-panel follow-up.
+- Implemented message-backed source-locale labels for the TDH History heading,
+  loading label, empty state, chart list label, chart titles, dataset labels,
+  and chart accessible names. Replaced the empty state with native `<output>`,
+  switched chart date and axis labels through the repo i18n helpers, and
+  replaced random chart keys with stable chart IDs.
+- Validation passed for the TDH History follow-up so far: focused TDH
+  History/i18n Jest suites (3 suites, 8 tests), targeted eslint for the
+  PR-specific TypeScript files, `typecheck:changed`, `react-doctor:diff`, and
+  browser smoke on `/punk6529/collected?activity=tdh-history`. React Doctor
+  still reports the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic and the pre-existing heavy Chart.js import warning
+  in the touched TDH chart component. Browser smoke verified the TDH History tab
+  selection/panel relationship, message-backed heading, chart list label, chart
+  headings, canvas accessible names, and no Next.js runtime session errors; the
+  remaining browser console errors were the known local shared API wave 500s and
+  blocked emoji-list request.
+- Opened review-ready stacked PR #2639 against PR #2638. Per workstream policy,
+  do not merge PR #2639.
+- Confirmed PR #2639 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed, CodeRabbit manual review passed, and no review threads are
+  open. Per workstream policy, do not merge PR #2639.
+- Started stacked branch `codex/user-profile-tabs-a11y-i18n` from PR #2639 for
+  the next low-risk profile shell follow-up.
+- Implemented message-backed source-locale labels for profile tab titles, beta
+  badge text, profile-section navigation landmark text, and tab-scroll button
+  labels. Added `aria-current="page"` to the active profile tab link, wrapped
+  the search-param-driven tab tree in a documented Suspense boundary, and made
+  the horizontal tab scroll listener passive.
+- Validation passed for the profile tabs follow-up so far: focused
+  layout-tabs/i18n Jest suites (4 suites, 20 tests), targeted eslint for the
+  PR-specific TypeScript files, `typecheck:changed`, `react-doctor:diff`, and
+  browser smoke on `/punk6529/collected?activity=tdh-history`. React Doctor
+  still reports the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic, still flags `useSearchParams` in the touched
+  profile tab files despite the `UserPageLayout` Suspense boundary, and still
+  flags the existing `router.replace()` redirect effect. Browser smoke verified
+  the `Profile sections` navigation landmark, message-backed tab labels, the
+  explicit `xTDH Beta` link name, `aria-current="page"` on Collected, and no
+  Next.js runtime session errors; remaining browser console errors were the
+  known local shared API wave 500s and blocked emoji-list request.
+- Opened review-ready stacked PR #2640 against PR #2639. Per workstream policy,
+  do not merge PR #2640.
+- Confirmed PR #2640 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed, CodeRabbit manual review passed, and no review threads are
+  open. Per workstream policy, do not merge PR #2640.
+- Started stacked branch `codex/user-followers-modal-a11y-i18n` from PR #2640
+  for the next low-risk profile modal/list follow-up.
+- Implemented message-backed source-locale labels for the profile followers
+  modal title, follower list label, loading status label, follower profile link
+  names, and follower avatar alt text. Converted the follower collection to a
+  semantic list/listitem structure, added `aria-busy` plus a polite loading
+  status, and switched follower avatars to `next/image` with `unoptimized` for
+  arbitrary remote profile hosts.
+- Validation passed for the followers modal/list follow-up so far: focused
+  followers/i18n Jest suites (5 suites, 11 tests), targeted eslint for the
+  PR-specific source files, `typecheck:changed`, `react-doctor:diff`, and live
+  browser smoke on `/punk6529` at desktop and 390px mobile widths. React Doctor
+  still reports only the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic. Browser smoke verified the `Followers` dialog
+  title, modal `aria-modal`, `Followers` list label, two list items, labeled
+  profile links, avatar alt text, close button on mobile, and no Next.js
+  runtime session errors; browser console errors were local API/resource
+  responses unrelated to the followers modal change.
+- Opened review-ready stacked PR #2641 against PR #2640. Per workstream policy,
+  do not merge PR #2641.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -881,3 +881,5 @@
   page-level mobile overflow, and no Next.js runtime session errors. Console
   resource errors were shared backend wave endpoints and blocked emoji feed
   noise.
+- Opened review-ready stacked PR #2634 against PR #2633. Per workstream policy,
+  do not merge PR #2634 without human approval.


### PR DESCRIPTION
## Issue
- Continue the progressive WCAG 2.2 AA + i18n migration on `/{user}/collected`, stacked after the collected details table PR.
- The expanded `Details` Boost Breakdown table still had hardcoded heading, link, column, row, season, and tooltip labels.
- The table lacked a screen-reader caption, row-header semantics, and the info tooltip trigger was pointer-oriented without an accessible name.

## Fix
- Route touched Boost Breakdown copy through the source-locale message dictionary while preserving current `en-US` behavior and fallback semantics.
- Add a screen-reader-only table caption, scoped row headers, and keyboard-focusable tooltip buttons with accessible names.
- Move touched boost numeric values through the repo i18n number formatting helper using the current default locale.

## Changes
- Added `user.collected.stats.boostBreakdown.*` source messages for table and tooltip copy.
- Updated Boost Breakdown table markup for captions, row headers, and keyboard/focus tooltip access.
- Updated focused Boost Breakdown and i18n coverage.
- Updated the collected-tab ops doc and workstream tracker.

## Validation
- Focused Jest with `--runTestsByPath`: Boost Breakdown component suites and i18n message suite passed, 3 suites / 8 tests.
- `lint:changed` passed.
- `typecheck:changed` passed for changed TypeScript files.
- `react-doctor:diff` exited 0; only the pre-existing unrelated `EmojiContext` fetch-in-effect diagnostic remains.
- `git diff --check` passed.
- Browser smoke passed on the live local frontend for `/punk6529/collected` at desktop and 390px mobile viewport. Verified `Details` opens, Boost Breakdown table caption, scoped column headers, row headers, keyboard-focusable tooltip buttons with accessible names, no page-level mobile overflow, and no Next.js runtime session errors. Console resource errors were shared backend wave endpoints and blocked emoji feed noise.

## Risk
- Level: Low
- Why: Read-only copy extraction, number formatting through existing default-locale helpers, and table/accessibility semantics inside the expanded details panel. No transaction, routing, API, or data-shape changes.
- Rollback: Revert this PR to restore the prior hardcoded Boost Breakdown labels and table markup.

## Review Notes
- This is review-ready only. Per workstream policy, do not merge page implementation PRs without human approval.
- Please focus on table semantics, tooltip keyboard access, message-key naming, and whether default-locale formatting keeps the migration appropriately scoped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Boost Breakdown component now supports multiple languages, displaying content based on user locale
* **Accessibility Improvements**
  * Enhanced screen reader support with improved table captions and headers
  * Keyboard navigation support for interactive elements and info buttons
  * Better semantic structure for improved accessibility and navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->