### PR TITLE
Fix anonymous scored wave discovery

### DIFF
--- a/__tests__/components/home/explore-waves/ExploreWavesSection.test.tsx
+++ b/__tests__/components/home/explore-waves/ExploreWavesSection.test.tsx
@@ -44,7 +44,7 @@ describe("ExploreWavesSection", () => {
     await waitFor(() => expect(fetchWavesV2PageMock).toHaveBeenCalled());
     expect(fetchWavesV2PageMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        excludeFollowed: false,
+        excludeFollowed: undefined,
       })
     );
   });

--- a/__tests__/components/home/explore-waves/ExploreWavesSection.test.tsx
+++ b/__tests__/components/home/explore-waves/ExploreWavesSection.test.tsx
@@ -1,0 +1,68 @@
+import { renderWithQueryClient } from "../../../utils/reactQuery";
+import { ExploreWavesSection } from "@/components/home/explore-waves/ExploreWavesSection";
+import { fetchWavesV2Page } from "@/services/api/waves-v2-api";
+import { waitFor } from "@testing-library/react";
+
+jest.mock("@/components/auth/Auth", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("@/components/home/explore-waves/ExploreWaveCard", () => ({
+  ExploreWaveCard: ({ wave }: { readonly wave: { readonly name: string } }) => (
+    <div>{wave.name}</div>
+  ),
+}));
+
+jest.mock("@/components/home/explore-waves/ExploreWaveCardSkeleton", () => ({
+  ExploreWaveCardSkeleton: () => <div>Loading wave</div>,
+}));
+
+jest.mock("@/services/api/waves-v2-api", () => ({
+  fetchWavesV2Page: jest.fn(),
+}));
+
+const useAuthMock = require("@/components/auth/Auth").useAuth as jest.Mock;
+const fetchWavesV2PageMock = fetchWavesV2Page as jest.Mock;
+
+describe("ExploreWavesSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchWavesV2PageMock.mockResolvedValue({
+      waves: [{ id: "wave-1", name: "Scored wave" }],
+      page: 1,
+      next: null,
+    });
+  });
+
+  it("does not request followed-wave exclusion for anonymous discovery", async () => {
+    useAuthMock.mockReturnValue({ connectedProfile: null });
+
+    renderWithQueryClient(
+      <ExploreWavesSection excludeFollowed showEmptyState />
+    );
+
+    await waitFor(() => expect(fetchWavesV2PageMock).toHaveBeenCalled());
+    expect(fetchWavesV2PageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        excludeFollowed: false,
+      })
+    );
+  });
+
+  it("requests followed-wave exclusion after a profile is connected", async () => {
+    useAuthMock.mockReturnValue({
+      connectedProfile: { id: "profile-1", handle: "alice" },
+    });
+
+    renderWithQueryClient(
+      <ExploreWavesSection excludeFollowed showEmptyState />
+    );
+
+    await waitFor(() => expect(fetchWavesV2PageMock).toHaveBeenCalled());
+    expect(fetchWavesV2PageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        excludeFollowed: true,
+      })
+    );
+  });
+});

--- a/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
+++ b/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
@@ -27,6 +27,7 @@ import { MyStreamWaveTab } from "@/types/waves.types";
 import WaveDropsSearchModal from "@/components/waves/drops/search/WaveDropsSearchModal";
 import WaveDescriptionPopover from "@/components/waves/header/WaveDescriptionPopover";
 import WavePicture from "../../../waves/WavePicture";
+import { WaveTrustSignals } from "@/components/waves/WaveTrustSignals";
 import MyStreamActionTooltip from "../MyStreamActionTooltip";
 import { useSidebarState } from "../../../../hooks/useSidebarState";
 
