### PR TITLE
Repair staging Playwright smoke harness

### DIFF
--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -155,6 +155,16 @@ The command sets:
 - `PLAYWRIGHT_BASE_URL=https://staging.6529.io`
 - `PLAYWRIGHT_SKIP_WEB_SERVER=1`
 
+When the staging access gate is enabled, provide the access code through
+`PLAYWRIGHT_STAGING_ACCESS_CODE` or `STAGING_AUTH`. Local Codex operators can
+load that value from the Windows Credential Manager target `STAGING_AUTH`, but
+must not print or persist it.
+
+The Playwright config disables traces when `PLAYWRIGHT_BASE_URL` is
+`https://staging.6529.io` so the access-code entry is not retained in retry
+artifacts. Do not re-enable traces for staging smoke runs unless the unlock flow
+has a separate redaction path.
+
 Keep deployed-environment tests production-safe: no public posts, purchases,
 wallet transfers, signer changes, destructive writes, or irreversible live
 actions.

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -30,9 +30,11 @@ Read this section first after compaction or handoff.
       https://6529.io/waves/05b14183-e153-4e47-bc66-42a0f49102d4?drop=b3df3435-2bae-4a7f-b9c2-5d93feb7b524
     - Follow The Repo deployment note:
       https://6529.io/waves/49f0e595-ec7c-4235-8695-a527f61b69f4?drop=f8edf3f7-4255-4889-8a24-0a8a2e8cc469
-  - `seize run test:e2e:staging` is still blocked by the existing harness
-    problem `Cannot find module '../testHelpers'`; direct authenticated browser
-    smoke against staging passed instead.
+  - PR #2792 added the executable testing strategy foundation and was deployed
+    to production on 2026-06-20.
+  - Follow-up branch `codex/fix-staging-playwright-smoke` restores
+    `tests/testHelpers.ts` and makes `seize run test:e2e:staging` run real
+    browser smoke when `PLAYWRIGHT_STAGING_ACCESS_CODE` or `STAGING_AUTH` is set.
 - 2026-06-20 user direction: update the plan for the actual frontend WCAG/i18n
   mega run now that reviewbot is live. Reviewbot is an additional reviewer and
   regression detector only; it does not replace extensive local validation.
@@ -228,13 +230,12 @@ Re-audit each PR against current `origin/main` before merging or deploying it.
 
 ## Next Actions
 
-1. Publish and iterate the strategy foundation PR 0 from
-   `codex/testing-strategy-foundation`. Current PR 0 contents include
-   `ops/scripts/testing-strategy.cjs`, validation manifest schemas/examples,
-   mutation endpoint registry contract, package wrapper, and focused Jest
-   coverage. Preserve the existing `.github/6529bot.yml` lanes unchanged.
-2. Implement PR 1: repair `tests/testHelpers.ts`, local/staging Playwright
-   smoke, and `@small`/`@medium`/`@large` test sizing.
+1. Finish and deploy the staging Playwright smoke repair from
+   `codex/fix-staging-playwright-smoke`. Preserve the existing
+   `.github/6529bot.yml` lanes unchanged.
+2. Continue the broader PR 1 test-harness work after smoke is green:
+   local smoke, shared route-ready helpers, mutation guards, artifact redaction,
+   test sizing, and test typecheck coverage.
 3. Reconcile the existing PR stack from current `origin/main` before opening
    broad new implementation PRs.
 4. For every implementation PR, complete the `mega-run-pr-playbook.md` pre-PR

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1569,3 +1569,40 @@
   - `seize run lint:changed`
   - `seize run typecheck:changed`
   - `codex-diff-check`
