### PR TITLE
Allow first-party monitoring in read-only smoke guard

### DIFF
--- a/__tests__/playwright/readonlyMutationGuard.test.ts
+++ b/__tests__/playwright/readonlyMutationGuard.test.ts
@@ -117,6 +117,44 @@ describe("Playwright read-only mutation guard", () => {
     });
   });
 
+  it("aborts same-origin telemetry POSTs without allowing external lookalikes", () => {
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://6529.io",
+        method: "POST",
+        readonly: true,
+        url: "https://6529.io/monitoring?o=123&p=456",
+      })
+    ).toMatchObject({
+      action: "abort",
+      reason: "ignored-first-party-telemetry",
+    });
+
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://staging.6529.io",
+        method: "POST",
+        readonly: true,
+        url: "https://staging.6529.io/monitoring/tunnel",
+      })
+    ).toMatchObject({
+      action: "abort",
+      reason: "ignored-first-party-telemetry",
+    });
+
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://6529.io",
+        method: "POST",
+        readonly: true,
+        url: "https://example.com/monitoring",
+      })
+    ).toMatchObject({
+      action: "block",
+      reason: "non-allowlisted-mutation",
+    });
+  });
+
   it("blocks non-allowlisted external POSTs", () => {
     expect(
       decideReadonlyRequest({

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1719,3 +1719,37 @@
     Manager target `STAGING_AUTH`: 6 passed.
 - Production promotion remains held until this tiny follow-up PR is reviewed,
   merged, redeployed to staging, and validated.
+
+## 2026-06-20T19:30Z PR 1 Production Smoke Guard Follow-Up
+
+- PR #2799 merged to `main` as `0d16551ca519ad595604f58dd7a9e0c629e5a27c`.
+- Staging deploy succeeded:
+  https://github.com/6529-Collections/6529seize-frontend/actions/runs/27880870400
+  - staging merge SHA: `b0fbdac2f082040da39f526bcb1a557beef8f29e`
+  - production candidate SHA:
+    `0d16551ca519ad595604f58dd7a9e0c629e5a27c`
+- Fresh deployed staging smoke with access code loaded from local Credential
+  Manager target `STAGING_AUTH`: 6 passed.
+- Production deploy succeeded:
+  https://github.com/6529-Collections/6529seize-frontend/actions/runs/27881187699
+  - deployed production SHA:
+    `0d16551ca519ad595604f58dd7a9e0c629e5a27c`
+- First production smoke found a read-only guard allowlist gap, not an app
+  deploy failure: the live app sends same-origin Sentry tunnel telemetry to
+  `POST /monitoring`, and the new guard blocked it as a non-allowlisted
+  mutation.
+- Implementing follow-up branch
+  `codex/testing-production-monitoring-guard` from current `origin/main` to
+  abort same-origin `/monitoring` telemetry while still blocking external
+  `/monitoring` lookalikes.
+- Follow-up branch validation:
+  - `seize run test:no-coverage -- __tests__/playwright/readonlyMutationGuard.test.ts`
+  - `seize run typecheck:playwright`
+  - `seize run lint:changed`
+  - `seize run typecheck:changed`
+  - `seize run format:changed`
+  - `codex-diff-check`
+  - `PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run
+    test:e2e:smoke`: 6 passed.
+  - `seize run test:e2e:staging` with access code loaded from local Credential
+    Manager target `STAGING_AUTH`: 6 passed.

--- a/tests/support/readonlyMutationGuard.ts
+++ b/tests/support/readonlyMutationGuard.ts
@@ -151,6 +151,18 @@ function isIgnoredExternalMutation(url: URL) {
   );
 }
 
+function isSameOrigin(url: URL, baseURL?: string) {
+  const base = baseURL ? parseUrl(baseURL) : null;
+  return base?.origin === url.origin;
+}
+
+function isFirstPartyTelemetryEndpoint(url: URL, baseURL?: string) {
+  return (
+    isSameOrigin(url, baseURL) &&
+    (url.pathname === "/monitoring" || url.pathname.startsWith("/monitoring/"))
+  );
+}
+
 function isWalletConnectRpc(url: URL) {
   return url.hostname === WALLETCONNECT_RPC_HOST && url.pathname === "/v1/";
 }
@@ -290,6 +302,10 @@ export function decideReadonlyRequest({
       reason: "registered-mutation-endpoint",
       ruleId: endpoint.id,
     };
+  }
+
+  if (isFirstPartyTelemetryEndpoint(parsed, baseURL)) {
+    return { action: "abort", reason: "ignored-first-party-telemetry" };
   }
 
   if (isWalletConnectRpc(parsed)) {


### PR DESCRIPTION
## Issue
- The PR1 train deployed successfully to production, but the first production smoke run exposed a test-harness allowlist gap.
- Live production sends Sentry tunnel telemetry through same-origin `POST /monitoring`.
- The new read-only Playwright guard treated that telemetry as a non-allowlisted mutation, causing production smoke to fail even though the deployment workflow and page checks were healthy.

## Fix
- Treat same-origin `/monitoring` and `/monitoring/*` as first-party telemetry in read-only remote Playwright runs.
- Abort those telemetry requests without failing the smoke run, matching the existing treatment for known third-party telemetry/SDK endpoints.
- Keep external lookalikes blocked: `https://example.com/monitoring` remains a non-allowlisted mutation.

## Changes
- Adds a same-origin telemetry classifier to `tests/support/readonlyMutationGuard.ts`.
- Adds Jest coverage for production `/monitoring`, staging `/monitoring/*`, and external `/monitoring` lookalikes.
- Records the staging/prod deploy and smoke evidence in the i18n/WCAG workstream run log.
- Does not modify `.github/6529bot.yml`; existing reviewbots remain the minimum review baseline.

## Validation
- `seize run test:no-coverage -- __tests__/playwright/readonlyMutationGuard.test.ts`
- `seize run typecheck:playwright`
- `seize run lint:changed`
- `seize run typecheck:changed`
- `seize run format:changed`
- `codex-diff-check`
- `PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:smoke` passed 6/6.
- `seize run test:e2e:staging` passed 6/6 with the access code loaded from local Credential Manager target `STAGING_AUTH`.

## Deployment Context
- #2799 merged to `main` as `0d16551ca519ad595604f58dd7a9e0c629e5a27c`.
- Staging deploy succeeded: https://github.com/6529-Collections/6529seize-frontend/actions/runs/27880870400
- Production deploy succeeded: https://github.com/6529-Collections/6529seize-frontend/actions/runs/27881187699
- This PR is a test-harness fix-forward so future production smokes do not fail on expected Sentry tunnel telemetry.

## Risk
- Level: Low.
- Why: test harness only, limited to same-origin `/monitoring`; external hosts remain blocked and registered mutation endpoints still block before telemetry classification.
- Rollback: revert this PR; production/staging app behavior is unaffected, but production read-only smoke will again fail on expected Sentry tunnel telemetry.

## Review Notes
- Please verify same-origin matching cannot allow third-party telemetry lookalikes.
- Please verify registered mutation endpoints still win before telemetry classification.
- Please verify this keeps production and staging smoke read-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of first-party telemetry requests to prevent blocking of legitimate same-origin monitoring traffic.

* **Tests**
  * Added comprehensive test coverage for read-only mutation guard functionality with various telemetry URL scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->