### PR TITLE
Harden production read-only E2E guard

### DIFF
--- a/__tests__/playwright/readonlyMutationGuard.test.ts
+++ b/__tests__/playwright/readonlyMutationGuard.test.ts
@@ -496,6 +496,64 @@ describe("Playwright read-only mutation guard", () => {
     }
   });
 
+  it("allows only read-only public Ethereum RPC POSTs", () => {
+    for (const url of [
+      "https://eth.llamarpc.com/",
+      "https://cloudflare-eth.com/",
+      "https://ethereum-rpc.publicnode.com/",
+    ]) {
+      expect(
+        decideReadonlyRequest({
+          baseURL: "https://6529.io",
+          method: "POST",
+          postData: JSON.stringify([
+            { id: 1, jsonrpc: "2.0", method: "eth_chainId" },
+            { id: 2, jsonrpc: "2.0", method: "eth_call" },
+          ]),
+          readonly: true,
+          url,
+        })
+      ).toMatchObject({
+        action: "allow",
+        reason: "read-only-ethereum-rpc",
+      });
+
+      expect(
+        decideReadonlyRequest({
+          baseURL: "https://6529.io",
+          method: "POST",
+          postData: JSON.stringify({
+            id: 1,
+            jsonrpc: "2.0",
+            method: "eth_sendRawTransaction",
+          }),
+          readonly: true,
+          url,
+        })
+      ).toMatchObject({
+        action: "block",
+        reason: "unsafe-ethereum-rpc",
+      });
+    }
+
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://6529.io",
+        method: "POST",
+        postData: JSON.stringify({
+          id: 1,
+          jsonrpc: "2.0",
+          method: "eth_chainId",
+        }),
+        readonly: true,
+        url: "https://rpc.example.com/",
+      })
+    ).toMatchObject({
+      action: "block",
+      reason: "non-allowlisted-mutation",
+    });
+  });
+
   it("redacts URL query strings in guard summaries", () => {
     expect(
       sanitizeReadonlyRequestUrl(

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -5,6 +5,44 @@
 Read this section first after compaction or handoff.
 
 - Latest testing-roadmap state, 2026-06-22T08:32Z:
+  - PR #2823 is merged and deployed. Production is serving
+    `02382bc81f1d945083b28bf78641ab2469e2212e`.
+  - Staging deploy run:
+    https://github.com/6529-Collections/6529seize-frontend/actions/runs/27943628946
+    - staging SHA: `43d6f711a7f3856c62b5544736d001319f285bef`
+    - workflow HTTP version evidence matched the staging SHA.
+    - local staging validation passed:
+      `test:e2e:staging:smoke` 12 passed,
+      `test:e2e:staging` 24 passed / 6 skipped,
+      `test:e2e:wcag-i18n:surface-matrix` 6 passed.
+  - Production deploy run:
+    https://github.com/6529-Collections/6529seize-frontend/actions/runs/27944602623
+    - workflow HTTP version evidence matched the production SHA.
+    - local production `/api/version` probe matched the production SHA.
+  - Current branch:
+    `codex/e2e-production-readonly-hardening`, based on current `origin/main`.
+  - Active follow-up fixes the production-readonly aggregate after live
+    validation found a real test-harness gap:
+    - current production mint card can render dynamic interactive art inside an
+      iframe, while the test only accepted direct `img[id^="image-"]` media.
+    - the read-only mutation guard blocked safe read-only Ethereum JSON-RPC
+      POSTs to known public RPC hosts used by the mint page.
+    - the app was not rolled back: production app runtime is healthy and this
+      branch changes test harness behavior only.
+  - Validation passed for this follow-up:
+    - `seize run test:no-coverage -- __tests__/playwright/readonlyMutationGuard.test.ts`
+    - focused ESLint on the changed E2E/guard files
+    - failing production mint test rerun: 1 passed
+    - full `seize run test:e2e:production:readonly`: 65 passed
+    - `seize run lint:changed`
+    - `seize run typecheck:changed`
+    - `codex-diff-check`
+    - clean risk floor: Level 3
+    - changed secret scan passed.
+  - Next action: commit, open PR, iterate all reviewbot lanes including the
+    now-live GLM reviewer, then merge/deploy if CI and bots add no further
+    value.
+- Previous testing-roadmap state, 2026-06-22T08:32Z:
   - PR #2822 is merged and deployed. Production is serving
     `7693d1138987175e0ccd6c54841d7547d99ce322`, and the full production-safe
     read-only aggregate passed again: `seize run test:e2e:production:readonly`

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -3175,3 +3175,57 @@ test-results/app-pr-ci/public-groups-tools-secret-scan.json`: clean.
   and 0.0% new-code duplication.
 - As of this log entry, App PR CI, Dependency Governance, CodeQL, and latest
   6529bot/GLM follow-up signals were still pending or queued.
+
+## 2026-06-22T10:25Z PR #2823 Shipped And Production Read-Only Harness Follow-Up
+
+- PR #2823 merged into `origin/main` as
+  `02382bc81f1d945083b28bf78641ab2469e2212e`.
+- Staged the release by merging current `origin/main` into `1a-staging` as
+  `43d6f711a7f3856c62b5544736d001319f285bef`.
+- Staging deploy run #27943628946 succeeded:
+  https://github.com/6529-Collections/6529seize-frontend/actions/runs/27943628946
+  - workflow `deployment-version-evidence.json` matched
+    `43d6f711a7f3856c62b5544736d001319f285bef`.
+  - local staging `/api/version` probe matched the same SHA.
+  - local staging validation passed:
+    `test:e2e:staging:smoke` 12 passed,
+    `test:e2e:staging` 24 passed / 6 skipped,
+    `test:e2e:wcag-i18n:surface-matrix` 6 passed.
+- Production deploy run #27944602623 succeeded from exact `origin/main` SHA
+  `02382bc81f1d945083b28bf78641ab2469e2212e`:
+  https://github.com/6529-Collections/6529seize-frontend/actions/runs/27944602623
+  - workflow `deployment-version-evidence.json` matched the production SHA.
+  - local production `/api/version` probe matched the production SHA.
+- Initial post-production `seize run test:e2e:production:readonly` run found two
+  failures:
+  - delegation wallet-checker empty-state test stayed on loading for 20s, then
+    passed immediately on isolated rerun. Treat as transient production/API
+    timing unless repeated.
+  - The Memes mint page test failed repeatedly because live production card
+    #512 renders dynamic iframe art and the test only accepted direct image
+    media. The read-only guard also blocked safe Ethereum JSON-RPC read POSTs
+    to `eth.llamarpc.com`, `cloudflare-eth.com`, and
+    `ethereum-rpc.publicnode.com`.
+- Started branch `codex/e2e-production-readonly-hardening` from current
+  `origin/main`.
+- Follow-up test-harness changes:
+  - `tests/media/media-mint-detail-readonly.spec.ts` now accepts either direct
+    image media or visible iframe art on the mint page.
+  - `tests/support/readonlyMutationGuard.ts` allows only safe Ethereum JSON-RPC
+    read methods on the observed public RPC hosts, while still blocking unsafe
+    methods such as `eth_sendRawTransaction` and unknown RPC hosts.
+  - `__tests__/playwright/readonlyMutationGuard.test.ts` covers the new public
+    RPC allow/block behavior.
+- Validation completed before PR publication:
+  - `seize run test:no-coverage -- __tests__/playwright/readonlyMutationGuard.test.ts`:
+    14 passed.
+  - focused ESLint on changed guard/E2E files.
+  - production mint-page focused rerun: 1 passed.
+  - `seize run test:e2e:production:readonly`: 65 passed.
+  - `seize run lint:changed`
+  - `seize run typecheck:changed`
+  - `codex-diff-check`
+  - `seize run testing-strategy -- compute-risk-floor --changed-from origin/main --json`:
+    Level 3.
+  - `seize run testing-strategy -- scan-changed-secrets --changed-from origin/main --output test-results/app-pr-ci/production-readonly-hardening-secret-scan-clean.json`:
+    passed.

--- a/tests/media/media-mint-detail-readonly.spec.ts
+++ b/tests/media/media-mint-detail-readonly.spec.ts
@@ -120,7 +120,7 @@ test.describe("Media, mint, and detail read-only coverage @surface @medium @larg
       page.locator("main a[href^='/the-memes/']").first()
     ).toBeVisible({ timeout: 15000 });
     await expect(
-      page.locator("main img[id^='image-'][alt]").first()
+      page.locator("main img[id^='image-'][alt], main iframe").first()
     ).toBeVisible();
     await expect(
       page.getByRole("link", { name: "Distribution Plan" })

--- a/tests/support/readonlyMutationGuard.ts
+++ b/tests/support/readonlyMutationGuard.ts
@@ -61,7 +61,12 @@ const YOUTUBE_TELEMETRY_HOSTS = new Set([
   "www.youtube-nocookie.com",
 ]);
 const WALLETCONNECT_RPC_HOST = "rpc.walletconnect.org";
-const SAFE_WALLETCONNECT_RPC_METHODS = new Set([
+const PUBLIC_ETHEREUM_RPC_HOSTS = new Set([
+  "cloudflare-eth.com",
+  "eth.llamarpc.com",
+  "ethereum-rpc.publicnode.com",
+]);
+const SAFE_ETHEREUM_RPC_METHODS = new Set([
   "eth_accounts",
   "eth_blockNumber",
   "eth_call",
@@ -212,6 +217,10 @@ function isWalletConnectRpc(url: URL) {
   return url.hostname === WALLETCONNECT_RPC_HOST && url.pathname === "/v1/";
 }
 
+function isPublicEthereumRpc(url: URL) {
+  return PUBLIC_ETHEREUM_RPC_HOSTS.has(url.hostname) && url.pathname === "/";
+}
+
 function parseJsonRpcPayload(postData?: string | null) {
   if (!postData) {
     return null;
@@ -231,7 +240,7 @@ function getJsonRpcCalls(payload: unknown) {
   return [payload];
 }
 
-function isSafeWalletConnectRpcPost(postData?: string | null) {
+function isSafeEthereumRpcPost(postData?: string | null) {
   const payload = parseJsonRpcPayload(postData);
   if (!payload) {
     return false;
@@ -249,7 +258,7 @@ function isSafeWalletConnectRpcPost(postData?: string | null) {
 
     const method = (call as { method?: unknown }).method;
     return (
-      typeof method === "string" && SAFE_WALLETCONNECT_RPC_METHODS.has(method)
+      typeof method === "string" && SAFE_ETHEREUM_RPC_METHODS.has(method)
     );
   });
 }
@@ -362,11 +371,19 @@ export function decideReadonlyRequest({
   }
 
   if (isWalletConnectRpc(parsed)) {
-    if (isSafeWalletConnectRpcPost(postData)) {
+    if (isSafeEthereumRpcPost(postData)) {
       return { action: "allow", reason: "read-only-walletconnect-rpc" };
     }
 
     return { action: "block", reason: "unsafe-walletconnect-rpc" };
+  }
+
+  if (isPublicEthereumRpc(parsed)) {
+    if (isSafeEthereumRpcPost(postData)) {
+      return { action: "allow", reason: "read-only-ethereum-rpc" };
+    }
+
+    return { action: "block", reason: "unsafe-ethereum-rpc" };
   }
 
   if (isIgnoredExternalMutation(parsed)) {


### PR DESCRIPTION
## Issue
- Post-production validation for PR #2823 exposed a repeatable failure in `test:e2e:production:readonly` on the live The Memes mint page.
- The current mint card can render dynamic interactive art inside an iframe, while the E2E assertion only accepted direct `img[id^='image-']` media.
- The read-only mutation guard also treated safe Ethereum JSON-RPC read calls to common public RPC hosts as blocked mutations.

## Fix
- Accept either direct image media or visible iframe art as valid primary media on the mint page.
- Generalize the safe JSON-RPC read-method allowlist beyond WalletConnect and apply it only to known public Ethereum RPC hosts observed in production.
- Keep unsafe JSON-RPC methods, malformed payloads, and unknown RPC hosts blocked.
- Record the deployment/validation context in the testing roadmap memory.

## Risk / Impact
- Level: 3.
- Runtime impact: none; this changes Playwright test harness behavior and workstream memory only.
- Safety: `eth_sendRawTransaction` remains blocked, unknown hosts remain blocked, and only explicitly listed read-only JSON-RPC methods are allowed.

## Validation
- `seize run test:no-coverage -- __tests__/playwright/readonlyMutationGuard.test.ts` (14 passed)
- focused ESLint on `tests/support/readonlyMutationGuard.ts`, `tests/media/media-mint-detail-readonly.spec.ts`, and `__tests__/playwright/readonlyMutationGuard.test.ts`
- live production focused rerun: mint-page test passed
- `seize run test:e2e:production:readonly` (65 passed)
- `seize run lint:changed`
- `seize run typecheck:changed`
- `codex-diff-check`
- `seize run testing-strategy -- compute-risk-floor --changed-from origin/main --json` (Level 3)
- changed secret scan passed

## Review Notes
- Please focus on whether the public RPC allowlist is narrow enough and whether accepting iframe art is the correct assertion for dynamic mint cards.
- This PR is a follow-up to deployed production validation for #2823; it does not alter production app runtime code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test validation for read-only Ethereum JSON-RPC endpoint operations, ensuring only safe methods are permitted
  * Enhanced security controls to block unsafe blockchain transaction submissions on public RPC hosts
  * Improved test coverage for dynamic content rendering on mint pages, including iframe support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->