### PR TITLE
[codex] Restore help bot frontend follow-ups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,16 @@ is available, use it; otherwise read the relevant files in
 
 - User-facing docs live under `ops/docs/`. Update them when visible behavior,
   routes, loading/empty/error states, or user workflows change.
+- When adding or changing user-facing routes, terminology, workflows, prominent
+  controls, empty states, or navigation that users may ask `@help6529` about,
+  update the 6529 Help Bot corpus in the same PR. The frontend-owned source is
+  `ops/help/help-index.json`, and `6529 run help-index:sync` validates it and
+  publishes `public/help-index.json` for the backend runtime to consume from the
+  deployed site. Keep the spec
+  `ops/docs/specs/2026-06-19-6529-help-bot-knowledge-index.md`, source records,
+  generated artifact, and any future `data-help-*` metadata aligned with the
+  changed UI. Do not rely on the backend or LLM to discover new frontend routes,
+  links, or controls at answer time.
 - Treat `ops/docs/` as curated product docs, not a complete source of truth.
   Compare docs against `app/**/page.tsx`, `app/**/route.ts`, components, API
   helpers, tests, and configs before making behavior claims.

--- a/__tests__/app/api/meme-calendar/current.route.test.ts
+++ b/__tests__/app/api/meme-calendar/current.route.test.ts
@@ -1,0 +1,84 @@
+const nextResponseJson = jest.fn();
+
+jest.mock("next/server", () => ({
+  NextResponse: { json: nextResponseJson },
+}));
+
+import {
+  MEME_CALENDAR_API_CACHE_HEADERS,
+  getCurrentMintTimelineDetails,
+  getNextMintTimelineDetails,
+} from "@/app/api/meme-calendar/meme-calendar-response";
+import { GET } from "@/app/api/meme-calendar/current/route";
+
+describe("/api/meme-calendar/current", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    nextResponseJson.mockReset();
+    nextResponseJson.mockImplementation((body: unknown) => ({
+      status: 200,
+      body,
+      json: async () => body,
+    }));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns the live mint when the current mint window is open", async () => {
+    jest.setSystemTime(new Date("2024-07-03T15:00:00.000Z"));
+    const expected = getCurrentMintTimelineDetails(new Date());
+    expect(expected).not.toBeNull();
+    if (!expected) {
+      throw new Error("Expected a live mint timeline");
+    }
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(nextResponseJson).toHaveBeenCalledWith(
+      {
+        status: "live",
+        current: {
+          mint_number: expected.mintNumber,
+          mint_date: "2024-07-03",
+          mint_start: "2024-07-03T14:40:00.000Z",
+          mint_end: "2024-07-04T14:00:00.000Z",
+          status: "live",
+          season: expected.seasonNumber,
+          year: expected.yearNumber,
+          epoch: expected.epochNumber,
+          period: expected.periodNumber,
+          era: expected.eraNumber,
+          eon: expected.eonNumber,
+          calendar_path: "/meme-calendar",
+          mint_path: `/the-memes/${expected.mintNumber}`,
+        },
+      },
+      { headers: MEME_CALENDAR_API_CACHE_HEADERS }
+    );
+  });
+
+  it("returns the next mint when nothing is live", async () => {
+    jest.setSystemTime(new Date("2024-07-03T12:00:00.000Z"));
+    const expected = getNextMintTimelineDetails(new Date());
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(nextResponseJson).toHaveBeenCalledWith(
+      {
+        status: "none",
+        current: null,
+        next: expect.objectContaining({
+          mint_number: expected.mintNumber,
+          mint_start: "2024-07-03T14:40:00.000Z",
+          mint_end: "2024-07-04T14:00:00.000Z",
+          status: "upcoming",
+        }),
+      },
+      { headers: MEME_CALENDAR_API_CACHE_HEADERS }
+    );
+  });
+});

--- a/__tests__/app/api/meme-calendar/id.route.test.ts
+++ b/__tests__/app/api/meme-calendar/id.route.test.ts
@@ -85,7 +85,7 @@ describe("/api/meme-calendar/[id]", () => {
     }
   );
 
