### PR TITLE
[codex] Filter Coinbase WalletLink websocket 1006 noise

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -67,6 +67,34 @@ describe("instrumentation-client", () => {
     mockCaptureRouterTransitionStart.mockReset();
   });
 
+  it("drops Coinbase WalletLink websocket 1006 unhandled rejections", () => {
+    const beforeSend = loadBeforeSend();
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1006:",
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "node_modules/.pnpm/@coinbase+wallet-sdk@3.9.3/node_modules/@coinbase/wallet-sdk/dist/relay/walletlink/connection/WalletLinkWebSocket.js",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    const result = beforeSend(event, {
+      originalException: new Error("websocket error 1006:"),
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("drops sampled-out first-party browser transport network errors", () => {
     const beforeSend = loadBeforeSend();
     const event = {

--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -75,11 +75,16 @@ describe("instrumentation-client", () => {
           {
             type: "Error",
             value: "websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
             stacktrace: {
               frames: [
                 {
                   filename:
-                    "node_modules/.pnpm/@coinbase+wallet-sdk@3.9.3/node_modules/@coinbase/wallet-sdk/dist/relay/walletlink/connection/WalletLinkWebSocket.js",
+                    "https://dnclu2fna0b2b.cloudfront.net/_next/static/chunks/app/layout-123.js",
+                  function: "webSocket.onclose",
                 },
               ],
             },

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -1846,6 +1846,68 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
+  it("filters Coinbase WalletLink websocket 1006 close errors before source-map symbolication", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "https://dnclu2fna0b2b.cloudfront.net/_next/static/chunks/app/layout-123.js",
+                  function: "webSocket.onclose",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("filters pre-symbolication Coinbase WalletLink websocket 1006 close errors from the original exception stack", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+          },
+        ],
+      },
+    });
+    const error = new Error("websocket error 1006:");
+    error.stack =
+      "Error: websocket error 1006:\n    at webSocket.onclose (https://dnclu2fna0b2b.cloudfront.net/_next/static/chunks/app/layout-123.js:1:1)";
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event, {
+      originalException: error,
+    });
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
   it("filters Coinbase WalletLink websocket 1006 close errors from the original exception stack", () => {
     // Arrange
     const event = createCoinbaseWalletLinkWebSocketEvent({
@@ -1884,6 +1946,72 @@ describe("sentry-client-filters", () => {
                 {
                   filename: "services/websocket/WebSocketProvider.tsx",
                   abs_path: "services/websocket/WebSocketProvider.tsx",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter handled websocket 1006 errors from raw browser frames", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: true,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "https://dnclu2fna0b2b.cloudfront.net/_next/static/chunks/app/layout-123.js",
+                  function: "webSocket.onclose",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter raw browser websocket 1006 errors without the WalletLink close function", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "https://dnclu2fna0b2b.cloudfront.net/_next/static/chunks/app/layout-123.js",
+                  function: "onclose",
                 },
               ],
             },

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -4,6 +4,7 @@ import {
   getLowValueNetworkErrorTargetUrl,
   getNetworkErrorMessageTargetUrl,
   shouldFilterByFilenameExceptions,
+  shouldFilterCoinbaseWalletLinkWebSocket1006,
   shouldFilterInjectedWalletCollision,
   shouldFilterThirdPartyTelemetrySpan,
   shouldFilterTwitterConfigReferenceError,
@@ -84,6 +85,31 @@ describe("sentry-client-filters", () => {
               arguments: [
                 "[WagmiSetup] Failed to install safe ethereum proxy Error:",
                 "Cannot set property ethereum of #<Window> which has only a getter",
+              ],
+            },
+          },
+        ],
+      },
+      ...overrides,
+    }) as any;
+
+  const createCoinbaseWalletLinkWebSocketEvent = (
+    overrides: Record<string, unknown> = {}
+  ) =>
+    ({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1006:",
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "node_modules/.pnpm/@coinbase+wallet-sdk@3.9.3/node_modules/@coinbase/wallet-sdk/dist/relay/walletlink/connection/WalletLinkWebSocket.js",
+                  abs_path:
+                    "node_modules/.pnpm/@coinbase+wallet-sdk@3.9.3/node_modules/@coinbase/wallet-sdk/dist/relay/walletlink/connection/WalletLinkWebSocket.js",
+                },
               ],
             },
           },
@@ -1779,6 +1805,154 @@ describe("sentry-client-filters", () => {
 
     // Assert
     expect(result).toBe(true);
+  });
+
+  it("filters Coinbase WalletLink websocket 1006 close errors", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent();
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("filters Coinbase WalletLink websocket 1006 close errors from pnpm virtual-store paths", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1006:",
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "node_modules/.pnpm/@coinbase+wallet-sdk@3.9.3/dist/relay/walletlink/connection/WalletLinkWebSocket.js",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("filters Coinbase WalletLink websocket 1006 close errors from the original exception stack", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1006:",
+          },
+        ],
+      },
+    });
+    const error = new Error("websocket error 1006:");
+    error.stack =
+      "Error: websocket error 1006:\n    at webSocket.onclose (node_modules/.pnpm/@coinbase+wallet-sdk@3.9.3/node_modules/@coinbase/wallet-sdk/dist/relay/walletlink/connection/WalletLinkWebSocket.js:52:28)";
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event, {
+      originalException: error,
+    });
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("does not filter app-owned websocket 1006 errors", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1006:",
+            stacktrace: {
+              frames: [
+                {
+                  filename: "services/websocket/WebSocketProvider.tsx",
+                  abs_path: "services/websocket/WebSocketProvider.tsx",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter other Coinbase WalletLink websocket close codes", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1001: Going Away",
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "node_modules/.pnpm/@coinbase+wallet-sdk@3.9.3/node_modules/@coinbase/wallet-sdk/dist/relay/walletlink/connection/WalletLinkWebSocket.js",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter broader Coinbase SDK websocket errors", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1006:",
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "node_modules/.pnpm/@coinbase+wallet-sdk@3.9.3/node_modules/@coinbase/wallet-sdk/dist/relay/SomeOtherWebSocket.js",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
+
+    // Assert
+    expect(result).toBe(false);
   });
 
   it("filters injected wallet collisions when stack frames are empty", () => {

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -18,6 +18,7 @@ import {
   getNetworkErrorMessageTargetUrl,
   getThirdPartyTelemetrySpanTargetKey,
   shouldFilterByFilenameExceptions,
+  shouldFilterCoinbaseWalletLinkWebSocket1006,
   shouldFilterInjectedWalletCollision,
   shouldFilterThirdPartyTelemetrySpan,
   shouldFilterTwitterConfigReferenceError,
@@ -111,6 +112,10 @@ function shouldFilterEvent(
   }
 
   if (shouldFilterInjectedWalletCollision(event, hint)) {
+    return true;
+  }
+
+  if (shouldFilterCoinbaseWalletLinkWebSocket1006(event, hint)) {
     return true;
   }
 

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -87,6 +87,13 @@ const walletCollisionPatterns = [
   'cannot assign to read only property "ethereum"',
   "cannot redefine property: ethereum",
 ];
+const coinbaseWalletSdkPathTokens = [
+  "@coinbase/wallet-sdk",
+  "@coinbase+wallet-sdk",
+];
+const coinbaseWalletLinkWebSocketFile = "WalletLinkWebSocket.js";
+const coinbaseWalletLinkWebSocket1006Pattern =
+  /^websocket error 1006(?::.*)?$/i;
 const noisyThirdPartyTelemetryTargets = new Set([
   "cca-lite.coinbase.com/amp",
   "cca-lite.coinbase.com/metrics",
@@ -881,6 +888,37 @@ function getHintExceptionStack(hint?: SentryEventHint): string {
   return "";
 }
 
+function isCoinbaseWalletLinkWebSocket1006Message(value: string): boolean {
+  return coinbaseWalletLinkWebSocket1006Pattern.test(value.trim());
+}
+
+function isCoinbaseWalletLinkWebSocketPath(path: string | undefined): boolean {
+  return (
+    typeof path === "string" &&
+    path.includes(coinbaseWalletLinkWebSocketFile) &&
+    coinbaseWalletSdkPathTokens.some((token) => path.includes(token))
+  );
+}
+
+function hasCoinbaseWalletLinkWebSocketFrame(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  return (
+    Array.isArray(frames) &&
+    frames.some((frame) =>
+      [frame.filename, frame.abs_path].some(isCoinbaseWalletLinkWebSocketPath)
+    )
+  );
+}
+
+function hasCoinbaseWalletLinkWebSocketStack(hint?: SentryEventHint): boolean {
+  const stack = getHintExceptionStack(hint);
+  return (
+    stack.includes(coinbaseWalletLinkWebSocketFile) &&
+    coinbaseWalletSdkPathTokens.some((token) => stack.includes(token))
+  );
+}
+
 function matchesWalletCollisionPattern(value: string): boolean {
   const normalizedValue = value.toLowerCase();
   return walletCollisionPatterns.some((pattern) =>
@@ -1143,6 +1181,32 @@ export function shouldFilterTwitterConfigReferenceError(
   return hasOnlyAppUriFrames(value.stacktrace?.frames);
 }
 
+export function shouldFilterCoinbaseWalletLinkWebSocket1006(
+  event: SentryClientEvent,
+  hint?: SentryEventHint
+): boolean {
+  const value = event.exception?.values?.[0];
+  const messageCandidates = [
+    value?.value,
+    event.message,
+    getHintExceptionMessage(hint),
+  ];
+  const hasTargetMessage = messageCandidates.some(
+    (candidate) =>
+      typeof candidate === "string" &&
+      isCoinbaseWalletLinkWebSocket1006Message(candidate)
+  );
+
+  if (!hasTargetMessage) {
+    return false;
+  }
+
+  return (
+    hasCoinbaseWalletLinkWebSocketFrame(value?.stacktrace?.frames) ||
+    hasCoinbaseWalletLinkWebSocketStack(hint)
+  );
+}
+
 export function shouldFilterInjectedWalletCollision(
   event: SentryClientEvent,
   hint?: SentryEventHint
@@ -1162,5 +1226,8 @@ export const __testing = {
   isTwitterBrowser,
   matchesWalletCollisionPattern,
   noisyThirdPartyTelemetryTargets,
+  isCoinbaseWalletLinkWebSocket1006Message,
+  isCoinbaseWalletLinkWebSocketPath,
+  hasCoinbaseWalletLinkWebSocketFrame,
   shouldFilterThirdPartyTelemetrySpan,
 };

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -1,6 +1,7 @@
 export type SentryStackFrame = {
   filename?: string | undefined;
   abs_path?: string | undefined;
+  function?: string | undefined;
 };
 
 export type SentryTransactionSpan = {
@@ -35,6 +36,12 @@ type FailedBreadcrumbScanResult =
 type SentryExceptionValue = {
   type?: string | undefined;
   value?: string | undefined;
+  mechanism?:
+    | {
+        type?: string | undefined;
+        handled?: boolean | undefined;
+      }
+    | undefined;
   stacktrace?:
     | {
         frames?: SentryStackFrame[] | undefined;
@@ -92,6 +99,9 @@ const coinbaseWalletSdkPathTokens = [
   "@coinbase+wallet-sdk",
 ];
 const coinbaseWalletLinkWebSocketFile = "WalletLinkWebSocket.js";
+const coinbaseWalletLinkWebSocketCloseFunction = "webSocket.onclose";
+const browserUnhandledRejectionMechanism =
+  "auto.browser.global_handlers.onunhandledrejection";
 const coinbaseWalletLinkWebSocket1006Pattern =
   /^websocket error 1006(?::.*)?$/i;
 const noisyThirdPartyTelemetryTargets = new Set([
@@ -911,11 +921,42 @@ function hasCoinbaseWalletLinkWebSocketFrame(
   );
 }
 
+function hasCoinbaseWalletLinkWebSocketCloseFunction(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  return (
+    Array.isArray(frames) &&
+    frames.some(
+      (frame) => frame.function === coinbaseWalletLinkWebSocketCloseFunction
+    )
+  );
+}
+
 function hasCoinbaseWalletLinkWebSocketStack(hint?: SentryEventHint): boolean {
   const stack = getHintExceptionStack(hint);
   return (
     stack.includes(coinbaseWalletLinkWebSocketFile) &&
     coinbaseWalletSdkPathTokens.some((token) => stack.includes(token))
+  );
+}
+
+function hasCoinbaseWalletLinkWebSocketCloseStack(
+  hint?: SentryEventHint
+): boolean {
+  return getHintExceptionStack(hint).includes(
+    coinbaseWalletLinkWebSocketCloseFunction
+  );
+}
+
+function hasWalletLinkWebSocketUnhandledRejectionSignature(
+  value: SentryExceptionValue | undefined,
+  hint?: SentryEventHint
+): boolean {
+  return (
+    value?.mechanism?.type === browserUnhandledRejectionMechanism &&
+    value.mechanism.handled === false &&
+    (hasCoinbaseWalletLinkWebSocketCloseFunction(value.stacktrace?.frames) ||
+      hasCoinbaseWalletLinkWebSocketCloseStack(hint))
   );
 }
 
@@ -1203,7 +1244,8 @@ export function shouldFilterCoinbaseWalletLinkWebSocket1006(
 
   return (
     hasCoinbaseWalletLinkWebSocketFrame(value?.stacktrace?.frames) ||
-    hasCoinbaseWalletLinkWebSocketStack(hint)
+    hasCoinbaseWalletLinkWebSocketStack(hint) ||
+    hasWalletLinkWebSocketUnhandledRejectionSignature(value, hint)
   );
 }
 
@@ -1229,5 +1271,7 @@ export const __testing = {
   isCoinbaseWalletLinkWebSocket1006Message,
   isCoinbaseWalletLinkWebSocketPath,
   hasCoinbaseWalletLinkWebSocketFrame,
+  hasCoinbaseWalletLinkWebSocketCloseFunction,
+  hasCoinbaseWalletLinkWebSocketCloseStack,
   shouldFilterThirdPartyTelemetrySpan,
 };


### PR DESCRIPTION
## Issue
- Sentry issue 6529-FRONTEND-N is a high-frequency client error from Coinbase Wallet SDK WalletLink websocket close code 1006.
- The inspected representative event is an unhandled browser promise rejection from `@coinbase/wallet-sdk` `WalletLinkWebSocket.js`, mostly on Mobile Safari UI/WKWebView, not app-owned websocket code.

## Fix
- Add a narrow client `beforeSend` filter for Coinbase WalletLink websocket 1006 close errors.
- The filter requires the exact `websocket error 1006` message plus either a symbolicated Coinbase WalletLink websocket frame, an original exception stack with that frame, or pre-symbolication browser signals from the unhandled-rejection mechanism and `webSocket.onclose` frame/stack function.
- Other close codes, handled errors, and app-owned websocket errors remain reportable.

## Changes
- Wire the new predicate into `instrumentation-client.ts` before generic stack filtering.
- Add utility tests for Coinbase WalletLink 1006 matching, pnpm virtual-store paths, original exception stacks, raw pre-symbolication frames/stacks, app-owned 1006 errors, handled 1006 errors, other close codes, and broader Coinbase SDK frames.
- Add an integration test for the actual `beforeSend` drop path using raw browser-frame data.

## Validation
- Passed: `git diff --check`
- Passed before the follow-up commit: `6529 run lint:changed`
- Blocked after the follow-up commit: `6529 run lint:changed` because this worktree has no installed dependencies (`eslint` was not found).
- Blocked locally: `6529 run test -- __tests__/utils/sentry-client-filters.test.ts __tests__/instrumentation-client.test.ts` because this worktree has no installed dependencies (`cross-env` was not found).
- Blocked locally: `6529 run typecheck:changed` because this worktree has no installed dependencies (`typescript` was not found).

## Risk
- Level: Low
- Why: client-side Sentry filtering only; matching is constrained to Coinbase WalletLink websocket 1006 signatures and preserves unrelated websocket errors.
- Rollback: revert this PR to restore full reporting.

## Review Notes
- The second commit addresses Codex review feedback that client `beforeSend` runs before Sentry source-map symbolication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added filtering for Coinbase WalletLink WebSocket error code 1006 exceptions in error reporting to reduce noise and improve error tracking signal quality.

* **Tests**
  * Added comprehensive test cases for the new WebSocket 1006 error filtering, covering multiple scenarios including matching patterns, edge cases, and non-matching events to ensure accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->