### PR TITLE
Improve 6529 OpenGraph previews

### DIFF
--- a/__tests__/components/waves/LinkPreviewCard.test.tsx
+++ b/__tests__/components/waves/LinkPreviewCard.test.tsx
@@ -49,6 +49,18 @@ describe("LinkPreviewCard", () => {
     );
     return frame;
   };
+  const assertFirstPartyFrame = () => {
+    const frame = screen.getByTestId("link-preview-card-stable-frame");
+    expect(frame).toHaveClass(
+      "tw-h-[15rem]",
+      "tw-min-h-[15rem]",
+      "tw-max-h-[15rem]",
+      "lg:tw-h-[11rem]",
+      "lg:tw-min-h-[11rem]",
+      "lg:tw-max-h-[11rem]"
+    );
+    return frame;
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -122,6 +134,37 @@ describe("LinkPreviewCard", () => {
       expect(screen.getByTestId("fallback")).toBeInTheDocument();
     });
     assertStableFrame();
+  });
+
+  it("uses the richer chat frame for generated first-party previews", async () => {
+    fetchLinkPreview.mockResolvedValue({
+      title: "punk6529bot",
+      description: "Identity | 6529.io",
+      image: {
+        url: "https://6529.io/api/og-metadata/profiles/punk6529bot",
+      },
+      siteName: "6529.io",
+    });
+
+    render(
+      <LinkPreviewCard
+        href="https://6529.io/punk6529bot"
+        renderFallback={() => <div data-testid="fallback">fallback</div>}
+      />
+    );
+
+    assertStableFrame();
+
+    await waitFor(() =>
+      expect(mockOpenGraphPreview).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          href: "https://6529.io/punk6529bot",
+          preview: expect.objectContaining({ title: "punk6529bot" }),
+        })
+      )
+    );
+
+    assertFirstPartyFrame();
   });
 
   it("renders ENS previews when ENS data is returned", async () => {

--- a/__tests__/components/waves/OpenGraphPreview.test.tsx
+++ b/__tests__/components/waves/OpenGraphPreview.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 
-import OpenGraphPreview from "@/components/waves/OpenGraphPreview";
+import OpenGraphPreview, {
+  getFirstPartyOpenGraphPreviewKind,
+} from "@/components/waves/OpenGraphPreview";
 
 jest.mock("next/link", () => ({
   __esModule: true,
@@ -139,6 +141,72 @@ describe("OpenGraphPreview", () => {
     expect(image.parentElement).not.toHaveClass("tw-aspect-[16/9]");
     expect(screen.getByText("An example description")).toBeInTheDocument();
     expect(screen.getByTestId("href-buttons")).toHaveTextContent("/article");
+  });
+
+  it("preserves generated 6529 profile cards instead of cropping them", () => {
+    (removeBaseEndpoint as jest.Mock).mockReturnValue("/punk6529bot");
+
+    render(
+      <OpenGraphPreview
+        href="https://6529.io/punk6529bot"
+        preview={{
+          title: "punk6529bot",
+          description: "Identity | 6529.io",
+          siteName: "6529.io",
+          image: {
+            url: "https://6529.io/api/og-metadata/profiles/punk6529bot",
+          },
+        }}
+      />
+    );
+
+    const card = screen.getByTestId("og-preview-card");
+    expect(card).toHaveAttribute("data-og-kind", "profile");
+    expect(screen.getByText("Profile")).toBeInTheDocument();
+
+    const mediaLink = screen.getAllByRole("link", {
+      name: "punk6529bot",
+    })[0];
+    expect(mediaLink).toHaveClass(
+      "tw-h-28",
+      "lg:tw-h-full",
+      "lg:tw-w-72",
+      "xl:tw-w-80"
+    );
+
+    const image = screen.getByAltText("punk6529bot");
+    expect(image).toHaveAttribute(
+      "src",
+      "https://6529.io/api/og-metadata/profiles/punk6529bot"
+    );
+    expect(image).toHaveClass("tw-object-contain");
+    expect(image).toHaveAttribute(
+      "sizes",
+      "(max-width: 640px) 100vw, (max-width: 768px) 14rem, (max-width: 1024px) 18rem, 20rem"
+    );
+  });
+
+  it("identifies generated first-party OpenGraph metadata", () => {
+    expect(
+      getFirstPartyOpenGraphPreviewKind({
+        image: "https://6529.io/api/og-metadata/profiles/punk6529",
+      })
+    ).toBe("profile");
+    expect(
+      getFirstPartyOpenGraphPreviewKind({
+        image: "https://staging.6529.io/api/og-metadata/drops/123",
+      })
+    ).toBe("drop");
+    expect(
+      getFirstPartyOpenGraphPreviewKind({
+        image: "https://6529.io/api/og-metadata/waves/wave-id",
+      })
+    ).toBe("wave");
+    expect(
+      getFirstPartyOpenGraphPreviewKind({
+        image: "https://example.com/preview.png",
+      })
+    ).toBeNull();
   });
 
   it("handles external links and image arrays", () => {

--- a/__tests__/components/waves/OpenGraphPreview.test.tsx
+++ b/__tests__/components/waves/OpenGraphPreview.test.tsx
@@ -207,6 +207,11 @@ describe("OpenGraphPreview", () => {
         image: "https://example.com/preview.png",
       })
     ).toBeNull();
+    expect(
+      getFirstPartyOpenGraphPreviewKind({
+        image: "https://evil.example.com/api/og-metadata/profiles/x",
+      })
+    ).toBeNull();
   });
 
   it("handles external links and image arrays", () => {

--- a/components/waves/LinkPreviewCard.tsx
+++ b/components/waves/LinkPreviewCard.tsx
@@ -3,6 +3,7 @@
 import { type ReactElement, useEffect, useState } from "react";
 
 import OpenGraphPreview, {
+  getFirstPartyOpenGraphPreviewKind,
   hasOpenGraphContent,
   LinkPreviewCardLayout,
   type OpenGraphPreviewData,
@@ -33,6 +34,8 @@ type PreviewState =
 
 const CHAT_STABLE_FRAME_CLASSES =
   "tw-h-[10rem] tw-min-h-[10rem] tw-max-h-[10rem] tw-w-full md:tw-h-[11rem] md:tw-min-h-[11rem] md:tw-max-h-[11rem]";
+const CHAT_FIRST_PARTY_FRAME_CLASSES =
+  "tw-h-[15rem] tw-min-h-[15rem] tw-max-h-[15rem] tw-w-full lg:tw-h-[11rem] lg:tw-min-h-[11rem] lg:tw-max-h-[11rem]";
 
 const toPreviewData = (
   response: Awaited<ReturnType<typeof fetchLinkPreview>>
@@ -156,9 +159,16 @@ export default function LinkPreviewCard({
     return content;
   }
 
+  const stableFrameClasses =
+    isCurrent &&
+    state.type === "success" &&
+    getFirstPartyOpenGraphPreviewKind(state.data)
+      ? CHAT_FIRST_PARTY_FRAME_CLASSES
+      : CHAT_STABLE_FRAME_CLASSES;
+
   return (
     <div
-      className={CHAT_STABLE_FRAME_CLASSES}
+      className={stableFrameClasses}
       data-testid="link-preview-card-stable-frame"
     >
       {content}

--- a/components/waves/OpenGraphPreview.tsx
+++ b/components/waves/OpenGraphPreview.tsx
@@ -77,6 +77,14 @@ const FIRST_PARTY_OG_KIND_LABELS: Record<
   wave: "Wave",
 };
 
+function isFirstParty6529Hostname(hostname: string): boolean {
+  const normalizedHostname = hostname.toLowerCase();
+  return (
+    normalizedHostname === "6529.io" ||
+    normalizedHostname.endsWith(".6529.io")
+  );
+}
+
 function readFirstString(
   data: OpenGraphPreviewData | null | undefined,
   keys: readonly string[]
@@ -175,6 +183,9 @@ function getFirstPartyOgKindFromImageUrl(
   }
 
   const pathname = parsed.pathname.toLowerCase();
+  if (!isFirstParty6529Hostname(parsed.hostname)) {
+    return null;
+  }
 
   if (pathname.startsWith("/api/og-metadata/profiles/")) {
     return "profile";
@@ -520,7 +531,7 @@ export default function OpenGraphPreview({
   const domain = deriveDomain(href, preview);
   const githubPreview = extractGithubPreview(preview);
   const hasContent = Boolean(title ?? description ?? imageUrl);
-  const firstPartyKind = getFirstPartyOpenGraphPreviewKind(preview);
+  const firstPartyKind = getFirstPartyOgKindFromImageUrl(imageUrl);
 
   if (imageOnly && imageUrl) {
     return (

--- a/components/waves/OpenGraphPreview.tsx
+++ b/components/waves/OpenGraphPreview.tsx
@@ -66,6 +66,17 @@ const IMAGE_KEYS = [
 const IMAGE_COLLECTION_KEYS = ["images", "ogImages", "og_images", "thumbnails"];
 const LONG_UNBROKEN_SEGMENT_THRESHOLD = 32;
 
+export type FirstPartyOpenGraphPreviewKind = "profile" | "drop" | "wave";
+
+const FIRST_PARTY_OG_KIND_LABELS: Record<
+  FirstPartyOpenGraphPreviewKind,
+  string
+> = {
+  profile: "Profile",
+  drop: "Drop",
+  wave: "Wave",
+};
+
 function readFirstString(
   data: OpenGraphPreviewData | null | undefined,
   keys: readonly string[]
@@ -147,6 +158,43 @@ function extractImageUrl(
   }
 
   return undefined;
+}
+
+function getFirstPartyOgKindFromImageUrl(
+  imageUrl: string | undefined
+): FirstPartyOpenGraphPreviewKind | null {
+  if (!imageUrl) {
+    return null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(imageUrl, "https://6529.io");
+  } catch {
+    return null;
+  }
+
+  const pathname = parsed.pathname.toLowerCase();
+
+  if (pathname.startsWith("/api/og-metadata/profiles/")) {
+    return "profile";
+  }
+
+  if (pathname.startsWith("/api/og-metadata/drops/")) {
+    return "drop";
+  }
+
+  if (pathname.startsWith("/api/og-metadata/waves/")) {
+    return "wave";
+  }
+
+  return null;
+}
+
+export function getFirstPartyOpenGraphPreviewKind(
+  preview: OpenGraphPreviewData | null | undefined
+): FirstPartyOpenGraphPreviewKind | null {
+  return getFirstPartyOgKindFromImageUrl(extractImageUrl(preview));
 }
 
 function wrapLongUnbrokenSegments(value: string | undefined): ReactNode {
@@ -332,6 +380,81 @@ export function hasOpenGraphContent(
   );
 }
 
+function FirstPartyOpenGraphPreviewCard({
+  effectiveHref,
+  linkTarget,
+  linkRel,
+  imageUrl,
+  title,
+  domain,
+  description,
+  kind,
+}: {
+  readonly effectiveHref: string;
+  readonly linkTarget: "_blank" | undefined;
+  readonly linkRel: string | undefined;
+  readonly imageUrl: string;
+  readonly title: string;
+  readonly domain: string | undefined;
+  readonly description: string | undefined;
+  readonly kind: FirstPartyOpenGraphPreviewKind;
+}) {
+  const kindLabel = FIRST_PARTY_OG_KIND_LABELS[kind];
+
+  return (
+    <div
+      className="tw-relative tw-h-full tw-min-h-0 tw-w-full tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/40 tw-p-3 sm:tw-p-4"
+      data-testid="og-preview-card"
+      data-og-kind={kind}>
+      <div className="tw-flex tw-h-full tw-min-h-0 tw-flex-col tw-gap-2 lg:tw-flex-row lg:tw-gap-3">
+        <Link
+          href={effectiveHref}
+          target={linkTarget}
+          rel={linkRel}
+          className="tw-relative tw-block tw-h-28 tw-w-full tw-flex-shrink-0 tw-overflow-hidden tw-rounded-lg tw-bg-black/35 lg:tw-h-full lg:tw-w-72 xl:tw-w-80">
+          {/* Generated 6529 OG images are already complete cards; preserve them. */}
+          <Image
+            src={imageUrl}
+            alt={title}
+            fill
+            className="tw-object-contain"
+            loading="lazy"
+            sizes="(max-width: 640px) 100vw, (max-width: 768px) 14rem, (max-width: 1024px) 18rem, 20rem"
+            unoptimized
+          />
+        </Link>
+
+        <div className="tw-flex tw-min-h-0 tw-min-w-0 tw-flex-1 tw-flex-col tw-justify-center tw-gap-y-1.5 tw-overflow-hidden">
+          <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
+            {domain && (
+              <span className="tw-min-w-0 tw-truncate tw-text-xs tw-font-semibold tw-uppercase tw-tracking-wide tw-text-iron-400">
+                {wrapLongUnbrokenSegments(domain)}
+              </span>
+            )}
+            <span className="tw-flex-shrink-0 tw-rounded-full tw-border tw-border-primary-400/35 tw-bg-primary-400/10 tw-px-2 tw-py-0.5 tw-text-[0.68rem] tw-font-semibold tw-uppercase tw-tracking-wide tw-text-primary-200">
+              {kindLabel}
+            </span>
+          </div>
+
+          <Link
+            href={effectiveHref}
+            target={linkTarget}
+            rel={linkRel}
+            className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-block tw-break-words tw-text-base tw-font-semibold tw-leading-snug tw-text-iron-100 tw-no-underline tw-transition tw-duration-200 hover:tw-text-white">
+            {wrapLongUnbrokenSegments(title)}
+          </Link>
+
+          {description && (
+            <p className="tw-[overflow-wrap:anywhere] tw-m-0 tw-line-clamp-1 tw-whitespace-pre-line tw-break-words tw-text-sm tw-leading-snug tw-text-iron-300 sm:tw-line-clamp-2">
+              {wrapLongUnbrokenSegments(description)}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function OpenGraphPreview({
   href,
   preview,
@@ -397,6 +520,7 @@ export default function OpenGraphPreview({
   const domain = deriveDomain(href, preview);
   const githubPreview = extractGithubPreview(preview);
   const hasContent = Boolean(title ?? description ?? imageUrl);
+  const firstPartyKind = getFirstPartyOpenGraphPreviewKind(preview);
 
   if (imageOnly && imageUrl) {
     return (
@@ -483,6 +607,27 @@ export default function OpenGraphPreview({
             </Link>
           </div>
         </div>
+      </LinkPreviewCardLayout>
+    );
+  }
+
+  if (resolvedVariant !== "home" && imageUrl && firstPartyKind) {
+    return (
+      <LinkPreviewCardLayout
+        href={href}
+        variant={resolvedVariant}
+        hideActions={hideActions}
+      >
+        <FirstPartyOpenGraphPreviewCard
+          effectiveHref={effectiveHref}
+          linkTarget={linkTarget}
+          linkRel={linkRel}
+          imageUrl={imageUrl}
+          title={title ?? domain ?? href}
+          domain={domain}
+          description={description}
+          kind={firstPartyKind}
+        />
       </LinkPreviewCardLayout>
     );
   }


### PR DESCRIPTION
## Summary
- Detect generated first-party 6529 OG images for profiles, drops, and waves.
- Render those previews with a richer card that preserves the generated image instead of cropping it into the generic thumbnail rail.
- Use a taller stacked frame on mobile/tablet and a compact horizontal layout on desktop.
- Add coverage for first-party detection, profile rendering, and async frame sizing.

## Verification
- `pnpm run test:no-coverage -- --runInBand __tests__/components/waves/OpenGraphPreview.test.tsx __tests__/components/waves/LinkPreviewCard.test.tsx`
- `pnpm run typecheck:changed`
- `pnpm exec eslint --no-warn-ignored --max-warnings=0 components/waves/OpenGraphPreview.tsx components/waves/LinkPreviewCard.tsx __tests__/components/waves/OpenGraphPreview.test.tsx __tests__/components/waves/LinkPreviewCard.test.tsx`
- Browser-rendered harness checked at 1280x720, 820x1180, and 390x844: first-party cards had no overflow and used `object-fit: contain`.

Note: `pnpm run lint:changed` could not run on this Windows shell because the helper invokes `xargs`, which is not available here, so ESLint was run directly on the changed files.