### PR TITLE
[codex] Add 6529 collection link previews

### DIFF
--- a/__tests__/app/api/open-graph.6529.service.test.ts
+++ b/__tests__/app/api/open-graph.6529.service.test.ts
@@ -1,5 +1,5 @@
 import { createFirstParty6529Plan } from "@/app/api/open-graph/6529/service";
-import { MEMES_CONTRACT } from "@/constants/constants";
+import { MEMELAB_CONTRACT, MEMES_CONTRACT } from "@/constants/constants";
 import { publicEnv } from "@/config/env";
 
 const originalFetch = global.fetch;
@@ -116,7 +116,9 @@ describe("createFirstParty6529Plan", () => {
     );
 
     expect(plan).not.toBeNull();
-    expect(plan?.cacheKey).toBe("6529:auth:the-memes:/the-memes/509");
+    expect(plan?.cacheKey).toMatch(
+      /^6529:auth:[a-f0-9]{24}:the-memes:\/the-memes\/509$/
+    );
 
     const { data } = await plan!.execute();
 
@@ -148,6 +150,254 @@ describe("createFirstParty6529Plan", () => {
       { label: "TDH rate", value: "25.1" },
       { label: "Season", value: "15" },
       { label: "Mint date", value: "1 Jun 2026" },
+    ]);
+  });
+
+  it("isolates authenticated collection preview cache keys by auth token", () => {
+    const url = new URL("https://6529.io/the-memes/509");
+    const publicPlan = createFirstParty6529Plan(url);
+    const firstAuthPlan = createFirstParty6529Plan(url, { apiAuth: "alpha" });
+    const secondAuthPlan = createFirstParty6529Plan(url, { apiAuth: "beta" });
+
+    publicEnv.STAGING_API_KEY = "staging-secret";
+    const stagingPlan = createFirstParty6529Plan(url);
+
+    expect(publicPlan?.cacheKey).toBe("6529:public:the-memes:/the-memes/509");
+    expect(firstAuthPlan?.cacheKey).toMatch(
+      /^6529:auth:[a-f0-9]{24}:the-memes:\/the-memes\/509$/
+    );
+    expect(secondAuthPlan?.cacheKey).toMatch(
+      /^6529:auth:[a-f0-9]{24}:the-memes:\/the-memes\/509$/
+    );
+    expect(firstAuthPlan?.cacheKey).not.toBe(secondAuthPlan?.cacheKey);
+    expect(stagingPlan?.cacheKey).toBe("6529:staging:the-memes:/the-memes/509");
+  });
+
+  it("only matches exact 6529 hosts and subdomains", () => {
+    expect(
+      createFirstParty6529Plan(new URL("https://6529.io/the-memes/509"))
+    ).not.toBeNull();
+    expect(
+      createFirstParty6529Plan(new URL("https://staging.6529.io/the-memes/509"))
+    ).not.toBeNull();
+    expect(
+      createFirstParty6529Plan(new URL("https://6529.io.evil.com/the-memes/509"))
+    ).toBeNull();
+    expect(
+      createFirstParty6529Plan(new URL("https://evil6529.io/the-memes/509"))
+    ).toBeNull();
+  });
+
+  it("skips unsafe image schemes and uses the next safe image candidate", async () => {
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = readFetchUrl(input);
+
+      if (url.pathname === "/api/nfts") {
+        return jsonResponse({
+          data: [
+            {
+              id: 509,
+              name: "The Collective Synapse",
+              artist_seize_handle: "elnaz555",
+              hodl_rate: 25.1019,
+              mint_date: "2026-06-01T00:00:00.000Z",
+              thumbnail: "javascript:alert(1)",
+              scaled: "https://cdn.6529.io/memes/509-safe.png",
+              metadata: {
+                image: "data:image/svg+xml;base64,PHN2Zy8+",
+                attributes: [{ trait_type: "Type - Season", value: 15 }],
+              },
+            },
+          ],
+        });
+      }
+
+      if (url.pathname === "/api/memes_extended_data") {
+        return jsonResponse({ data: [] });
+      }
+
+      if (
+        url.pathname ===
+        `/api/minting-claims/${MEMES_CONTRACT}/claims/509`
+      ) {
+        return jsonResponse({}, 404);
+      }
+
+      if (url.pathname === "/api/memes-mint-stats/509") {
+        return jsonResponse({}, 404);
+      }
+
+      return jsonResponse({}, 404);
+    });
+
+    const plan = createFirstParty6529Plan(
+      new URL("https://6529.io/the-memes/509")
+    );
+    const { data } = await plan!.execute();
+
+    expect(data.image).toEqual({
+      url: "https://cdn.6529.io/memes/509-safe.png",
+      secureUrl: "https://cdn.6529.io/memes/509-safe.png",
+    });
+    expect(data.images).toEqual([data.image]);
+  });
+
+  it("builds Meme Lab previews with artist and edition size", async () => {
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = readFetchUrl(input);
+
+      if (url.pathname === "/api/nfts_memelab") {
+        return jsonResponse({
+          data: [
+            {
+              id: 71,
+              name: "The Outsiders Companion",
+              artist: "Artist 6529",
+              artist_seize_handle: "artist6529",
+              mint_date: "2025-03-02T00:00:00.000Z",
+              thumbnail: "https://cdn.6529.io/memelab/71.png",
+            },
+          ],
+        });
+      }
+
+      if (url.pathname === "/api/lab_extended_data") {
+        return jsonResponse({
+          data: [{ id: 71, edition_size: 420 }],
+        });
+      }
+
+      return jsonResponse({}, 404);
+    });
+
+    const plan = createFirstParty6529Plan(
+      new URL("https://6529.io/meme-lab/71")
+    );
+    const { data } = await plan!.execute();
+
+    const fetchUrls = mockFetch.mock.calls.map((call) =>
+      readFetchUrl(call[0]).toString()
+    );
+    expect(fetchUrls).toEqual(
+      expect.arrayContaining([
+        `https://api.test/api/nfts_memelab?contract=${MEMELAB_CONTRACT}&id=71`,
+        "https://api.test/api/lab_extended_data?id=71",
+      ])
+    );
+    expect(data).toMatchObject({
+      type: "6529.collection",
+      kind: "meme-lab",
+      title: "The Outsiders Companion",
+      kicker: "Meme Lab #71",
+      people: [{ label: "by", name: "artist6529", href: "/artist6529" }],
+    });
+    expect(data.facts).toEqual([
+      { label: "Edition size", value: "420" },
+      { label: "Mint date", value: "2 Mar 2025" },
+    ]);
+  });
+
+  it("builds Gradient previews with artist, collector, TDH, and mint date", async () => {
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = readFetchUrl(input);
+
+      if (url.pathname === "/api/nfts/gradients") {
+        return jsonResponse({
+          data: [
+            {
+              id: 92,
+              name: "6529 Gradient #92",
+              artist: "6529er",
+              artist_seize_handle: "6529er",
+              owner: "0x000000000000000000000000000000000000dEaD",
+              owner_display: "punk6529",
+              hodl_rate: 13.456,
+              mint_date: "2022-09-10T00:00:00.000Z",
+              thumbnail: "https://cdn.6529.io/gradients/92.png",
+            },
+          ],
+        });
+      }
+
+      if (url.pathname === "/api/identities/punk6529") {
+        return jsonResponse({ handle: "punk6529" });
+      }
+
+      return jsonResponse({}, 404);
+    });
+
+    const plan = createFirstParty6529Plan(
+      new URL("https://6529.io/6529-gradient/92")
+    );
+    const { data } = await plan!.execute();
+
+    expect(data).toMatchObject({
+      type: "6529.collection",
+      kind: "6529-gradient",
+      title: "6529 Gradient #92",
+      people: [
+        { label: "Artist", name: "6529er", href: "/6529er" },
+        { label: "Collector", name: "punk6529", href: "/punk6529" },
+      ],
+    });
+    expect(data.kicker).toBeNull();
+    expect(data.facts).toEqual([
+      { label: "TDH rate", value: "13.46" },
+      { label: "Mint date", value: "10 Sept 2022" },
+    ]);
+  });
+
+  it("builds ReMemes previews with creator, references, edition size, and replicas", async () => {
+    const contract = "0x1234567890abcdef1234567890abcdef12345678";
+
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = readFetchUrl(input);
+
+      if (url.pathname === "/api/rememes") {
+        return jsonResponse({
+          data: [
+            {
+              contract,
+              id: 1,
+              added_by: "fallback6529",
+              s3_image_thumbnail: "https://cdn.6529.io/rememes/1.png",
+              meme_references: [509],
+              replicas: [{ id: 1 }, { id: 2 }],
+              metadata: {
+                name: "Touch the OM",
+                attributes: [
+                  { trait_type: "SEIZE Artist Profile", value: "artist6529" },
+                  { trait_type: "Edition Size", value: 88 },
+                ],
+              },
+            },
+          ],
+        });
+      }
+
+      if (url.pathname === "/api/identities/artist6529") {
+        return jsonResponse({ handle: "artist6529" });
+      }
+
+      return jsonResponse({}, 404);
+    });
+
+    const plan = createFirstParty6529Plan(
+      new URL(`https://6529.io/rememes/${contract}/1`)
+    );
+    const { data } = await plan!.execute();
+
+    expect(data).toMatchObject({
+      type: "6529.collection",
+      kind: "rememes",
+      title: "Touch the OM",
+      kicker: "ReMemes",
+      people: [{ label: "by", name: "artist6529", href: "/artist6529" }],
+    });
+    expect(data.facts).toEqual([
+      { label: "References", value: "The Memes #509" },
+      { label: "Edition size", value: "88" },
+      { label: "Replicas", value: "2" },
     ]);
   });
 

--- a/__tests__/app/api/open-graph.6529.service.test.ts
+++ b/__tests__/app/api/open-graph.6529.service.test.ts
@@ -578,9 +578,63 @@ describe("createFirstParty6529Plan", () => {
     ).toEqual(
       expect.arrayContaining([
         "https://api.test/api/nextgen/tokens/514",
-        "https://api.test/api/nextgen/collections?page_size=100",
+        "https://api.test/api/nextgen/collections?page_size=5",
         "https://api.test/api/nextgen/tokens/10000000514",
       ])
+    );
+  });
+
+  it("caps NextGen normalized-token expansion probes", async () => {
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = readFetchUrl(input);
+
+      if (url.pathname === "/api/nextgen/tokens/42") {
+        return jsonResponse({}, 404);
+      }
+
+      if (url.pathname === "/api/nextgen/collections") {
+        return jsonResponse({
+          data: [
+            { id: 1 },
+            { id: 2 },
+            { id: 3 },
+            { id: 4 },
+            { id: 5 },
+            { id: 6 },
+            { id: 7 },
+          ],
+        });
+      }
+
+      if (url.pathname.startsWith("/api/nextgen/tokens/")) {
+        return jsonResponse({}, 404);
+      }
+
+      return jsonResponse({}, 404);
+    });
+
+    const plan = createFirstParty6529Plan(
+      new URL("https://6529.io/nextgen/token/42")
+    );
+
+    await expect(plan!.execute()).rejects.toThrow("NextGen token was not found.");
+
+    const fetchUrls = mockFetch.mock.calls.map((call) =>
+      readFetchUrl(call[0]).toString()
+    );
+    expect(fetchUrls).toEqual(
+      expect.arrayContaining([
+        "https://api.test/api/nextgen/tokens/42",
+        "https://api.test/api/nextgen/collections?page_size=5",
+        "https://api.test/api/nextgen/tokens/10000000042",
+        "https://api.test/api/nextgen/tokens/20000000042",
+        "https://api.test/api/nextgen/tokens/30000000042",
+        "https://api.test/api/nextgen/tokens/40000000042",
+        "https://api.test/api/nextgen/tokens/50000000042",
+      ])
+    );
+    expect(fetchUrls).not.toContain(
+      "https://api.test/api/nextgen/tokens/60000000042"
     );
   });
 });

