### PR TITLE
[codex] Polish wave trust and REP details

### DIFF
--- a/__tests__/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.test.tsx
+++ b/__tests__/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.test.tsx
@@ -101,4 +101,23 @@ describe("MyStreamWaveTabsHeader", () => {
     expect(scoreActions).toHaveClass("-tw-ml-1.5");
     expect(scoreActions).toHaveClass("tw-mt-1");
   });
+
+  it("keeps the compact mobile header to score only", () => {
+    render(
+      <MyStreamWaveTabsHeader
+        wave={wave}
+        activeContentTab={MyStreamWaveTab.CHAT}
+        setActiveContentTab={jest.fn()}
+        onSelectCuration={jest.fn()}
+        isCompact={true}
+        showBackButton={false}
+        headerActionsTooltipId="header-actions"
+        headerClassName="tw-flex"
+        actionsClassName="tw-flex"
+      />
+    );
+
+    expect(screen.getByTestId("wave-score")).toBeInTheDocument();
+    expect(screen.queryByText("Add REP")).toBeNull();
+  });
 });

--- a/__tests__/components/waves/header/WaveHeader.test.tsx
+++ b/__tests__/components/waves/header/WaveHeader.test.tsx
@@ -226,8 +226,23 @@ describe("WaveHeader", () => {
     expect(within(stats).getByText("Hot")).toBeInTheDocument();
     expect(within(stats).getByText("98")).toBeInTheDocument();
     expect(within(stats).getByText("Wave REP")).toBeInTheDocument();
-    expect(within(stats).getByText("+494.1K")).toBeInTheDocument();
+    expect(within(stats).getByText("494.1K")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Wave REP/i })).toBeNull();
+  });
+
+  it("does not show wave trust stats for DMs", () => {
+    wrapper({
+      ...baseWave,
+      chat: { scope: { group: { is_direct_message: true } } },
+      wave_score: {
+        visibility_score: 94.9,
+        quality_score: 93.4,
+        hotness_score: 97.69,
+      },
+      wave_rep: { total_rep: 494061, authenticated_user_contribution: null },
+    });
+
+    expect(screen.queryByLabelText("Wave trust stats")).toBeNull();
   });
 
   it("shows a visible Add REP action for eligible non-author waves", () => {
@@ -248,7 +263,7 @@ describe("WaveHeader", () => {
     });
     expect(within(addButton).getByText("Add REP")).toBeInTheDocument();
     expect(within(addButton).queryByText("1.3K")).toBeNull();
-    expect(screen.getByText("+1.3K")).toBeInTheDocument();
+    expect(screen.getByText("1.3K")).toBeInTheDocument();
   });
 
   it("shows an edit REP action when the user already contributed", () => {

--- a/__tests__/components/waves/header/WaveHeader.test.tsx
+++ b/__tests__/components/waves/header/WaveHeader.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import React from "react";
 import WaveHeader from "@/components/waves/header/WaveHeader";
 import { ApiWaveType } from "@/generated/models/ApiWaveType";
@@ -108,7 +108,9 @@ describe("WaveHeader", () => {
   });
 
   it("shows pin action for root waves", () => {
-    wrapper({ ...baseWave, subscribed_actions: ["drop_created"] });
+    wrapper({ ...baseWave, subscribed_actions: ["drop_created"] }, undefined, {
+      connectedProfile: { handle: "alice" },
+    });
 
     expect(screen.getByTestId("wave-header-pin")).toBeInTheDocument();
   });
@@ -182,7 +184,7 @@ describe("WaveHeader", () => {
     expect(screen.queryByTestId("wave-header-pin")).toBeNull();
   });
 
-  it("places owner options next to the pin action", () => {
+  it("places pin in the main action row and owner options beside the title", () => {
     wrapper({ ...baseWave, subscribed_actions: ["drop_created"] }, undefined, {
       connectedProfile: { handle: "a" },
     });
@@ -192,7 +194,6 @@ describe("WaveHeader", () => {
     const options = screen.getByTestId("wave-header-options");
     const pin = screen.getByTestId("wave-header-pin");
     const topActionRow = follow.parentElement?.parentElement;
-    const pinActionGroup = pin.parentElement;
 
     expect(topActionRow).toHaveClass(
       "tw-mt-8",
@@ -202,12 +203,31 @@ describe("WaveHeader", () => {
       "tw-justify-end"
     );
     expect(notifications.parentElement?.parentElement).toBe(topActionRow);
-    expect(options.parentElement).toBe(pinActionGroup);
-    expect(pinActionGroup).toHaveClass("tw-gap-1.5");
-    expect(pinActionGroup).not.toBe(topActionRow);
-    expect(
-      options.compareDocumentPosition(pin) & Node.DOCUMENT_POSITION_FOLLOWING
-    ).toBeTruthy();
+    expect(pin.parentElement?.parentElement).toBe(topActionRow);
+    expect(options.parentElement).not.toBe(topActionRow);
+  });
+
+  it("shows wave trust stats in the about header for logged-out users", () => {
+    wrapper({
+      ...baseWave,
+      wave_score: {
+        visibility_score: 94.9,
+        quality_score: 93.4,
+        hotness_score: 97.69,
+      },
+      wave_rep: { total_rep: 494061, authenticated_user_contribution: null },
+    });
+
+    const stats = screen.getByLabelText("Wave trust stats");
+    expect(within(stats).getByText("Score")).toBeInTheDocument();
+    expect(within(stats).getByText("95")).toBeInTheDocument();
+    expect(within(stats).getByText("Quality")).toBeInTheDocument();
+    expect(within(stats).getByText("93")).toBeInTheDocument();
+    expect(within(stats).getByText("Hot")).toBeInTheDocument();
+    expect(within(stats).getByText("98")).toBeInTheDocument();
+    expect(within(stats).getByText("Wave REP")).toBeInTheDocument();
+    expect(within(stats).getByText("+494.1K")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Wave REP/i })).toBeNull();
   });
 
   it("shows a visible Add REP action for eligible non-author waves", () => {
@@ -223,11 +243,15 @@ describe("WaveHeader", () => {
     expect(
       screen.getByRole("button", { name: /Add Wave REP to this wave/i })
     ).toBeInTheDocument();
-    expect(screen.getByText("Add REP")).toBeInTheDocument();
-    expect(screen.getByText("1.3K")).toBeInTheDocument();
+    const addButton = screen.getByRole("button", {
+      name: /Add Wave REP to this wave/i,
+    });
+    expect(within(addButton).getByText("Add REP")).toBeInTheDocument();
+    expect(within(addButton).queryByText("1.3K")).toBeNull();
+    expect(screen.getByText("+1.3K")).toBeInTheDocument();
   });
 
-  it("shows a remove REP action when the user already contributed", () => {
+  it("shows an edit REP action when the user already contributed", () => {
     wrapper(
       {
         ...baseWave,
@@ -241,8 +265,8 @@ describe("WaveHeader", () => {
     );
 
     expect(
-      screen.getByRole("button", { name: /Edit or remove your Wave REP/i })
+      screen.getByRole("button", { name: /Edit your Wave REP/i })
     ).toBeInTheDocument();
-    expect(screen.getByText("Remove REP")).toBeInTheDocument();
+    expect(screen.getByText("Edit REP")).toBeInTheDocument();
   });
 });

--- a/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
+++ b/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.tsx
@@ -113,7 +113,9 @@ function MyStreamWaveHeaderIdentity({
         mode="summary"
         learnMoreHref={waveScoreLearnMoreHref}
       />
-      {showWaveRepAction && <WaveRepButton wave={wave} variant="compact" />}
+      {showWaveRepAction && !isCompact && (
+        <WaveRepButton wave={wave} variant="compact" />
+      )}
     </span>
   );
 

--- a/components/waves/header/WaveHeader.tsx
+++ b/components/waves/header/WaveHeader.tsx
@@ -2,7 +2,7 @@
 
 import { useContext, useMemo } from "react";
 import type { ApiWave } from "@/generated/models/ApiWave";
-import { getTimeAgo, numberWithCommas } from "@/helpers/Helpers";
+import { getTimeAgo } from "@/helpers/Helpers";
 import WaveHeaderFollow, { WaveFollowBtnSize } from "./WaveHeaderFollow";
 import { AuthContext } from "@/components/auth/Auth";
 import WaveHeaderOptions from "./options/WaveHeaderOptions";
@@ -17,6 +17,18 @@ import { canEditWave } from "@/helpers/waves/waves.helpers";
 import WaveHeaderPictureEdit from "./picture/WaveHeaderPictureEdit";
 import WaveRepButton from "./rep/WaveRepButton";
 import WaveHeaderTrustStats from "./WaveHeaderTrustStats";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { formatDate, formatInteger } from "@/i18n/format";
+import { t, type MessageKey } from "@/i18n/messages";
+
+const WAVE_HEADER_LOCALE = DEFAULT_LOCALE;
+
+const getPostsCountMessageKey = (count: number): MessageKey => {
+  const pluralCategory = new Intl.PluralRules(WAVE_HEADER_LOCALE).select(count);
+  return pluralCategory === "one"
+    ? "waves.header.postsCount.one"
+    : "waves.header.postsCount.other";
+};
 
 interface WaveHeaderProps {
   readonly wave: ApiWave;
@@ -75,7 +87,21 @@ export default function WaveHeader({
     normalizedConnectedHandle !== normalizedWaveAuthorHandle;
   const showOptions = showOwnerOptions || showCreateSubwaveOption;
   const showPinAction = !isSubwave;
+  const showTrustStats = !isDirectMessage;
   const titleActionAlignmentClass = isSubwave ? "tw-mt-[22px]" : "";
+  const createdDate = formatDate(
+    WAVE_HEADER_LOCALE,
+    Time.millis(wave.created_at).toDate()
+  );
+  const postsCount = formatInteger(
+    WAVE_HEADER_LOCALE,
+    wave.metrics.drops_count
+  );
+  const postsCountLabel = t(
+    WAVE_HEADER_LOCALE,
+    getPostsCountMessageKey(wave.metrics.drops_count),
+    { count: postsCount }
+  );
 
   return (
     <div
@@ -176,8 +202,10 @@ export default function WaveHeader({
 
         <div className="tw-mt-1 tw-text-sm">
           <span className="tw-font-normal tw-text-iron-500">
-            Created {created} ·{" "}
-            {Time.millis(wave.created_at).toDate().toLocaleDateString()}
+            {t(WAVE_HEADER_LOCALE, "waves.header.createdLabel", {
+              relativeTime: created,
+              date: createdDate,
+            })}
           </span>
         </div>
 
@@ -192,15 +220,15 @@ export default function WaveHeader({
                 <div className="tw-flex tw-items-center">
                   <span className="tw-ml-2.5 tw-text-sm tw-font-normal tw-leading-5 tw-text-iron-500">
                     <span className="tw-text-sm tw-font-medium tw-leading-5 tw-text-iron-50">
-                      {numberWithCommas(wave.metrics.drops_count)}
+                      {postsCount}
                     </span>{" "}
-                    {wave.metrics.drops_count === 1 ? "Post" : "Posts"}
+                    {postsCountLabel}
                   </span>
                 </div>
               )}
             </div>
           </div>
-          <WaveHeaderTrustStats wave={wave} />
+          {showTrustStats && <WaveHeaderTrustStats wave={wave} />}
           {showWaveRepAction && (
             <div className="tw-flex">
               <WaveRepButton wave={wave} />

--- a/components/waves/header/WaveHeader.tsx
+++ b/components/waves/header/WaveHeader.tsx
@@ -16,6 +16,7 @@ import WaveNotificationSettings from "../specs/WaveNotificationSettings";
 import { canEditWave } from "@/helpers/waves/waves.helpers";
 import WaveHeaderPictureEdit from "./picture/WaveHeaderPictureEdit";
 import WaveRepButton from "./rep/WaveRepButton";
+import WaveHeaderTrustStats from "./WaveHeaderTrustStats";
 
 interface WaveHeaderProps {
   readonly wave: ApiWave;
@@ -73,6 +74,7 @@ export default function WaveHeader({
     normalizedWaveAuthorHandle !== null &&
     normalizedConnectedHandle !== normalizedWaveAuthorHandle;
   const showOptions = showOwnerOptions || showCreateSubwaveOption;
+  const showPinAction = !isSubwave;
   const titleActionAlignmentClass = isSubwave ? "tw-mt-[22px]" : "";
 
   return (
@@ -147,6 +149,11 @@ export default function WaveHeader({
               <div className="tw-shrink-0">
                 <WaveHeaderFollow wave={wave} size={WaveFollowBtnSize.SMALL} />
               </div>
+              {showPinAction && (
+                <div className="tw-shrink-0">
+                  <WaveHeaderPinButton waveId={wave.id} />
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -155,17 +162,14 @@ export default function WaveHeader({
           <div className="tw-min-w-0 tw-flex-1">
             <WaveHeaderName wave={wave} />
           </div>
-          {(showOptions || !isSubwave) && (
+          {showOptions && (
             <div
               className={`tw-flex tw-shrink-0 tw-items-center tw-justify-end tw-gap-1.5 ${titleActionAlignmentClass}`}
             >
-              {showOptions && (
-                <WaveHeaderOptions
-                  wave={wave}
-                  showOwnerActions={showOwnerOptions}
-                />
-              )}
-              {!isSubwave && <WaveHeaderPinButton waveId={wave.id} />}
+              <WaveHeaderOptions
+                wave={wave}
+                showOwnerActions={showOwnerOptions}
+              />
             </div>
           )}
         </div>
@@ -195,12 +199,13 @@ export default function WaveHeader({
                 </div>
               )}
             </div>
-            {showWaveRepAction && (
-              <div className="tw-shrink-0">
-                <WaveRepButton wave={wave} />
-              </div>
-            )}
           </div>
+          <WaveHeaderTrustStats wave={wave} />
+          {showWaveRepAction && (
+            <div className="tw-flex">
+              <WaveRepButton wave={wave} />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/components/waves/header/WaveHeaderTrustStats.tsx
+++ b/components/waves/header/WaveHeaderTrustStats.tsx
@@ -1,0 +1,195 @@
+import type { ApiWave } from "@/generated/models/ApiWave";
+import { formatInteger, formatNumber } from "@/i18n/format";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
+import {
+  ChartBarIcon,
+  FireIcon,
+  ScaleIcon,
+  ShieldCheckIcon,
+} from "@heroicons/react/24/outline";
+import type { ComponentType, SVGProps } from "react";
+
+const WAVE_HEADER_TRUST_LOCALE = DEFAULT_LOCALE;
+
+const formatScore = (value: number | null | undefined): string | null => {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return null;
+  }
+
+  return formatInteger(WAVE_HEADER_TRUST_LOCALE, Math.round(value));
+};
+
+const formatCompactSigned = (
+  value: number | null | undefined
+): string | null => {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return null;
+  }
+
+  const formatted = formatNumber(WAVE_HEADER_TRUST_LOCALE, Math.abs(value), {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  });
+
+  if (value > 0) {
+    return `+${formatted}`;
+  }
+
+  if (value < 0) {
+    return `-${formatted}`;
+  }
+
+  return formatted;
+};
+
+const formatSignedFullNumber = (
+  value: number | null | undefined
+): string | null => {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return null;
+  }
+
+  const formatted = formatInteger(WAVE_HEADER_TRUST_LOCALE, Math.abs(value));
+  if (value > 0) {
+    return `+${formatted}`;
+  }
+  if (value < 0) {
+    return `-${formatted}`;
+  }
+  return formatted;
+};
+
+type TrustStatTone = "score" | "quality" | "hot" | "rep";
+
+interface TrustStat {
+  readonly id: string;
+  readonly label: string;
+  readonly value: string;
+  readonly ariaLabel: string;
+  readonly icon: ComponentType<SVGProps<SVGSVGElement>>;
+  readonly tone: TrustStatTone;
+}
+
+const toneClasses: Record<TrustStatTone, string> = {
+  score: "tw-border-emerald-400/20 tw-bg-emerald-500/10 tw-text-emerald-200",
+  quality: "tw-border-sky-400/20 tw-bg-sky-500/10 tw-text-sky-200",
+  hot: "tw-border-amber-400/20 tw-bg-amber-500/10 tw-text-amber-200",
+  rep: "tw-border-violet-400/20 tw-bg-violet-500/10 tw-text-violet-200",
+};
+
+export default function WaveHeaderTrustStats({
+  wave,
+}: {
+  readonly wave: ApiWave;
+}) {
+  const visibilityScore = formatScore(wave.wave_score?.visibility_score);
+  const qualityScore = formatScore(wave.wave_score?.quality_score);
+  const hotnessScore = formatScore(wave.wave_score?.hotness_score);
+  const compactWaveRep = formatCompactSigned(wave.wave_rep?.total_rep);
+  const fullWaveRep = formatSignedFullNumber(wave.wave_rep?.total_rep);
+  const stats: TrustStat[] = [
+    ...(visibilityScore === null
+      ? []
+      : [
+          {
+            id: "score",
+            label: t(
+              WAVE_HEADER_TRUST_LOCALE,
+              "waves.score.details.scoreLabel"
+            ),
+            value: visibilityScore,
+            ariaLabel: t(
+              WAVE_HEADER_TRUST_LOCALE,
+              "waves.score.details.visibilityAria",
+              { visibilityScore }
+            ),
+            icon: ShieldCheckIcon,
+            tone: "score" as const,
+          },
+        ]),
+    ...(qualityScore === null
+      ? []
+      : [
+          {
+            id: "quality",
+            label: t(WAVE_HEADER_TRUST_LOCALE, "waves.score.summary.quality"),
+            value: qualityScore,
+            ariaLabel: t(
+              WAVE_HEADER_TRUST_LOCALE,
+              "waves.score.summary.qualityAria",
+              { qualityScore }
+            ),
+            icon: ChartBarIcon,
+            tone: "quality" as const,
+          },
+        ]),
+    ...(hotnessScore === null
+      ? []
+      : [
+          {
+            id: "hot",
+            label: t(WAVE_HEADER_TRUST_LOCALE, "waves.score.details.hotLabel"),
+            value: hotnessScore,
+            ariaLabel: t(
+              WAVE_HEADER_TRUST_LOCALE,
+              "waves.score.details.hotnessAria",
+              { hotnessScore }
+            ),
+            icon: FireIcon,
+            tone: "hot" as const,
+          },
+        ]),
+    ...(compactWaveRep === null
+      ? []
+      : [
+          {
+            id: "wave-rep",
+            label: t(WAVE_HEADER_TRUST_LOCALE, "waves.score.summary.waveRep"),
+            value: compactWaveRep,
+            ariaLabel: t(
+              WAVE_HEADER_TRUST_LOCALE,
+              "waves.score.details.repAriaRaw",
+              { value: fullWaveRep ?? compactWaveRep }
+            ),
+            icon: ScaleIcon,
+            tone: "rep" as const,
+          },
+        ]),
+  ];
+
+  if (!stats.length) {
+    return null;
+  }
+
+  return (
+    <dl
+      aria-label={t(
+        WAVE_HEADER_TRUST_LOCALE,
+        "waves.score.details.statsAriaLabel"
+      )}
+      className="tw-grid tw-grid-cols-2 tw-gap-2 sm:tw-grid-cols-4"
+    >
+      {stats.map((stat) => {
+        const Icon = stat.icon;
+        return (
+          <div
+            key={stat.id}
+            aria-label={stat.ariaLabel}
+            className={`tw-flex tw-min-w-0 tw-items-center tw-gap-2 tw-rounded-lg tw-border tw-border-solid tw-px-2.5 tw-py-2 ${toneClasses[stat.tone]}`}
+          >
+            <Icon className="tw-size-4 tw-flex-shrink-0" aria-hidden="true" />
+            <div className="tw-min-w-0">
+              <dt className="tw-truncate tw-text-[10px] tw-font-semibold tw-uppercase tw-leading-4 tw-tracking-wide tw-text-iron-400">
+                {stat.label}
+              </dt>
+              <dd className="tw-m-0 tw-truncate tw-text-sm tw-font-semibold tw-leading-5 tw-tabular-nums tw-text-current">
+                {stat.value}
+              </dd>
+            </div>
+          </div>
+        );
+      })}
+    </dl>
+  );
+}

--- a/components/waves/header/WaveHeaderTrustStats.tsx
+++ b/components/waves/header/WaveHeaderTrustStats.tsx
@@ -20,44 +20,27 @@ const formatScore = (value: number | null | undefined): string | null => {
   return formatInteger(WAVE_HEADER_TRUST_LOCALE, Math.round(value));
 };
 
-const formatCompactSigned = (
+const formatCompactRepTotal = (
   value: number | null | undefined
 ): string | null => {
   if (value === null || value === undefined || !Number.isFinite(value)) {
     return null;
   }
 
-  const formatted = formatNumber(WAVE_HEADER_TRUST_LOCALE, Math.abs(value), {
+  return formatNumber(WAVE_HEADER_TRUST_LOCALE, value, {
     notation: "compact",
     maximumFractionDigits: 1,
   });
-
-  if (value > 0) {
-    return `+${formatted}`;
-  }
-
-  if (value < 0) {
-    return `-${formatted}`;
-  }
-
-  return formatted;
 };
 
-const formatSignedFullNumber = (
+const formatFullRepTotal = (
   value: number | null | undefined
 ): string | null => {
   if (value === null || value === undefined || !Number.isFinite(value)) {
     return null;
   }
 
-  const formatted = formatInteger(WAVE_HEADER_TRUST_LOCALE, Math.abs(value));
-  if (value > 0) {
-    return `+${formatted}`;
-  }
-  if (value < 0) {
-    return `-${formatted}`;
-  }
-  return formatted;
+  return formatInteger(WAVE_HEADER_TRUST_LOCALE, value);
 };
 
 type TrustStatTone = "score" | "quality" | "hot" | "rep";
@@ -86,8 +69,8 @@ export default function WaveHeaderTrustStats({
   const visibilityScore = formatScore(wave.wave_score?.visibility_score);
   const qualityScore = formatScore(wave.wave_score?.quality_score);
   const hotnessScore = formatScore(wave.wave_score?.hotness_score);
-  const compactWaveRep = formatCompactSigned(wave.wave_rep?.total_rep);
-  const fullWaveRep = formatSignedFullNumber(wave.wave_rep?.total_rep);
+  const compactWaveRep = formatCompactRepTotal(wave.wave_rep?.total_rep);
+  const fullWaveRep = formatFullRepTotal(wave.wave_rep?.total_rep);
   const stats: TrustStat[] = [
     ...(visibilityScore === null
       ? []
@@ -149,7 +132,7 @@ export default function WaveHeaderTrustStats({
             value: compactWaveRep,
             ariaLabel: t(
               WAVE_HEADER_TRUST_LOCALE,
-              "waves.score.details.repAriaRaw",
+              "waves.score.details.repTotalAria",
               { value: fullWaveRep ?? compactWaveRep }
             ),
             icon: ScaleIcon,

--- a/components/waves/header/rep/WaveRepButton.tsx
+++ b/components/waves/header/rep/WaveRepButton.tsx
@@ -26,22 +26,23 @@ export default function WaveRepButton({
   readonly variant?: WaveRepButtonVariant | undefined;
 }) {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const totalRep = wave.wave_rep?.total_rep ?? null;
   const authenticatedUserContribution =
     wave.wave_rep?.authenticated_user_contribution ?? 0;
   const hasUserContribution = authenticatedUserContribution !== 0;
-  const formattedTotalRep =
-    totalRep === null ? null : formatCompactRep(totalRep);
   const actionText = hasUserContribution
-    ? t(WAVE_REP_ACTION_LOCALE, "waves.rep.action.remove")
+    ? t(WAVE_REP_ACTION_LOCALE, "waves.rep.action.edit")
     : t(WAVE_REP_ACTION_LOCALE, "waves.rep.action.add");
   const label = hasUserContribution
-    ? t(WAVE_REP_ACTION_LOCALE, "waves.rep.action.editRemoveAriaLabel", {
+    ? t(WAVE_REP_ACTION_LOCALE, "waves.rep.action.editAriaLabel", {
         contribution: formatCompactRep(authenticatedUserContribution),
       })
     : t(WAVE_REP_ACTION_LOCALE, "waves.rep.action.addAriaLabel");
+  const tooltipContent = t(WAVE_REP_ACTION_LOCALE, "waves.rep.action.tooltip");
   const tooltipId = `wave-rep-rating-${wave.id}`;
   const isCompact = variant === "compact";
+  const sizeClasses = isCompact
+    ? "tw-h-7 tw-min-w-7 tw-gap-x-1 tw-rounded-md tw-px-1.5 tw-text-[11px]"
+    : "tw-h-8 tw-min-w-8 tw-gap-x-1.5 tw-rounded-lg tw-px-2.5 tw-text-xs";
 
   return (
     <>
@@ -49,19 +50,12 @@ export default function WaveRepButton({
         type="button"
         aria-label={label}
         data-tooltip-id={tooltipId}
-        data-tooltip-content={label}
+        data-tooltip-content={tooltipContent}
         onClick={() => setIsModalOpen(true)}
-        className={`tw-flex tw-h-8 tw-min-w-8 tw-items-center tw-justify-center tw-gap-x-1.5 tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900 tw-text-xs tw-font-semibold tw-text-iron-200 tw-transition-all tw-duration-200 hover:tw-border-primary-400/70 hover:tw-bg-iron-800 hover:tw-text-white focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950 ${
-          isCompact ? "tw-px-2" : "tw-px-2.5"
-        }`}
+        className={`tw-flex tw-items-center tw-justify-center tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-900 tw-font-semibold tw-text-iron-200 tw-transition-all tw-duration-200 hover:tw-border-primary-400/70 hover:tw-bg-iron-800 hover:tw-text-white focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950 ${sizeClasses}`}
       >
         <ScaleIcon className="tw-size-4 tw-flex-shrink-0" aria-hidden="true" />
         <span>{actionText}</span>
-        {!isCompact && formattedTotalRep !== null && (
-          <span className="tw-rounded-md tw-bg-black/25 tw-px-1.5 tw-py-0.5 tw-text-iron-300">
-            {formattedTotalRep}
-          </span>
-        )}
       </button>
       <MyStreamActionTooltip id={tooltipId} />
       {isModalOpen && (

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -296,6 +296,7 @@ const WAVE_SCORE_SUMMARY_MESSAGES = objectMessages("waves.score.summary", {
 } as const);
 
 const WAVE_SCORE_DETAILS_MESSAGES = objectMessages("waves.score.details", {
+  statsAriaLabel: "Wave trust stats",
   visibilityAria: "Visibility score {visibilityScore} out of 100",
   hotnessAria: "Hotness score {hotnessScore} out of 100",
   hotnessTitle: "Hotness score: {hotnessScore}",
@@ -317,10 +318,12 @@ const WAVE_SCORE_DETAILS_MESSAGES = objectMessages("waves.score.details", {
 
 const WAVE_REP_ACTION_MESSAGES = objectMessages("waves.rep.action", {
   add: "Add REP",
-  remove: "Remove REP",
+  edit: "Edit REP",
   addAriaLabel: "Add Wave REP to this wave",
-  editRemoveAriaLabel:
-    "Edit or remove your Wave REP for this wave. Current contribution {contribution}",
+  editAriaLabel:
+    "Edit your Wave REP for this wave. Current contribution {contribution}",
+  tooltip:
+    "Add, increase, decrease, or remove your Wave REP using your available TDH-backed REP credit.",
 } as const);
 
 const WAVE_REP_MODAL_MESSAGES = objectMessages("waves.rep.modal", {

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -276,6 +276,12 @@ const WAVES_SIDEBAR_MESSAGES = objectMessages("waves.sidebar", {
   allQualityRankedAriaLabel: "All quality-ranked waves list",
 } as const);
 
+const WAVE_HEADER_MESSAGES = objectMessages("waves.header", {
+  createdLabel: "Created {relativeTime} · {date}",
+  "postsCount.one": "{count} Post",
+  "postsCount.other": "{count} Posts",
+} as const);
+
 const WAVE_SCORE_SUMMARY_MESSAGES = objectMessages("waves.score.summary", {
   title: "Score",
   quality: "Quality",
@@ -310,6 +316,7 @@ const WAVE_SCORE_DETAILS_MESSAGES = objectMessages("waves.score.details", {
   repNegative: "negative {value}",
   repNeutral: "{value}",
   repAriaRaw: "Wave REP {value}",
+  repTotalAria: "Wave REP total {value}",
   repAriaScore: "Wave REP score {repScore} out of 100",
   scoreLabel: "Score",
   hotLabel: "Hot",
@@ -920,6 +927,7 @@ export const EN_US_MESSAGES = {
   ...USER_PROFILE_TABS_MESSAGES,
   ...FOLLOWERS_MESSAGES,
   ...WAVES_SIDEBAR_MESSAGES,
+  ...WAVE_HEADER_MESSAGES,
   ...WAVE_SCORE_SUMMARY_MESSAGES,
   ...WAVE_SCORE_DETAILS_MESSAGES,
   ...WAVE_REP_ACTION_MESSAGES,


### PR DESCRIPTION
## Issue
- Wave trust and Wave REP were too hard to find in the full wave details experience, especially on mobile.
- The compact chat header could become busy because the REP action competed with the score and title.
- The existing REP action wording did not clearly express that users can increase, decrease, or clear an existing contribution.

## Fix
- Keep the main chat header compact while moving the complete trust breakdown into the shared Wave Details/About header.
- Separate the REP action from the REP total so users see stats as stats and actions as actions.
- Use `Add REP` for no current contribution and `Edit REP` for any existing positive or negative contribution.

## Changes
- Added a shared wave trust stats band with `Score`, `Quality`, `Hot`, and `Wave REP` values.
- Rendered that trust stats band in the shared wave header used by desktop About and mobile Wave Details.
- Moved the pin control into the main action row for the expanded wave header.
- Removed the REP total from the REP action button and tightened the compact REP action styling.
- Suppressed the REP action in the compact mobile chat header so mobile keeps only the score there; the full REP action lives in Wave Details.
- Updated Wave REP action copy and accessibility labels.
- Added regression tests for logged-out stats visibility, Add/Edit REP labels, separated REP total/action, pin placement, and compact mobile header behavior.

## Validation
- `seize run test:no-coverage -- __tests__/components/waves/header/WaveHeader.test.tsx __tests__/components/waves/WaveTrustSignals.test.tsx __tests__/components/brain/my-stream/tabs/MyStreamWaveTabsHeader.test.tsx __tests__/components/waves/header/rep/WaveRepRatingModal.test.tsx`
- `seize run typecheck:changed`
- `seize run lint:changed`
- `codex-diff-check`
- Attempted local browser verification, but the local Next dev server hung compiling instrumentation and route requests, including `/`, timed out. Staging E2E/screenshots should cover the deployed browser path before production.

## Risk
- Level: Medium
- Why: User-facing wave header/About/mobile details UI changes, but no API, data, auth, or backend contract changes.
- Rollback: Revert this frontend PR and redeploy the previous frontend build.

## Review Notes
- Please focus on compact/mobile header behavior, Wave Details stat visibility, and whether the new trust stat band feels appropriately clear without making the main chat header busier.