### PR TITLE
Add deployed HTTP version verification gates

### DIFF
--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -332,6 +332,27 @@ jobs:
             echo "Deployed version valid!"
           fi
 
+      - name: Verify production HTTP version
+        run: |
+          set -euo pipefail
+
+          node ops/scripts/verify-deployment-version.cjs \
+            --base-url https://6529.io \
+            --expected-version "${COMMIT_SHA}" \
+            --attempts 12 \
+            --delay-ms 10000 \
+            --timeout-ms 10000 \
+            --output deployment-version-evidence.json
+
+          node ops/scripts/deployment-bus.cjs record-post-deploy-watch \
+            --file deployment-bus-manifest.json \
+            --status in_progress \
+            --observed-duration-minutes 0 \
+            --checkpoint http-version-match \
+            --checkpoint-status passed \
+            --evidence "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --notes "GET /api/version matched the production commit SHA."
+
       - name: Mark production deployment terminal
         if: always() && steps.deployment-record.outputs.deployment_id != ''
         env:
@@ -418,6 +439,7 @@ jobs:
           path: |
             deployment-bus-manifest.json
             deployment-release-report.md
+            deployment-version-evidence.json
           if-no-files-found: ignore
           retention-days: 90
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -407,6 +407,29 @@ jobs:
             exit 1
           fi
 
+      - name: Verify staging HTTP version
+        env:
+          STAGING_AUTH: ${{ secrets.STAGING_AUTH }}
+        run: |
+          set -euo pipefail
+
+          node ops/scripts/verify-deployment-version.cjs \
+            --base-url https://staging.6529.io \
+            --expected-version "${{ steps.expected-commit.outputs.sha }}" \
+            --attempts 12 \
+            --delay-ms 10000 \
+            --timeout-ms 10000 \
+            --output deployment-version-evidence.json
+
+          node ops/scripts/deployment-bus.cjs record-post-deploy-watch \
+            --file deployment-bus-manifest.json \
+            --status in_progress \
+            --observed-duration-minutes 0 \
+            --checkpoint http-version-match \
+            --checkpoint-status passed \
+            --evidence "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --notes "GET /api/version matched the staging deploy SHA."
+
       - name: Mark staging deployment terminal
         if: always() && steps.deployment-record.outputs.deployment_id != ''
         env:
@@ -491,5 +514,6 @@ jobs:
           path: |
             deployment-bus-manifest.json
             deployment-release-report.md
+            deployment-version-evidence.json
           if-no-files-found: ignore
           retention-days: 30

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -32,12 +32,12 @@ function releaseArtifact(uri, metadata) {
   };
 }
 
