### PR TITLE
Add deployment bus post-deploy watch evidence

### DIFF
--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -371,6 +371,34 @@ jobs:
             --environment-url "https://6529.io" \
             --log-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
+      - name: Record production post-deploy watch checkpoint
+        if: always() && hashFiles('deployment-bus-manifest.json') != ''
+        env:
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          set -euo pipefail
+
+          if [ "$JOB_STATUS" = "success" ]; then
+            watch_status="in_progress"
+            checkpoint_status="passed"
+            observed_minutes="0"
+            notes="Elastic Beanstalk health/readiness and deployed version validation passed; release-captain post-deploy watch still needs deployed-environment validation evidence."
+          else
+            watch_status="failed"
+            checkpoint_status="failed"
+            observed_minutes="0"
+            notes="Production workflow did not complete deploy verification successfully."
+          fi
+
+          node ops/scripts/deployment-bus.cjs record-post-deploy-watch \
+            --file deployment-bus-manifest.json \
+            --status "$watch_status" \
+            --observed-duration-minutes "$observed_minutes" \
+            --checkpoint eb-version-health \
+            --checkpoint-status "$checkpoint_status" \
+            --evidence "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --notes "$notes"
+
       - name: Create production release report
         if: always()
         run: |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -446,6 +446,32 @@ jobs:
             --environment-url "https://staging.6529.io" \
             --log-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
+      - name: Record staging post-deploy watch
+        if: always() && hashFiles('deployment-bus-manifest.json') != ''
+        env:
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          set -euo pipefail
+
+          if [ "$JOB_STATUS" = "success" ]; then
+            watch_status="passed"
+            observed_minutes="15"
+            notes="SSM deployment completed and staging deployed SHA verification passed."
+          else
+            watch_status="failed"
+            observed_minutes="0"
+            notes="Staging workflow did not complete deploy verification successfully."
+          fi
+
+          node ops/scripts/deployment-bus.cjs record-post-deploy-watch \
+            --file deployment-bus-manifest.json \
+            --status "$watch_status" \
+            --observed-duration-minutes "$observed_minutes" \
+            --checkpoint staging-deploy-verification \
+            --checkpoint-status "$watch_status" \
+            --evidence "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --notes "$notes"
+
       - name: Create staging release report
         if: always()
         run: |

--- a/__tests__/playwright/readonlyMutationGuard.test.ts
+++ b/__tests__/playwright/readonlyMutationGuard.test.ts
@@ -68,6 +68,46 @@ describe("Playwright read-only mutation guard", () => {
     });
   });
 
