### PR TITLE
[codex] Add rich GitHub preview cards

### DIFF
--- a/__tests__/app/api/github-preview.route.test.ts
+++ b/__tests__/app/api/github-preview.route.test.ts
@@ -267,6 +267,32 @@ describe("github-preview API route", () => {
     });
   });
 
+  it("omits file excerpts when line anchors start past the file length", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        type: "file",
+        name: "short.ts",
+        path: "short.ts",
+        size: 12,
+        encoding: "base64",
+        content: Buffer.from("const one = 1;\n").toString("base64"),
+        html_url: "https://github.com/o/r/blob/main/short.ts",
+      })
+    );
+
+    const response = await GET(
+      requestFor("https://github.com/o/r/blob/main/short.ts#L300-L320")
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      type: "github.file",
+      lineCount: 2,
+      lineStart: null,
+      lineEnd: null,
+      excerpt: null,
+    });
+  });
+
   it("tries longer ref splits for file links on slash-named branches", async () => {
     fetchMock
       .mockResolvedValueOnce(
@@ -316,6 +342,32 @@ describe("github-preview API route", () => {
       entries: ["a.ts", "b.ts", "components"],
       fileCount: 2,
       directoryCount: 1,
+    });
+  });
+
+  it("maps single-object GitHub directory responses with null excerpt fields", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        type: "dir",
+        name: "src",
+        path: "src",
+        html_url: "https://github.com/o/r/tree/main/src",
+      })
+    );
+
+    const response = await GET(
+      requestFor("https://github.com/o/r/tree/main/src")
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      type: "github.directory",
+      title: "src",
+      path: "src",
+      ref: "main",
+      lineCount: null,
+      lineStart: null,
+      lineEnd: null,
+      excerpt: null,
     });
   });
 
@@ -658,6 +710,52 @@ describe("github-preview API route", () => {
         failed: 0,
         pending: 0,
         url: "https://github.com/o/r/actions/runs/1/job/1",
+      },
+    });
+  });
+
+  it("falls back to combined status when check-runs are truncated", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          html_url: "https://github.com/o/r/pull/10",
+          title: "Lots of checks",
+          state: "open",
+          merged: false,
+          draft: false,
+          mergeable_state: "clean",
+          head: { ref: "feature/checks", sha: "abc123" },
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          total_count: 51,
+          check_runs: Array.from({ length: 50 }, () => ({
+            status: "completed",
+            conclusion: "success",
+          })),
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          state: "failure",
+          total_count: 1,
+          target_url: "https://github.com/o/r/actions",
+        })
+      );
+
+    const response = await GET(requestFor("https://github.com/o/r/pull/10"));
+
+    await expect(response.json()).resolves.toMatchObject({
+      type: "github.pull_request",
+      checks: {
+        state: "failure",
+        total: 1,
+        successful: null,
+        failed: null,
+        pending: null,
+        url: "https://github.com/o/r/actions",
       },
     });
   });

--- a/__tests__/app/api/github-preview.route.test.ts
+++ b/__tests__/app/api/github-preview.route.test.ts
@@ -60,6 +60,13 @@ describe("github-preview API route", () => {
         title: "Remove tab",
         state: "open",
         state_reason: null,
+        user: { login: "alice" },
+        updated_at: "2026-06-16T12:00:00Z",
+        comments: 3,
+        labels: [
+          { name: "frontend", color: "0e8a16" },
+          { name: "cards", color: "fbca04" },
+        ],
         assignees: [{ login: "alice" }, { login: "bob" }],
       })
     );
@@ -74,6 +81,13 @@ describe("github-preview API route", () => {
       type: "github.issue",
       state: "open",
       number: 2308,
+      author: "alice",
+      updatedAt: "2026-06-16T12:00:00Z",
+      comments: 3,
+      labels: [
+        { name: "frontend", color: "0e8a16" },
+        { name: "cards", color: "fbca04" },
+      ],
       assignees: ["alice", "bob"],
     });
   });
@@ -176,6 +190,10 @@ describe("github-preview API route", () => {
         open_issues_count: 5,
         visibility: "public",
         archived: false,
+        updated_at: "2026-06-15T00:00:00Z",
+        pushed_at: "2026-06-16T00:00:00Z",
+        topics: ["nextjs", "6529"],
+        license: { spdx_id: "MIT" },
         html_url: "https://github.com/6529-Collections/6529seize-frontend",
       })
     );
@@ -191,16 +209,33 @@ describe("github-preview API route", () => {
       language: "TypeScript",
       stars: 42,
       forks: 7,
+      updatedAt: "2026-06-15T00:00:00Z",
+      pushedAt: "2026-06-16T00:00:00Z",
+      topics: ["nextjs", "6529"],
+      license: "MIT",
     });
   });
 
   it("maps GitHub file links", async () => {
+    const fileSource = [
+      "import React from 'react';",
+      "",
+      "export function GithubLinkPreview() {",
+      "  return <a href=\"https://github.com\">GitHub</a>;",
+      "}",
+      "const one = 1;",
+      "const two = 2;",
+      "const three = 3;",
+    ].join("\n");
+
     fetchMock.mockResolvedValueOnce(
       jsonResponse({
         type: "file",
         name: "GithubLinkPreview.tsx",
         path: "components/waves/github/GithubLinkPreview.tsx",
         size: 12345,
+        encoding: "base64",
+        content: Buffer.from(fileSource).toString("base64"),
         html_url:
           "https://github.com/o/r/blob/main/components/waves/github/GithubLinkPreview.tsx",
       })
@@ -208,7 +243,7 @@ describe("github-preview API route", () => {
 
     const response = await GET(
       requestFor(
-        "https://github.com/o/r/blob/main/components/waves/github/GithubLinkPreview.tsx#L12"
+        "https://github.com/o/r/blob/main/components/waves/github/GithubLinkPreview.tsx#L3-L8"
       )
     );
 
@@ -218,6 +253,17 @@ describe("github-preview API route", () => {
       path: "components/waves/github/GithubLinkPreview.tsx",
       ref: "main",
       size: 12345,
+      language: "TypeScript",
+      lineCount: 8,
+      lineStart: 3,
+      lineEnd: 8,
+      excerpt: [
+        "export function GithubLinkPreview() {",
+        "  return <a href=\"https://github.com\">GitHub</a>;",
+        "}",
+        "const one = 1;",
+        "const two = 2;",
+      ],
     });
   });
 
@@ -253,6 +299,7 @@ describe("github-preview API route", () => {
       jsonResponse([
         { type: "file", name: "a.ts", path: "src/a.ts" },
         { type: "file", name: "b.ts", path: "src/b.ts" },
+        { type: "dir", name: "components", path: "src/components" },
       ])
     );
 
@@ -265,7 +312,10 @@ describe("github-preview API route", () => {
       title: "src",
       path: "src",
       ref: "main",
-      itemCount: 2,
+      itemCount: 3,
+      entries: ["a.ts", "b.ts", "components"],
+      fileCount: 2,
+      directoryCount: 1,
     });
   });
 
@@ -279,6 +329,8 @@ describe("github-preview API route", () => {
           author: { name: "Alice", date: "2026-06-15T00:00:00Z" },
         },
         author: { login: "alice" },
+        stats: { additions: 10, deletions: 2 },
+        files: [{ filename: "a.ts" }, { filename: "b.ts" }],
       })
     );
 
@@ -291,6 +343,9 @@ describe("github-preview API route", () => {
       title: "Ship richer GitHub previews",
       shortSha: "abc123456789",
       author: "alice",
+      additions: 10,
+      deletions: 2,
+      changedFiles: 2,
     });
   });
 
@@ -501,6 +556,109 @@ describe("github-preview API route", () => {
       merged: true,
       reviewState: "approved",
       mergeableState: "clean",
+    });
+  });
+
+  it("maps pull request people, labels, checks, and change stats", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          html_url: "https://github.com/o/r/pull/9",
+          title: "Richer cards",
+          state: "open",
+          merged: false,
+          draft: false,
+          mergeable_state: "clean",
+          issue_url: "https://api.github.com/repos/o/r/issues/9",
+          user: { login: "alice" },
+          created_at: "2026-06-15T00:00:00Z",
+          updated_at: "2026-06-16T00:00:00Z",
+          comments: 2,
+          review_comments: 5,
+          commits: 3,
+          additions: 120,
+          deletions: 15,
+          changed_files: 6,
+          base: { ref: "main" },
+          head: { ref: "codex/github-preview-cards", sha: "abc123" },
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 1,
+            user: { login: "bob" },
+            state: "APPROVED",
+            submitted_at: "2026-06-16T01:00:00Z",
+          },
+        ])
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          html_url: "https://github.com/o/r/issues/9",
+          title: "Richer cards",
+          state: "open",
+          user: { login: "alice" },
+          comments: 4,
+          labels: [
+            { name: "frontend", color: "0e8a16" },
+            { name: "github", color: "5319e7" },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          total_count: 3,
+          check_runs: [
+            {
+              status: "completed",
+              conclusion: "success",
+              html_url: "https://github.com/o/r/actions/runs/1/job/1",
+            },
+            { status: "completed", conclusion: "success" },
+            { status: "completed", conclusion: "success" },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          state: "success",
+          total_count: 3,
+          target_url: "https://github.com/o/r/actions",
+        })
+      );
+
+    const response = await GET(requestFor("https://github.com/o/r/pull/9"));
+
+    await expect(response.json()).resolves.toMatchObject({
+      type: "github.pull_request",
+      state: "open",
+      reviewState: "approved",
+      mergeableState: "clean",
+      author: "alice",
+      createdAt: "2026-06-15T00:00:00Z",
+      updatedAt: "2026-06-16T00:00:00Z",
+      comments: 4,
+      reviewComments: 5,
+      commits: 3,
+      changedFiles: 6,
+      additions: 120,
+      deletions: 15,
+      baseRef: "main",
+      headRef: "codex/github-preview-cards",
+      headSha: "abc123",
+      labels: [
+        { name: "frontend", color: "0e8a16" },
+        { name: "github", color: "5319e7" },
+      ],
+      checks: {
+        state: "success",
+        total: 3,
+        successful: 3,
+        failed: 0,
+        pending: 0,
+        url: "https://github.com/o/r/actions/runs/1/job/1",
+      },
     });
   });
 

