### PR TITLE
Localize profile stats row

### DIFF
--- a/__tests__/components/user/user-page-header/UserPageHeaderAbout.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeaderAbout.test.tsx
@@ -1,32 +1,60 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import UserPageHeaderAbout from '@/components/user/user-page-header/about/UserPageHeaderAbout';
-import type { ApiIdentity } from '@/generated/models/ApiIdentity';
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UserPageHeaderAbout from "@/components/user/user-page-header/about/UserPageHeaderAbout";
+import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 
-jest.mock('@/components/user/user-page-header/about/UserPageHeaderAboutStatement', () => (props: any) => (
-  <div data-testid="statement">{JSON.stringify(props)}</div>
-));
+jest.mock(
+  "@/components/user/user-page-header/about/UserPageHeaderAboutStatement",
+  () => (props: any) => (
+    <div data-testid="statement">{JSON.stringify(props)}</div>
+  )
+);
 
-jest.mock('@/components/user/user-page-header/about/UserPageHeaderAboutEdit', () => (props: any) => (
-  <div data-testid="edit" onClick={() => props.onClose()} />
-));
+jest.mock(
+  "@/components/user/user-page-header/about/UserPageHeaderAboutEdit",
+  () => (props: any) => (
+    <button data-testid="edit" type="button" onClick={() => props.onClose()} />
+  )
+);
 
-const profile: ApiIdentity = { handle: 'alice' } as any;
+const profile: ApiIdentity = { handle: "alice" } as any;
 
