### PR TITLE
[codex] Sort subwaves by latest activity

### DIFF
--- a/__tests__/hooks/useSidebarWaveTree.test.tsx
+++ b/__tests__/hooks/useSidebarWaveTree.test.tsx
@@ -9,6 +9,12 @@ describe("useSidebarWaveTree", () => {
     globalThis.sessionStorage.clear();
   });
 
+  const createNewDropsCount = (latestDropTimestamp: number | null) => ({
+    count: 0,
+    latestDropTimestamp,
+    firstUnreadSerialNo: null,
+  });
+
   const waves = [
     createMockMinimalWave({
       id: "parent",
@@ -18,16 +24,18 @@ describe("useSidebarWaveTree", () => {
       id: "newer-child",
       parentWaveId: "parent",
       createdAt: 20,
+      newDropsCount: createNewDropsCount(100),
     }),
     createMockMinimalWave({
       id: "older-child",
       parentWaveId: "parent",
       hasSubwaves: true,
       createdAt: 10,
+      newDropsCount: createNewDropsCount(200),
     }),
   ];
 
-  it("keeps manual expansion in memory and sorts expanded subwaves by created time", () => {
+  it("keeps manual expansion in memory and sorts expanded subwaves by latest activity", () => {
     const onParentExpand = jest.fn();
     const { result } = renderHook(() =>
       useSidebarWaveTree({

--- a/__tests__/hooks/useWaveSubwaves.test.ts
+++ b/__tests__/hooks/useWaveSubwaves.test.ts
@@ -11,25 +11,52 @@ jest.mock("@/services/api/waves-v2-api", () => ({
   fetchWaveSubwavesPage: jest.fn(),
 }));
 
-const fetchWaveSubwavesPageMock =
-  fetchWaveSubwavesPage as jest.MockedFunction<typeof fetchWaveSubwavesPage>;
+const fetchWaveSubwavesPageMock = fetchWaveSubwavesPage as jest.MockedFunction<
+  typeof fetchWaveSubwavesPage
+>;
 
-const createSubwave = (id: string) => ({ id }) as SidebarWave;
+const createSubwave = ({
+  id,
+  createdAt = 0,
+  latestDropTimestamp = null,
+  name = id,
+}: {
+  readonly id: string;
+  readonly createdAt?: number | undefined;
+  readonly latestDropTimestamp?: number | null | undefined;
+  readonly name?: string | undefined;
+}) =>
+  ({
+    id,
+    name,
+    createdAt,
+    latestDropTimestamp,
+  }) as SidebarWave;
 
 describe("fetchAllWaveSubwaves", () => {
   beforeEach(() => {
     fetchWaveSubwavesPageMock.mockReset();
   });
 
-  it("loads every subwave page until the endpoint reports no next page", async () => {
+  it("loads every page and returns subwaves by latest activity", async () => {
     fetchWaveSubwavesPageMock
       .mockResolvedValueOnce({
-        waves: [createSubwave("child-1")],
+        waves: [
+          createSubwave({
+            id: "child-1",
+            latestDropTimestamp: 100,
+          }),
+        ],
         page: 1,
         next: true,
       })
       .mockResolvedValueOnce({
-        waves: [createSubwave("child-2")],
+        waves: [
+          createSubwave({
+            id: "child-2",
+            latestDropTimestamp: 300,
+          }),
+        ],
         page: 2,
         next: false,
       });
@@ -53,12 +80,38 @@ describe("fetchAllWaveSubwaves", () => {
       pageSize: 100,
       sort: ApiSubwavesSort.CreatedAt,
     });
-    expect(subwaves.map((wave) => wave.id)).toEqual(["child-1", "child-2"]);
+    expect(subwaves.map((wave) => wave.id)).toEqual(["child-2", "child-1"]);
+  });
+
+  it("falls back to newest created time when subwaves have no drops", async () => {
+    fetchWaveSubwavesPageMock.mockResolvedValueOnce({
+      waves: [
+        createSubwave({
+          id: "older-empty-child",
+          createdAt: 100,
+        }),
+        createSubwave({
+          id: "newer-empty-child",
+          createdAt: 300,
+        }),
+      ],
+      page: 1,
+      next: false,
+    });
+
+    const subwaves = await fetchAllWaveSubwaves({
+      parentWaveId: "parent-wave",
+    });
+
+    expect(subwaves.map((wave) => wave.id)).toEqual([
+      "newer-empty-child",
+      "older-empty-child",
+    ]);
   });
 
   it("stops after the first page when there is no next page", async () => {
     fetchWaveSubwavesPageMock.mockResolvedValueOnce({
-      waves: [createSubwave("child-1")],
+      waves: [createSubwave({ id: "child-1" })],
       page: 1,
       next: false,
     });

--- a/helpers/waves/subwave-activity.helpers.ts
+++ b/helpers/waves/subwave-activity.helpers.ts
@@ -1,0 +1,45 @@
+type SortableSubwaveActivity = {
+  readonly id: string;
+  readonly name: string;
+  readonly createdAt: number;
+  readonly latestDropTimestamp?: number | null | undefined;
+  readonly newDropsCount?:
+    | {
+        readonly latestDropTimestamp?: number | null | undefined;
+      }
+    | undefined;
+};
+
+const getSubwaveActivityTimestamp = (wave: SortableSubwaveActivity) => {
+  // Raw SidebarWave data uses latestDropTimestamp; enhanced sidebar rows fold
+  // API and websocket activity into newDropsCount.latestDropTimestamp.
+  return (
+    wave.newDropsCount?.latestDropTimestamp ?? wave.latestDropTimestamp ?? 0
+  );
+};
+
+export const compareSubwavesByLatestActivity = <
+  T extends SortableSubwaveActivity,
+>(
+  a: T,
+  b: T
+) => {
+  const activityDelta =
+    getSubwaveActivityTimestamp(b) - getSubwaveActivityTimestamp(a);
+
+  if (activityDelta !== 0) {
+    return activityDelta;
+  }
+
+  const createdAtDelta = b.createdAt - a.createdAt;
+  if (createdAtDelta !== 0) {
+    return createdAtDelta;
+  }
+
+  const nameDelta = a.name.localeCompare(b.name);
+  if (nameDelta !== 0) {
+    return nameDelta;
+  }
+
+  return a.id.localeCompare(b.id);
+};

--- a/hooks/useSidebarWaveTree.ts
+++ b/hooks/useSidebarWaveTree.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import type { MinimalWave } from "@/contexts/wave/hooks/useEnhancedWavesListCore";
+import { compareSubwavesByLatestActivity } from "@/helpers/waves/subwave-activity.helpers";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 type SidebarWaveDepth = 0 | 1;
@@ -91,7 +92,7 @@ const buildSubwavesByParentId = (waves: readonly MinimalWave[]) => {
   }
 
   for (const subwaves of map.values()) {
-    subwaves.sort((a, b) => a.createdAt - b.createdAt);
+    subwaves.sort(compareSubwavesByLatestActivity);
   }
 
   return map;

--- a/hooks/useWaveSubwaves.ts
+++ b/hooks/useWaveSubwaves.ts
@@ -3,6 +3,7 @@
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import { SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS } from "@/components/react-query-wrapper/utils/query-utils";
 import { ApiSubwavesSort } from "@/generated/models/ApiSubwavesSort";
+import { compareSubwavesByLatestActivity } from "@/helpers/waves/subwave-activity.helpers";
 import {
   fetchWaveSubwavesPage,
   type WaveSubwavesQueryKeyParams,
@@ -88,7 +89,7 @@ export async function fetchAllWaveSubwaves({
     page += 1;
   }
 
-  return waves;
+  return [...waves].sort(compareSubwavesByLatestActivity);
 }
 
 export function useWaveSubwavesMap({


### PR DESCRIPTION
## Summary

- Sort fetched subwaves by latest drop activity before exposing them to the sidebar/mobile wave UI.
- Use the same activity comparator for expanded sidebar child rows.
- Keep deterministic fallbacks for empty/equal-activity subwaves: newest created time, then name, then id.

## Context

Follow The Repo now has practical subwaves whose usefulness depends on activity order. The API response can return subwaves in created-time order, which leaves recently active subwaves below stale ones.

## Validation

- `seize exec jest --runTestsByPath __tests__/hooks/useWaveSubwaves.test.ts __tests__/hooks/useSidebarWaveTree.test.tsx --runInBand --silent --coverage=false`
- `seize exec eslint --no-warn-ignored --max-warnings=0 helpers/waves/subwave-activity.helpers.ts hooks/useWaveSubwaves.ts hooks/useSidebarWaveTree.ts __tests__/hooks/useWaveSubwaves.test.ts __tests__/hooks/useSidebarWaveTree.test.tsx`
- `seize run typecheck:ci`
- `codex-diff-check`