### PR TITLE
Render boosted markdown images as media

### DIFF
--- a/__tests__/components/home/boosted/BoostedDropCardHome.test.tsx
+++ b/__tests__/components/home/boosted/BoostedDropCardHome.test.tsx
@@ -481,6 +481,34 @@ describe("BoostedDropCardHome", () => {
     expect(screen.queryByText("!Seize")).not.toBeInTheDocument();
   });
 
+  it("derives standalone markdown image mime type from the URL", () => {
+    const imageUrl = "https://example.com/art.png";
+
+    renderWithAuth(
+      <BoostedDropCardHome
+        drop={createDrop({
+          parts: [
+            {
+              content: `![Art](${imageUrl})`,
+              media: [],
+            },
+          ],
+        })}
+        onClick={jest.fn()}
+        variant="chat"
+        rank={1}
+      />
+    );
+
+    expect(mockDropListItemContentMedia).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        media_mime_type: "image/png",
+        media_url: imageUrl,
+      })
+    );
+    expect(mockBoostedDropLinkPreview).not.toHaveBeenCalled();
+  });
+
   it("does not render supplemental chat content after the lead media", () => {
     renderWithAuth(
       <BoostedDropCardHome

--- a/__tests__/components/home/boosted/BoostedDropCardHome.test.tsx
+++ b/__tests__/components/home/boosted/BoostedDropCardHome.test.tsx
@@ -9,6 +9,7 @@ import {
 
 const mockToggleBoost = jest.fn();
 const mockBoostedDropLinkPreview = jest.fn();
+const mockDropListItemContentMedia = jest.fn();
 type ResizeObserverHarness = {
   restore: () => void;
   trigger: () => void;
@@ -43,7 +44,13 @@ jest.mock(
   "@/components/drops/view/item/content/media/DropListItemContentMedia",
   () => ({
     __esModule: true,
-    default: () => <div data-testid="drop-media" />,
+    default: (props: {
+      readonly media_mime_type: string;
+      readonly media_url: string;
+    }) => {
+      mockDropListItemContentMedia(props);
+      return <div data-testid="drop-media" />;
+    },
   })
 );
 
@@ -195,6 +202,7 @@ const getBoostPill = (): HTMLElement => {
 describe("BoostedDropCardHome", () => {
   beforeEach(() => {
     mockBoostedDropLinkPreview.mockClear();
+    mockDropListItemContentMedia.mockClear();
     mockToggleBoost.mockReset();
   });
 
@@ -439,6 +447,38 @@ describe("BoostedDropCardHome", () => {
 
     expect(screen.getAllByTestId("drop-media")).toHaveLength(1);
     expect(screen.queryByTestId("content-display")).not.toBeInTheDocument();
+  });
+
+  it("renders standalone markdown images as boosted media instead of link previews", () => {
+    const imageUrl =
+      "https://img.transient.xyz/?n=-1&output=webp&url=https%3A%2F%2Fipfs.transientusercontent.xyz%2Fipfs%2FQmVsjJs2AfMZkdudRx1bUypA1pr5cDBcp8Y8qshdw74Civ%2Fnft.jpg&w=3072&we=";
+
+    renderWithAuth(
+      <BoostedDropCardHome
+        drop={createDrop({
+          parts: [
+            {
+              content: `![Seize](${imageUrl})`,
+              media: [],
+            },
+          ],
+        })}
+        onClick={jest.fn()}
+        variant="chat"
+        rank={1}
+      />
+    );
+
+    expect(screen.getByTestId("drop-media")).toBeInTheDocument();
+    expect(mockDropListItemContentMedia).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        media_mime_type: "image/webp",
+        media_url: imageUrl,
+      })
+    );
+    expect(mockBoostedDropLinkPreview).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("link-preview")).not.toBeInTheDocument();
+    expect(screen.queryByText("!Seize")).not.toBeInTheDocument();
   });
 
   it("does not render supplemental chat content after the lead media", () => {

--- a/__tests__/components/home/boosted/extractStandaloneUrl.test.ts
+++ b/__tests__/components/home/boosted/extractStandaloneUrl.test.ts
@@ -1,0 +1,11 @@
+import { removePreviewUrlFromContent } from "@/components/home/boosted/extractStandaloneUrl";
+
+describe("removePreviewUrlFromContent", () => {
+  it("keeps markdown image URLs intact when the preview URL matches", () => {
+    const imageUrl =
+      "https://img.transient.xyz/?n=-1&output=webp&url=https%3A%2F%2Fipfs.transientusercontent.xyz%2Fipfs%2FQmVsjJs2AfMZkdudRx1bUypA1pr5cDBcp8Y8qshdw74Civ%2Fnft.jpg&w=3072&we=";
+    const content = `![Seize](${imageUrl})`;
+
+    expect(removePreviewUrlFromContent(content, imageUrl)).toBe(content);
+  });
+});

--- a/components/home/boosted/BoostedDropCardHomeContent.tsx
+++ b/components/home/boosted/BoostedDropCardHomeContent.tsx
@@ -17,11 +17,15 @@ import {
 import BoostedDropLinkPreview from "./BoostedDropLinkPreview";
 import {
   extractFirstUrl,
+  extractStandaloneMarkdownImage,
   removePreviewUrlFromContent,
 } from "./extractStandaloneUrl";
 
 type BoostedDropPart = ApiDrop["parts"][number];
-type BoostedDropMediaItem = BoostedDropPart["media"][number];
+type BoostedDropMediaItem = Pick<
+  BoostedDropPart["media"][number],
+  "mime_type" | "url"
+>;
 type OverflowElements = {
   readonly container: HTMLDivElement;
   readonly preview: HTMLDivElement;
@@ -489,7 +493,17 @@ BoostedDropCardTextSection.displayName = "BoostedDropCardTextSection";
 
 const BoostedDropCardHomeContent = memo(
   ({ part, isChatVariant }: BoostedDropCardHomeContentProps) => {
-    const media = part?.media[0];
+    const standaloneMarkdownImage = extractStandaloneMarkdownImage(
+      part?.content
+    );
+    const media =
+      part?.media[0] ??
+      (standaloneMarkdownImage
+        ? {
+            mime_type: "image/webp",
+            url: standaloneMarkdownImage.url,
+          }
+        : undefined);
 
     if (!media) {
       return (

--- a/components/home/boosted/BoostedDropCardHomeContent.tsx
+++ b/components/home/boosted/BoostedDropCardHomeContent.tsx
@@ -43,6 +43,55 @@ const HOME_PREVIEW_CONTAINER_CLASSES = `tw-relative tw-flex ${HOME_ASPECT_RATIO_
 const HOME_TEXT_CONTAINER_CLASSES = `tw-relative tw-flex ${HOME_ASPECT_RATIO_CLASSES} tw-w-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-xl tw-px-6 tw-pb-6 sm:tw-pb-0 tw-pt-4 sm:tw-pt-16 md:tw-pt-12`;
 const CHAT_PREVIEW_WRAPPER_BASE_CLASSES =
   "tw-pointer-events-none tw-relative tw-z-30 tw-grid tw-h-full tw-w-full tw-min-w-0 tw-max-w-full tw-grid-rows-[minmax(0,1fr)_auto] [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto [&_video]:tw-pointer-events-auto";
+const IMAGE_MIME_TYPES_BY_TOKEN: Readonly<Record<string, string>> = {
+  avif: "image/avif",
+  gif: "image/gif",
+  jpeg: "image/jpeg",
+  jpg: "image/jpeg",
+  png: "image/png",
+  svg: "image/svg+xml",
+  webp: "image/webp",
+};
+
+const getImageMimeTypeFromToken = (
+  token: string | null | undefined
+): string | null => {
+  if (!token) {
+    return null;
+  }
+
+  const normalizedToken = token.toLowerCase().replace(/^\./, "");
+  return IMAGE_MIME_TYPES_BY_TOKEN[normalizedToken] ?? null;
+};
+
+const getStandaloneMarkdownImageMimeType = (url: string): string => {
+  try {
+    const parsedUrl = new URL(url);
+    const outputMimeType = getImageMimeTypeFromToken(
+      parsedUrl.searchParams.get("output")
+    );
+
+    if (outputMimeType) {
+      return outputMimeType;
+    }
+
+    const extension = parsedUrl.pathname.split(".").pop();
+    const extensionMimeType = getImageMimeTypeFromToken(extension);
+
+    if (extensionMimeType) {
+      return extensionMimeType;
+    }
+  } catch {
+    const extension = url.split(/[?#]/)[0]?.split(".").pop();
+    const extensionMimeType = getImageMimeTypeFromToken(extension);
+
+    if (extensionMimeType) {
+      return extensionMimeType;
+    }
+  }
+
+  return "image/*";
+};
 const HOME_PREVIEW_WRAPPER_BASE_CLASSES =
   "tw-pointer-events-none tw-relative tw-z-30 tw-grid tw-h-full tw-w-full tw-min-w-0 tw-max-w-full tw-grid-rows-[minmax(0,1fr)_auto] [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto [&_video]:tw-pointer-events-auto";
 const CHAT_TEXT_WRAPPER_CLASSES =
@@ -493,17 +542,24 @@ BoostedDropCardTextSection.displayName = "BoostedDropCardTextSection";
 
 const BoostedDropCardHomeContent = memo(
   ({ part, isChatVariant }: BoostedDropCardHomeContentProps) => {
-    const standaloneMarkdownImage = extractStandaloneMarkdownImage(
-      part?.content
+    const standaloneMarkdownImage = useMemo(
+      () => extractStandaloneMarkdownImage(part?.content),
+      [part?.content]
     );
-    const media =
-      part?.media[0] ??
-      (standaloneMarkdownImage
-        ? {
-            mime_type: "image/webp",
-            url: standaloneMarkdownImage.url,
-          }
-        : undefined);
+    const attachedMedia = part?.media[0];
+    const media = useMemo(
+      () =>
+        attachedMedia ??
+        (standaloneMarkdownImage
+          ? {
+              mime_type: getStandaloneMarkdownImageMimeType(
+                standaloneMarkdownImage.url
+              ),
+              url: standaloneMarkdownImage.url,
+            }
+          : undefined),
+      [attachedMedia, standaloneMarkdownImage]
+    );
 
     if (!media) {
       return (

--- a/components/home/boosted/extractStandaloneUrl.ts
+++ b/components/home/boosted/extractStandaloneUrl.ts
@@ -1,6 +1,4 @@
 const URL_REGEX = /(https?:\/\/[^\s<]+[^\s<.,;:!?)\]"'])/g;
-const MARKDOWN_LINK_REGEX =
-  /(!?)\[([^\]\n]*)]\(\s*(<[^>\n]+>|[^\s)\n]+)(?:\s+(?:"[^"\n]*"|'[^'\n]*'|\([^)\n]*\)))?\s*\)/g;
 const resetGlobalRegex = (regex: RegExp): RegExp => {
   regex.lastIndex = 0;
   return regex;
@@ -50,30 +48,191 @@ type MarkdownImage = {
   readonly url: string;
 };
 
+type MarkdownDestination = {
+  readonly destination: string;
+  readonly end: number;
+  readonly index: number;
+};
+
+const isHorizontalWhitespace = (value: string | undefined): boolean =>
+  value === " " || value === "\t";
+
+const skipHorizontalWhitespace = (text: string, index: number): number => {
+  let cursor = index;
+
+  while (isHorizontalWhitespace(text[cursor])) {
+    cursor += 1;
+  }
+
+  return cursor;
+};
+
+const findMarkdownLabelEnd = (text: string, openIndex: number): number => {
+  for (let cursor = openIndex + 1; cursor < text.length; cursor += 1) {
+    const value = text[cursor];
+
+    if (value === "\n") {
+      return -1;
+    }
+
+    if (value === "]") {
+      return cursor;
+    }
+  }
+
+  return -1;
+};
+
+const readMarkdownTitleEnd = (
+  text: string,
+  titleStartIndex: number
+): number | null => {
+  let cursor = skipHorizontalWhitespace(text, titleStartIndex);
+  const opener = text[cursor];
+
+  if (opener === '"' || opener === "'") {
+    cursor += 1;
+
+    while (cursor < text.length) {
+      const value = text[cursor];
+
+      if (value === "\n") {
+        return null;
+      }
+
+      if (value === opener) {
+        cursor += 1;
+        cursor = skipHorizontalWhitespace(text, cursor);
+        return text[cursor] === ")" ? cursor + 1 : null;
+      }
+
+      cursor += 1;
+    }
+
+    return null;
+  }
+
+  if (opener === "(") {
+    cursor += 1;
+
+    while (cursor < text.length) {
+      const value = text[cursor];
+
+      if (value === "\n") {
+        return null;
+      }
+
+      if (value === ")") {
+        cursor += 1;
+        cursor = skipHorizontalWhitespace(text, cursor);
+        return text[cursor] === ")" ? cursor + 1 : null;
+      }
+
+      cursor += 1;
+    }
+  }
+
+  return null;
+};
+
+const readMarkdownDestination = (
+  text: string,
+  destinationStartIndex: number
+): MarkdownDestination | null => {
+  let cursor = skipHorizontalWhitespace(text, destinationStartIndex);
+  const destinationIndex = cursor;
+
+  if (cursor >= text.length || text[cursor] === ")" || text[cursor] === "\n") {
+    return null;
+  }
+
+  if (text[cursor] === "<") {
+    cursor += 1;
+
+    while (cursor < text.length && text[cursor] !== ">") {
+      if (text[cursor] === "\n") {
+        return null;
+      }
+      cursor += 1;
+    }
+
+    if (text[cursor] !== ">") {
+      return null;
+    }
+
+    cursor += 1;
+  } else {
+    while (cursor < text.length) {
+      const value = text[cursor];
+
+      if (value === ")" || value === "\n" || isHorizontalWhitespace(value)) {
+        break;
+      }
+
+      cursor += 1;
+    }
+  }
+
+  if (cursor === destinationIndex) {
+    return null;
+  }
+
+  const destination = text.slice(destinationIndex, cursor);
+  cursor = skipHorizontalWhitespace(text, cursor);
+
+  if (text[cursor] === ")") {
+    return {
+      destination,
+      end: cursor + 1,
+      index: destinationIndex,
+    };
+  }
+
+  const titleEnd = readMarkdownTitleEnd(text, cursor);
+  if (titleEnd === null) {
+    return null;
+  }
+
+  return {
+    destination,
+    end: titleEnd,
+    index: destinationIndex,
+  };
+};
+
 const collectMarkdownLinkCandidates = (
   text: string
 ): MarkdownLinkCandidate[] => {
   const candidates: MarkdownLinkCandidate[] = [];
-  const markdownLinkRegex = resetGlobalRegex(MARKDOWN_LINK_REGEX);
 
-  for (const match of text.matchAll(markdownLinkRegex)) {
-    const bang = match[1] ?? "";
-    const label = match[2] ?? "";
-    const url = match[3];
-    if (typeof url !== "string" || !url.trim()) {
+  for (let cursor = 0; cursor < text.length; cursor += 1) {
+    const isImage = text[cursor] === "!" && text[cursor + 1] === "[";
+    const labelOpenIndex = isImage ? cursor + 1 : cursor;
+
+    if (text[labelOpenIndex] !== "[") {
       continue;
     }
 
-    const baseIndex = match.index;
-    const urlOffset = match[0].indexOf(url);
+    const labelEndIndex = findMarkdownLabelEnd(text, labelOpenIndex);
+    if (labelEndIndex === -1 || text[labelEndIndex + 1] !== "(") {
+      continue;
+    }
+
+    const destination = readMarkdownDestination(text, labelEndIndex + 2);
+    if (!destination) {
+      continue;
+    }
+
     candidates.push({
-      end: baseIndex + match[0].length,
-      index: baseIndex + Math.max(urlOffset, 0),
-      isImage: bang === "!",
-      label,
-      start: baseIndex,
-      url,
+      end: destination.end,
+      index: destination.index,
+      isImage,
+      label: text.slice(labelOpenIndex + 1, labelEndIndex),
+      start: isImage ? cursor : labelOpenIndex,
+      url: destination.destination,
     });
+
+    cursor = destination.end - 1;
   }
 
   return candidates;
@@ -164,6 +323,10 @@ export const extractStandaloneMarkdownImage = (
   }
 
   const imageCandidate = imageCandidates[0];
+  if (!imageCandidate) {
+    return null;
+  }
+
   const remainder = `${trimmed.slice(0, imageCandidate.start)}${trimmed.slice(
     imageCandidate.end
   )}`;
@@ -203,30 +366,36 @@ export const removePreviewUrlFromContent = (
     return content;
   }
 
-  const markdownLinkRegex = resetGlobalRegex(MARKDOWN_LINK_REGEX);
-  let result = content.replace(
-    markdownLinkRegex,
-    (
-      match,
-      bang: string | undefined,
-      label: string | undefined,
-      url: string | undefined
-    ) => {
-      if (bang === "!") {
-        return match;
-      }
+  const markdownCandidates = collectMarkdownLinkCandidates(content);
+  let result = content;
 
-      const normalized =
-        typeof url === "string" ? normalizeUrlCandidate(url) : null;
-      if (normalized && normalized === normalizedTarget) {
-        return label ?? "";
-      }
-      return match;
+  if (markdownCandidates.length > 0) {
+    let cursor = 0;
+    result = "";
+
+    for (const candidate of markdownCandidates) {
+      result += content.slice(cursor, candidate.start);
+
+      const match = content.slice(candidate.start, candidate.end);
+      const normalized = normalizeUrlCandidate(candidate.url);
+      result +=
+        !candidate.isImage && normalized === normalizedTarget
+          ? candidate.label
+          : match;
+
+      cursor = candidate.end;
     }
-  );
+
+    result += content.slice(cursor);
+  }
 
   const urlRegex = resetGlobalRegex(URL_REGEX);
-  result = result.replace(urlRegex, (match) => {
+  const remainingMarkdownCandidates = collectMarkdownLinkCandidates(result);
+  result = result.replace(urlRegex, (match, _url: string, offset: number) => {
+    if (isIndexInsideMarkdownCandidate(offset, remainingMarkdownCandidates)) {
+      return match;
+    }
+
     const normalized = normalizeUrlCandidate(match);
     return normalized && normalized === normalizedTarget ? "" : match;
   });

--- a/components/home/boosted/extractStandaloneUrl.ts
+++ b/components/home/boosted/extractStandaloneUrl.ts
@@ -1,12 +1,23 @@
 const URL_REGEX = /(https?:\/\/[^\s<]+[^\s<.,;:!?)\]"'])/g;
-const MARKDOWN_LINK_REGEX = /\[([^\]]*)\]\(\s*(https?:\/\/[^\s)]+)\s*\)/g;
+const MARKDOWN_LINK_REGEX =
+  /(!?)\[([^\]\n]*)]\(\s*(<[^>\n]+>|[^\s)\n]+)(?:\s+(?:"[^"\n]*"|'[^'\n]*'|\([^)\n]*\)))?\s*\)/g;
 const resetGlobalRegex = (regex: RegExp): RegExp => {
   regex.lastIndex = 0;
   return regex;
 };
 
+const stripDestinationWrappers = (destination: string): string => {
+  const trimmed = destination.trim();
+
+  if (trimmed.startsWith("<") && trimmed.endsWith(">")) {
+    return trimmed.slice(1, -1);
+  }
+
+  return trimmed;
+};
+
 const normalizeUrlCandidate = (candidate: string): string | null => {
-  const trimmed = candidate.trim();
+  const trimmed = stripDestinationWrappers(candidate);
   if (!trimmed) {
     return null;
   }
@@ -27,12 +38,28 @@ type UrlCandidate = {
   readonly index: number;
 };
 
-const collectUrlCandidates = (text: string): UrlCandidate[] => {
-  const candidates: UrlCandidate[] = [];
+type MarkdownLinkCandidate = UrlCandidate & {
+  readonly end: number;
+  readonly isImage: boolean;
+  readonly label: string;
+  readonly start: number;
+};
+
+type MarkdownImage = {
+  readonly alt: string;
+  readonly url: string;
+};
+
+const collectMarkdownLinkCandidates = (
+  text: string
+): MarkdownLinkCandidate[] => {
+  const candidates: MarkdownLinkCandidate[] = [];
   const markdownLinkRegex = resetGlobalRegex(MARKDOWN_LINK_REGEX);
 
   for (const match of text.matchAll(markdownLinkRegex)) {
-    const url = match[2];
+    const bang = match[1] ?? "";
+    const label = match[2] ?? "";
+    const url = match[3];
     if (typeof url !== "string" || !url.trim()) {
       continue;
     }
@@ -40,15 +67,43 @@ const collectUrlCandidates = (text: string): UrlCandidate[] => {
     const baseIndex = match.index;
     const urlOffset = match[0].indexOf(url);
     candidates.push({
-      url,
+      end: baseIndex + match[0].length,
       index: baseIndex + Math.max(urlOffset, 0),
+      isImage: bang === "!",
+      label,
+      start: baseIndex,
+      url,
     });
+  }
+
+  return candidates;
+};
+
+const isIndexInsideMarkdownCandidate = (
+  index: number,
+  candidates: readonly MarkdownLinkCandidate[]
+): boolean =>
+  candidates.some(
+    (candidate) => index >= candidate.start && index < candidate.end
+  );
+
+const collectUrlCandidates = (text: string): UrlCandidate[] => {
+  const candidates: UrlCandidate[] = [];
+  const markdownCandidates = collectMarkdownLinkCandidates(text);
+
+  for (const candidate of markdownCandidates) {
+    if (!candidate.isImage) {
+      candidates.push({ index: candidate.index, url: candidate.url });
+    }
   }
 
   const urlRegex = resetGlobalRegex(URL_REGEX);
   for (const match of text.matchAll(urlRegex)) {
     const url = match[0];
-    if (typeof url === "string") {
+    if (
+      typeof url === "string" &&
+      !isIndexInsideMarkdownCandidate(match.index, markdownCandidates)
+    ) {
       candidates.push({ url, index: match.index });
     }
   }
@@ -86,6 +141,49 @@ export const extractFirstUrl = (
 };
 
 /**
+ * Returns a single markdown image when it is the only visible content.
+ */
+export const extractStandaloneMarkdownImage = (
+  content: string | null | undefined
+): MarkdownImage | null => {
+  if (!content) {
+    return null;
+  }
+
+  const trimmed = content.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const imageCandidates = collectMarkdownLinkCandidates(trimmed).filter(
+    (candidate) => candidate.isImage
+  );
+
+  if (imageCandidates.length !== 1) {
+    return null;
+  }
+
+  const imageCandidate = imageCandidates[0];
+  const remainder = `${trimmed.slice(0, imageCandidate.start)}${trimmed.slice(
+    imageCandidate.end
+  )}`;
+
+  if (remainder.trim()) {
+    return null;
+  }
+
+  const normalizedUrl = normalizeUrlCandidate(imageCandidate.url);
+  if (!normalizedUrl) {
+    return null;
+  }
+
+  return {
+    alt: imageCandidate.label.trim() || "Media",
+    url: normalizedUrl,
+  };
+};
+
+/**
  * Removes a matching preview URL from content while keeping markdown link labels.
  */
 export const removePreviewUrlFromContent = (
@@ -108,7 +206,16 @@ export const removePreviewUrlFromContent = (
   const markdownLinkRegex = resetGlobalRegex(MARKDOWN_LINK_REGEX);
   let result = content.replace(
     markdownLinkRegex,
-    (match, label: string | undefined, url: string | undefined) => {
+    (
+      match,
+      bang: string | undefined,
+      label: string | undefined,
+      url: string | undefined
+    ) => {
+      if (bang === "!") {
+        return match;
+      }
+
       const normalized =
         typeof url === "string" ? normalizeUrlCandidate(url) : null;
       if (normalized && normalized === normalizedTarget) {


### PR DESCRIPTION
## Summary
- Treat standalone Markdown image drops in boosted posts as media instead of generic link previews.
- Keep Markdown image syntax out of preview URL extraction/removal so labels like `!Seize` do not leak into the card body.
- Add a focused regression test for the transient image URL pattern seen in maybe's dive bar.

## Validation
- `seize exec prettier --write components/home/boosted/extractStandaloneUrl.ts components/home/boosted/BoostedDropCardHomeContent.tsx __tests__/components/home/boosted/BoostedDropCardHome.test.tsx`
- `seize run lint:single -- components/home/boosted/extractStandaloneUrl.ts components/home/boosted/BoostedDropCardHomeContent.tsx`
- `seize run test:no-coverage -- __tests__/components/home/boosted/BoostedDropCardHome.test.tsx --runInBand`
- `seize run typecheck:changed`
- `codex-diff-check -- components/home/boosted/extractStandaloneUrl.ts components/home/boosted/BoostedDropCardHomeContent.tsx __tests__/components/home/boosted/BoostedDropCardHome.test.tsx`

## Visual check
- Local browser route `/waves/b38288e6-ca9d-45ce-8323-3dc5e094f04e` is blocked by the shared API not running on `localhost:3000` in this worktree (`fetch failed` from access-control middleware). I will do the real visual verification after deploy against the live environment where the API is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced boosted card rendering to detect standalone markdown image URLs and display them as boosted media when no explicit media is available.
  * Improved markdown/URL parsing with a new helper to reliably extract a single standalone markdown image (including better URL normalization).
* **Bug Fixes**
  * Refined preview URL handling to preserve matching markdown images while converting matching markdown links to their label text.
* **Tests**
  * Added coverage for “chat” variant boosted cards to verify correct MIME type selection and that link preview UI is not rendered for markdown images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->