### PR TITLE
Add frontend testing strategy controls

### DIFF
--- a/__tests__/scripts/testing-strategy.test.ts
+++ b/__tests__/scripts/testing-strategy.test.ts
@@ -224,7 +224,7 @@ describe("testing strategy risk floor", () => {
     expect(result.modifiers).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "feature-flag-diff-risk" }),
-      ]),
+      ])
     );
   });
 
@@ -237,7 +237,7 @@ describe("testing strategy risk floor", () => {
     expect(result.modifiers).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "i18n-layout-risk" }),
-      ]),
+      ])
     );
     expect(result.route_impacts).toContain("/waves/:param");
   });
@@ -249,10 +249,10 @@ describe("testing strategy validation manifest", () => {
       fs.readFileSync(
         path.join(
           process.cwd(),
-          "ops/testing-strategy/examples/minimal.validation-manifest.json",
+          "ops/testing-strategy/examples/minimal.validation-manifest.json"
         ),
-        "utf8",
-      ),
+        "utf8"
+      )
     );
 
     expect(validateValidationManifest(manifest)).toEqual({
@@ -280,7 +280,7 @@ describe("testing strategy validation manifest", () => {
         "risk.downgrade_approval.approver: required",
         "risk.downgrade_approval.reason: required",
         "risk.downgrade_approval.expires_at: required",
-      ]),
+      ])
     );
   });
 
@@ -300,7 +300,7 @@ describe("testing strategy validation manifest", () => {
 
     expect(result.ok).toBe(false);
     expect(result.errors).toContain(
-      "artifacts: Level 3+ manifests require at least one validated durable artifact pointer",
+      "artifacts: Level 3+ manifests require at least one validated durable artifact pointer"
     );
   });
 
@@ -311,7 +311,7 @@ describe("testing strategy validation manifest", () => {
         redaction_status: "raw",
         sha256: undefined,
       }),
-      0,
+      0
     );
 
     expect(errors).toEqual(
@@ -320,46 +320,46 @@ describe("testing strategy validation manifest", () => {
         "artifacts[0].uri: must start with s3://6529-artifacts/, https://artifacts.6529.io/, ipfs://, or ipns://",
         "artifacts[0]: must include at least one integrity field: sha256, cid, etag, or version_id",
         "artifacts[0].redaction_status: must be one of verified-redacted, not-sensitive, public-redacted",
-      ]),
+      ])
     );
   });
 
   it("rejects artifact pointers outside 6529-controlled storage", () => {
     const s3Errors = validateArtifactPointer(
       artifactPointer({ uri: "s3://not-6529-owned/private-trace.zip" }),
-      0,
+      0
     );
     const httpsErrors = validateArtifactPointer(
       artifactPointer({
         uri: "https://6529-artifacts.evil.example/trace.zip",
       }),
-      1,
+      1
     );
     const ipfsErrors = validateArtifactPointer(
       artifactPointer({
         uri: "ipfs://bafyexample",
         redaction_status: "verified-redacted",
       }),
-      2,
+      2
     );
     const uppercaseErrors = validateArtifactPointer(
       artifactPointer({
         uri: "S3://6529-ARTIFACTS/private-trace.zip",
       }),
-      3,
+      3
     );
 
     expect(s3Errors).toContain(
-      "artifacts[0].uri: must start with s3://6529-artifacts/, https://artifacts.6529.io/, ipfs://, or ipns://",
+      "artifacts[0].uri: must start with s3://6529-artifacts/, https://artifacts.6529.io/, ipfs://, or ipns://"
     );
     expect(httpsErrors).toContain(
-      "artifacts[1].uri: must start with s3://6529-artifacts/, https://artifacts.6529.io/, ipfs://, or ipns://",
+      "artifacts[1].uri: must start with s3://6529-artifacts/, https://artifacts.6529.io/, ipfs://, or ipns://"
     );
     expect(ipfsErrors).toContain(
-      "artifacts[2].redaction_status: must be public-redacted for IPFS/IPNS artifact pointers",
+      "artifacts[2].redaction_status: must be public-redacted for IPFS/IPNS artifact pointers"
     );
     expect(uppercaseErrors).toContain(
-      "artifacts[3].uri: must start with s3://6529-artifacts/, https://artifacts.6529.io/, ipfs://, or ipns://",
+      "artifacts[3].uri: must start with s3://6529-artifacts/, https://artifacts.6529.io/, ipfs://, or ipns://"
     );
   });
 
@@ -378,7 +378,7 @@ describe("testing strategy validation manifest", () => {
 
     expect(result.ok).toBe(false);
     expect(result.errors).toContain(
-      "review.reviewbot.required_lanes: must include existing reviewbot lane: responsiveness",
+      "review.reviewbot.required_lanes: must include existing reviewbot lane: responsiveness"
     );
   });
 
@@ -391,7 +391,7 @@ describe("testing strategy validation manifest", () => {
 
     expect(result.ok).toBe(false);
     expect(result.errors).toContain(
-      "review.reviewbot.required_lanes: required; every PR must preserve the existing reviewbot lanes",
+      "review.reviewbot.required_lanes: required; every PR must preserve the existing reviewbot lanes"
     );
   });
 
@@ -409,7 +409,7 @@ describe("testing strategy validation manifest", () => {
         "hazards: must be an array",
         "commands: must be an array",
         "artifacts: must be an array",
-      ]),
+      ])
     );
   });
 
@@ -418,14 +418,14 @@ describe("testing strategy validation manifest", () => {
       fs.readFileSync(
         path.join(
           process.cwd(),
-          "ops/testing-strategy/validation-manifest.v1.schema.json",
+          "ops/testing-strategy/validation-manifest.v1.schema.json"
         ),
-        "utf8",
-      ),
+        "utf8"
+      )
     );
 
     expect(schema.properties.schema_version.const).toBe(
-      VALIDATION_MANIFEST_SCHEMA_VERSION,
+      VALIDATION_MANIFEST_SCHEMA_VERSION
     );
   });
 
@@ -434,14 +434,14 @@ describe("testing strategy validation manifest", () => {
       fs.readFileSync(
         path.join(
           process.cwd(),
-          "ops/testing-strategy/validation-manifest.v1.schema.json",
+          "ops/testing-strategy/validation-manifest.v1.schema.json"
         ),
-        "utf8",
-      ),
+        "utf8"
+      )
     );
     const configText = fs.readFileSync(
       path.join(process.cwd(), ".github/6529bot.yml"),
-      "utf8",
+      "utf8"
     );
     const config = YAML.parse(configText) as {
       reviewKinds?: { initial?: string[] };
@@ -449,7 +449,7 @@ describe("testing strategy validation manifest", () => {
     const configLanes = config.reviewKinds?.initial ?? [];
     const schemaLanes =
       schema.properties.review.properties.reviewbot.properties.required_lanes.allOf.map(
-        (rule: { contains: { const: string } }) => rule.contains.const,
+        (rule: { contains: { const: string } }) => rule.contains.const
       );
 
     expect(configLanes).toEqual(REVIEWBOT_LANES);
@@ -464,10 +464,10 @@ describe("testing strategy mutation registry", () => {
       fs.readFileSync(
         path.join(
           process.cwd(),
-          "ops/testing-strategy/mutation-endpoint-registry.json",
+          "ops/testing-strategy/mutation-endpoint-registry.json"
         ),
-        "utf8",
-      ),
+        "utf8"
+      )
     );
 
     expect(validateMutationRegistry(registry)).toEqual({
@@ -512,7 +512,7 @@ describe("testing strategy mutation registry", () => {
         "endpoints[1].id: duplicate id: post-wave",
         "endpoints[1].methods: invalid HTTP method: TRACE",
         "endpoints[1].allowed_in_readonly_tests: must be false unless a separate allowlist explicitly handles the endpoint",
-      ]),
+      ])
     );
   });
 
@@ -521,14 +521,14 @@ describe("testing strategy mutation registry", () => {
       fs.readFileSync(
         path.join(
           process.cwd(),
-          "ops/testing-strategy/mutation-endpoint-registry.v1.schema.json",
+          "ops/testing-strategy/mutation-endpoint-registry.v1.schema.json"
         ),
-        "utf8",
-      ),
+        "utf8"
+      )
     );
 
     expect(schema.properties.schema_version.const).toBe(
-      MUTATION_REGISTRY_SCHEMA_VERSION,
+      MUTATION_REGISTRY_SCHEMA_VERSION
     );
   });
 });

--- a/__tests__/scripts/testing-strategy.test.ts
+++ b/__tests__/scripts/testing-strategy.test.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const YAML = require("yaml") as { parse: (text: string) => unknown };
+
 type RiskResult = {
   computed_floor: number;
   risk_level: string;
@@ -339,6 +342,12 @@ describe("testing strategy validation manifest", () => {
       }),
       2,
     );
+    const uppercaseErrors = validateArtifactPointer(
+      artifactPointer({
+        uri: "S3://6529-ARTIFACTS/private-trace.zip",
+      }),
+      3,
+    );
 
     expect(s3Errors).toContain(
       "artifacts[0].uri: must start with s3://6529-artifacts/, https://artifacts.6529.io/, ipfs://, or ipns://",
@@ -348,6 +357,9 @@ describe("testing strategy validation manifest", () => {
     );
     expect(ipfsErrors).toContain(
       "artifacts[2].redaction_status: must be public-redacted for IPFS/IPNS artifact pointers",
+    );
+    expect(uppercaseErrors).toContain(
+      "artifacts[3].uri: must start with s3://6529-artifacts/, https://artifacts.6529.io/, ipfs://, or ipns://",
     );
   });
 
@@ -383,6 +395,24 @@ describe("testing strategy validation manifest", () => {
     );
   });
 
+  it("rejects missing required manifest array sections", () => {
+    const manifest = validManifest();
+    delete (manifest as Record<string, unknown>).hazards;
+    delete (manifest as Record<string, unknown>).commands;
+    delete (manifest as Record<string, unknown>).artifacts;
+
+    const result = validateValidationManifest(manifest);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        "hazards: must be an array",
+        "commands: must be an array",
+        "artifacts: must be an array",
+      ]),
+    );
+  });
+
   it("keeps the schema const in sync with the validator", () => {
     const schema = JSON.parse(
       fs.readFileSync(
@@ -413,8 +443,10 @@ describe("testing strategy validation manifest", () => {
       path.join(process.cwd(), ".github/6529bot.yml"),
       "utf8",
     );
-    const initialLine = /initial:\s*\[([^\]]+)\]/.exec(configText)?.[1] ?? "";
-    const configLanes = initialLine.split(",").map((lane) => lane.trim());
+    const config = YAML.parse(configText) as {
+      reviewKinds?: { initial?: string[] };
+    };
+    const configLanes = config.reviewKinds?.initial ?? [];
     const schemaLanes =
       schema.properties.review.properties.reviewbot.properties.required_lanes.allOf.map(
         (rule: { contains: { const: string } }) => rule.contains.const,

--- a/__tests__/scripts/testing-strategy.test.ts
+++ b/__tests__/scripts/testing-strategy.test.ts
@@ -1,0 +1,398 @@
+import fs from "node:fs";
+import path from "node:path";
+
+type RiskResult = {
+  computed_floor: number;
+  risk_level: string;
+  files: string[];
+  reasons: Array<{ path: string; level: number; rule: string }>;
+  modifiers: Array<{ name: string; level_delta: number }>;
+  route_impacts: string[];
+};
+
+type ValidationResult = {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+};
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const {
+  EXISTING_REVIEWBOT_INITIAL_LANES,
+  MUTATION_REGISTRY_SCHEMA_VERSION,
+  VALIDATION_MANIFEST_SCHEMA_VERSION,
+  classifyChangedFiles,
+  validateArtifactPointer,
+  validateMutationRegistry,
+  validateValidationManifest,
+} = require("../../ops/scripts/testing-strategy.cjs") as {
+  EXISTING_REVIEWBOT_INITIAL_LANES: string[];
+  MUTATION_REGISTRY_SCHEMA_VERSION: string;
+  VALIDATION_MANIFEST_SCHEMA_VERSION: string;
+  classifyChangedFiles: (files: string[]) => RiskResult;
+  validateArtifactPointer: (artifact: unknown, index: number) => string[];
+  validateMutationRegistry: (registry: unknown) => ValidationResult;
+  validateValidationManifest: (manifest: unknown) => ValidationResult;
+};
+
+const REVIEWBOT_LANES = [
+  "general",
+  "wcag",
+  "i18n",
+  "security",
+  "responsiveness",
+];
+
+function validManifest(overrides: Record<string, unknown> = {}) {
+  return {
+    schema_version: VALIDATION_MANIFEST_SCHEMA_VERSION,
+    risk: {
+      computed_floor: 2,
+      declared: 2,
+      final: 2,
+      reasons: [
+        {
+          path: "components/example/Example.tsx",
+          level: 2,
+          rule: "user-visible-runtime",
+        },
+      ],
+      downgrade_approval: null,
+    },
+    changed_files: [{ path: "components/example/Example.tsx" }],
+    hazards: [
+      {
+        hazard: "Visible label regression",
+        severity: "medium",
+        likelihood: "low",
+        detection: "focused component test",
+        required_test:
+          "seize run test:no-coverage -- __tests__/scripts/testing-strategy.test.ts",
+        rollback_or_fix_forward: "revert label change",
+      },
+    ],
+    commands: [
+      {
+        command:
+          "seize run test:no-coverage -- __tests__/scripts/testing-strategy.test.ts",
+        status: "passed",
+      },
+    ],
+    artifacts: [],
+    review: {
+      reviewbot: {
+        required_lanes: REVIEWBOT_LANES,
+      },
+    },
+    ...overrides,
+  };
+}
+
+function artifactPointer(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: "playwright-trace",
+    uri: "s3://6529-artifacts/frontend/pr-1/trace.zip",
+    sha256: "abc123",
+    redaction_status: "verified-redacted",
+    retention_class: "pr-validation",
+    producing_command: "seize run test:e2e",
+    ...overrides,
+  };
+}
+
+describe("testing strategy risk floor", () => {
+  it("keeps docs and tests in the fast lane", () => {
+    const result = classifyChangedFiles([
+      "ops/workstreams/frontend-a11y-i18n/testing-improvement-plan.md",
+      "__tests__/components/example.test.tsx",
+    ]);
+
+    expect(result.computed_floor).toBe(0);
+    expect(result.risk_level).toBe("level-0");
+    expect(result.reasons.map((reason) => reason.rule)).toEqual([
+      "docs-tests-or-metadata",
+      "docs-tests-or-metadata",
+    ]);
+  });
+
+  it("classifies user-visible app code as standard risk", () => {
+    const result = classifyChangedFiles(["components/header/NavMenu.tsx"]);
+
+    expect(result.computed_floor).toBe(2);
+    expect(result.reasons[0]).toMatchObject({
+      level: 2,
+      rule: "user-visible-runtime",
+    });
+  });
+
+  it("routes auth wallet upload and admin surfaces to guarded risk", () => {
+    const result = classifyChangedFiles([
+      "components/wallet/ConnectButton.tsx",
+      "components/admin/DeleteWaveButton.tsx",
+      "helpers/upload/sanitizeUrl.ts",
+    ]);
+
+    expect(result.computed_floor).toBe(3);
+    expect(result.reasons.map((reason) => reason.rule)).toEqual([
+      "auth-wallet-upload-admin",
+      "auth-wallet-upload-admin",
+      "auth-wallet-upload-admin",
+    ]);
+  });
+
+  it("routes workflows and testing controls to release-captain risk", () => {
+    const result = classifyChangedFiles([
+      ".github/workflows/app-pr.yml",
+      "ops/scripts/testing-strategy.cjs",
+    ]);
+
+    expect(result.computed_floor).toBe(4);
+    expect(result.reasons.map((reason) => reason.rule)).toEqual([
+      "deployment-or-release-control",
+      "deployment-or-release-control",
+    ]);
+  });
+
+  it("routes secret and production authority paths to critical risk", () => {
+    const result = classifyChangedFiles([
+      ".env.production",
+      ".github/workflows/build-upload-deploy-prod.yml",
+    ]);
+
+    expect(result.computed_floor).toBe(5);
+    expect(result.reasons.map((reason) => reason.rule)).toEqual([
+      "credentials-or-secrets",
+      "deploy-authority-or-artifact-access",
+    ]);
+  });
+
+  it("raises feature flag runtime changes by one level below release risk", () => {
+    const result = classifyChangedFiles(["lib/feature-flags/eligibility.ts"]);
+
+    expect(result.computed_floor).toBe(3);
+    expect(result.modifiers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "feature-flag-diff-risk" }),
+      ]),
+    );
+  });
+
+  it("records i18n layout modifiers and route impact hints", () => {
+    const result = classifyChangedFiles([
+      "i18n/messages.ts",
+      "app/waves/[waveId]/page.tsx",
+    ]);
+
+    expect(result.modifiers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "i18n-layout-risk" }),
+      ]),
+    );
+    expect(result.route_impacts).toContain("/waves/:param");
+  });
+});
+
+describe("testing strategy validation manifest", () => {
+  it("accepts the checked-in minimal example", () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          process.cwd(),
+          "ops/testing-strategy/examples/minimal.validation-manifest.json",
+        ),
+        "utf8",
+      ),
+    );
+
+    expect(validateValidationManifest(manifest)).toEqual({
+      ok: true,
+      errors: [],
+      warnings: [],
+    });
+  });
+
+  it("requires release-captain approval for risk downgrades", () => {
+    const manifest = validManifest({
+      risk: {
+        computed_floor: 4,
+        declared: 2,
+        final: 2,
+        reasons: [],
+      },
+    });
+
+    const result = validateValidationManifest(manifest);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        "risk.downgrade_approval.approver: required",
+        "risk.downgrade_approval.reason: required",
+        "risk.downgrade_approval.expires_at: required",
+      ]),
+    );
+  });
+
+  it("requires durable artifact pointers for Level 3 and higher manifests", () => {
+    const manifest = validManifest({
+      risk: {
+        computed_floor: 3,
+        declared: 3,
+        final: 3,
+        reasons: [],
+        downgrade_approval: null,
+      },
+      artifacts: [],
+    });
+
+    const result = validateValidationManifest(manifest);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      "artifacts: Level 3+ manifests require at least one validated durable artifact pointer",
+    );
+  });
+
+  it("rejects local or unredacted artifact pointers", () => {
+    const errors = validateArtifactPointer(
+      artifactPointer({
+        uri: "file:///tmp/trace.zip",
+        redaction_status: "raw",
+        sha256: undefined,
+      }),
+      0,
+    );
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        "artifacts[0].uri: must be a durable artifact pointer, not a local path or Git LFS object",
+        "artifacts[0].uri: must start with one of s3://, ipfs://, ipns://, https://artifacts.6529.io/, https://6529-artifacts",
+        "artifacts[0]: must include at least one integrity field: sha256, cid, etag, or version_id",
+        "artifacts[0].redaction_status: must be one of verified-redacted, not-sensitive, public-redacted",
+      ]),
+    );
+  });
+
+  it("keeps all existing reviewbot initial lanes required", () => {
+    expect(EXISTING_REVIEWBOT_INITIAL_LANES).toEqual(REVIEWBOT_LANES);
+
+    const manifest = validManifest({
+      review: {
+        reviewbot: {
+          required_lanes: ["general", "wcag", "i18n", "security"],
+        },
+      },
+    });
+
+    const result = validateValidationManifest(manifest);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      "review.reviewbot.required_lanes: must include existing reviewbot lane: responsiveness",
+    );
+  });
+
+  it("requires manifests to record the existing reviewbot lanes", () => {
+    const manifest = validManifest({
+      review: {},
+    });
+
+    const result = validateValidationManifest(manifest);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toContain(
+      "review.reviewbot.required_lanes: required; every PR must preserve the existing reviewbot lanes",
+    );
+  });
+
+  it("keeps the schema const in sync with the validator", () => {
+    const schema = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          process.cwd(),
+          "ops/testing-strategy/validation-manifest.v1.schema.json",
+        ),
+        "utf8",
+      ),
+    );
+
+    expect(schema.properties.schema_version.const).toBe(
+      VALIDATION_MANIFEST_SCHEMA_VERSION,
+    );
+  });
+});
+
+describe("testing strategy mutation registry", () => {
+  it("accepts the checked-in empty registry contract", () => {
+    const registry = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          process.cwd(),
+          "ops/testing-strategy/mutation-endpoint-registry.json",
+        ),
+        "utf8",
+      ),
+    );
+
+    expect(validateMutationRegistry(registry)).toEqual({
+      ok: true,
+      errors: [],
+      warnings: [],
+    });
+  });
+
+  it("rejects duplicate or read-only-allowed mutation entries", () => {
+    const registry = {
+      schema_version: MUTATION_REGISTRY_SCHEMA_VERSION,
+      owner: "frontend-release-captain",
+      updated_at: "2026-06-20T00:00:00.000Z",
+      endpoints: [
+        {
+          id: "post-wave",
+          pattern: "/api/waves/**",
+          methods: ["POST"],
+          surface: "posting",
+          risk_level: 3,
+          mutation: true,
+          allowed_in_readonly_tests: false,
+        },
+        {
+          id: "post-wave",
+          pattern: "/api/waves/**",
+          methods: ["TRACE"],
+          surface: "posting",
+          risk_level: 3,
+          mutation: true,
+          allowed_in_readonly_tests: true,
+        },
+      ],
+    };
+
+    const result = validateMutationRegistry(registry);
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        "endpoints[1].id: duplicate id: post-wave",
+        "endpoints[1].methods: invalid HTTP method: TRACE",
+        "endpoints[1].allowed_in_readonly_tests: must be false unless a separate allowlist explicitly handles the endpoint",
+      ]),
+    );
+  });
+
+  it("keeps the mutation registry schema const in sync with the validator", () => {
+    const schema = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          process.cwd(),
+          "ops/testing-strategy/mutation-endpoint-registry.v1.schema.json",
+        ),
+        "utf8",
+      ),
+    );
+
+    expect(schema.properties.schema_version.const).toBe(
+      MUTATION_REGISTRY_SCHEMA_VERSION,
+    );
+  });
+});

--- a/__tests__/scripts/testing-strategy.test.ts
+++ b/__tests__/scripts/testing-strategy.test.ts
@@ -153,6 +153,54 @@ describe("testing strategy risk floor", () => {
     ]);
   });
 
+  it("does not let config or routing infrastructure fall into Level 0", () => {
+    const result = classifyChangedFiles([
+      "config/securityHeaders.ts",
+      "config/env.schema.ts",
+      "middleware.ts",
+      "instrumentation.ts",
+    ]);
+
+    expect(result.computed_floor).toBe(4);
+    expect(result.reasons.map((reason) => reason.rule)).toEqual([
+      "deployment-or-release-control",
+      "deployment-or-release-control",
+      "deployment-or-release-control",
+      "deployment-or-release-control",
+    ]);
+  });
+
+  it("classifies unknown source files conservatively and catches hyphenated sensitive names", () => {
+    const result = classifyChangedFiles([
+      "src/errors/renderFailure.ts",
+      "src/errors/wallet-auth.ts",
+    ]);
+
+    expect(result.computed_floor).toBe(3);
+    expect(result.reasons).toEqual([
+      expect.objectContaining({
+        path: "src/errors/renderFailure.ts",
+        level: 2,
+        rule: "user-visible-runtime",
+      }),
+      expect.objectContaining({
+        path: "src/errors/wallet-auth.ts",
+        level: 3,
+        rule: "auth-wallet-upload-admin",
+      }),
+    ]);
+  });
+
+  it("defaults unmatched files to standard risk instead of docs risk", () => {
+    const result = classifyChangedFiles(["unknown-runtime-file.foo"]);
+
+    expect(result.computed_floor).toBe(2);
+    expect(result.reasons[0]).toMatchObject({
+      level: 2,
+      rule: "unclassified-runtime-or-config",
+    });
+  });
+
   it("routes secret and production authority paths to critical risk", () => {
     const result = classifyChangedFiles([
       ".env.production",
@@ -266,10 +314,40 @@ describe("testing strategy validation manifest", () => {
     expect(errors).toEqual(
       expect.arrayContaining([
         "artifacts[0].uri: must be a durable artifact pointer, not a local path or Git LFS object",
-        "artifacts[0].uri: must start with one of s3://, ipfs://, ipns://, https://artifacts.6529.io/, https://6529-artifacts",
+        "artifacts[0].uri: must start with s3://6529-artifacts/, https://artifacts.6529.io/, ipfs://, or ipns://",
         "artifacts[0]: must include at least one integrity field: sha256, cid, etag, or version_id",
         "artifacts[0].redaction_status: must be one of verified-redacted, not-sensitive, public-redacted",
       ]),
+    );
+  });
+
+  it("rejects artifact pointers outside 6529-controlled storage", () => {
+    const s3Errors = validateArtifactPointer(
+      artifactPointer({ uri: "s3://not-6529-owned/private-trace.zip" }),
+      0,
+    );
+    const httpsErrors = validateArtifactPointer(
+      artifactPointer({
+        uri: "https://6529-artifacts.evil.example/trace.zip",
+      }),
+      1,
+    );
+    const ipfsErrors = validateArtifactPointer(
+      artifactPointer({
+        uri: "ipfs://bafyexample",
+        redaction_status: "verified-redacted",
+      }),
+      2,
+    );
+
+    expect(s3Errors).toContain(
+      "artifacts[0].uri: must start with s3://6529-artifacts/, https://artifacts.6529.io/, ipfs://, or ipns://",
+    );
+    expect(httpsErrors).toContain(
+      "artifacts[1].uri: must start with s3://6529-artifacts/, https://artifacts.6529.io/, ipfs://, or ipns://",
+    );
+    expect(ipfsErrors).toContain(
+      "artifacts[2].redaction_status: must be public-redacted for IPFS/IPNS artifact pointers",
     );
   });
 
@@ -319,6 +397,32 @@ describe("testing strategy validation manifest", () => {
     expect(schema.properties.schema_version.const).toBe(
       VALIDATION_MANIFEST_SCHEMA_VERSION,
     );
+  });
+
+  it("keeps required reviewbot lanes in sync with the schema and repo config", () => {
+    const schema = JSON.parse(
+      fs.readFileSync(
+        path.join(
+          process.cwd(),
+          "ops/testing-strategy/validation-manifest.v1.schema.json",
+        ),
+        "utf8",
+      ),
+    );
+    const configText = fs.readFileSync(
+      path.join(process.cwd(), ".github/6529bot.yml"),
+      "utf8",
+    );
+    const initialLine = /initial:\s*\[([^\]]+)\]/.exec(configText)?.[1] ?? "";
+    const configLanes = initialLine.split(",").map((lane) => lane.trim());
+    const schemaLanes =
+      schema.properties.review.properties.reviewbot.properties.required_lanes.allOf.map(
+        (rule: { contains: { const: string } }) => rule.contains.const,
+      );
+
+    expect(configLanes).toEqual(REVIEWBOT_LANES);
+    expect(schemaLanes).toEqual(REVIEWBOT_LANES);
+    expect(EXISTING_REVIEWBOT_INITIAL_LANES).toEqual(REVIEWBOT_LANES);
   });
 });
 

--- a/ops/scripts/README.md
+++ b/ops/scripts/README.md
@@ -14,6 +14,8 @@ wrapper expects that location.
   `ops/docs`.
 - `deployment-bus.cjs`: deployment bus manifest, validation, heartbeat,
   production-preflight, and GitHub Deployment status helper.
+- `testing-strategy.cjs`: frontend testing strategy risk-floor classifier,
+  validation manifest checker, and mutation endpoint registry checker.
 - `run-docs-area-remediator-loop.sh`: iterative docs remediation loop.
 - `process-docs-commit-queue.sh`: docs update queue helper for commit-based
   remediation workflows.

--- a/ops/scripts/testing-strategy.cjs
+++ b/ops/scripts/testing-strategy.cjs
@@ -737,7 +737,19 @@ function printValidation(result, successMessage) {
     }
     return;
   }