@@ -287,50 +288,64 @@ export default function MyStreamWaveTabsHeader({
                   contributors={wavePictureContributors}
                 />
               </div>
-              {showDescriptionPreview ? (
-                <WaveDescriptionPopover
-                  wave={wave}
-                  align="left"
-                  ariaLabel="Show wave description"
-                  triggerClassName={`tw-group tw-flex tw-min-w-0 tw-cursor-pointer tw-border-0 tw-bg-transparent tw-p-0 tw-text-left ${
-                isCompact ? "tw-items-center" : "tw-flex-col tw-items-start"
-              }`}
-            >
-              {isCompact ? (
-                <h1 className="tw-mb-0 tw-flex tw-min-w-0 tw-items-center tw-gap-x-1.5 tw-text-sm tw-font-semibold tw-tracking-tight tw-text-white/95">
-                  <span className="tw-min-w-0 tw-truncate">{wave.name}</span>
-                  <ChevronDownIcon
-                    aria-hidden="true"
-                    className="tw-h-4 tw-w-4 tw-flex-shrink-0 tw-text-iron-300 tw-transition-colors group-hover:tw-text-white"
-                      />
-                </h1>
-              ) : (
-                <>
-                      <h1 className="tw-mb-0 tw-w-full tw-truncate tw-text-sm tw-font-semibold tw-tracking-tight tw-text-white/95 lg:tw-text-xl">
-                        {wave.name}
-                      </h1>
-                      <span className="tw-mt-0.5 tw-flex tw-w-full tw-min-w-0 tw-max-w-xl tw-items-center tw-gap-x-1.5">
-                        <span
-                          ref={descriptionPreviewRef}
-                          className="tw-min-w-0 tw-flex-1 tw-truncate tw-text-xs tw-font-normal tw-text-iron-400 tw-transition-colors tw-duration-300 group-hover:tw-text-iron-300"
-                        >
-                          {previewText}
+              <div className="tw-flex tw-min-w-0 tw-flex-col">
+                {showDescriptionPreview ? (
+                  <WaveDescriptionPopover
+                    wave={wave}
+                    align="left"
+                    ariaLabel="Show wave description"
+                    triggerClassName={`tw-group tw-flex tw-min-w-0 tw-cursor-pointer tw-border-0 tw-bg-transparent tw-p-0 tw-text-left ${
+                      isCompact
+                        ? "tw-items-center"
+                        : "tw-flex-col tw-items-start"
+                    }`}
+                  >
+                    {isCompact ? (
+                      <h1 className="tw-mb-0 tw-flex tw-min-w-0 tw-items-center tw-gap-x-1.5 tw-text-sm tw-font-semibold tw-tracking-tight tw-text-white/95">
+                        <span className="tw-min-w-0 tw-truncate">
+                          {wave.name}
                         </span>
-                        {isDescriptionPreviewTruncated && (
-                          <ChevronDownIcon
-                            aria-hidden="true"
-                            className="tw-h-4 tw-w-4 tw-flex-shrink-0 tw-text-iron-300 tw-transition-colors group-hover:tw-text-white"
-                          />
-                        )}
-                      </span>
-                    </>
-              )}
-            </WaveDescriptionPopover>
-              ) : (
-                <h1 className="tw-mb-0 tw-truncate tw-text-sm tw-font-semibold tw-tracking-tight tw-text-white/95 lg:tw-text-xl">
-                  {wave.name}
-                </h1>
-              )}
+                        <ChevronDownIcon
+                          aria-hidden="true"
+                          className="tw-h-4 tw-w-4 tw-flex-shrink-0 tw-text-iron-300 tw-transition-colors group-hover:tw-text-white"
+                        />
+                      </h1>
+                    ) : (
+                      <>
+                        <h1 className="tw-mb-0 tw-w-full tw-truncate tw-text-sm tw-font-semibold tw-tracking-tight tw-text-white/95 lg:tw-text-xl">
+                          {wave.name}
+                        </h1>
+                        <span className="tw-mt-0.5 tw-flex tw-w-full tw-min-w-0 tw-max-w-xl tw-items-center tw-gap-x-1.5">
+                          <span
+                            ref={descriptionPreviewRef}
+                            className="tw-min-w-0 tw-flex-1 tw-truncate tw-text-xs tw-font-normal tw-text-iron-400 tw-transition-colors tw-duration-300 group-hover:tw-text-iron-300"
+                          >
+                            {previewText}
+                          </span>
+                          {isDescriptionPreviewTruncated && (
+                            <ChevronDownIcon
+                              aria-hidden="true"
+                              className="tw-h-4 tw-w-4 tw-flex-shrink-0 tw-text-iron-300 tw-transition-colors group-hover:tw-text-white"
+                            />
+                          )}
+                        </span>
+                      </>
+                    )}
+                  </WaveDescriptionPopover>
+                ) : (
+                  <h1 className="tw-mb-0 tw-truncate tw-text-sm tw-font-semibold tw-tracking-tight tw-text-white/95 lg:tw-text-xl">
+                    {wave.name}
+                  </h1>
+                )}
+                {!isCompact && (
+                  <WaveTrustSignals
+                    waveRep={wave.wave_rep}
+                    waveScore={wave.wave_score}
+                    variant="sidebar"
+                    className="tw-mt-1"
+                  />
+                )}
+              </div>
             </>
           )}
         </div>

