### PR TITLE
Harden deployment evidence reporting

### DIFF
--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -60,6 +60,7 @@ jobs:
             --environment production \
             --production-candidate-sha "${COMMIT_SHA}" \
             --production-eligible true \
+            --required-packs "playwright:core-smoke,playwright:wcag-i18n" \
             --release-captain "github-actions/${{ github.actor }}" \
             --status queued \
             --phase queued \
@@ -342,17 +343,26 @@ jobs:
           case "$JOB_STATUS" in
             success)
               state="success"
+              manifest_status="deploy_verified"
               description="Production deployment verified"
               ;;
             cancelled)
               state="error"
+              manifest_status="cancelled"
               description="Production deployment cancelled before verification"
               ;;
             *)
               state="failure"
+              manifest_status="failed"
               description="Production deployment failed before verification"
               ;;
           esac
+
+          node ops/scripts/deployment-bus.cjs heartbeat-manifest \
+            --file deployment-bus-manifest.json \
+            --status "$manifest_status" \
+            --phase terminal \
+            --message "$description"
 
           node ops/scripts/deployment-bus.cjs github-create-status \
             --deployment-id "${{ steps.deployment-record.outputs.deployment_id }}" \
@@ -361,12 +371,25 @@ jobs:
             --environment-url "https://6529.io" \
             --log-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
+      - name: Create production release report
+        if: always()
+        run: |
+          if [ -f deployment-bus-manifest.json ]; then
+            node ops/scripts/deployment-bus.cjs release-report \
+              --file deployment-bus-manifest.json \
+              --output deployment-release-report.md
+          else
+            echo "No deployment-bus-manifest.json was created; skipping release report."
+          fi
+
       - name: Upload deployment bus manifest
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: deployment-bus-production-${{ env.COMMIT_SHA || github.run_id }}
-          path: deployment-bus-manifest.json
+          path: |
+            deployment-bus-manifest.json
+            deployment-release-report.md
           if-no-files-found: ignore
           retention-days: 90
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -65,6 +65,7 @@ jobs:
             --staging-deploy-sha "${{ steps.expected-commit.outputs.sha }}" \
             --production-candidate-sha "${{ steps.production-candidate.outputs.sha }}" \
             --production-eligible "${{ steps.production-candidate.outputs.eligible }}" \
+            --required-packs "playwright:core-smoke,playwright:wcag-i18n" \
             --release-captain "github-actions/${{ github.actor }}" \
             --status queued \
             --phase queued \
@@ -417,17 +418,26 @@ jobs:
           case "$JOB_STATUS" in
             success)
               state="success"
+              manifest_status="deploy_verified"
               description="Staging deployment verified"
               ;;
             cancelled)
               state="error"
+              manifest_status="cancelled"
               description="Staging deployment cancelled before verification"
               ;;
             *)
               state="failure"
+              manifest_status="failed"
               description="Staging deployment failed before verification"
               ;;
           esac
+
+          node ops/scripts/deployment-bus.cjs heartbeat-manifest \
+            --file deployment-bus-manifest.json \
+            --status "$manifest_status" \
+            --phase terminal \
+            --message "$description"
 
           node ops/scripts/deployment-bus.cjs github-create-status \
             --deployment-id "${{ steps.deployment-record.outputs.deployment_id }}" \
@@ -436,11 +446,24 @@ jobs:
             --environment-url "https://staging.6529.io" \
             --log-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
+      - name: Create staging release report
+        if: always()
+        run: |
+          if [ -f deployment-bus-manifest.json ]; then
+            node ops/scripts/deployment-bus.cjs release-report \
+              --file deployment-bus-manifest.json \
+              --output deployment-release-report.md
+          else
+            echo "No deployment-bus-manifest.json was created; skipping release report."
+          fi
+
       - name: Upload deployment bus manifest
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: deployment-bus-staging-${{ steps.expected-commit.outputs.sha || github.run_id }}
-          path: deployment-bus-manifest.json
+          path: |
+            deployment-bus-manifest.json
+            deployment-release-report.md
           if-no-files-found: ignore
           retention-days: 30

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -46,7 +46,7 @@ function releaseReadyValidationChecks() {
         {
           uri: "https://artifacts.6529.io/frontend/release/wcag-i18n.json",
           redaction_status: "verified-redacted",
-          etag: "release-wcag-i18n-etag",
+          etag: "9b2cf535f27731c974343645a3985328",
           retention_days: 90,
         },
       ],
@@ -116,6 +116,22 @@ describe("deployment bus manifest", () => {
           "PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n",
       }),
     ]);
