### PR TITLE
Retry pending drop media images

### DIFF
--- a/__tests__/components/waves/drops/WaveDropPartContentMediaImage.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropPartContentMediaImage.test.tsx
@@ -55,6 +55,18 @@ afterEach(() => {
   jest.useRealTimers();
 });
 
+const failCurrentImageThroughFallback = async () => {
+  fireEvent.error(screen.getByAltText("Drop media"));
+
+  await waitFor(() => {
+    expect(screen.getByAltText("Drop media").getAttribute("src")).not.toContain(
+      "scale=auto"
+    );
+  });
+
+  fireEvent.error(screen.getByAltText("Drop media"));
+};
+
 describe("WaveDropPartContentMediaImage", () => {
   it("fills a reserved-height media container without natural aspect sizing", () => {
     const { container } = render(
@@ -119,15 +131,7 @@ describe("WaveDropPartContentMediaImage", () => {
       "https://example.com/path/image.png?scale=auto"
     );
 
-    fireEvent.error(image);
-    await waitFor(() => {
-      expect(image).toHaveAttribute(
-        "src",
-        "https://example.com/path/image.png"
-      );
-    });
-
-    fireEvent.error(image);
+    await failCurrentImageThroughFallback();
 
     expect(screen.getByText("Processing image")).toBeInTheDocument();
     expect(screen.queryByText("Couldn’t load image.")).not.toBeInTheDocument();
@@ -140,6 +144,45 @@ describe("WaveDropPartContentMediaImage", () => {
       expect(screen.getByAltText("Drop media")).toHaveAttribute(
         "src",
         "https://example.com/path/image.png?scale=auto&drop_media_retry=1"
+      );
+    });
+  });
+
+  it("shows manual retry after auto-retries are exhausted", async () => {
+    jest.useFakeTimers();
+
+    render(
+      <WaveDropPartContentMediaImage src="https://example.com/path/image.png" />
+    );
+
+    for (let retryAttempt = 1; retryAttempt <= 40; retryAttempt++) {
+      await failCurrentImageThroughFallback();
+
+      expect(screen.getByText("Processing image")).toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(1500);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByAltText("Drop media")).toHaveAttribute(
+          "src",
+          `https://example.com/path/image.png?scale=auto&drop_media_retry=${retryAttempt}`
+        );
+      });
+    }
+
+    await failCurrentImageThroughFallback();
+
+    expect(screen.getByText("Couldn’t load image.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(screen.getByAltText("Drop media")).toHaveAttribute(
+        "src",
+        "https://example.com/path/image.png?scale=auto&drop_media_retry=41"
       );
     });
   });

--- a/__tests__/components/waves/drops/WaveDropPartContentMediaImage.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropPartContentMediaImage.test.tsx
@@ -1,9 +1,31 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { forwardRef, type ComponentProps } from "react";
 import WaveDropPartContentMediaImage from "@/components/waves/drops/WaveDropPartContentMediaImage";
 import useCapacitor from "@/hooks/useCapacitor";
 
+type MockNextImageProps = ComponentProps<"img"> & {
+  readonly fill?: boolean | undefined;
+  readonly unoptimized?: boolean | undefined;
+};
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: forwardRef<HTMLImageElement, MockNextImageProps>(
+    // eslint-disable-next-line react/display-name
+    ({ fill: _fill, unoptimized: _unoptimized, alt, ...rest }, ref) => (
+      <img ref={ref} alt={alt ?? ""} {...rest} />
+    )
+  ),
+}));
+
 jest.mock("@/helpers/image.helpers", () => ({
-  getScaledImageUri: (_src: string) => _src,
+  getScaledImageUri: (_src: string) => `${_src}?scale=auto`,
   ImageScale: { AUTOx450: "AUTOx450", AUTOx1080: "AUTOx1080" },
 }));
 
@@ -27,6 +49,10 @@ beforeEach(() => {
       return undefined;
     }
   };
