### PR TITLE
Enable automatic i18n 6529bot review

### DIFF
--- a/.github/6529bot.yml
+++ b/.github/6529bot.yml
@@ -3,7 +3,7 @@ enabled: true
 
 reviewKinds:
   allowed: [general, followup, wcag, i18n, security, responsiveness]
-  initial: [general, security, responsiveness]
+  initial: [general, i18n, security, responsiveness]
   followup: [followup]
 
 commands:


### PR DESCRIPTION
## Summary
- add i18n to the automatic 6529bot initial review set
- keep existing general, security, and responsiveness reviews enabled

## Validation
- parsed .github/6529bot.yml with 6529reviewbot repository config parser
- codex-diff-check -- .github/6529bot.yml