### PR TITLE
[codex] Make production EB version deploy idempotent

### DIFF
--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -152,6 +152,8 @@ jobs:
 
       - name: Ensure ElasticBeanstalk Application Version
         run: |
+          set -euo pipefail
+
           SOURCE_BUNDLE_KEY="web_build/${COMMIT_SHA}/package.zip"
 
           create_application_version() {
@@ -162,38 +164,33 @@ jobs:
               --description "${COMMIT_MESSAGE}"
           }
 
-          VERSION_COUNT=$(aws elasticbeanstalk describe-application-versions \
+          APPLICATION_VERSION_JSON=$(aws elasticbeanstalk describe-application-versions \
             --application-name "${BEANSTALK_APP_NAME}" \
             --version-labels "${COMMIT_SHA}" \
-            --query 'length(ApplicationVersions)' \
-            --output text)
+            --output json)
+          VERSION_COUNT=$(jq '.ApplicationVersions | length' <<< "$APPLICATION_VERSION_JSON")
 
-          if [ "$VERSION_COUNT" = "0" ]; then
-            echo "Creating Elastic Beanstalk application version ${COMMIT_SHA}."
-            create_application_version
-          else
-            EXISTING_BUCKET=$(aws elasticbeanstalk describe-application-versions \
-              --application-name "${BEANSTALK_APP_NAME}" \
-              --version-labels "${COMMIT_SHA}" \
-              --query 'ApplicationVersions[0].SourceBundle.S3Bucket' \
-              --output text)
-            EXISTING_KEY=$(aws elasticbeanstalk describe-application-versions \
-              --application-name "${BEANSTALK_APP_NAME}" \
-              --version-labels "${COMMIT_SHA}" \
-              --query 'ApplicationVersions[0].SourceBundle.S3Key' \
-              --output text)
-
-            if [ "$EXISTING_BUCKET" = "$AWS_BUCKET" ] && [ "$EXISTING_KEY" = "$SOURCE_BUNDLE_KEY" ]; then
-              echo "Elastic Beanstalk application version ${COMMIT_SHA} already exists with the expected source bundle; reusing it."
-            else
-              echo "::warning::Elastic Beanstalk application version ${COMMIT_SHA} already exists with source s3://${EXISTING_BUCKET}/${EXISTING_KEY}; recreating it with s3://${AWS_BUCKET}/${SOURCE_BUNDLE_KEY}."
-              aws elasticbeanstalk delete-application-version \
-                --application-name "${BEANSTALK_APP_NAME}" \
-                --version-label "${COMMIT_SHA}" \
-                --no-delete-source-bundle
+          case "$VERSION_COUNT" in
+            0)
+              echo "Creating Elastic Beanstalk application version ${COMMIT_SHA}."
               create_application_version
-            fi
-          fi
+              ;;
+            1)
+              EXISTING_BUCKET=$(jq -r '.ApplicationVersions[0].SourceBundle.S3Bucket // ""' <<< "$APPLICATION_VERSION_JSON")
+              EXISTING_KEY=$(jq -r '.ApplicationVersions[0].SourceBundle.S3Key // ""' <<< "$APPLICATION_VERSION_JSON")
+
+              if [ "$EXISTING_BUCKET" = "$AWS_BUCKET" ] && [ "$EXISTING_KEY" = "$SOURCE_BUNDLE_KEY" ]; then
+                echo "Elastic Beanstalk application version ${COMMIT_SHA} already exists with the expected source bundle; reusing it."
+              else
+                echo "::error::Elastic Beanstalk application version ${COMMIT_SHA} already exists with unexpected source s3://${EXISTING_BUCKET}/${EXISTING_KEY}; expected s3://${AWS_BUCKET}/${SOURCE_BUNDLE_KEY}. Refusing to replace an unexpected production version label automatically."
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::Expected at most one Elastic Beanstalk application version for ${COMMIT_SHA}, found ${VERSION_COUNT}."
+              exit 1
+              ;;
+          esac
 
       - name: Deploy new Version to ElasticBeanstalk with Runtime Environment Variables
         env:

--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -150,13 +150,50 @@ jobs:
       - name: Get commit message
         run: echo "COMMIT_MESSAGE=$(git show -s --format=%s)" >> $GITHUB_ENV
 
-      - name: Create new ElasticBeanstalk Application Version
+      - name: Ensure ElasticBeanstalk Application Version
         run: |
