### PR TITLE
Add all-waves link to profile wave previews

### DIFF
--- a/__tests__/components/user/brain/UserPageBrainSidebar.test.tsx
+++ b/__tests__/components/user/brain/UserPageBrainSidebar.test.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import UserPageBrainSidebar from "@/components/user/brain/UserPageBrainSidebar";
 import { useFavouriteWavesOfIdentity } from "@/hooks/useFavouriteWavesOfIdentity";
@@ -5,9 +6,8 @@ import { useWaves } from "@/hooks/useWaves";
 
 jest.mock("next/image", () => ({
   __esModule: true,
-  default: ({ alt, fill, unoptimized, ...props }: any) => (
-    <img alt={alt ?? ""} {...props} />
-  ),
+  default: ({ alt, fill, unoptimized, ...props }: any) =>
+    React.createElement("img", { alt: alt ?? "", ...props }),
 }));
 jest.mock("next/link", () => ({
   __esModule: true,
@@ -245,6 +245,7 @@ describe("UserPageBrainSidebar", () => {
   });
 
   it("expands and collapses the created waves list", () => {
+    const hiddenWaveName = "Hidden Wave";
     mockedUseWaves.mockReturnValue({
       waves: [
         makeWave(),
@@ -254,6 +255,24 @@ describe("UserPageBrainSidebar", () => {
           metrics: {
             drops_count: 8,
             subscribers_count: 10,
+            latest_drop_timestamp: Date.now(),
+          },
+        }),
+        makeWave({
+          id: "wave-3",
+          name: "Elsewhere Event",
+          metrics: {
+            drops_count: 14,
+            subscribers_count: 18,
+            latest_drop_timestamp: Date.now(),
+          },
+        }),
+        makeWave({
+          id: "wave-4",
+          name: hiddenWaveName,
+          metrics: {
+            drops_count: 3,
+            subscribers_count: 4,
             latest_drop_timestamp: Date.now(),
           },
         }),
@@ -271,16 +290,28 @@ describe("UserPageBrainSidebar", () => {
     const desktopSidebar = screen.getByTestId("brain-sidebar-desktop");
 
     expect(within(desktopSidebar).getByText("Show 1 more")).toBeInTheDocument();
-    expect(within(desktopSidebar).queryByText("Meme Card Curation")).toBeNull();
+    expect(
+      within(desktopSidebar).getByText("Meme Card Curation")
+    ).toBeInTheDocument();
+    expect(
+      within(desktopSidebar).getByText("Elsewhere Event")
+    ).toBeInTheDocument();
+    expect(within(desktopSidebar).queryByText(hiddenWaveName)).toBeNull();
 
     fireEvent.click(within(desktopSidebar).getByText("Show 1 more"));
     expect(
-      within(desktopSidebar).getByText("Meme Card Curation")
+      within(desktopSidebar).getByText(hiddenWaveName)
     ).toBeInTheDocument();
     expect(within(desktopSidebar).getByText("Show less")).toBeInTheDocument();
 
     fireEvent.click(within(desktopSidebar).getByText("Show less"));
-    expect(within(desktopSidebar).queryByText("Meme Card Curation")).toBeNull();
+    expect(within(desktopSidebar).queryByText(hiddenWaveName)).toBeNull();
+    expect(
+      within(desktopSidebar).getByText("Meme Card Curation")
+    ).toBeInTheDocument();
+    expect(
+      within(desktopSidebar).getByText("Elsewhere Event")
+    ).toBeInTheDocument();
   });
 
   it("opens the created waves modal from the compact strip overflow chip", () => {

--- a/__tests__/components/waves/drops/CurationWavePreviewCard.test.tsx
+++ b/__tests__/components/waves/drops/CurationWavePreviewCard.test.tsx
@@ -58,7 +58,9 @@ jest.mock("@fortawesome/react-fontawesome", () => ({
 }));
 
 jest.mock("@heroicons/react/24/outline", () => ({
-  ArrowRightIcon: () => <span aria-hidden="true" />,
+  ArrowRightIcon: () => (
+    <span aria-hidden="true" data-testid="arrow-right-icon" />
+  ),
   LinkIcon: () => <span aria-hidden="true" />,
   PlayIcon: () => <span aria-hidden="true" data-testid="video-play-icon" />,
 }));
@@ -245,15 +247,21 @@ describe("CurationWavePreviewCard", () => {
       "https://example.com/wave.png",
       ImageScale.W_AUTO_H_50
     );
-    expect(screen.getByRole("link", { name: /open wave/i })).toBeVisible();
+    expect(
+      screen.queryByText("Profile wave", { selector: "span" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Open profile wave" })
+    ).toBeVisible();
   });
 
-  it("links to the profile brain view for other waves", () => {
+  it("links to the profile brain view for other waves without another arrow", () => {
     render(<CurationWavePreviewCard waveId="wave-1" profileIdentity="alice" />);
 
     expect(
       screen.getByRole("link", { name: "Show all waves" })
     ).toHaveAttribute("href", "/alice/brain");
+    expect(screen.getAllByTestId("arrow-right-icon")).toHaveLength(1);
   });
 
   it("omits the all-waves link without a profile identity", () => {

--- a/__tests__/components/waves/drops/CurationWavePreviewCard.test.tsx
+++ b/__tests__/components/waves/drops/CurationWavePreviewCard.test.tsx
@@ -35,15 +35,14 @@ jest.mock("@/components/common/FallbackImage", () => ({
     readonly alt: string;
     readonly fallbackSrc: string;
     readonly primarySrc: string;
-  }) => (
-    <img
-      alt={alt}
-      src={primarySrc || fallbackSrc}
-      data-testid="fallback-image"
-      data-fallback-src={fallbackSrc}
-      data-primary-src={primarySrc}
-    />
-  ),
+  }) =>
+    React.createElement("img", {
+      alt,
+      src: primarySrc || fallbackSrc,
+      "data-testid": "fallback-image",
+      "data-fallback-src": fallbackSrc,
+      "data-primary-src": primarySrc,
+    }),
 }));
 
 jest.mock("@/helpers/image.helpers", () => ({
@@ -247,6 +246,22 @@ describe("CurationWavePreviewCard", () => {
       ImageScale.W_AUTO_H_50
     );
     expect(screen.getByRole("link", { name: /open wave/i })).toBeVisible();
+  });
+
+  it("links to the profile brain view for other waves", () => {
+    render(<CurationWavePreviewCard waveId="wave-1" profileIdentity="alice" />);
+
+    expect(
+      screen.getByRole("link", { name: "Show all waves" })
+    ).toHaveAttribute("href", "/alice/brain");
+  });
+
+  it("omits the all-waves link without a profile identity", () => {
+    render(<CurationWavePreviewCard waveId="wave-1" />);
+
+    expect(
+      screen.queryByRole("link", { name: "Show all waves" })
+    ).not.toBeInTheDocument();
   });
 
   it("renders image preview media as an image tile", () => {

--- a/components/user/brain/UserPageBrainSidebarCreated.tsx
+++ b/components/user/brain/UserPageBrainSidebarCreated.tsx
@@ -5,6 +5,8 @@ import { useState } from "react";
 import type { ApiWave } from "@/generated/models/ApiWave";
 import UserPageBrainSidebarWaveItem from "./UserPageBrainSidebarWaveItem";
 
+const DEFAULT_VISIBLE_CREATED_WAVES = 3;
+
 interface UserPageBrainSidebarCreatedProps {
   readonly identity: string;
   readonly waves: ApiWave[];
@@ -18,8 +20,13 @@ export default function UserPageBrainSidebarCreated({
 }: UserPageBrainSidebarCreatedProps) {
   const [expandedIdentity, setExpandedIdentity] = useState<string | null>(null);
   const showAllWaves = expandedIdentity === identity;
-  const visibleWaves = showAllWaves ? waves : waves.slice(0, 1);
-  const remainingWavesCount = Math.max(waves.length - 1, 0);
+  const visibleWaves = showAllWaves
+    ? waves
+    : waves.slice(0, DEFAULT_VISIBLE_CREATED_WAVES);
+  const remainingWavesCount = Math.max(
+    waves.length - DEFAULT_VISIBLE_CREATED_WAVES,
+    0
+  );
   const showMoreLabel =
     remainingWavesCount === 1
       ? "Show 1 more"
@@ -59,7 +66,7 @@ export default function UserPageBrainSidebarCreated({
             {visibleWaves.map((wave) => (
               <UserPageBrainSidebarWaveItem key={wave.id} wave={wave} />
             ))}
-            {waves.length > 1 && (
+            {waves.length > DEFAULT_VISIBLE_CREATED_WAVES && (
               <button
                 type="button"
                 onClick={() =>

--- a/components/waves/drops/CurationWavePreviewCard.tsx
+++ b/components/waves/drops/CurationWavePreviewCard.tsx
@@ -173,6 +173,9 @@ export const CurationWavePreviewCard: React.FC<
   const description = getWaveDescriptionPreviewText(resolvedWave);
   const previewItems = getPreviewItems(drops);
   const waveHref = getWaveHref({ waveId, wave: resolvedWave, curationId });
+  const profileBrainHref = normalizedProfileIdentity
+    ? `/${encodeURIComponent(normalizedProfileIdentity)}/brain`
+    : null;
   const bannerBackground = getBannerBackground({
     banner1: resolvedWave?.author.banner1_color,
     banner2: resolvedWave?.author.banner2_color,
@@ -249,7 +252,7 @@ export const CurationWavePreviewCard: React.FC<
         />
       </CurationPreviewBody>
 
-      <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/[0.06] tw-px-5 tw-py-3">
+      <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-x-4 tw-gap-y-2 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/[0.06] tw-px-5 tw-py-3">
         <Link
           href={waveHref}
           prefetch={false}
@@ -261,6 +264,19 @@ export const CurationWavePreviewCard: React.FC<
             aria-hidden="true"
           />
         </Link>
+        {profileBrainHref && (
+          <Link
+            href={profileBrainHref}
+            prefetch={false}
+            className="tw-group/show-all-waves tw-inline-flex tw-items-center tw-gap-1.5 tw-text-[13px] tw-font-semibold tw-text-iron-300 tw-no-underline tw-transition-colors tw-duration-300 desktop-hover:hover:tw-text-iron-100"
+          >
+            Show all waves
+            <ArrowRightIcon
+              className="tw-h-3.5 tw-w-3.5 tw-transition-transform tw-duration-300 tw-ease-out desktop-hover:group-hover/show-all-waves:tw-translate-x-0.5"
+              aria-hidden="true"
+            />
+          </Link>
+        )}
       </div>
     </CurationPreviewShell>
   );

--- a/components/waves/drops/CurationWavePreviewCard.tsx
+++ b/components/waves/drops/CurationWavePreviewCard.tsx
@@ -258,7 +258,7 @@ export const CurationWavePreviewCard: React.FC<
           prefetch={false}
           className="tw-group/open-wave tw-inline-flex tw-items-center tw-gap-1.5 tw-text-[13px] tw-font-bold tw-text-primary-400 tw-no-underline tw-transition-colors tw-duration-300 desktop-hover:hover:tw-text-primary-300"
         >
-          Open wave
+          Open profile wave
           <ArrowRightIcon
             className="tw-h-3.5 tw-w-3.5 tw-transition-transform tw-duration-300 tw-ease-out desktop-hover:group-hover/open-wave:tw-translate-x-0.5"
             aria-hidden="true"
@@ -268,13 +268,9 @@ export const CurationWavePreviewCard: React.FC<
           <Link
             href={profileBrainHref}
             prefetch={false}
-            className="tw-group/show-all-waves tw-inline-flex tw-items-center tw-gap-1.5 tw-text-[13px] tw-font-semibold tw-text-iron-300 tw-no-underline tw-transition-colors tw-duration-300 desktop-hover:hover:tw-text-iron-100"
+            className="tw-inline-flex tw-items-center tw-text-[13px] tw-font-semibold tw-text-iron-300 tw-no-underline tw-decoration-iron-500/70 tw-underline-offset-4 tw-transition-colors tw-duration-300 desktop-hover:hover:tw-text-iron-100 desktop-hover:hover:tw-underline"
           >
             Show all waves
-            <ArrowRightIcon
-              className="tw-h-3.5 tw-w-3.5 tw-transition-transform tw-duration-300 tw-ease-out desktop-hover:group-hover/show-all-waves:tw-translate-x-0.5"
-              aria-hidden="true"
-            />
           </Link>
         )}
       </div>

--- a/ops/docs/profiles/tabs/feature-brain-wave-sidebar.md
+++ b/ops/docs/profiles/tabs/feature-brain-wave-sidebar.md
@@ -28,8 +28,8 @@ created, or into the waves where that profile is most active.
 2. If created-wave or most-active wave data is available, the companion surface
    appears beside or above the feed.
 3. Desktop shows:
-   - `Created Waves`: the first created wave plus a `Show N more` toggle when
-     more created waves exist
+   - `Created Waves`: up to three created waves plus a `Show N more` toggle
+     when more created waves exist
    - `Most Active In`: up to three waves
 4. Small screens show `Created` and `Active In` pill rows above the feed.
 5. If more created waves exist on small screens, select the overflow chip to
@@ -74,8 +74,8 @@ created, or into the waves where that profile is most active.
 
 ## Limitations / Notes
 
-- Desktop inline created-waves view shows only one item until expanded, even
-  when more authored waves exist.
+- Desktop inline created-waves view shows up to three items until expanded,
+  even when more authored waves exist.
 - The mobile strip surfaces only the first created wave inline, plus up to
   three `Most Active In` items.
 - The full modal lists created waves only; it does not provide a full-screen

--- a/ops/docs/waves/drop-actions/feature-wave-creator-badge.md
+++ b/ops/docs/waves/drop-actions/feature-wave-creator-badge.md
@@ -9,7 +9,9 @@ as a square profile-wave picture badge.
 Selecting the compact water-drop button opens the shared created-waves viewer
 (`Waves by {profile}`), so users can jump into waves that author created.
 Selecting the chat-feed profile-wave badge opens that author's profile wave
-directly.
+directly. The profile-wave preview keeps `Open wave` as the primary action and
+adds `Show all waves` as a secondary path to the author's `/{user}/brain`
+surface, where their other created and active waves are discoverable.
 
 ## Location in the Site
 
@@ -28,7 +30,8 @@ directly.
   author-status badges.
 - Select the water-drop button, or the profile-wave badge in the chat feed.
 - On non-mobile layouts, hover tooltip text is `View created waves` for the
-  compact button and `{wave}` for the chat-feed profile-wave badge.
+  compact button and `{wave}` for the chat-feed profile-wave badge; the
+  profile-wave hover card includes `Open wave` and `Show all waves` links.
 
 ## User Journey
 
@@ -37,11 +40,11 @@ directly.
 2. If the author is a wave creator, the water-drop badge or profile-wave badge
    appears in the author identity row.
 3. Select the badge.
-4. The shared `Waves by {profile}` viewer opens, or the profile wave opens
-   directly from the chat-feed badge.
+4. The shared `Waves by {profile}` viewer opens, or the profile-wave preview
+   lets the user open the featured wave or select `Show all waves`.
 5. If the viewer opened, review created-wave rows, then select a row to open
-   that wave at `/waves/{waveId}`; if the profile wave opened directly, skip
-   this step.
+   that wave at `/waves/{waveId}`. If `Show all waves` is selected, the profile
+   Brain tab opens at `/{user}/brain`.
 
 ## Common Scenarios
 
@@ -50,6 +53,8 @@ directly.
   instead of forcing horizontal overflow.
 - The opened viewer uses the same created-waves surface as the Profile Brain
   tab overflow flow.
+- The profile-wave preview deprioritizes non-promoted waves by linking to the
+  profile Brain tab instead of listing every wave in the preview card.
 - Viewer rows show a wave picture when available, otherwise a wave/chat icon
   fallback.
 - Viewer title uses the profile handle when available, or a shortened wallet

--- a/ops/docs/waves/drop-actions/feature-wave-creator-badge.md
+++ b/ops/docs/waves/drop-actions/feature-wave-creator-badge.md
@@ -8,9 +8,9 @@ as a square profile-wave picture badge.
 
 Selecting the compact water-drop button opens the shared created-waves viewer
 (`Waves by {profile}`), so users can jump into waves that author created.
-Selecting the chat-feed profile-wave badge opens that author's profile wave
-directly. The profile-wave preview keeps `Open wave` as the primary action and
-adds `Show all waves` as a secondary path to the author's `/{user}/brain`
+Selecting the chat-feed profile-wave badge opens that author's profile-wave
+preview. The preview keeps `Open profile wave` as the primary action and adds
+`Show all waves` as a quieter secondary path to the author's `/{user}/brain`
 surface, where their other created and active waves are discoverable.
 
 ## Location in the Site
@@ -31,7 +31,8 @@ surface, where their other created and active waves are discoverable.
 - Select the water-drop button, or the profile-wave badge in the chat feed.
 - On non-mobile layouts, hover tooltip text is `View created waves` for the
   compact button and `{wave}` for the chat-feed profile-wave badge; the
-  profile-wave hover card includes `Open wave` and `Show all waves` links.
+  profile-wave hover card includes `Open profile wave` and `Show all waves`
+  links.
 
 ## User Journey
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a secondary **“Show all waves”** link to wave preview cards, routing users to the author’s full waves in the brain tab.
  * Updated the primary action label to **“Open profile wave”** and improved the layout for multiple actions.
* **Improvements**
  * Increased the default number of created waves shown in the brain sidebar to **up to three** before expanding.
* **Documentation**
  * Refreshed wave creator/profile preview flow docs and sidebar behavior wording.
* **Tests**
  * Expanded and adjusted UI test coverage for links and created-wave expansion/collapse behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->