### PR TITLE
[codex] Improve wave score network UX

### DIFF
--- a/__tests__/app/networkPages.test.tsx
+++ b/__tests__/app/networkPages.test.tsx
@@ -7,6 +7,9 @@ import GroupsPage, {
 import TDHPage, {
   generateMetadata as generateTDHMetadata,
 } from "@/app/network/tdh/page";
+import NetworkWaveScorePage, {
+  generateMetadata as generateWaveScoreMetadata,
+} from "@/app/network/wave-score/page";
 import { AuthContext } from "@/components/auth/Auth";
 import { render, screen } from "@testing-library/react";
 import React from "react";
@@ -89,6 +92,18 @@ describe("network pages render", () => {
     expect(screen.getByText(/Unique Memes/i)).toBeInTheDocument();
   });
 
+  it("renders Wave Score page in Network", () => {
+    renderWithAuth(<NetworkWaveScorePage />);
+    expect(
+      screen.getByRole("heading", { level: 1, name: /Wave score transparency/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Network menu / Wave Score")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Calculate a wave" })
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Quality").length).toBeGreaterThan(0);
+  });
+
   it("generates metadata for Groups page", async () => {
     const metadata = await generateGroupsMetadata();
     expect(metadata.title).toEqual("Groups");
@@ -105,5 +120,13 @@ describe("network pages render", () => {
     const metadata = await generateDefinitionsMetadata();
     expect(metadata.title).toEqual("Definitions");
     expect(metadata.description).toEqual("Network | 6529.io");
+  });
+
+  it("generates metadata for Wave Score page", async () => {
+    const metadata = await generateWaveScoreMetadata();
+    expect(metadata.title).toEqual("Wave Score");
+    expect(metadata.description).toEqual(
+      "Network wave score formula and calculator | 6529.io"
+    );
   });
 });

--- a/__tests__/components/header/AppSidebar.test.tsx
+++ b/__tests__/components/header/AppSidebar.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { render } from "@testing-library/react";
 import AppSidebar from "@/components/header/AppSidebar";
+import { DEFAULT_DROP_FORGE_PERMISSIONS } from "../../helpers/dropForgePermissions";
 
 let headerProps: any = null;
 let menuProps: any = null;
@@ -20,6 +21,9 @@ jest.mock("@/components/header/AppUserConnect", () => (props: any) => {
 });
 
 jest.mock("@/components/app-wallets/AppWalletsContext");
+jest.mock("@/hooks/useDropForgePermissions", () => ({
+  useDropForgePermissions: () => ({ ...DEFAULT_DROP_FORGE_PERMISSIONS }),
+}));
 
 ((describe) => {
   const {
@@ -49,8 +53,19 @@ jest.mock("@/components/app-wallets/AppWalletsContext");
       expect(networkChildren).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ label: "xTDH", path: "/xtdh" }),
+          expect.objectContaining({
+            label: "Wave Score",
+            path: "/network/wave-score",
+          }),
         ])
       );
+      const xtdhIndex = networkChildren.findIndex(
+        (child: any) => child.label === "xTDH"
+      );
+      const waveScoreIndex = networkChildren.findIndex(
+        (child: any) => child.label === "Wave Score"
+      );
+      expect(waveScoreIndex).toBe(xtdhIndex + 1);
       expect(
         menuProps.menu.find((m: any) => m.label === "Tools").children[0]
       ).toEqual({ label: "App Wallets", path: "/tools/app-wallets" });

--- a/__tests__/components/header/HeaderSearchModal.test.tsx
+++ b/__tests__/components/header/HeaderSearchModal.test.tsx
@@ -21,17 +21,16 @@ const useSidebarSectionsMock = jest.fn();
 const capacitorMock = jest.fn();
 const useDropForgePermissionsMock = jest.fn();
 const originalScrollIntoView = Element.prototype.scrollIntoView;
