### PR TITLE
Use CloudFront for delegation docs package

### DIFF
--- a/__tests__/components/delegation/html/delegationContent.test.ts
+++ b/__tests__/components/delegation/html/delegationContent.test.ts
@@ -72,6 +72,11 @@ describe("delegationContent", () => {
   if (!publishedRootCid) {
     throw new Error("Expected delegation content manifest to define rootCid");
   }
+  const publishedCloudFrontBaseUrl =
+    delegationContentManifest.acceleration.cloudFrontBaseUrl;
+  if (!publishedCloudFrontBaseUrl) {
+    throw new Error("Expected delegation content manifest to define CDN URL");
+  }
   const publishedGatewayBaseUrl = `https://ipfs.6529.io/ipfs/${publishedRootCid}`;
 
   it("keeps the reviewed source manifest and public mirror in sync", async () => {
@@ -114,11 +119,12 @@ describe("delegationContent", () => {
     expect(missingAlt).toEqual([]);
   });
 
-  it("uses CID-addressed IPFS gateways, then the local bundle", () => {
+  it("uses CloudFront, CID-addressed IPFS gateways, then the local bundle", () => {
     const article = getDelegationArticle("delegation-faq");
 
     expect(article).toBeDefined();
     expect(buildDelegationArticleUrls(article!)).toEqual([
+      `${publishedCloudFrontBaseUrl}/html/delegation-faq.html`,
       `${publishedGatewayBaseUrl}/html/delegation-faq.html`,
       `https://ipfs.io/ipfs/${publishedRootCid}/html/delegation-faq.html`,
       "/delegation-content/delegation-docs-2026-06-16/html/delegation-faq.html",
@@ -195,7 +201,7 @@ describe("delegationContent", () => {
     ).resolves.toMatchObject({
       article,
       html,
-      url: `${publishedGatewayBaseUrl}/html/delegation-faq.html`,
+      url: `${publishedCloudFrontBaseUrl}/html/delegation-faq.html`,
     });
   });
 
@@ -211,9 +217,9 @@ describe("delegationContent", () => {
     await expect(
       fetchDelegationArticleHtml("using-safe", fetchArticle)
     ).resolves.toMatchObject({
-      url: `${publishedGatewayBaseUrl}/html/using-safe.html`,
+      url: `${publishedCloudFrontBaseUrl}/html/using-safe.html`,
       html: expect.stringContaining(
-        `src="${publishedGatewayBaseUrl}/assets/screenshots/safe1.png"`
+        `src="${publishedCloudFrontBaseUrl}/assets/screenshots/safe1.png"`
       ),
     });
   });
@@ -259,7 +265,7 @@ describe("delegationContent", () => {
       fetchDelegationArticleHtml("register-delegation", fetchArticle)
     ).resolves.toMatchObject({
       article,
-      url: `${publishedGatewayBaseUrl}/html/register-delegation.html`,
+      url: `${publishedCloudFrontBaseUrl}/html/register-delegation.html`,
     });
     expect(text).not.toHaveBeenCalled();
   });

--- a/content/delegation/manifest.json
+++ b/content/delegation/manifest.json
@@ -16,7 +16,7 @@
     "fallbackGatewayBaseUrls": [
       "https://ipfs.io/ipfs"
     ],
-    "cloudFrontBaseUrl": null,
+    "cloudFrontBaseUrl": "https://d3lqz0a4bldqgf.cloudfront.net/delegation-content/bafybeieb2sb6bid4usgivmujduxcvpzjyouaipnep5defzefwq7dljx5xq",
     "note": "CloudFront/S3 may be used only as a CID/version-addressed mirror. Runtime verifies article hashes before rendering."
   },
   "localBasePath": "/delegation-content/delegation-docs-2026-06-16",

--- a/public/delegation-content/delegation-docs-2026-06-16/manifest.json
+++ b/public/delegation-content/delegation-docs-2026-06-16/manifest.json
@@ -16,7 +16,7 @@
     "fallbackGatewayBaseUrls": [
       "https://ipfs.io/ipfs"
     ],
-    "cloudFrontBaseUrl": null,
+    "cloudFrontBaseUrl": "https://d3lqz0a4bldqgf.cloudfront.net/delegation-content/bafybeieb2sb6bid4usgivmujduxcvpzjyouaipnep5defzefwq7dljx5xq",
     "note": "CloudFront/S3 may be used only as a CID/version-addressed mirror. Runtime verifies article hashes before rendering."
   },
   "localBasePath": "/delegation-content/delegation-docs-2026-06-16",


### PR DESCRIPTION
## Summary
- point the reviewed delegation manifest and public mirror at the published CloudFront package URL
- keep the IPFS CID/source URIs and IPFS/local fallback chain intact
- update resolver tests to assert CloudFront first, then IPFS gateways, then local bundle

## Validation
- seize run test:no-coverage -- __tests__/components/delegation/html/delegationContent.test.ts __tests__/components/delegation/html/DelegationHTML.test.tsx
- codex-diff-check -- content/delegation/manifest.json public/delegation-content/delegation-docs-2026-06-16/manifest.json __tests__/components/delegation/html/delegationContent.test.ts
- CloudFront browser-UA HEAD returned 200 for the package manifest/article