### PR TITLE
Fix release notes redirect origin

### DIFF
--- a/__tests__/app/about/release-notes.route.test.ts
+++ b/__tests__/app/about/release-notes.route.test.ts
@@ -32,7 +32,7 @@ describe("/about/release-notes redirect route", () => {
 
   it("permanently redirects GET requests to the Releases wave", () => {
     const request = createRequest(
-      "https://6529.io/about/release-notes?utm_source=sitemap"
+      "https://0.0.0.0:3001/about/release-notes?utm_source=sitemap"
     );
 
     const response = GET(request);

--- a/app/about/release-notes/route.ts
+++ b/app/about/release-notes/route.ts
@@ -1,11 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server";
 
-const RELEASES_WAVE_PATH = "/waves/05b14183-e153-4e47-bc66-42a0f49102d4";
+const RELEASES_WAVE_URL =
+  "https://6529.io/waves/05b14183-e153-4e47-bc66-42a0f49102d4";
 
-function redirectToReleasesWave(request: NextRequest): NextResponse {
-  const targetUrl = new URL(RELEASES_WAVE_PATH, request.url);
-
-  return NextResponse.redirect(targetUrl, 301);
+function redirectToReleasesWave(_request: NextRequest): NextResponse {
+  return NextResponse.redirect(new URL(RELEASES_WAVE_URL), 301);
 }
 
 export function GET(request: NextRequest): NextResponse {


### PR DESCRIPTION
## Summary
- make the `/about/release-notes` route redirect to the canonical `https://6529.io` Releases wave URL
- cover the production-like internal-origin request URL so the redirect host cannot regress to `0.0.0.0:3001`

## Verification
- `seize run test:no-coverage -- __tests__/app/about/release-notes.route.test.ts`
- `seize run lint:changed`
- `seize run typecheck:changed`
- `codex-diff-check`