### PR TITLE
Keep wave trust stats readable in details panel

### DIFF
--- a/components/waves/header/WaveHeaderTrustStats.tsx
+++ b/components/waves/header/WaveHeaderTrustStats.tsx
@@ -151,7 +151,7 @@ export default function WaveHeaderTrustStats({
         WAVE_HEADER_TRUST_LOCALE,
         "waves.score.details.statsAriaLabel"
       )}
-      className="tw-grid tw-grid-cols-2 tw-gap-2 sm:tw-grid-cols-4"
+      className="tw-grid tw-grid-cols-2 tw-gap-2"
     >
       {stats.map((stat) => {
         const Icon = stat.icon;


### PR DESCRIPTION
## Summary
- keep the Wave Details trust stats band at two columns so labels remain readable in the narrow panel
- preserves the existing Score / Quality / Hot / Wave REP stat content and tones

## Validation
- `seize run test:no-coverage -- __tests__/components/waves/header/WaveHeader.test.tsx __tests__/components/waves/WaveTrustSignals.test.tsx`
- `seize run typecheck:changed`
- `seize run lint:changed`
- `codex-diff-check`

## Release note
- Polishes the Wave Details score/REP stats layout before production rollout.