+
+## 2026-06-20T12:35Z PR 1 Staging Playwright Smoke Repair Started
+
+- Created clean branch `codex/fix-staging-playwright-smoke` from current
+  `origin/main`.
+- Added `tests/testHelpers.ts` so existing Playwright smoke specs can import
+  shared `test` and `expect` again.
+- The helper unlocks `staging.6529.io` only when the Playwright base URL is
+  staging and `PLAYWRIGHT_STAGING_ACCESS_CODE` or `STAGING_AUTH` is available.
+  It does not print or persist the access code.
+- Refreshed stale title/section assertions in the deployed staging smoke specs
+  for home, `/about/the-memes`, `/about/6529-gradient`, `/about/subscriptions`,
+  and `/the-memes`.
+- Local validation:
+  - `seize run test:e2e:staging` with the access code loaded from local
+    Credential Manager target `STAGING_AUTH`: 6 passed.
+
+## 2026-06-20T12:55Z PR 1 Review Feedback Integrated
+
+- Preserved `.github/6529bot.yml` unchanged; existing initial lanes remain
+  `general`, `wcag`, `i18n`, `security`, and `responsiveness`.
+- Fixed SonarCloud findings by renaming the Playwright fixture callback
+  parameter and re-exporting `expect` directly.
+- Addressed independent subagent security feedback by disabling Playwright
+  traces whenever `PLAYWRIGHT_BASE_URL` targets `staging.6529.io`, preventing
+  the staging access code from being retained in retry trace artifacts.
+- Removed the brittle home smoke assertion that expected a live `/the-memes/`
+  latest-drop link even when staging has no active mint card. The home smoke now
+  asserts stable landing content and active wave links.
+- Local validation after the feedback patch:
+  - `seize exec eslint playwright.config.ts tests/testHelpers.ts tests/home/home.spec.ts tests/pages/about.spec.ts tests/pages/the-memes.spec.ts --no-warn-ignored --max-warnings=0`
+  - `seize run typecheck:changed`
+  - `seize run lint:changed`
+  - `seize run testing-strategy -- compute-risk-floor --changed-from origin/main --json` returned Level 2 because `playwright.config.ts` is touched.
+  - `seize run test:e2e:staging` with the access code loaded from local
+    Credential Manager target `STAGING_AUTH`: 6 passed.
+  - `codex-diff-check`

--- a/ops/workstreams/frontend-a11y-i18n/testing-improvement-plan.md
+++ b/ops/workstreams/frontend-a11y-i18n/testing-improvement-plan.md
@@ -101,10 +101,12 @@ Existing strengths:
 
 Current gaps:
 
-- The Playwright suite on `origin/main` is not a reliable gate because smoke
-  specs import `../testHelpers`, but `tests/testHelpers.ts` is absent.
-- `test:e2e:staging` depends on those smoke specs, so staging E2E cannot yet
-  be treated as a hard promotion signal.
+- The first follow-up testing PR restores the missing `tests/testHelpers.ts`
+  import path and makes `test:e2e:staging` run real deployed browser checks
+  when `PLAYWRIGHT_STAGING_ACCESS_CODE` or `STAGING_AUTH` is available.
+- The Playwright suite still needs broader hardening before it becomes a full
+  promotion signal: route-ready helpers, console/page-error policy, mutation
+  guards, artifact redaction, test sizing, and test typecheck coverage.
 - There is no broad ordinary-PR CI workflow for app changes.
 - Playwright currently runs only a desktop Chromium project.
 - Playwright artifacts are not yet standardized for trace, screenshot, console,
@@ -491,7 +493,9 @@ Purpose:
 
 Required shared fixtures:
 
-- `test` and `expect` exports from `tests/testHelpers.ts`.
+- `test` and `expect` exports from `tests/testHelpers.ts`. The minimal staging
+  smoke fixture unlocks `staging.6529.io` from `PLAYWRIGHT_STAGING_ACCESS_CODE`
+  or `STAGING_AUTH`; it must not log or persist the access code.
 - `gotoAndReady(path)` that waits for usable route state and asserts successful
   response where applicable.
 - Console error, page error, and failed request collection with narrow allowlist.
@@ -1145,8 +1149,8 @@ Exit criteria:
 
 Goals:
 
-- Restore or replace `tests/testHelpers.ts`.
-- Repair local and staging Playwright smoke.
+- Restore or replace `tests/testHelpers.ts` and repair deployed-staging smoke.
+- Repair local Playwright smoke after the staging smoke path is stable.
 - Add shared page error, console error, no-overflow, screenshot, and route-ready
   helpers.
 - Add read-only mutation guard with request interception for staging and

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,14 @@ dotenv.config(); // Loads variables from .env
 dotenv.config({ path: ".env.test" }); // Overrides or adds variables from .env
 
 const baseURL = process.env["PLAYWRIGHT_BASE_URL"] || "http://localhost:3001";
+const stagingHostname = "staging.6529.io";
+const isStagingBaseURL = (() => {
+  try {
+    return new URL(baseURL).hostname === stagingHostname;
+  } catch {
+    return false;
+  }
+})();
 const skipWebServer =
   process.env["PLAYWRIGHT_SKIP_WEB_SERVER"] === "1" ||
   process.env["PLAYWRIGHT_SKIP_WEB_SERVER"] === "true";
