### PR TITLE
[codex] Add profile native CMS roadmap

### DIFF
--- a/ops/workstreams/profile-native-cms-roadmap/README.md
+++ b/ops/workstreams/profile-native-cms-roadmap/README.md
@@ -1,0 +1,85 @@
+# Profile Native CMS Roadmap
+
+## Charter
+
+Build a profile-native CMS that lets any 6529 profile publish a beautiful,
+crypto-native website at `/{handle}/index.html`, while keeping the normal
+profile page at `/{handle}` intact.
+
+The CMS must launch before full decentralization, but it must not create a
+future migration trap. Published sites should be portable, content addressed,
+signed by profile authority, mirrorable outside 6529.io, and renderable by
+alternative web, desktop, mobile, and Electron clients.
+
+## Core Idea
+
+6529.io should stop treating Museum, Capital, About, Education, Blog, News, and
+similar content families as privileged app sections. Those should become
+examples of profile-owned websites built with the same CMS available to every
+profile.
+
+Examples:
+
+- `/punk6529` remains the normal profile page.
+- `/punk6529/index.html` is punk6529's chosen profile website.
+- The profile page links to `/punk6529/index.html` when a primary CMS site is
+  published.
+- `6529museum`, `6529capital`, and other institutional profiles can publish
+  their own sites through the same system.
+
+## Planning Docs
+
+- [Product And Technical Roadmap](product-technical-roadmap.md)
+- [Agentic Storm Execution Plan](agentic-storm-execution-plan.md)
+- [Art And NFT Display Best Practices](art-nft-display-best-practices.md)
+- [Phase 0 Decision Record](phase-0/decision-record.md)
+- [Phase 0 Storm Lanes](phase-0/storm-lanes.md)
+- [Phase 0 Test Matrix](phase-0/test-matrix.md)
+- [Phase 0 PR Wave Plan](phase-0/pr-wave-plan.md)
+- [Phase 1 Protocol Foundation](phase-1/README.md)
+- [Phase 1 Schema Index](phase-1/schema-index.md)
+- [Phase 1 Fixture Corpus](phase-1/fixtures/README.md)
+- [Phase 1 Validation Plan](phase-1/validation-plan.md)
+- [Active Context](active-context.md)
+- [Run Log](run-log.md)
+
+## Initial Build Mode
+
+This workstream should proceed as a sequence of reviewable FE and BE PRs:
+
+1. Decide the V1 storage, signing, hashing, pointer, route-conflict, and media
+   limit details.
+2. Stabilize package, pointer, renderer, and publish foundations.
+3. Ship primary profile CMS sites with decentralized storage receipts.
+4. Expand the builder from wallet gallery generation into a true site builder.
+5. Add crypto-native page types: NFT, collection, transaction, exhibition room,
+   and knowledge packet pages.
+6. Harden for decentralization: open schemas, standalone renderer, Electron
+   support, third-party clients, and mirrorable registry/index data.
+
+## V1 Cutline
+
+V1 should prove the whole shape without trying to become a generic website
+builder:
+
+- Primary profile website at `/{handle}/index.html`.
+- Profile page button to the primary website.
+- Simple guided builder.
+- Wallet gallery generator.
+- AI-agent affordances such as schemas, source packets, MCP tools, `SKILL.md`,
+  validation, and patch import so users can bring their own AI.
+- Home, collection, and NFT pages.
+- Art/NFT display primitives: art assets, display variants, NFT media profiles,
+  posters, provenance panels, lightbox, optional deep zoom manifests, simple 3D
+  rooms, and basic GLB/glTF object viewing.
+- Signed immutable package.
+- IPFS and/or Arweave storage receipt.
+- 6529 CDN acceleration as optional convenience.
+- Package export and provenance panel.
+- Astro/Starlight-inspired native ideas: typed content collections, source
+  loaders, static-first interactive islands, frontmatter-style page metadata,
+  generated navigation, static search, and i18n-ready fields.
+- Jekyll/Hugo/Eleventy/Docusaurus/VitePress/MkDocs/Gatsby/Zola-inspired native
+  ideas: scoped metadata defaults, archetypes, taxonomies, safe block macros,
+  data cascade rules, pagination, permalinks and aliases, site/build manifests,
+  Markdown import/export, and standalone local tooling direction.

--- a/ops/workstreams/profile-native-cms-roadmap/active-context.md
+++ b/ops/workstreams/profile-native-cms-roadmap/active-context.md
@@ -1,0 +1,79 @@
+# Active Context
+
+Last updated: 2026-06-17.
+
+## Current State
+
+Phase 0 and Phase 1 are now delivered as docs/protocol artifacts in this repo.
+They are ready to seed implementation PRs, but they are not executable product
+code yet.
+
+Available now:
+
+- Phase 0 decision record for URL, storage, signing, hashing, pointer, route,
+  analytics, media, art display, AI-agent, and feature-flag choices.
+- Phase 0 storm lane map, test matrix, and PR wave plan.
+- Phase 1 versioned CMS package and payload JSON schema.
+- Phase 1 agent patch and validation-result JSON schemas.
+- Phase 1 valid and invalid fixture corpus.
+- Phase 1 hash/canonicalization vector plan.
+- Page types for pages, posts, galleries, collections, NFT/card details, and
+  room-style pages.
+- Blocks for headings, rich text, images, galleries, quotes, callouts, button
+  links, NFT references, collection references, transaction references, and
+  generated wallet gallery summaries.
+- Theme and share metadata fields.
+- Provenance, package hash, payload hash, storage location, and signature
+  envelope concepts.
+- A dedicated art/NFT display research spec now exists at
+  `art-nft-display-best-practices.md`.
+- A phase-based agentic storm execution plan now exists at
+  `agentic-storm-execution-plan.md`.
+
+Important limits:
+
+- No runtime CMS route, renderer, builder, publish endpoint, storage adapter, or
+  pointer implementation has been landed by this Phase 0/1 pass.
+- The broader schema is ahead of any authoring experience.
+- Real IPFS and Arweave upload adapters are still needed.
+- Real wallet signature verification is still needed.
+- Live NFT indexing, full collection pages, full NFT pages, and 3D rooms are
+  not implemented yet.
+- There is no general WYSIWYG/block editor yet.
+
+## Product Decisions Already Made
+
+- The normal profile page remains `/{handle}`.
+- The CMS website lives at `/{handle}/index.html`.
+- The profile page should show a clear button/link to the CMS site when one is
+  published.
+- CMS capability should be available to all profiles, not privileged app route
+  families.
+- Do not build a verified/official content lane into the protocol. Authority
+  comes from profile control, signatures, reputation, nIC, and user trust.
+- Decentralized storage should be part of the first real publish path, not a
+  later migration.
+- AWS/CloudFront/S3 may accelerate delivery, but the base artifact should be
+  content addressed and independently mirrorable.
+
+## Next Implementation Slice
+
+The highest leverage next slice is Wave 0 implementation from
+`phase-0/pr-wave-plan.md`:
+
+1. Move or mirror the Phase 1 schemas into executable protocol code under
+   `lib/profile-cms/protocol/v1/` or a shared 6529mono package.
+2. Implement RFC 8785 canonical JSON and SHA-256 vectors.
+3. Add a real schema and semantic validator against the Phase 1 fixtures.
+4. Add FE and BE CI checks that parse and validate the same fixture corpus.
+5. Only then begin route/render/publish/builder/gallery parallel waves.
+
+## Decisions To Make Before Coding More
+
+- Human signoff on the Phase 0 decision record.
+- Whether public launch should require both IPFS and Arweave receipts instead
+  of one required plus one preferred.
+- Exact EIP-712 typed-data domain and user-facing signing copy.
+- Whether Phase 1 executable schema work starts in this FE repo or immediately
+  moves into a shared 6529mono package.
+- Exact first institutional migration pilot.

--- a/ops/workstreams/profile-native-cms-roadmap/agentic-storm-execution-plan.md
+++ b/ops/workstreams/profile-native-cms-roadmap/agentic-storm-execution-plan.md
@@ -1,0 +1,977 @@
+# Profile Native CMS Agentic Storm Execution Plan
+
+Last updated: 2026-06-17.
+
+## Purpose
+
+Organize the profile-native CMS roadmap into logical phases that many agents can
+execute aggressively in parallel.
+
+This is the storm map. The deeper product detail lives in:
+
+- `product-technical-roadmap.md`
+- `art-nft-display-best-practices.md`
+- `active-context.md`
+- `run-log.md`
+
+## North Star
+
+Ship a profile-native CMS where any 6529 profile can publish a signed,
+content-addressed, decentralized website at `/{handle}/index.html`, while the
+normal profile remains at `/{handle}`.
+
+The first public version should prove the whole architecture:
+
+- Profile website route.
+- Profile page website button.
+- Signed immutable package.
+- IPFS and/or Arweave storage receipt.
+- 6529 CDN acceleration as convenience only.
+- Simple guided builder.
+- Wallet gallery generator.
+- Home, collection, and NFT pages.
+- Strong 2D art/NFT display.
+- Basic 3D room/object display primitives.
+- Package export and provenance.
+- AI-agent affordances: schemas, source packets, MCP, `SKILL.md`, validation,
+  and patch review.
+
+## Storm Rules
+
+### Rule 1: Package Contract First
+
+No large implementation lane should invent its own package shape.
+
+Before feature PRs fan out, lock:
+
+- Schema names.
+- Canonical JSON/hash rules.
+- Package fixture corpus.
+- Route manifest rules.
+- Storage receipt rules.
+- Signature envelope rules.
+- Pointer event rules.
+- Art/NFT media entity names.
+
+### Rule 2: Small PRs, Shared Fixtures
+
+Agents should work in small PRs that compile against shared fixtures.
+
+Required shared fixtures:
+
+- Minimal profile homepage package.
+- Wallet gallery package.
+- NFT detail package.
+- Collection page package.
+- Art/media package with image/video/model/poster variants.
+- 3D room package.
+- Invalid package corpus.
+- Legacy/migration package for Museum/Capital-style content.
+
+### Rule 3: Parallel Lanes, Explicit Owners
+
+Each lane owns paths and APIs. Cross-lane edits require a comment in the PR
+description explaining why.
+
+### Rule 4: Feature Flags Until The Path Is Whole
+
+Use feature flags or hidden routes until:
+
+- Package validates.
+- Route renders.
+- Publish signs.
+- Storage receipt exists.
+- Profile link works.
+- Browser checks pass.
+
+### Rule 5: Decentralization Is A Gate, Not A Slogan
+
+For launch scope, every published package must be:
+
+- Downloadable.
+- Hashable.
+- Signed.
+- Validatable.
+- Stored on decentralized storage or explicitly blocked from public launch.
+- Renderable from package data without live indexer access.
+
+### Rule 6: Agents Do Not Own Final Publish Authority
+
+Agents can create drafts, patches, packages, fixtures, and PRs.
+
+Human/profile authority controls:
+
+- Package signing.
+- Primary pointer publish.
+- Institutional profile ownership.
+- Production launch.
+
+## Phase Overview
+
+### Phase 0: Command Center And Decision Lock
+
+Goal:
+
+Prepare the storm so agents can move fast without creating incompatible
+architecture.
+
+Outputs:
+
+- Final V1 decision record.
+- Path ownership map.
+- PR labels.
+- Fixture list.
+- Shared schema package plan.
+- FE/BE branch plan.
+- Test matrix.
+
+Must decide:
+
+- IPFS only, Arweave only, or one required plus one recommended.
+- EIP-712 vs EIP-191.
+- Canonical JSON library/rules.
+- Pointer concurrency model.
+- Route conflict policy.
+- Media/package size limits.
+- First custom 6529 collections.
+- V1 AI-agent affordance list.
+
+Parallel agents:
+
+- `storm-lead`: owns decision record and phase gates.
+- `schema-captain`: owns package contract.
+- `repo-coordinator`: maps FE/BE paths and PR order.
+- `qa-captain`: owns test matrix.
+
+Exit criteria:
+
+- `agentic-storm-execution-plan.md` is accepted.
+- Decision record exists.
+- No open V1 blocker decisions remain for Phase 1.
+
+### Phase 1: Protocol And Fixture Foundation
+
+Goal:
+
+Create the stable contract every lane can build against.
+
+Scope:
+
+- CMS package schema.
+- Site manifest.
+- Typed content collections.
+- Page metadata/frontmatter.
+- Metadata defaults.
+- Data cascade.
+- Source loader output.
+- Navigation.
+- Taxonomies.
+- Archetypes.
+- Safe block macros.
+- Pagination.
+- Permalinks and aliases.
+- Static search manifest.
+- Locale/i18n fields.
+- Art asset.
+- Display variant.
+- NFT media profile.
+- Deep zoom manifest.
+- Exhibition room.
+- Artwork placement.
+- Interactive policy.
+- Storage receipts.
+- Signature envelope.
+- Pointer event.
+- Agent patch.
+- Static build manifest.
+- Fixture corpus.
+- Validator baseline.
+
+Primary repos:
+
+- FE for shared TS schemas/renderer fixtures if current architecture keeps them
+  there.
+- BE for validation/publish API schemas.
+- 6529mono later if the team moves shared protocol packages there.
+
+Parallel lanes:
+
+- `schema-core`: package, payload, site manifest, hash fixtures.
+- `schema-content`: pages, blocks, metadata, defaults, cascade.
+- `schema-media`: art assets, variants, NFT media profile, deep zoom.
+- `schema-3d`: room, placement, interactive policy.
+- `schema-agent`: source packets, agent patches, validation errors.
+- `fixture-agent`: valid and invalid package corpus.
+
+Exit criteria:
+
+- Fixture packages validate.
+- Invalid corpus fails for expected reasons.
+- Hash test vectors are deterministic.
+- FE and BE use the same fixtures.
+
+### Phase 2: Native Renderer, Routes, And Static Export
+
+Goal:
+
+Render package data as real profile websites before building a fancy editor.
+
+Scope:
+
+- `/{handle}/index.html` route.
+- CMS subpage routes.
+- Profile page website button.
+- Package fetch/cache layer.
+- Safe renderer shell.
+- 2D grid renderer.
+- NFT detail renderer.
+- Collection page renderer.
+- Page metadata/OpenGraph renderer.
+- Navigation renderer.
+- Taxonomy/term page renderer.
+- Pagination route renderer.
+- Static search manifest support.
+- Provenance panel.
+- Plain static HTML export.
+- Error states.
+
+Parallel lanes:
+
+- `fe-route`: route resolution, handle/profile lookup, profile button.
+- `fe-render-core`: page/block renderer, metadata, navigation.
+- `fe-render-art`: grids, NFT detail, lightbox, posters, provenance.
+- `fe-static-export`: static output directory, route list, build manifest.
+- `fe-error-states`: invalid package, missing package, not accelerated,
+  storage unavailable.
+
+Dependencies:
+
+- Phase 1 fixtures.
+
+Exit criteria:
+
+- Fixture packages render locally.
+- `/{handle}/index.html` works behind flag.
+- Static export works from fixture package.
+- Browser screenshots pass desktop and mobile for home, collection, NFT detail.
+- Metadata/OpenGraph tests pass.
+
+### Phase 3: Publish, Storage, Signing, And Pointer Ledger
+
+Goal:
+
+Make publishing create durable artifacts, not database-only content.
+
+Scope:
+
+- Draft storage.
+- Package validation endpoint.
+- Publish candidate creation.
+- Wallet/profile signing flow.
+- Signature verification.
+- IPFS upload/pin adapter.
+- Arweave upload adapter.
+- Storage receipt verification.
+- Package records.
+- Profile primary pointer.
+- Pointer event log.
+- Rollback.
+- Package export.
+- Pointer registry snapshot.
+
+Parallel lanes:
+
+- `be-drafts`: draft CRUD and validation states.
+- `be-package`: package records, fetch, validation endpoint.
+- `be-signing`: auth, signer authorization, signature verification.
+- `be-storage-ipfs`: upload/pin/verify.
+- `be-storage-arweave`: upload/verify.
+- `be-pointer`: primary pointer, pointer events, rollback.
+- `fe-publish`: sign/publish UX, progress states, errors.
+
+Dependencies:
+
+- Phase 1 package contract.
+- Phase 2 route can render packages.
+
+Exit criteria:
+
+- User can publish a signed fixture-derived site.
+- Package has decentralized storage receipt.
+- Pointer resolves to package.
+- Rollback works.
+- Package export works.
+- Unauthorized publish tests pass.
+
+### Phase 4: Builder MVP
+
+Goal:
+
+Let a profile owner create and edit a simple useful site without touching JSON.
+
+Scope:
+
+- Builder dashboard.
+- Site type picker.
+- Draft autosave.
+- Site tree.
+- Page editor.
+- Block editor.
+- Metadata editor.
+- Navigation controls.
+- Theme controls.
+- Media library.
+- Validation checklist.
+- Preview desktop/mobile/social.
+- Publish CTA.
+- Version history.
+
+Parallel lanes:
+
+- `fe-builder-shell`: dashboard, route, profile auth state.
+- `fe-builder-pages`: site tree, page CRUD, page settings.
+- `fe-builder-blocks`: block add/edit/reorder.
+- `fe-builder-media`: media library, asset upload/select, posters.
+- `fe-builder-validation`: warnings/errors with deep links.
+- `fe-builder-publish`: preview, publish, version history.
+
+Dependencies:
+
+- Phase 1 schemas.
+- Phase 2 renderer.
+- Phase 3 draft/publish APIs.
+
+Exit criteria:
+
+- User can create, preview, validate, publish, and roll back a basic profile
+  homepage.
+- Builder uses same renderer as published route.
+- Validation blocks unsafe publish.
+- Mobile and desktop builder critical flows are usable.
+
+### Phase 5: Wallet Gallery Generator
+
+Goal:
+
+Ship the first killer feature: paste wallets, get a beautiful gallery site.
+
+Scope:
+
+- Wallet/ENS input.
+- Wallet source loader.
+- NFT ownership import.
+- Collection grouping.
+- Spam/unwanted asset hiding.
+- Featured works/collections.
+- Snapshot freeze.
+- Generated home.
+- Generated collections index.
+- Generated collection pages.
+- Generated NFT detail pages.
+- Generated media profiles and display variants.
+- Generated taxonomies/tags where useful.
+- Paginated all-NFT and collection routes.
+- Social images.
+
+Parallel lanes:
+
+- `be-wallet-loader`: ENS/address resolution, holdings snapshot.
+- `be-nft-normalizer`: metadata normalization, media extraction, provenance.
+- `be-gallery-generator`: package page generation from snapshot.
+- `fe-gallery-flow`: guided wallet import and review.
+- `fe-gallery-pages`: generated gallery previews and hide/feature controls.
+- `media-variants`: thumbnails, posters, detail variants, social images.
+
+Dependencies:
+
+- Phase 1 media schemas.
+- Phase 2 renderers.
+- Phase 3 package/publish.
+- Phase 4 builder shell.
+
+Exit criteria:
+
+- Multi-wallet gallery can be generated, edited, previewed, and published.
+- Home, collection, NFT pages render from frozen snapshot.
+- Social previews exist.
+- Spam/unwanted NFTs can be hidden before publish.
+
+### Phase 6: Art/NFT Display Excellence
+
+Goal:
+
+Make 6529 CMS art display materially better than marketplace pages.
+
+Scope:
+
+- Art-first collection grids.
+- Detail page polish.
+- Lightbox/focused inspection.
+- Original vs derivative provenance.
+- Poster/fallback coverage.
+- Optional deep zoom manifest support.
+- Video/audio/interactive media policies.
+- Rights/license fields.
+- C2PA/content credential display where present.
+- Accessibility checks for alt/captions/transcripts.
+
+Parallel lanes:
+
+- `fe-art-grid`: editorial/dense/contact-sheet/grid modes.
+- `fe-nft-detail`: layout, traits, provenance, related works.
+- `fe-lightbox`: keyboard, zoom, fullscreen, metadata toggle.
+- `media-pipeline`: derivatives, posters, dimensions, hashes.
+- `a11y-media`: alt text, captions, transcripts, reduced motion.
+- `provenance-ui`: original media, metadata URI, storage, package details.
+
+Dependencies:
+
+- Phase 2 renderer.
+- Phase 5 NFT/media generation.
+
+Exit criteria:
+
+- Top fixture NFTs look excellent in 2D.
+- Original media and derivatives are clearly separated.
+- Accessibility/media validations run.
+- Visual screenshots pass desktop and mobile.
+
+### Phase 7: 3D Rooms And Object Viewer
+
+Goal:
+
+Add simple, reliable 3D display without turning V1 into a game engine.
+
+Scope:
+
+- Basic GLB/glTF object viewer.
+- Simple wall-room renderer.
+- Room presets.
+- Artwork placements.
+- Faithful 2D art surface mode.
+- Gallery ambient mode.
+- Poster/static preview.
+- Deferred loading.
+- Mobile fallback.
+- Click works to NFT detail.
+- Canvas nonblank tests.
+- Performance budgets.
+
+Parallel lanes:
+
+- `fe-object-viewer`: GLB/glTF viewer, camera controls, poster, error state.
+- `fe-room-renderer`: room scene, wall frames, placement, click targets.
+- `fe-room-builder`: choose style, place works, preview.
+- `media-3d`: model metadata, compression flags, bounds, camera hints.
+- `qa-3d`: Playwright screenshots, canvas pixel checks, mobile fallback.
+
+Dependencies:
+
+- Phase 1 3D schemas.
+- Phase 2 renderer.
+- Phase 5 media profiles.
+
+Exit criteria:
+
+- Simple generated room renders nonblank on desktop.
+- Mobile fallback works.
+- Every room work links to detail page.
+- 2D faithful detail page remains canonical inspection path.
+
+### Phase 8: AI-Agent Affordances
+
+Goal:
+
+Let users bring their own AI to build, inspect, repair, and improve CMS sites.
+
+Scope:
+
+- JSON schema bundle export.
+- Source packet export.
+- MCP read tools.
+- MCP validate/preview tools.
+- Agent patch schema.
+- Agent patch validation.
+- Agent patch import/review UI.
+- `SKILL.md` files.
+- Structured validation errors.
+- Prompt-injection-safe source packets.
+
+Parallel lanes:
+
+- `agent-schema`: schema bundle and examples.
+- `agent-source`: source packets for profile, wallet, collection, NFT,
+  transaction, draft, package.
+- `agent-mcp`: MCP tools.
+- `agent-patch`: patch schema, validation, review/apply flow.
+- `agent-skills`: `SKILL.md` docs for external agents.
+
+Dependencies:
+
+- Phase 1 schemas.
+- Phase 3 validation APIs.
+- Phase 4 draft APIs.
+
+Exit criteria:
+
+- External/user agent can read a draft/package, propose a patch, validate it,
+  and hand it back for user review.
+- Publishing still requires explicit user/profile authority.
+- Agent output cannot bypass validation or renderer sanitization.
+
+### Phase 9: Institutional Migration Pilot
+
+Goal:
+
+Prove that hardcoded content families can become profile-owned CMS sites.
+
+Pilot candidates:
+
+- `6529museum`.
+- `6529capital`.
+- Education/docs section.
+
+Scope:
+
+- Inventory old routes.
+- Map route to owning profile.
+- Import content into CMS package.
+- Preserve SEO/social metadata.
+- Publish package.
+- Add redirects/canonicals/links.
+- Retire bespoke content implementation where safe.
+
+Parallel lanes:
+
+- `migration-inventory`: routes/assets/metadata inventory.
+- `migration-content`: content import and page structure.
+- `migration-seo`: redirects, canonicals, social previews.
+- `migration-profile`: profile ownership/publish authority.
+- `migration-qa`: link checks and visual regression.
+
+Dependencies:
+
+- Phase 2 rendering.
+- Phase 3 publishing.
+- Phase 4 builder or import tooling.
+
+Exit criteria:
+
+- One institutional section runs as profile CMS.
+- Old important URLs have migration behavior.
+- No new privileged content route family is introduced.
+
+### Phase 10: Decentralization Hardening
+
+Goal:
+
+Reduce dependence on 6529-operated services after V1 proves the path.
+
+Scope:
+
+- Standalone validator.
+- Standalone renderer package.
+- Static exporter CLI.
+- Package inspector/diff CLI.
+- Mirror guide.
+- Pointer registry snapshot export.
+- Electron local cache integration.
+- Gateway fallback.
+- Package corpus compatibility tests.
+- Third-party client docs.
+
+Parallel lanes:
+
+- `standalone-validator`.
+- `standalone-renderer`.
+- `static-export-cli`.
+- `mirror-operator-docs`.
+- `electron-cache`.
+- `registry-snapshot`.
+
+Dependencies:
+
+- Stable package schema.
+- Real published packages.
+
+Exit criteria:
+
+- A package can be validated outside 6529.io.
+- A site can be rendered from IPFS/Arweave without 6529 API.
+- A mirror can serve profile sites from package/pointer data.
+- Electron can browse cached/pinned sites.
+
+## Critical Path
+
+The critical path is:
+
+1. Phase 0 decisions.
+2. Phase 1 package/schema/fixtures.
+3. Phase 2 renderer/route.
+4. Phase 3 publish/storage/sign/pointer.
+5. Phase 4 builder shell.
+6. Phase 5 wallet gallery generator.
+
+Everything else should support or branch from that path.
+
+Do not let 3D rooms, AI-agent affordances, or institutional migration block the
+first end-to-end profile CMS publish unless they expose a foundational schema
+problem.
+
+## Parallelization Map
+
+Can start immediately after Phase 0:
+
+- Schema lanes.
+- Fixture corpus.
+- Art/NFT display fixture design.
+- AI-agent schema/skill draft docs.
+- Institutional route inventory.
+- QA test matrix.
+
+Can start after Phase 1 fixtures:
+
+- Renderer lanes.
+- Static export.
+- Backend package records.
+- Draft APIs.
+- Storage adapters.
+- Builder shell.
+- Wallet loader normalization design.
+
+Can start after Phase 2 renderer:
+
+- Art display polish.
+- Lightbox.
+- NFT detail page.
+- 3D renderer prototype.
+- Static export validation.
+
+Can start after Phase 3 publish APIs:
+
+- Publish UX.
+- Version history.
+- Rollback.
+- Package provenance panel.
+- Institutional migration publish path.
+
+Can start after Phase 4 builder shell:
+
+- Wallet gallery guided flow.
+- Agent patch import UI.
+- Media library.
+- Page/block editor.
+
+## Suggested Agent Roster
+
+### Storm Lead
+
+Owns:
+
+- Phase gates.
+- Cross-repo sequencing.
+- Decision log.
+- PR labels.
+- Merge readiness.
+
+### Schema Captain
+
+Owns:
+
+- Package contract.
+- Fixture corpus.
+- Hash test vectors.
+- Schema review.
+
+### Frontend Route/Renderer Agent
+
+Owns:
+
+- CMS route.
+- Profile button.
+- Renderer shell.
+- Metadata/OpenGraph.
+
+### Frontend Builder Agent
+
+Owns:
+
+- Dashboard.
+- Site tree.
+- Page/block editor.
+- Validation UI.
+
+### Art Display Agent
+
+Owns:
+
+- Grids.
+- NFT detail.
+- Lightbox.
+- Posters.
+- Provenance UI.
+
+### 3D Agent
+
+Owns:
+
+- Object viewer.
+- Room renderer.
+- Canvas tests.
+- Fallbacks.
+
+### Backend Publish Agent
+
+Owns:
+
+- Package records.
+- Validation.
+- Drafts.
+- Pointer events.
+- Rollback.
+
+### Storage Agent
+
+Owns:
+
+- IPFS.
+- Arweave.
+- Receipt verification.
+- Retry/status.
+
+### Wallet/Indexer Agent
+
+Owns:
+
+- Wallet snapshot.
+- NFT metadata normalization.
+- Collection grouping.
+- Spam/hide model.
+
+### AI-Agent Affordance Agent
+
+Owns:
+
+- MCP tools.
+- Source packets.
+- Agent patches.
+- `SKILL.md`.
+- Schema export.
+
+### QA/Security Agent
+
+Owns:
+
+- Test matrix.
+- Browser screenshots.
+- Security checklist.
+- Accessibility/media checks.
+- CI/bot feedback loop.
+
+### Migration Agent
+
+Owns:
+
+- Museum/Capital/About route inventory.
+- Import/migration plan.
+- SEO/social preservation.
+
+## PR Wave Plan
+
+### Wave 0: Decisions And Fixtures
+
+PRs:
+
+- Decision record.
+- Schema skeleton.
+- Fixture corpus.
+- Hash/canonicalization tests.
+
+Gate:
+
+- FE/BE agree on fixtures.
+
+### Wave 1: Route And Render
+
+PRs:
+
+- FE CMS route/profile button.
+- FE renderer core.
+- FE art/NFT primitive renderer.
+- FE static export fixture.
+- BE package fetch placeholder if needed.
+
+Gate:
+
+- Fixture package renders at `/{handle}/index.html`.
+
+### Wave 2: Publish Spine
+
+PRs:
+
+- BE package records.
+- BE draft/validation.
+- BE signing/authorization.
+- BE pointer events.
+- BE storage adapters.
+- FE publish/sign/provenance UI.
+
+Gate:
+
+- Signed package publishes and resolves through pointer.
+
+### Wave 3: Builder MVP
+
+PRs:
+
+- FE builder shell.
+- FE page/block editor.
+- FE media library.
+- FE validation checklist.
+- FE version history.
+
+Gate:
+
+- User can build and publish simple site.
+
+### Wave 4: Gallery MVP
+
+PRs:
+
+- Wallet loader.
+- NFT metadata normalization.
+- Gallery generator.
+- Generated collection/NFT pages.
+- Media variants/social images.
+- Hide/feature controls.
+
+Gate:
+
+- User can paste wallets and publish gallery site.
+
+### Wave 5: Experience Polish
+
+PRs:
+
+- Lightbox.
+- Deep zoom manifest support.
+- 3D room MVP.
+- Object viewer.
+- Static search.
+- Taxonomy pages.
+- Mobile polish.
+
+Gate:
+
+- Gallery and NFT display feel launch-quality.
+
+### Wave 6: AI-Agent And Migration
+
+PRs:
+
+- MCP read/validate/preview tools.
+- Source packet export.
+- Agent patch validation/import.
+- `SKILL.md` bundle.
+- Institutional migration pilot.
+
+Gate:
+
+- External/user agent can propose valid site changes.
+- One institutional site can run as profile CMS.
+
+### Wave 7: Decentralization Hardening
+
+PRs:
+
+- Standalone validator.
+- Standalone/static renderer direction.
+- Static export CLI.
+- Pointer registry snapshot.
+- Mirror docs.
+- Electron cache path.
+
+Gate:
+
+- Package can be validated and rendered without 6529.io.
+
+## Launch Readiness Gate
+
+Public launch requires:
+
+- Profile site route works.
+- Profile page button works.
+- Builder can create/publish.
+- Wallet gallery generator works with live data.
+- Home, collection, NFT pages render.
+- Package is signed.
+- Package has decentralized storage receipt.
+- Package can be exported.
+- Provenance panel works.
+- Social previews work.
+- Mobile screenshots pass.
+- Security review covers untrusted content.
+- Accessibility/media checks pass.
+- Rollback works.
+- Agent docs do not imply 6529 pays for inference.
+- Known centralized dependencies are listed with escape hatches.
+
+## Storm Anti-Patterns
+
+Avoid:
+
+- Huge all-in-one PRs.
+- Building 3D before package/media schemas settle.
+- Building builder UI against fake local-only state.
+- Treating S3/database content as canonical.
+- Adding Astro/Starlight/Jekyll/etc exporters in V1.
+- Letting agents invent route patterns.
+- Letting AI-agent patch import bypass user review.
+- Rendering arbitrary HTML/JS in the main app context.
+- Cropping art detail pages like marketplace thumbnails.
+- Adding "official/verified" protocol lanes.
+
+## First 72 Hours Of A Real Storm
+
+Hour 0-6:
+
+- Storm lead locks V1 decision record.
+- Schema captain drafts schema file list and fixture corpus.
+- QA captain drafts test matrix.
+- Repo coordinator assigns lanes and PR labels.
+
+Hour 6-24:
+
+- Schema lanes implement initial schemas and fixtures.
+- FE route agent stubs route behind flag against fixture.
+- BE package agent stubs package fetch/validate against fixture.
+- Art display agent creates media fixture package.
+- AI-agent agent drafts schema export and first `SKILL.md`.
+
+Hour 24-48:
+
+- Renderer renders fixture home/collection/NFT pages.
+- Static export renders fixture package.
+- BE package validation and pointer skeleton land.
+- Storage agents prototype IPFS/Arweave receipt adapters.
+- Builder shell starts against drafts/fixtures.
+
+Hour 48-72:
+
+- First end-to-end fixture site renders at `/{handle}/index.html`.
+- First signed/pointer publish path is mocked or live in dev.
+- First browser screenshots collected.
+- First bot review loop starts.
+- Storm lead reviews dependency graph and splits next PR wave.
+
+## Current Recommendation
+
+Start the storm with Phase 0 and Phase 1 only.
+
+Reason:
+
+The roadmap is now broad enough that implementation can move very fast, but only
+if package schemas, fixtures, route rules, hash rules, and publish invariants are
+stable first. Once those are locked, many agents can work in parallel without
+accidental architecture drift.
+

