### PR TITLE
[codex] Fix delegation staging E2E issues

### DIFF
--- a/__tests__/components/delegation/html/delegationContent.test.ts
+++ b/__tests__/components/delegation/html/delegationContent.test.ts
@@ -86,6 +86,28 @@ describe("delegationContent", () => {
     expect(JSON.parse(publicManifest)).toEqual(JSON.parse(sourceManifest));
   });
 
+  it("publishes article images with alt text", async () => {
+    const missingAlt: string[] = [];
+
+    for (const [slug, article] of Object.entries(
+      delegationContentManifest.articles
+    )) {
+      const html = await readFile(getReviewedArticlePath(article), "utf8");
+      const template = document.createElement("template");
+      template.innerHTML = html;
+
+      for (const image of Array.from(
+        template.content.querySelectorAll("img")
+      )) {
+        if (!image.hasAttribute("alt")) {
+          missingAlt.push(`${slug}: ${image.getAttribute("src") ?? ""}`);
+        }
+      }
+    }
+
+    expect(missingAlt).toEqual([]);
+  });
+
   it("uses the reviewed local bundle while the IPFS CID is pending", () => {
     const article = getDelegationArticle("delegation-faq");
 

--- a/components/delegation/delegation-constants.ts
+++ b/components/delegation/delegation-constants.ts
@@ -27,24 +27,21 @@ export const MEMES_COLLECTION: DelegationCollection = {
   title: "The Memes",
   display: `The Memes - ${MEMES_CONTRACT}`,
   contract: MEMES_CONTRACT,
-  preview:
-    "https://d3lqz0a4bldqgf.cloudfront.net/images/scaled_x450/0x33FD426905F149f8376e227d0C9D3340AaD17aF1/1.WEBP",
+  preview: "/memes-preview.png",
 };
 
 export const MEME_LAB_COLLECTION: DelegationCollection = {
   title: "Meme Lab",
   display: `Meme Lab - ${MEMELAB_CONTRACT}`,
   contract: MEMELAB_CONTRACT,
-  preview:
-    "https://d3lqz0a4bldqgf.cloudfront.net/images/scaled_x450/0x4db52a61dc491e15a2f78f5ac001c14ffe3568cb/1.WEBP",
+  preview: "/meme-lab.jpg",
 };
 
 export const GRADIENTS_COLLECTION: DelegationCollection = {
   title: "6529 Gradient",
   display: `6529 Gradient - ${GRADIENT_CONTRACT}`,
   contract: GRADIENT_CONTRACT,
-  preview:
-    "https://d3lqz0a4bldqgf.cloudfront.net/images/scaled_x450/0x0c58ef43ff3032005e472cb5709f8908acb00205/0.WEBP",
+  preview: "/gradients-preview.png",
 };
 
 export const SUPPORTED_COLLECTIONS: DelegationCollection[] = [

--- a/content/delegation/manifest.json
+++ b/content/delegation/manifest.json
@@ -381,7 +381,7 @@
       "path": "html/register-delegation.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/register-delegation.html",
       "sourceUri": null,
-      "sha256": "31ce2842e8ff73d4de62d096b6067993340ebbce8488638bd537bdeb121e0801"
+      "sha256": "39f02aa853204f7f0327db558ba0b8011dbd0a909ebd0897d6277a7476539344"
     },
     "register-sub-delegation": {
       "title": "How to Register a Delegation Manager?",
@@ -390,7 +390,7 @@
       "path": "html/register-sub-delegation.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/register-sub-delegation.html",
       "sourceUri": null,
-      "sha256": "b32847c4ad659430d13d0ffa6caab370fc40224781b51cccc0054be836e2ecba"
+      "sha256": "3fcd286098883e5666d57c465395ef59a01bbf5df836989af70c38e63d4c10cd"
     },
     "register-consolidation": {
       "title": "How to Register a Consolidation?",
@@ -399,7 +399,7 @@
       "path": "html/register-consolidation.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/register-consolidation.html",
       "sourceUri": null,
-      "sha256": "d7dbb0df9ad3e71fac99a477be880d6d237c362b05838a4742d70b617d9ca360"
+      "sha256": "3f21039fdd816615c23c828539da9249d0afd36aa1d3a46a8e7e8e75144d7b35"
     },
     "reference-delegations-2address-del-manager": {
       "title": "How to Register Delegations (2-Address Architecture) with Delegation Manager?",
@@ -408,7 +408,7 @@
       "path": "html/reference-delegations-2address-del-manager.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/reference-delegations-2address-del-manager.html",
       "sourceUri": null,
-      "sha256": "6d87d53d4a4bb3d1195f1f4418fa9da31cb8dfbaf09ae2b16151cc3a98068be1"
+      "sha256": "ed4e91330a45276b6a3452351a75a1ace0f73cf1d78636bf9796c6472e881084"
     },
     "reference-delegations-3address-del-manager": {
       "title": "How to Register Delegations (TAP) with Delegation Manager?",
@@ -417,7 +417,7 @@
       "path": "html/reference-delegations-3address-del-manager.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/reference-delegations-3address-del-manager.html",
       "sourceUri": null,
-      "sha256": "81f4d5b48b78c856a65a31a581b86c1e233150fb69ef0aec7da9f1e70805df72"
+      "sha256": "9fa7669db4c87684e971f93ba311965c6a9d74ecbd7b8695599e1f7c756752c7"
     },
     "reference-consolidations-2address": {
       "title": "How to Register Consolidations (2-Address Architecture)?",
@@ -426,7 +426,7 @@
       "path": "html/reference-consolidations-2address.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/reference-consolidations-2address.html",
       "sourceUri": null,
-      "sha256": "e0c495f50d3ee36ee48ef1912b8dcd77f7b48df0d9b3a8c3f8ab634b04c71e88"
+      "sha256": "c5eb012a780f51bd95ea391b5b38077d3012631c72e9a18f5f5cbb00bb6b3cd9"
     },
     "reference-consolidations-3address": {
       "title": "How to Register Consolidations (TAP)?",
@@ -435,7 +435,7 @@
       "path": "html/reference-consolidations-3address.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/reference-consolidations-3address.html",
       "sourceUri": null,
-      "sha256": "bc3019f33b76d78f8c1c596879b04bf23480f658713a79ea1071c3e747bf2e94"
+      "sha256": "a0a74e85ee2dfea13720c5b1fa8878ae004e60c0d77248d56ba143232c4bac8a"
     },
     "reference-consolidations-3address-del-manager": {
       "title": "How to Register Consolidations (TAP) with Delegation Manager?",
@@ -444,7 +444,7 @@
       "path": "html/reference-consolidations-3address-del-manager.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/reference-consolidations-3address-del-manager.html",
       "sourceUri": null,
-      "sha256": "708e81247df24e47f94c556807804ac6fcd4bf887ca41f47b00bfd1c28290057"
+      "sha256": "ee83175ecd7bdcebf6b79e349659de5af9b3e36419ef91235392eb0776826a24"
     },
     "using-safe": {
       "title": "How to Delegate using SAFE (formerly GNOSIS)?",
@@ -453,7 +453,7 @@
       "path": "html/using-safe.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/using-safe.html",
       "sourceUri": null,
-      "sha256": "b88d389fc32193d8e7015b7fc3245a977b79cf24aaa78ea25c63c3bc62c563f1"
+      "sha256": "c75abde346ddb0cad7055f3e4200ab012690aadd2505e657571fe3aff8583595"
     },
     "use-cases-overview": {
       "title": "Which Use Cases are Supported?",
@@ -471,7 +471,7 @@
       "path": "html/view-delegations.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/view-delegations.html",
       "sourceUri": null,
-      "sha256": "7372ee3f0af310a7c661a3a9dd160dd67e8f8248837a7c05424954bf24aa1379"
+      "sha256": "6f9a72ff4713ea118c3efa5d3ac318ff41257923a218963f5d1ebceb7af70c27"
     },
     "view-sub-delegations": {
       "title": "How to View Your Delegation Managers?",
@@ -480,7 +480,7 @@
       "path": "html/view-sub-delegations.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/view-sub-delegations.html",
       "sourceUri": null,
-      "sha256": "769017de3ce98b964c6e73a67a0a40e9daac3cee4e6283d1003f0012c3ee9925"
+      "sha256": "88c2de34d7ad704cd1ab6d88905e0b497065d0ebf32c581790f5d0a6d5d3f9be"
     },
     "view-consolidations": {
       "title": "How to View Your Consolidations?",
@@ -489,7 +489,7 @@
       "path": "html/view-consolidations.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/view-consolidations.html",
       "sourceUri": null,
-      "sha256": "9793b8a8b894e9e38aecf854176d92385bb4397ed80cc218f032b11231834640"
+      "sha256": "b0af143773cdc0cd4c6f86032c12dab3951c34347345782498dce9e77937fe9c"
     },
     "manage-update": {
       "title": "How to Update a Delegation, Delegation Manager, or Consolidation?",
@@ -498,7 +498,7 @@
       "path": "html/manage-update.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/manage-update.html",
       "sourceUri": null,
-      "sha256": "519304288b84992e25f0e85fea0ae4853d7e23f618f079734e5dff9bd3106db5"
+      "sha256": "91d59c1a14213e5019a618e47f7b29a012023faeb58afc8e261550613e5d6e37"
     },
     "manage-revoke": {
       "title": "How to Revoke a Delegation, Delegation Manager, or Consolidation?",
@@ -507,7 +507,7 @@
       "path": "html/manage-revoke.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/manage-revoke.html",
       "sourceUri": null,
-      "sha256": "9c50eb855c2145cf4b42ce8eaaf18b4cdae0733a03a96032d99ed59655198c1c"
+      "sha256": "2179111bb5df8891b81dfa8d2902408bc6aac312a0ba4b48b55e57226005e8ab"
     },
     "register-delegation-using-sub-delegation": {
       "title": "How to Register a Delegation Using Delegation Management Rights?",
@@ -516,7 +516,7 @@
       "path": "html/register-delegation-using-sub-delegation.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/register-delegation-using-sub-delegation.html",
       "sourceUri": null,
-      "sha256": "476df1a30feda31e8dc906321b9df2767bf0d578ce8a92b46a7a0fafdbab36bc"
+      "sha256": "e21a8bcb7c13c445a04bf73766fce3b388cd916f2d6827eb3adf462c2a42b83b"
     },
     "revoke-delegation-using-sub-delegation": {
       "title": "How to Revoke a Delegation Using Delegation Management Rights?",
@@ -525,7 +525,7 @@
       "path": "html/revoke-delegation-using-sub-delegation.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/revoke-delegation-using-sub-delegation.html",
       "sourceUri": null,
-      "sha256": "661cd1486637d1cede70a1e4507fc7f7e5827d0532973dc782abbcaf30e7155d"
+      "sha256": "12c46f3cccc9acae8a41b80f361d5a3ef2dff5346d822d00c095e1588263a9f7"
     },
     "lock-global": {
       "title": "How to Lock Your Wallet for Any Collection?",
@@ -534,7 +534,7 @@
       "path": "html/lock-global.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/lock-global.html",
       "sourceUri": null,
-      "sha256": "716f1cdcc373e1ef6f080d3bf2106666d390603686e6f6b8b9096dbe02243adb"
+      "sha256": "607a9fa4f66b0de50d38d5b4964ee60dbeb5561706d49d520e668bdf3d6053c7"
     },
     "lock-collection": {
       "title": "How to Lock Your Wallet for a Specific Collection?",
@@ -543,7 +543,7 @@
       "path": "html/lock-collection.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/lock-collection.html",
       "sourceUri": null,
-      "sha256": "84ed73c5cd9644b26627385878e0a078d93658568b25ad16f8e974237db63feb"
+      "sha256": "c1fc51dd328544e92920f1d3eed35fd75ed475fd3ccce921c69adb129b397640"
     },
     "lock-use-case": {
       "title": "How to Lock Your Wallet for a Specific Use Case on a Collection?",
@@ -552,7 +552,7 @@
       "path": "html/lock-use-case.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/lock-use-case.html",
       "sourceUri": null,
-      "sha256": "34ce2fcb51d42245c6b1ea0b49f86ae4dc366e41997c833513d83c2f0cd11ec3"
+      "sha256": "ddea428b41d300b0a77b695ff3d58fc4fd8be28ad995f976ca4ba936ce72aab3"
     },
     "unlock-global": {
       "title": "How to Unlock Your Wallet for Any Collection?",
@@ -561,7 +561,7 @@
       "path": "html/unlock-global.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/unlock-global.html",
       "sourceUri": null,
-      "sha256": "22103e8b7d22aeefe5f1744816fe95e7a5c9bf63173f81050596c88061e39e19"
+      "sha256": "d23b8134255b726c6aa576dc0a8cc3047ebdc8a4f2cdeb5929dce526d9fb6af2"
     },
     "unlock-collection": {
       "title": "How to Unlock Your Wallet for a Specific Collection?",
@@ -570,7 +570,7 @@
       "path": "html/unlock-collection.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/unlock-collection.html",
       "sourceUri": null,
-      "sha256": "0fd1d8df301de34d064f6b076ca92dc8e85b1788a4db94430d9772033e15bb06"
+      "sha256": "24618638441199e17a31f5dd340943a981c27446864eb365398eb05875539f14"
     },
     "unlock-use-case": {
       "title": "How to Unlock Your Wallet for a Specific Use Case?",
@@ -579,7 +579,7 @@
       "path": "html/unlock-use-case.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/unlock-use-case.html",
       "sourceUri": null,
-      "sha256": "c830e53b2809068480804a464dadf1c407d9cdc2fd31458560a929e268fac7d1"
+      "sha256": "79978ff7b50eec8c5d51ba85f0c67d706eb927fc957b183a01ebdbbf8db6a991"
     }
   }
 }