+  it("allows the same-origin open-graph metadata lookup in read-only mode", () => {
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://6529.io",
+        method: "POST",
+        readonly: true,
+        url: "https://6529.io/api/open-graph",
+      })
+    ).toMatchObject({
+      action: "allow",
+      reason: "first-party-readonly-route-handler",
+    });
+
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://6529.io",
+        method: "POST",
+        readonly: true,
+        url: "https://example.com/api/open-graph",
+      })
+    ).toMatchObject({
+      action: "block",
+      reason: "non-allowlisted-mutation",
+    });
+  });
+
+  it("aborts Next.js dev inspector stack-frame lookups without recording an app mutation", () => {
+    expect(
+      decideReadonlyRequest({
+        baseURL: "http://localhost:3001",
+        method: "POST",
+        readonly: true,
+        url: "http://localhost:3001/__nextjs_original-stack-frames",
+      })
+    ).toMatchObject({
+      action: "abort",
+      reason: "ignored-next-dev-inspector",
+    });
+  });
+
   it("allows safe methods", () => {
     expect(
       decideReadonlyRequest({

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -9,6 +9,7 @@ const {
   evaluateReleaseReadiness,
   heartbeatManifest,
   productionPreflight,
+  recordPostDeployWatch,
   recordValidationCheck,
   summarizeManifest,
   validateManifest,
@@ -73,6 +74,29 @@ function releaseReadyValidationChecks() {
   ];
 }
 
+function releaseReadyPostDeployWatch(overrides = {}) {
+  return {
+    required: true,
+    status: "passed",
+    min_duration_minutes: 30,
+    observed_duration_minutes: 30,
+    started_at: "2026-06-18T13:00:00.000Z",
+    completed_at: "2026-06-18T13:30:00.000Z",
+    checkpoints: [
+      {
+        id: "version-match",
+        status: "passed",
+        recorded_at: "2026-06-18T13:30:00.000Z",
+        evidence: [
+          "https://github.com/6529-Collections/6529seize-frontend/actions/runs/123",
+        ],
+      },
+    ],
+    notes: "Post-deploy watch passed.",
+    ...overrides,
+  };
+}
+
 describe("deployment bus manifest", () => {
   afterEach(() => {
     jest.restoreAllMocks();
@@ -117,6 +141,14 @@ describe("deployment bus manifest", () => {
       required: true,
       git_lfs_allowed: false,
     });
+    expect(manifest.post_deploy_watch).toMatchObject({
+      required: false,
+      status: "not_started",
+    });
+    expect(manifest.canary_readiness).toMatchObject({
+      current_capability: "not-applicable",
+      traffic_splitting_supported: false,
+    });
   });
 
   it("records standard production validation pack commands", () => {
@@ -144,6 +176,14 @@ describe("deployment bus manifest", () => {
           "PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n:surface-matrix",
       }),
     ]);
+    expect(manifest.post_deploy_watch).toMatchObject({
+      required: true,
+      min_duration_minutes: 30,
+    });
+    expect(manifest.canary_readiness).toMatchObject({
+      current_capability: "auto-hold-only",
+      traffic_splitting_supported: false,
+    });
   });
 
   it("forces durable evidence for production-like manifests", () => {
@@ -349,12 +389,43 @@ describe("deployment bus manifest", () => {
     expect(validateManifest(passed).ok).toBe(true);
   });
 
+  it("records durable artifact retention policy metadata", () => {
+    const base = buildManifest({
+      environment: "staging",
+      stagingDeploySha: STAGING_SHA,
+      productionCandidateSha: MAIN_SHA,
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    const updated = recordValidationCheck(base, {
+      pack: "playwright:core-smoke",
+      status: "passed",
+      artifactUri: "s3://6529-artifacts/frontend/release/core-smoke.json",
+      artifactSha256: ARTIFACT_SHA256,
+      redactionStatus: "verified-redacted",
+      retentionPolicy: "standard-90-days",
+      now: "2026-06-18T12:30:00.000Z",
+    });
+
+    expect(updated.validation.checks[0].artifacts[0]).toMatchObject({
+      retention_policy: "standard-90-days",
+    });
+    expect(validateManifest(updated).errors).toEqual([]);
+  });
+
   it("passes release readiness with required packs and durable artifacts", () => {
     const manifest = buildManifest({
       environment: "production",
       productionCandidateSha: MAIN_SHA,
       status: "released",
       validationChecks: JSON.stringify(releaseReadyValidationChecks()),
+      postDeployWatchStatus: "passed",
+      postDeployWatchObservedDurationMinutes: "30",
+      postDeployWatchStartedAt: "2026-06-18T13:00:00.000Z",
+      postDeployWatchCompletedAt: "2026-06-18T13:30:00.000Z",
+      postDeployWatchCheckpoints: JSON.stringify(
+        releaseReadyPostDeployWatch().checkpoints
+      ),
       now: "2026-06-18T12:00:00.000Z",
     });
 
@@ -368,6 +439,98 @@ describe("deployment bus manifest", () => {
       holds: [],
       warnings: [],
     });
+  });
+
+  it("holds production readiness until post-deploy watch passes", () => {
+    const manifest = buildManifest({
+      environment: "production",
+      productionCandidateSha: MAIN_SHA,
+      status: "released",
+      validationChecks: JSON.stringify(releaseReadyValidationChecks()),
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    expect(validateManifest(manifest).errors).toContain(
+      "release_readiness.post-deploy-watch-missing: post-deploy watch has not recorded a passed status"
+    );
+    expect(evaluateReleaseReadiness(manifest).holds).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "post-deploy-watch-missing" }),
+      ])
+    );
+  });
+
+  it("records post-deploy watch evidence without satisfying durable artifact holds", () => {
+    const checksWithoutArtifacts = releaseReadyValidationChecks().map(
+      (check) => ({
+        ...check,
+        artifacts: [],
+      })
+    );
+    const manifest = buildManifest({
+      environment: "production",
+      productionCandidateSha: MAIN_SHA,
+      status: "deploy_verified",
+      validationChecks: JSON.stringify(checksWithoutArtifacts),
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    const watched = recordPostDeployWatch(manifest, {
+      status: "passed",
+      observedDurationMinutes: "30",
+      checkpoint: "version-match",
+      evidence:
+        "https://github.com/6529-Collections/6529seize-frontend/actions/runs/123",
+      notes: "EB health green and deployed version matched.",
+      now: "2026-06-18T13:30:00.000Z",
+    });
+    const readiness = evaluateReleaseReadiness(watched);
+    const report = createReleaseReport(watched, {
+      now: "2026-06-18T13:35:00.000Z",
+    });
+
+    expect(watched.post_deploy_watch).toMatchObject({
+      status: "passed",
+      observed_duration_minutes: 30,
+    });
+    expect(watched.post_deploy_watch.checkpoints[0]).toMatchObject({
+      id: "version-match",
+      status: "passed",
+      evidence: [
+        "https://github.com/6529-Collections/6529seize-frontend/actions/runs/123",
+      ],
+    });
+    expect(readiness.holds).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "durable-artifact-pointer-missing" }),
+      ])
+    );
+    expect(readiness.holds).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "post-deploy-watch-missing" }),
+      ])
+    );
+    expect(report).toContain("## Post-Deploy Watch");
+    expect(report).toContain("version-match: passed");
+    expect(report).toContain(
+      "https://github.com/6529-Collections/6529seize-frontend/actions/runs/123"
+    );
+    expect(report).toContain("## Canary Readiness");
+    expect(report).toContain("current capability: auto-hold-only");
+  });
+
+  it("rejects impossible traffic-split canary declarations", () => {
+    const manifest = buildManifest({
+      environment: "production",
+      productionCandidateSha: MAIN_SHA,
+      canaryCapability: "traffic-split",
+      trafficSplittingSupported: "false",
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    expect(validateManifest(manifest).errors).toContain(
+      "canary_readiness.traffic_splitting_supported: must be true when current_capability is traffic-split"
+    );
   });
 
   it("rejects unapproved durable artifact prefixes before artifact matching", () => {
@@ -574,6 +737,11 @@ describe("deployment bus manifest", () => {
       productionCandidateSha: MAIN_SHA,
       status: "released",
       validationChecks: JSON.stringify(releaseReadyValidationChecks()),
+      postDeployWatchStatus: "passed",
+      postDeployWatchObservedDurationMinutes: "30",
+      postDeployWatchCheckpoints: JSON.stringify(
+        releaseReadyPostDeployWatch().checkpoints
+      ),
       now: "2026-06-18T12:00:00.000Z",
     });
     manifest.release_id = "";

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -84,7 +84,7 @@ function releaseReadyPostDeployWatch(overrides = {}) {
     completed_at: "2026-06-18T13:30:00.000Z",
     checkpoints: [
       {
-        id: "version-match",
+        id: "release-captain-validation",
         status: "passed",
         recorded_at: "2026-06-18T13:30:00.000Z",
         evidence: [
@@ -199,6 +199,27 @@ describe("deployment bus manifest", () => {
     manifest.validation.durable_artifacts.required = false;
     expect(validateManifest(manifest).errors).toContain(
       "validation.durable_artifacts.required: must be true for production or production-eligible manifests"
+    );
+  });
+
+  it("forces post-deploy watch requirements for production manifests", () => {
+    const manifest = buildManifest({
+      environment: "production",
+      productionCandidateSha: MAIN_SHA,
+      postDeployWatchRequired: "false",
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    expect(manifest.post_deploy_watch.required).toBe(true);
+
+    manifest.post_deploy_watch.required = false;
+    expect(validateManifest(manifest).errors).toContain(
+      "post_deploy_watch.required: must be true for production manifests"
+    );
+    expect(evaluateReleaseReadiness(manifest).holds).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "post-deploy-watch-required" }),
+      ])
     );
   });
 
@@ -460,6 +481,41 @@ describe("deployment bus manifest", () => {
     );
   });
 
+  it("holds production readiness until release-captain validation evidence is recorded", () => {
+    const manifest = buildManifest({
+      environment: "production",
+      productionCandidateSha: MAIN_SHA,
+      status: "released",
+      validationChecks: JSON.stringify(releaseReadyValidationChecks()),
+      postDeployWatchStatus: "passed",
+      postDeployWatchObservedDurationMinutes: "30",
+      postDeployWatchStartedAt: "2026-06-18T13:00:00.000Z",
+      postDeployWatchCompletedAt: "2026-06-18T13:30:00.000Z",
+      postDeployWatchCheckpoints: JSON.stringify([
+        {
+          id: "version-match",
+          status: "passed",
+          recorded_at: "2026-06-18T13:30:00.000Z",
+          evidence: [
+            "https://github.com/6529-Collections/6529seize-frontend/actions/runs/123",
+          ],
+        },
+      ]),
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    expect(validateManifest(manifest).errors).toContain(
+      "release_readiness.post-deploy-watch-validation-checkpoint-missing: post-deploy watch requires a passed release-captain-validation checkpoint with evidence"
+    );
+    expect(evaluateReleaseReadiness(manifest).holds).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "post-deploy-watch-validation-checkpoint-missing",
+        }),
+      ])
+    );
+  });
+
   it("records post-deploy watch evidence without satisfying durable artifact holds", () => {
     const checksWithoutArtifacts = releaseReadyValidationChecks().map(
       (check) => ({
@@ -478,7 +534,7 @@ describe("deployment bus manifest", () => {
     const watched = recordPostDeployWatch(manifest, {
       status: "passed",
       observedDurationMinutes: "30",
-      checkpoint: "version-match",
+      checkpoint: "release-captain-validation",
       evidence:
         "https://github.com/6529-Collections/6529seize-frontend/actions/runs/123",
       notes: "EB health green and deployed version matched.",
@@ -494,7 +550,7 @@ describe("deployment bus manifest", () => {
       observed_duration_minutes: 30,
     });
     expect(watched.post_deploy_watch.checkpoints[0]).toMatchObject({
-      id: "version-match",
+      id: "release-captain-validation",
       status: "passed",
       evidence: [
         "https://github.com/6529-Collections/6529seize-frontend/actions/runs/123",
@@ -511,7 +567,7 @@ describe("deployment bus manifest", () => {
       ])
     );
     expect(report).toContain("## Post-Deploy Watch");
-    expect(report).toContain("version-match: passed");
+    expect(report).toContain("release-captain-validation: passed");
     expect(report).toContain(
       "https://github.com/6529-Collections/6529seize-frontend/actions/runs/123"
     );
@@ -728,6 +784,41 @@ describe("deployment bus manifest", () => {
       "validation.checks[0].artifacts[0].uri: artifact URI must not include query strings or fragments"
     );
     expect(report).toContain("Report status: hold");
+    expect(report).toContain("[query-or-fragment redacted]");
+    expect(report).not.toContain("X-Amz-Signature");
+  });
+
+  it("rejects tokenized post-deploy watch evidence and redacts it in reports", () => {
+    const manifest = buildManifest({
+      environment: "production",
+      productionCandidateSha: MAIN_SHA,
+      status: "released",
+      validationChecks: JSON.stringify(releaseReadyValidationChecks()),
+      postDeployWatchStatus: "passed",
+      postDeployWatchObservedDurationMinutes: "30",
+      postDeployWatchStartedAt: "2026-06-18T13:00:00.000Z",
+      postDeployWatchCompletedAt: "2026-06-18T13:30:00.000Z",
+      postDeployWatchCheckpoints: JSON.stringify([
+        {
+          id: "release-captain-validation",
+          status: "passed",
+          recorded_at: "2026-06-18T13:30:00.000Z",
+          evidence: [
+            "https://artifacts.6529.io/frontend/release/watch.json?X-Amz-Signature=secret#frag",
+          ],
+        },
+      ]),
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    const result = validateManifest(manifest);
+    const report = createReleaseReport(manifest, {
+      now: "2026-06-18T14:00:00.000Z",
+    });
+
+    expect(result.errors).toContain(
+      "post_deploy_watch.checkpoints[0].evidence[0]: evidence URI must not include query strings or fragments"
+    );
     expect(report).toContain("[query-or-fragment redacted]");
     expect(report).not.toContain("X-Amz-Signature");
   });

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -519,6 +519,27 @@ describe("deployment bus manifest", () => {
     expect(report).toContain("current capability: auto-hold-only");
   });
 
+  it("defaults not-started checkpoint records to not-run", () => {
+    const manifest = buildManifest({
+      environment: "staging",
+      stagingDeploySha: STAGING_SHA,
+      productionCandidateSha: MAIN_SHA,
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    const watched = recordPostDeployWatch(manifest, {
+      status: "not_started",
+      checkpoint: "manual-watch",
+      now: "2026-06-18T12:05:00.000Z",
+    });
+
+    expect(watched.post_deploy_watch.checkpoints[0]).toMatchObject({
+      id: "manual-watch",
+      status: "not_run",
+    });
+    expect(validateManifest(watched).errors).toEqual([]);
+  });
+
   it("rejects impossible traffic-split canary declarations", () => {
     const manifest = buildManifest({
       environment: "production",

--- a/ops/deployment-bus/manifest.v1.schema.json
+++ b/ops/deployment-bus/manifest.v1.schema.json
@@ -20,6 +20,8 @@
     "included_prs",
     "backend_dependencies",
     "validation",
+    "post_deploy_watch",
+    "canary_readiness",
     "deployment",
     "long_running",
     "plans",
@@ -278,6 +280,101 @@
             }
           }
         }
+      }
+    },
+    "post_deploy_watch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "required",
+        "status",
+        "min_duration_minutes",
+        "observed_duration_minutes",
+        "started_at",
+        "completed_at",
+        "checkpoints",
+        "notes"
+      ],
+      "properties": {
+        "required": { "type": "boolean" },
+        "status": {
+          "enum": [
+            "not_started",
+            "in_progress",
+            "passed",
+            "failed",
+            "blocked",
+            "skipped"
+          ]
+        },
+        "min_duration_minutes": { "type": "integer", "minimum": 0 },
+        "observed_duration_minutes": { "type": "integer", "minimum": 0 },
+        "started_at": { "type": ["string", "null"], "format": "date-time" },
+        "completed_at": { "type": ["string", "null"], "format": "date-time" },
+        "checkpoints": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "status", "recorded_at", "evidence"],
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "status": {
+                "enum": [
+                  "not_run",
+                  "in_progress",
+                  "passed",
+                  "failed",
+                  "blocked",
+                  "skipped"
+                ]
+              },
+              "recorded_at": {
+                "type": ["string", "null"],
+                "format": "date-time"
+              },
+              "evidence": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "notes": { "type": "string" }
+            }
+          }
+        },
+        "notes": { "type": ["string", "null"] }
+      }
+    },
+    "canary_readiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "current_capability",
+        "traffic_splitting_supported",
+        "feature_flag_strategy",
+        "candidate_control_metrics",
+        "prerequisites_for_traffic_split",
+        "notes"
+      ],
+      "properties": {
+        "current_capability": {
+          "enum": [
+            "auto-hold-only",
+            "feature-flag-only",
+            "traffic-split",
+            "not-applicable"
+          ]
+        },
+        "traffic_splitting_supported": { "type": "boolean" },
+        "feature_flag_strategy": { "type": "string" },
+        "candidate_control_metrics": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "prerequisites_for_traffic_split": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "notes": { "type": ["string", "null"] }
       }
     },
     "deployment": {

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -1,6 +1,6 @@
 # Deployment Bus Automation
 
-Status: first automation slice. The deployment bus process remains defined in
+Status: deployment-bus automation slices. The deployment bus process remains defined in
 `ops/docs/developer/deployment-bus-process.md`; this page documents the durable
 automation primitives added around the current staging and production workflows.
 
@@ -17,6 +17,8 @@ safe bus needs before queue automation can make decisions:
 - release report artifacts retained beside the manifest
 - standard deployed-environment validation pack names and commands
 - auto-hold evaluation for missing or failed required evidence
+- post-deploy watch evidence in the release report
+- explicit canary-readiness fields that say what rollout capability exists
 - production workflow check that fails if `origin/main` advances during the
   build before Elastic Beanstalk is updated
 - deployed-staging Playwright mode through `PLAYWRIGHT_BASE_URL` and
@@ -52,7 +54,15 @@ Validate and summarize:
   --artifact-uri s3://6529-artifacts/frontend/<release-id>/core-smoke.json \
   --redaction-status verified-redacted \
   --artifact-sha256 <sha256> \
-  --retention-days 90
+  --retention-policy standard-90-days
+6529 run deployment-bus -- record-post-deploy-watch \
+  --file deployment-bus-manifest.json \
+  --status passed \
+  --observed-duration-minutes 30 \
+  --checkpoint version-match \
+  --checkpoint-status passed \
+  --evidence https://github.com/6529-Collections/6529seize-frontend/actions/runs/<run-id> \
+  --notes "API version, route smoke, and static asset checks passed"
 6529 run deployment-bus -- release-report --file deployment-bus-manifest.json --output deployment-release-report.md
 ```
 
@@ -82,11 +92,11 @@ packs in `validation.required_packs` and expands them in
 `playwright:core-smoke` is the fast route smoke pack. `playwright:surface-matrix`
 is the broader route/navigation workflow pack.
 
-| Pack                        | Staging command                                                                                                                | Production command                                                                                             |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
-| `playwright:core-smoke`     | `seize run test:e2e:staging:smoke`                                                                                             | `PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:smoke:surface-matrix`     |
-| `playwright:surface-matrix` | `seize run test:e2e:staging`                                                                                                   | `PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:surface-matrix`           |
-| `playwright:wcag-i18n`      | `PLAYWRIGHT_BASE_URL=https://staging.6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n:surface-matrix`         | `PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n:surface-matrix` |
+| Pack                        | Staging command                                                                                                        | Production command                                                                                             |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `playwright:core-smoke`     | `seize run test:e2e:staging:smoke`                                                                                     | `PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:smoke:surface-matrix`     |
+| `playwright:surface-matrix` | `seize run test:e2e:staging`                                                                                           | `PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:surface-matrix`           |
+| `playwright:wcag-i18n`      | `PLAYWRIGHT_BASE_URL=https://staging.6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n:surface-matrix` | `PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n:surface-matrix` |
 
 The standard pack plan records `web:desktop-chromium` and
 `web:mobile-chromium` as the covered deployed web surfaces. Firefox, WebKit,
@@ -110,6 +120,8 @@ it. The report includes:
 - release captain and environment URL;
 - required validation packs and their commands;
 - recorded validation checks and artifact pointers;
+- post-deploy watch status, duration, checkpoints, and evidence links;
+- current canary capability and future traffic-split prerequisites;
 - auto-hold findings;
 - included PRs and artifact policy.
 
@@ -143,6 +155,8 @@ Current auto-hold criteria:
 - a production-eligible manifest's latest passing required-pack check lacks an
   approved durable artifact pointer with verified redaction, integrity metadata,
   and retention metadata;
+- a production release manifest has not recorded a passed post-deploy watch, or
+  the watch duration/checkpoints do not satisfy the manifest;
 - the production candidate SHA no longer matches the staging-validated release
   set.
 
@@ -151,6 +165,39 @@ as `s3://6529-artifacts/`, `https://artifacts.6529.io/`, or `ipfs://` for
 intentionally public redacted provenance. Git LFS and committed generated files
 are not durable release evidence stores. Do not record temporary signed URLs,
 query-string credentials, fragments, local paths, or unredacted artifacts.
+
+GitHub Actions workflow artifacts and run URLs are useful temporary evidence,
+but they are not durable artifact pointers. They can appear in post-deploy watch
+checkpoints and release reports; they do not satisfy the durable-artifact hold
+for retained Playwright traces, screenshots, or validation outputs.
+
+## Post-Deploy Watch And Canary Readiness
+
+Every manifest has `post_deploy_watch` and `canary_readiness` fields.
+
+`post_deploy_watch` records:
+
+- whether a watch is required;
+- current status: `not_started`, `in_progress`, `passed`, `failed`,
+  `blocked`, or `skipped`;
+- minimum and observed watch duration;
+- timestamped checkpoints with evidence links;
+- notes for the release captain or validation agents.
+
+The staging workflow records a staging deploy-verification checkpoint after SSM
+and deployed-SHA verification. The production workflow records an
+`eb-version-health` checkpoint after Elastic Beanstalk health/readiness and
+version-label validation. Production workflow evidence starts the watch but
+does not by itself complete the release-captain post-deploy watch; production
+validation agents should record the final `passed` watch after the deployed
+environment checks finish.
+
+`canary_readiness` records current rollout capability. Today the frontend bus
+supports auto-hold and explicit staged watch. Generic deployment traffic
+splitting is not currently supported, and feature flags are app-specific rather
+than a release-lane capability. The manifest records candidate/control metrics
+and prerequisites so a future traffic-split canary implementation has a clear
+contract instead of being inferred from prose.
 
 ## GitHub Deployment Ledger
 

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -211,6 +211,10 @@ Production watch completion is intentionally a two-step handoff:
   --notes "Production smoke, surface matrix, WCAG/i18n, and API version checks passed"
 ```
 
+Use canonical evidence URLs without query strings or fragments; signed URLs and
+tokenized dashboard links do not belong in deployment-bus manifests or release
+reports.
+
 If production validation fails, record `failed` or `blocked` instead and keep
 the release on hold until rollback or fix-forward validation passes.
 

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -192,6 +192,28 @@ does not by itself complete the release-captain post-deploy watch; production
 validation agents should record the final `passed` watch after the deployed
 environment checks finish.
 
+Production watch completion is intentionally a two-step handoff:
+
+1. The production workflow records the automated `eb-version-health` checkpoint
+   and leaves `post_deploy_watch.status` as `in_progress`.
+2. The release captain or validation agent runs the production-safe smoke,
+   surface-matrix, WCAG/i18n, API version, and changed-surface checks.
+3. After those checks pass, the validator records the terminal watch status:
+
+```bash
+6529 run deployment-bus -- record-post-deploy-watch \
+  --file deployment-bus-manifest.json \
+  --status passed \
+  --observed-duration-minutes 30 \
+  --checkpoint release-captain-validation \
+  --checkpoint-status passed \
+  --evidence https://github.com/6529-Collections/6529seize-frontend/actions/runs/<run-id> \
+  --notes "Production smoke, surface matrix, WCAG/i18n, and API version checks passed"
+```
+
+If production validation fails, record `failed` or `blocked` instead and keep
+the release on hold until rollback or fix-forward validation passes.
+
 `canary_readiness` records current rollout capability. Today the frontend bus
 supports auto-hold and explicit staged watch. Generic deployment traffic
 splitting is not currently supported, and feature flags are app-specific rather

--- a/ops/docs/developer/deployment-bus-process.md
+++ b/ops/docs/developer/deployment-bus-process.md
@@ -11,8 +11,9 @@ Implementation note: the automation slices are documented in
 validation, GitHub Deployment ledger records, workflow artifacts, standard
 deployed-environment validation pack names, release report artifacts,
 deployed-staging smoke support, auto-hold evaluation for missing release
-evidence, and long-running deployment heartbeats without automating queue
-movement or production promotion.
+evidence, post-deploy watch checkpoints, canary-readiness declarations, and
+long-running deployment heartbeats without automating queue movement or
+production promotion.
 
 ## Why This Exists
 
@@ -83,11 +84,22 @@ Known current gaps after the first automation slice:
 - The durable manifest artifact is authoritative for this slice; GitHub
   Deployment records are the status/history pointer, not the full manifest
   datastore.
+- Current rollout capability:
+  - auto-hold: supported by release-readiness evaluation;
+  - staged watch: supported through workflow checkpoints, Deployment statuses,
+    release-report fields, and release-captain validation updates;
+  - feature flags: app-specific only, not a generic release-lane capability;
+  - traffic-split canary rollout: not currently supported by the deployment bus;
+  - durable artifact storage: schema and validator are ready, but the approved
+    private storage/IAM/upload path still needs infrastructure wiring.
 - Release reports evaluate whether required packs and durable artifact pointers
   are recorded, but the workflows still do not automatically run those
   post-deploy Playwright packs. The release captain or validation agents must
   run them and record results with `record-validation-check` until a later
   automation slice wires pack execution into the lane.
+- The workflows record post-deploy deploy-verification checkpoints. These are
+  useful watch evidence, but GitHub Actions run URLs and temporary artifacts do
+  not satisfy durable artifact pointer requirements.
 - The current standard pack plan requires desktop Chromium and mobile Chromium
   evidence for `playwright:core-smoke`, `playwright:surface-matrix`, and
   `playwright:wcag-i18n`. Firefox, WebKit, Capacitor simulation, and Electron
@@ -186,6 +198,13 @@ validation:
   core_smoke_owner:
   required_packs:
   exploratory_checks:
+post_deploy_watch:
+  required:
+  status:
+  checkpoints:
+canary_readiness:
+  current_capability:
+  traffic_splitting_supported:
 status: queued | deploying | validating | passed | failed | held | superseded
 ```
 
@@ -252,6 +271,8 @@ Production validation:
 
 - verify the production deploy run and deployed SHA/version label
 - run production-safe smoke checks for changed behavior
+- record post-deploy watch checkpoints and final watch status in the deployment
+  bus manifest before release notes
 - avoid public posts, purchases, transfers, signer changes, destructive data
   work, or other irreversible actions unless the user explicitly requested
   that live action

--- a/ops/scripts/deployment-bus.cjs
+++ b/ops/scripts/deployment-bus.cjs
@@ -359,10 +359,10 @@ function buildManifest(options, env = process.env) {
   const packPlan = buildPackPlanList(requiredPacks, environment);
   const productionLikeEvidenceRequired =
     environment === "production" || productionEligible;
-  const postDeployWatchRequired = parseBoolean(
-    options.postDeployWatchRequired,
+  const postDeployWatchRequired =
     environment === "production"
-  );
+      ? true
+      : parseBoolean(options.postDeployWatchRequired, false);
   const longRunning =
     complexity === "complex" || expectedDurationMinutes > 120
       ? {
@@ -473,6 +473,13 @@ function buildManifest(options, env = process.env) {
             "Production candidate SHA differs from current origin/main or from the staging-validated release set.",
           recovery:
             "Rerun staging for the current candidate or remove superseded work from the train.",
+        },
+        {
+          id: "post-deploy-watch-validation-checkpoint-missing",
+          hold_when:
+            "A production release manifest lacks a passed release-captain-validation checkpoint with evidence.",
+          recovery:
+            "Run production-safe validation, then record the release-captain-validation checkpoint with canonical evidence before release notes.",
         },
       ],
     },
@@ -775,6 +782,16 @@ function validatePostDeployWatch(manifest, errors) {
   if (typeof postDeployWatch.required !== "boolean") {
     pushError(errors, "post_deploy_watch.required", "must be boolean");
   }
+  if (
+    manifest.environment === "production" &&
+    postDeployWatch.required !== true
+  ) {
+    pushError(
+      errors,
+      "post_deploy_watch.required",
+      "must be true for production manifests"
+    );
+  }
   if (!VALID_POST_DEPLOY_WATCH_STATUSES.has(postDeployWatch.status)) {
     pushError(
       errors,
@@ -850,6 +867,24 @@ function validateWatchCheckpoints(checkpoints, errors) {
       !Array.isArray(checkpoint.evidence)
     ) {
       pushError(errors, `${pathName}.evidence`, "must be an array");
+    } else if (Array.isArray(checkpoint?.evidence)) {
+      checkpoint.evidence.forEach((uri, evidenceIndex) => {
+        if (typeof uri !== "string") {
+          pushError(
+            errors,
+            `${pathName}.evidence[${evidenceIndex}]`,
+            "must be a string"
+          );
+          return;
+        }
+        if (uri.includes("?") || uri.includes("#")) {
+          pushError(
+            errors,
+            `${pathName}.evidence[${evidenceIndex}]`,
+            "evidence URI must not include query strings or fragments"
+          );
+        }
+      });
     }
   });
 }
@@ -1398,6 +1433,10 @@ function evaluatePostDeployWatchReadiness(manifest, holds) {
 
   const postDeployWatch = manifest.post_deploy_watch;
   if (!postDeployWatch || postDeployWatch.required !== true) {
+    holds.push({
+      id: "post-deploy-watch-required",
+      message: "production release requires a post-deploy watch contract",
+    });
     return;
   }
 
@@ -1436,6 +1475,27 @@ function evaluatePostDeployWatchReadiness(manifest, holds) {
       message: `${failedCheckpoint.id} recorded ${failedCheckpoint.status}`,
     });
   }
+
+  const releaseCaptainCheckpoint = postDeployWatch.checkpoints?.find(
+    (checkpoint) => checkpoint.id === "release-captain-validation"
+  );
+  if (
+    releaseCaptainCheckpoint?.status !== "passed" ||
+    !hasCheckpointEvidence(releaseCaptainCheckpoint)
+  ) {
+    holds.push({
+      id: "post-deploy-watch-validation-checkpoint-missing",
+      message:
+        "post-deploy watch requires a passed release-captain-validation checkpoint with evidence",
+    });
+  }
+}
+
+function hasCheckpointEvidence(checkpoint) {
+  return (
+    Array.isArray(checkpoint?.evidence) &&
+    checkpoint.evidence.some((uri) => typeof uri === "string" && uri.trim())
+  );
 }
 
 function recordValidationCheck(manifest, options) {
@@ -1701,7 +1761,9 @@ function formatPostDeployWatch(manifest) {
             const evidence =
               Array.isArray(checkpoint.evidence) &&
               checkpoint.evidence.length > 0
-                ? `; evidence: ${checkpoint.evidence.join(", ")}`
+                ? `; evidence: ${checkpoint.evidence
+                    .map(formatArtifactUriForReport)
+                    .join(", ")}`
                 : "";
             const notes = checkpoint.notes
               ? `; notes: ${checkpoint.notes}`

--- a/ops/scripts/deployment-bus.cjs
+++ b/ops/scripts/deployment-bus.cjs
@@ -78,6 +78,28 @@ const VALID_CHECK_STATUSES = new Set([
   "skipped",
   "not_run",
 ]);
+const VALID_POST_DEPLOY_WATCH_STATUSES = new Set([
+  "not_started",
+  "in_progress",
+  "passed",
+  "failed",
+  "blocked",
+  "skipped",
+]);
+const VALID_POST_DEPLOY_WATCH_CHECKPOINT_STATUSES = new Set([
+  "not_run",
+  "in_progress",
+  "passed",
+  "failed",
+  "blocked",
+  "skipped",
+]);
+const VALID_CANARY_CAPABILITIES = new Set([
+  "auto-hold-only",
+  "feature-flag-only",
+  "traffic-split",
+  "not-applicable",
+]);
 const VALID_STATUSES = new Set([
   "collecting",
   "queued",
@@ -337,6 +359,10 @@ function buildManifest(options, env = process.env) {
   const packPlan = buildPackPlanList(requiredPacks, environment);
   const productionLikeEvidenceRequired =
     environment === "production" || productionEligible;
+  const postDeployWatchRequired = parseBoolean(
+    options.postDeployWatchRequired,
+    environment === "production"
+  );
   const longRunning =
     complexity === "complex" || expectedDurationMinutes > 120
       ? {
@@ -449,6 +475,47 @@ function buildManifest(options, env = process.env) {
             "Rerun staging for the current candidate or remove superseded work from the train.",
         },
       ],
+    },
+    post_deploy_watch: {
+      required: postDeployWatchRequired,
+      status: options.postDeployWatchStatus || "not_started",
+      min_duration_minutes: parseInteger(
+        options.postDeployWatchMinDurationMinutes,
+        environment === "production" ? 30 : 0
+      ),
+      observed_duration_minutes: parseInteger(
+        options.postDeployWatchObservedDurationMinutes,
+        0
+      ),
+      started_at: options.postDeployWatchStartedAt || null,
+      completed_at: options.postDeployWatchCompletedAt || null,
+      checkpoints: parseJsonOption(options.postDeployWatchCheckpoints, []),
+      notes:
+        options.postDeployWatchNotes ||
+        "Post-deploy watch records health evidence before release notes. It is separate from traffic-split canary rollout.",
+    },
+    canary_readiness: {
+      current_capability:
+        options.canaryCapability ||
+        (environment === "production" ? "auto-hold-only" : "not-applicable"),
+      traffic_splitting_supported: parseBoolean(
+        options.trafficSplittingSupported,
+        false
+      ),
+      feature_flag_strategy:
+        options.featureFlagStrategy ||
+        "App-specific flags only; no deployment-bus traffic splitting.",
+      candidate_control_metrics: parseCsv(
+        options.candidateControlMetrics ||
+          "version-match,core-route-smoke,api-health,static-asset-health,frontend-error-rate"
+      ),
+      prerequisites_for_traffic_split: parseCsv(
+        options.canaryPrerequisites ||
+          "traffic-router-support,automated-health-thresholds,rollback-automation,artifact-storage-ready"
+      ),
+      notes:
+        options.canaryNotes ||
+        "Current deployment bus supports auto-hold plus explicit watch. Traffic-split canary rollout is a future infrastructure capability.",
     },
     deployment: {
       github_deployment_id: options.githubDeploymentId || null,
@@ -674,6 +741,8 @@ function validateManifest(manifest) {
     pushError(errors, "validation.core_smoke_owner", "required");
   }
   validateValidationPlan(manifest, errors, warnings);
+  validatePostDeployWatch(manifest, errors);
+  validateCanaryReadiness(manifest, errors);
   if (!Array.isArray(manifest.progress) || manifest.progress.length === 0) {
     pushError(errors, "progress", "must include at least one event");
   }
@@ -688,6 +757,147 @@ function validateManifest(manifest) {
   }
 
   return { ok: errors.length === 0, errors, warnings };
+}
+
+function validatePostDeployWatch(manifest, errors) {
+  const postDeployWatch = manifest.post_deploy_watch;
+  if (!postDeployWatch) {
+    if (manifest.environment === "production") {
+      pushError(
+        errors,
+        "post_deploy_watch",
+        "required for production manifests"
+      );
+    }
+    return;
+  }
+
+  if (typeof postDeployWatch.required !== "boolean") {
+    pushError(errors, "post_deploy_watch.required", "must be boolean");
+  }
+  if (!VALID_POST_DEPLOY_WATCH_STATUSES.has(postDeployWatch.status)) {
+    pushError(
+      errors,
+      "post_deploy_watch.status",
+      `must be one of ${[...VALID_POST_DEPLOY_WATCH_STATUSES].join(", ")}`
+    );
+  }
+  if (
+    !Number.isInteger(postDeployWatch.min_duration_minutes) ||
+    postDeployWatch.min_duration_minutes < 0
+  ) {
+    pushError(
+      errors,
+      "post_deploy_watch.min_duration_minutes",
+      "must be a non-negative integer"
+    );
+  }
+  if (
+    !Number.isInteger(postDeployWatch.observed_duration_minutes) ||
+    postDeployWatch.observed_duration_minutes < 0
+  ) {
+    pushError(
+      errors,
+      "post_deploy_watch.observed_duration_minutes",
+      "must be a non-negative integer"
+    );
+  }
+  validateOptionalIso(
+    errors,
+    "post_deploy_watch.started_at",
+    postDeployWatch.started_at
+  );
+  validateOptionalIso(
+    errors,
+    "post_deploy_watch.completed_at",
+    postDeployWatch.completed_at
+  );
+  validateWatchCheckpoints(postDeployWatch.checkpoints, errors);
+}
+
+function validateOptionalIso(errors, pathName, value) {
+  if (value === null || value === undefined || value === "") {
+    return;
+  }
+  validateIso(errors, pathName, value);
+}
+
+function validateWatchCheckpoints(checkpoints, errors) {
+  if (!Array.isArray(checkpoints)) {
+    pushError(errors, "post_deploy_watch.checkpoints", "must be an array");
+    return;
+  }
+
+  checkpoints.forEach((checkpoint, index) => {
+    const pathName = `post_deploy_watch.checkpoints[${index}]`;
+    if (!checkpoint?.id) {
+      pushError(errors, `${pathName}.id`, "required");
+    }
+    if (!VALID_POST_DEPLOY_WATCH_CHECKPOINT_STATUSES.has(checkpoint?.status)) {
+      pushError(
+        errors,
+        `${pathName}.status`,
+        `must be one of ${[...VALID_POST_DEPLOY_WATCH_CHECKPOINT_STATUSES].join(", ")}`
+      );
+    }
+    validateOptionalIso(
+      errors,
+      `${pathName}.recorded_at`,
+      checkpoint?.recorded_at
+    );
+    if (
+      checkpoint?.evidence !== undefined &&
+      !Array.isArray(checkpoint.evidence)
+    ) {
+      pushError(errors, `${pathName}.evidence`, "must be an array");
+    }
+  });
+}
+
+function validateCanaryReadiness(manifest, errors) {
+  const canaryReadiness = manifest.canary_readiness;
+  if (!canaryReadiness) {
+    return;
+  }
+
+  if (!VALID_CANARY_CAPABILITIES.has(canaryReadiness.current_capability)) {
+    pushError(
+      errors,
+      "canary_readiness.current_capability",
+      `must be one of ${[...VALID_CANARY_CAPABILITIES].join(", ")}`
+    );
+  }
+  if (typeof canaryReadiness.traffic_splitting_supported !== "boolean") {
+    pushError(
+      errors,
+      "canary_readiness.traffic_splitting_supported",
+      "must be boolean"
+    );
+  }
+  if (
+    canaryReadiness.current_capability === "traffic-split" &&
+    canaryReadiness.traffic_splitting_supported !== true
+  ) {
+    pushError(
+      errors,
+      "canary_readiness.traffic_splitting_supported",
+      "must be true when current_capability is traffic-split"
+    );
+  }
+  if (!Array.isArray(canaryReadiness.candidate_control_metrics)) {
+    pushError(
+      errors,
+      "canary_readiness.candidate_control_metrics",
+      "must be an array"
+    );
+  }
+  if (!Array.isArray(canaryReadiness.prerequisites_for_traffic_split)) {
+    pushError(
+      errors,
+      "canary_readiness.prerequisites_for_traffic_split",
+      "must be an array"
+    );
+  }
 }
 
 function validateValidationPlan(manifest, errors, warnings) {
@@ -930,6 +1140,9 @@ function parseArtifactPointers(value, options = {}) {
     ...(options.retentionUntil
       ? { retention_until: options.retentionUntil }
       : {}),
+    ...(options.retentionPolicy
+      ? { retention_policy: options.retentionPolicy }
+      : {}),
   }));
 }
 
@@ -1109,7 +1322,9 @@ function missingStandardPackSurfaces(packId, check) {
     ? new Set(check.surfaces)
     : new Set();
 
-  return [...expectedSurfaces].filter((surface) => !recordedSurfaces.has(surface));
+  return [...expectedSurfaces].filter(
+    (surface) => !recordedSurfaces.has(surface)
+  );
 }
 
 function evaluateReleaseReadiness(manifest) {
@@ -1167,11 +1382,60 @@ function evaluateReleaseReadiness(manifest) {
     }
   }
 
+  evaluatePostDeployWatchReadiness(manifest, holds);
+
   if (manifest.production_eligible !== true) {
     warnings.push("Manifest is not production eligible.");
   }
 
   return { ok: holds.length === 0, holds, warnings };
+}
+
+function evaluatePostDeployWatchReadiness(manifest, holds) {
+  if (manifest.environment !== "production") {
+    return;
+  }
+
+  const postDeployWatch = manifest.post_deploy_watch;
+  if (!postDeployWatch || postDeployWatch.required !== true) {
+    return;
+  }
+
+  if (["failed", "blocked"].includes(postDeployWatch.status)) {
+    holds.push({
+      id: "post-deploy-watch-failed",
+      message: `post-deploy watch recorded ${postDeployWatch.status}`,
+    });
+    return;
+  }
+
+  if (postDeployWatch.status !== "passed") {
+    holds.push({
+      id: "post-deploy-watch-missing",
+      message: "post-deploy watch has not recorded a passed status",
+    });
+    return;
+  }
+
+  if (
+    postDeployWatch.observed_duration_minutes <
+    postDeployWatch.min_duration_minutes
+  ) {
+    holds.push({
+      id: "post-deploy-watch-too-short",
+      message: `post-deploy watch observed ${postDeployWatch.observed_duration_minutes}m, below required ${postDeployWatch.min_duration_minutes}m`,
+    });
+  }
+
+  const failedCheckpoint = postDeployWatch.checkpoints?.find((checkpoint) =>
+    ["failed", "blocked"].includes(checkpoint.status)
+  );
+  if (failedCheckpoint) {
+    holds.push({
+      id: "post-deploy-watch-checkpoint-failed",
+      message: `${failedCheckpoint.id} recorded ${failedCheckpoint.status}`,
+    });
+  }
 }
 
 function recordValidationCheck(manifest, options) {
@@ -1197,6 +1461,7 @@ function recordValidationCheck(manifest, options) {
       cid: options.artifactCid,
       retentionDays: options.retentionDays,
       retentionUntil: options.retentionUntil,
+      retentionPolicy: options.retentionPolicy,
     }
   );
   const check = {
@@ -1398,6 +1663,14 @@ function createReleaseReport(manifest, options = {}) {
     "",
     formatMarkdownList([...new Set(warnings)]),
     "",
+    "## Post-Deploy Watch",
+    "",
+    formatPostDeployWatch(manifest),
+    "",
+    "## Canary Readiness",
+    "",
+    formatCanaryReadiness(manifest),
+    "",
     "## Included PRs",
     "",
     formatMarkdownList(
@@ -1412,6 +1685,53 @@ function createReleaseReport(manifest, options = {}) {
     `- accepted prefixes: ${(manifest.validation?.durable_artifacts?.accepted_prefixes || APPROVED_DURABLE_ARTIFACT_PREFIXES).join(", ")}`,
     "- Git LFS allowed: false",
     "",
+  ].join("\n");
+}
+
+function formatPostDeployWatch(manifest) {
+  const watch = manifest.post_deploy_watch;
+  if (!watch) {
+    return "- no post-deploy watch contract recorded";
+  }
+
+  const checkpointLines =
+    Array.isArray(watch.checkpoints) && watch.checkpoints.length > 0
+      ? watch.checkpoints
+          .map((checkpoint) => {
+            const evidence =
+              Array.isArray(checkpoint.evidence) &&
+              checkpoint.evidence.length > 0
+                ? `; evidence: ${checkpoint.evidence.join(", ")}`
+                : "";
+            const notes = checkpoint.notes
+              ? `; notes: ${checkpoint.notes}`
+              : "";
+            return `  - ${checkpoint.id}: ${checkpoint.status}${evidence}${notes}`;
+          })
+          .join("\n")
+      : "  - no checkpoints recorded";
+
+  return [
+    `- required: ${watch.required === true}`,
+    `- status: ${watch.status}`,
+    `- duration: ${watch.observed_duration_minutes || 0}/${watch.min_duration_minutes || 0} minutes`,
+    "- checkpoints:",
+    checkpointLines,
+  ].join("\n");
+}
+
+function formatCanaryReadiness(manifest) {
+  const canary = manifest.canary_readiness;
+  if (!canary) {
+    return "- no canary readiness contract recorded";
+  }
+
+  return [
+    `- current capability: ${canary.current_capability}`,
+    `- traffic splitting supported: ${canary.traffic_splitting_supported === true}`,
+    `- feature flag strategy: ${canary.feature_flag_strategy || "not recorded"}`,
+    `- candidate/control metrics: ${(canary.candidate_control_metrics || []).join(", ") || "none"}`,
+    `- traffic-split prerequisites: ${(canary.prerequisites_for_traffic_split || []).join(", ") || "none"}`,
   ].join("\n");
 }
 
@@ -1434,6 +1754,96 @@ function heartbeatManifest(manifest, options) {
       },
     ],
   };
+  return next;
+}
+
+function recordPostDeployWatch(manifest, options) {
+  const now = options.now || new Date().toISOString();
+  const existingWatch = manifest.post_deploy_watch || {};
+  const status = options.status || existingWatch.status || "in_progress";
+  if (!VALID_POST_DEPLOY_WATCH_STATUSES.has(status)) {
+    throw new Error(`Invalid post-deploy watch status: ${status}`);
+  }
+
+  const startedAt =
+    options.startedAt ||
+    existingWatch.started_at ||
+    (status === "in_progress" ? now : null);
+  const completedAt =
+    options.completedAt ||
+    existingWatch.completed_at ||
+    (["passed", "failed", "blocked", "skipped"].includes(status) ? now : null);
+  const watch = {
+    required:
+      existingWatch.required !== undefined
+        ? existingWatch.required
+        : manifest.environment === "production",
+    status,
+    min_duration_minutes:
+      existingWatch.min_duration_minutes ??
+      (manifest.environment === "production" ? 30 : 0),
+    observed_duration_minutes: parseInteger(
+      options.observedDurationMinutes,
+      existingWatch.observed_duration_minutes || 0
+    ),
+    started_at: startedAt,
+    completed_at: completedAt,
+    checkpoints: updateWatchCheckpoints(existingWatch.checkpoints || [], {
+      id: options.checkpoint || options.checkpointId,
+      status: options.checkpointStatus || status,
+      evidence: parseCsv(options.evidence || options.evidenceUri),
+      notes: options.notes,
+      recorded_at: now,
+    }),
+    notes: options.notes || existingWatch.notes || null,
+  };
+
+  return {
+    ...manifest,
+    updated_at: now,
+    lane: {
+      ...manifest.lane,
+      heartbeat_at: now,
+    },
+    post_deploy_watch: watch,
+    progress: [
+      ...(Array.isArray(manifest.progress) ? manifest.progress : []),
+      {
+        at: now,
+        phase: "post-deploy-watch",
+        status: manifest.status,
+        message: `Post-deploy watch recorded as ${status}`,
+      },
+    ],
+  };
+}
+
+function updateWatchCheckpoints(checkpoints, update) {
+  if (!update.id) {
+    return Array.isArray(checkpoints) ? checkpoints : [];
+  }
+
+  const nextCheckpoint = {
+    id: update.id,
+    status: update.status,
+    recorded_at: update.recorded_at,
+    evidence: update.evidence,
+    ...(update.notes ? { notes: update.notes } : {}),
+  };
+  const next = Array.isArray(checkpoints) ? [...checkpoints] : [];
+  const index = next.findIndex((checkpoint) => checkpoint.id === update.id);
+  if (index === -1) {
+    next.push(nextCheckpoint);
+  } else {
+    next[index] = {
+      ...next[index],
+      ...nextCheckpoint,
+      evidence:
+        nextCheckpoint.evidence.length > 0
+          ? nextCheckpoint.evidence
+          : next[index].evidence || [],
+    };
+  }
   return next;
 }
 
@@ -1692,6 +2102,7 @@ function usage() {
   node ops/scripts/deployment-bus.cjs record-validation-check --file <file> --pack playwright:core-smoke --status passed --surfaces web:desktop-chromium,web:mobile-chromium --artifact-uri s3://6529-artifacts/... --redaction-status verified-redacted --artifact-sha256 <hex> --retention-days 90
   node ops/scripts/deployment-bus.cjs release-report --file <file> --output <markdown-file>
   node ops/scripts/deployment-bus.cjs heartbeat-manifest --file <file> --message <text> [--status deploying] [--phase build]
+  node ops/scripts/deployment-bus.cjs record-post-deploy-watch --file <file> --status passed --observed-duration-minutes 30 --checkpoint version-match --evidence https://github.com/.../actions/runs/...
   node ops/scripts/deployment-bus.cjs production-preflight --file <file> --current-main-sha <sha> [--remote origin] [--branch main]
   node ops/scripts/deployment-bus.cjs github-create-deployment --file <file> --ref <sha> --environment <name>
   node ops/scripts/deployment-bus.cjs github-create-status --deployment-id <id> --state in_progress
@@ -1732,6 +2143,22 @@ async function main(argv = process.argv.slice(2), env = process.env) {
             exploratoryChecks: args["exploratory-checks"],
             validationChecks: args["validation-checks"],
             durableArtifactsRequired: args["durable-artifacts-required"],
+            postDeployWatchRequired: args["post-deploy-watch-required"],
+            postDeployWatchStatus: args["post-deploy-watch-status"],
+            postDeployWatchMinDurationMinutes:
+              args["post-deploy-watch-min-duration-minutes"],
+            postDeployWatchObservedDurationMinutes:
+              args["post-deploy-watch-observed-duration-minutes"],
+            postDeployWatchStartedAt: args["post-deploy-watch-started-at"],
+            postDeployWatchCompletedAt: args["post-deploy-watch-completed-at"],
+            postDeployWatchCheckpoints: args["post-deploy-watch-checkpoints"],
+            postDeployWatchNotes: args["post-deploy-watch-notes"],
+            canaryCapability: args["canary-capability"],
+            trafficSplittingSupported: args["traffic-splitting-supported"],
+            featureFlagStrategy: args["feature-flag-strategy"],
+            candidateControlMetrics: args["candidate-control-metrics"],
+            canaryPrerequisites: args["canary-prerequisites"],
+            canaryNotes: args["canary-notes"],
             rollbackPlan: args["rollback-plan"],
             fixForwardPlan: args["fix-forward-plan"],
             approvals: args.approvals,
@@ -1785,6 +2212,7 @@ async function main(argv = process.argv.slice(2), env = process.env) {
           artifactCid: args["artifact-cid"],
           retentionDays: args["retention-days"],
           retentionUntil: args["retention-until"],
+          retentionPolicy: args["retention-policy"],
           runUrl: args["run-url"],
           source: args.source,
           notes: args.notes,
@@ -1828,6 +2256,29 @@ async function main(argv = process.argv.slice(2), env = process.env) {
           status: args.status,
           phase: args.phase,
           message: args.message,
+          now: args.now,
+        });
+        const result = validateManifest(manifest);
+        printValidation(result);
+        if (!result.ok) {
+          process.exitCode = 1;
+          return;
+        }
+        writeJson(args.output || file, manifest);
+        writeStdout(`Updated ${args.output || file}`);
+        break;
+      }
+      case "record-post-deploy-watch": {
+        const file = args.file;
+        const manifest = recordPostDeployWatch(readJson(file), {
+          status: args.status,
+          observedDurationMinutes: args["observed-duration-minutes"],
+          startedAt: args["started-at"],
+          completedAt: args["completed-at"],
+          checkpoint: args.checkpoint,
+          checkpointStatus: args["checkpoint-status"],
+          evidence: args.evidence || args["evidence-uri"],
+          notes: args.notes,
           now: args.now,
         });
         const result = validateManifest(manifest);
@@ -1913,6 +2364,7 @@ module.exports = {
   heartbeatManifest,
   parseArgs,
   productionPreflight,
+  recordPostDeployWatch,
   recordValidationCheck,
   summarizeManifest,
   validateManifest,

--- a/ops/scripts/deployment-bus.cjs
+++ b/ops/scripts/deployment-bus.cjs
@@ -1790,7 +1790,7 @@ function recordPostDeployWatch(manifest, options) {
     completed_at: completedAt,
     checkpoints: updateWatchCheckpoints(existingWatch.checkpoints || [], {
       id: options.checkpoint || options.checkpointId,
-      status: options.checkpointStatus || status,
+      status: options.checkpointStatus || defaultWatchCheckpointStatus(status),
       evidence: parseCsv(options.evidence || options.evidenceUri),
       notes: options.notes,
       recorded_at: now,
@@ -1816,6 +1816,10 @@ function recordPostDeployWatch(manifest, options) {
       },
     ],
   };
+}
+
+function defaultWatchCheckpointStatus(status) {
+  return status === "not_started" ? "not_run" : status;
 }
 
 function updateWatchCheckpoints(checkpoints, update) {

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -4,6 +4,31 @@
 
 Read this section first after compaction or handoff.
 
+- Latest testing-roadmap state, 2026-06-21T15:05Z:
+  - PR #2806 and PR #2805 are merged and deployed to production.
+    - PR #2806 merge SHA:
+      `745130a19785fdc844410a2798ba63a6db8256e8`
+    - PR #2805 merge SHA and production version:
+      `cd8635e004191fc0509f253bc8d9a66c8ff51805`
+    - staging deploy run:
+      https://github.com/6529-Collections/6529seize-frontend/actions/runs/27906005657
+    - production deploy run:
+      https://github.com/6529-Collections/6529seize-frontend/actions/runs/27906579357
+  - Production validation passed for API version, smoke surface matrix, full
+    surface matrix, and WCAG/i18n surface matrix. Public release note `4.41.7`
+    and Follow The Repo deployment note are posted.
+  - Durable artifact storage remains an operational follow-up. The deployment
+    bus accepts approved S3/artifact-service/IPFS pointers, but the expected
+    `s3://6529-artifacts/` storage path was not present during validation.
+  - Current branch: `codex/testing-roadmap-e2e-next`, based on production
+    `origin/main` `cd8635e004191fc0509f253bc8d9a66c8ff51805`.
+  - Active PR7a implementation adds executable post-deploy watch and
+    canary-readiness contracts to the deployment bus, workflow release reports,
+    and docs. It does not add real traffic-split canary infra.
+  - Subagent audit consensus: next high-value E2E PR after PR7a should cover
+    richer read-only Waves and public profile identity workflows across desktop
+    and mobile, then media/delegation, NextGen/groups/tools, and broad
+    network/open-data/static route matrices.
 - Latest rollout state, 2026-06-19T23:10Z:
   - `6529reviewbot` PR #399 is merged and live on reviewbot `main`:
     https://github.com/6529-Collections/6529reviewbot/pull/399

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -2186,10 +2186,10 @@ test:e2e:smoke`: first run after production build hit stale local dev cache
   - `seize run test:e2e:browser-diversity`: 18 passed, 8 skipped.
   - `seize run test:e2e:native-sim`: 17 passed, 13 skipped.
   - `seize run testing-strategy -- scan-changed-secrets --changed-from
-    origin/main --output test-results/app-pr-ci/pr4-secret-scan.json`: clean.
+origin/main --output test-results/app-pr-ci/pr4-secret-scan.json`: clean.
   - `seize run testing-strategy -- validate-workflow-security --changed-from
-    origin/main --output
-    test-results/app-pr-ci/pr4-workflow-security.json`: clean.
+origin/main --output
+test-results/app-pr-ci/pr4-workflow-security.json`: clean.
   - `codex-diff-check`
 - Browser diversity validation required installing local Playwright Firefox and
   WebKit browsers before the final pass.
@@ -2217,8 +2217,8 @@ test:e2e:smoke`: first run after production build hit stale local dev cache
   - workflow YAML parse for app PR CI, staging deploy, and production deploy
     workflows passed.
   - `seize run testing-strategy -- validate-workflow-security --changed-from
-    origin/main --output
-    test-results/app-pr-ci/pr4-workflow-security.json`: clean.
+origin/main --output
+test-results/app-pr-ci/pr4-workflow-security.json`: clean.
   - `seize run test:e2e:surface-matrix`: 25 passed, 7 skipped.
   - `seize run test:e2e:wcag-i18n:surface-matrix`: 6 passed.
   - `$env:CIRCLE_NODE_TOTAL='1'; seize run build`: passed after deleting a
@@ -2291,9 +2291,9 @@ test:e2e:smoke`: first run after production build hit stale local dev cache
   - `seize run test:e2e:browser-diversity`: 18 passed, 6 skipped.
   - `seize run test:e2e:native-sim`: 16 passed, 11 skipped.
   - `seize run testing-strategy -- validate-workflow-security --output
-    test-results/app-pr-ci/pr4-workflow-security-rebased.json`: clean.
+test-results/app-pr-ci/pr4-workflow-security-rebased.json`: clean.
   - `seize run testing-strategy -- scan-changed-secrets --changed-from
-    origin/main --output test-results/app-pr-ci/pr4-secret-scan-rebased.json`:
+origin/main --output test-results/app-pr-ci/pr4-secret-scan-rebased.json`:
     clean.
   - `$env:CIRCLE_NODE_TOTAL='1'; seize run build`: passed after clearing stale
     ignored `.next` dev type cache. The first build attempt failed on a corrupt
@@ -2304,3 +2304,53 @@ test:e2e:smoke`: first run after production build hit stale local dev cache
 - Build regeneration again added EOF blank-line noise to three generated model
   files; those generated files were restored and the worktree is clean before
   the PR branch push.
+
+## 2026-06-21T15:05Z Surface Matrix Train Deployed And PR7a Started
+
+- PR #2806 critical route-shell guards merged and deployed:
+  - merge SHA: `745130a19785fdc844410a2798ba63a6db8256e8`
+  - PR: https://github.com/6529-Collections/6529seize-frontend/pull/2806
+- PR #2805 surface matrix and deployment evidence hardening merged and
+  deployed:
+  - merge SHA / production version:
+    `cd8635e004191fc0509f253bc8d9a66c8ff51805`
+  - PR: https://github.com/6529-Collections/6529seize-frontend/pull/2805
+- Staging deployment:
+  - run: https://github.com/6529-Collections/6529seize-frontend/actions/runs/27906005657
+  - staging SHA: `ab1077c2d8949d421cf755872efc0868fe04057b`
+  - production candidate SHA:
+    `cd8635e004191fc0509f253bc8d9a66c8ff51805`
+  - validation: staging smoke 12 passed, staging surface matrix 24 passed / 6
+    skipped, staging WCAG/i18n surface matrix 6 passed.
+- Production deployment:
+  - run: https://github.com/6529-Collections/6529seize-frontend/actions/runs/27906579357
+  - production deployed SHA/version:
+    `cd8635e004191fc0509f253bc8d9a66c8ff51805`
+  - validation: `/api/version` matched deployed SHA, smoke surface matrix 12
+    passed, full surface matrix 24 passed / 6 skipped, WCAG/i18n surface
+    matrix 6 passed.
+- Public closeout notes:
+  - release note `4.41.7` drop:
+    `72478e18-4a9a-4841-a0c1-e47c1626ec59`
+  - Follow The Repo deployment note drop:
+    `b551b85c-93c8-41b6-b8c7-a2e515310736`
+- Residual operational gap:
+  - durable artifact pointers are schema/validator enforced, but the expected
+    approved storage path `s3://6529-artifacts/` was not present. Treat artifact
+    storage wiring as an infra follow-up; do not weaken durable-artifact holds
+    or treat GitHub Actions artifacts as durable retained evidence.
+- Started branch `codex/testing-roadmap-e2e-next` from deployed `origin/main`
+  for the next roadmap run.
+- Subagent audit consensus:
+  - PR7a should add executable post-deploy watch/canary-readiness reporting
+    without requiring new infra secrets;
+  - the first richer app E2E PR after PR7a should cover Waves and public profile
+    identity workflows before media/delegation, NextGen/groups/tools, and broad
+    network/open-data/static route matrices.
+- PR7a implementation in progress:
+  - `post_deploy_watch` manifest and release-report section;
+  - `canary_readiness` current-capability contract;
+  - staging and production workflow watch checkpoints;
+  - production `released` readiness hold until post-deploy watch passes;
+  - `record-post-deploy-watch` CLI command;
+  - `record-validation-check --retention-policy` support.

--- a/ops/workstreams/frontend-a11y-i18n/testing-improvement-plan.md
+++ b/ops/workstreams/frontend-a11y-i18n/testing-improvement-plan.md
@@ -158,7 +158,7 @@ these fields before a non-trivial WCAG/i18n migration PR opens:
 - Risk assessment: computed risk floor, declared risk level, final risk level,
   downgrade approval when final risk is below the computed floor, and hazard
   analysis in the format `hazard -> severity -> likelihood -> detection ->
-  required test -> rollback or fix-forward`.
+required test -> rollback or fix-forward`.
 - Validation and artifacts: validation manifest path, durable artifact storage
   plan, artifact redaction strategy for secrets/local paths/prompts/private data,
   and expected reviewbot lanes.
@@ -235,14 +235,14 @@ Deployment:
 Every PR and deployment train needs a risk level. The risk level selects the
 minimum gates; owners can always run more.
 
-| Lane | Risk | Examples | Minimum gates |
-| --- | --- | --- | --- |
-| Fast | Level 0 | Docs, comments, test-only changes, non-runtime metadata | Whitespace/doc checks, changed lint when applicable, reviewer confirms no runtime path changed |
-| Fast | Level 1 | Isolated copy, labels, styles, non-shared presentational UI | Changed lint/typecheck, focused component tests where present, `@a11y` or `@i18n` if visible, mobile overflow if layout changed |
-| Standard | Level 2 | User-facing UI behavior, forms, navigation, menus, dialogs, route rendering, shared components | Level 1 gates, focused Jest, changed-route Playwright, keyboard/focus, mobile, locale, reviewbot findings addressed |
-| Guarded | Level 3 | Auth, session, wallet-adjacent UI, uploads, link previews, posting, moderation/admin, generated API, route protection, deploy config, shared data fetching | Level 2 gates, build, security pack, read-only destructive-action guard, staging validation for exact SHA, independent verifier |
-| Release-captain | Level 4 | Cross-surface changes, broad shared infrastructure, production routing, cache behavior, native-shell behavior, release-train changes | Level 3 gates, release captain, broader surface matrix, deployment manifest, rollback/fix-forward note, post-deploy watch |
-| Release-captain | Level 5 | Security-critical changes, funds or signing flows, irreversible data writes, credentials, infra/deploy control | Level 4 gates, explicit threat model, independent security review, least-privilege/secret review, release-captain approval, production monitoring checkpoints before public notes |
+| Lane            | Risk    | Examples                                                                                                                                                   | Minimum gates                                                                                                                                                                     |
+| --------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Fast            | Level 0 | Docs, comments, test-only changes, non-runtime metadata                                                                                                    | Whitespace/doc checks, changed lint when applicable, reviewer confirms no runtime path changed                                                                                    |
+| Fast            | Level 1 | Isolated copy, labels, styles, non-shared presentational UI                                                                                                | Changed lint/typecheck, focused component tests where present, `@a11y` or `@i18n` if visible, mobile overflow if layout changed                                                   |
+| Standard        | Level 2 | User-facing UI behavior, forms, navigation, menus, dialogs, route rendering, shared components                                                             | Level 1 gates, focused Jest, changed-route Playwright, keyboard/focus, mobile, locale, reviewbot findings addressed                                                               |
+| Guarded         | Level 3 | Auth, session, wallet-adjacent UI, uploads, link previews, posting, moderation/admin, generated API, route protection, deploy config, shared data fetching | Level 2 gates, build, security pack, read-only destructive-action guard, staging validation for exact SHA, independent verifier                                                   |
+| Release-captain | Level 4 | Cross-surface changes, broad shared infrastructure, production routing, cache behavior, native-shell behavior, release-train changes                       | Level 3 gates, release captain, broader surface matrix, deployment manifest, rollback/fix-forward note, post-deploy watch                                                         |
+| Release-captain | Level 5 | Security-critical changes, funds or signing flows, irreversible data writes, credentials, infra/deploy control                                             | Level 4 gates, explicit threat model, independent security review, least-privilege/secret review, release-captain approval, production monitoring checkpoints before public notes |
 
 Risk can only move down with a written reason. If agents disagree, use the
 higher risk level until a human or release captain resolves it.
@@ -275,14 +275,14 @@ release captain records a downgrade reason in the validation manifest.
 
 Initial risk-floor table:
 
-| Change pattern | Minimum risk |
-| --- | --- |
-| Docs-only under `ops/`, Markdown docs, comments, non-runtime metadata | Level 0 |
-| Isolated non-shared style/copy/component changes outside auth/wallet/upload/admin/deploy paths | Level 1 |
-| `app/**`, `components/**`, `hooks/**`, `contexts/**`, `store/**`, `helpers/**`, `lib/**`, `utils/**` touching user-visible route/workflow behavior | Level 2 |
-| Any auth/session, wallet, signing, profile identity, TDH/delegation, upload, media/link-preview, posting, moderation, admin, route protection, generated API model, shared data-fetching, or Next.js rendering-mode path | Level 3 |
-| Deployment workflows, deployment bus, environment schema, build/release config, cache/routing infrastructure, native-shell behavior, broad shared primitives used across many route families | Level 4 |
-| Credentials, secret handling, signing/funds, irreversible data writes, deploy-control authority, artifact-store access controls, or security-critical auth/wallet/admin changes | Level 5 |
+| Change pattern                                                                                                                                                                                                           | Minimum risk |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------ |
+| Docs-only under `ops/`, Markdown docs, comments, non-runtime metadata                                                                                                                                                    | Level 0      |
+| Isolated non-shared style/copy/component changes outside auth/wallet/upload/admin/deploy paths                                                                                                                           | Level 1      |
+| `app/**`, `components/**`, `hooks/**`, `contexts/**`, `store/**`, `helpers/**`, `lib/**`, `utils/**` touching user-visible route/workflow behavior                                                                       | Level 2      |
+| Any auth/session, wallet, signing, profile identity, TDH/delegation, upload, media/link-preview, posting, moderation, admin, route protection, generated API model, shared data-fetching, or Next.js rendering-mode path | Level 3      |
+| Deployment workflows, deployment bus, environment schema, build/release config, cache/routing infrastructure, native-shell behavior, broad shared primitives used across many route families                             | Level 4      |
+| Credentials, secret handling, signing/funds, irreversible data writes, deploy-control authority, artifact-store access controls, or security-critical auth/wallet/admin changes                                          | Level 5      |
 
 The first implementation must encode the Level 3+ floor with explicit path
 globs. Start conservative; false positives are cheaper than silently treating a
@@ -377,11 +377,11 @@ Temporary foundation constraint:
 
 Use Google-style test sizing to keep the suite fast and deterministic.
 
-| Size | Definition | 6529 examples | Runs |
-| --- | --- | --- | --- |
-| `@small` | Single process, deterministic, no network, no real browser, no external service | Pure helpers, formatters, reducers, URL guards, small components with fakes | Local, PR CI, changed-file gates |
-| `@medium` | Single machine, localhost allowed, local browser or local services allowed | Playwright against local frontend, local API smoke, component integration with browser, local upload validation | Local, PR CI when selected, train validation |
-| `@large` | Deployed or real external service, staging/prod, real native shell, production-like environment | Staging Playwright, production read-only smoke, real Capacitor/Electron shell smoke, train-level security smoke | Staging, production, release trains, scheduled runs |
+| Size      | Definition                                                                                      | 6529 examples                                                                                                   | Runs                                                |
+| --------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| `@small`  | Single process, deterministic, no network, no real browser, no external service                 | Pure helpers, formatters, reducers, URL guards, small components with fakes                                     | Local, PR CI, changed-file gates                    |
+| `@medium` | Single machine, localhost allowed, local browser or local services allowed                      | Playwright against local frontend, local API smoke, component integration with browser, local upload validation | Local, PR CI when selected, train validation        |
+| `@large`  | Deployed or real external service, staging/prod, real native shell, production-like environment | Staging Playwright, production read-only smoke, real Capacitor/Electron shell smoke, train-level security smoke | Staging, production, release trains, scheduled runs |
 
 Rules:
 
@@ -641,16 +641,16 @@ Pack types:
 
 ## Surface Evidence
 
-| Surface | Coverage goal | Testing mode |
-| --- | --- | --- |
-| Main desktop web | Full migration confidence | Jest, Playwright desktop, axe, keyboard, staging/prod smoke |
-| Mobile web | Layout and touch confidence | Playwright mobile projects, viewport screenshots, touch/zoom checks |
-| Capacitor iOS | Native-adjacent confidence | Simulated Playwright first, real shell smoke later |
-| Capacitor Android | Native-adjacent confidence | Simulated Playwright first, real shell smoke later |
-| Electron/Desktop Shell | Shell-adjacent confidence | Electron user-agent simulation first, real shell smoke later |
-| Standalone/exported surfaces | Independent confidence | Surface-specific build/export and browser smoke |
-| Staging | Deployment candidate confidence | Deployed Playwright smoke plus release-specific packs |
-| Production | Live safety confidence | Read-only smoke, changed-route checks, console/network checks |
+| Surface                      | Coverage goal                   | Testing mode                                                        |
+| ---------------------------- | ------------------------------- | ------------------------------------------------------------------- |
+| Main desktop web             | Full migration confidence       | Jest, Playwright desktop, axe, keyboard, staging/prod smoke         |
+| Mobile web                   | Layout and touch confidence     | Playwright mobile projects, viewport screenshots, touch/zoom checks |
+| Capacitor iOS                | Native-adjacent confidence      | Simulated Playwright first, real shell smoke later                  |
+| Capacitor Android            | Native-adjacent confidence      | Simulated Playwright first, real shell smoke later                  |
+| Electron/Desktop Shell       | Shell-adjacent confidence       | Electron user-agent simulation first, real shell smoke later        |
+| Standalone/exported surfaces | Independent confidence          | Surface-specific build/export and browser smoke                     |
+| Staging                      | Deployment candidate confidence | Deployed Playwright smoke plus release-specific packs               |
+| Production                   | Live safety confidence          | Read-only smoke, changed-route checks, console/network checks       |
 
 Evidence labels:
 
@@ -668,16 +668,16 @@ when only browser simulation was run.
 
 ## Execution Ladder
 
-| Stage | Goal | Required signal |
-| --- | --- | --- |
-| Local inner loop | Fast agent/developer feedback | `@small` tests, changed lint/typecheck, focused component tests |
-| Local pre-PR | Prove touched workflow locally | Risk level, hazard analysis, selected packs, focused Playwright for visible UI |
-| PR CI | Repo-owned baseline before review/deploy | frozen install, lint, typecheck, test typecheck, focused/full Jest by risk, build when needed, small Playwright smoke |
-| Review | Independent reasoning | 6529reviewbot lanes, GLM swarm when available, human/agent review, findings mapped into manifest |
-| Post-merge/train | Validate train composition | exact PR set, exact SHA, release report, selected medium/large packs |
-| Staging | Validate production candidate | read-only staging Playwright, changed routes, owner validation, durable artifacts |
-| Production | Validate live release | exact deployed SHA, read-only smoke, error/route/API watch, public notes only after green |
-| Nightly/scheduled | Catch drift cheaply | broader browsers, Firefox/WebKit, full Jest, flake detection, dependency/security checks |
+| Stage             | Goal                                     | Required signal                                                                                                       |
+| ----------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Local inner loop  | Fast agent/developer feedback            | `@small` tests, changed lint/typecheck, focused component tests                                                       |
+| Local pre-PR      | Prove touched workflow locally           | Risk level, hazard analysis, selected packs, focused Playwright for visible UI                                        |
+| PR CI             | Repo-owned baseline before review/deploy | frozen install, lint, typecheck, test typecheck, focused/full Jest by risk, build when needed, small Playwright smoke |
+| Review            | Independent reasoning                    | 6529reviewbot lanes, GLM swarm when available, human/agent review, findings mapped into manifest                      |
+| Post-merge/train  | Validate train composition               | exact PR set, exact SHA, release report, selected medium/large packs                                                  |
+| Staging           | Validate production candidate            | read-only staging Playwright, changed routes, owner validation, durable artifacts                                     |
+| Production        | Validate live release                    | exact deployed SHA, read-only smoke, error/route/API watch, public notes only after green                             |
+| Nightly/scheduled | Catch drift cheaply                      | broader browsers, Firefox/WebKit, full Jest, flake detection, dependency/security checks                              |
 
 ## Pull Request Workflow
 
@@ -1304,8 +1304,22 @@ Goals:
 
 Exit criteria:
 
-- Current production watch is explicit.
+- Current production post-deploy watch is explicit.
 - Future canary work has clear prerequisites.
+
+Executable PR7a slice:
+
+- Add `post_deploy_watch` to deployment-bus manifests and release reports.
+- Add `canary_readiness` to record current rollout capability:
+  `auto-hold-only`, `feature-flag-only`, `traffic-split`, or
+  `not-applicable`.
+- Record staging and production workflow watch checkpoints without treating
+  GitHub Actions run URLs as durable artifact evidence.
+- Require a passed post-deploy watch before a production manifest in `released`
+  state is considered release-ready.
+- Keep traffic-split canary rollout as future infrastructure work until the
+  router, health thresholds, rollback automation, and durable artifact storage
+  are available.
 
 ## Page-Cluster PR Requirements After The Sidequest
 

--- a/tests/critical-shell/critical-shell.spec.ts
+++ b/tests/critical-shell/critical-shell.spec.ts
@@ -15,6 +15,8 @@ type ConsoleDiagnostics = {
 
 const CRITICAL_SHELL_ALLOWED_CONSOLE_ERROR_PATTERNS = [
   /^Error fetching emoji list: Error: Failed to load emoji list(?:\n|$)/,
+  /^Analytics SDK: TypeError: Failed to fetch(?:\n|$)/,
+  /^Failed to fetch cookie consent status Error: Network request failed\. Please check your connection and try again\. \(https:\/\/api\.6529\.io\/api\/policies\/country-check\)(?:\n|$)/,
 ];
 
 function attachConsoleDiagnostics(page: Page): ConsoleDiagnostics {

--- a/tests/support/readonlyMutationGuard.ts
+++ b/tests/support/readonlyMutationGuard.ts
@@ -163,6 +163,26 @@ function isFirstPartyTelemetryEndpoint(url: URL, baseURL?: string) {
   );
 }
 
+function isFirstPartyReadonlyRouteHandler(
+  method: string,
+  url: URL,
+  baseURL?: string
+) {
+  return (
+    method === "POST" &&
+    isSameOrigin(url, baseURL) &&
+    url.pathname === "/api/open-graph"
+  );
+}
+
+function isNextDevInspectorEndpoint(url: URL, baseURL?: string) {
+  return (
+    isSameOrigin(url, baseURL) &&
+    (url.pathname === "/__nextjs_original-stack-frame" ||
+      url.pathname === "/__nextjs_original-stack-frames")
+  );
+}
+
 function isWalletConnectRpc(url: URL) {
   return url.hostname === WALLETCONNECT_RPC_HOST && url.pathname === "/v1/";
 }
@@ -293,6 +313,14 @@ export function decideReadonlyRequest({
   const parsed = parseUrl(url);
   if (!parsed || !["http:", "https:"].includes(parsed.protocol)) {
     return { action: "allow", reason: "non-http-url" };
+  }
+
+  if (isFirstPartyReadonlyRouteHandler(upperMethod, parsed, baseURL)) {
+    return { action: "allow", reason: "first-party-readonly-route-handler" };
+  }
+
+  if (isNextDevInspectorEndpoint(parsed, baseURL)) {
+    return { action: "abort", reason: "ignored-next-dev-inspector" };
   }
 
   const endpoint = registryMatch(upperMethod, parsed, baseURL);


### PR DESCRIPTION
## Issue
- This is part of the WCAG 2.2 AA and i18n migration testing hardening roadmap.
- The deployment bus could already record required validation packs and durable artifact holds, but post-deploy watch/canary readiness remained mostly prose.
- Release reports also needed a clear distinction between temporary workflow evidence and durable retained artifact pointers.

## Fix
- Add executable post-deploy watch and canary-readiness contracts to the deployment bus manifest, validator, release report, and CLI.
- Keep the existing durable artifact hold intact: GitHub Actions run URLs can document watch checkpoints, but they do not satisfy durable artifact pointer requirements.
- Wire staging and production deploy workflows to record deploy-verification watch checkpoints before generating the release report.

## Changes
- Adds `post_deploy_watch` and `canary_readiness` manifest fields plus schema validation.
- Adds `record-post-deploy-watch` to record watch status, duration, checkpoints, evidence links, and notes.
- Adds release-report sections for `Post-Deploy Watch` and `Canary Readiness`.
- Requires a passed post-deploy watch before a production manifest in `released` state is considered release-ready.
- Adds `record-validation-check --retention-policy` support.
- Updates deployment-bus process docs and the frontend testing roadmap to state current capability explicitly: auto-hold and post-deploy watch are supported; generic traffic-split canary rollout is not currently supported.

## Validation
- `node --check ops/scripts/deployment-bus.cjs`
- `seize run test:no-coverage -- __tests__/scripts/deployment-bus.test.ts` (33 passed)
- `seize exec eslint ops/scripts/deployment-bus.cjs __tests__/scripts/deployment-bus.test.ts --no-warn-ignored --max-warnings=0`
- Workflow YAML parse for staging and production deploy workflows
- `seize run typecheck:changed`
- `seize run lint:changed`
- `seize run testing-strategy -- validate-workflow-security --changed-from origin/main --output test-results/app-pr-ci/pr7a-workflow-security.json`
- `seize run testing-strategy -- scan-changed-secrets --changed-from origin/main --output test-results/app-pr-ci/pr7a-secret-scan.json`
- CLI smoke: create production manifest, record a durable validation check using `--retention-policy`, record an in-progress post-deploy watch checkpoint, and generate a release report
- `codex-diff-check`

## Risk
- Level: High
- Why: touches deployment workflows and deployment-bus release gating/reporting, though no runtime user-facing app behavior changes.
- Rollback: revert this PR; deploy workflows return to the prior manifest/report behavior.

## Review Notes
- Please focus on workflow safety, release-readiness semantics, and whether the post-deploy watch evidence can be recorded without weakening durable artifact requirements.
- The existing reviewbot lanes remain required and additive; GLM swarm review is expected to run separately as part of the normal bot feedback loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added post-deploy watch checkpoint recording to staging and production deployment workflows, with required release-gating in release readiness and expanded release report sections.
  * Introduced canary readiness fields in deployment manifests for rollout capability tracking.
* **Tests**
  * Expanded deployment-bus validation and release-readiness tests for post-deploy watch and canary readiness.
  * Added Playwright coverage for read-only mutation guarding and updated critical-shell allowed console-error patterns.
* **Chores**
  * Updated the deployment-bus manifest schema and improved deployment-bus documentation, including the new post-deploy watch recording flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->