### PR TITLE
Localize profile followers modal

### DIFF
--- a/__tests__/components/user/followers/UserPageFollowersModal.test.tsx
+++ b/__tests__/components/user/followers/UserPageFollowersModal.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import UserPageFollowersModal from "@/components/user/followers/UserPageFollowersModal";
+import useFollowersList from "@/hooks/useFollowersList";
+
+const followersListWrapper = jest.fn((props: any) => (
+  <div data-testid="followers-list">{props.followers.length}</div>
+));
+
+jest.mock("@/components/mobile-wrapper-dialog/MobileWrapperDialog", () => ({
+  __esModule: true,
+  default: ({ title, children }: any) => (
+    <section role="dialog" aria-label={title}>
+      {children}
+    </section>
+  ),
+}));
+
+jest.mock("@/components/utils/followers/FollowersListWrapper", () => ({
+  __esModule: true,
+  default: (props: any) => followersListWrapper(props),
+}));
+
+jest.mock("@/hooks/useFollowersList");
+
+const mockedUseFollowersList = useFollowersList as jest.Mock;
+
+describe("UserPageFollowersModal", () => {
+  beforeEach(() => {
+    followersListWrapper.mockClear();
+    mockedUseFollowersList.mockReturnValue({
+      followers: [{ identity: { id: "1", handle: "alice" } }],
+      isFetching: false,
+      onBottomIntersection: jest.fn(),
+    });
+  });
+
+  it("uses the localized followers title and forwards list state", () => {
+    render(
+      <UserPageFollowersModal
+        profileId="profile-1"
+        isOpen={true}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole("dialog", { name: "Followers" })).toBeInTheDocument();
+    expect(mockedUseFollowersList).toHaveBeenCalledWith({
+      profileId: "profile-1",
+      enabled: true,
+    });
+    expect(followersListWrapper).toHaveBeenCalledWith(
+      expect.objectContaining({
+        followers: [{ identity: { id: "1", handle: "alice" } }],
+        loading: false,
+        showFollowButtons: true,
+      })
+    );
+  });
+});

--- a/__tests__/components/utils/followers/Follower.test.tsx
+++ b/__tests__/components/utils/followers/Follower.test.tsx
@@ -1,11 +1,21 @@
-import type { ReactElement } from "react";
+import React, { type ReactElement } from "react";
 import { render, screen } from "@testing-library/react";
 import Follower from "@/components/utils/followers/Follower";
 import { AuthContext } from "@/components/auth/Auth";
 
 jest.mock("next/link", () => ({
   __esModule: true,
-  default: ({ href, children }: any) => <a href={href}>{children}</a>,
+  default: ({ href, children, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ alt, fill, sizes, unoptimized, ...props }: any) =>
+    React.createElement("img", { alt: alt ?? "", ...props }),
 }));
 
 jest.mock("@/helpers/Helpers", () => ({ cicToType: jest.fn(() => "UNKNOWN") }));
@@ -23,7 +33,7 @@ jest.mock("@/components/user/utils/UserFollowBtn", () => ({
 }));
 
 const baseFollower: any = {
-  identity: { handle: "alice", level: 5, cic: 0, pfp: "pic.png" },
+  identity: { id: "1", handle: "alice", level: 5, cic: 0, pfp: "pic.png" },
 };
 
 const renderWithAuth = (ui: ReactElement, connectedProfile: any = null) =>
