### PR TITLE
Fix missing profile CMS site metadata fallback

### DIFF
--- a/__tests__/app/profile-cms-route.test.tsx
+++ b/__tests__/app/profile-cms-route.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react";
 
-import ProfileCmsPage from "@/app/[user]/[...cmsPath]/page";
+import ProfileCmsPage, {
+  generateMetadata,
+} from "@/app/[user]/[...cmsPath]/page";
 import exhibitionRoomPackage from "@/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/exhibition-room.package.json";
 import minimalPackage from "@/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/minimal-profile-homepage.package.json";
 import type { CmsPackageV1 } from "@/lib/profile-cms/protocol/v1";
@@ -128,6 +130,19 @@ describe("profile CMS App Router catch-all", () => {
         }),
       })
     ).rejects.toThrow("NEXT_NOT_FOUND");
+  });
+
+  it("does not throw from metadata when no primary CMS site exists", async () => {
+    getProfileCmsPrimarySiteMock.mockResolvedValueOnce(null);
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({
+        user: "punk6529",
+        cmsPath: ["index.html"],
+      }),
+    });
+
+    expect(metadata.title).toBeDefined();
   });
 
   it("shows an empty state for published packages missing a route", async () => {

--- a/app/[user]/[...cmsPath]/page.tsx
+++ b/app/[user]/[...cmsPath]/page.tsx
@@ -3,7 +3,11 @@ import { ProfileCmsEmptyState } from "@/components/profile-cms/CmsSiteStates";
 import { getAppMetadata } from "@/components/providers/metadata";
 import { getAppCommonHeaders } from "@/helpers/server.app.helpers";
 import { getUserProfile } from "@/helpers/server.helpers";
-import { normalizeLocale, type SupportedLocale } from "@/i18n/locales";
+import {
+  DEFAULT_LOCALE,
+  normalizeLocale,
+  type SupportedLocale,
+} from "@/i18n/locales";
 import { t } from "@/i18n/messages";
 import { getProfileCmsPrimarySite } from "@/lib/profile-cms/runtime/fetcher";
 import {
@@ -92,7 +96,10 @@ export async function generateMetadata({
   }
 
   if (!context?.site) {
-    return notFound();
+    return getAppMetadata({
+      title: t(DEFAULT_LOCALE, "profileCms.state.empty.title"),
+      description: t(DEFAULT_LOCALE, "profileCms.state.empty.description"),
+    });
   }
 
   const routeResolution = resolveCmsRoute(


### PR DESCRIPTION
## Summary

Fixes a production smoke failure after the Profile CMS release train: `/punk6529/index.html` rendered the CMS error boundary (`Website unavailable`) when no primary CMS package exists.

Root cause: `generateMetadata` called `notFound()` when the profile had no primary CMS site. In production this can surface as a Server Components render error before the page returns its own safe no-site/404 behavior.

Changes:
- Return generic CMS empty-state metadata when there is no primary CMS package.
- Add a route regression test proving metadata generation does not throw for missing primary CMS sites.

## Validation

- `seize run test:no-coverage -- __tests__/app/profile-cms-route.test.tsx --runInBand` via temporary Jest path workaround: 7 tests passed
- `seize run lint:changed`
- `seize run typecheck:changed`
- `codex-diff-check`

## Production Context

This is a fix-forward after production deploy `2b27ee1e` completed successfully but smoke found `/punk6529/index.html` rendering `Website unavailable` instead of a safe missing-site result. Builder remains hidden in production as 404 when CMS builder flags are off.