### PR TITLE
Add profile-native CMS vertical slice

### DIFF
--- a/__tests__/components/cms/CmsPageRenderer.test.tsx
+++ b/__tests__/components/cms/CmsPageRenderer.test.tsx
@@ -97,4 +97,72 @@ describe("CmsPageRenderer", () => {
     expect(screen.getByText("Unsafe collection").closest("a")).toBeNull();
     expect(screen.getAllByRole("img")[0]).toHaveAttribute("src", "/6529io.png");
   });
+
+  it("keeps package-authored headings below the page title level", () => {
+    const h1BlockPackage: CmsPublishedPackage = {
+      ...cmsFixturePackages.gallery,
+      payload: {
+        ...cmsFixturePackages.gallery.payload,
+        blocks: [
+          {
+            id: "package-heading",
+            type: "heading",
+            level: 1,
+            text: "Package supplied heading",
+          },
+        ],
+      },
+    };
+
+    render(<CmsPageRenderer cmsPackage={h1BlockPackage} />);
+
+    expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: "Package supplied heading",
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("renders duplicate rich text, facts, and actions without key collisions", () => {
+    const errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const duplicateContentPackage: CmsPublishedPackage = {
+      ...cmsFixturePackages.gallery,
+      payload: {
+        ...cmsFixturePackages.gallery.payload,
+        blocks: [
+          {
+            id: "duplicate-copy",
+            type: "rich_text",
+            paragraphs: ["Repeated", "Repeated"],
+          },
+          {
+            id: "duplicate-actions",
+            type: "transaction_reference",
+            chain_id: 1,
+            hash: "0x6529652965296529652965296529652965296529652965296529652965296529",
+            block_number: 22500000,
+            timestamp: "2026-06-16T00:00:00.000Z",
+            summary: "Duplicate content should still render cleanly.",
+            from: "0x0000000000000000000000000000000000006529",
+            to: "0x0000000000000000000000000000000000000001",
+            value_eth: "0",
+            actions: ["Same action", "Same action"],
+          },
+        ],
+      },
+    };
+
+    render(<CmsPageRenderer cmsPackage={duplicateContentPackage} />);
+
+    expect(screen.getAllByText("Repeated")).toHaveLength(2);
+    expect(screen.getAllByText("Same action")).toHaveLength(2);
+    expect(
+      errorSpy.mock.calls.some(([message]) =>
+        String(message).includes("Encountered two children with the same key")
+      )
+    ).toBe(false);
+    errorSpy.mockRestore();
+  });
 });

--- a/__tests__/components/cms/CmsPageRenderer.test.tsx
+++ b/__tests__/components/cms/CmsPageRenderer.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 
 import CmsPageRenderer from "@/components/cms/public/CmsPageRenderer";
 import { cmsFixturePackages } from "@/lib/cms/fixtures";