--- a/ops/scripts/build-delegation-docs-content.mjs
+++ b/ops/scripts/build-delegation-docs-content.mjs
@@ -314,6 +314,49 @@ function rewriteContentReferences(rawHtml, assetSources, routeByArticleSlug) {
   return `${normalizeGeneratedHtml($.root().html()?.trim() ?? "")}\n`;
 }
 
+function humanizeAssetName(reference) {
+  const cleanReference = reference.split(/[?#]/, 1)[0] ?? "";
+  const fileName = decodeURIComponent(path.posix.basename(cleanReference));
+  const stem = fileName.replace(/\.[^.]+$/, "");
+  const words = stem
+    .replace(/__+/g, " ")
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return words || "delegation article image";
+}
+
+function inferImageKind(reference) {
+  if (reference.includes("/diagrams/")) {
+    return "diagram";
+  }
+
+  if (
+    reference.includes("/screenshots/") ||
+    reference.includes("/assets/html/")
+  ) {
+    return "screenshot";
+  }
+
+  return "image";
+}
+
+function addMissingImageAltText($) {
+  $("img").each((_, element) => {
+    const $element = $(element);
+
+    if ($element.attr("alt") !== undefined) {
+      return;
+    }
+
+    const reference = $element.attr("src") ?? "";
+    const label = humanizeAssetName(reference);
+    const kind = inferImageKind(reference);
+    $element.attr("alt", `${label} ${kind}`);
+  });
+}
+
 function sanitizeHtmlFragment(rawHtml) {
   const $ = cheerio.load(rawHtml, { decodeEntities: false }, false);
 
@@ -360,6 +403,8 @@ function sanitizeHtmlFragment(rawHtml) {
     relTokens.add("noreferrer");
     $element.attr("rel", [...relTokens].join(" "));
   });
+
+  addMissingImageAltText($);
 
   const sanitized = $.root().html()?.trim() ?? "";
 

--- a/public/delegation-content/delegation-docs-2026-06-16/html/lock-collection.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/lock-collection.html
@@ -16,6 +16,6 @@ To lock your wallet for a specific collection:<br>
 <ol>
   <li>Go to the Delegation Center Section and click the 'View/Manage' button for a specific collection (e.g., 'The Memes Collection').</li><br>
   <li>At the bottom of the Manage/View Any Collection page, click the 'Lock Wallet' button.<br>
-    <img src="../assets/screenshots/lock_wallet_global_1.png"></li><br>
+    <img src="../assets/screenshots/lock_wallet_global_1.png" alt="lock wallet global 1 screenshot"></li><br>
     <li>Execute the transaction.</li><br>
 </ol>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/lock-global.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/lock-global.html
@@ -13,6 +13,6 @@ To lock your wallet globally:<br>
 <ol>
   <li>Go to the Delegation Center Section and click the 'View/Manage' button for 'Any Collection'.</li><br>
   <li>At the bottom of the Manage/View Any Collection page, click the 'Lock Wallet' button.<br>
-    <img src="../assets/screenshots/lock_wallet_global_1.png"></li><br>
+    <img src="../assets/screenshots/lock_wallet_global_1.png" alt="lock wallet global 1 screenshot"></li><br>
     <li>Execute the transaction.</li><br>
 </ol>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/lock-use-case.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/lock-use-case.html
@@ -15,9 +15,9 @@ To lock your wallet for a specific use case:<br>
 <br>
 <ol>
   <li>At the bottom of the Manage/View Collection page, click on the 'Lock/Unlock Use Case' dropdown list and select a Use Case.<br>
-    <img src="../assets/screenshots/lock_wallet_usecase_1.png">
+    <img src="../assets/screenshots/lock_wallet_usecase_1.png" alt="lock wallet usecase 1 screenshot">
   </li><br>
   <li>2.	Click the 'Lock Use Case' button.<br>
-    <img src="../assets/screenshots/lock_wallet_usecase_2.png"></li><br>
+    <img src="../assets/screenshots/lock_wallet_usecase_2.png" alt="lock wallet usecase 2 screenshot"></li><br>
     <li>Execute the transaction.</li><br>
 </ol>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/manage-revoke.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/manage-revoke.html
@@ -13,7 +13,7 @@
     <li>
       On the Manage/View Collection page, find the address you want to revoke
       and click the 'Revoke' button next to it.<br>
-      <img src="../assets/screenshots/update_delegation_1.png">
+      <img src="../assets/screenshots/update_delegation_1.png" alt="update delegation 1 screenshot">
     </li>
     <br>
     <li>Execute the transaction.</li>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/manage-update.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/manage-update.html
@@ -13,7 +13,7 @@
     <li>
       On the Manage/View Collection page, find the address you want to update
       and click the 'Update' button next to it.<br>
-      <img src="../assets/screenshots/update_delegation_1.png">
+      <img src="../assets/screenshots/update_delegation_1.png" alt="update delegation 1 screenshot">
     </li>
     <br>
     <li>
@@ -27,7 +27,7 @@
         <li>
           Specify if the updated delegation applies to all tokens owned by the
           delegator or just a specific token.<br>
-          <img src="../assets/screenshots/update_delegation_2.png">
+          <img src="../assets/screenshots/update_delegation_2.png" alt="update delegation 2 screenshot">
         </li>
       </ul>
     </li>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/reference-consolidations-2address.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/reference-consolidations-2address.html
@@ -10,7 +10,7 @@
     <li>Address A (vault) : 0xAcf42B85eCb77d9332584119FD78a3DE9953c2a0</li><br>
     <li>Address B (transaction/minting wallet) : 0x3558C942EeA9e9Bb9b1a6A02d272756EDD3A1Fe4</li>
   </ul>
-  <img src="../assets/diagrams/2-address-consolidation.png">
+  <img src="../assets/diagrams/2-address-consolidation.png" alt="2 address consolidation diagram">
     <br>
   </div>
   <br><b>Using Address A:</b><br>
@@ -18,14 +18,14 @@
   <ul>
         <li>Navigate to the Delegation Center Section, click 'Register Consolidation,' choose 'The Memes' collection, enter wallet Address B, and execute the transaction.</li>
   </ul>
-  <img src="../assets/diagrams/2-add-con-trans1.png">
+  <img src="../assets/diagrams/2-add-con-trans1.png" alt="2 add con trans1 diagram">
 <br>
   <b>Using Address B:</b><br>
   <br> Set a consolidation with Address A:<br>
   <ul>
         <li>Navigate to the Delegation Center Section, click 'Register Consolidation,' choose 'The Memes' collection, enter wallet Address A, and execute the transaction.</li>
   </ul>
-  <img src="../assets/diagrams/2-add-con-trans2.png">
+  <img src="../assets/diagrams/2-add-con-trans2.png" alt="2 add con trans2 diagram">
 <br>
   In the Delegation Center Section, click 'View/Manage' in 'The Memes Collection,' and check the consolidation status in the Consolidations area.<br>
   <br><b>Notes</b><br>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/reference-consolidations-3address-del-manager.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/reference-consolidations-3address-del-manager.html
@@ -11,7 +11,7 @@
     <li>Address B (transaction wallet) : 0x3558C942EeA9e9Bb9b1a6A02d272756EDD3A1Fe4</li><br>
     <li>Address C (minting wallet) : 0xD0f03CB42Fe821c0654846E474c19484865c5B4a</li>
   </ul>
-  <img src="../assets/diagrams/3-address-consolidation.png">
+  <img src="../assets/diagrams/3-address-consolidation.png" alt="3 address consolidation diagram">
 <br>
   <br> Below is a process that assumes you have <a href="/delegation/wallet-architecture">TAP</a> and have granted Delegation Management (Sub-delegation) rights from your vault to your transaction wallet.
 <br>
@@ -23,7 +23,7 @@ Before proceeding please make sure that you granted <a href="/delegation/delegat
     <br>
     <li>Set a consolidation with Address A:<br>
       <br>
-      <img src="../assets/diagrams/3-address-consolidation-del-man-trans1.png">
+      <img src="../assets/diagrams/3-address-consolidation-del-man-trans1.png" alt="3 address consolidation del man trans1 diagram">
     <br>
       <ul>
         <li>Navigate to the Delegation Center Section, click 'Register Consolidation,' choose 'The Memes' collection, enter wallet Address A, and execute the transaction.</li>
@@ -32,7 +32,7 @@ Before proceeding please make sure that you granted <a href="/delegation/delegat
     <br>
     <li>Set a consolidation with Address C:<br>
       <br>
-      <img src="../assets/diagrams/3-address-consolidation-del-man-trans2.png">
+      <img src="../assets/diagrams/3-address-consolidation-del-man-trans2.png" alt="3 address consolidation del man trans2 diagram">
     <br>
       <ul>
         <li>Follow the same steps as above and enter wallet Address C.</li>
@@ -49,14 +49,14 @@ Before proceeding please make sure that you granted <a href="/delegation/delegat
     <br>
     <li>Register consolidation using Delegation Management (Sub-delegation) Rights:<br>
       <br>
-      <img src="../assets/diagrams/3-address-consolidation-del-man-trans3.png">
+      <img src="../assets/diagrams/3-address-consolidation-del-man-trans3.png" alt="3 address consolidation del man trans3 diagram">
     <br>
       <ul>
         <li>Choose 'The Memes' collection and enter wallet Address B.</li><br>
         <li>Execute the transaction.</li>
       </ul>
       <br>
-      <img src="../assets/diagrams/3-address-consolidation-del-man-trans4.png">
+      <img src="../assets/diagrams/3-address-consolidation-del-man-trans4.png" alt="3 address consolidation del man trans4 diagram">
     <br>
       <ul>
         <li>Choose 'The Memes' collection and enter wallet Address C.</li><br>
@@ -69,7 +69,7 @@ Before proceeding please make sure that you granted <a href="/delegation/delegat
     <br>
     <li>Set a consolidation with Address A:<br>
       <br>
-      <img src="../assets/diagrams/3-address-consolidation-del-man-trans5.png">
+      <img src="../assets/diagrams/3-address-consolidation-del-man-trans5.png" alt="3 address consolidation del man trans5 diagram">
     <br>
       <ul>
         <li>Navigate to the Delegation Center Section, click 'Register Consolidation,' choose 'The Memes' collection, enter wallet Address A, and execute the transaction.</li>
@@ -78,7 +78,7 @@ Before proceeding please make sure that you granted <a href="/delegation/delegat
     <br>
     <li>Set a consolidation with Address B:<br>
       <br>
-      <img src="../assets/diagrams/3-address-consolidation-del-man-trans6.png">
+      <img src="../assets/diagrams/3-address-consolidation-del-man-trans6.png" alt="3 address consolidation del man trans6 diagram">
     <br>
       <ul>
         <li>Follow the same steps as above and enter wallet Address B.</li>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/reference-consolidations-3address.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/reference-consolidations-3address.html
@@ -12,7 +12,7 @@
     <li>Address B (transaction wallet) : 0x3558C942EeA9e9Bb9b1a6A02d272756EDD3A1Fe4</li><br>
     <li>Address C (minting wallet) : 0xD0f03CB42Fe821c0654846E474c19484865c5B4a</li>
   </ul>
-  <img src="../assets/diagrams/3-address-consolidation.png">
+  <img src="../assets/diagrams/3-address-consolidation.png" alt="3 address consolidation diagram">
     <br>
   </div>
   <br><b>Using Address A:</b>
@@ -20,7 +20,7 @@
     <br>
     <li>Set a consolidation with Address B:<br>
       <br>
-      <img src="../assets/diagrams/3-address-consolidation-trans1.png">
+      <img src="../assets/diagrams/3-address-consolidation-trans1.png" alt="3 address consolidation trans1 diagram">
     <br>
       <ul>
         <li>Navigate to the Delegation Center Section, click 'Register Consolidation,' choose 'The Memes' collection, enter wallet Address B, and execute the transaction.</li>
@@ -29,7 +29,7 @@
     <br>
     <li>Set a consolidation with Address C:<br>
       <br>
-      <img src="../assets/diagrams/3-address-consolidation-trans2.png">
+      <img src="../assets/diagrams/3-address-consolidation-trans2.png" alt="3 address consolidation trans2 diagram">
   <br>
       <ul>
         <li>Follow the same steps as above and enter wallet Address C.</li>
@@ -42,7 +42,7 @@
     <br>
     <li>Set a consolidation with Address A:<br>
       <br>
-      <img src="../assets/diagrams/3-address-consolidation-trans3.png">
+      <img src="../assets/diagrams/3-address-consolidation-trans3.png" alt="3 address consolidation trans3 diagram">
   <br>
       <ul>
         <li>Navigate to the Delegation Center Section, click 'Register Consolidation,' choose 'The Memes' collection, enter wallet Address A, and execute the transaction.</li>
@@ -51,7 +51,7 @@
     <br>
     <li>Set a consolidation with Address C:<br>
       <br>
-      <img src="../assets/diagrams/3-address-consolidation-trans4.png">
+      <img src="../assets/diagrams/3-address-consolidation-trans4.png" alt="3 address consolidation trans4 diagram">
   <br>
       <ul>
         <li>Follow the same steps as above and enter wallet Address C.</li>
@@ -64,7 +64,7 @@
     <br>
     <li>Set a consolidation with Address A:<br>
       <br>
-      <img src="../assets/diagrams/3-address-consolidation-trans5.png">
+      <img src="../assets/diagrams/3-address-consolidation-trans5.png" alt="3 address consolidation trans5 diagram">
   <br>
       <ul>
         <li>Navigate to the Delegation Center Section, click 'Register Consolidation,' choose 'The Memes' collection, enter wallet Address A, and execute the transaction.</li>
@@ -73,7 +73,7 @@
     <br>
     <li>Set a consolidation with Address B:<br>
       <br>
-      <img src="../assets/diagrams/3-address-consolidation-trans6.png">
+      <img src="../assets/diagrams/3-address-consolidation-trans6.png" alt="3 address consolidation trans6 diagram">
   <br>
       <ul>
         <li>Follow the same steps as above and enter wallet Address B.</li>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/reference-delegations-2address-del-manager.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/reference-delegations-2address-del-manager.html
@@ -15,12 +15,12 @@
       Connect to Seize.io with Address A (vault):
       <ul>
         <br>
-        <img src="../assets/diagrams/set-delegation-manager.png">
+        <img src="../assets/diagrams/set-delegation-manager.png" alt="set delegation manager diagram">
         <li>Set Address B (transaction) as the Subdelegate of Address A.</li><br>
         <li>Go to the Delegation Center section and click the Register Delegation Manager (Sub-Delegation) button.</li><br>
         <li>Choose 'Any Collection' and enter the wallet Address B.<br>
           <br>
-          <img src="../assets/html/reference-delegation/proposed_set_delegation_step1__2.png">
+          <img src="../assets/html/reference-delegation/proposed_set_delegation_step1__2.png" alt="proposed set delegation step1 2 screenshot">
         </li><br>
         <li>Click on 'Submit' and execute the transaction.</li>
       </ul>
@@ -30,20 +30,20 @@
       Connect to Seize.io with Address B (transaction):
       <ol type="a">
         <br>
-        <img src="../assets/diagrams/register-using-delegation-manager-2add.png">
+        <img src="../assets/diagrams/register-using-delegation-manager-2add.png" alt="register using delegation manager 2add diagram">
         <li>
           Delegate Case 2 (minting/allowlist) on behalf of Address A (vault) to Address B (transaction).<br>
           <br>
           <ul>
             <li>Go to the Delegation Center section, click the View/Manage button on 'Any Collection,' and locate the incoming Delegation Manager under the Delegation Managers (Sub-delegations) area.
               <br>
-              <img src="../assets/html/reference-delegation/proposed_set_delegation_step2b__1.png">
+              <img src="../assets/html/reference-delegation/proposed_set_delegation_step2b__1.png" alt="proposed set delegation step2b 1 screenshot">
               <br>
 
             </li><br>
             <li>Select the Address of wallet A and click the Register Delegation button.
               <br>
-              <img src="../assets/html/reference-delegation/proposed_set_delegation_step2b__2.png">
+              <img src="../assets/html/reference-delegation/proposed_set_delegation_step2b__2.png" alt="proposed set delegation step2b 2 screenshot">
               <br>
             </li><br>
             <li>Complete the Register Delegation Using Delegation Management (Sub-delegation) Rights form:<br>
@@ -56,7 +56,7 @@
                 <li>Click on 'Submit' and execute the transaction.</li>
               </ul>
               <br>
-              <img src="../assets/screenshots/proposed_set_delegation-2address_step2b.png">
+              <img src="../assets/screenshots/proposed_set_delegation-2address_step2b.png" alt="proposed set delegation 2address step2b screenshot">
             <br>
             </li><br>
           </ul>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/reference-delegations-3address-del-manager.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/reference-delegations-3address-del-manager.html
@@ -18,12 +18,12 @@
       Connect to Seize.io with Address A (vault):
       <ul>
         <br>
-        <img src="../assets/diagrams/set-delegation-manager.png">
+        <img src="../assets/diagrams/set-delegation-manager.png" alt="set delegation manager diagram">
         <li>Set Address B (transaction) as the Subdelegate of Address A.</li><br>
         <li>Go to the Delegation Center section and click the Register Delegation Manager (Sub-Delegation) button.</li><br>
         <li>Choose 'Any Collection' and enter the wallet Address B.<br>
           <br>
-          <img src="../assets/html/reference-delegation/proposed_set_delegation_step1__2.png">
+          <img src="../assets/html/reference-delegation/proposed_set_delegation_step1__2.png" alt="proposed set delegation step1 2 screenshot">
         </li><br>
         <li>Click on 'Submit' and execute the transaction.</li>
       </ul>
@@ -42,24 +42,24 @@
             <li>Choose an expiry date (e.g., Never), specify if the delegation applies to all tokens owned by Address B or a specific token ID (it is recommended not to select a specific token ID).</li><br>
             <li>Click on 'Submit' and execute the transaction.</li><br>
           </ul>
-          <img src="../assets/html/reference-delegation/proposed_set_delegation_step2a__2.png">
+          <img src="../assets/html/reference-delegation/proposed_set_delegation_step2a__2.png" alt="proposed set delegation step2a 2 screenshot">
         </li>
         <br>
         <li>
           Delegate Case 2 (minting/allowlist) on behalf of Address A (vault) to Address C (minting).<br>
           <br>
-          <img src="../assets/diagrams/register-using-delegation-manager.png">
+          <img src="../assets/diagrams/register-using-delegation-manager.png" alt="register using delegation manager diagram">
 
           <ul>
             <li>Go to the Delegation Center section, click the View/Manage button on 'Any Collection,' and locate the incoming Delegation Manager under the Delegation Managers (Sub-delegations) area.
               <br>
-              <img src="../assets/html/reference-delegation/proposed_set_delegation_step2b__1.png">
+              <img src="../assets/html/reference-delegation/proposed_set_delegation_step2b__1.png" alt="proposed set delegation step2b 1 screenshot">
               <br>
 
             </li><br>
             <li>Select the Address of wallet A and click the Register Delegation button.
               <br>
-              <img src="../assets/html/reference-delegation/proposed_set_delegation_step2b__2.png">
+              <img src="../assets/html/reference-delegation/proposed_set_delegation_step2b__2.png" alt="proposed set delegation step2b 2 screenshot">
               <br>
             </li><br>
             <li>Complete the Register Delegation Using Delegation Management (Sub-delegation) Rights form:<br>
@@ -72,7 +72,7 @@
                 <li>Click on 'Submit' and execute the transaction.</li>
               </ul>
               <br>
-              <img src="../assets/html/reference-delegation/proposed_set_delegation_step2b__3.png">
+              <img src="../assets/html/reference-delegation/proposed_set_delegation_step2b__3.png" alt="proposed set delegation step2b 3 screenshot">
             <br>
             </li><br>
           </ul>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/register-consolidation.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/register-consolidation.html
@@ -13,7 +13,7 @@
   <ol>
     <li>Go to the Delegation Center section and click the Register Consolidation button.
       <div>
-        <img src="../assets/screenshots/how_to_register_consolidation_1.png">
+        <img src="../assets/screenshots/how_to_register_consolidation_1.png" alt="how to register consolidation 1 screenshot">
       </div>
     </li>
     <li>Complete the Register Consolidation Form: <br>
@@ -24,7 +24,7 @@
       <li>Click the 'Submit' button and execute the transaction.</li><br>
     </ol>
 <div>
-  <img src="../assets/screenshots/how_to_register_consolidation_2.png">
+  <img src="../assets/screenshots/how_to_register_consolidation_2.png" alt="how to register consolidation 2 screenshot">
 </div>
 Notes:<br>
 <br>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/register-delegation-using-sub-delegation.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/register-delegation-using-sub-delegation.html
@@ -10,7 +10,7 @@ by delegating all contract interactions, including changing delegations, to a "D
 <br>
 Before proceeding please make sure that granted <a href="/delegation/delegation-faq/register-sub-delegation">Delegation Management (Sub-delegation) rights from your vault to your transaction wallet</a>.
 <br>
-<img src="../assets/diagrams/register-using-delegation-manager.png">
+<img src="../assets/diagrams/register-using-delegation-manager.png" alt="register using delegation manager diagram">
     <br>
 <div>
   <ol>
@@ -23,13 +23,13 @@ Before proceeding please make sure that granted <a href="/delegation/delegation-
     <li>
       In the Delegation Managers (Sub-Delegations) area, check for incoming Sub-delegations. If any are
       present, related actions will be displayed within that area.<br>
-      <img src="../assets/screenshots/register_delegation_sub-del_1.png">
+      <img src="../assets/screenshots/register_delegation_sub-del_1.png" alt="register delegation sub del 1 screenshot">
     </li>
     <br>
     <li>
       To register a new delegation using Delegation Management (Sub-Delegation) rights, select the
       delegator address and click the 'Register Delegation' button. <br>
-      <img src="../assets/screenshots/register_delegation_sub-del_2.png">
+      <img src="../assets/screenshots/register_delegation_sub-del_2.png" alt="register delegation sub del 2 screenshot">
     </li>
     <br>
     <li>
@@ -54,7 +54,7 @@ Before proceeding please make sure that granted <a href="/delegation/delegation-
         <li>
           Specify if the delegation pertains to all tokens owned by the
           delegator or a specific token ID (e.g., 'All').<br>
-          <img src="../assets/screenshots/register_delegation_sub-del_3.png">
+          <img src="../assets/screenshots/register_delegation_sub-del_3.png" alt="register delegation sub del 3 screenshot">
         </li>
       </ul>
     </li>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/register-delegation.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/register-delegation.html
@@ -4,14 +4,14 @@ with an NFT without transferring the ownership of the NFT.
 <br>
 Simly put, you can use a delegation to allow a “hotter” wallet to take actions on behalf of a “colder” wallet.
 <br>
-<img src="../assets/diagrams/normal-delegation.png">
+<img src="../assets/diagrams/normal-delegation.png" alt="normal delegation diagram">
     <br>
 <div>
   <ol>
     <br>
     <li>Go to the Delegation Center Section and click the 'Register Delegation' button.
     </li>
-      <img src="../assets/screenshots/how_to_register_delegation_1.png">
+      <img src="../assets/screenshots/how_to_register_delegation_1.png" alt="how to register delegation 1 screenshot">
     <br>
     <li>Complete the Register Delegation Form:<br>
       <br>
@@ -28,5 +28,5 @@ Simly put, you can use a delegation to allow a “hotter” wallet to take actio
   </ol>
 </div>
 <div>
-<img src="../assets/screenshots/how_to_register_delegation_2.png">
+<img src="../assets/screenshots/how_to_register_delegation_2.png" alt="how to register delegation 2 screenshot">
 </div>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/register-sub-delegation.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/register-sub-delegation.html
@@ -13,11 +13,11 @@
     <li>Utilize the "Delegated Wallet" with Delegation Management (Sub-delegation) permissions to register future or additional delegations on behalf of the delegator.</li><br>
   </ol>
 </div>
-  <img src="../assets/diagrams/set-delegation-manager.png">
+  <img src="../assets/diagrams/set-delegation-manager.png" alt="set delegation manager diagram">
     <br>
 <div>
   To set up Delegation Management (Sub-delegation), go to the Delegation Center section and click the Register Delegation Manager (Sub-Delegation) button.<br>
-  <img src="../assets/screenshots/how_to_register_sub-delegation_1.png">
+  <img src="../assets/screenshots/how_to_register_sub-delegation_1.png" alt="how to register sub delegation 1 screenshot">
 </div>
 <div>
   To complete the Register Delegation Manager (Sub-Delegation) form:<br>
@@ -29,5 +29,5 @@
   </ol>
 </div>
 <div>
-<img src="../assets/screenshots/how_to_register_sub-delegation_2.png">
+<img src="../assets/screenshots/how_to_register_sub-delegation_2.png" alt="how to register sub delegation 2 screenshot">
 </div>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/revoke-delegation-using-sub-delegation.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/revoke-delegation-using-sub-delegation.html
@@ -14,13 +14,13 @@
     <li>
       In the  Delegation Managers (Sub-Delegations) area, check for incoming Sub-delegations. If any are
       present, related actions will be displayed within that area.<br>
-      <img src="../assets/screenshots/register_delegation_sub-del_1.png">
+      <img src="../assets/screenshots/register_delegation_sub-del_1.png" alt="register delegation sub del 1 screenshot">
     </li>
     <br>
     <li>
       To revoke a delegation using Delegation Management (Sub-Delegation) rights, select the delegator address for
       which you want to revoke the delegation and click the 'Revoke' button. <br>
-      <img src="../assets/screenshots/revoke_delegation_sub-del_1.png">
+      <img src="../assets/screenshots/revoke_delegation_sub-del_1.png" alt="revoke delegation sub del 1 screenshot">
     </li>
     <br>
     <li>
@@ -33,7 +33,7 @@
         <br>
         <li>Enter the wallet address.</li>
         <br>
-          <img src="../assets/screenshots/revoke_delegation_sub-del_2.png">
+          <img src="../assets/screenshots/revoke_delegation_sub-del_2.png" alt="revoke delegation sub del 2 screenshot">
 
       </ul>
     </li>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/unlock-collection.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/unlock-collection.html
@@ -4,7 +4,7 @@
 <ol>
   <li>Go to the Delegation Center Section and click the 'View/Manage' button for a specific collection (e.g., 'The Memes Collection').</li><br>
   <li>At the bottom of the Manage/View Any Collection page, click the 'Unlock Wallet' button.<br>
-    <img src="../assets/screenshots/unlock_collection_wallet_1.png"></li>
+    <img src="../assets/screenshots/unlock_collection_wallet_1.png" alt="unlock collection wallet 1 screenshot"></li>
     <li>Execute the transaction. Your wallet will be unlocked, and it will start accepting incoming delegations for that specific collection.</li><br>
 </ol>
 

--- a/public/delegation-content/delegation-docs-2026-06-16/html/unlock-global.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/unlock-global.html
@@ -4,7 +4,7 @@
 <ol>
   <li>Go to the Delegation Center Section and click the 'View/Manage' button for 'Any Collection'.</li><br>
   <li>At the bottom of the Manage/View Any Collection page, click the 'Unlock Wallet' button.<br>
-    <img src="../assets/screenshots/unlock_collection_wallet_1.png"></li>
+    <img src="../assets/screenshots/unlock_collection_wallet_1.png" alt="unlock collection wallet 1 screenshot"></li>
     <li>Execute the transaction. Your wallet will be unlocked, and it will start accepting incoming delegations for any collection.</li><br>
 </ol>
 

--- a/public/delegation-content/delegation-docs-2026-06-16/html/unlock-use-case.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/unlock-use-case.html
@@ -4,7 +4,7 @@
 <ol>
   <li>At the bottom of the Manage/View Collection page, click on the 'Lock/Unlock Use Case' dropdown list and select a locked Use Case.</li><br>
   <li>Click the 'Unlock Use Case' button.<br>
-    <img src="../assets/screenshots/unlock_wallet_usecase_1.png"></li>
+    <img src="../assets/screenshots/unlock_wallet_usecase_1.png" alt="unlock wallet usecase 1 screenshot"></li>
     <li>Execute the transaction. Your wallet will be unlocked, and it will start accepting incoming delegations for that specific use case on the collection.</li><br>
 </ol>
 

--- a/public/delegation-content/delegation-docs-2026-06-16/html/using-safe.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/using-safe.html
@@ -22,7 +22,7 @@ If you would like to set a different type of delegation, you would follow the sa
       <ul>
         <li>Enter the NFTDelegation.com smart contract Address: 0x2202CB9c00487e7e8EF21e6d8E914B32e709f43d</li><br>
         <li>Enter the NFTDelegation.com smart contract ABI. <a href="../assets/screenshots/NFTDelegationABI.js.json" target="_blank" rel="noopener noreferrer">Click here to get the ABI.</a></li>
-        <img src="../assets/screenshots/safe1.png">
+        <img src="../assets/screenshots/safe1.png" alt="safe1 screenshot">
       </ul>
     </li>
     <li>In the Transaction information Area:<br>
@@ -36,21 +36,21 @@ If you would like to set a different type of delegation, you would follow the sa
         <li>Enter true in the allTokens input box.</li><br>
         <li>Enter 0 in the tokenId input box.</li><br>
         <li>Click the 'Add transaction' button.</li>
-        <img src="../assets/screenshots/safe2.png">
+        <img src="../assets/screenshots/safe2.png" alt="safe2 screenshot">
       </ul>
     </li>
       <li>To Execute the transaction:<br>
         <br>
         <ul>
           <li>Click on the 'Create Batch' button.<br>
-            <img src="../assets/screenshots/safe3.png">
+            <img src="../assets/screenshots/safe3.png" alt="safe3 screenshot">
           </li>
           <li>Click on the 'Send Batch' button.<br>
-            <img src="../assets/screenshots/safe4.png">
+            <img src="../assets/screenshots/safe4.png" alt="safe4 screenshot">
 
           </li>
           <li>Click on the 'Submit' button and execute the transaction.<br>
-            <img src="../assets/screenshots/safe5.png">
+            <img src="../assets/screenshots/safe5.png" alt="safe5 screenshot">
           </li>
         </ul>
     </li>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/view-consolidations.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/view-consolidations.html
@@ -3,10 +3,10 @@
 <br>
 <ol>
   <li>Go to the Delegation Center Section and click the 'View/Manage' button for (e.g., 'Any Collection' for all collections or a specific collection such as 'The Memes Collection').<br>
-    <img src="../assets/screenshots/view_manage_1.png">
+    <img src="../assets/screenshots/view_manage_1.png" alt="view manage 1 screenshot">
   </li><br>
   <li>At the Consolidations Area you will be able to view your outgoing and incoming consolidations.<br>
-    <img src="../assets/screenshots/view_manage_5.png"></li>
+    <img src="../assets/screenshots/view_manage_5.png" alt="view manage 5 screenshot"></li>
 </ol>
 
 </div>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/view-delegations.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/view-delegations.html
@@ -3,10 +3,10 @@
 <br>
 <ol>
   <li>Go to the Delegation Center Section and click the 'View/Manage' button for (e.g., 'Any Collection' for all collections or a specific collection such as 'The Memes Collection').<br>
-    <img src="../assets/screenshots/view_manage_1.png">
+    <img src="../assets/screenshots/view_manage_1.png" alt="view manage 1 screenshot">
   </li><br>
   <li>At the Delegations Area you will be able to view your outgoing and incoming delegations.<br>
-    <img src="../assets/screenshots/view_manage_3.png"></li>
+    <img src="../assets/screenshots/view_manage_3.png" alt="view manage 3 screenshot"></li>
 </ol>
 
 </div>

--- a/public/delegation-content/delegation-docs-2026-06-16/html/view-sub-delegations.html
+++ b/public/delegation-content/delegation-docs-2026-06-16/html/view-sub-delegations.html
@@ -3,10 +3,10 @@
 <br>
 <ol>
   <li>Go to the Delegation Center Section and click the 'View/Manage' button for (e.g., 'Any Collection' for all collections or a specific collection such as 'The Memes Collection').<br>
-    <img src="../assets/screenshots/view_manage_1.png">
+    <img src="../assets/screenshots/view_manage_1.png" alt="view manage 1 screenshot">
   </li><br>
   <li>At the Delegation Managers (Sub-Delegations) Area you will be able to view your outgoing and incoming sub-delegations.<br>
-    <img src="../assets/screenshots/view_manage_4.png"></li>
+    <img src="../assets/screenshots/view_manage_4.png" alt="view manage 4 screenshot"></li>
 </ol>
 
 </div>

--- a/public/delegation-content/delegation-docs-2026-06-16/manifest.json
+++ b/public/delegation-content/delegation-docs-2026-06-16/manifest.json
@@ -381,7 +381,7 @@
       "path": "html/register-delegation.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/register-delegation.html",
       "sourceUri": null,
-      "sha256": "31ce2842e8ff73d4de62d096b6067993340ebbce8488638bd537bdeb121e0801"
+      "sha256": "39f02aa853204f7f0327db558ba0b8011dbd0a909ebd0897d6277a7476539344"
     },
     "register-sub-delegation": {
       "title": "How to Register a Delegation Manager?",
@@ -390,7 +390,7 @@
       "path": "html/register-sub-delegation.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/register-sub-delegation.html",
       "sourceUri": null,
-      "sha256": "b32847c4ad659430d13d0ffa6caab370fc40224781b51cccc0054be836e2ecba"
+      "sha256": "3fcd286098883e5666d57c465395ef59a01bbf5df836989af70c38e63d4c10cd"
     },
     "register-consolidation": {
       "title": "How to Register a Consolidation?",
@@ -399,7 +399,7 @@
       "path": "html/register-consolidation.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/register-consolidation.html",
       "sourceUri": null,
-      "sha256": "d7dbb0df9ad3e71fac99a477be880d6d237c362b05838a4742d70b617d9ca360"
+      "sha256": "3f21039fdd816615c23c828539da9249d0afd36aa1d3a46a8e7e8e75144d7b35"
     },
     "reference-delegations-2address-del-manager": {
       "title": "How to Register Delegations (2-Address Architecture) with Delegation Manager?",
@@ -408,7 +408,7 @@
       "path": "html/reference-delegations-2address-del-manager.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/reference-delegations-2address-del-manager.html",
       "sourceUri": null,
-      "sha256": "6d87d53d4a4bb3d1195f1f4418fa9da31cb8dfbaf09ae2b16151cc3a98068be1"
+      "sha256": "ed4e91330a45276b6a3452351a75a1ace0f73cf1d78636bf9796c6472e881084"
     },
     "reference-delegations-3address-del-manager": {
       "title": "How to Register Delegations (TAP) with Delegation Manager?",
@@ -417,7 +417,7 @@
       "path": "html/reference-delegations-3address-del-manager.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/reference-delegations-3address-del-manager.html",
       "sourceUri": null,
-      "sha256": "81f4d5b48b78c856a65a31a581b86c1e233150fb69ef0aec7da9f1e70805df72"
+      "sha256": "9fa7669db4c87684e971f93ba311965c6a9d74ecbd7b8695599e1f7c756752c7"
     },
     "reference-consolidations-2address": {
       "title": "How to Register Consolidations (2-Address Architecture)?",
@@ -426,7 +426,7 @@
       "path": "html/reference-consolidations-2address.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/reference-consolidations-2address.html",
       "sourceUri": null,
-      "sha256": "e0c495f50d3ee36ee48ef1912b8dcd77f7b48df0d9b3a8c3f8ab634b04c71e88"
+      "sha256": "c5eb012a780f51bd95ea391b5b38077d3012631c72e9a18f5f5cbb00bb6b3cd9"
     },
     "reference-consolidations-3address": {
       "title": "How to Register Consolidations (TAP)?",
@@ -435,7 +435,7 @@
       "path": "html/reference-consolidations-3address.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/reference-consolidations-3address.html",
       "sourceUri": null,
-      "sha256": "bc3019f33b76d78f8c1c596879b04bf23480f658713a79ea1071c3e747bf2e94"
+      "sha256": "a0a74e85ee2dfea13720c5b1fa8878ae004e60c0d77248d56ba143232c4bac8a"
     },
     "reference-consolidations-3address-del-manager": {
       "title": "How to Register Consolidations (TAP) with Delegation Manager?",
@@ -444,7 +444,7 @@
       "path": "html/reference-consolidations-3address-del-manager.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/reference-consolidations-3address-del-manager.html",
       "sourceUri": null,
-      "sha256": "708e81247df24e47f94c556807804ac6fcd4bf887ca41f47b00bfd1c28290057"
+      "sha256": "ee83175ecd7bdcebf6b79e349659de5af9b3e36419ef91235392eb0776826a24"
     },
     "using-safe": {
       "title": "How to Delegate using SAFE (formerly GNOSIS)?",
@@ -453,7 +453,7 @@
       "path": "html/using-safe.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/using-safe.html",
       "sourceUri": null,
-      "sha256": "b88d389fc32193d8e7015b7fc3245a977b79cf24aaa78ea25c63c3bc62c563f1"
+      "sha256": "c75abde346ddb0cad7055f3e4200ab012690aadd2505e657571fe3aff8583595"
     },
     "use-cases-overview": {
       "title": "Which Use Cases are Supported?",
@@ -471,7 +471,7 @@
       "path": "html/view-delegations.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/view-delegations.html",
       "sourceUri": null,
-      "sha256": "7372ee3f0af310a7c661a3a9dd160dd67e8f8248837a7c05424954bf24aa1379"
+      "sha256": "6f9a72ff4713ea118c3efa5d3ac318ff41257923a218963f5d1ebceb7af70c27"
     },
     "view-sub-delegations": {
       "title": "How to View Your Delegation Managers?",
@@ -480,7 +480,7 @@
       "path": "html/view-sub-delegations.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/view-sub-delegations.html",
       "sourceUri": null,
-      "sha256": "769017de3ce98b964c6e73a67a0a40e9daac3cee4e6283d1003f0012c3ee9925"
+      "sha256": "88c2de34d7ad704cd1ab6d88905e0b497065d0ebf32c581790f5d0a6d5d3f9be"
     },
     "view-consolidations": {
       "title": "How to View Your Consolidations?",
@@ -489,7 +489,7 @@
       "path": "html/view-consolidations.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/view-consolidations.html",
       "sourceUri": null,
-      "sha256": "9793b8a8b894e9e38aecf854176d92385bb4397ed80cc218f032b11231834640"
+      "sha256": "b0af143773cdc0cd4c6f86032c12dab3951c34347345782498dce9e77937fe9c"
     },
     "manage-update": {
       "title": "How to Update a Delegation, Delegation Manager, or Consolidation?",
@@ -498,7 +498,7 @@
       "path": "html/manage-update.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/manage-update.html",
       "sourceUri": null,
-      "sha256": "519304288b84992e25f0e85fea0ae4853d7e23f618f079734e5dff9bd3106db5"
+      "sha256": "91d59c1a14213e5019a618e47f7b29a012023faeb58afc8e261550613e5d6e37"
     },
     "manage-revoke": {
       "title": "How to Revoke a Delegation, Delegation Manager, or Consolidation?",
@@ -507,7 +507,7 @@
       "path": "html/manage-revoke.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/manage-revoke.html",
       "sourceUri": null,
-      "sha256": "9c50eb855c2145cf4b42ce8eaaf18b4cdae0733a03a96032d99ed59655198c1c"
+      "sha256": "2179111bb5df8891b81dfa8d2902408bc6aac312a0ba4b48b55e57226005e8ab"
     },
     "register-delegation-using-sub-delegation": {
       "title": "How to Register a Delegation Using Delegation Management Rights?",
@@ -516,7 +516,7 @@
       "path": "html/register-delegation-using-sub-delegation.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/register-delegation-using-sub-delegation.html",
       "sourceUri": null,
-      "sha256": "476df1a30feda31e8dc906321b9df2767bf0d578ce8a92b46a7a0fafdbab36bc"
+      "sha256": "e21a8bcb7c13c445a04bf73766fce3b388cd916f2d6827eb3adf462c2a42b83b"
     },
     "revoke-delegation-using-sub-delegation": {
       "title": "How to Revoke a Delegation Using Delegation Management Rights?",
@@ -525,7 +525,7 @@
       "path": "html/revoke-delegation-using-sub-delegation.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/revoke-delegation-using-sub-delegation.html",
       "sourceUri": null,
-      "sha256": "661cd1486637d1cede70a1e4507fc7f7e5827d0532973dc782abbcaf30e7155d"
+      "sha256": "12c46f3cccc9acae8a41b80f361d5a3ef2dff5346d822d00c095e1588263a9f7"
     },
     "lock-global": {
       "title": "How to Lock Your Wallet for Any Collection?",
@@ -534,7 +534,7 @@
       "path": "html/lock-global.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/lock-global.html",
       "sourceUri": null,
-      "sha256": "716f1cdcc373e1ef6f080d3bf2106666d390603686e6f6b8b9096dbe02243adb"
+      "sha256": "607a9fa4f66b0de50d38d5b4964ee60dbeb5561706d49d520e668bdf3d6053c7"
     },
     "lock-collection": {
       "title": "How to Lock Your Wallet for a Specific Collection?",
@@ -543,7 +543,7 @@
       "path": "html/lock-collection.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/lock-collection.html",
       "sourceUri": null,
-      "sha256": "84ed73c5cd9644b26627385878e0a078d93658568b25ad16f8e974237db63feb"
+      "sha256": "c1fc51dd328544e92920f1d3eed35fd75ed475fd3ccce921c69adb129b397640"
     },
     "lock-use-case": {
       "title": "How to Lock Your Wallet for a Specific Use Case on a Collection?",
@@ -552,7 +552,7 @@
       "path": "html/lock-use-case.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/lock-use-case.html",
       "sourceUri": null,
-      "sha256": "34ce2fcb51d42245c6b1ea0b49f86ae4dc366e41997c833513d83c2f0cd11ec3"
+      "sha256": "ddea428b41d300b0a77b695ff3d58fc4fd8be28ad995f976ca4ba936ce72aab3"
     },
     "unlock-global": {
       "title": "How to Unlock Your Wallet for Any Collection?",
@@ -561,7 +561,7 @@
       "path": "html/unlock-global.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/unlock-global.html",
       "sourceUri": null,
-      "sha256": "22103e8b7d22aeefe5f1744816fe95e7a5c9bf63173f81050596c88061e39e19"
+      "sha256": "d23b8134255b726c6aa576dc0a8cc3047ebdc8a4f2cdeb5929dce526d9fb6af2"
     },
     "unlock-collection": {
       "title": "How to Unlock Your Wallet for a Specific Collection?",
@@ -570,7 +570,7 @@
       "path": "html/unlock-collection.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/unlock-collection.html",
       "sourceUri": null,
-      "sha256": "0fd1d8df301de34d064f6b076ca92dc8e85b1788a4db94430d9772033e15bb06"
+      "sha256": "24618638441199e17a31f5dd340943a981c27446864eb365398eb05875539f14"
     },
     "unlock-use-case": {
       "title": "How to Unlock Your Wallet for a Specific Use Case?",
@@ -579,7 +579,7 @@
       "path": "html/unlock-use-case.html",
       "sourceUrl": "https://6529bucket.s3.eu-west-1.amazonaws.com/seize_html/delegations-center-getting-started/html/unlock-use-case.html",
       "sourceUri": null,
-      "sha256": "c830e53b2809068480804a464dadf1c407d9cdc2fd31458560a929e268fac7d1"
+      "sha256": "79978ff7b50eec8c5d51ba85f0c67d706eb927fc957b183a01ebdbbf8db6a991"
     }
   }
 }