+});
+
+afterEach(() => {
+  jest.useRealTimers();
 });
 
 describe("WaveDropPartContentMediaImage", () => {
@@ -55,7 +81,7 @@ describe("WaveDropPartContentMediaImage", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /open drop media/i }));
     expect(screen.getByAltText("Full size drop media")).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /close modal/i }));
+    fireEvent.click(screen.getByTestId("modal-backdrop"));
     expect(
       screen.queryByAltText("Full size drop media")
     ).not.toBeInTheDocument();
@@ -78,5 +104,43 @@ describe("WaveDropPartContentMediaImage", () => {
     ).not.toBeInTheDocument();
 
     expect(requestFullscreen).not.toHaveBeenCalled();
+  });
+
+  it("auto-retries transient image load failures before showing manual retry", async () => {
+    jest.useFakeTimers();
+
+    render(
+      <WaveDropPartContentMediaImage src="https://example.com/path/image.png" />
+    );
+
+    const image = screen.getByAltText("Drop media");
+    expect(image).toHaveAttribute(
+      "src",
+      "https://example.com/path/image.png?scale=auto"
+    );
+
+    fireEvent.error(image);
+    await waitFor(() => {
+      expect(image).toHaveAttribute(
+        "src",
+        "https://example.com/path/image.png"
+      );
+    });
+
+    fireEvent.error(image);
+
+    expect(screen.getByText("Processing image")).toBeInTheDocument();
+    expect(screen.queryByText("Couldn’t load image.")).not.toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByAltText("Drop media")).toHaveAttribute(
+        "src",
+        "https://example.com/path/image.png?scale=auto&drop_media_retry=1"
+      );
+    });
   });
 });

