### PR TITLE
Center quick vote videos

### DIFF
--- a/__tests__/components/drops/view/item/content/media/DropListItemContentMedia.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/DropListItemContentMedia.test.tsx
@@ -13,7 +13,12 @@ jest.mock(
 );
 jest.mock(
   "@/components/drops/view/item/content/media/DropListItemContentMediaVideo",
-  () => ({ __esModule: true, default: () => <div data-testid="video" /> })
+  () => ({
+    __esModule: true,
+    default: (props: { readonly align?: string | undefined }) => (
+      <div data-testid="video" data-align={props.align} />
+    ),
+  })
 );
 jest.mock(
   "@/components/drops/view/item/content/media/DropListItemContentMediaAudio",
@@ -63,6 +68,17 @@ describe("DropListItemContentMedia", () => {
       <DropListItemContentMedia media_mime_type="video/mp4" media_url="vid" />
     );
     expect(screen.getByTestId("video")).toBeInTheDocument();
+  });
+
+  it("forwards video alignment", () => {
+    render(
+      <DropListItemContentMedia
+        media_mime_type="video/mp4"
+        media_url="vid"
+        videoAlign="center"
+      />
+    );
+    expect(screen.getByTestId("video")).toHaveAttribute("data-align", "center");
   });
 
   it("renders audio component", () => {

--- a/__tests__/components/drops/view/item/content/media/DropListItemContentMediaVideo.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/DropListItemContentMediaVideo.test.tsx
@@ -63,6 +63,23 @@ describe("DropListItemContentMediaVideo", () => {
     expect(vid.autoplay).toBe(false); // Component uses useEffect for controlled playback
   });
 
+  it("centers the natural video player when requested", () => {
+    const ref = {
+      current: document.createElement("div"),
+    } as React.RefObject<HTMLDivElement>;
+    mockUseInView.mockReturnValue([ref, true]);
+    mockUseOptimizedVideo.mockReturnValue({
+      playableUrl: "foo.mp4",
+      isHls: false,
+    });
+
+    render(<DropListItemContentMediaVideo src="foo.mp4" align="center" />);
+
+    expect(screen.getByRole("group", { name: "Video player" })).toHaveClass(
+      "tw-mx-auto"
+    );
+  });
+
   it("renders video even when not in view (but paused)", () => {
     const ref = {
       current: document.createElement("div"),

--- a/components/brain/left-sidebar/waves/memes-quick-vote/MemesQuickVotePreview.tsx
+++ b/components/brain/left-sidebar/waves/memes-quick-vote/MemesQuickVotePreview.tsx
@@ -70,6 +70,7 @@ function getQuickVoteArtworkMediaContent({
       disableModal={hasTouchScreen}
       htmlPreviewImageUrl={htmlPreviewImageUrl}
       loadStrategy={loadStrategy}
+      videoAlign="center"
     />
   );
 }

--- a/components/drops/view/item/content/media/DropListItemContentMedia.tsx
+++ b/components/drops/view/item/content/media/DropListItemContentMedia.tsx
@@ -35,6 +35,7 @@ export default function DropListItemContentMedia({
   disableModal = false,
   disableAutoPlay = false,
   fillVideoContainer = false,
+  videoAlign,
   imageObjectPosition,
   imageScale = ImageScale.AUTOx800,
   htmlIframeContainerClassName,
@@ -48,6 +49,7 @@ export default function DropListItemContentMedia({
   readonly disableModal?: boolean | undefined;
   readonly disableAutoPlay?: boolean | undefined;
   readonly fillVideoContainer?: boolean | undefined;
+  readonly videoAlign?: "left" | "center" | undefined;
   readonly imageObjectPosition?: string | undefined;
   readonly imageScale?: ImageScale | undefined;
   readonly htmlIframeContainerClassName?: string | undefined;
@@ -104,6 +106,7 @@ export default function DropListItemContentMedia({
           mimeType={media_mime_type}
           disableAutoPlay={disableAutoPlay}
           fillContainer={fillVideoContainer}
+          align={videoAlign}
           showFullscreen={showVideoFullscreen}
         />
       );

--- a/components/drops/view/item/content/media/DropListItemContentMediaVideo.tsx
+++ b/components/drops/view/item/content/media/DropListItemContentMediaVideo.tsx
@@ -14,6 +14,7 @@ interface Props {
   readonly mimeType?: string | undefined;
   readonly disableAutoPlay?: boolean | undefined;
   readonly fillContainer?: boolean | undefined;
+  readonly align?: "left" | "center" | undefined;
   readonly showFullscreen?: boolean | undefined;
 }
 
@@ -22,6 +23,7 @@ function DropListItemContentMediaVideo({
   mimeType,
   disableAutoPlay = false,
   fillContainer = false,
+  align = "left",
   showFullscreen = true,
 }: Props) {
   const [wrapperRef, inView] = useInView<HTMLDivElement>({ threshold: 0.1 });
@@ -125,6 +127,7 @@ function DropListItemContentMediaVideo({
         videoRef={videoRef}
         autoPlay={false}
         layout={fillContainer ? "fill" : "natural"}
+        align={align}
         showFullscreen={showFullscreen}
         onDownload={downloadMedia}
         onOpen={openMedia}


### PR DESCRIPTION
## Issue
- Vertical videos in Memes quick vote render against the left edge of the preview stage.

## Fix
- Thread the existing video player alignment option through the shared drop media video renderer.
- Set quick vote media previews to request centered video alignment, which centers portrait/narrow video players while leaving full-width landscape videos visually unchanged.

## Changes
- Adds a `videoAlign` option to `DropListItemContentMedia` and forwards it to `DropListItemContentMediaVideo`.
- Applies `videoAlign="center"` in the quick vote preview renderer.
- Adds focused tests for alignment forwarding and the centered video player class.

## Validation
- `./bin/6529 run test -- __tests__/components/drops/view/item/content/media/DropListItemContentMedia.test.tsx __tests__/components/drops/view/item/content/media/DropListItemContentMediaVideo.test.tsx`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff`
- `./bin/6529 run lint:diff`
- `./bin/6529 run typecheck`
- `git diff --check`

## Risk
- Level: Low
- Why: Scoped layout-only change using an existing video player alignment prop.
- Rollback: Revert the quick vote `videoAlign` usage and prop forwarding commit.

## Review Notes
- Please focus on the quick vote video media path and whether any other media surfaces should opt into centered video alignment separately.