### PR TITLE
Wire durable deployment evidence uploads

### DIFF
--- a/.github/workflows/build-upload-deploy-prod.yml
+++ b/.github/workflows/build-upload-deploy-prod.yml
@@ -353,6 +353,30 @@ jobs:
             --evidence "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --notes "GET /api/version matched the production commit SHA."
 
+      - name: Upload durable production version evidence
+        id: durable-version-evidence
+        continue-on-error: true
+        env:
+          DEPLOYMENT_ARTIFACT_S3_PREFIX: ${{ vars.DEPLOYMENT_ARTIFACT_S3_PREFIX || 's3://6529reviewbot-prod-artifacts/frontend-deployment/' }}
+        run: |
+          set -euo pipefail
+
+          node ops/scripts/deployment-bus.cjs upload-validation-artifact \
+            --file deployment-bus-manifest.json \
+            --pack deployment:http-version \
+            --status passed \
+            --source-file deployment-version-evidence.json \
+            --artifact-name deployment-version-evidence.json \
+            --s3-prefix "${DEPLOYMENT_ARTIFACT_S3_PREFIX}" \
+            --retention-policy standard-90-days \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --notes "Durable production GET /api/version evidence."
+
+      - name: Warn if durable production evidence upload failed
+        if: steps.durable-version-evidence.outcome == 'failure'
+        run: |
+          echo "::warning::Durable production version evidence upload failed. The deployment can continue, but release readiness remains incomplete until artifact storage/IAM is fixed and evidence is recorded."
+
       - name: Mark production deployment terminal
         if: always() && steps.deployment-record.outputs.deployment_id != ''
         env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -430,6 +430,30 @@ jobs:
             --evidence "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             --notes "GET /api/version matched the staging deploy SHA."
 
+      - name: Upload durable staging version evidence
+        id: durable-version-evidence
+        continue-on-error: true
+        env:
+          DEPLOYMENT_ARTIFACT_S3_PREFIX: ${{ vars.DEPLOYMENT_ARTIFACT_S3_PREFIX || 's3://6529reviewbot-prod-artifacts/frontend-deployment/' }}
+        run: |
+          set -euo pipefail
+
+          node ops/scripts/deployment-bus.cjs upload-validation-artifact \
+            --file deployment-bus-manifest.json \
+            --pack deployment:http-version \
+            --status passed \
+            --source-file deployment-version-evidence.json \
+            --artifact-name deployment-version-evidence.json \
+            --s3-prefix "${DEPLOYMENT_ARTIFACT_S3_PREFIX}" \
+            --retention-policy standard-90-days \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --notes "Durable staging GET /api/version evidence."
+
+      - name: Warn if durable staging evidence upload failed
+        if: steps.durable-version-evidence.outcome == 'failure'
+        run: |
+          echo "::warning::Durable staging version evidence upload failed. The deployment can continue, but release readiness remains incomplete until artifact storage/IAM is fixed and evidence is recorded."
+
       - name: Mark staging deployment terminal
         if: always() && steps.deployment-record.outputs.deployment_id != ''
         env:

--- a/__tests__/scripts/deployment-bus.test.ts
+++ b/__tests__/scripts/deployment-bus.test.ts
@@ -11,10 +11,15 @@ const {
   productionPreflight,
   recordPostDeployWatch,
   recordValidationCheck,
+  redactArtifactText,
   summarizeManifest,
+  uploadValidationArtifact,
   validateManifest,
+  verifyArtifactTextRedacted,
 } = require("../../ops/scripts/deployment-bus.cjs");
+const childProcess = require("node:child_process");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 
 const STAGING_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
@@ -40,6 +45,29 @@ function releasePackCheck({ pack, command, artifact, surfaces }) {
     surfaces: surfaces ?? [...REQUIRED_WEB_SURFACES],
     artifacts: [artifact],
   };
