### PR TITLE
subwave label in the right sidebar

### DIFF
--- a/__tests__/components/waves/header/WaveHeader.test.tsx
+++ b/__tests__/components/waves/header/WaveHeader.test.tsx
@@ -176,6 +176,9 @@ describe("WaveHeader", () => {
       "data-show-owner",
       "true"
     );
+    expect(
+      screen.getByTestId("wave-header-options").parentElement?.className
+    ).toContain("tw-mt-[22px]");
     expect(screen.queryByTestId("wave-header-pin")).toBeNull();
   });
 

--- a/__tests__/components/waves/header/name/WaveHeaderName.test.tsx
+++ b/__tests__/components/waves/header/name/WaveHeaderName.test.tsx
@@ -4,7 +4,11 @@ import WaveHeaderName from "@/components/waves/header/name/WaveHeaderName";
 
 jest.mock("next/link", () => ({
   __esModule: true,
-  default: ({ href, children }: any) => <a href={href}>{children}</a>,
+  default: ({ href, children, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
 }));
 
 jest.mock(
@@ -21,6 +25,7 @@ describe("WaveHeaderName", () => {
     id: "w1",
     name: "Wave",
     author: { handle: "bob" },
+    chat: { scope: { group: { is_direct_message: false } } },
     wave: {},
   } as any;
 
@@ -51,5 +56,45 @@ describe("WaveHeaderName", () => {
       />
     );
     expect(screen.queryByTestId("edit")).toBeNull();
+  });
+
+  it("shows subwave context with parent link", () => {
+    (canEditWave as jest.Mock).mockReturnValue(false);
+    render(
+      <WaveHeaderName
+        wave={{
+          ...wave,
+          name: "Child Wave",
+          parent_wave: { id: "parent-wave", name: "Parent Wave" },
+        }}
+      />
+    );
+
+    const hierarchy = screen.getByRole("navigation", {
+      name: "Wave hierarchy",
+    });
+    expect(hierarchy).toBeInTheDocument();
+    expect(hierarchy).toHaveTextContent(/Subwave of\s*Parent Wave/);
+    expect(screen.getByText("Subwave of")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Parent Wave" })).toHaveAttribute(
+      "href",
+      "/waves/parent-wave"
+    );
+    expect(screen.getAllByText("Child Wave")).toHaveLength(1);
+    expect(screen.getByRole("link", { name: "Child Wave" })).toHaveAttribute(
+      "href",
+      "/waves/w1"
+    );
+  });
+
+  it("hides subwave hierarchy for root waves", () => {
+    (canEditWave as jest.Mock).mockReturnValue(false);
+    render(<WaveHeaderName wave={wave} />);
+
+    expect(
+      screen.queryByRole("navigation", { name: "Wave hierarchy" })
+    ).toBeNull();
+    expect(screen.queryByText("Subwave of")).toBeNull();
+    expect(screen.queryByText("Parent Wave")).toBeNull();
   });
 });

--- a/__tests__/components/waves/header/name/WaveHeaderName.test.tsx
+++ b/__tests__/components/waves/header/name/WaveHeaderName.test.tsx
@@ -16,7 +16,10 @@ jest.mock(
   () => (props: any) => <div data-testid="edit" />
 );
 
-jest.mock("@/helpers/waves/waves.helpers", () => ({ canEditWave: jest.fn() }));
+jest.mock("@/helpers/waves/waves.helpers", () => ({
+  ...jest.requireActual("@/helpers/waves/waves.helpers"),
+  canEditWave: jest.fn(),
+}));
 
 const { canEditWave } = require("@/helpers/waves/waves.helpers");
 

--- a/__tests__/components/waves/specs/WaveSpecs.test.tsx
+++ b/__tests__/components/waves/specs/WaveSpecs.test.tsx
@@ -6,6 +6,14 @@ import { ApiWaveParticipationSubmissionStrategyType } from "@/generated/models/A
 import { ApiWaveType } from "@/generated/models/ApiWaveType";
 import { render, screen } from "@testing-library/react";
 
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
 jest.mock("@/components/waves/specs/WaveTypeIcon", () => () => (
   <div data-testid="wave-type-icon" />
 ));
@@ -21,6 +29,7 @@ const makeWave = (
     readonly waveType?: ApiWaveType | undefined;
     readonly creditScope?: ApiWaveCreditScope | undefined;
     readonly submissionStrategy?: any;
+    readonly parentWave?: { readonly id: string; readonly name?: string };
   } = {}
 ): any => ({
   id: "wave-1",
@@ -69,6 +78,7 @@ const makeWave = (
     authenticated_user_eligible_for_admin: false,
   },
   metrics: { your_participation_drops_count: 0 },
+  parent_wave: overrides.parentWave,
 });
 
 describe("WaveSpecs", () => {
@@ -108,6 +118,28 @@ describe("WaveSpecs", () => {
 
     expect(screen.getByText("Voting power")).toBeInTheDocument();
     expect(screen.getByText("Each drop")).toBeInTheDocument();
+  });
+
+  it("shows linked parent wave row for subwaves", () => {
+    render(
+      <WaveSpecs
+        wave={makeWave({
+          parentWave: { id: "parent-wave", name: "Parent Wave" },
+        })}
+      />
+    );
+
+    expect(screen.getByText("Parent wave")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Parent Wave" })).toHaveAttribute(
+      "href",
+      "/waves/parent-wave"
+    );
+  });
+
+  it("hides parent wave row for root waves", () => {
+    render(<WaveSpecs wave={makeWave()} />);
+
+    expect(screen.queryByText("Parent wave")).toBeNull();
   });
 
   it("keeps approve edit settings out of overview", () => {

--- a/components/waves/header/WaveHeader.tsx
+++ b/components/waves/header/WaveHeader.tsx
@@ -62,6 +62,7 @@ export default function WaveHeader({
     !isSubwave &&
     wave.wave.authenticated_user_eligible_for_admin === true;
   const showOptions = showOwnerOptions || showCreateSubwaveOption;
+  const titleActionAlignmentClass = isSubwave ? "tw-mt-[22px]" : "";
 
   return (
     <div
@@ -144,7 +145,9 @@ export default function WaveHeader({
             <WaveHeaderName wave={wave} />
           </div>
           {(showOptions || !isSubwave) && (
-            <div className="tw-flex tw-shrink-0 tw-items-center tw-justify-end tw-gap-1.5">
+            <div
+              className={`tw-flex tw-shrink-0 tw-items-center tw-justify-end tw-gap-1.5 ${titleActionAlignmentClass}`}
+            >
               {showOptions && (
                 <WaveHeaderOptions
                   wave={wave}

--- a/components/waves/header/name/WaveHeaderName.tsx
+++ b/components/waves/header/name/WaveHeaderName.tsx
@@ -5,19 +5,8 @@ import type { ApiWave } from "@/generated/models/ApiWave";
 import { useContext } from "react";
 import { AuthContext } from "@/components/auth/Auth";
 import WaveHeaderNameEdit from "./WaveHeaderNameEdit";
-import { canEditWave } from "@/helpers/waves/waves.helpers";
+import { canEditWave, getParentWaveName } from "@/helpers/waves/waves.helpers";
 import { getWavePathRoute } from "@/helpers/navigation.helpers";
-
-function getParentWaveName(
-  parentWave: ApiWave["parent_wave"]
-): string | undefined {
-  if (!parentWave) {
-    return undefined;
-  }
-
-  const trimmedName = parentWave.name.trim();
-  return trimmedName.length > 0 ? trimmedName : parentWave.id;
-}
 
 export default function WaveHeaderName({ wave }: { readonly wave: ApiWave }) {
   const { connectedProfile, activeProfileProxy } = useContext(AuthContext);

--- a/components/waves/header/name/WaveHeaderName.tsx
+++ b/components/waves/header/name/WaveHeaderName.tsx
@@ -8,28 +8,59 @@ import WaveHeaderNameEdit from "./WaveHeaderNameEdit";
 import { canEditWave } from "@/helpers/waves/waves.helpers";
 import { getWavePathRoute } from "@/helpers/navigation.helpers";
 
+function getParentWaveName(
+  parentWave: ApiWave["parent_wave"]
+): string | undefined {
+  if (!parentWave) {
+    return undefined;
+  }
+
+  const trimmedName = parentWave.name.trim();
+  return trimmedName.length > 0 ? trimmedName : parentWave.id;
+}
+
 export default function WaveHeaderName({ wave }: { readonly wave: ApiWave }) {
   const { connectedProfile, activeProfileProxy } = useContext(AuthContext);
   const isDirectMessage = wave.chat.scope.group?.is_direct_message ?? false;
+  const parentWave = wave.parent_wave;
+  const parentWaveName = getParentWaveName(parentWave);
   const showEdit =
     !isDirectMessage &&
     canEditWave({ connectedProfile, activeProfileProxy, wave });
 
   return (
-    <div className="tw-group tw-flex tw-min-w-0 tw-items-start tw-space-x-2">
-      <Link
-        href={getWavePathRoute(wave.id)}
-        className="tw-min-w-0 tw-no-underline"
-      >
-        <h1 className="tw-mb-0 tw-text-lg tw-font-semibold tw-leading-normal tw-tracking-tight tw-text-iron-50 tw-transition tw-duration-300 tw-ease-out desktop-hover:group-hover:tw-text-iron-400">
-          {wave.name}
-        </h1>
-      </Link>
-      {showEdit && (
-        <div className="tw-mt-[7px] tw-size-4 tw-shrink-0">
-          <WaveHeaderNameEdit wave={wave} />
-        </div>
+    <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-y-1">
+      {parentWave && parentWaveName && (
+        <nav
+          aria-label="Wave hierarchy"
+          className="tw-flex tw-min-w-0 tw-items-center tw-gap-x-1.5 tw-text-xs tw-leading-5"
+        >
+          <span className="tw-shrink-0 tw-font-medium tw-text-iron-400">
+            Subwave of
+          </span>
+          <Link
+            href={getWavePathRoute(parentWave.id)}
+            className="tw-block tw-min-w-0 tw-max-w-[50%] tw-shrink tw-truncate tw-font-medium tw-text-iron-300 tw-no-underline tw-transition tw-duration-200 tw-ease-out hover:tw-text-iron-100 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950"
+          >
+            {parentWaveName}
+          </Link>
+        </nav>
       )}
+      <div className="tw-group tw-flex tw-min-w-0 tw-items-start tw-gap-x-2">
+        <Link
+          href={getWavePathRoute(wave.id)}
+          className="tw-block tw-min-w-0 tw-flex-1 tw-no-underline"
+        >
+          <h1 className="tw-mb-0 tw-truncate tw-text-lg tw-font-semibold tw-leading-normal tw-tracking-tight tw-text-iron-50 tw-transition tw-duration-300 tw-ease-out desktop-hover:group-hover:tw-text-iron-400">
+            {wave.name}
+          </h1>
+        </Link>
+        {showEdit && (
+          <div className="tw-mt-[7px] tw-size-4 tw-shrink-0">
+            <WaveHeaderNameEdit wave={wave} />
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/components/waves/specs/WaveSpecs.tsx
+++ b/components/waves/specs/WaveSpecs.tsx
@@ -8,22 +8,12 @@ import WaveTypeIcon from "./WaveTypeIcon";
 import WaveRating from "./WaveRating";
 import { WaveIdentitySubmissionSpecsRows } from "./WaveIdentitySubmissionSpecs";
 import { getWavePathRoute } from "@/helpers/navigation.helpers";
+import { getParentWaveName } from "@/helpers/waves/waves.helpers";
 
 const CREDIT_SCOPE_LABELS: Record<ApiWaveCreditScope, string> = {
   [ApiWaveCreditScope.Wave]: "Whole wave",
   [ApiWaveCreditScope.Drop]: "Each drop",
 };
-
-function getParentWaveName(
-  parentWave: ApiWave["parent_wave"]
-): string | undefined {
-  if (!parentWave) {
-    return undefined;
-  }
-
-  const trimmedName = parentWave.name.trim();
-  return trimmedName.length > 0 ? trimmedName : parentWave.id;
-}
 
 interface WaveSpecsProps {
   readonly wave: ApiWave;

--- a/components/waves/specs/WaveSpecs.tsx
+++ b/components/waves/specs/WaveSpecs.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import type { ApiWave } from "@/generated/models/ApiWave";
 import { ApiWaveCreditType } from "@/generated/models/ApiWaveCreditType";
 import { ApiWaveCreditScope } from "@/generated/models/ApiWaveCreditScope";
@@ -6,11 +7,23 @@ import WaveAuthor from "./WaveAuthor";
 import WaveTypeIcon from "./WaveTypeIcon";
 import WaveRating from "./WaveRating";
 import { WaveIdentitySubmissionSpecsRows } from "./WaveIdentitySubmissionSpecs";
+import { getWavePathRoute } from "@/helpers/navigation.helpers";
 
 const CREDIT_SCOPE_LABELS: Record<ApiWaveCreditScope, string> = {
   [ApiWaveCreditScope.Wave]: "Whole wave",
   [ApiWaveCreditScope.Drop]: "Each drop",
 };
+
+function getParentWaveName(
+  parentWave: ApiWave["parent_wave"]
+): string | undefined {
+  if (!parentWave) {
+    return undefined;
+  }
+
+  const trimmedName = parentWave.name.trim();
+  return trimmedName.length > 0 ? trimmedName : parentWave.id;
+}
 
 interface WaveSpecsProps {
   readonly wave: ApiWave;
@@ -22,10 +35,7 @@ export default function WaveSpecs({ wave, useRing = true }: WaveSpecsProps) {
     ? "tw-ring-1 tw-ring-inset tw-ring-iron-800 tw-rounded-xl"
     : "";
   const isChatWave = wave.wave.type === ApiWaveType.Chat;
-  const creditScope = wave.voting.credit_scope ?? ApiWaveCreditScope.Wave;
-  const creditScopeLabel =
-    CREDIT_SCOPE_LABELS[creditScope] ??
-    CREDIT_SCOPE_LABELS[ApiWaveCreditScope.Wave];
+  const creditScopeLabel = CREDIT_SCOPE_LABELS[wave.voting.credit_scope];
   const hasVotingDetails =
     wave.voting.credit_type === ApiWaveCreditType.CardSetTdh ||
     !!wave.voting.credit_category ||
@@ -33,6 +43,8 @@ export default function WaveSpecs({ wave, useRing = true }: WaveSpecsProps) {
   const votingRowAlignmentClass = hasVotingDetails
     ? "tw-items-start"
     : "tw-items-center";
+  const parentWave = wave.parent_wave;
+  const parentWaveName = getParentWaveName(parentWave);
 
   return (
     <div
@@ -52,6 +64,20 @@ export default function WaveSpecs({ wave, useRing = true }: WaveSpecsProps) {
               <WaveTypeIcon waveType={wave.wave.type} />
             </div>
           </div>
+
+          {parentWave && parentWaveName && (
+            <div className="tw-group tw-flex tw-min-h-8 tw-w-full tw-items-center tw-justify-between tw-gap-2 tw-px-2 tw-py-1 tw-text-sm">
+              <span className="tw-shrink-0 tw-font-normal tw-text-iron-500">
+                Parent wave
+              </span>
+              <Link
+                href={getWavePathRoute(parentWave.id)}
+                className="tw-block tw-min-w-0 tw-truncate tw-text-right tw-font-medium tw-text-iron-50 tw-no-underline tw-transition tw-duration-200 tw-ease-out hover:tw-text-iron-300 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950"
+              >
+                {parentWaveName}
+              </Link>
+            </div>
+          )}
 
           {!isChatWave && (
             <>

--- a/helpers/waves/waves.helpers.ts
+++ b/helpers/waves/waves.helpers.ts
@@ -22,6 +22,17 @@ export const getCreateWaveStepStatus = ({
   return CreateWaveStepStatus.PENDING;
 };
 
+export const getParentWaveName = (
+  parentWave: ApiWave["parent_wave"]
+): string | undefined => {
+  if (!parentWave) {
+    return undefined;
+  }
+
+  const trimmedName = parentWave.name.trim();
+  return trimmedName.length > 0 ? trimmedName : parentWave.id;
+};
+
 const getPeriodUpdate = <T>(
   period: T | null | undefined
 ): Partial<{ readonly period: T }> => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wave hierarchy navigation for subwaves, including a “Parent wave” row in wave specs and “Subwave of …” info in the wave header.
* **Bug Fixes**
  * Credit scope label now reflects the actual voting credit scope instead of defaulting to “whole wave” when it’s not present.
* **Style**
  * Improved header right-side action vertical alignment for subwaves.
* **Tests**
  * Updated and expanded component tests to cover the new parent/subwave UI and link rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->