### PR TITLE
[codex] Polish 6529 collection preview cards

### DIFF
--- a/__tests__/app/api/open-graph.6529.service.test.ts
+++ b/__tests__/app/api/open-graph.6529.service.test.ts
@@ -500,6 +500,7 @@ describe("createFirstParty6529Plan", () => {
           mint_date: "2024-04-11T12:00:00.000Z",
           rarity_score_rank: 86,
           thumbnail_url: "https://cdn.6529.io/nextgen/514.png",
+          owner: "0x06e13bd0a3cba08e61028f2326b9ea2ca2539900",
         });
       }
 
@@ -556,6 +557,16 @@ describe("createFirstParty6529Plan", () => {
         return jsonResponse({ handle: "zeblocks" });
       }
 
+      if (
+        url.pathname ===
+        "/api/identities/0x06e13bd0a3cba08e61028f2326b9ea2ca2539900"
+      ) {
+        return jsonResponse({
+          handle: "perilousvault",
+          display: "perilousvault.eth",
+        });
+      }
+
       return jsonResponse({}, 404);
     });
 
@@ -574,7 +585,14 @@ describe("createFirstParty6529Plan", () => {
       kicker: "NextGen \u00b7 Pebbles",
       requestUrl: "https://6529.io/nextgen/token/10000000514",
       url: "https://6529.io/nextgen/token/10000000514",
-      people: [{ label: "by", name: "Zeblocks", href: "/zeblocks" }],
+      people: [
+        { label: "by", name: "Zeblocks", href: "/zeblocks" },
+        {
+          label: "Collector",
+          name: "perilousvault.eth",
+          href: "/perilousvault",
+        },
+      ],
     });
     expect(data.facts).toEqual([
       { label: "Rarity", value: "#86 / 1,000" },

--- a/__tests__/components/waves/OpenGraphPreview.test.tsx
+++ b/__tests__/components/waves/OpenGraphPreview.test.tsx
@@ -337,6 +337,13 @@ describe("OpenGraphPreview", () => {
     );
 
     expect(screen.getByTestId("6529-collection-preview-card")).toBeInTheDocument();
+    expect(screen.getByTestId("6529-collection-preview-image-frame")).toHaveClass(
+      "tw-bg-black",
+      "tw-border-black"
+    );
+    expect(screen.getByAltText("The Collective Synapse")).toHaveClass(
+      "tw-object-contain"
+    );
     expect(screen.getAllByText("The Memes #509")).toHaveLength(1);
     expect(screen.getByText("The Collective Synapse")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "elnaz555" })).toHaveAttribute(
@@ -365,7 +372,14 @@ describe("OpenGraphPreview", () => {
           kind: "nextgen-token",
           title: "Pebbles #514",
           kicker: "NextGen \u00b7 Pebbles",
-          people: [{ label: "by", name: "Zeblocks", href: "/zeblocks" }],
+          people: [
+            { label: "by", name: "Zeblocks", href: "/zeblocks" },
+            {
+              label: "Collector",
+              name: "perilousvault.eth",
+              href: "/perilousvault",
+            },
+          ],
           facts: [
             { label: "Rarity", value: "#86 / 1,000" },
             { label: "Mint date", value: "11 Apr 2024" },
@@ -381,6 +395,11 @@ describe("OpenGraphPreview", () => {
     );
 
     expect(screen.getByTestId("6529-collection-preview-card")).toBeInTheDocument();
+    expect(screen.getByTestId("6529-collection-preview-image-frame")).toHaveClass(
+      "tw-bg-black",
+      "tw-border-black"
+    );
+    expect(screen.getByAltText("Pebbles #514")).toHaveClass("tw-object-contain");
     expect(screen.getByText("Pebbles #514")).toBeInTheDocument();
     expect(screen.getByText("NextGen \u00b7 Pebbles")).toBeInTheDocument();
     expect(screen.getByText("Rarity")).toBeInTheDocument();
@@ -392,5 +411,8 @@ describe("OpenGraphPreview", () => {
       "href",
       "/zeblocks"
     );
+    expect(
+      screen.getByRole("link", { name: "perilousvault.eth" })
+    ).toHaveAttribute("href", "/perilousvault");
   });
 });

--- a/app/api/open-graph/6529/service.ts
+++ b/app/api/open-graph/6529/service.ts
@@ -540,14 +540,26 @@ async function resolveProfileHref(
     return undefined;
   }
 
-  const profile = await fetchOptionalApiJson<IdentityResponse>(
+  const profile = await resolveIdentityProfile(candidate, context);
+  const handle = firstNonEmptyString(profile?.handle, profile?.normalised_handle);
+
+  return handle ? `/${handle.replace(/^@/, "")}` : undefined;
+}
+
+async function resolveIdentityProfile(
+  value: string | null | undefined,
+  context?: ApiContext
+): Promise<IdentityResponse | null> {
+  const candidate = profileLookupCandidate(value);
+  if (!candidate) {
+    return null;
+  }
+
+  return await fetchOptionalApiJson<IdentityResponse>(
     `identities/${encodeURIComponent(candidate.toLowerCase())}`,
     undefined,
     context
   );
-  const handle = firstNonEmptyString(profile?.handle, profile?.normalised_handle);
-
-  return handle ? `/${handle.replace(/^@/, "")}` : undefined;
 }
 
 function shouldUseExtendedEditionSize(
@@ -933,6 +945,19 @@ async function fetchNextGenPreview(
   const rarityRank = readPositiveNumber(token.rarity_score_rank);
   const mintDate = formatMintDate(token.mint_date);
   const artistHref = await resolveProfileHref(collection?.artist, context);
+  const collectorProfile = await resolveIdentityProfile(token.owner, context);
+  const collectorHandle = firstNonEmptyString(
+    collectorProfile?.handle,
+    collectorProfile?.normalised_handle
+  );
+  const collectorHref = collectorHandle
+    ? `/${collectorHandle.replace(/^@/, "")}`
+    : undefined;
+  const collectorDisplay = firstNonEmptyString(
+    collectorProfile?.display,
+    collectorProfile?.handle,
+    collectorProfile?.normalised_handle
+  );
   const canonicalRequestUrl = new URL(
     `/nextgen/token/${token.id}`,
     requestUrl.origin
@@ -948,6 +973,11 @@ async function fetchNextGenPreview(
         label: "by",
         name: collection?.artist,
         href: artistHref,
+      }),
+      createPerson({
+        label: "Collector",
+        name: collectorDisplay,
+        href: collectorHref,
       }),
     ]),
     facts: compactFacts([

--- a/app/api/open-graph/6529/service.ts
+++ b/app/api/open-graph/6529/service.ts
@@ -522,8 +522,8 @@ function compactPeople(
   );
 }
 
-function profileLookupCandidate(value: string | null | undefined): string | null {
-  const normalized = value?.trim().replace(/^@/, "");
+function profileLookupCandidate(value: unknown): string | null {
+  const normalized = readString(value)?.replace(/^@/, "");
   if (!normalized || normalized.includes(",") || normalized.includes(" ")) {
     return null;
   }
@@ -531,8 +531,31 @@ function profileLookupCandidate(value: string | null | undefined): string | null
   return normalized;
 }
 
+function identityProfileHandle(
+  profile: IdentityResponse | null | undefined
+): string | undefined {
+  return firstNonEmptyString(profile?.handle, profile?.normalised_handle);
+}
+
+function identityProfileHref(
+  profile: IdentityResponse | null | undefined
+): string | undefined {
+  const handle = identityProfileHandle(profile);
+  return handle ? `/${handle.replace(/^@/, "")}` : undefined;
+}
+
+function identityProfileDisplay(
+  profile: IdentityResponse | null | undefined
+): string | undefined {
+  return firstNonEmptyString(
+    profile?.display,
+    profile?.handle,
+    profile?.normalised_handle
+  );
+}
+
 async function resolveProfileHref(
-  value: string | null | undefined,
+  value: unknown,
   context?: ApiContext
 ): Promise<string | undefined> {
   const candidate = profileLookupCandidate(value);
@@ -541,13 +564,11 @@ async function resolveProfileHref(
   }
 
   const profile = await resolveIdentityProfile(candidate, context);
-  const handle = firstNonEmptyString(profile?.handle, profile?.normalised_handle);
-
-  return handle ? `/${handle.replace(/^@/, "")}` : undefined;
+  return identityProfileHref(profile);
 }
 
 async function resolveIdentityProfile(
-  value: string | null | undefined,
+  value: unknown,
   context?: ApiContext
 ): Promise<IdentityResponse | null> {
   const candidate = profileLookupCandidate(value);
@@ -944,20 +965,12 @@ async function fetchNextGenPreview(
   );
   const rarityRank = readPositiveNumber(token.rarity_score_rank);
   const mintDate = formatMintDate(token.mint_date);
-  const artistHref = await resolveProfileHref(collection?.artist, context);
-  const collectorProfile = await resolveIdentityProfile(token.owner, context);
-  const collectorHandle = firstNonEmptyString(
-    collectorProfile?.handle,
-    collectorProfile?.normalised_handle
-  );
-  const collectorHref = collectorHandle
-    ? `/${collectorHandle.replace(/^@/, "")}`
-    : undefined;
-  const collectorDisplay = firstNonEmptyString(
-    collectorProfile?.display,
-    collectorProfile?.handle,
-    collectorProfile?.normalised_handle
-  );
+  const [artistHref, collectorProfile] = await Promise.all([
+    resolveProfileHref(collection?.artist, context),
+    resolveIdentityProfile(readString(token.owner), context),
+  ]);
+  const collectorHref = identityProfileHref(collectorProfile);
+  const collectorDisplay = identityProfileDisplay(collectorProfile);
   const canonicalRequestUrl = new URL(
     `/nextgen/token/${token.id}`,
     requestUrl.origin

--- a/components/waves/OpenGraphPreview.tsx
+++ b/components/waves/OpenGraphPreview.tsx
@@ -524,17 +524,17 @@ function SeizeCollectionPreviewCard({
     >
       <div
         className={[
-          "tw-h-full tw-min-h-0 tw-w-full tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-py-3 tw-pl-3",
+          "tw-flex tw-h-full tw-min-h-0 tw-w-full tw-items-center tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-p-3",
           isHome
             ? "tw-border-white/10 tw-bg-black/30"
             : "tw-border-iron-700 tw-bg-iron-950/70",
-          !isHome && !hideActions ? "tw-pr-12 sm:tw-pr-3" : "tw-pr-3",
+          !isHome && !hideActions ? "tw-pr-12 sm:tw-pr-3" : "",
         ].join(" ")}
         data-testid="6529-collection-preview-card"
       >
         <div
           className={[
-            "tw-grid tw-h-full tw-min-h-0 tw-min-w-0 tw-items-center tw-gap-3",
+            "tw-grid tw-w-full tw-min-w-0 tw-items-center tw-gap-3 sm:tw-gap-4",
             imageUrl
               ? "tw-grid-cols-[5.5rem,minmax(0,1fr)] sm:tw-grid-cols-[6.75rem,minmax(0,1fr)] md:tw-grid-cols-[8.25rem,minmax(0,1fr)]"
               : "tw-grid-cols-1",
@@ -546,22 +546,25 @@ function SeizeCollectionPreviewCard({
               target={linkTarget}
               rel={linkRel}
               onClick={(e) => e.stopPropagation()}
-              className="tw-relative tw-block tw-aspect-square tw-w-full tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-iron-800 tw-bg-black tw-no-underline"
+              className="tw-flex tw-aspect-square tw-w-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-black tw-bg-black tw-p-1 tw-no-underline tw-shadow-[inset_0_0_0_1px_rgba(255,255,255,0.05)]"
+              data-testid="6529-collection-preview-image-frame"
             >
-              <Image
-                src={imageUrl}
-                alt={preview.title}
-                fill
-                className="tw-object-cover"
-                loading="lazy"
-                sizes="(max-width: 640px) 5.5rem, (max-width: 768px) 6.75rem, 8.25rem"
-                unoptimized
-              />
+              <span className="tw-relative tw-block tw-h-full tw-w-full">
+                <Image
+                  src={imageUrl}
+                  alt={preview.title}
+                  fill
+                  className="tw-object-contain"
+                  loading="lazy"
+                  sizes="(max-width: 640px) 5.5rem, (max-width: 768px) 6.75rem, 8.25rem"
+                  unoptimized
+                />
+              </span>
             </Link>
           )}
-          <div className="tw-flex tw-min-h-0 tw-min-w-0 tw-flex-1 tw-flex-col tw-justify-center tw-gap-1.5 tw-overflow-hidden">
+          <div className="tw-flex tw-min-h-0 tw-min-w-0 tw-flex-1 tw-flex-col tw-justify-center tw-gap-1.5 tw-overflow-hidden md:tw-gap-2">
             {preview.kicker && (
-              <div className="tw-[overflow-wrap:anywhere] tw-line-clamp-1 tw-break-words tw-text-xs tw-font-medium tw-text-iron-400">
+              <div className="tw-[overflow-wrap:anywhere] tw-line-clamp-1 tw-break-words tw-text-xs tw-font-medium tw-leading-5 tw-text-iron-400">
                 {wrapLongUnbrokenSegments(preview.kicker)}
               </div>
             )}
@@ -570,12 +573,12 @@ function SeizeCollectionPreviewCard({
               target={linkTarget}
               rel={linkRel}
               onClick={(e) => e.stopPropagation()}
-              className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-block tw-break-words tw-text-base tw-font-semibold tw-leading-tight tw-text-iron-50 tw-no-underline tw-transition tw-duration-200 hover:tw-text-white"
+              className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-block tw-break-words tw-text-base tw-font-semibold tw-leading-tight tw-text-iron-50 tw-no-underline tw-transition tw-duration-200 hover:tw-text-white md:tw-text-lg"
             >
               {wrapLongUnbrokenSegments(preview.title)}
             </Link>
             {people.length > 0 && (
-              <div className="tw-flex tw-min-w-0 tw-flex-wrap tw-gap-x-3 tw-gap-y-1 tw-overflow-hidden tw-text-xs tw-leading-5">
+              <div className="tw-flex tw-min-w-0 tw-flex-wrap tw-gap-x-3 tw-gap-y-1 tw-overflow-hidden tw-text-xs tw-leading-5 md:tw-text-sm">
                 {people.map((person, index) => {
                   const personHref = person.href ?? undefined;
                   const personIsExternal = isExternalHref(personHref);
@@ -617,7 +620,7 @@ function SeizeCollectionPreviewCard({
                 {facts.map((fact) => (
                   <span
                     key={`${fact.label}-${fact.value}`}
-                    className="tw-inline-flex tw-max-w-full tw-items-center tw-gap-1 tw-rounded-md tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-900/75 tw-px-2 tw-py-0.5 tw-text-[11px] tw-leading-5"
+                    className="tw-inline-flex tw-min-w-0 tw-max-w-full tw-items-center tw-gap-1 tw-rounded-md tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-900/75 tw-px-2 tw-py-0.5 tw-text-[11px] tw-leading-5"
                   >
                     <span className="tw-flex-shrink-0 tw-text-iron-400">
                       {fact.label}

--- a/ops/docs/waves/link-previews/feature-6529-collection-previews.md
+++ b/ops/docs/waves/link-previews/feature-6529-collection-previews.md
@@ -79,7 +79,9 @@ supply as final edition size.
 
 - Title: token name, for example `Pebbles #514`
 - Kicker: `NextGen &middot; {collection name}`
-- People: artist profile link when resolvable
+- People:
+  - artist profile link when resolvable
+  - `Collector {profile or display}` when the current owner resolves
 - Facts:
   - `Rarity #{rank} / {supply}`
   - `Mint date {date}`
@@ -110,6 +112,9 @@ the card lands on the real token page.
   the right.
 - Mobile: same left/right structure with smaller fixed thumbnail dimensions so
   chat cards stay scannable and stable.
+- Collection art renders inside a black square matte with a black border and
+  preserved aspect ratio. The card should show the whole NFT image instead of
+  cropping it.
 - Text is clamped and wrapped inside the card; long titles, handles, or trait
   values must not resize the preview frame.
 - Facts and traits wrap into compact chips and overflow is clipped inside the

--- a/styles/seize-bootstrap.scss
+++ b/styles/seize-bootstrap.scss
@@ -8,8 +8,9 @@ $orange: #ffa500;
 $yellow: #ffff00;
 // Add any other Bootstrap variables you want to set globally BEFORE the import.
 
-// Import Bootstrap's full SCSS using @use and configure its variables.
-@use "bootstrap/scss/bootstrap" with (
+// Import Bootstrap's full SCSS by explicit path so Turbopack/Sass resolves
+// Bootstrap partials before similarly named npm packages.
+@use "../node_modules/bootstrap/scss/bootstrap" with (
   $pink: $pink,
   $green: $green,
   $blue: $blue,


### PR DESCRIPTION
## Summary
- render 6529 collection preview images inside a black square matte with preserved aspect ratio
- include resolved NextGen collector identity alongside artist info
- document the updated card behavior and keep Bootstrap Sass resolution stable for builds

## Validation
- `seize run build` (exits 0; existing Bootstrap Sass deprecation warnings and non-fatal next-sitemap TS config warning still print)
- `seize run test:no-coverage -- __tests__/app/api/open-graph.6529.service.test.ts __tests__/components/waves/OpenGraphPreview.test.tsx __tests__/components/waves/LinkPreviewCard.test.tsx`
- `seize run lint:diff`
- `seize run typecheck:changed`
- `codex-diff-check`
- Local Playwright visual pass on desktop/tablet/mobile via temporary route; screenshots saved under `tmp/card-preview-screenshots-polish-clean/`, metrics showed 5/5 images loaded, square frames, and no horizontal overflow.

## Note
- `seize run react-doctor:diff` is blocked in this Windows EC2 worktree by `spawnSync ... react-doctor.cmd EINVAL`; running the POSIX shim through Git Bash is also blocked by the Windows worktree gitdir path.