### PR TITLE
Enable WCAG reviewbot checks for frontend PRs

### DIFF
--- a/.github/6529bot.yml
+++ b/.github/6529bot.yml
@@ -3,7 +3,7 @@ enabled: true
 
 reviewKinds:
   allowed: [general, followup, wcag, i18n, security, responsiveness]
-  initial: [general, i18n, security, responsiveness]
+  initial: [general, wcag, i18n, security, responsiveness]
   followup: [followup]
 
 commands:
@@ -14,7 +14,7 @@ lanes:
     model: claude-opus-4-8
 
 limits:
-  maxJobsPerDelivery: 4
+  maxJobsPerDelivery: 5
 
 admission:
   publicRepoMode: trusted


### PR DESCRIPTION
## Summary
- Add `wcag` to initial 6529bot review kinds for frontend PRs.
- Raise `maxJobsPerDelivery` from 4 to 5 so general, WCAG, i18n, security, and responsiveness can all run on initial PR events.

## Dependency
- Requires merged 6529reviewbot PR #399 (`db1fced6`) so WCAG/i18n reviews use strengthened frontend policy context and deterministic review leads.

## Verification
- `node D:\repos\6529reviewbot-i18n-wcag\bin\validate-repository-config.cjs D:\repos\6529seize-frontend-i18n-wcag-bot-config\.github\6529bot.yml`