--- a/ops/workstreams/profile-native-cms-roadmap/art-nft-display-best-practices.md
+++ b/ops/workstreams/profile-native-cms-roadmap/art-nft-display-best-practices.md
@@ -1,0 +1,844 @@
+# Art And NFT Display Best Practices
+
+Last updated: 2026-06-17.
+
+## Purpose
+
+Define how the profile-native CMS should display art and NFTs in 2D and 3D.
+
+The goal is not to imitate marketplaces or block explorers. The goal is to make
+art look excellent, remain faithful to the source, load well, preserve
+provenance, work accessibly, and support decentralized storage and alternative
+clients.
+
+## Research Baseline
+
+Official sources reviewed:
+
+- IIIF Image API: `https://iiif.io/api/image/3.0/`.
+- IIIF Presentation API: `https://iiif.io/api/presentation/2.0/`.
+- ERC-721: `https://eips.ethereum.org/EIPS/eip-721`.
+- OpenSea metadata standards:
+  `https://docs.opensea.io/docs/metadata-standards`.
+- Khronos glTF: `https://www.khronos.org/gltf/`.
+- Khronos glTF PBR: `https://www.khronos.org/gltf/pbr/`.
+- three.js GLTFLoader:
+  `https://threejs.org/docs/pages/GLTFLoader.html`.
+- three.js DRACOLoader:
+  `https://threejs.org/docs/pages/DRACOLoader.html`.
+- three.js KTX2Loader:
+  `https://threejs.org/docs/pages/KTX2Loader.html`.
+- three.js LoadingManager:
+  `https://threejs.org/docs/pages/LoadingManager.html`.
+- model-viewer:
+  `https://web.dev/articles/model-viewer` and
+  `https://modelviewer.dev/docs/`.
+- web.dev image performance:
+  `https://web.dev/learn/performance/image-performance`.
+- web.dev browser lazy loading:
+  `https://web.dev/articles/browser-level-image-lazy-loading`.
+- WCAG 2.2: `https://www.w3.org/TR/WCAG22/`.
+- W3C alt decision tree:
+  `https://www.w3.org/WAI/tutorials/images/decision-tree/`.
+- W3C captions and transcripts:
+  `https://www.w3.org/WAI/media/av/captions/` and
+  `https://www.w3.org/WAI/media/av/transcripts/`.
+- C2PA: `https://c2pa.org/`.
+
+## Core Principles
+
+### Art First
+
+The art surface should be the first visual priority.
+
+Do:
+
+- Give the work space.
+- Preserve aspect ratio.
+- Let users inspect detail.
+- Keep metadata available but not dominant.
+- Use quiet, neutral UI around the work.
+
+Do not:
+
+- Trap artwork in tiny marketplace cards.
+- Crop detail pages.
+- Bury the media below stats.
+- Overdecorate the frame or room.
+- Make price/floor data the primary context.
+
+### Faithful By Default
+
+Display should not modify the artwork unless explicitly requested by the
+publisher or viewer.
+
+Rules:
+
+- Preserve the original aspect ratio in detail views.
+- Do not apply CSS filters, blur, saturation, or contrast changes to artwork.
+- Preserve transparent backgrounds by showing a checker, neutral field, or
+  publisher-selected background.
+- Make derivative crops/thumbnails clearly secondary to the original display.
+- Keep a link to the original asset and source metadata where possible.
+
+### Context On Demand
+
+Context is valuable, but it should not crowd the art.
+
+Use a layered model:
+
+1. Artwork.
+2. Title, artist/creator, collection.
+3. Short caption or curatorial note.
+4. Expandable provenance and chain facts.
+5. Deep technical metadata.
+
+### Provenance Always
+
+NFT display must expose where the media and facts came from.
+
+Important provenance:
+
+- Chain.
+- Contract.
+- Token id.
+- Token standard.
+- Metadata URI.
+- Original media URI.
+- IPFS/Arweave/content hash where known.
+- Snapshot block/time.
+- Owner at snapshot.
+- Collection/contract metadata.
+- Display derivative hashes.
+- Package hash.
+- Any C2PA/content credential reference if present.
+
+### Static First, Interactive When Worth It
+
+Most art pages should render useful static HTML.
+
+Interactive behavior should be added only where it improves inspection:
+
+- Deep zoom.
+- Carousel.
+- 3D room.
+- 3D object viewer.
+- Interactive HTML artwork sandbox.
+
+Every interactive display needs a static fallback.
+
+## NFT Media Taxonomy
+
+The CMS should treat NFT media as a family of related assets, not a single URL.
+
+### Source Asset
+
+The original or canonical media referenced by token metadata or collection
+knowledge.
+
+Examples:
+
+- `image`.
+- `image_data`.
+- `animation_url`.
+- `external_url`.
+- Contract-level media.
+- Artist-supplied alternate file.
+
+### Display Derivatives
+
+Generated or curated assets optimized for viewing.
+
+Examples:
+
+- Thumbnail.
+- Grid tile.
+- Detail image.
+- Fullscreen image.
+- Deep zoom tiles.
+- Video MP4/WebM transcode.
+- Audio waveform/poster.
+- 3D poster.
+- Social image.
+
+Derivative rules:
+
+- Derivatives must never replace the original as provenance.
+- Derivatives should be content-addressed when possible.
+- Derivatives should record generation settings and source hash.
+- The user should be able to open the original where safe.
+
+### Posters
+
+Every non-instant media type should have a poster:
+
+- Video.
+- Audio.
+- 3D model.
+- Interactive HTML.
+- Heavy generative art.
+- 3D room.
+
+Poster requirements:
+
+- Content-addressed if possible.
+- Aspect ratio recorded.
+- Used for social sharing when appropriate.
+- Used as static fallback.
+
+### Metadata
+
+OpenSea's metadata convention supports image, multimedia attachments, audio,
+video, 3D models, and interactive traits. ERC-721 itself defines the core NFT
+contract API and metadata extension surface.
+
+CMS implication:
+
+- Store raw metadata.
+- Store normalized metadata.
+- Store source and retrieval details.
+- Support more than one media field.
+- Show when marketplace metadata differs from direct token metadata.
+
+## 2D Display Modes
+
+### Collection Grid
+
+Use for browsing many works.
+
+Best practices:
+
+- Default to aspect-ratio-preserving tiles.
+- Offer optional uniform crop mode for dense scanning.
+- Never use cropped grid thumbnails as the detail-page display.
+- Use stable tile dimensions to avoid layout shift.
+- Lazy-load offscreen images.
+- Avoid lazy-loading the main above-the-fold image.
+- Show title/collection/creator on hover or under tile depending on density.
+- Keep floor/rarity/market data off by default or secondary.
+
+Recommended grid modes:
+
+- Editorial grid: fewer works, larger tiles, captions.
+- Dense collector grid: many works, compact labels.
+- Contact sheet: uniform rows for quick scanning.
+- Chronological wall: by mint/acquire date.
+- Collection grouped grid: sections by collection.
+
+### Detail Page
+
+Use for one work.
+
+Required:
+
+- Large media display.
+- Title.
+- Creator/artist when known.
+- Collection.
+- Chain/contract/token id.
+- Owner snapshot.
+- Source/provenance panel.
+- Share metadata.
+- Links to collection and profile/gallery context.
+
+Recommended:
+
+- Fullscreen mode.
+- Zoom/pan for high-resolution still images.
+- Download/open-original action where appropriate.
+- Related works.
+- Curatorial note.
+- Trait/attribute panel.
+- Provenance timeline.
+- Display variant selector if multiple media assets exist.
+
+### Lightbox
+
+Use for focused inspection without leaving context.
+
+Best practices:
+
+- Keyboard navigation.
+- Escape closes.
+- Arrow keys move between works.
+- Zoom controls.
+- Fullscreen action.
+- Captions and metadata toggle.
+- Do not trap focus incorrectly.
+- Preserve browser back behavior where possible.
+
+### Deep Zoom
+
+For large still images, adopt an IIIF-like tile pyramid model even if we do not
+implement full IIIF immediately.
+
+Why:
+
+- High-resolution art should be inspectable without loading huge originals.
+- Tiles let users zoom into detail.
+- Cultural heritage institutions use IIIF for high-quality attributed image
+  delivery at scale.
+
+CMS model:
+
+- Original image.
+- Tile manifest.
+- Tile levels.
+- Tile size.
+- Dimensions.
+- Format.
+- Generator version.
+- Source hash.
+
+V1:
+
+- Support optional deep zoom for very large images.
+- Generate tiles only for curated/high-value images or when user requests it.
+- Keep normal responsive image variants for standard display.
+
+### Editorial Display
+
+For essays, museum pages, and artist pages:
+
+- Let text and image alternate rhythmically.
+- Support captions and credits.
+- Support image comparisons.
+- Support side-by-side details.
+- Support pull quotes/callouts.
+- Support footnotes/source references.
+- Keep the artwork visually primary, not decoration.
+
+### Comparison Mode
+
+Useful for:
+
+- Meme Card and Rememe relationships.
+- Before/after metadata or artwork variants.
+- Multi-edition comparisons.
+- Trait comparisons.
+- Collection study pages.
+
+Best practices:
+
+- Keep synchronized zoom/pan optional.
+- Show clear labels.
+- Preserve aspect ratios.
+- Avoid overloading mobile layouts.
+
+## Image Performance
+
+Images are usually among the heaviest web resources, so art pages need a strong
+media pipeline.
+
+Required variants:
+
+- Thumbnail.
+- Grid tile.
+- Detail display.
+- Fullscreen.
+- Social image.
+- Original.
+
+Best practices:
+
+- Use responsive image sizes.
+- Set width/height or aspect-ratio to avoid layout shift.
+- Lazy-load offscreen images.
+- Do not lazy-load the LCP/hero artwork.
+- Use modern formats for derivatives where safe.
+- Keep original file accessible separately.
+- Generate blur/solid-color placeholders from the image.
+- Keep asset hashes and dimensions in the package.
+
+CMS validation should warn when:
+
+- An image lacks dimensions.
+- A grid uses only original files.
+- A page has no social image.
+- A huge original is used as a thumbnail.
+- Important media lacks a poster/fallback.
+
+## Video, Audio, Animated, And Interactive Media
+
+### Video
+
+Best practices:
+
+- Use poster image.
+- Use native controls or accessible custom controls.
+- Avoid autoplay with sound.
+- Provide captions when audio carries meaning.
+- Provide transcript or descriptive transcript where needed.
+- Offer reduced-motion or still fallback for loops.
+- Use MP4/WebM derivatives while preserving the original source reference.
+
+### Audio
+
+Best practices:
+
+- Use accessible controls.
+- Provide transcript for spoken audio.
+- Provide cover/poster image.
+- Show duration and waveform only as enhancement.
+
+### Animated GIFs
+
+Best practices:
+
+- Preserve original when it is the artwork.
+- Generate video derivative for performance when appropriate.
+- Provide pause/reduce-motion controls for long or intense animation.
+
+### Interactive HTML NFTs
+
+Best practices:
+
+- Render in sandboxed iframe or equivalent isolation.
+- Use a poster/static fallback.
+- Require click-to-activate for heavy or script-based work.
+- Restrict privileges.
+- Keep source URL and content hash where possible.
+- Do not execute arbitrary HTML inside the main app context.
+
+## 3D Display Modes
+
+### Object Viewer
+
+Use for a single 3D NFT/model.
+
+Best practices:
+
+- Prefer GLB/glTF for runtime display.
+- Use a poster before loading.
+- Lazy/defer model loading.
+- Provide camera controls.
+- Provide reset view.
+- Provide fullscreen.
+- Provide model metadata.
+- Provide 2D fallback.
+- Avoid autoplaying animation unless subtle and pausable.
+
+model-viewer is good prior art for simple object display: declarative model
+embedding, poster images, responsive behavior, camera controls, AR support, and
+visibility-aware loading.
+
+### 3D Room
+
+Use for a profile gallery, exhibition, or room-like presentation.
+
+Core UX:
+
+- Immediate poster/static preview.
+- Click/tap to enter.
+- Works arranged on walls or pedestals.
+- Click a work to open metadata/detail page.
+- Keyboard, mouse, and touch controls.
+- Exit/fullscreen controls.
+- Minimap or room list for larger exhibitions.
+- Mobile fallback.
+
+Room types:
+
+- Simple wall room.
+- Salon wall.
+- White cube.
+- Dark room.
+- Outdoor/plaza.
+- Timeline room.
+- Collection-specific themed room.
+- Card-specific immersive room.
+
+V1 should start with simple wall rooms, not a full 3D world editor.
+
+### 2D Art In 3D Rooms
+
+This is surprisingly important.
+
+If lighting and shadows alter the artwork, the result may be beautiful but not
+faithful. We need two modes:
+
+Faithful mode:
+
+- Artwork surface uses unlit or color-faithful material.
+- Room lighting affects frame/wall, not the pixels of the art.
+- Best for canonical display.
+
+Gallery mode:
+
+- Artwork can receive subtle environmental integration.
+- Frames, glass, shadows, and lighting can make the room feel real.
+- Must not be the only way to inspect the work.
+
+Rule:
+
+Every 2D work in a 3D room must link to a faithful 2D detail page.
+
+### 3D NFT Models
+
+For native 3D works:
+
+- Respect artist-provided model, animations, and materials.
+- Prefer glTF/GLB as display format.
+- Preserve source asset and provide optimized derivative if needed.
+- Do not bake the work into a generic room in a way that changes it.
+- Provide object viewer and optional room placement.
+
+### 3D Asset Pipeline
+
+Recommended runtime formats:
+
+- GLB/glTF for web 3D.
+- KTX2/Basis compressed textures where useful.
+- Draco or Meshopt geometry compression where useful.
+- USDZ only as an optional AR export path, not core package format.
+
+Use glTF because Khronos defines it for efficient transmission/loading of 3D
+scenes and models, with PBR support for realistic material rendering.
+
+Asset metadata:
+
+- Source URI.
+- Runtime URI.
+- Poster URI.
+- File size.
+- Vertex/triangle count where known.
+- Texture count and dimensions.
+- Animation list.
+- Compression extensions.
+- Bounds.
+- Recommended camera.
+- License/rights notes.
+
+Validation warnings:
+
+- Model too large.
+- Textures too large.
+- No poster.
+- No fallback.
+- No camera/bounds.
+- No compressed derivative for heavy asset.
+- Unsupported extension.
+
+### 3D Performance
+
+Best practices:
+
+- Defer loading until user intent or viewport.
+- Use poster image.
+- Use progress and error states.
+- Use LoadingManager-style progress accounting.
+- Reuse decoders.
+- Dispose resources when leaving room.
+- Cap device pixel ratio.
+- Use adaptive quality on mobile.
+- Avoid loading many models at once.
+- Use instancing for repeated frames.
+- Use compressed textures.
+- Use simple geometry for frames/walls.
+
+Suggested V1 budgets:
+
+- Simple room initial JS and scene should stay small enough to load quickly on
+  mobile.
+- 2D wall art should use display derivatives, not originals.
+- GLB object viewer should warn above a configured file-size threshold.
+- Texture dimensions should be capped or flagged.
+- If the room cannot hit performance targets, fall back to 2D.
+
+### 3D Navigation And Comfort
+
+Avoid making users fight the camera.
+
+V1 controls:
+
+- Orbit/pan for object viewer.
+- Guided hotspots or simple walk/teleport for room.
+- Keyboard alternatives.
+- Touch-friendly controls.
+- Reset view.
+- Exit room.
+
+Avoid in V1:
+
+- Forced pointer lock.
+- Fast first-person motion.
+- Complex physics.
+- Collision-heavy navigation.
+- Motion that cannot be paused.
+
+Accessibility:
+
+- Provide DOM list of works in the room.
+- Provide detail pages for every work.
+- Provide keyboard path to every work.
+- Respect reduced motion.
+- Do not rely on spatial position as the only navigation method.
+
+### 3D Visual Quality
+
+Use a restrained museum-like default:
+
+- Neutral wall/background.
+- Subtle floor.
+- Good spacing.
+- Reasonable frame thickness.
+- Soft lighting.
+- No decorative clutter.
+- No gradients/orbs/bokeh as substitute for design.
+
+Rendering:
+
+- Use correct color workflow.
+- Use PBR for room materials.
+- Use unlit/faithful option for 2D artwork.
+- Use environment maps carefully.
+- Avoid post-processing that changes artwork colors.
+- Keep labels readable and not floating over art unless requested.
+
+## NFT Detail Page Structure
+
+Recommended layout:
+
+1. Media display.
+2. Title and collection.
+3. Creator/artist/project.
+4. Short curatorial text or caption.
+5. Primary facts:
+   - Chain.
+   - Contract.
+   - Token id.
+   - Token standard.
+   - Owner snapshot.
+   - Metadata source.
+6. Provenance:
+   - Mint.
+   - Transfers.
+   - Sales if source is reliable and labeled.
+   - Package snapshot block/time.
+7. Attributes/traits.
+8. Related works.
+9. Source links:
+   - Original media.
+   - Metadata URI.
+   - Marketplace/explorer links.
+   - IPFS/Arweave links.
+10. Rights/license notes where known.
+
+Do not treat marketplace links as canonical. They are useful context, not the
+source of truth.
+
+## Gallery Builder Implications
+
+The builder should ask simple questions:
+
+- Which wallets?
+- Which collections matter most?
+- Hide spam/unwanted NFTs?
+- Which works are featured?
+- What mood: editorial, dense, museum wall, 3D room, archive?
+- What background: light, dark, neutral, transparent-aware?
+- Generate individual NFT pages?
+- Generate collection pages?
+- Generate 3D room?
+- Freeze snapshot at current block/time?
+
+The builder should infer sensible defaults, but users need override controls.
+
+## Schema Implications
+
+Add or expand these CMS entities:
+
+### `art_asset`
+
+Fields:
+
+- `id`.
+- `kind`: image, video, audio, model, html, document, social_image.
+- `source_uri`.
+- `content_hash`.
+- `mime_type`.
+- `width`.
+- `height`.
+- `duration`.
+- `file_size`.
+- `source_role`: original, derivative, poster, thumbnail, tile, social.
+- `storage_locations`.
+- `generation_provenance`.
+- `rights`.
+
+### `display_variant`
+
+Fields:
+
+- `asset_id`.
+- `role`: grid, detail, fullscreen, poster, social, tile.
+- `width`.
+- `height`.
+- `crop_mode`.
+- `background`.
+- `content_hash`.
+- `source_asset_id`.
+
+### `nft_media_profile`
+
+Fields:
+
+- `chain_id`.
+- `contract`.
+- `token_id`.
+- `metadata_uri`.
+- `metadata_hash`.
+- `original_assets`.
+- `display_variants`.
+- `animation_assets`.
+- `model_assets`.
+- `interactive_assets`.
+- `poster_asset`.
+- `snapshot`.
+
+### `deep_zoom_manifest`
+
+Fields:
+
+- `source_asset_id`.
+- `tile_size`.
+- `levels`.
+- `format`.
+- `dimensions`.
+- `tile_uri_template`.
+- `content_hash`.
+- `generator`.
+
+### `exhibition_room`
+
+Fields:
+
+- `id`.
+- `title`.
+- `room_type`.
+- `layout`.
+- `placements`.
+- `lighting`.
+- `navigation_mode`.
+- `fallback_page_id`.
+- `poster_asset_id`.
+- `performance_budget`.
+
+### `artwork_placement`
+
+Fields:
+
+- `nft_reference`.
+- `asset_id`.
+- `position`.
+- `rotation`.
+- `size`.
+- `frame_style`.
+- `label`.
+- `display_mode`: faithful, gallery.
+- `detail_page`.
+
+### `interactive_policy`
+
+Fields:
+
+- `hydration`: static, client_island, deferred_island, sandboxed_embed.
+- `requires_user_activation`.
+- `fallback_asset_id`.
+- `sandbox_permissions`.
+- `performance_budget`.
+
+## Recommended V1 Scope
+
+2D:
+
+- Collection grid.
+- NFT detail page.
+- Lightbox.
+- Responsive display variants.
+- Original asset link.
+- Posters for video/audio/3D/interactive media.
+- Basic deep zoom manifest support, optional generation later.
+- Provenance panel.
+- Social image.
+
+3D:
+
+- Simple generated room for 2D works.
+- Faithful art surface mode.
+- Clickable works to detail pages.
+- Poster and 2D fallback.
+- Basic object viewer for GLB/glTF.
+- Deferred loading.
+- Desktop/mobile Playwright and canvas checks.
+
+Not V1:
+
+- Full 3D world editor.
+- VR.
+- Complex multi-room navigation.
+- Arbitrary 3D plugin runtime.
+- Arbitrary scripts in room.
+- Automatic AR pipeline.
+- Per-card custom cinematic rooms for every card.
+
+## Later Opportunities
+
+- Custom Meme Card rooms.
+- Season-level 3D exhibitions.
+- Collection-specific room templates.
+- Guided tours with narration.
+- AR object viewing.
+- Synchronized zoom comparisons.
+- IIIF-compatible export for still images.
+- C2PA/content credential display.
+- Local 3D package validator.
+- Community room template registry.
+
+## Testing Requirements
+
+2D:
+
+- Aspect ratio preservation.
+- No text overlap on mobile/desktop.
+- Responsive image variants selected correctly.
+- Lazy loading not applied to LCP image.
+- Lightbox keyboard navigation.
+- Alt text validation.
+- Captions/transcripts for media where required.
+- Provenance panel renders.
+
+3D:
+
+- Canvas nonblank.
+- Poster visible before load.
+- Model/room load success.
+- Model/room error state.
+- Click work opens detail page.
+- Keyboard/touch controls.
+- Reduced motion behavior.
+- Mobile fallback.
+- Performance budget smoke test.
+- Asset cleanup/dispose on route leave.
+
+Security:
+
+- Interactive HTML sandboxing.
+- URL/media sanitization.
+- Package schema validation.
+- Size limits.
+- Unsupported asset fallback.
+
+## Open Questions
+
+- Do we build deep zoom tiles ourselves, or define the manifest first and add
+  generation later?
+- What file-size and texture-size budgets should V1 enforce?
+- Should V1 use `model-viewer` for object viewing, Three.js directly, or both?
+- What is the minimum acceptable mobile 3D fallback?
+- Which 6529 collections deserve custom 2D/3D display templates first?
+- How should rights/license metadata be represented when unknown?
+- Should C2PA/content credentials be displayed in V1 or later?
+- How aggressive should we be about copying remote NFT media into decentralized
+  package storage?
+

--- a/ops/workstreams/profile-native-cms-roadmap/phase-0/decision-record.md
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-0/decision-record.md
@@ -1,0 +1,286 @@
+# Phase 0 Decision Record
+
+Last updated: 2026-06-17.
+
+## Status
+
+Agent-default implementation decisions for Phase 1.
+
+These decisions are concrete enough for an agentic storm to begin. They remain
+human-overridable before public launch or before a cross-repo protocol package
+is cut.
+
+Decision owner:
+
+- `storm-lead` until a human owner signs off.
+
+Signoff format:
+
+- `Accepted by: <name or handle>`
+- `Accepted at: <YYYY-MM-DD>`
+- `Scope: Phase 0/1 protocol foundation`
+
+Current signoff:
+
+- `Accepted by: pending human review`
+- `Accepted at: pending`
+- `Scope: Phase 0/1 protocol foundation`
+
+## Scope
+
+Phase 0 locks the choices that prevent frontend, backend, storage, renderer,
+builder, and AI-agent lanes from inventing incompatible protocol assumptions.
+
+## Decisions
+
+### URL Model
+
+Decision:
+
+- `/{handle}` remains the normal profile page.
+- `/{handle}/index.html` is the profile's primary CMS website.
+- CMS subpages use `/{handle}/{path}/index.html`.
+- App-owned reserved routes win over handles.
+- CMS pages must use the `index.html` suffix.
+
+Rationale:
+
+- Preserves existing profile behavior.
+- Makes static export and IPFS/Arweave directory packaging natural.
+- Avoids ambiguous app/profile/CMS routing.
+
+### Storage Policy
+
+Decision:
+
+- V1 public publish requires at least one decentralized storage receipt.
+- Default publish should attempt both IPFS and Arweave.
+- If one provider is degraded, publish may proceed with one decentralized
+  receipt only when the UI clearly labels partial storage.
+- S3/CloudFront/CDN locations are acceleration receipts, never canonical
+  storage receipts.
+
+Rationale:
+
+- Meets the "not migrate later" requirement without blocking all publishing on
+  one provider outage.
+- Keeps canonical artifact decentralized from first real publish.
+
+### Signature Policy
+
+Decision:
+
+- Production package signing uses EIP-712.
+- `fixture` signatures are allowed only in fixtures/tests/dev examples.
+- EIP-191 is not the production default.
+- Signature signs the profile, package hash, payload hash, package schema,
+  storage receipt hashes, and intended pointer target.
+- EIP-1271/Safe signature verification is required before institutional
+  profiles rely on multi-sig publishing.
+- Signatures must include domain separation for environment and chain where
+  applicable.
+- Replay protection uses package hash plus profile pointer target and expected
+  previous pointer.
+
+Rationale:
+
+- EIP-712 gives structured, inspectable signing semantics.
+- Fixtures need deterministic non-wallet examples.
+
+### Hashing And Canonicalization
+
+Decision:
+
+- Canonical JSON uses RFC 8785 JSON Canonicalization Scheme.
+- Hash algorithm is SHA-256 over canonical UTF-8 bytes.
+- Hash string format is `sha256:<64-lowercase-hex>`.
+- Package hash excludes mutable delivery locations that are not part of the
+  signed package payload.
+- Storage receipts include provider-specific content ids such as IPFS CID or
+  Arweave transaction id.
+
+Rationale:
+
+- Deterministic across languages and clients.
+- Friendly to standalone validators and non-JS clients.
+
+### Pointer Model
+
+Decision:
+
+- Profile primary pointer is mutable and append-only-audited.
+- Pointer update requires expected previous pointer version/hash.
+- Every publish or rollback creates a pointer event.
+- Rollback points to an earlier immutable package; it never mutates that
+  package.
+- Pointer state starts in backend and is later replicated to decentralized
+  profile state.
+- Duplicate publish requests should be idempotent by idempotency key and
+  package hash.
+- Stale expected previous pointer must fail.
+
+Rationale:
+
+- Prevents lost updates.
+- Keeps rollback auditable.
+- Allows launch before the 6529 special-purpose chain exists.
+
+### Package Versioning
+
+Decision:
+
+- V1 schemas use explicit names such as `6529.cms.package.v1`.
+- Breaking schema changes require `.v2`.
+- Backward-compatible optional fields can stay in `.v1`.
+- A package corpus must be kept for compatibility tests.
+
+Rationale:
+
+- Lets alternative clients safely detect support.
+
+### Route Conflict Examples
+
+Decision:
+
+- `/about` remains the app route, even if a profile handle `about` exists.
+- `/about/index.html` is not enabled unless product explicitly allows reserved
+  root handles later.
+- `/punk6529/index.html` resolves the profile CMS primary site.
+- `/punk6529/collected/index.html` is a CMS page only if emitted by the package
+  route manifest; `/punk6529/collected` remains profile/app behavior.
+- Route matching is case-insensitive for handle lookup, but canonical output
+  paths use the profile handle chosen by the profile service.
+- Duplicate CMS paths and alias collisions are validation errors.
+
+Rationale:
+
+- Makes frontend implementation mechanical and avoids profile tab bleed-through.
+
+### Analytics
+
+Decision:
+
+- CMS primary route class: `profile_cms_site`.
+- CMS subpage route class: `profile_cms_subpage`.
+- Package error state class: `profile_cms_error`.
+- Profile page button click event distinguishes published, not-accelerated, and
+  blocked states.
+
+Rationale:
+
+- Prevents CMS pages from being misclassified as generic profile subpages.
+
+### Shared Contract Location
+
+Decision:
+
+- Phase 1 source-of-truth artifacts live in
+  `ops/workstreams/profile-native-cms-roadmap/phase-1/`.
+- Implementation should move or mirror them into a shared protocol package
+  before frontend and backend production code diverge.
+- Preferred future frontend path is `lib/profile-cms/protocol/v1/`.
+- Preferred long-term path is a shared 6529mono package if that migration
+  happens before implementation begins.
+
+Rationale:
+
+- Delivers Phase 1 in the current repo while making split-brain schema risk
+  explicit.
+
+### Media And Package Limits
+
+Decision:
+
+- Package JSON target limit: 5 MB.
+- Package JSON hard warning: 10 MB.
+- Individual image original warning: 100 MB.
+- Individual generated display derivative warning: 15 MB.
+- Individual video derivative warning: 250 MB.
+- Individual GLB/glTF warning: 50 MB, strong warning above 25 MB for mobile.
+- Texture dimension warning: above 4096 px on either axis.
+- Total package asset warning: 500 MB.
+
+Rationale:
+
+- Keeps IPFS/Arweave and mobile rendering practical.
+- Warnings are not permanent protocol bans; they are V1 launch guardrails.
+
+### Art/NFT Display V1
+
+Decision:
+
+- V1 includes art assets, display variants, NFT media profiles, posters,
+  provenance panels, lightbox, optional deep zoom manifests, simple 3D rooms,
+  and basic GLB/glTF object viewing.
+- 2D art in 3D rooms must have a faithful mode and link to a faithful 2D detail
+  page.
+
+Rationale:
+
+- Makes art display first-class without building a full 3D world editor.
+
+### Static Site Prior Art
+
+Decision:
+
+- V1 does not build Astro, Starlight, Jekyll, Hugo, Eleventy, Docusaurus,
+  VitePress, MkDocs, Gatsby, or Zola exporters.
+- V1 natively adopts their best ideas: typed collections, source loaders,
+  frontmatter-style metadata, static-first islands, scoped defaults,
+  archetypes, taxonomies, data cascade, pagination, permalinks, aliases, static
+  search, site/build manifests, Markdown import/export, and local tooling
+  direction.
+
+Rationale:
+
+- Preserves framework-neutral protocol.
+- Still benefits from decades of static-site design.
+
+### AI-Agent Affordances
+
+Decision:
+
+- 6529 does not pay for arbitrary user inference.
+- V1 provides AI-friendly affordances: JSON schema bundle, source packets,
+  read/validate/preview MCP tools, `SKILL.md` guidance, structured validation
+  errors, and agent patch schema.
+- Agent patch import/review UI is V1.1 unless V1 capacity permits.
+- Publishing/signing remains explicit profile-owner action.
+
+Rationale:
+
+- Lets users bring their own AI while keeping 6529 protocol open and low-cost.
+
+### First Custom 6529 Collections
+
+Decision:
+
+- First native collection templates target:
+  - The Memes by 6529.
+  - 6529 Gradients.
+  - NextGen, if current metadata paths are stable enough.
+
+Rationale:
+
+- These are core 6529 collections and good demonstrations of spectacular
+  collection/card pages.
+
+### Feature Flag
+
+Decision:
+
+- All runtime CMS routes, builder entry points, and publish actions launch
+  behind a feature flag until Phase 3 end-to-end publish resolves a signed
+  package through a pointer.
+
+Rationale:
+
+- Allows aggressive PR merge sequencing without exposing partial product.
+
+## Remaining Human Review Items
+
+- Confirm whether public launch should require both IPFS and Arweave receipts
+  instead of one required plus one preferred.
+- Confirm EIP-712 signing copy and exact typed-data domain.
+- Confirm media limits against expected 6529 collection assets.
+- Confirm first institutional migration pilot.

--- a/ops/workstreams/profile-native-cms-roadmap/phase-0/pr-wave-plan.md
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-0/pr-wave-plan.md
@@ -1,0 +1,98 @@
+# Phase 0 PR Wave Plan
+
+Last updated: 2026-06-17.
+
+## Purpose
+
+Name the exact PR order that lets an agentic storm move quickly while preserving
+shared protocol invariants.
+
+## Wave 0: Decisions And Fixtures
+
+Repos:
+
+- Frontend repo for Phase 0/1 docs and initial protocol artifacts.
+- Backend repo receives copied/generated fixtures once package schema is stable.
+
+PRs:
+
+1. Phase 0/1 decision, schema, fixture, and validation docs.
+2. Executable frontend protocol package under `lib/profile-cms/protocol/v1/`.
+3. Backend schema/fixture consumption PR.
+
+Gate:
+
+- FE and BE both parse the same fixture corpus.
+- Hash test vectors are deterministic in both repos or in a shared package.
+
+## Wave 1: Route And Render
+
+PRs:
+
+1. FE CMS route resolution behind feature flag.
+2. FE renderer core against fixtures.
+3. FE art/NFT primitive renderer against fixtures.
+4. FE static export proof against fixtures.
+
+Gate:
+
+- Fixture package renders at `/{handle}/index.html`.
+
+## Wave 2: Publish Spine
+
+PRs:
+
+1. BE package records and validation.
+2. BE signing and profile authorization.
+3. BE storage adapters and receipts.
+4. BE pointer events and rollback.
+5. FE publish/sign/provenance UI.
+
+Gate:
+
+- Signed package publishes and resolves through profile pointer in dev.
+
+## Wave 3: Builder MVP
+
+PRs:
+
+1. FE builder dashboard.
+2. FE page/block editor.
+3. FE media library.
+4. FE validation checklist.
+5. FE version history and rollback UI.
+
+Gate:
+
+- User can build and publish a simple profile homepage.
+
+## Wave 4: Wallet Gallery MVP
+
+PRs:
+
+1. Wallet/ENS loader.
+2. NFT metadata normalization.
+3. Gallery package generator.
+4. Generated collection/NFT pages.
+5. Media variants/social images.
+6. Hide/feature controls.
+
+Gate:
+
+- User can paste wallets and publish a gallery site with home, collection, and
+  NFT pages.
+
+## Wave 5: Experience And Decentralization
+
+PRs:
+
+1. Art display polish.
+2. 3D room/object viewer MVP.
+3. AI-agent affordances.
+4. Institutional migration pilot.
+5. Standalone validator/exporter/mirror docs.
+
+Gate:
+
+- Public launch readiness checklist passes.
+

