### PR TITLE
[codex] Polish profile Brain mobile strip

### DIFF
--- a/components/user/brain/UserPageBrainSidebarMobileStrip.tsx
+++ b/components/user/brain/UserPageBrainSidebarMobileStrip.tsx
@@ -127,11 +127,11 @@ export default function UserPageBrainSidebarMobileStrip({
   return (
     <section
       aria-label="Brain waves strip"
-      className="lg:tw-hidden"
+      className="tw-mb-5 lg:tw-hidden"
       data-testid="brain-sidebar-mobile-strip"
     >
-      <div className="tw-relative tw-overflow-hidden">
-        <div className="tw-flex tw-items-end tw-gap-4 tw-overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:tw-hidden">
+      <div className="tw-relative tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/[0.08] tw-bg-iron-950/70 tw-p-3 tw-shadow-sm">
+        <div className="tw-flex tw-items-end tw-gap-4 tw-overflow-x-auto tw-overflow-y-hidden tw-pb-2 tw-scrollbar-thin tw-scrollbar-track-iron-900 tw-scrollbar-thumb-iron-600 desktop-hover:hover:tw-scrollbar-thumb-iron-400">
           {shouldShowCreatedSection && (
             <div className="tw-flex tw-shrink-0 tw-flex-col tw-gap-2">
               <span className="tw-px-1 tw-text-[10px] tw-font-semibold tw-uppercase tw-tracking-wider tw-text-iron-500">


### PR DESCRIPTION
﻿## Summary
- Frames the mobile Brain waves strip with a subtle Tailwind surface.
- Restores a visible horizontal scroll affordance and adds bottom spacing before the main Brain content.
- Preserves all links, modal behavior, loading state, and item counts.

## UI/UX Note
The mobile strip previously floated without enough separation and hid its horizontal scroll cue. The updated surface makes the wave shortcuts easier to recognize as a scannable, scrollable module while staying aligned with the dense dark Brain sidebar surfaces.

## Current Branch Cleanup
- Rebuilt the draft branch as one signed commit on current `main` to clear the previous DCO failure.
- Kept the code delta to the original one-file mobile strip styling change.

## Local Validation
- `seize run lint:changed`
- `seize run typecheck:changed`
  - Typecheck passed for 9 changed TypeScript files.
- `seize run test:no-coverage -- --findRelatedTests components/user/brain/UserPageBrainSidebarMobileStrip.tsx --passWithNoTests`
  - 3 suites, 13 tests passed. Jest reported the known worker-exit warning from the current base test setup.
- `seize run react-doctor:diff`
- `codex-diff-check`

## Review Notes
Please focus on mobile profile Brain layout only: the strip surface, horizontal scrolling affordance, and spacing before the main Brain content. Desktop Brain sidebar rendering should remain unchanged.
