### PR TITLE
Add WCAG/i18n Playwright evidence pack

### DIFF
--- a/__tests__/playwright/a11yAssertions.test.ts
+++ b/__tests__/playwright/a11yAssertions.test.ts
@@ -1,0 +1,95 @@
+import {
+  getUnexpectedAxeViolations,
+  summarizeAxeViolations,
+  validateAxeAllowances,
+  type AxeViolationAllowance,
+} from "../../tests/support/a11yAllowlist";
+
+const activeAllowance: AxeViolationAllowance = {
+  expires: "2026-12-31",
+  owner: "frontend-accessibility",
+  reason: "Known debt while route migration is in progress.",
+  route: "/the-memes?locale=de-DE",
+  ruleId: "color-contrast",
+  selector: ".known-contrast-debt",
+};
+
+describe("Playwright axe assertions", () => {
+  it("rejects expired and broad axe allowlist entries", () => {
+    const errors = validateAxeAllowances(
+      [
+        {
+          ...activeAllowance,
+          expires: "2026-01-01",
+          selector: "main",
+        },
+      ],
+      new Date("2026-06-20T00:00:00.000Z")
+    );
+
+    expect(errors).toEqual([
+      "color-contrast: selector is too broad",
+      "color-contrast: allowance expired on 2026-01-01",
+    ]);
+  });
+
+  it("rejects empty selectors and non-real expiry dates", () => {
+    const errors = validateAxeAllowances(
+      [
+        {
+          ...activeAllowance,
+          expires: "2026-02-31",
+          selector: "   ",
+        },
+      ],
+      new Date("2026-01-01T00:00:00.000Z")
+    );
+
+    expect(errors).toEqual([
+      "color-contrast: selector is required",
+      "color-contrast: expires is not a valid date",
+    ]);
+  });
+
+  it("filters only exact route, rule, and selector matches", () => {
+    const result = getUnexpectedAxeViolations(
+      [
+        {
+          help: "Elements must meet minimum color contrast ratio thresholds",
+          helpUrl: "https://dequeuniversity.com/rules/axe/4.11/color-contrast",
+          id: "color-contrast",
+          impact: "serious",
+          nodes: [
+            { target: [".known-contrast-debt"] },
+            { target: [".unexpected-contrast-debt"] },
+          ],
+        },
+      ],
+      {
+        allowlist: [activeAllowance],
+        route: "/the-memes?locale=de-DE",
+      }
+    );
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: "color-contrast",
+        nodes: [{ target: [".unexpected-contrast-debt"] }],
+      }),
+    ]);
+  });
+
+  it("summarizes violations with rule and target evidence", () => {
+    expect(
+      summarizeAxeViolations([
+        {
+          help: "Buttons must have discernible text",
+          helpUrl: "https://dequeuniversity.com/rules/axe/4.11/button-name",
+          id: "button-name",
+          impact: "critical",
+          nodes: [{ target: ["button.icon-only"] }],
+        },
+      ])
+    ).toContain("button-name (critical): Buttons must have discernible text");
+  });
+});

--- a/__tests__/playwright/a11yAssertions.test.ts
+++ b/__tests__/playwright/a11yAssertions.test.ts
@@ -80,16 +80,22 @@ describe("Playwright axe assertions", () => {
   });
 
   it("summarizes violations with rule and target evidence", () => {
-    expect(
-      summarizeAxeViolations([
-        {
-          help: "Buttons must have discernible text",
-          helpUrl: "https://dequeuniversity.com/rules/axe/4.11/button-name",
-          id: "button-name",
-          impact: "critical",
-          nodes: [{ target: ["button.icon-only"] }],
-        },
-      ])
-    ).toContain("button-name (critical): Buttons must have discernible text");
+    const summary = summarizeAxeViolations([
+      {
+        help: "Buttons must have discernible text",
+        helpUrl: "https://dequeuniversity.com/rules/axe/4.11/button-name",
+        id: "button-name",
+        impact: "critical",
+        nodes: [{ target: ["button.icon-only"] }],
+      },
+    ]);
+
+    expect(summary).toContain(
+      "button-name (critical): Buttons must have discernible text"
+    );
+    expect(summary).toContain(
+      "https://dequeuniversity.com/rules/axe/4.11/button-name"
+    );
+    expect(summary).toContain("- button.icon-only");
   });
 });

--- a/__tests__/playwright/i18nFixtures.test.ts
+++ b/__tests__/playwright/i18nFixtures.test.ts
@@ -1,0 +1,29 @@
+import {
+  getLocaleStressPaths,
+  LONG_TEXT_STRESS_LOCALE,
+  withLocale,
+} from "../../tests/support/i18nFixtures";
+
+describe("Playwright i18n fixtures", () => {
+  it("adds non-default locales while omitting the default locale", () => {
+    expect(withLocale("/the-memes?sort=age", "de-DE")).toBe(
+      "/the-memes?sort=age&locale=de-DE"
+    );
+    expect(withLocale("/the-memes?sort=age&locale=fr-FR", "en-US")).toBe(
+      "/the-memes?sort=age"
+    );
+  });
+
+  it("builds locale stress paths from supported locales", () => {
+    const paths = getLocaleStressPaths(["/the-memes"]);
+
+    expect(paths).toContainEqual({
+      locale: LONG_TEXT_STRESS_LOCALE,
+      path: "/the-memes?locale=de-DE",
+    });
+    expect(paths).toContainEqual({
+      locale: "en-US",
+      path: "/the-memes",
+    });
+  });
+});

--- a/config/nextConfig.ts
+++ b/config/nextConfig.ts
@@ -10,13 +10,17 @@ import { fileURLToPath } from "node:url";
 
 const HTML_LIMITED_METADATA_BOTS =
   /facebookexternalhit|facebookcatalog|Twitterbot|LinkedInBot|Slackbot|Discordbot|WhatsApp|SkypeUriPreview|TelegramBot|redditbot|Pinterestbot|opentweet/i;
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+);
+const NODE_MODULES_PATH = path.resolve(REPO_ROOT, "node_modules");
 const SASS_LOAD_PATHS = [
-  path.resolve(
-    path.dirname(fileURLToPath(import.meta.url)),
-    "..",
-    "node_modules"
-  ),
+  path.resolve(NODE_MODULES_PATH, "bootstrap", "scss"),
+  NODE_MODULES_PATH,
 ];
