### PR TITLE
[codex] Guard prod deploy workflow ref

### DIFF
--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -2,6 +2,10 @@ name: Web Deploy - PROD
 
 on: workflow_dispatch
 
+concurrency:
+  group: web-deploy-prod
+  cancel-in-progress: false
+
 env:
   AWS_BUCKET: "seize-web"
   COMMIT_SHA: "${{ github.sha }}"
@@ -20,8 +24,25 @@ env:
   ASSETS_FROM_S3: "true"
 
 jobs:
-  build-upload-deploy:
+  assert-main-ref:
+    name: Assert main ref
     runs-on: ubuntu-latest
+    permissions: {}
+
+    steps:
+      - name: Assert production deploy runs from main
+        run: |
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
+            echo "::error::Production deploys must be run from the main branch. Selected ref: ${GITHUB_REF_NAME} (${GITHUB_SHA})."
+            exit 1
+          fi
+
+  build-upload-deploy:
+    needs: assert-main-ref
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment: production
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- fail the production web deploy workflow before build/upload/deploy when the selected ref is not `main`
- add a `web-deploy-prod` concurrency group so production deploys queue instead of overlapping
- attach the deploy job to the GitHub `production` environment, now configured with a `main` branch deployment policy
- limit workflow `GITHUB_TOKEN` permissions per CodeQL feedback

## Why
A manual `Web Deploy - PROD` run was dispatched from `codex/prod-subwave-chevron-2747`. The SHA was already merged into `main`, but the workflow should not permit production deploys from any non-main selected ref.

## Validation
- `codex-diff-check -- .github/workflows/build-upload-deploy-prod.yml`
- parsed `.github/workflows/build-upload-deploy-prod.yml` with PyYAML
- confirmed guard text, production environment, concurrency group, and explicit permissions are present