### PR TITLE
Enable responsiveness 6529bot review

### DIFF
--- a/.github/6529bot.yml
+++ b/.github/6529bot.yml
@@ -2,8 +2,8 @@ version: 1
 enabled: true
 
 reviewKinds:
-  allowed: [general, followup, wcag, i18n, security]
-  initial: [general, security]
+  allowed: [general, followup, wcag, i18n, security, responsiveness]
+  initial: [general, security, responsiveness]
   followup: [followup]
 
 commands:


### PR DESCRIPTION
## Summary
- allow the new 6529bot responsiveness review kind
- add responsiveness as the third automatic initial 6529bot review alongside general and security

## Validation
- Parsed with 6529reviewbot repository config validator on the deployed reviewbot schema.