-  it("returns 400 for values above max safe integer", async () => {
+  it("returns 400 for oversized numeric ids", async () => {
     const response = await GET({} as any, {
       params: Promise.resolve({ id: "9007199254740992" }),
     });

--- a/__tests__/app/api/meme-calendar/id.route.test.ts
+++ b/__tests__/app/api/meme-calendar/id.route.test.ts
@@ -8,10 +8,16 @@ import {
   getMintTimelineDetails,
   toISO,
 } from "@/components/meme-calendar/meme-calendar.helpers";
+import {
+  MEME_CALENDAR_API_CACHE_HEADERS,
+  getMintTimelineStatus,
+} from "@/app/api/meme-calendar/meme-calendar-response";
 import { GET } from "@/app/api/meme-calendar/[id]/route";
 
 describe("/api/meme-calendar/[id]", () => {
   beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
     nextResponseJson.mockReset();
     nextResponseJson.mockImplementation(
       (
@@ -27,24 +33,38 @@ describe("/api/meme-calendar/[id]", () => {
     );
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it("returns mint calendar fields for a valid id", async () => {
     const id = 500;
     const expected = getMintTimelineDetails(id);
+    const now = new Date();
 
     const response = await GET({} as any, {
       params: Promise.resolve({ id: String(id) }),
     });
 
     expect(response.status).toBe(200);
-    expect(nextResponseJson).toHaveBeenCalledWith({
-      mint_date: toISO(expected.instantUtc),
-      season: expected.seasonNumber,
-      year: expected.yearNumber,
-      epoch: expected.epochNumber,
-      period: expected.periodNumber,
-      era: expected.eraNumber,
-      eon: expected.eonNumber,
-    });
+    expect(nextResponseJson).toHaveBeenCalledWith(
+      {
+        mint_number: expected.mintNumber,
+        mint_date: toISO(expected.instantUtc),
+        mint_start: expected.instantUtc.toISOString(),
+        mint_end: expected.mintEndUtc.toISOString(),
+        status: getMintTimelineStatus(expected, now),
+        season: expected.seasonNumber,
+        year: expected.yearNumber,
+        epoch: expected.epochNumber,
+        period: expected.periodNumber,
+        era: expected.eraNumber,
+        eon: expected.eonNumber,
+        calendar_path: "/meme-calendar",
+        mint_path: `/the-memes/${id}`,
+      },
+      { headers: MEME_CALENDAR_API_CACHE_HEADERS }
+    );
   });
 
   it.each(["abc", "1.5", "-7", "0"])(
@@ -58,7 +78,7 @@ describe("/api/meme-calendar/[id]", () => {
       expect(nextResponseJson).toHaveBeenCalledWith(
         {
           error:
-            "Invalid id. Use a positive integer in /api/meme-calendar/<id>.",
+            "Invalid id. Use a positive integer up to 100000 in /api/meme-calendar/<id>.",
         },
         { status: 400 }
       );
@@ -74,7 +94,22 @@ describe("/api/meme-calendar/[id]", () => {
     expect(nextResponseJson).toHaveBeenCalledWith(
       {
         error:
-          "Invalid id. Use a positive integer in /api/meme-calendar/<id>.",
+          "Invalid id. Use a positive integer up to 100000 in /api/meme-calendar/<id>.",
+      },
+      { status: 400 }
+    );
+  });
+
+  it("returns 400 for values above the supported calendar lookup range", async () => {
+    const response = await GET({} as any, {
+      params: Promise.resolve({ id: "100001" }),
+    });
+
+    expect(response.status).toBe(400);
+    expect(nextResponseJson).toHaveBeenCalledWith(
+      {
+        error:
+          "Invalid id. Use a positive integer up to 100000 in /api/meme-calendar/<id>.",
       },
       { status: 400 }
     );

--- a/__tests__/app/api/meme-calendar/next.route.test.ts
+++ b/__tests__/app/api/meme-calendar/next.route.test.ts
@@ -1,0 +1,55 @@
+const nextResponseJson = jest.fn();
+
+jest.mock("next/server", () => ({
+  NextResponse: { json: nextResponseJson },
+}));
+
+import {
+  MEME_CALENDAR_API_CACHE_HEADERS,
+  getNextMintTimelineDetails,
+  getMintTimelineStatus,
+} from "@/app/api/meme-calendar/meme-calendar-response";
+import { GET } from "@/app/api/meme-calendar/next/route";
+
+describe("/api/meme-calendar/next", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2024-07-03T12:00:00.000Z"));
+    nextResponseJson.mockReset();
+    nextResponseJson.mockImplementation((body: unknown) => ({
+      status: 200,
+      body,
+      json: async () => body,
+    }));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("returns the next upcoming mint with its full mint window", async () => {
+    const now = new Date();
+    const expected = getNextMintTimelineDetails(now);
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(nextResponseJson).toHaveBeenCalledWith(
+      {
+        mint_number: expected.mintNumber,
+        mint_date: "2024-07-03",
+        mint_start: "2024-07-03T14:40:00.000Z",
+        mint_end: "2024-07-04T14:00:00.000Z",
+        status: getMintTimelineStatus(expected, now),
+        season: expected.seasonNumber,
+        year: expected.yearNumber,
+        epoch: expected.epochNumber,
+        period: expected.periodNumber,
+        era: expected.eraNumber,
+        eon: expected.eonNumber,
+        calendar_path: "/meme-calendar",
+        mint_path: `/the-memes/${expected.mintNumber}`,
+      },
+      { headers: MEME_CALENDAR_API_CACHE_HEADERS }
+    );
+  });
+});

--- a/__tests__/components/brain/my-stream/MyStreamWaveChat.test.tsx
+++ b/__tests__/components/brain/my-stream/MyStreamWaveChat.test.tsx
@@ -27,6 +27,7 @@ const mockRemoveAllDeliveredNotifications = jest
 const invalidateNotificationsMock = jest.fn();
 const mockUseAuth = jest.fn();
 const mockApprovalStatus = jest.fn();
+const mockFetchAroundSerialNo = jest.fn();
 
 let documentVisibilityState: DocumentVisibilityState = "visible";
 
@@ -136,6 +137,12 @@ jest.mock("@/contexts/wave/UnreadDividerContext", () => ({
   }),
 }));
 
+jest.mock("@/contexts/wave/MyStreamContext", () => ({
+  useMyStream: () => ({
+    fetchAroundSerialNo: mockFetchAroundSerialNo,
+  }),
+}));
+
 jest.mock("@/components/waves/gallery", () => ({
   WaveGallery: () => <div data-testid="gallery" />,
 }));
@@ -202,6 +209,7 @@ describe("MyStreamWaveChat", () => {
     mockRemoveWaveDeliveredNotifications.mockClear();
     mockRemoveAllDeliveredNotifications.mockClear();
     invalidateNotificationsMock.mockClear();
+    mockFetchAroundSerialNo.mockClear();
     mockApprovalStatus.mockReset();
     mockApprovalStatus.mockReturnValue({
       winningThreshold: null,
@@ -673,6 +681,7 @@ describe("MyStreamWaveChat", () => {
 
     expect(screen.getByTestId("gallery")).toBeInTheDocument();
     expect(replaceMock).not.toHaveBeenCalled();
+    expect(mockFetchAroundSerialNo).not.toHaveBeenCalled();
 
     rerender(
       <ReactQueryWrapperContext.Provider
@@ -692,6 +701,27 @@ describe("MyStreamWaveChat", () => {
     await waitFor(() => {
       expect(replaceMock).toHaveBeenCalledTimes(1);
       expect(capturedPropsHolder.current.initialDrop).toBe(5);
+      expect(mockFetchAroundSerialNo).toHaveBeenCalledWith("10", 5);
+    });
+  });
+
+  it("hydrates the serial target when opening a wave from a route param", async () => {
+    searchParamsMock.get.mockImplementation((key: string) =>
+      key === "serialNo" ? "6679" : null
+    );
+    searchParamsMock.toString.mockReturnValue("serialNo=6679");
+
+    renderWithProvider(
+      <MyStreamWaveChat
+        wave={wave}
+        firstUnreadSerialNo={null}
+        viewMode="chat"
+        onDropClick={mockOnDropClick}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockFetchAroundSerialNo).toHaveBeenCalledWith("10", 6679);
     });
   });
 

--- a/__tests__/components/react-query-wrapper/utils/addDropsToDrops.test.ts
+++ b/__tests__/components/react-query-wrapper/utils/addDropsToDrops.test.ts
@@ -119,3 +119,41 @@ test("replaces existing websocket drops instead of duplicating them", () => {
     drop,
   ]);
 });
+
+test("skips media-only caches when a websocket drop omits parts", () => {
+  const qc = new QueryClient();
+  const mediaKey = [
+    QueryKey.DROPS,
+    {
+      waveId: "w",
+      limit: 20,
+      dropType: null,
+      containsMedia: true,
+      curationId: null,
+      context: "wave-drops",
+    },
+  ];
+  const regularKey = [
+    QueryKey.DROPS,
+    {
+      waveId: "w",
+      limit: 20,
+      dropType: null,
+      containsMedia: false,
+      curationId: null,
+      context: "wave-drops",
+    },
+  ];
+  qc.setQueryData(mediaKey, { pages: [{ drops: [{ id: "media-old" }] }] });
+  qc.setQueryData(regularKey, { pages: [{ drops: [{ id: "regular-old" }] }] });
+
+  const drop: any = { id: "partial-websocket-drop", wave: { id: "w" } };
+  upsertDropIntoMatchingDropsQueries(qc, { drop });
+
+  expect((qc.getQueryData(mediaKey) as any).pages[0].drops[0].id).toBe(
+    "media-old"
+  );
+  expect((qc.getQueryData(regularKey) as any).pages[0].drops[0].id).toBe(
+    "partial-websocket-drop"
+  );
+});

--- a/__tests__/components/react-query-wrapper/utils/addDropsToDrops.test.ts
+++ b/__tests__/components/react-query-wrapper/utils/addDropsToDrops.test.ts
@@ -59,6 +59,28 @@ test("upserts websocket drops into active wave feed caches", () => {
   );
 });
 
+test("skips media-filtered caches when websocket drop omits parts", () => {
+  const qc = new QueryClient();
+  const activeWaveKey = [
+    QueryKey.DROPS,
+    {
+      waveId: "w",
+      limit: 20,
+      dropType: null,
+      containsMedia: true,
+      curationId: null,
+      context: "wave-drops",
+    },
+  ];
+  qc.setQueryData(activeWaveKey, { pages: [{ drops: [{ id: "old" }] }] });
+
+  const drop: any = { id: "new", wave: { id: "w" } };
+  expect(() => upsertDropIntoMatchingDropsQueries(qc, { drop })).not.toThrow();
+  expect((qc.getQueryData(activeWaveKey) as any).pages[0].drops[0].id).toBe(
+    "old"
+  );
+});
+
 test("upserts websocket reply drops into matching reply caches", () => {
   const qc = new QueryClient();
   const baseKey = [QueryKey.DROPS, { limit: 50, waveId: "w", dropId: null }];

--- a/__tests__/components/react-query-wrapper/utils/addDropsToDrops.test.ts
+++ b/__tests__/components/react-query-wrapper/utils/addDropsToDrops.test.ts
@@ -1,15 +1,121 @@
-import { QueryClient } from '@tanstack/react-query';
-import { addDropToDrops } from '@/components/react-query-wrapper/utils/addDropsToDrops';
-import { QueryKey } from '@/components/react-query-wrapper/ReactQueryWrapper';
+import { QueryClient } from "@tanstack/react-query";
+import {
+  addDropToDrops,
+  upsertDropIntoMatchingDropsQueries,
+} from "@/components/react-query-wrapper/utils/addDropsToDrops";
+import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 
-test('adds drop to relevant caches', () => {
+test("adds drop to relevant caches", () => {
   const qc = new QueryClient();
-  const baseKey = [QueryKey.DROPS, { limit: 50, waveId: 'w', dropId: null }];
-  const replyKey = [QueryKey.DROPS, { limit: 50, waveId: 'w', dropId: 'r' }];
-  qc.setQueryData(baseKey, { pages: [{ drops: [{ id: 'old' }] }] });
-  qc.setQueryData(replyKey, { pages: [{ drops: [{ id: 'old' }] }] });
-  const drop: any = { id: 'new', wave: { id: 'w' }, reply_to: { drop_id: 'r' } };
+  const baseKey = [QueryKey.DROPS, { limit: 50, waveId: "w", dropId: null }];
+  const replyKey = [QueryKey.DROPS, { limit: 50, waveId: "w", dropId: "r" }];
+  qc.setQueryData(baseKey, { pages: [{ drops: [{ id: "old" }] }] });
+  qc.setQueryData(replyKey, { pages: [{ drops: [{ id: "old" }] }] });
+  const drop: any = {
+    id: "new",
+    wave: { id: "w" },
+    reply_to: { drop_id: "r" },
+  };
   addDropToDrops(qc, { drop });
-  expect((qc.getQueryData(baseKey) as any).pages[0].drops[0].id).toBe('new');
-  expect((qc.getQueryData(replyKey) as any).pages[0].drops[0].id).toBe('new');
+  expect((qc.getQueryData(baseKey) as any).pages[0].drops[0].id).toBe("new");
+  expect((qc.getQueryData(replyKey) as any).pages[0].drops[0].id).toBe("new");
+});
+
+test("upserts websocket drops into active wave feed caches", () => {
+  const qc = new QueryClient();
+  const activeWaveKey = [
+    QueryKey.DROPS,
+    {
+      waveId: "w",
+      limit: 20,
+      dropType: null,
+      containsMedia: false,
+      curationId: null,
+      context: "wave-drops",
+    },
+  ];
+  const otherWaveKey = [
+    QueryKey.DROPS,
+    {
+      waveId: "other",
+      limit: 20,
+      dropType: null,
+      containsMedia: false,
+      curationId: null,
+      context: "wave-drops",
+    },
+  ];
+  qc.setQueryData(activeWaveKey, { pages: [{ drops: [{ id: "old" }] }] });
+  qc.setQueryData(otherWaveKey, { pages: [{ drops: [{ id: "other-old" }] }] });
+
+  const drop: any = { id: "new", wave: { id: "w" }, parts: [] };
+  upsertDropIntoMatchingDropsQueries(qc, { drop });
+
+  expect((qc.getQueryData(activeWaveKey) as any).pages[0].drops[0].id).toBe(
+    "new"
+  );
+  expect((qc.getQueryData(otherWaveKey) as any).pages[0].drops[0].id).toBe(
+    "other-old"
+  );
+});
+
+test("upserts websocket reply drops into matching reply caches", () => {
+  const qc = new QueryClient();
+  const baseKey = [QueryKey.DROPS, { limit: 50, waveId: "w", dropId: null }];
+  const matchingReplyKey = [
+    QueryKey.DROPS,
+    { limit: 50, waveId: "w", dropId: "parent-drop" },
+  ];
+  const otherReplyKey = [
+    QueryKey.DROPS,
+    { limit: 50, waveId: "w", dropId: "other-parent" },
+  ];
+  qc.setQueryData(baseKey, { pages: [{ drops: [{ id: "old" }] }] });
+  qc.setQueryData(matchingReplyKey, {
+    pages: [{ drops: [{ id: "reply-old" }] }],
+  });
+  qc.setQueryData(otherReplyKey, { pages: [{ drops: [{ id: "other-old" }] }] });
+
+  const drop: any = {
+    id: "bot-reply",
+    wave: { id: "w" },
+    reply_to: { drop_id: "parent-drop" },
+    parts: [],
+  };
+  upsertDropIntoMatchingDropsQueries(qc, { drop });
+
+  expect((qc.getQueryData(baseKey) as any).pages[0].drops[0].id).toBe(
+    "bot-reply"
+  );
+  expect((qc.getQueryData(matchingReplyKey) as any).pages[0].drops[0].id).toBe(
+    "bot-reply"
+  );
+  expect((qc.getQueryData(otherReplyKey) as any).pages[0].drops[0].id).toBe(
+    "other-old"
+  );
+});
+
+test("replaces existing websocket drops instead of duplicating them", () => {
+  const qc = new QueryClient();
+  const activeWaveKey = [
+    QueryKey.DROPS,
+    {
+      waveId: "w",
+      limit: 20,
+      dropType: null,
+      containsMedia: false,
+      curationId: null,
+      context: "wave-drops",
+    },
+  ];
+  qc.setQueryData(activeWaveKey, {
+    pages: [{ drops: [{ id: "drop-1", rating: 1 }] }],
+  });
+
+  const drop: any = { id: "drop-1", rating: 2, wave: { id: "w" }, parts: [] };
+  upsertDropIntoMatchingDropsQueries(qc, { drop });
+
+  expect((qc.getQueryData(activeWaveKey) as any).pages[0].drops).toEqual([
+    drop,
+  ]);
 });

--- a/__tests__/hooks/useDropMessages.test.ts
+++ b/__tests__/hooks/useDropMessages.test.ts
@@ -1,6 +1,7 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { UseInfiniteQueryResult } from '@tanstack/react-query';
+import { QueryKey } from '@/components/react-query-wrapper/ReactQueryWrapper';
 
 // Setup mock for useInfiniteQuery so tests can control its behaviour
 const useInfiniteQueryMock = jest.fn();
@@ -26,8 +27,8 @@ jest.mock('@/services/api/common-api', () => ({
   commonApiFetch: jest.fn().mockResolvedValue({ drops: [], wave: null }),
 }));
 
-const createWrapper = () => {
-  const queryClient = new QueryClient({
+const createQueryClient = () =>
+  new QueryClient({
     defaultOptions: {
       queries: {
         retry: false,
@@ -35,6 +36,8 @@ const createWrapper = () => {
       },
     },
   });
+
+const createWrapper = (queryClient = createQueryClient()) => {
   return ({ children }: { children: React.ReactNode }) =>
     React.createElement(QueryClientProvider, { client: queryClient }, children);
 };
@@ -129,6 +132,55 @@ describe('useDropMessages', () => {
     unmount();
     jest.useRealTimers();
   });
+});
+
+it('upserts websocket replies into the matching reply cache', () => {
+  const refetch = jest.fn().mockResolvedValue(undefined);
+  useInfiniteQueryMock.mockReturnValue({
+    data: { pages: [] },
+    fetchNextPage: jest.fn(),
+    hasNextPage: false,
+    isFetching: false,
+    isFetchingNextPage: false,
+    refetch,
+  } as Partial<UseInfiniteQueryResult>);
+
+  let wsCallback: any;
+  const {
+    useWebSocketMessage,
+  } = require('@/services/websocket/useWebSocketMessage');
+  (useWebSocketMessage as jest.Mock).mockImplementation((type, cb) => {
+    if (type === 'DROP_UPDATE') {
+      wsCallback = cb;
+    }
+    return { isConnected: true };
+  });
+
+  const queryClient = createQueryClient();
+  const replyQueryKey = [
+    QueryKey.DROPS,
+    { waveId: 'wave-x', limit: 50, dropId: 'drop-y' },
+  ];
+  queryClient.setQueryData(replyQueryKey, {
+    pages: [{ drops: [{ id: 'old-reply' }] }],
+  });
+
+  renderHook(() => useDropMessages('wave-x', 'drop-y'), {
+    wrapper: createWrapper(queryClient),
+  });
+
+  act(() => {
+    wsCallback({
+      id: 'bot-reply',
+      wave: { id: 'wave-x' },
+      reply_to: { drop_id: 'drop-y' },
+      parts: [],
+    });
+  });
+
+  expect(
+    (queryClient.getQueryData(replyQueryKey) as any).pages[0].drops[0].id
+  ).toBe('bot-reply');
 });
 it('ignores websocket messages when dropId is null', () => {
   const refetch = jest.fn();

--- a/__tests__/hooks/useWaveDrops.test.ts
+++ b/__tests__/hooks/useWaveDrops.test.ts
@@ -20,7 +20,11 @@ const fetchWaveDropsFeedV2Mock = fetchWaveDropsFeedV2 as jest.Mock;
 describe("useWaveDrops", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useQueryClientMock.mockReturnValue({ setQueriesData: jest.fn() });
+    useQueryClientMock.mockReturnValue({
+      getQueryCache: jest.fn(() => ({ findAll: jest.fn(() => []) })),
+      setQueriesData: jest.fn(),
+      setQueryData: jest.fn(),
+    });
     useInfiniteQueryMock.mockReturnValue({
       data: { pages: [] },
       fetchNextPage: jest.fn(),

--- a/__tests__/useWaveRealtimeUpdater.test.ts
+++ b/__tests__/useWaveRealtimeUpdater.test.ts
@@ -336,6 +336,53 @@ describe("useWaveRealtimeUpdater", () => {
     );
   });
 
+  it("does not sync newest messages after helpbot reactions without a known serial", async () => {
+    const store = {
+      wave1: {
+        drops: [
+          {
+            id: "helpbot-no-serial",
+            type: DropSize.FULL,
+            stableKey: "helpbot-no-serial",
+            stableHash: "helpbot-no-serial",
+            author: {},
+          },
+        ],
+        latestFetchedSerialNo: null,
+      },
+    };
+    const props = baseProps(store);
+    fetchDropByIdBatched.mockResolvedValue({
+      id: "helpbot-no-serial",
+      author: {},
+      wave: { id: "wave1" },
+      context_profile_context: null,
+    });
+    const { result } = renderHook(() => useWaveRealtimeUpdater(props));
+    const drop: any = {
+      id: "helpbot-no-serial",
+      wave: { id: "wave1" },
+      author: {},
+      reactions: [
+        {
+          reaction: ":white_check_mark:",
+          profiles: [{ handle: "help6529" }],
+        },
+      ],
+    };
+
+    await act(async () =>
+      result.current.processIncomingDrop(
+        drop,
+        ProcessIncomingDropType.DROP_REACTION_UPDATE
+      )
+    );
+    await flushPromises();
+
+    expect(fetchDropByIdBatched).toHaveBeenCalledWith("helpbot-no-serial");
+    expect(props.syncNewestMessages).not.toHaveBeenCalled();
+  });
+
   it("marks active wave as read after visible reaction updates", async () => {
     const store = {
       wave1: {

--- a/__tests__/useWaveRealtimeUpdater.test.ts
+++ b/__tests__/useWaveRealtimeUpdater.test.ts
@@ -6,6 +6,9 @@ import {
 import { DropSize } from "@/helpers/waves/drop.helpers";
 
 const mockSetQueriesData = jest.fn();
+const mockSetQueryData = jest.fn();
+const mockCancelQueries = jest.fn().mockResolvedValue(undefined);
+const mockFindAll = jest.fn(() => []);
 
 jest.mock("@/services/websocket/useWebSocketMessage", () => ({
   useWebSocketMessage: () => ({ isConnected: true }),
@@ -55,6 +58,11 @@ jest.mock("@/contexts/wave/drop-visibility", () => ({
 
 jest.mock("@tanstack/react-query", () => ({
   useQueryClient: jest.fn(() => ({
+    cancelQueries: mockCancelQueries,
+    getQueryCache: () => ({
+      findAll: mockFindAll,
+    }),
+    setQueryData: mockSetQueryData,
     setQueriesData: mockSetQueriesData,
   })),
 }));
@@ -218,6 +226,114 @@ describe("useWaveRealtimeUpdater", () => {
     });
     expect(mockSetQueriesData).toHaveBeenCalled();
     expect(props.updateData).toHaveBeenCalled();
+  });
+
+  it("syncs newest messages after helpbot final reaction updates", async () => {
+    const store = {
+      wave1: {
+        drops: [
+          {
+            id: "helpbot-target",
+            type: DropSize.FULL,
+            stableKey: "helpbot-target",
+            stableHash: "helpbot-target",
+            serial_no: 20,
+            author: {},
+          },
+        ],
+        latestFetchedSerialNo: 20,
+      },
+    };
+    const props = baseProps(store);
+    fetchDropByIdBatched.mockResolvedValue({
+      id: "helpbot-target",
+      author: {},
+      wave: { id: "wave1" },
+      context_profile_context: null,
+    });
+    const { result } = renderHook(() => useWaveRealtimeUpdater(props));
+    const drop: any = {
+      id: "helpbot-target",
+      wave: { id: "wave1" },
+      author: {},
+      reactions: [
+        {
+          reaction: ":white_check_mark:",
+          profiles: [{ handle: "help6529" }],
+        },
+      ],
+    };
+
+    await act(async () =>
+      result.current.processIncomingDrop(
+        drop,
+        ProcessIncomingDropType.DROP_REACTION_UPDATE
+      )
+    );
+    await flushPromises();
+
+    expect(props.syncNewestMessages).toHaveBeenCalledWith(
+      "wave1",
+      20,
+      expect.any(AbortSignal)
+    );
+  });
+
+  it("syncs newest messages after helpbot final reactions without reaction profile handles", async () => {
+    const store = {
+      wave1: {
+        drops: [
+          {
+            id: "helpbot-target",
+            type: DropSize.FULL,
+            stableKey: "helpbot-target",
+            stableHash: "helpbot-target",
+            serial_no: 20,
+            author: {},
+          },
+        ],
+        latestFetchedSerialNo: 20,
+      },
+    };
+    const props = baseProps(store);
+    fetchDropByIdBatched.mockResolvedValue({
+      id: "helpbot-target",
+      author: {},
+      wave: { id: "wave1" },
+      context_profile_context: null,
+    });
+    const { result } = renderHook(() => useWaveRealtimeUpdater(props));
+    const drop: any = {
+      id: "helpbot-target",
+      wave: { id: "wave1" },
+      author: {},
+      mentioned_users: [
+        {
+          handle_in_content: "help6529",
+          current_handle: "help6529",
+        },
+      ],
+      reactions: [
+        {
+          reaction: ":white_check_mark:",
+          profiles: [{}],
+        },
+      ],
+    };
+
+    await act(async () =>
+      result.current.processIncomingDrop(
+        drop,
+        ProcessIncomingDropType.DROP_REACTION_UPDATE
+      )
+    );
+    await flushPromises();
+
+    expect(props.syncNewestMessages).toHaveBeenCalledWith(
+      "wave1",
+      20,
+      expect.any(AbortSignal)
+    );
   });
 
   it("marks active wave as read after visible reaction updates", async () => {

--- a/__tests__/useWaveRealtimeUpdater.test.ts
+++ b/__tests__/useWaveRealtimeUpdater.test.ts
@@ -383,6 +383,65 @@ describe("useWaveRealtimeUpdater", () => {
     expect(props.syncNewestMessages).not.toHaveBeenCalled();
   });
 
+  it("syncs newest messages after helpbot final reactions even when canonical reaction is stale", async () => {
+    const store = {
+      wave1: {
+        drops: [
+          {
+            id: "helpbot-stale-target",
+            type: DropSize.FULL,
+            stableKey: "helpbot-stale-target",
+            stableHash: "helpbot-stale-target",
+            serial_no: 20,
+            author: {},
+          },
+        ],
+        latestFetchedSerialNo: 20,
+      },
+    };
+    const props = baseProps(store);
+    fetchDropByIdBatched.mockResolvedValue({
+      id: "helpbot-stale-target",
+      author: {},
+      wave: { id: "wave1" },
+      context_profile_context: { reaction: ":old:" },
+    });
+    (recordReactionRealtimeReconciliation as jest.Mock).mockReturnValueOnce({
+      shouldApplyCanonicalDrop: false,
+      expectedReaction: ":new:",
+      serverReaction: ":old:",
+      supersededByMutationId: "mutation-2",
+    });
+    const { result } = renderHook(() => useWaveRealtimeUpdater(props));
+    const drop: any = {
+      id: "helpbot-stale-target",
+      wave: { id: "wave1" },
+      author: {},
+      reactions: [
+        {
+          reaction: ":white_check_mark:",
+          profiles: [{ handle: "help6529" }],
+        },
+      ],
+    };
+
+    await act(async () =>
+      result.current.processIncomingDrop(
+        drop,
+        ProcessIncomingDropType.DROP_REACTION_UPDATE
+      )
+    );
+    await flushPromises();
+
+    expect(props.updateData).not.toHaveBeenCalled();
+    expect(mockSetQueriesData).not.toHaveBeenCalled();
+    expect(props.syncNewestMessages).toHaveBeenCalledWith(
+      "wave1",
+      20,
+      expect.any(AbortSignal)
+    );
+  });
+
   it("marks active wave as read after visible reaction updates", async () => {
     const store = {
       wave1: {

--- a/app/api/meme-calendar/[id]/route.ts
+++ b/app/api/meme-calendar/[id]/route.ts
@@ -1,15 +1,20 @@
-import {
-  getMintTimelineDetails,
-  toISO,
-} from "@/components/meme-calendar/meme-calendar.helpers";
+import { getMintTimelineDetails } from "@/components/meme-calendar/meme-calendar.helpers";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import {
+  buildMemeCalendarMintResponse,
+  MEME_CALENDAR_API_CACHE_HEADERS,
+} from "../meme-calendar-response";
 
 const POSITIVE_INTEGER_PATTERN = /^[1-9]\d*$/;
+const MAX_MINT_ID = 100_000;
 
 const invalidIdResponse = () =>
   NextResponse.json(
-    { error: "Invalid id. Use a positive integer in /api/meme-calendar/<id>." },
+    {
+      error:
+        "Invalid id. Use a positive integer up to 100000 in /api/meme-calendar/<id>.",
+    },
     { status: 400 }
   );
 
@@ -28,7 +33,7 @@ function parseMintId(id: string): number | null {
   }
 
   const mintId = Number(id);
-  if (!Number.isSafeInteger(mintId)) {
+  if (!Number.isSafeInteger(mintId) || mintId > MAX_MINT_ID) {
     return null;
   }
 
@@ -47,19 +52,14 @@ export async function GET(
   }
 
   try {
+    const now = new Date();
     const timeline = getMintTimelineDetails(mintId);
     if (!Number.isFinite(timeline.instantUtc.getTime())) {
       return unresolvedTimelineResponse();
     }
 
-    return NextResponse.json({
-      mint_date: toISO(timeline.instantUtc),
-      season: timeline.seasonNumber,
-      year: timeline.yearNumber,
-      epoch: timeline.epochNumber,
-      period: timeline.periodNumber,
-      era: timeline.eraNumber,
-      eon: timeline.eonNumber,
+    return NextResponse.json(buildMemeCalendarMintResponse(timeline, now), {
+      headers: MEME_CALENDAR_API_CACHE_HEADERS,
     });
   } catch {
     return unresolvedTimelineResponse();

--- a/app/api/meme-calendar/current/route.ts
+++ b/app/api/meme-calendar/current/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import {
+  buildMemeCalendarMintResponse,
+  getCurrentMintTimelineDetails,
+  getNextMintTimelineDetails,
+  MEME_CALENDAR_API_CACHE_HEADERS,
+} from "../meme-calendar-response";
+
+export async function GET() {
+  const now = new Date();
+  const current = getCurrentMintTimelineDetails(now);
+
+  if (current) {
+    return NextResponse.json(
+      {
+        status: "live",
+        current: buildMemeCalendarMintResponse(current, now),
+      },
+      { headers: MEME_CALENDAR_API_CACHE_HEADERS }
+    );
+  }
+
+  const next = getNextMintTimelineDetails(now);
+
+  return NextResponse.json(
+    {
+      status: "none",
+      current: null,
+      next: buildMemeCalendarMintResponse(next, now),
+    },
+    { headers: MEME_CALENDAR_API_CACHE_HEADERS }
+  );
+}

--- a/app/api/meme-calendar/meme-calendar-response.ts
+++ b/app/api/meme-calendar/meme-calendar-response.ts
@@ -62,6 +62,8 @@ export function getCurrentMintTimelineDetails(
   const candidates = [nextTimeline, currentOrPreviousTimeline];
   const previousMintNumber = currentOrPreviousTimeline.mintNumber - 1;
   if (previousMintNumber > 0) {
+    // Meme mint windows are shorter than the regular mint cadence, so the
+    // live window can only be the date-derived mint or its immediate neighbor.
     candidates.push(getMintTimelineDetails(previousMintNumber));
   }
 

--- a/app/api/meme-calendar/meme-calendar-response.ts
+++ b/app/api/meme-calendar/meme-calendar-response.ts
@@ -12,9 +12,9 @@ export const MEME_CALENDAR_API_CACHE_HEADERS = {
   "Cache-Control": "public, max-age=30, s-maxage=60, stale-while-revalidate=60",
 } as const;
 
-export const MEME_CALENDAR_PATH = "/meme-calendar";
+const MEME_CALENDAR_PATH = "/meme-calendar";
 
-export const getMemeCalendarMintPath = (mintNumber: number) =>
+const getMemeCalendarMintPath = (mintNumber: number) =>
   `/the-memes/${mintNumber}`;
 
 interface MemeCalendarMintResponse {

--- a/app/api/meme-calendar/meme-calendar-response.ts
+++ b/app/api/meme-calendar/meme-calendar-response.ts
@@ -1,0 +1,94 @@
+import {
+  getCanonicalNextMintNumber,
+  getMintNumberForMintDate,
+  getMintTimelineDetails,
+  toISO,
+} from "@/components/meme-calendar/meme-calendar.helpers";
+
+type MintTimelineDetails = ReturnType<typeof getMintTimelineDetails>;
+type MintTimelineStatus = "past" | "live" | "upcoming";
+
+export const MEME_CALENDAR_API_CACHE_HEADERS = {
+  "Cache-Control": "public, max-age=30, s-maxage=60, stale-while-revalidate=60",
+} as const;
+
+export const MEME_CALENDAR_PATH = "/meme-calendar";
+
+export const getMemeCalendarMintPath = (mintNumber: number) =>
+  `/the-memes/${mintNumber}`;
+
+interface MemeCalendarMintResponse {
+  readonly mint_number: number;
+  readonly mint_date: string;
+  readonly mint_start: string;
+  readonly mint_end: string;
+  readonly status: MintTimelineStatus;
+  readonly season: number;
+  readonly year: number;
+  readonly epoch: number;
+  readonly period: number;
+  readonly era: number;
+  readonly eon: number;
+  readonly calendar_path: string;
+  readonly mint_path: string;
+}
+
+export function getMintTimelineStatus(
+  timeline: MintTimelineDetails,
+  now: Date = new Date()
+): MintTimelineStatus {
+  if (now < timeline.instantUtc) {
+    return "upcoming";
+  }
+  if (now < timeline.mintEndUtc) {
+    return "live";
+  }
+  return "past";
+}
+
+export function getNextMintTimelineDetails(
+  now: Date = new Date()
+): MintTimelineDetails {
+  return getMintTimelineDetails(getCanonicalNextMintNumber(now));
+}
+
+export function getCurrentMintTimelineDetails(
+  now: Date = new Date()
+): MintTimelineDetails | null {
+  const nextTimeline = getNextMintTimelineDetails(now);
+  const currentOrPreviousTimeline = getMintTimelineDetails(
+    getMintNumberForMintDate(now)
+  );
+  const candidates = [nextTimeline, currentOrPreviousTimeline];
+  const previousMintNumber = currentOrPreviousTimeline.mintNumber - 1;
+  if (previousMintNumber > 0) {
+    candidates.push(getMintTimelineDetails(previousMintNumber));
+  }
+
+  return (
+    candidates.find(
+      (timeline) => getMintTimelineStatus(timeline, now) === "live"
+    ) ?? null
+  );
+}
+
+export function buildMemeCalendarMintResponse(
+  timeline: MintTimelineDetails,
+  now: Date = new Date()
+): MemeCalendarMintResponse {
+  return {
+    mint_number: timeline.mintNumber,
+    mint_date: toISO(timeline.instantUtc),
+    mint_start: timeline.instantUtc.toISOString(),
+    mint_end: timeline.mintEndUtc.toISOString(),
+    status: getMintTimelineStatus(timeline, now),
+    season: timeline.seasonNumber,
+    year: timeline.yearNumber,
+    epoch: timeline.epochNumber,
+    period: timeline.periodNumber,
+    era: timeline.eraNumber,
+    eon: timeline.eonNumber,
+    calendar_path: MEME_CALENDAR_PATH,
+    mint_path: getMemeCalendarMintPath(timeline.mintNumber),
+  };
+}

--- a/app/api/meme-calendar/next/route.ts
+++ b/app/api/meme-calendar/next/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+import {
+  buildMemeCalendarMintResponse,
+  getNextMintTimelineDetails,
+  MEME_CALENDAR_API_CACHE_HEADERS,
+} from "../meme-calendar-response";
+
+export async function GET() {
+  const now = new Date();
+  const timeline = getNextMintTimelineDetails(now);
+
+  return NextResponse.json(buildMemeCalendarMintResponse(timeline, now), {
+    headers: MEME_CALENDAR_API_CACHE_HEADERS,
+  });
+}

--- a/components/brain/my-stream/MyStreamWaveChat.tsx
+++ b/components/brain/my-stream/MyStreamWaveChat.tsx
@@ -21,6 +21,7 @@ import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import { WaveSubmissionExperience } from "@/helpers/waves/wave-submission-experience.helpers";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
 import { useMarkWaveNotificationsRead } from "@/hooks/useMarkWaveNotificationsRead";
+import { useMyStream } from "@/contexts/wave/MyStreamContext";
 import { useApprovalWaveStatus } from "@/hooks/waves/useApprovalWaveStatus";
 import type { WaveViewMode } from "@/hooks/useWaveViewMode";
 import { selectEditingDropId } from "@/store/editSlice";
@@ -100,6 +101,7 @@ const MyStreamWaveChat: React.FC<MyStreamWaveChatProps> = ({
   onCloseChatSubmitDrop,
 }) => {
   const router = useRouter();
+  const { fetchAroundSerialNo } = useMyStream();
   // react-doctor-disable-next-line react-doctor/nextjs-no-use-search-params-without-suspense covered by MyStreamWave Suspense wrapper
   const searchParams = useSearchParams();
   const pathname = usePathname();
@@ -186,6 +188,14 @@ const MyStreamWaveChat: React.FC<MyStreamWaveChatProps> = ({
   } else if (capturedDividerState.waveId === wave.id) {
     dividerTarget = capturedDividerState.serialNo;
   }
+
+  useEffect(() => {
+    if (!initialDropState || viewMode === "gallery") {
+      return;
+    }
+
+    fetchAroundSerialNo(wave.id, initialDropState.serialNo);
+  }, [fetchAroundSerialNo, initialDropState, viewMode, wave.id]);
 
   useEffect(() => {
     if (!initialDropState || viewMode === "gallery") {

--- a/components/react-query-wrapper/utils/addDropsToDrops.ts
+++ b/components/react-query-wrapper/utils/addDropsToDrops.ts
@@ -1,7 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query";
 import type { ApiDrop } from "@/generated/models/ApiDrop";
 import type { ApiWaveDropsFeed } from "@/generated/models/ApiWaveDropsFeed";
-import { QueryKey } from "../ReactQueryWrapper";
+import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 
 type DropsQueryData = {
   pages?: ApiWaveDropsFeed[] | undefined;
@@ -16,6 +16,22 @@ type DropsQueryParams = {
 const getDropsQueryKey = (params: DropsQueryParams) =>
   [QueryKey.DROPS, params] as const;
 
+type DropsFeedPage = {
+  drops?: ApiDrop[] | undefined;
+};
+
+type DropsInfiniteData = {
+  pages?: DropsFeedPage[] | undefined;
+};
+
+type DropsCacheQueryParams = {
+  waveId?: unknown;
+  dropId?: unknown;
+  dropType?: unknown;
+  containsMedia?: unknown;
+  curationId?: unknown;
+};
+
 const updateQueryData = (
   oldData: DropsQueryData | undefined,
   drop: ApiDrop
@@ -23,8 +39,18 @@ const updateQueryData = (
   if (!oldData?.pages || oldData.pages.length === 0) {
     return oldData;
   }
-  const pages: ApiWaveDropsFeed[] = JSON.parse(JSON.stringify(oldData.pages));
+  const pages = oldData.pages.map((page) => ({
+    ...page,
+    drops: [...page.drops],
+  }));
   if (pages[0]) {
+    const existingDropIndex = pages[0].drops.findIndex(
+      (cachedDrop) => cachedDrop.id === drop.id
+    );
+    if (existingDropIndex !== -1) {
+      pages[0].drops[existingDropIndex] = drop;
+      return { ...oldData, pages };
+    }
     pages[0].drops.unshift({
       ...drop,
     });
@@ -39,7 +65,7 @@ const updateDropsQuery = (
   drop: ApiDrop
 ) => {
   const queryKey = getDropsQueryKey(queryParams);
-  queryClient.cancelQueries({ queryKey });
+  queryClient.cancelQueries({ queryKey }).catch(() => undefined);
   queryClient.setQueryData<DropsQueryData | undefined>(
     queryKey,
     (oldData) => updateQueryData(oldData, drop),
@@ -66,3 +92,107 @@ export const addDropToDrops = (
     );
   }
 };
+
+function hasMedia(drop: ApiDrop): boolean {
+  return drop.parts.some((part) => part.media.length > 0);
+}
+
+function readDropsQueryParams(queryKey: readonly unknown[]) {
+  const params = queryKey[1];
+  if (typeof params !== "object" || params === null || Array.isArray(params)) {
+    return null;
+  }
+  return params as DropsCacheQueryParams;
+}
+
+function isMatchingDropsQuery(
+  params: DropsCacheQueryParams,
+  drop: ApiDrop
+): boolean {
+  if (params.waveId !== drop.wave.id) {
+    return false;
+  }
+
+  if (
+    params.dropType !== undefined &&
+    params.dropType !== null &&
+    params.dropType !== drop.drop_type
+  ) {
+    return false;
+  }
+
+  if (params.containsMedia === true && !hasMedia(drop)) {
+    return false;
+  }
+
+  if (params.curationId !== undefined && params.curationId !== null) {
+    return false;
+  }
+
+  if (params.dropId === undefined || params.dropId === null) {
+    return true;
+  }
+
+  return (
+    typeof params.dropId === "string" &&
+    drop.reply_to?.drop_id === params.dropId
+  );
+}
+
+function upsertDropInQueryData(
+  oldData: DropsInfiniteData | undefined,
+  drop: ApiDrop
+): DropsInfiniteData | undefined {
+  if (!oldData?.pages || oldData.pages.length === 0) {
+    return oldData;
+  }
+
+  const pages = oldData.pages.map((page) => ({
+    ...page,
+    drops: page.drops ? [...page.drops] : page.drops,
+  }));
+
+  for (const page of pages) {
+    const pageDrops = page.drops;
+    const existingDropIndex = pageDrops?.findIndex(
+      (cachedDrop) => cachedDrop.id === drop.id
+    );
+    if (
+      pageDrops &&
+      existingDropIndex !== undefined &&
+      existingDropIndex !== -1
+    ) {
+      pageDrops[existingDropIndex] = drop;
+      return { ...oldData, pages };
+    }
+  }
+
+  if (!pages[0]?.drops) {
+    return oldData;
+  }
+
+  pages[0].drops.unshift(drop);
+  return { ...oldData, pages };
+}
+
+export function upsertDropIntoMatchingDropsQueries(
+  queryClient: QueryClient,
+  { drop }: { readonly drop: ApiDrop }
+): void {
+  const queries = queryClient
+    .getQueryCache()
+    .findAll({ queryKey: [QueryKey.DROPS] });
+
+  for (const query of queries) {
+    const params = readDropsQueryParams(query.queryKey);
+    if (!params || !isMatchingDropsQuery(params, drop)) {
+      continue;
+    }
+
+    queryClient.setQueryData<DropsInfiniteData | undefined>(
+      query.queryKey,
+      (oldData) => upsertDropInQueryData(oldData, drop),
+      { updatedAt: Date.now() }
+    );
+  }
+}

--- a/components/react-query-wrapper/utils/addDropsToDrops.ts
+++ b/components/react-query-wrapper/utils/addDropsToDrops.ts
@@ -94,7 +94,7 @@ export const addDropToDrops = (
 };
 
 function hasMedia(drop: ApiDrop): boolean {
-  return drop.parts.some((part) => part.media.length > 0);
+  return (drop.parts ?? []).some((part) => part.media.length > 0);
 }
 
 function readDropsQueryParams(queryKey: readonly unknown[]) {

--- a/contexts/wave/hooks/useWaveRealtimeUpdater.ts
+++ b/contexts/wave/hooks/useWaveRealtimeUpdater.ts
@@ -15,7 +15,7 @@ import { fetchDropByIdBatched } from "@/services/api/drop-api";
 import { useWebSocketMessage } from "@/services/websocket/useWebSocketMessage";
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { useWaveEligibility } from "../WaveEligibilityContext";
-import type { WaveDataStoreUpdater } from "./types";
+import type { WaveDataStoreUpdater, WaveMessages } from "./types";
 import { WebSocketStatus } from "@/services/websocket/WebSocketTypes";
 import { recordReactionRealtimeReconciliation } from "@/utils/monitoring/dropReactionMonitoring";
 import { useQueryClient, type QueryClient } from "@tanstack/react-query";
@@ -24,7 +24,14 @@ import {
   updateAttachmentInCachedDrops,
   updateDropInCachedDrops,
 } from "@/components/react-query-wrapper/utils/updateAttachmentInCachedDrops";
+import { upsertDropIntoMatchingDropsQueries } from "@/components/react-query-wrapper/utils/addDropsToDrops";
 import { isWaveDropNearViewport } from "@/contexts/wave/drop-visibility";
+
+const HELP_BOT_HANDLE = "help6529";
+const HELP_BOT_FINAL_REACTIONS = new Set([
+  ":white_check_mark:",
+  ":warning:",
+]);
 
 interface UseWaveRealtimeUpdaterProps extends WaveDataStoreUpdater {
   readonly activeWaveId: string | null;
@@ -50,7 +57,7 @@ type ProcessIncomingDropFn = (
   options?: ProcessIncomingDropOptions
 ) => Promise<void>;
 
-interface ProcessIncomingDropOptions {
+export interface ProcessIncomingDropOptions {
   readonly preferExistingPollVote?: boolean;
 }
 
@@ -83,6 +90,79 @@ const getIncomingWaveId = (drop: ApiDrop): string | null => {
 const isCanonicalDropUpdate = (type: ProcessIncomingDropType): boolean =>
   type === ProcessIncomingDropType.DROP_RATING_UPDATE ||
   type === ProcessIncomingDropType.DROP_REACTION_UPDATE;
+
+const shouldUpdateCachedDrop = (type: ProcessIncomingDropType): boolean =>
+  type !== ProcessIncomingDropType.DROP_REACTION_UPDATE;
+
+const updateCachedDrop = ({
+  drop,
+  options,
+  queryClient,
+  type,
+}: {
+  readonly drop: ApiDrop;
+  readonly options: ProcessIncomingDropOptions;
+  readonly queryClient: QueryClient;
+  readonly type: ProcessIncomingDropType;
+}): void => {
+  if (!shouldUpdateCachedDrop(type)) {
+    return;
+  }
+
+  if (type === ProcessIncomingDropType.DROP_INSERT) {
+    upsertDropIntoMatchingDropsQueries(queryClient, { drop });
+  }
+
+  const preferExistingPollVote = options.preferExistingPollVote;
+  if (preferExistingPollVote === undefined) {
+    updateDropInCachedDrops(queryClient, drop);
+    return;
+  }
+
+    updateDropInCachedDrops(queryClient, drop, { preferExistingPollVote });
+};
+
+const normalizeHandle = (handle: string | null | undefined): string =>
+  handle?.replace(/^@/, "").trim().toLowerCase() ?? "";
+
+const hasHelpBotReactionProfile = (drop: ApiDrop): boolean =>
+  (drop.reactions ?? []).some(
+    (reaction) =>
+      HELP_BOT_FINAL_REACTIONS.has(reaction.reaction) &&
+      reaction.profiles.some(
+        (profile) => normalizeHandle(profile.handle) === HELP_BOT_HANDLE
+      )
+  );
+
+const hasHelpBotMention = (drop: ApiDrop): boolean =>
+  (drop.mentioned_users ?? []).some((user) => {
+    const mention = user as {
+      readonly handle_in_content?: string | null | undefined;
+      readonly current_handle?: string | null | undefined;
+    };
+    return (
+      normalizeHandle(mention.handle_in_content) === HELP_BOT_HANDLE ||
+      normalizeHandle(mention.current_handle) === HELP_BOT_HANDLE
+    );
+  });
+
+const isHelpBotFinalReactionUpdate = (drop: ApiDrop): boolean =>
+  hasHelpBotReactionProfile(drop) ||
+  (hasHelpBotMention(drop) &&
+    (drop.reactions ?? []).some((reaction) =>
+      HELP_BOT_FINAL_REACTIONS.has(reaction.reaction)
+    ));
+
+const getNewestKnownSerialNo = (waveMessages: WaveMessages): number | null => {
+  if (waveMessages.latestFetchedSerialNo !== null) {
+    return waveMessages.latestFetchedSerialNo;
+  }
+
+  const serials = waveMessages.drops
+    .map((drop) => drop.serial_no)
+    .filter((serialNo) => Number.isFinite(serialNo));
+  return serials.length ? Math.max(...serials) : null;
+};
 
 const reportBackgroundTaskError = (message: string, error: unknown): void => {
   console.error(message, error);
@@ -549,16 +629,7 @@ const useProcessIncomingDrop = ({
         return;
       }
 
-      if (type !== ProcessIncomingDropType.DROP_REACTION_UPDATE) {
-        const preferExistingPollVote = options.preferExistingPollVote;
-        if (preferExistingPollVote === undefined) {
-          updateDropInCachedDrops(queryClient, drop);
-        } else {
-          updateDropInCachedDrops(queryClient, drop, {
-            preferExistingPollVote,
-          });
-        }
-      }
+      updateCachedDrop({ drop, options, queryClient, type });
 
       if (isWaveMuted(waveId)) {
         return;
@@ -589,6 +660,16 @@ const useProcessIncomingDrop = ({
           type,
           options,
         });
+        if (
+          type === ProcessIncomingDropType.DROP_REACTION_UPDATE &&
+          isHelpBotFinalReactionUpdate(drop)
+        ) {
+          await syncNewestMessagesAfterDropUpdate(
+            waveId,
+            getNewestKnownSerialNo(currentData),
+            drop.id
+          );
+        }
         if (
           type === ProcessIncomingDropType.DROP_REACTION_UPDATE &&
           isWaveDropNearViewport(waveId, drop.id)

--- a/contexts/wave/hooks/useWaveRealtimeUpdater.ts
+++ b/contexts/wave/hooks/useWaveRealtimeUpdater.ts
@@ -57,7 +57,7 @@ type ProcessIncomingDropFn = (
   options?: ProcessIncomingDropOptions
 ) => Promise<void>;
 
-export interface ProcessIncomingDropOptions {
+interface ProcessIncomingDropOptions {
   readonly preferExistingPollVote?: boolean;
 }
 
@@ -119,7 +119,7 @@ const updateCachedDrop = ({
     return;
   }
 
-    updateDropInCachedDrops(queryClient, drop, { preferExistingPollVote });
+  updateDropInCachedDrops(queryClient, drop, { preferExistingPollVote });
 };
 
 const normalizeHandle = (handle: string | null | undefined): string =>

--- a/hooks/useDropMessages.ts
+++ b/hooks/useDropMessages.ts
@@ -11,6 +11,7 @@ import useCapacitor from "./useCapacitor";
 import { useDebouncedQueryRefetch } from "./useDebouncedQueryRefetch";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import { WAVE_DROPS_PARAMS } from "@/components/react-query-wrapper/utils/query-utils";
+import { upsertDropIntoMatchingDropsQueries } from "@/components/react-query-wrapper/utils/addDropsToDrops";
 import {
   updateAttachmentInCachedDrops,
   updateDropInCachedDrops,
@@ -133,6 +134,7 @@ export function useDropMessages(
           return;
         }
 
+        upsertDropIntoMatchingDropsQueries(queryClient, { drop: message });
         updateDropInCachedDrops(queryClient, message, {
           preferExistingPollVote: true,
         });

--- a/hooks/useWaveDrops.ts
+++ b/hooks/useWaveDrops.ts
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
+import { upsertDropIntoMatchingDropsQueries } from "@/components/react-query-wrapper/utils/addDropsToDrops";
 import {
   updateAttachmentInCachedDrops,
   updateDropInCachedDrops,
@@ -178,6 +179,7 @@ export function useWaveDrops({
           return;
         }
 
+        upsertDropIntoMatchingDropsQueries(queryClient, { drop: message });
         updateDropInCachedDrops(queryClient, message, {
           preferExistingPollVote: true,
         });

--- a/ops/docs/media/memes/feature-minting-calendar.md
+++ b/ops/docs/media/memes/feature-minting-calendar.md
@@ -102,11 +102,19 @@ distribution routes.
   - `/the-memes/{id}` requires an integer for fallback mode.
   - `/the-memes/{id}/distribution` requires a positive integer.
 - If timing looks wrong, switch `Local`/`UTC` to compare output.
+- `/api/meme-calendar/next` returns the next scheduled Meme Card mint.
+- `/api/meme-calendar/current` returns the live mint when an overall mint window
+  is open, or `current: null` plus the next mint when nothing is live.
 - `/api/meme-calendar/{id}` responses:
   - `200` for valid ids, with:
+    - `mint_number`
     - `mint_date` as `YYYY-MM-DD` (UTC day string, for example
       `2025-03-18`)
+    - `mint_start` and `mint_end` as UTC ISO timestamps for the overall mint
+      window
+    - `status` as `past`, `live`, or `upcoming`
     - `season`, `year`, `epoch`, `period`, `era`, `eon`
+    - `calendar_path` and `mint_path`
   - `400` for invalid ids (non-numeric, `0`, decimals, negatives, or above
     JavaScript `MAX_SAFE_INTEGER`):
     - `{"error":"Invalid id. Use a positive integer in /api/meme-calendar/<id>."}`


### PR DESCRIPTION
## Summary
- restores the unmerged Help6529 frontend follow-ups after PR #2786 merged from an older head
- adds meme calendar current/next API routes and shared calendar response formatting
- restores wave realtime/drop cache recovery for websocket-created help bot replies
- keeps this on a clean branch from current main to avoid reopening stale unrelated diffs

## Notes
- Draft PR only per request.
- I did not wait for CI.
- I did not deploy or merge to staging.