### PR TITLE
[codex] Polish wave sidebar chevron and trust cards

### DIFF
--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
@@ -246,12 +246,12 @@ describe("BrainLeftSidebarWave", () => {
     expect(expandButton).not.toHaveClass("tw-absolute");
     expect(expandButton).toHaveClass("tw-relative");
     expect(expandButton).toHaveClass("tw-inline-flex");
-    expect(expandButton).toHaveClass("tw-size-6");
+    expect(expandButton).toHaveClass("tw-size-5");
     expect(expandButton).toHaveClass("tw-rounded-full");
     expect(expandButton).toHaveClass("tw-border-0");
     expect(expandButton).toHaveClass("tw-bg-transparent");
     expect(expandButton).toHaveClass("desktop-hover:hover:tw-bg-iron-700/70");
-    expect(expandButton.querySelector("svg")).toHaveClass("tw-size-4");
+    expect(expandButton.querySelector("svg")).toHaveClass("tw-size-3.5");
     expect(expandButton.querySelector(".tw-bg-primary-400")).toBeNull();
     const unreadSubwavesDot = getWaveRow().querySelector(".tw-bg-primary-400");
     expect(unreadSubwavesDot).not.toBeNull();

--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -353,7 +353,7 @@ it("auto-expands the parent for the active subwave", () => {
   expect(screen.getByTestId("wave-child")).toBeInTheDocument();
 });
 
-it("loads and expands a direct active subwave parent before the child row is available", async () => {
+it("loads a direct active subwave parent before showing it expanded", async () => {
   mockUseMyStream.mockReturnValue({
     activeWave: { id: "child", parentWaveId: "parent", set: jest.fn() },
     waves: {
@@ -377,7 +377,7 @@ it("loads and expands a direct active subwave parent before the child row is ava
 
   expect(screen.getByTestId("wave-parent")).toHaveAttribute(
     "data-expanded",
-    "true"
+    "false"
   );
   expect(screen.queryByTestId("wave-child")).toBeNull();
 

--- a/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
@@ -116,12 +116,12 @@ describe("ExpandedWave", () => {
     expect(expandButton).not.toHaveClass("tw-absolute");
     expect(expandButton).toHaveClass("tw-relative");
     expect(expandButton).toHaveClass("tw-inline-flex");
-    expect(expandButton).toHaveClass("tw-size-6");
+    expect(expandButton).toHaveClass("tw-size-5");
     expect(expandButton).toHaveClass("tw-rounded-full");
     expect(expandButton).toHaveClass("tw-border-0");
     expect(expandButton).toHaveClass("tw-bg-transparent");
     expect(expandButton).toHaveClass("desktop-hover:hover:tw-bg-iron-700/70");
-    expect(expandButton.querySelector("svg")).toHaveClass("tw-size-4");
+    expect(expandButton.querySelector("svg")).toHaveClass("tw-size-3.5");
     expect(expandButton.querySelector(".tw-bg-primary-400")).toBeNull();
     const unreadSubwavesDot = getWaveRow().querySelector(".tw-bg-primary-400");
     expect(unreadSubwavesDot).not.toBeNull();

--- a/__tests__/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.test.tsx
@@ -447,7 +447,7 @@ it("auto-expands the parent for the active subwave", () => {
   expect(screen.getByTestId("wave-child")).toBeInTheDocument();
 });
 
-it("loads and expands a direct active subwave parent before the child row is available", async () => {
+it("loads a direct active subwave parent before showing it expanded", async () => {
   mockUseMyStream.mockReturnValue({
     activeWave: { id: "child", parentWaveId: "parent", set: jest.fn() },
     waves: {
@@ -472,7 +472,7 @@ it("loads and expands a direct active subwave parent before the child row is ava
 
   expect(screen.getByTestId("wave-parent")).toHaveAttribute(
     "data-expanded",
-    "true"
+    "false"
   );
   expect(screen.queryByTestId("wave-child")).toBeNull();
 

--- a/__tests__/hooks/useSidebarWaveTree.test.tsx
+++ b/__tests__/hooks/useSidebarWaveTree.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { createMockMinimalWave } from "@/__tests__/utils/mockFactories";
 import { useSidebarWaveTree } from "@/hooks/useSidebarWaveTree";
+import type { MinimalWave } from "@/contexts/wave/hooks/useEnhancedWavesListCore";
 
 describe("useSidebarWaveTree", () => {
   beforeEach(() => {
@@ -300,15 +301,21 @@ describe("useSidebarWaveTree", () => {
     expect(onParentExpand).toHaveBeenLastCalledWith("parent");
   });
 
-  it("loads a direct active subwave parent before the child is in the list", () => {
+  it("loads a direct active subwave parent without showing it expanded before rows exist", () => {
     const onParentExpand = jest.fn();
-    const { result } = renderHook(() =>
-      useSidebarWaveTree({
-        waves: [waves[0]!],
-        activeWaveId: "direct-child",
-        activeParentWaveId: "parent",
-        onParentExpand,
-      })
+    const { result, rerender } = renderHook(
+      ({ currentWaves }: { readonly currentWaves: readonly MinimalWave[] }) =>
+        useSidebarWaveTree({
+          waves: currentWaves,
+          activeWaveId: "direct-child",
+          activeParentWaveId: "parent",
+          onParentExpand,
+        }),
+      {
+        initialProps: {
+          currentWaves: [waves[0]!],
+        },
+      }
     );
 
     const rows = result.current.getRows(result.current.topLevelWaves);
@@ -317,6 +324,27 @@ describe("useSidebarWaveTree", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({
       wave: expect.objectContaining({ id: "parent" }),
+      isExpanded: false,
+    });
+
+    rerender({
+      currentWaves: [
+        waves[0]!,
+        createMockMinimalWave({
+          id: "direct-child",
+          parentWaveId: "parent",
+          createdAt: 30,
+        }),
+      ],
+    });
+
+    const loadedRows = result.current.getRows(result.current.topLevelWaves);
+
+    expect(loadedRows.map((row) => row.wave.id)).toEqual([
+      "parent",
+      "direct-child",
+    ]);
+    expect(loadedRows[0]).toMatchObject({
       isExpanded: true,
     });
   });

--- a/components/brain/left-sidebar/waves/SidebarWaveExpandControl.tsx
+++ b/components/brain/left-sidebar/waves/SidebarWaveExpandControl.tsx
@@ -34,10 +34,10 @@ export function SidebarWaveExpandControl({
       onClick={onClick}
       onFocus={onFocus}
       onBlur={onBlur}
-      className={`tw-relative tw-inline-flex tw-size-6 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-p-0 tw-transition-all tw-duration-200 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:hover:tw-bg-iron-700/70 desktop-hover:hover:tw-text-iron-200 desktop-hover:hover:tw-opacity-100 ${buttonStateClasses}`}
+      className={`tw-relative tw-inline-flex tw-size-5 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-p-0 tw-transition-all tw-duration-200 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:hover:tw-bg-iron-700/70 desktop-hover:hover:tw-text-iron-200 desktop-hover:hover:tw-opacity-100 ${buttonStateClasses}`}
     >
       <ChevronRightIcon
-        className={`tw-size-4 tw-transition-transform tw-duration-200 tw-ease-out ${
+        className={`tw-size-3.5 tw-transition-transform tw-duration-200 tw-ease-out ${
           isExpanded ? "tw-rotate-90" : ""
         }`}
         strokeWidth={2.75}

--- a/components/waves/header/WaveHeaderTrustStats.tsx
+++ b/components/waves/header/WaveHeaderTrustStats.tsx
@@ -151,7 +151,7 @@ export default function WaveHeaderTrustStats({
         WAVE_HEADER_TRUST_LOCALE,
         "waves.score.details.statsAriaLabel"
       )}
-      className="tw-grid tw-grid-cols-2 tw-gap-2"
+      className="tw-grid tw-grid-cols-2 tw-gap-1.5"
     >
       {stats.map((stat) => {
         const Icon = stat.icon;
@@ -159,14 +159,17 @@ export default function WaveHeaderTrustStats({
           <div
             key={stat.id}
             aria-label={stat.ariaLabel}
-            className={`tw-flex tw-min-w-0 tw-items-center tw-gap-2 tw-rounded-lg tw-border tw-border-solid tw-px-2.5 tw-py-2 ${toneClasses[stat.tone]}`}
+            className={`tw-flex tw-min-w-0 tw-items-center tw-gap-1.5 tw-rounded-md tw-border tw-border-solid tw-px-2 tw-py-1.5 ${toneClasses[stat.tone]}`}
           >
-            <Icon className="tw-size-4 tw-flex-shrink-0" aria-hidden="true" />
+            <Icon
+              className="tw-size-3.5 tw-flex-shrink-0"
+              aria-hidden="true"
+            />
             <div className="tw-min-w-0">
-              <dt className="tw-truncate tw-text-[10px] tw-font-semibold tw-uppercase tw-leading-4 tw-tracking-wide tw-text-iron-400">
+              <dt className="tw-truncate tw-text-[9px] tw-font-semibold tw-uppercase tw-leading-3 tw-tracking-wide tw-text-iron-400">
                 {stat.label}
               </dt>
-              <dd className="tw-m-0 tw-truncate tw-text-sm tw-font-semibold tw-tabular-nums tw-leading-5 tw-text-current">
+              <dd className="tw-m-0 tw-truncate tw-text-[13px] tw-font-semibold tw-tabular-nums tw-leading-4 tw-text-current">
                 {stat.value}
               </dd>
             </div>

--- a/hooks/useSidebarWaveTree.ts
+++ b/hooks/useSidebarWaveTree.ts
@@ -128,7 +128,10 @@ const buildSidebarWaveRows = ({
     const canExpand =
       wave.parentWaveId === null && (wave.hasSubwaves || subwaves.length > 0);
     const isExpanded =
-      showExpandedSubwaves && canExpand && getIsExpanded(wave.id);
+      showExpandedSubwaves &&
+      canExpand &&
+      subwaves.length > 0 &&
+      getIsExpanded(wave.id);
     const hasUnreadSubwaves = canExpand && getHasUnreadSubwaves(wave.id);
 
     rows.push({
@@ -263,9 +266,17 @@ export function useSidebarWaveTree({
     [subwavesByParentId]
   );
 
+  const getIsVisiblyExpanded = useCallback(
+    (waveId: string) =>
+      showExpandedSubwaves &&
+      (subwavesByParentId.get(waveId)?.length ?? 0) > 0 &&
+      getIsExpanded(waveId),
+    [getIsExpanded, showExpandedSubwaves, subwavesByParentId]
+  );
+
   const toggleParent = useCallback(
     (waveId: string) => {
-      const isExpanded = getIsExpanded(waveId);
+      const isExpanded = getIsVisiblyExpanded(waveId);
       if (!isExpanded) {
         requestParentExpand(waveId, { force: true });
       }
@@ -294,7 +305,7 @@ export function useSidebarWaveTree({
         return nextState;
       });
     },
-    [getIsExpanded, requestParentExpand]
+    [getIsVisiblyExpanded, requestParentExpand]
   );
 
   const getRows = useCallback(


### PR DESCRIPTION
## Summary
- shrink the subwave chevron control in the wave sidebar so it reads as a secondary affordance
- keep parents visually collapsed while active/manual subwave expansion is still waiting for fetched child rows
- tighten Wave Details trust stat cards by reducing spacing, radius, icon size, and value type

## Why
A parent wave could show a down chevron before any subwave rows were actually visible, which made users click closed/open again to reveal the children. The trust stat cards also had more weight than needed in compact desktop/mobile details panels.

## Validation
- `seize run lint:changed`
- `seize run typecheck:changed`
- `seize run test:no-coverage -- __tests__/hooks/useSidebarWaveTree.test.tsx __tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx __tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx __tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx __tests__/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.test.tsx __tests__/components/waves/header/WaveHeader.test.tsx`
- `codex-diff-check`