-  console.log(successMessage);
+  writeStdout(successMessage);
+}
+
+function writeStdout(message = "") {
+  process.stdout.write(`${message}\n`);
+}
+
+function canRunCommand(command) {
+  const result = spawnSync(command, ["--version"], {
+    encoding: "utf8",
+    stdio: ["ignore", "ignore", "ignore"],
+  });
+  return result.status === 0;
 }
 
 function resolveGitCommand() {
@@ -751,7 +763,7 @@ function resolveGitCommand() {
     String.raw`C:\Program Files\Git\cmd\git.exe`,
     String.raw`C:\Program Files\Git\bin\git.exe`,
   ];
-  return candidates.find((candidate) => fs.existsSync(candidate)) || "git";
+  return candidates.find((candidate) => canRunCommand(candidate)) || "git";
 }
 
 function changedFilesFromGit(baseRef, cwd = process.cwd()) {
@@ -839,16 +851,16 @@ function usage() {
 function commandComputeRiskFloor(args) {
   const result = classifyChangedFiles(filesFromArgs(args));
   if (args.json) {
-    console.log(JSON.stringify(result, null, 2));
+    writeStdout(JSON.stringify(result, null, 2));
     return;
   }
 
-  console.log(`Risk floor: ${result.risk_level}`);
+  writeStdout(`Risk floor: ${result.risk_level}`);
   for (const reason of result.reasons) {
-    console.log(`- ${reason.path}: level-${reason.level} (${reason.rule})`);
+    writeStdout(`- ${reason.path}: level-${reason.level} (${reason.rule})`);
   }
   for (const modifier of result.modifiers) {
-    console.log(`- modifier ${modifier.name}: ${modifier.reason}`);
+    writeStdout(`- modifier ${modifier.name}: ${modifier.reason}`);
   }
 }
 
@@ -861,7 +873,7 @@ function commandValidateManifest(args) {
 }
 
 function commandSummarizeManifest(args) {
-  console.log(summarizeValidationManifest(readJson(args.file)));
+  writeStdout(summarizeValidationManifest(readJson(args.file)));
 }
 
 function commandValidateMutationRegistry(args) {
@@ -886,7 +898,7 @@ async function main(argv = process.argv.slice(2)) {
   try {
     const handler = COMMAND_HANDLERS[command];
     if (!handler) {
-      console.log(usage());
+      writeStdout(usage());
       process.exitCode = command ? 1 : 0;
       return;
     }

--- a/ops/scripts/testing-strategy.cjs
+++ b/ops/scripts/testing-strategy.cjs
@@ -1,0 +1,804 @@
+#!/usr/bin/env node
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const VALIDATION_MANIFEST_SCHEMA_VERSION =
+  "frontend-testing.validation-manifest.v1";
+const MUTATION_REGISTRY_SCHEMA_VERSION =
+  "frontend-testing.mutation-endpoint-registry.v1";
+const MAX_RISK_LEVEL = 5;
+const EXISTING_REVIEWBOT_INITIAL_LANES = Object.freeze([
+  "general",
+  "wcag",
+  "i18n",
+  "security",
+  "responsiveness",
+]);
+const ARTIFACT_URI_PREFIXES = [
+  "s3://",
+  "ipfs://",
+  "ipns://",
+  "https://artifacts.6529.io/",
+  "https://6529-artifacts",
+];
+const ARTIFACT_REDACTION_STATUSES = new Set([
+  "verified-redacted",
+  "not-sensitive",
+  "public-redacted",
+]);
+const COMMAND_STATUSES = new Set(["passed", "failed", "skipped", "not-run"]);
+const HTTP_METHODS = new Set([
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "OPTIONS",
+]);
+
+const RISK_RULES = [
+  {
+    level: 5,
+    name: "credentials-or-secrets",
+    patterns: [
+      /(^|\/)\.env($|[./_-])/,
+      /(^|\/)(credentials?|secrets?|secret-handling|private[-_]?key)(\/|\.|$)/,
+      /(^|\/)(staging_auth|staging_api_key|wallet[-_]?seed)(\/|\.|$)/,
+    ],
+    reason: "Credentials or secret-handling paths require release-captain review.",
+  },
+  {
+    level: 5,
+    name: "signing-funds-or-irreversible",
+    patterns: [
+      /(^|\/)(signing|signature|transaction|tx|funds?|mint|burn|transfer)(\/|\.|$)/,
+      /(^|\/)(irreversible|destructive[-_]?action)(\/|\.|$)/,
+    ],
+    reason: "Signing, funds, or irreversible-action paths are safety critical.",
+  },
+  {
+    level: 5,
+    name: "deploy-authority-or-artifact-access",
+    patterns: [
+      /(^|\/)(iam|oidc|artifact[-_]?store[-_]?access|production[-_]?secrets)(\/|\.|$)/,
+      /(^|\/)\.github\/workflows\/.*prod.*\.ya?ml$/,
+    ],
+    reason: "Production authority and artifact access controls are critical.",
+  },
+  {
+    level: 4,
+    name: "deployment-or-release-control",
+    patterns: [
+      /^\.github\/workflows\//,
+      /^ops\/deployment-bus\//,
+      /^ops\/scripts\/deployment-bus\.cjs$/,
+      /^ops\/scripts\/testing-strategy\.cjs$/,
+      /^ops\/testing-strategy\//,
+      /^package\.json$/,
+      /^pnpm-lock\.yaml$/,
+      /^next\.config\./,
+      /^sentry\./,
+      /^scripts\/(build|start|dev|run-secure|enforce|require-6529|quality|typecheck)/,
+      /(^|\/)(deploy|deployment|release|rollback|fix-forward)(\/|\.|$)/,
+    ],
+    reason: "Deployment, release, build, and operational controls affect promotion safety.",
+  },
+  {
+    level: 4,
+    name: "native-or-cross-surface-runtime",
+    patterns: [
+      /^capacitor\.config\./,
+      /^android\//,
+      /^ios\//,
+      /^electron\//,
+      /(^|\/)(capacitor|electron|native-shell|webview2)(\/|\.|$)/,
+    ],
+    reason: "Native or cross-surface runtime behavior needs broader validation.",
+  },
+  {
+    level: 3,
+    name: "auth-wallet-upload-admin",
+    patterns: [
+      /(^|\/)(auth|session|login|logout|oauth|cookie|jwt|token)(\/|\.|$)/,
+      /(^|\/)(wallet|wagmi|viem|ethers|ens)(\/|\.|$)/,
+      /(^|\/)(profile|identity|tdh|delegation|owner|ownership)(\/|\.|$)/,
+      /(^|\/)(upload|uploads|media|link-preview|open-graph|sanitize|safe-url)(\/|\.|$)/,
+      /(^|\/)(waves?|drops?|posting|moderation|admin|vote|delete)(\/|\.|$)/,
+    ],
+    reason: "Auth, wallet, upload, posting, moderation, and admin paths are guarded.",
+  },
+  {
+    level: 3,
+    name: "api-route-or-shared-data",
+    patterns: [
+      /^app\/api\//,
+      /^generated\//,
+      /^services\//,
+      /^api\//,
+      /(^|\/)(api-client|route-protection|server-action|data-fetch|query-client)(\/|\.|$)/,
+    ],
+    reason: "API models, route handlers, and shared data paths can affect trust boundaries.",
+  },
+  {
+    level: 2,
+    name: "user-visible-runtime",
+    patterns: [
+      /^app\//,
+      /^components\//,
+      /^contexts\//,
+      /^hooks\//,
+      /^store\//,
+      /^helpers\//,
+      /^lib\//,
+      /^utils\//,
+      /^styles\//,
+      /^i18n\//,
+    ],
+    reason: "User-visible app behavior needs standard browser and component evidence.",
+  },
+  {
+    level: 1,
+    name: "presentational-assets",
+    patterns: [/^public\//, /^assets\//, /\.(css|scss|svg|png|jpe?g|webp)$/],
+    reason: "Presentational asset changes need fast visual/layout validation.",
+  },
+  {
+    level: 0,
+    name: "docs-tests-or-metadata",
+    patterns: [
+      /^ops\/.*\.md$/,
+      /^.*\.md$/,
+      /^__tests__\//,
+      /^tests\//,
+      /^docs\//,
+      /^\.github\/(pull_request_template|ISSUE_TEMPLATE)\//,
+    ],
+    reason: "Docs, tests, and non-runtime metadata are fast-lane by default.",
+  },
+];
+
+const FEATURE_FLAG_PATTERNS = [
+  /(^|\/)(feature[-_]?flags?|flags?|experiments?)(\/|\.|$)/,
+  /(^|\/)(env\.schema|runtime[-_]?config|eligibility)(\/|\.|$)/,
+];
+
+const I18N_PAYLOAD_PATTERNS = [
+  /^i18n\/(messages|locales|translations)/,
+  /(^|\/)(messages|locales|translations)\.(json|ts|tsx|js)$/,
+  /(^|\/)(copy|labels|aria|forms|modals|navigation)(\/|\.|$)/,
+];
+
+function parseArgs(argv) {
+  const args = { _: [] };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith("--")) {
+      args._.push(token);
+      continue;
+    }
+
+    const rawKey = token.slice(2);
+    const eqIndex = rawKey.indexOf("=");
+    if (eqIndex !== -1) {
+      args[rawKey.slice(0, eqIndex)] = rawKey.slice(eqIndex + 1);
+      continue;
+    }
+
+    const next = argv[i + 1];
+    if (!next || next.startsWith("--")) {
+      args[rawKey] = true;
+      continue;
+    }
+
+    args[rawKey] = next;
+    i += 1;
+  }
+
+  return args;
+}
+
+function normalizePath(value) {
+  return displayPath(value).toLowerCase();
+}
+
+function displayPath(value) {
+  return String(value || "")
+    .replace(/\\/g, "/")
+    .replace(/^\.\//, "")
+    .replace(/^\/+/, "");
+}
+
+function matchesAny(filePath, patterns) {
+  return patterns.some((pattern) => pattern.test(filePath));
+}
+
+function ruleForFile(filePath) {
+  const normalized = normalizePath(filePath);
+  return (
+    RISK_RULES.find((rule) => matchesAny(normalized, rule.patterns)) ||
+    RISK_RULES[RISK_RULES.length - 1]
+  );
+}
+
+function inferRouteImpacts(files) {
+  const routes = new Set();
+
+  for (const file of files.map(normalizePath)) {
+    const appMatch = /^app\/(.+)\/(?:page|layout|template|loading|error|not-found)\.(tsx?|jsx?)$/.exec(
+      file,
+    );
+    if (appMatch) {
+      const route = `/${appMatch[1]
+        .replace(/\([^)]*\)\//g, "")
+        .replace(/\/?page$/, "")
+        .replace(/\/index$/, "")
+        .replace(/\[[^\]]+\]/g, ":param")}`;
+      routes.add(route === "/." ? "/" : route);
+    }
+
+    const pagesMatch = /^pages\/(.+)\.(tsx?|jsx?)$/.exec(file);
+    if (pagesMatch && !pagesMatch[1].startsWith("api/")) {
+      routes.add(`/${pagesMatch[1].replace(/\/index$/, "")}`);
+    }
+  }
+
+  return [...routes].sort();
+}
+
+function classifyChangedFiles(files) {
+  const fileMap = new Map();
+  for (const file of files) {
+    const display = displayPath(file);
+    if (display) {
+      fileMap.set(normalizePath(display), display);
+    }
+  }
+  const fileEntries = [...fileMap.entries()].map(([normalized, display]) => ({
+    normalized,
+    display,
+  }));
+  const reasons = fileEntries.map((file) => {
+    const rule = ruleForFile(file.normalized);
+    return {
+      path: file.display,
+      level: rule.level,
+      rule: rule.name,
+      reason: rule.reason,
+    };
+  });
+  let computedFloor = reasons.reduce(
+    (highest, reason) => Math.max(highest, reason.level),
+    0,
+  );
+  const modifiers = [];
+
+  if (
+    computedFloor < 4 &&
+    fileEntries.some((file) => matchesAny(file.normalized, FEATURE_FLAG_PATTERNS))
+  ) {
+    computedFloor = Math.min(MAX_RISK_LEVEL, computedFloor + 1);
+    modifiers.push({
+      name: "feature-flag-diff-risk",
+      level_delta: 1,
+      reason:
+        "Feature flag, runtime config, or eligibility changes can alter ON/OFF behavior.",
+    });
+  }
+
+  if (
+    fileEntries.some((file) => matchesAny(file.normalized, I18N_PAYLOAD_PATTERNS))
+  ) {
+    modifiers.push({
+      name: "i18n-layout-risk",
+      level_delta: 0,
+      reason:
+        "I18n or label payload changes require mobile overflow and accessible-name evidence.",
+    });
+  }
+
+  return {
+    schema_version: "frontend-testing.risk-floor.v1",
+    computed_floor: computedFloor,
+    risk_level: `level-${computedFloor}`,
+    files: fileEntries.map((file) => file.display),
+    reasons,
+    modifiers,
+    route_impacts: inferRouteImpacts(fileEntries.map((file) => file.normalized)),
+  };
+}
+
+function isIntegerRisk(value) {
+  return Number.isInteger(value) && value >= 0 && value <= MAX_RISK_LEVEL;
+}
+
+function readJson(file) {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- Operator CLI reads caller-supplied manifest paths.
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function pushError(errors, pathName, message) {
+  errors.push(`${pathName}: ${message}`);
+}
+
+function validateArtifactPointer(artifact, index) {
+  const errors = [];
+  const prefix = `artifacts[${index}]`;
+
+  if (!artifact || typeof artifact !== "object" || Array.isArray(artifact)) {
+    pushError(errors, prefix, "must be an object");
+    return errors;
+  }
+
+  if (!artifact.kind) {
+    pushError(errors, `${prefix}.kind`, "required");
+  }
+
+  if (!artifact.uri || typeof artifact.uri !== "string") {
+    pushError(errors, `${prefix}.uri`, "required");
+  } else {
+    const uri = artifact.uri;
+    const lowerUri = uri.toLowerCase();
+    if (
+      lowerUri.startsWith("file://") ||
+      /^[a-z]:[\\/]/i.test(uri) ||
+      lowerUri.includes("git-lfs")
+    ) {
+      pushError(
+        errors,
+        `${prefix}.uri`,
+        "must be a durable artifact pointer, not a local path or Git LFS object",
+      );
+    }
+    if (!ARTIFACT_URI_PREFIXES.some((candidate) => lowerUri.startsWith(candidate))) {
+      pushError(
+        errors,
+        `${prefix}.uri`,
+        `must start with one of ${ARTIFACT_URI_PREFIXES.join(", ")}`,
+      );
+    }
+  }
+
+  if (
+    !artifact.sha256 &&
+    !artifact.cid &&
+    !artifact.etag &&
+    !artifact.version_id
+  ) {
+    pushError(
+      errors,
+      prefix,
+      "must include at least one integrity field: sha256, cid, etag, or version_id",
+    );
+  }
+
+  if (!ARTIFACT_REDACTION_STATUSES.has(artifact.redaction_status)) {
+    pushError(
+      errors,
+      `${prefix}.redaction_status`,
+      `must be one of ${[...ARTIFACT_REDACTION_STATUSES].join(", ")}`,
+    );
+  }
+
+  if (!artifact.producing_command) {
+    pushError(errors, `${prefix}.producing_command`, "required");
+  }
+
+  if (!artifact.retention_class) {
+    pushError(errors, `${prefix}.retention_class`, "required");
+  }
+
+  return errors;
+}
+
+function validateReviewbotLanes(review, errors) {
+  const lanes = review?.reviewbot?.required_lanes;
+  if (!lanes) {
+    return;
+  }
+  if (!Array.isArray(lanes)) {
+    pushError(errors, "review.reviewbot.required_lanes", "must be an array");
+    return;
+  }
+
+  for (const lane of EXISTING_REVIEWBOT_INITIAL_LANES) {
+    if (!lanes.includes(lane)) {
+      pushError(
+        errors,
+        "review.reviewbot.required_lanes",
+        `must include existing reviewbot lane: ${lane}`,
+      );
+    }
+  }
+}
+
+function validateValidationManifest(manifest) {
+  const errors = [];
+  const warnings = [];
+
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+    return {
+      ok: false,
+      errors: ["manifest: must be an object"],
+      warnings,
+    };
+  }
+
+  if (manifest.schema_version !== VALIDATION_MANIFEST_SCHEMA_VERSION) {
+    pushError(
+      errors,
+      "schema_version",
+      `must be ${VALIDATION_MANIFEST_SCHEMA_VERSION}`,
+    );
+  }
+
+  const risk = manifest.risk || {};
+  for (const field of ["computed_floor", "declared", "final"]) {
+    if (!isIntegerRisk(risk[field])) {
+      pushError(errors, `risk.${field}`, "must be an integer from 0 through 5");
+    }
+  }
+  if (!Array.isArray(risk.reasons)) {
+    pushError(errors, "risk.reasons", "must be an array");
+  }
+
+  if (
+    isIntegerRisk(risk.final) &&
+    isIntegerRisk(risk.computed_floor) &&
+    risk.final < risk.computed_floor
+  ) {
+    const approval = risk.downgrade_approval || {};
+    if (!approval.approver) {
+      pushError(errors, "risk.downgrade_approval.approver", "required");
+    }
+    if (!approval.reason) {
+      pushError(errors, "risk.downgrade_approval.reason", "required");
+    }
+    if (!approval.expires_at) {
+      pushError(errors, "risk.downgrade_approval.expires_at", "required");
+    }
+  }
+
+  if (!Array.isArray(manifest.changed_files)) {
+    pushError(errors, "changed_files", "must be an array");
+  }
+
+  const hazards = manifest.hazards || [];
+  if (!Array.isArray(hazards)) {
+    pushError(errors, "hazards", "must be an array");
+  } else {
+    hazards.forEach((hazard, index) => {
+      for (const field of [
+        "hazard",
+        "severity",
+        "likelihood",
+        "detection",
+        "required_test",
+        "rollback_or_fix_forward",
+      ]) {
+        if (!hazard?.[field]) {
+          pushError(errors, `hazards[${index}].${field}`, "required");
+        }
+      }
+    });
+  }
+
+  const commands = manifest.commands || [];
+  if (!Array.isArray(commands)) {
+    pushError(errors, "commands", "must be an array");
+  } else {
+    commands.forEach((command, index) => {
+      if (!command?.command) {
+        pushError(errors, `commands[${index}].command`, "required");
+      }
+      if (!COMMAND_STATUSES.has(command?.status)) {
+        pushError(
+          errors,
+          `commands[${index}].status`,
+          `must be one of ${[...COMMAND_STATUSES].join(", ")}`,
+        );
+      }
+    });
+  }
+
+  const artifacts = manifest.artifacts || [];
+  if (!Array.isArray(artifacts)) {
+    pushError(errors, "artifacts", "must be an array");
+  } else {
+    artifacts.forEach((artifact, index) => {
+      errors.push(...validateArtifactPointer(artifact, index));
+    });
+  }
+
+  if (isIntegerRisk(risk.final) && risk.final >= 3 && artifacts.length === 0) {
+    pushError(
+      errors,
+      "artifacts",
+      "Level 3+ manifests require at least one validated durable artifact pointer",
+    );
+  }
+
+  validateReviewbotLanes(manifest.review, errors);
+
+  if (!manifest.review?.reviewbot?.required_lanes) {
+    pushError(
+      errors,
+      "review.reviewbot.required_lanes",
+      "required; every PR must preserve the existing reviewbot lanes",
+    );
+  }
+
+  return { ok: errors.length === 0, errors, warnings };
+}
+
+function summarizeValidationManifest(manifest) {
+  const risk = manifest.risk || {};
+  const reviewLanes = manifest.review?.reviewbot?.required_lanes || [];
+  return [
+    `schema_version: ${manifest.schema_version}`,
+    `risk: computed ${risk.computed_floor}, declared ${risk.declared}, final ${risk.final}`,
+    `changed_files: ${(manifest.changed_files || []).length}`,
+    `hazards: ${(manifest.hazards || []).length}`,
+    `commands: ${(manifest.commands || []).length}`,
+    `artifacts: ${(manifest.artifacts || []).length}`,
+    `reviewbot_lanes: ${reviewLanes.join(", ") || "not recorded"}`,
+  ].join("\n");
+}
+
+function validateMutationRegistry(registry) {
+  const errors = [];
+  const warnings = [];
+
+  if (!registry || typeof registry !== "object" || Array.isArray(registry)) {
+    return {
+      ok: false,
+      errors: ["registry: must be an object"],
+      warnings,
+    };
+  }
+
+  if (registry.schema_version !== MUTATION_REGISTRY_SCHEMA_VERSION) {
+    pushError(
+      errors,
+      "schema_version",
+      `must be ${MUTATION_REGISTRY_SCHEMA_VERSION}`,
+    );
+  }
+  if (!registry.owner) {
+    pushError(errors, "owner", "required");
+  }
+  if (!registry.updated_at) {
+    pushError(errors, "updated_at", "required");
+  }
+  if (!Array.isArray(registry.endpoints)) {
+    pushError(errors, "endpoints", "must be an array");
+    return { ok: errors.length === 0, errors, warnings };
+  }
+
+  const ids = new Set();
+  registry.endpoints.forEach((endpoint, index) => {
+    const prefix = `endpoints[${index}]`;
+    if (!endpoint || typeof endpoint !== "object" || Array.isArray(endpoint)) {
+      pushError(errors, prefix, "must be an object");
+      return;
+    }
+    if (!endpoint.id) {
+      pushError(errors, `${prefix}.id`, "required");
+    } else if (ids.has(endpoint.id)) {
+      pushError(errors, `${prefix}.id`, `duplicate id: ${endpoint.id}`);
+    } else {
+      ids.add(endpoint.id);
+    }
+    if (!endpoint.pattern) {
+      pushError(errors, `${prefix}.pattern`, "required");
+    }
+    if (!Array.isArray(endpoint.methods) || endpoint.methods.length === 0) {
+      pushError(errors, `${prefix}.methods`, "must include at least one method");
+    } else {
+      for (const method of endpoint.methods) {
+        if (!HTTP_METHODS.has(method)) {
+          pushError(errors, `${prefix}.methods`, `invalid HTTP method: ${method}`);
+        }
+      }
+    }
+    if (!endpoint.surface) {
+      pushError(errors, `${prefix}.surface`, "required");
+    }
+    if (!isIntegerRisk(endpoint.risk_level)) {
+      pushError(errors, `${prefix}.risk_level`, "must be an integer from 0 through 5");
+    }
+    if (endpoint.mutation !== true) {
+      pushError(errors, `${prefix}.mutation`, "must be true for registry entries");
+    }
+    if (endpoint.allowed_in_readonly_tests !== false) {
+      pushError(
+        errors,
+        `${prefix}.allowed_in_readonly_tests`,
+        "must be false unless a separate allowlist explicitly handles the endpoint",
+      );
+    }
+  });
+
+  return { ok: errors.length === 0, errors, warnings };
+}
+
+function printValidation(result, successMessage) {
+  for (const warning of result.warnings) {
+    console.warn(`warning: ${warning}`);
+  }
+  if (!result.ok) {
+    for (const error of result.errors) {
+      console.error(`error: ${error}`);
+    }
+    return;
+  }
+  console.log(successMessage);
+}
+
+function resolveGitCommand() {
+  if (process.env.GIT_COMMAND) {
+    return process.env.GIT_COMMAND;
+  }
+  if (process.platform !== "win32") {
+    return "git";
+  }
+  const candidates = [
+    String.raw`C:\Program Files\Git\cmd\git.exe`,
+    String.raw`C:\Program Files\Git\bin\git.exe`,
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate)) || "git";
+}
+
+function changedFilesFromGit(baseRef, cwd = process.cwd()) {
+  const diffResult = spawnSync(
+    resolveGitCommand(),
+    ["diff", "--name-only", "--diff-filter=ACMR", "-z", `${baseRef}...HEAD`],
+    {
+      cwd,
+      encoding: "buffer",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  if (diffResult.status !== 0) {
+    throw new Error(diffResult.stderr.toString("utf8").trim() || "git diff failed");
+  }
+
+  const workspaceResult = spawnSync(
+    resolveGitCommand(),
+    ["diff", "--name-only", "--diff-filter=ACMR", "-z", "HEAD"],
+    {
+      cwd,
+      encoding: "buffer",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  if (workspaceResult.status !== 0) {
+    throw new Error(
+      workspaceResult.stderr.toString("utf8").trim() ||
+        "git diff HEAD failed",
+    );
+  }
+
+  const untrackedResult = spawnSync(
+    resolveGitCommand(),
+    ["ls-files", "--others", "--exclude-standard", "-z"],
+    {
+      cwd,
+      encoding: "buffer",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  if (untrackedResult.status !== 0) {
+    throw new Error(
+      untrackedResult.stderr.toString("utf8").trim() ||
+        "git ls-files --others failed",
+    );
+  }
+
+  return Buffer.concat([
+    diffResult.stdout,
+    workspaceResult.stdout,
+    untrackedResult.stdout,
+  ])
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean);
+}
+
+function filesFromArgs(args) {
+  if (args.files) {
+    return String(args.files)
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+  if (args["changed-from"]) {
+    return changedFilesFromGit(args["changed-from"]);
+  }
+  return args._;
+}
+
+function usage() {
+  return `Usage:
+  node ops/scripts/testing-strategy.cjs compute-risk-floor --changed-from origin/main [--json]
+  node ops/scripts/testing-strategy.cjs compute-risk-floor --files app/page.tsx,components/Foo.tsx [--json]
+  node ops/scripts/testing-strategy.cjs validate-manifest --file <file>
+  node ops/scripts/testing-strategy.cjs summarize-manifest --file <file>
+  node ops/scripts/testing-strategy.cjs validate-mutation-registry --file <file>
+`;
+}
+
+async function main(argv = process.argv.slice(2)) {
+  const [command, ...rest] = argv;
+  const args = parseArgs(rest);
+
+  try {
+    switch (command) {
+      case "compute-risk-floor": {
+        const result = classifyChangedFiles(filesFromArgs(args));
+        if (args.json) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Risk floor: ${result.risk_level}`);
+          for (const reason of result.reasons) {
+            console.log(`- ${reason.path}: level-${reason.level} (${reason.rule})`);
+          }
+          for (const modifier of result.modifiers) {
+            console.log(`- modifier ${modifier.name}: ${modifier.reason}`);
+          }
+        }
+        break;
+      }
+      case "validate-manifest": {
+        const result = validateValidationManifest(readJson(args.file));
+        printValidation(result, "Validation manifest is valid.");
+        if (!result.ok) {
+          process.exitCode = 1;
+        }
+        break;
+      }
+      case "summarize-manifest": {
+        console.log(summarizeValidationManifest(readJson(args.file)));
+        break;
+      }
+      case "validate-mutation-registry": {
+        const result = validateMutationRegistry(readJson(args.file));
+        printValidation(result, "Mutation endpoint registry is valid.");
+        if (!result.ok) {
+          process.exitCode = 1;
+        }
+        break;
+      }
+      default:
+        console.log(usage());
+        process.exitCode = command ? 1 : 0;
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  EXISTING_REVIEWBOT_INITIAL_LANES,
+  MUTATION_REGISTRY_SCHEMA_VERSION,
+  VALIDATION_MANIFEST_SCHEMA_VERSION,
+  classifyChangedFiles,
+  inferRouteImpacts,
+  normalizePath,
+  parseArgs,
+  summarizeValidationManifest,
+  validateArtifactPointer,
+  validateMutationRegistry,
+  validateValidationManifest,
+};

--- a/ops/scripts/testing-strategy.cjs
+++ b/ops/scripts/testing-strategy.cjs
@@ -55,6 +55,7 @@ const FALLBACK_RISK_RULE = {
     "Unclassified files default to standard risk so runtime/config changes cannot silently enter the docs fast lane.",
 };
 
+// Rules are intentionally ordered from highest to lowest risk. First match wins.
 const RISK_RULES = [
   {
     level: 5,
@@ -457,13 +458,13 @@ function validateArtifactUri(artifact, prefix, errors) {
     );
   }
 
-  if (lowerUri.startsWith(S3_ARTIFACT_PREFIX)) {
+  if (uri.startsWith(S3_ARTIFACT_PREFIX)) {
     return;
   }
-  if (lowerUri.startsWith(HTTPS_ARTIFACT_PREFIX)) {
+  if (uri.startsWith(HTTPS_ARTIFACT_PREFIX)) {
     return;
   }
-  if (lowerUri.startsWith("ipfs://") || lowerUri.startsWith("ipns://")) {
+  if (uri.startsWith("ipfs://") || uri.startsWith("ipns://")) {
     if (artifact.redaction_status !== "public-redacted") {
       pushError(
         errors,
@@ -618,9 +619,9 @@ function validateValidationManifest(manifest) {
     pushError(errors, "changed_files", "must be an array");
   }
 
-  validateHazards(manifest.hazards || [], errors);
-  validateCommands(manifest.commands || [], errors);
-  validateArtifacts(manifest.artifacts || [], risk.final, errors);
+  validateHazards(manifest.hazards, errors);
+  validateCommands(manifest.commands, errors);
+  validateArtifacts(manifest.artifacts, risk.final, errors);
 
   validateReviewbotLanes(manifest.review, errors);
 

--- a/ops/scripts/testing-strategy.cjs
+++ b/ops/scripts/testing-strategy.cjs
@@ -3,7 +3,6 @@
 
 const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
-const path = require("node:path");
 
 const VALIDATION_MANIFEST_SCHEMA_VERSION =
   "frontend-testing.validation-manifest.v1";

--- a/ops/scripts/testing-strategy.cjs
+++ b/ops/scripts/testing-strategy.cjs
@@ -17,13 +17,8 @@ const EXISTING_REVIEWBOT_INITIAL_LANES = Object.freeze([
   "security",
   "responsiveness",
 ]);
-const ARTIFACT_URI_PREFIXES = [
-  "s3://",
-  "ipfs://",
-  "ipns://",
-  "https://artifacts.6529.io/",
-  "https://6529-artifacts",
-];
+const S3_ARTIFACT_PREFIX = "s3://6529-artifacts/";
+const HTTPS_ARTIFACT_PREFIX = "https://artifacts.6529.io/";
 const ARTIFACT_REDACTION_STATUSES = new Set([
   "verified-redacted",
   "not-sensitive",
@@ -38,6 +33,28 @@ const HTTP_METHODS = new Set([
   "DELETE",
   "OPTIONS",
 ]);
+const ROUTE_FILE_STEMS = new Set([
+  "page",
+  "layout",
+  "template",
+  "loading",
+  "error",
+  "not-found",
+]);
+const ROUTE_FILE_EXTENSIONS = [
+  ".tsx",
+  ".ts",
+  ".jsx",
+  ".js",
+  ".mjs",
+  ".cjs",
+];
+const FALLBACK_RISK_RULE = {
+  level: 2,
+  name: "unclassified-runtime-or-config",
+  reason:
+    "Unclassified files default to standard risk so runtime/config changes cannot silently enter the docs fast lane.",
+};
 
 const RISK_RULES = [
   {
@@ -79,6 +96,9 @@ const RISK_RULES = [
       /^ops\/testing-strategy\//,
       /^package\.json$/,
       /^pnpm-lock\.yaml$/,
+      /^config\//,
+      /^middleware\.(tsx?|jsx?|mjs|cjs)$/,
+      /^instrumentation(?:-[^.]+)?\.(tsx?|jsx?|mjs|cjs)$/,
       /^next\.config\./,
       /^sentry\./,
       /^scripts\/(build|start|dev|run-secure|enforce|require-6529|quality|typecheck)/,
@@ -103,10 +123,15 @@ const RISK_RULES = [
     name: "auth-wallet-upload-admin",
     patterns: [
       /(^|\/)(auth|session|login|logout|oauth|cookie|jwt|token)(\/|\.|$)/,
+      /(^|[\/._-])(auth|session|login|logout|oauth|cookie|jwt|token)([\/._-]|$)/,
       /(^|\/)(wallet|wagmi|viem|ethers|ens)(\/|\.|$)/,
+      /(^|[\/._-])(wallet|wagmi|viem|ethers|ens)([\/._-]|$)/,
       /(^|\/)(profile|identity|tdh|delegation|owner|ownership)(\/|\.|$)/,
+      /(^|[\/._-])(profile|identity|tdh|delegation|owner|ownership)([\/._-]|$)/,
       /(^|\/)(upload|uploads|media|link-preview|open-graph|sanitize|safe-url)(\/|\.|$)/,
+      /(^|[\/._-])(upload|uploads|media|link-preview|open-graph|sanitize|safe-url)([\/._-]|$)/,
       /(^|\/)(waves?|drops?|posting|moderation|admin|vote|delete)(\/|\.|$)/,
+      /(^|[\/._-])(waves?|drops?|posting|moderation|admin|vote|delete)([\/._-]|$)/,
     ],
     reason: "Auth, wallet, upload, posting, moderation, and admin paths are guarded.",
   },
@@ -133,6 +158,7 @@ const RISK_RULES = [
       /^store\//,
       /^helpers\//,
       /^lib\//,
+      /^src\//,
       /^utils\//,
       /^styles\//,
       /^i18n\//,
@@ -207,7 +233,7 @@ function normalizePath(value) {
 
 function displayPath(value) {
   return String(value || "")
-    .replace(/\\/g, "/")
+    .replaceAll("\\", "/")
     .replace(/^\.\//, "")
     .replace(/^\/+/, "");
 }
@@ -218,35 +244,77 @@ function matchesAny(filePath, patterns) {
 
 function ruleForFile(filePath) {
   const normalized = normalizePath(filePath);
-  return (
-    RISK_RULES.find((rule) => matchesAny(normalized, rule.patterns)) ||
-    RISK_RULES[RISK_RULES.length - 1]
+  return RISK_RULES.find((rule) => matchesAny(normalized, rule.patterns)) || FALLBACK_RISK_RULE;
+}
+
+function routeFileStem(fileName) {
+  if (!fileName) {
+    return null;
+  }
+  for (const extension of ROUTE_FILE_EXTENSIONS) {
+    if (fileName.endsWith(extension)) {
+      return fileName.slice(0, -extension.length);
+    }
+  }
+  return null;
+}
+
+function normalizeRouteSegment(segment) {
+  if (segment.startsWith("(") && segment.endsWith(")")) {
+    return null;
+  }
+  if (segment.startsWith("[") && segment.endsWith("]")) {
+    return ":param";
+  }
+  return segment;
+}
+
+function routeFromSegments(segments) {
+  const routeParts = segments.map(normalizeRouteSegment).filter(Boolean);
+  return routeParts.length === 0 ? "/" : `/${routeParts.join("/")}`;
+}
+
+function appRouteImpact(file) {
+  if (!file.startsWith("app/")) {
+    return null;
+  }
+  const parts = file.slice("app/".length).split("/");
+  const stem = routeFileStem(parts.at(-1));
+  if (!ROUTE_FILE_STEMS.has(stem)) {
+    return null;
+  }
+  return routeFromSegments(parts.slice(0, -1));
+}
+
+function pagesRouteImpact(file) {
+  if (!file.startsWith("pages/")) {
+    return null;
+  }
+  const parts = file.slice("pages/".length).split("/");
+  if (parts[0] === "api") {
+    return null;
+  }
+  const stem = routeFileStem(parts.at(-1));
+  if (!stem) {
+    return null;
+  }
+  const routeParts = [...parts.slice(0, -1), stem].filter(
+    (part, index, source) => !(part === "index" && index === source.length - 1),
   );
+  return routeFromSegments(routeParts);
 }
 
 function inferRouteImpacts(files) {
   const routes = new Set();
 
   for (const file of files.map(normalizePath)) {
-    const appMatch = /^app\/(.+)\/(?:page|layout|template|loading|error|not-found)\.(tsx?|jsx?)$/.exec(
-      file,
-    );
-    if (appMatch) {
-      const route = `/${appMatch[1]
-        .replace(/\([^)]*\)\//g, "")
-        .replace(/\/?page$/, "")
-        .replace(/\/index$/, "")
-        .replace(/\[[^\]]+\]/g, ":param")}`;
-      routes.add(route === "/." ? "/" : route);
-    }
-
-    const pagesMatch = /^pages\/(.+)\.(tsx?|jsx?)$/.exec(file);
-    if (pagesMatch && !pagesMatch[1].startsWith("api/")) {
-      routes.add(`/${pagesMatch[1].replace(/\/index$/, "")}`);
+    const route = appRouteImpact(file) || pagesRouteImpact(file);
+    if (route) {
+      routes.add(route);
     }
   }
 
-  return [...routes].sort();
+  return [...routes].sort((left, right) => left.localeCompare(right));
 }
 
 function classifyChangedFiles(files) {
@@ -340,26 +408,7 @@ function validateArtifactPointer(artifact, index) {
   if (!artifact.uri || typeof artifact.uri !== "string") {
     pushError(errors, `${prefix}.uri`, "required");
   } else {
-    const uri = artifact.uri;
-    const lowerUri = uri.toLowerCase();
-    if (
-      lowerUri.startsWith("file://") ||
-      /^[a-z]:[\\/]/i.test(uri) ||
-      lowerUri.includes("git-lfs")
-    ) {
-      pushError(
-        errors,
-        `${prefix}.uri`,
-        "must be a durable artifact pointer, not a local path or Git LFS object",
-      );
-    }
-    if (!ARTIFACT_URI_PREFIXES.some((candidate) => lowerUri.startsWith(candidate))) {
-      pushError(
-        errors,
-        `${prefix}.uri`,
-        `must start with one of ${ARTIFACT_URI_PREFIXES.join(", ")}`,
-      );
-    }
+    validateArtifactUri(artifact, prefix, errors);
   }
 
   if (
@@ -394,6 +443,45 @@ function validateArtifactPointer(artifact, index) {
   return errors;
 }
 
+function validateArtifactUri(artifact, prefix, errors) {
+  const uri = artifact.uri;
+  const lowerUri = uri.toLowerCase();
+  if (
+    lowerUri.startsWith("file://") ||
+    /^[a-z]:[\\/]/i.test(uri) ||
+    lowerUri.includes("git-lfs")
+  ) {
+    pushError(
+      errors,
+      `${prefix}.uri`,
+      "must be a durable artifact pointer, not a local path or Git LFS object",
+    );
+  }
+
+  if (lowerUri.startsWith(S3_ARTIFACT_PREFIX)) {
+    return;
+  }
+  if (lowerUri.startsWith(HTTPS_ARTIFACT_PREFIX)) {
+    return;
+  }
+  if (lowerUri.startsWith("ipfs://") || lowerUri.startsWith("ipns://")) {
+    if (artifact.redaction_status !== "public-redacted") {
+      pushError(
+        errors,
+        `${prefix}.redaction_status`,
+        "must be public-redacted for IPFS/IPNS artifact pointers",
+      );
+    }
+    return;
+  }
+
+  pushError(
+    errors,
+    `${prefix}.uri`,
+    `must start with ${S3_ARTIFACT_PREFIX}, ${HTTPS_ARTIFACT_PREFIX}, ipfs://, or ipns://`,
+  );
+}
+
 function validateReviewbotLanes(review, errors) {
   const lanes = review?.reviewbot?.required_lanes;
   if (!lanes) {
@@ -415,27 +503,7 @@ function validateReviewbotLanes(review, errors) {
   }
 }
 
-function validateValidationManifest(manifest) {
-  const errors = [];
-  const warnings = [];
-
-  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
-    return {
-      ok: false,
-      errors: ["manifest: must be an object"],
-      warnings,
-    };
-  }
-
-  if (manifest.schema_version !== VALIDATION_MANIFEST_SCHEMA_VERSION) {
-    pushError(
-      errors,
-      "schema_version",
-      `must be ${VALIDATION_MANIFEST_SCHEMA_VERSION}`,
-    );
-  }
-
-  const risk = manifest.risk || {};
+function validateRiskSection(risk, errors) {
   for (const field of ["computed_floor", "declared", "final"]) {
     if (!isIntegerRisk(risk[field])) {
       pushError(errors, `risk.${field}`, "must be an integer from 0 through 5");
@@ -461,65 +529,99 @@ function validateValidationManifest(manifest) {
       pushError(errors, "risk.downgrade_approval.expires_at", "required");
     }
   }
+}
 
-  if (!Array.isArray(manifest.changed_files)) {
-    pushError(errors, "changed_files", "must be an array");
-  }
-
-  const hazards = manifest.hazards || [];
+function validateHazards(hazards, errors) {
   if (!Array.isArray(hazards)) {
     pushError(errors, "hazards", "must be an array");
-  } else {
-    hazards.forEach((hazard, index) => {
-      for (const field of [
-        "hazard",
-        "severity",
-        "likelihood",
-        "detection",
-        "required_test",
-        "rollback_or_fix_forward",
-      ]) {
-        if (!hazard?.[field]) {
-          pushError(errors, `hazards[${index}].${field}`, "required");
-        }
-      }
-    });
+    return;
   }
 
-  const commands = manifest.commands || [];
+  hazards.forEach((hazard, index) => {
+    for (const field of [
+      "hazard",
+      "severity",
+      "likelihood",
+      "detection",
+      "required_test",
+      "rollback_or_fix_forward",
+    ]) {
+      if (!hazard?.[field]) {
+        pushError(errors, `hazards[${index}].${field}`, "required");
+      }
+    }
+  });
+}
+
+function validateCommands(commands, errors) {
   if (!Array.isArray(commands)) {
     pushError(errors, "commands", "must be an array");
-  } else {
-    commands.forEach((command, index) => {
-      if (!command?.command) {
-        pushError(errors, `commands[${index}].command`, "required");
-      }
-      if (!COMMAND_STATUSES.has(command?.status)) {
-        pushError(
-          errors,
-          `commands[${index}].status`,
-          `must be one of ${[...COMMAND_STATUSES].join(", ")}`,
-        );
-      }
-    });
+    return;
   }
 
-  const artifacts = manifest.artifacts || [];
+  commands.forEach((command, index) => {
+    if (!command?.command) {
+      pushError(errors, `commands[${index}].command`, "required");
+    }
+    if (!COMMAND_STATUSES.has(command?.status)) {
+      pushError(
+        errors,
+        `commands[${index}].status`,
+        `must be one of ${[...COMMAND_STATUSES].join(", ")}`,
+      );
+    }
+  });
+}
+
+function validateArtifacts(artifacts, finalRisk, errors) {
   if (!Array.isArray(artifacts)) {
     pushError(errors, "artifacts", "must be an array");
-  } else {
-    artifacts.forEach((artifact, index) => {
-      errors.push(...validateArtifactPointer(artifact, index));
-    });
+    return;
   }
 
-  if (isIntegerRisk(risk.final) && risk.final >= 3 && artifacts.length === 0) {
+  artifacts.forEach((artifact, index) => {
+    errors.push(...validateArtifactPointer(artifact, index));
+  });
+
+  if (isIntegerRisk(finalRisk) && finalRisk >= 3 && artifacts.length === 0) {
     pushError(
       errors,
       "artifacts",
       "Level 3+ manifests require at least one validated durable artifact pointer",
     );
   }
+}
+
+function validateValidationManifest(manifest) {
+  const errors = [];
+  const warnings = [];
+
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+    return {
+      ok: false,
+      errors: ["manifest: must be an object"],
+      warnings,
+    };
+  }
+
+  if (manifest.schema_version !== VALIDATION_MANIFEST_SCHEMA_VERSION) {
+    pushError(
+      errors,
+      "schema_version",
+      `must be ${VALIDATION_MANIFEST_SCHEMA_VERSION}`,
+    );
+  }
+
+  const risk = manifest.risk || {};
+  validateRiskSection(risk, errors);
+
+  if (!Array.isArray(manifest.changed_files)) {
+    pushError(errors, "changed_files", "must be an array");
+  }
+
+  validateHazards(manifest.hazards || [], errors);
+  validateCommands(manifest.commands || [], errors);
+  validateArtifacts(manifest.artifacts || [], risk.final, errors);
 
   validateReviewbotLanes(manifest.review, errors);
 
@@ -734,51 +836,61 @@ function usage() {
 `;
 }
 
+function commandComputeRiskFloor(args) {
+  const result = classifyChangedFiles(filesFromArgs(args));
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log(`Risk floor: ${result.risk_level}`);
+  for (const reason of result.reasons) {
+    console.log(`- ${reason.path}: level-${reason.level} (${reason.rule})`);
+  }
+  for (const modifier of result.modifiers) {
+    console.log(`- modifier ${modifier.name}: ${modifier.reason}`);
+  }
+}
+
+function commandValidateManifest(args) {
+  const result = validateValidationManifest(readJson(args.file));
+  printValidation(result, "Validation manifest is valid.");
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+}
+
+function commandSummarizeManifest(args) {
+  console.log(summarizeValidationManifest(readJson(args.file)));
+}
+
+function commandValidateMutationRegistry(args) {
+  const result = validateMutationRegistry(readJson(args.file));
+  printValidation(result, "Mutation endpoint registry is valid.");
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+}
+
+const COMMAND_HANDLERS = {
+  "compute-risk-floor": commandComputeRiskFloor,
+  "validate-manifest": commandValidateManifest,
+  "summarize-manifest": commandSummarizeManifest,
+  "validate-mutation-registry": commandValidateMutationRegistry,
+};
+
 async function main(argv = process.argv.slice(2)) {
   const [command, ...rest] = argv;
   const args = parseArgs(rest);
 
   try {
-    switch (command) {
-      case "compute-risk-floor": {
-        const result = classifyChangedFiles(filesFromArgs(args));
-        if (args.json) {
-          console.log(JSON.stringify(result, null, 2));
-        } else {
-          console.log(`Risk floor: ${result.risk_level}`);
-          for (const reason of result.reasons) {
-            console.log(`- ${reason.path}: level-${reason.level} (${reason.rule})`);
-          }
-          for (const modifier of result.modifiers) {
-            console.log(`- modifier ${modifier.name}: ${modifier.reason}`);
-          }
-        }
-        break;
-      }
-      case "validate-manifest": {
-        const result = validateValidationManifest(readJson(args.file));
-        printValidation(result, "Validation manifest is valid.");
-        if (!result.ok) {
-          process.exitCode = 1;
-        }
-        break;
-      }
-      case "summarize-manifest": {
-        console.log(summarizeValidationManifest(readJson(args.file)));
-        break;
-      }
-      case "validate-mutation-registry": {
-        const result = validateMutationRegistry(readJson(args.file));
-        printValidation(result, "Mutation endpoint registry is valid.");
-        if (!result.ok) {
-          process.exitCode = 1;
-        }
-        break;
-      }
-      default:
-        console.log(usage());
-        process.exitCode = command ? 1 : 0;
+    const handler = COMMAND_HANDLERS[command];
+    if (!handler) {
+      console.log(usage());
+      process.exitCode = command ? 1 : 0;
+      return;
     }
+    await handler(args);
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
     process.exitCode = 1;

--- a/ops/testing-strategy/examples/minimal.validation-manifest.json
+++ b/ops/testing-strategy/examples/minimal.validation-manifest.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": "frontend-testing.validation-manifest.v1",
+  "pr": {
+    "number": null,
+    "branch": "codex/testing-strategy-foundation",
+    "owner": "codex",
+    "verifier": "codex"
+  },
+  "risk": {
+    "computed_floor": 4,
+    "declared": 4,
+    "final": 4,
+    "reasons": [
+      {
+        "path": "ops/scripts/testing-strategy.cjs",
+        "level": 4,
+        "rule": "deployment-or-release-control",
+        "reason": "Operational testing controls affect promotion safety."
+      }
+    ],
+    "downgrade_approval": null
+  },
+  "changed_files": [
+    {
+      "path": "ops/scripts/testing-strategy.cjs",
+      "impact": ["testing-strategy", "release-controls"]
+    }
+  ],
+  "invariants": ["deployment_sha_consistency", "no_secret_leak"],
+  "hazards": [
+    {
+      "hazard": "Risk floor computes too low for guarded surfaces",
+      "severity": "high",
+      "likelihood": "medium",
+      "detection": "focused Jest path-classification tests",
+      "required_test": "seize run test:no-coverage -- __tests__/scripts/testing-strategy.test.ts",
+      "rollback_or_fix_forward": "revert classifier change or add stricter path rule"
+    }
+  ],
+  "commands": [
+    {
+      "command": "seize run test:no-coverage -- __tests__/scripts/testing-strategy.test.ts",
+      "status": "not-run",
+      "evidence": "to be filled by PR owner"
+    }
+  ],
+  "artifacts": [
+    {
+      "kind": "jest-report",
+      "uri": "s3://6529-artifacts/example/frontend-testing/pr0/jest-report.json",
+      "sha256": "example-sha256-fill-with-real-value",
+      "redaction_status": "not-sensitive",
+      "retention_class": "pr-validation",
+      "producing_command": "seize run test:no-coverage -- __tests__/scripts/testing-strategy.test.ts"
+    }
+  ],
+  "review": {
+    "reviewbot": {
+      "required_lanes": [
+        "general",
+        "wcag",
+        "i18n",
+        "security",
+        "responsiveness"
+      ],
+      "status": "pending",
+      "urls": []
+    },
+    "glm_swarm": {
+      "status": "not-run",
+      "urls": []
+    }
+  },
+  "deployment": {
+    "staging": null,
+    "production": null
+  },
+  "exceptions": []
+}

--- a/ops/testing-strategy/mutation-endpoint-registry.json
+++ b/ops/testing-strategy/mutation-endpoint-registry.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "frontend-testing.mutation-endpoint-registry.v1",
+  "owner": "frontend-release-captain",
+  "updated_at": "2026-06-20T00:00:00.000Z",
+  "description": "Versioned registry contract for endpoints that must be blocked by read-only staging and production Playwright mutation guards. PR1 should populate concrete endpoint patterns from the repaired E2E harness.",
+  "endpoints": []
+}

--- a/ops/testing-strategy/mutation-endpoint-registry.v1.schema.json
+++ b/ops/testing-strategy/mutation-endpoint-registry.v1.schema.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://6529.io/schemas/frontend-testing.mutation-endpoint-registry.v1.json",
+  "title": "6529 Frontend Mutation Endpoint Registry",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["schema_version", "owner", "updated_at", "endpoints"],
+  "properties": {
+    "schema_version": {
+      "const": "frontend-testing.mutation-endpoint-registry.v1"
+    },
+    "owner": {
+      "type": "string",
+      "minLength": 1
+    },
+    "updated_at": {
+      "type": "string",
+      "minLength": 1
+    },
+    "endpoints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "id",
+          "pattern",
+          "methods",
+          "surface",
+          "risk_level",
+          "mutation",
+          "allowed_in_readonly_tests"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "pattern": {
+            "type": "string",
+            "minLength": 1
+          },
+          "methods": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "enum": ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+            }
+          },
+          "surface": {
+            "type": "string",
+            "minLength": 1
+          },
+          "risk_level": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 5
+          },
+          "mutation": {
+            "const": true
+          },
+          "allowed_in_readonly_tests": {
+            "const": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/ops/testing-strategy/validation-manifest.v1.schema.json
+++ b/ops/testing-strategy/validation-manifest.v1.schema.json
@@ -149,9 +149,33 @@
               "items": {
                 "type": "string"
               },
-              "contains": {
-                "const": "general"
-              }
+              "allOf": [
+                {
+                  "contains": {
+                    "const": "general"
+                  }
+                },
+                {
+                  "contains": {
+                    "const": "wcag"
+                  }
+                },
+                {
+                  "contains": {
+                    "const": "i18n"
+                  }
+                },
+                {
+                  "contains": {
+                    "const": "security"
+                  }
+                },
+                {
+                  "contains": {
+                    "const": "responsiveness"
+                  }
+                }
+              ]
             }
           }
         }
@@ -181,7 +205,7 @@
         },
         "uri": {
           "type": "string",
-          "minLength": 1
+          "pattern": "^(s3://6529-artifacts/|https://artifacts\\.6529\\.io/|ipfs://|ipns://)"
         },
         "sha256": {
           "type": "string",
@@ -223,6 +247,25 @@
         },
         {
           "required": ["version_id"]
+        }
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "uri": {
+                "pattern": "^(ipfs://|ipns://)"
+              }
+            },
+            "required": ["uri"]
+          },
+          "then": {
+            "properties": {
+              "redaction_status": {
+                "const": "public-redacted"
+              }
+            }
+          }
         }
       ]
     }

--- a/ops/testing-strategy/validation-manifest.v1.schema.json
+++ b/ops/testing-strategy/validation-manifest.v1.schema.json
@@ -1,0 +1,230 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://6529.io/schemas/frontend-testing.validation-manifest.v1.json",
+  "title": "6529 Frontend Validation Manifest",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "risk",
+    "changed_files",
+    "hazards",
+    "commands",
+    "artifacts",
+    "review"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "frontend-testing.validation-manifest.v1"
+    },
+    "risk": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["computed_floor", "declared", "final", "reasons"],
+      "properties": {
+        "computed_floor": {
+          "$ref": "#/$defs/riskLevel"
+        },
+        "declared": {
+          "$ref": "#/$defs/riskLevel"
+        },
+        "final": {
+          "$ref": "#/$defs/riskLevel"
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "downgrade_approval": {
+          "type": ["object", "null"],
+          "additionalProperties": true,
+          "properties": {
+            "approver": {
+              "type": "string",
+              "minLength": 1
+            },
+            "reason": {
+              "type": "string",
+              "minLength": 1
+            },
+            "expires_at": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "changed_files": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["path"],
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "hazards": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "hazard",
+          "severity",
+          "likelihood",
+          "detection",
+          "required_test",
+          "rollback_or_fix_forward"
+        ],
+        "properties": {
+          "hazard": {
+            "type": "string",
+            "minLength": 1
+          },
+          "severity": {
+            "type": "string",
+            "minLength": 1
+          },
+          "likelihood": {
+            "type": "string",
+            "minLength": 1
+          },
+          "detection": {
+            "type": "string",
+            "minLength": 1
+          },
+          "required_test": {
+            "type": "string",
+            "minLength": 1
+          },
+          "rollback_or_fix_forward": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "commands": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["command", "status"],
+        "properties": {
+          "command": {
+            "type": "string",
+            "minLength": 1
+          },
+          "status": {
+            "enum": ["passed", "failed", "skipped", "not-run"]
+          }
+        }
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/artifactPointer"
+      }
+    },
+    "review": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "reviewbot": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "required_lanes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "contains": {
+                "const": "general"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "riskLevel": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 5
+    },
+    "artifactPointer": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "kind",
+        "uri",
+        "redaction_status",
+        "retention_class",
+        "producing_command"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "uri": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "type": "string",
+          "minLength": 1
+        },
+        "cid": {
+          "type": "string",
+          "minLength": 1
+        },
+        "etag": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "redaction_status": {
+          "enum": ["verified-redacted", "not-sensitive", "public-redacted"]
+        },
+        "retention_class": {
+          "type": "string",
+          "minLength": 1
+        },
+        "producing_command": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "anyOf": [
+        {
+          "required": ["sha256"]
+        },
+        {
+          "required": ["cid"]
+        },
+        {
+          "required": ["etag"]
+        },
+        {
+          "required": ["version_id"]
+        }
+      ]
+    }
+  }
+}

--- a/ops/workstreams/frontend-a11y-i18n/README.md
+++ b/ops/workstreams/frontend-a11y-i18n/README.md
@@ -13,7 +13,13 @@ page surfaces one PR at a time.
 3. `ops/skills/write-prs/SKILL.md`
 4. `ops/standards/README.md`
 5. `active-context.md`
-6. `run-log.md`
+6. `stack-audit.md`
+7. `audit-inventory.md`
+8. `combined-plan.md`
+9. `testing-improvement-plan.md`
+10. `mega-run-pr-playbook.md`
+11. `continuous-swarm-engine-notes.md`
+12. `run-log.md`
 
 ## Owned Paths
 
@@ -35,10 +41,20 @@ page surfaces one PR at a time.
 Every PR must record:
 
 - changed surface
+- pre-PR functionality, UX, safety, web, Mobile/Capacitor, and
+  Electron/Desktop Shell impact assessment
+- local testing strategy created before opening the PR
+- selected test packs from `testing-improvement-plan.md`
 - validation commands
-- browser or manual UI checks when visible behavior changes
+- Playwright browser checks when visible behavior changes
+- keyboard, focus, mobile, locale, and native-shell fallback decisions where
+  relevant
 - bot feedback decisions
 - remaining risks or exceptions
+
+Future self-organizing queue and Codex worker orchestration ideas live in
+`continuous-swarm-engine-notes.md`. They should not expand the immediate testing
+sidequest unless explicitly promoted into implementation work.
 
 ## Escalation Triggers
 

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -1,13 +1,128 @@
 # Active Context
 
+## Resume First
+
+Read this section first after compaction or handoff.
+
+- Latest rollout state, 2026-06-19T23:10Z:
+  - `6529reviewbot` PR #399 is merged and live on reviewbot `main`:
+    https://github.com/6529-Collections/6529reviewbot/pull/399
+    - merge SHA: `db1fced6105af2a975965c5604a79d578fe5080b`
+    - adds deterministic, frontend-scoped i18n/WCAG review leads and trusted
+      base-ref policy context for `6529seize-frontend` reviews.
+  - `6529seize-frontend` PR #2789 is merged:
+    https://github.com/6529-Collections/6529seize-frontend/pull/2789
+    - merge SHA: `7c966099173d3610b34a40ff989cea41340a6637`
+    - `.github/6529bot.yml` now runs initial reviews:
+      `general, wcag, i18n, security, responsiveness`.
+  - The frontend deployment train containing PR #2788 and PR #2789 reached
+    production successfully:
+    - staging run: https://github.com/6529-Collections/6529seize-frontend/actions/runs/27851212528
+    - staging SHA: `15504066aa5cee0c2bfaca69022fbdbf7da72590`
+    - production run: https://github.com/6529-Collections/6529seize-frontend/actions/runs/27851738857
+    - production SHA: `7c966099173d3610b34a40ff989cea41340a6637`
+  - Production browser smoke passed for `/`, `/about/the-memes`, and
+    `/the-memes` on `https://6529.io`. Non-fatal 403s were limited to current
+    CloudFront media renditions for one drop video; pages returned 200 and
+    rendered expected content.
+  - Public notes are posted:
+    - release note:
+      https://6529.io/waves/05b14183-e153-4e47-bc66-42a0f49102d4?drop=b3df3435-2bae-4a7f-b9c2-5d93feb7b524
+    - Follow The Repo deployment note:
+      https://6529.io/waves/49f0e595-ec7c-4235-8695-a527f61b69f4?drop=f8edf3f7-4255-4889-8a24-0a8a2e8cc469
+  - `seize run test:e2e:staging` is still blocked by the existing harness
+    problem `Cannot find module '../testHelpers'`; direct authenticated browser
+    smoke against staging passed instead.
+- 2026-06-20 user direction: update the plan for the actual frontend WCAG/i18n
+  mega run now that reviewbot is live. Reviewbot is an additional reviewer and
+  regression detector only; it does not replace extensive local validation.
+- 2026-06-20 user direction: each page or page-cluster PR needs an explicit
+  functionality, UX, safety, web, Mobile/Capacitor, and Electron/Desktop Shell
+  impact assessment plus a local testing strategy before opening the PR. Use
+  `mega-run-pr-playbook.md`.
+- 2026-06-20 user direction: pause to design a world-class testing improvement
+  sidequest before scaling agentic page-cluster work. Use
+  `testing-improvement-plan.md`; reviewbot is still only a second reviewer.
+- Current mission changed on 2026-06-19: autonomously carry the combined
+  accessibility, i18n, and reviewbot plan from PR #2788 through implementation
+  trains, staging, production, and validation, using subagents when useful.
+- PR #2788 is already merged into `main`:
+  - PR: https://github.com/6529-Collections/6529seize-frontend/pull/2788
+  - head: `127ae232ce047781ec5b4e79831f9749808f14a3`
+  - merge commit: `9bc89b3b4b9f8f17e9ccb7a216aec1320a131b9f`
+  - merged at: `2026-06-19T21:44:39Z`
+- User explicitly authorized autonomous merge/deploy work through production,
+  without permission prompts, and specifically asked to merge/deploy
+  `6529reviewbot` changes first so review bots can review later PRs.
+- Deployment authority: `ops/skills/deploy-6529/SKILL.md`. This file was
+  absent in this local dirty branch, but exists on `origin/main`; reload with:
+  `git show origin/main:ops/skills/deploy-6529/SKILL.md`.
+- Local branch at mission start: `codex/polish-boosted-link-cards`, local HEAD
+  `6c048340a`, with many dirty changes across tests, app, components, docs,
+  skills, and workstream files. Preserve unrelated user/agent changes.
+- Use local Windows wrappers: prefer `seize` for frontend package commands in
+  this Codex shell, and `seize-local-dev` for local env/port setup.
+- Historical reviewbot and PR #2788 investigations are complete; reviewbot and
+  frontend config are live.
+- User clarification: the core deliverable is to decide and implement the
+  i18n and WCAG review bots in `6529reviewbot` so they automatically run on
+  `6529seize-frontend` PRs. Do not treat arbitrary unrelated open reviewbot PRs
+  as the prerequisite.
+- For future `6529seize-frontend` patches, base work on current merged GitHub
+  `origin/main` in a clean worktree, not this dirty local branch.
+
 ## Current Goal
 
-Deliver the standards and repo-local skill foundation, then start review-ready
-page migration PRs for safe media surfaces.
+The 2026-06-19 reviewbot/config deployment train is complete in production.
+Current planning goal is the testing sidequest for the frontend WCAG/i18n mega
+run: repair and harden local, CI, Playwright, WCAG, i18n, security-sensitive,
+surface-matrix, staging, and production validation before scaling page-cluster
+work.
+
+The testing sidequest now has a coherent strategy document:
+`testing-improvement-plan.md` is titled `Frontend Testing And Release Strategy`.
+It integrates the safety-case model, 6529.io web-app speed lanes, Google-style
+`@small`/`@medium`/`@large` test sizing, CI execution ladder, release reports,
+auto-hold/canary direction, artifact storage, reviewbot/GLM swarm, and PRR-lite
+for Level 4-5 work.
+
+Opus 4.8 second review on 2026-06-20 identified four foundation controls that
+must be executable before scaling page-cluster remediation: deterministic
+risk-floor classifier, staging/production request-interception mutation guard,
+artifact redaction pipeline with fake-secret regression test, and explicit
+Level 3+ blocking or temporary manual-validation exception until Playwright
+harness plus deployment evidence gates are green.
+
+GPT 5.5 Pro feedback on 2026-06-20 added an important calibration: keep the
+immediate strategy focused on testing, but treat Codex/reviewbot/swarms as
+high-recall hypothesis generators. Their default role is to feed Codex another
+iteration, not take decision authority away from the agent. Hard promotion
+blocks should be rare and reserved for deterministic, reproducible
+disaster-class invariant violations or missing required safety evidence for a
+train. Codex plus review bots should be allowed to cycle until they stop adding
+useful findings or safe patches; safe auto-merge can start with narrow classes
+once deterministic gates pass.
+
+Future self-organizing queue work is parked in
+`continuous-swarm-engine-notes.md`. Do not expand the immediate testing
+sidequest into a queue/worker/CCR implementation unless explicitly asked.
+
+Apply the strategy as a web-app speed model, not Bitcoin-Core-style release
+gravity. Use fast lanes for low-risk docs/tests/copy/style changes, standard
+lanes for page/workflow changes, guarded lanes for auth, wallet, upload,
+posting, admin, generated API, shared data fetching, and deploy-sensitive
+changes, and release-captain lanes for production-risk, irreversible-data,
+credentials, signing/funds, identity, or deploy-control changes.
+
+Every non-trivial PR needs risk level, hazard analysis, validation manifest,
+traceable test/review/deploy evidence, and stop-the-line handling. Durable
+validation artifacts must live on 6529-controlled infrastructure such as private
+S3, pinned IPFS, or a future artifact service. Do not use Git LFS or committed
+generated artifacts as the durable evidence store.
 
 ## Current Branch
 
-`codex/user-followers-modal-a11y-i18n`
+`codex/user-about-edit-a11y-i18n`
 
 ## Constraints
 
@@ -19,9 +134,31 @@ page migration PRs for safe media surfaces.
 - Use `6529` wrapper commands for project checks.
 - Use signed commits with the configured Git identity.
 - Merge only the standards PR when bot-happy and branch protection allows.
-- Do not merge page implementation PRs.
+- Page implementation PRs may now be merged only as part of the mega run after
+  they are reconciled with current `origin/main`, locally validated,
+  reviewbot-happy, and assigned to a deployment train.
+- Level 3+ implementation PRs require independent verifier signoff before
+  merge; Level 4+ trains require a named release captain and post-deploy watch.
+- No PR joins a deployment train without a validation manifest and durable
+  artifact pointers for required retained evidence.
+- Foundation work should start with the strategy's PR 0 and PR 1: manifest and
+  artifact schema, then Playwright harness repair plus test-size taxonomy.
+- PR 0 now means executable safety controls and manifest schema: risk-floor
+  classifier, risk downgrade approval fields, redaction contract, mutation-guard
+  contract, artifact schema validation, mutation endpoint registry, and
+  stop-the-line states.
+- PR 1 now means Playwright harness repair plus request-interception mutation
+  guard, artifact redaction hook, fake-secret redaction regression test, and
+  test-size taxonomy.
+- Level 3+ page-cluster work is blocked until PR 1 and PR 5 gates are green,
+  unless a release captain records a temporary manual-validation exception.
+- Level 0-1 fast-lane PRs should use minimal manifests and avoid full train
+  ceremony unless they affect runtime/deploy/high-risk surfaces.
 
-## Defaults
+## Historical Stack Snapshot
+
+The PR statuses below are historical context from the pre-reviewbot rollout.
+Re-audit each PR against current `origin/main` before merging or deploying it.
 
 - WCAG target: WCAG 2.2 AA.
 - Source locale: `en-US`.
@@ -47,21 +184,65 @@ page migration PRs for safe media surfaces.
   covers profile shell tab titles, beta badge text, navigation landmark labels,
   scroll button labels, and active-page semantics. It is stacked from PR #2639
   and must not be merged.
-- PR #2641 is open and review-ready only. It covers the profile followers modal
-  title, follower list label, loading status, follower profile link names,
+- PR #2641 is bot-happy on the latest head and remains review-ready only. It
+  covers the profile followers modal title, follower list label, loading
+  status, nullable follower handle fallback, follower profile link names,
   avatar alt text, and semantic list structure. It is stacked from PR #2640 and
   must not be merged.
+- PR #2642 is bot-happy on the latest head and remains review-ready only. It
+  covers the user profile header stats row labels, accessible names, and
+  follower-count formatting. It is stacked from PR #2641 and must not be
+  merged.
+- PR #2643 is bot-happy on the latest head and remains review-ready only. It
+  covers the user profile header identity/name/media labels, profile-enabled
+  date formatting, and read-only wrapper semantics. It is stacked from PR #2642
+  and must not be merged.
+- PR #2644 is bot-happy on the latest head and remains review-ready only. It
+  covers the user profile header About statement placeholder, add/edit controls,
+  mobile expand/collapse toggle, and nested-interactive-control cleanup. It is
+  stacked from PR #2643 and must not be merged.
+- PR #2645 is open and review-ready only. It covers the user profile About edit
+  form labels, placeholder, character count, actions, success toast, moderation
+  errors, alert semantics, and error-dismiss name. It is stacked from PR #2644
+  and must not be merged.
 - Non-source locales currently fall back to `en-US` until reviewed
   translations are added.
 - Full locale-prefixed routing is deferred.
+- 2026-06-13 stack audit: PR #2604 and PRs #2607-#2645 are open, non-draft,
+  mergeable, and green on the visible GitHub check rollup.
+- Related-looking open PR #2597 is older OG metadata work, not part of this
+  WCAG/i18n stack.
+- Open PR #2632 is separate 6529bot admin dashboard work, not part of this
+  WCAG/i18n stack.
+- 2026-06-14 bottom-stack pass: PR #2604 received a passive scroll listener
+  hardening commit (`23d119e`) and local validation/browser smoke passed.
+  GitHub's visible latest-head rollup is green and a validation snapshot was
+  posted on the PR. CodeRabbit's new incremental review was rate-limited, but
+  prior actionable CodeRabbit findings are already fixed in the current code.
+- 2026-06-14 audit inventory: `audit-inventory.md` records candidate hotspots
+  for static copy, interaction semantics, locale formatting, image alt review,
+  and i18n helper adoption.
 
 ## Next Actions
 
-1. Iterate on PR #2641 with available bots/checks without
-   merging.
-2. Keep PR #2641 review-ready only; do not merge.
-3. Keep PR #2640 review-ready only; do not merge.
-4. Maintain PRs #2639, #2638, #2637, and earlier page PRs as review-ready only;
-   do not merge.
-5. Preserve the unrelated dirty EmojiContext, RememeImage test, and bootstrap
+1. Publish and iterate the strategy foundation PR 0 from
+   `codex/testing-strategy-foundation`. Current PR 0 contents include
+   `ops/scripts/testing-strategy.cjs`, validation manifest schemas/examples,
+   mutation endpoint registry contract, package wrapper, and focused Jest
+   coverage. Preserve the existing `.github/6529bot.yml` lanes unchanged.
+2. Implement PR 1: repair `tests/testHelpers.ts`, local/staging Playwright
+   smoke, and `@small`/`@medium`/`@large` test sizing.
+3. Reconcile the existing PR stack from current `origin/main` before opening
+   broad new implementation PRs.
+4. For every implementation PR, complete the `mega-run-pr-playbook.md` pre-PR
+   impact/testing plan before opening the PR.
+5. For every implementation PR, assign a risk level, write hazard analysis,
+   create the validation manifest, and select durable artifact storage before
+   opening the PR.
+6. For every implementation PR, run extensive local validation first; treat the
+   live `wcag` and `i18n` reviewbot lanes as additional review, not a local-test
+   substitute.
+7. Group only green, locally validated, reviewbot-happy PRs into deployment
+   trains.
+8. Preserve the unrelated dirty EmojiContext, RememeImage test, and bootstrap
    style files.

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -88,10 +88,13 @@ for Level 4-5 work.
 
 Opus 4.8 second review on 2026-06-20 identified four foundation controls that
 must be executable before scaling page-cluster remediation: deterministic
-risk-floor classifier, staging/production request-interception mutation guard,
-artifact redaction pipeline with fake-secret regression test, and explicit
-Level 3+ blocking or temporary manual-validation exception until Playwright
-harness plus deployment evidence gates are green.
+risk-floor classifier (`testing-improvement-plan.md` section
+`PR 0: Executable Safety Controls And Manifest Schema`), staging/production
+request-interception mutation guard (`PR 1: Test Harness Repair And Test
+Sizing`), artifact redaction pipeline with fake-secret regression test (`PR 1:
+Test Harness Repair And Test Sizing`), and explicit Level 3+ blocking or
+temporary manual-validation exception until Playwright harness plus deployment
+evidence gates are green (`Safety Case And Validation Manifest`).
 
 GPT 5.5 Pro feedback on 2026-06-20 added an important calibration: keep the
 immediate strategy focused on testing, but treat Codex/reviewbot/swarms as

--- a/ops/workstreams/frontend-a11y-i18n/combined-plan.md
+++ b/ops/workstreams/frontend-a11y-i18n/combined-plan.md
@@ -7,6 +7,22 @@ new PR review-bot enforcement. It covers the main Next.js website, mobile web
 surfaces, standalone/exported surfaces, and future reviewbot rules that prevent
 new accessibility or localization regressions while the migration proceeds.
 
+## Current State As Of 2026-06-20
+
+- The reviewbot prerequisite is complete and live:
+  - `6529reviewbot` PR #399 is merged at
+    `db1fced6105af2a975965c5604a79d578fe5080b`.
+  - `6529seize-frontend` PR #2789 is merged at
+    `7c966099173d3610b34a40ff989cea41340a6637`.
+  - Frontend PRs now automatically run `general`, `wcag`, `i18n`, `security`,
+    and `responsiveness` review lanes.
+- PR #2788 delivered this combined plan and is live in production.
+- The remaining mission is the actual frontend WCAG/i18n mega run: rebase,
+  re-audit, merge, deploy, and validate frontend remediation PRs with the new
+  reviewbot as a second reviewer.
+- Future frontend implementation should use clean worktrees based on current
+  `origin/main`; do not base patches on older local dirty branches.
+
 ## Source Standards
 
 - Accessibility baseline: `ops/standards/frontend-accessibility-wcag-22-aa.md`.
@@ -63,14 +79,13 @@ new accessibility or localization regressions while the migration proceeds.
 
 ### Reviewbot Surfaces
 
-- The reviewbot implementation repository, once available in the workspace or
-  as a linked checkout.
+- The reviewbot implementation repository for maintenance and tuning only; the
+  first i18n/WCAG rollout is already live.
 - Frontend reviewbot dashboards and docs already tracked by
   `ops/workstreams/reviewbot-production-manager/` when reviewbot API or
   dashboard behavior changes.
-- New i18n and WCAG review-bot rule packs should be integrated with the
-  reviewbot's existing event, findings, commenting, and check-run model after
-  architecture review.
+- Future i18n and WCAG rule-pack changes should preserve the reviewbot's
+  existing event, diff, prompt, commenting, and check-run model.
 
 ## Workstream Artifacts
 
@@ -83,15 +98,29 @@ Maintain the following files in this workstream:
 - `pr-links.md`: related PRs, branches, and status.
 - `bot-decisions.md`: CI and review-bot findings with fix/defer decisions.
 - `combined-plan.md`: this combined migration and bot-enforcement plan.
+- `testing-improvement-plan.md`: testing sidequest plan required before
+  scaling page-cluster remediation PRs.
+- `mega-run-pr-playbook.md`: required pre-PR impact/testing plan and PR
+  description templates for each page cluster.
+- `continuous-swarm-engine-notes.md`: future self-organizing queue, Codex
+  worker wrapper, conflict resolver, and auto-PR architecture notes. This is
+  not part of the immediate testing sidequest unless explicitly promoted.
 
 Add these files when the next implementation phase needs them:
 
 - `exceptions.md`: accepted i18n and WCAG deferrals.
 - `qa-matrix.md`: route-by-route browser, keyboard, locale, mobile, and
   standalone verification matrix.
-- `bot-rules/i18n-rules.md`: i18n review-bot rule definitions.
-- `bot-rules/wcag-rules.md`: accessibility review-bot rule definitions.
-- `bot-rules/severity-model.md`: severity, confidence, and blocking criteria.
+- `mega-run-status.md`: PR train, validation, deployment, and residual-debt
+  ledger for the actual frontend remediation run.
+- `deployment-trains.md`: staging and production train composition, SHAs, and
+  smoke evidence.
+- `bot-rules/i18n-rules.md`: optional durable i18n rule documentation when
+  changing the already-live reviewbot implementation.
+- `bot-rules/wcag-rules.md`: optional durable accessibility rule documentation
+  when changing the already-live reviewbot implementation.
+- `bot-rules/severity-model.md`: optional severity, confidence, and blocking
+  criteria documentation for future bot hardening.
 
 ## Migration Status Model
 
@@ -120,6 +149,8 @@ Use these labels for each route/component/surface:
 5. Preserve unrelated user or agent changes. Do not widen scope to unrelated
    generated files, dependency changes, auth/security behavior, or deployment
    behavior without explicit need.
+6. Treat the live i18n/WCAG reviewbot as a required second reviewer for every
+   implementation PR in the mega run.
 
 ## Phase 1: Shared I18n Foundation
 
@@ -215,6 +246,15 @@ For each route or component slice:
 
 ## Phase 5: Automation And Quality Gates
 
+Current live guardrail:
+
+- `6529reviewbot` PR #399 added frontend-scoped i18n and WCAG changed-line
+  leads plus trusted base-ref policy context.
+- Frontend PR #2789 enabled automatic initial `wcag` and `i18n` review lanes
+  alongside `general`, `security`, and `responsiveness`.
+- The mega run should assume those bots are available on every frontend PR and
+  should fix or explicitly defer their findings before merge.
+
 Add or strengthen static checks for:
 
 - new hardcoded JSX text in migrated areas;
@@ -234,37 +274,29 @@ Prefer deterministic AST or ESLint-style findings before LLM review. Use LLMs
 for context, explanation, suggested remediation, and manual-check prompts rather
 than for ungrounded line comments.
 
-## Phase 6: Dedicated I18n And WCAG Review Bots
+## Phase 6: I18n And WCAG Reviewbot Guardrail
 
-### Bot Strategy
+Status: complete for the first rollout; maintain and tune during the mega run.
 
-Build two specialized review bots on the shared reviewbot infrastructure:
+The implemented strategy uses the shared `6529reviewbot` infrastructure with
+specialized `i18n` and `wcag` review kinds. They share event handling, diff
+acquisition, prompt construction, commenting, check-run behavior, budgeting, and
+deployment, while keeping separate frontend policy context and changed-line
+review leads.
 
-1. `6529-i18n-reviewbot`
-2. `6529-wcag-reviewbot`
+### Live Reviewbot Capabilities
 
-They may share event handling, diff parsing, findings storage, comments, and
-check-run publishing, but should have separate rule packs, prompts, severity
-rubrics, labels, and rollout gates.
-
-### Reviewbot Repo Prerequisite
-
-Before implementation, inspect the `6529reviewbot` repository in its actual
-checkout and document:
-
-- webhook or polling event model;
-- PR diff acquisition path;
-- findings schema;
-- check-run/status publishing;
-- inline comment support;
-- retry/idempotency behavior;
-- cost, rate-limit, and token-budget controls;
-- test harness and fixture conventions;
-- deployment and rollout process;
-- current frontend dashboard/API contract impacts.
-
-If the repo is not available locally, record that limitation and do not invent
-architecture-specific details.
+- The bot reads trusted frontend policy context from the PR base ref, not the
+  PR head.
+- It scans changed lines for high-signal i18n and WCAG leads and asks the model
+  to verify them rather than blindly commenting.
+- It covers likely hardcoded JSX text, hardcoded accessible names, direct locale
+  formatting, sentence concatenation, invalid locale ids, clickable
+  non-interactive elements, unlabeled form controls, icon-only controls, dialog
+  focus issues, focus-outline removal, and autofocus risks.
+- It skips test and fixture paths for these frontend policy hints.
+- It keeps public comments grounded in changed files and avoids treating legacy
+  untouched debt as a new PR blocker.
 
 ### Shared Bot Finding Schema
 
@@ -340,23 +372,25 @@ Non-goals:
 
 ### Bot Review Modes
 
-1. `advisory-summary`: post summary only; no inline comments; no blocking.
-2. `inline-advisory`: line comments for high-confidence findings; no blocking.
-3. `soft-blocking`: required check only for invalid bot config, bot runtime
-   errors, missing source keys, or clear new blockers.
-4. `migrated-path-blocking`: block high-confidence violations only in surfaces
-   marked migrated or in newly touched UI where standards apply.
+1. Current mode: advisory review with required check execution and human/agent
+   fix-forward discipline.
+2. During the mega run, treat every actionable i18n/WCAG finding as a merge
+   gate unless it is clearly a false positive or an accepted exception.
+3. Escalate to blocking mode only after false-positive rates are understood on
+   migrated paths.
 
 ### Bot Rollout Sequence
 
-1. Review `6529reviewbot` architecture and add no-op i18n/WCAG reviewers.
-2. Add deterministic i18n scanner and fixture tests.
-3. Add deterministic WCAG scanner and fixture tests.
-4. Add LLM explanation layer that only comments on diff-backed findings.
-5. Add frontend repo config and workstream exception/status integration.
-6. Enable advisory mode on frontend PRs.
-7. Tune false positives.
-8. Enable blocking only for migrated paths and high-confidence new regressions.
+1. Done: review `6529reviewbot` architecture.
+2. Done: add deterministic i18n changed-line leads and fixture tests.
+3. Done: add deterministic WCAG changed-line leads and fixture tests.
+4. Done: add LLM explanation layer that uses diff-backed findings as review
+   leads.
+5. Done: add frontend repo config and automatic advisory rollout.
+6. Active during mega run: tune false positives and missing leads from real PR
+   feedback.
+7. Future: enable blocking only for migrated paths and high-confidence new
+   regressions after the advisory data is strong enough.
 
 ### Bot Comment Style
 
@@ -382,6 +416,11 @@ Comments should be short, actionable, and grounded in the changed line:
 - Track costs, token usage, retries, and duplicate comments.
 
 ## Phase 7: Validation Matrix
+
+The reviewbot is an additional reviewer and regression detector. It does not
+replace local testing. Every implementation PR still needs focused local
+validation before merge, and every deployment train still needs staging and
+production verification.
 
 ### Docs-Only Or Workstream-Only PRs
 
@@ -470,12 +509,138 @@ behavior.
 
 ### Reviewbot PRs
 
-1. Reviewbot architecture discovery and no-op reviewers.
-2. I18n deterministic scanner.
-3. WCAG deterministic scanner.
-4. LLM explanation layer.
+Completed:
+
+1. Reviewbot architecture discovery.
+2. I18n deterministic changed-line leads.
+3. WCAG deterministic changed-line leads.
+4. LLM explanation layer with trusted base-ref frontend policy context.
 5. Frontend repo config and advisory rollout.
-6. Blocking rollout for migrated paths.
+
+Future only:
+
+1. False-positive tuning from real mega-run PRs.
+2. More deterministic coverage where the live bot misses repeated issue
+   patterns.
+3. Blocking rollout for migrated paths after advisory behavior is proven.
+
+## Phase 9: Mega Run Execution
+
+This is the active next phase. The goal is to move from planning and guardrails
+to actual frontend WCAG/i18n remediation, reviewed by the now-live bots and
+deployed through controlled trains.
+
+### Mega Run Rules
+
+1. Start every implementation branch from current `origin/main` in a clean
+   worktree.
+2. Preserve unrelated dirty local changes in the long-lived workspace.
+3. Re-review existing WCAG/i18n implementation PRs before merging; do not assume
+   older green checks are still valid after main has moved.
+4. Complete the `mega-run-pr-playbook.md` pre-PR impact and testing plan for
+   each page or page cluster before opening the PR.
+5. Require the automatic `general`, `wcag`, `i18n`, `security`, and
+   `responsiveness` bot lanes to complete on every PR.
+6. Treat actionable i18n/WCAG bot comments as required fixes unless the finding
+   is a clear false positive or an exception is recorded.
+7. Run extensive local validation before relying on reviewbot output:
+   changed-file lint/typecheck/checks, targeted Jest, real browser smoke,
+   keyboard/focus checks, mobile viewport checks, and locale formatting checks
+   appropriate to the touched surface.
+8. Keep PRs reviewable by route family, primitive, or tightly related workflow;
+   group only green PRs into deployment trains.
+9. Deploy every train to staging first, validate staging, then promote the same
+   release set from `origin/main` to production.
+10. Record validation, train membership, SHAs, bot decisions, and remaining debt
+   in this workstream.
+
+### Existing Stack Reconciliation
+
+The existing open WCAG/i18n stack should be reconciled before creating broad new
+surface PRs:
+
+1. Fetch and inventory all open PRs listed in `pr-links.md`,
+   `stack-audit.md`, and `active-context.md`.
+2. For each PR, decide whether to:
+   - rebase/update it directly;
+   - rebuild the same slice from current `origin/main`;
+   - split it because the diff grew too large;
+   - close/supersede it because main already contains the work or the approach
+     is stale.
+3. Re-run focused local checks after each update.
+4. Trigger or wait for the live reviewbot lanes.
+5. Fix all real bot findings before merge.
+
+Start with the bottom of the existing stack, then advance upward. If a lower PR
+is stale or too tangled, rebuild that slice from `origin/main` rather than
+dragging stale stacked history forward.
+
+### Suggested Deployment Trains
+
+Train composition must be confirmed from current diffs and check status before
+merge. Initial target grouping:
+
+1. Foundation and low-risk shared helpers.
+2. Public media read paths: The Memes, Meme Lab, Rememes, distribution,
+   activity, and related metadata/read-only surfaces.
+3. Profile read paths and profile shell: tabs, followers, header stats,
+   identity, About display, and About edit.
+4. App shell and navigation primitives.
+5. Waves/messages shell and composer.
+6. Forms, dialogs, popovers, menus, toasts, and status patterns.
+7. Complex workflows: delegation, Network/TDH dashboards, Drop Forge, NextGen,
+   EMMA, admin-like flows, and mint paths.
+8. Mobile-specific, zoom, reduced-motion, safe-area, and standalone/exported
+   passes.
+
+Do not ship a train because it is large. Ship a train only when each member PR
+is green, reviewbot-happy, locally validated, and coherent to roll back or
+fix-forward.
+
+### Per-PR Loop
+
+1. Identify the route/component slice and user impact.
+2. Read nearby code, tests, route docs, standards, and existing helper patterns.
+3. Complete the playbook impact assessment for functionality, UX, safety, web,
+   Mobile/Capacitor, and Electron/Desktop Shell.
+4. Design the local testing strategy before opening the PR.
+5. Implement i18n and WCAG fixes together for touched UI.
+6. Add or update focused tests.
+7. Run changed-file lint/typecheck/checks plus targeted Jest.
+8. Use real browser verification for visible UI, including keyboard and mobile
+   checks where relevant.
+9. Open or update the PR with the full playbook PR description template.
+10. Wait for all 6529bot lanes and external checks.
+11. Fix real findings; record false positives or exceptions.
+12. Merge only after the PR is green and train-ready.
+
+### Per-Train Loop
+
+1. Confirm no overlapping staging or production deploys.
+2. Merge selected green PRs to `main`.
+3. Create a staging train from the exact release set and deploy to
+   `1a-staging`.
+4. Validate staging with route-specific browser smoke, keyboard smoke, and
+   locale checks.
+5. Promote from `origin/main` only after staging passes and main has not moved
+   unexpectedly.
+6. Validate production with workflow checks and independent browser smoke.
+7. Post public release/deployment notes when user-facing behavior changes.
+8. Update workstream memory before continuing to the next train.
+
+### Mega Run Completion Criteria
+
+The mega run is complete when:
+
+- prioritized route families have either `complete` or `exception-recorded`
+  status;
+- the existing stale PR stack has been merged, superseded, or closed;
+- no known new WCAG/i18n regressions remain in touched UI;
+- the live reviewbot is tuned for repeated real findings discovered during the
+  run;
+- staging and production validation evidence exists for every deployment train;
+- public release notes describe user-facing changes without exposing internal
+  secrets or local paths.
 
 ## Stop Conditions
 
@@ -491,8 +656,8 @@ Pause autonomous implementation and request human/product review when:
   secret-handling behavior might change;
 - generated files, lockfiles, package metadata, docs, or environment behavior
   change unexpectedly;
-- reviewbot architecture is unavailable but implementation would require
-  architecture-specific assumptions.
+- the live reviewbot reports repeated false positives that would block safe
+  progress without tuning.
 
 ## Definition Of Done
 
@@ -514,5 +679,5 @@ A surface is done when:
 - standalone/exported behavior is verified where applicable;
 - automated checks pass or limitations are documented;
 - remaining debt has an exception with owner/follow-up/remediation path;
-- i18n and WCAG review bots, once available, are green or findings are fixed or
-  explicitly deferred with rationale.
+- i18n and WCAG reviewbot lanes are green, or findings are fixed or explicitly
+  deferred with rationale.

--- a/ops/workstreams/frontend-a11y-i18n/combined-plan.md
+++ b/ops/workstreams/frontend-a11y-i18n/combined-plan.md
@@ -533,20 +533,25 @@ deployed through controlled trains.
 ### Mega Run Rules
 
 1. Start every implementation branch from current `origin/main` in a clean
-   worktree.
-2. Preserve unrelated dirty local changes in the long-lived workspace.
+   worktree (`testing-improvement-plan.md` section `Pull Request Workflow`).
+2. Preserve unrelated dirty local changes in the long-lived workspace
+   (`active-context.md` section `Constraints`).
 3. Re-review existing WCAG/i18n implementation PRs before merging; do not assume
    older green checks are still valid after main has moved.
 4. Complete the `mega-run-pr-playbook.md` pre-PR impact and testing plan for
-   each page or page cluster before opening the PR.
+   each page or page cluster before opening the PR (`mega-run-pr-playbook.md`
+   section `Required Order`).
 5. Require the automatic `general`, `wcag`, `i18n`, `security`, and
-   `responsiveness` bot lanes to complete on every PR.
+   `responsiveness` bot lanes to complete on every PR
+   (`testing-improvement-plan.md` section `Reviewbot And GLM Swarm`).
 6. Treat actionable i18n/WCAG bot comments as required fixes unless the finding
-   is a clear false positive or an exception is recorded.
+   is a clear false positive or an exception is recorded
+   (`testing-improvement-plan.md` section `Reviewbot And GLM Swarm`).
 7. Run extensive local validation before relying on reviewbot output:
    changed-file lint/typecheck/checks, targeted Jest, real browser smoke,
    keyboard/focus checks, mobile viewport checks, and locale formatting checks
-   appropriate to the touched surface.
+   appropriate to the touched surface (`testing-improvement-plan.md` section
+   `Execution Ladder`).
 8. Keep PRs reviewable by route family, primitive, or tightly related workflow;
    group only green PRs into deployment trains.
 9. Deploy every train to staging first, validate staging, then promote the same

--- a/ops/workstreams/frontend-a11y-i18n/continuous-swarm-engine-notes.md
+++ b/ops/workstreams/frontend-a11y-i18n/continuous-swarm-engine-notes.md
@@ -1,0 +1,92 @@
+# Continuous Swarm Engine Notes
+
+Status: future architecture note, not part of the immediate testing sidequest.
+Date: 2026-06-20.
+
+## Purpose
+
+Capture the future self-organizing queue idea without expanding the current
+frontend testing strategy beyond its immediate goal. The near-term work remains:
+fix local/CI/Playwright/reviewbot/deploy testing so the WCAG/i18n mega run can
+move faster and safer.
+
+The future direction is a 24/7 autonomous engineering system where Codex and
+review bots cycle together until they stop adding useful findings or safe
+patches. Review bots and tests feed Codex; they do not outrank Codex unless
+they produce deterministic disaster-class evidence. A small invariant gate
+controls merge and promotion safety.
+
+## Core Idea
+
+Codex is an execution worker, not a queue consumer by itself. A production swarm
+system needs orchestration around Codex:
+
+- a router that creates typed jobs;
+- a queue that stores work;
+- Codex workers that execute one bounded job at a time;
+- analysis workers that produce findings;
+- a conflict resolver that deduplicates and stabilizes findings;
+- an invariant gate that decides what can merge;
+- an artifact/state graph that records evidence, patches, and outcomes.
+
+## Authority Model
+
+Swarms generate hypotheses. Codex decides how to iterate on them. Invariants
+decide the rare promotion-blocking truth.
+
+Promotion-blocking authority should stay small and deterministic:
+
+- auth/session correctness;
+- wallet/signing correctness;
+- destructive action safety;
+- secret and artifact leakage;
+- deployment SHA consistency;
+- required Level 3+ evidence presence.
+
+Everything else is advisory, an auto-fix candidate, or logged noise unless it
+maps to a disaster-class hard invariant violation with reproducible evidence.
+
+## Future Components
+
+- Swarm Router: chooses which jobs run, how deep the fan-out goes, and what cost
+  budget applies.
+- Job Queue: stores typed work such as `wcag_fix`, `i18n_fix`,
+  `test_generation`, `playwright_stabilize`, `security_probe`, and
+  `ui_refactor`.
+- Codex Worker Wrapper: checks out a target SHA, builds a constrained prompt,
+  asks Codex for a patch, stores artifacts, and emits results.
+- Analysis Workers: GLM/reviewbot/scanner/Playwright jobs that produce
+  structured findings only.
+- Conflict Resolver: deduplicates findings, resolves contradictions by
+  invariant precedence and reproducibility, detects oscillation, and suppresses
+  low-confidence noise.
+- Mutation Engine: converts stable findings into patch PRs.
+- Invariant Gate: minimal hard truth layer for merge/promotion.
+- Artifact And State Graph: maps PRs, jobs, findings, patches, artifacts,
+  invariant results, and merge decisions.
+
+## Initial PR Classes
+
+- Safe auto-PR candidates: docs, test scaffolding, i18n dictionary-only fixes,
+  constrained accessible-name/label fixes with passing tests.
+- Guarded PRs: UI behavior, routing, shared components, layout changes, and
+  non-trivial WCAG/i18n migrations.
+- Critical PRs: auth, wallet, upload, posting, moderation/admin, deploy,
+  credentials, irreversible data, and security-critical surfaces.
+
+Auto-merge should start narrower than auto-PR creation. Layout and UI behavior
+fixes may be generated automatically, but should not auto-merge until browser
+and visual evidence are trustworthy enough to avoid oscillation.
+
+## Later Design Questions
+
+- Queue backend: Redis, SQS, Postgres jobs, or another durable queue.
+- State graph backend and schema.
+- Codex worker invocation model and isolation.
+- Prompt builder format for each job type.
+- Cost throttling by job class and risk level.
+- Conflict resolver algorithm and confidence calibration.
+- Oscillation detection for repeated fix/break loops.
+- GitHub PR creation, update, close, and merge automation.
+- How to safely auto-merge safe classes after Codex plus review bots stop
+  adding value.

--- a/ops/workstreams/frontend-a11y-i18n/mega-run-pr-playbook.md
+++ b/ops/workstreams/frontend-a11y-i18n/mega-run-pr-playbook.md
@@ -1,0 +1,240 @@
+# Mega Run PR Playbook
+
+Use this playbook for every page or cluster of pages in the frontend WCAG/i18n
+mega run. The reviewbot is an additional reviewer, not a substitute for local
+engineering judgment, local testing, or browser verification.
+
+## Required Order
+
+1. Define the page cluster and affected workflows.
+2. Complete the pre-PR impact and testing plan before opening the PR.
+3. Implement the changes in a clean worktree based on current `origin/main`.
+4. Run the planned local validation, including Playwright where UI behavior is
+   visible or cross-surface behavior matters.
+5. Open the PR with the full PR description template below.
+6. Wait for `general`, `wcag`, `i18n`, `security`, and `responsiveness`
+   reviewbot lanes plus external checks.
+7. Fix real findings, document false positives or accepted exceptions, then
+   assign the PR to a deployment train.
+
+## Local Environment Standard
+
+Keep a strong local environment for the whole mega run:
+
+- Bootstrap each frontend worktree with `seize-local-dev bootstrap`.
+- Use the shared local backend, MySQL, and Redis services unless the page
+  cluster explicitly requires backend ownership.
+- Use the local wrapper for project commands in Windows Codex shells:
+  `seize run <script>`, `seize exec playwright test`, and `seize-local-dev
+  start-frontend`.
+- Prefer focused checks first, then broaden when the change touches shared
+  primitives, routing, config, or build-sensitive code.
+- Use Playwright for real browser verification. Curl or status-only checks are
+  not enough for UI changes because they miss hydration, focus, layout,
+  JavaScript, and runtime errors.
+- Capture enough Playwright evidence to prove the changed workflows work on the
+  relevant surfaces. Screenshots are required when visual layout changes.
+- Record all known local-environment gaps, such as unavailable native shells or
+  known broken staging harnesses.
+
+## Surface Matrix
+
+For every page cluster, assess all three surfaces. If a surface is not relevant,
+say why.
+
+| Surface | Required questions | Minimum local validation |
+| --- | --- | --- |
+| Web | What desktop and mobile web routes, auth states, loading states, URL params, metadata, and navigation paths can change? | Desktop and mobile Playwright smoke for changed routes; keyboard/focus checks; console/page-error review; route docs review. |
+| Mobile/Capacitor | Does the change affect app shell, deep links, safe areas, keyboard behavior, push/share/upload flows, scanner, hidden desktop-only controls, or Capacitor-only branches? | Mobile viewport Playwright checks; user-agent or runtime-flag simulation where practical; virtual keyboard and safe-area review when forms or fixed UI are touched. |
+| Electron/Desktop Shell | Does the change affect share/deep-link flows, desktop app connection handoff, hidden Electron branches, external links, storage, window sizing, or desktop-only controls? | Browser checks for Electron-gated UI branches where simulation exists; route docs/code review for shell-specific branches; explicit residual risk if native Electron cannot be run locally. |
+
+## Pre-PR Impact And Testing Plan Template
+
+Complete this before opening the PR. Keep it in the PR body, and optionally copy
+it into `mega-run-status.md` when the cluster is large.
+
+```md
+## Migration Context
+
+This PR is part of the frontend WCAG 2.2 AA and i18n migration mega run. It
+keeps visible copy, accessible names, locale-sensitive formatting, semantic
+interaction, keyboard/focus behavior, mobile behavior, and native-shell-adjacent
+surfaces aligned with the frontend accessibility and localization standards.
+
+## Page Cluster
+
+- Routes/pages:
+- Components/primitives:
+- User workflows:
+- Auth/data states:
+- Related docs/tests:
+
+## Change Intent
+
+- WCAG goals:
+- I18n goals:
+- Non-goals:
+- Existing debt intentionally left:
+
+## Functionality Impact
+
+- User-visible behavior that should remain unchanged:
+- Behavior intentionally changed:
+- Data fetching, caching, routing, URL params, metadata, or state risks:
+- Backward compatibility risks:
+
+## UX Impact
+
+- Layout, responsive, wrapping, overflow, or density risks:
+- Focus order and visible focus risks:
+- Loading, empty, error, disabled, selected, and validation states:
+- Copy, labels, names, and long-text risks:
+
+## Safety And Security Impact
+
+- Auth, wallet, transaction, signing, admin, moderation, upload, or privacy risks:
+- External links, media, embeds, markdown, or user-generated content risks:
+- Secret, token, local path, prompt, or private-data exposure risks:
+- Abuse, spoofing, phishing, or accessibility dark-pattern risks:
+
+## Surface Assessment
+
+- Web:
+  - Relevant? yes/no:
+  - Why:
+  - Test plan:
+- Mobile/Capacitor:
+  - Relevant? yes/no:
+  - Why:
+  - Test plan:
+- Electron/Desktop Shell:
+  - Relevant? yes/no:
+  - Why:
+  - Test plan:
+
+## Local Testing Strategy
+
+- Unit/component tests:
+- Lint/typecheck/check commands:
+- Playwright routes and viewports:
+- Keyboard/focus checks:
+- Screen-reader or accessibility tree smoke:
+- Locale checks (`en-US`, `en-GB`, `fr-FR`, `es-ES`, `de-DE`):
+- Mobile/Capacitor simulation:
+- Electron simulation or code-review fallback:
+- Screenshots/videos to capture:
+- Known local test limitations:
+```
+
+## PR Description Template
+
+Use this structure when opening the PR. Keep it concrete enough for reviewers,
+reviewbot, and future deployment agents to understand the blast radius.
+
+```md
+## Migration Context
+
+This PR is part of the frontend WCAG 2.2 AA and i18n migration mega run.
+
+- Accessibility standard: `ops/standards/frontend-accessibility-wcag-22-aa.md`
+- I18n standard: `ops/standards/frontend-i18n-localization.md`
+- Reviewbot role: additional i18n/WCAG reviewer; not a substitute for local
+  validation.
+- Testing posture: local validation first, reviewbot second, deployment
+  validation last.
+
+## Summary
+
+-
+-
+-
+
+## Page Cluster And Workflows
+
+- Routes/pages:
+- Components/primitives:
+- Main user workflows:
+- Auth/data states covered:
+
+## WCAG Changes
+
+-
+-
+-
+
+## I18n Changes
+
+-
+-
+-
+
+## Functionality And UX Impact
+
+- Expected behavior preserved:
+- Intentional behavior changes:
+- Layout/responsive/focus/copy risks considered:
+- Existing debt or exceptions:
+
+## Surface Impact
+
+| Surface | Impact | Validation |
+| --- | --- | --- |
+| Web |  |  |
+| Mobile/Capacitor |  |  |
+| Electron/Desktop Shell |  |  |
+
+## Safety And Security Review
+
+- Auth/wallet/admin/transaction impact:
+- Upload/media/embed/user-generated content impact:
+- Secret/private-data exposure review:
+- Abuse/spoofing/phishing considerations:
+
+## Local Validation
+
+- [ ] `seize run lint:changed`
+- [ ] `seize run typecheck:changed`
+- [ ] `seize run check:changed` or documented focused substitute
+- [ ] Targeted Jest/component tests:
+- [ ] Playwright desktop routes:
+- [ ] Playwright mobile routes:
+- [ ] Keyboard/focus checks:
+- [ ] Locale checks:
+- [ ] Screenshots/videos attached or described when visual behavior changed
+
+## Reviewbot And External Checks
+
+- 6529bot `general`:
+- 6529bot `wcag`:
+- 6529bot `i18n`:
+- 6529bot `security`:
+- 6529bot `responsiveness`:
+- CodeRabbit/Sonar/Snyk/CodeQL/DCO:
+- Findings fixed:
+- Findings deferred or false-positive rationale:
+
+## Deployment Train Notes
+
+- Suggested train:
+- Rollback/fix-forward considerations:
+- Staging smoke routes:
+- Production smoke routes:
+```
+
+## Playwright Expectations
+
+For visible UI changes, use Playwright to verify the actual rendered app:
+
+- desktop viewport for primary workflows;
+- 390px or equivalent mobile viewport for responsive behavior;
+- keyboard-only interaction for focusable controls;
+- relevant locale query or state for i18n surfaces;
+- loading, empty, error, selected, disabled, and validation states when
+  reachable locally;
+- console error and page error collection;
+- screenshots for layout, visual, focus, overflow, and responsive changes.
+
+When native Capacitor or Electron runtime cannot be exercised locally, document
+the unavailable native capability, simulate the closest web/runtime flag path
+where practical, and inspect the native-gated branch in code. Do not silently
+mark native behavior verified from ordinary desktop web smoke alone.

--- a/ops/workstreams/frontend-a11y-i18n/mega-run-pr-playbook.md
+++ b/ops/workstreams/frontend-a11y-i18n/mega-run-pr-playbook.md
@@ -24,9 +24,10 @@ Keep a strong local environment for the whole mega run:
 - Bootstrap each frontend worktree with `seize-local-dev bootstrap`.
 - Use the shared local backend, MySQL, and Redis services unless the page
   cluster explicitly requires backend ownership.
-- Use the local wrapper for project commands in Windows Codex shells:
-  `seize run <script>`, `seize exec playwright test`, and `seize-local-dev
-  start-frontend`.
+- Use the repo command model. On this Windows Codex host, AGENTS.md documents
+  the local helpers: `seize run <script>`, `seize exec playwright test`, and
+  `seize-local-dev start-frontend`. In other repo environments, use the
+  equivalent repo `6529` wrapper command.
 - Prefer focused checks first, then broaden when the change touches shared
   primitives, routing, config, or build-sensitive code.
 - Use Playwright for real browser verification. Curl or status-only checks are
@@ -124,6 +125,24 @@ surfaces aligned with the frontend accessibility and localization standards.
 - Electron simulation or code-review fallback:
 - Screenshots/videos to capture:
 - Known local test limitations:
+
+## Risk Assessment
+
+- Computed risk floor:
+- Declared risk level:
+- Final risk level:
+- Downgrade approval, if any:
+- Hazard analysis:
+  - hazard -> severity -> likelihood -> detection -> required test -> rollback
+    or fix-forward:
+
+## Validation And Artifacts
+
+- Validation manifest path:
+- Durable artifact storage plan:
+- Artifact redaction strategy for secrets, local paths, prompts, and private
+  data:
+- Reviewbot lanes expected:
 ```
 
 ## PR Description Template
@@ -190,6 +209,15 @@ This PR is part of the frontend WCAG 2.2 AA and i18n migration mega run.
 - Secret/private-data exposure review:
 - Abuse/spoofing/phishing considerations:
 
+## Risk And Validation
+
+- Computed risk floor:
+- Declared/final risk level:
+- Hazard analysis summary:
+- Validation manifest:
+- Durable artifact pointers:
+- Artifact redaction status:
+
 ## Local Validation
 
 - [ ] `seize run lint:changed`
@@ -225,6 +253,24 @@ This PR is part of the frontend WCAG 2.2 AA and i18n migration mega run.
 
 For visible UI changes, use Playwright to verify the actual rendered app:
 
+### Evidence Labels
+
+Use these labels from `testing-improvement-plan.md` section `Surface Evidence`
+when documenting Playwright results:
+
+- `simulated`: browser-driven approximation, such as desktop Chromium, mobile
+  viewport, Capacitor flag simulation, or Electron user-agent simulation.
+- `shell-smoke`: app launched in an actual native or desktop shell with basic
+  route and interaction checks.
+- `real-device`: app checked on a real mobile device, emulator, simulator, or
+  desktop shell that exercises the target runtime.
+- `production-observed`: read-only validation against production for the exact
+  deployed version.
+
+For a page-cluster PR, desktop web and mobile viewport Playwright are normally
+`simulated`. Capacitor and Electron browser approximations are also
+`simulated` until PR 4 adds stronger native-adjacent integration.
+
 - desktop viewport for primary workflows;
 - 390px or equivalent mobile viewport for responsive behavior;
 - keyboard-only interaction for focusable controls;
@@ -235,6 +281,6 @@ For visible UI changes, use Playwright to verify the actual rendered app:
 - screenshots for layout, visual, focus, overflow, and responsive changes.
 
 When native Capacitor or Electron runtime cannot be exercised locally, document
-the unavailable native capability, simulate the closest web/runtime flag path
-where practical, and inspect the native-gated branch in code. Do not silently
-mark native behavior verified from ordinary desktop web smoke alone.
+the unavailable native capability with the evidence label used. Do not use
+`shell-smoke` or `real-device` when only `simulated` browser Playwright was run.
+Inspect the native-gated branch in code and record the residual risk.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1071,29 +1071,501 @@
   responses unrelated to the followers modal change.
 - Opened review-ready stacked PR #2641 against PR #2640. Per workstream policy,
   do not merge PR #2641.
-- Recorded `/about/tech` and `/about/tech/[reportSlug]` fallback debt while
-  addressing PR #2719 bot feedback: the report index/detail count chrome now
-  uses source-locale messages and `formatInteger`, and the not-found metadata
-  fallback is message-backed. Remaining debt is the broader tech-report chrome
-  and editorial report data (`dateLabel`, `publishedAt`, repo focus summaries,
-  and markdown report bodies), which intentionally stays `en-US` until the
-  About Tech shelf gets a full localization pass.
-- Recorded brain left-sidebar waves filter fallback debt while addressing PR
-  #2778 bot feedback: `WavesFilterToggle`, `UnifiedWavesList`, and
-  `WebUnifiedWavesList` now use source-locale message keys for the All/Joined
-  labels, filter group name, and joined empty state, but the sidebar has no
-  viewer-locale source yet and therefore falls back to `en-US`. Non-English
-  viewers may see English sidebar filter copy until locale is threaded through
-  the brain sidebar shell; owner is the frontend a11y/i18n workstream, and the
-  remediation path is to pass the resolved app locale into the brain sidebar
-  components before translating this surface.
-- Recorded Discover/explore wave-card fallback debt while addressing PR #2782
-  bot feedback: `ExploreWaveCard` card copy, drops count text, image alt text,
-  link accessible names, and the inlined compact score/hotness/REP metrics now
-  use source-locale messages and locale-aware integer/compact-number formatting.
-  The metric row derives its visible chips and link accessible-name suffix from
-  the same `ExploreWaveMetric` data. The surface still resolves through
-  `DEFAULT_LOCALE` until the active locale can be threaded through the
-  Discover/home explore grids. User impact: non-English users continue to see
-  English labels on this card surface. Follow-up owner: frontend i18n migration
-  workstream.
+- Fixed a PR #2641 typecheck issue for followers without handles by falling
+  back to the follower's primary address for profile routes and accessible
+  labels. Validation passed for the focused followers/i18n Jest suites,
+  targeted ESLint, `typecheck:changed`, `react-doctor:diff`, `git diff
+  --check`, and desktop/mobile browser smoke on `/punk6529`.
+- Confirmed PR #2641 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed, CodeRabbit passed with no review threads, and Claude
+  remained configured for manual review only. Per workstream policy, do not
+  merge PR #2641.
+- Started stacked branch `codex/user-header-stats-a11y-i18n` from PR #2641 for
+  the next low-risk user profile header follow-up.
+- Implemented message-backed source-locale labels and accessible names for the
+  profile header stats row. The TDH, xTDH, NIC, Rep, and follower controls now
+  expose explicit action labels that include the handle and current values, and
+  follower counts use the repo i18n integer formatting helper.
+- Validation passed for the stats-row follow-up so far: focused stats/i18n Jest
+  suites (3 suites, 8 tests), targeted ESLint for the touched source files,
+  `typecheck:changed`, `react-doctor:diff`, `git diff --check`, Next MCP
+  runtime diagnostics, and desktop/mobile browser smoke on `/punk6529`. React
+  Doctor still reports only the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic.
+- Opened review-ready stacked PR #2642 against PR #2641. Per workstream policy,
+  do not merge PR #2642.
+- Confirmed PR #2642 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed with 0 new issues and 0.0% duplication, CodeRabbit manual
+  review passed with no actionable comments and no review threads, and Claude
+  remained configured for manual review only. CodeRabbit's generic docstring
+  coverage warning was deferred because the touched helpers are self-explanatory
+  and repo style avoids low-value comments. Per workstream policy, do not merge
+  PR #2642.
+- Started stacked branch `codex/user-header-identity-a11y-i18n` from PR #2642
+  for the next low-risk profile header follow-up.
+- Implemented message-backed source-locale labels for the profile header name
+  edit action, profile picture alt/edit labels, banner edit label, and
+  profile-enabled date line. Removed disabled edit buttons from read-only name
+  and profile-picture wrappers so the public profile header uses plain
+  non-interactive containers when editing is unavailable. The profile-enabled
+  month/year now uses the repo i18n date formatting helper.
+- Validation passed for the header identity/media follow-up so far: focused
+  header/i18n Jest suites (6 suites, 18 tests), targeted ESLint for touched
+  source files, `typecheck:changed`, `react-doctor:diff`, `git diff --check`,
+  Next MCP runtime diagnostics, and desktop/mobile browser smoke on `/punk6529`.
+  React Doctor still reports the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic and a test-only `next/image` mock warning.
+- Opened review-ready stacked PR #2643 against PR #2642. Per workstream policy,
+  do not merge PR #2643.
+- Fixed PR #2643 bot feedback: SonarCloud reported accessibility findings in
+  test mocks, so the affected mocks now use semantic buttons and a
+  `next/image` mock with explicit alt text. CodeRabbit requested direct profile
+  header helper coverage and single-source profile label derivation for the
+  banner; added focused helper assertions and threaded the client-computed
+  `profileLabel` into `UserPageHeaderBanner`.
+- Validation after the PR #2643 bot-feedback fixes passed for the focused
+  header/i18n Jest suites (6 suites, 19 tests), targeted ESLint for touched
+  source files, `typecheck:changed`, `react-doctor:diff`, and `git diff
+  --check`. React Doctor still reports only the unrelated dirty
+  `contexts/EmojiContext.tsx` fetch-in-effect diagnostic.
+- Confirmed PR #2643 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed with 0 new issues, CodeRabbit manual review passed, no
+  review threads are open, and Claude remained configured for manual review
+  only. Per workstream policy, do not merge PR #2643.
+- Started stacked branch `codex/user-header-about-a11y-i18n` from PR #2643 for
+  the next low-risk profile header follow-up.
+- Implemented message-backed source-locale labels for the profile header About
+  placeholder, add/edit actions, and mobile expand/collapse control. Split the
+  existing statement edit affordance so long statements can keep their own
+  expand button without being nested inside a parent edit button. The public
+  read-only profile continues to render no hidden About edit controls.
+- Validation passed for the About statement follow-up so far: focused about/i18n
+  Jest suites (3 suites, 10 tests), targeted ESLint for touched source files,
+  `typecheck:changed`, `react-doctor:diff`, `git diff --check`, Next MCP runtime
+  diagnostics, and desktop/mobile browser smoke on `/punk6529`. React Doctor
+  still reports only the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic; the local browser console still shows known shared
+  API/emoji resource errors.
+- Opened review-ready stacked PR #2644 against PR #2643. Per workstream policy,
+  do not merge PR #2644.
+- Confirmed PR #2644 is bot-happy on the latest head: DCO passed, Snyk passed,
+  SonarCloud passed with 0 new issues, CodeRabbit manual review passed, no
+  review threads are open, and Claude remained configured for manual review
+  only. Per workstream policy, do not merge PR #2644.
+- Started stacked branch `codex/user-about-edit-a11y-i18n` from PR #2644 for the
+  next adjacent profile About follow-up.
+- Implemented message-backed source-locale labels for the profile About edit
+  form textarea, placeholder, character count, cancel/save controls, success
+  toast, moderation error copy, unknown-error title, and error-dismiss action.
+  The moderation error container now uses `role="alert"` so errors are announced.
+- Validation passed for the About edit-form follow-up so far: focused edit
+  form/error/i18n Jest suites (3 suites, 7 tests), targeted ESLint for touched
+  source files, `typecheck:changed`, `react-doctor:diff`, `git diff --check`,
+  Next MCP runtime diagnostics, and desktop browser smoke on `/punk6529`. React
+  Doctor still reports only the unrelated dirty `contexts/EmojiContext.tsx`
+  fetch-in-effect diagnostic; the local browser console still shows known shared
+  API/emoji resource errors.
+- Opened review-ready stacked PR #2645 against PR #2644. Per workstream policy,
+  do not merge PR #2645.
+
+## 2026-06-13
+
+- Audited the open WCAG/i18n PR stack after user concern about the number of
+  related PRs. Confirmed PR #2604 and PRs #2607-#2645 are expected workstream
+  implementation PRs, are open, non-draft, mergeable, and green on the visible
+  GitHub check rollup. Recorded the stack snapshot in `stack-audit.md`.
+- Confirmed related-looking PR #2597 is older OG metadata work and PR #2632 is
+  separate 6529bot admin dashboard work; neither is part of this WCAG/i18n
+  migration stack.
+- Updated active context to pause new page PR creation until the current stack
+  is reviewed or a new scope is chosen.
+
+## 2026-06-14
+
+- Rechecked the bottom of the WCAG/i18n stack and used a clean temp worktree for
+  PR #2604.
+- Pushed signed hardening commit `23d119e` to PR #2604, making the The Memes
+  scroll listener passive.
+- Validation passed for PR #2604: changed-file lint, changed-file typecheck,
+  targeted The Memes card and i18n Jest suites, React Doctor PR-diff review,
+  `git diff --check`, and desktop/mobile browser smoke on
+  `/the-memes?locale=de-DE`.
+- Browser smoke used a local-only Bootstrap import fix that is already present
+  on current `main`; this verification-only tweak was not committed to #2604.
+- Confirmed stale CodeRabbit findings on #2604 are already handled in current
+  code: localized document title, case-insensitive locale normalization, and
+  exhaustive enum label guards.
+- Recorded the latest CodeRabbit caveat: the visible status context is green,
+  but the new incremental review was rate-limited, so treat new bot review as
+  unavailable until the limit resets.
+- Rechecked PR #2604 after CodeQL completed. The latest visible GitHub rollup
+  passed for head `23d119e`: CodeQL, DCO, SonarCloud, Snyk, and CodeRabbit
+  status context.
+- Posted a PR validation snapshot comment documenting the local checks, browser
+  smoke, green rollup, and CodeRabbit rate-limit caveat.
+- Added `audit-inventory.md` with candidate hotspots for static copy,
+  interaction semantics, locale formatting, image alt review, and i18n helper
+  adoption to guide the next safe stack.
+# 2026-06-19 Autonomous Production Rollout
+
+## 2026-06-19T21:49Z Mission Start
+
+- User requested autonomous overnight implementation and deployment of the
+  combined accessibility, i18n, and reviewbot plan, including production
+  rollout and fix-forward responsibility.
+- Loaded `ops/skills/6529-autonomous-manager/SKILL.md`.
+- Loaded deployment authority from `origin/main` because local dirty branch does
+  not currently contain `ops/skills/deploy-6529/SKILL.md`:
+  `git show origin/main:ops/skills/deploy-6529/SKILL.md`.
+- Loaded GitHub plugin skills for PR orientation, review comments, and CI
+  inspection.
+- Initialized Next.js DevTools MCP for the frontend repo worktree.
+- Created persistent Codex goal for this rollout.
+- Fetched remotes. `origin/main` is `9bc89b3b4b9f8f17e9ccb7a216aec1320a131b9f`.
+- Confirmed PR #2788 is merged:
+  - URL: https://github.com/6529-Collections/6529seize-frontend/pull/2788
+  - title: `Add combined accessibility, i18n, and reviewbot plan`
+  - head: `127ae232ce047781ec5b4e79831f9749808f14a3`
+  - merge commit: `9bc89b3b4b9f8f17e9ccb7a216aec1320a131b9f`
+  - checks: DCO, CodeQL, CodeRabbit, SonarCloud, Snyk green/neutral as expected
+  - 6529bot i18n/general/security reviews: no blocking findings.
+- Started read-only subagents:
+  - `Harvey` (`019ee1dd-6a7d-72e2-9475-b6139e90f108`): map
+    6529reviewbot-related PR/branch/deploy state.
+  - `Lovelace` (`019ee1dd-9304-75f1-bfc7-644bd0068833`): audit PR #2788 state,
+    checks, comments, risk, and validation needs.
+
+## Next
+
+1. Check active staging and production deployment lanes.
+2. Determine whether `9bc89b3b` is deployed to staging and production.
+3. If not, deploy `origin/main` through staging first, run staging validation,
+   then promote the same current `origin/main` SHA to production.
+4. Use reviewbot findings on subsequent implementation PRs once reviewbot is
+   confirmed live.
+
+## 2026-06-19T21:55Z Frontend Staging Start
+
+- Active staging lane check: no in-progress `deploy-staging.yml` run before
+  push.
+- Active production lane check: no in-progress `build-upload-deploy-prod.yml`
+  run before push.
+- Release set since last production deploy `52f3b1e5...`: exactly PR #2788,
+  docs-only, one new file.
+- Created a clean release worktree for the PR 2788 deployment lane.
+- Created signed staging merge commit:
+  `cbefed0ac379d7bd17bd51d4c9b0213d387cab5c`.
+- Pushed fast-forward to `origin/1a-staging`, triggering staging deploy:
+  https://github.com/6529-Collections/6529seize-frontend/actions/runs/27850097993
+- Production remains held until staging passes and current `origin/main` is
+  still `9bc89b3b4b9f8f17e9ccb7a216aec1320a131b9f`.
+
+## 2026-06-19T21:56Z Reviewbot Prerequisite Delegation
+
+- Frontend-side reviewbot enablement already merged before PR #2788:
+  - #2646 `Enable 6529bot reviewer config`
+  - #2710 `Enable responsiveness 6529bot review`
+  - #2716 `Enable automatic i18n 6529bot review`
+  - #2605/#2632/#2652 dashboard/admin/cost surfaces
+- PR #2788 itself received live `6529bot` i18n, general, and security reviews.
+- Central repo `6529-Collections/6529reviewbot` has open PR #397:
+  `Page usage events for admin summaries`.
+- Delegated central reviewbot merge/deploy lane to worker agent
+  `019ee1e1-6171-73a0-bd0c-458cebf23a36`. Worker owns only the reviewbot
+  repository; frontend production promotion remains held until reviewbot
+  prerequisite status is clear.
+
+## 2026-06-19T22:00Z User Clarification
+
+- User clarified the intended reviewbot prerequisite: decide and implement the
+  i18n and WCAG review bots in `6529reviewbot`, then make them automatically
+  run on `6529seize-frontend` PRs.
+- Redirected reviewbot worker away from unrelated PR #397 merge/deploy unless
+  directly needed for the new bot deliverable.
+- User also clarified frontend patches should match current merged GitHub
+  `main`. Future frontend edits will use a clean `origin/main` worktree rather
+  than the dirty local integration branch.
+
+## 2026-06-19T23:10Z Reviewbot And Frontend Config Live
+
+- Implemented and merged `6529reviewbot` PR #399:
+  https://github.com/6529-Collections/6529reviewbot/pull/399
+  - merge SHA: `db1fced6105af2a975965c5604a79d578fe5080b`
+  - strengthened `review:i18n` and `review:wcag` by adding deterministic,
+    frontend-scoped review leads for locale formatting, hardcoded accessible
+    copy, hardcoded JSX text, sentence concatenation, invalid locale ids,
+    clickable non-interactive elements, unlabeled form controls, icon-only
+    buttons, dialog focus, focus-outline removal, and autofocus.
+  - added trusted base-ref policy context from frontend standards/skills so PR
+    heads cannot alter their own review instructions.
+  - fixed the diff parser so legitimate added lines such as `++index;` are
+    retained while file headers are ignored.
+  - verification passed: `npm test`, `npm run check`, `codex-diff-check`,
+    CodeRabbit, 6529bot follow-up reviews, and an independent subagent review.
+- Implemented and merged frontend PR #2789:
+  https://github.com/6529-Collections/6529seize-frontend/pull/2789
+  - merge SHA: `7c966099173d3610b34a40ff989cea41340a6637`
+  - `.github/6529bot.yml` now automatically runs initial review lanes:
+    `general, wcag, i18n, security, responsiveness`.
+  - `limits.maxJobsPerDelivery` increased to `5` to allow all initial lanes to
+    run in one delivery.
+  - reviewbot config validator passed.
+  - PR checks passed: CodeQL, CodeRabbit, DCO, SonarCloud, Snyk.
+  - manual `/6529bot review wcag i18n` on #2789 confirmed the deployed
+    reviewbot worker at `db1fced6105af2a975965c5604a79d578fe5080b` completed
+    clean WCAG and i18n reviews.
+
+## 2026-06-19T23:11Z Deployment Train Complete
+
+- Release train:
+  - PR #2788 combined accessibility/i18n/reviewbot plan, merge SHA
+    `9bc89b3b4b9f8f17e9ccb7a216aec1320a131b9f`.
+  - PR #2789 frontend automatic WCAG reviewbot config, merge SHA
+    `7c966099173d3610b34a40ff989cea41340a6637`.
+- Staging:
+  - created signed staging merge commit
+    `15504066aa5cee0c2bfaca69022fbdbf7da72590`.
+  - pushed to `origin/1a-staging`.
+  - staging deploy passed:
+    https://github.com/6529-Collections/6529seize-frontend/actions/runs/27851212528
+  - `seize run test:e2e:staging` remains blocked by the existing harness error
+    `Cannot find module '../testHelpers'` from staging Playwright specs.
+  - direct authenticated Playwright smoke passed on staging for `/`,
+    `/about/the-memes`, and `/the-memes`.
+- Production:
+  - confirmed no overlapping production deploy and that `origin/main` was still
+    `7c966099173d3610b34a40ff989cea41340a6637` before production mutation.
+  - production deploy passed:
+    https://github.com/6529-Collections/6529seize-frontend/actions/runs/27851738857
+  - workflow validation passed at production SHA
+    `7c966099173d3610b34a40ff989cea41340a6637`.
+  - independent Playwright smoke passed on `https://6529.io` for `/`,
+    `/about/the-memes`, and `/the-memes`; each route returned HTTP 200 and
+    rendered expected content.
+  - observed three non-fatal 403 resource loads for current CloudFront video
+    renditions for one drop (`m3u8`, 1080p mp4, 720p mp4). Core page content
+    and deploy validation were healthy.
+- Public notes:
+  - release note `4.41.1` posted to 6529 Releases:
+    https://6529.io/waves/05b14183-e153-4e47-bc66-42a0f49102d4?drop=b3df3435-2bae-4a7f-b9c2-5d93feb7b524
+  - deployment note posted to Follow The Repo:
+    https://6529.io/waves/49f0e595-ec7c-4235-8695-a527f61b69f4?drop=f8edf3f7-4255-4889-8a24-0a8a2e8cc469
+
+## 2026-06-20T00:00Z Mega Run Plan Refresh
+
+- Re-reviewed `combined-plan.md` after the reviewbot rollout.
+- Updated the plan to mark the reviewbot prerequisite complete:
+  - `6529reviewbot` PR #399 is live.
+  - frontend PR #2789 is live.
+  - frontend PRs automatically run `general`, `wcag`, `i18n`, `security`, and
+    `responsiveness` lanes.
+- Reframed the remaining work as the actual frontend WCAG/i18n mega run:
+  reconcile existing implementation PRs against current `origin/main`, run
+  extensive local validation, use reviewbot as an additional reviewer, and
+  deploy green PRs in controlled staging/production trains.
+- Made explicit that reviewbot is additive only; it does not replace local
+  lint/typecheck/tests/browser/keyboard/mobile/locale validation.
+- Updated `active-context.md` so future resumes no longer inherit the stale
+  "do not merge page implementation PRs" instruction. Page implementation PRs
+  may now merge only after rebase/revalidation, local testing, reviewbot
+  review, and train assignment.
+
+## 2026-06-20T00:10Z Page-Cluster Testing And PR Template
+
+- Added `mega-run-pr-playbook.md` as the required operating template for every
+  page or page-cluster PR in the mega run.
+- The playbook requires a pre-PR impact assessment for functionality, UX,
+  safety/security, web, Mobile/Capacitor, and Electron/Desktop Shell.
+- The playbook requires a local testing strategy before opening a PR, with
+  Playwright used for rendered web verification and explicit native-shell
+  fallback notes when Capacitor or Electron cannot be exercised locally.
+- Added a PR description template covering summary, cluster/workflows, WCAG,
+  i18n, functionality/UX impact, surface impact, safety/security review, local
+  validation, reviewbot/external checks, and deployment-train notes.
+- Linked the playbook from `combined-plan.md`, added it to the workstream
+  reload order, and updated `active-context.md` so future agents apply it.
+- Updated the templates so both the pre-PR plan and PR description explicitly
+  identify the work as part of the frontend WCAG 2.2 AA and i18n migration mega
+  run, with local validation first and reviewbot as an additional reviewer.
+
+## 2026-06-20T00:45Z Testing Improvement Sidequest Draft
+
+- Added `testing-improvement-plan.md` after external research and internal
+  repo review.
+- The plan frames testing as a sidequest prerequisite before scaling the
+  WCAG/i18n page-cluster mega run.
+- It records current gaps, including the broken staging Playwright helper,
+  missing broad app PR CI, narrow Playwright surface matrix, missing test
+  typecheck project, and lack of standard WCAG/i18n/security browser packs.
+- It defines testing layers: static gates, Jest/component tests, Playwright
+  browser harness, WCAG packs, i18n packs, security-sensitive read-only packs,
+  responsiveness/visual/performance packs, deployment gates, and agentic swarm
+  evidence rules.
+- It proposes the first implementation train:
+  1. test harness repair,
+  2. app PR CI baseline,
+  3. WCAG/i18n Playwright foundation,
+  4. surface matrix,
+  5. deployment evidence integration.
+- Linked the plan from `README.md` and `combined-plan.md`, and updated
+  `active-context.md` to treat the testing sidequest as the current gating
+  planning goal.
+
+## 2026-06-20T01:05Z Open-Model Swarm Reviewbot Added To Plan
+
+- Updated `testing-improvement-plan.md` to keep the existing Opus-backed
+  `6529reviewbot` review lanes unchanged.
+- Added a separate GLM/OpenRouter swarm reviewbot concept that runs in parallel
+  and posts one synthesized `6529bot GLM Swarm Review` comment.
+- Documented the proposed 20 internal GLM review threads, including diff risk,
+  missing test evidence, WCAG, i18n, mobile, Capacitor, Electron, auth, wallet,
+  upload, XSS, Next.js rendering, deployment, and contrarian review lanes.
+- Added implementation rules: one posted synthesized comment, concrete
+  file/evidence citations, advisory first rollout, no secrets, raw outputs kept
+  as artifacts/logs, cost caps, telemetry, and kill switch.
+- Added OpenRouter/Z.ai pricing references with a reminder to recheck pricing
+  and availability before implementation.
+
+## 2026-06-20T01:20Z Safety-Case Testing Layer Added
+
+- Updated `testing-improvement-plan.md` with the aerospace-style safety lens:
+  risk levels, requirements traceability, hazard analysis, independent
+  verification, stop-the-line rules, post-deploy watch, and quality metrics.
+- Added PR 0 to the first implementation train for the validation manifest,
+  risk/hazard templates, artifact pointer schema, redaction rules, and
+  train-assignment requirements.
+- Made durable evidence a first-class release artifact: Playwright reports,
+  traces, screenshots, reviewbot outputs, staging/prod evidence, and manifests
+  should live on 6529-controlled artifact infrastructure such as private S3,
+  pinned IPFS, or a future artifact service.
+- Explicitly ruled out Git LFS and committed large generated files as the
+  artifact store. GitHub Actions artifacts remain acceptable for short-term CI
+  debugging, but not as the durable record for the mega run.
+
+## 2026-06-20T01:35Z 6529.io Web-App Speed Model Added
+
+- Updated `testing-improvement-plan.md` to clarify that 6529.io should use the
+  parts of the blockchain-core safety lens that speed safe web-app development,
+  not Bitcoin-Core-style release gravity for ordinary frontend changes.
+- Added autonomy lanes:
+  - fast lane for Level 0-1 docs/tests/copy/style changes,
+  - standard lane for Level 2 page and workflow changes,
+  - guarded lane for Level 3 auth, wallet, upload, posting, admin, generated
+    API, shared data, and deploy-sensitive changes,
+  - release-captain lane for Level 4-5 production-risk, irreversible-data,
+    credentials, signing/funds, identity, and deploy-control changes.
+- Added 6529.io invariants for wallet/profile identity, signing prompts,
+  posting/destructive actions, auth/permissions, uploads/link previews,
+  WCAG/i18n, and exact deployment SHA tracking.
+- Added adversarial GLM swarm prompts focused on wrong wallet/profile state,
+  unsafe signing language, unauthorized actions, unsafe previews, hidden mobile
+  actions, missing accessible names, admin exposure, and overstated evidence.
+- Made private 6529-controlled object storage the practical default for durable
+  validation artifacts, with IPFS/IPNS reserved for public content-addressed
+  provenance when useful.
+
+## 2026-06-20T01:55Z Testing Strategy Coherence Refactor
+
+- Rewrote `testing-improvement-plan.md` from an accumulated plan into a coherent
+  `Frontend Testing And Release Strategy`.
+- Integrated the prior safety-case, 6529.io speed-lane, artifact, reviewbot,
+  and GLM swarm decisions into one flow:
+  purpose, design inputs, current state, principles, invariants, risk lanes,
+  safety case, test sizing, packs, architecture, surfaces, execution ladder,
+  PR workflow, CI/deploy gates, release reports, artifacts, agents, reviewbot,
+  PRR-lite, metrics, roadmap, page-cluster requirements, and success criteria.
+- Added Google-inspired structure:
+  - `@small` / `@medium` / `@large` test sizing,
+  - execution ladder from local inner loop through production and nightly,
+  - large-test ownership and flake policy,
+  - deployment train release reports,
+  - auto-hold criteria and future canary direction,
+  - PRR-lite only for Level 4-5 work.
+- Updated `active-context.md` so future agents start with PR 0 and PR 1
+  foundation work before scaling page-cluster remediation.
+
+## 2026-06-20T09:35Z Opus 4.8 Review Findings Integrated
+
+- Sent the strategy to Anthropic Claude Opus 4.8 for independent review using
+  the local `ANTHROPIC_API_KEY`. The first request failed because `temperature`
+  is deprecated for `claude-opus-4-8`; the retry without `temperature`
+  succeeded.
+- Integrated Opus's P0/P1 review into `testing-improvement-plan.md`:
+  - added deterministic CI risk-floor classifier and release-captain downgrade
+    approval;
+  - added temporary Level 3+ block until Playwright harness and deployment
+    evidence gates are green, with only release-captain manual-validation
+    exceptions;
+  - added staging/production request-interception mutation guard;
+  - added artifact `scrub -> verify -> upload` redaction pipeline with
+    fake-secret regression test;
+  - restricted auth/wallet/security/upload/production traces to private,
+    deletable 6529-controlled object storage, not IPFS/IPNS;
+  - added fork/untrusted PR secret restrictions and `pull_request_target`
+    warning;
+  - made production promotion SHA-pinned to the staging-validated candidate;
+  - made verifier independence mechanical;
+  - added axe profile/allowlist, native runtime detection consolidation,
+    high-risk flake caps, and GLM risk/cost controls.
+- Updated the first implementation train so PR 0 and PR 1 deliver executable
+  safety controls before page-cluster remediation scales.
+
+## 2026-06-20T10:05Z GPT 5.5 Pro Calibration Integrated
+
+- Reviewed user-provided GPT 5.5 Pro feedback.
+- Kept the immediate focus on fixing testing rather than expanding into a full
+  queue/orchestrator implementation.
+- Updated `testing-improvement-plan.md` to:
+  - add fast-lane execution mode for Level 0-1 PRs;
+  - clarify that swarms/reviewbots are high-recall hypothesis generators, while
+    only deterministic gates and hard invariant violations have blocking
+    authority;
+  - allow Codex plus review bots to cycle until no new useful findings or safe
+    patches appear;
+  - add risk modifiers for feature flags, large translations, and route-impact
+    heuristics;
+  - add CI-enforced artifact schema/pointer validation;
+  - add a versioned mutation endpoint registry for read-only guards;
+  - add CI runtime budgets, retry limits, and quarantine registry;
+  - move security baseline checks into the PR CI baseline.
+- Added `continuous-swarm-engine-notes.md` as a future architecture note for the
+  self-organizing queue, Codex worker wrapper, conflict resolver, invariant
+  gate, and auto-PR factory.
+- Linked the future note from `README.md` and `combined-plan.md`, while keeping
+  it explicitly outside the immediate testing sidequest unless promoted later.
+- Tightened the authority model after user clarification: tests, reviewbots,
+  and swarms are feedback loops for Codex by default. Hard promotion blocks are
+  rare and reserved for deterministic, reproducible disaster-class invariant
+  violations or missing required safety evidence, not ordinary model findings.
+
+## 2026-06-20T12:20Z PR 0 Executable Testing Controls Implemented
+
+- Created clean branch `codex/testing-strategy-foundation` from current
+  `origin/main` in a separate local worktree.
+- Added `ops/scripts/testing-strategy.cjs` with:
+  - deterministic changed-file risk-floor classification;
+  - feature-flag and i18n/layout modifiers;
+  - route-impact hints;
+  - validation manifest checks;
+  - durable artifact pointer checks;
+  - mutation endpoint registry validation;
+  - explicit preservation of existing reviewbot initial lanes.
+- Added `ops/testing-strategy/` schemas, checked-in minimal validation
+  manifest example, and mutation endpoint registry contract.
+- Added package wrapper `testing-strategy` and documented the ops script.
+- Added `__tests__/scripts/testing-strategy.test.ts` covering risk floors,
+  downgrade approval, Level 3+ artifact evidence, local-artifact rejection,
+  existing reviewbot lane preservation, schema constants, and registry
+  validation.
+- Confirmed `.github/6529bot.yml` is untouched; existing `general`, `wcag`,
+  `i18n`, `security`, and `responsiveness` lanes remain the minimum reviewbot
+  baseline.
+- Local validation:
+  - `seize install:frozen`
+  - `seize run test:no-coverage -- __tests__/scripts/testing-strategy.test.ts`
+  - `seize run testing-strategy -- validate-manifest --file ops/testing-strategy/examples/minimal.validation-manifest.json`
+  - `seize run testing-strategy -- validate-mutation-registry --file ops/testing-strategy/mutation-endpoint-registry.json`
+  - `seize run testing-strategy -- compute-risk-floor --changed-from origin/main --json`
+  - `seize run lint:changed`
+  - `seize run typecheck:changed`
+  - `codex-diff-check`

--- a/ops/workstreams/frontend-a11y-i18n/testing-improvement-plan.md
+++ b/ops/workstreams/frontend-a11y-i18n/testing-improvement-plan.md
@@ -146,6 +146,27 @@ Current gaps:
 14. Most test, reviewbot, and swarm output is feedback to Codex. It should drive
     another iteration, not take decision authority away from the agent.
 
+## Pre-PR Template Contract
+
+The executable pre-PR template lives in
+`ops/workstreams/frontend-a11y-i18n/mega-run-pr-playbook.md`. That playbook is
+the source of truth for page-cluster PR planning, and it must continue to collect
+these fields before a non-trivial WCAG/i18n migration PR opens:
+
+- Risk assessment: computed risk floor, declared risk level, final risk level,
+  downgrade approval when final risk is below the computed floor, and hazard
+  analysis in the format `hazard -> severity -> likelihood -> detection ->
+  required test -> rollback or fix-forward`.
+- Validation and artifacts: validation manifest path, durable artifact storage
+  plan, artifact redaction strategy for secrets/local paths/prompts/private data,
+  and expected reviewbot lanes.
+- PR description risk summary: risk level summary, hazard summary, validation
+  manifest status, and durable artifact pointers or planned artifact locations.
+
+This contract connects the playbook template to the validation manifest schema in
+`ops/testing-strategy/validation-manifest.v1.schema.json` and to the safety-case
+requirements in this strategy's "Safety Case And Validation Manifest" section.
+
 ## 6529.io Invariants
 
 High-risk PRs must map their evidence to the relevant invariants below. Add

--- a/ops/workstreams/frontend-a11y-i18n/testing-improvement-plan.md
+++ b/ops/workstreams/frontend-a11y-i18n/testing-improvement-plan.md
@@ -1,0 +1,1355 @@
+# Frontend Testing And Release Strategy
+
+Status: draft strategy for the WCAG 2.2 AA and i18n mega run.
+Date: 2026-06-20.
+Scope: `6529seize-frontend` local, CI, review, staging, production, and
+agentic-swarm validation.
+
+## Purpose
+
+Build a testing and release system that lets 6529.io move faster without
+flattening risk. 6529.io is a web app with decentralization features, not a
+live consensus client. The right target is not Bitcoin-Core-style release
+gravity for every change. The target is:
+
+- low-risk changes move quickly with standardized evidence;
+- page and workflow changes get strong local, browser, and reviewbot coverage;
+- auth, wallet, upload, posting, admin, deploy, data-loss, identity, and
+  decentralization-adjacent risk are routed into guarded lanes;
+- deployment trains are traceable by exact SHA, validation evidence, artifacts,
+  and post-deploy watch.
+
+This is a prerequisite for scaling the frontend WCAG/i18n mega run. Broad
+page-cluster remediation should not accelerate until the foundation PRs in this
+document are in place.
+
+## Design Inputs
+
+External inputs:
+
+- Next.js Playwright and Jest guides:
+  https://nextjs.org/docs/app/guides/testing/playwright
+  https://nextjs.org/docs/app/guides/testing/jest
+- Playwright projects, fixtures, traces, CI, mocking, and accessibility:
+  https://playwright.dev/docs/test-projects
+  https://playwright.dev/docs/test-fixtures
+  https://playwright.dev/docs/trace-viewer
+  https://playwright.dev/docs/ci
+  https://playwright.dev/docs/mock
+  https://playwright.dev/docs/accessibility-testing
+- WCAG 2.2:
+  https://www.w3.org/TR/WCAG22/
+- MDN Intl and Unicode CLDR:
+  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl
+  https://cldr.unicode.org/
+- OWASP ASVS and Web Security Testing Guide:
+  https://owasp.org/www-project-application-security-verification-standard/
+  https://owasp.org/www-project-web-security-testing-guide/
+- GitHub Actions secure use, OpenSSF Scorecard, and SLSA:
+  https://docs.github.com/en/actions/reference/security/secure-use
+  https://scorecard.dev/
+  https://slsa.dev/
+- Electron automated testing, Playwright WebView2, and Capacitor docs:
+  https://www.electronjs.org/docs/latest/tutorial/automated-testing
+  https://playwright.dev/docs/webview2
+  https://capacitorjs.com/docs
+- Google testing, release, and SRE ideas:
+  https://abseil.io/resources/swe-book/html/ch11.html
+  https://abseil.io/resources/swe-book/html/ch14.html
+  https://abseil.io/resources/swe-book/html/ch23.html
+  https://sre.google/sre-book/release-engineering/
+  https://sre.google/workbook/canarying-releases/
+  https://sre.google/sre-book/reliable-product-launches/
+  https://sre.google/sre-book/evolving-sre-engagement-model/
+- OpenRouter GLM 5.2 listing and Z.ai direct pricing:
+  https://openrouter.ai/z-ai/glm-5.2
+  https://docs.z.ai/guides/overview/pricing
+
+Internal inputs:
+
+- Repo and local environment rules in `AGENTS.md`.
+- WCAG standard in `ops/standards/frontend-accessibility-wcag-22-aa.md`.
+- I18n standard in `ops/standards/frontend-i18n-localization.md`.
+- Autonomous manager skill in `ops/skills/6529-autonomous-manager/SKILL.md`.
+- WCAG and i18n skills in `ops/skills/wcag-22-aa/SKILL.md` and
+  `ops/skills/i18n-localization/SKILL.md`.
+- Deployment skill and bus docs in `ops/skills/deploy-6529/SKILL.md`,
+  `ops/docs/developer/deployment-bus-process.md`, and
+  `ops/docs/developer/deployment-bus-automation.md`.
+- Current test config in `package.json`, `jest.config.js`, `jest.setup.js`,
+  `playwright.config.ts`, `tests/`, and `__tests__/`.
+- Reviewbot config in `.github/6529bot.yml`.
+- Page-cluster workflow in
+  `ops/workstreams/frontend-a11y-i18n/mega-run-pr-playbook.md`.
+
+## Current State
+
+Existing strengths:
+
+- Thousands of Jest unit and component tests under `__tests__/`.
+- Existing Testing Library usage with accessible-role queries.
+- Existing i18n helpers in `i18n/locales.ts`, `i18n/format.ts`, and
+  `i18n/messages.ts`.
+- Existing locale tests for route params, formatting, and locale-preserving
+  links in several migrated areas.
+- Existing security-sensitive tests around auth, route handlers, URL guards,
+  upload helpers, sanitizers, rate limits, and preview APIs.
+- Existing `eslint-plugin-jsx-a11y`, `eslint-plugin-security`, dependency
+  governance, deploy manifests, deployment concurrency, and reviewbot lanes.
+- Reviewbot now runs `general`, `wcag`, `i18n`, `security`, and
+  `responsiveness` on frontend PRs.
+
+Current gaps:
+
+- The Playwright suite on `origin/main` is not a reliable gate because smoke
+  specs import `../testHelpers`, but `tests/testHelpers.ts` is absent.
+- `test:e2e:staging` depends on those smoke specs, so staging E2E cannot yet
+  be treated as a hard promotion signal.
+- There is no broad ordinary-PR CI workflow for app changes.
+- Playwright currently runs only a desktop Chromium project.
+- Playwright artifacts are not yet standardized for trace, screenshot, console,
+  network, locale, overflow, accessibility, and surface evidence.
+- Tests are not typechecked as a first-class project.
+- Some changed-file scripts compare against different base refs.
+- Browser E2E does not yet systematically cover keyboard/focus, locale
+  wrapping, mobile overflow, native-adjacent branches, or production-safe
+  security smoke.
+- Native behavior detection is spread across hooks and direct Capacitor imports,
+  so simulated browser checks can overstate true native coverage.
+
+## Core Principles
+
+1. Testing is a speed system, not a ceremony system.
+2. Use the smallest sufficient test for each behavior.
+3. Production confidence requires multiple layers: static, small tests, browser
+   tests, deployed tests, reviewbot, and monitoring.
+4. Browser tests should exercise user-observable behavior.
+5. Accessibility automation supports WCAG review but does not prove WCAG
+   conformance by itself.
+6. I18n tests must cover visible copy, accessible names, locale formatting,
+   fallback behavior, wrapping, and sorting.
+7. Security-sensitive tests are read-only by default in staging and production.
+8. Native-simulated tests must be labeled as simulated unless they run inside a
+   real native shell.
+9. Every deployment train needs exact SHA evidence, a validation manifest, and
+   a release report.
+10. Reviewbot is a second reviewer, not a substitute for local and deployed
+    tests.
+11. Stop-the-line is rare and reserved for confirmed disaster-class evidence,
+    not ordinary uncertainty or model disagreement.
+12. Swarms are high-recall hypothesis generators. Only deterministic gates and
+    reproducible disaster-class invariant violations have promotion-blocking
+    authority.
+13. Codex plus review bots should cycle until they are no longer adding useful
+    findings or patches; the system should then promote safe work instead of
+    waiting for ritual human review.
+14. Most test, reviewbot, and swarm output is feedback to Codex. It should drive
+    another iteration, not take decision authority away from the agent.
+
+## 6529.io Invariants
+
+High-risk PRs must map their evidence to the relevant invariants below. Add
+narrower invariants in the validation manifest when a workflow has special
+rules.
+
+Identity and wallet:
+
+- A user must never be shown as connected to the wrong wallet, profile, or
+  identity.
+- Wallet connection, switching, and disconnect states must be visible,
+  reversible, and fail closed.
+- A signing prompt must never misdescribe what is being signed or imply a safer
+  action than the wallet is actually requesting.
+- Wallet, TDH, delegation, ownership, or identity claims must not be inferred
+  from stale client state when fresh authoritative data is required.
+
+Posting and user actions:
+
+- Posting, deletion, moderation, voting, admin, or other state-changing actions
+  must not happen from automated tests unless the environment and fixture are
+  explicitly safe for that action.
+- Destructive or irreversible actions must have clear accessible labels and must
+  not become available to unauthorized users.
+- Read-only production smoke must never mutate production state unless the user
+  explicitly requests that exact operation.
+
+Auth and permissions:
+
+- Auth/session failures must fail closed.
+- Admin and moderation affordances must not appear to unauthorized users.
+- Route protection and API authorization must not rely only on hidden client UI.
+- Cookies, tokens, staging credentials, wallet data, and user-private data must
+  not appear in logs, screenshots, traces, reviewbot prompts, or artifacts.
+
+Uploads, media, and links:
+
+- Uploaded content and link previews must not execute script or unsafe HTML.
+- URLs must be sanitized and rendered with safe link behavior.
+- Media failures must degrade without hiding primary actions or breaking page
+  navigation.
+
+WCAG and i18n:
+
+- I18n migration must not remove accessible names, labels, roles, or status
+  announcements.
+- Long translated text must not hide controls, overlap content, or cause
+  horizontal overflow.
+- Locale formatting must preserve meaning for dates, numbers, percentages,
+  relative time, and sorting.
+- Keyboard users must be able to reach and operate every changed interactive
+  control.
+
+Deployment:
+
+- Every staging and production result must map to an exact known SHA or release
+  set.
+- A deployment train must not mix stale branches or hidden unreviewed changes.
+- Production validation must check the actual deployed version, not just the
+  branch that was intended to deploy.
+
+## Risk And Autonomy Lanes
+
+Every PR and deployment train needs a risk level. The risk level selects the
+minimum gates; owners can always run more.
+
+| Lane | Risk | Examples | Minimum gates |
+| --- | --- | --- | --- |
+| Fast | Level 0 | Docs, comments, test-only changes, non-runtime metadata | Whitespace/doc checks, changed lint when applicable, reviewer confirms no runtime path changed |
+| Fast | Level 1 | Isolated copy, labels, styles, non-shared presentational UI | Changed lint/typecheck, focused component tests where present, `@a11y` or `@i18n` if visible, mobile overflow if layout changed |
+| Standard | Level 2 | User-facing UI behavior, forms, navigation, menus, dialogs, route rendering, shared components | Level 1 gates, focused Jest, changed-route Playwright, keyboard/focus, mobile, locale, reviewbot findings addressed |
+| Guarded | Level 3 | Auth, session, wallet-adjacent UI, uploads, link previews, posting, moderation/admin, generated API, route protection, deploy config, shared data fetching | Level 2 gates, build, security pack, read-only destructive-action guard, staging validation for exact SHA, independent verifier |
+| Release-captain | Level 4 | Cross-surface changes, broad shared infrastructure, production routing, cache behavior, native-shell behavior, release-train changes | Level 3 gates, release captain, broader surface matrix, deployment manifest, rollback/fix-forward note, post-deploy watch |
+| Release-captain | Level 5 | Security-critical changes, funds or signing flows, irreversible data writes, credentials, infra/deploy control | Level 4 gates, explicit threat model, independent security review, least-privilege/secret review, release-captain approval, production monitoring checkpoints before public notes |
+
+Risk can only move down with a written reason. If agents disagree, use the
+higher risk level until a human or release captain resolves it.
+
+Fast lane execution mode:
+
+- Level 0-1 PRs use a minimal validation manifest: risk floor, changed files,
+  commands run, reviewbot status, and residual risk.
+- Level 0-1 PRs do not require full deployment train release reports unless
+  they affect runtime routes, deployment config, auth/wallet/upload/admin paths,
+  or a release captain explicitly groups them into a train.
+- GLM swarm is not required for Level 0-1 PRs. Run only cheap risk/evidence
+  classifiers when useful.
+- Staging is optional for Level 0-1 PRs unless route rendering, build behavior,
+  runtime config, or deploy packaging changed.
+- Auto-merge can be allowed for tightly scoped safe classes once Codex, CI, and
+  reviewbot stop producing new useful findings. Initial safe classes are docs,
+  test scaffolding, i18n dictionary-only fixes, and constrained accessible-name
+  or label fixes with passing tests.
+- Layout and UI behavior fixes may auto-open PRs, but should not auto-merge
+  until visual/browser evidence is reliable enough to avoid oscillation.
+
+### Risk Classification Mechanism
+
+Risk classification must be enforced by a deterministic CI risk-floor
+classifier, not only by the PR owner. The classifier computes a minimum risk
+level from changed paths, package/config changes, and declared impact. The PR
+may declare a higher risk level. It may not declare a lower risk level unless a
+release captain records a downgrade reason in the validation manifest.
+
+Initial risk-floor table:
+
+| Change pattern | Minimum risk |
+| --- | --- |
+| Docs-only under `ops/`, Markdown docs, comments, non-runtime metadata | Level 0 |
+| Isolated non-shared style/copy/component changes outside auth/wallet/upload/admin/deploy paths | Level 1 |
+| `app/**`, `components/**`, `hooks/**`, `contexts/**`, `store/**`, `helpers/**`, `lib/**`, `utils/**` touching user-visible route/workflow behavior | Level 2 |
+| Any auth/session, wallet, signing, profile identity, TDH/delegation, upload, media/link-preview, posting, moderation, admin, route protection, generated API model, shared data-fetching, or Next.js rendering-mode path | Level 3 |
+| Deployment workflows, deployment bus, environment schema, build/release config, cache/routing infrastructure, native-shell behavior, broad shared primitives used across many route families | Level 4 |
+| Credentials, secret handling, signing/funds, irreversible data writes, deploy-control authority, artifact-store access controls, or security-critical auth/wallet/admin changes | Level 5 |
+
+The first implementation must encode the Level 3+ floor with explicit path
+globs. Start conservative; false positives are cheaper than silently treating a
+wallet or deploy change as ordinary UI. The validation manifest must record:
+
+- computed risk floor;
+- declared risk level;
+- final risk level;
+- downgrade approver and reason when final risk is below the computed floor.
+
+Risk modifiers:
+
+- Feature-flag changes that alter ON/OFF behavior, default values, or runtime
+  eligibility rules escalate the computed risk by one level unless already at
+  Level 4 or Level 5.
+- Large i18n payload changes, unusually long translated strings, or dictionary
+  changes touching primary navigation, forms, modals, or action labels add a
+  layout/i18n risk modifier and require mobile/overflow evidence.
+- Route-impact heuristics should map changed routes/components to affected
+  workflows so the classifier can request targeted smoke instead of sending
+  every PR through the full matrix.
+
+## Safety Case And Validation Manifest
+
+Every non-trivial PR must make explicit claims about what changed, what can
+fail, which evidence covers those failures, who validated the evidence, and
+which deployed SHA carries the change.
+
+Required safety-case chain:
+
+```text
+changed requirement or risk
+-> implementation files
+-> local test evidence
+-> PR/CI/review evidence
+-> staging evidence
+-> production evidence
+```
+
+Validation manifest fields:
+
+- PR, branch, owner, verifier, and risk level.
+- Computed risk floor, declared risk level, final risk level, and downgrade
+  approval if any.
+- Affected routes, workflows, user-visible requirements, and invariants.
+- Changed files grouped by behavior, accessibility, i18n, security, and
+  deployment impact.
+- Required test sizes, packs, commands, and pass/fail results.
+- Playwright report, screenshots, traces, console/network evidence, and
+  artifact pointers.
+- Reviewbot, GLM swarm, and human review URLs or run IDs.
+- Staging deployment URL, candidate SHA, and validation result when applicable.
+- Production version/SHA and read-only smoke result when applicable.
+- Known skipped checks, why they were skipped, who accepted the risk, and when
+  they must be revisited.
+
+Hazard analysis format:
+
+```text
+hazard -> severity -> likelihood -> detection -> required test -> rollback or fix-forward
+```
+
+Default hazards for the mega run:
+
+- Inaccessible navigation, dialog, menu, or form interaction.
+- Broken focus order, focus trap, or focus return.
+- Missing accessible names after copy or icon migration.
+- Locale formatting corruption for dates, numbers, addresses, or sorting.
+- Long translated text breaking layout or hiding controls.
+- Mobile layout blocking a primary action.
+- Auth/session state lost or misrepresented.
+- Wallet/signing UI confusion or unsafe confirmation language.
+- Upload, media, or link-preview path accepting unsafe URLs or HTML.
+- Posting, deletion, moderation, or admin action accidentally becoming
+  destructive in tests.
+- Native shell behavior claimed from browser-only simulation.
+- Staging SHA, production SHA, or deployment candidate set unclear.
+- Stale branch merged after `origin/main` moved.
+
+Any hazard without a detection path is not ready for merge. Any hazard without a
+rollback or fix-forward path is not ready for production.
+
+Temporary foundation constraint:
+
+- Until the Playwright harness repair and deployment evidence integration are
+  both green, Level 3+ page-cluster work is blocked by default.
+- A release captain may allow a one-off Level 3+ exception only with a written
+  manual-validation plan, explicit expiry, and a follow-up to replace the manual
+  evidence with automated evidence once the gates exist.
+
+## Test Size Taxonomy
+
+Use Google-style test sizing to keep the suite fast and deterministic.
+
+| Size | Definition | 6529 examples | Runs |
+| --- | --- | --- | --- |
+| `@small` | Single process, deterministic, no network, no real browser, no external service | Pure helpers, formatters, reducers, URL guards, small components with fakes | Local, PR CI, changed-file gates |
+| `@medium` | Single machine, localhost allowed, local browser or local services allowed | Playwright against local frontend, local API smoke, component integration with browser, local upload validation | Local, PR CI when selected, train validation |
+| `@large` | Deployed or real external service, staging/prod, real native shell, production-like environment | Staging Playwright, production read-only smoke, real Capacitor/Electron shell smoke, train-level security smoke | Staging, production, release trains, scheduled runs |
+
+Rules:
+
+- Prefer many `@small`, some `@medium`, and few `@large` tests.
+- If a large test catches a bug, add the smallest practical regression test
+  below it.
+- Large tests need an owner, purpose, runtime expectation, flake policy, and
+  repair owner.
+- Larger tests should not silently rot behind retries; quarantine and repair
+  them with an owner and deadline.
+- During Level 3+ deployment trains, zero quarantined `@auth`, `@wallet`,
+  `@security`, `@upload`, `@readonly-prod`, or deployment-gate tests are
+  allowed unless the release captain removes the affected PR from the train.
+
+CI runtime and flake controls:
+
+- Each lane should have a runtime budget after baseline measurements:
+  - Fast lane target: under 10 minutes;
+  - Standard lane target: under 20 minutes;
+  - Guarded lane target: under 35 minutes before staging;
+  - Release-captain lane target: explicit train budget recorded in the release
+    report.
+- Default retry budget is 0 for unit/static tests and 1 for browser tests
+  unless a pack owner records a narrower rule.
+- Quarantined tests must be listed in a versioned quarantine registry with test
+  id, pack, risk surface, owner, reason, expiry, and blocking effect.
+- A quarantined high-risk test cannot silently downgrade coverage; it either
+  blocks the affected train or the release captain removes the affected PR.
+
+## Test Pack Taxonomy
+
+Use consistent tags or project names:
+
+- `@small`
+- `@medium`
+- `@large`
+- `@smoke`
+- `@route`
+- `@a11y`
+- `@keyboard`
+- `@i18n`
+- `@mobile`
+- `@capacitor-sim`
+- `@electron-sim`
+- `@security`
+- `@upload`
+- `@wallet`
+- `@auth`
+- `@readonly-prod`
+- `@visual`
+- `@performance`
+- `@staging`
+- `@production`
+
+Pack selection is route/risk based. Not every PR runs every pack, but every PR
+explains why its selected packs are enough.
+
+## Test Architecture
+
+### Static And Structural Gates
+
+Required capabilities:
+
+- Format and whitespace checks.
+- Changed-file lint and full lint in CI.
+- `eslint-plugin-jsx-a11y` for obvious accessibility issues.
+- `eslint-plugin-security` for obvious security smells.
+- Typecheck app code.
+- Typecheck tests and Playwright helpers.
+- Hardcoded user-facing string detection for migrated areas.
+- Missing source message detection for i18n dictionaries.
+- Dependency governance and dependency-risk gates.
+- Workflow permission review: least privilege, pinned actions where practical,
+  no secret exposure in artifacts.
+
+First targets:
+
+- Add `typecheck:tests`.
+- Fix JSON scripts that point at missing helpers.
+- Normalize changed-file base refs.
+- Add normal app PR CI.
+
+### Small Unit And Component Tests
+
+Purpose:
+
+- Fast feedback for helpers, primitives, hooks, formatters, route helpers, auth
+  boundaries, API request builders, and shared UI states.
+
+Rules:
+
+- Use Testing Library role/name queries when practical.
+- Test visible text and accessible names together for migrated UI.
+- Test locale helpers with `en-US`, `en-GB`, `fr-FR`, `es-ES`, and `de-DE`.
+- Test fallback to `en-US` without crashes.
+- Test formatting through repo helpers, not raw `toLocaleString()` in newly
+  touched UI.
+- Keep security helper tests close to URL, upload, auth, sanitizer, and route
+  boundary code.
+- Use Playwright instead of Jest when rendered async Server Component behavior
+  is the more faithful test.
+
+### Medium Browser Harness
+
+Purpose:
+
+- Validate rendered, hydrated, user-observable behavior against local app
+  targets.
+
+Required shared fixtures:
+
+- `test` and `expect` exports from `tests/testHelpers.ts`.
+- `gotoAndReady(path)` that waits for usable route state and asserts successful
+  response where applicable.
+- Console error, page error, and failed request collection with narrow allowlist.
+- `expectNoHorizontalOverflow()`.
+- `expectVisibleFocus()` and keyboard tab helpers.
+- `expectLandmarks()` for main/header/nav/footer where applicable.
+- `expectAxeClean()` using `@axe-core/playwright`.
+- `expectNoMissingI18nKeys()` when app instrumentation exists.
+- Stable screenshot names:
+  `<pack>-<route-slug>-<surface>-<locale>-<state>-<short-hash>`.
+- Trace and screenshot capture on failure.
+- Read-only mutation guard for staging and production:
+  - `PLAYWRIGHT_READONLY=1` is default outside local.
+  - shared fixtures intercept network requests and fail the test on
+    non-allowlisted mutations;
+  - the denylist must include posting, deletion, voting, moderation, admin,
+    wallet/signing, upload, profile write, and deploy-control endpoints;
+  - allowlists are environment-specific, reviewed, and stored with the test
+    harness;
+  - read-only safety is enforced by interception, not by test discipline.
+- Redaction fixture hook that runs before traces, screenshots, videos, console
+  logs, or network logs leave the runner.
+
+PR-gating Playwright baseline:
+
+- `web-desktop-chromium`.
+- `web-mobile-chromium`.
+
+Train or nightly projects until stable:
+
+- `web-tablet-chromium`.
+- `web-desktop-firefox` for train or nightly.
+- `web-desktop-webkit` for train or nightly.
+- `capacitor-ios-simulated`.
+- `capacitor-android-simulated`.
+- `electron-simulated`.
+
+Config targets:
+
+- Keep `PLAYWRIGHT_BASE_URL` for local, staging, and production targets.
+- Add `PLAYWRIGHT_ENV=local|staging|production`.
+- Add `PLAYWRIGHT_READONLY=1` for staging/production by default.
+- Prefer production-like build/start validation for release trains when time
+  permits.
+- Centralize native runtime detection before relying on `@capacitor-sim` or
+  `@electron-sim`; simulation projects should target one shared detection API
+  rather than scattered direct Capacitor imports or user-agent checks.
+
+### Accessibility Packs
+
+Pack types:
+
+- `a11y-smoke`: axe smoke on selected routes.
+- `keyboard-flow`: tab order, focus visibility, escape behavior, focus return.
+- `dialog-menu-overlay`: focus trap, labels, roles, state, close behavior.
+- `form-a11y`: labels, descriptions, errors, required/invalid state.
+- `media-a11y`: image alt, video controls/captions where applicable.
+- `landmark-heading`: main/header/nav/footer, heading order, page title.
+- `screen-reader-smoke`: accessible tree snapshots or manual SR notes for
+  high-risk flows.
+
+Rules:
+
+- Automated a11y is a regression guard, not a WCAG certificate.
+- `expectAxeClean()` must use a documented axe profile. Start with rules that
+  catch owned semantic, label, color-contrast, landmark, and form issues without
+  blocking on known third-party or user-generated content outside our control.
+- Known axe exceptions require a route/component, selector, owner, reason,
+  expiry, and follow-up. Do not disable axe wholesale for a route family.
+- New visible UI needs keyboard/focus evidence.
+- Icon-only controls need accessible names and hover/focus tooltips where
+  useful.
+- Do not attach mouse/keyboard handlers to non-interactive elements.
+
+### I18n Packs
+
+Pack types:
+
+- `i18n-source-messages`: source locale key completeness.
+- `i18n-locale-matrix`: route smoke across supported locales.
+- `i18n-formatting`: dates, times, numbers, percentages, lists, relative time,
+  compact values.
+- `i18n-accessible-names`: visible copy and accessible names share messages.
+- `i18n-long-text`: wrapping and overflow for long labels.
+- `i18n-sort-filter`: locale-sensitive sorting and filtering when applicable.
+- `i18n-metadata`: page titles, descriptions, alt text, and canonical/locale
+  policy where touched.
+
+Rules:
+
+- `en-US` remains canonical source locale.
+- Non-source locales may fall back to `en-US` until reviewed translations are
+  available.
+- User-generated content remains in the user's authored language unless a
+  product translation feature explicitly changes it.
+- Optional later stress cases: pseudo-locale, long German strings,
+  accent-heavy French/Spanish, and bidi smoke when RTL is in scope.
+
+### Security-Sensitive Packs
+
+Pack types:
+
+- `security-readonly-auth`: anonymous/authenticated boundary behavior with
+  approved test identity only.
+- `security-wallet-readonly`: wallet UI state, connection prompts, and blocked
+  transaction paths without signing.
+- `security-upload-local`: file validation, drag/drop, paste, size/type
+  rejection, preview behavior.
+- `security-preview-api`: URL preview and media proxy safety paths.
+- `security-xss-smoke`: unsafe HTML, markdown, link, and preview payload smoke
+  using local or mocked data.
+- `security-headers`: CSP/security header checks where configured.
+- `security-prod-safe`: production smoke that forbids public posts, purchases,
+  transfers, signer changes, Safe actions, and destructive data mutations.
+
+Rules:
+
+- Use OWASP ASVS and WSTG as a coverage map, not a promise of certification.
+- Keep exploit details out of public artifacts and PR descriptions.
+
+### Performance, Visual, And Responsiveness Packs
+
+Pack types:
+
+- `responsive-layout`: desktop, tablet, mobile widths, no horizontal overflow.
+- `visual-smoke`: stable screenshots for high-risk migrated surfaces.
+- `performance-smoke`: basic load and route interaction timing for train
+  validation, with budgets only after baseline data exists.
+- `reduced-motion`: major animated UI respects reduced motion.
+- `canvas-media-smoke`: images, video, NFT previews, and canvas-heavy areas are
+  nonblank and framed correctly.
+
+## Surface Evidence
+
+| Surface | Coverage goal | Testing mode |
+| --- | --- | --- |
+| Main desktop web | Full migration confidence | Jest, Playwright desktop, axe, keyboard, staging/prod smoke |
+| Mobile web | Layout and touch confidence | Playwright mobile projects, viewport screenshots, touch/zoom checks |
+| Capacitor iOS | Native-adjacent confidence | Simulated Playwright first, real shell smoke later |
+| Capacitor Android | Native-adjacent confidence | Simulated Playwright first, real shell smoke later |
+| Electron/Desktop Shell | Shell-adjacent confidence | Electron user-agent simulation first, real shell smoke later |
+| Standalone/exported surfaces | Independent confidence | Surface-specific build/export and browser smoke |
+| Staging | Deployment candidate confidence | Deployed Playwright smoke plus release-specific packs |
+| Production | Live safety confidence | Read-only smoke, changed-route checks, console/network checks |
+
+Evidence labels:
+
+- `simulated`: browser-driven approximation, such as mobile viewport,
+  Capacitor flag simulation, or Electron user-agent simulation.
+- `shell-smoke`: app launched in actual native or desktop shell with basic route
+  and interaction checks.
+- `real-device`: app checked on a real mobile device, emulator, simulator, or
+  desktop shell that exercises the target runtime.
+- `production-observed`: read-only validation against production for the exact
+  deployed version.
+
+Do not write "Capacitor verified", "Electron verified", or "native verified"
+when only browser simulation was run.
+
+## Execution Ladder
+
+| Stage | Goal | Required signal |
+| --- | --- | --- |
+| Local inner loop | Fast agent/developer feedback | `@small` tests, changed lint/typecheck, focused component tests |
+| Local pre-PR | Prove touched workflow locally | Risk level, hazard analysis, selected packs, focused Playwright for visible UI |
+| PR CI | Repo-owned baseline before review/deploy | frozen install, lint, typecheck, test typecheck, focused/full Jest by risk, build when needed, small Playwright smoke |
+| Review | Independent reasoning | 6529reviewbot lanes, GLM swarm when available, human/agent review, findings mapped into manifest |
+| Post-merge/train | Validate train composition | exact PR set, exact SHA, release report, selected medium/large packs |
+| Staging | Validate production candidate | read-only staging Playwright, changed routes, owner validation, durable artifacts |
+| Production | Validate live release | exact deployed SHA, read-only smoke, error/route/API watch, public notes only after green |
+| Nightly/scheduled | Catch drift cheaply | broader browsers, Firefox/WebKit, full Jest, flake detection, dependency/security checks |
+
+## Pull Request Workflow
+
+Before opening:
+
+- Use a clean worktree based on current `origin/main`.
+- Run `seize-local-dev bootstrap`.
+- Use the assigned frontend port from `seize-local-dev status`.
+- Use `seize` for package commands in Windows Codex shells.
+- Use the shared backend API unless the task explicitly owns backend state.
+- Complete the pre-PR impact/testing plan from `mega-run-pr-playbook.md`.
+- Assign risk level and hazard analysis.
+- Select required sizes and packs.
+- Prepare the validation manifest and artifact storage plan.
+
+Minimum local validation:
+
+- `seize run lint:changed`.
+- `seize run typecheck:changed`.
+- Focused Jest tests for touched helpers/components.
+- Focused Playwright route pack for touched visible UI.
+- Keyboard/focus evidence for visible UI.
+- Locale matrix evidence for migrated UI.
+- Mobile viewport evidence.
+- Native-surface decision: web-only, simulated native, or real native needed.
+- Security safety decision for auth/wallet/upload/posting/admin surfaces.
+
+Before merge:
+
+- Required local checks pass.
+- Required CI checks pass.
+- Reviewbot findings are fixed or explicitly deferred.
+- Required artifacts and durable pointers exist for retained evidence.
+- Level 3+ PRs have independent verifier signoff.
+- PR is assigned to a deployment train.
+
+## CI And Deployment Gates
+
+### Pull Request CI
+
+Required baseline:
+
+- Deterministic risk-floor classifier plus manually declared risk level.
+- Frozen install.
+- Package metadata and lockfile checks.
+- Typecheck app.
+- Typecheck tests.
+- Lint.
+- Jest focused or full run based on risk and cost.
+- Build when routing, Next config, generated models, deployment-sensitive code,
+  or shared behavior changes.
+- Security baseline: secret scan, dependency vulnerability policy check, and
+  workflow permission/secret exposure check.
+- Playwright smoke for core routes and changed routes when feasible.
+- Short-term artifact upload for CI debugging.
+- Validation manifest check for Level 2+ PRs.
+- Fork PRs and untrusted PRs do not receive secrets, staging credentials,
+  Anthropic/OpenRouter keys, artifact-store write access, or deployment
+  permissions. Use `pull_request` for untrusted validation; do not use
+  `pull_request_target` for code execution from forks.
+
+### Staging
+
+Required before production promotion:
+
+- Exact staging SHA recorded.
+- Included PRs recorded.
+- Risk level for each PR and train overall recorded.
+- Required packs listed by release risk.
+- Core deployed smoke passes.
+- Each PR owner validates their surface.
+- Independent verifier signs off for Level 3+ PRs.
+- Durable artifact pointers for staging reports, traces, screenshots, and
+  validation manifests recorded.
+- Failed, flaky, or held checks are resolved or removed from the candidate.
+- Level 3+ trains are not eligible for production promotion unless PR 1
+  harness repair and PR 5 deployment evidence integration are already green, or
+  a release captain records a temporary manual-validation exception.
+
+### Production
+
+Required after production deployment:
+
+- Exact production SHA or version label recorded.
+- Production promotion uses the exact immutable SHA validated on staging. If
+  `origin/main` advanced after staging validation, re-validate the new SHA or
+  promote the already validated SHA through the deployment process.
+- Production artifact manifest recorded on 6529-controlled storage.
+- Changed routes load and hydrate.
+- Critical API calls succeed.
+- Console and network checks show no release-critical errors.
+- Static assets load from expected build.
+- No destructive actions unless explicitly requested.
+- Required post-deploy watch checkpoints completed for Level 4+ and Level 5
+  trains.
+- Public release notes and Follow The Repo notes only after production
+  validation is green.
+
+### Auto-Hold And Canary Direction
+
+Initial implementation should be auto-hold, human rollback. Future deployment
+infra can move toward true canary or traffic-split rollout.
+
+Hold the train if any of these occur:
+
+- Production candidate SHA or included PR set is unclear.
+- Staging failed and the cause is unknown.
+- Test evidence contradicts PR or release-report claims.
+- Auth, wallet, upload, posting, admin, infra, or deploy control changed
+  without required security packs.
+- Native behavior is claimed but only browser simulation was run.
+- High-confidence security, WCAG, data-loss, or deployment-risk finding is
+  open.
+- Production Sentry, API errors, console errors, or critical route health
+  worsens after deployment and the cause is unknown.
+- Required durable artifacts are missing or only exist as temporary logs.
+- Any `@auth`, `@wallet`, `@security`, `@upload`, `@readonly-prod`, or
+  deployment-gate test needed for the train is quarantined.
+
+Future canary target:
+
+- Deploy candidate to a small production slice or feature-flag population.
+- Compare candidate and control for route health, API errors, frontend errors,
+  latency, static assets, and key workflow smoke.
+- Automatically hold or roll back when canary health fails.
+
+## Deployment Train Release Report
+
+Every train should produce a release report with:
+
+- Train name, release captain, staging SHA, production SHA, and timestamps.
+- Included PRs, titles, owners, verifiers, and risk levels.
+- Diff range since previous production release.
+- Required test packs and commands.
+- CI, reviewbot, GLM swarm, human review, staging, and production evidence.
+- Durable artifact pointers.
+- Skipped checks, accepted risk, and follow-up owners.
+- Rollback/fix-forward path.
+- Post-deploy watch result.
+- Public note URLs after production validation is green.
+
+This report is the human-readable release record. The validation manifests and
+artifact store are the machine-readable evidence.
+
+## Artifact Strategy
+
+Evidence is a first-class release artifact:
+
+- Command names and summarized results.
+- Jest summaries.
+- Playwright HTML reports.
+- Playwright traces, screenshots, videos when useful, and console/network logs.
+- Axe results and manual keyboard/focus notes.
+- Locale screenshots or extracted text samples for migrated UI.
+- Reviewbot, GLM swarm, and human review URLs.
+- Staging and production run URLs, candidate SHAs, and validation manifests.
+- Known skipped checks and accepted-risk notes.
+
+Do not store validation artifacts in Git LFS. Do not commit large generated
+artifacts into the repo. GitHub Actions artifacts are acceptable for short-term
+CI debugging, but they are not the durable record for the mega run.
+
+Durable artifacts should live on 6529-controlled infrastructure. The practical
+default is a private S3 bucket or equivalent private object store because most
+reports, traces, logs, and screenshots are internal validation material.
+IPFS/IPNS with controlled pinning is useful when public, content-addressed
+provenance is desired. A future 6529 artifact service can wrap either storage
+backend.
+
+Manifest pointers should include:
+
+- S3 URI plus ETag/version ID or IPFS CID.
+- Content hash.
+- Retention class.
+- Access class.
+- Redaction status.
+- Producing workflow run and command.
+
+Artifact rules:
+
+- Validation manifests and artifact pointer files must be checked against a
+  versioned JSON schema in CI before Level 2+ train assignment.
+- Missing required artifacts or invalid artifact pointers are hard gate failures
+  for Level 3+ PRs and deployment trains.
+- If artifact upload fails after tests pass, the PR or train remains held until
+  the artifact is uploaded or a release captain records a temporary exception
+  with expiry.
+- Redact or avoid secrets, cookies, auth headers, wallet data, private user
+  data, local paths, and hidden prompts.
+- Keep sensitive artifacts private and separated from public PR comments.
+- Store only durable pointers in PR descriptions when the raw artifact should
+  remain private.
+- Prefer content-addressed or versioned storage where possible.
+- All retained artifacts pass through `scrub -> verify -> upload`:
+  - scrub removes cookies, authorization headers, API keys, wallet addresses
+    when not needed, session identifiers, local paths, prompt internals, request
+    bodies for private endpoints, and response bodies with user-private data;
+  - verify fails closed if known secret patterns, credential headers, staging
+    credentials, bearer tokens, wallet-signing payloads, or local credential
+    paths remain;
+  - upload happens only after verification passes.
+- Add a regression test that plants fake secrets into representative trace/log
+  content and proves the verifier blocks the upload.
+- `@auth`, `@wallet`, `@security`, `@upload`, and `@readonly-prod` raw traces
+  and network logs must remain in private, deletable 6529-controlled object
+  storage. Do not publish these artifacts to IPFS/IPNS.
+- IPFS/IPNS is reserved for public, deliberately redacted, content-addressed
+  provenance artifacts only.
+
+## Mutation Endpoint Registry
+
+The read-only mutation guard depends on a versioned registry of state-changing
+endpoints and wallet/signing operations.
+
+Registry requirements:
+
+- Store endpoint patterns, HTTP methods, owning surface, environment-specific
+  allowlist status, and review owner.
+- CI should fail when route handlers, API clients, or mutation helpers add
+  state-changing calls that are not represented in the registry.
+- Staging and production Playwright fixtures must load the registry and fail on
+  non-allowlisted mutations when `PLAYWRIGHT_READONLY=1`.
+- Registry drift between local, staging, and production must be visible in the
+  release report.
+- The registry is a safety control, not documentation; tests should prove it
+  catches representative unsafe mutations.
+
+## Agentic Operating Model
+
+Manager:
+
+- Owns workstream goal, memory, release train, and final evidence.
+- Keeps `README.md`, `active-context.md`, `run-log.md`, this strategy, and PR
+  descriptions current.
+- Splits work into non-overlapping implementation scopes.
+- Assigns validation owners per PR and per train.
+- Enforces risk levels, stop-the-line rules, and durable artifact requirements.
+- Keeps deployment trains serialized unless a release captain approves overlap.
+
+Explorer agents:
+
+- Inspect route/test/deploy context.
+- Return file paths, risks, and proposed packs.
+- Do not edit files.
+
+Worker agents:
+
+- Implement bounded testing infrastructure or page-cluster fixes.
+- Own disjoint file sets.
+- Add or update focused tests.
+- Preserve unrelated dirty changes.
+
+Verifier agents:
+
+- Run local commands and Playwright packs.
+- Inspect screenshots, traces, logs, manifests, and deploy evidence.
+- Try to falsify the PR owner's claims.
+- Refuse native, staging, or production claims that are only simulated or
+  missing exact SHA evidence.
+- For Level 3+ PRs, use a different agent instance from the worker, preferably a
+  different model family when available.
+- Start from a clean worktree based on the PR head, rerun required commands,
+  and inspect generated artifacts rather than trusting worker-reported output.
+- Write a separate verifier note or manifest section with commands run,
+  evidence inspected, unresolved doubts, and final signoff/hold decision.
+
+Reviewer agents:
+
+- Review final diffs for regressions, missing tests, security, WCAG, i18n, and
+  deployment risk.
+
+Release captain:
+
+- Owns one deployment train at a time.
+- Confirms every PR has risk level, validation manifest, and artifact pointers.
+- Confirms all train PRs are reconciled with current `origin/main`.
+- Confirms staging and production promotion use the same immutable candidate
+  SHA, or records why re-validation was required after `origin/main` advanced.
+- Decides rollback versus fix-forward when a train stops.
+
+Command-and-control rules:
+
+- One owner per PR.
+- One release captain per deployment train.
+- One independent verifier for Level 3+ PRs.
+- Owned paths must be explicit before implementation begins.
+- No PR joins a train without a validation manifest.
+- No stale patch joins a train without reconciliation against current
+  `origin/main`.
+- No train deploys while another train controls the same production lane unless
+  release captains coordinate the overlap.
+
+## Reviewbot And GLM Swarm
+
+The existing `6529reviewbot` lanes remain required but secondary to tests:
+
+- `general` for broad correctness.
+- `wcag` for accessibility risks.
+- `i18n` for localization risks.
+- `security` for security-sensitive changes.
+- `responsiveness` for layout and viewport risk.
+
+Every PR description must state how reviewbot findings were fixed, deferred,
+or marked false positive. For Level 3+ PRs, reviewbot findings must be mapped
+into the validation manifest.
+
+Swarm and reviewbot feedback model:
+
+- Reviewbot, GLM, Codex reviewers, and scanner outputs are hypothesis
+  generators. They are allowed to be high-recall, noisy, and redundant.
+- A swarm finding normally creates feedback for Codex to evaluate, fix, rerun,
+  or explicitly dismiss. It does not take decision authority away from Codex.
+- A finding can block promotion only when it maps to a disaster-class hard
+  invariant violation with deterministic, reproducible evidence.
+- Missing evidence required by the risk floor holds promotion until Codex
+  produces the evidence, records an accepted exception, or moves the PR out of
+  the train. It should not stop Codex from continuing to iterate.
+- Non-invariant findings become advisory risk signals, auto-fix candidates, or
+  logged noise. They should not block merge by volume, majority vote, or model
+  confidence alone.
+- No PR may be blocked solely because two swarms disagree. Contradictions are
+  resolved by invariant precedence, reproducibility, and deterministic test
+  evidence.
+- Codex plus review bots should continue cycling on a PR until no new useful
+  findings or safe patches are produced. For safe classes, merge can proceed
+  once deterministic gates pass and the cycle has stopped adding value.
+- Hard blocks should be exceptional. When in doubt, feed the finding back into
+  Codex for another iteration rather than giving the bot/test more authority
+  than the coding agent.
+
+Add a separate, parallel GLM/OpenRouter swarm review path. It should not
+replace the existing Opus-backed lanes. It should run beside them and post one
+synthesized comment: `6529bot GLM Swarm Review`.
+
+Initial target model:
+
+- `z-ai/glm-5.2` through OpenRouter, subject to verification at implementation
+  time.
+- As of 2026-06-20, OpenRouter listed GLM 5.2 at a 1M-token context window with
+  `$1.20 / 1M` input tokens and `$4.10 / 1M` output tokens.
+- Z.ai direct pricing listed GLM-5.2 at `$1.40 / 1M` input tokens, `$0.26 / 1M`
+  cached input tokens, and `$4.40 / 1M` output tokens.
+- Prices, routing, context limits, and provider availability must be rechecked
+  before implementation.
+
+Suggested GLM internal threads:
+
+1. Diff risk classifier.
+2. Missing test evidence auditor.
+3. Changed-route smoke planner.
+4. WCAG semantic HTML reviewer.
+5. Keyboard and visible-focus reviewer.
+6. Dialog, menu, popover, and overlay reviewer.
+7. I18n hardcoded-copy reviewer.
+8. I18n date, number, percent, relative-time, and sorting reviewer.
+9. Long translated text and wrapping reviewer.
+10. Mobile and responsive layout reviewer.
+11. Capacitor/native-adjacent reviewer.
+12. Electron/Desktop Shell reviewer.
+13. Auth, session, cookie, and token reviewer.
+14. Wallet, signing, and transaction-safety reviewer.
+15. Upload, media, and link-preview reviewer.
+16. XSS, unsafe URL, and unsafe HTML reviewer.
+17. Next.js rendering, hydration, routing, and build-risk reviewer.
+18. Loading, error, empty-state, and recovery reviewer.
+19. Deployment, staging, production, and rollback-risk reviewer.
+20. Contrarian reviewer: strongest argument this PR should not merge yet.
+
+High-risk GLM lanes should be adversarial:
+
+- How could this break auth or session recovery?
+- How could this show the wrong wallet, profile, owner, or identity?
+- How could this misdescribe a signing action?
+- How could this make posting, deletion, moderation, voting, or admin actions
+  available when they should not be?
+- How could this upload, media, or link-preview path allow unsafe URLs, unsafe
+  HTML, or script execution?
+- How could translated or long text hide an important action?
+- How could this remove accessible names, focus order, or keyboard operation?
+- How could this route expose admin or private UI to the wrong user?
+- How could this PR claim mobile, Capacitor, Electron, staging, or production
+  evidence that was not actually collected?
+- What exact invariant from this strategy is untested or contradicted?
+
+GLM posting rules:
+
+- Post one synthesized comment, not twenty comments.
+- Keep the final comment to the strongest findings.
+- Every finding must cite a file/line, PR section, CI result, or missing
+  evidence field.
+- Mark severity and confidence.
+- Include required test packs for evidence findings.
+- Treat GLM swarm findings as advisory at first.
+- Do not pass secrets, credentials, cookies, raw production data, or hidden
+  prompts to the GLM job.
+- Store retained raw swarm outputs on approved artifact storage, not Git LFS.
+- Record model slug, provider, prompt version, prompt hash, tokens, cost,
+  latency, and comment URL.
+- Do not run GLM or any external-model job with secrets on fork or untrusted
+  PRs. For untrusted PRs, run only local static classifiers that do not require
+  external API keys.
+- Thread selection is risk based:
+  - Level 0-1: risk classifier plus missing-evidence auditor only;
+  - Level 2: add WCAG, i18n, mobile, and changed-route planning lanes;
+  - Level 3+: allow full adversarial fan-out when within budget;
+  - Level 4-5: full fan-out plus release/deploy and contrarian lanes.
+- Initial budget caps:
+  - per PR hard cap: 300k input tokens and 40k output tokens;
+  - full fan-out hard cap: 20 internal threads;
+  - diff-size cap: summarize or chunk large diffs before fan-out;
+  - kill switch: one config flag disables GLM without disabling existing
+    Opus-backed reviewbot lanes.
+
+## Production Readiness For Level 4-5
+
+Use PRR-lite only for Level 4-5 work. Do not apply it to ordinary UI patches.
+
+Checklist:
+
+- What production user journey can fail?
+- What dependencies are involved?
+- What metrics and alerts observe the change?
+- What is the rollback or fix-forward path?
+- What data, auth, wallet, upload, or admin state can be harmed?
+- What secrets, credentials, or private artifacts are involved?
+- What is the capacity/performance risk?
+- Who is release captain?
+- Who is verifier?
+- Who watches production and for how long?
+- What public communication waits for production validation?
+
+## Metrics And Project Health
+
+Track whether the system is getting safer and faster:
+
+- Escaped defects by risk level and test pack.
+- Failed staging causes.
+- Production rollback or fix-forward events.
+- Reviewbot true positives and false positives.
+- GLM swarm unique useful findings, duplicates, and false positives.
+- Average PR validation time by risk level.
+- Flaky test rate by pack and surface.
+- Percent of PRs with complete validation manifests.
+- Percent of deployment trains with durable artifact pointers.
+- Percent of Level 3+ PRs independently verified before merge.
+- Large test runtime and ownership coverage.
+- Time from merge to production validation.
+
+Metrics guide investment. They should not punish honest stop-the-line calls.
+
+## First Implementation Train
+
+### PR 0: Executable Safety Controls And Manifest Schema
+
+Goals:
+
+- Land this coherent strategy.
+- Add validation manifest schema and examples.
+- Add risk-level and hazard-analysis templates.
+- Implement deterministic risk-floor classifier with conservative Level 3+
+  path globs.
+- Add risk downgrade fields that require release-captain approval.
+- Define artifact pointer fields for S3, IPFS, or future 6529 artifact service.
+- Define redaction contract for screenshots, traces, logs, and model outputs.
+- Define read-only mutation-guard contract for staging and production tests.
+- Define stop-the-line states and train assignment requirements.
+
+Exit criteria:
+
+- Page-cluster PRs have a standard safety-case template.
+- Low-risk PRs can move quickly without pretending to be high-risk releases.
+- Guarded risks are automatically routed to guarded lanes by an executable
+  classifier, not by self-reporting.
+- Risk downgrades are impossible without a release-captain manifest entry.
+- Agents can record artifact URI, hash/CID/ETag, retention class, redaction
+  status, workflow run, and producing command.
+- The strategy is explicit that Git LFS is not the artifact store.
+
+### PR 1: Test Harness Repair And Test Sizing
+
+Goals:
+
+- Restore or replace `tests/testHelpers.ts`.
+- Repair local and staging Playwright smoke.
+- Add shared page error, console error, no-overflow, screenshot, and route-ready
+  helpers.
+- Add read-only mutation guard with request interception for staging and
+  production tests.
+- Add artifact redaction hook and fake-secret regression test before retained
+  traces/logs/screenshots are uploaded anywhere.
+- Add `@small`, `@medium`, `@large` conventions.
+- Add test typecheck coverage for Playwright helpers.
+
+Exit criteria:
+
+- `seize run test:e2e` can run at least core local smoke.
+- `seize run test:e2e:staging` can run against staging in read-only mode.
+- Staging/production tests fail closed on non-allowlisted mutations.
+- Representative fake secrets are blocked by the redaction verifier.
+- Missing helper imports are impossible to miss in test typecheck.
+- Test-size guidance is visible to agents and reviewbot.
+
+### PR 2: App PR CI Baseline
+
+Goals:
+
+- Add broad pull request workflow for ordinary app changes.
+- Run install, lint, typecheck, test typecheck, Jest, build when needed, and a
+  small Playwright smoke pack.
+- Add risk-aware execution ladder.
+- Enforce the deterministic risk-floor classifier in PR CI.
+- Add security baseline checks: secret scanning, dependency vulnerability
+  thresholds, and workflow permission/secret exposure review.
+- Upload short-term CI artifacts.
+- Avoid secret exposure for fork PRs.
+- Use least-privilege workflow permissions.
+
+Exit criteria:
+
+- Ordinary app PRs receive repo-owned CI signal before reviewbot/deployment.
+- Untrusted PRs never receive API keys, staging credentials, deployment
+  permissions, or artifact-store write credentials.
+- CI evidence is inspectable by agents.
+- Expensive checks run in the right stage, not on every tiny PR.
+
+### PR 3: WCAG/I18n Playwright Foundation
+
+Goals:
+
+- Add `@axe-core/playwright`.
+- Add accessibility fixture and first route-level axe smoke.
+- Add documented axe rule profile and expiring allowlist mechanism.
+- Add keyboard/focus helpers.
+- Add locale fixture for supported locale matrix.
+- Add first long-label/wrapping smoke for migrated public routes.
+
+Exit criteria:
+
+- A migrated route can produce WCAG/i18n browser evidence with one command.
+- Reports distinguish automated a11y from manual WCAG verification.
+
+### PR 4: Surface Matrix And Large-Test Ownership
+
+Goals:
+
+- Add Playwright projects for desktop and mobile.
+- Centralize native runtime detection before relying on simulation projects.
+- Add Electron simulation against the centralized detection API.
+- Add Capacitor iOS/Android simulation against the centralized detection API.
+- Document simulation limits.
+- Add owner/purpose/runtime/flake policy for large Playwright packs.
+- Keep Firefox, WebKit, tablet, Capacitor simulation, and Electron simulation
+  train/nightly-only until desktop and mobile Chromium are stable.
+- Identify what is needed for future real native shell smoke.
+
+Exit criteria:
+
+- Page-cluster PRs can declare exact covered surfaces.
+- Simulated native evidence is never mislabeled as real native evidence.
+- Large tests have owners and repair expectations.
+- Native-adjacent simulation is based on one shared runtime-detection path.
+
+### PR 5: Deployment Evidence And Release Reports
+
+Goals:
+
+- Connect Playwright outputs to deployment bus manifests.
+- Define staging and production pack names.
+- Add train-level release report template.
+- Integrate validation manifests with approved artifact storage.
+- Store durable artifact pointers, not Git LFS blobs.
+- Require surface owners to report validation slices.
+- Add auto-hold criteria for staging/production promotion.
+- Add SHA-pinned promotion: production promotes the exact staging-validated SHA
+  or re-validates if `origin/main` advanced.
+
+Exit criteria:
+
+- A deployment train has exact SHA, included PRs, required packs, owners,
+  evidence, failures, skipped checks, and final status.
+- Staging and production evidence can be reloaded from 6529-controlled artifact
+  storage by a future agent.
+- Release reports make train state clear to humans.
+- Level 3+ page-cluster work is blocked unless PR 1 and PR 5 gates are green or
+  a release captain records a temporary manual-validation exception.
+
+### PR 6: Open-Model Swarm Reviewbot
+
+Goals:
+
+- Keep current Opus-backed `6529reviewbot` lanes unchanged.
+- Add a separate GLM/OpenRouter swarm review job.
+- Fan out one PR review into narrow internal GLM threads.
+- Synthesize outputs into one posted GLM swarm review comment.
+- Add cost caps, telemetry, prompt/version tracking, and kill switch.
+- Add risk-based thread selection, per-PR token caps, diff-size caps, and
+  untrusted-PR restrictions.
+- Store retained raw swarm outputs on approved artifact storage.
+- Keep first rollout advisory.
+
+Exit criteria:
+
+- A test PR receives normal reviewbot plus one separate GLM swarm comment.
+- GLM comments cite concrete file lines or missing evidence.
+- Raw internal outputs are available for maintainers but do not spam the PR.
+- Cost, latency, and usefulness can be measured per PR.
+- Full fan-out cannot run accidentally on low-risk or untrusted PRs.
+
+### PR 7: Canary And Feature-Flag Direction
+
+Goals:
+
+- Document what current infra can support: auto-hold, staged watch, feature
+  flags, traffic splitting, or none.
+- Add canary-readiness requirements for Level 4-5 changes.
+- Define candidate-vs-control metrics for future rollout automation.
+
+Exit criteria:
+
+- Current production watch is explicit.
+- Future canary work has clear prerequisites.
+
+## Page-Cluster PR Requirements After The Sidequest
+
+Before opening:
+
+- Complete the pre-PR impact and testing plan from `mega-run-pr-playbook.md`.
+- Record computed risk floor, declared risk level, final risk level, and hazard
+  analysis.
+- Select required test sizes and packs from this strategy.
+- Run the local checks that match the impact plan.
+- Capture evidence for web, mobile, and relevant native-adjacent surfaces.
+- Prepare the validation manifest and durable artifact storage plan.
+- For Level 3+ PRs, confirm PR 1 and PR 5 gates are already green or obtain a
+  release-captain temporary manual-validation exception before opening.
+
+In the PR description:
+
+- State this is part of the WCAG 2.2 AA and i18n mega run.
+- State risk level, safety-case summary, and required gates.
+- Link the affected route cluster.
+- State functionality, UX, safety, web, mobile/Capacitor, and Electron impact.
+- List local commands and Playwright packs run.
+- List manual checks performed.
+- Link durable artifact pointers or explain when they will be produced.
+- List reviewbot findings and decisions.
+- List residual risk and exceptions.
+
+Before production:
+
+- Staging passed for the exact immutable production candidate SHA or release
+  set. If `origin/main` advanced after staging, re-validate or promote the
+  already validated SHA.
+- Changed surfaces have owner validation.
+- Core smoke passed.
+- Required post-deploy watch plan exists.
+- Production deployment is SHA-pinned and matches the release report.
+
+## Success Criteria
+
+The sidequest is complete when:
+
+- Local Playwright and deployed staging smoke are reliable.
+- Ordinary app PRs have repo-owned CI gates.
+- Test files and helpers are typechecked.
+- Deterministic risk-floor classifier is enforced in CI and downgrade requires
+  release-captain manifest approval.
+- Staging/production Playwright has request-interception mutation guard.
+- Artifact redaction pipeline is tested with fake-secret regression coverage.
+- `@small`, `@medium`, and `@large` sizing exists and is used.
+- WCAG/i18n Playwright helpers exist and are documented.
+- Desktop and mobile browser projects exist.
+- Native-adjacent simulation is explicit and documented.
+- Native runtime detection is centralized before Capacitor/Electron simulation
+  is trusted.
+- Large Playwright packs have owners, purpose, runtime expectations, and flake
+  policies.
+- Staging and production validation produce durable artifact pointers on
+  6529-controlled infrastructure, not Git LFS.
+- Page-cluster PRs use risk levels, hazard analysis, validation manifests, and
+  traceable safety-case evidence.
+- Fast, standard, guarded, and release-captain lanes speed safe work without
+  flattening risk.
+- Reviewbot and GLM swarm ask adversarial questions tied to invariants.
+- Level 3+ PRs receive independent verification before merge.
+- Level 4-5 PRs receive PRR-lite review.
+- Deployment trains have release captains, release reports, exact candidate
+  SHAs, auto-hold criteria, and post-deploy watch evidence.
+- GLM swarm has risk-based fan-out, cost caps, diff caps, untrusted-PR
+  restrictions, and a kill switch.
+- Agents can join the workstream, read this strategy, and produce comparable
+  validation evidence without bespoke instructions.
+
+## Open Decisions
+
+- Decide exact first-pass risk-floor glob list during PR 0 implementation.
+- Decide whether first CI workflow should run changed-file Jest plus scheduled
+  full runs, or full Jest on every PR after baseline timing is measured.
+- WebKit and Firefox default to train/nightly gates until desktop/mobile
+  Chromium is stable; decide when to promote them to PR gates.
+- Decide when real Capacitor/Electron smoke becomes mandatory instead of
+  simulated only.
+- Decide whether coverage ratchets should apply only to critical helpers first
+  or to broader directories.
+- Decide whether to add pseudo-locale support during this sidequest or after the
+  first successful page-cluster train.
+- Private 6529-controlled object storage is the default durable artifact
+  backend; decide exact bucket/service names, retention classes, and IAM roles.
+- IPFS/IPNS is only for intentionally public, redacted provenance artifacts.
+- Decide what current deployment infra can support for auto-hold, feature flags,
+  and future canary rollout.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-doctor:diff": "node scripts/require-6529-command.cjs && node scripts/react-doctor-diff.cjs",
     "dependency:risk-gate": "node scripts/require-6529-command.cjs && node scripts/dependency-risk-gate.cjs",
     "deployment-bus": "node scripts/require-6529-command.cjs && node ops/scripts/deployment-bus.cjs",
+    "testing-strategy": "node scripts/require-6529-command.cjs && node ops/scripts/testing-strategy.cjs",
     "format": "node scripts/require-6529-command.cjs && prettier --write .",
     "format:check": "node scripts/require-6529-command.cjs && prettier --check .",
     "format:changed": "node scripts/require-6529-command.cjs && bash -lc '{ git diff --name-only -z --diff-filter=ACMR main...HEAD -- \"*.js\" \"*.jsx\" \"*.ts\" \"*.tsx\" \"*.json\" \"*.css\" \"*.scss\" \":(exclude)generated/**\"; git ls-files --others --exclude-standard -z -- \"*.js\" \"*.jsx\" \"*.ts\" \"*.tsx\" \"*.json\" \"*.css\" \"*.scss\" \":(exclude)generated/**\"; } | xargs -0 prettier --write --ignore-unknown'",


### PR DESCRIPTION
## Issue
- This is PR 0 for the WCAG 2.2 AA and i18n migration testing sidequest.
- The workstream needed executable safety controls before broad page-cluster remediation accelerates: deterministic risk floors, validation manifest contracts, durable artifact pointer rules, and mutation-registry scaffolding.
- Existing `6529reviewbot` reviews must remain the minimum PR review floor; this PR does not modify `.github/6529bot.yml`.

## Fix
- Adds an ops-owned testing strategy CLI that classifies changed-file risk floors, validates PR validation manifests, validates durable artifact pointers, and validates the mutation endpoint registry contract.
- Adds schemas and a minimal example manifest so future agents can produce comparable evidence.
- Refactors the testing strategy docs into a coherent, implementation-ready release/testing strategy while parking the self-organizing queue in a future note.

## Changes
- Added `ops/scripts/testing-strategy.cjs` with commands:
  - `compute-risk-floor`
  - `validate-manifest`
  - `summarize-manifest`
  - `validate-mutation-registry`
- Added `ops/testing-strategy/` schema and example artifacts:
  - validation manifest schema
  - mutation endpoint registry schema
  - checked-in registry contract
  - minimal validation manifest example
- Added `testing-strategy` package script through the repo wrapper.
- Added focused Jest coverage for:
  - docs/test fast-lane classification
  - user-visible runtime risk
  - auth/wallet/upload/admin guarded risk
  - release/deploy/tooling Level 4 risk
  - secret/prod-authority Level 5 risk
  - feature-flag and i18n modifiers
  - route-impact hints
  - downgrade approval requirements
  - Level 3+ durable artifact pointer requirements
  - local/Git-LFS artifact rejection
  - required preservation of all existing reviewbot initial lanes
  - mutation registry validation
- Updated workstream docs and playbook for the i18n/WCAG mega run, Codex/reviewbot feedback loop, artifact handling, and future swarm notes.

## Validation
- `seize install:frozen`
- `seize run test:no-coverage -- __tests__/scripts/testing-strategy.test.ts`
- `seize run lint:changed`
- `seize run typecheck:changed`
- `seize run testing-strategy -- validate-manifest --file ops/testing-strategy/examples/minimal.validation-manifest.json`
- `seize run testing-strategy -- validate-mutation-registry --file ops/testing-strategy/mutation-endpoint-registry.json`
- `seize run testing-strategy -- compute-risk-floor --changed-from origin/main --json`
- `codex-diff-check`
- Manual scan: changed files contain no non-ASCII, trailing whitespace, local absolute paths, or changes to `.github/6529bot.yml`.

## Risk
- Level: High
- Why: This touches operational testing and release-safety controls plus `package.json`, so the new classifier correctly computes Level 4. It does not change app runtime, auth, wallet, upload, admin, or deploy workflows.
- Rollback: revert this PR. It only adds ops tooling/docs and a package script; no runtime state or deployment config is mutated.

## Review Notes
- Please focus on whether the risk-floor rules are conservative enough without becoming unusably broad.
- Please check that manifest validation preserves the existing reviewbot baseline: `general`, `wcag`, `i18n`, `security`, and `responsiveness`.
- Future PR1 will repair Playwright helpers and implement read-only mutation guards; this PR only establishes the executable contracts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a testing strategy risk-floor classifier with commands to compute risk floors and validate validation manifests and mutation endpoint registries.
  * Introduced a mutation endpoint registry contract for staging/production read-only mutation controls.
  * Added an npm script to run the testing strategy utility.
* **Documentation**
  * Added/expanded frontend accessibility & i18n mega-run playbooks and workflow guidance, including evidence and validation expectations.
* **Tests**
  * Added Jest test coverage for risk classification and JSON schema/validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->