-function releasePackCheck({ pack, command, artifact }) {
+function releasePackCheck({ pack, command, artifact, surfaces }) {
   return {
     pack,
     status: "passed",
     command,
-    surfaces: [...REQUIRED_WEB_SURFACES],
+    surfaces: surfaces ?? [...REQUIRED_WEB_SURFACES],
     artifacts: [artifact],
   };
 }
@@ -184,6 +184,86 @@ describe("deployment bus manifest", () => {
       current_capability: "auto-hold-only",
       traffic_splitting_supported: false,
     });
+  });
+
+  it("supports the production read-only aggregate as required production evidence", () => {
+    const requiredPacks = [
+      ...DEFAULT_REQUIRED_PACKS,
+      "playwright:production-readonly",
+    ];
+    const manifest = buildManifest({
+      environment: "production",
+      productionCandidateSha: MAIN_SHA,
+      status: "released",
+      requiredPacks: requiredPacks.join(","),
+      validationChecks: JSON.stringify([
+        ...releaseReadyValidationChecks(),
+        releasePackCheck({
+          pack: "playwright:production-readonly",
+          command: "seize run test:e2e:production:readonly",
+          surfaces: ["web:desktop-chromium"],
+          artifact: releaseArtifact(
+            "s3://6529-artifacts/frontend/release/production-readonly.json",
+            { sha256: ARTIFACT_SHA256 }
+          ),
+        }),
+      ]),
+      postDeployWatchStatus: "passed",
+      postDeployWatchObservedDurationMinutes: "30",
+      postDeployWatchStartedAt: "2026-06-18T13:00:00.000Z",
+      postDeployWatchCompletedAt: "2026-06-18T13:30:00.000Z",
+      postDeployWatchCheckpoints: JSON.stringify(
+        releaseReadyPostDeployWatch().checkpoints
+      ),
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    expect(manifest.validation.required_packs).toEqual(requiredPacks);
+    expect(manifest.validation.pack_plan).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "playwright:production-readonly",
+          command: "seize run test:e2e:production:readonly",
+          surfaces: ["web:desktop-chromium"],
+        }),
+      ])
+    );
+    expect(validateManifest(manifest)).toEqual({
+      ok: true,
+      errors: [],
+      warnings: [],
+    });
+    expect(evaluateReleaseReadiness(manifest)).toEqual({
+      ok: true,
+      holds: [],
+      warnings: [],
+    });
+  });
+
+  it("rejects production-only standard packs on staging manifests", () => {
+    const manifest = buildManifest({
+      environment: "staging",
+      stagingDeploySha: STAGING_SHA,
+      productionCandidateSha: MAIN_SHA,
+      productionEligible: "true",
+      requiredPacks: [
+        ...DEFAULT_REQUIRED_PACKS,
+        "playwright:production-readonly",
+      ].join(","),
+      now: "2026-06-18T12:00:00.000Z",
+    });
+
+    expect(manifest.validation.pack_plan).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "playwright:production-readonly",
+          command: null,
+        }),
+      ])
+    );
+    expect(validateManifest(manifest).errors).toContain(
+      "validation.required_packs: playwright:production-readonly has no standard command for staging"
+    );
   });
 
   it("forces durable evidence for production-like manifests", () => {

--- a/__tests__/scripts/verify-deployment-version.test.ts
+++ b/__tests__/scripts/verify-deployment-version.test.ts
@@ -1,3 +1,5 @@
+const { spawnSync } = require("node:child_process");
+const path = require("node:path");
 const {
   STAGING_ACCESS_COOKIE_NAME,
   normalizeBaseUrl,
@@ -44,6 +46,27 @@ describe("verify-deployment-version", () => {
     expect(() => normalizeBaseUrl("https://user:pass@6529.io")).toThrow(
       "--base-url must not include credentials"
     );
+  });
+
+  it("loads the CLI argument parser before validating required options", () => {
+    const script = path.join(
+      process.cwd(),
+      "ops/scripts/verify-deployment-version.cjs"
+    );
+    const result = spawnSync(process.execPath, [script], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PLAYWRIGHT_STAGING_ACCESS_CODE: "",
+        STAGING_AUTH: "",
+      },
+    });
+    const output = `${result.stdout}${result.stderr}`;
+
+    expect(result.status).toBe(1);
+    expect(output).toContain("--expected-version is required");
+    expect(output).not.toContain("parseArgs is not a function");
   });
 
   it("passes when /api/version returns the expected version with no-store", async () => {

--- a/__tests__/scripts/verify-deployment-version.test.ts
+++ b/__tests__/scripts/verify-deployment-version.test.ts
@@ -1,0 +1,187 @@
+const {
+  STAGING_ACCESS_COOKIE_NAME,
+  normalizeBaseUrl,
+  resolveVersionEndpoint,
+  verifyDeploymentVersion,
+} = require("../../ops/scripts/verify-deployment-version.cjs");
+
+const EXPECTED_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+function response({
+  status = 200,
+  cacheControl = "no-store, must-revalidate",
+  body = { version: EXPECTED_SHA },
+} = {}) {
+  return {
+    status,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "cache-control" ? cacheControl : null,
+    },
+    json: jest.fn().mockResolvedValue(body),
+  };
+}
+
+function deterministicClock() {
+  let tick = 0;
+  return {
+    now: () => `2026-06-22T00:00:0${tick++}.000Z`,
+    monotonicNow: () => tick * 100,
+  };
+}
+
+describe("verify-deployment-version", () => {
+  it("normalizes deployment base URLs to an origin", () => {
+    expect(normalizeBaseUrl("https://6529.io/some/path?token=secret")).toBe(
+      "https://6529.io"
+    );
+    expect(resolveVersionEndpoint("https://6529.io")).toBe(
+      "https://6529.io/api/version"
+    );
+  });
+
+  it("rejects credential-bearing base URLs", () => {
+    expect(() => normalizeBaseUrl("https://user:pass@6529.io")).toThrow(
+      "--base-url must not include credentials"
+    );
+  });
+
+  it("passes when /api/version returns the expected version with no-store", async () => {
+    const clock = deterministicClock();
+    const fetchImpl = jest.fn().mockResolvedValue(response());
+
+    const result = await verifyDeploymentVersion({
+      baseUrl: "https://6529.io",
+      expectedVersion: EXPECTED_SHA,
+      attempts: 1,
+      delayMs: 1,
+      timeoutMs: 100,
+      fetchImpl,
+      sleep: jest.fn(),
+      ...clock,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://6529.io/api/version",
+      expect.objectContaining({
+        method: "GET",
+        redirect: "manual",
+      })
+    );
+    expect(result.evidence).toMatchObject({
+      base_url: "https://6529.io",
+      endpoint_path: "/api/version",
+      expected_version: EXPECTED_SHA,
+      actual_version: EXPECTED_SHA,
+      matched: true,
+      no_store: true,
+      status: 200,
+    });
+  });
+
+  it("retries until the live HTTP version matches the expected version", async () => {
+    const clock = deterministicClock();
+    const sleep = jest.fn().mockResolvedValue(undefined);
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(
+        response({
+          body: { version: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
+        })
+      )
+      .mockResolvedValueOnce(response());
+
+    const result = await verifyDeploymentVersion({
+      baseUrl: "https://6529.io",
+      expectedVersion: EXPECTED_SHA,
+      attempts: 2,
+      delayMs: 1,
+      timeoutMs: 100,
+      fetchImpl,
+      sleep,
+      ...clock,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(1);
+    expect(result.evidence.attempt).toBe(2);
+  });
+
+  it("fails when the version never matches", async () => {
+    const clock = deterministicClock();
+    const fetchImpl = jest.fn().mockResolvedValue(
+      response({
+        body: { version: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
+      })
+    );
+
+    const result = await verifyDeploymentVersion({
+      baseUrl: "https://6529.io",
+      expectedVersion: EXPECTED_SHA,
+      attempts: 1,
+      delayMs: 1,
+      timeoutMs: 100,
+      fetchImpl,
+      sleep: jest.fn(),
+      ...clock,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.evidence).toMatchObject({
+      actual_version: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      matched: false,
+      error: null,
+    });
+  });
+
+  it("requires no-store cache control", async () => {
+    const clock = deterministicClock();
+    const fetchImpl = jest.fn().mockResolvedValue(
+      response({
+        cacheControl: "public, max-age=300",
+      })
+    );
+
+    const result = await verifyDeploymentVersion({
+      baseUrl: "https://6529.io",
+      expectedVersion: EXPECTED_SHA,
+      attempts: 1,
+      delayMs: 1,
+      timeoutMs: 100,
+      fetchImpl,
+      sleep: jest.fn(),
+      ...clock,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.evidence).toMatchObject({
+      no_store: false,
+      cache_control: "public, max-age=300",
+    });
+  });
+
+  it("sends staging access only to the staging host and omits it from evidence", async () => {
+    const clock = deterministicClock();
+    const fetchImpl = jest.fn().mockResolvedValue(response());
+
+    const result = await verifyDeploymentVersion({
+      baseUrl: "https://staging.6529.io",
+      expectedVersion: EXPECTED_SHA,
+      attempts: 1,
+      delayMs: 1,
+      timeoutMs: 100,
+      env: { ["STAGING_" + "AUTH"]: "stage-test-code" },
+      fetchImpl,
+      sleep: jest.fn(),
+      ...clock,
+    });
+
+    const headers = fetchImpl.mock.calls[0][1].headers;
+    expect(headers.Cookie).toBe(
+      `${STAGING_ACCESS_COOKIE_NAME}=stage-test-code`
+    );
+    expect(JSON.stringify(result.evidence)).not.toContain("stage-test-code");
+  });
+});

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -19,6 +19,8 @@ safe bus needs before queue automation can make decisions:
 - auto-hold evaluation for missing or failed required evidence
 - post-deploy watch evidence in the release report
 - explicit canary-readiness fields that say what rollout capability exists
+- deployed HTTP `/api/version` checks that prove the live app serves the
+  deployed SHA before the workflow marks a deployment verified
 - production workflow check that fails if `origin/main` advances during the
   build before Elastic Beanstalk is updated
 - deployed-staging Playwright mode through `PLAYWRIGHT_BASE_URL` and
@@ -90,20 +92,27 @@ packs in `validation.required_packs` and expands them in
 `validation.pack_plan`.
 
 `playwright:core-smoke` is the fast route smoke pack. `playwright:surface-matrix`
-is the broader route/navigation workflow pack.
+is the broader route/navigation workflow pack. `playwright:production-readonly`
+is a known production-only aggregate pack that release captains can opt into
+when recording full production-safe read-only evidence; it is not in the
+default required pack set until durable artifact upload and recording are
+automated.
 
-| Pack                        | Staging command                                                                                                        | Production command                                                                                             |
-| --------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `playwright:core-smoke`     | `seize run test:e2e:staging:smoke`                                                                                     | `PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:smoke:surface-matrix`     |
-| `playwright:surface-matrix` | `seize run test:e2e:staging`                                                                                           | `PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:surface-matrix`           |
-| `playwright:wcag-i18n`      | `PLAYWRIGHT_BASE_URL=https://staging.6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n:surface-matrix` | `PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n:surface-matrix` |
+| Pack                             | Staging command                                                                                                        | Production command                                                                                             |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `playwright:core-smoke`          | `seize run test:e2e:staging:smoke`                                                                                     | `PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:smoke:surface-matrix`     |
+| `playwright:surface-matrix`      | `seize run test:e2e:staging`                                                                                           | `PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:surface-matrix`           |
+| `playwright:wcag-i18n`           | `PLAYWRIGHT_BASE_URL=https://staging.6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n:surface-matrix` | `PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n:surface-matrix` |
+| `playwright:production-readonly` | production-only                                                                                                        | `seize run test:e2e:production:readonly`                                                                       |
 
-The standard pack plan records `web:desktop-chromium` and
-`web:mobile-chromium` as the covered deployed web surfaces. Firefox, WebKit,
-Capacitor simulation, and Electron simulation remain optional train/nightly or
-targeted validation lanes until they are stable enough to make them required
-deployment evidence. Browser simulation must not be described as real native or
-real Electron shell coverage.
+The default required standard pack plan records `web:desktop-chromium` and
+`web:mobile-chromium` as the covered deployed web surfaces. The production
+read-only aggregate records `web:desktop-chromium` only because production
+scripts intentionally run production-safe public checks on desktop Chromium.
+Firefox, WebKit, Capacitor simulation, and Electron simulation remain optional
+train/nightly or targeted validation lanes until they are stable enough to make
+them required deployment evidence. Browser simulation must not be described as
+real native or real Electron shell coverage.
 
 For standard required packs, release readiness requires the latest passing
 check to record the pack-plan command and every required pack-plan surface.
@@ -185,12 +194,28 @@ Every manifest has `post_deploy_watch` and `canary_readiness` fields.
 - notes for the release captain or validation agents.
 
 The staging workflow records a staging deploy-verification checkpoint after SSM
-and deployed-SHA verification. The production workflow records an
-`eb-version-health` checkpoint after Elastic Beanstalk health/readiness and
-version-label validation. Production workflow evidence starts the watch but
-does not by itself complete the release-captain post-deploy watch; production
-validation agents should record the final `passed` watch after the deployed
-environment checks finish.
+and deployed-SHA verification. Both deploy workflows also run a GET-only
+`/api/version` check against the deployed environment and upload
+`deployment-version-evidence.json` with the workflow artifacts. The production
+workflow records an `eb-version-health` checkpoint after Elastic Beanstalk
+health/readiness and version-label validation. Production workflow evidence
+starts the watch but does not by itself complete the release-captain
+post-deploy watch; production validation agents should record the final
+`passed` watch after the deployed environment checks finish.
+
+Run the same HTTP version probe locally or from a release-captain shell with:
+
+```bash
+6529 run verify:deployment-version -- \
+  --base-url https://6529.io \
+  --expected-version <sha> \
+  --output deployment-version-evidence.json
+```
+
+For staging, provide the access code through `PLAYWRIGHT_STAGING_ACCESS_CODE` or
+`STAGING_AUTH` only as an environment value. The evidence file records the
+target origin, `/api/version` status, cache policy, expected version, and actual
+version, but never request headers or cookies.
 
 Production watch completion is intentionally a two-step handoff:
 

--- a/ops/docs/developer/deployment-bus-process.md
+++ b/ops/docs/developer/deployment-bus-process.md
@@ -97,14 +97,18 @@ Known current gaps after the first automation slice:
   post-deploy Playwright packs. The release captain or validation agents must
   run them and record results with `record-validation-check` until a later
   automation slice wires pack execution into the lane.
-- The workflows record post-deploy deploy-verification checkpoints. These are
-  useful watch evidence, but GitHub Actions run URLs and temporary artifacts do
-  not satisfy durable artifact pointer requirements.
+- The workflows record post-deploy deploy-verification checkpoints and run a
+  GET-only `/api/version` check against the deployed HTTP app. These are useful
+  watch evidence, but GitHub Actions run URLs and temporary artifacts do not
+  satisfy durable artifact pointer requirements.
 - The current standard pack plan requires desktop Chromium and mobile Chromium
   evidence for `playwright:core-smoke`, `playwright:surface-matrix`, and
-  `playwright:wcag-i18n`. Firefox, WebKit, Capacitor simulation, and Electron
-  simulation remain optional train/nightly or targeted validation lanes and
-  must not be described as real native or real Electron shell coverage.
+  `playwright:wcag-i18n`. The deployment bus also knows the optional
+  production-only `playwright:production-readonly` aggregate, which records
+  desktop Chromium production evidence when a release captain explicitly opts
+  into it. Firefox, WebKit, Capacitor simulation, and Electron simulation remain
+  optional train/nightly or targeted validation lanes and must not be described
+  as real native or real Electron shell coverage.
 - Backend coordination is still a cross-repo handoff, not a shared automated
   release train.
 

--- a/ops/scripts/cli-args.cjs
+++ b/ops/scripts/cli-args.cjs
@@ -1,0 +1,39 @@
+"use strict";
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  let index = 0;
+
+  while (index < argv.length) {
+    const token = argv[index];
+    if (!token.startsWith("--")) {
+      args._.push(token);
+      index += 1;
+      continue;
+    }
+
+    const rawKey = token.slice(2);
+    const eqIndex = rawKey.indexOf("=");
+    if (eqIndex !== -1) {
+      args[rawKey.slice(0, eqIndex)] = rawKey.slice(eqIndex + 1);
+      index += 1;
+      continue;
+    }
+
+    const nextToken = argv[index + 1];
+    if (!nextToken || nextToken.startsWith("--")) {
+      args[rawKey] = true;
+      index += 1;
+      continue;
+    }
+
+    args[rawKey] = nextToken;
+    index += 2;
+  }
+
+  return args;
+}
+
+module.exports = {
+  parseArgs,
+};

--- a/ops/scripts/deployment-bus.cjs
+++ b/ops/scripts/deployment-bus.cjs
@@ -3,6 +3,7 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
+const { parseArgs } = require("./cli-args.cjs");
 
 const SCHEMA_VERSION = "deployment-bus.v1";
 const SHA_RE = /^[0-9a-f]{40}$/i;
@@ -160,40 +161,6 @@ function createPlaywrightPack({
     }),
     artifacts: PLAYWRIGHT_ARTIFACT_PATTERNS,
   });
-}
-
-function parseArgs(argv) {
-  const args = { _: [] };
-  let index = 0;
-
-  while (index < argv.length) {
-    const token = argv[index];
-    if (!token.startsWith("--")) {
-      args._.push(token);
-      index += 1;
-      continue;
-    }
-
-    const rawKey = token.slice(2);
-    const eqIndex = rawKey.indexOf("=");
-    if (eqIndex !== -1) {
-      args[rawKey.slice(0, eqIndex)] = rawKey.slice(eqIndex + 1);
-      index += 1;
-      continue;
-    }
-
-    const nextToken = argv[index + 1];
-    if (!nextToken || nextToken.startsWith("--")) {
-      args[rawKey] = true;
-      index += 1;
-      continue;
-    }
-
-    args[rawKey] = nextToken;
-    index += 2;
-  }
-
-  return args;
 }
 
 function readJson(file) {

--- a/ops/scripts/deployment-bus.cjs
+++ b/ops/scripts/deployment-bus.cjs
@@ -10,7 +10,6 @@ const SHA256_RE = /^[0-9a-f]{64}$/i;
 const ETAG_RE = /^"?[0-9a-f]{32}(?:-\d+)?"?$/i;
 const CID_RE = /^(Qm[1-9A-HJ-NP-Za-km-z]{44}|b[a-z2-7]{20,})$/;
 const VALID_ENVIRONMENTS = new Set(["staging", "production"]);
-const DEPLOYED_ENVIRONMENTS = Object.freeze(["staging", "production"]);
 const REQUIRED_WEB_SURFACES = Object.freeze([
   "web:desktop-chromium",
   "web:mobile-chromium",
@@ -43,6 +42,13 @@ const VALIDATION_PACKS = Object.freeze({
       "PLAYWRIGHT_BASE_URL=https://staging.6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n:surface-matrix",
     productionCommand:
       "PLAYWRIGHT_BASE_URL=https://6529.io PLAYWRIGHT_SKIP_WEB_SERVER=1 seize run test:e2e:wcag-i18n:surface-matrix",
+  }),
+  "playwright:production-readonly": createPlaywrightPack({
+    id: "playwright:production-readonly",
+    description:
+      "Aggregate production-safe read-only pack across public high-value app workflows.",
+    productionCommand: "seize run test:e2e:production:readonly",
+    surfaces: ["web:desktop-chromium"],
   }),
 });
 const DEFAULT_REQUIRED_PACKS = Object.freeze([
@@ -135,13 +141,19 @@ function createPlaywrightPack({
   description,
   stagingCommand,
   productionCommand,
+  surfaces = REQUIRED_WEB_SURFACES,
 }) {
+  const environments = [
+    ...(stagingCommand ? ["staging"] : []),
+    ...(productionCommand ? ["production"] : []),
+  ];
+
   return Object.freeze({
     id,
     size: "large",
     description,
-    environments: DEPLOYED_ENVIRONMENTS,
-    surfaces: REQUIRED_WEB_SURFACES,
+    environments,
+    surfaces,
     commands: Object.freeze({
       staging: stagingCommand,
       production: productionCommand,
@@ -937,7 +949,12 @@ function validateCanaryReadiness(manifest, errors) {
 
 function validateValidationPlan(manifest, errors, warnings) {
   const validation = manifest.validation || {};
-  const requiredPacks = validateRequiredPacks(validation, errors, warnings);
+  const requiredPacks = validateRequiredPacks(
+    manifest,
+    validation,
+    errors,
+    warnings
+  );
   if (!requiredPacks) {
     return;
   }
@@ -957,7 +974,7 @@ function validateValidationPlan(manifest, errors, warnings) {
   addReadinessFindings(manifest, errors, warnings);
 }
 
-function validateRequiredPacks(validation, errors, warnings) {
+function validateRequiredPacks(manifest, validation, errors, warnings) {
   const requiredPacks = validation.required_packs;
   if (!Array.isArray(requiredPacks) || requiredPacks.length === 0) {
     pushError(
@@ -969,9 +986,16 @@ function validateRequiredPacks(validation, errors, warnings) {
   }
 
   for (const packId of requiredPacks) {
-    if (!VALIDATION_PACKS[packId]) {
+    const pack = VALIDATION_PACKS[packId];
+    if (!pack) {
       warnings.push(
         `validation.required_packs: ${packId} is not a standard frontend pack; record command and artifacts in validation.checks`
+      );
+    } else if (!pack.commands[manifest.environment]) {
+      pushError(
+        errors,
+        "validation.required_packs",
+        `${packId} has no standard command for ${manifest.environment}`
       );
     }
   }

--- a/ops/scripts/verify-deployment-version.cjs
+++ b/ops/scripts/verify-deployment-version.cjs
@@ -197,7 +197,7 @@ async function verifyDeploymentVersion(options) {
   const env = options.env || process.env;
   const fetchImpl = options.fetchImpl || globalThis.fetch;
   if (typeof fetchImpl !== "function") {
-    throw new Error("global fetch is not available");
+    throw new TypeError("global fetch is not available");
   }
 
   const expectedVersion = options.expectedVersion;

--- a/ops/scripts/verify-deployment-version.cjs
+++ b/ops/scripts/verify-deployment-version.cjs
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const SCHEMA_VERSION = "deployment-version-evidence.v1";
+const VERSION_ENDPOINT_PATH = "/api/version";
+const STAGING_HOSTNAME = "staging.6529.io";
+const STAGING_ACCESS_COOKIE_NAME = "x-6529-auth";
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  let index = 0;
+
+  while (index < argv.length) {
+    const token = argv[index];
+    if (!token.startsWith("--")) {
+      args._.push(token);
+      index += 1;
+      continue;
+    }
+
+    const rawKey = token.slice(2);
+    const eqIndex = rawKey.indexOf("=");
+    if (eqIndex !== -1) {
+      args[rawKey.slice(0, eqIndex)] = rawKey.slice(eqIndex + 1);
+      index += 1;
+      continue;
+    }
+
+    const nextToken = argv[index + 1];
+    if (!nextToken || nextToken.startsWith("--")) {
+      args[rawKey] = true;
+      index += 1;
+      continue;
+    }
+
+    args[rawKey] = nextToken;
+    index += 2;
+  }
+
+  return args;
+}
+
+function parsePositiveInteger(value, fallback, optionName) {
+  if (value === undefined || value === null || value === "") {
+    return fallback;
+  }
+
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${optionName} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function normalizeBaseUrl(rawBaseUrl) {
+  if (!rawBaseUrl) {
+    throw new Error("--base-url is required");
+  }
+
+  const parsed = new URL(rawBaseUrl);
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("--base-url must use http or https");
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error("--base-url must not include credentials");
+  }
+
+  return `${parsed.protocol}//${parsed.host}`;
+}
+
+function resolveVersionEndpoint(baseUrl) {
+  return new URL(VERSION_ENDPOINT_PATH, baseUrl).toString();
+}
+
+function getHeader(headers, name) {
+  if (!headers) {
+    return "";
+  }
+  if (typeof headers.get === "function") {
+    return headers.get(name) || "";
+  }
+  return headers[name] || headers[name.toLowerCase()] || "";
+}
+
+function getStagingAccessCode(env) {
+  return env.PLAYWRIGHT_STAGING_ACCESS_CODE || env.STAGING_AUTH || "";
+}
+
+function assertSafeCookieValue(value) {
+  if (/[\r\n;]/.test(value)) {
+    throw new Error(
+      "staging access code is not safe for an HTTP cookie header"
+    );
+  }
+}
+
+function buildRequestHeaders(endpointUrl, env) {
+  const headers = {
+    Accept: "application/json",
+    "Cache-Control": "no-cache",
+    Pragma: "no-cache",
+    "User-Agent": "6529-deployment-version-check/1",
+  };
+  const endpoint = new URL(endpointUrl);
+  const stagingAccessCode = getStagingAccessCode(env);
+
+  if (endpoint.hostname === STAGING_HOSTNAME && stagingAccessCode) {
+    assertSafeCookieValue(stagingAccessCode);
+    headers.Cookie = `${STAGING_ACCESS_COOKIE_NAME}=${stagingAccessCode}`;
+  }
+
+  return headers;
+}
+
+function sanitizeError(error) {
+  if (!error) {
+    return "unknown error";
+  }
+  if (error.name === "AbortError") {
+    return "request timed out";
+  }
+  return String(error.message || error).replace(/[\r\n]+/g, " ");
+}
+
+async function fetchVersion({ fetchImpl, endpointUrl, headers, timeoutMs }) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetchImpl(endpointUrl, {
+      method: "GET",
+      headers,
+      redirect: "manual",
+      signal: controller.signal,
+    });
+    const cacheControl = getHeader(response.headers, "cache-control");
+    let body;
+
+    try {
+      body = await response.json();
+    } catch {
+      body = null;
+    }
+
+    return {
+      status: response.status,
+      cacheControl,
+      body,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function buildEvidence({
+  baseUrl,
+  expectedVersion,
+  attempt,
+  maxAttempts,
+  startedAt,
+  checkedAt,
+  durationMs,
+  result,
+  error,
+}) {
+  const actualVersion =
+    typeof result?.body?.version === "string" ? result.body.version : null;
+  const cacheControl = result?.cacheControl || "";
+  const noStore = cacheControl.toLowerCase().includes("no-store");
+  const status = result?.status ?? null;
+  const matched =
+    status === 200 && noStore === true && actualVersion === expectedVersion;
+
+  return {
+    schema_version: SCHEMA_VERSION,
+    base_url: baseUrl,
+    endpoint_path: VERSION_ENDPOINT_PATH,
+    expected_version: expectedVersion,
+    actual_version: actualVersion,
+    matched,
+    status,
+    cache_control: cacheControl,
+    no_store: noStore,
+    attempt,
+    max_attempts: maxAttempts,
+    started_at: startedAt,
+    checked_at: checkedAt,
+    duration_ms: durationMs,
+    error: error ? sanitizeError(error) : null,
+  };
+}
+
+async function verifyDeploymentVersion(options) {
+  const env = options.env || process.env;
+  const fetchImpl = options.fetchImpl || globalThis.fetch;
+  if (typeof fetchImpl !== "function") {
+    throw new Error("global fetch is not available");
+  }
+
+  const expectedVersion = options.expectedVersion;
+  if (!expectedVersion || typeof expectedVersion !== "string") {
+    throw new Error("--expected-version is required");
+  }
+
+  const baseUrl = normalizeBaseUrl(options.baseUrl);
+  const endpointUrl = resolveVersionEndpoint(baseUrl);
+  const attempts = parsePositiveInteger(options.attempts, 8, "--attempts");
+  const delayMs = parsePositiveInteger(options.delayMs, 15000, "--delay-ms");
+  const timeoutMs = parsePositiveInteger(
+    options.timeoutMs,
+    10000,
+    "--timeout-ms"
+  );
+  const sleep =
+    options.sleep ||
+    ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const now = options.now || (() => new Date().toISOString());
+  const monotonicNow = options.monotonicNow || (() => Date.now());
+  const headers = buildRequestHeaders(endpointUrl, env);
+  const startedAt = now();
+  const startedMs = monotonicNow();
+  let evidence = null;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const result = await fetchVersion({
+        fetchImpl,
+        endpointUrl,
+        headers,
+        timeoutMs,
+      });
+      evidence = buildEvidence({
+        baseUrl,
+        expectedVersion,
+        attempt,
+        maxAttempts: attempts,
+        startedAt,
+        checkedAt: now(),
+        durationMs: monotonicNow() - startedMs,
+        result,
+      });
+    } catch (error) {
+      evidence = buildEvidence({
+        baseUrl,
+        expectedVersion,
+        attempt,
+        maxAttempts: attempts,
+        startedAt,
+        checkedAt: now(),
+        durationMs: monotonicNow() - startedMs,
+        error,
+      });
+    }
+
+    if (evidence.matched) {
+      return { ok: true, evidence };
+    }
+
+    if (attempt < attempts) {
+      await sleep(delayMs);
+    }
+  }
+
+  return { ok: false, evidence };
+}
+
+function writeEvidenceFile(output, evidence) {
+  if (!output) {
+    return;
+  }
+
+  const target = path.resolve(output);
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- Operator CLI writes evidence to an explicit workflow/local path.
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- Operator CLI writes evidence to an explicit workflow/local path.
+  fs.writeFileSync(target, `${JSON.stringify(evidence, null, 2)}\n`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const result = await verifyDeploymentVersion({
+    baseUrl: args["base-url"],
+    expectedVersion: args["expected-version"],
+    attempts: args.attempts,
+    delayMs: args["delay-ms"],
+    timeoutMs: args["timeout-ms"],
+  });
+
+  writeEvidenceFile(args.output, result.evidence);
+
+  if (result.ok) {
+    process.stdout.write(
+      `Deployment version verified at ${result.evidence.base_url}${result.evidence.endpoint_path}: ${result.evidence.actual_version}`
+    );
+    process.stdout.write("\n");
+    return;
+  }
+
+  console.error(
+    `Deployment version check failed at ${result.evidence.base_url}${result.evidence.endpoint_path}: expected ${result.evidence.expected_version}, got ${result.evidence.actual_version || "no version"}`
+  );
+  process.exitCode = 1;
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`Deployment version check failed: ${sanitizeError(error)}`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  SCHEMA_VERSION,
+  STAGING_ACCESS_COOKIE_NAME,
+  VERSION_ENDPOINT_PATH,
+  buildRequestHeaders,
+  normalizeBaseUrl,
+  resolveVersionEndpoint,
+  verifyDeploymentVersion,
+  writeEvidenceFile,
+};

--- a/ops/scripts/verify-deployment-version.cjs
+++ b/ops/scripts/verify-deployment-version.cjs
@@ -3,7 +3,7 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
-const { parseArgs } = require("./deployment-bus.cjs");
+const { parseArgs } = require("./cli-args.cjs");
 
 const SCHEMA_VERSION = "deployment-version-evidence.v1";
 const VERSION_ENDPOINT_PATH = "/api/version";

--- a/ops/scripts/verify-deployment-version.cjs
+++ b/ops/scripts/verify-deployment-version.cjs
@@ -3,45 +3,12 @@
 
 const fs = require("node:fs");
 const path = require("node:path");
+const { parseArgs } = require("./deployment-bus.cjs");
 
 const SCHEMA_VERSION = "deployment-version-evidence.v1";
 const VERSION_ENDPOINT_PATH = "/api/version";
 const STAGING_HOSTNAME = "staging.6529.io";
 const STAGING_ACCESS_COOKIE_NAME = "x-6529-auth";
-
-function parseArgs(argv) {
-  const args = { _: [] };
-  let index = 0;
-
-  while (index < argv.length) {
-    const token = argv[index];
-    if (!token.startsWith("--")) {
-      args._.push(token);
-      index += 1;
-      continue;
-    }
-
-    const rawKey = token.slice(2);
-    const eqIndex = rawKey.indexOf("=");
-    if (eqIndex !== -1) {
-      args[rawKey.slice(0, eqIndex)] = rawKey.slice(eqIndex + 1);
-      index += 1;
-      continue;
-    }
-
-    const nextToken = argv[index + 1];
-    if (!nextToken || nextToken.startsWith("--")) {
-      args[rawKey] = true;
-      index += 1;
-      continue;
-    }
-
-    args[rawKey] = nextToken;
-    index += 2;
-  }
-
-  return args;
-}
 
 function parsePositiveInteger(value, fallback, optionName) {
   if (value === undefined || value === null || value === "") {

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -4,6 +4,45 @@
 
 Read this section first after compaction or handoff.
 
+- Latest testing-roadmap state, 2026-06-22T08:32Z:
+  - PR #2822 is merged and deployed. Production is serving
+    `7693d1138987175e0ccd6c54841d7547d99ce322`, and the full production-safe
+    read-only aggregate passed again: `seize run test:e2e:production:readonly`
+    reported 65/65 passed.
+  - Current branch: `codex/deployment-evidence-verification`, based on current
+    `origin/main`.
+  - Active slice closes a deployment evidence gap:
+    - adds `ops/scripts/verify-deployment-version.cjs` and
+      `seize run verify:deployment-version` to GET `/api/version`, require
+      HTTP 200, `Cache-Control: no-store`, and exact expected SHA match, with
+      bounded retry and redacted `deployment-version-evidence.json` output.
+    - wires staging and production workflows to run the HTTP version check
+      before marking deploys verified and upload the evidence JSON beside the
+      deployment-bus manifest/report.
+    - records an `http-version-match` post-deploy-watch checkpoint when the
+      workflow probe passes.
+    - adds optional deployment-bus pack `playwright:production-readonly` for
+      the existing production aggregate. It is production-only,
+      desktop-Chromium only, and intentionally not in `DEFAULT_REQUIRED_PACKS`
+      until durable artifact upload/recording is automated.
+    - rejects known standard packs when required in an unsupported environment,
+      so `playwright:production-readonly` cannot silently become a null-command
+      staging requirement.
+  - Validation passed for this slice:
+    `node --check ops/scripts/verify-deployment-version.cjs`; focused ESLint on
+    deployment-bus/verifier files; `seize run test:no-coverage --
+__tests__/scripts/verify-deployment-version.test.ts
+__tests__/scripts/deployment-bus.test.ts
+__tests__/app/api/version/route.test.ts
+__tests__/hooks/useVersion.test.tsx` (51 tests); `lint:changed`;
+    `typecheck:changed`; risk-floor computed Level 5; changed secret scan;
+    workflow-security scan; live production version probe; live staging version
+    probe; `codex-diff-check`; and production aggregate E2E 65/65.
+  - Reviewer subagent `Kepler` is inspecting the final uncommitted diff. Wait
+    for it before committing/publishing.
+  - GLM reviewbot is live and remains additive. Do not remove, downgrade, or
+    replace existing Opus/general/WCAG/i18n/security/responsiveness reviewbot
+    lanes.
 - Latest testing-roadmap state, 2026-06-22T05:45Z:
   - PR #2819 is merged into `origin/main` as
     `174b2d054 Add search and wave read-only E2E coverage (#2819)`.
@@ -307,7 +346,7 @@ generated artifacts as the durable evidence store.
 
 ## Current Branch
 
-`codex/e2e-composer-sandbox`
+`codex/deployment-evidence-verification`
 
 ## Constraints
 
@@ -472,14 +511,24 @@ Re-audit each PR against current `origin/main` before merging or deploying it.
 
 ## Current Next Actions
 
-1. Publish the production read-only aggregate follow-up PR from
-   `codex/fix-production-collections-readonly`, iterate CI/reviewbots, merge,
-   and deploy because it updates release-validation controls.
-2. Keep `/notifications` out of staging/production read-only smoke until a
+1. Wait for reviewer subagent `Kepler` on the deployment evidence diff. Fix any
+   valid findings before PR publication.
+2. Commit, push, and open the `codex/deployment-evidence-verification` PR with
+   the Level 5 risk, workflow change, version probe, optional
+   `playwright:production-readonly` pack, validation evidence, and explicit note
+   that the pack remains additive/opt-in until durable artifact automation is
+   wired.
+3. Iterate CI, CodeRabbit, Opus reviewbot, GLM reviewbot, Sonar, Snyk, CodeQL,
+   and workflow checks until Codex judges the loop is no longer adding material
+   value.
+4. Merge and deploy this release-control PR through staging and production,
+   because it changes deployment workflows. Validate exact deployed SHAs and run
+   the production read-only aggregate after production.
+5. Keep `/notifications` out of staging/production read-only smoke until a
    disposable sandbox account/backend or product-safe non-mutating test path
    exists.
-3. Start the next high-value E2E pack after this PR: wallet/native/Electron
+6. Start the next high-value E2E pack after this PR: wallet/native/Electron
    shell coverage, deployment evidence/version verification, or the next
    guarded authenticated sandbox pack.
-4. Keep durable artifact storage as an infra follow-up; do not fake S3/IPFS
+7. Keep durable artifact storage as an infra follow-up; do not fake S3/IPFS
    artifact pointers or weaken release holds.

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -511,17 +511,19 @@ Re-audit each PR against current `origin/main` before merging or deploying it.
 
 ## Current Next Actions
 
-1. Wait for reviewer subagent `Kepler` on the deployment evidence diff. Fix any
-   valid findings before PR publication.
-2. Commit, push, and open the `codex/deployment-evidence-verification` PR with
-   the Level 5 risk, workflow change, version probe, optional
-   `playwright:production-readonly` pack, validation evidence, and explicit note
-   that the pack remains additive/opt-in until durable artifact automation is
-   wired.
-3. Iterate CI, CodeRabbit, Opus reviewbot, GLM reviewbot, Sonar, Snyk, CodeQL,
-   and workflow checks until Codex judges the loop is no longer adding material
-   value.
-4. Merge and deploy this release-control PR through staging and production,
+1. Continue PR #2823
+   (`codex/deployment-evidence-verification`) review/check iteration on head
+   `dba0a6c6cf05fae6f68a786554d6e5388b33aa99`.
+2. Wait for App PR CI, Dependency Governance, CodeQL, 6529bot follow-up, GLM
+   reviewbot if it posts on this repo, and any remaining installed-app checks to
+   reach terminal status. CodeRabbit is rate-limited on this PR; keep its
+   existing review signal, but do not treat rate limiting as a hard block unless
+   it later posts an actionable finding.
+3. Confirm the latest 6529bot follow-up has no new blocking findings. The prior
+   `874ccc35` finding was addressed by moving the shared parser into
+   `ops/scripts/cli-args.cjs` and adding a verifier CLI smoke test.
+4. Update the PR body validation notes if needed, then merge and deploy this
+   release-control PR through staging and production,
    because it changes deployment workflows. Validate exact deployed SHAs and run
    the production read-only aggregate after production.
 5. Keep `/notifications` out of staging/production read-only smoke until a

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -3147,3 +3147,31 @@ test-results/app-pr-ci/public-groups-tools-secret-scan.json`: clean.
   - `seize run test:e2e:production:readonly`: 65 passed.
 - Independent reviewer subagent `Kepler` is inspecting the final diff before
   commit/PR publication.
+
+## 2026-06-22T09:10Z PR #2823 Reviewbot Iteration
+
+- Opened PR #2823:
+  https://github.com/6529-Collections/6529seize-frontend/pull/2823
+- Sonar first reported two useful signals:
+  - `new Error()` should be a more specific `TypeError` for unavailable
+    `fetch`.
+  - new-code duplication exceeded the quality gate because the verifier copied
+    deployment-bus CLI argument parsing.
+- Addressed the `TypeError` finding in
+  `ops/scripts/verify-deployment-version.cjs`.
+- Addressed the duplication and 6529bot CLI-contract review by adding
+  `ops/scripts/cli-args.cjs`, importing it from both deployment CLIs, and adding
+  a no-network verifier CLI smoke test that proves the parser loads before the
+  script validates required options.
+- Validation for the parser-helper follow-up passed:
+  - `node --check ops/scripts/cli-args.cjs; node --check ops/scripts/deployment-bus.cjs; node --check ops/scripts/verify-deployment-version.cjs`
+  - `seize exec eslint --no-warn-ignored --max-warnings=0 ops/scripts/cli-args.cjs ops/scripts/verify-deployment-version.cjs ops/scripts/deployment-bus.cjs __tests__/scripts/verify-deployment-version.test.ts __tests__/scripts/deployment-bus.test.ts`
+  - `seize run test:no-coverage -- __tests__/scripts/verify-deployment-version.test.ts __tests__/scripts/deployment-bus.test.ts`: 2 suites, 47 tests passed.
+  - `seize run testing-strategy -- scan-changed-secrets --changed-from origin/main --output test-results/app-pr-ci/deployment-version-secret-scan-cli-helper-rerun.json`
+  - `seize run testing-strategy -- validate-workflow-security --changed-from origin/main --output test-results/app-pr-ci/deployment-version-workflow-security-cli-helper-rerun.json`
+  - `codex-diff-check`
+- Pushed head `dba0a6c6cf05fae6f68a786554d6e5388b33aa99`.
+- SonarCloud passed on the latest head with 0 new issues, 0 security hotspots,
+  and 0.0% new-code duplication.
+- As of this log entry, App PR CI, Dependency Governance, CodeQL, and latest
+  6529bot/GLM follow-up signals were still pending or queued.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -2560,9 +2560,9 @@ origin/main --output test-results/app-pr-ci/pr4-secret-scan-rebased.json`:
   - `seize run typecheck:changed`
   - `seize run typecheck:playwright`
   - `seize run testing-strategy -- scan-changed-secrets --changed-from
-     origin/main --output
-     test-results/app-pr-ci/network-open-data-secret-scan.json`
-   - `codex-diff-check`
+ origin/main --output
+ test-results/app-pr-ci/network-open-data-secret-scan.json`
+  - `codex-diff-check`
 
 ## 2026-06-21T23:59Z Network/Open Data Rebase Validation
 
@@ -2607,8 +2607,8 @@ origin/main --output test-results/app-pr-ci/pr4-secret-scan-rebased.json`:
     project.
   - `seize run typecheck:playwright`
   - `seize run testing-strategy -- scan-changed-secrets --changed-from
-    origin/main --output
-    test-results/app-pr-ci/collections-readonly-secret-scan.json`: clean.
+origin/main --output
+test-results/app-pr-ci/collections-readonly-secret-scan.json`: clean.
   - `codex-diff-check`
 
 ## 2026-06-21T20:02Z Collections Verifier Follow-Up
@@ -2639,9 +2639,9 @@ origin/main --output test-results/app-pr-ci/pr4-secret-scan-rebased.json`:
   - `seize run test:no-coverage -- __tests__/moreStaticPages.test.tsx`: 6
     passed.
   - `seize run test:no-coverage --findRelatedTests
-    components/6529Gradient/6529Gradient.tsx
-    tests/collections/nextgen-collections-readonly.spec.ts
-    --passWithNoTests`: 13 passed across 3 suites.
+components/6529Gradient/6529Gradient.tsx
+tests/collections/nextgen-collections-readonly.spec.ts
+--passWithNoTests`: 13 passed across 3 suites.
   - `seize run lint:changed`
   - `seize run typecheck:changed`: 1 changed TypeScript file passed.
   - `seize run typecheck:playwright`
@@ -2684,8 +2684,8 @@ origin/main --output test-results/app-pr-ci/pr4-secret-scan-rebased.json`:
   - `seize run lint:changed`
   - `seize run typecheck:changed`
   - `seize run testing-strategy -- scan-changed-secrets --changed-from
-    origin/main --output
-    test-results/app-pr-ci/public-groups-tools-secret-scan.json`: clean.
+origin/main --output
+test-results/app-pr-ci/public-groups-tools-secret-scan.json`: clean.
   - `codex-diff-check`
 
 ## 2026-06-21T21:07Z Public Content Read-Only Pack Started
@@ -2731,6 +2731,7 @@ origin/main --output test-results/app-pr-ci/pr4-secret-scan-rebased.json`:
   E2E pack passes after the overflow fix, so rerun
   `seize run test:e2e:production:public-content-readonly` only after this
   change is deployed.
+
 ## 2026-06-21T22:35Z Authenticated Shell E2E Pack Started
 
 - Started clean worktree branch `codex/e2e-authenticated-shells-readonly` from
@@ -3091,3 +3092,58 @@ origin/main --output test-results/app-pr-ci/pr4-secret-scan-rebased.json`:
   - Treat the staging result as an environment/API stability signal to track,
     not evidence that this title assertion or aggregate production script change
     regressed application runtime behavior.
+
+## 2026-06-22T08:32Z Deployment Evidence Verification Slice Started
+
+- PR #2822 merged and shipped before this slice. Production deploy run
+  #27938016895 succeeded from
+  `7693d1138987175e0ccd6c54841d7547d99ce322`, and production post-deploy
+  validation passed: `seize run test:e2e:production:readonly` reported 65/65.
+- Started branch `codex/deployment-evidence-verification` from current
+  `origin/main` for the next testing roadmap gap: release workflows verified
+  git checkout / Elastic Beanstalk labels, but did not prove the live HTTP app
+  served the expected `/api/version` SHA.
+- Added `ops/scripts/verify-deployment-version.cjs` and package script
+  `verify:deployment-version`.
+  - The verifier performs GET-only `/api/version` checks.
+  - It requires HTTP 200, `Cache-Control` containing `no-store`, and exact
+    expected-version match.
+  - It retries for bounded deploy-readiness lag.
+  - It writes sanitized `deployment-version-evidence.json` without request
+    headers, cookies, or raw response bodies.
+  - It only sends the staging access cookie to `staging.6529.io` when the
+    caller provides `PLAYWRIGHT_STAGING_ACCESS_CODE` or `STAGING_AUTH` as an
+    environment value.
+- Wired the staging and production deploy workflows to run the verifier before
+  marking the deployment terminal/verified, upload `deployment-version-evidence.json`,
+  and record an `http-version-match` post-deploy-watch checkpoint on success.
+- Added optional deployment-bus pack `playwright:production-readonly` for the
+  existing aggregate `seize run test:e2e:production:readonly`.
+  - It records `web:desktop-chromium` only, matching the production aggregate
+    command.
+  - It is not in `DEFAULT_REQUIRED_PACKS` and is not required by staging or
+    production workflows yet.
+  - Deployment-bus validation now rejects known standard packs required in an
+    environment where that pack has no standard command, preventing a
+    null-command staging requirement.
+- Updated deployment-bus docs and test README to document the HTTP version
+  probe, optional production-readonly pack semantics, and durable-evidence
+  limits.
+- Validation completed before PR publication:
+  - `node --check ops/scripts/verify-deployment-version.cjs`
+  - `seize exec prettier --write ops/scripts/verify-deployment-version.cjs`
+  - focused ESLint on verifier/deployment-bus files
+  - `seize run test:no-coverage -- __tests__/scripts/verify-deployment-version.test.ts __tests__/scripts/deployment-bus.test.ts __tests__/app/api/version/route.test.ts __tests__/hooks/useVersion.test.tsx`: 4 suites, 51 tests passed.
+  - `seize run lint:changed`
+  - `seize run typecheck:changed`
+  - `seize run testing-strategy -- compute-risk-floor --changed-from origin/main --json`: Level 5 due production workflow/deploy authority.
+  - `seize run testing-strategy -- scan-changed-secrets --changed-from origin/main --output test-results/app-pr-ci/deployment-version-secret-scan.json`
+  - `seize run testing-strategy -- validate-workflow-security --changed-from origin/main --output test-results/app-pr-ci/deployment-version-workflow-security.json`
+  - live production probe:
+    `seize run verify:deployment-version -- --base-url https://6529.io --expected-version 7693d1138987175e0ccd6c54841d7547d99ce322 --attempts 1 --delay-ms 1 --timeout-ms 10000 --output test-results/deployment-version-production-current.json`
+  - live staging probe against current `origin/1a-staging`
+    `7b094eb85737524d26c392d47847900ef9e116d8` passed with the same verifier.
+  - `codex-diff-check`
+  - `seize run test:e2e:production:readonly`: 65 passed.
+- Independent reviewer subagent `Kepler` is inspecting the final diff before
+  commit/PR publication.

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "react-doctor:diff": "node scripts/require-6529-command.cjs && node scripts/react-doctor-diff.cjs",
     "dependency:risk-gate": "node scripts/require-6529-command.cjs && node scripts/dependency-risk-gate.cjs",
     "deployment-bus": "node scripts/require-6529-command.cjs && node ops/scripts/deployment-bus.cjs",
+    "verify:deployment-version": "node scripts/require-6529-command.cjs && node ops/scripts/verify-deployment-version.cjs",
     "testing-strategy": "node scripts/require-6529-command.cjs && node ops/scripts/testing-strategy.cjs",
     "format": "node scripts/require-6529-command.cjs && prettier --write .",
     "format:check": "node scripts/require-6529-command.cjs && prettier --check .",

--- a/tests/README.md
+++ b/tests/README.md
@@ -166,7 +166,10 @@ Surface matrix:
   smoke.
 - `test:e2e:production:readonly` runs the full production-safe read-only pack
   family in one Playwright invocation so release validation fails fast and
-  returns one aggregate status.
+  returns one aggregate status. Deployment-bus manifests know this as the
+  optional production-only `playwright:production-readonly` pack; record that
+  pack only with redacted durable evidence and desktop Chromium surface
+  metadata.
 - `web-desktop-firefox` and `web-desktop-webkit` are browser-diversity
   projects for train, nightly, or targeted compatibility checks.
 - `capacitor-ios-sim`, `capacitor-android-sim`, and `electron-shell-sim` are
@@ -238,6 +241,12 @@ Large-pack ownership:
   files to staging or production. Treat it as coverage for composer/drop/upload
   API safety, not as a guarantee that every external read-only media or metadata
   endpoint is isolated.
+- `test:e2e:production:readonly` is owned by the release captain or validation
+  agent after a production deploy. It is a production-safe aggregate of the
+  individual public read-only packs and is the command behind the optional
+  deployment-bus pack `playwright:production-readonly`. Do not make it a
+  staging requirement unless a real staging aggregate command and evidence path
+  exist.
 - `test:e2e:browser-diversity` is a train/nightly compatibility pack. A PR
   owner should run it when changing browser-sensitive rendering, media,
   focus/keyboard behavior, or CSS layout primitives.


### PR DESCRIPTION
## Issue
- Deployment workflows verified staging git checkout and production Elastic Beanstalk labels, but did not prove the live HTTP app was serving the expected `/api/version` SHA.
- The production-safe read-only E2E aggregate existed as a script, but deployment-bus did not know how to record it as a named optional validation pack.

## Fix
- Added a GET-only deployed-version verifier that checks `/api/version` for HTTP 200, `Cache-Control: no-store`, and exact expected SHA match before deploy workflows mark the release verified.
- Added a shared CLI argument parser for ops scripts so the verifier and deployment-bus CLIs share parser behavior without cross-coupling.
- Added an optional production-only deployment-bus pack for `test:e2e:production:readonly`, while keeping default required packs unchanged until durable artifact upload/recording is automated.

## Changes
- Adds `ops/scripts/verify-deployment-version.cjs`, `ops/scripts/cli-args.cjs`, and `seize run verify:deployment-version`.
- Wires staging and production deploy workflows to run the HTTP version check and upload `deployment-version-evidence.json` with deployment-bus artifacts.
- Records an `http-version-match` post-deploy-watch checkpoint when the live HTTP version probe passes.
- Adds `playwright:production-readonly` as a known production-only, desktop-Chromium deployment-bus pack.
- Rejects known standard packs when required in an unsupported environment, preventing null-command staging requirements.
- Updates deployment-bus docs, test README, and workstream memory for the new evidence contract.

## Validation
- `node --check` for `ops/scripts/cli-args.cjs`, `ops/scripts/verify-deployment-version.cjs`, and `ops/scripts/deployment-bus.cjs`.
- Focused ESLint on verifier, deployment-bus, shared CLI parser, and related tests.
- `seize run test:no-coverage -- __tests__/scripts/verify-deployment-version.test.ts __tests__/scripts/deployment-bus.test.ts __tests__/app/api/version/route.test.ts __tests__/hooks/useVersion.test.tsx` (51 tests passed).
- Follow-up parser-contract validation: `seize run test:no-coverage -- __tests__/scripts/verify-deployment-version.test.ts __tests__/scripts/deployment-bus.test.ts` (47 tests passed).
- `seize run lint:changed`.
- `seize run typecheck:changed`.
- `seize run testing-strategy -- compute-risk-floor --changed-from origin/main --json` (Level 5).
- Changed-file secret scan and workflow-security validation passed.
- Live production version probe against the current deployed SHA passed.
- Live staging version probe against the current staging SHA passed.
- `seize run test:e2e:production:readonly` (65 passed).
- `codex-diff-check` passed.
- App PR CI, Dependency Governance, CodeQL, DCO, Snyk, SonarCloud, and CodeRabbit all pass on head `723baa72c8ee94c32aa90cbd84f0f28cc11a9309`.
- 6529bot/Opus follow-up review found no new findings after the shared-parser fix; manual CodeRabbit review generated no actionable comments.

## Risk
- Level: High / Level 5.
- Why: touches staging and production deployment workflows plus deployment-bus release controls. The verifier is GET-only, bounded-retry, and fails before terminal deploy verification when live HTTP version evidence is wrong.
- Rollback: revert this PR to remove the workflow version gate and optional pack metadata; app runtime behavior is otherwise unchanged.

## Review Notes
- Please focus on workflow ordering, secret handling for staging access, evidence redaction, retry bounds, and the opt-in semantics for `playwright:production-readonly`.
- The optional production-readonly pack is intentionally not in `DEFAULT_REQUIRED_PACKS` and is not required by staging.
- `origin/main` advanced after the initial PR base with unrelated Sentry/design-guidance changes and no overlapping deploy/test files; staging and production validation will run against the final merged `main` candidate.