### PR TITLE
Polish wave sidebar and score actions

### DIFF
--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -81,8 +81,9 @@ const sentinel = document.createElement("div");
 
 const baseWaves = [
   createMockMinimalWave({ id: "a1" }),
-  createMockMinimalWave({ id: "o1", isOfficial: true }),
+  createMockMinimalWave({ id: "h1", sidebarSection: "highly-rated" }),
   createMockMinimalWave({ id: "p1", isPinned: true }),
+  createMockMinimalWave({ id: "f1", isFollowing: true }),
   createMockMinimalWave({ id: "r1", isPinned: false }),
 ];
 
@@ -133,7 +134,7 @@ it("renders structure even when no waves", () => {
   expect(screen.getByTestId("switch")).toBeInTheDocument();
 });
 
-it("renders announcement, official, pinned, and regular waves with headers and switch", () => {
+it("renders announcement, highly rated, pinned, following, and all waves with headers and switch", () => {
   const ref = React.createRef<UnifiedWavesListWavesHandle>();
   render(
     <UnifiedWavesListWaves
@@ -146,20 +147,25 @@ it("renders announcement, official, pinned, and regular waves with headers and s
   expect(screen.getByTestId("header-All Waves")).toBeInTheDocument();
   expect(screen.getByTestId("switch")).toBeInTheDocument();
   expect(screen.getByLabelText("Announcement waves")).toBeInTheDocument();
-  expect(screen.getByLabelText("Official waves")).toBeInTheDocument();
+  expect(screen.getByLabelText("Highly rated waves")).toBeInTheDocument();
   expect(screen.getByLabelText("Pinned waves")).toBeInTheDocument();
+  expect(screen.getByLabelText("Following waves")).toBeInTheDocument();
+  expect(
+    screen.getByLabelText("All quality-ranked waves list")
+  ).toBeInTheDocument();
   expect(screen.getByTestId("wave-a1")).toHaveAttribute("data-pin", "false");
-  expect(screen.getByTestId("wave-o1")).toHaveAttribute("data-pin", "false");
+  expect(screen.getByTestId("wave-h1")).toHaveAttribute("data-pin", "false");
   expect(screen.getByTestId("wave-p1")).toHaveAttribute("data-pin", "true");
+  expect(screen.getByTestId("wave-f1")).toHaveAttribute("data-pin", "true");
   expect(screen.getByTestId("wave-r1")).toHaveAttribute("data-pin", "true");
   expect(
     screen.getAllByTestId(/^wave-/).map((item) => item.dataset.testid)
-  ).toEqual(["wave-a1", "wave-o1", "wave-p1", "wave-r1"]);
+  ).toEqual(["wave-a1", "wave-h1", "wave-p1", "wave-f1", "wave-r1"]);
   expect(ref.current?.containerRef.current).toBe(container);
   expect(ref.current?.sentinelRef.current).toBeInstanceOf(HTMLElement);
 });
 
-it("hides pin controls for pinned official waves", () => {
+it("does not give special placement to official waves", () => {
   render(
     <UnifiedWavesListWaves
       waves={[
@@ -174,7 +180,8 @@ it("hides pin controls for pinned official waves", () => {
     />
   );
 
-  expect(screen.getByTestId("wave-o1")).toHaveAttribute("data-pin", "false");
+  expect(screen.getByLabelText("Pinned waves")).toBeInTheDocument();
+  expect(screen.getByTestId("wave-o1")).toHaveAttribute("data-pin", "true");
 });
 
 it("passes pin controls through for pinned announcement waves", () => {
@@ -213,7 +220,7 @@ it("respects hide options and does not render toggle when not connected", () => 
   expect(screen.queryByTestId("header-All Waves")).toBeNull();
   expect(screen.queryByTestId("switch")).toBeNull();
   expect(screen.getByTestId("wave-a1")).toHaveAttribute("data-pin", "false");
-  expect(screen.getByTestId("wave-o1")).toHaveAttribute("data-pin", "false");
+  expect(screen.getByTestId("wave-h1")).toHaveAttribute("data-pin", "false");
   expect(screen.queryByTestId("wave-p1")).toBeNull();
   expect(screen.getByTestId("wave-r1")).toHaveAttribute("data-pin", "false");
 });

--- a/__tests__/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.test.tsx
@@ -66,8 +66,9 @@ const sentinel = document.createElement("div");
 
 const baseWaves = [
   createMockMinimalWave({ id: "a1" }),
-  createMockMinimalWave({ id: "o1", isOfficial: true }),
+  createMockMinimalWave({ id: "h1", sidebarSection: "highly-rated" }),
   createMockMinimalWave({ id: "p1", isPinned: true }),
+  createMockMinimalWave({ id: "f1", isFollowing: true }),
   createMockMinimalWave({ id: "r1", isPinned: false }),
 ];
 
@@ -118,7 +119,7 @@ jest.mock(
   )
 );
 
-it("renders announcement, official, pinned, and regular sections without double rendering", () => {
+it("renders announcement, highly rated, pinned, following, and all sections without double rendering", () => {
   const sentinelRef = React.createRef<HTMLDivElement>();
 
   render(
@@ -137,19 +138,24 @@ it("renders announcement, official, pinned, and regular sections without double 
   );
   expect(screen.getByTestId("waves-filter-toggle")).toBeInTheDocument();
   expect(screen.getByLabelText("Announcement waves")).toBeInTheDocument();
-  expect(screen.getByLabelText("Official waves")).toBeInTheDocument();
+  expect(screen.getByLabelText("Highly rated waves")).toBeInTheDocument();
   expect(screen.getByLabelText("Pinned waves")).toBeInTheDocument();
+  expect(screen.getByLabelText("Following waves")).toBeInTheDocument();
+  expect(
+    screen.getByLabelText("All quality-ranked waves list")
+  ).toBeInTheDocument();
   expect(screen.getByTestId("wave-a1")).toHaveAttribute("data-pin", "false");
-  expect(screen.getByTestId("wave-o1")).toHaveAttribute("data-pin", "false");
+  expect(screen.getByTestId("wave-h1")).toHaveAttribute("data-pin", "false");
   expect(screen.getByTestId("wave-p1")).toHaveAttribute("data-pin", "true");
+  expect(screen.getByTestId("wave-f1")).toHaveAttribute("data-pin", "true");
   expect(screen.getByTestId("wave-r1")).toHaveAttribute("data-pin", "true");
   expect(
     screen.getAllByTestId(/^wave-/).map((item) => item.dataset.testid)
-  ).toEqual(["wave-a1", "wave-o1", "wave-p1", "wave-r1"]);
+  ).toEqual(["wave-a1", "wave-h1", "wave-p1", "wave-f1", "wave-r1"]);
   expect(sentinelRef.current).toBeInstanceOf(HTMLDivElement);
 });
 
-it("hides pin controls for pinned official waves", () => {
+it("does not give special placement to official waves", () => {
   render(
     <WebUnifiedWavesListWaves
       waves={[
@@ -165,7 +171,8 @@ it("hides pin controls for pinned official waves", () => {
     />
   );
 
-  expect(screen.getByTestId("wave-o1")).toHaveAttribute("data-pin", "false");
+  expect(screen.getByLabelText("Pinned waves")).toBeInTheDocument();
+  expect(screen.getByTestId("wave-o1")).toHaveAttribute("data-pin", "true");
 });
 
 it("passes pin controls through for pinned announcement waves", () => {
@@ -349,56 +356,57 @@ it("keeps child rows mounted while collapse animation runs", () => {
   }
 });
 
-it("keeps official child rows mounted while the section exit animation runs", () => {
+it("keeps highly rated child rows mounted while the section exit animation runs", () => {
   jest.useFakeTimers();
 
   try {
-    const officialParent = createMockMinimalWave({
-      id: "official-parent",
-      isOfficial: true,
+    const highlyRatedParent = createMockMinimalWave({
+      id: "highly-rated-parent",
+      sidebarSection: "highly-rated",
       hasSubwaves: true,
     });
-    const officialChild = createMockMinimalWave({
-      id: "official-child",
-      parentWaveId: "official-parent",
+    const highlyRatedChild = createMockMinimalWave({
+      id: "highly-rated-child",
+      parentWaveId: "highly-rated-parent",
+      sidebarSection: "highly-rated",
       createdAt: 10,
     });
     const sentinelRef = React.createRef<HTMLDivElement>();
     const { rerender } = render(
       <WebUnifiedWavesListWaves
-        waves={[officialParent, officialChild]}
+        waves={[highlyRatedParent, highlyRatedChild]}
         onHover={jest.fn()}
         scrollContainerRef={scrollRef}
         sentinelRef={sentinelRef}
       />
     );
 
-    fireEvent.click(screen.getByTestId("toggle-official-parent"));
-    expect(loadSubwavesForParent).toHaveBeenCalledWith("official-parent");
-    expect(screen.getByLabelText("Official waves")).toBeInTheDocument();
-    expect(screen.getByTestId("wave-official-child")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("toggle-highly-rated-parent"));
+    expect(loadSubwavesForParent).toHaveBeenCalledWith("highly-rated-parent");
+    expect(screen.getByLabelText("Highly rated waves")).toBeInTheDocument();
+    expect(screen.getByTestId("wave-highly-rated-child")).toBeInTheDocument();
 
     rerender(
       <WebUnifiedWavesListWaves
-        waves={[officialChild]}
+        waves={[highlyRatedChild]}
         onHover={jest.fn()}
         scrollContainerRef={scrollRef}
         sentinelRef={sentinelRef}
       />
     );
 
-    expect(screen.queryByTestId("wave-official-parent")).toBeNull();
-    expect(screen.getByLabelText("Official waves")).toBeInTheDocument();
+    expect(screen.queryByTestId("wave-highly-rated-parent")).toBeNull();
+    expect(screen.getByLabelText("Highly rated waves")).toBeInTheDocument();
     expect(
-      screen.getByTestId("wave-official-child").parentElement
+      screen.getByTestId("wave-highly-rated-child").parentElement
     ).toHaveAttribute("data-sidebar-subwave-row-state", "exiting");
 
     act(() => {
       jest.advanceTimersByTime(SIDEBAR_SUBWAVE_ROW_TRANSITION_MS);
     });
 
-    expect(screen.queryByTestId("wave-official-child")).toBeNull();
-    expect(screen.queryByLabelText("Official waves")).toBeNull();
+    expect(screen.queryByTestId("wave-highly-rated-child")).toBeNull();
+    expect(screen.queryByLabelText("Highly rated waves")).toBeNull();
   } finally {
     jest.useRealTimers();
   }

--- a/__tests__/components/waves/WaveTrustSignals.test.tsx
+++ b/__tests__/components/waves/WaveTrustSignals.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { ApiWaveRepSummary } from "@/generated/models/ApiWaveRepSummary";
 import type { ApiWaveScore } from "@/generated/models/ApiWaveScore";
 import { WaveTrustSignals } from "@/components/waves/WaveTrustSignals";
@@ -42,11 +42,11 @@ describe("WaveTrustSignals", () => {
     expect(summaryBadge).toHaveAttribute(
       "aria-label",
       expect.stringContaining(
-        "Combined score: 83. A quick signal for which waves deserve broad attention. Quality: 78 (65% of visibility). Hotness: 92 (gated, 35% of visibility)."
+        "Wave score 83. Quality 78, 65% of visibility. Hotness 92, gated, 35% of visibility."
       )
     );
     expect(summaryBadge?.getAttribute("aria-label")).toMatch(
-      /^Combined score: 83\. A quick signal for which waves deserve broad attention\. Quality: 78 \(65% of visibility\)\. Hotness: 92 \(gated, 35% of visibility\)\. REP: .+ raw, 41 score\. Open Network > Wave Score for the formula$/
+      /^Wave score 83\. Quality 78, 65% of visibility\. Hotness 92, gated, 35% of visibility\. REP: .+ raw, 41 score$/
     );
     expect(summaryBadge).not.toHaveAttribute("title");
     expect(screen.getByText("Score")).toBeInTheDocument();
@@ -71,16 +71,18 @@ describe("WaveTrustSignals", () => {
     expect(summaryBadge).not.toBeNull();
     expect(summaryBadge).not.toHaveAttribute("title");
     expect(
-      screen.getByRole("button", { name: /^Combined score: 83\./ })
+      screen.getByRole("button", { name: /^Wave score 83\./ })
     ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /^Wave score 83\./ }));
     expect(
-      screen.getByRole("link", { name: "Open full formula" })
+      screen.getByRole("link", { name: "Learn more" })
     ).toHaveAttribute("href", "/network/wave-score");
-    expect(screen.getByText("REP")).toBeInTheDocument();
-    expect(screen.getByText("+1.3K")).toBeInTheDocument();
-    expect(
-      screen.getByText("A quick signal for which waves deserve broad attention")
-    ).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Wave score details" }))
+      .toBeInTheDocument();
+    expect(screen.getByText("Quality")).toBeInTheDocument();
+    expect(screen.getByText("Hotness")).toBeInTheDocument();
+    expect(screen.getByText("Wave REP")).toBeInTheDocument();
+    expect(screen.queryByText("REP")).not.toBeInTheDocument();
   });
 
   it("does not attach hover tooltip content in sidebar summary mode", () => {

--- a/__tests__/components/waves/header/WaveHeader.test.tsx
+++ b/__tests__/components/waves/header/WaveHeader.test.tsx
@@ -214,16 +214,35 @@ describe("WaveHeader", () => {
     wrapper(
       {
         ...baseWave,
-        wave_rep: { total_rep: 1250 },
+        wave_rep: { total_rep: 1250, authenticated_user_contribution: null },
       },
       undefined,
       { connectedProfile: { handle: "alice" } }
     );
 
     expect(
-      screen.getByRole("button", { name: /Add or edit Wave REP/i })
+      screen.getByRole("button", { name: /Add Wave REP to this wave/i })
     ).toBeInTheDocument();
     expect(screen.getByText("Add REP")).toBeInTheDocument();
     expect(screen.getByText("1.3K")).toBeInTheDocument();
+  });
+
+  it("shows a remove REP action when the user already contributed", () => {
+    wrapper(
+      {
+        ...baseWave,
+        wave_rep: {
+          total_rep: 1250,
+          authenticated_user_contribution: 25,
+        },
+      },
+      undefined,
+      { connectedProfile: { handle: "alice" } }
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Edit or remove your Wave REP/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Remove REP")).toBeInTheDocument();
   });
 });

--- a/__tests__/components/waves/header/rep/WaveRepRatingModal.test.tsx
+++ b/__tests__/components/waves/header/rep/WaveRepRatingModal.test.tsx
@@ -200,6 +200,22 @@ describe("WaveRepRatingModal", () => {
     expect(commonApiPostMock).not.toHaveBeenCalled();
   });
 
+  it("explains when the user has no available Wave REP credit", async () => {
+    useWaveRepAllocationMock.mockReturnValue({
+      currentRating: 0,
+      availableWaveRep: 0,
+      minMaxValues: { min: 0, max: 0 },
+      isLoading: false,
+    });
+
+    renderModal();
+
+    expect(
+      await screen.findByText(/No available Wave REP credit/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save Wave REP" })).toBeDisabled();
+  });
+
   it("shows one mutation error toast and clears the busy state", async () => {
     commonApiPostMock.mockRejectedValue(new Error("failed"));
     const { setToast } = renderModal();
@@ -239,6 +255,23 @@ describe("WaveRepRatingModal", () => {
     });
     expect(invalidateQueriesSpy).toHaveBeenCalledWith({
       queryKey: [QueryKey.WAVE_REP_CREDIT],
+    });
+  });
+
+  it("can remove an existing category rating by saving zero", async () => {
+    const { onClose } = renderModal();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Remove Wave REP" })
+    );
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(commonApiPostMock).toHaveBeenCalledWith({
+      body: {
+        amount: 0,
+        category: "quality",
+      },
+      endpoint: "waves/wave-1/rep/rating",
     });
   });
 });

--- a/__tests__/hooks/usePinnedWavesServer.test.tsx
+++ b/__tests__/hooks/usePinnedWavesServer.test.tsx
@@ -157,7 +157,7 @@ test("keeps the pinned cache key at the logical limit but requests API pages of 
   expect(fetchWavesV2PageMock).toHaveBeenCalledWith({
     page: 1,
     pageSize: 20,
-    overviewType: ApiWavesOverviewType.MostSubscribed,
+    overviewType: ApiWavesOverviewType.RecentlyDroppedTo,
     pinned: ApiWavesPinFilter.Pinned,
   });
 });

--- a/__tests__/hooks/useWavesList.test.tsx
+++ b/__tests__/hooks/useWavesList.test.tsx
@@ -7,6 +7,7 @@ import { useWaveById } from "@/hooks/useWaveById";
 import { SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS } from "@/components/react-query-wrapper/utils/query-utils";
 import { ApiWavesOverviewType } from "@/generated/models/ApiWavesOverviewType";
 import { ApiWaveScoreSort } from "@/generated/models/ApiWaveScoreSort";
+import { ApiWavesPinFilter } from "@/generated/models/ApiWavesPinFilter";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 jest.mock("@/hooks/useWavesV2", () => {
@@ -31,10 +32,6 @@ jest.mock("@/hooks/useWaveById", () => ({
 
 jest.mock("@/hooks/useShowFollowingWaves", () => ({
   useShowFollowingWaves: jest.fn(() => [false]),
-}));
-
-jest.mock("@/hooks/useOfficialWaves", () => ({
-  useOfficialWaves: jest.fn(),
 }));
 
 jest.mock("@/hooks/useWaveSubwaves", () => ({
@@ -67,8 +64,6 @@ const useSeizeConnectContextMock =
 const useSeizeSettingsMock = require("@/contexts/SeizeSettingsContext")
   .useSeizeSettings as jest.Mock;
 const useWaveByIdMock = useWaveById as jest.Mock;
-const useOfficialWavesMock = require("@/hooks/useOfficialWaves")
-  .useOfficialWaves as jest.Mock;
 const useShowFollowingWavesMock = require("@/hooks/useShowFollowingWaves")
   .useShowFollowingWaves as jest.Mock;
 const useWaveSubwavesMapMock = require("@/hooks/useWaveSubwaves")
@@ -167,22 +162,8 @@ const announcementWave = createSidebarWave({
   id: "4",
   latestDropTimestamp: 300,
 });
-const officialWave = createSidebarWave({
-  id: "5",
-  latestDropTimestamp: 250,
-});
-const pinnedOfficialWave = createSidebarWave({
-  id: "6",
-  latestDropTimestamp: 350,
-});
-const stalePinnedOfficialWave = createSidebarWave({
-  id: "7",
-  latestDropTimestamp: 275,
-  pinned: true,
-});
 const legacyAnnouncementWave = createLegacyApiWave("4", 300);
 let announcementRefetchMock: jest.Mock;
-let officialWavesRefetchMock: jest.Mock;
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -190,7 +171,6 @@ beforeEach(() => {
     defaultOptions: { queries: { retry: false } },
   });
   announcementRefetchMock = jest.fn();
-  officialWavesRefetchMock = jest.fn();
   useShowFollowingWavesMock.mockReturnValue([false]);
   useSeizeConnectContextMock.mockReturnValue({ address: "0xABC" });
   useWavesV2Mock.mockReturnValue({
@@ -210,12 +190,6 @@ beforeEach(() => {
     isLoading: false,
     isError: false,
     refetch: jest.fn(),
-  });
-  useOfficialWavesMock.mockReturnValue({
-    waves: [],
-    isFetching: false,
-    status: "success",
-    refetch: officialWavesRefetchMock,
   });
   useSeizeSettingsMock.mockReturnValue({
     seizeSettings: {
@@ -250,10 +224,22 @@ test("combines main and pinned waves, filtering DMs and flagging pinned", () => 
     expect.arrayContaining([
       expect.objectContaining({
         overviewType: ApiWavesOverviewType.ScoredRecentlyDroppedTo,
+        pageSize: 10,
+        directMessage: false,
+        excludeFollowed: true,
+        pinned: ApiWavesPinFilter.NotPinned,
+        scoreSort: ApiWaveScoreSort.Quality,
+        enabled: true,
+        refetchInterval: SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
+        refetchIntervalInBackground: false,
+      }),
+      expect.objectContaining({
+        overviewType: ApiWavesOverviewType.ScoredRecentlyDroppedTo,
         pageSize: 20,
         directMessage: false,
         excludeFollowed: true,
-        scoreSort: ApiWaveScoreSort.Balanced,
+        pinned: ApiWavesPinFilter.NotPinned,
+        scoreSort: ApiWaveScoreSort.Quality,
         enabled: true,
         refetchInterval: SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
         refetchIntervalInBackground: false,
@@ -274,13 +260,6 @@ test("combines main and pinned waves, filtering DMs and flagging pinned", () => 
       (args) => args.overviewType === ApiWavesOverviewType.RecentlyDroppedTo
     )
   ).not.toHaveProperty("scoreSort");
-  expect(useOfficialWavesMock).toHaveBeenCalledWith(
-    expect.objectContaining({
-      viewerIdentityKey: "0xabc:primary",
-      refetchInterval: SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
-      refetchIntervalInBackground: false,
-    })
-  );
 });
 
 test("polls followed activity when the sidebar is in joined mode", () => {
@@ -290,13 +269,13 @@ test("polls followed activity when the sidebar is in joined mode", () => {
 
   const waveQueryArgs = useWavesV2Mock.mock.calls.map(([args]) => args);
   expect(
-    waveQueryArgs.find(
-      (args) =>
-        args.overviewType === ApiWavesOverviewType.ScoredRecentlyDroppedTo
-    )
-  ).toMatchObject({
-    enabled: false,
-  });
+    waveQueryArgs
+      .filter(
+        (args) =>
+          args.overviewType === ApiWavesOverviewType.ScoredRecentlyDroppedTo
+      )
+      .every((args) => args.enabled === false)
+  ).toBe(true);
   expect(
     waveQueryArgs.find(
       (args) => args.overviewType === ApiWavesOverviewType.RecentlyDroppedTo
@@ -307,7 +286,7 @@ test("polls followed activity when the sidebar is in joined mode", () => {
   });
 });
 
-test("puts followed activity before combined-score discovery rows", () => {
+test("puts highly rated discovery before followed activity", () => {
   const followedOld = createSidebarWave({
     id: "followed-old",
     latestDropTimestamp: 10,
@@ -323,11 +302,13 @@ test("puts followed activity before combined-score discovery rows", () => {
     latestDropTimestamp: 999,
   });
 
-  useWavesV2Mock.mockImplementation(({ overviewType }) => ({
+  useWavesV2Mock.mockImplementation(({ overviewType, pageSize }) => ({
     waves:
       overviewType === ApiWavesOverviewType.RecentlyDroppedTo
         ? [followedOld, followedNew]
-        : [scoreSuggestion, followedOld],
+        : pageSize === 10
+          ? [scoreSuggestion]
+          : [scoreSuggestion, followedOld],
     isFetching: false,
     isFetchingNextPage: false,
     hasNextPage: false,
@@ -348,9 +329,9 @@ test("puts followed activity before combined-score discovery rows", () => {
   const { result } = renderHook(() => useWavesList(), { wrapper });
 
   expect(result.current.waves.map((wave: any) => wave.id)).toEqual([
+    "score-suggestion",
     "followed-new",
     "followed-old",
-    "score-suggestion",
   ]);
 });
 
@@ -511,26 +492,6 @@ test("keeps public fetching state scoped to root wave sources", () => {
   rerender();
 
   expect(result.current.isFetching).toBe(true);
-
-  useWavesV2Mock.mockReturnValue({
-    waves: [mainWave],
-    isFetching: false,
-    isFetchingNextPage: false,
-    hasNextPage: false,
-    fetchNextPage: jest.fn(),
-    status: "success",
-    refetch: jest.fn(),
-  });
-  useOfficialWavesMock.mockReturnValue({
-    waves: [],
-    isFetching: true,
-    status: "success",
-    refetch: officialWavesRefetchMock,
-  });
-
-  rerender();
-
-  expect(result.current.isFetching).toBe(true);
 });
 
 test("prefetches subwaves without adding parent ids to rendered rows", () => {
@@ -587,30 +548,43 @@ test("prefetches subwaves without adding parent ids to rendered rows", () => {
   expect(result.current.waves.map((wave: any) => wave.id)).toEqual(["parent"]);
 });
 
-test("places official waves below announcements and ignores stale official pinned flags", () => {
-  useWavesV2Mock.mockReturnValue({
-    waves: [announcementWave, stalePinnedOfficialWave, officialWave, mainWave],
+test("places highly rated waves below announcements and before known-wave sections", () => {
+  const highlyRatedWave = createSidebarWave({
+    id: "highly-rated",
+    latestDropTimestamp: 50,
+  });
+  const followedWave = createSidebarWave({
+    id: "following",
+    latestDropTimestamp: 500,
+    subscribed: true,
+  });
+  const allQualityWave = createSidebarWave({
+    id: "all-quality",
+    latestDropTimestamp: 400,
+  });
+
+  useWavesV2Mock.mockImplementation(({ overviewType, pageSize }) => ({
+    waves:
+      overviewType === ApiWavesOverviewType.RecentlyDroppedTo
+        ? [followedWave]
+        : pageSize === 10
+          ? [highlyRatedWave]
+          : [announcementWave, allQualityWave],
     isFetching: false,
     isFetchingNextPage: false,
     hasNextPage: false,
     fetchNextPage: jest.fn(),
     status: "success",
     refetch: jest.fn(),
-  });
+  }));
   usePinnedWavesServerMock.mockReturnValue({
-    pinnedIds: ["2", "3", "5", "6"],
-    pinnedWaves: [pinnedExtra, officialWave, pinnedOfficialWave],
+    pinnedIds: ["3"],
+    pinnedWaves: [pinnedExtra],
     pinWave: jest.fn(),
     unpinWave: jest.fn(),
     isLoading: false,
     isError: false,
     refetch: jest.fn(),
-  });
-  useOfficialWavesMock.mockReturnValue({
-    waves: [officialWave, pinnedOfficialWave, stalePinnedOfficialWave],
-    isFetching: false,
-    status: "success",
-    refetch: officialWavesRefetchMock,
   });
   useSeizeSettingsMock.mockReturnValue({
     seizeSettings: {
@@ -623,37 +597,40 @@ test("places official waves below announcements and ignores stale official pinne
 
   expect(result.current.waves.map((wave: any) => wave.id)).toEqual([
     "4",
-    "6",
-    "7",
-    "5",
+    "highly-rated",
     "3",
-    "2",
+    "following",
+    "all-quality",
   ]);
-  expect(
-    result.current.waves
-      .filter((wave: any) => wave.isOfficial)
-      .map((wave: any) => ({ id: wave.id, isPinned: wave.isPinned }))
-  ).toEqual([
-    { id: "6", isPinned: true },
-    { id: "7", isPinned: false },
-    { id: "5", isPinned: true },
-  ]);
+  expect(result.current.waves.find((wave: any) => wave.id === "highly-rated"))
+    .toMatchObject({
+      isPinned: false,
+      sidebarSection: "highly-rated",
+      subscribed: false,
+    });
   expect(result.current.pinnedWaves.map((wave: any) => wave.id)).toEqual(["3"]);
 });
 
-test("refetches official waves when refetching all waves", () => {
-  const mainWavesRefetch = jest.fn();
+test("refetches discovery, activity, pinned, and subwave sources", () => {
+  const highlyRatedRefetch = jest.fn();
+  const allQualityRefetch = jest.fn();
+  const followedActivityRefetch = jest.fn();
   const pinnedRefetch = jest.fn();
   const subwavesRefetch = jest.fn();
-  useWavesV2Mock.mockReturnValue({
+  useWavesV2Mock.mockImplementation(({ overviewType, pageSize }) => ({
     waves: [mainWave],
     isFetching: false,
     isFetchingNextPage: false,
     hasNextPage: false,
     fetchNextPage: jest.fn(),
     status: "success",
-    refetch: mainWavesRefetch,
-  });
+    refetch:
+      overviewType === ApiWavesOverviewType.RecentlyDroppedTo
+        ? followedActivityRefetch
+        : pageSize === 10
+          ? highlyRatedRefetch
+          : allQualityRefetch,
+  }));
   usePinnedWavesServerMock.mockReturnValue({
     pinnedIds: [],
     pinnedWaves: [],
@@ -674,8 +651,9 @@ test("refetches official waves when refetching all waves", () => {
 
   result.current.refetchAllWaves();
 
-  expect(mainWavesRefetch).toHaveBeenCalled();
-  expect(officialWavesRefetchMock).toHaveBeenCalled();
+  expect(highlyRatedRefetch).toHaveBeenCalled();
+  expect(allQualityRefetch).toHaveBeenCalled();
+  expect(followedActivityRefetch).toHaveBeenCalled();
   expect(pinnedRefetch).toHaveBeenCalled();
   expect(subwavesRefetch).toHaveBeenCalled();
 });

--- a/__tests__/services/api/waves-v2-api.test.ts
+++ b/__tests__/services/api/waves-v2-api.test.ts
@@ -204,7 +204,7 @@ describe("waves-v2-api", () => {
     });
   });
 
-  it("falls through to legacy wave search when v2 search returns no matches", async () => {
+  it("uses v2 wave search as authoritative when it completes empty", async () => {
     commonApiFetchMock.mockImplementation(async ({ endpoint }) => {
       if (endpoint === "v2/waves") {
         return {
@@ -212,6 +212,31 @@ describe("waves-v2-api", () => {
           next: false,
           data: [],
         };
+      }
+      throw new Error("legacy search should not be called");
+    });
+
+    const result = await searchWavesByName({ name: "missing", pageSize: 5 });
+
+    expect(commonApiFetchMock).toHaveBeenCalledWith({
+      endpoint: "v2/waves",
+      params: {
+        view: "SEARCH",
+        page: "1",
+        page_size: "5",
+        direct_message: "false",
+        name: "missing",
+      },
+      headers: undefined,
+    });
+    expect(commonApiFetchMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([]);
+  });
+
+  it("falls back to legacy wave search only when v2 search fails", async () => {
+    commonApiFetchMock.mockImplementation(async ({ endpoint }) => {
+      if (endpoint === "v2/waves") {
+        throw new Error("v2 search failed");
       }
       if (endpoint === "waves") {
         return [
@@ -246,17 +271,6 @@ describe("waves-v2-api", () => {
     const result = await searchWavesByName({ name: "legacy", pageSize: 5 });
 
     expect(commonApiFetchMock).toHaveBeenCalledWith({
-      endpoint: "v2/waves",
-      params: {
-        view: "SEARCH",
-        page: "1",
-        page_size: "5",
-        direct_message: "false",
-        name: "legacy",
-      },
-      headers: undefined,
-    });
-    expect(commonApiFetchMock).toHaveBeenCalledWith({
       endpoint: "waves",
       params: {
         name: "legacy",
@@ -269,22 +283,6 @@ describe("waves-v2-api", () => {
       id: "legacy-wave",
       name: "Legacy Wave",
     });
-  });
-
-  it("returns no matches when every wave search endpoint completes empty", async () => {
-    commonApiFetchMock.mockImplementation(async ({ endpoint }) => {
-      if (endpoint === "v2/waves") {
-        return {
-          page: 1,
-          next: false,
-          data: [],
-        };
-      }
-      return [];
-    });
-
-    await expect(searchWavesByName({ name: "missing" })).resolves.toEqual([]);
-    expect(commonApiFetchMock).toHaveBeenCalledTimes(3);
   });
 
   it("surfaces primary search failure when fallback searches complete empty", async () => {
@@ -302,23 +300,6 @@ describe("waves-v2-api", () => {
       cause: primaryError,
     });
     expect(commonApiFetchMock).toHaveBeenCalledTimes(3);
-  });
-
-  it("surfaces unavailable search when empty results are followed by fallback failures", async () => {
-    commonApiFetchMock.mockImplementation(async ({ endpoint }) => {
-      if (endpoint === "v2/waves") {
-        return {
-          page: 1,
-          next: false,
-          data: [],
-        };
-      }
-      throw new Error("search failed");
-    });
-
-    await expect(searchWavesByName({ name: "missing" })).rejects.toThrow(
-      "Wave search is unavailable. Try a wave URL or id."
-    );
   });
 
   it("surfaces unavailable search when every wave search endpoint fails", async () => {

--- a/__tests__/utils/mockFactories.ts
+++ b/__tests__/utils/mockFactories.ts
@@ -30,6 +30,9 @@ export function createMockMinimalWave(
     latestReadTimestamp: 0,
     firstUnreadDropSerialNo: null,
     isMuted: false,
+    waveRep: null,
+    waveScore: null,
+    sidebarSection: null,
     ...overrides,
   };
 }

--- a/components/brain/left-sidebar/waves/UnifiedWavesListWaves.tsx
+++ b/components/brain/left-sidebar/waves/UnifiedWavesListWaves.tsx
@@ -27,6 +27,8 @@ import {
   isValidSidebarWave,
   validateSidebarWaveDetailed,
 } from "./sidebarWaveListUtils";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 
 // Height for empty waves placeholder to maintain consistent layout (matches UnifiedWavesListEmpty)
 const EMPTY_WAVES_PLACEHOLDER_HEIGHT = "48px" as const;
@@ -35,6 +37,7 @@ const EMPTY_WAVES_PLACEHOLDER_HEIGHT = "48px" as const;
 const WAVE_ROW_HEIGHT = 62 as const; // Height of each wave row in pixels
 const SUBWAVE_ROW_HEIGHT = 54 as const;
 const VIRTUALIZATION_OVERSCAN = 5 as const; // Number of extra items to render outside viewport
+const SIDEBAR_LOCALE = DEFAULT_LOCALE;
 
 // Common styles for positioned elements
 const listContainerStyle = {
@@ -140,10 +143,10 @@ const UnifiedWavesListWaves = forwardRef<
 
     const {
       announcementWaves,
-      officialWaves,
+      highlyRatedWaves,
       pinnedWaves,
       followingWaves,
-      scoreWaves,
+      allWaves,
     } = useMemo(
       () =>
         groupSidebarWaves({
@@ -160,9 +163,9 @@ const UnifiedWavesListWaves = forwardRef<
       () => getRows(announcementWaves),
       [announcementWaves, getRows]
     );
-    const officialRows = useMemo(
-      () => getRows(officialWaves),
-      [officialWaves, getRows]
+    const highlyRatedRows = useMemo(
+      () => getRows(highlyRatedWaves),
+      [highlyRatedWaves, getRows]
     );
     const pinnedRows = useMemo(
       () => getRows(pinnedWaves),
@@ -172,21 +175,22 @@ const UnifiedWavesListWaves = forwardRef<
       () => getRows(followingWaves),
       [followingWaves, getRows]
     );
-    const scoreRows = useMemo(() => getRows(scoreWaves), [scoreWaves, getRows]);
+    const allRows = useMemo(() => getRows(allWaves), [allWaves, getRows]);
     const animatedAnnouncementRows =
       useAnimatedSidebarWaveRows(announcementRows);
-    const animatedOfficialRows = useAnimatedSidebarWaveRows(officialRows);
+    const animatedHighlyRatedRows =
+      useAnimatedSidebarWaveRows(highlyRatedRows);
     const animatedPinnedRows = useAnimatedSidebarWaveRows(pinnedRows);
     const animatedFollowingRows = useAnimatedSidebarWaveRows(followingRows);
-    const animatedScoreRows = useAnimatedSidebarWaveRows(scoreRows);
+    const animatedAllRows = useAnimatedSidebarWaveRows(allRows);
     const virtualizedRows =
-      animatedScoreRows.length > 0 ? animatedScoreRows : animatedFollowingRows;
+      animatedAllRows.length > 0 ? animatedAllRows : animatedFollowingRows;
     const staticFollowingRows =
-      animatedScoreRows.length > 0 ? animatedFollowingRows : [];
+      animatedAllRows.length > 0 ? animatedFollowingRows : [];
     const virtualizedAriaLabel =
-      animatedScoreRows.length > 0
-        ? "Combined score waves list"
-        : "Following waves list";
+      animatedAllRows.length > 0
+        ? t(SIDEBAR_LOCALE, "waves.sidebar.allQualityRankedAriaLabel")
+        : t(SIDEBAR_LOCALE, "waves.sidebar.followingListAriaLabel");
     const getSidebarRowHeight = useCallback(
       (row: SidebarWaveTreeRow) =>
         row.depth === 1 ? SUBWAVE_ROW_HEIGHT : WAVE_ROW_HEIGHT,
@@ -196,8 +200,8 @@ const UnifiedWavesListWaves = forwardRef<
     const virtual = useVirtualizedWaves<SidebarWaveTreeRow>({
       items: virtualizedRows,
       key:
-        animatedScoreRows.length > 0
-          ? "unified-waves-score"
+        animatedAllRows.length > 0
+          ? "unified-waves-all"
           : "unified-waves-following",
       scrollContainerRef,
       listContainerRef,
@@ -258,44 +262,56 @@ const UnifiedWavesListWaves = forwardRef<
 
         {!hideHeaders &&
           announcementRows.length > 0 &&
-          (officialRows.length > 0 ||
+          (highlyRatedRows.length > 0 ||
             pinnedRows.length > 0 ||
             followingRows.length > 0 ||
-            scoreRows.length > 0) && (
+            allRows.length > 0) && (
             <div className="tw-my-3 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700" />
           )}
 
-        {officialRows.length > 0 && (
-          <SidebarWaveRowsSection
-            ariaLabel="Official waves"
-            className="tw-flex tw-flex-col"
-            getRowHeight={getSidebarRowHeight}
-            isRowVisible={(row) =>
-              isVisibleStaticRow({
-                detailedLabel: "Official",
-                row,
-                sectionName: "official",
-              })
-            }
-            renderRow={(row) => renderWaveRow(row, false)}
-            rows={animatedOfficialRows}
-          />
+        {highlyRatedRows.length > 0 && (
+          <>
+            {!hideHeaders && (
+              <SidebarCategoryLabel
+                label={t(SIDEBAR_LOCALE, "waves.sidebar.highlyRated")}
+              />
+            )}
+            <SidebarWaveRowsSection
+              ariaLabel={t(
+                SIDEBAR_LOCALE,
+                "waves.sidebar.highlyRatedAriaLabel"
+              )}
+              className="tw-flex tw-flex-col"
+              getRowHeight={getSidebarRowHeight}
+              isRowVisible={(row) =>
+                isVisibleStaticRow({
+                  detailedLabel: "Highly rated",
+                  row,
+                  sectionName: "highly rated",
+                })
+              }
+              renderRow={(row) => renderWaveRow(row, false)}
+              rows={animatedHighlyRatedRows}
+            />
+          </>
         )}
 
         {!hideHeaders &&
-          officialRows.length > 0 &&
+          highlyRatedRows.length > 0 &&
           (pinnedRows.length > 0 ||
             followingRows.length > 0 ||
-            scoreRows.length > 0) && (
+            allRows.length > 0) && (
             <div className="tw-my-3 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700" />
           )}
 
         {/* Conditionally show pinned section */}
         {!hideHeaders && pinnedRows.length > 0 && (
           <>
-            <SidebarCategoryLabel label="Pinned" />
+            <SidebarCategoryLabel
+              label={t(SIDEBAR_LOCALE, "waves.sidebar.pinned")}
+            />
             <SidebarWaveRowsSection
-              ariaLabel="Pinned waves"
+              ariaLabel={t(SIDEBAR_LOCALE, "waves.sidebar.pinnedAriaLabel")}
               className="tw-flex tw-flex-col"
               getRowHeight={getSidebarRowHeight}
               isRowVisible={(row) =>
@@ -313,15 +329,22 @@ const UnifiedWavesListWaves = forwardRef<
 
         {!hideHeaders &&
           pinnedRows.length > 0 &&
-          (followingRows.length > 0 || scoreRows.length > 0) && (
+          (followingRows.length > 0 || allRows.length > 0) && (
             <div className="tw-my-3 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700" />
           )}
 
         {staticFollowingRows.length > 0 && (
           <>
-            {!hideHeaders && <SidebarCategoryLabel label="Following" />}
+            {!hideHeaders && (
+              <SidebarCategoryLabel
+                label={t(SIDEBAR_LOCALE, "waves.sidebar.following")}
+              />
+            )}
             <SidebarWaveRowsSection
-              ariaLabel="Following waves"
+              ariaLabel={t(
+                SIDEBAR_LOCALE,
+                "waves.sidebar.followingAriaLabel"
+              )}
               className="tw-flex tw-flex-col"
               getRowHeight={getSidebarRowHeight}
               isRowVisible={(row) =>
@@ -339,12 +362,14 @@ const UnifiedWavesListWaves = forwardRef<
 
         {!hideHeaders &&
           staticFollowingRows.length > 0 &&
-          animatedScoreRows.length > 0 && (
+          animatedAllRows.length > 0 && (
             <div className="tw-my-3 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700" />
           )}
 
-        {!hideHeaders && animatedScoreRows.length > 0 && (
-          <SidebarCategoryLabel label="Combined Score" />
+        {!hideHeaders && animatedAllRows.length > 0 && (
+          <SidebarCategoryLabel
+            label={t(SIDEBAR_LOCALE, "waves.sidebar.all")}
+          />
         )}
 
         {virtualizedRows.length > 0 ? (

--- a/components/brain/left-sidebar/waves/sidebarWaveListUtils.ts
+++ b/components/brain/left-sidebar/waves/sidebarWaveListUtils.ts
@@ -2,10 +2,10 @@ import type { MinimalWave } from "@/contexts/wave/hooks/useEnhancedWavesListCore
 
 export interface SidebarWaveGroups {
   readonly announcementWaves: MinimalWave[];
-  readonly officialWaves: MinimalWave[];
+  readonly highlyRatedWaves: MinimalWave[];
   readonly pinnedWaves: MinimalWave[];
   readonly followingWaves: MinimalWave[];
-  readonly scoreWaves: MinimalWave[];
+  readonly allWaves: MinimalWave[];
 }
 
 export const isValidSidebarWave = (wave: unknown): wave is MinimalWave => {
@@ -62,30 +62,30 @@ export const groupSidebarWaves = ({
   readonly waves: readonly MinimalWave[];
 }): SidebarWaveGroups => {
   const announcementWaves: MinimalWave[] = [];
-  const officialWaves: MinimalWave[] = [];
+  const highlyRatedWaves: MinimalWave[] = [];
   const pinnedWaves: MinimalWave[] = [];
   const followingWaves: MinimalWave[] = [];
-  const scoreWaves: MinimalWave[] = [];
+  const allWaves: MinimalWave[] = [];
 
   for (const wave of waves) {
     if (isAnnouncementsWave?.(wave.id) === true) {
       announcementWaves.push(wave);
-    } else if (wave.isOfficial) {
-      officialWaves.push(wave);
     } else if (wave.isPinned) {
       pinnedWaves.push(wave);
     } else if (wave.isFollowing) {
       followingWaves.push(wave);
+    } else if (wave.sidebarSection === "highly-rated") {
+      highlyRatedWaves.push(wave);
     } else {
-      scoreWaves.push(wave);
+      allWaves.push(wave);
     }
   }
 
   return {
     announcementWaves,
-    officialWaves,
+    highlyRatedWaves,
     pinnedWaves,
     followingWaves,
-    scoreWaves,
+    allWaves,
   };
 };

--- a/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.tsx
+++ b/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.tsx
@@ -28,6 +28,8 @@ import {
   groupSidebarWaves,
   isValidSidebarWave,
 } from "../waves/sidebarWaveListUtils";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 
 const EMPTY_WAVES_PLACEHOLDER_HEIGHT = "48px" as const;
 
@@ -36,6 +38,7 @@ const WAVE_ROW_HEIGHT_COLLAPSED = 52 as const;
 const SUBWAVE_ROW_HEIGHT = 54 as const;
 const PROFILE_FEED_TOOLTIP_ID = "profile-feed-shortcut-tooltip";
 const PROFILE_FEED_LABEL = "Profile Waves Feed";
+const SIDEBAR_LOCALE = DEFAULT_LOCALE;
 const TOOLTIP_STYLE = {
   padding: "6px 10px",
   background: "#37373E",
@@ -299,10 +302,10 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
 
   const {
     announcementWaves,
-    officialWaves,
+    highlyRatedWaves,
     pinnedWaves,
     followingWaves,
-    scoreWaves,
+    allWaves,
   } = useMemo(
     () =>
       groupSidebarWaves({
@@ -319,9 +322,9 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
     () => getRows(announcementWaves),
     [announcementWaves, getRows]
   );
-  const officialRows = useMemo(
-    () => getRows(officialWaves),
-    [officialWaves, getRows]
+  const highlyRatedRows = useMemo(
+    () => getRows(highlyRatedWaves),
+    [highlyRatedWaves, getRows]
   );
   const pinnedRows = useMemo(
     () => getRows(pinnedWaves),
@@ -331,7 +334,7 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
     () => getRows(followingWaves),
     [followingWaves, getRows]
   );
-  const scoreRows = useMemo(() => getRows(scoreWaves), [scoreWaves, getRows]);
+  const allRows = useMemo(() => getRows(allWaves), [allWaves, getRows]);
   const rowAnimationOptions = useMemo(
     () => ({ keepExitingRows: !isCollapsed }),
     [isCollapsed]
@@ -340,8 +343,8 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
     announcementRows,
     rowAnimationOptions
   );
-  const animatedOfficialRows = useAnimatedSidebarWaveRows(
-    officialRows,
+  const animatedHighlyRatedRows = useAnimatedSidebarWaveRows(
+    highlyRatedRows,
     rowAnimationOptions
   );
   const animatedPinnedRows = useAnimatedSidebarWaveRows(
@@ -352,22 +355,22 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
     followingRows,
     rowAnimationOptions
   );
-  const animatedScoreRows = useAnimatedSidebarWaveRows(
-    scoreRows,
+  const animatedAllRows = useAnimatedSidebarWaveRows(
+    allRows,
     rowAnimationOptions
   );
   const hasAnnouncementRows = animatedAnnouncementRows.length > 0;
-  const hasOfficialRows = animatedOfficialRows.length > 0;
+  const hasHighlyRatedRows = animatedHighlyRatedRows.length > 0;
   const hasPinnedRows = animatedPinnedRows.length > 0;
   const hasFollowingRows = animatedFollowingRows.length > 0;
-  const hasScoreRows = animatedScoreRows.length > 0;
-  const virtualizedRows = hasScoreRows
-    ? animatedScoreRows
+  const hasAllRows = animatedAllRows.length > 0;
+  const virtualizedRows = hasAllRows
+    ? animatedAllRows
     : animatedFollowingRows;
-  const staticFollowingRows = hasScoreRows ? animatedFollowingRows : [];
-  const virtualizedAriaLabel = hasScoreRows
-    ? "Combined score waves list"
-    : "Following waves list";
+  const staticFollowingRows = hasAllRows ? animatedFollowingRows : [];
+  const virtualizedAriaLabel = hasAllRows
+    ? t(SIDEBAR_LOCALE, "waves.sidebar.allQualityRankedAriaLabel")
+    : t(SIDEBAR_LOCALE, "waves.sidebar.followingListAriaLabel");
   const headerPaddingClassName = "tw-px-4";
   const filterPaddingClassName = "tw-px-4";
   const sectionClassName = isCollapsed
@@ -385,8 +388,8 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
 
   const virtual = useVirtualizedWaves<SidebarWaveTreeRow>({
     items: virtualizedRows,
-    key: hasScoreRows
-      ? "web-unified-waves-score"
+    key: hasAllRows
+      ? "web-unified-waves-all"
       : "web-unified-waves-following",
     scrollContainerRef: scrollContainerRef ?? listContainerRef,
     listContainerRef,
@@ -455,35 +458,50 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
           )}
           {hasAnnouncementRows &&
             !hideHeaders &&
-            (hasOfficialRows ||
+            (hasHighlyRatedRows ||
               hasPinnedRows ||
               hasFollowingRows ||
-              hasScoreRows) && (
+              hasAllRows) && (
               <div className="tw-my-2 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700" />
             )}
-          {hasOfficialRows && (
-            <SidebarWaveRowsSection
-              ariaLabel="Official waves"
-              className={sectionClassName}
-              getRowHeight={getSidebarRowHeight}
-              isRowVisible={(row) =>
-                isVisibleSectionRow({ row, sectionName: "official" })
-              }
-              renderRow={(row) => renderWaveRow(row, false)}
-              rows={animatedOfficialRows}
-              transitionClassName="tw-w-full"
-            />
+
+          {hasHighlyRatedRows && (
+            <>
+              {!hideHeaders && !isCollapsed && (
+                <SidebarCategoryLabel
+                  label={t(SIDEBAR_LOCALE, "waves.sidebar.highlyRated")}
+                />
+              )}
+              <SidebarWaveRowsSection
+                ariaLabel={t(
+                  SIDEBAR_LOCALE,
+                  "waves.sidebar.highlyRatedAriaLabel"
+                )}
+                className={sectionClassName}
+                getRowHeight={getSidebarRowHeight}
+                isRowVisible={(row) =>
+                  isVisibleSectionRow({ row, sectionName: "highly rated" })
+                }
+                renderRow={(row) => renderWaveRow(row, false)}
+                rows={animatedHighlyRatedRows}
+                transitionClassName="tw-w-full"
+              />
+            </>
           )}
-          {hasOfficialRows &&
+          {hasHighlyRatedRows &&
             !hideHeaders &&
-            (hasPinnedRows || hasFollowingRows || hasScoreRows) && (
+            (hasPinnedRows || hasFollowingRows || hasAllRows) && (
               <div className="tw-my-2 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700" />
             )}
           {!hideHeaders && hasPinnedRows && (
             <>
-              {!isCollapsed && <SidebarCategoryLabel label="Pinned" />}
+              {!isCollapsed && (
+                <SidebarCategoryLabel
+                  label={t(SIDEBAR_LOCALE, "waves.sidebar.pinned")}
+                />
+              )}
               <SidebarWaveRowsSection
-                ariaLabel="Pinned waves"
+                ariaLabel={t(SIDEBAR_LOCALE, "waves.sidebar.pinnedAriaLabel")}
                 className={sectionClassName}
                 getRowHeight={getSidebarRowHeight}
                 isRowVisible={(row) =>
@@ -499,16 +517,21 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
           )}
           {!hideHeaders &&
             hasPinnedRows &&
-            (hasFollowingRows || hasScoreRows) && (
+            (hasFollowingRows || hasAllRows) && (
               <div className="tw-my-2 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700" />
             )}
           {staticFollowingRows.length > 0 && (
             <>
               {!hideHeaders && !isCollapsed && (
-                <SidebarCategoryLabel label="Following" />
+                <SidebarCategoryLabel
+                  label={t(SIDEBAR_LOCALE, "waves.sidebar.following")}
+                />
               )}
               <SidebarWaveRowsSection
-                ariaLabel="Following waves"
+                ariaLabel={t(
+                  SIDEBAR_LOCALE,
+                  "waves.sidebar.followingAriaLabel"
+                )}
                 className={sectionClassName}
                 getRowHeight={getSidebarRowHeight}
                 isRowVisible={(row) =>
@@ -522,11 +545,13 @@ const WebUnifiedWavesListWaves: React.FC<WebUnifiedWavesListWavesProps> = ({
               />
             </>
           )}
-          {!hideHeaders && staticFollowingRows.length > 0 && hasScoreRows && (
+          {!hideHeaders && staticFollowingRows.length > 0 && hasAllRows && (
             <div className="tw-my-2 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-700" />
           )}
-          {!hideHeaders && !isCollapsed && hasScoreRows && (
-            <SidebarCategoryLabel label="Combined Score" />
+          {!hideHeaders && !isCollapsed && hasAllRows && (
+            <SidebarCategoryLabel
+              label={t(SIDEBAR_LOCALE, "waves.sidebar.all")}
+            />
           )}
           {virtualizedRows.length > 0 ? (
             <section

--- a/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
+++ b/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
@@ -30,6 +30,7 @@ import WavePicture from "../../../waves/WavePicture";
 import { WaveTrustSignals } from "@/components/waves/WaveTrustSignals";
 import MyStreamActionTooltip from "../MyStreamActionTooltip";
 import { useSidebarState } from "../../../../hooks/useSidebarState";
+import WaveRepButton from "@/components/waves/header/rep/WaveRepButton";
 
 const TRUNCATION_EPSILON_PX = 1;
 const WAVE_SCORE_LEARN_MORE_HREF = "/network/wave-score";
@@ -75,6 +76,7 @@ interface MyStreamWaveHeaderIdentityProps {
   readonly wave: ApiWave;
   readonly wavePictureContributors: WavePictureContributors;
   readonly waveScoreLearnMoreHref: string;
+  readonly showWaveRepAction: boolean;
 }
 
 function getWaveScoreLearnMoreHref({
@@ -100,7 +102,21 @@ function MyStreamWaveHeaderIdentity({
   wave,
   wavePictureContributors,
   waveScoreLearnMoreHref,
+  showWaveRepAction,
 }: MyStreamWaveHeaderIdentityProps) {
+  const scoreActions = (
+    <span className="tw-mt-1 tw-flex tw-min-w-0 tw-flex-wrap tw-items-center tw-gap-1.5">
+      <WaveTrustSignals
+        waveRep={wave.wave_rep}
+        waveScore={wave.wave_score}
+        variant="header-inline"
+        mode="summary"
+        learnMoreHref={waveScoreLearnMoreHref}
+      />
+      {showWaveRepAction && <WaveRepButton wave={wave} variant="compact" />}
+    </span>
+  );
+
   if (directMessageProfileHref) {
     return (
       <Link
@@ -175,39 +191,16 @@ function MyStreamWaveHeaderIdentity({
               )}
             </WaveDescriptionPopover>
             {!isCompact && (
-              <WaveTrustSignals
-                waveRep={wave.wave_rep}
-                waveScore={wave.wave_score}
-                variant="header-inline"
-                mode="summary"
-                className="tw-mt-1 tw-self-start"
-                learnMoreHref={waveScoreLearnMoreHref}
-              />
+              <span className="tw-self-start">{scoreActions}</span>
             )}
-            {isCompact && (
-              <WaveTrustSignals
-                waveRep={wave.wave_rep}
-                waveScore={wave.wave_score}
-                variant="header-inline"
-                mode="summary"
-                className="tw-mt-1"
-                learnMoreHref={waveScoreLearnMoreHref}
-              />
-            )}
+            {isCompact && scoreActions}
           </>
         ) : (
           <>
             <h1 className="tw-mb-0 tw-truncate tw-text-sm tw-font-semibold tw-tracking-tight tw-text-white/95 lg:tw-text-xl">
               {wave.name}
             </h1>
-            <WaveTrustSignals
-              waveRep={wave.wave_rep}
-              waveScore={wave.wave_score}
-              variant="header-inline"
-              mode="summary"
-              className="tw-mt-1"
-              learnMoreHref={waveScoreLearnMoreHref}
-            />
+            {scoreActions}
           </>
         )}
       </div>
@@ -245,6 +238,14 @@ export default function MyStreamWaveTabsHeader({
     useState(false);
   const waveChatScroll = useWaveChatScrollOptional();
   const isDirectMessage = wave.chat.scope.group?.is_direct_message ?? false;
+  const connectedHandle = connectedProfile?.handle?.toLowerCase() ?? null;
+  const waveAuthorHandle = wave.author?.handle?.toLowerCase() ?? null;
+  const showWaveRepAction =
+    connectedHandle !== null &&
+    !activeProfileProxy &&
+    !isDirectMessage &&
+    waveAuthorHandle !== null &&
+    connectedHandle !== waveAuthorHandle;
   const directMessageProfileHref = getDirectMessageProfileHref({
     isDirectMessage,
     identity: wave.name,
@@ -431,6 +432,7 @@ export default function MyStreamWaveTabsHeader({
             wave={wave}
             wavePictureContributors={wavePictureContributors}
             waveScoreLearnMoreHref={waveScoreLearnMoreHref}
+            showWaveRepAction={showWaveRepAction}
           />
         </div>
         <div className={actionsClassName}>

--- a/components/waves/WaveTrustSignals.tsx
+++ b/components/waves/WaveTrustSignals.tsx
@@ -1,12 +1,16 @@
 import type { ApiWaveRepSummary } from "@/generated/models/ApiWaveRepSummary";
 import type { ApiWaveScore } from "@/generated/models/ApiWaveScore";
+import HoverCard from "@/components/utils/tooltip/HoverCard";
 import {
   FireIcon,
   ScaleIcon,
   ShieldCheckIcon,
 } from "@heroicons/react/24/outline";
+import { formatInteger, formatNumber } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import Link from "next/link";
-import { useId, type ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
 
 type WaveTrustSignalsVariant =
   | "card"
@@ -23,22 +27,21 @@ interface WaveTrustSignalsProps {
   readonly className?: string | undefined;
   readonly tooltipId?: string | undefined;
   readonly learnMoreHref?: string | undefined;
-  readonly showHeaderRepChip?: boolean | undefined;
 }
 
-const compactNumberFormatter = new Intl.NumberFormat(undefined, {
-  notation: "compact",
-  maximumFractionDigits: 1,
-});
-const fullNumberFormatter = new Intl.NumberFormat();
-const WAVE_SCORE_FORMULA_HINT = "Open Network > Wave Score for the formula";
+const WAVE_TRUST_LOCALE = DEFAULT_LOCALE;
+const compactNumber = (value: number): string =>
+  formatNumber(WAVE_TRUST_LOCALE, value, {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  });
 
 const formatScore = (value: number | null | undefined): string | null => {
   if (value === null || value === undefined || !Number.isFinite(value)) {
     return null;
   }
 
-  return `${Math.round(value)}`;
+  return formatInteger(WAVE_TRUST_LOCALE, Math.round(value));
 };
 
 const formatRep = (value: number | null | undefined): string | null => {
@@ -47,10 +50,10 @@ const formatRep = (value: number | null | undefined): string | null => {
   }
 
   if (value > 0) {
-    return `+${compactNumberFormatter.format(value)}`;
+    return `+${compactNumber(value)}`;
   }
 
-  return compactNumberFormatter.format(value);
+  return compactNumber(value);
 };
 
 const formatSignedFullNumber = (
@@ -60,7 +63,7 @@ const formatSignedFullNumber = (
     return null;
   }
 
-  const formatted = fullNumberFormatter.format(Math.abs(value));
+  const formatted = formatInteger(WAVE_TRUST_LOCALE, Math.abs(value));
   if (value > 0) {
     return `+${formatted}`;
   }
@@ -77,14 +80,20 @@ const formatRepAccessibleValue = (
     return null;
   }
 
-  const formatted = fullNumberFormatter.format(Math.abs(value));
+  const formatted = formatInteger(WAVE_TRUST_LOCALE, Math.abs(value));
   if (value > 0) {
-    return `positive ${formatted}`;
+    return t(WAVE_TRUST_LOCALE, "waves.score.details.repPositive", {
+      value: formatted,
+    });
   }
   if (value < 0) {
-    return `negative ${formatted}`;
+    return t(WAVE_TRUST_LOCALE, "waves.score.details.repNegative", {
+      value: formatted,
+    });
   }
-  return formatted;
+  return t(WAVE_TRUST_LOCALE, "waves.score.details.repNeutral", {
+    value: formatted,
+  });
 };
 
 const isInlineSidebarVariant = (variant: WaveTrustSignalsVariant): boolean =>
@@ -377,15 +386,22 @@ const buildSummaryRepDetail = ({
   readonly repSortScore: string | null;
 }): string | null => {
   if (rawRep !== null && repSortScore !== null) {
-    return `REP: ${rawRep} raw, ${repSortScore} score`;
+    return t(WAVE_TRUST_LOCALE, "waves.score.summary.repRawAndScore", {
+      rawRep,
+      repSortScore,
+    });
   }
 
   if (rawRep !== null) {
-    return `REP: ${rawRep} raw`;
+    return t(WAVE_TRUST_LOCALE, "waves.score.summary.repRaw", {
+      rawRep,
+    });
   }
 
   if (repSortScore !== null) {
-    return `REP score: ${repSortScore}`;
+    return t(WAVE_TRUST_LOCALE, "waves.score.summary.repScore", {
+      repSortScore,
+    });
   }
 
   return null;
@@ -408,16 +424,24 @@ const buildSummaryDetails = ({
   const repDetail = buildSummaryRepDetail({ rawRep, repSortScore });
 
   return [
-    `Combined score: ${visibilityScore}`,
-    "Discovery signal for evaluating new waves",
+    t(WAVE_TRUST_LOCALE, "waves.score.summary.scoreAria", {
+      visibilityScore,
+    }),
     ...(qualityScore === null
       ? []
-      : [`Quality: ${qualityScore} (65% of visibility)`]),
+      : [
+          t(WAVE_TRUST_LOCALE, "waves.score.summary.qualityAria", {
+            qualityScore,
+          }),
+        ]),
     ...(hotnessScore === null
       ? []
-      : [`Hotness: ${hotnessScore} (gated, 35% of visibility)`]),
+      : [
+          t(WAVE_TRUST_LOCALE, "waves.score.summary.hotnessAria", {
+            hotnessScore,
+          }),
+        ]),
     ...(repDetail === null ? [] : [repDetail]),
-    WAVE_SCORE_FORMULA_HINT,
   ];
 };
 
@@ -429,13 +453,18 @@ const buildHotnessDetails = ({
   readonly qualityScore: string | null;
 }): string[] => {
   return [
-    `Hotness score: ${hotnessScore}`,
+    t(WAVE_TRUST_LOCALE, "waves.score.details.hotnessTitle", {
+      hotnessScore,
+    }),
     ...(qualityScore === null
       ? []
-      : [`Quality input: ${qualityScore} (35% of hotness)`]),
-    "Recent trusted activity carries the other 65%",
-    "Hotness is gated by quality before visibility",
-    WAVE_SCORE_FORMULA_HINT,
+      : [
+          t(WAVE_TRUST_LOCALE, "waves.score.details.qualityInput", {
+            qualityScore,
+          }),
+        ]),
+    t(WAVE_TRUST_LOCALE, "waves.score.details.recentTrustedActivity"),
+    t(WAVE_TRUST_LOCALE, "waves.score.details.hotnessQualityGate"),
   ];
 };
 
@@ -449,52 +478,162 @@ const buildRepDetails = ({
   const rawRep = formatSignedFullNumber(waveRep?.total_rep);
 
   return [
-    ...(rawRep === null ? [] : [`Wave REP: ${rawRep} raw`]),
-    ...(repSortScore === null ? [] : [`REP score: ${repSortScore}`]),
-    "REP contributes 35% of quality",
-    WAVE_SCORE_FORMULA_HINT,
+    ...(rawRep === null
+      ? []
+      : [
+          t(WAVE_TRUST_LOCALE, "waves.score.details.repRaw", {
+            rawRep,
+          }),
+        ]),
+    ...(repSortScore === null
+      ? []
+      : [
+          t(WAVE_TRUST_LOCALE, "waves.score.details.repScore", {
+            repSortScore,
+          }),
+        ]),
+    t(WAVE_TRUST_LOCALE, "waves.score.details.repQualityWeight"),
   ];
 };
 
-function WaveScoreSummaryTooltip({
-  details,
-  id,
+function WaveScoreSummaryPopoverContent({
   learnMoreHref,
+  visibilityScore,
+  qualityScore,
+  hotnessScore,
+  repSortScore,
+  waveRep,
 }: {
-  readonly details: readonly string[];
-  readonly id: string;
   readonly learnMoreHref: string;
+  readonly visibilityScore: string;
+  readonly qualityScore: string | null;
+  readonly hotnessScore: string | null;
+  readonly repSortScore: string | null;
+  readonly waveRep: ApiWaveRepSummary | null | undefined;
 }) {
-  const [primaryDetail, ...secondaryDetails] = details;
+  const rawRep = formatSignedFullNumber(waveRep?.total_rep);
+  const rows = [
+    ...(qualityScore === null
+      ? []
+      : [
+          {
+            label: t(WAVE_TRUST_LOCALE, "waves.score.summary.quality"),
+            value: t(WAVE_TRUST_LOCALE, "waves.score.summary.qualityValue", {
+              qualityScore,
+            }),
+          },
+        ]),
+    ...(hotnessScore === null
+      ? []
+      : [
+          {
+            label: t(WAVE_TRUST_LOCALE, "waves.score.summary.hotness"),
+            value: t(WAVE_TRUST_LOCALE, "waves.score.summary.hotnessValue", {
+              hotnessScore,
+            }),
+          },
+        ]),
+    ...(rawRep === null && repSortScore === null
+      ? []
+      : [
+          {
+            label: t(WAVE_TRUST_LOCALE, "waves.score.summary.waveRep"),
+            value:
+              rawRep !== null && repSortScore !== null
+                ? t(
+                    WAVE_TRUST_LOCALE,
+                    "waves.score.summary.repRawAndScoreValue",
+                    {
+                      rawRep,
+                      repSortScore,
+                    }
+                  )
+                : (rawRep ??
+                  t(WAVE_TRUST_LOCALE, "waves.score.summary.repScoreValue", {
+                    repSortScore: repSortScore ?? "",
+                  })),
+          },
+        ]),
+  ];
 
   return (
-    <span
-      id={id}
-      role="tooltip"
-      className="tw-pointer-events-auto tw-absolute tw-left-0 tw-top-full tw-z-[10000] tw-mt-2 tw-hidden tw-w-72 tw-rounded-lg tw-bg-iron-950 tw-p-3 tw-text-left tw-text-xs tw-font-normal tw-leading-5 tw-text-iron-200 tw-shadow-2xl tw-ring-1 tw-ring-white/10 group-focus-within:tw-block group-hover:tw-block"
-    >
-      {primaryDetail && (
-        <span className="tw-block tw-text-sm tw-font-semibold tw-text-white">
-          {primaryDetail}
+    <div className="tw-w-56 tw-bg-iron-950 tw-p-3 tw-text-left tw-text-xs tw-text-iron-300">
+      <div className="tw-flex tw-items-baseline tw-justify-between tw-gap-3">
+        <span className="tw-font-semibold tw-text-white">
+          {t(WAVE_TRUST_LOCALE, "waves.score.summary.title")}
         </span>
+        <span className="tw-font-semibold tw-tabular-nums tw-text-primary-300">
+          {visibilityScore}
+        </span>
+      </div>
+      {rows.length > 0 && (
+        <div className="tw-mt-2 tw-space-y-1.5 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/10 tw-pt-2">
+          {rows.map((row) => (
+            <div
+              key={row.label}
+              className="tw-grid tw-grid-cols-[minmax(0,1fr)_auto] tw-items-baseline tw-gap-3"
+            >
+              <span className="tw-min-w-0 tw-truncate tw-text-iron-500">
+                {row.label}
+              </span>
+              <span className="tw-text-right tw-font-medium tw-tabular-nums tw-text-iron-200">
+                {row.value}
+              </span>
+            </div>
+          ))}
+        </div>
       )}
-      <span className="tw-mt-2 tw-block tw-space-y-1.5">
-        {secondaryDetails.map((detail) => (
-          <span key={detail} className="tw-block tw-text-iron-300">
-            {detail}
-          </span>
-        ))}
-      </span>
       <Link
         href={learnMoreHref}
         className="desktop-hover:hover:tw-text-primary-200 tw-mt-3 tw-inline-flex tw-items-center tw-rounded-md tw-text-xs tw-font-semibold tw-text-primary-300 tw-no-underline tw-transition focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
       >
-        Open full formula
+        {t(WAVE_TRUST_LOCALE, "waves.score.summary.learnMore")}
       </Link>
-    </span>
+    </div>
   );
 }
 
+function WaveScoreSummaryHoverCard({
+  children,
+  learnMoreHref,
+  visibilityScore,
+  qualityScore,
+  hotnessScore,
+  repSortScore,
+  waveRep,
+}: {
+  readonly children: ReactElement;
+  readonly learnMoreHref: string;
+  readonly visibilityScore: string;
+  readonly qualityScore: string | null;
+  readonly hotnessScore: string | null;
+  readonly repSortScore: string | null;
+  readonly waveRep: ApiWaveRepSummary | null | undefined;
+}) {
+  return (
+    <HoverCard
+      ariaLabel={t(WAVE_TRUST_LOCALE, "waves.score.summary.detailsAriaLabel")}
+      placement="bottom"
+      delayShow={100}
+      delayHide={120}
+      hoverTransitionDelay={80}
+      offset={8}
+      openOnClick
+      content={
+        <WaveScoreSummaryPopoverContent
+          learnMoreHref={learnMoreHref}
+          visibilityScore={visibilityScore}
+          qualityScore={qualityScore}
+          hotnessScore={hotnessScore}
+          repSortScore={repSortScore}
+          waveRep={waveRep}
+        />
+      }
+    >
+      {children}
+    </HoverCard>
+  );
+}
 const renderContainer = ({
   children,
   className,
@@ -519,9 +658,7 @@ export function WaveTrustSignals({
   className,
   tooltipId,
   learnMoreHref,
-  showHeaderRepChip = true,
 }: WaveTrustSignalsProps) {
-  const generatedTooltipId = useId();
   const visibilityScore = formatScore(waveScore?.visibility_score);
   const qualityScore = formatScore(waveScore?.quality_score);
   const hotnessScore = formatScore(waveScore?.hotness_score);
@@ -534,10 +671,14 @@ export function WaveTrustSignals({
   }
   let repLabel: string | null = null;
   if (hasRepSummary && repAccessibleValue !== null) {
-    repLabel = `Wave REP ${repAccessibleValue}`;
+    repLabel = t(WAVE_TRUST_LOCALE, "waves.score.details.repAriaRaw", {
+      value: repAccessibleValue,
+    });
   }
   if (!hasRepSummary && repScore !== null) {
-    repLabel = `Wave REP score ${repScore} out of 100`;
+    repLabel = t(WAVE_TRUST_LOCALE, "waves.score.details.repAriaScore", {
+      repScore,
+    });
   }
   const repToneValue =
     waveRep !== null && waveRep !== undefined ? waveRep.total_rep : null;
@@ -576,7 +717,6 @@ export function WaveTrustSignals({
       repSortScore,
       waveRep,
     });
-    const richTooltipId = `${generatedTooltipId}-wave-score-tooltip`;
     const hasRichTooltip = learnMoreHref !== undefined;
     const hasNativeTitle = !hasRichTooltip && !isSidebarVariant(variant);
     const summaryLabel = summaryDetails.join(". ");
@@ -587,16 +727,10 @@ export function WaveTrustSignals({
       mode,
       getVisibilityToneClasses(variant, waveScore?.visibility_score)
     );
-    const richTooltipWrapperClasses =
-      "tw-group tw-relative tw-isolate tw-inline-flex tw-overflow-visible tw-align-middle desktop-hover:hover:tw-z-[10000] focus-within:tw-z-[10000]";
     const summaryButtonResetClasses = isInlineHeaderVariant(variant)
       ? "tw-bg-transparent"
       : "";
     const showSummaryLabel = !isInlineSidebarVariant(variant);
-    const showHeaderRepSummary =
-      showHeaderRepChip && isInlineHeaderVariant(variant) && hasRepScore;
-    const headerRepDetails = buildRepDetails({ repSortScore, waveRep });
-    const headerRepTitle = headerRepDetails.join("\n");
     const summaryChipContent = (
       <>
         <ShieldCheckIcon
@@ -605,7 +739,9 @@ export function WaveTrustSignals({
           aria-hidden="true"
         />
         {showSummaryLabel && (
-          <span className={getChipLabelClasses(variant)}>Score</span>
+          <span className={getChipLabelClasses(variant)}>
+            {t(WAVE_TRUST_LOCALE, "waves.score.details.scoreLabel")}
+          </span>
         )}
         <span className={getValueClasses(variant)}>{visibilityScore}</span>
       </>
@@ -620,21 +756,22 @@ export function WaveTrustSignals({
       children: (
         <>
           {hasRichTooltip ? (
-            <span className={richTooltipWrapperClasses}>
+            <WaveScoreSummaryHoverCard
+              learnMoreHref={learnMoreHref}
+              visibilityScore={visibilityScore}
+              qualityScore={qualityScore}
+              hotnessScore={hotnessScore}
+              repSortScore={repSortScore}
+              waveRep={waveRep}
+            >
               <button
                 type="button"
-                className={`${summaryChipClasses} tw-border-0 tw-font-[inherit] ${summaryButtonResetClasses}`}
+                className={`${summaryChipClasses} tw-border-0 tw-font-[inherit] tw-transition focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950 ${summaryButtonResetClasses}`}
                 aria-label={summaryLabel}
-                aria-describedby={richTooltipId}
               >
                 {summaryChipContent}
               </button>
-              <WaveScoreSummaryTooltip
-                id={richTooltipId}
-                details={summaryDetails}
-                learnMoreHref={learnMoreHref}
-              />
-            </span>
+            </WaveScoreSummaryHoverCard>
           ) : (
             <span
               className={summaryChipClasses}
@@ -643,25 +780,6 @@ export function WaveTrustSignals({
               {...inlineSidebarTooltipAttributes}
             >
               {summaryChipContent}
-            </span>
-          )}
-          {showHeaderRepSummary && (
-            <span
-              className={getChipClasses(
-                variant,
-                mode,
-                getRepToneClasses(repToneValue, variant)
-              )}
-              aria-label={repLabel ?? undefined}
-              title={headerRepTitle}
-            >
-              <ScaleIcon
-                className={getIconClasses(variant)}
-                strokeWidth={isInlineVariant(variant) ? 1.5 : undefined}
-                aria-hidden="true"
-              />
-              <span className={getChipLabelClasses(variant)}>REP</span>
-              <span className={getValueClasses(variant)}>{repScore}</span>
             </span>
           )}
         </>
@@ -703,7 +821,9 @@ export function WaveTrustSignals({
             mode,
             getVisibilityToneClasses(variant, waveScore?.visibility_score)
           )}
-          aria-label={`Visibility score ${visibilityScore} out of 100`}
+          aria-label={t(WAVE_TRUST_LOCALE, "waves.score.details.visibilityAria", {
+            visibilityScore,
+          })}
           title={visibilityTitle}
           {...getTooltipAttributes(
             shouldUseInlineSidebarTooltip ? inlineSidebarTooltipId : undefined,
@@ -716,7 +836,9 @@ export function WaveTrustSignals({
             aria-hidden="true"
           />
           {showLabels && (
-            <span className={getChipLabelClasses(variant)}>Score</span>
+            <span className={getChipLabelClasses(variant)}>
+              {t(WAVE_TRUST_LOCALE, "waves.score.details.scoreLabel")}
+            </span>
           )}
           <span className={getValueClasses(variant)}>{visibilityScore}</span>
         </span>
@@ -733,7 +855,9 @@ export function WaveTrustSignals({
             mode,
             getHotnessToneClasses(variant)
           )}
-          aria-label={`Hotness score ${hotnessScore} out of 100`}
+          aria-label={t(WAVE_TRUST_LOCALE, "waves.score.details.hotnessAria", {
+            hotnessScore: hotnessScore ?? "",
+          })}
           title={hotnessTitle}
           {...getTooltipAttributes(
             shouldUseInlineSidebarTooltip ? inlineSidebarTooltipId : undefined,
@@ -746,7 +870,9 @@ export function WaveTrustSignals({
             aria-hidden="true"
           />
           {showLabels && (
-            <span className={getChipLabelClasses(variant)}>Hot</span>
+            <span className={getChipLabelClasses(variant)}>
+              {t(WAVE_TRUST_LOCALE, "waves.score.details.hotLabel")}
+            </span>
           )}
           <span className={getValueClasses(variant)}>{hotnessScore}</span>
         </span>
@@ -776,7 +902,9 @@ export function WaveTrustSignals({
             aria-hidden="true"
           />
           {showLabels && (
-            <span className={getChipLabelClasses(variant)}>REP</span>
+            <span className={getChipLabelClasses(variant)}>
+              {t(WAVE_TRUST_LOCALE, "waves.score.details.repLabel")}
+            </span>
           )}
           <span className={getValueClasses(variant)}>{repScore}</span>
         </span>

--- a/components/waves/header/rep/WaveRepButton.tsx
+++ b/components/waves/header/rep/WaveRepButton.tsx
@@ -2,25 +2,46 @@
 
 import MyStreamActionTooltip from "@/components/brain/my-stream/MyStreamActionTooltip";
 import type { ApiWave } from "@/generated/models/ApiWave";
+import { formatNumber } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import { ScaleIcon } from "@heroicons/react/24/outline";
 import { useState } from "react";
 import WaveRepRatingModal from "./WaveRepRatingModal";
 
-const compactNumberFormatter = new Intl.NumberFormat(undefined, {
-  notation: "compact",
-  maximumFractionDigits: 1,
-});
+const WAVE_REP_ACTION_LOCALE = DEFAULT_LOCALE;
+const formatCompactRep = (value: number): string =>
+  formatNumber(WAVE_REP_ACTION_LOCALE, value, {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  });
 
-export default function WaveRepButton({ wave }: { readonly wave: ApiWave }) {
+type WaveRepButtonVariant = "default" | "compact";
+
+export default function WaveRepButton({
+  wave,
+  variant = "default",
+}: {
+  readonly wave: ApiWave;
+  readonly variant?: WaveRepButtonVariant | undefined;
+}) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const totalRep = wave.wave_rep?.total_rep ?? null;
+  const authenticatedUserContribution =
+    wave.wave_rep?.authenticated_user_contribution ?? 0;
+  const hasUserContribution = authenticatedUserContribution !== 0;
   const formattedTotalRep =
-    totalRep === null ? null : compactNumberFormatter.format(totalRep);
-  const label =
-    formattedTotalRep === null
-      ? "Add or edit Wave REP"
-      : `Add or edit Wave REP. Current total ${formattedTotalRep}`;
+    totalRep === null ? null : formatCompactRep(totalRep);
+  const actionText = hasUserContribution
+    ? t(WAVE_REP_ACTION_LOCALE, "waves.rep.action.remove")
+    : t(WAVE_REP_ACTION_LOCALE, "waves.rep.action.add");
+  const label = hasUserContribution
+    ? t(WAVE_REP_ACTION_LOCALE, "waves.rep.action.editRemoveAriaLabel", {
+        contribution: formatCompactRep(authenticatedUserContribution),
+      })
+    : t(WAVE_REP_ACTION_LOCALE, "waves.rep.action.addAriaLabel");
   const tooltipId = `wave-rep-rating-${wave.id}`;
+  const isCompact = variant === "compact";
 
   return (
     <>
@@ -30,11 +51,13 @@ export default function WaveRepButton({ wave }: { readonly wave: ApiWave }) {
         data-tooltip-id={tooltipId}
         data-tooltip-content={label}
         onClick={() => setIsModalOpen(true)}
-        className="tw-flex tw-h-8 tw-min-w-8 tw-items-center tw-justify-center tw-gap-x-1.5 tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900 tw-px-2.5 tw-text-xs tw-font-semibold tw-text-iron-200 tw-transition-all tw-duration-200 hover:tw-border-primary-400/70 hover:tw-bg-iron-800 hover:tw-text-white"
+        className={`tw-flex tw-h-8 tw-min-w-8 tw-items-center tw-justify-center tw-gap-x-1.5 tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900 tw-text-xs tw-font-semibold tw-text-iron-200 tw-transition-all tw-duration-200 hover:tw-border-primary-400/70 hover:tw-bg-iron-800 hover:tw-text-white focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950 ${
+          isCompact ? "tw-px-2" : "tw-px-2.5"
+        }`}
       >
         <ScaleIcon className="tw-size-4 tw-flex-shrink-0" aria-hidden="true" />
-        <span>Add REP</span>
-        {formattedTotalRep !== null && (
+        <span>{actionText}</span>
+        {!isCompact && formattedTotalRep !== null && (
           <span className="tw-rounded-md tw-bg-black/25 tw-px-1.5 tw-py-0.5 tw-text-iron-300">
             {formattedTotalRep}
           </span>

--- a/components/waves/header/rep/WaveRepRatingModal.tsx
+++ b/components/waves/header/rep/WaveRepRatingModal.tsx
@@ -11,6 +11,8 @@ import {
   formatNumberWithCommas,
   getStringAsNumberOrZero,
 } from "@/helpers/Helpers";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import { getToastErrorDetails } from "@/helpers/toast.helpers";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useWaveRepAllocation } from "@/hooks/useWaveRepAllocation";
@@ -22,6 +24,7 @@ import { createPortal } from "react-dom";
 
 const WAVE_REP_CATEGORY_PATTERN = /^[\p{L}\p{N}?!,.'() ]{1,100}$/u;
 const CATEGORY_SETTLE_DELAY_MS = 350;
+const WAVE_REP_MODAL_LOCALE = DEFAULT_LOCALE;
 
 function getInitialCategory(wave: ApiWave): string {
   return wave.wave_rep?.categories?.[0]?.category ?? "quality";
@@ -43,7 +46,7 @@ export default function WaveRepRatingModal({
   const categoryErrorId = useId();
   const amountInputId = useId();
   const [isMounted, setIsMounted] = useState(false);
-  const [category, setCategory] = useState(getInitialCategory(wave));
+  const [category, setCategory] = useState(() => getInitialCategory(wave));
   const trimmedCategory = category.trim();
   const debouncedCategory = useDebouncedValue(
     trimmedCategory,
@@ -112,6 +115,10 @@ export default function WaveRepRatingModal({
   const isProxyMode = Boolean(activeProfileProxy);
   const isSaveDisabled =
     isProxyMode || mutating || !allocationReady || !amountValid || !haveChanged;
+  const canRemoveRating =
+    !isProxyMode && !mutating && allocationReady && currentRating !== 0;
+  const hasNoAvailableWaveRep =
+    allocationReady && availableWaveRep <= 0 && currentRating === 0;
 
   const mutation = useMutation({
     mutationFn: async ({
@@ -159,8 +166,7 @@ export default function WaveRepRatingModal({
     },
   });
 
-  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const saveRating = async (nextAmount: number) => {
     if (isProxyMode) {
       setToast({
         message: "Wave REP can't be changed while acting as proxy.",
@@ -168,7 +174,6 @@ export default function WaveRepRatingModal({
       });
       return;
     }
-    const nextAmount = getStringAsNumberOrZero(amountStr);
     const nextAmountValid =
       nextAmount >= minMaxValues.min && nextAmount <= minMaxValues.max;
     if (
@@ -210,6 +215,20 @@ export default function WaveRepRatingModal({
       setMutating(false);
       if (shouldClose) onClose();
     }
+  };
+
+  const onSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await saveRating(getStringAsNumberOrZero(amountStr));
+  };
+
+  const onRemove = async () => {
+    if (!canRemoveRating) {
+      return;
+    }
+    setAmountDirty(true);
+    setAmountStr("0");
+    await saveRating(0);
   };
 
   if (!isMounted || globalThis.document === undefined) {
@@ -323,6 +342,17 @@ export default function WaveRepRatingModal({
               adjustedValue={amount}
               adjustmentType="Wave REP"
             />
+            {hasNoAvailableWaveRep && (
+              <p
+                role="status"
+                className="tw-mb-0 tw-mt-3 tw-rounded-lg tw-border tw-border-solid tw-border-amber-500/30 tw-bg-amber-500/10 tw-px-3 tw-py-2 tw-text-sm tw-font-medium tw-text-amber-200"
+              >
+                {t(
+                  WAVE_REP_MODAL_LOCALE,
+                  "waves.rep.modal.noAvailableCredit"
+                )}
+              </p>
+            )}
           </div>
 
           <div className="tw-mt-8 tw-flex tw-flex-col tw-gap-3 sm:tw-flex-row-reverse">
@@ -346,6 +376,19 @@ export default function WaveRepRatingModal({
                 "Save"
               )}
             </button>
+            {canRemoveRating && (
+              <button
+                type="button"
+                onClick={onRemove}
+                aria-label={t(
+                  WAVE_REP_MODAL_LOCALE,
+                  "waves.rep.modal.removeAriaLabel"
+                )}
+                className="tw-w-full tw-cursor-pointer tw-rounded-lg tw-border tw-border-solid tw-border-red/40 tw-bg-red/10 tw-px-4 tw-py-3 tw-text-sm tw-font-semibold tw-text-red tw-transition hover:tw-border-red/70 hover:tw-bg-red/15 sm:tw-w-auto"
+              >
+                {t(WAVE_REP_MODAL_LOCALE, "waves.rep.modal.remove")}
+              </button>
+            )}
             <button
               type="button"
               onClick={onClose}

--- a/contexts/wave/hooks/useEnhancedWavesListCore.ts
+++ b/contexts/wave/hooks/useEnhancedWavesListCore.ts
@@ -3,6 +3,7 @@
 import type { ApiWaveType } from "@/generated/models/ApiWaveType";
 import type { ApiWaveRepSummary } from "@/generated/models/ApiWaveRepSummary";
 import type { ApiWaveScore } from "@/generated/models/ApiWaveScore";
+import type { SidebarDiscoverySection } from "@/hooks/useWavesList";
 import type { SidebarWave, SidebarWaveContributor } from "@/types/waves.types";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { MinimalWaveNewDropsCount } from "./useNewDropCounter";
@@ -29,11 +30,13 @@ export interface MinimalWave {
   firstUnreadDropSerialNo: number | null;
   waveRep: ApiWaveRepSummary | null;
   waveScore: ApiWaveScore | null;
+  sidebarSection: SidebarDiscoverySection | null;
 }
 
 type EnhancedSidebarWave = SidebarWave & {
   readonly isPinned?: boolean;
   readonly isOfficial?: boolean;
+  readonly sidebarSection?: SidebarDiscoverySection;
 };
 
 interface WavesDataSource {
@@ -190,6 +193,7 @@ function useEnhancedWavesListCore(
         firstUnreadDropSerialNo,
         waveRep: wave.waveRep,
         waveScore: wave.waveScore,
+        sidebarSection: wave.sidebarSection ?? null,
       };
     },
     [

--- a/hooks/usePinnedWavesServer.ts
+++ b/hooks/usePinnedWavesServer.ts
@@ -61,7 +61,7 @@ function createPinnedWavesQueryKey(
   return [
     QueryKey.WAVES_V2,
     getWavesV2OverviewQueryKeyParams({
-      overviewType: ApiWavesOverviewType.MostSubscribed,
+      overviewType: ApiWavesOverviewType.RecentlyDroppedTo,
       pageSize: PINNED_WAVES_QUERY_LIMIT,
       pinned: ApiWavesPinFilter.Pinned,
       viewerIdentityKey,
@@ -86,7 +86,7 @@ async function fetchPinnedWavesPages(): Promise<SidebarWave[]> {
     const page = await fetchWavesV2Page({
       page: pageNumber,
       pageSize: PINNED_WAVES_API_PAGE_SIZE,
-      overviewType: ApiWavesOverviewType.MostSubscribed,
+      overviewType: ApiWavesOverviewType.RecentlyDroppedTo,
       pinned: ApiWavesPinFilter.Pinned,
     });
 

--- a/hooks/useWavesList.ts
+++ b/hooks/useWavesList.ts
@@ -11,6 +11,8 @@ import {
   WAVE_FOLLOWING_WAVES_PARAMS,
   WAVE_SCORE_DISCOVERY_PARAMS,
 } from "@/components/react-query-wrapper/utils/query-utils";
+import { ApiWaveScoreSort } from "@/generated/models/ApiWaveScoreSort";
+import { ApiWavesPinFilter } from "@/generated/models/ApiWavesPinFilter";
 import { usePinnedWavesServer } from "./usePinnedWavesServer";
 import { useWaveById } from "./useWaveById";
 import {
@@ -18,7 +20,6 @@ import {
   useWaveSubwavesMap,
 } from "./useWaveSubwaves";
 import { useShowFollowingWaves } from "./useShowFollowingWaves";
-import { useOfficialWaves } from "./useOfficialWaves";
 import type { SidebarWave } from "@/types/waves.types";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -26,9 +27,19 @@ import { useQueryClient } from "@tanstack/react-query";
 type EnhancedWave = SidebarWave & {
   readonly isPinned: boolean;
   readonly isOfficial?: boolean;
+  readonly sidebarSection?: SidebarDiscoverySection;
 };
 
-// V2 overview, pinned, official, and announcement wave sources are root-wave
+export type SidebarDiscoverySection = "highly-rated" | "all";
+
+type SidebarWaveWithDiscoverySection = SidebarWave & {
+  readonly sidebarSection?: SidebarDiscoverySection;
+};
+
+const HIGHLY_RATED_WAVE_LIMIT = 3;
+const HIGHLY_RATED_QUERY_PAGE_SIZE = 10;
+
+// V2 overview, pinned, and announcement wave sources are root-wave
 // sources. This guard is defensive against stale or malformed cached data; it is
 // not intended to hide user-visible subwaves.
 const isExpectedRootSidebarWave = (wave: SidebarWave) =>
@@ -74,22 +85,45 @@ const useWavesList = () => {
     return `${normalizedAddress}:primary`;
   }, [address, activeProfileProxy?.id]);
 
-  // Fetch score-ranked waves for sidebar discovery.
+  const nonPinnedFilter = isConnectedIdentity
+    ? ApiWavesPinFilter.NotPinned
+    : undefined;
+
+  // Fetch the best quality-ranked waves that are neither pinned nor followed.
   const {
-    waves: scoreWaves,
-    isFetching: isScoreWavesFetching,
-    isFetchingNextPage: isScoreWavesFetchingNextPage,
-    hasNextPage: hasScoreWavesNextPage,
-    fetchNextPage: fetchNextScoreWavesPage,
-    status: scoreWavesStatus,
-    refetch: scoreWavesRefetch,
+    waves: highlyRatedWaves,
+    isFetching: isHighlyRatedWavesFetching,
+    refetch: highlyRatedWavesRefetch,
+  } = useWavesV2({
+    overviewType: WAVE_SCORE_DISCOVERY_PARAMS.overviewType,
+    pageSize: HIGHLY_RATED_QUERY_PAGE_SIZE,
+    following: false,
+    directMessage: false,
+    excludeFollowed: isConnectedIdentity ? true : undefined,
+    pinned: nonPinnedFilter,
+    scoreSort: ApiWaveScoreSort.Quality,
+    viewerIdentityKey,
+    refetchInterval: SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
+    refetchIntervalInBackground: false,
+    enabled: !following,
+  });
+  // Fetch quality-ranked waves for the broad discovery section and pagination.
+  const {
+    waves: allQualityWaves,
+    isFetching: isAllQualityWavesFetching,
+    isFetchingNextPage: isAllQualityWavesFetchingNextPage,
+    hasNextPage: hasAllQualityWavesNextPage,
+    fetchNextPage: fetchNextAllQualityWavesPage,
+    status: allQualityWavesStatus,
+    refetch: allQualityWavesRefetch,
   } = useWavesV2({
     overviewType: WAVE_SCORE_DISCOVERY_PARAMS.overviewType,
     pageSize: WAVE_FOLLOWING_WAVES_PARAMS.limit,
     following: false,
     directMessage: false,
     excludeFollowed: isConnectedIdentity ? true : undefined,
-    scoreSort: WAVE_SCORE_DISCOVERY_PARAMS.scoreSort,
+    pinned: nonPinnedFilter,
+    scoreSort: ApiWaveScoreSort.Quality,
     viewerIdentityKey,
     refetchInterval: SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
     refetchIntervalInBackground: false,
@@ -116,62 +150,55 @@ const useWavesList = () => {
     refetchIntervalInBackground: false,
     enabled: isConnectedIdentity,
   });
-  const mainWaves = useMemo(
+  const mainWaves = useMemo<SidebarWaveWithDiscoverySection[]>(
     () =>
       following
         ? followedActivityWaves
-        : [...followedActivityWaves, ...scoreWaves],
-    [following, followedActivityWaves, scoreWaves]
+        : [
+            ...followedActivityWaves,
+            // Keep the highly-rated slice before the broader all-quality list:
+            // duplicate wave ids retain their first sidebarSection during merge.
+            ...highlyRatedWaves.slice(0, HIGHLY_RATED_WAVE_LIMIT).map(
+              (wave): SidebarWaveWithDiscoverySection => ({
+                ...wave,
+                sidebarSection: "highly-rated",
+              })
+            ),
+            ...allQualityWaves.map(
+              (wave): SidebarWaveWithDiscoverySection => ({
+                ...wave,
+                sidebarSection: "all",
+              })
+            ),
+          ],
+    [following, followedActivityWaves, highlyRatedWaves, allQualityWaves]
   );
   const isMainWavesFetching = following
     ? isFollowedActivityWavesFetching
-    : isScoreWavesFetching || isFollowedActivityWavesFetching;
+    : isAllQualityWavesFetching ||
+      isHighlyRatedWavesFetching ||
+      isFollowedActivityWavesFetching;
   const isMainWavesFetchingNextPage = following
     ? isFollowedActivityWavesFetchingNextPage
-    : isScoreWavesFetchingNextPage;
+    : isAllQualityWavesFetchingNextPage;
   const hasMainWavesNextPage = following
     ? hasFollowedActivityWavesNextPage
-    : hasScoreWavesNextPage;
+    : hasAllQualityWavesNextPage;
   const fetchNextMainWavesPage = following
     ? fetchNextFollowedActivityWavesPage
-    : fetchNextScoreWavesPage;
+    : fetchNextAllQualityWavesPage;
   const mainWavesStatus = following
     ? followedActivityWavesStatus
-    : scoreWavesStatus;
+    : allQualityWavesStatus;
   const mainWavesRefetch = following
     ? followedActivityWavesRefetch
-    : scoreWavesRefetch;
-  const {
-    waves: officialWaves,
-    isFetching: isOfficialWavesFetching,
-    refetch: officialWavesRefetch,
-  } = useOfficialWaves({
-    viewerIdentityKey,
-    refetchInterval: SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
-    refetchIntervalInBackground: false,
-  });
-  const officialWaveIds = useMemo(
-    () => new Set(officialWaves.map((wave) => wave.id)),
-    [officialWaves]
-  );
-  const visibleOfficialWaves = useMemo(
-    () =>
-      officialWaves.filter(
-        (wave) =>
-          !wave.isDirectMessage &&
-          isExpectedRootSidebarWave(wave) &&
-          !isAnnouncementsWave(wave.id)
-      ),
-    [officialWaves, isAnnouncementsWave]
-  );
-
+    : allQualityWavesRefetch;
   const trackedAnnouncementWave = useMemo(
     () =>
       mainWaves.find((wave) => isAnnouncementsWave(wave.id)) ??
-      officialWaves.find((wave) => isAnnouncementsWave(wave.id)) ??
       serverPinnedWaves.find((wave) => isAnnouncementsWave(wave.id)) ??
       null,
-    [mainWaves, officialWaves, serverPinnedWaves, isAnnouncementsWave]
+    [mainWaves, serverPinnedWaves, isAnnouncementsWave]
   );
   const shouldFetchAnnouncementWave = Boolean(
     announcementsWaveId && !trackedAnnouncementWave
@@ -213,7 +240,7 @@ const useWavesList = () => {
   const mainWavesMap = useMemo(() => {
     const map = new Map<string, SidebarWave>();
     mainWaves.forEach((wave) => {
-      if (!isAnnouncementsWave(wave.id) && !officialWaveIds.has(wave.id)) {
+      if (!isAnnouncementsWave(wave.id)) {
         if (!isExpectedRootSidebarWave(wave)) {
           return;
         }
@@ -221,7 +248,7 @@ const useWavesList = () => {
       }
     });
     return map;
-  }, [mainWaves, isAnnouncementsWave, officialWaveIds]);
+  }, [mainWaves, isAnnouncementsWave]);
 
   // Set of wave IDs in the main list for quick checking
   const mainWaveIds = useMemo(() => {
@@ -238,10 +265,9 @@ const useWavesList = () => {
       (wave) =>
         !mainWaveIds.has(wave.id) &&
         isExpectedRootSidebarWave(wave) &&
-        !isAnnouncementsWave(wave.id) &&
-        !officialWaveIds.has(wave.id)
+        !isAnnouncementsWave(wave.id)
     );
-  }, [serverPinnedWaves, mainWaveIds, isAnnouncementsWave, officialWaveIds]);
+  }, [serverPinnedWaves, mainWaveIds, isAnnouncementsWave]);
 
   // Collect ALL pinned waves (both from mainWaves and server-provided)
   const allPinnedWaves = useMemo(() => {
@@ -252,15 +278,14 @@ const useWavesList = () => {
       if (
         !wave.isDirectMessage &&
         isExpectedRootSidebarWave(wave) &&
-        !isAnnouncementsWave(wave.id) &&
-        !officialWaveIds.has(wave.id)
+        !isAnnouncementsWave(wave.id)
       ) {
         result.push({ ...wave, isPinned: true });
       }
     });
 
     return result;
-  }, [serverPinnedWaves, isAnnouncementsWave, officialWaveIds]);
+  }, [serverPinnedWaves, isAnnouncementsWave]);
 
   // New drops counts are now managed externally
 
@@ -275,29 +300,22 @@ const useWavesList = () => {
       if (
         wave.isDirectMessage ||
         !isExpectedRootSidebarWave(wave) ||
-        isAnnouncementsWave(wave.id) ||
-        officialWaveIds.has(wave.id)
+        isAnnouncementsWave(wave.id)
       ) {
         return;
       }
 
       const existingWave = allWavesMap.get(wave.id);
+      const sidebarSection: SidebarDiscoverySection | undefined = (
+        wave as SidebarWaveWithDiscoverySection
+      ).sidebarSection;
       allWavesMap.set(wave.id, {
         ...wave,
         subscribed: existingWave?.subscribed || wave.subscribed,
         isPinned: pinnedWavesSet.has(wave.id),
+        sidebarSection: existingWave?.sidebarSection ?? sidebarSection ?? "all",
       });
     });
-
-    const sortedOfficialWaves = visibleOfficialWaves
-      .map((wave) => ({
-        ...wave,
-        isPinned: pinnedWavesSet.has(wave.id),
-        isOfficial: true,
-      }))
-      .sort(
-        (a, b) => (b.latestDropTimestamp ?? 0) - (a.latestDropTimestamp ?? 0)
-      );
 
     const nonAnnouncementWaves = [...allWavesMap.values()];
     const sortedPinnedWaves = nonAnnouncementWaves
@@ -310,10 +328,20 @@ const useWavesList = () => {
       .sort(
         (a, b) => (b.latestDropTimestamp ?? 0) - (a.latestDropTimestamp ?? 0)
       );
+    const highlyRatedDiscoveryWaves = nonAnnouncementWaves.filter(
+      (wave) =>
+        !wave.isPinned &&
+        !wave.subscribed &&
+        wave.sidebarSection === "highly-rated"
+    );
     const backendOrderedScoreWaves = nonAnnouncementWaves.filter(
-      (wave) => !wave.isPinned && !wave.subscribed
+      (wave) =>
+        !wave.isPinned &&
+        !wave.subscribed &&
+        wave.sidebarSection !== "highly-rated"
     );
     const sortedNonAnnouncementWaves = [
+      ...highlyRatedDiscoveryWaves,
       ...sortedPinnedWaves,
       ...activityOrderedFollowingWaves,
       ...backendOrderedScoreWaves,
@@ -326,18 +354,15 @@ const useWavesList = () => {
       });
     }
 
-    allWavesArray.push(...sortedOfficialWaves);
     allWavesArray.push(...sortedNonAnnouncementWaves);
 
     return allWavesArray;
   }, [
     mainWaves,
     separatelyFetchedPinnedWaves,
-    visibleOfficialWaves,
     pinnedIds,
     announcementWave,
     isAnnouncementsWave,
-    officialWaveIds,
   ]);
 
   const [loadedSubwaveParentIds, setLoadedSubwaveParentIds] = useState<
@@ -386,20 +411,20 @@ const useWavesList = () => {
     viewerIdentityKey,
   });
 
-  // Function to refetch all waves (main, pinned, official, announcements, subwaves)
+  // Function to refetch all waves (main, pinned, announcements, subwaves)
   const refetchAllWaves = useCallback(() => {
-    scoreWavesRefetch();
+    allQualityWavesRefetch();
+    highlyRatedWavesRefetch();
     followedActivityWavesRefetch();
-    officialWavesRefetch();
     void refetchPinnedWaves();
     refetchSubwaves();
     if (shouldFetchAnnouncementWave) {
       void announcementRefetch();
     }
   }, [
-    scoreWavesRefetch,
+    allQualityWavesRefetch,
+    highlyRatedWavesRefetch,
     followedActivityWavesRefetch,
-    officialWavesRefetch,
     refetchPinnedWaves,
     refetchSubwaves,
     announcementRefetch,
@@ -431,7 +456,7 @@ const useWavesList = () => {
       waves: allWaves,
 
       // Original waves pagination and loading
-      isFetching: isMainWavesFetching || isOfficialWavesFetching,
+      isFetching: isMainWavesFetching,
       isFetchingNextPage: isMainWavesFetchingNextPage,
       hasNextPage: hasMainWavesNextPage,
       fetchNextPage: fetchNextPageStable,
@@ -463,7 +488,6 @@ const useWavesList = () => {
     [
       allWaves,
       isMainWavesFetching,
-      isOfficialWavesFetching,
       isMainWavesFetchingNextPage,
       hasMainWavesNextPage,
       fetchNextPageStable,

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -258,6 +258,72 @@ const FOLLOWERS_MESSAGES = objectMessages("followers", {
   "profile.avatarAlt": "{handle}'s profile image",
 } as const);
 
+const WAVES_SIDEBAR_MESSAGES = objectMessages("waves.sidebar", {
+  highlyRated: "Highly Rated",
+  pinned: "Pinned",
+  following: "Following",
+  all: "All",
+  highlyRatedAriaLabel: "Highly rated waves",
+  pinnedAriaLabel: "Pinned waves",
+  followingAriaLabel: "Following waves",
+  followingListAriaLabel: "Following waves list",
+  allQualityRankedAriaLabel: "All quality-ranked waves list",
+} as const);
+
+const WAVE_SCORE_SUMMARY_MESSAGES = objectMessages("waves.score.summary", {
+  title: "Score",
+  quality: "Quality",
+  hotness: "Hotness",
+  waveRep: "Wave REP",
+  learnMore: "Learn more",
+  detailsAriaLabel: "Wave score details",
+  scoreAria: "Wave score {visibilityScore}",
+  qualityAria: "Quality {qualityScore}, 65% of visibility",
+  hotnessAria: "Hotness {hotnessScore}, gated, 35% of visibility",
+  repRawAndScore: "REP: {rawRep} raw, {repSortScore} score",
+  repRaw: "REP: {rawRep} raw",
+  repScore: "REP score: {repSortScore}",
+  qualityValue: "{qualityScore} / 65%",
+  hotnessValue: "{hotnessScore} / 35% gated",
+  repRawAndScoreValue: "{rawRep} / score {repSortScore}",
+  repScoreValue: "score {repSortScore}",
+} as const);
+
+const WAVE_SCORE_DETAILS_MESSAGES = objectMessages("waves.score.details", {
+  visibilityAria: "Visibility score {visibilityScore} out of 100",
+  hotnessAria: "Hotness score {hotnessScore} out of 100",
+  hotnessTitle: "Hotness score: {hotnessScore}",
+  qualityInput: "Quality input: {qualityScore} (35% of hotness)",
+  recentTrustedActivity: "Recent trusted activity carries the other 65%",
+  hotnessQualityGate: "Hotness is gated by quality before visibility",
+  repRaw: "Wave REP: {rawRep} raw",
+  repScore: "REP score: {repSortScore}",
+  repQualityWeight: "REP contributes 35% of quality",
+  repPositive: "positive {value}",
+  repNegative: "negative {value}",
+  repNeutral: "{value}",
+  repAriaRaw: "Wave REP {value}",
+  repAriaScore: "Wave REP score {repScore} out of 100",
+  scoreLabel: "Score",
+  hotLabel: "Hot",
+  repLabel: "REP",
+} as const);
+
+const WAVE_REP_ACTION_MESSAGES = objectMessages("waves.rep.action", {
+  add: "Add REP",
+  remove: "Remove REP",
+  addAriaLabel: "Add Wave REP to this wave",
+  editRemoveAriaLabel:
+    "Edit or remove your Wave REP for this wave. Current contribution {contribution}",
+} as const);
+
+const WAVE_REP_MODAL_MESSAGES = objectMessages("waves.rep.modal", {
+  remove: "Remove",
+  removeAriaLabel: "Remove Wave REP",
+  noAvailableCredit:
+    "No available Wave REP credit for this category. You can adjust existing REP when you have a current contribution, or come back when more credit is available.",
+} as const);
+
 const ABOUT_TECH_MESSAGES = objectMessages("about.tech", {
   "metadata.title": "Tech",
   "metadata.description": "About",
@@ -806,6 +872,11 @@ export const EN_US_MESSAGES = {
   "user.collected.networkCards.xtdhPerDay": "xTDH/day",
   ...USER_PROFILE_TABS_MESSAGES,
   ...FOLLOWERS_MESSAGES,
+  ...WAVES_SIDEBAR_MESSAGES,
+  ...WAVE_SCORE_SUMMARY_MESSAGES,
+  ...WAVE_SCORE_DETAILS_MESSAGES,
+  ...WAVE_REP_ACTION_MESSAGES,
+  ...WAVE_REP_MODAL_MESSAGES,
   ...ABOUT_TECH_MESSAGES,
   ...REMEMES_DETAIL_MESSAGES,
 } as const;

--- a/services/api/waves-v2-api.ts
+++ b/services/api/waves-v2-api.ts
@@ -415,11 +415,7 @@ export async function searchWavesByName({
   let firstSearchError: unknown;
 
   try {
-    const waves = await searchWavesV2ByName({ name, pageSize, headers });
-    completedSearches += 1;
-    if (waves.length > 0) {
-      return waves;
-    }
+    return await searchWavesV2ByName({ name, pageSize, headers });
   } catch (error) {
     failedSearches += 1;
     primarySearchError = error;


### PR DESCRIPTION
## Issue
- Wave score UI still had too much friction in the sidebar and wave header.
- Known waves should prioritize recent activity, while discovery should prioritize score quality.
- Wave score calculator search should rely on the v2 wave search path when available.

## Fix
- Reworked the left sidebar into score/discovery and known-wave sections: Highly Rated, Pinned, Following, and All.
- Replaced the passive header REP display with an Add/Remove REP action chip.
- Polished the wave score hover card with compact score details and a Learn more CTA.
- Made wave-score calculator search use v2 search as authoritative when v2 responds, keeping legacy fallback only for v2 errors.

## Changes
- Sidebar score queries now request quality-ranked, not-pinned, not-followed waves for Highly Rated and All.
- Pinned and followed waves are activity ordered by latest post.
- Wave header score chip opens a proper hover/focus/click card rather than a hard-to-hit native tooltip.
- Wave REP modal can remove an existing rating by submitting zero.
- Tests cover sidebar grouping, Wave REP add/remove state, tooltip content, pinned sorting, and wave search fallback behavior.

## Validation
- `seize run lint:changed`
- `seize run typecheck:changed`
- `seize run test:no-coverage -- __tests__/components/waves/WaveTrustSignals.test.tsx __tests__/components/waves/header/WaveHeader.test.tsx __tests__/components/waves/header/rep/WaveRepRatingModal.test.tsx __tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx __tests__/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.test.tsx __tests__/hooks/useWavesList.test.tsx __tests__/hooks/usePinnedWavesServer.test.tsx __tests__/services/api/waves-v2-api.test.ts`
- `codex-diff-check`
- `seize run react-doctor:diff` was run during the uncommitted diff pass; it reported existing structural warnings plus one lazy-state warning that this PR fixed. After commit, the diff helper skipped because it compares the current branch to HEAD.

## Risk
- Level: Medium
- Why: changes high-traffic sidebar ordering, wave header controls, and the calculator search path.
- Rollback: revert this frontend commit; backend contracts are unchanged.

## Review Notes
- Please focus on sidebar grouping semantics, score chip hover/click behavior, and the Wave REP add/remove flow.