-          aws elasticbeanstalk create-application-version \
-          --application-name "${{ env.BEANSTALK_APP_NAME }}" \
-          --source-bundle S3Bucket="${{ env.AWS_BUCKET }}",S3Key="web_build/${{ env.COMMIT_SHA }}/package.zip" \
-          --version-label "${{ env.COMMIT_SHA }}" \
-          --description "${{ env.COMMIT_MESSAGE }}"
+          SOURCE_BUNDLE_KEY="web_build/${COMMIT_SHA}/package.zip"
+
+          create_application_version() {
+            aws elasticbeanstalk create-application-version \
+              --application-name "${BEANSTALK_APP_NAME}" \
+              --source-bundle S3Bucket="${AWS_BUCKET}",S3Key="${SOURCE_BUNDLE_KEY}" \
+              --version-label "${COMMIT_SHA}" \
+              --description "${COMMIT_MESSAGE}"
+          }
+
+          VERSION_COUNT=$(aws elasticbeanstalk describe-application-versions \
+            --application-name "${BEANSTALK_APP_NAME}" \
+            --version-labels "${COMMIT_SHA}" \
+            --query 'length(ApplicationVersions)' \
+            --output text)
+
+          if [ "$VERSION_COUNT" = "0" ]; then
+            echo "Creating Elastic Beanstalk application version ${COMMIT_SHA}."
+            create_application_version
+          else
+            EXISTING_BUCKET=$(aws elasticbeanstalk describe-application-versions \
+              --application-name "${BEANSTALK_APP_NAME}" \
+              --version-labels "${COMMIT_SHA}" \
+              --query 'ApplicationVersions[0].SourceBundle.S3Bucket' \
+              --output text)
+            EXISTING_KEY=$(aws elasticbeanstalk describe-application-versions \
+              --application-name "${BEANSTALK_APP_NAME}" \
+              --version-labels "${COMMIT_SHA}" \
+              --query 'ApplicationVersions[0].SourceBundle.S3Key' \
+              --output text)
+
+            if [ "$EXISTING_BUCKET" = "$AWS_BUCKET" ] && [ "$EXISTING_KEY" = "$SOURCE_BUNDLE_KEY" ]; then
+              echo "Elastic Beanstalk application version ${COMMIT_SHA} already exists with the expected source bundle; reusing it."
+            else
+              echo "::warning::Elastic Beanstalk application version ${COMMIT_SHA} already exists with source s3://${EXISTING_BUCKET}/${EXISTING_KEY}; recreating it with s3://${AWS_BUCKET}/${SOURCE_BUNDLE_KEY}."
+              aws elasticbeanstalk delete-application-version \
+                --application-name "${BEANSTALK_APP_NAME}" \
+                --version-label "${COMMIT_SHA}" \
+                --no-delete-source-bundle
+              create_application_version
+            fi
+          fi
 
       - name: Deploy new Version to ElasticBeanstalk with Runtime Environment Variables
         env:

--- a/ops/docs/developer/pnpm-and-socket-firewall.md
+++ b/ops/docs/developer/pnpm-and-socket-firewall.md
@@ -180,6 +180,11 @@ The production workflow now:
    `.ebextensions/`, and `.platform/`.
 5. Uploads `target/_next/static` and `package.zip` to S3 under the build
    version path.
+6. Ensures the Elastic Beanstalk application version for the commit SHA exists.
+   If a previous failed attempt already created the version with the expected
+   S3 source bundle, the workflow reuses it and continues the deploy. If that
+   label points at a different source bundle, the workflow deletes the stale
+   application version metadata and recreates it with the current package.
 
 At deploy time, [`runtime-bundle.config`](../../../.ebextensions/runtime-bundle.config)
 restores the real `package.json`, verifies the standalone runtime bundle, and

--- a/ops/docs/developer/pnpm-and-socket-firewall.md
+++ b/ops/docs/developer/pnpm-and-socket-firewall.md
@@ -182,9 +182,9 @@ The production workflow now:
    version path.
 6. Ensures the Elastic Beanstalk application version for the commit SHA exists.
    If a previous failed attempt already created the version with the expected
-   S3 source bundle, the workflow reuses it and continues the deploy. If that
-   label points at a different source bundle, the workflow deletes the stale
-   application version metadata and recreates it with the current package.
+   S3 source bundle, the workflow reuses it and continues the deploy. If the
+   label points at a different source bundle, the workflow fails instead of
+   automatically replacing a potentially live production version label.
 
 At deploy time, [`runtime-bundle.config`](../../../.ebextensions/runtime-bundle.config)
 restores the real `package.json`, verifies the standalone runtime bundle, and


### PR DESCRIPTION
## Issue
- Production Elastic Beanstalk deploy reruns can fail when a previous failed attempt already created the application version for the same commit SHA.
- The workflow stopped at `create-application-version` instead of continuing to deploy the existing version.

## Fix
- Make the production deploy workflow ensure the Elastic Beanstalk application version exists before updating the environment.
- If the version already exists with the expected S3 source bundle, the workflow reuses it and continues.
- If the version label exists but points at a different source bundle, the workflow now fails loudly instead of replacing a potentially live production version label automatically.

## Changes
- Replaced the create-only EB application version step in `build-upload-deploy-prod.yml` with idempotent create/reuse logic.
- Added strict bash mode and a single cached EB version metadata read for the ensure step.
- Documented the retry behavior in the developer deploy notes.

## Validation
- `git diff --check`
- Parsed `.github/workflows/build-upload-deploy-prod.yml` as YAML locally.
- Ran a bash syntax check against the edited `Ensure ElasticBeanstalk Application Version` step.
- Did not run the full frontend test/build suite because this is a deploy-workflow-only YAML/docs change.

## Risk
- Level: Low
- Why: The normal existing-version path now avoids a known retry failure and still deploys the same commit SHA/source bundle. Unexpected source-bundle mismatches stop the deploy for operator inspection instead of mutating production EB metadata.
- Rollback: Revert this PR to restore the previous create-only behavior.

## Review Notes
- Please focus on the EB application version branch logic and whether mismatch should remain a hard stop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced production deployment workflow with improved application version management to prevent unintended overwrites during deployment processes.
  * Updated developer documentation regarding deployment procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->