### PR TITLE
[codex] Harden auth switch query boundaries

### DIFF
--- a/__tests__/components/auth/Auth.test.tsx
+++ b/__tests__/components/auth/Auth.test.tsx
@@ -395,7 +395,13 @@ describe("Auth component", () => {
     it("returns showWaves true when wallet and profile", async () => {
       // Set up profile mock to return a profile with handle
       mockUseIdentity.mockReturnValue({
-        profile: { id: "1", handle: "testuser", query: "testuser" },
+        profile: {
+          id: "1",
+          handle: "testuser",
+          query: "testuser",
+          primary_wallet: walletAddress,
+          wallets: [],
+        },
         isLoading: false,
       });
 
@@ -1084,7 +1090,13 @@ describe("Auth component", () => {
         wasCancelled: false,
         shouldShowModal: false,
       });
-      const mockProfile = { id: "1", handle: "testuser", query: "testuser" };
+      const mockProfile = {
+        id: "1",
+        handle: "testuser",
+        query: "testuser",
+        primary_wallet: walletAddress,
+        wallets: [],
+      };
 
       // Mock useIdentity to return the profile immediately
       mockUseIdentity.mockReturnValue({
@@ -1144,7 +1156,13 @@ describe("Auth component", () => {
         wasCancelled: false,
         shouldShowModal: false,
       });
-      const mockProfile = { id: "1", handle: "testuser", query: "testuser" };
+      const mockProfile = {
+        id: "1",
+        handle: "testuser",
+        query: "testuser",
+        primary_wallet: walletAddress,
+        wallets: [],
+      };
 
       // Mock useIdentity to simulate profile fetching
       mockUseIdentity.mockReturnValue({
@@ -1221,6 +1239,37 @@ describe("Auth component", () => {
           handle: "stale",
           query: "stale",
           primary_wallet: "0x2222222222222222222222222222222222222222",
+          wallets: [],
+        },
+        isLoading: false,
+      });
+
+      render(
+        <ReactQueryWrapperContext.Provider
+          value={{ invalidateAll: jest.fn() } as any}
+        >
+          <Auth>
+            <ShowAuthState />
+          </Auth>
+        </ReactQueryWrapperContext.Provider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("profile-id")).toHaveTextContent("none");
+      });
+      expect(screen.getByTestId("fetching")).toHaveTextContent("true");
+      expect(screen.getByTestId("authenticated")).toHaveTextContent("false");
+      expect(screen.getByTestId("waves")).toHaveTextContent("false");
+    });
+
+    it("does not authenticate a profile without any usable wallet addresses", async () => {
+      walletAddress = "0x1111111111111111111111111111111111111111";
+      mockUseIdentity.mockReturnValue({
+        profile: {
+          id: "malformed-profile",
+          handle: "malformed",
+          query: "malformed",
+          primary_wallet: null,
           wallets: [],
         },
         isLoading: false,

--- a/__tests__/components/auth/Auth.test.tsx
+++ b/__tests__/components/auth/Auth.test.tsx
@@ -1295,7 +1295,65 @@ describe("Auth component", () => {
         expect.anything(),
         { wave_id: "private-wave" },
       ]);
+      expect(
+        mockQueryClient.getQueryData.mock.invocationCallOrder[0]
+      ).toBeLessThan(
+        invalidateAuthSensitiveQueries.mock.invocationCallOrder[0]
+      );
       expect(mockRouterReplace).toHaveBeenCalledWith("/messages");
+
+      window.dispatchEvent(new Event(authUtils.PROFILE_SWITCHED_EVENT));
+
+      await waitFor(() => {
+        expect(invalidateAuthSensitiveQueries).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it("uses the conservative waves fallback when profile switching from an uncached wave route", async () => {
+      walletAddress = "0x1111111111111111111111111111111111111111";
+      mockUsePathname.mockReturnValue("/waves/uncached-wave");
+      mockQueryClient.getQueryData.mockReturnValue(undefined);
+      mockUseIdentity.mockReturnValue({
+        profile: {
+          id: "profile-1",
+          handle: "profile",
+          query: "profile",
+          primary_wallet: walletAddress,
+          wallets: [],
+        },
+        isLoading: false,
+      });
+      const authUtils = require("@/services/auth/auth.utils");
+      const mockGetWalletAddress =
+        authUtils.getWalletAddress as jest.MockedFunction<any>;
+      const invalidateAuthSensitiveQueries = jest.fn();
+      mockGetWalletAddress.mockReturnValue(walletAddress);
+
+      render(
+        <ReactQueryWrapperContext.Provider
+          value={
+            {
+              invalidateAll: jest.fn(),
+              invalidateAuthSensitiveQueries,
+            } as any
+          }
+        >
+          <Auth>
+            <ShowAuthState />
+          </Auth>
+        </ReactQueryWrapperContext.Provider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("authenticated")).toHaveTextContent("true");
+      });
+
+      window.dispatchEvent(new Event(authUtils.PROFILE_SWITCHED_EVENT));
+
+      await waitFor(() => {
+        expect(mockRouterReplace).toHaveBeenCalledWith("/waves");
+      });
+      expect(invalidateAuthSensitiveQueries).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/__tests__/components/auth/Auth.test.tsx
+++ b/__tests__/components/auth/Auth.test.tsx
@@ -6,6 +6,13 @@ import { ReactQueryWrapperContext } from "@/components/react-query-wrapper/React
 import { mockTitleContextModule } from "@/__tests__/utils/titleTestUtils";
 import { commonApiFetch, commonApiPost } from "@/services/api/common-api";
 
+const mockQueryClient = {
+  getQueryData: jest.fn(),
+};
+const mockRouterReplace = jest.fn();
+const mockRouterPush = jest.fn();
+const mockUsePathname = jest.fn(() => "/");
+
 jest.mock("react-toastify", () => ({
   toast: jest.fn(),
   ToastContainer: () => <div data-testid="toast" />,
@@ -60,6 +67,7 @@ jest.mock("@/services/auth/session-v2.utils", () => ({
 
 jest.mock("@tanstack/react-query", () => ({
   useQuery: jest.fn(() => ({ data: undefined })),
+  useQueryClient: jest.fn(() => mockQueryClient),
 }));
 
 jest.mock("@reown/appkit/react", () => ({
@@ -105,11 +113,11 @@ jest.mock("@/services/auth/jwt-validation.utils", () => ({
 }));
 
 jest.mock("next/navigation", () => ({
-  usePathname: jest.fn(() => "/"),
-  useRouter: jest.fn(() => ({
-    replace: jest.fn(),
-    push: jest.fn(),
-  })),
+  usePathname: () => mockUsePathname(),
+  useRouter: () => ({
+    replace: mockRouterReplace,
+    push: mockRouterPush,
+  }),
   useSearchParams: jest.fn(() => new URLSearchParams()),
 }));
 
@@ -236,6 +244,19 @@ function ShowWaves() {
   return <span data-testid="waves">{String(showWaves)}</span>;
 }
 
+function ShowAuthState() {
+  const { connectedProfile, fetchingProfile, isAuthenticated, showWaves } =
+    useAuth();
+  return (
+    <div>
+      <span data-testid="profile-id">{connectedProfile?.id ?? "none"}</span>
+      <span data-testid="fetching">{String(fetchingProfile)}</span>
+      <span data-testid="authenticated">{String(isAuthenticated)}</span>
+      <span data-testid="waves">{String(showWaves)}</span>
+    </div>
+  );
+}
+
 function RequestAuthButton() {
   const { requestAuth } = useAuth();
   return (
@@ -258,6 +279,8 @@ describe("Auth component", () => {
     };
     globalThis.localStorage?.clear();
     jest.clearAllMocks();
+    mockQueryClient.getQueryData.mockReturnValue(undefined);
+    mockUsePathname.mockReturnValue("/");
 
     const authUtils = require("@/services/auth/auth.utils");
     const mockIsAuthAddressAuthorized =
@@ -1188,6 +1211,91 @@ describe("Auth component", () => {
       });
 
       expect(contextValues.connectedProfile).toBeNull();
+    });
+
+    it("does not authenticate a profile loaded for a different wallet address", async () => {
+      walletAddress = "0x1111111111111111111111111111111111111111";
+      mockUseIdentity.mockReturnValue({
+        profile: {
+          id: "stale-profile",
+          handle: "stale",
+          query: "stale",
+          primary_wallet: "0x2222222222222222222222222222222222222222",
+          wallets: [],
+        },
+        isLoading: false,
+      });
+
+      render(
+        <ReactQueryWrapperContext.Provider
+          value={{ invalidateAll: jest.fn() } as any}
+        >
+          <Auth>
+            <ShowAuthState />
+          </Auth>
+        </ReactQueryWrapperContext.Provider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("profile-id")).toHaveTextContent("none");
+      });
+      expect(screen.getByTestId("fetching")).toHaveTextContent("true");
+      expect(screen.getByTestId("authenticated")).toHaveTextContent("false");
+      expect(screen.getByTestId("waves")).toHaveTextContent("false");
+    });
+
+    it("invalidates auth-sensitive queries and exits private message waves after a profile switch", async () => {
+      walletAddress = "0x1111111111111111111111111111111111111111";
+      mockUsePathname.mockReturnValue("/messages/private-wave");
+      mockQueryClient.getQueryData.mockReturnValue({
+        id: "private-wave",
+        visibility: { scope: { group: { id: "private-group" } } },
+      });
+      mockUseIdentity.mockReturnValue({
+        profile: {
+          id: "profile-1",
+          handle: "profile",
+          query: "profile",
+          primary_wallet: walletAddress,
+          wallets: [],
+        },
+        isLoading: false,
+      });
+      const authUtils = require("@/services/auth/auth.utils");
+      const mockGetWalletAddress =
+        authUtils.getWalletAddress as jest.MockedFunction<any>;
+      const invalidateAuthSensitiveQueries = jest.fn();
+      mockGetWalletAddress.mockReturnValue(walletAddress);
+
+      render(
+        <ReactQueryWrapperContext.Provider
+          value={
+            {
+              invalidateAll: jest.fn(),
+              invalidateAuthSensitiveQueries,
+            } as any
+          }
+        >
+          <Auth>
+            <ShowAuthState />
+          </Auth>
+        </ReactQueryWrapperContext.Provider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId("authenticated")).toHaveTextContent("true");
+      });
+
+      window.dispatchEvent(new Event(authUtils.PROFILE_SWITCHED_EVENT));
+
+      await waitFor(() => {
+        expect(invalidateAuthSensitiveQueries).toHaveBeenCalledTimes(1);
+      });
+      expect(mockQueryClient.getQueryData).toHaveBeenCalledWith([
+        expect.anything(),
+        { wave_id: "private-wave" },
+      ]);
+      expect(mockRouterReplace).toHaveBeenCalledWith("/messages");
     });
   });
 

--- a/__tests__/components/react-query-wrapper/ReactQueryWrapper.test.tsx
+++ b/__tests__/components/react-query-wrapper/ReactQueryWrapper.test.tsx
@@ -33,6 +33,7 @@ type ContextType = {
   onGroupChanged: (params: { groupId: string }) => void;
   onIdentityBulkRate: () => void;
   invalidateNotifications: () => void;
+  invalidateAuthSensitiveQueries: () => void;
 };
 
 const createTestSetup = () => {
@@ -257,6 +258,38 @@ it("invalidateAll calls queryClient.invalidateQueries with no args", () => {
     queryKey: [QueryKey.WAVE],
   });
   expect(client.invalidateQueries).toHaveBeenCalledWith();
+});
+
+it("invalidates auth-sensitive queries without clearing unrelated cache", () => {
+  const { client, ctx } = createTestSetup();
+  client.setQueryData([QueryKey.PROFILE, "alice"], { handle: "alice" });
+  client.setQueryData([QueryKey.WAVES_V2, { viewer_identity: "0x1" }], []);
+  client.setQueryData(
+    [QueryKey.OFFICIAL_WAVES, { viewer_identity: "0x1" }],
+    []
+  );
+  client.setQueryData([QueryKey.GLOBAL_TDH_STATS], { total: 1 });
+
+  act(() => ctx.invalidateAuthSensitiveQueries());
+
+  expect(client.invalidateQueries).toHaveBeenCalledWith({
+    predicate: expect.any(Function),
+  });
+  const { predicate } = (client.invalidateQueries as jest.Mock).mock.calls.at(
+    -1
+  )![0] as {
+    predicate: (query: { queryKey: readonly unknown[] }) => boolean;
+  };
+  expect(predicate({ queryKey: [QueryKey.PROFILE, "alice"] })).toBe(true);
+  expect(
+    predicate({ queryKey: [QueryKey.WAVES_V2, { viewer_identity: "0x1" }] })
+  ).toBe(true);
+  expect(
+    predicate({
+      queryKey: [QueryKey.OFFICIAL_WAVES, { viewer_identity: "0x1" }],
+    })
+  ).toBe(true);
+  expect(predicate({ queryKey: [QueryKey.GLOBAL_TDH_STATS] })).toBe(false);
 });
 
 it("sets profile proxy and invalidates on modify", () => {

--- a/__tests__/components/waves/WavesLayout.test.tsx
+++ b/__tests__/components/waves/WavesLayout.test.tsx
@@ -87,6 +87,23 @@ describe("WavesLayout", () => {
     expect(screen.queryByTestId("connect-wallet")).not.toBeInTheDocument();
   });
 
+  it("keeps the Waves shell mounted without children while auth state is loading", () => {
+    mockUseAuthenticatedContent.mockReturnValue({
+      contentState: "loading",
+    });
+
+    render(
+      <WavesLayout>
+        <div data-testid="wave-content">Real wave content</div>
+      </WavesLayout>
+    );
+
+    expect(screen.getByTestId("waves-desktop")).toBeInTheDocument();
+    expect(screen.queryByTestId("wave-content")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("connect-wallet")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("setup-profile")).not.toBeInTheDocument();
+  });
+
   it("shows setup CTA instead of Waves content when profile setup is needed", () => {
     mockUseAuthenticatedContent.mockReturnValue({
       contentState: "needs-profile",

--- a/__tests__/components/waves/drops/WaveDropsAll.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropsAll.test.tsx
@@ -222,6 +222,8 @@ function setupMocks(options: MockSetupOptions = {}) {
   scrollButtonProps = undefined;
   mockFetchNextPage.mockReset();
   mockFetchNextPage.mockResolvedValue(undefined);
+  mockWaitAndRevealDrop.mockReset();
+  mockWaitAndRevealDrop.mockResolvedValue(false);
 
   // Setup useVirtualizedWaveDrops mock
   const defaultWaveMessages: WaveMessagesMock = {
@@ -478,7 +480,6 @@ describe("WaveDropsAll", () => {
         waveId: "test-wave",
         dropId: "target-drop",
         activeDrop: mockActiveDrop,
-        initialDrop: 5,
         winningThreshold: 11,
         winningThresholdMinDurationMs: 120_000,
         isVotingClosed: true,
@@ -552,7 +553,7 @@ describe("WaveDropsAll", () => {
       expect(mockPush).toHaveBeenCalledWith("/waves/other-wave?serialNo=42");
     });
 
-    it("sets serial number for same wave quote navigation", () => {
+    it("sets serial number for same wave quote navigation", async () => {
       const mockDrop = createMockDrop({
         wave: {
           id: "current-wave",
@@ -574,7 +575,19 @@ describe("WaveDropsAll", () => {
       });
 
       expect(mockPush).not.toHaveBeenCalled();
-      // Serial number state change is internal - we test the behavior, not the state
+      await waitFor(() => {
+        expect(mockFetchNextPage).toHaveBeenCalledWith(
+          {
+            waveId: "current-wave",
+            type: "LIGHT",
+            targetSerialNo: 42,
+          },
+          null
+        );
+      });
+      await waitFor(() => {
+        expect(dropsProps.suspendLightDropHydration).toBe(false);
+      });
     });
   });
 

--- a/__tests__/hooks/useAuthenticatedContent.test.tsx
+++ b/__tests__/hooks/useAuthenticatedContent.test.tsx
@@ -1,7 +1,9 @@
 import { AuthContext } from "@/components/auth/Auth";
+import { ProfileConnectedStatus } from "@/entities/IProfile";
+import { ApiIdentity } from "@/generated/models/ApiIdentity";
 import { useAuthenticatedContent } from "@/hooks/useAuthenticatedContent";
 import { renderHook } from "@testing-library/react";
-import type { ReactNode } from "react";
+import type { ContextType, ReactNode } from "react";
 
 const mockUseLayout = jest.fn();
 const mockUseSeizeConnectContext = jest.fn();
@@ -14,26 +16,33 @@ jest.mock("@/components/auth/SeizeConnectContext", () => ({
   useSeizeConnectContext: () => mockUseSeizeConnectContext(),
 }));
 
-const defaultAuthContext = {
+type AuthContextValue = ContextType<typeof AuthContext>;
+
+const createConnectedProfile = (handle: string): ApiIdentity =>
+  Object.assign(new ApiIdentity(), {
+    id: "profile-1",
+    handle,
+    query: handle,
+  });
+
+const defaultAuthContext: AuthContextValue = {
   connectedProfile: null,
   isAuthenticated: false,
   fetchingProfile: false,
-  connectionStatus: "DISCONNECTED",
+  connectionStatus: ProfileConnectedStatus.NOT_CONNECTED,
   receivedProfileProxies: [],
   activeProfileProxy: null,
   showWaves: false,
   sessionUpgradeRequired: false,
-  requestAuth: jest.fn(),
+  requestAuth: jest.fn(async () => ({ success: false })),
   setToast: jest.fn(),
-  setActiveProfileProxy: jest.fn(),
+  setActiveProfileProxy: jest.fn(async () => undefined),
 };
 
 const createWrapper =
-  (authContext: Partial<typeof defaultAuthContext> = {}) =>
+  (authContext: Partial<AuthContextValue> = {}) =>
   ({ children }: { readonly children: ReactNode }) => (
-    <AuthContext.Provider
-      value={{ ...defaultAuthContext, ...authContext } as any}
-    >
+    <AuthContext.Provider value={{ ...defaultAuthContext, ...authContext }}>
       {children}
     </AuthContext.Provider>
   );
@@ -60,6 +69,25 @@ describe("useAuthenticatedContent", () => {
         fetchingProfile: false,
         isAuthenticated: false,
         showWaves: false,
+      }),
+    });
+
+    expect(result.current.contentState).toBe("not-authenticated");
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it("does not let stale authenticated state override invalid wallet auth", () => {
+    mockUseSeizeConnectContext.mockReturnValue({
+      address: "0xabc",
+      hasValidWalletAuth: false,
+    });
+
+    const { result } = renderHook(() => useAuthenticatedContent(), {
+      wrapper: createWrapper({
+        connectedProfile: createConnectedProfile("alice"),
+        fetchingProfile: false,
+        isAuthenticated: true,
+        showWaves: true,
       }),
     });
 

--- a/__tests__/hooks/useAuthenticatedContent.test.tsx
+++ b/__tests__/hooks/useAuthenticatedContent.test.tsx
@@ -1,0 +1,87 @@
+import { AuthContext } from "@/components/auth/Auth";
+import { useAuthenticatedContent } from "@/hooks/useAuthenticatedContent";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+const mockUseLayout = jest.fn();
+const mockUseSeizeConnectContext = jest.fn();
+
+jest.mock("@/components/brain/my-stream/layout/LayoutContext", () => ({
+  useLayout: () => mockUseLayout(),
+}));
+
+jest.mock("@/components/auth/SeizeConnectContext", () => ({
+  useSeizeConnectContext: () => mockUseSeizeConnectContext(),
+}));
+
+const defaultAuthContext = {
+  connectedProfile: null,
+  isAuthenticated: false,
+  fetchingProfile: false,
+  connectionStatus: "DISCONNECTED",
+  receivedProfileProxies: [],
+  activeProfileProxy: null,
+  showWaves: false,
+  sessionUpgradeRequired: false,
+  requestAuth: jest.fn(),
+  setToast: jest.fn(),
+  setActiveProfileProxy: jest.fn(),
+};
+
+const createWrapper =
+  (authContext: Partial<typeof defaultAuthContext> = {}) =>
+  ({ children }: { readonly children: ReactNode }) => (
+    <AuthContext.Provider
+      value={{ ...defaultAuthContext, ...authContext } as any}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+
+describe("useAuthenticatedContent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseLayout.mockReturnValue({ spaces: { measurementsComplete: true } });
+    mockUseSeizeConnectContext.mockReturnValue({
+      address: null,
+      hasValidWalletAuth: false,
+    });
+  });
+
+  it("returns not-authenticated for connected wallets with invalid auth after profile loading settles", () => {
+    mockUseSeizeConnectContext.mockReturnValue({
+      address: "0xabc",
+      hasValidWalletAuth: false,
+    });
+
+    const { result } = renderHook(() => useAuthenticatedContent(), {
+      wrapper: createWrapper({
+        connectedProfile: null,
+        fetchingProfile: false,
+        isAuthenticated: false,
+        showWaves: false,
+      }),
+    });
+
+    expect(result.current.contentState).toBe("not-authenticated");
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it("keeps invalid-auth wallets loading while profile loading is still settling", () => {
+    mockUseSeizeConnectContext.mockReturnValue({
+      address: "0xabc",
+      hasValidWalletAuth: false,
+    });
+
+    const { result } = renderHook(() => useAuthenticatedContent(), {
+      wrapper: createWrapper({
+        connectedProfile: null,
+        fetchingProfile: true,
+        isAuthenticated: false,
+        showWaves: false,
+      }),
+    });
+
+    expect(result.current.contentState).toBe("loading");
+  });
+});

--- a/__tests__/hooks/useDmWavesList.test.tsx
+++ b/__tests__/hooks/useDmWavesList.test.tsx
@@ -24,7 +24,12 @@ const useWavesV2Mock = require("@/hooks/useWavesV2").useWavesV2 as jest.Mock;
 describe("useDmWavesList", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useAuthMock.mockReturnValue({ activeProfileProxy: null });
+    useAuthMock.mockReturnValue({
+      activeProfileProxy: null,
+      connectedProfile: { handle: "me" },
+      fetchingProfile: false,
+      isAuthenticated: true,
+    });
     useSeizeConnectContextMock.mockReturnValue({
       address: "0xABC",
       hasValidWalletAuth: true,
@@ -64,12 +69,26 @@ describe("useDmWavesList", () => {
   });
 
   it("disables the DM query while wallet auth is invalid", () => {
+    const fetchNextPage = jest.fn();
+    const refetch = jest.fn();
     useSeizeConnectContextMock.mockReturnValue({
       address: "0xABC",
       hasValidWalletAuth: false,
     });
+    useWavesV2Mock.mockReturnValue({
+      waves: [
+        { id: "older", latestDropTimestamp: 100 },
+        { id: "newer", latestDropTimestamp: 200 },
+      ],
+      isFetching: true,
+      isFetchingNextPage: true,
+      hasNextPage: true,
+      fetchNextPage,
+      status: "success",
+      refetch,
+    });
 
-    renderHook(() => useDmWavesList());
+    const { result } = renderHook(() => useDmWavesList());
 
     expect(useWavesV2Mock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -78,6 +97,18 @@ describe("useDmWavesList", () => {
         enabled: false,
       })
     );
+    expect(result.current.waves).toEqual([]);
+    expect(result.current.mainWaves).toEqual([]);
+    expect(result.current.isFetching).toBe(false);
+    expect(result.current.isFetchingNextPage).toBe(false);
+    expect(result.current.hasNextPage).toBe(false);
+
+    result.current.fetchNextPage();
+    result.current.mainWavesRefetch();
+    result.current.refetchAllWaves();
+
+    expect(fetchNextPage).not.toHaveBeenCalled();
+    expect(refetch).not.toHaveBeenCalled();
   });
 
   it("re-enables the DM query after profile loading settles", () => {

--- a/__tests__/hooks/useDmWavesList.test.tsx
+++ b/__tests__/hooks/useDmWavesList.test.tsx
@@ -25,7 +25,10 @@ describe("useDmWavesList", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     useAuthMock.mockReturnValue({ activeProfileProxy: null });
-    useSeizeConnectContextMock.mockReturnValue({ address: "0xABC" });
+    useSeizeConnectContextMock.mockReturnValue({
+      address: "0xABC",
+      hasValidWalletAuth: true,
+    });
     useWavesV2Mock.mockReturnValue({
       waves: [
         { id: "older", latestDropTimestamp: 100 },
@@ -53,8 +56,26 @@ describe("useDmWavesList", () => {
         pageSize: 20,
         directMessage: true,
         viewerIdentityKey: "0xabc:primary",
+        enabled: true,
         refetchInterval: SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
         refetchIntervalInBackground: false,
+      })
+    );
+  });
+
+  it("disables the DM query while wallet auth is invalid", () => {
+    useSeizeConnectContextMock.mockReturnValue({
+      address: "0xABC",
+      hasValidWalletAuth: false,
+    });
+
+    renderHook(() => useDmWavesList());
+
+    expect(useWavesV2Mock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directMessage: true,
+        viewerIdentityKey: null,
+        enabled: false,
       })
     );
   });

--- a/__tests__/hooks/useDmWavesList.test.tsx
+++ b/__tests__/hooks/useDmWavesList.test.tsx
@@ -79,4 +79,35 @@ describe("useDmWavesList", () => {
       })
     );
   });
+
+  it("re-enables the DM query after profile loading settles", () => {
+    let fetchingProfile = true;
+    useAuthMock.mockImplementation(() => ({
+      activeProfileProxy: null,
+      fetchingProfile,
+      isAuthenticated: true,
+    }));
+
+    const { rerender } = renderHook(() => useDmWavesList());
+
+    expect(useWavesV2Mock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        directMessage: true,
+        viewerIdentityKey: "0xabc:primary",
+        enabled: false,
+      })
+    );
+
+    useWavesV2Mock.mockClear();
+    fetchingProfile = false;
+    rerender();
+
+    expect(useWavesV2Mock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        directMessage: true,
+        viewerIdentityKey: "0xabc:primary",
+        enabled: true,
+      })
+    );
+  });
 });

--- a/__tests__/hooks/useMarkWaveNotificationsRead.test.tsx
+++ b/__tests__/hooks/useMarkWaveNotificationsRead.test.tsx
@@ -505,7 +505,7 @@ describe("useMarkWaveNotificationsRead", () => {
     expect(invalidateNotifications).toHaveBeenCalledTimes(2);
   });
 
-  it("rejects an old cached account callback after switching accounts", async () => {
+  it("skips an old cached account callback after switching accounts", async () => {
     const invalidateNotifications = jest.fn();
 
     setActiveIdentity({ address: "0xAAA", jwt: "jwt-a" });
@@ -522,9 +522,7 @@ describe("useMarkWaveNotificationsRead", () => {
 
     expect(result.current).not.toBe(accountCallback);
 
-    await expect(accountCallback("wave-1")).rejects.toThrow(
-      "wallet address changed or disconnected"
-    );
+    await expect(accountCallback("wave-1")).resolves.toBe("skipped");
 
     expect(apiPostMock).not.toHaveBeenCalled();
     expect(invalidateNotifications).not.toHaveBeenCalled();
@@ -898,7 +896,7 @@ describe("useMarkWaveNotificationsRead", () => {
     expect(invalidateNotifications).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects a cleared queued proxy read on wallet address switch", async () => {
+  it("skips a cleared queued proxy read on wallet address switch", async () => {
     const invalidateNotifications = jest.fn();
 
     setActiveIdentity({
@@ -923,9 +921,7 @@ describe("useMarkWaveNotificationsRead", () => {
     rerender();
 
     const firstAccountPromise = result.current("wave-1");
-    const rejection = expect(firstAccountPromise).rejects.toThrow(
-      "wallet address changed or disconnected"
-    );
+    const skipped = expect(firstAccountPromise).resolves.toBe("skipped");
 
     expect(apiPostMock).not.toHaveBeenCalled();
 
@@ -937,7 +933,7 @@ describe("useMarkWaveNotificationsRead", () => {
     });
     rerender();
 
-    await rejection;
+    await skipped;
 
     expect(apiPostMock).not.toHaveBeenCalled();
 
@@ -1318,7 +1314,7 @@ describe("useMarkWaveNotificationsRead", () => {
     expect(invalidateNotifications).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects a queued read when the wallet disconnects", async () => {
+  it("skips a queued read when the wallet disconnects", async () => {
     const invalidateNotifications = jest.fn();
 
     setActiveIdentity({ address: "0xAAA", jwt: null });
@@ -1330,20 +1326,18 @@ describe("useMarkWaveNotificationsRead", () => {
     );
 
     const queuedPromise = result.current("wave-disconnect");
-    const rejection = expect(queuedPromise).rejects.toThrow(
-      "wallet address changed or disconnected"
-    );
+    const skipped = expect(queuedPromise).resolves.toBe("skipped");
 
     setActiveIdentity({ address: undefined, jwt: null });
     rerender();
 
-    await rejection;
+    await skipped;
 
     expect(apiPostMock).not.toHaveBeenCalled();
     expect(invalidateNotifications).not.toHaveBeenCalled();
   });
 
-  it("rejects a queued read when the wallet address switches", async () => {
+  it("skips a queued read when the wallet address switches", async () => {
     const invalidateNotifications = jest.fn();
 
     setActiveIdentity({ address: "0xAAA", jwt: null });
@@ -1355,20 +1349,18 @@ describe("useMarkWaveNotificationsRead", () => {
     );
 
     const queuedPromise = result.current("wave-address-switch");
-    const rejection = expect(queuedPromise).rejects.toThrow(
-      "wallet address changed or disconnected"
-    );
+    const skipped = expect(queuedPromise).resolves.toBe("skipped");
 
     setActiveIdentity({ address: "0xBBB", jwt: "jwt-b" });
     rerender();
 
-    await rejection;
+    await skipped;
 
     expect(apiPostMock).not.toHaveBeenCalled();
     expect(invalidateNotifications).not.toHaveBeenCalled();
   });
 
-  it("clears queued reads when the last marker hook unmounts", async () => {
+  it("skips queued reads when the last marker hook unmounts", async () => {
     jest.useFakeTimers();
     const invalidateNotifications = jest.fn();
 
@@ -1383,9 +1375,7 @@ describe("useMarkWaveNotificationsRead", () => {
 
       const queuedPromise = result.current("wave-last-unmount");
       const queuedSettlement = trackPromiseSettlement(queuedPromise);
-      const rejection = expect(queuedPromise).rejects.toThrow(
-        "no marker hooks are mounted"
-      );
+      const skipped = expect(queuedPromise).resolves.toBe("skipped");
 
       unmount();
       await flushMicrotasks();
@@ -1396,7 +1386,7 @@ describe("useMarkWaveNotificationsRead", () => {
         jest.runOnlyPendingTimers();
       });
 
-      await rejection;
+      await skipped;
 
       expect(apiPostMock).not.toHaveBeenCalled();
       expect(invalidateNotifications).not.toHaveBeenCalled();
@@ -1483,7 +1473,7 @@ describe("useMarkWaveNotificationsRead", () => {
     }
   });
 
-  it("rejects queued reads when a different wallet remounts before deferred cleanup runs", async () => {
+  it("skips queued reads when a different wallet remounts before deferred cleanup runs", async () => {
     jest.useFakeTimers();
     const invalidateNotifications = jest.fn();
 
@@ -1496,9 +1486,7 @@ describe("useMarkWaveNotificationsRead", () => {
       const queuedPromise = firstHook.result.current(
         "wave-remount-address-switch"
       );
-      const rejection = expect(queuedPromise).rejects.toThrow(
-        "wallet address changed or disconnected"
-      );
+      const skipped = expect(queuedPromise).resolves.toBe("skipped");
 
       firstHook.unmount();
 
@@ -1507,7 +1495,7 @@ describe("useMarkWaveNotificationsRead", () => {
         wrapper: createWrapper(invalidateNotifications),
       });
 
-      await rejection;
+      await skipped;
 
       act(() => {
         jest.runOnlyPendingTimers();
@@ -2020,7 +2008,7 @@ describe("useMarkWaveNotificationsRead", () => {
     expect(invalidateNotifications).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects an old temporary proxy-role callback after wallet address switch", async () => {
+  it("skips an old temporary proxy-role callback after wallet address switch", async () => {
     const invalidateNotifications = jest.fn();
 
     setActiveIdentity({
@@ -2041,9 +2029,7 @@ describe("useMarkWaveNotificationsRead", () => {
 
     expect(result.current).not.toBe(oldRoleCallback);
 
-    await expect(oldRoleCallback("wave-1")).rejects.toThrow(
-      "wallet address changed or disconnected"
-    );
+    await expect(oldRoleCallback("wave-1")).resolves.toBe("skipped");
 
     expect(apiPostMock).not.toHaveBeenCalled();
 
@@ -2222,7 +2208,7 @@ describe("useMarkWaveNotificationsRead", () => {
     expect(invalidateNotifications).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects an old missing-auth account callback after wallet address switch", async () => {
+  it("skips an old missing-auth account callback after wallet address switch", async () => {
     const invalidateNotifications = jest.fn();
 
     setActiveIdentity({ address: "0xAAA", jwt: null });
@@ -2239,9 +2225,7 @@ describe("useMarkWaveNotificationsRead", () => {
 
     expect(result.current).not.toBe(oldAccountCallback);
 
-    await expect(oldAccountCallback("wave-1")).rejects.toThrow(
-      "wallet address changed or disconnected"
-    );
+    await expect(oldAccountCallback("wave-1")).resolves.toBe("skipped");
 
     expect(apiPostMock).not.toHaveBeenCalled();
 
@@ -2264,16 +2248,14 @@ describe("useMarkWaveNotificationsRead", () => {
     );
 
     const firstAccountPromise = result.current("wave-1");
-    const rejection = expect(firstAccountPromise).rejects.toThrow(
-      "wallet address changed or disconnected"
-    );
+    const skipped = expect(firstAccountPromise).resolves.toBe("skipped");
 
     expect(apiPostMock).not.toHaveBeenCalled();
 
     setActiveIdentity({ address: "0xBBB", jwt: "jwt-b" });
     rerender();
 
-    await rejection;
+    await skipped;
 
     expect(apiPostMock).not.toHaveBeenCalled();
 
@@ -2481,7 +2463,7 @@ describe("useMarkWaveNotificationsRead", () => {
     expect(invalidateNotifications).not.toHaveBeenCalled();
   });
 
-  it("rejects a queued missing-JWT read that becomes stale before JWT verification", async () => {
+  it("skips a queued missing-JWT read that becomes stale before JWT verification", async () => {
     const invalidateNotifications = jest.fn();
     const addressKey = "0xaaa";
     const waveId = "wave-stale-missing-jwt";
@@ -2509,9 +2491,7 @@ describe("useMarkWaveNotificationsRead", () => {
         shouldSend: undefined,
         queueIfBlocked: true,
       });
-      const rejection = expect(queuedPromise).rejects.toThrow(
-        "wallet address changed or disconnected"
-      );
+      const skipped = expect(queuedPromise).resolves.toBe("skipped");
 
       latestAddressEpochRef.current = {};
       flushPendingWaveReadRequests({
@@ -2519,7 +2499,7 @@ describe("useMarkWaveNotificationsRead", () => {
         invalidateNotificationsRef: { current: invalidateNotifications },
       });
 
-      await rejection;
+      await skipped;
       expect(apiPostMock).not.toHaveBeenCalled();
       expect(invalidateNotifications).not.toHaveBeenCalled();
     } finally {
@@ -2581,9 +2561,7 @@ describe("useMarkWaveNotificationsRead", () => {
         shouldSend: undefined,
         queueIfBlocked: true,
       });
-      const staleRejection = expect(stalePromise).rejects.toThrow(
-        "wallet address changed or disconnected"
-      );
+      const staleSkipped = expect(stalePromise).resolves.toBe("skipped");
 
       staleEpochState.latestAddressEpochRef.current = {};
       flushPendingWaveReadRequests({
@@ -2591,7 +2569,7 @@ describe("useMarkWaveNotificationsRead", () => {
         invalidateNotificationsRef: { current: invalidateNotifications },
       });
 
-      await staleRejection;
+      await staleSkipped;
       await expect(freshPromise).resolves.toBe("sent");
       expect(apiPostMock).toHaveBeenCalledTimes(1);
       expect(apiPostMock).toHaveBeenCalledWith({
@@ -2604,7 +2582,7 @@ describe("useMarkWaveNotificationsRead", () => {
     }
   });
 
-  it("rejects a stale queued read on the cleared-auth flush path", async () => {
+  it("skips a stale queued read on the cleared-auth flush path", async () => {
     const invalidateNotifications = jest.fn();
     const addressKey = "0xaaa";
     const waveId = "wave-stale-cleared-auth";
@@ -2630,9 +2608,7 @@ describe("useMarkWaveNotificationsRead", () => {
         shouldSend: undefined,
         queueIfBlocked: true,
       });
-      const rejection = expect(queuedPromise).rejects.toThrow(
-        "wallet address changed or disconnected"
-      );
+      const skipped = expect(queuedPromise).resolves.toBe("skipped");
 
       latestAddressEpochRef.current = {};
       flushPendingClearedWaveReadRequests({
@@ -2640,7 +2616,7 @@ describe("useMarkWaveNotificationsRead", () => {
         invalidateNotificationsRef: { current: invalidateNotifications },
       });
 
-      await rejection;
+      await skipped;
       expect(apiPostMock).not.toHaveBeenCalled();
       expect(invalidateNotifications).not.toHaveBeenCalled();
     } finally {

--- a/__tests__/hooks/usePinnedWavesServer.test.tsx
+++ b/__tests__/hooks/usePinnedWavesServer.test.tsx
@@ -127,7 +127,10 @@ beforeEach(() => {
     error: null,
     refetch: jest.fn(),
   });
-  useSeizeConnectContextMock.mockReturnValue({ address: "0xabc" });
+  useSeizeConnectContextMock.mockReturnValue({
+    address: "0xabc",
+    hasValidWalletAuth: true,
+  });
   useSeizeSettingsOptionalMock.mockReturnValue({
     isAnnouncementsWave: (waveId: string | null | undefined) =>
       waveId === "announcement-wave",
@@ -159,6 +162,29 @@ test("keeps the pinned cache key at the logical limit but requests API pages of 
     pageSize: 20,
     overviewType: ApiWavesOverviewType.RecentlyDroppedTo,
     pinned: ApiWavesPinFilter.Pinned,
+  });
+});
+
+test("disables pinned and official wave reads while wallet auth is invalid", () => {
+  useSeizeConnectContextMock.mockReturnValue({
+    address: "0xabc",
+    hasValidWalletAuth: false,
+  });
+
+  renderHook(() => usePinnedWavesServer(), { wrapper });
+
+  expect(useQueryMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      enabled: false,
+      queryKey: expect.arrayContaining([
+        expect.anything(),
+        expect.not.objectContaining({ viewer_identity: expect.any(String) }),
+      ]),
+    })
+  );
+  expect(useOfficialWavesMock).toHaveBeenCalledWith({
+    viewerIdentityKey: null,
+    enabled: false,
   });
 });
 

--- a/__tests__/hooks/useWaves.test.ts
+++ b/__tests__/hooks/useWaves.test.ts
@@ -1,9 +1,10 @@
-import { renderHook } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { useWaves } from "@/hooks/useWaves";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthContext } from "@/components/auth/Auth";
 import React from "react";
 import { commonApiFetch } from "@/services/api/common-api";
+import { ProfileConnectedStatus } from "@/entities/IProfile";
 
 // Mock dependencies
 jest.mock("react-use", () => ({
@@ -11,7 +12,7 @@ jest.mock("react-use", () => ({
 }));
 
 jest.mock("@/services/api/common-api", () => ({
-  commonApiFetch: jest.fn().mockResolvedValue({ waves: [], count: 0 }),
+  commonApiFetch: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock("@/components/auth/SeizeConnectContext", () => ({
@@ -41,7 +42,7 @@ const createWrapper = () => {
     setToast: jest.fn(),
     setActiveProfileProxy: jest.fn(),
     fetchingProfile: false,
-    connectionStatus: "DISCONNECTED" as any,
+    connectionStatus: ProfileConnectedStatus.NOT_CONNECTED,
     receivedProfileProxies: [],
     showWaves: false,
     title: "",
@@ -101,6 +102,46 @@ describe("useWaves", () => {
     );
 
     await Promise.resolve();
+
+    expect(commonApiFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("masks cached waves and live methods while connected wallet auth is invalid", async () => {
+    commonApiFetchMock.mockResolvedValueOnce([{ id: "cached", serial_no: 10 }]);
+    useSeizeConnectContextMock.mockReturnValue({
+      address: undefined,
+      hasValidWalletAuth: true,
+    });
+
+    const { result, rerender } = renderHook(
+      () =>
+        useWaves({
+          identity: null,
+          waveName: null,
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => {
+      expect(result.current.waves).toEqual([
+        expect.objectContaining({ id: "cached" }),
+      ]);
+    });
+
+    commonApiFetchMock.mockClear();
+    useSeizeConnectContextMock.mockReturnValue({
+      address: "0xABC",
+      hasValidWalletAuth: false,
+    });
+    rerender();
+
+    expect(result.current.waves).toEqual([]);
+    expect(result.current.hasNextPage).toBe(false);
+    expect(result.current.lastPageSize).toBe(0);
+    expect(result.current.status).toBe("pending");
+
+    await result.current.fetchNextPage();
+    await result.current.refetch();
 
     expect(commonApiFetchMock).not.toHaveBeenCalled();
   });

--- a/__tests__/hooks/useWaves.test.ts
+++ b/__tests__/hooks/useWaves.test.ts
@@ -1,17 +1,27 @@
-import { renderHook } from '@testing-library/react';
-import { useWaves } from '@/hooks/useWaves';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { AuthContext } from '@/components/auth/Auth';
-import React from 'react';
+import { renderHook } from "@testing-library/react";
+import { useWaves } from "@/hooks/useWaves";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AuthContext } from "@/components/auth/Auth";
+import React from "react";
+import { commonApiFetch } from "@/services/api/common-api";
 
 // Mock dependencies
-jest.mock('react-use', () => ({
+jest.mock("react-use", () => ({
   useDebounce: jest.fn(),
 }));
 
-jest.mock('@/services/api/common-api', () => ({
+jest.mock("@/services/api/common-api", () => ({
   commonApiFetch: jest.fn().mockResolvedValue({ waves: [], count: 0 }),
 }));
+
+jest.mock("@/components/auth/SeizeConnectContext", () => ({
+  useSeizeConnectContext: jest.fn(),
+}));
+
+const useSeizeConnectContextMock =
+  require("@/components/auth/SeizeConnectContext")
+    .useSeizeConnectContext as jest.Mock;
+const commonApiFetchMock = commonApiFetch as jest.Mock;
 
 const createWrapper = () => {
   const queryClient = new QueryClient({
@@ -22,7 +32,7 @@ const createWrapper = () => {
       },
     },
   });
-  
+
   const defaultAuthContext = {
     connectedProfile: null,
     activeProfileProxy: null,
@@ -31,12 +41,12 @@ const createWrapper = () => {
     setToast: jest.fn(),
     setActiveProfileProxy: jest.fn(),
     fetchingProfile: false,
-    connectionStatus: 'DISCONNECTED' as any,
+    connectionStatus: "DISCONNECTED" as any,
     receivedProfileProxies: [],
     showWaves: false,
-    title: '',
+    title: "",
   };
-  
+
   return ({ children }: { children: React.ReactNode }) =>
     React.createElement(
       QueryClientProvider,
@@ -49,20 +59,49 @@ const createWrapper = () => {
     );
 };
 
-describe('useWaves', () => {
-  it('should return expected hook properties', () => {
+describe("useWaves", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useSeizeConnectContextMock.mockReturnValue({
+      address: undefined,
+      hasValidWalletAuth: false,
+    });
+  });
+
+  it("should return expected hook properties", () => {
     const { result } = renderHook(
-      () => useWaves({
-        identity: null,
-        waveName: null,
-      }),
+      () =>
+        useWaves({
+          identity: null,
+          waveName: null,
+        }),
       { wrapper: createWrapper() }
     );
 
-    expect(result.current).toHaveProperty('waves');
-    expect(result.current).toHaveProperty('hasNextPage');
-    expect(result.current).toHaveProperty('fetchNextPage');
-    expect(result.current).toHaveProperty('isFetching');
-    expect(result.current).toHaveProperty('isFetchingNextPage');
+    expect(result.current).toHaveProperty("waves");
+    expect(result.current).toHaveProperty("hasNextPage");
+    expect(result.current).toHaveProperty("fetchNextPage");
+    expect(result.current).toHaveProperty("isFetching");
+    expect(result.current).toHaveProperty("isFetchingNextPage");
+  });
+
+  it("does not fetch public or private waves while a connected wallet lacks valid auth", async () => {
+    useSeizeConnectContextMock.mockReturnValue({
+      address: "0xABC",
+      hasValidWalletAuth: false,
+    });
+
+    renderHook(
+      () =>
+        useWaves({
+          identity: null,
+          waveName: null,
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    await Promise.resolve();
+
+    expect(commonApiFetchMock).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/hooks/useWavesList.test.tsx
+++ b/__tests__/hooks/useWavesList.test.tsx
@@ -97,6 +97,16 @@ const wrapperWithoutConnectedIdentity: React.FC<{
   </QueryClientProvider>
 );
 
+const createWrapperWithAuth =
+  (getAuthContext: () => unknown): React.FC<{ children: React.ReactNode }> =>
+  ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      <AuthContext.Provider value={getAuthContext() as any}>
+        {children}
+      </AuthContext.Provider>
+    </QueryClientProvider>
+  );
+
 const createSidebarWave = ({
   id,
   latestDropTimestamp,
@@ -255,6 +265,41 @@ test("pauses viewer-scoped wave sources while wallet auth is invalid", () => {
   ).toBe(true);
   expect(
     useWavesV2Mock.mock.calls.every(([args]) => args.viewerIdentityKey === null)
+  ).toBe(true);
+});
+
+test("re-enables viewer-scoped wave sources after profile loading settles", () => {
+  useSeizeConnectContextMock.mockReturnValue({
+    address: "0xABC",
+    hasValidWalletAuth: true,
+  });
+  let fetchingProfile = true;
+  const authWrapper = createWrapperWithAuth(() => ({
+    connectedProfile: { handle: "me" },
+    activeProfileProxy: null,
+    fetchingProfile,
+    isAuthenticated: true,
+  }));
+
+  const { rerender } = renderHook(() => useWavesList(), {
+    wrapper: authWrapper,
+  });
+
+  expect(
+    useWavesV2Mock.mock.calls.every(([args]) => args.enabled === false)
+  ).toBe(true);
+
+  useWavesV2Mock.mockClear();
+  fetchingProfile = false;
+  rerender();
+
+  expect(
+    useWavesV2Mock.mock.calls.some(([args]) => args.enabled === true)
+  ).toBe(true);
+  expect(
+    useWavesV2Mock.mock.calls.some(
+      ([args]) => args.viewerIdentityKey === "0xabc:primary"
+    )
   ).toBe(true);
 });
 

--- a/__tests__/hooks/useWavesList.test.tsx
+++ b/__tests__/hooks/useWavesList.test.tsx
@@ -246,12 +246,36 @@ beforeEach(() => {
 });
 
 test("pauses viewer-scoped wave sources while wallet auth is invalid", () => {
+  const fetchNextPage = jest.fn();
+  const refetch = jest.fn();
+  const pinnedRefetch = jest.fn();
+  const pinWave = jest.fn();
+  const unpinWave = jest.fn();
+  const prefetchSpy = jest.spyOn(queryClient, "prefetchQuery");
   useSeizeConnectContextMock.mockReturnValue({
     address: "0xABC",
     hasValidWalletAuth: false,
   });
+  useWavesV2Mock.mockReturnValue({
+    waves: [mainWave],
+    isFetching: true,
+    isFetchingNextPage: true,
+    hasNextPage: true,
+    fetchNextPage,
+    status: "success",
+    refetch,
+  });
+  usePinnedWavesServerMock.mockReturnValue({
+    pinnedIds: ["2", "3"],
+    pinnedWaves: [pinnedExtra],
+    pinWave,
+    unpinWave,
+    isLoading: false,
+    isError: false,
+    refetch: pinnedRefetch,
+  });
 
-  renderHook(() => useWavesList(), { wrapper });
+  const { result } = renderHook(() => useWavesList(), { wrapper });
 
   expect(useWavesV2Mock).toHaveBeenCalledWith(
     expect.objectContaining({
@@ -266,6 +290,29 @@ test("pauses viewer-scoped wave sources while wallet auth is invalid", () => {
   expect(
     useWavesV2Mock.mock.calls.every(([args]) => args.viewerIdentityKey === null)
   ).toBe(true);
+  expect(result.current.waves).toEqual([]);
+  expect(result.current.mainWaves).toEqual([]);
+  expect(result.current.pinnedWaves).toEqual([]);
+  expect(result.current.isFetching).toBe(false);
+  expect(result.current.isFetchingNextPage).toBe(false);
+  expect(result.current.hasNextPage).toBe(false);
+
+  act(() => {
+    result.current.fetchNextPage();
+    result.current.mainWavesRefetch();
+    result.current.refetchAllWaves();
+    result.current.addPinnedWave("2");
+    result.current.removePinnedWave("2");
+    result.current.loadSubwavesForParent("2");
+    result.current.prefetchSubwavesForParent("2");
+  });
+
+  expect(fetchNextPage).not.toHaveBeenCalled();
+  expect(refetch).not.toHaveBeenCalled();
+  expect(pinnedRefetch).not.toHaveBeenCalled();
+  expect(pinWave).not.toHaveBeenCalled();
+  expect(unpinWave).not.toHaveBeenCalled();
+  expect(prefetchSpy).not.toHaveBeenCalled();
 });
 
 test("re-enables viewer-scoped wave sources after profile loading settles", () => {

--- a/__tests__/hooks/useWavesList.test.tsx
+++ b/__tests__/hooks/useWavesList.test.tsx
@@ -235,6 +235,29 @@ beforeEach(() => {
   });
 });
 
+test("pauses viewer-scoped wave sources while wallet auth is invalid", () => {
+  useSeizeConnectContextMock.mockReturnValue({
+    address: "0xABC",
+    hasValidWalletAuth: false,
+  });
+
+  renderHook(() => useWavesList(), { wrapper });
+
+  expect(useWavesV2Mock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      enabled: false,
+      viewerIdentityKey: null,
+      following: false,
+    })
+  );
+  expect(
+    useWavesV2Mock.mock.calls.every(([args]) => args.enabled === false)
+  ).toBe(true);
+  expect(
+    useWavesV2Mock.mock.calls.every(([args]) => args.viewerIdentityKey === null)
+  ).toBe(true);
+});
+
 test("combines main and pinned waves, filtering DMs and flagging pinned", () => {
   const { result } = renderHook(() => useWavesList(), { wrapper });
   const waves = result.current.waves;

--- a/__tests__/services/auth.utils.test.ts
+++ b/__tests__/services/auth.utils.test.ts
@@ -1,5 +1,6 @@
 import { safeLocalStorage } from "@/helpers/safeLocalStorage";
 import {
+  AUTH_TOKEN_CHANGED_EVENT,
   canStoreAnotherWalletAccount,
   clearAllWalletAuth,
   getConnectedWalletAccounts,
@@ -9,6 +10,7 @@ import {
   getWalletAddress,
   hasActiveSessionV2Auth,
   isAuthAddressAuthorized,
+  PROFILE_SWITCHED_EVENT,
   removeAuthJwt,
   setActiveWalletAccount,
   setAuthJwt,
@@ -107,6 +109,19 @@ describe("auth.utils", () => {
       "auth-role-addr",
       "role"
     );
+  });
+
+  it("emits an auth token changed event when the wallet auth cookie changes", () => {
+    setupStorageMocks();
+    const listener = jest.fn();
+    globalThis.addEventListener(AUTH_TOKEN_CHANGED_EVENT, listener);
+    (jwtDecode as jest.Mock).mockReturnValue({ exp: 86400 * 2 });
+    jest.spyOn(Date, "now").mockReturnValue(0);
+
+    setAuthJwt("addr", "jwt", "refresh", "role");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    globalThis.removeEventListener(AUTH_TOKEN_CHANGED_EVENT, listener);
   });
 
   it("setAuthJwt clears role storage when role is missing", () => {
@@ -357,6 +372,23 @@ describe("auth.utils", () => {
     const remainingAccounts = getConnectedWalletAccounts();
     expect(remainingAccounts).toHaveLength(1);
     expect(remainingAccounts[0]?.address).toBe("0x111");
+  });
+
+  it("emits a profile switched event when removing auth promotes another account", async () => {
+    setupStorageMocks();
+    const listener = jest.fn();
+    globalThis.addEventListener(PROFILE_SWITCHED_EVENT, listener);
+    (jwtDecode as jest.Mock).mockReturnValue({ exp: 86400 * 2 });
+    jest.spyOn(Date, "now").mockReturnValue(0);
+
+    setAuthJwt("0x111", "jwt-1", "refresh-1", "role-1");
+    setAuthJwt("0x222", "jwt-2", "refresh-2", "role-2");
+    listener.mockClear();
+
+    await removeAuthJwt();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    globalThis.removeEventListener(PROFILE_SWITCHED_EVENT, listener);
   });
 
   it("clearAllWalletAuth clears all accounts and cookie", async () => {

--- a/__tests__/services/auth.utils.test.ts
+++ b/__tests__/services/auth.utils.test.ts
@@ -124,6 +124,20 @@ describe("auth.utils", () => {
     globalThis.removeEventListener(AUTH_TOKEN_CHANGED_EVENT, listener);
   });
 
+  it("does not emit an auth token changed event when the wallet auth cookie value is unchanged", () => {
+    setupStorageMocks();
+    const listener = jest.fn();
+    globalThis.addEventListener(AUTH_TOKEN_CHANGED_EVENT, listener);
+    (Cookies.get as jest.Mock).mockReturnValue("jwt");
+    (jwtDecode as jest.Mock).mockReturnValue({ exp: 86400 * 2 });
+    jest.spyOn(Date, "now").mockReturnValue(0);
+
+    setAuthJwt("addr", "jwt", "refresh", "role");
+
+    expect(listener).not.toHaveBeenCalled();
+    globalThis.removeEventListener(AUTH_TOKEN_CHANGED_EVENT, listener);
+  });
+
   it("setAuthJwt clears role storage when role is missing", () => {
     (jwtDecode as jest.Mock).mockReturnValue({ exp: 86400 * 2 });
     jest.spyOn(Date, "now").mockReturnValue(0);

--- a/__tests__/services/websocket/useWebSocketHealth.test.ts
+++ b/__tests__/services/websocket/useWebSocketHealth.test.ts
@@ -2,10 +2,15 @@ import { act, renderHook } from "@testing-library/react";
 import { useWebSocketHealth } from "@/services/websocket/useWebSocketHealth";
 import { WebSocketStatus } from "@/services/websocket/WebSocketTypes";
 import { useWebSocket } from "@/services/websocket/useWebSocket";
-import { getAuthJwt, WALLET_AUTH_COOKIE } from "@/services/auth/auth.utils";
+import {
+  AUTH_TOKEN_CHANGED_EVENT,
+  getAuthJwt,
+  WALLET_AUTH_COOKIE,
+} from "@/services/auth/auth.utils";
 
 jest.mock("@/services/websocket/useWebSocket");
 jest.mock("@/services/auth/auth.utils", () => ({
+  AUTH_TOKEN_CHANGED_EVENT: "6529-auth-token-changed",
   getAuthJwt: jest.fn(),
   WALLET_AUTH_COOKIE: "wallet-auth",
 }));
@@ -342,6 +347,26 @@ describe("useWebSocketHealth", () => {
     );
     expect(channel.close).toHaveBeenCalledTimes(1);
   });
+  it("responds to same-tab auth token change events", () => {
+    mockGetAuthJwt.mockReturnValue("token-a");
+    mockUseWebSocket.mockReturnValue({
+      connect: mockConnect,
+      disconnect: mockDisconnect,
+      status: WebSocketStatus.CONNECTED,
+    });
+
+    renderHook(() => useWebSocketHealth());
+
+    mockConnect.mockClear();
+    mockGetAuthJwt.mockReturnValue("token-b");
+
+    act(() => {
+      window.dispatchEvent(new Event(AUTH_TOKEN_CHANGED_EVENT));
+    });
+
+    expect(mockConnect).toHaveBeenCalledWith("token-b");
+  });
+
   it("broadcasts token changes to other listeners when detected", () => {
     (window as any).BroadcastChannel =
       MockBroadcastChannel as unknown as typeof BroadcastChannel;

--- a/components/auth/Auth.tsx
+++ b/components/auth/Auth.tsx
@@ -215,7 +215,7 @@ const isProfileForAddress = ({
   );
 
   if (walletAddresses.length === 0) {
-    return true;
+    return false;
   }
 
   return walletAddresses.some(

--- a/components/auth/Auth.tsx
+++ b/components/auth/Auth.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import {
@@ -28,6 +28,7 @@ import {
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import type { ApiProfileProxy } from "@/generated/models/ApiProfileProxy";
 import type { ApiSessionNonceResponse } from "@/generated/models/ApiSessionNonceResponse";
+import type { ApiWave } from "@/generated/models/ApiWave";
 import { safeLocalStorage } from "@/helpers/safeLocalStorage";
 import { getActiveWaveIdFromUrl } from "@/helpers/navigation.helpers";
 import { groupProfileProxies } from "@/helpers/profile-proxy.helpers";
@@ -103,6 +104,7 @@ class NonceResponseValidationError extends Error {
 
 type AuthContextType = {
   readonly connectedProfile: ApiIdentity | null;
+  readonly isAuthenticated?: boolean;
   readonly fetchingProfile: boolean;
   readonly connectionStatus: ProfileConnectedStatus;
   readonly receivedProfileProxies: ApiProfileProxy[];
@@ -188,6 +190,41 @@ const normalizeSessionV2MigrationDeadline = (
 
 const normalizeReminderAddress = (address: string): string =>
   address.toLowerCase();
+
+const normalizeWalletAddress = (walletAddress: string): string =>
+  walletAddress.trim().toLowerCase();
+
+const isProfileForAddress = ({
+  profile,
+  address,
+}: {
+  readonly profile: ApiIdentity | null;
+  readonly address: string | null | undefined;
+}): boolean => {
+  if (!profile || !address) {
+    return false;
+  }
+
+  const normalizedAddress = normalizeWalletAddress(address);
+  const walletAddresses = [
+    profile.primary_wallet,
+    ...(profile.wallets?.map((wallet) => wallet.wallet) ?? []),
+  ].filter(
+    (walletAddress): walletAddress is string =>
+      typeof walletAddress === "string" && walletAddress.trim().length > 0
+  );
+
+  if (walletAddresses.length === 0) {
+    return true;
+  }
+
+  return walletAddresses.some(
+    (walletAddress) =>
+      normalizeWalletAddress(walletAddress) === normalizedAddress
+  );
+};
+
+const isPublicWave = (wave: ApiWave): boolean => !wave.visibility?.scope?.group;
 
 const parseSessionUpgradeReminders = (): Record<
   string,
@@ -495,6 +532,7 @@ const runImmediateAuthValidation = async ({
 
 export const AuthContext = createContext<AuthContextType>({
   connectedProfile: null,
+  isAuthenticated: false,
   fetchingProfile: false,
   receivedProfileProxies: [],
   activeProfileProxy: null,
@@ -518,7 +556,10 @@ export default function Auth({
   readonly children: React.ReactNode;
   readonly enableWalletAuthentication?: boolean;
 }) {
-  const { invalidateAll } = useContext(ReactQueryWrapperContext);
+  const { invalidateAll, invalidateAuthSensitiveQueries } = useContext(
+    ReactQueryWrapperContext
+  );
+  const queryClient = useQueryClient();
   const pathname = usePathname();
   const router = useRouter();
   const seizeSettingsContext = useSeizeSettingsOptional();
@@ -554,18 +595,29 @@ export default function Auth({
   const [sessionUpgradeRequired, setSessionUpgradeRequired] = useState(false);
   const signModalReasonRef = useRef<SignModalReason>(signModalReason);
 
-  const { profile: connectedProfile, isLoading: fetchingProfile } = useIdentity(
-    {
-      handleOrWallet: address,
-      initialProfile: null,
-    }
+  const { profile: loadedProfile, isLoading: fetchingProfile } = useIdentity({
+    handleOrWallet: address,
+    initialProfile: null,
+  });
+  const isConnectedProfileForAddress = isProfileForAddress({
+    profile: loadedProfile,
+    address,
+  });
+  const connectedProfile = isConnectedProfileForAddress ? loadedProfile : null;
+  const isConnectedProfileSettling = Boolean(
+    address && loadedProfile && !isConnectedProfileForAddress
   );
+  const isFetchingConnectedProfile =
+    fetchingProfile || isConnectedProfileSettling;
 
   // Race condition prevention: AbortController and operation tracking
   const abortControllerRef = useRef<AbortController | null>(null);
   const latestAddressRef = useRef<string | undefined>(address);
   const activeValidationOperationIdRef = useRef<string | null>(null);
   const expiredSessionUpgradeAddressRef = useRef<string | null>(null);
+  const [pendingProfileSwitch, setPendingProfileSwitch] = useState<{
+    readonly targetAddress: string | null;
+  } | null>(null);
   const [authLoadingState, setAuthLoadingState] =
     useState<AuthLoadingState>("idle");
   const settingsAuth = seizeSettingsContext?.seizeSettings.auth;
@@ -1403,6 +1455,14 @@ export default function Auth({
       return;
     }
 
+    const cachedWave = queryClient.getQueryData<ApiWave>([
+      QueryKey.WAVE,
+      { wave_id: activeWaveId },
+    ]);
+    if (cachedWave && isPublicWave(cachedWave)) {
+      return;
+    }
+
     const isMessagesRoute =
       pathname === "/messages" || pathname.startsWith("/messages/");
     if (isMessagesRoute) {
@@ -1415,12 +1475,13 @@ export default function Auth({
     if (isWavesRoute || pathname === "/") {
       router.replace("/waves");
     }
-  }, [pathname, router]);
+  }, [pathname, queryClient, router]);
 
   useEffect(() => {
     const onProfileSwitched = () => {
-      invalidateAll();
-      navigateAfterProfileSwitch();
+      setPendingProfileSwitch({
+        targetAddress: getWalletAddress()?.toLowerCase() ?? null,
+      });
     };
 
     if (globalThis.window === undefined) {
@@ -1437,11 +1498,53 @@ export default function Auth({
         onProfileSwitched
       );
     };
-  }, [invalidateAll, navigateAfterProfileSwitch]);
+  }, []);
+
+  useEffect(() => {
+    if (!pendingProfileSwitch) {
+      return;
+    }
+
+    const targetAddress = pendingProfileSwitch.targetAddress;
+    const currentAddress = address?.toLowerCase() ?? null;
+    if (targetAddress && targetAddress !== currentAddress) {
+      return;
+    }
+
+    if (isFetchingConnectedProfile) {
+      return;
+    }
+
+    const timeoutId = globalThis.setTimeout(() => {
+      invalidateAuthSensitiveQueries();
+      navigateAfterProfileSwitch();
+      setPendingProfileSwitch(null);
+    }, 0);
+
+    return () => {
+      globalThis.clearTimeout(timeoutId);
+    };
+  }, [
+    address,
+    invalidateAuthSensitiveQueries,
+    isFetchingConnectedProfile,
+    navigateAfterProfileSwitch,
+    pendingProfileSwitch,
+  ]);
 
   const showWaves = useMemo(() => {
-    return !!connectedProfile?.handle && !activeProfileProxy && !!address;
-  }, [connectedProfile?.handle, activeProfileProxy, address]);
+    return (
+      !!connectedProfile?.handle &&
+      !activeProfileProxy &&
+      !!address &&
+      isAddressAuthorized
+    );
+  }, [
+    connectedProfile?.handle,
+    activeProfileProxy,
+    address,
+    isAddressAuthorized,
+  ]);
 
   const onCancelSignRequest = useCallback(() => {
     if (signModalReason === "session-upgrade") {
@@ -1570,7 +1673,10 @@ export default function Auth({
         requestAuth,
         setToast,
         connectedProfile: connectedProfile ?? null,
-        fetchingProfile,
+        isAuthenticated: Boolean(
+          connectedProfile?.handle && isAddressAuthorized
+        ),
+        fetchingProfile: isFetchingConnectedProfile,
         receivedProfileProxies,
         activeProfileProxy,
         showWaves,

--- a/components/auth/Auth.tsx
+++ b/components/auth/Auth.tsx
@@ -1516,8 +1516,8 @@ export default function Auth({
     }
 
     const timeoutId = globalThis.setTimeout(() => {
-      invalidateAuthSensitiveQueries();
       navigateAfterProfileSwitch();
+      invalidateAuthSensitiveQueries();
       setPendingProfileSwitch(null);
     }, 0);
 

--- a/components/brain/notifications/hooks/useNotificationsController.ts
+++ b/components/brain/notifications/hooks/useNotificationsController.ts
@@ -67,6 +67,7 @@ export const useNotificationsController =
   (): UseNotificationsControllerResult => {
     const {
       connectedProfile,
+      isAuthenticated: isAuthContextAuthenticated,
       activeProfileProxy,
       fetchingProfile,
       requestAuth,
@@ -93,7 +94,9 @@ export const useNotificationsController =
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
     const reload = searchParams?.get("reload") ?? undefined;
-    const isAuthenticated = !!connectedProfile?.handle && !activeProfileProxy;
+    const isAuthenticated =
+      (isAuthContextAuthenticated ?? !!connectedProfile?.handle) &&
+      !activeProfileProxy;
     const isLoadingProfile = fetchingProfile && !connectedProfile;
     const hasConnectedProfile = !!connectedProfile;
     const hasProfileHandle = !!connectedProfile?.handle;

--- a/components/react-query-wrapper/ReactQueryWrapper.tsx
+++ b/components/react-query-wrapper/ReactQueryWrapper.tsx
@@ -223,6 +223,7 @@ type ReactQueryWrapperContextType = {
     following: boolean;
   }) => void;
   invalidateAll: () => void;
+  invalidateAuthSensitiveQueries: () => void;
   invalidateNotifications: () => void;
   invalidateIdentityTdhStats: (params: { identity: string }) => void;
 };
@@ -253,9 +254,33 @@ export const ReactQueryWrapperContext =
     onWaveCreated: () => {},
     onWaveFollowChange: () => {},
     invalidateAll: () => {},
+    invalidateAuthSensitiveQueries: () => {},
     invalidateNotifications: () => {},
     invalidateIdentityTdhStats: () => {},
   });
+
+const AUTH_SENSITIVE_QUERY_KEYS = [
+  QueryKey.PROFILE,
+  QueryKey.PROFILE_PROFILE_PROXIES,
+  QueryKey.PROFILE_PROXY,
+  QueryKey.IDENTITY_AVAILABLE_CREDIT,
+  QueryKey.IDENTITY_NOTIFICATIONS,
+  QueryKey.CONNECTED_ACCOUNT_UNREAD_NOTIFICATIONS,
+  QueryKey.WAVES_OVERVIEW,
+  QueryKey.WAVES_V2,
+  QueryKey.WAVE_SUBWAVES,
+  QueryKey.OFFICIAL_WAVES,
+  QueryKey.WAVES,
+  QueryKey.WAVE,
+  QueryKey.DROPS,
+  QueryKey.DROPS_LEADERBOARD,
+  QueryKey.DROP,
+  QueryKey.FEED_ITEMS,
+] as const;
+
+const AUTH_SENSITIVE_QUERY_KEY_SET = new Set<QueryKey>(
+  AUTH_SENSITIVE_QUERY_KEYS
+);
 
 const getHandlesFromProfile = (profile: ApiIdentity): string[] => {
   const handles: string[] = [];
@@ -1065,6 +1090,18 @@ const createReactQueryContextValue = (
     queryClient.invalidateQueries();
   };
 
+  const invalidateAuthSensitiveQueries = () => {
+    queryClient.invalidateQueries({
+      predicate: (query) => {
+        const [queryKey] = query.queryKey;
+        return (
+          typeof queryKey === "string" &&
+          AUTH_SENSITIVE_QUERY_KEY_SET.has(queryKey as QueryKey)
+        );
+      },
+    });
+  };
+
   const invalidateNotifications = () => {
     queryClient
       .invalidateQueries({
@@ -1107,6 +1144,7 @@ const createReactQueryContextValue = (
     onWaveCreated,
     onWaveFollowChange,
     invalidateAll,
+    invalidateAuthSensitiveQueries,
     onIdentityFollowChange,
     invalidateDrops,
     invalidateNotifications,

--- a/components/waves/layout/WavesLayout.tsx
+++ b/components/waves/layout/WavesLayout.tsx
@@ -72,12 +72,17 @@ function WavesLayoutContent({ children }: { readonly children: ReactNode }) {
   const containerClassName =
     "tw-relative tw-flex tw-flex-col tw-flex-1 tailwind-scope";
   const connectPrompt = getConnectPrompt(contentState);
+  const shouldRenderWavesContent =
+    contentState === "ready" ||
+    contentState === "not-authenticated" ||
+    contentState === "loading" ||
+    contentState === "measuring";
 
   let content: ReactNode = null;
 
-  if (contentState === "ready" || contentState === "not-authenticated") {
+  if (shouldRenderWavesContent) {
     content = getWavesContent({
-      children,
+      children: contentState === "loading" ? null : children,
       containerClassName,
       isApp,
     });

--- a/hooks/useAuthenticatedContent.tsx
+++ b/hooks/useAuthenticatedContent.tsx
@@ -27,6 +27,10 @@ export function useAuthenticatedContent() {
       return "not-authenticated";
     }
 
+    if (!hasValidWalletAuthorization && !fetchingProfile) {
+      return "not-authenticated";
+    }
+
     if (fetchingProfile) {
       return "loading";
     }

--- a/hooks/useAuthenticatedContent.tsx
+++ b/hooks/useAuthenticatedContent.tsx
@@ -20,7 +20,8 @@ export function useAuthenticatedContent() {
   const { address, hasValidWalletAuth } = useSeizeConnectContext();
   const hasValidWalletAuthorization = hasValidWalletAuth !== false;
   const hasAuthenticatedProfile =
-    isAuthenticated ?? (!!connectedProfile?.handle && showWaves);
+    hasValidWalletAuthorization &&
+    (isAuthenticated ?? (!!connectedProfile?.handle && showWaves));
 
   const contentState = useMemo<ContentState>(() => {
     if (!address) {

--- a/hooks/useAuthenticatedContent.tsx
+++ b/hooks/useAuthenticatedContent.tsx
@@ -14,40 +14,44 @@ type ContentState =
   | "ready";
 
 export function useAuthenticatedContent() {
-  const { showWaves, connectedProfile, fetchingProfile } =
+  const { showWaves, connectedProfile, fetchingProfile, isAuthenticated } =
     useContext(AuthContext);
   const { spaces } = useLayout();
-  const { hasValidWalletAuth } = useSeizeConnectContext();
+  const { address, hasValidWalletAuth } = useSeizeConnectContext();
+  const hasValidWalletAuthorization = hasValidWalletAuth !== false;
+  const hasAuthenticatedProfile =
+    isAuthenticated ?? (!!connectedProfile?.handle && showWaves);
 
   const contentState = useMemo<ContentState>(() => {
-    if (!hasValidWalletAuth) {
+    if (!address) {
       return "not-authenticated";
     }
 
-    // Only check fetching if we're authenticated
     if (fetchingProfile) {
       return "loading";
     }
 
-    // Authenticated but no profile
     if (!connectedProfile?.handle) {
-      return "needs-profile";
+      return hasValidWalletAuthorization ? "needs-profile" : "loading";
     }
 
-    // Profile exists but waves not enabled (proxy or other reason)
+    if (!hasAuthenticatedProfile) {
+      return "loading";
+    }
+
     if (!showWaves) {
       return "not-available";
     }
 
-    // Everything ready but still measuring layout
     if (!spaces.measurementsComplete) {
       return "measuring";
     }
 
-    // All good, show content
     return "ready";
   }, [
-    hasValidWalletAuth,
+    address,
+    hasValidWalletAuthorization,
+    hasAuthenticatedProfile,
     fetchingProfile,
     connectedProfile,
     showWaves,
@@ -56,7 +60,7 @@ export function useAuthenticatedContent() {
 
   return {
     contentState,
-    isAuthenticated: hasValidWalletAuth,
+    isAuthenticated: hasAuthenticatedProfile,
     connectedProfile,
     showWaves,
     fetchingProfile,

--- a/hooks/useDmWavesList.ts
+++ b/hooks/useDmWavesList.ts
@@ -13,10 +13,16 @@ import { ApiWavesOverviewType } from "@/generated/models/ApiWavesOverviewType";
 const noopWaveAction = () => {};
 
 const useDmWavesList = () => {
-  const { address } = useSeizeConnectContext();
-  const { activeProfileProxy } = useAuth();
+  const { address, hasValidWalletAuth } = useSeizeConnectContext();
+  const { activeProfileProxy, fetchingProfile, isAuthenticated } = useAuth();
+  const hasValidWalletAuthorization = hasValidWalletAuth !== false;
+  const hasAuthenticatedProfile =
+    isAuthenticated ?? hasValidWalletAuthorization;
+  const isPendingAuthSwitch = Boolean(
+    address && (!hasValidWalletAuthorization || fetchingProfile)
+  );
   const viewerIdentityKey = useMemo(() => {
-    if (!address) {
+    if (!address || !hasValidWalletAuthorization) {
       return null;
     }
 
@@ -26,7 +32,7 @@ const useDmWavesList = () => {
     }
 
     return `${normalizedAddress}:primary`;
-  }, [address, activeProfileProxy?.id]);
+  }, [address, activeProfileProxy?.id, hasValidWalletAuthorization]);
 
   const {
     waves: mainWaves,
@@ -41,6 +47,9 @@ const useDmWavesList = () => {
     pageSize: WAVE_FOLLOWING_WAVES_PARAMS.limit,
     directMessage: true,
     viewerIdentityKey,
+    enabled: Boolean(
+      address && hasAuthenticatedProfile && !isPendingAuthSwitch
+    ),
     refetchInterval: SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
     refetchIntervalInBackground: false,
   });

--- a/hooks/useDmWavesList.ts
+++ b/hooks/useDmWavesList.ts
@@ -11,18 +11,25 @@ import {
 import { ApiWavesOverviewType } from "@/generated/models/ApiWavesOverviewType";
 
 const noopWaveAction = () => {};
+const noopAsyncWaveAction = async () => undefined;
 
 const useDmWavesList = () => {
   const { address, hasValidWalletAuth } = useSeizeConnectContext();
-  const { activeProfileProxy, fetchingProfile, isAuthenticated } = useAuth();
+  const {
+    activeProfileProxy,
+    connectedProfile,
+    fetchingProfile,
+    isAuthenticated,
+  } = useAuth();
   const hasValidWalletAuthorization = hasValidWalletAuth !== false;
   const hasAuthenticatedProfile =
-    isAuthenticated ?? hasValidWalletAuthorization;
+    hasValidWalletAuthorization &&
+    (isAuthenticated ?? !!connectedProfile?.handle);
   const isPendingAuthSwitch = Boolean(
     address && (!hasValidWalletAuthorization || fetchingProfile)
   );
   const viewerIdentityKey = useMemo(() => {
-    if (!address || !hasValidWalletAuthorization) {
+    if (!address || !hasValidWalletAuthorization || !hasAuthenticatedProfile) {
       return null;
     }
 
@@ -32,7 +39,18 @@ const useDmWavesList = () => {
     }
 
     return `${normalizedAddress}:primary`;
-  }, [address, activeProfileProxy?.id, hasValidWalletAuthorization]);
+  }, [
+    address,
+    activeProfileProxy?.id,
+    hasAuthenticatedProfile,
+    hasValidWalletAuthorization,
+  ]);
+  const shouldFetchDmWaves = Boolean(
+    address &&
+    hasAuthenticatedProfile &&
+    viewerIdentityKey &&
+    !isPendingAuthSwitch
+  );
 
   const {
     waves: mainWaves,
@@ -47,19 +65,21 @@ const useDmWavesList = () => {
     pageSize: WAVE_FOLLOWING_WAVES_PARAMS.limit,
     directMessage: true,
     viewerIdentityKey,
-    enabled: Boolean(
-      address && hasAuthenticatedProfile && !isPendingAuthSwitch
-    ),
+    enabled: shouldFetchDmWaves,
     refetchInterval: SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
     refetchIntervalInBackground: false,
   });
 
   // sort by latest drop
   const sorted = useMemo(() => {
+    if (!shouldFetchDmWaves) {
+      return [];
+    }
+
     return [...mainWaves].sort(
       (a, b) => (b.latestDropTimestamp ?? 0) - (a.latestDropTimestamp ?? 0)
     );
-  }, [mainWaves]);
+  }, [mainWaves, shouldFetchDmWaves]);
 
   // minimal wrapper to match waves list return signature
   const addPinnedWave = noopWaveAction;
@@ -67,19 +87,30 @@ const useDmWavesList = () => {
   const loadSubwavesForParent = noopWaveAction;
   const prefetchSubwavesForParent = noopWaveAction;
 
-  const fetchNextPageStable = useCallback(
-    () => fetchNextPage(),
-    [fetchNextPage]
-  );
+  const fetchNextPageStable = useCallback(() => {
+    if (!shouldFetchDmWaves) {
+      return noopAsyncWaveAction();
+    }
+
+    return fetchNextPage();
+  }, [fetchNextPage, shouldFetchDmWaves]);
+
+  const refetchStable = useCallback(() => {
+    if (!shouldFetchDmWaves) {
+      return noopAsyncWaveAction();
+    }
+
+    return refetch();
+  }, [refetch, shouldFetchDmWaves]);
 
   return useMemo(
     () => ({
       waves: sorted,
-      isFetching,
-      isFetchingNextPage,
-      hasNextPage,
+      isFetching: shouldFetchDmWaves ? isFetching : false,
+      isFetchingNextPage: shouldFetchDmWaves ? isFetchingNextPage : false,
+      hasNextPage: shouldFetchDmWaves ? hasNextPage : false,
       fetchNextPage: fetchNextPageStable,
-      status,
+      status: shouldFetchDmWaves ? status : "pending",
       pinnedWaves: [],
       isPinnedWavesLoading: false,
       hasPinnedWavesError: false,
@@ -87,10 +118,10 @@ const useDmWavesList = () => {
       removePinnedWave,
       loadSubwavesForParent,
       prefetchSubwavesForParent,
-      mainWaves,
+      mainWaves: shouldFetchDmWaves ? mainWaves : [],
       missingPinnedIds: [],
-      mainWavesRefetch: refetch,
-      refetchAllWaves: refetch,
+      mainWavesRefetch: refetchStable,
+      refetchAllWaves: refetchStable,
     }),
     [
       sorted,
@@ -100,7 +131,8 @@ const useDmWavesList = () => {
       fetchNextPageStable,
       status,
       mainWaves,
-      refetch,
+      refetchStable,
+      shouldFetchDmWaves,
     ]
   );
 };

--- a/hooks/useMarkWaveNotificationsRead.requests.ts
+++ b/hooks/useMarkWaveNotificationsRead.requests.ts
@@ -29,9 +29,6 @@ const latestVerifiedWaveReadIdentityByAddress = new Map<
   WaveReadVerifiedIdentity
 >();
 
-const createClearedWaveReadStateError = (reason: string): Error =>
-  new Error(`Pending wave notification read cleared: ${reason}.`);
-
 export const getStaleAddressEpochWaveReadResult = ({
   addressEpoch,
   latestAddressEpochRef,
@@ -49,9 +46,7 @@ export const getStaleAddressEpochWaveReadResult = ({
     return Promise.resolve("skipped");
   }
 
-  return Promise.reject(
-    createClearedWaveReadStateError("wallet address changed or disconnected")
-  );
+  return Promise.resolve("skipped");
 };
 
 const clearInFlightWaveReadState = (state: WaveReadRequestState): void => {
@@ -69,9 +64,7 @@ export const clearPendingWaveReadsForAddress = (addressKey: string): void => {
     }
 
     pendingWaveReadRequests.delete(requestKey);
-    state.reject(
-      createClearedWaveReadStateError("wallet address changed or disconnected")
-    );
+    state.resolve("skipped");
   }
 
   for (const [requestKey, state] of inFlightWaveReadRequests) {
@@ -89,9 +82,7 @@ export const clearPendingWaveReadsForAddress = (addressKey: string): void => {
 
 export const clearAllWaveReadState = (): void => {
   for (const state of pendingWaveReadRequests.values()) {
-    state.reject(
-      createClearedWaveReadStateError("no marker hooks are mounted")
-    );
+    state.resolve("skipped");
   }
 
   pendingWaveReadRequests.clear();
@@ -505,11 +496,7 @@ const flushQueuedWaveReadRequests = ({
       queuedRequest.addressEpoch !== queuedRequest.latestAddressEpochRef.current
     ) {
       pendingWaveReadRequests.delete(queuedRequest.requestKey);
-      queuedRequest.reject(
-        createClearedWaveReadStateError(
-          "wallet address changed or disconnected"
-        )
-      );
+      queuedRequest.resolve("skipped");
       continue;
     }
 

--- a/hooks/useOfficialWaves.ts
+++ b/hooks/useOfficialWaves.ts
@@ -10,6 +10,7 @@ interface UseOfficialWavesProps {
   readonly viewerIdentityKey?: string | null | undefined;
   readonly refetchInterval?: number | undefined;
   readonly refetchIntervalInBackground?: boolean | undefined;
+  readonly enabled?: boolean | undefined;
 }
 
 interface OfficialWavesQueryKeyParams {
@@ -31,6 +32,7 @@ export function useOfficialWaves({
   viewerIdentityKey,
   refetchInterval = Infinity,
   refetchIntervalInBackground = false,
+  enabled = true,
 }: UseOfficialWavesProps = {}) {
   const queryKeyParams = useMemo(
     () => getOfficialWavesQueryKeyParams(viewerIdentityKey),
@@ -48,6 +50,7 @@ export function useOfficialWaves({
     queryFn: fetchOfficialWaves,
     refetchInterval,
     refetchIntervalInBackground,
+    enabled,
     ...getDefaultQueryRetry(handleRetryFailure),
   });
 

--- a/hooks/usePinnedWavesServer.ts
+++ b/hooks/usePinnedWavesServer.ts
@@ -380,14 +380,27 @@ function usePinnedWaveMutations(
 }
 
 export function usePinnedWavesServer(): UsePinnedWavesServerReturn {
-  const { connectedProfile, activeProfileProxy } = useAuth();
-  const { address } = useSeizeConnectContext();
+  const {
+    connectedProfile,
+    activeProfileProxy,
+    fetchingProfile,
+    isAuthenticated,
+  } = useAuth();
+  const { address, hasValidWalletAuth } = useSeizeConnectContext();
   const queryClient = useQueryClient();
   const ongoingOperations = useRef<Set<string>>(new Set());
-  const isAuthenticated = !!connectedProfile?.handle && !activeProfileProxy;
+  const hasValidWalletAuthorization = hasValidWalletAuth !== false;
+  const hasAuthContextProfile =
+    isAuthenticated ??
+    (!!connectedProfile?.handle && hasValidWalletAuthorization);
+  const hasAuthenticatedProfile =
+    !!connectedProfile?.handle && !activeProfileProxy && hasAuthContextProfile;
   const activeProfileProxyId = activeProfileProxy?.id ?? null;
+  const isPendingAuthSwitch = Boolean(
+    address && (!hasValidWalletAuthorization || fetchingProfile)
+  );
   const viewerIdentityKey = useMemo(() => {
-    if (!address) {
+    if (!address || !hasValidWalletAuthorization || isPendingAuthSwitch) {
       return null;
     }
 
@@ -397,9 +410,17 @@ export function usePinnedWavesServer(): UsePinnedWavesServerReturn {
     }
 
     return `${normalizedAddress}:primary`;
-  }, [address, activeProfileProxyId]);
+  }, [
+    address,
+    activeProfileProxyId,
+    hasValidWalletAuthorization,
+    isPendingAuthSwitch,
+  ]);
   const pinnedWavesQueryKey = usePinnedWavesQueryKey(viewerIdentityKey);
-  const { waves: officialWaves } = useOfficialWaves({ viewerIdentityKey });
+  const { waves: officialWaves } = useOfficialWaves({
+    viewerIdentityKey,
+    enabled: !isPendingAuthSwitch,
+  });
   const officialWaveIds = useMemo(
     () => new Set(officialWaves.map((wave) => wave.id)),
     [officialWaves]
@@ -407,7 +428,7 @@ export function usePinnedWavesServer(): UsePinnedWavesServerReturn {
   const { data, isLoading, isError, error, refetch } = usePinnedWavesQuery(
     queryClient,
     pinnedWavesQueryKey,
-    isAuthenticated
+    hasAuthenticatedProfile && !isPendingAuthSwitch
   );
   const pinnedWaves = data ?? [];
   const { pinnedIds, canPinWave } = usePinnedWavesBudget(

--- a/hooks/useWaves.ts
+++ b/hooks/useWaves.ts
@@ -29,6 +29,8 @@ interface UseWavesParams {
   readonly directMessage?: boolean | undefined;
 }
 
+const noopAsyncWaveAction = async () => undefined;
+
 export function useWaves({
   identity,
   waveName,
@@ -47,8 +49,8 @@ export function useWaves({
 
   const hasValidWalletAuthorization = hasValidWalletAuth !== false;
   const hasAuthenticatedProfile =
-    isAuthenticated ??
-    (!!connectedProfile?.handle && hasValidWalletAuthorization);
+    hasValidWalletAuthorization &&
+    (isAuthenticated ?? !!connectedProfile?.handle);
   const isPendingAuthSwitch = Boolean(
     address && (!hasValidWalletAuthorization || fetchingProfile)
   );
@@ -129,28 +131,35 @@ export function useWaves({
     ...getDefaultQueryRetry(),
   });
 
+  const shouldMaskWaveData = !enabled || isPendingAuthSwitch;
   const waves = useMemo<ApiWave[]>(() => {
-    if (!enabled) {
+    if (shouldMaskWaveData) {
       return [];
     }
     if (usePublicWaves) {
       return publicQuery.data?.pages.flat() ?? [];
     }
     return authQuery.data?.pages.flat() ?? [];
-  }, [enabled, authQuery.data, publicQuery.data, usePublicWaves]);
+  }, [authQuery.data, publicQuery.data, shouldMaskWaveData, usePublicWaves]);
 
   const activeQuery = usePublicWaves ? publicQuery : authQuery;
-  const lastPageSize = activeQuery.data?.pages.at(-1)?.length ?? 0;
+  const lastPageSize = shouldMaskWaveData
+    ? 0
+    : (activeQuery.data?.pages.at(-1)?.length ?? 0);
 
   return {
     waves,
-    isFetching: activeQuery.isFetching,
-    isFetchingNextPage: activeQuery.isFetchingNextPage,
-    hasNextPage: activeQuery.hasNextPage,
+    isFetching: shouldMaskWaveData ? false : activeQuery.isFetching,
+    isFetchingNextPage: shouldMaskWaveData
+      ? false
+      : activeQuery.isFetchingNextPage,
+    hasNextPage: shouldMaskWaveData ? false : activeQuery.hasNextPage,
     lastPageSize,
-    fetchNextPage: activeQuery.fetchNextPage,
-    status: activeQuery.status,
-    error: activeQuery.error,
-    refetch: activeQuery.refetch,
+    fetchNextPage: shouldMaskWaveData
+      ? noopAsyncWaveAction
+      : activeQuery.fetchNextPage,
+    status: shouldMaskWaveData ? "pending" : activeQuery.status,
+    error: shouldMaskWaveData ? null : activeQuery.error,
+    refetch: shouldMaskWaveData ? noopAsyncWaveAction : activeQuery.refetch,
   };
 }

--- a/hooks/useWaves.ts
+++ b/hooks/useWaves.ts
@@ -6,6 +6,7 @@ import { useContext, useMemo, useState } from "react";
 
 import { useDebounce } from "react-use";
 import { AuthContext } from "@/components/auth/Auth";
+import { useSeizeConnectContext } from "@/components/auth/SeizeConnectContext";
 import { commonApiFetch } from "@/services/api/common-api";
 import type { ApiWave } from "@/generated/models/ApiWave";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
@@ -36,9 +37,25 @@ export function useWaves({
   enabled = true,
   directMessage,
 }: UseWavesParams) {
-  const { connectedProfile, activeProfileProxy } = useContext(AuthContext);
+  const {
+    connectedProfile,
+    activeProfileProxy,
+    fetchingProfile,
+    isAuthenticated,
+  } = useContext(AuthContext);
+  const { address, hasValidWalletAuth } = useSeizeConnectContext();
 
-  const usePublicWaves = !connectedProfile?.handle || !!activeProfileProxy;
+  const hasValidWalletAuthorization = hasValidWalletAuth !== false;
+  const hasAuthenticatedProfile =
+    isAuthenticated ??
+    (!!connectedProfile?.handle && hasValidWalletAuthorization);
+  const isPendingAuthSwitch = Boolean(
+    address && (!hasValidWalletAuthorization || fetchingProfile)
+  );
+  const usePublicWaves =
+    !connectedProfile?.handle ||
+    !!activeProfileProxy ||
+    !hasAuthenticatedProfile;
 
   const params = useMemo<SearchWavesParams>(
     () => ({
@@ -79,7 +96,7 @@ export function useWaves({
     },
     initialPageParam: null,
     getNextPageParam: (lastPage) => lastPage.at(-1)?.serial_no ?? null,
-    enabled: enabled && !usePublicWaves,
+    enabled: enabled && !usePublicWaves && !isPendingAuthSwitch,
     refetchInterval,
     ...getDefaultQueryRetry(),
   });
@@ -107,7 +124,7 @@ export function useWaves({
     },
     initialPageParam: null,
     getNextPageParam: (lastPage) => lastPage.at(-1)?.serial_no ?? null,
-    enabled: enabled && usePublicWaves,
+    enabled: enabled && usePublicWaves && !isPendingAuthSwitch,
     refetchInterval,
     ...getDefaultQueryRetry(),
   });

--- a/hooks/useWavesList.ts
+++ b/hooks/useWavesList.ts
@@ -584,7 +584,6 @@ const useWavesList = () => {
   // Function to refetch all waves (main, pinned, announcements, subwaves)
   const refetchAllWaves = useCallback(() => {
     if (isPendingAuthSwitch) {
-      void noopAsyncWaveAction();
       return;
     }
 

--- a/hooks/useWavesList.ts
+++ b/hooks/useWavesList.ts
@@ -85,8 +85,13 @@ const isKnownWaveForCurrentViewer = (wave: SidebarWave) =>
  */
 const useWavesList = () => {
   const queryClient = useQueryClient();
-  const { connectedProfile, activeProfileProxy } = useAuth();
-  const { address } = useSeizeConnectContext();
+  const {
+    connectedProfile,
+    activeProfileProxy,
+    fetchingProfile,
+    isAuthenticated,
+  } = useAuth();
+  const { address, hasValidWalletAuth } = useSeizeConnectContext();
   const { seizeSettings, isAnnouncementsWave } = useSeizeSettings();
   const {
     pinnedIds,
@@ -101,14 +106,25 @@ const useWavesList = () => {
   const announcementsWaveId = normalizeOptionalWaveId(
     seizeSettings.announcements_wave_id
   );
+  const hasValidWalletAuthorization = hasValidWalletAuth !== false;
+  const hasAuthenticatedProfile =
+    isAuthenticated ??
+    (!!connectedProfile?.handle && hasValidWalletAuthorization);
 
   // Track connected identity state - memoize to prevent re-renders
   const isConnectedIdentity = useMemo(() => {
-    return !!connectedProfile?.handle && !activeProfileProxy;
-  }, [connectedProfile?.handle, activeProfileProxy]);
+    return (
+      !!connectedProfile?.handle &&
+      !activeProfileProxy &&
+      hasAuthenticatedProfile
+    );
+  }, [connectedProfile?.handle, activeProfileProxy, hasAuthenticatedProfile]);
   const isJoinedMode = following && isConnectedIdentity;
+  const isPendingAuthSwitch = Boolean(
+    address && (!hasValidWalletAuthorization || fetchingProfile)
+  );
   const viewerIdentityKey = useMemo(() => {
-    if (!address) {
+    if (!address || !hasValidWalletAuthorization) {
       return null;
     }
 
@@ -119,7 +135,7 @@ const useWavesList = () => {
     }
 
     return `${normalizedAddress}:primary`;
-  }, [address, activeProfileProxy?.id]);
+  }, [address, activeProfileProxy?.id, hasValidWalletAuthorization]);
 
   const nonPinnedFilter = isConnectedIdentity
     ? ApiWavesPinFilter.NotPinned
@@ -141,7 +157,7 @@ const useWavesList = () => {
     viewerIdentityKey,
     refetchInterval: SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
     refetchIntervalInBackground: false,
-    enabled: true,
+    enabled: !isPendingAuthSwitch,
   });
   // Fetch recent activity for the broad bottom section and pagination.
   const {
@@ -163,7 +179,7 @@ const useWavesList = () => {
       ? false
       : SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS,
     refetchIntervalInBackground: false,
-    enabled: !isJoinedMode,
+    enabled: !isJoinedMode && !isPendingAuthSwitch,
   });
   // Fetch followed waves by latest post activity for the known-wave sidebar.
   const {
@@ -184,7 +200,7 @@ const useWavesList = () => {
       ? SIDEBAR_WAVES_OVERVIEW_REFETCH_INTERVAL_MS
       : false,
     refetchIntervalInBackground: false,
-    enabled: isJoinedMode,
+    enabled: isJoinedMode && !isPendingAuthSwitch,
   });
   const mainWaves = useMemo<SidebarWaveWithDiscoverySection[]>(() => {
     return [

--- a/hooks/useWavesList.ts
+++ b/hooks/useWavesList.ts
@@ -79,6 +79,9 @@ const getFirstUnreadSerialNo = (
 const isKnownWaveForCurrentViewer = (wave: SidebarWave) =>
   wave.subscribed || wave.followedSubwavesCount > 0;
 
+const noopWaveAction = async (_waveId: string) => undefined;
+const noopAsyncWaveAction = async () => undefined;
+
 /**
  * Hook for managing and fetching waves list including pinned waves
  * @returns Wave list data and loading states
@@ -108,8 +111,8 @@ const useWavesList = () => {
   );
   const hasValidWalletAuthorization = hasValidWalletAuth !== false;
   const hasAuthenticatedProfile =
-    isAuthenticated ??
-    (!!connectedProfile?.handle && hasValidWalletAuthorization);
+    hasValidWalletAuthorization &&
+    (isAuthenticated ?? !!connectedProfile?.handle);
 
   // Track connected identity state - memoize to prevent re-renders
   const isConnectedIdentity = useMemo(() => {
@@ -124,7 +127,7 @@ const useWavesList = () => {
     address && (!hasValidWalletAuthorization || fetchingProfile)
   );
   const viewerIdentityKey = useMemo(() => {
-    if (!address || !hasValidWalletAuthorization) {
+    if (!address || !hasValidWalletAuthorization || !hasAuthenticatedProfile) {
       return null;
     }
 
@@ -135,7 +138,12 @@ const useWavesList = () => {
     }
 
     return `${normalizedAddress}:primary`;
-  }, [address, activeProfileProxy?.id, hasValidWalletAuthorization]);
+  }, [
+    address,
+    activeProfileProxy?.id,
+    hasAuthenticatedProfile,
+    hasValidWalletAuthorization,
+  ]);
 
   const nonPinnedFilter = isConnectedIdentity
     ? ApiWavesPinFilter.NotPinned
@@ -203,6 +211,10 @@ const useWavesList = () => {
     enabled: isJoinedMode && !isPendingAuthSwitch,
   });
   const mainWaves = useMemo<SidebarWaveWithDiscoverySection[]>(() => {
+    if (isPendingAuthSwitch) {
+      return [];
+    }
+
     return [
       // Keep the highly-rated slice before the broader activity list:
       // duplicate wave ids retain their first sidebarSection during merge.
@@ -224,26 +236,41 @@ const useWavesList = () => {
             })
           )),
     ];
-  }, [isJoinedMode, followedActivityWaves, highlyRatedWaves, allActivityWaves]);
-  const isMainWavesFetching =
-    (!isJoinedMode &&
-      (isAllActivityWavesFetching || isHighlyRatedWavesFetching)) ||
-    isFollowedActivityWavesFetching;
-  const isMainWavesFetchingNextPage = isJoinedMode
-    ? isFollowedActivityWavesFetchingNextPage
-    : isAllActivityWavesFetchingNextPage;
-  const hasMainWavesNextPage = isJoinedMode
-    ? hasFollowedActivityWavesNextPage
-    : hasAllActivityWavesNextPage;
+  }, [
+    allActivityWaves,
+    followedActivityWaves,
+    highlyRatedWaves,
+    isJoinedMode,
+    isPendingAuthSwitch,
+  ]);
+  const isMainWavesFetching = isPendingAuthSwitch
+    ? false
+    : (!isJoinedMode &&
+        (isAllActivityWavesFetching || isHighlyRatedWavesFetching)) ||
+      isFollowedActivityWavesFetching;
+  const isMainWavesFetchingNextPage = isPendingAuthSwitch
+    ? false
+    : isJoinedMode
+      ? isFollowedActivityWavesFetchingNextPage
+      : isAllActivityWavesFetchingNextPage;
+  const hasMainWavesNextPage = isPendingAuthSwitch
+    ? false
+    : isJoinedMode
+      ? hasFollowedActivityWavesNextPage
+      : hasAllActivityWavesNextPage;
   const fetchNextMainWavesPage = useCallback(() => {
-    if (isJoinedMode) {
-      fetchNextFollowedActivityWavesPage();
-      return;
+    if (isPendingAuthSwitch) {
+      return noopAsyncWaveAction();
     }
 
-    fetchNextAllActivityWavesPage();
+    if (isJoinedMode) {
+      return fetchNextFollowedActivityWavesPage();
+    }
+
+    return fetchNextAllActivityWavesPage();
   }, [
     isJoinedMode,
+    isPendingAuthSwitch,
     fetchNextAllActivityWavesPage,
     fetchNextFollowedActivityWavesPage,
   ]);
@@ -251,13 +278,21 @@ const useWavesList = () => {
     ? followedActivityWavesStatus
     : allActivityWavesStatus;
   const mainWavesRefetch = useCallback(() => {
-    if (isJoinedMode) {
-      followedActivityWavesRefetch();
-      return;
+    if (isPendingAuthSwitch) {
+      return noopAsyncWaveAction();
     }
 
-    allActivityWavesRefetch();
-  }, [isJoinedMode, allActivityWavesRefetch, followedActivityWavesRefetch]);
+    if (isJoinedMode) {
+      return followedActivityWavesRefetch();
+    }
+
+    return allActivityWavesRefetch();
+  }, [
+    isJoinedMode,
+    isPendingAuthSwitch,
+    allActivityWavesRefetch,
+    followedActivityWavesRefetch,
+  ]);
   const trackedAnnouncementWave = useMemo(
     () =>
       mainWaves.find((wave) => isAnnouncementsWave(wave.id)) ??
@@ -266,7 +301,7 @@ const useWavesList = () => {
     [mainWaves, serverPinnedWaves, isAnnouncementsWave]
   );
   const shouldFetchAnnouncementWave = Boolean(
-    announcementsWaveId && !trackedAnnouncementWave
+    announcementsWaveId && !trackedAnnouncementWave && !isPendingAuthSwitch
   );
   const {
     wave: fetchedAnnouncementWave,
@@ -325,6 +360,10 @@ const useWavesList = () => {
 
   // Use server-provided pinned waves
   const separatelyFetchedPinnedWaves = useMemo(() => {
+    if (isPendingAuthSwitch) {
+      return [];
+    }
+
     // Filter out pinned waves that are already in mainWaves to avoid duplicates
     return serverPinnedWaves.filter(
       (wave) =>
@@ -332,10 +371,19 @@ const useWavesList = () => {
         isExpectedRootSidebarWave(wave) &&
         !isAnnouncementsWave(wave.id)
     );
-  }, [serverPinnedWaves, mainWaveIds, isAnnouncementsWave]);
+  }, [
+    isPendingAuthSwitch,
+    serverPinnedWaves,
+    mainWaveIds,
+    isAnnouncementsWave,
+  ]);
 
   // Collect ALL pinned waves (both from mainWaves and server-provided)
   const allPinnedWaves = useMemo(() => {
+    if (isPendingAuthSwitch) {
+      return [];
+    }
+
     const result: EnhancedWave[] = [];
 
     // Add all server-provided pinned waves, filtering out DMs
@@ -350,13 +398,17 @@ const useWavesList = () => {
     });
 
     return result;
-  }, [serverPinnedWaves, isAnnouncementsWave]);
+  }, [isPendingAuthSwitch, serverPinnedWaves, isAnnouncementsWave]);
 
   // New drops counts are now managed externally
 
   // Combine activity and discovery sources. Top sections are grouped later;
   // regular bottom-list rows share one latest-activity order.
   const combinedWaves = useMemo(() => {
+    if (isPendingAuthSwitch) {
+      return [];
+    }
+
     const allWavesMap = new Map<string, EnhancedWave>();
     const pinnedWavesSet = new Set(pinnedIds);
     const allWavesArray: EnhancedWave[] = [];
@@ -460,6 +512,7 @@ const useWavesList = () => {
     pinnedIds,
     announcementWave,
     isAnnouncementsWave,
+    isPendingAuthSwitch,
   ]);
 
   const [loadedSubwaveParentIds, setLoadedSubwaveParentIds] = useState<
@@ -473,6 +526,10 @@ const useWavesList = () => {
 
   const loadSubwavesForParent = useCallback(
     (parentWaveId: string) => {
+      if (isPendingAuthSwitch) {
+        return;
+      }
+
       if (!rootWaveIds.has(parentWaveId)) {
         return;
       }
@@ -485,11 +542,15 @@ const useWavesList = () => {
         return [...previousParentIds, parentWaveId];
       });
     },
-    [rootWaveIds]
+    [isPendingAuthSwitch, rootWaveIds]
   );
 
   const prefetchSubwavesForParent = useCallback(
     (parentWaveId: string) => {
+      if (isPendingAuthSwitch) {
+        return;
+      }
+
       if (!rootWaveIds.has(parentWaveId)) {
         return;
       }
@@ -500,7 +561,7 @@ const useWavesList = () => {
         )
         .catch(() => undefined);
     },
-    [queryClient, rootWaveIds, viewerIdentityKey]
+    [isPendingAuthSwitch, queryClient, rootWaveIds, viewerIdentityKey]
   );
 
   const {
@@ -508,8 +569,8 @@ const useWavesList = () => {
     subwavesByParentId,
     refetch: refetchSubwaves,
   } = useWaveSubwavesMap({
-    parentWaveIds: loadedSubwaveParentIds,
-    viewerIdentityKey,
+    parentWaveIds: isPendingAuthSwitch ? [] : loadedSubwaveParentIds,
+    viewerIdentityKey: isPendingAuthSwitch ? null : viewerIdentityKey,
   });
   const loadingSubwaveParentIds = useMemo(
     () =>
@@ -522,6 +583,11 @@ const useWavesList = () => {
 
   // Function to refetch all waves (main, pinned, announcements, subwaves)
   const refetchAllWaves = useCallback(() => {
+    if (isPendingAuthSwitch) {
+      void noopAsyncWaveAction();
+      return;
+    }
+
     if (isJoinedMode) {
       followedActivityWavesRefetch();
     } else {
@@ -538,6 +604,7 @@ const useWavesList = () => {
     highlyRatedWavesRefetch,
     followedActivityWavesRefetch,
     isJoinedMode,
+    isPendingAuthSwitch,
     refetchPinnedWaves,
     refetchSubwaves,
     announcementRefetch,
@@ -562,16 +629,25 @@ const useWavesList = () => {
 
   // Derived data should come directly from memoized inputs.
   const allWaves = useMemo(
-    () => [
-      ...combinedWaves,
-      ...subwaves.filter(
-        (wave) =>
-          !isJoinedMode ||
-          wave.subscribed ||
-          topSectionWaveIds.has(wave.parentWaveId ?? "")
-      ),
-    ],
-    [combinedWaves, isJoinedMode, subwaves, topSectionWaveIds]
+    () =>
+      isPendingAuthSwitch
+        ? []
+        : [
+            ...combinedWaves,
+            ...subwaves.filter(
+              (wave) =>
+                !isJoinedMode ||
+                wave.subscribed ||
+                topSectionWaveIds.has(wave.parentWaveId ?? "")
+            ),
+          ],
+    [
+      combinedWaves,
+      isJoinedMode,
+      isPendingAuthSwitch,
+      subwaves,
+      topSectionWaveIds,
+    ]
   );
 
   // New drops counting logic has been removed and will be managed by context
@@ -610,8 +686,8 @@ const useWavesList = () => {
       announcementRefetch,
 
       // Pinned waves management functions
-      addPinnedWave: pinWave,
-      removePinnedWave: unpinWave,
+      addPinnedWave: isPendingAuthSwitch ? noopWaveAction : pinWave,
+      removePinnedWave: isPendingAuthSwitch ? noopWaveAction : unpinWave,
 
       // Additional data that might be useful
       mainWaves,
@@ -641,6 +717,7 @@ const useWavesList = () => {
       announcementRefetch,
       pinWave,
       unpinWave,
+      isPendingAuthSwitch,
       missingPinnedIds,
       mainWavesRefetch,
       refetchAllWaves,

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -5,7 +5,63 @@ import {
   TransformStream,
   WritableStream,
 } from "node:stream/web";
-import { MessageChannel, MessagePort } from "node:worker_threads";
+import { MessagePort } from "node:worker_threads";
+
+class TestMessagePort {
+  constructor() {
+    this.onmessage = null;
+    this.onmessageerror = null;
+    this.target = null;
+    this.listeners = new Set();
+  }
+
+  postMessage(data) {
+    const timeout = setTimeout(() => {
+      const event = { data, target: this.target };
+      this.target?.onmessage?.(event);
+      this.target?.listeners.forEach((listener) => listener(event));
+    }, 0);
+    timeout.unref?.();
+  }
+
+  addEventListener(type, listener) {
+    if (type === "message") {
+      this.listeners.add(listener);
+    }
+  }
+
+  removeEventListener(type, listener) {
+    if (type === "message") {
+      this.listeners.delete(listener);
+    }
+  }
+
+  dispatchEvent(event) {
+    this.listeners.forEach((listener) => listener(event));
+    return true;
+  }
+
+  close() {
+    this.listeners.clear();
+    this.onmessage = null;
+    this.onmessageerror = null;
+  }
+
+  start() {}
+
+  ref() {}
+
+  unref() {}
+}
+
+class TestMessageChannel {
+  constructor() {
+    this.port1 = new TestMessagePort();
+    this.port2 = new TestMessagePort();
+    this.port1.target = this.port2;
+    this.port2.target = this.port1;
+  }
+}
 
 // Load environment variables for tests
 config({ path: ".env.development" });
@@ -15,7 +71,7 @@ globalThis.TextDecoder = TextDecoder;
 globalThis.ReadableStream = globalThis.ReadableStream ?? ReadableStream;
 globalThis.TransformStream = globalThis.TransformStream ?? TransformStream;
 globalThis.WritableStream = globalThis.WritableStream ?? WritableStream;
-globalThis.MessageChannel = globalThis.MessageChannel ?? MessageChannel;
+globalThis.MessageChannel = TestMessageChannel;
 globalThis.MessagePort = globalThis.MessagePort ?? MessagePort;
 
 require("@testing-library/jest-dom");
@@ -45,6 +101,9 @@ globalThis.css = (element, property, value) => {
 
 // Only set up window mocks in jsdom environment
 if (globalThis.window !== undefined) {
+  globalThis.window.MessageChannel = TestMessageChannel;
+  globalThis.window.MessagePort = globalThis.window.MessagePort ?? MessagePort;
+
   // Mock CSS parsing for react-bootstrap and other CSS-dependent components
   Object.defineProperty(window, "getComputedStyle", {
     value: () => ({

--- a/services/auth/auth.utils.ts
+++ b/services/auth/auth.utils.ts
@@ -99,10 +99,21 @@ const emitAuthTokenChanged = (): void => {
   }
 };
 
+const emitAuthTokenChangedIfChanged = (
+  previousJwt: string | null,
+  nextJwt: string | null
+): void => {
+  if (previousJwt !== nextJwt) {
+    emitAuthTokenChanged();
+  }
+};
+
 const setWalletAuthCookie = (jwt: string | null): void => {
+  const previousJwt = Cookies.get(WALLET_AUTH_COOKIE) ?? null;
+
   if (!jwt) {
     Cookies.remove(WALLET_AUTH_COOKIE, COOKIE_OPTIONS);
-    emitAuthTokenChanged();
+    emitAuthTokenChangedIfChanged(previousJwt, null);
     return;
   }
 
@@ -112,7 +123,7 @@ const setWalletAuthCookie = (jwt: string | null): void => {
     const expiresInSeconds = jwtExpiration - now;
     if (expiresInSeconds <= 0) {
       Cookies.remove(WALLET_AUTH_COOKIE, COOKIE_OPTIONS);
-      emitAuthTokenChanged();
+      emitAuthTokenChangedIfChanged(previousJwt, null);
       return;
     }
     const expiresInDays = expiresInSeconds / 86400;
@@ -121,10 +132,10 @@ const setWalletAuthCookie = (jwt: string | null): void => {
       ...COOKIE_OPTIONS,
       expires: expiresInDays,
     });
-    emitAuthTokenChanged();
+    emitAuthTokenChangedIfChanged(previousJwt, jwt);
   } catch {
     Cookies.remove(WALLET_AUTH_COOKIE, COOKIE_OPTIONS);
-    emitAuthTokenChanged();
+    emitAuthTokenChangedIfChanged(previousJwt, null);
   }
 };
 

--- a/services/auth/auth.utils.ts
+++ b/services/auth/auth.utils.ts
@@ -8,6 +8,7 @@ import { removeNativeRefreshToken } from "./native-refresh-token-storage";
 export const WALLET_AUTH_COOKIE = "wallet-auth";
 export const WALLET_ACCOUNTS_UPDATED_EVENT = "6529-wallet-accounts-updated";
 export const PROFILE_SWITCHED_EVENT = "6529-profile-switched";
+export const AUTH_TOKEN_CHANGED_EVENT = "6529-auth-token-changed";
 export type AuthSessionVersion = "v2";
 
 const WALLET_ADDRESS_STORAGE_KEY = "6529-wallet-address";
@@ -92,9 +93,16 @@ const emitProfileSwitched = (): void => {
   }
 };
 
+const emitAuthTokenChanged = (): void => {
+  if (globalThis.window !== undefined) {
+    globalThis.dispatchEvent(new CustomEvent(AUTH_TOKEN_CHANGED_EVENT));
+  }
+};
+
 const setWalletAuthCookie = (jwt: string | null): void => {
   if (!jwt) {
     Cookies.remove(WALLET_AUTH_COOKIE, COOKIE_OPTIONS);
+    emitAuthTokenChanged();
     return;
   }
 
@@ -104,6 +112,7 @@ const setWalletAuthCookie = (jwt: string | null): void => {
     const expiresInSeconds = jwtExpiration - now;
     if (expiresInSeconds <= 0) {
       Cookies.remove(WALLET_AUTH_COOKIE, COOKIE_OPTIONS);
+      emitAuthTokenChanged();
       return;
     }
     const expiresInDays = expiresInSeconds / 86400;
@@ -112,8 +121,10 @@ const setWalletAuthCookie = (jwt: string | null): void => {
       ...COOKIE_OPTIONS,
       expires: expiresInDays,
     });
+    emitAuthTokenChanged();
   } catch {
     Cookies.remove(WALLET_AUTH_COOKIE, COOKIE_OPTIONS);
+    emitAuthTokenChanged();
   }
 };
 
@@ -249,6 +260,22 @@ const getActiveAccountFromAccounts = (
   return active ?? accounts[0] ?? null;
 };
 
+const hasActiveAddressChanged = (
+  previousActiveAddress: string | null,
+  nextActiveAddress: string | null
+): boolean => {
+  if (!previousActiveAddress) {
+    return false;
+  }
+  if (!nextActiveAddress) {
+    return true;
+  }
+  return (
+    normalizeAddress(previousActiveAddress) !==
+    normalizeAddress(nextActiveAddress)
+  );
+};
+
 const migrateLegacyStorageIfNeeded = (): void => {
   const hasAccountsStorage =
     safeLocalStorage.getItem(WALLET_ACCOUNTS_STORAGE_KEY) !== null;
@@ -370,6 +397,7 @@ export const setAuthJwt = (
   } = {}
 ): boolean => {
   const storedAccounts = getStoredAccounts();
+  const previousActiveAddress = getActiveAddressFromStorage();
   const existingAccount =
     storedAccounts.find(
       (account) =>
@@ -409,6 +437,9 @@ export const setAuthJwt = (
   }
 
   emitWalletAccountsUpdated();
+  if (hasActiveAddressChanged(previousActiveAddress, address)) {
+    emitProfileSwitched();
+  }
   return true;
 };
 
@@ -483,6 +514,7 @@ const getNativeRefreshTokenCleanupAddresses = (
 
 export const clearAllWalletAuth = async (): Promise<void> => {
   const accounts = getStoredAccounts();
+  const previousActiveAddress = getActiveAddressFromStorage();
   await Promise.all(
     getNativeRefreshTokenCleanupAddresses(accounts).map((address) =>
       removeNativeRefreshToken(address)
@@ -490,11 +522,18 @@ export const clearAllWalletAuth = async (): Promise<void> => {
   );
   persistAccountsWithActive([], null);
   emitWalletAccountsUpdated();
+  if (previousActiveAddress) {
+    emitProfileSwitched();
+  }
 };
 
 export const removeAuthJwt = async (): Promise<void> => {
   const accounts = getStoredAccounts();
   const activeAccount = getActiveAccountFromAccounts(accounts);
+  const previousActiveAddress =
+    activeAccount?.address ??
+    getActiveAddressFromStorage() ??
+    safeLocalStorage.getItem(WALLET_ADDRESS_STORAGE_KEY);
 
   if (!activeAccount) {
     const legacyAddress = safeLocalStorage.getItem(WALLET_ADDRESS_STORAGE_KEY);
@@ -504,6 +543,9 @@ export const removeAuthJwt = async (): Promise<void> => {
     }
     persistAccountsWithActive([], null);
     emitWalletAccountsUpdated();
+    if (previousActiveAddress) {
+      emitProfileSwitched();
+    }
     return;
   }
 
@@ -520,6 +562,9 @@ export const removeAuthJwt = async (): Promise<void> => {
   const nextActiveAddress = remainingAccounts[0]?.address ?? null;
   persistAccountsWithActive(remainingAccounts, nextActiveAddress);
   emitWalletAccountsUpdated();
+  if (hasActiveAddressChanged(previousActiveAddress, nextActiveAddress)) {
+    emitProfileSwitched();
+  }
 };
 
 /**

--- a/services/websocket/useWebSocketHealth.ts
+++ b/services/websocket/useWebSocketHealth.ts
@@ -1,7 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
-import { getAuthJwt, WALLET_AUTH_COOKIE } from "../auth/auth.utils";
+import {
+  AUTH_TOKEN_CHANGED_EVENT,
+  getAuthJwt,
+  WALLET_AUTH_COOKIE,
+} from "../auth/auth.utils";
 import { useWebSocket } from "./useWebSocket";
 import { WebSocketStatus } from "./WebSocketTypes";
 
@@ -198,6 +202,11 @@ export function useWebSocketHealth() {
       return;
     }
 
+    const handleAuthTokenChanged = () => {
+      performHealthCheck();
+    };
+    window.addEventListener(AUTH_TOKEN_CHANGED_EVENT, handleAuthTokenChanged);
+
     const cookieStore = (
       window as unknown as {
         cookieStore?: CookieStoreWithEvents | undefined;
@@ -278,6 +287,10 @@ export function useWebSocketHealth() {
     }
 
     return () => {
+      window.removeEventListener(
+        AUTH_TOKEN_CHANGED_EVENT,
+        handleAuthTokenChanged
+      );
       removeCookieListener?.();
       closeBroadcastChannel?.();
     };


### PR DESCRIPTION
﻿﻿﻿## Summary

Supersedes stale PR #2455 with a fresh implementation on current `main`.

This PR tightens account/profile switching so auth-sensitive Waves, DM, pinned-wave, notification, and profile-query surfaces do not fetch, render, or operate with a stale wallet/profile boundary while active wallet auth is invalid or still settling.

## Why

The old PR predated the newer wallet-auth boundary. This replacement keeps the newer `hasValidWalletAuth` model and avoids using wallet address alone as proof that authenticated data is safe to fetch or render.

## Changes

- Add same-tab auth-token/profile-switch events so auth cookie changes and active-account changes are observable immediately.
- Dedupe auth-token-change events so rewriting the same JWT does not trigger unnecessary WebSocket reconnects.
- Add targeted `invalidateAuthSensitiveQueries()` to `ReactQueryWrapper` instead of broad invalidation on profile switch.
- Make `Auth` expose a connected profile only when the loaded profile belongs to the active wallet; malformed profile payloads with no usable wallet addresses fail closed.
- Delay profile-switch invalidation/navigation until the target wallet address is active and profile loading has settled.
- Read cached wave metadata before auth-sensitive invalidation, preserving cached public wave routes and conservatively resetting private/unknown wave routes to list pages.
- Gate and mask Waves/DM/pinned/official wave query paths on valid wallet auth, authenticated profile state, and profile-loading state.
- Return empty data and inert fetch/refetch/pin/subwave callbacks while auth is invalid or unsettled, preventing stale viewer-scoped data operations.
- Keep the Waves shell mounted during auth-loading transitions while hiding child content to avoid stale private content flashes.
- Resolve stale queued wave-notification-read work as `skipped`; real network/API errors still reject.

## Impact Assessment

Functional impact:
- Account switching should stop using the previous profile or previous viewer identity for authenticated wave queries.
- DM, pinned, and viewer-scoped wave reads pause and mask cached rows while the wallet is connected but lacks valid auth.
- Public wave navigation is preserved when safe; private or unknown message/wave routes reset to `/messages` or `/waves` after profile switch.

UX impact:
- During auth/profile settling, Waves layout keeps the shell mounted but suppresses content children.
- Connected wallets with invalid auth settle to the not-authenticated state instead of an indefinite empty loading shell.
- Stale notification-read callbacks become quiet skips rather than user-visible stale-auth failures.

Security/privacy impact:
- Reduces stale private data exposure risk during rapid wallet/account changes.
- Fails closed on malformed profile wallet ownership data.
- Avoids broad cache invalidation where targeted auth-sensitive invalidation is sufficient.

Surface coverage:
- Web: primary target, covered by focused Jest suites and changed-file checks.
- Mobile/native capacity: same auth/query hooks are shared; no device-specific runtime validation in this PR.
- Electron/app shell: same hook-level behavior; no app-shell-specific code touched.

## Local Verification

- `seize exec jest --coverage=false --runInBand __tests__/components/waves/drops/WaveDropsAll.test.tsx __tests__/services/auth.utils.test.ts __tests__/services/websocket/useWebSocketHealth.test.ts __tests__/components/react-query-wrapper/ReactQueryWrapper.test.tsx __tests__/components/waves/WavesLayout.test.tsx __tests__/components/auth/Auth.test.tsx __tests__/hooks/useAuthenticatedContent.test.tsx __tests__/hooks/useWaves.test.ts __tests__/hooks/useWavesList.test.tsx __tests__/hooks/useDmWavesList.test.tsx __tests__/hooks/usePinnedWavesServer.test.tsx __tests__/hooks/useMarkWaveNotificationsRead.test.tsx`
  - 12 suites, 248 tests passed; process exited naturally without `--forceExit`.
- `seize run test:no-coverage -- --runInBand __tests__/components/auth/Auth.test.tsx __tests__/hooks/useWavesList.test.tsx`
  - 2 suites, 69 tests passed; verifies the repo script path exits without hanging on React scheduler `MessageChannel` handles.
- `seize run lint:changed`
- `seize run typecheck:changed`
  - Typecheck passed for 22 changed TypeScript files.
- `seize run react-doctor:diff`
  - Passed with pre-existing Auth size/state warnings.
- `codex-diff-check`
- `seize run build`
  - Production compile, TypeScript, page-data collection, and static generation completed, including 257 generated static pages.
  - Local Windows retry failed only at the final standalone output copy with `EBUSY` file-lock errors under `.next/standalone`; this appears local-environment-specific. GitHub/Linux CI remains the authoritative build gate for this PR.

## Notes For Reviewers / Bots

Please focus on:
- Whether any auth-sensitive query family should be added to `invalidateAuthSensitiveQueries()`.
- Whether any Waves/DM/pinned hook still permits stale viewer identity, cached private data, or live fetch/pin/refetch operations during wallet-auth invalidation.
- Whether resolving stale wave-notification-read work as `skipped` could hide a real error. Intentional behavior: stale auth/lifecycle cleanup skips; actual API failures still reject.
- Whether conservative fallback from uncached wave routes after profile switch is the right UX/security tradeoff.

## Follow-up

After this replacement merges, stale PR #2455 should be closed as superseded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced authentication state tracking across wallet profile switches.
  * WebSocket connections now automatically refresh when authentication tokens change.

* **Bug Fixes**
  * Fixed query invalidation to properly refresh auth-sensitive data during profile switching.
  * Improved loading state handling during authentication transitions.
  * Fixed notification handling to correctly skip stale requests during wallet changes.

* **Tests**
  * Extended test coverage for profile switching and authentication state scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


