### PR TITLE
[codex] Filter MetaMask update-url Sentry noise

### DIFF
--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -13,6 +13,8 @@ import {
 describe("sentry-client-filters", () => {
   const wrappedNetworkMessage =
     "Network request failed. Please check your connection and try again. (/api/waves-overview)";
+  const metaMaskCircularMetaElementMessage =
+    "Converting circular structure to JSON --> starting at object with constructor 'HTMLMetaElement' | property '__reactFiber$nkfb4ziusym' -> object with constructor 'ry' --- property 'stateNode' closes the circle";
 
   const buildSpan = (overrides: Record<string, unknown> = {}) =>
     ({
@@ -84,6 +86,35 @@ describe("sentry-client-filters", () => {
               arguments: [
                 "[WagmiSetup] Failed to install safe ethereum proxy Error:",
                 "Cannot set property ethereum of #<Window> which has only a getter",
+              ],
+            },
+          },
+        ],
+      },
+      ...overrides,
+    }) as any;
+
+  const createMetaMaskUpdateUrlCircularEvent = (
+    overrides: Record<string, unknown> = {}
+  ) =>
+    ({
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: metaMaskCircularMetaElementMessage,
+            stacktrace: {
+              frames: [
+                {
+                  filename: "<anonymous>",
+                  abs_path: "<anonymous>",
+                  function: "JSON.stringify",
+                },
+                {
+                  filename: "<anonymous>",
+                  abs_path: "<anonymous>",
+                  function: "__mm__updateUrl",
+                },
               ],
             },
           },
@@ -1840,6 +1871,111 @@ describe("sentry-client-filters", () => {
 
     // Assert
     expect(result).toBe(true);
+  });
+
+  it("filters MetaMask mobile update-url circular React meta element errors", () => {
+    // Arrange
+    const event = createMetaMaskUpdateUrlCircularEvent();
+
+    // Act
+    const result = shouldFilterInjectedWalletCollision(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("filters MetaMask mobile update-url circular errors from the original exception stack", () => {
+    // Arrange
+    const event = createMetaMaskUpdateUrlCircularEvent({
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: metaMaskCircularMetaElementMessage,
+          },
+        ],
+      },
+    });
+    const error = new TypeError(metaMaskCircularMetaElementMessage);
+    error.stack =
+      "TypeError: Converting circular structure to JSON\n    at JSON.stringify (<anonymous>:12:77)\n    at __mm__updateUrl (<anonymous>:36:7)";
+
+    // Act
+    const result = shouldFilterInjectedWalletCollision(event, {
+      originalException: error,
+    });
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("does not filter generic app circular JSON errors without MetaMask update-url frames", () => {
+    // Arrange
+    const event = createMetaMaskUpdateUrlCircularEvent({
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: metaMaskCircularMetaElementMessage,
+            stacktrace: {
+              frames: [
+                {
+                  filename: "https://6529.io/_next/static/chunks/app.js",
+                  abs_path: "https://6529.io/_next/static/chunks/app.js",
+                  function: "JSON.stringify",
+                },
+                {
+                  filename: "https://6529.io/_next/static/chunks/app.js",
+                  abs_path: "https://6529.io/_next/static/chunks/app.js",
+                  function: "serializeMetadata",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterInjectedWalletCollision(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter MetaMask update-url errors without the React meta element circular path", () => {
+    // Arrange
+    const event = createMetaMaskUpdateUrlCircularEvent({
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value:
+              "Converting circular structure to JSON --> starting at object with constructor 'Object'",
+            stacktrace: {
+              frames: [
+                {
+                  filename: "<anonymous>",
+                  abs_path: "<anonymous>",
+                  function: "JSON.stringify",
+                },
+                {
+                  filename: "<anonymous>",
+                  abs_path: "<anonymous>",
+                  function: "__mm__updateUrl",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterInjectedWalletCollision(event);
+
+    // Assert
+    expect(result).toBe(false);
   });
 
   it("does not filter injected wallet collisions when a web frame is present", () => {

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -1,6 +1,7 @@
 export type SentryStackFrame = {
   filename?: string | undefined;
   abs_path?: string | undefined;
+  function?: string | undefined;
 };
 
 export type SentryTransactionSpan = {
@@ -86,6 +87,14 @@ const walletCollisionPatterns = [
   "cannot assign to read only property 'ethereum'",
   'cannot assign to read only property "ethereum"',
   "cannot redefine property: ethereum",
+];
+const metaMaskMobileUpdateUrlFunction = "__mm__updateUrl";
+const jsonStringifyFunction = "JSON.stringify";
+const circularReactMetaElementMessagePatterns = [
+  "Converting circular structure to JSON",
+  "HTMLMetaElement",
+  "__reactFiber",
+  "stateNode",
 ];
 const noisyThirdPartyTelemetryTargets = new Set([
   "cca-lite.coinbase.com/amp",
@@ -1100,6 +1109,75 @@ function hasWalletCollisionSignature(
   );
 }
 
+function hasCircularReactMetaElementMessage(
+  event: SentryClientEvent,
+  hint?: SentryEventHint
+): boolean {
+  const value = event.exception?.values?.[0];
+  const candidates = [
+    value?.value,
+    getHintExceptionMessage(hint),
+    ...getBreadcrumbMessages(event),
+  ];
+
+  return candidates.some(
+    (candidate) =>
+      typeof candidate === "string" &&
+      circularReactMetaElementMessagePatterns.every((pattern) =>
+        candidate.includes(pattern)
+      )
+  );
+}
+
+function getStackSignatureValues(
+  frames: SentryStackFrame[] | undefined,
+  hint?: SentryEventHint
+): string[] {
+  const frameValues = Array.isArray(frames)
+    ? frames.flatMap((frame) => [
+        frame.function,
+        frame.filename,
+        frame.abs_path,
+      ])
+    : [];
+
+  return [...frameValues, getHintExceptionStack(hint)].filter(
+    (value): value is string => typeof value === "string" && value.length > 0
+  );
+}
+
+function hasMetaMaskUpdateUrlJsonStringifySignature(
+  frames: SentryStackFrame[] | undefined,
+  hint?: SentryEventHint
+): boolean {
+  const stackSignatureValues = getStackSignatureValues(frames, hint);
+  return (
+    stackSignatureValues.some((value) =>
+      value.includes(metaMaskMobileUpdateUrlFunction)
+    ) &&
+    stackSignatureValues.some((value) => value.includes(jsonStringifyFunction))
+  );
+}
+
+function hasMetaMaskMobileUpdateUrlCircularJsonSignature(
+  event: SentryClientEvent,
+  hint?: SentryEventHint
+): boolean {
+  const value = event.exception?.values?.[0];
+  if (value?.type !== "TypeError") {
+    return false;
+  }
+
+  if (!hasCircularReactMetaElementMessage(event, hint)) {
+    return false;
+  }
+
+  return hasMetaMaskUpdateUrlJsonStringifySignature(
+    value.stacktrace?.frames,
+    hint
+  );
+}
+
 function isTwitterBrowser(event: SentryClientEvent): boolean {
   const contextBrowserName = getContextString(event, "browser", "name");
   if (contextBrowserName === "Twitter") {
@@ -1147,6 +1225,10 @@ export function shouldFilterInjectedWalletCollision(
   event: SentryClientEvent,
   hint?: SentryEventHint
 ): boolean {
+  if (hasMetaMaskMobileUpdateUrlCircularJsonSignature(event, hint)) {
+    return true;
+  }
+
   const frames = event.exception?.values?.[0]?.stacktrace?.frames;
   if (!hasInjectedAppUriSignature(frames, hint)) {
     return false;


### PR DESCRIPTION
## Issue
- Sentry issue `6529-FRONTEND-CQ` reports `TypeError: Converting circular structure to JSON` from anonymous `JSON.stringify` / `__mm__updateUrl` frames.
- The sampled event is Chrome Mobile WebView on Android with `MetaMaskMobile` in the user agent, mechanism `auto.browser.browserapierrors.setTimeout`, and a circular path through `HTMLMetaElement.__reactFiber...stateNode`.

## Fix
- Extend the existing injected wallet client-side Sentry filter with a narrow MetaMask update-url signature.
- The new filter requires all of: `TypeError`, the circular JSON message with `HTMLMetaElement`, `__reactFiber`, and `stateNode`, plus stack evidence for both `JSON.stringify` and `__mm__updateUrl`.
- This keeps generic app circular-JSON errors reportable.

## Changes
- Added Sentry frame `function` support to the client filter type.
- Added focused predicate coverage for the `__mm__updateUrl` circular React meta element signature.
- Added negative tests for app circular JSON errors and non-React-meta MetaMask update-url errors.

## Validation
- Inspected Sentry issue `6529-FRONTEND-CQ` in the browser: representative/latest event shows Chrome Mobile WebView 149 on Android 16, `MetaMaskMobile` UA, route `/:user`, URL `/Saed`, top URL distribution `/waves/b6128077-ea78-4dd9-b381-52c4eadb2077`, production environment, release `f82890f24a4e`, stack `JSON.stringify` -> `__mm__updateUrl`, mechanism `auto.browser.browserapierrors.setTimeout`.
- `git diff --check` passed.
- Attempted `./bin/6529 run test:no-coverage -- __tests__/utils/sentry-client-filters.test.ts`, but this worktree has no installed dependencies: `cross-env: command not found` / `node_modules missing`.

## Risk
- Level: Low
- Why: Client-side Sentry filtering only; predicate is constrained to the MetaMask `__mm__updateUrl` circular React meta element signature.
- Rollback: Revert this PR to restore previous Sentry filtering behavior.

## Review Notes
- Please focus on whether the signature is narrow enough for Sentry noise without dropping real app circular-structure errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended test coverage for MetaMask mobile wallet integration error detection and handling scenarios

* **Bug Fixes**
  * Enhanced error filtering system to properly identify and handle specific MetaMask mobile wallet errors, reducing false positives and improving the accuracy of error reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->