### PR TITLE
[codex] Harden staging deploy checkout

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -215,6 +215,10 @@ jobs:
             exit 1
           fi
 
+          echo "Resetting deploy checkout before switching to $BRANCH"
+          git reset --hard HEAD
+          git clean -fd generated
+
           git checkout -B "$BRANCH" FETCH_HEAD
           git config "branch.$BRANCH.remote" origin
           git config "branch.$BRANCH.merge" "refs/heads/$BRANCH"


### PR DESCRIPTION
## Summary
- reset tracked deploy-time changes before switching the staging checkout to the expected ref
- clean generated leftovers that can block checkout on the staging EC2 worktree

## Validation
- git diff --check

Reason: staging deploy for d05a21d6 failed because generated model files were dirty on the staging instance before checkout.