### PR TITLE
Fallback anonymous staging previews to public API

### DIFF
--- a/__tests__/app/api/open-graph.6529.service.test.ts
+++ b/__tests__/app/api/open-graph.6529.service.test.ts
@@ -48,6 +48,10 @@ function readFetchUrl(input: RequestInfo | URL): URL {
   return new URL(String(input));
 }
 
+function readFetchHeaders(init: RequestInit | undefined): Record<string, string> {
+  return Object.fromEntries(new Headers(init?.headers).entries());
+}
+
 function mockFreshTheMemesLiveCountApis(): void {
   mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
     const url = readFetchUrl(input);
@@ -452,7 +456,48 @@ describe("createFirstParty6529Plan", () => {
     ]);
   });
 
-  it("does not retry production fallback for primary auth failures", async () => {
+  it("falls back to the production public API for anonymous staging auth gates", async () => {
+    publicEnv.API_ENDPOINT = "https://api.staging.6529.io";
+
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = readFetchUrl(input);
+
+      if (url.hostname === "api.staging.6529.io") {
+        return jsonResponse({ message: "Unauthorized" }, 401);
+      }
+
+      if (url.hostname === "api.6529.io") {
+        const response = productionTheMemesResponse(url);
+        if (response) {
+          return response;
+        }
+      }
+
+      return jsonResponse({}, 404);
+    });
+
+    const plan = createFirstParty6529Plan(
+      new URL("https://6529.io/the-memes/509")
+    );
+    const { data } = await plan!.execute();
+
+    expect(data.title).toBe("The Collective Synapse");
+    expect(data.facts).toEqual([
+      { label: "Edition size", value: "328" },
+      { label: "TDH rate", value: "22.78" },
+      { label: "Season", value: "15" },
+      { label: "Mint date", value: "15 Jun 2026" },
+    ]);
+    expect(
+      mockFetch.mock.calls.some(
+        (call) =>
+          readFetchUrl(call[0]).hostname === "api.6529.io" &&
+          readFetchHeaders(call[1])["x-6529-auth"] !== undefined
+      )
+    ).toBe(false);
+  });
+
+  it("does not retry production fallback for authenticated primary auth failures", async () => {
     publicEnv.API_ENDPOINT = "https://api.staging.6529.io";
 
     mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
@@ -466,7 +511,8 @@ describe("createFirstParty6529Plan", () => {
     });
 
     const plan = createFirstParty6529Plan(
-      new URL("https://6529.io/the-memes/509")
+      new URL("https://6529.io/the-memes/509"),
+      { apiAuth: "bad-staging-auth" }
     );
 
     await expect(plan!.execute()).rejects.toThrow("The Memes card was not found.");

--- a/app/api/open-graph/6529/service.ts
+++ b/app/api/open-graph/6529/service.ts
@@ -214,8 +214,19 @@ const PUBLIC_API_HEADERS: HeadersInit = {
   accept: "application/json",
 };
 
-function shouldRetryApiStatus(status: number): boolean {
-  return status >= 500 && status < 600;
+function hasApiAuth(context?: ApiContext): boolean {
+  return getApiAuth(context) !== undefined;
+}
+
+function shouldRetryApiStatus(
+  status: number,
+  context?: ApiContext
+): boolean {
+  if (status >= 500 && status < 600) {
+    return true;
+  }
+
+  return (status === 401 || status === 403) && !hasApiAuth(context);
 }
 
 async function getApiFetch(): Promise<typeof fetch> {
@@ -258,7 +269,7 @@ async function fetchApiJson<T>(
         primaryStatus = response.status;
       }
 
-      if (!shouldRetryApiStatus(response.status)) {
+      if (!shouldRetryApiStatus(response.status, context)) {
         break;
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- allow first-party 6529 preview enrichment to retry public api.6529.io when anonymous staging API access is gated with 401/403
- keep authenticated 401/403 terminal so caller/staging auth failures are not masked
- keep production fallback requests public-only without x-6529-auth

## Validation
- seize run test:no-coverage -- __tests__/app/api/open-graph.6529.service.test.ts __tests__/app/api/open-graph.route.test.ts
- seize run lint:changed
- seize run typecheck:changed
- codex-diff-check