--- a/components/home/explore-waves/ExploreWavesSection.tsx
+++ b/components/home/explore-waves/ExploreWavesSection.tsx
@@ -88,7 +88,7 @@ export function ExploreWavesSection({
         overviewType,
         page: 1,
         pageSize: limit,
-        excludeFollowed: effectiveExcludeFollowed,
+        excludeFollowed: effectiveExcludeFollowed ? true : undefined,
         scoreSort,
         minVisibilityScore,
         minQualityScore,

--- a/components/home/explore-waves/ExploreWavesSection.tsx
+++ b/components/home/explore-waves/ExploreWavesSection.tsx
@@ -61,6 +61,7 @@ export function ExploreWavesSection({
     connectedProfile?.normalised_handle ??
     connectedProfile?.handle ??
     null;
+  const effectiveExcludeFollowed = excludeFollowed && userScope !== null;
 
   const {
     data: waves,
@@ -78,7 +79,7 @@ export function ExploreWavesSection({
       minRepSortScore,
       visibilityTier,
       limit,
-      excludeFollowed,
+      effectiveExcludeFollowed,
       userScope,
     ],
     queryFn: async () => {
@@ -87,7 +88,7 @@ export function ExploreWavesSection({
         overviewType,
         page: 1,
         pageSize: limit,
-        excludeFollowed,
+        excludeFollowed: effectiveExcludeFollowed,
         scoreSort,
         minVisibilityScore,
         minQualityScore,
@@ -97,8 +98,8 @@ export function ExploreWavesSection({
       });
       return page.waves;
     },
-    staleTime: excludeFollowed ? 0 : 5 * 60 * 1000,
-    ...(excludeFollowed ? { gcTime: 0 } : {}),
+    staleTime: effectiveExcludeFollowed ? 0 : 5 * 60 * 1000,
+    ...(effectiveExcludeFollowed ? { gcTime: 0 } : {}),
   });
 
   if (isError) {

--- a/services/api/waves-v2-api.ts
+++ b/services/api/waves-v2-api.ts
@@ -265,8 +265,8 @@ export async function fetchWavesV2Page({
     params["pinned"] = pinned;
   }
 
-  if (excludeFollowed !== undefined) {
-    params["exclude_followed"] = `${excludeFollowed}`;
+  if (excludeFollowed === true) {
+    params["exclude_followed"] = "true";
   }
 
   if (identity !== undefined) {


### PR DESCRIPTION
## Summary
- avoid sending exclude_followed=true for anonymous scored wave discovery
- keep followed-wave exclusion enabled once a profile is connected
- add a regression test for anonymous and connected discovery requests

## Verification
- seize run typecheck:changed
- seize run lint:changed
- seize run test:no-coverage -- __tests__/components/home/explore-waves/ExploreWavesSection.test.tsx --runInBand --detectOpenHandles