### PR TITLE
Polish boosted post cards

### DIFF
--- a/__tests__/components/drops/view/DropsList.test.tsx
+++ b/__tests__/components/drops/view/DropsList.test.tsx
@@ -273,14 +273,8 @@ describe("DropsList", () => {
     const boostedCard = screen.getByTestId("boosted-card");
 
     expect(boostedCard.parentElement).toHaveClass(
-      "tw-rounded-2xl",
-      "tw-bg-iron-900/50",
-      "tw-p-2",
-      "sm:tw-p-3"
-    );
-    expect(boostedCard.parentElement?.parentElement).toHaveClass(
       "tw-px-3",
-      "tw-py-4",
+      "tw-py-3",
       "sm:tw-px-4"
     );
   });

--- a/__tests__/components/home/boosted/BoostedDropCardHome.test.tsx
+++ b/__tests__/components/home/boosted/BoostedDropCardHome.test.tsx
@@ -1,12 +1,6 @@
 import BoostedDropCardHome from "@/components/home/boosted/BoostedDropCardHome";
 import { AuthContext } from "@/components/auth/Auth";
-import {
-  act,
-  createEvent,
-  fireEvent,
-  render,
-  screen,
-} from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import {
   createElement,
   type ImgHTMLAttributes,
@@ -198,24 +192,6 @@ const getBoostPill = (): HTMLElement => {
   return pill as HTMLElement;
 };
 
-const getBoostedCard = (): HTMLElement => {
-  const card = screen.getByText("+2").closest('[role="button"]');
-
-  expect(card).not.toBeNull();
-
-  return card as HTMLElement;
-};
-
-const firePointerDown = (element: HTMLElement, pointerType: string) => {
-  const event = createEvent.pointerDown(element);
-
-  Object.defineProperty(event, "pointerType", {
-    value: pointerType,
-  });
-
-  fireEvent(element, event);
-};
-
 describe("BoostedDropCardHome", () => {
   beforeEach(() => {
     mockBoostedDropLinkPreview.mockClear();
@@ -243,7 +219,7 @@ describe("BoostedDropCardHome", () => {
     );
   });
 
-  it("hides chat header metadata and the wave pill", () => {
+  it("uses a quiet boosted header in the chat variant", () => {
     renderWithAuth(
       <BoostedDropCardHome
         drop={createDrop()}
@@ -256,10 +232,14 @@ describe("BoostedDropCardHome", () => {
     expect(screen.queryByText("#2")).not.toBeInTheDocument();
     expect(screen.queryByText("1m")).not.toBeInTheDocument();
     expect(screen.queryByText("Spec Wave")).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Boost" })).toBeInTheDocument();
+    expect(screen.getByText("Boosted post")).toBeInTheDocument();
+    expect(screen.getByText("7 boosts")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Boost post by alice" })
+    ).toBeInTheDocument();
   });
 
-  it("adds chat-only hover fade classes to the boost pill", () => {
+  it("keeps the chat boost metadata out of the old overlay fade treatment", () => {
     renderWithAuth(
       <BoostedDropCardHome
         drop={createDrop()}
@@ -269,142 +249,23 @@ describe("BoostedDropCardHome", () => {
       />
     );
 
-    expect(getBoostPill()).toHaveClass(
+    expect(screen.getByText("7 boosts")).not.toHaveClass(
       "desktop-hover:group-hover:tw-opacity-0",
-      "tw-transition-opacity",
-      "tw-duration-150",
+      "tw-opacity-0",
       "tw-pointer-events-none"
     );
   });
 
-  it("temporarily hides the chat boost pill on touch pointer press", () => {
-    jest.useFakeTimers();
-    const view = renderWithAuth(
-      <BoostedDropCardHome
-        drop={createDrop()}
-        onClick={jest.fn()}
-        variant="chat"
-        rank={2}
-      />
-    );
-
-    try {
-      const pill = getBoostPill();
-
-      expect(pill).not.toHaveClass("tw-opacity-0");
-
-      firePointerDown(getBoostedCard(), "touch");
-
-      expect(pill).toHaveClass("tw-opacity-0");
-
-      act(() => {
-        jest.advanceTimersByTime(2999);
-      });
-
-      expect(pill).toHaveClass("tw-opacity-0");
-
-      act(() => {
-        jest.advanceTimersByTime(1);
-      });
-
-      expect(pill).not.toHaveClass("tw-opacity-0");
-    } finally {
-      view.unmount();
-      jest.useRealTimers();
-    }
-  });
-
-  it("uses touch start as a fallback to hide the chat boost pill", () => {
-    jest.useFakeTimers();
-    const view = renderWithAuth(
-      <BoostedDropCardHome
-        drop={createDrop()}
-        onClick={jest.fn()}
-        variant="chat"
-        rank={2}
-      />
-    );
-
-    try {
-      const pill = getBoostPill();
-
-      fireEvent.touchStart(getBoostedCard());
-
-      expect(pill).toHaveClass("tw-opacity-0");
-
-      act(() => {
-        jest.advanceTimersByTime(3000);
-      });
-
-      expect(pill).not.toHaveClass("tw-opacity-0");
-    } finally {
-      view.unmount();
-      jest.useRealTimers();
-    }
-  });
-
-  it("does not hide the chat boost pill on mouse pointer press", () => {
-    renderWithAuth(
-      <BoostedDropCardHome
-        drop={createDrop()}
-        onClick={jest.fn()}
-        variant="chat"
-        rank={2}
-      />
-    );
-
-    const pill = getBoostPill();
-
-    firePointerDown(getBoostedCard(), "mouse");
-
-    expect(pill).not.toHaveClass("tw-opacity-0");
-  });
-
-  it("keeps the outer card click after touch pointer press", () => {
-    jest.useFakeTimers();
-    const onClick = jest.fn();
-
-    const view = renderWithAuth(
-      <BoostedDropCardHome
-        drop={createDrop()}
-        onClick={onClick}
-        variant="chat"
-        rank={2}
-      />
-    );
-
-    try {
-      const card = getBoostedCard();
-
-      firePointerDown(card, "touch");
-      fireEvent.click(card);
-
-      expect(onClick).toHaveBeenCalledTimes(1);
-    } finally {
-      view.unmount();
-      jest.useRealTimers();
-    }
-  });
-
-  it("does not add chat-only hide behavior to the home variant", () => {
+  it("does not add chat-only boosted metadata to the home variant", () => {
     renderWithAuth(
       <BoostedDropCardHome drop={createDrop()} onClick={jest.fn()} />
     );
 
     const pill = getBoostPill();
 
-    for (const className of [
-      "desktop-hover:group-hover:tw-opacity-0",
-      "tw-pointer-events-none",
-      "tw-transition-opacity",
-      "tw-duration-150",
-    ]) {
-      expect(pill).not.toHaveClass(className);
-    }
-
-    firePointerDown(getBoostedCard(), "touch");
-
-    expect(pill).not.toHaveClass("tw-opacity-0");
+    expect(screen.queryByText("Boosted post")).not.toBeInTheDocument();
+    expect(screen.queryByText("7 boosts")).not.toBeInTheDocument();
+    expect(pill).toBeInTheDocument();
   });
 
   it("uses a capped auto-height text frame in the chat variant", () => {
@@ -498,7 +359,7 @@ describe("BoostedDropCardHome", () => {
     );
   });
 
-  it("reuses the homepage preview variant for standalone urls in chat boosted cards", () => {
+  it("uses the compact chat preview variant for standalone urls in chat boosted cards", () => {
     renderWithAuth(
       <BoostedDropCardHome
         drop={createDrop({
@@ -518,12 +379,14 @@ describe("BoostedDropCardHome", () => {
     expect(mockBoostedDropLinkPreview).toHaveBeenLastCalledWith(
       expect.objectContaining({
         href: "https://example.com/article",
-        variant: "home",
+        variant: "chat",
       })
     );
 
     expect(screen.getByTestId("boosted-drop-content-frame")).toHaveClass(
-      "tw-max-h-[11rem]"
+      "tw-max-h-[15rem]",
+      "tw-bg-black/20",
+      "tw-p-3"
     );
     expect(screen.getByTestId("boosted-drop-content-frame")).not.toHaveClass(
       "tw-aspect-[2/1]"
@@ -548,7 +411,7 @@ describe("BoostedDropCardHome", () => {
     );
 
     expect(screen.getByTestId("boosted-drop-content-frame")).toHaveClass(
-      "tw-max-h-[11rem]"
+      "tw-max-h-[15rem]"
     );
     expect(screen.getByTestId("boosted-drop-content-frame")).not.toHaveClass(
       "tw-aspect-[2/1]"
@@ -684,13 +547,15 @@ describe("BoostedDropCardHome", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Boost" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Boost post by alice" })
+    );
 
     expect(mockToggleBoost).toHaveBeenCalledTimes(1);
     expect(onClick).not.toHaveBeenCalled();
   });
 
-  it("does not trigger the outer card keyboard handler from the author link", () => {
+  it("opens the card from its explicit open control", () => {
     const onClick = jest.fn();
 
     renderWithAuth(
@@ -702,9 +567,24 @@ describe("BoostedDropCardHome", () => {
       />
     );
 
-    fireEvent.keyDown(screen.getByRole("link", { name: /alice/i }), {
-      key: "Enter",
-    });
+    fireEvent.click(screen.getByLabelText("Open boosted post from alice"));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not trigger the outer card click from the author link", () => {
+    const onClick = jest.fn();
+
+    renderWithAuth(
+      <BoostedDropCardHome
+        drop={createDrop()}
+        onClick={onClick}
+        variant="chat"
+        rank={1}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: /alice/i }));
 
     expect(onClick).not.toHaveBeenCalled();
   });

--- a/__tests__/components/waves/LinkPreviewCard.test.tsx
+++ b/__tests__/components/waves/LinkPreviewCard.test.tsx
@@ -31,6 +31,11 @@ jest.mock("@/components/waves/ens/EnsPreviewCard", () => ({
   default: (props: any) => mockEnsPreviewCard(props),
 }));
 
+jest.mock("@/components/waves/ChatItemHrefButtons", () => ({
+  __esModule: true,
+  default: () => <div data-testid="href-buttons" />,
+}));
+
 jest.mock("@/services/api/link-preview-api", () => ({
   fetchLinkPreview: jest.fn(),
 }));
@@ -47,6 +52,14 @@ describe("LinkPreviewCard", () => {
       "md:tw-min-h-[11rem]",
       "md:tw-max-h-[11rem]"
     );
+    return frame;
+  };
+  const assertFallbackFrame = () => {
+    const frame = screen.getByTestId("link-preview-card-stable-frame");
+    expect(frame).toHaveClass("tw-min-h-[4.5rem]", "tw-w-full");
+    expect(frame.className).not.toContain("tw-h-[10rem]");
+    expect(frame.className).not.toContain("tw-max-h-[10rem]");
+    expect(frame.className).not.toContain("md:tw-h-[11rem]");
     return frame;
   };
   const assertFirstPartyFrame = () => {
@@ -117,7 +130,7 @@ describe("LinkPreviewCard", () => {
     await waitFor(() => {
       expect(screen.getByTestId("fallback")).toBeInTheDocument();
     });
-    assertStableFrame();
+    assertFallbackFrame();
   });
 
   it("renders fallback when request fails", async () => {
@@ -133,7 +146,25 @@ describe("LinkPreviewCard", () => {
     await waitFor(() => {
       expect(screen.getByTestId("fallback")).toBeInTheDocument();
     });
-    assertStableFrame();
+    assertFallbackFrame();
+  });
+
+  it("hides link actions in fallback state when requested", async () => {
+    fetchLinkPreview.mockRejectedValue(new Error("network"));
+
+    render(
+      <LinkPreviewCard
+        hideActions
+        href="https://example.com/article"
+        renderFallback={() => <div data-testid="fallback">fallback</div>}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("fallback")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("href-buttons")).toBeNull();
   });
 
   it("uses the richer chat frame for generated first-party previews", async () => {

--- a/components/common/icons/BoostIcon.tsx
+++ b/components/common/icons/BoostIcon.tsx
@@ -1,4 +1,6 @@
-interface BoostIconProps {
+import type { SVGProps } from "react";
+
+interface BoostIconProps extends Omit<SVGProps<SVGSVGElement>, "className"> {
   readonly className?: string;
   /**
    * - "filled": Solid flame (for boosted state)
@@ -8,7 +10,11 @@ interface BoostIconProps {
   readonly variant?: "filled" | "outlined" | "animated";
 }
 
-const BoostIcon = ({ className, variant = "filled" }: BoostIconProps) => {
+const BoostIcon = ({
+  className,
+  variant = "filled",
+  ...props
+}: BoostIconProps) => {
   const isFilled = variant === "filled" || variant === "animated";
 
   return (
@@ -19,6 +25,7 @@ const BoostIcon = ({ className, variant = "filled" }: BoostIconProps) => {
       stroke="currentColor"
       strokeWidth={isFilled ? 0 : 1.5}
       xmlns="http://www.w3.org/2000/svg"
+      {...props}
     >
       <path
         d="M12 23C16.1421 23 19.5 19.6421 19.5 15.5C19.5 14.1685 19.1755 12.9177 18.6062 11.8214C17.7863 13.0488 16.5 13.5 15.5 13C15.5 11 14.5 8 12 5.5C11 8 10.5 9.5 9 11C8.11281 11.8872 7.5 13.1287 7.5 14.5C7.5 15.5 8 17 9 18C8 17.5 7 16.5 6.5 15C5.83333 16 5 17.5 5 19C5 20.5 5.5 21.5 6.5 22.5C8 21 8.5 20 8.5 19C8.5 20.5 9.5 22 11 23H12Z"

--- a/components/drops/view/DropsList.tsx
+++ b/components/drops/view/DropsList.tsx
@@ -200,16 +200,14 @@ const DropsList = memo(
         return (
           <div
             key={`boost-card-${boostedIndex}-${boostedDrop.id}`}
-            className="tw-px-3 tw-py-4 sm:tw-px-4"
+            className="tw-px-3 tw-py-3 sm:tw-px-4"
           >
-            <div className="tw-rounded-2xl tw-bg-iron-900/50 tw-p-2 sm:tw-p-3">
-              <BoostedDropCardHome
-                drop={boostedDrop}
-                variant="chat"
-                rank={boostedIndex + 1}
-                onClick={() => onBoostedDropClick(boostedDrop.serial_no)}
-              />
-            </div>
+            <BoostedDropCardHome
+              drop={boostedDrop}
+              variant="chat"
+              rank={boostedIndex + 1}
+              onClick={() => onBoostedDropClick(boostedDrop.serial_no)}
+            />
           </div>
         );
       },

--- a/components/home/boosted/BoostedDropCardHome.tsx
+++ b/components/home/boosted/BoostedDropCardHome.tsx
@@ -11,19 +11,17 @@ import { getScaledImageUri, ImageScale } from "@/helpers/image.helpers";
 import { getWaveRoute } from "@/helpers/navigation.helpers";
 import { convertApiDropToExtendedDrop } from "@/helpers/waves/drop.helpers";
 import { useDropBoostMutation } from "@/hooks/drops/useDropBoostMutation";
+import { formatInteger } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import Image from "next/image";
 import Link from "next/link";
 import {
   memo,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
-  useRef,
-  useState,
-  type KeyboardEvent as ReactKeyboardEvent,
   type MouseEvent as ReactMouseEvent,
-  type PointerEvent as ReactPointerEvent,
 } from "react";
 import BoostedDropCardHomeContent from "./BoostedDropCardHomeContent";
 
@@ -37,13 +35,17 @@ interface BoostedDropCardHomeProps {
 }
 
 const MAX_FIRE_ICONS = 5;
-const BOOST_HEADER_HIDE_MS = 3000;
-const CARD_CLASSES =
-  "tw-group tw-relative tw-flex tw-w-full tw-cursor-pointer tw-flex-col tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-black/70 tw-p-0 tw-text-left tw-transition-all tw-duration-500 tw-ease-out hover:-tw-translate-y-1.5 hover:tw-shadow-[0_0_32px_-10px_rgba(255,255,255,0.12)]";
+const HOME_CARD_CLASSES =
+  "tw-group tw-relative tw-flex tw-w-full tw-flex-col tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-black/70 tw-p-0 tw-text-left tw-transition-all tw-duration-500 tw-ease-out hover:-tw-translate-y-1.5 hover:tw-shadow-[0_0_32px_-10px_rgba(255,255,255,0.12)]";
+const CHAT_CARD_CLASSES =
+  "tw-group tw-relative tw-flex tw-w-full tw-flex-col tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-iron-800/80 tw-bg-iron-950/95 tw-p-0 tw-text-left tw-shadow-[0_14px_36px_-28px_rgba(0,0,0,0.85)] tw-transition-colors tw-duration-300 tw-ease-out hover:tw-border-iron-700 hover:tw-bg-iron-950";
+const CLICKABLE_CARD_CLASS = "tw-cursor-pointer";
 const CARD_BORDER_CLASSES =
   "tw-pointer-events-none tw-absolute tw-inset-0 tw-z-20 tw-rounded-xl tw-border tw-border-solid tw-border-white/5";
 const HEADER_CLASSES =
   "tw-absolute tw-left-3 tw-right-3 tw-top-3 tw-z-30 tw-flex tw-flex-nowrap tw-items-center tw-justify-between tw-gap-2";
+const CHAT_HEADER_CLASSES =
+  "tw-relative tw-z-10 tw-flex tw-min-w-0 tw-items-center tw-justify-between tw-gap-3 tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-800/80 tw-bg-iron-950/90 tw-px-4 tw-py-2.5";
 const HEADER_LEFT_CLASSES =
   "tw-flex tw-min-w-0 tw-items-center tw-gap-2 tw-overflow-hidden";
 const PILL_CLASSES =
@@ -51,22 +53,42 @@ const PILL_CLASSES =
 const FOOTER_CLASSES =
   "tw-relative tw-z-10 tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-900 tw-bg-black/70 tw-px-4 tw-py-3";
 const AUTHOR_LINK_CLASSES =
-  "tw-flex tw-max-w-full tw-flex-wrap tw-items-center tw-gap-2 tw-no-underline tw-transition-opacity desktop-hover:hover:tw-opacity-80";
+  "tw-flex tw-max-w-full tw-flex-wrap tw-items-center tw-gap-2 tw-rounded-md tw-no-underline tw-transition-opacity desktop-hover:hover:tw-opacity-80 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400";
 const WAVE_LINK_CLASSES =
-  "tw-group/wave tw-flex tw-max-w-full tw-flex-wrap tw-items-center tw-gap-2 tw-rounded-full tw-bg-white/5 tw-py-1 tw-pl-2.5 tw-pr-1 tw-no-underline tw-transition-all active:tw-scale-95 desktop-hover:hover:tw-bg-white/10";
+  "tw-group/wave tw-flex tw-max-w-full tw-flex-wrap tw-items-center tw-gap-2 tw-rounded-full tw-bg-white/5 tw-py-1 tw-pl-2.5 tw-pr-1 tw-no-underline tw-transition-all active:tw-scale-95 desktop-hover:hover:tw-bg-white/10 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400";
+const OPEN_DROP_BUTTON_CLASSES =
+  "tw-sr-only focus:tw-not-sr-only focus:tw-absolute focus:tw-left-3 focus:tw-top-3 focus:tw-z-40 focus:tw-rounded-md focus:tw-border focus:tw-border-solid focus:tw-border-primary-400 focus:tw-bg-iron-950 focus:tw-px-3 focus:tw-py-1.5 focus:tw-text-xs focus:tw-font-semibold focus:tw-text-iron-50 focus:tw-outline focus:tw-outline-2 focus:tw-outline-offset-2 focus:tw-outline-primary-400";
+const CARD_INTERACTIVE_TARGET_SELECTOR =
+  'a, button, input, select, textarea, summary, [role="button"], [role="link"], [contenteditable="true"]';
 
-const useCardKeyDown = (onClick?: () => void) =>
+const getBoostLabel = (boosts: number): string =>
+  t(
+    DEFAULT_LOCALE,
+    boosts === 1
+      ? "home.boostedDrop.boostCount.one"
+      : "home.boostedDrop.boostCount.many",
+    { count: formatInteger(DEFAULT_LOCALE, boosts) }
+  );
+
+const getAuthorLabel = (handle: string | null | undefined): string =>
+  handle?.trim() || t(DEFAULT_LOCALE, "home.boostedDrop.anonymousAuthor");
+
+const getOpenDropLabel = (authorHandle: string | null | undefined): string =>
+  t(DEFAULT_LOCALE, "home.boostedDrop.openDrop", {
+    author: getAuthorLabel(authorHandle),
+  });
+
+const isInteractiveEventTarget = (target: EventTarget | null): boolean =>
+  target instanceof Element &&
+  Boolean(target.closest(CARD_INTERACTIVE_TARGET_SELECTOR));
+
+const useCardClick = (onClick?: () => void) =>
   useCallback(
-    (event: ReactKeyboardEvent<HTMLDivElement>) => {
-      if (
-        !onClick ||
-        event.target !== event.currentTarget ||
-        (event.key !== "Enter" && event.key !== " ")
-      ) {
+    (event: ReactMouseEvent<HTMLElement>) => {
+      if (!onClick || isInteractiveEventTarget(event.target)) {
         return;
       }
 
-      event.preventDefault();
       onClick();
     },
     [onClick]
@@ -84,7 +106,9 @@ const BoostedDropCardChatBoostButton = memo(
 
     const isBoosted = drop.context_profile_context?.boosted ?? false;
     const canBoost = !!connectedProfile && !drop.id.startsWith("temp-");
-    const chatBoostButtonLabel = isBoosted ? "Boosted" : "Boost";
+    const chatBoostButtonLabel = isBoosted
+      ? t(DEFAULT_LOCALE, "home.boostedDrop.boosted")
+      : t(DEFAULT_LOCALE, "home.boostedDrop.boost");
 
     const handleBoostClick = useCallback(
       (event: ReactMouseEvent<HTMLButtonElement>) => {
@@ -107,17 +131,29 @@ const BoostedDropCardChatBoostButton = memo(
           }
         }}
         disabled={!canBoost || isPending}
-        className={`tw-flex tw-flex-shrink-0 tw-items-center tw-gap-1.5 tw-rounded-full tw-border tw-border-solid tw-px-3 tw-py-1.5 tw-text-xs tw-font-semibold tw-transition-colors ${
+        className={`tw-flex tw-flex-shrink-0 tw-items-center tw-gap-1.5 tw-rounded-full tw-border tw-border-solid tw-px-3 tw-py-1 tw-text-[11px] tw-font-semibold tw-leading-5 tw-transition-colors focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 ${
           canBoost
-            ? "tw-cursor-pointer tw-border-amber-500/20 tw-bg-amber-600/10 hover:tw-bg-amber-600/20"
-            : "tw-cursor-default tw-border-white/10 tw-bg-white/5 tw-text-iron-500"
+            ? "tw-cursor-pointer tw-border-iron-700 tw-bg-iron-900/70 tw-text-iron-300 hover:tw-border-amber-500/40 hover:tw-bg-amber-500/10 hover:tw-text-amber-100"
+            : "tw-cursor-default tw-border-iron-800 tw-bg-iron-900/50 tw-text-iron-600"
         } ${
-          isBoosted && canBoost ? "tw-bg-amber-600/20 tw-text-amber-200" : ""
+          isBoosted && canBoost
+            ? "tw-border-amber-500/40 tw-bg-amber-500/15 tw-text-amber-100"
+            : ""
         }`}
-        aria-label={isBoosted ? "Remove boost" : "Boost"}
+        aria-label={
+          isBoosted
+            ? t(DEFAULT_LOCALE, "home.boostedDrop.removeBoostFromDrop", {
+                author: getAuthorLabel(drop.author.handle),
+              })
+            : t(DEFAULT_LOCALE, "home.boostedDrop.boostDrop", {
+                author: getAuthorLabel(drop.author.handle),
+              })
+        }
       >
         <BoostIcon
+          aria-hidden="true"
           className="tw-size-3.5 tw-flex-shrink-0 tw-text-amber-400"
+          focusable="false"
           variant={isBoosted ? "filled" : "outlined"}
         />
         <span>{chatBoostButtonLabel}</span>
@@ -132,47 +168,58 @@ const BoostedDropCardHeader = memo(
   ({
     createdAt,
     fireIconsToShow,
-    isBoostHeaderHidden,
     isChatVariant,
     remainingBoosts,
+    totalBoosts,
   }: {
     readonly createdAt: ApiDrop["created_at"];
     readonly fireIconsToShow: number;
-    readonly isBoostHeaderHidden: boolean;
     readonly isChatVariant: boolean;
     readonly remainingBoosts: number;
+    readonly totalBoosts: number;
   }) => {
-    let chatHeaderClasses = "";
-    let chatBoostPillClasses = "";
-
     if (isChatVariant) {
-      chatHeaderClasses = "tw-pointer-events-none tw-justify-end";
-      chatBoostPillClasses =
-        "tw-pointer-events-none tw-transition-opacity tw-duration-150 desktop-hover:group-hover:tw-opacity-0";
-    }
-
-    if (isChatVariant && isBoostHeaderHidden) {
-      chatBoostPillClasses = `${chatBoostPillClasses} tw-opacity-0`;
+      return (
+        <div className={CHAT_HEADER_CLASSES}>
+          <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
+            <span className="tw-flex tw-size-6 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-border tw-border-solid tw-border-amber-500/20 tw-bg-amber-500/10">
+              <BoostIcon
+                aria-hidden="true"
+                className="tw-size-3.5 tw-text-amber-300"
+                focusable="false"
+                variant="filled"
+              />
+            </span>
+            <span className="tw-truncate tw-text-[11px] tw-font-semibold tw-uppercase tw-leading-5 tw-tracking-wide tw-text-iron-300">
+              {t(DEFAULT_LOCALE, "home.boostedDrop.badge")}
+            </span>
+          </div>
+          <span className="tw-flex tw-flex-shrink-0 tw-items-center tw-rounded-full tw-border tw-border-solid tw-border-iron-800 tw-bg-black/30 tw-px-2 tw-py-1 tw-text-[11px] tw-font-medium tw-leading-4 tw-text-iron-400">
+            {getBoostLabel(totalBoosts)}
+          </span>
+        </div>
+      );
     }
 
     return (
-      <div className={`${HEADER_CLASSES} ${chatHeaderClasses}`}>
-        {!isChatVariant && (
-          <div className={HEADER_LEFT_CLASSES}>
-            <div className={PILL_CLASSES}>
-              <span className="tw-text-[10px] tw-font-semibold tw-leading-4 tw-tracking-wide tw-text-iron-300">
-                {getTimeAgoShort(createdAt)}
-              </span>
-            </div>
+      <div className={HEADER_CLASSES}>
+        <div className={HEADER_LEFT_CLASSES}>
+          <div className={PILL_CLASSES}>
+            <span className="tw-text-[10px] tw-font-semibold tw-leading-4 tw-tracking-wide tw-text-iron-300">
+              {getTimeAgoShort(createdAt)}
+            </span>
           </div>
-        )}
+        </div>
         <div
-          className={`${PILL_CLASSES} tw-gap-0.5 sm:tw-ml-auto ${chatBoostPillClasses}`}
+          className={`${PILL_CLASSES} tw-gap-0.5 sm:tw-ml-auto`}
+          aria-label={getBoostLabel(totalBoosts)}
         >
           {Array.from({ length: fireIconsToShow }).map((_, index) => (
             <BoostIcon
               key={index}
+              aria-hidden="true"
               className="tw-size-3 tw-flex-shrink-0 tw-text-orange-400 tw-drop-shadow-sm"
+              focusable="false"
               variant="filled"
             />
           ))}
@@ -210,14 +257,17 @@ const BoostedDropCardFooter = memo(
         href={author.handle ? `/${author.handle}` : "#"}
         onClick={(event) => event.stopPropagation()}
         className={AUTHOR_LINK_CLASSES}
+        aria-label={t(DEFAULT_LOCALE, "home.boostedDrop.viewAuthor", {
+          author: getAuthorLabel(author.handle),
+        })}
       >
         <ProfileAvatar
           pfpUrl={author.pfp}
-          alt={author.handle ?? "User"}
+          alt=""
           size={ProfileBadgeSize.SMALL}
         />
         <span className="tw-break-words tw-text-sm tw-font-medium tw-text-iron-50">
-          {author.handle ?? "Anonymous"}
+          {getAuthorLabel(author.handle)}
         </span>
       </Link>
 
@@ -235,7 +285,7 @@ const BoostedDropCardFooter = memo(
           {wavePicture && (
             <Image
               src={getScaledImageUri(wavePicture, ImageScale.W_AUTO_H_50)}
-              alt={waveName}
+              alt=""
               width={20}
               height={20}
               className="tw-size-5 tw-shrink-0 tw-rounded-full tw-object-cover tw-ring-1 tw-ring-white/10"
@@ -249,84 +299,66 @@ const BoostedDropCardFooter = memo(
 
 BoostedDropCardFooter.displayName = "BoostedDropCardFooter";
 
+const BoostedDropCardOpenButton = memo(
+  ({
+    label,
+    onClick,
+  }: {
+    readonly label: string;
+    readonly onClick?: (() => void) | undefined;
+  }) => {
+    if (!onClick) {
+      return null;
+    }
+
+    return (
+      <button
+        type="button"
+        className={OPEN_DROP_BUTTON_CLASSES}
+        onClick={(event) => {
+          event.stopPropagation();
+          onClick();
+        }}
+      >
+        {label}
+      </button>
+    );
+  }
+);
+
+BoostedDropCardOpenButton.displayName = "BoostedDropCardOpenButton";
+
 const BoostedDropCardHome = memo(
   ({ drop, onClick, variant = "home" }: BoostedDropCardHomeProps) => {
-    const [isBoostHeaderHidden, setIsBoostHeaderHidden] = useState(false);
-    const boostHeaderHideTimeoutRef = useRef<ReturnType<
-      typeof globalThis.setTimeout
-    > | null>(null);
     const part = drop.parts[0];
     const { author, wave, boosts } = drop;
     const fireIconsToShow = Math.min(boosts, MAX_FIRE_ICONS);
-    const remainingBoosts = boosts - MAX_FIRE_ICONS;
+    const remainingBoosts = Math.max(boosts - MAX_FIRE_ICONS, 0);
     const isChatVariant = variant === "chat";
-    const handleCardKeyDown = useCardKeyDown(onClick);
+    const handleCardClick = useCardClick(onClick);
+    const openDropLabel = getOpenDropLabel(author.handle);
     const waveHref = getWaveRoute({
       waveId: wave.id,
       isDirectMessage: false,
       isApp: false,
     });
 
-    const hideBoostHeaderTemporarily = useCallback(() => {
-      if (!isChatVariant) {
-        return;
-      }
-
-      setIsBoostHeaderHidden(true);
-
-      if (boostHeaderHideTimeoutRef.current) {
-        globalThis.clearTimeout(boostHeaderHideTimeoutRef.current);
-      }
-
-      boostHeaderHideTimeoutRef.current = globalThis.setTimeout(() => {
-        setIsBoostHeaderHidden(false);
-        boostHeaderHideTimeoutRef.current = null;
-      }, BOOST_HEADER_HIDE_MS);
-    }, [isChatVariant]);
-
-    const handleCardPointerDownCapture = useCallback(
-      (event: ReactPointerEvent<HTMLDivElement>) => {
-        if (event.pointerType !== "mouse") {
-          hideBoostHeaderTemporarily();
-        }
-      },
-      [hideBoostHeaderTemporarily]
-    );
-
-    const handleCardTouchStartCapture = useCallback(() => {
-      hideBoostHeaderTemporarily();
-    }, [hideBoostHeaderTemporarily]);
-
-    useEffect(
-      () => () => {
-        if (boostHeaderHideTimeoutRef.current) {
-          globalThis.clearTimeout(boostHeaderHideTimeoutRef.current);
-        }
-      },
-      []
-    );
-
     return (
-      <div
-        role="button"
-        tabIndex={0}
-        onClick={onClick}
-        onKeyDown={handleCardKeyDown}
-        onPointerDownCapture={
-          isChatVariant ? handleCardPointerDownCapture : undefined
-        }
-        onTouchStartCapture={
-          isChatVariant ? handleCardTouchStartCapture : undefined
-        }
-        className={CARD_CLASSES}
+      <article
+        aria-label={openDropLabel}
+        onClick={handleCardClick}
+        className={`${isChatVariant ? CHAT_CARD_CLASSES : HOME_CARD_CLASSES} ${
+          onClick ? CLICKABLE_CARD_CLASS : ""
+        }`}
       >
-        <div className={CARD_BORDER_CLASSES} />
+        <BoostedDropCardOpenButton label={openDropLabel} onClick={onClick} />
+        {!isChatVariant && <div className={CARD_BORDER_CLASSES} />}
         <BoostedDropCardHeader
           createdAt={drop.created_at}
           fireIconsToShow={fireIconsToShow}
-          isBoostHeaderHidden={isBoostHeaderHidden}
           isChatVariant={isChatVariant}
           remainingBoosts={remainingBoosts}
+          totalBoosts={boosts}
         />
         <BoostedDropCardHomeContent isChatVariant={isChatVariant} part={part} />
         <BoostedDropCardFooter
@@ -337,7 +369,7 @@ const BoostedDropCardHome = memo(
           waveName={wave.name}
           wavePicture={wave.picture}
         />
-      </div>
+      </article>
     );
   }
 );

--- a/components/home/boosted/BoostedDropCardHomeContent.tsx
+++ b/components/home/boosted/BoostedDropCardHomeContent.tsx
@@ -31,9 +31,10 @@ type OverflowElements = {
 
 const HOME_ASPECT_RATIO_CLASSES =
   "tw-aspect-[2/1] sm:tw-aspect-[5/4] md:tw-aspect-[8/5] lg:tw-aspect-[5/4] xl:tw-aspect-[8/5]";
-const CHAT_MAX_HEIGHT_CLASSES = "tw-max-h-[11rem] md:tw-max-h-[12rem]";
-const CHAT_PREVIEW_CONTAINER_CLASSES = `tw-relative tw-flex ${CHAT_MAX_HEIGHT_CLASSES} tw-w-full tw-flex-col tw-items-stretch tw-justify-stretch tw-gap-3 tw-overflow-hidden tw-rounded-xl`;
-const CHAT_TEXT_CONTAINER_CLASSES = `tw-relative tw-flex ${CHAT_MAX_HEIGHT_CLASSES} tw-w-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-xl tw-px-4 tw-py-4 sm:tw-px-6`;
+const CHAT_TEXT_MAX_HEIGHT_CLASSES = "tw-max-h-[11rem] md:tw-max-h-[12rem]";
+const CHAT_PREVIEW_MAX_HEIGHT_CLASSES = "tw-max-h-[15rem] md:tw-max-h-[16rem]";
+const CHAT_PREVIEW_CONTAINER_CLASSES = `tw-relative tw-flex ${CHAT_PREVIEW_MAX_HEIGHT_CLASSES} tw-w-full tw-flex-col tw-items-stretch tw-justify-stretch tw-gap-3 tw-overflow-hidden tw-bg-black/20 tw-p-3`;
+const CHAT_TEXT_CONTAINER_CLASSES = `tw-relative tw-flex ${CHAT_TEXT_MAX_HEIGHT_CLASSES} tw-w-full tw-items-center tw-justify-center tw-overflow-hidden tw-bg-black/20 tw-px-4 tw-py-5 sm:tw-px-6`;
 const HOME_PREVIEW_CONTAINER_CLASSES = `tw-relative tw-flex ${HOME_ASPECT_RATIO_CLASSES} tw-w-full tw-flex-col tw-items-stretch tw-justify-stretch tw-gap-3 tw-overflow-hidden tw-rounded-xl`;
 const HOME_TEXT_CONTAINER_CLASSES = `tw-relative tw-flex ${HOME_ASPECT_RATIO_CLASSES} tw-w-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-xl tw-px-6 tw-pb-6 sm:tw-pb-0 tw-pt-4 sm:tw-pt-16 md:tw-pt-12`;
 const CHAT_PREVIEW_WRAPPER_BASE_CLASSES =
@@ -45,13 +46,15 @@ const CHAT_TEXT_WRAPPER_CLASSES =
 const HOME_TEXT_WRAPPER_CLASSES =
   "tw-relative tw-z-10 tw-flex tw-h-full tw-w-full tw-min-w-0 tw-max-w-full tw-items-center tw-justify-center";
 const WITH_PREVIEW_CONTENT_CLASS_NAME =
-  "tw-flex tw-w-full tw-max-w-full tw-flex-col tw-items-start tw-gap-1 tw-break-words tw-px-3 tw-pb-3 sm:tw-px-4 sm:tw-pb-4 tw-tracking-[0.01em] tw-font-normal tw-text-iron-300";
+  "tw-flex tw-w-full tw-max-w-full tw-flex-col tw-items-start tw-gap-1 tw-break-words tw-px-3 tw-pb-3 tw-text-left sm:tw-px-4 sm:tw-pb-4 tw-tracking-[0.01em] tw-font-normal tw-text-iron-300";
+const CHAT_WITH_PREVIEW_CONTENT_CLASS_NAME =
+  "tw-flex tw-w-full tw-max-w-full tw-flex-col tw-items-start tw-gap-1 tw-break-words tw-px-3 tw-pb-3 tw-text-left tw-tracking-[0.01em] tw-font-normal tw-text-iron-400";
 const HOME_TEXT_CONTENT_CLASS_NAME =
   "tw-flex tw-w-fit tw-max-w-full tw-flex-col tw-items-start tw-gap-1 tw-break-words tw-tracking-[0.01em] tw-font-normal tw-text-iron-300";
 const WITH_PREVIEW_TEXT_CLAMP_CLASS = "tw-line-clamp-2 sm:tw-line-clamp-3";
 const WITHOUT_PREVIEW_TEXT_CLAMP_CLASS = "tw-line-clamp-6";
 const CONTENT_TEXT_BASE_CLASSES =
-  "tw-max-w-full tw-break-words tw-tracking-[0.01em] tw-font-normal";
+  "tw-block tw-w-full tw-max-w-full tw-break-words tw-text-left tw-tracking-[0.01em] tw-font-normal";
 const MAX_OVERFLOW_MEASUREMENT_ATTEMPTS = 12;
 const OVERFLOW_MEASUREMENT_INTERVAL_MS = 200;
 
@@ -109,11 +112,15 @@ const getContentWrapperClasses = ({
 
 const getContentClassName = ({
   hasPreview,
+  isChatVariant,
 }: {
   readonly hasPreview: boolean;
+  readonly isChatVariant: boolean;
 }): string => {
   if (hasPreview) {
-    return WITH_PREVIEW_CONTENT_CLASS_NAME;
+    return isChatVariant
+      ? CHAT_WITH_PREVIEW_CONTENT_CLASS_NAME
+      : WITH_PREVIEW_CONTENT_CLASS_NAME;
   }
 
   return HOME_TEXT_CONTENT_CLASS_NAME;
@@ -371,7 +378,7 @@ const BoostedDropCardHomeMedia = memo(
   }) => (
     <div
       data-testid="boosted-drop-media-frame"
-      className={`tw-relative ${HOME_ASPECT_RATIO_CLASSES} ${isChatVariant ? CHAT_MAX_HEIGHT_CLASSES : ""} tw-w-full tw-overflow-hidden tw-rounded-xl`}
+      className={`tw-relative ${HOME_ASPECT_RATIO_CLASSES} ${isChatVariant ? CHAT_TEXT_MAX_HEIGHT_CLASSES : ""} tw-w-full tw-overflow-hidden tw-rounded-xl`}
     >
       <div className="tw-relative tw-h-full tw-w-full">
         <div className="tw-relative tw-z-0 tw-flex tw-h-full tw-w-full tw-items-center tw-justify-center tw-rounded-xl tw-transition-transform tw-duration-700 group-hover:tw-scale-[1.02]">
@@ -423,9 +430,14 @@ const BoostedDropCardTextSection = memo(
       hasTextContent,
       isChatVariant,
     });
-    const contentClassName = getContentClassName({ hasPreview });
+    const contentClassName = getContentClassName({
+      hasPreview,
+      isChatVariant,
+    });
     const contentTextClassName = getContentTextClassName(hasPreview);
-    const previewWrapperClassName = "tw-min-h-0 tw-overflow-hidden";
+    const previewWrapperClassName = isChatVariant
+      ? "tw-min-h-0 tw-overflow-hidden tw-rounded-lg"
+      : "tw-min-h-0 tw-overflow-hidden";
 
     return (
       <div
@@ -436,7 +448,10 @@ const BoostedDropCardTextSection = memo(
         <div className={contentWrapperClasses} ref={contentWrapperRef}>
           {previewUrl && (
             <div className={previewWrapperClassName} ref={previewRef}>
-              <BoostedDropLinkPreview href={previewUrl} variant="home" />
+              <BoostedDropLinkPreview
+                href={previewUrl}
+                variant={isChatVariant ? "chat" : "home"}
+              />
             </div>
           )}
           {shouldMeasureOverflow && previewUrl && hasTextContent && (

--- a/components/home/boosted/BoostedDropLinkPreview.tsx
+++ b/components/home/boosted/BoostedDropLinkPreview.tsx
@@ -1,19 +1,56 @@
 "use client";
 
-import type { SyntheticEvent } from "react";
-
 import { ensureTwitterLink } from "@/components/drops/view/part/dropPartMarkdown/twitter";
 import SmartLinkPreview from "@/components/waves/SmartLinkPreview";
 import TwitterPreviewCard from "@/components/waves/TwitterPreviewCard";
 import type { LinkPreviewVariant } from "@/components/waves/LinkPreviewContext";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 
-const getFallbackLabel = (href: string): string => {
+const KNOWN_INTERNAL_LINK_TITLES: Record<string, string> = {
+  "/network/wavescore": "Network: Wave Score",
+};
+
+const titleCaseSegment = (segment: string): string =>
+  segment
+    .replace(/[-_]+/g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .replace(/\bwavescore\b/i, "wave score")
+    .trim()
+    .split(/\s+/)
+    .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+    .join(" ");
+
+const getFallbackPreview = ({
+  href,
+}: {
+  readonly href: string;
+}): {
+  readonly isInternal6529: boolean;
+  readonly source: string;
+  readonly title: string;
+} => {
   try {
     const url = new URL(href);
     const host = url.hostname.replace(/^www\./i, "");
-    return host || href;
+    const source = host || href;
+    const isInternal6529 = source === "6529.io" || source.endsWith(".6529.io");
+    const knownTitle = KNOWN_INTERNAL_LINK_TITLES[url.pathname.toLowerCase()];
+
+    if (knownTitle) {
+      return { isInternal6529, source, title: knownTitle };
+    }
+
+    const pathTitle = url.pathname
+      .split("/")
+      .filter(Boolean)
+      .map(titleCaseSegment)
+      .filter(Boolean)
+      .join(" / ");
+
+    return { isInternal6529, source, title: pathTitle || source };
   } catch {
-    return href;
+    return { isInternal6529: false, source: href, title: href };
   }
 };
 
@@ -25,10 +62,16 @@ const getTwitterPayload = (href: string) => {
   }
 };
 
-const stopPropagation = (event: SyntheticEvent) => {
-  event.stopPropagation();
-  event.nativeEvent.stopImmediatePropagation();
-};
+const getFallbackSourceLabel = ({
+  isInternal6529,
+  source,
+}: {
+  readonly isInternal6529: boolean;
+  readonly source: string;
+}): string =>
+  isInternal6529
+    ? t(DEFAULT_LOCALE, "home.boostedDrop.internalLinkSource", { source })
+    : source;
 
 export default function BoostedDropLinkPreview({
   href,
@@ -41,40 +84,46 @@ export default function BoostedDropLinkPreview({
   if (twitterPayload) {
     const { tweetId, href: normalizedHref } = twitterPayload;
     return (
-      <div
-        className="tw-h-full tw-w-full tw-min-w-0 tw-max-w-full"
-        onClick={stopPropagation}
-        onMouseDown={stopPropagation}
-        onPointerDown={stopPropagation}
-        onTouchStart={stopPropagation}
-      >
+      <div className="tw-h-full tw-w-full tw-min-w-0 tw-max-w-full">
         <TwitterPreviewCard href={normalizedHref} tweetId={tweetId} />
       </div>
     );
   }
 
   return (
-    <div
-      className="tw-h-full tw-w-full tw-min-w-0 tw-max-w-full"
-      onClick={stopPropagation}
-      onMouseDown={stopPropagation}
-      onPointerDown={stopPropagation}
-      onTouchStart={stopPropagation}
-    >
+    <div className="tw-h-full tw-w-full tw-min-w-0 tw-max-w-full">
       <SmartLinkPreview
+        hideActions
         href={href}
         variant={variant}
-        renderFallback={() => (
-          <a
-            href={href}
-            target="_blank"
-            rel="noopener noreferrer nofollow"
-            onClick={(e) => e.stopPropagation()}
-            className="tw-[overflow-wrap:anywhere] tw-break-words tw-text-sm tw-font-semibold tw-text-iron-100 tw-no-underline tw-transition tw-duration-200 hover:tw-text-white"
-          >
-            {getFallbackLabel(href)}
-          </a>
-        )}
+        renderFallback={() => {
+          const fallback = getFallbackPreview({ href });
+          const sourceLabel = getFallbackSourceLabel(fallback);
+
+          return (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer nofollow"
+              onClick={(e) => e.stopPropagation()}
+              className="tw-[overflow-wrap:anywhere] tw-flex tw-h-full tw-min-h-[4.5rem] tw-w-full tw-flex-col tw-justify-center tw-gap-1.5 tw-rounded-lg tw-bg-iron-900/35 tw-px-3 tw-py-2.5 tw-text-left tw-no-underline tw-shadow-[inset_2px_0_0_rgba(245,158,11,0.34)] tw-transition tw-duration-200 hover:tw-bg-iron-900/60 hover:tw-text-white focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400"
+            >
+              <span className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
+                {fallback.isInternal6529 && (
+                  <span className="tw-flex tw-size-5 tw-flex-shrink-0 tw--translate-y-px tw-items-center tw-justify-center tw-rounded-md tw-border tw-border-solid tw-border-amber-400/15 tw-bg-amber-400/10 tw-text-[8px] tw-font-bold tw-leading-none tw-text-amber-200">
+                    6529
+                  </span>
+                )}
+                <span className="tw-line-clamp-1 tw-text-[11px] tw-font-semibold tw-uppercase tw-leading-4 tw-tracking-wide tw-text-iron-500">
+                  {sourceLabel}
+                </span>
+              </span>
+              <span className="tw-line-clamp-2 tw-text-sm tw-font-semibold tw-leading-5 tw-text-iron-100">
+                {fallback.title}
+              </span>
+            </a>
+          );
+        }}
       />
     </div>
   );

--- a/components/waves/LinkPreviewCard.tsx
+++ b/components/waves/LinkPreviewCard.tsx
@@ -18,6 +18,7 @@ import {
 
 interface LinkPreviewCardProps {
   readonly href: string;
+  readonly hideActions?: boolean | undefined;
   readonly renderFallback: () => ReactElement;
   readonly variant?: LinkPreviewVariant | undefined;
 }
@@ -34,6 +35,7 @@ type PreviewState =
 
 const CHAT_STABLE_FRAME_CLASSES =
   "tw-h-[10rem] tw-min-h-[10rem] tw-max-h-[10rem] tw-w-full md:tw-h-[11rem] md:tw-min-h-[11rem] md:tw-max-h-[11rem]";
+const CHAT_FALLBACK_FRAME_CLASSES = "tw-min-h-[4.5rem] tw-w-full";
 const CHAT_FIRST_PARTY_FRAME_CLASSES =
   "tw-h-[15rem] tw-min-h-[15rem] tw-max-h-[15rem] tw-w-full lg:tw-h-[11rem] lg:tw-min-h-[11rem] lg:tw-max-h-[11rem]";
 const CHAT_COLLECTION_FRAME_CLASSES =
@@ -62,6 +64,7 @@ const toPreviewData = (
 };
 
 export default function LinkPreviewCard({
+  hideActions = false,
   href,
   renderFallback,
   variant,
@@ -113,12 +116,16 @@ export default function LinkPreviewCard({
   if (isCurrent && state.type === "fallback") {
     const fallbackContent = renderFallback();
     content = (
-      <LinkPreviewCardLayout href={href} variant={resolvedVariant}>
+      <LinkPreviewCardLayout
+        href={href}
+        hideActions={hideActions}
+        variant={resolvedVariant}
+      >
         <div
           className={
             resolvedVariant === "home"
               ? "tw-relative tw-h-full tw-w-full tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-black/30 tw-p-4"
-              : "tw-h-full tw-min-h-0 tw-w-full tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/40 tw-p-4"
+              : "tw-h-full tw-min-h-0 tw-w-full tw-overflow-hidden tw-rounded-lg tw-bg-transparent"
           }
         >
           <div className="tw-[overflow-wrap:anywhere] tw-flex tw-h-full tw-min-h-0 tw-w-full tw-max-w-full tw-items-center tw-justify-start tw-overflow-y-auto tw-break-words">
@@ -130,6 +137,7 @@ export default function LinkPreviewCard({
   } else if (isCurrent && state.type === "success") {
     content = (
       <OpenGraphPreview
+        hideActions={hideActions}
         href={href}
         preview={state.data}
         variant={resolvedVariant}
@@ -137,7 +145,11 @@ export default function LinkPreviewCard({
     );
   } else if (isCurrent && state.type === "ens") {
     content = (
-      <LinkPreviewCardLayout href={href} variant={resolvedVariant}>
+      <LinkPreviewCardLayout
+        href={href}
+        hideActions={hideActions}
+        variant={resolvedVariant}
+      >
         <div
           className={
             resolvedVariant === "home"
@@ -154,6 +166,7 @@ export default function LinkPreviewCard({
   } else {
     content = (
       <OpenGraphPreview
+        hideActions={hideActions}
         href={href}
         preview={undefined}
         variant={resolvedVariant}
@@ -166,7 +179,9 @@ export default function LinkPreviewCard({
   }
 
   let stableFrameClasses = CHAT_STABLE_FRAME_CLASSES;
-  if (isCurrent && state.type === "success") {
+  if (isCurrent && state.type === "fallback") {
+    stableFrameClasses = CHAT_FALLBACK_FRAME_CLASSES;
+  } else if (isCurrent && state.type === "success") {
     if (getFirstPartyOpenGraphPreviewKind(state.data)) {
       stableFrameClasses = CHAT_FIRST_PARTY_FRAME_CLASSES;
     } else if (isSeizeCollectionPreview(state.data)) {

--- a/components/waves/SmartLinkPreview.tsx
+++ b/components/waves/SmartLinkPreview.tsx
@@ -20,6 +20,7 @@ import {
 
 interface SmartLinkPreviewProps {
   readonly href: string;
+  readonly hideActions?: boolean | undefined;
   readonly variant?: LinkPreviewVariant | undefined;
   readonly renderFallback?: (() => ReactElement) | undefined;
 }
@@ -77,6 +78,7 @@ const findMatch = (
 };
 
 export default function SmartLinkPreview({
+  hideActions = false,
   href,
   variant,
   renderFallback,
@@ -102,6 +104,7 @@ export default function SmartLinkPreview({
 
     return (
       <LinkPreviewCard
+        hideActions={hideActions}
         href={stableHref}
         variant={resolvedVariant}
         renderFallback={fallbackRenderer}

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -589,6 +589,18 @@ const THE_MEMES_DETAIL_ART_MESSAGES = namespaceMessages("theMemes.detail.art", [
 ] as const);
 
 export const EN_US_MESSAGES = {
+  "home.boostedDrop.anonymousAuthor": "Anonymous",
+  "home.boostedDrop.badge": "Boosted post",
+  "home.boostedDrop.boost": "Boost",
+  "home.boostedDrop.boostDrop": "Boost post by {author}",
+  "home.boostedDrop.boosted": "Boosted",
+  "home.boostedDrop.boostCount.one": "{count} boost",
+  "home.boostedDrop.boostCount.many": "{count} boosts",
+  "home.boostedDrop.internalLinkSource": "{source} link",
+  "home.boostedDrop.openDrop": "Open boosted post from {author}",
+  "home.boostedDrop.removeBoost": "Remove boost",
+  "home.boostedDrop.removeBoostFromDrop": "Remove boost from post by {author}",
+  "home.boostedDrop.viewAuthor": "View {author}'s profile",
   "theMemes.documentTitle": "The Memes | Collections",
   "theMemes.description.collections": "Collections",
   "theMemes.title": "The Memes",


### PR DESCRIPTION
## Summary
- Redesign inline boosted cards as compact boosted **post** cards with a clear header, boost count, calmer footer, and no nested wrapper shell.
- Make internal 6529 link fallbacks read as deliberate `6529.io link` previews with stronger title hierarchy and hidden inline link actions.
- Improve accessibility/copy around boost/open/author actions and add focused coverage for compact fallback behavior.

## Design Review
- Iterated locally with screenshot review and Anthropic Opus 4.8 feedback until it returned `VERDICT: HAPPY` for PR readiness.

## Checks
- `seize run lint:single -- components/common/icons/BoostIcon.tsx components/home/boosted/BoostedDropCardHome.tsx components/home/boosted/BoostedDropCardHomeContent.tsx components/home/boosted/BoostedDropLinkPreview.tsx components/drops/view/DropsList.tsx components/waves/LinkPreviewCard.tsx components/waves/SmartLinkPreview.tsx i18n/messages/en-US.ts __tests__/components/home/boosted/BoostedDropCardHome.test.tsx __tests__/components/waves/LinkPreviewCard.test.tsx __tests__/components/drops/view/DropsList.test.tsx`
- `seize run test:no-coverage -- __tests__/components/waves/LinkPreviewCard.test.tsx __tests__/components/home/boosted/BoostedDropCardHome.test.tsx __tests__/components/drops/view/DropsList.test.tsx`
- `seize run typecheck`
- `codex-diff-check -- components/common/icons/BoostIcon.tsx components/home/boosted/BoostedDropCardHome.tsx components/home/boosted/BoostedDropCardHomeContent.tsx components/home/boosted/BoostedDropLinkPreview.tsx components/drops/view/DropsList.tsx components/waves/LinkPreviewCard.tsx components/waves/SmartLinkPreview.tsx i18n/messages/en-US.ts __tests__/components/home/boosted/BoostedDropCardHome.test.tsx __tests__/components/waves/LinkPreviewCard.test.tsx __tests__/components/drops/view/DropsList.test.tsx