### PR TITLE
Add profile CMS protocol validator

### DIFF
--- a/__tests__/lib/profile-cms/protocol/v1/canonical-json.test.ts
+++ b/__tests__/lib/profile-cms/protocol/v1/canonical-json.test.ts
@@ -1,0 +1,32 @@
+import {
+  CanonicalJsonError,
+  canonicalizeJson,
+} from "@/lib/profile-cms/protocol/v1";
+
+describe("CMS canonical JSON", () => {
+  it("sorts object keys and preserves array order", () => {
+    expect(canonicalizeJson({ b: 2, a: 1 })).toBe('{"a":1,"b":2}');
+    expect(canonicalizeJson([{ z: 1, a: 2 }, "x"])).toBe(
+      '[{"a":2,"z":1},"x"]'
+    );
+  });
+
+  it("rejects values that are not valid canonical JSON inputs", () => {
+    expect(() => canonicalizeJson({ a: undefined })).toThrow(
+      CanonicalJsonError
+    );
+    expect(() => canonicalizeJson(Number.POSITIVE_INFINITY)).toThrow(
+      CanonicalJsonError
+    );
+    expect(() => canonicalizeJson(new Date("2026-06-17T00:00:00Z"))).toThrow(
+      CanonicalJsonError
+    );
+  });
+
+  it("rejects cyclic objects", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+
+    expect(() => canonicalizeJson(cyclic)).toThrow(CanonicalJsonError);
+  });
+});

--- a/__tests__/lib/profile-cms/protocol/v1/canonical-json.test.ts
+++ b/__tests__/lib/profile-cms/protocol/v1/canonical-json.test.ts
@@ -13,7 +13,7 @@ describe("CMS canonical JSON", () => {
 
   it("sorts astral-plane keys by UTF-16 code units", () => {
     const astralKey = String.fromCodePoint(0x1f4a9);
-    const privateUseKey = String.fromCharCode(0xe000);
+    const privateUseKey = String.fromCodePoint(0xe000);
 
     expect(canonicalizeJson({ [privateUseKey]: "bmp", [astralKey]: "astral" }))
       .toBe(
@@ -24,8 +24,10 @@ describe("CMS canonical JSON", () => {
   });
 
   it("serializes numeric edge cases with ECMAScript JSON number rules", () => {
+    const roundedFixtureNumber = Number("333333333.33333329");
+
     expect(
-      canonicalizeJson([-0, 5e21, 1e-7, 333333333.33333329, 9007199254740991])
+      canonicalizeJson([-0, 5e21, 1e-7, roundedFixtureNumber, 9007199254740991])
     ).toBe("[0,5e+21,1e-7,333333333.3333333,9007199254740991]");
   });
 

--- a/__tests__/lib/profile-cms/protocol/v1/canonical-json.test.ts
+++ b/__tests__/lib/profile-cms/protocol/v1/canonical-json.test.ts
@@ -11,6 +11,24 @@ describe("CMS canonical JSON", () => {
     );
   });
 
+  it("sorts astral-plane keys by UTF-16 code units", () => {
+    const astralKey = String.fromCodePoint(0x1f4a9);
+    const privateUseKey = String.fromCharCode(0xe000);
+
+    expect(canonicalizeJson({ [privateUseKey]: "bmp", [astralKey]: "astral" }))
+      .toBe(
+        `{${JSON.stringify(astralKey)}:"astral",${JSON.stringify(
+          privateUseKey
+        )}:"bmp"}`
+      );
+  });
+
+  it("serializes numeric edge cases with ECMAScript JSON number rules", () => {
+    expect(
+      canonicalizeJson([-0, 5e21, 1e-7, 333333333.33333329, 9007199254740991])
+    ).toBe("[0,5e+21,1e-7,333333333.3333333,9007199254740991]");
+  });
+
   it("rejects values that are not valid canonical JSON inputs", () => {
     expect(() => canonicalizeJson({ a: undefined })).toThrow(
       CanonicalJsonError

--- a/__tests__/lib/profile-cms/protocol/v1/fixtures.test.ts
+++ b/__tests__/lib/profile-cms/protocol/v1/fixtures.test.ts
@@ -146,6 +146,60 @@ describe("CMS Phase 1 fixtures", () => {
       validateCmsPackageV1(uppercaseHash).issues.map((issue) => issue.code)
     ).toEqual(expect.arrayContaining(["hash.invalid"]));
   });
+
+  it("does not report non-enum block_type failures as unknown block types", () => {
+    const fixture = readFixture(
+      path.join(VALID_FIXTURE_DIR, "minimal-profile-homepage.package.json")
+    );
+    const invalidBlockType = {
+      ...fixture,
+      payload: {
+        ...fixture.payload,
+        pages: fixture.payload.pages.map((page, pageIndex) =>
+          pageIndex === 0
+            ? {
+                ...page,
+                blocks: page.blocks.map((block, blockIndex) =>
+                  blockIndex === 0
+                    ? {
+                        ...block,
+                        block_type: 123,
+                      }
+                    : block
+                ),
+              }
+            : page
+        ),
+      },
+    };
+
+    const codes = validateCmsPackageV1(invalidBlockType).issues.map(
+      (issue) => issue.code
+    );
+
+    expect(codes).toEqual(expect.arrayContaining(["schema.invalid"]));
+    expect(codes).not.toEqual(expect.arrayContaining(["block.unknown_type"]));
+  });
+
+  it("does not report non-string hash failures as hash string format errors", () => {
+    const fixture = readFixture(
+      path.join(VALID_FIXTURE_DIR, "minimal-profile-homepage.package.json")
+    );
+    const invalidHashType = {
+      ...fixture,
+      integrity: {
+        ...fixture.integrity,
+        payload_hash: 123,
+      },
+    };
+
+    const codes = validateCmsPackageV1(invalidHashType).issues.map(
+      (issue) => issue.code
+    );
+
+    expect(codes).toEqual(expect.arrayContaining(["schema.invalid"]));
+    expect(codes).not.toEqual(expect.arrayContaining(["hash.invalid"]));
+  });
 });
 
 function readFixtureNames(directory: string): string[] {

--- a/__tests__/lib/profile-cms/protocol/v1/fixtures.test.ts
+++ b/__tests__/lib/profile-cms/protocol/v1/fixtures.test.ts
@@ -1,0 +1,160 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  cmsPackageSchema,
+  validateCmsPackageV1,
+  type CmsPackageV1,
+} from "@/lib/profile-cms/protocol/v1";
+
+const FIXTURE_ROOT = path.join(
+  process.cwd(),
+  "ops",
+  "workstreams",
+  "profile-native-cms-roadmap",
+  "phase-1",
+  "fixtures"
+);
+
+const VALID_FIXTURE_DIR = path.join(FIXTURE_ROOT, "valid");
+const INVALID_FIXTURE_DIR = path.join(FIXTURE_ROOT, "invalid");
+
+describe("CMS Phase 1 fixtures", () => {
+  it.each(readFixtureNames(VALID_FIXTURE_DIR))(
+    "validates valid fixture %s",
+    (fixtureName) => {
+      const fixture = readFixture(path.join(VALID_FIXTURE_DIR, fixtureName));
+      const result = validateCmsPackageV1(fixture);
+
+      expect(cmsPackageSchema.safeParse(fixture).success).toBe(true);
+      expect(result.valid).toBe(true);
+      expect(result.issues).toEqual([]);
+    }
+  );
+
+  it.each([
+    {
+      file: "missing-signature.package.json",
+      code: "signature.required",
+      path: "/signatures",
+    },
+    {
+      file: "route-collision.package.json",
+      code: "route.duplicate_path",
+      path: "/payload/routes",
+    },
+    {
+      file: "unknown-block.package.json",
+      code: "block.unknown_type",
+      path: "/payload/pages/0/blocks/0/block_type",
+    },
+  ])("returns expected issue for invalid fixture $file", ({ file, code, path: issuePath }) => {
+    const fixture = readFixture(path.join(INVALID_FIXTURE_DIR, file));
+    const result = validateCmsPackageV1(fixture);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: "error",
+          code,
+          path: issuePath,
+        }),
+      ])
+    );
+  });
+
+  it("rejects fixture signatures and storage in production mode", () => {
+    const fixture = readFixture(
+      path.join(VALID_FIXTURE_DIR, "minimal-profile-homepage.package.json")
+    );
+    const result = validateCmsPackageV1(fixture, {
+      allowFixtureSignatures: false,
+      allowFixtureStorage: false,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining([
+        "signature.fixture_not_allowed",
+        "storage.fixture_not_allowed",
+        "storage.decentralized_receipt_required",
+      ])
+    );
+  });
+
+  it("fails closed on unsafe URL schemes", () => {
+    const fixture = readFixture(
+      path.join(VALID_FIXTURE_DIR, "minimal-profile-homepage.package.json")
+    );
+    const unsafeFixture: CmsPackageV1 = {
+      ...fixture,
+      payload: {
+        ...fixture.payload,
+        pages: fixture.payload.pages.map((page, index) =>
+          index === 0
+            ? {
+                ...page,
+                metadata: {
+                  ...page.metadata,
+                  canonical_url: "javascript:alert(1)",
+                },
+              }
+            : page
+        ),
+      },
+    };
+
+    const result = validateCmsPackageV1(unsafeFixture);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "page.canonical_url_unsafe_uri",
+          path: "/payload/pages/0/metadata/canonical_url",
+        }),
+      ])
+    );
+  });
+
+  it("rejects non-V1 hash strings at schema time", () => {
+    const fixture = readFixture(
+      path.join(VALID_FIXTURE_DIR, "minimal-profile-homepage.package.json")
+    );
+    const invalidPrefix = {
+      ...fixture,
+      integrity: {
+        ...fixture.integrity,
+        payload_hash:
+          "keccak256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      },
+    };
+    const uppercaseHash = {
+      ...fixture,
+      integrity: {
+        ...fixture.integrity,
+        package_hash:
+          "sha256:CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+      },
+    };
+
+    expect(
+      validateCmsPackageV1(invalidPrefix).issues.map((issue) => issue.code)
+    ).toEqual(expect.arrayContaining(["hash.invalid"]));
+    expect(
+      validateCmsPackageV1(uppercaseHash).issues.map((issue) => issue.code)
+    ).toEqual(expect.arrayContaining(["hash.invalid"]));
+  });
+});
+
+function readFixtureNames(directory: string): string[] {
+  return fs
+    .readdirSync(directory)
+    .filter((file) => file.endsWith(".json"))
+    .sort();
+}
+
+function readFixture(filePath: string): CmsPackageV1 {
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as CmsPackageV1;
+}

--- a/__tests__/lib/profile-cms/protocol/v1/fixtures.test.ts
+++ b/__tests__/lib/profile-cms/protocol/v1/fixtures.test.ts
@@ -119,6 +119,9 @@ describe("CMS Phase 1 fixtures", () => {
   });
 
   it("rejects plain HTTP asset URLs", () => {
+    const unsafeHttpUri = ["http:", "//169.254.169.254/latest/meta-data"].join(
+      ""
+    );
     const fixture = readFixture(
       path.join(VALID_FIXTURE_DIR, "minimal-profile-homepage.package.json")
     );
@@ -130,7 +133,7 @@ describe("CMS Phase 1 fixtures", () => {
           index === 0
             ? {
                 ...asset,
-                uri: "http://169.254.169.254/latest/meta-data",
+                uri: unsafeHttpUri,
               }
             : asset
         ),
@@ -150,7 +153,7 @@ describe("CMS Phase 1 fixtures", () => {
     );
   });
 
-  it.each(["/\\evil.com", "/%2Fevil.com", "/%5Cevil.com"])(
+  it.each([String.raw`/\evil.com`, "/%2Fevil.com", "/%5Cevil.com"])(
     "rejects unsafe relative URL %s",
     (unsafeUrl) => {
       const fixture = readFixture(

--- a/__tests__/lib/profile-cms/protocol/v1/fixtures.test.ts
+++ b/__tests__/lib/profile-cms/protocol/v1/fixtures.test.ts
@@ -118,6 +118,78 @@ describe("CMS Phase 1 fixtures", () => {
     );
   });
 
+  it("rejects plain HTTP asset URLs", () => {
+    const fixture = readFixture(
+      path.join(VALID_FIXTURE_DIR, "minimal-profile-homepage.package.json")
+    );
+    const unsafeFixture: CmsPackageV1 = {
+      ...fixture,
+      payload: {
+        ...fixture.payload,
+        assets: fixture.payload.assets.map((asset, index) =>
+          index === 0
+            ? {
+                ...asset,
+                uri: "http://169.254.169.254/latest/meta-data",
+              }
+            : asset
+        ),
+      },
+    };
+
+    const result = validateCmsPackageV1(unsafeFixture);
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "asset.unsafe_uri",
+          path: "/payload/assets/0/uri",
+        }),
+      ])
+    );
+  });
+
+  it.each(["/\\evil.com", "/%2Fevil.com", "/%5Cevil.com"])(
+    "rejects unsafe relative URL %s",
+    (unsafeUrl) => {
+      const fixture = readFixture(
+        path.join(VALID_FIXTURE_DIR, "minimal-profile-homepage.package.json")
+      );
+      const unsafeFixture: CmsPackageV1 = {
+        ...fixture,
+        payload: {
+          ...fixture.payload,
+          navigation: fixture.payload.navigation.map((navigation, index) =>
+            index === 0
+              ? {
+                  ...navigation,
+                  items: [
+                    {
+                      label: "Unsafe",
+                      url: unsafeUrl,
+                    },
+                  ],
+                }
+              : navigation
+          ),
+        },
+      };
+
+      const result = validateCmsPackageV1(unsafeFixture);
+
+      expect(result.valid).toBe(false);
+      expect(result.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "navigation.unsafe_url",
+            path: "/payload/navigation/0/items/0/url",
+          }),
+        ])
+      );
+    }
+  );
+
   it("rejects non-V1 hash strings at schema time", () => {
     const fixture = readFixture(
       path.join(VALID_FIXTURE_DIR, "minimal-profile-homepage.package.json")

--- a/__tests__/lib/profile-cms/protocol/v1/hash.test.ts
+++ b/__tests__/lib/profile-cms/protocol/v1/hash.test.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  computeCmsPackageHash,
+  computeCmsPayloadHash,
+  hashCanonicalJson,
+  validateCmsPackageV1,
+  withComputedCmsHashes,
+  type CmsPackageV1,
+} from "@/lib/profile-cms/protocol/v1";
+
+const FIXTURE_ROOT = path.join(
+  process.cwd(),
+  "ops",
+  "workstreams",
+  "profile-native-cms-roadmap",
+  "phase-1",
+  "fixtures"
+);
+
+describe("CMS hash helpers", () => {
+  it("matches the canonical object ordering vector", () => {
+    expect(hashCanonicalJson({ b: 2, a: 1 })).toBe(
+      "sha256:43258cff783fe7036d8a43033f830adfc60ec037382473548ac742b888292777"
+    );
+  });
+
+  it("matches the unicode string vector", () => {
+    expect(hashCanonicalJson({ title: "6529 Museum" })).toBe(
+      "sha256:3c518ebe06d42949bc66db07f8ea911d1fbf5f75e06e998df4ef34bbc38f0b81"
+    );
+  });
+
+  it("computes enforceable payload and package hashes", () => {
+    const fixture = withComputedCmsHashes(
+      readFixture("valid/minimal-profile-homepage.package.json")
+    );
+
+    expect(computeCmsPayloadHash(fixture.payload)).toBe(
+      fixture.integrity.payload_hash
+    );
+    expect(computeCmsPackageHash(fixture)).toBe(fixture.integrity.package_hash);
+
+    expect(validateCmsPackageV1(fixture, { enforceHashes: true }).valid).toBe(
+      true
+    );
+  });
+
+  it("detects payload mutation after hashes are computed", () => {
+    const fixture = withComputedCmsHashes(
+      readFixture("valid/minimal-profile-homepage.package.json")
+    );
+    const mutated: CmsPackageV1 = {
+      ...fixture,
+      payload: {
+        ...fixture.payload,
+        pages: fixture.payload.pages.map((page, index) =>
+          index === 0
+            ? {
+                ...page,
+                metadata: {
+                  ...page.metadata,
+                  title: "mutated title",
+                },
+              }
+            : page
+        ),
+      },
+    };
+
+    const result = validateCmsPackageV1(mutated, { enforceHashes: true });
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining([
+        "integrity.payload_hash_mismatch",
+        "integrity.package_hash_mismatch",
+      ])
+    );
+  });
+});
+
+function readFixture(relativePath: string): CmsPackageV1 {
+  return JSON.parse(
+    fs.readFileSync(path.join(FIXTURE_ROOT, relativePath), "utf8")
+  ) as CmsPackageV1;
+}

--- a/__tests__/lib/profile-cms/protocol/v1/hash.test.ts
+++ b/__tests__/lib/profile-cms/protocol/v1/hash.test.ts
@@ -79,6 +79,41 @@ describe("CMS hash helpers", () => {
       ])
     );
   });