--- a/components/waves/drops/WaveDropPartContentMediaImage.tsx
+++ b/components/waves/drops/WaveDropPartContentMediaImage.tsx
@@ -49,13 +49,15 @@ function ImageProcessingRetryState() {
 function ImageLoadErrorState({ onRetry }: { readonly onRetry: () => void }) {
   return (
     <div className="tw-flex tw-h-full tw-min-h-40 tw-w-full tw-flex-col tw-items-center tw-justify-center tw-gap-2 tw-px-4 tw-py-8">
-      <span className="tw-text-sm tw-text-iron-400">Couldn’t load image.</span>
+      <span className="tw-text-sm tw-text-iron-400">
+        {t(DEFAULT_LOCALE, "drop.media.loadFailed")}
+      </span>
       <button
         type="button"
         onClick={onRetry}
         className="tw-rounded-md tw-bg-iron-700 tw-px-3 tw-py-1 tw-text-xs tw-text-white hover:tw-bg-iron-600"
       >
-        Retry
+        {t(DEFAULT_LOCALE, "drop.media.retry")}
       </button>
     </div>
   );

--- a/components/waves/drops/WaveDropPartContentMediaImage.tsx
+++ b/components/waves/drops/WaveDropPartContentMediaImage.tsx
@@ -10,7 +10,56 @@ import { useMediaActions } from "@/components/drops/view/item/content/media/useM
 import { useDropImageGallery } from "@/components/drops/view/part/DropImageGalleryProvider";
 import { getScaledImageUri, ImageScale } from "@/helpers/image.helpers";
 import useCapacitor from "@/hooks/useCapacitor";
-import React, { useCallback, useRef, useState } from "react";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+const AUTO_RETRY_DELAY_MS = 1500;
+const MAX_AUTO_RETRY_ATTEMPTS = 40;
+const IMAGE_RETRY_QUERY_PARAM = "drop_media_retry";
+
+function withRetryCacheBust(src: string, retryTick: number): string {
+  if (retryTick === 0) {
+    return src;
+  }
+
+  try {
+    const url = new URL(src);
+    url.searchParams.set(IMAGE_RETRY_QUERY_PARAM, String(retryTick));
+    return url.toString();
+  } catch {
+    const separator = src.includes("?") ? "&" : "?";
+    return `${src}${separator}${IMAGE_RETRY_QUERY_PARAM}=${retryTick}`;
+  }
+}
+
+function ImageProcessingRetryState() {
+  return (
+    <div
+      className="tw-flex tw-h-full tw-min-h-40 tw-w-full tw-items-center tw-justify-center tw-px-4 tw-py-8"
+      aria-live="polite"
+    >
+      <span className="tw-text-sm tw-text-iron-400">
+        {t(DEFAULT_LOCALE, "drop.media.processing")}
+      </span>
+    </div>
+  );
+}
+
+function ImageLoadErrorState({ onRetry }: { readonly onRetry: () => void }) {
+  return (
+    <div className="tw-flex tw-h-full tw-min-h-40 tw-w-full tw-flex-col tw-items-center tw-justify-center tw-gap-2 tw-px-4 tw-py-8">
+      <span className="tw-text-sm tw-text-iron-400">Couldn’t load image.</span>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="tw-rounded-md tw-bg-iron-700 tw-px-3 tw-py-1 tw-text-xs tw-text-white hover:tw-bg-iron-600"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
 
 function NaturalHeightImage({
   imgRef,
@@ -106,22 +155,40 @@ function FillContainerImage({
   );
 }
 
-export default function WaveDropPartContentMediaImage({
-  src,
-  imageScale = ImageScale.AUTOx450,
-  imageObjectPosition = "center",
-  galleryItemId,
-  fillContainer = false,
-}: {
+type WaveDropPartContentMediaImageProps = {
   readonly src: string;
   readonly imageScale?: ImageScale | undefined;
   readonly imageObjectPosition?: string | undefined;
   readonly galleryItemId?: string | undefined;
   readonly fillContainer?: boolean | undefined;
-}) {
+};
+
+export default function WaveDropPartContentMediaImage({
+  src,
+  imageScale = ImageScale.AUTOx450,
+  ...props
+}: WaveDropPartContentMediaImageProps) {
+  return (
+    <WaveDropPartContentMediaImageContent
+      key={`${src}:${imageScale}`}
+      src={src}
+      imageScale={imageScale}
+      {...props}
+    />
+  );
+}
+
+function WaveDropPartContentMediaImageContent({
+  src,
+  imageScale,
+  imageObjectPosition = "center",
+  galleryItemId,
+  fillContainer = false,
+}: WaveDropPartContentMediaImageProps & { readonly imageScale: ImageScale }) {
   const [loaded, setLoaded] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [errorCount, setErrorCount] = useState(0);
+  const [failedAttempts, setFailedAttempts] = useState(0);
+  const [retryPending, setRetryPending] = useState(false);
   const [retryTick, setRetryTick] = useState(0);
   const { isCapacitor } = useCapacitor();
   const imageGallery = useDropImageGallery();
@@ -137,17 +204,40 @@ export default function WaveDropPartContentMediaImage({
 
   const handleImageLoad = useCallback(() => {
     setLoaded(true);
+    setFailedAttempts(0);
+    setRetryPending(false);
   }, []);
 
   const handleError = useCallback(() => {
-    setErrorCount(1);
+    setLoaded(false);
+    setFailedAttempts((currentAttempts) => {
+      const nextAttempts = currentAttempts + 1;
+      if (nextAttempts <= MAX_AUTO_RETRY_ATTEMPTS) {
+        setRetryPending(true);
+      }
+      return nextAttempts;
+    });
   }, []);
 
   const manualRetry = useCallback(() => {
     setLoaded(false);
-    setErrorCount(0);
+    setFailedAttempts(0);
+    setRetryPending(false);
     setRetryTick((currentTick) => currentTick + 1);
   }, []);
+
+  useEffect(() => {
+    if (!retryPending) {
+      return;
+    }
+
+    const retryTimeout = window.setTimeout(() => {
+      setRetryPending(false);
+      setRetryTick((currentTick) => currentTick + 1);
+    }, AUTO_RETRY_DELAY_MS);
+
+    return () => window.clearTimeout(retryTimeout);
+  }, [retryPending]);
 
   const handleOpenModal = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -172,30 +262,25 @@ export default function WaveDropPartContentMediaImage({
     }
   }, []);
 
-  if (errorCount > 0) {
-    return (
-      <div className="tw-flex tw-flex-col tw-items-center tw-justify-center tw-gap-2 tw-px-4 tw-py-8">
-        <span className="tw-text-sm tw-text-iron-400">
-          Couldn’t load image.
-        </span>
-        <button
-          type="button"
-          onClick={manualRetry}
-          className="tw-rounded-md tw-bg-iron-700 tw-px-3 tw-py-1 tw-text-xs tw-text-white hover:tw-bg-iron-600"
-        >
-          Retry
-        </button>
-      </div>
-    );
+  if (failedAttempts > MAX_AUTO_RETRY_ATTEMPTS) {
+    return <ImageLoadErrorState onRetry={manualRetry} />;
   }
 
-  const primarySrc = getScaledImageUri(src, imageScale);
+  if (retryPending) {
+    return <ImageProcessingRetryState />;
+  }
+
+  const primarySrc = withRetryCacheBust(
+    getScaledImageUri(src, imageScale),
+    retryTick
+  );
+  const fallbackSrc = withRetryCacheBust(src, retryTick);
   const image = fillContainer ? (
     <FillContainerImage
       key={retryTick}
       imgRef={imgRef}
       primarySrc={primarySrc}
-      fallbackSrc={src}
+      fallbackSrc={fallbackSrc}
       retryTick={retryTick}
       onLoad={handleImageLoad}
       onFinalError={handleError}
@@ -206,7 +291,7 @@ export default function WaveDropPartContentMediaImage({
       key={retryTick}
       imgRef={imgRef}
       primarySrc={primarySrc}
-      fallbackSrc={src}
+      fallbackSrc={fallbackSrc}
       retryTick={retryTick}
       onLoad={handleImageLoad}
       onFinalError={handleError}

--- a/components/waves/drops/WaveDropPartContentMediaImage.tsx
+++ b/components/waves/drops/WaveDropPartContentMediaImage.tsx
@@ -16,6 +16,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 
 const AUTO_RETRY_DELAY_MS = 1500;
 const MAX_AUTO_RETRY_ATTEMPTS = 40;
+const MAX_FAILED_LOAD_ATTEMPTS = MAX_AUTO_RETRY_ATTEMPTS + 1;
 const IMAGE_RETRY_QUERY_PARAM = "drop_media_retry";
 
 function withRetryCacheBust(src: string, retryTick: number): string {
@@ -264,7 +265,7 @@ function WaveDropPartContentMediaImageContent({
     }
   }, []);
 
-  if (failedAttempts > MAX_AUTO_RETRY_ATTEMPTS) {
+  if (failedAttempts >= MAX_FAILED_LOAD_ATTEMPTS) {
     return <ImageLoadErrorState onRetry={manualRetry} />;
   }
 

--- a/i18n/messages/de-DE.ts
+++ b/i18n/messages/de-DE.ts
@@ -19,6 +19,8 @@ export const DE_DE_MESSAGES = {
   "profileCms.interactive.exitFullscreen": "Vollbild beenden",
   "drop.media.processing": "Bild wird verarbeitet",
   "drop.media.unavailable": "Bild nicht verfuegbar",
+  "drop.media.loadFailed": "Bild konnte nicht geladen werden.",
+  "drop.media.retry": "Erneut versuchen",
   "drop.media.processingFailed": "Bildverarbeitung fehlgeschlagen.",
   "drop.media.processingTimedOut": "Zeitlimit fuer Bildverarbeitung erreicht.",
   ...DE_DE_NEW_VERSION_TOAST_MESSAGES,

--- a/i18n/messages/en-GB.ts
+++ b/i18n/messages/en-GB.ts
@@ -19,6 +19,8 @@ export const EN_GB_MESSAGES = {
   "profileCms.interactive.exitFullscreen": "Exit full screen",
   "drop.media.processing": "Processing image",
   "drop.media.unavailable": "Image unavailable",
+  "drop.media.loadFailed": "Couldn’t load image.",
+  "drop.media.retry": "Retry",
   "drop.media.processingFailed": "Image processing failed.",
   "drop.media.processingTimedOut": "Image processing timed out.",
   ...EN_GB_NEW_VERSION_TOAST_MESSAGES,

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -990,6 +990,8 @@ export const EN_US_MESSAGES = {
   "user.collected.networkCards.xtdhPerDay": "xTDH/day",
   "drop.media.processing": "Processing image",
   "drop.media.unavailable": "Image unavailable",
+  "drop.media.loadFailed": "Couldn’t load image.",
+  "drop.media.retry": "Retry",
   "drop.media.processingFailed": "Image processing failed.",
   "drop.media.processingTimedOut": "Image processing timed out.",
   ...USER_PROFILE_TABS_MESSAGES,

--- a/i18n/messages/es-ES.ts
+++ b/i18n/messages/es-ES.ts
@@ -19,6 +19,8 @@ export const ES_ES_MESSAGES = {
   "profileCms.interactive.exitFullscreen": "Salir de pantalla completa",
   "drop.media.processing": "Procesando imagen",
   "drop.media.unavailable": "Imagen no disponible",
+  "drop.media.loadFailed": "No se pudo cargar la imagen.",
+  "drop.media.retry": "Reintentar",
   "drop.media.processingFailed": "El procesamiento de la imagen fallo.",
   "drop.media.processingTimedOut": "El procesamiento de la imagen expiro.",
   ...ES_ES_NEW_VERSION_TOAST_MESSAGES,

--- a/i18n/messages/fr-FR.ts
+++ b/i18n/messages/fr-FR.ts
@@ -20,6 +20,8 @@ export const FR_FR_MESSAGES = {
   "profileCms.interactive.exitFullscreen": "Quitter le plein ecran",
   "drop.media.processing": "Image en cours de traitement",
   "drop.media.unavailable": "Image indisponible",
+  "drop.media.loadFailed": "Impossible de charger l'image.",
+  "drop.media.retry": "Reessayer",
   "drop.media.processingFailed": "Le traitement de l'image a echoue.",
   "drop.media.processingTimedOut": "Le traitement de l'image a expire.",
   ...FR_FR_NEW_VERSION_TOAST_MESSAGES,


### PR DESCRIPTION
## Issue
- Newly sanitized drop images can be posted before the sanitized public object or resized derivative is immediately reachable.
- The drop image renderer treated the first scaled/full-size load failure as terminal, showing “Couldn’t load image” until a page refresh remounted the component.

## Fix
- Keep the existing async media UX by showing the localized processing state after a transient image load failure.
- Automatically retry the scaled image URL with a cache-busting query parameter for a bounded window before falling back to the manual retry button.

## Changes
- Adds bounded retry/cache-busting behavior to the wave drop image renderer.
- Resets image retry state through a keyed wrapper when the image source or scale changes.
- Adds coverage for primary failure, fallback failure, processing state, and retry URL behavior.

## Validation
- `./bin/6529 run test -- __tests__/components/waves/drops/WaveDropPartContentMediaImage.test.tsx`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` scanned the changed files before commit; it reported warnings only for the test image mock and existing related image state.
- `./bin/6529 run check:changed` ran formatting/lint/typecheck but failed on existing repo-wide Knip dead-code findings unrelated to this patch.

## Risk
- Level: Low
- Why: Scoped to drop image load error recovery; it does not change upload or backend status behavior.
- Rollback: Revert the frontend commit to restore the previous immediate error state.

## Review Notes
- Please focus on the retry window, cache-busting behavior, and whether the temporary processing state fits the async sanitizer flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Images now automatically retry loading on failures before showing an error message
  * Added processing indicator during retry attempts with cache-busting between retries

* **Tests**
  * Updated test suite for improved image mocking and new retry behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->