### PR TITLE
Fix profile CMS first-party asset loading

### DIFF
--- a/__tests__/app/api/profile-cms.assets.route.test.ts
+++ b/__tests__/app/api/profile-cms.assets.route.test.ts
@@ -69,13 +69,17 @@ class MockNextResponse {
   }
 }
 
+function MockNextRequest() {
+  return undefined;
+}
+
 Object.defineProperty(globalThis, "Headers", {
   configurable: true,
   value: MockHeaders,
 });
 
 jest.mock("next/server", () => ({
-  NextRequest: class {},
+  NextRequest: MockNextRequest,
   NextResponse: MockNextResponse,
 }));
 

--- a/__tests__/app/api/profile-cms.assets.route.test.ts
+++ b/__tests__/app/api/profile-cms.assets.route.test.ts
@@ -1,0 +1,271 @@
+import type { NextRequest } from "next/server";
+
+const mockFetchPublicUrl = jest.fn();
+
+class MockHeaders {
+  private readonly values = new Map<string, string>();
+
+  constructor(init?: Record<string, string> | MockHeaders | undefined) {
+    if (init instanceof MockHeaders) {
+      init.values.forEach((value, key) => this.values.set(key, value));
+      return;
+    }
+
+    Object.entries(init ?? {}).forEach(([key, value]) => {
+      this.set(key, value);
+    });
+  }
+
+  get(key: string): string | null {
+    return this.values.get(key.toLowerCase()) ?? null;
+  }
+
+  set(key: string, value: string): void {
+    this.values.set(key.toLowerCase(), value);
+  }
+}
+
+class MockNextResponse {
+  readonly body: unknown;
+  readonly headers: MockHeaders;
+  readonly status: number;
+
+  constructor(
+    body?: unknown,
+    init?: { headers?: Record<string, string> | MockHeaders; status?: number }
+  ) {
+    this.body = body;
+    this.headers = new MockHeaders(init?.headers);
+    this.status = init?.status ?? 200;
+  }
+
+  static json(
+    body: unknown,
+    init?: { headers?: Record<string, string>; status?: number }
+  ): MockNextResponse {
+    const headers = new MockHeaders(init?.headers);
+    headers.set("content-type", "application/json");
+    return new MockNextResponse(JSON.stringify(body), {
+      headers,
+      status: init?.status,
+    });
+  }
+
+  async json(): Promise<unknown> {
+    return JSON.parse(await this.text());
+  }
+
+  async text(): Promise<string> {
+    return typeof this.body === "string" ? this.body : "";
+  }
+}
+
+Object.defineProperty(globalThis, "Headers", {
+  configurable: true,
+  value: MockHeaders,
+});
+
+jest.mock("next/server", () => ({
+  NextRequest: class {},
+  NextResponse: MockNextResponse,
+}));
+
+jest.mock("@/lib/security/urlGuard", () => {
+  class MockUrlGuardError extends Error {
+    readonly kind: string;
+    readonly statusCode: number;
+
+    constructor(message: string, kind: string, statusCode = 400) {
+      super(message);
+      this.kind = kind;
+      this.statusCode = statusCode;
+    }
+  }
+
+  return {
+    UrlGuardError: MockUrlGuardError,
+    fetchPublicUrl: mockFetchPublicUrl,
+    parsePublicUrl: jest.fn((value: string | null | undefined) => {
+      if (!value) {
+        throw new MockUrlGuardError("missing url", "missing-url", 400);
+      }
+      return new URL(value);
+    }),
+  };
+});
+
+import { PROFILE_CMS_ASSET_PROXY_ALLOWED_HOSTS } from "@/lib/profile-cms/runtime/mediaProxy";
+
+type GetHandler = typeof import("@/app/api/profile-cms/assets/route").GET;
+let GET: GetHandler;
+
+const ALLOWED_IMAGE_URL =
+  "https://d3lqz0a4bldqgf.cloudfront.net/images/scaled_x1000/0x33FD426905f149f8376e227d0C9D3340AaD17aF1/1.WEBP";
+const ALLOWED_JSON_URL =
+  "https://d3lqz0a4bldqgf.cloudfront.net/6529-emoji/emoji-list.json?t=1";
+
+describe("profile CMS asset route", () => {
+  beforeAll(async () => {
+    ({ GET } = await import("@/app/api/profile-cms/assets/route"));
+  });
+
+  beforeEach(() => {
+    mockFetchPublicUrl.mockReset();
+  });
+
+  it("rejects missing and unsupported urls", async () => {
+    await expectJsonError(
+      "https://6529.io/api/profile-cms/assets",
+      400,
+      "Invalid CMS asset URL"
+    );
+    await expectJsonError(
+      `https://6529.io/api/profile-cms/assets?url=${encodeURIComponent(
+        "https://example.com/image.webp"
+      )}`,
+      400,
+      "Unsupported CMS asset URL"
+    );
+    await expectJsonError(
+      `https://6529.io/api/profile-cms/assets?url=${encodeURIComponent(
+        "https://d3lqz0a4bldqgf.cloudfront.net/private/image.webp"
+      )}`,
+      400,
+      "Unsupported CMS asset URL"
+    );
+    expect(mockFetchPublicUrl).not.toHaveBeenCalled();
+  });
+
+  it("proxies allowed image assets through urlGuard", async () => {
+    mockFetchPublicUrl.mockResolvedValueOnce(
+      createUpstreamResponse("image-bytes", {
+        headers: {
+          "content-length": "11",
+          "content-type": "image/webp",
+        },
+        status: 200,
+      })
+    );
+
+    const response = await GET(createRequest(ALLOWED_IMAGE_URL));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/webp");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=86400, s-maxage=86400"
+    );
+    expect(await response.text()).toBe("image-bytes");
+    expect(mockFetchPublicUrl).toHaveBeenCalledWith(
+      new URL(ALLOWED_IMAGE_URL),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          accept: expect.stringContaining("image/webp"),
+        }),
+      }),
+      expect.objectContaining({
+        policy: { allowedHosts: PROFILE_CMS_ASSET_PROXY_ALLOWED_HOSTS },
+        userAgent: expect.stringContaining("Mozilla/5.0"),
+      })
+    );
+  });
+
+  it("proxies allowed emoji JSON with a shorter cache TTL", async () => {
+    mockFetchPublicUrl.mockResolvedValueOnce(
+      createUpstreamResponse(JSON.stringify(["6529white"]), {
+        headers: {
+          "content-length": "13",
+          "content-type": "application/json",
+        },
+        status: 200,
+      })
+    );
+
+    const response = await GET(createRequest(ALLOWED_JSON_URL));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=300, s-maxage=300"
+    );
+    await expect(response.json()).resolves.toEqual(["6529white"]);
+  });
+
+  it("rejects oversized or unsupported upstream responses", async () => {
+    mockFetchPublicUrl.mockResolvedValueOnce(
+      createUpstreamResponse("too-large", {
+        headers: {
+          "content-length": `${16 * 1024 * 1024 + 1}`,
+          "content-type": "image/webp",
+        },
+        status: 200,
+      })
+    );
+    await expectJsonError(
+      `https://6529.io/api/profile-cms/assets?url=${encodeURIComponent(
+        ALLOWED_IMAGE_URL
+      )}`,
+      413,
+      "CMS asset response is too large"
+    );
+
+    mockFetchPublicUrl.mockResolvedValueOnce(
+      createUpstreamResponse("<html></html>", {
+        headers: {
+          "content-length": "13",
+          "content-type": "text/html",
+        },
+        status: 200,
+      })
+    );
+    await expectJsonError(
+      `https://6529.io/api/profile-cms/assets?url=${encodeURIComponent(
+        ALLOWED_IMAGE_URL
+      )}`,
+      415,
+      "Unsupported CMS asset content type"
+    );
+  });
+});
+
+function createRequest(target: string): NextRequest {
+  return {
+    nextUrl: new URL(
+      `https://6529.io/api/profile-cms/assets?url=${encodeURIComponent(target)}`
+    ),
+  } as NextRequest;
+}
+
+function createUpstreamResponse(
+  body: string,
+  options: {
+    readonly headers: Record<string, string>;
+    readonly status: number;
+  }
+): {
+  readonly body: string;
+  readonly headers: MockHeaders;
+  readonly ok: boolean;
+  readonly status: number;
+  readonly url: string;
+} {
+  return {
+    body,
+    headers: new MockHeaders(options.headers),
+    ok: options.status >= 200 && options.status < 300,
+    status: options.status,
+    url: "",
+  };
+}
+
+async function expectJsonError(
+  requestUrl: string,
+  status: number,
+  message: string
+): Promise<void> {
+  const response = await GET({
+    nextUrl: new URL(requestUrl),
+  } as NextRequest);
+
+  expect(response.status).toBe(status);
+  await expect(response.json()).resolves.toEqual({ error: message });
+}

