### PR TITLE
Polish Twitter/X link preview cards

### DIFF
--- a/__tests__/components/waves/TwitterPreviewCard.test.tsx
+++ b/__tests__/components/waves/TwitterPreviewCard.test.tsx
@@ -8,10 +8,6 @@ jest.mock("@/services/api/twitter-preview-api", () => ({
   fetchTwitterPreview: jest.fn(),
 }));
 
-jest.mock("@/components/waves/LinkPreviewContext", () => ({
-  useLinkPreviewContext: () => ({ hideActions: false }),
-}));
-
 const mockedFetchTwitterPreview = fetchTwitterPreview as jest.MockedFunction<
   typeof fetchTwitterPreview
 >;
@@ -66,11 +62,18 @@ describe("TwitterPreviewCard", () => {
       expect(screen.getByTestId("twitter-post-preview")).toBeInTheDocument();
     });
 
+    expect(screen.getByText("X")).toBeInTheDocument();
+    expect(screen.getByText("Post")).toBeInTheDocument();
     expect(screen.getByText("Mayudrops")).toBeInTheDocument();
     expect(screen.getByText(/@Mayudropsphotos/)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Follow" })).toHaveAttribute(
+    expect(
+      screen.queryByRole("link", { name: "Follow" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Open post on X" })
+    ).toHaveAttribute(
       "href",
-      "https://x.com/intent/follow?screen_name=Mayudropsphotos"
+      "https://x.com/Mayudropsphotos/status/2049202644879565155"
     );
     expect(
       screen.getByText("These jobs won't be here forever.")
@@ -82,23 +85,18 @@ describe("TwitterPreviewCard", () => {
     expect(
       screen.getByRole("img", { name: "These jobs won't be here forever." })
     ).toHaveAttribute("src", "https://pbs.twimg.com/media/example.jpg");
-    expect(screen.getByText(/· Apr 28, 2026/)).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Like" })).toHaveAttribute(
-      "href",
-      "https://x.com/intent/like?tweet_id=2049202644879565155"
-    );
-    expect(screen.getByRole("link", { name: "Reply" })).toHaveAttribute(
-      "href",
-      "https://x.com/intent/tweet?in_reply_to=2049202644879565155"
-    );
-    expect(screen.getByRole("link", { name: "Repost" })).toHaveAttribute(
-      "href",
-      "https://x.com/intent/retweet?tweet_id=2049202644879565155"
-    );
-    expect(screen.getByLabelText("Bookmarks")).toHaveTextContent("1");
+    expect(screen.getByText(/Apr 28, 2026/)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Like" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Reply" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Repost" })).toBeNull();
+    expect(screen.getByText("Views")).toBeInTheDocument();
+    expect(screen.getByText("137")).toBeInTheDocument();
+    expect(screen.getByText("Likes")).toBeInTheDocument();
     expect(screen.getByText("94.6K")).toBeInTheDocument();
+    expect(screen.getByText("Replies")).toBeInTheDocument();
     expect(screen.getByText("3.9K")).toBeInTheDocument();
-    expect(screen.getByText("137 Views")).toBeInTheDocument();
+    expect(screen.getByText("Reposts")).toBeInTheDocument();
+    expect(screen.getByText("Bookmarks")).toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "Read 3,951 replies" })
     ).not.toBeInTheDocument();
@@ -325,11 +323,48 @@ describe("TwitterPreviewCard", () => {
 
     await screen.findByTestId("twitter-post-preview");
     expect(
-      screen.getByRole("link", { name: "Open tweet on X" })
+      screen.getByRole("link", { name: "Open post on X" })
     ).toHaveAttribute(
       "href",
       "https://x.com/Mayudropsphotos/status/2049202644879565155"
     );
+    expect(
+      screen.getAllByRole("link", { name: "Open post on X" })
+    ).toHaveLength(1);
+    expect(screen.queryByRole("link", { name: "Open X post" })).toBeNull();
+  });
+
+  it("renders source fallback and hides empty facts when counts are unavailable", async () => {
+    mockedFetchTwitterPreview.mockResolvedValue({
+      tweetId: "2049202644879565155",
+      url: "https://x.com/Mayudropsphotos/status/2049202644879565155",
+      authorName: "Mayudrops",
+      authorHandle: "Mayudropsphotos",
+      text: "Post text",
+      favoriteCount: 0,
+      conversationCount: 0,
+      retweetCount: 0,
+      bookmarkCount: 0,
+      viewCount: 0,
+    });
+
+    render(
+      <TwitterPreviewCard
+        href="https://x.com/Mayudropsphotos/status/2049202644879565155"
+        tweetId="2049202644879565155"
+      />
+    );
+
+    await screen.findByTestId("twitter-post-preview");
+
+    expect(
+      screen.getByText("x.com/Mayudropsphotos/status/2049202644879565155")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Views")).not.toBeInTheDocument();
+    expect(screen.queryByText("Likes")).not.toBeInTheDocument();
+    expect(screen.queryByText("Replies")).not.toBeInTheDocument();
+    expect(screen.queryByText("Reposts")).not.toBeInTheDocument();
+    expect(screen.queryByText("Bookmarks")).not.toBeInTheDocument();
   });
 
   it("renders multiple media items in a gallery grid", async () => {
@@ -459,7 +494,7 @@ describe("TwitterPreviewCard", () => {
     );
   });
 
-  it("does not show a copy action in the tweet action row", async () => {
+  it("does not show old tweet intent actions in the preview card", async () => {
     mockedFetchTwitterPreview.mockResolvedValue({
       tweetId: "2049202644879565155",
       url: "https://x.com/Mayudropsphotos/status/2049202644879565155",
@@ -473,6 +508,9 @@ describe("TwitterPreviewCard", () => {
 
     await screen.findByTestId("twitter-post-preview");
     expect(screen.queryByRole("button", { name: /copy/i })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Like" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Reply" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Repost" })).toBeNull();
   });
 
   it("shows a native fallback card when metadata cannot be fetched", async () => {
@@ -488,7 +526,7 @@ describe("TwitterPreviewCard", () => {
     await waitFor(() => {
       expect(screen.getByTestId("twitter-post-fallback")).toBeInTheDocument();
     });
-    expect(screen.getByText("Tweet preview unavailable")).toBeInTheDocument();
+    expect(screen.getByText("X post preview unavailable")).toBeInTheDocument();
     expect(
       screen.getByText(
         "https://x.com/Mayudropsphotos/status/2057513333985554492"

--- a/__tests__/lib/twitter/parser.test.ts
+++ b/__tests__/lib/twitter/parser.test.ts
@@ -67,6 +67,26 @@ describe("Twitter preview parsing", () => {
     expect(preview.mediaLink).toBeUndefined();
   });
 
+  it("ignores pic.twitter.com text when the href is not a Twitter media redirect", () => {
+    const preview = parseTwitterOEmbed(
+      {
+        author_name: "Mayudrops",
+        author_url: "https://twitter.com/Mayudropsphotos",
+        html: `<blockquote class="twitter-tweet">
+          <p>
+            Text with a relative non-media link.
+            <a href="/not-twitter-media">pic.twitter.com/not-media</a>
+          </p>
+          <a href="https://twitter.com/Mayudropsphotos/status/2057513333985554492">May 21, 2026</a>
+        </blockquote>`,
+      },
+      "https://x.com/Mayudropsphotos/status/2057513333985554492",
+      "2057513333985554492"
+    );
+
+    expect(preview.mediaLink).toBeUndefined();
+  });
+
   it("detects scheme-less pic.twitter.com media text", () => {
     const preview = parseTwitterOEmbed(
       {
@@ -85,5 +105,25 @@ describe("Twitter preview parsing", () => {
     );
 
     expect(preview.mediaLink).toBe("https://t.co/media");
+  });
+
+  it("detects direct pic.twitter.com media hrefs", () => {
+    const preview = parseTwitterOEmbed(
+      {
+        author_name: "Mayudrops",
+        author_url: "https://twitter.com/Mayudropsphotos",
+        html: `<blockquote class="twitter-tweet">
+          <p>
+            Text with direct media.
+            <a href="https://pic.twitter.com/direct-media">pic.twitter.com/direct-media</a>
+          </p>
+          <a href="https://twitter.com/Mayudropsphotos/status/2057513333985554492">May 21, 2026</a>
+        </blockquote>`,
+      },
+      "https://x.com/Mayudropsphotos/status/2057513333985554492",
+      "2057513333985554492"
+    );
+
+    expect(preview.mediaLink).toBe("https://pic.twitter.com/direct-media");
   });
 });

--- a/components/waves/TwitterPreviewCard.tsx
+++ b/components/waves/TwitterPreviewCard.tsx
@@ -2,12 +2,8 @@
 
 import {
   ArrowLeftIcon,
-  ArrowPathRoundedSquareIcon,
-  BookmarkIcon,
-  ChatBubbleOvalLeftIcon,
   CheckIcon,
   Cog6ToothIcon,
-  HeartIcon,
   LinkIcon,
   PlayIcon,
 } from "@heroicons/react/24/outline";
@@ -34,8 +30,6 @@ import { fetchTwitterPreview } from "@/services/api/twitter-preview-api";
 import SeizeVideoPlayer, {
   type SeizeVideoTemplate,
 } from "@/components/drops/view/item/content/media/SeizeVideoPlayer";
-
-import { useLinkPreviewContext } from "./LinkPreviewContext";
 
 type PreviewState =
   | { readonly type: "loading" }
@@ -66,13 +60,12 @@ interface TwitterPreviewCardProps {
 }
 
 const TWITTER_CARD_CLASSES =
-  "tw-w-full tw-min-w-0 tw-max-w-full md:tw-max-w-[560px] tw-overflow-hidden tw-rounded-2xl tw-border tw-border-solid tw-border-[#42566b] tw-bg-[#15202b] tw-text-[#f7f9f9] tw-shadow-sm";
+  "tw-relative tw-w-full tw-min-w-0 tw-max-w-full tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950/70 tw-text-iron-50 tw-shadow-sm tw-shadow-black/20 tw-transition tw-duration-200 hover:tw-border-iron-600";
 
 const ACTION_CLASSES =
-  "tw-inline-flex tw-items-center tw-gap-x-2 tw-rounded-full tw-border-0 tw-bg-transparent tw-px-2 tw-py-1 tw-text-sm tw-font-semibold tw-text-[#8b98a5] tw-no-underline tw-transition tw-duration-200 hover:tw-text-[#1d9bf0] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400";
+  "tw-inline-flex tw-items-center tw-gap-x-2 tw-rounded-md tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/70 tw-px-3 tw-py-2 tw-text-sm tw-font-semibold tw-text-iron-100 tw-no-underline tw-transition tw-duration-200 hover:tw-border-sky-400/50 hover:tw-bg-sky-400/10 hover:tw-text-sky-100 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400";
 
-const STATIC_ACTION_CLASSES =
-  "tw-inline-flex tw-items-center tw-gap-x-2 tw-px-2 tw-py-1 tw-text-sm tw-font-semibold tw-text-[#8b98a5]";
+const TWITTER_ACCENT_COLOR = "#1d9bf0";
 
 function stopCardEvent(event: MouseEvent<HTMLElement>) {
   event.stopPropagation();
@@ -123,16 +116,22 @@ function formatTweetTimestamp(preview: TweetPreview): string | undefined {
         day: "numeric",
         year: "numeric",
       }).format(date);
-      return `${time} · ${day}`;
+      return `${time}, ${day}`;
     }
   }
 
   return preview.createdAtText;
 }
 
+function formatInteger(value: number): string {
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(
+    value
+  );
+}
+
 function formatCount(value: number): string {
   if (value < 1000) {
-    return value.toLocaleString();
+    return formatInteger(value);
   }
 
   const units = [
@@ -142,15 +141,13 @@ function formatCount(value: number): string {
   ];
   const unit = units.find((candidate) => value >= candidate.value);
   if (!unit) {
-    return value.toLocaleString();
+    return formatInteger(value);
   }
 
   const floored = Math.floor((value / unit.value) * 10) / 10;
-  return `${Number.isInteger(floored) ? floored.toFixed(0) : floored.toFixed(1)}${unit.suffix}`;
-}
-
-function formatViews(value: number): string {
-  return `${formatCount(value)} ${value === 1 ? "View" : "Views"}`;
+  return `${
+    Number.isInteger(floored) ? floored.toFixed(0) : floored.toFixed(1)
+  }${unit.suffix}`;
 }
 
 function formatBitrate(value: number): string {
@@ -442,7 +439,7 @@ function TwitterHandleLink({ handle }: { readonly handle: string }) {
       target="_blank"
       rel="noopener noreferrer nofollow"
       onClick={stopCardEvent}
-      className="tw-text-[#6ecbff] tw-no-underline hover:tw-underline"
+      className="tw-text-sky-200 tw-no-underline hover:tw-text-sky-100 hover:tw-underline"
     >
       @{handle}
     </Link>
@@ -482,28 +479,35 @@ function renderTweetText(text: string): ReactNode[] {
 function LoadingCard() {
   return (
     <div
-      className={`${TWITTER_CARD_CLASSES} tw-p-4`}
+      className={`${TWITTER_CARD_CLASSES} tw-p-3 sm:tw-p-4`}
       data-testid="twitter-post-skeleton"
     >
-      <div className="tw-flex tw-animate-pulse tw-flex-col tw-gap-y-4">
+      <span
+        aria-hidden="true"
+        className="tw-absolute tw-inset-y-0 tw-left-0 tw-w-1 tw-opacity-85"
+        style={{ backgroundColor: TWITTER_ACCENT_COLOR }}
+      />
+      <div className="tw-flex tw-animate-pulse tw-flex-col tw-gap-y-3 tw-pl-1">
+        <div className="tw-flex tw-items-center tw-gap-x-2">
+          <div className="tw-h-3 tw-w-10 tw-rounded tw-bg-iron-800/70" />
+          <div className="tw-h-5 tw-w-12 tw-rounded-md tw-bg-sky-400/15" />
+        </div>
         <div className="tw-flex tw-items-center tw-gap-x-3">
-          <div className="tw-h-10 tw-w-10 tw-rounded-full tw-bg-[#263544]" />
+          <div className="tw-h-10 tw-w-10 tw-rounded-full tw-bg-iron-800" />
           <div className="tw-flex tw-flex-col tw-gap-y-2">
-            <div className="tw-h-4 tw-w-40 tw-rounded tw-bg-[#263544]" />
-            <div className="tw-h-3 tw-w-36 tw-rounded tw-bg-[#263544]/80" />
+            <div className="tw-h-4 tw-w-40 tw-rounded tw-bg-iron-800" />
+            <div className="tw-h-3 tw-w-32 tw-rounded tw-bg-iron-800/70" />
           </div>
         </div>
         <div className="tw-space-y-2">
-          <div className="tw-h-4 tw-w-full tw-rounded tw-bg-[#263544]" />
-          <div className="tw-h-4 tw-w-11/12 tw-rounded tw-bg-[#263544]" />
+          <div className="tw-h-4 tw-w-full tw-rounded tw-bg-iron-800" />
+          <div className="tw-h-4 tw-w-11/12 tw-rounded tw-bg-iron-800" />
         </div>
-        <div className="tw-aspect-[4/3] tw-min-h-72 tw-rounded-xl tw-bg-[#263544]/80" />
-        <div className="tw-h-4 tw-w-44 tw-rounded tw-bg-[#263544]" />
-        <div className="tw-h-px tw-w-full tw-bg-[#42566b]" />
-        <div className="tw-flex tw-gap-x-8">
-          <div className="tw-h-4 tw-w-16 tw-rounded tw-bg-[#263544]" />
-          <div className="tw-h-4 tw-w-20 tw-rounded tw-bg-[#263544]" />
-          <div className="tw-h-4 tw-w-24 tw-rounded tw-bg-[#263544]" />
+        <div className="tw-aspect-video tw-rounded-lg tw-bg-iron-900" />
+        <div className="tw-flex tw-gap-1.5">
+          <div className="tw-h-6 tw-w-16 tw-rounded-md tw-bg-iron-900" />
+          <div className="tw-h-6 tw-w-20 tw-rounded-md tw-bg-iron-900" />
+          <div className="tw-h-6 tw-w-16 tw-rounded-md tw-bg-iron-900" />
         </div>
       </div>
     </div>
@@ -524,33 +528,38 @@ function UnavailableCard({
       className={TWITTER_CARD_CLASSES}
       data-testid="twitter-post-fallback"
     >
-      <div className="tw-flex tw-flex-col tw-gap-y-3 tw-p-4">
+      <span
+        aria-hidden="true"
+        className="tw-absolute tw-inset-y-0 tw-left-0 tw-w-1 tw-opacity-85"
+        style={{ backgroundColor: TWITTER_ACCENT_COLOR }}
+      />
+      <div className="tw-flex tw-flex-col tw-gap-y-3 tw-p-3 tw-pl-4 sm:tw-p-4 sm:tw-pl-5">
         <div className="tw-flex tw-items-start tw-gap-x-3">
-          <div className="tw-flex tw-h-10 tw-w-10 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-bg-[#0f1720] tw-p-2">
+          <div className="tw-flex tw-h-10 tw-w-10 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-border-sky-400/20 tw-bg-sky-400/10 tw-p-2 tw-text-sky-100">
             <XIcon />
           </div>
           <div className="tw-min-w-0 tw-flex-1">
-            <p className="tw-m-0 tw-text-lg tw-font-semibold tw-leading-6 tw-text-[#f7f9f9]">
-              Tweet preview unavailable
+            <p className="tw-m-0 tw-text-base tw-font-semibold tw-leading-6 tw-text-iron-50">
+              X post preview unavailable
             </p>
             <Link
               href={href}
               target="_blank"
               rel="noopener noreferrer nofollow"
               onClick={stopCardEvent}
-              className="tw-mt-1 tw-block tw-truncate tw-text-sm tw-leading-5 tw-text-[#8b98a5] tw-no-underline hover:tw-text-[#f7f9f9]"
+              className="tw-mt-1 tw-block tw-truncate tw-text-sm tw-leading-5 tw-text-iron-400 tw-no-underline hover:tw-text-iron-100"
             >
               {href}
             </Link>
           </div>
         </div>
-        <div className="tw-grid tw-grid-cols-2 tw-gap-x-3 tw-gap-y-2">
+        <div className="tw-grid tw-grid-cols-1 tw-gap-2 sm:tw-grid-cols-2">
           <Link
             href={href}
             target="_blank"
             rel="noopener noreferrer nofollow"
             onClick={stopCardEvent}
-            className="tw-inline-flex tw-w-full tw-items-center tw-justify-center tw-rounded-full tw-border tw-border-solid tw-border-[#42566b] tw-bg-transparent tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-[#6ecbff] tw-no-underline tw-transition hover:tw-border-[#5a7088] hover:tw-text-[#9bddff]"
+            className="tw-inline-flex tw-w-full tw-items-center tw-justify-center tw-rounded-md tw-border tw-border-solid tw-border-sky-400/30 tw-bg-sky-400/10 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-text-sky-100 tw-no-underline tw-transition hover:tw-border-sky-300/60 hover:tw-bg-sky-400/15 hover:tw-text-white"
           >
             Open on X
           </Link>
@@ -589,11 +598,11 @@ function AuthorAvatar({
         <img
           src={profileImageUrl}
           alt={authorName}
-          className="tw-h-10 tw-w-10 tw-flex-shrink-0 tw-rounded-full tw-object-cover"
+          className="tw-h-10 tw-w-10 tw-flex-shrink-0 tw-rounded-full tw-border tw-border-solid tw-border-white/10 tw-object-cover"
           loading="lazy"
         />
       ) : (
-        <div className="tw-flex tw-h-10 tw-w-10 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-bg-[#0f1720] tw-p-2">
+        <div className="tw-flex tw-h-10 tw-w-10 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-border tw-border-solid tw-border-sky-400/20 tw-bg-sky-400/10 tw-p-2 tw-text-sky-100">
           <XIcon />
         </div>
       )}
@@ -605,12 +614,10 @@ function TweetAuthorBlock({
   authorHref,
   authorName,
   authorHandle,
-  followHref,
 }: {
   readonly authorHref: string;
   readonly authorName: string;
   readonly authorHandle: string | undefined;
-  readonly followHref: string | undefined;
 }) {
   return (
     <div className="tw-min-w-0">
@@ -619,30 +626,20 @@ function TweetAuthorBlock({
         target="_blank"
         rel="noopener noreferrer nofollow"
         onClick={stopCardEvent}
-        className="tw-line-clamp-1 tw-text-sm tw-font-bold tw-leading-4 tw-text-[#f7f9f9] tw-no-underline hover:tw-underline"
+        className="tw-line-clamp-1 tw-text-sm tw-font-semibold tw-leading-5 tw-text-iron-50 tw-no-underline hover:tw-text-white hover:tw-underline"
       >
         {authorName}
       </Link>
       {authorHandle && (
-        <div className="tw-line-clamp-1 tw-text-xs tw-leading-4 tw-text-[#8b98a5]">
+        <div className="tw-line-clamp-1 tw-text-xs tw-leading-4 tw-text-iron-400">
           <Link
             href={authorHref}
             target="_blank"
             rel="noopener noreferrer nofollow"
             onClick={stopCardEvent}
-            className="tw-text-[#8b98a5] tw-no-underline hover:tw-underline"
+            className="tw-text-iron-400 tw-no-underline hover:tw-text-iron-200 hover:tw-underline"
           >
             @{authorHandle}
-          </Link>
-          <span className="tw-px-1">·</span>
-          <Link
-            href={followHref ?? authorHref}
-            target="_blank"
-            rel="noopener noreferrer nofollow"
-            onClick={stopCardEvent}
-            className="tw-font-semibold tw-text-[#6ecbff] tw-no-underline hover:tw-text-[#9bddff]"
-          >
-            Follow
           </Link>
         </div>
       )}
@@ -653,14 +650,10 @@ function TweetAuthorBlock({
 function TweetHeader({
   authorHref,
   authorName,
-  followHref,
-  href,
   preview,
 }: {
   readonly authorHref: string;
   readonly authorName: string;
-  readonly followHref: string | undefined;
-  readonly href: string;
   readonly preview: TweetPreview;
 }) {
   return (
@@ -675,18 +668,43 @@ function TweetHeader({
           authorHref={authorHref}
           authorName={authorName}
           authorHandle={preview.authorHandle}
-          followHref={followHref}
         />
       </div>
+      <span
+        aria-hidden="true"
+        className="tw-flex tw-h-8 tw-w-8 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-border-iron-800 tw-bg-black/20 tw-p-1.5 tw-text-iron-200 tw-transition hover:tw-border-sky-400/40 hover:tw-bg-sky-400/10 hover:tw-text-white focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400"
+      >
+        <XIcon />
+      </span>
+    </div>
+  );
+}
+
+function TweetKicker({
+  href,
+  timestamp,
+  xPostPath,
+}: {
+  readonly href: string;
+  readonly timestamp: string | undefined;
+  readonly xPostPath: string;
+}) {
+  return (
+    <div className="tw-flex tw-min-w-0 tw-flex-wrap tw-items-center tw-gap-1.5">
+      <span className="tw-text-[11px] tw-font-semibold tw-uppercase tw-leading-none tw-text-iron-500">
+        X
+      </span>
+      <span className="tw-inline-flex tw-items-center tw-rounded-md tw-border tw-border-solid tw-border-sky-400/30 tw-bg-sky-400/10 tw-px-2 tw-py-1 tw-text-[11px] tw-font-semibold tw-leading-none tw-text-sky-100">
+        Post
+      </span>
       <Link
         href={href}
         target="_blank"
         rel="noopener noreferrer nofollow"
         onClick={stopCardEvent}
-        aria-label="Open post on X"
-        className="tw-h-7 tw-w-7 tw-flex-shrink-0 tw-text-[#f7f9f9] tw-transition hover:tw-text-white"
+        className="tw-min-w-0 tw-truncate tw-text-xs tw-font-medium tw-leading-5 tw-text-iron-500 tw-no-underline hover:tw-text-iron-300"
       >
-        <XIcon />
+        {timestamp ?? `x.com${xPostPath}`}
       </Link>
     </div>
   );
@@ -707,11 +725,11 @@ function TweetBodyText({
     return (
       <div className="tw-flex tw-flex-col tw-gap-y-1">
         {replyToHandle && (
-          <p className="tw-m-0 tw-text-sm tw-font-semibold tw-leading-5 tw-text-[#8b98a5]">
+          <p className="tw-m-0 tw-text-sm tw-font-semibold tw-leading-5 tw-text-iron-400">
             Replying to <TwitterHandleLink handle={replyToHandle} />
           </p>
         )}
-        <p className="tw-m-0 tw-whitespace-pre-line tw-break-words tw-text-base tw-font-normal tw-leading-6 tw-text-[#f7f9f9]">
+        <p className="tw-m-0 tw-line-clamp-6 tw-whitespace-pre-line tw-break-words tw-text-sm tw-font-normal tw-leading-6 tw-text-iron-100 sm:tw-text-base">
           {renderTweetText(text)}
         </p>
       </div>
@@ -720,10 +738,10 @@ function TweetBodyText({
 
   return (
     <div className="tw-flex tw-flex-col tw-gap-y-2">
-      <p className="tw-m-0 tw-text-lg tw-font-semibold tw-leading-6 tw-text-[#f7f9f9]">
-        Tweet preview unavailable
+      <p className="tw-m-0 tw-text-base tw-font-semibold tw-leading-6 tw-text-iron-50">
+        X post preview unavailable
       </p>
-      <p className="tw-m-0 tw-break-all tw-text-sm tw-leading-5 tw-text-[#8b98a5]">
+      <p className="tw-m-0 tw-break-all tw-text-sm tw-leading-5 tw-text-iron-400">
         {href || authorName}
       </p>
     </div>
@@ -799,7 +817,7 @@ function VideoQualityMenu({
               <span>
                 {option.label}
                 {option.id === "auto" && autoQuality && (
-                  <span className="tw-ml-1 tw-text-[#8b98a5]">
+                  <span className="tw-ml-1 tw-text-iron-400">
                     ({autoQuality}p)
                   </span>
                 )}
@@ -809,7 +827,7 @@ function VideoQualityMenu({
                 className={`tw-flex tw-h-5 tw-w-5 tw-items-center tw-justify-center tw-rounded-full tw-border-2 tw-border-solid ${
                   isSelected
                     ? "tw-border-[#1d9bf0] tw-bg-[#1d9bf0]"
-                    : "tw-border-[#8b98a5]"
+                    : "tw-border-iron-500"
                 }`}
               >
                 {isSelected && <CheckIcon className="tw-h-3.5 tw-w-3.5" />}
@@ -1032,7 +1050,7 @@ function TweetVideo({
   readonly videoUrl: string;
 }) {
   return (
-    <div className="tw-relative tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-[#42566b] tw-bg-black">
+    <div className="tw-relative tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-iron-800 tw-bg-black">
       <TwitterVideoPlayer
         captionsUrl={captionsUrl}
         className="tw-block tw-h-auto tw-max-h-[24rem] tw-w-full tw-object-contain"
@@ -1135,11 +1153,11 @@ function TweetMediaGrid({
 }) {
   const visibleMediaItems = mediaItems.slice(0, 4);
   return (
-    <div className="tw-grid tw-aspect-video tw-grid-cols-2 tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-[#42566b] tw-bg-black">
+    <div className="tw-grid tw-aspect-video tw-grid-cols-2 tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-iron-800 tw-bg-black">
       {visibleMediaItems.map((media, index) => (
         <div
           key={media.videoUrl ?? media.imageUrl ?? media.posterUrl ?? index}
-          className="tw-min-h-0 tw-min-w-0 tw-overflow-hidden tw-border-0 tw-border-solid tw-border-[#42566b] odd:tw-border-r [&:nth-child(-n+2)]:tw-border-b"
+          className="tw-min-h-0 tw-min-w-0 tw-overflow-hidden tw-border-0 tw-border-solid tw-border-iron-800 odd:tw-border-r [&:nth-child(-n+2)]:tw-border-b"
         >
           <TweetMediaGridItem alt={alt} href={href} media={media} />
         </div>
@@ -1163,12 +1181,12 @@ function TweetImage({
       target="_blank"
       rel="noopener noreferrer nofollow"
       onClick={stopCardEvent}
-      className="tw-block tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-[#42566b] tw-bg-black tw-no-underline"
+      className="tw-block tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-iron-800 tw-bg-black tw-no-underline"
     >
       <img
         src={imageUrl}
         alt={alt}
-        className="tw-h-auto tw-max-h-[24rem] tw-w-full tw-object-contain"
+        className="tw-h-auto tw-max-h-[26rem] tw-w-full tw-object-contain"
         loading="lazy"
       />
     </Link>
@@ -1182,7 +1200,7 @@ function TweetMediaLink({ mediaLink }: { readonly mediaLink: string }) {
       target="_blank"
       rel="noopener noreferrer nofollow"
       onClick={stopCardEvent}
-      className="tw-flex tw-min-h-24 tw-items-center tw-justify-center tw-rounded-xl tw-border tw-border-solid tw-border-[#42566b] tw-bg-[#0f1720] tw-p-4 tw-text-center tw-text-sm tw-font-semibold tw-text-[#8b98a5] tw-no-underline tw-transition hover:tw-border-[#5a7088] hover:tw-text-[#f7f9f9]"
+      className="tw-flex tw-min-h-24 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-900/60 tw-p-4 tw-text-center tw-text-sm tw-font-semibold tw-text-iron-300 tw-no-underline tw-transition hover:tw-border-iron-600 hover:tw-text-iron-100"
     >
       Media on X
     </Link>
@@ -1237,64 +1255,60 @@ function TweetMedia({
   return null;
 }
 
-function TweetActions({
-  preview,
-  tweetId,
-}: {
-  readonly preview: TweetPreview;
-  readonly tweetId: string;
-}) {
+interface TweetFact {
+  readonly label: string;
+  readonly value: string;
+}
+
+function compactFacts(
+  facts: readonly (TweetFact | null)[]
+): readonly TweetFact[] {
+  return facts.filter(
+    (fact): fact is TweetFact => fact !== null && fact.value.trim().length > 0
+  );
+}
+
+function getTweetFacts(preview: TweetPreview): readonly TweetFact[] {
+  return compactFacts([
+    preview.viewCount !== undefined && preview.viewCount > 0
+      ? { label: "Views", value: formatCount(preview.viewCount) }
+      : null,
+    preview.favoriteCount !== undefined && preview.favoriteCount > 0
+      ? { label: "Likes", value: formatCount(preview.favoriteCount) }
+      : null,
+    preview.conversationCount !== undefined && preview.conversationCount > 0
+      ? { label: "Replies", value: formatCount(preview.conversationCount) }
+      : null,
+    preview.retweetCount !== undefined && preview.retweetCount > 0
+      ? { label: "Reposts", value: formatCount(preview.retweetCount) }
+      : null,
+    preview.bookmarkCount !== undefined && preview.bookmarkCount > 0
+      ? { label: "Bookmarks", value: formatCount(preview.bookmarkCount) }
+      : null,
+  ]);
+}
+
+function TweetFacts({ preview }: { readonly preview: TweetPreview }) {
+  const facts = getTweetFacts(preview);
+  if (facts.length === 0) {
+    return null;
+  }
+
   return (
-    <div className="tw-flex tw-w-full tw-flex-wrap tw-items-center tw-justify-between tw-gap-x-3 tw-gap-y-2 tw-px-10">
-      <Link
-        href={`https://x.com/intent/tweet?in_reply_to=${tweetId}`}
-        target="_blank"
-        rel="noopener noreferrer nofollow"
-        onClick={stopCardEvent}
-        aria-label="Reply"
-        className={ACTION_CLASSES}
-      >
-        <ChatBubbleOvalLeftIcon className="tw-h-5 tw-w-5" />
-        <span>
-          {preview.conversationCount === undefined
-            ? "0"
-            : formatCount(preview.conversationCount)}
+    <div className="tw-flex tw-min-w-0 tw-flex-wrap tw-gap-1.5">
+      {facts.map((fact) => (
+        <span
+          key={`${fact.label}-${fact.value}`}
+          className="tw-inline-flex tw-min-w-0 tw-max-w-full tw-items-baseline tw-gap-1 tw-rounded-md tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-900/75 tw-px-2 tw-py-0.5 tw-text-[11px] tw-leading-5"
+        >
+          <span className="tw-flex-shrink-0 tw-text-iron-400">
+            {fact.label}
+          </span>
+          <span className="tw-truncate tw-font-semibold tw-text-iron-100">
+            {fact.value}
+          </span>
         </span>
-      </Link>
-      <Link
-        href={`https://x.com/intent/retweet?tweet_id=${tweetId}`}
-        target="_blank"
-        rel="noopener noreferrer nofollow"
-        onClick={stopCardEvent}
-        aria-label="Repost"
-        className={`${ACTION_CLASSES} hover:tw-text-[#00ba7c]`}
-      >
-        <ArrowPathRoundedSquareIcon className="tw-h-5 tw-w-5" />
-        {preview.retweetCount !== undefined && preview.retweetCount > 0 && (
-          <span>{formatCount(preview.retweetCount)}</span>
-        )}
-      </Link>
-      <Link
-        href={`https://x.com/intent/like?tweet_id=${tweetId}`}
-        target="_blank"
-        rel="noopener noreferrer nofollow"
-        onClick={stopCardEvent}
-        aria-label="Like"
-        className={`${ACTION_CLASSES} hover:tw-text-[#f91880]`}
-      >
-        <HeartIcon className="tw-h-5 tw-w-5" />
-        <span>
-          {preview.favoriteCount === undefined
-            ? "0"
-            : formatCount(preview.favoriteCount)}
-        </span>
-      </Link>
-      {preview.bookmarkCount !== undefined && (
-        <div className={STATIC_ACTION_CLASSES} aria-label="Bookmarks">
-          <BookmarkIcon className="tw-h-5 tw-w-5" />
-          <span>{formatCount(preview.bookmarkCount)}</span>
-        </div>
-      )}
+      ))}
     </div>
   );
 }
@@ -1303,7 +1317,6 @@ export default function TwitterPreviewCard({
   href,
   tweetId,
 }: TwitterPreviewCardProps) {
-  const { hideActions } = useLinkPreviewContext();
   const [state, setState] = useState<PreviewState>({ type: "loading" });
   const [copied, setCopied] = useState(false);
 
@@ -1349,11 +1362,6 @@ export default function TwitterPreviewCard({
   const authorHref =
     preview.authorUrl ??
     (preview.authorHandle ? `https://x.com/${preview.authorHandle}` : href);
-  const followHref = preview.authorHandle
-    ? `https://x.com/intent/follow?screen_name=${encodeURIComponent(
-        preview.authorHandle
-      )}`
-    : undefined;
   const xPostPath = useMemo(
     () => getXPostPath(preview.url || href),
     [href, preview.url]
@@ -1370,22 +1378,27 @@ export default function TwitterPreviewCard({
 
   return (
     <article
-      className={`${TWITTER_CARD_CLASSES} tw-relative`}
+      className={TWITTER_CARD_CLASSES}
       data-testid="twitter-post-preview"
     >
+      <span
+        aria-hidden="true"
+        className="tw-absolute tw-inset-y-0 tw-left-0 tw-w-1 tw-opacity-85"
+        style={{ backgroundColor: TWITTER_ACCENT_COLOR }}
+      />
       <Link
         href={href}
         target="_blank"
         rel="noopener noreferrer nofollow"
-        aria-label="Open tweet on X"
-        className="tw-absolute tw-inset-0 tw-z-0 tw-rounded-2xl"
+        aria-label="Open post on X"
+        className="tw-absolute tw-inset-0 tw-z-0 tw-rounded-lg"
       />
-      <div className="tw-pointer-events-none tw-relative tw-z-10 tw-flex tw-flex-col tw-gap-y-3 tw-p-3 [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto [&_video]:tw-pointer-events-auto">
+      <div className="tw-pointer-events-none tw-relative tw-z-10 tw-flex tw-flex-col tw-gap-y-3 tw-p-3 tw-pl-4 sm:tw-p-4 sm:tw-pl-5 [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto [&_video]:tw-pointer-events-auto">
+        <TweetKicker href={href} timestamp={timestamp} xPostPath={xPostPath} />
+
         <TweetHeader
           authorHref={authorHref}
           authorName={authorName}
-          followHref={followHref}
-          href={href}
           preview={preview}
         />
 
@@ -1398,27 +1411,7 @@ export default function TwitterPreviewCard({
 
         <TweetMedia authorName={authorName} href={href} preview={preview} />
 
-        <div className="tw-flex tw-items-center tw-gap-x-2 tw-border-0 tw-border-b tw-border-solid tw-border-[#42566b] tw-pb-3 tw-text-sm tw-text-[#8b98a5]">
-          <Link
-            href={href}
-            target="_blank"
-            rel="noopener noreferrer nofollow"
-            onClick={stopCardEvent}
-            className="tw-min-w-0 tw-truncate tw-text-[#8b98a5] tw-no-underline hover:tw-text-[#8b98a5] focus:tw-text-[#8b98a5]"
-          >
-            {timestamp ?? `x.com${xPostPath}`}
-          </Link>
-          {preview.viewCount !== undefined && preview.viewCount > 0 && (
-            <>
-              <span>·</span>
-              <span className="tw-flex-shrink-0">
-                {formatViews(preview.viewCount)}
-              </span>
-            </>
-          )}
-        </div>
-
-        {!hideActions && <TweetActions preview={preview} tweetId={tweetId} />}
+        <TweetFacts preview={preview} />
       </div>
     </article>
   );

--- a/lib/twitter/parser.ts
+++ b/lib/twitter/parser.ts
@@ -19,6 +19,16 @@ const normalizeUrlCandidate = (value: string): string => {
   return /^[a-z][a-z\d+\-.]*:/i.test(trimmed) ? trimmed : `https://${trimmed}`;
 };
 
+const normalizeTweetText = (value: string): string | undefined => {
+  const normalized = value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n");
+
+  return readString(normalized);
+};
+
 const parseHandleFromUrl = (url: string | undefined): string | undefined => {
   if (!url) {
     return undefined;
@@ -46,7 +56,7 @@ const findMediaLink = (
     (element: ReturnType<typeof $.root>[number]) => {
       const href = $(element).attr("href") ?? "";
       const text = $(element).text();
-      return isPicTwitterUrl(href) || isPicTwitterUrl(text);
+      return isPicTwitterUrl(href) || (isTcoUrl(href) && isPicTwitterUrl(text));
     }
   );
 
@@ -69,6 +79,15 @@ const isPicTwitterUrl = (value: string): boolean => {
   }
 };
 
+const isTcoUrl = (value: string): boolean => {
+  try {
+    const parsed = new URL(normalizeUrlCandidate(value));
+    return matchesDomainOrSubdomain(parsed.hostname, "t.co");
+  } catch {
+    return false;
+  }
+};
+
 export function parseTwitterOEmbed(
   oembed: TwitterOEmbedResponse,
   sourceUrl: string,
@@ -77,7 +96,9 @@ export function parseTwitterOEmbed(
   const $ = cheerio.load(oembed.html ?? "");
   const paragraph = $("blockquote p").first();
   paragraph.find("br").replaceWith("\n");
-  const text = readString(paragraph.clone().children().remove().end().text());
+  const text = normalizeTweetText(
+    paragraph.clone().children().remove().end().text()
+  );
   const tweetUrl =
     readString($("blockquote a").last().attr("href")) ?? sourceUrl;
   const createdAtText = readString($("blockquote a").last().text());

--- a/ops/docs/waves/link-previews/feature-twitter-link-previews.md
+++ b/ops/docs/waves/link-previews/feature-twitter-link-previews.md
@@ -52,8 +52,11 @@ Links that do not match these rules stay regular links.
 3. A tweet-shaped loading state appears.
 4. The app requests `/api/twitter/preview`, which fetches
    `https://publish.twitter.com/oembed` server-side and parses the returned HTML.
-5. If oEmbed metadata loads, the post text and media link render inline.
-6. The card includes X intent actions for liking and replying, plus copy link.
+5. If oEmbed metadata loads, the source, author, post text, media, timestamp,
+   and available engagement facts render inline.
+6. Engagement facts are passive labels. The card links to the original post,
+   while wave side actions provide open/copy controls where that layout supports
+   them.
 7. In wave/DM chat layouts, side actions (open/copy) appear beside the card.
    In home-style layouts, side actions are hidden.
 
@@ -91,8 +94,8 @@ Links that do not match these rules stay regular links.
 - This page covers tweet cards in wave/DM markdown, leaderboard markdown, and
   boosted `/` cards.
 - This page does not cover non-drop tweet surfaces.
-- Real-time X engagement counts are not fetched; actions link out to X intent
-  routes.
+- Real-time X engagement counts are not fetched. Any engagement facts shown come
+  from the preview payload and are not interactive X intent actions.
 
 ## Related Pages
 


### PR DESCRIPTION
## Issue
- Twitter/X link previews still looked like a mini X client, with follow/intent actions that were less useful inside waves and less consistent with the newer rich card direction.

## Fix
- Reworked the Twitter/X preview into a wave-native card with source/kicker, author, text, media, timestamp, and passive engagement facts.
- Removed the old follow/like/reply/repost intent affordances from the inline preview.
- Tightened Twitter oEmbed parsing for text whitespace and media-link detection.

## Changes
- Restyled `TwitterPreviewCard` with the shared dark card treatment, a small X accent, compact fact chips, responsive media, and a single card-level open action.
- Updated Twitter parser logic so `pic.twitter.com` text is trusted only when the href is a Twitter media redirect or a direct `pic.twitter.com` URL.
- Expanded component and parser coverage for sparse fact data, single open-link accessibility, direct media hrefs, and non-media `pic.twitter.com` text.
- Updated Twitter/X link preview docs to describe passive facts and wave side open/copy actions.

## Validation
- `seize run test:no-coverage -- __tests__/lib/twitter/parser.test.ts __tests__/lib/twitter/fetcher.test.ts __tests__/app/api/twitter.preview.route.test.ts __tests__/components/drops/view/part/dropPartMarkdown/twitter.test.ts __tests__/components/drops/view/part/dropPartMarkdown/linkPreviewDetection.test.ts __tests__/components/waves/TwitterPreviewCard.test.tsx` passed: 55 tests.
- `seize run lint:changed` passed.
- `seize run typecheck:changed` passed.
- `codex-diff-check` passed.
- Local browser QA covered desktop 1440x900, tablet 834x1112, and mobile 390x844 with no horizontal overflow.
- Claude Opus 4.8 external review loop completed; final pass reported no blockers.
- `seize run check:changed` could not complete in this Windows Codex shell because `scripts/quality.js` calls the repo `.cmd` wrapper internally, which fails path conversion here. Its direct changed-file format/lint/typecheck equivalents passed; direct knip reports existing repo-wide debt unrelated to this diff.

## Risk
- Level: Low
- Why: scoped to Twitter/X link preview rendering and Twitter oEmbed parsing/tests/docs. No schema, auth, payment, or deployment config changes.
- Rollback: revert this PR to restore the previous Twitter/X preview UI and parser behavior.

## Review Notes
- Please focus on the new single-open-link accessibility model, sparse/no-count fact rendering, and Twitter media-link parser tightening.