### PR TITLE
Localize profile about edit form

### DIFF
--- a/__tests__/components/user/user-page-header/UserPageHeaderAboutEditError.test.tsx
+++ b/__tests__/components/user/user-page-header/UserPageHeaderAboutEditError.test.tsx
@@ -1,23 +1,26 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import UserPageHeaderAboutEditError from '@/components/user/user-page-header/about/UserPageHeaderAboutEditError';
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UserPageHeaderAboutEditError from "@/components/user/user-page-header/about/UserPageHeaderAboutEditError";
 
-describe('UserPageHeaderAboutEditError', () => {
-  it('detects known error types', () => {
+describe("UserPageHeaderAboutEditError", () => {
+  it("detects known error types", () => {
     render(
       <UserPageHeaderAboutEditError
         msg="contains personal insults"
         closeError={jest.fn()}
       />
     );
-    expect(screen.getByText('Error: Personal Insults')).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("Error: Personal Insults")).toBeInTheDocument();
   });
 
-  it('handles unknown errors and close click', async () => {
+  it("handles unknown errors and close click", async () => {
     const close = jest.fn();
     render(<UserPageHeaderAboutEditError msg="something" closeError={close} />);
-    expect(screen.getByText('Unknown Error')).toBeInTheDocument();
-    await userEvent.click(screen.getByRole('button'));
+    expect(screen.getByText("Unknown Error")).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Dismiss About statement error" })
+    );
     expect(close).toHaveBeenCalled();
   });
 });

--- a/__tests__/components/user/user-page-header/about/UserPageHeaderAboutEdit.test.tsx
+++ b/__tests__/components/user/user-page-header/about/UserPageHeaderAboutEdit.test.tsx
@@ -1,16 +1,23 @@
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import UserPageHeaderAboutEdit from '@/components/user/user-page-header/about/UserPageHeaderAboutEdit';
-import { AuthContext } from '@/components/auth/Auth';
-import { ReactQueryWrapperContext } from '@/components/react-query-wrapper/ReactQueryWrapper';
-import { useMutation } from '@tanstack/react-query';
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UserPageHeaderAboutEdit from "@/components/user/user-page-header/about/UserPageHeaderAboutEdit";
+import { AuthContext } from "@/components/auth/Auth";
+import { ReactQueryWrapperContext } from "@/components/react-query-wrapper/ReactQueryWrapper";
+import { useMutation } from "@tanstack/react-query";
 
-jest.mock('react-use', () => ({ useKeyPressEvent: jest.fn() }));
+jest.mock("react-use", () => ({ useKeyPressEvent: jest.fn() }));
 
-jest.mock('@tanstack/react-query', () => ({ useMutation: jest.fn() }));
-jest.mock('@/services/api/common-api', () => ({ commonApiPost: jest.fn().mockResolvedValue({}) }));
-jest.mock('framer-motion', () => ({ AnimatePresence: (props: any) => <div>{props.children}</div> }));
-jest.mock('@/components/user/user-page-header/about/UserPageHeaderAboutEditError', () => (props: any) => <div>{props.msg}</div>);
+jest.mock("@tanstack/react-query", () => ({ useMutation: jest.fn() }));
+jest.mock("@/services/api/common-api", () => ({
+  commonApiPost: jest.fn().mockResolvedValue({}),
+}));
+jest.mock("framer-motion", () => ({
+  AnimatePresence: (props: any) => <div>{props.children}</div>,
+}));
+jest.mock(
+  "@/components/user/user-page-header/about/UserPageHeaderAboutEditError",
+  () => (props: any) => <div>{props.msg}</div>
+);
 
 (useMutation as jest.Mock).mockImplementation((opts) => {
   return {
@@ -22,24 +29,37 @@ jest.mock('@/components/user/user-page-header/about/UserPageHeaderAboutEditError
   };
 });
 
-describe('UserPageHeaderAboutEdit', () => {
-  const auth = { requestAuth: jest.fn().mockResolvedValue({ success: true }), setToast: jest.fn() } as any;
+describe("UserPageHeaderAboutEdit", () => {
+  const auth = {
+    requestAuth: jest.fn().mockResolvedValue({ success: true }),
+    setToast: jest.fn(),
+  } as any;
   const ctx = { onProfileStatementAdd: jest.fn() } as any;
 
-  it('enables save when value changes and submits', async () => {
+  it("enables save when value changes and submits", async () => {
     render(
       <AuthContext.Provider value={auth}>
         <ReactQueryWrapperContext.Provider value={ctx}>
-          <UserPageHeaderAboutEdit profile={{ query: 'alice' } as any} statement={{ statement_value: 'old' } as any} onClose={jest.fn()} />
+          <UserPageHeaderAboutEdit
+            profile={{ query: "alice" } as any}
+            statement={{ statement_value: "old" } as any}
+            onClose={jest.fn()}
+          />
         </ReactQueryWrapperContext.Provider>
       </AuthContext.Provider>
     );
-    const input = screen.getByRole('textbox');
+    const input = screen.getByRole("textbox", { name: "About statement" });
+    expect(input).toHaveAttribute("placeholder", "Write an About statement");
     await userEvent.clear(input);
-    await userEvent.type(input, 'new');
-    const btn = screen.getByRole('button', { name: 'Save' });
+    await userEvent.type(input, "new");
+    expect(screen.getByText("3/500")).toBeInTheDocument();
+    const btn = screen.getByRole("button", { name: "Save" });
     expect(btn).not.toBeDisabled();
     await userEvent.click(btn);
     expect(auth.requestAuth).toHaveBeenCalled();
+    expect(auth.setToast).toHaveBeenCalledWith({
+      message: "About statement added.",
+      type: "success",
+    });
   });
 });

--- a/__tests__/i18n/messages.test.ts
+++ b/__tests__/i18n/messages.test.ts
@@ -228,6 +228,7 @@ describe("frontend i18n helpers", () => {
     expect(t("de-DE", "user.profileHeader.about.empty")).toBe(
       "Click to add an About statement"
     );
+    expect(t("fr-FR", "user.profileHeader.aboutEdit.save")).toBe("Save");
     expect(t("es-ES", "user.collected.networkCards.empty")).toBe(
       t("en-US", "user.collected.networkCards.empty")
     );

--- a/components/user/user-page-header/about/UserPageHeaderAboutEdit.tsx
+++ b/components/user/user-page-header/about/UserPageHeaderAboutEdit.tsx
@@ -10,11 +10,14 @@ import type {
 } from "@/entities/IProfile";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import { STATEMENT_GROUP, STATEMENT_TYPE } from "@/helpers/Types";
+import { formatInteger } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
 import { commonApiPost } from "@/services/api/common-api";
 import { useMutation } from "@tanstack/react-query";
 import { AnimatePresence } from "framer-motion";
 import { useContext, useEffect, useRef, useState } from "react";
 import { useKeyPressEvent } from "react-use";
+import { getUserProfileHeaderMessage } from "../user-page-header.messages";
 import UserPageHeaderAboutEditError from "./UserPageHeaderAboutEditError";
 export default function UserPageHeaderAboutEdit({
   profile,
@@ -85,7 +88,9 @@ export default function UserPageHeaderAboutEdit({
     onSuccess: () => {
       setErrorMsg(null);
       setToast({
-        message: "About statement added.",
+        message: getUserProfileHeaderMessage(
+          "user.profileHeader.aboutEdit.success"
+        ),
         type: "success",
       });
       onProfileStatementAdd({
@@ -114,6 +119,13 @@ export default function UserPageHeaderAboutEdit({
     event.preventDefault();
     await submitStatement();
   };
+  const characterCount = getUserProfileHeaderMessage(
+    "user.profileHeader.aboutEdit.characterCount",
+    {
+      count: formatInteger(DEFAULT_LOCALE, value.length),
+      max: formatInteger(DEFAULT_LOCALE, MAX_STATEMENT_LENGTH),
+    }
+  );
 
   return (
     <div className="tw-w-full tw-max-w-xl">
@@ -122,8 +134,12 @@ export default function UserPageHeaderAboutEdit({
           className="tw-form-input tw-block tw-min-h-28 tw-w-full tw-appearance-none tw-rounded-lg tw-border-0 tw-bg-iron-900 tw-px-3.5 tw-py-3 tw-text-sm tw-font-medium tw-leading-6 tw-text-iron-50 tw-caret-primary-400 tw-shadow-sm tw-ring-1 tw-ring-inset tw-ring-iron-700 tw-transition tw-duration-300 tw-ease-out placeholder:tw-text-iron-500 hover:tw-ring-iron-600 focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-primary-400"
           name="profile-about"
           id="profile-about-input"
-          aria-label="About statement"
-          placeholder="Write an About statement"
+          aria-label={getUserProfileHeaderMessage(
+            "user.profileHeader.aboutEdit.textareaLabel"
+          )}
+          placeholder={getUserProfileHeaderMessage(
+            "user.profileHeader.aboutEdit.placeholder"
+          )}
           required
           value={value}
           onChange={handleInputChange}
@@ -132,19 +148,24 @@ export default function UserPageHeaderAboutEdit({
         ></textarea>
         <div className="tw-mt-3 tw-flex tw-flex-col tw-gap-3 sm:tw-flex-row sm:tw-items-center sm:tw-justify-between">
           <div className="tw-text-xs tw-font-medium tw-text-iron-500">
-            {value.length}/{MAX_STATEMENT_LENGTH}
+            {characterCount}
           </div>
           <div className="tw-flex tw-w-full tw-gap-2 sm:tw-w-auto">
             <SecondaryButton disabled={loading} onClicked={onClose}>
-              Cancel
+              {getUserProfileHeaderMessage(
+                "user.profileHeader.aboutEdit.cancel"
+              )}
             </SecondaryButton>
             <PrimaryButton
               disabled={isDisabled}
               loading={loading}
               onClicked={submitStatement}
+              ariaLabel={getUserProfileHeaderMessage(
+                "user.profileHeader.aboutEdit.save"
+              )}
               hideChildrenWhenLoading
             >
-              Save
+              {getUserProfileHeaderMessage("user.profileHeader.aboutEdit.save")}
             </PrimaryButton>
           </div>
         </div>

--- a/components/user/user-page-header/about/UserPageHeaderAboutEditError.tsx
+++ b/components/user/user-page-header/about/UserPageHeaderAboutEditError.tsx
@@ -1,3 +1,5 @@
+import { getUserProfileHeaderMessage } from "../user-page-header.messages";
+
 enum AboutEditError {
   HATE_SPEECH = "HATE_SPEECH",
   PERSONAL_INSULTS = "PERSONAL_INSULTS",
@@ -22,24 +24,36 @@ const ERROR_TEXT: {
   };
 } = {
   [AboutEditError.HATE_SPEECH]: {
-    title: "Error: Hate Speech",
-    value:
-      "Your About text was not accepted because our automated checks flagged it for potentially containing hate speech.  We want to keep seize a welcoming place!  We'd appreciate it if you adjusted your text.",
+    title: getUserProfileHeaderMessage(
+      "user.profileHeader.aboutEdit.errors.hateSpeech.title"
+    ),
+    value: getUserProfileHeaderMessage(
+      "user.profileHeader.aboutEdit.errors.hateSpeech.value"
+    ),
   },
   [AboutEditError.PERSONAL_INSULTS]: {
-    title: "Error: Personal Insults",
-    value:
-      "Your About text was not accepted because our automated checks flagged it for potentially containing a personal insult.  We want to keep seize a welcoming place!.   We'd appreciate it if you adjusted your text.",
+    title: getUserProfileHeaderMessage(
+      "user.profileHeader.aboutEdit.errors.personalInsults.title"
+    ),
+    value: getUserProfileHeaderMessage(
+      "user.profileHeader.aboutEdit.errors.personalInsults.value"
+    ),
   },
   [AboutEditError.INAPPROPRIATE_LANGUAGE]: {
-    title: "Error: Inappropriate Language",
-    value:
-      "Your About text was not accepted because our automated checks flagged it for potentially containing inappropriate language that may make others uncomfortable.   We want to keep seize a welcoming place!  We'd appreciate it if you adjusted your text.",
+    title: getUserProfileHeaderMessage(
+      "user.profileHeader.aboutEdit.errors.inappropriateLanguage.title"
+    ),
+    value: getUserProfileHeaderMessage(
+      "user.profileHeader.aboutEdit.errors.inappropriateLanguage.value"
+    ),
   },
   [AboutEditError.DOXXING]: {
-    title: "Error: Doxxing of Another Person",
-    value:
-      "Your About text was not accepted because our automated checks flagged it for potentially doxxing another user of the system.   We have a strong cultural value towards respecting pseudonymity so we'd appreciate if if you adjusted your text.",
+    title: getUserProfileHeaderMessage(
+      "user.profileHeader.aboutEdit.errors.doxxing.title"
+    ),
+    value: getUserProfileHeaderMessage(
+      "user.profileHeader.aboutEdit.errors.doxxing.value"
+    ),
   },
 };
 
@@ -64,20 +78,29 @@ export default function UserPageHeaderAboutEditError({
   const errorText =
     errorType === AboutEditError.UNKNOWN
       ? {
-          title: "Unknown Error",
+          title: getUserProfileHeaderMessage(
+            "user.profileHeader.aboutEdit.errors.unknown.title"
+          ),
           value: msg,
         }
       : ERROR_TEXT[errorType];
 
   return (
     <div>
-      <div className="tw-relative tw-inline-flex tw-w-full tw-items-center tw-rounded-lg tw-border tw-border-solid tw-border-red/30 tw-bg-red/5 tw-p-4 lg:tw-max-w-xl">
+      <div
+        role="alert"
+        className="tw-relative tw-inline-flex tw-w-full tw-items-center tw-rounded-lg tw-border tw-border-solid tw-border-red/30 tw-bg-red/5 tw-p-4 lg:tw-max-w-xl"
+      >
         <div className="tw-absolute tw-right-2 tw-top-2">
           <button
             onClick={closeError}
             type="button"
-            title="Close"
-            aria-label="Close"
+            title={getUserProfileHeaderMessage(
+              "user.profileHeader.aboutEdit.errors.close"
+            )}
+            aria-label={getUserProfileHeaderMessage(
+              "user.profileHeader.aboutEdit.errors.close"
+            )}
             className="tw-group tw-inline-flex tw-rounded-md tw-border-none tw-bg-transparent focus:tw-outline-none"
           >
             <svg

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -285,6 +285,27 @@ const USER_PROFILE_HEADER_MESSAGES = objectMessages("user.profileHeader", {
   "about.empty": "Click to add an About statement",
   "about.expand": "See more",
   "about.collapse": "See less",
+  "aboutEdit.textareaLabel": "About statement",
+  "aboutEdit.placeholder": "Write an About statement",
+  "aboutEdit.characterCount": "{count}/{max}",
+  "aboutEdit.cancel": "Cancel",
+  "aboutEdit.save": "Save",
+  "aboutEdit.success": "About statement added.",
+  "aboutEdit.errors.close": "Dismiss About statement error",
+  "aboutEdit.errors.unknown.title": "Unknown Error",
+  "aboutEdit.errors.hateSpeech.title": "Error: Hate Speech",
+  "aboutEdit.errors.hateSpeech.value":
+    "Your About text was not accepted because our automated checks flagged it for potentially containing hate speech. We want to keep seize a welcoming place! We'd appreciate it if you adjusted your text.",
+  "aboutEdit.errors.personalInsults.title": "Error: Personal Insults",
+  "aboutEdit.errors.personalInsults.value":
+    "Your About text was not accepted because our automated checks flagged it for potentially containing a personal insult. We want to keep seize a welcoming place! We'd appreciate it if you adjusted your text.",
+  "aboutEdit.errors.inappropriateLanguage.title":
+    "Error: Inappropriate Language",
+  "aboutEdit.errors.inappropriateLanguage.value":
+    "Your About text was not accepted because our automated checks flagged it for potentially containing inappropriate language that may make others uncomfortable. We want to keep seize a welcoming place! We'd appreciate it if you adjusted your text.",
+  "aboutEdit.errors.doxxing.title": "Error: Doxxing of Another Person",
+  "aboutEdit.errors.doxxing.value":
+    "Your About text was not accepted because our automated checks flagged it for potentially doxxing another user of the system. We have a strong cultural value around respecting pseudonymity, so we'd appreciate it if you adjusted your text.",
 } as const);
 
 const MEME_LAB_DETAIL_MESSAGES = namespaceMessages("memeLab.detail", [

--- a/ops/workstreams/frontend-a11y-i18n/README.md
+++ b/ops/workstreams/frontend-a11y-i18n/README.md
@@ -13,7 +13,9 @@ page surfaces one PR at a time.
 3. `ops/skills/write-prs/SKILL.md`
 4. `ops/standards/README.md`
 5. `active-context.md`
-6. `run-log.md`
+6. `stack-audit.md`
+7. `audit-inventory.md`
+8. `run-log.md`
 
 ## Owned Paths
 

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -7,7 +7,7 @@ page migration PRs for safe media surfaces.
 
 ## Current Branch
 
-`codex/user-header-about-a11y-i18n`
+`codex/user-about-edit-a11y-i18n`
 
 ## Constraints
 
@@ -60,22 +60,24 @@ page migration PRs for safe media surfaces.
   covers the user profile header identity/name/media labels, profile-enabled
   date formatting, and read-only wrapper semantics. It is stacked from PR #2642
   and must not be merged.
-- PR #2644 is open and review-ready only. It covers the user profile header
-  About statement placeholder, add/edit controls, mobile expand/collapse toggle,
-  and nested-interactive-control cleanup. It is stacked from PR #2643 and must
-  not be merged.
+- PR #2644 is bot-happy on the latest head and remains review-ready only. It
+  covers the user profile header About statement placeholder, add/edit controls,
+  mobile expand/collapse toggle, and nested-interactive-control cleanup. It is
+  stacked from PR #2643 and must not be merged.
 - Non-source locales currently fall back to `en-US` until reviewed
   translations are added.
 - Full locale-prefixed routing is deferred.
 
 ## Next Actions
 
-1. Iterate on PR #2644 with available bots/checks without merging.
-2. Keep PR #2643 review-ready only; do not merge.
-3. Keep PR #2642 review-ready only; do not merge.
-4. Keep PR #2641 review-ready only; do not merge.
-5. Keep PR #2640 review-ready only; do not merge.
-6. Maintain PRs #2639, #2638, #2637, and earlier page PRs as review-ready only;
+1. Open the profile About edit form PR from `codex/user-about-edit-a11y-i18n`,
+   then iterate with available bots/checks without merging.
+2. Keep PR #2644 review-ready only; do not merge.
+3. Keep PR #2643 review-ready only; do not merge.
+4. Keep PR #2642 review-ready only; do not merge.
+5. Keep PR #2641 review-ready only; do not merge.
+6. Keep PR #2640 review-ready only; do not merge.
+7. Maintain PRs #2639, #2638, #2637, and earlier page PRs as review-ready only;
    do not merge.
-7. Preserve the unrelated dirty EmojiContext, RememeImage test, and bootstrap
+8. Preserve the unrelated dirty EmojiContext, RememeImage test, and bootstrap
    style files.

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -2,8 +2,9 @@
 
 ## Current Goal
 
-Deliver the standards and repo-local skill foundation, then start review-ready
-page migration PRs for safe media surfaces.
+Maintain the existing review-ready WCAG/i18n implementation stack, harden it
+bottom-up where safe, and build durable inventory for the next stack. Do not
+merge page implementation PRs.
 
 ## Current Branch
 
@@ -71,16 +72,27 @@ page migration PRs for safe media surfaces.
 - Non-source locales currently fall back to `en-US` until reviewed
   translations are added.
 - Full locale-prefixed routing is deferred.
+- 2026-06-13 stack audit: PR #2604 and PRs #2607-#2645 are open, non-draft,
+  mergeable, and green on the visible GitHub check rollup.
+- Related-looking open PR #2597 is older OG metadata work, not part of this
+  WCAG/i18n stack.
+- Open PR #2632 is separate 6529bot admin dashboard work, not part of this
+  WCAG/i18n stack.
+- 2026-06-14 bottom-stack pass: PR #2604 received a passive scroll listener
+  hardening commit (`23d119e`) and local validation/browser smoke passed.
+  GitHub's visible latest-head rollup is green and a validation snapshot was
+  posted on the PR. CodeRabbit's new incremental review was rate-limited, but
+  prior actionable CodeRabbit findings are already fixed in the current code.
+- 2026-06-14 audit inventory: `audit-inventory.md` records candidate hotspots
+  for static copy, interaction semantics, locale formatting, image alt review,
+  and i18n helper adoption.
 
 ## Next Actions
 
-1. Iterate on PR #2645 with available bots/checks without merging.
-2. Keep PR #2644 review-ready only; do not merge.
-3. Keep PR #2643 review-ready only; do not merge.
-4. Keep PR #2642 review-ready only; do not merge.
-5. Keep PR #2641 review-ready only; do not merge.
-6. Keep PR #2640 review-ready only; do not merge.
-7. Maintain PRs #2639, #2638, #2637, and earlier page PRs as review-ready only;
-   do not merge.
-8. Preserve the unrelated dirty EmojiContext, RememeImage test, and bootstrap
+1. Hold new page PR creation until the existing stack is reviewed.
+2. Keep PR #2604 and PRs #2607-#2645 review-ready only; do not merge without
+   human approval.
+3. If asked to advance the stack, continue bottom-up from PR #2607 after the
+   #2604 validation snapshot.
+4. Preserve the unrelated dirty EmojiContext, RememeImage test, and bootstrap
    style files.

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -64,14 +64,17 @@ page migration PRs for safe media surfaces.
   covers the user profile header About statement placeholder, add/edit controls,
   mobile expand/collapse toggle, and nested-interactive-control cleanup. It is
   stacked from PR #2643 and must not be merged.
+- PR #2645 is open and review-ready only. It covers the user profile About edit
+  form labels, placeholder, character count, actions, success toast, moderation
+  errors, alert semantics, and error-dismiss name. It is stacked from PR #2644
+  and must not be merged.
 - Non-source locales currently fall back to `en-US` until reviewed
   translations are added.
 - Full locale-prefixed routing is deferred.
 
 ## Next Actions
 
-1. Open the profile About edit form PR from `codex/user-about-edit-a11y-i18n`,
-   then iterate with available bots/checks without merging.
+1. Iterate on PR #2645 with available bots/checks without merging.
 2. Keep PR #2644 review-ready only; do not merge.
 3. Keep PR #2643 review-ready only; do not merge.
 4. Keep PR #2642 review-ready only; do not merge.

--- a/ops/workstreams/frontend-a11y-i18n/audit-inventory.md
+++ b/ops/workstreams/frontend-a11y-i18n/audit-inventory.md
@@ -1,0 +1,82 @@
+# WCAG/I18n Audit Inventory
+
+## 2026-06-14
+
+This inventory is a triage map, not a bug list. The scans intentionally find
+candidate areas where accessibility or localization debt may exist, then future
+PRs should verify each hit against the standards before changing code.
+
+Scans ran from the current workstream branch after the profile stack was opened.
+
+## Scan Summary
+
+| Category | Files | Matches | Signal |
+| --- | ---: | ---: | --- |
+| Static copy attributes | 525 | 2753 | Hardcoded `aria-label`, `placeholder`, or `title` values likely need message-backed treatment when touched. |
+| Interaction candidates | 859 | 1687 | Dense `onClick`, key, `tabIndex`, or role usage that needs semantic-control review before WCAG claims. |
+| Locale formatting candidates | 86 | 186 | Direct `toLocale*` or `Intl.*` usage that may need the repo i18n helper path. |
+| Image alt candidates | 213 | 596 | `<img>` and empty/null alt patterns that need decorative-vs-informative review. |
+| I18n helper adoption | 77 | 621 | Current usage of `t()`, locale normalization, and repo formatting helpers. |
+
+## Top Hotspots
+
+Static copy attributes:
+
+- `app/museum/6529-fund-szn1/cod/page.tsx`
+- `app/museum/genesis/fragments-of-an-infinite-field/page.tsx`
+- `app/blog/from-fibonacci-to-fidenza/page.tsx`
+- `app/museum/6529-fund-szn1/incomplete-control/page.tsx`
+- `app/museum/6529-fund-szn1/rarepepe/page.tsx`
+
+Interaction candidates:
+
+- `components/nextGen/admin/NextGenAdmin.tsx`
+- `components/drop-forge/craft/DropForgeCraftClaimPageClient.tsx`
+- `components/waves/TwitterPreviewCard.tsx`
+- `components/meme-calendar/MemeCalendar.tsx`
+- `components/delegation/CollectionDelegation.tsx`
+
+Locale formatting candidates:
+
+- `components/drop-forge/launch/DropForgeLaunchClaimPageClient.view.tsx`
+- `components/drop-forge/craft/DropForgeCraftClaimPageClient.tsx`
+- `components/distribution-plan-tool/create-custom-snapshots/form/CreateCustomSnapshotForm.tsx`
+- `components/distribution-plan-tool/create-snapshots/table/CreateSnapshotTableRow.tsx`
+- `components/meme-calendar/meme-calendar.helpers.tsx`
+
+Image alt candidates:
+
+- `app/museum/6529-fund-szn1/capsule-house/page.tsx`
+- `app/museum/6529-fund-szn1/cod/page.tsx`
+- `app/museum/page.tsx`
+- `app/om/6529-museum-district/page.tsx`
+- `app/capital/company-portfolio/page.tsx`
+
+I18n helper adoption is currently concentrated in the media/profile migration
+surface, especially `components/the-memes`, `components/memelab`,
+`components/rememes`, `components/meme-calendar`, and user profile components.
+
+## Recommendations
+
+- Keep the current implementation stack review-ready only until humans are
+  comfortable with the size and shape of the migration.
+- Continue bottom-up hardening, starting with PR #2604, because it supplies the
+  i18n helpers inherited by the rest of the stack.
+- Prefer safe public media or static surfaces for the next stack. `meme-calendar`
+  and read-only media/card surfaces are better candidates than claim, admin,
+  delegation, or transaction flows.
+- Treat museum, blog, capital, and OM pages as a separate editorial/static-page
+  backlog. They have many image and static-copy hits, but the translation and
+  content-review burden is different from app UI.
+- Defer `drop-forge`, `nextGen/admin`, distribution tooling, delegation, and
+  transfer flows until the helper pattern and review appetite are proven.
+
+## Commands
+
+```powershell
+rg --count-matches -g '*.tsx' -g '*.ts' 'aria-label=\x22[^\x22]+\x22|placeholder=\x22[^\x22]+\x22|title=\x22[^\x22]+\x22' app components contexts hooks pages
+rg --count-matches -g '*.tsx' 'role=\x22button\x22|role=\x22dialog\x22|tabIndex=|onClick=|onKeyDown=|onMouseDown=|onMouseUp=' app components pages
+rg --count-matches -g '*.tsx' -g '*.ts' 'toLocaleString|toLocaleDateString|toLocaleTimeString|Intl\.' app components contexts hooks lib pages
+rg --count-matches -g '*.tsx' '<img\b|alt=\{?\x22\x22|alt=\x22\x22|alt=\{undefined\}|alt=\{null\}' app components pages
+rg --count-matches -g '*.tsx' -g '*.ts' '\bt\(|\bformatInteger\(|\bformatNumber\(|\bformatDate\(|\bformatRelativeTime\(|\bnormalizeLocale\(' app components i18n
+```

--- a/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
+++ b/ops/workstreams/frontend-a11y-i18n/bot-decisions.md
@@ -12,6 +12,9 @@ Record review-bot and CI decisions here for this workstream.
 | 2026-06-11 | #2604 | Claude       | Review skipped because organization monthly code review cap was reached   | Treat as unavailable, not actionable |
 | 2026-06-11 | #2604 | SonarCloud   | Flagged i18n default object parameters and interpolation character class  | Fixed                                |
 | 2026-06-11 | #2604 | CodeRabbit   | Flagged Suspense, title i18n, locale matching, and exhaustive guards      | Fixed                                |
+| 2026-06-14 | #2604 | React Doctor | Flagged non-passive scroll listener during PR-diff review                 | Fixed                                |
+| 2026-06-14 | #2604 | CodeRabbit   | Latest one-file incremental review was rate-limited                       | Treat as unavailable until reset     |
+| 2026-06-14 | #2604 | GitHub checks | Latest visible rollup passed on head `23d119e`                            | Accept                               |
 | 2026-06-12 | #2607 | SonarCloud   | Quality Gate passed with 0 new issues                                     | Accept                               |
 | 2026-06-12 | #2607 | Snyk         | PR check passed                                                           | Accept                               |
 | 2026-06-12 | #2607 | CodeRabbit   | Flagged dead `MemeTab.title` and duplicate `MEME_FOCUS_VALUES` guards     | Fixed                                |

--- a/ops/workstreams/frontend-a11y-i18n/pr-links.md
+++ b/ops/workstreams/frontend-a11y-i18n/pr-links.md
@@ -41,3 +41,4 @@
 | Profile stats row         | `codex/user-header-stats-a11y-i18n`                     | #2642 | Open, review-ready only |
 | Profile header identity   | `codex/user-header-identity-a11y-i18n`                  | #2643 | Open, review-ready only |
 | Profile header About      | `codex/user-header-about-a11y-i18n`                     | #2644 | Open, review-ready only |
+| Profile About edit form   | `codex/user-about-edit-a11y-i18n`                       | #2645 | Open, review-ready only |

--- a/ops/workstreams/frontend-a11y-i18n/route-page-status.md
+++ b/ops/workstreams/frontend-a11y-i18n/route-page-status.md
@@ -42,4 +42,4 @@
 | User profile header stats row          | PR open              | PR open            | PR #2642; review-ready only; stacked on PR #2641; do not merge yet |
 | User profile header identity/media     | PR open              | PR open            | PR #2643; review-ready only; stacked on PR #2642; do not merge yet |
 | User profile header About statement    | PR open              | PR open            | PR #2644; review-ready only; stacked on PR #2643; do not merge yet |
-| User profile About edit form           | Branch ready         | Branch ready       | Pending PR; stacked on PR #2644; do not merge page PRs             |
+| User profile About edit form           | PR open              | PR open            | PR #2645; review-ready only; stacked on PR #2644; do not merge yet |

--- a/ops/workstreams/frontend-a11y-i18n/route-page-status.md
+++ b/ops/workstreams/frontend-a11y-i18n/route-page-status.md
@@ -42,3 +42,4 @@
 | User profile header stats row          | PR open              | PR open            | PR #2642; review-ready only; stacked on PR #2641; do not merge yet |
 | User profile header identity/media     | PR open              | PR open            | PR #2643; review-ready only; stacked on PR #2642; do not merge yet |
 | User profile header About statement    | PR open              | PR open            | PR #2644; review-ready only; stacked on PR #2643; do not merge yet |
+| User profile About edit form           | Branch ready         | Branch ready       | Pending PR; stacked on PR #2644; do not merge page PRs             |

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1148,3 +1148,20 @@
   API/emoji resource errors.
 - Opened review-ready stacked PR #2644 against PR #2643. Per workstream policy,
   do not merge PR #2644.
+- Confirmed PR #2644 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed with 0 new issues, CodeRabbit manual review passed, no
+  review threads are open, and Claude remained configured for manual review
+  only. Per workstream policy, do not merge PR #2644.
+- Started stacked branch `codex/user-about-edit-a11y-i18n` from PR #2644 for the
+  next adjacent profile About follow-up.
+- Implemented message-backed source-locale labels for the profile About edit
+  form textarea, placeholder, character count, cancel/save controls, success
+  toast, moderation error copy, unknown-error title, and error-dismiss action.
+  The moderation error container now uses `role="alert"` so errors are announced.
+- Validation passed for the About edit-form follow-up so far: focused edit
+  form/error/i18n Jest suites (3 suites, 7 tests), targeted ESLint for touched
+  source files, `typecheck:changed`, `react-doctor:diff`, `git diff --check`,
+  Next MCP runtime diagnostics, and desktop browser smoke on `/punk6529`. React
+  Doctor still reports only the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic; the local browser console still shows known shared
+  API/emoji resource errors.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1165,3 +1165,5 @@
   Doctor still reports only the unrelated dirty `contexts/EmojiContext.tsx`
   fetch-in-effect diagnostic; the local browser console still shows known shared
   API/emoji resource errors.
+- Opened review-ready stacked PR #2645 against PR #2644. Per workstream policy,
+  do not merge PR #2645.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1167,3 +1167,42 @@
   API/emoji resource errors.
 - Opened review-ready stacked PR #2645 against PR #2644. Per workstream policy,
   do not merge PR #2645.
+
+## 2026-06-13
+
+- Audited the open WCAG/i18n PR stack after user concern about the number of
+  related PRs. Confirmed PR #2604 and PRs #2607-#2645 are expected workstream
+  implementation PRs, are open, non-draft, mergeable, and green on the visible
+  GitHub check rollup. Recorded the stack snapshot in `stack-audit.md`.
+- Confirmed related-looking PR #2597 is older OG metadata work and PR #2632 is
+  separate 6529bot admin dashboard work; neither is part of this WCAG/i18n
+  migration stack.
+- Updated active context to pause new page PR creation until the current stack
+  is reviewed or a new scope is chosen.
+
+## 2026-06-14
+
+- Rechecked the bottom of the WCAG/i18n stack and used a clean temp worktree for
+  PR #2604.
+- Pushed signed hardening commit `23d119e` to PR #2604, making the The Memes
+  scroll listener passive.
+- Validation passed for PR #2604: changed-file lint, changed-file typecheck,
+  targeted The Memes card and i18n Jest suites, React Doctor PR-diff review,
+  `git diff --check`, and desktop/mobile browser smoke on
+  `/the-memes?locale=de-DE`.
+- Browser smoke used a local-only Bootstrap import fix that is already present
+  on current `main`; this verification-only tweak was not committed to #2604.
+- Confirmed stale CodeRabbit findings on #2604 are already handled in current
+  code: localized document title, case-insensitive locale normalization, and
+  exhaustive enum label guards.
+- Recorded the latest CodeRabbit caveat: the visible status context is green,
+  but the new incremental review was rate-limited, so treat new bot review as
+  unavailable until the limit resets.
+- Rechecked PR #2604 after CodeQL completed. The latest visible GitHub rollup
+  passed for head `23d119e`: CodeQL, DCO, SonarCloud, Snyk, and CodeRabbit
+  status context.
+- Posted a PR validation snapshot comment documenting the local checks, browser
+  smoke, green rollup, and CodeRabbit rate-limit caveat.
+- Added `audit-inventory.md` with candidate hotspots for static copy,
+  interaction semantics, locale formatting, image alt review, and i18n helper
+  adoption to guide the next safe stack.

--- a/ops/workstreams/frontend-a11y-i18n/stack-audit.md
+++ b/ops/workstreams/frontend-a11y-i18n/stack-audit.md
@@ -1,0 +1,63 @@
+# WCAG/I18n PR Stack Audit
+
+## 2026-06-13T21:52:58Z
+
+GitHub audit command:
+
+```powershell
+gh pr list --repo 6529-Collections/6529seize-frontend --state open --limit 100 --json number,title,headRefName,baseRefName,isDraft,mergeable,updatedAt,statusCheckRollup
+```
+
+## Summary
+
+- Standards PR #2603 is merged.
+- Implementation PRs #2604 and #2607-#2645 are expected workstream PRs.
+- All tracked implementation PRs are open, non-draft, mergeable, and green on
+  the visible GitHub check rollup.
+- Page implementation PRs remain review-ready only. Do not merge them without
+  human approval.
+- Pause new page PR creation until the existing stack is reviewed or the next
+  explicit scope is chosen.
+
+## Chain Shape
+
+| Range | Scope | Current State |
+| --- | --- | --- |
+| #2604 | The Memes list-card foundation | Open, non-draft, mergeable, green |
+| #2607-#2625 | The Memes, Meme Lab, Rememes, meme calendar/media surfaces | Open, non-draft, mergeable, green |
+| #2626-#2639 | `/{user}/collected` cards, filters, details, and activity surfaces | Open, non-draft, mergeable, green |
+| #2640-#2645 | Profile tabs, followers modal, header, and About edit surfaces | Open, non-draft, mergeable, green |
+
+## Related-Looking PRs Outside This Workstream
+
+| PR | Title | Why It Is Not In This Workstream |
+| --- | --- | --- |
+| #2597 | Standardize NextGen and ReMemes OG metadata | Older OG metadata stack; mentions Rememes but is not WCAG/i18n page migration work |
+| #2632 | Add private 6529bot admin dashboard | Separate admin dashboard work |
+
+## Recommendation
+
+Keep the current implementation stack intact and review it bottom-up, starting
+with #2604. Do not open more page migration PRs until humans are comfortable
+with the existing stack size, or until a separate follow-up stack is explicitly
+requested.
+
+## 2026-06-14 Bottom-Stack Follow-Up
+
+- PR #2604 received a focused hardening commit:
+  `23d119ed1497f8b3b25ba099c75e0447de4e7608`.
+- The commit makes the The Memes infinite-scroll listener passive.
+- Local validation passed for lint, changed-file typecheck, targeted The Memes
+  card and i18n tests, React Doctor PR-diff review, and desktop/mobile browser
+  smoke on `/the-memes?locale=de-DE`.
+- Browser smoke required a local-only Bootstrap import fix already present on
+  current `main`; that verification-only tweak was not committed to PR #2604.
+- Known local browser noise remained limited to the shared backend wave
+  endpoints and the blocked emoji-list resource.
+- CodeRabbit posted a rate-limit notice for the latest one-file delta. The
+  visible CodeRabbit status context is green, but the incremental review should
+  be treated as unavailable until the rate limit resets or a manual review is
+  requested later.
+- The latest visible GitHub rollup for head `23d119e` is green: CodeQL, DCO,
+  SonarCloud, Snyk, and CodeRabbit status context.
+- A validation snapshot comment was posted on PR #2604.


### PR DESCRIPTION
## Summary
- Add message-backed source-locale copy for the profile About edit form textarea, placeholder, character count, buttons, success toast, and moderation errors.
- Give the About edit error container `role="alert"` and a specific dismiss control name.
- Record #2644 as bot-happy and track this stacked follow-up in the workstream memory.

## Validation
- `6529 run test -- --runTestsByPath __tests__/components/user/user-page-header/about/UserPageHeaderAboutEdit.test.tsx __tests__/components/user/user-page-header/UserPageHeaderAboutEditError.test.tsx __tests__/i18n/messages.test.ts --silent --verbose=false --coverageReporters=none`
- `6529 exec eslint components/user/user-page-header/about/UserPageHeaderAboutEdit.tsx components/user/user-page-header/about/UserPageHeaderAboutEditError.tsx i18n/messages/en-US.ts`
- `6529 run typecheck:changed`
- `6529 run react-doctor:diff` (still reports unrelated dirty `contexts/EmojiContext.tsx` fetch-in-effect)
- `git diff --check`
- Next MCP `get_errors`
- Browser smoke on `/punk6529`

Review-ready only. Do not merge this page implementation PR yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * About statement editing form now supports multiple languages with localized text for labels, placeholders, buttons, character counter, and error messages.

* **Tests**
  * Enhanced test coverage for the About statement form and error handling to verify functionality and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->