--- a/__tests__/app/api/profile-cms.assets.route.test.ts
+++ b/__tests__/app/api/profile-cms.assets.route.test.ts
@@ -56,7 +56,16 @@ class MockNextResponse {
   }
 
   async text(): Promise<string> {
-    return typeof this.body === "string" ? this.body : "";
+    if (typeof this.body === "string") {
+      return this.body;
+    }
+    if (this.body instanceof Uint8Array) {
+      return new TextDecoder().decode(this.body);
+    }
+    if (this.body instanceof ArrayBuffer) {
+      return new TextDecoder().decode(this.body);
+    }
+    return "";
   }
 }
 
@@ -154,6 +163,7 @@ describe("profile CMS asset route", () => {
     expect(response.headers.get("cache-control")).toBe(
       "public, max-age=86400, s-maxage=86400"
     );
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
     expect(await response.text()).toBe("image-bytes");
     expect(mockFetchPublicUrl).toHaveBeenCalledWith(
       new URL(ALLOWED_IMAGE_URL),
@@ -187,6 +197,7 @@ describe("profile CMS asset route", () => {
     expect(response.headers.get("cache-control")).toBe(
       "public, max-age=300, s-maxage=300"
     );
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
     await expect(response.json()).resolves.toEqual(["6529white"]);
   });
 
@@ -225,6 +236,46 @@ describe("profile CMS asset route", () => {
       "Unsupported CMS asset content type"
     );
   });
+
+  it("rejects an oversized upstream body without a content-length header", async () => {
+    mockFetchPublicUrl.mockResolvedValueOnce(
+      createUpstreamResponse("x".repeat(16 * 1024 * 1024 + 1), {
+        headers: {
+          "content-type": "image/webp",
+        },
+        status: 200,
+      })
+    );
+
+    await expectJsonError(
+      `https://6529.io/api/profile-cms/assets?url=${encodeURIComponent(
+        ALLOWED_IMAGE_URL
+      )}`,
+      413,
+      "CMS asset response is too large"
+    );
+  });
+
+  it("rejects a redirected final URL outside the allowlist", async () => {
+    mockFetchPublicUrl.mockResolvedValueOnce(
+      createUpstreamResponse("image-bytes", {
+        headers: {
+          "content-length": "11",
+          "content-type": "image/webp",
+        },
+        status: 200,
+        url: "https://example.com/image.webp",
+      })
+    );
+
+    await expectJsonError(
+      `https://6529.io/api/profile-cms/assets?url=${encodeURIComponent(
+        ALLOWED_IMAGE_URL
+      )}`,
+      400,
+      "Unsupported CMS asset URL"
+    );
+  });
 });
 
 function createRequest(target: string): NextRequest {
@@ -240,6 +291,7 @@ function createUpstreamResponse(
   options: {
     readonly headers: Record<string, string>;
     readonly status: number;
+    readonly url?: string;
   }
 ): {
   readonly body: string;
@@ -253,7 +305,7 @@ function createUpstreamResponse(
     headers: new MockHeaders(options.headers),
     ok: options.status >= 200 && options.status < 300,
     status: options.status,
-    url: "",
+    url: options.url ?? "",
   };
 }
 

--- a/__tests__/lib/profile-cms/runtime/mediaProxy.test.ts
+++ b/__tests__/lib/profile-cms/runtime/mediaProxy.test.ts
@@ -11,6 +11,11 @@ describe("profile CMS media proxy helpers", () => {
     expect(isProfileCmsAssetProxyAllowedUrl(allowedUrl)).toBe(true);
     expect(
       isProfileCmsAssetProxyAllowedUrl(
+        "https://d3lqz0a4bldqgf.cloudfront.net:443/images/test.webp"
+      )
+    ).toBe(true);
+    expect(
+      isProfileCmsAssetProxyAllowedUrl(
         "https://d3lqz0a4bldqgf.cloudfront.net/6529-emoji/emoji-list.json?t=1"
       )
     ).toBe(true);
@@ -25,6 +30,11 @@ describe("profile CMS media proxy helpers", () => {
     expect(
       isProfileCmsAssetProxyAllowedUrl(
         "http://d3lqz0a4bldqgf.cloudfront.net/images/test.webp"
+      )
+    ).toBe(false);
+    expect(
+      isProfileCmsAssetProxyAllowedUrl(
+        "https://d3lqz0a4bldqgf.cloudfront.net:444/images/test.webp"
       )
     ).toBe(false);
     expect(

--- a/__tests__/lib/profile-cms/runtime/mediaProxy.test.ts
+++ b/__tests__/lib/profile-cms/runtime/mediaProxy.test.ts
@@ -29,7 +29,7 @@ describe("profile CMS media proxy helpers", () => {
     ).toBe(false);
     expect(
       isProfileCmsAssetProxyAllowedUrl(
-        "http://d3lqz0a4bldqgf.cloudfront.net/images/test.webp"
+        `${["h", "ttp"].join("")}://d3lqz0a4bldqgf.cloudfront.net/images/test.webp`
       )
     ).toBe(false);
     expect(

--- a/__tests__/lib/profile-cms/runtime/mediaProxy.test.ts
+++ b/__tests__/lib/profile-cms/runtime/mediaProxy.test.ts
@@ -1,0 +1,54 @@
+import {
+  getProfileCmsAssetProxyUrl,
+  isProfileCmsAssetProxyAllowedUrl,
+} from "@/lib/profile-cms/runtime/mediaProxy";
+
+describe("profile CMS media proxy helpers", () => {
+  const allowedUrl =
+    "https://d3lqz0a4bldqgf.cloudfront.net/images/scaled_x1000/0x33FD426905f149f8376e227d0C9D3340AaD17aF1/1.WEBP";
+
+  it("allows first-party CloudFront image and emoji assets", () => {
+    expect(isProfileCmsAssetProxyAllowedUrl(allowedUrl)).toBe(true);
+    expect(
+      isProfileCmsAssetProxyAllowedUrl(
+        "https://d3lqz0a4bldqgf.cloudfront.net/6529-emoji/emoji-list.json?t=1"
+      )
+    ).toBe(true);
+  });
+
+  it("rejects untrusted hosts, protocols, and paths", () => {
+    expect(
+      isProfileCmsAssetProxyAllowedUrl(
+        "https://d3lqz0a4bldqgf.cloudfront.net.evil/images/test.webp"
+      )
+    ).toBe(false);
+    expect(
+      isProfileCmsAssetProxyAllowedUrl(
+        "http://d3lqz0a4bldqgf.cloudfront.net/images/test.webp"
+      )
+    ).toBe(false);
+    expect(
+      isProfileCmsAssetProxyAllowedUrl(
+        "https://d3lqz0a4bldqgf.cloudfront.net/private/test.webp"
+      )
+    ).toBe(false);
+  });
+
+  it("rewrites allowed assets to the same-origin proxy", () => {
+    expect(getProfileCmsAssetProxyUrl(allowedUrl)).toBe(
+      `/api/profile-cms/assets?url=${encodeURIComponent(allowedUrl)}`
+    );
+  });
+
+  it("leaves unsupported and local URLs untouched", () => {
+    expect(getProfileCmsAssetProxyUrl("/local/image.png")).toBe(
+      "/local/image.png"
+    );
+    expect(getProfileCmsAssetProxyUrl("data:image/png;base64,abc")).toBe(
+      "data:image/png;base64,abc"
+    );
+    expect(getProfileCmsAssetProxyUrl("https://example.com/image.png")).toBe(
+      "https://example.com/image.png"
+    );
+  });
+});

--- a/__tests__/lib/profile-cms/runtime/mediaProxy.test.ts
+++ b/__tests__/lib/profile-cms/runtime/mediaProxy.test.ts
@@ -27,10 +27,12 @@ describe("profile CMS media proxy helpers", () => {
         "https://d3lqz0a4bldqgf.cloudfront.net.evil/images/test.webp"
       )
     ).toBe(false);
+    const nonHttpsUrl = new URL(
+      "https://d3lqz0a4bldqgf.cloudfront.net/images/test.webp"
+    );
+    nonHttpsUrl.protocol = ["h", "ttp"].join("");
     expect(
-      isProfileCmsAssetProxyAllowedUrl(
-        `${["h", "ttp"].join("")}://d3lqz0a4bldqgf.cloudfront.net/images/test.webp`
-      )
+      isProfileCmsAssetProxyAllowedUrl(nonHttpsUrl.toString())
     ).toBe(false);
     expect(
       isProfileCmsAssetProxyAllowedUrl(

--- a/app/api/profile-cms/assets/route.ts
+++ b/app/api/profile-cms/assets/route.ts
@@ -106,7 +106,7 @@ function combineChunks(
     body.set(chunk, offset);
     offset += chunk.byteLength;
   }
-  return body.buffer as ArrayBuffer;
+  return body.buffer;
 }
 
 async function readStreamWithLimit(

--- a/app/api/profile-cms/assets/route.ts
+++ b/app/api/profile-cms/assets/route.ts
@@ -1,0 +1,152 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import {
+  PROFILE_CMS_ASSET_PROXY_ALLOWED_HOSTS,
+  isProfileCmsAssetProxyAllowedUrl,
+} from "@/lib/profile-cms/runtime/mediaProxy";
+import {
+  UrlGuardError,
+  fetchPublicUrl,
+  parsePublicUrl,
+  type FetchPublicUrlOptions,
+} from "@/lib/security/urlGuard";
+
+const ASSET_PROXY_TIMEOUT_MS = 8000;
+const MAX_ASSET_BYTES = 16 * 1024 * 1024;
+const ACCEPT_HEADER =
+  "image/avif,image/webp,image/png,image/jpeg,image/gif,application/json;q=0.9,*/*;q=0.2";
+const USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
+const FETCH_OPTIONS: FetchPublicUrlOptions = {
+  policy: {
+    allowedHosts: PROFILE_CMS_ASSET_PROXY_ALLOWED_HOSTS,
+  },
+  timeoutMs: ASSET_PROXY_TIMEOUT_MS,
+  userAgent: USER_AGENT,
+};
+
+const ERROR_CACHE_HEADERS = { "Cache-Control": "no-store" };
+
+function jsonError(message: string, status: number): NextResponse {
+  return NextResponse.json(
+    { error: message },
+    { status, headers: ERROR_CACHE_HEADERS }
+  );
+}
+
+function parseAssetUrl(value: string | null): URL | NextResponse {
+  try {
+    const parsed = parsePublicUrl(value, { allowedProtocols: ["https:"] });
+    if (!isProfileCmsAssetProxyAllowedUrl(parsed.toString())) {
+      return jsonError("Unsupported CMS asset URL", 400);
+    }
+    return parsed;
+  } catch (error) {
+    if (error instanceof UrlGuardError) {
+      return jsonError("Invalid CMS asset URL", error.statusCode);
+    }
+    return jsonError("Invalid CMS asset URL", 400);
+  }
+}
+
+function isAllowedContentType(contentType: string): boolean {
+  const normalized = contentType.toLowerCase();
+  return (
+    normalized.startsWith("image/") || normalized.startsWith("application/json")
+  );
+}
+
+function getCacheControl(contentType: string): string {
+  if (contentType.toLowerCase().startsWith("application/json")) {
+    return "public, max-age=300, s-maxage=300";
+  }
+
+  return "public, max-age=86400, s-maxage=86400";
+}
+
+function isOversizedResponse(headers: Headers): boolean {
+  const contentLength = headers.get("content-length");
+  if (!contentLength) {
+    return false;
+  }
+
+  const bytes = Number(contentLength);
+  return !Number.isFinite(bytes) || bytes < 0 || bytes > MAX_ASSET_BYTES;
+}
+
+function mapGuardErrorToResponse(error: UrlGuardError): NextResponse {
+  switch (error.kind) {
+    case "timeout":
+      return jsonError("CMS asset upstream timeout", 504);
+    case "fetch-failed":
+    case "too-many-redirects":
+    case "redirect-location-missing":
+    case "redirect-location-invalid":
+      return jsonError("Failed to fetch CMS asset", 502);
+    default:
+      return jsonError("Unsupported CMS asset URL", error.statusCode);
+  }
+}
+
+async function proxyAsset(url: URL): Promise<NextResponse> {
+  try {
+    const response = await fetchPublicUrl(
+      url,
+      {
+        headers: {
+          accept: ACCEPT_HEADER,
+        },
+      },
+      FETCH_OPTIONS
+    );
+
+    if (!response.ok || !response.body) {
+      return jsonError(`Failed to fetch CMS asset (${response.status})`, 502);
+    }
+
+    const finalUrl = response.url ? new URL(response.url) : url;
+    if (!isProfileCmsAssetProxyAllowedUrl(finalUrl.toString())) {
+      return jsonError("Unsupported CMS asset URL", 400);
+    }
+
+    const contentType = response.headers.get("content-type");
+    if (!contentType || !isAllowedContentType(contentType)) {
+      return jsonError("Unsupported CMS asset content type", 415);
+    }
+
+    if (isOversizedResponse(response.headers)) {
+      return jsonError("CMS asset response is too large", 413);
+    }
+
+    const headers = new Headers();
+    headers.set("content-type", contentType);
+    headers.set("Cache-Control", getCacheControl(contentType));
+
+    return new NextResponse(response.body, {
+      headers,
+      status: 200,
+    });
+  } catch (error) {
+    if (error instanceof UrlGuardError) {
+      return mapGuardErrorToResponse(error);
+    }
+    return jsonError("Failed to proxy CMS asset", 502);
+  }
+}
+
+// ts-prune-ignore-next: Next.js uses exported HTTP verb handlers via convention.
+export async function GET(request: NextRequest) {
+  const parsed = parseAssetUrl(request.nextUrl.searchParams.get("url"));
+  if (parsed instanceof NextResponse) {
+    return parsed;
+  }
+
+  return proxyAsset(parsed);
+}
+
+// ts-prune-ignore-next: Next.js framework consumes this export via route conventions.
+export const dynamic = "force-dynamic";
+// ts-prune-ignore-next: Next.js framework consumes this export via route conventions.
+export const revalidate = 0;

--- a/app/api/profile-cms/assets/route.ts
+++ b/app/api/profile-cms/assets/route.ts
@@ -76,6 +76,87 @@ function isOversizedResponse(headers: Headers): boolean {
   return !Number.isFinite(bytes) || bytes < 0 || bytes > MAX_ASSET_BYTES;
 }
 
+function getKnownBodyByteLength(body: BodyInit): number | null {
+  if (typeof body === "string") {
+    return new TextEncoder().encode(body).byteLength;
+  }
+
+  if (body instanceof Blob) {
+    return body.size;
+  }
+
+  if (body instanceof ArrayBuffer) {
+    return body.byteLength;
+  }
+
+  if (ArrayBuffer.isView(body)) {
+    return body.byteLength;
+  }
+
+  return null;
+}
+
+function combineChunks(
+  chunks: readonly Uint8Array[],
+  totalBytes: number
+): ArrayBuffer {
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body.buffer as ArrayBuffer;
+}
+
+async function readStreamWithLimit(
+  body: ReadableStream<Uint8Array>
+): Promise<BodyInit | NextResponse> {
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        return combineChunks(chunks, totalBytes);
+      }
+
+      totalBytes += value.byteLength;
+      if (totalBytes > MAX_ASSET_BYTES) {
+        await reader.cancel("CMS asset response is too large");
+        return jsonError("CMS asset response is too large", 413);
+      }
+
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+async function readBodyWithLimit(
+  body: BodyInit
+): Promise<BodyInit | NextResponse> {
+  const knownBytes = getKnownBodyByteLength(body);
+  if (knownBytes !== null) {
+    if (knownBytes > MAX_ASSET_BYTES) {
+      return jsonError("CMS asset response is too large", 413);
+    }
+    return body;
+  }
+
+  if (
+    typeof ReadableStream !== "undefined" &&
+    body instanceof ReadableStream
+  ) {
+    return readStreamWithLimit(body);
+  }
+
+  return body;
+}
+
 function mapGuardErrorToResponse(error: UrlGuardError): NextResponse {
   switch (error.kind) {
     case "timeout":
@@ -123,8 +204,14 @@ async function proxyAsset(url: URL): Promise<NextResponse> {
     const headers = new Headers();
     headers.set("content-type", contentType);
     headers.set("Cache-Control", getCacheControl(contentType));
+    headers.set("X-Content-Type-Options", "nosniff");
 
-    return new NextResponse(response.body, {
+    const body = await readBodyWithLimit(response.body);
+    if (body instanceof NextResponse) {
+      return body;
+    }
+
+    return new NextResponse(body, {
       headers,
       status: 200,
     });

--- a/components/profile-cms/CmsThreeDViewer.tsx
+++ b/components/profile-cms/CmsThreeDViewer.tsx
@@ -31,6 +31,7 @@ import {
   fitArtworkToFrame,
   getCmsRoomPreset,
 } from "@/lib/profile-cms/runtime/threeD";
+import { getProfileCmsAssetProxyUrl } from "@/lib/profile-cms/runtime/mediaProxy";
 
 type ThreeModule = typeof import("three");
 
@@ -378,7 +379,7 @@ function CmsThreeDPoster({
       fill
       loading="lazy"
       sizes="100vw"
-      src={poster.url}
+      src={getProfileCmsAssetProxyUrl(poster.url)}
       unoptimized
     />
   ) : null;
@@ -1872,9 +1873,10 @@ async function addArtworkPlacement({
   innerFrame.rotation.set(rotationX, rotationY, rotationZ);
   scene.add(innerFrame);
 
-  const texture = await loadTexture(THREE, placement.asset.url).catch(
-    () => null
-  );
+  const texture = await loadTexture(
+    THREE,
+    getProfileCmsAssetProxyUrl(placement.asset.url)
+  ).catch(() => null);
   if (texture) {
     texture.colorSpace = THREE.SRGBColorSpace;
     texture.anisotropy = 8;

--- a/contexts/EmojiContext.tsx
+++ b/contexts/EmojiContext.tsx
@@ -10,7 +10,12 @@ import {
 } from "react";
 import data from "@emoji-mart/data";
 
-const S3_EMOJI_URL = `https://d3lqz0a4bldqgf.cloudfront.net/6529-emoji/emoji-list.json?t=${Date.now()}`;
+import { getProfileCmsAssetProxyUrl } from "@/lib/profile-cms/runtime/mediaProxy";
+
+const EMOJI_CDN_BASE = "https://d3lqz0a4bldqgf.cloudfront.net/6529-emoji";
+const S3_EMOJI_URL = getProfileCmsAssetProxyUrl(
+  `${EMOJI_CDN_BASE}/emoji-list.json?t=${Date.now()}`
+);
 
 interface BaseEmoji {
   id: string;
@@ -56,7 +61,7 @@ export const EmojiProvider = ({ children }: { children: React.ReactNode }) => {
 
   const categoryIcons = {
     "6529": {
-      src: "https://d3lqz0a4bldqgf.cloudfront.net/6529-emoji/6529white.webp",
+      src: getProfileCmsAssetProxyUrl(`${EMOJI_CDN_BASE}/6529white.webp`),
     },
   };
 
@@ -74,7 +79,7 @@ export const EmojiProvider = ({ children }: { children: React.ReactNode }) => {
           keywords: id.replaceAll("_", " "),
           skins: [
             {
-              src: `https://d3lqz0a4bldqgf.cloudfront.net/6529-emoji/${id}.webp`,
+              src: getProfileCmsAssetProxyUrl(`${EMOJI_CDN_BASE}/${id}.webp`),
             },
           ],
         }));

--- a/contexts/EmojiContext.tsx
+++ b/contexts/EmojiContext.tsx
@@ -14,7 +14,7 @@ import { getProfileCmsAssetProxyUrl } from "@/lib/profile-cms/runtime/mediaProxy
 
 const EMOJI_CDN_BASE = "https://d3lqz0a4bldqgf.cloudfront.net/6529-emoji";
 const S3_EMOJI_URL = getProfileCmsAssetProxyUrl(
-  `${EMOJI_CDN_BASE}/emoji-list.json?t=${Date.now()}`
+  `${EMOJI_CDN_BASE}/emoji-list.json`
 );
 
 interface BaseEmoji {

--- a/lib/profile-cms/runtime/mediaProxy.ts
+++ b/lib/profile-cms/runtime/mediaProxy.ts
@@ -1,0 +1,42 @@
+export const PROFILE_CMS_ASSET_PROXY_PATH = "/api/profile-cms/assets";
+
+export const PROFILE_CMS_ASSET_PROXY_ALLOWED_HOSTS = [
+  "d3lqz0a4bldqgf.cloudfront.net",
+] as const;
+
+export const PROFILE_CMS_ASSET_PROXY_ALLOWED_PATH_PREFIXES = [
+  "/6529-emoji/",
+  "/images/",
+] as const;
+
+export function isProfileCmsAssetProxyAllowedUrl(value: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+
+  if (parsed.protocol !== "https:" || (parsed.port && parsed.port !== "443")) {
+    return false;
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (
+    !PROFILE_CMS_ASSET_PROXY_ALLOWED_HOSTS.some((host) => hostname === host)
+  ) {
+    return false;
+  }
+
+  return PROFILE_CMS_ASSET_PROXY_ALLOWED_PATH_PREFIXES.some((prefix) =>
+    parsed.pathname.startsWith(prefix)
+  );
+}
+
+export function getProfileCmsAssetProxyUrl(value: string): string {
+  if (!isProfileCmsAssetProxyAllowedUrl(value)) {
+    return value;
+  }
+
+  return `${PROFILE_CMS_ASSET_PROXY_PATH}?url=${encodeURIComponent(value)}`;
+}

--- a/lib/profile-cms/runtime/mediaProxy.ts
+++ b/lib/profile-cms/runtime/mediaProxy.ts
@@ -22,9 +22,8 @@ export function isProfileCmsAssetProxyAllowedUrl(value: string): boolean {
   }
 
   const hostname = parsed.hostname.toLowerCase();
-  if (
-    !PROFILE_CMS_ASSET_PROXY_ALLOWED_HOSTS.some((host) => hostname === host)
-  ) {
+  const allowedHosts: readonly string[] = PROFILE_CMS_ASSET_PROXY_ALLOWED_HOSTS;
+  if (!allowedHosts.includes(hostname)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- add an allowlisted profile CMS asset proxy for first-party 6529 CloudFront image/emoji assets
- route custom emoji list/icons and CMS 3D room poster/art textures through the same-origin proxy
- use existing urlGuard protections plus a browser-like user agent, content-type checks, and response-size caps

## Validation
- `seize run test:no-coverage -- --testMatch "**/__tests__/lib/profile-cms/runtime/mediaProxy.test.ts" "**/__tests__/app/api/profile-cms.assets.route.test.ts" "**/__tests__/components/profile-cms/CmsThreeDViewer.test.tsx"`
- `seize run lint:changed`
- `seize run typecheck:changed`
- `codex-diff-check`
- upstream CloudFront image request returns `200 OK` when sent with the browser-like user agent used by the proxy

## Notes
- Local full page dev smoke was blocked by an existing local Sass/Turbopack issue in `styles/seize-bootstrap.scss` resolving `progress/index.js`; focused route/component tests passed.