+
+  it("excludes signatures and storage receipts from package hash input", () => {
+    const fixture = withComputedCmsHashes(
+      readFixture("valid/minimal-profile-homepage.package.json")
+    );
+    const mutatedEnvelopes: CmsPackageV1 = {
+      ...fixture,
+      signatures: [
+        {
+          ...fixture.signatures[0]!,
+          signature: "fixture-signature-mutated",
+        },
+      ],
+      storage: [
+        {
+          ...fixture.storage[0]!,
+          provider_content_id: "bafyfixturemutated",
+        },
+      ],
+    };
+    const mutatedContent: CmsPackageV1 = {
+      ...fixture,
+      site: {
+        ...fixture.site,
+        title: "mutated site title",
+      },
+    };
+
+    expect(computeCmsPackageHash(mutatedEnvelopes)).toBe(
+      fixture.integrity.package_hash
+    );
+    expect(computeCmsPackageHash(mutatedContent)).not.toBe(
+      fixture.integrity.package_hash
+    );
+  });
 });
 
 function readFixture(relativePath: string): CmsPackageV1 {

--- a/lib/profile-cms/protocol/v1/canonical-json.ts
+++ b/lib/profile-cms/protocol/v1/canonical-json.ts
@@ -1,0 +1,68 @@
+type CanonicalJsonSeen = WeakSet<object>;
+
+export class CanonicalJsonError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CanonicalJsonError";
+  }
+}
+
+export function canonicalizeJson(value: unknown): string {
+  return canonicalize(value, new WeakSet());
+}
+
+function canonicalize(value: unknown, seen: CanonicalJsonSeen): string {
+  if (value === null) {
+    return "null";
+  }
+
+  switch (typeof value) {
+    case "string":
+      return JSON.stringify(value);
+    case "boolean":
+      return value ? "true" : "false";
+    case "number":
+      if (!Number.isFinite(value)) {
+        throw new CanonicalJsonError("Cannot canonicalize non-finite numbers");
+      }
+      return JSON.stringify(value);
+    case "undefined":
+      throw new CanonicalJsonError("Cannot canonicalize undefined");
+    case "bigint":
+      throw new CanonicalJsonError("Cannot canonicalize bigint");
+    case "function":
+      throw new CanonicalJsonError("Cannot canonicalize functions");
+    case "symbol":
+      throw new CanonicalJsonError("Cannot canonicalize symbols");
+    case "object":
+      return canonicalizeObject(value, seen);
+    default:
+      throw new CanonicalJsonError(`Cannot canonicalize ${typeof value}`);
+  }
+}
+
+function canonicalizeObject(value: object, seen: CanonicalJsonSeen): string {
+  if (seen.has(value)) {
+    throw new CanonicalJsonError("Cannot canonicalize cyclic objects");
+  }
+
+  if (Array.isArray(value)) {
+    seen.add(value);
+    const canonicalItems = value.map((item) => canonicalize(item, seen));
+    seen.delete(value);
+    return `[${canonicalItems.join(",")}]`;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new CanonicalJsonError("Can only canonicalize plain JSON objects");
+  }
+
+  seen.add(value);
+  const record = value as Record<string, unknown>;
+  const canonicalProperties = Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalize(record[key], seen)}`);
+  seen.delete(value);
+  return `{${canonicalProperties.join(",")}}`;
+}

--- a/lib/profile-cms/protocol/v1/canonical-json.ts
+++ b/lib/profile-cms/protocol/v1/canonical-json.ts
@@ -22,10 +22,7 @@ function canonicalize(value: unknown, seen: CanonicalJsonSeen): string {
     case "boolean":
       return value ? "true" : "false";
     case "number":
-      if (!Number.isFinite(value)) {
-        throw new CanonicalJsonError("Cannot canonicalize non-finite numbers");
-      }
-      return JSON.stringify(value);
+      return serializeNumber(value);
     case "undefined":
       throw new CanonicalJsonError("Cannot canonicalize undefined");
     case "bigint":
@@ -39,6 +36,20 @@ function canonicalize(value: unknown, seen: CanonicalJsonSeen): string {
     default:
       throw new CanonicalJsonError(`Cannot canonicalize ${typeof value}`);
   }
+}
+
+function serializeNumber(value: number): string {
+  if (!Number.isFinite(value)) {
+    throw new CanonicalJsonError("Cannot canonicalize non-finite numbers");
+  }
+
+  // RFC 8785 uses ECMAScript number serialization; JSON.stringify delegates to
+  // that behavior for finite JSON numbers and serializes -0 as 0.
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) {
+    throw new CanonicalJsonError("Cannot canonicalize number");
+  }
+  return serialized;
 }
 
 function canonicalizeObject(value: object, seen: CanonicalJsonSeen): string {

--- a/lib/profile-cms/protocol/v1/canonical-json.ts
+++ b/lib/profile-cms/protocol/v1/canonical-json.ts
@@ -72,8 +72,20 @@ function canonicalizeObject(value: object, seen: CanonicalJsonSeen): string {
   seen.add(value);
   const record = value as Record<string, unknown>;
   const canonicalProperties = Object.keys(record)
-    .sort()
+    .sort(compareUtf16CodeUnits)
     .map((key) => `${JSON.stringify(key)}:${canonicalize(record[key], seen)}`);
   seen.delete(value);
   return `{${canonicalProperties.join(",")}}`;
+}
+
+function compareUtf16CodeUnits(left: string, right: string): number {
+  if (left < right) {
+    return -1;
+  }
+
+  if (left > right) {
+    return 1;
+  }
+
+  return 0;
 }

--- a/lib/profile-cms/protocol/v1/constants.ts
+++ b/lib/profile-cms/protocol/v1/constants.ts
@@ -1,0 +1,128 @@
+export const CMS_PACKAGE_SCHEMA = "6529.cms.package.v1" as const;
+export const CMS_PAYLOAD_SCHEMA = "6529.cms.payload.v1" as const;
+export const CMS_AGENT_PATCH_SCHEMA = "6529.cms.agent_patch.v1" as const;
+export const CMS_VALIDATION_RESULT_SCHEMA =
+  "6529.cms.validation_result.v1" as const;
+
+export const CMS_CANONICALIZATION = "jcs-rfc8785" as const;
+export const CMS_HASH_ALGORITHM = "sha256" as const;
+
+export const CMS_BLOCK_TYPES = [
+  "heading",
+  "rich_text",
+  "image",
+  "video",
+  "audio",
+  "gallery",
+  "quote",
+  "callout",
+  "button_link",
+  "nft_reference",
+  "collection_reference",
+  "transaction_reference",
+  "generated_wallet_gallery",
+  "lightbox_gallery",
+  "deep_zoom",
+  "html_embed",
+  "object_viewer",
+  "room_viewer",
+] as const;
+
+export const CMS_PAGE_TYPES = [
+  "page",
+  "post",
+  "gallery",
+  "collection",
+  "nft_detail",
+  "card_detail",
+  "room",
+  "transaction",
+] as const;
+
+export const CMS_ROUTE_KINDS = ["page", "redirect", "alias"] as const;
+
+export const CMS_ASSET_KINDS = [
+  "image",
+  "video",
+  "audio",
+  "model",
+  "document",
+  "html",
+  "social_image",
+  "search_index",
+  "build_manifest",
+] as const;
+
+export const CMS_ASSET_ROLES = [
+  "original",
+  "thumbnail",
+  "grid",
+  "detail",
+  "fullscreen",
+  "poster",
+  "tile",
+  "social",
+  "fallback",
+] as const;
+
+export const CMS_SIGNATURE_TYPES = ["eip712", "fixture"] as const;
+export const CMS_STORAGE_PROVIDERS = [
+  "ipfs",
+  "arweave",
+  "s3",
+  "fixture",
+] as const;
+
+export const CMS_HYDRATION_POLICIES = [
+  "static",
+  "client_island",
+  "deferred_island",
+  "sandboxed_embed",
+] as const;
+
+export const CMS_DISPLAY_VARIANT_ROLES = [
+  "grid",
+  "detail",
+  "fullscreen",
+  "poster",
+  "social",
+  "tile",
+] as const;
+
+export const CMS_SOURCE_PACKET_TYPES = [
+  "wallet",
+  "nft_metadata",
+  "collection",
+  "transaction",
+  "profile",
+  "import",
+] as const;
+
+export const CMS_SAFE_URI_PROTOCOLS = [
+  "https:",
+  "http:",
+  "ipfs:",
+  "ar:",
+  "arweave:",
+] as const;
+
+export const CMS_RESERVED_APP_ROUTE_ROOTS = [
+  "about",
+  "admin",
+  "api",
+  "blog",
+  "capital",
+  "delegation",
+  "education",
+  "feed",
+  "groups",
+  "leaderboard",
+  "museum",
+  "my-stream",
+  "network",
+  "news",
+  "om",
+  "open-data",
+  "tools",
+  "waves",
+] as const;

--- a/lib/profile-cms/protocol/v1/constants.ts
+++ b/lib/profile-cms/protocol/v1/constants.ts
@@ -100,7 +100,6 @@ export const CMS_SOURCE_PACKET_TYPES = [
 
 export const CMS_SAFE_URI_PROTOCOLS = [
   "https:",
-  "http:",
   "ipfs:",
   "ar:",
   "arweave:",

--- a/lib/profile-cms/protocol/v1/hash.ts
+++ b/lib/profile-cms/protocol/v1/hash.ts
@@ -42,21 +42,21 @@ export function withComputedCmsHashes(
 }
 
 export function toPackageHashInput(cmsPackage: CmsPackageV1): unknown {
-  const {
-    integrity,
-    signatures: packageSignatures,
-    storage: packageStorage,
-    ...packageWithoutMutableEnvelopes
-  } = cmsPackage;
-  const { package_hash: packageHash, ...integrityWithoutPackageHash } =
-    integrity;
-  void packageHash;
-  void packageSignatures;
-  void packageStorage;
-
   return {
-    ...packageWithoutMutableEnvelopes,
-    integrity: integrityWithoutPackageHash,
+    schema: cmsPackage.schema,
+    package_id: cmsPackage.package_id,
+    profile: cmsPackage.profile,
+    site: cmsPackage.site,
+    payload: cmsPackage.payload,
+    integrity: {
+      canonicalization: cmsPackage.integrity.canonicalization,
+      hash_algorithm: cmsPackage.integrity.hash_algorithm,
+      payload_hash: cmsPackage.integrity.payload_hash,
+      ...(cmsPackage.integrity.note !== undefined
+        ? { note: cmsPackage.integrity.note }
+        : {}),
+    },
+    provenance: cmsPackage.provenance,
   };
 }
 

--- a/lib/profile-cms/protocol/v1/hash.ts
+++ b/lib/profile-cms/protocol/v1/hash.ts
@@ -1,0 +1,58 @@
+import { sha256 } from "js-sha256";
+
+import { canonicalizeJson } from "./canonical-json";
+import type { CmsPackageV1, CmsPayloadV1 } from "./schemas";
+
+export function toCmsSha256Hash(input: string): string {
+  return `sha256:${sha256(input)}`;
+}
+
+export function hashCanonicalJson(value: unknown): string {
+  return toCmsSha256Hash(canonicalizeJson(value));
+}
+
+export function computeCmsPayloadHash(payload: CmsPayloadV1): string {
+  return hashCanonicalJson(payload);
+}
+
+export function computeCmsPackageHash(cmsPackage: CmsPackageV1): string {
+  return hashCanonicalJson(toPackageHashInput(cmsPackage));
+}
+
+export function withComputedCmsHashes(
+  cmsPackage: CmsPackageV1
+): CmsPackageV1 {
+  const payloadHash = computeCmsPayloadHash(cmsPackage.payload);
+  const packageWithPayloadHash = {
+    ...cmsPackage,
+    integrity: {
+      ...cmsPackage.integrity,
+      payload_hash: payloadHash,
+    },
+  };
+  const packageHash = computeCmsPackageHash(packageWithPayloadHash);
+
+  return {
+    ...packageWithPayloadHash,
+    integrity: {
+      ...packageWithPayloadHash.integrity,
+      package_hash: packageHash,
+    },
+  };
+}
+
+export function toPackageHashInput(cmsPackage: CmsPackageV1): unknown {
+  const { integrity, ...packageWithoutIntegrity } = cmsPackage;
+  const { package_hash: packageHash, ...integrityWithoutPackageHash } =
+    integrity;
+  void packageHash;
+
+  return {
+    ...packageWithoutIntegrity,
+    integrity: integrityWithoutPackageHash,
+  };
+}
+
+export function isCmsSha256Hash(value: string): boolean {
+  return /^sha256:[a-f0-9]{64}$/.test(value);
+}

--- a/lib/profile-cms/protocol/v1/hash.ts
+++ b/lib/profile-cms/protocol/v1/hash.ts
@@ -42,13 +42,20 @@ export function withComputedCmsHashes(
 }
 
 export function toPackageHashInput(cmsPackage: CmsPackageV1): unknown {
-  const { integrity, ...packageWithoutIntegrity } = cmsPackage;
+  const {
+    integrity,
+    signatures: packageSignatures,
+    storage: packageStorage,
+    ...packageWithoutMutableEnvelopes
+  } = cmsPackage;
   const { package_hash: packageHash, ...integrityWithoutPackageHash } =
     integrity;
   void packageHash;
+  void packageSignatures;
+  void packageStorage;
 
   return {
-    ...packageWithoutIntegrity,
+    ...packageWithoutMutableEnvelopes,
     integrity: integrityWithoutPackageHash,
   };
 }

--- a/lib/profile-cms/protocol/v1/hash.ts
+++ b/lib/profile-cms/protocol/v1/hash.ts
@@ -42,20 +42,23 @@ export function withComputedCmsHashes(
 }
 
 export function toPackageHashInput(cmsPackage: CmsPackageV1): unknown {
+  const baseIntegrity = {
+    canonicalization: cmsPackage.integrity.canonicalization,
+    hash_algorithm: cmsPackage.integrity.hash_algorithm,
+    payload_hash: cmsPackage.integrity.payload_hash,
+  };
+  const integrity =
+    typeof cmsPackage.integrity.note === "string"
+      ? { ...baseIntegrity, note: cmsPackage.integrity.note }
+      : baseIntegrity;
+
   return {
     schema: cmsPackage.schema,
     package_id: cmsPackage.package_id,
     profile: cmsPackage.profile,
     site: cmsPackage.site,
     payload: cmsPackage.payload,
-    integrity: {
-      canonicalization: cmsPackage.integrity.canonicalization,
-      hash_algorithm: cmsPackage.integrity.hash_algorithm,
-      payload_hash: cmsPackage.integrity.payload_hash,
-      ...(cmsPackage.integrity.note !== undefined
-        ? { note: cmsPackage.integrity.note }
-        : {}),
-    },
+    integrity,
     provenance: cmsPackage.provenance,
   };
 }

--- a/lib/profile-cms/protocol/v1/index.ts
+++ b/lib/profile-cms/protocol/v1/index.ts
@@ -1,0 +1,5 @@
+export * from "./canonical-json";
+export * from "./constants";
+export * from "./hash";
+export * from "./schemas";
+export * from "./validation";

--- a/lib/profile-cms/protocol/v1/schemas.ts
+++ b/lib/profile-cms/protocol/v1/schemas.ts
@@ -1,0 +1,477 @@
+import { z } from "zod";
+
+import {
+  CMS_AGENT_PATCH_SCHEMA,
+  CMS_ASSET_KINDS,
+  CMS_ASSET_ROLES,
+  CMS_BLOCK_TYPES,
+  CMS_CANONICALIZATION,
+  CMS_DISPLAY_VARIANT_ROLES,
+  CMS_HASH_ALGORITHM,
+  CMS_HYDRATION_POLICIES,
+  CMS_PACKAGE_SCHEMA,
+  CMS_PAGE_TYPES,
+  CMS_PAYLOAD_SCHEMA,
+  CMS_ROUTE_KINDS,
+  CMS_SIGNATURE_TYPES,
+  CMS_SOURCE_PACKET_TYPES,
+  CMS_STORAGE_PROVIDERS,
+  CMS_VALIDATION_RESULT_SCHEMA,
+} from "./constants";
+
+const idSchema = z
+  .string()
+  .regex(/^[a-zA-Z0-9][a-zA-Z0-9._:-]{1,127}$/);
+const slugSchema = z.string().regex(/^[a-z0-9][a-z0-9-]{0,127}$/);
+const cmsPathSchema = z
+  .string()
+  .regex(/^\/[a-zA-Z0-9._~!$&'()*+,;=:@/-]+\/index\.html$/);
+const uriSchema = z.string().min(1).max(2048);
+const hashSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/);
+const localeSchema = z.string().regex(/^[a-z]{2}(-[A-Z]{2})?$/);
+const ethereumAddressSchema = z.string().regex(/^0x[a-fA-F0-9]{40}$/);
+const dateTimeSchema = z.string().datetime({ offset: true });
+
+const blockValueSchema: z.ZodType<
+  string | number | boolean | null | unknown[] | Record<string, unknown>
+> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(blockValueSchema),
+    z.record(blockValueSchema),
+  ])
+);
+
+export const profileRefSchema = z
+  .object({
+    handle: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9_-]{1,63}$/),
+    profile_id: z.string().optional(),
+    primary_wallet: ethereumAddressSchema.optional(),
+  })
+  .strict();
+
+export const themeSchema = z
+  .object({
+    mode: z.enum(["light", "dark", "system"]),
+    accent: z.string().regex(/^#[0-9a-fA-F]{6}$/),
+    tokens: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
+  })
+  .strict();
+
+export const pageMetadataPartialSchema = z
+  .object({
+    title: z.string().min(1).max(160).optional(),
+    description: z.string().max(300).optional(),
+    locale: localeSchema.optional(),
+    canonical_url: uriSchema.optional(),
+    social_image_asset_id: idSchema.optional(),
+    square_social_image_asset_id: idSchema.optional(),
+    navigation_label: z.string().max(80).optional(),
+    search: z.enum(["include", "exclude"]).optional(),
+    robots: z.enum(["index", "noindex"]).optional(),
+    last_updated: dateTimeSchema.optional(),
+  })
+  .strict();
+
+export const pageMetadataSchema = pageMetadataPartialSchema
+  .extend({
+    title: z.string().min(1).max(160),
+    description: z.string().max(300),
+    locale: localeSchema,
+    canonical_url: uriSchema,
+  })
+  .strict();
+
+export const metadataDefaultSchema = z
+  .object({
+    scope: z
+      .object({
+        collection: z.string().optional(),
+        path_prefix: z.string().optional(),
+        page_type: z.string().optional(),
+      })
+      .strict(),
+    values: pageMetadataPartialSchema,
+  })
+  .strict();
+
+export const searchConfigSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    manifest_asset_id: idSchema.optional(),
+  })
+  .strict();
+
+export const siteManifestSchema = z
+  .object({
+    title: z.string().min(1).max(160),
+    description: z.string().max(300).optional(),
+    base_path: cmsPathSchema,
+    default_locale: localeSchema,
+    direction: z.enum(["ltr", "rtl"]).optional(),
+    theme: themeSchema,
+    navigation_id: idSchema,
+    metadata_defaults: z.array(metadataDefaultSchema).optional(),
+    search: searchConfigSchema.optional(),
+    required_renderer_capabilities: z.array(z.string()).optional(),
+  })
+  .strict();
+
+export const interactivePolicySchema = z
+  .object({
+    hydration: z.enum(CMS_HYDRATION_POLICIES),
+    requires_user_activation: z.boolean().optional(),
+    fallback_asset_id: idSchema.optional(),
+    sandbox_permissions: z.array(z.string()).optional(),
+    performance_budget: z
+      .record(z.union([z.number(), z.string()]))
+      .optional(),
+  })
+  .strict();
+
+export const blockSchema = z
+  .object({
+    id: idSchema,
+    block_type: z.enum(CMS_BLOCK_TYPES),
+    interactive_policy: interactivePolicySchema.optional(),
+  })
+  .catchall(blockValueSchema);
+
+export const sourceRefSchema = z
+  .object({
+    source_packet_id: idSchema.optional(),
+    field_sources: z.record(z.string()).optional(),
+  })
+  .strict();
+
+export const pageSchema = z
+  .object({
+    id: idSchema,
+    type: z.enum(CMS_PAGE_TYPES),
+    path: cmsPathSchema,
+    metadata: pageMetadataSchema,
+    blocks: z.array(blockSchema),
+    source: sourceRefSchema.optional(),
+  })
+  .strict();
+
+export const routeSchema = z
+  .object({
+    path: cmsPathSchema,
+    kind: z.enum(CMS_ROUTE_KINDS),
+    page_id: idSchema.optional(),
+    target: z.string().optional(),
+  })
+  .strict();
+
+export const assetSchema = z
+  .object({
+    id: idSchema,
+    kind: z.enum(CMS_ASSET_KINDS),
+    uri: uriSchema,
+    content_hash: hashSchema,
+    mime_type: z.string(),
+    width: z.number().int().min(1).optional(),
+    height: z.number().int().min(1).optional(),
+    duration_seconds: z.number().min(0).optional(),
+    file_size_bytes: z.number().int().min(0).optional(),
+    roles: z.array(z.enum(CMS_ASSET_ROLES)).optional(),
+    alt_text: z.string().optional(),
+    decorative: z.boolean().optional(),
+    rights: z.string().optional(),
+  })
+  .strict();
+
+export const displayVariantSchema = z
+  .object({
+    asset_id: idSchema,
+    role: z.enum(CMS_DISPLAY_VARIANT_ROLES),
+    crop_mode: z.enum(["preserve", "cover", "contain"]).optional(),
+    background: z.string().optional(),
+    source_asset_id: idSchema.optional(),
+  })
+  .strict();
+
+export const snapshotSchema = z
+  .object({
+    owner: z.string().optional(),
+    block_number: z.number().int().min(0).optional(),
+    captured_at: dateTimeSchema.optional(),
+  })
+  .strict();
+
+export const nftMediaProfileSchema = z
+  .object({
+    id: idSchema,
+    chain_id: z.number().int().min(1),
+    contract: ethereumAddressSchema,
+    token_id: z.string().min(1),
+    metadata_uri: uriSchema.optional(),
+    metadata_hash: hashSchema.optional(),
+    original_asset_ids: z.array(idSchema).optional(),
+    display_variants: z.array(displayVariantSchema),
+    poster_asset_id: idSchema.optional(),
+    snapshot: snapshotSchema.optional(),
+  })
+  .strict();
+
+export const deepZoomManifestSchema = z
+  .object({
+    id: idSchema,
+    source_asset_id: idSchema,
+    tile_size: z.number().int().min(128),
+    levels: z.number().int().min(1),
+    format: z.enum(["jpg", "png", "webp", "avif"]),
+    tile_uri_template: uriSchema.optional(),
+    content_hash: hashSchema.optional(),
+  })
+  .strict();
+
+export const artworkPlacementSchema = z
+  .object({
+    id: idSchema,
+    asset_id: idSchema,
+    nft_media_profile_id: idSchema.optional(),
+    detail_page_id: idSchema,
+    position: z.tuple([z.number(), z.number(), z.number()]).optional(),
+    rotation: z.tuple([z.number(), z.number(), z.number()]).optional(),
+    size: z.tuple([z.number().positive(), z.number().positive()]).optional(),
+    display_mode: z.enum(["faithful", "gallery"]),
+    label: z.string().optional(),
+  })
+  .strict();
+
+export const exhibitionRoomSchema = z
+  .object({
+    id: idSchema,
+    title: z.string().min(1),
+    room_type: z.enum(["wall", "salon", "white_cube", "dark_room"]),
+    poster_asset_id: idSchema.optional(),
+    fallback_page_id: idSchema,
+    navigation_mode: z.enum(["orbit", "guided_hotspots", "walk"]).optional(),
+    placements: z.array(artworkPlacementSchema),
+  })
+  .strict();
+
+export interface CmsNavigationItemShape {
+  label: string;
+  page_id?: string | undefined;
+  url?: string | undefined;
+  children?: CmsNavigationItemShape[] | undefined;
+}
+
+export const navigationItemSchema: z.ZodType<CmsNavigationItemShape> = z.lazy(
+  () =>
+    z
+      .object({
+        label: z.string(),
+        page_id: idSchema.optional(),
+        url: uriSchema.optional(),
+        children: z.array(navigationItemSchema).optional(),
+      })
+      .strict()
+);
+
+export const navigationSchema = z
+  .object({
+    id: idSchema,
+    items: z.array(navigationItemSchema),
+  })
+  .strict();
+
+export const taxonomySchema = z
+  .object({
+    id: idSchema,
+    name: z.string(),
+    terms: z.array(
+      z
+        .object({
+          slug: slugSchema,
+          label: z.string(),
+          page_id: idSchema.optional(),
+        })
+        .strict()
+    ),
+  })
+  .strict();
+
+export const sourcePacketSchema = z
+  .object({
+    id: idSchema,
+    source_type: z.enum(CMS_SOURCE_PACKET_TYPES),
+    captured_at: dateTimeSchema,
+    content_hash: hashSchema.optional(),
+  })
+  .catchall(blockValueSchema);
+
+export const buildManifestSchema = z
+  .object({
+    renderer: z.string().optional(),
+    renderer_version: z.string().optional(),
+    route_count: z.number().int().min(0).optional(),
+    asset_count: z.number().int().min(0).optional(),
+    warnings: z.array(z.string()).optional(),
+  })
+  .strict();
+
+export const cmsPayloadSchema = z
+  .object({
+    schema: z.literal(CMS_PAYLOAD_SCHEMA),
+    routes: z.array(routeSchema),
+    pages: z.array(pageSchema),
+    assets: z.array(assetSchema),
+    nft_media_profiles: z.array(nftMediaProfileSchema).optional(),
+    deep_zoom_manifests: z.array(deepZoomManifestSchema).optional(),
+    exhibition_rooms: z.array(exhibitionRoomSchema).optional(),
+    navigation: z.array(navigationSchema),
+    taxonomies: z.array(taxonomySchema).optional(),
+    source_packets: z.array(sourcePacketSchema).optional(),
+    build_manifest: buildManifestSchema.optional(),
+  })
+  .strict();
+
+export const integritySchema = z
+  .object({
+    canonicalization: z.literal(CMS_CANONICALIZATION),
+    hash_algorithm: z.literal(CMS_HASH_ALGORITHM),
+    payload_hash: hashSchema,
+    package_hash: hashSchema,
+    note: z.string().optional(),
+  })
+  .strict();
+
+export const signatureEnvelopeSchema = z
+  .object({
+    type: z.enum(CMS_SIGNATURE_TYPES),
+    signer: z.string(),
+    signature: z.string(),
+    signed_at: dateTimeSchema,
+    domain: z.record(z.unknown()).optional(),
+  })
+  .strict();
+
+export const storageReceiptSchema = z
+  .object({
+    provider: z.enum(CMS_STORAGE_PROVIDERS),
+    uri: uriSchema,
+    content_hash: hashSchema,
+    provider_content_id: z.string().optional(),
+    pinned: z.boolean().optional(),
+    canonical: z.boolean().optional(),
+    recorded_at: dateTimeSchema,
+  })
+  .strict();
+
+export const packageProvenanceSchema = z
+  .object({
+    builder: z.string(),
+    builder_version: z.string().optional(),
+    created_at: dateTimeSchema,
+    notes: z.string().optional(),
+  })
+  .strict();
+
+export const cmsPackageSchema = z
+  .object({
+    schema: z.literal(CMS_PACKAGE_SCHEMA),
+    package_id: idSchema,
+    profile: profileRefSchema,
+    site: siteManifestSchema,
+    payload: cmsPayloadSchema,
+    integrity: integritySchema,
+    signatures: z.array(signatureEnvelopeSchema).min(1),
+    storage: z.array(storageReceiptSchema).min(1),
+    provenance: packageProvenanceSchema,
+  })
+  .strict();
+
+export const validationIssueSchema = z
+  .object({
+    severity: z.enum(["error", "warning", "note"]),
+    code: z.string(),
+    message: z.string(),
+    path: z.string(),
+    page_id: z.string().optional(),
+    block_id: z.string().optional(),
+    suggested_fix: z.string().optional(),
+  })
+  .strict();
+
+export const validationResultSchema = z
+  .object({
+    schema: z.literal(CMS_VALIDATION_RESULT_SCHEMA),
+    valid: z.boolean(),
+    checked_at: dateTimeSchema,
+    validator: z.string().optional(),
+    validator_version: z.string().optional(),
+    target: z
+      .object({
+        package_hash: hashSchema.optional(),
+        draft_id: z.string().optional(),
+        package_id: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    issues: z.array(validationIssueSchema),
+  })
+  .strict();
+
+export const agentPatchOperationSchema = z
+  .object({
+    op: z.enum([
+      "add_page",
+      "remove_page",
+      "update_page_metadata",
+      "add_block",
+      "update_block",
+      "remove_block",
+      "reorder_blocks",
+      "update_navigation",
+      "update_theme",
+      "update_share_metadata",
+      "attach_source_packet",
+      "set_taxonomy_terms",
+    ]),
+    path: z.string().min(1),
+    value: z.unknown().optional(),
+    reason: z.string().optional(),
+    source_packet_ids: z.array(z.string()).optional(),
+  })
+  .strict();
+
+export const agentPatchSchema = z
+  .object({
+    schema: z.literal(CMS_AGENT_PATCH_SCHEMA),
+    patch_id: z.string().min(1),
+    target: z
+      .object({
+        draft_id: z.string(),
+        base_version: z.number().int().min(0),
+        base_package_hash: hashSchema.optional(),
+      })
+      .strict(),
+    operations: z.array(agentPatchOperationSchema).min(1),
+    provenance: z
+      .object({
+        created_at: dateTimeSchema,
+        author_type: z.enum(["user_agent", "local_tool", "human"]),
+        agent_name: z.string().optional(),
+        agent_version: z.string().optional(),
+        notes: z.string().optional(),
+      })
+      .strict(),
+  })
+  .strict();
+
+export type CmsPackageV1 = z.infer<typeof cmsPackageSchema>;
+export type CmsPayloadV1 = z.infer<typeof cmsPayloadSchema>;
+export type CmsPageV1 = z.infer<typeof pageSchema>;
+export type CmsBlockV1 = z.infer<typeof blockSchema>;
+export type CmsAssetV1 = z.infer<typeof assetSchema>;
+export type CmsNavigationItemV1 = z.infer<typeof navigationItemSchema>;
+export type CmsValidationIssueV1 = z.infer<typeof validationIssueSchema>;
+export type CmsValidationResultV1 = z.infer<typeof validationResultSchema>;
+export type CmsAgentPatchV1 = z.infer<typeof agentPatchSchema>;

--- a/lib/profile-cms/protocol/v1/validation.ts
+++ b/lib/profile-cms/protocol/v1/validation.ts
@@ -78,6 +78,13 @@ const DEEP_ZOOM_REFERENCE_FIELDS = [
 
 const ALLOWED_BLOCK_URL_FIELDS = new Set(["url", "href", "src", "uri"]);
 const URL_LIKE_FIELD = /(url|uri|href|src)$/i;
+const HASH_FIELD_NAMES = new Set([
+  "base_package_hash",
+  "content_hash",
+  "metadata_hash",
+  "package_hash",
+  "payload_hash",
+]);
 
 export function validateCmsPackageV1(
   input: unknown,
@@ -1261,7 +1268,10 @@ function mapZodIssue(issue: ZodIssue): CmsValidationIssueV1 {
     });
   }
 
-  if (issue.path[issue.path.length - 1] === "block_type") {
+  if (
+    issue.code === "invalid_enum_value" &&
+    issue.path[issue.path.length - 1] === "block_type"
+  ) {
     return issueFromInput({
       code: "block.unknown_type",
       message: "Unknown block type. V1 CMS packages fail closed.",
@@ -1269,7 +1279,13 @@ function mapZodIssue(issue: ZodIssue): CmsValidationIssueV1 {
     });
   }
 
-  if (issue.path.some((segment) => String(segment).includes("hash"))) {
+  const lastPathSegment = issue.path[issue.path.length - 1];
+  if (
+    issue.code === "invalid_string" &&
+    issue.validation === "regex" &&
+    typeof lastPathSegment === "string" &&
+    HASH_FIELD_NAMES.has(lastPathSegment)
+  ) {
     return issueFromInput({
       code: "hash.invalid",
       message: issue.message,

--- a/lib/profile-cms/protocol/v1/validation.ts
+++ b/lib/profile-cms/protocol/v1/validation.ts
@@ -1,0 +1,1358 @@
+import { getAddress } from "ethers";
+import type { ZodIssue } from "zod";
+
+import {
+  CMS_RESERVED_APP_ROUTE_ROOTS,
+  CMS_SAFE_URI_PROTOCOLS,
+  CMS_VALIDATION_RESULT_SCHEMA,
+} from "./constants";
+import {
+  computeCmsPackageHash,
+  computeCmsPayloadHash,
+  isCmsSha256Hash,
+} from "./hash";
+import {
+  cmsPackageSchema,
+  validationResultSchema,
+  type CmsAssetV1,
+  type CmsBlockV1,
+  type CmsNavigationItemV1,
+  type CmsPackageV1,
+  type CmsValidationIssueV1,
+  type CmsValidationResultV1,
+} from "./schemas";
+
+export interface CmsValidationOptions {
+  checkedAt?: Date | string;
+  validator?: string;
+  validatorVersion?: string;
+  allowFixtureSignatures?: boolean;
+  allowFixtureStorage?: boolean;
+  enforceHashes?: boolean;
+}
+
+interface IssueInput {
+  severity?: CmsValidationIssueV1["severity"] | undefined;
+  code: string;
+  message: string;
+  path: string;
+  pageId?: string | undefined;
+  blockId?: string | undefined;
+  suggestedFix?: string | undefined;
+}
+
+type IdMap<T extends { id: string }> = Map<string, { value: T; index: number }>;
+
+const VALIDATOR_NAME = "6529-cms-protocol-v1";
+const VALIDATOR_VERSION = "0.1.0";
+
+const ASSET_REFERENCE_FIELDS = [
+  "asset_id",
+  "poster_asset_id",
+  "fallback_asset_id",
+  "source_asset_id",
+  "thumbnail_asset_id",
+  "social_image_asset_id",
+] as const;
+
+const ASSET_REFERENCE_ARRAY_FIELDS = [
+  "asset_ids",
+  "original_asset_ids",
+  "featured_asset_ids",
+] as const;
+
+const PAGE_REFERENCE_FIELDS = [
+  "page_id",
+  "detail_page_id",
+  "fallback_page_id",
+] as const;
+
+const PAGE_REFERENCE_ARRAY_FIELDS = ["page_ids", "featured_page_ids"] as const;
+
+const NFT_PROFILE_REFERENCE_FIELDS = ["nft_media_profile_id"] as const;
+const ROOM_REFERENCE_FIELDS = ["room_id"] as const;
+const DEEP_ZOOM_REFERENCE_FIELDS = [
+  "deep_zoom_id",
+  "deep_zoom_manifest_id",
+] as const;
+
+const ALLOWED_BLOCK_URL_FIELDS = new Set(["url", "href", "src", "uri"]);
+const URL_LIKE_FIELD = /(url|uri|href|src)$/i;
+
+export function validateCmsPackageV1(
+  input: unknown,
+  options: CmsValidationOptions = {}
+): CmsValidationResultV1 {
+  const checkedAt = formatCheckedAt(options.checkedAt);
+  const parsed = cmsPackageSchema.safeParse(input);
+
+  if (!parsed.success) {
+    const target = getTarget(input);
+    return buildValidationResult({
+      checkedAt,
+      issues: parsed.error.issues.map(mapZodIssue),
+      options,
+      ...(target ? { target } : {}),
+    });
+  }
+
+  const target = getTarget(parsed.data);
+  return buildValidationResult({
+    checkedAt,
+    issues: validateSemantics(parsed.data, options),
+    options,
+    ...(target ? { target } : {}),
+  });
+}
+
+function buildValidationResult({
+  checkedAt,
+  issues,
+  options,
+  target,
+}: {
+  checkedAt: string;
+  issues: CmsValidationIssueV1[];
+  options: CmsValidationOptions;
+  target?: CmsValidationResultV1["target"] | undefined;
+}): CmsValidationResultV1 {
+  const result = {
+    schema: CMS_VALIDATION_RESULT_SCHEMA,
+    valid: !issues.some((issue) => issue.severity === "error"),
+    checked_at: checkedAt,
+    validator: options.validator ?? VALIDATOR_NAME,
+    validator_version: options.validatorVersion ?? VALIDATOR_VERSION,
+    ...(target ? { target } : {}),
+    issues,
+  };
+
+  return validationResultSchema.parse(result);
+}
+
+function validateSemantics(
+  cmsPackage: CmsPackageV1,
+  options: CmsValidationOptions
+): CmsValidationIssueV1[] {
+  const issues: CmsValidationIssueV1[] = [];
+  const payload = cmsPackage.payload;
+  const pageMap = toIdMap(payload.pages, "/payload/pages", "page", issues);
+  const assetMap = toIdMap(payload.assets, "/payload/assets", "asset", issues);
+  const nftProfileMap = toIdMap(
+    payload.nft_media_profiles ?? [],
+    "/payload/nft_media_profiles",
+    "nft_media_profile",
+    issues
+  );
+  const deepZoomMap = toIdMap(
+    payload.deep_zoom_manifests ?? [],
+    "/payload/deep_zoom_manifests",
+    "deep_zoom_manifest",
+    issues
+  );
+  const roomMap = toIdMap(
+    payload.exhibition_rooms ?? [],
+    "/payload/exhibition_rooms",
+    "exhibition_room",
+    issues
+  );
+  const sourcePacketMap = toIdMap(
+    payload.source_packets ?? [],
+    "/payload/source_packets",
+    "source_packet",
+    issues
+  );
+
+  validateRoutes(cmsPackage, pageMap, issues);
+  validateSiteManifest(cmsPackage, assetMap, issues);
+  validatePages(
+    cmsPackage,
+    pageMap,
+    assetMap,
+    nftProfileMap,
+    deepZoomMap,
+    roomMap,
+    sourcePacketMap,
+    issues
+  );
+  validateAssets(payload.assets, issues);
+  validateNftMediaProfiles(payload.nft_media_profiles ?? [], assetMap, issues);
+  validateDeepZoomManifests(payload.deep_zoom_manifests ?? [], assetMap, issues);
+  validateExhibitionRooms(
+    payload.exhibition_rooms ?? [],
+    pageMap,
+    assetMap,
+    nftProfileMap,
+    issues
+  );
+  validateNavigation(cmsPackage, pageMap, issues);
+  validateTaxonomies(cmsPackage, pageMap, issues);
+  validateSignatures(cmsPackage, options, issues);
+  validateStorage(cmsPackage, options, issues);
+  validateHashes(cmsPackage, options, issues);
+  validateBuildManifest(cmsPackage, issues);
+
+  return issues;
+}
+
+function validateRoutes(
+  cmsPackage: CmsPackageV1,
+  pageMap: IdMap<CmsPackageV1["payload"]["pages"][number]>,
+  issues: CmsValidationIssueV1[]
+): void {
+  const routePaths = new Map<string, number>();
+  const canonicalProfilePath = `/${cmsPackage.profile.handle}/index.html`;
+  const routePathSet = new Set(cmsPackage.payload.routes.map((route) => route.path));
+
+  cmsPackage.payload.routes.forEach((route, index) => {
+    if (routePaths.has(route.path)) {
+      addIssue(issues, {
+        code: "route.duplicate_path",
+        message: `Route path '${route.path}' appears more than once.`,
+        path: "/payload/routes",
+        suggestedFix: "Keep exactly one route for each CMS path.",
+      });
+    } else {
+      routePaths.set(route.path, index);
+    }
+
+    validateProfileNamespace(
+      route.path,
+      cmsPackage.profile.handle,
+      `/payload/routes/${index}/path`,
+      issues,
+      "route.profile_namespace"
+    );
+    validateReservedRouteRoot(route.path, `/payload/routes/${index}/path`, issues);
+
+    if (route.kind === "page") {
+      if (!route.page_id) {
+        addIssue(issues, {
+          code: "route.page_id.required",
+          message: "Page routes must include page_id.",
+          path: `/payload/routes/${index}/page_id`,
+        });
+      } else if (!pageMap.has(route.page_id)) {
+        addIssue(issues, {
+          code: "route.page_missing",
+          message: `Route references missing page '${route.page_id}'.`,
+          path: `/payload/routes/${index}/page_id`,
+        });
+      }
+
+      if (route.target) {
+        addIssue(issues, {
+          code: "route.target_forbidden",
+          message: "Page routes cannot include target.",
+          path: `/payload/routes/${index}/target`,
+        });
+      }
+    } else {
+      if (!route.target) {
+        addIssue(issues, {
+          code: "route.target.required",
+          message: `${route.kind} routes must include target.`,
+          path: `/payload/routes/${index}/target`,
+        });
+      } else {
+        validateRouteTarget(
+          route.target,
+          route.kind,
+          cmsPackage.profile.handle,
+          routePathSet,
+          `/payload/routes/${index}/target`,
+          issues
+        );
+      }
+
+      if (route.page_id) {
+        addIssue(issues, {
+          code: "route.page_id_forbidden",
+          message: `${route.kind} routes cannot include page_id.`,
+          path: `/payload/routes/${index}/page_id`,
+        });
+      }
+    }
+  });
+
+  if (!routePathSet.has(canonicalProfilePath)) {
+    addIssue(issues, {
+      code: "route.primary_missing",
+      message: `Profile CMS package must include '${canonicalProfilePath}'.`,
+      path: "/payload/routes",
+      suggestedFix: `Add a page route for ${canonicalProfilePath}.`,
+    });
+  }
+
+  if (!routePathSet.has(cmsPackage.site.base_path)) {
+    addIssue(issues, {
+      code: "site.base_path_route_missing",
+      message: `Site base path '${cmsPackage.site.base_path}' has no route.`,
+      path: "/site/base_path",
+    });
+  }
+}
+
+function validateRouteTarget(
+  target: string,
+  kind: CmsPackageV1["payload"]["routes"][number]["kind"],
+  profileHandle: string,
+  routePathSet: Set<string>,
+  path: string,
+  issues: CmsValidationIssueV1[]
+): void {
+  if (target.startsWith("/")) {
+    validateProfileNamespace(
+      target,
+      profileHandle,
+      path,
+      issues,
+      "route.profile_namespace"
+    );
+    validateReservedRouteRoot(target, path, issues);
+
+    if (!routePathSet.has(target)) {
+      addIssue(issues, {
+        code: "route.target_missing",
+        message: `${kind} route target '${target}' is not in the route manifest.`,
+        path,
+      });
+    }
+    return;
+  }
+
+  validateSafeUri(target, path, issues, "route.target_unsafe_uri", false);
+}
+
+function validateSiteManifest(
+  cmsPackage: CmsPackageV1,
+  assetMap: IdMap<CmsAssetV1>,
+  issues: CmsValidationIssueV1[]
+): void {
+  validateProfileNamespace(
+    cmsPackage.site.base_path,
+    cmsPackage.profile.handle,
+    "/site/base_path",
+    issues,
+    "site.profile_namespace"
+  );
+  validateReservedRouteRoot(cmsPackage.site.base_path, "/site/base_path", issues);
+
+  if (
+    cmsPackage.site.search?.manifest_asset_id &&
+    !assetMap.has(cmsPackage.site.search.manifest_asset_id)
+  ) {
+    addIssue(issues, {
+      code: "site.search_manifest_asset_missing",
+      message: `Search manifest asset '${cmsPackage.site.search.manifest_asset_id}' does not exist.`,
+      path: "/site/search/manifest_asset_id",
+    });
+  }
+
+  if (
+    !cmsPackage.payload.navigation.some(
+      (navigation) => navigation.id === cmsPackage.site.navigation_id
+    )
+  ) {
+    addIssue(issues, {
+      code: "site.navigation_missing",
+      message: `Site navigation '${cmsPackage.site.navigation_id}' does not exist.`,
+      path: "/site/navigation_id",
+    });
+  }
+}
+
+function validatePages(
+  cmsPackage: CmsPackageV1,
+  pageMap: IdMap<CmsPackageV1["payload"]["pages"][number]>,
+  assetMap: IdMap<CmsAssetV1>,
+  nftProfileMap: IdMap<
+    NonNullable<CmsPackageV1["payload"]["nft_media_profiles"]>[number]
+  >,
+  deepZoomMap: IdMap<
+    NonNullable<CmsPackageV1["payload"]["deep_zoom_manifests"]>[number]
+  >,
+  roomMap: IdMap<
+    NonNullable<CmsPackageV1["payload"]["exhibition_rooms"]>[number]
+  >,
+  sourcePacketMap: IdMap<
+    NonNullable<CmsPackageV1["payload"]["source_packets"]>[number]
+  >,
+  issues: CmsValidationIssueV1[]
+): void {
+  const routePaths = new Set(cmsPackage.payload.routes.map((route) => route.path));
+
+  cmsPackage.payload.pages.forEach((page, pageIndex) => {
+    const pagePath = `/payload/pages/${pageIndex}`;
+
+    validateProfileNamespace(
+      page.path,
+      cmsPackage.profile.handle,
+      `${pagePath}/path`,
+      issues,
+      "page.profile_namespace"
+    );
+    validateReservedRouteRoot(page.path, `${pagePath}/path`, issues);
+    validateSafeUri(
+      page.metadata.canonical_url,
+      `${pagePath}/metadata/canonical_url`,
+      issues,
+      "page.canonical_url_unsafe_uri",
+      false
+    );
+
+    if (!routePaths.has(page.path)) {
+      addIssue(issues, {
+        code: "page.route_missing",
+        message: `Page path '${page.path}' has no route.`,
+        path: `${pagePath}/path`,
+        pageId: page.id,
+      });
+    }
+
+    validateOptionalAssetReference(
+      page.metadata.social_image_asset_id,
+      assetMap,
+      `${pagePath}/metadata/social_image_asset_id`,
+      issues,
+      "asset.reference_missing",
+      page.id
+    );
+    validateOptionalAssetReference(
+      page.metadata.square_social_image_asset_id,
+      assetMap,
+      `${pagePath}/metadata/square_social_image_asset_id`,
+      issues,
+      "asset.reference_missing",
+      page.id
+    );
+
+    if (
+      page.source?.source_packet_id &&
+      !sourcePacketMap.has(page.source.source_packet_id)
+    ) {
+      addIssue(issues, {
+        code: "source_packet.reference_missing",
+        message: `Page references missing source packet '${page.source.source_packet_id}'.`,
+        path: `${pagePath}/source/source_packet_id`,
+        pageId: page.id,
+      });
+    }
+
+    validateBlocks(
+      page.blocks,
+      pagePath,
+      page.id,
+      pageMap,
+      assetMap,
+      nftProfileMap,
+      deepZoomMap,
+      roomMap,
+      issues
+    );
+  });
+}
+
+function validateBlocks(
+  blocks: CmsBlockV1[],
+  pagePath: string,
+  pageId: string,
+  pageMap: IdMap<CmsPackageV1["payload"]["pages"][number]>,
+  assetMap: IdMap<CmsAssetV1>,
+  nftProfileMap: IdMap<
+    NonNullable<CmsPackageV1["payload"]["nft_media_profiles"]>[number]
+  >,
+  deepZoomMap: IdMap<
+    NonNullable<CmsPackageV1["payload"]["deep_zoom_manifests"]>[number]
+  >,
+  roomMap: IdMap<
+    NonNullable<CmsPackageV1["payload"]["exhibition_rooms"]>[number]
+  >,
+  issues: CmsValidationIssueV1[]
+): void {
+  const blockIds = new Set<string>();
+
+  blocks.forEach((block, blockIndex) => {
+    const blockPath = `${pagePath}/blocks/${blockIndex}`;
+    const record = block as Record<string, unknown>;
+
+    if (blockIds.has(block.id)) {
+      addIssue(issues, {
+        code: "block.duplicate_id",
+        message: `Block id '${block.id}' is duplicated on page '${pageId}'.`,
+        path: `${blockPath}/id`,
+        pageId,
+        blockId: block.id,
+      });
+    }
+    blockIds.add(block.id);
+
+    validateBlockReferenceFields(
+      record,
+      ASSET_REFERENCE_FIELDS,
+      assetMap,
+      blockPath,
+      issues,
+      "asset.reference_missing",
+      pageId,
+      block.id
+    );
+    validateBlockReferenceArrayFields(
+      record,
+      ASSET_REFERENCE_ARRAY_FIELDS,
+      assetMap,
+      blockPath,
+      issues,
+      "asset.reference_missing",
+      pageId,
+      block.id
+    );
+    validateBlockReferenceFields(
+      record,
+      PAGE_REFERENCE_FIELDS,
+      pageMap,
+      blockPath,
+      issues,
+      "page.reference_missing",
+      pageId,
+      block.id
+    );
+    validateBlockReferenceArrayFields(
+      record,
+      PAGE_REFERENCE_ARRAY_FIELDS,
+      pageMap,
+      blockPath,
+      issues,
+      "page.reference_missing",
+      pageId,
+      block.id
+    );
+    validateBlockReferenceFields(
+      record,
+      NFT_PROFILE_REFERENCE_FIELDS,
+      nftProfileMap,
+      blockPath,
+      issues,
+      "nft_media_profile.reference_missing",
+      pageId,
+      block.id
+    );
+    validateBlockReferenceFields(
+      record,
+      DEEP_ZOOM_REFERENCE_FIELDS,
+      deepZoomMap,
+      blockPath,
+      issues,
+      "deep_zoom.reference_missing",
+      pageId,
+      block.id
+    );
+    validateBlockReferenceFields(
+      record,
+      ROOM_REFERENCE_FIELDS,
+      roomMap,
+      blockPath,
+      issues,
+      "room.reference_missing",
+      pageId,
+      block.id
+    );
+    validateInteractivePolicyReferences(
+      block,
+      assetMap,
+      blockPath,
+      pageId,
+      issues
+    );
+    validateBlockUrls(record, blockPath, pageId, block.id, issues);
+    validateHeavyMediaBlock(block, assetMap, blockPath, pageId, issues);
+  });
+}
+
+function validateAssets(
+  assets: CmsAssetV1[],
+  issues: CmsValidationIssueV1[]
+): void {
+  assets.forEach((asset, index) => {
+    const path = `/payload/assets/${index}`;
+    validateSafeUri(asset.uri, `${path}/uri`, issues, "asset.unsafe_uri", false);
+
+    if (
+      ["image", "video", "social_image"].includes(asset.kind) &&
+      (!asset.width || !asset.height)
+    ) {
+      addIssue(issues, {
+        code: "asset.dimensions_required",
+        message: `${asset.kind} asset '${asset.id}' must include width and height.`,
+        path,
+      });
+    }
+  });
+}
+
+function validateNftMediaProfiles(
+  profiles: NonNullable<CmsPackageV1["payload"]["nft_media_profiles"]>,
+  assetMap: IdMap<CmsAssetV1>,
+  issues: CmsValidationIssueV1[]
+): void {
+  profiles.forEach((profile, profileIndex) => {
+    const path = `/payload/nft_media_profiles/${profileIndex}`;
+    validateEthereumAddress(
+      profile.contract,
+      `${path}/contract`,
+      issues,
+      "nft_media_profile.contract_invalid"
+    );
+
+    if (profile.metadata_uri) {
+      validateSafeUri(
+        profile.metadata_uri,
+        `${path}/metadata_uri`,
+        issues,
+        "nft_media_profile.metadata_uri_unsafe",
+        false
+      );
+    }
+
+    profile.original_asset_ids?.forEach((assetId, assetIndex) => {
+      validateAssetReference(
+        assetId,
+        assetMap,
+        `${path}/original_asset_ids/${assetIndex}`,
+        issues,
+        "asset.reference_missing"
+      );
+    });
+
+    validateOptionalAssetReference(
+      profile.poster_asset_id,
+      assetMap,
+      `${path}/poster_asset_id`,
+      issues,
+      "asset.reference_missing"
+    );
+
+    profile.display_variants.forEach((variant, variantIndex) => {
+      validateAssetReference(
+        variant.asset_id,
+        assetMap,
+        `${path}/display_variants/${variantIndex}/asset_id`,
+        issues,
+        "asset.reference_missing"
+      );
+      validateOptionalAssetReference(
+        variant.source_asset_id,
+        assetMap,
+        `${path}/display_variants/${variantIndex}/source_asset_id`,
+        issues,
+        "asset.reference_missing"
+      );
+    });
+
+    if (profile.snapshot?.owner) {
+      validateEthereumAddress(
+        profile.snapshot.owner,
+        `${path}/snapshot/owner`,
+        issues,
+        "nft_media_profile.owner_invalid"
+      );
+    }
+  });
+}
+
+function validateDeepZoomManifests(
+  manifests: NonNullable<CmsPackageV1["payload"]["deep_zoom_manifests"]>,
+  assetMap: IdMap<CmsAssetV1>,
+  issues: CmsValidationIssueV1[]
+): void {
+  manifests.forEach((manifest, index) => {
+    const path = `/payload/deep_zoom_manifests/${index}`;
+    validateAssetReference(
+      manifest.source_asset_id,
+      assetMap,
+      `${path}/source_asset_id`,
+      issues,
+      "asset.reference_missing"
+    );
+
+    if (manifest.tile_uri_template) {
+      validateSafeUri(
+        manifest.tile_uri_template,
+        `${path}/tile_uri_template`,
+        issues,
+        "deep_zoom.tile_uri_unsafe",
+        false
+      );
+    }
+  });
+}
+
+function validateExhibitionRooms(
+  rooms: NonNullable<CmsPackageV1["payload"]["exhibition_rooms"]>,
+  pageMap: IdMap<CmsPackageV1["payload"]["pages"][number]>,
+  assetMap: IdMap<CmsAssetV1>,
+  nftProfileMap: IdMap<
+    NonNullable<CmsPackageV1["payload"]["nft_media_profiles"]>[number]
+  >,
+  issues: CmsValidationIssueV1[]
+): void {
+  rooms.forEach((room, roomIndex) => {
+    const path = `/payload/exhibition_rooms/${roomIndex}`;
+    validateOptionalAssetReference(
+      room.poster_asset_id,
+      assetMap,
+      `${path}/poster_asset_id`,
+      issues,
+      "asset.reference_missing"
+    );
+    validatePageReference(
+      room.fallback_page_id,
+      pageMap,
+      `${path}/fallback_page_id`,
+      issues,
+      "page.reference_missing"
+    );
+
+    room.placements.forEach((placement, placementIndex) => {
+      const placementPath = `${path}/placements/${placementIndex}`;
+      validateAssetReference(
+        placement.asset_id,
+        assetMap,
+        `${placementPath}/asset_id`,
+        issues,
+        "asset.reference_missing"
+      );
+      validateOptionalReference(
+        placement.nft_media_profile_id,
+        nftProfileMap,
+        `${placementPath}/nft_media_profile_id`,
+        issues,
+        "nft_media_profile.reference_missing"
+      );
+      validatePageReference(
+        placement.detail_page_id,
+        pageMap,
+        `${placementPath}/detail_page_id`,
+        issues,
+        "page.reference_missing"
+      );
+    });
+  });
+}
+
+function validateNavigation(
+  cmsPackage: CmsPackageV1,
+  pageMap: IdMap<CmsPackageV1["payload"]["pages"][number]>,
+  issues: CmsValidationIssueV1[]
+): void {
+  cmsPackage.payload.navigation.forEach((navigation, navigationIndex) => {
+    navigation.items.forEach((item, itemIndex) => {
+      validateNavigationItem(
+        item,
+        pageMap,
+        `/payload/navigation/${navigationIndex}/items/${itemIndex}`,
+        issues
+      );
+    });
+  });
+}
+
+function validateNavigationItem(
+  item: CmsNavigationItemV1,
+  pageMap: IdMap<CmsPackageV1["payload"]["pages"][number]>,
+  path: string,
+  issues: CmsValidationIssueV1[]
+): void {
+  validateOptionalReference(
+    item.page_id,
+    pageMap,
+    `${path}/page_id`,
+    issues,
+    "navigation.page_missing"
+  );
+
+  if (item.url) {
+    validateSafeUri(item.url, `${path}/url`, issues, "navigation.unsafe_url", true);
+  }
+
+  if (!item.page_id && !item.url && !item.children?.length) {
+    addIssue(issues, {
+      code: "navigation.target_missing",
+      message: `Navigation item '${item.label}' needs a page_id, url, or children.`,
+      path,
+    });
+  }
+
+  item.children?.forEach((child, childIndex) => {
+    validateNavigationItem(child, pageMap, `${path}/children/${childIndex}`, issues);
+  });
+}
+
+function validateTaxonomies(
+  cmsPackage: CmsPackageV1,
+  pageMap: IdMap<CmsPackageV1["payload"]["pages"][number]>,
+  issues: CmsValidationIssueV1[]
+): void {
+  cmsPackage.payload.taxonomies?.forEach((taxonomy, taxonomyIndex) => {
+    taxonomy.terms.forEach((term, termIndex) => {
+      validateOptionalReference(
+        term.page_id,
+        pageMap,
+        `/payload/taxonomies/${taxonomyIndex}/terms/${termIndex}/page_id`,
+        issues,
+        "taxonomy.page_missing"
+      );
+    });
+  });
+}
+
+function validateSignatures(
+  cmsPackage: CmsPackageV1,
+  options: CmsValidationOptions,
+  issues: CmsValidationIssueV1[]
+): void {
+  cmsPackage.signatures.forEach((signature, index) => {
+    if (signature.type === "fixture" && options.allowFixtureSignatures === false) {
+      addIssue(issues, {
+        code: "signature.fixture_not_allowed",
+        message: "Fixture signatures are not valid for production publish.",
+        path: `/signatures/${index}/type`,
+      });
+    }
+
+    if (signature.type === "eip712") {
+      validateEthereumAddress(
+        signature.signer,
+        `/signatures/${index}/signer`,
+        issues,
+        "signature.signer_invalid"
+      );
+    }
+  });
+
+  if (cmsPackage.profile.primary_wallet) {
+    validateEthereumAddress(
+      cmsPackage.profile.primary_wallet,
+      "/profile/primary_wallet",
+      issues,
+      "profile.primary_wallet_invalid"
+    );
+  }
+}
+
+function validateStorage(
+  cmsPackage: CmsPackageV1,
+  options: CmsValidationOptions,
+  issues: CmsValidationIssueV1[]
+): void {
+  let hasDecentralizedReceipt = false;
+
+  cmsPackage.storage.forEach((receipt, index) => {
+    const path = `/storage/${index}`;
+    validateSafeUri(receipt.uri, `${path}/uri`, issues, "storage.unsafe_uri", false);
+
+    if (receipt.provider === "fixture" && options.allowFixtureStorage === false) {
+      addIssue(issues, {
+        code: "storage.fixture_not_allowed",
+        message: "Fixture storage receipts are not valid for production publish.",
+        path: `${path}/provider`,
+      });
+    }
+
+    if (receipt.provider === "s3" && receipt.canonical) {
+      addIssue(issues, {
+        code: "storage.s3_cannot_be_canonical",
+        message: "S3 may accelerate delivery, but it cannot be canonical storage.",
+        path: `${path}/canonical`,
+      });
+    }
+
+    if (receipt.provider === "ipfs" || receipt.provider === "arweave") {
+      hasDecentralizedReceipt = true;
+    }
+  });
+
+  if (options.allowFixtureStorage === false && !hasDecentralizedReceipt) {
+    addIssue(issues, {
+      code: "storage.decentralized_receipt_required",
+      message: "Production publish requires IPFS or Arweave storage.",
+      path: "/storage",
+    });
+  }
+}
+
+function validateHashes(
+  cmsPackage: CmsPackageV1,
+  options: CmsValidationOptions,
+  issues: CmsValidationIssueV1[]
+): void {
+  if (!options.enforceHashes) {
+    return;
+  }
+
+  const actualPayloadHash = computeCmsPayloadHash(cmsPackage.payload);
+  if (cmsPackage.integrity.payload_hash !== actualPayloadHash) {
+    addIssue(issues, {
+      code: "integrity.payload_hash_mismatch",
+      message: "Payload hash does not match the canonical payload.",
+      path: "/integrity/payload_hash",
+      suggestedFix: `Expected ${actualPayloadHash}.`,
+    });
+  }
+
+  const actualPackageHash = computeCmsPackageHash(cmsPackage);
+  if (cmsPackage.integrity.package_hash !== actualPackageHash) {
+    addIssue(issues, {
+      code: "integrity.package_hash_mismatch",
+      message: "Package hash does not match the canonical package hash input.",
+      path: "/integrity/package_hash",
+      suggestedFix: `Expected ${actualPackageHash}.`,
+    });
+  }
+}
+
+function validateBuildManifest(
+  cmsPackage: CmsPackageV1,
+  issues: CmsValidationIssueV1[]
+): void {
+  const buildManifest = cmsPackage.payload.build_manifest;
+  if (!buildManifest) {
+    return;
+  }
+
+  if (
+    buildManifest.route_count !== undefined &&
+    buildManifest.route_count !== cmsPackage.payload.routes.length
+  ) {
+    addIssue(issues, {
+      severity: "warning",
+      code: "build_manifest.route_count_mismatch",
+      message: "Build manifest route_count does not match the route manifest.",
+      path: "/payload/build_manifest/route_count",
+    });
+  }
+
+  if (
+    buildManifest.asset_count !== undefined &&
+    buildManifest.asset_count !== cmsPackage.payload.assets.length
+  ) {
+    addIssue(issues, {
+      severity: "warning",
+      code: "build_manifest.asset_count_mismatch",
+      message: "Build manifest asset_count does not match the asset manifest.",
+      path: "/payload/build_manifest/asset_count",
+    });
+  }
+}
+
+function validateInteractivePolicyReferences(
+  block: CmsBlockV1,
+  assetMap: IdMap<CmsAssetV1>,
+  blockPath: string,
+  pageId: string,
+  issues: CmsValidationIssueV1[]
+): void {
+  if (!block.interactive_policy?.fallback_asset_id) {
+    return;
+  }
+
+  validateAssetReference(
+    block.interactive_policy.fallback_asset_id,
+    assetMap,
+    `${blockPath}/interactive_policy/fallback_asset_id`,
+    issues,
+    "asset.reference_missing",
+    pageId,
+    block.id
+  );
+}
+
+function validateBlockUrls(
+  block: Record<string, unknown>,
+  blockPath: string,
+  pageId: string,
+  blockId: string,
+  issues: CmsValidationIssueV1[]
+): void {
+  Object.entries(block).forEach(([key, value]) => {
+    if (!URL_LIKE_FIELD.test(key)) {
+      return;
+    }
+
+    const path = `${blockPath}/${escapePointerSegment(key)}`;
+    if (!ALLOWED_BLOCK_URL_FIELDS.has(key)) {
+      addIssue(issues, {
+        code: "block.unknown_url_field",
+        message: `URL-like block field '${key}' is not part of V1's safe URL contract.`,
+        path,
+        pageId,
+        blockId,
+      });
+      return;
+    }
+
+    if (typeof value === "string") {
+      validateSafeUri(value, path, issues, "block.unsafe_url", true, pageId, blockId);
+    }
+  });
+}
+
+function validateHeavyMediaBlock(
+  block: CmsBlockV1,
+  assetMap: IdMap<CmsAssetV1>,
+  blockPath: string,
+  pageId: string,
+  issues: CmsValidationIssueV1[]
+): void {
+  const record = block as Record<string, unknown>;
+  const assetId = getString(record["asset_id"]);
+  const asset = assetId ? assetMap.get(assetId)?.value : undefined;
+  const isHeavyBlock =
+    ["video", "html_embed", "object_viewer"].includes(block.block_type) ||
+    asset?.kind === "video" ||
+    asset?.kind === "html" ||
+    asset?.kind === "model";
+
+  if (!isHeavyBlock) {
+    return;
+  }
+
+  const hasPoster = typeof record["poster_asset_id"] === "string";
+  const hasFallback = !!block.interactive_policy?.fallback_asset_id;
+
+  if (!hasPoster && !hasFallback) {
+    addIssue(issues, {
+      code: "media.fallback_required",
+      message: "Heavy media blocks need a poster_asset_id or fallback_asset_id.",
+      path: blockPath,
+      pageId,
+      blockId: block.id,
+    });
+  }
+}
+
+function validateBlockReferenceFields<T extends { id: string }>(
+  block: Record<string, unknown>,
+  fields: readonly string[],
+  referenceMap: IdMap<T>,
+  blockPath: string,
+  issues: CmsValidationIssueV1[],
+  code: string,
+  pageId: string,
+  blockId: string
+): void {
+  fields.forEach((field) => {
+    validateOptionalReference(
+      getString(block[field]),
+      referenceMap,
+      `${blockPath}/${field}`,
+      issues,
+      code,
+      pageId,
+      blockId
+    );
+  });
+}
+
+function validateBlockReferenceArrayFields<T extends { id: string }>(
+  block: Record<string, unknown>,
+  fields: readonly string[],
+  referenceMap: IdMap<T>,
+  blockPath: string,
+  issues: CmsValidationIssueV1[],
+  code: string,
+  pageId: string,
+  blockId: string
+): void {
+  fields.forEach((field) => {
+    const value = block[field];
+    if (!Array.isArray(value)) {
+      return;
+    }
+
+    value.forEach((item, index) => {
+      validateOptionalReference(
+        getString(item),
+        referenceMap,
+        `${blockPath}/${field}/${index}`,
+        issues,
+        code,
+        pageId,
+        blockId
+      );
+    });
+  });
+}
+
+function validateAssetReference(
+  assetId: string,
+  assetMap: IdMap<CmsAssetV1>,
+  path: string,
+  issues: CmsValidationIssueV1[],
+  code: string,
+  pageId?: string,
+  blockId?: string
+): void {
+  validateOptionalReference(assetId, assetMap, path, issues, code, pageId, blockId);
+}
+
+function validateOptionalAssetReference(
+  assetId: string | undefined,
+  assetMap: IdMap<CmsAssetV1>,
+  path: string,
+  issues: CmsValidationIssueV1[],
+  code: string,
+  pageId?: string,
+  blockId?: string
+): void {
+  validateOptionalReference(assetId, assetMap, path, issues, code, pageId, blockId);
+}
+
+function validatePageReference(
+  pageId: string,
+  pageMap: IdMap<CmsPackageV1["payload"]["pages"][number]>,
+  path: string,
+  issues: CmsValidationIssueV1[],
+  code: string
+): void {
+  validateOptionalReference(pageId, pageMap, path, issues, code);
+}
+
+function validateOptionalReference<T extends { id: string }>(
+  id: string | undefined,
+  referenceMap: IdMap<T>,
+  path: string,
+  issues: CmsValidationIssueV1[],
+  code: string,
+  pageId?: string,
+  blockId?: string
+): void {
+  if (!id || referenceMap.has(id)) {
+    return;
+  }
+
+  addIssue(issues, {
+    code,
+    message: `Reference '${id}' does not exist.`,
+    path,
+    pageId,
+    blockId,
+  });
+}
+
+function validateProfileNamespace(
+  pathValue: string,
+  profileHandle: string,
+  path: string,
+  issues: CmsValidationIssueV1[],
+  code: string
+): void {
+  const expectedPrefix = `/${profileHandle.toLowerCase()}/`;
+  if (!pathValue.toLowerCase().startsWith(expectedPrefix)) {
+    addIssue(issues, {
+      code,
+      message: `CMS path '${pathValue}' must stay under /${profileHandle}/.`,
+      path,
+    });
+  }
+}
+
+function validateReservedRouteRoot(
+  pathValue: string,
+  path: string,
+  issues: CmsValidationIssueV1[]
+): void {
+  const routeRoot = pathValue.split("/")[1]?.toLowerCase();
+  if (!routeRoot) {
+    return;
+  }
+
+  if ((CMS_RESERVED_APP_ROUTE_ROOTS as readonly string[]).includes(routeRoot)) {
+    addIssue(issues, {
+      code: "route.reserved_root",
+      message: `Route root '/${routeRoot}' is reserved by the application.`,
+      path,
+    });
+  }
+}
+
+function validateSafeUri(
+  value: string,
+  path: string,
+  issues: CmsValidationIssueV1[],
+  code: string,
+  allowRelative: boolean,
+  pageId?: string,
+  blockId?: string
+): void {
+  if (isSafeUri(value, allowRelative)) {
+    return;
+  }
+
+  addIssue(issues, {
+    code,
+    message: `Unsafe or unsupported URI '${value}'.`,
+    path,
+    pageId,
+    blockId,
+  });
+}
+
+function isSafeUri(value: string, allowRelative: boolean): boolean {
+  if (allowRelative && value.startsWith("/") && !value.startsWith("//")) {
+    return true;
+  }
+
+  try {
+    const protocol = new URL(value).protocol.toLowerCase();
+    return (CMS_SAFE_URI_PROTOCOLS as readonly string[]).includes(protocol);
+  } catch {
+    return false;
+  }
+}
+
+function validateEthereumAddress(
+  value: string,
+  path: string,
+  issues: CmsValidationIssueV1[],
+  code: string
+): void {
+  try {
+    getAddress(value);
+  } catch {
+    addIssue(issues, {
+      code,
+      message: `Invalid Ethereum address '${value}'.`,
+      path,
+    });
+  }
+}
+
+function toIdMap<T extends { id: string }>(
+  items: T[],
+  path: string,
+  label: string,
+  issues: CmsValidationIssueV1[]
+): IdMap<T> {
+  const map: IdMap<T> = new Map();
+
+  items.forEach((item, index) => {
+    if (map.has(item.id)) {
+      addIssue(issues, {
+        code: `${label}.duplicate_id`,
+        message: `${label} id '${item.id}' appears more than once.`,
+        path: `${path}/${index}/id`,
+      });
+    } else {
+      map.set(item.id, { value: item, index });
+    }
+  });
+
+  return map;
+}
+
+function mapZodIssue(issue: ZodIssue): CmsValidationIssueV1 {
+  const path = toJsonPointer(issue.path);
+
+  if (issue.path[0] === "signatures") {
+    return issueFromInput({
+      code: "signature.required",
+      message: "At least one signature is required.",
+      path: "/signatures",
+    });
+  }
+
+  if (issue.path[issue.path.length - 1] === "block_type") {
+    return issueFromInput({
+      code: "block.unknown_type",
+      message: "Unknown block type. V1 CMS packages fail closed.",
+      path,
+    });
+  }
+
+  if (issue.path.some((segment) => String(segment).includes("hash"))) {
+    return issueFromInput({
+      code: "hash.invalid",
+      message: issue.message,
+      path,
+    });
+  }
+
+  return issueFromInput({
+    code: "schema.invalid",
+    message: issue.message,
+    path,
+  });
+}
+
+function addIssue(
+  issues: CmsValidationIssueV1[],
+  input: IssueInput
+): void {
+  issues.push(issueFromInput(input));
+}
+
+function issueFromInput(input: IssueInput): CmsValidationIssueV1 {
+  return {
+    severity: input.severity ?? "error",
+    code: input.code,
+    message: input.message,
+    path: input.path,
+    ...(input.pageId ? { page_id: input.pageId } : {}),
+    ...(input.blockId ? { block_id: input.blockId } : {}),
+    ...(input.suggestedFix ? { suggested_fix: input.suggestedFix } : {}),
+  };
+}
+
+function formatCheckedAt(value: Date | string | undefined): string {
+  if (!value) {
+    return new Date().toISOString();
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  return value;
+}
+
+function toJsonPointer(path: ZodIssue["path"]): string {
+  if (!path.length) {
+    return "/";
+  }
+
+  return `/${path.map((segment) => escapePointerSegment(String(segment))).join("/")}`;
+}
+
+function escapePointerSegment(segment: string): string {
+  return segment.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+function getTarget(input: unknown): CmsValidationResultV1["target"] | undefined {
+  if (!isRecord(input)) {
+    return undefined;
+  }
+
+  const inputIntegrity = input["integrity"];
+  const integrity = isRecord(inputIntegrity) ? inputIntegrity : undefined;
+  const target: NonNullable<CmsValidationResultV1["target"]> = {};
+  const packageHash = integrity?.["package_hash"];
+  const packageId = input["package_id"];
+
+  if (typeof packageHash === "string" && isCmsSha256Hash(packageHash)) {
+    target.package_hash = packageHash;
+  }
+
+  if (typeof packageId === "string") {
+    target.package_id = packageId;
+  }
+
+  return Object.keys(target).length ? target : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}

--- a/lib/profile-cms/protocol/v1/validation.ts
+++ b/lib/profile-cms/protocol/v1/validation.ts
@@ -1205,8 +1205,8 @@ function validateSafeUri(
 }
 
 function isSafeUri(value: string, allowRelative: boolean): boolean {
-  if (allowRelative && value.startsWith("/") && !value.startsWith("//")) {
-    return true;
+  if (allowRelative && value.startsWith("/")) {
+    return isSafeRelativeUri(value);
   }
 
   try {
@@ -1215,6 +1215,19 @@ function isSafeUri(value: string, allowRelative: boolean): boolean {
   } catch {
     return false;
   }
+}
+
+function isSafeRelativeUri(value: string): boolean {
+  if (value.startsWith("//")) {
+    return false;
+  }
+
+  if (/[\\\u0000-\u001f\u007f]/.test(value)) {
+    return false;
+  }
+
+  const lowercaseValue = value.toLowerCase();
+  return !lowercaseValue.startsWith("/%2f") && !lowercaseValue.startsWith("/%5c");
 }
 
 function validateEthereumAddress(

--- a/lib/profile-cms/protocol/v1/validation.ts
+++ b/lib/profile-cms/protocol/v1/validation.ts
@@ -254,13 +254,7 @@ function validateRoutes(
         });
       }
     } else {
-      if (!route.target) {
-        addIssue(issues, {
-          code: "route.target.required",
-          message: `${route.kind} routes must include target.`,
-          path: `/payload/routes/${index}/target`,
-        });
-      } else {
+      if (route.target) {
         validateRouteTarget(
           route.target,
           route.kind,
@@ -269,6 +263,12 @@ function validateRoutes(
           `/payload/routes/${index}/target`,
           issues
         );
+      } else {
+        addIssue(issues, {
+          code: "route.target.required",
+          message: `${route.kind} routes must include target.`,
+          path: `/payload/routes/${index}/target`,
+        });
       }
 
       if (route.page_id) {
@@ -1353,7 +1353,7 @@ function toJsonPointer(path: ZodIssue["path"]): string {
 }
 
 function escapePointerSegment(segment: string): string {
-  return segment.replace(/~/g, "~0").replace(/\//g, "~1");
+  return segment.replaceAll("~", "~0").replaceAll("/", "~1");
 }
 
 function getTarget(input: unknown): CmsValidationResultV1["target"] | undefined {

--- a/lib/profile-cms/protocol/v1/validation.ts
+++ b/lib/profile-cms/protocol/v1/validation.ts
@@ -42,6 +42,39 @@ interface IssueInput {
 }
 
 type IdMap<T extends { id: string }> = Map<string, { value: T; index: number }>;
+type CmsPageV1 = CmsPackageV1["payload"]["pages"][number];
+type CmsNftMediaProfileV1 = NonNullable<
+  CmsPackageV1["payload"]["nft_media_profiles"]
+>[number];
+type CmsDeepZoomManifestV1 = NonNullable<
+  CmsPackageV1["payload"]["deep_zoom_manifests"]
+>[number];
+type CmsExhibitionRoomV1 = NonNullable<
+  CmsPackageV1["payload"]["exhibition_rooms"]
+>[number];
+type CmsSourcePacketV1 = NonNullable<
+  CmsPackageV1["payload"]["source_packets"]
+>[number];
+
+interface SemanticValidationContext {
+  issues: CmsValidationIssueV1[];
+  pageMap: IdMap<CmsPageV1>;
+  assetMap: IdMap<CmsAssetV1>;
+  nftProfileMap: IdMap<CmsNftMediaProfileV1>;
+  deepZoomMap: IdMap<CmsDeepZoomManifestV1>;
+  roomMap: IdMap<CmsExhibitionRoomV1>;
+  sourcePacketMap: IdMap<CmsSourcePacketV1>;
+}
+
+interface PageValidationContext {
+  pageId: string;
+  pagePath: string;
+}
+
+interface BlockValidationContext extends PageValidationContext {
+  blockId: string;
+  blockPath: string;
+}
 
 const VALIDATOR_NAME = "6529-cms-protocol-v1";
 const VALIDATOR_VERSION = "0.1.0";
@@ -168,19 +201,19 @@ function validateSemantics(
     "source_packet",
     issues
   );
-
-  validateRoutes(cmsPackage, pageMap, issues);
-  validateSiteManifest(cmsPackage, assetMap, issues);
-  validatePages(
-    cmsPackage,
+  const context: SemanticValidationContext = {
+    issues,
     pageMap,
     assetMap,
     nftProfileMap,
     deepZoomMap,
     roomMap,
     sourcePacketMap,
-    issues
-  );
+  };
+
+  validateRoutes(cmsPackage, pageMap, issues);
+  validateSiteManifest(cmsPackage, assetMap, issues);
+  validatePages(cmsPackage, context);
   validateAssets(payload.assets, issues);
   validateNftMediaProfiles(payload.nft_media_profiles ?? [], assetMap, issues);
   validateDeepZoomManifests(payload.deep_zoom_manifests ?? [], assetMap, issues);
@@ -370,22 +403,9 @@ function validateSiteManifest(
 
 function validatePages(
   cmsPackage: CmsPackageV1,
-  pageMap: IdMap<CmsPackageV1["payload"]["pages"][number]>,
-  assetMap: IdMap<CmsAssetV1>,
-  nftProfileMap: IdMap<
-    NonNullable<CmsPackageV1["payload"]["nft_media_profiles"]>[number]
-  >,
-  deepZoomMap: IdMap<
-    NonNullable<CmsPackageV1["payload"]["deep_zoom_manifests"]>[number]
-  >,
-  roomMap: IdMap<
-    NonNullable<CmsPackageV1["payload"]["exhibition_rooms"]>[number]
-  >,
-  sourcePacketMap: IdMap<
-    NonNullable<CmsPackageV1["payload"]["source_packets"]>[number]
-  >,
-  issues: CmsValidationIssueV1[]
+  context: SemanticValidationContext
 ): void {
+  const { assetMap, issues, sourcePacketMap } = context;
   const routePaths = new Set(cmsPackage.payload.routes.map((route) => route.path));
 
   cmsPackage.payload.pages.forEach((page, pageIndex) => {
@@ -445,49 +465,33 @@ function validatePages(
       });
     }
 
-    validateBlocks(
-      page.blocks,
-      pagePath,
-      page.id,
-      pageMap,
-      assetMap,
-      nftProfileMap,
-      deepZoomMap,
-      roomMap,
-      issues
-    );
+    validateBlocks(page.blocks, { pageId: page.id, pagePath }, context);
   });
 }
 
 function validateBlocks(
   blocks: CmsBlockV1[],
-  pagePath: string,
-  pageId: string,
-  pageMap: IdMap<CmsPackageV1["payload"]["pages"][number]>,
-  assetMap: IdMap<CmsAssetV1>,
-  nftProfileMap: IdMap<
-    NonNullable<CmsPackageV1["payload"]["nft_media_profiles"]>[number]
-  >,
-  deepZoomMap: IdMap<
-    NonNullable<CmsPackageV1["payload"]["deep_zoom_manifests"]>[number]
-  >,
-  roomMap: IdMap<
-    NonNullable<CmsPackageV1["payload"]["exhibition_rooms"]>[number]
-  >,
-  issues: CmsValidationIssueV1[]
+  pageContext: PageValidationContext,
+  context: SemanticValidationContext
 ): void {
+  const { assetMap, deepZoomMap, issues, nftProfileMap, pageMap, roomMap } = context;
   const blockIds = new Set<string>();
 
   blocks.forEach((block, blockIndex) => {
-    const blockPath = `${pagePath}/blocks/${blockIndex}`;
+    const blockPath = `${pageContext.pagePath}/blocks/${blockIndex}`;
+    const blockContext: BlockValidationContext = {
+      ...pageContext,
+      blockId: block.id,
+      blockPath,
+    };
     const record = block as Record<string, unknown>;
 
     if (blockIds.has(block.id)) {
       addIssue(issues, {
         code: "block.duplicate_id",
-        message: `Block id '${block.id}' is duplicated on page '${pageId}'.`,
+        message: `Block id '${block.id}' is duplicated on page '${pageContext.pageId}'.`,
         path: `${blockPath}/id`,
-        pageId,
+        pageId: pageContext.pageId,
         blockId: block.id,
       });
     }
@@ -497,81 +501,67 @@ function validateBlocks(
       record,
       ASSET_REFERENCE_FIELDS,
       assetMap,
-      blockPath,
+      blockContext,
       issues,
-      "asset.reference_missing",
-      pageId,
-      block.id
+      "asset.reference_missing"
     );
     validateBlockReferenceArrayFields(
       record,
       ASSET_REFERENCE_ARRAY_FIELDS,
       assetMap,
-      blockPath,
+      blockContext,
       issues,
-      "asset.reference_missing",
-      pageId,
-      block.id
+      "asset.reference_missing"
     );
     validateBlockReferenceFields(
       record,
       PAGE_REFERENCE_FIELDS,
       pageMap,
-      blockPath,
+      blockContext,
       issues,
-      "page.reference_missing",
-      pageId,
-      block.id
+      "page.reference_missing"
     );
     validateBlockReferenceArrayFields(
       record,
       PAGE_REFERENCE_ARRAY_FIELDS,
       pageMap,
-      blockPath,
+      blockContext,
       issues,
-      "page.reference_missing",
-      pageId,
-      block.id
+      "page.reference_missing"
     );
     validateBlockReferenceFields(
       record,
       NFT_PROFILE_REFERENCE_FIELDS,
       nftProfileMap,
-      blockPath,
+      blockContext,
       issues,
-      "nft_media_profile.reference_missing",
-      pageId,
-      block.id
+      "nft_media_profile.reference_missing"
     );
     validateBlockReferenceFields(
       record,
       DEEP_ZOOM_REFERENCE_FIELDS,
       deepZoomMap,
-      blockPath,
+      blockContext,
       issues,
-      "deep_zoom.reference_missing",
-      pageId,
-      block.id
+      "deep_zoom.reference_missing"
     );
     validateBlockReferenceFields(
       record,
       ROOM_REFERENCE_FIELDS,
       roomMap,
-      blockPath,
+      blockContext,
       issues,
-      "room.reference_missing",
-      pageId,
-      block.id
+      "room.reference_missing"
     );
     validateInteractivePolicyReferences(
       block,
       assetMap,
       blockPath,
-      pageId,
+      pageContext.pageId,
       issues
     );
-    validateBlockUrls(record, blockPath, pageId, block.id, issues);
-    validateHeavyMediaBlock(block, assetMap, blockPath, pageId, issues);
+    validateBlockUrls(record, blockPath, pageContext.pageId, block.id, issues);
+    validateHeavyMediaBlock(block, assetMap, blockPath, pageContext.pageId, issues);
   });
 }
 
@@ -1041,21 +1031,19 @@ function validateBlockReferenceFields<T extends { id: string }>(
   block: Record<string, unknown>,
   fields: readonly string[],
   referenceMap: IdMap<T>,
-  blockPath: string,
+  blockContext: BlockValidationContext,
   issues: CmsValidationIssueV1[],
-  code: string,
-  pageId: string,
-  blockId: string
+  code: string
 ): void {
   fields.forEach((field) => {
     validateOptionalReference(
       getString(block[field]),
       referenceMap,
-      `${blockPath}/${field}`,
+      `${blockContext.blockPath}/${field}`,
       issues,
       code,
-      pageId,
-      blockId
+      blockContext.pageId,
+      blockContext.blockId
     );
   });
 }
@@ -1064,11 +1052,9 @@ function validateBlockReferenceArrayFields<T extends { id: string }>(
   block: Record<string, unknown>,
   fields: readonly string[],
   referenceMap: IdMap<T>,
-  blockPath: string,
+  blockContext: BlockValidationContext,
   issues: CmsValidationIssueV1[],
-  code: string,
-  pageId: string,
-  blockId: string
+  code: string
 ): void {
   fields.forEach((field) => {
     const value = block[field];
@@ -1080,11 +1066,11 @@ function validateBlockReferenceArrayFields<T extends { id: string }>(
       validateOptionalReference(
         getString(item),
         referenceMap,
-        `${blockPath}/${field}/${index}`,
+        `${blockContext.blockPath}/${field}/${index}`,
         issues,
         code,
-        pageId,
-        blockId
+        blockContext.pageId,
+        blockContext.blockId
       );
     });
   });

--- a/ops/workstreams/profile-native-cms-roadmap/active-context.md
+++ b/ops/workstreams/profile-native-cms-roadmap/active-context.md
@@ -4,9 +4,9 @@ Last updated: 2026-06-17.
 
 ## Current State
 
-Phase 0 and Phase 1 are now delivered as docs/protocol artifacts in this repo.
-They are ready to seed implementation PRs, but they are not executable product
-code yet.
+Phase 0 and Phase 1 are delivered as docs/protocol artifacts in this repo, and
+Wave 0 now adds an executable frontend protocol bridge under
+`lib/profile-cms/protocol/v1/`.
 
 Available now:
 
@@ -17,6 +17,15 @@ Available now:
 - Phase 1 agent patch and validation-result JSON schemas.
 - Phase 1 valid and invalid fixture corpus.
 - Phase 1 hash/canonicalization vector plan.
+- Executable Zod schema mirror for CMS package, payload, agent patch, and
+  validation-result shapes.
+- Strict canonical JSON and `sha256:<hex>` helpers.
+- Real hash vectors for minimal objects and the minimal profile homepage
+  fixture.
+- Semantic validator for route, namespace, reference, URL, fixture-mode,
+  media, storage, signature, and optional hash checks.
+- Jest tests for canonicalization, hashing, and all valid/invalid Phase 1
+  fixtures.
 - Page types for pages, posts, galleries, collections, NFT/card details, and
   room-style pages.
 - Blocks for headings, rich text, images, galleries, quotes, callouts, button
@@ -37,6 +46,9 @@ Important limits:
 - The broader schema is ahead of any authoring experience.
 - Real IPFS and Arweave upload adapters are still needed.
 - Real wallet signature verification is still needed.
+- The executable validator is currently a Zod mirror plus semantic pass. The
+  JSON Schema files remain the protocol reference; a later shared-package pass
+  should decide whether to add direct AJV execution.
 - Live NFT indexing, full collection pages, full NFT pages, and 3D rooms are
   not implemented yet.
 - There is no general WYSIWYG/block editor yet.
@@ -58,15 +70,18 @@ Important limits:
 
 ## Next Implementation Slice
 
-The highest leverage next slice is Wave 0 implementation from
-`phase-0/pr-wave-plan.md`:
+The highest leverage next slice is Wave 1 from `phase-0/pr-wave-plan.md`:
 
-1. Move or mirror the Phase 1 schemas into executable protocol code under
-   `lib/profile-cms/protocol/v1/` or a shared 6529mono package.
-2. Implement RFC 8785 canonical JSON and SHA-256 vectors.
-3. Add a real schema and semantic validator against the Phase 1 fixtures.
-4. Add FE and BE CI checks that parse and validate the same fixture corpus.
-5. Only then begin route/render/publish/builder/gallery parallel waves.
+1. Decide whether this executable protocol stays in FE temporarily or moves to
+   a shared 6529mono package before BE adoption.
+2. Add backend tests that consume the same Phase 1 fixture corpus and validation
+   result shape.
+3. Start the `/{handle}/index.html` route and native static renderer behind a
+   feature flag.
+4. Add profile-page website button plumbing for profiles with a published CMS
+   pointer.
+5. Only then fan out publish/storage, builder, wallet-gallery generation, art
+   display, 3D rooms, and AI-agent affordances.
 
 ## Decisions To Make Before Coding More
 
@@ -74,6 +89,6 @@ The highest leverage next slice is Wave 0 implementation from
 - Whether public launch should require both IPFS and Arweave receipts instead
   of one required plus one preferred.
 - Exact EIP-712 typed-data domain and user-facing signing copy.
-- Whether Phase 1 executable schema work starts in this FE repo or immediately
-  moves into a shared 6529mono package.
+- Whether the Wave 0 executable protocol moves into a shared 6529mono package
+  before backend implementation, or is copied into BE as a temporary bridge.
 - Exact first institutional migration pilot.

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/README.md
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/README.md
@@ -56,6 +56,14 @@ These schemas are the first protocol foundation, not the final generated API
 model. Implementation PRs should either use these directly or move them into a
 shared protocol package with identical semantics.
 
-Current validation is docs/artifact-level only: JSON parse and focused semantic
-checks have run, but full JSON Schema validation has not run in this pass
-because `ajv` is not currently resolvable in the local Node environment.
+Wave 0 now mirrors the package contract into executable TypeScript under
+`lib/profile-cms/protocol/v1/`:
+
+- Zod schema mirror for package, payload, agent patch, and validation result.
+- Strict canonical JSON helper.
+- SHA-256 helpers and real hash vectors.
+- Semantic validator against the Phase 1 fixture corpus.
+
+The JSON Schema files remain the protocol reference. A later shared-package pass
+can decide whether to add a direct AJV dependency for literal draft-2020-12
+execution or keep the Zod mirror as the runtime validator.

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/hash-test-vectors.md
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/hash-test-vectors.md
@@ -73,15 +73,19 @@ sha256:ad8d45da7c8810c3b3096cf0290b853a946e39cf579bfa05f7a9d20e30fa7d80
 Expected package hash:
 
 ```text
-sha256:b8a7cc1340a7e3591c66696efcc7f44c560332bc1a044b7cd124879349607f9b
+sha256:16395e1fece98a76de58fcc4fc42569661b7a3fc88bf33272d5ee2be0c6c4f91
 ```
 
 Package hash input rule for Wave 0:
 
 - Compute and set `integrity.payload_hash` first.
-- Compute package hash over the package with `integrity.package_hash` omitted.
-- Signatures and storage receipts remain part of that package hash input; the
-  self-referential `package_hash` field is the only omitted field.
+- Compute package hash over the package with `integrity.package_hash`,
+  `signatures`, and `storage` omitted.
+- Production signatures should attest to the payload/package hash commitment
+  through the EIP-712 publish flow, not to a package hash that contains their
+  own signature envelope.
+- Storage receipts are verification/delivery evidence and must be verified
+  against their own content IDs and content hashes in the publish/storage wave.
 
 ## Validator Requirements
 

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/hash-test-vectors.md
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/hash-test-vectors.md
@@ -41,7 +41,7 @@ Canonical bytes:
 Expected hash:
 
 ```text
-pending implementation
+sha256:43258cff783fe7036d8a43033f830adfc60ec037382473548ac742b888292777
 ```
 
 ### Vector 2: Unicode String
@@ -55,7 +55,7 @@ Input:
 Expected hash:
 
 ```text
-pending implementation
+sha256:3c518ebe06d42949bc66db07f8ea911d1fbf5f75e06e998df4ef34bbc38f0b81
 ```
 
 ### Vector 3: Minimal Profile Homepage Payload
@@ -67,14 +67,21 @@ Input:
 Expected payload hash:
 
 ```text
-pending implementation
+sha256:ad8d45da7c8810c3b3096cf0290b853a946e39cf579bfa05f7a9d20e30fa7d80
 ```
 
 Expected package hash:
 
 ```text
-pending implementation
+sha256:b8a7cc1340a7e3591c66696efcc7f44c560332bc1a044b7cd124879349607f9b
 ```
+
+Package hash input rule for Wave 0:
+
+- Compute and set `integrity.payload_hash` first.
+- Compute package hash over the package with `integrity.package_hash` omitted.
+- Signatures and storage receipts remain part of that package hash input; the
+  self-referential `package_hash` field is the only omitted field.
 
 ## Validator Requirements
 
@@ -85,4 +92,3 @@ Hash validator must:
 - Reject non-`sha256:` prefixes for V1.
 - Treat CDN delivery URL changes as non-canonical if outside signed package, but
   reject storage receipt mutations inside signed package.
-

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/schema-index.md
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/schema-index.md
@@ -58,17 +58,24 @@ Valid:
 
 - Minimal profile homepage.
 - Wallet gallery with generated collection and NFT routes.
+- Collection page with a knowledge packet source.
 - NFT detail page with art assets and display variants.
+- Mixed media page with image, video, audio, HTML embed, and 3D model assets.
 - 3D exhibition room with faithful 2D fallback.
+- Legacy institutional route migration package.
 
 Invalid:
 
 - Missing signature.
 - Route collision.
+- Unknown block type.
 
 ## Canonical Hashing
 
-Phase 1 fixtures use placeholder hashes where noted. Implementation must
-replace placeholders with RFC 8785 canonical JSON + SHA-256 vectors before
-Phase 2 renderer/publish work is considered protocol-stable.
+Phase 1 fixture package hashes remain placeholder-shaped where noted, so they
+can document the protocol without pretending publish hashes are final.
 
+Wave 0 implementation now provides executable canonical JSON + SHA-256 helpers
+under `lib/profile-cms/protocol/v1/`, and `hash-test-vectors.md` includes real
+small-object and minimal-homepage vectors. Phase 2 renderer/publish work should
+use those helpers rather than inventing a second hash path.

--- a/ops/workstreams/profile-native-cms-roadmap/phase-1/validation-plan.md
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-1/validation-plan.md
@@ -103,18 +103,33 @@ Phase 1 docs live in the frontend repo. Before production code lands:
 
 ## Current Artifact Validation Evidence
 
-Completed in this docs-only Phase 0/1 pass:
+Completed in the docs-only Phase 0/1 pass:
 
 - All Phase 1 JSON schemas and fixtures parse as JSON.
 - All valid fixtures have unique route paths.
 - `invalid/route-collision.package.json` intentionally duplicates
   `/punk6529/index.html`.
 
-Not completed in this pass:
+Completed in Wave 0 executable bridge:
 
-- Full JSON Schema validation. `ajv` was not resolvable in the local Node
-  environment, and Python `jsonschema` was also unavailable, so implementation
-  must add an explicit validator dependency or repo-approved validation path
-  before treating the schema as executable.
-- Real RFC 8785 hash vectors. Fixture hashes are placeholder-shaped until the
-  canonicalization implementation lands.
+- `lib/profile-cms/protocol/v1/` exports a Zod schema mirror, canonical JSON
+  helper, SHA-256 helper, and semantic validator.
+- Valid fixture corpus passes the executable validator.
+- Invalid fixture corpus returns the documented error codes for missing
+  signature, duplicate route, and unknown block type.
+- Fixture signatures/storage are accepted in default fixture/dev mode and
+  rejected when production options disable them.
+- Optional hash enforcement catches payload and package mutations once computed
+  hashes are applied.
+- Hash shape validation rejects uppercase hex and non-`sha256:` prefixes.
+
+Still not completed:
+
+- Literal draft-2020-12 JSON Schema execution. The runtime bridge uses Zod plus
+  semantic validation; if we need exact JSON Schema execution, add a direct AJV
+  dependency in a later shared-package pass.
+- Full production signature authority verification, EIP-1271/Safe verification,
+  pointer expected-previous concurrency, and storage provider receipt checks.
+- Replacement of every placeholder fixture root hash. The helper can compute
+  hashes now, but fixtures keep placeholder-shaped values until the publish
+  package format is signed off.

--- a/ops/workstreams/profile-native-cms-roadmap/run-log.md
+++ b/ops/workstreams/profile-native-cms-roadmap/run-log.md
@@ -263,6 +263,84 @@ Changes made from bot feedback:
   validation.
 - Tightened roadmap language so unsupported blocks fail closed in V1.
 
+## 2026-06-17: Wave 0 Executable Protocol Bridge
+
+### Current Objective
+
+Turn the Phase 1 CMS protocol artifacts into executable frontend code that
+future FE, BE, renderer, builder, and agent lanes can validate against.
+
+### Output
+
+Added executable protocol package:
+
+- `lib/profile-cms/protocol/v1/constants.ts`
+- `lib/profile-cms/protocol/v1/schemas.ts`
+- `lib/profile-cms/protocol/v1/canonical-json.ts`
+- `lib/profile-cms/protocol/v1/hash.ts`
+- `lib/profile-cms/protocol/v1/validation.ts`
+- `lib/profile-cms/protocol/v1/index.ts`
+
+Added tests:
+
+- `__tests__/lib/profile-cms/protocol/v1/canonical-json.test.ts`
+- `__tests__/lib/profile-cms/protocol/v1/hash.test.ts`
+- `__tests__/lib/profile-cms/protocol/v1/fixtures.test.ts`
+
+Updated docs:
+
+- `ops/workstreams/profile-native-cms-roadmap/active-context.md`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/README.md`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/schema-index.md`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/hash-test-vectors.md`
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/validation-plan.md`
+
+### Implementation Notes
+
+- Runtime validation uses existing direct `zod` dependency, not a new AJV
+  dependency.
+- JSON Schema files remain the protocol reference.
+- Canonical JSON rejects undefined, functions, symbols, bigint, non-finite
+  numbers, non-plain objects, and cycles.
+- Hash helper uses `sha256:<64 lowercase hex>`.
+- Package hash input omits only `integrity.package_hash` to avoid
+  self-reference; `integrity.payload_hash`, signatures, and storage receipts
+  remain in the hash input.
+- Default validation accepts fixture signatures/storage for fixture/dev usage.
+  Production mode can disable both.
+- Hash enforcement is optional so placeholder-hash fixtures can stay useful
+  until publish/signing finalizes.
+
+### Validation Evidence
+
+Completed locally:
+
+- `seize run test:no-coverage -- __tests__/lib/profile-cms/protocol/v1`
+  passed.
+- `seize run lint:changed` passed.
+- `seize run typecheck:changed` passed.
+- `codex-diff-check -- lib/profile-cms __tests__/lib/profile-cms ops/workstreams/profile-native-cms-roadmap`
+  passed.
+
+Coverage from that slice:
+
+- Canonical JSON object ordering, array order, and invalid input rejection.
+- Hash vectors for object ordering and unicode title.
+- Computed minimal-profile payload and package hash enforcement.
+- Mutation detection for payload/package hash mismatch.
+- All seven valid Phase 1 fixtures pass.
+- All three invalid fixtures return documented error codes.
+- Production-mode fixture signature/storage rejection.
+- Unsafe URL-scheme rejection.
+- Uppercase hash hex and non-`sha256:` prefix rejection.
+
+### Remaining Work
+
+- Decide whether to move the executable protocol into a shared 6529mono package
+  before BE adoption.
+- Add BE tests against the same fixture corpus.
+- Start Wave 1 route/render/profile-button work behind feature flags.
+
 ## 2026-06-17: Art And NFT Display Research
 
 ### Current Objective

--- a/ops/workstreams/profile-native-cms-roadmap/run-log.md
+++ b/ops/workstreams/profile-native-cms-roadmap/run-log.md
@@ -303,9 +303,8 @@ Updated docs:
 - Canonical JSON rejects undefined, functions, symbols, bigint, non-finite
   numbers, non-plain objects, and cycles.
 - Hash helper uses `sha256:<64 lowercase hex>`.
-- Package hash input omits only `integrity.package_hash` to avoid
-  self-reference; `integrity.payload_hash`, signatures, and storage receipts
-  remain in the hash input.
+- Package hash input omits `integrity.package_hash`, `signatures`, and
+  `storage` to avoid self-reference and mutable envelope coupling.
 - Default validation accepts fixture signatures/storage for fixture/dev usage.
   Production mode can disable both.
 - Hash enforcement is optional so placeholder-hash fixtures can stay useful
@@ -333,8 +332,11 @@ Coverage from that slice:
 - All three invalid fixtures return documented error codes.
 - Production-mode fixture signature/storage rejection.
 - Unsafe URL-scheme rejection.
+- Plain HTTP asset URI rejection.
+- Unsafe relative URL rejection for backslash and encoded scheme-relative forms.
 - Uppercase hash hex and non-`sha256:` prefix rejection.
 - Type-vs-format schema failures for block types and hash fields.
+- Signature/storage envelope exclusion from package hash input.
 
 ### Bot Review Iteration
 
@@ -344,6 +346,12 @@ Coverage from that slice:
 - Adding an astral-key ordering vector.
 - Narrowing `block_type` issue mapping to enum failures only.
 - Narrowing `hash.invalid` issue mapping to regex failures on known hash fields.
+- Excluding signatures/storage from package hash input and documenting that
+  production signatures attest through EIP-712 rather than signing over their
+  own signature envelope.
+- Removing plain `http:` from the CMS URI allowlist.
+- Rejecting unsafe relative URL forms with backslashes, control characters, and
+  encoded scheme-relative prefixes.
 
 Follow-up changes were made and revalidated locally.
 

--- a/ops/workstreams/profile-native-cms-roadmap/run-log.md
+++ b/ops/workstreams/profile-native-cms-roadmap/run-log.md
@@ -325,6 +325,7 @@ Completed locally:
 Coverage from that slice:
 
 - Canonical JSON object ordering, array order, and invalid input rejection.
+- RFC 8785/JCS-oriented numeric edge cases and astral-key ordering.
 - Hash vectors for object ordering and unicode title.
 - Computed minimal-profile payload and package hash enforcement.
 - Mutation detection for payload/package hash mismatch.
@@ -333,6 +334,18 @@ Coverage from that slice:
 - Production-mode fixture signature/storage rejection.
 - Unsafe URL-scheme rejection.
 - Uppercase hash hex and non-`sha256:` prefix rejection.
+- Type-vs-format schema failures for block types and hash fields.
+
+### Bot Review Iteration
+
+6529bot general review requested changes on:
+
+- Making the canonical number path explicit and adding JCS edge vectors.
+- Adding an astral-key ordering vector.
+- Narrowing `block_type` issue mapping to enum failures only.
+- Narrowing `hash.invalid` issue mapping to regex failures on known hash fields.
+
+Follow-up changes were made and revalidated locally.
 
 ### Remaining Work
 


### PR DESCRIPTION
## Summary
- add executable profile CMS v1 protocol exports with constants, Zod schema mirror, canonical JSON, SHA-256 hash helpers, and semantic validation
- validate Phase 1 fixture corpus for routes, profile namespace, references, URL schemes, fixture production modes, media fallbacks, storage, signatures, and optional hash enforcement
- add Jest coverage for canonicalization, hash vectors, valid/invalid fixtures, unsafe URLs, fixture production rejection, and hash mutation detection
- update roadmap docs with Wave 0 status, real hash vectors, fixture coverage, and remaining shared-package/BE handoff items

## Verification
- `seize run test:no-coverage -- __tests__/lib/profile-cms/protocol/v1`
- `seize run lint:changed`
- `seize run typecheck:changed`
- `codex-diff-check -- lib/profile-cms __tests__/lib/profile-cms ops/workstreams/profile-native-cms-roadmap`