### PR TITLE
[codex] Fix wave screenshot paste uploads

### DIFF
--- a/__tests__/components/DragDropPastePlugin.test.tsx
+++ b/__tests__/components/DragDropPastePlugin.test.tsx
@@ -9,14 +9,24 @@ jest.mock("@/components/auth/Auth", () => ({
 }));
 
 const editorState = { id: "editor-state" };
+const selectionMock = {
+  insertParagraph: jest.fn(),
+  insertRawText: jest.fn(),
+  insertText: jest.fn(),
+};
 const update = (fn: any, options?: { onUpdate?: () => void }) => {
   fn();
   options?.onUpdate?.();
 };
-let commandHandler: any;
+let dragDropPasteHandler: any;
+let pasteHandler: any;
 const editor = {
-  registerCommand: jest.fn((_cmd: any, fn: any) => {
-    commandHandler = fn;
+  registerCommand: jest.fn((cmd: any, fn: any) => {
+    if (cmd === "PASTE_COMMAND") {
+      pasteHandler = fn;
+    } else {
+      dragDropPasteHandler = fn;
+    }
     return () => {};
   }),
   getEditorState: jest.fn(() => editorState),
@@ -34,11 +44,16 @@ jest.mock("@/components/waves/create-wave/services/multiPartUpload", () => ({
 }));
 
 jest.mock("lexical", () => ({
-  $insertNodes: jest.fn(),
+  $getSelection: jest.fn(() => selectionMock),
   $getNodeByKey: jest.fn(() => ({ replace: jest.fn(), remove: jest.fn() })),
+  $insertNodes: jest.fn(),
+  $isRangeSelection: jest.fn(() => true),
   COMMAND_PRIORITY_LOW: 1,
+  PASTE_COMMAND: "PASTE_COMMAND",
 }));
-jest.mock("@lexical/rich-text", () => ({ DRAG_DROP_PASTE: "PASTE" }));
+jest.mock("@lexical/rich-text", () => ({
+  DRAG_DROP_PASTE: "DRAG_DROP_PASTE",
+}));
 jest.mock("@lexical/utils", () => ({
   isMimeType: jest.fn((file: File, acceptableTypes: string[]) =>
     acceptableTypes.some(
@@ -62,6 +77,9 @@ const { useAuth } = require("@/components/auth/Auth");
 describe("DragDropPastePlugin", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    selectionMock.insertParagraph.mockClear();
+    selectionMock.insertRawText.mockClear();
+    selectionMock.insertText.mockClear();
     (useLexicalComposerContext as jest.Mock).mockReturnValue([editor]);
     const { mediaFileReader } = require("@lexical/utils");
     (mediaFileReader as jest.Mock).mockResolvedValue([
@@ -77,7 +95,9 @@ describe("DragDropPastePlugin", () => {
   it("uploads image on paste", async () => {
     renderPlugin();
     await act(async () => {
-      await commandHandler([new File(["a"], "a.png", { type: "image/png" })]);
+      await dragDropPasteHandler([
+        new File(["a"], "a.png", { type: "image/png" }),
+      ]);
       await Promise.resolve();
     });
     expect(multiPartUpload).toHaveBeenCalled();
@@ -85,12 +105,149 @@ describe("DragDropPastePlugin", () => {
     expect($getNodeByKey).toHaveBeenCalledWith("1");
   });
 
+  it("uploads pasted HTML data images before Lexical imports the base64 src", async () => {
+    const { mediaFileReader } = require("@lexical/utils");
+    (mediaFileReader as jest.Mock).mockImplementation((files: File[]) =>
+      Promise.resolve(files.map((file) => ({ file })))
+    );
+    const preventDefault = jest.fn();
+    const getData = jest.fn((type: string) =>
+      type === "text/html"
+        ? '<img src="data:image/png;base64,YQ==" alt="screenshot">'
+        : ""
+    );
+
+    renderPlugin();
+    await act(async () => {
+      const handled = pasteHandler({
+        preventDefault,
+        clipboardData: {
+          files: [],
+          items: [],
+          getData,
+        },
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(handled).toBe(true);
+    });
+
+    const uploadArg = (multiPartUpload as jest.Mock).mock.calls[0][0];
+    expect(preventDefault).toHaveBeenCalled();
+    expect(uploadArg.file).toBeInstanceOf(File);
+    expect(uploadArg.file.name).toBe("pasted-image-0.png");
+    expect(uploadArg.file.type).toBe("image/png");
+    expect($insertNodes).toHaveBeenCalled();
+  });
+
+  it("preserves pasted plain text when image paste includes text", async () => {
+    const { mediaFileReader } = require("@lexical/utils");
+    (mediaFileReader as jest.Mock).mockImplementation((files: File[]) =>
+      Promise.resolve(files.map((file) => ({ file })))
+    );
+    const preventDefault = jest.fn();
+    const imageFile = new File(["a"], "a.png", { type: "image/png" });
+
+    renderPlugin();
+    await act(async () => {
+      const handled = pasteHandler({
+        preventDefault,
+        clipboardData: {
+          files: [imageFile],
+          items: [],
+          getData: jest.fn((type: string) =>
+            type === "text/html"
+              ? '<img src="data:image/png;base64,YQ==" alt="screenshot">'
+              : type === "text/plain"
+                ? "caption"
+                : ""
+          ),
+        },
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(handled).toBe(true);
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+    expect($insertNodes.mock.invocationCallOrder[0]).toBeLessThan(
+      selectionMock.insertText.mock.invocationCallOrder[0]
+    );
+    expect(selectionMock.insertText).toHaveBeenCalledWith("caption");
+    expect(multiPartUpload).toHaveBeenCalledWith(
+      expect.objectContaining({ file: imageFile, path: "drop" })
+    );
+  });
+
+  it("lets attachment-only paste fall through to Lexical", async () => {
+    const { mediaFileReader } = require("@lexical/utils");
+    const preventDefault = jest.fn();
+
+    renderPlugin();
+    const handled = pasteHandler({
+      preventDefault,
+      clipboardData: {
+        files: [new File(["a"], "a.pdf", { type: "application/pdf" })],
+        items: [],
+        getData: jest.fn(() => ""),
+      },
+    });
+
+    expect(handled).toBe(false);
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(mediaFileReader).not.toHaveBeenCalled();
+    expect(multiPartUpload).not.toHaveBeenCalled();
+  });
+
+  it("uploads HTML data images when clipboard files are not images", async () => {
+    const { mediaFileReader } = require("@lexical/utils");
+    (mediaFileReader as jest.Mock).mockImplementation((files: File[]) =>
+      Promise.resolve(
+        files
+          .filter((file) => file.type.startsWith("image/"))
+          .map((file) => ({ file }))
+      )
+    );
+    const preventDefault = jest.fn();
+    const textFile = new File(["a"], "note.txt", { type: "text/plain" });
+
+    renderPlugin();
+    await act(async () => {
+      const handled = pasteHandler({
+        preventDefault,
+        clipboardData: {
+          files: [textFile],
+          items: [],
+          getData: jest.fn((type: string) =>
+            type === "text/html"
+              ? '<img src="data:image/png;base64,YQ==" alt="screenshot">'
+              : ""
+          ),
+        },
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(handled).toBe(true);
+    });
+
+    const fileReaderFiles = (mediaFileReader as jest.Mock).mock.calls[0][0];
+    const uploadArg = (multiPartUpload as jest.Mock).mock.calls[0][0];
+    expect(preventDefault).toHaveBeenCalled();
+    expect(fileReaderFiles).toHaveLength(2);
+    expect(fileReaderFiles[0]).toBe(textFile);
+    expect(fileReaderFiles[1].name).toBe("pasted-image-0.png");
+    expect(uploadArg.file.name).toBe("pasted-image-0.png");
+    expect(uploadArg.file.type).toBe("image/png");
+  });
+
   it("shows error when file unsupported", async () => {
     const { mediaFileReader } = require("@lexical/utils");
     (mediaFileReader as jest.Mock).mockResolvedValue([]);
     renderPlugin();
     await act(async () => {
-      await commandHandler([new File(["a"], "a.txt", { type: "text/plain" })]);
+      await dragDropPasteHandler([
+        new File(["a"], "a.txt", { type: "text/plain" }),
+      ]);
       await Promise.resolve();
     });
     expect(toastMock).toHaveBeenCalled();
@@ -108,7 +265,7 @@ describe("DragDropPastePlugin", () => {
 
     renderPlugin({ onAttachmentFiles });
     await act(async () => {
-      await commandHandler(files);
+      await dragDropPasteHandler(files);
       await Promise.resolve();
     });
 
@@ -123,7 +280,9 @@ describe("DragDropPastePlugin", () => {
     renderPlugin({ disabled: true, onAttachmentFiles });
 
     await act(async () => {
-      await commandHandler([new File(["a"], "a.png", { type: "image/png" })]);
+      await dragDropPasteHandler([
+        new File(["a"], "a.png", { type: "image/png" }),
+      ]);
       await Promise.resolve();
     });
 
@@ -158,7 +317,7 @@ describe("DragDropPastePlugin", () => {
     });
 
     act(() => {
-      commandHandler([imageFile, attachmentFile]);
+      dragDropPasteHandler([imageFile, attachmentFile]);
     });
 
     rerender(
@@ -196,7 +355,7 @@ describe("DragDropPastePlugin", () => {
       <DragDropPastePlugin onAttachmentFiles={() => {}} />
     );
     await act(async () => {
-      commandHandler([new File(["a"], "a.png", { type: "image/png" })]);
+      dragDropPasteHandler([new File(["a"], "a.png", { type: "image/png" })]);
       await Promise.resolve();
     });
 
@@ -227,7 +386,7 @@ describe("DragDropPastePlugin", () => {
       />
     );
     await act(async () => {
-      commandHandler([new File(["a"], "a.png", { type: "image/png" })]);
+      dragDropPasteHandler([new File(["a"], "a.png", { type: "image/png" })]);
       await Promise.resolve();
     });
 
@@ -264,7 +423,7 @@ describe("DragDropPastePlugin", () => {
       />
     );
     await act(async () => {
-      commandHandler([new File(["a"], "a.png", { type: "image/png" })]);
+      dragDropPasteHandler([new File(["a"], "a.png", { type: "image/png" })]);
       await Promise.resolve();
     });
 
@@ -296,7 +455,7 @@ describe("DragDropPastePlugin", () => {
 
     renderPlugin();
     await act(async () => {
-      commandHandler([new File(["a"], "a.png", { type: "image/png" })]);
+      dragDropPasteHandler([new File(["a"], "a.png", { type: "image/png" })]);
       await Promise.resolve();
     });
 
@@ -326,7 +485,7 @@ describe("DragDropPastePlugin", () => {
       />
     );
     await act(async () => {
-      commandHandler([new File(["a"], "a.png", { type: "image/png" })]);
+      dragDropPasteHandler([new File(["a"], "a.png", { type: "image/png" })]);
       await Promise.resolve();
     });
 

--- a/__tests__/components/waves/CreateDropContent.identity.test.tsx
+++ b/__tests__/components/waves/CreateDropContent.identity.test.tsx
@@ -119,6 +119,7 @@ jest.mock("@/components/waves/CreateDropInput", () => {
   return {
     __esModule: true,
     default: ReactLib.forwardRef((props: any, ref: any) => {
+      const typedContentCountRef = ReactLib.useRef(0);
       ReactLib.useImperativeHandle(ref, () => ({
         clearEditorState: () => undefined,
         focus: () => undefined,
@@ -128,9 +129,24 @@ jest.mock("@/components/waves/CreateDropInput", () => {
         <div data-testid="input">
           <button
             type="button"
-            onClick={() => props.onEditorState({ __markdown: "typed content" })}
+            onClick={() => {
+              typedContentCountRef.current += 1;
+              props.onEditorState({
+                __markdown: `typed content ${typedContentCountRef.current}`,
+              });
+            }}
           >
             type content
+          </button>
+          <button
+            type="button"
+            onClick={() =>
+              props.onEditorState({
+                __markdown: "pending ![Seize](loading)",
+              })
+            }
+          >
+            type pending image
           </button>
           <button
             type="button"
@@ -316,10 +332,33 @@ describe("CreateDropContent identity picker flow", () => {
     });
   });
 
+  it("does not submit while an inline image upload is unresolved", async () => {
+    const submitDrop = jest.fn(() => true);
+    renderSubject({ isDropMode: false, submitDrop });
+
+    await userEvent.click(screen.getByText("type pending image"));
+    await userEvent.click(screen.getByText("submit"));
+
+    expect(mockRequestAuth).not.toHaveBeenCalled();
+    expect(submitDrop).not.toHaveBeenCalled();
+  });
+
+  it("does not submit a GIF while an inline image upload is unresolved", async () => {
+    const submitDrop = jest.fn(() => true);
+    renderSubject({ isDropMode: false, submitDrop });
+
+    await userEvent.click(screen.getByText("type pending image"));
+    await userEvent.click(screen.getByText("select gif"));
+
+    expect(mockRequestAuth).not.toHaveBeenCalled();
+    expect(submitDrop).not.toHaveBeenCalled();
+  });
+
   const baseWave = {
     id: "wave-1",
+    author: { handle: "creator" },
     wave: { type: ApiWaveType.Rank },
-    chat: { enabled: true },
+    chat: { enabled: true, links_disabled: false },
     participation: {
       submission_strategy: {
         config: {

--- a/components/drops/create/lexical/plugins/DragDropPastePlugin.tsx
+++ b/components/drops/create/lexical/plugins/DragDropPastePlugin.tsx
@@ -3,8 +3,15 @@
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { DRAG_DROP_PASTE } from "@lexical/rich-text";
 import { isMimeType, mediaFileReader } from "@lexical/utils";
-import type { EditorState } from "lexical";
-import { $getNodeByKey, $insertNodes, COMMAND_PRIORITY_LOW } from "lexical";
+import type { EditorState, RangeSelection } from "lexical";
+import {
+  $getSelection,
+  $getNodeByKey,
+  $insertNodes,
+  $isRangeSelection,
+  COMMAND_PRIORITY_LOW,
+  PASTE_COMMAND,
+} from "lexical";
 import { useEffect, useLayoutEffect, useRef } from "react";
 import { $createImageNode } from "../nodes/ImageNode";
 import { multiPartUpload } from "@/components/waves/create-wave/services/multiPartUpload";
@@ -23,6 +30,105 @@ const ACCEPTABLE_IMAGE_TYPES = [
 ];
 
 const INLINE_IMAGE_UPLOAD_TIMEOUT_MS = 30_000;
+const TEXT_HTML_MIME_TYPE = "text/html";
+const TEXT_PLAIN_MIME_TYPE = "text/plain";
+const DATA_IMAGE_URL_PATTERN =
+  /^data:(image\/[a-z0-9.+-]+);base64,([a-z0-9+/=\s]+)$/i;
+const NEWLINE_OR_TAB_REGEX = /(\r?\n|\t)/;
+
+interface ClipboardFiles {
+  readonly files: File[];
+  readonly hasHtmlDataImage: boolean;
+}
+
+function getFileExtension(mimeType: string): string {
+  switch (mimeType.toLowerCase()) {
+    case "image/jpeg":
+      return "jpg";
+    case "image/svg+xml":
+      return "svg";
+    default:
+      return mimeType.split("/")[1]?.replaceAll("+", "-") || "png";
+  }
+}
+
+function dataUrlToImageFile(dataUrl: string, index: number): File | null {
+  const match = DATA_IMAGE_URL_PATTERN.exec(dataUrl.trim());
+  if (!match || typeof globalThis.atob !== "function") {
+    return null;
+  }
+
+  const [, mimeType, base64] = match;
+  if (!mimeType || !base64) {
+    return null;
+  }
+
+  try {
+    const binary = globalThis.atob(base64.replaceAll(/\s/g, ""));
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+
+    return new File(
+      [bytes],
+      `pasted-image-${index}.${getFileExtension(mimeType)}`,
+      {
+        type: mimeType,
+      }
+    );
+  } catch {
+    return null;
+  }
+}
+
+function getHtmlDataImageFiles(html: string): File[] {
+  if (!html || typeof globalThis.document === "undefined") {
+    return [];
+  }
+
+  const template = globalThis.document.createElement("template");
+  template.innerHTML = html;
+
+  return Array.from(template.content.querySelectorAll("img"))
+    .map((image, index) =>
+      dataUrlToImageFile(image.getAttribute("src") ?? "", index)
+    )
+    .filter((file): file is File => file !== null);
+}
+
+function getDataTransferFiles(dataTransfer: DataTransfer): ClipboardFiles {
+  const files = Array.from(dataTransfer.files ?? []);
+  const seenFiles = new Set(files);
+
+  for (const item of Array.from(dataTransfer.items ?? [])) {
+    if (item.kind !== "file") {
+      continue;
+    }
+
+    const file = item.getAsFile();
+    if (file && !seenFiles.has(file)) {
+      seenFiles.add(file);
+      files.push(file);
+    }
+  }
+
+  const hasImageFile = files.some((file) =>
+    isMimeType(file, ACCEPTABLE_IMAGE_TYPES)
+  );
+  const htmlDataImageFiles = getHtmlDataImageFiles(
+    dataTransfer.getData(TEXT_HTML_MIME_TYPE)
+  );
+
+  if (!hasImageFile && htmlDataImageFiles.length > 0) {
+    files.push(...htmlDataImageFiles);
+  }
+
+  return {
+    files,
+    hasHtmlDataImage: htmlDataImageFiles.length > 0,
+  };
+}
 
 function isAcceptableAttachment(file: File): boolean {
   return (
@@ -50,6 +156,52 @@ function withTimeout<T>(
       globalThis.clearTimeout(timeoutId);
     }
   });
+}
+
+function insertRangeSelectionText(
+  selection: RangeSelection,
+  text: string
+): void {
+  const parts = text.split(NEWLINE_OR_TAB_REGEX);
+  if (parts[parts.length - 1] === "") {
+    parts.pop();
+  }
+
+  for (const part of parts) {
+    if (part === "\n" || part === "\r\n") {
+      selection.insertParagraph();
+      continue;
+    }
+
+    if (part === "\t") {
+      selection.insertText(part);
+      continue;
+    }
+
+    if (part.length === 0) {
+      continue;
+    }
+
+    selection.insertText(part);
+  }
+}
+
+function insertPlainText(text: string): void {
+  if (!text.length) {
+    return;
+  }
+
+  const selection = $getSelection();
+  if (!selection) {
+    return;
+  }
+
+  if ($isRangeSelection(selection)) {
+    insertRangeSelectionText(selection, text);
+    return;
+  }
+
+  selection.insertRawText(text);
 }
 
 async function uploadImage(file: File): Promise<string> {
@@ -100,104 +252,148 @@ export default function DragDropPaste({
       onUploadEditorStateChangeRef.current?.(editor.getEditorState());
     };
 
-    const unregister = editor.registerCommand(
+    const processFiles = (files: File[], plainText = "") => {
+      void (async () => {
+        const filesResult = await mediaFileReader(
+          files,
+          [ACCEPTABLE_IMAGE_TYPES].flatMap((x) => x)
+        );
+
+        if (disabledRef.current || !isMounted) {
+          return;
+        }
+
+        const currentOnAttachmentFiles = onAttachmentFilesRef.current;
+        const attachmentFiles = currentOnAttachmentFiles
+          ? files.filter(isAcceptableAttachment)
+          : [];
+
+        if (attachmentFiles.length > 0) {
+          currentOnAttachmentFiles?.(attachmentFiles);
+        }
+
+        if (filesResult.length === 0 && attachmentFiles.length === 0) {
+          setToast({
+            message: `Unsupported file type. Accepted Types: ${ACCEPTED_FILE_TYPE_LABELS}`,
+            type: "error",
+          });
+          return;
+        }
+
+        for (const { file } of filesResult) {
+          if (isMimeType(file, ACCEPTABLE_IMAGE_TYPES)) {
+            editor.update(() => {
+              const imageNode = $createImageNode({ src: "loading" });
+              $insertNodes([imageNode]);
+              const key = imageNode.getKey();
+              uploadImage(file)
+                .then((url: string) => {
+                  if (!isMounted) return;
+                  let replacedLoadingImage = false;
+                  editor.update(
+                    () => {
+                      const node = $getNodeByKey(key);
+                      if (node) {
+                        node.replace($createImageNode({ src: url }));
+                        replacedLoadingImage = true;
+                      }
+                    },
+                    {
+                      onUpdate: () => {
+                        if (replacedLoadingImage) {
+                          syncUploadEditorStateWhenDisabled();
+                        }
+                      },
+                    }
+                  );
+                })
+                .catch((err: unknown) => {
+                  if (!isMounted) return;
+                  let removedLoadingImage = false;
+                  editor.update(
+                    () => {
+                      const node = $getNodeByKey(key);
+                      if (node) {
+                        node.remove();
+                        removedLoadingImage = true;
+                      }
+                    },
+                    {
+                      onUpdate: () => {
+                        if (removedLoadingImage) {
+                          syncUploadEditorStateWhenDisabled();
+                        }
+                      },
+                    }
+                  );
+                  setToast({
+                    message:
+                      err instanceof Error
+                        ? err.message
+                        : "Error uploading image. Please try again.",
+                    type: "error",
+                  });
+                });
+            });
+          }
+        }
+
+        if (plainText) {
+          editor.update(() => {
+            insertPlainText(plainText);
+          });
+        }
+      })();
+    };
+
+    const unregisterPaste = editor.registerCommand<ClipboardEvent>(
+      PASTE_COMMAND,
+      (event) => {
+        const clipboardData = event.clipboardData;
+        if (!clipboardData) {
+          return false;
+        }
+
+        const clipboardFiles = getDataTransferFiles(clipboardData);
+        if (!clipboardFiles.hasHtmlDataImage) {
+          return false;
+        }
+
+        if (clipboardFiles.files.length === 0) {
+          return false;
+        }
+
+        event.preventDefault();
+
+        if (disabledRef.current) {
+          return true;
+        }
+
+        processFiles(
+          clipboardFiles.files,
+          clipboardData.getData(TEXT_PLAIN_MIME_TYPE)
+        );
+        return true;
+      },
+      COMMAND_PRIORITY_LOW
+    );
+
+    const unregisterDragDropPaste = editor.registerCommand(
       DRAG_DROP_PASTE,
       (files) => {
         if (disabledRef.current) {
           return true;
         }
 
-        void (async () => {
-          const filesResult = await mediaFileReader(
-            files,
-            [ACCEPTABLE_IMAGE_TYPES].flatMap((x) => x)
-          );
-
-          if (disabledRef.current || !isMounted) {
-            return;
-          }
-
-          const currentOnAttachmentFiles = onAttachmentFilesRef.current;
-          const attachmentFiles = currentOnAttachmentFiles
-            ? files.filter(isAcceptableAttachment)
-            : [];
-
-          if (attachmentFiles.length > 0) {
-            currentOnAttachmentFiles?.(attachmentFiles);
-          }
-
-          if (filesResult.length === 0 && attachmentFiles.length === 0) {
-            setToast({
-              message: `Unsupported file type. Accepted Types: ${ACCEPTED_FILE_TYPE_LABELS}`,
-              type: "error",
-            });
-            return;
-          }
-          for (const { file } of filesResult) {
-            if (isMimeType(file, ACCEPTABLE_IMAGE_TYPES)) {
-              editor.update(() => {
-                const imageNode = $createImageNode({ src: "loading" });
-                $insertNodes([imageNode]);
-                const key = imageNode.getKey();
-                uploadImage(file)
-                  .then((url: string) => {
-                    if (!isMounted) return;
-                    let replacedLoadingImage = false;
-                    editor.update(
-                      () => {
-                        const node = $getNodeByKey(key);
-                        if (node) {
-                          node.replace($createImageNode({ src: url }));
-                          replacedLoadingImage = true;
-                        }
-                      },
-                      {
-                        onUpdate: () => {
-                          if (replacedLoadingImage) {
-                            syncUploadEditorStateWhenDisabled();
-                          }
-                        },
-                      }
-                    );
-                  })
-                  .catch((err: unknown) => {
-                    if (!isMounted) return;
-                    let removedLoadingImage = false;
-                    editor.update(
-                      () => {
-                        const node = $getNodeByKey(key);
-                        if (node) {
-                          node.remove();
-                          removedLoadingImage = true;
-                        }
-                      },
-                      {
-                        onUpdate: () => {
-                          if (removedLoadingImage) {
-                            syncUploadEditorStateWhenDisabled();
-                          }
-                        },
-                      }
-                    );
-                    setToast({
-                      message:
-                        err instanceof Error
-                          ? err.message
-                          : "Error uploading image. Please try again.",
-                      type: "error",
-                    });
-                  });
-              });
-            }
-          }
-        })();
+        processFiles(files);
         return true;
       },
       COMMAND_PRIORITY_LOW
     );
 
     return () => {
-      unregister();
+      unregisterPaste();
+      unregisterDragDropPaste();
       isMounted = false;
     };
   }, [editor, setToast]);

--- a/components/waves/CreateDropContent.tsx
+++ b/components/waves/CreateDropContent.tsx
@@ -91,6 +91,10 @@ import {
   hasCurrentDropPartContent,
   shouldUseInitialDropConfig,
 } from "./utils/createDropContentSubmission";
+import {
+  hasPendingInlineImageUploadDrop,
+  hasPendingInlineImageUploadMarkdown,
+} from "@/helpers/waves/inline-image-upload.helpers";
 import type { MissingRequirements } from "./utils/getMissingRequirements";
 import { getMissingRequirements } from "./utils/getMissingRequirements";
 import { getOptimisticDrop } from "./utils/getOptimisticDrop";
@@ -803,6 +807,13 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
     return true;
   };
 
+  const hasPendingInlineImageUpload = useMemo(
+    () =>
+      hasPendingInlineImageUploadMarkdown(getMarkdown) ||
+      (drop ? hasPendingInlineImageUploadDrop(drop) : false),
+    [drop, getMarkdown]
+  );
+
   const getCanSubmit = () => {
     const dropParts = drop?.parts ?? [];
 
@@ -814,6 +825,7 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
         hasMetadata,
         hasPoll: hasValidPoll,
       }) &&
+      !hasPendingInlineImageUpload &&
       !hasMetadataValidationErrors &&
       !hasPollValidationError &&
       !!(dropParts.length ? getCanSubmitStorm() : true)
@@ -828,7 +840,10 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
       getMarkdown?.length ?? 0
     ) ?? 0) >= 24000;
 
-  const getCanAddPart = () => getHaveMarkdownOrFile() && !getIsDropLimit();
+  const getCanAddPart = () =>
+    getHaveMarkdownOrFile() &&
+    !hasPendingInlineImageUpload &&
+    !getIsDropLimit();
   const isSlowModeSubmitBlocked = isChatBlockedBySlowMode && !isDropMode;
   const isChatLinksRestrictionActive = isChatLinkRestrictionApplicable({
     dropType: ApiDropType.Chat,
@@ -1462,6 +1477,10 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
       return;
     }
 
+    if (hasPendingInlineImageUpload) {
+      return;
+    }
+
     if (isSlowModeSubmitBlocked) {
       return;
     }
@@ -1511,6 +1530,9 @@ const CreateDropContent: React.FC<CreateDropContentProps> = ({
 
   const onGifDrop = async (gif: string): Promise<void> => {
     if (submitting) {
+      return;
+    }
+    if (hasPendingInlineImageUpload) {
       return;
     }
     if (identityValidationMessage) {

--- a/helpers/waves/inline-image-upload.helpers.ts
+++ b/helpers/waves/inline-image-upload.helpers.ts
@@ -1,11 +1,14 @@
 import type { CreateDropConfig } from "@/entities/IDrop";
 
 const INLINE_IMAGE_UPLOAD_MARKDOWN_PLACEHOLDER = "![Seize](loading)";
+const INLINE_IMAGE_DATA_URL_MARKDOWN_PATTERN =
+  /!\[[^\]]*\]\(data:image\/[a-z0-9.+-]+;base64,[^)]+\)/i;
 
 export const hasPendingInlineImageUploadMarkdown = (
   content: string | null | undefined
 ): boolean =>
-  content?.includes(INLINE_IMAGE_UPLOAD_MARKDOWN_PLACEHOLDER) ?? false;
+  Boolean(content?.includes(INLINE_IMAGE_UPLOAD_MARKDOWN_PLACEHOLDER)) ||
+  INLINE_IMAGE_DATA_URL_MARKDOWN_PATTERN.test(content ?? "");
 
 export const hasPendingInlineImageUploadDrop = (
   drop: Pick<CreateDropConfig, "parts">


### PR DESCRIPTION
## What changed
- Intercept screenshot/image paste events in the wave editor and upload pasted image files before inserting markdown.
- Decode pasted HTML data-image screenshots into files when the clipboard has no direct `File` entry.
- Block submit/add-part while inline image upload placeholders or data-image markdown are still pending.
- Add regressions for pasted data-image upload and pending-image submit blocking.

## Why
Pasting a screenshot-only clipboard could insert a large `data:image/...;base64,...` markdown URL directly into the drop. Submitting that content tripped the API content length guard (`32768` chars) before the image had a chance to become an uploaded attachment.

## Checks
- `seize run test:no-coverage -- __tests__/components/DragDropPastePlugin.test.tsx --runInBand`
- `seize run test:no-coverage -- __tests__/components/waves/CreateDropContent.identity.test.tsx --runInBand`
- `seize exec eslint --quiet --no-warn-ignored __tests__/components/DragDropPastePlugin.test.tsx __tests__/components/waves/CreateDropContent.identity.test.tsx components/drops/create/lexical/plugins/DragDropPastePlugin.tsx components/waves/CreateDropContent.tsx helpers/waves/inline-image-upload.helpers.ts`
- `codex-diff-check -- __tests__/components/DragDropPastePlugin.test.tsx __tests__/components/waves/CreateDropContent.identity.test.tsx components/drops/create/lexical/plugins/DragDropPastePlugin.tsx components/waves/CreateDropContent.tsx helpers/waves/inline-image-upload.helpers.ts`
- `seize run typecheck:changed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for pasting HTML content with embedded images directly into the editor.

* **Improvements**
  * Prevents submitting or adding new parts while inline image uploads are in progress, ensuring complete content saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->