### PR TITLE
Fix hover action stacking above boosted cards

### DIFF
--- a/components/waves/drops/WaveDrop.tsx
+++ b/components/waves/drops/WaveDrop.tsx
@@ -71,9 +71,11 @@ const getPointerId = (event: React.PointerEvent<HTMLDivElement>): number =>
 const isPrimaryPointerButton = (
   event: React.PointerEvent<HTMLDivElement>
 ): boolean => {
-  const maybeButton = (event as React.PointerEvent<HTMLDivElement> & {
-    readonly button?: number | undefined;
-  }).button;
+  const maybeButton = (
+    event as React.PointerEvent<HTMLDivElement> & {
+      readonly button?: number | undefined;
+    }
+  ).button;
 
   return (
     maybeButton === undefined ||
@@ -182,7 +184,7 @@ const getDropClasses = (
   isDrop: boolean
 ): string => {
   const baseClasses =
-    "touch-select-none tw-cursor-default tw-relative tw-group tw-w-full tw-flex tw-flex-col tw-px-4 tw-transition-colors tw-duration-300";
+    "touch-select-none tw-cursor-default tw-relative tw-group tw-w-full tw-flex tw-flex-col tw-px-4 tw-transition-colors tw-duration-300 desktop-hover:hover:tw-z-30 focus-within:tw-z-30";
 
   const streamClasses = "tw-rounded-xl";
 


### PR DESCRIPTION
## Issue
Staging showed the wave drop hover action/emoji bar still sitting below the adjacent boosted-card boost button when the message is directly under a boosted drop. The previous fix raised the action toolbar itself, but the toolbar remained inside a lower sibling stacking context.

## Fix
Lift the hovered/focused `WaveDrop` wrapper with `desktop-hover:hover:tw-z-30 focus-within:tw-z-30` so its action toolbar can stack above neighboring boosted-card internals.

## Validation
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 exec prettier --check components/waves/drops/WaveDrop.tsx`

## Risk
Low. The lift only applies while a drop is hovered or focused, and it uses the same bounded z-index pattern already used by other hover-lifted cards.