### PR TITLE
Fix profile CMS missing primary site handling

### DIFF
--- a/__tests__/lib/profile-cms/runtime/fetcher.test.ts
+++ b/__tests__/lib/profile-cms/runtime/fetcher.test.ts
@@ -150,6 +150,19 @@ describe("profile CMS primary-site fetcher", () => {
     });
   });
 
+  it("returns null for the backend no-primary-site message", async () => {
+    commonApiFetchMock.mockRejectedValueOnce(
+      "Profile punk6529 has no primary published CMS package"
+    );
+
+    await expect(
+      fetchProfileCmsPrimarySite({
+        handle: "punk6529",
+        headers: {},
+      })
+    ).resolves.toBeNull();
+  });
+
   it("uses the dev fixture only when explicitly enabled and the API is unavailable", async () => {
     process.env["PROFILE_CMS_RUNTIME_FIXTURE_PRIMARY"] = "true";
     commonApiFetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));

--- a/lib/profile-cms/runtime/fetcher.ts
+++ b/lib/profile-cms/runtime/fetcher.ts
@@ -357,7 +357,9 @@ function isNotFoundError(error: unknown): boolean {
   }
 
   const message = getErrorMessage(error);
-  return /not found|cannot get|404/i.test(message);
+  return /not found|cannot get|404|no primary published cms package/i.test(
+    message
+  );
 }
 
 function getErrorStatus(error: unknown): number | undefined {


### PR DESCRIPTION
## Summary

- Treat the backend `Profile <handle> has no primary published CMS package` response as an expected missing primary CMS site.
- Preserve the no-site empty-state behavior for `/[handle]/index.html` and nested CMS routes when no primary package exists.
- Add regression coverage for the production backend message.

## Validation

- `seize exec jest --testMatch=**/*.test.ts --testMatch=**/*.test.tsx --testPathIgnorePatterns=/node_modules/ --testPathIgnorePatterns=/.next/ --testPathIgnorePatterns=/tests/ --testPathIgnorePatterns=/e2e/ --runTestsByPath __tests__/lib/profile-cms/runtime/fetcher.test.ts __tests__/app/profile-cms-route.test.tsx --runInBand --silent --verbose=false --coverage=false`
- `seize run lint:changed`
- `seize run typecheck:changed`
- `codex-diff-check`
- `seize run base-build`
- Local production smoke against `http://localhost:3152/punk6529/index.html`: renders `Website page not found`, not `Website unavailable`.

Release train: `profile-cms-phase-0-8`.