### PR TITLE
Allow delegation publish script lint exceptions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -516,9 +516,12 @@ export const createEslintConfig = ({
       },
     },
 
-    // Standalone build/export scripts legitimately use computed paths and stdout logging.
+    // Build/export/publish scripts legitimately use computed paths and stdout logging.
     {
-      files: ["standalone/standalone-memes-mint/scripts/**/*.{js,cjs,mjs}"],
+      files: [
+        "ops/scripts/publish-delegation-docs-content.mjs",
+        "standalone/standalone-memes-mint/scripts/**/*.{js,cjs,mjs}",
+      ],
       rules: {
         "security/detect-non-literal-fs-filename": "off",
         "no-console": "off",


### PR DESCRIPTION
## Summary
- Extend the existing build/export script ESLint override to the delegation docs IPFS publisher.
- Keeps dynamic filesystem path and stdout logging allowances centralized in ESLint config.

## Validation
- `seize exec eslint ops/scripts/publish-delegation-docs-content.mjs --quiet`
- `codex-diff-check -- eslint.config.mjs ops/scripts/publish-delegation-docs-content.mjs`
- `seize run build` (completed; existing Sass/next-sitemap warnings remain)

## Deploy note
This fixes the staging deploy failure where full build lint rejected `ops/scripts/publish-delegation-docs-content.mjs`.