### PR TITLE
Improve OG metadata link previews

### DIFF
--- a/__tests__/app/api/og-metadata.drops.image.test.tsx
+++ b/__tests__/app/api/og-metadata.drops.image.test.tsx
@@ -173,6 +173,37 @@ describe("renderDropOgImage", () => {
     );
   });
 
+  it("renders trailing ellipsis on segmented content lines", () => {
+    const element = renderDropOgImage({
+      id: "6413",
+      origin: "http://localhost:3001",
+      author: undefined,
+      wave: undefined,
+      drop: {
+        id: "drop-1",
+        serial_no: 6413,
+        drop_type: "CHAT" as any,
+        content: [
+          "one",
+          "two",
+          "three",
+          "four",
+          "five",
+          "six",
+          "seven",
+          "@[eight]",
+          "nine",
+        ].join("\n"),
+      },
+    });
+
+    const textNodes = collectTextNodes(element);
+
+    expect(textNodes).toContain("@eight...");
+    expect(textNodes).not.toContain("@eight");
+    expect(textNodes).not.toContain("nine");
+  });
+
   it("renders submission drops with winner, media type, visual image, and votes", () => {
     const element = renderDropOgImage({
       id: "5905",

--- a/__tests__/app/api/og-metadata.drops.image.test.tsx
+++ b/__tests__/app/api/og-metadata.drops.image.test.tsx
@@ -143,6 +143,36 @@ describe("renderDropOgImage", () => {
     expect(textNodes).not.toContain("Drop #6411");
   });
 
+  it("renders mention and wave markdown tokens without brackets", () => {
+    const element = renderDropOgImage({
+      id: "6412",
+      origin: "http://localhost:3001",
+      author: undefined,
+      wave: undefined,
+      drop: {
+        id: "drop-1",
+        serial_no: 6412,
+        drop_type: "CHAT" as any,
+        content:
+          "Color refs for @[prxt0] and #[The Memes - Main Stage] inline",
+      },
+    });
+
+    const styles = collectStyles(element);
+    const textNodes = collectTextNodes(element);
+    const renderedText = textNodes.join("");
+
+    expect(renderedText).toContain("@prxt0");
+    expect(renderedText).toContain("#The Memes - Main Stage");
+    expect(renderedText).not.toContain("@[prxt0]");
+    expect(renderedText).not.toContain("#[The Memes - Main Stage]");
+    expect(styles).toContainEqual(
+      expect.objectContaining({
+        color: "#79B8FF",
+      })
+    );
+  });
+
   it("renders submission drops with winner, media type, visual image, and votes", () => {
     const element = renderDropOgImage({
       id: "5905",

--- a/__tests__/app/api/og-metadata.image.route.test.ts
+++ b/__tests__/app/api/og-metadata.image.route.test.ts
@@ -1,3 +1,8 @@
+jest.mock("undici", () => ({
+  Agent: jest.fn().mockImplementation(() => ({})),
+  fetch: jest.fn(),
+}));
+
 jest.mock("@/lib/security/urlGuard", () => {
   const actual = jest.requireActual("@/lib/security/urlGuard");
   return {
@@ -56,6 +61,10 @@ const PNG_1X1 = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
   "base64"
 );
+const GIF_2_FRAME = Buffer.from(
+  "R0lGODlhAgACAPAAAP8AAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh+QQAAAAAACwAAAAAAgACAAACAoRRACH5BAAKAAAALAAAAAACAAIAgAAA/wAAAAIChFEAOw==",
+  "base64"
+);
 
 const createRequest = (sourceUrl: string): NextRequest =>
   ({
@@ -90,7 +99,8 @@ const createHeaders = (values: Record<string, string>) => ({
 const mockImageResponse = (
   contentLength: number,
   contentType = "image/png",
-  body = PNG_1X1
+  body = PNG_1X1,
+  status = 200
 ): void => {
   mockFetchPublicUrl.mockResolvedValueOnce({
     body: createReadableBody(body),
@@ -100,8 +110,8 @@ const mockImageResponse = (
         "content-type": contentType,
       }).get,
     },
-    ok: true,
-    status: 200,
+    ok: status >= 200 && status < 300,
+    status,
   });
 };
 
@@ -136,7 +146,7 @@ describe("/api/og-metadata/image", () => {
 
   it("uses a bounded range request for oversized GIF previews", async () => {
     mockImageResponse(108 * 1024 * 1024, "image/gif");
-    mockImageResponse(PNG_1X1.byteLength, "image/gif");
+    mockImageResponse(GIF_2_FRAME.byteLength, "image/gif", GIF_2_FRAME, 206);
 
     const response = await GET(
       createRequest("https://d3lqz0a4bldqgf.cloudfront.net/large.gif")
@@ -150,6 +160,21 @@ describe("/api/og-metadata/image", () => {
         range: "bytes=0-8388607",
       }),
     });
+  });
+
+  it("rejects oversized GIF range responses when the upstream ignores Range", async () => {
+    mockImageResponse(108 * 1024 * 1024, "image/gif");
+    mockImageResponse(GIF_2_FRAME.byteLength, "image/gif", GIF_2_FRAME, 200);
+
+    const response = await GET(
+      createRequest("https://d3lqz0a4bldqgf.cloudfront.net/large.gif")
+    );
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to normalize image",
+    });
+    expect(mockFetchPublicUrl).toHaveBeenCalledTimes(2);
   });
 
   it("keeps invalid media urls as JSON errors", async () => {

--- a/__tests__/app/api/og-metadata.image.route.test.ts
+++ b/__tests__/app/api/og-metadata.image.route.test.ts
@@ -77,9 +77,11 @@ const createRequest = (sourceUrl: string): NextRequest =>
 
 const createReadableBody = (buffer: Buffer) => {
   let hasRead = false;
+  const cancel = jest.fn();
   return {
+    cancel,
     getReader: () => ({
-      cancel: jest.fn(),
+      cancel,
       read: jest.fn(async () => {
         if (hasRead) {
           return { done: true, value: undefined };
@@ -101,9 +103,10 @@ const mockImageResponse = (
   contentType = "image/png",
   body = PNG_1X1,
   status = 200
-): void => {
+): jest.Mock => {
+  const responseBody = createReadableBody(body);
   mockFetchPublicUrl.mockResolvedValueOnce({
-    body: createReadableBody(body),
+    body: responseBody,
     headers: {
       get: createHeaders({
         "content-length": `${contentLength}`,
@@ -113,6 +116,7 @@ const mockImageResponse = (
     ok: status >= 200 && status < 300,
     status,
   });
+  return responseBody.cancel;
 };
 
 describe("/api/og-metadata/image", () => {
@@ -164,7 +168,12 @@ describe("/api/og-metadata/image", () => {
 
   it("rejects oversized GIF range responses when the upstream ignores Range", async () => {
     mockImageResponse(108 * 1024 * 1024, "image/gif");
-    mockImageResponse(GIF_2_FRAME.byteLength, "image/gif", GIF_2_FRAME, 200);
+    const cancelRangeBody = mockImageResponse(
+      GIF_2_FRAME.byteLength,
+      "image/gif",
+      GIF_2_FRAME,
+      200
+    );
 
     const response = await GET(
       createRequest("https://d3lqz0a4bldqgf.cloudfront.net/large.gif")
@@ -175,6 +184,28 @@ describe("/api/og-metadata/image", () => {
       error: "Failed to normalize image",
     });
     expect(mockFetchPublicUrl).toHaveBeenCalledTimes(2);
+    expect(cancelRangeBody).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels oversized GIF range responses before rejecting their content length", async () => {
+    mockImageResponse(108 * 1024 * 1024, "image/gif");
+    const cancelRangeBody = mockImageResponse(
+      9 * 1024 * 1024,
+      "image/gif",
+      GIF_2_FRAME,
+      206
+    );
+
+    const response = await GET(
+      createRequest("https://d3lqz0a4bldqgf.cloudfront.net/large.gif")
+    );
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to normalize image",
+    });
+    expect(mockFetchPublicUrl).toHaveBeenCalledTimes(2);
+    expect(cancelRangeBody).toHaveBeenCalledTimes(1);
   });
 
   it("keeps invalid media urls as JSON errors", async () => {

--- a/__tests__/app/api/og-metadata.image.route.test.ts
+++ b/__tests__/app/api/og-metadata.image.route.test.ts
@@ -87,13 +87,17 @@ const createHeaders = (values: Record<string, string>) => ({
   get: (name: string) => values[name.toLowerCase()] ?? null,
 });
 
-const mockImageResponse = (contentLength: number): void => {
-  mockFetchPublicUrl.mockResolvedValue({
-    body: createReadableBody(PNG_1X1),
+const mockImageResponse = (
+  contentLength: number,
+  contentType = "image/png",
+  body = PNG_1X1
+): void => {
+  mockFetchPublicUrl.mockResolvedValueOnce({
+    body: createReadableBody(body),
     headers: {
       get: createHeaders({
         "content-length": `${contentLength}`,
-        "content-type": "image/png",
+        "content-type": contentType,
       }).get,
     },
     ok: true,
@@ -127,6 +131,24 @@ describe("/api/og-metadata/image", () => {
     expect(response.status).toBe(502);
     await expect(response.json()).resolves.toEqual({
       error: "Failed to normalize image",
+    });
+  });
+
+  it("uses a bounded range request for oversized GIF previews", async () => {
+    mockImageResponse(108 * 1024 * 1024, "image/gif");
+    mockImageResponse(PNG_1X1.byteLength, "image/gif");
+
+    const response = await GET(
+      createRequest("https://d3lqz0a4bldqgf.cloudfront.net/large.gif")
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(mockFetchPublicUrl).toHaveBeenCalledTimes(2);
+    expect(mockFetchPublicUrl.mock.calls[1]?.[1]).toMatchObject({
+      headers: expect.objectContaining({
+        range: "bytes=0-8388607",
+      }),
     });
   });
 

--- a/app/api/og-metadata/drops/[id]/image.tsx
+++ b/app/api/og-metadata/drops/[id]/image.tsx
@@ -96,6 +96,7 @@ const SUBMISSION_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
 });
 const URL_TOKEN_PATTERN = /^(?:https?:\/\/|www\.)\S+$/i;
+const CONTENT_REFERENCE_PATTERN = /([@#])\[([^\]\r\n]+)\]/g;
 const IMAGE_URL_PATTERN = /\.(?:avif|gif|jpe?g|png|webp)(?:$|[?#])/i;
 const INTERACTIVE_URL_PATTERN = /\.(?:glb|gltf|html?)(?:$|[?#])/i;
 const VIDEO_URL_PATTERN = /\.(?:m4v|mov|mp4|webm)(?:$|[?#])/i;
@@ -123,8 +124,18 @@ type DropContentLineKind =
   | "video"
   | "file"
   | "attachment-summary";
+type DropContentSegmentKind = "text" | "reference";
+type DropContentLineSegment = {
+  readonly kind: DropContentSegmentKind;
+  readonly text: string;
+};
 type DropContentLine = {
   readonly kind: DropContentLineKind;
+  readonly segments?: readonly DropContentLineSegment[] | undefined;
+  readonly text: string;
+};
+type DropContentWord = {
+  readonly kind: DropContentSegmentKind;
   readonly text: string;
 };
 type DropMediaItem = {
@@ -275,11 +286,13 @@ const addHardWrappedTokenLines = ({
   lines,
   token,
   kind,
+  segmentKind,
   maxLines,
 }: {
   readonly lines: DropContentLine[];
   readonly token: string;
   readonly kind: DropContentLineKind;
+  readonly segmentKind?: DropContentSegmentKind | undefined;
   readonly maxLines: number;
 }): void => {
   let remaining = token;
@@ -293,10 +306,18 @@ const addHardWrappedTokenLines = ({
         ? appendContentEllipsis(prefix)
         : prefix;
 
-    lines.push({
-      kind,
-      text,
-    });
+    lines.push(
+      segmentKind
+        ? {
+            kind,
+            segments: [{ kind: segmentKind, text }],
+            text,
+          }
+        : {
+            kind,
+            text,
+          }
+    );
 
     remaining = remaining.slice(prefix.length);
   }
@@ -620,16 +641,33 @@ const getDropText = (
 type ContentLineBuildContext = {
   lines: DropContentLine[];
   currentLine: string;
+  currentSegments: DropContentLineSegment[];
   readonly maxLines: number;
 };
+
+const hasReferenceSegment = (
+  segments: readonly DropContentLineSegment[]
+): boolean => segments.some((segment) => segment.kind === "reference");
 
 const flushCurrentContentLine = (context: ContentLineBuildContext): void => {
   if (!context.currentLine || context.lines.length >= context.maxLines) {
     return;
   }
 
-  context.lines.push({ kind: "text", text: context.currentLine });
+  context.lines.push(
+    hasReferenceSegment(context.currentSegments)
+      ? {
+          kind: "text",
+          segments: context.currentSegments,
+          text: context.currentLine,
+        }
+      : {
+          kind: "text",
+          text: context.currentLine,
+        }
+  );
   context.currentLine = "";
+  context.currentSegments = [];
 };
 
 const addEllipsisIfMoreWordsRemain = ({
@@ -639,7 +677,7 @@ const addEllipsisIfMoreWordsRemain = ({
 }: {
   readonly context: ContentLineBuildContext;
   readonly index: number;
-  readonly words: readonly string[];
+  readonly words: readonly DropContentWord[];
 }): void => {
   if (context.lines.length === context.maxLines && index < words.length - 1) {
     addTrailingContentEllipsis(context.lines);
@@ -655,7 +693,7 @@ const appendUrlContentLine = ({
   readonly context: ContentLineBuildContext;
   readonly index: number;
   readonly word: string;
-  readonly words: readonly string[];
+  readonly words: readonly DropContentWord[];
 }): void => {
   flushCurrentContentLine(context);
   addHardWrappedTokenLines({
@@ -678,16 +716,31 @@ const appendLongContentWord = ({
 }: {
   readonly context: ContentLineBuildContext;
   readonly index: number;
-  readonly word: string;
-  readonly words: readonly string[];
+  readonly word: DropContentWord;
+  readonly words: readonly DropContentWord[];
 }): void => {
   addHardWrappedTokenLines({
     lines: context.lines,
-    token: word,
+    token: word.text,
     kind: "text",
+    segmentKind: word.kind,
     maxLines: context.maxLines,
   });
   addEllipsisIfMoreWordsRemain({ context, index, words });
+};
+
+const appendCurrentContentWord = (
+  context: ContentLineBuildContext,
+  word: DropContentWord
+): void => {
+  if (context.currentLine) {
+    context.currentLine = `${context.currentLine} ${word.text}`;
+    context.currentSegments.push({ kind: "text", text: " " });
+  } else {
+    context.currentLine = word.text;
+  }
+
+  context.currentSegments.push(word);
 };
 
 const appendTextContentLine = ({
@@ -698,20 +751,20 @@ const appendTextContentLine = ({
 }: {
   readonly context: ContentLineBuildContext;
   readonly index: number;
-  readonly word: string;
-  readonly words: readonly string[];
+  readonly word: DropContentWord;
+  readonly words: readonly DropContentWord[];
 }): void => {
   const nextLine = context.currentLine
-    ? `${context.currentLine} ${word}`
-    : word;
+    ? `${context.currentLine} ${word.text}`
+    : word.text;
   if (fitsContentLine(nextLine)) {
-    context.currentLine = nextLine;
+    appendCurrentContentWord(context, word);
     return;
   }
 
   flushCurrentContentLine(context);
-  if (fitsContentLine(word)) {
-    context.currentLine = word;
+  if (fitsContentLine(word.text)) {
+    appendCurrentContentWord(context, word);
     return;
   }
 
@@ -723,6 +776,43 @@ const getNormalizedContentParagraph = (value: string): string =>
 
 const getContentParagraphs = (value: string): readonly string[] =>
   value.split(/\r\n|\n|\r/);
+
+const getTextContentWords = (value: string): readonly DropContentWord[] =>
+  value
+    .split(" ")
+    .filter(Boolean)
+    .map((text) => ({ kind: "text" as const, text }));
+
+const getReferenceContentWord = (
+  marker: string,
+  label: string
+): DropContentWord | null => {
+  const text = getUsableText(label)?.replace(/\s+/g, " ");
+  return text ? { kind: "reference", text: `${marker}${text}` } : null;
+};
+
+const getContentWords = (paragraph: string): readonly DropContentWord[] => {
+  const words: DropContentWord[] = [];
+  let lastIndex = 0;
+
+  for (const match of paragraph.matchAll(CONTENT_REFERENCE_PATTERN)) {
+    const matchIndex = match.index ?? 0;
+    words.push(...getTextContentWords(paragraph.slice(lastIndex, matchIndex)));
+
+    const marker = match[1];
+    const label = match[2];
+    const referenceWord =
+      marker && label ? getReferenceContentWord(marker, label) : null;
+    if (referenceWord) {
+      words.push(referenceWord);
+    }
+
+    lastIndex = matchIndex + match[0].length;
+  }
+
+  words.push(...getTextContentWords(paragraph.slice(lastIndex)));
+  return words;
+};
 
 const hasRemainingContentParagraph = ({
   paragraphs,
@@ -751,7 +841,7 @@ const appendContentParagraph = ({
   readonly context: ContentLineBuildContext;
   readonly paragraph: string;
 }): void => {
-  const words = paragraph.split(" ");
+  const words = getContentWords(paragraph);
 
   for (const [index, word] of words.entries()) {
     if (context.lines.length === context.maxLines) {
@@ -759,8 +849,8 @@ const appendContentParagraph = ({
       break;
     }
 
-    if (isUrlToken(word)) {
-      appendUrlContentLine({ context, index, word, words });
+    if (word.kind === "text" && isUrlToken(word.text)) {
+      appendUrlContentLine({ context, index, word: word.text, words });
       continue;
     }
 
@@ -783,6 +873,7 @@ const getContentLines = ({
   const context: ContentLineBuildContext = {
     lines: [],
     currentLine: "",
+    currentSegments: [],
     maxLines,
   };
 
@@ -1759,6 +1850,14 @@ const getContentLineRows = (
   });
 };
 
+const getContentSegmentColor = (segment: DropContentLineSegment): string =>
+  segment.kind === "reference" ? LINK_TEXT : "#ffffff";
+
+const getContentLineSegments = (
+  line: DropContentLine
+): readonly DropContentLineSegment[] =>
+  line.segments ?? [{ kind: "text", text: line.text }];
+
 const DropContentLines = ({
   contentLines,
   contentTop,
@@ -1810,7 +1909,16 @@ const DropContentLines = ({
         >
           {line.kind === "video" ? <VideoContentIcon /> : null}
           {line.kind === "file" ? <FileContentIcon /> : null}
-          {line.text}
+          {line.segments
+            ? getContentLineSegments(line).map((segment, segmentIndex) => (
+                <span
+                  key={`${line.text}-${segmentIndex}`}
+                  style={{ color: getContentSegmentColor(segment) }}
+                >
+                  {segment.text}
+                </span>
+              ))
+            : line.text}
         </div>
       ))}
     </div>

--- a/app/api/og-metadata/drops/[id]/image.tsx
+++ b/app/api/og-metadata/drops/[id]/image.tsx
@@ -329,10 +329,50 @@ const addTrailingContentEllipsis = (lines: DropContentLine[]): void => {
     return;
   }
 
+  const text = appendContentEllipsis(lastLine.text);
+  const segments = lastLine.segments
+    ? getSegmentsForLineText(lastLine.segments, text)
+    : undefined;
+
   lines.splice(-1, 1, {
     ...lastLine,
-    text: appendContentEllipsis(lastLine.text),
+    ...(segments ? { segments } : {}),
+    text,
   });
+};
+
+const getSegmentsForLineText = (
+  segments: readonly DropContentLineSegment[],
+  text: string
+): readonly DropContentLineSegment[] => {
+  const nextSegments: DropContentLineSegment[] = [];
+  let cursor = 0;
+
+  for (const segment of segments) {
+    if (cursor >= text.length) {
+      break;
+    }
+
+    const nextCursor = Math.min(cursor + segment.text.length, text.length);
+    nextSegments.push({
+      ...segment,
+      text: text.slice(cursor, nextCursor),
+    });
+    cursor = nextCursor;
+  }
+
+  if (cursor < text.length) {
+    const remainingText = text.slice(cursor);
+    const lastSegment = nextSegments.at(-1);
+    if (lastSegment) {
+      nextSegments.splice(-1, 1, {
+        ...lastSegment,
+        text: `${lastSegment.text}${remainingText}`,
+      });
+    }
+  }
+
+  return nextSegments;
 };
 
 const isUrlToken = (value: string): boolean => URL_TOKEN_PATTERN.test(value);
@@ -1912,7 +1952,7 @@ const DropContentLines = ({
           {line.segments
             ? getContentLineSegments(line).map((segment, segmentIndex) => (
                 <span
-                  key={`${line.text}-${segmentIndex}`}
+                  key={`${key}-${segmentIndex}`}
                   style={{ color: getContentSegmentColor(segment) }}
                 >
                   {segment.text}

--- a/app/api/og-metadata/image/route.ts
+++ b/app/api/og-metadata/image/route.ts
@@ -169,7 +169,10 @@ const mapErrorToResponse = (error: unknown): NextResponse => {
   return jsonError("Failed to normalize image", 502);
 };
 
-const readImageResponseBuffer = async (response: Response): Promise<Buffer> => {
+const readImageResponseBuffer = async (
+  response: Response,
+  maxBytes = OG_IMAGE_PROXY_MAX_BYTES
+): Promise<Buffer> => {
   if (!response.body) {
     throw new Error("Image response did not include a readable body.");
   }
@@ -187,9 +190,9 @@ const readImageResponseBuffer = async (response: Response): Promise<Buffer> => {
 
       const chunk = Buffer.from(value);
       totalBytes += chunk.byteLength;
-      if (totalBytes > OG_IMAGE_PROXY_MAX_BYTES) {
+      if (totalBytes > maxBytes) {
         await reader.cancel("Image response exceeded maximum size.");
-        ensureAllowedImageSize(totalBytes);
+        throw new Error("Image response exceeded maximum size.");
       }
       chunks.push(chunk);
     }
@@ -241,7 +244,7 @@ const fetchOversizedGifPreviewBuffer = async (url: URL): Promise<Buffer> => {
     FETCH_OPTIONS
   );
 
-  if (!response.ok && response.status !== 206) {
+  if (response.status !== 206) {
     throw new Error(`Image range request failed: ${response.status}`);
   }
 
@@ -250,8 +253,14 @@ const fetchOversizedGifPreviewBuffer = async (url: URL): Promise<Buffer> => {
     ensureAllowedGifPreviewSize(contentLength);
   }
 
-  const buffer = await readImageResponseBuffer(response);
+  const buffer = await readImageResponseBuffer(
+    response,
+    OVERSIZED_GIF_PREVIEW_MAX_BYTES
+  );
   ensureAllowedGifPreviewSize(buffer.byteLength);
+  if (detectContentType(buffer) !== GIF_CONTENT_TYPE) {
+    throw new Error("GIF range response is not a GIF.");
+  }
   return buffer;
 };
 
@@ -300,16 +309,8 @@ const normalizeImageToPng = async ({
     .toBuffer();
 };
 
-const getGifPreviewPage = (pages: number | undefined): number => {
-  if (!pages || pages < 2) {
-    return 0;
-  }
-
-  return Math.min(pages - 1, Math.floor(pages / 2));
-};
-
 const createGifPreviewImage = async (buffer: Buffer): Promise<sharp.Sharp> => {
-  const metadata = await sharp(buffer, {
+  await sharp(buffer, {
     animated: true,
     limitInputPixels: false,
     sequentialRead: true,
@@ -317,7 +318,7 @@ const createGifPreviewImage = async (buffer: Buffer): Promise<sharp.Sharp> => {
 
   return sharp(buffer, {
     limitInputPixels: false,
-    page: getGifPreviewPage(metadata.pages),
+    page: 0,
     pages: 1,
     sequentialRead: true,
   });

--- a/app/api/og-metadata/image/route.ts
+++ b/app/api/og-metadata/image/route.ts
@@ -245,12 +245,18 @@ const fetchOversizedGifPreviewBuffer = async (url: URL): Promise<Buffer> => {
   );
 
   if (response.status !== 206) {
+    await cancelResponseBody(response);
     throw new Error(`Image range request failed: ${response.status}`);
   }
 
   const contentLength = getContentLength(response);
   if (contentLength !== null) {
-    ensureAllowedGifPreviewSize(contentLength);
+    try {
+      ensureAllowedGifPreviewSize(contentLength);
+    } catch (error) {
+      await cancelResponseBody(response);
+      throw error;
+    }
   }
 
   const buffer = await readImageResponseBuffer(

--- a/app/api/og-metadata/image/route.ts
+++ b/app/api/og-metadata/image/route.ts
@@ -13,7 +13,9 @@ export const revalidate = 604800;
 
 const DEFAULT_WIDTH = 1200;
 const MAX_WIDTH = 1200;
+const OVERSIZED_GIF_PREVIEW_MAX_BYTES = 8 * 1024 * 1024;
 const PNG_CONTENT_TYPE = "image/png";
+const GIF_CONTENT_TYPE = "image/gif";
 const CACHE_CONTROL =
   "public, max-age=604800, s-maxage=2592000, stale-while-revalidate=2592000";
 const IMAGE_ACCEPT_HEADER =
@@ -106,9 +108,43 @@ const getContentLength = (response: Response): number | null => {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
 };
 
+const getResponseContentType = (response: Response): string | null => {
+  const contentType = response.headers.get("content-type");
+  return contentType?.split(";")[0]?.trim().toLowerCase() || null;
+};
+
 const ensureAllowedImageSize = (byteLength: number): void => {
   if (byteLength > OG_IMAGE_PROXY_MAX_BYTES) {
     throw new Error("Image response exceeded maximum size.");
+  }
+};
+
+const ensureAllowedGifPreviewSize = (byteLength: number): void => {
+  if (byteLength > OVERSIZED_GIF_PREVIEW_MAX_BYTES) {
+    throw new Error("GIF preview response exceeded maximum size.");
+  }
+};
+
+const isGifUrl = (url: URL): boolean => /\.gif(?:$|[?#])/i.test(url.pathname);
+
+const shouldUseOversizedGifPreview = ({
+  contentLength,
+  contentType,
+  url,
+}: {
+  readonly contentLength: number | null;
+  readonly contentType: string | null;
+  readonly url: URL;
+}): boolean =>
+  contentLength !== null &&
+  contentLength > OG_IMAGE_PROXY_MAX_BYTES &&
+  (contentType === GIF_CONTENT_TYPE || isGifUrl(url));
+
+const cancelResponseBody = async (response: Response): Promise<void> => {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Best-effort cleanup before issuing a bounded range request.
   }
 };
 
@@ -180,11 +216,43 @@ const fetchImageBuffer = async (url: URL): Promise<Buffer> => {
   }
 
   const contentLength = getContentLength(response);
+  const contentType = getResponseContentType(response);
+  if (shouldUseOversizedGifPreview({ contentLength, contentType, url })) {
+    await cancelResponseBody(response);
+    return fetchOversizedGifPreviewBuffer(url);
+  }
+
   if (contentLength !== null) {
     ensureAllowedImageSize(contentLength);
   }
 
   return readImageResponseBuffer(response);
+};
+
+const fetchOversizedGifPreviewBuffer = async (url: URL): Promise<Buffer> => {
+  const response = await fetchPublicUrl(
+    url,
+    {
+      headers: {
+        accept: IMAGE_ACCEPT_HEADER,
+        range: `bytes=0-${OVERSIZED_GIF_PREVIEW_MAX_BYTES - 1}`,
+      },
+    },
+    FETCH_OPTIONS
+  );
+
+  if (!response.ok && response.status !== 206) {
+    throw new Error(`Image range request failed: ${response.status}`);
+  }
+
+  const contentLength = getContentLength(response);
+  if (contentLength !== null) {
+    ensureAllowedGifPreviewSize(contentLength);
+  }
+
+  const buffer = await readImageResponseBuffer(response);
+  ensureAllowedGifPreviewSize(buffer.byteLength);
+  return buffer;
 };
 
 const detectContentType = (buffer: Buffer): string | null => {
@@ -215,16 +283,44 @@ const normalizeImageToPng = async ({
     throw new Error("Upstream response is not an image.");
   }
 
-  return sharp(buffer, {
-    limitInputPixels: false,
-    pages: 1,
-    sequentialRead: true,
-  })
+  const image =
+    detectedContentType === GIF_CONTENT_TYPE
+      ? await createGifPreviewImage(buffer)
+      : sharp(buffer, {
+          limitInputPixels: false,
+          pages: 1,
+          sequentialRead: true,
+        });
+
+  return image
     .timeout({ seconds: 7 })
     .rotate()
     .resize(width, undefined, { withoutEnlargement: true })
     .png({ quality: 100 })
     .toBuffer();
+};
+
+const getGifPreviewPage = (pages: number | undefined): number => {
+  if (!pages || pages < 2) {
+    return 0;
+  }
+
+  return Math.min(pages - 1, Math.floor(pages / 2));
+};
+
+const createGifPreviewImage = async (buffer: Buffer): Promise<sharp.Sharp> => {
+  const metadata = await sharp(buffer, {
+    animated: true,
+    limitInputPixels: false,
+    sequentialRead: true,
+  }).metadata();
+
+  return sharp(buffer, {
+    limitInputPixels: false,
+    page: getGifPreviewPage(metadata.pages),
+    pages: 1,
+    sequentialRead: true,
+  });
 };
 
 const parseImageUrl = (value: string | null): URL => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced OG image preview handling for oversized GIFs by using byte-range fetching, improving robustness when ranges are ignored, and normalizing GIFs to PNG for consistent rendering.
  * Added support for inline reference markers in drop content, including distinct styling and segment-aware word-wrapping with correct ellipsis truncation.
* **Tests**
  * Expanded coverage for reference-marker parsing/styling and ellipsis behavior when content overflows line segmentation.
  * Added/updated route tests to validate oversized GIF range behavior and failure handling when the upstream response doesn’t comply.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->