### PR TITLE
[codex] Fix group edit submit label

### DIFF
--- a/__tests__/components/groups/page/create/actions/GroupCreateActions.test.tsx
+++ b/__tests__/components/groups/page/create/actions/GroupCreateActions.test.tsx
@@ -71,19 +71,49 @@ it('disables create button when no filters selected', () => {
   expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
 });
 
-it('creates group and marks visible on save', async () => {
+it('shows save button when editing an existing group', () => {
+  mockValidate.mockReturnValue({ valid: false, issues: [] });
+  renderActions({ originalGroup: { id: 'old' } as any });
+  expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  expect(screen.queryByRole('button', { name: 'Create' })).not.toBeInTheDocument();
+});
+
+it('creates group and marks visible on create', async () => {
   const groupConfig = {
     ...defaultGroup,
     name: 'New Group',
+    group: { ...defaultGroup.group, identity_addresses: ['0x1'] },
+  };
+  mockValidate.mockReturnValue({ valid: true, issues: [] });
+  mockSubmit.mockResolvedValueOnce({ ok: true, group: { id: '123' }, published: true });
+
+  const { auth, onCompleted } = renderActions({ groupConfig });
+
+  await userEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+  await waitFor(() => expect(mockSubmit).toHaveBeenCalledTimes(1));
+  expect(mockSubmit).toHaveBeenCalledWith({
+    payload: groupConfig,
+    previousGroup: null,
+    currentHandle: 'alice',
+  });
+  expect(auth.setToast).toHaveBeenCalledWith({ message: 'Group created.', type: 'success' });
+  expect(onCompleted).toHaveBeenCalled();
+});
+
+it('saves group changes in edit mode', async () => {
+  const groupConfig = {
+    ...defaultGroup,
+    name: 'Edited Group',
     group: { ...defaultGroup.group, identity_addresses: ['0x1'] },
   };
   const originalGroup = { id: 'old', created_by: { handle: 'Alice' } } as any;
   mockValidate.mockReturnValue({ valid: true, issues: [] });
   mockSubmit.mockResolvedValueOnce({ ok: true, group: { id: '123' }, published: true });
 
-  const { auth, queryCtx, onCompleted } = renderActions({ groupConfig, originalGroup });
+  const { auth, onCompleted } = renderActions({ groupConfig, originalGroup });
 
-  await userEvent.click(screen.getByRole('button', { name: 'Create' }));
+  await userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
   await waitFor(() => expect(mockSubmit).toHaveBeenCalledTimes(1));
   expect(mockSubmit).toHaveBeenCalledWith({
@@ -91,6 +121,6 @@ it('creates group and marks visible on save', async () => {
     previousGroup: originalGroup,
     currentHandle: 'alice',
   });
-  expect(auth.setToast).toHaveBeenCalledWith({ message: 'Group created.', type: 'success' });
+  expect(auth.setToast).toHaveBeenCalledWith({ message: 'Group saved.', type: 'success' });
   expect(onCompleted).toHaveBeenCalled();
 });

--- a/components/groups/page/create/actions/GroupCreateActions.tsx
+++ b/components/groups/page/create/actions/GroupCreateActions.tsx
@@ -8,11 +8,8 @@ import CircleLoader from "@/components/distribution-plan-tool/common/CircleLoade
 import GroupCreateTest from "./GroupCreateTest";
 import { ReactQueryWrapperContext } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import SecondaryButton from "@/components/utils/button/SecondaryButton";
-import type {
-  SubmitArgs} from "@/hooks/groups/useGroupMutations";
-import {
-  useGroupMutations,
-} from "@/hooks/groups/useGroupMutations";
+import type { SubmitArgs } from "@/hooks/groups/useGroupMutations";
+import { useGroupMutations } from "@/hooks/groups/useGroupMutations";
 
 export default function GroupCreateActions({
   originalGroup,
@@ -32,6 +29,9 @@ export default function GroupCreateActions({
 
   const validation = validate(groupConfig);
   const isActionsDisabled = !validation.valid || isSubmitting;
+  const isEditMode = !!originalGroup;
+  const submitLabel = isEditMode ? "Save" : "Create";
+  const successMessage = isEditMode ? "Group saved." : "Group created.";
 
   const onSave = async (): Promise<void> => {
     if (isSubmitting) {
@@ -45,7 +45,7 @@ export default function GroupCreateActions({
     const result = await submit(submitArgs);
     if (result.ok) {
       setToast({
-        message: "Group created.",
+        message: successMessage,
         type: "success",
       });
       onCompleted();
@@ -92,7 +92,7 @@ export default function GroupCreateActions({
               } tw-flex tw-items-center tw-whitespace-nowrap tw-border tw-border-solid tw-border-primary-500 tw-rounded-lg tw-bg-primary-500 tw-px-3.5 tw-py-2.5 tw-text-sm tw-font-semibold tw-shadow-sm focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-600 tw-transition tw-duration-300 tw-ease-out`}>
               <div className="tw-flex tw-items-center tw-justify-center tw-gap-x-2">
                 {isSubmitting && <CircleLoader />}
-                <span>Create</span>
+                <span>{submitLabel}</span>
               </div>
             </button>
           </div>


### PR DESCRIPTION
## Summary

- Show `Save` instead of `Create` when editing an existing group.
- Keep `Create` for new groups.
- Use an edit-specific success toast: `Group saved.`
- Add focused coverage for create and edit submit labels/submission behavior.

## Root Cause

The group create/edit action component reused the same submit UI for both modes, but the visible submit label was hard-coded to `Create` even when `originalGroup` was present.

## Validation

- `seize install:frozen`
- `seize run test:no-coverage -- --runTestsByPath __tests__/components/groups/page/create/actions/GroupCreateActions.test.tsx --runInBand --forceExit`
- `seize exec eslint --no-warn-ignored --max-warnings=0 components/groups/page/create/actions/GroupCreateActions.tsx __tests__/components/groups/page/create/actions/GroupCreateActions.test.tsx`
- `codex-diff-check -- components/groups/page/create/actions/GroupCreateActions.tsx __tests__/components/groups/page/create/actions/GroupCreateActions.test.tsx`