### PR TITLE
[codex] Fix wave score tooltip hover layer

### DIFF
--- a/components/waves/WaveTrustSignals.tsx
+++ b/components/waves/WaveTrustSignals.tsx
@@ -578,7 +578,7 @@ export function WaveTrustSignals({
       getVisibilityToneClasses(variant, waveScore?.visibility_score)
     )} ${
       hasRichTooltip
-        ? "tw-group tw-relative tw-isolate tw-overflow-visible tw-no-underline"
+        ? "tw-group tw-relative tw-isolate tw-overflow-visible tw-no-underline desktop-hover:hover:tw-z-[10000] focus:tw-z-[10000] focus-visible:tw-z-[10000]"
         : ""
     }`;
     const summaryChipContent = (


### PR DESCRIPTION
## Summary
- Raise the score chip stacking context only while it is hovered or focused.
- Keep the chip isolated at rest, and keep the elevated z-index scoped to the tooltip/open interaction.

## Why
The previous fix scoped high z-index to the tooltip element, but staging E2E showed the tooltip was still painted under the wave stream because its parent score-link stacking context stayed below the stream. This keeps the bot-requested safe default (`tw-isolate`) while raising the parent only during hover/focus, when the tooltip is visible.

## Validation
- `seize run test:no-coverage -- __tests__/components/waves/WaveTrustSignals.test.tsx __tests__/app/networkPages.test.tsx --runInBand --forceExit`
- `seize run lint:single -- components/waves/WaveTrustSignals.tsx components/waves/discovery/WaveScoreTransparencyPage.tsx`
- `codex-diff-check -- components/waves/WaveTrustSignals.tsx`
- Authenticated staging E2E on candidate `7476d55b...` exposed the parent-stacking issue; this PR is the narrow correction for that failure.