### PR TITLE
Harden production read-only E2E flakes

### DIFF
--- a/__tests__/playwright/readonlyMutationGuard.test.ts
+++ b/__tests__/playwright/readonlyMutationGuard.test.ts
@@ -308,6 +308,18 @@ describe("Playwright read-only mutation guard", () => {
 
     expect(
       decideReadonlyRequest({
+        baseURL: "https://6529.io",
+        method: "POST",
+        readonly: true,
+        url: "https://csp.withgoogle.com/csp/script-inclusions/1a74b362328347702024274e29d77eb5",
+      })
+    ).toMatchObject({
+      action: "abort",
+      reason: "ignored-external-sdk-endpoint",
+    });
+
+    expect(
+      decideReadonlyRequest({
         baseURL: "https://staging.6529.io",
         method: "POST",
         readonly: true,
@@ -326,6 +338,7 @@ describe("Playwright read-only mutation guard", () => {
       "https://www.youtube-nocookie.com/api/stats/watchtime",
       "https://youtube-nocookie.com/youtubei/v1/log_event?prettyPrint=false",
       "https://jnn-pa.googleapis.com/$rpc/google.internal.waa.v1.Waa/GenerateIT",
+      "https://csp.withgoogle.com/csp/script-inclusions/1A74B362328347702024274E29D77EB5",
     ]) {
       expect(
         decideReadonlyRequest({
@@ -422,6 +435,18 @@ describe("Playwright read-only mutation guard", () => {
         method: "POST",
         readonly: true,
         url: "https://www.google.com/unknown-write",
+      })
+    ).toMatchObject({
+      action: "block",
+      reason: "non-allowlisted-mutation",
+    });
+
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://6529.io",
+        method: "POST",
+        readonly: true,
+        url: "https://csp.withgoogle.com/csp/script-inclusions/not-a-report-id",
       })
     ).toMatchObject({
       action: "block",

--- a/__tests__/playwright/readonlyMutationGuard.test.ts
+++ b/__tests__/playwright/readonlyMutationGuard.test.ts
@@ -373,6 +373,20 @@ describe("Playwright read-only mutation guard", () => {
     }
   });
 
+  it("aborts exact Google CSP script-inclusion reports", () => {
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://6529.io",
+        method: "POST",
+        readonly: true,
+        url: "https://csp.withgoogle.com/csp/script-inclusions/1a74b362328347702024274e29d77eb5",
+      })
+    ).toMatchObject({
+      action: "abort",
+      reason: "ignored-external-sdk-endpoint",
+    });
+  });
+
   it("aborts same-origin telemetry POSTs without allowing external lookalikes", () => {
     expect(
       decideReadonlyRequest({

--- a/__tests__/playwright/readonlyMutationGuard.test.ts
+++ b/__tests__/playwright/readonlyMutationGuard.test.ts
@@ -146,6 +146,25 @@ describe("Playwright read-only mutation guard", () => {
       action: "block",
       reason: "non-allowlisted-mutation",
     });
+
+    for (const url of [
+      "https://csp.withgoogle.com/csp/script-inclusions/1a74b362328347702024274e29d77eb",
+      "https://csp.withgoogle.com/csp/script-inclusions/1a74b362328347702024274e29d77eb55",
+      "https://csp.withgoogle.com/csp/script-inclusions/1a74b362328347702024274e29d77eg5",
+      "https://csp.withgoogle.com/csp/script-inclusions/1a74b362328347702024274e29d77eb5/",
+    ]) {
+      expect(
+        decideReadonlyRequest({
+          baseURL: "https://6529.io",
+          method: "POST",
+          readonly: true,
+          url,
+        })
+      ).toMatchObject({
+        action: "block",
+        reason: "non-allowlisted-mutation",
+      });
+    }
   });
 
   it("aborts Next.js dev inspector stack-frame lookups without recording an app mutation", () => {

--- a/__tests__/playwright/routeReadiness.test.ts
+++ b/__tests__/playwright/routeReadiness.test.ts
@@ -1,0 +1,88 @@
+import type { Page, Response } from "@playwright/test";
+
+jest.mock("../../tests/testHelpers", () => ({
+  expect: global.expect,
+  expectNoHorizontalOverflow: jest.fn(),
+  waitForRouteReady: jest.fn(),
+}));
+
+import { gotoDocumentWithTransientRetry } from "../../tests/support/routeReadiness";
+
+function mockResponse(status: number) {
+  return { status: () => status } as Response;
+}
+
+function mockPageWithResponses(responses: Array<Response | null>) {
+  const goto = jest.fn(async () => responses.shift() ?? null);
+  const waitForTimeout = jest.fn(async () => undefined);
+
+  return {
+    goto,
+    page: { goto, waitForTimeout } as unknown as Page,
+    waitForTimeout,
+  };
+}
+
+describe("Playwright route readiness navigation", () => {
+  it("returns successful document responses without retrying", async () => {
+    const response = mockResponse(200);
+    const { goto, page, waitForTimeout } = mockPageWithResponses([response]);
+
+    await expect(gotoDocumentWithTransientRetry(page, "/waves")).resolves.toBe(
+      response
+    );
+    expect(goto).toHaveBeenCalledTimes(1);
+    expect(waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it("returns non-transient document responses without retrying", async () => {
+    const response = mockResponse(404);
+    const { goto, page, waitForTimeout } = mockPageWithResponses([response]);
+
+    await expect(
+      gotoDocumentWithTransientRetry(page, "/missing")
+    ).resolves.toBe(response);
+    expect(goto).toHaveBeenCalledTimes(1);
+    expect(waitForTimeout).not.toHaveBeenCalled();
+  });
+
+  it("retries once after a transient document response", async () => {
+    const response = mockResponse(200);
+    const { goto, page, waitForTimeout } = mockPageWithResponses([
+      mockResponse(502),
+      response,
+    ]);
+
+    await expect(
+      gotoDocumentWithTransientRetry(page, "/rememes")
+    ).resolves.toBe(response);
+    expect(goto).toHaveBeenCalledTimes(2);
+    expect(waitForTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when the retry still returns a transient document response", async () => {
+    const { page } = mockPageWithResponses([
+      mockResponse(502),
+      mockResponse(503),
+    ]);
+
+    await expect(
+      gotoDocumentWithTransientRetry(page, "/education")
+    ).rejects.toThrow(
+      "Document navigation to /education returned transient HTTP 503 after retry."
+    );
+  });
+
+  it("returns null when the retry produces no document response", async () => {
+    const { goto, page, waitForTimeout } = mockPageWithResponses([
+      mockResponse(504),
+      null,
+    ]);
+
+    await expect(
+      gotoDocumentWithTransientRetry(page, "/network")
+    ).resolves.toBeNull();
+    expect(goto).toHaveBeenCalledTimes(2);
+    expect(waitForTimeout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -39,6 +39,16 @@ Read this section first after compaction or handoff.
       tweak: 3/3 each passed
     - full `seize run test:e2e:production:readonly`: 65/65 passed
     - `codex-diff-check`
+  - PR #2847 first review loop was useful and fixed:
+    - persistent transient document responses now throw a direct
+      `Document navigation ... returned transient HTTP ... after retry` error.
+    - Google CSP report tests now cover exact-boundary negatives: 31 chars, 33
+      chars, non-hex same-length IDs, and trailing slashes.
+    - the Waves/Profile legacy-link test now selects the first internal
+      `/waves/{id}` link inside the wave-list region instead of the first
+      `Open ...` link, because live production can show external X links first.
+    - post-fix focused Waves/Profile production check passed, and full
+      `seize run test:e2e:production:readonly` passed 65/65 again.
   - Independent verifier `Heisenberg` found the ReMemes visible-title assertion
     was over-specific and recommended replacing exact text with the
     breakpoint-aware `Collection: ReMemes` button candidate. Fixed before PR

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -49,6 +49,16 @@ Read this section first after compaction or handoff.
       `Open ...` link, because live production can show external X links first.
     - post-fix focused Waves/Profile production check passed, and full
       `seize run test:e2e:production:readonly` passed 65/65 again.
+  - GLM swarm review on PR #2847 was useful and fixed:
+    - added unit coverage for `gotoDocumentWithTransientRetry` success,
+      non-transient pass-through, transient retry, persistent transient throw,
+      and transient-then-null behavior.
+    - made Google CSP report positive coverage a named test case.
+    - tightened Waves/Profile wave-id extraction to poll for actual UUID detail
+      paths inside the wave-list region, instead of any `/waves/` prefix.
+    - post-fix unit coverage passed 20 tests across route readiness and the
+      read-only guard, and full `seize run test:e2e:production:readonly`
+      passed 65/65 again.
   - Independent verifier `Heisenberg` found the ReMemes visible-title assertion
     was over-specific and recommended replacing exact text with the
     breakpoint-aware `Collection: ReMemes` button candidate. Fixed before PR

--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -4,6 +4,50 @@
 
 Read this section first after compaction or handoff.
 
+- Latest testing-roadmap state, 2026-06-22T17:31Z:
+  - PR #2846 is merged and deployed. Production serves
+    `cf0503f787ea4f0b86696f6e0dacc75c01e1ed3d`, and production smoke passed
+    after deploy.
+  - Post-deploy production read-only validation exposed test-harness drift, not
+    a live runtime rollback condition:
+    - ReMemes browse needed to wait on `/api/rememes` before asserting filters.
+    - Google CSP script-inclusion POST reports needed a narrow abort-only
+      read-only guard allowance.
+    - Legacy content routes can occasionally receive transient production
+      document 502s during live aggregate runs.
+    - The ReMemes detail fixture title is now `SeizeGenart | ReMemes`, with no
+      required `| 6529.io` suffix.
+  - Current branch:
+    `codex/production-readonly-flake-hardening`, based on current
+    `origin/main` `cf0503f787ea4f0b86696f6e0dacc75c01e1ed3d`.
+  - Active slice is test-only production-readonly hardening:
+    `gotoDocumentWithTransientRetry` retries one explicit 502/503/504 document
+    response, production-readonly packs share that helper, ReMemes browse uses
+    API-readiness plus breakpoint-aware collection identity checks, ReMemes
+    detail accepts the current live title contract, and the mutation guard
+    aborts only exact `csp.withgoogle.com/csp/script-inclusions/<32-hex>`
+    reports while continuing to block lookalikes.
+  - Local and live validation passed for the final diff:
+    - `seize exec prettier --check ...`
+    - `seize run test:no-coverage -- __tests__/playwright/readonlyMutationGuard.test.ts`
+    - `seize run typecheck:playwright`
+    - `seize run lint:changed`
+    - `seize run typecheck:changed`
+    - focused production ReMemes browse check: 1 passed
+    - focused production ReMemes detail check: 1 passed
+    - focused production ReMemes and `/education` soak before final verifier
+      tweak: 3/3 each passed
+    - full `seize run test:e2e:production:readonly`: 65/65 passed
+    - `codex-diff-check`
+  - Independent verifier `Heisenberg` found the ReMemes visible-title assertion
+    was over-specific and recommended replacing exact text with the
+    breakpoint-aware `Collection: ReMemes` button candidate. Fixed before PR
+    publication.
+  - Next action: commit, push, open PR, trigger all existing reviewbot lanes
+    plus GLM swarm, iterate CI/review feedback, then merge/deploy if Codex,
+    bots, and checks stop adding material value.
+  - GLM reviewbot remains live and additive. Do not remove, downgrade, or make
+    optional any existing reviewbot lanes.
 - Latest testing-roadmap state, 2026-06-22T15:20Z:
   - PR #2844 is merged and deployed. Current production is serving
     `d26393b40d2fec0e9a2bf557f911324b27bc7686`.
@@ -476,7 +520,7 @@ generated artifacts as the durable evidence store.
 
 ## Current Branch
 
-`codex/e2e-wave-create-sandbox`
+`codex/production-readonly-flake-hardening`
 
 ## Constraints
 
@@ -641,12 +685,13 @@ Re-audit each PR against current `origin/main` before merging or deploying it.
 
 ## Current Next Actions
 
-1. Finish local implementation and validation for `codex/e2e-wave-create-sandbox`.
+1. Commit, push, and open PR for
+   `codex/production-readonly-flake-hardening`.
 2. Trigger and iterate CI, CodeRabbit, Sonar, 6529bot, GLM, and specialized
    reviewbot lanes until Codex judges the loop is no longer adding material
    value.
-3. Merge the create-wave sandbox E2E PR after checks and review signals are
-   green or consciously dispositioned, then deploy the resulting current
+3. Merge the production-readonly hardening PR after checks and review signals
+   are green or consciously dispositioned, then deploy the resulting current
    `origin/main` through staging and production with exact-SHA validation.
 4. Continue the next high-value E2E hardening slice: wallet/native/Electron
    shell coverage, real native runtime detection, or upload/posting/admin

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -3441,3 +3441,29 @@ test-results/app-pr-ci/public-groups-tools-secret-scan.json`: clean.
   - `codex-diff-check`
 - Next action: commit/push the follow-up, rerun PR checks and reviewbot lanes on
   the new head, then merge/deploy if no material feedback remains.
+
+## 2026-06-22T18:18Z PR #2847 GLM Swarm Follow-Up
+
+- GLM swarm reviewed head `efe131b4dd44` and found useful additional test
+  harness hardening ideas.
+- Fixed valid GLM feedback:
+  - added `__tests__/playwright/routeReadiness.test.ts` covering
+    `gotoDocumentWithTransientRetry` success, non-transient pass-through,
+    transient retry, persistent transient throw, and transient-then-null
+    behavior.
+  - made exact Google CSP script-inclusion report positive coverage an explicit
+    named unit test.
+  - tightened the Waves/Profile legacy-link selector to poll for UUID-shaped
+    `/waves/{id}` detail paths inside the wave-list region, avoiding future
+    `/waves/create` or `/waves/feed` false positives.
+- Post-fix validation passed:
+  - `seize run test:no-coverage -- __tests__/playwright/routeReadiness.test.ts __tests__/playwright/readonlyMutationGuard.test.ts`:
+    20 tests passed.
+  - `seize run typecheck:playwright`
+  - `seize run lint:changed`
+  - `seize run typecheck:changed`
+  - focused production Waves/Profile legacy-link test: 1 passed
+  - full `seize run test:e2e:production:readonly`: 65/65 passed
+  - `codex-diff-check`
+- Next action: commit/push this GLM follow-up and rerun PR checks plus bots on
+  the final head.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -3410,3 +3410,34 @@ test-results/app-pr-ci/public-groups-tools-secret-scan.json`: clean.
 - Next action: commit, push, open PR, trigger all existing reviewbot lanes plus
   GLM swarm, iterate feedback, then merge/deploy when Codex and the bots stop
   adding material value.
+
+## 2026-06-22T17:58Z PR #2847 Reviewbot Follow-Up
+
+- PR #2847 opened and triggered:
+  `/6529bot review general wcag i18n security responsiveness glm-swarm`.
+- CI/status checks passed on first head:
+  CodeQL, DCO, Installed app checks, Plan risk and security checks, SonarCloud,
+  Snyk, and CodeRabbit.
+- 6529bot returned Good-to-merge / no-finding results for the visible Opus
+  lanes, plus useful nice-to-have feedback.
+- Fixed valid review/test-loop feedback:
+  - `gotoDocumentWithTransientRetry` now throws a direct error if the retried
+    document response is still 502/503/504.
+  - CSP report negative coverage now locks exact 32-hex behavior for 31-char,
+    33-char, same-length non-hex, and trailing-slash report IDs.
+  - The Waves/Profile legacy-link test now chooses the first internal
+    `/waves/{id}` link from the wave-list region instead of relying on the
+    first `Open ...` link, because live production can surface an external X
+    link first.
+- Dispositioned one bot note as a miss: ReMemes browse already awaits
+  `gotoReadyWithApiResponse` at line 277.
+- Post-fix validation passed:
+  - focused production Waves/Profile legacy-link test: 1 passed
+  - `seize run test:no-coverage -- __tests__/playwright/readonlyMutationGuard.test.ts`
+  - `seize run typecheck:playwright`
+  - `seize run lint:changed`
+  - `seize run typecheck:changed`
+  - full `seize run test:e2e:production:readonly`: 65/65 passed
+  - `codex-diff-check`
+- Next action: commit/push the follow-up, rerun PR checks and reviewbot lanes on
+  the new head, then merge/deploy if no material feedback remains.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -3371,3 +3371,42 @@ test-results/app-pr-ci/public-groups-tools-secret-scan.json`: clean.
     and `codex-diff-check`
 - Hubble re-reviewed the updated diff and found no remaining publication
   blockers.
+
+## 2026-06-22T17:31Z Production Read-Only Aggregate Hardening Slice
+
+- PR #2846 merged and shipped to production as
+  `cf0503f787ea4f0b86696f6e0dacc75c01e1ed3d`.
+- Started fresh branch `codex/production-readonly-flake-hardening` from that
+  `origin/main` to fix post-deploy production-readonly test-harness drift.
+- Implemented test-only hardening:
+  - `tests/support/routeReadiness.ts` now has
+    `gotoDocumentWithTransientRetry`, which retries one top-level document
+    navigation only for explicit 502/503/504 responses.
+  - Production-readonly packs that had local navigation wrappers now use that
+    helper.
+  - ReMemes browse waits for `/api/rememes` before asserting filter and card
+    readiness.
+  - ReMemes browse keeps page-identity coverage with the visible logo or the
+    breakpoint-specific `Collection: ReMemes` control, instead of exact body
+    text that does not exist on current production.
+  - ReMemes detail title accepts the current production contract
+    `SeizeGenart | ReMemes`, while still allowing the previous site suffix.
+  - The read-only mutation guard aborts exact Google CSP
+    `csp/script-inclusions/<32-hex>` report POSTs and continues blocking
+    malformed lookalikes.
+- Independent verifier `Heisenberg` diagnosed the ReMemes browse failure as a
+  test over-assertion, not a product regression, and recommended the
+  breakpoint-aware header identity candidate now in the diff.
+- Final validation passed:
+  - `seize exec prettier --check ...`
+  - `seize run test:no-coverage -- __tests__/playwright/readonlyMutationGuard.test.ts`
+  - `seize run typecheck:playwright`
+  - `seize run lint:changed`
+  - `seize run typecheck:changed`
+  - focused production ReMemes browse check: 1 passed
+  - focused production ReMemes detail check: 1 passed
+  - full `seize run test:e2e:production:readonly`: 65/65 passed
+  - `codex-diff-check`
+- Next action: commit, push, open PR, trigger all existing reviewbot lanes plus
+  GLM swarm, iterate feedback, then merge/deploy when Codex and the bots stop
+  adding material value.

--- a/tests/collections/nextgen-collections-readonly.spec.ts
+++ b/tests/collections/nextgen-collections-readonly.spec.ts
@@ -274,15 +274,19 @@ test.describe("NextGen and collections read-only coverage @surface @medium @larg
   test("ReMemes browse page keeps public filters and cards reachable", async ({
     page,
   }) => {
-    await gotoReady(page, "/rememes");
+    await gotoReadyWithApiResponse(
+      page,
+      "/rememes",
+      (url) => url.pathname === "/api/rememes"
+    );
 
     await expect(page).toHaveTitle("ReMemes | Collections");
     await expectAnyVisible(
       [
         page.getByAltText("ReMemes"),
-        page.getByText("ReMemes", { exact: true }),
+        page.getByRole("button", { name: "Collection: ReMemes" }),
       ],
-      "Expected ReMemes title or logo to render"
+      "Expected ReMemes collection header to render"
     );
     for (const filter of [/^Sort:/, /^Token Type:/, /^Meme Reference:/]) {
       await expect(page.getByRole("button", { name: filter })).toBeVisible();

--- a/tests/content/public-content-readonly.spec.ts
+++ b/tests/content/public-content-readonly.spec.ts
@@ -6,6 +6,7 @@ import {
   test,
   waitForRouteReady,
 } from "../testHelpers";
+import { gotoDocumentWithTransientRetry } from "../support/routeReadiness";
 
 type RouteExpectation = {
   path: string;
@@ -93,7 +94,7 @@ const CONTENT_ROUTES: RouteExpectation[] = [
 ];
 
 async function gotoContentRoute(page: Page, path: string) {
-  await page.goto(path, { waitUntil: "domcontentloaded" });
+  await gotoDocumentWithTransientRetry(page, path);
   await waitForRouteReady(page, { readySelector: "body" });
   await expect(page).not.toHaveTitle(/404|PAGE NOT FOUND/i);
   await expectNoHorizontalOverflow(page);

--- a/tests/delegation/delegation-readonly.spec.ts
+++ b/tests/delegation/delegation-readonly.spec.ts
@@ -6,6 +6,7 @@ import {
   test,
   waitForRouteReady,
 } from "../testHelpers";
+import { gotoDocumentWithTransientRetry } from "../support/routeReadiness";
 
 const SYNTHETIC_EMPTY_WALLET = "0x000000000000000000000000000000000000dEaD";
 
@@ -81,7 +82,7 @@ const COLLECTION_ROUTES = [
 ] as const;
 
 async function gotoReady(page: Page, path: string) {
-  await page.goto(path, { waitUntil: "domcontentloaded" });
+  await gotoDocumentWithTransientRetry(page, path);
   await waitForRouteReady(page);
   await expectNoHorizontalOverflow(page);
   await expect(page).not.toHaveTitle("404 | PAGE NOT FOUND");
@@ -148,7 +149,9 @@ test.describe("Delegation read-only coverage @surface @medium @large @readonly",
         ).toBeVisible();
       }
       await expectHeading(page, article.heading);
-      await expect(page.getByText("Loading delegation article...")).toBeHidden();
+      await expect(
+        page.getByText("Loading delegation article...")
+      ).toBeHidden();
     });
   }
 
@@ -158,7 +161,9 @@ test.describe("Delegation read-only coverage @surface @medium @large @readonly",
     await expect(page).toHaveTitle("Wallet Checker | 6529.io");
     await expectHeading(page, "Wallet Checker");
     await expect(
-      page.getByText("This is read-only and does not require wallet connection.")
+      page.getByText(
+        "This is read-only and does not require wallet connection."
+      )
     ).toBeVisible();
 
     const input = page.getByLabel("Wallet address or ENS name");

--- a/tests/media/media-mint-detail-readonly.spec.ts
+++ b/tests/media/media-mint-detail-readonly.spec.ts
@@ -6,9 +6,10 @@ import {
   test,
   waitForRouteReady,
 } from "../testHelpers";
+import { gotoDocumentWithTransientRetry } from "../support/routeReadiness";
 
 async function gotoReady(page: Page, path: string) {
-  await page.goto(path, { waitUntil: "domcontentloaded" });
+  await gotoDocumentWithTransientRetry(page, path);
   await waitForRouteReady(page);
   await expectNoHorizontalOverflow(page);
 }
@@ -195,7 +196,9 @@ test.describe("Media, mint, and detail read-only coverage @surface @medium @larg
       await expect(
         page.getByRole("link", { name: "Back to ReMemes" })
       ).toHaveAttribute("href", "/rememes");
-      await expect(page).toHaveTitle("SeizeGenart | ReMemes | 6529.io");
+      await expect(page).toHaveTitle(
+        /^SeizeGenart \| ReMemes(?: \| 6529\.io)?$/
+      );
       await expect(
         page.getByRole("heading", { level: 1, name: "ReMemes - SeizeGenart" })
       ).toBeVisible();

--- a/tests/public-groups-tools/public-groups-tools-readonly.spec.ts
+++ b/tests/public-groups-tools/public-groups-tools-readonly.spec.ts
@@ -6,13 +6,14 @@ import {
   test,
   waitForRouteReady,
 } from "../testHelpers";
+import { gotoDocumentWithTransientRetry } from "../support/routeReadiness";
 
 async function gotoReady(
   page: Page,
   path: string,
   options: { readySelector?: string } = {}
 ) {
-  await page.goto(path, { waitUntil: "domcontentloaded" });
+  await gotoDocumentWithTransientRetry(page, path);
   await waitForRouteReady(page, options);
   await expectNoHorizontalOverflow(page);
 }

--- a/tests/social/profileReadonlyHelpers.ts
+++ b/tests/social/profileReadonlyHelpers.ts
@@ -5,11 +5,12 @@ import {
   expectNoHorizontalOverflow,
   waitForRouteReady,
 } from "../testHelpers";
+import { gotoDocumentWithTransientRetry } from "../support/routeReadiness";
 
 export const PROFILE_HANDLE = "punk6529";
 
 export async function gotoReady(page: Page, path: string) {
-  await page.goto(path, { waitUntil: "domcontentloaded" });
+  await gotoDocumentWithTransientRetry(page, path);
   await waitForRouteReady(page);
   await expectNoHorizontalOverflow(page);
 }

--- a/tests/social/search-waves-readonly.spec.ts
+++ b/tests/social/search-waves-readonly.spec.ts
@@ -6,6 +6,7 @@ import {
   test,
   waitForRouteReady,
 } from "../testHelpers";
+import { gotoDocumentWithTransientRetry } from "../support/routeReadiness";
 
 const NAVIGATION_TIMEOUT_MS = 15000;
 const GLOBAL_SEARCH_QUERY = "wave score";
@@ -170,7 +171,7 @@ const localFixtureWave = {
 };
 
 async function gotoReady(page: Page, path: string) {
-  await page.goto(path, { waitUntil: "domcontentloaded" });
+  await gotoDocumentWithTransientRetry(page, path);
   await waitForRouteReady(page);
   await expectNoHorizontalOverflow(page);
 }

--- a/tests/social/waves-profile-readonly.spec.ts
+++ b/tests/social/waves-profile-readonly.spec.ts
@@ -29,7 +29,11 @@ const PROFILE_TAB_PATHS = [
 async function getFirstWaveId(page: Page) {
   await gotoReady(page, "/waves");
 
-  const firstWaveLink = page.getByRole("link", { name: /^Open / }).first();
+  const waveList = page.getByRole("region", {
+    name: /All recent waves list|Regular waves list/,
+  });
+  await expect(waveList).toBeVisible({ timeout: 15000 });
+  const firstWaveLink = waveList.locator('a[href^="/waves/"]').first();
   await expect(firstWaveLink).toBeVisible({ timeout: 15000 });
   const href = await firstWaveLink.getAttribute("href");
   const pathname = href ? new URL(href, page.url()).pathname : "";

--- a/tests/social/waves-profile-readonly.spec.ts
+++ b/tests/social/waves-profile-readonly.spec.ts
@@ -33,9 +33,27 @@ async function getFirstWaveId(page: Page) {
     name: /All recent waves list|Regular waves list/,
   });
   await expect(waveList).toBeVisible({ timeout: 15000 });
-  const firstWaveLink = waveList.locator('a[href^="/waves/"]').first();
-  await expect(firstWaveLink).toBeVisible({ timeout: 15000 });
-  const href = await firstWaveLink.getAttribute("href");
+  let href: string | null = null;
+  await expect
+    .poll(
+      async () => {
+        href = await waveList.locator('a[href^="/waves/"]').evaluateAll(
+          (links, baseUrl) =>
+            links
+              .map((link) => link.getAttribute("href"))
+              .filter((candidate): candidate is string => Boolean(candidate))
+              .find((candidate) =>
+                /^\/waves\/[0-9a-f-]{36}$/i.test(
+                  new URL(candidate, baseUrl).pathname
+                )
+              ) ?? null,
+          page.url()
+        );
+        return href !== null;
+      },
+      { message: "Expected wave list to contain a wave detail link" }
+    )
+    .toBe(true);
   const pathname = href ? new URL(href, page.url()).pathname : "";
   const match = pathname.match(/^\/waves\/([^/]+)$/);
 

--- a/tests/support/readonlyMutationGuard.ts
+++ b/tests/support/readonlyMutationGuard.ts
@@ -90,6 +90,13 @@ const SAFE_ETHEREUM_RPC_METHODS = new Set([
   "web3_clientVersion",
 ]);
 
+function isGoogleCspReportEndpoint(url: URL) {
+  return (
+    url.hostname === "csp.withgoogle.com" &&
+    /^\/csp\/script-inclusions\/[a-f0-9]{32}$/i.test(url.pathname)
+  );
+}
+
 function parseUrl(url: string) {
   try {
     return new URL(url);
@@ -166,6 +173,10 @@ function isIgnoredExternalMutation(url: URL) {
     (url.pathname.startsWith("/api/stats/") ||
       url.pathname === "/youtubei/v1/log_event")
   ) {
+    return true;
+  }
+
+  if (isGoogleCspReportEndpoint(url)) {
     return true;
   }
 
@@ -257,9 +268,7 @@ function isSafeEthereumRpcPost(postData?: string | null) {
     }
 
     const method = (call as { method?: unknown }).method;
-    return (
-      typeof method === "string" && SAFE_ETHEREUM_RPC_METHODS.has(method)
-    );
+    return typeof method === "string" && SAFE_ETHEREUM_RPC_METHODS.has(method);
   });
 }
 

--- a/tests/support/routeReadiness.ts
+++ b/tests/support/routeReadiness.ts
@@ -22,16 +22,24 @@ export async function gotoReady(page: Page, path: string) {
 export async function gotoDocumentWithTransientRetry(page: Page, path: string) {
   for (let attempt = 1; attempt <= 2; attempt++) {
     const response = await page.goto(path, { waitUntil: "domcontentloaded" });
-    const shouldRetry =
-      attempt === 1 &&
+    const transientStatus =
       response !== null &&
-      TRANSIENT_DOCUMENT_STATUS_CODES.has(response.status());
+      TRANSIENT_DOCUMENT_STATUS_CODES.has(response.status())
+        ? response.status()
+        : null;
 
-    if (!shouldRetry) {
+    if (transientStatus === null) {
       return response;
     }
 
-    await page.waitForTimeout(TRANSIENT_DOCUMENT_RETRY_DELAY_MS);
+    if (attempt === 1) {
+      await page.waitForTimeout(TRANSIENT_DOCUMENT_RETRY_DELAY_MS);
+      continue;
+    }
+
+    throw new Error(
+      `Document navigation to ${path} returned transient HTTP ${transientStatus} after retry.`
+    );
   }
 
   return null;

--- a/tests/support/routeReadiness.ts
+++ b/tests/support/routeReadiness.ts
@@ -7,14 +7,34 @@ import {
 } from "../testHelpers";
 
 export const RESPONSE_TIMEOUT_MS = 20000;
+const TRANSIENT_DOCUMENT_STATUS_CODES = new Set([502, 503, 504]);
+const TRANSIENT_DOCUMENT_RETRY_DELAY_MS = 1000;
 
 export type ApiResponseMatcher = (url: URL) => boolean;
 
 export async function gotoReady(page: Page, path: string) {
-  await page.goto(path, { waitUntil: "domcontentloaded" });
+  await gotoDocumentWithTransientRetry(page, path);
   await waitForRouteReady(page);
   await expectNoHorizontalOverflow(page);
   await expect(page).not.toHaveTitle("404 | PAGE NOT FOUND");
+}
+
+export async function gotoDocumentWithTransientRetry(page: Page, path: string) {
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    const response = await page.goto(path, { waitUntil: "domcontentloaded" });
+    const shouldRetry =
+      attempt === 1 &&
+      response !== null &&
+      TRANSIENT_DOCUMENT_STATUS_CODES.has(response.status());
+
+    if (!shouldRetry) {
+      return response;
+    }
+
+    await page.waitForTimeout(TRANSIENT_DOCUMENT_RETRY_DELAY_MS);
+  }
+
+  return null;
 }
 
 export async function waitForApiResponse(


### PR DESCRIPTION
﻿## Issue
- Production post-deploy validation for PR #2846 exposed production read-only E2E drift and live-edge flakiness.
- The failures were test-harness issues, not product rollback conditions: ReMemes browse could assert before `/api/rememes` settled, legacy content routes can occasionally receive transient document 502s, Google CSP report POSTs were treated as unsafe mutations, the production ReMemes detail title no longer requires the `| 6529.io` suffix, and live Waves data can place external links before internal wave-detail links.

## Fix
- Harden the production-safe read-only Playwright harness without changing app runtime behavior.
- Add a shared document navigation helper that retries once only for explicit top-level `502/503/504` document responses, then throws a direct error if the retry still receives a transient response.
- Keep mutation safety strict by aborting only exact Google CSP script-inclusion reports while continuing to block malformed lookalikes.
- Make ReMemes and Waves/Profile assertions wait for the correct signals and select the intended internal app links.
- Add Jest coverage for the new route-readiness retry contract.

## Changes
- `tests/support/routeReadiness.ts`: adds `gotoDocumentWithTransientRetry` and uses it from shared route readiness.
- `__tests__/playwright/routeReadiness.test.ts`: covers successful pass-through, non-transient pass-through, transient retry, persistent transient throw, and transient-then-null behavior.
- Production-readonly specs with local navigation wrappers now use the same transient-document helper.
- ReMemes browse waits for `/api/rememes` and checks either the wide-screen logo or the responsive `Collection: ReMemes` control before filters/cards.
- ReMemes detail fixture accepts `SeizeGenart | ReMemes` with the previous site suffix still allowed.
- Waves/Profile legacy-link coverage polls for the first UUID-shaped internal `/waves/{id}` link inside the wave-list region.
- `readonlyMutationGuard` aborts exact `csp.withgoogle.com/csp/script-inclusions/<32-hex>` report POSTs and blocks non-matching report-like POSTs, including 31-char, 33-char, non-hex, and trailing-slash cases.
- Workstream memory records the shipped PR #2846 state, this hardening slice, and reviewbot/GLM follow-ups.

## Validation
- `seize exec prettier --check ...`
- `seize run test:no-coverage -- __tests__/playwright/routeReadiness.test.ts __tests__/playwright/readonlyMutationGuard.test.ts` (20 passed)
- `seize run typecheck:playwright`
- `seize run lint:changed`
- `seize run typecheck:changed`
- Focused production ReMemes browse check: 1 passed
- Focused production ReMemes detail check: 1 passed
- Focused production Waves/Profile legacy-link check: 1 passed
- Focused production ReMemes and `/education` soak before final verifier tweak: 3/3 each passed
- `seize run test:e2e:production:readonly` (65 passed) after initial patch
- `seize run test:e2e:production:readonly` (65 passed) after reviewbot/live-data follow-up
- `seize run test:e2e:production:readonly` (65 passed) after GLM-requested Waves/Profile selector hardening
- `codex-diff-check`

## Risk
- Level: Low
- Why: test-only harness/spec updates plus workstream memory; no runtime app code, API behavior, auth, wallet, data mutation, dependency, or deploy config changes.
- Rollback: revert this PR to restore the previous assertions/guard behavior. The worst expected impact is production-readonly validation becoming noisier again.

## Review Notes
- Please focus on the narrowness of the transient retry: one retry, document navigation only, explicit `502/503/504`, direct failure if the transient response persists.
- Please check the Google CSP allowance remains abort-only and exact enough to avoid masking arbitrary external writes.
- Please check the ReMemes and Waves/Profile assertions still preserve useful product signal while matching current production behavior.
- Existing reviewbot lanes must remain additive; this PR does not remove or weaken any bot configuration.