### PR TITLE
[codex] Add GitHub link preview cards

### DIFF
--- a/__tests__/app/api/github-preview.route.test.ts
+++ b/__tests__/app/api/github-preview.route.test.ts
@@ -136,9 +136,241 @@ describe("github-preview API route", () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toMatchObject({
-      error: "Only github.com issue and pull request URLs are supported.",
+      error: "Only github.com repository URLs are supported.",
     });
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("maps repository links", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        full_name: "6529-Collections/6529seize-frontend",
+        description: "6529 Seize frontend",
+        default_branch: "main",
+        language: "TypeScript",
+        stargazers_count: 42,
+        forks_count: 7,
+        open_issues_count: 5,
+        visibility: "public",
+        archived: false,
+        html_url: "https://github.com/6529-Collections/6529seize-frontend",
+      })
+    );
+
+    const response = await GET(
+      requestFor("https://github.com/6529-Collections/6529seize-frontend")
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      type: "github.repository",
+      title: "6529-Collections/6529seize-frontend",
+      description: "6529 Seize frontend",
+      language: "TypeScript",
+      stars: 42,
+      forks: 7,
+    });
+  });
+
+  it("maps GitHub file links", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        type: "file",
+        name: "GithubLinkPreview.tsx",
+        path: "components/waves/github/GithubLinkPreview.tsx",
+        size: 12345,
+        html_url:
+          "https://github.com/o/r/blob/main/components/waves/github/GithubLinkPreview.tsx",
+      })
+    );
+
+    const response = await GET(
+      requestFor(
+        "https://github.com/o/r/blob/main/components/waves/github/GithubLinkPreview.tsx#L12"
+      )
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      type: "github.file",
+      title: "GithubLinkPreview.tsx",
+      path: "components/waves/github/GithubLinkPreview.tsx",
+      ref: "main",
+      size: 12345,
+    });
+  });
+
+  it("tries longer ref splits for file links on slash-named branches", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({ message: "Not Found" }, { status: 404 })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          type: "file",
+          name: "app.ts",
+          path: "src/app.ts",
+          size: 10,
+          html_url: "https://github.com/o/r/blob/feature/work/src/app.ts",
+        })
+      );
+
+    const response = await GET(
+      requestFor("https://github.com/o/r/blob/feature/work/src/app.ts")
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      type: "github.file",
+      ref: "feature/work",
+      path: "src/app.ts",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("maps GitHub directory links", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        { type: "file", name: "a.ts", path: "src/a.ts" },
+        { type: "file", name: "b.ts", path: "src/b.ts" },
+      ])
+    );
+
+    const response = await GET(
+      requestFor("https://github.com/o/r/tree/main/src")
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      type: "github.directory",
+      title: "src",
+      path: "src",
+      ref: "main",
+      itemCount: 2,
+    });
+  });
+
+  it("maps commit links", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        html_url: "https://github.com/o/r/commit/abc123",
+        sha: "abc1234567890",
+        commit: {
+          message: "Ship richer GitHub previews\n\nDetails",
+          author: { name: "Alice", date: "2026-06-15T00:00:00Z" },
+        },
+        author: { login: "alice" },
+      })
+    );
+
+    const response = await GET(
+      requestFor("https://github.com/o/r/commit/abc123")
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      type: "github.commit",
+      title: "Ship richer GitHub previews",
+      shortSha: "abc123456789",
+      author: "alice",
+    });
+  });
+
+  it("maps release links", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        html_url: "https://github.com/o/r/releases/tag/v1.0.0",
+        name: "Version 1",
+        tag_name: "v1.0.0",
+        draft: false,
+        prerelease: true,
+        published_at: "2026-06-15T00:00:00Z",
+      })
+    );
+
+    const response = await GET(
+      requestFor("https://github.com/o/r/releases/tag/v1.0.0")
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      type: "github.release",
+      title: "Version 1",
+      tagName: "v1.0.0",
+      state: "prerelease",
+    });
+  });
+
+  it("maps GitHub Actions run links", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        html_url: "https://github.com/o/r/actions/runs/99",
+        name: "CI",
+        display_title: "Run tests",
+        status: "completed",
+        conclusion: "success",
+        run_number: 418,
+        event: "pull_request",
+      })
+    );
+
+    const response = await GET(
+      requestFor("https://github.com/o/r/actions/runs/99")
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      type: "github.actions",
+      title: "Run tests",
+      status: "completed",
+      conclusion: "success",
+      runNumber: 418,
+    });
+  });
+
+  it("maps GitHub discussion links with GraphQL metadata", async () => {
+    process.env["SSR_CLIENT_ID"] = "test-client";
+    process.env["SSR_CLIENT_SECRET"] = "test-secret";
+    process.env["GITHUB_LINK_STATUS_PREVIEW_TOKEN"] = "test-token";
+    await loadRoute();
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        data: {
+          repository: {
+            discussion: {
+              title: "Preview all GitHub resources",
+              url: "https://github.com/o/r/discussions/12",
+              number: 12,
+              closed: false,
+              answerChosenAt: "2026-06-15T00:00:00Z",
+              category: { name: "Ideas" },
+              comments: { totalCount: 3 },
+            },
+          },
+        },
+      })
+    );
+
+    const response = await GET(
+      requestFor("https://github.com/o/r/discussions/12")
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      type: "github.discussion",
+      title: "Preview all GitHub resources",
+      number: 12,
+      category: "Ideas",
+      comments: 3,
+      state: "answered",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/graphql",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-token",
+        }),
+      })
+    );
+
+    delete process.env["SSR_CLIENT_ID"];
+    delete process.env["SSR_CLIENT_SECRET"];
+    delete process.env["GITHUB_LINK_STATUS_PREVIEW_TOKEN"];
   });
 
   it("deduplicates concurrent uncached status requests", async () => {

--- a/__tests__/app/api/github-preview.route.test.ts
+++ b/__tests__/app/api/github-preview.route.test.ts
@@ -141,6 +141,29 @@ describe("github-preview API route", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("rejects unsupported GitHub repository subpaths before fetching", async () => {
+    const response = await GET(requestFor("https://github.com/o/r/settings"));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Only github.com repository URLs are supported.",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed GitHub content links before fetching", async () => {
+    const bareBlob = await GET(requestFor("https://github.com/o/r/blob"));
+    const blobWithoutPath = await GET(
+      requestFor("https://github.com/o/r/blob/main")
+    );
+    const bareTree = await GET(requestFor("https://github.com/o/r/tree"));
+
+    expect(bareBlob.status).toBe(400);
+    expect(blobWithoutPath.status).toBe(400);
+    expect(bareTree.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("maps repository links", async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse({
@@ -387,6 +410,28 @@ describe("github-preview API route", () => {
       GET(requestFor("https://github.com/o/r/issues/11")),
       GET(requestFor("https://github.com/o/r/issues/11")),
     ]);
+
+    await expect(first.json()).resolves.toMatchObject({ state: "open" });
+    await expect(second.json()).resolves.toMatchObject({ state: "open" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("normalizes cache keys across query and fragment variants", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        html_url: "https://github.com/o/r/issues/12",
+        title: "Cached issue",
+        state: "open",
+        state_reason: null,
+      })
+    );
+
+    const first = await GET(
+      requestFor("https://github.com/o/r/issues/12?utm_source=a#first")
+    );
+    const second = await GET(
+      requestFor("https://github.com/o/r/issues/12?utm_source=b#second")
+    );
 
     await expect(first.json()).resolves.toMatchObject({ state: "open" });
     await expect(second.json()).resolves.toMatchObject({ state: "open" });

--- a/__tests__/components/drops/view/part/dropPartMarkdown/handlers/github.test.tsx
+++ b/__tests__/components/drops/view/part/dropPartMarkdown/handlers/github.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { createLinkHandlers } from "@/components/drops/view/part/dropPartMarkdown/handlers";
+
+jest.mock("@/components/waves/github/GithubLinkPreview", () => {
+  const actual = jest.requireActual(
+    "@/components/waves/github/GithubLinkPreview"
+  );
+
+  return {
+    __esModule: true,
+    ...actual,
+    default: ({ href }: { readonly href: string }) => (
+      <div data-testid="github-link-preview" data-href={href} />
+    ),
+  };
+});
+
+describe("GitHub markdown link handler", () => {
+  it("renders GitHub pull requests before generic OpenGraph fallback", () => {
+    const href = "https://github.com/6529-Collections/6529Stream/pull/355";
+    const handler = createLinkHandlers().find((candidate) =>
+      candidate.match(href)
+    );
+
+    expect(handler).toBeDefined();
+    expect(handler?.display).toBe("block");
+
+    render(<>{handler?.render(href)}</>);
+
+    expect(screen.getByTestId("github-link-preview")).toHaveAttribute(
+      "data-href",
+      href
+    );
+  });
+
+  it("matches repository links too", () => {
+    const href = "https://github.com/6529-Collections/6529Stream";
+    const handler = createLinkHandlers().find((candidate) =>
+      candidate.match(href)
+    );
+
+    expect(handler).toBeDefined();
+    expect(handler?.display).toBe("block");
+  });
+});

--- a/__tests__/components/waves/github/GithubLinkPreview.test.tsx
+++ b/__tests__/components/waves/github/GithubLinkPreview.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+
+import GithubLinkPreview, {
+  parseGithubLink,
+} from "@/components/waves/github/GithubLinkPreview";
+import { fetchGithubPreview } from "@/services/api/github-preview-api";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children, prefetch: _prefetch, ...rest }: any) => (
+    <a
+      href={typeof href === "string" ? href : (href?.pathname ?? "")}
+      {...rest}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: function MockNextImage({
+    alt = "",
+    unoptimized: _unoptimized,
+    ...rest
+  }: any) {
+    return <img alt={alt} {...rest} />;
+  },
+}));
+
+jest.mock("@/components/waves/ChatItemHrefButtons", () => ({
+  __esModule: true,
+  default: ({ href }: { readonly href: string }) => (
+    <div data-testid="href-buttons" data-href={href} />
+  ),
+}));
+
+jest.mock("@/services/api/github-preview-api", () => ({
+  fetchGithubPreview: jest.fn(),
+}));
+
+const mockedFetchGithubPreview = fetchGithubPreview as jest.MockedFunction<
+  typeof fetchGithubPreview
+>;
+
+describe("GithubLinkPreview", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("parses pull request, issue, and repository GitHub links", () => {
+    expect(
+      parseGithubLink("https://github.com/6529-Collections/6529Stream/pull/355")
+    ).toEqual(
+      expect.objectContaining({
+        owner: "6529-Collections",
+        repo: "6529Stream",
+        kind: "pull",
+        number: 355,
+      })
+    );
+
+    expect(
+      parseGithubLink(
+        "https://github.com/6529-Collections/6529Stream/issues/392"
+      )
+    ).toEqual(
+      expect.objectContaining({
+        kind: "issue",
+        number: 392,
+      })
+    );
+
+    expect(
+      parseGithubLink("https://github.com/6529-Collections/6529Stream")
+    ).toEqual(
+      expect.objectContaining({
+        kind: "repository",
+        owner: "6529-Collections",
+        repo: "6529Stream",
+      })
+    );
+  });
+
+  it("renders a compact PR card with inline status and no OpenGraph image", async () => {
+    mockedFetchGithubPreview.mockResolvedValue({
+      type: "github.pull_request",
+      owner: "6529-Collections",
+      repo: "6529Stream",
+      number: 355,
+      title: "[codex] Hydrate command reviews and expose PR costs",
+      state: "merged",
+      reviewState: "none",
+      mergeableState: "clean",
+      merged: true,
+      draft: false,
+      url: "https://github.com/6529-Collections/6529Stream/pull/355",
+    });
+
+    render(
+      <GithubLinkPreview href="https://github.com/6529-Collections/6529Stream/pull/355" />
+    );
+
+    expect(screen.getByText("Pull request #355")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("[codex] Hydrate command reviews and expose PR costs")
+      ).toBeInTheDocument();
+    });
+
+    const card = screen.getByTestId("github-link-preview-card");
+    expect(card).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("Open GitHub pull request")
+    );
+    expect(card).not.toHaveClass("tw-h-[10rem]");
+    expect(card).not.toHaveClass("md:tw-h-[11rem]");
+    expect(screen.getByAltText("")).toHaveAttribute("src", "/github_w.png");
+
+    const badge = screen.getByTestId("github-preview-status-badge");
+    expect(badge).toHaveTextContent("Merged");
+    expect(badge).toHaveClass("tw-relative");
+    expect(badge).not.toHaveClass("tw-absolute");
+    expect(screen.getByTestId("href-buttons")).toHaveAttribute(
+      "data-href",
+      "https://github.com/6529-Collections/6529Stream/pull/355"
+    );
+  });
+
+  it("renders repository links without fetching PR or issue status", () => {
+    render(
+      <GithubLinkPreview href="https://github.com/6529-Collections/6529Stream" />
+    );
+
+    expect(screen.getByText("Repository")).toBeInTheDocument();
+    expect(screen.getAllByText("6529-Collections/6529Stream")).toHaveLength(2);
+    expect(mockedFetchGithubPreview).not.toHaveBeenCalled();
+  });
+
+  it("keeps an issue card useful when status metadata fails", async () => {
+    mockedFetchGithubPreview.mockRejectedValue(new Error("network"));
+
+    render(
+      <GithubLinkPreview href="https://github.com/6529-Collections/6529Stream/issues/392" />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Status unavailable")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Issue #392")).toBeInTheDocument();
+    expect(
+      screen.getByText("6529-Collections/6529Stream - issue #392")
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/github/GithubLinkPreview.test.tsx
+++ b/__tests__/components/waves/github/GithubLinkPreview.test.tsx
@@ -129,6 +129,37 @@ describe("GithubLinkPreview", () => {
     );
   });
 
+  it("does not render nested interactive descendants inside the card link", async () => {
+    mockedFetchGithubPreview.mockResolvedValue({
+      type: "github.pull_request",
+      owner: "6529-Collections",
+      repo: "6529Stream",
+      number: 355,
+      title: "[codex] Hydrate command reviews and expose PR costs",
+      state: "open",
+      reviewState: "none",
+      mergeableState: "clean",
+      merged: false,
+      draft: false,
+      url: "https://github.com/6529-Collections/6529Stream/pull/355",
+    });
+
+    render(
+      <GithubLinkPreview href="https://github.com/6529-Collections/6529Stream/pull/355" />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Open")).toBeInTheDocument();
+    });
+
+    const card = screen.getByTestId("github-link-preview-card");
+    expect(
+      card.querySelectorAll(
+        'a, button, input, select, textarea, [role="button"], [tabindex]:not([tabindex="-1"])'
+      )
+    ).toHaveLength(0);
+  });
+
   it("renders repository links without fetching PR or issue status", () => {
     render(
       <GithubLinkPreview href="https://github.com/6529-Collections/6529Stream" />

--- a/__tests__/components/waves/github/GithubLinkPreview.test.tsx
+++ b/__tests__/components/waves/github/GithubLinkPreview.test.tsx
@@ -103,6 +103,15 @@ describe("GithubLinkPreview", () => {
         pathLabel: "main/src",
       })
     );
+
+    expect(
+      parseGithubLink("https://github.com/6529-Collections/6529Stream/settings")
+    ).toEqual(
+      expect.objectContaining({
+        kind: "github",
+        pathLabel: "settings",
+      })
+    );
   });
 
   it("renders a compact PR card with inline status and no OpenGraph image", async () => {
@@ -242,6 +251,16 @@ describe("GithubLinkPreview", () => {
 
     expect(screen.getByText(/src\/app\.ts/)).toBeInTheDocument();
     expect(screen.getByText(/2 KB/)).toBeInTheDocument();
+  });
+
+  it("does not fetch rich metadata for unsupported GitHub subroutes", () => {
+    render(
+      <GithubLinkPreview href="https://github.com/6529-Collections/6529Stream/settings" />
+    );
+
+    expect(screen.getAllByText("GitHub")).not.toHaveLength(0);
+    expect(screen.getByText("settings")).toBeInTheDocument();
+    expect(mockedFetchGithubPreview).not.toHaveBeenCalled();
   });
 
   it("keeps an issue card useful when status metadata fails", async () => {

--- a/__tests__/components/waves/github/GithubLinkPreview.test.tsx
+++ b/__tests__/components/waves/github/GithubLinkPreview.test.tsx
@@ -153,6 +153,7 @@ describe("GithubLinkPreview", () => {
     });
 
     const card = screen.getByTestId("github-link-preview-card");
+    expect(document.body.querySelectorAll("a")).toHaveLength(1);
     expect(
       card.querySelectorAll(
         'a, button, input, select, textarea, [role="button"], [tabindex]:not([tabindex="-1"])'

--- a/__tests__/components/waves/github/GithubLinkPreview.test.tsx
+++ b/__tests__/components/waves/github/GithubLinkPreview.test.tsx
@@ -81,6 +81,28 @@ describe("GithubLinkPreview", () => {
         repo: "6529Stream",
       })
     );
+
+    expect(
+      parseGithubLink(
+        "https://github.com/6529-Collections/6529Stream/blob/main/src/app.ts"
+      )
+    ).toEqual(
+      expect.objectContaining({
+        kind: "file",
+        pathLabel: "main/src/app.ts",
+      })
+    );
+
+    expect(
+      parseGithubLink(
+        "https://github.com/6529-Collections/6529Stream/tree/main/src"
+      )
+    ).toEqual(
+      expect.objectContaining({
+        kind: "directory",
+        pathLabel: "main/src",
+      })
+    );
   });
 
   it("renders a compact PR card with inline status and no OpenGraph image", async () => {
@@ -161,14 +183,65 @@ describe("GithubLinkPreview", () => {
     ).toHaveLength(0);
   });
 
-  it("renders repository links without fetching PR or issue status", () => {
+  it("renders enriched repository links", async () => {
+    mockedFetchGithubPreview.mockResolvedValue({
+      type: "github.repository",
+      owner: "6529-Collections",
+      repo: "6529Stream",
+      title: "6529-Collections/6529Stream",
+      description: "Streaming API and bots",
+      defaultBranch: "main",
+      language: "TypeScript",
+      stars: 1200,
+      forks: 34,
+      openIssues: 9,
+      visibility: "public",
+      archived: false,
+      url: "https://github.com/6529-Collections/6529Stream",
+    });
+
     render(
       <GithubLinkPreview href="https://github.com/6529-Collections/6529Stream" />
     );
 
     expect(screen.getByText("Repository")).toBeInTheDocument();
-    expect(screen.getAllByText("6529-Collections/6529Stream")).toHaveLength(2);
-    expect(mockedFetchGithubPreview).not.toHaveBeenCalled();
+    expect(mockedFetchGithubPreview).toHaveBeenCalledWith(
+      "https://github.com/6529-Collections/6529Stream"
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Streaming API and bots/)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/TypeScript/)).toBeInTheDocument();
+    expect(screen.queryByTestId("github-preview-status-badge")).toBeNull();
+  });
+
+  it("renders enriched file links", async () => {
+    mockedFetchGithubPreview.mockResolvedValue({
+      type: "github.file",
+      owner: "6529-Collections",
+      repo: "6529Stream",
+      title: "app.ts",
+      path: "src/app.ts",
+      ref: "main",
+      size: 2048,
+      itemCount: null,
+      url: "https://github.com/6529-Collections/6529Stream/blob/main/src/app.ts",
+    });
+
+    render(
+      <GithubLinkPreview href="https://github.com/6529-Collections/6529Stream/blob/main/src/app.ts" />
+    );
+
+    expect(screen.getByText("File")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("app.ts")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/src\/app\.ts/)).toBeInTheDocument();
+    expect(screen.getByText(/2 KB/)).toBeInTheDocument();
   });
 
   it("keeps an issue card useful when status metadata fails", async () => {

--- a/app/api/github-preview/service.ts
+++ b/app/api/github-preview/service.ts
@@ -329,12 +329,20 @@ const parseGithubResource = (rawUrl: string | null): GithubResource => {
       }
       throw new Error("Only github.com repository URLs are supported.");
     case "blob":
+      if (rest.length < 2) {
+        throw new Error("Only github.com repository URLs are supported.");
+      }
+      return { ...base, kind: "content", mode: kindSegment, segments: rest };
     case "tree":
+      if (rest.length < 1) {
+        throw new Error("Only github.com repository URLs are supported.");
+      }
       return { ...base, kind: "content", mode: kindSegment, segments: rest };
     case "commit":
-      return rest[0]
-        ? { ...base, kind: "commit", ref: rest[0] }
-        : { ...base, kind: "repository" };
+      if (!rest[0]) {
+        throw new Error("Only github.com repository URLs are supported.");
+      }
+      return { ...base, kind: "commit", ref: rest[0] };
     case "releases":
       return {
         ...base,
@@ -351,7 +359,67 @@ const parseGithubResource = (rawUrl: string | null): GithubResource => {
     case "discussions":
       return { ...base, kind: "discussion", number };
     default:
-      return { ...base, kind: "repository" };
+      throw new Error("Only github.com repository URLs are supported.");
+  }
+};
+
+const getResourceCacheKey = (resource: GithubResource): string => {
+  const base = [resource.owner, resource.repo];
+
+  switch (resource.kind) {
+    case "repository":
+      return JSON.stringify(["github-preview", "repository", ...base]);
+    case "issue":
+      return JSON.stringify([
+        "github-preview",
+        "issue",
+        ...base,
+        resource.number,
+      ]);
+    case "pull":
+      return JSON.stringify([
+        "github-preview",
+        "pull",
+        ...base,
+        resource.number,
+      ]);
+    case "content":
+      return JSON.stringify([
+        "github-preview",
+        "content",
+        ...base,
+        resource.mode,
+        ...resource.segments,
+      ]);
+    case "commit":
+      return JSON.stringify([
+        "github-preview",
+        "commit",
+        ...base,
+        resource.ref,
+      ]);
+    case "release":
+      return JSON.stringify([
+        "github-preview",
+        "release",
+        ...base,
+        resource.tag,
+      ]);
+    case "actions":
+      return JSON.stringify([
+        "github-preview",
+        "actions",
+        ...base,
+        resource.runId,
+        resource.workflowId,
+      ]);
+    case "discussion":
+      return JSON.stringify([
+        "github-preview",
+        "discussion",
+        ...base,
+        resource.number,
+      ]);
   }
 };
 
@@ -767,17 +835,7 @@ const resolveContentPreview = async (
   resource: GithubContentResource
 ): Promise<GithubContentPreviewResponse> => {
   if (resource.segments.length === 0) {
-    return {
-      type: "github.directory",
-      owner: resource.owner,
-      repo: resource.repo,
-      title: resource.repo,
-      path: null,
-      ref: null,
-      size: null,
-      itemCount: null,
-      url: resource.href,
-    };
+    throw new Error("Only github.com repository URLs are supported.");
   }
 
   let lastNotFound: Error | null = null;
@@ -874,7 +932,11 @@ const buildReleasePreview = (
     url:
       release.html_url ??
       (tagName
-        ? `https://github.com/${resource.owner}/${resource.repo}/releases/tag/${tagName}`
+        ? `https://github.com/${encodeURIComponent(
+            resource.owner
+          )}/${encodeURIComponent(resource.repo)}/releases/tag/${encodeGithubPath(
+            tagName
+          )}`
         : resource.href),
   };
 };
@@ -1103,7 +1165,7 @@ export const resolveGithubPreview = async (
   options?: { readonly bypassCache?: boolean | undefined }
 ): Promise<GithubPreviewResponse> => {
   const resource = parseGithubResource(rawUrl);
-  const cacheKey = resource.href;
+  const cacheKey = getResourceCacheKey(resource);
   const bypassCache = options?.bypassCache === true;
   const cached = bypassCache ? undefined : cache.get(cacheKey);
 

--- a/app/api/github-preview/service.ts
+++ b/app/api/github-preview/service.ts
@@ -1,16 +1,24 @@
 import LruTtlCache from "@/lib/cache/lruTtl";
 import { serverEnv } from "@/config/serverEnv";
 import type {
+  GithubActionsPreviewResponse,
+  GithubCommitPreviewResponse,
+  GithubContentPreviewResponse,
+  GithubDiscussionPreviewResponse,
   GithubIssuePreviewResponse,
   GithubPreviewResponse,
   GithubPullRequestPreviewResponse,
+  GithubReleasePreviewResponse,
+  GithubRepositoryPreviewResponse,
 } from "@/services/api/github-preview-api";
 
 const GITHUB_API_BASE = "https://api.github.com";
+const GITHUB_GRAPHQL_URL = `${GITHUB_API_BASE}/graphql`;
 const CACHE_TTL_MS = 2 * 60 * 1000;
 const CACHE_MAX_ITEMS = 500;
 const FETCH_TIMEOUT_MS = 5000;
-const GITHUB_ISSUE_OR_PULL_NUMBER_PATTERN = /^\d+$/;
+const GITHUB_NUMBER_PATTERN = /^\d+$/;
+const CONTENT_REF_SPLIT_LIMIT = 8;
 
 const cache = new LruTtlCache<string, GithubPreviewResponse>({
   max: CACHE_MAX_ITEMS,
@@ -18,12 +26,71 @@ const cache = new LruTtlCache<string, GithubPreviewResponse>({
 });
 const inFlight = new Map<string, Promise<GithubPreviewResponse>>();
 
-interface GithubResource {
+class GithubApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message);
+  }
+}
+
+interface GithubResourceBase {
+  readonly href: string;
   readonly owner: string;
   readonly repo: string;
-  readonly number: number;
-  readonly kind: "issue" | "pull";
 }
+
+interface GithubRepositoryResource extends GithubResourceBase {
+  readonly kind: "repository";
+}
+
+interface GithubIssueResource extends GithubResourceBase {
+  readonly kind: "issue";
+  readonly number: number;
+}
+
+interface GithubPullResource extends GithubResourceBase {
+  readonly kind: "pull";
+  readonly number: number;
+}
+
+interface GithubContentResource extends GithubResourceBase {
+  readonly kind: "content";
+  readonly mode: "blob" | "tree";
+  readonly segments: readonly string[];
+}
+
+interface GithubCommitResource extends GithubResourceBase {
+  readonly kind: "commit";
+  readonly ref: string;
+}
+
+interface GithubReleaseResource extends GithubResourceBase {
+  readonly kind: "release";
+  readonly tag: string | null;
+}
+
+interface GithubActionsResource extends GithubResourceBase {
+  readonly kind: "actions";
+  readonly runId: number | null;
+  readonly workflowId: string | null;
+}
+
+interface GithubDiscussionResource extends GithubResourceBase {
+  readonly kind: "discussion";
+  readonly number: number | null;
+}
+
+type GithubResource =
+  | GithubRepositoryResource
+  | GithubIssueResource
+  | GithubPullResource
+  | GithubContentResource
+  | GithubCommitResource
+  | GithubReleaseResource
+  | GithubActionsResource
+  | GithubDiscussionResource;
 
 interface GithubIssueApiResponse {
   readonly html_url?: string | null;
@@ -54,7 +121,108 @@ interface GithubPullReviewApiResponse {
   readonly submitted_at?: string | null;
 }
 
-type GithubResourceKind = GithubResource["kind"];
+interface GithubRepositoryApiResponse {
+  readonly full_name?: string | null;
+  readonly description?: string | null;
+  readonly default_branch?: string | null;
+  readonly language?: string | null;
+  readonly stargazers_count?: number | null;
+  readonly forks_count?: number | null;
+  readonly open_issues_count?: number | null;
+  readonly visibility?: string | null;
+  readonly private?: boolean | null;
+  readonly archived?: boolean | null;
+  readonly html_url?: string | null;
+}
+
+interface GithubContentApiItem {
+  readonly type?: string | null;
+  readonly name?: string | null;
+  readonly path?: string | null;
+  readonly html_url?: string | null;
+  readonly size?: number | null;
+}
+
+type GithubContentApiResponse =
+  | GithubContentApiItem
+  | readonly GithubContentApiItem[];
+
+interface GithubCommitApiResponse {
+  readonly html_url?: string | null;
+  readonly sha?: string | null;
+  readonly commit?: {
+    readonly message?: string | null;
+    readonly author?: {
+      readonly name?: string | null;
+      readonly date?: string | null;
+    } | null;
+    readonly committer?: {
+      readonly name?: string | null;
+      readonly date?: string | null;
+    } | null;
+  } | null;
+  readonly author?: { readonly login?: string | null } | null;
+  readonly committer?: { readonly login?: string | null } | null;
+}
+
+interface GithubReleaseApiResponse {
+  readonly html_url?: string | null;
+  readonly name?: string | null;
+  readonly tag_name?: string | null;
+  readonly draft?: boolean | null;
+  readonly prerelease?: boolean | null;
+  readonly published_at?: string | null;
+}
+
+interface GithubActionsRunApiResponse {
+  readonly html_url?: string | null;
+  readonly name?: string | null;
+  readonly display_title?: string | null;
+  readonly status?: string | null;
+  readonly conclusion?: string | null;
+  readonly run_number?: number | null;
+  readonly event?: string | null;
+}
+
+interface GithubActionsRunsApiResponse {
+  readonly workflow_runs?: readonly GithubActionsRunApiResponse[] | null;
+}
+
+interface GithubWorkflowApiResponse {
+  readonly html_url?: string | null;
+  readonly name?: string | null;
+  readonly path?: string | null;
+  readonly state?: string | null;
+}
+
+interface GithubDiscussionGraphqlNode {
+  readonly title?: string | null;
+  readonly url?: string | null;
+  readonly number?: number | null;
+  readonly closed?: boolean | null;
+  readonly answerChosenAt?: string | null;
+  readonly category?: { readonly name?: string | null } | null;
+  readonly comments?: { readonly totalCount?: number | null } | null;
+}
+
+interface GithubDiscussionGraphqlData {
+  readonly repository?: {
+    readonly discussion?: GithubDiscussionGraphqlNode | null;
+    readonly discussions?: {
+      readonly totalCount?: number | null;
+      readonly nodes?: readonly GithubDiscussionGraphqlNode[] | null;
+    } | null;
+  } | null;
+}
+
+interface GithubGraphqlResponse<T> {
+  readonly data?: T | null;
+  readonly errors?:
+    | readonly { readonly message?: string | null }[]
+    | null
+    | undefined;
+}
+
 type GithubReviewApiState = "APPROVED" | "CHANGES_REQUESTED" | "DISMISSED";
 
 const createAbortController = (): {
@@ -81,6 +249,35 @@ const toGithubRequestError = (error: unknown): Error => {
   return new Error("GitHub request failed.");
 };
 
+const isGithubApiNotFoundError = (error: unknown): error is GithubApiError =>
+  error instanceof GithubApiError && error.status === 404;
+
+const isGithubContentApiDirectoryResponse = (
+  content: GithubContentApiResponse
+): content is readonly GithubContentApiItem[] => Array.isArray(content);
+
+const safeDecode = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+const encodePathPart = (value: string): string => encodeURIComponent(value);
+
+const encodeGithubPath = (path: string): string =>
+  path.split("/").map(encodePathPart).join("/");
+
+const toPositiveNumber = (value: string | undefined): number | null => {
+  if (!value || !GITHUB_NUMBER_PATTERN.test(value)) {
+    return null;
+  }
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+};
+
 const parseGithubResource = (rawUrl: string | null): GithubResource => {
   if (!rawUrl) {
     throw new Error("A url query parameter is required.");
@@ -99,41 +296,63 @@ const parseGithubResource = (rawUrl: string | null): GithubResource => {
 
   const hostname = parsed.hostname.replace(/^www\./i, "").toLowerCase();
   if (hostname !== "github.com") {
-    throw new Error(
-      "Only github.com issue and pull request URLs are supported."
-    );
+    throw new Error("Only github.com repository URLs are supported.");
   }
 
-  const [owner, repo, kindSegment, numberSegment] = parsed.pathname
+  const [owner, repo, kindSegment, ...rest] = parsed.pathname
     .split("/")
-    .filter(Boolean);
-  const kind = getGithubResourceKind(kindSegment);
-  const isValidNumberSegment = GITHUB_ISSUE_OR_PULL_NUMBER_PATTERN.test(
-    numberSegment ?? ""
-  );
-  const number = isValidNumberSegment ? Number(numberSegment) : Number.NaN;
+    .filter(Boolean)
+    .map(safeDecode);
 
-  if (!owner || !repo || !kind || !Number.isInteger(number) || number <= 0) {
-    throw new Error(
-      "Only github.com issue and pull request URLs are supported."
-    );
+  if (!owner || !repo) {
+    throw new Error("Only github.com repository URLs are supported.");
   }
 
-  return { owner, repo, kind, number };
-};
+  const base = { href: rawUrl.trim(), owner, repo };
+  const number = toPositiveNumber(rest[0]);
 
-const getGithubResourceKind = (
-  kindSegment: string | undefined
-): GithubResourceKind | null => {
-  if (kindSegment === "issues") {
-    return "issue";
+  switch (kindSegment) {
+    case undefined:
+    case "pulls":
+      return { ...base, kind: "repository" };
+    case "issues":
+      if (!rest[0]) {
+        return { ...base, kind: "repository" };
+      }
+      if (number) {
+        return { ...base, kind: "issue", number };
+      }
+      throw new Error("Only github.com repository URLs are supported.");
+    case "pull":
+      if (number) {
+        return { ...base, kind: "pull", number };
+      }
+      throw new Error("Only github.com repository URLs are supported.");
+    case "blob":
+    case "tree":
+      return { ...base, kind: "content", mode: kindSegment, segments: rest };
+    case "commit":
+      return rest[0]
+        ? { ...base, kind: "commit", ref: rest[0] }
+        : { ...base, kind: "repository" };
+    case "releases":
+      return {
+        ...base,
+        kind: "release",
+        tag: rest[0] === "tag" && rest[1] ? rest.slice(1).join("/") : null,
+      };
+    case "actions":
+      return {
+        ...base,
+        kind: "actions",
+        runId: rest[0] === "runs" ? toPositiveNumber(rest[1]) : null,
+        workflowId: rest[0] === "workflows" && rest[1] ? rest[1] : null,
+      };
+    case "discussions":
+      return { ...base, kind: "discussion", number };
+    default:
+      return { ...base, kind: "repository" };
   }
-
-  if (kindSegment === "pull") {
-    return "pull";
-  }
-
-  return null;
 };
 
 const fetchGithubJson = async <T>(path: string): Promise<T> => {
@@ -156,10 +375,66 @@ const fetchGithubJson = async <T>(path: string): Promise<T> => {
     });
 
     if (!response.ok) {
-      throw new Error(`GitHub request failed with status ${response.status}.`);
+      throw new GithubApiError(
+        `GitHub request failed with status ${response.status}.`,
+        response.status
+      );
     }
 
     return (await response.json()) as T;
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw new Error("GitHub request timed out.");
+    }
+
+    throw toGithubRequestError(error);
+  } finally {
+    cancel();
+  }
+};
+
+const fetchGithubGraphql = async <T>(
+  query: string,
+  variables: Record<string, unknown>
+): Promise<T> => {
+  const githubToken = serverEnv?.GITHUB_LINK_STATUS_PREVIEW_TOKEN;
+  if (!githubToken) {
+    throw new Error("GitHub discussion preview metadata is unavailable.");
+  }
+
+  const { controller, cancel } = createAbortController();
+
+  try {
+    const response = await fetch(GITHUB_GRAPHQL_URL, {
+      method: "POST",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${githubToken}`,
+        "content-type": "application/json",
+        "user-agent": "6529seize-github-preview/1.0",
+      },
+      body: JSON.stringify({ query, variables }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new GithubApiError(
+        `GitHub GraphQL request failed with status ${response.status}.`,
+        response.status
+      );
+    }
+
+    const body = (await response.json()) as GithubGraphqlResponse<T>;
+    const [firstError] = body.errors ?? [];
+    if (firstError) {
+      throw new Error(firstError.message ?? "GitHub GraphQL request failed.");
+    }
+
+    if (!body.data) {
+      throw new Error("GitHub GraphQL response did not include data.");
+    }
+
+    return body.data;
   } catch (error) {
     if (isAbortError(error)) {
       throw new Error("GitHub request timed out.");
@@ -333,7 +608,7 @@ const getPullRequestReviewState = (
 };
 
 const buildPullPreview = (
-  resource: GithubResource,
+  resource: GithubPullResource,
   pull: GithubPullApiResponse,
   reviews: readonly GithubPullReviewApiResponse[]
 ): GithubPullRequestPreviewResponse => ({
@@ -353,7 +628,7 @@ const buildPullPreview = (
 });
 
 const resolvePullPreview = async (
-  resource: GithubResource
+  resource: GithubPullResource
 ): Promise<GithubPullRequestPreviewResponse> => {
   const encodedOwner = encodeURIComponent(resource.owner);
   const encodedRepo = encodeURIComponent(resource.repo);
@@ -368,7 +643,7 @@ const resolvePullPreview = async (
 };
 
 const resolveIssuePreview = async (
-  resource: GithubResource
+  resource: GithubIssueResource
 ): Promise<GithubPreviewResponse> => {
   const issue = await fetchGithubJson<GithubIssueApiResponse>(
     `/repos/${encodeURIComponent(resource.owner)}/${encodeURIComponent(
@@ -394,12 +669,441 @@ const resolveIssuePreview = async (
   };
 };
 
+const resolveRepositoryPreview = async (
+  resource: GithubRepositoryResource
+): Promise<GithubRepositoryPreviewResponse> => {
+  const repository = await fetchGithubJson<GithubRepositoryApiResponse>(
+    `/repos/${encodeURIComponent(resource.owner)}/${encodeURIComponent(
+      resource.repo
+    )}`
+  );
+
+  return {
+    type: "github.repository",
+    owner: resource.owner,
+    repo: resource.repo,
+    title: repository.full_name ?? `${resource.owner}/${resource.repo}`,
+    description: repository.description ?? null,
+    defaultBranch: repository.default_branch ?? null,
+    language: repository.language ?? null,
+    stars: repository.stargazers_count ?? null,
+    forks: repository.forks_count ?? null,
+    openIssues: repository.open_issues_count ?? null,
+    visibility:
+      repository.visibility ?? (repository.private === true ? "private" : null),
+    archived: repository.archived === true,
+    url:
+      repository.html_url ??
+      `https://github.com/${resource.owner}/${resource.repo}`,
+  };
+};
+
+const buildContentCandidates = (
+  segments: readonly string[]
+): readonly { readonly ref: string; readonly path: string }[] => {
+  const maxRefSegments = Math.min(segments.length, CONTENT_REF_SPLIT_LIMIT);
+  const candidates: { readonly ref: string; readonly path: string }[] = [];
+
+  for (let index = 1; index <= maxRefSegments; index += 1) {
+    candidates.push({
+      ref: segments.slice(0, index).join("/"),
+      path: segments.slice(index).join("/"),
+    });
+  }
+
+  return candidates;
+};
+
+const getFallbackContentTitle = (
+  resource: GithubContentResource,
+  path: string
+): string => {
+  const [lastSegment] = path.split("/").filter(Boolean).slice(-1);
+  if (lastSegment) {
+    return lastSegment;
+  }
+
+  return resource.mode === "tree" ? resource.repo : "Code";
+};
+
+const buildContentPreview = (
+  resource: GithubContentResource,
+  candidate: { readonly ref: string; readonly path: string },
+  content: GithubContentApiResponse
+): GithubContentPreviewResponse => {
+  if (isGithubContentApiDirectoryResponse(content)) {
+    return {
+      type: "github.directory",
+      owner: resource.owner,
+      repo: resource.repo,
+      title: getFallbackContentTitle(resource, candidate.path),
+      path: candidate.path || null,
+      ref: candidate.ref,
+      size: null,
+      itemCount: content.length,
+      url: resource.href,
+    };
+  }
+
+  const type =
+    content.type === "dir" || resource.mode === "tree"
+      ? "github.directory"
+      : "github.file";
+
+  return {
+    type,
+    owner: resource.owner,
+    repo: resource.repo,
+    title: content.name ?? getFallbackContentTitle(resource, candidate.path),
+    path: content.path ?? (candidate.path || null),
+    ref: candidate.ref,
+    size: typeof content.size === "number" ? content.size : null,
+    itemCount: null,
+    url: content.html_url ?? resource.href,
+  };
+};
+
+const resolveContentPreview = async (
+  resource: GithubContentResource
+): Promise<GithubContentPreviewResponse> => {
+  if (resource.segments.length === 0) {
+    return {
+      type: "github.directory",
+      owner: resource.owner,
+      repo: resource.repo,
+      title: resource.repo,
+      path: null,
+      ref: null,
+      size: null,
+      itemCount: null,
+      url: resource.href,
+    };
+  }
+
+  let lastNotFound: Error | null = null;
+
+  for (const candidate of buildContentCandidates(resource.segments)) {
+    const encodedOwner = encodeURIComponent(resource.owner);
+    const encodedRepo = encodeURIComponent(resource.repo);
+    const encodedPath = candidate.path
+      ? `/${encodeGithubPath(candidate.path)}`
+      : "";
+    const params = new URLSearchParams({ ref: candidate.ref });
+
+    try {
+      const content = await fetchGithubJson<GithubContentApiResponse>(
+        `/repos/${encodedOwner}/${encodedRepo}/contents${encodedPath}?${params.toString()}`
+      );
+      return buildContentPreview(resource, candidate, content);
+    } catch (error) {
+      if (!isGithubApiNotFoundError(error)) {
+        throw error;
+      }
+      lastNotFound = error;
+    }
+  }
+
+  throw lastNotFound ?? new Error("GitHub content preview metadata not found.");
+};
+
+const getCommitTitle = (commit: GithubCommitApiResponse): string | null => {
+  const [firstLine] = commit.commit?.message?.split(/\r?\n/) ?? [];
+  const title = firstLine?.trim();
+  return title && title.length > 0 ? title : null;
+};
+
+const resolveCommitPreview = async (
+  resource: GithubCommitResource
+): Promise<GithubCommitPreviewResponse> => {
+  const commit = await fetchGithubJson<GithubCommitApiResponse>(
+    `/repos/${encodeURIComponent(resource.owner)}/${encodeURIComponent(
+      resource.repo
+    )}/commits/${encodePathPart(resource.ref)}`
+  );
+  const sha = commit.sha ?? resource.ref;
+
+  return {
+    type: "github.commit",
+    owner: resource.owner,
+    repo: resource.repo,
+    title: getCommitTitle(commit),
+    sha,
+    shortSha: sha.slice(0, 12),
+    author:
+      commit.author?.login ??
+      commit.commit?.author?.name ??
+      commit.committer?.login ??
+      commit.commit?.committer?.name ??
+      null,
+    committedAt:
+      commit.commit?.author?.date ?? commit.commit?.committer?.date ?? null,
+    url:
+      commit.html_url ??
+      `https://github.com/${resource.owner}/${resource.repo}/commit/${sha}`,
+  };
+};
+
+const getReleaseState = (
+  release: GithubReleaseApiResponse
+): GithubReleasePreviewResponse["state"] => {
+  if (release.draft === true) {
+    return "draft";
+  }
+
+  if (release.prerelease === true) {
+    return "prerelease";
+  }
+
+  return "published";
+};
+
+const buildReleasePreview = (
+  resource: GithubReleaseResource,
+  release: GithubReleaseApiResponse
+): GithubReleasePreviewResponse => {
+  const tagName = release.tag_name ?? resource.tag;
+
+  return {
+    type: "github.release",
+    owner: resource.owner,
+    repo: resource.repo,
+    title: release.name ?? tagName ?? "Release",
+    tagName,
+    state: getReleaseState(release),
+    publishedAt: release.published_at ?? null,
+    url:
+      release.html_url ??
+      (tagName
+        ? `https://github.com/${resource.owner}/${resource.repo}/releases/tag/${tagName}`
+        : resource.href),
+  };
+};
+
+const fallbackReleasePreview = (
+  resource: GithubReleaseResource
+): GithubReleasePreviewResponse => ({
+  type: "github.release",
+  owner: resource.owner,
+  repo: resource.repo,
+  title: resource.tag ?? "Releases",
+  tagName: resource.tag,
+  state: "published",
+  publishedAt: null,
+  url: resource.href,
+});
+
+const resolveReleasePreview = async (
+  resource: GithubReleaseResource
+): Promise<GithubReleasePreviewResponse> => {
+  const encodedOwner = encodeURIComponent(resource.owner);
+  const encodedRepo = encodeURIComponent(resource.repo);
+  const endpoint = resource.tag
+    ? `/repos/${encodedOwner}/${encodedRepo}/releases/tags/${encodePathPart(
+        resource.tag
+      )}`
+    : `/repos/${encodedOwner}/${encodedRepo}/releases/latest`;
+
+  try {
+    const release = await fetchGithubJson<GithubReleaseApiResponse>(endpoint);
+    return buildReleasePreview(resource, release);
+  } catch (error) {
+    if (isGithubApiNotFoundError(error)) {
+      return fallbackReleasePreview(resource);
+    }
+    throw error;
+  }
+};
+
+const buildActionsRunPreview = (
+  resource: GithubActionsResource,
+  run: GithubActionsRunApiResponse
+): GithubActionsPreviewResponse => ({
+  type: "github.actions",
+  owner: resource.owner,
+  repo: resource.repo,
+  title:
+    run.display_title ??
+    run.name ??
+    (run.run_number ? `Workflow run #${run.run_number}` : "Workflow run"),
+  status: run.status ?? null,
+  conclusion: run.conclusion ?? null,
+  runNumber: run.run_number ?? null,
+  event: run.event ?? null,
+  url: run.html_url ?? resource.href,
+});
+
+const resolveActionsPreview = async (
+  resource: GithubActionsResource
+): Promise<GithubActionsPreviewResponse> => {
+  const encodedOwner = encodeURIComponent(resource.owner);
+  const encodedRepo = encodeURIComponent(resource.repo);
+
+  if (resource.runId) {
+    const run = await fetchGithubJson<GithubActionsRunApiResponse>(
+      `/repos/${encodedOwner}/${encodedRepo}/actions/runs/${resource.runId}`
+    );
+    return buildActionsRunPreview(resource, run);
+  }
+
+  if (resource.workflowId) {
+    const workflow = await fetchGithubJson<GithubWorkflowApiResponse>(
+      `/repos/${encodedOwner}/${encodedRepo}/actions/workflows/${encodePathPart(
+        resource.workflowId
+      )}`
+    );
+
+    return {
+      type: "github.actions",
+      owner: resource.owner,
+      repo: resource.repo,
+      title: workflow.name ?? workflow.path ?? "Workflow",
+      status: workflow.state ?? null,
+      conclusion: null,
+      runNumber: null,
+      event: null,
+      url: workflow.html_url ?? resource.href,
+    };
+  }
+
+  const runs = await fetchGithubJson<GithubActionsRunsApiResponse>(
+    `/repos/${encodedOwner}/${encodedRepo}/actions/runs?per_page=1`
+  );
+  const [latestRun] = runs.workflow_runs ?? [];
+
+  if (!latestRun) {
+    return {
+      type: "github.actions",
+      owner: resource.owner,
+      repo: resource.repo,
+      title: "Actions",
+      status: null,
+      conclusion: null,
+      runNumber: null,
+      event: null,
+      url: resource.href,
+    };
+  }
+
+  return buildActionsRunPreview(resource, latestRun);
+};
+
+const getDiscussionState = (
+  discussion: GithubDiscussionGraphqlNode
+): GithubDiscussionPreviewResponse["state"] => {
+  if (discussion.answerChosenAt) {
+    return "answered";
+  }
+
+  if (discussion.closed === true) {
+    return "closed";
+  }
+
+  return "open";
+};
+
+const buildDiscussionPreview = (
+  resource: GithubDiscussionResource,
+  discussion: GithubDiscussionGraphqlNode | null
+): GithubDiscussionPreviewResponse => ({
+  type: "github.discussion",
+  owner: resource.owner,
+  repo: resource.repo,
+  number: discussion?.number ?? resource.number,
+  title:
+    discussion?.title ??
+    (resource.number ? `Discussion #${resource.number}` : "Discussions"),
+  category: discussion?.category?.name ?? null,
+  comments: discussion?.comments?.totalCount ?? null,
+  state: discussion ? getDiscussionState(discussion) : null,
+  url: discussion?.url ?? resource.href,
+});
+
+const resolveDiscussionPreview = async (
+  resource: GithubDiscussionResource
+): Promise<GithubDiscussionPreviewResponse> => {
+  if (!serverEnv?.GITHUB_LINK_STATUS_PREVIEW_TOKEN) {
+    return buildDiscussionPreview(resource, null);
+  }
+
+  const data = await fetchGithubGraphql<GithubDiscussionGraphqlData>(
+    resource.number
+      ? `
+        query GithubDiscussionPreview($owner: String!, $repo: String!, $number: Int!) {
+          repository(owner: $owner, name: $repo) {
+            discussion(number: $number) {
+              title
+              url
+              number
+              closed
+              answerChosenAt
+              category { name }
+              comments { totalCount }
+            }
+          }
+        }
+      `
+      : `
+        query GithubDiscussionsPreview($owner: String!, $repo: String!) {
+          repository(owner: $owner, name: $repo) {
+            discussions(first: 1, orderBy: { field: UPDATED_AT, direction: DESC }) {
+              totalCount
+              nodes {
+                title
+                url
+                number
+                closed
+                answerChosenAt
+                category { name }
+                comments { totalCount }
+              }
+            }
+          }
+        }
+      `,
+    {
+      owner: resource.owner,
+      repo: resource.repo,
+      ...(resource.number ? { number: resource.number } : {}),
+    }
+  );
+
+  const discussion =
+    data.repository?.discussion ??
+    data.repository?.discussions?.nodes?.[0] ??
+    null;
+
+  return buildDiscussionPreview(resource, discussion);
+};
+
+const resolvePreviewForResource = async (
+  resource: GithubResource
+): Promise<GithubPreviewResponse> => {
+  switch (resource.kind) {
+    case "issue":
+      return resolveIssuePreview(resource);
+    case "pull":
+      return resolvePullPreview(resource);
+    case "repository":
+      return resolveRepositoryPreview(resource);
+    case "content":
+      return resolveContentPreview(resource);
+    case "commit":
+      return resolveCommitPreview(resource);
+    case "release":
+      return resolveReleasePreview(resource);
+    case "actions":
+      return resolveActionsPreview(resource);
+    case "discussion":
+      return resolveDiscussionPreview(resource);
+  }
+};
+
 export const resolveGithubPreview = async (
   rawUrl: string | null,
   options?: { readonly bypassCache?: boolean | undefined }
 ): Promise<GithubPreviewResponse> => {
   const resource = parseGithubResource(rawUrl);
-  const cacheKey = `${resource.owner}/${resource.repo}/${resource.kind}/${resource.number}`;
+  const cacheKey = resource.href;
   const bypassCache = options?.bypassCache === true;
   const cached = bypassCache ? undefined : cache.get(cacheKey);
 
@@ -414,10 +1118,7 @@ export const resolveGithubPreview = async (
     }
   }
 
-  const previewRequest =
-    resource.kind === "pull"
-      ? resolvePullPreview(resource)
-      : resolveIssuePreview(resource);
+  const previewRequest = resolvePreviewForResource(resource);
 
   if (bypassCache) {
     return previewRequest;

--- a/components/drops/view/part/dropPartMarkdown/handlers/github.tsx
+++ b/components/drops/view/part/dropPartMarkdown/handlers/github.tsx
@@ -1,0 +1,10 @@
+import GithubLinkPreview, {
+  parseGithubLink,
+} from "@/components/waves/github/GithubLinkPreview";
+import type { LinkHandler } from "../linkTypes";
+
+export const createGithubHandler = (): LinkHandler => ({
+  match: (href: string) => parseGithubLink(href) !== null,
+  render: (href: string) => <GithubLinkPreview href={href} />,
+  display: "block",
+});

--- a/components/drops/view/part/dropPartMarkdown/handlers/index.ts
+++ b/components/drops/view/part/dropPartMarkdown/handlers/index.ts
@@ -4,6 +4,7 @@ import { createCompoundHandler } from "./compound";
 import { createEnsHandler } from "./ens";
 import { createFarcasterHandler } from "./farcaster";
 import { createGifHandler } from "./gif";
+import { createGithubHandler } from "./github";
 import { createGoogleWorkspaceHandler } from "./googleWorkspace";
 import { createNftMarketplacesHandler } from "./nftMarketplaces";
 import { createPepeHandler } from "./pepe";
@@ -17,6 +18,7 @@ export const createLinkHandlers = (options?: {
   readonly linkPreviewVariant?: LinkPreviewVariant;
   readonly fullWidthLinkPreviews?: boolean | undefined;
 }): LinkHandler[] => [
+  createGithubHandler(),
   createYoutubeHandler(),
   createTikTokHandler(),
   createGoogleWorkspaceHandler(),

--- a/components/waves/GithubPreviewStatusBadge.tsx
+++ b/components/waves/GithubPreviewStatusBadge.tsx
@@ -6,12 +6,12 @@ import { SignalSlashIcon } from "@heroicons/react/24/outline";
 import CustomTooltip from "@/components/utils/tooltip/CustomTooltip";
 import {
   fetchGithubPreview,
-  type GithubPreviewResponse,
+  type GithubStatusPreviewResponse,
 } from "@/services/api/github-preview-api";
 
 interface GithubPreviewStatusBadgeProps {
   readonly href: string;
-  readonly initialPreview?: GithubPreviewResponse | null | undefined;
+  readonly initialPreview?: GithubStatusPreviewResponse | null | undefined;
   readonly compact?: boolean | undefined;
   readonly placement?: "absolute" | "inline" | undefined;
 }
@@ -69,7 +69,9 @@ const parseGithubPreviewUrlInfo = (
   return null;
 };
 
-const getBadgeViewModel = (preview: GithubPreviewResponse): BadgeViewModel => {
+const getBadgeViewModel = (
+  preview: GithubStatusPreviewResponse
+): BadgeViewModel => {
   if (preview.type === "github.issue") {
     switch (preview.state) {
       case "open":
@@ -130,7 +132,7 @@ const VISIBLE_REFRESH_INTERVAL_MS = 30 * 1000;
 type GithubStatusState =
   | { readonly type: "idle" }
   | { readonly type: "loading" }
-  | { readonly type: "success"; readonly preview: GithubPreviewResponse }
+  | { readonly type: "success"; readonly preview: GithubStatusPreviewResponse }
   | { readonly type: "error"; readonly message: string };
 
 const getErrorMessage = (error: unknown): string => {
@@ -175,7 +177,7 @@ interface IssueAssigneeLabels {
 }
 
 const getIssueAssigneeLabels = (
-  preview: GithubPreviewResponse
+  preview: GithubStatusPreviewResponse
 ): IssueAssigneeLabels | null => {
   if (preview.type !== "github.issue") {
     return null;
@@ -280,7 +282,14 @@ export default function GithubPreviewStatusBadge({
     fetchGithubPreview(githubInfo.url.toString())
       .then((response) => {
         if (active) {
-          setStatus({ type: "success", preview: response });
+          if (
+            response.type === "github.issue" ||
+            response.type === "github.pull_request"
+          ) {
+            setStatus({ type: "success", preview: response });
+          } else {
+            setStatus({ type: "idle" });
+          }
         }
       })
       .catch((error: unknown) => {
@@ -308,7 +317,14 @@ export default function GithubPreviewStatusBadge({
       fetchGithubPreview(githubInfo.url.toString(), { bypassCache: true })
         .then((response) => {
           if (active) {
-            setStatus({ type: "success", preview: response });
+            if (
+              response.type === "github.issue" ||
+              response.type === "github.pull_request"
+            ) {
+              setStatus({ type: "success", preview: response });
+            } else {
+              setStatus({ type: "idle" });
+            }
           }
         })
         .catch((error: unknown) => {

--- a/components/waves/GithubPreviewStatusBadge.tsx
+++ b/components/waves/GithubPreviewStatusBadge.tsx
@@ -13,6 +13,7 @@ interface GithubPreviewStatusBadgeProps {
   readonly href: string;
   readonly initialPreview?: GithubPreviewResponse | null | undefined;
   readonly compact?: boolean | undefined;
+  readonly placement?: "absolute" | "inline" | undefined;
 }
 
 type BadgeTone = "green" | "purple" | "red" | "gray" | "amber";
@@ -221,6 +222,7 @@ export default function GithubPreviewStatusBadge({
   href,
   initialPreview,
   compact = false,
+  placement = "absolute",
 }: GithubPreviewStatusBadgeProps) {
   const githubInfo = useMemo(() => parseGithubPreviewUrlInfo(href), [href]);
   const badgeRef = useRef<HTMLSpanElement | null>(null);
@@ -343,10 +345,14 @@ export default function GithubPreviewStatusBadge({
     viewModel,
     issueAssigneeLabels?.desktop ?? detail
   );
+  const placementClasses =
+    placement === "absolute"
+      ? "tw-absolute tw-right-2 tw-top-2 tw-z-20 tw-max-w-[calc(100%-1rem)]"
+      : "tw-relative tw-max-w-full";
   const badge = (
     <span
       ref={badgeRef}
-      className={`tw-pointer-events-auto tw-absolute tw-right-2 tw-top-2 tw-z-20 tw-inline-flex tw-max-w-[calc(100%-1rem)] tw-items-center tw-gap-1.5 tw-rounded-full tw-border tw-border-solid tw-px-2.5 tw-py-1 tw-text-[11px] tw-font-semibold tw-leading-none tw-shadow-lg tw-backdrop-blur-md ${TONE_CLASSES[viewModel.tone]}`}
+      className={`tw-pointer-events-auto tw-inline-flex tw-items-center tw-gap-1.5 tw-rounded-full tw-border tw-border-solid tw-px-2.5 tw-py-1 tw-text-[11px] tw-font-semibold tw-leading-none tw-shadow-lg tw-backdrop-blur-md ${placementClasses} ${TONE_CLASSES[viewModel.tone]}`}
       data-testid="github-preview-status-badge"
       aria-label={title}
     >

--- a/components/waves/GithubPreviewStatusBadge.tsx
+++ b/components/waves/GithubPreviewStatusBadge.tsx
@@ -408,6 +408,10 @@ export default function GithubPreviewStatusBadge({
     return badge;
   }
 
+  if (placement === "inline") {
+    return badge;
+  }
+
   return (
     <CustomTooltip content="Status unavailable" placement="top" delayShow={200}>
       {badge}

--- a/components/waves/OpenGraphPreview.tsx
+++ b/components/waves/OpenGraphPreview.tsx
@@ -7,6 +7,7 @@ import { removeBaseEndpoint } from "@/helpers/Helpers";
 import type {
   GithubPreviewEnvelope,
   GithubPreviewResponse,
+  GithubStatusPreviewResponse,
 } from "@/services/api/github-preview-api";
 import ChatItemHrefButtons from "./ChatItemHrefButtons";
 import GithubPreviewStatusBadge from "./GithubPreviewStatusBadge";
@@ -238,7 +239,17 @@ function isGithubPreviewResponse(
   }
 
   const type = (value as { readonly type?: unknown }).type;
-  return type === "github.issue" || type === "github.pull_request";
+  return (
+    type === "github.issue" ||
+    type === "github.pull_request" ||
+    type === "github.repository" ||
+    type === "github.file" ||
+    type === "github.directory" ||
+    type === "github.commit" ||
+    type === "github.release" ||
+    type === "github.actions" ||
+    type === "github.discussion"
+  );
 }
 
 function extractGithubPreview(
@@ -247,6 +258,14 @@ function extractGithubPreview(
   const githubPreview = (preview as GithubPreviewEnvelope | null | undefined)
     ?.githubPreview;
   return isGithubPreviewResponse(githubPreview) ? githubPreview : null;
+}
+
+function isGithubStatusPreviewResponse(
+  preview: GithubPreviewResponse | null
+): preview is GithubStatusPreviewResponse {
+  return (
+    preview?.type === "github.issue" || preview?.type === "github.pull_request"
+  );
 }
 
 function getRelativeHref(href: string): string | undefined {
@@ -483,11 +502,13 @@ export default function OpenGraphPreview({
           className="tw-relative tw-block tw-h-full tw-min-h-0 tw-w-full tw-overflow-hidden tw-rounded-t-xl tw-border tw-border-solid tw-border-white/10 tw-bg-black/30 tw-no-underline"
           data-testid="og-preview-card"
         >
-          <GithubPreviewStatusBadge
-            href={href}
-            initialPreview={githubPreview}
-            compact
-          />
+          {isGithubStatusPreviewResponse(githubPreview) && (
+            <GithubPreviewStatusBadge
+              href={href}
+              initialPreview={githubPreview}
+              compact
+            />
+          )}
           {imageUrl && (
             <Image
               src={imageUrl}
@@ -523,10 +544,12 @@ export default function OpenGraphPreview({
           className="tw-relative tw-h-full tw-min-h-0 tw-w-full tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/40 tw-p-4"
           data-testid="og-preview-card"
         >
-          <GithubPreviewStatusBadge
-            href={href}
-            initialPreview={githubPreview}
-          />
+          {isGithubStatusPreviewResponse(githubPreview) && (
+            <GithubPreviewStatusBadge
+              href={href}
+              initialPreview={githubPreview}
+            />
+          )}
           <div
             className={
               imageUrl

--- a/components/waves/github/GithubLinkPreview.tsx
+++ b/components/waves/github/GithubLinkPreview.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import Image from "next/image";
+import Link from "next/link";
+
+import LinkHandlerFrame from "@/components/waves/LinkHandlerFrame";
+import GithubPreviewStatusBadge from "@/components/waves/GithubPreviewStatusBadge";
+import {
+  fetchGithubPreview,
+  type GithubPreviewResponse,
+} from "@/services/api/github-preview-api";
+
+interface GithubLinkPreviewProps {
+  readonly href: string;
+}
+
+type GithubLinkKind =
+  | "pull"
+  | "issue"
+  | "repository"
+  | "code"
+  | "commit"
+  | "release"
+  | "actions"
+  | "discussion"
+  | "github";
+
+export interface ParsedGithubLink {
+  readonly href: string;
+  readonly owner: string;
+  readonly repo: string;
+  readonly kind: GithubLinkKind;
+  readonly number?: number | undefined;
+  readonly pathLabel?: string | undefined;
+}
+
+type GithubPreviewState =
+  | { readonly type: "idle" }
+  | { readonly type: "loading" }
+  | { readonly type: "success"; readonly preview: GithubPreviewResponse }
+  | { readonly type: "error" };
+
+const GITHUB_NUMBER_PATTERN = /^\d+$/;
+
+const safeDecode = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+const toPositiveNumber = (value: string | undefined): number | undefined => {
+  if (!value || !GITHUB_NUMBER_PATTERN.test(value)) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+};
+
+const getRepositoryPathLabel = (
+  segment: string | undefined,
+  rest: readonly string[]
+): { readonly kind: GithubLinkKind; readonly label?: string | undefined } => {
+  switch (segment) {
+    case undefined:
+      return { kind: "repository" };
+    case "tree":
+    case "blob":
+      return { kind: "code", label: rest.length > 0 ? rest.join("/") : "Code" };
+    case "commit":
+      return {
+        kind: "commit",
+        label: rest[0] ? rest[0].slice(0, 12) : "Commit",
+      };
+    case "releases":
+      return {
+        kind: "release",
+        label: rest[0] === "tag" && rest[1] ? rest[1] : "Releases",
+      };
+    case "actions":
+      return { kind: "actions", label: "Actions" };
+    case "discussions":
+      return {
+        kind: "discussion",
+        label: rest[0] ? `#${rest[0]}` : "Discussions",
+      };
+    case "issues":
+      return { kind: "repository", label: "Issues" };
+    case "pulls":
+      return { kind: "repository", label: "Pull requests" };
+    default:
+      return { kind: "github", label: segment };
+  }
+};
+
+export const parseGithubLink = (href: string): ParsedGithubLink | null => {
+  let url: URL;
+
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+
+  const hostname = url.hostname.replace(/^www\./i, "").toLowerCase();
+  if (hostname !== "github.com") {
+    return null;
+  }
+
+  const [ownerSegment, repoSegment, kindSegment, numberSegment, ...rest] =
+    url.pathname.split("/").filter(Boolean);
+
+  if (!ownerSegment || !repoSegment) {
+    return null;
+  }
+
+  const owner = safeDecode(ownerSegment);
+  const repo = safeDecode(repoSegment);
+  const number = toPositiveNumber(numberSegment);
+
+  if (kindSegment === "pull" && number) {
+    return {
+      href,
+      owner,
+      repo,
+      kind: "pull",
+      number,
+    };
+  }
+
+  if (kindSegment === "issues" && number) {
+    return {
+      href,
+      owner,
+      repo,
+      kind: "issue",
+      number,
+    };
+  }
+
+  const repositoryPath = getRepositoryPathLabel(
+    kindSegment,
+    [numberSegment, ...rest].filter((value): value is string => Boolean(value))
+  );
+
+  return {
+    href,
+    owner,
+    repo,
+    kind: repositoryPath.kind,
+    pathLabel: repositoryPath.label,
+  };
+};
+
+const shouldFetchGithubPreview = (link: ParsedGithubLink): boolean =>
+  link.kind === "pull" || link.kind === "issue";
+
+const getKindLabel = (
+  link: ParsedGithubLink,
+  preview: GithubPreviewResponse | null
+): string => {
+  const effectiveKind =
+    preview?.type === "github.pull_request"
+      ? "pull"
+      : preview?.type === "github.issue"
+        ? "issue"
+        : link.kind;
+
+  switch (effectiveKind) {
+    case "pull":
+      return "Pull request";
+    case "issue":
+      return "Issue";
+    case "code":
+      return "Code";
+    case "commit":
+      return "Commit";
+    case "release":
+      return "Release";
+    case "actions":
+      return "Actions";
+    case "discussion":
+      return "Discussion";
+    case "repository":
+      return "Repository";
+    case "github":
+      return "GitHub";
+  }
+};
+
+const getFallbackTitle = (link: ParsedGithubLink): string => {
+  switch (link.kind) {
+    case "pull":
+      return `Pull request #${link.number}`;
+    case "issue":
+      return `Issue #${link.number}`;
+    case "repository":
+      return `${link.owner}/${link.repo}`;
+    case "code":
+      return link.pathLabel ?? "Code";
+    case "commit":
+      return `Commit ${link.pathLabel ?? ""}`.trim();
+    case "release":
+      return link.pathLabel ?? "Release";
+    case "actions":
+      return link.pathLabel ?? "Actions";
+    case "discussion":
+      return `Discussion ${link.pathLabel ?? ""}`.trim();
+    case "github":
+      return link.pathLabel ?? `${link.owner}/${link.repo}`;
+  }
+};
+
+const getCardTitle = (
+  link: ParsedGithubLink,
+  preview: GithubPreviewResponse | null
+): string => {
+  const title = preview?.title?.trim();
+  return title && title.length > 0 ? title : getFallbackTitle(link);
+};
+
+const getDetailText = (
+  link: ParsedGithubLink,
+  preview: GithubPreviewResponse | null
+): string => {
+  const repoLabel = `${link.owner}/${link.repo}`;
+
+  if (preview?.type === "github.pull_request") {
+    return `${repoLabel} - PR #${preview.number}`;
+  }
+
+  if (preview?.type === "github.issue") {
+    return `${repoLabel} - issue #${preview.number}`;
+  }
+
+  if (link.kind === "pull" && link.number) {
+    return `${repoLabel} - PR #${link.number}`;
+  }
+
+  if (link.kind === "issue" && link.number) {
+    return `${repoLabel} - issue #${link.number}`;
+  }
+
+  if (link.pathLabel) {
+    return `${repoLabel} - ${link.pathLabel}`;
+  }
+
+  return repoLabel;
+};
+
+const getAriaLabel = (
+  link: ParsedGithubLink,
+  preview: GithubPreviewResponse | null
+): string => {
+  const kindLabel = getKindLabel(link, preview).toLowerCase();
+  const title = getCardTitle(link, preview);
+  return `Open GitHub ${kindLabel}: ${title} (opens in a new tab)`;
+};
+
+const LoadingStatus = () => (
+  <span className="tw-inline-flex tw-items-center tw-gap-1.5 tw-rounded-full tw-border tw-border-solid tw-border-iron-600/50 tw-bg-iron-950/80 tw-px-2.5 tw-py-1 tw-text-[11px] tw-font-semibold tw-leading-none tw-text-iron-200 tw-shadow-lg tw-shadow-black/30">
+    <span className="tw-h-2 tw-w-2 tw-animate-spin tw-rounded-full tw-border tw-border-solid tw-border-current tw-border-r-transparent" />
+    Loading
+  </span>
+);
+
+const UnavailableStatus = () => (
+  <span className="tw-inline-flex tw-items-center tw-rounded-full tw-border tw-border-solid tw-border-iron-600/50 tw-bg-iron-950/80 tw-px-2.5 tw-py-1 tw-text-[11px] tw-font-semibold tw-leading-none tw-text-iron-300 tw-shadow-lg tw-shadow-black/30">
+    Status unavailable
+  </span>
+);
+
+export default function GithubLinkPreview({ href }: GithubLinkPreviewProps) {
+  const link = useMemo(() => parseGithubLink(href), [href]);
+  const [state, setState] = useState<GithubPreviewState>({ type: "idle" });
+
+  useEffect(() => {
+    if (!link || !shouldFetchGithubPreview(link)) {
+      setState({ type: "idle" });
+      return;
+    }
+
+    let active = true;
+    setState({ type: "loading" });
+
+    fetchGithubPreview(link.href)
+      .then((preview) => {
+        if (active) {
+          setState({ type: "success", preview });
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setState({ type: "error" });
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [link]);
+
+  if (!link) {
+    return null;
+  }
+
+  const preview = state.type === "success" ? state.preview : null;
+  const title = getCardTitle(link, preview);
+  const kindLabel = getKindLabel(link, preview);
+  const detailText = getDetailText(link, preview);
+
+  return (
+    <LinkHandlerFrame href={href}>
+      <Link
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        prefetch={false}
+        onClick={(event) => event.stopPropagation()}
+        className="tw-relative tw-block tw-w-full tw-min-w-0 tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/55 tw-p-3 tw-pr-12 tw-no-underline tw-shadow-sm tw-shadow-black/20 tw-transition tw-duration-200 hover:tw-border-iron-600 hover:tw-bg-iron-900/75 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 sm:tw-p-4 sm:tw-pr-14"
+        data-testid="github-link-preview-card"
+        aria-label={getAriaLabel(link, preview)}
+      >
+        <div className="tw-flex tw-min-w-0 tw-gap-3">
+          <span className="tw-flex tw-h-10 tw-w-10 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-border-white/10 tw-bg-black/35">
+            <Image
+              src="/github_w.png"
+              alt=""
+              aria-hidden="true"
+              width={24}
+              height={24}
+              unoptimized
+              className="tw-h-6 tw-w-6 tw-opacity-90"
+            />
+          </span>
+          <span className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-2">
+            <span className="tw-flex tw-min-w-0 tw-flex-wrap tw-items-center tw-gap-2">
+              <span className="tw-text-[11px] tw-font-semibold tw-uppercase tw-leading-none tw-tracking-wide tw-text-iron-400">
+                GitHub
+              </span>
+              <span className="tw-inline-flex tw-items-center tw-rounded-full tw-bg-iron-800/80 tw-px-2 tw-py-1 tw-text-[11px] tw-font-semibold tw-leading-none tw-text-iron-200">
+                {kindLabel}
+              </span>
+              {state.type === "loading" && <LoadingStatus />}
+              {state.type === "error" && <UnavailableStatus />}
+              {preview && (
+                <GithubPreviewStatusBadge
+                  href={href}
+                  initialPreview={preview}
+                  compact
+                  placement="inline"
+                />
+              )}
+            </span>
+            <span className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-break-words tw-text-sm tw-font-semibold tw-leading-snug tw-text-iron-100 sm:tw-text-base">
+              {title}
+            </span>
+            <span className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-break-words tw-text-xs tw-font-medium tw-leading-5 tw-text-iron-400">
+              {detailText}
+            </span>
+          </span>
+        </div>
+      </Link>
+    </LinkHandlerFrame>
+  );
+}

--- a/components/waves/github/GithubLinkPreview.tsx
+++ b/components/waves/github/GithubLinkPreview.tsx
@@ -163,12 +163,12 @@ const getKindLabel = (
   link: ParsedGithubLink,
   preview: GithubPreviewResponse | null
 ): string => {
-  const effectiveKind =
-    preview?.type === "github.pull_request"
-      ? "pull"
-      : preview?.type === "github.issue"
-        ? "issue"
-        : link.kind;
+  let effectiveKind = link.kind;
+  if (preview?.type === "github.pull_request") {
+    effectiveKind = "pull";
+  } else if (preview?.type === "github.issue") {
+    effectiveKind = "issue";
+  }
 
   switch (effectiveKind) {
     case "pull":
@@ -264,7 +264,7 @@ const getAriaLabel = (
 const LoadingStatus = () => (
   <span className="tw-inline-flex tw-items-center tw-gap-1.5 tw-rounded-full tw-border tw-border-solid tw-border-iron-600/50 tw-bg-iron-950/80 tw-px-2.5 tw-py-1 tw-text-[11px] tw-font-semibold tw-leading-none tw-text-iron-200 tw-shadow-lg tw-shadow-black/30">
     <span className="tw-h-2 tw-w-2 tw-animate-spin tw-rounded-full tw-border tw-border-solid tw-border-current tw-border-r-transparent" />
-    Loading
+    <span>Loading</span>
   </span>
 );
 

--- a/components/waves/github/GithubLinkPreview.tsx
+++ b/components/waves/github/GithubLinkPreview.tsx
@@ -10,6 +10,7 @@ import GithubPreviewStatusBadge from "@/components/waves/GithubPreviewStatusBadg
 import {
   fetchGithubPreview,
   type GithubPreviewResponse,
+  type GithubStatusPreviewResponse,
 } from "@/services/api/github-preview-api";
 
 interface GithubLinkPreviewProps {
@@ -20,7 +21,8 @@ type GithubLinkKind =
   | "pull"
   | "issue"
   | "repository"
-  | "code"
+  | "file"
+  | "directory"
   | "commit"
   | "release"
   | "actions"
@@ -68,9 +70,13 @@ const getRepositoryPathLabel = (
   switch (segment) {
     case undefined:
       return { kind: "repository" };
-    case "tree":
     case "blob":
-      return { kind: "code", label: rest.length > 0 ? rest.join("/") : "Code" };
+      return { kind: "file", label: rest.length > 0 ? rest.join("/") : "File" };
+    case "tree":
+      return {
+        kind: "directory",
+        label: rest.length > 0 ? rest.join("/") : "Directory",
+      };
     case "commit":
       return {
         kind: "commit",
@@ -79,7 +85,8 @@ const getRepositoryPathLabel = (
     case "releases":
       return {
         kind: "release",
-        label: rest[0] === "tag" && rest[1] ? rest[1] : "Releases",
+        label:
+          rest[0] === "tag" && rest[1] ? rest.slice(1).join("/") : "Releases",
       };
     case "actions":
       return { kind: "actions", label: "Actions" };
@@ -158,11 +165,70 @@ export const parseGithubLink = (href: string): ParsedGithubLink | null => {
   };
 };
 
-const shouldFetchGithubPreview = (link: ParsedGithubLink): boolean => {
-  // The GitHub metadata endpoint currently returns rich state for PRs/issues;
-  // repository, code, commit, and release cards intentionally use local labels.
-  return link.kind === "pull" || link.kind === "issue";
+const shouldFetchGithubPreview = (link: ParsedGithubLink): boolean =>
+  link.kind !== "github";
+
+const isStatusPreview = (
+  preview: GithubPreviewResponse | null
+): preview is GithubStatusPreviewResponse =>
+  preview?.type === "github.issue" || preview?.type === "github.pull_request";
+
+const formatCompactNumber = (
+  value: number | null | undefined
+): string | null =>
+  typeof value === "number"
+    ? new Intl.NumberFormat(undefined, {
+        notation: "compact",
+        maximumFractionDigits: 1,
+      }).format(value)
+    : null;
+
+const formatInteger = (value: number | null | undefined): string | null =>
+  typeof value === "number" ? new Intl.NumberFormat().format(value) : null;
+
+const formatBytes = (value: number | null | undefined): string | null => {
+  if (typeof value !== "number") {
+    return null;
+  }
+
+  const units = ["B", "KB", "MB", "GB"] as const;
+  let size = value;
+  let unitIndex = 0;
+
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${new Intl.NumberFormat(undefined, {
+    maximumFractionDigits: unitIndex === 0 ? 0 : 1,
+  }).format(size)} ${units[unitIndex]}`;
 };
+
+const formatDate = (value: string | null | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(date);
+};
+
+const normalizeStatusText = (
+  value: string | null | undefined
+): string | null => (value ? value.replaceAll("_", " ") : null);
+
+const joinDetailParts = (
+  parts: readonly (string | null | undefined)[]
+): string => parts.filter((part): part is string => Boolean(part)).join(" - ");
 
 const getKindLabel = (
   link: ParsedGithubLink,
@@ -180,8 +246,10 @@ const getKindLabel = (
       return "Pull request";
     case "issue":
       return "Issue";
-    case "code":
-      return "Code";
+    case "file":
+      return "File";
+    case "directory":
+      return "Directory";
     case "commit":
       return "Commit";
     case "release":
@@ -197,6 +265,33 @@ const getKindLabel = (
   }
 };
 
+const getKindLabelFromPreview = (
+  preview: GithubPreviewResponse | null
+): string | null => {
+  switch (preview?.type) {
+    case "github.issue":
+      return "Issue";
+    case "github.pull_request":
+      return "Pull request";
+    case "github.repository":
+      return "Repository";
+    case "github.file":
+      return "File";
+    case "github.directory":
+      return "Directory";
+    case "github.commit":
+      return "Commit";
+    case "github.release":
+      return "Release";
+    case "github.actions":
+      return "Actions";
+    case "github.discussion":
+      return "Discussion";
+    case undefined:
+      return null;
+  }
+};
+
 const getFallbackTitle = (link: ParsedGithubLink): string => {
   switch (link.kind) {
     case "pull":
@@ -205,8 +300,10 @@ const getFallbackTitle = (link: ParsedGithubLink): string => {
       return `Issue #${link.number}`;
     case "repository":
       return `${link.owner}/${link.repo}`;
-    case "code":
-      return link.pathLabel ?? "Code";
+    case "file":
+      return link.pathLabel ?? "File";
+    case "directory":
+      return link.pathLabel ?? "Directory";
     case "commit":
       return `Commit ${link.pathLabel ?? ""}`.trim();
     case "release":
@@ -242,6 +339,72 @@ const getDetailText = (
     return `${repoLabel} - issue #${preview.number}`;
   }
 
+  if (preview?.type === "github.repository") {
+    return joinDetailParts([
+      repoLabel,
+      preview.description,
+      preview.language,
+      preview.archived ? "archived" : null,
+      preview.stars !== null
+        ? `${formatCompactNumber(preview.stars)} stars`
+        : null,
+      preview.forks !== null
+        ? `${formatCompactNumber(preview.forks)} forks`
+        : null,
+    ]);
+  }
+
+  if (preview?.type === "github.file" || preview?.type === "github.directory") {
+    return joinDetailParts([
+      repoLabel,
+      preview.path,
+      preview.ref,
+      preview.type === "github.file" ? formatBytes(preview.size) : null,
+      preview.type === "github.directory" && preview.itemCount !== null
+        ? `${formatInteger(preview.itemCount)} items`
+        : null,
+    ]);
+  }
+
+  if (preview?.type === "github.commit") {
+    return joinDetailParts([
+      repoLabel,
+      preview.shortSha,
+      preview.author ? `@${preview.author}` : null,
+      formatDate(preview.committedAt),
+    ]);
+  }
+
+  if (preview?.type === "github.release") {
+    return joinDetailParts([
+      repoLabel,
+      preview.tagName,
+      preview.state,
+      formatDate(preview.publishedAt),
+    ]);
+  }
+
+  if (preview?.type === "github.actions") {
+    return joinDetailParts([
+      repoLabel,
+      preview.runNumber ? `run #${formatInteger(preview.runNumber)}` : null,
+      normalizeStatusText(preview.conclusion ?? preview.status),
+      preview.event,
+    ]);
+  }
+
+  if (preview?.type === "github.discussion") {
+    return joinDetailParts([
+      repoLabel,
+      preview.number ? `discussion #${preview.number}` : null,
+      preview.category,
+      normalizeStatusText(preview.state),
+      preview.comments !== null
+        ? `${formatInteger(preview.comments)} comments`
+        : null,
+    ]);
+  }
+
   if (link.kind === "pull" && link.number) {
     return `${repoLabel} - PR #${link.number}`;
   }
@@ -261,7 +424,9 @@ const getAriaLabel = (
   link: ParsedGithubLink,
   preview: GithubPreviewResponse | null
 ): string => {
-  const kindLabel = getKindLabel(link, preview).toLowerCase();
+  const kindLabel = (
+    getKindLabelFromPreview(preview) ?? getKindLabel(link, preview)
+  ).toLowerCase();
   const title = getCardTitle(link, preview);
   return `Open GitHub ${kindLabel}: ${title} (opens in a new tab)`;
 };
@@ -315,7 +480,8 @@ export default function GithubLinkPreview({ href }: GithubLinkPreviewProps) {
 
   const preview = state.type === "success" ? state.preview : null;
   const title = getCardTitle(link, preview);
-  const kindLabel = getKindLabel(link, preview);
+  const kindLabel =
+    getKindLabelFromPreview(preview) ?? getKindLabel(link, preview);
   const detailText = getDetailText(link, preview);
 
   return (
@@ -352,7 +518,7 @@ export default function GithubLinkPreview({ href }: GithubLinkPreviewProps) {
               </span>
               {state.type === "loading" && <LoadingStatus />}
               {state.type === "error" && <UnavailableStatus />}
-              {preview && (
+              {isStatusPreview(preview) && (
                 <GithubPreviewStatusBadge
                   href={href}
                   initialPreview={preview}

--- a/components/waves/github/GithubLinkPreview.tsx
+++ b/components/waves/github/GithubLinkPreview.tsx
@@ -165,6 +165,8 @@ export const parseGithubLink = (href: string): ParsedGithubLink | null => {
   };
 };
 
+// Rich previews fetch only for known GitHub resource shapes. Unknown subroutes
+// keep local labels to avoid broad fan-out through the server API route.
 const shouldFetchGithubPreview = (link: ParsedGithubLink): boolean =>
   link.kind !== "github";
 
@@ -313,6 +315,7 @@ const getFallbackTitle = (link: ParsedGithubLink): string => {
     case "discussion":
       return `Discussion ${link.pathLabel ?? ""}`.trim();
     case "github":
+      // Unknown GitHub subroutes intentionally skip metadata fetching.
       return link.pathLabel ?? `${link.owner}/${link.repo}`;
   }
 };

--- a/components/waves/github/GithubLinkPreview.tsx
+++ b/components/waves/github/GithubLinkPreview.tsx
@@ -142,6 +142,8 @@ export const parseGithubLink = (href: string): ParsedGithubLink | null => {
     };
   }
 
+  // Non-PR/issue GitHub routes keep the segment after the repo as part of the
+  // display path, e.g. /commit/<sha> exposes the sha as numberSegment here.
   const repositoryPath = getRepositoryPathLabel(
     kindSegment,
     [numberSegment, ...rest].filter((value): value is string => Boolean(value))
@@ -156,8 +158,11 @@ export const parseGithubLink = (href: string): ParsedGithubLink | null => {
   };
 };
 
-const shouldFetchGithubPreview = (link: ParsedGithubLink): boolean =>
-  link.kind === "pull" || link.kind === "issue";
+const shouldFetchGithubPreview = (link: ParsedGithubLink): boolean => {
+  // The GitHub metadata endpoint currently returns rich state for PRs/issues;
+  // repository, code, commit, and release cards intentionally use local labels.
+  return link.kind === "pull" || link.kind === "issue";
+};
 
 const getKindLabel = (
   link: ParsedGithubLink,

--- a/services/api/github-preview-api.ts
+++ b/services/api/github-preview-api.ts
@@ -31,9 +31,93 @@ export interface GithubPullRequestPreviewResponse {
   readonly url: string;
 }
 
-export type GithubPreviewResponse =
+export interface GithubRepositoryPreviewResponse {
+  readonly type: "github.repository";
+  readonly owner: string;
+  readonly repo: string;
+  readonly title: string | null;
+  readonly description: string | null;
+  readonly defaultBranch: string | null;
+  readonly language: string | null;
+  readonly stars: number | null;
+  readonly forks: number | null;
+  readonly openIssues: number | null;
+  readonly visibility: string | null;
+  readonly archived: boolean;
+  readonly url: string;
+}
+
+export interface GithubContentPreviewResponse {
+  readonly type: "github.file" | "github.directory";
+  readonly owner: string;
+  readonly repo: string;
+  readonly title: string | null;
+  readonly path: string | null;
+  readonly ref: string | null;
+  readonly size: number | null;
+  readonly itemCount: number | null;
+  readonly url: string;
+}
+
+export interface GithubCommitPreviewResponse {
+  readonly type: "github.commit";
+  readonly owner: string;
+  readonly repo: string;
+  readonly title: string | null;
+  readonly sha: string;
+  readonly shortSha: string;
+  readonly author: string | null;
+  readonly committedAt: string | null;
+  readonly url: string;
+}
+
+export interface GithubReleasePreviewResponse {
+  readonly type: "github.release";
+  readonly owner: string;
+  readonly repo: string;
+  readonly title: string | null;
+  readonly tagName: string | null;
+  readonly state: "draft" | "prerelease" | "published";
+  readonly publishedAt: string | null;
+  readonly url: string;
+}
+
+export interface GithubActionsPreviewResponse {
+  readonly type: "github.actions";
+  readonly owner: string;
+  readonly repo: string;
+  readonly title: string | null;
+  readonly status: string | null;
+  readonly conclusion: string | null;
+  readonly runNumber: number | null;
+  readonly event: string | null;
+  readonly url: string;
+}
+
+export interface GithubDiscussionPreviewResponse {
+  readonly type: "github.discussion";
+  readonly owner: string;
+  readonly repo: string;
+  readonly number: number | null;
+  readonly title: string | null;
+  readonly category: string | null;
+  readonly comments: number | null;
+  readonly state: "open" | "closed" | "answered" | null;
+  readonly url: string;
+}
+
+export type GithubStatusPreviewResponse =
   | GithubIssuePreviewResponse
   | GithubPullRequestPreviewResponse;
+
+export type GithubPreviewResponse =
+  | GithubStatusPreviewResponse
+  | GithubRepositoryPreviewResponse
+  | GithubContentPreviewResponse
+  | GithubCommitPreviewResponse
+  | GithubReleasePreviewResponse
+  | GithubActionsPreviewResponse
+  | GithubDiscussionPreviewResponse;
 
 export interface GithubPreviewEnvelope {
   readonly githubPreview?: GithubPreviewResponse | null | undefined;


### PR DESCRIPTION
## Summary
- add a purpose-built GitHub link handler before the generic OpenGraph handler
- render compact GitHub cards for repos, PRs, issues, code, commits, releases, actions, and discussions
- reuse GitHub PR/issue status metadata inline so mobile cards avoid the oversized social preview layout

## Local verification
- `pnpm exec jest --runInBand --coverage=false __tests__/components/waves/github/GithubLinkPreview.test.tsx __tests__/components/drops/view/part/dropPartMarkdown/handlers/github.test.tsx __tests__/components/waves/GithubPreviewStatusBadge.test.tsx`
- `pnpm run typecheck:changed`
- `pnpm exec eslint --no-warn-ignored --max-warnings=0 components/waves/GithubPreviewStatusBadge.tsx components/waves/github/GithubLinkPreview.tsx components/drops/view/part/dropPartMarkdown/handlers/github.tsx components/drops/view/part/dropPartMarkdown/handlers/index.ts __tests__/components/waves/github/GithubLinkPreview.test.tsx __tests__/components/drops/view/part/dropPartMarkdown/handlers/github.test.tsx`

Note: `pnpm run check:changed` was blocked locally by the EC2 Windows shell resolving the repo's `bash -lc ... xargs ...` formatter pipeline without `xargs`; direct Prettier on the changed files reported all unchanged.