### PR TITLE
[codex] Add profile CMS Phase 5-8 QA harness

### DIFF
--- a/__tests__/components/profile-cms/CmsSiteRenderer.phase5-8.test.tsx
+++ b/__tests__/components/profile-cms/CmsSiteRenderer.phase5-8.test.tsx
@@ -26,6 +26,12 @@ jest.mock("next/link", () => ({
   ),
 }));
 
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+
 const walletGalleryCmsPackage = walletGalleryPackage as unknown as CmsPackageV1;
 const collectionCmsPackage = collectionPagePackage as unknown as CmsPackageV1;
 const nftDetailCmsPackage = nftDetailPackage as unknown as CmsPackageV1;
@@ -56,7 +62,7 @@ describe("CmsSiteRenderer Phase 5-8 fixtures", () => {
     );
   });
 
-  it("renders the generated collection page contract and knowledge context", () => {
+  it("renders the generated collection page knowledge context and contact sheet", () => {
     renderFixturePage(collectionCmsPackage, "page-collection");
 
     expect(
@@ -69,9 +75,11 @@ describe("CmsSiteRenderer Phase 5-8 fixtures", () => {
         "Collection context fixture grounded in a knowledge packet."
       )
     ).toBeInTheDocument();
-    expect(screen.getByText("Chain 1")).toBeInTheDocument();
     expect(
-      screen.getByText("0x33fd426905f149f8376e227d0c9d3340aad17af1")
+      screen.getAllByAltText("The Memes by 6529 card number 1").length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("heading", { name: "Collection contact sheet" })
     ).toBeInTheDocument();
   });
 
@@ -84,11 +92,13 @@ describe("CmsSiteRenderer Phase 5-8 fixtures", () => {
       "src",
       "https://media.6529.io/ipfs/bafyfixturenft/original.png"
     );
-    expect(screen.getByText("Token #1")).toBeInTheDocument();
-    expect(screen.getByText("Chain 1")).toBeInTheDocument();
+    expect(screen.getAllByText("Token ID").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("1").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Chain").length).toBeGreaterThan(0);
     expect(
-      screen.getByText("0x33fd426905f149f8376e227d0c9d3340aad17af1")
-    ).toBeInTheDocument();
+      screen.getAllByText("0x33fd426905f149f8376e227d0c9d3340aad17af1")
+        .length
+    ).toBeGreaterThan(0);
   });
 
   it("renders the 3D room fixture as an inspectable fallback linked to detail", () => {
@@ -102,7 +112,7 @@ describe("CmsSiteRenderer Phase 5-8 fixtures", () => {
       "https://media.6529.io/ipfs/bafyfixtureroom/poster.jpg"
     );
     expect(
-      screen.getByRole("link", { name: "Open source media" })
+      screen.getByRole("link", { name: "Open 2D fallback" })
     ).toHaveAttribute(
       "href",
       "/punk6529/nfts/ethereum/0x33fd426905f149f8376e227d0c9d3340aad17af1/1/index.html"
@@ -116,7 +126,7 @@ describe("CmsSiteRenderer Phase 5-8 fixtures", () => {
       "sandbox",
       "allow-scripts"
     );
-    expect(screen.getByText("3D object preview")).toBeInTheDocument();
+    expect(screen.getAllByText("3D object preview").length).toBeGreaterThan(0);
     expect(
       screen.getByRole("link", { name: "Open source media" })
     ).toHaveAttribute(

--- a/__tests__/components/profile-cms/CmsSiteRenderer.phase5-8.test.tsx
+++ b/__tests__/components/profile-cms/CmsSiteRenderer.phase5-8.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import CmsSiteRenderer from "@/components/profile-cms/CmsSiteRenderer";
+import artMediaPackage from "@/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/art-media.package.json";
+import collectionPagePackage from "@/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/collection-page.package.json";
+import exhibitionRoomPackage from "@/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/exhibition-room.package.json";
+import nftDetailPackage from "@/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/nft-detail.package.json";
+import walletGalleryPackage from "@/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/wallet-gallery.package.json";
+import type { CmsPackageV1 } from "@/lib/profile-cms/protocol/v1";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    readonly href: string;
+    readonly children: ReactNode;
+    readonly className?: string;
+  }) => (
+    <a className={className} href={href}>
+      {children}
+    </a>
+  ),
+}));
+
+const walletGalleryCmsPackage = walletGalleryPackage as unknown as CmsPackageV1;
+const collectionCmsPackage = collectionPagePackage as unknown as CmsPackageV1;
+const nftDetailCmsPackage = nftDetailPackage as unknown as CmsPackageV1;
+const exhibitionRoomCmsPackage =
+  exhibitionRoomPackage as unknown as CmsPackageV1;
+const artMediaCmsPackage = artMediaPackage as unknown as CmsPackageV1;
+
+describe("CmsSiteRenderer Phase 5-8 fixtures", () => {
+  it("renders the generated wallet gallery home snapshot and featured routes", () => {
+    renderFixturePage(walletGalleryCmsPackage, "page-gallery");
+
+    expect(
+      screen.getByRole("heading", { name: "Gallery", level: 1 })
+    ).toBeInTheDocument();
+    const gallerySection = getSectionByHeading("Wallet gallery");
+    expect(within(gallerySection).getByText("2 wallets")).toBeInTheDocument();
+    expect(within(gallerySection).getByText("22,000,000")).toBeInTheDocument();
+    expect(
+      within(gallerySection).getByText("Jun 17, 2026")
+    ).toBeInTheDocument();
+
+    const featuredLinks = within(gallerySection).getAllByRole("link");
+    expect(featuredLinks.map((link) => link.getAttribute("href"))).toEqual(
+      expect.arrayContaining([
+        "/punk6529/collections/the-memes/index.html",
+        "/punk6529/nfts/ethereum/0x33fd426905f149f8376e227d0c9d3340aad17af1/1/index.html",
+      ])
+    );
+  });
+
+  it("renders the generated collection page contract and knowledge context", () => {
+    renderFixturePage(collectionCmsPackage, "page-collection");
+
+    expect(
+      screen.getAllByRole("heading", {
+        name: "The Memes by 6529",
+      }).length
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      screen.getByText(
+        "Collection context fixture grounded in a knowledge packet."
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText("Chain 1")).toBeInTheDocument();
+    expect(
+      screen.getByText("0x33fd426905f149f8376e227d0c9d3340aad17af1")
+    ).toBeInTheDocument();
+  });
+
+  it("renders the NFT detail page with preserved artwork and token provenance", () => {
+    renderFixturePage(nftDetailCmsPackage, "page-nft");
+
+    expect(
+      screen.getByAltText("The Memes by 6529 number 1 original artwork")
+    ).toHaveAttribute(
+      "src",
+      "https://media.6529.io/ipfs/bafyfixturenft/original.png"
+    );
+    expect(screen.getByText("Token #1")).toBeInTheDocument();
+    expect(screen.getByText("Chain 1")).toBeInTheDocument();
+    expect(
+      screen.getByText("0x33fd426905f149f8376e227d0c9d3340aad17af1")
+    ).toBeInTheDocument();
+  });
+
+  it("renders the 3D room fixture as an inspectable fallback linked to detail", () => {
+    renderFixturePage(exhibitionRoomCmsPackage, "page-room");
+
+    expect(screen.getByText("Simple Wall Room")).toBeInTheDocument();
+    expect(
+      screen.getByAltText("Poster for a simple 3D exhibition room")
+    ).toHaveAttribute(
+      "src",
+      "https://media.6529.io/ipfs/bafyfixtureroom/poster.jpg"
+    );
+    expect(
+      screen.getByRole("link", { name: "Open source media" })
+    ).toHaveAttribute(
+      "href",
+      "/punk6529/nfts/ethereum/0x33fd426905f149f8376e227d0c9d3340aad17af1/1/index.html"
+    );
+  });
+
+  it("renders mixed art media with sandboxed embeds and object fallbacks", () => {
+    renderFixturePage(artMediaCmsPackage, "page-home");
+
+    expect(screen.getByTitle("Embedded profile website media")).toHaveAttribute(
+      "sandbox",
+      "allow-scripts"
+    );
+    expect(screen.getByText("3D object preview")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Open source media" })
+    ).toHaveAttribute(
+      "href",
+      "https://media.6529.io/ipfs/bafyfixturemedia/model.glb"
+    );
+  });
+});
+
+function renderFixturePage(cmsPackage: CmsPackageV1, pageId: string): void {
+  const page = cmsPackage.payload.pages.find(
+    (candidate) => candidate.id === pageId
+  );
+  if (!page) {
+    throw new Error(`Missing CMS fixture page '${pageId}'.`);
+  }
+
+  render(<CmsSiteRenderer cmsPackage={cmsPackage} page={page} />);
+}
+
+function getSectionByHeading(name: string): HTMLElement {
+  const heading = screen.getByRole("heading", { name });
+  const section = heading.closest("section");
+  if (!section) {
+    throw new Error(`Missing section for heading '${name}'.`);
+  }
+  return section;
+}

--- a/ops/workstreams/profile-native-cms-roadmap/README.md
+++ b/ops/workstreams/profile-native-cms-roadmap/README.md
@@ -43,6 +43,7 @@ Examples:
 - [Runtime Bridge Integration Assumptions](runtime-bridge-integration-assumptions.md)
 - [Builder MVP Integration Assumptions](builder-mvp-integration-assumptions.md)
 - [Phase 6 Art Display Excellence](phase-6-art-display/README.md)
+- [Phase 5-8 QA Checklist](phase-5-8-qa-checklist.md)
 - [Active Context](active-context.md)
 - [Run Log](run-log.md)
 

--- a/ops/workstreams/profile-native-cms-roadmap/active-context.md
+++ b/ops/workstreams/profile-native-cms-roadmap/active-context.md
@@ -47,10 +47,14 @@ Available now:
   `/{handle}/cms/builder` route, guided homepage editor, real renderer preview,
   local V1 validation checklist, JSON import/export, and save/validate/publish
   adapter stubs.
-- The Phase 7 frontend 3D lane is in progress on
-  `codex/cms-3d-rooms-mvp`, stacked on the builder MVP. It adds a bounded
-  Three.js client island for GLB/glTF object viewing and simple exhibition room
-  rendering, plus a builder-facing 3D room primitive.
+- The Phase 7 frontend 3D lane adds a bounded Three.js client island for
+  GLB/glTF object viewing and simple exhibition room rendering, plus a
+  builder-facing 3D room primitive.
+- Phase 5-8 QA/integration is now tracked on
+  `codex/cms-phase5-8-qa-integration` with a living checklist at
+  `phase-5-8-qa-checklist.md`, fixture renderer coverage for wallet gallery,
+  collection, NFT detail, mixed media, and 3D room fallback packages, and an
+  opt-in Playwright smoke harness prepared for worker branch integration.
 
 Important limits:
 
@@ -74,6 +78,8 @@ Important limits:
   poster/static preview, deferred room/object loading, faithful 2D art
   surfaces, canonical detail links, and mobile fallback.
 - There is no general WYSIWYG/block editor yet.
+- The Phase 5-8 smoke harness is opt-in because it needs deployed/staged routes
+  and fixture data for the full generated gallery and 3D surfaces.
 
 ## Product Decisions Already Made
 

--- a/ops/workstreams/profile-native-cms-roadmap/phase-5-8-qa-checklist.md
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-5-8-qa-checklist.md
@@ -159,6 +159,9 @@ For every worker PR that claims visual readiness, capture:
 - For 3D, canvas pixel result or explicit mobile fallback result.
 - For social preview, metadata values and rendered card/image output where a
   route exists.
+- For localized worker branches, migrate brittle English smoke selectors to
+  stable locale-independent contracts, such as roles by semantic meaning or
+  agreed test ids.
 
 Failures should be actionable: include the route, selector or state that failed,
 viewport, screenshot name, and whether the failure is fixture, backend, or UI

--- a/ops/workstreams/profile-native-cms-roadmap/phase-5-8-qa-checklist.md
+++ b/ops/workstreams/profile-native-cms-roadmap/phase-5-8-qa-checklist.md
@@ -1,0 +1,165 @@
+# Phase 5-8 QA Checklist
+
+Last updated: 2026-06-18.
+
+## Purpose
+
+This is the living QA and integration checklist for the profile-native CMS
+Phase 5-8 lanes:
+
+- Phase 5: wallet gallery generator.
+- Phase 6: art and NFT display excellence.
+- Phase 7: 3D rooms and object viewer.
+- Phase 8: AI-agent affordances.
+
+The checklist tracks expected worker branches, early contract collisions,
+fixture-driven coverage, and browser smoke requirements. Keep it current as
+worker PRs appear.
+
+## Current Baseline
+
+- Base branch for this QA lane: `codex/profile-cms-builder-mvp`.
+- QA branch: `codex/cms-phase5-8-qa-integration`.
+- Builder MVP reference PR: [#2726](https://github.com/6529-Collections/6529seize-frontend/pull/2726).
+- Runtime bridge reference: PR #2720 per the workstream run log.
+- Local worker refs for `codex/cms-gallery-builder-flow`,
+  `codex/cms-art-display-excellence`, `codex/cms-3d-rooms-mvp`, and
+  `codex/cms-ai-agent-affordances-ui` currently have no diff from the builder
+  base. An explicit fetch found no remote ref for
+  `codex/cms-gallery-builder-flow`, so the later worker branches should be
+  treated as expected/local-only until pushed.
+
+## Worker Branch Tracker
+
+| Lane | Expected branch | Current status | Collision watch |
+| --- | --- | --- | --- |
+| Phase 5 gallery | `codex/cms-gallery-builder-flow` | Local ref, no diff from base, no PR observed | Builder state/types, wallet source packets, generated routes, media profiles, social image assets |
+| Phase 6 art display | `codex/cms-art-display-excellence` | Local ref, no diff from base, no PR observed | `CmsSiteRenderer`, media blocks, image/video/model fallbacks, i18n keys, fixture assets |
+| Phase 7 3D rooms | `codex/cms-3d-rooms-mvp` | Local ref, no diff from base, no PR observed | `room_viewer`, `object_viewer`, Three.js/model-viewer choices, canvas fallback, mobile behavior |
+| Phase 8 AI-agent | `codex/cms-ai-agent-affordances-ui` | Local ref, no diff from base, no PR observed | agent patch schema, source packets, validation output, builder import/review flow, publish gating |
+
+## Contract Collision Watch
+
+Review these paths first when worker branches start moving:
+
+- `ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/*.package.json`
+- `lib/profile-cms/protocol/v1/*`
+- `lib/profile-cms/builder/*`
+- `lib/profile-cms/runtime/*`
+- `components/profile-cms/CmsSiteRenderer.tsx`
+- `components/profile-cms-builder/ProfileCmsBuilder.tsx`
+- `app/[user]/[...cmsPath]/page.tsx`
+- `app/[user]/cms/builder/page.tsx`
+- `i18n/messages/en-US.ts`
+- `config/env.schema.ts`
+- `config/profileCmsBuilderEnv.ts`
+- `config/profileCmsRuntimeEnv.ts`
+
+## Fixture Regression Coverage
+
+Current fixture-driven coverage added by the QA lane:
+
+- `__tests__/components/profile-cms/CmsSiteRenderer.phase5-8.test.tsx`
+  renders wallet gallery, collection, NFT detail, mixed media, object fallback,
+  and 3D room fallback fixtures.
+- `tests/profile-cms/phase5-8-smoke.spec.ts` prepares opt-in Playwright smoke
+  coverage for branch integration. It is intentionally disabled unless
+  `RUN_PROFILE_CMS_PHASE5_8_E2E=true` and the relevant route env vars are set.
+
+Run focused fixture coverage with:
+
+```powershell
+seize run test:no-coverage -- --testMatch "**/__tests__/components/profile-cms/CmsSiteRenderer.phase5-8.test.tsx" --runInBand
+```
+
+Run optional browser smoke after a worker branch exposes the relevant routes:
+
+```powershell
+$env:RUN_PROFILE_CMS_PHASE5_8_E2E="true"
+$env:PROFILE_CMS_BUILDER_SMOKE_PATH="/punk6529/cms/builder"
+$env:PROFILE_CMS_GALLERY_HOME_PATH="/punk6529/index.html"
+$env:PROFILE_CMS_COLLECTION_PAGE_PATH="/punk6529/collections/the-memes/index.html"
+$env:PROFILE_CMS_NFT_DETAIL_PATH="/punk6529/nfts/ethereum/0x33fd426905f149f8376e227d0c9d3340aad17af1/1/index.html"
+$env:PROFILE_CMS_SOCIAL_PREVIEW_PATH="/punk6529/index.html"
+$env:PROFILE_CMS_ROOM_PATH="/punk6529/rooms/main/index.html"
+$env:PROFILE_CMS_AGENT_PATCH_PATH="/punk6529/cms/builder/patches"
+seize exec playwright test tests/profile-cms/phase5-8-smoke.spec.ts --project=chromium
+```
+
+If a worker branch uses different hidden routes during review, set the env vars
+to those paths rather than changing the test.
+
+## Phase 5 Gallery Checklist
+
+- Wallet and ENS inputs normalize, deduplicate, and preserve user intent.
+- Multi-wallet snapshots freeze block number, capture time, wallets, owner
+  state, hidden NFTs, featured NFTs, and featured collections.
+- Generated home, collection, NFT detail, and paginated all-NFT routes stay
+  inside the owning profile namespace.
+- Generated pages use `nft_media_profiles`, `display_variants`, posters, and
+  social image assets rather than raw marketplace thumbnails.
+- Hide/spam controls affect generated packages before publish and cannot hide
+  provenance needed for audit.
+- Published gallery packages do not require live wallet/indexer fetches to
+  render.
+- Desktop and mobile screenshots cover gallery home, collection page, and NFT
+  detail page.
+- Social metadata exists for generated home, collection, and NFT detail pages.
+
+## Phase 6 Art/NFT Display Checklist
+
+- Detail views preserve artwork aspect ratio and do not crop originals.
+- Grid/dense/contact-sheet modes have stable dimensions and no horizontal
+  overflow.
+- Video, audio, HTML, model, and deep zoom blocks have posters or readable
+  fallback states.
+- Sandboxed HTML embeds never use `srcdoc` or `allow-same-origin`.
+- Lightbox/focused inspection has keyboard, escape, focus return, reduced
+  motion, and metadata-toggle coverage once implemented.
+- Original media, derivatives, posters, metadata URI, storage receipt, and
+  package provenance are visually distinguishable.
+- Accessibility coverage includes alt text, captions/transcripts where media
+  requires them, and reduced-motion behavior.
+
+## Phase 7 3D Checklist
+
+- Desktop route renders a nonblank canvas when 3D is enabled.
+- Mobile route renders either a functional lightweight room or a clear fallback
+  with a link to the faithful 2D detail page.
+- Every room placement links to the canonical NFT/detail page.
+- Poster/static preview appears before deferred 3D hydration.
+- Canvas checks sample pixels and fail with route, viewport, and screenshot.
+- Scene loading handles missing GLB/glTF, failed textures, and reduced-motion
+  users without blank UI.
+- Performance budget is documented before merge: model size, texture size,
+  initial JS, and first-interaction target.
+
+## Phase 8 AI-Agent Checklist
+
+- Schema bundle export includes package, agent patch, and validation result
+  schemas with versioned names.
+- Source packets strip executable HTML and include enough context for safe
+  patch generation.
+- Agent patch import validates route namespace, unsafe URLs, unknown blocks,
+  hash/package drift, and patch operation bounds.
+- Review UI shows proposed changes before apply and never publishes directly.
+- Apply flow records validation output and keeps publish/signing as a separate
+  profile-authorized action.
+- MCP or external-agent docs state that user agents bring their own inference
+  and 6529 does not pay for arbitrary generation.
+
+## Browser Evidence Standard
+
+For every worker PR that claims visual readiness, capture:
+
+- Route, branch, commit, viewport, and fixture/data mode.
+- Screenshot artifact for each covered route.
+- Page response status, console/page errors, image load status, and horizontal
+  overflow result.
+- For 3D, canvas pixel result or explicit mobile fallback result.
+- For social preview, metadata values and rendered card/image output where a
+  route exists.
+
+Failures should be actionable: include the route, selector or state that failed,
+viewport, screenshot name, and whether the failure is fixture, backend, or UI
+owned.

--- a/ops/workstreams/profile-native-cms-roadmap/run-log.md
+++ b/ops/workstreams/profile-native-cms-roadmap/run-log.md
@@ -951,3 +951,29 @@ Updated:
 - Existing Playwright specs in `tests/` import `../testHelpers`, but no tracked
   `tests/testHelpers.ts` is present in this checkout. The new Phase 5-8 smoke
   spec imports Playwright directly to avoid depending on that missing helper.
+
+## 2026-06-18 - Phase 5-8 QA Review Follow-Up
+
+### Feedback Addressed
+
+- 6529bot general review requested a stronger smoke harness after PR #2733 was
+  opened as a draft.
+- Updated the Playwright smoke helper to settle briefly and re-assert collected
+  page/console errors after navigation and after route-level assertions.
+- Replaced the implicit `/` route fallback with an explicit missing-env failure
+  when smoke is enabled.
+- Named the horizontal overflow tolerance and documented why it exists.
+- Added a WebGL `readPixels` caveat to blank-canvas failure messages so 3D
+  worker branches inspect the screenshot before treating the result as proof of
+  an empty render.
+- Added a checklist note to migrate English smoke selectors to stable
+  locale-independent contracts when localized worker branches land.
+
+### Validation
+
+- `seize run format:changed`
+- `seize run test:no-coverage -- --testMatch "**/__tests__/components/profile-cms/CmsSiteRenderer.phase5-8.test.tsx" --runInBand`
+- `seize run lint:changed`
+- `seize run typecheck:changed`
+- `seize run react-doctor:diff`
+- `seize exec playwright test tests/profile-cms/phase5-8-smoke.spec.ts --list`

--- a/ops/workstreams/profile-native-cms-roadmap/run-log.md
+++ b/ops/workstreams/profile-native-cms-roadmap/run-log.md
@@ -886,3 +886,68 @@ Browser smoke:
   local helper/process env behavior: `seize-local-dev start-frontend` exits on
   `PORT_SEARCH_LIMIT=0`; direct `seize run dev` starts on occupied port `3001`.
   No screenshot captured.
+## 2026-06-18 - Phase 5-8 QA Integration Lane
+
+### Current Objective
+
+Own the QA/integration lane for Phase 5 wallet gallery, Phase 6 art/NFT
+display, Phase 7 3D rooms, and Phase 8 AI-agent affordances while feature
+workers prepare their branches.
+
+### Output
+
+Added:
+
+- `ops/workstreams/profile-native-cms-roadmap/phase-5-8-qa-checklist.md`
+- `__tests__/components/profile-cms/CmsSiteRenderer.phase5-8.test.tsx`
+- `tests/profile-cms/phase5-8-smoke.spec.ts`
+
+Updated:
+
+- `ops/workstreams/profile-native-cms-roadmap/README.md`
+- `ops/workstreams/profile-native-cms-roadmap/active-context.md`
+
+### Integration Notes
+
+- QA branch: `codex/cms-phase5-8-qa-integration`.
+- Base branch: `codex/profile-cms-builder-mvp`.
+- Builder MVP reference PR: #2726.
+- Expected worker branches
+  `codex/cms-gallery-builder-flow`, `codex/cms-art-display-excellence`,
+  `codex/cms-3d-rooms-mvp`, and
+  `codex/cms-ai-agent-affordances-ui` currently have no diff from the builder
+  base in this local worktree. An explicit fetch did not find a remote
+  `codex/cms-gallery-builder-flow` ref, so those branches are tracked as
+  expected/local-only until pushed.
+
+### Coverage Prepared
+
+- Fixture regression coverage now renders wallet gallery home, collection page,
+  NFT detail page, mixed media/object fallback, and 3D room fallback packages
+  through `CmsSiteRenderer`.
+- Optional Playwright smoke coverage is prepared for gallery builder flow,
+  generated gallery home, collection page, NFT detail page, social preview
+  metadata, 3D room canvas/mobile fallback, and agent patch review flow. The
+  smoke spec is disabled by default and requires
+  `RUN_PROFILE_CMS_PHASE5_8_E2E=true` plus per-route env vars so it can run
+  against whichever worker branch exposes each surface first.
+
+### Validation
+
+- `seize run format:changed`
+- `seize run test:no-coverage -- --testMatch "**/__tests__/components/profile-cms/CmsSiteRenderer.phase5-8.test.tsx" --runInBand`
+- `seize run lint:changed`
+- `seize run typecheck:changed`
+- `seize run react-doctor:diff`
+- `seize exec playwright test tests/profile-cms/phase5-8-smoke.spec.ts --list`
+
+### Remaining Risks
+
+- Browser smoke is not yet evidence of worker functionality because the Phase
+  5-8 worker branches have not landed runnable diffs in this worktree.
+- The current app-level runtime fixture primary only covers the minimal
+  `punk6529` homepage. Full generated gallery/collection/NFT/room browser smoke
+  needs worker routes, a fixture route, or backend/profile data availability.
+- Existing Playwright specs in `tests/` import `../testHelpers`, but no tracked
+  `tests/testHelpers.ts` is present in this checkout. The new Phase 5-8 smoke
+  spec imports Playwright directly to avoid depending on that missing helper.

--- a/tests/profile-cms/phase5-8-smoke.spec.ts
+++ b/tests/profile-cms/phase5-8-smoke.spec.ts
@@ -1,0 +1,244 @@
+import {
+  expect,
+  test,
+  type Locator,
+  type Page,
+  type TestInfo,
+} from "@playwright/test";
+
+const RUN_SMOKE_ENV = "RUN_PROFILE_CMS_PHASE5_8_E2E";
+const SMOKE_ENABLED = process.env[RUN_SMOKE_ENV] === "true";
+
+test.describe("profile CMS Phase 5-8 browser smoke", () => {
+  test("gallery builder flow exposes editor, preview, JSON, and validation affordances", async ({
+    page,
+  }, testInfo) => {
+    const path = requireSmokePath("PROFILE_CMS_BUILDER_SMOKE_PATH");
+    await gotoAndCheck(page, path);
+
+    await expect(
+      page.getByRole("heading", { name: "Profile CMS builder" })
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Editor" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Preview" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "JSON" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Validation" })
+    ).toBeVisible();
+    await captureSmokeScreenshot(page, testInfo, "builder-flow");
+  });
+
+  test("generated gallery home renders snapshot and featured routes", async ({
+    page,
+  }, testInfo) => {
+    const path = requireSmokePath("PROFILE_CMS_GALLERY_HOME_PATH");
+    await gotoAndCheck(page, path);
+
+    await expect(page.getByRole("heading", { name: /Gallery/i })).toBeVisible();
+    await expect(page.getByText("Wallet gallery")).toBeVisible();
+    await expect(page.getByText(/wallets?/i)).toBeVisible();
+    await captureSmokeScreenshot(page, testInfo, "gallery-home");
+  });
+
+  test("generated collection page renders contract context", async ({
+    page,
+  }, testInfo) => {
+    const path = requireSmokePath("PROFILE_CMS_COLLECTION_PAGE_PATH");
+    await gotoAndCheck(page, path);
+
+    await expect(
+      page.getByRole("heading", { name: /Memes|Collection/i })
+    ).toBeVisible();
+    await expect(page.getByText(/Chain \d+/)).toBeVisible();
+    await captureSmokeScreenshot(page, testInfo, "collection-page");
+  });
+
+  test("generated NFT detail page renders artwork and token panel", async ({
+    page,
+  }, testInfo) => {
+    const path = requireSmokePath("PROFILE_CMS_NFT_DETAIL_PATH");
+    await gotoAndCheck(page, path);
+
+    await expect(
+      page.getByRole("heading", { name: /#|NFT|Token/i })
+    ).toBeVisible();
+    await expect(page.getByRole("img").first()).toBeVisible();
+    await expect(page.getByText(/Token #|Chain \d+/)).toBeVisible();
+    await captureSmokeScreenshot(page, testInfo, "nft-detail");
+  });
+
+  test("social preview metadata is populated for a generated CMS page", async ({
+    page,
+  }) => {
+    const path = requireSmokePath("PROFILE_CMS_SOCIAL_PREVIEW_PATH");
+    await gotoAndCheck(page, path);
+
+    const metadata = await page.evaluate(() => ({
+      description:
+        document
+          .querySelector('meta[name="description"]')
+          ?.getAttribute("content") ?? "",
+      ogImage:
+        document
+          .querySelector('meta[property="og:image"]')
+          ?.getAttribute("content") ?? "",
+      ogTitle:
+        document
+          .querySelector('meta[property="og:title"]')
+          ?.getAttribute("content") ?? "",
+      twitterCard:
+        document
+          .querySelector('meta[name="twitter:card"]')
+          ?.getAttribute("content") ?? "",
+    }));
+
+    expect(metadata.ogTitle).not.toHaveLength(0);
+    expect(metadata.description).not.toHaveLength(0);
+    expect(metadata.ogImage).toMatch(/^https?:\/\//);
+    expect(metadata.twitterCard).toContain("summary");
+  });
+
+  test("3D room route has either a nonblank canvas or mobile-safe fallback", async ({
+    page,
+  }, testInfo) => {
+    const path = requireSmokePath("PROFILE_CMS_ROOM_PATH");
+    await page.setViewportSize({ width: 390, height: 844 });
+    await gotoAndCheck(page, path);
+
+    const canvas = page.locator("canvas").first();
+    if (await canvas.count()) {
+      await expectNonBlankCanvas(canvas);
+    } else {
+      await expect(
+        page.getByText(/Room preview|Open source media/i)
+      ).toBeVisible();
+    }
+    await captureSmokeScreenshot(page, testInfo, "room-mobile");
+  });
+
+  test("agent patch import flow keeps review and publish as separate actions", async ({
+    page,
+  }, testInfo) => {
+    const path = requireSmokePath("PROFILE_CMS_AGENT_PATCH_PATH");
+    await gotoAndCheck(page, path);
+
+    await expect(page.getByText(/patch/i)).toBeVisible();
+    await expect(page.getByText(/review|validate/i)).toBeVisible();
+    await expect(page.getByText(/publish/i)).toBeVisible();
+    await captureSmokeScreenshot(page, testInfo, "agent-patch-review");
+  });
+});
+
+function requireSmokePath(envName: string): string {
+  const value = process.env[envName]?.trim();
+  test.skip(
+    !SMOKE_ENABLED,
+    `Set ${RUN_SMOKE_ENV}=true to run Phase 5-8 CMS smoke coverage.`
+  );
+  test.skip(!!SMOKE_ENABLED && !value, `Set ${envName} for this smoke test.`);
+  return value ?? "/";
+}
+
+async function gotoAndCheck(page: Page, path: string): Promise<void> {
+  const errors = collectPageErrors(page);
+  const response = await page.goto(path, { waitUntil: "networkidle" });
+  expect(
+    response?.ok(),
+    `Expected ${path} to return a successful response.`
+  ).toBe(true);
+  expect(errors, `Unexpected page errors on ${path}.`).toEqual([]);
+  await expectNoHorizontalOverflow(page);
+}
+
+function collectPageErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      errors.push(message.text());
+    }
+  });
+  return errors;
+}
+
+async function expectNoHorizontalOverflow(page: Page): Promise<void> {
+  const overflowPixels = await page.evaluate(
+    () =>
+      document.documentElement.scrollWidth -
+      document.documentElement.clientWidth
+  );
+  expect(overflowPixels).toBeLessThanOrEqual(1);
+}
+
+async function expectNonBlankCanvas(canvas: Locator): Promise<void> {
+  const sample = await canvas.evaluate((element) => {
+    const node = element as HTMLCanvasElement;
+    const width = node.width;
+    const height = node.height;
+    if (!width || !height) {
+      return { nonBlank: false, reason: "canvas has zero size", width, height };
+    }
+
+    const sampleWidth = Math.min(width, 64);
+    const sampleHeight = Math.min(height, 64);
+    const gl = node.getContext("webgl2") ?? node.getContext("webgl");
+    if (gl) {
+      const pixels = new Uint8Array(sampleWidth * sampleHeight * 4);
+      gl.readPixels(
+        0,
+        0,
+        sampleWidth,
+        sampleHeight,
+        gl.RGBA,
+        gl.UNSIGNED_BYTE,
+        pixels
+      );
+      return {
+        nonBlank: pixels.some((value) => value !== 0),
+        reason: "webgl pixels were all zero",
+        width,
+        height,
+      };
+    }
+
+    const context = node.getContext("2d");
+    if (!context) {
+      return {
+        nonBlank: false,
+        reason: "canvas has no readable 2D or WebGL context",
+        width,
+        height,
+      };
+    }
+
+    try {
+      const pixels = context.getImageData(0, 0, sampleWidth, sampleHeight).data;
+      return {
+        nonBlank: Array.from(pixels).some((value) => value !== 0),
+        reason: "2D pixels were all zero",
+        width,
+        height,
+      };
+    } catch {
+      return {
+        nonBlank: false,
+        reason: "canvas pixels could not be read",
+        width,
+        height,
+      };
+    }
+  });
+
+  expect(sample.nonBlank, sample.reason).toBe(true);
+}
+
+async function captureSmokeScreenshot(
+  page: Page,
+  testInfo: TestInfo,
+  name: string
+): Promise<void> {
+  await page.screenshot({
+    fullPage: true,
+    path: testInfo.outputPath(`${name}.png`),
+  });
+}

--- a/tests/profile-cms/phase5-8-smoke.spec.ts
+++ b/tests/profile-cms/phase5-8-smoke.spec.ts
@@ -8,13 +8,18 @@ import {
 
 const RUN_SMOKE_ENV = "RUN_PROFILE_CMS_PHASE5_8_E2E";
 const SMOKE_ENABLED = process.env[RUN_SMOKE_ENV] === "true";
+const PAGE_ERROR_SETTLE_MS = 250;
+// Allows browser/DPR sub-pixel rounding; tune only with screenshot evidence.
+const HORIZONTAL_OVERFLOW_TOLERANCE_PX = 1;
+const WEBGL_READ_PIXELS_CAVEAT =
+  "WebGL readPixels can return all-zero samples when preserveDrawingBuffer is false; inspect the smoke screenshot before treating this as a blank canvas.";
 
 test.describe("profile CMS Phase 5-8 browser smoke", () => {
   test("gallery builder flow exposes editor, preview, JSON, and validation affordances", async ({
     page,
   }, testInfo) => {
     const path = requireSmokePath("PROFILE_CMS_BUILDER_SMOKE_PATH");
-    await gotoAndCheck(page, path);
+    const pageErrors = await gotoAndCheck(page, path);
 
     await expect(
       page.getByRole("heading", { name: "Profile CMS builder" })
@@ -26,38 +31,56 @@ test.describe("profile CMS Phase 5-8 browser smoke", () => {
       page.getByRole("heading", { name: "Validation" })
     ).toBeVisible();
     await captureSmokeScreenshot(page, testInfo, "builder-flow");
+    await assertNoCollectedPageErrorsAfterSettle(
+      page,
+      pageErrors,
+      path,
+      "post-builder assertions"
+    );
   });
 
   test("generated gallery home renders snapshot and featured routes", async ({
     page,
   }, testInfo) => {
     const path = requireSmokePath("PROFILE_CMS_GALLERY_HOME_PATH");
-    await gotoAndCheck(page, path);
+    const pageErrors = await gotoAndCheck(page, path);
 
     await expect(page.getByRole("heading", { name: /Gallery/i })).toBeVisible();
     await expect(page.getByText("Wallet gallery")).toBeVisible();
     await expect(page.getByText(/wallets?/i)).toBeVisible();
     await captureSmokeScreenshot(page, testInfo, "gallery-home");
+    await assertNoCollectedPageErrorsAfterSettle(
+      page,
+      pageErrors,
+      path,
+      "post-gallery assertions"
+    );
   });
 
   test("generated collection page renders contract context", async ({
     page,
   }, testInfo) => {
     const path = requireSmokePath("PROFILE_CMS_COLLECTION_PAGE_PATH");
-    await gotoAndCheck(page, path);
+    const pageErrors = await gotoAndCheck(page, path);
 
     await expect(
       page.getByRole("heading", { name: /Memes|Collection/i })
     ).toBeVisible();
     await expect(page.getByText(/Chain \d+/)).toBeVisible();
     await captureSmokeScreenshot(page, testInfo, "collection-page");
+    await assertNoCollectedPageErrorsAfterSettle(
+      page,
+      pageErrors,
+      path,
+      "post-collection assertions"
+    );
   });
 
   test("generated NFT detail page renders artwork and token panel", async ({
     page,
   }, testInfo) => {
     const path = requireSmokePath("PROFILE_CMS_NFT_DETAIL_PATH");
-    await gotoAndCheck(page, path);
+    const pageErrors = await gotoAndCheck(page, path);
 
     await expect(
       page.getByRole("heading", { name: /#|NFT|Token/i })
@@ -65,13 +88,19 @@ test.describe("profile CMS Phase 5-8 browser smoke", () => {
     await expect(page.getByRole("img").first()).toBeVisible();
     await expect(page.getByText(/Token #|Chain \d+/)).toBeVisible();
     await captureSmokeScreenshot(page, testInfo, "nft-detail");
+    await assertNoCollectedPageErrorsAfterSettle(
+      page,
+      pageErrors,
+      path,
+      "post-nft assertions"
+    );
   });
 
   test("social preview metadata is populated for a generated CMS page", async ({
     page,
   }) => {
     const path = requireSmokePath("PROFILE_CMS_SOCIAL_PREVIEW_PATH");
-    await gotoAndCheck(page, path);
+    const pageErrors = await gotoAndCheck(page, path);
 
     const metadata = await page.evaluate(() => ({
       description:
@@ -96,6 +125,12 @@ test.describe("profile CMS Phase 5-8 browser smoke", () => {
     expect(metadata.description).not.toHaveLength(0);
     expect(metadata.ogImage).toMatch(/^https?:\/\//);
     expect(metadata.twitterCard).toContain("summary");
+    await assertNoCollectedPageErrorsAfterSettle(
+      page,
+      pageErrors,
+      path,
+      "post-metadata assertions"
+    );
   });
 
   test("3D room route has either a nonblank canvas or mobile-safe fallback", async ({
@@ -103,51 +138,72 @@ test.describe("profile CMS Phase 5-8 browser smoke", () => {
   }, testInfo) => {
     const path = requireSmokePath("PROFILE_CMS_ROOM_PATH");
     await page.setViewportSize({ width: 390, height: 844 });
-    await gotoAndCheck(page, path);
+    const pageErrors = await gotoAndCheck(page, path);
 
     const canvas = page.locator("canvas").first();
     if (await canvas.count()) {
+      await captureSmokeScreenshot(page, testInfo, "room-mobile");
       await expectNonBlankCanvas(canvas);
     } else {
       await expect(
         page.getByText(/Room preview|Open source media/i)
       ).toBeVisible();
+      await captureSmokeScreenshot(page, testInfo, "room-mobile");
     }
-    await captureSmokeScreenshot(page, testInfo, "room-mobile");
+    await assertNoCollectedPageErrorsAfterSettle(
+      page,
+      pageErrors,
+      path,
+      "post-room assertions"
+    );
   });
 
   test("agent patch import flow keeps review and publish as separate actions", async ({
     page,
   }, testInfo) => {
     const path = requireSmokePath("PROFILE_CMS_AGENT_PATCH_PATH");
-    await gotoAndCheck(page, path);
+    const pageErrors = await gotoAndCheck(page, path);
 
     await expect(page.getByText(/patch/i)).toBeVisible();
     await expect(page.getByText(/review|validate/i)).toBeVisible();
     await expect(page.getByText(/publish/i)).toBeVisible();
     await captureSmokeScreenshot(page, testInfo, "agent-patch-review");
+    await assertNoCollectedPageErrorsAfterSettle(
+      page,
+      pageErrors,
+      path,
+      "post-agent assertions"
+    );
   });
 });
 
 function requireSmokePath(envName: string): string {
+  if (!SMOKE_ENABLED) {
+    test.skip(
+      true,
+      `Set ${RUN_SMOKE_ENV}=true to run Phase 5-8 CMS smoke coverage.`
+    );
+  }
+
   const value = process.env[envName]?.trim();
-  test.skip(
-    !SMOKE_ENABLED,
-    `Set ${RUN_SMOKE_ENV}=true to run Phase 5-8 CMS smoke coverage.`
-  );
-  test.skip(!!SMOKE_ENABLED && !value, `Set ${envName} for this smoke test.`);
-  return value ?? "/";
+  if (!value) {
+    throw new Error(
+      `Missing ${envName}; set it to a route path when ${RUN_SMOKE_ENV}=true.`
+    );
+  }
+  return value;
 }
 
-async function gotoAndCheck(page: Page, path: string): Promise<void> {
+async function gotoAndCheck(page: Page, path: string): Promise<string[]> {
   const errors = collectPageErrors(page);
   const response = await page.goto(path, { waitUntil: "networkidle" });
   expect(
     response?.ok(),
     `Expected ${path} to return a successful response.`
   ).toBe(true);
-  expect(errors, `Unexpected page errors on ${path}.`).toEqual([]);
+  await assertNoCollectedPageErrorsAfterSettle(page, errors, path, "post-load");
   await expectNoHorizontalOverflow(page);
+  return errors;
 }
 
 function collectPageErrors(page: Page): string[] {
@@ -161,13 +217,26 @@ function collectPageErrors(page: Page): string[] {
   return errors;
 }
 
+async function assertNoCollectedPageErrorsAfterSettle(
+  page: Page,
+  errors: readonly string[],
+  path: string,
+  phase: string
+): Promise<void> {
+  await page.waitForTimeout(PAGE_ERROR_SETTLE_MS);
+  expect(
+    errors,
+    `Unexpected page or console errors on ${path} (${phase}).`
+  ).toEqual([]);
+}
+
 async function expectNoHorizontalOverflow(page: Page): Promise<void> {
   const overflowPixels = await page.evaluate(
     () =>
       document.documentElement.scrollWidth -
       document.documentElement.clientWidth
   );
-  expect(overflowPixels).toBeLessThanOrEqual(1);
+  expect(overflowPixels).toBeLessThanOrEqual(HORIZONTAL_OVERFLOW_TOLERANCE_PX);
 }
 
 async function expectNonBlankCanvas(canvas: Locator): Promise<void> {
@@ -195,7 +264,7 @@ async function expectNonBlankCanvas(canvas: Locator): Promise<void> {
       );
       return {
         nonBlank: pixels.some((value) => value !== 0),
-        reason: "webgl pixels were all zero",
+        reason: `webgl pixels were all zero. ${WEBGL_READ_PIXELS_CAVEAT}`,
         width,
         height,
       };


### PR DESCRIPTION
## Issue
- Phase 5-8 CMS feature lanes need a shared QA matrix and reusable integration smoke coverage before the wallet gallery, art display, 3D room, and AI-agent branches start landing.

## Fix
- Add a living Phase 5-8 QA checklist plus fixture-driven renderer coverage and an opt-in Playwright smoke spec that can be pointed at whichever worker branch exposes each route first.

## Changes
- Adds `ops/workstreams/profile-native-cms-roadmap/phase-5-8-qa-checklist.md` and links it from the workstream README.
- Updates active context and run-log notes with the QA branch, expected worker branches, coverage prepared, validation, and remaining risks.
- Adds renderer regression coverage for wallet gallery, collection, NFT detail, mixed media, and 3D room fallback Phase 1 fixtures.
- Adds env-gated Playwright smoke coverage for builder, gallery home, collection page, NFT detail page, social metadata, 3D room canvas/mobile fallback, and agent patch review flow.

## Validation
- `seize run format:changed`
- `seize run test:no-coverage -- --testMatch "**/__tests__/components/profile-cms/CmsSiteRenderer.phase5-8.test.tsx" --runInBand`
- `seize run lint:changed`
- `seize run typecheck:changed`
- `seize run react-doctor:diff`
- `seize exec playwright test tests/profile-cms/phase5-8-smoke.spec.ts --list`
- `codex-diff-check --cached`
- Live browser smoke is intentionally not run yet because runnable Phase 5-8 worker branch routes were not available during this pass.

## Risk
- Level: Low
- Why: This is docs and test harness coverage only. The new Playwright spec is disabled unless explicit env vars opt it in.
- Rollback: Revert the commit if the QA harness conflicts with the eventual worker route contracts.

## Review Notes
- Please focus on whether the env-gated smoke paths and checklist contract watch points match the intended Phase 5-8 branch boundaries.
- This PR should remain draft until the orchestrator decides whether to merge it before or alongside the feature worker PRs.