### PR TITLE
Add guarded chat-drop sandbox E2E coverage

### DIFF
--- a/ops/workstreams/frontend-a11y-i18n/active-context.md
+++ b/ops/workstreams/frontend-a11y-i18n/active-context.md
@@ -4,6 +4,26 @@
 
 Read this section first after compaction or handoff.
 
+- Latest testing-roadmap state, 2026-06-23T08:10Z:
+  - Current rebase worktree:
+    `D:\repos\6529seize-frontend-native-shell-readonly`.
+  - Current active branch:
+    `codex/e2e-upload-admin-guards`, rebasing PR #2850 onto current
+    `origin/main` after PR #2855 merged.
+  - Active slice is local-only guarded chat-drop sandbox E2E coverage:
+    the mock composer sandbox allows exactly one synthetic chat-drop POST with
+    the expected body and signature shape, then rejects duplicate or non-exact
+    drop bodies with 409 responses. All other dangerous composer/drop/media
+    mutation paths remain fail-closed.
+  - Rebase conflict was limited to workstream memory files
+    (`active-context.md`, `run-log.md`). Code conflicts have not appeared in
+    the sandbox server or Playwright spec so far.
+  - Before republishing PR #2850, rerun focused sandbox validation, Playwright
+    typecheck, changed typecheck/lint or focused ESLint as needed, risk/secret
+    scans, workflow-security scan, and `codex-diff-check`, then trigger the
+    unchanged existing reviewbot lanes plus GLM-swarm. Do not weaken any
+    existing reviewbot lane.
+
 - Latest testing-roadmap state, 2026-06-23T05:00Z:
   - Current active worktree:
     `D:\repos\6529seize-frontend-admin-guards`.

