### PR TITLE
Narrow group rating matters

### DIFF
--- a/components/groups/page/list/card/GroupCard.tsx
+++ b/components/groups/page/list/card/GroupCard.tsx
@@ -20,6 +20,8 @@ export enum CreditDirection {
   SUBTRACT = "SUBTRACT",
 }
 
+export type GroupCardRateMatter = ApiRateMatter.Rep | ApiRateMatter.Cic;
+
 export default function GroupCard({
   group,
   activeGroupIdVoteAll,

--- a/components/groups/page/list/card/GroupCardActionWrapper.tsx
+++ b/components/groups/page/list/card/GroupCardActionWrapper.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import GroupCardActionFooter from "./utils/GroupCardActionFooter";
 import { ApiRateMatter } from "@/generated/models/ApiRateMatter";
+import type { GroupCardRateMatter } from "./GroupCard";
 
 export default function GroupCardActionWrapper({
   loading,
@@ -20,13 +21,13 @@ export default function GroupCardActionWrapper({
   readonly addingRates: boolean;
   readonly membersCount: number | null;
   readonly doneMembersCount: number | null;
-  readonly matter: ApiRateMatter;
+  readonly matter: GroupCardRateMatter;
   readonly onSave: () => void;
   readonly onCancel: () => void;
 
   readonly children: React.ReactNode;
 }) {
-  const MATTER_LABEL: Record<ApiRateMatter, string> = {
+  const MATTER_LABEL: Record<GroupCardRateMatter, string> = {
     [ApiRateMatter.Rep]: "Rep",
     [ApiRateMatter.Cic]: "NIC",
   };

--- a/components/groups/page/list/card/utils/GroupCardActionStats.tsx
+++ b/components/groups/page/list/card/utils/GroupCardActionStats.tsx
@@ -12,16 +12,18 @@ import { commonApiFetch } from "@/services/api/common-api";
 import type { ApiAvailableRatingCredit } from "@/generated/models/ApiAvailableRatingCredit";
 import { assertUnreachable } from "@/helpers/AllowlistToolHelpers";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
+import type { GroupCardRateMatter } from "../GroupCard";
+
 export default function GroupCardActionStats({
   matter,
   membersCount,
   loadingMembersCount,
 }: {
-  readonly matter: ApiRateMatter;
+  readonly matter: GroupCardRateMatter;
   readonly membersCount: number | null;
   readonly loadingMembersCount: boolean;
 }) {
-  const MATTER_LABEL: Record<ApiRateMatter, string> = {
+  const MATTER_LABEL: Record<GroupCardRateMatter, string> = {
     [ApiRateMatter.Rep]: "Rep",
     [ApiRateMatter.Cic]: "Nic",
   };

--- a/components/groups/page/list/card/vote-all/GroupCardVoteAll.tsx
+++ b/components/groups/page/list/card/vote-all/GroupCardVoteAll.tsx
@@ -18,6 +18,7 @@ import { commonApiFetch, commonApiPost } from "@/services/api/common-api";
 
 import GroupCardActionWrapper from "../GroupCardActionWrapper";
 import { ApiRateMatter } from "@/generated/models/ApiRateMatter";
+import type { GroupCardRateMatter } from "../GroupCard";
 import GroupCardActionStats from "../utils/GroupCardActionStats";
 import GroupCardVoteAllInputs from "./GroupCardVoteAllInputs";
 import { ApiCommunityMembersSortOption } from "@/generated/models/ApiCommunityMembersSortOption";
@@ -29,11 +30,11 @@ export default function GroupCardVoteAll({
   group,
   onCancel,
 }: {
-  readonly matter: ApiRateMatter;
+  readonly matter: GroupCardRateMatter;
   readonly group?: ApiGroupFull | undefined;
   readonly onCancel: () => void;
 }) {
-  const SUCCESS_LABEL: Record<ApiRateMatter, string> = {
+  const SUCCESS_LABEL: Record<GroupCardRateMatter, string> = {
     [ApiRateMatter.Cic]: "NIC distributed.",
     [ApiRateMatter.Rep]: "Rep distributed.",
   };

--- a/components/groups/page/list/card/vote-all/GroupCardVoteAllInputs.tsx
+++ b/components/groups/page/list/card/vote-all/GroupCardVoteAllInputs.tsx
@@ -4,6 +4,7 @@ import RepCategorySearch, {
   RepCategorySearchSize,
 } from "@/components/utils/input/rep-category/RepCategorySearch";
 import type { CreditDirection } from "../GroupCard";
+import type { GroupCardRateMatter } from "../GroupCard";
 import GroupCardActionNumberInput from "../utils/GroupCardActionNumberInput";
 
 import type { JSX } from "react";
@@ -18,7 +19,7 @@ export default function GroupCardVoteAllInputs({
   setAmountToAdd,
   setCreditDirection,
 }: {
-  readonly matter: ApiRateMatter;
+  readonly matter: GroupCardRateMatter;
   readonly group: ApiGroupFull;
   readonly amountToAdd: number | null;
   readonly category: string | null;
@@ -27,7 +28,7 @@ export default function GroupCardVoteAllInputs({
   readonly setAmountToAdd: (amountToGive: number | null) => void;
   readonly setCreditDirection: (creditDirection: CreditDirection) => void;
 }) {
-  const components: Record<ApiRateMatter, JSX.Element> = {
+  const components: Record<GroupCardRateMatter, JSX.Element> = {
     [ApiRateMatter.Cic]: (
       <div className="tw-w-full xl:tw-max-w-[17.156rem]">
         <GroupCardActionNumberInput


### PR DESCRIPTION
## Summary
- narrow group vote-all components to identity REP/NIC matters
- keep WAVE_REP out of group bulk-rating UI after the generated ApiRateMatter enum expanded

## Verification
- `seize run typecheck:changed`
- `seize run lint:changed`

## Deploy note
- fixes the staging `next build` failure after Wave REP added `ApiRateMatter.WaveRep`