### PR TITLE
Fix wave drop action z-index

### DIFF
--- a/components/waves/drops/WaveDrop.tsx
+++ b/components/waves/drops/WaveDrop.tsx
@@ -127,7 +127,7 @@ const getDropClasses = (
   isDrop: boolean
 ): string => {
   const baseClasses =
-    "touch-select-none tw-cursor-default tw-relative tw-group tw-w-full tw-flex tw-flex-col tw-px-4 tw-transition-colors tw-duration-300";
+    "touch-select-none tw-cursor-default tw-relative tw-group tw-w-full tw-flex tw-flex-col tw-px-4 tw-transition-colors tw-duration-300 desktop-hover:hover:tw-z-30 focus-within:tw-z-30";
 
   const streamClasses = "tw-rounded-xl";
 

--- a/components/waves/drops/WaveDropActions.tsx
+++ b/components/waves/drops/WaveDropActions.tsx
@@ -14,6 +14,7 @@ import WaveDropActionsMore from "./WaveDropActionsMore";
 import WaveDropActionsQuickReact from "./WaveDropActionsQuickReact";
 import WaveDropActionsRate from "./WaveDropActionsRate";
 import WaveDropActionsReply from "./WaveDropActionsReply";
+import { useWaveDropLayers } from "./WaveDropLayerContext";
 
 interface WaveDropActionsProps {
   readonly drop: ExtendedDrop;
@@ -35,6 +36,7 @@ export default function WaveDropActions({
   const { isMemesWave } = useSeizeSettings();
   const { connectedProfile } = useAuth();
   const compact = useCompactMode();
+  const { desktopActionsZIndexClassName } = useWaveDropLayers();
   const [isMoreDropdownOpen, setIsMoreDropdownOpen] = useState(false);
   const showGuestCopyOnly = !connectedProfile?.handle;
 
@@ -55,7 +57,7 @@ export default function WaveDropActions({
 
   return (
     <div
-      className={`tw-absolute tw-right-2 tw-z-20 ${
+      className={`tw-absolute tw-right-2 ${desktopActionsZIndexClassName} ${
         compact ? "-tw-top-4" : "-tw-top-9"
       } tw-transition-opacity tw-duration-200 tw-ease-in-out ${visibilityClasses}`}
     >

--- a/components/waves/drops/WaveDropLayerContext.test.tsx
+++ b/components/waves/drops/WaveDropLayerContext.test.tsx
@@ -1,0 +1,113 @@
+import { render, renderHook } from "@testing-library/react";
+import { ApiDropType } from "@/generated/models/ApiDropType";
+import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
+import type { ReactNode } from "react";
+import WaveDropActions from "./WaveDropActions";
+import {
+  useWaveDropLayers,
+  WaveDropLayerProvider,
+} from "./WaveDropLayerContext";
+
+jest.mock("@/components/auth/Auth", () => ({
+  useAuth: () => ({ connectedProfile: { handle: "alice" } }),
+}));
+
+jest.mock("@/contexts/CompactModeContext", () => ({
+  useCompactMode: () => false,
+}));
+
+jest.mock("@/contexts/SeizeSettingsContext", () => ({
+  useSeizeSettings: () => ({ isMemesWave: () => false }),
+}));
+
+jest.mock("./WaveDropActionsAddReaction", () => ({
+  __esModule: true,
+  default: () => <button type="button">add reaction</button>,
+}));
+
+jest.mock("./WaveDropActionsBoost", () => ({
+  __esModule: true,
+  default: () => <button type="button">boost</button>,
+}));
+
+jest.mock("./WaveDropActionsCopyLink", () => ({
+  __esModule: true,
+  default: () => <button type="button">copy link</button>,
+}));
+
+jest.mock("./WaveDropActionsMore", () => ({
+  __esModule: true,
+  default: () => <button type="button">more</button>,
+}));
+
+jest.mock("./WaveDropActionsQuickReact", () => ({
+  __esModule: true,
+  default: () => <button type="button">quick react</button>,
+}));
+
+jest.mock("./WaveDropActionsRate", () => ({
+  __esModule: true,
+  default: () => <button type="button">rate</button>,
+}));
+
+jest.mock("./WaveDropActionsReply", () => ({
+  __esModule: true,
+  default: () => <button type="button">reply</button>,
+}));
+
+const drop = {
+  id: "drop-1",
+  drop_type: ApiDropType.Chat,
+  wave: { id: "wave-1" },
+  context_profile_context: {},
+} as ExtendedDrop;
+
+describe("WaveDropLayerContext", () => {
+  it("places desktop actions above boosted drop card internals by default", () => {
+    const { result } = renderHook(() => useWaveDropLayers());
+
+    expect(result.current.desktopActionsZIndexClassName).toBe("tw-z-40");
+  });
+
+  it("keeps the desktop action layer when only mobile layers are overridden", () => {
+    const wrapper = ({ children }: { readonly children: ReactNode }) => (
+      <WaveDropLayerProvider
+        value={{
+          mobileMenuZIndexClassName: "tw-z-[1020]",
+          mobileDialogZIndexClassName: "tw-z-[1030]",
+        }}
+      >
+        {children}
+      </WaveDropLayerProvider>
+    );
+
+    const { result } = renderHook(() => useWaveDropLayers(), { wrapper });
+
+    expect(result.current.desktopActionsZIndexClassName).toBe("tw-z-40");
+    expect(result.current.mobileMenuZIndexClassName).toBe("tw-z-[1020]");
+    expect(result.current.mobileDialogZIndexClassName).toBe("tw-z-[1030]");
+  });
+});
+
+describe("WaveDropActions layer", () => {
+  it("uses the default desktop action layer on the hover action wrapper", () => {
+    const { container } = render(
+      <WaveDropActions drop={drop} activePartIndex={0} onReply={jest.fn()} />
+    );
+
+    expect(container.firstElementChild).toHaveClass("tw-z-40");
+    expect(container.firstElementChild).not.toHaveClass("tw-z-20");
+  });
+
+  it("uses the contextual desktop action layer when provided", () => {
+    const { container } = render(
+      <WaveDropLayerProvider
+        value={{ desktopActionsZIndexClassName: "tw-z-50" }}
+      >
+        <WaveDropActions drop={drop} activePartIndex={0} onReply={jest.fn()} />
+      </WaveDropLayerProvider>
+    );
+
+    expect(container.firstElementChild).toHaveClass("tw-z-50");
+  });
+});

--- a/components/waves/drops/WaveDropLayerContext.tsx
+++ b/components/waves/drops/WaveDropLayerContext.tsx
@@ -3,11 +3,15 @@
 import React, { createContext, useContext, useMemo } from "react";
 
 type WaveDropLayerContextValue = {
+  // Override values must be Tailwind classes emitted by the build, either as
+  // static literals like these defaults or through the Tailwind safelist.
+  readonly desktopActionsZIndexClassName: string;
   readonly mobileMenuZIndexClassName: string;
   readonly mobileDialogZIndexClassName: string;
 };
 
 const DEFAULT_WAVE_DROP_LAYER_CONTEXT: WaveDropLayerContextValue = {
+  desktopActionsZIndexClassName: "tw-z-40",
   mobileMenuZIndexClassName: "tw-z-[1000]",
   mobileDialogZIndexClassName: "tw-z-[1010]",
 };
@@ -25,6 +29,9 @@ export function WaveDropLayerProvider({
 }) {
   const mergedValue = useMemo<WaveDropLayerContextValue>(
     () => ({
+      desktopActionsZIndexClassName:
+        value?.desktopActionsZIndexClassName ??
+        DEFAULT_WAVE_DROP_LAYER_CONTEXT.desktopActionsZIndexClassName,
       mobileMenuZIndexClassName:
         value?.mobileMenuZIndexClassName ??
         DEFAULT_WAVE_DROP_LAYER_CONTEXT.mobileMenuZIndexClassName,


### PR DESCRIPTION
## Issue
The wave drop desktop hover action bar, including quick reactions, can sit underneath a boosted drop card when a message appears directly below the boosted drop. The action wrapper used `tw-z-20`, while boosted drop content uses higher local layers such as `tw-z-30`.

## Fix
Raise the default desktop action layer through `WaveDropLayerContext` to `tw-z-40`, and have `WaveDropActions` consume that contextual layer instead of hardcoding `tw-z-20`.

## Changes
- Add `desktopActionsZIndexClassName` to `WaveDropLayerContext`.
- Preserve existing partial layer override behavior.
- Use the contextual desktop action z-index in `WaveDropActions`.
- Add tests for the default, override preservation, and rendered action wrapper class.

## Validation
- `./bin/6529 exec cross-env NODE_ENV=test jest --silent --verbose=false --coverageReporters=none --runInBand --forceExit components/waves/drops/WaveDropLayerContext.test.tsx`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff`
- `./bin/6529 exec prettier --check components/waves/drops/WaveDropLayerContext.test.tsx components/waves/drops/WaveDropActions.tsx components/waves/drops/WaveDropLayerContext.tsx`

## Staging
This fix was already merged to `1a-staging` via #2856 and deployed successfully to staging at `b0c010bf42c3c4aad276d6c4b80ce7c4f524a254`.

## Risk
Low. This only adjusts the local stacking layer for the hover action bar and keeps it below higher app/modal layers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced z-index management system for action components by implementing context-based configuration, replacing hardcoded values for more flexible layering control.

* **Tests**
  * Added comprehensive unit tests to verify z-index layering behavior across different configurations, ensuring correct visual stacking on desktop and mobile platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->