+const BOOTSTRAP_PROGRESS_PARTIAL =
+  "./node_modules/bootstrap/scss/_progress.scss";
 
 export function sharedConfig(
   publicEnv: PublicEnv,
@@ -28,7 +32,16 @@ export function sharedConfig(
     reactStrictMode: false,
     htmlLimitedBots: HTML_LIMITED_METADATA_BOTS,
     compress: true,
-    sassOptions: { loadPaths: SASS_LOAD_PATHS, quietDeps: true },
+    sassOptions: {
+      loadPaths: SASS_LOAD_PATHS,
+      quietDeps: true,
+      silenceDeprecations: [
+        "color-functions",
+        "global-builtin",
+        "if-function",
+        "import",
+      ],
+    },
     allowedDevOrigins: ["172.20.10.3", "192.168.1.77"],
     images: {
       loader: "default",
@@ -92,6 +105,7 @@ export function sharedConfig(
       resolveAlias: {
         canvas: "./stubs/empty.js",
         encoding: "./stubs/empty.js",
+        progress: BOOTSTRAP_PROGRESS_PARTIAL,
         "@react-native-async-storage/async-storage": "./stubs/empty.js",
         "react-native": "./stubs/empty.js",
         "idb-keyval": "./lib/storage/idb-keyval.ts",

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1939,3 +1939,6 @@ origin/main --output test-results/app-pr-ci/workflow-security.json`
   - `codex-diff-check`
 - Existing 6529bot review lanes remain untouched; this PR is a local testing
   enhancement that complements bot review rather than replacing it.
+- Addressed the latest Sonar maintainability findings before merge by splitting
+  axe allowlist validation into smaller helpers, replacing a target lookup with
+  `.includes()`, and using `globalThis.getComputedStyle` in the focus helper.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1885,3 +1885,57 @@ origin/main --output test-results/app-pr-ci/workflow-security.json`
   `http://localhost:3001` and set `PLAYWRIGHT_WEB_SERVER_COMMAND` to
   `./bin/6529 run dev`, preserving the repo wrapper and avoiding a Next config
   exception just for CI.
+
+## 2026-06-20T23:15Z PR 3 WCAG/i18n Browser Evidence Harness
+
+- Started PR 3 from merged `origin/main` after PR #2802:
+  `codex/testing-pr3-wcag-i18n-playwright`.
+- Added `@axe-core/playwright` as a dev dependency for first-party browser
+  accessibility scans.
+- Implementing shared Playwright helpers for:
+  - WCAG 2.2 A/AA axe assertions scoped to `main` by default;
+  - exact, owned, expiring axe debt allowlists;
+  - visible keyboard focus smoke checks;
+  - locale stress URL generation.
+- First route evidence target is `/the-memes?locale=fr-FR&sort=age&sort_dir=asc`
+  because it already has smoke coverage, meaningful localized labels, locale
+  preserving card links, and a stable public route surface.
+- Local browser validation initially exposed a Bootstrap Sass partial resolution
+  collision where Bootstrap's internal `progress` import resolved to the JS
+  `progress` package under pnpm. The PR keeps Bootstrap on the package-form
+  `@use "bootstrap/scss/bootstrap"` import, keeps Bootstrap's SCSS directory
+  before generic `node_modules` in Next Sass load paths, adds a narrow
+  Turbopack alias for Bootstrap's `_progress.scss` partial, silences
+  Bootstrap's known dependency deprecation warnings, and extends the guard to
+  keep that setup intact.
+- Final local validation before PR publication:
+  - `seize install:frozen`
+  - `seize run format:uncommitted`
+  - `seize run guard:bootstrap-sass`
+  - `seize run lint:diff`
+  - `seize run lint:changed`
+  - `seize run typecheck:ci`
+  - `seize run typecheck:playwright`
+  - `seize run test:no-coverage -- __tests__/playwright/a11yAssertions.test.ts
+    __tests__/playwright/i18nFixtures.test.ts`: 2 suites, 5 tests passed.
+  - `seize run testing-strategy -- ci-plan --changed-from main --output
+    test-results/app-pr-ci/pr3-ci-plan.json`: Level 4 because of Next config,
+    package, and lockfile changes.
+  - `seize run testing-strategy -- scan-changed-secrets --changed-from main
+    --output test-results/app-pr-ci/pr3-secret-scan.json`: clean.
+  - `seize run dependency:risk-gate`: high risk / auto-merge blocked because
+    the PR adds a new direct dev dependency; package metadata was independently
+    checked and the risk is documented for review.
+  - `$env:CIRCLE_NODE_TOTAL='1'; seize run build`: passed full prebuild,
+    lint, production Next build, standalone output, and postbuild sitemap.
+    Without the local worker cap, Windows hit repeat `EBUSY` copy races after
+    successful compile, typecheck, and static generation; CI runs on Ubuntu.
+  - `$env:PLAYWRIGHT_WEB_SERVER_COMMAND='seize run dev'; seize run
+    test:e2e:wcag-i18n`: 3 passed.
+  - `$env:PLAYWRIGHT_WEB_SERVER_COMMAND='seize run dev'; seize run
+    test:e2e:smoke`: first run after production build hit stale local dev cache
+    404s; after isolating the production `.next` output and starting a fresh dev
+    cache, 6 passed.
+  - `codex-diff-check`
+- Existing 6529bot review lanes remain untouched; this PR is a local testing
+  enhancement that complements bot review rather than replacing it.

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test-extract-failed-names": "node scripts/require-6529-command.cjs && node test-results/list-failed-tests.cjs",
     "test:e2e": "node scripts/require-6529-command.cjs && playwright test",
     "test:e2e:smoke": "node scripts/require-6529-command.cjs && playwright test tests/home/home.spec.ts tests/pages/about.spec.ts tests/pages/the-memes.spec.ts --grep @smoke --workers=1",
+    "test:e2e:wcag-i18n": "node scripts/require-6529-command.cjs && playwright test tests/wcag-i18n --workers=1",
     "test:e2e:staging": "node scripts/require-6529-command.cjs && cross-env PLAYWRIGHT_BASE_URL=https://staging.6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 playwright test tests/home/home.spec.ts tests/pages/about.spec.ts tests/pages/the-memes.spec.ts --workers=1",
     "test:e2e:ui": "node scripts/require-6529-command.cjs && playwright test --ui",
     "knip": "node scripts/require-6529-command.cjs && knip --fix --allow-remove-files",
@@ -186,6 +187,7 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
+    "@axe-core/playwright": "4.11.3",
     "@jest/globals": "30.3.0",
     "@openapitools/openapi-generator-cli": "2.31.1",
     "@playwright/test": "1.58.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,6 +356,9 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
     devDependencies:
+      '@axe-core/playwright':
+        specifier: 4.11.3
+        version: 4.11.3(playwright-core@1.58.2)
       '@jest/globals':
         specifier: 30.3.0
         version: 30.3.0
@@ -560,6 +563,11 @@ packages:
 
   '@aws-sdk/util-utf8-browser@3.259.0':
     resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
+
+  '@axe-core/playwright@4.11.3':
+    resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -9274,6 +9282,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@axe-core/playwright@4.11.3(playwright-core@1.58.2)':
+    dependencies:
+      axe-core: 4.11.4
+      playwright-core: 1.58.2
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -10770,7 +10783,7 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
       lodash: 4.18.1
       pony-cause: 2.1.11
-      semver: 7.7.4
+      semver: 7.8.4
       uuid: 11.1.1
     transitivePeerDependencies:
       - supports-color
@@ -10794,7 +10807,7 @@ snapshots:
       '@types/debug': 4.1.13
       debug: 4.4.3(supports-color@5.5.0)
       pony-cause: 2.1.11
-      semver: 7.7.4
+      semver: 7.8.4
       uuid: 11.1.1
     transitivePeerDependencies:
       - supports-color
@@ -17422,7 +17435,7 @@ snapshots:
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.4
 
   make-error@1.3.6: {}
 

--- a/scripts/guard-bootstrap-sass-import.cjs
+++ b/scripts/guard-bootstrap-sass-import.cjs
@@ -130,9 +130,11 @@ function hasBootstrapPackageUse(source) {
   );
 }
 
-function hasNodeModulesBootstrapStatement(source) {
+function hasUnexpectedBootstrapStatement(source) {
   return getSassImportStatements(source).some((line) =>
-    line.includes("node_modules/bootstrap/scss/bootstrap")
+    line.includes("bootstrap/scss/bootstrap") &&
+    !line.startsWith('@use "bootstrap/scss/bootstrap"') &&
+    !line.startsWith("@use 'bootstrap/scss/bootstrap'")
   );
 }
 
@@ -146,18 +148,29 @@ if (!hasBootstrapPackageUse(bootstrapScss)) {
   );
 }
 
-if (hasNodeModulesBootstrapStatement(bootstrapScss)) {
+if (hasUnexpectedBootstrapStatement(bootstrapScss)) {
   failures.push(
-    `${bootstrapScssPath} must not import Bootstrap through a node_modules path.`
+    `${bootstrapScssPath} must use only the package-form Bootstrap Sass import.`
   );
 }
 
 if (
   !nextConfig.includes("const SASS_LOAD_PATHS") ||
+  !nextConfig.includes("const BOOTSTRAP_PROGRESS_PARTIAL") ||
+  !nextConfig.includes('"bootstrap", "scss"') ||
   !nextConfig.includes('"node_modules"')
 ) {
   failures.push(
-    `${nextConfigPath} must keep SASS_LOAD_PATHS pointed at node_modules.`
+    `${nextConfigPath} must keep SASS_LOAD_PATHS pointed at Bootstrap SCSS before node_modules.`
+  );
+}
+
+if (
+  !nextConfig.includes("progress: BOOTSTRAP_PROGRESS_PARTIAL") ||
+  !nextConfig.includes('"./node_modules/bootstrap/scss/_progress.scss"')
+) {
+  failures.push(
+    `${nextConfigPath} must keep Turbopack's Bootstrap progress partial alias to avoid resolving the JS progress package from Bootstrap Sass.`
   );
 }
 
@@ -166,10 +179,22 @@ const sassOptionsUsesLoadPaths =
   nextConfig.includes("loadPaths: SASS_LOAD_PATHS");
 const sassOptionsUsesQuietDeps =
   nextConfig.includes("sassOptions:") && nextConfig.includes("quietDeps: true");
+const sassOptionsSilencesBootstrapDeprecations =
+  nextConfig.includes("silenceDeprecations:") &&
+  nextConfig.includes('"import"') &&
+  nextConfig.includes('"global-builtin"') &&
+  nextConfig.includes('"color-functions"') &&
+  nextConfig.includes('"if-function"');
 
 if (!sassOptionsUsesLoadPaths || !sassOptionsUsesQuietDeps) {
   failures.push(
     `${nextConfigPath} must keep sassOptions.loadPaths and quietDeps enabled.`
+  );
+}
+
+if (!sassOptionsSilencesBootstrapDeprecations) {
+  failures.push(
+    `${nextConfigPath} must silence Bootstrap Sass dependency deprecation warnings.`
   );
 }
 

--- a/scripts/guard-bootstrap-sass-import.cjs
+++ b/scripts/guard-bootstrap-sass-import.cjs
@@ -138,6 +138,50 @@ function hasUnexpectedBootstrapStatement(source) {
   );
 }
 
+function readBalancedArrayInitializer(source, constName) {
+  const declaration = `const ${constName}`;
+  const declarationIndex = source.indexOf(declaration);
+  if (declarationIndex === -1) {
+    return null;
+  }
+
+  const arrayStartIndex = source.indexOf("[", declarationIndex);
+  if (arrayStartIndex === -1) {
+    return null;
+  }
+
+  let depth = 0;
+  for (let index = arrayStartIndex; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === "[") {
+      depth += 1;
+    } else if (char === "]") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(arrayStartIndex, index + 1);
+      }
+    }
+  }
+
+  return null;
+}
+
+function hasBootstrapLoadPathBeforeNodeModules(source) {
+  const initializer = readBalancedArrayInitializer(source, "SASS_LOAD_PATHS");
+  if (!initializer) {
+    return false;
+  }
+
+  const bootstrapIndex = initializer.indexOf('"bootstrap", "scss"');
+  const nodeModulesIndex = initializer.indexOf("  NODE_MODULES_PATH");
+
+  return (
+    bootstrapIndex !== -1 &&
+    nodeModulesIndex !== -1 &&
+    bootstrapIndex < nodeModulesIndex
+  );
+}
+
 const bootstrapScss = stripComments(readRequiredFile(bootstrapScssPath));
 const nextConfig = stripComments(readRequiredFile(nextConfigPath));
 const failures = [];
@@ -154,12 +198,7 @@ if (hasUnexpectedBootstrapStatement(bootstrapScss)) {
   );
 }
 
