### PR TITLE
[codex] Surface reviewbot usage analysis

### DIFF
--- a/__tests__/services/reviewbot-admin-api.test.ts
+++ b/__tests__/services/reviewbot-admin-api.test.ts
@@ -181,4 +181,136 @@ describe("reviewbot admin api", () => {
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
+
+  it("parses enriched admin usage analysis and PR author rows", async () => {
+    const fetchImpl = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/api/v2/notifications")) {
+        return jsonResponse({ ok: true });
+      }
+      if (url.includes("/api/admin/usage/summary")) {
+        return jsonResponse({
+          ok: true,
+          visibility: "admin",
+          kind: "usage_summary",
+          range: { days: 30 },
+          totals: {
+            reviewRuns: 4,
+            costUsd: 12,
+            totalTokens: 6000,
+            budgetSkippedRuns: 1,
+            uniquePrs: 3,
+            averageCostPerReviewRunUsd: 3,
+            averageCostPerPrUsd: 4,
+          },
+          analysis: {
+            budgetSkipRate: 25,
+            averageTokensPerReviewRun: 1500,
+            averageTokensPerPr: 2000,
+            topCostRepo: null,
+            topCostProviderModel: null,
+            topCostReviewKind: null,
+            topCostRequestor: {
+              key: "punk6529",
+              reviewRuns: 3,
+              costUsd: 9,
+              averageCostUsd: 3,
+              totalTokens: 4500,
+              budgetSkippedRuns: 0,
+              costSharePercent: 75,
+            },
+            topCostPrAuthor: {
+              key: "ragnep",
+              reviewRuns: 2,
+              costUsd: 8,
+              averageCostUsd: 4,
+              totalTokens: 4000,
+              budgetSkippedRuns: 0,
+              costSharePercent: 66.67,
+            },
+            topCostPr: {
+              key: "6529-Collections/6529seize-frontend#2700",
+              repoFullName: "6529-Collections/6529seize-frontend",
+              prNumber: 2700,
+              prAuthor: "ragnep",
+              latestHeadSha: "abcdef1234567890",
+              lastReviewAt: "2026-06-15T08:00:00.000Z",
+              reviewRuns: 2,
+              costUsd: 8,
+              averageCostUsd: 4,
+              totalTokens: 4000,
+              budgetSkippedRuns: 0,
+              costSharePercent: 66.67,
+            },
+          },
+          byDay: [],
+          byRepo: [],
+          byProviderModel: [],
+          byReviewKind: [],
+          byRequestor: [],
+          byPrAuthor: [
+            {
+              key: "ragnep",
+              reviewRuns: 2,
+              costUsd: 8,
+              averageCostUsd: 4,
+              totalTokens: 4000,
+              budgetSkippedRuns: 0,
+            },
+          ],
+          byPr: [
+            {
+              key: "6529-Collections/6529seize-frontend#2700",
+              repoFullName: "6529-Collections/6529seize-frontend",
+              prNumber: 2700,
+              prAuthor: "ragnep",
+              latestHeadSha: "abcdef1234567890",
+              lastReviewAt: "2026-06-15T08:00:00.000Z",
+              reviewRuns: 2,
+              costUsd: 8,
+              averageCostUsd: 4,
+              totalTokens: 4000,
+              budgetSkippedRuns: 0,
+            },
+          ],
+        });
+      }
+      return jsonResponse({ ok: true });
+    });
+
+    const result = await getReviewbotAdminDashboard({
+      env: baseEnv(),
+      fetchImpl,
+      now: futureDate,
+      walletAuthJwt: createJwt(allowedWallet),
+    });
+
+    expect(result).toMatchObject({
+      status: "ok",
+      dashboard: {
+        totals: {
+          uniquePrs: 3,
+          averageCostPerPrUsd: 4,
+        },
+        summary: {
+          status: "ok",
+          data: {
+            analysis: {
+              budgetSkipRate: 25,
+              topCostPr: {
+                prAuthor: "ragnep",
+                costSharePercent: 66.67,
+              },
+            },
+            byPrAuthor: [{ key: "ragnep" }],
+            byPr: [
+              {
+                latestHeadSha: "abcdef1234567890",
+              },
+            ],
+          },
+        },
+      },
+    });
+  });
 });