+const originalHtmlScrollIntoView = HTMLElement.prototype.scrollIntoView;
 
 beforeAll(() => {
   Element.prototype.scrollIntoView = jest.fn();
+  HTMLElement.prototype.scrollIntoView = jest.fn();
 });
 
 afterAll(() => {
   Element.prototype.scrollIntoView = originalScrollIntoView;
-});
-
-beforeAll(() => {
-  HTMLElement.prototype.scrollIntoView = jest.fn();
+  HTMLElement.prototype.scrollIntoView = originalHtmlScrollIntoView;
 });
 
 jest.mock("react-use", () => {

--- a/__tests__/components/header/HeaderSearchModal.test.tsx
+++ b/__tests__/components/header/HeaderSearchModal.test.tsx
@@ -30,6 +30,10 @@ afterAll(() => {
   Element.prototype.scrollIntoView = originalScrollIntoView;
 });
 
+beforeAll(() => {
+  HTMLElement.prototype.scrollIntoView = jest.fn();
+});
+
 jest.mock("react-use", () => {
   return {
     createBreakpoint: () => () => "MD",
@@ -112,6 +116,16 @@ jest.mock("@/components/header/header-search/HeaderSearchModalItem", () => {
 const profile = { handle: "alice", wallet: "0x1", display: "Alice", level: 1 };
 
 const defaultSidebarSections = [
+  {
+    key: "network",
+    name: "Network",
+    icon: () => null,
+    items: [
+      { name: "xTDH", href: "/xtdh" },
+      { name: "Wave Score", href: "/network/wave-score" },
+    ],
+    subsections: [],
+  },
   {
     key: "tools",
     name: "Tools",
@@ -293,6 +307,24 @@ describe("HeaderSearchModal", () => {
       .map((element) => element.textContent ?? "");
     expect(
       renderedItems.some((content) => content.includes('"type":"PAGE"'))
+    ).toBe(true);
+  });
+
+  it("finds the Network Wave Score page by formula aliases", () => {
+    setup();
+    const input = screen.getByRole("textbox", { name: "Search" });
+    fireEvent.change(input, { target: { value: "wave rep formula" } });
+
+    const renderedItems = screen
+      .getAllByTestId("item")
+      .map((element) => element.textContent ?? "");
+    expect(
+      renderedItems.some(
+        (content) =>
+          content.includes('"title":"Wave Score"') &&
+          content.includes('"/network/wave-score"') &&
+          content.includes('"breadcrumbs":["Network"]')
+      )
     ).toBe(true);
   });
 

--- a/__tests__/components/waves/WaveTrustSignals.test.tsx
+++ b/__tests__/components/waves/WaveTrustSignals.test.tsx
@@ -41,19 +41,61 @@ describe("WaveTrustSignals", () => {
     expect(summaryBadge).not.toBeNull();
     expect(summaryBadge).toHaveAttribute(
       "aria-label",
-      expect.stringContaining("Combined score: 83. Quality: 78. Hotness: 92.")
+      expect.stringContaining(
+        "Combined score: 83. A quick signal for which waves deserve broad attention. Quality: 78 (65% of visibility). Hotness: 92 (gated, 35% of visibility)."
+      )
     );
     expect(summaryBadge?.getAttribute("aria-label")).toMatch(
-      /^Combined score: 83\. Quality: 78\. Hotness: 92\. REP: .+ raw, 41 score$/
+      /^Combined score: 83\. A quick signal for which waves deserve broad attention\. Quality: 78 \(65% of visibility\)\. Hotness: 92 \(gated, 35% of visibility\)\. REP: .+ raw, 41 score\. Open Network > Wave Score for the formula$/
     );
-    expect(summaryBadge).toHaveAttribute(
-      "title",
-      expect.stringContaining("Combined score: 83\nQuality: 78\nHotness: 92")
-    );
+    expect(summaryBadge).not.toHaveAttribute("title");
     expect(screen.getByText("Score")).toBeInTheDocument();
     expect(screen.getByText("83")).toBeInTheDocument();
     expect(screen.queryByText("Hot")).not.toBeInTheDocument();
     expect(screen.queryByText("REP")).not.toBeInTheDocument();
+  });
+
+  it("renders a dark learn-more popover when requested", () => {
+    render(
+      <WaveTrustSignals
+        waveRep={waveRep}
+        waveScore={waveScore}
+        variant="header-inline"
+        mode="summary"
+        learnMoreHref="/network/wave-score"
+      />
+    );
+
+    const summaryBadge = screen.getByText("Score").closest("[aria-label]");
+
+    expect(summaryBadge).not.toBeNull();
+    expect(summaryBadge).toHaveAttribute("tabindex", "0");
+    expect(summaryBadge).not.toHaveAttribute("title");
+    expect(
+      screen.getByRole("link", { name: "Learn how wave score works" })
+    ).toHaveAttribute("href", "/network/wave-score");
+    expect(
+      screen.getByText("A quick signal for which waves deserve broad attention")
+    ).toBeInTheDocument();
+  });
+
+  it("does not attach hover tooltip content in sidebar summary mode", () => {
+    render(
+      <WaveTrustSignals
+        waveRep={waveRep}
+        waveScore={waveScore}
+        variant="sidebar-inline"
+        mode="summary"
+        tooltipId="wave-score-tooltip"
+      />
+    );
+
+    const summaryBadge = screen.getByText("Score").closest("[aria-label]");
+
+    expect(summaryBadge).not.toBeNull();
+    expect(summaryBadge).not.toHaveAttribute("data-tooltip-content");
+    expect(summaryBadge).not.toHaveAttribute("data-tooltip-id");
+    expect(summaryBadge).not.toHaveAttribute("title");
   });
 
   it("renders nothing in summary mode without a combined score", () => {

--- a/__tests__/components/waves/WaveTrustSignals.test.tsx
+++ b/__tests__/components/waves/WaveTrustSignals.test.tsx
@@ -69,11 +69,13 @@ describe("WaveTrustSignals", () => {
     const summaryBadge = screen.getByText("Score").closest("[aria-label]");
 
     expect(summaryBadge).not.toBeNull();
-    expect(summaryBadge).toHaveAttribute("tabindex", "0");
     expect(summaryBadge).not.toHaveAttribute("title");
     expect(
-      screen.getByRole("link", { name: "Learn how wave score works" })
+      screen.getByRole("link", { name: /^Combined score: 83\./ })
     ).toHaveAttribute("href", "/network/wave-score");
+    expect(
+      screen.getByText("Click score to open the full formula")
+    ).toBeInTheDocument();
     expect(
       screen.getByText("A quick signal for which waves deserve broad attention")
     ).toBeInTheDocument();

--- a/__tests__/components/waves/header/WaveHeader.test.tsx
+++ b/__tests__/components/waves/header/WaveHeader.test.tsx
@@ -209,4 +209,21 @@ describe("WaveHeader", () => {
       options.compareDocumentPosition(pin) & Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
   });
+
+  it("shows a visible Add REP action for eligible non-author waves", () => {
+    wrapper(
+      {
+        ...baseWave,
+        wave_rep: { total_rep: 1250 },
+      },
+      undefined,
+      { connectedProfile: { handle: "alice" } }
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Add or edit Wave REP/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Add REP")).toBeInTheDocument();
+    expect(screen.getByText("1.3K")).toBeInTheDocument();
+  });
 });

--- a/__tests__/hooks/useSidebarSections.test.ts
+++ b/__tests__/hooks/useSidebarSections.test.ts
@@ -2,7 +2,7 @@ import { renderHook } from "@testing-library/react";
 import { useSidebarSections } from "@/hooks/useSidebarSections";
 
 describe("useSidebarSections", () => {
-  it("places xTDH under Network and removes it from Collections", () => {
+  it("places xTDH and Wave Score under Network and removes xTDH from Collections", () => {
     const { result } = renderHook(() => useSidebarSections(false, false, "US"));
 
     const networkSection = result.current.find(
@@ -19,6 +19,18 @@ describe("useSidebarSections", () => {
         (item) => item.name === "xTDH" && item.href === "/xtdh"
       )
     ).toBe(true);
+    expect(
+      networkSection?.items.some(
+        (item) =>
+          item.name === "Wave Score" && item.href === "/network/wave-score"
+      )
+    ).toBe(true);
+    const xtdhIndex =
+      networkSection?.items.findIndex((item) => item.name === "xTDH") ?? -1;
+    const waveScoreIndex =
+      networkSection?.items.findIndex((item) => item.name === "Wave Score") ??
+      -1;
+    expect(waveScoreIndex).toBe(xtdhIndex + 1);
     expect(
       networkSection?.items.some(
         (item) => item.name === "xTDH" && item.href === "/network/xtdh"

--- a/app/network/wave-score/page.tsx
+++ b/app/network/wave-score/page.tsx
@@ -2,7 +2,7 @@ import { getAppMetadata } from "@/components/providers/metadata";
 import { WaveScoreTransparencyPage } from "@/components/waves/discovery/WaveScoreTransparencyPage";
 import type { Metadata } from "next";
 
-export default function DiscoverWaveScorePage() {
+export default function NetworkWaveScorePage() {
   return (
     <main className="tailwind-scope tw-min-h-screen tw-bg-black">
       <WaveScoreTransparencyPage />
@@ -13,6 +13,6 @@ export default function DiscoverWaveScorePage() {
 export function generateMetadata(): Metadata {
   return getAppMetadata({
     title: "Wave Score",
-    description: "Wave score formula and calculator",
+    description: "Network wave score formula and calculator",
   });
 }

--- a/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
+++ b/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
@@ -32,6 +32,7 @@ import MyStreamActionTooltip from "../MyStreamActionTooltip";
 import { useSidebarState } from "../../../../hooks/useSidebarState";
 
 const TRUNCATION_EPSILON_PX = 1;
+const WAVE_SCORE_LEARN_MORE_HREF = "/network/wave-score";
 
 export interface MyStreamWaveTabsHeaderActionContext {
   readonly activeContentTab: MyStreamWaveTab;
@@ -141,7 +142,7 @@ function MyStreamWaveHeaderIdentity({
                   <h1 className="tw-mb-0 tw-w-full tw-truncate tw-text-sm tw-font-semibold tw-tracking-tight tw-text-white/95 lg:tw-text-xl">
                     {wave.name}
                   </h1>
-                  <span className="tw-mt-0.5 tw-flex tw-w-full tw-min-w-0 tw-items-center tw-gap-x-6">
+                  <span className="tw-mt-0.5 tw-flex tw-w-full tw-min-w-0 tw-items-center tw-gap-x-1.5">
                     <span
                       ref={descriptionPreviewRef}
                       className="tw-min-w-0 tw-truncate tw-text-xs tw-font-normal tw-text-iron-400 tw-transition-colors tw-duration-300 group-hover:tw-text-iron-300"
@@ -154,17 +155,20 @@ function MyStreamWaveHeaderIdentity({
                         className="tw-h-4 tw-w-4 tw-flex-shrink-0 tw-text-iron-300 tw-transition-colors group-hover:tw-text-white"
                       />
                     )}
-                    <WaveTrustSignals
-                      waveRep={wave.wave_rep}
-                      waveScore={wave.wave_score}
-                      variant="header-inline"
-                      mode="summary"
-                      className="tw-shrink-0"
-                    />
                   </span>
                 </>
               )}
             </WaveDescriptionPopover>
+            {!isCompact && (
+              <WaveTrustSignals
+                waveRep={wave.wave_rep}
+                waveScore={wave.wave_score}
+                variant="header-inline"
+                mode="summary"
+                className="tw-mt-1 tw-self-start"
+                learnMoreHref={WAVE_SCORE_LEARN_MORE_HREF}
+              />
+            )}
             {isCompact && (
               <WaveTrustSignals
                 waveRep={wave.wave_rep}
@@ -172,6 +176,7 @@ function MyStreamWaveHeaderIdentity({
                 variant="header-inline"
                 mode="summary"
                 className="tw-mt-1"
+                learnMoreHref={WAVE_SCORE_LEARN_MORE_HREF}
               />
             )}
           </>
@@ -186,6 +191,7 @@ function MyStreamWaveHeaderIdentity({
               variant="header-inline"
               mode="summary"
               className="tw-mt-1"
+              learnMoreHref={WAVE_SCORE_LEARN_MORE_HREF}
             />
           </>
         )}

--- a/components/header/AppSidebar.tsx
+++ b/components/header/AppSidebar.tsx
@@ -40,6 +40,7 @@ const MENU: SidebarMenu = [
       { label: "Memes Calendar", path: "/meme-calendar" },
       { label: "TDH", path: "/network/tdh" },
       { label: "xTDH", path: "/xtdh" },
+      { label: "Wave Score", path: "/network/wave-score" },
       { label: "Metrics", section: true },
       { label: "Health", path: "/network/health" },
       { label: "Definitions", path: "/network/definitions" },

--- a/components/header/header-search/HeaderSearchModal.tsx
+++ b/components/header/header-search/HeaderSearchModal.tsx
@@ -121,8 +121,8 @@ const PRIMARY_NAVIGATION_PAGES: SidebarPageEntry[] = [
   },
   {
     name: "Wave Score",
-    href: "/discover/wave-score",
-    section: "Discovery",
+    href: "/network/wave-score",
+    section: "Network",
     icon: ScaleIcon,
   },
   {
@@ -559,9 +559,10 @@ const PAGE_SEARCH_ALIASES_BY_HREF: Record<string, string[]> = {
   [DROP_FORGE_PATH]: [DROP_FORGE_TITLE],
   [DROP_FORGE_SECTIONS.CRAFT.path]: [`${DROP_FORGE_TITLE} Craft`],
   [DROP_FORGE_SECTIONS.LAUNCH.path]: [`${DROP_FORGE_TITLE} Launch`],
-  "/discover/wave-score": [
+  "/network/wave-score": [
     "Wave scoring",
     "Wave score formula",
+    "Wave score calculator",
     "Visibility score",
     "Hotness score",
     "Wave REP formula",

--- a/components/waves/WaveTrustSignals.tsx
+++ b/components/waves/WaveTrustSignals.tsx
@@ -101,55 +101,69 @@ const isSidebarVariant = (variant: WaveTrustSignalsVariant): boolean =>
 const INLINE_STAT_TONE_CLASSES =
   "tw-text-[#e2e8f0]/[0.85] desktop-hover:hover:tw-text-[#e2e8f0]/[0.95]";
 
+type VisibilityTone = "excellent" | "healthy" | "low" | "default";
+type VisibilityToneContext = "inline-sidebar" | "inline-header" | "default";
+
+const VISIBILITY_TONE_CLASSES: Record<
+  VisibilityToneContext,
+  Record<VisibilityTone, string>
+> = {
+  "inline-sidebar": {
+    excellent: "tw-text-emerald-300 desktop-hover:hover:tw-text-emerald-200",
+    healthy: "tw-text-amber-300 desktop-hover:hover:tw-text-amber-200",
+    low: "tw-text-rose-300 desktop-hover:hover:tw-text-rose-200",
+    default: INLINE_STAT_TONE_CLASSES,
+  },
+  "inline-header": {
+    excellent: "tw-text-emerald-400 desktop-hover:hover:tw-text-emerald-300",
+    healthy: "tw-text-amber-400 desktop-hover:hover:tw-text-amber-300",
+    low: "tw-text-rose-400 desktop-hover:hover:tw-text-rose-300",
+    default: "tw-text-primary-300 desktop-hover:hover:tw-text-[#A8C4FF]",
+  },
+  default: {
+    excellent:
+      "tw-bg-emerald-500/10 tw-text-emerald-200 tw-ring-emerald-400/25",
+    healthy: "tw-bg-amber-500/10 tw-text-amber-200 tw-ring-amber-400/25",
+    low: "tw-bg-rose-500/10 tw-text-rose-200 tw-ring-rose-400/25",
+    default: "tw-bg-sky-500/10 tw-text-sky-200 tw-ring-sky-400/25",
+  },
+};
+
+const getVisibilityTone = (
+  value: number | null | undefined
+): VisibilityTone => {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return "default";
+  }
+
+  if (value >= 85) {
+    return "excellent";
+  }
+
+  if (value >= 65) {
+    return "healthy";
+  }
+
+  return value < 35 ? "low" : "default";
+};
+
+const getVisibilityToneContext = (
+  variant: WaveTrustSignalsVariant
+): VisibilityToneContext => {
+  if (isInlineSidebarVariant(variant)) {
+    return "inline-sidebar";
+  }
+
+  return isInlineHeaderVariant(variant) ? "inline-header" : "default";
+};
+
 const getVisibilityToneClasses = (
   variant: WaveTrustSignalsVariant,
   value: number | null | undefined
-): string => {
-  const numericValue =
-    value !== null && value !== undefined && Number.isFinite(value)
-      ? value
-      : null;
-
-  if (isInlineSidebarVariant(variant)) {
-    if (numericValue !== null && numericValue >= 85) {
-      return "tw-text-emerald-300 desktop-hover:hover:tw-text-emerald-200";
-    }
-    if (numericValue !== null && numericValue >= 65) {
-      return "tw-text-amber-300 desktop-hover:hover:tw-text-amber-200";
-    }
-    if (numericValue !== null && numericValue < 35) {
-      return "tw-text-rose-300 desktop-hover:hover:tw-text-rose-200";
-    }
-
-    return INLINE_STAT_TONE_CLASSES;
-  }
-
-  if (isInlineHeaderVariant(variant)) {
-    if (numericValue !== null && numericValue >= 85) {
-      return "tw-text-emerald-400 desktop-hover:hover:tw-text-emerald-300";
-    }
-    if (numericValue !== null && numericValue >= 65) {
-      return "tw-text-amber-400 desktop-hover:hover:tw-text-amber-300";
-    }
-    if (numericValue !== null && numericValue < 35) {
-      return "tw-text-rose-400 desktop-hover:hover:tw-text-rose-300";
-    }
-
-    return "tw-text-primary-300 desktop-hover:hover:tw-text-[#A8C4FF]";
-  }
-
-  if (numericValue !== null && numericValue >= 85) {
-    return "tw-bg-emerald-500/10 tw-text-emerald-200 tw-ring-emerald-400/25";
-  }
-  if (numericValue !== null && numericValue >= 65) {
-    return "tw-bg-amber-500/10 tw-text-amber-200 tw-ring-amber-400/25";
-  }
-  if (numericValue !== null && numericValue < 35) {
-    return "tw-bg-rose-500/10 tw-text-rose-200 tw-ring-rose-400/25";
-  }
-
-  return "tw-bg-sky-500/10 tw-text-sky-200 tw-ring-sky-400/25";
-};
+): string =>
+  VISIBILITY_TONE_CLASSES[getVisibilityToneContext(variant)][
+    getVisibilityTone(value)
+  ];
 
 const getHotnessToneClasses = (variant: WaveTrustSignalsVariant): string => {
   if (isInlineSidebarVariant(variant)) {
@@ -363,32 +377,29 @@ const buildSummaryDetails = ({
   readonly hotnessScore: string | null;
   readonly repSortScore: string | null;
   readonly waveRep: ApiWaveRepSummary | null | undefined;
-}) => {
-  const details = [
+}): string[] => {
+  const rawRep = formatSignedFullNumber(waveRep?.total_rep);
+  const repDetail =
+    rawRep !== null && repSortScore !== null
+      ? `REP: ${rawRep} raw, ${repSortScore} score`
+      : rawRep !== null
+        ? `REP: ${rawRep} raw`
+        : repSortScore !== null
+          ? `REP score: ${repSortScore}`
+          : null;
+
+  return [
     `Combined score: ${visibilityScore}`,
     "A quick signal for which waves deserve broad attention",
+    ...(qualityScore === null
+      ? []
+      : [`Quality: ${qualityScore} (65% of visibility)`]),
+    ...(hotnessScore === null
+      ? []
+      : [`Hotness: ${hotnessScore} (gated, 35% of visibility)`]),
+    ...(repDetail === null ? [] : [repDetail]),
+    WAVE_SCORE_FORMULA_HINT,
   ];
-
-  if (qualityScore !== null) {
-    details.push(`Quality: ${qualityScore} (65% of visibility)`);
-  }
-
-  if (hotnessScore !== null) {
-    details.push(`Hotness: ${hotnessScore} (gated, 35% of visibility)`);
-  }
-
-  const rawRep = formatSignedFullNumber(waveRep?.total_rep);
-  if (rawRep !== null && repSortScore !== null) {
-    details.push(`REP: ${rawRep} raw, ${repSortScore} score`);
-  } else if (rawRep !== null) {
-    details.push(`REP: ${rawRep} raw`);
-  } else if (repSortScore !== null) {
-    details.push(`REP score: ${repSortScore}`);
-  }
-
-  details.push(WAVE_SCORE_FORMULA_HINT);
-
-  return details;
 };
 
 const buildHotnessDetails = ({
@@ -398,17 +409,15 @@ const buildHotnessDetails = ({
   readonly hotnessScore: string;
   readonly qualityScore: string | null;
 }): string[] => {
-  const details = [`Hotness score: ${hotnessScore}`];
-
-  if (qualityScore !== null) {
-    details.push(`Quality input: ${qualityScore} (35% of hotness)`);
-  }
-
-  details.push("Recent trusted activity carries the other 65%");
-  details.push("Hotness is gated by quality before visibility");
-  details.push(WAVE_SCORE_FORMULA_HINT);
-
-  return details;
+  return [
+    `Hotness score: ${hotnessScore}`,
+    ...(qualityScore === null
+      ? []
+      : [`Quality input: ${qualityScore} (35% of hotness)`]),
+    "Recent trusted activity carries the other 65%",
+    "Hotness is gated by quality before visibility",
+    WAVE_SCORE_FORMULA_HINT,
+  ];
 };
 
 const buildRepDetails = ({
@@ -418,31 +427,22 @@ const buildRepDetails = ({
   readonly repSortScore: string | null;
   readonly waveRep: ApiWaveRepSummary | null | undefined;
 }): string[] => {
-  const details: string[] = [];
   const rawRep = formatSignedFullNumber(waveRep?.total_rep);
 
-  if (rawRep !== null) {
-    details.push(`Wave REP: ${rawRep} raw`);
-  }
-
-  if (repSortScore !== null) {
-    details.push(`REP score: ${repSortScore}`);
-  }
-
-  details.push("REP contributes 35% of quality");
-  details.push(WAVE_SCORE_FORMULA_HINT);
-
-  return details;
+  return [
+    ...(rawRep === null ? [] : [`Wave REP: ${rawRep} raw`]),
+    ...(repSortScore === null ? [] : [`REP score: ${repSortScore}`]),
+    "REP contributes 35% of quality",
+    WAVE_SCORE_FORMULA_HINT,
+  ];
 };
 
 function WaveScoreSummaryTooltip({
   details,
   id,
-  learnMoreHref,
 }: {
   readonly details: readonly string[];
   readonly id: string;
-  readonly learnMoreHref: string;
 }) {
   const [primaryDetail, ...secondaryDetails] = details;
 
@@ -464,12 +464,9 @@ function WaveScoreSummaryTooltip({
           </span>
         ))}
       </span>
-      <Link
-        href={learnMoreHref}
-        className="tw-pointer-events-auto tw-mt-3 tw-inline-flex tw-items-center tw-rounded-md tw-bg-primary-500/15 tw-px-2 tw-py-1.5 tw-text-xs tw-font-semibold tw-text-primary-200 tw-no-underline tw-ring-1 tw-ring-inset tw-ring-primary-400/30 tw-transition hover:tw-bg-primary-500/25 hover:tw-text-primary-100 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-300"
-      >
-        Learn how wave score works
-      </Link>
+      <span className="tw-mt-3 tw-block tw-text-xs tw-font-semibold tw-text-primary-300">
+        Click score to open the full formula
+      </span>
     </span>
   );
 }
@@ -560,64 +557,77 @@ export function WaveTrustSignals({
     const summaryLabel = summaryDetails.join(". ");
     const summaryTitle = hasNativeTitle ? summaryDetails.join("\n") : undefined;
     const summaryTooltip = summaryDetails.join(" | ");
+    const summaryChipClasses = `${getChipClasses(
+      variant,
+      mode,
+      getVisibilityToneClasses(variant, waveScore?.visibility_score)
+    )} ${
+      hasRichTooltip
+        ? "tw-group tw-relative tw-isolate tw-overflow-visible tw-no-underline"
+        : ""
+    }`;
+    const summaryChipContent = (
+      <>
+        <ShieldCheckIcon
+          className={getIconClasses(variant)}
+          strokeWidth={isInlineVariant(variant) ? 1.5 : undefined}
+          aria-hidden="true"
+        />
+        <span className={getChipLabelClasses(variant)}>Score</span>
+        <span className={getValueClasses(variant)}>{visibilityScore}</span>
+        {hasRichTooltip && (
+          <WaveScoreSummaryTooltip id={richTooltipId} details={summaryDetails} />
+        )}
+      </>
+    );
 
     return renderContainer({
       variant,
       className: containerClasses,
       children: (
-        <span
-          className={`${getChipClasses(
-            variant,
-            mode,
-            getVisibilityToneClasses(variant, waveScore?.visibility_score)
-          )} ${
-            hasRichTooltip
-              ? "tw-group tw-relative tw-isolate tw-overflow-visible"
-              : ""
-          }`}
-          aria-label={summaryLabel}
-          aria-describedby={hasRichTooltip ? richTooltipId : undefined}
-          tabIndex={hasRichTooltip ? 0 : undefined}
-          title={summaryTitle}
-          {...(hasRichTooltip || !shouldUseInlineSidebarTooltip
-            ? {}
-            : getTooltipAttributes(inlineSidebarTooltipId, summaryTooltip))}
-        >
-          <ShieldCheckIcon
-            className={getIconClasses(variant)}
-            strokeWidth={isInlineVariant(variant) ? 1.5 : undefined}
-            aria-hidden="true"
-          />
-          <span className={getChipLabelClasses(variant)}>Score</span>
-          <span className={getValueClasses(variant)}>{visibilityScore}</span>
-          {hasRichTooltip && (
-            <WaveScoreSummaryTooltip
-              id={richTooltipId}
-              details={summaryDetails}
-              learnMoreHref={learnMoreHref}
-            />
+        <>
+          {hasRichTooltip ? (
+            <Link
+              href={learnMoreHref}
+              className={summaryChipClasses}
+              aria-label={summaryLabel}
+              aria-describedby={richTooltipId}
+            >
+              {summaryChipContent}
+            </Link>
+          ) : (
+            <span
+              className={summaryChipClasses}
+              aria-label={summaryLabel}
+              title={summaryTitle}
+              {...(shouldUseInlineSidebarTooltip
+                ? getTooltipAttributes(inlineSidebarTooltipId, summaryTooltip)
+                : {})}
+            >
+              {summaryChipContent}
+            </span>
           )}
-        </span>
+        </>
       ),
     });
   }
 
   const visibilityDetails =
-    visibilityScore !== null
-      ? buildSummaryDetails({
+    visibilityScore === null
+      ? []
+      : buildSummaryDetails({
           visibilityScore,
           qualityScore,
           hotnessScore,
           repSortScore,
           waveRep,
-        })
-      : [];
+        });
   const visibilityTitle = visibilityDetails.join("\n");
   const visibilityTooltip = visibilityDetails.join(" | ");
   const hotnessDetails =
-    hotnessScore !== null
-      ? buildHotnessDetails({ hotnessScore, qualityScore })
-      : [];
+    hotnessScore === null
+      ? []
+      : buildHotnessDetails({ hotnessScore, qualityScore });
   const hotnessTitle = hotnessDetails.join("\n");
   const hotnessTooltip = hotnessDetails.join(" | ");
   const repDetails =

--- a/components/waves/WaveTrustSignals.tsx
+++ b/components/waves/WaveTrustSignals.tsx
@@ -5,7 +5,8 @@ import {
   ScaleIcon,
   ShieldCheckIcon,
 } from "@heroicons/react/24/outline";
-import type { ReactNode } from "react";
+import Link from "next/link";
+import { useId, type ReactNode } from "react";
 
 type WaveTrustSignalsVariant =
   | "card"
@@ -21,6 +22,7 @@ interface WaveTrustSignalsProps {
   readonly mode?: WaveTrustSignalsMode | undefined;
   readonly className?: string | undefined;
   readonly tooltipId?: string | undefined;
+  readonly learnMoreHref?: string | undefined;
 }
 
 const compactNumberFormatter = new Intl.NumberFormat(undefined, {
@@ -28,6 +30,7 @@ const compactNumberFormatter = new Intl.NumberFormat(undefined, {
   maximumFractionDigits: 1,
 });
 const fullNumberFormatter = new Intl.NumberFormat();
+const WAVE_SCORE_FORMULA_HINT = "Open Network > Wave Score for the formula";
 
 const formatScore = (value: number | null | undefined): string | null => {
   if (value === null || value === undefined || !Number.isFinite(value)) {
@@ -92,16 +95,57 @@ const isInlineHeaderVariant = (variant: WaveTrustSignalsVariant): boolean =>
 const isInlineVariant = (variant: WaveTrustSignalsVariant): boolean =>
   isInlineSidebarVariant(variant) || isInlineHeaderVariant(variant);
 
+const isSidebarVariant = (variant: WaveTrustSignalsVariant): boolean =>
+  variant === "sidebar" || isInlineSidebarVariant(variant);
+
 const INLINE_STAT_TONE_CLASSES =
   "tw-text-[#e2e8f0]/[0.85] desktop-hover:hover:tw-text-[#e2e8f0]/[0.95]";
 
-const getVisibilityToneClasses = (variant: WaveTrustSignalsVariant): string => {
+const getVisibilityToneClasses = (
+  variant: WaveTrustSignalsVariant,
+  value: number | null | undefined
+): string => {
+  const numericValue =
+    value !== null && value !== undefined && Number.isFinite(value)
+      ? value
+      : null;
+
   if (isInlineSidebarVariant(variant)) {
+    if (numericValue !== null && numericValue >= 85) {
+      return "tw-text-emerald-300 desktop-hover:hover:tw-text-emerald-200";
+    }
+    if (numericValue !== null && numericValue >= 65) {
+      return "tw-text-amber-300 desktop-hover:hover:tw-text-amber-200";
+    }
+    if (numericValue !== null && numericValue < 35) {
+      return "tw-text-rose-300 desktop-hover:hover:tw-text-rose-200";
+    }
+
     return INLINE_STAT_TONE_CLASSES;
   }
 
   if (isInlineHeaderVariant(variant)) {
+    if (numericValue !== null && numericValue >= 85) {
+      return "tw-text-emerald-400 desktop-hover:hover:tw-text-emerald-300";
+    }
+    if (numericValue !== null && numericValue >= 65) {
+      return "tw-text-amber-400 desktop-hover:hover:tw-text-amber-300";
+    }
+    if (numericValue !== null && numericValue < 35) {
+      return "tw-text-rose-400 desktop-hover:hover:tw-text-rose-300";
+    }
+
     return "tw-text-primary-300 desktop-hover:hover:tw-text-[#A8C4FF]";
+  }
+
+  if (numericValue !== null && numericValue >= 85) {
+    return "tw-bg-emerald-500/10 tw-text-emerald-200 tw-ring-emerald-400/25";
+  }
+  if (numericValue !== null && numericValue >= 65) {
+    return "tw-bg-amber-500/10 tw-text-amber-200 tw-ring-amber-400/25";
+  }
+  if (numericValue !== null && numericValue < 35) {
+    return "tw-bg-rose-500/10 tw-text-rose-200 tw-ring-rose-400/25";
   }
 
   return "tw-bg-sky-500/10 tw-text-sky-200 tw-ring-sky-400/25";
@@ -190,7 +234,7 @@ const getChipClasses = (
     sizeClasses = "";
   } else if (isInlineHeaderVariant(variant)) {
     variantClasses =
-      "tw-cursor-default tw-gap-1 tw-whitespace-nowrap tw-text-[11px] tw-font-semibold tw-leading-none";
+      "tw-cursor-help tw-gap-1 tw-whitespace-nowrap tw-rounded-md tw-px-1.5 tw-py-1 tw-text-[11px] tw-font-semibold tw-leading-none";
     sizeClasses = "";
   } else if (variant === "sidebar") {
     sizeClasses = "tw-h-5 tw-px-1.5 tw-text-[10px]";
@@ -243,14 +287,14 @@ const getIconClasses = (variant: WaveTrustSignalsVariant): string => {
 
 const getValueClasses = (variant: WaveTrustSignalsVariant): string => {
   if (isInlineSidebarVariant(variant)) {
-    return "";
+    return "tw-tabular-nums";
   }
 
   if (isInlineHeaderVariant(variant)) {
-    return "tw-text-[11px] tw-font-semibold";
+    return "tw-text-[11px] tw-font-semibold tw-tabular-nums";
   }
 
-  return "";
+  return "tw-tabular-nums";
 };
 
 const getSeparatorClasses = (variant: WaveTrustSignalsVariant): string => {
@@ -320,14 +364,17 @@ const buildSummaryDetails = ({
   readonly repSortScore: string | null;
   readonly waveRep: ApiWaveRepSummary | null | undefined;
 }) => {
-  const details = [`Combined score: ${visibilityScore}`];
+  const details = [
+    `Combined score: ${visibilityScore}`,
+    "A quick signal for which waves deserve broad attention",
+  ];
 
   if (qualityScore !== null) {
-    details.push(`Quality: ${qualityScore}`);
+    details.push(`Quality: ${qualityScore} (65% of visibility)`);
   }
 
   if (hotnessScore !== null) {
-    details.push(`Hotness: ${hotnessScore}`);
+    details.push(`Hotness: ${hotnessScore} (gated, 35% of visibility)`);
   }
 
   const rawRep = formatSignedFullNumber(waveRep?.total_rep);
@@ -339,8 +386,93 @@ const buildSummaryDetails = ({
     details.push(`REP score: ${repSortScore}`);
   }
 
+  details.push(WAVE_SCORE_FORMULA_HINT);
+
   return details;
 };
+
+const buildHotnessDetails = ({
+  hotnessScore,
+  qualityScore,
+}: {
+  readonly hotnessScore: string;
+  readonly qualityScore: string | null;
+}): string[] => {
+  const details = [`Hotness score: ${hotnessScore}`];
+
+  if (qualityScore !== null) {
+    details.push(`Quality input: ${qualityScore} (35% of hotness)`);
+  }
+
+  details.push("Recent trusted activity carries the other 65%");
+  details.push("Hotness is gated by quality before visibility");
+  details.push(WAVE_SCORE_FORMULA_HINT);
+
+  return details;
+};
+
+const buildRepDetails = ({
+  repSortScore,
+  waveRep,
+}: {
+  readonly repSortScore: string | null;
+  readonly waveRep: ApiWaveRepSummary | null | undefined;
+}): string[] => {
+  const details: string[] = [];
+  const rawRep = formatSignedFullNumber(waveRep?.total_rep);
+
+  if (rawRep !== null) {
+    details.push(`Wave REP: ${rawRep} raw`);
+  }
+
+  if (repSortScore !== null) {
+    details.push(`REP score: ${repSortScore}`);
+  }
+
+  details.push("REP contributes 35% of quality");
+  details.push(WAVE_SCORE_FORMULA_HINT);
+
+  return details;
+};
+
+function WaveScoreSummaryTooltip({
+  details,
+  id,
+  learnMoreHref,
+}: {
+  readonly details: readonly string[];
+  readonly id: string;
+  readonly learnMoreHref: string;
+}) {
+  const [primaryDetail, ...secondaryDetails] = details;
+
+  return (
+    <span
+      id={id}
+      role="tooltip"
+      className="tw-pointer-events-none tw-absolute tw-left-0 tw-top-full tw-z-50 tw-mt-2 tw-hidden tw-w-72 tw-rounded-lg tw-bg-iron-950 tw-p-3 tw-text-left tw-text-xs tw-font-normal tw-leading-5 tw-text-iron-200 tw-shadow-2xl tw-ring-1 tw-ring-white/10 group-hover:tw-block group-focus-within:tw-block"
+    >
+      {primaryDetail && (
+        <span className="tw-block tw-text-sm tw-font-semibold tw-text-white">
+          {primaryDetail}
+        </span>
+      )}
+      <span className="tw-mt-2 tw-block tw-space-y-1.5">
+        {secondaryDetails.map((detail) => (
+          <span key={detail} className="tw-block tw-text-iron-300">
+            {detail}
+          </span>
+        ))}
+      </span>
+      <Link
+        href={learnMoreHref}
+        className="tw-pointer-events-auto tw-mt-3 tw-inline-flex tw-items-center tw-rounded-md tw-bg-primary-500/15 tw-px-2 tw-py-1.5 tw-text-xs tw-font-semibold tw-text-primary-200 tw-no-underline tw-ring-1 tw-ring-inset tw-ring-primary-400/30 tw-transition hover:tw-bg-primary-500/25 hover:tw-text-primary-100 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-300"
+      >
+        Learn how wave score works
+      </Link>
+    </span>
+  );
+}
 
 const renderContainer = ({
   children,
@@ -365,7 +497,9 @@ export function WaveTrustSignals({
   mode = "details",
   className,
   tooltipId,
+  learnMoreHref,
 }: WaveTrustSignalsProps) {
+  const generatedTooltipId = useId();
   const visibilityScore = formatScore(waveScore?.visibility_score);
   const qualityScore = formatScore(waveScore?.quality_score);
   const hotnessScore = formatScore(waveScore?.hotness_score);
@@ -390,6 +524,8 @@ export function WaveTrustSignals({
   const inlineSidebarTooltipId = isInlineSidebarVariant(variant)
     ? tooltipId
     : undefined;
+  const shouldUseInlineSidebarTooltip =
+    inlineSidebarTooltipId !== undefined && mode !== "summary";
   const hasVisibilityScore = visibilityScore !== null;
   const hasHotnessScore = hotnessScore !== null;
   const hasRepScore = repScore !== null;
@@ -418,8 +554,11 @@ export function WaveTrustSignals({
       repSortScore,
       waveRep,
     });
+    const richTooltipId = `${generatedTooltipId}-wave-score-tooltip`;
+    const hasRichTooltip = learnMoreHref !== undefined;
+    const hasNativeTitle = !hasRichTooltip && !isSidebarVariant(variant);
     const summaryLabel = summaryDetails.join(". ");
-    const summaryTitle = summaryDetails.join("\n");
+    const summaryTitle = hasNativeTitle ? summaryDetails.join("\n") : undefined;
     const summaryTooltip = summaryDetails.join(" | ");
 
     return renderContainer({
@@ -427,14 +566,22 @@ export function WaveTrustSignals({
       className: containerClasses,
       children: (
         <span
-          className={getChipClasses(
+          className={`${getChipClasses(
             variant,
             mode,
-            getVisibilityToneClasses(variant)
-          )}
+            getVisibilityToneClasses(variant, waveScore?.visibility_score)
+          )} ${
+            hasRichTooltip
+              ? "tw-group tw-relative tw-isolate tw-overflow-visible"
+              : ""
+          }`}
           aria-label={summaryLabel}
+          aria-describedby={hasRichTooltip ? richTooltipId : undefined}
+          tabIndex={hasRichTooltip ? 0 : undefined}
           title={summaryTitle}
-          {...getTooltipAttributes(inlineSidebarTooltipId, summaryTooltip)}
+          {...(hasRichTooltip || !shouldUseInlineSidebarTooltip
+            ? {}
+            : getTooltipAttributes(inlineSidebarTooltipId, summaryTooltip))}
         >
           <ShieldCheckIcon
             className={getIconClasses(variant)}
@@ -443,10 +590,42 @@ export function WaveTrustSignals({
           />
           <span className={getChipLabelClasses(variant)}>Score</span>
           <span className={getValueClasses(variant)}>{visibilityScore}</span>
+          {hasRichTooltip && (
+            <WaveScoreSummaryTooltip
+              id={richTooltipId}
+              details={summaryDetails}
+              learnMoreHref={learnMoreHref}
+            />
+          )}
         </span>
       ),
     });
   }
+
+  const visibilityDetails =
+    visibilityScore !== null
+      ? buildSummaryDetails({
+          visibilityScore,
+          qualityScore,
+          hotnessScore,
+          repSortScore,
+          waveRep,
+        })
+      : [];
+  const visibilityTitle = visibilityDetails.join("\n");
+  const visibilityTooltip = visibilityDetails.join(" | ");
+  const hotnessDetails =
+    hotnessScore !== null
+      ? buildHotnessDetails({ hotnessScore, qualityScore })
+      : [];
+  const hotnessTitle = hotnessDetails.join("\n");
+  const hotnessTooltip = hotnessDetails.join(" | ");
+  const repDetails =
+    hasRepScore || repSortScore !== null
+      ? buildRepDetails({ repSortScore, waveRep })
+      : [];
+  const repTitle = repDetails.join("\n");
+  const repTooltip = repDetails.join(" | ");
 
   const signals = (
     <>
@@ -455,10 +634,14 @@ export function WaveTrustSignals({
           className={getChipClasses(
             variant,
             mode,
-            getVisibilityToneClasses(variant)
+            getVisibilityToneClasses(variant, waveScore?.visibility_score)
           )}
           aria-label={`Visibility score ${visibilityScore} out of 100`}
-          {...getTooltipAttributes(inlineSidebarTooltipId, "Score")}
+          title={visibilityTitle}
+          {...getTooltipAttributes(
+            shouldUseInlineSidebarTooltip ? inlineSidebarTooltipId : undefined,
+            visibilityTooltip
+          )}
         >
           <ShieldCheckIcon
             className={getIconClasses(variant)}
@@ -484,7 +667,11 @@ export function WaveTrustSignals({
             getHotnessToneClasses(variant)
           )}
           aria-label={`Hotness score ${hotnessScore} out of 100`}
-          {...getTooltipAttributes(inlineSidebarTooltipId, "Hot")}
+          title={hotnessTitle}
+          {...getTooltipAttributes(
+            shouldUseInlineSidebarTooltip ? inlineSidebarTooltipId : undefined,
+            hotnessTooltip
+          )}
         >
           <FireIcon
             className={getIconClasses(variant)}
@@ -510,7 +697,11 @@ export function WaveTrustSignals({
             getRepToneClasses(repToneValue, variant)
           )}
           aria-label={repLabel ?? undefined}
-          {...getTooltipAttributes(inlineSidebarTooltipId, "REP")}
+          title={repTitle}
+          {...getTooltipAttributes(
+            shouldUseInlineSidebarTooltip ? inlineSidebarTooltipId : undefined,
+            repTooltip
+          )}
         >
           <ScaleIcon
             className={getIconClasses(variant)}

--- a/components/waves/WaveTrustSignals.tsx
+++ b/components/waves/WaveTrustSignals.tsx
@@ -365,6 +365,28 @@ export const hasWaveTrustSummaryScore = (
   waveScore?: ApiWaveScore | null | undefined
 ): boolean => formatScore(waveScore?.visibility_score) !== null;
 
+const buildSummaryRepDetail = ({
+  rawRep,
+  repSortScore,
+}: {
+  readonly rawRep: string | null;
+  readonly repSortScore: string | null;
+}): string | null => {
+  if (rawRep !== null && repSortScore !== null) {
+    return `REP: ${rawRep} raw, ${repSortScore} score`;
+  }
+
+  if (rawRep !== null) {
+    return `REP: ${rawRep} raw`;
+  }
+
+  if (repSortScore !== null) {
+    return `REP score: ${repSortScore}`;
+  }
+
+  return null;
+};
+
 const buildSummaryDetails = ({
   visibilityScore,
   qualityScore,
@@ -379,14 +401,7 @@ const buildSummaryDetails = ({
   readonly waveRep: ApiWaveRepSummary | null | undefined;
 }): string[] => {
   const rawRep = formatSignedFullNumber(waveRep?.total_rep);
-  const repDetail =
-    rawRep !== null && repSortScore !== null
-      ? `REP: ${rawRep} raw, ${repSortScore} score`
-      : rawRep !== null
-        ? `REP: ${rawRep} raw`
-        : repSortScore !== null
-          ? `REP score: ${repSortScore}`
-          : null;
+  const repDetail = buildSummaryRepDetail({ rawRep, repSortScore });
 
   return [
     `Combined score: ${visibilityScore}`,
@@ -580,6 +595,9 @@ export function WaveTrustSignals({
         )}
       </>
     );
+    const inlineSidebarTooltipAttributes = shouldUseInlineSidebarTooltip
+      ? getTooltipAttributes(inlineSidebarTooltipId, summaryTooltip)
+      : {};
 
     return renderContainer({
       variant,
@@ -600,9 +618,7 @@ export function WaveTrustSignals({
               className={summaryChipClasses}
               aria-label={summaryLabel}
               title={summaryTitle}
-              {...(shouldUseInlineSidebarTooltip
-                ? getTooltipAttributes(inlineSidebarTooltipId, summaryTooltip)
-                : {})}
+              {...inlineSidebarTooltipAttributes}
             >
               {summaryChipContent}
             </span>

--- a/components/waves/discovery/DiscoverWaveExplorer.tsx
+++ b/components/waves/discovery/DiscoverWaveExplorer.tsx
@@ -181,7 +181,7 @@ function DiscoverWaveControls({
   return (
     <div className="tw-flex tw-w-full tw-flex-col tw-gap-3 md:tw-w-auto md:tw-items-end">
       <Link
-        href="/discover/wave-score"
+        href="/network/wave-score"
         className="tw-inline-flex tw-h-8 tw-items-center tw-justify-center tw-gap-1.5 tw-self-start tw-rounded-md tw-bg-iron-950 tw-px-2.5 tw-text-xs tw-font-semibold tw-text-iron-200 tw-no-underline tw-ring-1 tw-ring-inset tw-ring-white/10 tw-transition focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 desktop-hover:hover:tw-bg-iron-800 desktop-hover:hover:tw-text-white md:tw-self-end"
       >
         <CalculatorIcon className="tw-size-4" aria-hidden="true" />

--- a/components/waves/discovery/WaveScoreTransparencyPage.tsx
+++ b/components/waves/discovery/WaveScoreTransparencyPage.tsx
@@ -16,6 +16,7 @@ import { parseSeizeWaveLink } from "@/helpers/SeizeLinkParser";
 import { fetchWaveById, searchWavesByName } from "@/services/api/waves-v2-api";
 import type { SidebarWave } from "@/types/waves.types";
 import {
+  ArrowLongLeftIcon,
   ArrowLongRightIcon,
   ArrowPathIcon,
   CalculatorIcon,
@@ -1388,8 +1389,8 @@ export function WaveScoreTransparencyPage() {
               href="/network"
               className="tw-text-primary-200 desktop-hover:hover:tw-text-primary-100 tw-inline-flex tw-items-center tw-gap-2 tw-text-sm tw-font-medium tw-no-underline tw-transition focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
             >
-              <ArrowLongRightIcon
-                className="tw-size-4 tw-rotate-180"
+              <ArrowLongLeftIcon
+                className="tw-size-4"
                 aria-hidden="true"
               />
               Back to Network

--- a/components/waves/discovery/WaveScoreTransparencyPage.tsx
+++ b/components/waves/discovery/WaveScoreTransparencyPage.tsx
@@ -1306,7 +1306,7 @@ function ConstantStat({
 }
 
 export function WaveScoreTransparencyPage() {
-  useSetTitle("Wave Score | Discovery");
+  useSetTitle("Wave Score | Network");
 
   const [input, setInput] = useState("");
   const [status, setStatus] = useState<CalculatorStatus>("idle");
@@ -1382,27 +1382,30 @@ export function WaveScoreTransparencyPage() {
   return (
     <div className="tw-px-4 tw-pb-16 tw-pt-6 md:tw-px-6 md:tw-pt-8 lg:tw-px-8">
       <div className="tw-mx-auto tw-max-w-7xl tw-space-y-8">
-        <section className="tw-grid tw-gap-6 lg:tw-grid-cols-[minmax(0,1.05fr)_minmax(340px,0.95fr)]">
+        <section className="tw-grid tw-gap-6 xl:tw-grid-cols-[minmax(0,0.9fr)_minmax(380px,1.1fr)]">
           <div className="tw-rounded-lg tw-bg-iron-950/50 tw-p-5 tw-ring-1 tw-ring-inset tw-ring-white/10 md:tw-p-6">
             <Link
-              href="/discover"
+              href="/network"
               className="tw-text-primary-200 desktop-hover:hover:tw-text-primary-100 tw-inline-flex tw-items-center tw-gap-2 tw-text-sm tw-font-medium tw-no-underline tw-transition focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
             >
               <ArrowLongRightIcon
                 className="tw-size-4 tw-rotate-180"
                 aria-hidden="true"
               />
-              Back to discovery
+              Back to Network
             </Link>
+            <p className="tw-mt-5 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-wide tw-text-iron-500">
+              Network menu / Wave Score
+            </p>
             <h1 className="tw-mt-5 tw-text-3xl tw-font-semibold tw-leading-tight tw-text-white md:tw-text-4xl">
               Wave score transparency
             </h1>
             <p className="tw-mt-4 tw-max-w-3xl tw-text-base tw-leading-7 tw-text-iron-300">
-              Discovery uses a visibility score made from quality and gated
-              hotness. Quality is where TDH-backed REP, creator level, and the
-              level of posters carry the most weight.
+              This Network page explains the score shown on waves across
+              discovery, the sidebar, home, and wave pages. Find it from the
+              Network menu directly below xTDH whenever you want the formula or
+              a live wave calculation.
             </p>
-            <FormulaPipeline />
           </div>
 
           <CalculatorPanel
@@ -1417,6 +1420,8 @@ export function WaveScoreTransparencyPage() {
             }}
           />
         </section>
+
+        <FormulaPipeline />
 
         <FormulaSummary />
 

--- a/components/waves/header/rep/WaveRepButton.tsx
+++ b/components/waves/header/rep/WaveRepButton.tsx
@@ -18,8 +18,8 @@ export default function WaveRepButton({ wave }: { readonly wave: ApiWave }) {
     totalRep === null ? null : compactNumberFormatter.format(totalRep);
   const label =
     formattedTotalRep === null
-      ? "Rate wave REP"
-      : `Rate wave REP. Current total ${formattedTotalRep}`;
+      ? "Add or edit Wave REP"
+      : `Add or edit Wave REP. Current total ${formattedTotalRep}`;
   const tooltipId = `wave-rep-rating-${wave.id}`;
 
   return (
@@ -30,10 +30,15 @@ export default function WaveRepButton({ wave }: { readonly wave: ApiWave }) {
         data-tooltip-id={tooltipId}
         data-tooltip-content={label}
         onClick={() => setIsModalOpen(true)}
-        className="tw-flex tw-h-8 tw-min-w-8 tw-items-center tw-justify-center tw-gap-x-1.5 tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900 tw-px-2 tw-text-xs tw-font-semibold tw-text-iron-200 tw-transition-all tw-duration-200 hover:tw-border-primary-400/70 hover:tw-bg-iron-800 hover:tw-text-white"
+        className="tw-flex tw-h-8 tw-min-w-8 tw-items-center tw-justify-center tw-gap-x-1.5 tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900 tw-px-2.5 tw-text-xs tw-font-semibold tw-text-iron-200 tw-transition-all tw-duration-200 hover:tw-border-primary-400/70 hover:tw-bg-iron-800 hover:tw-text-white"
       >
         <ScaleIcon className="tw-size-4 tw-flex-shrink-0" aria-hidden="true" />
-        {formattedTotalRep !== null && <span>{formattedTotalRep}</span>}
+        <span>Add REP</span>
+        {formattedTotalRep !== null && (
+          <span className="tw-rounded-md tw-bg-black/25 tw-px-1.5 tw-py-0.5 tw-text-iron-300">
+            {formattedTotalRep}
+          </span>
+        )}
       </button>
       <MyStreamActionTooltip id={tooltipId} />
       {isModalOpen && (

--- a/hooks/useSidebarSections.ts
+++ b/hooks/useSidebarSections.ts
@@ -22,6 +22,7 @@ function getNetworkSection(): SidebarSection {
       { name: "Memes Calendar", href: "/meme-calendar" },
       { name: "TDH", href: "/network/tdh" },
       { name: "xTDH", href: "/xtdh" },
+      { name: "Wave Score", href: "/network/wave-score" },
     ],
     subsections: [
       {


### PR DESCRIPTION
## Summary

- Move the Wave Score transparency experience into Network at `/network/wave-score`, add Network menu/sidebar/search entry points, and remove the old Discover route.
- Fix wave score badges so sidebar rows show one compact combined score without the large clipped hover tooltip, while header score badges get a dark explanatory hover with a learn-more link.
- Make Wave REP voting easier to find by labeling the wave REP action as `Add REP`.

## Validation

- `seize exec jest --runTestsByPath __tests__/hooks/useSidebarSections.test.ts __tests__/components/header/AppSidebar.test.tsx __tests__/components/header/HeaderSearchModal.test.tsx __tests__/components/waves/WaveTrustSignals.test.tsx __tests__/components/waves/header/WaveHeader.test.tsx __tests__/app/networkPages.test.tsx --silent --coverage=false`
- `seize run lint:changed`
- `seize run typecheck:changed`
- `seize run build`
- Browser smoke tested `/network/wave-score` at desktop and mobile sizes; confirmed `/discover/wave-score` returns 404 locally.

## Notes

- Local calculator search could not complete against the shared local backend because the local wave search endpoints returned 500s; the page handled this with its unavailable-search message. Direct stage/prod verification should use live API data.
- The production build exits successfully. Existing build noise remains: Bootstrap Sass deprecation warnings, the existing OG metadata dynamic-server warning, and the current `next-sitemap.config.ts` extension warning printed by postbuild.