### PR TITLE
Add Farcaster Mini App link previews

### DIFF
--- a/__tests__/app/api/open-graph.route.test.ts
+++ b/__tests__/app/api/open-graph.route.test.ts
@@ -521,6 +521,7 @@ describe("open-graph API route", () => {
       expect.objectContaining({
         type: "farcaster.miniapp",
         embedKind: "miniapp",
+        url: "https://mini.example/app",
         title: "Example Mini",
         appName: "Example Mini",
         buttonTitle: "Launch",
@@ -608,6 +609,63 @@ describe("open-graph API route", () => {
     );
   });
 
+  it("keeps the canonical URL when Mini App actions point to another host", async () => {
+    const miniAppMetadata = {
+      version: "1",
+      imageUrl: "https://mini.example/preview.png",
+      button: {
+        title: "Launch",
+        action: {
+          type: "launch_miniapp",
+          name: "Cross Host Mini",
+          url: "https://launch.example/app",
+        },
+      },
+    };
+    const html = `
+      <html>
+        <head>
+          <meta name='fc:miniapp' content='${JSON.stringify(
+            miniAppMetadata
+          )}' />
+          <meta property="og:title" content="Cross Host Mini" />
+        </head>
+      </html>
+    `;
+    mockFetchPublicUrl.mockResolvedValueOnce(
+      createResponse(200, {
+        headers: { "content-type": "text/html" },
+        body: html,
+        url: "https://mini.example/app",
+      })
+    );
+    utils.buildResponse.mockReturnValue({
+      requestUrl: "https://mini.example/app",
+      url: "https://mini.example/app",
+      title: "Cross Host Mini",
+      description: null,
+      siteName: "Mini Example",
+      source: "mini.example",
+      image: null,
+      images: [],
+    });
+
+    const response = await GET({
+      nextUrl: new URL(
+        "https://app.local/api/open-graph?url=https://mini.example/app"
+      ),
+    } as any);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        type: "farcaster.miniapp",
+        url: "https://mini.example/app",
+        actionUrl: "https://launch.example/app",
+      })
+    );
+  });
+
   it("returns typed previews for legacy Farcaster frame metadata", async () => {
     const html = `
       <html>
@@ -652,7 +710,7 @@ describe("open-graph API route", () => {
         type: "farcaster.frame",
         embedKind: "legacy-frame",
         title: "Legacy Frame",
-        appName: "Legacy Example",
+        appName: null,
         buttonTitle: "Mint",
         actionUrl: "https://legacy.example/mint",
         imageUrl: "https://legacy.example/legacy.png",
@@ -764,7 +822,65 @@ describe("open-graph API route", () => {
     await expect(response.json()).resolves.toEqual(
       expect.objectContaining({
         type: "farcaster.miniapp",
+        actionType: "launch_miniapp",
         actionUrl: "https://mini.example/app",
+      })
+    );
+  });
+
+  it("drops unknown Mini App action types", async () => {
+    const miniAppMetadata = {
+      version: "1",
+      imageUrl: "https://mini.example/preview.png",
+      button: {
+        title: "Launch",
+        action: {
+          type: "surprise_action",
+          name: "Unknown Action Mini",
+          url: "https://mini.example/launch",
+        },
+      },
+    };
+    const html = `
+      <html>
+        <head>
+          <meta name='fc:miniapp' content='${JSON.stringify(
+            miniAppMetadata
+          )}' />
+          <meta property="og:title" content="Unknown Action Mini" />
+        </head>
+      </html>
+    `;
+    mockFetchPublicUrl.mockResolvedValueOnce(
+      createResponse(200, {
+        headers: { "content-type": "text/html" },
+        body: html,
+        url: "https://mini.example/app",
+      })
+    );
+    utils.buildResponse.mockReturnValue({
+      requestUrl: "https://mini.example/app",
+      url: "https://mini.example/app",
+      title: "Unknown Action Mini",
+      description: null,
+      siteName: "Mini Example",
+      source: "mini.example",
+      image: null,
+      images: [],
+    });
+
+    const response = await GET({
+      nextUrl: new URL(
+        "https://app.local/api/open-graph?url=https://mini.example/app"
+      ),
+    } as any);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        type: "farcaster.miniapp",
+        actionType: null,
+        actionUrl: "https://mini.example/launch",
       })
     );
   });

--- a/__tests__/app/api/open-graph.route.test.ts
+++ b/__tests__/app/api/open-graph.route.test.ts
@@ -465,6 +465,467 @@ describe("open-graph API route", () => {
     );
   });
 
+  it("returns typed Farcaster Mini App previews from fc:miniapp metadata", async () => {
+    const miniAppMetadata = {
+      version: "1",
+      imageUrl: "https://mini.example/preview.png",
+      button: {
+        title: "Launch",
+        action: {
+          type: "launch_miniapp",
+          name: "Example Mini",
+          url: "/launch",
+          splashImageUrl: "https://mini.example/splash.png",
+          splashBackgroundColor: "#855dcd",
+        },
+      },
+    };
+    const html = `
+      <html>
+        <head>
+          <meta name='fc:miniapp' content='${JSON.stringify(
+            miniAppMetadata
+          )}' />
+          <meta property="og:title" content="OG Example Mini" />
+          <meta property="og:description" content="Launch the example app" />
+        </head>
+      </html>
+    `;
+    mockFetchPublicUrl.mockResolvedValueOnce(
+      createResponse(200, {
+        headers: { "content-type": "text/html" },
+        body: html,
+        url: "https://mini.example/app",
+      })
+    );
+    utils.buildResponse.mockReturnValue({
+      requestUrl: "https://mini.example/app",
+      url: "https://mini.example/app",
+      title: "OG Example Mini",
+      description: "Launch the example app",
+      siteName: "Mini Example",
+      source: "mini.example",
+      image: null,
+      images: [],
+    });
+
+    const response = await GET({
+      nextUrl: new URL(
+        "https://app.local/api/open-graph?url=https://mini.example/app"
+      ),
+    } as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual(
+      expect.objectContaining({
+        type: "farcaster.miniapp",
+        embedKind: "miniapp",
+        title: "Example Mini",
+        appName: "Example Mini",
+        buttonTitle: "Launch",
+        actionType: "launch_miniapp",
+        actionUrl: "https://mini.example/launch",
+        imageUrl: "https://mini.example/preview.png",
+        splashImageUrl: "https://mini.example/splash.png",
+        splashBackgroundColor: "#855dcd",
+        mediaType: "application",
+      })
+    );
+    expect(body.image).toEqual({
+      url: "https://mini.example/preview.png",
+      secureUrl: "https://mini.example/preview.png",
+    });
+    expect(body.images).toEqual([body.image]);
+    expect(guard.assertPublicUrl).toHaveBeenCalledWith(
+      new URL("https://mini.example/preview.png"),
+      expect.any(Object)
+    );
+    expect(guard.assertPublicUrl).toHaveBeenCalledWith(
+      new URL("https://mini.example/launch"),
+      expect.any(Object)
+    );
+    expect(guard.assertPublicUrl).toHaveBeenCalledWith(
+      new URL("https://mini.example/splash.png"),
+      expect.any(Object)
+    );
+  });
+
+  it("uses JSON fc:frame metadata as a backward-compatible Mini App preview", async () => {
+    const frameMetadata = {
+      version: "1",
+      imageUrl: "https://frame.example/frame.png",
+      button: {
+        title: "Start",
+        action: {
+          type: "launch_frame",
+          name: "Frame Thing",
+          url: "https://frame.example/play",
+        },
+      },
+    };
+    const html = `
+      <html>
+        <head>
+          <meta name='fc:frame' content='${JSON.stringify(frameMetadata)}' />
+          <title>Frame fallback title</title>
+        </head>
+      </html>
+    `;
+    mockFetchPublicUrl.mockResolvedValueOnce(
+      createResponse(200, {
+        headers: { "content-type": "text/html" },
+        body: html,
+        url: "https://frame.example/app",
+      })
+    );
+    utils.buildResponse.mockReturnValue({
+      requestUrl: "https://frame.example/app",
+      url: "https://frame.example/app",
+      title: "Frame fallback title",
+      description: null,
+      siteName: "Frame Example",
+      source: "frame.example",
+      image: null,
+      images: [],
+    });
+
+    const response = await GET({
+      nextUrl: new URL(
+        "https://app.local/api/open-graph?url=https://frame.example/app"
+      ),
+    } as any);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        type: "farcaster.miniapp",
+        embedKind: "frame",
+        title: "Frame Thing",
+        buttonTitle: "Start",
+        actionUrl: "https://frame.example/play",
+      })
+    );
+  });
+
+  it("returns typed previews for legacy Farcaster frame metadata", async () => {
+    const html = `
+      <html>
+        <head>
+          <meta name="fc:frame" content="vNext" />
+          <meta name="fc:frame:image" content="/legacy.png" />
+          <meta name="fc:frame:button:1" content="Mint" />
+          <meta name="fc:frame:button:1:action" content="link" />
+          <meta name="fc:frame:button:1:target" content="/mint" />
+          <meta property="og:title" content="Legacy Frame" />
+        </head>
+      </html>
+    `;
+    mockFetchPublicUrl.mockResolvedValueOnce(
+      createResponse(200, {
+        headers: { "content-type": "text/html" },
+        body: html,
+        url: "https://legacy.example/frame",
+      })
+    );
+    utils.buildResponse.mockReturnValue({
+      requestUrl: "https://legacy.example/frame",
+      url: "https://legacy.example/frame",
+      title: "Legacy Frame",
+      description: null,
+      siteName: "Legacy Example",
+      source: "legacy.example",
+      image: null,
+      images: [],
+    });
+
+    const response = await GET({
+      nextUrl: new URL(
+        "https://app.local/api/open-graph?url=https://legacy.example/frame"
+      ),
+    } as any);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual(
+      expect.objectContaining({
+        type: "farcaster.frame",
+        embedKind: "legacy-frame",
+        title: "Legacy Frame",
+        appName: "Legacy Example",
+        buttonTitle: "Mint",
+        actionUrl: "https://legacy.example/mint",
+        imageUrl: "https://legacy.example/legacy.png",
+        buttons: ["Mint"],
+      })
+    );
+  });
+
+  it("uses only link-action targets for legacy Farcaster frame navigation", async () => {
+    const html = `
+      <html>
+        <head>
+          <meta name="fc:frame" content="vNext" />
+          <meta name="fc:frame:image" content="/legacy.png" />
+          <meta name="fc:frame:button:1" content="Vote" />
+          <meta name="fc:frame:button:1:action" content="post" />
+          <meta name="fc:frame:button:1:target" content="/vote" />
+          <meta name="fc:frame:button:2" content="View" />
+          <meta name="fc:frame:button:2:action" content="link" />
+          <meta name="fc:frame:button:2:target" content="/view" />
+          <meta property="og:title" content="Legacy Frame" />
+        </head>
+      </html>
+    `;
+    mockFetchPublicUrl.mockResolvedValueOnce(
+      createResponse(200, {
+        headers: { "content-type": "text/html" },
+        body: html,
+        url: "https://legacy.example/frame",
+      })
+    );
+    utils.buildResponse.mockReturnValue({
+      requestUrl: "https://legacy.example/frame",
+      url: "https://legacy.example/frame",
+      title: "Legacy Frame",
+      description: null,
+      siteName: "Legacy Example",
+      source: "legacy.example",
+      image: null,
+      images: [],
+    });
+
+    const response = await GET({
+      nextUrl: new URL(
+        "https://app.local/api/open-graph?url=https://legacy.example/frame"
+      ),
+    } as any);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        type: "farcaster.frame",
+        embedKind: "legacy-frame",
+        buttonTitle: "View",
+        actionUrl: "https://legacy.example/view",
+        buttons: ["Vote", "View"],
+      })
+    );
+  });
+
+  it("falls back to the Mini App URL when action schemes are unsafe", async () => {
+    const miniAppMetadata = {
+      version: "1",
+      imageUrl: "https://mini.example/preview.png",
+      button: {
+        title: "Launch",
+        action: {
+          type: "launch_miniapp",
+          name: "Unsafe Action Mini",
+          url: "javascript:alert(1)",
+        },
+      },
+    };
+    const html = `
+      <html>
+        <head>
+          <meta name='fc:miniapp' content='${JSON.stringify(
+            miniAppMetadata
+          )}' />
+          <meta property="og:title" content="Unsafe Action Mini" />
+        </head>
+      </html>
+    `;
+    mockFetchPublicUrl.mockResolvedValueOnce(
+      createResponse(200, {
+        headers: { "content-type": "text/html" },
+        body: html,
+        url: "https://mini.example/app",
+      })
+    );
+    utils.buildResponse.mockReturnValue({
+      requestUrl: "https://mini.example/app",
+      url: "https://mini.example/app",
+      title: "Unsafe Action Mini",
+      description: null,
+      siteName: "Mini Example",
+      source: "mini.example",
+      image: null,
+      images: [],
+    });
+
+    const response = await GET({
+      nextUrl: new URL(
+        "https://app.local/api/open-graph?url=https://mini.example/app"
+      ),
+    } as any);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        type: "farcaster.miniapp",
+        actionUrl: "https://mini.example/app",
+      })
+    );
+  });
+
+  it("drops Mini App splash images when they are not public", async () => {
+    const miniAppMetadata = {
+      version: "1",
+      imageUrl: "https://mini.example/preview.png",
+      button: {
+        title: "Launch",
+        action: {
+          type: "launch_miniapp",
+          name: "Private Splash Mini",
+          url: "https://mini.example/launch",
+          splashImageUrl: "http://127.0.0.1/splash.png",
+        },
+      },
+    };
+    const html = `
+      <html>
+        <head>
+          <meta name='fc:miniapp' content='${JSON.stringify(
+            miniAppMetadata
+          )}' />
+          <meta property="og:title" content="Private Splash Mini" />
+        </head>
+      </html>
+    `;
+    guard.assertPublicUrl.mockImplementation(async (url: URL) => {
+      if (url.hostname === "127.0.0.1") {
+        throw new UrlGuardError("private URL", "private-url", 400);
+      }
+    });
+    mockFetchPublicUrl.mockResolvedValueOnce(
+      createResponse(200, {
+        headers: { "content-type": "text/html" },
+        body: html,
+        url: "https://mini.example/app",
+      })
+    );
+    utils.buildResponse.mockReturnValue({
+      requestUrl: "https://mini.example/app",
+      url: "https://mini.example/app",
+      title: "Private Splash Mini",
+      description: null,
+      siteName: "Mini Example",
+      source: "mini.example",
+      image: null,
+      images: [],
+    });
+
+    const response = await GET({
+      nextUrl: new URL(
+        "https://app.local/api/open-graph?url=https://mini.example/app"
+      ),
+    } as any);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        type: "farcaster.miniapp",
+        splashImageUrl: null,
+      })
+    );
+  });
+
+  it("falls back to generic metadata when Mini App JSON is malformed", async () => {
+    const html = `
+      <html>
+        <head>
+          <meta name="fc:miniapp" content="{not json" />
+          <meta property="og:title" content="Plain Page" />
+        </head>
+      </html>
+    `;
+    const genericPayload = {
+      requestUrl: "https://plain.example/app",
+      url: "https://plain.example/app",
+      title: "Plain Page",
+      description: null,
+      siteName: "Plain Example",
+      source: "plain.example",
+      image: null,
+      images: [],
+    };
+    mockFetchPublicUrl.mockResolvedValueOnce(
+      createResponse(200, {
+        headers: { "content-type": "text/html" },
+        body: html,
+        url: "https://plain.example/app",
+      })
+    );
+    utils.buildResponse.mockReturnValue(genericPayload);
+
+    const response = await GET({
+      nextUrl: new URL(
+        "https://app.local/api/open-graph?url=https://plain.example/app"
+      ),
+    } as any);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(genericPayload);
+  });
+
+  it("drops Mini App metadata when media URLs are not public", async () => {
+    const miniAppMetadata = {
+      version: "1",
+      imageUrl: "http://127.0.0.1/preview.png",
+      button: {
+        title: "Launch",
+        action: {
+          type: "launch_miniapp",
+          name: "Private Media Mini",
+          url: "https://private-media.example/launch",
+        },
+      },
+    };
+    const html = `
+      <html>
+        <head>
+          <meta name='fc:miniapp' content='${JSON.stringify(
+            miniAppMetadata
+          )}' />
+          <meta property="og:title" content="Private Media Mini" />
+        </head>
+      </html>
+    `;
+    const genericPayload = {
+      requestUrl: "https://private-media.example/app",
+      url: "https://private-media.example/app",
+      title: "Private Media Mini",
+      description: null,
+      siteName: "Private Media Example",
+      source: "private-media.example",
+      image: null,
+      images: [],
+    };
+    guard.assertPublicUrl.mockImplementation(async (url: URL) => {
+      if (url.hostname === "127.0.0.1") {
+        throw new UrlGuardError("private URL", "private-url", 400);
+      }
+    });
+    mockFetchPublicUrl.mockResolvedValueOnce(
+      createResponse(200, {
+        headers: { "content-type": "text/html" },
+        body: html,
+        url: "https://private-media.example/app",
+      })
+    );
+    utils.buildResponse.mockReturnValue(genericPayload);
+
+    const response = await GET({
+      nextUrl: new URL(
+        "https://app.local/api/open-graph?url=https://private-media.example/app"
+      ),
+    } as any);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(genericPayload);
+  });
+
   it("returns typed YouTube video previews before generic metadata", async () => {
     const oembedPayload = {
       title: "A Good Video",

--- a/__tests__/components/waves/OpenGraphPreview.test.tsx
+++ b/__tests__/components/waves/OpenGraphPreview.test.tsx
@@ -343,6 +343,33 @@ describe("OpenGraphPreview", () => {
     );
   });
 
+  it("falls Farcaster action links back to the pasted URL for http targets", () => {
+    (removeBaseEndpoint as jest.Mock).mockReturnValue(
+      "https://mini.example/app"
+    );
+
+    render(
+      <OpenGraphPreview
+        href="https://mini.example/app"
+        preview={{
+          type: "farcaster.miniapp",
+          embedKind: "miniapp",
+          title: "Example Mini",
+          appName: "Example Mini",
+          siteName: "Example Mini",
+          buttonTitle: "Launch",
+          actionUrl: "http://mini.example/launch",
+          imageUrl: "https://mini.example/preview.png",
+        }}
+      />
+    );
+
+    expect(screen.getByRole("link", { name: "Launch" })).toHaveAttribute(
+      "href",
+      "https://mini.example/app"
+    );
+  });
+
   it("renders sparse article metadata with a source label and no empty fields", () => {
     (removeBaseEndpoint as jest.Mock).mockReturnValue("/research/notes");
 

--- a/__tests__/components/waves/OpenGraphPreview.test.tsx
+++ b/__tests__/components/waves/OpenGraphPreview.test.tsx
@@ -265,6 +265,84 @@ describe("OpenGraphPreview", () => {
     expect(screen.queryByText("by [object Object]")).toBeNull();
   });
 
+  it("renders Farcaster Mini App previews with launch metadata", () => {
+    (removeBaseEndpoint as jest.Mock).mockReturnValue(
+      "https://mini.example/app"
+    );
+
+    render(
+      <OpenGraphPreview
+        href="https://mini.example/app"
+        preview={{
+          type: "farcaster.miniapp",
+          embedKind: "miniapp",
+          title: "Example Mini",
+          appName: "Example Mini",
+          description: "Launch the example app",
+          siteName: "Example Mini",
+          buttonTitle: "Launch",
+          actionUrl: "https://mini.example/launch",
+          imageUrl: "https://mini.example/preview.png",
+          splashImageUrl: "https://mini.example/splash.png",
+          splashBackgroundColor: "#855dcd",
+        }}
+      />
+    );
+
+    expect(
+      screen.getByTestId("farcaster-embed-preview-card")
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Mini App").length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("link", { name: "Example Mini" })
+    ).toHaveAttribute("href", "https://mini.example/app");
+    expect(screen.getByText("Launch the example app")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Launch" })).toHaveAttribute(
+      "href",
+      "https://mini.example/launch"
+    );
+    expect(
+      screen.getByRole("img", {
+        name: "Farcaster embed preview for Example Mini",
+      })
+    ).toHaveAttribute("src", "https://mini.example/preview.png");
+    expect(screen.getByAltText("")).toHaveAttribute(
+      "src",
+      "https://mini.example/splash.png"
+    );
+  });
+
+  it("renders legacy Farcaster frame titles before the site label", () => {
+    (removeBaseEndpoint as jest.Mock).mockReturnValue(
+      "https://legacy.example/frame"
+    );
+
+    render(
+      <OpenGraphPreview
+        href="https://legacy.example/frame"
+        preview={{
+          type: "farcaster.frame",
+          embedKind: "legacy-frame",
+          title: "Legacy Frame",
+          appName: "Legacy Example",
+          siteName: "Legacy Example",
+          buttonTitle: "View",
+          actionUrl: "https://legacy.example/view",
+          imageUrl: "https://legacy.example/frame.png",
+        }}
+      />
+    );
+
+    expect(
+      screen.getByRole("link", { name: "Legacy Frame" })
+    ).toHaveAttribute("href", "https://legacy.example/frame");
+    expect(screen.getByText("Legacy Example")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View" })).toHaveAttribute(
+      "href",
+      "https://legacy.example/view"
+    );
+  });
+
   it("renders sparse article metadata with a source label and no empty fields", () => {
     (removeBaseEndpoint as jest.Mock).mockReturnValue("/research/notes");
 

--- a/app/api/open-graph/farcaster/service.ts
+++ b/app/api/open-graph/farcaster/service.ts
@@ -1,0 +1,416 @@
+import { load } from "cheerio";
+
+import type {
+  FarcasterEmbedKind,
+  FarcasterEmbedLinkPreview,
+  LinkPreviewMedia,
+  LinkPreviewResponse,
+} from "@/services/api/link-preview-api";
+
+type LoadedHtml = ReturnType<typeof load>;
+
+interface BuildFarcasterEmbedOptions {
+  readonly assertPublicUrl: (url: URL) => Promise<void>;
+}
+
+const META_JSON_MAX_CHARS = 16 * 1024;
+const TEXT_MAX_CHARS = 180;
+const ACTION_URL_MAX_CHARS = 2048;
+const MAX_LEGACY_FRAME_BUTTONS = 4;
+const COLOR_PATTERN = /^#[0-9a-f]{6}$/i;
+
+const MINIAPP_META_KEYS = ["fc:miniapp"] as const;
+const FRAME_META_KEYS = ["fc:frame"] as const;
+const FRAME_IMAGE_KEYS = [
+  "fc:frame:image",
+  "og:image",
+  "twitter:image",
+] as const;
+const TITLE_KEYS = ["og:title", "twitter:title"] as const;
+const DESCRIPTION_KEYS = ["og:description", "twitter:description"] as const;
+const SITE_NAME_KEYS = ["og:site_name", "application-name"] as const;
+
+type MiniAppMetadata = {
+  readonly version?: unknown;
+  readonly imageUrl?: unknown;
+  readonly button?: {
+    readonly title?: unknown;
+    readonly action?: {
+      readonly type?: unknown;
+      readonly name?: unknown;
+      readonly url?: unknown;
+      readonly splashImageUrl?: unknown;
+      readonly splashBackgroundColor?: unknown;
+    };
+  };
+};
+
+interface LegacyFrameButton {
+  readonly label: string;
+  readonly action: string | null;
+  readonly target: string | null;
+}
+
+function normalizeWhitespace(value: string | undefined): string | undefined {
+  const trimmed = value?.replace(/\s+/g, " ").trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readString(value: unknown, maxChars = TEXT_MAX_CHARS): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = normalizeWhitespace(value);
+  if (!normalized) {
+    return null;
+  }
+
+  return normalized.slice(0, maxChars);
+}
+
+function getMetaIdentifier($: LoadedHtml, element: unknown): string | undefined {
+  const tag = $(element);
+  return normalizeWhitespace(
+    tag.attr("property") ?? tag.attr("name") ?? tag.attr("itemprop")
+  )?.toLowerCase();
+}
+
+function getFirstMetaContent(
+  $: LoadedHtml,
+  keys: readonly string[]
+): string | undefined {
+  const keySet = new Set(keys.map((key) => key.toLowerCase()));
+  let result: string | undefined;
+
+  $("meta").each((_index: number, element: unknown) => {
+    if (result) {
+      return;
+    }
+
+    const identifier = getMetaIdentifier($, element);
+    if (!identifier || !keySet.has(identifier)) {
+      return;
+    }
+
+    result = normalizeWhitespace($(element).attr("content"));
+  });
+
+  return result;
+}
+
+function getTitleTag($: LoadedHtml): string | null {
+  return readString($("title").first().text());
+}
+
+function parseMiniAppMetadata(value: string | undefined): MiniAppMetadata | null {
+  if (!value || value.length > META_JSON_MAX_CHARS) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (typeof parsed !== "object" || parsed === null) {
+      return null;
+    }
+
+    return parsed as MiniAppMetadata;
+  } catch {
+    return null;
+  }
+}
+
+function getFallbackTitle(
+  $: LoadedHtml,
+  basePreview: LinkPreviewResponse
+): string | null {
+  return (
+    readString(basePreview.title) ??
+    readString(getFirstMetaContent($, TITLE_KEYS)) ??
+    getTitleTag($)
+  );
+}
+
+function getFallbackDescription(
+  $: LoadedHtml,
+  basePreview: LinkPreviewResponse
+): string | null {
+  return (
+    readString(basePreview.description, 260) ??
+    readString(getFirstMetaContent($, DESCRIPTION_KEYS), 260)
+  );
+}
+
+function getFallbackSiteName(
+  $: LoadedHtml,
+  basePreview: LinkPreviewResponse,
+  url: URL
+): string {
+  return (
+    readString(basePreview.siteName) ??
+    readString(basePreview.source) ??
+    readString(getFirstMetaContent($, SITE_NAME_KEYS)) ??
+    url.hostname.replace(/^www\./i, "")
+  );
+}
+
+async function resolvePublicUrl(
+  baseUrl: string,
+  value: string | null,
+  assertPublicUrl: (url: URL) => Promise<void>
+): Promise<string | null> {
+  if (!value || value.length > ACTION_URL_MAX_CHARS) {
+    return null;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value, baseUrl);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return null;
+  }
+
+  try {
+    await assertPublicUrl(parsed);
+  } catch {
+    return null;
+  }
+
+  return parsed.toString();
+}
+
+function normalizeSplashColor(value: unknown): string | null {
+  const color = readString(value, 7);
+  return color && COLOR_PATTERN.test(color) ? color : null;
+}
+
+function createImageEntry(imageUrl: string | null): LinkPreviewMedia | null {
+  return imageUrl
+    ? {
+        url: imageUrl,
+        secureUrl: imageUrl,
+      }
+    : null;
+}
+
+function buildPreview({
+  actionType,
+  actionUrl,
+  appName,
+  basePreview,
+  buttonTitle,
+  buttons,
+  description,
+  embedKind,
+  imageUrl,
+  siteName,
+  splashBackgroundColor,
+  splashImageUrl,
+  title,
+  url,
+}: {
+  readonly actionType?: string | null | undefined;
+  readonly actionUrl?: string | null | undefined;
+  readonly appName?: string | null | undefined;
+  readonly basePreview: LinkPreviewResponse;
+  readonly buttonTitle?: string | null | undefined;
+  readonly buttons?: readonly string[] | null | undefined;
+  readonly description?: string | null | undefined;
+  readonly embedKind: FarcasterEmbedKind;
+  readonly imageUrl?: string | null | undefined;
+  readonly siteName: string;
+  readonly splashBackgroundColor?: string | null | undefined;
+  readonly splashImageUrl?: string | null | undefined;
+  readonly title?: string | null | undefined;
+  readonly url: URL;
+}): FarcasterEmbedLinkPreview {
+  const image = createImageEntry(imageUrl ?? null);
+  const resolvedTitle = title ?? appName ?? buttonTitle ?? siteName;
+  const responseType =
+    embedKind === "legacy-frame" ? "farcaster.frame" : "farcaster.miniapp";
+
+  return {
+    ...basePreview,
+    type: responseType,
+    requestUrl: basePreview.requestUrl ?? url.toString(),
+    url: actionUrl ?? basePreview.url ?? url.toString(),
+    title: resolvedTitle,
+    description: description ?? basePreview.description ?? null,
+    siteName,
+    mediaType: "application",
+    source: siteName,
+    image,
+    images: image ? [image] : [],
+    embedKind,
+    appName: appName ?? null,
+    buttonTitle: buttonTitle ?? null,
+    actionType: actionType ?? null,
+    actionUrl: actionUrl ?? null,
+    imageUrl: imageUrl ?? null,
+    splashImageUrl: splashImageUrl ?? null,
+    splashBackgroundColor: splashBackgroundColor ?? null,
+    buttons: buttons ?? null,
+  };
+}
+
+async function buildJsonPreview(
+  $: LoadedHtml,
+  url: URL,
+  basePreview: LinkPreviewResponse,
+  metadata: MiniAppMetadata,
+  embedKind: FarcasterEmbedKind,
+  options: BuildFarcasterEmbedOptions
+): Promise<FarcasterEmbedLinkPreview | null> {
+  const imageUrl = await resolvePublicUrl(
+    url.toString(),
+    readString(metadata.imageUrl, ACTION_URL_MAX_CHARS),
+    options.assertPublicUrl
+  );
+  if (!imageUrl) {
+    return null;
+  }
+
+  const button = metadata.button;
+  const action = button?.action;
+  const buttonTitle = readString(button?.title, 64);
+  const actionType = readString(action?.type, 64);
+  const appName = readString(action?.name, 96);
+  const actionUrl =
+    (await resolvePublicUrl(
+      url.toString(),
+      readString(action?.url, ACTION_URL_MAX_CHARS),
+      options.assertPublicUrl
+    )) ?? url.toString();
+  const splashImageUrl = await resolvePublicUrl(
+    url.toString(),
+    readString(action?.splashImageUrl, ACTION_URL_MAX_CHARS),
+    options.assertPublicUrl
+  );
+  const siteName = appName ?? getFallbackSiteName($, basePreview, url);
+
+  return buildPreview({
+    actionType,
+    actionUrl,
+    appName,
+    basePreview,
+    buttonTitle,
+    buttons: buttonTitle ? [buttonTitle] : null,
+    description: getFallbackDescription($, basePreview),
+    embedKind,
+    imageUrl,
+    siteName,
+    splashBackgroundColor: normalizeSplashColor(action?.splashBackgroundColor),
+    splashImageUrl,
+    title: appName ?? getFallbackTitle($, basePreview),
+    url,
+  });
+}
+
+async function buildLegacyFramePreview(
+  $: LoadedHtml,
+  url: URL,
+  basePreview: LinkPreviewResponse,
+  options: BuildFarcasterEmbedOptions
+): Promise<FarcasterEmbedLinkPreview | null> {
+  if (!getFirstMetaContent($, FRAME_META_KEYS)) {
+    return null;
+  }
+
+  const imageUrl = await resolvePublicUrl(
+    url.toString(),
+    readString(getFirstMetaContent($, FRAME_IMAGE_KEYS), ACTION_URL_MAX_CHARS),
+    options.assertPublicUrl
+  );
+  const title = getFallbackTitle($, basePreview);
+  if (!imageUrl && !title) {
+    return null;
+  }
+
+  const buttons: LegacyFrameButton[] = [];
+  for (let index = 1; index <= MAX_LEGACY_FRAME_BUTTONS; index += 1) {
+    const label = readString(
+      getFirstMetaContent($, [`fc:frame:button:${index}`]),
+      64
+    );
+    if (label) {
+      const action = readString(
+        getFirstMetaContent($, [`fc:frame:button:${index}:action`]),
+        64
+      );
+      const target = await resolvePublicUrl(
+        url.toString(),
+        readString(getFirstMetaContent($, [`fc:frame:button:${index}:target`])),
+        options.assertPublicUrl
+      );
+      buttons.push({ action, label, target });
+    }
+  }
+
+  const firstLinkButton = buttons.find(
+    (button) => button.action === "link" && button.target
+  );
+  const buttonLabels = buttons.map((button) => button.label);
+  const siteName = getFallbackSiteName($, basePreview, url);
+
+  return buildPreview({
+    actionUrl: firstLinkButton?.target ?? url.toString(),
+    appName: siteName,
+    basePreview,
+    buttonTitle: firstLinkButton?.label ?? buttonLabels[0] ?? null,
+    buttons: buttonLabels,
+    description: getFallbackDescription($, basePreview),
+    embedKind: "legacy-frame",
+    imageUrl,
+    siteName,
+    title,
+    url,
+  });
+}
+
+export async function buildFarcasterEmbedResponse(
+  url: URL,
+  html: string,
+  basePreview: LinkPreviewResponse,
+  options: BuildFarcasterEmbedOptions
+): Promise<FarcasterEmbedLinkPreview | null> {
+  const $ = load(html);
+  const miniAppMetadata = parseMiniAppMetadata(
+    getFirstMetaContent($, MINIAPP_META_KEYS)
+  );
+  if (miniAppMetadata) {
+    const preview = await buildJsonPreview(
+      $,
+      url,
+      basePreview,
+      miniAppMetadata,
+      "miniapp",
+      options
+    );
+    if (preview) {
+      return preview;
+    }
+  }
+
+  const frameMetadata = parseMiniAppMetadata(
+    getFirstMetaContent($, FRAME_META_KEYS)
+  );
+  if (frameMetadata) {
+    const preview = await buildJsonPreview(
+      $,
+      url,
+      basePreview,
+      frameMetadata,
+      "frame",
+      options
+    );
+    if (preview) {
+      return preview;
+    }
+  }
+
+  return buildLegacyFramePreview($, url, basePreview, options);
+}

--- a/app/api/open-graph/farcaster/service.ts
+++ b/app/api/open-graph/farcaster/service.ts
@@ -18,6 +18,11 @@ const TEXT_MAX_CHARS = 180;
 const ACTION_URL_MAX_CHARS = 2048;
 const MAX_LEGACY_FRAME_BUTTONS = 4;
 const COLOR_PATTERN = /^#[0-9a-f]{6}$/i;
+const MINIAPP_ACTION_TYPES = new Set([
+  "launch_frame",
+  "launch_miniapp",
+  "view_token",
+]);
 
 const MINIAPP_META_KEYS = ["fc:miniapp"] as const;
 const FRAME_META_KEYS = ["fc:frame"] as const;
@@ -188,6 +193,11 @@ function normalizeSplashColor(value: unknown): string | null {
   return color && COLOR_PATTERN.test(color) ? color : null;
 }
 
+function readMiniAppActionType(value: unknown): string | null {
+  const actionType = readString(value, 64);
+  return actionType && MINIAPP_ACTION_TYPES.has(actionType) ? actionType : null;
+}
+
 function createImageEntry(imageUrl: string | null): LinkPreviewMedia | null {
   return imageUrl
     ? {
@@ -237,7 +247,7 @@ function buildPreview({
     ...basePreview,
     type: responseType,
     requestUrl: basePreview.requestUrl ?? url.toString(),
-    url: actionUrl ?? basePreview.url ?? url.toString(),
+    url: basePreview.url ?? url.toString(),
     title: resolvedTitle,
     description: description ?? basePreview.description ?? null,
     siteName,
@@ -277,7 +287,7 @@ async function buildJsonPreview(
   const button = metadata.button;
   const action = button?.action;
   const buttonTitle = readString(button?.title, 64);
-  const actionType = readString(action?.type, 64);
+  const actionType = readMiniAppActionType(action?.type);
   const appName = readString(action?.name, 96);
   const actionUrl =
     (await resolvePublicUrl(
@@ -358,7 +368,7 @@ async function buildLegacyFramePreview(
 
   return buildPreview({
     actionUrl: firstLinkButton?.target ?? url.toString(),
-    appName: siteName,
+    appName: null,
     basePreview,
     buttonTitle: firstLinkButton?.label ?? buttonLabels[0] ?? null,
     buttons: buttonLabels,

--- a/app/api/open-graph/route.ts
+++ b/app/api/open-graph/route.ts
@@ -34,6 +34,7 @@ import { createOpenSeaPlan } from "./opensea/service";
 import { createFirstParty6529Plan } from "./6529/service";
 import { createTransientPlan } from "./transient/service";
 import { createYoutubePlan } from "./youtube/service";
+import { buildFarcasterEmbedResponse } from "./farcaster/service";
 import { detectEnsTarget, fetchEnsPreview, EnsPreviewError } from "./ens";
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
@@ -414,9 +415,26 @@ function createGenericPlan(url: URL): PreviewPlan {
         html,
         url
       );
-      const data =
-        googleWorkspace ??
-        buildResponse(finalUrlInstance, html, contentType, finalUrl);
+      if (googleWorkspace) {
+        return { data: googleWorkspace, ttl: CACHE_TTL_MS };
+      }
+
+      const genericData = buildResponse(
+        finalUrlInstance,
+        html,
+        contentType,
+        finalUrl
+      );
+      const farcasterEmbed = await buildFarcasterEmbedResponse(
+        finalUrlInstance,
+        html,
+        genericData,
+        {
+          assertPublicUrl: (candidate) =>
+            assertPublicUrl(candidate, PUBLIC_URL_OPTIONS),
+        }
+      );
+      const data = farcasterEmbed ?? genericData;
       return { data, ttl: CACHE_TTL_MS };
     },
   };

--- a/components/waves/LinkPreviewCard.tsx
+++ b/components/waves/LinkPreviewCard.tsx
@@ -42,6 +42,8 @@ const CHAT_COLLECTION_FRAME_CLASSES =
   "tw-min-h-[11rem] tw-w-full md:tw-min-h-[12rem]";
 const CHAT_VIDEO_FRAME_CLASSES =
   "tw-min-h-[18rem] tw-w-full sm:tw-min-h-[14rem] md:tw-min-h-[15rem]";
+const CHAT_FARCASTER_FRAME_CLASSES =
+  "tw-min-h-[24rem] tw-w-full sm:tw-min-h-[13rem] md:tw-min-h-[14rem]";
 
 const isSeizeCollectionPreview = (
   preview: OpenGraphPreviewData | null | undefined
@@ -50,6 +52,12 @@ const isSeizeCollectionPreview = (
 const isYoutubeVideoPreview = (
   preview: OpenGraphPreviewData | null | undefined
 ): boolean => preview?.["type"] === "youtube.video";
+
+const isFarcasterEmbedPreview = (
+  preview: OpenGraphPreviewData | null | undefined
+): boolean =>
+  preview?.["type"] === "farcaster.miniapp" ||
+  preview?.["type"] === "farcaster.frame";
 
 const toPreviewData = (
   response: Awaited<ReturnType<typeof fetchLinkPreview>>
@@ -194,6 +202,8 @@ export default function LinkPreviewCard({
       stableFrameClasses = CHAT_COLLECTION_FRAME_CLASSES;
     } else if (isYoutubeVideoPreview(state.data)) {
       stableFrameClasses = CHAT_VIDEO_FRAME_CLASSES;
+    } else if (isFarcasterEmbedPreview(state.data)) {
+      stableFrameClasses = CHAT_FARCASTER_FRAME_CLASSES;
     }
   }
 

--- a/components/waves/OpenGraphPreview.tsx
+++ b/components/waves/OpenGraphPreview.tsx
@@ -841,16 +841,14 @@ function isTrustedYoutubeEmbedHost(hostname: string): boolean {
   );
 }
 
-function getHttpHref(value: string | null | undefined): string | undefined {
+function getHttpsHref(value: string | null | undefined): string | undefined {
   if (!value) {
     return undefined;
   }
 
   try {
     const parsed = new URL(value);
-    return parsed.protocol === "https:" || parsed.protocol === "http:"
-      ? parsed.toString()
-      : undefined;
+    return parsed.protocol === "https:" ? parsed.toString() : undefined;
   } catch {
     return undefined;
   }
@@ -1218,7 +1216,7 @@ function FarcasterEmbedPreviewCard({
     (isMiniApp
       ? t(locale, "linkPreview.farcaster.openMiniApp")
       : t(locale, "linkPreview.farcaster.openFrame"));
-  const actionHref = getHttpHref(preview.actionUrl) ?? effectiveHref;
+  const actionHref = getHttpsHref(preview.actionUrl) ?? effectiveHref;
   const sourceLabel =
     preview.siteName?.trim() ||
     preview.source?.trim() ||

--- a/components/waves/OpenGraphPreview.tsx
+++ b/components/waves/OpenGraphPreview.tsx
@@ -18,6 +18,7 @@ import type {
   GithubStatusPreviewResponse,
 } from "@/services/api/github-preview-api";
 import type {
+  FarcasterEmbedLinkPreview,
   SeizeCollectionLinkPreview,
   YoutubeVideoLinkPreview,
 } from "@/services/api/link-preview-api";
@@ -104,6 +105,7 @@ const TRUSTED_YOUTUBE_EMBED_HOSTS = [
   "youtube-nocookie.com",
   "youtube.com",
 ] as const;
+const FARCASTER_EMBED_TYPES = new Set(["miniapp", "frame", "legacy-frame"]);
 const PUBLISHED_DATE_FORMAT_OPTIONS = {
   day: "numeric",
   month: "short",
@@ -791,6 +793,32 @@ function extractYoutubeVideoPreview(
   return isYoutubeVideoPreview(preview) ? preview : null;
 }
 
+function isFarcasterEmbedPreview(
+  value: unknown
+): value is FarcasterEmbedLinkPreview {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const record = value as {
+    readonly type?: unknown;
+    readonly embedKind?: unknown;
+  };
+
+  return (
+    (record.type === "farcaster.miniapp" ||
+      record.type === "farcaster.frame") &&
+    typeof record.embedKind === "string" &&
+    FARCASTER_EMBED_TYPES.has(record.embedKind)
+  );
+}
+
+function extractFarcasterEmbedPreview(
+  preview: OpenGraphPreviewData | null | undefined
+): FarcasterEmbedLinkPreview | null {
+  return isFarcasterEmbedPreview(preview) ? preview : null;
+}
+
 function getTrustedYoutubeEmbedUrl(value: string): string | undefined {
   let parsed: URL;
   try {
@@ -808,7 +836,24 @@ function getTrustedYoutubeEmbedUrl(value: string): string | undefined {
 }
 
 function isTrustedYoutubeEmbedHost(hostname: string): boolean {
-  return TRUSTED_YOUTUBE_EMBED_HOSTS.some((trustedHost) => hostname === trustedHost);
+  return TRUSTED_YOUTUBE_EMBED_HOSTS.some(
+    (trustedHost) => hostname === trustedHost
+  );
+}
+
+function getHttpHref(value: string | null | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "https:" || parsed.protocol === "http:"
+      ? parsed.toString()
+      : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function getRelativeHref(href: string): string | undefined {
@@ -873,6 +918,10 @@ export function hasOpenGraphContent(
   }
 
   if (isYoutubeVideoPreview(preview)) {
+    return true;
+  }
+
+  if (isFarcasterEmbedPreview(preview)) {
     return true;
   }
 
@@ -1128,6 +1177,176 @@ function SeizeCollectionPreviewCard({
   );
 }
 
+function FarcasterEmbedPreviewCard({
+  href,
+  preview,
+  effectiveHref,
+  linkTarget,
+  linkRel,
+  variant,
+  hideActions,
+  locale,
+}: {
+  readonly href: string;
+  readonly preview: FarcasterEmbedLinkPreview;
+  readonly effectiveHref: string;
+  readonly linkTarget?: "_blank" | undefined;
+  readonly linkRel?: string | undefined;
+  readonly variant?: LinkPreviewVariant | undefined;
+  readonly hideActions?: boolean | undefined;
+  readonly locale: SupportedLocale;
+}) {
+  const resolvedVariant = variant ?? "chat";
+  const isHome = resolvedVariant === "home";
+  const isMiniApp = preview.embedKind === "miniapp";
+  const title =
+    (preview.embedKind === "legacy-frame"
+      ? preview.title?.trim() || preview.appName?.trim()
+      : preview.appName?.trim() || preview.title?.trim()) ||
+    t(locale, "linkPreview.farcaster.titleFallback");
+  const imageUrl = preview.imageUrl ?? extractImageUrl(preview);
+  const imageAlt =
+    extractImageAlt(preview) ??
+    (title
+      ? t(locale, "linkPreview.farcaster.imageAlt", { title })
+      : t(locale, "linkPreview.farcaster.imageFallbackAlt"));
+  const badgeLabel = isMiniApp
+    ? t(locale, "linkPreview.farcaster.miniAppBadge")
+    : t(locale, "linkPreview.farcaster.frameBadge");
+  const ctaLabel =
+    preview.buttonTitle?.trim() ||
+    (isMiniApp
+      ? t(locale, "linkPreview.farcaster.openMiniApp")
+      : t(locale, "linkPreview.farcaster.openFrame"));
+  const actionHref = getHttpHref(preview.actionUrl) ?? effectiveHref;
+  const sourceLabel =
+    preview.siteName?.trim() ||
+    preview.source?.trim() ||
+    deriveDomain(href, preview);
+  // The API normalizes this to #rrggbb before it reaches the client.
+  const splashColor = preview.splashBackgroundColor ?? "#855dcd";
+  const mediaSizes = isHome
+    ? "(max-width: 768px) 100vw, 480px"
+    : "(max-width: 640px) 100vw, (max-width: 1024px) 13rem, 15rem";
+
+  return (
+    <LinkPreviewCardLayout
+      href={href}
+      variant={resolvedVariant}
+      hideActions={hideActions}
+    >
+      <div
+        className={[
+          "tw-relative tw-flex tw-h-full tw-min-h-0 tw-w-full tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-bg-iron-950/80 tw-shadow-sm tw-shadow-black/20",
+          isHome ? "tw-border-white/10" : "tw-border-iron-700",
+          !isHome && !hideActions ? "tw-pr-12 sm:tw-pr-14" : "",
+        ].join(" ")}
+        data-testid="farcaster-embed-preview-card"
+      >
+        <span className="tw-pointer-events-none tw-absolute tw-inset-y-0 tw-left-0 tw-w-1 tw-bg-[#855dcd]" />
+        <div
+          className={[
+            "tw-grid tw-h-full tw-w-full tw-min-w-0 tw-items-center tw-gap-3 tw-p-3 sm:tw-gap-4",
+            isHome
+              ? "tw-grid-cols-1"
+              : "tw-grid-cols-1 sm:tw-grid-cols-[minmax(9.5rem,13rem),minmax(0,1fr)]",
+          ].join(" ")}
+        >
+          <Link
+            href={actionHref}
+            target={linkTarget}
+            rel={linkRel}
+            onClick={(event) => event.stopPropagation()}
+            className="tw-relative tw-block tw-aspect-[3/2] tw-w-full tw-min-w-0 tw-overflow-hidden tw-rounded-lg tw-border tw-border-solid tw-border-black tw-bg-black tw-no-underline"
+          >
+            {imageUrl ? (
+              <Image
+                src={imageUrl}
+                alt={imageAlt}
+                fill
+                className="tw-object-cover tw-transition tw-duration-300 hover:tw-scale-[1.02]"
+                loading="lazy"
+                sizes={mediaSizes}
+                unoptimized
+              />
+            ) : (
+              <span
+                aria-hidden="true"
+                className="tw-absolute tw-inset-0 tw-bg-gradient-to-br tw-from-[#855dcd]/40 tw-via-black tw-to-iron-950"
+              />
+            )}
+            <span className="tw-absolute tw-inset-x-0 tw-bottom-0 tw-h-16 tw-bg-gradient-to-t tw-from-black/70 tw-to-transparent" />
+            <span
+              aria-hidden="true"
+              className="tw-absolute tw-bottom-2 tw-left-2 tw-inline-flex tw-items-center tw-gap-1.5 tw-rounded-md tw-bg-black/70 tw-px-2 tw-py-1 tw-text-[10px] tw-font-semibold tw-uppercase tw-leading-4 tw-text-white"
+            >
+              <span
+                aria-hidden="true"
+                className="tw-h-1.5 tw-w-1.5 tw-rounded-full tw-bg-[#855dcd]"
+              />
+              {badgeLabel}
+            </span>
+          </Link>
+
+          <div className="tw-flex tw-min-h-0 tw-min-w-0 tw-flex-col tw-justify-center tw-gap-2 tw-overflow-hidden">
+            <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
+              {preview.splashImageUrl && (
+                <span
+                  className="tw-relative tw-h-7 tw-w-7 tw-flex-shrink-0 tw-overflow-hidden tw-rounded-md tw-border tw-border-solid tw-border-white/10"
+                  style={{ backgroundColor: splashColor }}
+                  aria-hidden="true"
+                >
+                  <Image
+                    src={preview.splashImageUrl}
+                    alt=""
+                    fill
+                    className="tw-object-cover"
+                    loading="lazy"
+                    sizes="1.75rem"
+                    unoptimized
+                  />
+                </span>
+              )}
+              <span className="tw-flex-shrink-0 tw-rounded-md tw-border tw-border-[#855dcd]/30 tw-bg-[#855dcd]/15 tw-px-1.5 tw-py-0.5 tw-text-[10px] tw-font-semibold tw-uppercase tw-leading-4 tw-text-purple-100">
+                {badgeLabel}
+              </span>
+              {sourceLabel && (
+                <span className="tw-min-w-0 tw-truncate tw-text-xs tw-font-medium tw-leading-5 tw-text-iron-400">
+                  {sourceLabel}
+                </span>
+              )}
+            </div>
+            <Link
+              href={effectiveHref}
+              target={linkTarget}
+              rel={linkRel}
+              onClick={(event) => event.stopPropagation()}
+              className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-block tw-break-words tw-text-base tw-font-semibold tw-leading-snug tw-text-iron-50 tw-no-underline tw-transition tw-duration-200 hover:tw-text-white md:tw-text-lg"
+            >
+              {wrapLongUnbrokenSegments(title)}
+            </Link>
+            {preview.description && (
+              <p className="tw-[overflow-wrap:anywhere] tw-m-0 tw-line-clamp-2 tw-whitespace-pre-line tw-break-words tw-text-sm tw-leading-5 tw-text-iron-300">
+                {wrapLongUnbrokenSegments(preview.description)}
+              </p>
+            )}
+            <Link
+              href={actionHref}
+              target={linkTarget}
+              rel={linkRel}
+              onClick={(event) => event.stopPropagation()}
+              className="tw-inline-flex tw-w-fit tw-max-w-full tw-items-center tw-gap-1.5 tw-rounded-md tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-900/75 tw-px-2 tw-py-0.5 tw-text-xs tw-font-medium tw-leading-5 tw-text-iron-200 tw-no-underline tw-transition tw-duration-200 hover:tw-border-[#855dcd]/50 hover:tw-text-white"
+            >
+              <span className="tw-h-1.5 tw-w-1.5 tw-flex-shrink-0 tw-rounded-full tw-bg-[#855dcd]" />
+              <span className="tw-truncate">{ctaLabel}</span>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </LinkPreviewCardLayout>
+  );
+}
+
 function YoutubeVideoPreviewCard({
   href,
   preview,
@@ -1309,6 +1528,132 @@ function YoutubeVideoPreviewCard({
   );
 }
 
+function OpenGraphPreviewSkeleton({
+  href,
+  variant,
+  hideActions,
+}: {
+  readonly href: string;
+  readonly variant: LinkPreviewVariant;
+  readonly hideActions: boolean;
+}) {
+  if (variant === "home") {
+    return (
+      <LinkPreviewCardLayout
+        href={href}
+        variant={variant}
+        hideActions={hideActions}
+      >
+        <div
+          className="tw-relative tw-h-full tw-w-full tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-black/30"
+          data-testid="og-preview-skeleton"
+        >
+          <div className="tw-absolute tw-inset-0 tw-animate-pulse tw-bg-gradient-to-br tw-from-iron-900/40 tw-via-iron-800/20 tw-to-iron-900/40" />
+          <div className="tw-relative tw-z-10 tw-flex tw-h-full tw-flex-col tw-justify-end tw-gap-2 tw-p-4">
+            <div className="tw-h-3 tw-w-24 tw-rounded tw-bg-iron-800/50" />
+            <div className="tw-h-5 tw-w-3/4 tw-rounded tw-bg-iron-800/40" />
+            <div className="tw-h-4 tw-w-2/3 tw-rounded tw-bg-iron-800/30" />
+          </div>
+        </div>
+      </LinkPreviewCardLayout>
+    );
+  }
+
+  return (
+    <LinkPreviewCardLayout
+      href={href}
+      variant={variant}
+      hideActions={hideActions}
+    >
+      <div className="tw-h-full tw-min-h-0 tw-w-full tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/40 tw-p-4">
+        <div
+          className="tw-flex tw-h-full tw-min-h-0 tw-animate-pulse tw-flex-col tw-justify-end tw-gap-y-3"
+          data-testid="og-preview-skeleton"
+        >
+          <div className="tw-h-16 tw-w-full tw-flex-shrink-0 tw-rounded-lg tw-bg-iron-800/60" />
+          <div className="tw-h-4 tw-w-3/4 tw-rounded tw-bg-iron-800/40" />
+          <div className="tw-h-3 tw-w-full tw-rounded tw-bg-iron-800/30" />
+          <div className="tw-h-3 tw-w-2/3 tw-rounded tw-bg-iron-800/20" />
+        </div>
+      </div>
+    </LinkPreviewCardLayout>
+  );
+}
+
+function UnavailableOpenGraphPreview({
+  href,
+  effectiveHref,
+  linkTarget,
+  linkRel,
+  variant,
+  hideActions,
+  domain,
+}: {
+  readonly href: string;
+  readonly effectiveHref: string;
+  readonly linkTarget?: "_blank" | undefined;
+  readonly linkRel?: string | undefined;
+  readonly variant: LinkPreviewVariant;
+  readonly hideActions: boolean;
+  readonly domain?: string | null | undefined;
+}) {
+  if (variant === "home") {
+    return (
+      <LinkPreviewCardLayout
+        href={href}
+        variant={variant}
+        hideActions={hideActions}
+      >
+        <Link
+          href={effectiveHref}
+          target={linkTarget}
+          rel={linkRel}
+          onClick={(e) => e.stopPropagation()}
+          className="tw-relative tw-flex tw-h-full tw-w-full tw-items-end tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-black/30 tw-no-underline"
+          data-testid="og-preview-unavailable"
+        >
+          <div className="tw-absolute tw-inset-0 tw-bg-gradient-to-br tw-from-iron-900/30 tw-via-black/20 tw-to-iron-900/30" />
+          <div className="tw-relative tw-z-10 tw-flex tw-w-full tw-flex-col tw-gap-1 tw-p-4">
+            <span className="tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-iron-400">
+              Link unavailable
+            </span>
+            <span className="tw-[overflow-wrap:anywhere] tw-break-words tw-text-sm tw-font-semibold tw-leading-snug tw-text-iron-100 tw-transition tw-duration-200 hover:tw-text-white">
+              {wrapLongUnbrokenSegments(domain ?? href)}
+            </span>
+          </div>
+        </Link>
+      </LinkPreviewCardLayout>
+    );
+  }
+
+  return (
+    <LinkPreviewCardLayout
+      href={href}
+      variant={variant}
+      hideActions={hideActions}
+    >
+      <div
+        className="tw-flex tw-h-full tw-min-h-0 tw-w-full tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/40 tw-p-6"
+        data-testid="og-preview-unavailable"
+      >
+        <div className="tw-max-h-full tw-space-y-2 tw-overflow-y-auto tw-text-center">
+          <p className="tw-m-0 tw-text-sm tw-font-medium tw-text-iron-400">
+            Link unavailable
+          </p>
+          <Link
+            href={effectiveHref}
+            target={linkTarget}
+            rel={linkRel}
+            className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-block tw-break-words tw-text-sm tw-font-semibold tw-text-iron-100 tw-no-underline tw-transition tw-duration-200 hover:tw-text-white"
+          >
+            {wrapLongUnbrokenSegments(domain ?? href)}
+          </Link>
+        </div>
+      </div>
+    </LinkPreviewCardLayout>
+  );
+}
+
 export default function OpenGraphPreview({
   href,
   preview,
@@ -1326,46 +1671,12 @@ export default function OpenGraphPreview({
   const locale = GENERIC_LINK_PREVIEW_LOCALE;
 
   if (typeof preview === "undefined") {
-    if (resolvedVariant === "home") {
-      return (
-        <LinkPreviewCardLayout
-          href={href}
-          variant={resolvedVariant}
-          hideActions={hideActions}
-        >
-          <div
-            className="tw-relative tw-h-full tw-w-full tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-black/30"
-            data-testid="og-preview-skeleton"
-          >
-            <div className="tw-absolute tw-inset-0 tw-animate-pulse tw-bg-gradient-to-br tw-from-iron-900/40 tw-via-iron-800/20 tw-to-iron-900/40" />
-            <div className="tw-relative tw-z-10 tw-flex tw-h-full tw-flex-col tw-justify-end tw-gap-2 tw-p-4">
-              <div className="tw-h-3 tw-w-24 tw-rounded tw-bg-iron-800/50" />
-              <div className="tw-h-5 tw-w-3/4 tw-rounded tw-bg-iron-800/40" />
-              <div className="tw-h-4 tw-w-2/3 tw-rounded tw-bg-iron-800/30" />
-            </div>
-          </div>
-        </LinkPreviewCardLayout>
-      );
-    }
-
     return (
-      <LinkPreviewCardLayout
+      <OpenGraphPreviewSkeleton
         href={href}
         variant={resolvedVariant}
         hideActions={hideActions}
-      >
-        <div className="tw-h-full tw-min-h-0 tw-w-full tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/40 tw-p-4">
-          <div
-            className="tw-flex tw-h-full tw-min-h-0 tw-animate-pulse tw-flex-col tw-justify-end tw-gap-y-3"
-            data-testid="og-preview-skeleton"
-          >
-            <div className="tw-h-16 tw-w-full tw-flex-shrink-0 tw-rounded-lg tw-bg-iron-800/60" />
-            <div className="tw-h-4 tw-w-3/4 tw-rounded tw-bg-iron-800/40" />
-            <div className="tw-h-3 tw-w-full tw-rounded tw-bg-iron-800/30" />
-            <div className="tw-h-3 tw-w-2/3 tw-rounded tw-bg-iron-800/20" />
-          </div>
-        </div>
-      </LinkPreviewCardLayout>
+      />
     );
   }
 
@@ -1386,6 +1697,7 @@ export default function OpenGraphPreview({
   const githubPreview = extractGithubPreview(preview);
   const seizePreview = extractSeizeCollectionPreview(preview);
   const youtubePreview = extractYoutubeVideoPreview(preview);
+  const farcasterEmbedPreview = extractFarcasterEmbedPreview(preview);
   const hasContent = Boolean(title ?? description ?? imageUrl);
   const firstPartyKind = getFirstPartyOgKindFromImageUrl(imageUrl);
 
@@ -1421,60 +1733,16 @@ export default function OpenGraphPreview({
   }
 
   if (!hasContent) {
-    if (resolvedVariant === "home") {
-      return (
-        <LinkPreviewCardLayout
-          href={href}
-          variant={resolvedVariant}
-          hideActions={hideActions}
-        >
-          <Link
-            href={effectiveHref}
-            target={linkTarget}
-            rel={linkRel}
-            onClick={(e) => e.stopPropagation()}
-            className="tw-relative tw-flex tw-h-full tw-w-full tw-items-end tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/10 tw-bg-black/30 tw-no-underline"
-            data-testid="og-preview-unavailable"
-          >
-            <div className="tw-absolute tw-inset-0 tw-bg-gradient-to-br tw-from-iron-900/30 tw-via-black/20 tw-to-iron-900/30" />
-            <div className="tw-relative tw-z-10 tw-flex tw-w-full tw-flex-col tw-gap-1 tw-p-4">
-              <span className="tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-iron-400">
-                Link unavailable
-              </span>
-              <span className="tw-[overflow-wrap:anywhere] tw-break-words tw-text-sm tw-font-semibold tw-leading-snug tw-text-iron-100 tw-transition tw-duration-200 hover:tw-text-white">
-                {wrapLongUnbrokenSegments(domain ?? href)}
-              </span>
-            </div>
-          </Link>
-        </LinkPreviewCardLayout>
-      );
-    }
-
     return (
-      <LinkPreviewCardLayout
+      <UnavailableOpenGraphPreview
         href={href}
+        effectiveHref={effectiveHref}
+        linkTarget={linkTarget}
+        linkRel={linkRel}
         variant={resolvedVariant}
         hideActions={hideActions}
-      >
-        <div
-          className="tw-flex tw-h-full tw-min-h-0 tw-w-full tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900/40 tw-p-6"
-          data-testid="og-preview-unavailable"
-        >
-          <div className="tw-max-h-full tw-space-y-2 tw-overflow-y-auto tw-text-center">
-            <p className="tw-m-0 tw-text-sm tw-font-medium tw-text-iron-400">
-              Link unavailable
-            </p>
-            <Link
-              href={effectiveHref}
-              target={linkTarget}
-              rel={linkRel}
-              className="tw-[overflow-wrap:anywhere] tw-line-clamp-2 tw-block tw-break-words tw-text-sm tw-font-semibold tw-text-iron-100 tw-no-underline tw-transition tw-duration-200 hover:tw-text-white"
-            >
-              {wrapLongUnbrokenSegments(domain ?? href)}
-            </Link>
-          </div>
-        </div>
-      </LinkPreviewCardLayout>
+        domain={domain}
+      />
     );
   }
 
@@ -1497,6 +1765,21 @@ export default function OpenGraphPreview({
       <YoutubeVideoPreviewCard
         href={href}
         preview={youtubePreview}
+        effectiveHref={effectiveHref}
+        linkTarget={linkTarget}
+        linkRel={linkRel}
+        variant={resolvedVariant}
+        hideActions={hideActions}
+        locale={locale}
+      />
+    );
+  }
+
+  if (!imageOnly && farcasterEmbedPreview) {
+    return (
+      <FarcasterEmbedPreviewCard
+        href={href}
+        preview={farcasterEmbedPreview}
         effectiveHref={effectiveHref}
         linkTarget={linkTarget}
         linkRel={linkRel}

--- a/components/waves/OpenGraphPreview.tsx
+++ b/components/waves/OpenGraphPreview.tsx
@@ -1588,6 +1588,7 @@ function UnavailableOpenGraphPreview({
   variant,
   hideActions,
   domain,
+  locale,
 }: {
   readonly href: string;
   readonly effectiveHref: string;
@@ -1596,6 +1597,7 @@ function UnavailableOpenGraphPreview({
   readonly variant: LinkPreviewVariant;
   readonly hideActions: boolean;
   readonly domain?: string | null | undefined;
+  readonly locale: SupportedLocale;
 }) {
   if (variant === "home") {
     return (
@@ -1615,7 +1617,7 @@ function UnavailableOpenGraphPreview({
           <div className="tw-absolute tw-inset-0 tw-bg-gradient-to-br tw-from-iron-900/30 tw-via-black/20 tw-to-iron-900/30" />
           <div className="tw-relative tw-z-10 tw-flex tw-w-full tw-flex-col tw-gap-1 tw-p-4">
             <span className="tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-iron-400">
-              Link unavailable
+              {t(locale, "linkPreview.unavailable")}
             </span>
             <span className="tw-[overflow-wrap:anywhere] tw-break-words tw-text-sm tw-font-semibold tw-leading-snug tw-text-iron-100 tw-transition tw-duration-200 hover:tw-text-white">
               {wrapLongUnbrokenSegments(domain ?? href)}
@@ -1638,7 +1640,7 @@ function UnavailableOpenGraphPreview({
       >
         <div className="tw-max-h-full tw-space-y-2 tw-overflow-y-auto tw-text-center">
           <p className="tw-m-0 tw-text-sm tw-font-medium tw-text-iron-400">
-            Link unavailable
+            {t(locale, "linkPreview.unavailable")}
           </p>
           <Link
             href={effectiveHref}
@@ -1742,6 +1744,7 @@ export default function OpenGraphPreview({
         variant={resolvedVariant}
         hideActions={hideActions}
         domain={domain}
+        locale={locale}
       />
     );
   }

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -685,6 +685,13 @@ const MEDIA_VIDEO_MESSAGES = namespaceMessages("media.video", [
 const LINK_PREVIEW_MESSAGES = namespaceMessages("linkPreview", [
   ["externalSourceFallback", "External link"],
   ["byline", "by {author}"],
+  ["farcaster.frameBadge", "Frame"],
+  ["farcaster.imageAlt", "Farcaster embed preview for {title}"],
+  ["farcaster.imageFallbackAlt", "Farcaster embed preview"],
+  ["farcaster.miniAppBadge", "Mini App"],
+  ["farcaster.openFrame", "Open Frame"],
+  ["farcaster.openMiniApp", "Open Mini App"],
+  ["farcaster.titleFallback", "Farcaster Mini App"],
   ["mediaType.article", "Article"],
   ["mediaType.website", "Website"],
   ["youtube.providerFallback", "YouTube"],

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -694,6 +694,7 @@ const LINK_PREVIEW_MESSAGES = namespaceMessages("linkPreview", [
   ["farcaster.titleFallback", "Farcaster Mini App"],
   ["mediaType.article", "Article"],
   ["mediaType.website", "Website"],
+  ["unavailable", "Link unavailable"],
   ["youtube.providerFallback", "YouTube"],
   ["youtube.playVideo", "Play YouTube video: {title}"],
   ["youtube.thumbnailAlt", "YouTube thumbnail for {title}"],

--- a/ops/docs/waves/link-previews/feature-farcaster-miniapp-link-previews.md
+++ b/ops/docs/waves/link-previews/feature-farcaster-miniapp-link-previews.md
@@ -35,3 +35,18 @@ Typed `farcaster.miniapp` responses render as a native card with:
 - App title, description, source, optional splash image, and launch button.
 
 The card is responsive in chat, tablet, mobile, and home-feed variants.
+
+## Localization
+
+Fallback debt:
+
+- Route or component: `components/waves/OpenGraphPreview.tsx`
+- Untranslated surface: Farcaster embed badges, CTAs, image alt fallbacks, and
+  link-unavailable fallback text in partial locale dictionaries.
+- Current fallback behavior: `en-GB`, `de-DE`, `es-ES`, and `fr-FR` fall back to
+  canonical `en-US` messages for `linkPreview.*` keys not present locally.
+- User impact: non-English locale users may see English Farcaster preview labels.
+- Owner or follow-up issue: frontend i18n backlog.
+- Expected remediation path: add translated `linkPreview.farcaster.*` and
+  `linkPreview.unavailable` keys to partial locale dictionaries when this
+  surface is localized beyond `en-US`.

--- a/ops/docs/waves/link-previews/feature-farcaster-miniapp-link-previews.md
+++ b/ops/docs/waves/link-previews/feature-farcaster-miniapp-link-previews.md
@@ -1,0 +1,37 @@
+# Farcaster Mini App Link Previews
+
+6529 link previews enrich generic web pages that publish Farcaster Mini App or
+Frame metadata through the shared `/api/open-graph` endpoint.
+
+## Metadata Order
+
+The preview parser handles:
+
+- `fc:miniapp` JSON metadata from current Mini App embeds.
+- `fc:frame` JSON metadata for backward-compatible Mini App embeds.
+- Legacy frame tags such as `fc:frame:image` and `fc:frame:button:1`.
+
+Google Workspace previews keep priority over Farcaster metadata. When no
+Farcaster embed metadata is present, the endpoint falls back to the regular
+generic OpenGraph response.
+
+## Safety
+
+Fetched HTML is still bounded by the shared OpenGraph byte limit and public URL
+guard. Image, splash image, and action URLs extracted from third-party metadata
+are resolved against the final page URL and passed through the same public URL
+guard before they can appear in the response.
+
+The response does not emit server-built image alt text. The client card owns the
+localized accessible label.
+
+## Rendering
+
+Typed `farcaster.miniapp` responses render as a native card with:
+
+- A 3:2 media frame.
+- A Farcaster-colored accent.
+- Mini App or Frame badge.
+- App title, description, source, optional splash image, and launch button.
+
+The card is responsive in chat, tablet, mobile, and home-feed variants.

--- a/services/api/link-preview-api.ts
+++ b/services/api/link-preview-api.ts
@@ -125,6 +125,22 @@ export interface YoutubeVideoLinkPreview extends LinkPreviewBase {
   readonly startSeconds?: number | null | undefined;
 }
 
+export type FarcasterEmbedKind = "miniapp" | "frame" | "legacy-frame";
+export type FarcasterEmbedType = "farcaster.miniapp" | "farcaster.frame";
+
+export interface FarcasterEmbedLinkPreview extends LinkPreviewBase {
+  readonly type: FarcasterEmbedType;
+  readonly embedKind: FarcasterEmbedKind;
+  readonly appName?: string | null | undefined;
+  readonly buttonTitle?: string | null | undefined;
+  readonly actionType?: string | null | undefined;
+  readonly actionUrl?: string | null | undefined;
+  readonly imageUrl?: string | null | undefined;
+  readonly splashImageUrl?: string | null | undefined;
+  readonly splashBackgroundColor?: string | null | undefined;
+  readonly buttons?: readonly string[] | null | undefined;
+}
+
 interface ManifoldListingDetails {
   readonly listingId: string;
   readonly creatorHandle?: string | null | undefined;
@@ -148,7 +164,8 @@ export type LinkPreviewResponse =
   | ManifoldListingLinkPreview
   | SeizeCollectionLinkPreview
   | GoogleWorkspaceLinkPreview
-  | YoutubeVideoLinkPreview;
+  | YoutubeVideoLinkPreview
+  | FarcasterEmbedLinkPreview;
 
 const LINK_PREVIEW_CACHE_TTL_MS = 5 * 60 * 1000;
 const LINK_PREVIEW_CACHE_MAX_ITEMS = 200;


### PR DESCRIPTION
## Issue
- Farcaster Mini App and Frame URLs currently fall through to generic OpenGraph cards, losing the richer 3:2 app image, launch label, splash art, and Frame context.

## Fix
- Add a typed Farcaster embed parser inside `/api/open-graph` that recognizes `fc:miniapp`, JSON `fc:frame`, and legacy Frame meta tags.
- Render typed Farcaster cards with a stable 3:2 media area, a small purple Farcaster accent, safe CTA handling, and responsive desktop/tablet/mobile layouts.

## Changes
- Adds `farcaster.miniapp` / `farcaster.frame` link preview response support.
- Resolves Mini App and Frame image/action/splash URLs against the final page URL and validates them with the existing public URL guard before returning them.
- Keeps legacy Frame POST-style buttons inert; only `action=link` targets become navigable CTAs.
- Adds localized Farcaster card labels and docs for the new preview behavior.
- Splits the OpenGraph skeleton/unavailable branches into smaller components while preserving existing behavior.

## Validation
- `seize run test:no-coverage -- __tests__/app/api/open-graph.route.test.ts __tests__/components/waves/OpenGraphPreview.test.tsx __tests__/components/waves/LinkPreviewCard.test.tsx`
- `seize run typecheck:changed`
- `seize run lint:changed`
- `seize run react-doctor:diff` (100/100)
- `codex-diff-check --cached`
- Desktop, tablet, and mobile Playwright screenshot smoke on a temporary local preview route: cards rendered without horizontal overflow or clipped text.
- External Opus 4.8 review: no blocking findings after security/test hardening.

## Risk
- Level: Medium
- Why: touches the shared OpenGraph preview route and renders metadata from arbitrary public pages, but all extracted URLs are scheme-filtered and public-url guarded before use, with additional client-side CTA fallback.
- Rollback: revert this PR to return affected Farcaster/Mini App URLs to generic OpenGraph rendering.

## Review Notes
- Please focus on URL safety, legacy Frame action semantics, and responsive card layout.