--- a/__tests__/components/waves/github/GithubLinkPreview.test.tsx
+++ b/__tests__/components/waves/github/GithubLinkPreview.test.tsx
@@ -114,7 +114,7 @@ describe("GithubLinkPreview", () => {
     );
   });
 
-  it("renders a compact PR card with inline status and no OpenGraph image", async () => {
+  it("renders a rich PR card with inline status and no OpenGraph image", async () => {
     mockedFetchGithubPreview.mockResolvedValue({
       type: "github.pull_request",
       owner: "6529-Collections",
@@ -122,10 +122,30 @@ describe("GithubLinkPreview", () => {
       number: 355,
       title: "[codex] Hydrate command reviews and expose PR costs",
       state: "merged",
-      reviewState: "none",
+      reviewState: "approved",
       mergeableState: "clean",
       merged: true,
       draft: false,
+      author: "alice",
+      updatedAt: "2026-06-16T00:00:00Z",
+      comments: 4,
+      commits: 3,
+      changedFiles: 6,
+      additions: 120,
+      deletions: 15,
+      baseRef: "main",
+      headRef: "codex/github-preview-cards",
+      checks: {
+        state: "success",
+        total: 3,
+        successful: 3,
+        failed: 0,
+        pending: 0,
+      },
+      labels: [
+        { name: "frontend", color: "0e8a16" },
+        { name: "github", color: "5319e7" },
+      ],
       url: "https://github.com/6529-Collections/6529Stream/pull/355",
     });
 
@@ -149,6 +169,15 @@ describe("GithubLinkPreview", () => {
     expect(card).not.toHaveClass("tw-h-[10rem]");
     expect(card).not.toHaveClass("md:tw-h-[11rem]");
     expect(screen.getByAltText("")).toHaveAttribute("src", "/github_w.png");
+    expect(screen.getByText(/by @alice/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/codex\/github-preview-cards -> main/)
+    ).toBeInTheDocument();
+    expect(screen.getByText("Checks")).toBeInTheDocument();
+    expect(screen.getByText("3 passing")).toBeInTheDocument();
+    expect(screen.getByText("Diff")).toBeInTheDocument();
+    expect(screen.getByText("+120 / -15")).toBeInTheDocument();
+    expect(screen.getByText("frontend")).toBeInTheDocument();
 
     const badge = screen.getByTestId("github-preview-status-badge");
     expect(badge).toHaveTextContent("Merged");
@@ -206,6 +235,9 @@ describe("GithubLinkPreview", () => {
       openIssues: 9,
       visibility: "public",
       archived: false,
+      pushedAt: "2026-06-16T00:00:00Z",
+      topics: ["nextjs", "bots"],
+      license: "MIT",
       url: "https://github.com/6529-Collections/6529Stream",
     });
 
@@ -222,8 +254,10 @@ describe("GithubLinkPreview", () => {
       expect(screen.getByText(/Streaming API and bots/)).toBeInTheDocument();
     });
 
-    expect(screen.getByText(/TypeScript/)).toBeInTheDocument();
+    expect(screen.getAllByText(/TypeScript/).length).toBeGreaterThan(0);
     expect(screen.queryByTestId("github-preview-status-badge")).toBeNull();
+    expect(screen.getByText("nextjs")).toBeInTheDocument();
+    expect(screen.getByText("License")).toBeInTheDocument();
   });
 
   it("renders enriched file links", async () => {
@@ -236,6 +270,15 @@ describe("GithubLinkPreview", () => {
       ref: "main",
       size: 2048,
       itemCount: null,
+      language: "TypeScript",
+      lineCount: 12,
+      lineStart: 10,
+      lineEnd: 12,
+      excerpt: [
+        "export function handler() {",
+        "  return Response.json({ ok: true });",
+        "}",
+      ],
       url: "https://github.com/6529-Collections/6529Stream/blob/main/src/app.ts",
     });
 
@@ -249,8 +292,79 @@ describe("GithubLinkPreview", () => {
       expect(screen.getByText("app.ts")).toBeInTheDocument();
     });
 
-    expect(screen.getByText(/src\/app\.ts/)).toBeInTheDocument();
-    expect(screen.getByText(/2 KB/)).toBeInTheDocument();
+    expect(screen.getAllByText(/src\/app\.ts/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/2 KB/).length).toBeGreaterThan(0);
+    expect(screen.getByText("TypeScript")).toBeInTheDocument();
+    expect(screen.getByText("L10-L12")).toBeInTheDocument();
+    expect(screen.getByTestId("github-file-excerpt")).toHaveTextContent(
+      "Response.json"
+    );
+  });
+
+  it("renders enriched issue links", async () => {
+    mockedFetchGithubPreview.mockResolvedValue({
+      type: "github.issue",
+      owner: "6529-Collections",
+      repo: "6529Stream",
+      number: 392,
+      title: "Tighten link previews",
+      state: "open",
+      author: "alice",
+      updatedAt: "2026-06-16T00:00:00Z",
+      comments: 2,
+      labels: [{ name: "frontend", color: "0e8a16" }],
+      assignees: ["alice", "bob"],
+      url: "https://github.com/6529-Collections/6529Stream/issues/392",
+    });
+
+    render(
+      <GithubLinkPreview href="https://github.com/6529-Collections/6529Stream/issues/392" />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Tighten link previews")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/by @alice/)).toBeInTheDocument();
+    expect(screen.getByText("Assignees")).toBeInTheDocument();
+    expect(screen.getAllByText("@alice +1").length).toBeGreaterThan(0);
+    expect(screen.getByText("2 comments")).toBeInTheDocument();
+    expect(screen.getByText("frontend")).toBeInTheDocument();
+  });
+
+  it("renders enriched directory links", async () => {
+    mockedFetchGithubPreview.mockResolvedValue({
+      type: "github.directory",
+      owner: "6529-Collections",
+      repo: "6529Stream",
+      title: "src",
+      path: "src",
+      ref: "main",
+      size: null,
+      itemCount: 3,
+      language: null,
+      lineCount: null,
+      excerpt: null,
+      entries: ["app.ts", "api", "components"],
+      fileCount: 1,
+      directoryCount: 2,
+      url: "https://github.com/6529-Collections/6529Stream/tree/main/src",
+    });
+
+    render(
+      <GithubLinkPreview href="https://github.com/6529-Collections/6529Stream/tree/main/src" />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("src")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Items")).toBeInTheDocument();
+    expect(screen.getByText("3 items")).toBeInTheDocument();
+    expect(screen.getByText("Folders")).toBeInTheDocument();
+    expect(screen.getByText("2 folders")).toBeInTheDocument();
+    expect(screen.getByText("app.ts")).toBeInTheDocument();
+    expect(screen.getByText("components")).toBeInTheDocument();
   });
 
   it("does not fetch rich metadata for unsupported GitHub subroutes", () => {

--- a/__tests__/components/waves/github/GithubLinkPreview.test.tsx
+++ b/__tests__/components/waves/github/GithubLinkPreview.test.tsx
@@ -166,6 +166,13 @@ describe("GithubLinkPreview", () => {
       "aria-label",
       expect.stringContaining("Open GitHub pull request")
     );
+    expect(screen.getByTestId("github-preview-accent")).toHaveAttribute(
+      "data-accent-kind",
+      "pull"
+    );
+    expect(screen.getByTestId("github-preview-kind-badge")).toHaveTextContent(
+      "Pull request"
+    );
     expect(card).not.toHaveClass("tw-h-[10rem]");
     expect(card).not.toHaveClass("md:tw-h-[11rem]");
     expect(screen.getByAltText("")).toHaveAttribute("src", "/github_w.png");
@@ -246,6 +253,10 @@ describe("GithubLinkPreview", () => {
     );
 
     expect(screen.getByText("Repository")).toBeInTheDocument();
+    expect(screen.getByTestId("github-preview-accent")).toHaveAttribute(
+      "data-accent-kind",
+      "repository"
+    );
     expect(mockedFetchGithubPreview).toHaveBeenCalledWith(
       "https://github.com/6529-Collections/6529Stream"
     );
@@ -287,6 +298,10 @@ describe("GithubLinkPreview", () => {
     );
 
     expect(screen.getByText("File")).toBeInTheDocument();
+    expect(screen.getByTestId("github-preview-accent")).toHaveAttribute(
+      "data-accent-kind",
+      "file"
+    );
 
     await waitFor(() => {
       expect(screen.getByText("app.ts")).toBeInTheDocument();

--- a/app/api/github-preview/service.ts
+++ b/app/api/github-preview/service.ts
@@ -840,6 +840,13 @@ const buildCheckSummaryFromRuns = (
     return null;
   }
 
+  if (
+    typeof response.total_count === "number" &&
+    response.total_count > runs.length
+  ) {
+    return null;
+  }
+
   let successful = 0;
   let failed = 0;
   let pending = 0;
@@ -1169,10 +1176,22 @@ const buildContentExcerpt = (
   const lines = decoded.replace(/\r\n/g, "\n").split("\n");
   const lineCount = lines.length;
   const requestedStart = resource.lineStart ?? 1;
+  if (requestedStart > lineCount) {
+    return {
+      lineCount,
+      excerpt: null,
+      lineStart: null,
+      lineEnd: null,
+    };
+  }
+
+  const normalizedLineEnd = resource.lineStart
+    ? Math.min(resource.lineEnd ?? resource.lineStart, lineCount)
+    : null;
   const startIndex = Math.max(0, requestedStart - 1);
   const endIndex =
-    resource.lineEnd && resource.lineEnd >= requestedStart
-      ? Math.min(lines.length, resource.lineEnd)
+    normalizedLineEnd && normalizedLineEnd >= requestedStart
+      ? normalizedLineEnd
       : Math.min(lines.length, startIndex + CONTENT_EXCERPT_MAX_LINES);
   const excerpt = lines
     .slice(startIndex, Math.max(startIndex + 1, endIndex))
@@ -1183,9 +1202,7 @@ const buildContentExcerpt = (
     lineCount,
     excerpt,
     lineStart: resource.lineStart,
-    lineEnd: resource.lineStart
-      ? (resource.lineEnd ?? resource.lineStart)
-      : null,
+    lineEnd: normalizedLineEnd,
   };
 };
 
@@ -1242,7 +1259,14 @@ const buildContentPreview = (
       type === "github.file"
         ? getFileLanguage(content.path ?? candidate.path)
         : null,
-    ...(type === "github.file" ? buildContentExcerpt(content, resource) : {}),
+    ...(type === "github.file"
+      ? buildContentExcerpt(content, resource)
+      : {
+          lineCount: null,
+          excerpt: null,
+          lineStart: null,
+          lineEnd: null,
+        }),
     entries: null,
     fileCount: null,
     directoryCount: null,

--- a/app/api/github-preview/service.ts
+++ b/app/api/github-preview/service.ts
@@ -2,6 +2,8 @@ import LruTtlCache from "@/lib/cache/lruTtl";
 import { serverEnv } from "@/config/serverEnv";
 import type {
   GithubActionsPreviewResponse,
+  GithubPreviewChecks,
+  GithubPreviewLabel,
   GithubCommitPreviewResponse,
   GithubContentPreviewResponse,
   GithubDiscussionPreviewResponse,
@@ -19,6 +21,9 @@ const CACHE_MAX_ITEMS = 500;
 const FETCH_TIMEOUT_MS = 5000;
 const GITHUB_NUMBER_PATTERN = /^\d+$/;
 const CONTENT_REF_SPLIT_LIMIT = 8;
+const CONTENT_EXCERPT_MAX_BYTES = 64 * 1024;
+const CONTENT_EXCERPT_MAX_LINES = 5;
+const CONTENT_EXCERPT_MAX_LINE_LENGTH = 160;
 
 const cache = new LruTtlCache<string, GithubPreviewResponse>({
   max: CACHE_MAX_ITEMS,
@@ -59,6 +64,8 @@ interface GithubContentResource extends GithubResourceBase {
   readonly kind: "content";
   readonly mode: "blob" | "tree";
   readonly segments: readonly string[];
+  readonly lineStart: number | null;
+  readonly lineEnd: number | null;
 }
 
 interface GithubCommitResource extends GithubResourceBase {
@@ -97,6 +104,18 @@ interface GithubIssueApiResponse {
   readonly title?: string | null;
   readonly state?: string | null;
   readonly state_reason?: string | null;
+  readonly user?: { readonly login?: string | null } | null;
+  readonly created_at?: string | null;
+  readonly updated_at?: string | null;
+  readonly closed_at?: string | null;
+  readonly comments?: number | null;
+  readonly labels?:
+    | readonly {
+        readonly name?: string | null;
+        readonly color?: string | null;
+      }[]
+    | null
+    | undefined;
   readonly assignee?: { readonly login?: string | null } | null;
   readonly assignees?:
     | readonly { readonly login?: string | null }[]
@@ -112,6 +131,30 @@ interface GithubPullApiResponse {
   readonly merged?: boolean | null;
   readonly draft?: boolean | null;
   readonly mergeable_state?: string | null;
+  readonly issue_url?: string | null;
+  readonly user?: { readonly login?: string | null } | null;
+  readonly created_at?: string | null;
+  readonly updated_at?: string | null;
+  readonly closed_at?: string | null;
+  readonly comments?: number | null;
+  readonly review_comments?: number | null;
+  readonly commits?: number | null;
+  readonly additions?: number | null;
+  readonly deletions?: number | null;
+  readonly changed_files?: number | null;
+  readonly base?:
+    | {
+        readonly ref?: string | null;
+      }
+    | null
+    | undefined;
+  readonly head?:
+    | {
+        readonly ref?: string | null;
+        readonly sha?: string | null;
+      }
+    | null
+    | undefined;
 }
 
 interface GithubPullReviewApiResponse {
@@ -132,6 +175,10 @@ interface GithubRepositoryApiResponse {
   readonly visibility?: string | null;
   readonly private?: boolean | null;
   readonly archived?: boolean | null;
+  readonly updated_at?: string | null;
+  readonly pushed_at?: string | null;
+  readonly topics?: readonly string[] | null;
+  readonly license?: { readonly spdx_id?: string | null } | null;
   readonly html_url?: string | null;
 }
 
@@ -141,6 +188,8 @@ interface GithubContentApiItem {
   readonly path?: string | null;
   readonly html_url?: string | null;
   readonly size?: number | null;
+  readonly content?: string | null;
+  readonly encoding?: string | null;
 }
 
 type GithubContentApiResponse =
@@ -163,6 +212,32 @@ interface GithubCommitApiResponse {
   } | null;
   readonly author?: { readonly login?: string | null } | null;
   readonly committer?: { readonly login?: string | null } | null;
+  readonly stats?:
+    | {
+        readonly additions?: number | null;
+        readonly deletions?: number | null;
+      }
+    | null
+    | undefined;
+  readonly files?: readonly unknown[] | null;
+}
+
+interface GithubCombinedStatusApiResponse {
+  readonly state?: string | null;
+  readonly total_count?: number | null;
+  readonly target_url?: string | null;
+  readonly statuses?: readonly unknown[] | null;
+}
+
+interface GithubCheckRunApiResponse {
+  readonly status?: string | null;
+  readonly conclusion?: string | null;
+  readonly html_url?: string | null;
+}
+
+interface GithubCheckRunsApiResponse {
+  readonly total_count?: number | null;
+  readonly check_runs?: readonly GithubCheckRunApiResponse[] | null;
 }
 
 interface GithubReleaseApiResponse {
@@ -278,6 +353,27 @@ const toPositiveNumber = (value: string | undefined): number | null => {
   return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
 };
 
+const parseGithubLineAnchor = (
+  hash: string
+): { readonly lineStart: number | null; readonly lineEnd: number | null } => {
+  const normalized = hash.replace(/^#/, "");
+  const match = /^L(\d+)(?:-L(\d+))?$/i.exec(normalized);
+  if (!match) {
+    return { lineStart: null, lineEnd: null };
+  }
+
+  const lineStart = toPositiveNumber(match[1]);
+  const lineEnd = toPositiveNumber(match[2]);
+  if (!lineStart) {
+    return { lineStart: null, lineEnd: null };
+  }
+
+  return {
+    lineStart,
+    lineEnd: lineEnd && lineEnd >= lineStart ? lineEnd : lineStart,
+  };
+};
+
 const parseGithubResource = (rawUrl: string | null): GithubResource => {
   if (!rawUrl) {
     throw new Error("A url query parameter is required.");
@@ -310,6 +406,7 @@ const parseGithubResource = (rawUrl: string | null): GithubResource => {
 
   const base = { href: rawUrl.trim(), owner, repo };
   const number = toPositiveNumber(rest[0]);
+  const lineRange = parseGithubLineAnchor(parsed.hash);
 
   switch (kindSegment) {
     case undefined:
@@ -332,12 +429,25 @@ const parseGithubResource = (rawUrl: string | null): GithubResource => {
       if (rest.length < 2) {
         throw new Error("Only github.com repository URLs are supported.");
       }
-      return { ...base, kind: "content", mode: kindSegment, segments: rest };
+      return {
+        ...base,
+        kind: "content",
+        mode: kindSegment,
+        segments: rest,
+        ...lineRange,
+      };
     case "tree":
       if (rest.length < 1) {
         throw new Error("Only github.com repository URLs are supported.");
       }
-      return { ...base, kind: "content", mode: kindSegment, segments: rest };
+      return {
+        ...base,
+        kind: "content",
+        mode: kindSegment,
+        segments: rest,
+        lineStart: null,
+        lineEnd: null,
+      };
     case "commit":
       if (!rest[0]) {
         throw new Error("Only github.com repository URLs are supported.");
@@ -389,6 +499,8 @@ const getResourceCacheKey = (resource: GithubResource): string => {
         "content",
         ...base,
         resource.mode,
+        resource.lineStart,
+        resource.lineEnd,
         ...resource.segments,
       ]);
     case "commit":
@@ -548,6 +660,26 @@ const getIssueAssignees = (
   return legacyAssignee ? [legacyAssignee] : [];
 };
 
+const getLabels = (
+  labels: GithubIssueApiResponse["labels"]
+): readonly GithubPreviewLabel[] => {
+  return (
+    labels
+      ?.map((label): GithubPreviewLabel | null => {
+        const name = label.name?.trim();
+        if (!name) {
+          return null;
+        }
+
+        return {
+          name,
+          color: label.color?.trim() || null,
+        };
+      })
+      .filter((label): label is GithubPreviewLabel => label !== null) ?? []
+  );
+};
+
 const getPullRequestState = (
   pull: GithubPullApiResponse
 ): GithubPullRequestPreviewResponse["state"] => {
@@ -675,10 +807,141 @@ const getPullRequestReviewState = (
   return getHighestPriorityReviewState(latestMeaningfulReviewByUser.values());
 };
 
+const FAILURE_CHECK_CONCLUSIONS = new Set([
+  "failure",
+  "timed_out",
+  "cancelled",
+  "action_required",
+]);
+
+const NEUTRAL_CHECK_CONCLUSIONS = new Set(["neutral", "skipped"]);
+
+const toCombinedStatusState = (
+  value: string | null | undefined
+): GithubPreviewChecks["state"] => {
+  switch (value) {
+    case "success":
+      return "success";
+    case "failure":
+    case "error":
+      return "failure";
+    case "pending":
+      return "pending";
+    default:
+      return "unknown";
+  }
+};
+
+const buildCheckSummaryFromRuns = (
+  response: GithubCheckRunsApiResponse
+): GithubPreviewChecks | null => {
+  const runs = response.check_runs ?? [];
+  if (runs.length === 0 && !response.total_count) {
+    return null;
+  }
+
+  let successful = 0;
+  let failed = 0;
+  let pending = 0;
+  let neutral = 0;
+  let skipped = 0;
+  let firstUrl: string | null = null;
+
+  for (const run of runs) {
+    firstUrl ??= run.html_url ?? null;
+    if (run.status !== "completed") {
+      pending += 1;
+      continue;
+    }
+
+    if (run.conclusion === "success") {
+      successful += 1;
+      continue;
+    }
+
+    if (run.conclusion && FAILURE_CHECK_CONCLUSIONS.has(run.conclusion)) {
+      failed += 1;
+      continue;
+    }
+
+    if (run.conclusion === "skipped") {
+      skipped += 1;
+      continue;
+    }
+
+    if (run.conclusion && NEUTRAL_CHECK_CONCLUSIONS.has(run.conclusion)) {
+      neutral += 1;
+    }
+  }
+
+  const total = response.total_count ?? runs.length;
+  const state: GithubPreviewChecks["state"] =
+    failed > 0
+      ? "failure"
+      : pending > 0
+        ? "pending"
+        : total > 0 && successful === total
+          ? "success"
+          : skipped > 0
+            ? "skipped"
+            : neutral > 0
+              ? "neutral"
+              : "unknown";
+
+  return {
+    state,
+    total,
+    successful,
+    failed,
+    pending,
+    url: firstUrl,
+  };
+};
+
+const buildCheckSummaryFromCombinedStatus = (
+  status: GithubCombinedStatusApiResponse
+): GithubPreviewChecks => ({
+  state: toCombinedStatusState(status.state),
+  total: status.total_count ?? status.statuses?.length ?? null,
+  successful: null,
+  failed: null,
+  pending: null,
+  url: status.target_url ?? null,
+});
+
+const resolvePullChecks = async (
+  resource: GithubPullResource,
+  sha: string | null | undefined
+): Promise<GithubPreviewChecks | null> => {
+  if (!sha) {
+    return null;
+  }
+
+  const encodedOwner = encodeURIComponent(resource.owner);
+  const encodedRepo = encodeURIComponent(resource.repo);
+  const encodedSha = encodePathPart(sha);
+
+  const [runs, status] = await Promise.all([
+    fetchGithubJson<GithubCheckRunsApiResponse>(
+      `/repos/${encodedOwner}/${encodedRepo}/commits/${encodedSha}/check-runs?per_page=50`
+    ).catch(() => null),
+    fetchGithubJson<GithubCombinedStatusApiResponse>(
+      `/repos/${encodedOwner}/${encodedRepo}/commits/${encodedSha}/status`
+    ).catch(() => null),
+  ]);
+
+  return (
+    (runs ? buildCheckSummaryFromRuns(runs) : null) ??
+    (status ? buildCheckSummaryFromCombinedStatus(status) : null)
+  );
+};
+
 const buildPullPreview = (
   resource: GithubPullResource,
   pull: GithubPullApiResponse,
-  reviews: readonly GithubPullReviewApiResponse[]
+  reviews: readonly GithubPullReviewApiResponse[],
+  issue: GithubIssueApiResponse | null,
+  checks: GithubPreviewChecks | null
 ): GithubPullRequestPreviewResponse => ({
   type: "github.pull_request",
   owner: resource.owner,
@@ -690,6 +953,21 @@ const buildPullPreview = (
   mergeableState: pull.mergeable_state ?? null,
   merged: pull.merged === true,
   draft: pull.draft === true,
+  author: pull.user?.login ?? issue?.user?.login ?? null,
+  createdAt: pull.created_at ?? issue?.created_at ?? null,
+  updatedAt: pull.updated_at ?? issue?.updated_at ?? null,
+  closedAt: pull.closed_at ?? issue?.closed_at ?? null,
+  comments: issue?.comments ?? pull.comments ?? null,
+  reviewComments: pull.review_comments ?? null,
+  commits: pull.commits ?? null,
+  changedFiles: pull.changed_files ?? null,
+  additions: pull.additions ?? null,
+  deletions: pull.deletions ?? null,
+  baseRef: pull.base?.ref ?? null,
+  headRef: pull.head?.ref ?? null,
+  headSha: pull.head?.sha ?? null,
+  labels: getLabels(issue?.labels),
+  checks,
   url:
     pull.html_url ??
     `https://github.com/${resource.owner}/${resource.repo}/pull/${resource.number}`,
@@ -703,11 +981,19 @@ const resolvePullPreview = async (
   const pull = await fetchGithubJson<GithubPullApiResponse>(
     `/repos/${encodedOwner}/${encodedRepo}/pulls/${resource.number}`
   );
-  const reviews = await fetchGithubJson<GithubPullReviewApiResponse[]>(
-    `/repos/${encodedOwner}/${encodedRepo}/pulls/${resource.number}/reviews`
-  ).catch(() => []);
+  const [reviews, issue, checks] = await Promise.all([
+    fetchGithubJson<GithubPullReviewApiResponse[]>(
+      `/repos/${encodedOwner}/${encodedRepo}/pulls/${resource.number}/reviews`
+    ).catch(() => []),
+    pull.issue_url
+      ? fetchGithubJson<GithubIssueApiResponse>(
+          `/repos/${encodedOwner}/${encodedRepo}/issues/${resource.number}`
+        ).catch(() => null)
+      : Promise.resolve(null),
+    resolvePullChecks(resource, pull.head?.sha).catch(() => null),
+  ]);
 
-  return buildPullPreview(resource, pull, reviews);
+  return buildPullPreview(resource, pull, reviews, issue, checks);
 };
 
 const resolveIssuePreview = async (
@@ -730,6 +1016,12 @@ const resolveIssuePreview = async (
     number: resource.number,
     title: issue.title ?? null,
     state: getIssueState(issue),
+    author: issue.user?.login ?? null,
+    createdAt: issue.created_at ?? null,
+    updatedAt: issue.updated_at ?? null,
+    closedAt: issue.closed_at ?? null,
+    comments: issue.comments ?? null,
+    labels: getLabels(issue.labels),
     assignees: getIssueAssignees(issue),
     url:
       issue.html_url ??
@@ -760,6 +1052,10 @@ const resolveRepositoryPreview = async (
     visibility:
       repository.visibility ?? (repository.private === true ? "private" : null),
     archived: repository.archived === true,
+    updatedAt: repository.updated_at ?? null,
+    pushedAt: repository.pushed_at ?? null,
+    topics: repository.topics ?? [],
+    license: repository.license?.spdx_id ?? null,
     url:
       repository.html_url ??
       `https://github.com/${resource.owner}/${resource.repo}`,
@@ -794,12 +1090,121 @@ const getFallbackContentTitle = (
   return resource.mode === "tree" ? resource.repo : "Code";
 };
 
+const EXTENSION_LANGUAGE_MAP: Record<string, string> = {
+  cjs: "JavaScript",
+  css: "CSS",
+  go: "Go",
+  html: "HTML",
+  java: "Java",
+  js: "JavaScript",
+  json: "JSON",
+  jsx: "JavaScript",
+  md: "Markdown",
+  mdx: "MDX",
+  mjs: "JavaScript",
+  py: "Python",
+  rs: "Rust",
+  scss: "SCSS",
+  sh: "Shell",
+  sol: "Solidity",
+  sql: "SQL",
+  ts: "TypeScript",
+  tsx: "TypeScript",
+  txt: "Text",
+  yml: "YAML",
+  yaml: "YAML",
+};
+
+const getFileLanguage = (path: string | null | undefined): string | null => {
+  const extension = path?.split(".").pop()?.toLowerCase();
+  return extension ? (EXTENSION_LANGUAGE_MAP[extension] ?? null) : null;
+};
+
+const truncateExcerptLine = (line: string): string => {
+  const normalized = line.replace(/\t/g, "  ").trimEnd();
+  if (normalized.length <= CONTENT_EXCERPT_MAX_LINE_LENGTH) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, CONTENT_EXCERPT_MAX_LINE_LENGTH - 3)}...`;
+};
+
+const decodeTextContent = (content: GithubContentApiItem): string | null => {
+  if (
+    content.encoding !== "base64" ||
+    !content.content ||
+    (typeof content.size === "number" && content.size > CONTENT_EXCERPT_MAX_BYTES)
+  ) {
+    return null;
+  }
+
+  try {
+    return Buffer.from(content.content.replace(/\s/g, ""), "base64").toString(
+      "utf8"
+    );
+  } catch {
+    return null;
+  }
+};
+
+const buildContentExcerpt = (
+  content: GithubContentApiItem,
+  resource: GithubContentResource
+): {
+  readonly lineCount: number | null;
+  readonly excerpt: readonly string[] | null;
+  readonly lineStart: number | null;
+  readonly lineEnd: number | null;
+} => {
+  const decoded = decodeTextContent(content);
+  if (!decoded) {
+    return {
+      lineCount: null,
+      excerpt: null,
+      lineStart: resource.lineStart,
+      lineEnd: resource.lineEnd,
+    };
+  }
+
+  const lines = decoded.replace(/\r\n/g, "\n").split("\n");
+  const lineCount = lines.length;
+  const requestedStart = resource.lineStart ?? 1;
+  const startIndex = Math.max(0, requestedStart - 1);
+  const endIndex =
+    resource.lineEnd && resource.lineEnd >= requestedStart
+      ? Math.min(lines.length, resource.lineEnd)
+      : Math.min(lines.length, startIndex + CONTENT_EXCERPT_MAX_LINES);
+  const excerpt = lines
+    .slice(startIndex, Math.max(startIndex + 1, endIndex))
+    .slice(0, CONTENT_EXCERPT_MAX_LINES)
+    .map(truncateExcerptLine);
+
+  return {
+    lineCount,
+    excerpt,
+    lineStart: resource.lineStart,
+    lineEnd: resource.lineStart
+      ? (resource.lineEnd ?? resource.lineStart)
+      : null,
+  };
+};
+
+const countDirectoryItems = (
+  content: readonly GithubContentApiItem[],
+  type: "file" | "dir"
+): number => content.filter((item) => item.type === type).length;
+
 const buildContentPreview = (
   resource: GithubContentResource,
   candidate: { readonly ref: string; readonly path: string },
   content: GithubContentApiResponse
 ): GithubContentPreviewResponse => {
   if (isGithubContentApiDirectoryResponse(content)) {
+    const entries = content
+      .map((item) => item.name)
+      .filter((name): name is string => Boolean(name))
+      .slice(0, 4);
+
     return {
       type: "github.directory",
       owner: resource.owner,
@@ -809,6 +1214,12 @@ const buildContentPreview = (
       ref: candidate.ref,
       size: null,
       itemCount: content.length,
+      language: null,
+      lineCount: null,
+      excerpt: null,
+      entries,
+      fileCount: countDirectoryItems(content, "file"),
+      directoryCount: countDirectoryItems(content, "dir"),
       url: resource.href,
     };
   }
@@ -827,6 +1238,14 @@ const buildContentPreview = (
     ref: candidate.ref,
     size: typeof content.size === "number" ? content.size : null,
     itemCount: null,
+    language:
+      type === "github.file"
+        ? getFileLanguage(content.path ?? candidate.path)
+        : null,
+    ...(type === "github.file" ? buildContentExcerpt(content, resource) : {}),
+    entries: null,
+    fileCount: null,
+    directoryCount: null,
     url: content.html_url ?? resource.href,
   };
 };
@@ -895,6 +1314,9 @@ const resolveCommitPreview = async (
       null,
     committedAt:
       commit.commit?.author?.date ?? commit.commit?.committer?.date ?? null,
+    additions: commit.stats?.additions ?? null,
+    deletions: commit.stats?.deletions ?? null,
+    changedFiles: commit.files?.length ?? null,
     url:
       commit.html_url ??
       `https://github.com/${resource.owner}/${resource.repo}/commit/${sha}`,

--- a/components/waves/github/GithubLinkPreview.tsx
+++ b/components/waves/github/GithubLinkPreview.tsx
@@ -52,7 +52,81 @@ interface GithubFact {
   readonly tone?: "default" | "success" | "warning" | "danger" | undefined;
 }
 
+interface GithubAccent {
+  readonly kind: GithubLinkKind;
+  readonly railColor: string;
+  readonly borderColor: string;
+  readonly backgroundColor: string;
+  readonly textColor: string;
+}
+
 const GITHUB_NUMBER_PATTERN = /^\d+$/;
+
+const GITHUB_ACCENTS: Record<
+  GithubLinkKind,
+  Omit<GithubAccent, "kind">
+> = {
+  pull: {
+    railColor: "#8b5cf6",
+    borderColor: "rgba(139, 92, 246, 0.32)",
+    backgroundColor: "rgba(139, 92, 246, 0.12)",
+    textColor: "#ddd6fe",
+  },
+  issue: {
+    railColor: "#22c55e",
+    borderColor: "rgba(34, 197, 94, 0.3)",
+    backgroundColor: "rgba(34, 197, 94, 0.1)",
+    textColor: "#bbf7d0",
+  },
+  repository: {
+    railColor: "#38bdf8",
+    borderColor: "rgba(56, 189, 248, 0.28)",
+    backgroundColor: "rgba(56, 189, 248, 0.1)",
+    textColor: "#bae6fd",
+  },
+  file: {
+    railColor: "#f59e0b",
+    borderColor: "rgba(245, 158, 11, 0.32)",
+    backgroundColor: "rgba(245, 158, 11, 0.11)",
+    textColor: "#fde68a",
+  },
+  directory: {
+    railColor: "#14b8a6",
+    borderColor: "rgba(20, 184, 166, 0.3)",
+    backgroundColor: "rgba(20, 184, 166, 0.1)",
+    textColor: "#99f6e4",
+  },
+  commit: {
+    railColor: "#fb923c",
+    borderColor: "rgba(251, 146, 60, 0.3)",
+    backgroundColor: "rgba(251, 146, 60, 0.1)",
+    textColor: "#fed7aa",
+  },
+  release: {
+    railColor: "#10b981",
+    borderColor: "rgba(16, 185, 129, 0.3)",
+    backgroundColor: "rgba(16, 185, 129, 0.1)",
+    textColor: "#a7f3d0",
+  },
+  actions: {
+    railColor: "#60a5fa",
+    borderColor: "rgba(96, 165, 250, 0.3)",
+    backgroundColor: "rgba(96, 165, 250, 0.1)",
+    textColor: "#bfdbfe",
+  },
+  discussion: {
+    railColor: "#ec4899",
+    borderColor: "rgba(236, 72, 153, 0.3)",
+    backgroundColor: "rgba(236, 72, 153, 0.1)",
+    textColor: "#fbcfe8",
+  },
+  github: {
+    railColor: "#94a3b8",
+    borderColor: "rgba(148, 163, 184, 0.26)",
+    backgroundColor: "rgba(148, 163, 184, 0.08)",
+    textColor: "#cbd5e1",
+  },
+};
 
 const safeDecode = (value: string): string => {
   try {
@@ -381,6 +455,42 @@ const getKindLabelFromPreview = (
     case undefined:
       return null;
   }
+};
+
+const getAccentKind = (
+  link: ParsedGithubLink,
+  preview: GithubPreviewResponse | null
+): GithubLinkKind => {
+  switch (preview?.type) {
+    case "github.issue":
+      return "issue";
+    case "github.pull_request":
+      return "pull";
+    case "github.repository":
+      return "repository";
+    case "github.file":
+      return "file";
+    case "github.directory":
+      return "directory";
+    case "github.commit":
+      return "commit";
+    case "github.release":
+      return "release";
+    case "github.actions":
+      return "actions";
+    case "github.discussion":
+      return "discussion";
+    case undefined:
+      return link.kind;
+  }
+};
+
+const getAccent = (
+  link: ParsedGithubLink,
+  preview: GithubPreviewResponse | null
+): GithubAccent => {
+  const kind = getAccentKind(link, preview);
+  return { kind, ...GITHUB_ACCENTS[kind] };
 };
 
 const getFallbackTitle = (link: ParsedGithubLink): string => {
@@ -946,6 +1056,7 @@ export default function GithubLinkPreview({ href }: GithubLinkPreviewProps) {
   const metaText = getMetaText(preview);
   const facts = getPreviewFacts(preview);
   const labels = getPreviewLabels(preview);
+  const accent = getAccent(link, preview);
 
   return (
     <LinkHandlerFrame href={href}>
@@ -959,8 +1070,21 @@ export default function GithubLinkPreview({ href }: GithubLinkPreviewProps) {
         data-testid="github-link-preview-card"
         aria-label={getAriaLabel(link, preview)}
       >
+        <span
+          aria-hidden="true"
+          className="tw-absolute tw-inset-y-0 tw-left-0 tw-w-1 tw-opacity-85"
+          data-testid="github-preview-accent"
+          data-accent-kind={accent.kind}
+          style={{ backgroundColor: accent.railColor }}
+        />
         <span className="tw-grid tw-min-w-0 tw-grid-cols-[2.5rem,minmax(0,1fr)] tw-gap-3 sm:tw-grid-cols-[3rem,minmax(0,1fr)]">
-          <span className="tw-flex tw-h-10 tw-w-10 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-border-white/10 tw-bg-black/35 sm:tw-h-12 sm:tw-w-12">
+          <span
+            className="tw-flex tw-h-10 tw-w-10 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-border-white/10 tw-bg-black/35 sm:tw-h-12 sm:tw-w-12"
+            style={{
+              borderColor: accent.borderColor,
+              backgroundColor: accent.backgroundColor,
+            }}
+          >
             <Image
               src="/github_w.png"
               alt=""
@@ -976,7 +1100,15 @@ export default function GithubLinkPreview({ href }: GithubLinkPreviewProps) {
               <span className="tw-text-[11px] tw-font-semibold tw-uppercase tw-leading-none tw-text-iron-500">
                 GitHub
               </span>
-              <span className="tw-inline-flex tw-items-center tw-rounded-md tw-bg-iron-800/75 tw-px-2 tw-py-1 tw-text-[11px] tw-font-semibold tw-leading-none tw-text-iron-200">
+              <span
+                className="tw-inline-flex tw-items-center tw-rounded-md tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-800/75 tw-px-2 tw-py-1 tw-text-[11px] tw-font-semibold tw-leading-none tw-text-iron-200"
+                data-testid="github-preview-kind-badge"
+                style={{
+                  borderColor: accent.borderColor,
+                  backgroundColor: accent.backgroundColor,
+                  color: accent.textColor,
+                }}
+              >
                 {kindLabel}
               </span>
               {state.type === "loading" && <LoadingStatus />}

--- a/components/waves/github/GithubLinkPreview.tsx
+++ b/components/waves/github/GithubLinkPreview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { type CSSProperties, useEffect, useMemo, useState } from "react";
 
 import Image from "next/image";
 import Link from "next/link";
@@ -9,6 +9,8 @@ import LinkHandlerFrame from "@/components/waves/LinkHandlerFrame";
 import GithubPreviewStatusBadge from "@/components/waves/GithubPreviewStatusBadge";
 import {
   fetchGithubPreview,
+  type GithubPreviewChecks,
+  type GithubPreviewLabel,
   type GithubPreviewResponse,
   type GithubStatusPreviewResponse,
 } from "@/services/api/github-preview-api";
@@ -43,6 +45,12 @@ type GithubPreviewState =
   | { readonly type: "loading" }
   | { readonly type: "success"; readonly preview: GithubPreviewResponse }
   | { readonly type: "error" };
+
+interface GithubFact {
+  readonly label: string;
+  readonly value: string;
+  readonly tone?: "default" | "success" | "warning" | "danger" | undefined;
+}
 
 const GITHUB_NUMBER_PATTERN = /^\d+$/;
 
@@ -224,13 +232,94 @@ const formatDate = (value: string | null | undefined): string | null => {
   }).format(date);
 };
 
+const formatCount = (
+  value: number | null | undefined,
+  singular: string,
+  plural = `${singular}s`
+): string | null => {
+  if (typeof value !== "number") {
+    return null;
+  }
+
+  const noun = value === 1 ? singular : plural;
+  return `${formatInteger(value)} ${noun}`;
+};
+
+const formatDiff = (
+  additions: number | null | undefined,
+  deletions: number | null | undefined
+): string | null => {
+  if (typeof additions !== "number" && typeof deletions !== "number") {
+    return null;
+  }
+
+  return `+${formatInteger(additions ?? 0)} / -${formatInteger(deletions ?? 0)}`;
+};
+
 const normalizeStatusText = (
   value: string | null | undefined
 ): string | null => (value ? value.replaceAll("_", " ") : null);
 
+const titleCase = (value: string | null | undefined): string | null => {
+  const normalized = normalizeStatusText(value);
+  if (!normalized) {
+    return null;
+  }
+
+  return normalized.replace(/\b\w/g, (letter) => letter.toUpperCase());
+};
+
 const joinDetailParts = (
   parts: readonly (string | null | undefined)[]
 ): string => parts.filter((part): part is string => Boolean(part)).join(" - ");
+
+const joinMetaParts = (parts: readonly (string | null | undefined)[]): string =>
+  parts.filter((part): part is string => Boolean(part)).join(" / ");
+
+const getChecksLabel = (
+  checks: GithubPreviewChecks | null | undefined
+): string | null => {
+  if (!checks) {
+    return null;
+  }
+
+  if (checks.state === "success" && typeof checks.total === "number") {
+    return `${formatInteger(checks.total)} passing`;
+  }
+
+  if (checks.state === "failure" && typeof checks.failed === "number") {
+    return `${formatInteger(checks.failed)} failing`;
+  }
+
+  if (checks.state === "pending" && typeof checks.pending === "number") {
+    return `${formatInteger(checks.pending)} pending`;
+  }
+
+  return titleCase(checks.state);
+};
+
+const getChecksTone = (
+  checks: GithubPreviewChecks | null | undefined
+): GithubFact["tone"] => {
+  switch (checks?.state) {
+    case "success":
+      return "success";
+    case "failure":
+      return "danger";
+    case "pending":
+      return "warning";
+    default:
+      return "default";
+  }
+};
+
+const compactFacts = (
+  facts: readonly (GithubFact | null)[]
+): readonly GithubFact[] =>
+  facts.filter(
+    (fact): fact is GithubFact =>
+      fact !== null && fact.value.trim().length > 0
+  );
 
 const getKindLabel = (
   link: ParsedGithubLink,
@@ -423,6 +512,248 @@ const getDetailText = (
   return repoLabel;
 };
 
+const getMetaText = (preview: GithubPreviewResponse | null): string | null => {
+  if (!preview) {
+    return null;
+  }
+
+  if (preview.type === "github.pull_request") {
+    return joinMetaParts([
+      preview.author ? `by @${preview.author}` : null,
+      preview.updatedAt ? `updated ${formatDate(preview.updatedAt)}` : null,
+      preview.headRef && preview.baseRef
+        ? `${preview.headRef} -> ${preview.baseRef}`
+        : null,
+    ]);
+  }
+
+  if (preview.type === "github.issue") {
+    return joinMetaParts([
+      preview.author ? `by @${preview.author}` : null,
+      preview.updatedAt ? `updated ${formatDate(preview.updatedAt)}` : null,
+    ]);
+  }
+
+  if (preview.type === "github.repository") {
+    return joinMetaParts([
+      preview.visibility,
+      preview.defaultBranch ? `default ${preview.defaultBranch}` : null,
+      preview.pushedAt ? `pushed ${formatDate(preview.pushedAt)}` : null,
+    ]);
+  }
+
+  if (preview.type === "github.file" || preview.type === "github.directory") {
+    return joinMetaParts([preview.path, preview.ref ? `ref ${preview.ref}` : null]);
+  }
+
+  return null;
+};
+
+const getAssigneeLabel = (
+  assignees: readonly string[] | null | undefined
+): string | null => {
+  if (!assignees || assignees.length === 0) {
+    return null;
+  }
+
+  const [firstAssignee, ...rest] = assignees;
+  if (!firstAssignee) {
+    return null;
+  }
+
+  return rest.length > 0 ? `@${firstAssignee} +${rest.length}` : `@${firstAssignee}`;
+};
+
+const getPreviewLabels = (
+  preview: GithubPreviewResponse | null
+): readonly GithubPreviewLabel[] => {
+  if (
+    preview?.type === "github.issue" ||
+    preview?.type === "github.pull_request"
+  ) {
+    return preview.labels ?? [];
+  }
+
+  if (preview?.type === "github.repository") {
+    return (
+      preview.topics?.map((topic) => ({
+        name: topic,
+        color: null,
+      })) ?? []
+    );
+  }
+
+  return [];
+};
+
+const getPreviewFacts = (
+  preview: GithubPreviewResponse | null
+): readonly GithubFact[] => {
+  if (!preview) {
+    return [];
+  }
+
+  switch (preview.type) {
+    case "github.pull_request": {
+      const checksLabel = getChecksLabel(preview.checks);
+      return compactFacts([
+        checksLabel
+          ? {
+              label: "Checks",
+              value: checksLabel,
+              tone: getChecksTone(preview.checks),
+            }
+          : null,
+        preview.reviewState !== "none"
+          ? {
+              label: "Review",
+              value:
+                preview.reviewState === "changes_requested"
+                  ? "Changes requested"
+                  : "Approved",
+              tone:
+                preview.reviewState === "changes_requested"
+                  ? "danger"
+                  : "success",
+            }
+          : null,
+        formatDiff(preview.additions, preview.deletions)
+          ? {
+              label: "Diff",
+              value: formatDiff(preview.additions, preview.deletions)!,
+            }
+          : null,
+        formatCount(preview.changedFiles, "file")
+          ? { label: "Files", value: formatCount(preview.changedFiles, "file")! }
+          : null,
+        formatCount(preview.commits, "commit")
+          ? { label: "Commits", value: formatCount(preview.commits, "commit")! }
+          : null,
+        formatCount(preview.comments, "comment")
+          ? { label: "Comments", value: formatCount(preview.comments, "comment")! }
+          : null,
+      ]);
+    }
+    case "github.issue":
+      return compactFacts([
+        getAssigneeLabel(preview.assignees)
+          ? { label: "Assignees", value: getAssigneeLabel(preview.assignees)! }
+          : null,
+        formatCount(preview.comments, "comment")
+          ? { label: "Comments", value: formatCount(preview.comments, "comment")! }
+          : null,
+        preview.closedAt
+          ? { label: "Closed", value: formatDate(preview.closedAt) ?? "" }
+          : null,
+      ]);
+    case "github.repository":
+      return compactFacts([
+        preview.language ? { label: "Language", value: preview.language } : null,
+        formatCompactNumber(preview.stars)
+          ? { label: "Stars", value: formatCompactNumber(preview.stars)! }
+          : null,
+        formatCompactNumber(preview.forks)
+          ? { label: "Forks", value: formatCompactNumber(preview.forks)! }
+          : null,
+        formatCount(preview.openIssues, "issue")
+          ? { label: "Open", value: formatCount(preview.openIssues, "issue")! }
+          : null,
+        preview.license ? { label: "License", value: preview.license } : null,
+      ]);
+    case "github.file":
+      return compactFacts([
+        preview.language ? { label: "Language", value: preview.language } : null,
+        preview.ref ? { label: "Ref", value: preview.ref } : null,
+        formatBytes(preview.size)
+          ? { label: "Size", value: formatBytes(preview.size)! }
+          : null,
+        formatCount(preview.lineCount, "line")
+          ? { label: "Lines", value: formatCount(preview.lineCount, "line")! }
+          : null,
+        preview.lineStart
+          ? {
+              label: "Anchor",
+              value:
+                preview.lineEnd && preview.lineEnd !== preview.lineStart
+                  ? `L${preview.lineStart}-L${preview.lineEnd}`
+                  : `L${preview.lineStart}`,
+            }
+          : null,
+      ]);
+    case "github.directory":
+      return compactFacts([
+        preview.ref ? { label: "Ref", value: preview.ref } : null,
+        formatCount(preview.itemCount, "item")
+          ? { label: "Items", value: formatCount(preview.itemCount, "item")! }
+          : null,
+        formatCount(preview.fileCount, "file")
+          ? { label: "Files", value: formatCount(preview.fileCount, "file")! }
+          : null,
+        formatCount(preview.directoryCount, "folder")
+          ? {
+              label: "Folders",
+              value: formatCount(preview.directoryCount, "folder")!,
+            }
+          : null,
+      ]);
+    case "github.commit":
+      return compactFacts([
+        { label: "SHA", value: preview.shortSha },
+        preview.author ? { label: "Author", value: `@${preview.author}` } : null,
+        formatDate(preview.committedAt)
+          ? { label: "Date", value: formatDate(preview.committedAt)! }
+          : null,
+        formatDiff(preview.additions, preview.deletions)
+          ? {
+              label: "Diff",
+              value: formatDiff(preview.additions, preview.deletions)!,
+            }
+          : null,
+        formatCount(preview.changedFiles, "file")
+          ? { label: "Files", value: formatCount(preview.changedFiles, "file")! }
+          : null,
+      ]);
+    case "github.release":
+      return compactFacts([
+        preview.tagName ? { label: "Tag", value: preview.tagName } : null,
+        { label: "State", value: titleCase(preview.state) ?? preview.state },
+        formatDate(preview.publishedAt)
+          ? { label: "Published", value: formatDate(preview.publishedAt)! }
+          : null,
+      ]);
+    case "github.actions":
+      return compactFacts([
+        preview.runNumber
+          ? { label: "Run", value: `#${formatInteger(preview.runNumber)}` }
+          : null,
+        titleCase(preview.conclusion ?? preview.status)
+          ? {
+              label: "Status",
+              value: titleCase(preview.conclusion ?? preview.status)!,
+              tone:
+                preview.conclusion === "success"
+                  ? "success"
+                  : preview.conclusion
+                    ? "danger"
+                    : "default",
+            }
+          : null,
+        preview.event ? { label: "Event", value: preview.event } : null,
+      ]);
+    case "github.discussion":
+      return compactFacts([
+        preview.number ? { label: "Discussion", value: `#${preview.number}` } : null,
+        preview.category ? { label: "Category", value: preview.category } : null,
+        titleCase(preview.state)
+          ? { label: "State", value: titleCase(preview.state)! }
+          : null,
+        formatCount(preview.comments, "comment")
+          ? { label: "Comments", value: formatCount(preview.comments, "comment")! }
+          : null,
+      ]);
+  }
+};
+
 const getAriaLabel = (
   link: ParsedGithubLink,
   preview: GithubPreviewResponse | null
@@ -446,6 +777,132 @@ const UnavailableStatus = () => (
     Status unavailable
   </span>
 );
+
+const FACT_TONE_CLASSES: Record<NonNullable<GithubFact["tone"]>, string> = {
+  default: "tw-border-iron-800 tw-bg-iron-950/55 tw-text-iron-100",
+  success:
+    "tw-border-emerald-500/25 tw-bg-emerald-500/10 tw-text-emerald-100",
+  warning: "tw-border-amber-400/30 tw-bg-amber-500/10 tw-text-amber-100",
+  danger: "tw-border-rose-400/30 tw-bg-rose-500/10 tw-text-rose-100",
+};
+
+const FactChips = ({ facts }: { readonly facts: readonly GithubFact[] }) => {
+  if (facts.length === 0) {
+    return null;
+  }
+
+  return (
+    <span className="tw-flex tw-min-w-0 tw-flex-wrap tw-gap-1.5">
+      {facts.slice(0, 6).map((fact) => (
+        <span
+          key={`${fact.label}-${fact.value}`}
+          className={`tw-inline-flex tw-min-w-0 tw-max-w-full tw-items-baseline tw-gap-1 tw-rounded-md tw-border tw-border-solid tw-px-2 tw-py-0.5 tw-text-[11px] tw-leading-5 ${
+            FACT_TONE_CLASSES[fact.tone ?? "default"]
+          }`}
+        >
+          <span className="tw-flex-shrink-0 tw-text-iron-400">
+            {fact.label}
+          </span>
+          <span className="tw-truncate tw-font-semibold">{fact.value}</span>
+        </span>
+      ))}
+    </span>
+  );
+};
+
+const getLabelStyle = (
+  label: GithubPreviewLabel
+): CSSProperties | undefined => {
+  const color = label.color?.trim();
+  if (!color || !/^[0-9a-f]{6}$/i.test(color)) {
+    return undefined;
+  }
+
+  return {
+    borderColor: `#${color}88`,
+    backgroundColor: `#${color}22`,
+  };
+};
+
+const LabelChips = ({
+  labels,
+}: {
+  readonly labels: readonly GithubPreviewLabel[];
+}) => {
+  if (labels.length === 0) {
+    return null;
+  }
+
+  return (
+    <span className="tw-flex tw-min-w-0 tw-flex-wrap tw-gap-1.5">
+      {labels.slice(0, 4).map((label) => (
+        <span
+          key={label.name}
+          style={getLabelStyle(label)}
+          className="tw-inline-flex tw-max-w-full tw-rounded-full tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/65 tw-px-2 tw-py-0.5 tw-text-[11px] tw-font-medium tw-leading-5 tw-text-iron-100"
+        >
+          <span className="tw-truncate">{label.name}</span>
+        </span>
+      ))}
+      {labels.length > 4 && (
+        <span className="tw-rounded-full tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-950/60 tw-px-2 tw-py-0.5 tw-text-[11px] tw-font-medium tw-leading-5 tw-text-iron-400">
+          +{labels.length - 4}
+        </span>
+      )}
+    </span>
+  );
+};
+
+const FileExcerpt = ({
+  preview,
+}: {
+  readonly preview: GithubPreviewResponse | null;
+}) => {
+  if (preview?.type !== "github.file" || !preview.excerpt?.length) {
+    return null;
+  }
+
+  const start = preview.lineStart ?? 1;
+
+  return (
+    <span
+      className="tw-grid tw-max-h-24 tw-overflow-hidden tw-rounded-md tw-border tw-border-solid tw-border-iron-800 tw-bg-black/35 tw-p-2 tw-font-mono tw-text-[11px] tw-leading-4 tw-text-iron-200 sm:tw-text-xs"
+      data-testid="github-file-excerpt"
+    >
+      {preview.excerpt.map((line, index) => (
+        <span key={`${start + index}-${line}`} className="tw-flex tw-min-w-0">
+          <span className="tw-mr-2 tw-w-8 tw-flex-shrink-0 tw-select-none tw-text-right tw-text-iron-500">
+            {start + index}
+          </span>
+          <span className="tw-min-w-0 tw-truncate">{line || " "}</span>
+        </span>
+      ))}
+    </span>
+  );
+};
+
+const DirectoryEntries = ({
+  preview,
+}: {
+  readonly preview: GithubPreviewResponse | null;
+}) => {
+  if (preview?.type !== "github.directory" || !preview.entries?.length) {
+    return null;
+  }
+
+  return (
+    <span className="tw-flex tw-min-w-0 tw-flex-wrap tw-gap-1.5">
+      {preview.entries.map((entry) => (
+        <span
+          key={entry}
+          className="tw-inline-flex tw-max-w-full tw-rounded-md tw-bg-black/25 tw-px-2 tw-py-0.5 tw-font-mono tw-text-[11px] tw-leading-5 tw-text-iron-200"
+        >
+          <span className="tw-truncate">{entry}</span>
+        </span>
+      ))}
+    </span>
+  );
+};
 
 export default function GithubLinkPreview({ href }: GithubLinkPreviewProps) {
   const link = useMemo(() => parseGithubLink(href), [href]);
@@ -486,6 +943,9 @@ export default function GithubLinkPreview({ href }: GithubLinkPreviewProps) {
   const kindLabel =
     getKindLabelFromPreview(preview) ?? getKindLabel(link, preview);
   const detailText = getDetailText(link, preview);
+  const metaText = getMetaText(preview);
+  const facts = getPreviewFacts(preview);
+  const labels = getPreviewLabels(preview);
 
   return (
     <LinkHandlerFrame href={href}>
@@ -495,12 +955,12 @@ export default function GithubLinkPreview({ href }: GithubLinkPreviewProps) {
         rel="noopener noreferrer"
         prefetch={false}
         onClick={(event) => event.stopPropagation()}
-        className="tw-relative tw-block tw-w-full tw-min-w-0 tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/55 tw-p-3 tw-pr-12 tw-no-underline tw-shadow-sm tw-shadow-black/20 tw-transition tw-duration-200 hover:tw-border-iron-600 hover:tw-bg-iron-900/75 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 sm:tw-p-4 sm:tw-pr-14"
+        className="tw-relative tw-block tw-w-full tw-min-w-0 tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950/70 tw-p-3 tw-pr-12 tw-no-underline tw-shadow-sm tw-shadow-black/20 tw-transition tw-duration-200 hover:tw-border-iron-600 hover:tw-bg-iron-900/75 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 sm:tw-p-4 sm:tw-pr-14"
         data-testid="github-link-preview-card"
         aria-label={getAriaLabel(link, preview)}
       >
-        <div className="tw-flex tw-min-w-0 tw-gap-3">
-          <span className="tw-flex tw-h-10 tw-w-10 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-border-white/10 tw-bg-black/35">
+        <span className="tw-grid tw-min-w-0 tw-grid-cols-[2.5rem,minmax(0,1fr)] tw-gap-3 sm:tw-grid-cols-[3rem,minmax(0,1fr)]">
+          <span className="tw-flex tw-h-10 tw-w-10 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-border-white/10 tw-bg-black/35 sm:tw-h-12 sm:tw-w-12">
             <Image
               src="/github_w.png"
               alt=""
@@ -508,15 +968,15 @@ export default function GithubLinkPreview({ href }: GithubLinkPreviewProps) {
               width={24}
               height={24}
               unoptimized
-              className="tw-h-6 tw-w-6 tw-opacity-90"
+              className="tw-h-6 tw-w-6 tw-opacity-90 sm:tw-h-7 sm:tw-w-7"
             />
           </span>
-          <span className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-2">
-            <span className="tw-flex tw-min-w-0 tw-flex-wrap tw-items-center tw-gap-2">
-              <span className="tw-text-[11px] tw-font-semibold tw-uppercase tw-leading-none tw-tracking-wide tw-text-iron-400">
+          <span className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-2.5">
+            <span className="tw-flex tw-min-w-0 tw-flex-wrap tw-items-center tw-gap-1.5 sm:tw-gap-2">
+              <span className="tw-text-[11px] tw-font-semibold tw-uppercase tw-leading-none tw-text-iron-500">
                 GitHub
               </span>
-              <span className="tw-inline-flex tw-items-center tw-rounded-full tw-bg-iron-800/80 tw-px-2 tw-py-1 tw-text-[11px] tw-font-semibold tw-leading-none tw-text-iron-200">
+              <span className="tw-inline-flex tw-items-center tw-rounded-md tw-bg-iron-800/75 tw-px-2 tw-py-1 tw-text-[11px] tw-font-semibold tw-leading-none tw-text-iron-200">
                 {kindLabel}
               </span>
               {state.type === "loading" && <LoadingStatus />}
@@ -530,14 +990,25 @@ export default function GithubLinkPreview({ href }: GithubLinkPreviewProps) {
                 />
               )}
             </span>
-            <span className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-break-words tw-text-sm tw-font-semibold tw-leading-snug tw-text-iron-100 sm:tw-text-base">
-              {title}
+            <span className="tw-flex tw-min-w-0 tw-flex-col tw-gap-1">
+              <span className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-break-words tw-text-sm tw-font-semibold tw-leading-snug tw-text-iron-50 sm:tw-text-base">
+                {title}
+              </span>
+              <span className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-break-words tw-text-xs tw-font-medium tw-leading-5 tw-text-iron-400">
+                {detailText}
+              </span>
+              {metaText && (
+                <span className="tw-[overflow-wrap:anywhere] tw-line-clamp-1 tw-break-words tw-text-xs tw-leading-5 tw-text-iron-500">
+                  {metaText}
+                </span>
+              )}
             </span>
-            <span className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-break-words tw-text-xs tw-font-medium tw-leading-5 tw-text-iron-400">
-              {detailText}
-            </span>
+            <FactChips facts={facts} />
+            <LabelChips labels={labels} />
+            <DirectoryEntries preview={preview} />
+            <FileExcerpt preview={preview} />
           </span>
-        </div>
+        </span>
       </Link>
     </LinkHandlerFrame>
   );

--- a/services/api/github-preview-api.ts
+++ b/services/api/github-preview-api.ts
@@ -6,6 +6,26 @@ export type GithubPreviewIssueState =
   | "closed_not_planned"
   | "closed";
 
+export interface GithubPreviewLabel {
+  readonly name: string;
+  readonly color?: string | null | undefined;
+}
+
+export interface GithubPreviewChecks {
+  readonly state:
+    | "success"
+    | "failure"
+    | "pending"
+    | "neutral"
+    | "skipped"
+    | "unknown";
+  readonly total: number | null;
+  readonly successful: number | null;
+  readonly failed: number | null;
+  readonly pending: number | null;
+  readonly url?: string | null | undefined;
+}
+
 export interface GithubIssuePreviewResponse {
   readonly type: "github.issue";
   readonly owner: string;
@@ -13,6 +33,12 @@ export interface GithubIssuePreviewResponse {
   readonly number: number;
   readonly title: string | null;
   readonly state: GithubPreviewIssueState;
+  readonly author?: string | null | undefined;
+  readonly createdAt?: string | null | undefined;
+  readonly updatedAt?: string | null | undefined;
+  readonly closedAt?: string | null | undefined;
+  readonly comments?: number | null | undefined;
+  readonly labels?: readonly GithubPreviewLabel[] | null | undefined;
   readonly assignees: readonly string[];
   readonly url: string;
 }
@@ -28,6 +54,21 @@ export interface GithubPullRequestPreviewResponse {
   readonly mergeableState: string | null;
   readonly merged: boolean;
   readonly draft: boolean;
+  readonly author?: string | null | undefined;
+  readonly createdAt?: string | null | undefined;
+  readonly updatedAt?: string | null | undefined;
+  readonly closedAt?: string | null | undefined;
+  readonly comments?: number | null | undefined;
+  readonly reviewComments?: number | null | undefined;
+  readonly commits?: number | null | undefined;
+  readonly changedFiles?: number | null | undefined;
+  readonly additions?: number | null | undefined;
+  readonly deletions?: number | null | undefined;
+  readonly baseRef?: string | null | undefined;
+  readonly headRef?: string | null | undefined;
+  readonly headSha?: string | null | undefined;
+  readonly labels?: readonly GithubPreviewLabel[] | null | undefined;
+  readonly checks?: GithubPreviewChecks | null | undefined;
   readonly url: string;
 }
 
@@ -44,6 +85,10 @@ export interface GithubRepositoryPreviewResponse {
   readonly openIssues: number | null;
   readonly visibility: string | null;
   readonly archived: boolean;
+  readonly updatedAt?: string | null | undefined;
+  readonly pushedAt?: string | null | undefined;
+  readonly topics?: readonly string[] | null | undefined;
+  readonly license?: string | null | undefined;
   readonly url: string;
 }
 
@@ -56,6 +101,14 @@ export interface GithubContentPreviewResponse {
   readonly ref: string | null;
   readonly size: number | null;
   readonly itemCount: number | null;
+  readonly language?: string | null | undefined;
+  readonly lineCount?: number | null | undefined;
+  readonly lineStart?: number | null | undefined;
+  readonly lineEnd?: number | null | undefined;
+  readonly excerpt?: readonly string[] | null | undefined;
+  readonly entries?: readonly string[] | null | undefined;
+  readonly fileCount?: number | null | undefined;
+  readonly directoryCount?: number | null | undefined;
   readonly url: string;
 }
 
@@ -68,6 +121,9 @@ export interface GithubCommitPreviewResponse {
   readonly shortSha: string;
   readonly author: string | null;
   readonly committedAt: string | null;
+  readonly additions?: number | null | undefined;
+  readonly deletions?: number | null | undefined;
+  readonly changedFiles?: number | null | undefined;
   readonly url: string;
 }
 


### PR DESCRIPTION
## Summary

- Expands GitHub preview API responses with PR author/date/branch/diff/checks/labels, issue metadata, repository topics/license, file excerpts, directory entries, and commit stats.
- Redesigns the GitHub link preview card to show compact facts, labels, file snippets, and directory entries while preserving the single-link/no-nested-interactive structure.
- Adds focused route and component coverage for rich PR, issue, repository, file, directory, and commit previews.

## Validation

- `seize run test:no-coverage -- __tests__/app/api/github-preview.route.test.ts __tests__/components/waves/github/GithubLinkPreview.test.tsx __tests__/components/waves/GithubPreviewStatusBadge.test.tsx`
- `seize run lint:changed`
- `seize run typecheck:changed`
- `codex-diff-check`
- Local responsive QA at 1440 desktop, 820 tablet, and 390 mobile widths using the actual `GithubLinkPreview` component and real public GitHub URLs; verified 5 rendered cards per viewport with no horizontal overflow.

## Notes

Local wave SSR could not load the production Follow The Repo wave unauthenticated (`Wave ... not found`), so visual QA used a temporary local harness page that was removed before commit.