@@ -47,14 +57,16 @@ const renderWithAuth = (ui: ReactElement, connectedProfile: any = null) =>
 
 test("renders follower info with image", () => {
   render(<Follower follower={baseFollower} />);
-  expect(screen.getByRole("link")).toHaveAttribute("href", "/alice");
-  expect(screen.getByAltText("alice's profile")).toBeInTheDocument();
+  expect(
+    screen.getByRole("link", { name: "View alice's profile" })
+  ).toHaveAttribute("href", "/alice");
+  expect(screen.getByAltText("alice's profile image")).toBeInTheDocument();
   expect(screen.getByTestId("cic")).toHaveTextContent("5");
 });
 
 test("shows placeholder when no pfp", () => {
   const follower = {
-    identity: { handle: "bob", level: 1, cic: 0, pfp: "" },
+    identity: { id: "2", handle: "bob", level: 1, cic: 0, pfp: "" },
   } as any;
   const { container } = render(<Follower follower={follower} />);
   expect(container.querySelector("img")).toBeNull();

--- a/__tests__/components/utils/followers/Follower.test.tsx
+++ b/__tests__/components/utils/followers/Follower.test.tsx
@@ -33,7 +33,14 @@ jest.mock("@/components/user/utils/UserFollowBtn", () => ({
 }));
 
 const baseFollower: any = {
-  identity: { id: "1", handle: "alice", level: 5, cic: 0, pfp: "pic.png" },
+  identity: {
+    id: "1",
+    handle: "alice",
+    level: 5,
+    cic: 0,
+    pfp: "pic.png",
+    primary_address: "0xalice",
+  },
 };
 
 const renderWithAuth = (ui: ReactElement, connectedProfile: any = null) =>
@@ -64,9 +71,36 @@ test("renders follower info with image", () => {
   expect(screen.getByTestId("cic")).toHaveTextContent("5");
 });
 
+test("falls back to primary address when follower handle is missing", () => {
+  const follower = {
+    identity: {
+      id: "3",
+      handle: null,
+      level: 2,
+      cic: 0,
+      pfp: "pic.png",
+      primary_address: "0xabc",
+    },
+  } as any;
+
+  render(<Follower follower={follower} />);
+
+  expect(
+    screen.getByRole("link", { name: "View 0xabc's profile" })
+  ).toHaveAttribute("href", "/0xabc");
+  expect(screen.getByAltText("0xabc's profile image")).toBeInTheDocument();
+});
+
 test("shows placeholder when no pfp", () => {
   const follower = {
-    identity: { id: "2", handle: "bob", level: 1, cic: 0, pfp: "" },
+    identity: {
+      id: "2",
+      handle: "bob",
+      level: 1,
+      cic: 0,
+      pfp: "",
+      primary_address: "0xbob",
+    },
   } as any;
   const { container } = render(<Follower follower={follower} />);
   expect(container.querySelector("img")).toBeNull();

--- a/__tests__/components/utils/followers/FollowersList.test.tsx
+++ b/__tests__/components/utils/followers/FollowersList.test.tsx
@@ -32,6 +32,7 @@ describe('FollowersList', () => {
       { identity: { id: '2', handle: 'b' } } as any,
     ];
     render(<FollowersList followers={followers} />);
+    expect(screen.getByRole('list', { name: 'Followers' })).toBeInTheDocument();
     expect(Follower).toHaveBeenCalledTimes(2);
     expect(screen.getAllByTestId('follower').length).toBe(2);
   });

--- a/__tests__/components/utils/followers/FollowersListWrapper.test.tsx
+++ b/__tests__/components/utils/followers/FollowersListWrapper.test.tsx
@@ -21,6 +21,7 @@ describe('FollowersListWrapper', () => {
     const cb = jest.fn();
     render(<FollowersListWrapper followers={[{ id: '1' } as any]} loading={true} onBottomIntersection={cb} />);
     expect(screen.getByTestId('list').textContent).toBe('1');
+    expect(screen.getByRole('status', { name: 'Loading followers' })).toBeInTheDocument();
     expect(screen.getByTestId('loader')).toBeInTheDocument();
     expect(cb).toHaveBeenCalledWith(true);
   });

--- a/__tests__/i18n/messages.test.ts
+++ b/__tests__/i18n/messages.test.ts
@@ -188,6 +188,14 @@ describe("frontend i18n helpers", () => {
       t("en-US", "user.profile.tabs.navigationLabel")
     );
     expect(t("de-DE", "user.profile.tabs.badges.beta")).toBe("Beta");
+    expect(t("fr-FR", "followers.modal.title")).toBe(
+      t("en-US", "followers.modal.title")
+    );
+    expect(
+      t("de-DE", "followers.profile.linkAriaLabel", {
+        handle: "alice",
+      })
+    ).toBe("View alice's profile");
     expect(t("es-ES", "user.collected.networkCards.empty")).toBe(
       t("en-US", "user.collected.networkCards.empty")
     );

--- a/components/user/followers/UserPageFollowersModal.tsx
+++ b/components/user/followers/UserPageFollowersModal.tsx
@@ -1,5 +1,6 @@
 import MobileWrapperDialog from "@/components/mobile-wrapper-dialog/MobileWrapperDialog";
 import FollowersListWrapper from "@/components/utils/followers/FollowersListWrapper";
+import { getFollowersMessage } from "@/components/utils/followers/followers.messages";
 import useFollowersList from "@/hooks/useFollowersList";
 
 export default function UserPageFollowersModal({
@@ -18,7 +19,7 @@ export default function UserPageFollowersModal({
 
   return (
     <MobileWrapperDialog
-      title="Followers"
+      title={getFollowersMessage("followers.modal.title")}
       isOpen={isOpen}
       onClose={onClose}
       tall

--- a/components/utils/followers/Follower.tsx
+++ b/components/utils/followers/Follower.tsx
@@ -26,6 +26,9 @@ export default function Follower({
   const [shouldLoadFollowButton, setShouldLoadFollowButton] = useState(false);
   const { connectedProfile } = useContext(AuthContext);
   const followerHandle = follower.identity.handle;
+  const followerProfileRoute =
+    followerHandle ?? follower.identity.primary_address;
+  const followerProfileName = followerHandle ?? follower.identity.primary_address;
   const normalizedFollowerHandle = followerHandle?.toLowerCase() ?? null;
   const normalizedConnectedHandle =
     connectedProfile?.handle?.toLowerCase() ?? null;
@@ -37,10 +40,10 @@ export default function Follower({
   );
   const backgroundClass = mutedBackground ? "tw-bg-white/[0.01]" : "";
   const profileLabel = getFollowersMessage("followers.profile.linkAriaLabel", {
-    handle: followerHandle,
+    handle: followerProfileName,
   });
   const profileImageAlt = getFollowersMessage("followers.profile.avatarAlt", {
-    handle: followerHandle,
+    handle: followerProfileName,
   });
 
   useEffect(() => {
@@ -100,11 +103,11 @@ export default function Follower({
               <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-x-2">
                 <p className="tw-mb-0 tw-min-w-0 tw-text-md tw-font-semibold tw-leading-none tw-text-iron-50">
                   <Link
-                    href={`/${follower.identity.handle}`}
+                    href={`/${followerProfileRoute}`}
                     aria-label={profileLabel}
                     className="tw-block tw-truncate tw-no-underline tw-transition tw-duration-300 tw-ease-out hover:tw-text-iron-500 hover:tw-underline"
                   >
-                    {follower.identity.handle}
+                    {followerProfileName}
                   </Link>
                 </p>
                 <UserCICAndLevel

--- a/components/utils/followers/Follower.tsx
+++ b/components/utils/followers/Follower.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import Link from "next/link";
 import type { ApiIdentityAndSubscriptionActions } from "@/generated/models/ApiIdentityAndSubscriptionActions";
 import UserCICAndLevel, {
@@ -8,6 +9,7 @@ import { AuthContext } from "@/components/auth/Auth";
 import UserFollowBtn, {
   UserFollowBtnSize,
 } from "@/components/user/utils/UserFollowBtn";
+import { getFollowersMessage } from "./followers.messages";
 
 const FOLLOW_STATUS_PREFETCH_MARGIN = "360px";
 
@@ -20,7 +22,7 @@ export default function Follower({
   readonly showFollowButton?: boolean | undefined;
   readonly mutedBackground?: boolean | undefined;
 }) {
-  const rowRef = useRef<HTMLDivElement>(null);
+  const rowRef = useRef<HTMLLIElement>(null);
   const [shouldLoadFollowButton, setShouldLoadFollowButton] = useState(false);
   const { connectedProfile } = useContext(AuthContext);
   const followerHandle = follower.identity.handle;
@@ -34,6 +36,12 @@ export default function Follower({
       normalizedFollowerHandle !== normalizedConnectedHandle)
   );
   const backgroundClass = mutedBackground ? "tw-bg-white/[0.01]" : "";
+  const profileLabel = getFollowersMessage("followers.profile.linkAriaLabel", {
+    handle: followerHandle,
+  });
+  const profileImageAlt = getFollowersMessage("followers.profile.avatarAlt", {
+    handle: followerHandle,
+  });
 
   useEffect(() => {
     if (!shouldShowFollowButton || shouldLoadFollowButton) {
@@ -63,18 +71,22 @@ export default function Follower({
   }, [shouldShowFollowButton, shouldLoadFollowButton]);
 
   return (
-    <div ref={rowRef} className={`${backgroundClass} tw-py-3`}>
+    <li ref={rowRef} className={`${backgroundClass} tw-py-3`}>
       <div className="tw-flex tw-items-center tw-justify-between tw-gap-x-3 tw-px-4 sm:tw-px-6">
         <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-x-3">
           <div className="tw-relative tw-h-10 tw-w-10 tw-flex-shrink-0 tw-rounded-lg tw-bg-iron-800">
             <div className="tw-h-full tw-w-full tw-rounded-lg">
               <div className="tw-h-full tw-w-full tw-max-w-full tw-overflow-hidden tw-rounded-lg tw-bg-iron-800 tw-ring-1 tw-ring-inset tw-ring-white/5">
-                <div className="tw-flex tw-h-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-lg tw-text-center">
+                <div className="tw-relative tw-flex tw-h-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-lg tw-text-center">
                   {follower.identity.pfp ? (
-                    <img
+                    // Profile avatars can come from arbitrary remote hosts, so this stays unoptimized.
+                    <Image
                       src={follower.identity.pfp}
-                      alt={`${follower.identity.handle}'s profile`}
-                      className="tw-mx-auto tw-h-auto tw-max-h-full tw-w-auto tw-max-w-full tw-bg-transparent tw-object-contain"
+                      alt={profileImageAlt}
+                      fill
+                      unoptimized
+                      sizes="40px"
+                      className="tw-bg-transparent tw-object-contain"
                     />
                   ) : (
                     <div className="tw-mx-auto tw-h-auto tw-max-h-full tw-w-auto tw-max-w-full tw-bg-transparent tw-object-contain" />
@@ -89,6 +101,7 @@ export default function Follower({
                 <p className="tw-mb-0 tw-min-w-0 tw-text-md tw-font-semibold tw-leading-none tw-text-iron-50">
                   <Link
                     href={`/${follower.identity.handle}`}
+                    aria-label={profileLabel}
                     className="tw-block tw-truncate tw-no-underline tw-transition tw-duration-300 tw-ease-out hover:tw-text-iron-500 hover:tw-underline"
                   >
                     {follower.identity.handle}
@@ -115,6 +128,6 @@ export default function Follower({
           </div>
         )}
       </div>
-    </div>
+    </li>
   );
 }

--- a/components/utils/followers/FollowersList.tsx
+++ b/components/utils/followers/FollowersList.tsx
@@ -1,5 +1,6 @@
 import type { ApiIdentityAndSubscriptionActions } from "@/generated/models/ApiIdentityAndSubscriptionActions";
 import Follower from "./Follower";
+import { getFollowersMessage } from "./followers.messages";
 
 export default function FollowersList({
   followers,
@@ -8,8 +9,13 @@ export default function FollowersList({
   readonly followers: ApiIdentityAndSubscriptionActions[];
   readonly showFollowButtons?: boolean | undefined;
 }) {
+  const listLabel = getFollowersMessage("followers.list.label");
+
   return (
-    <div className="tw-mt-4 tw-flex tw-h-full tw-flex-col tw-overflow-hidden">
+    <ul
+      aria-label={listLabel}
+      className="tw-mb-0 tw-mt-4 tw-flex tw-h-full tw-list-none tw-flex-col tw-overflow-hidden tw-p-0"
+    >
       {followers.map((follower, index) => (
         <Follower
           key={follower.identity.id}
@@ -18,6 +24,6 @@ export default function FollowersList({
           mutedBackground={index % 2 === 1}
         />
       ))}
-    </div>
+    </ul>
   );
 }

--- a/components/utils/followers/FollowersListWrapper.tsx
+++ b/components/utils/followers/FollowersListWrapper.tsx
@@ -4,6 +4,7 @@ import CircleLoader, {
 } from "@/components/distribution-plan-tool/common/CircleLoader";
 import CommonIntersectionElement from "../CommonIntersectionElement";
 import FollowersList from "./FollowersList";
+import { getFollowersMessage } from "./followers.messages";
 
 export default function FollowersListWrapper({
   followers,
@@ -16,14 +17,22 @@ export default function FollowersListWrapper({
   readonly onBottomIntersection: (state: boolean) => void;
   readonly showFollowButtons?: boolean | undefined;
 }) {
+  const loadingLabel = getFollowersMessage("followers.list.loading");
+
   return (
-    <div className="tw-h-full tw-overflow-hidden">
+    <div className="tw-h-full tw-overflow-hidden" aria-busy={loading}>
       <FollowersList
         followers={followers}
         showFollowButtons={showFollowButtons}
       />
       {loading && (
-        <div className="tw-mt-8 tw-w-full tw-text-center">
+        <div
+          role="status"
+          aria-live="polite"
+          aria-label={loadingLabel}
+          className="tw-mt-8 tw-w-full tw-text-center"
+        >
+          <span className="tw-sr-only">{loadingLabel}</span>
           <CircleLoader size={CircleLoaderSize.XXLARGE} />
         </div>
       )}

--- a/components/utils/followers/followers.messages.ts
+++ b/components/utils/followers/followers.messages.ts
@@ -1,0 +1,13 @@
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
+
+type FollowersMessageKey = Extract<MessageKey, `followers.${string}`>;
+
+type MessageParams = Record<string, string | number>;
+
+export function getFollowersMessage(
+  key: FollowersMessageKey,
+  params: MessageParams = {}
+): string {
+  return t(DEFAULT_LOCALE, key, params);
+}

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -249,6 +249,14 @@ const USER_PROFILE_TABS_MESSAGES = objectMessages("user.profile.tabs", {
   "badges.beta": "Beta",
 } as const);
 
+const FOLLOWERS_MESSAGES = objectMessages("followers", {
+  "modal.title": "Followers",
+  "list.label": "Followers",
+  "list.loading": "Loading followers",
+  "profile.linkAriaLabel": "View {handle}'s profile",
+  "profile.avatarAlt": "{handle}'s profile image",
+} as const);
+
 const MEME_LAB_DETAIL_MESSAGES = namespaceMessages("memeLab.detail", [
   ["browserTitle", "{name} | Meme Lab #{tokenId}"],
   ["browserTitleWithTab", "{title} | {tab}"],
@@ -769,6 +777,7 @@ export const EN_US_MESSAGES = {
   "user.collected.networkCards.xtdh": "xTDH",
   "user.collected.networkCards.xtdhPerDay": "xTDH/day",
   ...USER_PROFILE_TABS_MESSAGES,
+  ...FOLLOWERS_MESSAGES,
   ...REMEMES_DETAIL_MESSAGES,
 } as const;
 

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -7,7 +7,7 @@ page migration PRs for safe media surfaces.
 
 ## Current Branch
 
-`codex/user-profile-tabs-a11y-i18n`
+`codex/user-followers-modal-a11y-i18n`
 
 ## Constraints
 
@@ -43,18 +43,24 @@ page migration PRs for safe media surfaces.
 - PR #2637 is bot-happy on the latest head and remains review-ready only.
 - PR #2638 is bot-happy on the latest head and remains review-ready only.
 - PR #2639 is bot-happy on the latest head and remains review-ready only.
-- PR #2640 is open and review-ready only. It covers profile shell tab titles,
-  beta badge text, navigation landmark labels, scroll button labels, and
-  active-page semantics. It is stacked from PR #2639 and must not be merged.
+- PR #2640 is bot-happy on the latest head and remains review-ready only. It
+  covers profile shell tab titles, beta badge text, navigation landmark labels,
+  scroll button labels, and active-page semantics. It is stacked from PR #2639
+  and must not be merged.
+- Current local branch `codex/user-followers-modal-a11y-i18n` is stacked from
+  PR #2640 for the next profile followers modal/list follow-up.
 - Non-source locales currently fall back to `en-US` until reviewed
   translations are added.
 - Full locale-prefixed routing is deferred.
 
 ## Next Actions
 
-1. Iterate on PR #2640 with available bots/checks without merging.
-2. Keep PR #2640 review-ready only; do not merge.
-3. Maintain PRs #2639, #2638, #2637, and earlier page PRs as review-ready only;
+1. Open the followers modal/list follow-up PR against PR #2640 after final diff
+   review.
+2. Iterate on the followers modal/list PR with available bots/checks without
+   merging.
+3. Keep PR #2640 review-ready only; do not merge.
+4. Maintain PRs #2639, #2638, #2637, and earlier page PRs as review-ready only;
    do not merge.
-4. Preserve the unrelated dirty EmojiContext, RememeImage test, and bootstrap
+5. Preserve the unrelated dirty EmojiContext, RememeImage test, and bootstrap
    style files.

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -47,18 +47,19 @@ page migration PRs for safe media surfaces.
   covers profile shell tab titles, beta badge text, navigation landmark labels,
   scroll button labels, and active-page semantics. It is stacked from PR #2639
   and must not be merged.
-- Current local branch `codex/user-followers-modal-a11y-i18n` is stacked from
-  PR #2640 for the next profile followers modal/list follow-up.
+- PR #2641 is open and review-ready only. It covers the profile followers modal
+  title, follower list label, loading status, follower profile link names,
+  avatar alt text, and semantic list structure. It is stacked from PR #2640 and
+  must not be merged.
 - Non-source locales currently fall back to `en-US` until reviewed
   translations are added.
 - Full locale-prefixed routing is deferred.
 
 ## Next Actions
 
-1. Open the followers modal/list follow-up PR against PR #2640 after final diff
-   review.
-2. Iterate on the followers modal/list PR with available bots/checks without
+1. Iterate on PR #2641 with available bots/checks without
    merging.
+2. Keep PR #2641 review-ready only; do not merge.
 3. Keep PR #2640 review-ready only; do not merge.
 4. Maintain PRs #2639, #2638, #2637, and earlier page PRs as review-ready only;
    do not merge.

--- a/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
+++ b/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
@@ -60,3 +60,7 @@ Record review-bot and CI decisions here for this workstream.
 | 2026-06-13 | #2639 | SonarCloud   | Quality Gate passed with 0 new issues                                     | Accept                               |
 | 2026-06-13 | #2639 | Snyk         | No manifest changes detected                                              | Accept                               |
 | 2026-06-13 | #2639 | CodeRabbit   | Latest head passed with no review threads                                 | Accept                               |
+| 2026-06-13 | #2640 | DCO          | Signed commits check passed                                               | Accept                               |
+| 2026-06-13 | #2640 | SonarCloud   | Quality Gate passed with 0 new issues                                     | Accept                               |
+| 2026-06-13 | #2640 | Snyk         | No manifest changes detected                                              | Accept                               |
+| 2026-06-13 | #2640 | CodeRabbit   | Manual review completed with no review threads                            | Accept                               |

--- a/ops/workstreams/frontend-a11y-i18n/pr-links.md
+++ b/ops/workstreams/frontend-a11y-i18n/pr-links.md
@@ -37,3 +37,4 @@
 | Profile distributions     | `codex/user-collected-distributions-a11y-i18n`          | #2638 | Open, review-ready only |
 | Profile TDH history       | `codex/user-collected-tdh-history-a11y-i18n`            | #2639 | Open, review-ready only |
 | Profile tabs shell        | `codex/user-profile-tabs-a11y-i18n`                     | #2640 | Open, review-ready only |
+| Profile followers modal   | `codex/user-followers-modal-a11y-i18n`                  | #2641 | Open, review-ready only |

--- a/ops/workstreams/frontend-a11y-i18n/route-page-status.md
+++ b/ops/workstreams/frontend-a11y-i18n/route-page-status.md
@@ -38,4 +38,4 @@
 | `/{user}/collected` distributions      | PR open              | PR open           | PR #2638; review-ready only; stacked on PR #2637; do not merge yet |
 | `/{user}/collected` TDH history        | PR open              | PR open           | PR #2639; review-ready only; stacked on PR #2638; do not merge yet |
 | User profile tabs shell                | PR open              | PR open           | PR #2640; review-ready only; stacked on PR #2639; do not merge yet |
-| User followers modal/list              | Local branch         | Local branch      | Branch `codex/user-followers-modal-a11y-i18n`; stacked on PR #2640 |
+| User followers modal/list              | PR open              | PR open           | PR #2641; review-ready only; stacked on PR #2640; do not merge yet |

--- a/ops/workstreams/frontend-a11y-i18n/route-page-status.md
+++ b/ops/workstreams/frontend-a11y-i18n/route-page-status.md
@@ -38,3 +38,4 @@
 | `/{user}/collected` distributions      | PR open              | PR open           | PR #2638; review-ready only; stacked on PR #2637; do not merge yet |
 | `/{user}/collected` TDH history        | PR open              | PR open           | PR #2639; review-ready only; stacked on PR #2638; do not merge yet |
 | User profile tabs shell                | PR open              | PR open           | PR #2640; review-ready only; stacked on PR #2639; do not merge yet |
+| User followers modal/list              | Local branch         | Local branch      | Branch `codex/user-followers-modal-a11y-i18n`; stacked on PR #2640 |

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1069,3 +1069,5 @@
   profile links, avatar alt text, close button on mobile, and no Next.js
   runtime session errors; browser console errors were local API/resource
   responses unrelated to the followers modal change.
+- Opened review-ready stacked PR #2641 against PR #2640. Per workstream policy,
+  do not merge PR #2641.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1048,3 +1048,24 @@
   known local shared API wave 500s and blocked emoji-list request.
 - Opened review-ready stacked PR #2640 against PR #2639. Per workstream policy,
   do not merge PR #2640.
+- Confirmed PR #2640 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed, CodeRabbit manual review passed, and no review threads are
+  open. Per workstream policy, do not merge PR #2640.
+- Started stacked branch `codex/user-followers-modal-a11y-i18n` from PR #2640
+  for the next low-risk profile modal/list follow-up.
+- Implemented message-backed source-locale labels for the profile followers
+  modal title, follower list label, loading status label, follower profile link
+  names, and follower avatar alt text. Converted the follower collection to a
+  semantic list/listitem structure, added `aria-busy` plus a polite loading
+  status, and switched follower avatars to `next/image` with `unoptimized` for
+  arbitrary remote profile hosts.
+- Validation passed for the followers modal/list follow-up so far: focused
+  followers/i18n Jest suites (5 suites, 11 tests), targeted eslint for the
+  PR-specific source files, `typecheck:changed`, `react-doctor:diff`, and live
+  browser smoke on `/punk6529` at desktop and 390px mobile widths. React Doctor
+  still reports only the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic. Browser smoke verified the `Followers` dialog
+  title, modal `aria-modal`, `Followers` list label, two list items, labeled
+  profile links, avatar alt text, close button on mobile, and no Next.js
+  runtime session errors; browser console errors were local API/resource
+  responses unrelated to the followers modal change.


### PR DESCRIPTION
## Issue
- Continue the progressive WCAG 2.2 AA and i18n workstream on a low-risk profile surface.
- Stack this follow-up on #2640; keep it review-ready only and do not merge page-change PRs yet.

## Fix
- Make the profile followers modal/list translation-ready while improving accessible structure for the repeated follower rows.

## Changes
- Adds source-locale follower messages for the modal title, list label, loading status, profile link names, and avatar alt text.
- Converts the follower collection to semantic list/listitem markup.
- Adds `aria-busy` and a polite loading status for the follower list wrapper.
- Uses `next/image` with `unoptimized` for arbitrary remote profile avatar URLs.
- Falls back to the primary address when follower handles are nullable.
- Records the #2640 bot-happy state and the new follow-up in the workstream tracker.

## Validation
- `seize-local-dev bootstrap`
- Focused Jest: followers modal/list/item/wrapper plus i18n messages, 5 suites / 12 tests passed.
- Targeted ESLint for PR-specific source files passed.
- `typecheck:changed` passed for 111 changed TypeScript files.
- `react-doctor:diff` exited 0; the only remaining diagnostic is the unrelated dirty `contexts/EmojiContext.tsx` fetch-in-effect finding.
- `git diff --check` passed with line-ending warnings only.
- Browser smoke on `/punk6529` at desktop and 390px mobile width verified dialog title, modal semantics, `Followers` list label, list items, labeled profile links, avatar alt text, close button, and no Next.js runtime session errors.
- Browser console still shows local API/resource errors unrelated to this modal change.

## Risk
- Level: Low
- Why: limited to followers modal/list rendering, source-locale message dictionary, tests, and workstream notes.
- Rollback: revert this PR to restore previous hardcoded labels and wrapper markup.

## Review Notes
- Please focus on the list/listitem markup, loading status semantics, nullable follower handles, and `next/image unoptimized` use for arbitrary remote profile avatars.
- This is review-ready only; per workstream policy, do not merge this page-change PR yet.