### PR TITLE
Fix boosted post card accessibility

### DIFF
--- a/__tests__/components/home/boosted/BoostedDropCardHome.test.tsx
+++ b/__tests__/components/home/boosted/BoostedDropCardHome.test.tsx
@@ -555,7 +555,7 @@ describe("BoostedDropCardHome", () => {
     expect(onClick).not.toHaveBeenCalled();
   });
 
-  it("opens the card from its explicit open control", () => {
+  it("opens the card from its semantic open control", () => {
     const onClick = jest.fn();
 
     renderWithAuth(
@@ -567,7 +567,11 @@ describe("BoostedDropCardHome", () => {
       />
     );
 
-    fireEvent.click(screen.getByLabelText("Open boosted post from alice"));
+    const openButton = screen.getByRole("button", {
+      name: "Open boosted post from alice",
+    });
+
+    fireEvent.click(openButton);
 
     expect(onClick).toHaveBeenCalledTimes(1);
   });

--- a/__tests__/components/home/boosted/BoostedDropLinkPreview.test.tsx
+++ b/__tests__/components/home/boosted/BoostedDropLinkPreview.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import BoostedDropLinkPreview from "@/components/home/boosted/BoostedDropLinkPreview";
+
+jest.mock("@/services/api/link-preview-api", () => ({
+  fetchLinkPreview: jest.fn(),
+}));
+
+describe("BoostedDropLinkPreview", () => {
+  const { fetchLinkPreview } = require("@/services/api/link-preview-api");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the known 6529 Wave Score route with message-backed fallback copy", async () => {
+    fetchLinkPreview.mockResolvedValue({});
+
+    render(
+      <BoostedDropLinkPreview
+        href="https://6529.io/network/wavescore"
+        variant="chat"
+      />
+    );
+
+    const link = await screen.findByRole("link", {
+      name: /Network: Wave Score/i,
+    });
+
+    expect(link).toHaveAttribute("href", "https://6529.io/network/wavescore");
+    expect(screen.getByText("6529")).toBeInTheDocument();
+    expect(screen.getByText("6529.io link")).toBeInTheDocument();
+    expect(fetchLinkPreview).toHaveBeenCalledWith(
+      "https://6529.io/network/wavescore"
+    );
+  });
+
+  it("uses literal internal paths for unknown 6529 routes", async () => {
+    fetchLinkPreview.mockResolvedValue({});
+
+    render(
+      <BoostedDropLinkPreview
+        href="https://6529.io/network/alpha-beta?tab=posts"
+        variant="chat"
+      />
+    );
+
+    expect(
+      await screen.findByText("6529.io/network/alpha-beta?tab=posts")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Network / Alpha Beta")).not.toBeInTheDocument();
+  });
+
+  it("keeps fallback link clicks out of the parent card open action", async () => {
+    const onParentClick = jest.fn();
+    const host = document.createElement("div");
+    const root = document.createElement("div");
+    fetchLinkPreview.mockResolvedValue({});
+    host.appendChild(root);
+    document.body.appendChild(host);
+    host.addEventListener("click", onParentClick);
+
+    const { unmount } = render(
+      <BoostedDropLinkPreview
+        href="https://6529.io/network/wavescore"
+        variant="chat"
+      />,
+      { container: root }
+    );
+
+    try {
+      fireEvent.click(
+        await screen.findByRole("link", { name: /Network: Wave Score/i })
+      );
+
+      expect(onParentClick).not.toHaveBeenCalled();
+    } finally {
+      unmount();
+      host.remove();
+    }
+  });
+});

--- a/components/home/boosted/BoostedDropCardHome.tsx
+++ b/components/home/boosted/BoostedDropCardHome.tsx
@@ -43,23 +43,21 @@ const CLICKABLE_CARD_CLASS = "tw-cursor-pointer";
 const CARD_BORDER_CLASSES =
   "tw-pointer-events-none tw-absolute tw-inset-0 tw-z-20 tw-rounded-xl tw-border tw-border-solid tw-border-white/5";
 const HEADER_CLASSES =
-  "tw-absolute tw-left-3 tw-right-3 tw-top-3 tw-z-30 tw-flex tw-flex-nowrap tw-items-center tw-justify-between tw-gap-2";
+  "tw-pointer-events-none tw-absolute tw-left-3 tw-right-3 tw-top-3 tw-z-30 tw-flex tw-flex-nowrap tw-items-center tw-justify-between tw-gap-2";
 const CHAT_HEADER_CLASSES =
-  "tw-relative tw-z-10 tw-flex tw-min-w-0 tw-items-center tw-justify-between tw-gap-3 tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-800/80 tw-bg-iron-950/90 tw-px-4 tw-py-2.5";
+  "tw-pointer-events-none tw-relative tw-z-30 tw-flex tw-min-w-0 tw-items-center tw-justify-between tw-gap-3 tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-iron-800/80 tw-bg-iron-950/90 tw-px-4 tw-py-2.5";
 const HEADER_LEFT_CLASSES =
   "tw-flex tw-min-w-0 tw-items-center tw-gap-2 tw-overflow-hidden";
 const PILL_CLASSES =
   "tw-flex tw-items-center tw-rounded-full tw-border tw-border-solid tw-border-white/10 tw-bg-black/40 tw-px-2.5 tw-py-1 tw-shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] tw-backdrop-blur-md tw-transition-colors group-hover:tw-bg-black/60";
 const FOOTER_CLASSES =
-  "tw-relative tw-z-10 tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-900 tw-bg-black/70 tw-px-4 tw-py-3";
-const AUTHOR_LINK_CLASSES =
+  "tw-relative tw-z-30 tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-900 tw-bg-black/70 tw-px-4 tw-py-3";
+const PROFILE_LINK_CLASSES =
   "tw-flex tw-max-w-full tw-flex-wrap tw-items-center tw-gap-2 tw-rounded-md tw-no-underline tw-transition-opacity desktop-hover:hover:tw-opacity-80 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400";
 const WAVE_LINK_CLASSES =
   "tw-group/wave tw-flex tw-max-w-full tw-flex-wrap tw-items-center tw-gap-2 tw-rounded-full tw-bg-white/5 tw-py-1 tw-pl-2.5 tw-pr-1 tw-no-underline tw-transition-all active:tw-scale-95 desktop-hover:hover:tw-bg-white/10 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400";
 const OPEN_DROP_BUTTON_CLASSES =
-  "tw-sr-only focus:tw-not-sr-only focus:tw-absolute focus:tw-left-3 focus:tw-top-3 focus:tw-z-40 focus:tw-rounded-md focus:tw-border focus:tw-border-solid focus:tw-border-primary-400 focus:tw-bg-iron-950 focus:tw-px-3 focus:tw-py-1.5 focus:tw-text-xs focus:tw-font-semibold focus:tw-text-iron-50 focus:tw-outline focus:tw-outline-2 focus:tw-outline-offset-2 focus:tw-outline-primary-400";
-const CARD_INTERACTIVE_TARGET_SELECTOR =
-  'a, button, input, select, textarea, summary, [role="button"], [role="link"], [contenteditable="true"]';
+  "tw-absolute tw-inset-0 tw-z-20 tw-m-0 tw-block tw-h-full tw-w-full tw-cursor-pointer tw-rounded-[inherit] tw-border-0 tw-bg-transparent tw-p-0 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400";
 
 const getBoostLabel = (boosts: number): string =>
   t(
@@ -77,22 +75,6 @@ const getOpenDropLabel = (authorHandle: string | null | undefined): string =>
   t(DEFAULT_LOCALE, "home.boostedDrop.openDrop", {
     author: getAuthorLabel(authorHandle),
   });
-
-const isInteractiveEventTarget = (target: EventTarget | null): boolean =>
-  target instanceof Element &&
-  Boolean(target.closest(CARD_INTERACTIVE_TARGET_SELECTOR));
-
-const useCardClick = (onClick?: () => void) =>
-  useCallback(
-    (event: ReactMouseEvent<HTMLElement>) => {
-      if (!onClick || isInteractiveEventTarget(event.target)) {
-        return;
-      }
-
-      onClick();
-    },
-    [onClick]
-  );
 
 const BoostedDropCardChatBoostButton = memo(
   ({ drop }: { readonly drop: ApiDrop }) => {
@@ -256,7 +238,7 @@ const BoostedDropCardFooter = memo(
       <Link
         href={author.handle ? `/${author.handle}` : "#"}
         onClick={(event) => event.stopPropagation()}
-        className={AUTHOR_LINK_CLASSES}
+        className={PROFILE_LINK_CLASSES}
         aria-label={t(DEFAULT_LOCALE, "home.boostedDrop.viewAuthor", {
           author: getAuthorLabel(author.handle),
         })}
@@ -315,12 +297,9 @@ const BoostedDropCardOpenButton = memo(
       <button
         type="button"
         className={OPEN_DROP_BUTTON_CLASSES}
-        onClick={(event) => {
-          event.stopPropagation();
-          onClick();
-        }}
+        onClick={onClick}
       >
-        {label}
+        <span className="tw-sr-only">{label}</span>
       </button>
     );
   }
@@ -335,7 +314,6 @@ const BoostedDropCardHome = memo(
     const fireIconsToShow = Math.min(boosts, MAX_FIRE_ICONS);
     const remainingBoosts = Math.max(boosts - MAX_FIRE_ICONS, 0);
     const isChatVariant = variant === "chat";
-    const handleCardClick = useCardClick(onClick);
     const openDropLabel = getOpenDropLabel(author.handle);
     const waveHref = getWaveRoute({
       waveId: wave.id,
@@ -345,8 +323,6 @@ const BoostedDropCardHome = memo(
 
     return (
       <article
-        aria-label={openDropLabel}
-        onClick={handleCardClick}
         className={`${isChatVariant ? CHAT_CARD_CLASSES : HOME_CARD_CLASSES} ${
           onClick ? CLICKABLE_CARD_CLASS : ""
         }`}

--- a/components/home/boosted/BoostedDropCardHomeContent.tsx
+++ b/components/home/boosted/BoostedDropCardHomeContent.tsx
@@ -38,13 +38,13 @@ const CHAT_TEXT_CONTAINER_CLASSES = `tw-relative tw-flex ${CHAT_TEXT_MAX_HEIGHT_
 const HOME_PREVIEW_CONTAINER_CLASSES = `tw-relative tw-flex ${HOME_ASPECT_RATIO_CLASSES} tw-w-full tw-flex-col tw-items-stretch tw-justify-stretch tw-gap-3 tw-overflow-hidden tw-rounded-xl`;
 const HOME_TEXT_CONTAINER_CLASSES = `tw-relative tw-flex ${HOME_ASPECT_RATIO_CLASSES} tw-w-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-xl tw-px-6 tw-pb-6 sm:tw-pb-0 tw-pt-4 sm:tw-pt-16 md:tw-pt-12`;
 const CHAT_PREVIEW_WRAPPER_BASE_CLASSES =
-  "tw-relative tw-z-10 tw-grid tw-h-full tw-w-full tw-min-w-0 tw-max-w-full tw-grid-rows-[minmax(0,1fr)_auto]";
+  "tw-pointer-events-none tw-relative tw-z-30 tw-grid tw-h-full tw-w-full tw-min-w-0 tw-max-w-full tw-grid-rows-[minmax(0,1fr)_auto] [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto [&_video]:tw-pointer-events-auto";
 const HOME_PREVIEW_WRAPPER_BASE_CLASSES =
-  "tw-relative tw-z-10 tw-grid tw-h-full tw-w-full tw-min-w-0 tw-max-w-full tw-grid-rows-[minmax(0,1fr)_auto]";
+  "tw-pointer-events-none tw-relative tw-z-30 tw-grid tw-h-full tw-w-full tw-min-w-0 tw-max-w-full tw-grid-rows-[minmax(0,1fr)_auto] [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto [&_video]:tw-pointer-events-auto";
 const CHAT_TEXT_WRAPPER_CLASSES =
-  "tw-relative tw-z-10 tw-flex tw-w-full tw-min-w-0 tw-max-w-full tw-items-center tw-justify-center";
+  "tw-pointer-events-none tw-relative tw-z-30 tw-flex tw-w-full tw-min-w-0 tw-max-w-full tw-items-center tw-justify-center [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto";
 const HOME_TEXT_WRAPPER_CLASSES =
-  "tw-relative tw-z-10 tw-flex tw-h-full tw-w-full tw-min-w-0 tw-max-w-full tw-items-center tw-justify-center";
+  "tw-pointer-events-none tw-relative tw-z-30 tw-flex tw-h-full tw-w-full tw-min-w-0 tw-max-w-full tw-items-center tw-justify-center [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto";
 const WITH_PREVIEW_CONTENT_CLASS_NAME =
   "tw-flex tw-w-full tw-max-w-full tw-flex-col tw-items-start tw-gap-1 tw-break-words tw-px-3 tw-pb-3 tw-text-left sm:tw-px-4 sm:tw-pb-4 tw-tracking-[0.01em] tw-font-normal tw-text-iron-300";
 const CHAT_WITH_PREVIEW_CONTENT_CLASS_NAME =

--- a/components/home/boosted/BoostedDropLinkPreview.tsx
+++ b/components/home/boosted/BoostedDropLinkPreview.tsx
@@ -5,21 +5,22 @@ import SmartLinkPreview from "@/components/waves/SmartLinkPreview";
 import TwitterPreviewCard from "@/components/waves/TwitterPreviewCard";
 import type { LinkPreviewVariant } from "@/components/waves/LinkPreviewContext";
 import { DEFAULT_LOCALE } from "@/i18n/locales";
-import { t } from "@/i18n/messages";
+import { t, type MessageKey } from "@/i18n/messages";
 
-const KNOWN_INTERNAL_LINK_TITLES: Record<string, string> = {
-  "/network/wavescore": "Network: Wave Score",
+const KNOWN_INTERNAL_LINK_TITLE_KEYS: Record<string, MessageKey> = {
+  "/network/wavescore": "home.boostedDrop.internalLinks.networkWaveScoreTitle",
 };
 
-const titleCaseSegment = (segment: string): string =>
-  segment
-    .replace(/[-_]+/g, " ")
-    .replace(/([a-z])([A-Z])/g, "$1 $2")
-    .replace(/\bwavescore\b/i, "wave score")
-    .trim()
-    .split(/\s+/)
-    .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
-    .join(" ");
+const getUrlDisplayTitle = ({
+  source,
+  url,
+}: {
+  readonly source: string;
+  readonly url: URL;
+}): string => {
+  const path = url.pathname === "/" ? "" : url.pathname;
+  return `${source}${path}${url.search}${url.hash}`;
+};
 
 const getFallbackPreview = ({
   href,
@@ -35,20 +36,23 @@ const getFallbackPreview = ({
     const host = url.hostname.replace(/^www\./i, "");
     const source = host || href;
     const isInternal6529 = source === "6529.io" || source.endsWith(".6529.io");
-    const knownTitle = KNOWN_INTERNAL_LINK_TITLES[url.pathname.toLowerCase()];
+    const knownTitleKey = isInternal6529
+      ? KNOWN_INTERNAL_LINK_TITLE_KEYS[url.pathname.toLowerCase()]
+      : undefined;
 
-    if (knownTitle) {
-      return { isInternal6529, source, title: knownTitle };
+    if (knownTitleKey) {
+      return {
+        isInternal6529,
+        source,
+        title: t(DEFAULT_LOCALE, knownTitleKey),
+      };
     }
 
-    const pathTitle = url.pathname
-      .split("/")
-      .filter(Boolean)
-      .map(titleCaseSegment)
-      .filter(Boolean)
-      .join(" / ");
-
-    return { isInternal6529, source, title: pathTitle || source };
+    return {
+      isInternal6529,
+      source,
+      title: getUrlDisplayTitle({ source, url }),
+    };
   } catch {
     return { isInternal6529: false, source: href, title: href };
   }

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -610,6 +610,7 @@ export const EN_US_MESSAGES = {
   "home.boostedDrop.boostCount.one": "{count} boost",
   "home.boostedDrop.boostCount.many": "{count} boosts",
   "home.boostedDrop.internalLinkSource": "{source} link",
+  "home.boostedDrop.internalLinks.networkWaveScoreTitle": "Network: Wave Score",
   "home.boostedDrop.openDrop": "Open boosted post from {author}",
   "home.boostedDrop.removeBoost": "Remove boost",
   "home.boostedDrop.removeBoostFromDrop": "Remove boost from post by {author}",


### PR DESCRIPTION
## Summary
- Replace the boosted post card's structural `article` click handler with a semantic full-card open button.
- Keep nested author, wave, boost, and link-preview controls independently clickable above the open target.
- Move the known internal Wave Score fallback title into i18n messages and add fallback preview coverage.

## Validation
- `seize run test:no-coverage -- __tests__/components/home/boosted/BoostedDropCardHome.test.tsx __tests__/components/home/boosted/BoostedDropLinkPreview.test.tsx __tests__/components/waves/LinkPreviewCard.test.tsx __tests__/components/drops/view/DropsList.test.tsx`
- `seize run lint:single -- components/home/boosted/BoostedDropCardHome.tsx components/home/boosted/BoostedDropCardHomeContent.tsx components/home/boosted/BoostedDropLinkPreview.tsx i18n/messages/en-US.ts __tests__/components/home/boosted/BoostedDropCardHome.test.tsx __tests__/components/home/boosted/BoostedDropLinkPreview.test.tsx`
- `seize run typecheck`
- `seize run react-doctor:diff`
- `codex-diff-check -- components/home/boosted/BoostedDropCardHome.tsx components/home/boosted/BoostedDropCardHomeContent.tsx components/home/boosted/BoostedDropLinkPreview.tsx i18n/messages/en-US.ts __tests__/components/home/boosted/BoostedDropCardHome.test.tsx __tests__/components/home/boosted/BoostedDropLinkPreview.test.tsx`