### PR TITLE
Add tooltip to Additional Action badge

### DIFF
--- a/__tests__/components/waves/drops/AdditionalActionPromiseBadge.test.tsx
+++ b/__tests__/components/waves/drops/AdditionalActionPromiseBadge.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from "react";
-import { render, screen } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
 
 import { AdditionalActionPromiseBadge } from "@/components/waves/drops/AdditionalActionPromiseBadge";
 
@@ -29,27 +29,27 @@ jest.mock("@/components/utils/tooltip/CustomTooltip", () => ({
 
 describe("AdditionalActionPromiseBadge", () => {
   it("shows the badge with explanatory tooltip copy", () => {
-    render(<AdditionalActionPromiseBadge />);
+    const markup = renderToStaticMarkup(<AdditionalActionPromiseBadge />);
 
-    const tooltip = screen.getByTestId("custom-tooltip");
-    const badge = screen.getByRole("button", { name: "Additional Action" });
-
-    expect(tooltip).toHaveAttribute(
-      "data-content",
-      "The creator marked this submission as promising an extra action beyond the artwork, such as an event, donation, physical item, airdrop, or future deliverable."
+    expect(markup).toContain('data-testid="custom-tooltip"');
+    expect(markup).toContain(
+      'data-content="The creator marked this submission as promising an extra action beyond the artwork, such as an event, donation, physical item, airdrop, or future deliverable."'
     );
-    expect(tooltip).toHaveAttribute("data-placement", "top");
-    expect(tooltip).toHaveAttribute("data-delay-show", "200");
-    expect(badge).toHaveAttribute("type", "button");
-    expect(badge).toHaveClass("tw-cursor-help");
+    expect(markup).toContain('data-placement="top"');
+    expect(markup).toContain('data-delay-show="200"');
+    expect(markup).toContain("<button");
+    expect(markup).toContain('type="button"');
+    expect(markup).toContain("tw-cursor-help");
+    expect(markup).toContain("Additional Action");
   });
 
   it("can disable keyboard focus when rendered inside another focus target", () => {
-    render(<AdditionalActionPromiseBadge focusable={false} />);
+    const markup = renderToStaticMarkup(
+      <AdditionalActionPromiseBadge focusable={false} />
+    );
 
-    const badge = screen.getByText("Additional Action");
-
-    expect(badge.tagName).toBe("SPAN");
-    expect(badge).not.toHaveAttribute("tabindex");
+    expect(markup).toContain('<span class="');
+    expect(markup).not.toContain("<button");
+    expect(markup).not.toContain("tabindex=");
   });
 });

--- a/__tests__/components/waves/drops/AdditionalActionPromiseBadge.test.tsx
+++ b/__tests__/components/waves/drops/AdditionalActionPromiseBadge.test.tsx
@@ -3,6 +3,9 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { AdditionalActionPromiseBadge } from "@/components/waves/drops/AdditionalActionPromiseBadge";
 
+const TOOLTIP_COPY =
+  "The creator marked this submission as promising an extra action beyond the artwork, such as an event, donation, physical item, airdrop, or future deliverable.";
+
 jest.mock("@/components/utils/tooltip/CustomTooltip", () => ({
   __esModule: true,
   default: ({
@@ -30,25 +33,33 @@ jest.mock("@/components/utils/tooltip/CustomTooltip", () => ({
 describe("AdditionalActionPromiseBadge", () => {
   it("shows the badge with explanatory tooltip copy", () => {
     const markup = renderToStaticMarkup(<AdditionalActionPromiseBadge />);
+    const descriptionId = markup.match(/aria-describedby="([^"]+)"/)?.[1];
 
     expect(markup).toContain('data-testid="custom-tooltip"');
-    expect(markup).toContain(
-      'data-content="The creator marked this submission as promising an extra action beyond the artwork, such as an event, donation, physical item, airdrop, or future deliverable."'
-    );
+    expect(markup).toContain(`data-content="${TOOLTIP_COPY}"`);
     expect(markup).toContain('data-placement="top"');
     expect(markup).toContain('data-delay-show="200"');
     expect(markup).toContain("<button");
     expect(markup).toContain('type="button"');
     expect(markup).toContain("tw-cursor-help");
     expect(markup).toContain("Additional Action");
+    expect(descriptionId).toBeTruthy();
+    expect(markup).toContain(
+      `<span id="${descriptionId}" class="tw-sr-only">${TOOLTIP_COPY}</span>`
+    );
   });
 
   it("can disable keyboard focus when rendered inside another focus target", () => {
     const markup = renderToStaticMarkup(
       <AdditionalActionPromiseBadge focusable={false} />
     );
+    const descriptionId = markup.match(/aria-describedby="([^"]+)"/)?.[1];
 
-    expect(markup).toContain('<span class="');
+    expect(markup).toContain(`<span aria-describedby="${descriptionId}"`);
+    expect(descriptionId).toBeTruthy();
+    expect(markup).toContain(
+      `<span id="${descriptionId}" class="tw-sr-only">${TOOLTIP_COPY}</span>`
+    );
     expect(markup).not.toContain("<button");
     expect(markup).not.toContain("tabindex=");
   });

--- a/__tests__/components/waves/drops/AdditionalActionPromiseBadge.test.tsx
+++ b/__tests__/components/waves/drops/AdditionalActionPromiseBadge.test.tsx
@@ -32,7 +32,7 @@ describe("AdditionalActionPromiseBadge", () => {
     render(<AdditionalActionPromiseBadge />);
 
     const tooltip = screen.getByTestId("custom-tooltip");
-    const badge = screen.getByText("Additional Action");
+    const badge = screen.getByRole("button", { name: "Additional Action" });
 
     expect(tooltip).toHaveAttribute(
       "data-content",
@@ -40,15 +40,16 @@ describe("AdditionalActionPromiseBadge", () => {
     );
     expect(tooltip).toHaveAttribute("data-placement", "top");
     expect(tooltip).toHaveAttribute("data-delay-show", "200");
-    expect(badge).toHaveAttribute("tabindex", "0");
+    expect(badge).toHaveAttribute("type", "button");
     expect(badge).toHaveClass("tw-cursor-help");
   });
 
   it("can disable keyboard focus when rendered inside another focus target", () => {
     render(<AdditionalActionPromiseBadge focusable={false} />);
 
-    expect(screen.getByText("Additional Action")).not.toHaveAttribute(
-      "tabindex"
-    );
+    const badge = screen.getByText("Additional Action");
+
+    expect(badge.tagName).toBe("SPAN");
+    expect(badge).not.toHaveAttribute("tabindex");
   });
 });

--- a/__tests__/components/waves/drops/AdditionalActionPromiseBadge.test.tsx
+++ b/__tests__/components/waves/drops/AdditionalActionPromiseBadge.test.tsx
@@ -2,9 +2,11 @@ import type { ReactElement, ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { AdditionalActionPromiseBadge } from "@/components/waves/drops/AdditionalActionPromiseBadge";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 
-const TOOLTIP_COPY =
-  "The creator marked this submission as promising an extra action beyond the artwork, such as an event, donation, physical item, airdrop, or future deliverable.";
+const BADGE_LABEL = t(DEFAULT_LOCALE, "drops.additionalActionBadge.label");
+const TOOLTIP_COPY = t(DEFAULT_LOCALE, "drops.additionalActionBadge.tooltip");
 
 jest.mock("@/components/utils/tooltip/CustomTooltip", () => ({
   __esModule: true,
@@ -42,7 +44,7 @@ describe("AdditionalActionPromiseBadge", () => {
     expect(markup).toContain("<button");
     expect(markup).toContain('type="button"');
     expect(markup).toContain("tw-cursor-help");
-    expect(markup).toContain("Additional Action");
+    expect(markup).toContain(BADGE_LABEL);
     expect(descriptionId).toBeTruthy();
     expect(markup).toContain(
       `<span id="${descriptionId}" class="tw-sr-only">${TOOLTIP_COPY}</span>`

--- a/__tests__/components/waves/drops/AdditionalActionPromiseBadge.test.tsx
+++ b/__tests__/components/waves/drops/AdditionalActionPromiseBadge.test.tsx
@@ -1,0 +1,54 @@
+import type { ReactElement, ReactNode } from "react";
+import { render, screen } from "@testing-library/react";
+
+import { AdditionalActionPromiseBadge } from "@/components/waves/drops/AdditionalActionPromiseBadge";
+
+jest.mock("@/components/utils/tooltip/CustomTooltip", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    content,
+    delayShow,
+    placement,
+  }: {
+    readonly children: ReactElement;
+    readonly content: ReactNode;
+    readonly delayShow?: number;
+    readonly placement?: string;
+  }) => (
+    <span
+      data-testid="custom-tooltip"
+      data-content={typeof content === "string" ? content : undefined}
+      data-delay-show={delayShow}
+      data-placement={placement}
+    >
+      {children}
+    </span>
+  ),
+}));
+
+describe("AdditionalActionPromiseBadge", () => {
+  it("shows the badge with explanatory tooltip copy", () => {
+    render(<AdditionalActionPromiseBadge />);
+
+    const tooltip = screen.getByTestId("custom-tooltip");
+    const badge = screen.getByText("Additional Action");
+
+    expect(tooltip).toHaveAttribute(
+      "data-content",
+      "The creator marked this submission as promising an extra action beyond the artwork, such as an event, donation, physical item, airdrop, or future deliverable."
+    );
+    expect(tooltip).toHaveAttribute("data-placement", "top");
+    expect(tooltip).toHaveAttribute("data-delay-show", "200");
+    expect(badge).toHaveAttribute("tabindex", "0");
+    expect(badge).toHaveClass("tw-cursor-help");
+  });
+
+  it("can disable keyboard focus when rendered inside another focus target", () => {
+    render(<AdditionalActionPromiseBadge focusable={false} />);
+
+    expect(screen.getByText("Additional Action")).not.toHaveAttribute(
+      "tabindex"
+    );
+  });
+});

--- a/components/memes/drops/MemeParticipationDrop.tsx
+++ b/components/memes/drops/MemeParticipationDrop.tsx
@@ -125,7 +125,7 @@ export default function MemeParticipationDrop({
     <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
       <MemeDropHeader title={title} />
       {drop.is_additional_action_promised === true && (
-        <AdditionalActionPromiseBadge />
+        <AdditionalActionPromiseBadge focusable={!isContentInteractive} />
       )}
     </div>
   );

--- a/components/waves/drops/AdditionalActionPromiseBadge.tsx
+++ b/components/waves/drops/AdditionalActionPromiseBadge.tsx
@@ -1,31 +1,46 @@
 "use client";
 
 import CustomTooltip from "@/components/utils/tooltip/CustomTooltip";
+import type { MouseEvent } from "react";
 
 const ADDITIONAL_ACTION_PROMISE_TOOLTIP =
   "The creator marked this submission as promising an extra action beyond the artwork, such as an event, donation, physical item, airdrop, or future deliverable.";
+
+const BADGE_CLASSES =
+  "tw-inline-flex tw-shrink-0 tw-cursor-help tw-items-center tw-rounded-full tw-bg-amber-400/10 tw-px-2 tw-py-0.5 tw-text-[11px] tw-font-semibold tw-leading-5 tw-text-amber-300 tw-ring-1 tw-ring-amber-300/25 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-amber-300";
 
 interface AdditionalActionPromiseBadgeProps {
   readonly className?: string | undefined;
   readonly focusable?: boolean | undefined;
 }
 
+function stopBadgeClickPropagation(event: MouseEvent<HTMLButtonElement>) {
+  event.stopPropagation();
+}
+
 export function AdditionalActionPromiseBadge({
   className = "",
   focusable = true,
 }: AdditionalActionPromiseBadgeProps) {
+  const badgeClassName = `${BADGE_CLASSES} ${className}`;
+
   return (
     <CustomTooltip
       content={ADDITIONAL_ACTION_PROMISE_TOOLTIP}
       placement="top"
       delayShow={200}
     >
-      <span
-        tabIndex={focusable ? 0 : undefined}
-        className={`tw-inline-flex tw-shrink-0 tw-cursor-help tw-items-center tw-rounded-full tw-bg-amber-400/10 tw-px-2 tw-py-0.5 tw-text-[11px] tw-font-semibold tw-leading-5 tw-text-amber-300 tw-ring-1 tw-ring-amber-300/25 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-amber-300 ${className}`}
-      >
-        Additional Action
-      </span>
+      {focusable ? (
+        <button
+          type="button"
+          onClick={stopBadgeClickPropagation}
+          className={`${badgeClassName} tw-border-0`}
+        >
+          Additional Action
+        </button>
+      ) : (
+        <span className={badgeClassName}>Additional Action</span>
+      )}
     </CustomTooltip>
   );
 }

--- a/components/waves/drops/AdditionalActionPromiseBadge.tsx
+++ b/components/waves/drops/AdditionalActionPromiseBadge.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import CustomTooltip from "@/components/utils/tooltip/CustomTooltip";
-import type { MouseEvent } from "react";
+import { useId, type MouseEvent } from "react";
 
 const ADDITIONAL_ACTION_PROMISE_TOOLTIP =
   "The creator marked this submission as promising an extra action beyond the artwork, such as an event, donation, physical item, airdrop, or future deliverable.";
@@ -23,24 +23,33 @@ export function AdditionalActionPromiseBadge({
   focusable = true,
 }: AdditionalActionPromiseBadgeProps) {
   const badgeClassName = `${BADGE_CLASSES} ${className}`;
+  const descriptionId = useId();
 
   return (
-    <CustomTooltip
-      content={ADDITIONAL_ACTION_PROMISE_TOOLTIP}
-      placement="top"
-      delayShow={200}
-    >
-      {focusable ? (
-        <button
-          type="button"
-          onClick={stopBadgeClickPropagation}
-          className={`${badgeClassName} tw-border-0`}
-        >
-          Additional Action
-        </button>
-      ) : (
-        <span className={badgeClassName}>Additional Action</span>
-      )}
-    </CustomTooltip>
+    <>
+      <CustomTooltip
+        content={ADDITIONAL_ACTION_PROMISE_TOOLTIP}
+        placement="top"
+        delayShow={200}
+      >
+        {focusable ? (
+          <button
+            type="button"
+            aria-describedby={descriptionId}
+            onClick={stopBadgeClickPropagation}
+            className={`${badgeClassName} tw-border-0`}
+          >
+            Additional Action
+          </button>
+        ) : (
+          <span aria-describedby={descriptionId} className={badgeClassName}>
+            Additional Action
+          </span>
+        )}
+      </CustomTooltip>
+      <span id={descriptionId} className="tw-sr-only">
+        {ADDITIONAL_ACTION_PROMISE_TOOLTIP}
+      </span>
+    </>
   );
 }

--- a/components/waves/drops/AdditionalActionPromiseBadge.tsx
+++ b/components/waves/drops/AdditionalActionPromiseBadge.tsx
@@ -1,15 +1,31 @@
+"use client";
+
+import CustomTooltip from "@/components/utils/tooltip/CustomTooltip";
+
+const ADDITIONAL_ACTION_PROMISE_TOOLTIP =
+  "The creator marked this submission as promising an extra action beyond the artwork, such as an event, donation, physical item, airdrop, or future deliverable.";
+
 interface AdditionalActionPromiseBadgeProps {
   readonly className?: string | undefined;
+  readonly focusable?: boolean | undefined;
 }
 
 export function AdditionalActionPromiseBadge({
   className = "",
+  focusable = true,
 }: AdditionalActionPromiseBadgeProps) {
   return (
-    <span
-      className={`tw-inline-flex tw-shrink-0 tw-items-center tw-rounded-full tw-bg-amber-400/10 tw-px-2 tw-py-0.5 tw-text-[11px] tw-font-semibold tw-leading-5 tw-text-amber-300 tw-ring-1 tw-ring-amber-300/25 ${className}`}
+    <CustomTooltip
+      content={ADDITIONAL_ACTION_PROMISE_TOOLTIP}
+      placement="top"
+      delayShow={200}
     >
-      Additional Action
-    </span>
+      <span
+        tabIndex={focusable ? 0 : undefined}
+        className={`tw-inline-flex tw-shrink-0 tw-cursor-help tw-items-center tw-rounded-full tw-bg-amber-400/10 tw-px-2 tw-py-0.5 tw-text-[11px] tw-font-semibold tw-leading-5 tw-text-amber-300 tw-ring-1 tw-ring-amber-300/25 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-amber-300 ${className}`}
+      >
+        Additional Action
+      </span>
+    </CustomTooltip>
   );
 }

--- a/components/waves/drops/AdditionalActionPromiseBadge.tsx
+++ b/components/waves/drops/AdditionalActionPromiseBadge.tsx
@@ -1,10 +1,19 @@
 "use client";
 
 import CustomTooltip from "@/components/utils/tooltip/CustomTooltip";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import { useId, type MouseEvent } from "react";
 
-const ADDITIONAL_ACTION_PROMISE_TOOLTIP =
-  "The creator marked this submission as promising an extra action beyond the artwork, such as an event, donation, physical item, airdrop, or future deliverable.";
+const ADDITIONAL_ACTION_PROMISE_LABEL = t(
+  DEFAULT_LOCALE,
+  "drops.additionalActionBadge.label"
+);
+
+const ADDITIONAL_ACTION_PROMISE_TOOLTIP = t(
+  DEFAULT_LOCALE,
+  "drops.additionalActionBadge.tooltip"
+);
 
 const BADGE_CLASSES =
   "tw-inline-flex tw-shrink-0 tw-cursor-help tw-items-center tw-rounded-full tw-bg-amber-400/10 tw-px-2 tw-py-0.5 tw-text-[11px] tw-font-semibold tw-leading-5 tw-text-amber-300 tw-ring-1 tw-ring-amber-300/25 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-amber-300";
@@ -39,11 +48,11 @@ export function AdditionalActionPromiseBadge({
             onClick={stopBadgeClickPropagation}
             className={`${badgeClassName} tw-border-0`}
           >
-            Additional Action
+            {ADDITIONAL_ACTION_PROMISE_LABEL}
           </button>
         ) : (
           <span aria-describedby={descriptionId} className={badgeClassName}>
-            Additional Action
+            {ADDITIONAL_ACTION_PROMISE_LABEL}
           </span>
         )}
       </CustomTooltip>

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -994,6 +994,9 @@ export const EN_US_MESSAGES = {
   "drop.media.retry": "Retry",
   "drop.media.processingFailed": "Image processing failed.",
   "drop.media.processingTimedOut": "Image processing timed out.",
+  "drops.additionalActionBadge.label": "Additional Action",
+  "drops.additionalActionBadge.tooltip":
+    "The creator marked this submission as promising an extra action beyond the artwork, such as an event, donation, physical item, airdrop, or future deliverable.",
   ...USER_PROFILE_TABS_MESSAGES,
   ...FOLLOWERS_MESSAGES,
   ...WAVES_SIDEBAR_MESSAGES,


### PR DESCRIPTION
## Issue
- The Additional Action badge appears on Memes submissions, but users have no inline explanation of what the badge means.

## Fix
- Add a tooltip to the shared Additional Action badge explaining that the creator marked the submission as promising an extra action beyond the artwork.
- Keep the visual badge styling unchanged while adding a help cursor and visible keyboard focus for safe contexts.

## Changes
- Wrap `AdditionalActionPromiseBadge` in the existing custom tooltip primitive.
- Add a `focusable` escape hatch for the existing participation-card path where the badge can render inside a content button.
- Add a focused component test for the tooltip copy and focus behavior.
- Frontend only; no API, backend, generated model, or deployment-order changes.

## Validation
- `6529 run format:uncommitted`
- `6529 run lint:diff`
- `6529 run typecheck`
- `6529 run lint:changed`
- `6529 run typecheck:changed`
- `6529 run react-doctor:diff` before commit: scanned the edited source files and reported no issues.
- `6529 run test -- AdditionalActionPromiseBadge.test.tsx --runInBand`: test assertions passed; local Jest process reported completion but stayed open, so it was stopped after the pass output.
- `6529 run check:changed` was not used as a passing gate because it currently fails on repo-wide existing Knip dead-code findings unrelated to this PR.

## Risk
- Level: Low
- Why: scoped tooltip/copy-only frontend UI change, with no data, API, auth, or deployable backend behavior changes.
- Rollback: revert the single frontend commit to remove the tooltip wrapper and focused test.

## Review Notes
- Please focus on whether the tooltip copy accurately communicates that the promise is creator-declared and not an app guarantee.