### PR TITLE
[codex] Fix The Memes preview edition size

### DIFF
--- a/__tests__/app/api/open-graph.6529.service.test.ts
+++ b/__tests__/app/api/open-graph.6529.service.test.ts
@@ -156,6 +156,74 @@ describe("createFirstParty6529Plan", () => {
     ]);
   });
 
+  it("uses The Memes claim edition size when the server can fetch claims", async () => {
+    let claimAuthHeader: string | null = null;
+
+    mockFetch.mockImplementation(async (input: RequestInfo | URL, init) => {
+      const url = readFetchUrl(input);
+      const headers = new Headers(init?.headers);
+
+      if (url.pathname === "/api/nfts") {
+        return jsonResponse({
+          data: [
+            {
+              id: 509,
+              name: "The Collective Synapse",
+              supply: 173,
+              artist: "elnaz555",
+              artist_seize_handle: "elnaz555",
+              hodl_rate: 22.7803,
+              mint_date: "2026-06-15T09:23:23.000Z",
+              thumbnail: "https://cdn.6529.io/memes/509.png",
+              metadata: {
+                attributes: [{ trait_type: "Type - Season", value: 15 }],
+              },
+            },
+          ],
+        });
+      }
+
+      if (url.pathname === "/api/memes_extended_data") {
+        return jsonResponse({
+          data: [{ id: 509, edition_size: 173, season: 15 }],
+        });
+      }
+
+      if (
+        url.pathname ===
+        `/api/minting-claims/${MEMES_CONTRACT}/claims/509`
+      ) {
+        claimAuthHeader = headers.get("x-6529-auth");
+        return jsonResponse({
+          name: "The Collective Synapse",
+          edition_size: 328,
+        });
+      }
+
+      if (url.pathname === "/api/memes-mint-stats/509") {
+        return jsonResponse({
+          mint_date: "2026-06-15T09:23:23.000Z",
+          total_count: 94,
+        });
+      }
+
+      return jsonResponse({}, 404);
+    });
+
+    const plan = createFirstParty6529Plan(
+      new URL("https://6529.io/the-memes/509")
+    );
+    const { data } = await plan!.execute();
+
+    expect(claimAuthHeader).toBeNull();
+    expect(data.facts).toEqual([
+      { label: "Edition size", value: "328" },
+      { label: "TDH rate", value: "22.78" },
+      { label: "Season", value: "15" },
+      { label: "Mint date", value: "15 Jun 2026" },
+    ]);
+  });
+
   it("isolates authenticated collection preview cache keys by auth token", () => {
     const url = new URL("https://6529.io/the-memes/509");
     const publicPlan = createFirstParty6529Plan(url);

--- a/app/api/open-graph/6529/service.ts
+++ b/app/api/open-graph/6529/service.ts
@@ -172,12 +172,27 @@ function createApiHeaders(context?: ApiContext): HeadersInit {
   return headers;
 }
 
+async function getApiFetch(): Promise<typeof fetch> {
+  if (typeof window !== "undefined") {
+    return fetch;
+  }
+
+  try {
+    const { ssrFetch } = await import("@/lib/fetch/ssrFetch");
+    return ssrFetch;
+  } catch {
+    // Preview enrichment should degrade to public API data if server signing is unavailable.
+    return fetch;
+  }
+}
+
 async function fetchApiJson<T>(
   endpoint: string,
   params?: Record<string, string | number | undefined>,
   context?: ApiContext
 ): Promise<T> {
-  const response = await fetch(buildApiUrl(endpoint, params), {
+  const fetchImpl = await getApiFetch();
+  const response = await fetchImpl(buildApiUrl(endpoint, params), {
     headers: createApiHeaders(context),
   });
 


### PR DESCRIPTION
## Summary
- Route first-party 6529 preview API calls through the existing server-side API fetch path when running on the server.
- This lets production use SSR internal API credentials for auth-gated minting-claim data, including final The Memes edition size.
- Add a regression test for live-mint The Memes cards where public minted supply differs from claim edition size.

## Root Cause
The collection preview service used raw `fetch`. In production, the public API exposes current minted supply for fresh The Memes cards, while the final edition size lives behind the minting-claims endpoint. Without the server-side API signing wrapper, public link previews could not read the claim and omitted `Edition size 328` for The Collective Synapse.

## Validation
- `seize run test:no-coverage -- __tests__/app/api/open-graph.6529.service.test.ts`
- `seize run test:no-coverage -- __tests__/app/api/open-graph.6529.service.test.ts __tests__/app/api/open-graph.route.test.ts`
- `seize run lint:changed`
- `seize run typecheck:changed`
- `codex-diff-check`
- `seize run build` (passes; existing Bootstrap Sass deprecation warnings and `next-sitemap.config.ts` warning still print)