--- a/ops/workstreams/profile-native-cms-roadmap/phase-0/storm-lanes.md
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-0/storm-lanes.md
@@ -1,0 +1,172 @@
+# Phase 0 Storm Lanes
+
+Last updated: 2026-06-17.
+
+## Purpose
+
+Assign non-overlapping lanes for Phase 1 and the first implementation waves.
+
+## Lane Map
+
+### Storm Lead
+
+Owned paths:
+
+- `ops/workstreams/profile-native-cms-roadmap/**`
+
+Responsibilities:
+
+- Decision record.
+- Phase gates.
+- Cross-lane sequencing.
+- PR labels and review checklist.
+
+### Schema Captain
+
+Owned paths:
+
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/schemas/**`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/hash-test-vectors.md`
+
+Responsibilities:
+
+- Package schema.
+- Payload schema.
+- Shared definitions.
+- Hash/canonicalization fixtures.
+
+### Fixture Agent
+
+Owned paths:
+
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/**`
+
+Responsibilities:
+
+- Valid package corpus.
+- Invalid package corpus.
+- Fixture README and intended validation results.
+
+### Frontend Renderer Agent
+
+Owned future paths:
+
+- CMS route files under `app/**` once implementation begins.
+- CMS renderer components under a future `components/cms/**` or equivalent.
+
+Responsibilities:
+
+- Route resolution.
+- Renderer shell.
+- Metadata/OpenGraph.
+- Static export integration.
+
+### Art Display Agent
+
+Owned future paths:
+
+- Art/NFT display components.
+- Media display fixtures and screenshots.
+
+Responsibilities:
+
+- Grids.
+- NFT detail page.
+- Lightbox.
+- Posters.
+- Provenance UI.
+
+### Backend Publish Agent
+
+Owned future paths:
+
+- Backend API and storage/pointer implementation in the backend repository.
+- FE API client contracts where required.
+
+Responsibilities:
+
+- Package records.
+- Validation.
+- Signing.
+- Pointer ledger.
+- Rollback.
+
+### Storage Agent
+
+Owned future paths:
+
+- IPFS/Arweave adapters.
+- Storage receipt verification.
+
+Responsibilities:
+
+- Decentralized storage uploads.
+- Receipt verification.
+- Retry/status model.
+
+### Builder Agent
+
+Owned future paths:
+
+- Builder dashboard and page/block editor.
+
+Responsibilities:
+
+- Draft UX.
+- Site tree.
+- Validation checklist.
+- Publish UX.
+
+### Wallet Gallery Agent
+
+Owned future paths:
+
+- Wallet source loader.
+- NFT metadata normalization.
+- Gallery generator.
+
+Responsibilities:
+
+- Multi-wallet import.
+- Snapshot provenance.
+- Generated pages.
+- Hide/feature controls.
+
+### AI-Agent Affordance Agent
+
+Owned future paths:
+
+- MCP tool definitions.
+- `SKILL.md` files.
+- Source packet and patch schemas.
+
+Responsibilities:
+
+- Schema export.
+- Source packets.
+- MCP read/validate/preview tools.
+- Agent patch schema and review flow.
+
+### QA/Security Agent
+
+Owned paths:
+
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/validation-plan.md`
+- Future tests/screenshot plans.
+
+Responsibilities:
+
+- Validation matrix.
+- Security checklist.
+- Accessibility and media checks.
+- CI/bot feedback loop.
+
+## Collision Rules
+
+- Schema changes require Schema Captain review.
+- Fixture changes require Fixture Agent and Schema Captain review.
+- Route shape changes require Storm Lead review.
+- Publish/sign/storage changes require Backend Publish Agent and Storage Agent
+  review.
+- No agent should edit unrelated dirty worktree files.
+

--- a/ops/workstreams/profile-native-cms-roadmap/phase-0/test-matrix.md
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-0/test-matrix.md
@@ -1,0 +1,63 @@
+# Phase 0 Test Matrix
+
+Last updated: 2026-06-17.
+
+## Purpose
+
+Define the validation bar for Phase 1 artifacts and the checks future waves must
+inherit.
+
+## Phase 1 Checks
+
+Docs and JSON artifacts:
+
+- All JSON schemas parse as JSON.
+- All valid fixtures parse as JSON.
+- All invalid fixtures parse as JSON and include documented expected failures.
+- `codex-diff-check -- ops/workstreams/profile-native-cms-roadmap` passes.
+- Workstream docs contain no accidental non-ASCII.
+
+Manual review:
+
+- Every Phase 0 blocker decision is either locked or marked human-review.
+- Every Phase 1 schema has an owning lane.
+- Every fixture maps to a launch-critical path.
+
+## Future Phase Checks
+
+Renderer:
+
+- Fixture package renders at `/{handle}/index.html`.
+- Metadata/OpenGraph tags render for home, collection, and NFT pages.
+- Static export emits `index.html` routes and build manifest.
+
+Publish:
+
+- Package canonicalizes deterministically.
+- Package hash matches fixture vector.
+- Signature verification rejects wrong signer and altered payload.
+- Pointer update rejects stale expected previous pointer.
+- Rollback creates new pointer event.
+
+Storage:
+
+- IPFS receipt verifies content id.
+- Arweave receipt verifies transaction/content relation.
+- CDN acceleration does not count as canonical storage.
+
+Art/NFT display:
+
+- Detail page preserves aspect ratio.
+- Grid layout has stable dimensions.
+- Posters show before video/3D/interactive load.
+- Lightbox keyboard path works.
+- 3D canvas is nonblank where enabled.
+- Mobile fallback exists for 3D room.
+
+AI-agent affordances:
+
+- Schema bundle export contains all V1 schemas.
+- Source packet strips executable/untrusted HTML.
+- Agent patch validation rejects unsafe URLs and route collisions.
+- Publishing cannot be triggered by patch import alone.
+

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/README.md
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/README.md
@@ -1,0 +1,61 @@
+# Phase 1 Protocol And Fixture Foundation
+
+Last updated: 2026-06-17.
+
+## Goal
+
+Create the shared package contract and fixture corpus that lets frontend,
+backend, renderer, storage, builder, wallet gallery, art display, 3D, and
+AI-agent lanes build in parallel without architecture drift.
+
+## Deliverables
+
+- Schema index.
+- V1 package schema.
+- V1 agent patch schema.
+- V1 validation result schema.
+- Valid fixture corpus.
+- Invalid fixture corpus.
+- Hash/canonicalization test vectors.
+- Validation plan.
+
+## Directories
+
+- `schemas/`: JSON schemas and schema index.
+- `fixtures/valid/`: packages expected to validate.
+- `fixtures/invalid/`: packages expected to fail validation for documented
+  reasons.
+
+## Phase 1 Status
+
+Delivered as planning/protocol artifacts in this repo:
+
+- `schema-index.md`
+- `schemas/cms-package-v1.schema.json`
+- `schemas/agent-patch-v1.schema.json`
+- `schemas/validation-result-v1.schema.json`
+- `fixtures/README.md`
+- Valid fixtures:
+  - `minimal-profile-homepage.package.json`
+  - `wallet-gallery.package.json`
+  - `collection-page.package.json`
+  - `nft-detail.package.json`
+  - `art-media.package.json`
+  - `exhibition-room.package.json`
+  - `legacy-migration.package.json`
+- Invalid fixtures:
+  - `missing-signature.package.json`
+  - `route-collision.package.json`
+  - `unknown-block.package.json`
+- `hash-test-vectors.md`
+- `validation-plan.md`
+
+## Notes
+
+These schemas are the first protocol foundation, not the final generated API
+model. Implementation PRs should either use these directly or move them into a
+shared protocol package with identical semantics.
+
+Current validation is docs/artifact-level only: JSON parse and focused semantic
+checks have run, but full JSON Schema validation has not run in this pass
+because `ajv` is not currently resolvable in the local Node environment.

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/README.md
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/README.md
@@ -1,0 +1,62 @@
+# Phase 1 Fixture Corpus
+
+Last updated: 2026-06-17.
+
+## Purpose
+
+Provide a shared package corpus that future frontend and backend agents can use
+to validate schema, renderer, route, storage, signing, pointer, and AI-agent
+patch behavior.
+
+## Valid Fixtures
+
+- `valid/minimal-profile-homepage.package.json`
+  - Minimal primary site at `/punk6529/index.html`.
+  - Exercises page metadata, navigation, social image, fixture signature, and
+    fixture storage receipt.
+- `valid/wallet-gallery.package.json`
+  - Generated gallery with wallet source packet, collection route, NFT route,
+    generated wallet gallery block, and NFT media profile.
+- `valid/collection-page.package.json`
+  - Collection page with taxonomy term, knowledge/source packet, and collection
+    reference.
+- `valid/nft-detail.package.json`
+  - NFT detail page with original asset, display variants, poster, provenance,
+    and source metadata.
+- `valid/art-media.package.json`
+  - Image, video, audio, HTML, and model media with posters/fallbacks and
+    interactive policy coverage.
+- `valid/exhibition-room.package.json`
+  - 3D room with faithful artwork placement and 2D fallback detail page.
+- `valid/legacy-migration.package.json`
+  - Institutional migration-style package for a `6529museum` profile.
+
+## Invalid Fixtures
+
+- `invalid/missing-signature.package.json`
+  - Fails because `signatures` is empty.
+- `invalid/route-collision.package.json`
+  - Fails semantic validation because two routes emit the same path.
+- `invalid/unknown-block.package.json`
+  - Fails schema validation because V1 does not accept unknown block types.
+
+## Future Invalid Fixtures
+
+Implementation should add:
+
+- Bad signature envelope.
+- Wrong signer.
+- Wrong domain/chain.
+- Stale pointer.
+- CDN-only storage.
+- Mismatched storage receipt hash.
+- Unsafe URL.
+- Unsafe HTML block.
+- Media missing dimensions.
+- Heavy model without poster.
+- Unsupported schema version.
+
+## Notes
+
+The JSON fixtures use deterministic placeholder hashes. Phase 2 implementation
+must replace or confirm them with actual RFC 8785 + SHA-256 test vectors.

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/invalid/missing-signature.package.json
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/invalid/missing-signature.package.json
@@ -1,0 +1,80 @@
+{
+  "schema": "6529.cms.package.v1",
+  "package_id": "pkg-invalid-missing-signature-v1",
+  "profile": {
+    "handle": "punk6529"
+  },
+  "site": {
+    "title": "Invalid Missing Signature",
+    "base_path": "/punk6529/index.html",
+    "default_locale": "en",
+    "theme": {
+      "mode": "system",
+      "accent": "#2f7df6"
+    },
+    "navigation_id": "nav-main"
+  },
+  "payload": {
+    "schema": "6529.cms.payload.v1",
+    "routes": [
+      {
+        "path": "/punk6529/index.html",
+        "kind": "page",
+        "page_id": "page-home"
+      }
+    ],
+    "pages": [
+      {
+        "id": "page-home",
+        "type": "page",
+        "path": "/punk6529/index.html",
+        "metadata": {
+          "title": "Invalid Missing Signature",
+          "description": "This fixture should fail because signatures are required.",
+          "locale": "en",
+          "canonical_url": "https://6529.io/punk6529/index.html"
+        },
+        "blocks": [
+          {
+            "id": "block-title",
+            "block_type": "heading",
+            "level": 1,
+            "text": "Invalid"
+          }
+        ]
+      }
+    ],
+    "assets": [],
+    "navigation": [
+      {
+        "id": "nav-main",
+        "items": [
+          {
+            "label": "Home",
+            "page_id": "page-home"
+          }
+        ]
+      }
+    ]
+  },
+  "integrity": {
+    "canonicalization": "jcs-rfc8785",
+    "hash_algorithm": "sha256",
+    "payload_hash": "sha256:4343434343434343434343434343434343434343434343434343434343434343",
+    "package_hash": "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+  },
+  "signatures": [],
+  "storage": [
+    {
+      "provider": "fixture",
+      "uri": "ipfs://bafyfixtureinvalidsignature",
+      "content_hash": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+      "recorded_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "provenance": {
+    "builder": "6529-cms-fixture",
+    "created_at": "2026-06-17T00:00:00Z"
+  }
+}
+

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/invalid/route-collision.package.json
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/invalid/route-collision.package.json
@@ -1,0 +1,110 @@
+{
+  "schema": "6529.cms.package.v1",
+  "package_id": "pkg-invalid-route-collision-v1",
+  "profile": {
+    "handle": "punk6529"
+  },
+  "site": {
+    "title": "Invalid Route Collision",
+    "base_path": "/punk6529/index.html",
+    "default_locale": "en",
+    "theme": {
+      "mode": "system",
+      "accent": "#2f7df6"
+    },
+    "navigation_id": "nav-main"
+  },
+  "payload": {
+    "schema": "6529.cms.payload.v1",
+    "routes": [
+      {
+        "path": "/punk6529/index.html",
+        "kind": "page",
+        "page_id": "page-home-a"
+      },
+      {
+        "path": "/punk6529/index.html",
+        "kind": "page",
+        "page_id": "page-home-b"
+      }
+    ],
+    "pages": [
+      {
+        "id": "page-home-a",
+        "type": "page",
+        "path": "/punk6529/index.html",
+        "metadata": {
+          "title": "Invalid Route A",
+          "description": "This page collides with another route.",
+          "locale": "en",
+          "canonical_url": "https://6529.io/punk6529/index.html"
+        },
+        "blocks": [
+          {
+            "id": "block-a",
+            "block_type": "heading",
+            "level": 1,
+            "text": "A"
+          }
+        ]
+      },
+      {
+        "id": "page-home-b",
+        "type": "page",
+        "path": "/punk6529/index.html",
+        "metadata": {
+          "title": "Invalid Route B",
+          "description": "This page collides with another route.",
+          "locale": "en",
+          "canonical_url": "https://6529.io/punk6529/index.html"
+        },
+        "blocks": [
+          {
+            "id": "block-b",
+            "block_type": "heading",
+            "level": 1,
+            "text": "B"
+          }
+        ]
+      }
+    ],
+    "assets": [],
+    "navigation": [
+      {
+        "id": "nav-main",
+        "items": [
+          {
+            "label": "Home",
+            "page_id": "page-home-a"
+          }
+        ]
+      }
+    ]
+  },
+  "integrity": {
+    "canonicalization": "jcs-rfc8785",
+    "hash_algorithm": "sha256",
+    "payload_hash": "sha256:4545454545454545454545454545454545454545454545454545454545454545",
+    "package_hash": "sha256:4646464646464646464646464646464646464646464646464646464646464646"
+  },
+  "signatures": [
+    {
+      "type": "fixture",
+      "signer": "fixture:punk6529",
+      "signature": "fixture-signature-route-collision",
+      "signed_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "storage": [
+    {
+      "provider": "fixture",
+      "uri": "ipfs://bafyfixtureinvalidroute",
+      "content_hash": "sha256:4646464646464646464646464646464646464646464646464646464646464646",
+      "recorded_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "provenance": {
+    "builder": "6529-cms-fixture",
+    "created_at": "2026-06-17T00:00:00Z"
+  }
+}

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/invalid/unknown-block.package.json
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/invalid/unknown-block.package.json
@@ -1,0 +1,87 @@
+{
+  "schema": "6529.cms.package.v1",
+  "package_id": "pkg-invalid-unknown-block-v1",
+  "profile": {
+    "handle": "punk6529"
+  },
+  "site": {
+    "title": "Invalid Unknown Block",
+    "base_path": "/punk6529/index.html",
+    "default_locale": "en",
+    "theme": {
+      "mode": "system",
+      "accent": "#00aaff"
+    },
+    "navigation_id": "nav-main"
+  },
+  "payload": {
+    "schema": "6529.cms.payload.v1",
+    "routes": [
+      {
+        "path": "/punk6529/index.html",
+        "kind": "page",
+        "page_id": "page-home"
+      }
+    ],
+    "pages": [
+      {
+        "id": "page-home",
+        "type": "page",
+        "path": "/punk6529/index.html",
+        "metadata": {
+          "title": "Invalid Unknown Block",
+          "description": "Fixture that should fail because V1 does not accept unknown block types.",
+          "locale": "en",
+          "canonical_url": "https://6529.io/punk6529/index.html"
+        },
+        "blocks": [
+          {
+            "id": "block-unknown",
+            "block_type": "unknown_future_block"
+          }
+        ]
+      }
+    ],
+    "assets": [],
+    "navigation": [
+      {
+        "id": "nav-main",
+        "items": [
+          {
+            "label": "Home",
+            "page_id": "page-home"
+          }
+        ]
+      }
+    ]
+  },
+  "integrity": {
+    "canonicalization": "jcs-rfc8785",
+    "hash_algorithm": "sha256",
+    "payload_hash": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+    "package_hash": "sha256:5656565656565656565656565656565656565656565656565656565656565656"
+  },
+  "signatures": [
+    {
+      "type": "fixture",
+      "signer": "fixture:punk6529",
+      "signature": "fixture-signature-invalid-unknown-block",
+      "signed_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "storage": [
+    {
+      "provider": "fixture",
+      "uri": "ipfs://bafyfixtureinvalidunknown",
+      "content_hash": "sha256:5656565656565656565656565656565656565656565656565656565656565656",
+      "provider_content_id": "bafyfixtureinvalidunknown",
+      "canonical": true,
+      "recorded_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "provenance": {
+    "builder": "6529-cms-fixture",
+    "created_at": "2026-06-17T00:00:00Z",
+    "notes": "Invalid fixture: unknown V1 block type must fail closed."
+  }
+}

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/art-media.package.json
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/art-media.package.json
@@ -1,0 +1,193 @@
+{
+  "schema": "6529.cms.package.v1",
+  "package_id": "pkg-art-media-v1",
+  "profile": {
+    "handle": "media6529",
+    "profile_id": "profile-media6529"
+  },
+  "site": {
+    "title": "Art Media Fixture",
+    "description": "Mixed media fixture with posters and fallbacks.",
+    "base_path": "/media6529/index.html",
+    "default_locale": "en",
+    "direction": "ltr",
+    "theme": {
+      "mode": "dark",
+      "accent": "#f6c744"
+    },
+    "navigation_id": "nav-main",
+    "required_renderer_capabilities": ["media_posters", "sandboxed_embed", "object_viewer"]
+  },
+  "payload": {
+    "schema": "6529.cms.payload.v1",
+    "routes": [
+      {
+        "path": "/media6529/index.html",
+        "kind": "page",
+        "page_id": "page-home"
+      }
+    ],
+    "pages": [
+      {
+        "id": "page-home",
+        "type": "page",
+        "path": "/media6529/index.html",
+        "metadata": {
+          "title": "Art Media Fixture",
+          "description": "Mixed media display fixture with image, video, audio, HTML, and model assets.",
+          "locale": "en",
+          "canonical_url": "https://6529.io/media6529/index.html",
+          "social_image_asset_id": "asset-og",
+          "navigation_label": "Media",
+          "search": "include",
+          "robots": "index"
+        },
+        "blocks": [
+          {
+            "id": "block-video",
+            "block_type": "video",
+            "asset_id": "asset-video",
+            "poster_asset_id": "asset-poster"
+          },
+          {
+            "id": "block-html",
+            "block_type": "html_embed",
+            "asset_id": "asset-html",
+            "interactive_policy": {
+              "hydration": "sandboxed_embed",
+              "requires_user_activation": true,
+              "fallback_asset_id": "asset-poster",
+              "sandbox_permissions": ["allow-scripts"]
+            }
+          },
+          {
+            "id": "block-model",
+            "block_type": "object_viewer",
+            "asset_id": "asset-model",
+            "interactive_policy": {
+              "hydration": "deferred_island",
+              "requires_user_activation": true,
+              "fallback_asset_id": "asset-poster"
+            }
+          }
+        ]
+      }
+    ],
+    "assets": [
+      {
+        "id": "asset-og",
+        "kind": "social_image",
+        "uri": "ipfs://bafyfixturemedia/og.png",
+        "content_hash": "sha256:2727272727272727272727272727272727272727272727272727272727272727",
+        "mime_type": "image/png",
+        "width": 1200,
+        "height": 630,
+        "file_size_bytes": 50000,
+        "roles": ["social"],
+        "alt_text": "Social preview for mixed media fixture"
+      },
+      {
+        "id": "asset-poster",
+        "kind": "image",
+        "uri": "ipfs://bafyfixturemedia/poster.jpg",
+        "content_hash": "sha256:2828282828282828282828282828282828282828282828282828282828282828",
+        "mime_type": "image/jpeg",
+        "width": 1600,
+        "height": 900,
+        "file_size_bytes": 160000,
+        "roles": ["poster", "fallback"],
+        "alt_text": "Poster fallback for mixed media artwork"
+      },
+      {
+        "id": "asset-video",
+        "kind": "video",
+        "uri": "ipfs://bafyfixturemedia/video.mp4",
+        "content_hash": "sha256:2929292929292929292929292929292929292929292929292929292929292929",
+        "mime_type": "video/mp4",
+        "width": 1920,
+        "height": 1080,
+        "duration_seconds": 12,
+        "file_size_bytes": 6000000,
+        "roles": ["original"]
+      },
+      {
+        "id": "asset-audio",
+        "kind": "audio",
+        "uri": "ipfs://bafyfixturemedia/audio.mp3",
+        "content_hash": "sha256:3030303030303030303030303030303030303030303030303030303030303030",
+        "mime_type": "audio/mpeg",
+        "duration_seconds": 33,
+        "file_size_bytes": 1200000,
+        "roles": ["original"]
+      },
+      {
+        "id": "asset-html",
+        "kind": "html",
+        "uri": "ipfs://bafyfixturemedia/index.html",
+        "content_hash": "sha256:3131313131313131313131313131313131313131313131313131313131313131",
+        "mime_type": "text/html",
+        "file_size_bytes": 40000,
+        "roles": ["original"]
+      },
+      {
+        "id": "asset-model",
+        "kind": "model",
+        "uri": "ipfs://bafyfixturemedia/model.glb",
+        "content_hash": "sha256:3232323232323232323232323232323232323232323232323232323232323232",
+        "mime_type": "model/gltf-binary",
+        "file_size_bytes": 8000000,
+        "roles": ["original"]
+      }
+    ],
+    "navigation": [
+      {
+        "id": "nav-main",
+        "items": [
+          {
+            "label": "Media",
+            "page_id": "page-home"
+          }
+        ]
+      }
+    ],
+    "build_manifest": {
+      "renderer": "6529-cms-static",
+      "renderer_version": "0.0.0-fixture",
+      "route_count": 1,
+      "asset_count": 6,
+      "warnings": []
+    }
+  },
+  "integrity": {
+    "canonicalization": "jcs-rfc8785",
+    "hash_algorithm": "sha256",
+    "payload_hash": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+    "package_hash": "sha256:3434343434343434343434343434343434343434343434343434343434343434",
+    "note": "Fixture placeholder hash; replace with generated vector before Phase 2."
+  },
+  "signatures": [
+    {
+      "type": "fixture",
+      "signer": "fixture:media6529",
+      "signature": "fixture-signature-art-media",
+      "signed_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "storage": [
+    {
+      "provider": "fixture",
+      "uri": "ipfs://bafyfixturemedia",
+      "content_hash": "sha256:3434343434343434343434343434343434343434343434343434343434343434",
+      "provider_content_id": "bafyfixturemedia",
+      "pinned": true,
+      "canonical": true,
+      "recorded_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "provenance": {
+    "builder": "6529-cms-fixture",
+    "builder_version": "0.0.0",
+    "created_at": "2026-06-17T00:00:00Z",
+    "notes": "Valid mixed media fixture."
+  }
+}

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/collection-page.package.json
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/collection-page.package.json
@@ -1,0 +1,189 @@
+{
+  "schema": "6529.cms.package.v1",
+  "package_id": "pkg-collection-page-v1",
+  "profile": {
+    "handle": "6529museum",
+    "profile_id": "profile-6529museum"
+  },
+  "site": {
+    "title": "6529 Museum Collection Fixture",
+    "description": "A collection page fixture.",
+    "base_path": "/6529museum/index.html",
+    "default_locale": "en",
+    "direction": "ltr",
+    "theme": {
+      "mode": "light",
+      "accent": "#111111"
+    },
+    "navigation_id": "nav-main",
+    "required_renderer_capabilities": ["static_blocks", "taxonomy_terms"]
+  },
+  "payload": {
+    "schema": "6529.cms.payload.v1",
+    "routes": [
+      {
+        "path": "/6529museum/index.html",
+        "kind": "page",
+        "page_id": "page-home"
+      },
+      {
+        "path": "/6529museum/collections/the-memes/index.html",
+        "kind": "page",
+        "page_id": "page-collection"
+      }
+    ],
+    "pages": [
+      {
+        "id": "page-home",
+        "type": "page",
+        "path": "/6529museum/index.html",
+        "metadata": {
+          "title": "6529 Museum",
+          "description": "Museum homepage fixture.",
+          "locale": "en",
+          "canonical_url": "https://6529.io/6529museum/index.html",
+          "social_image_asset_id": "asset-og",
+          "navigation_label": "Home",
+          "search": "include",
+          "robots": "index"
+        },
+        "blocks": [
+          {
+            "id": "block-home-heading",
+            "block_type": "heading",
+            "level": 1,
+            "text": "6529 Museum"
+          }
+        ]
+      },
+      {
+        "id": "page-collection",
+        "type": "collection",
+        "path": "/6529museum/collections/the-memes/index.html",
+        "metadata": {
+          "title": "The Memes by 6529",
+          "description": "A fixture for a rich collection page.",
+          "locale": "en",
+          "canonical_url": "https://6529.io/6529museum/collections/the-memes/index.html",
+          "social_image_asset_id": "asset-og",
+          "navigation_label": "The Memes",
+          "search": "include",
+          "robots": "index"
+        },
+        "source": {
+          "source_packet_id": "source-knowledge-the-memes"
+        },
+        "blocks": [
+          {
+            "id": "block-title",
+            "block_type": "heading",
+            "level": 1,
+            "text": "The Memes by 6529"
+          },
+          {
+            "id": "block-summary",
+            "block_type": "rich_text",
+            "content": "Collection context fixture grounded in a knowledge packet."
+          },
+          {
+            "id": "block-collection-ref",
+            "block_type": "collection_reference",
+            "chain_id": 1,
+            "contract": "0x33fd426905f149f8376e227d0c9d3340aad17af1",
+            "title": "The Memes by 6529"
+          }
+        ]
+      }
+    ],
+    "assets": [
+      {
+        "id": "asset-og",
+        "kind": "social_image",
+        "uri": "ipfs://bafyfixturecollection/og.png",
+        "content_hash": "sha256:1717171717171717171717171717171717171717171717171717171717171717",
+        "mime_type": "image/png",
+        "width": 1200,
+        "height": 630,
+        "file_size_bytes": 41000,
+        "roles": ["social"],
+        "alt_text": "The Memes collection social preview"
+      }
+    ],
+    "navigation": [
+      {
+        "id": "nav-main",
+        "items": [
+          {
+            "label": "Home",
+            "page_id": "page-home"
+          },
+          {
+            "label": "The Memes",
+            "page_id": "page-collection"
+          }
+        ]
+      }
+    ],
+    "taxonomies": [
+      {
+        "id": "taxonomy-series",
+        "name": "Series",
+        "terms": [
+          {
+            "slug": "the-memes",
+            "label": "The Memes",
+            "page_id": "page-collection"
+          }
+        ]
+      }
+    ],
+    "source_packets": [
+      {
+        "id": "source-knowledge-the-memes",
+        "source_type": "collection",
+        "captured_at": "2026-06-17T00:00:00Z",
+        "content_hash": "sha256:1818181818181818181818181818181818181818181818181818181818181818",
+        "knowledge_packet": "the-memes-v1"
+      }
+    ],
+    "build_manifest": {
+      "renderer": "6529-cms-static",
+      "renderer_version": "0.0.0-fixture",
+      "route_count": 2,
+      "asset_count": 1,
+      "warnings": []
+    }
+  },
+  "integrity": {
+    "canonicalization": "jcs-rfc8785",
+    "hash_algorithm": "sha256",
+    "payload_hash": "sha256:1919191919191919191919191919191919191919191919191919191919191919",
+    "package_hash": "sha256:2020202020202020202020202020202020202020202020202020202020202020",
+    "note": "Fixture placeholder hash; replace with generated vector before Phase 2."
+  },
+  "signatures": [
+    {
+      "type": "fixture",
+      "signer": "fixture:6529museum",
+      "signature": "fixture-signature-collection",
+      "signed_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "storage": [
+    {
+      "provider": "fixture",
+      "uri": "ipfs://bafyfixturecollection",
+      "content_hash": "sha256:2020202020202020202020202020202020202020202020202020202020202020",
+      "provider_content_id": "bafyfixturecollection",
+      "pinned": true,
+      "canonical": true,
+      "recorded_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "provenance": {
+    "builder": "6529-cms-fixture",
+    "builder_version": "0.0.0",
+    "created_at": "2026-06-17T00:00:00Z",
+    "notes": "Valid collection page fixture."
+  }
+}

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/exhibition-room.package.json
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/exhibition-room.package.json
@@ -1,0 +1,185 @@
+{
+  "schema": "6529.cms.package.v1",
+  "package_id": "pkg-exhibition-room-v1",
+  "profile": {
+    "handle": "punk6529",
+    "profile_id": "profile-punk6529"
+  },
+  "site": {
+    "title": "3D Room Fixture",
+    "description": "Simple 3D room fixture with faithful 2D fallback.",
+    "base_path": "/punk6529/index.html",
+    "default_locale": "en",
+    "direction": "ltr",
+    "theme": {
+      "mode": "dark",
+      "accent": "#ffffff"
+    },
+    "navigation_id": "nav-main",
+    "required_renderer_capabilities": ["room_viewer", "nft_detail"]
+  },
+  "payload": {
+    "schema": "6529.cms.payload.v1",
+    "routes": [
+      {
+        "path": "/punk6529/index.html",
+        "kind": "page",
+        "page_id": "page-room"
+      },
+      {
+        "path": "/punk6529/nfts/ethereum/0x33fd426905f149f8376e227d0c9d3340aad17af1/1/index.html",
+        "kind": "page",
+        "page_id": "page-nft"
+      }
+    ],
+    "pages": [
+      {
+        "id": "page-room",
+        "type": "room",
+        "path": "/punk6529/index.html",
+        "metadata": {
+          "title": "3D Room Fixture",
+          "description": "A simple wall room with faithful 2D fallback.",
+          "locale": "en",
+          "canonical_url": "https://6529.io/punk6529/index.html",
+          "social_image_asset_id": "asset-room-poster",
+          "navigation_label": "Room",
+          "search": "include",
+          "robots": "index"
+        },
+        "blocks": [
+          {
+            "id": "block-room",
+            "block_type": "room_viewer",
+            "room_id": "room-main",
+            "interactive_policy": {
+              "hydration": "deferred_island",
+              "requires_user_activation": true,
+              "fallback_asset_id": "asset-room-poster"
+            }
+          }
+        ]
+      },
+      {
+        "id": "page-nft",
+        "type": "nft_detail",
+        "path": "/punk6529/nfts/ethereum/0x33fd426905f149f8376e227d0c9d3340aad17af1/1/index.html",
+        "metadata": {
+          "title": "Room Work Detail",
+          "description": "Faithful 2D detail page for a room artwork.",
+          "locale": "en",
+          "canonical_url": "https://6529.io/punk6529/nfts/ethereum/0x33fd426905f149f8376e227d0c9d3340aad17af1/1/index.html",
+          "social_image_asset_id": "asset-room-work",
+          "navigation_label": "Work",
+          "search": "include",
+          "robots": "index"
+        },
+        "blocks": [
+          {
+            "id": "block-work-image",
+            "block_type": "image",
+            "asset_id": "asset-room-work"
+          }
+        ]
+      }
+    ],
+    "assets": [
+      {
+        "id": "asset-room-poster",
+        "kind": "image",
+        "uri": "ipfs://bafyfixtureroom/poster.jpg",
+        "content_hash": "sha256:3535353535353535353535353535353535353535353535353535353535353535",
+        "mime_type": "image/jpeg",
+        "width": 1600,
+        "height": 900,
+        "file_size_bytes": 180000,
+        "roles": ["poster", "social", "fallback"],
+        "alt_text": "Poster for a simple 3D exhibition room"
+      },
+      {
+        "id": "asset-room-work",
+        "kind": "image",
+        "uri": "ipfs://bafyfixtureroom/work.png",
+        "content_hash": "sha256:3636363636363636363636363636363636363636363636363636363636363636",
+        "mime_type": "image/png",
+        "width": 2400,
+        "height": 2400,
+        "file_size_bytes": 900000,
+        "roles": ["original", "detail", "fullscreen"],
+        "alt_text": "Artwork displayed in the 3D room"
+      }
+    ],
+    "exhibition_rooms": [
+      {
+        "id": "room-main",
+        "title": "Simple Wall Room",
+        "room_type": "wall",
+        "poster_asset_id": "asset-room-poster",
+        "fallback_page_id": "page-nft",
+        "navigation_mode": "guided_hotspots",
+        "placements": [
+          {
+            "id": "placement-work",
+            "asset_id": "asset-room-work",
+            "detail_page_id": "page-nft",
+            "position": [0, 1.5, -3],
+            "rotation": [0, 0, 0],
+            "size": [1.2, 1.2],
+            "display_mode": "faithful",
+            "label": "Room Work Detail"
+          }
+        ]
+      }
+    ],
+    "navigation": [
+      {
+        "id": "nav-main",
+        "items": [
+          {
+            "label": "Room",
+            "page_id": "page-room"
+          }
+        ]
+      }
+    ],
+    "build_manifest": {
+      "renderer": "6529-cms-static",
+      "renderer_version": "0.0.0-fixture",
+      "route_count": 2,
+      "asset_count": 2,
+      "warnings": []
+    }
+  },
+  "integrity": {
+    "canonicalization": "jcs-rfc8785",
+    "hash_algorithm": "sha256",
+    "payload_hash": "sha256:3737373737373737373737373737373737373737373737373737373737373737",
+    "package_hash": "sha256:3838383838383838383838383838383838383838383838383838383838383838",
+    "note": "Fixture placeholder hash; replace with generated vector before Phase 2."
+  },
+  "signatures": [
+    {
+      "type": "fixture",
+      "signer": "fixture:punk6529",
+      "signature": "fixture-signature-room",
+      "signed_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "storage": [
+    {
+      "provider": "fixture",
+      "uri": "ipfs://bafyfixtureroom",
+      "content_hash": "sha256:3838383838383838383838383838383838383838383838383838383838383838",
+      "provider_content_id": "bafyfixtureroom",
+      "pinned": true,
+      "canonical": true,
+      "recorded_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "provenance": {
+    "builder": "6529-cms-fixture",
+    "builder_version": "0.0.0",
+    "created_at": "2026-06-17T00:00:00Z",
+    "notes": "Valid 3D exhibition room fixture."
+  }
+}

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/legacy-migration.package.json
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/legacy-migration.package.json
@@ -1,0 +1,187 @@
+{
+  "schema": "6529.cms.package.v1",
+  "package_id": "pkg-legacy-migration-v1",
+  "profile": {
+    "handle": "6529museum",
+    "profile_id": "profile-6529museum"
+  },
+  "site": {
+    "title": "6529 Museum Migration Fixture",
+    "description": "A fixture for migrating a hardcoded content family into a profile CMS site.",
+    "base_path": "/6529museum/index.html",
+    "default_locale": "en",
+    "direction": "ltr",
+    "theme": {
+      "mode": "system",
+      "accent": "#444444"
+    },
+    "navigation_id": "nav-main",
+    "metadata_defaults": [
+      {
+        "scope": {
+          "path_prefix": "/6529museum/exhibitions/"
+        },
+        "values": {
+          "search": "include",
+          "robots": "index",
+          "locale": "en"
+        }
+      }
+    ],
+    "required_renderer_capabilities": ["static_blocks", "aliases"]
+  },
+  "payload": {
+    "schema": "6529.cms.payload.v1",
+    "routes": [
+      {
+        "path": "/6529museum/index.html",
+        "kind": "page",
+        "page_id": "page-home"
+      },
+      {
+        "path": "/6529museum/exhibitions/the-memes/index.html",
+        "kind": "page",
+        "page_id": "page-exhibition"
+      },
+      {
+        "path": "/6529museum/legacy/museum/the-memes/index.html",
+        "kind": "alias",
+        "target": "/6529museum/exhibitions/the-memes/index.html"
+      }
+    ],
+    "pages": [
+      {
+        "id": "page-home",
+        "type": "page",
+        "path": "/6529museum/index.html",
+        "metadata": {
+          "title": "6529 Museum",
+          "description": "Migrated museum homepage fixture.",
+          "locale": "en",
+          "canonical_url": "https://6529.io/6529museum/index.html",
+          "social_image_asset_id": "asset-og",
+          "navigation_label": "Museum",
+          "search": "include",
+          "robots": "index"
+        },
+        "blocks": [
+          {
+            "id": "block-home-title",
+            "block_type": "heading",
+            "level": 1,
+            "text": "6529 Museum"
+          }
+        ]
+      },
+      {
+        "id": "page-exhibition",
+        "type": "page",
+        "path": "/6529museum/exhibitions/the-memes/index.html",
+        "metadata": {
+          "title": "The Memes Exhibition",
+          "description": "Migrated exhibition page fixture.",
+          "locale": "en",
+          "canonical_url": "https://6529.io/6529museum/exhibitions/the-memes/index.html",
+          "social_image_asset_id": "asset-og",
+          "navigation_label": "The Memes",
+          "search": "include",
+          "robots": "index"
+        },
+        "source": {
+          "source_packet_id": "source-migration"
+        },
+        "blocks": [
+          {
+            "id": "block-exhibition-title",
+            "block_type": "heading",
+            "level": 1,
+            "text": "The Memes Exhibition"
+          },
+          {
+            "id": "block-migration-note",
+            "block_type": "callout",
+            "tone": "note",
+            "content": "This fixture models a route family migrated from hardcoded pages into profile CMS."
+          }
+        ]
+      }
+    ],
+    "assets": [
+      {
+        "id": "asset-og",
+        "kind": "social_image",
+        "uri": "ipfs://bafyfixturemigration/og.png",
+        "content_hash": "sha256:3939393939393939393939393939393939393939393939393939393939393939",
+        "mime_type": "image/png",
+        "width": 1200,
+        "height": 630,
+        "file_size_bytes": 47000,
+        "roles": ["social"],
+        "alt_text": "Social preview for migrated museum fixture"
+      }
+    ],
+    "navigation": [
+      {
+        "id": "nav-main",
+        "items": [
+          {
+            "label": "Museum",
+            "page_id": "page-home"
+          },
+          {
+            "label": "The Memes",
+            "page_id": "page-exhibition"
+          }
+        ]
+      }
+    ],
+    "source_packets": [
+      {
+        "id": "source-migration",
+        "source_type": "import",
+        "captured_at": "2026-06-17T00:00:00Z",
+        "content_hash": "sha256:4040404040404040404040404040404040404040404040404040404040404040",
+        "legacy_routes": ["/museum/the-memes"]
+      }
+    ],
+    "build_manifest": {
+      "renderer": "6529-cms-static",
+      "renderer_version": "0.0.0-fixture",
+      "route_count": 3,
+      "asset_count": 1,
+      "warnings": ["in-profile legacy alias route included for migration coverage"]
+    }
+  },
+  "integrity": {
+    "canonicalization": "jcs-rfc8785",
+    "hash_algorithm": "sha256",
+    "payload_hash": "sha256:4141414141414141414141414141414141414141414141414141414141414141",
+    "package_hash": "sha256:4242424242424242424242424242424242424242424242424242424242424242",
+    "note": "Fixture placeholder hash; replace with generated vector before Phase 2."
+  },
+  "signatures": [
+    {
+      "type": "fixture",
+      "signer": "fixture:6529museum",
+      "signature": "fixture-signature-migration",
+      "signed_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "storage": [
+    {
+      "provider": "fixture",
+      "uri": "ipfs://bafyfixturemigration",
+      "content_hash": "sha256:4242424242424242424242424242424242424242424242424242424242424242",
+      "provider_content_id": "bafyfixturemigration",
+      "pinned": true,
+      "canonical": true,
+      "recorded_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "provenance": {
+    "builder": "6529-cms-fixture",
+    "builder_version": "0.0.0",
+    "created_at": "2026-06-17T00:00:00Z",
+    "notes": "Valid institutional migration fixture."
+  }
+}

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/minimal-profile-homepage.package.json
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/minimal-profile-homepage.package.json
@@ -1,0 +1,140 @@
+{
+  "schema": "6529.cms.package.v1",
+  "package_id": "pkg-minimal-profile-homepage-v1",
+  "profile": {
+    "handle": "punk6529",
+    "profile_id": "profile-punk6529",
+    "primary_wallet": "0xf58fE66AF1A8C792Cd64D8d706edDabAdFCB2FD0"
+  },
+  "site": {
+    "title": "punk6529",
+    "description": "A profile-native 6529 CMS homepage fixture.",
+    "base_path": "/punk6529/index.html",
+    "default_locale": "en",
+    "direction": "ltr",
+    "theme": {
+      "mode": "system",
+      "accent": "#2f7df6"
+    },
+    "navigation_id": "nav-main",
+    "search": {
+      "enabled": true,
+      "manifest_asset_id": "asset-search"
+    },
+    "required_renderer_capabilities": ["static_blocks", "profile_cms_v1"]
+  },
+  "payload": {
+    "schema": "6529.cms.payload.v1",
+    "routes": [
+      {
+        "path": "/punk6529/index.html",
+        "kind": "page",
+        "page_id": "page-home"
+      }
+    ],
+    "pages": [
+      {
+        "id": "page-home",
+        "type": "page",
+        "path": "/punk6529/index.html",
+        "metadata": {
+          "title": "punk6529",
+          "description": "A portable profile website published by punk6529.",
+          "locale": "en",
+          "canonical_url": "https://6529.io/punk6529/index.html",
+          "social_image_asset_id": "asset-og",
+          "navigation_label": "Home",
+          "search": "include",
+          "robots": "index"
+        },
+        "blocks": [
+          {
+            "id": "block-heading",
+            "block_type": "heading",
+            "level": 1,
+            "text": "punk6529"
+          },
+          {
+            "id": "block-intro",
+            "block_type": "rich_text",
+            "content": "This is the smallest valid profile CMS homepage fixture."
+          }
+        ]
+      }
+    ],
+    "assets": [
+      {
+        "id": "asset-og",
+        "kind": "social_image",
+        "uri": "ipfs://bafyfixtureminimal/og.png",
+        "content_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "mime_type": "image/png",
+        "width": 1200,
+        "height": 630,
+        "file_size_bytes": 42000,
+        "roles": ["social"],
+        "alt_text": "Social preview image for punk6529"
+      },
+      {
+        "id": "asset-search",
+        "kind": "search_index",
+        "uri": "ipfs://bafyfixtureminimal/search.json",
+        "content_hash": "sha256:abababababababababababababababababababababababababababababababab",
+        "mime_type": "application/json",
+        "file_size_bytes": 1200,
+        "roles": ["fallback"]
+      }
+    ],
+    "navigation": [
+      {
+        "id": "nav-main",
+        "items": [
+          {
+            "label": "Home",
+            "page_id": "page-home"
+          }
+        ]
+      }
+    ],
+    "build_manifest": {
+      "renderer": "6529-cms-static",
+      "renderer_version": "0.0.0-fixture",
+      "route_count": 1,
+      "asset_count": 2,
+      "warnings": []
+    }
+  },
+  "integrity": {
+    "canonicalization": "jcs-rfc8785",
+    "hash_algorithm": "sha256",
+    "payload_hash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "package_hash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "note": "Fixture placeholder hash; replace with generated vector before Phase 2."
+  },
+  "signatures": [
+    {
+      "type": "fixture",
+      "signer": "fixture:punk6529",
+      "signature": "fixture-signature-minimal",
+      "signed_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "storage": [
+    {
+      "provider": "fixture",
+      "uri": "ipfs://bafyfixtureminimal",
+      "content_hash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "provider_content_id": "bafyfixtureminimal",
+      "pinned": true,
+      "canonical": true,
+      "recorded_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "provenance": {
+    "builder": "6529-cms-fixture",
+    "builder_version": "0.0.0",
+    "created_at": "2026-06-17T00:00:00Z",
+    "notes": "Minimal valid profile homepage fixture."
+  }
+}
+

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/nft-detail.package.json
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/nft-detail.package.json
@@ -1,0 +1,213 @@
+{
+  "schema": "6529.cms.package.v1",
+  "package_id": "pkg-nft-detail-v1",
+  "profile": {
+    "handle": "punk6529",
+    "profile_id": "profile-punk6529"
+  },
+  "site": {
+    "title": "NFT Detail Fixture",
+    "description": "NFT detail page fixture.",
+    "base_path": "/punk6529/index.html",
+    "default_locale": "en",
+    "direction": "ltr",
+    "theme": {
+      "mode": "system",
+      "accent": "#2f7df6"
+    },
+    "navigation_id": "nav-main",
+    "required_renderer_capabilities": ["nft_detail", "art_display"]
+  },
+  "payload": {
+    "schema": "6529.cms.payload.v1",
+    "routes": [
+      {
+        "path": "/punk6529/index.html",
+        "kind": "page",
+        "page_id": "page-home"
+      },
+      {
+        "path": "/punk6529/nfts/ethereum/0x33fd426905f149f8376e227d0c9d3340aad17af1/1/index.html",
+        "kind": "page",
+        "page_id": "page-nft"
+      }
+    ],
+    "pages": [
+      {
+        "id": "page-home",
+        "type": "page",
+        "path": "/punk6529/index.html",
+        "metadata": {
+          "title": "NFT Detail Fixture Home",
+          "description": "Home route for NFT detail fixture.",
+          "locale": "en",
+          "canonical_url": "https://6529.io/punk6529/index.html",
+          "social_image_asset_id": "asset-og",
+          "navigation_label": "Home",
+          "search": "include",
+          "robots": "index"
+        },
+        "blocks": [
+          {
+            "id": "block-home",
+            "block_type": "heading",
+            "level": 1,
+            "text": "NFT Detail Fixture"
+          }
+        ]
+      },
+      {
+        "id": "page-nft",
+        "type": "nft_detail",
+        "path": "/punk6529/nfts/ethereum/0x33fd426905f149f8376e227d0c9d3340aad17af1/1/index.html",
+        "metadata": {
+          "title": "The Memes #1",
+          "description": "Art-first NFT detail page fixture with provenance.",
+          "locale": "en",
+          "canonical_url": "https://6529.io/punk6529/nfts/ethereum/0x33fd426905f149f8376e227d0c9d3340aad17af1/1/index.html",
+          "social_image_asset_id": "asset-og",
+          "navigation_label": "The Memes #1",
+          "search": "include",
+          "robots": "index"
+        },
+        "blocks": [
+          {
+            "id": "block-media",
+            "block_type": "image",
+            "asset_id": "asset-original",
+            "display_variant_role": "detail"
+          },
+          {
+            "id": "block-nft-ref",
+            "block_type": "nft_reference",
+            "nft_media_profile_id": "nft-profile"
+          }
+        ]
+      }
+    ],
+    "assets": [
+      {
+        "id": "asset-original",
+        "kind": "image",
+        "uri": "ipfs://bafyfixturenft/original.png",
+        "content_hash": "sha256:2121212121212121212121212121212121212121212121212121212121212121",
+        "mime_type": "image/png",
+        "width": 3000,
+        "height": 3000,
+        "file_size_bytes": 1200000,
+        "roles": ["original", "detail", "fullscreen"],
+        "alt_text": "The Memes by 6529 number 1 original artwork"
+      },
+      {
+        "id": "asset-grid",
+        "kind": "image",
+        "uri": "ipfs://bafyfixturenft/grid.webp",
+        "content_hash": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        "mime_type": "image/webp",
+        "width": 800,
+        "height": 800,
+        "file_size_bytes": 120000,
+        "roles": ["grid", "thumbnail"],
+        "alt_text": "Grid derivative for The Memes number 1"
+      },
+      {
+        "id": "asset-og",
+        "kind": "social_image",
+        "uri": "ipfs://bafyfixturenft/og.png",
+        "content_hash": "sha256:2323232323232323232323232323232323232323232323232323232323232323",
+        "mime_type": "image/png",
+        "width": 1200,
+        "height": 630,
+        "file_size_bytes": 45000,
+        "roles": ["social"],
+        "alt_text": "Social preview for The Memes number 1"
+      }
+    ],
+    "nft_media_profiles": [
+      {
+        "id": "nft-profile",
+        "chain_id": 1,
+        "contract": "0x33fd426905f149f8376e227d0c9d3340aad17af1",
+        "token_id": "1",
+        "metadata_uri": "ipfs://bafyfixturenft/metadata.json",
+        "metadata_hash": "sha256:2424242424242424242424242424242424242424242424242424242424242424",
+        "original_asset_ids": ["asset-original"],
+        "display_variants": [
+          {
+            "asset_id": "asset-grid",
+            "role": "grid",
+            "crop_mode": "cover",
+            "source_asset_id": "asset-original"
+          },
+          {
+            "asset_id": "asset-original",
+            "role": "detail",
+            "crop_mode": "preserve",
+            "source_asset_id": "asset-original"
+          }
+        ],
+        "poster_asset_id": "asset-grid",
+        "snapshot": {
+          "owner": "0xf58fE66AF1A8C792Cd64D8d706edDabAdFCB2FD0",
+          "block_number": 22000000,
+          "captured_at": "2026-06-17T00:00:00Z"
+        }
+      }
+    ],
+    "navigation": [
+      {
+        "id": "nav-main",
+        "items": [
+          {
+            "label": "Home",
+            "page_id": "page-home"
+          },
+          {
+            "label": "NFT",
+            "page_id": "page-nft"
+          }
+        ]
+      }
+    ],
+    "build_manifest": {
+      "renderer": "6529-cms-static",
+      "renderer_version": "0.0.0-fixture",
+      "route_count": 2,
+      "asset_count": 3,
+      "warnings": []
+    }
+  },
+  "integrity": {
+    "canonicalization": "jcs-rfc8785",
+    "hash_algorithm": "sha256",
+    "payload_hash": "sha256:2525252525252525252525252525252525252525252525252525252525252525",
+    "package_hash": "sha256:2626262626262626262626262626262626262626262626262626262626262626",
+    "note": "Fixture placeholder hash; replace with generated vector before Phase 2."
+  },
+  "signatures": [
+    {
+      "type": "fixture",
+      "signer": "fixture:punk6529",
+      "signature": "fixture-signature-nft-detail",
+      "signed_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "storage": [
+    {
+      "provider": "fixture",
+      "uri": "ipfs://bafyfixturenft",
+      "content_hash": "sha256:2626262626262626262626262626262626262626262626262626262626262626",
+      "provider_content_id": "bafyfixturenft",
+      "pinned": true,
+      "canonical": true,
+      "recorded_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "provenance": {
+    "builder": "6529-cms-fixture",
+    "builder_version": "0.0.0",
+    "created_at": "2026-06-17T00:00:00Z",
+    "notes": "Valid NFT detail fixture."
+  }
+}
+

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/wallet-gallery.package.json
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/wallet-gallery.package.json
@@ -1,0 +1,247 @@
+{
+  "schema": "6529.cms.package.v1",
+  "package_id": "pkg-wallet-gallery-v1",
+  "profile": {
+    "handle": "punk6529",
+    "profile_id": "profile-punk6529",
+    "primary_wallet": "0xf58fE66AF1A8C792Cd64D8d706edDabAdFCB2FD0"
+  },
+  "site": {
+    "title": "punk6529 Gallery",
+    "description": "A generated multi-wallet gallery fixture.",
+    "base_path": "/punk6529/index.html",
+    "default_locale": "en",
+    "direction": "ltr",
+    "theme": {
+      "mode": "dark",
+      "accent": "#00a86b"
+    },
+    "navigation_id": "nav-main",
+    "required_renderer_capabilities": ["static_blocks", "nft_media_profile"]
+  },
+  "payload": {
+    "schema": "6529.cms.payload.v1",
+    "routes": [
+      {
+        "path": "/punk6529/index.html",
+        "kind": "page",
+        "page_id": "page-gallery"
+      },
+      {
+        "path": "/punk6529/collections/the-memes/index.html",
+        "kind": "page",
+        "page_id": "page-collection"
+      },
+      {
+        "path": "/punk6529/nfts/ethereum/0x33fd426905f149f8376e227d0c9d3340aad17af1/1/index.html",
+        "kind": "page",
+        "page_id": "page-nft-1"
+      }
+    ],
+    "pages": [
+      {
+        "id": "page-gallery",
+        "type": "gallery",
+        "path": "/punk6529/index.html",
+        "metadata": {
+          "title": "punk6529 Gallery",
+          "description": "Generated gallery from profile wallets.",
+          "locale": "en",
+          "canonical_url": "https://6529.io/punk6529/index.html",
+          "social_image_asset_id": "asset-og",
+          "navigation_label": "Gallery",
+          "search": "include",
+          "robots": "index"
+        },
+        "source": {
+          "source_packet_id": "source-wallets"
+        },
+        "blocks": [
+          {
+            "id": "block-gallery-heading",
+            "block_type": "heading",
+            "level": 1,
+            "text": "Gallery"
+          },
+          {
+            "id": "block-wallet-gallery",
+            "block_type": "generated_wallet_gallery",
+            "wallets": [
+              "0xf58fE66AF1A8C792Cd64D8d706edDabAdFCB2FD0",
+              "0xfDF8bcf56aF0584026f9DB963381db72C5cc8e3b"
+            ],
+            "snapshot": {
+              "block_number": 22000000,
+              "captured_at": "2026-06-17T00:00:00Z"
+            },
+            "featured_page_ids": ["page-collection", "page-nft-1"]
+          }
+        ]
+      },
+      {
+        "id": "page-collection",
+        "type": "collection",
+        "path": "/punk6529/collections/the-memes/index.html",
+        "metadata": {
+          "title": "The Memes by 6529",
+          "description": "Collection page generated from a wallet gallery snapshot.",
+          "locale": "en",
+          "canonical_url": "https://6529.io/punk6529/collections/the-memes/index.html",
+          "social_image_asset_id": "asset-og",
+          "navigation_label": "The Memes",
+          "search": "include",
+          "robots": "index"
+        },
+        "blocks": [
+          {
+            "id": "block-collection-ref",
+            "block_type": "collection_reference",
+            "chain_id": 1,
+            "contract": "0x33fd426905f149f8376e227d0c9d3340aad17af1",
+            "title": "The Memes by 6529"
+          }
+        ]
+      },
+      {
+        "id": "page-nft-1",
+        "type": "nft_detail",
+        "path": "/punk6529/nfts/ethereum/0x33fd426905f149f8376e227d0c9d3340aad17af1/1/index.html",
+        "metadata": {
+          "title": "The Memes #1",
+          "description": "NFT detail page generated from a wallet gallery snapshot.",
+          "locale": "en",
+          "canonical_url": "https://6529.io/punk6529/nfts/ethereum/0x33fd426905f149f8376e227d0c9d3340aad17af1/1/index.html",
+          "social_image_asset_id": "asset-og",
+          "navigation_label": "The Memes #1",
+          "search": "include",
+          "robots": "index"
+        },
+        "blocks": [
+          {
+            "id": "block-nft-ref",
+            "block_type": "nft_reference",
+            "nft_media_profile_id": "nft-memes-1"
+          }
+        ]
+      }
+    ],
+    "assets": [
+      {
+        "id": "asset-og",
+        "kind": "social_image",
+        "uri": "ipfs://bafyfixturegallery/og.png",
+        "content_hash": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        "mime_type": "image/png",
+        "width": 1200,
+        "height": 630,
+        "file_size_bytes": 50000,
+        "roles": ["social"],
+        "alt_text": "Social preview for generated wallet gallery"
+      },
+      {
+        "id": "asset-memes-1-original",
+        "kind": "image",
+        "uri": "ipfs://bafyfixturegallery/memes-1.png",
+        "content_hash": "sha256:1212121212121212121212121212121212121212121212121212121212121212",
+        "mime_type": "image/png",
+        "width": 2400,
+        "height": 2400,
+        "file_size_bytes": 900000,
+        "roles": ["original", "detail", "fullscreen"],
+        "alt_text": "The Memes by 6529 card number 1"
+      }
+    ],
+    "nft_media_profiles": [
+      {
+        "id": "nft-memes-1",
+        "chain_id": 1,
+        "contract": "0x33fd426905f149f8376e227d0c9d3340aad17af1",
+        "token_id": "1",
+        "metadata_uri": "ipfs://bafyfixturegallery/metadata/1.json",
+        "metadata_hash": "sha256:1313131313131313131313131313131313131313131313131313131313131313",
+        "original_asset_ids": ["asset-memes-1-original"],
+        "display_variants": [
+          {
+            "asset_id": "asset-memes-1-original",
+            "role": "detail",
+            "crop_mode": "preserve",
+            "source_asset_id": "asset-memes-1-original"
+          }
+        ],
+        "poster_asset_id": "asset-memes-1-original",
+        "snapshot": {
+          "owner": "0xf58fE66AF1A8C792Cd64D8d706edDabAdFCB2FD0",
+          "block_number": 22000000,
+          "captured_at": "2026-06-17T00:00:00Z"
+        }
+      }
+    ],
+    "navigation": [
+      {
+        "id": "nav-main",
+        "items": [
+          {
+            "label": "Gallery",
+            "page_id": "page-gallery"
+          },
+          {
+            "label": "The Memes",
+            "page_id": "page-collection"
+          }
+        ]
+      }
+    ],
+    "source_packets": [
+      {
+        "id": "source-wallets",
+        "source_type": "wallet",
+        "captured_at": "2026-06-17T00:00:00Z",
+        "content_hash": "sha256:1414141414141414141414141414141414141414141414141414141414141414",
+        "wallets": [
+          "0xf58fE66AF1A8C792Cd64D8d706edDabAdFCB2FD0",
+          "0xfDF8bcf56aF0584026f9DB963381db72C5cc8e3b"
+        ]
+      }
+    ],
+    "build_manifest": {
+      "renderer": "6529-cms-static",
+      "renderer_version": "0.0.0-fixture",
+      "route_count": 3,
+      "asset_count": 2,
+      "warnings": []
+    }
+  },
+  "integrity": {
+    "canonicalization": "jcs-rfc8785",
+    "hash_algorithm": "sha256",
+    "payload_hash": "sha256:1515151515151515151515151515151515151515151515151515151515151515",
+    "package_hash": "sha256:1616161616161616161616161616161616161616161616161616161616161616",
+    "note": "Fixture placeholder hash; replace with generated vector before Phase 2."
+  },
+  "signatures": [
+    {
+      "type": "fixture",
+      "signer": "fixture:punk6529",
+      "signature": "fixture-signature-gallery",
+      "signed_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "storage": [
+    {
+      "provider": "fixture",
+      "uri": "ipfs://bafyfixturegallery",
+      "content_hash": "sha256:1616161616161616161616161616161616161616161616161616161616161616",
+      "provider_content_id": "bafyfixturegallery",
+      "pinned": true,
+      "canonical": true,
+      "recorded_at": "2026-06-17T00:00:00Z"
+    }
+  ],
+  "provenance": {
+    "builder": "6529-cms-fixture",
+    "builder_version": "0.0.0",
+    "created_at": "2026-06-17T00:00:00Z",
+    "notes": "Valid generated wallet gallery fixture."
+  }
+}
+

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/hash-test-vectors.md
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/hash-test-vectors.md
@@ -1,0 +1,88 @@
+# Phase 1 Hash Test Vectors
+
+Last updated: 2026-06-17.
+
+## Canonicalization Decision
+
+- Canonicalization: RFC 8785 JSON Canonicalization Scheme.
+- Encoding: UTF-8.
+- Digest: SHA-256.
+- String format: `sha256:<64-lowercase-hex>`.
+
+## Placeholder Fixture Status
+
+The Phase 1 fixture package hashes are placeholders. They intentionally use
+valid hash string shapes so schema and route work can begin.
+
+Before Phase 2 publish work, implementation must generate real vectors:
+
+- Canonical payload bytes.
+- Payload hash.
+- Canonical package bytes for signed package fields.
+- Package hash.
+- Mutation examples that change hash.
+
+## Required Vectors
+
+### Vector 1: Minimal Object Ordering
+
+Input:
+
+```json
+{"b":2,"a":1}
+```
+
+Canonical bytes:
+
+```json
+{"a":1,"b":2}
+```
+
+Expected hash:
+
+```text
+pending implementation
+```
+
+### Vector 2: Unicode String
+
+Input:
+
+```json
+{"title":"6529 Museum"}
+```
+
+Expected hash:
+
+```text
+pending implementation
+```
+
+### Vector 3: Minimal Profile Homepage Payload
+
+Input:
+
+- `fixtures/valid/minimal-profile-homepage.package.json#/payload`
+
+Expected payload hash:
+
+```text
+pending implementation
+```
+
+Expected package hash:
+
+```text
+pending implementation
+```
+
+## Validator Requirements
+
+Hash validator must:
+
+- Reject non-canonical package hash after payload mutation.
+- Reject uppercase hash hex.
+- Reject non-`sha256:` prefixes for V1.
+- Treat CDN delivery URL changes as non-canonical if outside signed package, but
+  reject storage receipt mutations inside signed package.
+

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/schema-index.md
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/schema-index.md
@@ -1,0 +1,74 @@
+# Phase 1 Schema Index
+
+Last updated: 2026-06-17.
+
+## V1 Schema Names
+
+Package:
+
+- `6529.cms.package.v1`
+- `6529.cms.payload.v1`
+
+Agent:
+
+- `6529.cms.agent_patch.v1`
+- `6529.cms.validation_result.v1`
+
+## JSON Schema Files
+
+- `schemas/cms-package-v1.schema.json`: primary package/payload schema with
+  shared definitions for site manifest, page metadata, content entries, routes,
+  storage receipts, signatures, art assets, display variants, NFT media
+  profiles, rooms, placements, interactive policy, source packets, validation
+  inputs, and build manifests.
+- `schemas/agent-patch-v1.schema.json`: patch format for user-owned agents to
+  propose draft changes without rewriting a full package.
+- `schemas/validation-result-v1.schema.json`: structured validation result
+  format for builder UI, agents, CI, and standalone validators.
+
+## Future Schema Split
+
+The current package schema is intentionally consolidated so Phase 1 agents share
+one contract. Once implementation starts, it can split into:
+
+- `site-manifest-v1.schema.json`
+- `page-v1.schema.json`
+- `page-metadata-v1.schema.json`
+- `block-v1.schema.json`
+- `asset-v1.schema.json`
+- `art-asset-v1.schema.json`
+- `display-variant-v1.schema.json`
+- `nft-media-profile-v1.schema.json`
+- `deep-zoom-manifest-v1.schema.json`
+- `exhibition-room-v1.schema.json`
+- `artwork-placement-v1.schema.json`
+- `interactive-policy-v1.schema.json`
+- `route-manifest-v1.schema.json`
+- `navigation-v1.schema.json`
+- `taxonomy-v1.schema.json`
+- `source-packet-v1.schema.json`
+- `storage-receipt-v1.schema.json`
+- `signature-envelope-v1.schema.json`
+- `pointer-event-v1.schema.json`
+- `static-build-manifest-v1.schema.json`
+
+## Required Fixture Coverage
+
+Valid:
+
+- Minimal profile homepage.
+- Wallet gallery with generated collection and NFT routes.
+- NFT detail page with art assets and display variants.
+- 3D exhibition room with faithful 2D fallback.
+
+Invalid:
+
+- Missing signature.
+- Route collision.
+
+## Canonical Hashing
+
+Phase 1 fixtures use placeholder hashes where noted. Implementation must
+replace placeholders with RFC 8785 canonical JSON + SHA-256 vectors before
+Phase 2 renderer/publish work is considered protocol-stable.
+

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/schemas/agent-patch-v1.schema.json
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/schemas/agent-patch-v1.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://6529.io/schemas/cms-agent-patch-v1.schema.json",
+  "title": "6529 CMS Agent Patch v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "patch_id", "target", "operations", "provenance"],
+  "properties": {
+    "schema": { "const": "6529.cms.agent_patch.v1" },
+    "patch_id": { "type": "string", "minLength": 1 },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["draft_id", "base_version"],
+      "properties": {
+        "draft_id": { "type": "string" },
+        "base_version": { "type": "integer", "minimum": 0 },
+        "base_package_hash": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        }
+      }
+    },
+    "operations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["op", "path"],
+        "properties": {
+          "op": {
+            "enum": [
+              "add_page",
+              "remove_page",
+              "update_page_metadata",
+              "add_block",
+              "update_block",
+              "remove_block",
+              "reorder_blocks",
+              "update_navigation",
+              "update_theme",
+              "update_share_metadata",
+              "attach_source_packet",
+              "set_taxonomy_terms"
+            ]
+          },
+          "path": { "type": "string", "minLength": 1 },
+          "value": true,
+          "reason": { "type": "string" },
+          "source_packet_ids": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["created_at", "author_type"],
+      "properties": {
+        "created_at": { "type": "string", "format": "date-time" },
+        "author_type": { "enum": ["user_agent", "local_tool", "human"] },
+        "agent_name": { "type": "string" },
+        "agent_version": { "type": "string" },
+        "notes": { "type": "string" }
+      }
+    }
+  }
+}
+

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/schemas/cms-package-v1.schema.json
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/schemas/cms-package-v1.schema.json
@@ -1,0 +1,591 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://6529.io/schemas/cms-package-v1.schema.json",
+  "title": "6529 CMS Package v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "package_id",
+    "profile",
+    "site",
+    "payload",
+    "integrity",
+    "signatures",
+    "storage",
+    "provenance"
+  ],
+  "properties": {
+    "schema": { "const": "6529.cms.package.v1" },
+    "package_id": { "$ref": "#/$defs/id" },
+    "profile": { "$ref": "#/$defs/profile_ref" },
+    "site": { "$ref": "#/$defs/site_manifest" },
+    "payload": { "$ref": "#/$defs/payload" },
+    "integrity": { "$ref": "#/$defs/integrity" },
+    "signatures": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/signature_envelope" }
+    },
+    "storage": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/storage_receipt" }
+    },
+    "provenance": { "$ref": "#/$defs/package_provenance" }
+  },
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._:-]{1,127}$"
+    },
+    "slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{0,127}$"
+    },
+    "path": {
+      "type": "string",
+      "pattern": "^/[a-zA-Z0-9._~!$&'()*+,;=:@/-]+/index\\.html$"
+    },
+    "uri": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2048
+    },
+    "hash": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "profile_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["handle"],
+      "properties": {
+        "handle": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_-]{1,63}$"
+        },
+        "profile_id": { "type": "string" },
+        "primary_wallet": {
+          "type": "string",
+          "pattern": "^0x[a-fA-F0-9]{40}$"
+        }
+      }
+    },
+    "site_manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "base_path", "default_locale", "theme", "navigation_id"],
+      "properties": {
+        "title": { "type": "string", "minLength": 1, "maxLength": 160 },
+        "description": { "type": "string", "maxLength": 300 },
+        "base_path": { "$ref": "#/$defs/path" },
+        "default_locale": { "type": "string", "pattern": "^[a-z]{2}(-[A-Z]{2})?$" },
+        "direction": { "enum": ["ltr", "rtl"] },
+        "theme": { "$ref": "#/$defs/theme" },
+        "navigation_id": { "$ref": "#/$defs/id" },
+        "metadata_defaults": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/metadata_default" }
+        },
+        "search": { "$ref": "#/$defs/search_config" },
+        "required_renderer_capabilities": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "theme": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "accent"],
+      "properties": {
+        "mode": { "enum": ["light", "dark", "system"] },
+        "accent": {
+          "type": "string",
+          "pattern": "^#[0-9a-fA-F]{6}$"
+        },
+        "tokens": {
+          "type": "object",
+          "additionalProperties": {
+            "type": ["string", "number", "boolean"]
+          }
+        }
+      }
+    },
+    "metadata_default": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scope", "values"],
+      "properties": {
+        "scope": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "collection": { "type": "string" },
+            "path_prefix": { "type": "string" },
+            "page_type": { "type": "string" }
+          }
+        },
+        "values": { "$ref": "#/$defs/page_metadata_partial" }
+      }
+    },
+    "search_config": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "manifest_asset_id": { "$ref": "#/$defs/id" }
+      }
+    },
+    "payload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "routes", "pages", "assets", "navigation"],
+      "properties": {
+        "schema": { "const": "6529.cms.payload.v1" },
+        "routes": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/route" }
+        },
+        "pages": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/page" }
+        },
+        "assets": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/asset" }
+        },
+        "nft_media_profiles": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/nft_media_profile" }
+        },
+        "deep_zoom_manifests": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/deep_zoom_manifest" }
+        },
+        "exhibition_rooms": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/exhibition_room" }
+        },
+        "navigation": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/navigation" }
+        },
+        "taxonomies": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/taxonomy" }
+        },
+        "source_packets": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/source_packet" }
+        },
+        "build_manifest": { "$ref": "#/$defs/build_manifest" }
+      }
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "kind"],
+      "properties": {
+        "path": { "$ref": "#/$defs/path" },
+        "kind": { "enum": ["page", "redirect", "alias"] },
+        "page_id": { "$ref": "#/$defs/id" },
+        "target": { "type": "string" }
+      }
+    },
+    "page": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "path", "metadata", "blocks"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "type": {
+          "enum": [
+            "page",
+            "post",
+            "gallery",
+            "collection",
+            "nft_detail",
+            "card_detail",
+            "room",
+            "transaction"
+          ]
+        },
+        "path": { "$ref": "#/$defs/path" },
+        "metadata": { "$ref": "#/$defs/page_metadata" },
+        "blocks": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/block" }
+        },
+        "source": { "$ref": "#/$defs/source_ref" }
+      }
+    },
+    "page_metadata": {
+      "allOf": [
+        { "$ref": "#/$defs/page_metadata_partial" },
+        {
+          "type": "object",
+          "required": ["title", "description", "locale", "canonical_url"]
+        }
+      ]
+    },
+    "page_metadata_partial": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "title": { "type": "string", "minLength": 1, "maxLength": 160 },
+        "description": { "type": "string", "maxLength": 300 },
+        "locale": { "type": "string", "pattern": "^[a-z]{2}(-[A-Z]{2})?$" },
+        "canonical_url": { "$ref": "#/$defs/uri" },
+        "social_image_asset_id": { "$ref": "#/$defs/id" },
+        "square_social_image_asset_id": { "$ref": "#/$defs/id" },
+        "navigation_label": { "type": "string", "maxLength": 80 },
+        "search": { "enum": ["include", "exclude"] },
+        "robots": { "enum": ["index", "noindex"] },
+        "last_updated": { "type": "string", "format": "date-time" }
+      }
+    },
+    "block": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["id", "block_type"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "block_type": {
+          "enum": [
+            "heading",
+            "rich_text",
+            "image",
+            "video",
+            "audio",
+            "gallery",
+            "quote",
+            "callout",
+            "button_link",
+            "nft_reference",
+            "collection_reference",
+            "transaction_reference",
+            "generated_wallet_gallery",
+            "lightbox_gallery",
+            "deep_zoom",
+            "html_embed",
+            "object_viewer",
+            "room_viewer"
+          ]
+        },
+        "interactive_policy": { "$ref": "#/$defs/interactive_policy" }
+      }
+    },
+    "asset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "kind", "uri", "content_hash", "mime_type"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "kind": {
+          "enum": [
+            "image",
+            "video",
+            "audio",
+            "model",
+            "document",
+            "html",
+            "social_image",
+            "search_index",
+            "build_manifest"
+          ]
+        },
+        "uri": { "$ref": "#/$defs/uri" },
+        "content_hash": { "$ref": "#/$defs/hash" },
+        "mime_type": { "type": "string" },
+        "width": { "type": "integer", "minimum": 1 },
+        "height": { "type": "integer", "minimum": 1 },
+        "duration_seconds": { "type": "number", "minimum": 0 },
+        "file_size_bytes": { "type": "integer", "minimum": 0 },
+        "roles": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "original",
+              "thumbnail",
+              "grid",
+              "detail",
+              "fullscreen",
+              "poster",
+              "tile",
+              "social",
+              "fallback"
+            ]
+          }
+        },
+        "alt_text": { "type": "string" },
+        "decorative": { "type": "boolean" },
+        "rights": { "type": "string" }
+      }
+    },
+    "nft_media_profile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "chain_id", "contract", "token_id", "display_variants"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "chain_id": { "type": "integer", "minimum": 1 },
+        "contract": { "type": "string", "pattern": "^0x[a-fA-F0-9]{40}$" },
+        "token_id": { "type": "string", "minLength": 1 },
+        "metadata_uri": { "$ref": "#/$defs/uri" },
+        "metadata_hash": { "$ref": "#/$defs/hash" },
+        "original_asset_ids": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/id" }
+        },
+        "display_variants": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/display_variant" }
+        },
+        "poster_asset_id": { "$ref": "#/$defs/id" },
+        "snapshot": { "$ref": "#/$defs/snapshot" }
+      }
+    },
+    "display_variant": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["asset_id", "role"],
+      "properties": {
+        "asset_id": { "$ref": "#/$defs/id" },
+        "role": {
+          "enum": ["grid", "detail", "fullscreen", "poster", "social", "tile"]
+        },
+        "crop_mode": { "enum": ["preserve", "cover", "contain"] },
+        "background": { "type": "string" },
+        "source_asset_id": { "$ref": "#/$defs/id" }
+      }
+    },
+    "deep_zoom_manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "source_asset_id", "tile_size", "levels", "format"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "source_asset_id": { "$ref": "#/$defs/id" },
+        "tile_size": { "type": "integer", "minimum": 128 },
+        "levels": { "type": "integer", "minimum": 1 },
+        "format": { "enum": ["jpg", "png", "webp", "avif"] },
+        "tile_uri_template": { "$ref": "#/$defs/uri" },
+        "content_hash": { "$ref": "#/$defs/hash" }
+      }
+    },
+    "exhibition_room": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title", "room_type", "placements", "fallback_page_id"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "title": { "type": "string", "minLength": 1 },
+        "room_type": { "enum": ["wall", "salon", "white_cube", "dark_room"] },
+        "poster_asset_id": { "$ref": "#/$defs/id" },
+        "fallback_page_id": { "$ref": "#/$defs/id" },
+        "navigation_mode": { "enum": ["orbit", "guided_hotspots", "walk"] },
+        "placements": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/artwork_placement" }
+        }
+      }
+    },
+    "artwork_placement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "asset_id", "detail_page_id", "display_mode"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "asset_id": { "$ref": "#/$defs/id" },
+        "nft_media_profile_id": { "$ref": "#/$defs/id" },
+        "detail_page_id": { "$ref": "#/$defs/id" },
+        "position": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": { "type": "number" }
+        },
+        "rotation": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": { "type": "number" }
+        },
+        "size": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": { "type": "number", "exclusiveMinimum": 0 }
+        },
+        "display_mode": { "enum": ["faithful", "gallery"] },
+        "label": { "type": "string" }
+      }
+    },
+    "interactive_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["hydration"],
+      "properties": {
+        "hydration": {
+          "enum": ["static", "client_island", "deferred_island", "sandboxed_embed"]
+        },
+        "requires_user_activation": { "type": "boolean" },
+        "fallback_asset_id": { "$ref": "#/$defs/id" },
+        "sandbox_permissions": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "performance_budget": {
+          "type": "object",
+          "additionalProperties": { "type": ["number", "string"] }
+        }
+      }
+    },
+    "navigation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "items"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "items": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/navigation_item" }
+        }
+      }
+    },
+    "navigation_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label"],
+      "properties": {
+        "label": { "type": "string" },
+        "page_id": { "$ref": "#/$defs/id" },
+        "url": { "$ref": "#/$defs/uri" },
+        "children": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/navigation_item" }
+        }
+      }
+    },
+    "taxonomy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "terms"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "name": { "type": "string" },
+        "terms": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["slug", "label"],
+            "properties": {
+              "slug": { "$ref": "#/$defs/slug" },
+              "label": { "type": "string" },
+              "page_id": { "$ref": "#/$defs/id" }
+            }
+          }
+        }
+      }
+    },
+    "source_packet": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["id", "source_type", "captured_at"],
+      "properties": {
+        "id": { "$ref": "#/$defs/id" },
+        "source_type": {
+          "enum": ["wallet", "nft_metadata", "collection", "transaction", "profile", "import"]
+        },
+        "captured_at": { "type": "string", "format": "date-time" },
+        "content_hash": { "$ref": "#/$defs/hash" }
+      }
+    },
+    "source_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "source_packet_id": { "$ref": "#/$defs/id" },
+        "field_sources": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        }
+      }
+    },
+    "snapshot": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "owner": { "type": "string" },
+        "block_number": { "type": "integer", "minimum": 0 },
+        "captured_at": { "type": "string", "format": "date-time" }
+      }
+    },
+    "build_manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "renderer": { "type": "string" },
+        "renderer_version": { "type": "string" },
+        "route_count": { "type": "integer", "minimum": 0 },
+        "asset_count": { "type": "integer", "minimum": 0 },
+        "warnings": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "integrity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["canonicalization", "hash_algorithm", "payload_hash", "package_hash"],
+      "properties": {
+        "canonicalization": { "const": "jcs-rfc8785" },
+        "hash_algorithm": { "const": "sha256" },
+        "payload_hash": { "$ref": "#/$defs/hash" },
+        "package_hash": { "$ref": "#/$defs/hash" },
+        "note": { "type": "string" }
+      }
+    },
+    "signature_envelope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "signer", "signature", "signed_at"],
+      "properties": {
+        "type": { "enum": ["eip712", "fixture"] },
+        "signer": { "type": "string" },
+        "signature": { "type": "string" },
+        "signed_at": { "type": "string", "format": "date-time" },
+        "domain": { "type": "object", "additionalProperties": true }
+      }
+    },
+    "storage_receipt": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "uri", "content_hash", "recorded_at"],
+      "properties": {
+        "provider": { "enum": ["ipfs", "arweave", "s3", "fixture"] },
+        "uri": { "$ref": "#/$defs/uri" },
+        "content_hash": { "$ref": "#/$defs/hash" },
+        "provider_content_id": { "type": "string" },
+        "pinned": { "type": "boolean" },
+        "canonical": { "type": "boolean" },
+        "recorded_at": { "type": "string", "format": "date-time" }
+      }
+    },
+    "package_provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["builder", "created_at"],
+      "properties": {
+        "builder": { "type": "string" },
+        "builder_version": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" },
+        "notes": { "type": "string" }
+      }
+    }
+  }
+}

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/schemas/validation-result-v1.schema.json
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/schemas/validation-result-v1.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://6529.io/schemas/cms-validation-result-v1.schema.json",
+  "title": "6529 CMS Validation Result v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "valid", "checked_at", "issues"],
+  "properties": {
+    "schema": { "const": "6529.cms.validation_result.v1" },
+    "valid": { "type": "boolean" },
+    "checked_at": { "type": "string", "format": "date-time" },
+    "validator": { "type": "string" },
+    "validator_version": { "type": "string" },
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "package_hash": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "draft_id": { "type": "string" },
+        "package_id": { "type": "string" }
+      }
+    },
+    "issues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["severity", "code", "message", "path"],
+        "properties": {
+          "severity": { "enum": ["error", "warning", "note"] },
+          "code": { "type": "string" },
+          "message": { "type": "string" },
+          "path": { "type": "string" },
+          "page_id": { "type": "string" },
+          "block_id": { "type": "string" },
+          "suggested_fix": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/validation-plan.md
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/validation-plan.md
@@ -1,0 +1,120 @@
+# Phase 1 Validation Plan
+
+Last updated: 2026-06-17.
+
+## Purpose
+
+Define expected validator behavior for schemas, fixtures, hash vectors, agent
+patches, and future FE/BE contract tests.
+
+## Severity Levels
+
+- `error`: blocks publish.
+- `warning`: publish may proceed with explicit user awareness.
+- `note`: optional improvement.
+
+## Error Shape
+
+Validation errors should use:
+
+- `severity`.
+- `code`.
+- `message`.
+- `path`.
+- Optional `page_id`.
+- Optional `block_id`.
+- Optional `suggested_fix`.
+
+The shape is defined in `schemas/validation-result-v1.schema.json`.
+
+## Valid Fixture Expected Results
+
+All files under `fixtures/valid/` should:
+
+- Parse as JSON.
+- Match `schemas/cms-package-v1.schema.json`.
+- Have unique route paths.
+- Include at least one signature.
+- Include at least one storage receipt.
+- Include a route for `/{handle}/index.html`.
+- Include page metadata title, description, locale, and canonical URL.
+
+## Invalid Fixture Expected Results
+
+`fixtures/invalid/missing-signature.package.json`:
+
+- Expected code: `signature.required`.
+- Expected path: `/signatures`.
+- Expected severity: `error`.
+
+`fixtures/invalid/route-collision.package.json`:
+
+- Expected code: `route.duplicate_path`.
+- Expected path: `/payload/routes`.
+- Expected severity: `error`.
+
+`fixtures/invalid/unknown-block.package.json`:
+
+- Expected code: `block.unknown_type`.
+- Expected path: `/payload/pages/0/blocks/0/block_type`.
+- Expected severity: `error`.
+
+## Semantic Validators Needed After Schema Parse
+
+The JSON schema does not cover all protocol invariants. Implementation must add
+semantic validation for:
+
+- Route uniqueness.
+- Route page references.
+- Route kind variants:
+  - `page` requires `page_id` and forbids `target`.
+  - `alias` and `redirect` require `target` and forbid `page_id`.
+- Navigation page references.
+- Asset references.
+- NFT media profile asset references.
+- Room placement references.
+- Canonical route/profile handle match, including alias and redirect routes.
+- Reserved app route conflicts.
+- Storage receipt hash/provider consistency.
+- Signature signer authority.
+- Production rejection of `fixture` signatures.
+- Signer wallet normalization and EIP-55 checksum validation before authority
+  checks.
+- Pointer expected-previous concurrency.
+- Unsafe URL schemes across page canonical URLs, asset URIs, navigation URLs,
+  and URL-bearing fields inside block-specific properties.
+- Unknown URL-bearing properties on extensible blocks.
+- Unknown block types fail closed in V1.
+- Missing media dimensions.
+- Missing poster/fallback for heavy media.
+- Unsupported interactive policy.
+
+## FE/BE Shared Fixture Plan
+
+Phase 1 docs live in the frontend repo. Before production code lands:
+
+1. Move executable schemas to `lib/profile-cms/protocol/v1/` or a shared
+   6529mono package.
+2. Keep JSON fixtures in a location both FE and BE CI can consume.
+3. Add FE tests that parse and render valid fixtures.
+4. Add BE tests that parse, validate, sign-check, store, and pointer-check the
+   same fixtures.
+5. Add a compatibility rule that fixture changes require both FE and BE review.
+
+## Current Artifact Validation Evidence
+
+Completed in this docs-only Phase 0/1 pass:
+
+- All Phase 1 JSON schemas and fixtures parse as JSON.
+- All valid fixtures have unique route paths.
+- `invalid/route-collision.package.json` intentionally duplicates
+  `/punk6529/index.html`.
+
+Not completed in this pass:
+
+- Full JSON Schema validation. `ajv` was not resolvable in the local Node
+  environment, and Python `jsonschema` was also unavailable, so implementation
+  must add an explicit validator dependency or repo-approved validation path
+  before treating the schema as executable.
+- Real RFC 8785 hash vectors. Fixture hashes are placeholder-shaped until the
+  canonicalization implementation lands.

--- a/ops/workstreams/profile-native-cms-roadmap/product-technical-roadmap.md
+++ b/ops/workstreams/profile-native-cms-roadmap/product-technical-roadmap.md
@@ -1,0 +1,4238 @@
+# Profile Native CMS: Product And Technical Roadmap
+
+Last updated: 2026-06-17.
+
+## Executive Summary
+
+Build a CMS that lets every 6529 profile publish a native website, starting at
+`/{handle}/index.html`, without weakening the long-term decentralization goal.
+
+The first launch can use 6529-operated services for speed, indexing, preview,
+upload coordination, and CDN acceleration. The durable artifact must still be a
+signed, content-addressed package that can live on IPFS and/or Arweave, be
+mirrored by anyone, and be rendered by alternative clients.
+
+The product should feel like a consumer-grade site builder for crypto-native
+identity:
+
+- A collector can paste wallet addresses and get a beautiful gallery.
+- An artist can build a portfolio with NFT pages and collection pages.
+- A project can publish docs, news, education, museum, or capital pages without
+  privileged routes in the 6529 app.
+- A user can share an individual NFT, card, collection, room, or transaction
+  page and have it look excellent on social platforms.
+- A power user can export, mirror, inspect, and verify the package.
+
+The main strategic constraint is that this is not "content in a database that
+we later migrate." It is "content packages with an accelerated 6529 publishing
+service."
+
+## Product Principles
+
+### Launch Small, Preserve The Final Shape
+
+The first public version should do fewer things well, but every durable object
+it creates should already match the long-term model.
+
+Acceptable launch shortcuts:
+
+- 6529-operated builder.
+- 6529-operated upload service.
+- 6529-operated pointer API.
+- 6529-operated indexing for gallery generation.
+- 6529 CDN acceleration.
+
+Not acceptable:
+
+- Canonical content that only exists in a 6529 database.
+- Published packages that cannot be exported.
+- Routes that only work inside 6529.io app state.
+- Unsigned primary-site updates.
+- Storage receipts that cannot be independently checked.
+- A builder model that cannot produce a static/decentralized package later.
+
+### Profile Native
+
+Every website belongs to a profile.
+
+- `/{handle}` is the profile page.
+- `/{handle}/index.html` is the profile website.
+- Additional CMS pages live below that profile namespace, such as
+  `/{handle}/collections/fidenza/index.html`.
+- The profile page links to the profile website when a primary site exists.
+- The profile website can link back to the profile page.
+
+### No Privileged Content Families
+
+Museum, About, Education, Blog, News, OM, Capital, and similar sections should
+be profile-authored sites, not hardcoded protocol exceptions.
+
+Examples:
+
+- `6529museum` can publish a museum site.
+- `6529capital` can publish a capital site.
+- `punk6529` can publish a personal site.
+- Any other profile can publish similar site types.
+
+### Decentralized From First Real Publish
+
+The first production publish path should produce durable artifacts:
+
+- Canonical package hash.
+- Payload hash.
+- Storage receipts for IPFS and/or Arweave.
+- Profile signature.
+- Optional 6529 CDN acceleration.
+- A pointer from the profile to the current primary package.
+
+Do not make S3/database content the canonical source and promise a later
+migration.
+
+### Crypto Native, Not Generic CMS
+
+This is not just pages, text, and images. Native first-class objects include:
+
+- Wallets and ENS names.
+- NFTs and collections.
+- Meme Cards, Gradients, NextGen, and future 6529 assets.
+- TDH, REP, nIC, delegations, and protocol reputation signals.
+- Transactions, provenance, minting, transfers, sales, burns, and claims.
+- IPFS, Arweave, content hashes, and package signatures.
+- 2D galleries and eventually 3D exhibition rooms.
+
+### Consumer Simple, Power User Verifiable
+
+Default flows should hide complexity until needed:
+
+- Choose a site type.
+- Connect/profile-authenticate.
+- Add wallets or content.
+- Pick a style.
+- Preview.
+- Publish.
+- Share.
+
+Advanced views should expose:
+
+- Package hash.
+- Storage receipts.
+- Signature details.
+- Version history.
+- Export/download.
+- Mirror instructions.
+- Validation results.
+
+### Open Clients
+
+The CMS cannot assume 6529.io is the only renderer forever.
+
+The package, schemas, renderer contract, and validation rules should be open
+enough that someone can build:
+
+- Alternative web client.
+- Alternative mobile client.
+- Desktop/Electron client.
+- Archive browser.
+- CLI validator.
+- Mirror gateway.
+
+## Non-Goals And Guardrails
+
+### V1 Non-Goals
+
+Do not let V1 turn into an open-ended website builder project.
+
+V1 should not include:
+
+- Arbitrary custom JavaScript in normal pages.
+- Marketplace for third-party templates.
+- Custom domains.
+- Multi-author editorial workflow.
+- Private/gated CMS pages.
+- Full transaction decoder.
+- Full 3D room editor.
+- Paid arbitrary-collection indexing.
+- Onchain pointer registry.
+- Real-time collaborative editing.
+
+These are important later. They should not block the first public launch.
+
+### Hard Guardrails
+
+The following constraints should hold even in V1:
+
+- Published package is immutable.
+- Active profile pointer is mutable and auditable.
+- Package can be downloaded.
+- Package can be validated outside 6529.io.
+- Package records all centralized services used to generate it.
+- Any generated chain/indexer facts include source and snapshot metadata.
+- No route family receives privileged protocol status.
+
+## Success Metrics
+
+### Product Metrics
+
+Track whether users can actually build and share good sites:
+
+- Time from first builder open to published site.
+- Percent of started gallery flows that reach preview.
+- Percent of previews that publish.
+- Percent of published sites with complete share metadata.
+- Number of shared NFT/collection pages.
+- Number of profiles linking from `/{handle}` to `/{handle}/index.html`.
+- Number of published packages with both IPFS and Arweave receipts.
+
+### Decentralization Metrics
+
+Track whether the architecture is moving in the right direction:
+
+- Percent of published packages independently retrievable from IPFS/Arweave.
+- Percent of packages passing standalone validation.
+- Number of packages mirrored by non-6529 infrastructure.
+- Number of clients/renderers able to render package fixtures.
+- Number of pointer registry snapshots exported.
+- Number of builder/indexer facts with explicit source snapshots.
+
+### Quality Metrics
+
+Track whether this is good enough for consumer use:
+
+- Lighthouse or equivalent performance/accessibility baseline for generated
+  pages.
+- Mobile screenshot pass rate for core templates.
+- Social preview success rate for top shared pages.
+- Package render error rate.
+- Publish failure rate by storage provider.
+- Time to recover from failed publish.
+
+## What We Can Build With The Current Foundation
+
+The current implementation supports a broad content model and a first generator.
+
+Ready or near-ready:
+
+- Profile homepage package at `/{handle}/index.html`.
+- Wallet-gallery package generation.
+- Basic page rendering from CMS blocks.
+- Theme and social metadata.
+- Package hash and storage location concepts.
+- Backend pointer for primary package publish.
+
+Representable in schema, but not fully productized:
+
+- General pages.
+- Posts/articles.
+- Collection pages.
+- NFT/card pages.
+- Transaction explainer pages.
+- Room/exhibition pages.
+- Knowledge packet references.
+
+Not yet complete:
+
+- Full builder.
+- Real IPFS/Arweave upload path.
+- Real package signing and verification.
+- Live NFT/indexer integration.
+- Polished 3D gallery runtime.
+- Multi-page site tree editor.
+- Version history UI.
+- Third-party client validator.
+
+## Website Types
+
+### 1. Profile Home Site
+
+Purpose:
+
+Give a profile a personal or institutional homepage separate from the core
+profile UI.
+
+Examples:
+
+- `/punk6529/index.html`
+- `/6529museum/index.html`
+- `/6529capital/index.html`
+
+Core features:
+
+- Hero or intro section.
+- Profile identity summary.
+- Featured links.
+- Featured NFTs, collections, posts, rooms, or transactions.
+- Social share metadata.
+- Button on `/{handle}` profile page.
+
+MVP:
+
+- Template-driven page builder.
+- Profile link integration.
+- Publish signed package.
+
+Later:
+
+- Custom domains.
+- Multiple home templates.
+- Profile-controlled navigation.
+
+### 2. Collector Wallet Gallery
+
+Purpose:
+
+Generate a beautiful gallery from one or more ETH addresses.
+
+Inputs:
+
+- ETH addresses.
+- Optional ENS names.
+- Optional collection filters.
+- Optional hidden tokens.
+- Optional featured collections.
+- Optional statement or curatorial text.
+
+Pages:
+
+- Homepage gallery.
+- All NFTs.
+- Collections index.
+- Collection detail pages.
+- NFT detail pages.
+
+Styles:
+
+- Editorial.
+- Dense market grid.
+- Museum wall.
+- 3D room.
+- Minimal archive.
+
+MVP:
+
+- Address input.
+- NFT/collection import from approved indexers.
+- Generated pages for top collections and individual NFTs.
+- Share metadata for every page.
+
+Later:
+
+- Custom sorting.
+- Trait filters.
+- Per-token captions.
+- Multi-wallet collection merging.
+- Snapshot pinning by block number.
+
+### 3. Artist Or Creator Portfolio
+
+Purpose:
+
+Let creators show work, provenance, essays, exhibitions, and links to mint or
+market pages.
+
+Core features:
+
+- Featured works.
+- Collections and series.
+- Creator statement.
+- Exhibitions.
+- Press/news/posts.
+- External mint/market links.
+
+Crypto-native additions:
+
+- Contract provenance.
+- Mint history.
+- Holder distribution summaries.
+- Selected transactions.
+- Creator wallet attestations.
+
+MVP:
+
+- Portfolio template using manual blocks plus NFT/collection references.
+
+Later:
+
+- Creator-controlled knowledge packets.
+- Edition and series management.
+- Live sales and floor widgets clearly labeled by source.
+
+### 4. Collection Site
+
+Purpose:
+
+A project or curator can publish a standalone collection site.
+
+Examples:
+
+- Fidenza explainer.
+- CryptoPunks collector page.
+- Meme Cards season page.
+- 6529 Gradient collection page.
+
+Core features:
+
+- Collection summary.
+- Visual gallery.
+- Knowledge packet.
+- Contract and chain facts.
+- Creator/project links.
+- Notable tokens.
+- Selected sales and provenance.
+
+MVP:
+
+- Collection page template.
+- Open knowledge packet format.
+- NFT grid and token detail links.
+
+Later:
+
+- Extensible community knowledge packets.
+- Sponsored indexing for arbitrary collections.
+- Curated routes for top collections by market cap and cultural importance.
+
+### 5. Individual NFT Or Card Detail Page
+
+Purpose:
+
+Create a shareable, good-looking page for one token.
+
+Examples:
+
+- `/punk6529/nfts/ethereum/{contract}/{token_id}/index.html`
+- `/6529museum/cards/the-collector/index.html`
+
+Core features:
+
+- Media.
+- Title and collection.
+- Creator.
+- Owner snapshot.
+- Traits or edition facts.
+- Provenance timeline.
+- Related collection link.
+- Share card.
+
+6529-specific opportunities:
+
+- Meme Card pages can be spectacular.
+- Include artist, season, card number, edition, TDH relevance, cultural context,
+  known rememes, related drops, and onchain provenance.
+- Some cards can have custom 2D or 3D pages.
+
+MVP:
+
+- Standard token page from indexer data.
+- Custom rendering for 6529 collections where reliable metadata exists.
+
+Later:
+
+- Per-card immersive templates.
+- Collector notes.
+- Related Waves/discussions.
+- Historical context modules.
+
+### 6. 3D Exhibition Room
+
+Purpose:
+
+Let a profile publish a room-like exhibition experience.
+
+Core features:
+
+- Room layout.
+- Wall placement.
+- Token/media frames.
+- Optional audio/ambient controls.
+- Click through to NFT pages.
+- Mobile-friendly fallback.
+
+MVP:
+
+- 3D room as a template choice that renders a simple, reliable Three.js gallery.
+- 2D fallback for low-power devices and crawler/social contexts.
+- Basic room presets.
+
+Later:
+
+- Multiple connected rooms.
+- Custom frame styles.
+- Curator walkthrough mode.
+- Spatial comments or labels.
+- Exportable room package usable outside 6529.io.
+
+Important engineering rule:
+
+The package should store room data, not a 6529-only runtime assumption. Other
+clients should be able to render the same room differently if needed.
+
+### 7. Editorial, Blog, News, And Education Site
+
+Purpose:
+
+Replace hardcoded editorial/institutional sections with profile-authored sites.
+
+Core features:
+
+- Posts.
+- Pages.
+- Tags/categories.
+- Author/profile identity.
+- Rich media.
+- Social share.
+- Archives.
+
+MVP:
+
+- Manual article builder.
+- Post list template.
+- Basic navigation.
+
+Later:
+
+- RSS/Atom export.
+- Search index export.
+- Multi-author profile groups.
+- Review/publish workflow.
+
+### 8. Transaction Explainer Site
+
+Purpose:
+
+Make block explorer data human-readable.
+
+Core features:
+
+- Transaction summary in plain English.
+- Parties involved.
+- Asset movements.
+- Contract calls.
+- Value changes.
+- Links to chain explorers.
+- Warnings when interpretation is uncertain.
+
+Example use cases:
+
+- "This wallet minted this NFT."
+- "This wallet transferred Punk #1234 to this address."
+- "This sale routed through marketplace X."
+- "This claim created these assets."
+
+MVP:
+
+- Static transaction reference block.
+- Manual summary with structured transaction facts.
+
+Later:
+
+- Automatic decode service.
+- Human-readable event timeline.
+- Contract ABI/plugin registry.
+- Explainability confidence levels.
+- Shareable transaction cards.
+
+### 9. Initiative, Campaign, Or Organization Site
+
+Purpose:
+
+Let a profile publish a focused microsite for an initiative.
+
+Examples:
+
+- Capital initiative.
+- Museum exhibition.
+- Education course.
+- Meme campaign.
+- Event page.
+
+Core features:
+
+- Landing page.
+- Updates/posts.
+- Resources.
+- Team/profile links.
+- Calls to action.
+- NFT/transaction references where relevant.
+
+MVP:
+
+- Page and post templates.
+
+Later:
+
+- Time-based campaign modules.
+- Event schedules.
+- Claim/mint integrations where appropriate.
+
+### 10. Proof, Resume, Or Reputation Site
+
+Purpose:
+
+Let users publish a profile-owned proof page.
+
+Core features:
+
+- Wallet attestations.
+- REP/nIC/TDH summaries.
+- Delegations.
+- Collected/created assets.
+- Contributions.
+- External links.
+
+MVP:
+
+- Profile + wallet + protocol data blocks.
+
+Later:
+
+- Verifiable credentials.
+- Selective disclosure.
+- Portable proof bundle.
+
+## Art And NFT Display System
+
+Detailed display guidance lives in
+`ops/workstreams/profile-native-cms-roadmap/art-nft-display-best-practices.md`.
+
+Core decisions:
+
+- Art display should be art-first, faithful, aspect-ratio preserving, and
+  provenance-rich.
+- NFT media should be modeled as source assets plus display derivatives, not as
+  one URL.
+- 2D V1 should include collection grids, NFT detail pages, lightbox, responsive
+  display variants, posters, provenance panels, and social images.
+- High-resolution still images should support optional deep zoom/IIIF-like tile
+  manifests.
+- 3D V1 should include simple rooms for 2D works, basic object viewer support
+  for GLB/glTF, posters, deferred loading, and 2D fallback.
+- 2D art inside 3D rooms needs a faithful display mode where room lighting does
+  not alter the artwork pixels.
+- Every 3D room work should link to a faithful 2D detail page.
+- Interactive HTML and heavy media should be sandboxed or deferred with static
+  fallback.
+
+Required native entities:
+
+- `art_asset`.
+- `display_variant`.
+- `nft_media_profile`.
+- `deep_zoom_manifest`.
+- `exhibition_room`.
+- `artwork_placement`.
+- `interactive_policy`.
+
+## AI Agent Affordances
+
+6529 should not pay to run open-ended inference for every user's CMS work.
+Instead, the CMS should be extremely friendly to users' own AI tools, local
+models, paid model accounts, agents, and alternative clients.
+
+The product goal is:
+
+- 6529 provides structured facts, schemas, tools, docs, examples, and safe write
+  surfaces.
+- Users point their own AI at those affordances.
+- The AI can inspect, propose, edit, validate, and package a site.
+- The user remains in control of publish/sign actions.
+- Published sites remain static, signed, portable artifacts.
+
+This is better for cost, decentralization, openness, and ecosystem growth.
+
+### What 6529 Should Expose
+
+AI-friendly affordances should include:
+
+- JSON schemas for packages, pages, blocks, assets, knowledge packets, source
+  packets, validation results, and publish requests.
+- Machine-readable route manifests.
+- Stable API endpoints for profile, wallet, NFT, collection, transaction, draft,
+  validation, and package data.
+- MCP server tools for reading profile/CMS state and proposing edits.
+- `SKILL.md` files that teach Codex/Claude-like agents how to build valid 6529
+  CMS packages.
+- Example packages and fixtures.
+- Validation CLI.
+- Standalone renderer or render preview endpoint.
+- Import/export package JSON.
+- Diff format for proposed site edits.
+- Structured error output that agents can repair.
+- Human-readable docs that match the machine-readable contracts.
+
+### MCP Surface
+
+An MCP server for the CMS should expose read tools first:
+
+- `get_profile(handle)`.
+- `get_profile_site(handle)`.
+- `get_cms_package(package_hash)`.
+- `list_profile_site_versions(handle)`.
+- `get_wallet_snapshot(addresses, options)`.
+- `get_collection(contract, chain_id)`.
+- `get_nft(contract, token_id, chain_id)`.
+- `get_transaction(chain_id, tx_hash)`.
+- `get_knowledge_packet(id_or_hash)`.
+- `validate_cms_package(package)`.
+- `render_cms_preview(package_or_draft)`.
+
+Write/propose tools should be explicit and permissioned:
+
+- `create_draft(handle, template)`.
+- `apply_draft_patch(draft_id, patch)`.
+- `validate_draft(draft_id)`.
+- `prepare_publish_candidate(draft_id)`.
+
+Publish tools should require user-controlled auth/signing:
+
+- `request_package_signature(candidate_id)`.
+- `publish_signed_package(candidate_id, signature)`.
+- `rollback_profile_site(handle, package_hash)`.
+
+Rules:
+
+- Read-only tools should be easy to expose broadly.
+- Draft write tools require profile-owner/editor session.
+- Publish/signature tools must never run silently.
+- MCP output should be structured enough for agents to reason over without
+  scraping HTML.
+
+### SKILL.md Affordances
+
+Provide repo-owned skills for agents:
+
+- `profile-cms-site-builder`.
+- `profile-cms-wallet-gallery`.
+- `profile-cms-nft-page`.
+- `profile-cms-collection-page`.
+- `profile-cms-transaction-explainer`.
+- `profile-cms-3d-room`.
+- `profile-cms-validator`.
+- `profile-cms-publisher`.
+
+Each skill should include:
+
+- When to use it.
+- Required source data.
+- Package schema links.
+- Safe editing rules.
+- URL/slug rules.
+- Accessibility requirements.
+- Share metadata requirements.
+- Provenance requirements.
+- Validation command/API.
+- Publish/signing boundaries.
+
+This lets a user's agent build with 6529 conventions without 6529 operating the
+agent or paying for its model calls.
+
+### Source Packets For User Agents
+
+The system should produce compact, hashable source packets that a user can hand
+to their AI.
+
+Source packet examples:
+
+- Wallet holdings packet.
+- NFT metadata packet.
+- Collection knowledge packet.
+- Transaction facts packet.
+- Profile facts packet.
+- Existing draft/package packet.
+- Validation error packet.
+
+Source packets should be:
+
+- JSON.
+- Versioned.
+- Hashable.
+- Small enough for agent context when possible.
+- Explicit about source, timestamp, chain id, block, provider, and confidence.
+- Free of executable HTML/script content.
+
+Agents can use these packets to write captions, organize pages, explain
+transactions, suggest layouts, or produce package patches.
+
+### Agent Patch Format
+
+Agents should not need to rewrite a whole site package for small edits.
+
+Define a patch format for:
+
+- Add page.
+- Remove page.
+- Update page metadata.
+- Add block.
+- Update block.
+- Reorder blocks.
+- Update navigation.
+- Update theme.
+- Update share metadata.
+- Attach knowledge packet.
+- Mark source/provenance.
+
+Patch requirements:
+
+- JSON.
+- Schema-validated.
+- Human previewable.
+- Reversible where practical.
+- Bound to a draft/package version.
+- Rejects edits that would break route or package invariants.
+
+The builder can show an "AI proposed these changes" review screen before the
+user applies them.
+
+### Fact, Interpretation, And Author Copy
+
+Even if 6529 is not running the AI, packages should distinguish:
+
+- Fact: sourced from chain data, NFT metadata, knowledge packets, transaction
+  data, profile data, or explicit user input.
+- Interpretation: agent-authored or human-authored explanation based on facts.
+- Author copy: text the profile publisher takes responsibility for.
+
+This matters because user agents will generate text. The package should still
+make source and responsibility legible.
+
+Examples:
+
+- "Token ID 123 is owned by wallet X at block Y" is a fact.
+- "This appears to be one of the profile's key PFP holdings" is an
+  interpretation.
+- "This Punk is my favorite because it was my first major NFT" is author copy.
+
+### Agent Safety
+
+AI-facing data must be treated as hostile input.
+
+Risks:
+
+- NFT metadata prompt injection.
+- Collection description prompt injection.
+- Malicious HTML/script in metadata.
+- Poisoned knowledge packets.
+- Agent-proposed unsafe URLs.
+- Agent-proposed claims that look like sourced facts but are not.
+
+Mitigations:
+
+- Sanitize source packets.
+- Strip executable content from AI-facing source packets.
+- Label untrusted metadata.
+- Validate all agent patches.
+- Require user review for semantic/content changes.
+- Keep signing and publishing as explicit user actions.
+- Never let agent output bypass renderer sanitization.
+
+### Bring-Your-Own-AI UX
+
+The builder should support users who want AI help without 6529 operating the AI.
+
+Possible UX:
+
+- "Export source packet."
+- "Copy MCP connection details."
+- "Open in local agent."
+- "Import AI patch."
+- "Review proposed changes."
+- "Validate."
+- "Preview."
+- "Sign and publish."
+
+Later:
+
+- Browser extension integration.
+- Desktop/Electron local-agent integration.
+- Local model workflows.
+- Third-party builder integrations.
+
+### What 6529 May Still Generate
+
+6529 can still provide deterministic or bounded helper services that are not
+open-ended user inference:
+
+- Route/page generation from wallet snapshots.
+- Collection grouping from indexer data.
+- Static OpenGraph image rendering from templates.
+- Schema validation.
+- Accessibility checks.
+- Link/media checks.
+- Package canonicalization.
+
+If 6529 later offers optional hosted AI assistance, it should be clearly
+separate from the core CMS protocol and not required for publishing, rendering,
+or portability.
+
+## Framework Prior Art To Adopt
+
+We should study Astro and Starlight for product and architecture ideas, but we
+do not need Astro or Starlight exporters in V1.
+
+Recommended decision:
+
+- Use a framework-neutral CMS package as the protocol.
+- Keep 6529.io rendering inside the current app for integrated profile UX.
+- Build a plain static HTML export path before framework-specific exporters.
+- Use Astro/Starlight as prior art for package design, builder UX, validation,
+  static rendering, docs navigation, search, and i18n.
+- Leave Astro/Starlight adapters as possible community or later official
+  adapters after the package format is stable.
+
+Official prior art reviewed:
+
+- Astro content collections:
+  `https://docs.astro.build/en/guides/content-collections/`.
+- Astro content loader API:
+  `https://docs.astro.build/en/reference/content-loader-reference/`.
+- Astro islands architecture:
+  `https://docs.astro.build/en/concepts/islands/`.
+- Starlight frontmatter:
+  `https://starlight.astro.build/reference/frontmatter/`.
+- Starlight sidebar navigation:
+  `https://starlight.astro.build/guides/sidebar/`.
+- Starlight site search:
+  `https://starlight.astro.build/guides/site-search/`.
+- Starlight i18n:
+  `https://starlight.astro.build/guides/i18n/`.
+- Starlight plugins:
+  `https://starlight.astro.build/resources/plugins/`.
+
+### Why Not Adopt A Framework As Protocol
+
+The same package should be renderable by:
+
+- 6529.io web app.
+- Plain static mirror.
+- Electron client.
+- Mobile client.
+- Third-party client.
+- Local archive browser.
+- Future Astro/Starlight adapter if someone wants one.
+
+If the canonical artifact is an Astro project, a Starlight project, or a Next.js
+route tree, we inherit that framework's assumptions as protocol assumptions.
+That makes alternative clients, mobile rendering, Electron/offline rendering,
+and future migration harder.
+
+### Idea 1: Typed Content Collections
+
+Astro content collections are a strong pattern: related entries share a schema,
+can be queried, can reference each other, and can get editor/type support.
+
+Adopt this natively as CMS collections:
+
+- `pages`.
+- `posts`.
+- `assets`.
+- `nfts`.
+- `collections`.
+- `rooms`.
+- `transactions`.
+- `knowledge_packets`.
+- `source_packets`.
+- `navigation`.
+- `translations`.
+
+Each CMS collection should have:
+
+- JSON schema.
+- Stable id.
+- Slug/path rules.
+- References to other entries.
+- Validation errors.
+- Optional editor/agent JSON schema export.
+
+This gives us the best part of Astro content collections without making the
+package an Astro project.
+
+### Idea 2: Loader Model For Source Data
+
+Astro's loader concept is useful: content can come from local files, remote
+systems, or live data, but is normalized into typed collections.
+
+Adopt this as CMS source loaders:
+
+- Wallet holdings loader.
+- ENS/profile loader.
+- NFT metadata loader.
+- Collection metadata loader.
+- Knowledge packet loader.
+- Transaction facts loader.
+- Media loader.
+- Existing CMS package loader.
+
+Each loader should produce:
+
+- Source packet.
+- Normalized entries.
+- Fetch timestamp.
+- Chain id and block where relevant.
+- Provider/source.
+- Confidence/completeness notes.
+- Content hash where possible.
+
+Important rule:
+
+The published package should include a frozen snapshot of the facts needed to
+render. Live loaders can refresh drafts, but the public site should not require
+live loader access for core rendering.
+
+### Idea 3: Static-First Pages With Interactive Islands
+
+Astro's island pattern is the correct mental model for decentralized CMS sites:
+most of the page should be static HTML, and only specific widgets should hydrate
+or run interactive code.
+
+Adopt this as block-level rendering policy:
+
+- `static`: rendered as HTML, no client JavaScript.
+- `client_island`: isolated interactive widget.
+- `deferred_island`: loaded only after user intent or viewport visibility.
+- `sandboxed_embed`: iframe or equivalent isolation.
+- `static_fallback_required`: interactive block must include fallback HTML.
+
+Examples:
+
+- Rich text: `static`.
+- Image gallery: `static` or small `client_island`.
+- NFT media carousel: `client_island` only if needed.
+- 3D room: `deferred_island` with static fallback.
+- Transaction explainer: mostly `static`.
+- Interactive HTML artwork: `sandboxed_embed`.
+
+Every interactive block should declare:
+
+- Hydration policy.
+- Required assets.
+- Fallback block.
+- Accessibility fallback.
+- Security sandbox.
+- Performance budget.
+
+### Idea 4: Frontmatter-Like Page Metadata
+
+Starlight's page frontmatter pattern is useful: every page has typed metadata
+that drives title, description, SEO, social previews, navigation, and search.
+
+Adopt a `page_metadata` object for every CMS page:
+
+- Title.
+- Description.
+- Slug.
+- Page type.
+- Locale.
+- Canonical URL.
+- Social image.
+- Square social image.
+- Navigation label.
+- Search inclusion.
+- Robots/noindex state.
+- Last updated.
+- Source/provenance.
+
+Validation rules:
+
+- Title required.
+- Description strongly recommended for shareable pages.
+- Social image required for public launch templates.
+- Locale required once i18n exists.
+- Search inclusion must be explicit for private/gated or sensitive pages.
+
+### Idea 5: Generated Navigation With Manual Overrides
+
+Starlight's sidebar model has two useful modes: manual groups and autogenerated
+links from content structure.
+
+Adopt both:
+
+- Auto-generate navigation from the site tree.
+- Let users create manual groups.
+- Let users hide pages from nav.
+- Let users override labels and order.
+- Let templates create default nav.
+- Generate breadcrumbs.
+- Generate previous/next links where useful.
+
+Navigation should be data in the package, not only UI state.
+
+### Idea 6: Static Search Index
+
+Starlight uses a static-site-friendly search model by default. The CMS should
+have the same instinct: generate a local search index as part of the package or
+static export instead of depending on a centralized search service for basic
+site search.
+
+Adopt:
+
+- Package-level search index manifest.
+- Per-page search inclusion flag.
+- Per-block search exclusion flag.
+- Local static search index for public pages.
+- Optional external search adapter later.
+
+Rules:
+
+- Search index must not leak hidden/private/gated plaintext.
+- Search index should be content-addressed with the package.
+- Large gallery sites may use a compact index first: titles, collections,
+  token ids, captions, and tags.
+
+### Idea 7: I18n And Locale Fallbacks
+
+Starlight's i18n model is worth copying early at the data-model level even if
+the UI ships English-only first.
+
+Adopt:
+
+- Site default locale.
+- Page locale.
+- Translation groups across pages.
+- Fallback locale behavior.
+- RTL direction support.
+- Localized navigation labels.
+- Localized social metadata.
+
+Do not bolt this on later if the package route model makes it impossible.
+
+### Idea 8: Plugin Boundary Without Runtime Danger
+
+Starlight's plugin ecosystem is useful, but arbitrary runtime plugins would be
+dangerous for a decentralized CMS renderer.
+
+Adopt a safer plugin concept:
+
+- Source loader plugins.
+- Validator plugins.
+- Template plugins.
+- Export plugins.
+- Static transform plugins.
+- Transaction decoder plugins.
+- Knowledge packet plugins.
+
+Avoid in V1:
+
+- Arbitrary client JavaScript plugins in the main renderer.
+- Plugins that mutate published packages without validation.
+- Plugins that require a centralized service to render.
+
+Plugin manifests should declare:
+
+- Capabilities.
+- Input schemas.
+- Output schemas.
+- Network needs.
+- Security sandbox.
+- Package compatibility.
+
+### Idea 9: Docs-Site Ergonomics
+
+Starlight has good docs ergonomics that should become native CMS blocks and
+template behaviors:
+
+- Table of contents from headings.
+- Breadcrumbs.
+- Previous/next links.
+- Last updated.
+- Edit/source/provenance link.
+- Callouts.
+- Code blocks.
+- Link validation.
+- Broken-anchor validation.
+- Search.
+- Responsive side navigation for docs-heavy sites.
+
+This is how About, Education, Museum, Capital, and protocol docs can feel
+excellent without becoming hardcoded route families.
+
+### Idea 10: Editor And Agent Intellisense
+
+Astro's schema/type-safety direction is exactly what we want for user-owned AI
+agents and human editors.
+
+Adopt:
+
+- Export JSON schemas for every CMS collection.
+- Provide examples next to schemas.
+- Provide `SKILL.md` instructions that point to schemas.
+- Return structured validation errors with paths.
+- Support repair loops: agent proposes patch, validator returns path-specific
+  errors, agent fixes patch.
+- Keep package fixtures small enough for agent context.
+
+### V1 Framework Decision
+
+V1 should not build Astro or Starlight exporters.
+
+V1 should build:
+
+- Framework-neutral CMS package.
+- Native 6529 renderer.
+- Plain static HTML export.
+- Typed CMS collections.
+- Source loader model.
+- Static-first island-style block policies.
+- Page metadata/frontmatter object.
+- Generated navigation with overrides.
+- Basic static search manifest.
+- I18n-ready package fields.
+- Plugin boundaries.
+- AI-agent schemas, skills, source packets, and patch validation.
+
+Later:
+
+- Community Astro adapter.
+- Community Starlight adapter for docs-heavy packages.
+- Official adapters only if there is proven demand.
+
+## Additional Static Site Prior Art To Adopt
+
+We should also steal proven ideas from Jekyll, Hugo, Eleventy, Docusaurus,
+VitePress, MkDocs/Material, Gatsby, and Zola. The point is not to adopt their
+runtimes. The point is to make the native 6529 CMS package feel as mature as
+the best static-site systems.
+
+Official prior art reviewed:
+
+- Jekyll front matter:
+  `https://jekyllrb.com/docs/front-matter/`.
+- Jekyll front matter defaults:
+  `https://jekyllrb.com/docs/configuration/front-matter-defaults/`.
+- Jekyll collections:
+  `https://jekyllrb.com/docs/collections/`.
+- Hugo taxonomies:
+  `https://gohugo.io/content-management/taxonomies/`.
+- Hugo archetypes:
+  `https://gohugo.io/content-management/archetypes/`.
+- Eleventy data cascade:
+  `https://www.11ty.dev/docs/data-cascade/`.
+- Eleventy pagination:
+  `https://www.11ty.dev/docs/pagination/`.
+- Eleventy permalinks:
+  `https://www.11ty.dev/docs/permalinks/`.
+- Eleventy collections:
+  `https://www.11ty.dev/docs/collections/`.
+- Eleventy directory data:
+  `https://www.11ty.dev/docs/data-template-dir/`.
+- Docusaurus sidebar:
+  `https://docusaurus.io/docs/sidebar`.
+- Docusaurus versioning:
+  `https://docusaurus.io/docs/versioning`.
+- Docusaurus i18n:
+  `https://docusaurus.io/docs/i18n/tutorial`.
+- VitePress frontmatter:
+  `https://vitepress.dev/reference/frontmatter-config`.
+- VitePress build-time data loading:
+  `https://vitepress.dev/guide/data-loading`.
+- MkDocs configuration:
+  `https://www.mkdocs.org/user-guide/configuration/`.
+- Material for MkDocs:
+  `https://squidfunk.github.io/mkdocs-material/`.
+- Gatsby content and data:
+  `https://www.gatsbyjs.com/docs/content-and-data/`.
+- Zola overview:
+  `https://www.getzola.org/documentation/getting-started/overview/`.
+
+### Idea 11: Scoped Metadata Defaults
+
+Jekyll's front matter defaults and Eleventy's directory data are very useful.
+They let a site define defaults by scope instead of repeating the same metadata
+on every page.
+
+Adopt a `metadata_defaults` layer:
+
+- Site-level defaults.
+- Collection-level defaults.
+- Directory/path-prefix defaults.
+- Template defaults.
+- Page-level overrides.
+- Block-level overrides where needed.
+
+Precedence should be explicit:
+
+1. Computed/derived values.
+2. Page/block explicit values.
+3. Draft/template local values.
+4. Collection defaults.
+5. Path-prefix defaults.
+6. Site defaults.
+7. Protocol defaults.
+
+Rules:
+
+- The resolved metadata should be materialized during validation/export.
+- The package should preserve both raw defaults and resolved values where useful.
+- Validation errors should identify whether a value came from a default or an
+  explicit page override.
+- Authors and agents should be able to inspect the resolved output.
+
+Good uses:
+
+- Default layout for all collection pages.
+- Default social image for all posts.
+- Default search inclusion for docs pages.
+- Default locale and direction.
+- Default NFT page template for a collection.
+
+### Idea 12: Archetypes As Creation Recipes
+
+Hugo archetypes are a good model for new-content creation. In 6529 terms,
+archetypes should be creation recipes for pages and sites.
+
+Adopt CMS archetypes:
+
+- New profile homepage.
+- New collector gallery.
+- New post.
+- New collection page.
+- New NFT page.
+- New transaction explainer.
+- New 3D room.
+- New docs section.
+
+Each archetype should define:
+
+- Initial page/block structure.
+- Required source data.
+- Default metadata.
+- Validation checklist.
+- Suggested navigation placement.
+- Optional source loader.
+- Optional AI-agent instructions.
+
+This is different from a visual template:
+
+- Archetype: how to create a new thing with correct structure.
+- Template: how a thing looks.
+- Theme: shared visual tokens.
+
+### Idea 13: Taxonomies, Tags, And Facets
+
+Hugo's taxonomy model is directly useful for galleries and editorial sites.
+
+Adopt first-class taxonomies:
+
+- Tags.
+- Categories.
+- Series.
+- Collections.
+- Artists.
+- Wallets.
+- Contracts.
+- Seasons.
+- Traits.
+- Chains.
+- Media types.
+- Exhibition rooms.
+- Custom profile-defined taxonomies.
+
+Each taxonomy should support:
+
+- Term pages.
+- Term metadata.
+- Term ordering.
+- Term aliases.
+- Term social metadata.
+- Search inclusion.
+- Source/provenance.
+
+Crypto-native examples:
+
+- `/punk6529/tags/ai-art/index.html`.
+- `/punk6529/series/fidenzas/index.html`.
+- `/6529museum/seasons/memes-season-1/index.html`.
+- `/punk6529/contracts/ethereum/0xabc/index.html`.
+
+Rules:
+
+- Taxonomies are content organization, not protocol authority.
+- Terms can be generated from chain data but should be editable/curatable.
+- High-cardinality traits may need compact indexes instead of full page
+  generation by default.
+
+### Idea 14: Safe Shortcodes As Block Macros
+
+Hugo shortcodes and Jekyll includes show a useful pattern: authors need compact
+ways to insert richer content without hand-building full blocks.
+
+Adopt safe block macros:
+
+- NFT card.
+- Collection card.
+- Wallet card.
+- Transaction summary.
+- Callout.
+- Quote.
+- Button group.
+- Gallery slice.
+- Table of contents.
+- Video/media embed.
+
+Rules:
+
+- Macros expand to normal validated CMS blocks.
+- No arbitrary template execution in V1.
+- Macro inputs are schema-validated.
+- Macro expansion is deterministic.
+- Expanded output is visible in preview and package validation.
+
+This gives authors and AI agents a concise authoring surface without creating a
+dangerous runtime template system.
+
+### Idea 15: Data Cascade And Override Semantics
+
+Eleventy's data cascade is valuable because it makes data precedence explicit.
+6529 needs the same discipline for package data, generated data, user edits,
+template defaults, and source snapshots.
+
+Adopt a CMS data cascade:
+
+- Protocol defaults.
+- Site defaults.
+- Theme defaults.
+- Archetype defaults.
+- Source loader data.
+- Knowledge packet data.
+- Generated page data.
+- User-authored draft data.
+- Page/block explicit overrides.
+- Computed/resolved values.
+
+Rules:
+
+- Precedence order must be documented.
+- Each resolved field should know its source where practical.
+- Users must be able to override generated/imported values.
+- Refreshing source data must not silently overwrite explicit user edits.
+- Agent patches must declare which layer they modify.
+
+This is especially important for wallet gallery generation and knowledge
+packets.
+
+### Idea 16: Pagination And Large Collection Generation
+
+Eleventy's pagination model is useful for large wallets, large collections, and
+search/tag pages.
+
+Adopt pagination as a package-level route generation primitive:
+
+- Page size.
+- Sort key.
+- Filter.
+- Source collection.
+- Route pattern.
+- Previous/next links.
+- Canonical first page.
+- Search/noindex policy for deep pages.
+
+Examples:
+
+- All NFTs page with 60 items per page.
+- Collection page with trait filters.
+- Blog archive by year.
+- Transaction list.
+- Tag page.
+
+Rules:
+
+- Generated pagination routes must be deterministic.
+- Route collisions must fail validation.
+- Large high-cardinality routes should be opt-in.
+- Deep pagination should not bloat packages unnecessarily.
+
+### Idea 17: Permalinks And Collision Detection
+
+Eleventy and Jekyll both reinforce that stable URLs matter. For 6529, this is
+even more important because packages are mirrored and content-addressed.
+
+Adopt strict permalink rules:
+
+- Every page has a resolved output path.
+- Every route ends in `index.html` for static export.
+- Slug generation is deterministic.
+- Route collisions are validation errors.
+- Route redirects/aliases are package data.
+- Hidden pages can exist without navigation links.
+- Some entries can be processed but not emitted as standalone pages.
+
+Support aliases:
+
+- Old app route.
+- Old CMS route.
+- Custom short route.
+- Legacy collection slug.
+
+This helps migrate Museum/Capital/About content without breaking links.
+
+### Idea 18: Docs Versioning As Package Version Channels
+
+Docusaurus versioning is useful, but it also warns against unnecessary
+complexity. 6529 should not version every casual site like docs software.
+
+Adopt version channels only where they help:
+
+- Protocol docs.
+- Education docs.
+- Legal/policy pages.
+- Museum exhibitions.
+- Capital documentation.
+- API/reference docs.
+
+Model:
+
+- Current version.
+- Frozen versions.
+- Version label.
+- Version route prefix where needed.
+- Versioned navigation.
+- Versioned search index.
+- Version provenance.
+
+Rules:
+
+- Ordinary profile sites use package history, not docs-style version channels.
+- Version channels are opt-in.
+- Versioned docs must remain reachable after new publishes.
+
+### Idea 19: Site Config Manifest
+
+MkDocs' simple YAML config is a useful mental model. A CMS package should have a
+clear site-level manifest that can be read before page content.
+
+Adopt `site_manifest`:
+
+- Site title.
+- Profile id/handle.
+- Default locale.
+- Base route.
+- Theme id/tokens.
+- Navigation root.
+- Content collections.
+- Search settings.
+- Taxonomy settings.
+- Storage/provenance summary.
+- Package version.
+- Required renderer capabilities.
+
+The manifest should be:
+
+- Small.
+- JSON.
+- Validated first.
+- Useful for agents.
+- Useful for mirrors.
+- Useful for Electron/offline clients.
+
+### Idea 20: Source Plugin Model Without GraphQL Lock-In
+
+Gatsby's source plugin ecosystem has the right high-level idea: bring many data
+sources into one normalized content layer. The part to avoid is making GraphQL
+or a heavy build system the protocol.
+
+Adopt source plugins/loaders:
+
+- Wallets.
+- ENS.
+- NFT metadata.
+- Market data.
+- Transactions.
+- Knowledge packets.
+- Markdown/imported docs.
+- Existing package.
+- External JSON.
+
+Rules:
+
+- Loader outputs source packets and normalized collection entries.
+- Loader output is hashable.
+- Loader output can be frozen into package data.
+- Loader provenance is visible.
+- Loader does not run during public page rendering unless explicitly marked as
+  live enhancement.
+
+### Idea 21: Single-Binary / Local-First Tooling
+
+Zola's single-binary and database-free posture is aligned with 6529
+decentralization. We should eventually provide simple local tooling.
+
+Adopt:
+
+- Standalone validator binary or easily runnable CLI.
+- Static exporter CLI.
+- Package inspector CLI.
+- Local preview server.
+- Mirror/pin helper.
+- Package diff tool.
+
+Target user:
+
+- Power user.
+- Mirror operator.
+- Electron user.
+- Alternative client developer.
+- AI agent running locally.
+
+The CLI should not require the full 6529 frontend repo to validate or render a
+package.
+
+### Idea 22: Markdown Compatibility Without Markdown Lock-In
+
+Jekyll, Hugo, MkDocs, VitePress, Docusaurus, Zola, and Eleventy all benefit from
+Markdown being easy to write and easy for agents to edit.
+
+Adopt:
+
+- Markdown import.
+- Markdown export for docs/posts where possible.
+- Frontmatter-compatible metadata export.
+- CommonMark-ish subset for portable prose.
+- MDX/HTML only as advanced/sandboxed import, not core protocol.
+
+Rules:
+
+- The package canonical form remains structured JSON.
+- Markdown is an authoring/import/export format.
+- Rich crypto blocks should not be lossy when round-tripping through Markdown;
+  use safe block macros where needed.
+
+### Idea 23: Theme Override Slots, Not Runtime Swizzling
+
+Docusaurus swizzling and theme override systems show that advanced users want to
+override pieces of UI. For 6529, arbitrary component replacement is too risky
+for core rendering.
+
+Adopt controlled slots:
+
+- Header slot.
+- Footer slot.
+- Hero slot.
+- Collection card slot.
+- NFT card slot.
+- Social share card style.
+- Docs sidebar style.
+- Gallery tile style.
+
+Rules:
+
+- Slots accept schema-defined blocks or template ids.
+- No arbitrary React/Vue/runtime component injection in V1.
+- Slot output must pass renderer validation.
+- Static export must work with the slot.
+
+### Idea 24: Build Artifacts As First-Class Outputs
+
+Most SSGs produce build output, but do not always make the build manifest a
+first-class user artifact. We should.
+
+Adopt a build manifest:
+
+- Package hash.
+- Renderer version.
+- Static export version.
+- Route list.
+- Asset list.
+- Search index hash.
+- Sitemap hash.
+- OpenGraph image list.
+- Warnings.
+- Build timestamp.
+
+This helps:
+
+- Mirrors.
+- Debugging.
+- AI agents.
+- CI.
+- Electron cache.
+- Long-term archival.
+
+### Updated V1 Static-Site Decision
+
+V1 should build the native versions of the best SSG ideas:
+
+- Typed content collections.
+- Site manifest.
+- Scoped metadata defaults.
+- Archetypes.
+- Taxonomies.
+- Data cascade and override semantics.
+- Static-first island-style blocks.
+- Safe block macros.
+- Deterministic pagination.
+- Permalinks and collision detection.
+- Static search manifest.
+- I18n-ready fields.
+- Source loader/plugin boundary.
+- Markdown import/export for docs/posts.
+- Plain static HTML export.
+- Standalone validator/exporter direction.
+
+V1 should not build:
+
+- Jekyll/Hugo/Eleventy/Astro/Starlight/Docusaurus/VitePress/MkDocs/Gatsby/Zola
+  exporters.
+- Arbitrary template runtime.
+- Arbitrary client plugin execution.
+- GraphQL as a required protocol layer.
+
+## Primary User Journeys
+
+### Journey 1: Collector Publishes A Gallery
+
+Happy path:
+
+1. Profile owner opens website builder from their profile.
+2. Chooses "Collector gallery."
+3. Adds one or more wallets or ENS names.
+4. Reviews imported collections and NFTs.
+5. Hides spam/unwanted assets.
+6. Picks a style.
+7. Reviews generated home, collection, and NFT pages.
+8. Edits title, intro, featured works, and share image.
+9. Previews desktop, mobile, and social card.
+10. Publishes.
+11. Profile page now shows a website button.
+
+Must feel easy:
+
+- Wallet resolution.
+- Spam filtering.
+- Page generation.
+- Share metadata.
+- Publish.
+
+Advanced details stay available but secondary:
+
+- Snapshot block.
+- Indexer source.
+- Package hash.
+- Storage receipts.
+- Signature.
+
+### Journey 2: Institution Migrates A Hardcoded Section
+
+Example:
+
+Move a hardcoded Museum or Capital page family into a profile-owned CMS site.
+
+Happy path:
+
+1. Create or use the existing institutional profile.
+2. Import existing page content into CMS pages.
+3. Recreate navigation as site navigation.
+4. Attach profile identity and publishing authority.
+5. Publish package.
+6. Redirect or link old hardcoded routes to the new profile site.
+7. Keep old routes stable during transition.
+
+Acceptance criteria:
+
+- The institutional profile owns the site.
+- The published package is portable.
+- No new privileged route family is introduced.
+- Existing SEO/social links have a migration strategy.
+- Content editors use the same builder as every other profile.
+
+### Journey 3: Artist Publishes A Portfolio
+
+Happy path:
+
+1. Artist chooses "Creator portfolio."
+2. Adds creator wallet(s), collection contracts, and manual works.
+3. Picks featured works and series.
+4. Adds artist statement and links.
+5. Generates collection and NFT pages.
+6. Publishes a signed site.
+
+Important UX:
+
+- Manual curation must override automatic ordering.
+- Creator identity should be clear but not require protocol-level verification.
+- External sales/mint links must be clearly external.
+
+### Journey 4: User Shares One NFT Page
+
+Happy path:
+
+1. User opens an NFT/card detail page.
+2. Page shows media, title, collection, owner snapshot, provenance, and context.
+3. User copies URL or shares to social.
+4. Social preview is attractive and accurate.
+
+Acceptance criteria:
+
+- Page does not require the builder to be open.
+- Page has stable `index.html` route.
+- OpenGraph tags render server-side.
+- Crawler gets a meaningful image and description.
+
+### Journey 5: Power User Verifies A Site
+
+Happy path:
+
+1. User opens provenance panel.
+2. Downloads package or opens IPFS/Arweave link.
+3. Checks package hash and signature.
+4. Runs standalone validator.
+5. Mirrors package if desired.
+
+Acceptance criteria:
+
+- Verification does not depend on hidden 6529 admin tools.
+- Signature and package hash are visible.
+- Storage locations are visible.
+- Validator docs are linked.
+
+## Migration Of Existing Content Families
+
+### Goal
+
+Move content-heavy/static-ish app sections into profile-native CMS sites without
+breaking the existing public web surface.
+
+Candidate route families:
+
+- Museum.
+- Capital.
+- About.
+- Education.
+- Blog.
+- News.
+- OM.
+
+### Migration Strategy
+
+Step 1: Map ownership.
+
+- Decide which profile owns each section.
+- Example: Museum content belongs to `6529museum`.
+- Example: Capital content belongs to `6529capital`.
+- General protocol docs may belong to a protocol/profile account chosen by the
+  team.
+
+Step 2: Inventory content.
+
+- List current routes.
+- List assets.
+- List metadata and social previews.
+- List SEO-sensitive URLs.
+- List forms, dynamic widgets, or backend dependencies.
+
+Step 3: Convert to CMS package.
+
+- Import content into CMS pages.
+- Preserve page titles, descriptions, and share images.
+- Replace hardcoded app-only widgets with safe CMS blocks.
+- Record source route and migration provenance.
+
+Step 4: Publish under profile namespace.
+
+- Publish to `/{profile}/index.html` and subpages.
+- Store package on IPFS/Arweave.
+- Sign by profile authority.
+- Add provenance panel.
+
+Step 5: Bridge old routes.
+
+- Existing app routes can redirect, canonicalize, or link to profile CMS pages.
+- Route behavior should be explicit per section.
+- Do not create new hardcoded content systems during migration.
+
+Step 6: Retire privileged implementation.
+
+- Remove old bespoke page code after traffic, SEO, and redirects are stable.
+- Keep route shims only where needed for link continuity.
+
+### Migration Acceptance Criteria
+
+- The migrated section can be rendered from package data.
+- The owning profile can publish future updates through the CMS.
+- Existing important URLs have redirect/canonical behavior.
+- Social previews do not regress.
+- Decentralized storage receipts exist for the published package.
+- The old hardcoded route family no longer needs bespoke content deployment.
+
+## URL And Routing Model
+
+### Required Routes
+
+The core convention:
+
+- `/{handle}`: existing profile page.
+- `/{handle}/index.html`: primary CMS website.
+- `/{handle}/{path}/index.html`: CMS subpage.
+
+Examples:
+
+- `/punk6529/index.html`
+- `/punk6529/collections/fidenza/index.html`
+- `/punk6529/nfts/ethereum/0xabc/123/index.html`
+- `/punk6529/rooms/genesis/index.html`
+- `/punk6529/posts/why-open-metaverse/index.html`
+
+### Why `index.html`
+
+`index.html` is useful because:
+
+- It matches static site export conventions.
+- It makes mirrorability obvious.
+- It reduces conflicts with existing app routes.
+- It signals "website page" rather than "app profile tab."
+- It maps cleanly to IPFS/Arweave directory packages.
+
+### Profile Page Integration
+
+When a profile has a primary CMS package:
+
+- Show a clear website button on `/{handle}`.
+- The button links directly to `/{handle}/index.html`.
+- The profile page stays the profile page.
+- The CMS site should not replace the profile page.
+
+### Canonical URLs
+
+Each page should carry:
+
+- 6529 wrapper URL: `https://6529.io/{handle}/.../index.html`.
+- Content address: `ipfs://...` and/or `ar://...`.
+- Optional custom domain later.
+- Package version and hash.
+
+Canonical selection:
+
+- Use 6529 wrapper as canonical for SEO while the product is 6529-hosted.
+- Expose decentralized addresses in provenance UI and machine-readable metadata.
+- Allow custom domain canonical later if profile chooses it.
+
+### Route Resolution Protocol
+
+When a user requests `/{handle}/index.html` or a CMS subpage:
+
+1. Resolve `{handle}` to a profile id.
+2. Resolve the profile's active CMS pointer.
+3. Fetch the referenced package from local cache, CDN, IPFS, or Arweave.
+4. Validate package hash and schema.
+5. Resolve the requested path inside the package route manifest.
+6. Render the page with the CMS renderer.
+7. Render safe error states if any step fails.
+
+Resolution fallback order for 6529.io:
+
+1. Hot in-memory or edge cache.
+2. 6529 CDN/accelerated object.
+3. IPFS gateway.
+4. Arweave gateway.
+5. Backend package fetch API.
+6. Error with provenance and retry options.
+
+Resolution fallback order for Electron/offline:
+
+1. Local package cache.
+2. User-configured IPFS node or gateway.
+3. User-configured Arweave gateway.
+4. Optional 6529 API/CDN if the user allows network acceleration.
+5. Error with clear missing-package details.
+
+The renderer should never trust the fallback source by location alone. It must
+validate content against the pointer/package hash after fetch.
+
+### Route Conflict Rules
+
+CMS routes must not silently override core app routes.
+
+Rules:
+
+- `/{handle}` always remains the profile page.
+- `/{handle}/index.html` is reserved for the profile's primary CMS site.
+- CMS subpages require `index.html` suffix.
+- Existing app routes such as `/about`, `/waves`, `/memes`, `/nextgen`, and
+  admin/API routes remain app-owned.
+- If a handle conflicts with a core route, the core route wins unless product
+  explicitly reserves a profile namespace strategy.
+
+This route model keeps the CMS powerful while avoiding ambiguous app behavior.
+
+## Package Model
+
+### Core Entities
+
+The product should use a small set of durable concepts across FE, BE, storage,
+and future clients.
+
+Profile site:
+
+- Belongs to one profile.
+- Has one active primary pointer.
+- Has zero or more drafts.
+- Has zero or more published versions.
+
+Draft:
+
+- Mutable editing state.
+- Stored by 6529 services during the launch phase.
+- Not the canonical decentralized artifact.
+- Can be discarded, previewed, or published.
+
+Package:
+
+- Immutable published artifact.
+- Content addressed.
+- Signed by profile authority.
+- Stored on IPFS and/or Arweave.
+- Renderable outside 6529.io.
+
+Page:
+
+- Route-addressable item inside a package.
+- Has page type, slug, title, blocks, metadata, and optional data bindings.
+
+Block:
+
+- Small renderable unit inside a page.
+- Must be schema-validated.
+- Must be safe to render as untrusted content.
+
+Asset:
+
+- Image, video, model, document, social image, or other media.
+- Should have content hash and storage locations where possible.
+
+Pointer:
+
+- Mutable reference from profile to active package.
+- Initially served by backend.
+- Later replicated to decentralized profile state.
+
+Knowledge packet:
+
+- Versioned context object for a collection, token, artist, or concept.
+- Open and hashable.
+- Can be bundled into a package or referenced by hash.
+
+Indexer snapshot:
+
+- The data facts used when generating a page from chain/indexer state.
+- Includes source, block/time, chain, contracts, and hash where practical.
+
+### Package Boundary
+
+A published site package should include:
+
+- Site manifest.
+- Page manifests/content.
+- Asset manifest.
+- Theme.
+- Navigation.
+- Share metadata.
+- Provenance.
+- Package hash.
+- Payload hash.
+- Signature envelope.
+- Storage receipts.
+
+### Immutability
+
+Published packages are immutable.
+
+Updating a site creates a new package version and moves a profile pointer to the
+new package.
+
+This gives:
+
+- Auditability.
+- Rollback.
+- Mirrorability.
+- Deterministic validation.
+
+### Profile Pointer
+
+The pointer is mutable state:
+
+- Profile handle/id.
+- Active package hash.
+- IPFS CID.
+- Arweave transaction id.
+- Version.
+- Signer.
+- Published timestamp.
+- Previous pointer/package.
+
+The pointer can initially live in the backend. Long term, it should be
+replicated into the 6529 special-purpose chain or another decentralized profile
+state layer.
+
+### Hashing And Canonicalization
+
+Need deterministic package hashing:
+
+- Canonical JSON serialization.
+- Stable ordering.
+- No timestamps inside the hashed payload unless they are intentional content.
+- Content hashes for every asset.
+- Hash references rather than mutable URLs when possible.
+
+### Signatures
+
+MVP:
+
+- EIP-191 or EIP-712 signature from a profile-authorized wallet.
+- Backend verifies signer can publish for profile.
+- Package stores signature envelope.
+
+Later:
+
+- Delegated publishing keys.
+- Multi-sig approval for institutional profiles.
+- Revocation and recovery.
+- Offline signing support.
+
+### Storage Receipts
+
+A package should be able to record multiple storage locations:
+
+- IPFS CID.
+- Arweave transaction id.
+- 6529 CDN URL.
+- Local fixture/dev URL.
+
+Storage receipts should include:
+
+- Provider.
+- URI.
+- Content hash/CID.
+- Timestamp.
+- Pin/permanence status.
+- Uploader service id where relevant.
+
+### Content Lifecycle
+
+The CMS should treat draft, preview, publish, and rollback as distinct states.
+
+Draft:
+
+- Mutable.
+- Stored in backend for convenience.
+- Not canonical.
+- Can reference temporary uploads.
+- Can be deleted.
+
+Preview:
+
+- Rendered from draft state or an unsigned temporary package.
+- May use temporary assets.
+- Must be visually close to publish output.
+- Must clearly indicate it is not published.
+
+Publish candidate:
+
+- Fully validated.
+- Canonically serialized.
+- Has all required assets resolved.
+- Ready to hash and sign.
+
+Published package:
+
+- Immutable.
+- Signed.
+- Stored on decentralized storage.
+- Has package and payload hashes.
+- Can be mirrored.
+
+Pointer update:
+
+- Moves active profile site to a package.
+- Records signer, timestamp, previous pointer, and validation status.
+- Is the only mutable step in normal publish.
+
+Rollback:
+
+- Points profile back to an earlier package.
+- Does not mutate the old package.
+- Creates a new pointer event.
+
+Deletion:
+
+- Can remove drafts from 6529 services.
+- Can stop 6529.io acceleration.
+- Cannot guarantee removal from IPFS/Arweave or third-party mirrors.
+- Must be explained clearly to publishers.
+
+### Package Compatibility
+
+Versioning rules:
+
+- Schema version is required.
+- Renderer must declare supported schema versions.
+- Breaking schema changes require a new major version.
+- Old packages should remain renderable or receive a deterministic migration.
+- A package corpus should be kept for regression tests.
+
+Package migration rules:
+
+- Never rewrite a previously published package in place.
+- If migration is needed, create a new package with migration provenance.
+- Keep original package hash visible in migration metadata.
+
+## Builder Product Spec
+
+### Builder UX Goal
+
+The builder should not feel like a JSON package editor. It should feel like a
+guided publishing tool that happens to produce excellent decentralized artifacts.
+
+The default user should be able to make a good site without understanding:
+
+- IPFS.
+- Arweave.
+- Content hashes.
+- Signature envelopes.
+- Route manifests.
+- OpenGraph metadata.
+
+The advanced user should still be able to inspect all of those things before
+and after publishing.
+
+### Builder Mental Model
+
+Use a simple four-part mental model:
+
+1. Site: the whole profile website.
+2. Pages: home, collections, NFTs, posts, rooms, and custom pages.
+3. Blocks: content units inside each page.
+4. Publish: immutable package plus mutable profile pointer.
+
+Avoid exposing internal package terminology in the happy path. Use human words
+in the UI:
+
+- "Website" instead of "CMS package."
+- "Publish" instead of "write pointer."
+- "Permanent storage" instead of "storage receipt."
+- "Version" instead of "immutable payload."
+- "Verify" or "Details" for the advanced provenance panel.
+
+### Builder Layout
+
+Desktop layout:
+
+- Left rail: site tree, pages, navigation, publish status.
+- Center: live page canvas/preview.
+- Right panel: settings for selected page/block/site.
+- Top bar: profile identity, preview, save, publish, version status.
+
+Mobile layout:
+
+- Page preview first.
+- Bottom or top controls for add block, page tree, and settings.
+- Editing should be possible, but complex site organization can be desktop
+  optimized at first.
+
+Do not require users to navigate away from the builder to understand whether a
+page is ready to publish.
+
+### Builder States
+
+Every site should have clear state:
+
+- No site yet.
+- Draft exists.
+- Draft has validation warnings.
+- Draft ready to publish.
+- Publishing.
+- Published.
+- Published with partial storage.
+- Published but not currently accelerated by 6529.io.
+- Publish failed but draft saved.
+
+Every page should have clear state:
+
+- Draft.
+- Published.
+- Changed since last publish.
+- Hidden from navigation.
+- Missing share metadata.
+- Has validation errors.
+
+### First-Run Experience
+
+The first run should be heavily guided:
+
+1. Choose site type.
+2. Confirm profile.
+3. Add source material.
+4. Pick style.
+5. Review generated pages.
+6. Edit obvious details.
+7. Preview mobile and desktop.
+8. Publish.
+
+For a collector gallery, "source material" means wallets. For an editorial site,
+it means title, intro, pages/posts, and optional media. For a collection site,
+it means contract, chain, and knowledge packet.
+
+### Template System
+
+Templates should be composable, not one-off forks.
+
+Template parts:
+
+- Site type.
+- Page type.
+- Block presets.
+- Theme tokens.
+- Navigation pattern.
+- Social card design.
+- Optional data adapters.
+
+Initial templates:
+
+- Profile homepage.
+- Collector gallery.
+- Collection page.
+- NFT detail page.
+- Article/post.
+- Initiative page.
+
+Later templates:
+
+- 3D room.
+- Transaction explainer.
+- Artist portfolio.
+- Proof/reputation page.
+
+Template quality bar:
+
+- Looks good with sparse content.
+- Looks good with dense content.
+- Works on mobile.
+- Has complete social metadata.
+- Uses accessible headings and controls.
+- Has deterministic export behavior.
+
+### Editing Flow
+
+Common edits should be fast:
+
+- Click text to edit.
+- Drag or button-reorder blocks.
+- Add block from a short categorized menu.
+- Select media from wallet/imported assets or upload.
+- Choose NFT/collection/transaction from typed search.
+- Preview share card before publish.
+
+Advanced edits live in the right panel:
+
+- Slug.
+- SEO/share metadata.
+- Canonical URL.
+- Hide from navigation.
+- Data source/snapshot.
+- Alt text.
+- Block-specific settings.
+- Provenance details.
+
+### Validation UX
+
+Validation should be helpful, not punitive.
+
+Use three levels:
+
+- Error: cannot publish.
+- Warning: can publish, but likely poor result.
+- Note: optional improvement.
+
+Examples:
+
+- Error: invalid route slug.
+- Error: unsafe URL.
+- Error: package signature missing.
+- Warning: missing social image.
+- Warning: image missing alt text.
+- Warning: decentralized storage has only one provider.
+- Note: page description may be too long for social cards.
+
+Validation should link directly to the broken page/block/setting.
+
+### Version History UX
+
+Version history should show:
+
+- Publish time.
+- Publisher/signing wallet.
+- Package hash.
+- Storage providers.
+- Short change summary.
+- Restore action.
+- View package details.
+
+Restoring a version should publish a new pointer to an old package, not mutate
+the old package.
+
+### Provenance Panel
+
+Every published site should have an advanced provenance panel reachable from the
+site footer or profile/site settings.
+
+Show:
+
+- Package hash.
+- Payload hash.
+- Signature signer.
+- Storage locations.
+- IPFS CID.
+- Arweave transaction id.
+- Version.
+- Previous version.
+- Source snapshot information.
+- Validator result.
+
+This panel is part of the decentralization UX. It lets normal users ignore the
+details while power users can verify them.
+
+### Builder Entry Points
+
+Users should find the CMS through:
+
+- Profile owner controls on `/{handle}`.
+- A "Create website" or "Manage website" flow.
+- Direct Studio route for advanced users.
+- Future profile settings page.
+
+### Builder Dashboard
+
+The dashboard should show:
+
+- Current published site.
+- Drafts.
+- Last publish date.
+- Package hash.
+- Storage status.
+- Validation status.
+- Preview button.
+- Publish button.
+- Version history.
+
+Primary actions:
+
+- Edit site.
+- Create new site.
+- Generate gallery from wallets.
+- Add page.
+- Manage navigation.
+- Publish.
+- Roll back.
+
+### Site Type Picker
+
+Start with guided templates:
+
+- Personal/profile homepage.
+- Collector gallery.
+- Artist portfolio.
+- Collection site.
+- Blog/editorial site.
+- Organization/initiative site.
+- 3D exhibition room.
+- Transaction explainer.
+
+The template should create a useful first draft, not an empty canvas.
+
+### Page Tree
+
+The builder should show a simple site tree:
+
+- Home.
+- Collections.
+- NFTs.
+- Posts.
+- Rooms.
+- Custom pages.
+
+Each page has:
+
+- Title.
+- Slug.
+- Page type.
+- Draft/published status.
+- Share metadata status.
+- Validation warnings.
+
+### Block Editor
+
+Supported early blocks:
+
+- Heading.
+- Rich text.
+- Image.
+- Video.
+- Gallery.
+- Quote.
+- Callout.
+- Button/link.
+- NFT reference.
+- Collection reference.
+- Transaction reference.
+- Wallet gallery.
+- 3D room embed.
+
+Block behavior:
+
+- Add, remove, reorder.
+- Inline edit where simple.
+- Side panel for advanced settings.
+- Mobile preview.
+- Accessibility warnings.
+- URL and media validation.
+
+### Authored Content vs Generated Content
+
+The builder needs to distinguish content the user wrote from content generated
+from wallets, indexers, chain data, or knowledge packets.
+
+Authored content:
+
+- Title.
+- Intro copy.
+- Captions.
+- Essays/posts.
+- Navigation labels.
+- Featured selections.
+- Manual callouts.
+
+Generated content:
+
+- Wallet holdings.
+- Collection summaries.
+- NFT metadata.
+- Ownership snapshots.
+- Transaction facts.
+- Trait grids.
+- Provenance timelines.
+
+Generated content must carry:
+
+- Source.
+- Fetch time.
+- Chain id.
+- Block number where possible.
+- Indexer/provider.
+- Confidence or completeness status where relevant.
+
+User controls:
+
+- Freeze generated data into package.
+- Refresh generated data.
+- Override display text.
+- Hide generated items.
+- Mark generated facts as source-derived.
+
+Rule:
+
+Published pages should not depend on a live indexer to render their core
+content. Live refresh can be an enhancement, but the package should include the
+snapshot needed to render the published page.
+
+### Page Generation Rules
+
+When a generator creates multiple pages, it should produce a predictable route
+manifest.
+
+Collector gallery example:
+
+- `/{handle}/index.html`
+- `/{handle}/collections/index.html`
+- `/{handle}/collections/{collection_slug}/index.html`
+- `/{handle}/nfts/{chain}/{contract}/{token_id}/index.html`
+
+Rules:
+
+- Slugs must be deterministic and collision-safe.
+- Route changes after publish should create redirects where practical.
+- Generated pages should be editable after generation.
+- Deleting a generated page should not delete the source NFT/collection data.
+- Hidden pages can remain in the package but should not appear in navigation.
+
+### Media Library
+
+The builder should include a simple media library backed by content-addressed
+assets.
+
+MVP media sources:
+
+- Uploaded image.
+- Uploaded video.
+- NFT media imported from wallet data.
+- Social share image generated by 6529 service.
+
+Required metadata:
+
+- Asset kind.
+- MIME type.
+- Byte size.
+- Dimensions or duration where applicable.
+- Content hash.
+- Storage locations.
+- Alt text or decorative flag for images.
+
+Rules:
+
+- Avoid hotlinking mutable third-party media as the only source.
+- Prefer copying important media into package storage where licensing and size
+  allow it.
+- Preserve original source URL as provenance.
+- Support gateway rotation for IPFS/Arweave media.
+
+### Wallet Gallery Generator
+
+Flow:
+
+1. Enter one or more ETH addresses or ENS names.
+2. Resolve addresses.
+3. Fetch NFTs and collections.
+4. Show import summary.
+5. Choose style.
+6. Choose featured collections.
+7. Hide spam or unwanted assets.
+8. Generate site.
+9. Preview pages.
+10. Publish.
+
+Required generated pages:
+
+- Home.
+- Collections index.
+- Collection detail pages.
+- NFT detail pages.
+
+Required controls:
+
+- Re-import.
+- Freeze snapshot at block/time.
+- Hide assets.
+- Feature assets.
+- Edit captions.
+
+### Knowledge Packet System
+
+Knowledge packets provide collection context.
+
+They should be:
+
+- Open.
+- Versioned.
+- Hashable.
+- Extensible.
+- Source-cited where possible.
+- Usable by builders and renderers.
+
+Initial packet fields:
+
+- Collection name.
+- Contract(s).
+- Chain(s).
+- Creator/project.
+- Summary.
+- Historical context.
+- Traits or structure.
+- Notable works.
+- External references.
+- Security/source notes.
+- Version/hash.
+
+Top collection strategy:
+
+- Start with top collections by overall market cap and cultural relevance.
+- Include 6529 collections with deeper custom packets.
+- Allow community/project submitted packets later.
+
+### Social Share UX
+
+Every shareable page should have:
+
+- Title.
+- Description.
+- OpenGraph image.
+- Square image.
+- Canonical URL.
+- Safe fallback image.
+
+Builder should warn on:
+
+- Missing title.
+- Missing description.
+- Missing image.
+- Text too long for social preview.
+- Unsafe or unsupported media URL.
+
+Later:
+
+- Automatic OG image generation.
+- Per-template share card design.
+- NFT/card-specific share visuals.
+
+### Publish Flow
+
+User-facing steps:
+
+1. Validate.
+2. Preview.
+3. Upload to decentralized storage.
+4. Sign package.
+5. Publish pointer.
+6. Confirm live URL.
+
+Validation checks:
+
+- Schema valid.
+- URLs safe.
+- Required share metadata present.
+- Assets reachable or embedded by content hash.
+- Page slugs valid.
+- No route conflicts.
+- Signature valid.
+- Storage receipt matches package hash/CID.
+
+Failure handling:
+
+- Save draft if upload fails.
+- Retry storage providers independently.
+- Publish can proceed with one provider only if product policy allows it.
+- Clearly label storage state.
+
+## Renderer Spec
+
+### Rendering Modes
+
+Need at least four modes:
+
+- 6529.io web renderer.
+- Static/export renderer.
+- Electron/offline renderer.
+- Crawler/social metadata renderer.
+
+### Rendering Requirements
+
+Renderer must:
+
+- Validate package schema before rendering.
+- Sanitize URLs and rich text.
+- Enforce media allow rules.
+- Reject unsupported block types or render an explicit safe fallback only when a
+  future compatibility layer allows it.
+- Preserve page metadata.
+- Support mobile and desktop.
+- Avoid layout shifts.
+- Provide accessible navigation and controls.
+- Fail closed for unsafe interactive content.
+
+### Interactive HTML And 3D Safety
+
+For interactive blocks:
+
+- Use sandboxed iframes or equivalent isolation.
+- Restrict script privileges.
+- Restrict network behavior where possible.
+- Use CSP.
+- Provide static fallback.
+- Never let arbitrary package content execute inside the main app context.
+
+### 3D Rendering Requirements
+
+For Three.js rooms:
+
+- Nonblank canvas test.
+- Desktop and mobile viewport tests.
+- Loading state.
+- Reduced-motion or low-power fallback.
+- Keyboard and pointer interaction basics.
+- Clickable NFT/frame navigation.
+- Asset load failure handling.
+
+## Backend Spec
+
+### Services Needed
+
+MVP backend services:
+
+- Draft storage.
+- Package validation.
+- Package upload coordination.
+- AI-readable source packet export.
+- Agent patch validation and import.
+- MCP tools for read/validate/preview/propose flows.
+- IPFS publish/pin adapter.
+- Arweave publish adapter.
+- Profile publish authorization.
+- Profile pointer API.
+- Package fetch API.
+- Storage receipt verification.
+- OG image render service or worker.
+
+Later:
+
+- NFT indexer integration.
+- Transaction decode service.
+- Third-party agent integration registry.
+- Knowledge packet registry.
+- Site search indexing.
+- Version rollback.
+- Mirror registry export.
+- Paid indexing jobs for xTDH-like external collections.
+
+### API Surface Draft
+
+The exact paths can change, but the capabilities should be explicit.
+
+Read APIs:
+
+- Get active site pointer for profile.
+- Get package metadata by hash.
+- Fetch package by hash.
+- List published versions for profile.
+- List drafts for profile owner.
+- Get draft by id.
+- Get storage receipt status.
+- Get knowledge packet by id/hash.
+- Preview generated wallet import summary.
+
+Write APIs:
+
+- Create draft.
+- Update draft.
+- Delete draft.
+- Validate draft/package.
+- Create publish candidate.
+- Upload package to storage providers.
+- Submit package signature.
+- Publish profile pointer.
+- Roll back pointer to prior package.
+- Stop 6529 acceleration for a package.
+
+Generator APIs:
+
+- Resolve ENS/address inputs.
+- Import wallet holdings snapshot.
+- Group holdings by collection.
+- Generate collection pages.
+- Generate NFT pages.
+- Generate social images.
+
+Agent affordance APIs:
+
+- Export source packet for profile, wallet, collection, NFT, transaction, draft,
+  or package.
+- Export JSON schema bundle.
+- Export `SKILL.md` guidance bundle.
+- Validate agent patch.
+- Apply approved agent patch to draft.
+- Return structured validation errors for agent repair loops.
+- Return preview render result for a draft/package.
+
+Admin/operator APIs:
+
+- Re-run storage verification.
+- Export pointer registry snapshot.
+- Rebuild CDN acceleration object.
+- Review package moderation state.
+- Inspect publish audit log.
+
+API rules:
+
+- Publish APIs must be idempotent where practical.
+- Pointer update should be conditional on expected previous pointer/version.
+- Package fetch should be cacheable by hash.
+- Draft APIs require authenticated profile owner/editor access.
+- Public read APIs must never expose private draft state.
+- Validation errors should be structured enough for the builder to deep-link to
+  the relevant field, page, or block.
+
+### Data Tables Or Persistent Stores
+
+Backend likely needs these durable records:
+
+- `cms_drafts`: mutable draft state and owner profile.
+- `cms_packages`: immutable package metadata, hashes, schema version.
+- `cms_storage_receipts`: IPFS/Arweave/CDN receipt records.
+- `cms_profile_pointers`: active pointer per profile.
+- `cms_pointer_events`: append-only publish/rollback history.
+- `cms_publish_signatures`: signature envelopes and signer metadata.
+- `cms_validation_results`: latest validation summary and error details.
+- `cms_knowledge_packets`: curated packet records and hashes.
+- `cms_generation_jobs`: wallet/gallery/social image generation job state.
+- `cms_agent_patch_reviews`: optional records of imported agent patches,
+  validation status, reviewer, and applied draft version.
+
+Important:
+
+- Package bytes should not depend only on relational rows.
+- Database rows can index packages, but package storage must be independently
+  retrievable.
+- Pointer events should be append-only even if a convenience "current pointer"
+  table exists.
+
+### Profile Authorization
+
+Publishing should require:
+
+- Authenticated profile session.
+- Wallet signature.
+- Signer authorized for profile.
+- Optional delegated publisher role later.
+
+Do not add "official" or "verified" as a protocol-level lane.
+
+### Pointers And Registry
+
+Backend table/API should support:
+
+- Active primary site pointer by profile.
+- Historical versions.
+- Drafts.
+- Package records.
+- Storage receipts.
+- Publish signer.
+- Validation status.
+- Moderation/CDN acceleration status.
+
+Long-term decentralization:
+
+- Export pointer registry as content-addressed snapshots.
+- Replicate pointer state to the special-purpose 6529 chain.
+- Let alternative clients resolve profile site pointers without the 6529 API.
+
+### Indexing
+
+Separate trust tiers:
+
+- Core 6529 data such as TDH/REP should move to the special-purpose chain.
+- NFT ownership remains on Ethereum and supported chains.
+- TDH for 6529 collections can be highly decentralized because the data set is
+  small enough for many validators/indexers.
+- xTDH for arbitrary collections has more attack surface and should be labeled
+  as lower-security, opt-in, sponsor-funded indexing.
+
+For CMS:
+
+- Gallery generation can use 6529-operated indexers at launch.
+- Package should store snapshot facts and source metadata.
+- Users should be able to freeze a site to a block/time snapshot.
+- Later clients can re-index from chain data or compare against the snapshot.
+
+## Decentralization Architecture
+
+### Launch Architecture
+
+Practical launch path:
+
+- 6529 web app provides builder and renderer.
+- Backend validates, uploads, pins, and stores pointers.
+- IPFS and/or Arweave stores package data.
+- S3/CloudFront accelerates delivery.
+- Existing indexers power gallery generation.
+
+This is acceptable if the canonical artifact is decentralized and portable.
+
+### Target Architecture
+
+Medium-term target:
+
+- Profile/pointer state in 6529 special-purpose chain.
+- TDH/REP/Waves/core protocol data in special-purpose chain.
+- NFTs remain on Ethereum and supported chains.
+- CMS packages on IPFS/Arweave.
+- Media on IPFS/Arweave or peer-hosted content-addressed storage.
+- Electron/mobile/web clients can render without trusting 6529.io.
+- Any operator can run mirror/gateway/indexer services.
+
+### Mirrorability
+
+Anyone should be able to mirror:
+
+- CMS package blobs.
+- Asset blobs.
+- Pointer registry snapshots.
+- Knowledge packet registry.
+- Renderer code.
+
+6529.io can still be the best UX and fastest CDN.
+
+### Alternative Clients
+
+Document and support:
+
+- Package schema.
+- Validation CLI.
+- Renderer contract.
+- Pointer resolution.
+- Storage gateway fallback.
+- Signature verification.
+
+This enables:
+
+- Alternative website mirrors.
+- Mobile apps.
+- Desktop apps.
+- Archive nodes.
+- Community renderers.
+
+### Centralization Ledger
+
+Every centralized launch dependency should have an explicit target state.
+
+Builder UI:
+
+- Launch: hosted on 6529.io.
+- Target: open source/client-renderable builder logic where practical.
+- Escape hatch: users can create packages with CLI or alternative clients.
+
+Draft storage:
+
+- Launch: 6529 backend.
+- Target: client-local drafts plus optional encrypted/cloud backup.
+- Escape hatch: export draft/package JSON.
+
+Profile pointer:
+
+- Launch: 6529 backend table/API.
+- Target: 6529 special-purpose chain or decentralized profile state.
+- Escape hatch: signed pointer registry snapshots.
+
+Package storage:
+
+- Launch: IPFS/Arweave through 6529 upload service.
+- Target: users/operators can upload/pin independently.
+- Escape hatch: package hash and standalone validator.
+
+CDN acceleration:
+
+- Launch: 6529 S3/CloudFront or equivalent.
+- Target: optional acceleration only.
+- Escape hatch: IPFS/Arweave gateways and mirrors.
+
+NFT/gallery indexing:
+
+- Launch: 6529-operated or third-party indexers.
+- Target: reproducible chain/indexer snapshots; decentralized validators for
+  core 6529 collections.
+- Escape hatch: package embeds frozen snapshot metadata.
+
+Knowledge packets:
+
+- Launch: repo/6529-curated packets.
+- Target: open packet registry with review and versioning.
+- Escape hatch: package can bundle packet by hash.
+
+Social image rendering:
+
+- Launch: 6529 render worker.
+- Target: deterministic renderer or package-bundled image.
+- Escape hatch: uploaded/static social image.
+
+Moderation/CDN policy:
+
+- Launch: 6529 decides what it accelerates.
+- Target: transparent acceleration state; content remains independently
+  retrievable if legal and mirrored.
+- Escape hatch: third-party mirrors render package directly.
+
+## Privacy And Gating
+
+Most CMS websites should be public.
+
+For gated or private pages:
+
+- Do not rely on hidden routes for confidentiality.
+- Public static packages cannot keep plaintext private.
+- Use encrypted page/package payloads.
+- Gate access by distributing content keys to eligible members.
+
+Possible gated content model:
+
+- Public metadata and teaser.
+- Encrypted page payload.
+- Eligibility proof from TDH/REP/NFT/profile state.
+- Key envelope for eligible users or groups.
+- Rotation on meaningful membership changes.
+
+For large gated groups:
+
+- Accept practical rotation windows.
+- Use epoch keys.
+- Re-key on scheduled intervals or high-risk membership changes.
+- Clearly document that users who had access may have retained plaintext.
+
+This should be a later phase unless a near-term product needs it.
+
+## Security Requirements
+
+### Content Safety
+
+- Validate schemas server-side and client-side.
+- Sanitize rich text.
+- Restrict link protocols.
+- Restrict media hosts or require content-addressed media.
+- Isolate arbitrary HTML/JS.
+- Enforce CSP.
+- Treat package content as untrusted input.
+
+### Publishing Safety
+
+- Verify signer authorization.
+- Verify package hash before pointer update.
+- Verify storage receipts.
+- Store immutable publish records.
+- Support rollback to previous package.
+- Rate limit publish actions.
+
+### Supply Chain Safety
+
+- Avoid renderer dependencies that execute untrusted content unsafely.
+- Pin package schemas.
+- Add schema migration tests.
+- Add corpus tests for old packages.
+
+### Moderation And CDN Policy
+
+Decentralized storage means content may remain available outside 6529.
+
+6529.io still needs:
+
+- Terms/CDN acceleration policy.
+- Ability to stop accelerating illegal or abusive content.
+- Ability to hide links from the 6529 UI while preserving decentralized facts.
+- Transparent state labels when content is not accelerated by 6529.io.
+
+## Accessibility, Localization, And UX Quality
+
+All visible builder and renderer work should follow repo frontend standards:
+
+- WCAG 2.2 AA for touched UI.
+- Keyboard reachable controls.
+- Proper headings.
+- Alt text support and warnings.
+- No text overlap on mobile or desktop.
+- Responsive constraints for galleries/cards/buttons.
+- Localized dates, numbers, and sorting where applicable.
+
+Builder should help authors:
+
+- Warn when images lack alt text.
+- Warn when button text is vague.
+- Warn when color contrast is poor.
+- Warn when page title/share metadata is missing.
+
+## Milestone Roadmap
+
+### Milestone 0: Spec, Schema, And MVP Hardening
+
+Goal:
+
+Make the current foundation explicit and stable enough to build on.
+
+Scope:
+
+- Finalize package schema v1.
+- Finalize page/block schema v1.
+- Document URL model.
+- Document package hashing rules.
+- Document profile pointer model.
+- Add schema fixture tests.
+- Add renderer safety tests.
+
+Acceptance criteria:
+
+- Example packages validate deterministically.
+- Renderer handles all v1 blocks safely.
+- Unknown blocks render as safe fallback.
+- Hashes are stable across environments.
+- Roadmap/spec is committed and reviewed.
+
+### Milestone 1: Primary Profile Site Launch
+
+Goal:
+
+Let a profile publish a primary CMS site at `/{handle}/index.html`.
+
+Frontend scope:
+
+- Route for CMS site pages under `/{handle}/index.html`.
+- Profile page website button.
+- Basic CMS renderer.
+- Preview route.
+- Basic Studio dashboard.
+- Social metadata rendering.
+
+Backend scope:
+
+- Package records.
+- Profile primary pointer API.
+- Publish authorization.
+- Package validation.
+- Storage receipt model.
+
+Storage scope:
+
+- IPFS upload/pin adapter.
+- Arweave upload adapter or clear first-provider decision.
+- CDN acceleration path.
+
+Acceptance criteria:
+
+- A profile can publish a site.
+- Site is reachable at `/{handle}/index.html`.
+- Profile page links to it.
+- Package is signed.
+- Package has at least one decentralized storage receipt.
+- Page has valid OpenGraph metadata.
+- Browser tests cover desktop and mobile.
+
+### Milestone 2: Wallet Gallery Generator V1
+
+Goal:
+
+Make the first killer CMS flow: paste wallets, get a beautiful gallery site.
+
+Frontend scope:
+
+- Multi-address input.
+- ENS resolution UI.
+- Import summary.
+- Gallery style selector.
+- Collection hiding/featuring.
+- Generated page preview.
+- NFT and collection page preview.
+
+Backend scope:
+
+- NFT ownership import.
+- Collection grouping.
+- Snapshot by block/time.
+- Spam/unwanted asset filtering support.
+- Source metadata in package.
+
+Acceptance criteria:
+
+- User can generate a site from one or more wallets.
+- Site includes home, collection pages, and NFT pages.
+- Generated pages have share metadata.
+- Snapshot provenance is visible.
+- User can hide obvious unwanted assets before publish.
+
+### Milestone 3: General Page Builder V1
+
+Goal:
+
+Move from generator to real CMS.
+
+Frontend scope:
+
+- Site tree.
+- Add/edit/delete pages.
+- Block editor.
+- Navigation editor.
+- Theme controls.
+- Share metadata editor.
+- Draft autosave.
+- Publish validation checklist.
+
+Backend scope:
+
+- Draft persistence.
+- Version history.
+- Publish validation.
+- Rollback.
+
+Acceptance criteria:
+
+- User can build a basic multi-page site without hand-editing JSON.
+- User can publish and roll back.
+- Validation catches missing/unsafe required fields.
+- Published package remains portable and content-addressed.
+
+### Milestone 4: Collection And NFT Pages V1
+
+Goal:
+
+Make collection and token pages first-class, shareable, and beautiful.
+
+Frontend scope:
+
+- Collection page template.
+- NFT/card page template.
+- 6529 collection custom modules.
+- Share card previews.
+
+Backend scope:
+
+- Collection knowledge packet registry.
+- Top collection packet seed data.
+- 6529-specific metadata enrichment.
+- Optional sponsored external collection indexing model.
+
+Acceptance criteria:
+
+- Top collection pages render with knowledge context.
+- Individual token pages render with media/provenance facts.
+- 6529 Meme Cards and Gradients have richer native modules.
+- Shared pages look good on major social platforms.
+
+### Milestone 5: 3D Exhibition Rooms
+
+Goal:
+
+Ship real 3D room pages with reliable fallbacks.
+
+Frontend scope:
+
+- Three.js room renderer.
+- Room template presets.
+- Frame/token placement.
+- Pointer and keyboard navigation.
+- 2D fallback.
+- Screenshot/canvas tests.
+
+Backend scope:
+
+- Room data schema validation.
+- Asset optimization pipeline.
+- Model/media storage receipts.
+
+Acceptance criteria:
+
+- Generated 3D room is nonblank and interactive on desktop.
+- Mobile fallback is usable.
+- Each displayed work links to its NFT/page.
+- Package remains renderable by non-6529 clients.
+
+### Milestone 6: Transaction Explainers
+
+Goal:
+
+Build block explorer pages that explain transactions like a human would.
+
+Frontend scope:
+
+- Transaction page template.
+- Transaction reference block.
+- Event timeline UI.
+- Confidence/source labels.
+
+Backend scope:
+
+- Transaction fetch/decode adapter.
+- ABI/plugin registry.
+- Human-readable action extraction.
+- Source and confidence metadata.
+
+Acceptance criteria:
+
+- User can create/share a transaction page.
+- Page clearly explains parties, value, assets, and actions.
+- Raw explorer links remain available.
+- Uncertain interpretations are labeled.
+
+### Milestone 7: Decentralization Hardening
+
+Goal:
+
+Reduce dependence on 6529-operated services.
+
+Scope:
+
+- Standalone package validator CLI.
+- Standalone renderer package.
+- Electron renderer integration.
+- Pointer registry snapshot export.
+- Gateway fallback list.
+- Mirror documentation.
+- Third-party client docs.
+- Package corpus compatibility tests.
+
+Acceptance criteria:
+
+- A package can be validated outside 6529.io.
+- A site can be rendered from IPFS/Arweave without 6529 API.
+- Electron can browse cached/pinned sites.
+- A third-party mirror can resolve and serve known profile sites from exported
+  registry data.
+
+### Milestone 8: Ecosystem And Marketplace
+
+Goal:
+
+Let others extend templates, knowledge packets, rooms, and indexers.
+
+Scope:
+
+- Template registry.
+- Knowledge packet submissions.
+- Community review/versioning.
+- Paid indexing jobs for arbitrary collections.
+- Plugin model for transaction decoders.
+- Analytics that preserve privacy and do not become core infrastructure.
+
+Acceptance criteria:
+
+- External contributors can add templates/knowledge packets through a reviewed
+  path.
+- xTDH-like collection indexing is opt-in, lower-security, and sponsor-funded.
+- Core CMS publishing does not depend on any single centralized indexer.
+
+## Detailed Workstream Breakdown
+
+### Track A: Schema, Package, And Validator
+
+Purpose:
+
+Make the CMS artifact stable enough that every other track can trust it.
+
+Build:
+
+- Site manifest schema.
+- Canonical package schema.
+- Canonical payload schema.
+- Typed CMS collection registry.
+- Page schema.
+- Page metadata/frontmatter schema.
+- Metadata defaults schema.
+- Data cascade/resolved value schema.
+- Block schema.
+- Safe block macro schema.
+- Asset schema.
+- Art asset schema.
+- Display variant schema.
+- NFT media profile schema.
+- Deep zoom manifest schema.
+- Navigation schema.
+- Taxonomy schema.
+- Archetype schema.
+- Pagination schema.
+- Permalink/alias schema.
+- Static search manifest schema.
+- Locale/i18n schema.
+- Markdown import/export metadata schema.
+- Storage receipt schema.
+- Signature envelope schema.
+- Knowledge packet schema.
+- Indexer snapshot schema.
+- Agent/source provenance schema.
+- Source loader output schema.
+- Plugin manifest schema.
+- Exhibition room schema.
+- Artwork placement schema.
+- Interactive policy schema.
+- Static build manifest schema.
+- Canonical JSON/hash implementation.
+- Standalone validator CLI.
+- Fixture package corpus.
+
+Key outputs:
+
+- `cms-package.schema`.
+- `cms-payload.schema`.
+- `site-manifest.schema`.
+- Collection schemas for pages, posts, assets, NFTs, collections, rooms,
+  transactions, knowledge packets, source packets, navigation, and translations.
+- Schemas for defaults, taxonomies, archetypes, pagination, permalinks, aliases,
+  block macros, and build manifests.
+- Schemas for art assets, display variants, NFT media profiles, deep zoom
+  manifests, exhibition rooms, artwork placements, and interactive policies.
+- Package validator.
+- Hash test vectors.
+- Migration compatibility tests.
+
+Critical decisions:
+
+- Canonical JSON rules.
+- EIP-712 vs EIP-191.
+- Package size limits.
+- Required vs optional storage providers.
+
+### Track B: Profile Routing And Rendering
+
+Purpose:
+
+Make profile websites real routes in the app while keeping profile pages intact.
+
+Build:
+
+- CMS route resolver for `/{handle}/index.html`.
+- CMS subpage resolver for `/{handle}/{path}/index.html`.
+- Profile page website button.
+- Permalink and alias resolver.
+- Route collision detection.
+- Package fetch/cache layer.
+- Renderer shell.
+- Static HTML export path.
+- Static-first block renderer.
+- Interactive island policy support.
+- Safe block macro expansion.
+- 2D art grid renderer.
+- NFT detail renderer.
+- Lightbox/focused inspection renderer.
+- Poster/fallback renderer for video, audio, 3D, and interactive media.
+- Optional deep zoom renderer/manifest support.
+- 3D room renderer with faithful 2D artwork mode.
+- Page metadata renderer.
+- Generated navigation renderer.
+- Taxonomy/term page renderer.
+- Pagination route renderer.
+- Static search manifest renderer/loader.
+- Static build manifest output.
+- Error states.
+- Not-accelerated state.
+- Package provenance panel.
+
+Key outputs:
+
+- Profile website route.
+- Renderer components.
+- Plain static export.
+- Metadata integration.
+- Browser/E2E coverage.
+
+Critical decisions:
+
+- Route conflict rules.
+- Cache invalidation.
+- Edge/server rendering strategy.
+- How crawler requests resolve packages.
+
+### Track C: Publish, Storage, And Pointers
+
+Purpose:
+
+Make publishing create durable artifacts, not database-only content.
+
+Build:
+
+- Draft storage.
+- Publish candidate generation.
+- Package validation.
+- IPFS upload/pin adapter.
+- Arweave upload adapter.
+- Storage receipt verification.
+- Profile pointer model.
+- Pointer event log.
+- Rollback.
+- Package export.
+- Pointer registry snapshot export.
+
+Key outputs:
+
+- Publish API.
+- Storage worker/adapters.
+- Pointer API.
+- Version history.
+- Rollback flow.
+
+Critical decisions:
+
+- Required storage policy.
+- Pointer concurrency model.
+- Upload retry policy.
+- Moderation/acceleration state model.
+
+### Track D: Builder UX
+
+Purpose:
+
+Give normal users a builder that is simple enough to use and powerful enough to
+produce rich crypto-native sites.
+
+Build:
+
+- Builder dashboard.
+- Site type picker.
+- First-run guided flow.
+- Archetype picker for new pages/sites.
+- Site tree.
+- Page editor.
+- Block editor.
+- Safe block macro picker.
+- Frontmatter-style metadata editor.
+- Metadata defaults editor.
+- Theme controls.
+- Navigation editor.
+- Generated navigation controls.
+- Taxonomy/tag/series controls.
+- Pagination controls for large generated lists.
+- Permalink/alias controls.
+- Search inclusion controls.
+- Locale/i18n fields where present.
+- Media library.
+- Art/NFT display variant controls.
+- Poster/fallback controls for heavy media.
+- Lightbox/deep zoom enablement where supported.
+- 3D room style and faithful/gallery mode controls.
+- Share metadata editor.
+- Validation checklist.
+- Preview desktop/mobile/social.
+- Publish progress UI.
+- Version history UI.
+
+Key outputs:
+
+- Usable builder for primary site.
+- Draft/preview/publish UX.
+- Validation UX.
+
+Critical decisions:
+
+- Initial templates.
+- Mobile editing scope.
+- Autosave behavior.
+- How much freeform styling V1 allows.
+
+### Track E: Wallet Gallery Generator
+
+Purpose:
+
+Ship the first native killer feature.
+
+Build:
+
+- Wallet/ENS input.
+- Wallet source loader.
+- Wallet import job.
+- Collection grouping.
+- Spam/unwanted asset detection.
+- Snapshot freeze.
+- Featured collection suggestions.
+- Style selection.
+- Generated home page.
+- Generated collections index.
+- Generated collection pages.
+- Generated NFT pages.
+- Generated NFT media profiles.
+- Generated art display variants and posters.
+- Generated taxonomy/tag pages where useful.
+- Paginated all-NFT and collection routes.
+- Caption/share copy suggestions.
+
+Key outputs:
+
+- Live wallet gallery generation.
+- Editable generated pages.
+- Snapshot provenance.
+- Source loader output that can be exported to user-owned agents.
+
+Critical decisions:
+
+- Supported chains for V1.
+- NFT indexer source.
+- Spam scoring policy.
+- Maximum wallet/import size.
+
+### Track F: Collection And NFT Knowledge
+
+Purpose:
+
+Make NFT and collection pages genuinely better than generic indexer output.
+
+Build:
+
+- Knowledge packet schema.
+- Knowledge packet registry.
+- Top collection packet list.
+- 6529 collection deep packets.
+- Meme Card native modules.
+- Gradient native modules.
+- Notable token curation.
+- Source/citation model.
+- Packet versioning.
+
+Key outputs:
+
+- Collection page quality bar.
+- NFT/card page quality bar.
+- Open packet contribution path.
+
+Critical decisions:
+
+- First top collections.
+- Review policy for packets.
+- How packets are bundled/referenced in packages.
+- How to label lower-confidence community packets.
+
+### Track G: AI Agent Affordances
+
+Purpose:
+
+Let users bring their own AI agents to inspect, draft, edit, validate, and
+prepare CMS sites without 6529 paying for or operating their inference.
+
+Build:
+
+- MCP server tools for profile/CMS read, validate, preview, and draft patch
+  flows.
+- `SKILL.md` files for site building, wallet galleries, NFT pages, collection
+  pages, transaction explainers, validation, and publishing.
+- JSON schema bundle export.
+- Site manifest and build manifest export.
+- Source packet export.
+- Agent patch schema.
+- Agent patch import/review UI.
+- Structured validation errors for agent repair loops.
+- Prompt-injection-safe source packet sanitization.
+- Markdown import/export guidance for docs/posts.
+- Docs for bring-your-own-agent workflows.
+
+Key outputs:
+
+- AI-readable CMS contract.
+- User-owned agent workflow.
+- Validated patch handoff from external agents into the 6529 builder.
+- Clear boundary that signing/publishing remains user-controlled.
+
+Critical decisions:
+
+- Which MCP tools ship in V1.
+- Which `SKILL.md` files ship in V1.
+- Whether agent patch import is available in V1 or V1.1.
+- How agent patches are permissioned and reviewed.
+- What source packets are safe to export publicly vs only to the profile owner.
+
+### Track H: 3D Rooms
+
+Purpose:
+
+Make immersive exhibition pages a signature capability without sacrificing
+reliability.
+
+Build:
+
+- Room data schema.
+- Room preset templates.
+- Three.js renderer.
+- Basic GLB/glTF object viewer.
+- Media frame component.
+- Placement algorithm.
+- Faithful 2D artwork surface mode.
+- Gallery/ambient display mode.
+- Poster/static preview.
+- 2D fallback.
+- Mobile fallback.
+- Nonblank canvas tests.
+- Performance budget.
+
+Key outputs:
+
+- Simple generated exhibition room.
+- Basic object viewer.
+- Clickable works.
+- Shareable room page.
+- Faithful 2D detail-page path for every room artwork.
+
+Critical decisions:
+
+- V1 room navigation model.
+- Asset optimization limits.
+- Whether custom 3D models are allowed in V1.
+- How much room editing is manual vs generated.
+
+### Track I: Transaction Explainers
+
+Purpose:
+
+Make block explorer data understandable.
+
+Build:
+
+- Transaction reference block.
+- Transaction page template.
+- Chain transaction fetcher.
+- Event decoder.
+- ABI/plugin registry.
+- Human-readable action model.
+- Agent-readable transaction fact packet.
+- Confidence/source labels.
+
+Key outputs:
+
+- Shareable transaction page.
+- Event timeline.
+- Plain-English summary.
+
+Critical decisions:
+
+- Supported chains.
+- Supported transaction types.
+- How to label uncertainty.
+- Whether decoded facts are cached in package.
+
+### Track J: Decentralization And Alternative Clients
+
+Purpose:
+
+Ensure 6529.io is an excellent client, not the only viable client.
+
+Build:
+
+- Standalone validator.
+- Standalone renderer package.
+- Plain static HTML exporter.
+- Package inspector/diff CLI direction.
+- Static search index export.
+- Sitemap and build manifest export.
+- Electron renderer integration.
+- Local package cache.
+- Pointer registry export.
+- Mirror guide.
+- Gateway fallback guide.
+- Third-party client docs.
+- Package corpus tests.
+
+Key outputs:
+
+- Render package without 6529 API.
+- Validate package outside 6529.io.
+- Export static site without Astro/Starlight.
+- Mirror profile site.
+- Electron/offline browse path.
+
+Critical decisions:
+
+- Renderer package boundary.
+- Registry snapshot cadence.
+- How Electron discovers profile pointers before chain migration.
+
+### Track K: Security, Abuse, And Moderation
+
+Purpose:
+
+Keep CMS publishing safe for users and safe for 6529.io to accelerate.
+
+Build:
+
+- Rich text sanitizer.
+- URL validator.
+- Media validator.
+- CSP policy.
+- Sandbox policy.
+- Upload rate limits.
+- Package size limits.
+- Abuse reporting path.
+- Acceleration allow/deny state.
+- Publish audit log.
+
+Key outputs:
+
+- Renderer security posture.
+- Upload/publish abuse controls.
+- Moderation state transparency.
+
+Critical decisions:
+
+- CDN acceleration policy.
+- Illegal/abusive content handling.
+- Upload quotas.
+- Interactive HTML policy.
+
+### Track L: Operations And Review
+
+Purpose:
+
+Make the roadmap buildable by many PRs and reviewers.
+
+Build:
+
+- PR labels.
+- Milestone checklists.
+- Test packs.
+- Screenshot review procedure.
+- Bot review procedure.
+- Release gating.
+- Documentation updates.
+- Runbooks for storage failures.
+
+Key outputs:
+
+- Repeatable PR review process.
+- Clear launch readiness checklist.
+- Operational runbooks.
+
+Critical decisions:
+
+- Required checks per milestone.
+- Who can approve storage/signing/security changes.
+- What staging data/profiles are used for E2E.
+
+## Implementation Order
+
+Recommended sequence:
+
+1. Merge foundation PRs.
+2. Add typed CMS collections, source loader outputs, page metadata, navigation,
+   scoped metadata defaults, data cascade rules, archetypes, taxonomies, safe
+   block macros, pagination/permalinks, static search, locale fields, and block
+   interactivity policies.
+3. Add art/NFT display primitives: art assets, display variants, NFT media
+   profiles, posters, deep zoom manifests, exhibition rooms, placements, and
+   interactive policies.
+4. Add profile route/link integration.
+5. Add real signing and storage receipts.
+6. Add IPFS/Arweave upload adapters.
+7. Harden renderer and schema tests.
+8. Add plain static HTML export.
+9. Build basic site dashboard.
+10. Expand wallet gallery generator to live data.
+11. Add collection/NFT generated pages.
+12. Add general page builder.
+13. Add knowledge packet registry.
+14. Add AI-agent affordances: MCP tools, `SKILL.md`, schema export, and patch
+    import/review.
+15. Add 3D rooms.
+16. Add transaction explainers.
+17. Add standalone validator/renderer.
+18. Add mirror/Electron workflows.
+
+## Testing And Review Plan
+
+### Unit And Integration Tests
+
+Required coverage:
+
+- Schema validation.
+- Hash canonicalization.
+- Signature verification.
+- URL sanitization.
+- Block rendering.
+- AI source packet sanitization.
+- Agent patch schema validation.
+- Agent patch import cannot bypass user review, auth, or package validation.
+- Profile pointer API.
+- Publish authorization.
+- Storage receipt validation.
+- Migration compatibility.
+
+### Browser/E2E Tests
+
+Required flows:
+
+- Profile page shows website button when site exists.
+- `/{handle}/index.html` renders primary site.
+- Generated gallery renders on desktop and mobile.
+- Share metadata exists.
+- Builder validation blocks invalid publish.
+- Publish success path.
+- Rollback path.
+
+### Visual QA
+
+Use browser screenshots for:
+
+- Profile page integration.
+- Home site.
+- Gallery page.
+- Collection page.
+- NFT page.
+- Mobile views.
+- 3D room once implemented.
+
+### Security Review
+
+Review specifically:
+
+- Rich text sanitization.
+- URL/media validation.
+- Prompt-injection handling from NFT metadata, collection metadata, and user
+  supplied text in AI-facing source packets.
+- Agent patch validation, permissioning, and source labeling.
+- Interactive HTML sandboxing.
+- Signature authorization.
+- Pointer update race conditions.
+- Storage receipt spoofing.
+- CDN moderation behavior.
+
+### Bot/Human Review
+
+Each major milestone PR should include:
+
+- Product summary.
+- Decentralization impact.
+- Security notes.
+- Screenshots.
+- Test evidence.
+- Known limits.
+- Follow-up checklist.
+
+## Risk Register
+
+### Risk: Builder Scope Explosion
+
+Concern:
+
+The project becomes a generic website builder before proving the profile-native
+crypto workflows.
+
+Mitigation:
+
+- Keep V1 to primary profile site, gallery generator, simple pages, and publish
+  pipeline.
+- Defer custom domains, arbitrary JS, private pages, and marketplace features.
+- Measure time-to-publish and completion rate.
+
+### Risk: Decentralization Theater
+
+Concern:
+
+The app says IPFS/Arweave, but the real canonical source remains the 6529
+database.
+
+Mitigation:
+
+- Package hash and decentralized storage receipt required for launch publish.
+- Standalone validator required before public launch.
+- Package export required.
+- Pointer registry snapshot export required before decentralization hardening is
+  considered complete.
+
+### Risk: Unsafe Untrusted Content
+
+Concern:
+
+CMS content becomes an XSS or arbitrary-code execution path.
+
+Mitigation:
+
+- No arbitrary JS in V1.
+- Sanitize rich text.
+- Validate URLs.
+- Sandbox interactive content.
+- Add security review gate for renderer changes.
+
+### Risk: Indexer Trust Confusion
+
+Concern:
+
+Users mistake xTDH or arbitrary collection indexing for the same security level
+as core TDH.
+
+Mitigation:
+
+- Separate trust labels.
+- Embed source/snapshot metadata.
+- Treat xTDH-like indexing as opt-in and sponsor-funded.
+- Use stronger decentralized validation for core 6529 data.
+
+### Risk: Poor Consumer UX
+
+Concern:
+
+The decentralized mechanics leak into the happy path and normal users fail to
+publish.
+
+Mitigation:
+
+- Use guided templates.
+- Hide advanced provenance until needed.
+- Validate with user-flow E2E and screenshots.
+- Keep first-run gallery flow tight.
+
+### Risk: Storage Cost And Abuse
+
+Concern:
+
+Users upload large or abusive assets through 6529 storage services.
+
+Mitigation:
+
+- Size limits.
+- MIME/type validation.
+- Rate limits.
+- Profile-level quotas.
+- CDN acceleration policy.
+- Separate package publish from 6529 acceleration.
+
+### Risk: SEO And Route Breakage
+
+Concern:
+
+Moving hardcoded sections to CMS breaks existing links or social previews.
+
+Mitigation:
+
+- Inventory old routes.
+- Add redirect/canonical plan per migration.
+- Test social metadata.
+- Keep route shims until stable.
+
+## Decisions Needed Before First Build PRs
+
+These decisions should be made before implementation spreads across FE and BE:
+
+- Required storage policy: IPFS only, Arweave only, or one required plus one
+  recommended.
+- Signature scheme: EIP-712 from the start or EIP-191 first.
+- Canonical JSON/hash rules.
+- Initial backend pointer shape and optimistic-concurrency rules.
+- Initial route conflict policy for handles that overlap app routes.
+- Initial template list for V1.
+- Initial top collection knowledge packet list.
+- Initial moderation/CDN acceleration policy.
+- Initial package size and media upload limits.
+
+## Open Questions
+
+### Product
+
+- Should first production publish require both IPFS and Arweave, or allow one
+  required and one optional?
+- How much customization should V1 templates allow before the UX becomes too
+  complex?
+- Should profile sites support custom domains in V1, or later?
+- What is the first set of top collection knowledge packets?
+- Which 6529 collections deserve custom templates first?
+
+### Technical
+
+- Which canonical JSON library/rules should own hash determinism?
+- Do we use EIP-712 from the start or begin with EIP-191?
+- Where does the mutable pointer live before the special-purpose chain exists?
+- How do alternative clients resolve latest profile pointers without the 6529
+  API during the transition?
+- Which IPFS pinning and Arweave providers are acceptable for production?
+
+### Governance
+
+- What content will 6529.io refuse to accelerate even if it is decentralized?
+- Who can publish for institutional profiles?
+- How are compromised publishing keys revoked?
+- What labels do we use for lower-security xTDH/indexer-derived pages?
+
+## Near-Term PR Breakdown
+
+### PR 0: Shared Decisions And Test Fixtures
+
+Repos:
+
+- Frontend.
+- Backend.
+
+Scope:
+
+- Lock storage/signature/hash decisions.
+- Add canonical package fixtures.
+- Add typed CMS collection schemas.
+- Add page metadata/frontmatter schema.
+- Add site manifest, scoped metadata defaults, data cascade, archetype,
+  taxonomy, block macro, pagination, permalink/alias, and static build manifest
+  schemas.
+- Add art asset, display variant, NFT media profile, deep zoom manifest,
+  exhibition room, artwork placement, and interactive policy schemas.
+- Add source loader output schema.
+- Add navigation, static search, locale/i18n, and block interactivity policy
+  schemas.
+- Add hash test vectors.
+- Add schema fixture tests.
+- Add package corpus folder.
+- Document route conflict rules.
+
+Why first:
+
+This prevents FE and BE from building incompatible package assumptions.
+
+### FE PR 1: Route And Profile Integration
+
+- Add CMS route resolution for `/{handle}/index.html`.
+- Add profile website button.
+- Add metadata rendering.
+- Add safe loading/error states.
+- Add focused tests and screenshots.
+
+### BE PR 1: Package Records And Pointer V1
+
+- Add package record model.
+- Add primary pointer endpoints.
+- Add publish authorization.
+- Add validation status.
+- Add package fetch endpoint.
+- Add pointer event log.
+- Add optimistic concurrency on pointer update.
+
+### FE PR 2: Renderer And Provenance Panel
+
+- Render all V1 safe blocks.
+- Add package provenance panel.
+- Add unsupported-block fail-closed tests.
+- Add desktop/mobile rendering tests.
+- Add social metadata tests.
+
+### BE PR 2: Validation And Signing
+
+- Add package validation service.
+- Add signature verification.
+- Add signer authorization checks.
+- Add validation error structure for builder deep links.
+- Add tests for unauthorized publish.
+
+### FE PR 3: Builder Dashboard V1
+
+- Add dashboard entry.
+- Show current site/drafts.
+- Add preview/publish actions.
+- Add validation checklist.
+- Keep wallet-gallery generator available.
+
+### BE PR 3: Storage Receipts And Uploads
+
+- Add IPFS upload/pin adapter.
+- Add Arweave upload adapter.
+- Verify receipt matches package hash/CID.
+- Store receipts.
+- Add retry/status model.
+
+### FE PR 4: Live Wallet Gallery V1
+
+- Add live import flow.
+- Add generated collection and NFT pages.
+- Add hide/feature controls.
+- Add social share preview.
+
+### BE PR 4: Wallet Import And Snapshot V1
+
+- Resolve wallet/ENS inputs.
+- Import NFT holdings.
+- Group by collection.
+- Store snapshot metadata.
+- Provide preview data for FE generator.
+
+### Cross-Repo PR: AI Agent Affordances V1
+
+- Add JSON schema bundle export.
+- Add source packet export.
+- Add initial MCP read/validate/preview tools.
+- Add `SKILL.md` guidance for wallet gallery and package validation.
+- Add agent patch schema.
+- Add agent patch validation.
+- Add optional agent patch import/review UI if scope allows.
+
+### Cross-Repo PR: Publish End-To-End
+
+- Add package signing UX.
+- Add backend signature verification.
+- Add package signature display.
+- Add tests for unauthorized publish attempts.
+- Add upload, sign, pointer publish, and live route E2E.
+
+### Cross-Repo PR: Version History And Rollback
+
+- Add published version list.
+- Add rollback action.
+- Add pointer event display.
+- Add tests for rollback to earlier package.
+
+## Definition Of Done For Public Launch
+
+Public launch should not happen until:
+
+- Profiles can publish primary CMS sites.
+- Published packages are signed.
+- Published packages are stored on IPFS and/or Arweave.
+- 6529.io only accelerates content; it is not the sole canonical store.
+- Profile pages link clearly to primary sites.
+- Wallet gallery generator works with live data.
+- Social previews are good.
+- Renderer passes desktop and mobile checks.
+- Security review covers untrusted content handling.
+- Users can export package/provenance details.
+- Internal docs explain how to mirror and validate a package.

--- a/ops/workstreams/profile-native-cms-roadmap/run-log.md
+++ b/ops/workstreams/profile-native-cms-roadmap/run-log.md
@@ -1,0 +1,397 @@
+# Profile Native CMS Run Log
+
+## 2026-06-17
+
+### Current Objective
+
+Define the full roadmap for a profile-native 6529 CMS that can launch before
+full decentralization while minimizing future migration cost.
+
+The CMS should let any profile publish a website at `/{handle}/index.html`,
+with the normal profile page staying at `/{handle}`.
+
+### Current Status
+
+Roadmap/spec docs exist and are being iterated:
+
+- `ops/workstreams/profile-native-cms-roadmap/README.md`
+- `ops/workstreams/profile-native-cms-roadmap/active-context.md`
+- `ops/workstreams/profile-native-cms-roadmap/product-technical-roadmap.md`
+- `ops/workstreams/profile-native-cms-roadmap/run-log.md`
+
+No implementation code has been changed in this specific roadmap pass. This is
+planning/spec work.
+
+### Decisions Captured
+
+- CMS capability should be available to all profiles.
+- Museum, Capital, About, Education, Blog, News, OM, and similar sections should
+  become profile-owned CMS sites, not privileged app route families.
+- `/{handle}` remains the profile page.
+- `/{handle}/index.html` is the primary profile website.
+- The profile page should link directly to the CMS site when a primary site is
+  published.
+- The first real publish path should use decentralized storage from the start.
+- AWS/S3/CloudFront can accelerate content, but should not be canonical.
+- The durable artifact should be a signed, content-addressed, portable CMS
+  package.
+- 6529 should not pay for arbitrary user inference.
+- Instead, 6529 should expose AI-agent affordances: schemas, MCP tools,
+  `SKILL.md`, source packets, validation output, package examples, and patch
+  import/review.
+- Astro/Starlight exporters are not needed in V1.
+- Jekyll/Hugo/Eleventy/Docusaurus/VitePress/MkDocs/Gatsby/Zola exporters are
+  also not needed in V1.
+- We should steal proven static-site ideas and implement them natively in the
+  6529 CMS package/renderer.
+
+### Prior Art Studied
+
+Astro/Starlight:
+
+- Typed content collections.
+- Source loaders.
+- Static-first islands.
+- Frontmatter-style metadata.
+- Generated navigation.
+- Static search.
+- I18n-ready fields.
+- Plugin boundaries.
+- Docs ergonomics.
+- Editor/agent schema support.
+
+Additional static-site systems:
+
+- Jekyll: front matter, front matter defaults, collections.
+- Hugo: archetypes, taxonomies.
+- Eleventy: data cascade, pagination, permalinks, collections, directory data.
+- Docusaurus: sidebar, docs versioning, i18n.
+- VitePress: frontmatter, build-time data loading.
+- MkDocs/Material: simple site config, docs defaults, search/i18n ergonomics.
+- Gatsby: source plugin/data normalization idea, without GraphQL lock-in.
+- Zola: single-binary/local-first/static/no-database posture.
+
+### Native 6529 Ideas Added From Prior Art
+
+- Typed CMS collections.
+- Site manifest.
+- Scoped metadata defaults.
+- Data cascade and override semantics.
+- Archetypes as page/site creation recipes.
+- Taxonomies, tags, terms, and facets.
+- Safe block macros.
+- Deterministic pagination.
+- Permalinks, aliases, and route collision validation.
+- Static search manifest.
+- I18n-ready package fields.
+- Source loaders/source packets.
+- Markdown import/export for docs/posts.
+- Controlled theme slots rather than arbitrary runtime swizzling.
+- Static build manifest.
+- Standalone validator/exporter/local tooling direction.
+
+### Current Roadmap Shape
+
+Near-term sequence:
+
+1. Lock V1 cutline.
+2. Decide storage/signing/hash/pointer/route/media details.
+3. Add package schemas for typed collections, site manifest, defaults, cascade,
+   archetypes, taxonomies, macros, pagination, permalinks, aliases, search,
+   locale/i18n, loader outputs, plugin manifests, and build manifests.
+4. Add profile CMS route and profile-page website button.
+5. Add signed publish flow with IPFS/Arweave receipts.
+6. Harden renderer and validator.
+7. Add plain static HTML export.
+8. Build dashboard/builder V1.
+9. Expand wallet gallery generator into home, collection, NFT, taxonomy, and
+   paginated pages.
+10. Add AI-agent affordances.
+11. Add 3D rooms.
+12. Add transaction explainers.
+13. Add standalone validator/renderer and mirror/Electron workflows.
+
+### Open Decisions
+
+- Required storage policy: IPFS only, Arweave only, or one required plus one
+  recommended.
+- Signature scheme: EIP-712 now or EIP-191 first.
+- Canonical JSON/hash implementation.
+- Pointer concurrency and rollback event model.
+- Route conflict policy for handles that overlap app routes.
+- Initial package size/media upload limits.
+- First 6529 collections that get custom native templates.
+- Which AI-agent affordances ship in V1.
+- Whether agent patch import is V1 or V1.1.
+
+### Next Work
+
+If continuing this roadmap/spec exercise:
+
+1. Review the schema list and turn it into concrete JSON schema file names.
+2. Define V1 package manifest shape in more detail.
+3. Define V1 route manifest shape in more detail.
+4. Define V1 static export output directory shape.
+5. Define V1 MCP tool list and permissions.
+6. Define first `SKILL.md` files and what each should contain.
+7. Decide whether to keep this in frontend repo or move to 6529mono before
+   implementation planning begins.
+
+## 2026-06-17: Phase 0 And Phase 1 Delivery
+
+### Current Objective
+
+Enter `6529-autonomous-manager` mode with subagents and deliver Phase 0 and
+Phase 1 for the profile-native CMS roadmap.
+
+### Output
+
+Added Phase 0:
+
+- `ops/workstreams/profile-native-cms-roadmap/phase-0/decision-record.md`
+- `ops/workstreams/profile-native-cms-roadmap/phase-0/storm-lanes.md`
+- `ops/workstreams/profile-native-cms-roadmap/phase-0/test-matrix.md`
+- `ops/workstreams/profile-native-cms-roadmap/phase-0/pr-wave-plan.md`
+
+Added Phase 1:
+
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/README.md`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/schema-index.md`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/schemas/cms-package-v1.schema.json`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/schemas/agent-patch-v1.schema.json`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/schemas/validation-result-v1.schema.json`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/README.md`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/minimal-profile-homepage.package.json`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/wallet-gallery.package.json`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/collection-page.package.json`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/nft-detail.package.json`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/art-media.package.json`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/exhibition-room.package.json`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/legacy-migration.package.json`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/invalid/missing-signature.package.json`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/invalid/route-collision.package.json`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/hash-test-vectors.md`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/validation-plan.md`
+
+### Subagent Review Integrated
+
+- Schema/fixture review: keep the Phase 1 corpus portable, then move or mirror
+  executable protocol code into `lib/profile-cms/protocol/v1/` or a shared
+  6529mono package.
+- Publish/storage review: spell out canonicalization, signing, EIP-1271/Safe,
+  storage receipts, replay protection, pointer concurrency, rollback, and
+  idempotency.
+- Frontend route/render review: make `/{handle}` and
+  `/{handle}/index.html` distinct, reserve app roots, keep CMS pages outside
+  profile-tab layout, and classify CMS analytics separately.
+- Manager review: distinguish docs-only readiness from code landed, define
+  artifact paths, owner/signoff state, validator behavior, and residual gaps.
+
+### Validation Evidence
+
+Completed locally:
+
+- JSON parse for all Phase 1 schemas and fixtures.
+- Focused route duplicate check across valid and invalid fixtures.
+- `codex-diff-check -- ops/workstreams/profile-native-cms-roadmap` passed.
+- Non-ASCII scan for Markdown and JSON artifacts found no non-ASCII.
+- `node -e "require.resolve('ajv')"` confirmed `ajv` is not currently
+  resolvable, so full schema validation is explicitly deferred.
+- Documentation memory updated after review.
+
+Known gaps:
+
+- Full JSON Schema validation has not run because `ajv` is not currently
+  resolvable in the local Node environment.
+- Hash vectors are placeholder-shaped until RFC 8785 canonicalization lands.
+- No runtime FE or BE code was changed in this pass.
+
+### Next Work
+
+Wave 0 implementation:
+
+1. Add executable protocol code and schema validation.
+2. Generate real canonical hash vectors.
+3. Wire FE and BE tests to the same fixture corpus.
+4. Start route/render and publish/storage implementation behind feature flags.
+
+### Second-Pass Review
+
+Found and fixed:
+
+- `legacy-migration.package.json` was marked valid but emitted a CMS alias at
+  `/museum/the-memes/index.html`, outside the owning `6529museum` profile
+  namespace. The fixture now keeps the imported legacy route as provenance
+  metadata and emits the alias at
+  `/6529museum/legacy/museum/the-memes/index.html`.
+
+Additional validation completed:
+
+- Custom semantic pass over all fixtures for route namespace, duplicate routes,
+  page references, navigation references, metadata social-image references,
+  block asset/page/NFT references, NFT media profile asset references, deep zoom
+  references, room placement references, taxonomy page references, signatures,
+  storage receipts, and primary routes.
+- All seven valid fixtures passed that semantic pass.
+- `invalid/route-collision.package.json` still fails the intended duplicate
+  route check.
+- Python `jsonschema` is also unavailable locally, matching the existing
+  `ajv` full-schema-validation gap.
+
+### PR Bot Review Iteration
+
+PR #2707 bot feedback:
+
+- 6529bot security: no security findings; non-blocking notes on unsafe URL
+  schemes, extensible block fields, fixture signatures, signer normalization,
+  and EIP-55 validation.
+- 6529bot general: good to merge; non-blocking notes on route kind semantics,
+  route/profile namespace validation, `unknown` block semantics, and placeholder
+  hashes.
+- CodeRabbit: review rate limit reached, with status context passing and no
+  actionable inline findings.
+
+Changes made from bot feedback:
+
+- Added first-class `html_embed` block type.
+- Removed `unknown` from the V1 valid block type enum.
+- Changed the mixed-media fixture to use `html_embed` instead of `unknown`.
+- Added `invalid/unknown-block.package.json` to document fail-closed behavior.
+- Expanded validation-plan semantic checks for route kind variants, alias/redirect
+  namespace matching, unsafe URL schemes, unknown URL-bearing block properties,
+  production rejection of fixture signatures, signer normalization, and EIP-55
+  validation.
+- Tightened roadmap language so unsupported blocks fail closed in V1.
+
+## 2026-06-17: Art And NFT Display Research
+
+### Current Objective
+
+Go deep on best practices for displaying art and NFTs in both 2D and 3D.
+
+### Output
+
+Added:
+
+- `ops/workstreams/profile-native-cms-roadmap/art-nft-display-best-practices.md`
+
+Linked it from:
+
+- `ops/workstreams/profile-native-cms-roadmap/README.md`
+- `ops/workstreams/profile-native-cms-roadmap/active-context.md`
+
+### Research Sources
+
+Reviewed official or primary docs for:
+
+- IIIF Image and Presentation APIs.
+- ERC-721 and OpenSea metadata standards.
+- Khronos glTF and glTF PBR.
+- three.js GLTFLoader, DRACOLoader, KTX2Loader, LoadingManager.
+- model-viewer.
+- web.dev image performance and lazy loading.
+- WCAG 2.2, W3C alt text guidance, captions, and transcripts.
+- C2PA/content credentials.
+
+### Design Conclusions
+
+2D:
+
+- Art display should be art-first, aspect-ratio preserving, and faithful by
+  default.
+- Detail pages should never depend on cropped marketplace-style thumbnails.
+- Grids can have dense/cropped modes, but detail views need full artwork.
+- High-resolution still images need optional deep zoom/IIIF-like tile manifests.
+- Every heavy/non-instant media type needs a poster and fallback.
+- Provenance, source media, display derivatives, social images, and original
+  assets should be represented separately.
+
+3D:
+
+- V1 should ship simple 3D rooms and object viewers, not a full 3D world editor.
+- 2D art inside 3D rooms needs a faithful display mode where room lighting does
+  not alter the artwork pixels.
+- 3D rooms must always link each work to a faithful 2D detail page.
+- GLB/glTF should be the runtime default for 3D assets.
+- Posters, deferred loading, mobile fallback, canvas nonblank tests, and
+  performance budgets are required.
+
+Schema implications:
+
+- Add `art_asset`.
+- Add `display_variant`.
+- Add `nft_media_profile`.
+- Add `deep_zoom_manifest`.
+- Add `exhibition_room`.
+- Add `artwork_placement`.
+- Add `interactive_policy`.
+
+### Next Work
+
+- Fold the new art/NFT schema implications into the main product roadmap schema
+  and track sections.
+- Decide whether V1 object viewer uses `model-viewer`, Three.js directly, or
+  both.
+- Define V1 media size/texture budgets.
+- Define V1 3D room template and fallback behavior.
+- Decide which 6529 collections get custom art display templates first.
+
+## 2026-06-17: Agentic Storm Phase Plan
+
+### Current Objective
+
+Do a final roadmap review and reorganize the work into logical phases for an
+aggressive multi-agent implementation storm.
+
+### Output
+
+Added:
+
+- `ops/workstreams/profile-native-cms-roadmap/agentic-storm-execution-plan.md`
+
+Updated:
+
+- `ops/workstreams/profile-native-cms-roadmap/README.md`
+- `ops/workstreams/profile-native-cms-roadmap/active-context.md`
+
+### Phase Structure
+
+The roadmap is now organized into these execution phases:
+
+1. Command Center And Decision Lock.
+2. Protocol And Fixture Foundation.
+3. Native Renderer, Routes, And Static Export.
+4. Publish, Storage, Signing, And Pointer Ledger.
+5. Builder MVP.
+6. Wallet Gallery Generator.
+7. Art/NFT Display Excellence.
+8. 3D Rooms And Object Viewer.
+9. AI-Agent Affordances.
+10. Institutional Migration Pilot.
+11. Decentralization Hardening.
+
+### Storm Design
+
+The storm plan defines:
+
+- Storm rules.
+- Critical path.
+- Parallelization map.
+- Suggested agent roster.
+- PR wave plan.
+- Launch readiness gate.
+- Anti-patterns.
+- First 72 hours plan.
+
+### Key Recommendation
+
+Start with Phase 0 and Phase 1 only:
+
+- Lock decisions.
+- Assign lanes.
+- Build shared package schemas.
+- Build shared fixture corpus.
+- Build validator/hash test vectors.
+
+Only then fan agents out across route/render, publish/storage, builder, wallet
+gallery, art display, 3D, AI-agent affordances, and migration lanes.


### PR DESCRIPTION
## Summary

Adds the durable workstream docs for the profile-native CMS roadmap, including:

- full product and technical roadmap for making CMS sites available to all profiles
- agentic storm execution plan organized into phases
- art/NFT 2D and 3D display best-practices research
- Phase 0 decision record, storm lanes, test matrix, and PR wave plan
- Phase 1 protocol foundation with JSON schemas, fixture corpus, hash vector plan, and validation plan

## Validation

From the isolated PR worktree:

- Parsed all Phase 1 schemas and fixtures as JSON with Node.
- Ran custom semantic fixture checks over valid/invalid fixtures for route namespace, duplicate routes, page references, metadata social images, asset/page/NFT references, signatures, storage receipts, and primary routes.
- Confirmed the intentional invalid route-collision fixture still reports duplicate `/punk6529/index.html`.
- Ran `codex-diff-check -- ops\workstreams\profile-native-cms-roadmap`.
- Ran a non-ASCII scan over Markdown and JSON artifacts.

## Notes

This PR is docs/protocol/fixture work only. It does not change runtime frontend behavior.

Full JSON Schema validation remains explicitly deferred because neither local Node `ajv` nor Python `jsonschema` is available in this environment.