### PR TITLE
Polish video player ownership and sizing

### DIFF
--- a/__tests__/components/drops/view/item/content/media/MediaDisplay.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/MediaDisplay.test.tsx
@@ -16,7 +16,7 @@ jest.mock(
       data-testid="video"
       data-src={props.src}
       data-controls={String(props.showControls)}
-      data-disable={String(props.disableClickHandler)}
+      data-fill-container={String(props.fillContainer)}
     />
   )
 );
@@ -113,6 +113,22 @@ describe("MediaDisplay", () => {
     const node = screen.getByTestId("video");
     expect(node).toHaveAttribute("data-src", "vid.mp4");
     expect(node).toHaveAttribute("data-controls", "true");
+    expect(node).toHaveAttribute("data-fill-container", "false");
+  });
+
+  it("forwards fill container sizing to video media", () => {
+    render(
+      <MediaDisplay
+        media_mime_type="video/mp4"
+        media_url="vid.mp4"
+        fillVideoContainer
+      />
+    );
+
+    expect(screen.getByTestId("video")).toHaveAttribute(
+      "data-fill-container",
+      "true"
+    );
   });
 
   it("renders audio", () => {

--- a/__tests__/components/drops/view/item/content/media/MediaDisplayVideo.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/MediaDisplayVideo.test.tsx
@@ -84,6 +84,22 @@ describe("MediaDisplayVideo", () => {
     ).toBeInTheDocument();
   });
 
+  it("fills a reserved media container when requested", () => {
+    const { container } = render(
+      <MediaDisplayVideo src="foo.mp4" fillContainer />
+    );
+
+    const wrapper = container.firstElementChild;
+    const video = container.querySelector("video");
+
+    expect(wrapper).toHaveClass("tw-h-full", "tw-max-h-full");
+    expect(video?.parentElement).toHaveClass(
+      "tw-flex",
+      "tw-items-center",
+      "tw-justify-center"
+    );
+  });
+
   it("downloads the original video source from the custom button", async () => {
     const user = userEvent.setup();
     render(

--- a/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
@@ -51,15 +51,15 @@ function mockPrefersReducedMotion(matches: boolean) {
   jest.spyOn(globalThis, "matchMedia").mockImplementation(
     (query: string) =>
       ({
-      addEventListener: jest.fn(),
-      addListener: jest.fn(),
-      dispatchEvent: jest.fn(),
-      matches,
-      media: query,
-      onchange: null,
-      removeEventListener: jest.fn(),
-      removeListener: jest.fn(),
-    }) as MediaQueryList
+        addEventListener: jest.fn(),
+        addListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+        matches,
+        media: query,
+        onchange: null,
+        removeEventListener: jest.fn(),
+        removeListener: jest.fn(),
+      }) as MediaQueryList
   );
 }
 
@@ -337,9 +337,9 @@ describe("SeizeVideoPlayer", () => {
   });
 
   it("uses the mounted player wrapper as its fullscreen target", async () => {
-    const requestFullscreen = jest.fn().mockImplementation(function (this:
-      | HTMLElement
-      | undefined) {
+    const requestFullscreen = jest.fn().mockImplementation(function (
+      this: HTMLElement | undefined
+    ) {
       Object.defineProperty(document, "fullscreenElement", {
         configurable: true,
         value: this,
@@ -432,9 +432,8 @@ describe("SeizeVideoPlayer", () => {
     });
     fireEvent.play(video);
 
-    const pauseCallsBeforeClick = jest.mocked(
-      HTMLMediaElement.prototype.pause
-    ).mock.calls.length;
+    const pauseCallsBeforeClick = jest.mocked(HTMLMediaElement.prototype.pause)
+      .mock.calls.length;
 
     fireEvent.click(video);
 
@@ -596,7 +595,9 @@ describe("SeizeVideoPlayer", () => {
     const playSpy = jest.spyOn(HTMLMediaElement.prototype, "play");
     render(<SeizeVideoPlayer src="https://example.com/video.mp4" />);
 
-    await userEvent.click(screen.getAllByRole("button", { name: "Play video" })[0]);
+    await userEvent.click(
+      screen.getAllByRole("button", { name: "Play video" })[0]
+    );
 
     expect(playSpy).toHaveBeenCalled();
   });
@@ -689,10 +690,12 @@ describe("SeizeVideoPlayer", () => {
     }
 
     expect(video.muted).toBe(false);
+    expect(video.defaultMuted).toBe(false);
 
     await userEvent.click(screen.getByRole("button", { name: "Mute video" }));
 
     expect(video.muted).toBe(true);
+    expect(video.defaultMuted).toBe(true);
   });
 
   it("stays paused when play is rejected", async () => {

--- a/__tests__/components/waves/drops/WaveDropPartContentMedias.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropPartContentMedias.test.tsx
@@ -76,8 +76,9 @@ describe("WaveDropPartContentMedias", () => {
     );
     expect(image.parentElement).toHaveClass("tw-h-64");
     expect(video).toBeInTheDocument();
-    expect(video).toHaveAttribute("data-fill-video-container", "true");
-    expect(video.parentElement).toHaveClass("tw-h-64");
+    expect(video).toHaveAttribute("data-fill-video-container", "false");
+    expect(video.parentElement).not.toHaveClass("tw-h-64");
+    expect(video.parentElement).toHaveClass("tw-items-start");
     expect(container.querySelector(".tw-grid.tw-grid-cols-1")).toBeNull();
   });
 
@@ -137,7 +138,7 @@ describe("WaveDropPartContentMedias", () => {
     expect(video.parentElement).not.toHaveClass("tw-h-64");
   });
 
-  it("uses custom reserved height classes for normal image media", () => {
+  it("uses custom reserved height classes for normal image media only", () => {
     render(
       <WaveDropPartContentMedias
         activePart={basePart}
@@ -148,8 +149,12 @@ describe("WaveDropPartContentMedias", () => {
     expect(screen.getByTestId("wave-image-media").parentElement).toHaveClass(
       "tw-h-96"
     );
-    expect(screen.getByTestId("drop-media").parentElement).toHaveClass(
+    expect(screen.getByTestId("drop-media").parentElement).not.toHaveClass(
       "tw-h-96"
+    );
+    expect(screen.getByTestId("drop-media")).toHaveAttribute(
+      "data-fill-video-container",
+      "false"
     );
   });
 

--- a/components/drop-forge/craft/DropForgeCraftClaimPageClient.tsx
+++ b/components/drop-forge/craft/DropForgeCraftClaimPageClient.tsx
@@ -1157,6 +1157,7 @@ function AnimationSection({
                 <MediaDisplay
                   media_mime_type={animationPreviewMimeType}
                   media_url={animationDisplayUrl}
+                  fillVideoContainer
                 />
               </div>
             )}

--- a/components/drop-forge/launch/DropForgeLaunchClaimPageClient.view.tsx
+++ b/components/drop-forge/launch/DropForgeLaunchClaimPageClient.view.tsx
@@ -647,6 +647,7 @@ function DropForgeLaunchClaimMediaDisplayContent({
       <MediaDisplay
         media_mime_type={animationMimeType}
         media_url={claim.animation_url ?? ""}
+        fillVideoContainer
       />
     );
   }

--- a/components/drops/view/item/content/media/DropListItemContentMediaVideo.tsx
+++ b/components/drops/view/item/content/media/DropListItemContentMediaVideo.tsx
@@ -133,6 +133,9 @@ function DropListItemContentMediaVideo({
         onOpen={openMedia}
         openLabel={openLabel}
         isDownloading={isDownloading}
+        onVideoClick={(event) => {
+          event.preventDefault();
+        }}
       />
     </div>
   );

--- a/components/drops/view/item/content/media/MediaDisplay.tsx
+++ b/components/drops/view/item/content/media/MediaDisplay.tsx
@@ -170,6 +170,7 @@ export default function MediaDisplay({
   previewImageUrl,
   requireInteractionToLoad = false,
   iframeContainerClassName,
+  fillVideoContainer = false,
   loadStrategy = "in-view",
 }: {
   readonly media_mime_type: string;
@@ -179,6 +180,7 @@ export default function MediaDisplay({
   readonly previewImageUrl?: string | null | undefined;
   readonly requireInteractionToLoad?: boolean | undefined;
   readonly iframeContainerClassName?: string | undefined;
+  readonly fillVideoContainer?: boolean | undefined;
   readonly loadStrategy?: MediaLoadStrategy | undefined;
 }) {
   const getMediaType = (): MediaType => {
@@ -265,6 +267,7 @@ export default function MediaDisplay({
           src={media_url}
           mimeType={media_mime_type}
           showControls={!disableMediaInteraction}
+          fillContainer={fillVideoContainer}
         />
       );
     case MediaType.AUDIO:

--- a/components/drops/view/item/content/media/MediaDisplayVideo.tsx
+++ b/components/drops/view/item/content/media/MediaDisplayVideo.tsx
@@ -5,6 +5,7 @@ import { useInView } from "@/hooks/useInView";
 import { useOptimizedVideo } from "@/hooks/useOptimizedVideo";
 import { useHlsPlayer } from "@/hooks/useHlsPlayer";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
+import clsx from "clsx";
 import SeizeVideoPlayer from "./SeizeVideoPlayer";
 import { useMediaActions } from "./useMediaActions";
 
@@ -12,12 +13,14 @@ interface Props {
   readonly src: string;
   readonly mimeType?: string | undefined;
   readonly showControls?: boolean | undefined;
+  readonly fillContainer?: boolean | undefined;
 }
 
 const MediaDisplayVideo: React.FC<Props> = ({
   src,
   mimeType,
   showControls = false,
+  fillContainer = false,
 }) => {
   // Intersection observer for scroll-based triggers
   const [wrapperRef, inView] = useInView<HTMLDivElement>({ threshold: 0.1 });
@@ -105,15 +108,28 @@ const MediaDisplayVideo: React.FC<Props> = ({
   }, [isApp, videoRef]);
 
   return (
-    <div ref={wrapperRef} className="tw-flex tw-w-full tw-justify-start">
+    <div
+      ref={wrapperRef}
+      className={clsx(
+        "tw-flex tw-w-full tw-items-start",
+        fillContainer
+          ? "tw-h-full tw-max-h-full tw-justify-center"
+          : "tw-justify-start"
+      )}
+    >
       <SeizeVideoPlayer
         videoRef={videoRef}
         template="ambient-media"
+        layout={fillContainer ? "fill" : "natural"}
+        align={fillContainer ? "center" : "left"}
         showActions={showControls}
         onDownload={showControls ? downloadMedia : undefined}
         onOpen={showControls ? openMedia : undefined}
         openLabel={showControls ? openLabel : undefined}
         isDownloading={isDownloading}
+        onVideoClick={(event) => {
+          event.preventDefault();
+        }}
       />
     </div>
   );

--- a/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
+++ b/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
@@ -308,7 +308,9 @@ function SeizeVideoMinimalControls({
           )}
           {showFullscreen && (
             <SeizeVideoControlButton
-              label={isAnyFullscreen ? labels.exitFullscreen : labels.fullscreen}
+              label={
+                isAnyFullscreen ? labels.exitFullscreen : labels.fullscreen
+              }
               onClick={onFullscreenClick}
               onFocus={onControlsFocus}
               tabIndex={controlsTabIndex}
@@ -329,9 +331,7 @@ function SeizeVideoMinimalControls({
         </div>
       </div>
 
-      <div
-        className="tw-absolute tw-bottom-0 tw-left-0 tw-right-0 tw-z-30 tw-h-4 tw-overflow-hidden"
-      >
+      <div className="tw-absolute tw-bottom-0 tw-left-0 tw-right-0 tw-z-30 tw-h-4 tw-overflow-hidden">
         <input
           type="range"
           min="0"
@@ -441,7 +441,8 @@ function SeizeVideoElement({
 }) {
   return (
     <>
-      {/* NOSONAR: render captions only when a real VTT source exists. */}<video
+      {/* NOSONAR: render captions only when a real VTT source exists. */}
+      <video
         id={id}
         ref={setVideoRef}
         src={src}
@@ -589,7 +590,9 @@ export default function SeizeVideoPlayer({
   >();
   const [viewportHeight, setViewportHeight] = useState<number | undefined>(
     () =>
-      globalThis.window === undefined ? undefined : globalThis.window.innerHeight
+      globalThis.window === undefined
+        ? undefined
+        : globalThis.window.innerHeight
   );
   const [fallbackState, setFallbackState] = useState<{
     readonly originSrc?: string | undefined;
@@ -690,7 +693,8 @@ export default function SeizeVideoPlayer({
       updateProgress();
       const video = internalVideoRef.current;
       if (video && !video.paused && !video.ended) {
-        animationFrameRef.current = globalThis.window.requestAnimationFrame(tick);
+        animationFrameRef.current =
+          globalThis.window.requestAnimationFrame(tick);
       }
     };
     animationFrameRef.current = globalThis.window.requestAnimationFrame(tick);
@@ -831,7 +835,13 @@ export default function SeizeVideoPlayer({
   function toggleMuted(event: React.MouseEvent<HTMLButtonElement>) {
     event.preventDefault();
     event.stopPropagation();
-    setMutedState({ prop: resolvedTemplate.muted, src, value: !isMuted });
+    const nextMuted = !isMuted;
+    const video = internalVideoRef.current;
+    if (video) {
+      video.muted = nextMuted;
+      video.defaultMuted = nextMuted;
+    }
+    setMutedState({ prop: resolvedTemplate.muted, src, value: nextMuted });
     revealControls();
   }
 
@@ -995,10 +1005,8 @@ export default function SeizeVideoPlayer({
   const isWrapperFullscreen = isFullscreen;
   const controlsAreVisible = controlsVisible || isPaused || isAnyFullscreen;
   const responsiveMediaStyle = getResponsiveMediaStyle();
-  const duration =
-    durationState.src === directSrc ? durationState.value : 0;
-  const progress =
-    progressState.src === directSrc ? progressState.value : 0;
+  const duration = durationState.src === directSrc ? durationState.value : 0;
+  const progress = progressState.src === directSrc ? progressState.value : 0;
   const seekDisabled = duration <= 0;
   const hasUserPausedOwnedAutoplay = userPausedAutoplaySrc === directSrc;
   const labels = useMemo<SeizeVideoLabels>(
@@ -1051,6 +1059,15 @@ export default function SeizeVideoPlayer({
     // Browser playback is an imperative media side effect of visibility policy.
     syncOwnedAutoplay();
   }, [directSrc, syncOwnedAutoplay]);
+
+  useEffect(() => {
+    if (!videoElement) {
+      return;
+    }
+
+    videoElement.muted = isMuted;
+    videoElement.defaultMuted = isMuted;
+  }, [isMuted, videoElement]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- Add an opt-in `fillVideoContainer` path through `MediaDisplay` so Drop Forge animation previews can fill their reserved preview boxes without changing normal wave/drop video sizing.
- Keep externally-owned HLS/in-view media from toggling playback through raw video-surface clicks, so ownership stays with the surrounding media/list playback logic.
- Sync mute changes to both `muted` and `defaultMuted` on the DOM media element.
- Update media/player tests for the split between natural video sizing and fill-to-container preview templates.

## Supersedes
- Supersedes #2484. That branch is now old against current `main`, conflicts in the shared media player path, and its intended Drop Forge sizing behavior is covered here through the shared `MediaDisplay` template flag.

## Validation
- `seize run format:changed`
- `seize run lint:changed`
- `seize run typecheck:changed`
- `seize run test:no-coverage -- __tests__/components/drops/view/item/content/media/MediaDisplay.test.tsx __tests__/components/drops/view/item/content/media/MediaDisplayVideo.test.tsx __tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx __tests__/components/waves/drops/WaveDropPartContentMedias.test.tsx`
- `codex-diff-check`

Note: `seize run check:changed` is blocked in this Windows Codex worktree because `scripts/quality.js` shells back through repo `bin/6529.cmd` instead of the local `seize` wrapper; the direct subchecks above pass. Direct `knip --reporter json` still reports existing repo-wide dead-code findings unrelated to this branch.