@@ -21,7 +29,7 @@ const config = defineConfig({
   reporter: "html",
   use: {
     baseURL,
-    trace: "on-first-retry",
+    trace: isStagingBaseURL ? "off" : "on-first-retry",
   },
   projects: [
     {

--- a/tests/home/home.spec.ts
+++ b/tests/home/home.spec.ts
@@ -5,14 +5,25 @@ test.describe("Home Page", () => {
     await page.goto("/");
   });
 
-  test("should display the Latest Drop section", async ({ page }) => {
-    await expect(page).toHaveTitle("6529");
+  test("should display the home landing content", async ({ page }) => {
+    await expect(page).toHaveTitle("6529.io");
 
-    const heading = page.locator("h1", { hasText: "Latest Drop" });
-    await expect(heading).toBeVisible();
+    await expect(page.getByText("Latest Drop", { exact: true })).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Building a decentralized network state",
+      })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        level: 2,
+        name: "6529 is a network society",
+      })
+    ).toBeVisible();
 
-    const memeTitle = page.locator('h3 a[href^="/the-memes/"]');
-    await expect(memeTitle).toBeVisible();
+    const waveLink = page.getByRole("link", { name: /^View wave / }).first();
+    await expect(waveLink).toBeVisible();
   });
 
   test("should navigate to network health from the hero heart link", async ({

--- a/tests/pages/about.spec.ts
+++ b/tests/pages/about.spec.ts
@@ -3,14 +3,14 @@ import { test, expect } from "../testHelpers";
 test.describe("About Pages", () => {
   test("should load the about/the-memes page", async ({ page }) => {
     await page.goto("/about/the-memes");
-    await expect(page).toHaveTitle("About - THE MEMES | 6529.io");
+    await expect(page).toHaveTitle("The Memes | About");
     const text = page.getByText("large edition, CCO (public domain) NFTs");
     await expect(text).toBeVisible();
   });
 
   test("should display AboutGradients Page", async ({ page }) => {
     await page.goto("/about/6529-gradient");
-    await expect(page).toHaveTitle("About - 6529 GRADIENT | 6529.io");
+    await expect(page).toHaveTitle("6529 Gradient | About");
 
     const gradients = page.locator('[src="/gradients-preview.png"]');
     await expect(gradients).toBeVisible();
@@ -21,7 +21,7 @@ test.describe("About Pages", () => {
 
   test("should display AboutSubscriptions Page", async ({ page }) => {
     await page.goto("/about/subscriptions");
-    await expect(page).toHaveTitle("About - SUBSCRIPTIONS | 6529.io");
+    await expect(page).toHaveTitle("Subscriptions | About");
 
     // Look for the specific paragraph containing "Remote Minting"
     const remoteMintingParagraph = page.getByText("Remote Minting", {

--- a/tests/pages/the-memes.spec.ts
+++ b/tests/pages/the-memes.spec.ts
@@ -6,7 +6,7 @@ test.describe("The Memes Page", () => {
   });
 
   test("should load with correct title and heading", async ({ page }) => {
-    await expect(page).toHaveTitle("The Memes | 6529.io");
+    await expect(page).toHaveTitle("The Memes");
 
     const heading = page.locator("h1", { hasText: "The Memes" });
     await expect(heading).toBeVisible();

--- a/tests/testHelpers.ts
+++ b/tests/testHelpers.ts
@@ -1,0 +1,77 @@
+import { test as base } from "@playwright/test";
+
+const STAGING_HOSTNAME = "staging.6529.io";
+const STAGING_ACCESS_CODE =
+  process.env["PLAYWRIGHT_STAGING_ACCESS_CODE"] ?? process.env["STAGING_AUTH"];
+
+async function unlockStagingAccess(page: import("@playwright/test").Page) {
+  await page.goto("/");
+  if (!isAccessUrl(page.url())) {
+    return;
+  }
+
+  if (!STAGING_ACCESS_CODE) {
+    throw new Error(
+      "Staging Playwright tests require PLAYWRIGHT_STAGING_ACCESS_CODE or STAGING_AUTH."
+    );
+  }
+
+  const accessInput = page
+    .locator(
+      'input[aria-label="Team access code"], input[placeholder="Team Login"]'
+    )
+    .first();
+
+  await accessInput.fill(STAGING_ACCESS_CODE);
+  await Promise.all([
+    page
+      .waitForURL((url) => !isAccessPath(url), { timeout: 10000 })
+      .catch(() => undefined),
+    accessInput.press("Enter"),
+  ]);
+
+  if (isAccessUrl(page.url())) {
+    await page.goto("/");
+  }
+
+  if (isAccessUrl(page.url())) {
+    throw new Error("Staging access gate did not unlock.");
+  }
+}
+
+function isAccessPath(url: URL) {
+  return url.pathname === "/access" || url.pathname.startsWith("/access/");
+}
+
+function isAccessUrl(url: string) {
+  try {
+    return isAccessPath(new URL(url));
+  } catch {
+    return url.includes("/access");
+  }
+}
+
+function shouldUnlockStaging(baseURL?: string) {
+  if (!baseURL) {
+    return false;
+  }
+
+  try {
+    return new URL(baseURL).hostname === STAGING_HOSTNAME;
+  } catch {
+    return false;
+  }
+}
+
+const test = base.extend({
+  page: async ({ page, baseURL }, runTest) => {
+    if (shouldUnlockStaging(baseURL)) {
+      await unlockStagingAccess(page);
+    }
+
+    await runTest(page);
+  },
+});
+
+export { expect } from "@playwright/test";
+export { test };


### PR DESCRIPTION
## Issue
- The deployed-staging smoke pack existed, but it failed before browser execution because every legacy smoke spec imported `../testHelpers` and `tests/testHelpers.ts` was missing.
- During the PR #2792 production train, `seize run test:e2e:staging` failed at module resolution, so staging validation had to fall back to direct browser smoke.
- This PR repairs that first testing-foundation gap without changing app runtime behavior or the existing reviewbot configuration.

## Fix
- Adds `tests/testHelpers.ts` with shared Playwright `test` and `expect` exports.
- When the Playwright base URL is exactly `staging.6529.io`, the helper unlocks the staging access gate using `PLAYWRIGHT_STAGING_ACCESS_CODE` or `STAGING_AUTH` from the process environment.
- Disables Playwright traces for staging-base-url runs so the access-code entry is not retained in retry artifacts.
- Replaces stale/live-mint-dependent smoke assertions with stable current route assertions for the home page, about pages, and The Memes page.
- Updates testing/deployment docs so agents know how to supply staging access credentials without printing or persisting the secret.

## Changes
- `tests/testHelpers.ts`: restored shared smoke-test entrypoint and staging access unlock fixture.
- `playwright.config.ts`: keeps normal `trace: "on-first-retry"` locally, but turns traces off when `PLAYWRIGHT_BASE_URL` targets staging.
- `tests/home/home.spec.ts`: updated title/home-content assertions and removed the brittle `/the-memes/` latest-drop link assumption.
- `tests/pages/about.spec.ts`: updated current page title expectations.
- `tests/pages/the-memes.spec.ts`: updated current page title expectation.
- `ops/docs/developer/deployment-bus-automation.md` and WCAG/i18n workstream docs: recorded the staging access env contract, trace-retention guard, and remaining broader harness follow-ups.

## Validation
- `seize run testing-strategy -- compute-risk-floor --changed-from origin/main --json`: Level 2 because `playwright.config.ts` is touched.
- `seize run test:e2e:staging` with staging access loaded from the local Credential Manager target `STAGING_AUTH`: 6 passed.
- `seize exec eslint playwright.config.ts tests/testHelpers.ts tests/home/home.spec.ts tests/pages/about.spec.ts tests/pages/the-memes.spec.ts --no-warn-ignored --max-warnings=0`
- `seize run typecheck:changed`
- `seize run lint:changed`
- `codex-diff-check`
- Manual check: `.github/6529bot.yml` has an empty diff; existing reviewbot lanes remain the minimum baseline.

## Risk
- Level: Standard / Level 2.
- Computed floor: Level 2 (`playwright.config.ts` is classified as unclassified runtime/config; docs/tests remain Level 0).
- Why: Test harness and Playwright config only. It does not modify app runtime, auth, wallet, deployment workflows, or reviewbot config. The staging access code is read only from process env, never logged or persisted, and staging traces are disabled to prevent retry artifact retention.
- Rollback: revert this PR. The app runtime remains unchanged.

## Risk And Validation
- Computed / declared / final risk: 2 / Standard / Standard.
- Hazard analysis: staging access secret could leak -> severity high, likelihood low, detection via diff/log review, required test via staging smoke with no secret output, mitigation via staging trace disablement, rollback by reverting helper/config.
- Functionality risk: staging smoke could become flaky or too broad -> mitigated by asserting stable route/page contracts and running the suite against live staging.
- Validation manifest: N/A for this Level 2 test-harness repair; validation evidence is listed above.
- Durable artifacts: no retained traces or screenshots uploaded by this PR.

## Review Notes
- Please focus on whether the staging access fixture is narrow enough, whether disabling traces for staging is sufficient secret-retention mitigation, and whether the refreshed smoke assertions preserve useful deployed-route coverage.
- Do not remove or weaken any existing reviewbot lanes. This PR intentionally leaves `.github/6529bot.yml` unchanged.