### PR TITLE
[codex] Make wave sidebar rows fully clickable

### DIFF
--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
@@ -260,16 +260,24 @@ describe("BrainLeftSidebarWave", () => {
     expect(getWaveRow()).toHaveClass("tw-px-5");
     expect(getWaveRow()).toHaveClass("tw-gap-x-4");
     expect(getWaveRow()).not.toHaveClass("tw-pl-2");
-    const rowLink = screen.getByRole("link", { name: "Chat Wave" });
-    expect(rowLink).toHaveClass("tw-absolute");
-    expect(rowLink).toHaveClass("tw-inset-0");
-    expect(rowLink).toHaveClass("tw-z-10");
+    const titleLink = screen.getByRole("link", { name: "Chat Wave" });
+    expect(titleLink.nextElementSibling).toBe(expandButton);
+    expect(expandButton.parentElement).toContainElement(titleLink);
+    expect(titleLink).toHaveClass("tw-z-20");
     expect(getWaveRow()).toHaveClass("tw-cursor-pointer");
+    const rowOverlayLink = getWaveRow().querySelector(
+      'a[aria-hidden="true"]'
+    );
+    expect(rowOverlayLink).not.toBeNull();
+    expect(rowOverlayLink).toHaveAttribute("tabindex", "-1");
+    expect(rowOverlayLink).toHaveClass("tw-absolute");
+    expect(rowOverlayLink).toHaveClass("tw-inset-0");
+    expect(rowOverlayLink).toHaveClass("tw-z-10");
     const avatar = screen.getByTestId("sidebar-wave-avatar");
     expect(avatar).toHaveAttribute("aria-hidden", "true");
     expect(avatar.closest("a")).toBeNull();
     expect(screen.getAllByRole("link")).toHaveLength(1);
-    expect(rowLink).toHaveClass("focus-visible:tw-outline");
+    expect(titleLink).toHaveClass("focus-visible:tw-outline");
 
     await user.click(expandButton);
 

--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
@@ -44,8 +44,23 @@ jest.mock(
 );
 jest.mock(
   "@/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin",
-  () => (props: any) => <div data-testid="pin">{String(props.isPinned)}</div>
+  () => (props: any) => (
+    <button
+      type="button"
+      data-testid="pin"
+      className={props.className}
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        mockPinClick();
+      }}
+    >
+      {String(props.isPinned)}
+    </button>
+  )
 );
+
+const mockPinClick = jest.fn();
 
 const mockedPrefetch = usePrefetchWaveData as jest.Mock;
 const mockedUseMyStream = useMyStream as jest.Mock;
