### PR TITLE
Fix staging read-only smoke guard

### DIFF
--- a/__tests__/playwright/readonlyMutationGuard.test.ts
+++ b/__tests__/playwright/readonlyMutationGuard.test.ts
@@ -1,6 +1,7 @@
 import {
   decideReadonlyRequest,
   inferPlaywrightEnvironment,
+  sanitizeReadonlyRequestUrl,
   shouldUseReadonlyGuard,
 } from "../../tests/support/readonlyMutationGuard";
 
@@ -25,7 +26,20 @@ describe("Playwright read-only mutation guard", () => {
     expect(shouldUseReadonlyGuard("http://localhost:3001")).toBe(false);
   });
 
-  it("blocks registered production API mutations", () => {
+  it("blocks registered staging and production API mutations", () => {
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://staging.6529.io",
+        method: "POST",
+        readonly: true,
+        url: "https://api.staging.6529.io/api/waves",
+      })
+    ).toMatchObject({
+      action: "block",
+      reason: "registered-mutation-endpoint",
+      ruleId: "staging-backend-api-mutations",
+    });
+
     expect(
       decideReadonlyRequest({
         baseURL: "https://6529.io",
@@ -65,19 +79,45 @@ describe("Playwright read-only mutation guard", () => {
     ).toMatchObject({ action: "allow" });
   });
 
-  it("allows explicitly recognized external telemetry but blocks other POSTs", () => {
+  it("aborts recognized external SDK POSTs without failing read-only mode", () => {
     expect(
       decideReadonlyRequest({
         baseURL: "https://6529.io",
         method: "POST",
         readonly: true,
-        url: "https://www.google-analytics.com/g/collect",
+        url: "https://cca-lite.coinbase.com/metrics",
       })
     ).toMatchObject({
-      action: "allow",
-      reason: "allowed-telemetry-endpoint",
+      action: "abort",
+      reason: "ignored-external-sdk-endpoint",
     });
 
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://staging.6529.io",
+        method: "POST",
+        readonly: true,
+        url: "https://www.google.com/g/collect?v=2",
+      })
+    ).toMatchObject({
+      action: "abort",
+      reason: "ignored-external-sdk-endpoint",
+    });
+
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://staging.6529.io",
+        method: "POST",
+        readonly: true,
+        url: "https://pulse.walletconnect.org/batch?projectId=test",
+      })
+    ).toMatchObject({
+      action: "abort",
+      reason: "ignored-external-sdk-endpoint",
+    });
+  });
+
+  it("blocks non-allowlisted external POSTs", () => {
     expect(
       decideReadonlyRequest({
         baseURL: "https://6529.io",
@@ -89,6 +129,93 @@ describe("Playwright read-only mutation guard", () => {
       action: "block",
       reason: "non-allowlisted-mutation",
     });
+
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://6529.io",
+        method: "POST",
+        readonly: true,
+        url: "https://www.google.com/unknown-write",
+      })
+    ).toMatchObject({
+      action: "block",
+      reason: "non-allowlisted-mutation",
+    });
+  });
+
+  it("allows only read-only WalletConnect RPC POSTs", () => {
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://staging.6529.io",
+        method: "POST",
+        postData: JSON.stringify({
+          id: 1,
+          jsonrpc: "2.0",
+          method: "eth_chainId",
+        }),
+        readonly: true,
+        url: "https://rpc.walletconnect.org/v1/?chainId=eip155%3A1",
+      })
+    ).toMatchObject({
+      action: "allow",
+      reason: "read-only-walletconnect-rpc",
+    });
+
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://staging.6529.io",
+        method: "POST",
+        postData: JSON.stringify([
+          { id: 1, jsonrpc: "2.0", method: "eth_chainId" },
+          { id: 2, jsonrpc: "2.0", method: "eth_call" },
+        ]),
+        readonly: true,
+        url: "https://rpc.walletconnect.org/v1/?chainId=eip155%3A1",
+      })
+    ).toMatchObject({
+      action: "allow",
+      reason: "read-only-walletconnect-rpc",
+    });
+
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://staging.6529.io",
+        method: "POST",
+        postData: JSON.stringify({
+          id: 1,
+          jsonrpc: "2.0",
+          method: "eth_sendRawTransaction",
+        }),
+        readonly: true,
+        url: "https://rpc.walletconnect.org/v1/?chainId=eip155%3A1",
+      })
+    ).toMatchObject({
+      action: "block",
+      reason: "unsafe-walletconnect-rpc",
+    });
+
+    for (const postData of [undefined, "not-json", JSON.stringify([])]) {
+      expect(
+        decideReadonlyRequest({
+          baseURL: "https://staging.6529.io",
+          method: "POST",
+          postData,
+          readonly: true,
+          url: "https://rpc.walletconnect.org/v1/?chainId=eip155%3A1",
+        })
+      ).toMatchObject({
+        action: "block",
+        reason: "unsafe-walletconnect-rpc",
+      });
+    }
+  });
+
+  it("redacts URL query strings in guard summaries", () => {
+    expect(
+      sanitizeReadonlyRequestUrl(
+        "https://rpc.walletconnect.org/v1/?chainId=eip155%3A1&projectId=secret"
+      )
+    ).toBe("https://rpc.walletconnect.org/v1/?[redacted]");
   });
 
   it("does not attribute third-party API paths to first-party registry rules", () => {

--- a/ops/testing-strategy/mutation-endpoint-registry.json
+++ b/ops/testing-strategy/mutation-endpoint-registry.json
@@ -1,9 +1,18 @@
 {
   "schema_version": "frontend-testing.mutation-endpoint-registry.v1",
   "owner": "frontend-release-captain",
-  "updated_at": "2026-06-20T00:00:00.000Z",
+  "updated_at": "2026-06-20T18:00:00.000Z",
   "description": "Versioned registry contract for endpoints that must be blocked by read-only staging and production Playwright mutation guards.",
   "endpoints": [
+    {
+      "id": "staging-backend-api-mutations",
+      "pattern": "https://api.staging.6529.io/**",
+      "methods": ["POST", "PUT", "PATCH", "DELETE"],
+      "surface": "backend-api",
+      "risk_level": 3,
+      "mutation": true,
+      "allowed_in_readonly_tests": false
+    },
     {
       "id": "production-backend-api-mutations",
       "pattern": "https://api.6529.io/**",

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1654,3 +1654,37 @@
   `seize` wrapper. A direct `seize exec knip --reporter json` also reports
   broad pre-existing repo dead-code noise plus future-facing helper exports, so
   PR1 does not claim a clean repo-wide knip baseline.
+
+## 2026-06-20T18:20Z PR 1 Staging Harness Follow-Up
+
+- PR #2797 merged to `main` as `5f09e6fe22f496ced5f9992cfbf93fec95f2fb69`.
+- Staging deploy succeeded:
+  https://github.com/6529-Collections/6529seize-frontend/actions/runs/27879071807
+  - staging merge SHA: `efd5bda48c065d23410e0fc8ef42b38fab50dd45`
+  - production candidate SHA:
+    `5f09e6fe22f496ced5f9992cfbf93fec95f2fb69`
+- First staging smoke found harness issues before production promotion:
+  - known page-load SDK POSTs from Coinbase, Google Analytics, and
+    WalletConnect telemetry should be aborted without failing the read-only
+    run;
+  - WalletConnect RPC POSTs need body-level JSON-RPC classification so known
+    read-only methods can continue while unsafe, unknown, missing, or invalid
+    RPC payloads still fail;
+  - staging access login needs to accept the success dialog before waiting for
+    navigation;
+  - deployed staging smoke should run serially.
+- Implemented follow-up branch `codex/testing-pr1-guard-fix` from current
+  `origin/main`.
+- Local/staging validation on the follow-up branch:
+  - `seize run test:no-coverage -- __tests__/playwright/readonlyMutationGuard.test.ts`
+  - `seize run typecheck:playwright`
+  - `seize run testing-strategy -- validate-mutation-registry --file ops/testing-strategy/mutation-endpoint-registry.json`
+  - `seize run lint:package-json`
+  - `seize run lint:changed`
+  - `seize run typecheck:changed`
+  - `seize run format:changed`
+  - `codex-diff-check`
+  - `seize run test:e2e:staging` with access code loaded from local Credential
+    Manager target `STAGING_AUTH`: 6 passed.
+- Production promotion remains held until this follow-up PR is reviewed,
+  merged, redeployed to staging, and validated.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test-extract-failed-names": "node scripts/require-6529-command.cjs && node test-results/list-failed-tests.cjs",
     "test:e2e": "node scripts/require-6529-command.cjs && playwright test",
     "test:e2e:smoke": "node scripts/require-6529-command.cjs && playwright test tests/home/home.spec.ts tests/pages/about.spec.ts tests/pages/the-memes.spec.ts --grep @smoke --workers=1",
-    "test:e2e:staging": "node scripts/require-6529-command.cjs && cross-env PLAYWRIGHT_BASE_URL=https://staging.6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 playwright test tests/home/home.spec.ts tests/pages/about.spec.ts tests/pages/the-memes.spec.ts",
+    "test:e2e:staging": "node scripts/require-6529-command.cjs && cross-env PLAYWRIGHT_BASE_URL=https://staging.6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 playwright test tests/home/home.spec.ts tests/pages/about.spec.ts tests/pages/the-memes.spec.ts --workers=1",
     "test:e2e:ui": "node scripts/require-6529-command.cjs && playwright test --ui",
     "knip": "node scripts/require-6529-command.cjs && knip --fix --allow-remove-files",
     "lint:package-json": "node scripts/require-6529-command.cjs && node scripts/lint-package-json.cjs",

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,6 +21,12 @@ Remote read-only defaults:
 - `PLAYWRIGHT_READONLY=1` is the default for staging and production.
 - Non-GET/HEAD/OPTIONS requests fail unless explicitly allowlisted by the
   read-only mutation guard.
+- Known third-party SDK page-load POSTs, such as analytics and wallet SDK
+  telemetry, are aborted without failing the read-only run. This keeps remote
+  smoke tests private while still failing unknown external POSTs and all
+  registered first-party mutations.
+- WalletConnect RPC POSTs are body-classified: known read-only JSON-RPC methods
+  may continue, while unsafe, unknown, or unparseable calls fail the run.
 - For staging, the shared `context` fixture installs the read-only mutation
   guard before the `page` fixture unlocks the access gate. The current access
   gate uses safe GET requests plus a browser cookie.

--- a/tests/support/readonlyMutationGuard.ts
+++ b/tests/support/readonlyMutationGuard.ts
@@ -17,12 +17,13 @@ export type PlaywrightEnvironment =
 export type ReadonlyRequestInput = {
   baseURL?: string | undefined;
   method: string;
+  postData?: string | null | undefined;
   url: string;
   readonly: boolean;
 };
 
 export type ReadonlyRequestDecision = {
-  action: "allow" | "block";
+  action: "allow" | "abort" | "block";
   reason: string;
   ruleId?: string;
 };
@@ -43,13 +44,40 @@ const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 const STAGING_HOSTNAME = "staging.6529.io";
 const PRODUCTION_HOSTNAMES = new Set(["6529.io", "www.6529.io"]);
 
-const ALLOWED_EXTERNAL_MUTATION_HOSTS = [
-  /(^|\.)google-analytics\.com$/i,
-  /(^|\.)analytics\.google\.com$/i,
+const IGNORED_EXTERNAL_MUTATION_HOSTS = [
   /(^|\.)mixpanel\.com$/i,
   /(^|\.)ingest\.sentry\.io$/i,
   /^dataplane\.rum\.[a-z0-9-]+\.amazonaws\.com$/i,
 ];
+const GOOGLE_COLLECT_HOSTS = new Set([
+  "analytics.google.com",
+  "www.google-analytics.com",
+  "www.google.com",
+]);
+const WALLETCONNECT_RPC_HOST = "rpc.walletconnect.org";
+const SAFE_WALLETCONNECT_RPC_METHODS = new Set([
+  "eth_accounts",
+  "eth_blockNumber",
+  "eth_call",
+  "eth_chainId",
+  "eth_estimateGas",
+  "eth_feeHistory",
+  "eth_gasPrice",
+  "eth_getBalance",
+  "eth_getBlockByHash",
+  "eth_getBlockByNumber",
+  "eth_getBlockTransactionCountByHash",
+  "eth_getBlockTransactionCountByNumber",
+  "eth_getCode",
+  "eth_getLogs",
+  "eth_getStorageAt",
+  "eth_getTransactionByHash",
+  "eth_getTransactionCount",
+  "eth_getTransactionReceipt",
+  "eth_maxPriorityFeePerGas",
+  "net_version",
+  "web3_clientVersion",
+]);
 
 function parseUrl(url: string) {
   try {
@@ -102,10 +130,81 @@ export function shouldUseReadonlyGuard(baseURL?: string) {
   return environment === "staging" || environment === "production";
 }
 
-function isAllowedExternalMutation(url: URL) {
-  return ALLOWED_EXTERNAL_MUTATION_HOSTS.some((pattern) =>
+function isIgnoredExternalMutation(url: URL) {
+  if (
+    url.hostname === "cca-lite.coinbase.com" &&
+    (url.pathname === "/amp" || url.pathname === "/metrics")
+  ) {
+    return true;
+  }
+
+  if (url.hostname === "pulse.walletconnect.org" && url.pathname === "/batch") {
+    return true;
+  }
+
+  if (GOOGLE_COLLECT_HOSTS.has(url.hostname) && url.pathname === "/g/collect") {
+    return true;
+  }
+
+  return IGNORED_EXTERNAL_MUTATION_HOSTS.some((pattern) =>
     pattern.test(url.hostname)
   );
+}
+
+function isWalletConnectRpc(url: URL) {
+  return url.hostname === WALLETCONNECT_RPC_HOST && url.pathname === "/v1/";
+}
+
+function parseJsonRpcPayload(postData?: string | null) {
+  if (!postData) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(postData) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function getJsonRpcCalls(payload: unknown) {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  return [payload];
+}
+
+function isSafeWalletConnectRpcPost(postData?: string | null) {
+  const payload = parseJsonRpcPayload(postData);
+  if (!payload) {
+    return false;
+  }
+
+  const calls = getJsonRpcCalls(payload);
+  if (calls.length === 0) {
+    return false;
+  }
+
+  return calls.every((call) => {
+    if (!call || typeof call !== "object" || Array.isArray(call)) {
+      return false;
+    }
+
+    const method = (call as { method?: unknown }).method;
+    return (
+      typeof method === "string" && SAFE_WALLETCONNECT_RPC_METHODS.has(method)
+    );
+  });
+}
+
+export function sanitizeReadonlyRequestUrl(url: string) {
+  const parsed = parseUrl(url);
+  if (!parsed || !["http:", "https:"].includes(parsed.protocol)) {
+    return url;
+  }
+
+  const redactedSuffix = parsed.search || parsed.hash ? "?[redacted]" : "";
+  return `${parsed.origin}${parsed.pathname}${redactedSuffix}`;
 }
 
 function wildcardPatternToRegExp(pattern: string) {
@@ -170,6 +269,7 @@ function registryMatch(method: string, url: URL, baseURL?: string) {
 export function decideReadonlyRequest({
   baseURL,
   method,
+  postData,
   readonly,
   url,
 }: ReadonlyRequestInput): ReadonlyRequestDecision {
@@ -192,8 +292,16 @@ export function decideReadonlyRequest({
     };
   }
 
-  if (isAllowedExternalMutation(parsed)) {
-    return { action: "allow", reason: "allowed-telemetry-endpoint" };
+  if (isWalletConnectRpc(parsed)) {
+    if (isSafeWalletConnectRpcPost(postData)) {
+      return { action: "allow", reason: "read-only-walletconnect-rpc" };
+    }
+
+    return { action: "block", reason: "unsafe-walletconnect-rpc" };
+  }
+
+  if (isIgnoredExternalMutation(parsed)) {
+    return { action: "abort", reason: "ignored-external-sdk-endpoint" };
   }
 
   return {
@@ -221,14 +329,20 @@ export async function installReadonlyMutationGuard(
     const decision = decideReadonlyRequest({
       baseURL,
       method: request.method(),
+      postData: request.postData(),
       readonly,
       url: request.url(),
     });
 
+    if (decision.action === "abort") {
+      await route.abort("blockedbyclient");
+      return;
+    }
+
     if (decision.action === "block") {
       const blockedRequest: BlockedReadonlyRequest = {
         method: request.method(),
-        url: request.url(),
+        url: sanitizeReadonlyRequestUrl(request.url()),
         reason: decision.reason,
       };
       if (decision.ruleId) {

--- a/tests/testHelpers.ts
+++ b/tests/testHelpers.ts
@@ -10,10 +10,12 @@ import { installReadonlyMutationGuard } from "./support/readonlyMutationGuard";
 const STAGING_HOSTNAME = "staging.6529.io";
 const STAGING_ACCESS_CODE =
   process.env["PLAYWRIGHT_STAGING_ACCESS_CODE"] ?? process.env["STAGING_AUTH"];
+const ACCESS_INPUT_SELECTOR =
+  'input[aria-label="Team access code"], input[placeholder="Team Login"]';
 
 async function unlockStagingAccess(page: import("@playwright/test").Page) {
   await page.goto("/");
-  if (!isAccessUrl(page.url())) {
+  if (!(await isAccessGateVisible(page))) {
     return;
   }
 
@@ -23,25 +25,28 @@ async function unlockStagingAccess(page: import("@playwright/test").Page) {
     );
   }
 
-  const accessInput = page
-    .locator(
-      'input[aria-label="Team access code"], input[placeholder="Team Login"]'
-    )
-    .first();
+  const accessInput = page.locator(ACCESS_INPUT_SELECTOR).first();
 
+  await accessInput.waitFor({ state: "visible", timeout: 5000 });
   await accessInput.fill(STAGING_ACCESS_CODE);
-  await Promise.all([
-    page
-      .waitForURL((url) => !isAccessPath(url), { timeout: 10000 })
-      .catch(() => undefined),
-    accessInput.press("Enter"),
-  ]);
+  const loginDialog = page
+    .waitForEvent("dialog", { timeout: 10000 })
+    .then(async (dialog) => {
+      await dialog.accept();
+    })
+    .catch(() => undefined);
 
-  if (isAccessUrl(page.url())) {
-    await page.goto("/");
+  await accessInput.press("Enter");
+  await loginDialog;
+  await page
+    .waitForURL((url) => !isAccessPath(url), { timeout: 10000 })
+    .catch(() => undefined);
+
+  if (await isAccessGateVisible(page)) {
+    await page.goto("/", { waitUntil: "domcontentloaded" });
   }
 
-  if (isAccessUrl(page.url())) {
+  if (await isAccessGateVisible(page)) {
     throw new Error("Staging access gate did not unlock.");
   }
 }
@@ -56,6 +61,18 @@ function isAccessUrl(url: string) {
   } catch {
     return url.includes("/access");
   }
+}
+
+async function isAccessGateVisible(page: import("@playwright/test").Page) {
+  if (isAccessUrl(page.url())) {
+    return true;
+  }
+
+  return page
+    .locator(ACCESS_INPUT_SELECTOR)
+    .first()
+    .isVisible({ timeout: 500 })
+    .catch(() => false);
 }
 
 function shouldUnlockStaging(baseURL?: string) {


### PR DESCRIPTION
## Issue
- Follow-up to #2797 after staging deploy validation.
- The PR1 harness deployed to staging successfully, but deployed staging smoke found two harness issues before production promotion:
  - read-only mode treated known page-load SDK telemetry/RPC requests as hard mutation failures;
  - staging access login could be flaky because the access page shows a success dialog before redirecting.

## Fix
- Keeps first-party mutation protection fail-closed while separating non-essential third-party SDK egress from real mutations.
- Aborts known page-load telemetry without failing the run, classifies WalletConnect RPC bodies so only known read-only JSON-RPC methods continue, and keeps unsafe/unknown/unparseable RPC calls as hard failures.
- Makes the staging access helper accept the login dialog before waiting for navigation.
- Runs deployed staging smoke serially to avoid remote access-gate noise.

## Changes
- Adds `abort` as a read-only guard decision distinct from `allow` and `block`.
- Adds staging backend API mutation coverage to the mutation registry.
- Redacts URL query strings in read-only guard failure summaries.
- Adds unit coverage for staging API blocks, known SDK aborts, WalletConnect read-only vs unsafe RPC decisions, unknown third-party POST blocks, and URL query redaction.
- Updates `test:e2e:staging` to run with one worker.
- Updates Playwright test docs and the workstream run log with the staging finding and validation evidence.

## Validation
- `seize run test:no-coverage -- __tests__/playwright/readonlyMutationGuard.test.ts`
- `seize run typecheck:playwright`
- `seize run testing-strategy -- validate-mutation-registry --file ops/testing-strategy/mutation-endpoint-registry.json`
- `seize run lint:package-json`
- `seize run lint:changed`
- `seize run typecheck:changed`
- `seize run format:changed`
- `codex-diff-check`
- Deployed staging smoke using local Credential Manager target `STAGING_AUTH`: `seize run test:e2e:staging` passed 6/6 against `https://staging.6529.io`.

## Risk
- Level: Medium.
- Why: This is test infrastructure only, but it controls staging/production read-only safety behavior. First-party mutations remain blocked and failing. Known non-essential telemetry is aborted rather than allowed, reducing analytics/privacy noise.
- Rollback: Revert this PR to return to PR1 guard behavior, but production promotion should remain held because staging smoke would fail again.

## Review Notes
- Please focus on whether the WalletConnect RPC safe-method list is appropriately conservative.
- Please verify that third-party SDK egress is aborted, not allowed through.
- Please verify the staging API mutation rule and query redaction do not weaken first-party mutation detection.
- Existing reviewbot configuration is not changed and remains the minimum review baseline for every PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced read-only mode mutation guard test coverage to include third-party SDK requests, WalletConnect RPC calls, and mutation endpoint blocking scenarios.
  * Updated staging test execution to run serially for improved reliability.

* **Documentation**
  * Clarified read-only mode handling of third-party network requests and WalletConnect transactions.
  * Added deployment validation and staging harness follow-up documentation.

* **Chores**
  * Improved staging access unlock flow with enhanced visibility detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->