### PR TITLE
Embed profile CMS 3D rooms by default

### DIFF
--- a/__tests__/components/profile-cms/CmsThreeDViewer.test.tsx
+++ b/__tests__/components/profile-cms/CmsThreeDViewer.test.tsx
@@ -84,7 +84,7 @@ describe("CmsThreeDViewer", () => {
     expect(viewer).not.toHaveClass("tw-w-screen");
     expect(
       screen.getByRole("button", { name: "Full screen" })
-    ).toBeVisible();
+    ).toHaveAttribute("aria-pressed", "false");
   });
 
   it("requests fullscreen on the viewer frame", () => {

--- a/__tests__/components/profile-cms/CmsThreeDViewer.test.tsx
+++ b/__tests__/components/profile-cms/CmsThreeDViewer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import CmsThreeDViewer from "@/components/profile-cms/CmsThreeDViewer";
 import type { CmsThreeDViewerConfig } from "@/components/profile-cms/CmsThreeDTypes";
@@ -43,9 +43,22 @@ const roomConfig: CmsThreeDViewerConfig = {
 
 describe("CmsThreeDViewer", () => {
   const originalMatchMedia = globalThis.matchMedia;
+  const originalRequestFullscreen = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    "requestFullscreen"
+  );
 
   afterEach(() => {
     globalThis.matchMedia = originalMatchMedia;
+    if (originalRequestFullscreen) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        "requestFullscreen",
+        originalRequestFullscreen
+      );
+    } else {
+      Reflect.deleteProperty(HTMLElement.prototype, "requestFullscreen");
+    }
   });
 
   it("renders a deferred room canvas with canonical artwork links", () => {
@@ -58,6 +71,37 @@ describe("CmsThreeDViewer", () => {
     expect(
       screen.getByRole("link", { name: "Square artwork" })
     ).toHaveAttribute("href", "/punk6529/nfts/ethereum/contract/1/index.html");
+  });
+
+  it("keeps the 3D viewer embedded until fullscreen is requested", () => {
+    mockMatchMedia(false);
+
+    render(<CmsThreeDViewer config={roomConfig} />);
+
+    const viewer = screen.getByLabelText("Simple room");
+    expect(viewer).toHaveAttribute("data-cms-3d-fullscreen", "false");
+    expect(viewer).toHaveClass("tw-w-full");
+    expect(viewer).not.toHaveClass("tw-w-screen");
+    expect(
+      screen.getByRole("button", { name: "Full screen" })
+    ).toBeVisible();
+  });
+
+  it("requests fullscreen on the viewer frame", () => {
+    mockMatchMedia(false);
+    const requestFullscreen = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(HTMLElement.prototype, "requestFullscreen", {
+      configurable: true,
+      value: requestFullscreen,
+    });
+
+    render(<CmsThreeDViewer config={roomConfig} />);
+
+    const viewer = screen.getByLabelText("Simple room");
+    fireEvent.click(screen.getByRole("button", { name: "Full screen" }));
+
+    expect(requestFullscreen).toHaveBeenCalledTimes(1);
+    expect(requestFullscreen.mock.contexts[0]).toBe(viewer);
   });
 
   it("uses poster and 2D links on mobile", async () => {

--- a/components/profile-cms/CmsThreeDViewer.tsx
+++ b/components/profile-cms/CmsThreeDViewer.tsx
@@ -449,18 +449,22 @@ function CmsThreeDFullscreenControl({
   readonly locale: SupportedLocale;
   readonly onToggle: () => void;
 }) {
+  const label = t(
+    locale,
+    isFullscreen
+      ? "profileCms.interactive.exitFullscreen"
+      : "profileCms.interactive.fullscreen"
+  );
+
   return (
     <button
-      className="tw-absolute tw-right-4 tw-top-4 tw-z-30 tw-inline-flex tw-min-h-10 tw-items-center tw-border tw-border-white/15 tw-bg-black/55 tw-px-3 tw-text-xs tw-font-semibold tw-uppercase tw-text-white tw-backdrop-blur-md tw-transition hover:tw-border-white/35 hover:tw-text-primary-300"
+      aria-label={label}
+      aria-pressed={isFullscreen}
+      className="tw-absolute tw-right-4 tw-top-4 tw-z-30 tw-inline-flex tw-min-h-10 tw-max-w-[calc(100%-2rem)] tw-items-center tw-justify-center tw-border tw-border-white/15 tw-bg-black/55 tw-px-3 tw-text-center tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-white tw-backdrop-blur-md tw-transition hover:tw-border-white/35 hover:tw-text-primary-300"
       onClick={onToggle}
       type="button"
     >
-      {t(
-        locale,
-        isFullscreen
-          ? "profileCms.interactive.exitFullscreen"
-          : "profileCms.interactive.fullscreen"
-      )}
+      {label}
     </button>
   );
 }

--- a/components/profile-cms/CmsThreeDViewer.tsx
+++ b/components/profile-cms/CmsThreeDViewer.tsx
@@ -72,7 +72,9 @@ export default function CmsThreeDViewer({
   const hasAutoStartedRef = useRef(false);
   const pointerGestureRef = useRef({ moved: false, x: 0, y: 0 });
   const runtimeRef = useRef<CmsThreeDRuntime | null>(null);
+  const viewerFrameRef = useRef<HTMLElement | null>(null);
   const router = useRouter();
+  const [isFullscreen, setIsFullscreen] = useState(false);
   const [isMobileFallback, setIsMobileFallback] = useState(false);
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   const [progress, setProgress] = useState(0);
@@ -181,6 +183,42 @@ export default function CmsThreeDViewer({
 
   useEffect(() => disposeRuntime, [disposeRuntime]);
 
+  useEffect(() => {
+    const syncFullscreenState = () => {
+      setIsFullscreen(
+        !!viewerFrameRef.current &&
+          globalThis.document.fullscreenElement === viewerFrameRef.current
+      );
+    };
+
+    syncFullscreenState();
+    globalThis.document.addEventListener(
+      "fullscreenchange",
+      syncFullscreenState
+    );
+
+    return () => {
+      globalThis.document.removeEventListener(
+        "fullscreenchange",
+        syncFullscreenState
+      );
+    };
+  }, []);
+
+  const handleFullscreenToggle = useCallback(() => {
+    const frame = viewerFrameRef.current;
+    if (!frame) {
+      return;
+    }
+
+    if (globalThis.document.fullscreenElement === frame) {
+      globalThis.document.exitFullscreen?.().catch(() => undefined);
+      return;
+    }
+
+    frame.requestFullscreen?.().catch(() => undefined);
+  }, []);
+
   const onCanvasPointerDown = useCallback(
     (event: ReactPointerEvent<HTMLCanvasElement>) => {
       event.currentTarget.focus({ preventScroll: true });
@@ -231,13 +269,18 @@ export default function CmsThreeDViewer({
   );
 
   const showOverlay = status !== "ready" || isMobileFallback;
+  const frameClassName = isFullscreen
+    ? "tw-fixed tw-inset-0 tw-z-[9999] tw-h-screen tw-min-h-screen tw-w-screen tw-border-0"
+    : "tw-aspect-[16/9] tw-min-h-[22rem] tw-w-full tw-border tw-border-solid tw-border-iron-800 md:tw-min-h-[32rem]";
 
   return (
     <section
       aria-label={config.title}
-      className="tw-relative tw-left-1/2 tw-h-[calc(100vh-56px)] tw-min-h-[720px] tw-w-screen -tw-translate-x-1/2 tw-overflow-hidden tw-bg-black"
+      className={`tw-relative tw-isolate tw-overflow-hidden tw-bg-black ${frameClassName}`}
       data-cms-3d-kind={config.kind}
+      data-cms-3d-fullscreen={isFullscreen}
       data-cms-3d-status={isMobileFallback ? "mobile-fallback" : status}
+      ref={viewerFrameRef}
     >
       <div className="tw-absolute tw-inset-0" ref={containerRef}>
         <canvas
@@ -267,6 +310,11 @@ export default function CmsThreeDViewer({
         />
       ) : null}
 
+      <CmsThreeDFullscreenControl
+        isFullscreen={isFullscreen}
+        locale={locale}
+        onToggle={handleFullscreenToggle}
+      />
       <CmsThreeDLinkTray config={config} locale={locale} />
     </section>
   );
@@ -388,6 +436,31 @@ function CmsThreeDStartControl({
       type="button"
     >
       {getCmsThreeDStartLabel({ config, locale, progress, status })}
+    </button>
+  );
+}
+
+function CmsThreeDFullscreenControl({
+  isFullscreen,
+  locale,
+  onToggle,
+}: {
+  readonly isFullscreen: boolean;
+  readonly locale: SupportedLocale;
+  readonly onToggle: () => void;
+}) {
+  return (
+    <button
+      className="tw-absolute tw-right-4 tw-top-4 tw-z-30 tw-inline-flex tw-min-h-10 tw-items-center tw-border tw-border-white/15 tw-bg-black/55 tw-px-3 tw-text-xs tw-font-semibold tw-uppercase tw-text-white tw-backdrop-blur-md tw-transition hover:tw-border-white/35 hover:tw-text-primary-300"
+      onClick={onToggle}
+      type="button"
+    >
+      {t(
+        locale,
+        isFullscreen
+          ? "profileCms.interactive.exitFullscreen"
+          : "profileCms.interactive.fullscreen"
+      )}
     </button>
   );
 }
@@ -566,7 +639,7 @@ function CmsThreeDLinkTray({
   return (
     <nav
       aria-label={t(locale, "profileCms.interactive.roomWorksLabel")}
-      className="tw-absolute tw-bottom-5 tw-left-24 tw-right-5 tw-z-20 tw-flex tw-flex-wrap tw-gap-2"
+      className="tw-absolute tw-bottom-4 tw-left-4 tw-right-4 tw-z-20 tw-flex tw-flex-wrap tw-gap-2"
     >
       {config.placements.map((placement) => (
         <a

--- a/i18n/messages/de-DE.ts
+++ b/i18n/messages/de-DE.ts
@@ -15,6 +15,8 @@ export const DE_DE_MESSAGES = {
   "media.video.seek": "Videoposition andern",
   "media.video.unmute": "Videoton einschalten",
   "media.video.unsupported": "Ihr Browser unterstuetzt das Video-Tag nicht.",
+  "profileCms.interactive.fullscreen": "Vollbild",
+  "profileCms.interactive.exitFullscreen": "Vollbild beenden",
   ...DE_DE_NEW_VERSION_TOAST_MESSAGES,
   "theMemes.documentTitle": "The Memes | Sammlungen",
   "theMemes.description.collections": "Sammlungen",

--- a/i18n/messages/en-GB.ts
+++ b/i18n/messages/en-GB.ts
@@ -15,6 +15,8 @@ export const EN_GB_MESSAGES = {
   "media.video.seek": "Seek video",
   "media.video.unmute": "Unmute video",
   "media.video.unsupported": "Your browser does not support the video tag.",
+  "profileCms.interactive.fullscreen": "Full screen",
+  "profileCms.interactive.exitFullscreen": "Exit full screen",
   ...EN_GB_NEW_VERSION_TOAST_MESSAGES,
   "theMemes.documentTitle": "The Memes | Collections",
   "theMemes.description.collections": "Collections",

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -668,6 +668,8 @@ export const EN_US_MESSAGES = {
     "Enter a simple exhibition room. Every artwork still links to its canonical 2D detail page.",
   "profileCms.interactive.openSourceMedia": "Open source media",
   "profileCms.interactive.enterRoom": "Enter room",
+  "profileCms.interactive.fullscreen": "Full screen",
+  "profileCms.interactive.exitFullscreen": "Exit full screen",
   "profileCms.interactive.loadObject": "Load 3D object",
   "profileCms.interactive.loading": "Loading {progress}%",
   "profileCms.interactive.loadError":

--- a/i18n/messages/es-ES.ts
+++ b/i18n/messages/es-ES.ts
@@ -15,6 +15,8 @@ export const ES_ES_MESSAGES = {
   "media.video.seek": "Cambiar la posicion del video",
   "media.video.unmute": "Activar sonido del video",
   "media.video.unsupported": "Tu navegador no admite la etiqueta de video.",
+  "profileCms.interactive.fullscreen": "Pantalla completa",
+  "profileCms.interactive.exitFullscreen": "Salir de pantalla completa",
   ...ES_ES_NEW_VERSION_TOAST_MESSAGES,
   "theMemes.documentTitle": "The Memes | Colecciones",
   "theMemes.description.collections": "Colecciones",

--- a/i18n/messages/fr-FR.ts
+++ b/i18n/messages/fr-FR.ts
@@ -16,6 +16,8 @@ export const FR_FR_MESSAGES = {
   "media.video.unmute": "Activer le son de la video",
   "media.video.unsupported":
     "Votre navigateur ne prend pas en charge la balise video.",
+  "profileCms.interactive.fullscreen": "Plein ecran",
+  "profileCms.interactive.exitFullscreen": "Quitter le plein ecran",
   ...FR_FR_NEW_VERSION_TOAST_MESSAGES,
   "theMemes.documentTitle": "The Memes | Collections",
   "theMemes.description.collections": "Collections",


### PR DESCRIPTION
## Summary

- Keep profile CMS 3D rooms embedded inside the normal CMS page layout by default instead of forcing a viewport-wide/full-height takeover.
- Add an explicit Full screen / Exit full screen control that requests fullscreen on the viewer frame.
- Keep room work links inside the bounded viewer frame and add coverage for the embedded/default fullscreen behavior.

## Verification

- `seize run typecheck:changed`
- `seize run lint:changed`
- `codex-diff-check -- components/profile-cms/CmsThreeDViewer.tsx __tests__/components/profile-cms/CmsThreeDViewer.test.tsx i18n/messages/en-US.ts`
- Browser automation on `http://localhost:3152/punk6529bot/room/index.html?cms_room_embed_fix=1` with production CMS API data:
  - before activation: viewer `data-cms-3d-fullscreen=false`, class includes `tw-w-full`, button `Full screen` visible
  - after activation: canvas remains bounded in the viewer frame, page header text still present, status `ready`

## Notes

- Targeted Jest could not discover tests from this local `.codex\\worktrees` path (`No tests found ... Make sure Jest's configuration does not exclude this directory`). This appears to be path/discovery related, not a failing assertion.