### PR TITLE
Fix wave drop action z-index

### DIFF
--- a/components/waves/drops/WaveDropActions.tsx
+++ b/components/waves/drops/WaveDropActions.tsx
@@ -14,6 +14,7 @@ import WaveDropActionsMore from "./WaveDropActionsMore";
 import WaveDropActionsQuickReact from "./WaveDropActionsQuickReact";
 import WaveDropActionsRate from "./WaveDropActionsRate";
 import WaveDropActionsReply from "./WaveDropActionsReply";
+import { useWaveDropLayers } from "./WaveDropLayerContext";
 
 interface WaveDropActionsProps {
   readonly drop: ExtendedDrop;
@@ -35,6 +36,7 @@ export default function WaveDropActions({
   const { isMemesWave } = useSeizeSettings();
   const { connectedProfile } = useAuth();
   const compact = useCompactMode();
+  const { desktopActionsZIndexClassName } = useWaveDropLayers();
   const [isMoreDropdownOpen, setIsMoreDropdownOpen] = useState(false);
   const showGuestCopyOnly = !connectedProfile?.handle;
 
@@ -55,7 +57,7 @@ export default function WaveDropActions({
 
   return (
     <div
-      className={`tw-absolute tw-right-2 tw-z-20 ${
+      className={`tw-absolute tw-right-2 ${desktopActionsZIndexClassName} ${
         compact ? "-tw-top-4" : "-tw-top-9"
       } tw-transition-opacity tw-duration-200 tw-ease-in-out ${visibilityClasses}`}
     >

--- a/components/waves/drops/WaveDropLayerContext.test.tsx
+++ b/components/waves/drops/WaveDropLayerContext.test.tsx
@@ -1,0 +1,113 @@
+import { render, renderHook } from "@testing-library/react";
+import { ApiDropType } from "@/generated/models/ApiDropType";
+import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
+import type { ReactNode } from "react";
+import WaveDropActions from "./WaveDropActions";
+import {
+  useWaveDropLayers,
+  WaveDropLayerProvider,
+} from "./WaveDropLayerContext";
+
+jest.mock("@/components/auth/Auth", () => ({
+  useAuth: () => ({ connectedProfile: { handle: "alice" } }),
+}));
+
+jest.mock("@/contexts/CompactModeContext", () => ({
+  useCompactMode: () => false,
+}));
+
+jest.mock("@/contexts/SeizeSettingsContext", () => ({
+  useSeizeSettings: () => ({ isMemesWave: () => false }),
+}));
+
+jest.mock("./WaveDropActionsAddReaction", () => ({
+  __esModule: true,
+  default: () => <button type="button">add reaction</button>,
+}));
+
+jest.mock("./WaveDropActionsBoost", () => ({
+  __esModule: true,
+  default: () => <button type="button">boost</button>,
+}));
+
+jest.mock("./WaveDropActionsCopyLink", () => ({
+  __esModule: true,
+  default: () => <button type="button">copy link</button>,
+}));
+
+jest.mock("./WaveDropActionsMore", () => ({
+  __esModule: true,
+  default: () => <button type="button">more</button>,
+}));
+
+jest.mock("./WaveDropActionsQuickReact", () => ({
+  __esModule: true,
+  default: () => <button type="button">quick react</button>,
+}));
+
+jest.mock("./WaveDropActionsRate", () => ({
+  __esModule: true,
+  default: () => <button type="button">rate</button>,
+}));
+
+jest.mock("./WaveDropActionsReply", () => ({
+  __esModule: true,
+  default: () => <button type="button">reply</button>,
+}));
+
+const drop = {
+  id: "drop-1",
+  drop_type: ApiDropType.Chat,
+  wave: { id: "wave-1" },
+  context_profile_context: {},
+} as ExtendedDrop;
+
+describe("WaveDropLayerContext", () => {
+  it("places desktop actions above boosted drop card internals by default", () => {
+    const { result } = renderHook(() => useWaveDropLayers());
+
+    expect(result.current.desktopActionsZIndexClassName).toBe("tw-z-40");
+  });
+
+  it("keeps the desktop action layer when only mobile layers are overridden", () => {
+    const wrapper = ({ children }: { readonly children: ReactNode }) => (
+      <WaveDropLayerProvider
+        value={{
+          mobileMenuZIndexClassName: "tw-z-[1020]",
+          mobileDialogZIndexClassName: "tw-z-[1030]",
+        }}
+      >
+        {children}
+      </WaveDropLayerProvider>
+    );
+
+    const { result } = renderHook(() => useWaveDropLayers(), { wrapper });
+
+    expect(result.current.desktopActionsZIndexClassName).toBe("tw-z-40");
+    expect(result.current.mobileMenuZIndexClassName).toBe("tw-z-[1020]");
+    expect(result.current.mobileDialogZIndexClassName).toBe("tw-z-[1030]");
+  });
+});
+
+describe("WaveDropActions layer", () => {
+  it("uses the default desktop action layer on the hover action wrapper", () => {
+    const { container } = render(
+      <WaveDropActions drop={drop} activePartIndex={0} onReply={jest.fn()} />
+    );
+
+    expect(container.firstElementChild).toHaveClass("tw-z-40");
+    expect(container.firstElementChild).not.toHaveClass("tw-z-20");
+  });
+
+  it("uses the contextual desktop action layer when provided", () => {
+    const { container } = render(
+      <WaveDropLayerProvider
+        value={{ desktopActionsZIndexClassName: "tw-z-50" }}
+      >
+        <WaveDropActions drop={drop} activePartIndex={0} onReply={jest.fn()} />
+      </WaveDropLayerProvider>
+    );
+
+    expect(container.firstElementChild).toHaveClass("tw-z-50");
+  });
+});

--- a/components/waves/drops/WaveDropLayerContext.tsx
+++ b/components/waves/drops/WaveDropLayerContext.tsx
@@ -3,11 +3,13 @@
 import React, { createContext, useContext, useMemo } from "react";
 
 type WaveDropLayerContextValue = {
+  readonly desktopActionsZIndexClassName: string;
   readonly mobileMenuZIndexClassName: string;
   readonly mobileDialogZIndexClassName: string;
 };
 
 const DEFAULT_WAVE_DROP_LAYER_CONTEXT: WaveDropLayerContextValue = {
+  desktopActionsZIndexClassName: "tw-z-40",
   mobileMenuZIndexClassName: "tw-z-[1000]",
   mobileDialogZIndexClassName: "tw-z-[1010]",
 };
@@ -25,6 +27,9 @@ export function WaveDropLayerProvider({
 }) {
   const mergedValue = useMemo<WaveDropLayerContextValue>(
     () => ({
+      desktopActionsZIndexClassName:
+        value?.desktopActionsZIndexClassName ??
+        DEFAULT_WAVE_DROP_LAYER_CONTEXT.desktopActionsZIndexClassName,
       mobileMenuZIndexClassName:
         value?.mobileMenuZIndexClassName ??
         DEFAULT_WAVE_DROP_LAYER_CONTEXT.mobileMenuZIndexClassName,


### PR DESCRIPTION
## Issue
- The desktop hover action bar for wave drops can render under a boosted drop card when a message sits directly below the boosted card.

## Fix
- Move the desktop drop action overlay from the old hardcoded `tw-z-20` layer to a `WaveDropLayerContext` desktop action layer.
- Default the desktop action layer to `tw-z-40`, above boosted-card internals that use `tw-z-30`, while staying below mobile sheets/dialogs and app chrome.

## Changes
- Added `desktopActionsZIndexClassName` to the wave drop layer context.
- Updated `WaveDropActions` to use the contextual desktop action layer.
- Added focused tests for the default layer, partial mobile overrides, and the action wrapper class.

## Validation
- `./bin/6529 exec cross-env NODE_ENV=test jest --silent --verbose=false --coverageReporters=none --runInBand --forceExit components/waves/drops/WaveDropLayerContext.test.tsx`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff`
- `./bin/6529 exec prettier --check components/waves/drops/WaveDropLayerContext.test.tsx components/waves/drops/WaveDropActions.tsx components/waves/drops/WaveDropLayerContext.tsx`
- Local Playwright stacking check against the dev app: `tw-z-40` action layer computed as `40`, boosted comparison layer computed as `30`, and `elementFromPoint` hit the action layer at the overlap. The checked public route logged unrelated third-party/prod resource errors.

## Risk
- Level: Low
- Why: CSS stacking-only frontend change scoped to wave drop desktop actions; no API, generated model, data, auth, or backend deployment dependency.
- Rollback: Revert this PR to restore the previous `tw-z-20` action layer.

## Review Notes
- UI pattern reused: existing `WaveDropLayerContext` layer-token approach and existing Tailwind z-index tokens.
- Backend deploy order: none; frontend-only staging deploy is sufficient.
