### PR TITLE
Harden staging access navigation unlock

### DIFF
--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1704,5 +1704,18 @@
   - `seize run lint:changed`
   - `seize run test:e2e:staging` with access code loaded from local Credential
     Manager target `STAGING_AUTH`: 6 passed.
+- CodeRabbit review found a valid credential-safety edge: once the staging
+  helper wrapped `page.goto`, a deliberate navigation to a non-staging
+  `/access` URL could still trigger access-code submission. Hardened the helper
+  so it submits or retries only when the current page host is
+  `staging.6529.io`.
+- Follow-up validation after the CodeRabbit fix:
+  - `seize run typecheck:playwright`
+  - `seize run lint:changed`
+  - `seize run typecheck:changed`
+  - `seize run format:changed`
+  - `codex-diff-check`
+  - `seize run test:e2e:staging` with access code loaded from local Credential
+    Manager target `STAGING_AUTH`: 6 passed.
 - Production promotion remains held until this tiny follow-up PR is reviewed,
   merged, redeployed to staging, and validated.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1688,3 +1688,21 @@
     Manager target `STAGING_AUTH`: 6 passed.
 - Production promotion remains held until this follow-up PR is reviewed,
   merged, redeployed to staging, and validated.
+
+## 2026-06-20T18:45Z PR 1 Staging Access Retry Follow-Up
+
+- After PR #2798 merged and redeployed to staging, the first deployed smoke run
+  still found one access-gate flake: a later `page.goto(...)` could land back
+  on the access page after the initial fixture unlock.
+- Implemented follow-up branch `codex/testing-staging-access-goto-fix` from
+  current `origin/main`.
+- The staging page fixture now wraps `page.goto` only for staging targets; when
+  a navigation lands on the access gate, it submits the local staging access
+  code, accepts the success dialog, and retries the original navigation once.
+- Local/staging validation:
+  - `seize run typecheck:playwright`
+  - `seize run lint:changed`
+  - `seize run test:e2e:staging` with access code loaded from local Credential
+    Manager target `STAGING_AUTH`: 6 passed.
+- Production promotion remains held until this tiny follow-up PR is reviewed,
+  merged, redeployed to staging, and validated.

