### PR TITLE
Translate new version toast messages

### DIFF
--- a/__tests__/components/utils/NewVersionToast.test.tsx
+++ b/__tests__/components/utils/NewVersionToast.test.tsx
@@ -14,9 +14,17 @@ jest.mock("@/hooks/useDeviceInfo", () => ({
 const mockedUseIsVersionStale = useIsVersionStale as jest.Mock;
 const mockedUseDeviceInfo = useDeviceInfo as jest.Mock;
 
+const setBrowserLanguages = (languages: readonly string[]) => {
+  Object.defineProperty(globalThis.navigator, "languages", {
+    configurable: true,
+    value: languages,
+  });
+};
+
 describe("NewVersionToast", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    setBrowserLanguages(["en-US"]);
     globalThis.history.replaceState(
       { test: true },
       "",
@@ -40,6 +48,22 @@ describe("NewVersionToast", () => {
     expect(screen.getByText("Yes, again!")).toBeInTheDocument();
     expect(container.firstChild).toHaveClass("tw-bottom-24");
     expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("uses browser locale translations for visible and accessible copy", () => {
+    setBrowserLanguages(["fr-FR"]);
+    mockedUseIsVersionStale.mockReturnValue(true);
+    mockedUseDeviceInfo.mockReturnValue({ isApp: false });
+
+    render(<NewVersionToast />);
+
+    expect(
+      screen.getByText("Une nouvelle version est disponible")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Oui, encore !")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Actualiser la page" })
+    ).toHaveAttribute("title", "Actualiser la page");
   });
 
   it("removes the forced toast query param from the current path on refresh", () => {

--- a/__tests__/i18n/messages.test.ts
+++ b/__tests__/i18n/messages.test.ts
@@ -48,6 +48,22 @@ describe("frontend i18n helpers", () => {
     expect(t("de-DE", "media.video.unsupported")).toBe(
       "Ihr Browser unterstuetzt das Video-Tag nicht."
     );
+    expect(t("en-GB", "newVersionToast.refreshAction")).toBe("Refresh page");
+    expect(t("fr-FR", "newVersionToast.title")).toBe(
+      "Une nouvelle version est disponible"
+    );
+    expect(t("fr-FR", "newVersionToast.eyebrow")).toBe("Oui, encore !");
+    expect(t("es-ES", "newVersionToast.title")).toBe(
+      "Hay una nueva versión disponible"
+    );
+    expect(t("es-ES", "newVersionToast.eyebrow")).toBe("¡Sí, otra vez!");
+    expect(t("de-DE", "newVersionToast.refreshAction")).toBe(
+      "Seite aktualisieren"
+    );
+    expect(t("de-DE", "newVersionToast.title")).toBe(
+      "Eine neue Version ist verfügbar"
+    );
+    expect(t("de-DE", "newVersionToast.eyebrow")).toBe("Ja, schon wieder!");
     expect(t("en-GB", "theMemes.sorting.sortBy")).toBe("Sort by");
     expect(t("fr-FR", "theMemes.detail.tabs.collectors")).toBe("Collectors");
     expect(t("es-ES", "theMemes.detail.heading.card", { tokenId: 1 })).toBe(

--- a/__tests__/i18n/messages.test.ts
+++ b/__tests__/i18n/messages.test.ts
@@ -13,6 +13,33 @@ import {
 } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
 
+const NEW_VERSION_TOAST_LOCALE_MESSAGES = [
+  {
+    locale: "en-GB",
+    refreshAction: "Refresh page",
+    title: "A new version is available",
+    eyebrow: "Yes, again!",
+  },
+  {
+    locale: "fr-FR",
+    refreshAction: "Actualiser la page",
+    title: "Une nouvelle version est disponible",
+    eyebrow: "Oui, encore !",
+  },
+  {
+    locale: "es-ES",
+    refreshAction: "Actualizar la página",
+    title: "Hay una nueva versión disponible",
+    eyebrow: "¡Sí, otra vez!",
+  },
+  {
+    locale: "de-DE",
+    refreshAction: "Seite aktualisieren",
+    title: "Eine neue Version ist verfügbar",
+    eyebrow: "Ja, schon wieder!",
+  },
+] as const;
+
 describe("frontend i18n helpers", () => {
   it("defines the initial supported locale set", () => {
     expect(DEFAULT_LOCALE).toBe("en-US");
@@ -48,22 +75,15 @@ describe("frontend i18n helpers", () => {
     expect(t("de-DE", "media.video.unsupported")).toBe(
       "Ihr Browser unterstuetzt das Video-Tag nicht."
     );
-    expect(t("en-GB", "newVersionToast.refreshAction")).toBe("Refresh page");
-    expect(t("fr-FR", "newVersionToast.title")).toBe(
-      "Une nouvelle version est disponible"
-    );
-    expect(t("fr-FR", "newVersionToast.eyebrow")).toBe("Oui, encore !");
-    expect(t("es-ES", "newVersionToast.title")).toBe(
-      "Hay una nueva versión disponible"
-    );
-    expect(t("es-ES", "newVersionToast.eyebrow")).toBe("¡Sí, otra vez!");
-    expect(t("de-DE", "newVersionToast.refreshAction")).toBe(
-      "Seite aktualisieren"
-    );
-    expect(t("de-DE", "newVersionToast.title")).toBe(
-      "Eine neue Version ist verfügbar"
-    );
-    expect(t("de-DE", "newVersionToast.eyebrow")).toBe("Ja, schon wieder!");
+    for (const messages of NEW_VERSION_TOAST_LOCALE_MESSAGES) {
+      expect(t(messages.locale, "newVersionToast.refreshAction")).toBe(
+        messages.refreshAction
+      );
+      expect(t(messages.locale, "newVersionToast.title")).toBe(messages.title);
+      expect(t(messages.locale, "newVersionToast.eyebrow")).toBe(
+        messages.eyebrow
+      );
+    }
     expect(t("en-GB", "theMemes.sorting.sortBy")).toBe("Sort by");
     expect(t("fr-FR", "theMemes.detail.tabs.collectors")).toBe("Collectors");
     expect(t("es-ES", "theMemes.detail.heading.card", { tokenId: 1 })).toBe(

--- a/i18n/messages/de-DE.ts
+++ b/i18n/messages/de-DE.ts
@@ -14,6 +14,9 @@ export const DE_DE_MESSAGES = {
   "media.video.unmute": "Videoton einschalten",
   "media.video.unsupported":
     "Ihr Browser unterstuetzt das Video-Tag nicht.",
+  "newVersionToast.refreshAction": "Seite aktualisieren",
+  "newVersionToast.title": "Eine neue Version ist verfügbar",
+  "newVersionToast.eyebrow": "Ja, schon wieder!",
   "theMemes.documentTitle": "The Memes | Sammlungen",
   "theMemes.description.collections": "Sammlungen",
   "theMemes.sorting.regionLabel": "Meme-Sortierung",

--- a/i18n/messages/de-DE.ts
+++ b/i18n/messages/de-DE.ts
@@ -1,3 +1,4 @@
+import { DE_DE_NEW_VERSION_TOAST_MESSAGES } from "@/i18n/messages/new-version-toast";
 import type { MessageKey } from "@/i18n/messages/en-US";
 
 export const DE_DE_MESSAGES = {
@@ -14,9 +15,7 @@ export const DE_DE_MESSAGES = {
   "media.video.unmute": "Videoton einschalten",
   "media.video.unsupported":
     "Ihr Browser unterstuetzt das Video-Tag nicht.",
-  "newVersionToast.refreshAction": "Seite aktualisieren",
-  "newVersionToast.title": "Eine neue Version ist verfügbar",
-  "newVersionToast.eyebrow": "Ja, schon wieder!",
+  ...DE_DE_NEW_VERSION_TOAST_MESSAGES,
   "theMemes.documentTitle": "The Memes | Sammlungen",
   "theMemes.description.collections": "Sammlungen",
   "theMemes.sorting.regionLabel": "Meme-Sortierung",

--- a/i18n/messages/en-GB.ts
+++ b/i18n/messages/en-GB.ts
@@ -13,6 +13,9 @@ export const EN_GB_MESSAGES = {
   "media.video.playPreview": "Play video preview",
   "media.video.unmute": "Unmute video",
   "media.video.unsupported": "Your browser does not support the video tag.",
+  "newVersionToast.refreshAction": "Refresh page",
+  "newVersionToast.title": "A new version is available",
+  "newVersionToast.eyebrow": "Yes, again!",
   "theMemes.documentTitle": "The Memes | Collections",
   "theMemes.description.collections": "Collections",
 } satisfies Partial<Record<MessageKey, string>>;

--- a/i18n/messages/en-GB.ts
+++ b/i18n/messages/en-GB.ts
@@ -1,3 +1,4 @@
+import { EN_GB_NEW_VERSION_TOAST_MESSAGES } from "@/i18n/messages/new-version-toast";
 import type { MessageKey } from "@/i18n/messages/en-US";
 
 export const EN_GB_MESSAGES = {
@@ -13,9 +14,7 @@ export const EN_GB_MESSAGES = {
   "media.video.playPreview": "Play video preview",
   "media.video.unmute": "Unmute video",
   "media.video.unsupported": "Your browser does not support the video tag.",
-  "newVersionToast.refreshAction": "Refresh page",
-  "newVersionToast.title": "A new version is available",
-  "newVersionToast.eyebrow": "Yes, again!",
+  ...EN_GB_NEW_VERSION_TOAST_MESSAGES,
   "theMemes.documentTitle": "The Memes | Collections",
   "theMemes.description.collections": "Collections",
 } satisfies Partial<Record<MessageKey, string>>;

--- a/i18n/messages/es-ES.ts
+++ b/i18n/messages/es-ES.ts
@@ -1,3 +1,4 @@
+import { ES_ES_NEW_VERSION_TOAST_MESSAGES } from "@/i18n/messages/new-version-toast";
 import type { MessageKey } from "@/i18n/messages/en-US";
 
 export const ES_ES_MESSAGES = {
@@ -14,9 +15,7 @@ export const ES_ES_MESSAGES = {
   "media.video.unmute": "Activar sonido del video",
   "media.video.unsupported":
     "Tu navegador no admite la etiqueta de video.",
-  "newVersionToast.refreshAction": "Actualizar la página",
-  "newVersionToast.title": "Hay una nueva versión disponible",
-  "newVersionToast.eyebrow": "¡Sí, otra vez!",
+  ...ES_ES_NEW_VERSION_TOAST_MESSAGES,
   "theMemes.documentTitle": "The Memes | Colecciones",
   "theMemes.description.collections": "Colecciones",
   "theMemes.sorting.regionLabel": "Orden de memes",

--- a/i18n/messages/es-ES.ts
+++ b/i18n/messages/es-ES.ts
@@ -14,6 +14,9 @@ export const ES_ES_MESSAGES = {
   "media.video.unmute": "Activar sonido del video",
   "media.video.unsupported":
     "Tu navegador no admite la etiqueta de video.",
+  "newVersionToast.refreshAction": "Actualizar la página",
+  "newVersionToast.title": "Hay una nueva versión disponible",
+  "newVersionToast.eyebrow": "¡Sí, otra vez!",
   "theMemes.documentTitle": "The Memes | Colecciones",
   "theMemes.description.collections": "Colecciones",
   "theMemes.sorting.regionLabel": "Orden de memes",

--- a/i18n/messages/fr-FR.ts
+++ b/i18n/messages/fr-FR.ts
@@ -14,6 +14,9 @@ export const FR_FR_MESSAGES = {
   "media.video.unmute": "Activer le son de la video",
   "media.video.unsupported":
     "Votre navigateur ne prend pas en charge la balise video.",
+  "newVersionToast.refreshAction": "Actualiser la page",
+  "newVersionToast.title": "Une nouvelle version est disponible",
+  "newVersionToast.eyebrow": "Oui, encore !",
   "theMemes.documentTitle": "The Memes | Collections",
   "theMemes.description.collections": "Collections",
   "theMemes.sorting.regionLabel": "Tri des memes",

--- a/i18n/messages/fr-FR.ts
+++ b/i18n/messages/fr-FR.ts
@@ -1,3 +1,4 @@
+import { FR_FR_NEW_VERSION_TOAST_MESSAGES } from "@/i18n/messages/new-version-toast";
 import type { MessageKey } from "@/i18n/messages/en-US";
 
 export const FR_FR_MESSAGES = {
@@ -14,9 +15,7 @@ export const FR_FR_MESSAGES = {
   "media.video.unmute": "Activer le son de la video",
   "media.video.unsupported":
     "Votre navigateur ne prend pas en charge la balise video.",
-  "newVersionToast.refreshAction": "Actualiser la page",
-  "newVersionToast.title": "Une nouvelle version est disponible",
-  "newVersionToast.eyebrow": "Oui, encore !",
+  ...FR_FR_NEW_VERSION_TOAST_MESSAGES,
   "theMemes.documentTitle": "The Memes | Collections",
   "theMemes.description.collections": "Collections",
   "theMemes.sorting.regionLabel": "Tri des memes",

--- a/i18n/messages/new-version-toast.ts
+++ b/i18n/messages/new-version-toast.ts
@@ -1,0 +1,40 @@
+import type { MessageKey } from "@/i18n/messages/en-US";
+
+const NEW_VERSION_TOAST_MESSAGE_KEYS = [
+  "newVersionToast.refreshAction",
+  "newVersionToast.title",
+  "newVersionToast.eyebrow",
+] as const satisfies readonly MessageKey[];
+
+type NewVersionToastMessageKey = (typeof NEW_VERSION_TOAST_MESSAGE_KEYS)[number];
+
+const buildNewVersionToastMessages = (
+  values: readonly [string, string, string]
+): Record<NewVersionToastMessageKey, string> =>
+  Object.fromEntries(
+    NEW_VERSION_TOAST_MESSAGE_KEYS.map((key, index) => [key, values[index]])
+  ) as Record<NewVersionToastMessageKey, string>;
+
+export const EN_GB_NEW_VERSION_TOAST_MESSAGES = buildNewVersionToastMessages([
+  "Refresh page",
+  "A new version is available",
+  "Yes, again!",
+]);
+
+export const FR_FR_NEW_VERSION_TOAST_MESSAGES = buildNewVersionToastMessages([
+  "Actualiser la page",
+  "Une nouvelle version est disponible",
+  "Oui, encore !",
+]);
+
+export const ES_ES_NEW_VERSION_TOAST_MESSAGES = buildNewVersionToastMessages([
+  "Actualizar la página",
+  "Hay una nueva versión disponible",
+  "¡Sí, otra vez!",
+]);
+
+export const DE_DE_NEW_VERSION_TOAST_MESSAGES = buildNewVersionToastMessages([
+  "Seite aktualisieren",
+  "Eine neue Version ist verfügbar",
+  "Ja, schon wieder!",
+]);


### PR DESCRIPTION
## Summary
- add `newVersionToast` translations for `en-GB`, `fr-FR`, `es-ES`, and `de-DE`
- cover the translated toast messages in the central i18n helper test

## Validation
- `./bin/6529 install`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run test -- __tests__/i18n/messages.test.ts --runInBand` reported `PASS`; Jest stayed open during teardown and was interrupted after the pass result

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Localization**
  * Added localized “new version available” toast strings (refresh action, title, and eyebrow text) for English (GB), French, Spanish, and German.
* **Tests**
  * Extended i18n coverage to validate the new toast keys for each supported locale.
  * Updated toast UI tests to confirm locale-specific text and accessible button labeling by stubbing browser language settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->