-if (
-  !nextConfig.includes("const SASS_LOAD_PATHS") ||
-  !nextConfig.includes("const BOOTSTRAP_PROGRESS_PARTIAL") ||
-  !nextConfig.includes('"bootstrap", "scss"') ||
-  !nextConfig.includes('"node_modules"')
-) {
+if (!hasBootstrapLoadPathBeforeNodeModules(nextConfig)) {
   failures.push(
     `${nextConfigPath} must keep SASS_LOAD_PATHS pointed at Bootstrap SCSS before node_modules.`
   );

--- a/styles/seize-bootstrap.scss
+++ b/styles/seize-bootstrap.scss
@@ -8,8 +8,6 @@ $orange: #ffa500;
 $yellow: #ffff00;
 // Add any other Bootstrap variables you want to set globally BEFORE the import.
 
-// Import Bootstrap through the Sass load path so dependency deprecation warnings
-// remain silenced by quietDeps.
 @use "bootstrap/scss/bootstrap" with (
   $pink: $pink,
   $green: $green,

--- a/tests/README.md
+++ b/tests/README.md
@@ -45,3 +45,14 @@ App PR CI:
 - Uploaded PR CI artifacts are short-term debugging evidence. Durable
   deployment-train evidence still belongs on approved 6529-controlled artifact
   storage, not Git LFS.
+
+WCAG and i18n route evidence:
+
+- `test:e2e:wcag-i18n` runs the first dedicated WCAG/i18n browser evidence
+  pack under `tests/wcag-i18n`.
+- Axe checks use `@axe-core/playwright` with WCAG A/AA tags through 2.2 and
+  scope to `main` by default.
+- Axe allowlist entries must name an exact route, rule, selector, owner, reason,
+  and future expiry. Expired or broad entries fail before the scan runs.
+- Locale stress tests should wait for route-specific hydrated content before
+  checking axe, keyboard focus, overflow, or locale-preserving links.

--- a/tests/support/a11yAllowlist.ts
+++ b/tests/support/a11yAllowlist.ts
@@ -1,0 +1,160 @@
+export const WCAG_22_AA_TAGS = [
+  "wcag2a",
+  "wcag2aa",
+  "wcag21a",
+  "wcag21aa",
+  "wcag22aa",
+] as const;
+
+export type AxeViolationAllowance = {
+  readonly route: string;
+  readonly ruleId: string;
+  readonly selector: string;
+  readonly reason: string;
+  readonly owner: string;
+  readonly expires: string;
+};
+
+export type AxeNodeSummary = {
+  readonly failureSummary?: string | undefined;
+  readonly target: readonly string[];
+};
+
+export type AxeViolationSummary = {
+  readonly help: string;
+  readonly helpUrl: string;
+  readonly id: string;
+  readonly impact?: string | null | undefined;
+  readonly nodes: readonly AxeNodeSummary[];
+};
+
+const BROAD_SELECTORS = new Set(["*", "html", "body", "main", "#__next"]);
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export function validateAxeAllowances(
+  allowances: readonly AxeViolationAllowance[],
+  now = new Date()
+) {
+  const errors: string[] = [];
+
+  for (const allowance of allowances) {
+    if (!allowance.route.startsWith("/")) {
+      errors.push(`${allowance.ruleId}: route must start with /`);
+    }
+
+    const selector = allowance.selector.trim();
+    if (!selector) {
+      errors.push(`${allowance.ruleId}: selector is required`);
+    } else if (BROAD_SELECTORS.has(selector)) {
+      errors.push(`${allowance.ruleId}: selector is too broad`);
+    }
+
+    if (!allowance.reason.trim()) {
+      errors.push(`${allowance.ruleId}: reason is required`);
+    }
+
+    if (!allowance.owner.trim()) {
+      errors.push(`${allowance.ruleId}: owner is required`);
+    }
+
+    if (!ISO_DATE_PATTERN.test(allowance.expires)) {
+      errors.push(`${allowance.ruleId}: expires must use YYYY-MM-DD`);
+      continue;
+    }
+
+    const expiresAt = getStrictIsoDateEndTime(allowance.expires);
+    if (expiresAt === null) {
+      errors.push(`${allowance.ruleId}: expires is not a valid date`);
+      continue;
+    }
+
+    if (expiresAt < now.getTime()) {
+      errors.push(
+        `${allowance.ruleId}: allowance expired on ${allowance.expires}`
+      );
+    }
+  }
+
+  return errors;
+}
+
+function getStrictIsoDateEndTime(date: string) {
+  const [yearText, monthText, dayText] = date.split("-");
+  if (!yearText || !monthText || !dayText) {
+    return null;
+  }
+
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const expiresAt = Date.UTC(year, month - 1, day, 23, 59, 59, 999);
+
+  if (!Number.isFinite(expiresAt)) {
+    return null;
+  }
+
+  const expiresAtDate = new Date(expiresAt);
+  if (
+    expiresAtDate.getUTCFullYear() !== year ||
+    expiresAtDate.getUTCMonth() !== month - 1 ||
+    expiresAtDate.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return expiresAt;
+}
+
+export function getUnexpectedAxeViolations(
+  violations: readonly AxeViolationSummary[],
+  options: {
+    readonly allowlist?: readonly AxeViolationAllowance[];
+    readonly route: string;
+  }
+) {
+  const allowlist = options.allowlist ?? [];
+
+  return violations
+    .map((violation) => ({
+      ...violation,
+      nodes: violation.nodes.filter(
+        (node) => !isNodeAllowed(violation.id, node, options.route, allowlist)
+      ),
+    }))
+    .filter((violation) => violation.nodes.length > 0);
+}
+
+export function summarizeAxeViolations(
+  violations: readonly AxeViolationSummary[]
+) {
+  if (violations.length === 0) {
+    return "No unexpected axe violations.";
+  }
+
+  return violations
+    .map((violation) => {
+      const nodeTargets = violation.nodes
+        .map((node) => `- ${node.target.join(" | ")}`)
+        .join("\n");
+      return [
+        `${violation.id} (${violation.impact ?? "unknown impact"}): ${violation.help}`,
+        violation.helpUrl,
+        nodeTargets,
+      ].join("\n");
+    })
+    .join("\n\n");
+}
+
+function isNodeAllowed(
+  ruleId: string,
+  node: AxeNodeSummary,
+  route: string,
+  allowlist: readonly AxeViolationAllowance[]
+) {
+  return allowlist.some(
+    (allowance) =>
+      allowance.ruleId === ruleId &&
+      allowance.route === route &&
+      node.target.some((target) => target === allowance.selector)
+  );
+}

--- a/tests/support/a11yAllowlist.ts
+++ b/tests/support/a11yAllowlist.ts
@@ -35,47 +35,74 @@ export function validateAxeAllowances(
   allowances: readonly AxeViolationAllowance[],
   now = new Date()
 ) {
+  const nowTime = now.getTime();
+  return allowances.flatMap((allowance) =>
+    getAxeAllowanceErrors(allowance, nowTime)
+  );
+}
+
+function getAxeAllowanceErrors(
+  allowance: AxeViolationAllowance,
+  nowTime: number
+) {
   const errors: string[] = [];
 
-  for (const allowance of allowances) {
-    if (!allowance.route.startsWith("/")) {
-      errors.push(`${allowance.ruleId}: route must start with /`);
-    }
+  if (!allowance.route.startsWith("/")) {
+    errors.push(`${allowance.ruleId}: route must start with /`);
+  }
 
-    const selector = allowance.selector.trim();
-    if (!selector) {
-      errors.push(`${allowance.ruleId}: selector is required`);
-    } else if (BROAD_SELECTORS.has(selector)) {
-      errors.push(`${allowance.ruleId}: selector is too broad`);
-    }
+  const selectorError = getSelectorValidationError(allowance);
+  if (selectorError) {
+    errors.push(selectorError);
+  }
 
-    if (!allowance.reason.trim()) {
-      errors.push(`${allowance.ruleId}: reason is required`);
-    }
+  if (!allowance.reason.trim()) {
+    errors.push(`${allowance.ruleId}: reason is required`);
+  }
 
-    if (!allowance.owner.trim()) {
-      errors.push(`${allowance.ruleId}: owner is required`);
-    }
+  if (!allowance.owner.trim()) {
+    errors.push(`${allowance.ruleId}: owner is required`);
+  }
 
-    if (!ISO_DATE_PATTERN.test(allowance.expires)) {
-      errors.push(`${allowance.ruleId}: expires must use YYYY-MM-DD`);
-      continue;
-    }
-
-    const expiresAt = getStrictIsoDateEndTime(allowance.expires);
-    if (expiresAt === null) {
-      errors.push(`${allowance.ruleId}: expires is not a valid date`);
-      continue;
-    }
-
-    if (expiresAt < now.getTime()) {
-      errors.push(
-        `${allowance.ruleId}: allowance expired on ${allowance.expires}`
-      );
-    }
+  const expirationError = getExpirationValidationError(allowance, nowTime);
+  if (expirationError) {
+    errors.push(expirationError);
   }
 
   return errors;
+}
+
+function getSelectorValidationError(allowance: AxeViolationAllowance) {
+  const selector = allowance.selector.trim();
+  if (!selector) {
+    return `${allowance.ruleId}: selector is required`;
+  }
+
+  if (BROAD_SELECTORS.has(selector)) {
+    return `${allowance.ruleId}: selector is too broad`;
+  }
+
+  return null;
+}
+
+function getExpirationValidationError(
+  allowance: AxeViolationAllowance,
+  nowTime: number
+) {
+  if (!ISO_DATE_PATTERN.test(allowance.expires)) {
+    return `${allowance.ruleId}: expires must use YYYY-MM-DD`;
+  }
+
+  const expiresAt = getStrictIsoDateEndTime(allowance.expires);
+  if (expiresAt === null) {
+    return `${allowance.ruleId}: expires is not a valid date`;
+  }
+
+  if (expiresAt < nowTime) {
+    return `${allowance.ruleId}: allowance expired on ${allowance.expires}`;
+  }
+
+  return null;
 }
 
 function getStrictIsoDateEndTime(date: string) {
@@ -155,6 +182,6 @@ function isNodeAllowed(
     (allowance) =>
       allowance.ruleId === ruleId &&
       allowance.route === route &&
-      node.target.some((target) => target === allowance.selector)
+      node.target.includes(allowance.selector)
   );
 }

--- a/tests/support/a11yAssertions.ts
+++ b/tests/support/a11yAssertions.ts
@@ -1,0 +1,80 @@
+import { AxeBuilder } from "@axe-core/playwright";
+import { expect, type Page } from "@playwright/test";
+
+import {
+  getUnexpectedAxeViolations,
+  summarizeAxeViolations,
+  validateAxeAllowances,
+  WCAG_22_AA_TAGS,
+  type AxeViolationAllowance,
+} from "./a11yAllowlist";
+
+type AxeCleanOptions = {
+  readonly allowlist?: readonly AxeViolationAllowance[];
+  readonly disabledRules?: readonly string[];
+  readonly exclude?: readonly string[];
+  readonly include?: readonly string[];
+  readonly route?: string;
+  readonly tags?: readonly string[];
+};
+
+export async function expectAxeClean(
+  page: Page,
+  options: AxeCleanOptions = {}
+) {
+  const route = options.route ?? getRouteFromPage(page);
+  const allowanceErrors = validateAxeAllowances(options.allowlist ?? []);
+
+  expect(allowanceErrors, allowanceErrors.join("\n")).toEqual([]);
+
+  let builder = new AxeBuilder({ page }).withTags([
+    ...(options.tags ?? WCAG_22_AA_TAGS),
+  ]);
+
+  for (const selector of options.include ?? ["main"]) {
+    builder = builder.include(selector);
+  }
+
+  for (const selector of options.exclude ?? []) {
+    builder = builder.exclude(selector);
+  }
+
+  if (options.disabledRules && options.disabledRules.length > 0) {
+    builder = builder.disableRules([...options.disabledRules]);
+  }
+
+  const results = await builder.analyze();
+  const violations = results.violations.map((violation) => ({
+    help: violation.help,
+    helpUrl: violation.helpUrl,
+    id: violation.id,
+    impact: violation.impact,
+    nodes: violation.nodes.map((node) => ({
+      failureSummary: node.failureSummary,
+      target: node.target.map(String),
+    })),
+  }));
+  const unexpected = getUnexpectedAxeViolations(violations, {
+    allowlist: options.allowlist ?? [],
+    route,
+  });
+
+  expect(unexpected, summarizeAxeViolations(unexpected)).toEqual([]);
+}
+
+function getRouteFromPage(page: Page) {
+  try {
+    const url = new URL(page.url());
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return page.url();
+  }
+}
+
+export {
+  getUnexpectedAxeViolations,
+  summarizeAxeViolations,
+  validateAxeAllowances,
+  WCAG_22_AA_TAGS,
+  type AxeViolationAllowance,
+};

--- a/tests/support/i18nFixtures.ts
+++ b/tests/support/i18nFixtures.ts
@@ -1,0 +1,32 @@
+import {
+  DEFAULT_LOCALE,
+  SUPPORTED_LOCALES,
+  type SupportedLocale,
+} from "../../i18n/locales";
+
+export const LONG_TEXT_STRESS_LOCALE = "de-DE" satisfies SupportedLocale;
+export const ROUTE_LOCALE_PARAM = "locale";
+
+export function withLocale(path: string, locale: SupportedLocale) {
+  const url = new URL(path, "https://6529.local");
+
+  if (locale === DEFAULT_LOCALE) {
+    url.searchParams.delete(ROUTE_LOCALE_PARAM);
+  } else {
+    url.searchParams.set(ROUTE_LOCALE_PARAM, locale);
+  }
+
+  return `${url.pathname}${url.search}`;
+}
+
+export function getLocaleStressPaths(
+  paths: readonly string[],
+  locales: readonly SupportedLocale[] = SUPPORTED_LOCALES
+) {
+  return paths.flatMap((path) =>
+    locales.map((locale) => ({
+      locale,
+      path: withLocale(path, locale),
+    }))
+  );
+}

--- a/tests/support/keyboardFocus.ts
+++ b/tests/support/keyboardFocus.ts
@@ -86,7 +86,7 @@ async function hasVisibleFocus(page: Page, timeout: number) {
           return false;
         }
 
-        const style = window.getComputedStyle(activeElement);
+        const style = globalThis.getComputedStyle(activeElement);
         const outlineWidth = Number.parseFloat(style.outlineWidth || "0");
         const hasOutline =
           style.outlineStyle !== "none" &&

--- a/tests/support/keyboardFocus.ts
+++ b/tests/support/keyboardFocus.ts
@@ -1,0 +1,105 @@
+import { expect, type Page } from "@playwright/test";
+
+export type FocusSummary = {
+  readonly ariaLabel: string | null;
+  readonly id: string | null;
+  readonly role: string | null;
+  readonly tagName: string;
+  readonly text: string;
+};
+
+type FocusVisibleOptions = {
+  readonly maxTabs?: number;
+  readonly timeout?: number;
+};
+
+export async function pressTab(page: Page, count = 1) {
+  for (let index = 0; index < count; index += 1) {
+    await page.keyboard.press("Tab");
+  }
+}
+
+export async function expectKeyboardFocusVisibleWithinTabs(
+  page: Page,
+  options: FocusVisibleOptions = {}
+) {
+  const maxTabs = options.maxTabs ?? 8;
+  const timeout = options.timeout ?? 5000;
+
+  for (let tabIndex = 0; tabIndex < maxTabs; tabIndex += 1) {
+    await pressTab(page);
+
+    if (await hasVisibleFocus(page, timeout)) {
+      return getFocusedElementSummary(page);
+    }
+  }
+
+  const focused = await getFocusedElementSummary(page);
+  expect(
+    false,
+    `Expected visible keyboard focus within ${maxTabs} Tab presses. Last focus: ${JSON.stringify(
+      focused
+    )}`
+  ).toBe(true);
+  return focused;
+}
+
+export async function getFocusedElementSummary(
+  page: Page
+): Promise<FocusSummary> {
+  return page.evaluate(() => {
+    const activeElement = document.activeElement;
+
+    if (!(activeElement instanceof HTMLElement)) {
+      return {
+        ariaLabel: null,
+        id: null,
+        role: null,
+        tagName: "",
+        text: "",
+      };
+    }
+
+    return {
+      ariaLabel: activeElement.getAttribute("aria-label"),
+      id: activeElement.id || null,
+      role: activeElement.getAttribute("role"),
+      tagName: activeElement.tagName.toLowerCase(),
+      text: (activeElement.innerText || activeElement.textContent || "")
+        .trim()
+        .slice(0, 80),
+    };
+  });
+}
+
+async function hasVisibleFocus(page: Page, timeout: number) {
+  return page
+    .waitForFunction(
+      () => {
+        const activeElement = document.activeElement;
+
+        if (!(activeElement instanceof HTMLElement)) {
+          return false;
+        }
+
+        if (activeElement === document.body) {
+          return false;
+        }
+
+        const style = window.getComputedStyle(activeElement);
+        const outlineWidth = Number.parseFloat(style.outlineWidth || "0");
+        const hasOutline =
+          style.outlineStyle !== "none" &&
+          style.outlineColor !== "transparent" &&
+          outlineWidth > 0;
+        const hasBoxShadow =
+          style.boxShadow !== "none" && style.boxShadow.trim().length > 0;
+
+        return hasOutline || hasBoxShadow;
+      },
+      undefined,
+      { timeout }
+    )
+    .then(() => true)
+    .catch(() => false);
+}

--- a/tests/testHelpers.ts
+++ b/tests/testHelpers.ts
@@ -155,6 +155,26 @@ export {
   waitForRouteReady,
 } from "./support/pageAssertions";
 export {
+  expectAxeClean,
+  getUnexpectedAxeViolations,
+  summarizeAxeViolations,
+  validateAxeAllowances,
+  WCAG_22_AA_TAGS,
+  type AxeViolationAllowance,
+} from "./support/a11yAssertions";
+export {
+  expectKeyboardFocusVisibleWithinTabs,
+  getFocusedElementSummary,
+  pressTab,
+  type FocusSummary,
+} from "./support/keyboardFocus";
+export {
+  getLocaleStressPaths,
+  LONG_TEXT_STRESS_LOCALE,
+  ROUTE_LOCALE_PARAM,
+  withLocale,
+} from "./support/i18nFixtures";
+export {
   resolvePlaywrightTestSize,
   tagTestTitle,
   TEST_SIZE_TAGS,

--- a/tests/wcag-i18n/public-routes.spec.ts
+++ b/tests/wcag-i18n/public-routes.spec.ts
@@ -1,0 +1,95 @@
+import { type Page } from "@playwright/test";
+import {
+  expect,
+  expectAxeClean,
+  expectKeyboardFocusVisibleWithinTabs,
+  expectNoHorizontalOverflow,
+  test,
+  waitForRouteReady,
+  withLocale,
+} from "../testHelpers";
+
+const THE_MEMES_ROUTE = "/the-memes";
+const THE_MEMES_STRESS_ROUTE = `${withLocale(
+  THE_MEMES_ROUTE,
+  "fr-FR"
+)}&sort=age&sort_dir=asc`;
+const SORTING_REGION_NAME = "Tri des memes";
+const THE_MEMES_EMPTY_STATE_PATTERN = /Aucun meme/i;
+
+test.describe("WCAG and i18n public route evidence @wcag @i18n @medium @large", () => {
+  test("The Memes route has no WCAG 2.2 A/AA axe violations @wcag @medium @large", async ({
+    page,
+  }) => {
+    await page.goto(THE_MEMES_STRESS_ROUTE, { waitUntil: "domcontentloaded" });
+    await waitForTheMemesRouteReady(page);
+
+    await expect(page.locator("h1", { hasText: "The Memes" })).toBeVisible();
+    await expectAxeClean(page, { route: THE_MEMES_STRESS_ROUTE });
+  });
+
+  test("The Memes locale stress route keeps readable layout bounds @i18n @medium @large", async ({
+    page,
+  }) => {
+    await page.goto(THE_MEMES_STRESS_ROUTE, { waitUntil: "domcontentloaded" });
+    await waitForTheMemesRouteReady(page);
+
+    await expect(page).toHaveTitle(/The Memes/);
+    await expect(
+      page.getByRole("region", { name: SORTING_REGION_NAME })
+    ).toBeVisible();
+    await expectNoHorizontalOverflow(page);
+
+    const cardLinks = page.locator('main a[href*="/the-memes/"]');
+    if ((await cardLinks.count()) > 0) {
+      await expect(cardLinks.first()).toHaveAttribute("href", /locale=fr-FR/);
+    }
+  });
+
+  test("The Memes route exposes visible keyboard focus @wcag @keyboard @medium @large", async ({
+    page,
+  }) => {
+    await page.goto(THE_MEMES_STRESS_ROUTE, { waitUntil: "domcontentloaded" });
+    await waitForTheMemesRouteReady(page);
+
+    const focused = await expectKeyboardFocusVisibleWithinTabs(page);
+
+    expect(focused.tagName).not.toBe("");
+  });
+});
+
+async function waitForTheMemesRouteReady(page: Page) {
+  await waitForRouteReady(page);
+  await expect(
+    page.getByRole("region", { name: SORTING_REGION_NAME })
+  ).toBeVisible();
+  await expect
+    .poll(
+      async () => {
+        const hasCards =
+          (await page.locator('main a[href*="/the-memes/"]').count()) > 0;
+        if (hasCards) {
+          return "cards";
+        }
+
+        const hasEmptyState = await page
+          .getByText(THE_MEMES_EMPTY_STATE_PATTERN)
+          .isVisible()
+          .catch(() => false);
+        if (hasEmptyState) {
+          return "empty";
+        }
+
+        const statusVisible = await page
+          .getByRole("status")
+          .isVisible()
+          .catch(() => false);
+        return statusVisible ? "loading" : "waiting";
+      },
+      {
+        message: "Expected The Memes route to settle with cards or empty state",
+        timeout: 45000,
+      }
+    )
+    .toMatch(/^(cards|empty)$/);
+}


### PR DESCRIPTION
## Issue
- PR 3 of the frontend testing roadmap adds the first dedicated browser evidence pack for the WCAG 2.2 AA and i18n mega-run.
- The goal is to give Codex and reviewbots concrete local/CI feedback before page-cluster remediation PRs scale up.
- Existing 6529bot review lanes are preserved unchanged and remain the baseline review layer.

## Fix
- Add shared Playwright helpers for WCAG axe scans, exact/owned/expiring axe debt allowlists, visible keyboard focus checks, and locale-stress route generation.
- Add the first route evidence pack for `/the-memes?locale=fr-FR&sort=age&sort_dir=asc` covering axe, layout bounds, locale-preserving links, and keyboard focus.
- Add a package script so the route pack can run locally and from future CI/deployment train workflows.
- Harden Bootstrap Sass resolution for Next 16/Turbopack under pnpm so the local and CI builds do not resolve Bootstrap's internal `progress` Sass partial to the JS `progress` package.

## Changes
- New test helpers:
  - `tests/support/a11yAllowlist.ts`
  - `tests/support/a11yAssertions.ts`
  - `tests/support/keyboardFocus.ts`
  - `tests/support/i18nFixtures.ts`
- New tests:
  - `tests/wcag-i18n/public-routes.spec.ts`
  - `__tests__/playwright/a11yAssertions.test.ts`
  - `__tests__/playwright/i18nFixtures.test.ts`
- New script: `seize run test:e2e:wcag-i18n`.
- New dev dependency: `@axe-core/playwright@4.11.3`.
- Build config hardening:
  - keep Bootstrap imported via `@use bootstrap/scss/bootstrap`;
  - put Bootstrap SCSS ahead of generic `node_modules` in Sass load paths;
  - add a narrow Turbopack alias for Bootstrap's `_progress.scss` partial;
  - keep `quietDeps` plus Bootstrap Sass deprecation silencing;
  - extend `guard:bootstrap-sass` so future changes do not regress this setup.
- Docs/workstream notes updated in `tests/README.md` and `ops/workstreams/frontend-a11y-i18n/run-log.md`.

## Functionality, UX, And Safety Impact
- User-facing functionality: no intended product behavior changes.
- UX: no intended visual/UI changes, except the build config now resolves Bootstrap Sass deterministically under Turbopack.
- Safety/security: read-only test helpers only; staging/prod mutation guard remains in the shared Playwright fixture; changed-files secret scan is clean.
- Dependencies: adds one dev-only direct dependency for axe Playwright integration. `dependency:risk-gate` correctly marks this high risk / auto-merge blocked because it is a new direct dependency from a non-Dependabot PR.
- Reviewbots: no `.github/6529bot.yml` or reviewbot config changes. Existing reviewbot reviews on every PR remain intact.

## Surface Matrix
- Web: directly covered through local Playwright route evidence and smoke tests.
- Mobile/Capacitor: no mobile runtime code changed. Risk is indirect through shared Bootstrap/global styles and is covered by build plus public-route browser smoke.
- Electron/Desktop Shell: no shell/runtime code changed. Risk is indirect through shared frontend build output and is covered by build plus public-route smoke.

## Local Testing Strategy
- Treat this PR as Level 4 because it touches Next config, package metadata, and lockfile.
- Validate the new evidence helpers with focused Jest and Playwright typecheck.
- Validate Sass/Turbopack guard separately before build.
- Validate production build because Next config and package metadata changed.
- Validate both the new WCAG/i18n browser pack and the existing smoke pack.

## Validation
- `seize install:frozen`
- `seize run format:uncommitted`
- `seize run guard:bootstrap-sass`
- `seize run lint:diff`
- `seize run lint:changed`
- `seize run typecheck:ci`
- `seize run typecheck:playwright`
- `seize run test:no-coverage -- __tests__/playwright/a11yAssertions.test.ts __tests__/playwright/i18nFixtures.test.ts` (2 suites, 6 tests passed)
- `seize run testing-strategy -- ci-plan --changed-from main --output test-results/app-pr-ci/pr3-ci-plan.json` (Level 4)
- `seize run testing-strategy -- scan-changed-secrets --changed-from main --output test-results/app-pr-ci/pr3-secret-scan.json` (clean)
- `seize run dependency:risk-gate` (expected high risk / auto-merge blocked for new dev dependency)
- `$env:CIRCLE_NODE_TOTAL='1'; seize run build` (passed full prebuild, lint, production Next build, standalone output, and postbuild sitemap)
- `$env:PLAYWRIGHT_WEB_SERVER_COMMAND='seize run dev'; seize run test:e2e:wcag-i18n` (3 passed)
- `$env:PLAYWRIGHT_WEB_SERVER_COMMAND='seize run dev'; seize run test:e2e:smoke` (6 passed after starting from a fresh local dev cache)
- `codex-diff-check --cached`

Notes:
- On this Windows EC2 host, uncapped local `next build` repeatedly completed compile/typecheck/static generation but hit `EBUSY` while copying files into `.next/standalone`. Re-running with `CIRCLE_NODE_TOTAL=1` avoided the local Windows copy race. CI/deploy builds run on Ubuntu.
- A first smoke run immediately after production build saw stale local dev-cache 404s. After isolating production `.next` output and starting a fresh dev cache, smoke passed 6/6.

## Risk
- Level: High
- Why: The runtime product change is low, but PR risk is high because this touches Next build config, package metadata, lockfile, and global Bootstrap Sass resolution.
- Rollback: revert this PR. That removes the new test helpers, axe dependency, script, and Sass/Turbopack guard changes.

## Review Notes
- Please focus on the Sass/Turbopack alias approach, dependency addition, and whether the WCAG/i18n helper contracts are strict enough for later page-cluster PRs.
- A verifier subagent reviewed the final diff. Its actionable finding was to tighten malformed axe allowlist entries; this PR now rejects empty selectors and non-real ISO dates with unit coverage.
- Existing 6529bot review lanes should still run and should not be reduced for this or later PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added a Playwright WCAG/i18n evidence smoke test with accessibility scanning and locale stress routes
  * Added keyboard-focus visibility assertions for more reliable a11y checks
  * Added i18n test helpers for generating locale-specific URL fixtures

* **Tests**
  * Introduced Axe violation allowlisting with validation, filtering, and readable summaries
  * Added a public-route test suite covering WCAG A/AA readiness, layout sanity, and focus behavior
  * Added i18n and allowlist validation coverage for fixtures

* **Documentation**
  * Documented WCAG/i18n evidence test usage and allowlist format

* **Chores**
  * Improved Sass/Turbopack handling for Bootstrap progress and added a new e2e test command/dependency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->