--- a/__tests__/services/reviewbot-usage-api.test.ts
+++ b/__tests__/services/reviewbot-usage-api.test.ts
@@ -67,12 +67,32 @@ describe("reviewbot usage api", () => {
               costUsd: 1.25,
               totalTokens: 1000,
               budgetSkippedRuns: 1,
+              uniquePrs: 2,
+              averageCostPerReviewRunUsd: 0.625,
+              averageCostPerPrUsd: 0.625,
+            },
+            analysis: {
+              budgetSkipRate: 50,
+              averageTokensPerReviewRun: 500,
+              averageTokensPerPr: 500,
+              topCostRepo: {
+                key: "6529-Collections/example",
+                reviewRuns: 2,
+                costUsd: 1.25,
+                averageCostUsd: 0.625,
+                totalTokens: 1000,
+                budgetSkippedRuns: 1,
+                costSharePercent: 100,
+              },
+              topCostProviderModel: null,
+              topCostReviewKind: null,
             },
             byDay: [
               {
                 key: "2026-06-11",
                 reviewRuns: 2,
                 costUsd: 1.25,
+                averageCostUsd: 0.625,
                 totalTokens: 1000,
                 budgetSkippedRuns: 1,
               },
@@ -100,6 +120,15 @@ describe("reviewbot usage api", () => {
           costUsd: 1.25,
           totalTokens: 1000,
           budgetSkippedRuns: 1,
+          uniquePrs: 2,
+          averageCostPerReviewRunUsd: 0.625,
+          averageCostPerPrUsd: 0.625,
+        },
+        analysis: {
+          budgetSkipRate: 50,
+          topCostRepo: {
+            costSharePercent: 100,
+          },
         },
       },
     });

--- a/components/reviewbot-admin/ReviewbotAdminDashboard.tsx
+++ b/components/reviewbot-admin/ReviewbotAdminDashboard.tsx
@@ -9,7 +9,11 @@ import type {
   ReviewbotRuntimeStatus,
   ReviewbotAdminUsageSummary,
 } from "@/services/reviewbot-admin-api";
