### PR TITLE
Improve video controls and seeking

### DIFF
--- a/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
@@ -420,7 +420,7 @@ describe("SeizeVideoPlayer", () => {
   it("toggles minimal playback from video clicks", () => {
     let paused = false;
     const { container } = render(
-      <SeizeVideoPlayer src="https://example.com/video.mp4" autoPlay />
+      <SeizeVideoPlayer src="https://example.com/video.mp4" autoPlay={false} />
     );
     const video = container.querySelector("video");
     if (!video) {
@@ -430,15 +430,27 @@ describe("SeizeVideoPlayer", () => {
       configurable: true,
       get: () => paused,
     });
+    fireEvent.play(video);
+
+    const pauseCallsBeforeClick = jest.mocked(
+      HTMLMediaElement.prototype.pause
+    ).mock.calls.length;
 
     fireEvent.click(video);
 
-    expect(HTMLMediaElement.prototype.pause).toHaveBeenCalled();
+    expect(HTMLMediaElement.prototype.pause).toHaveBeenCalledTimes(
+      pauseCallsBeforeClick + 1
+    );
 
     paused = true;
+    const playCallsBeforeClick = jest.mocked(HTMLMediaElement.prototype.play)
+      .mock.calls.length;
+
     fireEvent.click(video);
 
-    expect(HTMLMediaElement.prototype.play).toHaveBeenCalled();
+    expect(HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(
+      playCallsBeforeClick + 1
+    );
   });
 
   it("does not toggle playback from native-control video clicks", () => {

--- a/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
@@ -407,6 +407,87 @@ describe("SeizeVideoPlayer", () => {
     expect(HTMLMediaElement.prototype.play).toHaveBeenCalled();
   });
 
+  it("places minimal playback on the left and mute on the right", () => {
+    render(<SeizeVideoPlayer src="https://example.com/video.mp4" autoPlay />);
+
+    const pauseButton = screen.getByRole("button", { name: "Pause video" });
+    const muteButton = screen.getByRole("button", { name: "Unmute video" });
+
+    expect(pauseButton.parentElement).toHaveClass("tw-left-3");
+    expect(muteButton.parentElement).toHaveClass("tw-right-3");
+  });
+
+  it("toggles minimal playback from video clicks", () => {
+    let paused = false;
+    const { container } = render(
+      <SeizeVideoPlayer src="https://example.com/video.mp4" autoPlay />
+    );
+    const video = container.querySelector("video");
+    if (!video) {
+      throw new Error("Expected video element to render");
+    }
+    Object.defineProperty(video, "paused", {
+      configurable: true,
+      get: () => paused,
+    });
+
+    fireEvent.click(video);
+
+    expect(HTMLMediaElement.prototype.pause).toHaveBeenCalled();
+
+    paused = true;
+    fireEvent.click(video);
+
+    expect(HTMLMediaElement.prototype.play).toHaveBeenCalled();
+  });
+
+  it("does not toggle playback from native-control video clicks", () => {
+    const { container } = render(
+      <SeizeVideoPlayer
+        src="https://example.com/video.mp4"
+        template="watch-media"
+      />
+    );
+    const video = container.querySelector("video");
+    if (!video) {
+      throw new Error("Expected video element to render");
+    }
+    Object.defineProperty(video, "paused", {
+      configurable: true,
+      value: false,
+    });
+
+    fireEvent.click(video);
+
+    expect(HTMLMediaElement.prototype.pause).not.toHaveBeenCalled();
+    expect(HTMLMediaElement.prototype.play).not.toHaveBeenCalled();
+  });
+
+  it("seeks minimal videos from the footer timeline", () => {
+    const { container } = render(
+      <SeizeVideoPlayer src="https://example.com/video.mp4" />
+    );
+    const video = container.querySelector("video");
+    if (!video) {
+      throw new Error("Expected video element to render");
+    }
+    Object.defineProperty(video, "duration", {
+      configurable: true,
+      value: 200,
+    });
+    video.currentTime = 0;
+
+    fireEvent.durationChange(video);
+
+    const seek = screen.getByRole("slider", { name: "Seek video" });
+    expect(seek).not.toBeDisabled();
+
+    fireEvent.change(seek, { target: { value: "25" } });
+
+    expect(video.currentTime).toBe(50);
+    expect(seek).toHaveValue("25");
+  });
+
   it("uses native controls for watch media and suppresses custom controls", () => {
     const { container } = render(
       <SeizeVideoPlayer

--- a/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
@@ -463,6 +463,12 @@ describe("SeizeVideoPlayer", () => {
     expect(HTMLMediaElement.prototype.play).not.toHaveBeenCalled();
   });
 
+  it("keeps footer seeking disabled until duration is known", () => {
+    render(<SeizeVideoPlayer src="https://example.com/video.mp4" />);
+
+    expect(screen.getByRole("slider", { name: "Seek video" })).toBeDisabled();
+  });
+
   it("seeks minimal videos from the footer timeline", () => {
     const { container } = render(
       <SeizeVideoPlayer src="https://example.com/video.mp4" />
@@ -482,10 +488,23 @@ describe("SeizeVideoPlayer", () => {
     const seek = screen.getByRole("slider", { name: "Seek video" });
     expect(seek).not.toBeDisabled();
 
+    jest.mocked(HTMLMediaElement.prototype.pause).mockClear();
+    jest.mocked(HTMLMediaElement.prototype.play).mockClear();
+
+    fireEvent.click(seek);
+
+    expect(HTMLMediaElement.prototype.pause).not.toHaveBeenCalled();
+    expect(HTMLMediaElement.prototype.play).not.toHaveBeenCalled();
+
     fireEvent.change(seek, { target: { value: "25" } });
 
     expect(video.currentTime).toBe(50);
     expect(seek).toHaveValue("25");
+
+    video.currentTime = 100;
+    fireEvent.seeked(video);
+
+    expect(seek).toHaveValue("50");
   });
 
   it("uses native controls for watch media and suppresses custom controls", () => {

--- a/__tests__/i18n/messages.test.ts
+++ b/__tests__/i18n/messages.test.ts
@@ -42,6 +42,7 @@ describe("frontend i18n helpers", () => {
     expect(t("de-DE", "theMemes.documentTitle")).toBe("The Memes | Sammlungen");
     expect(t("en-US", "media.video.playPreview")).toBe("Play video preview");
     expect(t("en-US", "media.video.player")).toBe("Video player");
+    expect(t("en-US", "media.video.seek")).toBe("Seek video");
     expect(t("en-GB", "media.video.exitFullscreen")).toBe("Exit full screen");
     expect(t("fr-FR", "media.video.play")).toBe("Lire la video");
     expect(t("es-ES", "media.video.fullscreen")).toBe("Pantalla completa");

--- a/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
+++ b/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
@@ -134,6 +134,7 @@ interface SeizeVideoLabels {
   readonly play: string;
   readonly player: string;
   readonly playPreview: string;
+  readonly seek: string;
   readonly unmute: string;
   readonly unsupported: string;
 }
@@ -178,8 +179,10 @@ function SeizeVideoMinimalControls({
   onMuteClick,
   onOpenClick,
   onPlaybackClick,
+  onSeekChange,
   openLabel,
   progress,
+  seekDisabled,
   showControls,
   showActions,
   showFullscreen,
@@ -203,8 +206,10 @@ function SeizeVideoMinimalControls({
   readonly onPlaybackClick: (
     event: React.MouseEvent<HTMLButtonElement>
   ) => void;
+  readonly onSeekChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   readonly openLabel?: string | undefined;
   readonly progress: number;
+  readonly seekDisabled: boolean;
   readonly showControls: boolean;
   readonly showActions: boolean;
   readonly showFullscreen: boolean;
@@ -247,6 +252,24 @@ function SeizeVideoMinimalControls({
             "tw-absolute tw-bottom-4 tw-left-3"
           )}
         >
+          {!isPaused && (
+            <SeizeVideoControlButton
+              label={labels.pause}
+              onClick={onPlaybackClick}
+              onFocus={onControlsFocus}
+              tabIndex={controlsTabIndex}
+            >
+              <PauseIcon className="tw-size-5" aria-hidden="true" />
+            </SeizeVideoControlButton>
+          )}
+        </div>
+
+        <div
+          className={clsx(
+            controlsHitTestClass,
+            "tw-absolute tw-bottom-4 tw-right-3 tw-flex tw-items-center tw-gap-2"
+          )}
+        >
           <SeizeVideoControlButton
             label={isMuted ? labels.unmute : labels.mute}
             onClick={onMuteClick}
@@ -259,24 +282,6 @@ function SeizeVideoMinimalControls({
               <SpeakerWaveIcon className="tw-size-5" aria-hidden="true" />
             )}
           </SeizeVideoControlButton>
-        </div>
-
-        <div
-          className={clsx(
-            controlsHitTestClass,
-            "tw-absolute tw-bottom-4 tw-right-3 tw-flex tw-items-center tw-gap-2"
-          )}
-        >
-          {!isPaused && (
-            <SeizeVideoControlButton
-              label={labels.pause}
-              onClick={onPlaybackClick}
-              onFocus={onControlsFocus}
-              tabIndex={controlsTabIndex}
-            >
-              <PauseIcon className="tw-size-5" aria-hidden="true" />
-            </SeizeVideoControlButton>
-          )}
           {showActions && onOpenClick && openLabel && (
             <SeizeVideoControlButton
               label={openLabel}
@@ -325,13 +330,29 @@ function SeizeVideoMinimalControls({
       </div>
 
       <div
-        className="tw-pointer-events-none tw-absolute tw-bottom-0 tw-left-0 tw-right-0 tw-z-30 tw-h-1 tw-bg-white/20"
-        aria-hidden="true"
+        className="tw-absolute tw-bottom-0 tw-left-0 tw-right-0 tw-z-30 tw-h-4 tw-overflow-hidden"
       >
-        <div
-          className="tw-h-full tw-bg-primary-400"
-          style={{ width: `${progress}%` }}
+        <input
+          type="range"
+          min="0"
+          max="100"
+          step="0.1"
+          value={Number.isFinite(progress) ? progress : 0}
+          disabled={seekDisabled}
+          aria-label={labels.seek}
+          onChange={onSeekChange}
+          onFocus={onControlsFocus}
+          className="tw-peer tw-absolute tw-inset-0 tw-z-10 tw-h-full tw-w-full tw-cursor-pointer tw-opacity-0 disabled:tw-cursor-default"
         />
+        <div
+          aria-hidden="true"
+          className="tw-pointer-events-none tw-absolute tw-bottom-0 tw-left-0 tw-right-0 tw-h-1 tw-bg-white/20 peer-focus-visible:tw-outline peer-focus-visible:tw-outline-2 peer-focus-visible:tw-outline-offset-2 peer-focus-visible:tw-outline-primary-400"
+        >
+          <div
+            className="tw-h-full tw-bg-primary-400"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
       </div>
     </>
   );
@@ -501,6 +522,7 @@ export default function SeizeVideoPlayer({
   "data-disable": dataDisable,
 }: SeizeVideoPlayerProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const internalVideoRef = useRef<HTMLVideoElement | null>(null);
   const hideControlsTimerRef = useRef<number | null>(null);
   const animationFrameRef = useRef<number | null>(null);
   const [wrapperElement, setWrapperElement] = useState<HTMLDivElement | null>(
@@ -532,7 +554,14 @@ export default function SeizeVideoPlayer({
   }>({});
   const [isPaused, setIsPaused] = useState(!resolvedTemplate.autoPlay);
   const [controlsVisible, setControlsVisible] = useState(true);
-  const [progress, setProgress] = useState(0);
+  const [progressState, setProgressState] = useState<{
+    readonly src?: string | undefined;
+    readonly value: number;
+  }>({ value: 0 });
+  const [durationState, setDurationState] = useState<{
+    readonly src?: string | undefined;
+    readonly value: number;
+  }>({ value: 0 });
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [isNativeFullscreen, setIsNativeFullscreen] = useState(false);
   const [openPosterGateKey, setOpenPosterGateKey] = useState<string | null>(
@@ -564,6 +593,8 @@ export default function SeizeVideoPlayer({
     return Array.from(new Set(sources));
   }, [fallbackSources, src]);
   const isInView = useElementInView(wrapperElement);
+  const directSrc =
+    fallbackState.originSrc === src ? (fallbackState.source ?? src) : src;
 
   const setWrapperRef = useCallback((element: HTMLDivElement | null) => {
     wrapperRef.current = element;
@@ -571,6 +602,7 @@ export default function SeizeVideoPlayer({
   }, []);
   const setVideoRef = useCallback(
     (element: HTMLVideoElement | null) => {
+      internalVideoRef.current = element;
       assignRef(videoRef, element);
       setVideoElement(element);
     },
@@ -612,10 +644,27 @@ export default function SeizeVideoPlayer({
   function updateProgress() {
     const video = videoElement;
     if (!video || !Number.isFinite(video.duration) || video.duration <= 0) {
-      setProgress(0);
+      setDurationState((current) =>
+        current.src === directSrc && current.value === 0
+          ? current
+          : { src: directSrc, value: 0 }
+      );
+      setProgressState((current) =>
+        current.src === directSrc && current.value === 0
+          ? current
+          : { src: directSrc, value: 0 }
+      );
       return;
     }
-    setProgress(Math.min(100, (video.currentTime / video.duration) * 100));
+    setDurationState((current) =>
+      current.src === directSrc && current.value === video.duration
+        ? current
+        : { src: directSrc, value: video.duration }
+    );
+    setProgressState({
+      src: directSrc,
+      value: Math.min(100, (video.currentTime / video.duration) * 100),
+    });
   }
 
   function stopProgressAnimation() {
@@ -756,6 +805,18 @@ export default function SeizeVideoPlayer({
     video.pause();
   }
 
+  function seekToProgress(nextProgress: number) {
+    const video = internalVideoRef.current;
+    if (!video || !Number.isFinite(video.duration) || video.duration <= 0) {
+      return;
+    }
+
+    const clampedProgress = Math.min(100, Math.max(0, nextProgress));
+    video.currentTime = (clampedProgress / 100) * video.duration;
+    setProgressState({ src: directSrc, value: clampedProgress });
+    revealControls();
+  }
+
   function toggleMuted(event: React.MouseEvent<HTMLButtonElement>) {
     event.preventDefault();
     event.stopPropagation();
@@ -809,9 +870,16 @@ export default function SeizeVideoPlayer({
   }
 
   function handleVideoClick(event: React.MouseEvent<HTMLVideoElement>) {
-    event.preventDefault();
     event.stopPropagation();
     onVideoClick?.(event);
+
+    if (!showMinimalControls || event.defaultPrevented) {
+      return;
+    }
+
+    event.preventDefault();
+    togglePlayback();
+    revealControls();
   }
 
   function openPosterGate(event: React.MouseEvent<HTMLButtonElement>) {
@@ -916,8 +984,11 @@ export default function SeizeVideoPlayer({
   const isWrapperFullscreen = isFullscreen;
   const controlsAreVisible = controlsVisible || isPaused || isAnyFullscreen;
   const responsiveMediaStyle = getResponsiveMediaStyle();
-  const directSrc =
-    fallbackState.originSrc === src ? (fallbackState.source ?? src) : src;
+  const duration =
+    durationState.src === directSrc ? durationState.value : 0;
+  const progress =
+    progressState.src === directSrc ? progressState.value : 0;
+  const seekDisabled = duration <= 0;
   const hasUserPausedOwnedAutoplay = userPausedAutoplaySrc === directSrc;
   const labels = useMemo<SeizeVideoLabels>(
     () => ({
@@ -931,6 +1002,7 @@ export default function SeizeVideoPlayer({
       play: t(locale, "media.video.play"),
       player: t(locale, "media.video.player"),
       playPreview: t(locale, "media.video.playPreview"),
+      seek: t(locale, "media.video.seek"),
       unmute: t(locale, "media.video.unmute"),
       unsupported: t(locale, "media.video.unsupported"),
     }),
@@ -1053,8 +1125,12 @@ export default function SeizeVideoPlayer({
             togglePlayback();
             revealControls();
           }}
+          onSeekChange={(event) => {
+            seekToProgress(Number(event.currentTarget.value));
+          }}
           openLabel={openLabel}
           progress={progress}
+          seekDisabled={seekDisabled}
           showControls={controlsAreVisible}
           showActions={showActions}
           showFullscreen={showFullscreen}

--- a/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
+++ b/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
@@ -337,11 +337,15 @@ function SeizeVideoMinimalControls({
           min="0"
           max="100"
           step="0.1"
-          value={Number.isFinite(progress) ? progress : 0}
+          value={progress}
           disabled={seekDisabled}
           aria-label={labels.seek}
           onChange={onSeekChange}
+          onClick={(event) => event.stopPropagation()}
           onFocus={onControlsFocus}
+          onPointerDown={(event) => event.stopPropagation()}
+          onPointerUp={(event) => event.stopPropagation()}
+          onTouchStart={(event) => event.stopPropagation()}
           className="tw-peer tw-absolute tw-inset-0 tw-z-10 tw-h-full tw-w-full tw-cursor-pointer tw-opacity-0 disabled:tw-cursor-default"
         />
         <div
@@ -384,6 +388,8 @@ function SeizeVideoElement({
   onPointerEnter,
   onPointerLeave,
   onPointerMove,
+  onSeeked,
+  onSeeking,
   onTimeUpdate,
   onTouchStart,
   poster,
@@ -420,6 +426,8 @@ function SeizeVideoElement({
   readonly onPointerEnter?: (() => void) | undefined;
   readonly onPointerLeave?: (() => void) | undefined;
   readonly onPointerMove?: (() => void) | undefined;
+  readonly onSeeked: () => void;
+  readonly onSeeking: () => void;
   readonly onTimeUpdate: () => void;
   readonly onTouchStart?: (() => void) | undefined;
   readonly poster?: string | undefined;
@@ -455,6 +463,8 @@ function SeizeVideoElement({
         onEnded={onEnded}
         onError={onError}
         onFocus={onFocus}
+        onSeeked={onSeeked}
+        onSeeking={onSeeking}
         onClick={onClick}
         onPointerEnter={onPointerEnter}
         onPointerMove={onPointerMove}
@@ -622,7 +632,7 @@ export default function SeizeVideoPlayer({
     }
     clearHideControlsTimer();
     hideControlsTimerRef.current = globalThis.window.setTimeout(() => {
-      const video = videoElement;
+      const video = internalVideoRef.current;
       const activeElement = globalThis.document.activeElement;
       const playerHasFocus = activeElement
         ? (wrapperRef.current?.contains(activeElement) ?? false)
@@ -642,7 +652,7 @@ export default function SeizeVideoPlayer({
   }
 
   function updateProgress() {
-    const video = videoElement;
+    const video = internalVideoRef.current;
     if (!video || !Number.isFinite(video.duration) || video.duration <= 0) {
       setDurationState((current) =>
         current.src === directSrc && current.value === 0
@@ -678,7 +688,7 @@ export default function SeizeVideoPlayer({
     stopProgressAnimation();
     const tick = () => {
       updateProgress();
-      const video = videoElement;
+      const video = internalVideoRef.current;
       if (video && !video.paused && !video.ended) {
         animationFrameRef.current = globalThis.window.requestAnimationFrame(tick);
       }
@@ -787,7 +797,7 @@ export default function SeizeVideoPlayer({
   }
 
   function togglePlayback() {
-    const video = videoElement;
+    const video = internalVideoRef.current;
     if (!video) return;
 
     if (video.paused || video.ended) {
@@ -814,6 +824,7 @@ export default function SeizeVideoPlayer({
     const clampedProgress = Math.min(100, Math.max(0, nextProgress));
     video.currentTime = (clampedProgress / 100) * video.duration;
     setProgressState({ src: directSrc, value: clampedProgress });
+    updateProgress();
     revealControls();
   }
 
@@ -1082,6 +1093,8 @@ export default function SeizeVideoPlayer({
         onPointerEnter={minimalVideoHandlers.onPointerEnter}
         onPointerLeave={minimalVideoHandlers.onPointerLeave}
         onPointerMove={minimalVideoHandlers.onPointerMove}
+        onSeeked={updateProgress}
+        onSeeking={updateProgress}
         onTimeUpdate={updateProgress}
         onTouchStart={minimalVideoHandlers.onTouchStart}
         poster={poster}

--- a/i18n/messages/de-DE.ts
+++ b/i18n/messages/de-DE.ts
@@ -11,7 +11,7 @@ export const DE_DE_MESSAGES = {
   "media.video.play": "Video abspielen",
   "media.video.player": "Videoplayer",
   "media.video.playPreview": "Videovorschau abspielen",
-  "media.video.seek": "Video durchsuchen",
+  "media.video.seek": "Videoposition andern",
   "media.video.unmute": "Videoton einschalten",
   "media.video.unsupported":
     "Ihr Browser unterstuetzt das Video-Tag nicht.",

--- a/i18n/messages/de-DE.ts
+++ b/i18n/messages/de-DE.ts
@@ -11,6 +11,7 @@ export const DE_DE_MESSAGES = {
   "media.video.play": "Video abspielen",
   "media.video.player": "Videoplayer",
   "media.video.playPreview": "Videovorschau abspielen",
+  "media.video.seek": "Video durchsuchen",
   "media.video.unmute": "Videoton einschalten",
   "media.video.unsupported":
     "Ihr Browser unterstuetzt das Video-Tag nicht.",

--- a/i18n/messages/en-GB.ts
+++ b/i18n/messages/en-GB.ts
@@ -11,6 +11,7 @@ export const EN_GB_MESSAGES = {
   "media.video.play": "Play video",
   "media.video.player": "Video player",
   "media.video.playPreview": "Play video preview",
+  "media.video.seek": "Seek video",
   "media.video.unmute": "Unmute video",
   "media.video.unsupported": "Your browser does not support the video tag.",
   "theMemes.documentTitle": "The Memes | Collections",

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -684,6 +684,7 @@ const MEDIA_VIDEO_MESSAGES = namespaceMessages("media.video", [
   ["play", "Play video"],
   ["player", "Video player"],
   ["playPreview", "Play video preview"],
+  ["seek", "Seek video"],
   ["unmute", "Unmute video"],
   ["unsupported", "Your browser does not support the video tag."],
 ] as const);

--- a/i18n/messages/es-ES.ts
+++ b/i18n/messages/es-ES.ts
@@ -11,7 +11,7 @@ export const ES_ES_MESSAGES = {
   "media.video.play": "Reproducir video",
   "media.video.player": "Reproductor de video",
   "media.video.playPreview": "Reproducir vista previa del video",
-  "media.video.seek": "Buscar en el video",
+  "media.video.seek": "Cambiar la posicion del video",
   "media.video.unmute": "Activar sonido del video",
   "media.video.unsupported":
     "Tu navegador no admite la etiqueta de video.",

--- a/i18n/messages/es-ES.ts
+++ b/i18n/messages/es-ES.ts
@@ -11,6 +11,7 @@ export const ES_ES_MESSAGES = {
   "media.video.play": "Reproducir video",
   "media.video.player": "Reproductor de video",
   "media.video.playPreview": "Reproducir vista previa del video",
+  "media.video.seek": "Buscar en el video",
   "media.video.unmute": "Activar sonido del video",
   "media.video.unsupported":
     "Tu navegador no admite la etiqueta de video.",

--- a/i18n/messages/fr-FR.ts
+++ b/i18n/messages/fr-FR.ts
@@ -11,6 +11,7 @@ export const FR_FR_MESSAGES = {
   "media.video.play": "Lire la video",
   "media.video.player": "Lecteur video",
   "media.video.playPreview": "Lire l'apercu video",
+  "media.video.seek": "Parcourir la video",
   "media.video.unmute": "Activer le son de la video",
   "media.video.unsupported":
     "Votre navigateur ne prend pas en charge la balise video.",

--- a/i18n/messages/fr-FR.ts
+++ b/i18n/messages/fr-FR.ts
@@ -11,7 +11,7 @@ export const FR_FR_MESSAGES = {
   "media.video.play": "Lire la video",
   "media.video.player": "Lecteur video",
   "media.video.playPreview": "Lire l'apercu video",
-  "media.video.seek": "Parcourir la video",
+  "media.video.seek": "Modifier la position de la video",
   "media.video.unmute": "Activer le son de la video",
   "media.video.unsupported":
     "Votre navigateur ne prend pas en charge la balise video.",


### PR DESCRIPTION
## Issue
- Custom video controls put mute on the left and play/pause on the right, which is backwards from the requested layout.
- Minimal-control videos did not toggle play/pause when the user clicked the video surface.
- The footer progress bar was display-only, so users could not click or drag it to seek.

## Fix
- Move the minimal playback control to the left control zone and move mute into the right control zone.
- Let clicks on minimal-control video surfaces toggle playback while leaving native-control videos on the browser/native path.
- Replace the display-only footer progress strip with a seekable range input over the same visual timeline.

## Changes
- Updated `SeizeVideoPlayer` minimal controls, progress state, and video click handling.
- Added a localized `media.video.seek` accessible label across locale dictionaries.
- Added focused tests for control placement, video-surface playback toggling, native-control click isolation, and footer seeking.

## Validation
- `./bin/6529 run test:no-coverage -- __tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx __tests__/i18n/messages.test.ts`
- `./bin/6529 run lint:diff`
- `./bin/6529 run typecheck:ci`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` passed before commit with existing large-component warnings only. After commit, the repo script skipped because it only saw uncommitted source changes in this setup.
- `git diff --check`

## Risk
- Level: Low
- Why: The change is scoped to the shared custom minimal controls and localized labels. Native controls remain native, and `playsInline`/mobile video attributes are unchanged for iOS/Android app behavior.
- Rollback: Revert this PR to restore the previous minimal-control layout and display-only progress strip.

## Review Notes
- Please focus on the custom minimal controls in ambient video surfaces and the native-control guard for mobile/browser-owned controls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a seek slider to the video player's minimal controls interface, enabling playback scrubbing with keyboard accessibility support
  * Added multi-language translations for the new seek feature (German, English GB/US, Spanish, French)

* **Tests**
  * Expanded test coverage for video player minimal controls seek behavior
  * Added i18n message key validation tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->