### PR DESCRIPTION
## What changed

- Switch Delegation Center collection preview images from remote CloudFront token previews to existing local public assets.
- Make the delegation docs content builder add missing `alt` text to published article images.
- Regenerate the reviewed delegation docs HTML/package manifests.
- Add a regression test that fails if any packaged delegation article image is missing `alt` text.

## Why

Authenticated staging E2E found two real release blockers after #2678/#2679 landed: the collection preview images were 403ing from the old remote image URLs, and S3/CloudFront-rendered article HTML images lacked accessible names. This keeps the reviewed content package as the source of truth while making the published package accessible by construction.

## Verification

- `node ops\scripts\build-delegation-docs-content.mjs`
- `seize run test:no-coverage -- __tests__/components/delegation/html/delegationContent.test.ts __tests__/components/delegation/html/DelegationHTML.test.tsx __tests__/components/delegation/DelegationCenterMenu.test.tsx --runInBand`
- `codex-diff-check`
- `seize run lint:changed`
- `seize run typecheck:changed`

Note: a local full `seize run build` completed the Next.js route generation step but failed in the postbuild sitemap step with `ERR_UNKNOWN_FILE_EXTENSION` for `next-sitemap.config.ts`; this appears to match the known local Windows/loader issue seen on adjacent release work. CI/deploy builds should arbitrate the full build path.