--- a/tests/testHelpers.ts
+++ b/tests/testHelpers.ts
@@ -1,4 +1,5 @@
 import { test as base } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
 import {
   assertNoPageErrors,
@@ -12,9 +13,25 @@ const STAGING_ACCESS_CODE =
   process.env["PLAYWRIGHT_STAGING_ACCESS_CODE"] ?? process.env["STAGING_AUTH"];
 const ACCESS_INPUT_SELECTOR =
   'input[aria-label="Team access code"], input[placeholder="Team Login"]';
+type PageGoto = (...args: Parameters<Page["goto"]>) => ReturnType<Page["goto"]>;
 
-async function unlockStagingAccess(page: import("@playwright/test").Page) {
-  await page.goto("/");
+async function installStagingAccessUnlock(page: Page) {
+  const originalGoto = page.goto.bind(page) as PageGoto;
+  const gotoWithAccessUnlock: PageGoto = async (...args) => {
+    const response = await originalGoto(...args);
+    if (!(await isAccessGateVisible(page))) {
+      return response;
+    }
+
+    await submitStagingAccess(page, originalGoto);
+    return originalGoto(...args);
+  };
+
+  page.goto = gotoWithAccessUnlock as Page["goto"];
+  await gotoWithAccessUnlock("/", { waitUntil: "domcontentloaded" });
+}
+
+async function submitStagingAccess(page: Page, goto: PageGoto) {
   if (!(await isAccessGateVisible(page))) {
     return;
   }
@@ -43,7 +60,7 @@ async function unlockStagingAccess(page: import("@playwright/test").Page) {
     .catch(() => undefined);
 
   if (await isAccessGateVisible(page)) {
-    await page.goto("/", { waitUntil: "domcontentloaded" });
+    await goto("/", { waitUntil: "domcontentloaded" });
   }
 
   if (await isAccessGateVisible(page)) {
@@ -63,7 +80,7 @@ function isAccessUrl(url: string) {
   }
 }
 
-async function isAccessGateVisible(page: import("@playwright/test").Page) {
+async function isAccessGateVisible(page: Page) {
   if (isAccessUrl(page.url())) {
     return true;
   }
@@ -99,7 +116,7 @@ const test = base.extend({
     const diagnostics = attachPageDiagnostics(page);
 
     if (shouldUnlockStaging(baseURL)) {
-      await unlockStagingAccess(page);
+      await installStagingAccessUnlock(page);
     }
 
     await runTest(page);

--- a/tests/testHelpers.ts
+++ b/tests/testHelpers.ts
@@ -23,6 +23,10 @@ async function installStagingAccessUnlock(page: Page) {
       return response;
     }
 
+    if (!isStagingPage(page)) {
+      return response;
+    }
+
     await submitStagingAccess(page, originalGoto);
     return originalGoto(...args);
   };
@@ -33,6 +37,10 @@ async function installStagingAccessUnlock(page: Page) {
 
 async function submitStagingAccess(page: Page, goto: PageGoto) {
   if (!(await isAccessGateVisible(page))) {
+    return;
+  }
+
+  if (!isStagingPage(page)) {
     return;
   }
 
@@ -60,6 +68,10 @@ async function submitStagingAccess(page: Page, goto: PageGoto) {
     .catch(() => undefined);
 
   if (await isAccessGateVisible(page)) {
+    if (!isStagingPage(page)) {
+      return;
+    }
+
     await goto("/", { waitUntil: "domcontentloaded" });
   }
 
@@ -77,6 +89,14 @@ function isAccessUrl(url: string) {
     return isAccessPath(new URL(url));
   } catch {
     return url.includes("/access");
+  }
+}
+
+function isStagingPage(page: Page) {
+  try {
+    return new URL(page.url()).hostname === STAGING_HOSTNAME;
+  } catch {
+    return false;
   }
 }
 


### PR DESCRIPTION
## Issue
- Follow-up to #2798 after the redeployed staging smoke found one remaining access-gate flake.
- A later `page.goto(...)` in a staging smoke spec could land back on the access page even after the initial fixture unlock had succeeded.

## Fix
- Wraps `page.goto` only for staging-targeted Playwright runs.
- If a navigation lands on the access gate, the fixture submits the staging access code, accepts the success dialog, and retries the original navigation once.
- Keeps the existing read-only mutation guard ordering intact: the context guard is installed before page unlock/navigation.

## Changes
- Refactors the staging access helper into a `page.goto` wrapper plus a reusable access submission function.
- Updates the workstream run log with the staging finding and validation evidence.
- Does not modify `.github/6529bot.yml`; existing reviewbots remain the minimum review baseline.

## Validation
- `seize run typecheck:playwright`
- `seize run lint:changed`
- `seize run typecheck:changed`
- `seize run format:changed`
- `codex-diff-check`
- Deployed staging smoke using local Credential Manager target `STAGING_AUTH`: `seize run test:e2e:staging` passed 6/6 against `https://staging.6529.io`.

## Risk
- Level: Low to Medium.
- Why: Test harness only, but it touches staging access behavior for Playwright. Scope is limited to staging base URL; production and local runs do not install this unlock wrapper.
- Rollback: Revert this PR to return to #2798 behavior, but staging smoke may intermittently fail when route navigation re-enters the access gate.

## Review Notes
- Please verify the `page.goto` wrapper cannot recurse and only activates for `staging.6529.io`.
- Please verify the guard-before-unlock ordering remains intact.
- Please verify the helper retries the original navigation after unlocking rather than silently passing on `/access`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved staging environment test fixture handling to enhance navigation flow reliability during validation.
  * Updated test infrastructure with refined retry logic for consistent staging environment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->