@@ -86,6 +101,7 @@ describe("BrainLeftSidebarWave", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockPinClick.mockClear();
     mockedPrefetch.mockReturnValue(prefetch);
     activeWaveId = null;
     mockedUseMyStream.mockImplementation(() => ({
@@ -209,6 +225,27 @@ describe("BrainLeftSidebarWave", () => {
     };
     render(<BrainLeftSidebarWave wave={wave} onHover={onHover} showPin />);
     expect(screen.getByTestId("pin")).toHaveTextContent("true");
+  });
+
+  it("keeps pin clicks independent from row navigation", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <BrainLeftSidebarWave
+        wave={{ ...baseWave, id: "pin-test", isPinned: true }}
+        onHover={onHover}
+        showPin
+      />
+    );
+
+    const pin = screen.getByTestId("pin");
+
+    expect(pin).toHaveClass("tw-z-20");
+
+    await user.click(pin);
+
+    expect(mockPinClick).toHaveBeenCalledTimes(1);
+    expect(setActiveWave).not.toHaveBeenCalled();
   });
 
   it("uses normal row padding when a wave has no subwaves", () => {
@@ -373,8 +410,12 @@ describe("BrainLeftSidebarWave", () => {
 
     expect(metadataRow?.children[0]).toBe(timestampWrapper);
     expect(metadataRow?.children[1]).toBe(score);
+    expect(metadataRow).toHaveClass("tw-pointer-events-none");
+    expect(metadataRow).toHaveClass("tw-relative");
+    expect(metadataRow).toHaveClass("tw-z-20");
     expect(timestampWrapper).not.toHaveClass("tw-ml-auto");
     expect(score).toHaveClass("tw-ml-auto");
+    expect(score).toHaveClass("tw-pointer-events-auto");
   });
 
   it("cancels subwave prefetch when hover intent ends early", () => {

--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
@@ -260,19 +260,16 @@ describe("BrainLeftSidebarWave", () => {
     expect(getWaveRow()).toHaveClass("tw-px-5");
     expect(getWaveRow()).toHaveClass("tw-gap-x-4");
     expect(getWaveRow()).not.toHaveClass("tw-pl-2");
-    const titleLink = screen.getByRole("link", { name: "Chat Wave" });
-    expect(titleLink.nextElementSibling).toBe(expandButton);
-    expect(expandButton.parentElement).toContainElement(titleLink);
+    const rowLink = screen.getByRole("link", { name: "Chat Wave" });
+    expect(rowLink).toHaveClass("tw-absolute");
+    expect(rowLink).toHaveClass("tw-inset-0");
+    expect(rowLink).toHaveClass("tw-z-10");
+    expect(getWaveRow()).toHaveClass("tw-cursor-pointer");
     const avatar = screen.getByTestId("sidebar-wave-avatar");
     expect(avatar).toHaveAttribute("aria-hidden", "true");
     expect(avatar.closest("a")).toBeNull();
     expect(screen.getAllByRole("link")).toHaveLength(1);
-    expect(
-      screen.getByRole("link", { name: "Chat Wave" }).closest(".tw-pr-7")
-    ).not.toBeNull();
-    expect(screen.getByRole("link", { name: "Chat Wave" })).toHaveClass(
-      "focus-visible:tw-outline"
-    );
+    expect(rowLink).toHaveClass("focus-visible:tw-outline");
 
     await user.click(expandButton);
 

--- a/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
@@ -130,21 +130,47 @@ describe("ExpandedWave", () => {
     expect(getWaveRow()).toHaveClass("tw-px-5");
     expect(getWaveRow()).toHaveClass("tw-gap-x-4");
     expect(getWaveRow()).not.toHaveClass("tw-pl-2");
-    const rowLink = screen.getByRole("link", { name: "Chat Wave" });
-    expect(rowLink).toHaveClass("tw-absolute");
-    expect(rowLink).toHaveClass("tw-inset-0");
-    expect(rowLink).toHaveClass("tw-z-10");
+    const titleLink = screen.getByRole("link", { name: "Chat Wave" });
+    expect(titleLink.nextElementSibling).toBe(expandButton);
+    expect(expandButton.parentElement).toContainElement(titleLink);
+    expect(titleLink).toHaveClass("tw-z-20");
     expect(getWaveRow()).toHaveClass("tw-cursor-pointer");
+    const rowOverlayLink = getWaveRow().querySelector(
+      'a[aria-hidden="true"]'
+    );
+    expect(rowOverlayLink).not.toBeNull();
+    expect(rowOverlayLink).toHaveAttribute("tabindex", "-1");
+    expect(rowOverlayLink).toHaveClass("tw-absolute");
+    expect(rowOverlayLink).toHaveClass("tw-inset-0");
+    expect(rowOverlayLink).toHaveClass("tw-z-10");
     const avatar = screen.getByTestId("sidebar-wave-avatar");
     expect(avatar).toHaveAttribute("aria-hidden", "true");
     expect(avatar.closest("a")).toBeNull();
     expect(screen.getAllByRole("link")).toHaveLength(1);
-    expect(rowLink).toHaveClass("focus-visible:tw-outline");
+    expect(titleLink).toHaveClass("focus-visible:tw-outline");
 
     await user.click(expandButton);
 
     expect(onToggleExpand).toHaveBeenCalledWith("1");
     expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("anchors the expanded tooltip to the visible title link", () => {
+    renderExpandedWave({
+      showExpandedTooltip: true,
+      tooltipContent: "Chat Wave",
+      tooltipId: "wave-expanded-1",
+    });
+
+    const titleLink = screen.getByRole("link", { name: "Chat Wave" });
+    const rowOverlayLink = getWaveRow().querySelector(
+      'a[aria-hidden="true"]'
+    );
+
+    expect(titleLink).toHaveAttribute("data-tooltip-id", "wave-expanded-1");
+    expect(titleLink).toHaveAttribute("data-tooltip-content", "Chat Wave");
+    expect(rowOverlayLink).not.toHaveAttribute("data-tooltip-id");
+    expect(rowOverlayLink).not.toHaveAttribute("data-tooltip-content");
   });
 
   it("does not render a nested expand button for child rows", () => {

--- a/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
@@ -36,8 +36,23 @@ jest.mock(
 );
 jest.mock(
   "@/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin",
-  () => (props: any) => <div data-testid="pin">{String(props.isPinned)}</div>
+  () => (props: any) => (
+    <button
+      type="button"
+      data-testid="pin"
+      className={props.className}
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        mockPinClick();
+      }}
+    >
+      {String(props.isPinned)}
+    </button>
+  )
 );
+
+const mockPinClick = jest.fn();
 
 const baseWave = createMockMinimalWave({
   id: "1",
@@ -85,6 +100,10 @@ const renderExpandedWave = (
 };
 
 describe("ExpandedWave", () => {
+  beforeEach(() => {
+    mockPinClick.mockClear();
+  });
+
   it("uses normal row padding when a wave has no subwaves", () => {
     renderExpandedWave({
       showPin: true,
@@ -173,6 +192,23 @@ describe("ExpandedWave", () => {
     expect(rowOverlayLink).not.toHaveAttribute("data-tooltip-content");
   });
 
+  it("keeps pin clicks independent from row navigation", async () => {
+    const user = userEvent.setup();
+    const { onClick } = renderExpandedWave({
+      isPinned: true,
+      showPin: true,
+    });
+
+    const pin = screen.getByTestId("pin");
+
+    expect(pin).toHaveClass("tw-z-20");
+
+    await user.click(pin);
+
+    expect(mockPinClick).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
   it("does not render a nested expand button for child rows", () => {
     renderExpandedWave({
       depth: 1,
@@ -230,8 +266,12 @@ describe("ExpandedWave", () => {
 
     expect(metadataRow?.children[0]).toBe(timestampWrapper);
     expect(metadataRow?.children[1]).toBe(score);
+    expect(metadataRow).toHaveClass("tw-pointer-events-none");
+    expect(metadataRow).toHaveClass("tw-relative");
+    expect(metadataRow).toHaveClass("tw-z-20");
     expect(timestampWrapper).not.toHaveClass("tw-ml-auto");
     expect(score).toHaveClass("tw-ml-auto");
+    expect(score).toHaveClass("tw-pointer-events-auto");
   });
 
   it("overlaps non-final child rails to avoid visible line gaps", () => {

--- a/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
@@ -130,19 +130,16 @@ describe("ExpandedWave", () => {
     expect(getWaveRow()).toHaveClass("tw-px-5");
     expect(getWaveRow()).toHaveClass("tw-gap-x-4");
     expect(getWaveRow()).not.toHaveClass("tw-pl-2");
-    const titleLink = screen.getByRole("link", { name: "Chat Wave" });
-    expect(titleLink.nextElementSibling).toBe(expandButton);
-    expect(expandButton.parentElement).toContainElement(titleLink);
+    const rowLink = screen.getByRole("link", { name: "Chat Wave" });
+    expect(rowLink).toHaveClass("tw-absolute");
+    expect(rowLink).toHaveClass("tw-inset-0");
+    expect(rowLink).toHaveClass("tw-z-10");
+    expect(getWaveRow()).toHaveClass("tw-cursor-pointer");
     const avatar = screen.getByTestId("sidebar-wave-avatar");
     expect(avatar).toHaveAttribute("aria-hidden", "true");
     expect(avatar.closest("a")).toBeNull();
     expect(screen.getAllByRole("link")).toHaveLength(1);
-    expect(
-      screen.getByRole("link", { name: "Chat Wave" }).closest(".tw-pr-7")
-    ).not.toBeNull();
-    expect(screen.getByRole("link", { name: "Chat Wave" })).toHaveClass(
-      "focus-visible:tw-outline"
-    );
+    expect(rowLink).toHaveClass("focus-visible:tw-outline");
 
     await user.click(expandButton);
 

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
@@ -366,7 +366,7 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
             />
           </div>
           {shouldShowTrustSignalsRow && (
-            <div className="tw-mt-0.5 tw-flex tw-min-w-0 tw-items-center tw-gap-2 tw-text-xs tw-text-iron-500">
+            <div className="tw-pointer-events-none tw-relative tw-z-20 tw-mt-0.5 tw-flex tw-min-w-0 tw-items-center tw-gap-2 tw-text-xs tw-text-iron-500">
               {latestDropTimestamp !== null && (
                 <span className="tw-flex tw-min-w-0 tw-items-center tw-whitespace-nowrap">
                   <BrainLeftSidebarWaveDropTime time={latestDropTimestamp} />
@@ -378,7 +378,7 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
                   waveScore={wave.waveScore}
                   variant="sidebar-inline"
                   mode="summary"
-                  className="tw-ml-auto tw-shrink-0"
+                  className="tw-pointer-events-auto tw-ml-auto tw-shrink-0"
                   tooltipId={trustSignalsTooltipId}
                 />
               )}

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
@@ -243,6 +243,7 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
   const dropBadgeClasses = isChildRow
     ? "tw-absolute tw-bottom-[-1px] tw-right-[-1px] tw-flex tw-size-3.5 tw-items-center tw-justify-center tw-rounded-full tw-bg-iron-950 tw-shadow-lg"
     : "tw-absolute tw-bottom-[-2px] tw-right-[-2px] tw-flex tw-size-3.5 tw-items-center tw-justify-center tw-rounded-full tw-bg-iron-950 tw-shadow-lg";
+  const rowLinkAriaLabel = formattedWaveName;
 
   return (
     <div
@@ -250,12 +251,21 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
         onMouseEnter: handleRowMouseEnter,
         onMouseLeave: cancelSubwavePrefetch,
       })}
-      className={`tw-group tw-relative tw-flex tw-items-start ${rowGapClasses} ${rowPaddingClasses} tw-py-2 tw-transition-all tw-duration-200 tw-ease-out ${
+      className={`tw-group tw-relative tw-flex tw-cursor-pointer tw-items-start ${rowGapClasses} ${rowPaddingClasses} tw-py-2 tw-transition-all tw-duration-200 tw-ease-out ${
         isActive
           ? "tw-bg-iron-700/50 desktop-hover:hover:tw-bg-iron-700/70"
           : "desktop-hover:hover:tw-bg-iron-800/80"
       }`}
     >
+      <Link
+        href={href}
+        prefetch={false}
+        onClick={handleWaveClick}
+        aria-label={rowLinkAriaLabel}
+        className="tw-absolute tw-inset-0 tw-z-10 tw-rounded-lg tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-[-2px] focus-visible:tw-outline-primary-400"
+      >
+        <span className="tw-sr-only">{rowLinkAriaLabel}</span>
+      </Link>
       {isChildRow && (
         <span
           aria-hidden="true"
@@ -330,20 +340,9 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
               shouldShowPinButton ? "tw-pr-7" : ""
             }`}
           >
-            <Link
-              href={href}
-              prefetch={false}
-              onClick={handleWaveClick}
-              className={`tw-min-w-0 tw-flex-shrink tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 ${
-                isActive
-                  ? "tw-text-white desktop-hover:group-hover:tw-text-white"
-                  : "tw-text-iron-400 desktop-hover:group-hover:tw-text-iron-300"
-              }`}
-            >
-              <span className="tw-block tw-truncate tw-text-sm tw-font-medium">
-                {formattedWaveName}
-              </span>
-            </Link>
+            <span className="tw-block tw-min-w-0 tw-flex-shrink tw-truncate tw-text-sm tw-font-medium">
+              {formattedWaveName}
+            </span>
             <SidebarWaveExpandControl
               formattedWaveName={formattedWaveName}
               isExpanded={isExpanded}
@@ -380,7 +379,7 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
           waveId={wave.id}
           isPinned={!!wave.isPinned}
           compact
-          className="tw-absolute tw-right-3 tw-top-3 tw-z-10"
+          className="tw-absolute tw-right-3 tw-top-3 tw-z-20"
         />
       )}
       {trustSignalsTooltipId !== undefined && hasSummaryScore && (

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
@@ -261,8 +261,9 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
         href={href}
         prefetch={false}
         onClick={handleWaveClick}
-        aria-label={rowLinkAriaLabel}
-        className="tw-absolute tw-inset-0 tw-z-10 tw-rounded-lg tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-[-2px] focus-visible:tw-outline-primary-400"
+        aria-hidden="true"
+        tabIndex={-1}
+        className="tw-absolute tw-inset-0 tw-z-10 tw-rounded-lg tw-no-underline"
       >
         <span className="tw-sr-only">{rowLinkAriaLabel}</span>
       </Link>
@@ -340,9 +341,20 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
               shouldShowPinButton ? "tw-pr-7" : ""
             }`}
           >
-            <span className="tw-block tw-min-w-0 tw-flex-shrink tw-truncate tw-text-sm tw-font-medium">
-              {formattedWaveName}
-            </span>
+            <Link
+              href={href}
+              prefetch={false}
+              onClick={handleWaveClick}
+              className={`tw-relative tw-z-20 tw-min-w-0 tw-flex-shrink tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 ${
+                isActive
+                  ? "tw-text-white desktop-hover:group-hover:tw-text-white"
+                  : "tw-text-iron-400 desktop-hover:group-hover:tw-text-iron-300"
+              }`}
+            >
+              <span className="tw-block tw-truncate tw-text-sm tw-font-medium">
+                {formattedWaveName}
+              </span>
+            </Link>
             <SidebarWaveExpandControl
               formattedWaveName={formattedWaveName}
               isExpanded={isExpanded}

--- a/components/brain/left-sidebar/waves/SidebarWaveExpandControl.tsx
+++ b/components/brain/left-sidebar/waves/SidebarWaveExpandControl.tsx
@@ -52,7 +52,7 @@ export function SidebarWaveExpandControl({
       onClick={onClick}
       onFocus={onFocus}
       onBlur={onBlur}
-      className={`tw-relative tw-inline-flex tw-size-5 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-p-0 tw-transition-all tw-duration-200 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:hover:tw-bg-iron-700/70 desktop-hover:hover:tw-text-iron-200 desktop-hover:hover:tw-opacity-100 ${buttonStateClasses}`}
+      className={`tw-relative tw-z-20 tw-inline-flex tw-size-5 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-p-0 tw-transition-all tw-duration-200 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 desktop-hover:hover:tw-bg-iron-700/70 desktop-hover:hover:tw-text-iron-200 desktop-hover:hover:tw-opacity-100 ${buttonStateClasses}`}
     >
       {isLoading ? (
         <ArrowPathIcon

--- a/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
+++ b/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
@@ -232,7 +232,7 @@ export const ExpandedWave = ({
             />
           </div>
           {shouldShowTrustSignalsRow && (
-            <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2 tw-text-xs tw-text-iron-500">
+            <div className="tw-pointer-events-none tw-relative tw-z-20 tw-flex tw-min-w-0 tw-items-center tw-gap-2 tw-text-xs tw-text-iron-500">
               {presentLatestDropTimestamp !== null && (
                 <span className="tw-flex tw-min-w-0 tw-items-center tw-whitespace-nowrap">
                   <BrainLeftSidebarWaveDropTime
@@ -246,7 +246,7 @@ export const ExpandedWave = ({
                   waveScore={wave.waveScore}
                   variant="sidebar-inline"
                   mode="summary"
-                  className="tw-ml-auto tw-shrink-0"
+                  className="tw-pointer-events-auto tw-ml-auto tw-shrink-0"
                   tooltipId={trustSignalsTooltipId}
                 />
               )}

--- a/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
+++ b/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
@@ -143,18 +143,29 @@ export const ExpandedWave = ({
     event.stopPropagation();
     onToggleExpand?.(waveId);
   };
+  const rowLinkAriaLabel = formattedWaveName;
 
   return (
     <div
       onMouseEnter={handleRowMouseEnter}
       onMouseLeave={cancelSubwavePrefetch}
       role="group"
-      className={`tw-group tw-relative tw-flex tw-items-start ${rowGapClasses} ${rowPaddingClasses} tw-py-2 tw-transition-all tw-duration-200 tw-ease-out ${
+      className={`tw-group tw-relative tw-flex tw-cursor-pointer tw-items-start ${rowGapClasses} ${rowPaddingClasses} tw-py-2 tw-transition-all tw-duration-200 tw-ease-out ${
         isActive
           ? "tw-bg-iron-700/60 desktop-hover:hover:tw-bg-iron-700/70"
           : "desktop-hover:hover:tw-bg-iron-800/80"
       }`}
     >
+      <Link
+        href={href}
+        prefetch={false}
+        onClick={onClick}
+        aria-label={rowLinkAriaLabel}
+        className="tw-absolute tw-inset-0 tw-z-10 tw-rounded-lg tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-[-2px] focus-visible:tw-outline-primary-400"
+        {...tooltipAttributes}
+      >
+        <span className="tw-sr-only">{rowLinkAriaLabel}</span>
+      </Link>
       {isChildRow && (
         <span
           aria-hidden="true"
@@ -194,22 +205,13 @@ export const ExpandedWave = ({
             className={`-tw-mt-1 tw-mb-1 tw-flex tw-min-w-0 tw-items-center tw-gap-1.5 ${
               shouldShowPinButton ? "tw-pr-7" : ""
             }`}
-            {...tooltipAttributes}
           >
-            <Link
-              href={href}
-              prefetch={false}
-              onClick={onClick}
-              className={`tw-min-w-0 tw-flex-shrink tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 ${
-                isActive
-                  ? "tw-text-white desktop-hover:group-hover:tw-text-white"
-                  : "tw-text-iron-400 desktop-hover:group-hover:tw-text-iron-300"
-              }`}
+            <div
+              ref={nameRef}
+              className="tw-min-w-0 tw-flex-shrink tw-truncate tw-text-sm"
             >
-              <div ref={nameRef} className="tw-truncate tw-text-sm">
-                {formattedWaveName}
-              </div>
-            </Link>
+              {formattedWaveName}
+            </div>
             <SidebarWaveExpandControl
               formattedWaveName={formattedWaveName}
               isExpanded={isExpanded}
@@ -248,7 +250,7 @@ export const ExpandedWave = ({
           waveId={waveId}
           isPinned={isPinned}
           compact
-          className="tw-absolute tw-right-3 tw-top-2 tw-z-10"
+          className="tw-absolute tw-right-3 tw-top-2 tw-z-20"
         />
       )}
       {showExpandedTooltip && (

--- a/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
+++ b/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
@@ -160,9 +160,9 @@ export const ExpandedWave = ({
         href={href}
         prefetch={false}
         onClick={onClick}
-        aria-label={rowLinkAriaLabel}
-        className="tw-absolute tw-inset-0 tw-z-10 tw-rounded-lg tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-[-2px] focus-visible:tw-outline-primary-400"
-        {...tooltipAttributes}
+        aria-hidden="true"
+        tabIndex={-1}
+        className="tw-absolute tw-inset-0 tw-z-10 tw-rounded-lg tw-no-underline"
       >
         <span className="tw-sr-only">{rowLinkAriaLabel}</span>
       </Link>
@@ -206,12 +206,21 @@ export const ExpandedWave = ({
               shouldShowPinButton ? "tw-pr-7" : ""
             }`}
           >
-            <div
-              ref={nameRef}
-              className="tw-min-w-0 tw-flex-shrink tw-truncate tw-text-sm"
+            <Link
+              href={href}
+              prefetch={false}
+              onClick={onClick}
+              className={`tw-relative tw-z-20 tw-min-w-0 tw-flex-shrink tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 ${
+                isActive
+                  ? "tw-text-white desktop-hover:group-hover:tw-text-white"
+                  : "tw-text-iron-400 desktop-hover:group-hover:tw-text-iron-300"
+              }`}
+              {...tooltipAttributes}
             >
-              {formattedWaveName}
-            </div>
+              <div ref={nameRef} className="tw-truncate tw-text-sm">
+                {formattedWaveName}
+              </div>
+            </Link>
             <SidebarWaveExpandControl
               formattedWaveName={formattedWaveName}
               isExpanded={isExpanded}


### PR DESCRIPTION
## Issue
- Wave rows on `/waves` visually read as full-row click targets, but only the wave title link opened the wave.
- Empty space inside normal, pinned, highly rated, following/all, and nested subwave rows did not navigate.

## Fix
- Keeps the visible wave title as the accessible/focusable `next/link`.
- Adds a sibling row overlay link, hidden from the accessibility tree and tab order, so pointer clicks on row whitespace navigate to the same href.
- Keeps expand/collapse and pin/unpin controls as sibling buttons above the overlay to preserve their independent behavior and avoid nested interactive markup.

## Changes
- Updated the app sidebar wave row and the web expanded sidebar wave row to make row whitespace clickable while preserving title-link behavior.
- Raised expand and pin controls above the row overlay so control clicks do not navigate.
- Updated focused component tests to assert the row overlay, title-link preservation, expand-control exclusion, and expanded tooltip trigger placement.

## Validation
- `./bin/6529 run test -- __tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx __tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed` (detached worktree did not detect changed TS files)
- `./bin/6529 run lint:single -- components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx components/brain/left-sidebar/waves/SidebarWaveExpandControl.tsx components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx __tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx __tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx`
- `./bin/6529 run typecheck:ci`
- `./bin/6529 run react-doctor:diff` (99/100, one existing component-size warning)

## Risk
- Level: Low
- Why: Scoped to sidebar row link structure and z-index ordering for existing controls; no data, auth, API, or persistence behavior changes.
- Rollback: Revert the PR commits to restore title-only row navigation.

## Review Notes
- Please focus on row overlay/title link semantics and whether expand/pin controls remain independently clickable in both top-level and nested rows.