### PR TITLE
[codex] Fix wave score tooltip layering

### DIFF
--- a/components/waves/WaveTrustSignals.tsx
+++ b/components/waves/WaveTrustSignals.tsx
@@ -465,7 +465,7 @@ function WaveScoreSummaryTooltip({
     <span
       id={id}
       role="tooltip"
-      className="tw-pointer-events-none tw-absolute tw-left-0 tw-top-full tw-z-50 tw-mt-2 tw-hidden tw-w-72 tw-rounded-lg tw-bg-iron-950 tw-p-3 tw-text-left tw-text-xs tw-font-normal tw-leading-5 tw-text-iron-200 tw-shadow-2xl tw-ring-1 tw-ring-white/10 group-hover:tw-block group-focus-within:tw-block"
+      className="tw-pointer-events-none tw-absolute tw-left-0 tw-top-full tw-z-[10000] tw-mt-2 tw-hidden tw-w-72 tw-rounded-lg tw-bg-iron-950 tw-p-3 tw-text-left tw-text-xs tw-font-normal tw-leading-5 tw-text-iron-200 tw-shadow-2xl tw-ring-1 tw-ring-white/10 group-hover:tw-block group-focus-within:tw-block"
     >
       {primaryDetail && (
         <span className="tw-block tw-text-sm tw-font-semibold tw-text-white">

--- a/components/waves/discovery/WaveScoreTransparencyPage.tsx
+++ b/components/waves/discovery/WaveScoreTransparencyPage.tsx
@@ -618,7 +618,7 @@ function CalculatorPanel({
               id="wave-score-calculator-input"
               value={input}
               onChange={(event) => onInputChange(event.target.value)}
-              placeholder="meme-chat or https://6529.io/waves/..."
+              placeholder="Memes-Chat or https://6529.io/waves/..."
               aria-invalid={Boolean(error)}
               aria-describedby={error ? errorId : undefined}
               className="tw-block tw-h-11 tw-w-full tw-rounded-lg tw-border-0 tw-bg-black/35 tw-px-10 tw-text-sm tw-text-white tw-ring-1 tw-ring-inset tw-ring-iron-700 tw-transition placeholder:tw-text-iron-500 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-primary-400"


### PR DESCRIPTION
## Summary
- Raise the rich Wave Score tooltip above the wave stream so it is actually visible on hover.
- Replace the calculator placeholder with a live exact wave-name example (`Memes-Chat`) instead of the non-matching lowercase sample.

## Why
Staging E2E showed the active-wave score tooltip had the right content and dark styling in the DOM, but it was painted underneath the wave content. The calculator also worked with exact wave names/URLs/ids, but the placeholder example did not match staging data.

## Validation
- `seize run test:no-coverage -- __tests__/components/waves/WaveTrustSignals.test.tsx __tests__/app/networkPages.test.tsx --runInBand`
- `seize run lint:single -- components/waves/WaveTrustSignals.tsx components/waves/discovery/WaveScoreTransparencyPage.tsx`
- `codex-diff-check -- components/waves/WaveTrustSignals.tsx components/waves/discovery/WaveScoreTransparencyPage.tsx`
- Authenticated staging Playwright debug confirmed the z-index adjustment makes the tooltip visible above the wave stream.