### PR TITLE
Fix user tab query index access

### DIFF
--- a/components/user/layout/UserPageTab.tsx
+++ b/components/user/layout/UserPageTab.tsx
@@ -38,10 +38,10 @@ export default function UserPageTab({
   const localeParam = searchParams?.get("locale");
 
   if (addressParam) {
-    tabQuery.address = addressParam;
+    tabQuery["address"] = addressParam;
   }
   if (localeParam) {
-    tabQuery.locale = localeParam;
+    tabQuery["locale"] = localeParam;
   }
 
   const isVisibleInViewportSide = () => {


### PR DESCRIPTION
## Summary
- use bracket access for preserved user tab query params to satisfy noPropertyAccessFromIndexSignature
- unblocks the staging/production Next build after current main

## Validation
- seize run lint:changed
- seize run typecheck:changed
- codex-diff-check