### PR TITLE
[codex] Compact wave score signals in sidebars

### DIFF
--- a/__tests__/components/waves/WaveTrustSignals.test.tsx
+++ b/__tests__/components/waves/WaveTrustSignals.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import type { ApiWaveRepSummary } from "@/generated/models/ApiWaveRepSummary";
+import type { ApiWaveScore } from "@/generated/models/ApiWaveScore";
+import { WaveTrustSignals } from "@/components/waves/WaveTrustSignals";
+
+const waveScore = {
+  visibility_score: 83,
+  quality_score: 78,
+  hotness_score: 92,
+  rep_sort_score: 41,
+} as ApiWaveScore;
+
+const waveRep = {
+  total_rep: 1250,
+} as ApiWaveRepSummary;
+
+describe("WaveTrustSignals", () => {
+  it("renders all trust badges in details mode", () => {
+    render(<WaveTrustSignals waveRep={waveRep} waveScore={waveScore} />);
+
+    expect(screen.getByText("Score")).toBeInTheDocument();
+    expect(screen.getByText("Hot")).toBeInTheDocument();
+    expect(screen.getByText("REP")).toBeInTheDocument();
+    expect(screen.getByText("83")).toBeInTheDocument();
+    expect(screen.getByText("92")).toBeInTheDocument();
+    expect(screen.getByText("+1.3K")).toBeInTheDocument();
+  });
+
+  it("renders one combined score badge in summary mode", () => {
+    render(
+      <WaveTrustSignals
+        waveRep={waveRep}
+        waveScore={waveScore}
+        variant="sidebar"
+        mode="summary"
+      />
+    );
+
+    const summaryBadge = screen.getByLabelText(
+      "Combined score: 83. Quality: 78. Hotness: 92. REP: +1,250 raw, 41 score"
+    );
+
+    expect(summaryBadge).toHaveAttribute(
+      "title",
+      "Combined score: 83\nQuality: 78\nHotness: 92\nREP: +1,250 raw, 41 score"
+    );
+    expect(screen.getByText("Score")).toBeInTheDocument();
+    expect(screen.getByText("83")).toBeInTheDocument();
+    expect(screen.queryByText("Hot")).not.toBeInTheDocument();
+    expect(screen.queryByText("REP")).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/WaveTrustSignals.test.tsx
+++ b/__tests__/components/waves/WaveTrustSignals.test.tsx
@@ -23,7 +23,7 @@ describe("WaveTrustSignals", () => {
     expect(screen.getByText("REP")).toBeInTheDocument();
     expect(screen.getByText("83")).toBeInTheDocument();
     expect(screen.getByText("92")).toBeInTheDocument();
-    expect(screen.getByText("+1.3K")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Wave REP positive/)).toBeInTheDocument();
   });
 
   it("renders one combined score badge in summary mode", () => {
@@ -36,17 +36,48 @@ describe("WaveTrustSignals", () => {
       />
     );
 
-    const summaryBadge = screen.getByLabelText(
-      "Combined score: 83. Quality: 78. Hotness: 92. REP: +1,250 raw, 41 score"
-    );
+    const summaryBadge = screen.getByText("Score").closest("[aria-label]");
 
+    expect(summaryBadge).not.toBeNull();
+    expect(summaryBadge).toHaveAttribute(
+      "aria-label",
+      expect.stringContaining("Combined score: 83. Quality: 78. Hotness: 92.")
+    );
+    expect(summaryBadge?.getAttribute("aria-label")).toMatch(
+      /^Combined score: 83\. Quality: 78\. Hotness: 92\. REP: .+ raw, 41 score$/
+    );
     expect(summaryBadge).toHaveAttribute(
       "title",
-      "Combined score: 83\nQuality: 78\nHotness: 92\nREP: +1,250 raw, 41 score"
+      expect.stringContaining("Combined score: 83\nQuality: 78\nHotness: 92")
     );
     expect(screen.getByText("Score")).toBeInTheDocument();
     expect(screen.getByText("83")).toBeInTheDocument();
     expect(screen.queryByText("Hot")).not.toBeInTheDocument();
     expect(screen.queryByText("REP")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing in summary mode without a combined score", () => {
+    const { container } = render(
+      <WaveTrustSignals
+        waveScore={
+          {
+            hotness_score: 92,
+            rep_sort_score: 41,
+          } as ApiWaveScore
+        }
+        variant="sidebar"
+        mode="summary"
+      />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing in summary mode without score data", () => {
+    const { container } = render(
+      <WaveTrustSignals waveScore={null} variant="sidebar" mode="summary" />
+    );
+
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
@@ -2,7 +2,7 @@
 
 import WavePicture from "@/components/waves/WavePicture";
 import {
-  hasWaveTrustSignals,
+  hasWaveTrustSummaryScore,
   WaveTrustSignals,
 } from "@/components/waves/WaveTrustSignals";
 import { useMyStream } from "@/contexts/wave/MyStreamContext";
@@ -113,12 +113,9 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
   const latestDropTimestamp = getPresentNumber(
     wave.newDropsCount.latestDropTimestamp
   );
-  const hasTrustSignals = hasWaveTrustSignals({
-    waveRep: wave.waveRep,
-    waveScore: wave.waveScore,
-  });
+  const hasSummaryScore = hasWaveTrustSummaryScore(wave.waveScore);
   const shouldShowTrustSignalsRow =
-    hasTrustSignals || latestDropTimestamp !== null;
+    hasSummaryScore || latestDropTimestamp !== null;
   const trustSignalsTooltipId = hasTouchScreen
     ? undefined
     : `sidebar-wave-trust-signals-${wave.id}`;
@@ -341,11 +338,12 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
           </div>
           {shouldShowTrustSignalsRow && (
             <div className="tw-mt-0.5 tw-flex tw-min-w-0 tw-items-center tw-gap-2 tw-text-xs tw-text-iron-500">
-              {hasTrustSignals && (
+              {hasSummaryScore && (
                 <WaveTrustSignals
                   waveRep={wave.waveRep}
                   waveScore={wave.waveScore}
                   variant="sidebar-inline"
+                  mode="summary"
                   className="tw-shrink-0"
                   tooltipId={trustSignalsTooltipId}
                 />
@@ -367,7 +365,7 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
           className="tw-absolute tw-right-3 tw-top-3 tw-z-10"
         />
       )}
-      {trustSignalsTooltipId !== undefined && hasTrustSignals && (
+      {trustSignalsTooltipId !== undefined && hasSummaryScore && (
         <Tooltip
           id={trustSignalsTooltipId}
           place="top"

--- a/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
+++ b/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
@@ -6,7 +6,7 @@ import BrainLeftSidebarWavePin from "@/components/brain/left-sidebar/waves/Brain
 import { SidebarWaveExpandControl } from "@/components/brain/left-sidebar/waves/SidebarWaveExpandControl";
 import { getSidebarWaveRowLayoutClasses } from "@/components/brain/left-sidebar/waves/sidebarWaveRowLayout";
 import {
-  hasWaveTrustSignals,
+  hasWaveTrustSummaryScore,
   WaveTrustSignals,
 } from "@/components/waves/WaveTrustSignals";
 import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
@@ -89,12 +89,9 @@ export const ExpandedWave = ({
   const shouldReserveExpandControlSpace = shouldShowExpandControl;
   const shouldShowPinButton = showPin && depth === 0;
   const trustSignalsTooltipId = `sidebar-expanded-wave-trust-signals-${waveId}`;
-  const hasTrustSignals = hasWaveTrustSignals({
-    waveRep: wave.waveRep,
-    waveScore: wave.waveScore,
-  });
+  const hasSummaryScore = hasWaveTrustSummaryScore(wave.waveScore);
   const shouldShowTrustSignalsRow =
-    hasTrustSignals || presentLatestDropTimestamp !== null;
+    hasSummaryScore || presentLatestDropTimestamp !== null;
   const { rowPaddingClasses, rowGapClasses, linkGapClasses } =
     getSidebarWaveRowLayoutClasses({
       isChildRow,
@@ -208,11 +205,12 @@ export const ExpandedWave = ({
           </div>
           {shouldShowTrustSignalsRow && (
             <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2 tw-text-xs tw-text-iron-500">
-              {hasTrustSignals && (
+              {hasSummaryScore && (
                 <WaveTrustSignals
                   waveRep={wave.waveRep}
                   waveScore={wave.waveScore}
                   variant="sidebar-inline"
+                  mode="summary"
                   className="tw-shrink-0"
                   tooltipId={trustSignalsTooltipId}
                 />
@@ -241,7 +239,7 @@ export const ExpandedWave = ({
           {tooltipContent}
         </WaveTooltip>
       )}
-      {hasTrustSignals && (
+      {hasSummaryScore && (
         <Tooltip
           id={trustSignalsTooltipId}
           place="top"

--- a/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
+++ b/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
@@ -158,6 +158,7 @@ function MyStreamWaveHeaderIdentity({
                       waveRep={wave.wave_rep}
                       waveScore={wave.wave_score}
                       variant="header-inline"
+                      mode="summary"
                       className="tw-shrink-0"
                     />
                   </span>
@@ -169,6 +170,7 @@ function MyStreamWaveHeaderIdentity({
                 waveRep={wave.wave_rep}
                 waveScore={wave.wave_score}
                 variant="header-inline"
+                mode="summary"
                 className="tw-mt-1"
               />
             )}
@@ -182,6 +184,7 @@ function MyStreamWaveHeaderIdentity({
               waveRep={wave.wave_rep}
               waveScore={wave.wave_score}
               variant="header-inline"
+              mode="summary"
               className="tw-mt-1"
             />
           </>

--- a/components/waves/WaveTrustSignals.tsx
+++ b/components/waves/WaveTrustSignals.tsx
@@ -5,17 +5,20 @@ import {
   ScaleIcon,
   ShieldCheckIcon,
 } from "@heroicons/react/24/outline";
+import type { ReactNode } from "react";
 
 type WaveTrustSignalsVariant =
   | "card"
   | "sidebar"
   | "sidebar-inline"
   | "header-inline";
+type WaveTrustSignalsMode = "details" | "summary";
 
 interface WaveTrustSignalsProps {
   readonly waveRep?: ApiWaveRepSummary | null | undefined;
   readonly waveScore?: ApiWaveScore | null | undefined;
   readonly variant?: WaveTrustSignalsVariant | undefined;
+  readonly mode?: WaveTrustSignalsMode | undefined;
   readonly className?: string | undefined;
   readonly tooltipId?: string | undefined;
 }
@@ -44,6 +47,23 @@ const formatRep = (value: number | null | undefined): string | null => {
   }
 
   return compactNumberFormatter.format(value);
+};
+
+const formatSignedFullNumber = (
+  value: number | null | undefined
+): string | null => {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return null;
+  }
+
+  const formatted = fullNumberFormatter.format(Math.abs(value));
+  if (value > 0) {
+    return `+${formatted}`;
+  }
+  if (value < 0) {
+    return `-${formatted}`;
+  }
+  return formatted;
 };
 
 const formatRepAccessibleValue = (
@@ -132,21 +152,33 @@ const getRepToneClasses = (
 
 const getContainerClasses = (
   variant: WaveTrustSignalsVariant,
+  mode: WaveTrustSignalsMode,
   className: string | undefined
 ) => {
   let baseClasses = "tw-flex tw-flex-wrap tw-items-center tw-gap-1.5";
-  if (isInlineSidebarVariant(variant)) {
-    baseClasses =
-      "tw-inline-flex tw-items-center tw-gap-[11px] tw-align-middle";
+  if (mode === "summary") {
+    baseClasses = "tw-flex tw-min-w-0 tw-flex-nowrap tw-items-center tw-gap-1.5";
   }
 
-  return [baseClasses, variant === "sidebar" ? "tw-mt-1" : "", className ?? ""]
+  if (isInlineSidebarVariant(variant)) {
+    baseClasses =
+      mode === "summary"
+        ? "tw-inline-flex tw-min-w-0 tw-items-center tw-gap-[4px] tw-align-middle"
+        : "tw-inline-flex tw-items-center tw-gap-[11px] tw-align-middle";
+  }
+
+  return [
+    baseClasses,
+    variant === "sidebar" && mode === "details" ? "tw-mt-1" : "",
+    className ?? "",
+  ]
     .filter(Boolean)
     .join(" ");
 };
 
 const getChipClasses = (
   variant: WaveTrustSignalsVariant,
+  mode: WaveTrustSignalsMode,
   toneClasses: string
 ) => {
   let variantClasses = "tw-gap-1 tw-rounded-md tw-ring-1 tw-ring-inset";
@@ -164,10 +196,19 @@ const getChipClasses = (
     sizeClasses = "tw-h-5 tw-px-1.5 tw-text-[10px]";
   }
 
+  const summaryClasses =
+    mode === "summary" &&
+    (variant === "sidebar" || isInlineSidebarVariant(variant))
+      ? "tw-w-[4.75rem] tw-shrink-0 tw-justify-center"
+      : mode === "summary"
+        ? "tw-shrink-0 tw-justify-center"
+        : "";
+
   return [
     "tw-inline-flex tw-items-center",
     variantClasses,
     sizeClasses,
+    summaryClasses,
     toneClasses,
   ].join(" ");
 };
@@ -175,6 +216,10 @@ const getChipClasses = (
 const getChipLabelClasses = (variant: WaveTrustSignalsVariant): string => {
   if (isInlineHeaderVariant(variant)) {
     return "tw-text-[11px] tw-font-medium tw-text-iron-400";
+  }
+
+  if (isInlineSidebarVariant(variant)) {
+    return "tw-text-[11px] tw-font-medium";
   }
 
   if (variant === "sidebar") {
@@ -258,15 +303,73 @@ export const hasWaveTrustSignals = ({
   return visibilityScore !== null || hotnessScore !== null || repScore !== null;
 };
 
+export const hasWaveTrustSummaryScore = (
+  waveScore?: ApiWaveScore | null | undefined
+): boolean => formatScore(waveScore?.visibility_score) !== null;
+
+const buildSummaryDetails = ({
+  visibilityScore,
+  qualityScore,
+  hotnessScore,
+  repSortScore,
+  waveRep,
+}: {
+  readonly visibilityScore: string;
+  readonly qualityScore: string | null;
+  readonly hotnessScore: string | null;
+  readonly repSortScore: string | null;
+  readonly waveRep: ApiWaveRepSummary | null | undefined;
+}) => {
+  const details = [`Combined score: ${visibilityScore}`];
+
+  if (qualityScore !== null) {
+    details.push(`Quality: ${qualityScore}`);
+  }
+
+  if (hotnessScore !== null) {
+    details.push(`Hotness: ${hotnessScore}`);
+  }
+
+  const rawRep = formatSignedFullNumber(waveRep?.total_rep);
+  if (rawRep !== null && repSortScore !== null) {
+    details.push(`REP: ${rawRep} raw, ${repSortScore} score`);
+  } else if (rawRep !== null) {
+    details.push(`REP: ${rawRep} raw`);
+  } else if (repSortScore !== null) {
+    details.push(`REP score: ${repSortScore}`);
+  }
+
+  return details;
+};
+
+const renderContainer = ({
+  children,
+  className,
+  variant,
+}: {
+  readonly children: ReactNode;
+  readonly className: string;
+  readonly variant: WaveTrustSignalsVariant;
+}) => {
+  if (isInlineVariant(variant)) {
+    return <span className={className}>{children}</span>;
+  }
+
+  return <div className={className}>{children}</div>;
+};
+
 export function WaveTrustSignals({
   waveRep,
   waveScore,
   variant = "card",
+  mode = "details",
   className,
   tooltipId,
 }: WaveTrustSignalsProps) {
   const visibilityScore = formatScore(waveScore?.visibility_score);
+  const qualityScore = formatScore(waveScore?.quality_score);
   const hotnessScore = formatScore(waveScore?.hotness_score);
+  const repSortScore = formatScore(waveScore?.rep_sort_score);
   const hasRepSummary = waveRep !== null && waveRep !== undefined;
   const repScore = getRepScore({ waveRep, waveScore });
   let repAccessibleValue: string | null = null;
@@ -301,11 +404,59 @@ export function WaveTrustSignals({
     return null;
   }
 
+  const containerClasses = getContainerClasses(variant, mode, className);
+
+  if (mode === "summary") {
+    if (visibilityScore === null) {
+      return null;
+    }
+
+    const summaryDetails = buildSummaryDetails({
+      visibilityScore,
+      qualityScore,
+      hotnessScore,
+      repSortScore,
+      waveRep,
+    });
+    const summaryLabel = summaryDetails.join(". ");
+    const summaryTitle = summaryDetails.join("\n");
+    const summaryTooltip = summaryDetails.join(" | ");
+
+    return renderContainer({
+      variant,
+      className: containerClasses,
+      children: (
+        <span
+          className={getChipClasses(
+            variant,
+            mode,
+            getVisibilityToneClasses(variant)
+          )}
+          aria-label={summaryLabel}
+          title={summaryTitle}
+          {...getTooltipAttributes(inlineSidebarTooltipId, summaryTooltip)}
+        >
+          <ShieldCheckIcon
+            className={getIconClasses(variant)}
+            strokeWidth={isInlineVariant(variant) ? 1.5 : undefined}
+            aria-hidden="true"
+          />
+          <span className={getChipLabelClasses(variant)}>Score</span>
+          <span className={getValueClasses(variant)}>{visibilityScore}</span>
+        </span>
+      ),
+    });
+  }
+
   const signals = (
     <>
       {hasVisibilityScore && (
         <span
-          className={getChipClasses(variant, getVisibilityToneClasses(variant))}
+          className={getChipClasses(
+            variant,
+            mode,
+            getVisibilityToneClasses(variant)
+          )}
           aria-label={`Visibility score ${visibilityScore} out of 100`}
           {...getTooltipAttributes(inlineSidebarTooltipId, "Score")}
         >
@@ -327,7 +478,11 @@ export function WaveTrustSignals({
       )}
       {hasHotnessScore && (
         <span
-          className={getChipClasses(variant, getHotnessToneClasses(variant))}
+          className={getChipClasses(
+            variant,
+            mode,
+            getHotnessToneClasses(variant)
+          )}
           aria-label={`Hotness score ${hotnessScore} out of 100`}
           {...getTooltipAttributes(inlineSidebarTooltipId, "Hot")}
         >
@@ -351,6 +506,7 @@ export function WaveTrustSignals({
         <span
           className={getChipClasses(
             variant,
+            mode,
             getRepToneClasses(repToneValue, variant)
           )}
           aria-label={repLabel ?? undefined}
@@ -369,11 +525,10 @@ export function WaveTrustSignals({
       )}
     </>
   );
-  const containerClasses = getContainerClasses(variant, className);
 
-  if (isInlineVariant(variant)) {
-    return <span className={containerClasses}>{signals}</span>;
-  }
-
-  return <div className={containerClasses}>{signals}</div>;
+  return renderContainer({
+    variant,
+    className: containerClasses,
+    children: signals,
+  });
 }

--- a/components/waves/WaveTrustSignals.tsx
+++ b/components/waves/WaveTrustSignals.tsx
@@ -196,13 +196,13 @@ const getChipClasses = (
     sizeClasses = "tw-h-5 tw-px-1.5 tw-text-[10px]";
   }
 
-  const summaryClasses =
-    mode === "summary" &&
-    (variant === "sidebar" || isInlineSidebarVariant(variant))
-      ? "tw-w-[4.75rem] tw-shrink-0 tw-justify-center"
-      : mode === "summary"
-        ? "tw-shrink-0 tw-justify-center"
-        : "";
+  let summaryClasses = "";
+  if (mode === "summary") {
+    summaryClasses = "tw-shrink-0 tw-justify-center";
+    if (variant === "sidebar" || isInlineSidebarVariant(variant)) {
+      summaryClasses = `${summaryClasses} tw-w-[4.75rem]`;
+    }
+  }
 
   return [
     "tw-inline-flex tw-items-center",


### PR DESCRIPTION
## Summary
- add a `summary` mode to `WaveTrustSignals` that shows one combined Score chip with Quality, Hotness, and REP details in hover/focus metadata
- switch dense sidebar wave rows and the active desktop wave header to the compact summary signal
- align sidebar metadata into one stable row: combined Score + Last drop
- keep Discover cards and the transparency/calculator page on the full detailed chip display

## Validation
- `seize run test:no-coverage -- __tests__/components/waves/WaveTrustSignals.test.tsx`
- `seize run typecheck:changed`
- `seize run lint:changed`

## Notes
- Local unauthenticated render checked on `http://localhost:3121/waves`; logged-in sidebar visual QA will be done from staging after deploy with production-like auth/data.