+  });
+
+  it("forces durable evidence for production-like manifests", () => {
+    const manifest = buildManifest({
+      environment: "production",
+      productionCandidateSha: MAIN_SHA,
+      durableArtifactsRequired: "false",
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    expect(manifest.validation.durable_artifacts.required).toBe(true);
+
+    manifest.validation.durable_artifacts.required = false;
+    expect(validateManifest(manifest).errors).toContain(
+      "validation.durable_artifacts.required: must be true for production or production-eligible manifests"
+    );
   });
 
   it("marks staging without a production candidate as exploratory", () => {
@@ -324,6 +340,84 @@ describe("deployment bus manifest", () => {
       holds: [],
       warnings: [],
     });
+  });
+
+  it("rejects unapproved durable artifact prefixes before artifact matching", () => {
+    const manifest = buildManifest({
+      environment: "production",
+      productionCandidateSha: MAIN_SHA,
+      status: "released",
+      validationChecks: JSON.stringify([
+        {
+          pack: "playwright:core-smoke",
+          status: "passed",
+          artifacts: [
+            {
+              uri: "https://untrusted.example/artifacts/core-smoke.json",
+              redaction_status: "verified-redacted",
+              sha256: ARTIFACT_SHA256,
+              retention_days: 90,
+            },
+          ],
+        },
+        releaseReadyValidationChecks()[1],
+      ]),
+      now: "2026-06-18T12:00:00.000Z",
+    });
+    manifest.validation.durable_artifacts.accepted_prefixes = [
+      "https://untrusted.example/artifacts/",
+    ];
+
+    const errors = validateManifest(manifest).errors;
+    expect(errors).toContain(
+      "validation.durable_artifacts.accepted_prefixes[0]: must be one of the approved durable artifact prefixes"
+    );
+    expect(errors).toContain(
+      "validation.checks[0].artifacts[0].uri: artifact URI does not use an approved durable artifact prefix"
+    );
+  });
+
+  it("requires well-formed artifact metadata for release readiness", () => {
+    const checks = releaseReadyValidationChecks();
+    checks[0].artifacts[0].sha256 = "not-a-sha";
+    checks[0].artifacts[0].retention_days = -1;
+    const manifest = buildManifest({
+      environment: "production",
+      productionCandidateSha: MAIN_SHA,
+      status: "released",
+      validationChecks: JSON.stringify(checks),
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    expect(validateManifest(manifest).errors).toContain(
+      "release_readiness.durable-artifact-pointer-missing: playwright:core-smoke has no approved durable artifact pointer with verified redaction, integrity metadata, and retention metadata"
+    );
+  });
+
+  it("uses recorded_at ordering for latest validation checks", () => {
+    const checks = releaseReadyValidationChecks();
+    const manifest = buildManifest({
+      environment: "production",
+      productionCandidateSha: MAIN_SHA,
+      status: "released",
+      validationChecks: JSON.stringify([
+        {
+          pack: "playwright:core-smoke",
+          status: "failed",
+          recorded_at: "2026-06-18T12:30:00.000Z",
+        },
+        {
+          ...checks[0],
+          recorded_at: "2026-06-18T12:15:00.000Z",
+        },
+        checks[1],
+      ]),
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    expect(validateManifest(manifest).errors).toContain(
+      "release_readiness.required-pack-failed: playwright:core-smoke recorded failed"
+    );
   });
 
   it("requires release-grade durable artifacts on the latest passing check for each pack", () => {

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -1,10 +1,15 @@
 const {
+  DEFAULT_REQUIRED_PACKS,
   VALID_STATUSES,
+  VALIDATION_PACKS,
   buildManifest,
   createGithubDeployment,
   createGithubDeploymentStatus,
+  createReleaseReport,
+  evaluateReleaseReadiness,
   heartbeatManifest,
   productionPreflight,
+  recordValidationCheck,
   summarizeManifest,
   validateManifest,
 } = require("../../ops/scripts/deployment-bus.cjs");
@@ -13,6 +18,41 @@ const path = require("node:path");
 
 const STAGING_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const MAIN_SHA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const ARTIFACT_SHA256 =
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+function releaseReadyValidationChecks() {
+  return [
+    {
+      pack: "playwright:core-smoke",
+      status: "passed",
+      command:
+        "PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:smoke",
+      artifacts: [
+        {
+          uri: "s3://6529-artifacts/frontend/release/core-smoke.json",
+          redaction_status: "verified-redacted",
+          sha256: ARTIFACT_SHA256,
+          retention_days: 90,
+        },
+      ],
+    },
+    {
+      pack: "playwright:wcag-i18n",
+      status: "passed",
+      command:
+        "PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n",
+      artifacts: [
+        {
+          uri: "https://artifacts.6529.io/frontend/release/wcag-i18n.json",
+          redaction_status: "verified-redacted",
+          etag: "release-wcag-i18n-etag",
+          retention_days: 90,
+        },
+      ],
+    },
+  ];
+}
 
 describe("deployment bus manifest", () => {
   afterEach(() => {
@@ -38,6 +78,44 @@ describe("deployment bus manifest", () => {
     expect(manifest.release_id).toContain("fe-staging-20260618T120000Z");
     expect(manifest.lane.heartbeat_interval_minutes).toBe(15);
     expect(manifest.lane.stale_after_minutes).toBe(45);
+    expect(manifest.validation.required_packs).toEqual(DEFAULT_REQUIRED_PACKS);
+    expect(manifest.validation.pack_plan).toEqual([
+      expect.objectContaining({
+        id: "playwright:core-smoke",
+        command: "seize run test:e2e:staging",
+      }),
+      expect.objectContaining({
+        id: "playwright:wcag-i18n",
+        command:
+          "PLAYWRIGHT_BASE_URL=https://staging.6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n",
+      }),
+    ]);
+    expect(manifest.validation.durable_artifacts).toMatchObject({
+      required: true,
+      git_lfs_allowed: false,
+    });
+  });
+
+  it("records standard production validation pack commands", () => {
+    const manifest = buildManifest({
+      environment: "production",
+      productionCandidateSha: MAIN_SHA,
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    expect(VALIDATION_PACKS["playwright:core-smoke"].size).toBe("large");
+    expect(manifest.validation.pack_plan).toEqual([
+      expect.objectContaining({
+        id: "playwright:core-smoke",
+        command:
+          "PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:smoke",
+      }),
+      expect.objectContaining({
+        id: "playwright:wcag-i18n",
+        command:
+          "PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n",
+      }),
+    ]);
   });
 
   it("marks staging without a production candidate as exploratory", () => {
@@ -52,7 +130,7 @@ describe("deployment bus manifest", () => {
 
     expect(result.ok).toBe(true);
     expect(result.warnings).toContain(
-      "staging manifest is exploratory only; it does not satisfy the production same-SHA gate",
+      "staging manifest is exploratory only; it does not satisfy the production same-SHA gate"
     );
   });
 
@@ -104,7 +182,7 @@ describe("deployment bus manifest", () => {
 
     expect(result.ok).toBe(false);
     expect(result.errors).toContain(
-      "lane.heartbeat_interval_minutes: must be at most half of lane.stale_after_minutes",
+      "lane.heartbeat_interval_minutes: must be at most half of lane.stale_after_minutes"
     );
   });
 
@@ -133,6 +211,242 @@ describe("deployment bus manifest", () => {
     expect(validateManifest(updated).ok).toBe(true);
   });
 
+  it("warns after deploy verification when required validation evidence is missing", () => {
+    const manifest = buildManifest({
+      environment: "staging",
+      stagingDeploySha: STAGING_SHA,
+      productionCandidateSha: MAIN_SHA,
+      status: "deploy_verified",
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    const result = validateManifest(manifest);
+    const readiness = evaluateReleaseReadiness(manifest);
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toContain(
+      "release_readiness.required-pack-missing-terminal-evidence: playwright:core-smoke has no passed validation check recorded"
+    );
+    expect(readiness.ok).toBe(false);
+    expect(readiness.holds).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "required-pack-missing-terminal-evidence",
+          pack: "playwright:core-smoke",
+        }),
+      ])
+    );
+  });
+
+  it("does not block recording failed or cancelled deploy terminal status", () => {
+    const failed = buildManifest({
+      environment: "staging",
+      stagingDeploySha: STAGING_SHA,
+      productionCandidateSha: MAIN_SHA,
+      status: "failed",
+      now: "2026-06-18T12:00:00.000Z",
+    });
+    const cancelled = buildManifest({
+      environment: "staging",
+      stagingDeploySha: STAGING_SHA,
+      productionCandidateSha: MAIN_SHA,
+      status: "cancelled",
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    expect(validateManifest(failed).errors).toEqual([]);
+    expect(validateManifest(cancelled).errors).toEqual([]);
+  });
+
+  it("records validation checks and lets later passing reruns clear pack holds", () => {
+    const base = buildManifest({
+      environment: "staging",
+      stagingDeploySha: STAGING_SHA,
+      productionCandidateSha: MAIN_SHA,
+      status: "deploy_verified",
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    const failed = recordValidationCheck(base, {
+      pack: "playwright:core-smoke",
+      status: "failed",
+      artifactUri:
+        "s3://6529-artifacts/frontend/release/core-smoke-failed.json",
+      now: "2026-06-18T12:15:00.000Z",
+    });
+    const passed = recordValidationCheck(failed, {
+      pack: "playwright:core-smoke",
+      status: "passed",
+      artifactUri:
+        "s3://6529-artifacts/frontend/release/core-smoke-passed.json",
+      artifactSha256: ARTIFACT_SHA256,
+      redactionStatus: "verified-redacted",
+      retentionDays: "90",
+      now: "2026-06-18T12:30:00.000Z",
+    });
+
+    expect(passed.validation.checks).toHaveLength(2);
+    expect(evaluateReleaseReadiness(failed).holds).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "required-pack-failed",
+          pack: "playwright:core-smoke",
+        }),
+      ])
+    );
+    expect(evaluateReleaseReadiness(passed).holds).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "required-pack-failed",
+          pack: "playwright:core-smoke",
+        }),
+      ])
+    );
+    expect(validateManifest(passed).ok).toBe(true);
+  });
+
+  it("passes release readiness with required packs and durable artifacts", () => {
+    const manifest = buildManifest({
+      environment: "production",
+      productionCandidateSha: MAIN_SHA,
+      status: "released",
+      validationChecks: JSON.stringify(releaseReadyValidationChecks()),
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    expect(validateManifest(manifest)).toEqual({
+      ok: true,
+      errors: [],
+      warnings: [],
+    });
+    expect(evaluateReleaseReadiness(manifest)).toEqual({
+      ok: true,
+      holds: [],
+      warnings: [],
+    });
+  });
+
+  it("requires release-grade durable artifacts on the latest passing check for each pack", () => {
+    const manifest = buildManifest({
+      environment: "production",
+      productionCandidateSha: MAIN_SHA,
+      status: "released",
+      validationChecks: JSON.stringify([
+        {
+          pack: "playwright:core-smoke",
+          status: "passed",
+          artifacts: [
+            {
+              uri: "s3://6529-artifacts/frontend/release/core-smoke.json",
+              redaction_status: "verified-redacted",
+              sha256: ARTIFACT_SHA256,
+              retention_days: 90,
+            },
+          ],
+        },
+        {
+          pack: "playwright:wcag-i18n",
+          status: "passed",
+          artifacts: [],
+        },
+        {
+          pack: "ad-hoc:notes",
+          status: "passed",
+          artifacts: [
+            {
+              uri: "s3://6529-artifacts/frontend/release/unrelated.json",
+              redaction_status: "verified-redacted",
+              sha256: ARTIFACT_SHA256,
+              retention_days: 90,
+            },
+          ],
+        },
+      ]),
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    expect(validateManifest(manifest).errors).toContain(
+      "release_readiness.durable-artifact-pointer-missing: playwright:wcag-i18n has no approved durable artifact pointer with verified redaction, integrity metadata, and retention metadata"
+    );
+  });
+
+  it("rejects tokenized artifact URIs and redacts them in reports", () => {
+    const manifest = buildManifest({
+      environment: "staging",
+      stagingDeploySha: STAGING_SHA,
+      productionCandidateSha: MAIN_SHA,
+      productionEligible: "true",
+      status: "deploy_verified",
+      validationChecks: JSON.stringify([
+        {
+          pack: "playwright:core-smoke",
+          status: "passed",
+          artifacts: [
+            {
+              uri: "https://artifacts.6529.io/frontend/release/core-smoke.json?X-Amz-Signature=secret",
+              redaction_status: "verified-redacted",
+              sha256: ARTIFACT_SHA256,
+              retention_days: 90,
+            },
+          ],
+        },
+      ]),
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    const result = validateManifest(manifest);
+    const report = createReleaseReport(manifest, {
+      now: "2026-06-18T13:00:00.000Z",
+    });
+
+    expect(result.errors).toContain(
+      "validation.checks[0].artifacts[0].uri: artifact URI must not include query strings or fragments"
+    );
+    expect(report).toContain("Report status: hold");
+    expect(report).toContain("[query-or-fragment redacted]");
+    expect(report).not.toContain("X-Amz-Signature");
+  });
+
+  it("creates a markdown release report with hold details", () => {
+    const manifest = buildManifest({
+      environment: "staging",
+      stagingDeploySha: STAGING_SHA,
+      productionCandidateSha: MAIN_SHA,
+      status: "deploy_verified",
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    const report = createReleaseReport(manifest, {
+      now: "2026-06-18T13:00:00.000Z",
+    });
+
+    expect(report).toContain("# staging Release Report");
+    expect(report).toContain("Report status: hold");
+    expect(report).toContain("playwright:core-smoke");
+    expect(report).toContain("required-pack-missing-terminal-evidence");
+    expect(report).toContain("Git LFS allowed: false");
+  });
+
+  it("keeps invalid manifests on hold even when release readiness passes", () => {
+    const manifest = buildManifest({
+      environment: "production",
+      productionCandidateSha: MAIN_SHA,
+      status: "released",
+      validationChecks: JSON.stringify(releaseReadyValidationChecks()),
+      now: "2026-06-18T12:00:00.000Z",
+    });
+    manifest.release_id = "";
+
+    const report = createReleaseReport(manifest, {
+      now: "2026-06-18T13:00:00.000Z",
+    });
+
+    expect(evaluateReleaseReadiness(manifest).ok).toBe(true);
+    expect(validateManifest(manifest).ok).toBe(false);
+    expect(report).toContain("Report status: hold");
+    expect(report).toContain("manifest-validation: release_id: required");
+  });
+
   it("summarizes the release id, shas, and lease timing", () => {
     const manifest = buildManifest({
       environment: "production",
@@ -141,7 +455,7 @@ describe("deployment bus manifest", () => {
     });
 
     expect(summarizeManifest(manifest)).toContain(
-      "production_candidate_sha: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "production_candidate_sha: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     );
     expect(summarizeManifest(manifest)).toContain("heartbeat: every 15m");
   });
@@ -150,8 +464,8 @@ describe("deployment bus manifest", () => {
     const schema = JSON.parse(
       fs.readFileSync(
         path.join(process.cwd(), "ops/deployment-bus/manifest.v1.schema.json"),
-        "utf8",
-      ),
+        "utf8"
+      )
     );
 
     expect(new Set(schema.properties.status.enum)).toEqual(VALID_STATUSES);
@@ -193,7 +507,7 @@ describe("deployment bus manifest", () => {
 
     expect(result.ok).toBe(false);
     expect(result.errors).toContain(
-      `production candidate ${MAIN_SHA} does not match origin/main ${newerMainSha}`,
+      `production candidate ${MAIN_SHA} does not match origin/main ${newerMainSha}`
     );
   });
 
@@ -211,7 +525,9 @@ describe("deployment bus manifest", () => {
     });
 
     expect(result.ok).toBe(false);
-    expect(result.errors).toContain("origin/main: current main SHA is required");
+    expect(result.errors).toContain(
+      "origin/main: current main SHA is required"
+    );
   });
 
   it("creates a GitHub Deployment with a static bus payload and returns the id", async () => {
@@ -240,14 +556,14 @@ describe("deployment bus manifest", () => {
         GITHUB_REPOSITORY: "6529-Collections/6529seize-frontend",
         GITHUB_TOKEN: "test-token",
         GITHUB_API_URL: "https://api.github.test",
-      },
+      }
     );
 
     expect(deployment.id).toBe(12345);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe(
-      "https://api.github.test/repos/6529-Collections/6529seize-frontend/deployments",
+      "https://api.github.test/repos/6529-Collections/6529seize-frontend/deployments"
     );
     const body = JSON.parse(init.body);
     expect(body).toMatchObject({
@@ -272,7 +588,8 @@ describe("deployment bus manifest", () => {
     globalThis.fetch = jest.fn(async () => ({
       ok: true,
       status: 202,
-      text: async () => JSON.stringify({ message: "Accepted without deployment" }),
+      text: async () =>
+        JSON.stringify({ message: "Accepted without deployment" }),
     })) as unknown as typeof fetch;
 
     await expect(
@@ -283,8 +600,8 @@ describe("deployment bus manifest", () => {
           GITHUB_REPOSITORY: "6529-Collections/6529seize-frontend",
           GITHUB_TOKEN: "test-token",
           GITHUB_API_URL: "https://api.github.test",
-        },
-      ),
+        }
+      )
     ).rejects.toThrow("did not include a numeric id");
   });
 
@@ -308,12 +625,12 @@ describe("deployment bus manifest", () => {
         GITHUB_REPOSITORY: "6529-Collections/6529seize-frontend",
         GITHUB_TOKEN: "test-token",
         GITHUB_API_URL: "https://api.github.test",
-      },
+      }
     );
 
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toBe(
-      "https://api.github.test/repos/6529-Collections/6529seize-frontend/deployments/12345/statuses",
+      "https://api.github.test/repos/6529-Collections/6529seize-frontend/deployments/12345/statuses"
     );
     expect(JSON.parse(init.body)).toMatchObject({
       state: "in_progress",
@@ -328,8 +645,8 @@ describe("deployment bus manifest", () => {
           GITHUB_REPOSITORY: "6529-Collections/6529seize-frontend",
           GITHUB_TOKEN: "test-token",
           GITHUB_API_URL: "https://api.github.test",
-        },
-      ),
+        }
+      )
     ).rejects.toThrow("deployment id must be numeric");
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/ops/deployment-bus/manifest.v1.schema.json
+++ b/ops/deployment-bus/manifest.v1.schema.json
@@ -252,7 +252,14 @@
             "required": { "type": "boolean" },
             "accepted_prefixes": {
               "type": "array",
-              "items": { "type": "string" }
+              "uniqueItems": true,
+              "items": {
+                "enum": [
+                  "s3://6529-artifacts/",
+                  "https://artifacts.6529.io/",
+                  "ipfs://"
+                ]
+              }
             },
             "git_lfs_allowed": { "const": false },
             "notes": { "type": "string" }

--- a/ops/deployment-bus/manifest.v1.schema.json
+++ b/ops/deployment-bus/manifest.v1.schema.json
@@ -147,7 +147,15 @@
       "items": {
         "type": "object",
         "additionalProperties": true,
-        "required": ["number", "title", "merge_sha", "risk", "areas", "validation_owner", "status"],
+        "required": [
+          "number",
+          "title",
+          "merge_sha",
+          "risk",
+          "areas",
+          "validation_owner",
+          "status"
+        ],
         "properties": {
           "number": { "type": "integer" },
           "title": { "type": "string" },
@@ -180,12 +188,48 @@
     "validation": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["core_smoke_owner", "required_packs", "exploratory_checks", "checks"],
+      "required": [
+        "core_smoke_owner",
+        "required_packs",
+        "exploratory_checks",
+        "checks"
+      ],
       "properties": {
         "core_smoke_owner": { "type": "string" },
         "required_packs": {
           "type": "array",
           "items": { "type": "string" }
+        },
+        "pack_plan": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "known",
+              "command",
+              "size",
+              "surfaces",
+              "artifact_paths",
+              "description"
+            ],
+            "properties": {
+              "id": { "type": "string" },
+              "known": { "type": "boolean" },
+              "command": { "type": ["string", "null"] },
+              "size": { "type": "string" },
+              "surfaces": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "artifact_paths": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "description": { "type": "string" }
+            }
+          }
         },
         "exploratory_checks": {
           "type": "array",
@@ -194,6 +238,38 @@
         "checks": {
           "type": "array",
           "items": { "type": "object", "additionalProperties": true }
+        },
+        "durable_artifacts": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "required",
+            "accepted_prefixes",
+            "git_lfs_allowed",
+            "notes"
+          ],
+          "properties": {
+            "required": { "type": "boolean" },
+            "accepted_prefixes": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "git_lfs_allowed": { "const": false },
+            "notes": { "type": "string" }
+          }
+        },
+        "auto_hold_criteria": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "hold_when", "recovery"],
+            "properties": {
+              "id": { "type": "string" },
+              "hold_when": { "type": "string" },
+              "recovery": { "type": "string" }
+            }
+          }
         }
       }
     },
@@ -245,7 +321,11 @@
     "human_gates": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["production_approval_required", "approvals", "override_reason"],
+      "required": [
+        "production_approval_required",
+        "approvals",
+        "override_reason"
+      ],
       "properties": {
         "production_approval_required": { "type": "boolean" },
         "approvals": {

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -14,6 +14,9 @@ safe bus needs before queue automation can make decisions:
 - GitHub Deployment records for staging and production deploy workflows
 - Deployment status heartbeats while SSM or Elastic Beanstalk waits are running
 - manifest artifacts retained from deploy workflow runs
+- release report artifacts retained beside the manifest
+- standard deployed-environment validation pack names and commands
+- auto-hold evaluation for missing or failed required evidence
 - production workflow check that fails if `origin/main` advances during the
   build before Elastic Beanstalk is updated
 - deployed-staging Playwright mode through `PLAYWRIGHT_BASE_URL` and
@@ -41,6 +44,15 @@ Validate and summarize:
 ```bash
 6529 run deployment-bus -- validate-manifest --file deployment-bus-manifest.json
 6529 run deployment-bus -- summarize-manifest --file deployment-bus-manifest.json
+6529 run deployment-bus -- record-validation-check \
+  --file deployment-bus-manifest.json \
+  --pack playwright:core-smoke \
+  --status passed \
+  --artifact-uri s3://6529-artifacts/frontend/<release-id>/core-smoke.json \
+  --redaction-status verified-redacted \
+  --artifact-sha256 <sha256> \
+  --retention-days 90
+6529 run deployment-bus -- release-report --file deployment-bus-manifest.json --output deployment-release-report.md
 ```
 
 The manifest separates:
@@ -59,6 +71,74 @@ Manifest creation is intentionally a hard deploy gate. If the workflow cannot
 create and validate the manifest, it stops before SSM, S3, or Elastic Beanstalk
 mutation. The deployment lane should not move when its release ledger cannot be
 written.
+
+## Standard Validation Packs
+
+The deployment manifest now records the standard frontend deployed-environment
+packs in `validation.required_packs` and expands them in
+`validation.pack_plan`.
+
+| Pack                    | Staging command                                                                                         | Production command                                                                              |
+| ----------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `playwright:core-smoke` | `seize run test:e2e:staging`                                                                            | `PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:smoke`     |
+| `playwright:wcag-i18n`  | `PLAYWRIGHT_BASE_URL=https://staging.6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n` | `PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n` |
+
+The current pack plan intentionally records `web:desktop-chromium` as the
+covered surface. Mobile Chromium, Firefox, WebKit, Capacitor simulation, and
+Electron simulation remain PR4 work and must not be claimed as covered until
+those projects exist and pass.
+
+## Release Reports And Auto-Hold
+
+Deploy workflows now update `deployment-bus-manifest.json` to a terminal deploy
+status before artifact upload and write `deployment-release-report.md` beside
+it. The report includes:
+
+- exact staging and production candidate SHAs;
+- release captain and environment URL;
+- required validation packs and their commands;
+- recorded validation checks and artifact pointers;
+- auto-hold findings;
+- included PRs and artifact policy.
+
+The report status is `hold` when required validation evidence has not been
+recorded yet. A hold does not mean the deploy failed. It means production
+promotion or public release notes still need the missing deployed-environment
+evidence or a recorded release-captain exception.
+
+`record-validation-check` appends a timestamped result to
+`validation.checks`. Use it after a required pack finishes so the next release
+report can distinguish unresolved findings from a fixed rerun. The latest
+recorded result for each required pack is authoritative for pack readiness; a
+failed run can be cleared by a later passing rerun with retained evidence.
+
+For release readiness, each required pack's latest passing check needs its own
+approved durable artifact pointer. An unrelated check's artifact does not prove
+the required pack. The pointer must include:
+
+- an approved durable URI without query strings, fragments, signed URL tokens,
+  local filesystem paths, or Git LFS pointers;
+- `redaction_status=verified-redacted`;
+- integrity metadata: `sha256`, `etag`, or `cid`;
+- retention metadata: `retention_days`, `retention_until`, or
+  `retention_policy`.
+
+Current auto-hold criteria:
+
+- any required validation pack records `failed`, `blocked`, or `timed_out`;
+- a deploy-verified or terminal manifest lacks a passed check for each required
+  validation pack;
+- a production-eligible manifest's latest passing required-pack check lacks an
+  approved durable artifact pointer with verified redaction, integrity metadata,
+  and retention metadata;
+- the production candidate SHA no longer matches the staging-validated release
+  set.
+
+Durable evidence must point at approved 6529-controlled artifact storage such
+as `s3://6529-artifacts/`, `https://artifacts.6529.io/`, or `ipfs://` for
+intentionally public redacted provenance. Git LFS and committed generated files
+are not durable release evidence stores. Do not record temporary signed URLs,
+query-string credentials, fragments, local paths, or unredacted artifacts.
 
 ## GitHub Deployment Ledger
 

--- a/ops/docs/developer/deployment-bus-process.md
+++ b/ops/docs/developer/deployment-bus-process.md
@@ -6,10 +6,12 @@ slices: durable manifests and GitHub Deployment records first, then queue
 materialization, labels, PR comments, dashboard helpers, and stricter
 production preflight gates.
 
-Implementation note: the first automation slice is documented in
-`ops/docs/developer/deployment-bus-automation.md`. It adds manifest validation,
-GitHub Deployment ledger records, workflow artifacts, deployed-staging smoke
-support, and long-running deployment heartbeats without automating queue
+Implementation note: the automation slices are documented in
+`ops/docs/developer/deployment-bus-automation.md`. They add manifest
+validation, GitHub Deployment ledger records, workflow artifacts, standard
+deployed-environment validation pack names, release report artifacts,
+deployed-staging smoke support, auto-hold evaluation for missing release
+evidence, and long-running deployment heartbeats without automating queue
 movement or production promotion.
 
 ## Why This Exists
@@ -81,6 +83,14 @@ Known current gaps after the first automation slice:
 - The durable manifest artifact is authoritative for this slice; GitHub
   Deployment records are the status/history pointer, not the full manifest
   datastore.
+- Release reports evaluate whether required packs and durable artifact pointers
+  are recorded, but the workflows still do not automatically run those
+  post-deploy Playwright packs. The release captain or validation agents must
+  run them and record results with `record-validation-check` until a later
+  automation slice wires pack execution into the lane.
+- The current standard pack plan covers desktop Chromium only. Mobile browser,
+  Firefox, WebKit, Capacitor simulation, and Electron simulation are explicit
+  future surface-matrix work.
 - Backend coordination is still a cross-repo handoff, not a shared automated
   release train.
 

--- a/ops/scripts/deployment-bus.cjs
+++ b/ops/scripts/deployment-bus.cjs
@@ -6,6 +6,9 @@ const path = require("node:path");
 
 const SCHEMA_VERSION = "deployment-bus.v1";
 const SHA_RE = /^[0-9a-f]{40}$/i;
+const SHA256_RE = /^[0-9a-f]{64}$/i;
+const ETAG_RE = /^"?[0-9a-f]{32}(?:-\d+)?"?$/i;
+const CID_RE = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{20,})$/;
 const VALID_ENVIRONMENTS = new Set(["staging", "production"]);
 const VALIDATION_PACKS = Object.freeze({
   "playwright:core-smoke": Object.freeze({
@@ -51,6 +54,12 @@ const APPROVED_DURABLE_ARTIFACT_PREFIXES = Object.freeze([
   "s3://6529-artifacts/",
   "https://artifacts.6529.io/",
   "ipfs://",
+]);
+const VALID_RETENTION_POLICIES = new Set([
+  "standard-30-days",
+  "standard-90-days",
+  "standard-1-year",
+  "permanent",
 ]);
 const RELEASE_READINESS_STATUSES = new Set([
   "deploy_verified",
@@ -364,10 +373,9 @@ function buildManifest(options, env = process.env) {
       exploratory_checks: parseJsonOption(options.exploratoryChecks, []),
       checks: parseJsonOption(options.validationChecks, []),
       durable_artifacts: {
-        required: parseBoolean(
-          options.durableArtifactsRequired,
-          productionLikeEvidenceRequired
-        ),
+        required: productionLikeEvidenceRequired
+          ? true
+          : parseBoolean(options.durableArtifactsRequired, false),
         accepted_prefixes: [...APPROVED_DURABLE_ARTIFACT_PREFIXES],
         git_lfs_allowed: false,
         notes:
@@ -652,7 +660,11 @@ function validateValidationPlan(manifest, errors, warnings) {
   }
 
   validatePackPlan(validation, errors);
-  validateDurableArtifactsConfig(validation.durable_artifacts, errors);
+  validateDurableArtifactsConfig(
+    validation.durable_artifacts,
+    manifest,
+    errors
+  );
 
   const checksOk = validateValidationChecks(validation, errors, warnings);
   if (!checksOk) {
@@ -693,7 +705,18 @@ function validatePackPlan(validation, errors) {
   }
 }
 
-function validateDurableArtifactsConfig(durableArtifacts, errors) {
+function validateDurableArtifactsConfig(durableArtifacts, manifest, errors) {
+  const durableEvidenceRequired =
+    manifest.environment === "production" ||
+    manifest.production_eligible === true;
+  if (durableEvidenceRequired && durableArtifacts?.required !== true) {
+    pushError(
+      errors,
+      "validation.durable_artifacts.required",
+      "must be true for production or production-eligible manifests"
+    );
+  }
+
   if (durableArtifacts !== undefined) {
     if (typeof durableArtifacts.required !== "boolean") {
       pushError(
@@ -708,6 +731,11 @@ function validateDurableArtifactsConfig(durableArtifacts, errors) {
         "validation.durable_artifacts.accepted_prefixes",
         "must be an array"
       );
+    } else {
+      validateAcceptedArtifactPrefixes(
+        durableArtifacts.accepted_prefixes,
+        errors
+      );
     }
     if (durableArtifacts.git_lfs_allowed !== false) {
       pushError(
@@ -719,10 +747,29 @@ function validateDurableArtifactsConfig(durableArtifacts, errors) {
   }
 }
 
+function validateAcceptedArtifactPrefixes(acceptedPrefixes, errors) {
+  acceptedPrefixes.forEach((prefix, index) => {
+    if (!APPROVED_DURABLE_ARTIFACT_PREFIXES.includes(prefix)) {
+      pushError(
+        errors,
+        `validation.durable_artifacts.accepted_prefixes[${index}]`,
+        "must be one of the approved durable artifact prefixes"
+      );
+    }
+  });
+}
+
 function validationAcceptedArtifactPrefixes(validation) {
   const acceptedPrefixes = validation.durable_artifacts?.accepted_prefixes;
-  return Array.isArray(acceptedPrefixes)
-    ? acceptedPrefixes
+  if (!Array.isArray(acceptedPrefixes)) {
+    return APPROVED_DURABLE_ARTIFACT_PREFIXES;
+  }
+
+  const approvedPrefixes = acceptedPrefixes.filter((prefix) =>
+    APPROVED_DURABLE_ARTIFACT_PREFIXES.includes(prefix)
+  );
+  return approvedPrefixes.length > 0
+    ? approvedPrefixes
     : APPROVED_DURABLE_ARTIFACT_PREFIXES;
 }
 
@@ -880,14 +927,50 @@ function artifactRejectionReason(uri, acceptedPrefixes) {
 }
 
 function artifactHasIntegrityMetadata(artifact) {
-  return Boolean(artifact?.sha256 || artifact?.etag || artifact?.cid);
+  return Boolean(
+    isValidSha256(artifact?.sha256) ||
+    isValidEtag(artifact?.etag) ||
+    isValidCid(artifact?.cid)
+  );
 }
 
 function artifactHasRetentionMetadata(artifact) {
   return Boolean(
-    artifact?.retention_days ||
-    artifact?.retention_until ||
-    artifact?.retention_policy
+    isPositiveIntegerValue(artifact?.retention_days) ||
+    isValidDateValue(artifact?.retention_until) ||
+    isValidRetentionPolicy(artifact?.retention_policy)
+  );
+}
+
+function isValidSha256(value) {
+  return typeof value === "string" && SHA256_RE.test(value.trim());
+}
+
+function isValidEtag(value) {
+  return typeof value === "string" && ETAG_RE.test(value.trim());
+}
+
+function isValidCid(value) {
+  return typeof value === "string" && CID_RE.test(value.trim());
+}
+
+function isPositiveIntegerValue(value) {
+  if (Number.isInteger(value)) {
+    return value > 0;
+  }
+  return typeof value === "string" && /^[1-9]\d*$/.test(value.trim());
+}
+
+function isValidDateValue(value) {
+  if (typeof value !== "string" || value.trim() === "") {
+    return false;
+  }
+  return !Number.isNaN(Date.parse(value));
+}
+
+function isValidRetentionPolicy(value) {
+  return (
+    typeof value === "string" && VALID_RETENTION_POLICIES.has(value.trim())
   );
 }
 
@@ -905,18 +988,60 @@ function artifactIsReleaseReady(artifact, acceptedPrefixes) {
 }
 
 function approvedDurableArtifactsForCheck(manifest, check) {
-  const acceptedPrefixes =
-    manifest.validation?.durable_artifacts?.accepted_prefixes ||
-    APPROVED_DURABLE_ARTIFACT_PREFIXES;
+  const acceptedPrefixes = validationAcceptedArtifactPrefixes(
+    manifest.validation || {}
+  );
 
   return checkArtifacts(check).filter((artifact) =>
     artifactIsReleaseReady(artifact, acceptedPrefixes)
   );
 }
 
+function checkTimestampMs(check) {
+  const value = check?.recorded_at || check?.completed_at || check?.at;
+  const ms = Date.parse(value || "");
+  return Number.isNaN(ms) ? null : ms;
+}
+
+function isNewerValidationCheck(
+  candidate,
+  candidateIndex,
+  latest,
+  latestIndex
+) {
+  const candidateMs = checkTimestampMs(candidate);
+  const latestMs = checkTimestampMs(latest);
+
+  if (candidateMs !== null && latestMs !== null) {
+    return (
+      candidateMs > latestMs ||
+      (candidateMs === latestMs && candidateIndex > latestIndex)
+    );
+  }
+  if (candidateMs !== null) {
+    return true;
+  }
+  if (latestMs !== null) {
+    return false;
+  }
+  return candidateIndex > latestIndex;
+}
+
 function latestCheckForPack(checks, packId) {
-  const packChecks = checks.filter((check) => checkPackId(check) === packId);
-  return packChecks[packChecks.length - 1] || null;
+  let latest = null;
+  let latestIndex = -1;
+
+  checks.forEach((check, index) => {
+    if (checkPackId(check) !== packId) {
+      return;
+    }
+    if (!latest || isNewerValidationCheck(check, index, latest, latestIndex)) {
+      latest = check;
+      latestIndex = index;
+    }
+  });
+
+  return latest;
 }
 
 function evaluateReleaseReadiness(manifest) {

--- a/ops/scripts/deployment-bus.cjs
+++ b/ops/scripts/deployment-bus.cjs
@@ -725,16 +725,16 @@ function validateDurableArtifactsConfig(durableArtifacts, manifest, errors) {
         "must be boolean"
       );
     }
-    if (!Array.isArray(durableArtifacts.accepted_prefixes)) {
+    if (Array.isArray(durableArtifacts.accepted_prefixes)) {
+      validateAcceptedArtifactPrefixes(
+        durableArtifacts.accepted_prefixes,
+        errors
+      );
+    } else {
       pushError(
         errors,
         "validation.durable_artifacts.accepted_prefixes",
         "must be an array"
-      );
-    } else {
-      validateAcceptedArtifactPrefixes(
-        durableArtifacts.accepted_prefixes,
-        errors
       );
     }
     if (durableArtifacts.git_lfs_allowed !== false) {
@@ -749,7 +749,7 @@ function validateDurableArtifactsConfig(durableArtifacts, manifest, errors) {
 
 function validateAcceptedArtifactPrefixes(acceptedPrefixes, errors) {
   acceptedPrefixes.forEach((prefix, index) => {
-    if (!APPROVED_DURABLE_ARTIFACT_PREFIXES.includes(prefix)) {
+    if (!isApprovedDurableArtifactPrefix(prefix)) {
       pushError(
         errors,
         `validation.durable_artifacts.accepted_prefixes[${index}]`,
@@ -759,18 +759,27 @@ function validateAcceptedArtifactPrefixes(acceptedPrefixes, errors) {
   });
 }
 
-function validationAcceptedArtifactPrefixes(validation) {
-  const acceptedPrefixes = validation.durable_artifacts?.accepted_prefixes;
-  if (!Array.isArray(acceptedPrefixes)) {
-    return APPROVED_DURABLE_ARTIFACT_PREFIXES;
-  }
-
-  const approvedPrefixes = acceptedPrefixes.filter((prefix) =>
+function isApprovedDurableArtifactPrefix(prefix) {
+  return (
+    typeof prefix === "string" &&
     APPROVED_DURABLE_ARTIFACT_PREFIXES.includes(prefix)
   );
-  return approvedPrefixes.length > 0
-    ? approvedPrefixes
-    : APPROVED_DURABLE_ARTIFACT_PREFIXES;
+}
+
+function validationAcceptedArtifactPrefixes(validation) {
+  const acceptedPrefixes = validation.durable_artifacts?.accepted_prefixes;
+  let approvedPrefixes = [...APPROVED_DURABLE_ARTIFACT_PREFIXES];
+
+  if (Array.isArray(acceptedPrefixes)) {
+    const manifestPrefixes = acceptedPrefixes.filter(
+      isApprovedDurableArtifactPrefix
+    );
+    if (manifestPrefixes.length > 0) {
+      approvedPrefixes = manifestPrefixes;
+    }
+  }
+
+  return approvedPrefixes;
 }
 
 function validateValidationChecks(validation, errors, warnings) {

--- a/ops/scripts/deployment-bus.cjs
+++ b/ops/scripts/deployment-bus.cjs
@@ -646,6 +646,23 @@ function validateManifest(manifest) {
 
 function validateValidationPlan(manifest, errors, warnings) {
   const validation = manifest.validation || {};
+  const requiredPacks = validateRequiredPacks(validation, errors, warnings);
+  if (!requiredPacks) {
+    return;
+  }
+
+  validatePackPlan(validation, errors);
+  validateDurableArtifactsConfig(validation.durable_artifacts, errors);
+
+  const checksOk = validateValidationChecks(validation, errors, warnings);
+  if (!checksOk) {
+    return;
+  }
+
+  addReadinessFindings(manifest, errors, warnings);
+}
+
+function validateRequiredPacks(validation, errors, warnings) {
   const requiredPacks = validation.required_packs;
   if (!Array.isArray(requiredPacks) || requiredPacks.length === 0) {
     pushError(
@@ -653,7 +670,7 @@ function validateValidationPlan(manifest, errors, warnings) {
       "validation.required_packs",
       "must include at least one pack"
     );
-    return;
+    return null;
   }
 
   for (const packId of requiredPacks) {
@@ -664,14 +681,19 @@ function validateValidationPlan(manifest, errors, warnings) {
     }
   }
 
+  return requiredPacks;
+}
+
+function validatePackPlan(validation, errors) {
   if (
     validation.pack_plan !== undefined &&
     !Array.isArray(validation.pack_plan)
   ) {
     pushError(errors, "validation.pack_plan", "must be an array when present");
   }
+}
 
-  const durableArtifacts = validation.durable_artifacts;
+function validateDurableArtifactsConfig(durableArtifacts, errors) {
   if (durableArtifacts !== undefined) {
     if (typeof durableArtifacts.required !== "boolean") {
       pushError(
@@ -695,55 +717,83 @@ function validateValidationPlan(manifest, errors, warnings) {
       );
     }
   }
+}
 
+function validationAcceptedArtifactPrefixes(validation) {
+  const acceptedPrefixes = validation.durable_artifacts?.accepted_prefixes;
+  return Array.isArray(acceptedPrefixes)
+    ? acceptedPrefixes
+    : APPROVED_DURABLE_ARTIFACT_PREFIXES;
+}
+
+function validateValidationChecks(validation, errors, warnings) {
   const checks = validation.checks;
   if (!Array.isArray(checks)) {
     pushError(errors, "validation.checks", "must be an array");
+    return false;
+  }
+
+  const acceptedPrefixes = validationAcceptedArtifactPrefixes(validation);
+  checks.forEach((check, checkIndex) => {
+    validateCheckArtifacts(
+      check,
+      checkIndex,
+      acceptedPrefixes,
+      errors,
+      warnings
+    );
+  });
+
+  return true;
+}
+
+function validateCheckArtifacts(
+  check,
+  checkIndex,
+  acceptedPrefixes,
+  errors,
+  warnings
+) {
+  const checkStatus = normalizeCheckStatus(check.status);
+  checkArtifacts(check).forEach((artifact, artifactIndex) => {
+    const path = `validation.checks[${checkIndex}].artifacts[${artifactIndex}]`;
+    const rejectionReason = artifactRejectionReason(
+      artifactUri(artifact),
+      acceptedPrefixes
+    );
+
+    if (rejectionReason) {
+      pushError(errors, `${path}.uri`, rejectionReason);
+      return;
+    }
+
+    addArtifactMetadataWarnings(path, artifact, checkStatus, warnings);
+  });
+}
+
+function addArtifactMetadataWarnings(path, artifact, checkStatus, warnings) {
+  if (typeof artifact === "string" || checkStatus !== "passed") {
     return;
   }
 
-  const acceptedPrefixes = Array.isArray(durableArtifacts?.accepted_prefixes)
-    ? durableArtifacts.accepted_prefixes
-    : APPROVED_DURABLE_ARTIFACT_PREFIXES;
-  checks.forEach((check, checkIndex) => {
-    checkArtifacts(check).forEach((artifact, artifactIndex) => {
-      const uri = artifactUri(artifact);
-      const rejectionReason = artifactRejectionReason(uri, acceptedPrefixes);
-      const path = `validation.checks[${checkIndex}].artifacts[${artifactIndex}]`;
-      if (rejectionReason) {
-        pushError(errors, `${path}.uri`, rejectionReason);
-        return;
-      }
-      if (
-        typeof artifact !== "string" &&
-        normalizeCheckStatus(check.status) === "passed" &&
-        artifact.redaction_status !== "verified-redacted"
-      ) {
-        warnings.push(
-          `${path}.redaction_status: passed checks need verified-redacted durable evidence before release readiness`
-        );
-      }
-      if (
-        typeof artifact !== "string" &&
-        normalizeCheckStatus(check.status) === "passed" &&
-        !artifactHasIntegrityMetadata(artifact)
-      ) {
-        warnings.push(
-          `${path}: passed checks need sha256, etag, or cid metadata before release readiness`
-        );
-      }
-      if (
-        typeof artifact !== "string" &&
-        normalizeCheckStatus(check.status) === "passed" &&
-        !artifactHasRetentionMetadata(artifact)
-      ) {
-        warnings.push(
-          `${path}: passed checks need retention metadata before release readiness`
-        );
-      }
-    });
-  });
+  if (artifact.redaction_status !== "verified-redacted") {
+    warnings.push(
+      `${path}.redaction_status: passed checks need verified-redacted durable evidence before release readiness`
+    );
+  }
+  if (!artifactHasIntegrityMetadata(artifact)) {
+    warnings.push(
+      `${path}: passed checks need sha256, etag, or cid metadata before release readiness`
+    );
+  }
+  if (!artifactHasRetentionMetadata(artifact)) {
+    warnings.push(
+      `${path}: passed checks need retention metadata before release readiness`
+    );
+  }
+}
 
+function addReadinessFindings(manifest, errors, warnings) {
   if (!RELEASE_READINESS_STATUSES.has(manifest.status)) {
     return;
   }
@@ -1238,41 +1288,16 @@ async function githubRequest(
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
     try {
-      const response = await fetch(
-        `${context.apiUrl}/repos/${context.owner}/${context.repo}${route}`,
-        {
-          method,
-          headers: {
-            Accept: "application/vnd.github+json",
-            Authorization: `Bearer ${context.token}`,
-            "Content-Type": "application/json",
-            "X-GitHub-Api-Version": "2022-11-28",
-          },
-          body: body ? JSON.stringify(body) : undefined,
-          signal: controller.signal,
-        }
+      return await githubRequestAttempt(
+        method,
+        route,
+        body,
+        context,
+        controller.signal
       );
-      const text = await response.text();
-      const data = text ? JSON.parse(text) : null;
-      if (response.ok) {
-        return data;
-      }
-
-      const message = data?.message || response.statusText;
-      lastError = new Error(
-        `GitHub API ${method} ${route} failed: ${response.status} ${message}`
-      );
-      const retryable = response.status === 429 || response.status >= 500;
-      if (!retryable || attempt === attempts) {
-        lastError.nonRetryable = !retryable;
-        throw lastError;
-      }
     } catch (error) {
       lastError = error;
-      if (error?.nonRetryable) {
-        throw lastError;
-      }
-      if (attempt === attempts) {
+      if (shouldStopGithubRetry(error, attempt, attempts)) {
         throw lastError;
       }
     } finally {
@@ -1283,6 +1308,60 @@ async function githubRequest(
   }
 
   throw lastError;
+}
+
+function githubRequestUrl(context, route) {
+  return `${context.apiUrl}/repos/${context.owner}/${context.repo}${route}`;
+}
+
+function githubRequestInit(method, body, context, signal) {
+  return {
+    method,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${context.token}`,
+      "Content-Type": "application/json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+    signal,
+  };
+}
+
+function githubApiError(method, route, response, data) {
+  const message = data?.message || response.statusText;
+  const error = new Error(
+    `GitHub API ${method} ${route} failed: ${response.status} ${message}`
+  );
+  error.nonRetryable = !isRetryableGithubStatus(response.status);
+  return error;
+}
+
+function isRetryableGithubStatus(status) {
+  return status === 429 || status >= 500;
+}
+
+async function parseGithubResponse(response) {
+  const text = await response.text();
+  return text ? JSON.parse(text) : null;
+}
+
+async function githubRequestAttempt(method, route, body, context, signal) {
+  const response = await fetch(
+    githubRequestUrl(context, route),
+    githubRequestInit(method, body, context, signal)
+  );
+  const data = await parseGithubResponse(response);
+
+  if (response.ok) {
+    return data;
+  }
+
+  throw githubApiError(method, route, response, data);
+}
+
+function shouldStopGithubRetry(error, attempt, attempts) {
+  return Boolean(error?.nonRetryable || attempt === attempts);
 }
 
 function normalizeDeploymentId(value) {
@@ -1506,15 +1585,15 @@ async function main(argv = process.argv.slice(2), env = process.env) {
           now: args.now,
         });
         const result = validateManifest(manifest);
-        if (!args.output) {
-          writeStdout(report);
-        } else {
+        if (args.output) {
           const target = path.resolve(args.output);
           // eslint-disable-next-line security/detect-non-literal-fs-filename -- Operator CLI writes release reports to supplied workflow paths.
           fs.mkdirSync(path.dirname(target), { recursive: true });
           // eslint-disable-next-line security/detect-non-literal-fs-filename -- Operator CLI writes release reports to supplied workflow paths.
           fs.writeFileSync(target, `${report}\n`);
           writeStdout(`Wrote ${args.output}`);
+        } else {
+          writeStdout(report);
         }
         printValidation(result);
         if (!result.ok) {

--- a/ops/scripts/deployment-bus.cjs
+++ b/ops/scripts/deployment-bus.cjs
@@ -7,6 +7,68 @@ const path = require("node:path");
 const SCHEMA_VERSION = "deployment-bus.v1";
 const SHA_RE = /^[0-9a-f]{40}$/i;
 const VALID_ENVIRONMENTS = new Set(["staging", "production"]);
+const VALIDATION_PACKS = Object.freeze({
+  "playwright:core-smoke": Object.freeze({
+    id: "playwright:core-smoke",
+    size: "large",
+    description: "Read-only core route smoke pack for deployed web health.",
+    environments: Object.freeze(["staging", "production"]),
+    surfaces: Object.freeze(["web:desktop-chromium"]),
+    commands: Object.freeze({
+      staging: "seize run test:e2e:staging",
+      production:
+        "PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:smoke",
+    }),
+    artifacts: Object.freeze([
+      "test-results/playwright/**",
+      "playwright-report/**",
+    ]),
+  }),
+  "playwright:wcag-i18n": Object.freeze({
+    id: "playwright:wcag-i18n",
+    size: "large",
+    description:
+      "Read-only WCAG/i18n route evidence pack for deployed public routes.",
+    environments: Object.freeze(["staging", "production"]),
+    surfaces: Object.freeze(["web:desktop-chromium"]),
+    commands: Object.freeze({
+      staging:
+        "PLAYWRIGHT_BASE_URL=https://staging.6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n",
+      production:
+        "PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n",
+    }),
+    artifacts: Object.freeze([
+      "test-results/playwright/**",
+      "playwright-report/**",
+    ]),
+  }),
+});
+const DEFAULT_REQUIRED_PACKS = Object.freeze([
+  "playwright:core-smoke",
+  "playwright:wcag-i18n",
+]);
+const APPROVED_DURABLE_ARTIFACT_PREFIXES = Object.freeze([
+  "s3://6529-artifacts/",
+  "https://artifacts.6529.io/",
+  "ipfs://",
+]);
+const RELEASE_READINESS_STATUSES = new Set([
+  "deploy_verified",
+  "validating",
+  "promoting",
+  "passed",
+  "released",
+]);
+const SUCCESSFUL_RELEASE_STATUSES = new Set(["passed", "released"]);
+const VALID_CHECK_STATUSES = new Set([
+  "passed",
+  "failed",
+  "blocked",
+  "timed_out",
+  "timeout",
+  "skipped",
+  "not_run",
+]);
 const VALID_STATUSES = new Set([
   "collecting",
   "queued",
@@ -125,6 +187,36 @@ function parseJsonOption(value, fallback) {
   return JSON.parse(value);
 }
 
+function buildPackPlan(packId, environment) {
+  const pack = VALIDATION_PACKS[packId];
+  if (!pack) {
+    return {
+      id: packId,
+      known: false,
+      command: null,
+      size: "unknown",
+      surfaces: [],
+      artifact_paths: [],
+      description:
+        "Custom validation pack. Record command, owner, artifacts, and result in validation.checks.",
+    };
+  }
+
+  return {
+    id: pack.id,
+    known: true,
+    command: pack.commands[environment] || null,
+    size: pack.size,
+    surfaces: [...pack.surfaces],
+    artifact_paths: [...pack.artifacts],
+    description: pack.description,
+  };
+}
+
+function buildPackPlanList(requiredPacks, environment) {
+  return requiredPacks.map((packId) => buildPackPlan(packId, environment));
+}
+
 function addMinutes(iso, minutes) {
   return new Date(new Date(iso).getTime() + minutes * 60 * 1000).toISOString();
 }
@@ -161,7 +253,9 @@ function buildManifest(options, env = process.env) {
   const now = options.now || new Date().toISOString();
   const environment = options.environment;
   if (!VALID_ENVIRONMENTS.has(environment)) {
-    throw new Error(`--environment must be one of: ${[...VALID_ENVIRONMENTS].join(", ")}`);
+    throw new Error(
+      `--environment must be one of: ${[...VALID_ENVIRONMENTS].join(", ")}`
+    );
   }
 
   const stagingDeploySha = options.stagingDeploySha || null;
@@ -170,47 +264,61 @@ function buildManifest(options, env = process.env) {
     environment === "production" || Boolean(productionCandidateSha);
   const productionEligible = parseBoolean(
     options.productionEligible,
-    productionEligibleDefault,
+    productionEligibleDefault
   );
   const expectedDurationMinutes = parseInteger(
     options.expectedDurationMinutes,
-    environment === "production" ? 120 : 75,
+    environment === "production" ? 120 : 75
   );
   const complexity =
     options.complexity ||
     (expectedDurationMinutes > 120 ? "complex" : "standard");
   const heartbeatIntervalMinutes = parseInteger(
     options.heartbeatIntervalMinutes,
-    expectedDurationMinutes > 120 ? 30 : 15,
+    expectedDurationMinutes > 120 ? 30 : 15
   );
   const staleAfterMinutes = parseInteger(
     options.staleAfterMinutes,
-    Math.max(heartbeatIntervalMinutes * 3, expectedDurationMinutes > 120 ? 90 : 45),
+    Math.max(
+      heartbeatIntervalMinutes * 3,
+      expectedDurationMinutes > 120 ? 90 : 45
+    )
   );
-  const releaseCaptain = options.releaseCaptain || env.GITHUB_ACTOR || "unassigned";
+  const releaseCaptain =
+    options.releaseCaptain || env.GITHUB_ACTOR || "unassigned";
   const baseSha =
-    productionCandidateSha || stagingDeploySha || options.ref || env.GITHUB_SHA || null;
+    productionCandidateSha ||
+    stagingDeploySha ||
+    options.ref ||
+    env.GITHUB_SHA ||
+    null;
   const releaseId =
     options.releaseId ||
     `fe-${environment}-${timestampSlug(now)}-${shortSha(baseSha)}`;
   const workflowRunUrl = options.workflowRunUrl || defaultRunUrl(env);
   const environmentUrl =
     options.environmentUrl || defaultEnvironmentUrl(environment);
+  const requiredPacks = parseCsv(
+    options.requiredPacks || DEFAULT_REQUIRED_PACKS.join(",")
+  );
+  const packPlan = buildPackPlanList(requiredPacks, environment);
+  const productionLikeEvidenceRequired =
+    environment === "production" || productionEligible;
   const longRunning =
     complexity === "complex" || expectedDurationMinutes > 120
       ? {
           enabled: true,
           heartbeat_interval_minutes: heartbeatIntervalMinutes,
           progress_update_channels: parseCsv(
-            options.progressUpdateChannels || "github-deployment-status,wave",
+            options.progressUpdateChannels || "github-deployment-status,wave"
           ),
           escalation_after_minutes: parseInteger(
             options.escalationAfterMinutes,
-            Math.max(staleAfterMinutes * 2, 180),
+            Math.max(staleAfterMinutes * 2, 180)
           ),
           checkpoint_labels: parseCsv(
             options.checkpointLabels ||
-              "preflight,deploy-started,mid-deploy,validation-started,terminal",
+              "preflight,deploy-started,mid-deploy,validation-started,terminal"
           ),
         }
       : {
@@ -221,7 +329,9 @@ function buildManifest(options, env = process.env) {
     schema_version: SCHEMA_VERSION,
     release_id: releaseId,
     repository:
-      options.repository || env.GITHUB_REPOSITORY || "6529-Collections/6529seize-frontend",
+      options.repository ||
+      env.GITHUB_REPOSITORY ||
+      "6529-Collections/6529seize-frontend",
     environment,
     status: options.status || "queued",
     created_at: now,
@@ -229,7 +339,9 @@ function buildManifest(options, env = process.env) {
     release_captain: releaseCaptain,
     complexity,
     production_eligible: productionEligible,
-    staging_branch: options.stagingBranch || (environment === "staging" ? "1a-staging" : null),
+    staging_branch:
+      options.stagingBranch ||
+      (environment === "staging" ? "1a-staging" : null),
     shas: {
       staging_deploy_sha: stagingDeploySha,
       production_candidate_sha: productionCandidateSha,
@@ -247,9 +359,50 @@ function buildManifest(options, env = process.env) {
     backend_dependencies: parseJsonOption(options.backendDependencies, []),
     validation: {
       core_smoke_owner: options.coreSmokeOwner || releaseCaptain,
-      required_packs: parseCsv(options.requiredPacks || "core-smoke"),
+      required_packs: requiredPacks,
+      pack_plan: packPlan,
       exploratory_checks: parseJsonOption(options.exploratoryChecks, []),
       checks: parseJsonOption(options.validationChecks, []),
+      durable_artifacts: {
+        required: parseBoolean(
+          options.durableArtifactsRequired,
+          productionLikeEvidenceRequired
+        ),
+        accepted_prefixes: [...APPROVED_DURABLE_ARTIFACT_PREFIXES],
+        git_lfs_allowed: false,
+        notes:
+          "Retained deployment evidence belongs on 6529-controlled artifact storage. Git LFS and committed generated artifacts are not durable evidence stores.",
+      },
+      auto_hold_criteria: [
+        {
+          id: "required-pack-failed",
+          hold_when:
+            "Any required validation pack records status failed, blocked, or timed_out.",
+          recovery:
+            "Fix forward or rerun once with evidence; repeated failures hold production.",
+        },
+        {
+          id: "required-pack-missing-terminal-evidence",
+          hold_when:
+            "A terminal passed/released manifest is missing a passed check for any required validation pack.",
+          recovery:
+            "Run the missing pack or record a release-captain exception before promotion.",
+        },
+        {
+          id: "durable-artifact-pointer-missing",
+          hold_when:
+            "A production-eligible terminal manifest lacks approved durable artifact pointers.",
+          recovery:
+            "Upload redacted evidence to approved storage and record the URI, hash/CID/ETag, retention, and redaction status.",
+        },
+        {
+          id: "candidate-sha-mismatch",
+          hold_when:
+            "Production candidate SHA differs from current origin/main or from the staging-validated release set.",
+          recovery:
+            "Rerun staging for the current candidate or remove superseded work from the train.",
+        },
+      ],
     },
     deployment: {
       github_deployment_id: options.githubDeploymentId || null,
@@ -321,7 +474,11 @@ function validateManifest(manifest) {
     pushError(errors, "environment", "must be staging or production");
   }
   if (!VALID_STATUSES.has(manifest.status)) {
-    pushError(errors, "status", `must be one of ${[...VALID_STATUSES].join(", ")}`);
+    pushError(
+      errors,
+      "status",
+      `must be one of ${[...VALID_STATUSES].join(", ")}`
+    );
   }
   if (!manifest.release_captain) {
     pushError(errors, "release_captain", "required");
@@ -334,17 +491,24 @@ function validateManifest(manifest) {
     errors,
     "shas.staging_deploy_sha",
     shas.staging_deploy_sha,
-    manifest.environment === "staging",
+    manifest.environment === "staging"
   );
   validateSha(
     errors,
     "shas.production_candidate_sha",
     shas.production_candidate_sha,
-    manifest.environment === "production" || manifest.production_eligible,
+    manifest.environment === "production" || manifest.production_eligible
   );
 
-  if (manifest.environment === "production" && manifest.production_eligible !== true) {
-    pushError(errors, "production_eligible", "production manifests must be eligible");
+  if (
+    manifest.environment === "production" &&
+    manifest.production_eligible !== true
+  ) {
+    pushError(
+      errors,
+      "production_eligible",
+      "production manifests must be eligible"
+    );
   }
 
   const lane = manifest.lane || {};
@@ -353,16 +517,37 @@ function validateManifest(manifest) {
   }
   validateIso(errors, "lane.acquired_at", lane.acquired_at);
   validateIso(errors, "lane.heartbeat_at", lane.heartbeat_at);
-  if (!Number.isInteger(lane.heartbeat_interval_minutes) || lane.heartbeat_interval_minutes <= 0) {
-    pushError(errors, "lane.heartbeat_interval_minutes", "must be a positive integer");
+  if (
+    !Number.isInteger(lane.heartbeat_interval_minutes) ||
+    lane.heartbeat_interval_minutes <= 0
+  ) {
+    pushError(
+      errors,
+      "lane.heartbeat_interval_minutes",
+      "must be a positive integer"
+    );
   }
-  if (!Number.isInteger(lane.stale_after_minutes) || lane.stale_after_minutes <= 0) {
+  if (
+    !Number.isInteger(lane.stale_after_minutes) ||
+    lane.stale_after_minutes <= 0
+  ) {
     pushError(errors, "lane.stale_after_minutes", "must be a positive integer");
   }
-  if (!Number.isInteger(lane.expected_duration_minutes) || lane.expected_duration_minutes <= 0) {
-    pushError(errors, "lane.expected_duration_minutes", "must be a positive integer");
+  if (
+    !Number.isInteger(lane.expected_duration_minutes) ||
+    lane.expected_duration_minutes <= 0
+  ) {
+    pushError(
+      errors,
+      "lane.expected_duration_minutes",
+      "must be a positive integer"
+    );
   }
-  validateIso(errors, "lane.expected_completion_at", lane.expected_completion_at);
+  validateIso(
+    errors,
+    "lane.expected_completion_at",
+    lane.expected_completion_at
+  );
 
   if (
     Number.isInteger(lane.heartbeat_interval_minutes) &&
@@ -372,7 +557,7 @@ function validateManifest(manifest) {
     pushError(
       errors,
       "lane.heartbeat_interval_minutes",
-      "must be at most half of lane.stale_after_minutes",
+      "must be at most half of lane.stale_after_minutes"
     );
   }
 
@@ -381,22 +566,55 @@ function validateManifest(manifest) {
   const longRunning = manifest.long_running || {};
   if (longRunningRequired) {
     if (longRunning.enabled !== true) {
-      pushError(errors, "long_running.enabled", "required for complex or multi-hour deploys");
+      pushError(
+        errors,
+        "long_running.enabled",
+        "required for complex or multi-hour deploys"
+      );
     }
-    if (!Array.isArray(longRunning.progress_update_channels) || longRunning.progress_update_channels.length === 0) {
-      pushError(errors, "long_running.progress_update_channels", "must name at least one channel");
+    if (
+      !Array.isArray(longRunning.progress_update_channels) ||
+      longRunning.progress_update_channels.length === 0
+    ) {
+      pushError(
+        errors,
+        "long_running.progress_update_channels",
+        "must name at least one channel"
+      );
     }
-    if (!Number.isInteger(longRunning.escalation_after_minutes) || longRunning.escalation_after_minutes <= lane.stale_after_minutes) {
-      pushError(errors, "long_running.escalation_after_minutes", "must exceed stale_after_minutes");
+    if (
+      !Number.isInteger(longRunning.escalation_after_minutes) ||
+      longRunning.escalation_after_minutes <= lane.stale_after_minutes
+    ) {
+      pushError(
+        errors,
+        "long_running.escalation_after_minutes",
+        "must exceed stale_after_minutes"
+      );
     }
-    if (!Array.isArray(longRunning.checkpoint_labels) || longRunning.checkpoint_labels.length < 3) {
-      pushError(errors, "long_running.checkpoint_labels", "must include at least three checkpoints");
+    if (
+      !Array.isArray(longRunning.checkpoint_labels) ||
+      longRunning.checkpoint_labels.length < 3
+    ) {
+      pushError(
+        errors,
+        "long_running.checkpoint_labels",
+        "must include at least three checkpoints"
+      );
     }
     if (!manifest.plans || !manifest.plans.rollback) {
-      pushError(errors, "plans.rollback", "required for complex or multi-hour deploys");
+      pushError(
+        errors,
+        "plans.rollback",
+        "required for complex or multi-hour deploys"
+      );
     }
     if (!manifest.plans || !manifest.plans.fix_forward) {
-      pushError(errors, "plans.fix_forward", "required for complex or multi-hour deploys");
+      pushError(
+        errors,
+        "plans.fix_forward",
+        "required for complex or multi-hour deploys"
+      );
     }
   }
 
@@ -409,6 +627,7 @@ function validateManifest(manifest) {
   if (!manifest.validation || !manifest.validation.core_smoke_owner) {
     pushError(errors, "validation.core_smoke_owner", "required");
   }
+  validateValidationPlan(manifest, errors, warnings);
   if (!Array.isArray(manifest.progress) || manifest.progress.length === 0) {
     pushError(errors, "progress", "must include at least one event");
   }
@@ -418,18 +637,359 @@ function validateManifest(manifest) {
     manifest.production_eligible !== true
   ) {
     warnings.push(
-      "staging manifest is exploratory only; it does not satisfy the production same-SHA gate",
+      "staging manifest is exploratory only; it does not satisfy the production same-SHA gate"
     );
   }
 
   return { ok: errors.length === 0, errors, warnings };
 }
 
+function validateValidationPlan(manifest, errors, warnings) {
+  const validation = manifest.validation || {};
+  const requiredPacks = validation.required_packs;
+  if (!Array.isArray(requiredPacks) || requiredPacks.length === 0) {
+    pushError(
+      errors,
+      "validation.required_packs",
+      "must include at least one pack"
+    );
+    return;
+  }
+
+  for (const packId of requiredPacks) {
+    if (!VALIDATION_PACKS[packId]) {
+      warnings.push(
+        `validation.required_packs: ${packId} is not a standard frontend pack; record command and artifacts in validation.checks`
+      );
+    }
+  }
+
+  if (
+    validation.pack_plan !== undefined &&
+    !Array.isArray(validation.pack_plan)
+  ) {
+    pushError(errors, "validation.pack_plan", "must be an array when present");
+  }
+
+  const durableArtifacts = validation.durable_artifacts;
+  if (durableArtifacts !== undefined) {
+    if (typeof durableArtifacts.required !== "boolean") {
+      pushError(
+        errors,
+        "validation.durable_artifacts.required",
+        "must be boolean"
+      );
+    }
+    if (!Array.isArray(durableArtifacts.accepted_prefixes)) {
+      pushError(
+        errors,
+        "validation.durable_artifacts.accepted_prefixes",
+        "must be an array"
+      );
+    }
+    if (durableArtifacts.git_lfs_allowed !== false) {
+      pushError(
+        errors,
+        "validation.durable_artifacts.git_lfs_allowed",
+        "must be false"
+      );
+    }
+  }
+
+  const checks = validation.checks;
+  if (!Array.isArray(checks)) {
+    pushError(errors, "validation.checks", "must be an array");
+    return;
+  }
+
+  const acceptedPrefixes = Array.isArray(durableArtifacts?.accepted_prefixes)
+    ? durableArtifacts.accepted_prefixes
+    : APPROVED_DURABLE_ARTIFACT_PREFIXES;
+  checks.forEach((check, checkIndex) => {
+    checkArtifacts(check).forEach((artifact, artifactIndex) => {
+      const uri = artifactUri(artifact);
+      const rejectionReason = artifactRejectionReason(uri, acceptedPrefixes);
+      const path = `validation.checks[${checkIndex}].artifacts[${artifactIndex}]`;
+      if (rejectionReason) {
+        pushError(errors, `${path}.uri`, rejectionReason);
+        return;
+      }
+      if (
+        typeof artifact !== "string" &&
+        normalizeCheckStatus(check.status) === "passed" &&
+        artifact.redaction_status !== "verified-redacted"
+      ) {
+        warnings.push(
+          `${path}.redaction_status: passed checks need verified-redacted durable evidence before release readiness`
+        );
+      }
+      if (
+        typeof artifact !== "string" &&
+        normalizeCheckStatus(check.status) === "passed" &&
+        !artifactHasIntegrityMetadata(artifact)
+      ) {
+        warnings.push(
+          `${path}: passed checks need sha256, etag, or cid metadata before release readiness`
+        );
+      }
+      if (
+        typeof artifact !== "string" &&
+        normalizeCheckStatus(check.status) === "passed" &&
+        !artifactHasRetentionMetadata(artifact)
+      ) {
+        warnings.push(
+          `${path}: passed checks need retention metadata before release readiness`
+        );
+      }
+    });
+  });
+
+  if (!RELEASE_READINESS_STATUSES.has(manifest.status)) {
+    return;
+  }
+
+  const readiness = evaluateReleaseReadiness(manifest);
+  if (SUCCESSFUL_RELEASE_STATUSES.has(manifest.status)) {
+    for (const hold of readiness.holds) {
+      pushError(errors, `release_readiness.${hold.id}`, hold.message);
+    }
+  } else {
+    for (const hold of readiness.holds) {
+      warnings.push(`release_readiness.${hold.id}: ${hold.message}`);
+    }
+  }
+}
+
+function normalizeCheckStatus(status) {
+  return String(status || "not-run").toLowerCase();
+}
+
+function checkPackId(check) {
+  return check.pack || check.pack_id || check.id || check.name || null;
+}
+
+function checkArtifacts(check) {
+  const artifacts = check.artifacts || check.artifact_pointers || [];
+  return Array.isArray(artifacts) ? artifacts : [];
+}
+
+function parseArtifactPointers(value, options = {}) {
+  return parseCsv(value).map((uri) => ({
+    uri,
+    redaction_status: options.redactionStatus || "not-recorded",
+    ...(options.sha256 ? { sha256: options.sha256 } : {}),
+    ...(options.etag ? { etag: options.etag } : {}),
+    ...(options.cid ? { cid: options.cid } : {}),
+    ...(options.retentionDays
+      ? { retention_days: parseInteger(options.retentionDays) }
+      : {}),
+    ...(options.retentionUntil
+      ? { retention_until: options.retentionUntil }
+      : {}),
+  }));
+}
+
+function artifactUri(artifact) {
+  if (typeof artifact === "string") {
+    return artifact;
+  }
+  return artifact?.uri || artifact?.url || artifact?.href || "";
+}
+
+function formatArtifactUriForReport(uri) {
+  const text = String(uri || "");
+  const queryIndex = text.search(/[?#]/);
+  if (queryIndex === -1) {
+    return text;
+  }
+  return `${text.slice(0, queryIndex)} [query-or-fragment redacted]`;
+}
+
+function artifactRejectionReason(uri, acceptedPrefixes) {
+  const text = String(uri || "");
+  if (!text) {
+    return "missing uri";
+  }
+  if (text.startsWith("git-lfs:")) {
+    return "Git LFS pointers are not durable release evidence";
+  }
+  if (
+    /^[a-z]:\\/i.test(text) ||
+    text.startsWith("\\\\") ||
+    text.startsWith("file:")
+  ) {
+    return "local filesystem paths are not durable release evidence";
+  }
+  if (text.includes("?") || text.includes("#")) {
+    return "artifact URI must not include query strings or fragments";
+  }
+  if (!acceptedPrefixes.some((prefix) => text.startsWith(prefix))) {
+    return "artifact URI does not use an approved durable artifact prefix";
+  }
+  return null;
+}
+
+function artifactHasIntegrityMetadata(artifact) {
+  return Boolean(artifact?.sha256 || artifact?.etag || artifact?.cid);
+}
+
+function artifactHasRetentionMetadata(artifact) {
+  return Boolean(
+    artifact?.retention_days ||
+    artifact?.retention_until ||
+    artifact?.retention_policy
+  );
+}
+
+function artifactIsReleaseReady(artifact, acceptedPrefixes) {
+  if (typeof artifact === "string") {
+    return false;
+  }
+  const uri = artifactUri(artifact);
+  return (
+    artifactRejectionReason(uri, acceptedPrefixes) === null &&
+    artifact.redaction_status === "verified-redacted" &&
+    artifactHasIntegrityMetadata(artifact) &&
+    artifactHasRetentionMetadata(artifact)
+  );
+}
+
+function approvedDurableArtifactsForCheck(manifest, check) {
+  const acceptedPrefixes =
+    manifest.validation?.durable_artifacts?.accepted_prefixes ||
+    APPROVED_DURABLE_ARTIFACT_PREFIXES;
+
+  return checkArtifacts(check).filter((artifact) =>
+    artifactIsReleaseReady(artifact, acceptedPrefixes)
+  );
+}
+
+function latestCheckForPack(checks, packId) {
+  const packChecks = checks.filter((check) => checkPackId(check) === packId);
+  return packChecks[packChecks.length - 1] || null;
+}
+
+function evaluateReleaseReadiness(manifest) {
+  const holds = [];
+  const warnings = [];
+  const validation = manifest.validation || {};
+  const checks = Array.isArray(validation.checks) ? validation.checks : [];
+  const requiredPacks = Array.isArray(validation.required_packs)
+    ? validation.required_packs
+    : [];
+
+  for (const packId of requiredPacks) {
+    const latestCheck = latestCheckForPack(checks, packId);
+    const latestStatus = normalizeCheckStatus(latestCheck?.status);
+
+    if (["failed", "blocked", "timed_out", "timeout"].includes(latestStatus)) {
+      holds.push({
+        id: "required-pack-failed",
+        pack: packId,
+        message: `${packId} recorded ${latestStatus}`,
+      });
+    } else if (latestStatus !== "passed") {
+      holds.push({
+        id: "required-pack-missing-terminal-evidence",
+        pack: packId,
+        message: `${packId} has no passed validation check recorded`,
+      });
+    } else if (
+      validation.durable_artifacts?.required === true &&
+      approvedDurableArtifactsForCheck(manifest, latestCheck).length === 0
+    ) {
+      holds.push({
+        id: "durable-artifact-pointer-missing",
+        pack: packId,
+        message: `${packId} has no approved durable artifact pointer with verified redaction, integrity metadata, and retention metadata`,
+      });
+    }
+  }
+
+  if (manifest.production_eligible !== true) {
+    warnings.push("Manifest is not production eligible.");
+  }
+
+  return { ok: holds.length === 0, holds, warnings };
+}
+
+function recordValidationCheck(manifest, options) {
+  const pack = options.pack || options.packId;
+  if (!pack) {
+    throw new Error("record-validation-check requires --pack");
+  }
+
+  const status = normalizeCheckStatus(options.status || "passed");
+  if (!VALID_CHECK_STATUSES.has(status)) {
+    throw new Error(`Invalid validation check status: ${options.status}`);
+  }
+
+  const now = options.now || new Date().toISOString();
+  const validation = manifest.validation || {};
+  const packPlan = buildPackPlan(pack, manifest.environment);
+  const artifacts = parseArtifactPointers(
+    options.artifactUri || options.artifactUris,
+    {
+      redactionStatus: options.redactionStatus,
+      sha256: options.artifactSha256,
+      etag: options.artifactEtag,
+      cid: options.artifactCid,
+      retentionDays: options.retentionDays,
+      retentionUntil: options.retentionUntil,
+    }
+  );
+  const check = {
+    pack,
+    status,
+    command: options.command || packPlan.command,
+    owner:
+      options.owner ||
+      validation.core_smoke_owner ||
+      manifest.release_captain ||
+      "unassigned",
+    recorded_at: now,
+    source: options.source || "deployment-bus",
+    artifacts,
+  };
+
+  if (options.runUrl) {
+    check.run_url = options.runUrl;
+  }
+  if (options.notes) {
+    check.notes = options.notes;
+  }
+
+  return {
+    ...manifest,
+    lane: {
+      ...manifest.lane,
+      heartbeat_at: now,
+    },
+    validation: {
+      ...validation,
+      checks: [
+        ...(Array.isArray(validation.checks) ? validation.checks : []),
+        check,
+      ],
+    },
+    progress: [
+      ...(Array.isArray(manifest.progress) ? manifest.progress : []),
+      {
+        at: now,
+        phase: "validation",
+        status: manifest.status,
+        message: `${pack} validation recorded as ${status}`,
+      },
+    ],
+  };
+}
+
 function summarizeManifest(manifest) {
   const deploymentId = manifest.deployment?.github_deployment_id || "none";
   const productionSha = manifest.shas?.production_candidate_sha || "none";
   const stagingSha = manifest.shas?.staging_deploy_sha || "none";
-  const owner = manifest.lane?.owner || manifest.release_captain || "unassigned";
+  const owner =
+    manifest.lane?.owner || manifest.release_captain || "unassigned";
 
   return [
     `${manifest.release_id} (${manifest.environment})`,
@@ -441,6 +1001,147 @@ function summarizeManifest(manifest) {
     `expected_duration_minutes: ${manifest.lane?.expected_duration_minutes ?? "unknown"}`,
     `heartbeat: every ${manifest.lane?.heartbeat_interval_minutes ?? "?"}m, stale after ${manifest.lane?.stale_after_minutes ?? "?"}m`,
     `github_deployment_id: ${deploymentId}`,
+  ].join("\n");
+}
+
+function formatMarkdownList(values) {
+  if (!values || values.length === 0) {
+    return "- none";
+  }
+  return values.map((value) => `- ${value}`).join("\n");
+}
+
+function formatPackPlan(manifest) {
+  const packPlan = manifest.validation?.pack_plan || [];
+  if (!Array.isArray(packPlan) || packPlan.length === 0) {
+    return "- no pack plan recorded";
+  }
+
+  return packPlan
+    .map((pack) => {
+      const command = pack.command || "record command in validation.checks";
+      const surfaces =
+        Array.isArray(pack.surfaces) && pack.surfaces.length > 0
+          ? pack.surfaces.join(", ")
+          : "unspecified";
+      return `- ${pack.id}: ${pack.description || "validation pack"}\n  - command: \`${command}\`\n  - surfaces: ${surfaces}`;
+    })
+    .join("\n");
+}
+
+function formatRecordedChecks(manifest) {
+  const checks = manifest.validation?.checks || [];
+  if (!Array.isArray(checks) || checks.length === 0) {
+    return "- no validation checks recorded yet";
+  }
+
+  return checks
+    .map((check) => {
+      const pack = checkPackId(check) || "unmapped";
+      const status = normalizeCheckStatus(check.status);
+      const command = check.command
+        ? `\n  - command: \`${check.command}\``
+        : "";
+      const artifacts = checkArtifacts(check)
+        .map((artifact) => {
+          const uri = formatArtifactUriForReport(artifactUri(artifact));
+          if (typeof artifact === "string") {
+            return uri;
+          }
+          const metadata = [
+            artifact.redaction_status
+              ? `redaction: ${artifact.redaction_status}`
+              : null,
+            artifact.sha256 ? "sha256 recorded" : null,
+            artifact.etag ? "etag recorded" : null,
+            artifact.cid ? "cid recorded" : null,
+            artifact.retention_days
+              ? `retention: ${artifact.retention_days} days`
+              : null,
+            artifact.retention_until
+              ? `retention until: ${artifact.retention_until}`
+              : null,
+            artifact.retention_policy
+              ? `retention policy: ${artifact.retention_policy}`
+              : null,
+          ].filter(Boolean);
+          return metadata.length > 0 ? `${uri} (${metadata.join(", ")})` : uri;
+        })
+        .filter(Boolean);
+      const artifactList = artifacts.map((uri) => `    - ${uri}`).join("\n");
+      const artifactLines =
+        artifacts.length > 0 ? `\n  - artifacts:\n${artifactList}` : "";
+      return `- ${pack}: ${status}${command}${artifactLines}`;
+    })
+    .join("\n");
+}
+
+function createReleaseReport(manifest, options = {}) {
+  const manifestValidation = validateManifest(manifest);
+  const readiness = evaluateReleaseReadiness(manifest);
+  const status = readiness.ok && manifestValidation.ok ? "ready" : "hold";
+  const generatedAt = options.now || new Date().toISOString();
+  const holds = [
+    ...manifestValidation.errors.map(
+      (error) => `manifest-validation: ${error}`
+    ),
+    ...readiness.holds.map((hold) => `${hold.id}: ${hold.message}`),
+  ];
+  const warnings = [
+    ...(manifestValidation.warnings || []),
+    ...readiness.warnings,
+  ];
+  const environmentUrl = manifest.deployment?.environment_url || "not recorded";
+
+  return [
+    `# ${manifest.environment} Release Report`,
+    "",
+    `Generated: ${generatedAt}`,
+    `Release ID: ${manifest.release_id}`,
+    `Report status: ${status}`,
+    `Manifest status: ${manifest.status}`,
+    `Environment URL: ${environmentUrl}`,
+    "",
+    "## Candidate",
+    "",
+    `- repository: ${manifest.repository}`,
+    `- release captain: ${manifest.release_captain}`,
+    `- staging deploy SHA: ${manifest.shas?.staging_deploy_sha || "none"}`,
+    `- production candidate SHA: ${manifest.shas?.production_candidate_sha || "none"}`,
+    `- production eligible: ${manifest.production_eligible === true}`,
+    "",
+    "## Required Packs",
+    "",
+    formatPackPlan(manifest),
+    "",
+    "## Recorded Validation",
+    "",
+    formatRecordedChecks(manifest),
+    "",
+    "## Auto-Hold Evaluation",
+    "",
+    holds.length === 0
+      ? "- no auto-hold criteria triggered"
+      : [...new Set(holds)].map((hold) => `- ${hold}`).join("\n"),
+    "",
+    "## Warnings",
+    "",
+    formatMarkdownList([...new Set(warnings)]),
+    "",
+    "## Included PRs",
+    "",
+    formatMarkdownList(
+      (manifest.included_prs || []).map(
+        (pr) => `#${pr.number} ${pr.title || ""} (${pr.merge_sha || "no sha"})`
+      )
+    ),
+    "",
+    "## Artifact Policy",
+    "",
+    `- durable artifacts required: ${manifest.validation?.durable_artifacts?.required === true}`,
+    `- accepted prefixes: ${(manifest.validation?.durable_artifacts?.accepted_prefixes || APPROVED_DURABLE_ARTIFACT_PREFIXES).join(", ")}`,
+    "- Git LFS allowed: false",
+    "",
   ].join("\n");
 }
 
@@ -474,7 +1175,10 @@ function productionPreflight(manifest, options = {}) {
   const validation = validateManifest(manifest);
   const errors = [...validation.errors];
 
-  if (manifest.environment !== "production" && manifest.production_eligible !== true) {
+  if (
+    manifest.environment !== "production" &&
+    manifest.production_eligible !== true
+  ) {
     errors.push("manifest is not marked production_eligible");
   }
   if (!mainSha) {
@@ -484,7 +1188,7 @@ function productionPreflight(manifest, options = {}) {
   }
   if (mainSha && (!candidateSha || candidateSha !== mainSha)) {
     errors.push(
-      `production candidate ${candidateSha || "none"} does not match ${remote}/${branch} ${mainSha}`,
+      `production candidate ${candidateSha || "none"} does not match ${remote}/${branch} ${mainSha}`
     );
   }
 
@@ -517,7 +1221,13 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function githubRequest(method, route, body, env = process.env, options = {}) {
+async function githubRequest(
+  method,
+  route,
+  body,
+  env = process.env,
+  options = {}
+) {
   const context = githubContext(env);
   const attempts = parseInteger(options.attempts, 3);
   const timeoutMs = parseInteger(options.timeoutMs, 10000);
@@ -540,7 +1250,7 @@ async function githubRequest(method, route, body, env = process.env, options = {
           },
           body: body ? JSON.stringify(body) : undefined,
           signal: controller.signal,
-        },
+        }
       );
       const text = await response.text();
       const data = text ? JSON.parse(text) : null;
@@ -550,7 +1260,7 @@ async function githubRequest(method, route, body, env = process.env, options = {
 
       const message = data?.message || response.statusText;
       lastError = new Error(
-        `GitHub API ${method} ${route} failed: ${response.status} ${message}`,
+        `GitHub API ${method} ${route} failed: ${response.status} ${message}`
       );
       const retryable = response.status === 429 || response.status >= 500;
       if (!retryable || attempt === attempts) {
@@ -578,7 +1288,9 @@ async function githubRequest(method, route, body, env = process.env, options = {
 function normalizeDeploymentId(value) {
   const deploymentId = String(value || "").trim();
   if (!/^\d+$/.test(deploymentId)) {
-    throw new Error(`GitHub deployment id must be numeric, received: ${value || "empty"}`);
+    throw new Error(
+      `GitHub deployment id must be numeric, received: ${value || "empty"}`
+    );
   }
   return deploymentId;
 }
@@ -586,7 +1298,9 @@ function normalizeDeploymentId(value) {
 async function createGithubDeployment(manifest, options, env = process.env) {
   const validation = validateManifest(manifest);
   if (!validation.ok) {
-    throw new Error(`Deployment bus manifest is invalid: ${validation.errors.join("; ")}`);
+    throw new Error(
+      `Deployment bus manifest is invalid: ${validation.errors.join("; ")}`
+    );
   }
   const ref = options.ref;
   if (!ref) {
@@ -616,12 +1330,12 @@ async function createGithubDeployment(manifest, options, env = process.env) {
       transient_environment: false,
       production_environment: environment === "production",
     },
-    env,
+    env
   );
 
   if (!Number.isInteger(deployment?.id)) {
     throw new Error(
-      `GitHub create deployment response did not include a numeric id: ${JSON.stringify(deployment)}`,
+      `GitHub create deployment response did not include a numeric id: ${JSON.stringify(deployment)}`
     );
   }
 
@@ -633,7 +1347,9 @@ async function createGithubDeploymentStatus(options, env = process.env) {
   const deploymentId = normalizeDeploymentId(options.deploymentId);
   const state = options.state;
   if (!GITHUB_DEPLOYMENT_STATES.has(state)) {
-    throw new Error(`--state must be one of ${[...GITHUB_DEPLOYMENT_STATES].join(", ")}`);
+    throw new Error(
+      `--state must be one of ${[...GITHUB_DEPLOYMENT_STATES].join(", ")}`
+    );
   }
 
   const status = await githubRequest(
@@ -646,12 +1362,12 @@ async function createGithubDeploymentStatus(options, env = process.env) {
       description: options.description || `Deployment ${state}`,
       auto_inactive: parseBoolean(options.autoInactive, false),
     },
-    env,
+    env
   );
 
   if (!status?.state) {
     throw new Error(
-      `GitHub create deployment status response did not include a state: ${JSON.stringify(status)}`,
+      `GitHub create deployment status response did not include a state: ${JSON.stringify(status)}`
     );
   }
 
@@ -674,6 +1390,8 @@ function usage() {
   node ops/scripts/deployment-bus.cjs create-manifest --environment staging --staging-deploy-sha <sha> --output <file>
   node ops/scripts/deployment-bus.cjs validate-manifest --file <file>
   node ops/scripts/deployment-bus.cjs summarize-manifest --file <file>
+  node ops/scripts/deployment-bus.cjs record-validation-check --file <file> --pack playwright:core-smoke --status passed --artifact-uri s3://6529-artifacts/... --redaction-status verified-redacted --artifact-sha256 <hex> --retention-days 90
+  node ops/scripts/deployment-bus.cjs release-report --file <file> --output <markdown-file>
   node ops/scripts/deployment-bus.cjs heartbeat-manifest --file <file> --message <text> [--status deploying] [--phase build]
   node ops/scripts/deployment-bus.cjs production-preflight --file <file> --current-main-sha <sha> [--remote origin] [--branch main]
   node ops/scripts/deployment-bus.cjs github-create-deployment --file <file> --ref <sha> --environment <name>
@@ -688,39 +1406,43 @@ async function main(argv = process.argv.slice(2), env = process.env) {
   try {
     switch (command) {
       case "create-manifest": {
-        const manifest = buildManifest({
-          environment: args.environment,
-          stagingDeploySha: args["staging-deploy-sha"],
-          productionCandidateSha: args["production-candidate-sha"],
-          productionEligible: args["production-eligible"],
-          stagingBranch: args["staging-branch"],
-          releaseCaptain: args["release-captain"],
-          releaseId: args["release-id"],
-          repository: args.repository,
-          status: args.status,
-          phase: args.phase,
-          message: args.message,
-          complexity: args.complexity,
-          expectedDurationMinutes: args["expected-duration-minutes"],
-          heartbeatIntervalMinutes: args["heartbeat-interval-minutes"],
-          staleAfterMinutes: args["stale-after-minutes"],
-          progressUpdateChannels: args["progress-update-channels"],
-          escalationAfterMinutes: args["escalation-after-minutes"],
-          checkpointLabels: args["checkpoint-labels"],
-          coreSmokeOwner: args["core-smoke-owner"],
-          requiredPacks: args["required-packs"],
-          includedPrs: args["included-prs"],
-          backendDependencies: args["backend-dependencies"],
-          exploratoryChecks: args["exploratory-checks"],
-          validationChecks: args["validation-checks"],
-          rollbackPlan: args["rollback-plan"],
-          fixForwardPlan: args["fix-forward-plan"],
-          approvals: args.approvals,
-          workflowRunUrl: args["workflow-run-url"],
-          environmentUrl: args["environment-url"],
-          ref: args.ref,
-          now: args.now,
-        }, env);
+        const manifest = buildManifest(
+          {
+            environment: args.environment,
+            stagingDeploySha: args["staging-deploy-sha"],
+            productionCandidateSha: args["production-candidate-sha"],
+            productionEligible: args["production-eligible"],
+            stagingBranch: args["staging-branch"],
+            releaseCaptain: args["release-captain"],
+            releaseId: args["release-id"],
+            repository: args.repository,
+            status: args.status,
+            phase: args.phase,
+            message: args.message,
+            complexity: args.complexity,
+            expectedDurationMinutes: args["expected-duration-minutes"],
+            heartbeatIntervalMinutes: args["heartbeat-interval-minutes"],
+            staleAfterMinutes: args["stale-after-minutes"],
+            progressUpdateChannels: args["progress-update-channels"],
+            escalationAfterMinutes: args["escalation-after-minutes"],
+            checkpointLabels: args["checkpoint-labels"],
+            coreSmokeOwner: args["core-smoke-owner"],
+            requiredPacks: args["required-packs"],
+            includedPrs: args["included-prs"],
+            backendDependencies: args["backend-dependencies"],
+            exploratoryChecks: args["exploratory-checks"],
+            validationChecks: args["validation-checks"],
+            durableArtifactsRequired: args["durable-artifacts-required"],
+            rollbackPlan: args["rollback-plan"],
+            fixForwardPlan: args["fix-forward-plan"],
+            approvals: args.approvals,
+            workflowRunUrl: args["workflow-run-url"],
+            environmentUrl: args["environment-url"],
+            ref: args.ref,
+            now: args.now,
+          },
+          env
+        );
         const result = validateManifest(manifest);
         printValidation(result);
         if (!result.ok) {
@@ -747,6 +1469,57 @@ async function main(argv = process.argv.slice(2), env = process.env) {
       }
       case "summarize-manifest": {
         writeStdout(summarizeManifest(readJson(args.file)));
+        break;
+      }
+      case "record-validation-check": {
+        const file = args.file;
+        const manifest = recordValidationCheck(readJson(file), {
+          pack: args.pack,
+          status: args.status,
+          command: args.command,
+          owner: args.owner,
+          artifactUri: args["artifact-uri"] || args["artifact-uris"],
+          redactionStatus: args["redaction-status"],
+          artifactSha256: args["artifact-sha256"],
+          artifactEtag: args["artifact-etag"],
+          artifactCid: args["artifact-cid"],
+          retentionDays: args["retention-days"],
+          retentionUntil: args["retention-until"],
+          runUrl: args["run-url"],
+          source: args.source,
+          notes: args.notes,
+          now: args.now,
+        });
+        const result = validateManifest(manifest);
+        printValidation(result);
+        if (!result.ok) {
+          process.exitCode = 1;
+          return;
+        }
+        writeJson(args.output || file, manifest);
+        writeStdout(`Updated ${args.output || file}`);
+        break;
+      }
+      case "release-report": {
+        const manifest = readJson(args.file);
+        const report = createReleaseReport(manifest, {
+          now: args.now,
+        });
+        const result = validateManifest(manifest);
+        if (!args.output) {
+          writeStdout(report);
+        } else {
+          const target = path.resolve(args.output);
+          // eslint-disable-next-line security/detect-non-literal-fs-filename -- Operator CLI writes release reports to supplied workflow paths.
+          fs.mkdirSync(path.dirname(target), { recursive: true });
+          // eslint-disable-next-line security/detect-non-literal-fs-filename -- Operator CLI writes release reports to supplied workflow paths.
+          fs.writeFileSync(target, `${report}\n`);
+          writeStdout(`Wrote ${args.output}`);
+        }
+        printValidation(result);
+        if (!result.ok) {
+          process.exitCode = 1;
+        }
         break;
       }
       case "heartbeat-manifest": {
@@ -779,30 +1552,37 @@ async function main(argv = process.argv.slice(2), env = process.env) {
           return;
         }
         writeStdout(
-          `Production preflight passed: ${result.candidateSha} matches ${args.remote || "origin"}/${args.branch || "main"}.`,
+          `Production preflight passed: ${result.candidateSha} matches ${args.remote || "origin"}/${args.branch || "main"}.`
         );
         break;
       }
       case "github-create-deployment": {
-        const deployment = await createGithubDeployment(readJson(args.file), {
-          ref: args.ref,
-          task: args.task,
-          environment: args.environment,
-          description: args.description,
-        }, env);
+        const deployment = await createGithubDeployment(
+          readJson(args.file),
+          {
+            ref: args.ref,
+            task: args.task,
+            environment: args.environment,
+            description: args.description,
+          },
+          env
+        );
         console.error(`Created GitHub deployment ${deployment.id}`);
         writeStdout(deployment.id);
         break;
       }
       case "github-create-status": {
-        const status = await createGithubDeploymentStatus({
-          deploymentId: args["deployment-id"],
-          state: args.state,
-          description: args.description,
-          logUrl: args["log-url"],
-          environmentUrl: args["environment-url"],
-          autoInactive: args["auto-inactive"],
-        }, env);
+        const status = await createGithubDeploymentStatus(
+          {
+            deploymentId: args["deployment-id"],
+            state: args.state,
+            description: args.description,
+            logUrl: args["log-url"],
+            environmentUrl: args["environment-url"],
+            autoInactive: args["auto-inactive"],
+          },
+          env
+        );
         writeStdout(`Created GitHub deployment status ${status.state}`);
         break;
       }
@@ -822,13 +1602,18 @@ if (require.main === module) {
 
 module.exports = {
   SCHEMA_VERSION,
+  DEFAULT_REQUIRED_PACKS,
+  VALIDATION_PACKS,
   VALID_STATUSES,
   buildManifest,
   createGithubDeployment,
   createGithubDeploymentStatus,
+  createReleaseReport,
+  evaluateReleaseReadiness,
   heartbeatManifest,
   parseArgs,
   productionPreflight,
+  recordValidationCheck,
   summarizeManifest,
   validateManifest,
 };

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -35,6 +35,25 @@ Read this section first after compaction or handoff.
   - Follow-up branch `codex/fix-staging-playwright-smoke` restores
     `tests/testHelpers.ts` and makes `seize run test:e2e:staging` run real
     browser smoke when `PLAYWRIGHT_STAGING_ACCESS_CODE` or `STAGING_AUTH` is set.
+- Latest testing-roadmap state, 2026-06-21T07:25Z:
+  - Current clean worktree branch: `codex/testing-roadmap-next`, based on
+    current `origin/main`.
+  - PR5 deployment evidence/reporting foundation is implemented locally:
+    deployed-environment pack plans, release reports, auto-hold readiness
+    evaluation, `record-validation-check`, workflow release-report artifacts,
+    and stricter durable artifact rules.
+  - Required deployed packs are currently `playwright:core-smoke` and
+    `playwright:wcag-i18n`. Both are still `web:desktop-chromium`; PR4 must add
+    broader mobile, Firefox, WebKit, Capacitor, and Electron/Desktop Shell
+    surface coverage before claiming those surfaces.
+  - Durable release evidence now requires one approved artifact pointer on each
+    required pack's latest passing check, with verified redaction, integrity
+    metadata (`sha256`, `etag`, or `cid`), retention metadata, and no query
+    strings/fragments/signed URLs/local paths/Git LFS pointers.
+  - Independent verifier `Linnaeus` found four P1s before PR publication:
+    global artifact readiness, invalid manifests producing ready reports, weak
+    artifact URI/redaction metadata handling, and generated EOF noise. All four
+    were fixed locally and covered by tests.
 - 2026-06-20 user direction: update the plan for the actual frontend WCAG/i18n
   mega run now that reviewbot is live. Reviewbot is an additional reviewer and
   regression detector only; it does not replace extensive local validation.
@@ -127,7 +146,7 @@ generated artifacts as the durable evidence store.
 
 ## Current Branch
 
-`codex/user-about-edit-a11y-i18n`
+`codex/testing-roadmap-next`
 
 ## Constraints
 
@@ -252,3 +271,7 @@ Re-audit each PR against current `origin/main` before merging or deploying it.
    trains.
 9. Preserve the unrelated dirty EmojiContext, RememeImage test, and bootstrap
    style files.
+10. After PR5 is merged/deployed, start PR4 surface-matrix work from current
+    `origin/main`: expand E2E project coverage for mobile-sized Chromium,
+    Firefox/WebKit where practical, and the documented Capacitor/Electron
+    simulation lanes without weakening existing reviewbot lanes.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1981,6 +1981,13 @@ test:e2e:smoke`: first run after production build hit stale local dev cache
   - `seize exec eslint ops/scripts/deployment-bus.cjs __tests__/scripts/deployment-bus.test.ts --no-warn-ignored --max-warnings=0`
   - `seize run test:no-coverage -- __tests__/scripts/deployment-bus.test.ts`:
     23 passed.
+  - `seize run lint:changed`
+  - `seize run typecheck:changed`
+  - `seize run testing-strategy -- scan-changed-secrets --changed-from origin/main --output test-results/app-pr-ci/pr5-secret-scan.json`:
+    clean.
+  - `seize run testing-strategy -- validate-workflow-security --changed-from origin/main --output test-results/app-pr-ci/pr5-workflow-security.json`:
+    clean.
+  - `codex-diff-check`
   - `seize run testing-strategy -- ci-plan --changed-from origin/main --output test-results/app-pr-ci/pr5-ci-plan.json`:
     Level 5 because production deploy authority is touched.
   - `seize run testing-strategy -- scan-changed-secrets --changed-from origin/main --output test-results/app-pr-ci/pr5-secret-scan.json`:
@@ -2000,3 +2007,19 @@ test:e2e:smoke`: first run after production build hit stale local dev cache
     production Next build, TypeScript, static generation, and sitemap
     generation. Nonfatal build warnings observed: known dynamic OG metadata
     image route warning and Node `punycode` deprecation warning.
+
+## 2026-06-21T09:10Z PR 5 Sonar Follow-Up
+
+- Addressed SonarCloud maintainability feedback on PR #2804 before continuing
+  the next testing-roadmap train:
+  - split `validateValidationPlan()` into smaller required-pack, pack-plan,
+    durable-artifact, check-artifact, and readiness helper functions;
+  - split `githubRequest()` URL/header/parse/retry helpers out of the retry
+    loop;
+  - flipped the `release-report` output branch to the positive `args.output`
+    path.
+- Focused validation after the refactor:
+  - `node --check ops/scripts/deployment-bus.cjs`
+  - `seize exec eslint ops/scripts/deployment-bus.cjs __tests__/scripts/deployment-bus.test.ts --no-warn-ignored --max-warnings=0`
+  - `seize run test:no-coverage -- __tests__/scripts/deployment-bus.test.ts`:
+    23 passed.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1989,6 +1989,25 @@ test:e2e:smoke`: first run after production build hit stale local dev cache
     clean.
   - `codex-diff-check`
 
+## 2026-06-21T09:55Z PR 5 Sonar Polish
+
+- Addressed the remaining SonarCloud code-smell report after the CodeRabbit
+  follow-up:
+  - changed durable artifact prefix validation to use a positive array branch;
+  - made approved-prefix selection single-return and type-explicit.
+- Validation:
+  - `node --check ops/scripts/deployment-bus.cjs`
+  - `seize exec eslint ops/scripts/deployment-bus.cjs __tests__/scripts/deployment-bus.test.ts --no-warn-ignored --max-warnings=0`
+  - `seize run test:no-coverage -- __tests__/scripts/deployment-bus.test.ts`:
+    27 passed.
+  - `seize run lint:changed`
+  - `seize run typecheck:changed`
+  - `seize run testing-strategy -- scan-changed-secrets --changed-from origin/main --output test-results/app-pr-ci/pr5-secret-scan.json`:
+    clean.
+  - `seize run testing-strategy -- validate-workflow-security --changed-from origin/main --output test-results/app-pr-ci/pr5-workflow-security.json`:
+    clean.
+  - `codex-diff-check`
+
 ## 2026-06-21T09:35Z PR 5 CodeRabbit Follow-Up
 
 - Addressed the first CodeRabbit review on PR #2804:

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1917,12 +1917,12 @@ origin/main --output test-results/app-pr-ci/workflow-security.json`
   - `seize run typecheck:ci`
   - `seize run typecheck:playwright`
   - `seize run test:no-coverage -- __tests__/playwright/a11yAssertions.test.ts
-    __tests__/playwright/i18nFixtures.test.ts`: 2 suites, 5 tests passed.
+__tests__/playwright/i18nFixtures.test.ts`: 2 suites, 5 tests passed.
   - `seize run testing-strategy -- ci-plan --changed-from main --output
-    test-results/app-pr-ci/pr3-ci-plan.json`: Level 4 because of Next config,
+test-results/app-pr-ci/pr3-ci-plan.json`: Level 4 because of Next config,
     package, and lockfile changes.
   - `seize run testing-strategy -- scan-changed-secrets --changed-from main
-    --output test-results/app-pr-ci/pr3-secret-scan.json`: clean.
+--output test-results/app-pr-ci/pr3-secret-scan.json`: clean.
   - `seize run dependency:risk-gate`: high risk / auto-merge blocked because
     the PR adds a new direct dev dependency; package metadata was independently
     checked and the risk is documented for review.
@@ -1931,9 +1931,9 @@ origin/main --output test-results/app-pr-ci/workflow-security.json`
     Without the local worker cap, Windows hit repeat `EBUSY` copy races after
     successful compile, typecheck, and static generation; CI runs on Ubuntu.
   - `$env:PLAYWRIGHT_WEB_SERVER_COMMAND='seize run dev'; seize run
-    test:e2e:wcag-i18n`: 3 passed.
+test:e2e:wcag-i18n`: 3 passed.
   - `$env:PLAYWRIGHT_WEB_SERVER_COMMAND='seize run dev'; seize run
-    test:e2e:smoke`: first run after production build hit stale local dev cache
+test:e2e:smoke`: first run after production build hit stale local dev cache
     404s; after isolating the production `.next` output and starting a fresh dev
     cache, 6 passed.
   - `codex-diff-check`
@@ -1942,3 +1942,61 @@ origin/main --output test-results/app-pr-ci/workflow-security.json`
 - Addressed the latest Sonar maintainability findings before merge by splitting
   axe allowlist validation into smaller helpers, replacing a target lookup with
   `.includes()`, and using `globalThis.getComputedStyle` in the focus helper.
+
+## 2026-06-21T07:25Z PR 5 Deployment Evidence Foundation
+
+- Continued the next autonomous testing-roadmap run from clean branch
+  `codex/testing-roadmap-next` based on current `origin/main`.
+- Reused `6529-autonomous-manager` mode and delegated an independent read-only
+  verifier pass to subagent `Linnaeus`.
+- Implemented the PR5 deployment evidence/reporting foundation:
+  - staging and production deploy workflows now include standard required packs
+    in the deployment-bus manifest and upload `deployment-release-report.md`
+    beside `deployment-bus-manifest.json`;
+  - terminal workflow status now heartbeats the manifest to `deploy_verified`,
+    `failed`, or `cancelled` before GitHub Deployment status publication;
+  - `ops/scripts/deployment-bus.cjs` now expands standard deployed-environment
+    pack plans, evaluates release readiness, generates Markdown release
+    reports, and appends validation results with `record-validation-check`;
+  - readiness uses the latest result for each required pack, so a failed run is
+    cleared by a later passing rerun with retained evidence;
+  - release readiness now requires each required pack's latest passing check to
+    include an approved durable artifact pointer with verified redaction,
+    integrity metadata (`sha256`, `etag`, or `cid`), retention metadata, and no
+    query strings/fragments/signed URLs/local paths/Git LFS pointers;
+  - invalid manifests produce `hold` release reports and make
+    `release-report` exit nonzero after writing the report.
+- Updated docs:
+  - `ops/docs/developer/deployment-bus-automation.md`
+  - `ops/docs/developer/deployment-bus-process.md`
+- Verifier feedback fixed before PR publication:
+  - global durable artifact readiness changed to per-required-pack readiness;
+  - invalid manifest reports can no longer say ready;
+  - artifact URI/redaction/integrity/retention rules were tightened;
+  - generated OpenAPI EOF-only changes from build were removed from the PR.
+- Local validation:
+  - `seize install:frozen` passed after clearing a partial `node_modules`
+    install left by Windows native-package unlink errors.
+  - `node --check ops/scripts/deployment-bus.cjs`
+  - `seize exec eslint ops/scripts/deployment-bus.cjs __tests__/scripts/deployment-bus.test.ts --no-warn-ignored --max-warnings=0`
+  - `seize run test:no-coverage -- __tests__/scripts/deployment-bus.test.ts`:
+    23 passed.
+  - `seize run testing-strategy -- ci-plan --changed-from origin/main --output test-results/app-pr-ci/pr5-ci-plan.json`:
+    Level 5 because production deploy authority is touched.
+  - `seize run testing-strategy -- scan-changed-secrets --changed-from origin/main --output test-results/app-pr-ci/pr5-secret-scan.json`:
+    clean.
+  - `seize run testing-strategy -- validate-workflow-security --changed-from origin/main --output test-results/app-pr-ci/pr5-workflow-security.json`:
+    clean.
+  - `seize run lint:changed`
+  - `seize run typecheck:changed`
+  - workflow YAML parse for staging and production workflows.
+  - `codex-diff-check`
+  - workflow-shaped CLI smoke:
+    `create-manifest -> heartbeat-manifest -> record-validation-check x2 -> release-report`;
+    report contained `Report status: ready`.
+  - `seize-local-dev bootstrap` assigned frontend port `3162` for this
+    worktree.
+  - `$env:CIRCLE_NODE_TOTAL='1'; seize run build` passed prebuild, lint,
+    production Next build, TypeScript, static generation, and sitemap
+    generation. Nonfatal build warnings observed: known dynamic OG metadata
+    image route warning and Node `punycode` deprecation warning.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -1988,6 +1988,31 @@ test:e2e:smoke`: first run after production build hit stale local dev cache
   - `seize run testing-strategy -- validate-workflow-security --changed-from origin/main --output test-results/app-pr-ci/pr5-workflow-security.json`:
     clean.
   - `codex-diff-check`
+
+## 2026-06-21T09:35Z PR 5 CodeRabbit Follow-Up
+
+- Addressed the first CodeRabbit review on PR #2804:
+  - schema and runtime validation now restrict durable artifact prefixes to the
+    approved catalog before artifact matching;
+  - production and production-eligible manifests cannot opt out of durable
+    evidence, even with `--durable-artifacts-required false`;
+  - release-ready artifact evidence now validates SHA-256, ETag, CID, retention
+    days, retention-until date, or known retention policy shape instead of
+    truthiness;
+  - latest validation check selection now uses `recorded_at` /
+    `completed_at` / `at` timestamps, with array order only as a tie-breaker.
+- Added regression tests for all four review findings. Focused validation:
+  - `node --check ops/scripts/deployment-bus.cjs`
+  - `seize exec eslint ops/scripts/deployment-bus.cjs __tests__/scripts/deployment-bus.test.ts --no-warn-ignored --max-warnings=0`
+  - `seize run test:no-coverage -- __tests__/scripts/deployment-bus.test.ts`:
+    27 passed.
+  - `seize run lint:changed`
+  - `seize run typecheck:changed`
+  - `seize run testing-strategy -- scan-changed-secrets --changed-from origin/main --output test-results/app-pr-ci/pr5-secret-scan.json`:
+    clean.
+  - `seize run testing-strategy -- validate-workflow-security --changed-from origin/main --output test-results/app-pr-ci/pr5-workflow-security.json`:
+    clean.
+  - `codex-diff-check`
   - `seize run testing-strategy -- ci-plan --changed-from origin/main --output test-results/app-pr-ci/pr5-ci-plan.json`:
     Level 5 because production deploy authority is touched.
   - `seize run testing-strategy -- scan-changed-secrets --changed-from origin/main --output test-results/app-pr-ci/pr5-secret-scan.json`:


### PR DESCRIPTION
﻿## Issue
- The WCAG/i18n testing hardening roadmap needs deployment evidence that agents and release captains can trust before scaling larger page-cluster work.
- Current deployment bus artifacts recorded deploy state, but they did not yet name standard post-deploy validation packs, generate release reports, or provide a CLI path for appending retained validation evidence.

## Fix
- Adds deployment-bus release reports and readiness evaluation for the standard deployed-environment packs.
- Adds `record-validation-check` so post-deploy validation agents can append pack results and durable artifact pointers after smoke/WCAG runs.
- Keeps reviewbots as additive feedback loops; this PR does not remove or weaken the existing `general`, `wcag`, `i18n`, `security`, or `responsiveness` reviews.

## Changes
- Staging and production deploy workflows now:
  - include required packs `playwright:core-smoke` and `playwright:wcag-i18n` in deployment manifests;
  - heartbeat manifests to `deploy_verified`, `failed`, or `cancelled` before publishing terminal GitHub Deployment status;
  - upload `deployment-release-report.md` beside `deployment-bus-manifest.json`.
- `ops/scripts/deployment-bus.cjs` now:
  - expands standard pack plans and commands;
  - evaluates release readiness with latest-result semantics per required pack;
  - writes Markdown release reports;
  - appends validation evidence via `record-validation-check`;
  - treats invalid manifests as report holds and exits nonzero after writing invalid reports;
  - requires each required pack's latest passing check to have its own approved durable artifact pointer with verified redaction, strict integrity metadata, retention metadata, approved durable prefixes, and no query strings/fragments/signed URLs/local paths/Git LFS pointers;
  - forces production and production-eligible manifests to require durable evidence.
- Updated the manifest schema, deployment bus docs, and durable workstream memory.

## Validation
- `seize install:frozen`
- `node --check ops/scripts/deployment-bus.cjs`
- `seize exec eslint ops/scripts/deployment-bus.cjs __tests__/scripts/deployment-bus.test.ts --no-warn-ignored --max-warnings=0`
- `seize run test:no-coverage -- __tests__/scripts/deployment-bus.test.ts` (27 passed)
- `seize run testing-strategy -- ci-plan --changed-from origin/main --output test-results/app-pr-ci/pr5-ci-plan.json` (Level 5)
- `seize run testing-strategy -- scan-changed-secrets --changed-from origin/main --output test-results/app-pr-ci/pr5-secret-scan.json` (clean)
- `seize run testing-strategy -- validate-workflow-security --changed-from origin/main --output test-results/app-pr-ci/pr5-workflow-security.json` (clean)
- `seize run lint:changed`
- `seize run typecheck:changed`
- Workflow YAML parse for staging and production deploy workflows
- `codex-diff-check`
- Workflow-shaped CLI smoke: `create-manifest -> heartbeat-manifest -> record-validation-check x2 -> release-report`, producing `Report status: ready`
- `seize run build` with the local Windows worker cap passed prebuild, lint, production Next build, TypeScript, static generation, and sitemap generation. Nonfatal existing warnings observed: dynamic OG metadata route warning and Node `punycode` deprecation warning.
- GitHub PR checks on latest head: App PR CI, CodeQL, DCO, Snyk, SonarCloud, and CodeRabbit passed.
- SonarCloud direct issue check on latest head reported 0 new open issues.

## Risk
- Level: High / Level 5
- Why: touches production and staging deployment workflows plus deployment evidence controls. App runtime behavior is not changed, but release safety artifacts and workflow status paths are.
- Rollback: revert this PR to restore prior deployment-bus manifest/report behavior. Failed or cancelled deployments remain recordable without requiring missing validation evidence.

## Review Notes
- CodeRabbit's four actionable findings were fixed and auto-resolved: approved-prefix schema/runtime enforcement, production-like durable-evidence requiredness, strict artifact metadata validation, and timestamp-based latest-check semantics.
- SonarCloud maintainability findings were fixed; the latest Sonar result reports zero new issues.
- The current pack plan intentionally covers `web:desktop-chromium` only; broader mobile/Firefox/WebKit/Capacitor/Electron surface matrix remains a later PR.
- Independent verifier feedback before publication found four P1s; this PR includes fixes and tests for all four: per-pack artifact readiness, invalid report readiness, tokenized artifact URI rejection/redaction, and generated-file noise removal.