-import type { ReviewbotUsageGroup } from "@/services/reviewbot-usage-api";
+import type {
+  ReviewbotUsageAnalysis,
+  ReviewbotUsageGroup,
+  ReviewbotUsagePrGroup,
+} from "@/services/reviewbot-usage-api";
 import {
   BellAlertIcon,
   ChartBarIcon,
@@ -17,6 +21,7 @@ import {
   ClockIcon,
   CpuChipIcon,
   CurrencyDollarIcon,
+  DocumentTextIcon,
   ExclamationTriangleIcon,
   LockClosedIcon,
   ShieldCheckIcon,
@@ -40,6 +45,15 @@ const currencyFormatter = new Intl.NumberFormat("en-US", {
 const percentFormatter = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 1,
   style: "percent",
+});
+
+const dateTimeFormatter = new Intl.DateTimeFormat("en-US", {
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+  month: "short",
+  timeZone: "UTC",
+  year: "numeric",
 });
 
 export default function ReviewbotAdminDashboard({
@@ -66,7 +80,7 @@ export default function ReviewbotAdminDashboard({
         </p>
       </div>
 
-      <div className="tw-mt-8 tw-grid tw-grid-cols-1 tw-gap-3 sm:tw-grid-cols-2 xl:tw-grid-cols-4">
+      <div className="tw-mt-8 tw-grid tw-grid-cols-1 tw-gap-3 sm:tw-grid-cols-2 xl:tw-grid-cols-3">
         <MetricCard
           icon={<ChartBarIcon className="tw-h-6 tw-w-6" />}
           label="Review Runs"
@@ -74,10 +88,28 @@ export default function ReviewbotAdminDashboard({
           value={formatInteger(dashboard.totals.reviewRuns)}
         />
         <MetricCard
+          icon={<DocumentTextIcon className="tw-h-6 tw-w-6" />}
+          label="Unique PRs"
+          tone="tw-text-primary-300"
+          value={formatInteger(dashboard.totals.uniquePrs)}
+        />
+        <MetricCard
           icon={<CurrencyDollarIcon className="tw-h-6 tw-w-6" />}
           label="Spend"
           tone="tw-text-success"
           value={formatCurrency(dashboard.totals.costUsd)}
+        />
+        <MetricCard
+          icon={<CurrencyDollarIcon className="tw-h-6 tw-w-6" />}
+          label="Avg / Run"
+          tone="tw-text-success"
+          value={formatCurrency(dashboard.totals.averageCostPerReviewRunUsd)}
+        />
+        <MetricCard
+          icon={<CurrencyDollarIcon className="tw-h-6 tw-w-6" />}
+          label="Avg / PR"
+          tone="tw-text-success"
+          value={formatCurrency(dashboard.totals.averageCostPerPrUsd)}
         />
         <MetricCard
           icon={<CpuChipIcon className="tw-h-6 tw-w-6" />}
@@ -308,6 +340,12 @@ function AdminSummaryTables({
         keyHeader="Requestor"
         title="Requestors"
       />
+      <UsageAnalysisPanel analysis={summary.analysis} />
+      <UsageSection
+        groups={summary.byPrAuthor}
+        keyHeader="PR Author"
+        title="PR Authors"
+      />
       <UsageSection
         groups={summary.byRepo}
         keyHeader="Repository"
@@ -318,12 +356,45 @@ function AdminSummaryTables({
         keyHeader="Provider and Model"
         title="Providers and Models"
       />
-      <UsageSection
-        groups={summary.byPr}
-        keyHeader="Pull Request"
-        title="Pull Requests"
-      />
+      <PrUsageSection groups={summary.byPr} title="Pull Requests" />
     </>
+  );
+}
+
+function UsageAnalysisPanel({
+  analysis,
+}: {
+  readonly analysis: ReviewbotUsageAnalysis;
+}) {
+  return (
+    <section className="tw-mt-10 tw-rounded-lg tw-border tw-border-solid tw-border-white/10 tw-bg-iron-950 tw-p-5">
+      <h2 className="tw-mb-4 tw-text-xl tw-font-semibold tw-text-white">
+        Cost Analysis
+      </h2>
+      <div className="tw-grid tw-grid-cols-1 tw-gap-4 sm:tw-grid-cols-2 xl:tw-grid-cols-3">
+        <MetricPair
+          label="Budget Skip Rate"
+          value={formatPercentValue(analysis.budgetSkipRate)}
+        />
+        <MetricPair
+          label="Avg Tokens / Run"
+          value={formatInteger(analysis.averageTokensPerReviewRun)}
+        />
+        <MetricPair
+          label="Avg Tokens / PR"
+          value={formatInteger(analysis.averageTokensPerPr)}
+        />
+        <MetricPair
+          label="Top Requestor"
+          value={formatTopCost(analysis.topCostRequestor)}
+        />
+        <MetricPair
+          label="Top PR Author"
+          value={formatTopCost(analysis.topCostPrAuthor)}
+        />
+        <MetricPair label="Top PR" value={formatTopCost(analysis.topCostPr)} />
+      </div>
+    </section>
   );
 }
 
@@ -488,6 +559,9 @@ function UsageSection({
                   Spend
                 </th>
                 <th className="tw-px-6 tw-py-3 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+                  Avg
+                </th>
+                <th className="tw-px-6 tw-py-3 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
                   Tokens
                 </th>
                 <th className="tw-py-3 tw-pl-6 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
@@ -511,10 +585,99 @@ function UsageSection({
                     {formatCurrency(group.costUsd)}
                   </td>
                   <td className="tw-px-6 tw-py-4 tw-text-right tw-text-sm tw-text-iron-200">
+                    {formatCurrency(group.averageCostUsd)}
+                  </td>
+                  <td className="tw-px-6 tw-py-4 tw-text-right tw-text-sm tw-text-iron-200">
                     {formatInteger(group.totalTokens)}
                   </td>
                   <td className="tw-py-4 tw-pl-6 tw-text-right tw-text-sm tw-text-iron-200">
                     {formatInteger(group.budgetSkippedRuns)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="tw-mb-0 tw-border-t tw-border-solid tw-border-white/10 tw-pt-4 tw-text-sm tw-text-iron-400">
+          No rows found.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function PrUsageSection({
+  groups,
+  title,
+}: {
+  readonly groups: readonly ReviewbotUsagePrGroup[];
+  readonly title: string;
+}) {
+  return (
+    <section className="tw-mt-10">
+      <div className="tw-mb-4 tw-flex tw-items-baseline tw-justify-between tw-gap-4">
+        <h2 className="tw-mb-0 tw-text-2xl tw-font-semibold tw-text-white">
+          {title}
+        </h2>
+        <span className="tw-text-sm tw-text-iron-400">
+          {groups.length} rows
+        </span>
+      </div>
+      {groups.length > 0 ? (
+        <div className="tw-overflow-x-auto">
+          <table className="tw-min-w-full tw-border-collapse">
+            <thead>
+              <tr className="tw-border-b tw-border-solid tw-border-white/10">
+                <th className="tw-py-3 tw-pr-6 tw-text-left tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+                  Pull Request
+                </th>
+                <th className="tw-px-6 tw-py-3 tw-text-left tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+                  Author
+                </th>
+                <th className="tw-px-6 tw-py-3 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+                  Runs
+                </th>
+                <th className="tw-px-6 tw-py-3 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+                  Spend
+                </th>
+                <th className="tw-px-6 tw-py-3 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+                  Avg
+                </th>
+                <th className="tw-px-6 tw-py-3 tw-text-left tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+                  Latest Head
+                </th>
+                <th className="tw-py-3 tw-pl-6 tw-text-left tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+                  Last Review
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {groups.map((group) => (
+                <tr
+                  className="tw-border-b tw-border-solid tw-border-white/5"
+                  key={group.key}
+                >
+                  <td className="tw-py-4 tw-pr-6 tw-text-sm tw-font-medium tw-text-white">
+                    {group.key}
+                  </td>
+                  <td className="tw-px-6 tw-py-4 tw-text-sm tw-text-iron-200">
+                    {group.prAuthor || "unknown"}
+                  </td>
+                  <td className="tw-px-6 tw-py-4 tw-text-right tw-text-sm tw-text-iron-200">
+                    {formatInteger(group.reviewRuns)}
+                  </td>
+                  <td className="tw-px-6 tw-py-4 tw-text-right tw-text-sm tw-text-iron-200">
+                    {formatCurrency(group.costUsd)}
+                  </td>
+                  <td className="tw-px-6 tw-py-4 tw-text-right tw-text-sm tw-text-iron-200">
+                    {formatCurrency(group.averageCostUsd)}
+                  </td>
+                  <td className="tw-px-6 tw-py-4 tw-font-mono tw-text-xs tw-text-iron-300">
+                    {formatSha(group.latestHeadSha)}
+                  </td>
+                  <td className="tw-py-4 tw-pl-6 tw-text-sm tw-text-iron-200">
+                    {formatDateTime(group.lastReviewAt)}
                   </td>
                 </tr>
               ))}
@@ -586,4 +749,37 @@ function formatInteger(value: number): string {
 
 function formatPercent(value: number): string {
   return percentFormatter.format(value / 100);
+}
+
+function formatPercentValue(value: number): string {
+  return `${value.toFixed(1)}%`;
+}
+
+function formatSha(value: string): string {
+  return value ? value.slice(0, 12) : "unknown";
+}
+
+function formatDateTime(value: string): string {
+  if (!value) {
+    return "unknown";
+  }
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? "unknown"
+    : dateTimeFormatter.format(date);
+}
+
+function formatTopCost(
+  group:
+    | ReviewbotUsageAnalysis["topCostRepo"]
+    | ReviewbotUsageAnalysis["topCostRequestor"]
+    | ReviewbotUsageAnalysis["topCostPr"]
+    | undefined
+): string {
+  if (!group) {
+    return "None";
+  }
+  return `${group.key} (${formatCurrency(group.costUsd)}, ${formatPercentValue(
+    group.costSharePercent
+  )})`;
 }

--- a/components/reviewbot-usage/ReviewbotUsageDashboard.tsx
+++ b/components/reviewbot-usage/ReviewbotUsageDashboard.tsx
@@ -1,4 +1,5 @@
 import type {
+  ReviewbotUsageAnalysis,
   ReviewbotUsageGroup,
   ReviewbotUsageResult,
 } from "@/services/reviewbot-usage-api";
@@ -6,6 +7,7 @@ import {
   ChartBarIcon,
   CpuChipIcon,
   CurrencyDollarIcon,
+  DocumentTextIcon,
   ShieldCheckIcon,
 } from "@heroicons/react/24/outline";
 import type { ReactNode } from "react";
@@ -38,8 +40,11 @@ export default function ReviewbotUsageDashboard({
   const totals = summary?.totals ?? {
     budgetSkippedRuns: 0,
     costUsd: 0,
+    averageCostPerPrUsd: 0,
+    averageCostPerReviewRunUsd: 0,
     reviewRuns: 0,
     totalTokens: 0,
+    uniquePrs: 0,
   };
   const unavailableMessage = result.status === "ok" ? "" : result.message;
 
@@ -55,7 +60,7 @@ export default function ReviewbotUsageDashboard({
         </p>
       </div>
 
-      <div className="tw-mt-8 tw-grid tw-grid-cols-1 tw-gap-3 sm:tw-grid-cols-2 xl:tw-grid-cols-4">
+      <div className="tw-mt-8 tw-grid tw-grid-cols-1 tw-gap-3 sm:tw-grid-cols-2 xl:tw-grid-cols-3">
         <MetricCard
           icon={<ChartBarIcon className="tw-h-6 tw-w-6" />}
           label="Review Runs"
@@ -63,10 +68,28 @@ export default function ReviewbotUsageDashboard({
           value={formatInteger(totals.reviewRuns)}
         />
         <MetricCard
+          icon={<DocumentTextIcon className="tw-h-6 tw-w-6" />}
+          label="Unique PRs"
+          tone="tw-text-primary-300"
+          value={formatInteger(totals.uniquePrs)}
+        />
+        <MetricCard
           icon={<CurrencyDollarIcon className="tw-h-6 tw-w-6" />}
           label="Estimated Spend"
           tone="tw-text-success"
           value={formatCurrency(totals.costUsd)}
+        />
+        <MetricCard
+          icon={<CurrencyDollarIcon className="tw-h-6 tw-w-6" />}
+          label="Avg / Run"
+          tone="tw-text-success"
+          value={formatCurrency(totals.averageCostPerReviewRunUsd)}
+        />
+        <MetricCard
+          icon={<CurrencyDollarIcon className="tw-h-6 tw-w-6" />}
+          label="Avg / PR"
+          tone="tw-text-success"
+          value={formatCurrency(totals.averageCostPerPrUsd)}
         />
         <MetricCard
           icon={<CpuChipIcon className="tw-h-6 tw-w-6" />}
@@ -81,6 +104,8 @@ export default function ReviewbotUsageDashboard({
           value={formatInteger(totals.budgetSkippedRuns)}
         />
       </div>
+
+      {summary ? <AnalysisHighlights analysis={summary.analysis} /> : null}
 
       {summary ? (
         <>
@@ -120,6 +145,46 @@ export default function ReviewbotUsageDashboard({
         </div>
       )}
     </div>
+  );
+}
+
+function AnalysisHighlights({
+  analysis,
+}: {
+  readonly analysis: ReviewbotUsageAnalysis;
+}) {
+  return (
+    <section className="tw-mt-8 tw-rounded-lg tw-border tw-border-solid tw-border-white/10 tw-bg-iron-950 tw-p-5">
+      <h2 className="tw-mb-4 tw-text-xl tw-font-semibold tw-text-white">
+        Cost Analysis
+      </h2>
+      <dl className="tw-grid tw-grid-cols-1 tw-gap-4 sm:tw-grid-cols-2 xl:tw-grid-cols-3">
+        <MetricPair
+          label="Budget Skip Rate"
+          value={formatPercent(analysis.budgetSkipRate)}
+        />
+        <MetricPair
+          label="Avg Tokens / Run"
+          value={formatInteger(analysis.averageTokensPerReviewRun)}
+        />
+        <MetricPair
+          label="Avg Tokens / PR"
+          value={formatInteger(analysis.averageTokensPerPr)}
+        />
+        <MetricPair
+          label="Top Repo"
+          value={formatTopCost(analysis.topCostRepo)}
+        />
+        <MetricPair
+          label="Top Provider"
+          value={formatTopCost(analysis.topCostProviderModel)}
+        />
+        <MetricPair
+          label="Top Review Type"
+          value={formatTopCost(analysis.topCostReviewKind)}
+        />
+      </dl>
+    </section>
   );
 }
 
@@ -183,6 +248,10 @@ function UsageSection({
                   <MetricPair
                     label="Spend"
                     value={formatCurrency(group.costUsd)}
+                  />
+                  <MetricPair
+                    label="Avg"
+                    value={formatCurrency(group.averageCostUsd)}
                   />
                   <MetricPair
                     label="Tokens"
@@ -250,6 +319,9 @@ function UsageTable({
               Spend
             </th>
             <th className="tw-px-6 tw-py-3 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
+              Avg
+            </th>
+            <th className="tw-px-6 tw-py-3 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
               Tokens
             </th>
             <th className="tw-py-3 tw-pl-6 tw-text-right tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-400">
@@ -271,6 +343,9 @@ function UsageTable({
               </td>
               <td className="tw-px-6 tw-py-4 tw-text-right tw-text-sm tw-text-iron-200">
                 {formatCurrency(group.costUsd)}
+              </td>
+              <td className="tw-px-6 tw-py-4 tw-text-right tw-text-sm tw-text-iron-200">
+                {formatCurrency(group.averageCostUsd)}
               </td>
               <td className="tw-px-6 tw-py-4 tw-text-right tw-text-sm tw-text-iron-200">
                 {formatInteger(group.totalTokens)}
@@ -303,4 +378,17 @@ function formatDate(value: string | undefined): string {
 
 function formatInteger(value: number): string {
   return compactNumberFormatter.format(value);
+}
+
+function formatPercent(value: number): string {
+  return `${value.toFixed(1)}%`;
+}
+
+function formatTopCost(group: ReviewbotUsageAnalysis["topCostRepo"]): string {
+  if (!group) {
+    return "None";
+  }
+  return `${group.key} (${formatCurrency(group.costUsd)}, ${formatPercent(
+    group.costSharePercent
+  )})`;
 }

--- a/ops/docs/api-tool/feature-6529bot-admin.md
+++ b/ops/docs/api-tool/feature-6529bot-admin.md
@@ -66,7 +66,13 @@ five minutes even if a larger value is supplied in deployment config.
 The route shows:
 
 - 30-day admin usage totals;
-- requestor, repository, provider/model, and pull-request usage tables;
+- unique PR count, average spend per review run, average spend per PR, budget
+  skip rate, and token averages;
+- top-cost requestor, PR author, and PR analysis with spend-share percentages;
+- requestor, PR-author, repository, provider/model, review-kind, and
+  pull-request usage tables;
+- pull-request rows with PR author, latest head SHA, latest review timestamp,
+  total spend, and average spend per review run;
 - budget policy status;
 - alert configuration status;
 - model price catalog health;

--- a/ops/docs/open-data/feature-6529bot-usage.md
+++ b/ops/docs/open-data/feature-6529bot-usage.md
@@ -34,6 +34,10 @@ production bot API path.
 The bot backend returns:
 
 - totals for review runs, estimated spend, token usage, and budget skips;
+- unique PR count, average spend per review run, and average spend per PR;
+- cost analysis for budget skip rate, average tokens per review run, average
+  tokens per PR, and the highest-cost visible repository, provider/model, and
+  review kind;
 - daily aggregates;
 - repository aggregates;
 - provider/model aggregates;

--- a/ops/workstreams/reviewbot-production-manager/README.md
+++ b/ops/workstreams/reviewbot-production-manager/README.md
@@ -1,0 +1,57 @@
+# Reviewbot Production Manager
+
+## Charter
+
+Own the frontend side of `6529bot` production operations and dashboard work.
+Use this workstream when coordinating the 6529.io public usage dashboard,
+private operator dashboard, reviewbot API contract changes, production dogfood
+evidence, or reviewbot rollout follow-up.
+
+## Reload Order
+
+1. `ops/skills/6529-autonomous-manager/SKILL.md`
+2. this file
+3. `active-context.md`
+4. `run-log.md`
+5. relevant `ops/docs/open-data/` and `ops/docs/api-tool/` pages
+6. current PRs and CI for touched frontend or reviewbot branches
+
+## Owned Paths
+
+- `app/open-data/6529bot/`
+- `app/tools/6529bot/admin/`
+- `components/reviewbot-usage/`
+- `components/reviewbot-admin/`
+- `config/reviewbotUsageEnv.ts`
+- `services/reviewbot-usage-api.ts`
+- `services/reviewbot-admin-api.ts`
+- `__tests__/services/reviewbot-usage-api.test.ts`
+- `__tests__/services/reviewbot-admin-api.test.ts`
+- `ops/docs/open-data/feature-6529bot-usage.md`
+- `ops/docs/api-tool/feature-6529bot-admin.md`
+- this workstream folder
+
+## Forbidden Paths
+
+- Secrets, wallet allowlists, HMAC values, provider keys, AWS credentials, and
+  production-only URLs outside public docs.
+- Unrelated frontend a11y/i18n workstream files unless explicitly coordinating
+  with that workstream.
+- Generated API models unless regenerated from source.
+
+## Evidence Standard
+
+Every closeout should include:
+
+- changed files or PR links;
+- focused `6529` validation commands;
+- CI and review-bot state when a PR is opened;
+- any skipped browser, staging, or production validation with reason;
+- remaining production risks and concrete next action.
+
+## Escalation Triggers
+
+- New admin auth behavior, wallet allowlist semantics, or HMAC signing changes.
+- Production deployment, staging deployment, or merge decisions.
+- Any finding that suggests browser exposure of server-only admin data.
+- Any reviewbot API contract change that is not backward-compatible.

--- a/ops/workstreams/reviewbot-production-manager/active-context.md
+++ b/ops/workstreams/reviewbot-production-manager/active-context.md
@@ -1,0 +1,77 @@
+# Active Context
+
+First file to read after compaction: this file.
+
+## Current Goal
+
+Operate the reviewbot production/frontend workstream through
+`6529-autonomous-manager`: keep the 6529.io dashboards aligned with the live
+reviewbot API, preserve evidence, and drive PRs through validation instead of
+one-off patches.
+
+## Current Branch
+
+- Frontend branch: `codex/reviewbot-cost-dashboard`
+- Base: `origin/main`
+- Reviewbot API PR #356 was merged as `cd15219` and adds derived usage
+  analysis fields.
+
+## Current Local Changes
+
+- Shared reviewbot usage schema accepts:
+  - `uniquePrs`
+  - `averageCostPerReviewRunUsd`
+  - `averageCostPerPrUsd`
+  - `analysis`
+  - admin `byPrAuthor`
+  - enriched admin `byPr` rows.
+- Public `/open-data/6529bot` dashboard shows unique PRs, average costs, and
+  cost-analysis highlights.
+- Private `/tools/6529bot/admin` dashboard shows unique PRs, average costs,
+  cost-analysis highlights, PR-author table, and enriched PR rows.
+- Service tests and docs are being updated for the expanded API contract.
+
+## Constraints
+
+- Use the repo-local `6529` wrapper for project commands.
+- Preserve unrelated dirty work in other frontend worktrees.
+- Keep admin secrets and wallet allowlist values out of public artifacts.
+- Do not merge or deploy frontend PRs unless explicitly in merge/staging/prod
+  mode and gates pass.
+
+## Evidence So Far
+
+- Read `AGENTS.md`.
+- Read `ops/skills/6529-autonomous-manager/SKILL.md`.
+- Read `ops/skills/write-prs/SKILL.md`.
+- Read relevant Next docs for Server Components, data fetching, pages,
+  cookies, and fetch.
+- Confirmed old `codex/reviewbot-admin-dashboard` branch corresponds to merged
+  frontend PR #2632 and created fresh branch from `origin/main`.
+- Reviewbot PR #356 passed local release checks, CI, Dependency Review, and was
+  merged.
+- On this EC2 Windows host, direct wrapper validation needed explicit guarded
+  command fallbacks:
+  - `bin\6529.cmd` handed a Windows path to `bash` and failed;
+  - `bash ./bin/6529 ...` hit CRLF parsing in `bin/6529`;
+  - `pnpm run format:changed` and `pnpm run lint:changed` passed the
+    `SEIZE_6529_COMMAND` guard but failed where their shell pipelines require
+    `xargs`.
+
+## Next Actions
+
+1. Finish frontend schema, UI, docs, and tests for the merged analysis fields.
+2. Run focused validation with `SEIZE_6529_COMMAND=1` plus explicit-file
+   fallbacks where Windows shell tooling blocks the wrapper scripts.
+3. Open a frontend PR with review-ready evidence.
+4. Wait for required CI and bot feedback.
+5. If explicitly approved for merge mode, merge only after gates are green.
+
+## Open Risks
+
+- No component tests currently cover the rendered reviewbot dashboards; service
+  tests cover parsing and server-side data loading.
+- Browser verification is still needed after the frontend patch if visual
+  layout risk looks non-trivial.
+- Production dashboard environment values remain operator-owned deployment
+  secrets.

--- a/ops/workstreams/reviewbot-production-manager/run-log.md
+++ b/ops/workstreams/reviewbot-production-manager/run-log.md
@@ -1,0 +1,37 @@
+# Run Log
+
+## 2026-06-15
+
+- Entered `6529-autonomous-manager` mode after user correction.
+- Loaded frontend root instructions and repo-local manager skill.
+- Found a clean reviewbot dashboard worktree and avoided the unrelated dirty
+  a11y/i18n checkout.
+- Confirmed `codex/reviewbot-admin-dashboard` was the old head for merged PR
+  #2632.
+- Created fresh frontend branch `codex/reviewbot-cost-dashboard` from
+  `origin/main`.
+- In `6529reviewbot`, added and merged PR #356:
+  - derived public/admin usage `analysis` fields;
+  - admin `byPrAuthor` grouping;
+  - top-cost requestor, PR author, and PR rollups;
+  - OpenAPI, docs, changelog, and smoke coverage.
+- Started frontend wiring for the new API fields:
+  - shared Zod schemas;
+  - public and private dashboard metric cards;
+  - admin cost-analysis panel;
+  - admin PR-author and enriched PR rows;
+  - service tests and docs.
+- Validation evidence:
+  - `git diff --check` passed with CRLF warnings only.
+  - `pnpm exec prettier --write ...` passed for touched files after
+    `pnpm run format:changed` hit missing Windows `xargs`.
+  - `pnpm exec jest __tests__/services/reviewbot-usage-api.test.ts
+--runInBand --coverage=false --silent=false --detectOpenHandles
+--forceExit` passed.
+  - `pnpm exec jest __tests__/services/reviewbot-admin-api.test.ts
+--runInBand --coverage=false --silent=false --detectOpenHandles
+--forceExit` passed.
+  - `pnpm run typecheck:changed` passed.
+  - `pnpm exec eslint --no-warn-ignored --max-warnings=0 ...` passed for
+    touched TypeScript files after `pnpm run lint:changed` hit missing Windows
+    `xargs`.

--- a/services/reviewbot-admin-api.ts
+++ b/services/reviewbot-admin-api.ts
@@ -3,6 +3,7 @@ import {
   normalizeReviewbotUsageApiBaseUrl,
   normalizeReviewbotUsagePath,
   usageGroupSchema,
+  usagePrGroupSchema,
   usageRangeSchema,
   usageSummarySchema,
   usageTotalsSchema,
@@ -47,7 +48,8 @@ const nullableNumberSchema = z
 
 const adminUsageSummarySchema = usageSummarySchema.extend({
   visibility: z.enum(["public", "admin"]).optional(),
-  byPr: z.array(usageGroupSchema).default([]),
+  byPr: z.array(usagePrGroupSchema).default([]),
+  byPrAuthor: z.array(usageGroupSchema).default([]),
   byRequestor: z.array(usageGroupSchema).default([]),
 });
 
@@ -528,8 +530,11 @@ async function buildDashboardData({
       usageTotalsSchema.parse({
         budgetSkippedRuns: 0,
         costUsd: 0,
+        averageCostPerPrUsd: 0,
+        averageCostPerReviewRunUsd: 0,
         reviewRuns: 0,
         totalTokens: 0,
+        uniquePrs: 0,
       }),
   };
 }

--- a/services/reviewbot-usage-api.ts
+++ b/services/reviewbot-usage-api.ts
@@ -16,6 +16,7 @@ export const usageGroupSchema = z.object({
   key: z.string().catch("unknown"),
   reviewRuns: safeIntegerSchema,
   costUsd: safeNumberSchema,
+  averageCostUsd: safeNumberSchema,
   totalTokens: safeIntegerSchema,
   budgetSkippedRuns: safeIntegerSchema,
 });
@@ -25,6 +26,39 @@ export const usageTotalsSchema = z.object({
   costUsd: safeNumberSchema,
   totalTokens: safeIntegerSchema,
   budgetSkippedRuns: safeIntegerSchema,
+  uniquePrs: safeIntegerSchema,
+  averageCostPerReviewRunUsd: safeNumberSchema,
+  averageCostPerPrUsd: safeNumberSchema,
+});
+
+export const usagePrGroupSchema = usageGroupSchema.extend({
+  repoFullName: z.string().catch(""),
+  prNumber: z
+    .union([z.coerce.number().int().nonnegative(), z.null()])
+    .catch(null),
+  prAuthor: z.string().catch(""),
+  latestHeadSha: z.string().catch(""),
+  lastReviewAt: z.string().catch(""),
+});
+
+export const usageAnalysisGroupSchema = usageGroupSchema.extend({
+  costSharePercent: safeNumberSchema,
+});
+
+export const usageAnalysisPrGroupSchema = usagePrGroupSchema.extend({
+  costSharePercent: safeNumberSchema,
+});
+
+export const usageAnalysisSchema = z.object({
+  budgetSkipRate: safeNumberSchema,
+  averageTokensPerReviewRun: safeIntegerSchema,
+  averageTokensPerPr: safeIntegerSchema,
+  topCostRepo: usageAnalysisGroupSchema.nullable().catch(null),
+  topCostProviderModel: usageAnalysisGroupSchema.nullable().catch(null),
+  topCostReviewKind: usageAnalysisGroupSchema.nullable().catch(null),
+  topCostRequestor: usageAnalysisGroupSchema.nullable().optional(),
+  topCostPrAuthor: usageAnalysisGroupSchema.nullable().optional(),
+  topCostPr: usageAnalysisPrGroupSchema.nullable().optional(),
 });
 
 export const usageRangeSchema = z.object({
@@ -43,6 +77,17 @@ export const usageSummarySchema = z.object({
     costUsd: 0,
     totalTokens: 0,
     budgetSkippedRuns: 0,
+    uniquePrs: 0,
+    averageCostPerReviewRunUsd: 0,
+    averageCostPerPrUsd: 0,
+  }),
+  analysis: usageAnalysisSchema.default({
+    budgetSkipRate: 0,
+    averageTokensPerReviewRun: 0,
+    averageTokensPerPr: 0,
+    topCostRepo: null,
+    topCostProviderModel: null,
+    topCostReviewKind: null,
   }),
   byDay: z.array(usageGroupSchema).default([]),
   byRepo: z.array(usageGroupSchema).default([]),
@@ -51,6 +96,8 @@ export const usageSummarySchema = z.object({
 });
 
 export type ReviewbotUsageGroup = z.infer<typeof usageGroupSchema>;
+export type ReviewbotUsagePrGroup = z.infer<typeof usagePrGroupSchema>;
+export type ReviewbotUsageAnalysis = z.infer<typeof usageAnalysisSchema>;
 export type ReviewbotUsageSummary = z.infer<typeof usageSummarySchema>;
 
 export type ReviewbotUsageResult =


### PR DESCRIPTION
## Issue

The reviewbot API now exposes richer spend analysis after 6529reviewbot PR #356: unique PR counts, average spend per run/PR, top-cost rollups, PR-author groupings, and enriched PR rows. The 6529.io public and admin dashboards needed to understand and display those fields so operators can reason about cost per PR and reviewbot behavior from the frontend.

## Fix

Wire the expanded reviewbot usage contract through the shared frontend schemas and dashboards:

- add Zod parsing for `uniquePrs`, average-cost totals, `analysis`, admin `byPrAuthor`, and enriched admin `byPr` rows;
- show public cost-analysis highlights on `/open-data/6529bot`;
- show admin cost-analysis highlights, PR-author spend rows, and enriched PR spend rows on `/tools/6529bot/admin`;
- update service tests and operator/open-data docs;
- add `ops/workstreams/reviewbot-production-manager` memory so future reviewbot dashboard work resumes through the repo-local autonomous-manager process.

## Validation

- `git diff --check` passed with CRLF warnings only.
- `SEIZE_6529_COMMAND=1 pnpm exec prettier --write ...` passed for touched files.
- `SEIZE_6529_COMMAND=1 pnpm exec jest __tests__/services/reviewbot-usage-api.test.ts --runInBand --coverage=false --silent=false --detectOpenHandles --forceExit` passed.
- `SEIZE_6529_COMMAND=1 pnpm exec jest __tests__/services/reviewbot-admin-api.test.ts --runInBand --coverage=false --silent=false --detectOpenHandles --forceExit` passed.
- `SEIZE_6529_COMMAND=1 pnpm run typecheck:changed` passed.
- `SEIZE_6529_COMMAND=1 pnpm exec eslint --no-warn-ignored --max-warnings=0 __tests__/services/reviewbot-admin-api.test.ts __tests__/services/reviewbot-usage-api.test.ts components/reviewbot-admin/ReviewbotAdminDashboard.tsx components/reviewbot-usage/ReviewbotUsageDashboard.tsx services/reviewbot-admin-api.ts services/reviewbot-usage-api.ts` passed.

Note: on this EC2 Windows host, `pnpm run format:changed` and `pnpm run lint:changed` passed the repo guard but failed because their bash pipelines require `xargs`; I used explicit-file equivalents and recorded that in the new workstream notes.

## Risk

Low to moderate. This is mostly additive UI/schema handling for fields that default safely when missing. The main residual risk is visual density in the admin PR table; browser/staging verification should be done before production deploy if this view is visually sensitive.