+import type { CmsPublishedPackage } from "@/lib/cms/types";
 
 describe("CmsPageRenderer", () => {
   it("renders a wallet gallery package from fixture data", () => {
@@ -34,5 +35,66 @@ describe("CmsPageRenderer", () => {
     expect(
       screen.getByText("Transferred The Memes token #1.")
     ).toBeInTheDocument();
+  });
+
+  it("renders unsafe package URLs as inert content", () => {
+    const unsafePackage: CmsPublishedPackage = {
+      ...cmsFixturePackages.gallery,
+      payload: {
+        ...cmsFixturePackages.gallery.payload,
+        assets: [
+          {
+            ...cmsFixturePackages.gallery.payload.assets[0],
+            src: "javascript:alert(1)",
+          },
+        ],
+        blocks: [
+          {
+            id: "unsafe-button",
+            type: "button_link",
+            label: "Unsafe action",
+            href: "javascript:alert(1)",
+          },
+          {
+            id: "unsafe-gallery",
+            type: "gallery",
+            items: [
+              {
+                asset_id: cmsFixturePackages.gallery.payload.assets[0].id,
+                title: "Unsafe gallery item",
+                href: "data:text/html,<h1>x</h1>",
+              },
+            ],
+          },
+          {
+            id: "unsafe-wallet-gallery",
+            type: "generated_wallet_gallery",
+            title: "Unsafe wallet gallery",
+            wallets: ["0xA4F6f8A1c2B3d4E5f60718293aBcDEF123456789"],
+            snapshot: { captured_at: "2026-06-16T00:00:00.000Z" },
+            stats: [{ label: "Collections", value: "1" }],
+            collections: [
+              {
+                title: "Unsafe collection",
+                count: 1,
+                asset_id: cmsFixturePackages.gallery.payload.assets[0].id,
+                href: "javascript:alert(2)",
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    render(<CmsPageRenderer cmsPackage={unsafePackage} />);
+
+    expect(screen.queryByRole("link", { name: "Unsafe action" })).toBeNull();
+    expect(screen.getByText("Unsafe action")).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    );
+    expect(screen.getByText("Unsafe gallery item").closest("a")).toBeNull();
+    expect(screen.getByText("Unsafe collection").closest("a")).toBeNull();
+    expect(screen.getAllByRole("img")[0]).toHaveAttribute("src", "/6529io.png");
   });
 });

--- a/__tests__/components/cms/CmsPageRenderer.test.tsx
+++ b/__tests__/components/cms/CmsPageRenderer.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+
+import CmsPageRenderer from "@/components/cms/public/CmsPageRenderer";
+import { cmsFixturePackages } from "@/lib/cms/fixtures";
+
+describe("CmsPageRenderer", () => {
+  it("renders a wallet gallery package from fixture data", () => {
+    render(<CmsPageRenderer cmsPackage={cmsFixturePackages.gallery} />);
+
+    expect(
+      screen.getByRole("heading", { name: "Collected Signals" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Wallet gallery snapshot")).toBeInTheDocument();
+    expect(screen.getAllByText("The Memes").length).toBeGreaterThan(0);
+    expect(screen.getByText("6529 Gradients")).toBeInTheDocument();
+    expect(screen.getByLabelText("CMS package evidence")).toHaveTextContent(
+      cmsFixturePackages.gallery.package_hash
+    );
+  });
+
+  it("renders transaction references as explained chain evidence", () => {
+    render(<CmsPageRenderer cmsPackage={cmsFixturePackages.transaction} />);
+
+    expect(
+      screen.getByRole("heading", {
+        name: "A transaction page should explain the event first",
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "The wallet transferred a 6529 Meme Card to a new collecting wallet and paid normal Ethereum gas."
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Transferred The Memes token #1.")
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/cms/canonicalize.test.ts
+++ b/__tests__/lib/cms/canonicalize.test.ts
@@ -1,0 +1,49 @@
+import { canonicalizeCmsJson } from "@/lib/cms/canonicalize";
+import {
+  assertCmsPackageHashes,
+  getCmsPayloadHash,
+  hashCmsJson,
+  parseCmsPackage,
+} from "@/lib/cms/package-utils";
+import { cmsFixturePackages } from "@/lib/cms/fixtures";
+
+describe("CMS package canonicalization", () => {
+  it("sorts object keys recursively without changing array order", () => {
+    const left = {
+      z: 1,
+      a: [{ b: true, a: "first" }, "second"],
+    };
+    const right = {
+      a: [{ a: "first", b: true }, "second"],
+      z: 1,
+    };
+
+    expect(canonicalizeCmsJson(left)).toBe(canonicalizeCmsJson(right));
+    expect(canonicalizeCmsJson(left)).toBe(
+      '{"a":[{"a":"first","b":true},"second"],"z":1}'
+    );
+  });
+
+  it("rejects unsupported JSON values", () => {
+    expect(() => canonicalizeCmsJson({ bad: Number.NaN })).toThrow(
+      "non-finite number"
+    );
+    expect(() => canonicalizeCmsJson({ bad: new Date() })).toThrow(
+      "unsupported value"
+    );
+  });
+
+  it("hashes fixture payloads and packages deterministically", () => {
+    const cmsPackage = cmsFixturePackages.gallery;
+
+    expect(getCmsPayloadHash(cmsPackage.payload)).toBe(cmsPackage.payload_hash);
+    expect(hashCmsJson(cmsPackage.payload)).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(() => assertCmsPackageHashes(cmsPackage)).not.toThrow();
+  });
+
+  it("validates fixture package schema", () => {
+    expect(
+      parseCmsPackage(cmsFixturePackages.transaction).payload.page.title
+    ).toBe("Transaction That Reads Like English");
+  });
+});

--- a/__tests__/lib/cms/media.test.ts
+++ b/__tests__/lib/cms/media.test.ts
@@ -1,0 +1,33 @@
+import {
+  getSafeCmsMediaUrl,
+  resolveCmsLinkUrl,
+  resolveCmsMediaUrl,
+} from "@/lib/cms/media";
+
+describe("CMS media URL helpers", () => {
+  it("allows profile-relative, http, https, ipfs, and arweave URLs", () => {
+    expect(resolveCmsLinkUrl("/punk6529/index.html")).toBe(
+      "/punk6529/index.html"
+    );
+    expect(resolveCmsLinkUrl("https://6529.io/punk6529/index.html")).toBe(
+      "https://6529.io/punk6529/index.html"
+    );
+    expect(resolveCmsLinkUrl("http://localhost:3001/punk6529")).toBe(
+      "http://localhost:3001/punk6529"
+    );
+    expect(resolveCmsMediaUrl("ipfs://bafy-test/image.png")).toContain(
+      "/ipfs/bafy-test/image.png"
+    );
+    expect(resolveCmsMediaUrl("ar://arweave-tx")).toBe(
+      "https://arweave.net/arweave-tx"
+    );
+  });
+
+  it("rejects executable or ambiguous URLs", () => {
+    expect(resolveCmsLinkUrl("javascript:alert(1)")).toBeNull();
+    expect(resolveCmsMediaUrl("data:image/svg+xml,<svg />")).toBeNull();
+    expect(resolveCmsLinkUrl("//evil.example/path")).toBeNull();
+    expect(resolveCmsLinkUrl("https://6529.io/\nnext")).toBeNull();
+    expect(getSafeCmsMediaUrl("javascript:alert(1)")).toBe("/6529io.png");
+  });
+});

--- a/__tests__/lib/cms/profile-sites.test.ts
+++ b/__tests__/lib/cms/profile-sites.test.ts
@@ -1,0 +1,76 @@
+import {
+  getPrimaryCmsSitePath,
+  getPublishedPrimaryCmsSiteForProfile,
+  getPublishedPrimaryCmsSiteForProfileIdentifier,
+} from "@/lib/cms/profile-sites";
+import { cmsFixturePackages } from "@/lib/cms/fixtures";
+
+function mockFetchResponse(response: Pick<Response, "ok" | "status" | "json">) {
+  return jest
+    .spyOn(global, "fetch")
+    .mockResolvedValue(response as unknown as Response);
+}
+
+describe("profile CMS sites", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("resolves the primary CMS site from the backend API", async () => {
+    const fetchMock = mockFetchResponse({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        site: {
+          primary_static_path: "/api-profile/index.html",
+        },
+        published_package: {
+          static_path: "/api-fallback/index.html",
+          package_json: cmsFixturePackages.gallery,
+        },
+      }),
+    });
+
+    const site =
+      await getPublishedPrimaryCmsSiteForProfileIdentifier("PUNK6529");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/cms\/profile\/punk6529\/primary$/),
+      { cache: "no-store" }
+    );
+    expect(site?.staticPath).toBe("/api-profile/index.html");
+    expect(site?.cmsPackage.package_hash).toBe(
+      cmsFixturePackages.gallery.package_hash
+    );
+  });
+
+  it("resolves the primary CMS site for a published profile", async () => {
+    mockFetchResponse({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    });
+
+    const site =
+      await getPublishedPrimaryCmsSiteForProfileIdentifier("PUNK6529");
+
+    expect(site?.staticPath).toBe("/punk6529/index.html");
+    expect(site?.cmsPackage.payload.site.owner_profile.handle).toBe("punk6529");
+  });
+
+  it("does not resolve a CMS site for an unpublished profile", async () => {
+    mockFetchResponse({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    });
+
+    await expect(
+      getPublishedPrimaryCmsSiteForProfile({ handle: "unpublished-profile" })
+    ).resolves.toBeNull();
+  });
+
+  it("builds primary CMS site paths under the profile route", () => {
+    expect(getPrimaryCmsSitePath("punk6529")).toBe("/punk6529/index.html");
+  });
+});

--- a/__tests__/lib/cms/profile-sites.test.ts
+++ b/__tests__/lib/cms/profile-sites.test.ts
@@ -5,10 +5,16 @@ import {
 } from "@/lib/cms/profile-sites";
 import { cmsFixturePackages } from "@/lib/cms/fixtures";
 
-function mockFetchResponse(response: Pick<Response, "ok" | "status" | "json">) {
+function mockFetchJsonResponse(status: number, body: unknown) {
+  const response = {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } satisfies Pick<Response, "ok" | "status" | "json">;
+
   return jest
-    .spyOn(global, "fetch")
-    .mockResolvedValue(response as unknown as Response);
+    .spyOn(globalThis, "fetch")
+    .mockImplementation(async () => response as Response);
 }
 
 describe("profile CMS sites", () => {
@@ -17,18 +23,14 @@ describe("profile CMS sites", () => {
   });
 
   it("resolves the primary CMS site from the backend API", async () => {
-    const fetchMock = mockFetchResponse({
-      ok: true,
-      status: 200,
-      json: async () => ({
-        site: {
-          primary_static_path: "/api-profile/index.html",
-        },
-        published_package: {
-          static_path: "/api-fallback/index.html",
-          package_json: cmsFixturePackages.gallery,
-        },
-      }),
+    const fetchMock = mockFetchJsonResponse(200, {
+      site: {
+        primary_static_path: "/api-profile/index.html",
+      },
+      published_package: {
+        static_path: "/api-fallback/index.html",
+        package_json: cmsFixturePackages.gallery,
+      },
     });
 
     const site =
@@ -45,11 +47,7 @@ describe("profile CMS sites", () => {
   });
 
   it("resolves the primary CMS site for a published profile", async () => {
-    mockFetchResponse({
-      ok: false,
-      status: 404,
-      json: async () => ({}),
-    });
+    mockFetchJsonResponse(404, {});
 
     const site =
       await getPublishedPrimaryCmsSiteForProfileIdentifier("PUNK6529");
@@ -59,11 +57,7 @@ describe("profile CMS sites", () => {
   });
 
   it("does not resolve a CMS site for an unpublished profile", async () => {
-    mockFetchResponse({
-      ok: false,
-      status: 404,
-      json: async () => ({}),
-    });
+    mockFetchJsonResponse(404, {});
 
     await expect(
       getPublishedPrimaryCmsSiteForProfile({ handle: "unpublished-profile" })

--- a/app/[user]/index.html/page.tsx
+++ b/app/[user]/index.html/page.tsx
@@ -1,5 +1,6 @@
 import CmsPageRenderer from "@/components/cms/public/CmsPageRenderer";
 import { getAppMetadata } from "@/components/providers/metadata";
+import { getSafeCmsMediaUrl } from "@/lib/cms/media";
 import { getPublishedPrimaryCmsSiteForProfileIdentifier } from "@/lib/cms/profile-sites";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
@@ -27,7 +28,7 @@ export async function generateMetadata({
   return getAppMetadata({
     title: social.title,
     description: social.description,
-    ogImage: social.open_graph_image.url,
+    ogImage: getSafeCmsMediaUrl(social.open_graph_image.url),
     ogImageAlt: social.open_graph_image.alt,
     ogImageHeight: social.open_graph_image.height,
     ogImageWidth: social.open_graph_image.width,

--- a/app/[user]/index.html/page.tsx
+++ b/app/[user]/index.html/page.tsx
@@ -1,0 +1,46 @@
+import CmsPageRenderer from "@/components/cms/public/CmsPageRenderer";
+import { getAppMetadata } from "@/components/providers/metadata";
+import { getPublishedPrimaryCmsSiteForProfileIdentifier } from "@/lib/cms/profile-sites";
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+
+type PageProps = {
+  readonly params: Promise<{
+    readonly user: string;
+  }>;
+};
+
+export function generateStaticParams() {
+  return [{ user: "punk6529" }];
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { user } = await params;
+  const site = await getPublishedPrimaryCmsSiteForProfileIdentifier(user);
+  if (!site) {
+    notFound();
+  }
+
+  const social = site.cmsPackage.payload.page.social;
+  return getAppMetadata({
+    title: social.title,
+    description: social.description,
+    ogImage: social.open_graph_image.url,
+    ogImageAlt: social.open_graph_image.alt,
+    ogImageHeight: social.open_graph_image.height,
+    ogImageWidth: social.open_graph_image.width,
+    twitterCard: "summary_large_image",
+  });
+}
+
+export default async function ProfileCmsHomePage({ params }: PageProps) {
+  const { user } = await params;
+  const site = await getPublishedPrimaryCmsSiteForProfileIdentifier(user);
+  if (!site) {
+    notFound();
+  }
+
+  return <CmsPageRenderer cmsPackage={site.cmsPackage} />;
+}

--- a/app/[user]/index.html/page.tsx
+++ b/app/[user]/index.html/page.tsx
@@ -11,8 +11,8 @@ type PageProps = {
   }>;
 };
 
-export function generateStaticParams() {
-  return [{ user: "punk6529" }];
+export function generateStaticParams(): { user: string }[] {
+  return [];
 }
 
 export async function generateMetadata({

--- a/app/cms-fixtures/[fixture]/page.tsx
+++ b/app/cms-fixtures/[fixture]/page.tsx
@@ -1,0 +1,51 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+
+import CmsPageRenderer from "@/components/cms/public/CmsPageRenderer";
+import { getAppMetadata } from "@/components/providers/metadata";
+import {
+  cmsFixtureSlugs,
+  getCmsFixturePackage,
+  type CmsFixtureSlug,
+} from "@/lib/cms/fixtures";
+
+type CmsFixturePageProps = {
+  readonly params: Promise<{
+    readonly fixture: string;
+  }>;
+};
+
+export function generateStaticParams(): { fixture: CmsFixtureSlug }[] {
+  return cmsFixtureSlugs.map((fixture) => ({ fixture }));
+}
+
+export async function generateMetadata({
+  params,
+}: CmsFixturePageProps): Promise<Metadata> {
+  const { fixture } = await params;
+  const cmsPackage = getCmsFixturePackage(fixture);
+  if (!cmsPackage) {
+    notFound();
+  }
+
+  const social = cmsPackage.payload.page.social;
+  return getAppMetadata({
+    title: social.title,
+    description: social.description,
+    ogImage: social.open_graph_image.url,
+    ogImageAlt: social.open_graph_image.alt,
+    ogImageHeight: social.open_graph_image.height,
+    ogImageWidth: social.open_graph_image.width,
+    twitterCard: "summary_large_image",
+  });
+}
+
+export default async function CmsFixturePage({ params }: CmsFixturePageProps) {
+  const { fixture } = await params;
+  const cmsPackage = getCmsFixturePackage(fixture);
+  if (!cmsPackage) {
+    notFound();
+  }
+
+  return <CmsPageRenderer cmsPackage={cmsPackage} />;
+}

--- a/app/cms-fixtures/[fixture]/page.tsx
+++ b/app/cms-fixtures/[fixture]/page.tsx
@@ -8,6 +8,7 @@ import {
   getCmsFixturePackage,
   type CmsFixtureSlug,
 } from "@/lib/cms/fixtures";
+import { getSafeCmsMediaUrl } from "@/lib/cms/media";
 
 type CmsFixturePageProps = {
   readonly params: Promise<{
@@ -32,7 +33,7 @@ export async function generateMetadata({
   return getAppMetadata({
     title: social.title,
     description: social.description,
-    ogImage: social.open_graph_image.url,
+    ogImage: getSafeCmsMediaUrl(social.open_graph_image.url),
     ogImageAlt: social.open_graph_image.alt,
     ogImageHeight: social.open_graph_image.height,
     ogImageWidth: social.open_graph_image.width,

--- a/app/tools/profile-cms/page.tsx
+++ b/app/tools/profile-cms/page.tsx
@@ -1,0 +1,14 @@
+import { getAppMetadata } from "@/components/providers/metadata";
+import type { Metadata } from "next";
+import ProfileCmsStudio from "@/components/cms/studio/ProfileCmsStudio";
+
+export default function ProfileCmsStudioPage() {
+  return <ProfileCmsStudio />;
+}
+
+export function generateMetadata(): Metadata {
+  return getAppMetadata({
+    title: "Profile CMS Studio",
+    description: "Tools",
+  });
+}

--- a/components/cms/public/CmsPageRenderer.module.scss
+++ b/components/cms/public/CmsPageRenderer.module.scss
@@ -365,6 +365,12 @@
   text-decoration: none;
 }
 
+.buttonLink[aria-disabled="true"] {
+  background: #2f3b46;
+  color: #ffffff;
+  cursor: not-allowed;
+}
+
 .fallback {
   border: 1px dashed rgba(255, 255, 255, 0.28);
   border-radius: 8px;

--- a/components/cms/public/CmsPageRenderer.module.scss
+++ b/components/cms/public/CmsPageRenderer.module.scss
@@ -1,0 +1,438 @@
+.shell {
+  --cms-accent: #36d1dc;
+  min-height: 100dvh;
+  background:
+    linear-gradient(180deg, rgba(8, 12, 16, 0.96), #050505 460px), #050505;
+  color: #f5f7fa;
+  letter-spacing: 0;
+}
+
+.hero {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 72px max(24px, calc((100vw - 1120px) / 2)) 42px;
+}
+
+.heroGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 410px);
+  gap: 36px;
+  align-items: end;
+}
+
+.eyebrow {
+  color: var(--cms-accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin-bottom: 14px;
+  text-transform: uppercase;
+}
+
+.title {
+  font-size: 5.2rem;
+  font-weight: 800;
+  line-height: 0.96;
+  letter-spacing: 0;
+  margin: 0;
+  max-width: 840px;
+}
+
+.titleLong {
+  font-size: 4.25rem;
+  line-height: 1;
+  max-width: 760px;
+}
+
+.description {
+  color: #c8d0da;
+  font-size: 1.08rem;
+  line-height: 1.65;
+  margin: 22px 0 0;
+  max-width: 720px;
+}
+
+.heroPanel {
+  background: rgba(255, 255, 255, 0.055);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  padding: 18px;
+}
+
+.hashLabel {
+  color: #9aa7b5;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  margin: 0 0 8px;
+  text-transform: uppercase;
+}
+
+.hashValue {
+  color: #f4f7fb;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 0.8rem;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+}
+
+.heroMeta {
+  display: grid;
+  gap: 12px;
+}
+
+.content {
+  display: grid;
+  gap: 34px;
+  margin: 0 auto;
+  max-width: 1120px;
+  padding: 42px 24px 72px;
+}
+
+.section {
+  display: grid;
+  gap: 18px;
+}
+
+.section h2,
+.section h3 {
+  letter-spacing: 0;
+  margin: 0;
+}
+
+.section h2 {
+  font-size: 2.6rem;
+  line-height: 1.05;
+}
+
+.section h3 {
+  font-size: 1.8rem;
+  line-height: 1.18;
+}
+
+.richText {
+  color: #dbe2ea;
+  display: grid;
+  gap: 16px;
+  font-size: 1.05rem;
+  line-height: 1.75;
+  max-width: 820px;
+}
+
+.richText p {
+  margin: 0;
+}
+
+.mediaFigure {
+  margin: 0;
+}
+
+.mediaImage {
+  background: #111821;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  display: block;
+  height: auto;
+  max-height: 720px;
+  object-fit: cover;
+  width: 100%;
+}
+
+.caption {
+  color: #aeb8c5;
+  font-size: 0.92rem;
+  line-height: 1.5;
+  margin-top: 10px;
+}
+
+.galleryGrid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.itemCard,
+.referenceCard,
+.transactionCard,
+.callout,
+.quote,
+.provenance {
+  background: rgba(255, 255, 255, 0.055);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+}
+
+.itemCard {
+  color: inherit;
+  display: grid;
+  overflow: hidden;
+  text-decoration: none;
+}
+
+.itemCard img {
+  aspect-ratio: 4 / 3;
+  border: 0;
+  border-radius: 0;
+  object-fit: cover;
+}
+
+.itemBody {
+  display: grid;
+  gap: 6px;
+  padding: 14px;
+}
+
+.itemTitle {
+  color: #ffffff;
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.itemCaption {
+  color: #aeb8c5;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.stats {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.stat {
+  border-left: 3px solid var(--cms-accent);
+  padding: 2px 0 2px 12px;
+}
+
+.statValue {
+  color: #ffffff;
+  font-size: 1.45rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.statLabel {
+  color: #9aa7b5;
+  font-size: 0.82rem;
+  margin-top: 5px;
+}
+
+.referenceCard {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(160px, 300px) minmax(0, 1fr);
+  padding: 18px;
+}
+
+.referenceCard img {
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+}
+
+.referenceBody {
+  align-content: center;
+  display: grid;
+  gap: 10px;
+}
+
+.referenceTitle {
+  color: #ffffff;
+  font-size: 1.45rem;
+  font-weight: 800;
+  line-height: 1.1;
+  margin: 0;
+}
+
+.referenceText {
+  color: #c8d0da;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.facts {
+  color: #aeb8c5;
+  display: grid;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 0.78rem;
+  gap: 6px;
+  overflow-wrap: anywhere;
+}
+
+.packet {
+  color: #98f1db;
+  font-size: 0.84rem;
+  font-weight: 700;
+}
+
+.transactionCard {
+  display: grid;
+  gap: 18px;
+  padding: 20px;
+}
+
+.transactionSummary {
+  color: #ffffff;
+  font-size: 1.25rem;
+  font-weight: 750;
+  line-height: 1.35;
+  margin: 0;
+}
+
+.statusBanner {
+  background: rgba(255, 208, 102, 0.11);
+  border: 1px solid rgba(255, 208, 102, 0.28);
+  border-radius: 8px;
+  display: grid;
+  gap: 8px;
+  padding: 16px 18px;
+}
+
+.statusBannerTitle {
+  color: #ffe3a3;
+  font-size: 0.9rem;
+  font-weight: 800;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.statusBanner p {
+  color: #f3dfb5;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.actionList {
+  color: #dbe2ea;
+  display: grid;
+  gap: 10px;
+  line-height: 1.55;
+  margin: 0;
+  padding-left: 22px;
+}
+
+.callout {
+  border-left: 4px solid var(--cms-accent);
+  padding: 18px 20px;
+}
+
+.callout h2,
+.callout h3,
+.callout h4 {
+  font-size: 1.1rem;
+  line-height: 1.25;
+  margin: 0 0 8px;
+}
+
+.callout p {
+  color: #c8d0da;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.quote {
+  color: #f4f7fb;
+  font-size: 1.7rem;
+  font-weight: 700;
+  line-height: 1.25;
+  margin: 0;
+  padding: 24px;
+}
+
+.quote figcaption {
+  color: #9aa7b5;
+  font-size: 0.95rem;
+  font-weight: 500;
+  margin-top: 14px;
+}
+
+.buttonLink {
+  align-items: center;
+  background: var(--cms-accent);
+  border-radius: 8px;
+  color: #001014;
+  display: inline-flex;
+  font-weight: 800;
+  justify-content: center;
+  max-width: max-content;
+  min-height: 44px;
+  padding: 0 18px;
+  text-decoration: none;
+}
+
+.fallback {
+  border: 1px dashed rgba(255, 255, 255, 0.28);
+  border-radius: 8px;
+  color: #c8d0da;
+  padding: 16px;
+}
+
+.provenance {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+}
+
+.provenanceGrid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.provenanceTitle {
+  color: #ffffff;
+  font-size: 1rem;
+  font-weight: 800;
+  margin: 0;
+}
+
+@media (max-width: 760px) {
+  .hero {
+    padding-top: 44px;
+  }
+
+  .title {
+    font-size: 2.6rem;
+  }
+
+  .titleLong {
+    font-size: 2.35rem;
+  }
+
+  .section h2 {
+    font-size: 1.8rem;
+  }
+
+  .section h3,
+  .quote {
+    font-size: 1.35rem;
+  }
+
+  .heroGrid,
+  .referenceCard {
+    grid-template-columns: 1fr;
+  }
+
+  .heroPanel {
+    padding: 14px;
+  }
+}
+
+@media (min-width: 761px) and (max-width: 1080px) {
+  .title {
+    font-size: 4rem;
+  }
+
+  .titleLong {
+    font-size: 3.4rem;
+  }
+
+  .section h2 {
+    font-size: 2.2rem;
+  }
+}

--- a/components/cms/public/CmsPageRenderer.tsx
+++ b/components/cms/public/CmsPageRenderer.tsx
@@ -111,8 +111,8 @@ function MediaImage({
 }
 
 function HeadingBlock({ block }: { readonly block: CmsHeadingBlock }) {
-  const headingTags: Record<CmsHeadingBlock["level"], "h1" | "h2" | "h3"> = {
-    1: "h1",
+  const headingTags: Record<CmsHeadingBlock["level"], "h2" | "h3"> = {
+    1: "h2",
     2: "h2",
     3: "h3",
   };
@@ -129,8 +129,8 @@ function HeadingBlock({ block }: { readonly block: CmsHeadingBlock }) {
 function RichTextBlock({ block }: { readonly block: CmsRichTextBlock }) {
   return (
     <section className={css.richText}>
-      {block.paragraphs.map((paragraph) => (
-        <p key={paragraph}>{paragraph}</p>
+      {block.paragraphs.map((paragraph, index) => (
+        <p key={`${block.id}-paragraph-${index}`}>{paragraph}</p>
       ))}
     </section>
   );
@@ -240,8 +240,8 @@ function ButtonLinkBlock({
 function Facts({ rows }: { readonly rows: readonly [string, string][] }) {
   return (
     <div className={css.facts}>
-      {rows.map(([label, value]) => (
-        <div key={label}>
+      {rows.map(([label, value], index) => (
+        <div key={`${label}-${index}`}>
           {label}: {value}
         </div>
       ))}
@@ -321,8 +321,8 @@ function TransactionReferenceBlock({
       <p className={css.eyebrow}>Transaction reference</p>
       <p className={css.transactionSummary}>{block.summary}</p>
       <ol className={css.actionList}>
-        {block.actions.map((action) => (
-          <li key={action}>{action}</li>
+        {block.actions.map((action, index) => (
+          <li key={`${block.id}-action-${index}`}>{action}</li>
         ))}
       </ol>
       <Facts

--- a/components/cms/public/CmsPageRenderer.tsx
+++ b/components/cms/public/CmsPageRenderer.tsx
@@ -1,6 +1,10 @@
 import type { CSSProperties, ReactNode } from "react";
 
-import { findCmsAsset, resolveCmsMediaUrl } from "@/lib/cms/media";
+import {
+  findCmsAsset,
+  getSafeCmsMediaUrl,
+  resolveCmsLinkUrl,
+} from "@/lib/cms/media";
 import type {
   CmsAsset,
   CmsBlock,
@@ -97,7 +101,7 @@ function MediaImage({
     // normal image element instead of coupling to Next image host allowlists.
     <img
       className={className ?? css.mediaImage}
-      src={resolveCmsMediaUrl(asset.src)}
+      src={getSafeCmsMediaUrl(asset.src)}
       alt={asset.alt}
       width={asset.width}
       height={asset.height}
@@ -174,9 +178,10 @@ function GalleryBlock({
               </div>
             </>
           );
-          if (item.href) {
+          const itemHref = item.href ? resolveCmsLinkUrl(item.href) : null;
+          if (itemHref) {
             return (
-              <a className={css.itemCard} href={item.href} key={item.asset_id}>
+              <a className={css.itemCard} href={itemHref} key={item.asset_id}>
                 {body}
               </a>
             );
@@ -214,9 +219,17 @@ function ButtonLinkBlock({
   href,
   children,
 }: {
-  readonly href: string;
+  readonly href: string | null;
   readonly children: ReactNode;
 }) {
+  if (!href) {
+    return (
+      <span aria-disabled="true" className={css.buttonLink}>
+        {children}
+      </span>
+    );
+  }
+
   return (
     <a className={css.buttonLink} href={href}>
       {children}
@@ -359,11 +372,14 @@ function WalletGalleryBlock({
               </div>
             </>
           );
-          if (collection.href) {
+          const collectionHref = collection.href
+            ? resolveCmsLinkUrl(collection.href)
+            : null;
+          if (collectionHref) {
             return (
               <a
                 className={css.itemCard}
-                href={collection.href}
+                href={collectionHref}
                 key={collection.title}
               >
                 {card}
@@ -416,7 +432,11 @@ function RenderBlock({
     case "callout":
       return <CalloutBlock block={block} />;
     case "button_link":
-      return <ButtonLinkBlock href={block.href}>{block.label}</ButtonLinkBlock>;
+      return (
+        <ButtonLinkBlock href={resolveCmsLinkUrl(block.href)}>
+          {block.label}
+        </ButtonLinkBlock>
+      );
     case "nft_reference":
       return <NftReferenceBlock block={block} assets={assets} />;
     case "collection_reference":

--- a/components/cms/public/CmsPageRenderer.tsx
+++ b/components/cms/public/CmsPageRenderer.tsx
@@ -1,0 +1,522 @@
+import type { CSSProperties, ReactNode } from "react";
+
+import { findCmsAsset, resolveCmsMediaUrl } from "@/lib/cms/media";
+import type {
+  CmsAsset,
+  CmsBlock,
+  CmsCalloutBlock,
+  CmsCollectionReferenceBlock,
+  CmsGalleryBlock,
+  CmsHeadingBlock,
+  CmsImageBlock,
+  CmsNftReferenceBlock,
+  CmsPublishedPackage,
+  CmsQuoteBlock,
+  CmsRichTextBlock,
+  CmsTransactionReferenceBlock,
+  CmsWalletGalleryBlock,
+} from "@/lib/cms/types";
+
+import styles from "./CmsPageRenderer.module.scss";
+
+type CmsRendererClassName =
+  | "actionList"
+  | "buttonLink"
+  | "callout"
+  | "caption"
+  | "content"
+  | "description"
+  | "eyebrow"
+  | "facts"
+  | "fallback"
+  | "galleryGrid"
+  | "hashLabel"
+  | "hashValue"
+  | "hero"
+  | "heroGrid"
+  | "heroMeta"
+  | "heroPanel"
+  | "itemBody"
+  | "itemCaption"
+  | "itemCard"
+  | "itemTitle"
+  | "mediaFigure"
+  | "mediaImage"
+  | "packet"
+  | "provenance"
+  | "provenanceGrid"
+  | "provenanceTitle"
+  | "quote"
+  | "referenceBody"
+  | "referenceCard"
+  | "referenceText"
+  | "referenceTitle"
+  | "richText"
+  | "section"
+  | "shell"
+  | "stat"
+  | "statLabel"
+  | "stats"
+  | "statValue"
+  | "statusBanner"
+  | "statusBannerTitle"
+  | "title"
+  | "titleLong"
+  | "transactionCard"
+  | "transactionSummary";
+
+const css = styles as Readonly<Record<CmsRendererClassName, string>>;
+
+type Props = {
+  readonly cmsPackage: CmsPublishedPackage;
+};
+
+function getAsset(assets: readonly CmsAsset[], assetId: string): CmsAsset {
+  const asset = findCmsAsset(assets, assetId);
+  if (!asset) {
+    return {
+      id: assetId,
+      kind: "image",
+      src: "/6529io.png",
+      alt: "Missing CMS asset",
+      title: "Missing asset",
+    };
+  }
+  return asset;
+}
+
+function MediaImage({
+  asset,
+  className,
+}: {
+  readonly asset: CmsAsset;
+  readonly className?: string;
+}) {
+  return (
+    // Published CMS packages can point at IPFS/Arweave/S3 mirrors, so use a
+    // normal image element instead of coupling to Next image host allowlists.
+    <img
+      className={className ?? css.mediaImage}
+      src={resolveCmsMediaUrl(asset.src)}
+      alt={asset.alt}
+      width={asset.width}
+      height={asset.height}
+      loading="lazy"
+    />
+  );
+}
+
+function HeadingBlock({ block }: { readonly block: CmsHeadingBlock }) {
+  const HeadingTag = `h${block.level}` as "h1" | "h2" | "h3";
+  return (
+    <section className={css.section}>
+      {block.eyebrow ? <p className={css.eyebrow}>{block.eyebrow}</p> : null}
+      <HeadingTag>{block.text}</HeadingTag>
+    </section>
+  );
+}
+
+function RichTextBlock({ block }: { readonly block: CmsRichTextBlock }) {
+  return (
+    <section className={css.richText}>
+      {block.paragraphs.map((paragraph) => (
+        <p key={paragraph}>{paragraph}</p>
+      ))}
+    </section>
+  );
+}
+
+function ImageBlock({
+  block,
+  assets,
+}: {
+  readonly block: CmsImageBlock;
+  readonly assets: readonly CmsAsset[];
+}) {
+  const asset = getAsset(assets, block.asset_id);
+  return (
+    <figure className={css.mediaFigure}>
+      <MediaImage asset={asset} />
+      <figcaption className={css.caption}>
+        {block.caption ?? asset.caption ?? asset.title}
+      </figcaption>
+    </figure>
+  );
+}
+
+function GalleryBlock({
+  block,
+  assets,
+}: {
+  readonly block: CmsGalleryBlock;
+  readonly assets: readonly CmsAsset[];
+}) {
+  return (
+    <section className={css.section}>
+      {block.title ? <h2>{block.title}</h2> : null}
+      <div className={css.galleryGrid}>
+        {block.items.map((item) => {
+          const asset = getAsset(assets, item.asset_id);
+          const body = (
+            <>
+              <MediaImage asset={asset} />
+              <div className={css.itemBody}>
+                <p className={css.itemTitle}>{item.title ?? asset.title}</p>
+                <p className={css.itemCaption}>
+                  {item.caption ?? asset.caption}
+                </p>
+              </div>
+            </>
+          );
+          if (item.href) {
+            return (
+              <a className={css.itemCard} href={item.href} key={item.asset_id}>
+                {body}
+              </a>
+            );
+          }
+          return (
+            <div className={css.itemCard} key={item.asset_id}>
+              {body}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function QuoteBlock({ block }: { readonly block: CmsQuoteBlock }) {
+  return (
+    <figure className={css.quote}>
+      <blockquote>{block.quote}</blockquote>
+      {block.attribution ? <figcaption>{block.attribution}</figcaption> : null}
+    </figure>
+  );
+}
+
+function CalloutBlock({ block }: { readonly block: CmsCalloutBlock }) {
+  return (
+    <aside className={css.callout}>
+      <h2>{block.title}</h2>
+      <p>{block.body}</p>
+    </aside>
+  );
+}
+
+function ButtonLinkBlock({
+  href,
+  children,
+}: {
+  readonly href: string;
+  readonly children: ReactNode;
+}) {
+  return (
+    <a className={css.buttonLink} href={href}>
+      {children}
+    </a>
+  );
+}
+
+function Facts({ rows }: { readonly rows: readonly [string, string][] }) {
+  return (
+    <div className={css.facts}>
+      {rows.map(([label, value]) => (
+        <div key={label}>
+          {label}: {value}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function NftReferenceBlock({
+  block,
+  assets,
+}: {
+  readonly block: CmsNftReferenceBlock;
+  readonly assets: readonly CmsAsset[];
+}) {
+  const asset = getAsset(assets, block.asset_id);
+  return (
+    <section className={css.referenceCard}>
+      <MediaImage asset={asset} />
+      <div className={css.referenceBody}>
+        <p className={css.eyebrow}>NFT reference</p>
+        <h2 className={css.referenceTitle}>{block.title}</h2>
+        <p className={css.referenceText}>
+          {block.collection}
+          {block.creator ? ` by ${block.creator}` : ""}
+        </p>
+        <Facts
+          rows={[
+            ["Chain", String(block.chain_id)],
+            ["Contract", block.contract],
+            ["Token", block.token_id],
+            ["Captured", block.snapshot.captured_at],
+          ]}
+        />
+      </div>
+    </section>
+  );
+}
+
+function CollectionReferenceBlock({
+  block,
+  assets,
+}: {
+  readonly block: CmsCollectionReferenceBlock;
+  readonly assets: readonly CmsAsset[];
+}) {
+  const asset = getAsset(assets, block.asset_id);
+  return (
+    <section className={css.referenceCard}>
+      <MediaImage asset={asset} />
+      <div className={css.referenceBody}>
+        <p className={css.eyebrow}>Collection reference</p>
+        <h2 className={css.referenceTitle}>{block.title}</h2>
+        <p className={css.referenceText}>{block.summary}</p>
+        {block.knowledge_packet ? (
+          <p className={css.packet}>
+            Packet {block.knowledge_packet.id} v{block.knowledge_packet.version}
+          </p>
+        ) : null}
+        <Facts
+          rows={[
+            ["Chain", String(block.chain_id)],
+            ["Contract", block.contract],
+          ]}
+        />
+      </div>
+    </section>
+  );
+}
+
+function TransactionReferenceBlock({
+  block,
+}: {
+  readonly block: CmsTransactionReferenceBlock;
+}) {
+  return (
+    <section className={css.transactionCard}>
+      <p className={css.eyebrow}>Transaction reference</p>
+      <p className={css.transactionSummary}>{block.summary}</p>
+      <ol className={css.actionList}>
+        {block.actions.map((action) => (
+          <li key={action}>{action}</li>
+        ))}
+      </ol>
+      <Facts
+        rows={[
+          ["Chain", String(block.chain_id)],
+          ["Hash", block.hash],
+          ["Block", String(block.block_number)],
+          ["From", block.from],
+          ["To", block.to],
+          ["Value", `${block.value_eth} ETH`],
+          ["Captured", block.timestamp],
+        ]}
+      />
+    </section>
+  );
+}
+
+function WalletGalleryBlock({
+  block,
+  assets,
+}: {
+  readonly block: CmsWalletGalleryBlock;
+  readonly assets: readonly CmsAsset[];
+}) {
+  return (
+    <section className={css.section}>
+      <h2>{block.title}</h2>
+      <div className={css.stats}>
+        {block.stats.map((stat) => (
+          <div className={css.stat} key={stat.label}>
+            <div className={css.statValue}>{stat.value}</div>
+            <div className={css.statLabel}>{stat.label}</div>
+          </div>
+        ))}
+      </div>
+      <div className={css.galleryGrid}>
+        {block.collections.map((collection) => {
+          const asset = getAsset(assets, collection.asset_id);
+          const card = (
+            <>
+              <MediaImage asset={asset} />
+              <div className={css.itemBody}>
+                <p className={css.itemTitle}>{collection.title}</p>
+                <p className={css.itemCaption}>
+                  {collection.count} works in snapshot
+                </p>
+              </div>
+            </>
+          );
+          if (collection.href) {
+            return (
+              <a
+                className={css.itemCard}
+                href={collection.href}
+                key={collection.title}
+              >
+                {card}
+              </a>
+            );
+          }
+          return (
+            <div className={css.itemCard} key={collection.title}>
+              {card}
+            </div>
+          );
+        })}
+      </div>
+      <Facts
+        rows={[
+          ["Wallets", block.wallets.join(", ")],
+          ["Captured", block.snapshot.captured_at],
+        ]}
+      />
+    </section>
+  );
+}
+
+function UnknownBlock({ block }: { readonly block: CmsBlock }) {
+  return (
+    <div className={css.fallback}>
+      Unknown CMS block: <strong>{block.type}</strong>
+    </div>
+  );
+}
+
+function RenderBlock({
+  block,
+  assets,
+}: {
+  readonly block: CmsBlock;
+  readonly assets: readonly CmsAsset[];
+}) {
+  switch (block.type) {
+    case "heading":
+      return <HeadingBlock block={block} />;
+    case "rich_text":
+      return <RichTextBlock block={block} />;
+    case "image":
+      return <ImageBlock block={block} assets={assets} />;
+    case "gallery":
+      return <GalleryBlock block={block} assets={assets} />;
+    case "quote":
+      return <QuoteBlock block={block} />;
+    case "callout":
+      return <CalloutBlock block={block} />;
+    case "button_link":
+      return <ButtonLinkBlock href={block.href}>{block.label}</ButtonLinkBlock>;
+    case "nft_reference":
+      return <NftReferenceBlock block={block} assets={assets} />;
+    case "collection_reference":
+      return <CollectionReferenceBlock block={block} assets={assets} />;
+    case "transaction_reference":
+      return <TransactionReferenceBlock block={block} />;
+    case "generated_wallet_gallery":
+      return <WalletGalleryBlock block={block} assets={assets} />;
+    default:
+      return <UnknownBlock block={block} />;
+  }
+}
+
+function isDraftPackage(cmsPackage: CmsPublishedPackage): boolean {
+  return (
+    cmsPackage.signature.signature_type === "fixture" ||
+    cmsPackage.storage.some(
+      (item) =>
+        item.uri.startsWith("fixture://") ||
+        item.uri.includes("pending-profile-cms-package")
+    )
+  );
+}
+
+export default function CmsPageRenderer({ cmsPackage }: Readonly<Props>) {
+  const { payload } = cmsPackage;
+  const showDraftBanner = isDraftPackage(cmsPackage);
+  const themeStyle = {
+    "--cms-accent": payload.site.theme.accent_color,
+  } as CSSProperties;
+  const titleClassName =
+    payload.page.title.length > 28
+      ? `${css.title} ${css.titleLong}`
+      : css.title;
+
+  return (
+    <article className={css.shell} style={themeStyle}>
+      <header className={css.hero}>
+        <div className={css.heroGrid}>
+          <div>
+            <p className={css.eyebrow}>{payload.site.title}</p>
+            <h1 className={titleClassName}>{payload.page.title}</h1>
+            <p className={css.description}>{payload.page.description}</p>
+          </div>
+          <aside className={css.heroPanel} aria-label="CMS package evidence">
+            <div className={css.heroMeta}>
+              <div>
+                <p className={css.hashLabel}>Package hash</p>
+                <div className={css.hashValue}>{cmsPackage.package_hash}</div>
+              </div>
+              <div>
+                <p className={css.hashLabel}>Static path</p>
+                <div className={css.hashValue}>
+                  {payload.page.static_export_path}
+                </div>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </header>
+
+      <div className={css.content}>
+        {showDraftBanner ? (
+          <aside className={css.statusBanner}>
+            <p className={css.statusBannerTitle}>Draft package evidence</p>
+            <p>
+              This preview contains fixture or pending signature/storage
+              receipts. Treat it as a package-rendering preview until a wallet
+              package signature and real IPFS or Arweave receipt are present.
+            </p>
+          </aside>
+        ) : null}
+
+        {payload.blocks.map((block) => (
+          <RenderBlock block={block} assets={payload.assets} key={block.id} />
+        ))}
+
+        <footer className={css.provenance}>
+          <p className={css.provenanceTitle}>Package provenance</p>
+          <div className={css.provenanceGrid}>
+            <div>
+              <p className={css.hashLabel}>Payload hash</p>
+              <div className={css.hashValue}>{cmsPackage.payload_hash}</div>
+            </div>
+            <div>
+              <p className={css.hashLabel}>Signature</p>
+              <div className={css.hashValue}>
+                {cmsPackage.signature.signature_type} -{" "}
+                {cmsPackage.signature.signing_wallet}
+              </div>
+            </div>
+            <div>
+              <p className={css.hashLabel}>Storage</p>
+              <div className={css.hashValue}>
+                {cmsPackage.storage.map((item) => item.uri).join(", ")}
+              </div>
+            </div>
+            <div>
+              <p className={css.hashLabel}>Builder</p>
+              <div className={css.hashValue}>
+                {payload.provenance.builder_version}
+              </div>
+            </div>
+          </div>
+        </footer>
+      </div>
+    </article>
+  );
+}

--- a/components/cms/public/CmsPageRenderer.tsx
+++ b/components/cms/public/CmsPageRenderer.tsx
@@ -107,7 +107,13 @@ function MediaImage({
 }
 
 function HeadingBlock({ block }: { readonly block: CmsHeadingBlock }) {
-  const HeadingTag = `h${block.level}` as "h1" | "h2" | "h3";
+  const headingTags: Record<CmsHeadingBlock["level"], "h1" | "h2" | "h3"> = {
+    1: "h1",
+    2: "h2",
+    3: "h3",
+  };
+  const HeadingTag = headingTags[block.level];
+
   return (
     <section className={css.section}>
       {block.eyebrow ? <p className={css.eyebrow}>{block.eyebrow}</p> : null}

--- a/components/cms/studio/ProfileCmsStudio.module.scss
+++ b/components/cms/studio/ProfileCmsStudio.module.scss
@@ -1,0 +1,505 @@
+.shell {
+  background: #07090c;
+  color: #f5f7fb;
+  min-height: 100dvh;
+  padding: 34px 24px 56px;
+}
+
+.header {
+  align-items: end;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+  margin: 0 auto 24px;
+  max-width: 1280px;
+  padding-bottom: 20px;
+}
+
+.header h1 {
+  font-size: 3rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 1;
+  margin: 0;
+}
+
+.eyebrow {
+  color: #36d1dc;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  margin: 0 0 10px;
+  text-transform: uppercase;
+}
+
+.headerMeta {
+  color: #aeb8c5;
+  display: flex;
+  flex-wrap: wrap;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 0.82rem;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.headerMeta span,
+.storageButtons button,
+.actionRow button {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+}
+
+.headerMeta span {
+  background: rgba(255, 255, 255, 0.055);
+  padding: 8px 10px;
+}
+
+.workspace {
+  align-items: start;
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(260px, 360px) minmax(0, 1fr) minmax(
+      280px,
+      360px
+    );
+  margin: 0 auto;
+  max-width: 1280px;
+}
+
+.panel {
+  align-content: start;
+  background: #11161d;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  display: grid;
+  gap: 16px;
+  padding: 18px;
+}
+
+.panel h2 {
+  font-size: 1rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  margin: 0;
+}
+
+.panel label {
+  display: grid;
+  gap: 7px;
+}
+
+.panel label span,
+.storageRow > span,
+.evidence p {
+  color: #aeb8c5;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.panel input,
+.panel textarea {
+  background: #07090c;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  color: #f5f7fb;
+  font: inherit;
+  min-height: 42px;
+  padding: 10px 12px;
+  resize: vertical;
+  width: 100%;
+}
+
+.panel textarea {
+  line-height: 1.45;
+}
+
+.errorList {
+  color: #ffb4b4;
+  display: grid;
+  font-size: 0.88rem;
+  gap: 6px;
+}
+
+.errorList p {
+  margin: 0;
+}
+
+.segmented {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.segmented button {
+  background: #07090c;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  color: #f5f7fb;
+  display: grid;
+  gap: 8px;
+  min-height: 132px;
+  padding: 14px;
+  text-align: left;
+}
+
+.segmented svg,
+.actionRow svg,
+.routeList svg,
+.selectedBadge svg {
+  flex: 0 0 auto;
+  height: 20px;
+  width: 20px;
+}
+
+.segmented span {
+  font-weight: 800;
+}
+
+.segmented small {
+  color: #aeb8c5;
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.segmented button:hover,
+.storageButtons button:hover {
+  background: #0b1118;
+}
+
+.selectedSegment,
+.selectedPill {
+  background: rgba(54, 209, 220, 0.08);
+  border-color: #36d1dc;
+  box-shadow: inset 0 0 0 1px rgba(54, 209, 220, 0.45);
+}
+
+.selectedBadge {
+  align-items: center;
+  color: #9df871;
+  display: inline-flex;
+  font-size: 0.78rem;
+  font-weight: 800;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.storageRow {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.storageButtons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.storageButtons button {
+  background: #07090c;
+  color: #f5f7fb;
+  font-size: 0.82rem;
+  min-height: 36px;
+  padding: 0 12px;
+}
+
+.storageHint {
+  color: #aeb8c5;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  margin: -4px 0 0;
+}
+
+.previewFrame {
+  background: #050607;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  display: grid;
+  gap: 22px;
+  min-height: 420px;
+  padding: 22px;
+}
+
+.previewFrame h3 {
+  font-size: 2.2rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 1.05;
+  margin: 0;
+}
+
+.previewFrame p {
+  color: #c8d0da;
+  line-height: 1.6;
+  margin: 12px 0 0;
+  max-width: 720px;
+}
+
+.previewGrid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.previewGrid img {
+  aspect-ratio: 4 / 3;
+  border-radius: 8px;
+  display: block;
+  height: auto;
+  object-fit: cover;
+  width: 100%;
+}
+
+.evidence {
+  display: grid;
+  gap: 8px;
+}
+
+.evidenceHeader {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.evidenceHeader button,
+.miniButton {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  color: #dbe2ea;
+  font-size: 0.78rem;
+  font-weight: 800;
+  min-height: 30px;
+  padding: 0 9px;
+}
+
+.evidenceHeader button:disabled,
+.miniButton:disabled {
+  color: #7f8a98;
+}
+
+.evidence code {
+  background: #07090c;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  color: #f5f7fb;
+  font-size: 0.76rem;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+  padding: 10px;
+}
+
+.routeList {
+  display: grid;
+  gap: 10px;
+}
+
+.routeList div {
+  align-items: start;
+  color: #dbe2ea;
+  display: flex;
+  font-size: 0.86rem;
+  gap: 8px;
+  overflow-wrap: anywhere;
+}
+
+.routeList svg {
+  color: #9df871;
+  margin-top: 1px;
+}
+
+.actionRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.actionRow button {
+  align-items: center;
+  background: #36d1dc;
+  color: #001014;
+  display: inline-flex;
+  font-weight: 800;
+  gap: 8px;
+  min-height: 42px;
+  padding: 0 13px;
+}
+
+.publishButton {
+  background: #9df871 !important;
+  color: #061306 !important;
+}
+
+.actionRow button:disabled {
+  background: rgba(255, 255, 255, 0.1);
+  color: #7f8a98;
+}
+
+.dialogLayer {
+  align-items: center;
+  display: grid;
+  inset: 0;
+  justify-items: center;
+  padding: 18px;
+  position: fixed;
+  z-index: 1100;
+}
+
+.dialogBackdrop {
+  background: rgba(0, 0, 0, 0.72);
+  border: 0;
+  cursor: pointer;
+  inset: 0;
+  padding: 0;
+  position: fixed;
+}
+
+.confirmDialog {
+  background: #11161d;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 8px;
+  color: #f5f7fb;
+  display: grid;
+  gap: 16px;
+  margin: 0;
+  max-width: 560px;
+  padding: 22px;
+  position: relative;
+  width: min(100%, 560px);
+}
+
+.confirmDialog h2 {
+  font-size: 1.45rem;
+  letter-spacing: 0;
+  margin: 0;
+}
+
+.confirmDialog p {
+  color: #c8d0da;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.confirmGrid {
+  display: grid;
+  gap: 10px;
+}
+
+.confirmGrid div {
+  background: #07090c;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  display: grid;
+  gap: 6px;
+  padding: 10px;
+}
+
+.confirmGrid span {
+  color: #aeb8c5;
+  font-size: 0.74rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.confirmGrid strong {
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 0.78rem;
+  overflow-wrap: anywhere;
+}
+
+.confirmActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.confirmActions button {
+  align-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  display: inline-flex;
+  font-weight: 800;
+  gap: 8px;
+  min-height: 42px;
+  padding: 0 13px;
+}
+
+.confirmActions svg {
+  height: 20px;
+  width: 20px;
+}
+
+.secondaryAction {
+  background: rgba(255, 255, 255, 0.06);
+  color: #f5f7fb;
+}
+
+.publishStatus {
+  border-radius: 8px;
+  font-size: 0.84rem;
+  line-height: 1.45;
+  margin: 0;
+  overflow-wrap: anywhere;
+  padding: 10px 12px;
+}
+
+.publishStatusSuccess {
+  background: rgba(157, 248, 113, 0.1);
+  color: #c9f8ba;
+}
+
+.publishStatusError {
+  background: rgba(255, 117, 117, 0.1);
+  color: #ffb4b4;
+}
+
+@media (max-width: 1080px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .shell {
+    padding: 22px 14px 42px;
+  }
+
+  .header {
+    align-items: start;
+    display: grid;
+  }
+
+  .header h1 {
+    font-size: 2.4rem;
+  }
+
+  .headerMeta {
+    justify-content: start;
+  }
+
+  .segmented,
+  .previewGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .storageRow {
+    align-items: start;
+    display: grid;
+  }
+
+  .storageButtons {
+    justify-content: start;
+  }
+}

--- a/components/cms/studio/ProfileCmsStudio.module.scss
+++ b/components/cms/studio/ProfileCmsStudio.module.scss
@@ -272,10 +272,10 @@
 
 .evidenceHeader button,
 .miniButton {
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: #202a35;
+  border: 1px solid #3a4654;
   border-radius: 8px;
-  color: #dbe2ea;
+  color: #f5f7fb;
   font-size: 0.78rem;
   font-weight: 800;
   min-height: 30px;
@@ -340,8 +340,8 @@
 }
 
 .actionRow button:disabled {
-  background: rgba(255, 255, 255, 0.1);
-  color: #7f8a98;
+  background: #22303d;
+  color: #d4dde7;
 }
 
 .dialogLayer {
@@ -442,8 +442,8 @@
 }
 
 .secondaryAction {
-  background: rgba(255, 255, 255, 0.06);
-  color: #f5f7fb;
+  background: #202a35;
+  color: #ffffff;
 }
 
 .publishStatus {
@@ -456,13 +456,13 @@
 }
 
 .publishStatusSuccess {
-  background: rgba(157, 248, 113, 0.1);
-  color: #c9f8ba;
+  background: #102b19;
+  color: #d8ffd0;
 }
 
 .publishStatusError {
-  background: rgba(255, 117, 117, 0.1);
-  color: #ffb4b4;
+  background: #341619;
+  color: #ffd7d7;
 }
 
 @media (max-width: 1080px) {

--- a/components/cms/studio/ProfileCmsStudio.tsx
+++ b/components/cms/studio/ProfileCmsStudio.tsx
@@ -121,7 +121,19 @@ function getWalletErrors(wallets: readonly string[]): string[] {
 }
 
 function getProfileHandlePath(value: string): string {
-  return value.trim().replace(/^\/+|\/+$/g, "") || "profile";
+  const trimmed = value.trim();
+  let start = 0;
+  let end = trimmed.length;
+
+  while (start < end && trimmed[start] === "/") {
+    start += 1;
+  }
+
+  while (end > start && trimmed[end - 1] === "/") {
+    end -= 1;
+  }
+
+  return trimmed.slice(start, end) || "profile";
 }
 
 function getStorage(storageTarget: StorageTarget) {

--- a/components/cms/studio/ProfileCmsStudio.tsx
+++ b/components/cms/studio/ProfileCmsStudio.tsx
@@ -1,0 +1,752 @@
+"use client";
+
+import {
+  ArrowDownTrayIcon,
+  CheckCircleIcon,
+  CloudArrowUpIcon,
+  CubeTransparentIcon,
+  DocumentDuplicateIcon,
+  PhotoIcon,
+  Squares2X2Icon,
+} from "@heroicons/react/24/outline";
+import Image from "next/image";
+import { useMemo, useState } from "react";
+
+import { useAuth } from "@/components/auth/Auth";
+import { buildCmsPackage } from "@/lib/cms/package-utils";
+import {
+  getCmsStudioErrorMessage,
+  getOrCreateCmsSite,
+  publishCmsPackage,
+} from "@/lib/cms/studio-api";
+import { CMS_PAYLOAD_SCHEMA, type CmsPayload } from "@/lib/cms/types";
+
+import styles from "./ProfileCmsStudio.module.scss";
+
+type GalleryStyle = "editorial" | "grid" | "room";
+type StorageTarget = "ipfs" | "arweave" | "both";
+type ProfileCmsStudioClassName =
+  | "actionRow"
+  | "confirmActions"
+  | "confirmDialog"
+  | "confirmGrid"
+  | "dialogBackdrop"
+  | "dialogLayer"
+  | "errorList"
+  | "evidence"
+  | "evidenceHeader"
+  | "eyebrow"
+  | "header"
+  | "headerMeta"
+  | "miniButton"
+  | "panel"
+  | "previewFrame"
+  | "previewGrid"
+  | "publishButton"
+  | "publishStatus"
+  | "publishStatusError"
+  | "publishStatusSuccess"
+  | "routeList"
+  | "secondaryAction"
+  | "segmented"
+  | "selectedBadge"
+  | "selectedPill"
+  | "selectedSegment"
+  | "shell"
+  | "storageButtons"
+  | "storageHint"
+  | "storageRow"
+  | "workspace";
+
+const DEFAULT_ADDRESS = "0x0000000000000000000000000000000000006529";
+const FIXTURE_TIMESTAMP = "2026-06-16T00:00:00.000Z";
+const css = styles as Readonly<Record<ProfileCmsStudioClassName, string>>;
+
+type PublishStatus = {
+  readonly type: "success" | "error";
+  readonly message: string;
+};
+
+type CopiedEvidence = "package" | "payload" | null;
+
+const styleOptions: readonly {
+  readonly id: GalleryStyle;
+  readonly label: string;
+  readonly description: string;
+  readonly icon: typeof PhotoIcon;
+}[] = [
+  {
+    id: "editorial",
+    label: "Editorial",
+    description: "Large works, collection notes, and share pages.",
+    icon: PhotoIcon,
+  },
+  {
+    id: "grid",
+    label: "Market Grid",
+    description: "Dense collection pages for scanning and comparing.",
+    icon: Squares2X2Icon,
+  },
+  {
+    id: "room",
+    label: "3D Room",
+    description: "Exhibition room package with 2D fallback.",
+    icon: CubeTransparentIcon,
+  },
+];
+
+const storageOptions: readonly {
+  readonly id: StorageTarget;
+  readonly label: string;
+}[] = [
+  { id: "both", label: "IPFS + Arweave" },
+  { id: "ipfs", label: "IPFS" },
+  { id: "arweave", label: "Arweave" },
+];
+
+function parseWallets(value: string): string[] {
+  return value
+    .split(/[\s,]+/)
+    .map((wallet) => wallet.trim())
+    .filter(Boolean);
+}
+
+function getWalletErrors(wallets: readonly string[]): string[] {
+  if (wallets.length === 0) {
+    return ["Add at least one ETH address."];
+  }
+  return wallets
+    .filter((wallet) => !/^0x[a-fA-F0-9]{40}$/.test(wallet))
+    .map((wallet) => `${wallet} is not an ETH address.`);
+}
+
+function getProfileHandlePath(value: string): string {
+  return value.trim().replace(/^\/+|\/+$/g, "") || "profile";
+}
+
+function getStorage(storageTarget: StorageTarget) {
+  const ipfs = {
+    provider: "ipfs" as const,
+    uri: "ipfs://pending-profile-cms-package",
+    pinned: false,
+  };
+  const arweave = {
+    provider: "arweave" as const,
+    uri: "ar://pending-profile-cms-package",
+    pinned: false,
+  };
+  if (storageTarget === "ipfs") {
+    return [ipfs];
+  }
+  if (storageTarget === "arweave") {
+    return [arweave];
+  }
+  return [ipfs, arweave];
+}
+
+function buildStudioPayload({
+  handle,
+  title,
+  description,
+  wallets,
+  galleryStyle,
+}: {
+  readonly handle: string;
+  readonly title: string;
+  readonly description: string;
+  readonly wallets: readonly string[];
+  readonly galleryStyle: GalleryStyle;
+}): CmsPayload {
+  const displayHandle = getProfileHandlePath(handle);
+  const styleLabel =
+    styleOptions.find((option) => option.id === galleryStyle)?.label ??
+    "Gallery";
+  return {
+    schema: CMS_PAYLOAD_SCHEMA,
+    site: {
+      id: `site-${displayHandle}`,
+      slug: "home",
+      title: displayHandle,
+      description,
+      owner_profile: {
+        id: `profile-${displayHandle}`,
+        handle: displayHandle,
+        display_name: displayHandle,
+        path: `/${displayHandle}`,
+      },
+      theme: {
+        mode: "dark",
+        accent_color: galleryStyle === "room" ? "#9df871" : "#36d1dc",
+      },
+    },
+    page: {
+      id: "page-home",
+      title,
+      description,
+      slug_path: "",
+      static_export_path: `/${displayHandle}/index.html`,
+      canonical_url: `https://6529.io/${displayHandle}/index.html`,
+      page_type: "gallery",
+      social: {
+        title,
+        description,
+        canonical_url: `https://6529.io/${displayHandle}/index.html`,
+        open_graph_image: {
+          url: "/memes-preview.png",
+          width: 1200,
+          height: 630,
+          alt: `${title} social preview`,
+        },
+      },
+      created_at: FIXTURE_TIMESTAMP,
+      updated_at: FIXTURE_TIMESTAMP,
+    },
+    assets: [
+      {
+        id: "asset-memes",
+        kind: "image",
+        src: "/memes-preview.png",
+        alt: "The Memes collection preview",
+        title: "The Memes",
+        width: 1200,
+        height: 630,
+      },
+      {
+        id: "asset-gradients",
+        kind: "image",
+        src: "/gradients-preview.png",
+        alt: "6529 Gradients collection preview",
+        title: "6529 Gradients",
+        width: 1200,
+        height: 630,
+      },
+      {
+        id: "asset-nextgen",
+        kind: "image",
+        src: "/nextgen.png",
+        alt: "NextGen collection preview",
+        title: "NextGen",
+        width: 1200,
+        height: 630,
+      },
+    ],
+    blocks: [
+      {
+        id: "studio-intro",
+        type: "heading",
+        level: 2,
+        eyebrow: "Generated gallery",
+        text: `${styleLabel} profile package`,
+      },
+      {
+        id: "studio-copy",
+        type: "rich_text",
+        paragraphs: [
+          "This package is shaped for decentralized publishing: deterministic content, explicit storage receipts, social metadata, and wallet snapshots.",
+        ],
+      },
+      {
+        id: "wallet-gallery",
+        type: "generated_wallet_gallery",
+        title: "Wallet gallery snapshot",
+        wallets,
+        snapshot: {
+          captured_at: FIXTURE_TIMESTAMP,
+          block_number: 22500000,
+        },
+        stats: [
+          { label: "Wallets", value: String(wallets.length) },
+          { label: "Collections", value: "3" },
+          { label: "Style", value: styleLabel },
+        ],
+        collections: [
+          {
+            title: "The Memes",
+            count: 25,
+            asset_id: "asset-memes",
+            href: `/${displayHandle}/collections/the-memes/index.html`,
+          },
+          {
+            title: "6529 Gradients",
+            count: 12,
+            asset_id: "asset-gradients",
+            href: `/${displayHandle}/collections/6529-gradients/index.html`,
+          },
+          {
+            title: "NextGen",
+            count: 11,
+            asset_id: "asset-nextgen",
+            href: `/${displayHandle}/collections/nextgen/index.html`,
+          },
+        ],
+      },
+      {
+        id: "publish-readiness",
+        type: "callout",
+        tone: "evidence",
+        title: "Publish-ready shape",
+        body: "The builder emits a package that can be stored on IPFS or Arweave and accelerated by 6529.io without making the hosted app the source of truth.",
+      },
+    ],
+    provenance: {
+      source: "wallet_gallery",
+      builder_version: "profile-cms-studio-0.1.0",
+      notes: [
+        "Wallet gallery pages are snapshot based.",
+        "3D rooms must carry a 2D fallback in the same package.",
+      ],
+    },
+  };
+}
+
+export default function ProfileCmsStudio() {
+  const { requestAuth, setToast } = useAuth();
+  const [handle, setHandle] = useState("punk6529");
+  const [title, setTitle] = useState("Collected Signals");
+  const [description, setDescription] = useState(
+    "A wallet-native gallery with collection pages, NFT pages, social cards, and decentralized package evidence."
+  );
+  const [walletText, setWalletText] = useState(DEFAULT_ADDRESS);
+  const [galleryStyle, setGalleryStyle] = useState<GalleryStyle>("editorial");
+  const [storageTarget, setStorageTarget] = useState<StorageTarget>("both");
+  const [copied, setCopied] = useState(false);
+  const [copiedEvidence, setCopiedEvidence] = useState<CopiedEvidence>(null);
+  const [isPublishing, setIsPublishing] = useState(false);
+  const [publishStatus, setPublishStatus] = useState<PublishStatus | null>(
+    null
+  );
+  const [showPublishConfirm, setShowPublishConfirm] = useState(false);
+
+  const displayHandle = getProfileHandlePath(handle);
+  const wallets = useMemo(() => parseWallets(walletText), [walletText]);
+  const walletErrors = useMemo(() => getWalletErrors(wallets), [wallets]);
+  const packageResult = useMemo(() => {
+    if (walletErrors.length > 0) {
+      return null;
+    }
+    return buildCmsPackage({
+      payload: buildStudioPayload({
+        handle,
+        title,
+        description,
+        wallets,
+        galleryStyle,
+      }),
+      signature: {
+        signature_type: "fixture",
+        signing_wallet: wallets[0] ?? DEFAULT_ADDRESS,
+        signed_at: FIXTURE_TIMESTAMP,
+        signature: "pending-wallet-signature",
+      },
+      storage: getStorage(storageTarget),
+    });
+  }, [
+    description,
+    galleryStyle,
+    handle,
+    storageTarget,
+    title,
+    walletErrors,
+    wallets,
+  ]);
+
+  const routes = packageResult
+    ? [
+        packageResult.payload.page.static_export_path,
+        `/${displayHandle}/collections/the-memes/index.html`,
+        `/${displayHandle}/collections/6529-gradients/index.html`,
+        `/${displayHandle}/nfts/ethereum/0x33fd426905f149f8376e227d0c9d3340aad17af1/1/index.html`,
+      ]
+    : [];
+
+  const copyPackage = async () => {
+    if (!packageResult) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(
+        JSON.stringify(packageResult, null, 2)
+      );
+      setCopied(true);
+      globalThis.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      setPublishStatus({
+        type: "error",
+        message: "Clipboard access is blocked. Use Export instead.",
+      });
+    }
+  };
+
+  const copyEvidence = async (
+    type: Exclude<CopiedEvidence, null>,
+    value: string | undefined
+  ) => {
+    if (!value) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopiedEvidence(type);
+      globalThis.setTimeout(() => setCopiedEvidence(null), 1800);
+    } catch {
+      setPublishStatus({
+        type: "error",
+        message: "Clipboard access is blocked. Use Export instead.",
+      });
+    }
+  };
+
+  const exportPackage = () => {
+    if (!packageResult) {
+      return;
+    }
+    const blob = new Blob([JSON.stringify(packageResult, null, 2)], {
+      type: "application/json",
+    });
+    const url = globalThis.URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `${displayHandle}-cms-package.json`;
+    anchor.click();
+    anchor.remove();
+    globalThis.URL.revokeObjectURL(url);
+  };
+
+  const requestPublishPackage = () => {
+    if (!packageResult || isPublishing) {
+      return;
+    }
+    setShowPublishConfirm(true);
+  };
+
+  const publishPackage = async () => {
+    if (!packageResult || isPublishing) {
+      return;
+    }
+
+    const auth = await requestAuth();
+    if (!auth.success) {
+      const message = "Connect and sign in to publish this CMS site.";
+      setPublishStatus({ type: "error", message });
+      setToast({ message, type: "error" });
+      return;
+    }
+
+    setIsPublishing(true);
+    setPublishStatus(null);
+    try {
+      const site = await getOrCreateCmsSite({ title, description });
+      const published = await publishCmsPackage({
+        siteId: site.id,
+        cmsPackage: packageResult,
+      });
+      const publishedPath =
+        published.site.primary_static_path ??
+        packageResult.payload.page.static_export_path;
+      const message = `Published ${publishedPath}`;
+      setPublishStatus({ type: "success", message });
+      setToast({ message: "CMS site published.", type: "success" });
+    } catch (error) {
+      const message = getCmsStudioErrorMessage(error);
+      setPublishStatus({ type: "error", message });
+      setToast({
+        type: "error",
+        title: "Couldn't publish CMS site.",
+        description: message,
+      });
+    } finally {
+      setIsPublishing(false);
+      setShowPublishConfirm(false);
+    }
+  };
+
+  return (
+    <main className={css.shell}>
+      <div className={css.header}>
+        <div>
+          <p className={css.eyebrow}>Profile CMS</p>
+          <h1>Studio</h1>
+        </div>
+        <div className={css.headerMeta}>
+          <span>/{displayHandle}/index.html</span>
+          <span>{packageResult ? "package ready" : "needs wallet"}</span>
+        </div>
+      </div>
+
+      <div className={css.workspace}>
+        <section className={css.panel} aria-labelledby="site-settings">
+          <h2 id="site-settings">Site</h2>
+          <label>
+            <span>Profile handle</span>
+            <input
+              value={handle}
+              onChange={(event) => setHandle(event.target.value)}
+              maxLength={32}
+            />
+          </label>
+          <label>
+            <span>Title</span>
+            <input
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              maxLength={80}
+            />
+          </label>
+          <label>
+            <span>Description</span>
+            <textarea
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              rows={4}
+              maxLength={240}
+            />
+          </label>
+          <label>
+            <span>Wallets</span>
+            <textarea
+              value={walletText}
+              onChange={(event) => setWalletText(event.target.value)}
+              rows={4}
+              spellCheck={false}
+            />
+          </label>
+          {walletErrors.length > 0 ? (
+            <div className={css.errorList}>
+              {walletErrors.map((error) => (
+                <p key={error}>{error}</p>
+              ))}
+            </div>
+          ) : null}
+        </section>
+
+        <section className={css.panel} aria-labelledby="gallery-settings">
+          <h2 id="gallery-settings">Gallery</h2>
+          <div
+            aria-label="Gallery style"
+            className={css.segmented}
+            role="radiogroup"
+          >
+            {styleOptions.map((option) => {
+              const Icon = option.icon;
+              const selected = galleryStyle === option.id;
+              return (
+                <button
+                  aria-checked={selected}
+                  className={selected ? css.selectedSegment : ""}
+                  key={option.id}
+                  onClick={() => setGalleryStyle(option.id)}
+                  role="radio"
+                  type="button"
+                >
+                  <Icon aria-hidden="true" />
+                  <span>{option.label}</span>
+                  <small>{option.description}</small>
+                  {selected ? (
+                    <span className={css.selectedBadge}>
+                      <CheckCircleIcon aria-hidden="true" />
+                      Selected
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className={css.storageRow}>
+            <span>Storage</span>
+            <div className={css.storageButtons}>
+              {storageOptions.map((option) => (
+                <button
+                  className={
+                    storageTarget === option.id ? css.selectedPill : ""
+                  }
+                  aria-pressed={storageTarget === option.id}
+                  key={option.id}
+                  onClick={() => setStorageTarget(option.id)}
+                  type="button"
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <p className={css.storageHint}>
+            IPFS improves retrieval and mirroring. Arweave records permanence.
+            6529.io can accelerate either path without being the source of
+            truth.
+          </p>
+
+          <div className={css.previewFrame}>
+            <div>
+              <p className={css.eyebrow}>{displayHandle}</p>
+              <h3>{title}</h3>
+              <p>{description}</p>
+            </div>
+            <div className={css.previewGrid}>
+              <Image
+                src="/memes-preview.png"
+                alt="The Memes preview"
+                width={480}
+                height={360}
+              />
+              <Image
+                src="/gradients-preview.png"
+                alt="6529 Gradients preview"
+                width={480}
+                height={360}
+              />
+              <Image
+                src="/nextgen.png"
+                alt="NextGen preview"
+                width={480}
+                height={360}
+              />
+            </div>
+          </div>
+        </section>
+
+        <aside className={css.panel} aria-labelledby="package-evidence">
+          <h2 id="package-evidence">Package</h2>
+          <div className={css.evidence}>
+            <div className={css.evidenceHeader}>
+              <p>Hash</p>
+              <button
+                disabled={!packageResult}
+                onClick={() =>
+                  copyEvidence("package", packageResult?.package_hash)
+                }
+                type="button"
+              >
+                {copiedEvidence === "package" ? "Copied" : "Copy"}
+              </button>
+            </div>
+            <code>{packageResult?.package_hash ?? "not generated"}</code>
+          </div>
+          <div className={css.evidence}>
+            <div className={css.evidenceHeader}>
+              <p>Payload</p>
+              <button
+                disabled={!packageResult}
+                onClick={() =>
+                  copyEvidence("payload", packageResult?.payload_hash)
+                }
+                type="button"
+              >
+                {copiedEvidence === "payload" ? "Copied" : "Copy"}
+              </button>
+            </div>
+            <code>{packageResult?.payload_hash ?? "not generated"}</code>
+          </div>
+          <div className={css.routeList}>
+            {routes.map((route) => (
+              <div key={route}>
+                <CheckCircleIcon aria-hidden="true" />
+                <span>{route}</span>
+              </div>
+            ))}
+          </div>
+          <div className={css.actionRow}>
+            <button
+              disabled={!packageResult}
+              onClick={copyPackage}
+              type="button"
+            >
+              <DocumentDuplicateIcon aria-hidden="true" />
+              <span>{copied ? "Copied" : "Copy JSON"}</span>
+            </button>
+            <button
+              disabled={!packageResult}
+              onClick={exportPackage}
+              type="button"
+            >
+              <ArrowDownTrayIcon aria-hidden="true" />
+              <span>Export</span>
+            </button>
+            <button
+              disabled={!packageResult || isPublishing}
+              onClick={requestPublishPackage}
+              className={css.publishButton}
+              type="button"
+            >
+              <CloudArrowUpIcon aria-hidden="true" />
+              <span>{isPublishing ? "Publishing" : "Publish"}</span>
+            </button>
+          </div>
+          {publishStatus ? (
+            <p
+              className={`${css.publishStatus} ${
+                publishStatus.type === "success"
+                  ? css.publishStatusSuccess
+                  : css.publishStatusError
+              }`}
+            >
+              {publishStatus.message}
+            </p>
+          ) : null}
+        </aside>
+      </div>
+      {showPublishConfirm && packageResult ? (
+        <div className={css.dialogLayer}>
+          <button
+            aria-label="Close publish confirmation"
+            className={css.dialogBackdrop}
+            onClick={() => setShowPublishConfirm(false)}
+            type="button"
+          />
+          <dialog
+            aria-labelledby="profile-cms-publish-title"
+            className={css.confirmDialog}
+            open
+          >
+            <p className={css.eyebrow}>Publish</p>
+            <h2 id="profile-cms-publish-title">Set primary CMS site</h2>
+            <p>
+              This will set {packageResult.payload.page.static_export_path} as{" "}
+              the profile&apos;s primary CMS website through the 6529 API
+              pointer. The package remains exportable and content-addressed.
+            </p>
+            <div className={css.confirmGrid}>
+              <div>
+                <span>Storage intent</span>
+                <strong>
+                  {
+                    storageOptions.find((option) => option.id === storageTarget)
+                      ?.label
+                  }
+                </strong>
+              </div>
+              <div>
+                <span>Package</span>
+                <strong>{packageResult.package_hash}</strong>
+              </div>
+            </div>
+            <p className={css.storageHint}>
+              Current MVP packages carry pending storage receipts and a draft
+              signature envelope. Final decentralized publish still needs the
+              wallet package-signature and real IPFS/Arweave receipt adapter.
+            </p>
+            <div className={css.confirmActions}>
+              <button
+                className={css.secondaryAction}
+                disabled={isPublishing}
+                onClick={() => setShowPublishConfirm(false)}
+                type="button"
+              >
+                Cancel
+              </button>
+              <button
+                className={css.publishButton}
+                disabled={isPublishing}
+                onClick={publishPackage}
+                type="button"
+              >
+                <CloudArrowUpIcon aria-hidden="true" />
+                <span>{isPublishing ? "Publishing" : "Confirm publish"}</span>
+              </button>
+            </div>
+          </dialog>
+        </div>
+      ) : null}
+    </main>
+  );
+}

--- a/components/user/user-page-header/UserPageHeader.tsx
+++ b/components/user/user-page-header/UserPageHeader.tsx
@@ -6,6 +6,7 @@ import { SortDirection } from "@/entities/ISort";
 import type { CountlessPage } from "@/helpers/Types";
 import type { ApiIncomingIdentitySubscriptionsPage } from "@/generated/models/ApiIncomingIdentitySubscriptionsPage";
 import { getAppCommonHeaders } from "@/helpers/server.app.helpers";
+import { getPublishedPrimaryCmsSiteForProfile } from "@/lib/cms/profile-sites";
 import { commonApiFetch } from "@/services/api/common-api";
 
 import UserPageHeaderClient from "./UserPageHeaderClient";
@@ -88,11 +89,12 @@ export default async function UserPageHeader({
   const headers = await getAppCommonHeaders();
   const normalizedHandle = handleOrWallet.toLowerCase();
 
-  const [statementsResult, profileLogResult, followersResult] =
+  const [statementsResult, profileLogResult, followersResult, cmsSiteResult] =
     await Promise.allSettled([
       fetchStatements(normalizedHandle, headers),
       fetchProfileEnabledLog(normalizedHandle, headers),
       fetchFollowersCount(profile.id, headers),
+      getPublishedPrimaryCmsSiteForProfile(profile),
     ]);
 
   const statements: CicStatement[] =
@@ -115,6 +117,11 @@ export default async function UserPageHeader({
       profileEnabledAt={extractProfileEnabledAt(profileLog)}
       followersCount={
         followersResult.status === "fulfilled" ? followersResult.value : null
+      }
+      primaryCmsSitePath={
+        cmsSiteResult.status === "fulfilled"
+          ? (cmsSiteResult.value?.staticPath ?? null)
+          : null
       }
     />
   );

--- a/components/user/user-page-header/UserPageHeaderClient.tsx
+++ b/components/user/user-page-header/UserPageHeaderClient.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
 import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useContext, useMemo, useState } from "react";
 
@@ -35,6 +37,7 @@ type Props = {
   readonly initialStatements: CicStatement[];
   readonly profileEnabledAt: string | null;
   readonly followersCount: number | null;
+  readonly primaryCmsSitePath: string | null;
 };
 
 export default function UserPageHeaderClient({
@@ -46,6 +49,7 @@ export default function UserPageHeaderClient({
   initialStatements,
   profileEnabledAt,
   followersCount,
+  primaryCmsSitePath,
 }: Readonly<Props>) {
   const params = useParams();
   const router = useRouter();
@@ -201,6 +205,19 @@ export default function UserPageHeaderClient({
               </div>
 
               <div className="tw-order-2 tw-mb-2 tw-mt-2 tw-flex tw-items-center tw-gap-3 tw-self-start md:tw-order-3 md:tw-mb-0">
+                {primaryCmsSitePath ? (
+                  <Link
+                    href={primaryCmsSitePath}
+                    aria-label={`${profile.handle ?? "Profile"} website`}
+                    className="tw-inline-flex tw-h-9 tw-items-center tw-gap-2 tw-rounded-lg tw-border tw-border-solid tw-border-white/10 tw-bg-white/[0.07] tw-px-3 tw-text-sm tw-font-semibold tw-text-white tw-no-underline tw-transition hover:tw-border-cyan-300/50 hover:tw-bg-cyan-300/10 hover:tw-text-white focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-cyan-300"
+                  >
+                    <span>Website</span>
+                    <ArrowTopRightOnSquareIcon
+                      aria-hidden="true"
+                      className="tw-h-4 tw-w-4 tw-flex-shrink-0"
+                    />
+                  </Link>
+                ) : null}
                 {!isMyProfile && profile.handle && connectedProfile?.handle ? (
                   <UserFollowBtn
                     handle={profile.handle}

--- a/components/waves/drop/VoteButton.module.scss
+++ b/components/waves/drop/VoteButton.module.scss
@@ -169,31 +169,27 @@ $btn-dimension: 72px;
   }
 }
 
-:global(.wave-drop-vote-submit-full) {
+:global(.wave-drop-vote-submit-full) .voteButton {
   width: 100%;
+  height: auto;
+  min-height: 40px;
+  padding: 10px 14px;
+  background: transparent;
+  border-color: #26272b;
+  color: #4c4c55;
+  box-shadow: none;
 
   > div {
     width: 100%;
   }
 
-  .voteButton {
-    width: 100%;
-    height: auto;
-    min-height: 40px;
-    padding: 10px 14px;
-    background: transparent;
-    border-color: #26272b;
-    color: #4c4c55;
-    box-shadow: none;
-
-    &:not(:disabled):hover {
-      background: rgba(255, 255, 255, 0.03);
-      border-color: #37373e;
-      color: #60606c;
-    }
+  &:not(:disabled):hover {
+    background: rgba(255, 255, 255, 0.03);
+    border-color: #37373e;
+    color: #60606c;
   }
 
-  .voteButtonPositive {
+  &.voteButtonPositive {
     background: #10b981;
     border-color: #10b981;
     color: #fff;
@@ -208,7 +204,7 @@ $btn-dimension: 72px;
     }
   }
 
-  .voteButtonNegative {
+  &.voteButtonNegative {
     background: #f43f5e;
     border-color: #f43f5e;
     color: #fff;
@@ -223,7 +219,7 @@ $btn-dimension: 72px;
     }
   }
 
-  .voteButtonNeutral {
+  &.voteButtonNeutral {
     background: transparent;
     border-color: #26272b;
     color: #4c4c55;

--- a/lib/cms/canonicalize.ts
+++ b/lib/cms/canonicalize.ts
@@ -1,0 +1,57 @@
+const TYPE_ORDER = new Set(["string", "number", "boolean"]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype: unknown = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function serialize(value: unknown, path: string): string {
+  if (value === null) {
+    return "null";
+  }
+
+  const valueType = typeof value;
+  if (TYPE_ORDER.has(valueType)) {
+    if (valueType === "number") {
+      if (!Number.isFinite(value)) {
+        throw new TypeError(
+          `CMS package contains non-finite number at ${path}`
+        );
+      }
+      return JSON.stringify(Object.is(value, -0) ? 0 : value);
+    }
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value
+      .map((item, index) => {
+        const itemPath = `${path}[${index}]`;
+        return serialize(item, itemPath);
+      })
+      .join(",")}]`;
+  }
+
+  if (isPlainObject(value)) {
+    const entries = Object.entries(value)
+      .filter(([, item]) => item !== undefined)
+      .sort(([a], [b]) => a.localeCompare(b));
+
+    return `{${entries
+      .map(([key, item]) => {
+        const itemPath = `${path}.${key}`;
+        return `${JSON.stringify(key)}:${serialize(item, itemPath)}`;
+      })
+      .join(",")}}`;
+  }
+
+  throw new TypeError(`CMS package contains unsupported value at ${path}`);
+}
+
+export function canonicalizeCmsJson(value: unknown): string {
+  return serialize(value, "$");
+}

--- a/lib/cms/fixtures.ts
+++ b/lib/cms/fixtures.ts
@@ -1,0 +1,322 @@
+import { buildCmsPackage } from "./package-utils";
+import {
+  CMS_PAYLOAD_SCHEMA,
+  type CmsPayload,
+  type CmsPublishedPackage,
+} from "./types";
+
+const FIXTURE_TIMESTAMP = "2026-06-16T00:00:00.000Z";
+
+const fixtureSignature = {
+  signature_type: "fixture" as const,
+  signing_wallet: "0x0000000000000000000000000000000000006529",
+  signed_at: FIXTURE_TIMESTAMP,
+  signature: "fixture-signature-profile-native-cms-v1",
+};
+
+const ownerProfile = {
+  id: "profile-punk6529",
+  handle: "punk6529",
+  display_name: "punk6529",
+  path: "/punk6529",
+};
+
+const baseSite = {
+  id: "site-punk6529-primary",
+  slug: "home",
+  title: "punk6529",
+  description: "A profile-native CMS site rendered from a signed package.",
+  owner_profile: ownerProfile,
+  theme: {
+    mode: "dark" as const,
+    accent_color: "#36d1dc",
+  },
+};
+
+const baseStorage = [
+  {
+    provider: "fixture" as const,
+    uri: "fixture://profile-native-cms/punk6529",
+    pinned: true,
+  },
+];
+
+const galleryPayload: CmsPayload = {
+  schema: CMS_PAYLOAD_SCHEMA,
+  site: baseSite,
+  page: {
+    id: "page-wallet-gallery",
+    title: "Collected Signals",
+    description:
+      "A wallet-native gallery page composed from stable NFT snapshots and collection context.",
+    slug_path: "",
+    static_export_path: "/punk6529/index.html",
+    canonical_url: "https://6529.io/punk6529/index.html",
+    page_type: "gallery",
+    social: {
+      title: "Collected Signals by punk6529",
+      description:
+        "A profile-native gallery with package hashes, collection context, and share-ready media.",
+      canonical_url: "https://6529.io/punk6529/index.html",
+      open_graph_image: {
+        url: "/nakamoto-card-og.png",
+        width: 1200,
+        height: 630,
+        alt: "6529 Nakamoto card social preview",
+      },
+      square_image: {
+        url: "/memes-preview.png",
+        width: 1200,
+        height: 1200,
+        alt: "The Memes preview",
+      },
+    },
+    created_at: FIXTURE_TIMESTAMP,
+    updated_at: FIXTURE_TIMESTAMP,
+  },
+  assets: [
+    {
+      id: "asset-memes",
+      kind: "image",
+      src: "/memes-preview.png",
+      alt: "The Memes collection preview",
+      title: "The Memes",
+      caption: "A 6529-native collection with cultural context packets.",
+      width: 1200,
+      height: 630,
+      mime_type: "image/png",
+    },
+    {
+      id: "asset-gradients",
+      kind: "image",
+      src: "/gradients-preview.png",
+      alt: "6529 Gradient collection preview",
+      title: "6529 Gradients",
+      caption: "Color-native identity primitives.",
+      width: 1200,
+      height: 630,
+      mime_type: "image/png",
+    },
+    {
+      id: "asset-nextgen",
+      kind: "image",
+      src: "/nextgen.png",
+      alt: "NextGen collection preview",
+      title: "NextGen",
+      caption: "Generative collections with first-party exhibition packs.",
+      width: 1200,
+      height: 630,
+      mime_type: "image/png",
+    },
+    {
+      id: "asset-nakamoto",
+      kind: "image",
+      src: "/nakamoto-card-og.png",
+      alt: "Nakamoto Freedom card preview",
+      title: "Nakamoto Freedom",
+      width: 1200,
+      height: 630,
+      mime_type: "image/png",
+    },
+  ],
+  blocks: [
+    {
+      id: "heading-hero",
+      type: "heading",
+      level: 2,
+      eyebrow: "Profile-native CMS",
+      text: "Portable gallery package",
+    },
+    {
+      id: "intro",
+      type: "rich_text",
+      paragraphs: [
+        "This page is rendered from a portable CMS package, not from mutable page-specific React code.",
+        "The hosted site can accelerate it, but the package carries the page, assets, provenance, route, social metadata, hashes, and signature envelope that alternative clients need.",
+      ],
+    },
+    {
+      id: "wallet-gallery",
+      type: "generated_wallet_gallery",
+      title: "Wallet gallery snapshot",
+      wallets: ["0x0000000000000000000000000000000000006529"],
+      snapshot: {
+        captured_at: FIXTURE_TIMESTAMP,
+        block_number: 22500000,
+      },
+      stats: [
+        { label: "Collections", value: "3" },
+        { label: "Featured works", value: "48" },
+        { label: "Storage", value: "Package-ready" },
+      ],
+      collections: [
+        {
+          title: "The Memes",
+          count: 25,
+          asset_id: "asset-memes",
+          href: "/punk6529/collections/the-memes/index.html",
+        },
+        {
+          title: "6529 Gradients",
+          count: 12,
+          asset_id: "asset-gradients",
+          href: "/punk6529/collections/6529-gradients/index.html",
+        },
+        {
+          title: "NextGen",
+          count: 11,
+          asset_id: "asset-nextgen",
+          href: "/punk6529/collections/nextgen/index.html",
+        },
+      ],
+    },
+    {
+      id: "collection-context",
+      type: "collection_reference",
+      chain_id: 1,
+      contract: "0x33fd426905f149f8376e227d0c9d3340aaD17aF1",
+      title: "The Memes",
+      summary:
+        "A collection page can include curated knowledge packet context while preserving the packet id, version, and hash used at publish time.",
+      asset_id: "asset-memes",
+      knowledge_packet: {
+        id: "6529.collections.the-memes",
+        version: "0.1.0",
+        hash: "sha256:80970f50d80f6384c59929e9ac4587d7db904ec2b22580b589b6f44c807d4f85",
+      },
+    },
+    {
+      id: "featured-card",
+      type: "nft_reference",
+      chain_id: 1,
+      contract: "0x33fd426905f149f8376e227d0c9d3340aaD17aF1",
+      token_id: "1",
+      title: "Nakamoto Freedom",
+      collection: "The Memes",
+      creator: "6529er",
+      asset_id: "asset-nakamoto",
+      snapshot: {
+        owner: "0x0000000000000000000000000000000000006529",
+        block_number: 22500000,
+        captured_at: FIXTURE_TIMESTAMP,
+      },
+    },
+    {
+      id: "durability-callout",
+      type: "callout",
+      tone: "evidence",
+      title: "Launch centralized, publish decentralized-shaped",
+      body: "Authoring can start in the hosted app. Published pages should already be deterministic packages with storage receipts and stable hashes.",
+    },
+  ],
+  provenance: {
+    source: "fixture",
+    builder_version: "profile-native-cms-fixture-0.1.0",
+    notes: [
+      "Fixture proves the renderer can work without authoring API state.",
+      "Wallet gallery blocks are snapshot based so mirrors can render offline.",
+    ],
+  },
+};
+
+const transactionPayload: CmsPayload = {
+  ...galleryPayload,
+  page: {
+    ...galleryPayload.page,
+    id: "page-transaction-explainer",
+    title: "Transaction That Reads Like English",
+    description:
+      "A block explorer style CMS page that explains what happened before showing raw chain facts.",
+    slug_path: "transaction-explainer",
+    static_export_path: "/punk6529/transaction-explainer/index.html",
+    canonical_url: "https://6529.io/punk6529/transaction-explainer/index.html",
+    page_type: "page",
+    social: {
+      ...galleryPayload.page.social,
+      title: "Transaction That Reads Like English",
+      description:
+        "A human-readable transaction page with immutable chain snapshot data.",
+      canonical_url:
+        "https://6529.io/punk6529/transaction-explainer/index.html",
+    },
+  },
+  blocks: [
+    {
+      id: "heading-transaction",
+      type: "heading",
+      level: 2,
+      eyebrow: "Chain evidence block",
+      text: "A transaction page should explain the event first",
+    },
+    {
+      id: "tx-intro",
+      type: "rich_text",
+      paragraphs: [
+        "Block explorers show facts but rarely explain meaning. CMS transaction blocks should keep raw facts visible while giving readers the plain-English story.",
+      ],
+    },
+    {
+      id: "tx-ref",
+      type: "transaction_reference",
+      chain_id: 1,
+      hash: "0x6529652965296529652965296529652965296529652965296529652965296529",
+      block_number: 22500000,
+      timestamp: FIXTURE_TIMESTAMP,
+      summary:
+        "The wallet transferred a 6529 Meme Card to a new collecting wallet and paid normal Ethereum gas.",
+      from: "0x0000000000000000000000000000000000006529",
+      to: "0x0000000000000000000000000000000000000001",
+      value_eth: "0",
+      actions: [
+        "Confirmed the sender wallet.",
+        "Transferred The Memes token #1.",
+        "Recorded block number, timestamp, and chain id in the package.",
+      ],
+    },
+    {
+      id: "raw-facts",
+      type: "callout",
+      tone: "note",
+      title: "Snapshot, not live dependency",
+      body: "A live overlay can refresh status later, but the published page must still render from the captured chain snapshot.",
+    },
+  ],
+  provenance: {
+    source: "fixture",
+    builder_version: "profile-native-cms-fixture-0.1.0",
+    notes: ["Transaction fixture keeps explanation and raw evidence together."],
+  },
+};
+
+export const cmsFixturePackages = {
+  gallery: buildCmsPackage({
+    payload: galleryPayload,
+    signature: fixtureSignature,
+    storage: baseStorage,
+  }),
+  transaction: buildCmsPackage({
+    payload: transactionPayload,
+    signature: fixtureSignature,
+    storage: [
+      {
+        provider: "fixture",
+        uri: "fixture://profile-native-cms/transaction",
+        pinned: true,
+      },
+    ],
+  }),
+} satisfies Record<string, CmsPublishedPackage>;
+
+export type CmsFixtureSlug = keyof typeof cmsFixturePackages;
+
+export const cmsFixtureSlugs = Object.keys(
+  cmsFixturePackages
+) as CmsFixtureSlug[];
+
+function isCmsFixtureSlug(slug: string): slug is CmsFixtureSlug {
+  return Object.prototype.hasOwnProperty.call(cmsFixturePackages, slug);
+}
+
+export function getCmsFixturePackage(slug: string): CmsPublishedPackage | null {
+  return isCmsFixtureSlug(slug) ? cmsFixturePackages[slug] : null;
+}

--- a/lib/cms/fixtures.ts
+++ b/lib/cms/fixtures.ts
@@ -1,4 +1,4 @@
-import { buildCmsPackage } from "./package-utils";
+import { assertCmsPackageHashes, buildCmsPackage } from "./package-utils";
 import {
   CMS_PAYLOAD_SCHEMA,
   type CmsPayload,
@@ -318,5 +318,11 @@ function isCmsFixtureSlug(slug: string): slug is CmsFixtureSlug {
 }
 
 export function getCmsFixturePackage(slug: string): CmsPublishedPackage | null {
-  return isCmsFixtureSlug(slug) ? cmsFixturePackages[slug] : null;
+  if (!isCmsFixtureSlug(slug)) {
+    return null;
+  }
+
+  const cmsPackage = cmsFixturePackages[slug];
+  assertCmsPackageHashes(cmsPackage);
+  return cmsPackage;
 }

--- a/lib/cms/fixtures.ts
+++ b/lib/cms/fixtures.ts
@@ -314,7 +314,7 @@ export const cmsFixtureSlugs = Object.keys(
 ) as CmsFixtureSlug[];
 
 function isCmsFixtureSlug(slug: string): slug is CmsFixtureSlug {
-  return Object.prototype.hasOwnProperty.call(cmsFixturePackages, slug);
+  return Object.hasOwn(cmsFixturePackages, slug);
 }
 
 export function getCmsFixturePackage(slug: string): CmsPublishedPackage | null {

--- a/lib/cms/media.ts
+++ b/lib/cms/media.ts
@@ -4,7 +4,7 @@ const IPFS_PROTOCOL = "ipfs://";
 const ARWEAVE_PROTOCOL = "ar://";
 const LOCAL_MEDIA_FALLBACK = "/6529io.png";
 const URL_SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:/i;
-const UNSAFE_URL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f\s\\]/;
+const UNSAFE_URL_CHARACTER_PATTERN = /[\u0000-\u0020\u007f\\]/;
 
 function trimTrailingSlash(value: string): string {
   return value.endsWith("/") ? trimTrailingSlash(value.slice(0, -1)) : value;

--- a/lib/cms/media.ts
+++ b/lib/cms/media.ts
@@ -1,0 +1,25 @@
+import { publicEnv } from "@/config/env";
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? trimTrailingSlash(value.slice(0, -1)) : value;
+}
+
+function getIpfsGatewayBase(): string {
+  const endpoint = trimTrailingSlash(publicEnv.IPFS_GATEWAY_ENDPOINT);
+  return endpoint.endsWith("/ipfs") ? endpoint.slice(0, -5) : endpoint;
+}
+
+export function resolveCmsMediaUrl(src: string): string {
+  if (!src.toLowerCase().startsWith("ipfs://")) {
+    return src;
+  }
+
+  return `${getIpfsGatewayBase()}/ipfs/${src.slice("ipfs://".length)}`;
+}
+
+export function findCmsAsset<TAsset extends { readonly id: string }>(
+  assets: readonly TAsset[],
+  assetId: string
+): TAsset | null {
+  return assets.find((asset) => asset.id === assetId) ?? null;
+}

--- a/lib/cms/media.ts
+++ b/lib/cms/media.ts
@@ -1,5 +1,11 @@
 import { publicEnv } from "@/config/env";
 
+const IPFS_PROTOCOL = "ipfs://";
+const ARWEAVE_PROTOCOL = "ar://";
+const LOCAL_MEDIA_FALLBACK = "/6529io.png";
+const URL_SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:/i;
+const UNSAFE_URL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f\s\\]/;
+
 function trimTrailingSlash(value: string): string {
   return value.endsWith("/") ? trimTrailingSlash(value.slice(0, -1)) : value;
 }
@@ -9,12 +15,57 @@ function getIpfsGatewayBase(): string {
   return endpoint.endsWith("/ipfs") ? endpoint.slice(0, -5) : endpoint;
 }
 
-export function resolveCmsMediaUrl(src: string): string {
-  if (!src.toLowerCase().startsWith("ipfs://")) {
-    return src;
+function isSafeRelativeCmsUrl(value: string): boolean {
+  if (value.startsWith("//")) {
+    return false;
   }
 
-  return `${getIpfsGatewayBase()}/ipfs/${src.slice("ipfs://".length)}`;
+  return (
+    value.startsWith("/") || value.startsWith("./") || value.startsWith("../")
+  );
+}
+
+export function resolveSafeCmsUrl(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || UNSAFE_URL_CHARACTER_PATTERN.test(trimmed)) {
+    return null;
+  }
+
+  const lowerValue = trimmed.toLowerCase();
+  if (lowerValue.startsWith(IPFS_PROTOCOL)) {
+    const ipfsPath = trimmed.slice(IPFS_PROTOCOL.length);
+    return ipfsPath ? `${getIpfsGatewayBase()}/ipfs/${ipfsPath}` : null;
+  }
+
+  if (lowerValue.startsWith(ARWEAVE_PROTOCOL)) {
+    const arweavePath = trimmed.slice(ARWEAVE_PROTOCOL.length);
+    return arweavePath ? `https://arweave.net/${arweavePath}` : null;
+  }
+
+  if (!URL_SCHEME_PATTERN.test(trimmed)) {
+    return isSafeRelativeCmsUrl(trimmed) ? trimmed : null;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === "https:" || parsed.protocol === "http:"
+      ? parsed.toString()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveCmsLinkUrl(href: string): string | null {
+  return resolveSafeCmsUrl(href);
+}
+
+export function resolveCmsMediaUrl(src: string): string | null {
+  return resolveSafeCmsUrl(src);
+}
+
+export function getSafeCmsMediaUrl(src: string): string {
+  return resolveCmsMediaUrl(src) ?? LOCAL_MEDIA_FALLBACK;
 }
 
 export function findCmsAsset<TAsset extends { readonly id: string }>(

--- a/lib/cms/package-utils.ts
+++ b/lib/cms/package-utils.ts
@@ -1,0 +1,78 @@
+import { sha256 } from "js-sha256";
+
+import { canonicalizeCmsJson } from "./canonicalize";
+import { cmsPackageSchema } from "./schema";
+import {
+  CMS_PACKAGE_SCHEMA,
+  type CmsHash,
+  type CmsPayload,
+  type CmsPublishedPackage,
+  type CmsSignatureEnvelope,
+  type CmsStorageLocation,
+} from "./types";
+
+export function hashCmsJson(value: unknown): CmsHash {
+  return `sha256:${sha256(canonicalizeCmsJson(value))}`;
+}
+
+export function getCmsPayloadHash(payload: CmsPayload): CmsHash {
+  return hashCmsJson(payload);
+}
+
+export function getCmsPackageHash(
+  cmsPackage: Omit<CmsPublishedPackage, "package_hash"> & {
+    readonly package_hash?: CmsHash;
+  }
+): CmsHash {
+  return hashCmsJson({
+    ...cmsPackage,
+    package_hash: null,
+  });
+}
+
+export function buildCmsPackage(param: {
+  readonly payload: CmsPayload;
+  readonly signature: CmsSignatureEnvelope;
+  readonly storage: readonly CmsStorageLocation[];
+}): CmsPublishedPackage {
+  const payloadHash = getCmsPayloadHash(param.payload);
+  const packageWithoutHash = {
+    schema: CMS_PACKAGE_SCHEMA,
+    payload_hash: payloadHash,
+    package_hash: null,
+    payload: param.payload,
+    signature: param.signature,
+    storage: param.storage,
+  };
+  const packageHash = hashCmsJson(packageWithoutHash);
+
+  return {
+    schema: CMS_PACKAGE_SCHEMA,
+    payload_hash: payloadHash,
+    package_hash: packageHash,
+    payload: param.payload,
+    signature: param.signature,
+    storage: param.storage,
+  };
+}
+
+export function parseCmsPackage(value: unknown): CmsPublishedPackage {
+  const parsed = cmsPackageSchema.parse(value);
+  return parsed as CmsPublishedPackage;
+}
+
+export function assertCmsPackageHashes(cmsPackage: CmsPublishedPackage): void {
+  const payloadHash = getCmsPayloadHash(cmsPackage.payload);
+  if (payloadHash !== cmsPackage.payload_hash) {
+    throw new Error(
+      `CMS payload hash mismatch: expected ${cmsPackage.payload_hash}, got ${payloadHash}`
+    );
+  }
+
+  const packageHash = getCmsPackageHash(cmsPackage);
+  if (packageHash !== cmsPackage.package_hash) {
+    throw new Error(
+      `CMS package hash mismatch: expected ${cmsPackage.package_hash}, got ${packageHash}`
+    );
+  }
+}

--- a/lib/cms/profile-sites.ts
+++ b/lib/cms/profile-sites.ts
@@ -118,6 +118,8 @@ function getPublishedCmsSiteFromFixtures(
     return null;
   }
 
+  assertCmsPackageHashes(cmsPackage);
+
   return {
     cmsPackage,
     staticPath: cmsPackage.payload.page.static_export_path,

--- a/lib/cms/profile-sites.ts
+++ b/lib/cms/profile-sites.ts
@@ -1,0 +1,162 @@
+import { publicEnv } from "@/config/env";
+import { cmsFixturePackages } from "@/lib/cms/fixtures";
+import {
+  assertCmsPackageHashes,
+  parseCmsPackage,
+} from "@/lib/cms/package-utils";
+import type { CmsPublishedPackage } from "@/lib/cms/types";
+
+export type PublishedProfileCmsSite = {
+  readonly cmsPackage: CmsPublishedPackage;
+  readonly staticPath: string;
+};
+
+type ProfileIdentifier = {
+  readonly handle?: string | null | undefined;
+  readonly primary_wallet?: string | null | undefined;
+  readonly primary_address?: string | null | undefined;
+  readonly query?: string | null | undefined;
+};
+
+type ApiCmsPublishedSite = {
+  readonly site: {
+    readonly primary_static_path?: string | null;
+  };
+  readonly published_package: {
+    readonly static_path: string;
+    readonly package_json: unknown;
+  };
+};
+
+function normalizeIdentifier(value: string | null | undefined): string | null {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) {
+    return null;
+  }
+  return normalized;
+}
+
+function getProfileIdentifiers(profile: ProfileIdentifier): readonly string[] {
+  return [
+    normalizeIdentifier(profile.handle),
+    normalizeIdentifier(profile.primary_wallet),
+    normalizeIdentifier(profile.primary_address),
+    normalizeIdentifier(profile.query),
+  ].filter((value): value is string => value !== null);
+}
+
+function getPackageOwnerIdentifiers(
+  cmsPackage: CmsPublishedPackage
+): readonly string[] {
+  const owner = cmsPackage.payload.site.owner_profile;
+  return [
+    normalizeIdentifier(owner.handle),
+    normalizeIdentifier(owner.id),
+  ].filter((value): value is string => value !== null);
+}
+
+function getCmsApiUrl(profileHandleOrWallet: string): string {
+  return `${publicEnv.API_ENDPOINT}/api/cms/profile/${encodeURIComponent(
+    profileHandleOrWallet
+  )}/primary`;
+}
+
+async function installSsrFetchWhenServerSide(): Promise<void> {
+  if (typeof document !== "undefined") {
+    return;
+  }
+  await import("@/lib/fetch/ssrFetch");
+}
+
+async function getPublishedCmsSiteFromApi(
+  profileHandleOrWallet: string
+): Promise<PublishedProfileCmsSite | null> {
+  await installSsrFetchWhenServerSide();
+  const response = await fetch(getCmsApiUrl(profileHandleOrWallet), {
+    cache: "no-store",
+  });
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`CMS site lookup failed with status ${response.status}`);
+  }
+
+  const apiSite = (await response.json()) as ApiCmsPublishedSite;
+  const cmsPackage = parseCmsPackage(apiSite.published_package.package_json);
+  assertCmsPackageHashes(cmsPackage);
+
+  return {
+    cmsPackage,
+    staticPath:
+      apiSite.site.primary_static_path ?? apiSite.published_package.static_path,
+  };
+}
+
+async function getFirstPublishedCmsSiteFromApi(
+  identifiers: readonly string[]
+): Promise<PublishedProfileCmsSite | null> {
+  for (const identifier of identifiers) {
+    const site = await getPublishedCmsSiteFromApi(identifier);
+    if (site) {
+      return site;
+    }
+  }
+  return null;
+}
+
+function getPublishedCmsSiteFromFixtures(
+  profileIdentifiers: ReadonlySet<string>
+): PublishedProfileCmsSite | null {
+  const cmsPackage = Object.values(cmsFixturePackages).find((candidate) =>
+    getPackageOwnerIdentifiers(candidate).some((identifier) =>
+      profileIdentifiers.has(identifier)
+    )
+  );
+
+  if (!cmsPackage) {
+    return null;
+  }
+
+  return {
+    cmsPackage,
+    staticPath: cmsPackage.payload.page.static_export_path,
+  };
+}
+
+export function getPrimaryCmsSitePath(profileHandleOrWallet: string): string {
+  return `/${encodeURIComponent(profileHandleOrWallet)}/index.html`;
+}
+
+export async function getPublishedPrimaryCmsSiteForProfile(
+  profile: ProfileIdentifier
+): Promise<PublishedProfileCmsSite | null> {
+  const profileIdentifiers = getProfileIdentifiers(profile);
+  if (profileIdentifiers.length === 0) {
+    return null;
+  }
+
+  try {
+    const apiSite = await getFirstPublishedCmsSiteFromApi(profileIdentifiers);
+    if (apiSite) {
+      return apiSite;
+    }
+  } catch (error) {
+    console.warn(
+      "CMS primary site API lookup failed, falling back to local fixtures.",
+      error instanceof Error ? error.message : error
+    );
+  }
+
+  return getPublishedCmsSiteFromFixtures(new Set(profileIdentifiers));
+}
+
+export async function getPublishedPrimaryCmsSiteForProfileIdentifier(
+  profileHandleOrWallet: string
+): Promise<PublishedProfileCmsSite | null> {
+  return getPublishedPrimaryCmsSiteForProfile({
+    handle: profileHandleOrWallet,
+    primary_wallet: profileHandleOrWallet,
+    query: profileHandleOrWallet,
+  });
+}

--- a/lib/cms/schema.ts
+++ b/lib/cms/schema.ts
@@ -1,0 +1,266 @@
+import { z } from "zod";
+
+import { CMS_PACKAGE_SCHEMA, CMS_PAYLOAD_SCHEMA } from "./types";
+
+const hashSchema = z.custom<`sha256:${string}`>(
+  (value) => typeof value === "string" && /^sha256:[0-9a-f]{64}$/i.test(value),
+  "Expected sha256:<64 hex chars>"
+);
+
+const jsonSchema: z.ZodType<unknown> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number().finite(),
+    z.boolean(),
+    z.null(),
+    z.array(jsonSchema),
+    z.record(jsonSchema),
+  ])
+);
+
+const profileRefSchema = z.object({
+  id: z.string().min(1),
+  handle: z.string().min(1),
+  display_name: z.string().min(1),
+  path: z.string().min(1),
+});
+
+const assetSchema = z.object({
+  id: z.string().min(1),
+  kind: z.enum(["image", "video", "model", "document", "social_image"]),
+  src: z.string().min(1),
+  alt: z.string().min(1),
+  title: z.string().optional(),
+  caption: z.string().optional(),
+  width: z.number().int().positive().optional(),
+  height: z.number().int().positive().optional(),
+  mime_type: z.string().optional(),
+  content_hash: hashSchema.optional(),
+});
+
+const socialImageSchema = z.object({
+  url: z.string().min(1),
+  width: z.number().int().positive(),
+  height: z.number().int().positive(),
+  alt: z.string().min(1),
+  content_hash: hashSchema.optional(),
+});
+
+const baseBlockSchema = z.object({
+  id: z.string().min(1),
+});
+
+const headingBlockSchema = baseBlockSchema.extend({
+  type: z.literal("heading"),
+  level: z.union([z.literal(1), z.literal(2), z.literal(3)]),
+  text: z.string().min(1),
+  eyebrow: z.string().optional(),
+});
+
+const richTextBlockSchema = baseBlockSchema.extend({
+  type: z.literal("rich_text"),
+  paragraphs: z.array(z.string().min(1)).min(1),
+});
+
+const imageBlockSchema = baseBlockSchema.extend({
+  type: z.literal("image"),
+  asset_id: z.string().min(1),
+  caption: z.string().optional(),
+});
+
+const galleryBlockSchema = baseBlockSchema.extend({
+  type: z.literal("gallery"),
+  title: z.string().optional(),
+  items: z
+    .array(
+      z.object({
+        asset_id: z.string().min(1),
+        title: z.string().optional(),
+        caption: z.string().optional(),
+        href: z.string().optional(),
+      })
+    )
+    .min(1),
+});
+
+const quoteBlockSchema = baseBlockSchema.extend({
+  type: z.literal("quote"),
+  quote: z.string().min(1),
+  attribution: z.string().optional(),
+});
+
+const calloutBlockSchema = baseBlockSchema.extend({
+  type: z.literal("callout"),
+  tone: z.enum(["note", "evidence", "warning"]),
+  title: z.string().min(1),
+  body: z.string().min(1),
+});
+
+const buttonLinkBlockSchema = baseBlockSchema.extend({
+  type: z.literal("button_link"),
+  label: z.string().min(1),
+  href: z.string().min(1),
+});
+
+const nftReferenceBlockSchema = baseBlockSchema.extend({
+  type: z.literal("nft_reference"),
+  chain_id: z.number().int().positive(),
+  contract: z.string().min(1),
+  token_id: z.string().min(1),
+  title: z.string().min(1),
+  collection: z.string().min(1),
+  creator: z.string().optional(),
+  asset_id: z.string().min(1),
+  snapshot: z.object({
+    owner: z.string().optional(),
+    block_number: z.number().int().positive().optional(),
+    captured_at: z.string().min(1),
+  }),
+});
+
+const collectionReferenceBlockSchema = baseBlockSchema.extend({
+  type: z.literal("collection_reference"),
+  chain_id: z.number().int().positive(),
+  contract: z.string().min(1),
+  title: z.string().min(1),
+  summary: z.string().min(1),
+  asset_id: z.string().min(1),
+  knowledge_packet: z
+    .object({
+      id: z.string().min(1),
+      version: z.string().min(1),
+      hash: hashSchema,
+    })
+    .optional(),
+});
+
+const transactionReferenceBlockSchema = baseBlockSchema.extend({
+  type: z.literal("transaction_reference"),
+  chain_id: z.number().int().positive(),
+  hash: z.string().min(1),
+  block_number: z.number().int().positive(),
+  timestamp: z.string().min(1),
+  summary: z.string().min(1),
+  from: z.string().min(1),
+  to: z.string().min(1),
+  value_eth: z.string().min(1),
+  actions: z.array(z.string().min(1)).min(1),
+});
+
+const walletGalleryBlockSchema = baseBlockSchema.extend({
+  type: z.literal("generated_wallet_gallery"),
+  title: z.string().min(1),
+  wallets: z.array(z.string().min(1)).min(1),
+  snapshot: z.object({
+    captured_at: z.string().min(1),
+    block_number: z.number().int().positive().optional(),
+  }),
+  stats: z
+    .array(
+      z.object({
+        label: z.string().min(1),
+        value: z.string().min(1),
+      })
+    )
+    .min(1),
+  collections: z
+    .array(
+      z.object({
+        title: z.string().min(1),
+        count: z.number().int().nonnegative(),
+        asset_id: z.string().min(1),
+        href: z.string().optional(),
+      })
+    )
+    .min(1),
+});
+
+const unknownBlockSchema = baseBlockSchema.extend({
+  type: z.literal("unknown"),
+  data: jsonSchema,
+});
+
+const blockSchema = z.discriminatedUnion("type", [
+  headingBlockSchema,
+  richTextBlockSchema,
+  imageBlockSchema,
+  galleryBlockSchema,
+  quoteBlockSchema,
+  calloutBlockSchema,
+  buttonLinkBlockSchema,
+  nftReferenceBlockSchema,
+  collectionReferenceBlockSchema,
+  transactionReferenceBlockSchema,
+  walletGalleryBlockSchema,
+  unknownBlockSchema,
+]);
+
+export const cmsPayloadSchema = z.object({
+  schema: z.literal(CMS_PAYLOAD_SCHEMA),
+  site: z.object({
+    id: z.string().min(1),
+    slug: z.string().min(1),
+    title: z.string().min(1),
+    description: z.string().min(1),
+    owner_profile: profileRefSchema,
+    theme: z.object({
+      mode: z.enum(["light", "dark", "system"]),
+      accent_color: z.string().min(1),
+    }),
+  }),
+  page: z.object({
+    id: z.string().min(1),
+    title: z.string().min(1),
+    description: z.string().min(1),
+    slug_path: z.string(),
+    static_export_path: z.string().min(1),
+    canonical_url: z.string().min(1),
+    page_type: z.enum([
+      "page",
+      "post",
+      "gallery",
+      "collection",
+      "nft_detail",
+      "card_detail",
+      "room",
+    ]),
+    social: z.object({
+      title: z.string().min(1),
+      description: z.string().min(1),
+      canonical_url: z.string().min(1),
+      open_graph_image: socialImageSchema,
+      square_image: socialImageSchema.optional(),
+    }),
+    created_at: z.string().min(1),
+    updated_at: z.string().min(1),
+  }),
+  assets: z.array(assetSchema),
+  blocks: z.array(blockSchema).min(1),
+  provenance: z.object({
+    source: z.enum(["manual", "wallet_gallery", "import", "fixture"]),
+    builder_version: z.string().min(1),
+    source_snapshot_hash: hashSchema.optional(),
+    notes: z.array(z.string().min(1)).optional(),
+  }),
+});
+
+export const cmsPackageSchema = z.object({
+  schema: z.literal(CMS_PACKAGE_SCHEMA),
+  payload_hash: hashSchema,
+  package_hash: hashSchema,
+  payload: cmsPayloadSchema,
+  signature: z.object({
+    signature_type: z.enum(["eip191", "eip712", "fixture"]),
+    signing_wallet: z.string().min(1),
+    signed_at: z.string().min(1),
+    signature: z.string().min(1),
+  }),
+  storage: z.array(
+    z.object({
+      provider: z.enum(["ipfs", "arweave", "s3", "fixture"]),
+      uri: z.string().min(1),
+      content_hash: hashSchema.optional(),
+      pinned: z.boolean().optional(),
+    })
+  ),
+});

--- a/lib/cms/studio-api.ts
+++ b/lib/cms/studio-api.ts
@@ -1,0 +1,97 @@
+import type { CmsPublishedPackage } from "@/lib/cms/types";
+import { commonApiFetch, commonApiPost } from "@/services/api/common-api";
+
+export type CmsApiSite = {
+  readonly id: string;
+  readonly slug: string;
+  readonly title: string;
+  readonly description?: string | null | undefined;
+  readonly primary_package_hash?: string | null | undefined;
+  readonly primary_static_path?: string | null | undefined;
+  readonly created_at: string;
+  readonly updated_at: string;
+};
+
+export type CmsApiPublishedSite = {
+  readonly site: CmsApiSite;
+  readonly published_package: unknown;
+};
+
+type CmsCreateSiteRequest = {
+  readonly slug: string;
+  readonly title: string;
+  readonly description?: string | undefined;
+};
+
+type CmsPublishPackageRequest = {
+  readonly package_hash: string;
+  readonly payload_hash: string;
+  readonly schema: string;
+  readonly title: string;
+  readonly description?: string | undefined;
+  readonly static_path: string;
+  readonly canonical_url: string;
+  readonly package_json: CmsPublishedPackage;
+  readonly storage: CmsPublishedPackage["storage"];
+  readonly signature: CmsPublishedPackage["signature"];
+  readonly set_primary: boolean;
+};
+
+export function getCmsStudioErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return "Something went wrong.";
+}
+
+export async function getOrCreateCmsSite({
+  title,
+  description,
+}: {
+  readonly title: string;
+  readonly description: string;
+}): Promise<CmsApiSite> {
+  const sites = await commonApiFetch<CmsApiSite[]>({
+    endpoint: "cms/my/sites",
+  });
+  const existingHomeSite = sites.find((site) => site.slug === "home");
+  if (existingHomeSite) {
+    return existingHomeSite;
+  }
+  return await commonApiPost<CmsCreateSiteRequest, CmsApiSite>({
+    endpoint: "cms/sites",
+    body: {
+      slug: "home",
+      title,
+      description,
+    },
+  });
+}
+
+export async function publishCmsPackage({
+  siteId,
+  cmsPackage,
+}: {
+  readonly siteId: string;
+  readonly cmsPackage: CmsPublishedPackage;
+}): Promise<CmsApiPublishedSite> {
+  return await commonApiPost<CmsPublishPackageRequest, CmsApiPublishedSite>({
+    endpoint: `cms/sites/${siteId}/published-packages`,
+    body: {
+      package_hash: cmsPackage.package_hash,
+      payload_hash: cmsPackage.payload_hash,
+      schema: cmsPackage.schema,
+      title: cmsPackage.payload.page.title,
+      description: cmsPackage.payload.page.description,
+      static_path: cmsPackage.payload.page.static_export_path,
+      canonical_url: cmsPackage.payload.page.canonical_url,
+      package_json: cmsPackage,
+      storage: cmsPackage.storage,
+      signature: cmsPackage.signature,
+      set_primary: true,
+    },
+  });
+}

--- a/lib/cms/types.ts
+++ b/lib/cms/types.ts
@@ -1,0 +1,255 @@
+export const CMS_PACKAGE_SCHEMA = "6529.cms.package.v1" as const;
+export const CMS_PAYLOAD_SCHEMA = "6529.cms.payload.v1" as const;
+
+export type CmsJsonPrimitive = string | number | boolean | null;
+export type CmsJsonValue =
+  | CmsJsonPrimitive
+  | readonly CmsJsonValue[]
+  | { readonly [key: string]: CmsJsonValue };
+
+export type CmsHash = `sha256:${string}`;
+
+export type CmsProfileRef = {
+  readonly id: string;
+  readonly handle: string;
+  readonly display_name: string;
+  readonly path: string;
+};
+
+export type CmsTheme = {
+  readonly mode: "light" | "dark" | "system";
+  readonly accent_color: string;
+};
+
+export type CmsSite = {
+  readonly id: string;
+  readonly slug: string;
+  readonly title: string;
+  readonly description: string;
+  readonly owner_profile: CmsProfileRef;
+  readonly theme: CmsTheme;
+};
+
+export type CmsSocialImage = {
+  readonly url: string;
+  readonly width: number;
+  readonly height: number;
+  readonly alt: string;
+  readonly content_hash?: CmsHash;
+};
+
+export type CmsPageSocial = {
+  readonly title: string;
+  readonly description: string;
+  readonly canonical_url: string;
+  readonly open_graph_image: CmsSocialImage;
+  readonly square_image?: CmsSocialImage;
+};
+
+export type CmsPage = {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly slug_path: string;
+  readonly static_export_path: string;
+  readonly canonical_url: string;
+  readonly page_type:
+    | "page"
+    | "post"
+    | "gallery"
+    | "collection"
+    | "nft_detail"
+    | "card_detail"
+    | "room";
+  readonly social: CmsPageSocial;
+  readonly created_at: string;
+  readonly updated_at: string;
+};
+
+export type CmsAsset = {
+  readonly id: string;
+  readonly kind: "image" | "video" | "model" | "document" | "social_image";
+  readonly src: string;
+  readonly alt: string;
+  readonly title?: string;
+  readonly caption?: string;
+  readonly width?: number;
+  readonly height?: number;
+  readonly mime_type?: string;
+  readonly content_hash?: CmsHash;
+};
+
+export type CmsBaseBlock = {
+  readonly id: string;
+  readonly type: string;
+};
+
+export type CmsHeadingBlock = CmsBaseBlock & {
+  readonly type: "heading";
+  readonly level: 1 | 2 | 3;
+  readonly text: string;
+  readonly eyebrow?: string;
+};
+
+export type CmsRichTextBlock = CmsBaseBlock & {
+  readonly type: "rich_text";
+  readonly paragraphs: readonly string[];
+};
+
+export type CmsImageBlock = CmsBaseBlock & {
+  readonly type: "image";
+  readonly asset_id: string;
+  readonly caption?: string;
+};
+
+export type CmsGalleryBlock = CmsBaseBlock & {
+  readonly type: "gallery";
+  readonly title?: string;
+  readonly items: readonly {
+    readonly asset_id: string;
+    readonly title?: string;
+    readonly caption?: string;
+    readonly href?: string;
+  }[];
+};
+
+export type CmsQuoteBlock = CmsBaseBlock & {
+  readonly type: "quote";
+  readonly quote: string;
+  readonly attribution?: string;
+};
+
+export type CmsCalloutBlock = CmsBaseBlock & {
+  readonly type: "callout";
+  readonly tone: "note" | "evidence" | "warning";
+  readonly title: string;
+  readonly body: string;
+};
+
+export type CmsButtonLinkBlock = CmsBaseBlock & {
+  readonly type: "button_link";
+  readonly label: string;
+  readonly href: string;
+};
+
+export type CmsNftReferenceBlock = CmsBaseBlock & {
+  readonly type: "nft_reference";
+  readonly chain_id: number;
+  readonly contract: string;
+  readonly token_id: string;
+  readonly title: string;
+  readonly collection: string;
+  readonly creator?: string;
+  readonly asset_id: string;
+  readonly snapshot: {
+    readonly owner?: string;
+    readonly block_number?: number;
+    readonly captured_at: string;
+  };
+};
+
+export type CmsCollectionReferenceBlock = CmsBaseBlock & {
+  readonly type: "collection_reference";
+  readonly chain_id: number;
+  readonly contract: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly asset_id: string;
+  readonly knowledge_packet?: {
+    readonly id: string;
+    readonly version: string;
+    readonly hash: CmsHash;
+  };
+};
+
+export type CmsTransactionReferenceBlock = CmsBaseBlock & {
+  readonly type: "transaction_reference";
+  readonly chain_id: number;
+  readonly hash: string;
+  readonly block_number: number;
+  readonly timestamp: string;
+  readonly summary: string;
+  readonly from: string;
+  readonly to: string;
+  readonly value_eth: string;
+  readonly actions: readonly string[];
+};
+
+export type CmsWalletGalleryBlock = CmsBaseBlock & {
+  readonly type: "generated_wallet_gallery";
+  readonly title: string;
+  readonly wallets: readonly string[];
+  readonly snapshot: {
+    readonly captured_at: string;
+    readonly block_number?: number;
+  };
+  readonly stats: readonly {
+    readonly label: string;
+    readonly value: string;
+  }[];
+  readonly collections: readonly {
+    readonly title: string;
+    readonly count: number;
+    readonly asset_id: string;
+    readonly href?: string;
+  }[];
+};
+
+export type CmsKnownBlock =
+  | CmsHeadingBlock
+  | CmsRichTextBlock
+  | CmsImageBlock
+  | CmsGalleryBlock
+  | CmsQuoteBlock
+  | CmsCalloutBlock
+  | CmsButtonLinkBlock
+  | CmsNftReferenceBlock
+  | CmsCollectionReferenceBlock
+  | CmsTransactionReferenceBlock
+  | CmsWalletGalleryBlock;
+
+export type CmsUnknownBlock = CmsBaseBlock & {
+  readonly type: "unknown";
+  readonly data: CmsJsonValue;
+};
+
+export type CmsBlock = CmsKnownBlock | CmsUnknownBlock;
+
+export type CmsProvenance = {
+  readonly source: "manual" | "wallet_gallery" | "import" | "fixture";
+  readonly builder_version: string;
+  readonly source_snapshot_hash?: CmsHash;
+  readonly notes?: readonly string[];
+};
+
+export type CmsPayload = {
+  readonly schema: typeof CMS_PAYLOAD_SCHEMA;
+  readonly site: CmsSite;
+  readonly page: CmsPage;
+  readonly assets: readonly CmsAsset[];
+  readonly blocks: readonly CmsBlock[];
+  readonly provenance: CmsProvenance;
+};
+
+export type CmsSignatureEnvelope = {
+  readonly signature_type: "eip191" | "eip712" | "fixture";
+  readonly signing_wallet: string;
+  readonly signed_at: string;
+  readonly signature: string;
+};
+
+export type CmsStorageLocation = {
+  readonly provider: "ipfs" | "arweave" | "s3" | "fixture";
+  readonly uri: string;
+  readonly content_hash?: CmsHash;
+  readonly pinned?: boolean;
+};
+
+export type CmsPublishedPackage = {
+  readonly schema: typeof CMS_PACKAGE_SCHEMA;
+  readonly payload_hash: CmsHash;
+  readonly package_hash: CmsHash;
+  readonly payload: CmsPayload;
+  readonly signature: CmsSignatureEnvelope;
+  readonly storage: readonly CmsStorageLocation[];
+};

--- a/ops/workstreams/profile-native-cms/README.md
+++ b/ops/workstreams/profile-native-cms/README.md
@@ -1,0 +1,39 @@
+# Profile Native CMS Workstream
+
+## Charter
+
+Build a profile-native CMS for 6529 that launches on the current FE/BE stack while publishing decentralized-shaped, signed, content-addressed packages from day one.
+
+## Reload Order
+
+1. `ops/workstreams/profile-native-cms/active-context.md`
+2. `ops/workstreams/profile-native-cms/run-log.md`
+3. `D:\repos\6529mono\white-paper\research\2026-06-15-6529-decentralization\2026-06-16-profile-native-cms-build-spec.md`
+4. Frontend branch: `D:\repos\6529seize-frontend-profile-native-cms`
+5. Backend branch: `D:\repos\6529seize-backend-profile-native-cms`
+
+## Owned Paths
+
+- Frontend CMS package contract, fixture renderer, public CMS routes, CMS editor/wizard, profile website CTA, tests, docs.
+- Backend CMS OpenAPI, generated models, entities, routes, repositories, services, tests, storage/publish skeletons.
+- Workstream docs under this folder.
+
+## Forbidden Paths
+
+- Do not touch unrelated dirty work in `D:\repos\6529seize-frontend`.
+- Do not touch unrelated dirty work in `D:\repos\6529seize-backend`.
+- Do not migrate legacy museum/capital routes by hardcoding new special cases.
+- Do not expose arbitrary raw HTML or JavaScript authoring.
+
+## Evidence Standard
+
+- Diffs must be scoped and reviewable.
+- Public renderer must render from package fixtures without authoring API state.
+- UI changes need browser verification and screenshots.
+- Backend API changes need OpenAPI generation where applicable and focused tests.
+- PRs need bot feedback review and iteration before handoff.
+
+## Escalation Triggers
+
+- Production secrets, destructive operations, merge/deploy actions, or irreversible product decisions.
+- If signing, wallet authorization, or IPFS provider choices block a shippable vertical slice, record a narrow MVP assumption instead of stalling.

--- a/ops/workstreams/profile-native-cms/active-context.md
+++ b/ops/workstreams/profile-native-cms/active-context.md
@@ -1,0 +1,70 @@
+# Active Context
+
+## Goal
+
+Build and PR a superb profile-native CMS roadmap implementation across 6529seize-frontend and 6529seize-backend, aligned with decentralization goals and excellent crypto/consumer UX.
+
+## Branches
+
+- Frontend: `D:\repos\6529seize-frontend-profile-native-cms`, branch `codex/profile-native-cms`
+- Backend: `D:\repos\6529seize-backend-profile-native-cms`, branch `codex/profile-native-cms`
+
+## Constraints
+
+- Current primary FE/BE worktrees are dirty with unrelated user/thread work. Use only the clean task worktrees above.
+- Use `seize` / `seize-local-dev` for frontend package/local commands in this Windows Codex environment.
+- Backend AGENTS says do not commit unless explicitly asked, but user requested PRs for this workstream, so commits/PRs are authorized when ready.
+- Backend API types must come from OpenAPI and generated models.
+- Next.js docs index has been loaded; fetch specific docs before App Router routing/metadata/static behavior changes.
+- Do not read or expose secret values. Anthropic key is available in Windows Credential Manager as `ANTHROPIC_API_KEY` if a review script needs it.
+
+## Current Strategy
+
+Permanent substrate is underway:
+
+1. FE CMS package contract, canonicalization, hash, validation, fixtures - built.
+2. FE public renderer from fixtures, including provenance and crypto/NFT blocks - built.
+3. FE profile website CTA and `/{profile}/index.html` public route - built with fixture-backed resolver boundary.
+4. Backend entities/OpenAPI/CRUD skeleton for sites/packages/publish pointer - built.
+5. Profile CMS Studio authoring surface for deterministic wallet-gallery package generation - built as first-pass UX.
+
+## Current FE Slice
+
+- Package schema/helpers: `lib/cms/*`.
+- Fixture packages: gallery and transaction explainer in `lib/cms/fixtures.ts`.
+- Public renderer: `components/cms/public/CmsPageRenderer.tsx`.
+- Fixture routes: `/cms-fixtures/gallery`, `/cms-fixtures/transaction`.
+- Profile CMS route shape: `/{profile}/index.html`, currently fixture-backed for `/punk6529/index.html`.
+- Profile CTA: `Website` button appears on `/punk6529` when a primary CMS package exists.
+- Resolver is backend-first via `/api/cms/profile/{identity}/primary`, validates package hashes, and falls back to fixtures for local/dev.
+- Authoring surface: `/tools/profile-cms` lets a profile draft a wallet gallery package, pick editorial/grid/3D-room style intent, choose IPFS/Arweave/both storage intent, copy deterministic package JSON, export a package file, and publish through existing wallet auth to the backend CMS primary pointer.
+- Dev verification blocker fixed: scoped `components/waves/drop/VoteButton.module.scss` pure selector so webpack dev can compile.
+
+## Current BE Slice
+
+- Entities: `cms_sites` and `cms_published_packages` via `src/entities/ICmsSite.ts`.
+- Public endpoints:
+  - `GET /api/cms/profile/{identity}/primary`
+  - `GET /api/cms/packages/{package_hash}`
+- Authenticated endpoints:
+  - `GET /api/cms/my/sites`
+  - `POST /api/cms/sites`
+  - `POST /api/cms/sites/{site_id}/published-packages`
+- Published package rows are immutable by `package_hash`; site rows carry the mutable primary pointer.
+- OpenAPI regenerated; new generated models are `ApiCms*`.
+
+## Open Decisions
+
+- MVP signing mechanism: existing wallet signature path versus server-side placeholder publish intent until wallet UX is wired.
+- IPFS provider for first live publish adapter.
+- The Studio publish action currently sends a placeholder fixture-style signature envelope; production signing still needs an EIP-191/EIP-712 package signature UX.
+- Initial collection knowledge packet fixtures.
+- Whether CMS public routes should bypass global app providers that trigger unrelated local wave/emoji fetch noise.
+
+## Next Actions
+
+- Re-run final FE changed-file typecheck/tests after Studio polish.
+- Re-run backend tsc/eslint/focused tests.
+- Decide whether to add direct authenticated publish from Studio before PR, based on existing FE auth/API client patterns.
+- Run second-review screenshot pass once screenshots are stable.
+- Prepare FE/BE commits, push branches, open PRs, and iterate on review bot feedback.

--- a/ops/workstreams/profile-native-cms/run-log.md
+++ b/ops/workstreams/profile-native-cms/run-log.md
@@ -1,0 +1,109 @@
+# Run Log
+
+## 2026-06-16
+
+- User requested autonomous-manager mode for a long-running FE/BE CMS build and PR workstream.
+- Read `ops/skills/6529-autonomous-manager/SKILL.md`.
+- Loaded root frontend `AGENTS.md`.
+- Initialized Next.js DevTools MCP and loaded the Next.js docs index.
+- Confirmed existing primary frontend and backend worktrees are dirty with unrelated changes.
+- Created clean worktrees:
+  - `D:\repos\6529seize-frontend-profile-native-cms`
+  - `D:\repos\6529seize-backend-profile-native-cms`
+- Loaded profile-native CMS build spec from `D:\repos\6529mono`.
+- Built the first frontend CMS substrate:
+  - deterministic CMS package canonicalization/hash helpers,
+  - Zod package validation,
+  - gallery and transaction CMS fixture packages,
+  - public package renderer with provenance/package evidence,
+  - `/cms-fixtures/[fixture]` review route,
+  - `/{profile}/index.html` profile website route,
+  - fixture-backed primary CMS site resolver,
+  - `Website` CTA on the profile header when a primary CMS site exists.
+- Fixed an existing CSS Modules purity issue in `components/waves/drop/VoteButton.module.scss` that blocked webpack dev verification.
+- Local FE checks passed:
+  - `seize run lint:diff`
+  - `seize run typecheck:changed`
+  - `seize run test:no-coverage -- __tests__/lib/cms/canonicalize.test.ts __tests__/lib/cms/profile-sites.test.ts __tests__/components/cms/CmsPageRenderer.test.tsx`
+  - `seize run format:uncommitted`
+  - `codex-diff-check`
+- Browser/E2E smoke:
+  - dev server on `http://localhost:3120` with webpack,
+  - `/punk6529/index.html` desktop/mobile render one H1, visible package hash/path, no broken local CMS images,
+  - `/cms-fixtures/transaction` renders one H1 and a transaction explainer block,
+  - `/punk6529` exposes `Website` link to `/punk6529/index.html`.
+- Screenshot/report artifacts are in `C:\Users\Administrator\AppData\Local\Temp\profile-native-cms-screens`.
+- Known local-dev noise:
+  - global app providers emit unrelated wave API 500s and emoji CloudFront 403s,
+  - MetaMask optional dependency warning appears in dev,
+  - delayed cookie banner can cover screenshots unless accepted before capture,
+  - `seize-local-dev start-frontend` sets `PORT_SEARCH_LIMIT=0`, but env schema requires positive values; manual webpack dev launch works.
+- Added backend CMS storage/API substrate:
+  - `cms_sites` and `cms_published_packages` TypeORM entities,
+  - OpenAPI CMS schemas/routes and regenerated `ApiCms*` models,
+  - `cmsDb`, `CmsApiService`, and `cms.routes`,
+  - API app mount at `/api/cms`,
+  - service tests for site creation and package publish ownership.
+- Backend checks passed:
+  - `.\node_modules\.bin\tsc.cmd -p tsconfig.json --noEmit`
+  - local eslint invocation equivalent to `npm run lint`
+  - `jest src/api-serverless/src/cms/cms-api-service.test.ts --runInBand`
+- Wired FE resolver to backend-first CMS API lookup with schema/hash validation and fixture fallback.
+- FE checks after API resolver passed:
+  - `seize run lint:diff`
+  - `seize run typecheck:changed`
+  - `seize run test:no-coverage -- __tests__/lib/cms/canonicalize.test.ts __tests__/lib/cms/profile-sites.test.ts __tests__/components/cms/CmsPageRenderer.test.tsx`
+- Added first-pass Profile CMS Studio at `/tools/profile-cms`:
+  - profile handle/title/description/wallet inputs,
+  - gallery style control for editorial, market grid, and 3D room intent,
+  - IPFS/Arweave/both storage intent,
+  - deterministic package hash/payload hash/route evidence,
+  - copy JSON, export package JSON, and authenticated publish actions.
+- Added Studio publish flow:
+  - uses existing `useAuth().requestAuth()`,
+  - reuses or creates the profile `home` CMS site through `/api/cms/my/sites` and `/api/cms/sites`,
+  - posts the generated package to `/api/cms/sites/{site_id}/published-packages` as the primary package.
+- Studio checks passed:
+  - `seize run format:uncommitted`
+  - `codex-diff-check`
+  - `seize run lint:diff`
+  - `seize run typecheck:changed`
+- Browser/E2E Studio pass:
+  - `/tools/profile-cms` desktop/mobile render one H1, no horizontal overflow, visible package hash, no broken preview images, no page errors,
+  - gallery style and storage controls are interactive,
+  - Export downloads `punk6529-cms-package.json`,
+  - Publish button is present and fits desktop/mobile layouts,
+  - `/punk6529/index.html` regression still renders one H1, package hash/path, and no broken local CMS images.
+- Refreshed screenshots:
+  - `C:\Users\Administrator\AppData\Local\Temp\profile-native-cms-screens\studio-desktop-polished.png`
+  - `C:\Users\Administrator\AppData\Local\Temp\profile-native-cms-screens\studio-mobile-polished.png`
+  - `C:\Users\Administrator\AppData\Local\Temp\profile-native-cms-screens\studio-desktop-publish.png`
+  - `C:\Users\Administrator\AppData\Local\Temp\profile-native-cms-screens\studio-mobile-publish.png`
+  - `C:\Users\Administrator\AppData\Local\Temp\profile-native-cms-screens\profile-site-regression-clean.png`
+- Backend final verification pass:
+  - `npx prettier --check src/constants/db-tables.ts src/entities/entities.ts src/entities/ICmsSite.ts src/api-serverless/src/app.ts "src/api-serverless/src/cms/*.ts" src/api-serverless/openapi.yaml`
+  - `.\node_modules\.bin\tsc.cmd -p tsconfig.json --noEmit`
+  - `$env:NODE_OPTIONS='--max-old-space-size=8192'; .\node_modules\.bin\eslint.cmd "src/**/*.ts" --max-warnings=0`
+  - `.\node_modules\.bin\jest.cmd src/api-serverless/src/cms/cms-api-service.test.ts --runInBand`
+- Backend `npm run check:changed` is blocked in this Windows shell because `scripts/check-changed.mjs` calls `spawnSync npm`, which cannot resolve `npm` instead of `npm.cmd`; direct equivalent checks above passed.
+- FE final verification after publish type correction:
+  - `codex-diff-check`
+  - `seize run lint:diff`
+  - `seize run typecheck:changed`
+- Ran second-review pass with Anthropic `claude-opus-4-8` using the Studio desktop/mobile and public site screenshots.
+- Reviewer findings acted on:
+  - added explicit selected state text in the Studio gallery style control,
+  - added per-hash copy buttons and graceful clipboard-denied handling,
+  - added storage tradeoff copy,
+  - added publish confirmation modal with backend-pointer destination and draft signature/storage caveat,
+  - separated Publish as the primary action,
+  - added draft/fixture evidence banner to public package-rendered pages.
+- Post-review FE verification passed:
+  - `seize run format:uncommitted`
+  - `codex-diff-check`
+  - `seize run lint:diff`
+  - `seize run typecheck:changed`
+  - `seize run test:no-coverage -- __tests__/lib/cms/canonicalize.test.ts __tests__/lib/cms/profile-sites.test.ts __tests__/components/cms/CmsPageRenderer.test.tsx --runInBand`
+- Post-review browser evidence:
+  - `C:\Users\Administrator\AppData\Local\Temp\profile-native-cms-screens\studio-publish-confirm-final.png`
+  - `C:\Users\Administrator\AppData\Local\Temp\profile-native-cms-screens\profile-site-draft-banner-final.png`


### PR DESCRIPTION
## Summary

Adds the first profile-native CMS vertical slice for 6529:

- deterministic CMS package contract, canonical JSON hashing, validation, fixtures, and media resolution,
- public package renderer with wallet galleries, NFT/collection references, transaction explainers, provenance, and draft evidence banners,
- `/{profile}/index.html` CMS website route while keeping `/{profile}` as the normal profile page,
- profile header `Website` CTA when a primary CMS site exists,
- `/tools/profile-cms` Studio for wallet-gallery package generation, style intent, IPFS/Arweave storage intent, JSON copy/export, and authenticated publish through the backend CMS pointer,
- `/cms-fixtures/gallery` and `/cms-fixtures/transaction` review routes,
- renderer hardening for safe package URLs/media, fixture hash assertions, one page-owned H1, duplicate package text/fact/action rendering, and no privileged hardcoded profile in generated CMS paths,
- scoped CSS Modules purity fix in `VoteButton.module.scss` needed for webpack dev verification,
- workstream notes under `ops/workstreams/profile-native-cms/`.

## Decentralization posture

Launches on the current hosted app while keeping the artifact shaped for decentralization from day one: deterministic payloads, stable hashes, explicit routes/static paths, storage receipts, signature envelope, and portable rendering. The hosted app can accelerate the content, but the package is the intended source of truth.

Known MVP caveat: Studio packages currently carry pending storage receipts and a draft/fixture signature envelope. The UI states this before publish and public fixture-rendered pages show a draft evidence banner. Final production publish still needs wallet package-signature UX and real IPFS/Arweave receipt adapters.

## Verification

- `seize run format:uncommitted`
- `codex-diff-check`
- `seize run lint:diff`
- `seize run typecheck:changed`
- `seize run test:no-coverage -- __tests__/lib/cms/canonicalize.test.ts __tests__/lib/cms/profile-sites.test.ts __tests__/lib/cms/media.test.ts __tests__/components/cms/CmsPageRenderer.test.tsx --runInBand`
- Playwright smoke on `http://localhost:3120` for `/punk6529/index.html`, `/cms-fixtures/gallery`, and `/tools/profile-cms`: page response OK, no page errors, no broken images, no horizontal overflow, expected H1 counts.
- Earlier Next.js MCP/browser smoke on `http://localhost:3120` for Studio, publish confirmation, export download, `/punk6529/index.html`, and profile Website CTA.

## Second review

Ran Anthropic `claude-opus-4-8` screenshot review and acted on selected-state, hash-copy, storage-copy, publish-confirmation, primary CTA, and draft-evidence feedback.