### PR TITLE
Harden video and media previews across drops, waves, and NFT renderers

### DIFF
--- a/__tests__/components/drops/view/item/content/media/DropListItemContentMediaVideo.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/DropListItemContentMediaVideo.test.tsx
@@ -4,12 +4,13 @@ import "@testing-library/jest-dom";
 import DropListItemContentMediaVideo from "@/components/drops/view/item/content/media/DropListItemContentMediaVideo";
 
 const downloadMediaUrlMock = jest.fn();
+let mockIsApp = false;
 
 jest.mock("@/hooks/useCapacitor", () => ({
   __esModule: true,
   default: () => ({ isCapacitor: false }),
 }));
-jest.mock("@/hooks/useDeviceInfo", () => () => ({ isApp: false }));
+jest.mock("@/hooks/useDeviceInfo", () => () => ({ isApp: mockIsApp }));
 jest.mock("@/hooks/useInView", () => ({ useInView: jest.fn() }));
 jest.mock("@/hooks/useOptimizedVideo", () => ({
   useOptimizedVideo: jest.fn(),
@@ -29,6 +30,7 @@ describe("DropListItemContentMediaVideo", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useRealTimers();
+    mockIsApp = false;
     downloadMediaUrlMock.mockClear();
     Object.defineProperty(document, "fullscreenElement", {
       configurable: true,
@@ -119,6 +121,38 @@ describe("DropListItemContentMediaVideo", () => {
     render(<DropListItemContentMediaVideo src="foo.mp4" />);
 
     expect(pauseSpy).not.toHaveBeenCalled();
+  });
+
+  it("pauses an app video after its wrapper fullscreen exits", () => {
+    mockIsApp = true;
+    const ref = {
+      current: document.createElement("div"),
+    } as React.RefObject<HTMLDivElement>;
+    mockUseInView.mockReturnValue([ref, false]);
+    mockUseOptimizedVideo.mockReturnValue({
+      playableUrl: "foo.mp4",
+      isHls: false,
+    });
+
+    const pauseSpy = jest.fn();
+    Object.defineProperty(HTMLVideoElement.prototype, "pause", {
+      configurable: true,
+      value: pauseSpy,
+    });
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      value: document.body,
+    });
+
+    render(<DropListItemContentMediaVideo src="foo.mp4" />);
+
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      value: null,
+    });
+    document.dispatchEvent(new Event("fullscreenchange"));
+
+    expect(pauseSpy).toHaveBeenCalledTimes(1);
   });
 
   it("always shows the inline video media actions", () => {

--- a/__tests__/components/drops/view/item/content/media/DropListItemContentMediaVideo.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/DropListItemContentMediaVideo.test.tsx
@@ -30,6 +30,10 @@ describe("DropListItemContentMediaVideo", () => {
     jest.clearAllMocks();
     jest.useRealTimers();
     downloadMediaUrlMock.mockClear();
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      value: null,
+    });
   });
 
   it("renders video when in view", () => {
@@ -89,6 +93,32 @@ describe("DropListItemContentMediaVideo", () => {
 
     render(<DropListItemContentMediaVideo src="foo.mp4" disableAutoPlay />);
     expect(playSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not pause while its video is in wrapper fullscreen", () => {
+    const ref = {
+      current: document.createElement("div"),
+    } as React.RefObject<HTMLDivElement>;
+    mockUseInView.mockReturnValue([ref, false]);
+    mockUseOptimizedVideo.mockReturnValue({
+      playableUrl: "foo.mp4",
+      isHls: false,
+    });
+
+    const pauseSpy = jest.fn();
+    Object.defineProperty(HTMLVideoElement.prototype, "pause", {
+      configurable: true,
+      value: pauseSpy,
+    });
+
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      value: document.body,
+    });
+
+    render(<DropListItemContentMediaVideo src="foo.mp4" />);
+
+    expect(pauseSpy).not.toHaveBeenCalled();
   });
 
   it("always shows the inline video media actions", () => {

--- a/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
@@ -6,6 +6,14 @@ import SeizeVideoPlayer from "@/components/drops/view/item/content/media/SeizeVi
 describe("SeizeVideoPlayer", () => {
   beforeEach(() => {
     jest.restoreAllMocks();
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      value: null,
+    });
+    Object.defineProperty(document, "fullscreenEnabled", {
+      configurable: true,
+      value: false,
+    });
     jest
       .spyOn(HTMLMediaElement.prototype, "load")
       .mockImplementation(() => undefined);
@@ -123,6 +131,53 @@ describe("SeizeVideoPlayer", () => {
     await waitFor(() => {
       expect(webkitEnterFullscreen).toHaveBeenCalled();
     });
+  });
+
+  it("uses the mounted player wrapper as its fullscreen target", async () => {
+    const requestFullscreen = jest.fn().mockImplementation(function (
+      this: HTMLElement
+    ) {
+      expect(this).not.toBe(document.documentElement);
+      expect(this).toHaveAttribute("aria-label", "Video player");
+      Object.defineProperty(document, "fullscreenElement", {
+        configurable: true,
+        value: this,
+      });
+      document.dispatchEvent(new Event("fullscreenchange"));
+      return Promise.resolve();
+    });
+    Object.defineProperty(document, "fullscreenEnabled", {
+      configurable: true,
+      value: true,
+    });
+    Object.defineProperty(HTMLElement.prototype, "requestFullscreen", {
+      configurable: true,
+      value: requestFullscreen,
+    });
+
+    render(<SeizeVideoPlayer src="https://example.com/video.mp4" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Full screen" }));
+
+    await waitFor(() => {
+      expect(requestFullscreen).toHaveBeenCalled();
+    });
+    expect(
+      screen.getByRole("button", { name: "Exit full screen" })
+    ).toBeInTheDocument();
+  });
+
+  it("can hide the fullscreen control", () => {
+    render(
+      <SeizeVideoPlayer
+        src="https://example.com/video.mp4"
+        showFullscreen={false}
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Full screen" })
+    ).not.toBeInTheDocument();
   });
 
   it("toggles playback when the video surface is clicked", async () => {

--- a/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
@@ -86,6 +86,25 @@ describe("SeizeVideoPlayer", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not carry a local mute toggle across source changes", async () => {
+    const { rerender } = render(
+      <SeizeVideoPlayer src="https://example.com/slide-1.mp4" muted={false} />
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Mute video" }));
+    expect(
+      screen.getByRole("button", { name: "Unmute video" })
+    ).toBeInTheDocument();
+
+    rerender(
+      <SeizeVideoPlayer src="https://example.com/slide-2.mp4" muted={false} />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Mute video" })
+    ).toBeInTheDocument();
+  });
+
   it("falls back to native iOS video fullscreen when wrapper fullscreen is unavailable", async () => {
     const webkitEnterFullscreen = jest.fn();
     Object.defineProperty(HTMLVideoElement.prototype, "webkitEnterFullscreen", {

--- a/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import SeizeVideoPlayer from "@/components/drops/view/item/content/media/SeizeVideoPlayer";
+
+describe("SeizeVideoPlayer", () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest
+      .spyOn(HTMLMediaElement.prototype, "load")
+      .mockImplementation(() => undefined);
+    jest
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockResolvedValue(undefined);
+    jest
+      .spyOn(HTMLMediaElement.prototype, "pause")
+      .mockImplementation(() => undefined);
+  });
+
+  it("advances through fallback sources when the direct source errors", () => {
+    const { container } = render(
+      <SeizeVideoPlayer
+        src="https://example.com/primary.mp4"
+        fallbackSources={["https://example.com/fallback.mp4"]}
+      />
+    );
+
+    const video = container.querySelector("video");
+    expect(video).toHaveAttribute("src", "https://example.com/primary.mp4");
+
+    if (!video) {
+      throw new Error("Expected video element to render");
+    }
+
+    fireEvent.error(video);
+
+    expect(video).toHaveAttribute("src", "https://example.com/fallback.mp4");
+    expect(HTMLMediaElement.prototype.load).toHaveBeenCalled();
+  });
+
+  it("toggles mute state from the custom control", async () => {
+    render(<SeizeVideoPlayer src="https://example.com/video.mp4" />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Unmute video" })
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Mute video" })
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to native iOS video fullscreen when wrapper fullscreen is unavailable", async () => {
+    const webkitEnterFullscreen = jest.fn();
+    Object.defineProperty(HTMLVideoElement.prototype, "webkitEnterFullscreen", {
+      configurable: true,
+      value: webkitEnterFullscreen,
+    });
+    Object.defineProperty(document, "fullscreenEnabled", {
+      configurable: true,
+      value: false,
+    });
+
+    render(<SeizeVideoPlayer src="https://example.com/video.mp4" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Full screen" }));
+
+    await waitFor(() => {
+      expect(webkitEnterFullscreen).toHaveBeenCalled();
+    });
+  });
+
+  it("toggles playback when the video surface is clicked", async () => {
+    render(
+      <SeizeVideoPlayer src="https://example.com/video.mp4" autoPlay={false} />
+    );
+
+    await userEvent.click(screen.getByRole("group", { name: "Video player" }));
+
+    expect(HTMLMediaElement.prototype.play).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
@@ -38,6 +38,24 @@ describe("SeizeVideoPlayer", () => {
     expect(HTMLMediaElement.prototype.load).toHaveBeenCalled();
   });
 
+  it("recovers to the first fallback source when the direct source is missing", () => {
+    const { container } = render(
+      <SeizeVideoPlayer
+        fallbackSources={["https://example.com/fallback.mp4"]}
+      />
+    );
+
+    const video = container.querySelector("video");
+    if (!video) {
+      throw new Error("Expected video element to render");
+    }
+
+    fireEvent.error(video);
+
+    expect(video).toHaveAttribute("src", "https://example.com/fallback.mp4");
+    expect(HTMLMediaElement.prototype.load).toHaveBeenCalled();
+  });
+
   it("toggles mute state from the custom control", async () => {
     render(<SeizeVideoPlayer src="https://example.com/video.mp4" />);
 
@@ -47,6 +65,24 @@ describe("SeizeVideoPlayer", () => {
 
     expect(
       screen.getByRole("button", { name: "Mute video" })
+    ).toBeInTheDocument();
+  });
+
+  it("syncs mute state when the muted prop changes", () => {
+    const { rerender } = render(
+      <SeizeVideoPlayer src="https://example.com/video.mp4" muted={false} />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Mute video" })
+    ).toBeInTheDocument();
+
+    rerender(
+      <SeizeVideoPlayer src="https://example.com/video.mp4" muted={true} />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Unmute video" })
     ).toBeInTheDocument();
   });
 

--- a/__tests__/components/nft-image/renderers/NFTVideoRenderer.test.tsx
+++ b/__tests__/components/nft-image/renderers/NFTVideoRenderer.test.tsx
@@ -197,9 +197,18 @@ describe("NFTVideoRenderer", () => {
       const video = container.querySelector("video");
       expect(video).toHaveAttribute("autoplay");
       expect(video).toHaveProperty("muted", true);
-      expect(video).toHaveAttribute("controls");
+      expect(video).not.toHaveAttribute("controls");
       expect(video).toHaveAttribute("loop");
       expect(video).toHaveAttribute("playsinline");
+      expect(
+        screen.getAllByRole("button", { name: "Pause video" }).length
+      ).toBeGreaterThan(0);
+      expect(
+        screen.getAllByRole("button", { name: "Unmute video" }).length
+      ).toBeGreaterThan(0);
+      expect(
+        screen.getByRole("button", { name: "Full screen" })
+      ).toBeInTheDocument();
     });
 
     it("uses custom id when provided", () => {
@@ -520,8 +529,14 @@ describe("NFTVideoRenderer", () => {
       const video = container.querySelector("video");
       expect(video).toBeInTheDocument();
       expect(video).toHaveProperty("muted", true); // Important for autoplay
-      expect(video).toHaveAttribute("controls"); // Accessibility
+      expect(video).not.toHaveAttribute("controls");
       expect(video).toHaveAttribute("playsinline"); // Mobile compatibility
+      expect(
+        screen.getAllByRole("button", { name: "Pause video" }).length
+      ).toBeGreaterThan(0);
+      expect(
+        screen.getAllByRole("button", { name: "Unmute video" }).length
+      ).toBeGreaterThan(0);
     });
 
     it("handles missing NFT name gracefully in video context", () => {
@@ -710,9 +725,13 @@ describe("NFTVideoRenderer", () => {
   describe("Error Resistance and Edge Cases", () => {
     it("handles completely empty NFT animation properties gracefully", () => {
       const nft = createMockNFT({
-        ...(undefined !== undefined ? { animation: undefined } : {}),
+        animation: undefined as any,
         compressed_animation: undefined,
-        ...(undefined !== undefined ? { metadata: undefined } : {}),
+        metadata: {
+          ...createMockNFT().metadata,
+          animation: undefined,
+          animation_url: undefined,
+        },
       });
       const props = createDefaultProps({ nft });
 

--- a/__tests__/components/waves/TwitterPreviewCard.test.tsx
+++ b/__tests__/components/waves/TwitterPreviewCard.test.tsx
@@ -22,6 +22,12 @@ describe("TwitterPreviewCard", () => {
     jest
       .spyOn(HTMLMediaElement.prototype, "load")
       .mockImplementation(() => undefined);
+    jest
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockResolvedValue(undefined);
+    jest
+      .spyOn(HTMLMediaElement.prototype, "pause")
+      .mockImplementation(() => undefined);
     mockedFetchTwitterPreview.mockReset();
     Object.assign(navigator, {
       clipboard: {
@@ -156,7 +162,8 @@ describe("TwitterPreviewCard", () => {
       "poster",
       "https://pbs.twimg.com/tweet_video_thumb/example.jpg"
     );
-    expect(video).toHaveAttribute("controls");
+    expect(video).not.toHaveAttribute("controls");
+    expect(screen.getByRole("button", { name: "Full screen" })).toBeInTheDocument();
     expect(container.querySelector("track")).toHaveAttribute(
       "kind",
       "captions"
@@ -185,6 +192,17 @@ describe("TwitterPreviewCard", () => {
     await userEvent.click(
       screen.getByRole("button", { name: "Close video quality menu" })
     );
+    expect(
+      screen.queryByRole("dialog", { name: "Video quality" })
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Video quality" })
+    );
+    expect(
+      screen.getByRole("dialog", { name: "Video quality" })
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("group", { name: "Video player" }));
     expect(
       screen.queryByRole("dialog", { name: "Video quality" })
     ).not.toBeInTheDocument();

--- a/components/community-curations/CommunityCurationsMasonry.tsx
+++ b/components/community-curations/CommunityCurationsMasonry.tsx
@@ -271,6 +271,7 @@ function CommunityCurationsMasonryItem({
           inlineAuthorOnDesktop={true}
           fullWidthMedia={true}
           fullWidthLinkPreviews={true}
+          showVideoFullscreen={false}
         />
       </WaveDropQuoteDisplayProvider>
       <div

--- a/components/drops/create/utils/file/CreateDropSelectedFilePreview.tsx
+++ b/components/drops/create/utils/file/CreateDropSelectedFilePreview.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from "react";
 import { useObjectUrl } from "@/hooks/useObjectUrl";
+import SeizeVideoPlayer from "@/components/drops/view/item/content/media/SeizeVideoPlayer";
 
 enum FILE_TYPES {
   IMAGE = "IMAGE",
@@ -42,10 +43,14 @@ export default function CreateDropSelectedFilePreview({
       <></>
     ),
     [FILE_TYPES.VIDEO]: previewUrl ? (
-      <video className="tw-h-full tw-w-full" controls>
-        <source src={previewUrl} type={file.type} />
-        Your browser does not support the video tag.
-      </video>
+      <SeizeVideoPlayer
+        src={previewUrl}
+        autoPlay={false}
+        muted
+        preload="metadata"
+        layout="fill"
+        showActions={false}
+      />
     ) : (
       <></>
     ),

--- a/components/drops/view/item/content/media/DropListItemContentMedia.tsx
+++ b/components/drops/view/item/content/media/DropListItemContentMedia.tsx
@@ -10,6 +10,7 @@ import DropListItemContentMediaImage from "./DropListItemContentMediaImage";
 import DropListItemContentMediaVideo from "./DropListItemContentMediaVideo";
 import MediaDisplay from "./MediaDisplay";
 import UnsupportedMediaLink from "./UnsupportedMediaLink";
+import { useOptionalDropContext } from "@/components/waves/drops/DropContext";
 
 enum MediaType {
   IMAGE = "IMAGE",
@@ -54,6 +55,9 @@ export default function DropListItemContentMedia({
   readonly loadStrategy?: MediaLoadStrategy | undefined;
   readonly galleryItemId?: string | undefined;
 }) {
+  const dropContext = useOptionalDropContext();
+  const showVideoFullscreen = dropContext?.showVideoFullscreen ?? true;
+
   const getMediaType = (): MediaType => {
     if (media_mime_type.includes("image")) {
       return MediaType.IMAGE;
@@ -100,6 +104,7 @@ export default function DropListItemContentMedia({
           mimeType={media_mime_type}
           disableAutoPlay={disableAutoPlay}
           fillContainer={fillVideoContainer}
+          showFullscreen={showVideoFullscreen}
         />
       );
     case MediaType.AUDIO:

--- a/components/drops/view/item/content/media/DropListItemContentMediaVideo.tsx
+++ b/components/drops/view/item/content/media/DropListItemContentMediaVideo.tsx
@@ -4,10 +4,9 @@ import { useInView } from "@/hooks/useInView";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
 import { useOptimizedVideo } from "@/hooks/useOptimizedVideo";
 import { useHlsPlayer } from "@/hooks/useHlsPlayer";
-import { PlayIcon } from "@heroicons/react/24/solid";
 import clsx from "clsx";
 import React, { useEffect } from "react";
-import { InlineMediaActions } from "./MediaActionToolbar";
+import SeizeVideoPlayer from "./SeizeVideoPlayer";
 import { useMediaActions } from "./useMediaActions";
 
 interface Props {
@@ -48,7 +47,6 @@ function DropListItemContentMediaVideo({
     fallbackSrc: src,
     autoPlay: inView && !isApp && !disableAutoPlay,
   });
-  const showNativeControls = !isApp;
 
   // 3) Play/pause & mute based on scroll visibility
   const shouldAutoPlay = inView && !isApp && !disableAutoPlay;
@@ -98,63 +96,18 @@ function DropListItemContentMediaVideo({
     };
   }, [isApp, videoRef]);
 
-  const enterFullscreenAndPlay = () => {
-    const videoEl = videoRef.current;
-    if (!videoEl) {
-      return;
-    }
-
-    videoEl.play().catch(() => undefined);
-    videoEl.requestFullscreen().catch(() => undefined);
-  };
-
   return (
     <div
       ref={wrapperRef}
       className={clsx(
-        "tw-group tw-relative tw-flex tw-w-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-xl tw-bg-black",
-        fillContainer
-          ? "tw-h-full tw-max-h-full"
-          : "tw-max-h-64 tw-min-h-[200px]"
+        "tw-flex tw-w-full tw-items-start tw-justify-start",
+        fillContainer && "tw-h-full tw-max-h-full"
       )}
     >
-      <video
-        ref={videoRef}
-        onClick={() => {
-          if (!isApp) {
-            return;
-          }
-          enterFullscreenAndPlay();
-        }}
-        playsInline
-        controls={showNativeControls}
-        controlsList="nodownload noplaybackrate"
+      <SeizeVideoPlayer
+        videoRef={videoRef}
         autoPlay={false}
-        muted
-        loop
-        className={clsx(
-          "tw-w-full tw-rounded-xl tw-object-contain",
-          fillContainer ? "tw-h-full tw-max-h-full" : "tw-h-auto tw-max-h-64"
-        )}
-      >
-        Your browser does not support the video tag.
-      </video>
-      {isApp && (
-        <button
-          type="button"
-          aria-label="Play video"
-          title="Play video"
-          onClick={(event) => {
-            event.stopPropagation();
-            enterFullscreenAndPlay();
-          }}
-          className="tw-absolute tw-left-1/2 tw-top-1/2 tw-z-20 tw-flex tw-size-16 -tw-translate-x-1/2 -tw-translate-y-1/2 tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-bg-iron-700/75 tw-text-white tw-shadow-lg tw-shadow-black/30 tw-backdrop-blur-sm"
-        >
-          <PlayIcon className="tw-ml-1 tw-size-8" aria-hidden="true" />
-        </button>
-      )}
-      <InlineMediaActions
-        variant="video"
+        layout={fillContainer ? "fill" : "natural"}
         onDownload={downloadMedia}
         onOpen={openMedia}
         openLabel={openLabel}

--- a/components/drops/view/item/content/media/DropListItemContentMediaVideo.tsx
+++ b/components/drops/view/item/content/media/DropListItemContentMediaVideo.tsx
@@ -80,7 +80,7 @@ function DropListItemContentMediaVideo({
 
     const pauseWhenFullscreenCloses = () => {
       const videoEl = videoRef.current;
-      if (!videoEl || document.fullscreenElement === videoEl) {
+      if (!videoEl || document.fullscreenElement) {
         return;
       }
 

--- a/components/drops/view/item/content/media/DropListItemContentMediaVideo.tsx
+++ b/components/drops/view/item/content/media/DropListItemContentMediaVideo.tsx
@@ -54,6 +54,10 @@ function DropListItemContentMediaVideo({
   useEffect(() => {
     const videoEl = videoRef.current;
     if (!videoEl || isLoading) return;
+    const fullscreenElement = document.fullscreenElement;
+    if (fullscreenElement?.contains(videoEl) ?? false) {
+      return;
+    }
 
     if (shouldAutoPlay) {
       // ensure muted autoplay works

--- a/components/drops/view/item/content/media/DropListItemContentMediaVideo.tsx
+++ b/components/drops/view/item/content/media/DropListItemContentMediaVideo.tsx
@@ -5,7 +5,7 @@ import useDeviceInfo from "@/hooks/useDeviceInfo";
 import { useOptimizedVideo } from "@/hooks/useOptimizedVideo";
 import { useHlsPlayer } from "@/hooks/useHlsPlayer";
 import clsx from "clsx";
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import SeizeVideoPlayer from "./SeizeVideoPlayer";
 import { useMediaActions } from "./useMediaActions";
 
@@ -14,6 +14,7 @@ interface Props {
   readonly mimeType?: string | undefined;
   readonly disableAutoPlay?: boolean | undefined;
   readonly fillContainer?: boolean | undefined;
+  readonly showFullscreen?: boolean | undefined;
 }
 
 function DropListItemContentMediaVideo({
@@ -21,8 +22,10 @@ function DropListItemContentMediaVideo({
   mimeType,
   disableAutoPlay = false,
   fillContainer = false,
+  showFullscreen = true,
 }: Props) {
   const [wrapperRef, inView] = useInView<HTMLDivElement>({ threshold: 0.1 });
+  const wasFullscreenRef = useRef(false);
   const { isApp } = useDeviceInfo();
   const { downloadMedia, isDownloading, openLabel, openMedia } =
     useMediaActions({
@@ -56,6 +59,7 @@ function DropListItemContentMediaVideo({
     if (!videoEl || isLoading) return;
     const fullscreenElement = document.fullscreenElement;
     if (fullscreenElement?.contains(videoEl) ?? false) {
+      wasFullscreenRef.current = true;
       return;
     }
 
@@ -84,11 +88,20 @@ function DropListItemContentMediaVideo({
 
     const pauseWhenFullscreenCloses = () => {
       const videoEl = videoRef.current;
-      if (!videoEl || document.fullscreenElement) {
+      if (!videoEl) {
         return;
       }
 
-      videoEl.pause();
+      const fullscreenElement = document.fullscreenElement;
+      if (fullscreenElement?.contains(videoEl) ?? false) {
+        wasFullscreenRef.current = true;
+        return;
+      }
+
+      if (wasFullscreenRef.current) {
+        wasFullscreenRef.current = false;
+        videoEl.pause();
+      }
     };
 
     document.addEventListener("fullscreenchange", pauseWhenFullscreenCloses);
@@ -112,6 +125,7 @@ function DropListItemContentMediaVideo({
         videoRef={videoRef}
         autoPlay={false}
         layout={fillContainer ? "fill" : "natural"}
+        showFullscreen={showFullscreen}
         onDownload={downloadMedia}
         onOpen={openMedia}
         openLabel={openLabel}

--- a/components/drops/view/item/content/media/MediaDisplayVideo.tsx
+++ b/components/drops/view/item/content/media/MediaDisplayVideo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import { useInView } from "@/hooks/useInView";
 import { useOptimizedVideo } from "@/hooks/useOptimizedVideo";
 import { useHlsPlayer } from "@/hooks/useHlsPlayer";
@@ -21,6 +21,7 @@ const MediaDisplayVideo: React.FC<Props> = ({
 }) => {
   // Intersection observer for scroll-based triggers
   const [wrapperRef, inView] = useInView<HTMLDivElement>({ threshold: 0.1 });
+  const wasFullscreenRef = useRef(false);
   const { isApp } = useDeviceInfo();
   const { downloadMedia, isDownloading, openLabel, openMedia } =
     useMediaActions({
@@ -59,6 +60,7 @@ const MediaDisplayVideo: React.FC<Props> = ({
     if (!vid || isLoading) return;
     const fullscreenElement = document.fullscreenElement;
     if (fullscreenElement?.contains(vid) ?? false) {
+      wasFullscreenRef.current = true;
       return;
     }
 
@@ -77,11 +79,20 @@ const MediaDisplayVideo: React.FC<Props> = ({
 
     const pauseWhenFullscreenCloses = () => {
       const vid = videoRef.current;
-      if (!vid || document.fullscreenElement) {
+      if (!vid) {
         return;
       }
 
-      vid.pause();
+      const fullscreenElement = document.fullscreenElement;
+      if (fullscreenElement?.contains(vid) ?? false) {
+        wasFullscreenRef.current = true;
+        return;
+      }
+
+      if (wasFullscreenRef.current) {
+        wasFullscreenRef.current = false;
+        vid.pause();
+      }
     };
 
     document.addEventListener("fullscreenchange", pauseWhenFullscreenCloses);

--- a/components/drops/view/item/content/media/MediaDisplayVideo.tsx
+++ b/components/drops/view/item/content/media/MediaDisplayVideo.tsx
@@ -73,7 +73,7 @@ const MediaDisplayVideo: React.FC<Props> = ({
 
     const pauseWhenFullscreenCloses = () => {
       const vid = videoRef.current;
-      if (!vid || document.fullscreenElement === vid) {
+      if (!vid || document.fullscreenElement) {
         return;
       }
 

--- a/components/drops/view/item/content/media/MediaDisplayVideo.tsx
+++ b/components/drops/view/item/content/media/MediaDisplayVideo.tsx
@@ -5,8 +5,7 @@ import { useInView } from "@/hooks/useInView";
 import { useOptimizedVideo } from "@/hooks/useOptimizedVideo";
 import { useHlsPlayer } from "@/hooks/useHlsPlayer";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
-import { PlayIcon } from "@heroicons/react/24/solid";
-import { InlineMediaActions } from "./MediaActionToolbar";
+import SeizeVideoPlayer from "./SeizeVideoPlayer";
 import { useMediaActions } from "./useMediaActions";
 
 interface Props {
@@ -46,8 +45,6 @@ const MediaDisplayVideo: React.FC<Props> = ({
     fallbackSrc: src, // if HLS fails, revert to original
     autoPlay: inView && !isApp, // only autoplay if in view and not in app
   });
-  const showNativeControls = showControls && !isApp;
-
   // Inline attributes for iOS / legacy WebKit
   useEffect(() => {
     const vid = videoRef.current;
@@ -92,79 +89,17 @@ const MediaDisplayVideo: React.FC<Props> = ({
     };
   }, [isApp, videoRef]);
 
-  const handleVideoClick = () => {
-    if (showControls) {
-      return;
-    }
-
-    const vid = videoRef.current;
-    if (!vid) {
-      return;
-    }
-
-    if (vid.paused) {
-      vid.play().catch(() => {});
-      return;
-    }
-
-    vid.pause();
-  };
-
-  const enterFullscreenAndPlay = () => {
-    const vid = videoRef.current;
-    if (!vid) {
-      return;
-    }
-
-    vid.play().catch(() => undefined);
-    vid.requestFullscreen().catch(() => undefined);
-  };
-
   return (
-    <div
-      ref={wrapperRef}
-      className="tw-relative tw-max-h-64 tw-min-h-[200px] tw-w-full tw-overflow-hidden tw-rounded-xl tw-bg-black"
-    >
-      <video
-        ref={videoRef}
-        onClick={() => {
-          if (showControls && isApp) {
-            enterFullscreenAndPlay();
-            return;
-          }
-          handleVideoClick();
-        }}
-        className="tw-h-auto tw-max-h-64 tw-w-full tw-rounded-xl tw-object-contain"
-        muted
-        loop
-        controls={showNativeControls}
-        controlsList="nodownload noplaybackrate"
-        playsInline
-        preload="auto"
+    <div ref={wrapperRef} className="tw-flex tw-w-full tw-justify-start">
+      <SeizeVideoPlayer
+        videoRef={videoRef}
+        autoPlay={false}
+        showActions={showControls}
+        onDownload={showControls ? downloadMedia : undefined}
+        onOpen={showControls ? openMedia : undefined}
+        openLabel={showControls ? openLabel : undefined}
+        isDownloading={isDownloading}
       />
-      {showControls && isApp && (
-        <button
-          type="button"
-          aria-label="Play video"
-          title="Play video"
-          onClick={(event) => {
-            event.stopPropagation();
-            enterFullscreenAndPlay();
-          }}
-          className="tw-absolute tw-left-1/2 tw-top-1/2 tw-z-20 tw-flex tw-size-16 -tw-translate-x-1/2 -tw-translate-y-1/2 tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-bg-iron-700/75 tw-text-white tw-shadow-lg tw-shadow-black/30 tw-backdrop-blur-sm"
-        >
-          <PlayIcon className="tw-ml-1 tw-size-8" aria-hidden="true" />
-        </button>
-      )}
-      {showControls && (
-        <InlineMediaActions
-          variant="video"
-          onDownload={downloadMedia}
-          onOpen={openMedia}
-          openLabel={openLabel}
-          isDownloading={isDownloading}
-        />
-      )}
     </div>
   );
 };

--- a/components/drops/view/item/content/media/MediaDisplayVideo.tsx
+++ b/components/drops/view/item/content/media/MediaDisplayVideo.tsx
@@ -57,6 +57,10 @@ const MediaDisplayVideo: React.FC<Props> = ({
   useEffect(() => {
     const vid = videoRef.current;
     if (!vid || isLoading) return;
+    const fullscreenElement = document.fullscreenElement;
+    if (fullscreenElement?.contains(vid) ?? false) {
+      return;
+    }
 
     if (!inView || isApp) {
       vid.pause();

--- a/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
+++ b/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
@@ -32,6 +32,7 @@ interface SeizeVideoPlayerProps {
   readonly className?: string | undefined;
   readonly videoClassName?: string | undefined;
   readonly showActions?: boolean | undefined;
+  readonly showFullscreen?: boolean | undefined;
   readonly onDownload?: (() => void) | undefined;
   readonly onOpen?: (() => void) | undefined;
   readonly openLabel?: string | undefined;
@@ -63,7 +64,7 @@ type FullscreenDocument = Document & {
   msExitFullscreen?: () => Promise<void> | void;
 };
 
-type FullscreenElement = HTMLDivElement & {
+type FullscreenElement = HTMLElement & {
   webkitRequestFullscreen?: () => Promise<void> | void;
   mozRequestFullScreen?: () => Promise<void> | void;
   msRequestFullscreen?: () => Promise<void> | void;
@@ -236,6 +237,7 @@ export default function SeizeVideoPlayer({
   className,
   videoClassName,
   showActions = true,
+  showFullscreen = true,
   onDownload,
   onOpen,
   openLabel,
@@ -444,10 +446,10 @@ export default function SeizeVideoPlayer({
       return;
     }
 
-    const enteredWrapper = await enterFullscreen(
+    const enteredFullscreen = await enterFullscreen(
       wrapper as FullscreenElement
     ).catch(() => false);
-    if (!enteredWrapper) {
+    if (!enteredFullscreen) {
       enterNativeVideoFullscreen(video);
     }
     revealControls();
@@ -679,16 +681,24 @@ export default function SeizeVideoPlayer({
               <ArrowDownTrayIcon className="tw-size-5" aria-hidden="true" />
             </SeizeVideoControlButton>
           )}
-          <SeizeVideoControlButton
-            label={isFullscreen ? "Exit full screen" : "Full screen"}
-            onClick={requestFullscreen}
-          >
-            {isFullscreen ? (
-              <ArrowsPointingInIcon className="tw-size-5" aria-hidden="true" />
-            ) : (
-              <ArrowsPointingOutIcon className="tw-size-5" aria-hidden="true" />
-            )}
-          </SeizeVideoControlButton>
+          {showFullscreen && (
+            <SeizeVideoControlButton
+              label={isFullscreen ? "Exit full screen" : "Full screen"}
+              onClick={requestFullscreen}
+            >
+              {isFullscreen ? (
+                <ArrowsPointingInIcon
+                  className="tw-size-5"
+                  aria-hidden="true"
+                />
+              ) : (
+                <ArrowsPointingOutIcon
+                  className="tw-size-5"
+                  aria-hidden="true"
+                />
+              )}
+            </SeizeVideoControlButton>
+          )}
         </div>
       </div>
 

--- a/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
+++ b/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
@@ -257,6 +257,7 @@ export default function SeizeVideoPlayer({
   const [aspectRatio, setAspectRatio] = useState<string | undefined>();
   const [orientation, setOrientation] = useState("unknown");
   const [mutedState, setMutedState] = useState<{
+    readonly src?: string | undefined;
     readonly prop?: boolean | undefined;
     readonly value?: boolean | undefined;
   }>({});
@@ -416,7 +417,7 @@ export default function SeizeVideoPlayer({
   function toggleMuted(event: React.MouseEvent<HTMLButtonElement>) {
     event.preventDefault();
     event.stopPropagation();
-    setMutedState({ prop: muted, value: !isMuted });
+    setMutedState({ prop: muted, src, value: !isMuted });
     revealControls();
   }
 
@@ -528,7 +529,9 @@ export default function SeizeVideoPlayer({
   const isFillLayout = layout === "fill";
   const widthClassName = getNaturalWidthClassName(orientation, layout);
   const isMuted =
-    mutedState.prop === muted && typeof mutedState.value === "boolean"
+    mutedState.src === src &&
+    mutedState.prop === muted &&
+    typeof mutedState.value === "boolean"
       ? mutedState.value
       : muted;
   const controlsAreVisible = controlsVisible || isPaused || isFullscreen;

--- a/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
+++ b/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
@@ -256,7 +256,10 @@ export default function SeizeVideoPlayer({
   const resolvedVideoRef = videoRef ?? internalVideoRef;
   const [aspectRatio, setAspectRatio] = useState<string | undefined>();
   const [orientation, setOrientation] = useState("unknown");
-  const [isMuted, setIsMuted] = useState(muted);
+  const [mutedState, setMutedState] = useState<{
+    readonly prop?: boolean | undefined;
+    readonly value?: boolean | undefined;
+  }>({});
   const [isPaused, setIsPaused] = useState(!autoPlay);
   const [controlsVisible, setControlsVisible] = useState(true);
   const [progress, setProgress] = useState(0);
@@ -413,7 +416,7 @@ export default function SeizeVideoPlayer({
   function toggleMuted(event: React.MouseEvent<HTMLButtonElement>) {
     event.preventDefault();
     event.stopPropagation();
-    setIsMuted((current) => !current);
+    setMutedState({ prop: muted, value: !isMuted });
     revealControls();
   }
 
@@ -524,6 +527,10 @@ export default function SeizeVideoPlayer({
 
   const isFillLayout = layout === "fill";
   const widthClassName = getNaturalWidthClassName(orientation, layout);
+  const isMuted =
+    mutedState.prop === muted && typeof mutedState.value === "boolean"
+      ? mutedState.value
+      : muted;
   const controlsAreVisible = controlsVisible || isPaused || isFullscreen;
   const responsiveMediaStyle = getResponsiveMediaStyle();
   const directSrc =

--- a/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
+++ b/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
@@ -37,6 +37,9 @@ interface SeizeVideoPlayerProps {
   readonly openLabel?: string | undefined;
   readonly isDownloading?: boolean | undefined;
   readonly fallbackSources?: readonly string[] | undefined;
+  readonly onVideoClick?:
+    | ((event: React.MouseEvent<HTMLDivElement>) => void)
+    | undefined;
   readonly onError?: React.ReactEventHandler<HTMLVideoElement> | undefined;
   readonly "aria-label"?: string | undefined;
   readonly "data-testid"?: string | undefined;
@@ -64,6 +67,11 @@ type FullscreenElement = HTMLDivElement & {
   webkitRequestFullscreen?: () => Promise<void> | void;
   mozRequestFullScreen?: () => Promise<void> | void;
   msRequestFullscreen?: () => Promise<void> | void;
+};
+
+type NativeFullscreenVideo = HTMLVideoElement & {
+  webkitEnterFullscreen?: () => void;
+  webkitEnterFullScreen?: () => void;
 };
 
 function getFullscreenElement() {
@@ -97,13 +105,18 @@ function isFullscreenEnabled() {
 async function enterFullscreen(element: FullscreenElement) {
   if (typeof element.requestFullscreen === "function") {
     await element.requestFullscreen();
+    return true;
   } else if (typeof element.webkitRequestFullscreen === "function") {
     await element.webkitRequestFullscreen();
+    return true;
   } else if (typeof element.mozRequestFullScreen === "function") {
     await element.mozRequestFullScreen();
+    return true;
   } else if (typeof element.msRequestFullscreen === "function") {
     await element.msRequestFullscreen();
+    return true;
   }
+  return false;
 }
 
 async function exitFullscreen() {
@@ -117,6 +130,23 @@ async function exitFullscreen() {
   } else if (typeof doc.msExitFullscreen === "function") {
     await doc.msExitFullscreen();
   }
+}
+
+function enterNativeVideoFullscreen(video: HTMLVideoElement | null) {
+  if (!video) {
+    return false;
+  }
+
+  const nativeFullscreenVideo = video as NativeFullscreenVideo;
+  if (typeof nativeFullscreenVideo.webkitEnterFullscreen === "function") {
+    nativeFullscreenVideo.webkitEnterFullscreen();
+    return true;
+  }
+  if (typeof nativeFullscreenVideo.webkitEnterFullScreen === "function") {
+    nativeFullscreenVideo.webkitEnterFullScreen();
+    return true;
+  }
+  return false;
 }
 
 function getAspectRatio(width: number, height: number): string | undefined {
@@ -211,6 +241,7 @@ export default function SeizeVideoPlayer({
   openLabel,
   isDownloading = false,
   fallbackSources,
+  onVideoClick,
   onError,
   "aria-label": ariaLabel,
   "data-testid": dataTestId,
@@ -390,7 +421,15 @@ export default function SeizeVideoPlayer({
     event.preventDefault();
     event.stopPropagation();
     const wrapper = wrapperRef.current;
-    if (!wrapper || !isFullscreenEnabled()) {
+    const video = resolvedVideoRef.current;
+    if (!wrapper) {
+      enterNativeVideoFullscreen(video);
+      revealControls();
+      return;
+    }
+
+    if (!isFullscreenEnabled()) {
+      enterNativeVideoFullscreen(video);
       revealControls();
       return;
     }
@@ -401,13 +440,19 @@ export default function SeizeVideoPlayer({
       return;
     }
 
-    await enterFullscreen(wrapper as FullscreenElement).catch(() => undefined);
+    const enteredWrapper = await enterFullscreen(
+      wrapper as FullscreenElement
+    ).catch(() => false);
+    if (!enteredWrapper) {
+      enterNativeVideoFullscreen(video);
+    }
     revealControls();
   }
 
   function handleWrapperClick(event: React.MouseEvent<HTMLDivElement>) {
     event.preventDefault();
     event.stopPropagation();
+    onVideoClick?.(event);
     revealControls();
     togglePlayback();
   }

--- a/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
+++ b/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
@@ -1,0 +1,648 @@
+"use client";
+
+import { fullScreenSupported } from "@/helpers/Helpers";
+import {
+  ArrowDownTrayIcon,
+  ArrowTopRightOnSquareIcon,
+  ArrowsPointingInIcon,
+  ArrowsPointingOutIcon,
+  PauseIcon,
+  PlayIcon,
+  SpeakerWaveIcon,
+  SpeakerXMarkIcon,
+} from "@heroicons/react/24/solid";
+import clsx from "clsx";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+type VideoLayout = "natural" | "fill" | "prominent";
+type VideoAlign = "left" | "center";
+
+interface SeizeVideoPlayerProps {
+  readonly src?: string | undefined;
+  readonly videoRef?: React.RefObject<HTMLVideoElement | null> | undefined;
+  readonly id?: string | undefined;
+  readonly autoPlay?: boolean | undefined;
+  readonly muted?: boolean | undefined;
+  readonly loop?: boolean | undefined;
+  readonly preload?: "auto" | "metadata" | "none" | undefined;
+  readonly poster?: string | undefined;
+  readonly captionsSrc?: string | undefined;
+  readonly layout?: VideoLayout | undefined;
+  readonly align?: VideoAlign | undefined;
+  readonly className?: string | undefined;
+  readonly videoClassName?: string | undefined;
+  readonly showActions?: boolean | undefined;
+  readonly onDownload?: (() => void) | undefined;
+  readonly onOpen?: (() => void) | undefined;
+  readonly openLabel?: string | undefined;
+  readonly isDownloading?: boolean | undefined;
+  readonly fallbackSources?: readonly string[] | undefined;
+  readonly onError?: React.ReactEventHandler<HTMLVideoElement> | undefined;
+  readonly "aria-label"?: string | undefined;
+  readonly "data-testid"?: string | undefined;
+  readonly "data-mime"?: string | undefined;
+  readonly "data-url"?: string | undefined;
+  readonly "data-disable"?: string | undefined;
+}
+
+const EMPTY_CAPTIONS_SRC = "data:text/vtt,WEBVTT";
+const CONTROL_HIDE_DELAY_MS = 1800;
+
+type FullscreenDocument = Document & {
+  readonly webkitFullscreenElement?: Element | null;
+  readonly mozFullScreenElement?: Element | null;
+  readonly msFullscreenElement?: Element | null;
+  readonly webkitFullscreenEnabled?: boolean | undefined;
+  readonly mozFullScreenEnabled?: boolean | undefined;
+  readonly msFullscreenEnabled?: boolean | undefined;
+  webkitExitFullscreen?: () => Promise<void> | void;
+  mozCancelFullScreen?: () => Promise<void> | void;
+  msExitFullscreen?: () => Promise<void> | void;
+};
+
+type FullscreenElement = HTMLDivElement & {
+  webkitRequestFullscreen?: () => Promise<void> | void;
+  mozRequestFullScreen?: () => Promise<void> | void;
+  msRequestFullscreen?: () => Promise<void> | void;
+};
+
+function getFullscreenElement() {
+  const doc = document as FullscreenDocument;
+  return (
+    document.fullscreenElement ??
+    doc.webkitFullscreenElement ??
+    doc.mozFullScreenElement ??
+    doc.msFullscreenElement ??
+    null
+  );
+}
+
+function isFullscreenEnabled() {
+  const doc = document as FullscreenDocument;
+  if (document.fullscreenEnabled) {
+    return true;
+  }
+  if (doc.webkitFullscreenEnabled === true) {
+    return true;
+  }
+  if (doc.mozFullScreenEnabled === true) {
+    return true;
+  }
+  if (doc.msFullscreenEnabled === true) {
+    return true;
+  }
+  return fullScreenSupported();
+}
+
+async function enterFullscreen(element: FullscreenElement) {
+  if (typeof element.requestFullscreen === "function") {
+    await element.requestFullscreen();
+  } else if (typeof element.webkitRequestFullscreen === "function") {
+    await element.webkitRequestFullscreen();
+  } else if (typeof element.mozRequestFullScreen === "function") {
+    await element.mozRequestFullScreen();
+  } else if (typeof element.msRequestFullscreen === "function") {
+    await element.msRequestFullscreen();
+  }
+}
+
+async function exitFullscreen() {
+  const doc = document as FullscreenDocument;
+  if (typeof document.exitFullscreen === "function") {
+    await document.exitFullscreen();
+  } else if (typeof doc.webkitExitFullscreen === "function") {
+    await doc.webkitExitFullscreen();
+  } else if (typeof doc.mozCancelFullScreen === "function") {
+    await doc.mozCancelFullScreen();
+  } else if (typeof doc.msExitFullscreen === "function") {
+    await doc.msExitFullscreen();
+  }
+}
+
+function getAspectRatio(width: number, height: number): string | undefined {
+  if (!Number.isFinite(width) || !Number.isFinite(height)) {
+    return undefined;
+  }
+  if (width <= 0 || height <= 0) {
+    return undefined;
+  }
+  return `${width} / ${height}`;
+}
+
+function getOrientation(width: number, height: number) {
+  if (width <= 0 || height <= 0) {
+    return "unknown";
+  }
+  if (width > height * 1.08) {
+    return "landscape";
+  }
+  if (height > width * 1.08) {
+    return "portrait";
+  }
+  return "square";
+}
+
+function getNaturalWidthClassName(orientation: string, layout: VideoLayout) {
+  if (layout === "fill") {
+    return "tw-h-full tw-w-full";
+  }
+
+  if (layout === "prominent") {
+    if (orientation === "portrait") {
+      return "tw-w-[min(100%,34rem)]";
+    }
+    if (orientation === "square") {
+      return "tw-w-[min(100%,42rem)]";
+    }
+    return "tw-w-full";
+  }
+
+  if (orientation === "portrait") {
+    return "tw-w-[min(100%,24rem)]";
+  }
+  if (orientation === "square") {
+    return "tw-w-[min(100%,32rem)]";
+  }
+  return "tw-w-full";
+}
+
+function SeizeVideoControlButton({
+  label,
+  onClick,
+  children,
+  disabled = false,
+}: {
+  readonly label: string;
+  readonly onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  readonly children: React.ReactNode;
+  readonly disabled?: boolean | undefined;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      disabled={disabled}
+      onClick={onClick}
+      className="tw-inline-flex tw-size-10 tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-bg-iron-950/70 tw-text-white tw-shadow-lg tw-shadow-black/25 tw-backdrop-blur-md tw-transition tw-duration-200 disabled:tw-cursor-default disabled:tw-opacity-60 desktop-hover:hover:tw-bg-iron-800/90"
+    >
+      {children}
+    </button>
+  );
+}
+
+export default function SeizeVideoPlayer({
+  src,
+  videoRef,
+  id,
+  autoPlay = true,
+  muted = true,
+  loop = true,
+  preload = "auto",
+  poster,
+  captionsSrc,
+  layout = "natural",
+  align = "left",
+  className,
+  videoClassName,
+  showActions = true,
+  onDownload,
+  onOpen,
+  openLabel,
+  isDownloading = false,
+  fallbackSources,
+  onError,
+  "aria-label": ariaLabel,
+  "data-testid": dataTestId,
+  "data-mime": dataMime,
+  "data-url": dataUrl,
+  "data-disable": dataDisable,
+}: SeizeVideoPlayerProps) {
+  const internalVideoRef = useRef<HTMLVideoElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const hideControlsTimerRef = useRef<number | null>(null);
+  const animationFrameRef = useRef<number | null>(null);
+  const resolvedVideoRef = videoRef ?? internalVideoRef;
+  const [aspectRatio, setAspectRatio] = useState<string | undefined>();
+  const [orientation, setOrientation] = useState("unknown");
+  const [isMuted, setIsMuted] = useState(muted);
+  const [isPaused, setIsPaused] = useState(!autoPlay);
+  const [controlsVisible, setControlsVisible] = useState(true);
+  const [progress, setProgress] = useState(0);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [videoSize, setVideoSize] = useState<
+    | {
+        readonly width: number;
+        readonly height: number;
+      }
+    | undefined
+  >();
+  const [viewportHeight, setViewportHeight] = useState<number | undefined>(
+    () => (typeof window === "undefined" ? undefined : window.innerHeight)
+  );
+  const [fallbackState, setFallbackState] = useState<{
+    readonly originSrc?: string | undefined;
+    readonly source?: string | undefined;
+  }>({});
+
+  const orderedFallbackSources = useMemo(() => {
+    const sources = [src, ...(fallbackSources ?? [])].filter(
+      (value): value is string => Boolean(value)
+    );
+    return Array.from(new Set(sources));
+  }, [fallbackSources, src]);
+
+  function clearHideControlsTimer() {
+    if (hideControlsTimerRef.current !== null) {
+      window.clearTimeout(hideControlsTimerRef.current);
+      hideControlsTimerRef.current = null;
+    }
+  }
+
+  function hideControlsSoon() {
+    clearHideControlsTimer();
+    hideControlsTimerRef.current = window.setTimeout(() => {
+      const video = resolvedVideoRef.current;
+      if (video && !video.paused) {
+        setControlsVisible(false);
+      }
+    }, CONTROL_HIDE_DELAY_MS);
+  }
+
+  function revealControls() {
+    setControlsVisible(true);
+    hideControlsSoon();
+  }
+
+  function updateProgress() {
+    const video = resolvedVideoRef.current;
+    if (!video || !Number.isFinite(video.duration) || video.duration <= 0) {
+      setProgress(0);
+      return;
+    }
+    setProgress(Math.min(100, (video.currentTime / video.duration) * 100));
+  }
+
+  function stopProgressAnimation() {
+    if (animationFrameRef.current !== null) {
+      window.cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
+    }
+  }
+
+  function startProgressAnimation() {
+    stopProgressAnimation();
+    const tick = () => {
+      updateProgress();
+      const video = resolvedVideoRef.current;
+      if (video && !video.paused && !video.ended) {
+        animationFrameRef.current = window.requestAnimationFrame(tick);
+      }
+    };
+    animationFrameRef.current = window.requestAnimationFrame(tick);
+  }
+
+  useEffect(() => {
+    const updateViewportHeight = () => {
+      setViewportHeight(window.innerHeight);
+    };
+    window.addEventListener("resize", updateViewportHeight);
+    return () => {
+      window.removeEventListener("resize", updateViewportHeight);
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(getFullscreenElement() === wrapperRef.current);
+      setControlsVisible(true);
+    };
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    document.addEventListener("webkitfullscreenchange", handleFullscreenChange);
+    document.addEventListener("mozfullscreenchange", handleFullscreenChange);
+    document.addEventListener("MSFullscreenChange", handleFullscreenChange);
+    return () => {
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+      document.removeEventListener(
+        "webkitfullscreenchange",
+        handleFullscreenChange
+      );
+      document.removeEventListener(
+        "mozfullscreenchange",
+        handleFullscreenChange
+      );
+      document.removeEventListener(
+        "MSFullscreenChange",
+        handleFullscreenChange
+      );
+    };
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      clearHideControlsTimer();
+      stopProgressAnimation();
+    };
+  }, []);
+
+  function handleMetadata() {
+    const video = resolvedVideoRef.current;
+    if (!video) return;
+    setVideoSize({ width: video.videoWidth, height: video.videoHeight });
+    setAspectRatio(getAspectRatio(video.videoWidth, video.videoHeight));
+    setOrientation(getOrientation(video.videoWidth, video.videoHeight));
+    updateProgress();
+  }
+
+  function handlePlay() {
+    setIsPaused(false);
+    startProgressAnimation();
+    hideControlsSoon();
+  }
+
+  function handlePause() {
+    setIsPaused(true);
+    setControlsVisible(true);
+    stopProgressAnimation();
+    updateProgress();
+  }
+
+  function togglePlayback() {
+    const video = resolvedVideoRef.current;
+    if (!video) return;
+
+    if (video.paused || video.ended) {
+      video.play().catch(() => undefined);
+      return;
+    }
+
+    video.pause();
+  }
+
+  function toggleMuted(event: React.MouseEvent<HTMLButtonElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+    setIsMuted((current) => !current);
+    revealControls();
+  }
+
+  async function requestFullscreen(event: React.MouseEvent<HTMLButtonElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+    const wrapper = wrapperRef.current;
+    if (!wrapper || !isFullscreenEnabled()) {
+      revealControls();
+      return;
+    }
+
+    if (getFullscreenElement() === wrapper) {
+      await exitFullscreen().catch(() => undefined);
+      revealControls();
+      return;
+    }
+
+    await enterFullscreen(wrapper as FullscreenElement).catch(() => undefined);
+    revealControls();
+  }
+
+  function handleWrapperClick(event: React.MouseEvent<HTMLDivElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+    revealControls();
+    togglePlayback();
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (event.key !== " " && event.key !== "Enter") {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    revealControls();
+    togglePlayback();
+  }
+
+  function handleError(event: React.SyntheticEvent<HTMLVideoElement, Event>) {
+    const currentIndex = orderedFallbackSources.findIndex(
+      (candidate) => candidate === directSrc
+    );
+    const nextSource = orderedFallbackSources[currentIndex + 1];
+    if (nextSource) {
+      event.currentTarget.src = nextSource;
+      event.currentTarget.load();
+      setFallbackState({ originSrc: src, source: nextSource });
+      return;
+    }
+    onError?.(event);
+  }
+
+  const stopAndRun =
+    (handler: () => void) => (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      handler();
+      revealControls();
+    };
+
+  function getResponsiveMediaStyle(): React.CSSProperties | undefined {
+    if (isFillLayout) {
+      return undefined;
+    }
+
+    const style: React.CSSProperties = {};
+    if (aspectRatio) {
+      style.aspectRatio = aspectRatio;
+    }
+
+    if (isFullscreen) {
+      return style;
+    }
+
+    const fallbackViewportHeight = viewportHeight ?? 900;
+    const maxViewportHeight =
+      layout === "prominent"
+        ? Math.max(320, fallbackViewportHeight - 220)
+        : Math.max(260, fallbackViewportHeight - 160);
+    const maxHeight = Math.min(
+      layout === "prominent" ? 650 : 520,
+      maxViewportHeight
+    );
+    style.maxHeight = `${maxHeight}px`;
+
+    if (videoSize && videoSize.height > videoSize.width) {
+      const ratio = videoSize.width / videoSize.height;
+      style.maxWidth = `${Math.floor(maxHeight * ratio)}px`;
+    }
+
+    return style;
+  }
+
+  const isFillLayout = layout === "fill";
+  const widthClassName = getNaturalWidthClassName(orientation, layout);
+  const controlsAreVisible = controlsVisible || isPaused || isFullscreen;
+  const responsiveMediaStyle = getResponsiveMediaStyle();
+  const directSrc =
+    fallbackState.originSrc === src ? (fallbackState.source ?? src) : src;
+  const videoSourceProps = directSrc ? { src: directSrc } : {};
+
+  return (
+    <div
+      ref={wrapperRef}
+      role="group"
+      tabIndex={0}
+      aria-label={ariaLabel ?? "Video player"}
+      onClick={handleWrapperClick}
+      onKeyDown={handleKeyDown}
+      onMouseMove={revealControls}
+      onMouseEnter={revealControls}
+      onMouseLeave={() => {
+        clearHideControlsTimer();
+        if (!isPaused) {
+          setControlsVisible(false);
+        }
+      }}
+      onTouchStart={revealControls}
+      className={clsx(
+        "tw-relative tw-max-w-full tw-cursor-pointer tw-overflow-hidden tw-rounded-xl tw-bg-transparent tw-outline-none tw-ring-primary-400/0 tw-transition focus-visible:tw-ring-2",
+        widthClassName,
+        align === "center" && "tw-mx-auto",
+        isFillLayout && "tw-flex tw-items-center tw-justify-center",
+        isFullscreen && "tw-h-screen tw-w-screen tw-rounded-none tw-bg-black",
+        className
+      )}
+      style={responsiveMediaStyle}
+      data-testid={dataTestId}
+      data-mime={dataMime}
+      data-url={dataUrl}
+      data-disable={dataDisable}
+    >
+      <video
+        id={id}
+        ref={resolvedVideoRef}
+        {...videoSourceProps}
+        autoPlay={autoPlay}
+        muted={isMuted}
+        loop={loop}
+        playsInline
+        preload={preload}
+        poster={poster}
+        controls={false}
+        controlsList="nodownload noplaybackrate"
+        {...{ "webkit-playsinline": "true", "x5-playsinline": "true" }}
+        onLoadedMetadata={handleMetadata}
+        onDurationChange={updateProgress}
+        onTimeUpdate={updateProgress}
+        onPlay={handlePlay}
+        onPause={handlePause}
+        onEnded={handlePause}
+        onError={handleError}
+        className={clsx(
+          "tw-block tw-h-full tw-w-full tw-rounded-xl tw-object-contain",
+          isFullscreen && "tw-rounded-none",
+          videoClassName
+        )}
+      >
+        {directSrc && <source src={directSrc} />}
+        <track
+          kind="captions"
+          src={captionsSrc ?? EMPTY_CAPTIONS_SRC}
+          srcLang="en"
+          label="No captions available"
+        />
+        Your browser does not support the video tag.
+      </video>
+
+      <div
+        className={clsx(
+          "tw-pointer-events-none tw-absolute tw-inset-0 tw-z-20 tw-transition-opacity tw-duration-200",
+          controlsAreVisible ? "tw-opacity-100" : "tw-opacity-0"
+        )}
+      >
+        {isPaused && (
+          <div className="tw-absolute tw-inset-0 tw-flex tw-items-center tw-justify-center">
+            <div className="tw-flex tw-size-16 tw-items-center tw-justify-center tw-rounded-full tw-bg-iron-950/65 tw-text-white tw-shadow-xl tw-shadow-black/30 tw-backdrop-blur-md">
+              <PlayIcon className="tw-ml-1 tw-size-8" aria-hidden="true" />
+            </div>
+          </div>
+        )}
+
+        <div className="tw-pointer-events-auto tw-absolute tw-bottom-4 tw-left-3">
+          <SeizeVideoControlButton
+            label={isMuted ? "Unmute video" : "Mute video"}
+            onClick={toggleMuted}
+          >
+            {isMuted ? (
+              <SpeakerXMarkIcon className="tw-size-5" aria-hidden="true" />
+            ) : (
+              <SpeakerWaveIcon className="tw-size-5" aria-hidden="true" />
+            )}
+          </SeizeVideoControlButton>
+        </div>
+
+        <div className="tw-pointer-events-auto tw-absolute tw-bottom-4 tw-right-3 tw-flex tw-items-center tw-gap-2">
+          {isPaused && (
+            <SeizeVideoControlButton
+              label="Play video"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                togglePlayback();
+              }}
+            >
+              <PlayIcon className="tw-ml-0.5 tw-size-5" aria-hidden="true" />
+            </SeizeVideoControlButton>
+          )}
+          {!isPaused && (
+            <SeizeVideoControlButton
+              label="Pause video"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                togglePlayback();
+              }}
+            >
+              <PauseIcon className="tw-size-5" aria-hidden="true" />
+            </SeizeVideoControlButton>
+          )}
+          {showActions && onOpen && openLabel && (
+            <SeizeVideoControlButton
+              label={openLabel}
+              onClick={stopAndRun(onOpen)}
+            >
+              <ArrowTopRightOnSquareIcon
+                className="tw-size-5"
+                aria-hidden="true"
+              />
+            </SeizeVideoControlButton>
+          )}
+          {showActions && onDownload && (
+            <SeizeVideoControlButton
+              label={isDownloading ? "Downloading media" : "Download media"}
+              onClick={stopAndRun(onDownload)}
+              disabled={isDownloading}
+            >
+              <ArrowDownTrayIcon className="tw-size-5" aria-hidden="true" />
+            </SeizeVideoControlButton>
+          )}
+          <SeizeVideoControlButton
+            label={isFullscreen ? "Exit full screen" : "Full screen"}
+            onClick={requestFullscreen}
+          >
+            {isFullscreen ? (
+              <ArrowsPointingInIcon className="tw-size-5" aria-hidden="true" />
+            ) : (
+              <ArrowsPointingOutIcon className="tw-size-5" aria-hidden="true" />
+            )}
+          </SeizeVideoControlButton>
+        </div>
+      </div>
+
+      <div className="tw-pointer-events-none tw-absolute tw-bottom-0 tw-left-0 tw-right-0 tw-z-30 tw-h-1 tw-bg-white/20">
+        <div
+          className="tw-h-full tw-bg-primary-400"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/lfg-slideshow/LFGSlideshow.tsx
+++ b/components/lfg-slideshow/LFGSlideshow.tsx
@@ -8,6 +8,7 @@ import { commonApiFetch } from "@/services/api/common-api";
 import type { ApiNftMedia } from "@/generated/models/ApiNftMedia";
 import { enterArtFullScreen, fullScreenSupported } from "@/helpers/Helpers";
 import { createPortal } from "react-dom";
+import SeizeVideoPlayer from "@/components/drops/view/item/content/media/SeizeVideoPlayer";
 
 const DEFAULT_TIMEOUT = 10000;
 const SLIDESHOW_ID = "lfg-slideshow";
@@ -193,23 +194,16 @@ const LFGSlideshow: React.FC<{
       </span>
       <div className={styles["slide"]} id={SLIDESHOW_ID}>
         {isVideo(currentAnimation) ? (
-          <video
-            ref={videoRef}
+          <SeizeVideoPlayer
+            videoRef={videoRef}
             autoPlay
-            controls
-            playsInline
             muted={isMuted}
             src={currentAnimation}
             poster={currentImage.length > 0 ? currentImage : undefined}
-          >
-            <track
-              kind="captions"
-              src={EMPTY_CAPTIONS_SRC}
-              srcLang="en"
-              label="No captions available"
-            />
-            Your browser does not support the video tag.
-          </video>
+            captionsSrc={EMPTY_CAPTIONS_SRC}
+            loop={false}
+            layout="fill"
+          />
         ) : (
           <img src={currentImage} alt={`LFG Slide ${currentIndex + 1}`} />
         )}

--- a/components/nft-image/RememeImage.tsx
+++ b/components/nft-image/RememeImage.tsx
@@ -3,6 +3,7 @@ import { Col } from "react-bootstrap";
 import type { Rememe } from "@/entities/INFT";
 import Image from "next/image";
 import { parseIpfsUrl, parseIpfsUrlToGateway } from "@/helpers/Helpers";
+import SeizeVideoPlayer from "@/components/drops/view/item/content/media/SeizeVideoPlayer";
 
 interface Props {
   nft: Rememe;
@@ -104,21 +105,16 @@ export default function RememeImage(props: Readonly<Props>) {
           props.height === 650 ? styles["height650"] : styles["height300"]
         } d-flex justify-content-center align-items-center`}
       >
-        <video
+        <SeizeVideoPlayer
           id={`${props.nft.contract}-${props.nft.id}`}
+          src={videoFallbackUrls[0]}
+          fallbackSources={videoFallbackUrls.slice(1)}
           autoPlay={props.animation}
           muted
-          controls
           loop
-          playsInline
-          src={videoFallbackUrls[0]}
-          onError={({ currentTarget }) => {
-            const nextFallback = videoFallbackUrls.shift();
-            if (nextFallback) {
-              currentTarget.src = nextFallback;
-            }
-          }}
-        ></video>
+          layout={props.height === 650 ? "prominent" : "natural"}
+          align="center"
+        />
       </Col>
     );
   }

--- a/components/nft-image/renderers/NFTVideoRenderer.tsx
+++ b/components/nft-image/renderers/NFTVideoRenderer.tsx
@@ -1,33 +1,25 @@
 "use client";
 
+import SeizeVideoPlayer from "@/components/drops/view/item/content/media/SeizeVideoPlayer";
 import NFTImageBalance from "@/components/nft-image/NFTImageBalance";
 import NFTMediaContainer from "@/components/nft-image/NFTMediaContainer";
 import styles from "@/components/nft-image/NFTImage.module.scss";
 import type { BaseRendererProps } from "@/components/nft-image/types/renderer-props";
 import { getResolvedAnimationSrc } from "@/components/nft-image/utils/animation-source";
-import { withArweaveFallback } from "@/components/nft-image/utils/gateway-fallback";
-
-const globalScope = globalThis as typeof globalThis & {
-  window?: Window | undefined;
-};
 
 export default function NFTVideoRenderer(props: Readonly<BaseRendererProps>) {
   const animationSrc = getResolvedAnimationSrc(props.nft);
   const animationClassName = styles["nftAnimation"] ?? "";
   const compressedAnimationSrc =
     "metadata" in props.nft ? props.nft.compressed_animation : undefined;
-  const normalizedCompressedAnimationSrc = (() => {
-    if (compressedAnimationSrc === undefined || compressedAnimationSrc === "") {
-      return undefined;
-    }
-
-    try {
-      const baseUrl = globalScope.window.location.href;
-      return new URL(compressedAnimationSrc, baseUrl).href;
-    } catch {
-      return undefined;
-    }
-  })();
+  const primarySrc =
+    !props.showOriginal &&
+    "metadata" in props.nft &&
+    props.nft.compressed_animation
+      ? props.nft.compressed_animation
+      : animationSrc;
+  const fallbackSources =
+    compressedAnimationSrc && animationSrc ? [animationSrc] : [];
 
   return (
     <NFTMediaContainer
@@ -40,32 +32,19 @@ export default function NFTVideoRenderer(props: Readonly<BaseRendererProps>) {
           height={props.height}
         />
       )}
-      <video
+      <SeizeVideoPlayer
         id={props.id ?? `video-${props.nft.id}`}
+        src={primarySrc}
+        fallbackSources={fallbackSources}
         autoPlay
         muted
-        controls
         loop
-        playsInline
         preload="auto"
-        src={
-          !props.showOriginal &&
-          "metadata" in props.nft &&
-          props.nft.compressed_animation
-            ? props.nft.compressed_animation
-            : animationSrc
-        }
-        className={props.imageStyle}
-        onError={withArweaveFallback(({ currentTarget }) => {
-          if (
-            "metadata" in props.nft &&
-            currentTarget.src === normalizedCompressedAnimationSrc &&
-            animationSrc
-          ) {
-            currentTarget.src = animationSrc;
-          }
-        })}
-      ></video>
+        layout="prominent"
+        align="center"
+        className={`${animationClassName} ${props.heightStyle} ${props.bgStyle} tw-flex tw-items-center tw-justify-center`}
+        videoClassName={props.imageStyle}
+      />
     </NFTMediaContainer>
   );
 }

--- a/components/timeline/TimelineMedia.tsx
+++ b/components/timeline/TimelineMedia.tsx
@@ -1,4 +1,5 @@
 import styles from "./Timeline.module.scss";
+import SeizeVideoPlayer from "@/components/drops/view/item/content/media/SeizeVideoPlayer";
 import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
 
@@ -21,16 +22,15 @@ export default function TimelineMediaComponent(props: Readonly<Props>) {
 
   if (props.type === MediaType.VIDEO) {
     return (
-      <video
-        aria-label={t(locale, "timeline.media.videoAriaLabel", { label })}
-        autoPlay
-        muted
-        controls
-        loop
-        playsInline
+      <SeizeVideoPlayer
         className={styles["timelineMediaImage"]}
         src={props.url}
-      ></video>
+        autoPlay
+        muted
+        loop
+        align="center"
+        aria-label={t(locale, "timeline.media.videoAriaLabel", { label })}
+      />
     );
   }
   if (props.type === MediaType.HTML) {

--- a/components/waves/TwitterPreviewCard.tsx
+++ b/components/waves/TwitterPreviewCard.tsx
@@ -31,6 +31,7 @@ import type {
 } from "@/lib/twitter";
 import { parseTweetUrl } from "@/lib/twitter/url";
 import { fetchTwitterPreview } from "@/services/api/twitter-preview-api";
+import SeizeVideoPlayer from "@/components/drops/view/item/content/media/SeizeVideoPlayer";
 
 import { useLinkPreviewContext } from "./LinkPreviewContext";
 
@@ -983,29 +984,16 @@ function TwitterVideoPlayer({
           />
         </>
       )}
-      <video
-        ref={videoRef}
+      <SeizeVideoPlayer
+        videoRef={videoRef}
         poster={posterUrl}
         className={className}
-        controls
-        playsInline
         preload="metadata"
         autoPlay={autoPlay}
-        onClick={(event) => {
-          if (isMenuOpen) {
-            setIsMenuOpen(false);
-          }
-          stopMediaEvent(event);
-        }}
-      >
-        <track
-          kind="captions"
-          src={captionsUrl ?? "data:text/vtt,WEBVTT"}
-          srcLang="en"
-          label="Captions"
-          default
-        />
-      </video>
+        captionsSrc={captionsUrl}
+        layout="fill"
+        showActions={false}
+      />
     </div>
   );
 }

--- a/components/waves/TwitterPreviewCard.tsx
+++ b/components/waves/TwitterPreviewCard.tsx
@@ -993,6 +993,10 @@ function TwitterVideoPlayer({
         captionsSrc={captionsUrl}
         layout="fill"
         showActions={false}
+        onVideoClick={(event) => {
+          stopMediaEvent(event);
+          setIsMenuOpen(false);
+        }}
       />
     </div>
   );

--- a/components/waves/drop/WaveDropAdditionalInfo.tsx
+++ b/components/waves/drop/WaveDropAdditionalInfo.tsx
@@ -5,6 +5,7 @@ import {
   MemesSubmissionAdditionalInfoKey,
 } from "@/components/waves/memes/submission/types/OperationalData";
 import { FallbackImage } from "@/components/common/FallbackImage";
+import SeizeVideoPlayer from "@/components/drops/view/item/content/media/SeizeVideoPlayer";
 import { resolveIpfsUrlSync } from "@/components/ipfs/IPFSContext";
 import { getFileInfoFromUrl } from "@/helpers/file.helpers";
 import { getScaledImageUri, ImageScale } from "@/helpers/image.helpers";
@@ -161,20 +162,13 @@ export const WaveDropAdditionalInfo = ({
             Promo Video
           </h3>
           <div className="tw-flex tw-justify-center">
-            <div className="tw-relative tw-aspect-video tw-w-full tw-max-w-2xl tw-overflow-hidden tw-bg-white/[0.02]">
-              <video
+            <div className="tw-flex tw-w-full tw-max-w-2xl tw-justify-center">
+              <SeizeVideoPlayer
                 src={promoVideo}
-                className="tw-h-full tw-w-full tw-object-contain"
-                controls
                 preload="metadata"
-              >
-                <track
-                  kind="captions"
-                  src="data:text/vtt,WEBVTT"
-                  srcLang="en"
-                  label="Captions"
-                />
-              </video>
+                layout="prominent"
+                align="center"
+              />
             </div>
           </div>
         </div>
@@ -196,19 +190,11 @@ export const WaveDropAdditionalInfo = ({
                 }`}
               >
                 {item.isVideo ? (
-                  <video
+                  <SeizeVideoPlayer
                     src={item.url}
-                    className="tw-h-full tw-w-full tw-object-cover"
-                    controls
                     preload="metadata"
-                  >
-                    <track
-                      kind="captions"
-                      src="data:text/vtt,WEBVTT"
-                      srcLang="en"
-                      label="Captions"
-                    />
-                  </video>
+                    layout="fill"
+                  />
                 ) : (
                   <FallbackImage
                     primarySrc={item.displayUrl}

--- a/components/waves/drops/Drop.tsx
+++ b/components/waves/drops/Drop.tsx
@@ -46,6 +46,7 @@ interface DropProps {
   readonly mediaImageScale?: ImageScale | undefined;
   readonly fullWidthMedia?: boolean | undefined;
   readonly fullWidthLinkPreviews?: boolean | undefined;
+  readonly showVideoFullscreen?: boolean | undefined;
   readonly winningThreshold?: number | null | undefined;
   readonly winningThresholdMinDurationMs?: number | null | undefined;
   readonly isVotingClosed?: boolean | undefined;
@@ -79,6 +80,7 @@ export default function Drop({
   mediaImageScale,
   fullWidthMedia,
   fullWidthLinkPreviews,
+  showVideoFullscreen = true,
   winningThreshold,
   winningThresholdMinDurationMs,
   isVotingClosed = false,
@@ -185,7 +187,10 @@ export default function Drop({
     ),
   };
 
-  const memoizedValue = useMemo(() => ({ drop, location }), [drop, location]);
+  const memoizedValue = useMemo(
+    () => ({ drop, location, showVideoFullscreen }),
+    [drop, location, showVideoFullscreen]
+  );
 
   return (
     <DropContext.Provider value={memoizedValue}>

--- a/components/waves/drops/DropContext.tsx
+++ b/components/waves/drops/DropContext.tsx
@@ -7,6 +7,7 @@ import type { DropLocation } from "./drop.types";
 interface DropContextType {
   drop: ExtendedDrop | null;
   location: DropLocation;
+  showVideoFullscreen?: boolean | undefined;
 }
 
 const DropContext = createContext<DropContextType | undefined>(undefined);
@@ -17,6 +18,10 @@ export function useDropContext() {
     throw new Error("useDropContext must be used within a DropProvider");
   }
   return context;
+}
+
+export function useOptionalDropContext() {
+  return useContext(DropContext);
 }
 
 export default DropContext;

--- a/components/waves/drops/WaveDropPartContentMedias.tsx
+++ b/components/waves/drops/WaveDropPartContentMedias.tsx
@@ -61,11 +61,13 @@ const WaveDropPartContentMedias: React.FC<WaveDropPartContentMediasProps> = ({
     reserveMediaHeight,
     useNaturalHeightMedia,
     useCompactLink,
+    alignStart,
   }: {
     readonly groupedImage: boolean;
     readonly reserveMediaHeight: boolean;
     readonly useNaturalHeightMedia: boolean;
     readonly useCompactLink: boolean;
+    readonly alignStart: boolean;
   }) => {
     if (useCompactLink) {
       return "tw-w-full";
@@ -84,7 +86,10 @@ const WaveDropPartContentMedias: React.FC<WaveDropPartContentMediasProps> = ({
     }
 
     if (useNaturalHeightMedia) {
-      return "tw-flex tw-w-full tw-min-w-[min(200px,100%)] tw-max-h-64 tw-items-center tw-justify-center";
+      return clsx(
+        "tw-flex tw-w-full tw-min-w-[min(200px,100%)] tw-items-start",
+        alignStart ? "tw-justify-start" : "tw-justify-center"
+      );
     }
 
     return clsx(
@@ -103,10 +108,8 @@ const WaveDropPartContentMedias: React.FC<WaveDropPartContentMediasProps> = ({
       fullWidthMedia && media.mime_type.includes("image");
     const useImageReservedHeight =
       !fullWidthMedia && media.mime_type.includes("image");
-    const useVideoReservedHeight =
-      !fullWidthMedia && media.mime_type.includes("video");
-    const useNaturalHeightVideo =
-      fullWidthMedia && media.mime_type.includes("video");
+    const useVideoReservedHeight = false;
+    const useNaturalHeightVideo = media.mime_type.includes("video");
     const galleryItemId = media.mime_type.includes("image")
       ? getDropImageGalleryItemId("media", i, media.url)
       : undefined;
@@ -116,6 +119,7 @@ const WaveDropPartContentMedias: React.FC<WaveDropPartContentMediasProps> = ({
       reserveMediaHeight: useImageReservedHeight || useVideoReservedHeight,
       useNaturalHeightMedia: useNaturalHeightImage || useNaturalHeightVideo,
       useCompactLink,
+      alignStart: useNaturalHeightVideo,
     });
     let mediaContent;
 

--- a/components/waves/marketplace/MarketplaceItemPreviewMediaLink.tsx
+++ b/components/waves/marketplace/MarketplaceItemPreviewMediaLink.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import type { ReactNode } from "react";
 
 import MediaDisplay from "@/components/drops/view/item/content/media/MediaDisplay";
+import SeizeVideoPlayer from "@/components/drops/view/item/content/media/SeizeVideoPlayer";
 import type { ResolvedPreviewHref } from "./MarketplaceItemPreviewCard.types";
 import { MARKETPLACE_MEDIA_FRAME_CLASS } from "./previewLayout";
 
@@ -60,14 +61,13 @@ export default function MarketplaceItemPreviewMediaLink({
     );
   } else if (isVideo) {
     mediaContent = (
-      <video
+      <SeizeVideoPlayer
         src={mediaUrl}
-        className="tw-h-full tw-w-full tw-rounded-xl tw-object-contain"
-        muted
-        loop
-        playsInline
+        className="tw-h-full tw-w-full"
         preload="auto"
         autoPlay
+        layout="fill"
+        showActions={false}
         data-testid="media-display"
         data-mime={mediaMimeType}
         data-url={mediaUrl}

--- a/components/waves/memes/file-upload/components/FilePreview.tsx
+++ b/components/waves/memes/file-upload/components/FilePreview.tsx
@@ -5,6 +5,7 @@ import type { FilePreviewProps } from "../reducers/types";
 import VideoFallbackPreview from "./VideoFallbackPreview";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowsRotate, faCube } from "@fortawesome/free-solid-svg-icons";
+import SeizeVideoPlayer from "@/components/drops/view/item/content/media/SeizeVideoPlayer";
 
 // Dynamically import GLB viewer to avoid SSR issues
 const MediaDisplayGLB = dynamic(
@@ -67,10 +68,14 @@ const FilePreview: React.FC<FilePreviewProps> = ({
   );
 
   const renderVideoPreview = () => (
-    <video
+    <SeizeVideoPlayer
       src={url}
-      className="tw-max-h-full tw-max-w-full tw-object-contain tw-shadow-lg"
-      controls
+      className="tw-max-h-full tw-max-w-full tw-shadow-lg"
+      autoPlay={false}
+      preload="metadata"
+      layout="prominent"
+      align="center"
+      showActions={false}
       onError={(e) => {
         console.error("Video playback error:", e);
       }}

--- a/components/waves/memes/submission/components/AdditionalMediaUpload.tsx
+++ b/components/waves/memes/submission/components/AdditionalMediaUpload.tsx
@@ -4,6 +4,7 @@ import { PlusIcon } from "@heroicons/react/24/outline";
 import Image from "next/image";
 import type { ChangeEvent, FC, RefObject } from "react";
 import { memo, useCallback, useEffect, useMemo, useRef } from "react";
+import SeizeVideoPlayer from "@/components/drops/view/item/content/media/SeizeVideoPlayer";
 import { TraitWrapper } from "../../traits/TraitWrapper";
 import { MediaUploadItem, useMediaUpload } from "../hooks/useMediaUpload";
 import FormSection from "../ui/FormSection";
@@ -134,13 +135,13 @@ const AdditionalMediaUpload: FC<AdditionalMediaUploadProps> = ({
         className="tw-relative tw-aspect-square tw-overflow-hidden tw-rounded-lg tw-border tw-border-iron-800 tw-bg-iron-900"
       >
         {isVideo ? (
-          <video
+          <SeizeVideoPlayer
             src={item.previewUrl}
             className={previewClassName}
-            controls
             muted
-            playsInline
             preload="metadata"
+            layout="fill"
+            showActions={false}
           />
         ) : (
           <Image


### PR DESCRIPTION
## Summary
- Tighten video rendering and preview behavior across NFT, drop, wave, timeline, and meme upload surfaces.
- Update supporting media preview components to use the revised video handling path consistently.
- Add coverage for NFT video renderer behavior to guard against regressions.

## Testing
- Updated and reviewed component-level test coverage for NFT video rendering.
- Not run (not requested).