-describe('UserPageHeaderAbout', () => {
-  it('toggles view on edit click', async () => {
-    render(<UserPageHeaderAbout profile={profile} statement={null} canEdit={true} />);
-    await userEvent.click(screen.getByRole('button'));
-    expect(screen.getByTestId('edit')).toBeInTheDocument();
+describe("UserPageHeaderAbout", () => {
+  it("opens edit view from the empty About add action", async () => {
+    render(
+      <UserPageHeaderAbout profile={profile} statement={null} canEdit={true} />
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add About statement" })
+    );
+    expect(screen.getByTestId("edit")).toBeInTheDocument();
   });
 
-  it('resets view when props change', () => {
+  it("opens edit view from the statement edit action", async () => {
+    render(
+      <UserPageHeaderAbout
+        profile={profile}
+        statement={{ statement_value: "Hello there" } as any}
+        canEdit={true}
+      />
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Edit About statement" })
+    );
+    expect(screen.getByTestId("edit")).toBeInTheDocument();
+  });
+
+  it("resets view when props change", () => {
     const { rerender } = render(
       <UserPageHeaderAbout profile={profile} statement={null} canEdit={true} />
     );
     rerender(
-      <UserPageHeaderAbout profile={{ handle: 'bob' } as any} statement={null} canEdit={true} />
+      <UserPageHeaderAbout
+        profile={{ handle: "bob" } as any}
+        statement={null}
+        canEdit={true}
+      />
     );
-    expect(screen.getByTestId('statement')).toBeInTheDocument();
+    expect(screen.getByTestId("statement")).toBeInTheDocument();
   });
 });

--- a/__tests__/components/user/user-page-header/UserPageHeaderAboutEditError.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeaderAboutEditError.test.tsx
@@ -1,23 +1,26 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import UserPageHeaderAboutEditError from '@/components/user/user-page-header/about/UserPageHeaderAboutEditError';
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UserPageHeaderAboutEditError from "@/components/user/user-page-header/about/UserPageHeaderAboutEditError";
 
-describe('UserPageHeaderAboutEditError', () => {
-  it('detects known error types', () => {
+describe("UserPageHeaderAboutEditError", () => {
+  it("detects known error types", () => {
     render(
       <UserPageHeaderAboutEditError
         msg="contains personal insults"
         closeError={jest.fn()}
       />
     );
-    expect(screen.getByText('Error: Personal Insults')).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("Error: Personal Insults")).toBeInTheDocument();
   });
 
-  it('handles unknown errors and close click', async () => {
+  it("handles unknown errors and close click", async () => {
     const close = jest.fn();
     render(<UserPageHeaderAboutEditError msg="something" closeError={close} />);
-    expect(screen.getByText('Unknown Error')).toBeInTheDocument();
-    await userEvent.click(screen.getByRole('button'));
+    expect(screen.getByText("Unknown Error")).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Dismiss About statement error" })
+    );
     expect(close).toHaveBeenCalled();
   });
 });

--- a/__tests__/components/user/user-page-header/UserPageHeaderAboutStatement.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeaderAboutStatement.test.tsx
@@ -1,16 +1,33 @@
-import { render, screen } from '@testing-library/react';
-import UserPageHeaderAboutStatement from '@/components/user/user-page-header/about/UserPageHeaderAboutStatement';
-import type { CicStatement } from '@/entities/IProfile';
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UserPageHeaderAboutStatement from "@/components/user/user-page-header/about/UserPageHeaderAboutStatement";
+import type { CicStatement } from "@/entities/IProfile";
 
-describe('UserPageHeaderAboutStatement', () => {
-  it('shows placeholder when statement is null', () => {
+describe("UserPageHeaderAboutStatement", () => {
+  it("shows placeholder when statement is null", () => {
     render(<UserPageHeaderAboutStatement statement={null} />);
-    expect(screen.getByText('Click to add an About statement')).toBeInTheDocument();
+    expect(
+      screen.getByText("Click to add an About statement")
+    ).toBeInTheDocument();
   });
 
-  it('renders statement value when provided', () => {
-    const statement: CicStatement = { statement_value: 'Hello there' } as any;
+  it("renders statement value when provided", () => {
+    const statement: CicStatement = { statement_value: "Hello there" } as any;
     render(<UserPageHeaderAboutStatement statement={statement} />);
-    expect(screen.getByText('Hello there')).toBeInTheDocument();
+    expect(screen.getByText("Hello there")).toBeInTheDocument();
+  });
+
+  it("toggles long statement expansion", async () => {
+    const statement: CicStatement = { statement_value: "a".repeat(241) } as any;
+    render(<UserPageHeaderAboutStatement statement={statement} />);
+
+    const toggle = screen.getByRole("button", { name: "See more" });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    await userEvent.click(toggle);
+    expect(screen.getByRole("button", { name: "See less" })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
   });
 });

--- a/__tests__/components/user/user-page-header/UserPageHeaderPfp.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeaderPfp.test.tsx
@@ -1,22 +1,41 @@
-import { render } from '@testing-library/react';
-import UserPageHeaderPfp from '@/components/user/user-page-header/pfp/UserPageHeaderPfp';
+import { render, screen } from "@testing-library/react";
+import { createElement } from "react";
 
-jest.mock('next/image', () => ({ __esModule: true, default: (props: any) => <img {...props} /> }));
+import UserPageHeaderPfp from "@/components/user/user-page-header/pfp/UserPageHeaderPfp";
 
-describe('UserPageHeaderPfp', () => {
-  it('renders image when profile has pfp', () => {
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: any) =>
+    createElement("img", { ...props, alt: props.alt ?? "" }),
+}));
+
+describe("UserPageHeaderPfp", () => {
+  it("renders image when profile has pfp", () => {
     const { container } = render(
-      <UserPageHeaderPfp profile={{ pfp: 'url' } as any} defaultBanner1="#000" defaultBanner2="#fff" />
+      <UserPageHeaderPfp
+        profile={{ pfp: "url" } as any}
+        profileLabel="Alice"
+        defaultBanner1="#000"
+        defaultBanner2="#fff"
+      />
     );
-    const img = container.querySelector('img');
+    const img = container.querySelector("img");
     expect(img).toBeInTheDocument();
-    expect(img?.getAttribute('src')).toContain('url');
+    expect(img?.getAttribute("src")).toContain("url");
+    expect(
+      screen.getByRole("img", { name: "Alice's profile picture" })
+    ).toBeInTheDocument();
   });
 
-  it('renders placeholder when no pfp', () => {
+  it("renders placeholder when no pfp", () => {
     const { container } = render(
-      <UserPageHeaderPfp profile={{} as any} defaultBanner1="#000" defaultBanner2="#fff" />
+      <UserPageHeaderPfp
+        profile={{} as any}
+        profileLabel="Alice"
+        defaultBanner1="#000"
+        defaultBanner2="#fff"
+      />
     );
-    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector("img")).toBeNull();
   });
 });

--- a/__tests__/components/user/user-page-header/UserPageHeaderPfpWrapper.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeaderPfpWrapper.test.tsx
@@ -1,29 +1,66 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import UserPageHeaderPfpWrapper from '@/components/user/user-page-header/pfp/UserPageHeaderPfpWrapper';
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
-jest.mock('@/components/utils/icons/PencilIcon', () => () => <span data-testid="pencil" />);
-jest.mock('@/components/user/user-page-header/pfp/UserPageHeaderEditPfp', () => (props: any) => (
-  <div data-testid="edit" onClick={props.onClose} />
+import UserPageHeaderPfpWrapper from "@/components/user/user-page-header/pfp/UserPageHeaderPfpWrapper";
+
+jest.mock("@/components/utils/icons/PencilIcon", () => () => (
+  <span data-testid="pencil" />
 ));
+jest.mock(
+  "@/components/user/user-page-header/pfp/UserPageHeaderEditPfp",
+  () => (props: any) => (
+    <button data-testid="edit" type="button" onClick={props.onClose} />
+  )
+);
 
-jest.mock('@/components/utils/animation/CommonAnimationWrapper', () => ({ children }: any) => <div>{children}</div>);
-jest.mock('@/components/utils/animation/CommonAnimationOpacity', () => ({ children, onClicked }: any) => (
-  <div data-testid="opacity" onClick={onClicked}>{children}</div>
-));
+jest.mock(
+  "@/components/utils/animation/CommonAnimationWrapper",
+  () =>
+    ({ children }: any) => <div>{children}</div>
+);
+jest.mock(
+  "@/components/utils/animation/CommonAnimationOpacity",
+  () =>
+    ({ children, onClicked }: any) => (
+      <button data-testid="opacity" type="button" onClick={onClicked}>
+        {children}
+      </button>
+    )
+);
 
-describe('UserPageHeaderPfpWrapper', () => {
-  it('opens and closes edit modal when button clicked', async () => {
+describe("UserPageHeaderPfpWrapper", () => {
+  it("opens and closes edit modal when button clicked", async () => {
     render(
-      <UserPageHeaderPfpWrapper profile={{} as any} canEdit={true}>
+      <UserPageHeaderPfpWrapper
+        profile={{} as any}
+        canEdit={true}
+        profileLabel="Alice"
+      >
         <span data-testid="child" />
       </UserPageHeaderPfpWrapper>
     );
 
-    await userEvent.click(screen.getByRole('button'));
-    expect(screen.getByTestId('edit')).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Edit Alice's profile picture" })
+    );
+    expect(screen.getByTestId("edit")).toBeInTheDocument();
 
-    await userEvent.click(screen.getByTestId('edit'));
-    expect(screen.queryByTestId('edit')).toBeNull();
+    await userEvent.click(screen.getByTestId("edit"));
+    expect(screen.queryByTestId("edit")).toBeNull();
+  });
+
+  it("does not render a disabled button when picture is read-only", () => {
+    render(
+      <UserPageHeaderPfpWrapper
+        profile={{} as any}
+        canEdit={false}
+        profileLabel="Alice"
+      >
+        <span data-testid="child" />
+      </UserPageHeaderPfpWrapper>
+    );
+
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getByTestId("child")).toBeInTheDocument();
   });
 });

--- a/__tests__/components/user/user-page-header/about/UserPageHeaderAboutEdit.test.tsx
+++ b/__tests__/components/user/user-page-header/about/UserPageHeaderAboutEdit.test.tsx
@@ -1,16 +1,23 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import UserPageHeaderAboutEdit from '@/components/user/user-page-header/about/UserPageHeaderAboutEdit';
-import { AuthContext } from '@/components/auth/Auth';
-import { ReactQueryWrapperContext } from '@/components/react-query-wrapper/ReactQueryWrapper';
-import { useMutation } from '@tanstack/react-query';
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UserPageHeaderAboutEdit from "@/components/user/user-page-header/about/UserPageHeaderAboutEdit";
+import { AuthContext } from "@/components/auth/Auth";
+import { ReactQueryWrapperContext } from "@/components/react-query-wrapper/ReactQueryWrapper";
+import { useMutation } from "@tanstack/react-query";
 
-jest.mock('react-use', () => ({ useKeyPressEvent: jest.fn() }));
+jest.mock("react-use", () => ({ useKeyPressEvent: jest.fn() }));
 
-jest.mock('@tanstack/react-query', () => ({ useMutation: jest.fn() }));
-jest.mock('@/services/api/common-api', () => ({ commonApiPost: jest.fn().mockResolvedValue({}) }));
-jest.mock('framer-motion', () => ({ AnimatePresence: (props: any) => <div>{props.children}</div> }));
-jest.mock('@/components/user/user-page-header/about/UserPageHeaderAboutEditError', () => (props: any) => <div>{props.msg}</div>);
+jest.mock("@tanstack/react-query", () => ({ useMutation: jest.fn() }));
+jest.mock("@/services/api/common-api", () => ({
+  commonApiPost: jest.fn().mockResolvedValue({}),
+}));
+jest.mock("framer-motion", () => ({
+  AnimatePresence: (props: any) => <div>{props.children}</div>,
+}));
+jest.mock(
+  "@/components/user/user-page-header/about/UserPageHeaderAboutEditError",
+  () => (props: any) => <div>{props.msg}</div>
+);
 
 (useMutation as jest.Mock).mockImplementation((opts) => {
   return {
@@ -22,24 +29,37 @@ jest.mock('@/components/user/user-page-header/about/UserPageHeaderAboutEditError
   };
 });
 
-describe('UserPageHeaderAboutEdit', () => {
-  const auth = { requestAuth: jest.fn().mockResolvedValue({ success: true }), setToast: jest.fn() } as any;
+describe("UserPageHeaderAboutEdit", () => {
+  const auth = {
+    requestAuth: jest.fn().mockResolvedValue({ success: true }),
+    setToast: jest.fn(),
+  } as any;
   const ctx = { onProfileStatementAdd: jest.fn() } as any;
 
-  it('enables save when value changes and submits', async () => {
+  it("enables save when value changes and submits", async () => {
     render(
       <AuthContext.Provider value={auth}>
         <ReactQueryWrapperContext.Provider value={ctx}>
-          <UserPageHeaderAboutEdit profile={{ query: 'alice' } as any} statement={{ statement_value: 'old' } as any} onClose={jest.fn()} />
+          <UserPageHeaderAboutEdit
+            profile={{ query: "alice" } as any}
+            statement={{ statement_value: "old" } as any}
+            onClose={jest.fn()}
+          />
         </ReactQueryWrapperContext.Provider>
       </AuthContext.Provider>
     );
-    const input = screen.getByRole('textbox');
+    const input = screen.getByRole("textbox", { name: "About statement" });
+    expect(input).toHaveAttribute("placeholder", "Write an About statement");
     await userEvent.clear(input);
-    await userEvent.type(input, 'new');
-    const btn = screen.getByRole('button', { name: 'Save' });
+    await userEvent.type(input, "new");
+    expect(screen.getByText("3/500")).toBeInTheDocument();
+    const btn = screen.getByRole("button", { name: "Save" });
     expect(btn).not.toBeDisabled();
     await userEvent.click(btn);
     expect(auth.requestAuth).toHaveBeenCalled();
+    expect(auth.setToast).toHaveBeenCalledWith({
+      message: "About statement added.",
+      type: "success",
+    });
   });
 });

--- a/__tests__/components/user/user-page-header/banner/UserPageHeaderBanner.test.tsx
+++ b/__tests__/components/user/user-page-header/banner/UserPageHeaderBanner.test.tsx
@@ -1,54 +1,84 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import UserPageHeaderBanner from '@/components/user/user-page-header/banner/UserPageHeaderBanner';
-import type { ApiIdentity } from '@/generated/models/ApiIdentity';
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
-jest.mock('@/components/utils/icons/PencilIcon', () => () => <span data-testid="pencil" />);
-jest.mock('@/components/utils/animation/CommonAnimationWrapper', () => ({ children }: any) => <div>{children}</div>);
-jest.mock('@/components/utils/animation/CommonAnimationOpacity', () => ({ children, onClicked }: any) => (
-  <div data-testid="opacity" onClick={onClicked}>{children}</div>
+import UserPageHeaderBanner from "@/components/user/user-page-header/banner/UserPageHeaderBanner";
+import type { ApiIdentity } from "@/generated/models/ApiIdentity";
+
+jest.mock("@/components/utils/icons/PencilIcon", () => () => (
+  <span data-testid="pencil" />
 ));
+jest.mock(
+  "@/components/utils/animation/CommonAnimationWrapper",
+  () =>
+    ({ children }: any) => <div>{children}</div>
+);
+jest.mock(
+  "@/components/utils/animation/CommonAnimationOpacity",
+  () =>
+    ({ children, onClicked }: any) => (
+      <button data-testid="opacity" type="button" onClick={onClicked}>
+        {children}
+      </button>
+    )
+);
 
-jest.mock('@/components/user/user-page-header/banner/UserPageHeaderEditBanner', () => (props: any) => (
-  <div data-testid="edit" onClick={props.onClose} />
-));
+jest.mock(
+  "@/components/user/user-page-header/banner/UserPageHeaderEditBanner",
+  () => (props: any) => (
+    <button data-testid="edit" type="button" onClick={props.onClose} />
+  )
+);
 
-describe('UserPageHeaderBanner', () => {
+describe("UserPageHeaderBanner", () => {
   const baseProfile: ApiIdentity = {
-    id: '1',
-    handle: 'alice',
+    id: "1",
+    handle: "alice",
     normalised_handle: null,
     pfp: null,
     cic: 0,
     rep: 0,
     level: 0,
     tdh: 0,
-    consolidation_key: '',
-    display: 'alice',
-    primary_wallet: '0xabc',
+    consolidation_key: "",
+    display: "alice",
+    primary_wallet: "0xabc",
     banner1: null,
     banner2: null,
     classification: 0 as any,
     sub_classification: null,
   };
 
-  it('opens and closes edit modal when button clicked', async () => {
+  it("opens and closes edit modal when button clicked", async () => {
     render(
-      <UserPageHeaderBanner profile={baseProfile} defaultBanner1="#000" defaultBanner2="#fff" canEdit={true} />
+      <UserPageHeaderBanner
+        profile={baseProfile}
+        defaultBanner1="#000"
+        defaultBanner2="#fff"
+        canEdit={true}
+        profileLabel="alice"
+      />
     );
 
-    await userEvent.click(screen.getByRole('button'));
-    expect(screen.getByTestId('edit')).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Edit alice's profile banner" })
+    );
+    expect(screen.getByTestId("edit")).toBeInTheDocument();
 
-    await userEvent.click(screen.getByTestId('edit'));
-    expect(screen.queryByTestId('edit')).toBeNull();
+    await userEvent.click(screen.getByTestId("edit"));
+    expect(screen.queryByTestId("edit")).toBeNull();
   });
 
-  it('hides edit button when cannot edit', () => {
+  it("hides edit button when cannot edit", () => {
     render(
-      <UserPageHeaderBanner profile={baseProfile} defaultBanner1="#000" defaultBanner2="#fff" canEdit={false} />
+      <UserPageHeaderBanner
+        profile={baseProfile}
+        defaultBanner1="#000"
+        defaultBanner2="#fff"
+        canEdit={false}
+        profileLabel="alice"
+      />
     );
 
-    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
   });
 });

--- a/__tests__/components/user/user-page-header/name/UserPageHeaderName.test.tsx
+++ b/__tests__/components/user/user-page-header/name/UserPageHeaderName.test.tsx
@@ -68,7 +68,11 @@ const baseProfile: ApiIdentity = {
   is_wave_creator: false,
 };
 
-function renderComponent(profile: Partial<ApiIdentity>, mainAddress = "0xabc") {
+function renderComponent(
+  profile: Partial<ApiIdentity>,
+  mainAddress = "0xabc",
+  profileEnabledAt: string | null = null
+) {
   const combined = { ...baseProfile, ...profile } as ApiIdentity;
   return render(
     <UserPageHeaderName
@@ -76,7 +80,7 @@ function renderComponent(profile: Partial<ApiIdentity>, mainAddress = "0xabc") {
       canEdit={false}
       mainAddress={mainAddress}
       level={combined.level}
-      profileEnabledAt={null}
+      profileEnabledAt={profileEnabledAt}
     />
   );
 }
@@ -133,5 +137,13 @@ describe("UserPageHeaderName", () => {
       "data-profile-wave-id",
       "featured-wave"
     );
+  });
+
+  it("renders the message-backed profile-enabled date", () => {
+    renderComponent({ handle: "Alice" }, "0x123", "2024-01-01T00:00:00.000Z");
+
+    expect(
+      screen.getByText("Profile enabled: January 2024")
+    ).toBeInTheDocument();
   });
 });

--- a/__tests__/components/user/user-page-header/name/UserPageHeaderNameWrapper.test.tsx
+++ b/__tests__/components/user/user-page-header/name/UserPageHeaderNameWrapper.test.tsx
@@ -1,30 +1,67 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import UserPageHeaderNameWrapper from '@/components/user/user-page-header/name/UserPageHeaderNameWrapper';
-import type { ApiIdentity } from '@/generated/models/ApiIdentity';
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
-jest.mock('@/components/utils/icons/PencilIcon', () => () => <span data-testid="pencil" />);
-jest.mock('@/components/utils/animation/CommonAnimationWrapper', () => ({ children }: any) => <div>{children}</div>);
-jest.mock('@/components/utils/animation/CommonAnimationOpacity', () => ({ children, onClicked }: any) => (
-  <div data-testid="opacity" onClick={onClicked}>{children}</div>
+import UserPageHeaderNameWrapper from "@/components/user/user-page-header/name/UserPageHeaderNameWrapper";
+import type { ApiIdentity } from "@/generated/models/ApiIdentity";
+
+jest.mock("@/components/utils/icons/PencilIcon", () => () => (
+  <span data-testid="pencil" />
 ));
+jest.mock(
+  "@/components/utils/animation/CommonAnimationWrapper",
+  () =>
+    ({ children }: any) => <div>{children}</div>
+);
+jest.mock(
+  "@/components/utils/animation/CommonAnimationOpacity",
+  () =>
+    ({ children, onClicked }: any) => (
+      <button data-testid="opacity" type="button" onClick={onClicked}>
+        {children}
+      </button>
+    )
+);
 
-jest.mock('@/components/user/user-page-header/name/UserPageHeaderEditName', () => (props: any) => (
-  <div data-testid="edit" onClick={props.onClose} />
-));
+jest.mock(
+  "@/components/user/user-page-header/name/UserPageHeaderEditName",
+  () => (props: any) => (
+    <button data-testid="edit" type="button" onClick={props.onClose} />
+  )
+);
 
-describe('UserPageHeaderNameWrapper', () => {
-  it('opens and closes edit modal when button clicked', async () => {
+describe("UserPageHeaderNameWrapper", () => {
+  it("opens and closes edit modal when button clicked", async () => {
     render(
-      <UserPageHeaderNameWrapper profile={{} as ApiIdentity} canEdit={true}>
+      <UserPageHeaderNameWrapper
+        profile={{} as ApiIdentity}
+        canEdit={true}
+        profileLabel="Alice"
+      >
         <span data-testid="child" />
       </UserPageHeaderNameWrapper>
     );
 
-    await userEvent.click(screen.getByRole('button'));
-    expect(screen.getByTestId('edit')).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Edit Alice's profile name" })
+    );
+    expect(screen.getByTestId("edit")).toBeInTheDocument();
 
-    await userEvent.click(screen.getByTestId('edit'));
-    expect(screen.queryByTestId('edit')).toBeNull();
+    await userEvent.click(screen.getByTestId("edit"));
+    expect(screen.queryByTestId("edit")).toBeNull();
+  });
+
+  it("does not render a disabled button when name is read-only", () => {
+    render(
+      <UserPageHeaderNameWrapper
+        profile={{} as ApiIdentity}
+        canEdit={false}
+        profileLabel="Alice"
+      >
+        <span data-testid="child" />
+      </UserPageHeaderNameWrapper>
+    );
+
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getByTestId("child")).toBeInTheDocument();
   });
 });

--- a/__tests__/components/user/utils/stats/UserStatsRow.test.tsx
+++ b/__tests__/components/user/utils/stats/UserStatsRow.test.tsx
@@ -33,5 +33,58 @@ describe("UserStatsRow", () => {
         "tw-text-iron-500"
       );
     }
+
+    expect(
+      screen.getByRole("link", {
+        name: "View bob's collected TDH: 1,234",
+      })
+    ).toHaveAttribute("href", "/bob/collected");
+    expect(
+      screen.getByRole("link", { name: "View bob's xTDH: 56" })
+    ).toHaveAttribute("href", "/bob/xtdh");
+    expect(
+      screen.getByRole("link", { name: "View bob's NIC: 7" })
+    ).toHaveAttribute("href", "/bob");
+    expect(
+      screen.getByRole("link", { name: "View bob's Rep: 8" })
+    ).toHaveAttribute("href", "/bob");
+    expect(
+      screen.getByRole("link", {
+        name: "View bob's followers: 9 Followers",
+      })
+    ).toHaveAttribute("href", "/bob");
+  });
+
+  it("uses a localized followers button label when followers open a modal", () => {
+    const onFollowersClick = jest.fn();
+
+    render(
+      <UserStatsRow
+        handle="bob"
+        tdh={1234}
+        tdh_rate={5}
+        xtdh={56}
+        xtdh_rate={2}
+        cic={7}
+        rep={8}
+        followersCount={1}
+        onFollowersClick={onFollowersClick}
+      />
+    );
+
+    expect(
+      screen.getByRole("link", {
+        name: "View bob's collected TDH: 1,234, +5",
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "View bob's xTDH: 56, +2" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Follower")).toHaveClass("tw-font-medium");
+    expect(
+      screen.getByRole("button", {
+        name: "Open bob's followers: 1 Follower",
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/__tests__/i18n/messages.test.ts
+++ b/__tests__/i18n/messages.test.ts
@@ -6,6 +6,11 @@ import {
   formatRelativeTime,
 } from "@/i18n/format";
 import {
+  formatUserProfileHeaderMonthYear,
+  getUserProfileHeaderDisplayName,
+  getUserProfileHeaderMessage,
+} from "@/components/user/user-page-header/user-page-header.messages";
+import {
   DEFAULT_LOCALE,
   SUPPORTED_LOCALES,
   isSupportedLocale,
@@ -210,6 +215,20 @@ describe("frontend i18n helpers", () => {
         followersLabel: "Follower",
       })
     ).toBe("Open alice's followers: 1 Follower");
+    expect(
+      t("de-DE", "user.profileHeader.pfp.alt", {
+        name: "alice",
+      })
+    ).toBe("alice's profile picture");
+    expect(
+      t("fr-FR", "user.profileHeader.name.profileEnabled", {
+        date: "January 2024",
+      })
+    ).toBe("Profile enabled: January 2024");
+    expect(t("de-DE", "user.profileHeader.about.empty")).toBe(
+      "Click to add an About statement"
+    );
+    expect(t("fr-FR", "user.profileHeader.aboutEdit.save")).toBe("Save");
     expect(t("es-ES", "user.collected.networkCards.empty")).toBe(
       t("en-US", "user.collected.networkCards.empty")
     );
@@ -337,6 +356,58 @@ describe("frontend i18n helpers", () => {
     expect(t("es-ES", "distribution.photos.alt", distributionPhotoParams)).toBe(
       t("en-US", "distribution.photos.alt", distributionPhotoParams)
     );
+  });
+
+  it("formats profile header helper messages with en-US defaults", () => {
+    expect(
+      getUserProfileHeaderMessage("user.profileHeader.pfp.alt", {
+        name: "alice",
+      })
+    ).toBe("alice's profile picture");
+    expect(formatUserProfileHeaderMonthYear(new Date(2024, 0, 15))).toBe(
+      "January 2024"
+    );
+
+    expect(
+      getUserProfileHeaderDisplayName(
+        {
+          handle: "alice",
+          display: "Alice Display",
+          primary_wallet: "0x123",
+        } as any,
+        "fallback"
+      )
+    ).toBe("alice");
+    expect(
+      getUserProfileHeaderDisplayName(
+        {
+          handle: null,
+          display: "Alice Display",
+          primary_wallet: "0x123",
+        } as any,
+        "fallback"
+      )
+    ).toBe("Alice Display");
+    expect(
+      getUserProfileHeaderDisplayName(
+        {
+          handle: null,
+          display: null,
+          primary_wallet: "0x123",
+        } as any,
+        "fallback"
+      )
+    ).toBe("0x123");
+    expect(
+      getUserProfileHeaderDisplayName(
+        {
+          handle: null,
+          display: null,
+          primary_wallet: null,
+        } as any,
+        "fallback"
+      )
+    ).toBe("fallback");
   });
 
   it("formats locale-sensitive values through Intl helpers", () => {

--- a/__tests__/i18n/messages.test.ts
+++ b/__tests__/i18n/messages.test.ts
@@ -196,6 +196,20 @@ describe("frontend i18n helpers", () => {
         handle: "alice",
       })
     ).toBe("View alice's profile");
+    expect(
+      t("fr-FR", "user.statsRow.links.tdhWithRate", {
+        handle: "alice",
+        value: "1,000",
+        rate: "5",
+      })
+    ).toBe("View alice's collected TDH: 1,000, +5");
+    expect(
+      t("es-ES", "user.statsRow.buttons.followers", {
+        handle: "alice",
+        value: "1",
+        followersLabel: "Follower",
+      })
+    ).toBe("Open alice's followers: 1 Follower");
     expect(t("es-ES", "user.collected.networkCards.empty")).toBe(
       t("en-US", "user.collected.networkCards.empty")
     );

--- a/components/user/user-page-header/UserPageHeaderClient.tsx
+++ b/components/user/user-page-header/UserPageHeaderClient.tsx
@@ -24,6 +24,7 @@ import UserPageHeaderName from "./name/UserPageHeaderName";
 import UserPageHeaderPfp from "./pfp/UserPageHeaderPfp";
 import UserPageHeaderPfpWrapper from "./pfp/UserPageHeaderPfpWrapper";
 import UserPageHeaderStats from "./stats/UserPageHeaderStats";
+import { getUserProfileHeaderDisplayName } from "./user-page-header.messages";
 
 type Props = {
   readonly profile: ApiIdentity;
@@ -77,6 +78,11 @@ export default function UserPageHeaderClient({
     }
     return fallbackMainAddress.toLowerCase();
   }, [profile.primary_wallet, fallbackMainAddress]);
+
+  const profileLabel = useMemo(
+    () => getUserProfileHeaderDisplayName(profile, mainAddress),
+    [profile, mainAddress]
+  );
 
   const [directMessageLoading, setDirectMessageLoading] =
     useState<boolean>(false);
@@ -164,6 +170,7 @@ export default function UserPageHeaderClient({
             defaultBanner1={banner1Color}
             defaultBanner2={banner2Color}
             canEdit={canEdit}
+            profileLabel={profileLabel}
           />
         </div>
 
@@ -171,9 +178,14 @@ export default function UserPageHeaderClient({
           <div className="tw-relative tw-z-10 tw-px-6 md:tw-px-9">
             <div className="tw-flex tw-flex-wrap tw-justify-between tw-gap-x-4 md:tw-pt-2">
               <div className="tw-relative tw-order-1 -tw-mt-10 tw-flex-shrink-0 tw-self-start sm:-tw-mt-[58px]">
-                <UserPageHeaderPfpWrapper profile={profile} canEdit={canEdit}>
+                <UserPageHeaderPfpWrapper
+                  profile={profile}
+                  canEdit={canEdit}
+                  profileLabel={profileLabel}
+                >
                   <UserPageHeaderPfp
                     profile={profile}
+                    profileLabel={profileLabel}
                     defaultBanner1={banner1Color}
                     defaultBanner2={banner2Color}
                   />

--- a/components/user/user-page-header/about/UserPageHeaderAbout.tsx
+++ b/components/user/user-page-header/about/UserPageHeaderAbout.tsx
@@ -6,6 +6,7 @@ import PencilIcon from "@/components/utils/icons/PencilIcon";
 import UserPageHeaderAboutStatement from "./UserPageHeaderAboutStatement";
 import UserPageHeaderAboutEdit from "./UserPageHeaderAboutEdit";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
+import { getUserProfileHeaderMessage } from "../user-page-header.messages";
 
 enum AboutStatementView {
   STATEMENT = "STATEMENT",
@@ -38,6 +39,9 @@ function UserPageHeaderAboutContent({
       toggleView();
     }
   };
+  const editActionLabel = getUserProfileHeaderMessage(
+    statement ? "user.profileHeader.about.edit" : "user.profileHeader.about.add"
+  );
 
   return (
     <>
@@ -51,13 +55,11 @@ function UserPageHeaderAboutContent({
               .filter(Boolean)
               .join(" ")}
           >
-            {canEdit ? (
+            {canEdit && !statement ? (
               <button
                 type="button"
                 onClick={onEditClick}
-                aria-label={
-                  statement ? "Edit About statement" : "Add About statement"
-                }
+                aria-label={editActionLabel}
                 className="tw-flex-1 tw-border-none tw-bg-transparent tw-p-0 tw-text-left"
               >
                 <UserPageHeaderAboutStatement statement={statement} />
@@ -65,16 +67,16 @@ function UserPageHeaderAboutContent({
             ) : (
               <UserPageHeaderAboutStatement statement={statement} />
             )}
-            {canEdit && (
+            {canEdit && statement && (
               <button
                 type="button"
                 onClick={onEditClick}
-                aria-label={
-                  statement ? "Edit About statement" : "Add About statement"
-                }
+                aria-label={editActionLabel}
                 className="tw-pointer-events-none tw-shrink-0 tw-border-none tw-bg-transparent tw-p-0 tw-text-iron-400 tw-opacity-0 tw-transition tw-duration-200 group-focus-within:tw-pointer-events-auto group-focus-within:tw-opacity-100 group-hover:tw-pointer-events-auto group-hover:tw-opacity-100 hover:tw-text-iron-200"
               >
-                <PencilIcon />
+                <span aria-hidden="true">
+                  <PencilIcon />
+                </span>
               </button>
             )}
           </div>

--- a/components/user/user-page-header/about/UserPageHeaderAboutEdit.tsx
+++ b/components/user/user-page-header/about/UserPageHeaderAboutEdit.tsx
@@ -10,11 +10,14 @@ import type {
 } from "@/entities/IProfile";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import { STATEMENT_GROUP, STATEMENT_TYPE } from "@/helpers/Types";
+import { formatInteger } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
 import { commonApiPost } from "@/services/api/common-api";
 import { useMutation } from "@tanstack/react-query";
 import { AnimatePresence } from "framer-motion";
 import { useContext, useEffect, useRef, useState } from "react";
 import { useKeyPressEvent } from "react-use";
+import { getUserProfileHeaderMessage } from "../user-page-header.messages";
 import UserPageHeaderAboutEditError from "./UserPageHeaderAboutEditError";
 export default function UserPageHeaderAboutEdit({
   profile,
@@ -85,7 +88,9 @@ export default function UserPageHeaderAboutEdit({
     onSuccess: () => {
       setErrorMsg(null);
       setToast({
-        message: "About statement added.",
+        message: getUserProfileHeaderMessage(
+          "user.profileHeader.aboutEdit.success"
+        ),
         type: "success",
       });
       onProfileStatementAdd({
@@ -114,6 +119,13 @@ export default function UserPageHeaderAboutEdit({
     event.preventDefault();
     await submitStatement();
   };
+  const characterCount = getUserProfileHeaderMessage(
+    "user.profileHeader.aboutEdit.characterCount",
+    {
+      count: formatInteger(DEFAULT_LOCALE, value.length),
+      max: formatInteger(DEFAULT_LOCALE, MAX_STATEMENT_LENGTH),
+    }
+  );
 
   return (
     <div className="tw-w-full tw-max-w-xl">
@@ -122,8 +134,12 @@ export default function UserPageHeaderAboutEdit({
           className="tw-form-input tw-block tw-min-h-28 tw-w-full tw-appearance-none tw-rounded-lg tw-border-0 tw-bg-iron-900 tw-px-3.5 tw-py-3 tw-text-sm tw-font-medium tw-leading-6 tw-text-iron-50 tw-caret-primary-400 tw-shadow-sm tw-ring-1 tw-ring-inset tw-ring-iron-700 tw-transition tw-duration-300 tw-ease-out placeholder:tw-text-iron-500 hover:tw-ring-iron-600 focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-primary-400"
           name="profile-about"
           id="profile-about-input"
-          aria-label="About statement"
-          placeholder="Write an About statement"
+          aria-label={getUserProfileHeaderMessage(
+            "user.profileHeader.aboutEdit.textareaLabel"
+          )}
+          placeholder={getUserProfileHeaderMessage(
+            "user.profileHeader.aboutEdit.placeholder"
+          )}
           required
           value={value}
           onChange={handleInputChange}
@@ -132,19 +148,24 @@ export default function UserPageHeaderAboutEdit({
         ></textarea>
         <div className="tw-mt-3 tw-flex tw-flex-col tw-gap-3 sm:tw-flex-row sm:tw-items-center sm:tw-justify-between">
           <div className="tw-text-xs tw-font-medium tw-text-iron-500">
-            {value.length}/{MAX_STATEMENT_LENGTH}
+            {characterCount}
           </div>
           <div className="tw-flex tw-w-full tw-gap-2 sm:tw-w-auto">
             <SecondaryButton disabled={loading} onClicked={onClose}>
-              Cancel
+              {getUserProfileHeaderMessage(
+                "user.profileHeader.aboutEdit.cancel"
+              )}
             </SecondaryButton>
             <PrimaryButton
               disabled={isDisabled}
               loading={loading}
               onClicked={submitStatement}
+              ariaLabel={getUserProfileHeaderMessage(
+                "user.profileHeader.aboutEdit.save"
+              )}
               hideChildrenWhenLoading
             >
-              Save
+              {getUserProfileHeaderMessage("user.profileHeader.aboutEdit.save")}
             </PrimaryButton>
           </div>
         </div>

--- a/components/user/user-page-header/about/UserPageHeaderAboutEditError.tsx
+++ b/components/user/user-page-header/about/UserPageHeaderAboutEditError.tsx
@@ -1,3 +1,5 @@
+import { getUserProfileHeaderMessage } from "../user-page-header.messages";
+
 enum AboutEditError {
   HATE_SPEECH = "HATE_SPEECH",
   PERSONAL_INSULTS = "PERSONAL_INSULTS",
@@ -22,24 +24,36 @@ const ERROR_TEXT: {
   };
 } = {
   [AboutEditError.HATE_SPEECH]: {
-    title: "Error: Hate Speech",
-    value:
-      "Your About text was not accepted because our automated checks flagged it for potentially containing hate speech.  We want to keep seize a welcoming place!  We'd appreciate it if you adjusted your text.",
+    title: getUserProfileHeaderMessage(
+      "user.profileHeader.aboutEdit.errors.hateSpeech.title"
+    ),
+    value: getUserProfileHeaderMessage(
+      "user.profileHeader.aboutEdit.errors.hateSpeech.value"
+    ),
   },
   [AboutEditError.PERSONAL_INSULTS]: {
-    title: "Error: Personal Insults",
-    value:
-      "Your About text was not accepted because our automated checks flagged it for potentially containing a personal insult.  We want to keep seize a welcoming place!.   We'd appreciate it if you adjusted your text.",
+    title: getUserProfileHeaderMessage(
+      "user.profileHeader.aboutEdit.errors.personalInsults.title"
+    ),
+    value: getUserProfileHeaderMessage(
+      "user.profileHeader.aboutEdit.errors.personalInsults.value"
+    ),
   },
   [AboutEditError.INAPPROPRIATE_LANGUAGE]: {
-    title: "Error: Inappropriate Language",
-    value:
-      "Your About text was not accepted because our automated checks flagged it for potentially containing inappropriate language that may make others uncomfortable.   We want to keep seize a welcoming place!  We'd appreciate it if you adjusted your text.",
+    title: getUserProfileHeaderMessage(
+      "user.profileHeader.aboutEdit.errors.inappropriateLanguage.title"
+    ),
+    value: getUserProfileHeaderMessage(
+      "user.profileHeader.aboutEdit.errors.inappropriateLanguage.value"
+    ),
   },
   [AboutEditError.DOXXING]: {
-    title: "Error: Doxxing of Another Person",
-    value:
-      "Your About text was not accepted because our automated checks flagged it for potentially doxxing another user of the system.   We have a strong cultural value towards respecting pseudonymity so we'd appreciate if if you adjusted your text.",
+    title: getUserProfileHeaderMessage(
+      "user.profileHeader.aboutEdit.errors.doxxing.title"
+    ),
+    value: getUserProfileHeaderMessage(
+      "user.profileHeader.aboutEdit.errors.doxxing.value"
+    ),
   },
 };
 
@@ -64,20 +78,29 @@ export default function UserPageHeaderAboutEditError({
   const errorText =
     errorType === AboutEditError.UNKNOWN
       ? {
-          title: "Unknown Error",
+          title: getUserProfileHeaderMessage(
+            "user.profileHeader.aboutEdit.errors.unknown.title"
+          ),
           value: msg,
         }
       : ERROR_TEXT[errorType];
 
   return (
     <div>
-      <div className="tw-relative tw-inline-flex tw-w-full tw-items-center tw-rounded-lg tw-border tw-border-solid tw-border-red/30 tw-bg-red/5 tw-p-4 lg:tw-max-w-xl">
+      <div
+        role="alert"
+        className="tw-relative tw-inline-flex tw-w-full tw-items-center tw-rounded-lg tw-border tw-border-solid tw-border-red/30 tw-bg-red/5 tw-p-4 lg:tw-max-w-xl"
+      >
         <div className="tw-absolute tw-right-2 tw-top-2">
           <button
             onClick={closeError}
             type="button"
-            title="Close"
-            aria-label="Close"
+            title={getUserProfileHeaderMessage(
+              "user.profileHeader.aboutEdit.errors.close"
+            )}
+            aria-label={getUserProfileHeaderMessage(
+              "user.profileHeader.aboutEdit.errors.close"
+            )}
             className="tw-group tw-inline-flex tw-rounded-md tw-border-none tw-bg-transparent focus:tw-outline-none"
           >
             <svg

--- a/components/user/user-page-header/about/UserPageHeaderAboutStatement.tsx
+++ b/components/user/user-page-header/about/UserPageHeaderAboutStatement.tsx
@@ -2,6 +2,7 @@
 
 import type { CicStatement } from "@/entities/IProfile";
 import { useState } from "react";
+import { getUserProfileHeaderMessage } from "../user-page-header.messages";
 
 export default function UserPageHeaderAboutStatement({
   statement,
@@ -12,7 +13,7 @@ export default function UserPageHeaderAboutStatement({
   if (!statement) {
     return (
       <div className="tw-text-sm tw-italic tw-text-white/40 tw-transition tw-duration-200 group-focus-within:tw-text-white/70 group-hover:tw-text-white/70">
-        Click to add an About statement
+        {getUserProfileHeaderMessage("user.profileHeader.about.empty")}
       </div>
     );
   }
@@ -36,9 +37,14 @@ export default function UserPageHeaderAboutStatement({
             event.stopPropagation();
             setExpanded((prev) => !prev);
           }}
+          aria-expanded={expanded}
           className="tw-border-0 tw-bg-transparent tw-px-1 tw-py-1 tw-text-sm tw-font-semibold tw-text-white/80 tw-transition tw-duration-200 tw-ease-out hover:tw-text-white md:tw-hidden"
         >
-          {expanded ? "See less" : "See more"}
+          {getUserProfileHeaderMessage(
+            expanded
+              ? "user.profileHeader.about.collapse"
+              : "user.profileHeader.about.expand"
+          )}
         </button>
       )}
     </div>

--- a/components/user/user-page-header/banner/UserPageHeaderBanner.tsx
+++ b/components/user/user-page-header/banner/UserPageHeaderBanner.tsx
@@ -11,17 +11,20 @@ import {
   getBannerImageUrl,
 } from "@/helpers/profile-banner.helpers";
 import UserPageHeaderEditBanner from "./UserPageHeaderEditBanner";
+import { getUserProfileHeaderMessage } from "../user-page-header.messages";
 
 export default function UserPageHeaderBanner({
   profile,
   defaultBanner1,
   defaultBanner2,
   canEdit,
+  profileLabel,
 }: {
   readonly profile: ApiIdentity;
   readonly defaultBanner1: string;
   readonly defaultBanner2: string;
   readonly canEdit: boolean;
+  readonly profileLabel: string;
 }) {
   const [isEditOpen, setIsEditOpen] = useState<boolean>(false);
   const bannerImageUrl = getBannerImageUrl(profile.banner1);
@@ -54,12 +57,19 @@ export default function UserPageHeaderBanner({
 
       {canEdit && (
         <button
+          type="button"
           onClick={() => setIsEditOpen(true)}
           className="tw-absolute tw-inset-0 tw-z-10 tw-h-full tw-w-full tw-border-none tw-bg-transparent tw-p-0"
-          aria-label="Edit banner"
+          aria-label={getUserProfileHeaderMessage(
+            "user.profileHeader.banner.edit",
+            { name: profileLabel }
+          )}
         >
           <div className="edit-profile tw-absolute tw-inset-0 tw-bg-black/30">
-            <div className="tw-absolute tw-bottom-4 tw-right-4">
+            <div
+              aria-hidden="true"
+              className="tw-absolute tw-bottom-4 tw-right-4"
+            >
               <PencilIcon />
             </div>
           </div>

--- a/components/user/user-page-header/name/UserPageHeaderName.tsx
+++ b/components/user/user-page-header/name/UserPageHeaderName.tsx
@@ -1,6 +1,5 @@
 import { CLASSIFICATIONS } from "@/entities/IProfile";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
-import { formatTimestampToMonthYear } from "@/helpers/Helpers";
 import ProfileNameWithAiMarker from "@/components/common/profile/ProfileNameWithAiMarker";
 import UserCICTypeIconWrapper from "@/components/user/utils/user-cic-type/UserCICTypeIconWrapper";
 import UserCICAndLevel, {
@@ -9,6 +8,11 @@ import UserCICAndLevel, {
 import UserPageClassificationWrapper from "./classification/UserPageClassificationWrapper";
 import ProfileCurationBadge from "./ProfileCurationBadge";
 import UserPageHeaderNameWrapper from "./UserPageHeaderNameWrapper";
+import {
+  formatUserProfileHeaderMonthYear,
+  getUserProfileHeaderDisplayName,
+  getUserProfileHeaderMessage,
+} from "../user-page-header.messages";
 
 export default function UserPageHeaderName({
   profile,
@@ -25,25 +29,9 @@ export default function UserPageHeaderName({
   readonly profileEnabledAt: string | null;
   readonly variant?: "full" | "title" | "meta";
 }) {
-  const getDisplayName = (): string => {
-    if (profile.handle) {
-      return profile.handle;
-    }
-
-    if (profile.display) {
-      return profile.display;
-    }
-
-    if (mainAddress.endsWith(".eth")) {
-      return mainAddress;
-    }
-
-    return mainAddress;
-  };
-
-  const displayName = getDisplayName();
+  const displayName = getUserProfileHeaderDisplayName(profile, mainAddress);
   const profileEnabledLabel = profileEnabledAt
-    ? formatTimestampToMonthYear(new Date(profileEnabledAt).getTime())
+    ? formatUserProfileHeaderMonthYear(profileEnabledAt)
     : null;
 
   const showTitle = variant !== "meta";
@@ -53,7 +41,11 @@ export default function UserPageHeaderName({
     <div className={showTitle && showMeta ? "tw-space-y-2" : ""}>
       {showTitle && (
         <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
-          <UserPageHeaderNameWrapper profile={profile} canEdit={canEdit}>
+          <UserPageHeaderNameWrapper
+            profile={profile}
+            canEdit={canEdit}
+            profileLabel={displayName}
+          >
             <ProfileNameWithAiMarker
               classification={profile.classification}
               markerClassName="tw-text-base md:tw-text-lg"
@@ -88,7 +80,10 @@ export default function UserPageHeaderName({
               className="tw-mb-0 tw-text-sm tw-font-medium tw-text-iron-500"
               suppressHydrationWarning
             >
-              Profile enabled: {profileEnabledLabel}
+              {getUserProfileHeaderMessage(
+                "user.profileHeader.name.profileEnabled",
+                { date: profileEnabledLabel }
+              )}
             </p>
           )}
         </div>

--- a/components/user/user-page-header/name/UserPageHeaderNameWrapper.tsx
+++ b/components/user/user-page-header/name/UserPageHeaderNameWrapper.tsx
@@ -6,35 +6,45 @@ import PencilIcon from "@/components/utils/icons/PencilIcon";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import React, { useState } from "react";
 import UserPageHeaderEditName from "./UserPageHeaderEditName";
+import { getUserProfileHeaderMessage } from "../user-page-header.messages";
 
 export default function UserPageHeaderNameWrapper({
   profile,
   canEdit,
+  profileLabel,
   children,
 }: {
   readonly profile: ApiIdentity;
   readonly canEdit: boolean;
+  readonly profileLabel: string;
   readonly children: React.ReactNode;
 }) {
   const [isEditNameOpen, setIsEditNameOpen] = useState<boolean>(false);
 
+  if (!canEdit) {
+    return <div>{children}</div>;
+  }
+
   return (
     <div>
       <button
+        type="button"
         onClick={() => setIsEditNameOpen(true)}
-        disabled={!canEdit}
-        aria-label="Edit profile name"
-        className={`${
-          canEdit ? "hover:tw-text-iron-400" : ""
-        } tw-group tw-bg-transparent tw-border-none tw-m-0 tw-p-0 tw-relative tw-transition tw-duration-300 tw-ease-out`}>
-        {children}
-        {canEdit && (
-          <div className="group-hover:tw-block tw-hidden tw-absolute tw-inset-0 tw-text-iron-400">
-            <div className="tw-absolute tw-top-1.5 -tw-left-5 tw-z-10">
-              <PencilIcon />
-            </div>
-          </div>
+        aria-label={getUserProfileHeaderMessage(
+          "user.profileHeader.name.edit",
+          { name: profileLabel }
         )}
+        className="tw-group tw-relative tw-m-0 tw-border-none tw-bg-transparent tw-p-0 tw-transition tw-duration-300 tw-ease-out hover:tw-text-iron-400"
+      >
+        {children}
+        <div
+          aria-hidden="true"
+          className="tw-absolute tw-inset-0 tw-hidden tw-text-iron-400 group-hover:tw-block"
+        >
+          <div className="tw-absolute -tw-left-5 tw-top-1.5 tw-z-10">
+            <PencilIcon />
+          </div>
+        </div>
       </button>
       <CommonAnimationWrapper mode="sync" initial={true}>
         {isEditNameOpen && (
@@ -42,7 +52,8 @@ export default function UserPageHeaderNameWrapper({
             key="modal"
             elementClasses="tw-absolute tw-z-10"
             elementRole="dialog"
-            onClicked={(e) => e.stopPropagation()}>
+            onClicked={(e) => e.stopPropagation()}
+          >
             <UserPageHeaderEditName
               profile={profile}
               onClose={() => setIsEditNameOpen(false)}

--- a/components/user/user-page-header/pfp/UserPageHeaderPfp.tsx
+++ b/components/user/user-page-header/pfp/UserPageHeaderPfp.tsx
@@ -1,13 +1,16 @@
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import Image from "next/image";
 import { getScaledImageUri, ImageScale } from "@/helpers/image.helpers";
+import { getUserProfileHeaderMessage } from "../user-page-header.messages";
 
 export default function UserPageHeaderPfp({
   profile,
+  profileLabel,
   defaultBanner1,
   defaultBanner2,
 }: {
   readonly profile: ApiIdentity;
+  readonly profileLabel: string;
   readonly defaultBanner1: string;
   readonly defaultBanner2: string;
 }) {
@@ -20,7 +23,9 @@ export default function UserPageHeaderPfp({
         <Image
           unoptimized
           src={getScaledImageUri(profile.pfp, ImageScale.W_200_H_200)}
-          alt="Profile picture"
+          alt={getUserProfileHeaderMessage("user.profileHeader.pfp.alt", {
+            name: profileLabel,
+          })}
           width="144"
           height="144"
           className="tw-h-20 tw-w-auto tw-max-w-20 tw-rounded-xl tw-bg-iron-800 tw-object-contain sm:tw-h-28 sm:tw-max-w-28"
@@ -32,6 +37,7 @@ export default function UserPageHeaderPfp({
   return (
     <div className={glassWrapperClass}>
       <div
+        aria-hidden="true"
         className="tw-h-20 tw-w-20 tw-rounded-xl sm:tw-h-28 sm:tw-w-28"
         style={{
           background: `linear-gradient(45deg, ${defaultBanner1} 0%, ${defaultBanner2} 100%)`,

--- a/components/user/user-page-header/pfp/UserPageHeaderPfpWrapper.tsx
+++ b/components/user/user-page-header/pfp/UserPageHeaderPfpWrapper.tsx
@@ -5,22 +5,20 @@ import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import PencilIcon from "@/components/utils/icons/PencilIcon";
 import { createPortal } from "react-dom";
 import UserPageHeaderEditPfp from "./UserPageHeaderEditPfp";
+import { getUserProfileHeaderMessage } from "../user-page-header.messages";
 
 export default function UserPageHeaderPfpWrapper({
   profile,
   canEdit,
+  profileLabel,
   children,
 }: {
   readonly profile: ApiIdentity;
   readonly canEdit: boolean;
+  readonly profileLabel: string;
   readonly children: React.ReactNode;
 }) {
   const [isEditPfpOpen, setIsEditPfpOpen] = useState<boolean>(false);
-  const [isMounted, setIsMounted] = useState(false);
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
 
   useEffect(() => {
     if (!isEditPfpOpen || typeof document === "undefined") {
@@ -41,26 +39,33 @@ export default function UserPageHeaderPfpWrapper({
     };
   }, [isEditPfpOpen]);
 
+  if (!canEdit) {
+    return <div className="tw-inline-flex tw-w-fit">{children}</div>;
+  }
+
   return (
     <div className="tw-inline-flex tw-w-fit">
       <button
+        type="button"
         onClick={() => setIsEditPfpOpen(true)}
-        disabled={!canEdit}
         className="tw-group tw-relative tw-inline-flex tw-w-fit tw-rounded-xl tw-border-none tw-bg-transparent tw-p-0"
-        aria-label={canEdit ? "Edit profile picture" : "Profile picture"}
+        aria-label={getUserProfileHeaderMessage("user.profileHeader.pfp.edit", {
+          name: profileLabel,
+        })}
       >
         {children}
 
-        {canEdit && (
-          <div className="edit-profile tw-absolute tw-inset-0 tw-z-20 tw-rounded-xl tw-bg-black tw-bg-black/50 tw-bg-opacity-50 tw-transition tw-duration-300 tw-ease-out">
-            <div className="tw-absolute tw-bottom-2 tw-right-2">
-              <PencilIcon />
-            </div>
+        <div
+          aria-hidden="true"
+          className="edit-profile tw-absolute tw-inset-0 tw-z-20 tw-rounded-xl tw-bg-black tw-bg-black/50 tw-bg-opacity-50 tw-transition tw-duration-300 tw-ease-out"
+        >
+          <div className="tw-absolute tw-bottom-2 tw-right-2">
+            <PencilIcon />
           </div>
-        )}
+        </div>
       </button>
-      {isMounted &&
-        isEditPfpOpen &&
+      {isEditPfpOpen &&
+        typeof document !== "undefined" &&
         createPortal(
           <UserPageHeaderEditPfp
             profile={profile}

--- a/components/user/user-page-header/user-page-header.messages.ts
+++ b/components/user/user-page-header/user-page-header.messages.ts
@@ -1,0 +1,38 @@
+import type { ApiIdentity } from "@/generated/models/ApiIdentity";
+import { formatDate } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
+
+type UserProfileHeaderMessageKey = Extract<
+  MessageKey,
+  `user.profileHeader.${string}`
+>;
+
+type MessageParams = Record<string, string | number>;
+
+const MONTH_YEAR_FORMAT = {
+  month: "long",
+  year: "numeric",
+} satisfies Intl.DateTimeFormatOptions;
+
+export function getUserProfileHeaderMessage(
+  key: UserProfileHeaderMessageKey,
+  params: MessageParams = {}
+): string {
+  return t(DEFAULT_LOCALE, key, params);
+}
+
+export function formatUserProfileHeaderMonthYear(
+  value: Date | string | number | null | undefined
+): string {
+  return formatDate(DEFAULT_LOCALE, value, MONTH_YEAR_FORMAT);
+}
+
+export function getUserProfileHeaderDisplayName(
+  profile: ApiIdentity,
+  fallback: string
+): string {
+  return (
+    profile.handle || profile.display || profile.primary_wallet || fallback
+  );
+}

--- a/components/user/utils/stats/UserStatsRow.tsx
+++ b/components/user/utils/stats/UserStatsRow.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { formatNumberWithCommas, formatStatFloor } from "@/helpers/Helpers";
+import { formatStatFloor } from "@/helpers/Helpers";
+import {
+  formatUserStatsRowInteger,
+  getUserStatsRowMessage,
+} from "./user-stats-row.messages";
 
 export enum UserStatsRowSize {
   SMALL = "SMALL",
@@ -51,21 +55,50 @@ export default function UserStatsRow({
 }: UserStatsRowProps) {
   const routeHandle = encodeURIComponent(handle.toLowerCase());
   const count = followersCount ?? 0;
-  const followerLabel = count === 1 ? "Follower" : "Followers";
+  const followerLabel = getUserStatsRowMessage(
+    count === 1
+      ? "user.statsRow.labels.followers.one"
+      : "user.statsRow.labels.followers.many"
+  );
   const classes = SIZE_CLASSES[size];
+  const tdhValue = formatStatFloor(tdh);
+  const tdhRateValue = formatStatFloor(tdh_rate);
+  const xtdhValue = formatStatFloor(xtdh);
+  const xtdhRateValue = formatStatFloor(xtdh_rate);
+  const nicValue = formatStatFloor(cic);
+  const repValue = formatStatFloor(rep);
+  const followersValue = formatUserStatsRowInteger(count);
+  const tdhLinkLabel = getUserStatsRowMessage(
+    tdh_rate > 0
+      ? "user.statsRow.links.tdhWithRate"
+      : "user.statsRow.links.tdh",
+    { handle, value: tdhValue, rate: tdhRateValue }
+  );
+  const xtdhLinkLabel = getUserStatsRowMessage(
+    xtdh_rate > 0
+      ? "user.statsRow.links.xtdhWithRate"
+      : "user.statsRow.links.xtdh",
+    { handle, value: xtdhValue, rate: xtdhRateValue }
+  );
+  const followersActionLabel = {
+    handle,
+    value: followersValue,
+    followersLabel: followerLabel,
+  };
 
   return (
     <div className={`@container ${className}`}>
       <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-y-1 sm:tw-gap-y-0.5 tw-gap-x-4 lg:tw-gap-x-6">
         <Link
           href={`/${routeHandle}/collected`}
+          aria-label={tdhLinkLabel}
           className="tw-no-underline desktop-hover:hover:tw-underline tw-transition tw-duration-300 tw-ease-out"
         >
           <span className={`${classes.text} tw-font-semibold tw-text-iron-300`}>
-            {formatStatFloor(tdh)}
+            {tdhValue}
           </span>{" "}
           <span className={`${classes.text} tw-font-medium tw-text-iron-500`}>
-            TDH
+            {getUserStatsRowMessage("user.statsRow.labels.tdh")}
           </span>
           {tdh_rate > 0 && (
             <>
@@ -73,7 +106,7 @@ export default function UserStatsRow({
               <span
                 className={`${classes.rate} tw-font-semibold tw-text-emerald-500`}
               >
-                +{formatStatFloor(tdh_rate)}
+                +{tdhRateValue}
               </span>
             </>
           )}
@@ -81,13 +114,14 @@ export default function UserStatsRow({
 
         <Link
           href={`/${routeHandle}/xtdh`}
+          aria-label={xtdhLinkLabel}
           className="tw-no-underline desktop-hover:hover:tw-underline tw-transition tw-duration-300 tw-ease-out"
         >
           <span className={`${classes.text} tw-font-semibold tw-text-iron-300`}>
-            {formatStatFloor(xtdh)}
+            {xtdhValue}
           </span>{" "}
           <span className={`${classes.text} tw-font-medium tw-text-iron-500`}>
-            xTDH
+            {getUserStatsRowMessage("user.statsRow.labels.xtdh")}
           </span>
           {xtdh_rate > 0 && (
             <>
@@ -95,7 +129,7 @@ export default function UserStatsRow({
               <span
                 className={`${classes.rate} tw-font-semibold tw-text-emerald-500`}
               >
-                +{formatStatFloor(xtdh_rate)}
+                +{xtdhRateValue}
               </span>
             </>
           )}
@@ -103,25 +137,33 @@ export default function UserStatsRow({
 
         <Link
           href={`/${routeHandle}`}
+          aria-label={getUserStatsRowMessage("user.statsRow.links.nic", {
+            handle,
+            value: nicValue,
+          })}
           className="tw-no-underline desktop-hover:hover:tw-underline tw-transition tw-duration-300 tw-ease-out"
         >
           <span className={`${classes.text} tw-font-semibold tw-text-iron-300`}>
-            {formatStatFloor(cic)}
+            {nicValue}
           </span>{" "}
           <span className={`${classes.text} tw-font-medium tw-text-iron-500`}>
-            NIC
+            {getUserStatsRowMessage("user.statsRow.labels.nic")}
           </span>
         </Link>
 
         <Link
           href={`/${routeHandle}`}
+          aria-label={getUserStatsRowMessage("user.statsRow.links.rep", {
+            handle,
+            value: repValue,
+          })}
           className="tw-no-underline desktop-hover:hover:tw-underline tw-transition tw-duration-300 tw-ease-out"
         >
           <span className={`${classes.text} tw-font-semibold tw-text-iron-300`}>
-            {formatStatFloor(rep)}
+            {repValue}
           </span>{" "}
           <span className={`${classes.text} tw-font-medium tw-text-iron-500`}>
-            Rep
+            {getUserStatsRowMessage("user.statsRow.labels.rep")}
           </span>
         </Link>
 
@@ -129,10 +171,14 @@ export default function UserStatsRow({
           <button
             type="button"
             onClick={onFollowersClick}
+            aria-label={getUserStatsRowMessage(
+              "user.statsRow.buttons.followers",
+              followersActionLabel
+            )}
             className="tw-bg-transparent tw-border-none tw-p-0 tw-cursor-pointer tw-no-underline desktop-hover:hover:tw-underline tw-transition tw-duration-300 tw-ease-out"
           >
             <span className={`${classes.text} tw-font-semibold tw-text-iron-300`}>
-              {formatNumberWithCommas(count)}
+              {followersValue}
             </span>{" "}
             <span className={`${classes.text} tw-font-medium tw-text-iron-500`}>
               {followerLabel}
@@ -141,10 +187,14 @@ export default function UserStatsRow({
         ) : (
           <Link
             href={`/${routeHandle}`}
+            aria-label={getUserStatsRowMessage(
+              "user.statsRow.links.followers",
+              followersActionLabel
+            )}
             className="tw-no-underline desktop-hover:hover:tw-underline tw-transition tw-duration-300 tw-ease-out"
           >
             <span className={`${classes.text} tw-font-semibold tw-text-iron-300`}>
-              {formatNumberWithCommas(count)}
+              {followersValue}
             </span>{" "}
             <span className={`${classes.text} tw-font-medium tw-text-iron-500`}>
               {followerLabel}

--- a/components/user/utils/stats/user-stats-row.messages.ts
+++ b/components/user/utils/stats/user-stats-row.messages.ts
@@ -1,0 +1,20 @@
+import { formatInteger } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t, type MessageKey } from "@/i18n/messages";
+
+type UserStatsRowMessageKey = Extract<MessageKey, `user.statsRow.${string}`>;
+
+type MessageParams = Record<string, string | number>;
+
+export function getUserStatsRowMessage(
+  key: UserStatsRowMessageKey,
+  params: MessageParams = {}
+): string {
+  return t(DEFAULT_LOCALE, key, params);
+}
+
+export function formatUserStatsRowInteger(
+  value: number | null | undefined
+): string {
+  return formatInteger(DEFAULT_LOCALE, value);
+}

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -274,6 +274,40 @@ const USER_STATS_ROW_MESSAGES = objectMessages("user.statsRow", {
   "buttons.followers": "Open {handle}'s followers: {value} {followersLabel}",
 } as const);
 
+const USER_PROFILE_HEADER_MESSAGES = objectMessages("user.profileHeader", {
+  "name.edit": "Edit {name}'s profile name",
+  "name.profileEnabled": "Profile enabled: {date}",
+  "pfp.alt": "{name}'s profile picture",
+  "pfp.edit": "Edit {name}'s profile picture",
+  "banner.edit": "Edit {name}'s profile banner",
+  "about.add": "Add About statement",
+  "about.edit": "Edit About statement",
+  "about.empty": "Click to add an About statement",
+  "about.expand": "See more",
+  "about.collapse": "See less",
+  "aboutEdit.textareaLabel": "About statement",
+  "aboutEdit.placeholder": "Write an About statement",
+  "aboutEdit.characterCount": "{count}/{max}",
+  "aboutEdit.cancel": "Cancel",
+  "aboutEdit.save": "Save",
+  "aboutEdit.success": "About statement added.",
+  "aboutEdit.errors.close": "Dismiss About statement error",
+  "aboutEdit.errors.unknown.title": "Unknown Error",
+  "aboutEdit.errors.hateSpeech.title": "Error: Hate Speech",
+  "aboutEdit.errors.hateSpeech.value":
+    "Your About text was not accepted because our automated checks flagged it for potentially containing hate speech. We want to keep seize a welcoming place! We'd appreciate it if you adjusted your text.",
+  "aboutEdit.errors.personalInsults.title": "Error: Personal Insults",
+  "aboutEdit.errors.personalInsults.value":
+    "Your About text was not accepted because our automated checks flagged it for potentially containing a personal insult. We want to keep seize a welcoming place! We'd appreciate it if you adjusted your text.",
+  "aboutEdit.errors.inappropriateLanguage.title":
+    "Error: Inappropriate Language",
+  "aboutEdit.errors.inappropriateLanguage.value":
+    "Your About text was not accepted because our automated checks flagged it for potentially containing inappropriate language that may make others uncomfortable. We want to keep seize a welcoming place! We'd appreciate it if you adjusted your text.",
+  "aboutEdit.errors.doxxing.title": "Error: Doxxing of Another Person",
+  "aboutEdit.errors.doxxing.value":
+    "Your About text was not accepted because our automated checks flagged it for potentially doxxing another user of the system. We have a strong cultural value around respecting pseudonymity, so we'd appreciate it if you adjusted your text.",
+} as const);
+
 const MEME_LAB_DETAIL_MESSAGES = namespaceMessages("memeLab.detail", [
   ["browserTitle", "{name} | Meme Lab #{tokenId}"],
   ["browserTitleWithTab", "{title} | {tab}"],
@@ -796,6 +830,7 @@ export const EN_US_MESSAGES = {
   ...USER_PROFILE_TABS_MESSAGES,
   ...FOLLOWERS_MESSAGES,
   ...USER_STATS_ROW_MESSAGES,
+  ...USER_PROFILE_HEADER_MESSAGES,
   ...REMEMES_DETAIL_MESSAGES,
 } as const;
 

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -257,6 +257,23 @@ const FOLLOWERS_MESSAGES = objectMessages("followers", {
   "profile.avatarAlt": "{handle}'s profile image",
 } as const);
 
+const USER_STATS_ROW_MESSAGES = objectMessages("user.statsRow", {
+  "labels.tdh": "TDH",
+  "labels.xtdh": "xTDH",
+  "labels.nic": "NIC",
+  "labels.rep": "Rep",
+  "labels.followers.one": "Follower",
+  "labels.followers.many": "Followers",
+  "links.tdh": "View {handle}'s collected TDH: {value}",
+  "links.tdhWithRate": "View {handle}'s collected TDH: {value}, +{rate}",
+  "links.xtdh": "View {handle}'s xTDH: {value}",
+  "links.xtdhWithRate": "View {handle}'s xTDH: {value}, +{rate}",
+  "links.nic": "View {handle}'s NIC: {value}",
+  "links.rep": "View {handle}'s Rep: {value}",
+  "links.followers": "View {handle}'s followers: {value} {followersLabel}",
+  "buttons.followers": "Open {handle}'s followers: {value} {followersLabel}",
+} as const);
+
 const MEME_LAB_DETAIL_MESSAGES = namespaceMessages("memeLab.detail", [
   ["browserTitle", "{name} | Meme Lab #{tokenId}"],
   ["browserTitleWithTab", "{title} | {tab}"],
@@ -778,6 +795,7 @@ export const EN_US_MESSAGES = {
   "user.collected.networkCards.xtdhPerDay": "xTDH/day",
   ...USER_PROFILE_TABS_MESSAGES,
   ...FOLLOWERS_MESSAGES,
+  ...USER_STATS_ROW_MESSAGES,
   ...REMEMES_DETAIL_MESSAGES,
 } as const;
 

--- a/ops/workstreams/frontend-a11y-i18n/README.md
+++ b/ops/workstreams/frontend-a11y-i18n/README.md
@@ -13,7 +13,9 @@ page surfaces one PR at a time.
 3. `ops/skills/write-prs/SKILL.md`
 4. `ops/standards/README.md`
 5. `active-context.md`
-6. `run-log.md`
+6. `stack-audit.md`
+7. `audit-inventory.md`
+8. `run-log.md`
 
 ## Owned Paths
 

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -52,16 +52,17 @@ page migration PRs for safe media surfaces.
   status, nullable follower handle fallback, follower profile link names,
   avatar alt text, and semantic list structure. It is stacked from PR #2640 and
   must not be merged.
-- PR #2642 is open and review-ready only. It covers the user profile header
-  stats row labels, accessible names, and follower-count formatting. It is
-  stacked from PR #2641 and must not be merged.
+- PR #2642 is bot-happy on the latest head and remains review-ready only. It
+  covers the user profile header stats row labels, accessible names, and
+  follower-count formatting. It is stacked from PR #2641 and must not be
+  merged.
 - Non-source locales currently fall back to `en-US` until reviewed
   translations are added.
 - Full locale-prefixed routing is deferred.
 
 ## Next Actions
 
-1. Iterate on PR #2642 with available bots/checks without merging.
+1. Keep PR #2642 review-ready only; do not merge.
 2. Keep PR #2641 review-ready only; do not merge.
 3. Keep PR #2640 review-ready only; do not merge.
 4. Maintain PRs #2639, #2638, #2637, and earlier page PRs as review-ready only;

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -7,7 +7,7 @@ page migration PRs for safe media surfaces.
 
 ## Current Branch
 
-`codex/user-followers-modal-a11y-i18n`
+`codex/user-header-stats-a11y-i18n`
 
 ## Constraints
 
@@ -47,18 +47,21 @@ page migration PRs for safe media surfaces.
   covers profile shell tab titles, beta badge text, navigation landmark labels,
   scroll button labels, and active-page semantics. It is stacked from PR #2639
   and must not be merged.
-- PR #2641 is open and review-ready only. It covers the profile followers modal
-  title, follower list label, loading status, follower profile link names,
+- PR #2641 is bot-happy on the latest head and remains review-ready only. It
+  covers the profile followers modal title, follower list label, loading
+  status, nullable follower handle fallback, follower profile link names,
   avatar alt text, and semantic list structure. It is stacked from PR #2640 and
   must not be merged.
+- Current branch is stacked from PR #2641 and covers the user profile header
+  stats row labels, accessible names, and follower-count formatting.
 - Non-source locales currently fall back to `en-US` until reviewed
   translations are added.
 - Full locale-prefixed routing is deferred.
 
 ## Next Actions
 
-1. Iterate on PR #2641 with available bots/checks without
-   merging.
+1. Publish the profile stats-row PR against PR #2641, then iterate with
+   available bots/checks without merging.
 2. Keep PR #2641 review-ready only; do not merge.
 3. Keep PR #2640 review-ready only; do not merge.
 4. Maintain PRs #2639, #2638, #2637, and earlier page PRs as review-ready only;

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -52,16 +52,16 @@ page migration PRs for safe media surfaces.
   status, nullable follower handle fallback, follower profile link names,
   avatar alt text, and semantic list structure. It is stacked from PR #2640 and
   must not be merged.
-- Current branch is stacked from PR #2641 and covers the user profile header
-  stats row labels, accessible names, and follower-count formatting.
+- PR #2642 is open and review-ready only. It covers the user profile header
+  stats row labels, accessible names, and follower-count formatting. It is
+  stacked from PR #2641 and must not be merged.
 - Non-source locales currently fall back to `en-US` until reviewed
   translations are added.
 - Full locale-prefixed routing is deferred.
 
 ## Next Actions
 
-1. Publish the profile stats-row PR against PR #2641, then iterate with
-   available bots/checks without merging.
+1. Iterate on PR #2642 with available bots/checks without merging.
 2. Keep PR #2641 review-ready only; do not merge.
 3. Keep PR #2640 review-ready only; do not merge.
 4. Maintain PRs #2639, #2638, #2637, and earlier page PRs as review-ready only;

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -2,12 +2,13 @@
 
 ## Current Goal
 
-Deliver the standards and repo-local skill foundation, then start review-ready
-page migration PRs for safe media surfaces.
+Maintain the existing review-ready WCAG/i18n implementation stack, harden it
+bottom-up where safe, and build durable inventory for the next stack. Do not
+merge page implementation PRs.
 
 ## Current Branch
 
-`codex/user-header-stats-a11y-i18n`
+`codex/user-about-edit-a11y-i18n`
 
 ## Constraints
 
@@ -56,16 +57,42 @@ page migration PRs for safe media surfaces.
   covers the user profile header stats row labels, accessible names, and
   follower-count formatting. It is stacked from PR #2641 and must not be
   merged.
+- PR #2643 is bot-happy on the latest head and remains review-ready only. It
+  covers the user profile header identity/name/media labels, profile-enabled
+  date formatting, and read-only wrapper semantics. It is stacked from PR #2642
+  and must not be merged.
+- PR #2644 is bot-happy on the latest head and remains review-ready only. It
+  covers the user profile header About statement placeholder, add/edit controls,
+  mobile expand/collapse toggle, and nested-interactive-control cleanup. It is
+  stacked from PR #2643 and must not be merged.
+- PR #2645 is open and review-ready only. It covers the user profile About edit
+  form labels, placeholder, character count, actions, success toast, moderation
+  errors, alert semantics, and error-dismiss name. It is stacked from PR #2644
+  and must not be merged.
 - Non-source locales currently fall back to `en-US` until reviewed
   translations are added.
 - Full locale-prefixed routing is deferred.
+- 2026-06-13 stack audit: PR #2604 and PRs #2607-#2645 are open, non-draft,
+  mergeable, and green on the visible GitHub check rollup.
+- Related-looking open PR #2597 is older OG metadata work, not part of this
+  WCAG/i18n stack.
+- Open PR #2632 is separate 6529bot admin dashboard work, not part of this
+  WCAG/i18n stack.
+- 2026-06-14 bottom-stack pass: PR #2604 received a passive scroll listener
+  hardening commit (`23d119e`) and local validation/browser smoke passed.
+  GitHub's visible latest-head rollup is green and a validation snapshot was
+  posted on the PR. CodeRabbit's new incremental review was rate-limited, but
+  prior actionable CodeRabbit findings are already fixed in the current code.
+- 2026-06-14 audit inventory: `audit-inventory.md` records candidate hotspots
+  for static copy, interaction semantics, locale formatting, image alt review,
+  and i18n helper adoption.
 
 ## Next Actions
 
-1. Keep PR #2642 review-ready only; do not merge.
-2. Keep PR #2641 review-ready only; do not merge.
-3. Keep PR #2640 review-ready only; do not merge.
-4. Maintain PRs #2639, #2638, #2637, and earlier page PRs as review-ready only;
-   do not merge.
-5. Preserve the unrelated dirty EmojiContext, RememeImage test, and bootstrap
+1. Hold new page PR creation until the existing stack is reviewed.
+2. Keep PR #2604 and PRs #2607-#2645 review-ready only; do not merge without
+   human approval.
+3. If asked to advance the stack, continue bottom-up from PR #2607 after the
+   #2604 validation snapshot.
+4. Preserve the unrelated dirty EmojiContext, RememeImage test, and bootstrap
    style files.

--- a/ops/workstreams/frontend-a11y-i18n/audit-inventory.md
+++ b/ops/workstreams/frontend-a11y-i18n/audit-inventory.md
@@ -1,0 +1,82 @@
+# WCAG/I18n Audit Inventory
+
+## 2026-06-14
+
+This inventory is a triage map, not a bug list. The scans intentionally find
+candidate areas where accessibility or localization debt may exist, then future
+PRs should verify each hit against the standards before changing code.
+
+Scans ran from the current workstream branch after the profile stack was opened.
+
+## Scan Summary
+
+| Category | Files | Matches | Signal |
+| --- | ---: | ---: | --- |
+| Static copy attributes | 525 | 2753 | Hardcoded `aria-label`, `placeholder`, or `title` values likely need message-backed treatment when touched. |
+| Interaction candidates | 859 | 1687 | Dense `onClick`, key, `tabIndex`, or role usage that needs semantic-control review before WCAG claims. |
+| Locale formatting candidates | 86 | 186 | Direct `toLocale*` or `Intl.*` usage that may need the repo i18n helper path. |
+| Image alt candidates | 213 | 596 | `<img>` and empty/null alt patterns that need decorative-vs-informative review. |
+| I18n helper adoption | 77 | 621 | Current usage of `t()`, locale normalization, and repo formatting helpers. |
+
+## Top Hotspots
+
+Static copy attributes:
+
+- `app/museum/6529-fund-szn1/cod/page.tsx`
+- `app/museum/genesis/fragments-of-an-infinite-field/page.tsx`
+- `app/blog/from-fibonacci-to-fidenza/page.tsx`
+- `app/museum/6529-fund-szn1/incomplete-control/page.tsx`
+- `app/museum/6529-fund-szn1/rarepepe/page.tsx`
+
+Interaction candidates:
+
+- `components/nextGen/admin/NextGenAdmin.tsx`
+- `components/drop-forge/craft/DropForgeCraftClaimPageClient.tsx`
+- `components/waves/TwitterPreviewCard.tsx`
+- `components/meme-calendar/MemeCalendar.tsx`
+- `components/delegation/CollectionDelegation.tsx`
+
+Locale formatting candidates:
+
+- `components/drop-forge/launch/DropForgeLaunchClaimPageClient.view.tsx`
+- `components/drop-forge/craft/DropForgeCraftClaimPageClient.tsx`
+- `components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotForm.tsx`
+- `components/distribution-plan-tool/create-snapshots/table/CreateSnapshotTableRow.tsx`
+- `components/meme-calendar/meme-calendar.helpers.tsx`
+
+Image alt candidates:
+
+- `app/museum/6529-fund-szn1/capsule-house/page.tsx`
+- `app/museum/6529-fund-szn1/cod/page.tsx`
+- `app/museum/page.tsx`
+- `app/om/6529-museum-district/page.tsx`
+- `app/capital/company-portfolio/page.tsx`
+
+I18n helper adoption is currently concentrated in the media/profile migration
+surface, especially `components/the-memes`, `components/memelab`,
+`components/rememes`, `components/meme-calendar`, and user profile components.
+
+## Recommendations
+
+- Keep the current implementation stack review-ready only until humans are
+  comfortable with the size and shape of the migration.
+- Continue bottom-up hardening, starting with PR #2604, because it supplies the
+  i18n helpers inherited by the rest of the stack.
+- Prefer safe public media or static surfaces for the next stack. `meme-calendar`
+  and read-only media/card surfaces are better candidates than claim, admin,
+  delegation, or transaction flows.
+- Treat museum, blog, capital, and OM pages as a separate editorial/static-page
+  backlog. They have many image and static-copy hits, but the translation and
+  content-review burden is different from app UI.
+- Defer `drop-forge`, `nextGen/admin`, distribution tooling, delegation, and
+  transfer flows until the helper pattern and review appetite are proven.
+
+## Commands
+
+```powershell
+rg --count-matches -g '*.tsx' -g '*.ts' 'aria-label=\x22[^\x22]+\x22|placeholder=\x22[^\x22]+\x22|title=\x22[^\x22]+\x22' app components contexts hooks pages
+rg --count-matches -g '*.tsx' 'role=\x22button\x22|role=\x22dialog\x22|tabIndex=|onClick=|onKeyDown=|onMouseDown=|onMouseUp=' app components pages
+rg --count-matches -g '*.tsx' -g '*.ts' 'toLocaleString|toLocaleDateString|toLocaleTimeString|Intl\.' app components contexts hooks lib pages
+rg --count-matches -g '*.tsx' '<img\b|alt=\{?\x22\x22|alt=\x22\x22|alt=\{undefined\}|alt=\{null\}' app components pages
+rg --count-matches -g '*.tsx' -g '*.ts' '\bt\(|\bformatInteger\(|\bformatNumber\(|\bformatDate\(|\bformatRelativeTime\(|\bnormalizeLocale\(' app components i18n
+```

--- a/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
+++ b/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
@@ -12,6 +12,9 @@ Record review-bot and CI decisions here for this workstream.
 | 2026-06-11 | #2604 | Claude       | Review skipped because organization monthly code review cap was reached   | Treat as unavailable, not actionable |
 | 2026-06-11 | #2604 | SonarCloud   | Flagged i18n default object parameters and interpolation character class  | Fixed                                |
 | 2026-06-11 | #2604 | CodeRabbit   | Flagged Suspense, title i18n, locale matching, and exhaustive guards      | Fixed                                |
+| 2026-06-14 | #2604 | React Doctor | Flagged non-passive scroll listener during PR-diff review                 | Fixed                                |
+| 2026-06-14 | #2604 | CodeRabbit   | Latest one-file incremental review was rate-limited                       | Treat as unavailable until reset     |
+| 2026-06-14 | #2604 | GitHub checks | Latest visible rollup passed on head `23d119e`                            | Accept                               |
 | 2026-06-12 | #2607 | SonarCloud   | Quality Gate passed with 0 new issues                                     | Accept                               |
 | 2026-06-12 | #2607 | Snyk         | PR check passed                                                           | Accept                               |
 | 2026-06-12 | #2607 | CodeRabbit   | Flagged dead `MemeTab.title` and duplicate `MEME_FOCUS_VALUES` guards     | Fixed                                |

--- a/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
+++ b/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
@@ -68,3 +68,9 @@ Record review-bot and CI decisions here for this workstream.
 | 2026-06-13 | #2641 | DCO          | Signed commits check passed                                               | Accept                               |
 | 2026-06-13 | #2641 | SonarCloud   | Quality Gate passed with 0 new issues                                     | Accept                               |
 | 2026-06-13 | #2641 | Snyk         | No manifest changes detected                                              | Accept                               |
+| 2026-06-13 | #2642 | DCO          | Signed commits check passed                                               | Accept                               |
+| 2026-06-13 | #2642 | SonarCloud   | Quality Gate passed with 0 new issues and 0.0% duplication                | Accept                               |
+| 2026-06-13 | #2642 | Snyk         | No manifest changes detected                                              | Accept                               |
+| 2026-06-13 | #2642 | CodeRabbit   | Manual review completed with no actionable comments or review threads     | Accept                               |
+| 2026-06-13 | #2642 | CodeRabbit   | Generic docstring coverage warning for simple helper functions            | Defer; repo style avoids noise       |
+| 2026-06-13 | #2642 | Claude       | PR configured for manual review only                                      | Treat as unavailable, not actionable |

--- a/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
+++ b/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
@@ -64,3 +64,7 @@ Record review-bot and CI decisions here for this workstream.
 | 2026-06-13 | #2640 | SonarCloud   | Quality Gate passed with 0 new issues                                     | Accept                               |
 | 2026-06-13 | #2640 | Snyk         | No manifest changes detected                                              | Accept                               |
 | 2026-06-13 | #2640 | CodeRabbit   | Manual review completed with no review threads                            | Accept                               |
+| 2026-06-13 | #2641 | CodeRabbit   | Latest head passed with no review threads                                 | Accept                               |
+| 2026-06-13 | #2641 | DCO          | Signed commits check passed                                               | Accept                               |
+| 2026-06-13 | #2641 | SonarCloud   | Quality Gate passed with 0 new issues                                     | Accept                               |
+| 2026-06-13 | #2641 | Snyk         | No manifest changes detected                                              | Accept                               |

--- a/ops/workstreams/frontend-a11y-i18n/pr-links.md
+++ b/ops/workstreams/frontend-a11y-i18n/pr-links.md
@@ -38,3 +38,4 @@
 | Profile TDH history       | `codex/user-collected-tdh-history-a11y-i18n`            | #2639 | Open, review-ready only |
 | Profile tabs shell        | `codex/user-profile-tabs-a11y-i18n`                     | #2640 | Open, review-ready only |
 | Profile followers modal   | `codex/user-followers-modal-a11y-i18n`                  | #2641 | Open, review-ready only |
+| Profile stats row         | `codex/user-header-stats-a11y-i18n`                     | #2642 | Open, review-ready only |

--- a/ops/workstreams/frontend-a11y-i18n/pr-links.md
+++ b/ops/workstreams/frontend-a11y-i18n/pr-links.md
@@ -39,3 +39,6 @@
 | Profile tabs shell        | `codex/user-profile-tabs-a11y-i18n`                     | #2640 | Open, review-ready only |
 | Profile followers modal   | `codex/user-followers-modal-a11y-i18n`                  | #2641 | Open, review-ready only |
 | Profile stats row         | `codex/user-header-stats-a11y-i18n`                     | #2642 | Open, review-ready only |
+| Profile header identity   | `codex/user-header-identity-a11y-i18n`                  | #2643 | Open, review-ready only |
+| Profile header About      | `codex/user-header-about-a11y-i18n`                     | #2644 | Open, review-ready only |
+| Profile About edit form   | `codex/user-about-edit-a11y-i18n`                       | #2645 | Open, review-ready only |

--- a/ops/workstreams/frontend-a11y-i18n/route-page-status.md
+++ b/ops/workstreams/frontend-a11y-i18n/route-page-status.md
@@ -39,3 +39,4 @@
 | `/{user}/collected` TDH history        | PR open              | PR open           | PR #2639; review-ready only; stacked on PR #2638; do not merge yet |
 | User profile tabs shell                | PR open              | PR open           | PR #2640; review-ready only; stacked on PR #2639; do not merge yet |
 | User followers modal/list              | PR open              | PR open           | PR #2641; review-ready only; stacked on PR #2640; do not merge yet |
+| User profile header stats row          | Branch in progress   | Branch in progress | Stacked on PR #2641; publish review-ready PR; do not merge yet     |

--- a/ops/workstreams/frontend-a11y-i18n/route-page-status.md
+++ b/ops/workstreams/frontend-a11y-i18n/route-page-status.md
@@ -39,4 +39,4 @@
 | `/{user}/collected` TDH history        | PR open              | PR open           | PR #2639; review-ready only; stacked on PR #2638; do not merge yet |
 | User profile tabs shell                | PR open              | PR open           | PR #2640; review-ready only; stacked on PR #2639; do not merge yet |
 | User followers modal/list              | PR open              | PR open           | PR #2641; review-ready only; stacked on PR #2640; do not merge yet |
-| User profile header stats row          | Branch in progress   | Branch in progress | Stacked on PR #2641; publish review-ready PR; do not merge yet     |
+| User profile header stats row          | PR open              | PR open            | PR #2642; review-ready only; stacked on PR #2641; do not merge yet |

--- a/ops/workstreams/frontend-a11y-i18n/route-page-status.md
+++ b/ops/workstreams/frontend-a11y-i18n/route-page-status.md
@@ -40,3 +40,6 @@
 | User profile tabs shell                | PR open              | PR open           | PR #2640; review-ready only; stacked on PR #2639; do not merge yet |
 | User followers modal/list              | PR open              | PR open           | PR #2641; review-ready only; stacked on PR #2640; do not merge yet |
 | User profile header stats row          | PR open              | PR open            | PR #2642; review-ready only; stacked on PR #2641; do not merge yet |
+| User profile header identity/media     | PR open              | PR open            | PR #2643; review-ready only; stacked on PR #2642; do not merge yet |
+| User profile header About statement    | PR open              | PR open            | PR #2644; review-ready only; stacked on PR #2643; do not merge yet |
+| User profile About edit form           | PR open              | PR open            | PR #2645; review-ready only; stacked on PR #2644; do not merge yet |

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1101,3 +1101,108 @@
   coverage warning was deferred because the touched helpers are self-explanatory
   and repo style avoids low-value comments. Per workstream policy, do not merge
   PR #2642.
+- Started stacked branch `codex/user-header-identity-a11y-i18n` from PR #2642
+  for the next low-risk profile header follow-up.
+- Implemented message-backed source-locale labels for the profile header name
+  edit action, profile picture alt/edit labels, banner edit label, and
+  profile-enabled date line. Removed disabled edit buttons from read-only name
+  and profile-picture wrappers so the public profile header uses plain
+  non-interactive containers when editing is unavailable. The profile-enabled
+  month/year now uses the repo i18n date formatting helper.
+- Validation passed for the header identity/media follow-up so far: focused
+  header/i18n Jest suites (6 suites, 18 tests), targeted ESLint for touched
+  source files, `typecheck:changed`, `react-doctor:diff`, `git diff --check`,
+  Next MCP runtime diagnostics, and desktop/mobile browser smoke on `/punk6529`.
+  React Doctor still reports the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic and a test-only `next/image` mock warning.
+- Opened review-ready stacked PR #2643 against PR #2642. Per workstream policy,
+  do not merge PR #2643.
+- Fixed PR #2643 bot feedback: SonarCloud reported accessibility findings in
+  test mocks, so the affected mocks now use semantic buttons and a
+  `next/image` mock with explicit alt text. CodeRabbit requested direct profile
+  header helper coverage and single-source profile label derivation for the
+  banner; added focused helper assertions and threaded the client-computed
+  `profileLabel` into `UserPageHeaderBanner`.
+- Validation after the PR #2643 bot-feedback fixes passed for the focused
+  header/i18n Jest suites (6 suites, 19 tests), targeted ESLint for touched
+  source files, `typecheck:changed`, `react-doctor:diff`, and `git diff
+  --check`. React Doctor still reports only the unrelated dirty
+  `contexts/EmojiContext.tsx` fetch-in-effect diagnostic.
+- Confirmed PR #2643 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed with 0 new issues, CodeRabbit manual review passed, no
+  review threads are open, and Claude remained configured for manual review
+  only. Per workstream policy, do not merge PR #2643.
+- Started stacked branch `codex/user-header-about-a11y-i18n` from PR #2643 for
+  the next low-risk profile header follow-up.
+- Implemented message-backed source-locale labels for the profile header About
+  placeholder, add/edit actions, and mobile expand/collapse control. Split the
+  existing statement edit affordance so long statements can keep their own
+  expand button without being nested inside a parent edit button. The public
+  read-only profile continues to render no hidden About edit controls.
+- Validation passed for the About statement follow-up so far: focused about/i18n
+  Jest suites (3 suites, 10 tests), targeted ESLint for touched source files,
+  `typecheck:changed`, `react-doctor:diff`, `git diff --check`, Next MCP runtime
+  diagnostics, and desktop/mobile browser smoke on `/punk6529`. React Doctor
+  still reports only the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic; the local browser console still shows known shared
+  API/emoji resource errors.
+- Opened review-ready stacked PR #2644 against PR #2643. Per workstream policy,
+  do not merge PR #2644.
+- Confirmed PR #2644 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed with 0 new issues, CodeRabbit manual review passed, no
+  review threads are open, and Claude remained configured for manual review
+  only. Per workstream policy, do not merge PR #2644.
+- Started stacked branch `codex/user-about-edit-a11y-i18n` from PR #2644 for the
+  next adjacent profile About follow-up.
+- Implemented message-backed source-locale labels for the profile About edit
+  form textarea, placeholder, character count, cancel/save controls, success
+  toast, moderation error copy, unknown-error title, and error-dismiss action.
+  The moderation error container now uses `role="alert"` so errors are announced.
+- Validation passed for the About edit-form follow-up so far: focused edit
+  form/error/i18n Jest suites (3 suites, 7 tests), targeted ESLint for touched
+  source files, `typecheck:changed`, `react-doctor:diff`, `git diff --check`,
+  Next MCP runtime diagnostics, and desktop browser smoke on `/punk6529`. React
+  Doctor still reports only the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic; the local browser console still shows known shared
+  API/emoji resource errors.
+- Opened review-ready stacked PR #2645 against PR #2644. Per workstream policy,
+  do not merge PR #2645.
+
+## 2026-06-13
+
+- Audited the open WCAG/i18n PR stack after user concern about the number of
+  related PRs. Confirmed PR #2604 and PRs #2607-#2645 are expected workstream
+  implementation PRs, are open, non-draft, mergeable, and green on the visible
+  GitHub check rollup. Recorded the stack snapshot in `stack-audit.md`.
+- Confirmed related-looking PR #2597 is older OG metadata work and PR #2632 is
+  separate 6529bot admin dashboard work; neither is part of this WCAG/i18n
+  migration stack.
+- Updated active context to pause new page PR creation until the current stack
+  is reviewed or a new scope is chosen.
+
+## 2026-06-14
+
+- Rechecked the bottom of the WCAG/i18n stack and used a clean temp worktree for
+  PR #2604.
+- Pushed signed hardening commit `23d119e` to PR #2604, making the The Memes
+  scroll listener passive.
+- Validation passed for PR #2604: changed-file lint, changed-file typecheck,
+  targeted The Memes card and i18n Jest suites, React Doctor PR-diff review,
+  `git diff --check`, and desktop/mobile browser smoke on
+  `/the-memes?locale=de-DE`.
+- Browser smoke used a local-only Bootstrap import fix that is already present
+  on current `main`; this verification-only tweak was not committed to #2604.
+- Confirmed stale CodeRabbit findings on #2604 are already handled in current
+  code: localized document title, case-insensitive locale normalization, and
+  exhaustive enum label guards.
+- Recorded the latest CodeRabbit caveat: the visible status context is green,
+  but the new incremental review was rate-limited, so treat new bot review as
+  unavailable until the limit resets.
+- Rechecked PR #2604 after CodeQL completed. The latest visible GitHub rollup
+  passed for head `23d119e`: CodeQL, DCO, SonarCloud, Snyk, and CodeRabbit
+  status context.
+- Posted a PR validation snapshot comment documenting the local checks, browser
+  smoke, green rollup, and CodeRabbit rate-limit caveat.
+- Added `audit-inventory.md` with candidate hotspots for static copy,
+  interaction semantics, locale formatting, image alt review, and i18n helper
+  adoption to guide the next safe stack.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1071,3 +1071,24 @@
   responses unrelated to the followers modal change.
 - Opened review-ready stacked PR #2641 against PR #2640. Per workstream policy,
   do not merge PR #2641.
+- Fixed a PR #2641 typecheck issue for followers without handles by falling
+  back to the follower's primary address for profile routes and accessible
+  labels. Validation passed for the focused followers/i18n Jest suites,
+  targeted ESLint, `typecheck:changed`, `react-doctor:diff`, `git diff
+  --check`, and desktop/mobile browser smoke on `/punk6529`.
+- Confirmed PR #2641 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed, CodeRabbit passed with no review threads, and Claude
+  remained configured for manual review only. Per workstream policy, do not
+  merge PR #2641.
+- Started stacked branch `codex/user-header-stats-a11y-i18n` from PR #2641 for
+  the next low-risk user profile header follow-up.
+- Implemented message-backed source-locale labels and accessible names for the
+  profile header stats row. The TDH, xTDH, NIC, Rep, and follower controls now
+  expose explicit action labels that include the handle and current values, and
+  follower counts use the repo i18n integer formatting helper.
+- Validation passed for the stats-row follow-up so far: focused stats/i18n Jest
+  suites (3 suites, 8 tests), targeted ESLint for the touched source files,
+  `typecheck:changed`, `react-doctor:diff`, `git diff --check`, Next MCP
+  runtime diagnostics, and desktop/mobile browser smoke on `/punk6529`. React
+  Doctor still reports only the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1092,3 +1092,5 @@
   runtime diagnostics, and desktop/mobile browser smoke on `/punk6529`. React
   Doctor still reports only the unrelated dirty `contexts/EmojiContext.tsx`
   fetch-in-effect diagnostic.
+- Opened review-ready stacked PR #2642 against PR #2641. Per workstream policy,
+  do not merge PR #2642.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1094,3 +1094,10 @@
   fetch-in-effect diagnostic.
 - Opened review-ready stacked PR #2642 against PR #2641. Per workstream policy,
   do not merge PR #2642.
+- Confirmed PR #2642 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed with 0 new issues and 0.0% duplication, CodeRabbit manual
+  review passed with no actionable comments and no review threads, and Claude
+  remained configured for manual review only. CodeRabbit's generic docstring
+  coverage warning was deferred because the touched helpers are self-explanatory
+  and repo style avoids low-value comments. Per workstream policy, do not merge
+  PR #2642.

--- a/ops/workstreams/frontend-a11y-i18n/stack-audit.md
+++ b/ops/workstreams/frontend-a11y-i18n/stack-audit.md
@@ -1,0 +1,63 @@
+# WCAG/I18n PR Stack Audit
+
+## 2026-06-13T21:52:58Z
+
+GitHub audit command:
+
+```powershell
+gh pr list --repo 6529-Collections/6529seize-frontend --state open --limit 100 --json number,title,headRefName,baseRefName,isDraft,mergeable,updatedAt,statusCheckRollup
+```
+
+## Summary
+
+- Standards PR #2603 is merged.
+- Implementation PRs #2604 and #2607-#2645 are expected workstream PRs.
+- All tracked implementation PRs are open, non-draft, mergeable, and green on
+  the visible GitHub check rollup.
+- Page implementation PRs remain review-ready only. Do not merge them without
+  human approval.
+- Pause new page PR creation until the existing stack is reviewed or the next
+  explicit scope is chosen.
+
+## Chain Shape
+
+| Range | Scope | Current State |
+| --- | --- | --- |
+| #2604 | The Memes list-card foundation | Open, non-draft, mergeable, green |
+| #2607-#2625 | The Memes, Meme Lab, Rememes, meme calendar/media surfaces | Open, non-draft, mergeable, green |
+| #2626-#2639 | `/{user}/collected` cards, filters, details, and activity surfaces | Open, non-draft, mergeable, green |
+| #2640-#2645 | Profile tabs, followers modal, header, and About edit surfaces | Open, non-draft, mergeable, green |
+
+## Related-Looking PRs Outside This Workstream
+
+| PR | Title | Why It Is Not In This Workstream |
+| --- | --- | --- |
+| #2597 | Standardize NextGen and ReMemes OG metadata | Older OG metadata stack; mentions Rememes but is not WCAG/i18n page migration work |
+| #2632 | Add private 6529bot admin dashboard | Separate admin dashboard work |
+
+## Recommendation
+
+Keep the current implementation stack intact and review it bottom-up, starting
+with #2604. Do not open more page migration PRs until humans are comfortable
+with the existing stack size, or until a separate follow-up stack is explicitly
+requested.
+
+## 2026-06-14 Bottom-Stack Follow-Up
+
+- PR #2604 received a focused hardening commit:
+  `23d119ed1497f8b3b25ba099c75e0447de4e7608`.
+- The commit makes the The Memes infinite-scroll listener passive.
+- Local validation passed for lint, changed-file typecheck, targeted The Memes
+  card and i18n tests, React Doctor PR-diff review, and desktop/mobile browser
+  smoke on `/the-memes?locale=de-DE`.
+- Browser smoke required a local-only Bootstrap import fix already present on
+  current `main`; that verification-only tweak was not committed to PR #2604.
+- Known local browser noise remained limited to the shared backend wave
+  endpoints and the blocked emoji-list resource.
+- CodeRabbit posted a rate-limit notice for the latest one-file delta. The
+  visible CodeRabbit status context is green, but the incremental review should
+  be treated as unavailable until the rate limit resets or a manual review is
+  requested later.
+- The latest visible GitHub rollup for head `23d119e` is green: CodeQL, DCO,
+  SonarCloud, Snyk, and CodeRabbit status context.
+- A validation snapshot comment was posted on PR #2604.


### PR DESCRIPTION
## Issue
- Continue the progressive WCAG 2.2 AA and i18n migration on a low-risk user profile surface.
- The profile header stats row still had hardcoded labels and link/button names that were less descriptive for assistive technology.

## Fix
- Move the touched stats-row labels and action names behind the source-locale message dictionary.
- Add explicit accessible names for the TDH, xTDH, NIC, Rep, and followers controls that include the active handle and displayed values.
- Keep this as a component-level migration using the existing `en-US` fallback path; no route-level locale migration is introduced.

## Changes
- Added a profile stats-row message helper and `user.statsRow.*` source messages.
- Updated `UserStatsRow` to use message-backed visible labels and accessible control names.
- Formatted follower counts through the repo i18n integer helper while preserving existing product formatting for TDH/xTDH/NIC/Rep values.
- Added focused tests for link/button accessible names, singular follower copy, rate labels, and fallback message behavior.
- Updated the durable frontend a11y/i18n workstream memory.

## Validation
- `6529 run test -- --runTestsByPath __tests__/components/user/utils/stats/UserStatsRow.test.tsx __tests__/components/user/user-page-header/stats/UserPageHeaderStats.test.tsx __tests__/i18n/messages.test.ts --silent --verbose=false --coverageReporters=none`: passed, 3 suites / 8 tests.
- Targeted ESLint for touched source files: passed.
- `6529 run typecheck:changed`: passed for 112 changed TypeScript files.
- `6529 run react-doctor:diff`: exited 0 at 99/100; only the known unrelated `contexts/EmojiContext.tsx` fetch-in-effect diagnostic remains.
- `git diff --check`: passed; only line-ending warnings on unrelated dirty local files.
- Next MCP `get_errors` on the live local frontend: no config or session errors.
- Browser smoke on `/punk6529` at desktop and 390px mobile widths verified the updated stat control accessible names and practical layout.

## Risk
- Level: Low
- Why: Component-level text/accessibility change on the profile header stats row, with no data fetching, routing, transaction, or dependency changes.
- Rollback: Revert this PR to restore the previous hardcoded labels and action names.

## Review Notes
- This PR is stacked on #2641 and is review-ready only. Per workstream policy, do not merge without human approval.
- Please focus review on accessible names, message-key shape, and whether the values included in the labels are useful without being noisy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Localized user profile stats row messages and number formatting (handles rates and singular/plural follower labels).

* **Improvements**
  * Improved accessibility for stat links and the followers action (clearer aria labels, accessible followers button).

* **Tests**
  * Expanded tests for localized messages and for followers link/button behavior and labels.

* **Documentation**
  * Updated workstream docs and run-log entries reflecting the accessibility/i18n changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->