### PR TITLE
[codex] Polish wave sidebar score details

### DIFF
--- a/__tests__/components/waves/WaveTrustSignals.test.tsx
+++ b/__tests__/components/waves/WaveTrustSignals.test.tsx
@@ -87,7 +87,7 @@ describe("WaveTrustSignals", () => {
     expect(screen.queryByText("REP")).not.toBeInTheDocument();
   });
 
-  it("does not attach hover tooltip content in sidebar summary mode", () => {
+  it("renders sidebar summary score as an accessible details trigger", () => {
     render(
       <WaveTrustSignals
         waveRep={waveRep}
@@ -98,13 +98,22 @@ describe("WaveTrustSignals", () => {
       />
     );
 
-    const summaryBadge = screen.getByText("83").closest("[aria-label]");
+    const summaryBadge = screen.getByRole("button", {
+      name: /^Wave score 83\./,
+    });
 
     expect(summaryBadge).not.toBeNull();
     expect(screen.queryByText("Score")).not.toBeInTheDocument();
     expect(summaryBadge).not.toHaveAttribute("data-tooltip-content");
     expect(summaryBadge).not.toHaveAttribute("data-tooltip-id");
     expect(summaryBadge).not.toHaveAttribute("title");
+    fireEvent.click(summaryBadge);
+    expect(
+      screen.getByRole("dialog", { name: "Wave score details" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Learn more" })
+    ).not.toBeInTheDocument();
   });
 
   it("renders nothing in summary mode without a combined score", () => {

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
@@ -114,8 +114,7 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
     wave.newDropsCount.latestDropTimestamp
   );
   const hasSummaryScore = hasWaveTrustSummaryScore(wave.waveScore);
-  const shouldShowTrustSignalsRow =
-    hasSummaryScore || latestDropTimestamp !== null;
+  const shouldShowDropTime = latestDropTimestamp !== null;
 
   const formattedWaveName = useMemo(() => getFormattedWaveName(wave), [wave]);
 
@@ -320,67 +319,62 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
           )}
         </div>
         <div className="tw-min-w-0 tw-flex-1">
-          <div
-            className={`tw-flex tw-min-w-0 tw-items-center tw-gap-1.5 ${
-              shouldShowPinButton ? "tw-pr-7" : ""
-            }`}
-          >
-            <Link
-              href={href}
-              prefetch={false}
-              onClick={handleWaveClick}
-              className={`tw-static tw-block tw-min-w-0 tw-flex-shrink tw-no-underline before:tw-absolute before:tw-inset-0 before:tw-z-[5] before:tw-content-[''] focus-visible:tw-outline-none focus-visible:before:tw-ring-2 focus-visible:before:tw-ring-inset focus-visible:before:tw-ring-primary-400 ${
-                isActive
-                  ? "tw-text-white desktop-hover:group-hover:tw-text-white"
-                  : "tw-text-iron-400 desktop-hover:group-hover:tw-text-iron-300"
-              }`}
-            >
-              <span className="tw-relative tw-z-[6] tw-block tw-truncate tw-text-sm tw-font-medium">
-                {formattedWaveName}
-              </span>
-            </Link>
-            {shouldShowExpandControl && (
-              <span className="tw-relative tw-z-10 tw-inline-flex">
-                <SidebarWaveExpandControl
-                  formattedWaveName={formattedWaveName}
-                  isExpanded={isExpanded}
-                  isLoading={isLoadingSubwaves}
-                  onBlur={cancelSubwavePrefetch}
-                  onClick={handleToggleExpand}
-                  onFocus={scheduleSubwavePrefetch}
-                  shouldShowButton={shouldShowExpandControl}
-                />
-              </span>
-            )}
-          </div>
-          {shouldShowTrustSignalsRow && (
-            <div className="tw-mt-0.5 tw-flex tw-min-w-0 tw-items-center tw-gap-2 tw-text-xs tw-text-iron-500">
-              {latestDropTimestamp !== null && (
-                <span className="tw-flex tw-min-w-0 tw-items-center tw-whitespace-nowrap">
-                  <BrainLeftSidebarWaveDropTime time={latestDropTimestamp} />
+          <div className="tw-flex tw-min-w-0 tw-items-start tw-gap-2">
+            <div className="tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-gap-1.5">
+              <Link
+                href={href}
+                prefetch={false}
+                onClick={handleWaveClick}
+                className={`tw-static tw-block tw-min-w-0 tw-flex-shrink tw-no-underline before:tw-absolute before:tw-inset-0 before:tw-z-[5] before:tw-content-[''] focus-visible:tw-outline-none focus-visible:before:tw-ring-2 focus-visible:before:tw-ring-inset focus-visible:before:tw-ring-primary-400 ${
+                  isActive
+                    ? "tw-text-white desktop-hover:group-hover:tw-text-white"
+                    : "tw-text-iron-400 desktop-hover:group-hover:tw-text-iron-300"
+                }`}
+              >
+                <span className="tw-relative tw-z-[6] tw-block tw-truncate tw-text-sm tw-font-medium">
+                  {formattedWaveName}
+                </span>
+              </Link>
+              {shouldShowExpandControl && (
+                <span className="tw-relative tw-z-10 tw-inline-flex">
+                  <SidebarWaveExpandControl
+                    formattedWaveName={formattedWaveName}
+                    isExpanded={isExpanded}
+                    isLoading={isLoadingSubwaves}
+                    onBlur={cancelSubwavePrefetch}
+                    onClick={handleToggleExpand}
+                    onFocus={scheduleSubwavePrefetch}
+                    shouldShowButton={shouldShowExpandControl}
+                  />
                 </span>
               )}
-              {hasSummaryScore && (
+              {shouldShowPinButton && (
+                <BrainLeftSidebarWavePin
+                  waveId={wave.id}
+                  isPinned={!!wave.isPinned}
+                  compact
+                  className="tw-relative tw-z-10 -tw-mt-1 tw-shrink-0"
+                />
+              )}
+            </div>
+            {hasSummaryScore && (
+              <span className="tw-relative tw-z-10 tw-ml-auto tw-mt-[1px] tw-shrink-0">
                 <WaveTrustSignals
                   waveRep={wave.waveRep}
                   waveScore={wave.waveScore}
                   variant="sidebar-inline"
                   mode="summary"
-                  className="tw-ml-auto tw-shrink-0"
                 />
-              )}
+              </span>
+            )}
+          </div>
+          {shouldShowDropTime && (
+            <div className="tw-mt-0.5 tw-inline-flex tw-min-w-0 tw-items-center tw-whitespace-nowrap tw-text-xs tw-text-iron-500 tw-transition-colors tw-duration-200 desktop-hover:group-hover:tw-text-iron-400">
+              <BrainLeftSidebarWaveDropTime time={latestDropTimestamp} />
             </div>
           )}
         </div>
       </div>
-      {shouldShowPinButton && (
-        <BrainLeftSidebarWavePin
-          waveId={wave.id}
-          isPinned={!!wave.isPinned}
-          compact
-          className="tw-absolute tw-right-3 tw-top-3 tw-z-10"
-        />
-      )}
     </div>
   );
 };

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
@@ -164,7 +164,7 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
     if (isPinned) {
       return "tw-bg-transparent tw-text-iron-300 desktop-hover:hover:tw-bg-transparent desktop-hover:hover:tw-text-iron-100 active:tw-bg-transparent tw-opacity-100";
     }
-    return "tw-text-iron-500 desktop-hover:hover:tw-text-iron-300 desktop-hover:hover:tw-bg-iron-700 tw-bg-transparent active:tw-bg-iron-700 tw-opacity-70";
+    return "tw-bg-transparent tw-text-iron-300 desktop-hover:hover:tw-bg-iron-700 desktop-hover:hover:tw-text-iron-100 active:tw-bg-iron-700";
   };
 
   const getAriaLabel = () => {

--- a/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
+++ b/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
@@ -88,8 +88,7 @@ export const ExpandedWave = ({
   const shouldShowExpandControl = canExpand && depth === 0;
   const shouldShowPinButton = showPin && depth === 0;
   const hasSummaryScore = hasWaveTrustSummaryScore(wave.waveScore);
-  const shouldShowTrustSignalsRow =
-    hasSummaryScore || presentLatestDropTimestamp !== null;
+  const shouldShowDropTime = presentLatestDropTimestamp !== null;
   const { rowPaddingClasses, rowGapClasses, linkGapClasses } =
     getSidebarWaveRowLayoutClasses({
       isChildRow,
@@ -187,73 +186,66 @@ export const ExpandedWave = ({
           )}
         </div>
         <div className="tw-min-w-0 tw-flex-1">
-          <div
-            className={`-tw-mt-1 tw-mb-1 tw-flex tw-min-w-0 tw-items-center tw-gap-1.5 ${
-              shouldShowPinButton ? "tw-pr-7" : ""
-            }`}
-          >
-            <Link
-              href={href}
-              prefetch={false}
-              onClick={onClick}
-              className={`tw-static tw-block tw-min-w-0 tw-flex-shrink tw-no-underline before:tw-absolute before:tw-inset-0 before:tw-z-[5] before:tw-content-[''] focus-visible:tw-outline-none focus-visible:before:tw-ring-2 focus-visible:before:tw-ring-inset focus-visible:before:tw-ring-primary-400 ${
-                isActive
-                  ? "tw-text-white desktop-hover:group-hover:tw-text-white"
-                  : "tw-text-iron-400 desktop-hover:group-hover:tw-text-iron-300"
-              }`}
-            >
-              <div
-                ref={nameRef}
-                className="tw-relative tw-z-[6] tw-truncate tw-text-sm"
-                {...tooltipAttributes}
+          <div className="tw-flex tw-min-w-0 tw-items-start tw-gap-2">
+            <div className="-tw-mt-1 tw-mb-1 tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-gap-1.5">
+              <Link
+                href={href}
+                prefetch={false}
+                onClick={onClick}
+                className={`tw-static tw-block tw-min-w-0 tw-flex-shrink tw-no-underline before:tw-absolute before:tw-inset-0 before:tw-z-[5] before:tw-content-[''] focus-visible:tw-outline-none focus-visible:before:tw-ring-2 focus-visible:before:tw-ring-inset focus-visible:before:tw-ring-primary-400 ${
+                  isActive
+                    ? "tw-text-white desktop-hover:group-hover:tw-text-white"
+                    : "tw-text-iron-400 desktop-hover:group-hover:tw-text-iron-300"
+                }`}
               >
-                {formattedWaveName}
-              </div>
-            </Link>
-            {shouldShowExpandControl && (
-              <span className="tw-relative tw-z-10 tw-inline-flex">
-                <SidebarWaveExpandControl
-                  formattedWaveName={formattedWaveName}
-                  isExpanded={isExpanded}
-                  isLoading={isLoadingSubwaves}
-                  onBlur={cancelSubwavePrefetch}
-                  onClick={handleToggleExpand}
-                  onFocus={scheduleSubwavePrefetch}
-                  shouldShowButton={shouldShowExpandControl}
-                />
-              </span>
-            )}
-          </div>
-          {shouldShowTrustSignalsRow && (
-            <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2 tw-text-xs tw-text-iron-500">
-              {presentLatestDropTimestamp !== null && (
-                <span className="tw-flex tw-min-w-0 tw-items-center tw-whitespace-nowrap">
-                  <BrainLeftSidebarWaveDropTime
-                    time={presentLatestDropTimestamp}
+                <div
+                  ref={nameRef}
+                  className="tw-relative tw-z-[6] tw-truncate tw-text-sm"
+                  {...tooltipAttributes}
+                >
+                  {formattedWaveName}
+                </div>
+              </Link>
+              {shouldShowExpandControl && (
+                <span className="tw-relative tw-z-10 tw-inline-flex">
+                  <SidebarWaveExpandControl
+                    formattedWaveName={formattedWaveName}
+                    isExpanded={isExpanded}
+                    isLoading={isLoadingSubwaves}
+                    onBlur={cancelSubwavePrefetch}
+                    onClick={handleToggleExpand}
+                    onFocus={scheduleSubwavePrefetch}
+                    shouldShowButton={shouldShowExpandControl}
                   />
                 </span>
               )}
-              {hasSummaryScore && (
+              {shouldShowPinButton && (
+                <BrainLeftSidebarWavePin
+                  waveId={waveId}
+                  isPinned={isPinned}
+                  compact
+                  className="tw-relative tw-z-10 -tw-mt-1 tw-shrink-0"
+                />
+              )}
+            </div>
+            {hasSummaryScore && (
+              <span className="tw-relative tw-z-10 tw-ml-auto tw-mt-[1px] tw-shrink-0">
                 <WaveTrustSignals
                   waveRep={wave.waveRep}
                   waveScore={wave.waveScore}
                   variant="sidebar-inline"
                   mode="summary"
-                  className="tw-ml-auto tw-shrink-0"
                 />
-              )}
+              </span>
+            )}
+          </div>
+          {shouldShowDropTime && (
+            <div className="tw-mt-0.5 tw-inline-flex tw-min-w-0 tw-items-center tw-whitespace-nowrap tw-text-xs tw-text-iron-500 tw-transition-colors tw-duration-200 desktop-hover:group-hover:tw-text-iron-400">
+              <BrainLeftSidebarWaveDropTime time={presentLatestDropTimestamp} />
             </div>
           )}
         </div>
       </div>
-      {shouldShowPinButton && (
-        <BrainLeftSidebarWavePin
-          waveId={waveId}
-          isPinned={isPinned}
-          compact
-          className="tw-absolute tw-right-3 tw-top-2 tw-z-10"
-        />
-      )}
       {showExpandedTooltip && (
         <WaveTooltip id={tooltipId} place={tooltipPlacement}>
           {tooltipContent}

--- a/components/utils/tooltip/HoverCard.tsx
+++ b/components/utils/tooltip/HoverCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { RefObject } from "react";
+import type { CSSProperties, RefObject } from "react";
 import React, {
   useCallback,
   useEffect,
@@ -32,6 +32,8 @@ interface HoverCardProps {
   readonly offset?: number | undefined;
   readonly hoverTransitionDelay?: number | undefined;
   readonly openOnClick?: boolean | undefined;
+  readonly triggerDisplay?: CSSProperties["display"] | undefined;
+  readonly contentStyle?: CSSProperties | undefined;
 }
 export default function HoverCard({
   children,
@@ -44,6 +46,8 @@ export default function HoverCard({
   offset = 8,
   hoverTransitionDelay = 150,
   openOnClick = false,
+  triggerDisplay = "contents",
+  contentStyle,
 }: HoverCardProps) {
   const [isVisible, setIsVisible] = useState(false);
   const [position, setPosition] = useState<TooltipCoordinates>({ x: 0, y: 0 });
@@ -430,7 +434,7 @@ export default function HoverCard({
       <span
         ref={triggerBoundaryRef}
         role="presentation"
-        style={{ display: "contents" }}
+        style={{ display: triggerDisplay }}
         onMouseEnter={handleTriggerMouseEnter}
         onMouseLeave={handleTriggerMouseLeave}
         onFocus={handleTriggerFocus}
@@ -469,6 +473,7 @@ export default function HoverCard({
                   styles["tooltipContent"],
                   "tw-overflow-hidden tw-rounded-xl"
                 )}
+                style={contentStyle}
               >
                 {content}
               </div>

--- a/components/waves/WaveTrustSignals.tsx
+++ b/components/waves/WaveTrustSignals.tsx
@@ -255,7 +255,7 @@ const getChipClasses = (
 
   if (isInlineSidebarVariant(variant)) {
     variantClasses =
-      "tw-cursor-[inherit] tw-gap-[3px] tw-whitespace-nowrap tw-text-[11px] tw-font-semibold tw-leading-none";
+      "tw-cursor-help tw-gap-[3px] tw-whitespace-nowrap tw-text-[11px] tw-font-semibold tw-leading-none";
     sizeClasses = "";
   } else if (isInlineHeaderVariant(variant)) {
     variantClasses =
@@ -526,7 +526,7 @@ function WaveScoreSummaryPopoverContent({
   repSortScore,
   waveRep,
 }: {
-  readonly learnMoreHref: string;
+  readonly learnMoreHref?: string | undefined;
   readonly visibilityScore: string;
   readonly qualityScore: string | null;
   readonly hotnessScore: string | null;
@@ -579,7 +579,7 @@ function WaveScoreSummaryPopoverContent({
   ];
 
   return (
-    <div className="tw-w-56 tw-bg-iron-950 tw-p-3 tw-text-left tw-text-xs tw-text-iron-300">
+    <div className="tw-w-48 tw-bg-transparent tw-text-left tw-text-[11px] tw-leading-4 tw-text-iron-300">
       <div className="tw-flex tw-items-baseline tw-justify-between tw-gap-3">
         <span className="tw-font-semibold tw-text-white">
           {t(WAVE_TRUST_LOCALE, "waves.score.summary.title")}
@@ -589,11 +589,11 @@ function WaveScoreSummaryPopoverContent({
         </span>
       </div>
       {rows.length > 0 && (
-        <div className="tw-mt-2 tw-space-y-1.5 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/10 tw-pt-2">
+        <div className="tw-mt-1.5 tw-space-y-1 tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-white/10 tw-pt-1.5">
           {rows.map((row) => (
             <div
               key={row.label}
-              className="tw-grid tw-grid-cols-[minmax(0,1fr)_auto] tw-items-baseline tw-gap-3"
+              className="tw-grid tw-grid-cols-[minmax(0,1fr)_auto] tw-items-baseline tw-gap-2.5"
             >
               <span className="tw-min-w-0 tw-truncate tw-text-iron-500">
                 {row.label}
@@ -605,12 +605,14 @@ function WaveScoreSummaryPopoverContent({
           ))}
         </div>
       )}
-      <Link
-        href={learnMoreHref}
-        className="desktop-hover:hover:tw-text-primary-200 tw-mt-3 tw-inline-flex tw-items-center tw-rounded-md tw-text-xs tw-font-semibold tw-text-primary-300 tw-no-underline tw-transition focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
-      >
-        {t(WAVE_TRUST_LOCALE, "waves.score.summary.learnMore")}
-      </Link>
+      {learnMoreHref !== undefined && (
+        <Link
+          href={learnMoreHref}
+          className="desktop-hover:hover:tw-text-primary-200 tw-mt-2 tw-inline-flex tw-items-center tw-rounded-md tw-text-[11px] tw-font-semibold tw-text-primary-300 tw-no-underline tw-transition focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400"
+        >
+          {t(WAVE_TRUST_LOCALE, "waves.score.summary.learnMore")}
+        </Link>
+      )}
     </div>
   );
 }
@@ -618,6 +620,7 @@ function WaveScoreSummaryPopoverContent({
 function WaveScoreSummaryHoverCard({
   children,
   learnMoreHref,
+  triggerDisplay,
   visibilityScore,
   qualityScore,
   hotnessScore,
@@ -625,7 +628,8 @@ function WaveScoreSummaryHoverCard({
   waveRep,
 }: {
   readonly children: ReactElement;
-  readonly learnMoreHref: string;
+  readonly learnMoreHref?: string | undefined;
+  readonly triggerDisplay?: "contents" | "inline-flex" | undefined;
   readonly visibilityScore: string;
   readonly qualityScore: string | null;
   readonly hotnessScore: string | null;
@@ -641,6 +645,8 @@ function WaveScoreSummaryHoverCard({
       hoverTransitionDelay={80}
       offset={8}
       openOnClick
+      triggerDisplay={triggerDisplay}
+      contentStyle={{ padding: "10px 12px" }}
       content={
         <WaveScoreSummaryPopoverContent
           learnMoreHref={learnMoreHref}
@@ -739,7 +745,8 @@ export function WaveTrustSignals({
       repSortScore,
       waveRep,
     });
-    const hasRichTooltip = learnMoreHref !== undefined;
+    const hasRichTooltip =
+      learnMoreHref !== undefined || isInlineSidebarVariant(variant);
     const hasNativeTitle = !hasRichTooltip && !isSidebarVariant(variant);
     const summaryLabel = summaryDetails.join(". ");
     const summaryTitle = hasNativeTitle ? summaryDetails.join("\n") : undefined;
@@ -751,6 +758,11 @@ export function WaveTrustSignals({
     );
     const summaryButtonResetClasses = isInlineHeaderVariant(variant)
       ? "tw-bg-transparent"
+      : isInlineSidebarVariant(variant)
+        ? "tw-bg-transparent tw-p-0"
+        : "";
+    const summaryButtonAffordanceClasses = isInlineSidebarVariant(variant)
+      ? "tw-rounded-sm desktop-hover:hover:tw-bg-white/[0.04]"
       : "";
     const showSummaryLabel = !isInlineSidebarVariant(variant);
     const summaryChipContent = (
@@ -780,6 +792,9 @@ export function WaveTrustSignals({
           {hasRichTooltip ? (
             <WaveScoreSummaryHoverCard
               learnMoreHref={learnMoreHref}
+              triggerDisplay={
+                isInlineSidebarVariant(variant) ? "inline-flex" : undefined
+              }
               visibilityScore={visibilityScore}
               qualityScore={qualityScore}
               hotnessScore={hotnessScore}
@@ -788,7 +803,7 @@ export function WaveTrustSignals({
             >
               <button
                 type="button"
-                className={`${summaryChipClasses} tw-border-0 tw-font-[inherit] tw-transition focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950 ${summaryButtonResetClasses}`}
+                className={`${summaryChipClasses} tw-border-0 tw-font-[inherit] tw-transition focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950 ${summaryButtonResetClasses} ${summaryButtonAffordanceClasses}`}
                 aria-label={summaryLabel}
               >
                 {summaryChipContent}


### PR DESCRIPTION
## Summary
- move sidebar pin controls next to the wave name while keeping the score chip aligned in the right-side row space
- add a compact hover/click Wave score info card for sidebar score chips
- keep the score trigger keyboard-focusable with an accessible label and visible hover/focus affordance

## Visual Review
- Captured desktop sidebar screenshots for normal, pinned/unpinned, and score-hover states.
- Sent screenshots to Anthropic Claude Opus 4.8 for a second visual review.
- Second Opus pass verdict: pass; no blocking visual issues.

## Validation
- `seize run test:no-coverage -- __tests__/components/waves/WaveTrustSignals.test.tsx`
- `seize exec eslint components/waves/WaveTrustSignals.tsx components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx __tests__/components/waves/WaveTrustSignals.test.tsx --no-warn-ignored --max-warnings=0`
- `seize run typecheck:changed`
- `seize run react-doctor:diff`
- `codex-diff-check -- components/waves/WaveTrustSignals.tsx components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx __tests__/components/waves/WaveTrustSignals.test.tsx`

Note: `seize run check:changed` is blocked in this Windows Codex worktree because `scripts/quality.js` shells through repo-local `bin\6529.cmd`; the local guidance says to use the `seize` wrapper instead. Running the equivalent focused commands through `seize` passed for the touched files. Branch-wide `lint:changed`/Knip also report pre-existing issues outside this PR diff.