### PR TITLE
[codex] Add delegation docs IPFS publish pipeline

### DIFF
--- a/.github/workflows/publish-delegation-docs-content.yml
+++ b/.github/workflows/publish-delegation-docs-content.yml
@@ -1,0 +1,98 @@
+name: Publish Delegation Docs Content
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build and receipt the bundle without publishing to IPFS"
+        required: true
+        default: true
+        type: boolean
+      skip_gateway_verify:
+        description: "Skip post-publish verification through the configured IPFS gateway"
+        required: true
+        default: false
+        type: boolean
+      skip_cdn_sync:
+        description: "Skip optional S3/CloudFront acceleration mirror sync"
+        required: true
+        default: false
+        type: boolean
+      version:
+        description: "Delegation docs package version"
+        required: true
+        default: "delegation-docs-2026-06-16"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    env:
+      DELEGATION_DOCS_VERSION: ${{ inputs.version }}
+      DELEGATION_DOCS_IPFS_API_ENDPOINT: ${{ secrets.DELEGATION_DOCS_IPFS_API_ENDPOINT }}
+      DELEGATION_DOCS_IPFS_API_BEARER_TOKEN: ${{ secrets.DELEGATION_DOCS_IPFS_API_BEARER_TOKEN }}
+      DELEGATION_DOCS_IPFS_API_AUTH_HEADER: ${{ secrets.DELEGATION_DOCS_IPFS_API_AUTH_HEADER }}
+      DELEGATION_DOCS_IPFS_GATEWAY_BASE_URL: ${{ vars.DELEGATION_DOCS_IPFS_GATEWAY_BASE_URL }}
+      DELEGATION_DOCS_CDN_S3_URI: ${{ vars.DELEGATION_DOCS_CDN_S3_URI }}
+      DELEGATION_DOCS_CDN_BASE_URL: ${{ vars.DELEGATION_DOCS_CDN_BASE_URL }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Activate pinned pnpm
+        run: |
+          corepack enable pnpm
+          corepack prepare "$(node -p 'require("./package.json").packageManager')" --activate
+          pnpm --version
+
+      - name: Install Socket Firewall
+        id: socket_firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall
+
+      - name: Assert npm lockfile is absent
+        run: ./bin/6529 guard:no-package-lock
+
+      - name: Install dependencies
+        env:
+          SFW_BIN: ${{ steps.socket_firewall.outputs.firewall-path-binary }}
+        run: ./bin/6529 install:frozen
+
+      - name: Configure AWS credentials for optional CDN sync
+        if: ${{ inputs.dry_run == false && inputs.skip_cdn_sync == false && startsWith(vars.DELEGATION_DOCS_CDN_S3_URI, 's3://') }}
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.DELEGATION_DOCS_CDN_AWS_REGION || 'us-east-1' }}
+
+      - name: Publish delegation docs package
+        run: |
+          args=()
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            args+=(--dry-run)
+          fi
+          if [ "${{ inputs.skip_gateway_verify }}" = "true" ]; then
+            args+=(--skip-gateway-verify)
+          fi
+          if [ "${{ inputs.skip_cdn_sync }}" = "true" ]; then
+            args+=(--skip-cdn-sync)
+          fi
+          node ops/scripts/publish-delegation-docs-content.mjs "${args[@]}"
+
+      - name: Upload publish receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: delegation-docs-ipfs-receipt
+          path: tmp/delegation-docs-publish/*.json

--- a/ops/docs/delegation/content-delivery-ipfs-pilot.md
+++ b/ops/docs/delegation/content-delivery-ipfs-pilot.md
@@ -26,7 +26,14 @@ slug/path.
 
 `ops/scripts/build-delegation-docs-content.mjs` packages the reviewed repo bundle by default. It removes active HTML, strips duplicate leading article headings, verifies packaged asset references, rewrites internal delegation links to absolute app routes, and refreshes the public bundle in place. Set `DELEGATION_DOCS_IMPORT_LEGACY_S3=1` only when intentionally refreshing article HTML from the legacy S3 source. Import mode still requires article assets to already exist as reviewed files under `content/delegation/assets`; new or changed remote assets must be downloaded and reviewed separately before rebuilding.
 
-The manifest currently has `canonicalStorage.rootCid: null` because the frontend repo does not have IPFS publishing credentials. After publishing the bundle directory to IPFS, update the manifest with the root CID and regenerate the public copy.
+`ops/scripts/publish-delegation-docs-content.mjs` publishes the reviewed bundle
+to the 6529-controlled internal IPFS node from an ops/CI context. Browser
+runtime code must never publish docs content or call a write-capable IPFS RPC
+endpoint.
+
+The manifest can have `canonicalStorage.rootCid: null` before the first publish.
+After the bundle is published and pinned, use the receipt root CID to update the
+repo manifest in a reviewed commit.
 
 ## Runtime Rules
 
@@ -48,8 +55,34 @@ Similar runtime S3-rendered content exists outside delegation, including About H
 1. Review article edits in `public/delegation-content/{version}/html`.
 2. Review asset edits in `content/delegation/assets`.
 3. Run `node ops/scripts/build-delegation-docs-content.mjs` to rebuild the manifest and public bundle.
-4. Publish `public/delegation-content/{version}` to IPFS from an admin or backend pipeline.
-5. Pin the root CID using 6529-controlled infrastructure.
-6. Set `DELEGATION_DOCS_IPFS_ROOT_CID` and rerun the build script.
-7. If using CloudFront/S3 acceleration, set `DELEGATION_DOCS_CDN_BASE_URL` to a CID or version-addressed mirror path.
+4. Publish `public/delegation-content/{version}` to IPFS through the internal
+   node:
+
+   ```bash
+   DELEGATION_DOCS_IPFS_API_ENDPOINT=https://api-ipfs.6529.io \
+     node ops/scripts/publish-delegation-docs-content.mjs
+   ```
+
+   Use `--dry-run` to build and receipt the file set without publishing.
+5. Keep the generated receipt from `tmp/delegation-docs-publish`. It records the
+   root CID, file hashes, IPFS entries, and byte-exact gateway/CDN verification
+   results for every published file.
+6. Set `DELEGATION_DOCS_IPFS_ROOT_CID` from the receipt and rerun the build
+   script. If using CloudFront/S3 acceleration, also set
+   `DELEGATION_DOCS_CDN_BASE_URL` to a CID or version-addressed mirror path.
+7. Commit the updated manifest/public bundle as a reviewed PR.
 8. Verify representative delegation article routes and confirm hash-verified rendering.
+
+The manual GitHub workflow `Publish Delegation Docs Content` runs the same
+script. Configure these secrets/vars before using it for a real publish:
+
+- `DELEGATION_DOCS_IPFS_API_ENDPOINT` secret: internal IPFS API endpoint.
+- `DELEGATION_DOCS_IPFS_API_BEARER_TOKEN` secret or
+  `DELEGATION_DOCS_IPFS_API_AUTH_HEADER` secret: optional auth for the internal
+  node.
+- `DELEGATION_DOCS_IPFS_GATEWAY_BASE_URL` var: gateway used for post-publish
+  verification, normally `https://ipfs.6529.io/ipfs`.
+- `DELEGATION_DOCS_CDN_S3_URI` var: optional S3 mirror destination. It may use
+  `{cid}` and `{version}` placeholders.
+- `DELEGATION_DOCS_CDN_BASE_URL` var: optional CloudFront base URL for
+  post-sync hash verification. It may use `{cid}` and `{version}` placeholders.

--- a/ops/docs/delegation/source-of-truth-spec.md
+++ b/ops/docs/delegation/source-of-truth-spec.md
@@ -127,13 +127,26 @@ Use this workflow for article edits.
 4. Run `node ops/scripts/build-delegation-docs-content.mjs`.
 5. Confirm `content/delegation/manifest.json` and the versioned public bundle
    were regenerated.
-6. Publish the versioned public bundle to IPFS from a controlled admin/backend
-   pipeline.
-7. Pin the root CID using 6529-controlled infrastructure.
-8. Set `DELEGATION_DOCS_IPFS_ROOT_CID` and rerun the build script.
-9. If using S3/CloudFront, set `DELEGATION_DOCS_CDN_BASE_URL` to a CID or
-   version-addressed mirror path.
-10. Verify representative article routes in a browser and confirm no hash
+6. Publish the versioned public bundle to IPFS from a controlled ops/CI context
+   using the 6529 internal IPFS node:
+
+   ```bash
+   DELEGATION_DOCS_IPFS_API_ENDPOINT=https://api-ipfs.6529.io \
+     node ops/scripts/publish-delegation-docs-content.mjs
+   ```
+
+   The manual GitHub workflow `Publish Delegation Docs Content` runs the same
+   script with repository secrets/vars.
+7. Pin the root CID using 6529-controlled infrastructure. The publish script
+   uses `pin=true` when calling the internal node.
+8. Save the receipt from `tmp/delegation-docs-publish`. It records the root CID,
+   the file hashes, the IPFS add response, and gateway/CDN verification results.
+9. Set `DELEGATION_DOCS_IPFS_ROOT_CID` from the receipt and rerun the build
+   script.
+10. If using S3/CloudFront, set `DELEGATION_DOCS_CDN_BASE_URL` to a CID or
+    version-addressed mirror path.
+11. Commit the updated manifest/public bundle through normal review.
+12. Verify representative article routes in a browser and confirm no hash
     errors.
 
 Do not treat current imported S3 bodies as permanent editorial quality. They
@@ -286,8 +299,8 @@ Use this status table before starting new delegation work.
 | FAQ child wrapper navigation | Built | React wrapper |
 | Repo-reviewed article package | Built | `content/delegation` |
 | Hash-verified runtime loader | Built | `delegationContent.ts` |
-| IPFS root CID publish | Pending | Admin/backend publish flow |
-| CloudFront/S3 acceleration mirror | Optional pending | CID/version-addressed mirror |
+| IPFS root CID publish | Built, pending credentials/config | `publish-delegation-docs-content.mjs` plus manual workflow |
+| CloudFront/S3 acceleration mirror | Built optional path, pending config | CID/version-addressed mirror |
 | Full article body rewrite package | Pending | `public/delegation-content/{version}/html` |
 | Image caption/alt pass for article bodies | Pending | `public/delegation-content/{version}/html` |
 | Similar S3 content migrations outside delegation | Future | Separate specs |

--- a/ops/scripts/publish-delegation-docs-content.mjs
+++ b/ops/scripts/publish-delegation-docs-content.mjs
@@ -1,0 +1,465 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, "..", "..");
+const VERSION = process.env.DELEGATION_DOCS_VERSION ?? "delegation-docs-2026-06-16";
+const BUNDLE_DIR = path.join(
+  REPO_ROOT,
+  "public",
+  "delegation-content",
+  VERSION
+);
+const RECEIPT_DIR = path.join(REPO_ROOT, "tmp", "delegation-docs-publish");
+const RECEIPT_PATH = path.join(RECEIPT_DIR, `${VERSION}-ipfs-receipt.json`);
+const DEFAULT_GATEWAY_BASE_URL = "https://ipfs.6529.io/ipfs";
+
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has("--dry-run");
+const skipBuild = args.has("--skip-build");
+const skipGatewayVerify = args.has("--skip-gateway-verify");
+const skipCdnSync = args.has("--skip-cdn-sync");
+
+function trimTrailingSlashes(value) {
+  let end = value.length;
+
+  while (end > 0 && value[end - 1] === "/") {
+    end--;
+  }
+
+  return value.slice(0, end);
+}
+
+function isPlainObject(value) {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function assertInsideRepo(targetPath) {
+  const resolved = path.resolve(targetPath);
+  const relative = path.relative(REPO_ROOT, resolved);
+
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`${targetPath} is outside the repository`);
+  }
+
+  return resolved;
+}
+
+function assertSafeUrl(value, label, { allowsInsecureLocalhost = false } = {}) {
+  const url = new URL(value);
+  const isLocalhost =
+    url.hostname === "localhost" ||
+    url.hostname === "127.0.0.1" ||
+    url.hostname === "::1";
+
+  if (url.protocol === "https:") {
+    return url;
+  }
+
+  if (
+    allowsInsecureLocalhost &&
+    url.protocol === "http:" &&
+    isLocalhost &&
+    process.env.DELEGATION_DOCS_ALLOW_INSECURE_LOCAL_IPFS_API === "1"
+  ) {
+    return url;
+  }
+
+  throw new Error(
+    `${label} must use https://${
+      allowsInsecureLocalhost
+        ? " unless explicitly allowing localhost with DELEGATION_DOCS_ALLOW_INSECURE_LOCAL_IPFS_API=1"
+        : ""
+    }`
+  );
+}
+
+function normalizeBundleRelativePath(filePath) {
+  return path.relative(BUNDLE_DIR, filePath).replaceAll(path.sep, "/");
+}
+
+async function listFiles(rootDir) {
+  const files = [];
+  const entries = await readdir(rootDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const entryPath = path.join(rootDir, entry.name);
+
+    if (entry.isDirectory()) {
+      files.push(...(await listFiles(entryPath)));
+      continue;
+    }
+
+    if (entry.isFile()) {
+      files.push(entryPath);
+    }
+  }
+
+  return files.sort((left, right) =>
+    normalizeBundleRelativePath(left).localeCompare(
+      normalizeBundleRelativePath(right)
+    )
+  );
+}
+
+async function sha256File(filePath) {
+  const hash = createHash("sha256");
+
+  await new Promise((resolve, reject) => {
+    createReadStream(filePath)
+      .on("data", (chunk) => hash.update(chunk))
+      .on("error", reject)
+      .on("end", resolve);
+  });
+
+  return hash.digest("hex");
+}
+
+function sha256Bytes(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function runCommand(command, commandArgs, options = {}) {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, commandArgs, {
+      cwd: REPO_ROOT,
+      env: process.env,
+      shell: process.platform === "win32",
+      stdio: options.capture ? ["ignore", "pipe", "pipe"] : "inherit",
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    if (options.capture) {
+      child.stdout?.on("data", (chunk) => {
+        stdout += chunk.toString();
+      });
+      child.stderr?.on("data", (chunk) => {
+        stderr += chunk.toString();
+      });
+    }
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+
+      reject(
+        new Error(
+          `${command} ${commandArgs.join(" ")} failed with exit code ${code}${
+            stderr ? `\n${stderr}` : ""
+          }`
+        )
+      );
+    });
+  });
+}
+
+async function buildBundle() {
+  if (skipBuild) {
+    return;
+  }
+
+  await runCommand("node", ["ops/scripts/build-delegation-docs-content.mjs"]);
+}
+
+function getIpfsApiEndpoint() {
+  return (
+    process.env.DELEGATION_DOCS_IPFS_API_ENDPOINT ??
+    process.env.IPFS_API_ENDPOINT ??
+    ""
+  ).trim();
+}
+
+function getIpfsHeaders() {
+  const headers = {};
+  const authHeader = process.env.DELEGATION_DOCS_IPFS_API_AUTH_HEADER?.trim();
+  const bearerToken = process.env.DELEGATION_DOCS_IPFS_API_BEARER_TOKEN?.trim();
+
+  if (authHeader) {
+    const separatorIndex = authHeader.indexOf(":");
+
+    if (separatorIndex === -1) {
+      throw new Error(
+        "DELEGATION_DOCS_IPFS_API_AUTH_HEADER must be formatted as 'Header-Name: value'"
+      );
+    }
+
+    headers[authHeader.slice(0, separatorIndex).trim()] = authHeader
+      .slice(separatorIndex + 1)
+      .trim();
+  }
+
+  if (bearerToken) {
+    headers.Authorization = `Bearer ${bearerToken}`;
+  }
+
+  return headers;
+}
+
+async function publishToIpfs(files) {
+  const apiEndpoint = getIpfsApiEndpoint();
+
+  if (!apiEndpoint) {
+    throw new Error(
+      "Set DELEGATION_DOCS_IPFS_API_ENDPOINT or IPFS_API_ENDPOINT to publish the delegation bundle"
+    );
+  }
+
+  assertSafeUrl(apiEndpoint, "DELEGATION_DOCS_IPFS_API_ENDPOINT", {
+    allowsInsecureLocalhost: true,
+  });
+
+  const form = new FormData();
+
+  for (const filePath of files) {
+    const bytes = await readFile(filePath);
+    const relativePath = normalizeBundleRelativePath(filePath);
+    form.append("file", new Blob([bytes]), relativePath);
+  }
+
+  const endpoint = new URL(`${trimTrailingSlashes(apiEndpoint)}/api/v0/add`);
+  endpoint.searchParams.set("cid-version", "1");
+  endpoint.searchParams.set("hash", "sha2-256");
+  endpoint.searchParams.set("pin", "true");
+  endpoint.searchParams.set("wrap-with-directory", "true");
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: getIpfsHeaders(),
+    body: form,
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `IPFS publish failed with ${response.status}: ${await response.text()}`
+    );
+  }
+
+  const lines = (await response.text())
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const entries = lines.map((line) => {
+    try {
+      return JSON.parse(line);
+    } catch (error) {
+      throw new Error(
+        `IPFS add response included non-JSON line: ${line.slice(0, 200)}`,
+        { cause: error }
+      );
+    }
+  });
+  const rootEntry = entries.find((entry) => entry.Name === "") ?? entries.at(-1);
+  const rootCid = rootEntry?.Hash;
+
+  if (!rootCid) {
+    throw new Error("IPFS add response did not include a root CID");
+  }
+
+  return { rootCid, entries };
+}
+
+function getGatewayBaseUrl() {
+  const gatewayBaseUrl = trimTrailingSlashes(
+    (
+      process.env.DELEGATION_DOCS_IPFS_GATEWAY_BASE_URL ??
+      process.env.DELEGATION_DOCS_PRIMARY_GATEWAY_BASE_URL ??
+      DEFAULT_GATEWAY_BASE_URL
+    ).trim()
+  );
+
+  assertSafeUrl(gatewayBaseUrl, "DELEGATION_DOCS_IPFS_GATEWAY_BASE_URL");
+
+  return gatewayBaseUrl;
+}
+
+async function fetchBytes(url) {
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(`${url} returned ${response.status}`);
+  }
+
+  return Buffer.from(await response.arrayBuffer());
+}
+
+async function verifyPublishedFiles(fileReceipts, baseUrl) {
+  const verifiedFiles = [];
+
+  for (const fileReceipt of fileReceipts) {
+    const url = `${baseUrl}/${fileReceipt.path}`;
+    const bytes = await fetchBytes(url);
+    const digest = sha256Bytes(bytes);
+
+    if (digest !== fileReceipt.sha256) {
+      throw new Error(
+        `${url} sha256 mismatch: expected ${fileReceipt.sha256}, received ${digest}`
+      );
+    }
+
+    verifiedFiles.push({
+      path: fileReceipt.path,
+      bytes: bytes.byteLength,
+      sha256: digest,
+      url,
+    });
+  }
+
+  return verifiedFiles;
+}
+
+async function verifyGateway(rootCid, fileReceipts) {
+  if (skipGatewayVerify) {
+    return [];
+  }
+
+  return await verifyPublishedFiles(
+    fileReceipts,
+    `${getGatewayBaseUrl()}/${rootCid}`
+  );
+}
+
+function resolveTemplate(value, rootCid) {
+  return value.replaceAll("{cid}", rootCid).replaceAll("{version}", VERSION);
+}
+
+async function syncCdn(rootCid) {
+  const s3UriTemplate = process.env.DELEGATION_DOCS_CDN_S3_URI?.trim();
+
+  if (skipCdnSync || !s3UriTemplate) {
+    return null;
+  }
+
+  const s3Uri = resolveTemplate(s3UriTemplate, rootCid);
+
+  if (!s3Uri.startsWith("s3://")) {
+    throw new Error("DELEGATION_DOCS_CDN_S3_URI must start with s3://");
+  }
+
+  await runCommand("aws", [
+    "s3",
+    "sync",
+    BUNDLE_DIR,
+    s3Uri,
+    "--delete",
+    "--cache-control",
+    "public,max-age=31536000,immutable",
+  ]);
+
+  return { s3Uri };
+}
+
+async function verifyCdn(rootCid, fileReceipts) {
+  const cdnBaseUrlTemplate = process.env.DELEGATION_DOCS_CDN_BASE_URL?.trim();
+
+  if (skipCdnSync || !cdnBaseUrlTemplate) {
+    return [];
+  }
+
+  const cdnBaseUrl = trimTrailingSlashes(
+    resolveTemplate(cdnBaseUrlTemplate, rootCid)
+  );
+
+  assertSafeUrl(cdnBaseUrl, "DELEGATION_DOCS_CDN_BASE_URL");
+
+  return await verifyPublishedFiles(fileReceipts, cdnBaseUrl);
+}
+
+async function readManifest() {
+  const manifestPath = path.join(BUNDLE_DIR, "manifest.json");
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+
+  if (!isPlainObject(manifest.articles)) {
+    throw new Error(`${manifestPath} must contain an articles object`);
+  }
+
+  return manifest;
+}
+
+async function collectFileReceipts(files) {
+  const receipts = [];
+
+  for (const filePath of files) {
+    const fileStat = await stat(filePath);
+    receipts.push({
+      path: normalizeBundleRelativePath(filePath),
+      bytes: fileStat.size,
+      sha256: await sha256File(filePath),
+    });
+  }
+
+  return receipts;
+}
+
+async function writeReceipt(receipt) {
+  await mkdir(RECEIPT_DIR, { recursive: true });
+  await writeFile(RECEIPT_PATH, `${JSON.stringify(receipt, null, 2)}\n`);
+}
+
+async function main() {
+  assertInsideRepo(BUNDLE_DIR);
+  await buildBundle();
+
+  const files = await listFiles(BUNDLE_DIR);
+  const manifest = await readManifest();
+  const fileReceipts = await collectFileReceipts(files);
+
+  if (dryRun) {
+    const receipt = {
+      dryRun: true,
+      version: VERSION,
+      bundleDir: BUNDLE_DIR,
+      files: fileReceipts,
+      nextStep:
+        "Run without --dry-run with DELEGATION_DOCS_IPFS_API_ENDPOINT set to publish to the internal IPFS node.",
+    };
+    await writeReceipt(receipt);
+    console.log(`dry-run receipt=${RECEIPT_PATH}`);
+    console.log(`files=${files.length}`);
+    return;
+  }
+
+  const published = await publishToIpfs(files);
+  const gatewayVerification = await verifyGateway(
+    published.rootCid,
+    fileReceipts
+  );
+  const cdnSync = await syncCdn(published.rootCid);
+  const cdnVerification = await verifyCdn(published.rootCid, fileReceipts);
+  const receipt = {
+    dryRun: false,
+    version: VERSION,
+    rootCid: published.rootCid,
+    rootUri: `ipfs://${published.rootCid}`,
+    gatewayBaseUrl: getGatewayBaseUrl(),
+    gatewayUrl: `${getGatewayBaseUrl()}/${published.rootCid}`,
+    cdnSync,
+    generatedAt: new Date().toISOString(),
+    bundleDir: BUNDLE_DIR,
+    files: fileReceipts,
+    ipfsEntries: published.entries,
+    gatewayVerification,
+    cdnVerification,
+    manifestUpdateCommand: `DELEGATION_DOCS_IPFS_ROOT_CID=${published.rootCid} node ops/scripts/build-delegation-docs-content.mjs`,
+  };
+
+  await writeReceipt(receipt);
+  console.log(`rootCid=${published.rootCid}`);
+  console.log(`receipt=${RECEIPT_PATH}`);
+  console.log(receipt.manifestUpdateCommand);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/ops/scripts/publish-delegation-docs-content.mjs
+++ b/ops/scripts/publish-delegation-docs-content.mjs
@@ -411,7 +411,7 @@ async function main() {
   await buildBundle();
 
   const files = await listFiles(BUNDLE_DIR);
-  const manifest = await readManifest();
+  await readManifest();
   const fileReceipts = await collectFileReceipts(files);
 
   if (dryRun) {
@@ -459,7 +459,9 @@ async function main() {
   console.log(receipt.manifestUpdateCommand);
 }
 
-main().catch((error) => {
+try {
+  await main();
+} catch (error) {
   console.error(error);
   process.exit(1);
-});
+}

--- a/ops/scripts/publish-delegation-docs-content.mjs
+++ b/ops/scripts/publish-delegation-docs-content.mjs
@@ -19,6 +19,7 @@ const BUNDLE_DIR = path.join(
 const RECEIPT_DIR = path.join(REPO_ROOT, "tmp", "delegation-docs-publish");
 const RECEIPT_PATH = path.join(RECEIPT_DIR, `${VERSION}-ipfs-receipt.json`);
 const DEFAULT_GATEWAY_BASE_URL = "https://ipfs.6529.io/ipfs";
+const CID_V1_BASE32_PATTERN = /^b[a-z2-7]{20,120}$/;
 
 const args = new Set(process.argv.slice(2));
 const dryRun = args.has("--dry-run");
@@ -38,6 +39,14 @@ function trimTrailingSlashes(value) {
 
 function isPlainObject(value) {
   return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function assertCid(value, label) {
+  if (typeof value !== "string" || !CID_V1_BASE32_PATTERN.test(value)) {
+    throw new Error(`${label} is not a CIDv1 base32 value: ${String(value)}`);
+  }
+
+  return value;
 }
 
 function assertInsideRepo(targetPath) {
@@ -260,13 +269,9 @@ async function publishToIpfs(files) {
     }
   });
   const rootEntry = entries.find((entry) => entry.Name === "") ?? entries.at(-1);
-  const rootCid = rootEntry?.Hash;
+  const rootCid = assertCid(rootEntry?.Hash, "IPFS root CID");
 
-  if (!rootCid) {
-    throw new Error("IPFS add response did not include a root CID");
-  }
-
-  return { rootCid, entries };
+  return { rootCid, entryCount: entries.length };
 }
 
 function getGatewayBaseUrl() {
@@ -447,7 +452,7 @@ async function main() {
     generatedAt: new Date().toISOString(),
     bundleDir: BUNDLE_DIR,
     files: fileReceipts,
-    ipfsEntries: published.entries,
+    ipfsEntryCount: published.entryCount,
     gatewayVerification,
     cdnVerification,
     manifestUpdateCommand: `DELEGATION_DOCS_IPFS_ROOT_CID=${published.rootCid} node ops/scripts/build-delegation-docs-content.mjs`,


### PR DESCRIPTION
## Summary
- Add a controlled delegation docs publisher that uploads the reviewed versioned bundle to the internal IPFS node, pins it, verifies article hashes through the gateway, optionally mirrors to S3/CloudFront, and writes a publish receipt.
- Add a manual GitHub workflow for dry-run or real delegation docs content publishing with repository secrets/vars.
- Update delegation source-of-truth docs to describe the actual repo -> internal IPFS -> optional S3/CloudFront pipeline and the reviewed CID-manifest follow-up.

## Validation
- `node ops/scripts/publish-delegation-docs-content.mjs --dry-run --skip-build --skip-gateway-verify --skip-cdn-sync`
- `seize install:frozen`
- `node ops/scripts/publish-delegation-docs-content.mjs --dry-run --skip-gateway-verify --skip-cdn-sync`
- `seize run lint:single -- ops/scripts/publish-delegation-docs-content.mjs`
- `codex-diff-check -- .github/workflows/publish-delegation-docs-content.yml ops/scripts/publish-delegation-docs-content.mjs ops/docs/delegation/content-delivery-ipfs-pilot.md ops/docs/delegation/source-of-truth-spec.md`

## Notes
- The script does not expose writable IPFS APIs to browser runtime code.
- Real publishing requires configuring `DELEGATION_DOCS_IPFS_API_ENDPOINT` and optional auth secrets for the internal IPFS node.
- The receipt root CID should be committed back into the delegation manifest in a separate reviewed PR after a real publish.