### PR TITLE
Render empty CMS state for missing primary site

### DIFF
--- a/__tests__/app/profile-cms-route.test.tsx
+++ b/__tests__/app/profile-cms-route.test.tsx
@@ -119,17 +119,19 @@ describe("profile CMS App Router catch-all", () => {
     );
   });
 
-  it("returns a safe not-found when no primary CMS site exists", async () => {
+  it("returns a safe empty state when no primary CMS site exists", async () => {
     getProfileCmsPrimarySiteMock.mockResolvedValueOnce(null);
 
-    await expect(
-      ProfileCmsPage({
-        params: Promise.resolve({
-          user: "punk6529",
-          cmsPath: ["index.html"],
-        }),
-      })
-    ).rejects.toThrow("NEXT_NOT_FOUND");
+    const page = await ProfileCmsPage({
+      params: Promise.resolve({
+        user: "punk6529",
+        cmsPath: ["index.html"],
+      }),
+    });
+
+    render(page);
+
+    expect(screen.getByText("Website page not found")).toBeInTheDocument();
   });
 
   it("does not throw from metadata when no primary CMS site exists", async () => {
@@ -143,6 +145,17 @@ describe("profile CMS App Router catch-all", () => {
     });
 
     expect(metadata.title).toBeDefined();
+  });
+
+  it("keeps non-CMS profile paths as not-found", async () => {
+    await expect(
+      ProfileCmsPage({
+        params: Promise.resolve({
+          user: "punk6529",
+          cmsPath: ["collected"],
+        }),
+      })
+    ).rejects.toThrow("NEXT_NOT_FOUND");
   });
 
   it("shows an empty state for published packages missing a route", async () => {

--- a/app/[user]/[...cmsPath]/page.tsx
+++ b/app/[user]/[...cmsPath]/page.tsx
@@ -47,7 +47,7 @@ export default async function ProfileCmsPage({
   }
 
   if (!context.site) {
-    return notFound();
+    return <ProfileCmsEmptyState locale={locale} />;
   }
 
   const routeResolution = resolveCmsRoute(
@@ -180,7 +180,11 @@ async function getProfileCmsRouteContext(
     headers,
   });
   if (!site) {
-    return null;
+    return {
+      cmsPath: requestCmsPath,
+      redirectTo: null,
+      site: null,
+    };
   }
 
   if (site.cmsPackage.profile.handle.toLowerCase() !== canonicalHandle) {


### PR DESCRIPTION
## Summary

Follow-up fix-forward for the Profile CMS production smoke failure.

PR #2768 removed the metadata `notFound()` throw, but production smoke still showed `/punk6529/index.html` rendering the CMS error boundary. This patch removes the page-level throw for the valid CMS route/no-primary-site case and renders the explicit CMS empty state instead.

Behavior preserved:
- Non-CMS profile paths like `/punk6529/collected` still return not-found.
- Published packages with missing internal CMS routes still render the CMS empty state.
- Builder remains gated by production flags.

## Validation

- Focused route regression test via temporary Jest config workaround: 8/8 passed
- `seize run lint:changed`
- `seize run typecheck:changed`
- `codex-diff-check`

## Production Context

Production deploy `6bf98060` still rendered `Website unavailable` at `/punk6529/index.html`. This PR should make missing primary CMS packages render `Website page not found` instead of tripping the route error boundary.