+}
+
+function withTempArtifactDir(callback) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "tmp-artifact-"));
+  try {
+    return callback(tempDir);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function mockSuccessfulS3Upload() {
+  return jest.spyOn(childProcess, "spawnSync").mockReturnValue({
+    status: 0,
+    stdout: "",
+    stderr: "",
+  });
+}
+
+function writeJsonEvidence(tempDir, fileName, value) {
+  const sourceFile = path.join(tempDir, fileName);
+  fs.writeFileSync(sourceFile, JSON.stringify(value));
+  return sourceFile;
 }
 
 function releaseReadyValidationChecks() {
@@ -512,6 +540,282 @@ describe("deployment bus manifest", () => {
       retention_policy: "standard-90-days",
     });
     expect(validateManifest(updated).errors).toEqual([]);
+  });
+
+  it("uploads redacted validation evidence to approved S3 storage", () => {
+    withTempArtifactDir((tempDir) => {
+      const redactedOutput = path.join(tempDir, "redacted.json");
+      const tokenValue = ["fake", "token", "value", "1234567890"].join("-");
+      const stagingEnvKey = ["STAGING", "AUTH"].join("_");
+      const stagingValue = ["fake", "stage", "code"].join("-");
+      const sourceFile = writeJsonEvidence(
+        tempDir,
+        "deployment-version-evidence.json",
+        {
+          status: "ok",
+          authorization: ["Authorization", `Bearer ${tokenValue}`].join(": "),
+          staging: `${stagingEnvKey}=${stagingValue}`,
+        }
+      );
+      const spawnSpy = mockSuccessfulS3Upload();
+      const base = buildManifest({
+        environment: "staging",
+        stagingDeploySha: STAGING_SHA,
+        productionCandidateSha: MAIN_SHA,
+        now: "2026-06-18T12:00:00.000Z",
+      });
+
+      const updated = uploadValidationArtifact(
+        base,
+        {
+          pack: "deployment:http-version",
+          status: "passed",
+          sourceFile,
+          artifactName: "deployment-version-evidence.json",
+          s3Prefix: "s3://6529reviewbot-prod-artifacts/frontend-deployment/",
+          retentionPolicy: "standard-90-days",
+          redactedOutput,
+          now: "2026-06-18T12:30:00.000Z",
+        },
+        {}
+      );
+
+      const check = updated.validation.checks[0];
+      const artifact = check.artifacts[0];
+      const redacted = fs.readFileSync(redactedOutput, "utf8");
+      expect(check).toMatchObject({
+        pack: "deployment:http-version",
+        status: "passed",
+        command: VALIDATION_PACKS["deployment:http-version"].commands.staging,
+        surfaces: [],
+      });
+      expect(redacted).toContain("[REDACTED]");
+      expect(redacted).not.toContain(tokenValue);
+      expect(redacted).not.toContain(stagingValue);
+      expect(verifyArtifactTextRedacted(redacted)).toEqual({
+        ok: true,
+        findings: [],
+      });
+      expect(artifact).toMatchObject({
+        uri: "s3://6529reviewbot-prod-artifacts/frontend-deployment/fe-staging-20260618T120000Z-bbbbbbbbbbbb/deployment-http-version/20260618T123000Z-deployment-version-evidence.json",
+        redaction_status: "verified-redacted",
+        retention_policy: "standard-90-days",
+      });
+      expect(artifact.sha256).toMatch(/^[0-9a-f]{64}$/);
+      expect(spawnSpy).toHaveBeenCalledWith(
+        "aws",
+        expect.arrayContaining([
+          "s3",
+          "cp",
+          redactedOutput,
+          artifact.uri,
+          "--only-show-errors",
+        ]),
+        expect.any(Object)
+      );
+      expect(validateManifest(updated).errors).toEqual([]);
+      expect(evaluateReleaseReadiness(updated).holds).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "required-pack-missing-terminal-evidence",
+            pack: "playwright:core-smoke",
+          }),
+          expect.objectContaining({
+            id: "required-pack-missing-terminal-evidence",
+            pack: "playwright:surface-matrix",
+          }),
+          expect.objectContaining({
+            id: "required-pack-missing-terminal-evidence",
+            pack: "playwright:wcag-i18n",
+          }),
+        ])
+      );
+      expect(
+        evaluateReleaseReadiness({
+          ...updated,
+          validation: {
+            ...updated.validation,
+            required_packs: ["deployment:http-version"],
+          },
+        }).holds
+      ).toEqual([]);
+    });
+  });
+
+  it("records workflow-shaped durable evidence without explicit surfaces", () => {
+    withTempArtifactDir((tempDir) => {
+      const sourceFile = writeJsonEvidence(
+        tempDir,
+        "deployment-version-evidence.json",
+        {
+          status: "ok",
+          expected_sha: STAGING_SHA,
+        }
+      );
+      const spawnSpy = mockSuccessfulS3Upload();
+      const base = buildManifest({
+        environment: "staging",
+        stagingDeploySha: STAGING_SHA,
+        productionCandidateSha: MAIN_SHA,
+        now: "2026-06-18T12:00:00.000Z",
+      });
+
+      const updated = uploadValidationArtifact(
+        base,
+        {
+          pack: "deployment:http-version",
+          status: "passed",
+          sourceFile,
+          artifactName: "deployment-version-evidence.json",
+          retentionPolicy: "standard-90-days",
+          runUrl:
+            "https://github.com/6529-Collections/6529seize-frontend/actions/runs/1",
+          notes: "Durable staging GET /api/version evidence.",
+          now: "2026-06-18T12:30:00.000Z",
+        },
+        {
+          DEPLOYMENT_ARTIFACT_S3_PREFIX:
+            "s3://6529reviewbot-prod-artifacts/frontend-deployment/",
+        }
+      );
+
+      const check = updated.validation.checks[0];
+      expect(check).toMatchObject({
+        pack: "deployment:http-version",
+        status: "passed",
+        surfaces: [],
+      });
+      expect(check.artifacts[0].uri).toBe(
+        "s3://6529reviewbot-prod-artifacts/frontend-deployment/fe-staging-20260618T120000Z-bbbbbbbbbbbb/deployment-http-version/20260618T123000Z-deployment-version-evidence.json"
+      );
+      expect(validateManifest(updated).errors).toEqual([]);
+      expect(spawnSpy).toHaveBeenCalledWith(
+        "aws",
+        expect.arrayContaining([
+          "s3",
+          "cp",
+          expect.any(String),
+          check.artifacts[0].uri,
+          "--only-show-errors",
+        ]),
+        expect.any(Object)
+      );
+    });
+  });
+
+  it("rejects unapproved S3 artifact prefixes before upload", () => {
+    withTempArtifactDir((tempDir) => {
+      const sourceFile = writeJsonEvidence(tempDir, "evidence.json", {
+        status: "ok",
+      });
+      const spawnSpy = jest.spyOn(childProcess, "spawnSync");
+      const base = buildManifest({
+        environment: "staging",
+        stagingDeploySha: STAGING_SHA,
+        productionCandidateSha: MAIN_SHA,
+        now: "2026-06-18T12:00:00.000Z",
+      });
+
+      expect(() =>
+        uploadValidationArtifact(
+          base,
+          {
+            pack: "deployment:http-version",
+            sourceFile,
+            s3Prefix: "s3://unapproved-artifacts/",
+          },
+          {}
+        )
+      ).toThrow("Artifact S3 prefix must be approved by the deployment bus");
+      expect(spawnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("removes traversal segments from artifact S3 keys", () => {
+    withTempArtifactDir((tempDir) => {
+      const sourceFile = writeJsonEvidence(tempDir, "evidence.json", {
+        status: "ok",
+      });
+      mockSuccessfulS3Upload();
+      const base = buildManifest({
+        environment: "staging",
+        stagingDeploySha: STAGING_SHA,
+        productionCandidateSha: MAIN_SHA,
+        now: "2026-06-18T12:00:00.000Z",
+      });
+
+      const updated = uploadValidationArtifact(
+        base,
+        {
+          pack: "a/../../x",
+          sourceFile,
+          artifactName: "../../deployment-version-evidence.json",
+          s3Prefix: "s3://6529reviewbot-prod-artifacts/frontend-deployment/",
+          retentionPolicy: "standard-90-days",
+          now: "2026-06-18T12:30:00.000Z",
+        },
+        {}
+      );
+
+      const artifactUri = updated.validation.checks[0].artifacts[0].uri;
+      expect(artifactUri).not.toContain("..");
+      expect(artifactUri).toContain("/a/x/");
+      expect(artifactUri).toContain(
+        "/20260618T123000Z-deployment-version-evidence.json"
+      );
+    });
+  });
+
+  it("redacts deployment artifact text with the shared release patterns", () => {
+    const cookieLine = ["Cookie", "session=fake-cookie-value"].join(": ");
+    const tokenValue = ["fake", "token", "value", "1234567890"].join("-");
+    const authLine = ["Authorization", `Bearer ${tokenValue}`].join(": ");
+    const basicAuthLine = ["Authorization", `Basic ${tokenValue}`].join(": ");
+    const raw = `${cookieLine}\n${authLine}\n${basicAuthLine}`;
+    const redacted = redactArtifactText(raw);
+
+    expect(redacted).toContain("[REDACTED]");
+    expect(redacted).not.toContain(tokenValue);
+    expect(verifyArtifactTextRedacted(redacted)).toEqual({
+      ok: true,
+      findings: [],
+    });
+
+    const overlappingKey = ["STAGING", "API", "KEY"].join("_");
+    const overlappingValue = ["fake", "token", "value", "1234567890"].join("-");
+    const overlapping = redactArtifactText(
+      `${overlappingKey}=${overlappingValue}`
+    );
+    expect(overlapping).toBe("[REDACTED]");
+    expect(overlapping).not.toContain(overlappingValue);
+    expect(verifyArtifactTextRedacted(overlapping)).toEqual({
+      ok: true,
+      findings: [],
+    });
+  });
+
+  it("redacts pretty-printed JSON secret keys before verification", () => {
+    const tokenValue = ["json", "secret", "value", "1234567890"].join("-");
+    const raw = `{
+  "status": "ok",
+  "nested": {
+    "token":
+      "${tokenValue}"
+  }
+}`;
+
+    expect(verifyArtifactTextRedacted(raw)).toMatchObject({
+      ok: false,
+      findings: [expect.objectContaining({ pattern: "json-secret-key" })],
+    });
+
+    const redacted = redactArtifactText(raw);
+    expect(redacted).toContain("[REDACTED]");
+    expect(redacted).not.toContain(tokenValue);
+    expect(verifyArtifactTextRedacted(redacted)).toEqual({
+      ok: true,
+      findings: [],
+    });
   });
 
   it("passes release readiness with required packs and durable artifacts", () => {

--- a/ops/deployment-bus/manifest.v1.schema.json
+++ b/ops/deployment-bus/manifest.v1.schema.json
@@ -258,6 +258,7 @@
               "items": {
                 "enum": [
                   "s3://6529-artifacts/",
+                  "s3://6529reviewbot-prod-artifacts/frontend-deployment/",
                   "https://artifacts.6529.io/",
                   "ipfs://"
                 ]

--- a/ops/docs/developer/deployment-bus-automation.md
+++ b/ops/docs/developer/deployment-bus-automation.md
@@ -53,9 +53,16 @@ Validate and summarize:
   --pack playwright:core-smoke \
   --status passed \
   --surfaces web:desktop-chromium,web:mobile-chromium \
-  --artifact-uri s3://6529-artifacts/frontend/<release-id>/core-smoke.json \
+  --artifact-uri s3://6529reviewbot-prod-artifacts/frontend-deployment/<release-id>/core-smoke.json \
   --redaction-status verified-redacted \
   --artifact-sha256 <sha256> \
+  --retention-policy standard-90-days
+6529 run deployment-bus -- upload-validation-artifact \
+  --file deployment-bus-manifest.json \
+  --pack deployment:http-version \
+  --status passed \
+  --source-file deployment-version-evidence.json \
+  --s3-prefix s3://6529reviewbot-prod-artifacts/frontend-deployment/ \
   --retention-policy standard-90-days
 6529 run deployment-bus -- record-post-deploy-watch \
   --file deployment-bus-manifest.json \
@@ -170,10 +177,22 @@ Current auto-hold criteria:
   set.
 
 Durable evidence must point at approved 6529-controlled artifact storage such
-as `s3://6529-artifacts/`, `https://artifacts.6529.io/`, or `ipfs://` for
-intentionally public redacted provenance. Git LFS and committed generated files
-are not durable release evidence stores. Do not record temporary signed URLs,
-query-string credentials, fragments, local paths, or unredacted artifacts.
+as `s3://6529reviewbot-prod-artifacts/frontend-deployment/`,
+`s3://6529-artifacts/` once that dedicated bucket exists,
+`https://artifacts.6529.io/`, or `ipfs://` for intentionally public redacted
+provenance. Git LFS and committed generated files are not durable release
+evidence stores. Do not record temporary signed URLs, query-string credentials,
+fragments, local paths, or unredacted artifacts.
+
+Use `upload-validation-artifact` when the evidence is a text or JSON file. The
+command redacts known secret patterns, verifies the redacted file, uploads it
+to an approved S3 prefix, records SHA-256 and retention metadata, and appends a
+validation check to the manifest. It fails before upload for unapproved S3
+prefixes or unredacted evidence. It currently supports text evidence only; do
+not use it for raw Playwright traces until a binary scrubbing contract exists.
+Deploy workflows run this as a non-blocking feedback step: successful uploads
+record durable evidence, while failed uploads warn and leave release readiness
+incomplete without inventing an artifact pointer.
 
 GitHub Actions workflow artifacts and run URLs are useful temporary evidence,
 but they are not durable artifact pointers. They can appear in post-deploy watch

--- a/ops/docs/developer/deployment-bus-process.md
+++ b/ops/docs/developer/deployment-bus-process.md
@@ -90,17 +90,24 @@ Known current gaps after the first automation slice:
     release-report fields, and release-captain validation updates;
   - feature flags: app-specific only, not a generic release-lane capability;
   - traffic-split canary rollout: not currently supported by the deployment bus;
-  - durable artifact storage: schema and validator are ready, but the approved
-    private storage/IAM/upload path still needs infrastructure wiring.
+  - durable artifact storage: deployment HTTP version evidence attempts an
+    approved private S3 upload when deploy verification passes; upload failure
+    warns but does not block the already-verified deployment, and no durable
+    artifact pointer is recorded unless the upload succeeds. Full
+    required-pack artifact capture still needs validation-pack automation.
 - Release reports evaluate whether required packs and durable artifact pointers
   are recorded, but the workflows still do not automatically run those
   post-deploy Playwright packs. The release captain or validation agents must
   run them and record results with `record-validation-check` until a later
   automation slice wires pack execution into the lane.
 - The workflows record post-deploy deploy-verification checkpoints and run a
-  GET-only `/api/version` check against the deployed HTTP app. These are useful
-  watch evidence, but GitHub Actions run URLs and temporary artifacts do not
-  satisfy durable artifact pointer requirements.
+  GET-only `/api/version` check against the deployed HTTP app. The redacted
+  version-evidence JSON is uploaded to approved S3 storage as
+  `deployment:http-version` evidence when the artifact IAM/storage path is
+  available. If that upload fails, the workflow emits a warning and leaves
+  release readiness incomplete instead of recording a fake durable pointer.
+  GitHub Actions run URLs and temporary artifacts remain useful context, but
+  only approved durable pointers satisfy durable artifact requirements.
 - The current standard pack plan requires desktop Chromium and mobile Chromium
   evidence for `playwright:core-smoke`, `playwright:surface-matrix`, and
   `playwright:wcag-i18n`. The deployment bus also knows the optional

--- a/ops/scripts/deployment-bus.cjs
+++ b/ops/scripts/deployment-bus.cjs
@@ -2,6 +2,9 @@
 "use strict";
 
 const fs = require("node:fs");
+const crypto = require("node:crypto");
+const childProcess = require("node:child_process");
+const os = require("node:os");
 const path = require("node:path");
 const { parseArgs } = require("./cli-args.cjs");
 
@@ -51,6 +54,20 @@ const VALIDATION_PACKS = Object.freeze({
     productionCommand: "seize run test:e2e:production:readonly",
     surfaces: ["web:desktop-chromium"],
   }),
+  "deployment:http-version": Object.freeze({
+    id: "deployment:http-version",
+    description:
+      "Durable redacted GET /api/version evidence from the deploy workflow.",
+    commands: Object.freeze({
+      staging:
+        "node ops/scripts/deployment-bus.cjs upload-validation-artifact --pack deployment:http-version",
+      production:
+        "node ops/scripts/deployment-bus.cjs upload-validation-artifact --pack deployment:http-version",
+    }),
+    size: "small",
+    surfaces: Object.freeze([]),
+    artifacts: Object.freeze(["deployment-version-evidence.json"]),
+  }),
 });
 const DEFAULT_REQUIRED_PACKS = Object.freeze([
   "playwright:core-smoke",
@@ -59,9 +76,12 @@ const DEFAULT_REQUIRED_PACKS = Object.freeze([
 ]);
 const APPROVED_DURABLE_ARTIFACT_PREFIXES = Object.freeze([
   "s3://6529-artifacts/",
+  "s3://6529reviewbot-prod-artifacts/frontend-deployment/",
   "https://artifacts.6529.io/",
   "ipfs://",
 ]);
+const DEFAULT_DEPLOYMENT_ARTIFACT_S3_PREFIX =
+  "s3://6529reviewbot-prod-artifacts/frontend-deployment/";
 const VALID_RETENTION_POLICIES = new Set([
   "standard-30-days",
   "standard-90-days",
@@ -136,6 +156,42 @@ const GITHUB_DEPLOYMENT_STATES = new Set([
   "pending",
   "success",
 ]);
+const REDACTION_TEXT = "[REDACTED]";
+const SECRET_JSON_KEY_RE =
+  /^(?:authorization|cookie|api[_-]?key|token|secret|password|private[_-]?key|staging_auth|staging_api_key|playwright_staging_access_code)$/i;
+const ARTIFACT_SECRET_PATTERNS = Object.freeze([
+  {
+    name: "authorization-header",
+    pattern:
+      /\bAuthorization:\s*[A-Za-z][A-Za-z0-9._~-]*\s+[A-Za-z0-9._~+/=-]{12,}/gi,
+  },
+  {
+    name: "staging-access-code",
+    pattern:
+      /\b(?:PLAYWRIGHT_STAGING_ACCESS_CODE|STAGING_AUTH|STAGING_API_KEY)\s*[=:]\s*["']?[^"'\s,;]{4,}/gi,
+  },
+  {
+    name: "secret-assignment",
+    pattern:
+      /\b(?:api[_-]?key|token|secret|password|private[_-]?key)\s*[=:]\s*["']?[^"'\s,;]{8,}/gi,
+  },
+  {
+    name: "aws-access-key",
+    pattern: /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g,
+  },
+  {
+    name: "github-token",
+    pattern: /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g,
+  },
+  {
+    name: "windows-local-path",
+    pattern: /\b[A-Z]:\\Users\\[^\\\s]+\\[^\n\r"]*/g,
+  },
+  {
+    name: "hidden-prompt-marker",
+    pattern: /\b(?:BEGIN|END) (?:SYSTEM|DEVELOPER|HIDDEN) PROMPT\b/gi,
+  },
+]);
 
 function createPlaywrightPack({
   id,
@@ -178,6 +234,392 @@ function writeJson(file, value) {
 
 function writeStdout(value) {
   process.stdout.write(`${value}\n`);
+}
+
+function splitArtifactLines(text) {
+  const lines = [];
+  let start = 0;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (char !== "\r" && char !== "\n") {
+      continue;
+    }
+
+    lines.push(text.slice(start, index));
+    if (char === "\r" && text[index + 1] === "\n") {
+      index += 1;
+    }
+    start = index + 1;
+  }
+
+  lines.push(text.slice(start));
+  return lines;
+}
+
+function firstNonWhitespaceIndex(text) {
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (char !== " " && char !== "\t" && char !== "\r") {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function isCookieHeaderLine(line) {
+  const start = firstNonWhitespaceIndex(line);
+  if (start < 0) {
+    return false;
+  }
+
+  const headerPrefix = "cookie:";
+  return (
+    line.slice(start, start + headerPrefix.length).toLowerCase() ===
+      headerPrefix && line.indexOf("=", start + headerPrefix.length) >= 0
+  );
+}
+
+function redactCookieHeaders(text) {
+  return splitArtifactLines(text)
+    .map((line) => {
+      if (!isCookieHeaderLine(line)) {
+        return line;
+      }
+      const colonIndex = line.indexOf(":");
+      return `${line.slice(0, colonIndex + 1)} ${REDACTION_TEXT}`;
+    })
+    .join("\n");
+}
+
+function artifactSecretPatterns() {
+  return ARTIFACT_SECRET_PATTERNS.map(({ name, pattern }) => ({
+    name,
+    pattern: new RegExp(pattern.source, pattern.flags),
+  }));
+}
+
+function redactPatternText(text) {
+  const redactedPatterns = artifactSecretPatterns().reduce(
+    (next, { pattern }) => next.replace(pattern, REDACTION_TEXT),
+    text
+  );
+  return redactCookieHeaders(redactedPatterns);
+}
+
+function redactJsonSecrets(value) {
+  if (Array.isArray(value)) {
+    return value.map(redactJsonSecrets);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, childValue]) => [
+        key,
+        SECRET_JSON_KEY_RE.test(key)
+          ? REDACTION_TEXT
+          : redactJsonSecrets(childValue),
+      ])
+    );
+  }
+
+  if (typeof value === "string") {
+    return redactPatternText(value);
+  }
+
+  return value;
+}
+
+function redactJsonText(text) {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+    return text;
+  }
+
+  try {
+    return JSON.stringify(redactJsonSecrets(JSON.parse(text)), null, 2);
+  } catch {
+    return text;
+  }
+}
+
+function redactArtifactText(text) {
+  return redactPatternText(redactJsonText(text));
+}
+
+function collectJsonSecretFindings(value, pathParts = []) {
+  if (Array.isArray(value)) {
+    return value.flatMap((childValue, index) =>
+      collectJsonSecretFindings(childValue, [...pathParts, String(index)])
+    );
+  }
+
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+
+  return Object.entries(value).flatMap(([key, childValue]) => {
+    const path = [...pathParts, key];
+    if (SECRET_JSON_KEY_RE.test(key) && childValue !== REDACTION_TEXT) {
+      return [
+        {
+          pattern: "json-secret-key",
+          sample: path.join(".").slice(0, 80),
+        },
+      ];
+    }
+    return collectJsonSecretFindings(childValue, path);
+  });
+}
+
+function jsonSecretFindings(text) {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+    return [];
+  }
+
+  try {
+    return collectJsonSecretFindings(JSON.parse(text));
+  } catch {
+    return [];
+  }
+}
+
+function verifyArtifactTextRedacted(text) {
+  const findings = jsonSecretFindings(text);
+
+  for (const { name, pattern } of artifactSecretPatterns()) {
+    const match = pattern.exec(text);
+    if (match?.[0]) {
+      findings.push({
+        pattern: name,
+        sample: match[0].slice(0, 80),
+      });
+    }
+  }
+
+  const cookieHeader = splitArtifactLines(text).find(isCookieHeaderLine);
+  if (cookieHeader) {
+    findings.push({
+      pattern: "cookie-header",
+      sample: cookieHeader.slice(0, 80),
+    });
+  }
+
+  return {
+    ok: findings.length === 0,
+    findings,
+  };
+}
+
+function sha256Hex(buffer) {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+function safeS3KeySegment(value, fallback = "artifact") {
+  const text = String(value || fallback)
+    .trim()
+    .replace(/[^A-Za-z0-9._/-]+/g, "-")
+    .replace(/\/+/g, "/");
+  const segments = text
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter((segment) => segment && segment !== "." && segment !== "..");
+  return segments.join("/") || fallback;
+}
+
+function ensureTrailingSlash(value) {
+  return value.endsWith("/") ? value : `${value}/`;
+}
+
+function parseS3Uri(uri) {
+  if (!uri.startsWith("s3://")) {
+    throw new Error(
+      `S3 artifact prefix must start with s3://, received: ${uri}`
+    );
+  }
+  const withoutScheme = uri.slice("s3://".length);
+  const slashIndex = withoutScheme.indexOf("/");
+  const bucket =
+    slashIndex === -1 ? withoutScheme : withoutScheme.slice(0, slashIndex);
+  const keyPrefix =
+    slashIndex === -1 ? "" : withoutScheme.slice(slashIndex + 1);
+  if (!bucket) {
+    throw new Error("S3 artifact prefix must include a bucket name");
+  }
+  return {
+    bucket,
+    keyPrefix,
+  };
+}
+
+function artifactUploadPrefix(options, env) {
+  const prefix =
+    options.s3Prefix ||
+    env.DEPLOYMENT_ARTIFACT_S3_PREFIX ||
+    DEFAULT_DEPLOYMENT_ARTIFACT_S3_PREFIX;
+  const normalized = ensureTrailingSlash(String(prefix || "").trim());
+  if (!isApprovedDurableArtifactPrefix(normalized)) {
+    throw new Error(
+      `Artifact S3 prefix must be approved by the deployment bus: ${normalized}`
+    );
+  }
+  return normalized;
+}
+
+function inferContentType(file) {
+  const extension = path.extname(file).toLowerCase();
+  if (extension === ".json") {
+    return "application/json";
+  }
+  if (extension === ".md") {
+    return "text/markdown; charset=utf-8";
+  }
+  return "text/plain; charset=utf-8";
+}
+
+function assertTextArtifactBuffer(buffer, sourceFile) {
+  if (buffer.includes(0)) {
+    throw new Error(
+      `Refusing to upload ${sourceFile}: deployment-bus artifact upload currently supports text evidence only`
+    );
+  }
+}
+
+function redactedArtifactBuffer(sourceFile) {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- Operator CLI reads caller-supplied evidence files.
+  const raw = fs.readFileSync(sourceFile);
+  assertTextArtifactBuffer(raw, sourceFile);
+  const redactedText = redactArtifactText(raw.toString("utf8"));
+  const verification = verifyArtifactTextRedacted(redactedText);
+  if (!verification.ok) {
+    throw new Error(
+      `Refusing to upload unredacted artifact ${sourceFile}: ${verification.findings
+        .map((finding) => finding.pattern)
+        .join(", ")}`
+    );
+  }
+  return Buffer.from(redactedText, "utf8");
+}
+
+function buildArtifactTargetUri(manifest, options, env = process.env) {
+  const now = options.now || new Date().toISOString();
+  const prefix = artifactUploadPrefix(options, env);
+  parseS3Uri(prefix);
+  const artifactName = safeS3KeySegment(
+    path.basename(
+      options.artifactName ||
+        path.basename(options.sourceFile || "artifact.txt")
+    )
+  );
+  const releaseId = safeS3KeySegment(
+    manifest.release_id || "unassigned-release"
+  );
+  const pack = safeS3KeySegment(options.pack || "unmapped-pack");
+  return `${prefix}${releaseId}/${pack}/${timestampSlug(now)}-${artifactName}`;
+}
+
+function writeTempArtifact(buffer, options) {
+  if (options.redactedOutput) {
+    const target = path.resolve(options.redactedOutput);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- Operator CLI writes caller-supplied redacted evidence paths.
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- Operator CLI writes caller-supplied redacted evidence paths.
+    fs.writeFileSync(target, buffer);
+    return { file: target, remove: false };
+  }
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "deployment-bus-"));
+  const tempFile = path.join(tempDir, "artifact");
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- Writes a temp artifact created by this process.
+  fs.writeFileSync(tempFile, buffer);
+  return { file: tempFile, remove: true, tempDir };
+}
+
+function safeCommandError(stderr) {
+  return String(stderr || "")
+    .split(/\r?\n/)
+    .map((line) => line.replace(/([?&][^=\s]+)=([^&\s]+)/g, "$1=[redacted]"))
+    .join("\n")
+    .trim();
+}
+
+function uploadFileToS3(localFile, targetUri, options) {
+  const contentType =
+    options.contentType || inferContentType(options.sourceFile);
+  const args = [
+    "s3",
+    "cp",
+    localFile,
+    targetUri,
+    "--only-show-errors",
+    "--content-type",
+    contentType,
+    "--metadata",
+    `sha256=${options.sha256},redaction-status=verified-redacted,retention-policy=${options.retentionPolicy}`,
+  ];
+  const result = childProcess.spawnSync(options.awsCommand || "aws", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      safeCommandError(result.stderr) ||
+        "aws s3 cp failed while uploading artifact"
+    );
+  }
+}
+
+function uploadValidationArtifact(manifest, options, env = process.env) {
+  if (!options.sourceFile) {
+    throw new Error("upload-validation-artifact requires --source-file");
+  }
+  if (!options.pack) {
+    throw new Error("upload-validation-artifact requires --pack");
+  }
+
+  const now = options.now || new Date().toISOString();
+  const targetUri = buildArtifactTargetUri(manifest, { ...options, now }, env);
+  const buffer = redactedArtifactBuffer(options.sourceFile);
+  const sha256 = sha256Hex(buffer);
+  const retentionPolicy = options.retentionPolicy || "standard-90-days";
+  if (!isValidRetentionPolicy(retentionPolicy)) {
+    throw new Error(
+      `--retention-policy must be one of ${[...VALID_RETENTION_POLICIES].join(", ")}`
+    );
+  }
+
+  const temp = writeTempArtifact(buffer, options);
+  try {
+    uploadFileToS3(temp.file, targetUri, {
+      sourceFile: options.sourceFile,
+      contentType: options.contentType,
+      awsCommand: options.awsCommand,
+      sha256,
+      retentionPolicy,
+    });
+  } finally {
+    if (temp.remove) {
+      fs.rmSync(temp.tempDir, { recursive: true, force: true });
+    }
+  }
+
+  return recordValidationCheck(manifest, {
+    pack: options.pack,
+    status: options.status || "passed",
+    command: options.command,
+    surfaces: options.surfaces || options.surface,
+    owner: options.owner,
+    artifactUri: targetUri,
+    artifactSha256: sha256,
+    redactionStatus: "verified-redacted",
+    retentionPolicy,
+    runUrl: options.runUrl,
+    source: options.source || "deployment-bus-artifact-upload",
+    notes: options.notes,
+    now,
+  });
 }
 
 function parseBoolean(value, fallback = false) {
@@ -2157,6 +2599,7 @@ function usage() {
   node ops/scripts/deployment-bus.cjs validate-manifest --file <file>
   node ops/scripts/deployment-bus.cjs summarize-manifest --file <file>
   node ops/scripts/deployment-bus.cjs record-validation-check --file <file> --pack playwright:core-smoke --status passed --surfaces web:desktop-chromium,web:mobile-chromium --artifact-uri s3://6529-artifacts/... --redaction-status verified-redacted --artifact-sha256 <hex> --retention-days 90
+  node ops/scripts/deployment-bus.cjs upload-validation-artifact --file <file> --pack deployment:http-version --source-file deployment-version-evidence.json --s3-prefix s3://6529reviewbot-prod-artifacts/frontend-deployment/
   node ops/scripts/deployment-bus.cjs release-report --file <file> --output <markdown-file>
   node ops/scripts/deployment-bus.cjs heartbeat-manifest --file <file> --message <text> [--status deploying] [--phase build]
   node ops/scripts/deployment-bus.cjs record-post-deploy-watch --file <file> --status passed --observed-duration-minutes 30 --checkpoint version-match --evidence https://github.com/.../actions/runs/...
@@ -2275,6 +2718,39 @@ async function main(argv = process.argv.slice(2), env = process.env) {
           notes: args.notes,
           now: args.now,
         });
+        const result = validateManifest(manifest);
+        printValidation(result);
+        if (!result.ok) {
+          process.exitCode = 1;
+          return;
+        }
+        writeJson(args.output || file, manifest);
+        writeStdout(`Updated ${args.output || file}`);
+        break;
+      }
+      case "upload-validation-artifact": {
+        const file = args.file;
+        const manifest = uploadValidationArtifact(
+          readJson(file),
+          {
+            pack: args.pack,
+            status: args.status,
+            command: args.command,
+            surfaces: args.surfaces || args.surface,
+            owner: args.owner,
+            sourceFile: args["source-file"],
+            artifactName: args["artifact-name"],
+            s3Prefix: args["s3-prefix"],
+            retentionPolicy: args["retention-policy"],
+            contentType: args["content-type"],
+            runUrl: args["run-url"],
+            source: args.source,
+            notes: args.notes,
+            redactedOutput: args["redacted-output"],
+            now: args.now,
+          },
+          env
+        );
         const result = validateManifest(manifest);
         printValidation(result);
         if (!result.ok) {
@@ -2423,6 +2899,9 @@ module.exports = {
   productionPreflight,
   recordPostDeployWatch,
   recordValidationCheck,
+  redactArtifactText,
   summarizeManifest,
+  uploadValidationArtifact,
   validateManifest,
+  verifyArtifactTextRedacted,
 };

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,6 +49,12 @@ App PR CI:
 - Uploaded PR CI artifacts are short-term debugging evidence. Durable
   deployment-train evidence still belongs on approved 6529-controlled artifact
   storage, not Git LFS.
+- Deployment workflows use `deployment-bus upload-validation-artifact` to
+  redact, hash, upload, and record GET `/api/version` evidence as
+  `deployment:http-version` when the approved artifact store is writable. A
+  failed upload warns and records no durable pointer. This is durable
+  deployment evidence, but it does not replace the required Playwright pack
+  artifacts for release readiness.
 
 WCAG and i18n route evidence:
 


### PR DESCRIPTION
﻿## Testing hardening context

This PR is part of the WCAG/i18n testing-hardening roadmap and specifically advances the durable artifact-storage slice. It wires deployment-bus evidence uploads onto 6529-controlled S3 storage instead of relying on Git LFS, committed generated files, temporary Actions artifacts, or local paths.

This does not remove, weaken, or bypass any existing reviewbot lanes. The existing general, WCAG, i18n, security, responsiveness, and additive GLM-swarm reviews should still run on the PR as usual.

## Changes

- Adds `deployment-bus upload-validation-artifact` for text/JSON evidence.
- Redacts known secret patterns before upload, verifies the redacted output, computes SHA-256, uploads to an approved S3 prefix, and records durable artifact metadata in the deployment manifest.
- Approves the current private artifact prefix `s3://6529reviewbot-prod-artifacts/frontend-deployment/` while keeping the future dedicated `s3://6529-artifacts/`, `https://artifacts.6529.io/`, and `ipfs://` options in the manifest policy.
- Updates staging and production deploy workflows to upload redacted `/api/version` evidence after HTTP version verification.
- Makes those upload steps non-blocking feedback: successful uploads record durable evidence; upload failure warns and records no fake pointer, so an already-verified deploy is not turned into a production outage because artifact IAM/storage needs repair.
- Documents the new command, current workflow behavior, and the remaining gap for full Playwright validation-pack artifact capture.

## Expected impact

- Web runtime: no application runtime/UI changes.
- Mobile/capacity surface: no direct runtime impact.
- Electron/native surface: no direct runtime impact.
- Deployment surface: staging/prod workflows get an extra post-verification evidence upload step. The step can improve release readiness when storage works, and warns without fabricating evidence when storage/IAM is unavailable.
- Security: evidence is redacted before upload and only approved durable prefixes are accepted. The helper refuses binary/null-byte artifacts until a binary scrubbing contract exists.

## Local testing on rebased head `899e9360`

- `node --check ops/scripts/deployment-bus.cjs`
- `seize exec eslint --no-warn-ignored --max-warnings=0 ops/scripts/deployment-bus.cjs __tests__/scripts/deployment-bus.test.ts`
- `seize run test:no-coverage -- __tests__/scripts/deployment-bus.test.ts __tests__/playwright/artifactRedaction.test.ts` -> 49 passed
- `node -e "const fs=require('fs'); const YAML=require('yaml'); for (const file of ['.github/workflows/build-upload-deploy-prod.yml','.github/workflows/deploy-staging.yml']) { YAML.parse(fs.readFileSync(file,'utf8')); console.log(file + ' ok'); }"`
- `seize run typecheck:changed` -> passed for 33 changed TypeScript files
- `seize run testing-strategy -- compute-risk-floor --changed-from origin/main --output test-results/artifact-store-risk-floor.json` -> level 5, expected for prod deployment/artifact workflow changes
- `seize run testing-strategy -- scan-changed-secrets --changed-from origin/main --output test-results/artifact-store-secret-scan.json` -> clean
- `seize run testing-strategy -- validate-workflow-security --changed-from origin/main --output test-results/artifact-store-workflow-security.json` -> clean
- `codex-diff-check`

`seize run lint:changed` was attempted after rebase and failed because the script compares against stale local `main` in this Windows worktree and expands too many files for the shell. Focused ESLint on the actual changed JS/CJS files passed.

## Rollout notes

- The artifact bucket exists in the 6529 AWS account and has default SSE enabled and public access blocked from local inspection.
- GitHub Actions IAM still needs real workflow execution to prove write permission from the deploy credentials. If the upload fails there, the workflow emits a warning and leaves release readiness incomplete rather than recording false durable evidence.
- Full required-pack artifact upload for Playwright packs remains a later roadmap slice; this PR only makes `/api/version` deploy evidence durable when upload succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced deployment automation to upload durable, verified deployment version evidence to approved S3 storage.
  * Upload failures no longer block already-verified deployments; readiness remains incomplete until evidence is successfully recorded.
* **Documentation**
  * Updated deployment-bus automation guides and process docs with the new approved S3 prefix, expected redaction/verification behavior, and example commands.
* **Tests**
  * Expanded coverage for evidence redaction, upload metadata/URI handling, and artifact validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
