### PR TITLE
Show wave score shields in discovery previews

### DIFF
--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -54,8 +54,13 @@ jest.mock(
 jest.mock(
   "@/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/WaveAvatar",
   () => ({
-    WaveAvatar: (props: { readonly wave: { readonly id: string } }) => (
-      <div data-testid={`preview-avatar-${props.wave.id}`} />
+    WaveAvatar: (props: any) => (
+      <div
+        data-testid={`preview-avatar-${props.wave.id}`}
+        data-is-drop-wave={String(props.isDropWave)}
+        data-show-new-drops-badge={String(props.showNewDropsBadge)}
+        data-show-unread-drops-badge={String(props.showUnreadDropsBadge)}
+      />
     ),
   })
 );
@@ -394,6 +399,49 @@ it("renders announcement, highly rated preview, pinned, and one filterable botto
   ).toEqual(["wave-a1", "wave-p1", "wave-f1", "wave-r1"]);
   expect(ref.current?.containerRef.current).toBe(container);
   expect(ref.current?.sentinelRef.current).toBeInstanceOf(HTMLElement);
+});
+
+it("shows highly rated preview score shields instead of unread badges", () => {
+  render(
+    <UnifiedWavesListWaves
+      waves={[
+        createMockMinimalWave({
+          id: "h-score",
+          name: "Scored Discovery",
+          sidebarSection: "highly-rated",
+          unreadDropsCount: 24,
+          newDropsCount: {
+            count: 99,
+            latestDropTimestamp: 123,
+            firstUnreadSerialNo: 42,
+          },
+          waveScore: {
+            visibility_score: 93,
+            quality_score: 91,
+            hotness_score: 97,
+            rep_sort_score: 73,
+          } as any,
+        }),
+      ]}
+      onHover={jest.fn()}
+      scrollContainerRef={scrollRef}
+    />
+  );
+
+  expect(
+    screen.getByRole("link", { name: "Open Scored Discovery, score 93" })
+  ).toBeInTheDocument();
+  expect(screen.getByText("93")).toBeInTheDocument();
+  expect(screen.getByText("Score 93")).toBeInTheDocument();
+  expect(screen.queryByRole("link", { name: /new messages/ })).toBeNull();
+  expect(screen.getByTestId("preview-avatar-h-score")).toHaveAttribute(
+    "data-show-new-drops-badge",
+    "false"
+  );
+  expect(screen.getByTestId("preview-avatar-h-score")).toHaveAttribute(
+    "data-show-unread-drops-badge",
+    "false"
+  );
 });
 
 it("caps highly rated previews at ten without rendering an overflow control", () => {

--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -402,7 +402,7 @@ it("renders announcement, highly rated preview, pinned, and one filterable botto
   expect(ref.current?.sentinelRef.current).toBeInstanceOf(HTMLElement);
 });
 
-it("shows highly rated preview score shields instead of unread badges", () => {
+it("uses highly rated preview score semantics instead of unread badges", () => {
   render(
     <UnifiedWavesListWaves
       waves={[
@@ -433,7 +433,6 @@ it("shows highly rated preview score shields instead of unread badges", () => {
   expect(
     screen.getByRole("link", { name: "Open Scored Discovery, score 93" })
   ).toBeInTheDocument();
-  expect(screen.getByText("93")).toBeInTheDocument();
   expect(screen.getByText("Score 93")).toBeInTheDocument();
   expect(screen.queryByRole("link", { name: /new messages/ })).toBeNull();
   expect(screen.getByTestId("preview-avatar-h-score")).toHaveAttribute(

--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -22,6 +22,7 @@ import { useVirtualizedWaves } from "@/hooks/useVirtualizedWaves";
 import { useSeizeSettingsOptional } from "@/contexts/SeizeSettingsContext";
 import { useMyStream } from "@/contexts/wave/MyStreamContext";
 import { createMockMinimalWave } from "@/__tests__/utils/mockFactories";
+import { ApiWaveType } from "@/generated/models/ApiWaveType";
 
 let mockDeviceInfo = { isApp: false, hasTouchScreen: false };
 
@@ -408,6 +409,7 @@ it("shows highly rated preview score shields instead of unread badges", () => {
         createMockMinimalWave({
           id: "h-score",
           name: "Scored Discovery",
+          type: ApiWaveType.Rank,
           sidebarSection: "highly-rated",
           unreadDropsCount: 24,
           newDropsCount: {
@@ -441,6 +443,10 @@ it("shows highly rated preview score shields instead of unread badges", () => {
   expect(screen.getByTestId("preview-avatar-h-score")).toHaveAttribute(
     "data-show-unread-drops-badge",
     "false"
+  );
+  expect(screen.getByTestId("preview-avatar-h-score")).toHaveAttribute(
+    "data-is-drop-wave",
+    "true"
   );
 });
 

--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -433,6 +433,7 @@ it("uses highly rated preview score semantics instead of unread badges", () => {
   expect(
     screen.getByRole("link", { name: "Open Scored Discovery, score 93" })
   ).toBeInTheDocument();
+  expect(screen.getByText("93", { selector: "text" })).toBeInTheDocument();
   expect(screen.getByText("Score 93")).toBeInTheDocument();
   expect(screen.queryByRole("link", { name: /new messages/ })).toBeNull();
   expect(screen.getByTestId("preview-avatar-h-score")).toHaveAttribute(

--- a/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
+++ b/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
@@ -249,13 +249,12 @@ function HighlyRatedWavePreviewScoreBadge({
   return (
     <span
       aria-hidden="true"
-      className="tw-pointer-events-none tw-absolute -tw-bottom-1 -tw-left-1 tw-z-10 tw-flex tw-h-4 tw-min-w-[1.75rem] tw-items-center tw-justify-center tw-gap-0.5 tw-rounded-full tw-border tw-border-solid tw-border-iron-950 tw-bg-iron-800/95 tw-px-1 tw-text-[10px] tw-font-semibold tw-leading-none tw-text-iron-100 tw-shadow-[0_0_0_1px_rgba(255,255,255,0.10),0_6px_14px_rgba(0,0,0,0.36)]"
+      className="tw-pointer-events-none tw-absolute -tw-bottom-0.5 -tw-left-0.5 tw-z-10 tw-flex tw-size-4 tw-items-center tw-justify-center tw-rounded-full tw-border tw-border-solid tw-border-iron-950 tw-bg-iron-800/95 tw-text-iron-100 tw-shadow-[0_0_0_1px_rgba(255,255,255,0.10),0_6px_14px_rgba(0,0,0,0.36)]"
     >
       <ShieldCheckIcon
-        className="tw-size-2.5 tw-flex-shrink-0 tw-text-iron-300"
+        className="tw-size-3 tw-flex-shrink-0 tw-text-iron-200"
         strokeWidth={1.8}
       />
-      <span>{scoreLabel}</span>
     </span>
   );
 }

--- a/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
+++ b/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
@@ -249,7 +249,7 @@ function HighlyRatedWavePreviewScoreBadge({
   return (
     <span
       aria-hidden="true"
-      className="tw-pointer-events-none tw-absolute -tw-bottom-1 -tw-right-1 tw-z-10 tw-flex tw-h-4 tw-min-w-[1.75rem] tw-items-center tw-justify-center tw-gap-0.5 tw-rounded-full tw-border tw-border-solid tw-border-iron-950 tw-bg-iron-800/95 tw-px-1 tw-text-[10px] tw-font-semibold tw-leading-none tw-text-iron-100 tw-shadow-[0_0_0_1px_rgba(255,255,255,0.10),0_6px_14px_rgba(0,0,0,0.36)]"
+      className="tw-pointer-events-none tw-absolute -tw-bottom-1 -tw-left-1 tw-z-10 tw-flex tw-h-4 tw-min-w-[1.75rem] tw-items-center tw-justify-center tw-gap-0.5 tw-rounded-full tw-border tw-border-solid tw-border-iron-950 tw-bg-iron-800/95 tw-px-1 tw-text-[10px] tw-font-semibold tw-leading-none tw-text-iron-100 tw-shadow-[0_0_0_1px_rgba(255,255,255,0.10),0_6px_14px_rgba(0,0,0,0.36)]"
     >
       <ShieldCheckIcon
         className="tw-size-2.5 tw-flex-shrink-0 tw-text-iron-300"
@@ -305,7 +305,7 @@ function HighlyRatedWavePreviewLink({
     >
       <WaveAvatar
         isActive={item.isActive}
-        isDropWave={isDropWave && scoreLabel === null}
+        isDropWave={isDropWave}
         showNewDropsBadge={false}
         showUnreadDropsBadge={false}
         wave={wave}

--- a/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
+++ b/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
@@ -10,7 +10,6 @@ import { ApiWaveType } from "@/generated/models/ApiWaveType";
 import { formatInteger } from "@/i18n/format";
 import { DEFAULT_LOCALE } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
-import { ShieldCheckIcon } from "@heroicons/react/24/outline";
 
 const SIDEBAR_LOCALE = DEFAULT_LOCALE;
 export const HIGHLY_RATED_PREVIEW_MAX_VISIBLE_COUNT = 10 as const;
@@ -143,6 +142,22 @@ const getWaveScoreLabel = (wave: MinimalWave): string | null => {
   return formatInteger(SIDEBAR_LOCALE, Math.round(score));
 };
 
+const getScoreBadgeFontSize = (scoreLabel: string) => {
+  if (scoreLabel.length >= 5) {
+    return 5;
+  }
+
+  if (scoreLabel.length === 4) {
+    return 5.8;
+  }
+
+  if (scoreLabel.length === 3) {
+    return 7;
+  }
+
+  return 8.8;
+};
+
 export const getFittingPreviewCount = ({
   itemCount,
   width,
@@ -247,15 +262,35 @@ function HighlyRatedWavePreviewScoreBadge({
   }
 
   return (
-    <span
+    <svg
       aria-hidden="true"
-      className="tw-pointer-events-none tw-absolute -tw-bottom-0.5 -tw-left-0.5 tw-z-10 tw-flex tw-size-4 tw-items-center tw-justify-center tw-rounded-full tw-border tw-border-solid tw-border-iron-950 tw-bg-iron-800/95 tw-text-iron-100 tw-shadow-[0_0_0_1px_rgba(255,255,255,0.10),0_6px_14px_rgba(0,0,0,0.36)]"
+      viewBox="0 0 24 28"
+      className="tw-pointer-events-none tw-absolute -tw-bottom-1.5 -tw-left-1.5 tw-z-10 tw-h-6 tw-w-5 tw-overflow-visible tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)]"
     >
-      <ShieldCheckIcon
-        className="tw-size-3 tw-flex-shrink-0 tw-text-iron-200"
-        strokeWidth={1.8}
+      <path
+        d="M12 1.8 21.4 5.45v7.35c0 6.1-3.7 11.05-9.4 13.4-5.7-2.35-9.4-7.3-9.4-13.4V5.45L12 1.8Z"
+        className="tw-fill-iron-800 tw-stroke-iron-950"
+        strokeWidth="2.8"
+        strokeLinejoin="round"
       />
-    </span>
+      <path
+        d="M12 3.9 19.1 6.65v6.1c0 4.95-2.65 8.95-7.1 11-4.45-2.05-7.1-6.05-7.1-11v-6.1L12 3.9Z"
+        className="tw-fill-none tw-stroke-white/20"
+        strokeWidth="1"
+        strokeLinejoin="round"
+      />
+      <text
+        x="12"
+        y="14.2"
+        dominantBaseline="middle"
+        textAnchor="middle"
+        fontSize={getScoreBadgeFontSize(scoreLabel)}
+        fontWeight="800"
+        className="tw-fill-iron-50"
+      >
+        {scoreLabel}
+      </text>
+    </svg>
   );
 }
 
@@ -324,11 +359,19 @@ function HighlyRatedWavePreviewLink({
           )}
           {scoreLabel !== null && (
             <span className="tw-ml-auto tw-inline-flex tw-items-center tw-gap-1 tw-whitespace-nowrap">
-              <ShieldCheckIcon
+              <svg
                 className="tw-size-3 tw-flex-shrink-0 tw-text-iron-400"
-                strokeWidth={1.8}
+                viewBox="0 0 24 28"
                 aria-hidden="true"
-              />
+              >
+                <path
+                  d="M12 2.2 21 5.7v7.1c0 5.9-3.55 10.6-9 12.9-5.45-2.3-9-7-9-12.9V5.7L12 2.2Z"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.2"
+                  strokeLinejoin="round"
+                />
+              </svg>
               {t(SIDEBAR_LOCALE, "waves.sidebar.highlyRatedPreviewScore", {
                 score: scoreLabel,
               })}

--- a/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
+++ b/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
@@ -10,6 +10,7 @@ import { ApiWaveType } from "@/generated/models/ApiWaveType";
 import { formatInteger } from "@/i18n/format";
 import { DEFAULT_LOCALE } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
+import { ShieldCheckIcon } from "@heroicons/react/24/outline";
 
 const SIDEBAR_LOCALE = DEFAULT_LOCALE;
 export const HIGHLY_RATED_PREVIEW_MAX_VISIBLE_COUNT = 10 as const;
@@ -133,11 +134,6 @@ export function buildHighlyRatedWavePreviewItems({
   }));
 }
 
-const getPluralKey = (count: number) => (count === 1 ? "one" : "other");
-
-const getUnreadCount = (wave: MinimalWave) =>
-  Math.max(wave.unreadDropsCount, wave.newDropsCount.count);
-
 const getWaveScoreLabel = (wave: MinimalWave): string | null => {
   const score = wave.waveScore?.visibility_score;
   if (typeof score !== "number" || !Number.isFinite(score)) {
@@ -241,6 +237,29 @@ export const getHighlyRatedPreviewTooltipAlignment = ({
   return "center";
 };
 
+function HighlyRatedWavePreviewScoreBadge({
+  scoreLabel,
+}: {
+  readonly scoreLabel: string | null;
+}) {
+  if (scoreLabel === null) {
+    return null;
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className="tw-pointer-events-none tw-absolute -tw-bottom-1 -tw-right-1 tw-z-10 tw-flex tw-h-4 tw-min-w-[1.75rem] tw-items-center tw-justify-center tw-gap-0.5 tw-rounded-full tw-border tw-border-solid tw-border-iron-950 tw-bg-iron-800/95 tw-px-1 tw-text-[10px] tw-font-semibold tw-leading-none tw-text-iron-100 tw-shadow-[0_0_0_1px_rgba(255,255,255,0.10),0_6px_14px_rgba(0,0,0,0.36)]"
+    >
+      <ShieldCheckIcon
+        className="tw-size-2.5 tw-flex-shrink-0 tw-text-iron-300"
+        strokeWidth={1.8}
+      />
+      <span>{scoreLabel}</span>
+    </span>
+  );
+}
+
 function HighlyRatedWavePreviewLink({
   item,
   tooltipAlignment,
@@ -249,8 +268,6 @@ function HighlyRatedWavePreviewLink({
   readonly tooltipAlignment: PreviewTooltipAlignment;
 }) {
   const { wave } = item;
-  const unreadCount = getUnreadCount(wave);
-  const countKey = getPluralKey(unreadCount);
   const isDropWave = wave.type !== ApiWaveType.Chat;
   const scoreLabel = getWaveScoreLabel(wave);
   const latestDropTimestamp =
@@ -260,13 +277,13 @@ function HighlyRatedWavePreviewLink({
       ? wave.newDropsCount.latestDropTimestamp
       : null;
   const linkLabel =
-    unreadCount > 0
+    scoreLabel !== null
       ? t(
           SIDEBAR_LOCALE,
-          `waves.sidebar.highlyRatedPreviewOpenAriaLabel.${countKey}`,
+          "waves.sidebar.highlyRatedPreviewOpenAriaLabel.withScore",
           {
             waveName: wave.name,
-            count: formatInteger(SIDEBAR_LOCALE, unreadCount),
+            score: scoreLabel,
           }
         )
       : t(
@@ -288,10 +305,12 @@ function HighlyRatedWavePreviewLink({
     >
       <WaveAvatar
         isActive={item.isActive}
-        isDropWave={isDropWave}
-        showNewDropsBadge={!item.isActive && unreadCount > 0}
+        isDropWave={isDropWave && scoreLabel === null}
+        showNewDropsBadge={false}
+        showUnreadDropsBadge={false}
         wave={wave}
       />
+      <HighlyRatedWavePreviewScoreBadge scoreLabel={scoreLabel} />
       <span
         className={`tw-pointer-events-none tw-absolute tw-top-10 tw-z-30 tw-hidden tw-w-48 tw-rounded-md tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-px-2.5 tw-py-2 tw-text-left tw-shadow-xl group-hover/preview:tw-block group-focus-visible/preview:tw-block ${PREVIEW_TOOLTIP_ALIGNMENT_CLASSNAMES[tooltipAlignment]}`}
       >
@@ -305,7 +324,12 @@ function HighlyRatedWavePreviewLink({
             </span>
           )}
           {scoreLabel !== null && (
-            <span className="tw-ml-auto tw-whitespace-nowrap">
+            <span className="tw-ml-auto tw-inline-flex tw-items-center tw-gap-1 tw-whitespace-nowrap">
+              <ShieldCheckIcon
+                className="tw-size-3 tw-flex-shrink-0 tw-text-iron-400"
+                strokeWidth={1.8}
+                aria-hidden="true"
+              />
               {t(SIDEBAR_LOCALE, "waves.sidebar.highlyRatedPreviewScore", {
                 score: scoreLabel,
               })}

--- a/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
+++ b/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
@@ -277,20 +277,20 @@ function HighlyRatedWavePreviewLink({
       ? wave.newDropsCount.latestDropTimestamp
       : null;
   const linkLabel =
-    scoreLabel !== null
+    scoreLabel === null
       ? t(
+          SIDEBAR_LOCALE,
+          "waves.sidebar.highlyRatedPreviewOpenAriaLabel.none",
+          {
+            waveName: wave.name,
+          }
+        )
+      : t(
           SIDEBAR_LOCALE,
           "waves.sidebar.highlyRatedPreviewOpenAriaLabel.withScore",
           {
             waveName: wave.name,
             score: scoreLabel,
-          }
-        )
-      : t(
-          SIDEBAR_LOCALE,
-          "waves.sidebar.highlyRatedPreviewOpenAriaLabel.none",
-          {
-            waveName: wave.name,
           }
         );
 

--- a/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/WaveAvatar.tsx
+++ b/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/WaveAvatar.tsx
@@ -7,6 +7,7 @@ interface WaveAvatarProps {
   readonly isActive: boolean;
   readonly isDropWave: boolean;
   readonly showNewDropsBadge: boolean;
+  readonly showUnreadDropsBadge?: boolean | undefined;
   readonly wave: MinimalWave;
   readonly size?: "default" | "sm" | undefined;
 }
@@ -37,11 +38,14 @@ export const WaveAvatar = ({
   isActive,
   isDropWave,
   showNewDropsBadge,
+  showUnreadDropsBadge = true,
   wave,
   size = "default",
 }: WaveAvatarProps) => {
   const showBadge =
-    !wave.isMuted && (wave.unreadDropsCount > 0 || showNewDropsBadge);
+    showUnreadDropsBadge &&
+    !wave.isMuted &&
+    (wave.unreadDropsCount > 0 || showNewDropsBadge);
   const rawCount = Math.max(wave.unreadDropsCount, wave.newDropsCount.count);
   const displayCount =
     rawCount > MAX_DISPLAY_COUNT ? `${MAX_DISPLAY_COUNT}+` : rawCount;

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -342,9 +342,8 @@ const WAVES_SIDEBAR_MESSAGES = objectMessages("waves.sidebar", {
   highlyRated: "Worth Checking Out",
   highlyRatedInfoTooltip: "Highly rated waves you don’t follow yet.",
   "highlyRatedPreviewOpenAriaLabel.none": "Open {waveName}",
-  "highlyRatedPreviewOpenAriaLabel.one": "Open {waveName}, {count} new message",
-  "highlyRatedPreviewOpenAriaLabel.other":
-    "Open {waveName}, {count} new messages",
+  "highlyRatedPreviewOpenAriaLabel.withScore":
+    "Open {waveName}, score {score}",
   highlyRatedPreviewScore: "Score {score}",
   pinned: "Pinned",
   allWaves: "All Waves",

--- a/pr-reports/2868.md
+++ b/pr-reports/2868.md
@@ -27,4 +27,4 @@ No config or environment changes.
 Worth Checking Out wave previews now use the wave score shield as the discovery badge, making the recommendation reason clearer for waves the user does not follow.
 
 ## Risks / Follow-Ups
-Staging deployment completion and deployed-environment smoke checks were intentionally not awaited per request.
+Frontend staging deploy run https://github.com/6529-Collections/6529seize-frontend/actions/runs/28083109317 was started from staging commit `c5df6e61dc3b995194ff4cd0696d49937111b4bb`; completion and deployed-environment smoke checks were intentionally not awaited per request.

--- a/pr-reports/2868.md
+++ b/pr-reports/2868.md
@@ -10,7 +10,7 @@ The Worth Checking Out sidebar preview strip now explains why a wave is being su
 
 ## What Changed
 - Added a context-specific opt-out for unread badges on shared sidebar wave avatars.
-- Rendered a compact shield score badge at the lower-right of highly rated preview avatars when a visibility score is available.
+- Rendered a compact shield score badge at the lower-left of highly rated preview avatars when a visibility score is available, preserving existing lower-right wave type markers.
 - Updated preview link accessible labels and hover tooltip copy to describe score semantics rather than unread messages.
 - Covered the unread-but-highly-rated case with a focused sidebar preview regression test.
 

--- a/pr-reports/2868.md
+++ b/pr-reports/2868.md
@@ -5,11 +5,11 @@ Branch: `codex/wave-rating-shield-badge` -> `main`
 Related PRs: None
 
 ## Summary
-The Worth Checking Out sidebar preview strip now explains why a wave is being suggested with a small score-shield marker, instead of reusing unread-message badges for waves the user does not follow.
+The Worth Checking Out sidebar preview strip now explains why a wave is being suggested with a shield-shaped score badge, instead of reusing unread-message badges for waves the user does not follow.
 
 ## What Changed
 - Added a context-specific opt-out for unread badges on shared sidebar wave avatars.
-- Rendered a compact lower-left shield marker on highly rated preview avatars when a visibility score is available, preserving existing lower-right wave type markers while keeping the numeric score in tooltip/accessibility copy.
+- Rendered a compact lower-left shield-shaped badge with the visibility score inside it, preserving existing lower-right wave type markers and keeping the score in tooltip/accessibility copy.
 - Updated preview link accessible labels and hover tooltip copy to describe score semantics rather than unread messages.
 - Covered the unread-but-highly-rated case with a focused sidebar preview regression test.
 
@@ -17,13 +17,13 @@ The Worth Checking Out sidebar preview strip now explains why a wave is being su
 - Routes/views: Waves sidebar and web/app brain left-sidebar wave discovery surfaces.
 - Components: Highly rated preview strip and shared sidebar wave avatar.
 - Generated API/client: Not affected.
-- User-visible behavior: Worth Checking Out avatars show a small score shield marker instead of unread-count bubbles, with numeric score details available on hover/focus.
+- User-visible behavior: Worth Checking Out avatars show the wave score inside a shield badge instead of unread-count bubbles, with score details also available on hover/focus.
 
 ## Config / Env
 No config or environment changes.
 
 ## Release Notes
-Worth Checking Out wave previews now use a wave score shield marker as the discovery badge, making the recommendation reason clearer for waves the user does not follow without overwhelming the avatar strip.
+Worth Checking Out wave previews now use a shield-shaped score badge as the discovery badge, making the recommendation reason clearer for waves the user does not follow without reusing unread counts.
 
 ## Risks / Follow-Ups
-Frontend staging deploy run https://github.com/6529-Collections/6529seize-frontend/actions/runs/28086541784 was started from staging commit `c89122e6f`; completion and deployed-environment smoke checks were intentionally not awaited per request.
+Frontend staging deploy completion and deployed-environment smoke checks will be intentionally not awaited per request.

--- a/pr-reports/2868.md
+++ b/pr-reports/2868.md
@@ -1,0 +1,30 @@
+# PR Report: Wave Score Shields In Discovery Previews
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/2868
+Branch: `codex/wave-rating-shield-badge` -> `main`
+Related PRs: None
+Mode: staging-deploy
+
+## Summary
+The Worth Checking Out sidebar preview strip now explains why a wave is being suggested by showing its wave score on the avatar, instead of reusing unread-message badges for waves the user does not follow.
+
+## What Changed
+- Added a context-specific opt-out for unread badges on shared sidebar wave avatars.
+- Rendered a compact shield score badge at the lower-right of highly rated preview avatars when a visibility score is available.
+- Updated preview link accessible labels and hover tooltip copy to describe score semantics rather than unread messages.
+- Covered the unread-but-highly-rated case with a focused sidebar preview regression test.
+
+## Frontend Impact
+- Routes/views: Waves sidebar and web/app brain left-sidebar wave discovery surfaces.
+- Components: Highly rated preview strip and shared sidebar wave avatar.
+- Generated API/client: Not affected.
+- User-visible behavior: Worth Checking Out avatars show score shields instead of unread-count bubbles.
+
+## Config / Env
+No config or environment changes.
+
+## Release Notes
+Worth Checking Out wave previews now use the wave score shield as the discovery badge, making the recommendation reason clearer for waves the user does not follow.
+
+## Risks / Follow-Ups
+Staging deployment completion and deployed-environment smoke checks were intentionally not awaited per request.

--- a/pr-reports/2868.md
+++ b/pr-reports/2868.md
@@ -26,4 +26,4 @@ No config or environment changes.
 Worth Checking Out wave previews now use a shield-shaped score badge as the discovery badge, making the recommendation reason clearer for waves the user does not follow without reusing unread counts.
 
 ## Risks / Follow-Ups
-Frontend staging deploy completion and deployed-environment smoke checks will be intentionally not awaited per request.
+Frontend staging deploy run https://github.com/6529-Collections/6529seize-frontend/actions/runs/28087852376 was started from staging commit `264c35206`; completion and deployed-environment smoke checks were intentionally not awaited per request.

--- a/pr-reports/2868.md
+++ b/pr-reports/2868.md
@@ -10,7 +10,7 @@ The Worth Checking Out sidebar preview strip now explains why a wave is being su
 
 ## What Changed
 - Added a context-specific opt-out for unread badges on shared sidebar wave avatars.
-- Rendered a compact shield score badge at the lower-left of highly rated preview avatars when a visibility score is available, preserving existing lower-right wave type markers.
+- Rendered a compact lower-left shield marker on highly rated preview avatars when a visibility score is available, preserving existing lower-right wave type markers while keeping the numeric score in tooltip/accessibility copy.
 - Updated preview link accessible labels and hover tooltip copy to describe score semantics rather than unread messages.
 - Covered the unread-but-highly-rated case with a focused sidebar preview regression test.
 
@@ -18,13 +18,13 @@ The Worth Checking Out sidebar preview strip now explains why a wave is being su
 - Routes/views: Waves sidebar and web/app brain left-sidebar wave discovery surfaces.
 - Components: Highly rated preview strip and shared sidebar wave avatar.
 - Generated API/client: Not affected.
-- User-visible behavior: Worth Checking Out avatars show score shields instead of unread-count bubbles.
+- User-visible behavior: Worth Checking Out avatars show a score shield marker instead of unread-count bubbles, with numeric score details available on hover/focus.
 
 ## Config / Env
 No config or environment changes.
 
 ## Release Notes
-Worth Checking Out wave previews now use the wave score shield as the discovery badge, making the recommendation reason clearer for waves the user does not follow.
+Worth Checking Out wave previews now use a wave score shield marker as the discovery badge, making the recommendation reason clearer for waves the user does not follow without overwhelming the avatar strip.
 
 ## Risks / Follow-Ups
 Frontend staging deploy run https://github.com/6529-Collections/6529seize-frontend/actions/runs/28083109317 was started from staging commit `c5df6e61dc3b995194ff4cd0696d49937111b4bb`; completion and deployed-environment smoke checks were intentionally not awaited per request.

--- a/pr-reports/2868.md
+++ b/pr-reports/2868.md
@@ -26,4 +26,4 @@ No config or environment changes.
 Worth Checking Out wave previews now use a wave score shield marker as the discovery badge, making the recommendation reason clearer for waves the user does not follow without overwhelming the avatar strip.
 
 ## Risks / Follow-Ups
-Frontend staging deploy run https://github.com/6529-Collections/6529seize-frontend/actions/runs/28083109317 was started from staging commit `c5df6e61dc3b995194ff4cd0696d49937111b4bb`; completion and deployed-environment smoke checks were intentionally not awaited per request.
+Frontend staging deploy run https://github.com/6529-Collections/6529seize-frontend/actions/runs/28086541784 was started from staging commit `c89122e6f`; completion and deployed-environment smoke checks were intentionally not awaited per request.

--- a/pr-reports/2868.md
+++ b/pr-reports/2868.md
@@ -3,10 +3,9 @@
 PR: https://github.com/6529-Collections/6529seize-frontend/pull/2868
 Branch: `codex/wave-rating-shield-badge` -> `main`
 Related PRs: None
-Mode: staging-deploy
 
 ## Summary
-The Worth Checking Out sidebar preview strip now explains why a wave is being suggested by showing its wave score on the avatar, instead of reusing unread-message badges for waves the user does not follow.
+The Worth Checking Out sidebar preview strip now explains why a wave is being suggested with a small score-shield marker, instead of reusing unread-message badges for waves the user does not follow.
 
 ## What Changed
 - Added a context-specific opt-out for unread badges on shared sidebar wave avatars.
@@ -18,7 +17,7 @@ The Worth Checking Out sidebar preview strip now explains why a wave is being su
 - Routes/views: Waves sidebar and web/app brain left-sidebar wave discovery surfaces.
 - Components: Highly rated preview strip and shared sidebar wave avatar.
 - Generated API/client: Not affected.
-- User-visible behavior: Worth Checking Out avatars show a score shield marker instead of unread-count bubbles, with numeric score details available on hover/focus.
+- User-visible behavior: Worth Checking Out avatars show a small score shield marker instead of unread-count bubbles, with numeric score details available on hover/focus.
 
 ## Config / Env
 No config or environment changes.


### PR DESCRIPTION
## Issue
- The Worth Checking Out preview strip surfaces highly rated waves the user does not follow, but its avatar badge reused unread-message counts, which made the discovery reason unclear.
- A shield-only marker was calmer visually, but did not convey the actual rating because every wave looked the same.

## Fix
- Replace unread-count badges in the highly rated preview strip with a lower-left shield-shaped score badge: the score is centered inside the shield, with no surrounding circle and no checkmark.
- Keep the full score semantics in the hover/focus tooltip and accessible label.

## Changes
- Added an opt-out for unread badges on the shared sidebar wave avatar.
- Rendered the Worth Checking Out score as a local shield-shaped SVG badge only in the highly rated preview strip, while preserving existing bottom-right wave type markers and the separate rating UI used elsewhere.
- Updated preview link accessible labels and hover tooltip content to describe the score instead of unread messages.
- Added a regression test for an unread highly rated wave to ensure the preview uses visible score semantics.

## Risk
- Level: Low
- Why: Scoped to the highly rated sidebar preview strip and a backward-compatible avatar prop default.
- Rollback: Revert this PR to restore the prior preview badge behavior.

## Review Notes
- Please focus on whether the number remains legible inside the shield at 32px avatar size and whether the lower-left placement avoids the existing bottom-right wave type marker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Highly rated wave previews now show a score-based badge and label instead of unread-message styling.
  * Accessible labels and tooltip text now describe wave scores more clearly.

* **Bug Fixes**
  * Fixed preview badges so they no longer imply unread/new activity for highly rated waves.
  * Improved sidebar preview behavior for waves with scores, keeping wave type indicators visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->