--- a/ops/workstreams/frontend-a11y-i18n/run-log.md
+++ b/ops/workstreams/frontend-a11y-i18n/run-log.md
@@ -3810,3 +3810,21 @@ test-results/app-pr-ci/public-groups-tools-secret-scan.json`: clean.
   ESLint command above passed.
 - Next action: amend the follow-up commit with this evidence, force-push with
   lease, then trigger the full existing 6529reviewbot lane set plus GLM-swarm.
+
+## 2026-06-23T08:10Z PR #2850 Rebase Restart
+
+- PR #2855 was merged to `origin/main` as
+  `0ae8b27f6b1d1f1ec1061fe8180d2d87cb18c6e7`, so PR #2850
+  (`codex/e2e-upload-admin-guards`) needed a current-main rebase before it
+  could be merged.
+- Started the rebase in
+  `D:\repos\6529seize-frontend-native-shell-readonly`.
+- The first rebase conflict was limited to workstream memory files:
+  `ops/workstreams/frontend-a11y-i18n/active-context.md` and
+  `ops/workstreams/frontend-a11y-i18n/run-log.md`.
+- Resolved by keeping the newer main-side deployment/admin-guard timeline and
+  adding this current PR #2850 note instead of preserving stale "current
+  branch" text from before the later deployment train.
+- Next action: finish the rebase, run the focused chat-drop sandbox validation
+  set, push the rebased head, and re-trigger the unchanged existing
+  reviewbot lanes plus GLM-swarm.

--- a/tests/README.md
+++ b/tests/README.md
@@ -123,21 +123,25 @@ Surface matrix:
 - `test:e2e:composer-sandbox` runs a local-only authenticated Waves composer
   sandbox on both baseline web projects. It starts a mock API runtime,
   renders a real wave detail route, verifies attachment queue/remove behavior
-  and deterministic link previews, and fails if composer submit/upload
-  endpoints are touched. It must run against a loopback base URL, but it is not
-  a full network-isolation harness and is not a staging or production smoke
-  pack.
+  and deterministic link previews, plus one exact synthetic chat-drop submit.
+  The mock API allows only that queryless `/api/drops` shape, with signer
+  limited to the configured sandbox wallet or the empty unsigned direct-contract
+  form; upload and attachment endpoints still fail closed. It must run against a
+  loopback base URL, but it is not a full network-isolation harness and is not a
+  staging or production smoke pack.
 - `test:e2e:auth-sandbox` runs the local authenticated sandbox on desktop
   Chromium. It includes the composer checks plus positive `/notifications`
   `/messages/create`, and `/waves/create` Chat-wave flows with deterministic
   mock API data. It allows only explicit local sandbox mutations such as
-  notification mark-read, synthetic direct-message creation, and synthetic
-  create-wave group/wave creation with exact sandbox IDs, queryless paths, and
-  request bodies. Unknown mock API writes fail the sandbox request audit, and
-  unexpected same-origin Next.js API writes or unknown unsafe external browser
-  writes are blocked by a browser route guard. Known wallet and analytics SDK
-  background writes are still blocked in-browser, but they do not fail the test.
-  This pack must never run against staging or production.
+  notification mark-read, synthetic direct-message creation, synthetic
+  create-wave group/wave creation, and the synthetic chat-drop submit with exact
+  sandbox IDs, queryless paths, and request bodies. The chat-drop signer is
+  bounded to the configured sandbox wallet or the empty unsigned direct-contract
+  form. Unknown mock API writes fail the sandbox request audit, and unexpected
+  same-origin Next.js API writes or unknown unsafe external browser writes are
+  blocked by a browser route guard. Known wallet and analytics SDK background
+  writes are still blocked in-browser, but they do not fail the test. This pack
+  must never run against staging or production.
 - `test:e2e:staging:smoke` runs the smoke surface matrix against staging.
 - `test:e2e:staging` runs the broader surface matrix against the same
   environment.
@@ -291,10 +295,11 @@ Large-pack ownership:
 - `test:e2e:composer-sandbox` is owned by PR or train owners changing Waves
   composer input, attachment preview/removal, link preview rendering, dev-auth
   composer eligibility, or local sandbox/mock API coverage. The pack may use
-  local synthetic auth and a mock API, but it must never submit a drop or upload
-  files to staging or production. Treat it as coverage for composer/drop/upload
-  API safety, not as a guarantee that every external read-only media or metadata
-  endpoint is isolated.
+  local synthetic auth and a mock API, and it may submit only the synthetic
+  chat-drop shape modeled by the mock API with the bounded sandbox signer. It
+  must never submit drops or upload files to staging or production. Treat it as
+  coverage for composer/drop/upload API safety, not as a guarantee that every
+  external read-only media or metadata endpoint is isolated.
 - `test:e2e:production:readonly` is owned by the release captain or validation
   agent after a production deploy. It is a production-safe aggregate of the
   individual public read-only packs on desktop Chromium and is the command

--- a/tests/social/waves-composer-sandbox.spec.ts
+++ b/tests/social/waves-composer-sandbox.spec.ts
@@ -147,7 +147,9 @@ test.describe("Waves composer local sandbox @auth @medium @local-only", () => {
         metadata_count: 0,
         signature: null,
         is_safe_signature: false,
-        signer_address: SANDBOX_WALLET,
+        signer_address: expect.stringMatching(
+          new RegExp(`^${SANDBOX_WALLET}$`, "i")
+        ),
       }),
     });
 

--- a/tests/social/waves-composer-sandbox.spec.ts
+++ b/tests/social/waves-composer-sandbox.spec.ts
@@ -151,6 +151,7 @@ test.describe("Waves composer local sandbox @auth @medium @local-only", () => {
       }),
     });
 
+    // Optimistic drops use timestamp serials; serial 2 is the mock server drop.
     const submittedDrop = page.locator('[data-serial-no="2"]');
     await expect(submittedDrop).toBeVisible({
       timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
@@ -171,6 +172,8 @@ test.describe("Waves composer local sandbox @auth @medium @local-only", () => {
   test("rejects repeated exact-shape chat drop mutation bodies", async ({
     baseURL,
   }) => {
+    await resetSandboxRequests(baseURL);
+
     const exactBody = buildExactChatDropBody();
     const apiOrigin = getSandboxApiOrigin(baseURL);
 
@@ -210,6 +213,8 @@ test.describe("Waves composer local sandbox @auth @medium @local-only", () => {
   });
 
   test("rejects non-exact chat drop mutation bodies", async ({ baseURL }) => {
+    await resetSandboxRequests(baseURL);
+
     const response = await fetch(`${getSandboxApiOrigin(baseURL)}/api/drops`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/tests/social/waves-composer-sandbox.spec.ts
+++ b/tests/social/waves-composer-sandbox.spec.ts
@@ -9,14 +9,19 @@ import {
 import {
   dismissNextDevTools,
   expectNoUnsafeSandboxMutations,
+  fetchSandboxRequests,
+  getSandboxApiOrigin,
   LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
+  resetSandboxRequests,
   useLocalSandboxMutationGuard,
 } from "../support/localSandbox";
 
 const SANDBOX_WAVE_ID = "00000000-0000-4000-8000-000000000529";
+const SANDBOX_WALLET = "0x0000000000000000000000000000000000000529";
 const PREVIEW_URL = "https://example.com/6529-composer-preview";
 const PREVIEW_TITLE = "Sandbox Preview Title";
 const PREVIEW_DESCRIPTION = "Deterministic local preview served by Playwright.";
+const SANDBOX_CHAT_DROP_CONTENT = "Local-only chat drop from Playwright.";
 
 test.describe.configure({ mode: "serial" });
 
@@ -89,7 +94,181 @@ test.describe("Waves composer local sandbox @auth @medium @local-only", () => {
     await expectNoHorizontalOverflow(page);
     await expectNoUnsafeSandboxMutations(baseURL);
   });
+
+  test("submits one exact-shape synthetic chat drop without uploads", async ({
+    baseURL,
+    page,
+  }) => {
+    await gotoSandboxWave(page);
+
+    const composer = page
+      .getByRole("textbox", { name: "Write a chat message" })
+      .last();
+    await composer.fill(SANDBOX_CHAT_DROP_CONTENT);
+    await expect(
+      page.getByRole("button", { name: "Post" }).last()
+    ).toBeEnabled();
+
+    await page.getByRole("button", { name: "Post" }).last().click();
+
+    await expect
+      .poll(
+        async () =>
+          (await fetchSandboxRequests(baseURL))
+            .filter(
+              (request) =>
+                request.method === "POST" && request.path === "/api/drops"
+            )
+            .map((request) => request.kind),
+        {
+          timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
+          message: "Expected exactly one chat submit to reach the mock API.",
+        }
+      )
+      .toEqual(["allowed-sandbox-mutation"]);
+
+    const dropRequests = (await fetchSandboxRequests(baseURL)).filter(
+      (request) => request.method === "POST" && request.path === "/api/drops"
+    );
+    expect(dropRequests).toHaveLength(1);
+    expect(dropRequests[0]).toMatchObject({
+      kind: "allowed-sandbox-mutation",
+      body: expect.objectContaining({
+        wave_id: SANDBOX_WAVE_ID,
+        drop_type: "CHAT",
+        content: SANDBOX_CHAT_DROP_CONTENT,
+        part_count: 1,
+        media_count: 0,
+        has_attachments: false,
+        referenced_nfts_count: 0,
+        mentioned_users_count: 0,
+        mentioned_groups_count: 0,
+        mentioned_waves_count: 0,
+        metadata_count: 0,
+        signature: null,
+        is_safe_signature: false,
+        signer_address: SANDBOX_WALLET,
+      }),
+    });
+
+    const submittedDrop = page.locator('[data-serial-no="2"]');
+    await expect(submittedDrop).toBeVisible({
+      timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
+    });
+    await expect(submittedDrop).toContainText(SANDBOX_CHAT_DROP_CONTENT);
+
+    const requests = await fetchSandboxRequests(baseURL);
+    expect(
+      requests.some((request) => request.path.startsWith("/api/drop-media"))
+    ).toBe(false);
+    expect(
+      requests.some((request) => request.path.startsWith("/api/attachments"))
+    ).toBe(false);
+    await expectNoHorizontalOverflow(page);
+    await expectNoUnsafeSandboxMutations(baseURL);
+  });
+
+  test("rejects repeated exact-shape chat drop mutation bodies", async ({
+    baseURL,
+  }) => {
+    const exactBody = buildExactChatDropBody();
+    const apiOrigin = getSandboxApiOrigin(baseURL);
+
+    const firstResponse = await fetch(`${apiOrigin}/api/drops`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(exactBody),
+    });
+    expect(firstResponse.status).toBe(200);
+
+    const secondResponse = await fetch(`${apiOrigin}/api/drops`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(exactBody),
+    });
+    expect(secondResponse.status).toBe(409);
+
+    await expect
+      .poll(
+        async () =>
+          (await fetchSandboxRequests(baseURL))
+            .filter(
+              (request) =>
+                request.method === "POST" && request.path === "/api/drops"
+            )
+            .map((request) => request.kind),
+        {
+          timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
+          message:
+            "Expected the mock API to allow one exact-shape submit only.",
+        }
+      )
+      .toEqual(["allowed-sandbox-mutation", "dangerous-composer-mutation"]);
+
+    await resetSandboxRequests(baseURL);
+    await expectNoUnsafeSandboxMutations(baseURL);
+  });
+
+  test("rejects non-exact chat drop mutation bodies", async ({ baseURL }) => {
+    const response = await fetch(`${getSandboxApiOrigin(baseURL)}/api/drops`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...buildExactChatDropBody(),
+        parts: [
+          {
+            content: "Unexpected sandbox chat body",
+            quoted_drop: null,
+            media: [],
+          },
+        ],
+      }),
+    });
+
+    expect(response.status).toBe(409);
+    await expect
+      .poll(async () => await fetchSandboxRequests(baseURL), {
+        timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
+        message: "Expected the mock API to log the rejected drop mutation.",
+      })
+      .toContainEqual(
+        expect.objectContaining({
+          method: "POST",
+          path: "/api/drops",
+          kind: "dangerous-composer-mutation",
+          body: expect.objectContaining({
+            content: "Unexpected sandbox chat body",
+          }),
+        })
+      );
+
+    await resetSandboxRequests(baseURL);
+    await expectNoUnsafeSandboxMutations(baseURL);
+  });
 });
+
+function buildExactChatDropBody() {
+  return {
+    wave_id: SANDBOX_WAVE_ID,
+    drop_type: "CHAT",
+    title: null,
+    parts: [
+      {
+        content: SANDBOX_CHAT_DROP_CONTENT,
+        quoted_drop: null,
+        media: [],
+      },
+    ],
+    referenced_nfts: [],
+    mentioned_users: [],
+    mentioned_groups: [],
+    mentioned_waves: [],
+    metadata: [],
+    signature: null,
+    is_safe_signature: false,
+    signer_address: "",
+  };
+}
 
 async function gotoSandboxWave(page: Page) {
   await installExternalDataFixtures(page);

--- a/tests/support/composerSandboxServer.cjs
+++ b/tests/support/composerSandboxServer.cjs
@@ -1070,6 +1070,7 @@ function isKnownSandboxMutation(method, pathname, searchParams, body) {
   }
 
   if (pathname === "/api/drops") {
+    // The diagnostics reset bounds this synthetic chat submit to one accepted request.
     return isExpectedChatDropBody(body) && !hasAcceptedChatDropSubmit();
   }
 
@@ -1246,238 +1247,189 @@ function handleDiagnostics(method, pathname, res) {
   return false;
 }
 
-function handleMockApi(method, pathname, url, body, res, requestKind) {
-  if (pathname === "/api/community-members" && isSafeReadMethod(method)) {
-    const query = url.searchParams.get("param") ?? "";
-    const members =
-      query.trim().length >= 3 ? [dmRecipientCommunityMember] : [];
-    writeJson(res, 200, members);
-    return true;
-  }
+function writeJsonResponse(res, payload) {
+  writeJson(res, 200, payload);
+  return true;
+}
 
-  if (pathname === "/api/groups" && isSafeReadMethod(method)) {
-    writeJson(res, 200, []);
-    return true;
-  }
+function writeEmptyResponse(res, status) {
+  writeEmpty(res, status);
+  return true;
+}
 
-  if (pathname === "/api/v2/waves" && isSafeReadMethod(method)) {
-    writeJson(res, 200, { data: [localWaveOverview], page: 1, next: false });
-    return true;
-  }
+const mockApiExactReadRoutes = new Map([
+  ["/api/groups", () => []],
+  [
+    "/api/v2/waves",
+    () => ({ data: [localWaveOverview], page: 1, next: false }),
+  ],
+  ["/api/v2/official-waves", () => [localWaveOverview]],
+  [`/api/waves/${SANDBOX_DM_WAVE_ID}`, () => dmWave],
+  [
+    `/api/v2/waves/${SANDBOX_DM_WAVE_ID}/drops`,
+    () => ({ wave: dmWaveOverview, drops: [] }),
+  ],
+  [`/api/waves/${SANDBOX_CREATED_WAVE_ID}`, () => createdWave],
+  [
+    `/api/v2/waves/${SANDBOX_CREATED_WAVE_ID}/drops`,
+    () => ({ wave: createdWaveOverview, drops: [createdWaveDrop] }),
+  ],
+  ["/api/v2/boosted-drops", () => emptyPage()],
+  ["/api/v2/drops", () => emptyPage()],
+  ["/api/feed", () => []],
+]);
 
-  if (pathname === "/api/v2/official-waves" && isSafeReadMethod(method)) {
-    writeJson(res, 200, [localWaveOverview]);
-    return true;
-  }
-
-  if (
-    pathname === `/api/waves/${SANDBOX_DM_WAVE_ID}` &&
-    isSafeReadMethod(method)
-  ) {
-    writeJson(res, 200, dmWave);
-    return true;
-  }
-
-  if (
-    pathname === `/api/v2/waves/${SANDBOX_DM_WAVE_ID}/drops` &&
-    isSafeReadMethod(method)
-  ) {
-    writeJson(res, 200, { wave: dmWaveOverview, drops: [] });
-    return true;
-  }
-
-  if (
-    pathname === `/api/waves/${SANDBOX_CREATED_WAVE_ID}` &&
-    isSafeReadMethod(method)
-  ) {
-    writeJson(res, 200, createdWave);
-    return true;
-  }
-
-  if (
-    pathname === `/api/v2/waves/${SANDBOX_CREATED_WAVE_ID}/drops` &&
-    isSafeReadMethod(method)
-  ) {
-    writeJson(res, 200, {
-      wave: createdWaveOverview,
-      drops: [createdWaveDrop],
-    });
-    return true;
-  }
-
-  if (/^\/api\/waves\/[^/]+$/.test(pathname) && isSafeReadMethod(method)) {
-    writeJson(res, 200, localWave);
-    return true;
-  }
-
-  if (
-    /^\/api\/v2\/waves\/[^/]+\/drops$/.test(pathname) &&
-    isSafeReadMethod(method)
-  ) {
-    writeJson(res, 200, { wave: localWaveOverview, drops: [localDrop] });
-    return true;
-  }
-
-  if (
-    /^\/api\/v2\/waves\/[^/]+\/search$/.test(pathname) &&
-    isSafeReadMethod(method)
-  ) {
-    writeJson(res, 200, { data: [], page: 1, next: false });
-    return true;
-  }
-
-  if (
-    /^\/api\/v2\/waves\/[^/]+\/leaderboard$/.test(pathname) &&
-    isSafeReadMethod(method)
-  ) {
-    writeJson(res, 200, {
+const mockApiPatternReadRoutes = [
+  { pattern: /^\/api\/waves\/[^/]+$/, response: () => localWave },
+  {
+    pattern: /^\/api\/v2\/waves\/[^/]+\/drops$/,
+    response: () => ({ wave: localWaveOverview, drops: [localDrop] }),
+  },
+  {
+    pattern: /^\/api\/v2\/waves\/[^/]+\/search$/,
+    response: () => ({ data: [], page: 1, next: false }),
+  },
+  {
+    pattern: /^\/api\/v2\/waves\/[^/]+\/leaderboard$/,
+    response: () => ({
       wave: localWaveMin,
       drops: [],
       count: 0,
       page: 1,
       next: false,
-    });
-    return true;
+    }),
+  },
+  { pattern: /^\/api\/v2\/waves\/[^/]+\/polls$/, response: () => emptyPage() },
+  { pattern: /^\/api\/waves\/[^/]+\/subwaves$/, response: () => emptyPage() },
+  { pattern: /^\/api\/v2\/waves\/[^/]+\/metadata$/, response: () => [] },
+  { pattern: /^\/api\/v2\/drops\/[^/]+\/metadata$/, response: () => [] },
+  { pattern: /^\/api\/v2\/drops\/[^/]+\/reactions$/, response: () => [] },
+  { pattern: /^\/api\/identities\/[^/]+$/, response: () => localProfile },
+  { pattern: /^\/api\/profiles\/[^/]+\/proxies$/, response: () => [] },
+];
+
+function handleCommunityMemberRead(pathname, url, res) {
+  if (pathname !== "/api/community-members") {
+    return false;
   }
 
-  if (
-    /^\/api\/v2\/waves\/[^/]+\/polls$/.test(pathname) &&
-    isSafeReadMethod(method)
-  ) {
-    writeJson(res, 200, emptyPage());
-    return true;
+  const query = url.searchParams.get("param") ?? "";
+  const members = query.trim().length >= 3 ? [dmRecipientCommunityMember] : [];
+  return writeJsonResponse(res, members);
+}
+
+function handleNotificationRead(pathname, url, res) {
+  if (pathname !== "/api/v2/notifications") {
+    return false;
   }
 
-  if (
-    /^\/api\/waves\/[^/]+\/subwaves$/.test(pathname) &&
-    isSafeReadMethod(method)
-  ) {
-    writeJson(res, 200, emptyPage());
-    return true;
+  return writeJsonResponse(res, notificationResponse(url.searchParams));
+}
+
+function handleExactMockApiRead(pathname, res) {
+  const response = mockApiExactReadRoutes.get(pathname);
+  if (!response) {
+    return false;
   }
 
-  if (
-    /^\/api\/v2\/waves\/[^/]+\/metadata$/.test(pathname) &&
-    isSafeReadMethod(method)
-  ) {
-    writeJson(res, 200, []);
-    return true;
+  return writeJsonResponse(res, response());
+}
+
+function handlePatternMockApiRead(pathname, res) {
+  const route = mockApiPatternReadRoutes.find(({ pattern }) =>
+    pattern.test(pathname)
+  );
+  if (!route) {
+    return false;
   }
 
-  if (pathname === "/api/v2/boosted-drops" && isSafeReadMethod(method)) {
-    writeJson(res, 200, emptyPage());
-    return true;
+  return writeJsonResponse(res, route.response());
+}
+
+function handleMockApiRead(method, pathname, url, res) {
+  if (!isSafeReadMethod(method)) {
+    return false;
   }
 
-  if (pathname === "/api/v2/drops" && isSafeReadMethod(method)) {
-    writeJson(res, 200, emptyPage());
-    return true;
+  return (
+    handleCommunityMemberRead(pathname, url, res) ||
+    handleNotificationRead(pathname, url, res) ||
+    handleExactMockApiRead(pathname, res) ||
+    handlePatternMockApiRead(pathname, res)
+  );
+}
+
+function isNotificationMutationPath(pathname) {
+  return (
+    pathname === "/api/notifications/read" ||
+    Boolean(notificationIdFromPath(pathname))
+  );
+}
+
+const mockApiKnownPostRoutes = [
+  {
+    matches: (pathname) => pathname === "/api/groups",
+    respond: (res) =>
+      writeJsonResponse(res, { ...sandboxAdminGroup, visible: false }),
+  },
+  {
+    matches: (pathname) =>
+      pathname === `/api/groups/${SANDBOX_ADMIN_GROUP_ID}/visible`,
+    respond: (res) => writeJsonResponse(res, sandboxAdminGroup),
+  },
+  {
+    matches: (pathname) => pathname === "/api/waves",
+    respond: (res) => writeJsonResponse(res, createdWave),
+  },
+  {
+    matches: (pathname) => Boolean(notificationWaveIdFromPath(pathname)),
+    respond: (res) => writeEmptyResponse(res, 204),
+  },
+  {
+    matches: isNotificationMutationPath,
+    respond: (res) => writeEmptyResponse(res, 204),
+  },
+  {
+    matches: (pathname) => pathname === "/api/waves/direct-message/new",
+    respond: (res) => writeJsonResponse(res, dmWave),
+  },
+];
+
+function handleAllowedChatDropPost(method, pathname, requestKind, res) {
+  if (method !== "POST" || pathname !== "/api/drops") {
+    return false;
   }
 
-  if (
-    /^\/api\/v2\/drops\/[^/]+\/metadata$/.test(pathname) &&
-    isSafeReadMethod(method)
-  ) {
-    writeJson(res, 200, []);
-    return true;
+  if (requestKind !== "allowed-sandbox-mutation") {
+    return false;
   }
 
-  if (
-    /^\/api\/v2\/drops\/[^/]+\/reactions$/.test(pathname) &&
-    isSafeReadMethod(method)
-  ) {
-    writeJson(res, 200, []);
-    return true;
+  return writeJsonResponse(res, submittedChatDrop);
+}
+
+function handleKnownSandboxPost(method, pathname, url, body, res) {
+  if (method !== "POST") {
+    return false;
   }
 
-  if (/^\/api\/identities\/[^/]+$/.test(pathname) && isSafeReadMethod(method)) {
-    writeJson(res, 200, localProfile);
-    return true;
+  if (!isKnownSandboxMutation(method, pathname, url.searchParams, body)) {
+    return false;
   }
 
-  if (
-    /^\/api\/profiles\/[^/]+\/proxies$/.test(pathname) &&
-    isSafeReadMethod(method)
-  ) {
-    writeJson(res, 200, []);
-    return true;
+  const route = mockApiKnownPostRoutes.find(({ matches }) => matches(pathname));
+  if (!route) {
+    return false;
   }
 
-  if (pathname === "/api/v2/notifications" && isSafeReadMethod(method)) {
-    writeJson(res, 200, notificationResponse(url.searchParams));
-    return true;
-  }
+  return route.respond(res);
+}
 
-  if (pathname === "/api/feed" && isSafeReadMethod(method)) {
-    writeJson(res, 200, []);
-    return true;
-  }
-
-  if (
-    method === "POST" &&
-    pathname === "/api/drops" &&
-    requestKind === "allowed-sandbox-mutation"
-  ) {
-    writeJson(res, 200, submittedChatDrop);
-    return true;
-  }
-
-  if (
-    method === "POST" &&
-    pathname === "/api/groups" &&
-    isKnownSandboxMutation(method, pathname, url.searchParams, body)
-  ) {
-    writeJson(res, 200, { ...sandboxAdminGroup, visible: false });
-    return true;
-  }
-
-  if (
-    method === "POST" &&
-    pathname === `/api/groups/${SANDBOX_ADMIN_GROUP_ID}/visible` &&
-    isKnownSandboxMutation(method, pathname, url.searchParams, body)
-  ) {
-    writeJson(res, 200, sandboxAdminGroup);
-    return true;
-  }
-
-  if (
-    method === "POST" &&
-    pathname === "/api/waves" &&
-    isKnownSandboxMutation(method, pathname, url.searchParams, body)
-  ) {
-    writeJson(res, 200, createdWave);
-    return true;
-  }
-
-  if (
-    method === "POST" &&
-    notificationWaveIdFromPath(pathname) &&
-    isKnownSandboxMutation(method, pathname, url.searchParams, body)
-  ) {
-    writeEmpty(res, 204);
-    return true;
-  }
-
-  if (
-    method === "POST" &&
-    (pathname === "/api/notifications/read" ||
-      notificationIdFromPath(pathname)) &&
-    isKnownSandboxMutation(method, pathname, url.searchParams, body)
-  ) {
-    writeEmpty(res, 204);
-    return true;
-  }
-
-  if (
-    method === "POST" &&
-    pathname === "/api/waves/direct-message/new" &&
-    isKnownSandboxMutation(method, pathname, url.searchParams, body)
-  ) {
-    writeJson(res, 200, dmWave);
-    return true;
-  }
-
-  return false;
+function handleMockApi(method, pathname, url, body, res, requestKind) {
+  return (
+    handleMockApiRead(method, pathname, url, res) ||
+    handleAllowedChatDropPost(method, pathname, requestKind, res) ||
+    handleKnownSandboxPost(method, pathname, url, body, res)
+  );
 }
 
 function readRequestBody(req) {

--- a/tests/support/composerSandboxServer.cjs
+++ b/tests/support/composerSandboxServer.cjs
@@ -35,9 +35,11 @@ const SANDBOX_NOTIFICATION_REACTION_DROP_ID =
 const SANDBOX_CREATED_WAVE_ID = "00000000-0000-4000-8000-000000000536";
 const SANDBOX_ADMIN_GROUP_ID = "00000000-0000-4000-8000-000000000537";
 const SANDBOX_CREATED_WAVE_DROP_ID = "00000000-0000-4000-8000-000000000538";
+const SANDBOX_SUBMITTED_CHAT_DROP_ID = "00000000-0000-4000-8000-000000000539";
 const SANDBOX_CREATED_WAVE_NAME = "Sandbox Created Wave";
 const SANDBOX_CREATED_WAVE_DESCRIPTION =
   "Local-only create-wave description for Playwright.";
+const SANDBOX_CHAT_DROP_CONTENT = "Local-only chat drop from Playwright.";
 const CREATED_AT = 1713744000000;
 const PREVIEW_URL = "https://example.com/6529-composer-preview";
 const publicScope = { group: null };
@@ -367,6 +369,55 @@ const localDrop = {
   nft_links: [],
 };
 
+const submittedChatDrop = {
+  id: SANDBOX_SUBMITTED_CHAT_DROP_ID,
+  serial_no: 2,
+  drop_type: "CHAT",
+  rank: null,
+  wave: localWaveMin,
+  author: localProfile,
+  created_at: CREATED_AT + 2000,
+  updated_at: null,
+  title: null,
+  parts: [
+    {
+      part_id: 1,
+      content: SANDBOX_CHAT_DROP_CONTENT,
+      media: [],
+      attachments: [],
+      quoted_drop: null,
+    },
+  ],
+  parts_count: 1,
+  referenced_nfts: [],
+  mentioned_users: [],
+  mentioned_groups: [],
+  mentioned_waves: [],
+  metadata: [],
+  rating: 0,
+  realtime_rating: 0,
+  rating_prediction: 0,
+  top_raters: [],
+  raters_count: 0,
+  context_profile_context: {
+    rating: 0,
+    min_rating: 0,
+    max_rating: 0,
+    reaction: null,
+    boosted: false,
+    bookmarked: false,
+    curatable: false,
+    curated: false,
+  },
+  subscribed_actions: [],
+  is_signed: false,
+  reactions: [],
+  boosts: 0,
+  is_additional_action_promised: false,
+  hide_link_preview: false,
+  nft_links: [],
+};
+
 const createdWaveMin = {
   ...localWaveMin,
   id: SANDBOX_CREATED_WAVE_ID,
@@ -684,6 +735,81 @@ function isExpectedDirectMessageBody(body) {
   );
 }
 
+function isExpectedChatDropPart(part) {
+  return (
+    hasOnlyKeys(part, ["content", "media", "quoted_drop"]) &&
+    part.content === SANDBOX_CHAT_DROP_CONTENT &&
+    part.quoted_drop === null &&
+    Array.isArray(part.media) &&
+    part.media.length === 0
+  );
+}
+
+function isExpectedChatDropSignerAddress(signerAddress) {
+  return signerAddress === "" || isSameAddress(signerAddress, SANDBOX_WALLET);
+}
+
+function isExpectedChatDropBody(body) {
+  if (
+    !hasOnlyKeys(body, [
+      "drop_type",
+      "is_safe_signature",
+      "mentioned_groups",
+      "mentioned_users",
+      "mentioned_waves",
+      "metadata",
+      "parts",
+      "referenced_nfts",
+      "signature",
+      "signer_address",
+      "title",
+      "wave_id",
+    ])
+  ) {
+    return false;
+  }
+
+  return (
+    body.wave_id === SANDBOX_WAVE_ID &&
+    body.drop_type === "CHAT" &&
+    body.title === null &&
+    body.signature === null &&
+    body.is_safe_signature === false &&
+    isExpectedChatDropSignerAddress(body.signer_address) &&
+    Array.isArray(body.parts) &&
+    body.parts.length === 1 &&
+    isExpectedChatDropPart(body.parts[0]) &&
+    Array.isArray(body.referenced_nfts) &&
+    body.referenced_nfts.length === 0 &&
+    Array.isArray(body.mentioned_users) &&
+    body.mentioned_users.length === 0 &&
+    Array.isArray(body.mentioned_groups) &&
+    body.mentioned_groups.length === 0 &&
+    Array.isArray(body.mentioned_waves) &&
+    body.mentioned_waves.length === 0 &&
+    Array.isArray(body.metadata) &&
+    body.metadata.length === 0
+  );
+}
+
+function hasAcceptedChatDropSubmit() {
+  return requests.some(
+    (request) =>
+      request.method === "POST" &&
+      request.path === "/api/drops" &&
+      request.kind === "allowed-sandbox-mutation"
+  );
+}
+
+function isLatestAllowedChatDropSubmit() {
+  const latestRequest = requests[requests.length - 1];
+  return (
+    latestRequest?.method === "POST" &&
+    latestRequest.path === "/api/drops" &&
+    latestRequest.kind === "allowed-sandbox-mutation"
+  );
+}
+
 function hasOnlyKeys(value, expectedKeys) {
   if (!isPlainObject(value)) {
     return false;
@@ -952,6 +1078,10 @@ function isKnownSandboxMutation(method, pathname, searchParams, body) {
     return isEmptyRequestBody(body);
   }
 
+  if (pathname === "/api/drops") {
+    return isExpectedChatDropBody(body) && !hasAcceptedChatDropSubmit();
+  }
+
   if (pathname === "/api/groups") {
     return isExpectedCreateAdminGroupBody(body);
   }
@@ -987,11 +1117,11 @@ function isKnownSandboxMutation(method, pathname, searchParams, body) {
 }
 
 function classifyRequest(method, pathname, searchParams, body) {
-  if (isDangerousComposerMutation(method, pathname)) {
-    return "dangerous-composer-mutation";
-  }
   if (isKnownSandboxMutation(method, pathname, searchParams, body)) {
     return "allowed-sandbox-mutation";
+  }
+  if (isDangerousComposerMutation(method, pathname)) {
+    return "dangerous-composer-mutation";
   }
   if (!isSafeReadMethod(method)) {
     return "unhandled-mutation";
@@ -1028,6 +1158,38 @@ function loggedRequestBody(pathname, body) {
     return {
       visible: body.visible,
       old_version_id: body.old_version_id,
+    };
+  }
+
+  if (pathname === "/api/drops") {
+    const firstPart = Array.isArray(body.parts) ? body.parts[0] : null;
+    return {
+      wave_id: typeof body.wave_id === "string" ? body.wave_id : null,
+      drop_type: typeof body.drop_type === "string" ? body.drop_type : null,
+      content: isPlainObject(firstPart) ? firstPart.content : null,
+      part_count: Array.isArray(body.parts) ? body.parts.length : 0,
+      part_keys: isPlainObject(firstPart) ? sortedKeys(firstPart) : [],
+      media_count: Array.isArray(firstPart?.media) ? firstPart.media.length : 0,
+      has_attachments:
+        isPlainObject(firstPart) &&
+        Object.prototype.hasOwnProperty.call(firstPart, "attachments"),
+      referenced_nfts_count: Array.isArray(body.referenced_nfts)
+        ? body.referenced_nfts.length
+        : 0,
+      mentioned_users_count: Array.isArray(body.mentioned_users)
+        ? body.mentioned_users.length
+        : 0,
+      mentioned_groups_count: Array.isArray(body.mentioned_groups)
+        ? body.mentioned_groups.length
+        : 0,
+      mentioned_waves_count: Array.isArray(body.mentioned_waves)
+        ? body.mentioned_waves.length
+        : 0,
+      metadata_count: Array.isArray(body.metadata) ? body.metadata.length : 0,
+      signature: body.signature,
+      is_safe_signature: body.is_safe_signature,
+      signer_address: body.signer_address,
+      keys: sortedKeys(body),
     };
   }
 
@@ -1256,6 +1418,15 @@ function handleMockApi(method, pathname, url, body, res) {
 
   if (pathname === "/api/feed" && isSafeReadMethod(method)) {
     writeJson(res, 200, []);
+    return true;
+  }
+
+  if (
+    method === "POST" &&
+    pathname === "/api/drops" &&
+    isLatestAllowedChatDropSubmit()
+  ) {
+    writeJson(res, 200, submittedChatDrop);
     return true;
   }
 

--- a/tests/support/composerSandboxServer.cjs
+++ b/tests/support/composerSandboxServer.cjs
@@ -801,15 +801,6 @@ function hasAcceptedChatDropSubmit() {
   );
 }
 
-function isLatestAllowedChatDropSubmit() {
-  const latestRequest = requests[requests.length - 1];
-  return (
-    latestRequest?.method === "POST" &&
-    latestRequest.path === "/api/drops" &&
-    latestRequest.kind === "allowed-sandbox-mutation"
-  );
-}
-
 function hasOnlyKeys(value, expectedKeys) {
   if (!isPlainObject(value)) {
     return false;
@@ -1171,8 +1162,7 @@ function loggedRequestBody(pathname, body) {
       part_keys: isPlainObject(firstPart) ? sortedKeys(firstPart) : [],
       media_count: Array.isArray(firstPart?.media) ? firstPart.media.length : 0,
       has_attachments:
-        isPlainObject(firstPart) &&
-        Object.prototype.hasOwnProperty.call(firstPart, "attachments"),
+        isPlainObject(firstPart) && Object.hasOwn(firstPart, "attachments"),
       referenced_nfts_count: Array.isArray(body.referenced_nfts)
         ? body.referenced_nfts.length
         : 0,
@@ -1223,18 +1213,20 @@ function loggedRequestBody(pathname, body) {
 function recordRequest(method, url, body) {
   const pathname = normalizedPath(url);
   if (pathname.startsWith("/__composer-sandbox")) {
-    return;
+    return undefined;
   }
   if (method === "OPTIONS") {
-    return;
+    return undefined;
   }
   const loggedBody = loggedRequestBody(pathname, body);
+  const kind = classifyRequest(method, pathname, url.searchParams, body);
   requests.push({
     method,
     path: pathname,
-    kind: classifyRequest(method, pathname, url.searchParams, body),
+    kind,
     ...(loggedBody === undefined ? {} : { body: loggedBody }),
   });
+  return kind;
 }
 
 function requestLog() {
@@ -1254,7 +1246,7 @@ function handleDiagnostics(method, pathname, res) {
   return false;
 }
 
-function handleMockApi(method, pathname, url, body, res) {
+function handleMockApi(method, pathname, url, body, res, requestKind) {
   if (pathname === "/api/community-members" && isSafeReadMethod(method)) {
     const query = url.searchParams.get("param") ?? "";
     const members =
@@ -1424,7 +1416,7 @@ function handleMockApi(method, pathname, url, body, res) {
   if (
     method === "POST" &&
     pathname === "/api/drops" &&
-    isLatestAllowedChatDropSubmit()
+    requestKind === "allowed-sandbox-mutation"
   ) {
     writeJson(res, 200, submittedChatDrop);
     return true;
@@ -1552,9 +1544,9 @@ async function handleRequest(req, res) {
     });
     return;
   }
-  recordRequest(method, url, requestBody);
+  const requestKind = recordRequest(method, url, requestBody);
 
-  if (handleMockApi(method, pathname, url, requestBody, res)) {
+  if (handleMockApi(method, pathname, url, requestBody, res, requestKind)) {
     return;
   }
 


### PR DESCRIPTION
﻿## Issue
- The local composer/auth sandbox covered attachment queue/remove, deterministic link previews, notifications, direct-message creation, and create-wave flows, but it did not exercise the real chat-drop submit path.
- For the WCAG/i18n testing roadmap, this left a risky gap around posting: we could verify upload endpoints stayed blocked, but not that one deliberately safe local chat submit worked end to end.

## Fix
- Extend the local mock API so `POST /api/drops` is still dangerous by default, but one exact-shape synthetic chat-drop submit is allowed per sandbox reset.
- Keep upload and attachment endpoints fail-closed, including `/api/drop-media*` and `/api/attachments*`.
- Add browser E2E coverage proving the real composer can submit the synthetic chat drop locally and that malformed or repeated drop mutations are rejected.

## Changes
- Added a deterministic mock `ApiDrop` response for the sandbox chat submit.
- Added a strict `/api/drops` validator for the sandbox wave, text-only part, empty metadata/mention/NFT arrays, null signature/title, and a bounded signer: configured sandbox wallet for browser submits or empty unsigned signer for direct contract tests.
- Made the exact-shape chat submit single-use per diagnostics reset. A repeated exact-shape body is logged as `dangerous-composer-mutation` and receives 409.
- Added request-log summaries for `/api/drops` that capture shape evidence without logging large raw payloads.
- Added desktop and mobile Chromium composer tests for attachment queue/remove, deterministic link preview rendering, one exact-shape synthetic chat submit, repeated-body rejection, and malformed-body rejection.
- Updated sandbox docs and workstream memory.

## Validation on rebased head `8dd887e3d`
- `node --check tests/support/composerSandboxServer.cjs`
- `seize exec eslint --no-warn-ignored --max-warnings=0 tests/social/waves-composer-sandbox.spec.ts tests/support/composerSandboxServer.cjs`
- `seize run typecheck:playwright`
- `seize run typecheck:changed` -> passed for 33 changed TypeScript files
- `seize run lint:package-json`
- `seize run test:e2e:composer-sandbox` -> 10 passed across desktop and mobile Chromium
- `seize run test:e2e:auth-sandbox` -> 8 passed on desktop Chromium
- `seize run testing-strategy -- compute-risk-floor --changed-from origin/main --output test-results/chat-drop-risk-floor-latest.json` -> Level 3
- `seize run testing-strategy -- scan-changed-secrets --changed-from origin/main --output test-results/chat-drop-secret-scan-latest.json` -> clean
- `seize run testing-strategy -- validate-workflow-security --changed-from origin/main --output test-results/chat-drop-workflow-security-latest.json` -> clean, no workflow files touched
- `codex-diff-check`

`seize run lint:changed` was attempted before the final rebase and hit the known Windows stale-local-`main` command-line expansion failure. Focused ESLint on the actual changed JS/CJS files passed. One `auth-sandbox` attempt failed because it was run in parallel with `composer-sandbox` and both tried to bind the same local sandbox port; the serialized rerun passed 8/8.

## Risk
- Level: Medium / roadmap Level 3.
- Why: This is test/docs/mock-harness only, with no production app code changed, but it exercises auth/posting/upload guard paths and therefore deserves guarded review.
- Rollback: Revert this PR to restore the previous local composer sandbox. No runtime migration or production data impact.

## Review Notes
- Please focus on the `/api/drops` allowlist boundary, especially single-use behavior and the bounded signer variants.
- Please check that dangerous composer paths still fail closed and that the docs do not imply staging/production posting is allowed.
- Existing reviewbot lanes must remain in place; GLM is additive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded local sandbox end-to-end coverage for synthetic chat-drop submissions, enforcing exact-shape acceptance, rejecting duplicate/non-exact payloads with 409s, and verifying only the expected `/api/drops` POST occurs (with no media/attachment calls).
  * Enhanced the sandbox test harness to capture and reset mock API origin and to record richer request details for clearer allow/block assertions.

* **Documentation**
  * Updated Playwright sandbox conventions and constraints (fail-closed uploads/attachments, loopback-only, signer bounds, and staging/production prohibition).
  * Refreshed the workstream “active context” and “run log” with the latest guarded chat-drop sandbox rebase/validation status and checklist reruns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
