### PR TITLE
Move subwave chevron beside wave names

### DIFF
--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
@@ -263,15 +263,10 @@ describe("BrainLeftSidebarWave", () => {
     const titleLink = screen.getByRole("link", { name: "Chat Wave" });
     expect(titleLink.nextElementSibling).toBe(expandButton);
     expect(expandButton.parentElement).toContainElement(titleLink);
-    expect(
-      screen.getByRole("link", { hidden: true, name: "" })
-    ).toHaveAttribute("aria-hidden", "true");
-    expect(
-      screen.getByRole("link", { hidden: true, name: "" })
-    ).toHaveAttribute("tabindex", "-1");
-    expect(
-      screen.getByRole("link", { hidden: true, name: "" })
-    ).toHaveAttribute("href", "/waves/1");
+    const avatar = screen.getByTestId("sidebar-wave-avatar");
+    expect(avatar).toHaveAttribute("aria-hidden", "true");
+    expect(avatar.closest("a")).toBeNull();
+    expect(screen.getAllByRole("link")).toHaveLength(1);
     expect(
       screen.getByRole("link", { name: "Chat Wave" }).closest(".tw-pr-7")
     ).not.toBeNull();

--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
@@ -8,12 +8,20 @@ import type { ApiWaveScore } from "@/generated/models/ApiWaveScore";
 
 jest.mock("next/link", () => ({
   __esModule: true,
-  default: ({ href, children, onMouseEnter, onClick, className }: any) => (
+  default: ({
+    href,
+    children,
+    onMouseEnter,
+    onClick,
+    className,
+    ...rest
+  }: any) => (
     <a
       href={href}
       onMouseEnter={onMouseEnter}
       onClick={onClick}
       className={className}
+      {...rest}
     >
       {children}
     </a>
@@ -41,6 +49,14 @@ jest.mock(
 
 const mockedPrefetch = usePrefetchWaveData as jest.Mock;
 const mockedUseMyStream = useMyStream as jest.Mock;
+
+const getWaveRow = (): HTMLElement => {
+  const row = screen.getByRole("link").closest(".tw-group");
+  if (row === null) {
+    throw new Error("Expected wave link to have a row ancestor");
+  }
+  return row as HTMLElement;
+};
 
 describe("BrainLeftSidebarWave", () => {
   const prefetch = jest.fn();
@@ -198,7 +214,7 @@ describe("BrainLeftSidebarWave", () => {
   it("uses normal row padding when a wave has no subwaves", () => {
     render(<BrainLeftSidebarWave wave={baseWave} onHover={onHover} />);
 
-    const row = screen.getByRole("link").parentElement;
+    const row = getWaveRow();
 
     expect(
       screen.queryByRole("button", { name: "Expand Chat Wave subwaves" })
@@ -206,13 +222,9 @@ describe("BrainLeftSidebarWave", () => {
     expect(row).toHaveClass("tw-px-5");
     expect(row).toHaveClass("tw-gap-x-4");
     expect(row).not.toHaveClass("tw-pl-2");
-    expect(screen.getByRole("link").previousElementSibling).toBeNull();
-    expect(screen.getByRole("link").nextElementSibling).toBe(
-      screen.getByTestId("pin")
-    );
   });
 
-  it("renders the subwave expand button before the pin without opening the wave", async () => {
+  it("renders the subwave expand button beside the wave name without opening the wave", async () => {
     const onToggleExpand = jest.fn();
     const user = userEvent.setup();
 
@@ -233,26 +245,38 @@ describe("BrainLeftSidebarWave", () => {
     expect(expandButton).toHaveAttribute("aria-expanded", "false");
     expect(expandButton).not.toHaveClass("tw-absolute");
     expect(expandButton).toHaveClass("tw-relative");
+    expect(expandButton).toHaveClass("tw-inline-flex");
     expect(expandButton).toHaveClass("tw-size-6");
-    expect(expandButton).toHaveClass("md:tw-size-5");
     expect(expandButton).toHaveClass("tw-rounded-full");
     expect(expandButton).toHaveClass("tw-border-0");
     expect(expandButton).toHaveClass("tw-bg-transparent");
     expect(expandButton).toHaveClass("desktop-hover:hover:tw-bg-iron-700/70");
+    expect(expandButton.querySelector("svg")).toHaveClass("tw-size-4");
     expect(expandButton.querySelector(".tw-bg-primary-400")).toBeNull();
-    const unreadSubwavesDot = screen
-      .getByRole("link")
-      .querySelector(".tw-bg-primary-400");
+    const unreadSubwavesDot = getWaveRow().querySelector(".tw-bg-primary-400");
     expect(unreadSubwavesDot).not.toBeNull();
     expect(unreadSubwavesDot).toHaveClass("tw-right-[-3px]");
     expect(unreadSubwavesDot).toHaveClass("tw-top-[-3px]");
-    expect(screen.getByRole("link").parentElement).toHaveClass("tw-pl-2");
-    expect(screen.getByRole("link").parentElement).toHaveClass("tw-gap-x-2");
-    expect(screen.getByRole("link").previousElementSibling).toContainElement(
-      expandButton
-    );
-    expect(screen.getByRole("link").nextElementSibling).toBe(
-      screen.getByTestId("pin")
+    expect(getWaveRow()).toHaveClass("tw-px-5");
+    expect(getWaveRow()).toHaveClass("tw-gap-x-4");
+    expect(getWaveRow()).not.toHaveClass("tw-pl-2");
+    const titleLink = screen.getByRole("link", { name: "Chat Wave" });
+    expect(titleLink.nextElementSibling).toBe(expandButton);
+    expect(expandButton.parentElement).toContainElement(titleLink);
+    expect(
+      screen.getByRole("link", { hidden: true, name: "" })
+    ).toHaveAttribute("aria-hidden", "true");
+    expect(
+      screen.getByRole("link", { hidden: true, name: "" })
+    ).toHaveAttribute("tabindex", "-1");
+    expect(
+      screen.getByRole("link", { hidden: true, name: "" })
+    ).toHaveAttribute("href", "/waves/1");
+    expect(
+      screen.getByRole("link", { name: "Chat Wave" }).closest(".tw-pr-7")
+    ).not.toBeNull();
+    expect(screen.getByRole("link", { name: "Chat Wave" })).toHaveClass(
+      "focus-visible:tw-outline"
     );
 
     await user.click(expandButton);
@@ -275,10 +299,7 @@ describe("BrainLeftSidebarWave", () => {
         />
       );
 
-      const waveRow = screen.getByRole("link").parentElement;
-      if (waveRow === null) {
-        throw new Error("Expected wave link to have a row parent");
-      }
+      const waveRow = getWaveRow();
 
       fireEvent.mouseEnter(waveRow);
 
@@ -312,7 +333,7 @@ describe("BrainLeftSidebarWave", () => {
     });
 
     expect(expandButton).toHaveClass("tw-bg-iron-700/60");
-    expect(expandButton).toHaveClass("tw-text-iron-300");
+    expect(expandButton).toHaveClass("tw-text-iron-200");
     expect(expandButton).toHaveClass("tw-opacity-100");
   });
 
@@ -349,10 +370,7 @@ describe("BrainLeftSidebarWave", () => {
         />
       );
 
-      const row = screen.getByRole("link").parentElement;
-      if (row === null) {
-        throw new Error("Expected wave link to have a row parent");
-      }
+      const row = getWaveRow();
 
       fireEvent.mouseEnter(row);
       fireEvent.mouseLeave(row);
@@ -381,22 +399,18 @@ describe("BrainLeftSidebarWave", () => {
     expect(
       screen.queryByRole("button", { name: "Expand Chat Wave subwaves" })
     ).not.toBeInTheDocument();
-    expect(screen.getByRole("link").parentElement).toHaveClass("tw-pl-[84px]");
-    expect(screen.getByRole("link").parentElement).toHaveClass("md:tw-pl-20");
+    expect(getWaveRow()).toHaveClass("tw-pl-[84px]");
+    expect(getWaveRow()).toHaveClass("md:tw-pl-20");
     expect(screen.getByTestId("wave-picture").parentElement).toHaveClass(
       "tw-size-7"
     );
-    const rail = screen
-      .getByRole("link")
-      .parentElement?.querySelector(".tw-w-px");
+    const rail = getWaveRow().querySelector(".tw-w-px");
     expect(rail).not.toBeNull();
     expect(rail).toHaveClass("tw-left-14");
     expect(rail).toHaveClass("md:tw-left-[52px]");
     expect(rail).toHaveClass("-tw-top-1");
     expect(rail).toHaveClass("tw-bottom-4");
-    expect(
-      screen.getByRole("link").parentElement?.querySelector(".tw-h-px")
-    ).toBeNull();
+    expect(getWaveRow().querySelector(".tw-h-px")).toBeNull();
     expect(screen.queryByTestId("pin")).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
@@ -7,12 +7,20 @@ import type { ApiWaveScore } from "@/generated/models/ApiWaveScore";
 
 jest.mock("next/link", () => ({
   __esModule: true,
-  default: ({ href, children, onMouseEnter, onClick, className }: any) => (
+  default: ({
+    href,
+    children,
+    onMouseEnter,
+    onClick,
+    className,
+    ...rest
+  }: any) => (
     <a
       href={href}
       onMouseEnter={onMouseEnter}
       onClick={onClick}
       className={className}
+      {...rest}
     >
       {children}
     </a>
@@ -41,6 +49,8 @@ const waveScore = {
   hotness_score: 92,
   rep_sort_score: 41,
 } as ApiWaveScore;
+
+const getWaveRow = (): HTMLElement => screen.getByRole("group");
 
 const renderExpandedWave = (
   overrides: Partial<React.ComponentProps<typeof ExpandedWave>> = {}
@@ -80,7 +90,7 @@ describe("ExpandedWave", () => {
       showPin: true,
     });
 
-    const row = screen.getByRole("link").parentElement;
+    const row = getWaveRow();
 
     expect(
       screen.queryByRole("button", { name: "Expand Chat Wave subwaves" })
@@ -88,13 +98,9 @@ describe("ExpandedWave", () => {
     expect(row).toHaveClass("tw-px-5");
     expect(row).toHaveClass("tw-gap-x-4");
     expect(row).not.toHaveClass("tw-pl-2");
-    expect(screen.getByRole("link").previousElementSibling).toBeNull();
-    expect(screen.getByRole("link").nextElementSibling).toBe(
-      screen.getByTestId("pin")
-    );
   });
 
-  it("renders the subwave expand button before the pin without opening the wave", async () => {
+  it("renders the subwave expand button beside the wave name without opening the wave", async () => {
     const user = userEvent.setup();
     const { onClick, onToggleExpand } = renderExpandedWave({
       canExpand: true,
@@ -109,28 +115,38 @@ describe("ExpandedWave", () => {
     expect(expandButton).toHaveAttribute("aria-expanded", "false");
     expect(expandButton).not.toHaveClass("tw-absolute");
     expect(expandButton).toHaveClass("tw-relative");
+    expect(expandButton).toHaveClass("tw-inline-flex");
     expect(expandButton).toHaveClass("tw-size-6");
-    expect(expandButton).toHaveClass("md:tw-size-5");
     expect(expandButton).toHaveClass("tw-rounded-full");
     expect(expandButton).toHaveClass("tw-border-0");
     expect(expandButton).toHaveClass("tw-bg-transparent");
     expect(expandButton).toHaveClass("desktop-hover:hover:tw-bg-iron-700/70");
+    expect(expandButton.querySelector("svg")).toHaveClass("tw-size-4");
     expect(expandButton.querySelector(".tw-bg-primary-400")).toBeNull();
-    const unreadSubwavesDot = screen
-      .getByRole("link")
-      .querySelector(".tw-bg-primary-400");
+    const unreadSubwavesDot = getWaveRow().querySelector(".tw-bg-primary-400");
     expect(unreadSubwavesDot).not.toBeNull();
     expect(unreadSubwavesDot).toHaveClass("tw-right-[-3px]");
     expect(unreadSubwavesDot).toHaveClass("tw-top-[-3px]");
-    expect(screen.getByRole("link").parentElement).toHaveClass("tw-pl-2");
-    expect(screen.getByRole("link").parentElement).toHaveClass("md:tw-pl-1");
-    expect(screen.getByRole("link").parentElement).toHaveClass("tw-gap-x-2");
-    expect(screen.getByRole("link").parentElement).toHaveClass("md:tw-gap-x-1");
-    expect(screen.getByRole("link").previousElementSibling).toContainElement(
-      expandButton
-    );
-    expect(screen.getByRole("link").nextElementSibling).toBe(
-      screen.getByTestId("pin")
+    expect(getWaveRow()).toHaveClass("tw-px-5");
+    expect(getWaveRow()).toHaveClass("tw-gap-x-4");
+    expect(getWaveRow()).not.toHaveClass("tw-pl-2");
+    const titleLink = screen.getByRole("link", { name: "Chat Wave" });
+    expect(titleLink.nextElementSibling).toBe(expandButton);
+    expect(expandButton.parentElement).toContainElement(titleLink);
+    expect(
+      screen.getByRole("link", { hidden: true, name: "" })
+    ).toHaveAttribute("aria-hidden", "true");
+    expect(
+      screen.getByRole("link", { hidden: true, name: "" })
+    ).toHaveAttribute("tabindex", "-1");
+    expect(
+      screen.getByRole("link", { hidden: true, name: "" })
+    ).toHaveAttribute("href", "/waves/1");
+    expect(
+      screen.getByRole("link", { name: "Chat Wave" }).closest(".tw-pr-7")
+    ).not.toBeNull();
+    expect(screen.getByRole("link", { name: "Chat Wave" })).toHaveClass(
+      "focus-visible:tw-outline"
     );
 
     await user.click(expandButton);
@@ -150,24 +166,18 @@ describe("ExpandedWave", () => {
     expect(
       screen.queryByRole("button", { name: "Expand Chat Wave subwaves" })
     ).not.toBeInTheDocument();
-    expect(screen.getByRole("link").parentElement).toHaveClass("tw-pl-[84px]");
-    expect(screen.getByRole("link").parentElement).toHaveClass(
-      "md:tw-pl-[72px]"
-    );
+    expect(getWaveRow()).toHaveClass("tw-pl-[84px]");
+    expect(getWaveRow()).toHaveClass("md:tw-pl-[72px]");
     expect(screen.getByTestId("wave-picture").parentElement).toHaveClass(
       "tw-size-7"
     );
-    const rail = screen
-      .getByRole("link")
-      .parentElement?.querySelector(".tw-w-px");
+    const rail = getWaveRow().querySelector(".tw-w-px");
     expect(rail).not.toBeNull();
     expect(rail).toHaveClass("tw-left-14");
     expect(rail).toHaveClass("md:tw-left-11");
     expect(rail).toHaveClass("-tw-top-1");
     expect(rail).toHaveClass("tw-bottom-4");
-    expect(
-      screen.getByRole("link").parentElement?.querySelector(".tw-h-px")
-    ).toBeNull();
+    expect(getWaveRow().querySelector(".tw-h-px")).toBeNull();
     expect(screen.queryByTestId("pin")).not.toBeInTheDocument();
   });
 
@@ -182,7 +192,7 @@ describe("ExpandedWave", () => {
     });
 
     expect(expandButton).toHaveClass("tw-bg-iron-700/60");
-    expect(expandButton).toHaveClass("tw-text-iron-300");
+    expect(expandButton).toHaveClass("tw-text-iron-200");
     expect(expandButton).toHaveClass("tw-opacity-100");
   });
 
@@ -212,9 +222,7 @@ describe("ExpandedWave", () => {
       isLastSubwave: false,
     });
 
-    const rail = screen
-      .getByRole("link")
-      .parentElement?.querySelector(".tw-w-px");
+    const rail = getWaveRow().querySelector(".tw-w-px");
 
     expect(rail).not.toBeNull();
     expect(rail).toHaveClass("-tw-top-1");
@@ -231,10 +239,7 @@ describe("ExpandedWave", () => {
         onPrefetchSubwaves,
       });
 
-      const waveRow = screen.getByRole("link").parentElement;
-      if (waveRow === null) {
-        throw new Error("Expected wave link to have a row parent");
-      }
+      const waveRow = getWaveRow();
 
       fireEvent.mouseEnter(waveRow);
 
@@ -262,10 +267,7 @@ describe("ExpandedWave", () => {
         onPrefetchSubwaves,
       });
 
-      const row = screen.getByRole("link").parentElement;
-      if (row === null) {
-        throw new Error("Expected wave link to have a row parent");
-      }
+      const row = getWaveRow();
 
       fireEvent.mouseEnter(row);
       fireEvent.mouseLeave(row);

--- a/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
@@ -133,15 +133,10 @@ describe("ExpandedWave", () => {
     const titleLink = screen.getByRole("link", { name: "Chat Wave" });
     expect(titleLink.nextElementSibling).toBe(expandButton);
     expect(expandButton.parentElement).toContainElement(titleLink);
-    expect(
-      screen.getByRole("link", { hidden: true, name: "" })
-    ).toHaveAttribute("aria-hidden", "true");
-    expect(
-      screen.getByRole("link", { hidden: true, name: "" })
-    ).toHaveAttribute("tabindex", "-1");
-    expect(
-      screen.getByRole("link", { hidden: true, name: "" })
-    ).toHaveAttribute("href", "/waves/1");
+    const avatar = screen.getByTestId("sidebar-wave-avatar");
+    expect(avatar).toHaveAttribute("aria-hidden", "true");
+    expect(avatar.closest("a")).toBeNull();
+    expect(screen.getAllByRole("link")).toHaveLength(1);
     expect(
       screen.getByRole("link", { name: "Chat Wave" }).closest(".tw-pr-7")
     ).not.toBeNull();

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
@@ -181,6 +181,11 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
     wave.id,
   ]);
 
+  const handleRowMouseEnter = useCallback(() => {
+    scheduleSubwavePrefetch();
+    onWaveHover();
+  }, [onWaveHover, scheduleSubwavePrefetch]);
+
   useEffect(() => cancelSubwavePrefetch, [cancelSubwavePrefetch]);
 
   const handleWaveClick = useCallback(
@@ -223,12 +228,10 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
 
   const isChildRow = depth === 1;
   const shouldShowExpandControl = canExpand && depth === 0;
-  const shouldReserveExpandControlSpace = shouldShowExpandControl;
   const shouldShowPinButton = showPin && depth === 0;
   const { rowPaddingClasses, rowGapClasses, linkGapClasses } =
     getSidebarWaveRowLayoutClasses({
       isChildRow,
-      shouldReserveExpandControlSpace,
       variant: "app",
     });
   const avatarSizeClasses = isChildRow ? "tw-size-7" : "tw-size-8";
@@ -242,7 +245,7 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
   return (
     <div
       {...(!hasTouchScreen && {
-        onMouseEnter: scheduleSubwavePrefetch,
+        onMouseEnter: handleRowMouseEnter,
         onMouseLeave: cancelSubwavePrefetch,
       })}
       className={`tw-group tw-relative tw-flex tw-items-start ${rowGapClasses} ${rowPaddingClasses} tw-py-2 tw-transition-all tw-duration-200 tw-ease-out ${
@@ -251,15 +254,6 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
           : "desktop-hover:hover:tw-bg-iron-800/80"
       }`}
     >
-      <SidebarWaveExpandControl
-        formattedWaveName={formattedWaveName}
-        isExpanded={isExpanded}
-        onBlur={cancelSubwavePrefetch}
-        onClick={handleToggleExpand}
-        onFocus={scheduleSubwavePrefetch}
-        shouldReserveSpace={shouldReserveExpandControlSpace}
-        shouldShowButton={shouldShowExpandControl}
-      />
       {isChildRow && (
         <span
           aria-hidden="true"
@@ -268,18 +262,21 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
           }`}
         />
       )}
-      <Link
-        href={href}
-        prefetch={false}
-        {...(!hasTouchScreen && { onMouseEnter: onWaveHover })}
-        onClick={handleWaveClick}
-        className={`tw-flex tw-min-w-0 tw-flex-1 ${linkGapClasses} tw-py-1 tw-no-underline tw-transition-all tw-duration-200 tw-ease-out ${
+      <div
+        className={`tw-flex tw-min-w-0 tw-flex-1 ${linkGapClasses} tw-py-1 tw-transition-all tw-duration-200 tw-ease-out ${
           isActive
             ? "tw-text-white desktop-hover:group-hover:tw-text-white"
             : "tw-text-iron-400 desktop-hover:group-hover:tw-text-iron-300"
         }`}
       >
-        <div className="tw-relative">
+        <Link
+          href={href}
+          prefetch={false}
+          onClick={handleWaveClick}
+          tabIndex={-1}
+          aria-hidden="true"
+          className="tw-relative tw-flex-shrink-0 tw-no-underline"
+        >
           <div
             className={`tw-relative ${avatarSizeClasses} tw-rounded-full tw-transition tw-duration-300 desktop-hover:group-hover:tw-brightness-110 ${getAvatarRingClasses()} ${
               isActive
@@ -327,14 +324,35 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
               className="tw-absolute tw-right-[-3px] tw-top-[-3px] tw-size-2.5 tw-rounded-full tw-border tw-border-solid tw-border-iron-950 tw-bg-primary-400"
             />
           )}
-        </div>
+        </Link>
         <div className="tw-min-w-0 tw-flex-1">
           <div
-            className={`tw-truncate tw-text-sm tw-font-medium ${
+            className={`tw-flex tw-min-w-0 tw-items-center tw-gap-1.5 ${
               shouldShowPinButton ? "tw-pr-7" : ""
             }`}
           >
-            {formattedWaveName}
+            <Link
+              href={href}
+              prefetch={false}
+              onClick={handleWaveClick}
+              className={`tw-min-w-0 tw-flex-shrink tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 ${
+                isActive
+                  ? "tw-text-white desktop-hover:group-hover:tw-text-white"
+                  : "tw-text-iron-400 desktop-hover:group-hover:tw-text-iron-300"
+              }`}
+            >
+              <span className="tw-block tw-truncate tw-text-sm tw-font-medium">
+                {formattedWaveName}
+              </span>
+            </Link>
+            <SidebarWaveExpandControl
+              formattedWaveName={formattedWaveName}
+              isExpanded={isExpanded}
+              onBlur={cancelSubwavePrefetch}
+              onClick={handleToggleExpand}
+              onFocus={scheduleSubwavePrefetch}
+              shouldShowButton={shouldShowExpandControl}
+            />
           </div>
           {shouldShowTrustSignalsRow && (
             <div className="tw-mt-0.5 tw-flex tw-min-w-0 tw-items-center tw-gap-2 tw-text-xs tw-text-iron-500">
@@ -356,7 +374,7 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
             </div>
           )}
         </div>
-      </Link>
+      </div>
       {shouldShowPinButton && (
         <BrainLeftSidebarWavePin
           waveId={wave.id}

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
@@ -269,13 +269,10 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
             : "tw-text-iron-400 desktop-hover:group-hover:tw-text-iron-300"
         }`}
       >
-        <Link
-          href={href}
-          prefetch={false}
-          onClick={handleWaveClick}
-          tabIndex={-1}
+        <div
           aria-hidden="true"
-          className="tw-relative tw-flex-shrink-0 tw-no-underline"
+          data-testid="sidebar-wave-avatar"
+          className="tw-relative tw-flex-shrink-0"
         >
           <div
             className={`tw-relative ${avatarSizeClasses} tw-rounded-full tw-transition tw-duration-300 desktop-hover:group-hover:tw-brightness-110 ${getAvatarRingClasses()} ${
@@ -324,7 +321,7 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
               className="tw-absolute tw-right-[-3px] tw-top-[-3px] tw-size-2.5 tw-rounded-full tw-border tw-border-solid tw-border-iron-950 tw-bg-primary-400"
             />
           )}
-        </Link>
+        </div>
         <div className="tw-min-w-0 tw-flex-1">
           <div
             className={`tw-flex tw-min-w-0 tw-items-center tw-gap-1.5 ${

--- a/components/brain/left-sidebar/waves/SidebarWaveExpandControl.tsx
+++ b/components/brain/left-sidebar/waves/SidebarWaveExpandControl.tsx
@@ -7,7 +7,6 @@ interface SidebarWaveExpandControlProps {
   readonly onBlur: () => void;
   readonly onClick: (event: MouseEvent<HTMLButtonElement>) => void;
   readonly onFocus: () => void;
-  readonly shouldReserveSpace: boolean;
   readonly shouldShowButton: boolean;
 }
 
@@ -17,37 +16,33 @@ export function SidebarWaveExpandControl({
   onBlur,
   onClick,
   onFocus,
-  shouldReserveSpace,
   shouldShowButton,
 }: SidebarWaveExpandControlProps) {
-  if (!shouldReserveSpace) {
+  if (!shouldShowButton) {
     return null;
   }
 
   const buttonStateClasses = isExpanded
-    ? "tw-bg-iron-700/60 tw-text-iron-300 tw-opacity-100"
-    : "tw-bg-transparent tw-text-iron-500 tw-opacity-70";
+    ? "tw-bg-iron-700/60 tw-text-iron-200 tw-opacity-100"
+    : "tw-bg-transparent tw-text-iron-500 tw-opacity-80";
 
   return (
-    <div className="tw-flex tw-h-10 tw-w-6 tw-flex-shrink-0 tw-items-center tw-justify-center md:tw-w-5">
-      {shouldShowButton && (
-        <button
-          type="button"
-          aria-label={`${isExpanded ? "Collapse" : "Expand"} ${formattedWaveName} subwaves`}
-          aria-expanded={isExpanded}
-          onClick={onClick}
-          onFocus={onFocus}
-          onBlur={onBlur}
-          className={`tw-relative tw-flex tw-size-6 tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-p-0 tw-transition-all tw-duration-200 desktop-hover:hover:tw-bg-iron-700/70 desktop-hover:hover:tw-text-iron-300 desktop-hover:hover:tw-opacity-100 md:tw-size-5 ${buttonStateClasses}`}
-        >
-          <ChevronRightIcon
-            className={`tw-size-3.5 tw-transition-transform tw-duration-200 tw-ease-out ${
-              isExpanded ? "tw-rotate-90" : ""
-            }`}
-            aria-hidden="true"
-          />
-        </button>
-      )}
-    </div>
+    <button
+      type="button"
+      aria-label={`${isExpanded ? "Collapse" : "Expand"} ${formattedWaveName} subwaves`}
+      aria-expanded={isExpanded}
+      onClick={onClick}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      className={`tw-relative tw-inline-flex tw-size-6 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-p-0 tw-transition-all tw-duration-200 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:hover:tw-bg-iron-700/70 desktop-hover:hover:tw-text-iron-200 desktop-hover:hover:tw-opacity-100 ${buttonStateClasses}`}
+    >
+      <ChevronRightIcon
+        className={`tw-size-4 tw-transition-transform tw-duration-200 tw-ease-out ${
+          isExpanded ? "tw-rotate-90" : ""
+        }`}
+        strokeWidth={2.75}
+        aria-hidden="true"
+      />
+    </button>
   );
 }

--- a/components/brain/left-sidebar/waves/sidebarWaveRowLayout.ts
+++ b/components/brain/left-sidebar/waves/sidebarWaveRowLayout.ts
@@ -2,7 +2,6 @@ type SidebarWaveRowLayoutVariant = "app" | "web";
 
 interface SidebarWaveRowLayoutInput {
   readonly isChildRow: boolean;
-  readonly shouldReserveExpandControlSpace: boolean;
   readonly variant: SidebarWaveRowLayoutVariant;
 }
 
@@ -21,11 +20,6 @@ const rowLayoutByVariant = {
       rowGapClasses: "tw-gap-x-2",
       linkGapClasses: "tw-space-x-2",
     },
-    reserved: {
-      rowPaddingClasses: "tw-pl-2 tw-pr-5",
-      rowGapClasses: "tw-gap-x-2",
-      linkGapClasses: DEFAULT_LINK_GAP_CLASSES,
-    },
     default: {
       rowPaddingClasses: "tw-px-5",
       rowGapClasses: "tw-gap-x-4",
@@ -38,11 +32,6 @@ const rowLayoutByVariant = {
       rowGapClasses: "tw-gap-x-2",
       linkGapClasses: "tw-space-x-2",
     },
-    reserved: {
-      rowPaddingClasses: "tw-pl-2 tw-pr-5 md:tw-pl-1",
-      rowGapClasses: "tw-gap-x-2 md:tw-gap-x-1",
-      linkGapClasses: DEFAULT_LINK_GAP_CLASSES,
-    },
     default: {
       rowPaddingClasses: "tw-px-5",
       rowGapClasses: "tw-gap-x-4",
@@ -51,22 +40,17 @@ const rowLayoutByVariant = {
   },
 } as const satisfies Record<
   SidebarWaveRowLayoutVariant,
-  Record<"child" | "reserved" | "default", SidebarWaveRowLayoutClasses>
+  Record<"child" | "default", SidebarWaveRowLayoutClasses>
 >;
 
 export const getSidebarWaveRowLayoutClasses = ({
   isChildRow,
-  shouldReserveExpandControlSpace,
   variant,
 }: SidebarWaveRowLayoutInput): SidebarWaveRowLayoutClasses => {
   const variantLayout = rowLayoutByVariant[variant];
 
   if (isChildRow) {
     return variantLayout.child;
-  }
-
-  if (shouldReserveExpandControlSpace) {
-    return variantLayout.reserved;
   }
 
   return variantLayout.default;

--- a/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
+++ b/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
@@ -168,13 +168,10 @@ export const ExpandedWave = ({
             : "tw-font-normal tw-text-iron-400 desktop-hover:group-hover:tw-text-iron-300"
         }`}
       >
-        <Link
-          href={href}
-          prefetch={false}
-          onClick={onClick}
-          tabIndex={-1}
+        <div
           aria-hidden="true"
-          className="tw-relative tw-flex-shrink-0 tw-no-underline"
+          data-testid="sidebar-wave-avatar"
+          className="tw-relative tw-flex-shrink-0"
         >
           <WaveAvatar
             isActive={isActive}
@@ -189,7 +186,7 @@ export const ExpandedWave = ({
               className="tw-absolute tw-right-[-3px] tw-top-[-3px] tw-size-2.5 tw-rounded-full tw-border tw-border-solid tw-border-iron-950 tw-bg-primary-400"
             />
           )}
-        </Link>
+        </div>
         <div className="tw-min-w-0 tw-flex-1">
           <div
             className={`-tw-mt-1 tw-mb-1 tw-flex tw-min-w-0 tw-items-center tw-gap-1.5 ${

--- a/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
+++ b/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
@@ -86,7 +86,6 @@ export const ExpandedWave = ({
       : null;
   const isChildRow = depth === 1;
   const shouldShowExpandControl = canExpand && depth === 0;
-  const shouldReserveExpandControlSpace = shouldShowExpandControl;
   const shouldShowPinButton = showPin && depth === 0;
   const trustSignalsTooltipId = `sidebar-expanded-wave-trust-signals-${waveId}`;
   const hasSummaryScore = hasWaveTrustSummaryScore(wave.waveScore);
@@ -95,7 +94,6 @@ export const ExpandedWave = ({
   const { rowPaddingClasses, rowGapClasses, linkGapClasses } =
     getSidebarWaveRowLayoutClasses({
       isChildRow,
-      shouldReserveExpandControlSpace,
       variant: "web",
     });
   const subwavePrefetchTimerRef = useRef<ReturnType<
@@ -131,6 +129,11 @@ export const ExpandedWave = ({
     waveId,
   ]);
 
+  const handleRowMouseEnter = useCallback(() => {
+    scheduleSubwavePrefetch();
+    onMouseEnter?.();
+  }, [onMouseEnter, scheduleSubwavePrefetch]);
+
   useEffect(() => cancelSubwavePrefetch, [cancelSubwavePrefetch]);
 
   const handleToggleExpand = (event: MouseEvent<HTMLButtonElement>) => {
@@ -141,7 +144,7 @@ export const ExpandedWave = ({
 
   return (
     <div
-      onMouseEnter={scheduleSubwavePrefetch}
+      onMouseEnter={handleRowMouseEnter}
       onMouseLeave={cancelSubwavePrefetch}
       role="group"
       className={`tw-group tw-relative tw-flex tw-items-start ${rowGapClasses} ${rowPaddingClasses} tw-py-2 tw-transition-all tw-duration-200 tw-ease-out ${
@@ -150,15 +153,6 @@ export const ExpandedWave = ({
           : "desktop-hover:hover:tw-bg-iron-800/80"
       }`}
     >
-      <SidebarWaveExpandControl
-        formattedWaveName={formattedWaveName}
-        isExpanded={isExpanded}
-        onBlur={cancelSubwavePrefetch}
-        onClick={handleToggleExpand}
-        onFocus={scheduleSubwavePrefetch}
-        shouldReserveSpace={shouldReserveExpandControlSpace}
-        shouldShowButton={shouldShowExpandControl}
-      />
       {isChildRow && (
         <span
           aria-hidden="true"
@@ -167,18 +161,21 @@ export const ExpandedWave = ({
           }`}
         />
       )}
-      <Link
-        href={href}
-        prefetch={false}
-        {...(onMouseEnter ? { onMouseEnter } : {})}
-        onClick={onClick}
-        className={`tw-flex tw-min-w-0 tw-flex-1 ${linkGapClasses} tw-py-1 tw-no-underline tw-transition-all tw-duration-200 tw-ease-out ${
+      <div
+        className={`tw-flex tw-min-w-0 tw-flex-1 ${linkGapClasses} tw-py-1 tw-transition-all tw-duration-200 tw-ease-out ${
           isActive
             ? "tw-font-medium tw-text-white desktop-hover:group-hover:tw-text-white"
             : "tw-font-normal tw-text-iron-400 desktop-hover:group-hover:tw-text-iron-300"
         }`}
       >
-        <div className="tw-relative">
+        <Link
+          href={href}
+          prefetch={false}
+          onClick={onClick}
+          tabIndex={-1}
+          aria-hidden="true"
+          className="tw-relative tw-flex-shrink-0 tw-no-underline"
+        >
           <WaveAvatar
             isActive={isActive}
             isDropWave={isDropWave}
@@ -192,16 +189,36 @@ export const ExpandedWave = ({
               className="tw-absolute tw-right-[-3px] tw-top-[-3px] tw-size-2.5 tw-rounded-full tw-border tw-border-solid tw-border-iron-950 tw-bg-primary-400"
             />
           )}
-        </div>
+        </Link>
         <div className="tw-min-w-0 tw-flex-1">
           <div
-            ref={nameRef}
-            className={`-tw-mt-1 tw-mb-1 tw-truncate tw-text-sm ${
+            className={`-tw-mt-1 tw-mb-1 tw-flex tw-min-w-0 tw-items-center tw-gap-1.5 ${
               shouldShowPinButton ? "tw-pr-7" : ""
             }`}
             {...tooltipAttributes}
           >
-            {formattedWaveName}
+            <Link
+              href={href}
+              prefetch={false}
+              onClick={onClick}
+              className={`tw-min-w-0 tw-flex-shrink tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 ${
+                isActive
+                  ? "tw-text-white desktop-hover:group-hover:tw-text-white"
+                  : "tw-text-iron-400 desktop-hover:group-hover:tw-text-iron-300"
+              }`}
+            >
+              <div ref={nameRef} className="tw-truncate tw-text-sm">
+                {formattedWaveName}
+              </div>
+            </Link>
+            <SidebarWaveExpandControl
+              formattedWaveName={formattedWaveName}
+              isExpanded={isExpanded}
+              onBlur={cancelSubwavePrefetch}
+              onClick={handleToggleExpand}
+              onFocus={scheduleSubwavePrefetch}
+              shouldShowButton={shouldShowExpandControl}
+            />
           </div>
           {shouldShowTrustSignalsRow && (
             <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2 tw-text-xs tw-text-iron-500">
@@ -225,7 +242,7 @@ export const ExpandedWave = ({
             </div>
           )}
         </div>
-      </Link>
+      </div>
       {shouldShowPinButton && (
         <BrainLeftSidebarWavePin
           waveId={waveId}


### PR DESCRIPTION
## Summary
- Move the subwave expand chevron inline to the right of the wave name so parent row avatars keep their vertical alignment.
- Restyle the control with a stronger icon stroke, clearer active state, and focus-visible treatment.
- Update app and web sidebar row tests for the new link/control structure.

## Testing
- `seize run format:changed`
- `seize run lint:changed`
- `seize run typecheck:changed`
- `seize run test:no-coverage -- __tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx __tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx --runInBand`
- `git diff --check --ignore-cr-at-eol main...HEAD`
- Local Playwright visual QA against mocked sidebar API data: parent wave title x positions remained aligned, chevron sits directly after the title, and expanded child rows retain their nested indentation.

## Local note
- `seize run quality:changed` / `seize run check:changed` currently fail in this Windows Codex worktree before the inner formatter prints output because `scripts/quality.js` invokes the repo-local `bin\6529.cmd`, whose Bash path handoff cannot open `D:\...\bin\6529` here. The same formatter, lint, typecheck, tests, and whitespace gates pass through the supported local `seize` wrapper.