### PR TITLE
Polish generic website link preview cards

### DIFF
--- a/__tests__/app/api/open-graph.route.test.ts
+++ b/__tests__/app/api/open-graph.route.test.ts
@@ -195,9 +195,7 @@ async function loadRoute(): Promise<void> {
   ) as {
     createTransientPlan: jest.Mock;
   };
-  firstParty6529 = jest.requireMock(
-    "@/app/api/open-graph/6529/service"
-  ) as {
+  firstParty6529 = jest.requireMock("@/app/api/open-graph/6529/service") as {
     createFirstParty6529Plan: jest.Mock;
   };
   ensRouteModule = jest.requireMock("@/app/api/open-graph/ens") as {
@@ -398,6 +396,72 @@ describe("open-graph API route", () => {
       html,
       "text/html",
       "https://cdn.safe.example/page"
+    );
+  });
+
+  it("passes through richer generic article metadata from the parser", async () => {
+    const html =
+      "<html><head><title>Article</title></head><body></body></html>";
+    const responsePayload = {
+      requestUrl: "https://news.example/articles/richer-card",
+      url: "https://news.example/articles/richer-card",
+      title: "A richer generic link preview",
+      description: "Article dek from destination metadata.",
+      siteName: "Example News",
+      mediaType: "article",
+      contentType: "text/html; charset=utf-8",
+      favicon: "https://news.example/favicon.ico",
+      favicons: ["https://news.example/favicon.ico"],
+      image: {
+        url: "https://news.example/images/richer-card.jpg",
+        secureUrl: "https://news.example/images/richer-card.jpg",
+        alt: "Article hero image",
+      },
+      images: [
+        {
+          url: "https://news.example/images/richer-card.jpg",
+          secureUrl: "https://news.example/images/richer-card.jpg",
+          alt: "Article hero image",
+        },
+      ],
+      author: "Example Reporter",
+      publishedTime: "2026-06-16T12:00:00.000Z",
+    };
+
+    const fetchResponse = createResponse(200, {
+      headers: { "content-type": "text/html; charset=utf-8" },
+      body: html,
+      url: "https://news.example/articles/richer-card",
+    });
+
+    mockFetch.mockResolvedValueOnce(fetchResponse);
+    mockFetchPublicUrl.mockImplementationOnce(
+      async (url, init = {}, options = {}) => {
+        expect(url).toEqual(
+          new URL("https://news.example/articles/richer-card")
+        );
+        const result = await options.fetchImpl?.(url, init);
+        return (result ?? fetchResponse) as any;
+      }
+    );
+    utils.buildGoogleWorkspaceResponse.mockResolvedValueOnce(null);
+    utils.buildResponse.mockReturnValue(responsePayload);
+
+    const request = {
+      nextUrl: new URL(
+        "https://app.local/api/open-graph?url=https://news.example/articles/richer-card"
+      ),
+    } as any;
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(responsePayload);
+    expect(utils.buildResponse).toHaveBeenCalledWith(
+      new URL("https://news.example/articles/richer-card"),
+      html,
+      "text/html; charset=utf-8",
+      "https://news.example/articles/richer-card"
     );
   });
 

--- a/__tests__/app/api/open-graph.test.ts
+++ b/__tests__/app/api/open-graph.test.ts
@@ -2,6 +2,17 @@ jest.mock("node:dns/promises", () => ({
   lookup: jest.fn(),
 }));
 
+const mockUndiciFetch = jest.fn();
+
+jest.mock("undici", () => ({
+  Agent: jest.fn(() => ({
+    close: jest.fn(),
+    destroy: jest.fn(),
+    dispatch: jest.fn(),
+  })),
+  fetch: (...args: unknown[]) => mockUndiciFetch(...args),
+}));
+
 import {
   buildGoogleWorkspaceResponse,
   buildResponse,
@@ -15,11 +26,7 @@ const { lookup } = require("node:dns/promises") as {
 const originalFetch = global.fetch;
 const mockFetch = jest.fn();
 
-const createMockFetchResponse = (
-  status: number,
-  body: string,
-  url: string
-) => {
+const createMockFetchResponse = (status: number, body: string, url: string) => {
   const headerMap = new Map<string, string>();
   headerMap.set("content-type", "text/html");
   return {
@@ -36,7 +43,12 @@ const createMockFetchResponse = (
 beforeEach(() => {
   lookup.mockReset();
   mockFetch.mockReset();
+  mockUndiciFetch.mockReset();
   global.fetch = mockFetch as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  expect(mockUndiciFetch).not.toHaveBeenCalled();
 });
 
 afterAll(() => {
@@ -55,6 +67,8 @@ describe("open-graph route helpers", () => {
           <meta property="og:title" content="OG Title" />
           <meta property="og:description" content="OG Description" />
           <meta property="og:image" content="/og-image.jpg" />
+          <meta name="twitter:image" content="/twitter-image.jpg" />
+          <meta name="twitter:image:alt" content="Twitter-only alt" />
           <meta property="og:url" content="https://example.com/page" />
           <meta property="og:site_name" content="Example Site" />
           <meta property="og:type" content="article" />
@@ -72,9 +86,33 @@ describe("open-graph route helpers", () => {
     expect(result.url).toBe("https://example.com/page");
     expect(result.mediaType).toBe("article");
     expect(result.image?.url).toBe("https://example.com/og-image.jpg");
-    expect(result.images?.[0]?.secureUrl).toBe("https://example.com/og-image.jpg");
+    expect(result.image?.alt).toBeNull();
+    expect(result.images?.[0]?.secureUrl).toBe(
+      "https://example.com/og-image.jpg"
+    );
+    expect(result.images?.[1]?.secureUrl).toBe(
+      "https://example.com/twitter-image.jpg"
+    );
     expect(result.favicon).toBe("https://example.com/favicon.ico");
     expect(result.contentType).toBe("text/html");
+  });
+
+  it("applies Twitter image alt only when the Twitter image is primary", () => {
+    const html = `
+      <html>
+        <head>
+          <title>Twitter Image</title>
+          <meta name="twitter:image" content="/twitter-image.jpg" />
+          <meta name="twitter:image:alt" content="Twitter image alt" />
+        </head>
+        <body></body>
+      </html>
+    `;
+
+    const result = buildResponse(baseUrl, html, "text/html");
+
+    expect(result.image?.url).toBe("https://example.com/twitter-image.jpg");
+    expect(result.image?.alt).toBe("Twitter image alt");
   });
 
   it("falls back to document title and canonical link", () => {
@@ -84,6 +122,7 @@ describe("open-graph route helpers", () => {
           <title>Plain Title</title>
           <meta name="description" content="Plain Description" />
           <link rel="canonical" href="/canonical" />
+          <link rel="apple-touch-icon" href="/apple.png" />
           <link rel="shortcut icon" href="https://cdn.example.com/icon.png" />
         </head>
         <body></body>
@@ -98,9 +137,79 @@ describe("open-graph route helpers", () => {
     expect(result.favicon).toBe("https://cdn.example.com/icon.png");
   });
 
+  it("ignores oversized JSON-LD blocks", () => {
+    const oversizedJsonLd = JSON.stringify({
+      "@type": "Article",
+      headline: "Oversized JSON-LD Title",
+      description: "x".repeat(140 * 1024),
+    });
+    const html = `
+      <html>
+        <head>
+          <title>Fallback Title</title>
+          <script type="application/ld+json">${oversizedJsonLd}</script>
+        </head>
+        <body></body>
+      </html>
+    `;
+
+    const result = buildResponse(baseUrl, html, "text/html");
+
+    expect(result.title).toBe("Fallback Title");
+  });
+
+  it("bounds deeply nested JSON-LD traversal", () => {
+    const deepJsonLd = JSON.stringify(
+      Array.from({ length: 20 }).reduce<unknown>((value) => [value], {
+        "@type": "Article",
+        headline: "Too Deep",
+      })
+    );
+    const html = `
+      <html>
+        <head>
+          <title>Safe Fallback</title>
+          <script type="application/ld+json">${deepJsonLd}</script>
+        </head>
+        <body></body>
+      </html>
+    `;
+
+    const result = buildResponse(baseUrl, html, "text/html");
+
+    expect(result.title).toBe("Safe Fallback");
+  });
+
+  it("bounds deeply nested JSON-LD image arrays", () => {
+    const deepImage = Array.from({ length: 20 }).reduce<unknown>(
+      (value) => [value],
+      "/deep-image.jpg"
+    );
+    const html = `
+      <html>
+        <head>
+          <title>Deep Image Fallback</title>
+          <script type="application/ld+json">${JSON.stringify({
+            "@type": "Article",
+            headline: "Deep Image Fallback",
+            image: deepImage,
+          })}</script>
+        </head>
+        <body></body>
+      </html>
+    `;
+
+    const result = buildResponse(baseUrl, html, "text/html");
+
+    expect(result.title).toBe("Deep Image Fallback");
+    expect(result.image).toBeNull();
+  });
+
   it("builds a Google Docs preview with public availability", async () => {
-    const initialHtml = "<html><head><title>Doc Title</title></head><body></body></html>";
-    const previewHtml = "<html><head><title>Preview Title</title></head><body></body></html>";
+    const initialHtml =
+      "<html><head><title>Doc Title</title></head><body></body></html>";
+    const previewHtml =
+      "<html><head><title>Preview Title</title></head><body></body></html>";
 
     mockFetch.mockResolvedValueOnce(
       Promise.resolve(
@@ -216,9 +325,9 @@ describe("open-graph route helpers", () => {
   });
 
   it("rejects hex-encoded IPv4 hosts", async () => {
-    await expect(
-      assertPublicUrl(new URL("http://0x7f000001"))
-    ).rejects.toThrow("URL host is not allowed.");
+    await expect(assertPublicUrl(new URL("http://0x7f000001"))).rejects.toThrow(
+      "URL host is not allowed."
+    );
   });
 
   it("allows domains that resolve to public addresses", async () => {
@@ -228,5 +337,4 @@ describe("open-graph route helpers", () => {
       assertPublicUrl(new URL("http://example.com"))
     ).resolves.toBeUndefined();
   });
-
 });

--- a/__tests__/components/waves/OpenGraphPreview.test.tsx
+++ b/__tests__/components/waves/OpenGraphPreview.test.tsx
@@ -25,7 +25,7 @@ jest.mock("next/image", () => ({
     fill: _fill,
     ...rest
   }: any) {
-    return <img alt={alt} {...rest} />;
+    return React.createElement("img", { alt, ...rest });
   },
 }));
 
@@ -106,7 +106,10 @@ describe("OpenGraphPreview", () => {
           title: "Example Title",
           description: "An example description",
           siteName: "Example.com",
-          image: "https://cdn.example.com/preview.png",
+          image: {
+            url: "https://cdn.example.com/preview.png",
+            alt: "Example article hero",
+          },
         }}
       />
     );
@@ -114,33 +117,111 @@ describe("OpenGraphPreview", () => {
     const card = screen.getByTestId("og-preview-card");
     expect(card).toBeInTheDocument();
     expect(card).toHaveClass("tw-h-full");
-    expect(card.firstElementChild).toHaveClass(
-      "tw-flex-row",
-      "tw-h-full",
-      "tw-min-h-0"
+    expect(card).toHaveClass(
+      "tw-grid-cols-[6rem,minmax(0,1fr)]",
+      "sm:tw-grid-cols-[8rem,minmax(0,1fr)]",
+      "md:tw-grid-cols-[10.5rem,minmax(0,1fr)]"
     );
     expect(screen.getByText("Example.com")).toBeInTheDocument();
-    const titleLinks = screen.getAllByRole("link", { name: "Example Title" });
-    expect(titleLinks).toHaveLength(2);
-    expect(titleLinks[0]).toHaveClass(
-      "tw-h-full",
-      "tw-w-28",
-      "sm:tw-w-32",
-      "md:tw-w-44"
-    );
-    const titleLink = titleLinks[1];
-    expect(titleLink).toHaveAttribute("href", "/article");
-    expect(titleLink).not.toHaveAttribute("target");
-    const image = screen.getByAltText("Example Title");
+    expect(card).toHaveAttribute("href", "/article");
+    expect(card).not.toHaveAttribute("target");
+    const image = screen.getByAltText("Example article hero");
     expect(image).toHaveAttribute("src", "https://cdn.example.com/preview.png");
     expect(image).toHaveAttribute(
       "sizes",
-      "(max-width: 640px) 7rem, (max-width: 768px) 8rem, 176px"
+      "(max-width: 640px) 6rem, (max-width: 768px) 8rem, 10.5rem"
     );
-    expect(image.parentElement).toHaveClass("tw-h-full", "tw-w-full");
-    expect(image.parentElement).not.toHaveClass("tw-aspect-[16/9]");
+    expect(image.parentElement).toHaveClass(
+      "tw-aspect-[16/10]",
+      "tw-bg-black/40"
+    );
     expect(screen.getByText("An example description")).toBeInTheDocument();
     expect(screen.getByTestId("href-buttons")).toHaveTextContent("/article");
+  });
+
+  it("renders sparse article metadata with a source label and no empty fields", () => {
+    (removeBaseEndpoint as jest.Mock).mockReturnValue("/research/notes");
+
+    render(
+      <OpenGraphPreview
+        href="https://journal.example/research/notes"
+        preview={{
+          type: "article",
+          title: "Research Notes",
+          source: "Example Journal",
+          author: "Ada Lovelace",
+          publishedTime: "2026-06-16T12:00:00.000Z",
+          favicon: "https://journal.example/favicon.ico",
+        }}
+      />
+    );
+
+    const card = screen.getByTestId("og-preview-card");
+    expect(card).toBeInTheDocument();
+    expect(screen.getByText("Example Journal")).toBeInTheDocument();
+
+    expect(card).toHaveAttribute("href", "/research/notes");
+    expect(card).not.toHaveAttribute("target");
+    expect(screen.getByText("Research Notes")).toBeInTheDocument();
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+    expect(screen.getByText("Jun 16, 2026")).toBeInTheDocument();
+    expect(screen.queryByText("Link unavailable")).toBeNull();
+  });
+
+  it("renders free-text published dates without invalid datetime attributes", () => {
+    (removeBaseEndpoint as jest.Mock).mockReturnValue("/dispatch");
+
+    render(
+      <OpenGraphPreview
+        href="https://journal.example/dispatch"
+        preview={{
+          title: "Field Dispatch",
+          source: "Example Journal",
+          publishedTime: "Spring 2026",
+        }}
+      />
+    );
+
+    const date = screen.getByText("Spring 2026");
+    expect(date.tagName).toBe("TIME");
+    expect(date).not.toHaveAttribute("datetime");
+  });
+
+  it("renders partially parseable published dates without invalid datetime attributes", () => {
+    (removeBaseEndpoint as jest.Mock).mockReturnValue("/dispatch");
+
+    render(
+      <OpenGraphPreview
+        href="https://journal.example/dispatch"
+        preview={{
+          title: "Field Dispatch",
+          source: "Example Journal",
+          publishedTime: "Jun 16 2026 after publication",
+        }}
+      />
+    );
+
+    const date = screen.getByText("Jun 16 2026 after publication");
+    expect(date.tagName).toBe("TIME");
+    expect(date).not.toHaveAttribute("datetime");
+  });
+
+  it("does not render generic badges for dotted provider-style types", () => {
+    (removeBaseEndpoint as jest.Mock).mockReturnValue("/provider");
+
+    render(
+      <OpenGraphPreview
+        href="https://journal.example/provider"
+        preview={{
+          title: "Provider Payload",
+          source: "Example Journal",
+          type: "github.repository",
+        }}
+      />
+    );
+
+    expect(screen.getByText("Provider Payload")).toBeInTheDocument();
+    expect(screen.queryByText("Github Repository")).toBeNull();
   });
 
   it("preserves generated 6529 profile cards instead of cropping them", () => {
@@ -336,11 +417,12 @@ describe("OpenGraphPreview", () => {
       />
     );
 
-    expect(screen.getByTestId("6529-collection-preview-card")).toBeInTheDocument();
-    expect(screen.getByTestId("6529-collection-preview-image-frame")).toHaveClass(
-      "tw-bg-black",
-      "tw-border-black"
-    );
+    expect(
+      screen.getByTestId("6529-collection-preview-card")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("6529-collection-preview-image-frame")
+    ).toHaveClass("tw-bg-black", "tw-border-black");
     expect(screen.getByAltText("The Collective Synapse")).toHaveClass(
       "tw-object-contain"
     );
@@ -394,12 +476,15 @@ describe("OpenGraphPreview", () => {
       />
     );
 
-    expect(screen.getByTestId("6529-collection-preview-card")).toBeInTheDocument();
-    expect(screen.getByTestId("6529-collection-preview-image-frame")).toHaveClass(
-      "tw-bg-black",
-      "tw-border-black"
+    expect(
+      screen.getByTestId("6529-collection-preview-card")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("6529-collection-preview-image-frame")
+    ).toHaveClass("tw-bg-black", "tw-border-black");
+    expect(screen.getByAltText("Pebbles #514")).toHaveClass(
+      "tw-object-contain"
     );
-    expect(screen.getByAltText("Pebbles #514")).toHaveClass("tw-object-contain");
     expect(screen.getByText("Pebbles #514")).toBeInTheDocument();
     expect(screen.getByText("NextGen \u00b7 Pebbles")).toBeInTheDocument();
     expect(screen.getByText("Rarity")).toBeInTheDocument();

--- a/__tests__/components/waves/OpenGraphPreview.test.tsx
+++ b/__tests__/components/waves/OpenGraphPreview.test.tsx
@@ -163,9 +163,66 @@ describe("OpenGraphPreview", () => {
     expect(card).toHaveAttribute("href", "/research/notes");
     expect(card).not.toHaveAttribute("target");
     expect(screen.getByText("Research Notes")).toBeInTheDocument();
-    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+    expect(screen.getByText("by Ada Lovelace")).toBeInTheDocument();
     expect(screen.getByText("Jun 16, 2026")).toBeInTheDocument();
     expect(screen.queryByText("Link unavailable")).toBeNull();
+  });
+
+  it("prefers canonical URL domains over source fallbacks", () => {
+    (removeBaseEndpoint as jest.Mock).mockReturnValue(
+      "https://canonical.example/article"
+    );
+
+    render(
+      <OpenGraphPreview
+        href="https://request.example/redirect"
+        preview={{
+          title: "Canonical Source",
+          canonicalUrl: "https://canonical.example/article",
+          source: "request.example",
+        }}
+      />
+    );
+
+    expect(screen.getByText("canonical.example")).toBeInTheDocument();
+    expect(screen.queryByText("request.example")).toBeNull();
+  });
+
+  it("formats supported calendar dates in UTC", () => {
+    (removeBaseEndpoint as jest.Mock).mockReturnValue("/research/notes");
+
+    render(
+      <OpenGraphPreview
+        href="https://journal.example/research/notes"
+        preview={{
+          title: "Late Dispatch",
+          source: "Example Journal",
+          publishedTime: "2026-06-16T23:30:00-05:00",
+        }}
+      />
+    );
+
+    const date = screen.getByText("Jun 17, 2026");
+    expect(date).toHaveAttribute("datetime", "2026-06-17T04:30:00.000Z");
+  });
+
+  it("renders timezone-ambiguous timestamps without datetime attributes", () => {
+    (removeBaseEndpoint as jest.Mock).mockReturnValue("/dispatch");
+
+    render(
+      <OpenGraphPreview
+        href="https://journal.example/dispatch"
+        preview={{
+          title: "Field Dispatch",
+          source: "Example Journal",
+          publishedTime: "2026-06-16 12:00",
+        }}
+      />
+    );
+
+    const date = screen.getByText("2026-06-16 12:00");
+    expect(date.tagName).toBe("TIME");
+    expect(date).not.toHaveAttribute("datetime");
   });
 
   it("renders free-text published dates without invalid datetime attributes", () => {

--- a/app/api/open-graph/utils.ts
+++ b/app/api/open-graph/utils.ts
@@ -5,7 +5,7 @@ import type {
   GoogleWorkspaceLinkPreview,
   LinkPreviewResponse,
 } from "@/services/api/link-preview-api";
-import { load, type CheerioAPI } from "cheerio";
+import { load } from "cheerio";
 
 const TITLE_KEYS = ["og:title", "twitter:title", "title"] as const;
 const DESCRIPTION_KEYS = [
@@ -66,6 +66,7 @@ const JSON_LD_MAX_DEPTH = 8;
 const JSON_LD_IMAGE_MAX_CANDIDATES = 16;
 
 type GoogleWorkspaceKind = "docs" | "sheets" | "slides";
+type LoadedHtml = ReturnType<typeof load>;
 
 const GOOGLE_RESOURCE_KIND: Record<string, GoogleWorkspaceKind | undefined> = {
   document: "docs",
@@ -205,7 +206,7 @@ function normalizeWhitespace(value: string | undefined): string | undefined {
 }
 
 function getMetaIdentifier(
-  $: CheerioAPI,
+  $: LoadedHtml,
   element: unknown
 ): string | undefined {
   const tag = $(element);
@@ -215,13 +216,13 @@ function getMetaIdentifier(
 }
 
 function collectMetaContent(
-  $: CheerioAPI,
+  $: LoadedHtml,
   keys: readonly string[]
 ): Map<string, string[]> {
   const keySet = new Set(keys.map((key) => key.toLowerCase()));
   const results = new Map<string, string[]>();
 
-  $("meta").each((_, element) => {
+  $("meta").each((_index: number, element: unknown) => {
     const identifier = getMetaIdentifier($, element);
     if (!identifier || !keySet.has(identifier)) {
       return;
@@ -241,7 +242,7 @@ function collectMetaContent(
 }
 
 function extractFirstMetaContent(
-  $: CheerioAPI,
+  $: LoadedHtml,
   keys: readonly string[]
 ): string | undefined {
   const metadata = collectMetaContent($, keys);
@@ -254,11 +255,11 @@ function extractFirstMetaContent(
   return undefined;
 }
 
-function extractTitleTag($: CheerioAPI): string | undefined {
+function extractTitleTag($: LoadedHtml): string | undefined {
   return normalizeWhitespace($("title").first().text());
 }
 
-function extractCanonicalUrl($: CheerioAPI, baseUrl: URL): string | undefined {
+function extractCanonicalUrl($: LoadedHtml, baseUrl: URL): string | undefined {
   const href = normalizeWhitespace(
     $('link[rel~="canonical"]').first().attr("href")
   );
@@ -283,10 +284,10 @@ function iconPreferenceScore(rel: string, href: string): number {
   return 0;
 }
 
-function extractIconLinks($: CheerioAPI, baseUrl: URL): string[] {
+function extractIconLinks($: LoadedHtml, baseUrl: URL): string[] {
   const byUrl = new Map<string, number>();
 
-  $("link").each((_, element) => {
+  $("link").each((_index: number, element: unknown) => {
     const tag = $(element);
     const rel = normalizeWhitespace(tag.attr("rel")) ?? "";
     const href = normalizeWhitespace(tag.attr("href"));
@@ -421,13 +422,15 @@ function pickJsonLdNode(nodes: readonly JsonLdNode[]): JsonLdNode | null {
   );
 }
 
-function extractJsonLdNodes($: CheerioAPI): JsonLdNode[] {
+function extractJsonLdNodes($: LoadedHtml): JsonLdNode[] {
   const nodes: JsonLdNode[] = [];
 
-  $('script[type="application/ld+json"]').each((_, element) => {
-    const parsed = safeParseJsonLd($(element).contents().text());
-    nodes.push(...flattenJsonLdNodes(parsed));
-  });
+  $('script[type="application/ld+json"]').each(
+    (_index: number, element: unknown) => {
+      const parsed = safeParseJsonLd($(element).contents().text());
+      nodes.push(...flattenJsonLdNodes(parsed));
+    }
+  );
 
   return nodes;
 }
@@ -442,6 +445,7 @@ function extractJsonLdImage(
     return undefined;
   }
 
+  // The shared budget limits candidate nodes across nested JSON-LD image arrays.
   const candidate = node["image"] ?? node["thumbnailUrl"] ?? node["thumbnail"];
   if (typeof candidate === "string") {
     budget.remaining -= 1;
@@ -496,7 +500,7 @@ function getImageSource(key: string): ImageCandidate["source"] {
 }
 
 function extractImageCandidates(
-  $: CheerioAPI,
+  $: LoadedHtml,
   baseUrl: URL,
   jsonLdImage: string | undefined
 ): ImageCandidate[] {
@@ -528,7 +532,7 @@ function extractImageCandidates(
 }
 
 function extractImageMetadataForSource(
-  $: CheerioAPI,
+  $: LoadedHtml,
   source: ImageCandidate["source"] | undefined
 ): {
   readonly alt?: string | undefined;

--- a/app/api/open-graph/utils.ts
+++ b/app/api/open-graph/utils.ts
@@ -1,4 +1,3 @@
-import { escapeRegExp } from "@/lib/text/regex";
 import type {
   GoogleDocsLinkPreview,
   GoogleSheetsLinkPreview,
@@ -6,6 +5,7 @@ import type {
   GoogleWorkspaceLinkPreview,
   LinkPreviewResponse,
 } from "@/services/api/link-preview-api";
+import { load, type CheerioAPI } from "cheerio";
 
 const TITLE_KEYS = ["og:title", "twitter:title", "title"] as const;
 const DESCRIPTION_KEYS = [
@@ -19,17 +19,33 @@ const TYPE_KEYS = ["og:type"] as const;
 const IMAGE_KEYS = [
   "og:image",
   "og:image:url",
+  "og:image:secure_url",
   "twitter:image",
   "twitter:image:src",
 ] as const;
-
-const ESCAPE_HTML_ENTITIES: Record<string, string> = {
-  amp: "&",
-  lt: "<",
-  gt: ">",
-  quot: '"',
-  apos: "'",
-};
+const AUTHOR_KEYS = [
+  "author",
+  "article:author",
+  "twitter:creator",
+  "parsely-author",
+  "sailthru.author",
+  "dc.creator",
+] as const;
+const PUBLISHED_TIME_KEYS = [
+  "article:published_time",
+  "date",
+  "datePublished",
+  "datepublished",
+  "pubdate",
+  "publishdate",
+] as const;
+const MODIFIED_TIME_KEYS = [
+  "article:modified_time",
+  "og:updated_time",
+  "dateModified",
+  "datemodified",
+] as const;
+const ARTICLE_SECTION_KEYS = ["article:section"] as const;
 
 export const HTML_ACCEPT_HEADER =
   "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8";
@@ -44,6 +60,10 @@ const GOOGLE_THUMBNAIL_BASE = "https://drive.google.com/thumbnail";
 const GOOGLE_PREVIEW_TIMEOUT_MS = 3000;
 const GOOGLE_PREVIEW_BYTE_LIMIT = 64 * 1024;
 const GOOGLE_TITLE_MAX_LENGTH = 160;
+const JSON_LD_SCRIPT_MAX_CHARS = 128 * 1024;
+const JSON_LD_MAX_NODES = 64;
+const JSON_LD_MAX_DEPTH = 8;
+const JSON_LD_IMAGE_MAX_CANDIDATES = 16;
 
 type GoogleWorkspaceKind = "docs" | "sheets" | "slides";
 
@@ -179,93 +199,118 @@ function validateGooglePreviewUrl(rawUrl: string): URL | null {
   return parsed;
 }
 
-function decodeHtmlEntities(value: string): string {
-  return value.replaceAll(/&(#x?[0-9a-fA-F]+|[a-zA-Z]+);/g, (_, entity: string) => {
-    if (entity.startsWith("#x") || entity.startsWith("#X")) {
-      const codePoint = parseInt(entity.slice(2), 16);
-      return Number.isNaN(codePoint) ? "" : String.fromCodePoint(codePoint);
+function normalizeWhitespace(value: string | undefined): string | undefined {
+  const trimmed = value?.replace(/\s+/g, " ").trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function getMetaIdentifier(
+  $: CheerioAPI,
+  element: unknown
+): string | undefined {
+  const tag = $(element);
+  return normalizeWhitespace(
+    tag.attr("property") ?? tag.attr("name") ?? tag.attr("itemprop")
+  )?.toLowerCase();
+}
+
+function collectMetaContent(
+  $: CheerioAPI,
+  keys: readonly string[]
+): Map<string, string[]> {
+  const keySet = new Set(keys.map((key) => key.toLowerCase()));
+  const results = new Map<string, string[]>();
+
+  $("meta").each((_, element) => {
+    const identifier = getMetaIdentifier($, element);
+    if (!identifier || !keySet.has(identifier)) {
+      return;
     }
-    if (entity.startsWith("#")) {
-      const codePoint = parseInt(entity.slice(1), 10);
-      return Number.isNaN(codePoint) ? "" : String.fromCodePoint(codePoint);
+
+    const content = normalizeWhitespace($(element).attr("content"));
+    if (!content) {
+      return;
     }
-    return ESCAPE_HTML_ENTITIES[entity] ?? "";
+
+    const values = results.get(identifier) ?? [];
+    values.push(content);
+    results.set(identifier, values);
   });
+
+  return results;
 }
 
 function extractFirstMetaContent(
-  html: string,
+  $: CheerioAPI,
   keys: readonly string[]
 ): string | undefined {
+  const metadata = collectMetaContent($, keys);
   for (const key of keys) {
-    const pattern = new RegExp(
-      `<meta[^>]+(?:property|name)=['"]${escapeRegExp(key)}['"][^>]*content=['"]([^'"]+)['"][^>]*>`,
-      "i"
-    );
-    const match = pattern.exec(html);
-    if (match && match[1]) {
-      return decodeHtmlEntities(match[1].trim());
+    const [first] = metadata.get(key.toLowerCase()) ?? [];
+    if (first) {
+      return first;
     }
   }
   return undefined;
 }
 
-function extractAllMetaContent(
-  html: string,
-  keys: readonly string[]
-): string[] {
-  const results = new Set<string>();
+function extractTitleTag($: CheerioAPI): string | undefined {
+  return normalizeWhitespace($("title").first().text());
+}
 
-  for (const key of keys) {
-    const pattern = new RegExp(
-      `<meta[^>]+(?:property|name)=['"]${escapeRegExp(key)}['"][^>]*content=['"]([^'"]+)['"][^>]*>`,
-      "gi"
-    );
-    let match: RegExpExecArray | null;
-    while ((match = pattern.exec(html))) {
-      if (match[1]) {
-        results.add(decodeHtmlEntities(match[1].trim()));
-      }
+function extractCanonicalUrl($: CheerioAPI, baseUrl: URL): string | undefined {
+  const href = normalizeWhitespace(
+    $('link[rel~="canonical"]').first().attr("href")
+  );
+  return resolveUrl(baseUrl, href);
+}
+
+function iconPreferenceScore(rel: string, href: string): number {
+  const normalizedRel = rel.toLowerCase();
+  const normalizedHref = href.toLowerCase();
+  if (normalizedRel.includes("shortcut icon")) {
+    return 4;
+  }
+  if (/\bicon\b/.test(normalizedRel) && !normalizedRel.includes("apple")) {
+    return 3;
+  }
+  if (normalizedHref.endsWith(".svg")) {
+    return 2;
+  }
+  if (normalizedRel.includes("apple-touch-icon")) {
+    return 1;
+  }
+  return 0;
+}
+
+function extractIconLinks($: CheerioAPI, baseUrl: URL): string[] {
+  const byUrl = new Map<string, number>();
+
+  $("link").each((_, element) => {
+    const tag = $(element);
+    const rel = normalizeWhitespace(tag.attr("rel")) ?? "";
+    const href = normalizeWhitespace(tag.attr("href"));
+    if (!href || !iconRelPattern.test(rel)) {
+      return;
     }
-  }
 
-  return Array.from(results);
-}
-
-function extractTitleTag(html: string): string | undefined {
-  const match = html.match(/<title[^>]*>([^<]*)<\/title>/i);
-  return match && match[1] ? decodeHtmlEntities(match[1].trim()) : undefined;
-}
-
-function extractCanonicalUrl(html: string, baseUrl: URL): string | undefined {
-  const pattern = /<link[^>]*rel=['"]canonical['"][^>]*href=['"]([^'"]+)['"][^>]*>/i;
-  const match = pattern.exec(html);
-  if (match && match[1]) {
-    return resolveUrl(baseUrl, decodeHtmlEntities(match[1].trim()));
-  }
-  return undefined;
-}
-
-function extractIconLinks(html: string, baseUrl: URL): string[] {
-  const results = new Set<string>();
-  const pattern = /<link[^>]*rel=['"]([^'"]+)['"][^>]*href=['"]([^'"]+)['"][^>]*>/gi;
-  let match: RegExpExecArray | null;
-
-  while ((match = pattern.exec(html))) {
-    const rel = match[1];
-    const href = match[2];
-    if (rel && href && iconRelPattern.test(rel)) {
-      const resolved = resolveUrl(baseUrl, decodeHtmlEntities(href.trim()));
-      if (resolved) {
-        results.add(resolved);
-      }
+    const resolved = resolveUrl(baseUrl, href);
+    if (!resolved) {
+      return;
     }
-  }
 
-  return Array.from(results);
+    byUrl.set(resolved, iconPreferenceScore(rel, href));
+  });
+
+  return Array.from(byUrl.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([url]) => url);
 }
 
-function resolveUrl(baseUrl: URL, value: string | undefined): string | undefined {
+function resolveUrl(
+  baseUrl: URL,
+  value: string | undefined
+): string | undefined {
   if (!value) {
     return undefined;
   }
@@ -275,6 +320,243 @@ function resolveUrl(baseUrl: URL, value: string | undefined): string | undefined
   } catch {
     return undefined;
   }
+}
+
+function parsePositiveInteger(value: string | undefined): number | undefined {
+  if (!value || !/^\d+$/.test(value)) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+type JsonLdNode = Record<string, unknown>;
+type ImageCandidate = {
+  readonly url: string;
+  readonly source: "json-ld" | "og" | "twitter";
+};
+
+function safeParseJsonLd(raw: string): unknown {
+  if (raw.length > JSON_LD_SCRIPT_MAX_CHARS) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function asRecord(value: unknown): JsonLdNode | null {
+  return typeof value === "object" && value !== null
+    ? (value as JsonLdNode)
+    : null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? normalizeWhitespace(value) : undefined;
+}
+
+function flattenJsonLdNodes(
+  value: unknown,
+  depth = 0,
+  budget: { remaining: number } = { remaining: JSON_LD_MAX_NODES }
+): JsonLdNode[] {
+  if (depth > JSON_LD_MAX_DEPTH || budget.remaining <= 0) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    const nodes: JsonLdNode[] = [];
+    for (const entry of value) {
+      nodes.push(...flattenJsonLdNodes(entry, depth + 1, budget));
+      if (budget.remaining <= 0) {
+        break;
+      }
+    }
+    return nodes;
+  }
+
+  const record = asRecord(value);
+  if (!record) {
+    return [];
+  }
+
+  budget.remaining -= 1;
+  const graph = record["@graph"];
+  const nodes = [record];
+
+  if (Array.isArray(graph) && budget.remaining > 0) {
+    for (const entry of graph) {
+      nodes.push(...flattenJsonLdNodes(entry, depth + 1, budget));
+      if (budget.remaining <= 0) {
+        break;
+      }
+    }
+  }
+
+  return nodes;
+}
+
+function getJsonLdType(node: JsonLdNode): string {
+  const type = node["@type"];
+  if (Array.isArray(type)) {
+    return type.map((entry) => String(entry).toLowerCase()).join(" ");
+  }
+  return typeof type === "string" ? type.toLowerCase() : "";
+}
+
+function pickJsonLdNode(nodes: readonly JsonLdNode[]): JsonLdNode | null {
+  return (
+    nodes.find((node) =>
+      /\b(article|newsarticle|blogposting|report|creativework)\b/.test(
+        getJsonLdType(node)
+      )
+    ) ??
+    nodes.find((node) => /\b(webpage|website)\b/.test(getJsonLdType(node))) ??
+    nodes[0] ??
+    null
+  );
+}
+
+function extractJsonLdNodes($: CheerioAPI): JsonLdNode[] {
+  const nodes: JsonLdNode[] = [];
+
+  $('script[type="application/ld+json"]').each((_, element) => {
+    const parsed = safeParseJsonLd($(element).contents().text());
+    nodes.push(...flattenJsonLdNodes(parsed));
+  });
+
+  return nodes;
+}
+
+function extractJsonLdImage(
+  node: JsonLdNode | null,
+  baseUrl: URL,
+  depth = 0,
+  budget: { remaining: number } = { remaining: JSON_LD_IMAGE_MAX_CANDIDATES }
+): string | undefined {
+  if (!node || depth > JSON_LD_MAX_DEPTH || budget.remaining <= 0) {
+    return undefined;
+  }
+
+  const candidate = node["image"] ?? node["thumbnailUrl"] ?? node["thumbnail"];
+  if (typeof candidate === "string") {
+    budget.remaining -= 1;
+    return resolveUrl(baseUrl, candidate);
+  }
+
+  if (Array.isArray(candidate)) {
+    for (const entry of candidate) {
+      const image = extractJsonLdImage(
+        { image: entry },
+        baseUrl,
+        depth + 1,
+        budget
+      );
+      if (image) {
+        return image;
+      }
+      if (budget.remaining <= 0) {
+        break;
+      }
+    }
+  }
+
+  const record = asRecord(candidate);
+  if (record) {
+    budget.remaining -= 1;
+  }
+  return resolveUrl(
+    baseUrl,
+    asString(record?.["url"]) ?? asString(record?.["contentUrl"])
+  );
+}
+
+function extractJsonLdAuthor(node: JsonLdNode | null): string | undefined {
+  const author = node?.["author"] ?? node?.["creator"];
+  if (typeof author === "string") {
+    return normalizeWhitespace(author);
+  }
+
+  if (Array.isArray(author)) {
+    const names = author
+      .map((entry) => asString(asRecord(entry)?.["name"]) ?? asString(entry))
+      .filter((name): name is string => Boolean(name));
+    return names.length > 0 ? names.join(", ") : undefined;
+  }
+
+  return asString(asRecord(author)?.["name"]);
+}
+
+function getImageSource(key: string): ImageCandidate["source"] {
+  return key.toLowerCase().startsWith("twitter:") ? "twitter" : "og";
+}
+
+function extractImageCandidates(
+  $: CheerioAPI,
+  baseUrl: URL,
+  jsonLdImage: string | undefined
+): ImageCandidate[] {
+  const imageMetadata = collectMetaContent($, IMAGE_KEYS);
+  const byUrl = new Map<string, ImageCandidate>();
+
+  for (const key of IMAGE_KEYS) {
+    for (const value of imageMetadata.get(key.toLowerCase()) ?? []) {
+      const resolved = resolveUrl(baseUrl, value);
+      if (!resolved || byUrl.has(resolved)) {
+        continue;
+      }
+
+      byUrl.set(resolved, {
+        url: resolved,
+        source: getImageSource(key),
+      });
+    }
+  }
+
+  if (jsonLdImage && !byUrl.has(jsonLdImage)) {
+    byUrl.set(jsonLdImage, {
+      url: jsonLdImage,
+      source: "json-ld",
+    });
+  }
+
+  return Array.from(byUrl.values());
+}
+
+function extractImageMetadataForSource(
+  $: CheerioAPI,
+  source: ImageCandidate["source"] | undefined
+): {
+  readonly alt?: string | undefined;
+  readonly width?: number | undefined;
+  readonly height?: number | undefined;
+} {
+  if (source === "json-ld" || !source) {
+    return {};
+  }
+
+  const keys =
+    source === "twitter"
+      ? {
+          alt: ["twitter:image:alt"] as const,
+          width: ["twitter:image:width"] as const,
+          height: ["twitter:image:height"] as const,
+        }
+      : {
+          alt: ["og:image:alt"] as const,
+          width: ["og:image:width"] as const,
+          height: ["og:image:height"] as const,
+        };
+
+  return {
+    alt: extractFirstMetaContent($, keys.alt),
+    width: parsePositiveInteger(extractFirstMetaContent($, keys.width)),
+    height: parsePositiveInteger(extractFirstMetaContent($, keys.height)),
+  };
 }
 
 function parseHashParams(hash: string): URLSearchParams {
@@ -314,7 +596,8 @@ function normalizeGoogleWorkspaceUrl(
   const hashParams = parseHashParams(url.hash);
 
   const gid = searchParams.get("gid") ?? hashParams.get("gid") ?? undefined;
-  const range = searchParams.get("range") ?? hashParams.get("range") ?? undefined;
+  const range =
+    searchParams.get("range") ?? hashParams.get("range") ?? undefined;
   const widget = searchParams.get("widget") ?? undefined;
   const headers = searchParams.get("headers") ?? undefined;
   const chrome = searchParams.get("chrome") ?? undefined;
@@ -339,7 +622,11 @@ function normalizeGoogleWorkspaceUrl(
   };
 }
 
-function buildSheetsPreviewUrl(base: string, gid: string, range?: string): string {
+function buildSheetsPreviewUrl(
+  base: string,
+  gid: string,
+  range?: string
+): string {
   const preview = new URL(`${base}/htmlview`);
   preview.searchParams.set("gid", gid);
   if (range) {
@@ -369,7 +656,10 @@ function buildGoogleThumbnailUrl(fileId: string): string {
   return `${GOOGLE_THUMBNAIL_BASE}?id=${encodeURIComponent(fileId)}&sz=w1000`;
 }
 
-function clampGoogleTitle(value: string | undefined | null, fallback: string): string {
+function clampGoogleTitle(
+  value: string | undefined | null,
+  fallback: string
+): string {
   const trimmed = typeof value === "string" ? value.trim() : "";
   const base = trimmed.length > 0 ? trimmed : fallback;
   if (base.length <= GOOGLE_TITLE_MAX_LENGTH) {
@@ -384,7 +674,9 @@ function isGoogleAccessRestricted(html: string | null | undefined): boolean {
   }
 
   const normalized = html.toLowerCase();
-  return GOOGLE_ACCESS_DENIED_PATTERNS.some((pattern) => normalized.includes(pattern));
+  return GOOGLE_ACCESS_DENIED_PATTERNS.some((pattern) =>
+    normalized.includes(pattern)
+  );
 }
 
 function truncateToLimit(value: string, byteLimit: number): string {
@@ -462,7 +754,10 @@ async function fetchGooglePreviewHtml(url: string): Promise<{
   }
 
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), GOOGLE_PREVIEW_TIMEOUT_MS);
+  const timeout = setTimeout(
+    () => controller.abort(),
+    GOOGLE_PREVIEW_TIMEOUT_MS
+  );
 
   try {
     const response = await fetch(validatedUrl.toString(), {
@@ -508,11 +803,9 @@ function buildTitleCandidates(html: string | null): Array<string | undefined> {
   if (!html) {
     return [];
   }
+  const $ = load(html);
 
-  return [
-    extractFirstMetaContent(html, TITLE_KEYS),
-    extractTitleTag(html),
-  ];
+  return [extractFirstMetaContent($, TITLE_KEYS), extractTitleTag($)];
 }
 
 function pickGoogleTitle(
@@ -676,21 +969,49 @@ export function buildResponse(
   contentType: string | null,
   _finalUrl?: string
 ): LinkPreviewResponse {
-
-
+  const $ = load(html);
+  const jsonLdNode = pickJsonLdNode(extractJsonLdNodes($));
   const title =
-    extractFirstMetaContent(html, TITLE_KEYS) ?? extractTitleTag(html);
-  const description = extractFirstMetaContent(html, DESCRIPTION_KEYS);
-  const siteName = extractFirstMetaContent(html, SITE_NAME_KEYS);
-  const resolvedImageUrls = extractAllMetaContent(html, IMAGE_KEYS)
-    .map((src) => resolveUrl(url, src))
-    .filter((src): src is string => Boolean(src));
+    extractFirstMetaContent($, TITLE_KEYS) ??
+    asString(jsonLdNode?.["headline"]) ??
+    asString(jsonLdNode?.["name"]) ??
+    extractTitleTag($);
+  const description =
+    extractFirstMetaContent($, DESCRIPTION_KEYS) ??
+    asString(jsonLdNode?.["description"]);
+  const siteName =
+    extractFirstMetaContent($, SITE_NAME_KEYS) ??
+    asString(asRecord(jsonLdNode?.["publisher"])?.["name"]);
+  const jsonLdImage = extractJsonLdImage(jsonLdNode, url);
+  const imageCandidates = extractImageCandidates($, url, jsonLdImage);
   const canonicalUrl =
-    extractFirstMetaContent(html, URL_KEYS) ?? extractCanonicalUrl(html, url);
-  const type = extractFirstMetaContent(html, TYPE_KEYS);
-  const favicons = extractIconLinks(html, url);
+    extractFirstMetaContent($, URL_KEYS) ?? extractCanonicalUrl($, url);
+  const type = extractFirstMetaContent($, TYPE_KEYS);
+  const favicons = extractIconLinks($, url);
+  const author =
+    extractFirstMetaContent($, AUTHOR_KEYS) ?? extractJsonLdAuthor(jsonLdNode);
+  const publishedTime =
+    extractFirstMetaContent($, PUBLISHED_TIME_KEYS) ??
+    asString(jsonLdNode?.["datePublished"]);
+  const modifiedTime =
+    extractFirstMetaContent($, MODIFIED_TIME_KEYS) ??
+    asString(jsonLdNode?.["dateModified"]);
+  const section = extractFirstMetaContent($, ARTICLE_SECTION_KEYS);
+  const primaryImage = imageCandidates[0];
+  const primaryImageMetadata = extractImageMetadataForSource(
+    $,
+    primaryImage?.source
+  );
 
-  const primaryImage = resolvedImageUrls[0];
+  const primaryImageData = primaryImage
+    ? {
+        url: primaryImage.url,
+        secureUrl: primaryImage.url,
+        width: primaryImageMetadata.width ?? null,
+        height: primaryImageMetadata.height ?? null,
+        alt: primaryImageMetadata.alt ?? null,
+      }
+    : null;
 
   return {
     requestUrl: url.toString(),
@@ -702,9 +1023,18 @@ export function buildResponse(
     contentType: contentType ?? null,
     favicon: favicons[0] ?? null,
     favicons,
-    image: primaryImage
-      ? { url: primaryImage, secureUrl: primaryImage }
-      : null,
-    images: resolvedImageUrls.map((src) => ({ url: src, secureUrl: src })),
+    image: primaryImageData,
+    images: imageCandidates.map((candidate, index) => ({
+      url: candidate.url,
+      secureUrl: candidate.url,
+      width: index === 0 ? (primaryImageMetadata.width ?? null) : null,
+      height: index === 0 ? (primaryImageMetadata.height ?? null) : null,
+      alt: index === 0 ? (primaryImageMetadata.alt ?? null) : null,
+    })),
+    source: siteName ?? url.hostname.replace(/^www\./i, ""),
+    author: author ?? null,
+    publishedTime: publishedTime ?? null,
+    modifiedTime: modifiedTime ?? null,
+    section: section ?? null,
   };
 }

--- a/components/waves/OpenGraphPreview.tsx
+++ b/components/waves/OpenGraphPreview.tsx
@@ -31,10 +31,20 @@ export interface OpenGraphPreviewData {
   imageUrl?: unknown | undefined;
   image_url?: unknown | undefined;
   images?: unknown | undefined;
+  favicon?: unknown | undefined;
+  favicons?: unknown | undefined;
   ogImage?: unknown | undefined;
   og_image?: unknown | undefined;
   thumbnailUrl?: unknown | undefined;
   thumbnail_url?: unknown | undefined;
+  author?: unknown | undefined;
+  byline?: unknown | undefined;
+  publishedTime?: unknown | undefined;
+  published_time?: unknown | undefined;
+  datePublished?: unknown | undefined;
+  date_published?: unknown | undefined;
+  mediaType?: unknown | undefined;
+  type?: unknown | undefined;
   [key: string]: unknown;
 }
 
@@ -50,7 +60,7 @@ type MaybeRecord = Record<string, unknown>;
 
 const TITLE_KEYS = ["title", "ogTitle", "name"];
 const DESCRIPTION_KEYS = ["description", "ogDescription", "summary"];
-const DOMAIN_KEYS = ["domain", "siteName", "site_name", "source"];
+const DOMAIN_KEYS = ["source", "siteName", "site_name", "domain"];
 const URL_KEYS = ["url", "canonicalUrl", "canonical_url"];
 const IMAGE_KEYS = [
   "image",
@@ -65,6 +75,17 @@ const IMAGE_KEYS = [
   "secureUrl",
 ];
 const IMAGE_COLLECTION_KEYS = ["images", "ogImages", "og_images", "thumbnails"];
+const IMAGE_ALT_KEYS = ["imageAlt", "image_alt", "ogImageAlt", "og_image_alt"];
+const FAVICON_KEYS = ["favicon"];
+const FAVICON_COLLECTION_KEYS = ["favicons"];
+const AUTHOR_KEYS = ["author", "byline"];
+const PUBLISHED_TIME_KEYS = [
+  "publishedTime",
+  "published_time",
+  "datePublished",
+  "date_published",
+];
+const MEDIA_TYPE_KEYS = ["mediaType", "type"];
 const LONG_UNBROKEN_SEGMENT_THRESHOLD = 32;
 
 export type FirstPartyOpenGraphPreviewKind = "profile" | "drop" | "wave";
@@ -81,8 +102,7 @@ const FIRST_PARTY_OG_KIND_LABELS: Record<
 function isFirstParty6529Hostname(hostname: string): boolean {
   const normalizedHostname = hostname.toLowerCase();
   return (
-    normalizedHostname === "6529.io" ||
-    normalizedHostname.endsWith(".6529.io")
+    normalizedHostname === "6529.io" || normalizedHostname.endsWith(".6529.io")
   );
 }
 
@@ -145,6 +165,34 @@ function extractImageFromValue(value: unknown): string | undefined {
   return undefined;
 }
 
+function extractStringFromValue(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function extractImageAltFromValue(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const extracted = extractImageAltFromValue(entry);
+      if (extracted) {
+        return extracted;
+      }
+    }
+    return undefined;
+  }
+
+  if (typeof value === "object" && value !== null) {
+    const record = value as MaybeRecord;
+    return extractStringFromValue(record["alt"]);
+  }
+
+  return undefined;
+}
+
 function extractImageUrl(
   data: OpenGraphPreviewData | null | undefined
 ): string | undefined {
@@ -163,6 +211,59 @@ function extractImageUrl(
     const imageUrl = extractImageFromValue(data[key]);
     if (imageUrl) {
       return imageUrl;
+    }
+  }
+
+  return undefined;
+}
+
+function extractImageAlt(
+  data: OpenGraphPreviewData | null | undefined
+): string | undefined {
+  if (!data) {
+    return undefined;
+  }
+
+  const topLevelAlt = readFirstString(data, IMAGE_ALT_KEYS);
+  if (topLevelAlt) {
+    return topLevelAlt;
+  }
+
+  for (const key of IMAGE_KEYS) {
+    const imageAlt = extractImageAltFromValue(data[key]);
+    if (imageAlt) {
+      return imageAlt;
+    }
+  }
+
+  for (const key of IMAGE_COLLECTION_KEYS) {
+    const imageAlt = extractImageAltFromValue(data[key]);
+    if (imageAlt) {
+      return imageAlt;
+    }
+  }
+
+  return undefined;
+}
+
+function extractFaviconUrl(
+  data: OpenGraphPreviewData | null | undefined
+): string | undefined {
+  if (!data) {
+    return undefined;
+  }
+
+  for (const key of FAVICON_KEYS) {
+    const faviconUrl = extractImageFromValue(data[key]);
+    if (faviconUrl) {
+      return faviconUrl;
+    }
+  }
+
+  for (const key of FAVICON_COLLECTION_KEYS) {
+    const faviconUrl = extractImageFromValue(data[key]);
+    if (faviconUrl) {
+      return faviconUrl;
     }
   }
 
@@ -288,6 +389,217 @@ function deriveDomain(
     readFirstString(preview, DOMAIN_KEYS) ??
     extractDomainFromUrl(readFirstString(preview, URL_KEYS)) ??
     extractDomainFromUrl(href)
+  );
+}
+
+function formatPublishedDate(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const timestamp = parseSupportedPublishedTimestamp(value);
+  if (timestamp === undefined) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  }).format(new Date(timestamp));
+}
+
+function getPublishedDateTime(value: string | undefined): string | undefined {
+  const timestamp = parseSupportedPublishedTimestamp(value);
+  if (timestamp === undefined) {
+    return undefined;
+  }
+
+  return new Date(timestamp).toISOString();
+}
+
+function parseSupportedPublishedTimestamp(
+  value: string | undefined
+): number | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const isIsoLikeDate = /^\d{4}-\d{2}-\d{2}(?:[T\s].*)?$/.test(trimmed);
+  const isMonthFirstDate = /^[A-Za-z]{3,}\s+\d{1,2},?\s+\d{4}$/.test(trimmed);
+  const isDayFirstDate = /^\d{1,2}\s+[A-Za-z]{3,}\s+\d{4}$/.test(trimmed);
+
+  if (!isIsoLikeDate && !isMonthFirstDate && !isDayFirstDate) {
+    return undefined;
+  }
+
+  const timestamp = Date.parse(trimmed);
+  return Number.isNaN(timestamp) ? undefined : timestamp;
+}
+
+function normalizeMediaTypeLabel(
+  value: string | undefined
+): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (!normalized || normalized.includes(".")) {
+    return undefined;
+  }
+
+  if (normalized.includes("article")) {
+    return "Article";
+  }
+
+  if (normalized === "website" || normalized === "webpage") {
+    return "Website";
+  }
+
+  return value
+    .replace(/[_:.]+/g, " ")
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+function GenericOpenGraphMetaRow({
+  author,
+  publishedDate,
+  publishedDateTime,
+}: {
+  readonly author?: string | undefined;
+  readonly publishedDate?: string | undefined;
+  readonly publishedDateTime?: string | undefined;
+}) {
+  if (!author && !publishedDate) {
+    return null;
+  }
+
+  return (
+    <div className="tw-flex tw-min-w-0 tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-1 tw-text-xs tw-leading-5 tw-text-iron-400">
+      {author && (
+        <span className="tw-inline-flex tw-min-w-0 tw-max-w-full tw-items-baseline tw-gap-1">
+          <span className="tw-flex-shrink-0">by</span>
+          <span className="tw-truncate tw-font-medium tw-text-iron-200">
+            {wrapLongUnbrokenSegments(author)}
+          </span>
+        </span>
+      )}
+      {author && publishedDate && (
+        <span className="tw-text-iron-600" aria-hidden="true">
+          /
+        </span>
+      )}
+      {publishedDate && (
+        <time className="tw-flex-shrink-0" dateTime={publishedDateTime}>
+          {publishedDate}
+        </time>
+      )}
+    </div>
+  );
+}
+
+function GenericOpenGraphPreviewCard({
+  effectiveHref,
+  linkTarget,
+  linkRel,
+  imageUrl,
+  imageAlt,
+  faviconUrl,
+  title,
+  description,
+  domain,
+  mediaTypeLabel,
+  author,
+  publishedDate,
+  publishedDateTime,
+}: {
+  readonly effectiveHref: string;
+  readonly linkTarget?: "_blank" | undefined;
+  readonly linkRel?: string | undefined;
+  readonly imageUrl?: string | undefined;
+  readonly imageAlt?: string | undefined;
+  readonly faviconUrl?: string | undefined;
+  readonly title: string;
+  readonly description?: string | undefined;
+  readonly domain?: string | undefined;
+  readonly mediaTypeLabel?: string | undefined;
+  readonly author?: string | undefined;
+  readonly publishedDate?: string | undefined;
+  readonly publishedDateTime?: string | undefined;
+}) {
+  const sourceLabel = domain ?? "External link";
+
+  return (
+    <Link
+      href={effectiveHref}
+      target={linkTarget}
+      rel={linkRel}
+      className={[
+        "tw-group/og-card tw-relative tw-grid tw-h-full tw-min-h-0 tw-w-full tw-min-w-0 tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950/70 tw-p-3 tw-pr-12 tw-no-underline tw-shadow-sm tw-shadow-black/20 tw-transition tw-duration-200 hover:tw-border-sky-400/40 hover:tw-bg-iron-900/80 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 sm:tw-pr-14",
+        imageUrl
+          ? "tw-grid-cols-[6rem,minmax(0,1fr)] tw-gap-3 sm:tw-grid-cols-[8rem,minmax(0,1fr)] md:tw-grid-cols-[10.5rem,minmax(0,1fr)]"
+          : "tw-grid-cols-1",
+      ].join(" ")}
+      data-testid="og-preview-card"
+    >
+      <span className="tw-pointer-events-none tw-absolute tw-inset-y-0 tw-left-0 tw-w-1 tw-bg-sky-400/70" />
+      {imageUrl && (
+        <span className="tw-relative tw-block tw-aspect-[16/10] tw-h-full tw-min-h-[6.5rem] tw-w-full tw-overflow-hidden tw-rounded-lg tw-bg-black/40 sm:tw-min-h-[7.5rem]">
+          <Image
+            src={imageUrl}
+            alt={imageAlt ?? title}
+            fill
+            className="tw-object-cover tw-transition tw-duration-300 group-hover/og-card:tw-scale-[1.02]"
+            loading="lazy"
+            sizes="(max-width: 640px) 6rem, (max-width: 768px) 8rem, 10.5rem"
+            unoptimized
+          />
+        </span>
+      )}
+      <span className="tw-flex tw-min-h-0 tw-min-w-0 tw-flex-col tw-justify-center tw-gap-1.5 tw-overflow-hidden">
+        <span className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
+          {faviconUrl && (
+            <span className="tw-relative tw-block tw-h-4 tw-w-4 tw-flex-shrink-0 tw-overflow-hidden tw-rounded-sm tw-bg-iron-800">
+              <Image
+                src={faviconUrl}
+                alt=""
+                fill
+                className="tw-object-contain"
+                loading="lazy"
+                sizes="16px"
+                unoptimized
+              />
+            </span>
+          )}
+          <span className="tw-min-w-0 tw-truncate tw-text-xs tw-font-semibold tw-leading-5 tw-text-iron-300">
+            {wrapLongUnbrokenSegments(sourceLabel)}
+          </span>
+          {mediaTypeLabel && (
+            <span className="tw-flex-shrink-0 tw-rounded-md tw-border tw-border-sky-400/25 tw-bg-sky-400/10 tw-px-1.5 tw-py-0.5 tw-text-[10px] tw-font-semibold tw-uppercase tw-leading-4 tw-text-sky-100">
+              {mediaTypeLabel}
+            </span>
+          )}
+        </span>
+        <span className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-break-words tw-text-base tw-font-semibold tw-leading-snug tw-text-iron-50 tw-transition tw-duration-200 group-hover/og-card:tw-text-white md:tw-text-lg">
+          {wrapLongUnbrokenSegments(title)}
+        </span>
+        <GenericOpenGraphMetaRow
+          author={author}
+          publishedDate={publishedDate}
+          publishedDateTime={publishedDateTime}
+        />
+        {description && (
+          <span className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-whitespace-pre-line tw-break-words tw-text-xs tw-leading-5 tw-text-iron-300 md:tw-text-sm">
+            {wrapLongUnbrokenSegments(description)}
+          </span>
+        )}
+      </span>
+    </Link>
   );
 }
 
@@ -442,13 +754,15 @@ function FirstPartyOpenGraphPreviewCard({
     <div
       className="tw-relative tw-h-full tw-min-h-0 tw-w-full tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/40 tw-p-3 sm:tw-p-4"
       data-testid="og-preview-card"
-      data-og-kind={kind}>
+      data-og-kind={kind}
+    >
       <div className="tw-flex tw-h-full tw-min-h-0 tw-flex-col tw-gap-2 lg:tw-flex-row lg:tw-gap-3">
         <Link
           href={effectiveHref}
           target={linkTarget}
           rel={linkRel}
-          className="tw-relative tw-block tw-h-28 tw-w-full tw-flex-shrink-0 tw-overflow-hidden tw-rounded-lg tw-bg-black/35 lg:tw-h-full lg:tw-w-72 xl:tw-w-80">
+          className="tw-relative tw-block tw-h-28 tw-w-full tw-flex-shrink-0 tw-overflow-hidden tw-rounded-lg tw-bg-black/35 lg:tw-h-full lg:tw-w-72 xl:tw-w-80"
+        >
           {/* Generated 6529 OG images are already complete cards; preserve them. */}
           <Image
             src={imageUrl}
@@ -468,7 +782,7 @@ function FirstPartyOpenGraphPreviewCard({
                 {wrapLongUnbrokenSegments(domain)}
               </span>
             )}
-            <span className="tw-flex-shrink-0 tw-rounded-full tw-border tw-border-primary-400/35 tw-bg-primary-400/10 tw-px-2 tw-py-0.5 tw-text-[0.68rem] tw-font-semibold tw-uppercase tw-tracking-wide tw-text-primary-200">
+            <span className="tw-text-primary-200 tw-flex-shrink-0 tw-rounded-full tw-border tw-border-primary-400/35 tw-bg-primary-400/10 tw-px-2 tw-py-0.5 tw-text-[0.68rem] tw-font-semibold tw-uppercase tw-tracking-wide">
               {kindLabel}
             </span>
           </div>
@@ -477,7 +791,8 @@ function FirstPartyOpenGraphPreviewCard({
             href={effectiveHref}
             target={linkTarget}
             rel={linkRel}
-            className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-block tw-break-words tw-text-base tw-font-semibold tw-leading-snug tw-text-iron-100 tw-no-underline tw-transition tw-duration-200 hover:tw-text-white">
+            className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-block tw-break-words tw-text-base tw-font-semibold tw-leading-snug tw-text-iron-100 tw-no-underline tw-transition tw-duration-200 hover:tw-text-white"
+          >
             {wrapLongUnbrokenSegments(title)}
           </Link>
 
@@ -512,7 +827,9 @@ function SeizeCollectionPreviewCard({
   const imageUrl = extractImageUrl(preview);
   const people = Array.isArray(preview.people) ? preview.people : [];
   const facts = Array.isArray(preview.facts) ? preview.facts : [];
-  const traits = Array.isArray(preview.traits) ? preview.traits.slice(0, 3) : [];
+  const traits = Array.isArray(preview.traits)
+    ? preview.traits.slice(0, 3)
+    : [];
   const resolvedVariant = variant ?? "chat";
   const isHome = resolvedVariant === "home";
 
@@ -579,13 +896,13 @@ function SeizeCollectionPreviewCard({
             </Link>
             {people.length > 0 && (
               <div className="tw-flex tw-min-w-0 tw-flex-wrap tw-gap-x-3 tw-gap-y-1 tw-overflow-hidden tw-text-xs tw-leading-5 md:tw-text-sm">
-                {people.map((person, index) => {
+                {people.map((person) => {
                   const personHref = person.href ?? undefined;
                   const personIsExternal = isExternalHref(personHref);
 
                   return (
                     <span
-                      key={`${person.label ?? "person"}-${person.name}-${index}`}
+                      key={`${person.label ?? "person"}-${person.name}-${person.href ?? "display"}`}
                       className="tw-inline-flex tw-min-w-0 tw-max-w-full tw-items-baseline tw-gap-1"
                     >
                       {person.label && (
@@ -715,7 +1032,16 @@ export default function OpenGraphPreview({
   const title = readFirstString(preview, TITLE_KEYS);
   const description = readFirstString(preview, DESCRIPTION_KEYS);
   const imageUrl = extractImageUrl(preview);
+  const imageAlt = extractImageAlt(preview);
+  const faviconUrl = extractFaviconUrl(preview);
   const domain = deriveDomain(href, preview);
+  const author = readFirstString(preview, AUTHOR_KEYS);
+  const publishedDateRaw = readFirstString(preview, PUBLISHED_TIME_KEYS);
+  const publishedDate = formatPublishedDate(publishedDateRaw);
+  const publishedDateTime = getPublishedDateTime(publishedDateRaw);
+  const mediaTypeLabel = normalizeMediaTypeLabel(
+    readFirstString(preview, MEDIA_TYPE_KEYS)
+  );
   const githubPreview = extractGithubPreview(preview);
   const seizePreview = extractSeizeCollectionPreview(preview);
   const hasContent = Boolean(title ?? description ?? imageUrl);
@@ -898,66 +1224,28 @@ export default function OpenGraphPreview({
           </div>
         </Link>
       ) : (
-        <div
-          className="tw-relative tw-h-full tw-min-h-0 tw-w-full tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/40 tw-p-4"
-          data-testid="og-preview-card"
-        >
+        <div className="tw-relative tw-h-full tw-min-h-0 tw-w-full">
           {isGithubStatusPreviewResponse(githubPreview) && (
             <GithubPreviewStatusBadge
               href={href}
               initialPreview={githubPreview}
             />
           )}
-          <div
-            className={
-              imageUrl
-                ? "tw-flex tw-h-full tw-min-h-0 tw-flex-row tw-gap-3"
-                : "tw-flex tw-h-full tw-min-h-0 tw-flex-col tw-gap-3 md:tw-flex-row"
-            }
-          >
-            {imageUrl && (
-              <Link
-                href={effectiveHref}
-                target={linkTarget}
-                rel={linkRel}
-                className="tw-block tw-h-full tw-w-28 tw-flex-shrink-0 sm:tw-w-32 md:tw-w-44"
-              >
-                <div className="tw-h-full tw-w-full tw-overflow-hidden tw-rounded-lg tw-bg-iron-900/60">
-                  {/* OG image hosts are arbitrary, so many are not in Next remotePatterns. */}
-                  <Image
-                    src={imageUrl}
-                    alt={title ?? domain ?? "Link preview"}
-                    width={1200}
-                    height={630}
-                    className="tw-h-full tw-w-full tw-object-cover"
-                    loading="lazy"
-                    sizes="(max-width: 640px) 7rem, (max-width: 768px) 8rem, 176px"
-                    unoptimized
-                  />
-                </div>
-              </Link>
-            )}
-            <div className="tw-flex tw-min-h-0 tw-min-w-0 tw-flex-1 tw-flex-col tw-justify-center tw-gap-y-1.5 tw-overflow-hidden">
-              {domain && (
-                <span className="tw-line-clamp-1 tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-iron-400">
-                  {wrapLongUnbrokenSegments(domain)}
-                </span>
-              )}
-              <Link
-                href={effectiveHref}
-                target={linkTarget}
-                rel={linkRel}
-                className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-block tw-break-words tw-text-base tw-font-semibold tw-leading-snug tw-text-iron-100 tw-no-underline tw-transition tw-duration-200 hover:tw-text-white"
-              >
-                {wrapLongUnbrokenSegments(title ?? domain ?? href)}
-              </Link>
-              {description && (
-                <p className="tw-[overflow-wrap:anywhere] tw-m-0 tw-line-clamp-2 tw-whitespace-pre-line tw-break-words tw-text-xs tw-text-iron-300">
-                  {wrapLongUnbrokenSegments(description)}
-                </p>
-              )}
-            </div>
-          </div>
+          <GenericOpenGraphPreviewCard
+            effectiveHref={effectiveHref}
+            linkTarget={linkTarget}
+            linkRel={linkRel}
+            imageUrl={imageUrl}
+            imageAlt={imageAlt}
+            faviconUrl={faviconUrl}
+            title={title ?? domain ?? href}
+            description={description}
+            domain={domain}
+            mediaTypeLabel={mediaTypeLabel}
+            author={author}
+            publishedDate={publishedDate}
+            publishedDateTime={publishedDateTime}
+          />
         </div>
       )}
     </LinkPreviewCardLayout>

--- a/components/waves/OpenGraphPreview.tsx
+++ b/components/waves/OpenGraphPreview.tsx
@@ -4,6 +4,9 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { removeBaseEndpoint } from "@/helpers/Helpers";
+import { formatDate } from "@/i18n/format";
+import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import type {
   GithubPreviewEnvelope,
   GithubPreviewResponse,
@@ -60,7 +63,8 @@ type MaybeRecord = Record<string, unknown>;
 
 const TITLE_KEYS = ["title", "ogTitle", "name"];
 const DESCRIPTION_KEYS = ["description", "ogDescription", "summary"];
-const DOMAIN_KEYS = ["source", "siteName", "site_name", "domain"];
+const DOMAIN_KEYS = ["siteName", "site_name", "domain"];
+const SOURCE_KEYS = ["source"];
 const URL_KEYS = ["url", "canonicalUrl", "canonical_url"];
 const IMAGE_KEYS = [
   "image",
@@ -87,6 +91,39 @@ const PUBLISHED_TIME_KEYS = [
 ];
 const MEDIA_TYPE_KEYS = ["mediaType", "type"];
 const LONG_UNBROKEN_SEGMENT_THRESHOLD = 32;
+const GENERIC_LINK_PREVIEW_LOCALE = DEFAULT_LOCALE;
+const PUBLISHED_DATE_FORMAT_OPTIONS = {
+  day: "numeric",
+  month: "short",
+  timeZone: "UTC",
+  year: "numeric",
+} satisfies Intl.DateTimeFormatOptions;
+const MONTH_INDEX_BY_NAME: Readonly<Record<string, number>> = {
+  jan: 0,
+  january: 0,
+  feb: 1,
+  february: 1,
+  mar: 2,
+  march: 2,
+  apr: 3,
+  april: 3,
+  may: 4,
+  jun: 5,
+  june: 5,
+  jul: 6,
+  july: 6,
+  aug: 7,
+  august: 7,
+  sep: 8,
+  sept: 8,
+  september: 8,
+  oct: 9,
+  october: 9,
+  nov: 10,
+  november: 10,
+  dec: 11,
+  december: 11,
+};
 
 export type FirstPartyOpenGraphPreviewKind = "profile" | "drop" | "wave";
 
@@ -388,11 +425,15 @@ function deriveDomain(
   return (
     readFirstString(preview, DOMAIN_KEYS) ??
     extractDomainFromUrl(readFirstString(preview, URL_KEYS)) ??
+    readFirstString(preview, SOURCE_KEYS) ??
     extractDomainFromUrl(href)
   );
 }
 
-function formatPublishedDate(value: string | undefined): string | undefined {
+function formatPublishedDate(
+  value: string | undefined,
+  locale: SupportedLocale
+): string | undefined {
   if (!value) {
     return undefined;
   }
@@ -402,11 +443,7 @@ function formatPublishedDate(value: string | undefined): string | undefined {
     return value;
   }
 
-  return new Intl.DateTimeFormat("en-US", {
-    day: "numeric",
-    month: "short",
-    year: "numeric",
-  }).format(new Date(timestamp));
+  return formatDate(locale, timestamp, PUBLISHED_DATE_FORMAT_OPTIONS);
 }
 
 function getPublishedDateTime(value: string | undefined): string | undefined {
@@ -418,6 +455,55 @@ function getPublishedDateTime(value: string | undefined): string | undefined {
   return new Date(timestamp).toISOString();
 }
 
+function parseUtcCalendarDate(
+  year: number,
+  monthIndex: number,
+  day: number
+): number | undefined {
+  const timestamp = Date.UTC(year, monthIndex, day);
+  const parsed = new Date(timestamp);
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== monthIndex ||
+    parsed.getUTCDate() !== day
+  ) {
+    return undefined;
+  }
+
+  return timestamp;
+}
+
+function parseNamedMonthDate(value: string): number | undefined {
+  const monthFirstMatch = value.match(
+    /^([A-Za-z]{3,})\s+(\d{1,2}),?\s+(\d{4})$/
+  );
+  if (monthFirstMatch) {
+    const monthIndex =
+      MONTH_INDEX_BY_NAME[monthFirstMatch[1]!.toLowerCase()];
+    return typeof monthIndex === "number"
+      ? parseUtcCalendarDate(
+          Number(monthFirstMatch[3]),
+          monthIndex,
+          Number(monthFirstMatch[2])
+        )
+      : undefined;
+  }
+
+  const dayFirstMatch = value.match(/^(\d{1,2})\s+([A-Za-z]{3,})\s+(\d{4})$/);
+  if (dayFirstMatch) {
+    const monthIndex = MONTH_INDEX_BY_NAME[dayFirstMatch[2]!.toLowerCase()];
+    return typeof monthIndex === "number"
+      ? parseUtcCalendarDate(
+          Number(dayFirstMatch[3]),
+          monthIndex,
+          Number(dayFirstMatch[1])
+        )
+      : undefined;
+  }
+
+  return undefined;
+}
+
 function parseSupportedPublishedTimestamp(
   value: string | undefined
 ): number | undefined {
@@ -426,20 +512,26 @@ function parseSupportedPublishedTimestamp(
     return undefined;
   }
 
-  const isIsoLikeDate = /^\d{4}-\d{2}-\d{2}(?:[T\s].*)?$/.test(trimmed);
-  const isMonthFirstDate = /^[A-Za-z]{3,}\s+\d{1,2},?\s+\d{4}$/.test(trimmed);
-  const isDayFirstDate = /^\d{1,2}\s+[A-Za-z]{3,}\s+\d{4}$/.test(trimmed);
-
-  if (!isIsoLikeDate && !isMonthFirstDate && !isDayFirstDate) {
-    return undefined;
+  const dateOnlyMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (dateOnlyMatch) {
+    return parseUtcCalendarDate(
+      Number(dateOnlyMatch[1]),
+      Number(dateOnlyMatch[2]) - 1,
+      Number(dateOnlyMatch[3])
+    );
   }
 
-  const timestamp = Date.parse(trimmed);
-  return Number.isNaN(timestamp) ? undefined : timestamp;
+  if (/^\d{4}-\d{2}-\d{2}T.*(?:Z|[+-]\d{2}:?\d{2})$/.test(trimmed)) {
+    const timestamp = Date.parse(trimmed);
+    return Number.isNaN(timestamp) ? undefined : timestamp;
+  }
+
+  return parseNamedMonthDate(trimmed);
 }
 
 function normalizeMediaTypeLabel(
-  value: string | undefined
+  value: string | undefined,
+  locale: SupportedLocale
 ): string | undefined {
   if (!value) {
     return undefined;
@@ -451,41 +543,43 @@ function normalizeMediaTypeLabel(
   }
 
   if (normalized.includes("article")) {
-    return "Article";
+    return t(locale, "linkPreview.mediaType.article");
   }
 
   if (normalized === "website" || normalized === "webpage") {
-    return "Website";
+    return t(locale, "linkPreview.mediaType.website");
   }
 
-  return value
-    .replace(/[_:.]+/g, " ")
-    .split(/\s+/)
-    .filter(Boolean)
-    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
-    .join(" ");
+  return undefined;
 }
 
 function GenericOpenGraphMetaRow({
   author,
   publishedDate,
   publishedDateTime,
+  locale,
 }: {
   readonly author?: string | undefined;
   readonly publishedDate?: string | undefined;
   readonly publishedDateTime?: string | undefined;
+  readonly locale: SupportedLocale;
 }) {
   if (!author && !publishedDate) {
     return null;
   }
 
+  const byline = author
+    ? t(locale, "linkPreview.byline", {
+        author,
+      })
+    : undefined;
+
   return (
     <div className="tw-flex tw-min-w-0 tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-1 tw-text-xs tw-leading-5 tw-text-iron-400">
-      {author && (
+      {byline && (
         <span className="tw-inline-flex tw-min-w-0 tw-max-w-full tw-items-baseline tw-gap-1">
-          <span className="tw-flex-shrink-0">by</span>
           <span className="tw-truncate tw-font-medium tw-text-iron-200">
-            {wrapLongUnbrokenSegments(author)}
+            {wrapLongUnbrokenSegments(byline)}
           </span>
         </span>
       )}
@@ -517,6 +611,7 @@ function GenericOpenGraphPreviewCard({
   author,
   publishedDate,
   publishedDateTime,
+  locale,
 }: {
   readonly effectiveHref: string;
   readonly linkTarget?: "_blank" | undefined;
@@ -531,8 +626,9 @@ function GenericOpenGraphPreviewCard({
   readonly author?: string | undefined;
   readonly publishedDate?: string | undefined;
   readonly publishedDateTime?: string | undefined;
+  readonly locale: SupportedLocale;
 }) {
-  const sourceLabel = domain ?? "External link";
+  const sourceLabel = domain ?? t(locale, "linkPreview.externalSourceFallback");
 
   return (
     <Link
@@ -592,6 +688,7 @@ function GenericOpenGraphPreviewCard({
           author={author}
           publishedDate={publishedDate}
           publishedDateTime={publishedDateTime}
+          locale={locale}
         />
         {description && (
           <span className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-whitespace-pre-line tw-break-words tw-text-xs tw-leading-5 tw-text-iron-300 md:tw-text-sm">
@@ -984,6 +1081,7 @@ export default function OpenGraphPreview({
   const isExternalLink = !relativeHref;
   const linkTarget = isExternalLink ? "_blank" : undefined;
   const linkRel = isExternalLink ? "noopener noreferrer" : undefined;
+  const locale = GENERIC_LINK_PREVIEW_LOCALE;
 
   if (typeof preview === "undefined") {
     if (resolvedVariant === "home") {
@@ -1037,10 +1135,11 @@ export default function OpenGraphPreview({
   const domain = deriveDomain(href, preview);
   const author = readFirstString(preview, AUTHOR_KEYS);
   const publishedDateRaw = readFirstString(preview, PUBLISHED_TIME_KEYS);
-  const publishedDate = formatPublishedDate(publishedDateRaw);
+  const publishedDate = formatPublishedDate(publishedDateRaw, locale);
   const publishedDateTime = getPublishedDateTime(publishedDateRaw);
   const mediaTypeLabel = normalizeMediaTypeLabel(
-    readFirstString(preview, MEDIA_TYPE_KEYS)
+    readFirstString(preview, MEDIA_TYPE_KEYS),
+    locale
   );
   const githubPreview = extractGithubPreview(preview);
   const seizePreview = extractSeizeCollectionPreview(preview);
@@ -1245,6 +1344,7 @@ export default function OpenGraphPreview({
             author={author}
             publishedDate={publishedDate}
             publishedDateTime={publishedDateTime}
+            locale={locale}
           />
         </div>
       )}

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -682,6 +682,13 @@ const MEDIA_VIDEO_MESSAGES = namespaceMessages("media.video", [
   ["unsupported", "Your browser does not support the video tag."],
 ] as const);
 
+const LINK_PREVIEW_MESSAGES = namespaceMessages("linkPreview", [
+  ["externalSourceFallback", "External link"],
+  ["byline", "by {author}"],
+  ["mediaType.article", "Article"],
+  ["mediaType.website", "Website"],
+] as const);
+
 export const EN_US_MESSAGES = {
   "home.boostedDrop.anonymousAuthor": "Anonymous",
   "home.boostedDrop.badge": "Boosted post",
@@ -896,6 +903,7 @@ export const EN_US_MESSAGES = {
   ...ABOUT_TECH_MESSAGES,
   ...REMEMES_DETAIL_MESSAGES,
   ...MEDIA_VIDEO_MESSAGES,
+  ...LINK_PREVIEW_MESSAGES,
 } as const;
 
 export type MessageKey = keyof typeof EN_US_MESSAGES;

--- a/ops/docs/waves/link-previews/feature-external-link-previews.md
+++ b/ops/docs/waves/link-previews/feature-external-link-previews.md
@@ -77,6 +77,9 @@ reduce layout shift while loading.
 - Card quality depends on metadata published by the destination.
 - Slow or redirect-heavy destinations can degrade preview quality or fall back to
   non-rich link states.
+- Link-preview chrome uses the app message catalog, but the wave preview stack
+  does not yet pass an active route locale into this component. Until that route
+  migration happens, generic preview labels and dates use the default locale.
 - This page does not cover provider-specific cards.
 
 ## Related Pages

--- a/ops/docs/waves/link-previews/feature-external-link-previews.md
+++ b/ops/docs/waves/link-previews/feature-external-link-previews.md
@@ -7,7 +7,9 @@ Parent: [Link Previews Index](README.md)
 Wave markdown renders generic external-link cards for eligible `http://` and
 `https://` URLs when no provider-specific handler matches first.
 
-Generic cards can show domain, title, description, and image.
+Generic website and article previews can use source/site, title, description,
+image, author, published date, and favicon metadata when the destination
+publishes it. The card omits missing fields instead of reserving empty space.
 In chat and direct-message layouts, cards render in a fixed-height frame to
 reduce layout shift while loading.
 
@@ -29,8 +31,8 @@ reduce layout shift while loading.
 
 1. Open a drop containing an eligible URL.
 2. A loading skeleton appears while preview metadata is fetched.
-3. If metadata resolves, the drop shows a card with title, description, domain,
-   and optional image.
+3. If metadata resolves, the drop shows a card from the available metadata,
+   usually source/site, title, description, and optional image.
 4. In chat/message cards, side actions show copy/open controls; eligible authors
    can also see `Hide link previews`.
 5. In home-style cards, side action buttons are not shown.
@@ -38,6 +40,9 @@ reduce layout shift while loading.
 ## Common Scenarios
 
 - News, blog, and docs URLs render as generic external cards.
+- Article metadata can include author and published date details when the
+  destination exposes standard article metadata.
+- Sites can provide favicon metadata for compact source identification.
 - Repeated views of the same URL can resolve faster because preview responses
   are cached.
 - Long unbroken metadata text wraps inside the card to avoid horizontal overflow.

--- a/services/api/link-preview-api.ts
+++ b/services/api/link-preview-api.ts
@@ -24,6 +24,11 @@ interface LinkPreviewBase {
   readonly favicons?: readonly string[] | null | undefined;
   readonly image?: LinkPreviewMedia | null | undefined;
   readonly images?: readonly LinkPreviewMedia[] | null | undefined;
+  readonly source?: string | null | undefined;
+  readonly author?: string | null | undefined;
+  readonly publishedTime?: string | null | undefined;
+  readonly modifiedTime?: string | null | undefined;
+  readonly section?: string | null | undefined;
   readonly [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Issue
- Generic website/article link previews were still fairly thin compared with the newer rich provider cards.
- They did not consistently use richer metadata such as source/site, favicon, author, published date, image alt/dimensions, or JSON-LD fallbacks.

## Fix
- Parse generic HTML with Cheerio and richer metadata fallbacks while keeping route fetches byte-limited and JSON-LD traversal bounded.
- Replace the generic fallback UI with a single-link, responsive card that presents source/favicon, type badge, title, byline/date, description, and image when available.

## Changes
- Adds richer generic OpenGraph parsing for favicon ordering, source, author, dates, section, image alt/width/height, and bounded JSON-LD headline/description/image/author fallbacks.
- Updates the generic card renderer to use the richer metadata and preserve a clean single target across chat/home variants.
- Extends link preview response typing for the new generic metadata fields.
- Adds route/helper/component coverage for metadata pass-through, OG/Twitter image priority, JSON-LD caps, date handling, dotted provider-style type badges, and sparse metadata rendering.
- Updates external link preview docs for the richer generic metadata behavior.

## Validation
- `seize run test:no-coverage -- __tests__/app/api/open-graph.test.ts __tests__/app/api/open-graph.route.test.ts __tests__/components/waves/OpenGraphPreview.test.tsx` (56 passing)
- `seize exec eslint --no-warn-ignored --max-warnings=0 __tests__/app/api/open-graph.test.ts __tests__/app/api/open-graph.route.test.ts __tests__/components/waves/OpenGraphPreview.test.tsx app/api/open-graph/utils.ts components/waves/OpenGraphPreview.tsx services/api/link-preview-api.ts`
- `seize run typecheck:changed`
- `seize run react-doctor:diff` (100/100, no issues)
- `codex-diff-check`
- Local Playwright visual QA at desktop, tablet, and mobile widths: six generic cards rendered at each size with no card overflow and no horizontal document scroll.
- External Opus review loop completed; final targeted pass reported no blocking findings.

## Risk
- Level: Medium
- Why: touches shared generic link-preview parsing and rendering, with bounded SSR fetch and parser hardening to reduce untrusted HTML risk.
- Rollback: revert this PR to restore the previous generic card UI/parser behavior.

## Review Notes
- Please focus on generic parser hardening, image metadata attribution, and whether the single-link card behavior feels right alongside existing first-party/provider-specific cards.