### PR TITLE
[codex] Add repo labels to GitHub preview badges

### DIFF
--- a/__tests__/components/waves/GithubPreviewStatusBadge.test.tsx
+++ b/__tests__/components/waves/GithubPreviewStatusBadge.test.tsx
@@ -103,7 +103,36 @@ describe("GithubPreviewStatusBadge", () => {
     expect(screen.getByTestId("github-preview-status-badge")).toHaveTextContent(
       "Merged"
     );
+    expect(screen.getByTestId("github-preview-repo-label")).toHaveTextContent(
+      "Frontend"
+    );
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("renders a known 6529 repository label for easier scanning", () => {
+    render(
+      <GithubPreviewStatusBadge
+        href="https://github.com/6529-Collections/6529seize-backend/issues/1661"
+        initialPreview={{
+          type: "github.issue",
+          owner: "6529-Collections",
+          repo: "6529seize-backend",
+          number: 1661,
+          title: "Backend issue",
+          state: "closed_completed",
+          assignees: [],
+          url: "https://github.com/6529-Collections/6529seize-backend/issues/1661",
+        }}
+      />
+    );
+
+    expect(screen.getByTestId("github-preview-repo-label")).toHaveTextContent(
+      "Backend"
+    );
+    expect(screen.getByTestId("github-preview-status-badge")).toHaveAttribute(
+      "aria-label",
+      "6529-Collections/6529seize-backend: Completed · Unassigned"
+    );
   });
 
   it("renders issue completion state after the GitHub metadata request resolves", async () => {
@@ -128,7 +157,7 @@ describe("GithubPreviewStatusBadge", () => {
     await waitFor(() => {
       expect(screen.getByTestId("github-preview-status-badge")).toHaveAttribute(
         "aria-label",
-        "Completed · @alice"
+        "6529-Collections/6529seize-frontend: Completed · @alice"
       );
     });
     expect(
@@ -161,7 +190,7 @@ describe("GithubPreviewStatusBadge", () => {
 
     expect(screen.getByTestId("github-preview-status-badge")).toHaveAttribute(
       "aria-label",
-      "Open · Unassigned"
+      "6529-Collections/6529seize-frontend: Open · Unassigned"
     );
     expect(
       screen.getByTestId("github-preview-assignee-label")
@@ -194,7 +223,7 @@ describe("GithubPreviewStatusBadge", () => {
     ).toHaveTextContent("@alice, @bob");
     expect(screen.getByTestId("github-preview-status-badge")).toHaveAttribute(
       "aria-label",
-      "Open · @alice, @bob"
+      "6529-Collections/6529seize-frontend: Open · @alice, @bob"
     );
   });
 
@@ -431,7 +460,7 @@ describe("GithubPreviewStatusBadge", () => {
     });
     expect(screen.getByTestId("github-preview-status-badge")).toHaveAttribute(
       "aria-label",
-      "Status unavailable"
+      "6529-Collections/6529seize-frontend: Status unavailable"
     );
     expect(
       screen.getByTestId("github-preview-status-badge")

--- a/components/waves/GithubPreviewStatusBadge.tsx
+++ b/components/waves/GithubPreviewStatusBadge.tsx
@@ -27,7 +27,19 @@ interface BadgeViewModel {
 
 interface GithubPreviewUrlInfo {
   readonly url: URL;
+  readonly owner: string;
+  readonly repo: string;
   readonly kind: "issue" | "pull";
+}
+
+interface GithubRepositoryLabel {
+  readonly label: string;
+  readonly ariaLabel: string;
+}
+
+interface KnownGithubRepositoryLabel {
+  readonly label: string;
+  readonly compactLabel: string;
 }
 
 const parseGithubPreviewUrl = (href: string): URL | null => {
@@ -57,16 +69,55 @@ const parseGithubPreviewUrlInfo = (
     return null;
   }
 
-  const [, , kind] = url.pathname.split("/").filter(Boolean);
+  const [owner, repo, kind] = url.pathname.split("/").filter(Boolean);
+  if (!owner || !repo) {
+    return null;
+  }
+
   if (kind === "pull") {
-    return { url, kind: "pull" };
+    return { url, owner, repo, kind: "pull" };
   }
 
   if (kind === "issues") {
-    return { url, kind: "issue" };
+    return { url, owner, repo, kind: "issue" };
   }
 
   return null;
+};
+
+const KNOWN_6529_REPOSITORY_LABELS: Record<
+  string,
+  KnownGithubRepositoryLabel
+> = {
+  "6529seize-frontend": { label: "Frontend", compactLabel: "FE" },
+  "6529seize-backend": { label: "Backend", compactLabel: "BE" },
+  "6529stream": { label: "Stream", compactLabel: "Stream" },
+  "6529-safe-app": { label: "Safe App", compactLabel: "Safe" },
+  "6529reviewbot": { label: "Review Bot", compactLabel: "Bot" },
+};
+
+const getGithubRepositoryLabel = (
+  githubInfo: GithubPreviewUrlInfo,
+  compact: boolean
+): GithubRepositoryLabel | null => {
+  if (githubInfo.owner.toLowerCase() !== "6529-collections") {
+    return null;
+  }
+
+  const repoKey = githubInfo.repo.toLowerCase();
+  const knownLabel = KNOWN_6529_REPOSITORY_LABELS[repoKey];
+  const ariaLabel = `6529-Collections/${githubInfo.repo}`;
+  if (knownLabel) {
+    return {
+      label: compact ? knownLabel.compactLabel : knownLabel.label,
+      ariaLabel,
+    };
+  }
+
+  return {
+    label: githubInfo.repo,
+    ariaLabel,
+  };
 };
 
 const getBadgeViewModel = (
@@ -356,11 +407,15 @@ export default function GithubPreviewStatusBadge({
   const detail = compact ? undefined : viewModel.detail;
   const issueAssigneeLabels =
     status.type === "success" ? getIssueAssigneeLabels(status.preview) : null;
-  const title = getBadgeTitle(
+  const statusTitle = getBadgeTitle(
     status,
     viewModel,
     issueAssigneeLabels?.desktop ?? detail
   );
+  const repoLabel = getGithubRepositoryLabel(githubInfo, compact);
+  const title = repoLabel
+    ? `${repoLabel.ariaLabel}: ${statusTitle}`
+    : statusTitle;
   const placementClasses =
     placement === "absolute"
       ? "tw-absolute tw-right-2 tw-top-2 tw-z-20 tw-max-w-[calc(100%-1rem)]"
@@ -368,10 +423,19 @@ export default function GithubPreviewStatusBadge({
   const badge = (
     <span
       ref={badgeRef}
-      className={`tw-pointer-events-auto tw-inline-flex tw-items-center tw-gap-1.5 tw-rounded-full tw-border tw-border-solid tw-px-2.5 tw-py-1 tw-text-[11px] tw-font-semibold tw-leading-none tw-shadow-lg tw-backdrop-blur-md ${placementClasses} ${TONE_CLASSES[viewModel.tone]}`}
+      className={`tw-pointer-events-auto tw-inline-flex tw-min-w-0 tw-items-center tw-gap-1.5 tw-rounded-full tw-border tw-border-solid tw-px-2.5 tw-py-1 tw-text-[11px] tw-font-semibold tw-leading-none tw-shadow-lg tw-backdrop-blur-md ${placementClasses} ${TONE_CLASSES[viewModel.tone]}`}
       data-testid="github-preview-status-badge"
       aria-label={title}
     >
+      {repoLabel && (
+        <span
+          className="tw-inline-flex tw-max-w-28 tw-shrink-0 tw-items-center tw-rounded-full tw-border tw-border-solid tw-border-cyan-300/35 tw-bg-cyan-950/80 tw-px-1.5 tw-py-0.5 tw-text-[10px] tw-font-bold tw-uppercase tw-leading-none tw-text-cyan-100"
+          data-testid="github-preview-repo-label"
+          title={repoLabel.ariaLabel}
+        >
+          <span className="tw-truncate">{repoLabel.label}</span>
+        </span>
+      )}
       {viewModel.loading && (
         <span className="tw-h-2 tw-w-2 tw-animate-spin tw-rounded-full tw-border tw-border-solid tw-border-current tw-border-r-transparent" />
       )}
@@ -382,7 +446,9 @@ export default function GithubPreviewStatusBadge({
           strokeWidth={2}
         />
       ) : (
-        <span className="tw-line-clamp-1 tw-capitalize">{viewModel.label}</span>
+        <span className="tw-line-clamp-1 tw-min-w-0 tw-capitalize">
+          {viewModel.label}
+        </span>
       )}
       {detail && (
         <span className="tw-hidden tw-font-medium tw-normal-case tw-opacity-70 sm:tw-inline">


### PR DESCRIPTION
## What changed
- Adds a compact repository chip to 6529 GitHub issue/PR preview status badges.
- Maps known 6529 repos to short scan labels such as Frontend, Backend, Stream, Safe App, and Review Bot.
- Includes the full `6529-Collections/<repo>` value in the badge accessible label.

## Why
When several 6529 repositories are active at once, GitHub cards are easier to scan if the repo identity is visible near the existing status and assignment state.

## Validation
- `seize run test:no-coverage -- __tests__/components/waves/GithubPreviewStatusBadge.test.tsx`
- `seize exec eslint --no-warn-ignored --max-warnings=0 components/waves/GithubPreviewStatusBadge.tsx __tests__/components/waves/GithubPreviewStatusBadge.test.tsx`
- `seize run typecheck:changed`
- `codex-diff-check -- components/waves/GithubPreviewStatusBadge.tsx __tests__/components/waves/GithubPreviewStatusBadge.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub preview status badges now display repository labels for known repositories
  * Repository context added to accessibility labels for improved screen reader support
  * Inline repository label chips render alongside status information for better context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->