### PR TITLE
Document deployment bus process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,9 @@ is available, use it; otherwise read the relevant files in
     state changes.
   - `ops/skills/sonar-guardrails/SKILL.md` for TS/JS quality-sensitive edits.
   - `ops/skills/write-skills/SKILL.md` for repo-local skill work.
+- For merge, staging, production, or release-lane work, read
+  `ops/docs/developer/deployment-bus-process.md` and
+  `ops/skills/deploy-6529/SKILL.md` before acting.
 - Operational plans, roadmaps, runbooks, workstream state, and agent process
   docs belong under `ops/`, not top-level `docs/`.
 - Operational scripts belong under `ops/scripts/`; app build/runtime scripts

--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ through [Procfile](Procfile).
 Repository and deployment helper details, including `ghruns`, `ghdeploy`,
 `6529 staging`, and PM2 launch examples, are documented in
 [ops/docs/developer/pnpm-and-socket-firewall.md](ops/docs/developer/pnpm-and-socket-firewall.md).
+The staging and production deployment-bus process for coordinating many
+agents, shared validation, backend dependencies, and production promotion is
+documented in
+[ops/docs/developer/deployment-bus-process.md](ops/docs/developer/deployment-bus-process.md).
 
 ## Contributing
 

--- a/ops/docs/developer/deployment-bus-process.md
+++ b/ops/docs/developer/deployment-bus-process.md
@@ -1,0 +1,304 @@
+# Staging And Production Deployment Bus
+
+Status: process proposal for team review. This page defines the operating
+model before automation. A later automation PR should add labels, queue
+materialization, GitHub Deployment records, manifests, staging E2E commands,
+and dashboard helpers.
+
+## Why This Exists
+
+The frontend and backend deployment lanes are shared, slow enough to become a
+team bottleneck, and increasingly used by many agents at once. Without a
+single process, agents can validate different assumptions, overwrite staging,
+or ask production to ship a commit that did not pass staging.
+
+The deployment bus turns staging and production into an explicit queue:
+
+- one owner per active deployment lane
+- exact SHAs and included PRs recorded before deploy
+- no overlapping deploys to the same environment
+- shared validation assignments for all included PR owners
+- production only from the same `origin/main` SHA or release set that passed
+  staging
+- human-owned production approval
+
+## Current Deployment Facts
+
+Frontend staging:
+
+- Staging uses the `1a-staging` branch.
+- `.github/workflows/deploy-staging.yml` runs on pushes to `1a-staging` and
+  manual dispatch.
+- The workflow uses `concurrency.group: staging-deploy` with
+  `cancel-in-progress: false`.
+- The workflow resolves the expected SHA, sends an SSM command to the staging
+  host, fetches `origin/1a-staging`, refuses to deploy if the fetched SHA is
+  not the expected SHA, runs `./bin/6529 staging`, and verifies the deployed
+  checkout still matches the expected SHA.
+- `scripts/staging.sh` installs dependencies, builds, restarts the PM2
+  `6529seize` process, and saves PM2 state.
+
+Frontend production:
+
+- `.github/workflows/build-upload-deploy-prod.yml` is manually dispatched.
+- The workflow uses `concurrency.group: web-deploy-prod` with
+  `cancel-in-progress: false`.
+- The `assert-main-ref` job rejects any selected ref other than
+  `refs/heads/main`.
+- Production builds in CI, uploads static assets and a Next standalone bundle,
+  creates an Elastic Beanstalk application version labeled with the GitHub SHA,
+  updates the production environment, waits for health, and verifies the EB
+  version label equals the workflow SHA.
+- `bin/ghdeploy` may be used only from a clean repo root on `main`, exactly in
+  sync with its upstream.
+
+Backend coordination:
+
+- Backend deploys use `6529seize-backend` and its own `deploy-6529` skill.
+- Backend `.github/workflows/deploy.yml` dispatches one service at a time for
+  `environment=staging` or `environment=prod`.
+- Backend releases must identify services and order before deploy.
+  `dbMigrationsLoop` goes before services that depend on entity sync, schema
+  behavior, explicit migrations, or backfills. `api` goes before frontend
+  production when the frontend depends on new API behavior.
+- Backward-compatible backend/API changes are preferred so frontend and backend
+  can roll independently.
+- Backend OpenAPI changes must show that backend generated files are current
+  and that the frontend generated client matches the intended backend contract
+  before frontend staging uses new API behavior.
+
+Known current gaps:
+
+- There is no durable staging bus ledger yet.
+- There is no dedicated deployed-staging E2E command yet. Current Playwright
+  E2E is local by default and starts a local dev server.
+- GitHub Deployment objects are not yet the authoritative ledger for staging or
+  production in this repo.
+- Backend coordination is still a cross-repo handoff, not a shared automated
+  release train.
+
+## Operating Roles
+
+Release captain:
+
+- owns one active environment lane until it is terminal and handed off
+- assembles the staging or production manifest
+- checks active deploy runs before moving the lane
+- assigns validation owners and keeps the status ledger current
+- decides whether a failure blocks the whole batch, needs fix-forward, or
+  needs human escalation
+- posts concise deployment-topic updates to the team wave when useful
+
+PR owner or validation agent:
+
+- validates the changed surface for a PR included in the batch
+- reports exact evidence: route, API, command, browser check, screenshot, run
+  URL, or failure
+- does not move staging, trigger production, or overwrite the active candidate
+  unless the release captain hands off the lane
+
+Core smoke validator:
+
+- validates common app health for the deployed candidate
+- checks route load, critical API responses, console/network failures, and
+  obvious static asset/version issues
+
+Human release approver:
+
+- approves production promotion from a staging-passed manifest
+- decides whether to include, hold, or override high-risk changes
+- owns decisions that are destructive, irreversible, or not represented by
+  automated checks
+
+## Staging Bus Policy
+
+Staging is the integration surface. It should move quickly when idle and batch
+when the team is generating more work than the lane can deploy.
+
+Departure policy:
+
+- If the staging lane is idle and exactly one eligible release set is ready,
+  depart immediately. Do not wait for the clock.
+- If the lane is busy or there is a backlog, use bus mode. Close the next
+  batch at a fixed cutoff and depart as soon as the previous staging cycle is
+  terminal.
+- Use 30 minutes as the initial maximum batching window under backlog. Tune it
+  from measured deploy duration, validation duration, queue length, and failure
+  rate.
+- Emergency fixes can bypass the normal batch window with an explicit human or
+  release-captain decision, but they still must obey the no-overlap and SHA
+  evidence gates.
+
+Eligible release set:
+
+- merged to `origin/main`, unless staging is intentionally testing a PR before
+  merge under a documented exception
+- required CI and review bots terminal or explicitly deferred
+- risk and area understood
+- backend dependencies listed with required deploy order
+- validation owner identified
+- rollback or fix-forward path understood
+
+Staging manifest:
+
+```text
+environment: staging
+candidate_sha: <frontend main or staging branch SHA>
+candidate_branch: 1a-staging
+included_prs:
+  - number:
+    title:
+    merge_sha:
+    risk:
+    areas:
+    validation_owner:
+    required_checks:
+backend_dependencies:
+  - repo:
+    pr:
+    sha:
+    service:
+    staging_sha:
+    prod_sha:
+    order:
+    openapi_or_generated_client:
+validation:
+  core_smoke_owner:
+  required_packs:
+  exploratory_checks:
+status: queued | deploying | validating | passed | failed | held | superseded
+```
+
+Until automation exists, the release captain can keep this manifest in the PR
+description, a deployment wave update, or a workstream note. The automation PR
+should make it a durable artifact and GitHub Deployment payload.
+
+## Multi-Agent Staging Validation
+
+After staging deploys:
+
+1. The release captain posts the deployed SHA, included PRs, owners, and
+   validation checklist.
+2. Each PR owner validates only their owned surface and reports evidence.
+3. The core smoke validator checks common app health.
+4. The release captain marks every included PR as passed, failed, held, or
+   superseded.
+5. Production remains blocked until every required validation item is passed or
+   explicitly held out of the production candidate.
+
+Failure handling:
+
+- If a release bug is found, fix forward through the normal PR path, merge the
+  fix, redeploy staging from the new SHA, and rerun the failed and smoke checks.
+- If the failure belongs to environment or data state, document the evidence,
+  coordinate the owner, rerun after correction, and keep production blocked
+  until the signal is clear.
+- If a check is flaky, rerun once with evidence. Repeated failures become a
+  release bug or test-hardening task.
+- If a single PR in a batch is held, production can proceed only if the held
+  behavior is not present in the production candidate. With the current
+  production-from-main gate, that usually means waiting for a fix-forward or
+  intentionally validating the newer `origin/main` SHA after the hold is
+  resolved.
+
+## Production Promotion Policy
+
+Production deploys from `origin/main` only in the current frontend workflow.
+That hard gate is intentional for this process proposal.
+
+Before production:
+
+- staging passed for the same ordered frontend/backend release set
+- the production candidate is exactly the current `origin/main` SHA
+- no newer unvalidated commit has landed on `origin/main` after staging passed
+- no production deploy is already active
+- backend production dependencies are deployed and validated first
+- the human release approver accepted the manifest
+
+If `origin/main` advances after staging passed, do not deploy production from
+the older validated SHA. Either:
+
+- rerun the staging bus for the new `origin/main` SHA, including the additional
+  PRs in the manifest, or
+- pause merging briefly before final staging validation and production
+  promotion.
+
+Production validation:
+
+- verify the production deploy run and deployed SHA/version label
+- run production-safe smoke checks for changed behavior
+- avoid public posts, purchases, transfers, signer changes, destructive data
+  work, or other irreversible actions unless the user explicitly requested
+  that live action
+- post public release notes and a Follow The Repo deployment overview only
+  after production validation is green, following `ops/skills/deploy-6529`
+
+## Cross-Repo Release Ordering
+
+Use this order when a release spans frontend and backend:
+
+1. Name the backend PR, SHA, services, deploy order, and owner in the manifest.
+2. Confirm backend OpenAPI/generated files are current when API contracts
+   changed.
+3. Regenerate or verify the frontend client against the intended backend
+   contract before using new API behavior.
+4. Merge and deploy additive backend changes to staging.
+5. Validate backend staging, including API or service smoke.
+6. Deploy frontend staging for the candidate that uses the backend behavior.
+7. Validate frontend staging and cross-repo behavior together.
+8. Deploy backend production first when frontend production depends on new
+   backend behavior.
+9. Validate backend production.
+10. Deploy frontend production from `origin/main`.
+11. Validate frontend production and the user-visible integrated behavior.
+
+Prefer compatibility windows:
+
+- Backend accepts old and new frontend clients.
+- Frontend feature flags or guards hide behavior until backend production is
+  ready.
+- OpenAPI/generated model changes are staged so either side can roll forward
+  safely.
+
+## Hotfix Path
+
+Hotfixes use the same lane with a smaller manifest.
+
+- Declare the hotfix reason and impacted risk area.
+- Check whether staging or production is active.
+- Prefer staging first. A production override needs explicit human approval and
+  a rollback or fix-forward plan.
+- Keep the production candidate on `origin/main`.
+- After the hotfix, resume the bus and mark superseded staging candidates.
+
+## Automation PR Scope
+
+The follow-up automation PR should implement the process above. Candidate work:
+
+- `staging:queued`, `staging:deployed`, `staging:passed`, `staging:failed`,
+  `release:candidate`, `release:hold`, and `release:blocked` labels
+- risk and area classification policy
+- staging queue collector
+- manifest generation as an artifact
+- GitHub Deployment and deployment status writes for staging and production
+- PR comments that record inclusion, deployed SHA, validation owner, and result
+- deployed-staging Playwright support without starting a local web server
+- a service-by-service backend smoke matrix or handoff template, likely in the
+  backend repo first
+- release captain dashboard or CLI for active lane, queue, and production lag
+- production preflight that detects when `origin/main` advanced after staging
+  validation
+- optional GitHub Actions concurrency queue settings once verified in this repo
+
+Keep automation out of this PR so the team can review the process before the
+repo starts enforcing it.
+
+## External Guidance Reviewed
+
+- [AWS Well-Architected Operational Excellence: frequent, small, reversible changes](https://docs.aws.amazon.com/wellarchitected/latest/operational-excellence-pillar/ops_dev_integ_freq_sm_rev_chg.html)
+- [AWS Elastic Beanstalk deployment policies](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.rolling-version-deploy.html)
+- [GitHub Actions environments and deployment records](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments)
+- [GitHub REST deployments](https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28)
+- [GitHub Actions concurrency](https://docs.github.com/en/enterprise-cloud@latest/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency)
+- [Google SRE Workbook: canarying releases](https://sre.google/workbook/canarying-releases/)
+- [Microsoft Azure Well-Architected: safe deployments](https://learn.microsoft.com/en-us/azure/well-architected/operational-excellence/safe-deployments)

--- a/ops/docs/developer/deployment-bus-process.md
+++ b/ops/docs/developer/deployment-bus-process.md
@@ -143,8 +143,9 @@ Staging manifest:
 
 ```text
 environment: staging
-candidate_sha: <frontend main or staging branch SHA>
-candidate_branch: 1a-staging
+staging_branch: 1a-staging
+staging_deploy_sha: <actual SHA deployed from 1a-staging>
+production_candidate_sha: <origin/main SHA contained in the staging deploy>
 included_prs:
   - number:
     title:
@@ -172,6 +173,11 @@ status: queued | deploying | validating | passed | failed | held | superseded
 Until automation exists, the release captain can keep this manifest in the PR
 description, a deployment wave update, or a workstream note. The automation PR
 should make it a durable artifact and GitHub Deployment payload.
+
+For production gating, `production_candidate_sha` is the important SHA. If the
+staging branch contains a tree that is not the current `origin/main` production
+candidate, staging can still be useful for exploratory validation, but it does
+not satisfy the production "same SHA passed staging" gate.
 
 ## Multi-Agent Staging Validation
 

--- a/ops/docs/developer/pnpm-and-socket-firewall.md
+++ b/ops/docs/developer/pnpm-and-socket-firewall.md
@@ -138,22 +138,28 @@ used.
 
 ### `ghdeploy`
 
-`ghdeploy` triggers the production deploy workflow for the current branch:
+`ghdeploy` triggers the production deploy workflow from a clean, upstream-synced
+`main` branch:
 
 ```bash
 ghdeploy
 ```
 
-Run it from the repository root. Before triggering
-`.github/workflows/build-upload-deploy-prod.yml`, it checks that:
+Run it from the repository root while checked out on `main`. The production
+workflow has a hard guard that rejects every non-`main` ref. Before triggering
+`.github/workflows/build-upload-deploy-prod.yml`, `ghdeploy` checks that:
 
-- the current branch is not detached
+- the current branch is not detached and should be `main` for production
 - the working tree is fully clean, including no untracked files
 - the current branch has an upstream
 - the current branch is exactly in sync with its upstream after a fetch
 
 If those checks pass, it asks for confirmation before running the production
-workflow against the current branch.
+workflow against `main`.
+
+For release-lane ownership, staging-bus cadence, shared validation, backend
+coordination, and production promotion gates, use
+[`deployment-bus-process.md`](deployment-bus-process.md).
 
 ## Guardrails in this repo
 

--- a/ops/roadmap/README.md
+++ b/ops/roadmap/README.md
@@ -64,11 +64,13 @@ branch model is:
 - High risk PRs can receive staging validation, but require explicit human
   approval before merging to the integration trunk unless the policy is later
   relaxed.
-- Production deploys selected release branches, not "whatever `main` currently
-  contains."
+- Current frontend production deploys from `origin/main` only. Production must
+  use the same `origin/main` SHA or ordered release set that passed staging. If
+  `origin/main` advances after staging validation, rerun staging or pause merges
+  before promotion.
 
 This keeps new work based on a common codebase while preserving production
-safety through release branch selection.
+safety through explicit staging evidence and human production approval.
 
 ### P1: Build A Staging Train
 
@@ -81,7 +83,9 @@ Triggers:
 - PR merged to `main`.
 - Manual dispatch.
 - Applying a staging queue label.
-- A scheduled bus, initially every 15 minutes.
+- A scheduled bus, initially using a 30 minute maximum batching window under
+  backlog. If staging is idle and one eligible release set is ready, deploy
+  immediately instead of waiting for the clock.
 
 Behavior:
 
@@ -134,21 +138,20 @@ Initial label mapping:
 Agents should also perform exploratory browser checks for visible behavior, but
 the scripted E2E packs are the durable release signal.
 
-### P1: Promote To Production Through Release Branches
+### P1: Promote To Production From A Staging-Passed Main SHA
 
 Production releases should be selected batches of validated work.
 
 Flow:
 
 - Resolve the latest production SHA from the last successful production deploy.
-- Create a branch such as `release/YYYY-MM-DD-N` from that SHA.
-- Cherry-pick selected validated PR merge commits in a deterministic order.
 - Generate a release manifest.
-- Deploy the release branch to a quiet pre-production environment or a staged
-  final-smoke window.
+- Verify the candidate is the current `origin/main` SHA and has passed staging
+  as the same ordered release set.
+- If new commits land on `origin/main` after staging passed, rerun staging for
+  the new release set or pause merges before final validation.
 - Require human approval of the manifest before production deploy.
-- Deploy production through the existing production workflow against the release
-  branch.
+- Deploy production through the existing production workflow against `main`.
 
 The release manifest should include:
 
@@ -167,7 +170,7 @@ Longer term, add a second environment:
 - `preprod-release`: quiet, exact production candidate.
 
 Until that exists, schedule release freezes where staging temporarily validates
-the exact release branch.
+the exact `origin/main` production candidate.
 
 ### P1: Create A Release Dashboard And Ledger
 
@@ -208,7 +211,7 @@ The most important health metrics are:
 3. Add GitHub Deployment-based staging ledger.
 4. Add the staging train workflow with serial and scheduled deploy modes.
 5. Add per-PR staging result comments.
-6. Add release branch creation and manifest generation.
+6. Add release manifest generation and production candidate preflight.
 7. Add pre-production or final-smoke release validation.
 8. Add a `ghtrain`-style dashboard or CLI once the data model is stable.
 

--- a/ops/roadmap/README.md
+++ b/ops/roadmap/README.md
@@ -9,7 +9,7 @@ instead of leaving conflicting guidance in place.
 
 ## Agent Release Railway Roadmap
 
-Last reviewed: 2026-06-11 against `origin/main` at `334b02c57`.
+Last reviewed: 2026-06-18 against `origin/main` at `97bb30914`.
 
 The repository is moving from one-human-per-PR review toward a higher-throughput
 agent development model. The operating goal is to stop treating "PR opened" as
@@ -83,9 +83,9 @@ Triggers:
 - PR merged to `main`.
 - Manual dispatch.
 - Applying a staging queue label.
-- A scheduled bus, initially using a 30 minute maximum batching window under
-  backlog. If staging is idle and one eligible release set is ready, deploy
-  immediately instead of waiting for the clock.
+- A scheduled bus that follows the cadence in
+  `ops/docs/developer/deployment-bus-process.md` so the process doc stays the
+  source of truth when the team tunes the batching window.
 
 Behavior:
 

--- a/ops/skills/6529-autonomous-manager/SKILL.md
+++ b/ops/skills/6529-autonomous-manager/SKILL.md
@@ -15,6 +15,7 @@ Choose one primary mode, then add others only when the work requires it:
 - **PR review manager**: Inspect reviewer, CodeRabbit, Claude, CI, and local findings; fix valid feedback; push updates when requested. Use `ops/skills/write-prs/SKILL.md` for PR creation, bot iteration, readiness, and merge preparation. Use `ops/skills/deploy-6529/SKILL.md` when the user requests merge/deploy execution.
 - **Docs/skills manager**: Create or update user-facing docs under `ops/docs/` and repo-local skills under `ops/skills/`, keeping current-state language and navigable structure.
 - **Release manager**: Carry an already-approved change through merge, staging, production, and smoke validation only when explicitly asked. Use `ops/skills/deploy-6529/SKILL.md` as the authority for merge, deployment, E2E validation, backend coordination, and cross-agent coordination.
+- **Deployment-bus manager**: Own a shared staging or production lane for a batch of PRs, assign validation slices to PR owners, keep the candidate SHA and included release set explicit, and use `ops/docs/developer/deployment-bus-process.md` plus `ops/skills/deploy-6529/SKILL.md` as the authority.
 - **Investigation manager**: Diagnose an issue, gather evidence, identify ownership, and turn findings into a concrete fix or handoff.
 
 ## Load Order

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -21,6 +21,30 @@ Carry an approved 6529 release from PR merge through staging validation and, whe
 
 Before deploying, check what else is already deploying to the same environment. Inspect active GitHub Actions deploy runs and any obvious active Codex/human release thread. If the lane is busy, wait. Coordinate only to identify the owner, expected finish, validation state, or explicit handoff; do not start an overlapping deploy.
 
+Use `ops/docs/developer/deployment-bus-process.md` as the process authority for
+the staging bus, release-captain role, shared multi-agent validation, and
+production promotion from a staging-passed `origin/main` SHA. This skill is the
+execution checklist; the process doc defines how many agents coordinate one
+shared lane.
+
+## Deployment Bus
+
+- Treat each active staging or production deploy as owned by one release
+  captain until the lane is terminal and handed off.
+- If staging is idle and exactly one eligible release set is ready, deploy it
+  immediately. If the lane is busy or a backlog exists, batch ready work and
+  depart when the previous staging cycle is terminal, using 30 minutes as the
+  initial maximum batching window under backlog.
+- Record a staging manifest before deployment: candidate SHA, included PRs,
+  risk/area notes, backend dependencies, validation owners, required checks,
+  and rollback or fix-forward notes.
+- After staging deploys, assign each included PR owner a validation slice and
+  run a core smoke validation. Production is blocked until required validation
+  passes or the failed/held work is excluded from the production candidate.
+- If `origin/main` advances after staging passed, do not deploy the older
+  staging-passed SHA to production. Rerun staging for the new `origin/main` SHA
+  or pause merges before final staging validation and production promotion.
+
 ## Preflight
 
 1. Identify the release set:
@@ -79,12 +103,13 @@ Before deploying, check what else is already deploying to the same environment. 
 
 1. Proceed to production when the user already asked to take the release through production, such as "take it all the way through prod." Ask only when the current request did not include production deployment.
 2. Reconfirm staging passed for the same SHAs or the same ordered frontend/backend release set.
-3. Confirm no active production deploy is in progress. If one is active or the state is unclear, wait until it finishes and production validation is complete or explicitly handed off.
-4. Deploy backend production before frontend production when frontend depends on new backend behavior. Use the backend `deploy-6529` skill from `6529-Collections/6529seize-backend` for backend service order, validation, and recovery.
-5. Deploy frontend production through the repo-approved path from `main` only, following the hard gate above. Current frontend production deploy is `Web Deploy - PROD` in `.github/workflows/build-upload-deploy-prod.yml`; `bin/ghdeploy` may be used only from a clean, upstream-synced `main` worktree.
-6. If the local worktree is dirty with unrelated user or agent changes, do not clean or revert them just to run `ghdeploy`. Use a clean worktree or trigger the workflow with an explicit verified ref through GitHub tooling.
-7. When triggering production through GitHub tooling instead of `ghdeploy`, use an explicit verified `main` ref or SHA that is already contained in `origin/main`.
-8. Watch production deployment to completion. Record the workflow run URL, Elastic Beanstalk or workflow health result, and deployed SHA/version label.
+3. Verify the production candidate is the current `origin/main` SHA and no newer unvalidated commit landed after staging passed. If `origin/main` advanced, rerun staging for the new release set before production.
+4. Confirm no active production deploy is in progress. If one is active or the state is unclear, wait until it finishes and production validation is complete or explicitly handed off.
+5. Deploy backend production before frontend production when frontend depends on new backend behavior. Use the backend `deploy-6529` skill from `6529-Collections/6529seize-backend` for backend service order, validation, and recovery.
+6. Deploy frontend production through the repo-approved path from `main` only, following the hard gate above. Current frontend production deploy is `Web Deploy - PROD` in `.github/workflows/build-upload-deploy-prod.yml`; `bin/ghdeploy` may be used only from a clean, upstream-synced `main` worktree.
+7. If the local worktree is dirty with unrelated user or agent changes, do not clean or revert them just to run `ghdeploy`. Use a clean worktree or trigger the workflow with an explicit verified ref through GitHub tooling.
+8. When triggering production through GitHub tooling instead of `ghdeploy`, use an explicit verified `main` ref or SHA that is already contained in `origin/main`.
+9. Watch production deployment to completion. Record the workflow run URL, Elastic Beanstalk or workflow health result, and deployed SHA/version label.
 
 ## Production E2E And Watch
 

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -31,10 +31,9 @@ shared lane.
 
 - Treat each active staging or production deploy as owned by one release
   captain until the lane is terminal and handed off.
-- If staging is idle and exactly one eligible release set is ready, deploy it
-  immediately. If the lane is busy or a backlog exists, batch ready work and
-  depart when the previous staging cycle is terminal, using 30 minutes as the
-  initial maximum batching window under backlog.
+- Use the staging departure cadence in
+  `ops/docs/developer/deployment-bus-process.md`; keep that process doc as the
+  source of truth when the team tunes the batching window.
 - Record a staging manifest before deployment: candidate SHA, included PRs,
   risk/area notes, backend dependencies, validation owners, required checks,
   and rollback or fix-forward notes.

--- a/ops/skills/write-prs/SKILL.md
+++ b/ops/skills/write-prs/SKILL.md
@@ -93,6 +93,7 @@ description: Write, open, iterate, and prepare pull requests for merge or deploy
 - Use `6529 run build` for build-time, generated API model, Next.js config, route, or deployment-sensitive changes.
 - Use `6529 run test:e2e` for local Playwright E2E when relevant; this repo's default Playwright config starts the app locally on port `3001`.
 - For staging or production validation, inspect the repo's current deploy and E2E configuration before running. If no target-specific E2E command exists, run the strongest available smoke checks and report the gap clearly.
+- For merge, staging, production, or release-lane work, include a deployment-bus handoff when relevant: release set, candidate SHA, included PRs, backend dependencies, validation owners, and held or blocked changes. Use `ops/docs/developer/deployment-bus-process.md` for the current process.
 
 ## Merge And Deploy Gates
 
@@ -100,7 +101,7 @@ description: Write, open, iterate, and prepare pull requests for merge or deploy
 - Use `ops/skills/deploy-6529/SKILL.md` for actual merge execution, staging deployment, production deployment, backend deployment coordination, cross-agent coordination, and deployed-environment E2E validation.
 - Before merging, ensure the PR is agent-happy, bot-happy, required checks are passing or explained, and required approvals are present.
 - Before staging deploy, confirm the merge commit/ref, use the repo-approved staging deployment path, then validate the deployed target. In this repo, the documented fresh-clone staging refresh path is `./bin/6529 staging`.
-- Before production deploy, require successful staging validation unless the user explicitly overrides it. Use the repo-approved production deployment path and verify the deployed version or visible behavior afterward. In this repo, production deploy is the `Web Deploy - PROD` workflow in `.github/workflows/build-upload-deploy-prod.yml`.
+- Before production deploy, require successful staging validation for the same `origin/main` SHA or ordered frontend/backend release set unless the user explicitly overrides it. Use the repo-approved production deployment path and verify the deployed version or visible behavior afterward. In this repo, production deploy is the `Web Deploy - PROD` workflow in `.github/workflows/build-upload-deploy-prod.yml`, and it rejects non-`main` refs.
 - If deployment or E2E fails, hand off to `ops/skills/deploy-6529/SKILL.md` to diagnose, fix, redeploy, and rerun validation before proceeding.
 
 ## Anti-Patterns


### PR DESCRIPTION
## Issue
- Deployment is becoming the shared bottleneck as more agents and humans ship frontend and backend work.
- The team discussion called for a deterministic deployment bus, shared validation model, and clearer staging-to-production gates before automating the workflow.

## Fix
- Adds a process-first deployment bus spec at `ops/docs/developer/deployment-bus-process.md`.
- Updates agent-facing deployment guidance so future merge/staging/prod work reads the bus process and keeps production tied to the staging-passed `origin/main` release set.
- Keeps workflow automation out of this PR so the process can be reviewed before labels, manifests, GitHub Deployment records, and queue automation are added.

## Changes
- Documents current frontend staging/prod facts: `1a-staging`, SSM staging deploy, serialized workflows, main-only production, and Elastic Beanstalk SHA validation.
- Defines release captain, PR owner validator, core smoke validator, and human release approver roles.
- Defines staging bus departure policy: immediate when idle with one ready release set; otherwise fixed-cutoff bus with 30 minute initial maximum batching window under backlog.
- Adds staging manifest fields for included PRs, backend dependencies, validation owners, required checks, held/blocked state, and OpenAPI/generated-client evidence.
- Clarifies cross-repo backend ordering: additive backend first, backend staging before frontend staging consumption, backend prod before frontend prod when frontend depends on new API behavior.
- Aligns README, AGENTS, roadmap, `deploy-6529`, `write-prs`, `6529-autonomous-manager`, and package/deploy docs with the spec/process model.

## Validation
- `codex-diff-check --cached`
- `python ops/skills/commit-docs-updater/scripts/validate_docs_links.py` → 266 Markdown files checked
- Read current frontend deployment workflows and backend deployment skill/workflow before drafting.
- Posted the proposed process summary to the deployment discussion wave for team feedback.

## Risk
- Level: Low
- Why: docs/skill/process only; no workflow, package, app runtime, or deployment script behavior changes.
- Rollback: revert this docs/process commit.

## Review Notes
- Please focus on whether the initial 30 minute max batching window is right under backlog.
- Please check whether the release captain / PR-owner validation split is enough for multiple agents validating one staging deploy.
- Automation follow-up should be separate: labels, queue collector, manifest artifact, GitHub Deployment ledger, PR comments, deployed-staging Playwright support, production preflight, and dashboard/CLI.