### PR TITLE
Polish Wave Score discovery and sidebar sorting

### DIFF
--- a/__tests__/app/networkPages.test.tsx
+++ b/__tests__/app/networkPages.test.tsx
@@ -92,16 +92,32 @@ describe("network pages render", () => {
     expect(screen.getByText(/Unique Memes/i)).toBeInTheDocument();
   });
 
-  it("renders Wave Score page in Network", () => {
-    renderWithAuth(<NetworkWaveScorePage />);
+  it("renders Wave Score page in Network", async () => {
+    const page = await NetworkWaveScorePage({});
+    renderWithAuth(page);
     expect(
-      screen.getByRole("heading", { level: 1, name: /Wave score transparency/i })
+      screen.getByRole("heading", {
+        level: 1,
+        name: /Wave score transparency/i,
+      })
     ).toBeInTheDocument();
     expect(screen.getByText("Network menu / Wave Score")).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { level: 2, name: "Calculate a wave" })
     ).toBeInTheDocument();
     expect(screen.getAllByText("Quality").length).toBeGreaterThan(0);
+  });
+
+  it("uses a safe Wave Score return link when provided", async () => {
+    const page = await NetworkWaveScorePage({
+      searchParams: Promise.resolve({ returnTo: "/waves/test-wave" }),
+    });
+    renderWithAuth(page);
+
+    expect(screen.getByRole("link", { name: "Back to wave" })).toHaveAttribute(
+      "href",
+      "/waves/test-wave"
+    );
   });
 
   it("generates metadata for Groups page", async () => {

--- a/__tests__/components/home/explore-waves/ExploreWavesSection.test.tsx
+++ b/__tests__/components/home/explore-waves/ExploreWavesSection.test.tsx
@@ -2,6 +2,8 @@ import { renderWithQueryClient } from "../../../utils/reactQuery";
 import { ExploreWavesSection } from "@/components/home/explore-waves/ExploreWavesSection";
 import { fetchWavesV2Page } from "@/services/api/waves-v2-api";
 import { waitFor } from "@testing-library/react";
+import { ApiWaveScoreSort } from "@/generated/models/ApiWaveScoreSort";
+import { ApiWavesOverviewType } from "@/generated/models/ApiWavesOverviewType";
 
 jest.mock("@/components/auth/Auth", () => ({
   useAuth: jest.fn(),
@@ -62,6 +64,39 @@ describe("ExploreWavesSection", () => {
     expect(fetchWavesV2PageMock).toHaveBeenCalledWith(
       expect.objectContaining({
         excludeFollowed: true,
+      })
+    );
+  });
+
+  it("defaults score sort only for scored discovery overview", async () => {
+    useAuthMock.mockReturnValue({ connectedProfile: null });
+
+    renderWithQueryClient(<ExploreWavesSection showEmptyState />);
+
+    await waitFor(() => expect(fetchWavesV2PageMock).toHaveBeenCalled());
+    expect(fetchWavesV2PageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        overviewType: ApiWavesOverviewType.ScoredRecentlyDroppedTo,
+        scoreSort: ApiWaveScoreSort.Balanced,
+      })
+    );
+  });
+
+  it("does not send score sort for latest-post overview", async () => {
+    useAuthMock.mockReturnValue({ connectedProfile: null });
+
+    renderWithQueryClient(
+      <ExploreWavesSection
+        overviewType={ApiWavesOverviewType.RecentlyDroppedTo}
+        showEmptyState
+      />
+    );
+
+    await waitFor(() => expect(fetchWavesV2PageMock).toHaveBeenCalled());
+    expect(fetchWavesV2PageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        overviewType: ApiWavesOverviewType.RecentlyDroppedTo,
+        scoreSort: undefined,
       })
     );
   });

--- a/__tests__/components/waves/WaveTrustSignals.test.tsx
+++ b/__tests__/components/waves/WaveTrustSignals.test.tsx
@@ -71,11 +71,13 @@ describe("WaveTrustSignals", () => {
     expect(summaryBadge).not.toBeNull();
     expect(summaryBadge).not.toHaveAttribute("title");
     expect(
-      screen.getByRole("link", { name: /^Combined score: 83\./ })
-    ).toHaveAttribute("href", "/network/wave-score");
-    expect(
-      screen.getByText("Click score to open the full formula")
+      screen.getByRole("button", { name: /^Combined score: 83\./ })
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Open full formula" })
+    ).toHaveAttribute("href", "/network/wave-score");
+    expect(screen.getByText("REP")).toBeInTheDocument();
+    expect(screen.getByText("+1.3K")).toBeInTheDocument();
     expect(
       screen.getByText("A quick signal for which waves deserve broad attention")
     ).toBeInTheDocument();
@@ -92,9 +94,10 @@ describe("WaveTrustSignals", () => {
       />
     );
 
-    const summaryBadge = screen.getByText("Score").closest("[aria-label]");
+    const summaryBadge = screen.getByText("83").closest("[aria-label]");
 
     expect(summaryBadge).not.toBeNull();
+    expect(screen.queryByText("Score")).not.toBeInTheDocument();
     expect(summaryBadge).not.toHaveAttribute("data-tooltip-content");
     expect(summaryBadge).not.toHaveAttribute("data-tooltip-id");
     expect(summaryBadge).not.toHaveAttribute("title");

--- a/__tests__/components/waves/discovery/DiscoverWaveExplorer.test.tsx
+++ b/__tests__/components/waves/discovery/DiscoverWaveExplorer.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import { DiscoverWaveExplorer } from "@/components/waves/discovery/DiscoverWaveExplorer";
+import { ApiWaveScoreSort } from "@/generated/models/ApiWaveScoreSort";
+import { ApiWavesOverviewType } from "@/generated/models/ApiWavesOverviewType";
+import { ApiWavesV2ListType } from "@/generated/models/ApiWavesV2ListType";
+
+const replaceMock = jest.fn();
+let searchParams = "";
+let latestExploreProps: Record<string, any> | null = null;
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/discover",
+  useRouter: () => ({ replace: replaceMock }),
+  useSearchParams: () => new URLSearchParams(searchParams),
+}));
+
+jest.mock("@/components/home/explore-waves/ExploreWavesSection", () => ({
+  ExploreWavesSection: (props: Record<string, any>) => {
+    latestExploreProps = props;
+    return <div>{props.headerControls}</div>;
+  },
+}));
+
+describe("DiscoverWaveExplorer", () => {
+  beforeEach(() => {
+    replaceMock.mockClear();
+    searchParams = "";
+    latestExploreProps = null;
+  });
+
+  it("uses combined score discovery by default", () => {
+    render(<DiscoverWaveExplorer />);
+
+    expect(latestExploreProps).toMatchObject({
+      title: "Active discussions you are not yet following",
+      excludeFollowed: true,
+      view: ApiWavesV2ListType.Overview,
+      overviewType: ApiWavesOverviewType.ScoredRecentlyDroppedTo,
+      scoreSort: ApiWaveScoreSort.Balanced,
+      statusLabel: "Balanced waves",
+    });
+  });
+
+  it("uses the latest-post backend overview without score filters", () => {
+    searchParams = "sort=LATEST_POSTS&filter=REP_60";
+
+    render(<DiscoverWaveExplorer />);
+
+    expect(latestExploreProps).toMatchObject({
+      excludeFollowed: true,
+      view: ApiWavesV2ListType.Overview,
+      overviewType: ApiWavesOverviewType.RecentlyDroppedTo,
+      scoreSort: undefined,
+      minRepSortScore: undefined,
+      statusLabel: "Latest Posts waves",
+    });
+    expect(screen.getByRole("radio", { name: "All" })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+    expect(screen.getByRole("radio", { name: "REP 60+" })).toBeDisabled();
+  });
+
+  it("uses search order for newest waves without client-side score filters", () => {
+    searchParams = "sort=NEWEST&filter=SCORE_50";
+
+    render(<DiscoverWaveExplorer />);
+
+    expect(latestExploreProps).toMatchObject({
+      title: "Newest waves",
+      excludeFollowed: false,
+      view: ApiWavesV2ListType.Search,
+      directMessage: false,
+      scoreSort: undefined,
+      minVisibilityScore: undefined,
+      statusLabel: "Newest waves",
+    });
+  });
+});

--- a/__tests__/components/waves/discovery/WaveScoreTransparencyPage.test.tsx
+++ b/__tests__/components/waves/discovery/WaveScoreTransparencyPage.test.tsx
@@ -1,0 +1,181 @@
+import { WaveScoreTransparencyPage } from "@/components/waves/discovery/WaveScoreTransparencyPage";
+import { ApiWaveType } from "@/generated/models/ApiWaveType";
+import { fetchWaveById, searchWavesByName } from "@/services/api/waves-v2-api";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("@/contexts/TitleContext", () => ({
+  __esModule: true,
+  useSetTitle: () => jest.fn(),
+}));
+
+jest.mock("@/services/api/waves-v2-api", () => ({
+  fetchWaveById: jest.fn(),
+  searchWavesByName: jest.fn(),
+}));
+
+const fetchWaveByIdMock = fetchWaveById as jest.MockedFunction<
+  typeof fetchWaveById
+>;
+const searchWavesByNameMock = searchWavesByName as jest.MockedFunction<
+  typeof searchWavesByName
+>;
+
+const WAVE_ID = "12345678-1234-1234-1234-123456789abc";
+
+const formula = {
+  max_level_raw_for_score: 25000000,
+  max_wave_rep_for_score: 200000000,
+  trusted_level_raw: 1000,
+  low_trust_level_raw: 25,
+  recent_activity_window_ms: 604800000,
+  recent_activity_half_life_ms: 172800000,
+  participation_saturation_scale: 600,
+  trusted_diversity_saturation_scale: 8,
+  trusted_subscription_saturation_scale: 30,
+  recent_activity_saturation_scale: 250,
+  trusted_visible_min_visibility_score: 55,
+  exploration_neutral_min_visibility_score: 25,
+  demoted_min_visibility_score: 10,
+  quality_component_weights: {
+    creator_score: 0.2,
+    level_weighted_participation_score: 0.2,
+    trusted_diversity_score: 0.15,
+    trusted_subscription_score: 0.1,
+    wave_rep_component_score: 0.35,
+  },
+  hotness_component_weights: {
+    recent_trusted_activity_score: 0.65,
+    quality_score: 0.35,
+  },
+  visibility_component_weights: {
+    quality_score: 0.65,
+    gated_hotness_score: 0.35,
+  },
+};
+
+const wave = {
+  id: WAVE_ID,
+  name: "Test Wave",
+  author: {
+    handle: "tester",
+  },
+  wave: {
+    type: ApiWaveType.Chat,
+  },
+  chat: {
+    scope: {
+      group: {
+        is_direct_message: false,
+      },
+    },
+  },
+  wave_rep: {
+    total_rep: 1256529,
+    positive_rep: 1300000,
+    negative_rep: -43471,
+    contributor_count: 9,
+  },
+  wave_score: {
+    score_version: "wave-score-v1",
+    visibility_score: 83,
+    quality_score: 78,
+    hotness_score: 92,
+    rep_sort_score: 87,
+    visibility_tier: "trusted_visible",
+    calculated_at: Date.UTC(2026, 5, 17, 12, 0, 0),
+    formula,
+    quality_gate: {
+      threshold: 25,
+      multiplier: 1,
+      gated_hotness_score: 92,
+    },
+    components: {
+      creator_score: 90,
+      level_weighted_participation_score: 80,
+      trusted_diversity_score: 75,
+      trusted_subscription_score: 60,
+      wave_rep_component_score: 87,
+      recent_trusted_activity_score: 94,
+    },
+    penalties: {
+      safety_multiplier: 1,
+      single_actor_penalty: 0,
+      low_trust_flood_penalty: 0,
+      cross_post_pressure: 3,
+      cross_post_penalty: 1,
+      negative_rep_penalty: 2,
+    },
+  },
+} as any;
+
+describe("WaveScoreTransparencyPage", () => {
+  const scrollIntoViewMock = jest.fn();
+  const writeTextMock = jest.fn();
+  const clipboardMock = {
+    writeText: writeTextMock,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchWaveByIdMock.mockResolvedValue(wave);
+    searchWavesByNameMock.mockResolvedValue([]);
+    writeTextMock.mockResolvedValue(undefined);
+    Object.defineProperty(globalThis.HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoViewMock,
+    });
+  });
+
+  it("returns to the source wave and exposes share actions for the calculated analysis", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(window.navigator, "clipboard", {
+      configurable: true,
+      value: clipboardMock,
+    });
+    render(<WaveScoreTransparencyPage initialReturnTo={`/waves/${WAVE_ID}`} />);
+
+    expect(screen.getByRole("link", { name: "Back to wave" })).toHaveAttribute(
+      "href",
+      `/waves/${WAVE_ID}`
+    );
+
+    await user.type(screen.getByLabelText("Wave name or URL"), WAVE_ID);
+    await user.click(screen.getByRole("button", { name: "Score" }));
+
+    const resultHeading = await screen.findByRole("heading", {
+      name: "Test Wave",
+    });
+    expect(fetchWaveByIdMock).toHaveBeenCalledWith({ waveId: WAVE_ID });
+    await waitFor(() => expect(scrollIntoViewMock).toHaveBeenCalled());
+
+    const summaryHeading = screen.getByRole("heading", {
+      name: "What the score is trying to do",
+    });
+    expect(
+      resultHeading.compareDocumentPosition(summaryHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Copy wave score analysis as Markdown",
+      })
+    );
+
+    await waitFor(() =>
+      expect(writeTextMock).toHaveBeenCalledWith(
+        expect.stringContaining("# Wave score analysis: Test Wave")
+      )
+    );
+    expect(writeTextMock).toHaveBeenCalledWith(
+      expect.stringContaining("- Wave REP: 1,256,529 raw -> 87 component")
+    );
+    expect(screen.getByText("Markdown analysis copied.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Download wave score analysis screenshot",
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/hooks/useWavesList.test.tsx
+++ b/__tests__/hooks/useWavesList.test.tsx
@@ -69,6 +69,8 @@ const useSeizeSettingsMock = require("@/contexts/SeizeSettingsContext")
 const useWaveByIdMock = useWaveById as jest.Mock;
 const useOfficialWavesMock = require("@/hooks/useOfficialWaves")
   .useOfficialWaves as jest.Mock;
+const useShowFollowingWavesMock = require("@/hooks/useShowFollowingWaves")
+  .useShowFollowingWaves as jest.Mock;
 const useWaveSubwavesMapMock = require("@/hooks/useWaveSubwaves")
   .useWaveSubwavesMap as jest.Mock;
 const getWaveSubwavesQueryOptionsMock = require("@/hooks/useWaveSubwaves")
@@ -94,12 +96,14 @@ const createSidebarWave = ({
   isDirectMessage = false,
   type = ApiWaveType.Rank,
   pinned = false,
+  subscribed = false,
 }: {
   readonly id: string;
   readonly latestDropTimestamp: number;
   readonly isDirectMessage?: boolean;
   readonly type?: ApiWaveType;
   readonly pinned?: boolean;
+  readonly subscribed?: boolean;
 }) => ({
   id,
   name: id,
@@ -123,7 +127,7 @@ const createSidebarWave = ({
   latestReadTimestamp: 0,
   pinned,
   muted: false,
-  subscribed: false,
+  subscribed,
 });
 
 const createLegacyApiWave = (id: string, latestDropTimestamp: number) =>
@@ -187,6 +191,7 @@ beforeEach(() => {
   });
   announcementRefetchMock = jest.fn();
   officialWavesRefetchMock = jest.fn();
+  useShowFollowingWavesMock.mockReturnValue([false]);
   useSeizeConnectContextMock.mockReturnValue({ address: "0xABC" });
   useWavesV2Mock.mockReturnValue({
     waves: [dmWave, mainWave],
@@ -240,16 +245,35 @@ test("combines main and pinned waves, filtering DMs and flagging pinned", () => 
   expect(waves.map((w: any) => w.id)).toEqual(["3", "2"]);
   expect(waves.every((w: any) => w.isPinned)).toBe(true);
   expect(result.current.pinnedWaves.map((w: any) => w.id)).toEqual(["3"]);
-  expect(useWavesV2Mock).toHaveBeenCalledWith(
-    expect.objectContaining({
-      overviewType: ApiWavesOverviewType.ScoredRecentlyDroppedTo,
-      pageSize: 20,
-      directMessage: false,
-      scoreSort: ApiWaveScoreSort.Balanced,
-      refetchInterval: SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
-      refetchIntervalInBackground: false,
-    })
+  const waveQueryArgs = useWavesV2Mock.mock.calls.map(([args]) => args);
+  expect(waveQueryArgs).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        overviewType: ApiWavesOverviewType.ScoredRecentlyDroppedTo,
+        pageSize: 20,
+        directMessage: false,
+        excludeFollowed: true,
+        scoreSort: ApiWaveScoreSort.Balanced,
+        enabled: true,
+        refetchInterval: SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
+        refetchIntervalInBackground: false,
+      }),
+      expect.objectContaining({
+        overviewType: ApiWavesOverviewType.RecentlyDroppedTo,
+        pageSize: 20,
+        following: true,
+        directMessage: false,
+        enabled: true,
+        refetchInterval: false,
+        refetchIntervalInBackground: false,
+      }),
+    ])
   );
+  expect(
+    waveQueryArgs.find(
+      (args) => args.overviewType === ApiWavesOverviewType.RecentlyDroppedTo
+    )
+  ).not.toHaveProperty("scoreSort");
   expect(useOfficialWavesMock).toHaveBeenCalledWith(
     expect.objectContaining({
       viewerIdentityKey: "0xabc:primary",
@@ -257,6 +281,77 @@ test("combines main and pinned waves, filtering DMs and flagging pinned", () => 
       refetchIntervalInBackground: false,
     })
   );
+});
+
+test("polls followed activity when the sidebar is in joined mode", () => {
+  useShowFollowingWavesMock.mockReturnValue([true]);
+
+  renderHook(() => useWavesList(), { wrapper });
+
+  const waveQueryArgs = useWavesV2Mock.mock.calls.map(([args]) => args);
+  expect(
+    waveQueryArgs.find(
+      (args) =>
+        args.overviewType === ApiWavesOverviewType.ScoredRecentlyDroppedTo
+    )
+  ).toMatchObject({
+    enabled: false,
+  });
+  expect(
+    waveQueryArgs.find(
+      (args) => args.overviewType === ApiWavesOverviewType.RecentlyDroppedTo
+    )
+  ).toMatchObject({
+    enabled: true,
+    refetchInterval: SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
+  });
+});
+
+test("puts followed activity before combined-score discovery rows", () => {
+  const followedOld = createSidebarWave({
+    id: "followed-old",
+    latestDropTimestamp: 10,
+    subscribed: true,
+  });
+  const followedNew = createSidebarWave({
+    id: "followed-new",
+    latestDropTimestamp: 500,
+    subscribed: true,
+  });
+  const scoreSuggestion = createSidebarWave({
+    id: "score-suggestion",
+    latestDropTimestamp: 999,
+  });
+
+  useWavesV2Mock.mockImplementation(({ overviewType }) => ({
+    waves:
+      overviewType === ApiWavesOverviewType.RecentlyDroppedTo
+        ? [followedOld, followedNew]
+        : [scoreSuggestion, followedOld],
+    isFetching: false,
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    fetchNextPage: jest.fn(),
+    status: "success",
+    refetch: jest.fn(),
+  }));
+  usePinnedWavesServerMock.mockReturnValue({
+    pinnedIds: [],
+    pinnedWaves: [],
+    pinWave: jest.fn(),
+    unpinWave: jest.fn(),
+    isLoading: false,
+    isError: false,
+    refetch: jest.fn(),
+  });
+
+  const { result } = renderHook(() => useWavesList(), { wrapper });
+
+  expect(result.current.waves.map((wave: any) => wave.id)).toEqual([
+    "followed-new",
+    "followed-old",
+    "score-suggestion",
+  ]);
 });
 
 test("preserves backend order for regular scored waves", () => {
@@ -269,15 +364,18 @@ test("preserves backend order for regular scored waves", () => {
     latestDropTimestamp: 999,
   });
 
-  useWavesV2Mock.mockReturnValue({
-    waves: [firstRegularWave, secondRegularWave],
+  useWavesV2Mock.mockImplementation(({ overviewType }) => ({
+    waves:
+      overviewType === ApiWavesOverviewType.RecentlyDroppedTo
+        ? []
+        : [firstRegularWave, secondRegularWave],
     isFetching: false,
     isFetchingNextPage: false,
     hasNextPage: false,
     fetchNextPage: jest.fn(),
     status: "success",
     refetch: jest.fn(),
-  });
+  }));
   usePinnedWavesServerMock.mockReturnValue({
     pinnedIds: [],
     pinnedWaves: [],

--- a/__tests__/utils/mockFactories.ts
+++ b/__tests__/utils/mockFactories.ts
@@ -22,6 +22,7 @@ export function createMockMinimalWave(
     picture: null,
     contributors: [],
     isPinned: false,
+    isFollowing: false,
     isOfficial: false,
     parentWaveId: null,
     hasSubwaves: false,

--- a/app/network/wave-score/page.tsx
+++ b/app/network/wave-score/page.tsx
@@ -2,10 +2,23 @@ import { getAppMetadata } from "@/components/providers/metadata";
 import { WaveScoreTransparencyPage } from "@/components/waves/discovery/WaveScoreTransparencyPage";
 import type { Metadata } from "next";
 
-export default function NetworkWaveScorePage() {
+interface NetworkWaveScorePageProps {
+  readonly searchParams?: Promise<{
+    readonly returnTo?: string | string[] | undefined;
+  }>;
+}
+
+export default async function NetworkWaveScorePage({
+  searchParams,
+}: NetworkWaveScorePageProps) {
+  const resolvedSearchParams = searchParams ? await searchParams : {};
+  const returnToParam = Array.isArray(resolvedSearchParams.returnTo)
+    ? resolvedSearchParams.returnTo[0]
+    : resolvedSearchParams.returnTo;
+
   return (
     <main className="tailwind-scope tw-min-h-screen tw-bg-black">
-      <WaveScoreTransparencyPage />
+      <WaveScoreTransparencyPage initialReturnTo={returnToParam ?? null} />
     </main>
   );
 }

--- a/components/brain/left-sidebar/waves/UnifiedWavesListWaves.tsx
+++ b/components/brain/left-sidebar/waves/UnifiedWavesListWaves.tsx
@@ -50,6 +50,14 @@ const emptyPlaceholderStyle = {
   minHeight: EMPTY_WAVES_PLACEHOLDER_HEIGHT,
 } as const satisfies React.CSSProperties;
 
+function SidebarCategoryLabel({ label }: { readonly label: string }) {
+  return (
+    <div className="tw-px-4 tw-pb-1 tw-pt-2 tw-text-[10px] tw-font-semibold tw-uppercase tw-tracking-wide tw-text-iron-500">
+      {label}
+    </div>
+  );
+}
+
 const isVisibleStaticRow = ({
   detailedLabel,
   row,
@@ -130,18 +138,23 @@ const UnifiedWavesListWaves = forwardRef<
       onParentExpand: streamWaves.loadSubwavesForParent,
     });
 
-    const { announcementWaves, officialWaves, pinnedWaves, regularWaves } =
-      useMemo(
-        () =>
-          groupSidebarWaves({
-            isAnnouncementsWave:
-              seizeSettings === null
-                ? undefined
-                : (waveId) => seizeSettings.isAnnouncementsWave(waveId),
-            waves: topLevelWaves,
-          }),
-        [topLevelWaves, seizeSettings]
-      );
+    const {
+      announcementWaves,
+      officialWaves,
+      pinnedWaves,
+      followingWaves,
+      scoreWaves,
+    } = useMemo(
+      () =>
+        groupSidebarWaves({
+          isAnnouncementsWave:
+            seizeSettings === null
+              ? undefined
+              : (waveId) => seizeSettings.isAnnouncementsWave(waveId),
+          waves: topLevelWaves,
+        }),
+      [topLevelWaves, seizeSettings]
+    );
 
     const announcementRows = useMemo(
       () => getRows(announcementWaves),
@@ -155,15 +168,25 @@ const UnifiedWavesListWaves = forwardRef<
       () => getRows(pinnedWaves),
       [pinnedWaves, getRows]
     );
-    const regularRows = useMemo(
-      () => getRows(regularWaves),
-      [regularWaves, getRows]
+    const followingRows = useMemo(
+      () => getRows(followingWaves),
+      [followingWaves, getRows]
     );
+    const scoreRows = useMemo(() => getRows(scoreWaves), [scoreWaves, getRows]);
     const animatedAnnouncementRows =
       useAnimatedSidebarWaveRows(announcementRows);
     const animatedOfficialRows = useAnimatedSidebarWaveRows(officialRows);
     const animatedPinnedRows = useAnimatedSidebarWaveRows(pinnedRows);
-    const animatedRegularRows = useAnimatedSidebarWaveRows(regularRows);
+    const animatedFollowingRows = useAnimatedSidebarWaveRows(followingRows);
+    const animatedScoreRows = useAnimatedSidebarWaveRows(scoreRows);
+    const virtualizedRows =
+      animatedScoreRows.length > 0 ? animatedScoreRows : animatedFollowingRows;
+    const staticFollowingRows =
+      animatedScoreRows.length > 0 ? animatedFollowingRows : [];
+    const virtualizedAriaLabel =
+      animatedScoreRows.length > 0
+        ? "Combined score waves list"
+        : "Following waves list";
     const getSidebarRowHeight = useCallback(
       (row: SidebarWaveTreeRow) =>
         row.depth === 1 ? SUBWAVE_ROW_HEIGHT : WAVE_ROW_HEIGHT,
@@ -171,8 +194,11 @@ const UnifiedWavesListWaves = forwardRef<
     );
 
     const virtual = useVirtualizedWaves<SidebarWaveTreeRow>({
-      items: animatedRegularRows,
-      key: "unified-waves-regular",
+      items: virtualizedRows,
+      key:
+        animatedScoreRows.length > 0
+          ? "unified-waves-score"
+          : "unified-waves-following",
       scrollContainerRef,
       listContainerRef,
       rowHeight: getSidebarRowHeight,
@@ -234,7 +260,8 @@ const UnifiedWavesListWaves = forwardRef<
           announcementRows.length > 0 &&
           (officialRows.length > 0 ||
             pinnedRows.length > 0 ||
-            regularRows.length > 0) && (
+            followingRows.length > 0 ||
+            scoreRows.length > 0) && (
             <div className="tw-my-3 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700" />
           )}
 
@@ -257,45 +284,80 @@ const UnifiedWavesListWaves = forwardRef<
 
         {!hideHeaders &&
           officialRows.length > 0 &&
-          (pinnedRows.length > 0 || regularRows.length > 0) && (
+          (pinnedRows.length > 0 ||
+            followingRows.length > 0 ||
+            scoreRows.length > 0) && (
             <div className="tw-my-3 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700" />
           )}
 
         {/* Conditionally show pinned section */}
         {!hideHeaders && pinnedRows.length > 0 && (
-          <SidebarWaveRowsSection
-            ariaLabel="Pinned waves"
-            className="tw-flex tw-flex-col"
-            getRowHeight={getSidebarRowHeight}
-            isRowVisible={(row) =>
-              isVisibleStaticRow({
-                detailedLabel: "Pinned",
-                row,
-                sectionName: "pinned",
-              })
-            }
-            renderRow={(row) => renderWaveRow(row, !hidePin)}
-            rows={animatedPinnedRows}
-          />
+          <>
+            <SidebarCategoryLabel label="Pinned" />
+            <SidebarWaveRowsSection
+              ariaLabel="Pinned waves"
+              className="tw-flex tw-flex-col"
+              getRowHeight={getSidebarRowHeight}
+              isRowVisible={(row) =>
+                isVisibleStaticRow({
+                  detailedLabel: "Pinned",
+                  row,
+                  sectionName: "pinned",
+                })
+              }
+              renderRow={(row) => renderWaveRow(row, !hidePin)}
+              rows={animatedPinnedRows}
+            />
+          </>
         )}
 
-        {/* Add divider between pinned and regular waves */}
-        {!hideHeaders && pinnedRows.length > 0 && regularRows.length > 0 && (
-          <div className="tw-my-3 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700" />
+        {!hideHeaders &&
+          pinnedRows.length > 0 &&
+          (followingRows.length > 0 || scoreRows.length > 0) && (
+            <div className="tw-my-3 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700" />
+          )}
+
+        {staticFollowingRows.length > 0 && (
+          <>
+            {!hideHeaders && <SidebarCategoryLabel label="Following" />}
+            <SidebarWaveRowsSection
+              ariaLabel="Following waves"
+              className="tw-flex tw-flex-col"
+              getRowHeight={getSidebarRowHeight}
+              isRowVisible={(row) =>
+                isVisibleStaticRow({
+                  detailedLabel: "Following",
+                  row,
+                  sectionName: "following",
+                })
+              }
+              renderRow={(row) => renderWaveRow(row, !hidePin)}
+              rows={staticFollowingRows}
+            />
+          </>
         )}
 
-        {/* Conditionally show regular waves or maintain structure */}
-        {animatedRegularRows.length > 0 ? (
+        {!hideHeaders &&
+          staticFollowingRows.length > 0 &&
+          animatedScoreRows.length > 0 && (
+            <div className="tw-my-3 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700" />
+          )}
+
+        {!hideHeaders && animatedScoreRows.length > 0 && (
+          <SidebarCategoryLabel label="Combined Score" />
+        )}
+
+        {virtualizedRows.length > 0 ? (
           <section
             ref={listContainerRef}
             style={{
               height: virtual.totalHeight,
               ...listContainerStyle,
             }}
-            aria-label="Regular waves list"
+            aria-label={virtualizedAriaLabel}
           >
             {virtual.virtualItems.map((v: VirtualItem) => {
-              if (v.index === animatedRegularRows.length) {
+              if (v.index === virtualizedRows.length) {
                 return (
                   <div
                     key="sentinel"
@@ -308,7 +370,7 @@ const UnifiedWavesListWaves = forwardRef<
                   />
                 );
               }
-              const row = animatedRegularRows[v.index];
+              const row = virtualizedRows[v.index];
               if (!row || !isValidSidebarWave(row.wave)) {
                 console.warn(
                   "Invalid wave object at index",

--- a/components/brain/left-sidebar/waves/sidebarWaveListUtils.ts
+++ b/components/brain/left-sidebar/waves/sidebarWaveListUtils.ts
@@ -4,7 +4,8 @@ export interface SidebarWaveGroups {
   readonly announcementWaves: MinimalWave[];
   readonly officialWaves: MinimalWave[];
   readonly pinnedWaves: MinimalWave[];
-  readonly regularWaves: MinimalWave[];
+  readonly followingWaves: MinimalWave[];
+  readonly scoreWaves: MinimalWave[];
 }
 
 export const isValidSidebarWave = (wave: unknown): wave is MinimalWave => {
@@ -17,7 +18,8 @@ export const isValidSidebarWave = (wave: unknown): wave is MinimalWave => {
     typeof w.id === "string" &&
     w.id.length > 0 &&
     typeof w.name === "string" &&
-    typeof w.isPinned === "boolean"
+    typeof w.isPinned === "boolean" &&
+    typeof w.isFollowing === "boolean"
   );
 };
 
@@ -62,7 +64,8 @@ export const groupSidebarWaves = ({
   const announcementWaves: MinimalWave[] = [];
   const officialWaves: MinimalWave[] = [];
   const pinnedWaves: MinimalWave[] = [];
-  const regularWaves: MinimalWave[] = [];
+  const followingWaves: MinimalWave[] = [];
+  const scoreWaves: MinimalWave[] = [];
 
   for (const wave of waves) {
     if (isAnnouncementsWave?.(wave.id) === true) {
@@ -71,8 +74,10 @@ export const groupSidebarWaves = ({
       officialWaves.push(wave);
     } else if (wave.isPinned) {
       pinnedWaves.push(wave);
+    } else if (wave.isFollowing) {
+      followingWaves.push(wave);
     } else {
-      regularWaves.push(wave);
+      scoreWaves.push(wave);
     }
   }
 
@@ -80,6 +85,7 @@ export const groupSidebarWaves = ({
     announcementWaves,
     officialWaves,
     pinnedWaves,
-    regularWaves,
+    followingWaves,
+    scoreWaves,
   };
 };

--- a/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.tsx
+++ b/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.tsx
@@ -68,6 +68,14 @@ function MasonryGridIcon() {
   );
 }
 
+function SidebarCategoryLabel({ label }: { readonly label: string }) {
+  return (
+    <div className="tw-px-5 tw-pb-1 tw-pt-2 tw-text-[10px] tw-font-semibold tw-uppercase tw-tracking-wide tw-text-iron-500">
+      {label}
+    </div>
+  );
+}
+
 interface WebUnifiedWavesListWavesProps {
   readonly waves: MinimalWave[];
   readonly onHover: (waveId: string) => void;
@@ -289,18 +297,23 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
   const showCreateWaveButton = !isApp && !!connectedProfile;
   const shouldShowProfileFeedShortcut = !hideHeaders && showProfileFeedShortcut;
 
-  const { announcementWaves, officialWaves, pinnedWaves, regularWaves } =
-    useMemo(
-      () =>
-        groupSidebarWaves({
-          isAnnouncementsWave:
-            seizeSettings === null
-              ? undefined
-              : (waveId) => seizeSettings.isAnnouncementsWave(waveId),
-          waves: topLevelWaves,
-        }),
-      [topLevelWaves, seizeSettings]
-    );
+  const {
+    announcementWaves,
+    officialWaves,
+    pinnedWaves,
+    followingWaves,
+    scoreWaves,
+  } = useMemo(
+    () =>
+      groupSidebarWaves({
+        isAnnouncementsWave:
+          seizeSettings === null
+            ? undefined
+            : (waveId) => seizeSettings.isAnnouncementsWave(waveId),
+        waves: topLevelWaves,
+      }),
+    [topLevelWaves, seizeSettings]
+  );
 
   const announcementRows = useMemo(
     () => getRows(announcementWaves),
@@ -314,10 +327,11 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
     () => getRows(pinnedWaves),
     [pinnedWaves, getRows]
   );
-  const regularRows = useMemo(
-    () => getRows(regularWaves),
-    [regularWaves, getRows]
+  const followingRows = useMemo(
+    () => getRows(followingWaves),
+    [followingWaves, getRows]
   );
+  const scoreRows = useMemo(() => getRows(scoreWaves), [scoreWaves, getRows]);
   const rowAnimationOptions = useMemo(
     () => ({ keepExitingRows: !isCollapsed }),
     [isCollapsed]
@@ -334,14 +348,26 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
     pinnedRows,
     rowAnimationOptions
   );
-  const animatedRegularRows = useAnimatedSidebarWaveRows(
-    regularRows,
+  const animatedFollowingRows = useAnimatedSidebarWaveRows(
+    followingRows,
+    rowAnimationOptions
+  );
+  const animatedScoreRows = useAnimatedSidebarWaveRows(
+    scoreRows,
     rowAnimationOptions
   );
   const hasAnnouncementRows = animatedAnnouncementRows.length > 0;
   const hasOfficialRows = animatedOfficialRows.length > 0;
   const hasPinnedRows = animatedPinnedRows.length > 0;
-  const hasRegularRows = animatedRegularRows.length > 0;
+  const hasFollowingRows = animatedFollowingRows.length > 0;
+  const hasScoreRows = animatedScoreRows.length > 0;
+  const virtualizedRows = hasScoreRows
+    ? animatedScoreRows
+    : animatedFollowingRows;
+  const staticFollowingRows = hasScoreRows ? animatedFollowingRows : [];
+  const virtualizedAriaLabel = hasScoreRows
+    ? "Combined score waves list"
+    : "Following waves list";
   const headerPaddingClassName = "tw-px-4";
   const filterPaddingClassName = "tw-px-4";
   const sectionClassName = isCollapsed
@@ -358,8 +384,10 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
   );
 
   const virtual = useVirtualizedWaves<SidebarWaveTreeRow>({
-    items: animatedRegularRows,
-    key: "web-unified-waves-regular",
+    items: virtualizedRows,
+    key: hasScoreRows
+      ? "web-unified-waves-score"
+      : "web-unified-waves-following",
     scrollContainerRef: scrollContainerRef ?? listContainerRef,
     listContainerRef,
     rowHeight: getSidebarRowHeight,
@@ -427,7 +455,10 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
           )}
           {hasAnnouncementRows &&
             !hideHeaders &&
-            (hasOfficialRows || hasPinnedRows || hasRegularRows) && (
+            (hasOfficialRows ||
+              hasPinnedRows ||
+              hasFollowingRows ||
+              hasScoreRows) && (
               <div className="tw-my-2 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700" />
             )}
           {hasOfficialRows && (
@@ -445,36 +476,69 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
           )}
           {hasOfficialRows &&
             !hideHeaders &&
-            (hasPinnedRows || hasRegularRows) && (
+            (hasPinnedRows || hasFollowingRows || hasScoreRows) && (
               <div className="tw-my-2 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700" />
             )}
           {!hideHeaders && hasPinnedRows && (
-            <SidebarWaveRowsSection
-              ariaLabel="Pinned waves"
-              className={sectionClassName}
-              getRowHeight={getSidebarRowHeight}
-              isRowVisible={(row) =>
-                isVisibleSectionRow({ row, sectionName: "pinned" })
-              }
-              renderRow={(row) => renderWaveRow(row, !hidePin && !isCollapsed)}
-              rows={animatedPinnedRows}
-              transitionClassName="tw-w-full"
-            />
+            <>
+              {!isCollapsed && <SidebarCategoryLabel label="Pinned" />}
+              <SidebarWaveRowsSection
+                ariaLabel="Pinned waves"
+                className={sectionClassName}
+                getRowHeight={getSidebarRowHeight}
+                isRowVisible={(row) =>
+                  isVisibleSectionRow({ row, sectionName: "pinned" })
+                }
+                renderRow={(row) =>
+                  renderWaveRow(row, !hidePin && !isCollapsed)
+                }
+                rows={animatedPinnedRows}
+                transitionClassName="tw-w-full"
+              />
+            </>
           )}
-          {!hideHeaders && hasPinnedRows && hasRegularRows && (
+          {!hideHeaders &&
+            hasPinnedRows &&
+            (hasFollowingRows || hasScoreRows) && (
+              <div className="tw-my-2 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700" />
+            )}
+          {staticFollowingRows.length > 0 && (
+            <>
+              {!hideHeaders && !isCollapsed && (
+                <SidebarCategoryLabel label="Following" />
+              )}
+              <SidebarWaveRowsSection
+                ariaLabel="Following waves"
+                className={sectionClassName}
+                getRowHeight={getSidebarRowHeight}
+                isRowVisible={(row) =>
+                  isVisibleSectionRow({ row, sectionName: "following" })
+                }
+                renderRow={(row) =>
+                  renderWaveRow(row, !hidePin && !isCollapsed)
+                }
+                rows={staticFollowingRows}
+                transitionClassName="tw-w-full"
+              />
+            </>
+          )}
+          {!hideHeaders && staticFollowingRows.length > 0 && hasScoreRows && (
             <div className="tw-my-2 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700" />
           )}
-          {hasRegularRows ? (
+          {!hideHeaders && !isCollapsed && hasScoreRows && (
+            <SidebarCategoryLabel label="Combined Score" />
+          )}
+          {virtualizedRows.length > 0 ? (
             <section
               ref={listContainerRef}
               style={{
                 height: virtual.totalHeight,
                 position: "relative",
               }}
-              aria-label="Regular waves list"
+              aria-label={virtualizedAriaLabel}
             >
               {virtual.virtualItems.map((v: VirtualItem) => {
-                if (v.index === animatedRegularRows.length) {
+                if (v.index === virtualizedRows.length) {
                   return (
                     <div
                       key="sentinel"
@@ -488,7 +552,7 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
                     />
                   );
                 }
-                const row = animatedRegularRows[v.index];
+                const row = virtualizedRows[v.index];
                 if (!row || !isValidSidebarWave(row.wave)) {
                   console.warn(
                     "Invalid wave object at index",

--- a/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
+++ b/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
@@ -74,6 +74,20 @@ interface MyStreamWaveHeaderIdentityProps {
   readonly showDescriptionPreview: boolean;
   readonly wave: ApiWave;
   readonly wavePictureContributors: WavePictureContributors;
+  readonly waveScoreLearnMoreHref: string;
+}
+
+function getWaveScoreLearnMoreHref({
+  pathname,
+  searchParams,
+}: {
+  readonly pathname: string;
+  readonly searchParams: { toString: () => string };
+}): string {
+  const currentQuery = searchParams.toString();
+  const returnTo = currentQuery ? `${pathname}?${currentQuery}` : pathname;
+  const params = new URLSearchParams({ returnTo });
+  return `${WAVE_SCORE_LEARN_MORE_HREF}?${params.toString()}`;
 }
 
 function MyStreamWaveHeaderIdentity({
@@ -85,6 +99,7 @@ function MyStreamWaveHeaderIdentity({
   showDescriptionPreview,
   wave,
   wavePictureContributors,
+  waveScoreLearnMoreHref,
 }: MyStreamWaveHeaderIdentityProps) {
   if (directMessageProfileHref) {
     return (
@@ -166,7 +181,7 @@ function MyStreamWaveHeaderIdentity({
                 variant="header-inline"
                 mode="summary"
                 className="tw-mt-1 tw-self-start"
-                learnMoreHref={WAVE_SCORE_LEARN_MORE_HREF}
+                learnMoreHref={waveScoreLearnMoreHref}
               />
             )}
             {isCompact && (
@@ -176,7 +191,7 @@ function MyStreamWaveHeaderIdentity({
                 variant="header-inline"
                 mode="summary"
                 className="tw-mt-1"
-                learnMoreHref={WAVE_SCORE_LEARN_MORE_HREF}
+                learnMoreHref={waveScoreLearnMoreHref}
               />
             )}
           </>
@@ -191,7 +206,7 @@ function MyStreamWaveHeaderIdentity({
               variant="header-inline"
               mode="summary"
               className="tw-mt-1"
-              learnMoreHref={WAVE_SCORE_LEARN_MORE_HREF}
+              learnMoreHref={waveScoreLearnMoreHref}
             />
           </>
         )}
@@ -218,6 +233,10 @@ export default function MyStreamWaveTabsHeader({
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
+  const waveScoreLearnMoreHref = getWaveScoreLearnMoreHref({
+    pathname,
+    searchParams,
+  });
   const { isApp } = useDeviceInfo();
   const { connectedProfile, activeProfileProxy } = useAuth();
   const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -411,6 +430,7 @@ export default function MyStreamWaveTabsHeader({
             showDescriptionPreview={showDescriptionPreview}
             wave={wave}
             wavePictureContributors={wavePictureContributors}
+            waveScoreLearnMoreHref={waveScoreLearnMoreHref}
           />
         </div>
         <div className={actionsClassName}>

--- a/components/home/explore-waves/ExploreWavesSection.tsx
+++ b/components/home/explore-waves/ExploreWavesSection.tsx
@@ -4,7 +4,10 @@ import { useAuth } from "@/components/auth/Auth";
 import { WAVE_SCORE_DISCOVERY_PARAMS } from "@/components/react-query-wrapper/utils/query-utils";
 import type { ApiWaveScoreSort } from "@/generated/models/ApiWaveScoreSort";
 import type { ApiWaveVisibilityTier } from "@/generated/models/ApiWaveVisibilityTier";
-import type { ApiWavesOverviewType } from "@/generated/models/ApiWavesOverviewType";
+import {
+  ApiWavesOverviewType,
+  type ApiWavesOverviewType as ApiWavesOverviewTypeValue,
+} from "@/generated/models/ApiWavesOverviewType";
 import { ApiWavesV2ListType } from "@/generated/models/ApiWavesV2ListType";
 import { fetchWavesV2Page } from "@/services/api/waves-v2-api";
 import { ArrowRightIcon } from "@heroicons/react/24/outline";
@@ -23,7 +26,8 @@ interface ExploreWavesSectionProps {
   readonly viewAllHref?: string | null | undefined;
   readonly excludeFollowed?: boolean | undefined;
   readonly view?: ApiWavesV2ListType | undefined;
-  readonly overviewType?: ApiWavesOverviewType | undefined;
+  readonly overviewType?: ApiWavesOverviewTypeValue | undefined;
+  readonly directMessage?: boolean | undefined;
   readonly scoreSort?: ApiWaveScoreSort | undefined;
   readonly minVisibilityScore?: number | undefined;
   readonly minQualityScore?: number | undefined;
@@ -44,7 +48,8 @@ export function ExploreWavesSection({
   excludeFollowed = false,
   view = ApiWavesV2ListType.Overview,
   overviewType = WAVE_SCORE_DISCOVERY_PARAMS.overviewType,
-  scoreSort = WAVE_SCORE_DISCOVERY_PARAMS.scoreSort,
+  directMessage,
+  scoreSort,
   minVisibilityScore,
   minQualityScore,
   minHotnessScore,
@@ -62,6 +67,16 @@ export function ExploreWavesSection({
     connectedProfile?.handle ??
     null;
   const effectiveExcludeFollowed = excludeFollowed && userScope !== null;
+  const shouldDefaultScoreSort =
+    view === ApiWavesV2ListType.Overview &&
+    overviewType === ApiWavesOverviewType.ScoredRecentlyDroppedTo;
+  const effectiveScoreSort =
+    scoreSort ??
+    (shouldDefaultScoreSort
+      ? WAVE_SCORE_DISCOVERY_PARAMS.scoreSort
+      : undefined);
+  const shouldServerExcludeFollowed =
+    effectiveExcludeFollowed && view !== ApiWavesV2ListType.Search;
 
   const {
     data: waves,
@@ -72,7 +87,8 @@ export function ExploreWavesSection({
       "explore-waves",
       view,
       overviewType,
-      scoreSort,
+      directMessage,
+      effectiveScoreSort,
       minVisibilityScore,
       minQualityScore,
       minHotnessScore,
@@ -88,8 +104,9 @@ export function ExploreWavesSection({
         overviewType,
         page: 1,
         pageSize: limit,
-        excludeFollowed: effectiveExcludeFollowed ? true : undefined,
-        scoreSort,
+        directMessage,
+        excludeFollowed: shouldServerExcludeFollowed ? true : undefined,
+        scoreSort: effectiveScoreSort,
         minVisibilityScore,
         minQualityScore,
         minHotnessScore,

--- a/components/react-query-wrapper/utils/query-utils.ts
+++ b/components/react-query-wrapper/utils/query-utils.ts
@@ -9,8 +9,7 @@ export const WAVE_SCORE_DISCOVERY_PARAMS = {
 
 export const WAVE_FOLLOWING_WAVES_PARAMS = {
   limit: 20,
-  initialWavesOverviewType: WAVE_SCORE_DISCOVERY_PARAMS.overviewType,
-  scoreSort: WAVE_SCORE_DISCOVERY_PARAMS.scoreSort,
+  initialWavesOverviewType: ApiWavesOverviewType.RecentlyDroppedTo,
   only_waves_followed_by_authenticated_user: true,
 };
 

--- a/components/waves/WaveTrustSignals.tsx
+++ b/components/waves/WaveTrustSignals.tsx
@@ -23,6 +23,7 @@ interface WaveTrustSignalsProps {
   readonly className?: string | undefined;
   readonly tooltipId?: string | undefined;
   readonly learnMoreHref?: string | undefined;
+  readonly showHeaderRepChip?: boolean | undefined;
 }
 
 const compactNumberFormatter = new Intl.NumberFormat(undefined, {
@@ -109,9 +110,9 @@ const VISIBILITY_TONE_CLASSES: Record<
   Record<VisibilityTone, string>
 > = {
   "inline-sidebar": {
-    excellent: "tw-text-emerald-300 desktop-hover:hover:tw-text-emerald-200",
-    healthy: "tw-text-amber-300 desktop-hover:hover:tw-text-amber-200",
-    low: "tw-text-rose-300 desktop-hover:hover:tw-text-rose-200",
+    excellent: INLINE_STAT_TONE_CLASSES,
+    healthy: INLINE_STAT_TONE_CLASSES,
+    low: INLINE_STAT_TONE_CLASSES,
     default: INLINE_STAT_TONE_CLASSES,
   },
   "inline-header": {
@@ -215,7 +216,8 @@ const getContainerClasses = (
 ) => {
   let baseClasses = "tw-flex tw-flex-wrap tw-items-center tw-gap-1.5";
   if (mode === "summary") {
-    baseClasses = "tw-flex tw-min-w-0 tw-flex-nowrap tw-items-center tw-gap-1.5";
+    baseClasses =
+      "tw-flex tw-min-w-0 tw-flex-nowrap tw-items-center tw-gap-1.5";
   }
 
   if (isInlineSidebarVariant(variant)) {
@@ -257,8 +259,10 @@ const getChipClasses = (
   let summaryClasses = "";
   if (mode === "summary") {
     summaryClasses = "tw-shrink-0 tw-justify-center";
-    if (variant === "sidebar" || isInlineSidebarVariant(variant)) {
+    if (variant === "sidebar") {
       summaryClasses = `${summaryClasses} tw-w-[4.75rem]`;
+    } else if (isInlineSidebarVariant(variant)) {
+      summaryClasses = `${summaryClasses} tw-min-w-[2.35rem]`;
     }
   }
 
@@ -405,7 +409,7 @@ const buildSummaryDetails = ({
 
   return [
     `Combined score: ${visibilityScore}`,
-    "A quick signal for which waves deserve broad attention",
+    "Discovery signal for evaluating new waves",
     ...(qualityScore === null
       ? []
       : [`Quality: ${qualityScore} (65% of visibility)`]),
@@ -455,9 +459,11 @@ const buildRepDetails = ({
 function WaveScoreSummaryTooltip({
   details,
   id,
+  learnMoreHref,
 }: {
   readonly details: readonly string[];
   readonly id: string;
+  readonly learnMoreHref: string;
 }) {
   const [primaryDetail, ...secondaryDetails] = details;
 
@@ -465,7 +471,7 @@ function WaveScoreSummaryTooltip({
     <span
       id={id}
       role="tooltip"
-      className="tw-pointer-events-none tw-absolute tw-left-0 tw-top-full tw-z-[10000] tw-mt-2 tw-hidden tw-w-72 tw-rounded-lg tw-bg-iron-950 tw-p-3 tw-text-left tw-text-xs tw-font-normal tw-leading-5 tw-text-iron-200 tw-shadow-2xl tw-ring-1 tw-ring-white/10 group-hover:tw-block group-focus-within:tw-block"
+      className="tw-pointer-events-auto tw-absolute tw-left-0 tw-top-full tw-z-[10000] tw-mt-2 tw-hidden tw-w-72 tw-rounded-lg tw-bg-iron-950 tw-p-3 tw-text-left tw-text-xs tw-font-normal tw-leading-5 tw-text-iron-200 tw-shadow-2xl tw-ring-1 tw-ring-white/10 group-focus-within:tw-block group-hover:tw-block"
     >
       {primaryDetail && (
         <span className="tw-block tw-text-sm tw-font-semibold tw-text-white">
@@ -479,9 +485,12 @@ function WaveScoreSummaryTooltip({
           </span>
         ))}
       </span>
-      <span className="tw-mt-3 tw-block tw-text-xs tw-font-semibold tw-text-primary-300">
-        Click score to open the full formula
-      </span>
+      <Link
+        href={learnMoreHref}
+        className="desktop-hover:hover:tw-text-primary-200 tw-mt-3 tw-inline-flex tw-items-center tw-rounded-md tw-text-xs tw-font-semibold tw-text-primary-300 tw-no-underline tw-transition focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
+      >
+        Open full formula
+      </Link>
     </span>
   );
 }
@@ -510,6 +519,7 @@ export function WaveTrustSignals({
   className,
   tooltipId,
   learnMoreHref,
+  showHeaderRepChip = true,
 }: WaveTrustSignalsProps) {
   const generatedTooltipId = useId();
   const visibilityScore = formatScore(waveScore?.visibility_score);
@@ -572,15 +582,21 @@ export function WaveTrustSignals({
     const summaryLabel = summaryDetails.join(". ");
     const summaryTitle = hasNativeTitle ? summaryDetails.join("\n") : undefined;
     const summaryTooltip = summaryDetails.join(" | ");
-    const summaryChipClasses = `${getChipClasses(
+    const summaryChipClasses = getChipClasses(
       variant,
       mode,
       getVisibilityToneClasses(variant, waveScore?.visibility_score)
-    )} ${
-      hasRichTooltip
-        ? "tw-group tw-relative tw-isolate tw-overflow-visible tw-no-underline desktop-hover:hover:tw-z-[10000] focus:tw-z-[10000] focus-visible:tw-z-[10000]"
-        : ""
-    }`;
+    );
+    const richTooltipWrapperClasses =
+      "tw-group tw-relative tw-isolate tw-inline-flex tw-overflow-visible tw-align-middle desktop-hover:hover:tw-z-[10000] focus-within:tw-z-[10000]";
+    const summaryButtonResetClasses = isInlineHeaderVariant(variant)
+      ? "tw-bg-transparent"
+      : "";
+    const showSummaryLabel = !isInlineSidebarVariant(variant);
+    const showHeaderRepSummary =
+      showHeaderRepChip && isInlineHeaderVariant(variant) && hasRepScore;
+    const headerRepDetails = buildRepDetails({ repSortScore, waveRep });
+    const headerRepTitle = headerRepDetails.join("\n");
     const summaryChipContent = (
       <>
         <ShieldCheckIcon
@@ -588,11 +604,10 @@ export function WaveTrustSignals({
           strokeWidth={isInlineVariant(variant) ? 1.5 : undefined}
           aria-hidden="true"
         />
-        <span className={getChipLabelClasses(variant)}>Score</span>
-        <span className={getValueClasses(variant)}>{visibilityScore}</span>
-        {hasRichTooltip && (
-          <WaveScoreSummaryTooltip id={richTooltipId} details={summaryDetails} />
+        {showSummaryLabel && (
+          <span className={getChipLabelClasses(variant)}>Score</span>
         )}
+        <span className={getValueClasses(variant)}>{visibilityScore}</span>
       </>
     );
     const inlineSidebarTooltipAttributes = shouldUseInlineSidebarTooltip
@@ -605,14 +620,21 @@ export function WaveTrustSignals({
       children: (
         <>
           {hasRichTooltip ? (
-            <Link
-              href={learnMoreHref}
-              className={summaryChipClasses}
-              aria-label={summaryLabel}
-              aria-describedby={richTooltipId}
-            >
-              {summaryChipContent}
-            </Link>
+            <span className={richTooltipWrapperClasses}>
+              <button
+                type="button"
+                className={`${summaryChipClasses} tw-border-0 tw-font-[inherit] ${summaryButtonResetClasses}`}
+                aria-label={summaryLabel}
+                aria-describedby={richTooltipId}
+              >
+                {summaryChipContent}
+              </button>
+              <WaveScoreSummaryTooltip
+                id={richTooltipId}
+                details={summaryDetails}
+                learnMoreHref={learnMoreHref}
+              />
+            </span>
           ) : (
             <span
               className={summaryChipClasses}
@@ -621,6 +643,25 @@ export function WaveTrustSignals({
               {...inlineSidebarTooltipAttributes}
             >
               {summaryChipContent}
+            </span>
+          )}
+          {showHeaderRepSummary && (
+            <span
+              className={getChipClasses(
+                variant,
+                mode,
+                getRepToneClasses(repToneValue, variant)
+              )}
+              aria-label={repLabel ?? undefined}
+              title={headerRepTitle}
+            >
+              <ScaleIcon
+                className={getIconClasses(variant)}
+                strokeWidth={isInlineVariant(variant) ? 1.5 : undefined}
+                aria-hidden="true"
+              />
+              <span className={getChipLabelClasses(variant)}>REP</span>
+              <span className={getValueClasses(variant)}>{repScore}</span>
             </span>
           )}
         </>

--- a/components/waves/discovery/DiscoverWaveExplorer.tsx
+++ b/components/waves/discovery/DiscoverWaveExplorer.tsx
@@ -3,8 +3,12 @@
 import { WAVE_SCORE_DISCOVERY_PARAMS } from "@/components/react-query-wrapper/utils/query-utils";
 import { ExploreWavesSection } from "@/components/home/explore-waves/ExploreWavesSection";
 import { ApiWaveScoreSort } from "@/generated/models/ApiWaveScoreSort";
+import { ApiWavesOverviewType } from "@/generated/models/ApiWavesOverviewType";
+import { ApiWavesV2ListType } from "@/generated/models/ApiWavesV2ListType";
 import {
+  CalendarDaysIcon,
   CalculatorIcon,
+  ClockIcon,
   FireIcon,
   ScaleIcon,
   ShieldCheckIcon,
@@ -16,6 +20,8 @@ import type { KeyboardEvent } from "react";
 import { useCallback, useMemo } from "react";
 
 type DiscoverScoreFilter = "ALL" | "SCORE_50" | "HOT_60" | "REP_60";
+type DiscoverChronologySort = "NEWEST" | "LATEST_POSTS";
+type DiscoverSort = ApiWaveScoreSort | DiscoverChronologySort;
 
 interface DiscoverFilterScores {
   readonly minVisibilityScore?: number | undefined;
@@ -25,7 +31,7 @@ interface DiscoverFilterScores {
 }
 
 interface DiscoverSortOption {
-  readonly value: ApiWaveScoreSort;
+  readonly value: DiscoverSort;
   readonly label: string;
 }
 
@@ -42,6 +48,8 @@ const SORT_OPTIONS: readonly DiscoverSortOption[] = [
   { value: ApiWaveScoreSort.Quality, label: "Quality" },
   { value: ApiWaveScoreSort.Hotness, label: "Hot" },
   { value: ApiWaveScoreSort.Rep, label: "REP" },
+  { value: "NEWEST", label: "Newest" },
+  { value: "LATEST_POSTS", label: "Latest Posts" },
 ];
 
 const FILTER_OPTIONS: readonly DiscoverFilterOption[] = [
@@ -51,12 +59,14 @@ const FILTER_OPTIONS: readonly DiscoverFilterOption[] = [
   { value: "REP_60", label: "REP 60+" },
 ];
 
-const parseSort = (value: string | null): ApiWaveScoreSort => {
+const parseSort = (value: string | null): DiscoverSort => {
   switch (value) {
     case ApiWaveScoreSort.Balanced:
     case ApiWaveScoreSort.Quality:
     case ApiWaveScoreSort.Hotness:
     case ApiWaveScoreSort.Rep:
+    case "NEWEST":
+    case "LATEST_POSTS":
       return value;
     default:
       return WAVE_SCORE_DISCOVERY_PARAMS.scoreSort;
@@ -85,6 +95,23 @@ const getFilterScores = (filter: DiscoverScoreFilter): DiscoverFilterScores => {
     case "ALL":
     default:
       return {};
+  }
+};
+
+const isScoreSort = (sort: DiscoverSort): sort is ApiWaveScoreSort => {
+  switch (sort) {
+    case ApiWaveScoreSort.Balanced:
+    case ApiWaveScoreSort.Quality:
+    case ApiWaveScoreSort.Hotness:
+    case ApiWaveScoreSort.Rep:
+      return true;
+    case "NEWEST":
+    case "LATEST_POSTS":
+      return false;
+    default: {
+      const exhaustiveSort: never = sort;
+      return exhaustiveSort;
+    }
   }
 };
 
@@ -154,7 +181,7 @@ function onRadioKeyDown<T extends string>({
   requestAnimationFrame(() => focusRadioByValue(radioGroup, nextValue));
 }
 
-function ScoreSortIcon({ sort }: { readonly sort: ApiWaveScoreSort }) {
+function ScoreSortIcon({ sort }: { readonly sort: DiscoverSort }) {
   switch (sort) {
     case ApiWaveScoreSort.Hotness:
       return <FireIcon className="tw-size-4" aria-hidden="true" />;
@@ -164,6 +191,10 @@ function ScoreSortIcon({ sort }: { readonly sort: ApiWaveScoreSort }) {
       return <ShieldCheckIcon className="tw-size-4" aria-hidden="true" />;
     case ApiWaveScoreSort.Balanced:
       return <Squares2X2Icon className="tw-size-4" aria-hidden="true" />;
+    case "NEWEST":
+      return <CalendarDaysIcon className="tw-size-4" aria-hidden="true" />;
+    case "LATEST_POSTS":
+      return <ClockIcon className="tw-size-4" aria-hidden="true" />;
   }
 }
 
@@ -174,10 +205,12 @@ function DiscoverWaveControls({
   onSortChange,
 }: {
   readonly activeFilter: DiscoverScoreFilter;
-  readonly activeSort: ApiWaveScoreSort;
+  readonly activeSort: DiscoverSort;
   readonly onFilterChange: (filter: DiscoverScoreFilter) => void;
-  readonly onSortChange: (sort: ApiWaveScoreSort) => void;
+  readonly onSortChange: (sort: DiscoverSort) => void;
 }) {
+  const scoreFiltersEnabled = isScoreSort(activeSort);
+
   return (
     <div className="tw-flex tw-w-full tw-flex-col tw-gap-3 md:tw-w-auto md:tw-items-end">
       <Link
@@ -189,8 +222,8 @@ function DiscoverWaveControls({
       </Link>
       <div
         role="radiogroup"
-        className="tw-grid tw-w-full tw-grid-cols-4 tw-gap-1 tw-rounded-lg tw-bg-iron-950 tw-p-1 tw-ring-1 tw-ring-inset tw-ring-white/10 md:tw-w-auto"
-        aria-label="Wave score sort"
+        className="tw-grid tw-w-full tw-grid-cols-2 tw-gap-1 tw-rounded-lg tw-bg-iron-950 tw-p-1 tw-ring-1 tw-ring-inset tw-ring-white/10 sm:tw-grid-cols-3 md:tw-w-auto xl:tw-grid-cols-6"
+        aria-label="Wave discovery sort"
       >
         {SORT_OPTIONS.map((option) => {
           const selected = activeSort === option.value;
@@ -225,8 +258,11 @@ function DiscoverWaveControls({
       </div>
       <div
         role="radiogroup"
-        className="tw-flex tw-w-full tw-flex-wrap tw-gap-1.5 md:tw-justify-end"
+        className={`tw-flex tw-w-full tw-flex-wrap tw-gap-1.5 tw-transition-opacity md:tw-justify-end ${
+          scoreFiltersEnabled ? "tw-opacity-100" : "tw-opacity-55"
+        }`}
         aria-label="Wave score filters"
+        aria-disabled={!scoreFiltersEnabled}
       >
         {FILTER_OPTIONS.map((option) => {
           const selected = activeFilter === option.value;
@@ -236,7 +272,8 @@ function DiscoverWaveControls({
               type="button"
               role="radio"
               aria-checked={selected}
-              tabIndex={selected ? 0 : -1}
+              disabled={!scoreFiltersEnabled}
+              tabIndex={scoreFiltersEnabled && selected ? 0 : -1}
               data-radio-value={option.value}
               onClick={() => onFilterChange(option.value)}
               onKeyDown={(event) =>
@@ -250,7 +287,7 @@ function DiscoverWaveControls({
               className={`tw-h-8 tw-rounded-md tw-border-0 tw-px-2.5 tw-text-xs tw-font-medium tw-transition-colors focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 ${
                 selected
                   ? "tw-text-primary-100 tw-bg-primary-500/20 tw-ring-1 tw-ring-inset tw-ring-primary-400/40"
-                  : "tw-bg-iron-950 tw-text-iron-400 tw-ring-1 tw-ring-inset tw-ring-white/10 desktop-hover:hover:tw-bg-iron-800 desktop-hover:hover:tw-text-iron-100"
+                  : "tw-bg-iron-950 tw-text-iron-400 tw-ring-1 tw-ring-inset tw-ring-white/10 disabled:tw-cursor-not-allowed disabled:tw-bg-iron-950 disabled:tw-text-iron-600 desktop-hover:hover:tw-bg-iron-800 desktop-hover:hover:tw-text-iron-100"
               }`}
             >
               {option.label}
@@ -275,15 +312,35 @@ export function DiscoverWaveExplorer() {
   const activeSortLabel =
     SORT_OPTIONS.find((option) => option.value === activeSort)?.label ??
     "Balanced";
+  const activeSortIsScoreSort = isScoreSort(activeSort);
+  const visibleActiveFilter = activeSortIsScoreSort ? activeFilter : "ALL";
+  const activeView =
+    activeSort === "NEWEST"
+      ? ApiWavesV2ListType.Search
+      : ApiWavesV2ListType.Overview;
+  const activeOverviewType =
+    activeSort === "LATEST_POSTS"
+      ? ApiWavesOverviewType.RecentlyDroppedTo
+      : WAVE_SCORE_DISCOVERY_PARAMS.overviewType;
+  const activeScoreSort = activeSortIsScoreSort ? activeSort : undefined;
+  const activeFilterScores: DiscoverFilterScores = activeSortIsScoreSort
+    ? filterScores
+    : {};
+  const title =
+    activeSort === "NEWEST"
+      ? "Newest waves"
+      : "Active discussions you are not yet following";
 
   const updateParams = useCallback(
     (updates: {
-      readonly sort?: ApiWaveScoreSort | undefined;
+      readonly sort?: DiscoverSort | undefined;
       readonly filter?: DiscoverScoreFilter | undefined;
     }) => {
       const params = new URLSearchParams(searchParams?.toString() ?? "");
       const nextSort = updates.sort ?? activeSort;
-      const nextFilter = updates.filter ?? activeFilter;
+      const nextFilter = isScoreSort(nextSort)
+        ? (updates.filter ?? activeFilter)
+        : "ALL";
 
       if (nextSort === WAVE_SCORE_DISCOVERY_PARAMS.scoreSort) {
         params.delete(SORT_PARAM);
@@ -307,23 +364,25 @@ export function DiscoverWaveExplorer() {
 
   return (
     <ExploreWavesSection
-      title="Active discussions you are not yet following"
+      title={title}
       subtitle={null}
       limit={20}
       viewAllHref={null}
-      excludeFollowed={true}
-      overviewType={WAVE_SCORE_DISCOVERY_PARAMS.overviewType}
-      scoreSort={activeSort}
-      minVisibilityScore={filterScores.minVisibilityScore}
-      minQualityScore={filterScores.minQualityScore}
-      minHotnessScore={filterScores.minHotnessScore}
-      minRepSortScore={filterScores.minRepSortScore}
+      excludeFollowed={activeSort !== "NEWEST"}
+      view={activeView}
+      overviewType={activeOverviewType}
+      directMessage={false}
+      scoreSort={activeScoreSort}
+      minVisibilityScore={activeFilterScores.minVisibilityScore}
+      minQualityScore={activeFilterScores.minQualityScore}
+      minHotnessScore={activeFilterScores.minHotnessScore}
+      minRepSortScore={activeFilterScores.minRepSortScore}
       statusLabel={`${activeSortLabel} waves`}
       showEmptyState={true}
       emptyStateLabel="No waves match these filters."
       headerControls={
         <DiscoverWaveControls
-          activeFilter={activeFilter}
+          activeFilter={visibleActiveFilter}
           activeSort={activeSort}
           onFilterChange={(filter) => updateParams({ filter })}
           onSortChange={(sort) => updateParams({ sort })}

--- a/components/waves/discovery/WaveScoreTransparencyPage.tsx
+++ b/components/waves/discovery/WaveScoreTransparencyPage.tsx
@@ -20,7 +20,9 @@ import {
   ArrowLongRightIcon,
   ArrowPathIcon,
   CalculatorIcon,
+  CameraIcon,
   ChartBarIcon,
+  ClipboardDocumentIcon,
   FireIcon,
   MagnifyingGlassIcon,
   ScaleIcon,
@@ -28,9 +30,32 @@ import {
   SparklesIcon,
 } from "@heroicons/react/24/outline";
 import Link from "next/link";
-import { useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
 
 type CalculatorStatus = "idle" | "loading" | "success" | "error";
+const SHARE_STATUS = {
+  IDLE: "idle",
+  COPIED: "copied",
+  COPY_ERROR: "copy-error",
+  SCREENSHOT_LOADING: "screenshot-loading",
+  SCREENSHOT_READY: "screenshot-ready",
+  SCREENSHOT_ERROR: "screenshot-error",
+} as const;
+
+type ShareStatus = (typeof SHARE_STATUS)[keyof typeof SHARE_STATUS];
+
+type OptionalClipboardNavigator = {
+  readonly clipboard?: {
+    readonly writeText?: (text: string) => Promise<void>;
+  };
+};
+
+const getClipboardNavigator = (): OptionalClipboardNavigator | undefined => {
+  if (typeof globalThis.window !== "undefined") {
+    return globalThis.window.navigator as OptionalClipboardNavigator;
+  }
+  return globalThis.navigator as OptionalClipboardNavigator | undefined;
+};
 
 interface CalculationRow {
   readonly label: string;
@@ -58,6 +83,7 @@ const UUID_REGEX =
   /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
 const SCORE_RECONCILIATION_EPSILON = 0.05;
+const DEFAULT_BACK_HREF = "/network";
 
 const DEFAULT_FORMULA: ApiWaveScoreFormula = {
   max_level_raw_for_score: 25000000,
@@ -122,7 +148,7 @@ const formulaSteps: readonly FormulaStep[] = [
     formula:
       "(creator x 20%) + (poster levels x 20%) + (diversity x 15%) + (subscriptions x 10%) + (REP x 35%)",
     description:
-      "The durable trust score. This is where TDH-backed Wave REP has the largest explicit weight.",
+      "The durable trust score for evaluating a new wave. This is where TDH-backed Wave REP has the largest explicit weight.",
     icon: ShieldCheckIcon,
     toneClasses: "tw-bg-sky-500/10 tw-text-sky-200 tw-ring-sky-400/25",
   },
@@ -247,6 +273,55 @@ function getCurrentOrigin(): string {
     return globalThis.location.origin;
   }
   return "https://6529.io";
+}
+
+function sanitizeReturnTo(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed || !trimmed.startsWith("/") || trimmed.startsWith("//")) {
+    return null;
+  }
+  if (trimmed.includes("\\") || /[\u0000-\u001f\u007f]/.test(trimmed)) {
+    return null;
+  }
+
+  try {
+    const url = new URL(trimmed, getCurrentOrigin());
+    if (url.origin !== getCurrentOrigin()) {
+      return null;
+    }
+    const safePath = `${url.pathname}${url.search}${url.hash}`;
+    if (url.pathname === "/network/wave-score") {
+      return null;
+    }
+    return safePath;
+  } catch {
+    return null;
+  }
+}
+
+function getBackLinkLabel(href: string): string {
+  if (href.startsWith("/waves/") || href.startsWith("/messages/")) {
+    return "Back to wave";
+  }
+  if (href !== DEFAULT_BACK_HREF) {
+    return "Back to previous page";
+  }
+  return "Back to Network";
+}
+
+function scrollElementIntoNearestView(element: HTMLElement | null): void {
+  if (!element) {
+    return;
+  }
+
+  const prefersReducedMotion =
+    typeof globalThis.matchMedia === "function" &&
+    globalThis.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  element.scrollIntoView({
+    behavior: prefersReducedMotion ? "auto" : "smooth",
+    block: "nearest",
+  });
 }
 
 function sanitizeWaveId(value: string | null): string | null {
@@ -698,9 +773,188 @@ function CalculatorPanel({
   );
 }
 
+function getShareStatusMessage(status: ShareStatus): string {
+  switch (status) {
+    case SHARE_STATUS.COPIED:
+      return "Markdown analysis copied.";
+    case SHARE_STATUS.COPY_ERROR:
+      return "Unable to copy the analysis.";
+    case SHARE_STATUS.SCREENSHOT_LOADING:
+      return "Preparing screenshot.";
+    case SHARE_STATUS.SCREENSHOT_READY:
+      return "Screenshot downloaded.";
+    case SHARE_STATUS.SCREENSHOT_ERROR:
+      return "Unable to create the screenshot.";
+    case SHARE_STATUS.IDLE:
+      return "";
+  }
+}
+
+function getWaveScoreScreenshotName(waveName: string): string {
+  const slugCharacters: string[] = [];
+  let lastWasSeparator = true;
+
+  for (const character of waveName.toLowerCase()) {
+    const codePoint = character.charCodeAt(0);
+    const isDigit = codePoint >= 48 && codePoint <= 57;
+    const isLowercaseLetter = codePoint >= 97 && codePoint <= 122;
+
+    if (isDigit || isLowercaseLetter) {
+      slugCharacters.push(character);
+      lastWasSeparator = false;
+    } else if (!lastWasSeparator && slugCharacters.length < 48) {
+      slugCharacters.push("-");
+      lastWasSeparator = true;
+    }
+
+    if (slugCharacters.length >= 48) {
+      break;
+    }
+  }
+
+  if (slugCharacters[slugCharacters.length - 1] === "-") {
+    slugCharacters.pop();
+  }
+
+  const slug = slugCharacters.join("");
+  return `${slug || "wave"}-score-analysis.png`;
+}
+
+function buildWaveScoreMarkdown({
+  wave,
+  waveHref,
+  score,
+  formula,
+  gate,
+  qualityRows,
+  qualityBeforeSafety,
+  safetyMultiplier,
+  computedQuality,
+  hotnessBeforeSafety,
+  computedHotness,
+  computedVisibility,
+  waveRepTotal,
+  formulaSource,
+  scoreMismatchDetail,
+}: {
+  readonly wave: ApiWave;
+  readonly waveHref: string;
+  readonly score: ApiWaveScore;
+  readonly formula: ApiWaveScoreFormula;
+  readonly gate: ApiWaveScoreQualityGate;
+  readonly qualityRows: readonly CalculationRow[];
+  readonly qualityBeforeSafety: number;
+  readonly safetyMultiplier: number;
+  readonly computedQuality: number;
+  readonly hotnessBeforeSafety: number;
+  readonly computedHotness: number;
+  readonly computedVisibility: number;
+  readonly waveRepTotal: number;
+  readonly formulaSource: string;
+  readonly scoreMismatchDetail: string;
+}): string {
+  const qualityLines = qualityRows.map((row) => {
+    const contribution = row.score * row.weight;
+    return `- ${row.label}: ${formatScore(row.score)} x ${formatWeight(
+      row.weight
+    )} = ${formatScore(contribution)}`;
+  });
+  const mismatchLines = scoreMismatchDetail
+    ? ["", `Formula drift: ${scoreMismatchDetail}`]
+    : [];
+
+  return [
+    `# Wave score analysis: ${wave.name}`,
+    "",
+    `Wave: ${getCurrentOrigin()}${waveHref}`,
+    `Creator: ${getWaveDisplayHandle(wave)}`,
+    `Calculated: ${formatTimestamp(score.calculated_at)}`,
+    `Version: ${score.score_version}`,
+    `Formula source: ${formulaSource}`,
+    "",
+    "## Scores",
+    `- Visibility: ${formatScore(score.visibility_score)} (${score.visibility_tier})`,
+    `- Quality: ${formatScore(score.quality_score)}`,
+    `- Hotness: ${formatScore(score.hotness_score)}`,
+    `- Wave REP: ${formatInteger(waveRepTotal)} raw -> ${formatScore(
+      score.components.wave_rep_component_score
+    )} component`,
+    ...mismatchLines,
+    "",
+    "## Quality",
+    ...qualityLines,
+    `- Base quality: ${formatScore(qualityBeforeSafety)}`,
+    `- Safety multiplier: ${formatScore(safetyMultiplier)}`,
+    `- Final quality: ${formatScore(score.quality_score)} (computed ${formatScore(
+      computedQuality
+    )})`,
+    "",
+    "## Hotness and visibility",
+    `- Recent trusted activity: ${formatScore(
+      score.components.recent_trusted_activity_score
+    )} x ${formatWeight(
+      formula.hotness_component_weights.recent_trusted_activity_score
+    )}`,
+    `- Quality in hotness: ${formatScore(
+      score.quality_score
+    )} x ${formatWeight(formula.hotness_component_weights.quality_score)}`,
+    `- Base hotness: ${formatScore(hotnessBeforeSafety)}`,
+    `- Final hotness: ${formatScore(score.hotness_score)} (computed ${formatScore(
+      computedHotness
+    )})`,
+    `- Quality gate: clamp(${formatScore(score.quality_score)} / ${formatScore(
+      gate.threshold
+    )}, 0, 1) = ${formatScore(gate.multiplier)}`,
+    `- Gated hotness: ${formatScore(gate.gated_hotness_score)}`,
+    `- Visibility: quality x ${formatWeight(
+      formula.visibility_component_weights.quality_score
+    )} + gated hotness x ${formatWeight(
+      formula.visibility_component_weights.gated_hotness_score
+    )} = ${formatScore(score.visibility_score)} (computed ${formatScore(
+      computedVisibility
+    )})`,
+    "",
+    "## Penalties",
+    `- Single actor: ${formatScore(score.penalties.single_actor_penalty)}%`,
+    `- Low trust flood: ${formatScore(score.penalties.low_trust_flood_penalty)}%`,
+    `- Cross-post pressure: ${formatScore(score.penalties.cross_post_pressure)}%`,
+    `- Cross-post penalty: ${formatScore(score.penalties.cross_post_penalty)}%`,
+    `- Negative REP: ${formatScore(score.penalties.negative_rep_penalty)}%`,
+    "",
+    `Formula page: ${getCurrentOrigin()}/network/wave-score`,
+  ].join("\n");
+}
+
 function WaveScoreResult({ wave }: { readonly wave: ApiWave }) {
   const score = wave.wave_score;
   const waveHref = getWaveHref(wave);
+  const analysisRef = useRef<HTMLElement>(null);
+  const shareStatusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  const [shareStatus, setShareStatus] = useState<ShareStatus>(
+    SHARE_STATUS.IDLE
+  );
+
+  useEffect(() => {
+    return () => {
+      if (shareStatusTimerRef.current) {
+        clearTimeout(shareStatusTimerRef.current);
+      }
+    };
+  }, []);
+
+  const setTemporaryShareStatus = (nextStatus: ShareStatus) => {
+    setShareStatus(nextStatus);
+    if (shareStatusTimerRef.current) {
+      clearTimeout(shareStatusTimerRef.current);
+    }
+    if (nextStatus !== SHARE_STATUS.SCREENSHOT_LOADING) {
+      shareStatusTimerRef.current = setTimeout(() => {
+        setShareStatus(SHARE_STATUS.IDLE);
+      }, 3000);
+    }
+  };
 
   if (!score) {
     return (
@@ -765,9 +1019,76 @@ function WaveScoreResult({ wave }: { readonly wave: ApiWave }) {
   const scoreMismatchDetail = scoreMismatches
     .map(formatScoreMismatch)
     .join("; ");
+  const markdownAnalysis = buildWaveScoreMarkdown({
+    wave,
+    waveHref,
+    score,
+    formula,
+    gate,
+    qualityRows,
+    qualityBeforeSafety,
+    safetyMultiplier,
+    computedQuality,
+    hotnessBeforeSafety,
+    computedHotness,
+    computedVisibility,
+    waveRepTotal,
+    formulaSource,
+    scoreMismatchDetail,
+  });
+
+  const handleCopyMarkdown = async () => {
+    try {
+      const clipboard = getClipboardNavigator()?.clipboard;
+      if (typeof clipboard?.writeText !== "function") {
+        throw new Error("Clipboard API unavailable");
+      }
+      await clipboard.writeText(markdownAnalysis);
+      setTemporaryShareStatus(SHARE_STATUS.COPIED);
+    } catch (copyError) {
+      console.error("Wave score markdown copy failed", copyError);
+      setTemporaryShareStatus(SHARE_STATUS.COPY_ERROR);
+    }
+  };
+
+  const handleDownloadScreenshot = async () => {
+    const analysisNode = analysisRef.current;
+    if (!analysisNode) {
+      setTemporaryShareStatus(SHARE_STATUS.SCREENSHOT_ERROR);
+      return;
+    }
+
+    setShareStatus(SHARE_STATUS.SCREENSHOT_LOADING);
+    try {
+      const { toPng } = await import("html-to-image");
+      const dataUrl = await toPng(analysisNode, {
+        backgroundColor: "#050505",
+        cacheBust: true,
+        pixelRatio: 2,
+        filter: (node) =>
+          !(
+            node instanceof HTMLElement &&
+            node.dataset["waveScoreScreenshotExclude"] === "true"
+          ),
+      });
+      const link = globalThis.document.createElement("a");
+      link.href = dataUrl;
+      link.download = getWaveScoreScreenshotName(wave.name);
+      globalThis.document.body.appendChild(link);
+      try {
+        link.click();
+      } finally {
+        link.remove();
+      }
+      setTemporaryShareStatus(SHARE_STATUS.SCREENSHOT_READY);
+    } catch (screenshotError) {
+      console.error("Wave score screenshot failed", screenshotError);
+      setTemporaryShareStatus(SHARE_STATUS.SCREENSHOT_ERROR);
+    }
+  };
 
   return (
-    <section className="tw-space-y-5" aria-live="polite">
+    <section ref={analysisRef} className="tw-space-y-5" aria-live="polite">
       <div className="tw-rounded-lg tw-bg-iron-950/70 tw-p-5 tw-ring-1 tw-ring-inset tw-ring-white/10">
         <div className="tw-flex tw-flex-col tw-gap-4 lg:tw-flex-row lg:tw-items-start lg:tw-justify-between">
           <div className="tw-min-w-0">
@@ -800,14 +1121,46 @@ function WaveScoreResult({ wave }: { readonly wave: ApiWave }) {
               className="tw-mt-4"
             />
           </div>
-          <Link
-            href={waveHref}
-            className="tw-inline-flex tw-h-10 tw-items-center tw-justify-center tw-gap-2 tw-rounded-lg tw-bg-white/5 tw-px-4 tw-text-sm tw-font-semibold tw-text-iron-100 tw-no-underline tw-ring-1 tw-ring-inset tw-ring-white/10 tw-transition focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 desktop-hover:hover:tw-bg-white/10"
+          <div
+            data-wave-score-screenshot-exclude="true"
+            className="tw-flex tw-flex-col tw-items-stretch tw-gap-2 sm:tw-flex-row lg:tw-items-start"
           >
-            Open wave
-            <ArrowLongRightIcon className="tw-size-4" aria-hidden="true" />
-          </Link>
+            <button
+              type="button"
+              onClick={() => void handleCopyMarkdown()}
+              className="tw-inline-flex tw-h-10 tw-items-center tw-justify-center tw-gap-2 tw-rounded-lg tw-border-0 tw-bg-white/5 tw-px-3 tw-text-sm tw-font-semibold tw-text-iron-100 tw-ring-1 tw-ring-inset tw-ring-white/10 tw-transition focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 desktop-hover:hover:tw-bg-white/10"
+              aria-label="Copy wave score analysis as Markdown"
+            >
+              <ClipboardDocumentIcon className="tw-size-4" aria-hidden="true" />
+              Copy
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleDownloadScreenshot()}
+              disabled={shareStatus === SHARE_STATUS.SCREENSHOT_LOADING}
+              className="tw-inline-flex tw-h-10 tw-items-center tw-justify-center tw-gap-2 tw-rounded-lg tw-border-0 tw-bg-white/5 tw-px-3 tw-text-sm tw-font-semibold tw-text-iron-100 tw-ring-1 tw-ring-inset tw-ring-white/10 tw-transition focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 disabled:tw-cursor-wait disabled:tw-opacity-60 desktop-hover:hover:tw-bg-white/10"
+              aria-label="Download wave score analysis screenshot"
+            >
+              <CameraIcon className="tw-size-4" aria-hidden="true" />
+              Screenshot
+            </button>
+            <Link
+              href={waveHref}
+              className="tw-inline-flex tw-h-10 tw-items-center tw-justify-center tw-gap-2 tw-rounded-lg tw-bg-white/5 tw-px-4 tw-text-sm tw-font-semibold tw-text-iron-100 tw-no-underline tw-ring-1 tw-ring-inset tw-ring-white/10 tw-transition focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 desktop-hover:hover:tw-bg-white/10"
+            >
+              Open wave
+              <ArrowLongRightIcon className="tw-size-4" aria-hidden="true" />
+            </Link>
+          </div>
         </div>
+        <p
+          data-wave-score-screenshot-exclude="true"
+          role="status"
+          aria-live="polite"
+          className="tw-mt-3 tw-min-h-5 tw-text-xs tw-font-medium tw-text-iron-300"
+        >
+          {getShareStatusMessage(shareStatus)}
+        </p>
 
         <div className="tw-mt-5 tw-grid tw-gap-3 sm:tw-grid-cols-2 xl:tw-grid-cols-4">
           <ScoreStat
@@ -1306,7 +1659,11 @@ function ConstantStat({
   );
 }
 
-export function WaveScoreTransparencyPage() {
+export function WaveScoreTransparencyPage({
+  initialReturnTo,
+}: {
+  readonly initialReturnTo?: string | null | undefined;
+}) {
   useSetTitle("Wave Score | Network");
 
   const [input, setInput] = useState("");
@@ -1314,11 +1671,14 @@ export function WaveScoreTransparencyPage() {
   const [error, setError] = useState<string | null>(null);
   const [wave, setWave] = useState<ApiWave | null>(null);
   const [matches, setMatches] = useState<SidebarWave[]>([]);
+  const returnTo = sanitizeReturnTo(initialReturnTo) ?? DEFAULT_BACK_HREF;
+  const resultContainerRef = useRef<HTMLDivElement>(null);
 
   const currentScore = wave?.wave_score ?? null;
   const apiHasFormulaMetadata = Boolean(
     currentScore?.formula && currentScore?.quality_gate
   );
+  const backLinkLabel = getBackLinkLabel(returnTo);
 
   const loadWave = async (waveId: string) => {
     setStatus("loading");
@@ -1328,6 +1688,15 @@ export function WaveScoreTransparencyPage() {
       const nextWave = await fetchWaveById({ waveId });
       setWave(nextWave);
       setStatus("success");
+      if (typeof globalThis.requestAnimationFrame === "function") {
+        globalThis.requestAnimationFrame(() => {
+          scrollElementIntoNearestView(resultContainerRef.current);
+        });
+      } else {
+        setTimeout(() => {
+          scrollElementIntoNearestView(resultContainerRef.current);
+        }, 0);
+      }
     } catch (loadError) {
       setStatus("error");
       setError(getErrorMessage(loadError));
@@ -1386,14 +1755,11 @@ export function WaveScoreTransparencyPage() {
         <section className="tw-grid tw-gap-6 xl:tw-grid-cols-[minmax(0,0.9fr)_minmax(380px,1.1fr)]">
           <div className="tw-rounded-lg tw-bg-iron-950/50 tw-p-5 tw-ring-1 tw-ring-inset tw-ring-white/10 md:tw-p-6">
             <Link
-              href="/network"
+              href={returnTo}
               className="tw-text-primary-200 desktop-hover:hover:tw-text-primary-100 tw-inline-flex tw-items-center tw-gap-2 tw-text-sm tw-font-medium tw-no-underline tw-transition focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
             >
-              <ArrowLongLeftIcon
-                className="tw-size-4"
-                aria-hidden="true"
-              />
-              Back to Network
+              <ArrowLongLeftIcon className="tw-size-4" aria-hidden="true" />
+              {backLinkLabel}
             </Link>
             <p className="tw-mt-5 tw-text-xs tw-font-semibold tw-uppercase tw-tracking-wide tw-text-iron-500">
               Network menu / Wave Score
@@ -1422,25 +1788,31 @@ export function WaveScoreTransparencyPage() {
           />
         </section>
 
-        <FormulaPipeline />
-
-        <FormulaSummary />
-
-        {currentScore && (
+        {wave && (
           <div
-            className={`tw-rounded-lg tw-p-4 tw-text-sm tw-ring-1 tw-ring-inset ${
-              apiHasFormulaMetadata
-                ? "tw-bg-emerald-500/10 tw-text-emerald-100 tw-ring-emerald-400/25"
-                : "tw-bg-amber-500/10 tw-text-amber-100 tw-ring-amber-400/25"
-            }`}
+            ref={resultContainerRef}
+            className="tw-animate-slideUp tw-space-y-3 motion-reduce:tw-animate-none"
           >
-            {apiHasFormulaMetadata
-              ? "This result is using formula constants returned by the API."
-              : "This result is using the v1 fallback constants because the API response did not include formula metadata yet."}
+            {currentScore && (
+              <div
+                className={`tw-rounded-lg tw-p-4 tw-text-sm tw-ring-1 tw-ring-inset ${
+                  apiHasFormulaMetadata
+                    ? "tw-bg-emerald-500/10 tw-text-emerald-100 tw-ring-emerald-400/25"
+                    : "tw-bg-amber-500/10 tw-text-amber-100 tw-ring-amber-400/25"
+                }`}
+              >
+                {apiHasFormulaMetadata
+                  ? "This result is using formula constants returned by the API."
+                  : "This result is using the v1 fallback constants because the API response did not include formula metadata yet."}
+              </div>
+            )}
+            <WaveScoreResult wave={wave} />
           </div>
         )}
 
-        {wave && <WaveScoreResult wave={wave} />}
+        <FormulaPipeline />
+
+        <FormulaSummary />
       </div>
     </div>
   );

--- a/contexts/wave/hooks/useEnhancedWavesListCore.ts
+++ b/contexts/wave/hooks/useEnhancedWavesListCore.ts
@@ -19,6 +19,7 @@ export interface MinimalWave {
   picture: string | null;
   contributors: readonly SidebarWaveContributor[];
   isPinned: boolean;
+  isFollowing: boolean;
   isOfficial: boolean;
   isMuted: boolean;
   parentWaveId: string | null;
@@ -179,6 +180,7 @@ function useEnhancedWavesListCore(
         isPinned: options.supportsPinning
           ? (wave.isPinned ?? wave.pinned ?? false)
           : false,
+        isFollowing: wave.subscribed ?? false,
         isOfficial: wave.isOfficial ?? false,
         isMuted: wave.muted,
         parentWaveId: wave.parentWaveId,

--- a/hooks/useWavesList.ts
+++ b/hooks/useWavesList.ts
@@ -9,6 +9,7 @@ import { mapApiWaveToSidebarWave, useWavesV2 } from "./useWavesV2";
 import {
   SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
   WAVE_FOLLOWING_WAVES_PARAMS,
+  WAVE_SCORE_DISCOVERY_PARAMS,
 } from "@/components/react-query-wrapper/utils/query-utils";
 import { usePinnedWavesServer } from "./usePinnedWavesServer";
 import { useWaveById } from "./useWaveById";
@@ -73,25 +74,73 @@ const useWavesList = () => {
     return `${normalizedAddress}:primary`;
   }, [address, activeProfileProxy?.id]);
 
-  // Fetch main waves list
+  // Fetch score-ranked waves for sidebar discovery.
   const {
-    waves: mainWaves,
-    isFetching,
-    isFetchingNextPage,
-    hasNextPage,
-    fetchNextPage,
-    status: mainWavesStatus,
-    refetch: mainWavesRefetch,
+    waves: scoreWaves,
+    isFetching: isScoreWavesFetching,
+    isFetchingNextPage: isScoreWavesFetchingNextPage,
+    hasNextPage: hasScoreWavesNextPage,
+    fetchNextPage: fetchNextScoreWavesPage,
+    status: scoreWavesStatus,
+    refetch: scoreWavesRefetch,
   } = useWavesV2({
-    overviewType: WAVE_FOLLOWING_WAVES_PARAMS.initialWavesOverviewType,
+    overviewType: WAVE_SCORE_DISCOVERY_PARAMS.overviewType,
     pageSize: WAVE_FOLLOWING_WAVES_PARAMS.limit,
-    following: isConnectedIdentity && following,
+    following: false,
     directMessage: false,
-    scoreSort: WAVE_FOLLOWING_WAVES_PARAMS.scoreSort,
+    excludeFollowed: isConnectedIdentity ? true : undefined,
+    scoreSort: WAVE_SCORE_DISCOVERY_PARAMS.scoreSort,
     viewerIdentityKey,
     refetchInterval: SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
     refetchIntervalInBackground: false,
+    enabled: !following,
   });
+  // Fetch followed waves by latest post activity for the known-wave sidebar.
+  const {
+    waves: followedActivityWaves,
+    isFetching: isFollowedActivityWavesFetching,
+    isFetchingNextPage: isFollowedActivityWavesFetchingNextPage,
+    hasNextPage: hasFollowedActivityWavesNextPage,
+    fetchNextPage: fetchNextFollowedActivityWavesPage,
+    status: followedActivityWavesStatus,
+    refetch: followedActivityWavesRefetch,
+  } = useWavesV2({
+    overviewType: WAVE_FOLLOWING_WAVES_PARAMS.initialWavesOverviewType,
+    pageSize: WAVE_FOLLOWING_WAVES_PARAMS.limit,
+    following: isConnectedIdentity,
+    directMessage: false,
+    viewerIdentityKey,
+    refetchInterval: following
+      ? SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS
+      : false,
+    refetchIntervalInBackground: false,
+    enabled: isConnectedIdentity,
+  });
+  const mainWaves = useMemo(
+    () =>
+      following
+        ? followedActivityWaves
+        : [...followedActivityWaves, ...scoreWaves],
+    [following, followedActivityWaves, scoreWaves]
+  );
+  const isMainWavesFetching = following
+    ? isFollowedActivityWavesFetching
+    : isScoreWavesFetching || isFollowedActivityWavesFetching;
+  const isMainWavesFetchingNextPage = following
+    ? isFollowedActivityWavesFetchingNextPage
+    : isScoreWavesFetchingNextPage;
+  const hasMainWavesNextPage = following
+    ? hasFollowedActivityWavesNextPage
+    : hasScoreWavesNextPage;
+  const fetchNextMainWavesPage = following
+    ? fetchNextFollowedActivityWavesPage
+    : fetchNextScoreWavesPage;
+  const mainWavesStatus = following
+    ? followedActivityWavesStatus
+    : scoreWavesStatus;
+  const mainWavesRefetch = following
+    ? followedActivityWavesRefetch
+    : scoreWavesRefetch;
   const {
     waves: officialWaves,
     isFetching: isOfficialWavesFetching,
@@ -215,8 +264,8 @@ const useWavesList = () => {
 
   // New drops counts are now managed externally
 
-  // Combine main waves with separately fetched pinned waves using useMemo
-  // Simplified order: All waves sorted by latest_drop_timestamp (most recent first)
+  // Combine activity and discovery sources. Pinned/followed rows are
+  // activity-first; non-followed rows preserve the score-ranked backend order.
   const combinedWaves = useMemo(() => {
     const allWavesMap = new Map<string, EnhancedWave>();
     const pinnedWavesSet = new Set(pinnedIds);
@@ -232,8 +281,10 @@ const useWavesList = () => {
         return;
       }
 
+      const existingWave = allWavesMap.get(wave.id);
       allWavesMap.set(wave.id, {
         ...wave,
+        subscribed: existingWave?.subscribed || wave.subscribed,
         isPinned: pinnedWavesSet.has(wave.id),
       });
     });
@@ -254,12 +305,18 @@ const useWavesList = () => {
       .sort(
         (a, b) => (b.latestDropTimestamp ?? 0) - (a.latestDropTimestamp ?? 0)
       );
-    const backendOrderedRegularWaves = nonAnnouncementWaves.filter(
-      (wave) => !wave.isPinned
+    const activityOrderedFollowingWaves = nonAnnouncementWaves
+      .filter((wave) => !wave.isPinned && wave.subscribed)
+      .sort(
+        (a, b) => (b.latestDropTimestamp ?? 0) - (a.latestDropTimestamp ?? 0)
+      );
+    const backendOrderedScoreWaves = nonAnnouncementWaves.filter(
+      (wave) => !wave.isPinned && !wave.subscribed
     );
     const sortedNonAnnouncementWaves = [
       ...sortedPinnedWaves,
-      ...backendOrderedRegularWaves,
+      ...activityOrderedFollowingWaves,
+      ...backendOrderedScoreWaves,
     ];
 
     if (announcementWave) {
@@ -331,7 +388,8 @@ const useWavesList = () => {
 
   // Function to refetch all waves (main, pinned, official, announcements, subwaves)
   const refetchAllWaves = useCallback(() => {
-    mainWavesRefetch();
+    scoreWavesRefetch();
+    followedActivityWavesRefetch();
     officialWavesRefetch();
     void refetchPinnedWaves();
     refetchSubwaves();
@@ -339,7 +397,8 @@ const useWavesList = () => {
       void announcementRefetch();
     }
   }, [
-    mainWavesRefetch,
+    scoreWavesRefetch,
+    followedActivityWavesRefetch,
     officialWavesRefetch,
     refetchPinnedWaves,
     refetchSubwaves,
@@ -361,8 +420,8 @@ const useWavesList = () => {
 
   // Memoize the fetchNextPage function to ensure it doesn't change on every render
   const fetchNextPageStable = useCallback(() => {
-    return fetchNextPage();
-  }, [fetchNextPage]);
+    return fetchNextMainWavesPage();
+  }, [fetchNextMainWavesPage]);
 
   // Memoize the entire return object to prevent unnecessary re-renders in consumer components
   // Components using this hook will only re-render when the values they use actually change
@@ -372,9 +431,9 @@ const useWavesList = () => {
       waves: allWaves,
 
       // Original waves pagination and loading
-      isFetching: isFetching || isOfficialWavesFetching,
-      isFetchingNextPage,
-      hasNextPage,
+      isFetching: isMainWavesFetching || isOfficialWavesFetching,
+      isFetchingNextPage: isMainWavesFetchingNextPage,
+      hasNextPage: hasMainWavesNextPage,
       fetchNextPage: fetchNextPageStable,
       status: mainWavesStatus,
 
@@ -403,10 +462,10 @@ const useWavesList = () => {
     }),
     [
       allWaves,
-      isFetching,
+      isMainWavesFetching,
       isOfficialWavesFetching,
-      isFetchingNextPage,
-      hasNextPage,
+      isMainWavesFetchingNextPage,
+      hasMainWavesNextPage,
       fetchNextPageStable,
       mainWavesStatus,
       mainWaves,

--- a/hooks/useWavesV2.ts
+++ b/hooks/useWavesV2.ts
@@ -23,14 +23,16 @@ interface UseWavesV2Props {
   readonly viewerIdentityKey?: string | null | undefined;
   readonly directMessage?: boolean | undefined;
   readonly pinned?: ApiWavesPinFilter | undefined;
+  readonly excludeFollowed?: boolean | undefined;
   readonly scoreSort?: ApiWaveScoreSort | undefined;
   readonly minVisibilityScore?: number | undefined;
   readonly minQualityScore?: number | undefined;
   readonly minHotnessScore?: number | undefined;
   readonly minRepSortScore?: number | undefined;
   readonly visibilityTier?: ApiWaveVisibilityTier | undefined;
-  readonly refetchInterval?: number | undefined;
+  readonly refetchInterval?: number | false | undefined;
   readonly refetchIntervalInBackground?: boolean | undefined;
+  readonly enabled?: boolean | undefined;
 }
 
 export const useWavesV2 = ({
@@ -40,6 +42,7 @@ export const useWavesV2 = ({
   viewerIdentityKey,
   directMessage,
   pinned,
+  excludeFollowed,
   scoreSort,
   minVisibilityScore,
   minQualityScore,
@@ -48,6 +51,7 @@ export const useWavesV2 = ({
   visibilityTier,
   refetchInterval = Infinity,
   refetchIntervalInBackground = false,
+  enabled = true,
 }: UseWavesV2Props) => {
   const queryKeyParams = useMemo(
     () =>
@@ -57,6 +61,7 @@ export const useWavesV2 = ({
         following,
         directMessage,
         pinned,
+        excludeFollowed,
         scoreSort,
         minVisibilityScore,
         minQualityScore,
@@ -71,6 +76,7 @@ export const useWavesV2 = ({
       following,
       directMessage,
       pinned,
+      excludeFollowed,
       scoreSort,
       minVisibilityScore,
       minQualityScore,
@@ -98,6 +104,7 @@ export const useWavesV2 = ({
         following,
         directMessage,
         pinned,
+        excludeFollowed,
         scoreSort,
         minVisibilityScore,
         minQualityScore,
@@ -128,6 +135,7 @@ export const useWavesV2 = ({
     },
     refetchInterval,
     refetchIntervalInBackground,
+    enabled,
     ...getDefaultQueryRetry(handleRetryFailure),
   });
 

--- a/services/api/waves-v2-api.ts
+++ b/services/api/waves-v2-api.ts
@@ -63,6 +63,7 @@ export interface WavesV2OverviewQueryKeyParams {
   readonly only_waves_followed_by_authenticated_user: boolean;
   readonly direct_message?: boolean | undefined;
   readonly pinned?: ApiWavesPinFilter | undefined;
+  readonly exclude_followed?: boolean | undefined;
   readonly score_sort?: ApiWaveScoreSort | undefined;
   readonly min_visibility_score?: number | undefined;
   readonly min_quality_score?: number | undefined;
@@ -78,6 +79,7 @@ export function getWavesV2OverviewQueryKeyParams({
   following = false,
   directMessage,
   pinned,
+  excludeFollowed,
   scoreSort,
   minVisibilityScore,
   minQualityScore,
@@ -91,6 +93,7 @@ export function getWavesV2OverviewQueryKeyParams({
   readonly following?: boolean | undefined;
   readonly directMessage?: boolean | undefined;
   readonly pinned?: ApiWavesPinFilter | undefined;
+  readonly excludeFollowed?: boolean | undefined;
   readonly scoreSort?: ApiWaveScoreSort | undefined;
   readonly minVisibilityScore?: number | undefined;
   readonly minQualityScore?: number | undefined;
@@ -109,6 +112,9 @@ export function getWavesV2OverviewQueryKeyParams({
     only_waves_followed_by_authenticated_user: following,
     ...(directMessage === undefined ? {} : { direct_message: directMessage }),
     ...(pinned === undefined ? {} : { pinned }),
+    ...(excludeFollowed === undefined
+      ? {}
+      : { exclude_followed: excludeFollowed }),
     ...(scoreSort === undefined ? {} : { score_sort: scoreSort }),
     ...(minVisibilityScore === undefined
       ? {}


### PR DESCRIPTION
## Summary
- Add Discover sort modes for `Newest` and `Latest Posts` using backend API ordering instead of client-side sorting.
- Split sidebar wave ordering into activity-first pinned/following buckets plus combined-score discovery suggestions.
- Polish Wave Score transparency/result UX with return links, inline result placement, copy Markdown, screenshot export, and tooltip/REP chip improvements.

## Verification
- `seize run test:no-coverage -- __tests__\hooks\useWavesList.test.tsx __tests__\components\waves\discovery\DiscoverWaveExplorer.test.tsx __tests__\components\waves\discovery\WaveScoreTransparencyPage.test.tsx __tests__\components\home\explore-waves\ExploreWavesSection.test.tsx --runInBand`
- `seize run lint:changed`
- `seize run typecheck:changed`
- `codex-diff-check`
- `git diff --check`

## Notes
- The Wave Score/Quality copy now frames score as a discovery/new-wave evaluation signal. Sidebar Pinned/Following buckets remain latest-activity-first for waves a user already knows.