--- a/__tests__/app/api/open-graph.6529.service.test.ts
+++ b/__tests__/app/api/open-graph.6529.service.test.ts
@@ -572,6 +572,8 @@ describe("createFirstParty6529Plan", () => {
       kind: "nextgen-token",
       title: "Pebbles #514",
       kicker: "NextGen \u00b7 Pebbles",
+      requestUrl: "https://6529.io/nextgen/token/10000000514",
+      url: "https://6529.io/nextgen/token/10000000514",
       people: [{ label: "by", name: "Zeblocks", href: "/zeblocks" }],
     });
     expect(data.facts).toEqual([

--- a/__tests__/app/api/open-graph.6529.service.test.ts
+++ b/__tests__/app/api/open-graph.6529.service.test.ts
@@ -104,7 +104,10 @@ describe("createFirstParty6529Plan", () => {
       }
 
       if (url.pathname === "/api/memes-mint-stats/509") {
-        return jsonResponse({}, 404);
+        return jsonResponse({
+          mint_date: new Date().toISOString(),
+          total_count: 94,
+        });
       }
 
       return jsonResponse({}, 404);

--- a/__tests__/app/api/open-graph.6529.service.test.ts
+++ b/__tests__/app/api/open-graph.6529.service.test.ts
@@ -173,6 +173,63 @@ describe("createFirstParty6529Plan", () => {
     expect(stagingPlan?.cacheKey).toBe("6529:staging:the-memes:/the-memes/509");
   });
 
+  it("uses public extended data for The Memes edition size when claim data is unavailable", async () => {
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = readFetchUrl(input);
+
+      if (url.pathname === "/api/nfts") {
+        return jsonResponse({
+          data: [
+            {
+              id: 509,
+              name: "The Collective Synapse",
+              supply: 173,
+              artist: "elnaz555",
+              artist_seize_handle: "elnaz555",
+              hodl_rate: 22.7803,
+              mint_date: "2026-06-15T00:00:00.000Z",
+              thumbnail: "https://cdn.6529.io/memes/509.png",
+              metadata: {
+                attributes: [{ trait_type: "Type - Season", value: 15 }],
+              },
+            },
+          ],
+        });
+      }
+
+      if (url.pathname === "/api/memes_extended_data") {
+        return jsonResponse({
+          data: [{ id: 509, edition_size: 173, season: 15 }],
+        });
+      }
+
+      if (
+        url.pathname ===
+        `/api/minting-claims/${MEMES_CONTRACT}/claims/509`
+      ) {
+        return jsonResponse("Unauthorized", 401);
+      }
+
+      if (url.pathname === "/api/memes-mint-stats/509") {
+        return jsonResponse({}, 404);
+      }
+
+      return jsonResponse({}, 404);
+    });
+
+    const plan = createFirstParty6529Plan(
+      new URL("https://6529.io/the-memes/509")
+    );
+    const { data } = await plan!.execute();
+
+    expect(data.facts).toEqual([
+      { label: "Edition size", value: "173" },
+      { label: "TDH rate", value: "22.78" },
+      { label: "Season", value: "15" },
+      { label: "Mint date", value: "15 Jun 2026" },
+    ]);
+  });
+
   it("only matches exact 6529 hosts and subdomains", () => {
     expect(
       createFirstParty6529Plan(new URL("https://6529.io/the-memes/509"))
@@ -405,9 +462,27 @@ describe("createFirstParty6529Plan", () => {
     mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
       const url = readFetchUrl(input);
 
+      if (url.pathname === "/api/nextgen/tokens/514") {
+        return jsonResponse({}, 404);
+      }
+
+      if (url.pathname === "/api/nextgen/collections") {
+        return jsonResponse({
+          data: [
+            {
+              id: 1,
+              name: "Pebbles",
+              artist: "Zeblocks",
+              total_supply: 1000,
+            },
+          ],
+        });
+      }
+
       if (url.pathname === "/api/nextgen/tokens/10000000514") {
         return jsonResponse({
           id: 10000000514,
+          normalised_id: 514,
           pending: false,
           name: "Pebbles #514",
           collection_id: 1,
@@ -475,7 +550,7 @@ describe("createFirstParty6529Plan", () => {
     });
 
     const plan = createFirstParty6529Plan(
-      new URL("https://6529.io/nextgen/token/10000000514")
+      new URL("https://6529.io/nextgen/token/514")
     );
 
     expect(plan).not.toBeNull();
@@ -498,5 +573,14 @@ describe("createFirstParty6529Plan", () => {
       { label: "Mint Type", value: "Public" },
       { label: "Color Density", value: "Sparse" },
     ]);
+    expect(
+      mockFetch.mock.calls.map((call) => readFetchUrl(call[0]).toString())
+    ).toEqual(
+      expect.arrayContaining([
+        "https://api.test/api/nextgen/tokens/514",
+        "https://api.test/api/nextgen/collections?page_size=100",
+        "https://api.test/api/nextgen/tokens/10000000514",
+      ])
+    );
   });
 });

--- a/__tests__/app/api/open-graph.6529.service.test.ts
+++ b/__tests__/app/api/open-graph.6529.service.test.ts
@@ -1,0 +1,252 @@
+import { createFirstParty6529Plan } from "@/app/api/open-graph/6529/service";
+import { MEMES_CONTRACT } from "@/constants/constants";
+import { publicEnv } from "@/config/env";
+
+const originalFetch = global.fetch;
+const mockFetch = jest.fn();
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+function readFetchUrl(input: RequestInfo | URL): URL {
+  if (typeof input === "string") {
+    return new URL(input);
+  }
+
+  if (input instanceof URL) {
+    return input;
+  }
+
+  if (typeof Request !== "undefined" && input instanceof Request) {
+    return new URL(input.url);
+  }
+
+  const requestUrl = (input as { readonly url?: unknown }).url;
+  if (typeof requestUrl === "string") {
+    return new URL(requestUrl);
+  }
+
+  return new URL(String(input));
+}
+
+describe("createFirstParty6529Plan", () => {
+  const originalApiEndpoint = publicEnv.API_ENDPOINT;
+  const originalBaseEndpoint = publicEnv.BASE_ENDPOINT;
+  const originalStagingApiKey = publicEnv.STAGING_API_KEY;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+    global.fetch = mockFetch as unknown as typeof fetch;
+    publicEnv.API_ENDPOINT = "https://api.test";
+    publicEnv.BASE_ENDPOINT = "https://6529.io";
+    publicEnv.STAGING_API_KEY = undefined;
+  });
+
+  afterEach(() => {
+    publicEnv.API_ENDPOINT = originalApiEndpoint;
+    publicEnv.BASE_ENDPOINT = originalBaseEndpoint;
+    publicEnv.STAGING_API_KEY = originalStagingApiKey;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("builds The Memes previews from richer internal API data", async () => {
+    let claimAuthHeader: string | null = null;
+
+    mockFetch.mockImplementation(async (input: RequestInfo | URL, init) => {
+      const url = readFetchUrl(input);
+      const headers = new Headers(init?.headers);
+
+      if (url.pathname === "/api/nfts") {
+        return jsonResponse({
+          data: [
+            {
+              id: 509,
+              name: "The Collective Synapse",
+              supply: 158,
+              artist: "Elnaz555",
+              artist_seize_handle: "elnaz555",
+              hodl_rate: 25.1019,
+              mint_date: "2026-06-01T00:00:00.000Z",
+              thumbnail: "https://cdn.6529.io/memes/509.png",
+              metadata: {
+                attributes: [{ trait_type: "Type - Season", value: 15 }],
+              },
+            },
+          ],
+        });
+      }
+
+      if (url.pathname === "/api/memes_extended_data") {
+        return jsonResponse({
+          data: [{ id: 509, edition_size: 158, season: 15 }],
+        });
+      }
+
+      if (
+        url.pathname ===
+        `/api/minting-claims/${MEMES_CONTRACT}/claims/509`
+      ) {
+        claimAuthHeader = headers.get("x-6529-auth");
+        return jsonResponse({
+          name: "The Collective Synapse",
+          edition_size: 328,
+          image_url: "https://cdn.6529.io/memes/509-claim.png",
+        });
+      }
+
+      if (url.pathname === "/api/memes-mint-stats/509") {
+        return jsonResponse({}, 404);
+      }
+
+      return jsonResponse({}, 404);
+    });
+
+    const plan = createFirstParty6529Plan(
+      new URL("https://6529.io/the-memes/509"),
+      { apiAuth: "secret" }
+    );
+
+    expect(plan).not.toBeNull();
+    expect(plan?.cacheKey).toBe("6529:auth:the-memes:/the-memes/509");
+
+    const { data } = await plan!.execute();
+
+    expect(claimAuthHeader).toBe("secret");
+    const fetchUrls = mockFetch.mock.calls.map((call) =>
+      readFetchUrl(call[0]).toString()
+    );
+    expect(fetchUrls).toEqual(
+      expect.arrayContaining([
+        `https://api.test/api/nfts?contract=${MEMES_CONTRACT}&id=509`,
+        "https://api.test/api/memes_extended_data?id=509",
+        `https://api.test/api/minting-claims/${MEMES_CONTRACT}/claims/509`,
+        "https://api.test/api/memes-mint-stats/509",
+      ])
+    );
+    expect(data).toMatchObject({
+      type: "6529.collection",
+      kind: "the-memes",
+      title: "The Collective Synapse",
+      kicker: "The Memes #509",
+      people: [{ label: "by", name: "elnaz555", href: "/elnaz555" }],
+      image: {
+        url: "https://cdn.6529.io/memes/509.png",
+        secureUrl: "https://cdn.6529.io/memes/509.png",
+      },
+    });
+    expect(data.facts).toEqual([
+      { label: "Edition size", value: "328" },
+      { label: "TDH rate", value: "25.1" },
+      { label: "Season", value: "15" },
+      { label: "Mint date", value: "1 Jun 2026" },
+    ]);
+  });
+
+  it("builds NextGen previews with rarity and the three rarest traits", async () => {
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = readFetchUrl(input);
+
+      if (url.pathname === "/api/nextgen/tokens/10000000514") {
+        return jsonResponse({
+          id: 10000000514,
+          pending: false,
+          name: "Pebbles #514",
+          collection_id: 1,
+          collection_name: "Pebbles",
+          mint_date: "2024-04-11T12:00:00.000Z",
+          rarity_score_rank: 86,
+          thumbnail_url: "https://cdn.6529.io/nextgen/514.png",
+        });
+      }
+
+      if (url.pathname === "/api/nextgen/tokens/10000000514/traits") {
+        return jsonResponse([
+          {
+            trait: "Collection Name",
+            value: "Pebbles",
+            token_count: 1000,
+            trait_count: 1000,
+            value_count: 1000,
+          },
+          {
+            trait: "Flow",
+            value: "Long",
+            token_count: 1000,
+            trait_count: 900,
+            value_count: 935,
+          },
+          {
+            trait: "Color Density",
+            value: "Sparse",
+            token_count: 1000,
+            trait_count: 200,
+            value_count: 143,
+          },
+          {
+            trait: "Mint Type",
+            value: "Public",
+            token_count: 1000,
+            trait_count: 100,
+            value_count: 50,
+          },
+          {
+            trait: "Palette",
+            value: "Blueprint",
+            token_count: 1000,
+            trait_count: 40,
+            value_count: 21,
+          },
+        ]);
+      }
+
+      if (url.pathname === "/api/nextgen/collections/1") {
+        return jsonResponse({
+          id: 1,
+          name: "Pebbles",
+          artist: "Zeblocks",
+          total_supply: 1000,
+        });
+      }
+
+      if (url.pathname === "/api/identities/zeblocks") {
+        return jsonResponse({ handle: "zeblocks" });
+      }
+
+      return jsonResponse({}, 404);
+    });
+
+    const plan = createFirstParty6529Plan(
+      new URL("https://6529.io/nextgen/token/10000000514")
+    );
+
+    expect(plan).not.toBeNull();
+
+    const { data } = await plan!.execute();
+
+    expect(data).toMatchObject({
+      type: "6529.collection",
+      kind: "nextgen-token",
+      title: "Pebbles #514",
+      kicker: "NextGen \u00b7 Pebbles",
+      people: [{ label: "by", name: "Zeblocks", href: "/zeblocks" }],
+    });
+    expect(data.facts).toEqual([
+      { label: "Rarity", value: "#86 / 1,000" },
+      { label: "Mint date", value: "11 Apr 2024" },
+    ]);
+    expect(data.traits).toEqual([
+      { label: "Palette", value: "Blueprint" },
+      { label: "Mint Type", value: "Public" },
+      { label: "Color Density", value: "Sparse" },
+    ]);
+  });
+});

--- a/__tests__/app/api/open-graph.6529.service.test.ts
+++ b/__tests__/app/api/open-graph.6529.service.test.ts
@@ -173,7 +173,7 @@ describe("createFirstParty6529Plan", () => {
     expect(stagingPlan?.cacheKey).toBe("6529:staging:the-memes:/the-memes/509");
   });
 
-  it("uses public extended data for The Memes edition size when claim data is unavailable", async () => {
+  it("does not label fresh public supply as The Memes edition size", async () => {
     mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
       const url = readFetchUrl(input);
 
@@ -187,7 +187,7 @@ describe("createFirstParty6529Plan", () => {
               artist: "elnaz555",
               artist_seize_handle: "elnaz555",
               hodl_rate: 22.7803,
-              mint_date: "2026-06-15T00:00:00.000Z",
+              mint_date: new Date().toISOString(),
               thumbnail: "https://cdn.6529.io/memes/509.png",
               metadata: {
                 attributes: [{ trait_type: "Type - Season", value: 15 }],
@@ -223,10 +223,17 @@ describe("createFirstParty6529Plan", () => {
     const { data } = await plan!.execute();
 
     expect(data.facts).toEqual([
-      { label: "Edition size", value: "173" },
       { label: "TDH rate", value: "22.78" },
       { label: "Season", value: "15" },
-      { label: "Mint date", value: "15 Jun 2026" },
+      {
+        label: "Mint date",
+        value: new Intl.DateTimeFormat("en-GB", {
+          day: "numeric",
+          month: "short",
+          year: "numeric",
+          timeZone: "UTC",
+        }).format(new Date()),
+      },
     ]);
   });
 

--- a/__tests__/app/api/open-graph.route.test.ts
+++ b/__tests__/app/api/open-graph.route.test.ts
@@ -1,6 +1,20 @@
 import type { NextRequest } from "next/server";
+import { ReadableStream as NodeReadableStream } from "node:stream/web";
+import { MessagePort as NodeMessagePort } from "node:worker_threads";
 
 import { publicEnv } from "@/config/env";
+
+if (typeof globalThis.ReadableStream === "undefined") {
+  Object.defineProperty(globalThis, "ReadableStream", {
+    value: NodeReadableStream,
+  });
+}
+
+if (typeof globalThis.MessagePort === "undefined") {
+  Object.defineProperty(globalThis, "MessagePort", {
+    value: NodeMessagePort,
+  });
+}
 
 const mockFetchPublicUrl = jest.fn();
 
@@ -65,6 +79,10 @@ jest.mock("@/app/api/open-graph/transient/service", () => ({
   createTransientPlan: jest.fn(() => null),
 }));
 
+jest.mock("@/app/api/open-graph/6529/service", () => ({
+  createFirstParty6529Plan: jest.fn(() => null),
+}));
+
 jest.mock("@/app/api/open-graph/ens", () => ({
   detectEnsTarget: jest.fn(),
   fetchEnsPreview: jest.fn(),
@@ -98,6 +116,9 @@ let opensea: {
 };
 let transient: {
   createTransientPlan: jest.Mock;
+};
+let firstParty6529: {
+  createFirstParty6529Plan: jest.Mock;
 };
 let UrlGuardError: typeof import("@/lib/security/urlGuard").UrlGuardError;
 let ensRouteModule: {
@@ -174,6 +195,11 @@ async function loadRoute(): Promise<void> {
   ) as {
     createTransientPlan: jest.Mock;
   };
+  firstParty6529 = jest.requireMock(
+    "@/app/api/open-graph/6529/service"
+  ) as {
+    createFirstParty6529Plan: jest.Mock;
+  };
   ensRouteModule = jest.requireMock("@/app/api/open-graph/ens") as {
     detectEnsTarget: jest.Mock;
     fetchEnsPreview: jest.Mock;
@@ -194,6 +220,7 @@ describe("open-graph API route", () => {
     foundation.createFoundationPlan.mockReturnValue(null);
     opensea.createOpenSeaPlan.mockReturnValue(null);
     transient.createTransientPlan.mockReturnValue(null);
+    firstParty6529.createFirstParty6529Plan.mockReturnValue(null);
     compound.createCompoundPlan.mockReturnValue(null);
     utils.buildGoogleWorkspaceResponse.mockResolvedValue(null);
     mockFetch.mockReset();
@@ -317,6 +344,10 @@ describe("open-graph API route", () => {
     const first = await GET(request);
     const second = await GET(request);
 
+    expect(firstParty6529.createFirstParty6529Plan).toHaveBeenCalledWith(
+      new URL("http://safe.example/article"),
+      { apiAuth: null }
+    );
     expect(compound.createCompoundPlan).toHaveBeenCalledWith(
       new URL("http://safe.example/article")
     );
@@ -368,6 +399,53 @@ describe("open-graph API route", () => {
       "text/html",
       "https://cdn.safe.example/page"
     );
+  });
+
+  it("uses first-party 6529 plans before provider and generic plans", async () => {
+    const firstPartyData = {
+      type: "6529.collection",
+      kind: "the-memes",
+      title: "The Collective Synapse",
+      kicker: "The Memes #509",
+    };
+    const execute = jest.fn(async () => ({
+      data: firstPartyData,
+      ttl: 45_000,
+    }));
+    const cookies = {
+      get: jest.fn(() => ({ value: "cookie-secret" })),
+    };
+
+    firstParty6529.createFirstParty6529Plan.mockReturnValue({
+      cacheKey: "6529:auth:the-memes:/the-memes/509",
+      execute,
+    });
+
+    const request = {
+      nextUrl: new URL(
+        "https://app.local/api/open-graph?url=https://6529.io/the-memes/509"
+      ),
+      cookies,
+      headers: new Headers({ "x-6529-auth": "header-secret" }),
+    } as any;
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(firstPartyData);
+    expect(firstParty6529.createFirstParty6529Plan).toHaveBeenCalledWith(
+      new URL("https://6529.io/the-memes/509"),
+      { apiAuth: "cookie-secret" }
+    );
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(guard.assertPublicUrl).not.toHaveBeenCalled();
+    expect(manifold.createManifoldPlan).not.toHaveBeenCalled();
+    expect(foundation.createFoundationPlan).not.toHaveBeenCalled();
+    expect(opensea.createOpenSeaPlan).not.toHaveBeenCalled();
+    expect(transient.createTransientPlan).not.toHaveBeenCalled();
+    expect(compound.createCompoundPlan).not.toHaveBeenCalled();
+    expect(mockFetchPublicUrl).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("applies host-specific overrides for facebook", async () => {

--- a/__tests__/app/api/open-graph.route.test.ts
+++ b/__tests__/app/api/open-graph.route.test.ts
@@ -498,6 +498,10 @@ describe("open-graph API route", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(fallbackData);
     expect(execute).toHaveBeenCalledTimes(1);
+    expect(guard.assertPublicUrl).toHaveBeenCalledWith(
+      new URL("https://6529.io/the-memes/509"),
+      expect.any(Object)
+    );
     expect(mockFetchPublicUrl).toHaveBeenCalledTimes(1);
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(utils.buildResponse).toHaveBeenCalledWith(

--- a/__tests__/app/api/open-graph.route.test.ts
+++ b/__tests__/app/api/open-graph.route.test.ts
@@ -448,6 +448,66 @@ describe("open-graph API route", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it("falls back to generic metadata when first-party 6529 enrichment fails", async () => {
+    const html =
+      "<html><head><title>The Collective Synapse</title></head><body></body></html>";
+    const fallbackData = {
+      requestUrl: "https://6529.io/the-memes/509",
+      url: "https://6529.io/the-memes/509",
+      title: "The Collective Synapse",
+      description: "The Memes #509 | Collections | 6529.io",
+      siteName: "6529.io",
+      image: {
+        url: "https://cdn.6529.io/memes/509.png",
+        secureUrl: "https://cdn.6529.io/memes/509.png",
+      },
+      images: [],
+    };
+    const execute = jest.fn(async () => {
+      throw new Error("The Memes card was not found.");
+    });
+    const fetchResponse = createResponse(200, {
+      headers: { "content-type": "text/html" },
+      body: html,
+      url: "https://6529.io/the-memes/509",
+    });
+
+    firstParty6529.createFirstParty6529Plan.mockReturnValue({
+      cacheKey: "6529:staging:the-memes:/the-memes/509",
+      execute,
+    });
+    mockFetch.mockResolvedValueOnce(fetchResponse);
+    mockFetchPublicUrl.mockImplementationOnce(
+      async (url, init = {}, options = {}) => {
+        expect(url).toEqual(new URL("https://6529.io/the-memes/509"));
+        const result = await options.fetchImpl?.(url, init);
+        return (result ?? fetchResponse) as any;
+      }
+    );
+    utils.buildGoogleWorkspaceResponse.mockResolvedValueOnce(null);
+    utils.buildResponse.mockReturnValue(fallbackData);
+
+    const request = {
+      nextUrl: new URL(
+        "https://app.local/api/open-graph?url=https://6529.io/the-memes/509"
+      ),
+    } as any;
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(fallbackData);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(mockFetchPublicUrl).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(utils.buildResponse).toHaveBeenCalledWith(
+      new URL("https://6529.io/the-memes/509"),
+      html,
+      "text/html",
+      "https://6529.io/the-memes/509"
+    );
+  });
+
   it("does not trust caller-supplied auth headers for first-party 6529 plans", async () => {
     const firstPartyData = {
       type: "6529.collection",

--- a/__tests__/app/api/open-graph.route.test.ts
+++ b/__tests__/app/api/open-graph.route.test.ts
@@ -448,6 +448,40 @@ describe("open-graph API route", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it("does not trust caller-supplied auth headers for first-party 6529 plans", async () => {
+    const firstPartyData = {
+      type: "6529.collection",
+      kind: "the-memes",
+      title: "The Collective Synapse",
+    };
+    const execute = jest.fn(async () => ({
+      data: firstPartyData,
+      ttl: 45_000,
+    }));
+
+    firstParty6529.createFirstParty6529Plan.mockReturnValue({
+      cacheKey: "6529:public:the-memes:/the-memes/509",
+      execute,
+    });
+
+    const request = {
+      nextUrl: new URL(
+        "https://app.local/api/open-graph?url=https://6529.io/the-memes/509"
+      ),
+      headers: new Headers({ "x-6529-auth": "header-secret" }),
+    } as any;
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(firstPartyData);
+    expect(firstParty6529.createFirstParty6529Plan).toHaveBeenCalledWith(
+      new URL("https://6529.io/the-memes/509"),
+      { apiAuth: null }
+    );
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
   it("applies host-specific overrides for facebook", async () => {
     const html = "<html></html>";
     const responsePayload = {

--- a/__tests__/components/waves/LinkPreviewCard.test.tsx
+++ b/__tests__/components/waves/LinkPreviewCard.test.tsx
@@ -192,6 +192,40 @@ describe("LinkPreviewCard", () => {
     assertStableFrame();
   });
 
+  it("lets 6529 collection previews grow beyond the generic fixed frame", async () => {
+    fetchLinkPreview.mockResolvedValue({
+      type: "6529.collection",
+      title: "Pebbles #514",
+      url: "https://6529.io/nextgen/token/514",
+      facts: [{ label: "Rarity", value: "#86 / 1,000" }],
+      traits: [
+        { label: "Palette", value: "Electric Blue" },
+        { label: "Mint Type", value: "Airdrop" },
+        { label: "Color Density", value: "Sparse" },
+      ],
+    });
+
+    render(
+      <LinkPreviewCard
+        href="https://6529.io/nextgen/token/514"
+        renderFallback={() => <div data-testid="fallback">fallback</div>}
+      />
+    );
+
+    await waitFor(() =>
+      expect(mockOpenGraphPreview).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          preview: expect.objectContaining({ type: "6529.collection" }),
+        })
+      )
+    );
+
+    const frame = screen.getByTestId("link-preview-card-stable-frame");
+    expect(frame).toHaveClass("tw-min-h-[11rem]", "md:tw-min-h-[12rem]");
+    expect(frame.className).not.toContain("tw-max-h-[11rem]");
+    expect(frame.className).not.toContain("tw-max-h-[12rem]");
+  });
+
   it("does not enforce chat stable frame for home variant", async () => {
     fetchLinkPreview.mockResolvedValue({});
 

--- a/__tests__/components/waves/OpenGraphPreview.test.tsx
+++ b/__tests__/components/waves/OpenGraphPreview.test.tsx
@@ -312,4 +312,85 @@ describe("OpenGraphPreview", () => {
       "https://cdn.example.com/preview.png"
     );
   });
+
+  it("renders first-party The Memes collection cards without duplicate mint counts", () => {
+    (removeBaseEndpoint as jest.Mock).mockReturnValue("/the-memes/509");
+
+    render(
+      <OpenGraphPreview
+        href="https://6529.io/the-memes/509"
+        preview={{
+          type: "6529.collection",
+          kind: "the-memes",
+          title: "The Collective Synapse",
+          kicker: "The Memes #509",
+          people: [{ label: "by", name: "elnaz555", href: "/elnaz555" }],
+          facts: [
+            { label: "Edition size", value: "328" },
+            { label: "TDH rate", value: "25.1" },
+            { label: "Season", value: "15" },
+            { label: "Mint date", value: "1 Jun 2026" },
+          ],
+          image: { url: "https://cdn.6529.io/memes/509.png" },
+        }}
+      />
+    );
+
+    expect(screen.getByTestId("6529-collection-preview-card")).toBeInTheDocument();
+    expect(screen.getAllByText("The Memes #509")).toHaveLength(1);
+    expect(screen.getByText("The Collective Synapse")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "elnaz555" })).toHaveAttribute(
+      "href",
+      "/elnaz555"
+    );
+    expect(screen.getByText("Edition size")).toBeInTheDocument();
+    expect(screen.getByText("328")).toBeInTheDocument();
+    expect(screen.getByText("TDH rate")).toBeInTheDocument();
+    expect(screen.getByText("25.1")).toBeInTheDocument();
+    expect(screen.getByText("Season")).toBeInTheDocument();
+    expect(screen.getByText("15")).toBeInTheDocument();
+    expect(screen.queryByText("158/328")).toBeNull();
+  });
+
+  it("renders first-party NextGen cards with capped rare trait chips", () => {
+    (removeBaseEndpoint as jest.Mock).mockReturnValue(
+      "/nextgen/token/10000000514"
+    );
+
+    render(
+      <OpenGraphPreview
+        href="https://6529.io/nextgen/token/10000000514"
+        preview={{
+          type: "6529.collection",
+          kind: "nextgen-token",
+          title: "Pebbles #514",
+          kicker: "NextGen \u00b7 Pebbles",
+          people: [{ label: "by", name: "Zeblocks", href: "/zeblocks" }],
+          facts: [
+            { label: "Rarity", value: "#86 / 1,000" },
+            { label: "Mint date", value: "11 Apr 2024" },
+          ],
+          traits: [
+            { label: "Palette", value: "Blueprint" },
+            { label: "Mint Type", value: "Public" },
+            { label: "Color Density", value: "Sparse" },
+          ],
+          image: { url: "https://cdn.6529.io/nextgen/514.png" },
+        }}
+      />
+    );
+
+    expect(screen.getByTestId("6529-collection-preview-card")).toBeInTheDocument();
+    expect(screen.getByText("Pebbles #514")).toBeInTheDocument();
+    expect(screen.getByText("NextGen \u00b7 Pebbles")).toBeInTheDocument();
+    expect(screen.getByText("Rarity")).toBeInTheDocument();
+    expect(screen.getByText("#86 / 1,000")).toBeInTheDocument();
+    expect(screen.getByText("Palette: Blueprint")).toBeInTheDocument();
+    expect(screen.getByText("Mint Type: Public")).toBeInTheDocument();
+    expect(screen.getByText("Color Density: Sparse")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Zeblocks" })).toHaveAttribute(
+      "href",
+      "/zeblocks"
+    );
+  });
 });

--- a/app/api/open-graph/6529/service.ts
+++ b/app/api/open-graph/6529/service.ts
@@ -28,7 +28,7 @@ import type {
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const FIRST_PARTY_HOST = "6529.io";
-const LIVE_MINT_FALLBACK_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+const NEXTGEN_TOKEN_ID_MULTIPLIER = 10_000_000_000;
 
 type ApiContext = {
   readonly apiAuth?: string | null | undefined;
@@ -547,25 +547,6 @@ async function resolveProfileHref(
   return handle ? `/${handle.replace(/^@/, "")}` : undefined;
 }
 
-function shouldUseExtendedEditionSize(
-  nft: NftRecord,
-  extendedEditionSize: number | undefined
-): boolean {
-  if (extendedEditionSize === undefined) {
-    return false;
-  }
-
-  const supply = readNumber(nft.supply);
-  const mintDate = new Date(readString(nft.mint_date) ?? "");
-  const looksLikeFreshLiveMintCount =
-    supply !== undefined &&
-    extendedEditionSize === supply &&
-    !Number.isNaN(mintDate.getTime()) &&
-    Date.now() - mintDate.getTime() < LIVE_MINT_FALLBACK_WINDOW_MS;
-
-  return !looksLikeFreshLiveMintCount;
-}
-
 function readMemeSeason(
   nft: MemesRecord,
   metadata: Record<string, unknown> | null
@@ -615,14 +596,8 @@ async function fetchTheMemesPreview(
   const claimEditionSize = readPositiveNumber(claim?.edition_size);
   const mintStatEditionSize = readPositiveNumber(mintStat?.total_count);
   const extendedEditionSize = readPositiveNumber(extended?.edition_size);
-  const fallbackEditionSize = shouldUseExtendedEditionSize(
-    source,
-    extendedEditionSize
-  )
-    ? extendedEditionSize
-    : undefined;
   const editionSize =
-    claimEditionSize ?? mintStatEditionSize ?? fallbackEditionSize;
+    claimEditionSize ?? mintStatEditionSize ?? extendedEditionSize;
   const season = readMemeSeason(source, metadata);
   const tdhRate = readPositiveNumber(source.hodl_rate);
   const mintDate = formatMintDate(source.mint_date);
@@ -811,18 +786,71 @@ function sortNextGenTraits(
     });
 }
 
-async function fetchNextGenPreview(
+async function fetchNextGenToken(
   tokenId: string,
-  requestUrl: URL,
   context?: ApiContext
-): Promise<SeizeCollectionLinkPreview> {
+): Promise<NextGenToken | null> {
   const token = await fetchOptionalApiJson<NextGenToken>(
     `nextgen/tokens/${tokenId}`,
     undefined,
     context
   );
 
-  if (!token || token.pending) {
+  return token && !token.pending ? token : null;
+}
+
+async function fetchNextGenCollections(
+  context?: ApiContext
+): Promise<readonly NextGenCollection[]> {
+  const page = await fetchOptionalApiJson<ApiPage<NextGenCollection>>(
+    "nextgen/collections",
+    { page_size: 100 },
+    context
+  );
+
+  return page?.data ?? [];
+}
+
+async function resolveNextGenToken(
+  tokenId: string,
+  context?: ApiContext
+): Promise<NextGenToken | null> {
+  const directToken = await fetchNextGenToken(tokenId, context);
+  if (directToken) {
+    return directToken;
+  }
+
+  const normalizedTokenId = readNumber(tokenId);
+  if (
+    normalizedTokenId === undefined ||
+    !Number.isInteger(normalizedTokenId) ||
+    normalizedTokenId < 0 ||
+    normalizedTokenId >= NEXTGEN_TOKEN_ID_MULTIPLIER
+  ) {
+    return null;
+  }
+
+  const collections = await fetchNextGenCollections(context);
+  for (const collection of collections) {
+    const expandedTokenId =
+      collection.id * NEXTGEN_TOKEN_ID_MULTIPLIER + normalizedTokenId;
+    const token = await fetchNextGenToken(String(expandedTokenId), context);
+    if (token?.normalised_id === normalizedTokenId) {
+      return token;
+    }
+  }
+
+  return null;
+}
+
+async function fetchNextGenPreview(
+  tokenId: string,
+  requestUrl: URL,
+  context?: ApiContext
+): Promise<SeizeCollectionLinkPreview> {
+  const token = await resolveNextGenToken(tokenId, context);
+
+  if (!token) {
     throw new Error("NextGen token was not found.");
   }
 

--- a/app/api/open-graph/6529/service.ts
+++ b/app/api/open-graph/6529/service.ts
@@ -28,6 +28,7 @@ import type {
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const FIRST_PARTY_HOST = "6529.io";
+const LIVE_MINT_FALLBACK_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 const NEXTGEN_TOKEN_ID_MULTIPLIER = 10_000_000_000;
 const NEXTGEN_SHORT_TOKEN_LOOKUP_MAX_COLLECTIONS = 5;
 
@@ -548,6 +549,25 @@ async function resolveProfileHref(
   return handle ? `/${handle.replace(/^@/, "")}` : undefined;
 }
 
+function shouldUseExtendedEditionSize(
+  nft: NftRecord,
+  extendedEditionSize: number | undefined
+): boolean {
+  if (extendedEditionSize === undefined) {
+    return false;
+  }
+
+  const supply = readNumber(nft.supply);
+  const mintDate = new Date(readString(nft.mint_date) ?? "");
+  const looksLikeFreshLiveMintCount =
+    supply !== undefined &&
+    extendedEditionSize === supply &&
+    !Number.isNaN(mintDate.getTime()) &&
+    Date.now() - mintDate.getTime() < LIVE_MINT_FALLBACK_WINDOW_MS;
+
+  return !looksLikeFreshLiveMintCount;
+}
+
 function readMemeSeason(
   nft: MemesRecord,
   metadata: Record<string, unknown> | null
@@ -597,8 +617,14 @@ async function fetchTheMemesPreview(
   const claimEditionSize = readPositiveNumber(claim?.edition_size);
   const mintStatEditionSize = readPositiveNumber(mintStat?.total_count);
   const extendedEditionSize = readPositiveNumber(extended?.edition_size);
+  const fallbackEditionSize = shouldUseExtendedEditionSize(
+    source,
+    extendedEditionSize
+  )
+    ? extendedEditionSize
+    : undefined;
   const editionSize =
-    claimEditionSize ?? mintStatEditionSize ?? extendedEditionSize;
+    claimEditionSize ?? mintStatEditionSize ?? fallbackEditionSize;
   const season = readMemeSeason(source, metadata);
   const tdhRate = readPositiveNumber(source.hodl_rate);
   const mintDate = formatMintDate(source.mint_date);

--- a/app/api/open-graph/6529/service.ts
+++ b/app/api/open-graph/6529/service.ts
@@ -29,6 +29,7 @@ import type {
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const FIRST_PARTY_HOST = "6529.io";
 const NEXTGEN_TOKEN_ID_MULTIPLIER = 10_000_000_000;
+const NEXTGEN_SHORT_TOKEN_LOOKUP_MAX_COLLECTIONS = 5;
 
 type ApiContext = {
   readonly apiAuth?: string | null | undefined;
@@ -804,7 +805,7 @@ async function fetchNextGenCollections(
 ): Promise<readonly NextGenCollection[]> {
   const page = await fetchOptionalApiJson<ApiPage<NextGenCollection>>(
     "nextgen/collections",
-    { page_size: 100 },
+    { page_size: NEXTGEN_SHORT_TOKEN_LOOKUP_MAX_COLLECTIONS },
     context
   );
 
@@ -830,17 +831,20 @@ async function resolveNextGenToken(
     return null;
   }
 
-  const collections = await fetchNextGenCollections(context);
-  for (const collection of collections) {
-    const expandedTokenId =
-      collection.id * NEXTGEN_TOKEN_ID_MULTIPLIER + normalizedTokenId;
-    const token = await fetchNextGenToken(String(expandedTokenId), context);
-    if (token?.normalised_id === normalizedTokenId) {
-      return token;
-    }
-  }
+  const tokenCandidates = await Promise.all(
+    (await fetchNextGenCollections(context))
+      .slice(0, NEXTGEN_SHORT_TOKEN_LOOKUP_MAX_COLLECTIONS)
+      .map(async (collection) => {
+        const expandedTokenId =
+          collection.id * NEXTGEN_TOKEN_ID_MULTIPLIER + normalizedTokenId;
+        return fetchNextGenToken(String(expandedTokenId), context);
+      })
+  );
 
-  return null;
+  return (
+    tokenCandidates.find((token) => token?.normalised_id === normalizedTokenId) ??
+    null
+  );
 }
 
 async function fetchNextGenPreview(

--- a/app/api/open-graph/6529/service.ts
+++ b/app/api/open-graph/6529/service.ts
@@ -89,19 +89,37 @@ type IdentityResponse = {
   readonly primary_wallet?: string | null | undefined;
 };
 
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "/") {
+    end -= 1;
+  }
+
+  return value.slice(0, end);
+}
+
+function trimLeadingSlashes(value: string): string {
+  let start = 0;
+  while (start < value.length && value[start] === "/") {
+    start += 1;
+  }
+
+  return value.slice(start);
+}
+
 function getApiBase(): string {
   const base = publicEnv.API_ENDPOINT?.trim();
   if (!base) {
     throw new Error("API endpoint is not configured.");
   }
-  return base.replace(/\/+$/, "");
+  return trimTrailingSlashes(base);
 }
 
 function buildApiUrl(
   endpoint: string,
   params?: Record<string, string | number | undefined>
 ): string {
-  const url = new URL(`/api/${endpoint.replace(/^\/+/, "")}`, `${getApiBase()}/`);
+  const url = new URL(`/api/${trimLeadingSlashes(endpoint)}`, `${getApiBase()}/`);
 
   if (params) {
     for (const [key, value] of Object.entries(params)) {

--- a/app/api/open-graph/6529/service.ts
+++ b/app/api/open-graph/6529/service.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import type { PreviewPlan } from "@/app/api/open-graph/compound/service";
 import { MEMELAB_CONTRACT, MEMES_CONTRACT } from "@/constants/constants";
 import { publicEnv } from "@/config/env";
@@ -112,11 +114,35 @@ function buildApiUrl(
   return url.toString();
 }
 
+function getCallerApiAuth(context?: ApiContext): string | undefined {
+  const apiAuth = context?.apiAuth?.trim();
+  return apiAuth || undefined;
+}
+
+function getApiAuth(context?: ApiContext): string | undefined {
+  return (
+    getCallerApiAuth(context) ?? publicEnv.STAGING_API_KEY?.trim() ?? undefined
+  );
+}
+
+function hashCacheToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex").slice(0, 24);
+}
+
+function getCacheAuthScope(context?: ApiContext): string {
+  const callerAuth = getCallerApiAuth(context);
+  if (callerAuth) {
+    return `auth:${hashCacheToken(callerAuth)}`;
+  }
+
+  return publicEnv.STAGING_API_KEY?.trim() ? "staging" : "public";
+}
+
 function createApiHeaders(context?: ApiContext): HeadersInit {
   const headers: Record<string, string> = {
     accept: "application/json",
   };
-  const apiAuth = context?.apiAuth?.trim() || publicEnv.STAGING_API_KEY;
+  const apiAuth = getApiAuth(context);
 
   if (apiAuth) {
     headers["x-6529-auth"] = apiAuth;
@@ -370,8 +396,34 @@ function compactFacts(
   );
 }
 
+function normalizeHttpsImageUrl(value: unknown): string | undefined {
+  const url = readString(value);
+  if (!url) {
+    return undefined;
+  }
+
+  try {
+    const parsed = new URL(url, "https://6529.io");
+    return parsed.protocol === "https:" ? parsed.toString() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function selectHttpsImageUrl(...values: readonly unknown[]): string | undefined {
+  for (const value of values) {
+    const url = normalizeHttpsImageUrl(value);
+    if (url) {
+      return url;
+    }
+  }
+
+  return undefined;
+}
+
 function createImageMedia(url: string | undefined): LinkPreviewMedia | null {
-  return url ? { url, secureUrl: url } : null;
+  const normalizedUrl = normalizeHttpsImageUrl(url);
+  return normalizedUrl ? { url: normalizedUrl, secureUrl: normalizedUrl } : null;
 }
 
 function buildPreview(input: PreviewBuildInput): SeizeCollectionLinkPreview {
@@ -586,7 +638,7 @@ async function fetchTheMemesPreview(
       createFact("Season", season !== undefined ? formatInteger(season) : undefined),
       createFact("Mint date", mintDate),
     ]),
-    imageUrl: firstNonEmptyString(
+    imageUrl: selectHttpsImageUrl(
       source.thumbnail,
       source.scaled,
       source.image,
@@ -645,7 +697,7 @@ async function fetchMemeLabPreview(
       ),
       createFact("Mint date", mintDate),
     ]),
-    imageUrl: firstNonEmptyString(
+    imageUrl: selectHttpsImageUrl(
       source.thumbnail,
       source.scaled,
       source.image,
@@ -703,7 +755,7 @@ async function fetchGradientPreview(
       ),
       createFact("Mint date", mintDate),
     ]),
-    imageUrl: firstNonEmptyString(
+    imageUrl: selectHttpsImageUrl(
       nft.thumbnail,
       nft.scaled,
       nft.image,
@@ -801,7 +853,7 @@ async function fetchNextGenPreview(
     traits: sortNextGenTraits(traits ?? [])
       .slice(0, 3)
       .map((trait) => ({ label: trait.trait, value: trait.value })),
-    imageUrl: firstNonEmptyString(
+    imageUrl: selectHttpsImageUrl(
       token.thumbnail_url,
       token.icon_url,
       token.image_url
@@ -892,7 +944,7 @@ async function fetchReMemesPreview(
         replicasCount > 1 ? formatInteger(replicasCount) : undefined
       ),
     ]),
-    imageUrl: firstNonEmptyString(
+    imageUrl: selectHttpsImageUrl(
       rememe.s3_image_thumbnail,
       rememe.s3_image_scaled,
       rememe.s3_image_original,
@@ -932,9 +984,7 @@ export function createFirstParty6529Plan(
   }
 
   return {
-    cacheKey: `6529:${
-      context?.apiAuth?.trim() || publicEnv.STAGING_API_KEY ? "auth" : "public"
-    }:${target.kind}:${url.pathname.toLowerCase()}`,
+    cacheKey: `6529:${getCacheAuthScope(context)}:${target.kind}:${url.pathname.toLowerCase()}`,
     execute: async () => {
       const data = await executeTarget(target, url, context);
       return { data, ttl: CACHE_TTL_MS };

--- a/app/api/open-graph/6529/service.ts
+++ b/app/api/open-graph/6529/service.ts
@@ -1,0 +1,943 @@
+import type { PreviewPlan } from "@/app/api/open-graph/compound/service";
+import { MEMELAB_CONTRACT, MEMES_CONTRACT } from "@/constants/constants";
+import { publicEnv } from "@/config/env";
+import type {
+  BaseNFT,
+  LabExtendedData,
+  LabNFT,
+  MemesExtendedData,
+  NFT,
+  Rememe,
+} from "@/entities/INFT";
+import type {
+  NextGenCollection,
+  NextGenToken,
+  NextGenTrait,
+} from "@/entities/INextgen";
+import { matchesDomainOrSubdomain } from "@/lib/url/domains";
+import type {
+  LinkPreviewMedia,
+  SeizeCollectionLinkPreview,
+  SeizeCollectionPreviewFact,
+  SeizeCollectionPreviewKind,
+  SeizeCollectionPreviewPerson,
+  SeizeCollectionPreviewTrait,
+} from "@/services/api/link-preview-api";
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const FIRST_PARTY_HOST = "6529.io";
+const LIVE_MINT_FALLBACK_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+type ApiContext = {
+  readonly apiAuth?: string | null | undefined;
+};
+
+type ApiPage<T> = {
+  readonly data?: readonly T[] | null | undefined;
+};
+
+type NftRecord = Partial<BaseNFT> &
+  Partial<NFT> &
+  Partial<LabNFT> & {
+    readonly owner?: string | null | undefined;
+    readonly owner_display?: string | null | undefined;
+  };
+
+type MemesRecord = NftRecord & Partial<MemesExtendedData>;
+type LabRecord = NftRecord & Partial<LabExtendedData>;
+
+type MintingClaimRecord = {
+  readonly edition_size?: number | null | undefined;
+  readonly name?: string | null | undefined;
+  readonly image_url?: string | null | undefined;
+  readonly attributes?: readonly AttributeRecord[] | null | undefined;
+};
+
+type MemesMintStatRecord = {
+  readonly total_count?: number | null | undefined;
+};
+
+type AttributeRecord = {
+  readonly trait_type?: string | null | undefined;
+  readonly value?: string | number | null | undefined;
+};
+
+type ResolvedTarget =
+  | { readonly kind: "the-memes"; readonly id: string }
+  | { readonly kind: "meme-lab"; readonly id: string }
+  | { readonly kind: "6529-gradient"; readonly id: string }
+  | { readonly kind: "nextgen-token"; readonly tokenId: string }
+  | { readonly kind: "rememes"; readonly contract: string; readonly id: string };
+
+type PreviewBuildInput = {
+  readonly kind: SeizeCollectionPreviewKind;
+  readonly requestUrl: URL;
+  readonly title: string;
+  readonly kicker?: string | null | undefined;
+  readonly people?: readonly SeizeCollectionPreviewPerson[] | undefined;
+  readonly facts?: readonly SeizeCollectionPreviewFact[] | undefined;
+  readonly traits?: readonly SeizeCollectionPreviewTrait[] | undefined;
+  readonly imageUrl?: string | null | undefined;
+};
+
+type IdentityResponse = {
+  readonly handle?: string | null | undefined;
+  readonly normalised_handle?: string | null | undefined;
+  readonly display?: string | null | undefined;
+  readonly primary_wallet?: string | null | undefined;
+};
+
+function getApiBase(): string {
+  const base = publicEnv.API_ENDPOINT?.trim();
+  if (!base) {
+    throw new Error("API endpoint is not configured.");
+  }
+  return base.replace(/\/+$/, "");
+}
+
+function buildApiUrl(
+  endpoint: string,
+  params?: Record<string, string | number | undefined>
+): string {
+  const url = new URL(`/api/${endpoint.replace(/^\/+/, "")}`, `${getApiBase()}/`);
+
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined) {
+        url.searchParams.set(key, String(value));
+      }
+    }
+  }
+
+  return url.toString();
+}
+
+function createApiHeaders(context?: ApiContext): HeadersInit {
+  const headers: Record<string, string> = {
+    accept: "application/json",
+  };
+  const apiAuth = context?.apiAuth?.trim() || publicEnv.STAGING_API_KEY;
+
+  if (apiAuth) {
+    headers["x-6529-auth"] = apiAuth;
+  }
+
+  return headers;
+}
+
+async function fetchApiJson<T>(
+  endpoint: string,
+  params?: Record<string, string | number | undefined>,
+  context?: ApiContext
+): Promise<T> {
+  const response = await fetch(buildApiUrl(endpoint, params), {
+    headers: createApiHeaders(context),
+  });
+
+  if (!response.ok) {
+    throw new Error(`6529 API request failed with status ${response.status}.`);
+  }
+
+  return (await response.json()) as T;
+}
+
+async function fetchOptionalApiJson<T>(
+  endpoint: string,
+  params?: Record<string, string | number | undefined>,
+  context?: ApiContext
+): Promise<T | null> {
+  try {
+    return await fetchApiJson<T>(endpoint, params, context);
+  } catch {
+    return null;
+  }
+}
+
+async function fetchFirstPageItem<T>(
+  endpoint: string,
+  params?: Record<string, string | number | undefined>,
+  context?: ApiContext
+): Promise<T | null> {
+  const page = await fetchOptionalApiJson<ApiPage<T>>(endpoint, params, context);
+  return page?.data?.[0] ?? null;
+}
+
+function isFirstPartyHost(url: URL): boolean {
+  const hostname = url.hostname.toLowerCase();
+  if (matchesDomainOrSubdomain(hostname, FIRST_PARTY_HOST)) {
+    return true;
+  }
+
+  if (!publicEnv.BASE_ENDPOINT) {
+    return false;
+  }
+
+  try {
+    return new URL(publicEnv.BASE_ENDPOINT).hostname.toLowerCase() === hostname;
+  } catch {
+    return false;
+  }
+}
+
+function readNumericPathSegment(value: string | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized && /^\d+$/.test(normalized) ? normalized : null;
+}
+
+function readContractSegment(value: string | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized && /^0x[a-f0-9]{40}$/i.test(normalized) ? normalized : null;
+}
+
+function resolveTarget(url: URL): ResolvedTarget | null {
+  if (!isFirstPartyHost(url)) {
+    return null;
+  }
+
+  const segments = url.pathname.split("/").filter(Boolean);
+  const [root, first, second] = segments;
+
+  if (root === "the-memes") {
+    const id = readNumericPathSegment(first);
+    return id ? { kind: "the-memes", id } : null;
+  }
+
+  if (root === "meme-lab") {
+    const id = readNumericPathSegment(first);
+    return id ? { kind: "meme-lab", id } : null;
+  }
+
+  if (root === "6529-gradient") {
+    const id = readNumericPathSegment(first);
+    return id ? { kind: "6529-gradient", id } : null;
+  }
+
+  if (root === "nextgen" && first === "token") {
+    const tokenId = readNumericPathSegment(second);
+    return tokenId ? { kind: "nextgen-token", tokenId } : null;
+  }
+
+  if (root === "rememes") {
+    const contract = readContractSegment(first);
+    const id = readNumericPathSegment(second);
+    return contract && id ? { kind: "rememes", contract, id } : null;
+  }
+
+  return null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function parseMetadata(value: unknown): Record<string, unknown> | null {
+  if (typeof value === "string") {
+    try {
+      return asRecord(JSON.parse(value));
+    } catch {
+      return null;
+    }
+  }
+
+  return asRecord(value);
+}
+
+function readString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function readPositiveNumber(value: unknown): number | undefined {
+  const parsed = readNumber(value);
+  return parsed !== undefined && parsed > 0 ? parsed : undefined;
+}
+
+function readMetadataString(
+  metadata: Record<string, unknown> | null,
+  key: string
+): string | undefined {
+  return metadata ? readString(metadata[key]) : undefined;
+}
+
+function readAttributes(
+  metadata: Record<string, unknown> | null
+): readonly AttributeRecord[] {
+  const attributes = metadata?.["attributes"];
+  return Array.isArray(attributes) ? (attributes as AttributeRecord[]) : [];
+}
+
+function normalizeTraitType(value: string | null | undefined): string {
+  return (value ?? "").trim().toLowerCase().replaceAll(/\s+/g, " ");
+}
+
+function readAttributeValue(
+  attributes: readonly AttributeRecord[],
+  traitType: string
+): string | undefined {
+  const normalizedTrait = normalizeTraitType(traitType);
+  const match = attributes.find(
+    (attribute) => normalizeTraitType(attribute.trait_type) === normalizedTrait
+  );
+
+  return readString(match?.value);
+}
+
+function firstNonEmptyString(
+  ...values: readonly unknown[]
+): string | undefined {
+  for (const value of values) {
+    const stringValue = readString(value);
+    if (stringValue) {
+      return stringValue;
+    }
+  }
+
+  return undefined;
+}
+
+function firstPositiveNumber(
+  ...values: readonly unknown[]
+): number | undefined {
+  for (const value of values) {
+    const numberValue = readPositiveNumber(value);
+    if (numberValue !== undefined) {
+      return numberValue;
+    }
+  }
+
+  return undefined;
+}
+
+function formatInteger(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 0,
+  }).format(value);
+}
+
+function formatDecimal(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatMintDate(value: unknown): string | undefined {
+  const raw = readString(value);
+  if (!raw) {
+    return undefined;
+  }
+
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(date);
+}
+
+function createFact(
+  label: string,
+  value: string | number | undefined
+): SeizeCollectionPreviewFact | null {
+  const stringValue = readString(value);
+  return stringValue ? { label, value: stringValue } : null;
+}
+
+function compactFacts(
+  facts: readonly (SeizeCollectionPreviewFact | null | undefined)[]
+): SeizeCollectionPreviewFact[] {
+  return facts.filter(
+    (fact): fact is SeizeCollectionPreviewFact => fact !== null && fact !== undefined
+  );
+}
+
+function createImageMedia(url: string | undefined): LinkPreviewMedia | null {
+  return url ? { url, secureUrl: url } : null;
+}
+
+function buildPreview(input: PreviewBuildInput): SeizeCollectionLinkPreview {
+  const image = createImageMedia(input.imageUrl ?? undefined);
+  const descriptionParts = [
+    input.kicker,
+    ...(input.people ?? []).map((person) =>
+      person.label ? `${person.label} ${person.name}` : person.name
+    ),
+    ...(input.facts ?? []).map((fact) => `${fact.label} ${fact.value}`),
+  ].filter((part): part is string => Boolean(part));
+
+  return {
+    type: "6529.collection",
+    kind: input.kind,
+    requestUrl: input.requestUrl.toString(),
+    url: input.requestUrl.toString(),
+    title: input.title,
+    description: descriptionParts.length > 0 ? descriptionParts.join(" | ") : null,
+    siteName: "6529",
+    mediaType: null,
+    contentType: null,
+    favicon: null,
+    favicons: [],
+    image,
+    images: image ? [image] : [],
+    kicker: input.kicker ?? null,
+    people: input.people ?? [],
+    facts: input.facts ?? [],
+    traits: input.traits ?? [],
+  };
+}
+
+function firstHandle(value: string | null | undefined): string | undefined {
+  return value
+    ?.split(",")
+    .map((handle) => handle.trim().replace(/^@/, ""))
+    .find((handle) => handle.length > 0);
+}
+
+function profileHrefForHandle(value: string | null | undefined): string | undefined {
+  const handle = firstHandle(value);
+  return handle ? `/${handle}` : undefined;
+}
+
+function createPerson({
+  label,
+  name,
+  href,
+}: {
+  readonly label?: string | null | undefined;
+  readonly name?: string | null | undefined;
+  readonly href?: string | null | undefined;
+}): SeizeCollectionPreviewPerson | null {
+  const displayName = readString(name);
+  if (!displayName) {
+    return null;
+  }
+
+  const normalizedHref = readString(href);
+
+  return {
+    ...(label ? { label } : {}),
+    name: displayName,
+    ...(normalizedHref ? { href: normalizedHref } : {}),
+  };
+}
+
+function compactPeople(
+  people: readonly (SeizeCollectionPreviewPerson | null | undefined)[]
+): SeizeCollectionPreviewPerson[] {
+  return people.filter(
+    (person): person is SeizeCollectionPreviewPerson =>
+      person !== null && person !== undefined
+  );
+}
+
+function profileLookupCandidate(value: string | null | undefined): string | null {
+  const normalized = value?.trim().replace(/^@/, "");
+  if (!normalized || normalized.includes(",") || normalized.includes(" ")) {
+    return null;
+  }
+
+  return normalized;
+}
+
+async function resolveProfileHref(
+  value: string | null | undefined,
+  context?: ApiContext
+): Promise<string | undefined> {
+  const candidate = profileLookupCandidate(value);
+  if (!candidate) {
+    return undefined;
+  }
+
+  const profile = await fetchOptionalApiJson<IdentityResponse>(
+    `identities/${encodeURIComponent(candidate.toLowerCase())}`,
+    undefined,
+    context
+  );
+  const handle = firstNonEmptyString(profile?.handle, profile?.normalised_handle);
+
+  return handle ? `/${handle.replace(/^@/, "")}` : undefined;
+}
+
+function shouldUseExtendedEditionSize(
+  nft: NftRecord,
+  extendedEditionSize: number | undefined
+): boolean {
+  if (extendedEditionSize === undefined) {
+    return false;
+  }
+
+  const supply = readNumber(nft.supply);
+  const mintDate = new Date(readString(nft.mint_date) ?? "");
+  const looksLikeFreshLiveMintCount =
+    supply !== undefined &&
+    extendedEditionSize === supply &&
+    !Number.isNaN(mintDate.getTime()) &&
+    Date.now() - mintDate.getTime() < LIVE_MINT_FALLBACK_WINDOW_MS;
+
+  return !looksLikeFreshLiveMintCount;
+}
+
+function readMemeSeason(
+  nft: MemesRecord,
+  metadata: Record<string, unknown> | null
+): number | undefined {
+  return firstPositiveNumber(
+    nft.season,
+    readAttributeValue(readAttributes(metadata), "Type - Season")
+  );
+}
+
+async function fetchTheMemesPreview(
+  id: string,
+  requestUrl: URL,
+  context?: ApiContext
+): Promise<SeizeCollectionLinkPreview> {
+  const [nft, extended, claim, mintStat] = await Promise.all([
+    fetchFirstPageItem<MemesRecord>(
+      "nfts",
+      { contract: MEMES_CONTRACT, id },
+      context
+    ),
+    fetchFirstPageItem<MemesRecord>("memes_extended_data", { id }, context),
+    fetchOptionalApiJson<MintingClaimRecord>(
+      `minting-claims/${encodeURIComponent(MEMES_CONTRACT)}/claims/${id}`,
+      undefined,
+      context
+    ),
+    fetchOptionalApiJson<MemesMintStatRecord>(
+      `memes-mint-stats/${id}`,
+      undefined,
+      context
+    ),
+  ]);
+
+  const source = nft ?? extended;
+  if (!source) {
+    throw new Error("The Memes card was not found.");
+  }
+
+  const metadata = parseMetadata(source.metadata);
+  const attributes = readAttributes(metadata);
+  const explicitArtistHandle = firstNonEmptyString(
+    source.artist_seize_handle,
+    readAttributeValue(attributes, "SEIZE Artist Profile")
+  );
+  const title = firstNonEmptyString(claim?.name, source.name, `The Memes #${id}`)!;
+  const claimEditionSize = readPositiveNumber(claim?.edition_size);
+  const mintStatEditionSize = readPositiveNumber(mintStat?.total_count);
+  const extendedEditionSize = readPositiveNumber(extended?.edition_size);
+  const fallbackEditionSize = shouldUseExtendedEditionSize(
+    source,
+    extendedEditionSize
+  )
+    ? extendedEditionSize
+    : undefined;
+  const editionSize =
+    claimEditionSize ?? mintStatEditionSize ?? fallbackEditionSize;
+  const season = readMemeSeason(source, metadata);
+  const tdhRate = readPositiveNumber(source.hodl_rate);
+  const mintDate = formatMintDate(source.mint_date);
+  const artistName = firstNonEmptyString(
+    explicitArtistHandle,
+    source.artist,
+    readAttributeValue(attributes, "Artist")
+  );
+
+  return buildPreview({
+    kind: "the-memes",
+    requestUrl,
+    title,
+    kicker: `The Memes #${id}`,
+    people: compactPeople([
+      createPerson({
+        label: "by",
+        name: artistName,
+        href: profileHrefForHandle(explicitArtistHandle),
+      }),
+    ]),
+    facts: compactFacts([
+      createFact(
+        "Edition size",
+        editionSize !== undefined ? formatInteger(editionSize) : undefined
+      ),
+      createFact(
+        "TDH rate",
+        tdhRate !== undefined ? formatDecimal(tdhRate) : undefined
+      ),
+      createFact("Season", season !== undefined ? formatInteger(season) : undefined),
+      createFact("Mint date", mintDate),
+    ]),
+    imageUrl: firstNonEmptyString(
+      source.thumbnail,
+      source.scaled,
+      source.image,
+      claim?.image_url,
+      readMetadataString(metadata, "image_url"),
+      readMetadataString(metadata, "image")
+    ),
+  });
+}
+
+async function fetchMemeLabPreview(
+  id: string,
+  requestUrl: URL,
+  context?: ApiContext
+): Promise<SeizeCollectionLinkPreview> {
+  const [nft, extended] = await Promise.all([
+    fetchFirstPageItem<LabRecord>(
+      "nfts_memelab",
+      { contract: MEMELAB_CONTRACT, id },
+      context
+    ),
+    fetchFirstPageItem<LabRecord>("lab_extended_data", { id }, context),
+  ]);
+
+  const source = nft ?? extended;
+  if (!source) {
+    throw new Error("Meme Lab card was not found.");
+  }
+
+  const metadata = parseMetadata(source.metadata);
+  const attributes = readAttributes(metadata);
+  const artistHandle = firstNonEmptyString(
+    source.artist_seize_handle,
+    readAttributeValue(attributes, "SEIZE Artist Profile")
+  );
+  const artistName = firstNonEmptyString(artistHandle, source.artist);
+  const editionSize = firstPositiveNumber(extended?.edition_size, source.supply);
+  const mintDate = formatMintDate(source.mint_date);
+
+  return buildPreview({
+    kind: "meme-lab",
+    requestUrl,
+    title: firstNonEmptyString(source.name, `Meme Lab #${id}`)!,
+    kicker: `Meme Lab #${id}`,
+    people: compactPeople([
+      createPerson({
+        label: "by",
+        name: artistName,
+        href: profileHrefForHandle(artistHandle),
+      }),
+    ]),
+    facts: compactFacts([
+      createFact(
+        "Edition size",
+        editionSize !== undefined ? formatInteger(editionSize) : undefined
+      ),
+      createFact("Mint date", mintDate),
+    ]),
+    imageUrl: firstNonEmptyString(
+      source.thumbnail,
+      source.scaled,
+      source.image,
+      readMetadataString(metadata, "image_url"),
+      readMetadataString(metadata, "image")
+    ),
+  });
+}
+
+async function fetchGradientPreview(
+  id: string,
+  requestUrl: URL,
+  context?: ApiContext
+): Promise<SeizeCollectionLinkPreview> {
+  const nft = await fetchFirstPageItem<NftRecord>(
+    "nfts/gradients",
+    { id, page_size: 1 },
+    context
+  );
+
+  if (!nft) {
+    throw new Error("6529 Gradient was not found.");
+  }
+
+  const metadata = parseMetadata(nft.metadata);
+  const artistHandle = firstHandle(nft.artist_seize_handle);
+  const ownerDisplay = readString(nft.owner_display);
+  const collectorHref = await resolveProfileHref(
+    firstNonEmptyString(ownerDisplay, nft.owner),
+    context
+  );
+  const tdhRate = readPositiveNumber(nft.hodl_rate);
+  const mintDate = formatMintDate(nft.mint_date);
+
+  return buildPreview({
+    kind: "6529-gradient",
+    requestUrl,
+    title: firstNonEmptyString(nft.name, `6529 Gradient #${id}`)!,
+    people: compactPeople([
+      createPerson({
+        label: "Artist",
+        name: firstNonEmptyString(artistHandle, nft.artist),
+        href: profileHrefForHandle(artistHandle),
+      }),
+      createPerson({
+        label: "Collector",
+        name: ownerDisplay,
+        href: collectorHref,
+      }),
+    ]),
+    facts: compactFacts([
+      createFact(
+        "TDH rate",
+        tdhRate !== undefined ? formatDecimal(tdhRate) : undefined
+      ),
+      createFact("Mint date", mintDate),
+    ]),
+    imageUrl: firstNonEmptyString(
+      nft.thumbnail,
+      nft.scaled,
+      nft.image,
+      readMetadataString(metadata, "image")
+    ),
+  });
+}
+
+function sortNextGenTraits(
+  traits: readonly NextGenTrait[]
+): readonly NextGenTrait[] {
+  return [...traits]
+    .filter((trait) => {
+      const traitName = trait.trait?.trim();
+      const value = trait.value?.trim();
+      return (
+        traitName &&
+        value &&
+        traitName.toLowerCase() !== "collection name" &&
+        value.toLowerCase() !== "none"
+      );
+    })
+    .sort((left, right) => {
+      const valueCountDelta =
+        (left.value_count || Number.MAX_SAFE_INTEGER) -
+        (right.value_count || Number.MAX_SAFE_INTEGER);
+      if (valueCountDelta !== 0) {
+        return valueCountDelta;
+      }
+
+      return (
+        (left.trait_count || Number.MAX_SAFE_INTEGER) -
+        (right.trait_count || Number.MAX_SAFE_INTEGER)
+      );
+    });
+}
+
+async function fetchNextGenPreview(
+  tokenId: string,
+  requestUrl: URL,
+  context?: ApiContext
+): Promise<SeizeCollectionLinkPreview> {
+  const token = await fetchOptionalApiJson<NextGenToken>(
+    `nextgen/tokens/${tokenId}`,
+    undefined,
+    context
+  );
+
+  if (!token || token.pending) {
+    throw new Error("NextGen token was not found.");
+  }
+
+  const [traits, collection] = await Promise.all([
+    fetchOptionalApiJson<NextGenTrait[]>(
+      `nextgen/tokens/${token.id}/traits`,
+      undefined,
+      context
+    ),
+    fetchOptionalApiJson<NextGenCollection>(
+      `nextgen/collections/${token.collection_id}`,
+      undefined,
+      context
+    ),
+  ]);
+  const collectionSupply = firstPositiveNumber(
+    traits?.[0]?.token_count,
+    collection?.total_supply,
+    collection?.final_supply_after_mint
+  );
+  const rarityRank = readPositiveNumber(token.rarity_score_rank);
+  const mintDate = formatMintDate(token.mint_date);
+  const artistHref = await resolveProfileHref(collection?.artist, context);
+
+  return buildPreview({
+    kind: "nextgen-token",
+    requestUrl,
+    title: firstNonEmptyString(token.name, `NextGen #${tokenId}`)!,
+    kicker: `NextGen \u00b7 ${firstNonEmptyString(collection?.name, token.collection_name, "Collection")}`,
+    people: compactPeople([
+      createPerson({
+        label: "by",
+        name: collection?.artist,
+        href: artistHref,
+      }),
+    ]),
+    facts: compactFacts([
+      createFact(
+        "Rarity",
+        rarityRank !== undefined && collectionSupply !== undefined
+          ? `#${formatInteger(rarityRank)} / ${formatInteger(collectionSupply)}`
+          : undefined
+      ),
+      createFact("Mint date", mintDate),
+    ]),
+    traits: sortNextGenTraits(traits ?? [])
+      .slice(0, 3)
+      .map((trait) => ({ label: trait.trait, value: trait.value })),
+    imageUrl: firstNonEmptyString(
+      token.thumbnail_url,
+      token.icon_url,
+      token.image_url
+    ),
+  });
+}
+
+function readRememeArtist(rememe: Rememe): string | undefined {
+  const metadata = parseMetadata(rememe.metadata);
+  const attributes = readAttributes(metadata);
+  return firstNonEmptyString(
+    readAttributeValue(attributes, "SEIZE Artist Profile"),
+    readAttributeValue(attributes, "Artist"),
+    readAttributeValue(attributes, "ARTIST"),
+    readAttributeValue(attributes, "Creator"),
+    readMetadataString(metadata, "created_by"),
+    rememe.added_by
+  );
+}
+
+function readRememeEditionSize(rememe: Rememe): number | undefined {
+  const metadata = parseMetadata(rememe.metadata);
+  const attributes = readAttributes(metadata);
+  const editionAttribute = attributes.find((attribute) =>
+    /edition/i.test(attribute.trait_type ?? "")
+  );
+
+  return firstPositiveNumber(
+    (metadata as Record<string, unknown> | null)?.["edition_size"],
+    (metadata as Record<string, unknown> | null)?.["editionSize"],
+    editionAttribute?.value
+  );
+}
+
+async function fetchReMemesPreview(
+  contract: string,
+  id: string,
+  requestUrl: URL,
+  context?: ApiContext
+): Promise<SeizeCollectionLinkPreview> {
+  const rememe = await fetchFirstPageItem<Rememe>(
+    "rememes",
+    { contract, id },
+    context
+  );
+
+  if (!rememe) {
+    throw new Error("ReMeme was not found.");
+  }
+
+  const metadata = parseMetadata(rememe.metadata);
+  const artist = readRememeArtist(rememe);
+  const artistHref = await resolveProfileHref(artist, context);
+  const references = Array.isArray(rememe.meme_references)
+    ? rememe.meme_references
+    : [];
+  const replicasCount = Array.isArray(rememe.replicas) ? rememe.replicas.length : 0;
+  const editionSize = readRememeEditionSize(rememe);
+  const referenceLabels = references
+    .map((reference) => `#${reference}`)
+    .join(", ");
+  const referencesValue =
+    referenceLabels.length > 0 ? `The Memes ${referenceLabels}` : undefined;
+
+  return buildPreview({
+    kind: "rememes",
+    requestUrl,
+    title: firstNonEmptyString(
+      readMetadataString(metadata, "name"),
+      `${contract} #${id}`
+    )!,
+    kicker: "ReMemes",
+    people: compactPeople([
+      createPerson({
+        label: "by",
+        name: artist,
+        href: artistHref,
+      }),
+    ]),
+    facts: compactFacts([
+      createFact("References", referencesValue),
+      createFact(
+        "Edition size",
+        editionSize !== undefined ? formatInteger(editionSize) : undefined
+      ),
+      createFact(
+        "Replicas",
+        replicasCount > 1 ? formatInteger(replicasCount) : undefined
+      ),
+    ]),
+    imageUrl: firstNonEmptyString(
+      rememe.s3_image_thumbnail,
+      rememe.s3_image_scaled,
+      rememe.s3_image_original,
+      rememe.image,
+      readMetadataString(metadata, "image_url"),
+      readMetadataString(metadata, "image")
+    ),
+  });
+}
+
+async function executeTarget(
+  target: ResolvedTarget,
+  requestUrl: URL,
+  context?: ApiContext
+): Promise<SeizeCollectionLinkPreview> {
+  switch (target.kind) {
+    case "the-memes":
+      return fetchTheMemesPreview(target.id, requestUrl, context);
+    case "meme-lab":
+      return fetchMemeLabPreview(target.id, requestUrl, context);
+    case "6529-gradient":
+      return fetchGradientPreview(target.id, requestUrl, context);
+    case "nextgen-token":
+      return fetchNextGenPreview(target.tokenId, requestUrl, context);
+    case "rememes":
+      return fetchReMemesPreview(target.contract, target.id, requestUrl, context);
+  }
+}
+
+export function createFirstParty6529Plan(
+  url: URL,
+  context?: ApiContext
+): PreviewPlan | null {
+  const target = resolveTarget(url);
+  if (!target) {
+    return null;
+  }
+
+  return {
+    cacheKey: `6529:${
+      context?.apiAuth?.trim() || publicEnv.STAGING_API_KEY ? "auth" : "public"
+    }:${target.kind}:${url.pathname.toLowerCase()}`,
+    execute: async () => {
+      const data = await executeTarget(target, url, context);
+      return { data, ttl: CACHE_TTL_MS };
+    },
+  };
+}

--- a/app/api/open-graph/6529/service.ts
+++ b/app/api/open-graph/6529/service.ts
@@ -933,10 +933,14 @@ async function fetchNextGenPreview(
   const rarityRank = readPositiveNumber(token.rarity_score_rank);
   const mintDate = formatMintDate(token.mint_date);
   const artistHref = await resolveProfileHref(collection?.artist, context);
+  const canonicalRequestUrl = new URL(
+    `/nextgen/token/${token.id}`,
+    requestUrl.origin
+  );
 
   return buildPreview({
     kind: "nextgen-token",
-    requestUrl,
+    requestUrl: canonicalRequestUrl,
     title: firstNonEmptyString(token.name, `NextGen #${tokenId}`)!,
     kicker: `NextGen \u00b7 ${firstNonEmptyString(collection?.name, token.collection_name, "Collection")}`,
     people: compactPeople([

--- a/app/api/open-graph/6529/service.ts
+++ b/app/api/open-graph/6529/service.ts
@@ -58,6 +58,7 @@ type MintingClaimRecord = {
 };
 
 type MemesMintStatRecord = {
+  readonly mint_date?: string | null | undefined;
   readonly total_count?: number | null | undefined;
 };
 
@@ -568,6 +569,27 @@ function shouldUseExtendedEditionSize(
   return !looksLikeFreshLiveMintCount;
 }
 
+function shouldUseMintStatEditionSize(
+  nft: NftRecord,
+  mintStat: MemesMintStatRecord | null | undefined,
+  mintStatEditionSize: number | undefined
+): boolean {
+  if (mintStatEditionSize === undefined) {
+    return false;
+  }
+
+  const supply = readNumber(nft.supply);
+  const mintDate = new Date(
+    readString(mintStat?.mint_date) ?? readString(nft.mint_date) ?? ""
+  );
+  const looksLikeFreshLiveMintCount =
+    !Number.isNaN(mintDate.getTime()) &&
+    Date.now() - mintDate.getTime() < LIVE_MINT_FALLBACK_WINDOW_MS &&
+    (supply === undefined || mintStatEditionSize <= supply);
+
+  return !looksLikeFreshLiveMintCount;
+}
+
 function readMemeSeason(
   nft: MemesRecord,
   metadata: Record<string, unknown> | null
@@ -616,6 +638,13 @@ async function fetchTheMemesPreview(
   const title = firstNonEmptyString(claim?.name, source.name, `The Memes #${id}`)!;
   const claimEditionSize = readPositiveNumber(claim?.edition_size);
   const mintStatEditionSize = readPositiveNumber(mintStat?.total_count);
+  const guardedMintStatEditionSize = shouldUseMintStatEditionSize(
+    source,
+    mintStat,
+    mintStatEditionSize
+  )
+    ? mintStatEditionSize
+    : undefined;
   const extendedEditionSize = readPositiveNumber(extended?.edition_size);
   const fallbackEditionSize = shouldUseExtendedEditionSize(
     source,
@@ -624,7 +653,7 @@ async function fetchTheMemesPreview(
     ? extendedEditionSize
     : undefined;
   const editionSize =
-    claimEditionSize ?? mintStatEditionSize ?? fallbackEditionSize;
+    claimEditionSize ?? guardedMintStatEditionSize ?? fallbackEditionSize;
   const season = readMemeSeason(source, metadata);
   const tdhRate = readPositiveNumber(source.hodl_rate);
   const mintDate = formatMintDate(source.mint_date);

--- a/app/api/open-graph/route.ts
+++ b/app/api/open-graph/route.ts
@@ -10,6 +10,7 @@ import {
   readLimitedJson,
   readLimitedText,
 } from "@/lib/fetch/limitedBody";
+import { API_AUTH_COOKIE } from "@/constants/constants";
 import {
   UrlGuardError,
   assertPublicUrl,
@@ -30,6 +31,7 @@ import { createCompoundPlan, type PreviewPlan } from "./compound/service";
 import { createFoundationPlan } from "./foundation/service";
 import { createManifoldPlan } from "./manifold/service";
 import { createOpenSeaPlan } from "./opensea/service";
+import { createFirstParty6529Plan } from "./6529/service";
 import { createTransientPlan } from "./transient/service";
 import { detectEnsTarget, fetchEnsPreview, EnsPreviewError } from "./ens";
 
@@ -73,6 +75,10 @@ type HostOverrides = {
   readonly domain: string;
   readonly headers?: HeaderOverrides | undefined;
   readonly userAgent?: string | undefined;
+};
+
+type PreviewContext = {
+  readonly apiAuth?: string | null | undefined;
 };
 
 const HOST_OVERRIDES: readonly HostOverrides[] = [
@@ -415,8 +421,26 @@ function createGenericPlan(url: URL): PreviewPlan {
   };
 }
 
+function getRequestApiAuth(request: NextRequest): string | null {
+  const cookieStore = (
+    request as {
+      readonly cookies?: {
+        get: (name: string) => { readonly value?: string } | undefined;
+      };
+    }
+  ).cookies;
+  const headers = (request as { readonly headers?: Headers }).headers;
+
+  return (
+    cookieStore?.get(API_AUTH_COOKIE)?.value ??
+    headers?.get(API_AUTH_COOKIE) ??
+    null
+  );
+}
+
 async function resolveLinkPreview(
-  rawUrl: string | null
+  rawUrl: string | null,
+  context?: PreviewContext
 ): Promise<LinkPreviewResponse> {
   const ensTarget = detectEnsTarget(rawUrl);
   if (ensTarget) {
@@ -424,29 +448,30 @@ async function resolveLinkPreview(
   }
 
   const targetUrl = parsePublicUrl(rawUrl);
-  await assertPublicUrl(targetUrl, PUBLIC_URL_OPTIONS);
+  const firstParty6529Plan = createFirstParty6529Plan(targetUrl, context);
 
-  const manifoldPlan = createManifoldPlan(targetUrl, {
-    fetchHtml,
-    assertPublicUrl: (url) => assertPublicUrl(url, PUBLIC_URL_OPTIONS),
-  });
-  const foundationPlan = createFoundationPlan(targetUrl, {
-    fetchHtml,
-    assertPublicUrl: (url) => assertPublicUrl(url, PUBLIC_URL_OPTIONS),
-  });
-  const openSeaPlan = createOpenSeaPlan(targetUrl, {
-    fetchHtml,
-    assertPublicUrl: (url) => assertPublicUrl(url, PUBLIC_URL_OPTIONS),
-  });
-  const transientPlan = createTransientPlan(targetUrl, {
-    fetchHtml,
-    assertPublicUrl: (url) => assertPublicUrl(url, PUBLIC_URL_OPTIONS),
-  });
+  if (!firstParty6529Plan) {
+    await assertPublicUrl(targetUrl, PUBLIC_URL_OPTIONS);
+  }
+
   const plan =
-    manifoldPlan ??
-    foundationPlan ??
-    openSeaPlan ??
-    transientPlan ??
+    firstParty6529Plan ??
+    createManifoldPlan(targetUrl, {
+      fetchHtml,
+      assertPublicUrl: (url) => assertPublicUrl(url, PUBLIC_URL_OPTIONS),
+    }) ??
+    createFoundationPlan(targetUrl, {
+      fetchHtml,
+      assertPublicUrl: (url) => assertPublicUrl(url, PUBLIC_URL_OPTIONS),
+    }) ??
+    createOpenSeaPlan(targetUrl, {
+      fetchHtml,
+      assertPublicUrl: (url) => assertPublicUrl(url, PUBLIC_URL_OPTIONS),
+    }) ??
+    createTransientPlan(targetUrl, {
+      fetchHtml,
+      assertPublicUrl: (url) => assertPublicUrl(url, PUBLIC_URL_OPTIONS),
+    }) ??
     createCompoundPlan(targetUrl) ??
     createGenericPlan(targetUrl);
 
@@ -466,7 +491,9 @@ export async function GET(request: NextRequest) {
   const rawUrl = request.nextUrl.searchParams.get("url");
 
   try {
-    const preview = await resolveLinkPreview(rawUrl);
+    const preview = await resolveLinkPreview(rawUrl, {
+      apiAuth: getRequestApiAuth(request),
+    });
     return NextResponse.json(preview);
   } catch (error) {
     return handlePreviewError(error);
@@ -520,9 +547,12 @@ async function mapWithConcurrency<T, R>(
   return results;
 }
 
-async function resolveBatchUrl(url: string): Promise<BatchResult> {
+async function resolveBatchUrl(
+  url: string,
+  context?: PreviewContext
+): Promise<BatchResult> {
   try {
-    const data = await resolveLinkPreview(url);
+    const data = await resolveLinkPreview(url, context);
     return { url, data };
   } catch (error) {
     return { url, error: getErrorMessage(error) };
@@ -563,10 +593,13 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  const context: PreviewContext = {
+    apiAuth: getRequestApiAuth(request),
+  };
   const batchResults = await mapWithConcurrency(
     urls,
     BATCH_CONCURRENCY,
-    resolveBatchUrl
+    (url) => resolveBatchUrl(url, context)
   );
   const results: Record<string, LinkPreviewResponse> = {};
   const errors: Record<string, string> = {};

--- a/app/api/open-graph/route.ts
+++ b/app/api/open-graph/route.ts
@@ -568,10 +568,9 @@ async function executeFirstParty6529Plan(
   try {
     return await executePlan(plan);
   } catch {
+    await assertPublicUrl(targetUrl, PUBLIC_URL_OPTIONS);
     const fallbackPlan = createGenericPlan(targetUrl);
-    const fallback = await executePlan(fallbackPlan);
-    cache.set(plan.cacheKey, fallback, CACHE_TTL_MS);
-    return fallback;
+    return executePlan(fallbackPlan);
   }
 }
 

--- a/app/api/open-graph/route.ts
+++ b/app/api/open-graph/route.ts
@@ -429,13 +429,7 @@ function getRequestApiAuth(request: NextRequest): string | null {
       };
     }
   ).cookies;
-  const headers = (request as { readonly headers?: Headers }).headers;
-
-  return (
-    cookieStore?.get(API_AUTH_COOKIE)?.value ??
-    headers?.get(API_AUTH_COOKIE) ??
-    null
-  );
+  return cookieStore?.get(API_AUTH_COOKIE)?.value ?? null;
 }
 
 async function resolveLinkPreview(

--- a/app/api/open-graph/route.ts
+++ b/app/api/open-graph/route.ts
@@ -469,16 +469,11 @@ async function resolveLinkPreview(
     createCompoundPlan(targetUrl) ??
     createGenericPlan(targetUrl);
 
-  const cached = cache.get(plan.cacheKey);
-
-  if (cached) {
-    return cached;
+  if (firstParty6529Plan) {
+    return executeFirstParty6529Plan(firstParty6529Plan, targetUrl);
   }
 
-  const { data, ttl } = await plan.execute();
-  cache.set(plan.cacheKey, data, ttl);
-
-  return data;
+  return executePlan(plan);
 }
 
 export async function GET(request: NextRequest) {
@@ -550,6 +545,33 @@ async function resolveBatchUrl(
     return { url, data };
   } catch (error) {
     return { url, error: getErrorMessage(error) };
+  }
+}
+
+async function executePlan(plan: PreviewPlan): Promise<LinkPreviewResponse> {
+  const cached = cache.get(plan.cacheKey);
+
+  if (cached) {
+    return cached;
+  }
+
+  const { data, ttl } = await plan.execute();
+  cache.set(plan.cacheKey, data, ttl);
+
+  return data;
+}
+
+async function executeFirstParty6529Plan(
+  plan: PreviewPlan,
+  targetUrl: URL
+): Promise<LinkPreviewResponse> {
+  try {
+    return await executePlan(plan);
+  } catch {
+    const fallbackPlan = createGenericPlan(targetUrl);
+    const fallback = await executePlan(fallbackPlan);
+    cache.set(plan.cacheKey, fallback, CACHE_TTL_MS);
+    return fallback;
   }
 }
 

--- a/components/waves/LinkPreviewCard.tsx
+++ b/components/waves/LinkPreviewCard.tsx
@@ -36,6 +36,12 @@ const CHAT_STABLE_FRAME_CLASSES =
   "tw-h-[10rem] tw-min-h-[10rem] tw-max-h-[10rem] tw-w-full md:tw-h-[11rem] md:tw-min-h-[11rem] md:tw-max-h-[11rem]";
 const CHAT_FIRST_PARTY_FRAME_CLASSES =
   "tw-h-[15rem] tw-min-h-[15rem] tw-max-h-[15rem] tw-w-full lg:tw-h-[11rem] lg:tw-min-h-[11rem] lg:tw-max-h-[11rem]";
+const CHAT_COLLECTION_FRAME_CLASSES =
+  "tw-min-h-[11rem] tw-w-full md:tw-min-h-[12rem]";
+
+const isSeizeCollectionPreview = (
+  preview: OpenGraphPreviewData | null | undefined
+): boolean => preview?.["type"] === "6529.collection";
 
 const toPreviewData = (
   response: Awaited<ReturnType<typeof fetchLinkPreview>>
@@ -159,12 +165,14 @@ export default function LinkPreviewCard({
     return content;
   }
 
-  const stableFrameClasses =
-    isCurrent &&
-    state.type === "success" &&
-    getFirstPartyOpenGraphPreviewKind(state.data)
-      ? CHAT_FIRST_PARTY_FRAME_CLASSES
-      : CHAT_STABLE_FRAME_CLASSES;
+  let stableFrameClasses = CHAT_STABLE_FRAME_CLASSES;
+  if (isCurrent && state.type === "success") {
+    if (getFirstPartyOpenGraphPreviewKind(state.data)) {
+      stableFrameClasses = CHAT_FIRST_PARTY_FRAME_CLASSES;
+    } else if (isSeizeCollectionPreview(state.data)) {
+      stableFrameClasses = CHAT_COLLECTION_FRAME_CLASSES;
+    }
+  }
 
   return (
     <div

--- a/components/waves/OpenGraphPreview.tsx
+++ b/components/waves/OpenGraphPreview.tsx
@@ -9,6 +9,7 @@ import type {
   GithubPreviewResponse,
   GithubStatusPreviewResponse,
 } from "@/services/api/github-preview-api";
+import type { SeizeCollectionLinkPreview } from "@/services/api/link-preview-api";
 import ChatItemHrefButtons from "./ChatItemHrefButtons";
 import GithubPreviewStatusBadge from "./GithubPreviewStatusBadge";
 import {
@@ -327,6 +328,23 @@ function isGithubStatusPreviewResponse(
   );
 }
 
+function isSeizeCollectionPreview(
+  value: unknown
+): value is SeizeCollectionLinkPreview {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const record = value as { readonly type?: unknown; readonly title?: unknown };
+  return record.type === "6529.collection" && typeof record.title === "string";
+}
+
+function extractSeizeCollectionPreview(
+  preview: OpenGraphPreviewData | null | undefined
+): SeizeCollectionLinkPreview | null {
+  return isSeizeCollectionPreview(preview) ? preview : null;
+}
+
 function getRelativeHref(href: string): string | undefined {
   const relative = removeBaseEndpoint(href);
   if (typeof relative !== "string" || relative.length === 0) {
@@ -384,11 +402,19 @@ export function hasOpenGraphContent(
     return false;
   }
 
+  if (isSeizeCollectionPreview(preview)) {
+    return true;
+  }
+
   return Boolean(
     readFirstString(preview, TITLE_KEYS) ??
     readFirstString(preview, DESCRIPTION_KEYS) ??
     extractImageUrl(preview)
   );
+}
+
+function isExternalHref(href: string | null | undefined): boolean {
+  return typeof href === "string" && /^https?:\/\//i.test(href);
 }
 
 function FirstPartyOpenGraphPreviewCard({
@@ -466,6 +492,164 @@ function FirstPartyOpenGraphPreviewCard({
   );
 }
 
+function SeizeCollectionPreviewCard({
+  href,
+  preview,
+  effectiveHref,
+  linkTarget,
+  linkRel,
+  variant,
+  hideActions,
+}: {
+  readonly href: string;
+  readonly preview: SeizeCollectionLinkPreview;
+  readonly effectiveHref: string;
+  readonly linkTarget?: string | undefined;
+  readonly linkRel?: string | undefined;
+  readonly variant?: LinkPreviewVariant | undefined;
+  readonly hideActions?: boolean | undefined;
+}) {
+  const imageUrl = extractImageUrl(preview);
+  const people = Array.isArray(preview.people) ? preview.people : [];
+  const facts = Array.isArray(preview.facts) ? preview.facts : [];
+  const traits = Array.isArray(preview.traits) ? preview.traits.slice(0, 3) : [];
+  const resolvedVariant = variant ?? "chat";
+  const isHome = resolvedVariant === "home";
+
+  return (
+    <LinkPreviewCardLayout
+      href={href}
+      variant={resolvedVariant}
+      hideActions={hideActions}
+    >
+      <div
+        className={[
+          "tw-h-full tw-min-h-0 tw-w-full tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-py-3 tw-pl-3",
+          isHome
+            ? "tw-border-white/10 tw-bg-black/30"
+            : "tw-border-iron-700 tw-bg-iron-950/70",
+          !isHome && !hideActions ? "tw-pr-12 sm:tw-pr-3" : "tw-pr-3",
+        ].join(" ")}
+        data-testid="6529-collection-preview-card"
+      >
+        <div
+          className={[
+            "tw-grid tw-h-full tw-min-h-0 tw-min-w-0 tw-items-center tw-gap-3",
+            imageUrl
+              ? "tw-grid-cols-[5.5rem,minmax(0,1fr)] sm:tw-grid-cols-[6.75rem,minmax(0,1fr)] md:tw-grid-cols-[8.25rem,minmax(0,1fr)]"
+              : "tw-grid-cols-1",
+          ].join(" ")}
+        >
+          {imageUrl && (
+            <Link
+              href={effectiveHref}
+              target={linkTarget}
+              rel={linkRel}
+              onClick={(e) => e.stopPropagation()}
+              className="tw-relative tw-block tw-aspect-square tw-w-full tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-iron-800 tw-bg-black tw-no-underline"
+            >
+              <Image
+                src={imageUrl}
+                alt={preview.title}
+                fill
+                className="tw-object-cover"
+                loading="lazy"
+                sizes="(max-width: 640px) 5.5rem, (max-width: 768px) 6.75rem, 8.25rem"
+                unoptimized
+              />
+            </Link>
+          )}
+          <div className="tw-flex tw-min-h-0 tw-min-w-0 tw-flex-1 tw-flex-col tw-justify-center tw-gap-1.5 tw-overflow-hidden">
+            {preview.kicker && (
+              <div className="tw-[overflow-wrap:anywhere] tw-line-clamp-1 tw-break-words tw-text-xs tw-font-medium tw-text-iron-400">
+                {wrapLongUnbrokenSegments(preview.kicker)}
+              </div>
+            )}
+            <Link
+              href={effectiveHref}
+              target={linkTarget}
+              rel={linkRel}
+              onClick={(e) => e.stopPropagation()}
+              className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-block tw-break-words tw-text-base tw-font-semibold tw-leading-tight tw-text-iron-50 tw-no-underline tw-transition tw-duration-200 hover:tw-text-white"
+            >
+              {wrapLongUnbrokenSegments(preview.title)}
+            </Link>
+            {people.length > 0 && (
+              <div className="tw-flex tw-min-w-0 tw-flex-wrap tw-gap-x-3 tw-gap-y-1 tw-overflow-hidden tw-text-xs tw-leading-5">
+                {people.map((person, index) => {
+                  const personHref = person.href ?? undefined;
+                  const personIsExternal = isExternalHref(personHref);
+
+                  return (
+                    <span
+                      key={`${person.label ?? "person"}-${person.name}-${index}`}
+                      className="tw-inline-flex tw-min-w-0 tw-max-w-full tw-items-baseline tw-gap-1"
+                    >
+                      {person.label && (
+                        <span className="tw-flex-shrink-0 tw-text-iron-500">
+                          {person.label}
+                        </span>
+                      )}
+                      {personHref ? (
+                        <Link
+                          href={personHref}
+                          target={personIsExternal ? "_blank" : undefined}
+                          rel={
+                            personIsExternal ? "noopener noreferrer" : undefined
+                          }
+                          onClick={(e) => e.stopPropagation()}
+                          className="tw-truncate tw-font-medium tw-text-iron-200 tw-no-underline hover:tw-text-white"
+                        >
+                          {person.name}
+                        </Link>
+                      ) : (
+                        <span className="tw-truncate tw-font-medium tw-text-iron-200">
+                          {person.name}
+                        </span>
+                      )}
+                    </span>
+                  );
+                })}
+              </div>
+            )}
+            {facts.length > 0 && (
+              <div className="tw-flex tw-min-w-0 tw-flex-wrap tw-gap-1.5 tw-overflow-hidden">
+                {facts.map((fact) => (
+                  <span
+                    key={`${fact.label}-${fact.value}`}
+                    className="tw-inline-flex tw-max-w-full tw-items-center tw-gap-1 tw-rounded-md tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-900/75 tw-px-2 tw-py-0.5 tw-text-[11px] tw-leading-5"
+                  >
+                    <span className="tw-flex-shrink-0 tw-text-iron-400">
+                      {fact.label}
+                    </span>
+                    <span className="tw-truncate tw-font-medium tw-text-iron-100">
+                      {fact.value}
+                    </span>
+                  </span>
+                ))}
+              </div>
+            )}
+            {traits.length > 0 && (
+              <div className="tw-flex tw-min-w-0 tw-flex-wrap tw-gap-1.5 tw-overflow-hidden">
+                {traits.map((trait) => (
+                  <span
+                    key={`${trait.label}-${trait.value}`}
+                    className="tw-inline-flex tw-max-w-full tw-rounded-md tw-bg-emerald-500/10 tw-px-2 tw-py-0.5 tw-text-[11px] tw-font-medium tw-leading-5 tw-text-emerald-100"
+                  >
+                    <span className="tw-truncate">
+                      {trait.label}: {trait.value}
+                    </span>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </LinkPreviewCardLayout>
+  );
+}
+
 export default function OpenGraphPreview({
   href,
   preview,
@@ -530,6 +714,7 @@ export default function OpenGraphPreview({
   const imageUrl = extractImageUrl(preview);
   const domain = deriveDomain(href, preview);
   const githubPreview = extractGithubPreview(preview);
+  const seizePreview = extractSeizeCollectionPreview(preview);
   const hasContent = Boolean(title ?? description ?? imageUrl);
   const firstPartyKind = getFirstPartyOgKindFromImageUrl(imageUrl);
 
@@ -619,6 +804,20 @@ export default function OpenGraphPreview({
           </div>
         </div>
       </LinkPreviewCardLayout>
+    );
+  }
+
+  if (!imageOnly && seizePreview) {
+    return (
+      <SeizeCollectionPreviewCard
+        href={href}
+        preview={seizePreview}
+        effectiveHref={effectiveHref}
+        linkTarget={linkTarget}
+        linkRel={linkRel}
+        variant={resolvedVariant}
+        hideActions={hideActions}
+      />
     );
   }
 

--- a/ops/docs/waves/link-previews/README.md
+++ b/ops/docs/waves/link-previews/README.md
@@ -40,6 +40,9 @@ suppress those controls.
   TikTok, Farcaster/Warpcast, and Tenor GIF previews.
 - [Wave Drop Knowledge and Workspace Previews](feature-knowledge-and-workspace-previews.md):
   Google Workspace and Wikimedia previews.
+- [Wave Drop 6529 Collection Previews](feature-6529-collection-previews.md):
+  first-party cards for The Memes, Meme Lab, 6529 Gradient, NextGen, and
+  ReMemes links.
 - [Wave Drop Web3 Preview Cards](feature-web3-preview-cards.md): ENS,
   marketplace, Art Blocks, Compound, and `pepe.wtf` previews.
 

--- a/ops/docs/waves/link-previews/feature-6529-collection-previews.md
+++ b/ops/docs/waves/link-previews/feature-6529-collection-previews.md
@@ -51,9 +51,9 @@ such as `158/328`.
   - `Mint date {date}` when available
 
 Edition size should prefer claim edition size, then mint stats, then public
-extended edition size. The card does not render live mint progress fractions
-such as `158/328`; when the public API only exposes an extended edition size for
-a fresh mint, the card uses that value rather than omitting the fact.
+extended edition size only when it does not look like a fresh live mint count.
+The card does not render live mint progress fractions such as `158/328`, and it
+does not label current minted supply as final edition size.
 
 ### Meme Lab
 

--- a/ops/docs/waves/link-previews/feature-6529-collection-previews.md
+++ b/ops/docs/waves/link-previews/feature-6529-collection-previews.md
@@ -50,8 +50,10 @@ such as `158/328`.
   - `Season {x}`
   - `Mint date {date}` when available
 
-Edition size should prefer claim or richer edition-cap data. It should not fall
-back to a fresh live minted count when the token is still near mint.
+Edition size should prefer claim edition size, then mint stats, then public
+extended edition size. The card does not render live mint progress fractions
+such as `158/328`; when the public API only exposes an extended edition size for
+a fresh mint, the card uses that value rather than omitting the fact.
 
 ### Meme Lab
 
@@ -112,6 +114,6 @@ back to a fresh live minted count when the token is still near mint.
 ## Failure Behavior
 
 If a first-party collection URL is recognized but the 6529 API cannot resolve
-the object, the preview request fails and the wave UI falls back to the standard
-link fallback state. Unrecognized 6529 URLs continue through the normal provider
-and generic OpenGraph pipeline.
+the object, the route falls back to guarded generic OpenGraph metadata so wave
+drops still show a useful card. Unrecognized 6529 URLs continue through the
+normal provider and generic OpenGraph pipeline.

--- a/ops/docs/waves/link-previews/feature-6529-collection-previews.md
+++ b/ops/docs/waves/link-previews/feature-6529-collection-previews.md
@@ -90,6 +90,10 @@ supply as final edition size.
   - hide `Collection Name` and `None`
   - render as `{trait}: {value}`
 
+Short token URLs such as `/nextgen/token/514` should resolve through the API
+and render the canonical preview URL `/nextgen/token/{full token id}` so opening
+the card lands on the real token page.
+
 ### ReMemes
 
 - Title: token metadata name

--- a/ops/docs/waves/link-previews/feature-6529-collection-previews.md
+++ b/ops/docs/waves/link-previews/feature-6529-collection-previews.md
@@ -50,10 +50,10 @@ such as `158/328`.
   - `Season {x}`
   - `Mint date {date}` when available
 
-Edition size should prefer claim edition size, then mint stats, then public
-extended edition size only when it does not look like a fresh live mint count.
-The card does not render live mint progress fractions such as `158/328`, and it
-does not label current minted supply as final edition size.
+Edition size should prefer claim edition size, then guarded mint stats, then
+guarded public extended edition size. The card does not render live mint
+progress fractions such as `158/328`, and it does not label current minted
+supply as final edition size.
 
 ### Meme Lab
 

--- a/ops/docs/waves/link-previews/feature-6529-collection-previews.md
+++ b/ops/docs/waves/link-previews/feature-6529-collection-previews.md
@@ -1,0 +1,117 @@
+# Wave Drop 6529 Collection Previews
+
+## Overview
+
+6529 collection URLs render as first-party collection cards instead of generic
+OpenGraph cards. The card fetches normalized data from the 6529 API and shows
+only the fields that help a user understand the object in chat.
+
+Museum cards are out of scope for this feature.
+
+## Supported URL Families
+
+- `/the-memes/{id}`
+- `/meme-lab/{id}`
+- `/6529-gradient/{id}`
+- `/nextgen/token/{token}`
+- `/rememes/{contract}/{id}`
+
+The route also recognizes the configured app host in local or staging
+environments.
+
+## Shared Card Contract
+
+Every first-party collection preview returns:
+
+- `type: "6529.collection"`
+- `kind`: one of `the-memes`, `meme-lab`, `6529-gradient`,
+  `nextgen-token`, or `rememes`
+- `title`: the display title
+- `kicker`: compact collection context when useful
+- `people`: named people with optional profile links
+- `facts`: label/value facts
+- `traits`: optional NextGen trait chips
+- `image` and `images`: normalized preview media
+
+Cards do not show floor price, live mint or phase status, or live minted count
+such as `158/328`.
+
+## Per Collection Rules
+
+### The Memes
+
+- Title: NFT name, for example `The Collective Synapse`
+- Kicker: `The Memes #{id}`
+- People: `by {artist}` with profile link when the API gives a resolvable 6529
+  handle
+- Facts:
+  - `Edition size {n}`
+  - `TDH rate {x}`
+  - `Season {x}`
+  - `Mint date {date}` when available
+
+Edition size should prefer claim or richer edition-cap data. It should not fall
+back to a fresh live minted count when the token is still near mint.
+
+### Meme Lab
+
+- Title: NFT name
+- Kicker: `Meme Lab #{id}`
+- People: artist profile link when resolvable
+- Facts:
+  - `Edition size {n}`
+  - `Mint date {date}` when available
+
+### 6529 Gradient
+
+- Title: token name, for example `6529 Gradient #92`
+- Kicker: omitted unless future data adds non-duplicative context
+- People:
+  - `Artist {profile}`
+  - `Collector {profile or display}` when the owner resolves
+- Facts:
+  - `TDH rate {x}`
+  - `Mint date {date}`
+
+### NextGen Token
+
+- Title: token name, for example `Pebbles #514`
+- Kicker: `NextGen &middot; {collection name}`
+- People: artist profile link when resolvable
+- Facts:
+  - `Rarity #{rank} / {supply}`
+  - `Mint date {date}`
+- Traits:
+  - show at most three chips by default
+  - choose the rarest values first by `value_count`
+  - break ties by `trait_count`
+  - hide `Collection Name` and `None`
+  - render as `{trait}: {value}`
+
+### ReMemes
+
+- Title: token metadata name
+- Kicker: `ReMemes`
+- People: creator or artist profile link when resolvable
+- Facts:
+  - `References The Memes #{id}` when references exist
+  - `Edition size {n}` when meaningful data exists
+  - `Replicas {n}` when more than one replica exists
+
+## Responsive Layout
+
+- Desktop and tablet: square art thumbnail on the left, text and metadata on
+  the right.
+- Mobile: same left/right structure with smaller fixed thumbnail dimensions so
+  chat cards stay scannable and stable.
+- Text is clamped and wrapped inside the card; long titles, handles, or trait
+  values must not resize the preview frame.
+- Facts and traits wrap into compact chips and overflow is clipped inside the
+  stable preview frame.
+
+## Failure Behavior
+
+If a first-party collection URL is recognized but the 6529 API cannot resolve
+the object, the preview request fails and the wave UI falls back to the standard
+link fallback state. Unrecognized 6529 URLs continue through the normal provider
+and generic OpenGraph pipeline.

--- a/services/api/link-preview-api.ts
+++ b/services/api/link-preview-api.ts
@@ -2,7 +2,7 @@ import LruTtlCache from "@/lib/cache/lruTtl";
 import type { EnsPreview } from "@/components/waves/ens/types";
 import { matchesDomainOrSubdomain } from "@/lib/url/domains";
 
-interface LinkPreviewMedia {
+export interface LinkPreviewMedia {
   readonly url?: string | null | undefined;
   readonly secureUrl?: string | null | undefined;
   readonly type?: string | null | undefined;
@@ -25,6 +25,39 @@ interface LinkPreviewBase {
   readonly image?: LinkPreviewMedia | null | undefined;
   readonly images?: readonly LinkPreviewMedia[] | null | undefined;
   readonly [key: string]: unknown;
+}
+
+export type SeizeCollectionPreviewKind =
+  | "the-memes"
+  | "meme-lab"
+  | "6529-gradient"
+  | "nextgen-token"
+  | "rememes";
+
+export interface SeizeCollectionPreviewPerson {
+  readonly label?: string | null | undefined;
+  readonly name: string;
+  readonly href?: string | null | undefined;
+}
+
+export interface SeizeCollectionPreviewFact {
+  readonly label: string;
+  readonly value: string;
+}
+
+export interface SeizeCollectionPreviewTrait {
+  readonly label: string;
+  readonly value: string;
+}
+
+export interface SeizeCollectionLinkPreview extends LinkPreviewBase {
+  readonly type: "6529.collection";
+  readonly kind: SeizeCollectionPreviewKind;
+  readonly title: string;
+  readonly kicker?: string | null | undefined;
+  readonly people?: readonly SeizeCollectionPreviewPerson[] | null | undefined;
+  readonly facts?: readonly SeizeCollectionPreviewFact[] | null | undefined;
+  readonly traits?: readonly SeizeCollectionPreviewTrait[] | null | undefined;
 }
 
 type GoogleWorkspaceAvailability = "public" | "restricted";
@@ -91,6 +124,7 @@ export type LinkPreviewResponse =
   | GenericLinkPreviewResponse
   | EnsLinkPreviewResponse
   | ManifoldListingLinkPreview
+  | SeizeCollectionLinkPreview
   | GoogleWorkspaceLinkPreview;
 
 const LINK_PREVIEW_CACHE_TTL_MS = 5 * 60 * 1000;


### PR DESCRIPTION
## Summary
- Add first-party 6529 collection link preview fetching for The Memes, Meme Lab, 6529 Gradient, NextGen, and ReMemes.
- Render normalized collection cards with collection-specific title/kicker/people/facts/traits rules and responsive desktop/tablet/mobile behavior.
- Document the supported card contract and add route/service/component coverage.

## Validation
- `pnpm run test:no-coverage -- --runInBand __tests__/app/api/open-graph.route.test.ts __tests__/app/api/open-graph.6529.service.test.ts __tests__/components/waves/OpenGraphPreview.test.tsx __tests__/components/waves/LinkPreviewCard.test.tsx`
- `pnpm exec eslint --no-warn-ignored --max-warnings=0 app/api/open-graph/route.ts app/api/open-graph/6529/service.ts components/waves/OpenGraphPreview.tsx components/waves/LinkPreviewCard.tsx services/api/link-preview-api.ts __tests__/app/api/open-graph.route.test.ts __tests__/app/api/open-graph.6529.service.test.ts __tests__/components/waves/OpenGraphPreview.test.tsx __tests__/components/waves/LinkPreviewCard.test.tsx`
- `pnpm run typecheck:changed`
- Browser checked temporary local render at desktop/tablet/mobile widths before cleanup; final mobile collection cards show all required facts/traits with no measured overflow.

Note: local Windows PowerShell cannot invoke the repo `6529` wrapper directly (`6529 install` parses as a PowerShell expression), so validation used `SEIZE_6529_COMMAND=1` with pnpm commands after `seize-local-dev bootstrap`.