### PR TITLE
[codex] Polish collected details panel spacing

### DIFF
--- a/components/user/collected/stats/subcomponents/CollectedStatsDetailsPanel.tsx
+++ b/components/user/collected/stats/subcomponents/CollectedStatsDetailsPanel.tsx
@@ -41,7 +41,7 @@ export function CollectedStatsDetailsPanel({
     <CommonAnimationHeight>
       <div id={detailsId}>
         {isOpen && (
-          <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800/90 tw-bg-gradient-to-b tw-from-iron-900/30 tw-to-transparent tw-px-4 tw-pb-5 sm:tw-px-6 sm:tw-pb-6">
+          <div className="tw-border-x-0 tw-border-b-0 tw-border-t tw-border-solid tw-border-iron-800/90 tw-bg-gradient-to-b tw-from-iron-900/50 tw-via-iron-950/40 tw-to-black tw-px-4 tw-pb-5 tw-pt-4 tw-ring-1 tw-ring-inset tw-ring-white/[0.04] sm:tw-px-6 sm:tw-pb-6 sm:tw-pt-5">
             {statsPath === null ? (
               <div className="tw-py-2 tw-text-sm tw-text-iron-400">
                 {unavailableMessage}

--- a/components/user/stats/activity/tabs/UserPageActivityTab.tsx
+++ b/components/user/stats/activity/tabs/UserPageActivityTab.tsx
@@ -34,7 +34,7 @@ export default function UserPageActivityTab({
 }) {
   const isActive = tab === activeTab;
   const className = [
-    "tw-border tw-border-solid tw-border-iron-700 tw-px-4 tw-py-2 tw-text-sm tw-font-semibold tw-transition tw-duration-300 tw-ease-out",
+    "tw-min-w-0 tw-flex-1 tw-border tw-border-solid tw-border-iron-700 tw-px-1.5 tw-py-2 tw-text-[11px] tw-font-semibold tw-leading-4 tw-transition tw-duration-300 tw-ease-out sm:tw-flex-none sm:tw-px-4 sm:tw-text-sm",
     isActive
       ? "tw-bg-iron-800 tw-text-iron-100"
       : "tw-bg-iron-950 tw-text-iron-500 hover:tw-bg-iron-900 hover:tw-text-iron-100",

--- a/components/user/stats/activity/tabs/UserPageActivityTabs.tsx
+++ b/components/user/stats/activity/tabs/UserPageActivityTabs.tsx
@@ -1,7 +1,7 @@
 import type { KeyboardEvent } from "react";
 import type { SupportedLocale } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
-import { USER_PAGE_ACTIVITY_TAB } from "../activity.types";
+import type { USER_PAGE_ACTIVITY_TAB } from "../activity.types";
 import {
   getActivityTabId,
   getNextActivityTab,
@@ -47,7 +47,7 @@ export default function UserPageActivityTabs({
     };
     const nextTab = keyToTab[event.key];
 
-    if (!nextTab) {
+    if (nextTab === undefined) {
       return;
     }
 
@@ -60,7 +60,7 @@ export default function UserPageActivityTabs({
     <div
       role="tablist"
       aria-label={t(locale, "user.collected.stats.activityTabs.listLabel")}
-      className="tw-inline-flex tw-overflow-hidden tw-rounded-lg"
+      className="tw-flex tw-w-full tw-overflow-hidden tw-rounded-lg sm:tw-inline-flex sm:tw-w-auto"
     >
       {USER_PAGE_ACTIVITY_TABS.map((tab) => (
         <UserPageActivityTab


### PR DESCRIPTION
## Summary
- Rebuilds the collected details spacing polish as one signed commit on current `main`.
- Adds stronger visual separation for the collected stats details panel.
- Makes the collected activity tabs fit better on mobile by letting the tablist fill the width and tightening mobile tab text/padding.

## Impact and risk
- Scope is limited to profile collected/stats UI polish.
- No data fetching, auth, routing, or security-sensitive behavior changes.
- Accessibility semantics are preserved: the tablist, tab roles, `aria-selected`, `aria-controls`, roving `tabIndex`, and keyboard handling stay intact.
- Mobile/web UX risk is low and focused on visual fit; desktop keeps the existing inline tab sizing at `sm` and above.

## Local validation
- `seize run lint:changed` passed.
- `seize run typecheck:changed` passed: 10 changed TypeScript files.
- `seize run test:no-coverage -- __tests__/components/user/stats/activity/UserPageActivityWrapper.test.tsx __tests__/components/user/stats/activity/UserPageActivityTab.test.tsx __tests__/components/user/stats/activity/tabs/UserPageActivityTabs.test.tsx __tests__/components/user/collected/UserPageCollectedStats.test.tsx` passed: 4 suites / 22 tests.
- `codex-diff-check` passed.

Note: Jest still emitted the known worker-exit warning in this branch because the broader test harness stabilization is in #2862, but all targeted tests passed.