### PR TITLE
[codex] Address mobile dock review cleanup

### DIFF
--- a/__tests__/components/navigation/BottomNavigation.test.tsx
+++ b/__tests__/components/navigation/BottomNavigation.test.tsx
@@ -5,7 +5,10 @@ import { useLayout } from "@/components/brain/my-stream/layout/LayoutContext";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
 import { useWave } from "@/hooks/useWave";
 import { useWaveData } from "@/hooks/useWaveData";
-import { getNotificationsRoute } from "@/helpers/navigation.helpers";
+import {
+  getNotificationsRoute,
+  MOBILE_BOTTOM_NAV_SCROLL_TARGET_SELECTOR,
+} from "@/helpers/navigation.helpers";
 
 jest.mock("@/components/navigation/NavItem", () => ({
   __esModule: true,
@@ -37,8 +40,18 @@ const { usePathname, useSearchParams } = require("next/navigation");
 
 let originalScrollYDescriptor: PropertyDescriptor | undefined;
 
+const getMobileBottomNavScrollTargetAttribute = () => {
+  const match = /^\[([^=\]]+)="true"\]$/.exec(
+    MOBILE_BOTTOM_NAV_SCROLL_TARGET_SELECTOR
+  );
+  if (!match?.[1]) {
+    throw new Error("Unexpected mobile bottom nav scroll target selector");
+  }
+  return match[1];
+};
+
 const MOBILE_BOTTOM_NAV_SCROLL_TARGET_ATTRIBUTE =
-  "data-mobile-bottom-nav-scroll-target";
+  getMobileBottomNavScrollTargetAttribute();
 
 const flushAnimationFrame = async () => {
   await act(async () => {

--- a/components/navigation/NavItem.tsx
+++ b/components/navigation/NavItem.tsx
@@ -42,25 +42,31 @@ const getIconSlotClass = ({
   return `tw-relative tw-z-10 tw-flex tw-items-center tw-justify-center tw-transition-transform tw-duration-300 tw-ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:tw-transition-none ${compactClassName}`;
 };
 
+const getActiveNavIndicatorClassName = ({
+  compact,
+  variant,
+}: {
+  readonly compact: boolean;
+  readonly variant: "floating" | "fixed";
+}) => {
+  if (variant === "fixed") {
+    return "tw-absolute tw-left-0 tw-top-0 tw-h-0.5 tw-w-full tw-rounded-full tw-bg-white";
+  }
+
+  const sizeClassName = compact
+    ? "tw-h-11 tw-w-[3.75rem] sm:tw-h-12 sm:tw-w-[4.25rem]"
+    : "tw-h-12 tw-w-[4.05rem] sm:tw-h-[3.15rem] sm:tw-w-[4.45rem]";
+
+  return `tw-absolute tw-left-1/2 tw-top-1/2 tw-z-0 -tw-translate-x-1/2 -tw-translate-y-1/2 tw-rounded-full tw-bg-white/[0.9] tw-shadow-[inset_0_1px_0_rgba(255,255,255,0.42),0_8px_24px_rgba(255,255,255,0.1)] tw-transition-[width,height] tw-duration-300 tw-ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:tw-transition-none ${sizeClassName}`;
+};
+
 const ActiveNavIndicator = ({
   compact,
   variant,
 }: {
   readonly compact: boolean;
   readonly variant: "floating" | "fixed";
-}) => (
-  <div
-    className={
-      variant === "fixed"
-        ? "tw-absolute tw-left-0 tw-top-0 tw-h-0.5 tw-w-full tw-rounded-full tw-bg-white"
-        : `tw-absolute tw-left-1/2 tw-top-1/2 tw-z-0 -tw-translate-x-1/2 -tw-translate-y-1/2 tw-rounded-full tw-bg-white/[0.9] tw-shadow-[inset_0_1px_0_rgba(255,255,255,0.42),0_8px_24px_rgba(255,255,255,0.1)] tw-transition-[width,height] tw-duration-300 tw-ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:tw-transition-none ${
-            compact
-              ? "tw-h-11 tw-w-[3.75rem] sm:tw-h-12 sm:tw-w-[4.25rem]"
-              : "tw-h-12 tw-w-[4.05rem] sm:tw-h-[3.15rem] sm:tw-w-[4.45rem]"
-          }`
-    }
-  />
-);
+}) => <div className={getActiveNavIndicatorClassName({ compact, variant })} />;
 
 const getHomeIconSizeClass = ({
   compact,

--- a/pr-reports/2865.md
+++ b/pr-reports/2865.md
@@ -21,6 +21,7 @@ Refines the mobile floating dock after the initial rollout so list routes consis
 - Replaced the shared-layout active pill animation with a local active indicator to avoid stale geometry when navigating from dock-hidden detail pages back to dock-visible pages.
 - Lowered and slightly enlarged the floating dock, tightened notification bottom spacing, preloaded/crossfaded the 6529 logo active colors, and matched the wave/message detail composer safe-area strip to the composer surface.
 - Added a small safe-area floor to wave/message detail composers and forced the composer placeholder to stay on one truncating line when action buttons are expanded.
+- Extracted the active indicator size-class selection out of a nested ternary and derived the scroll-target test attribute from the exported selector.
 
 ## Frontend Impact
 
@@ -36,3 +37,8 @@ None.
 ## Release Notes
 
 Improves the mobile floating dock rollout by using it on stream list pages, removing the transient pending highlight, hiding it on wave/message detail pages, and stabilizing composer/dock behavior found during staging review.
+
+## Review Follow-Up
+
+- Latest 6529bot responsiveness review for `a259f493b5b4` passed 44/44 checks with no blocking findings.
+- SonarCloud's nested-ternary issue in `NavItem.tsx` was addressed in follow-up cleanup.


### PR DESCRIPTION
## Summary
- Extract the mobile dock active-indicator size classes out of the nested ternary flagged by SonarCloud.
- Derive the bottom-nav scroll-target test attribute from the exported selector instead of duplicating the literal.
- Update the PR report with the current 6529bot responsiveness pass and Sonar cleanup note.

## Validation
- `./bin/6529 run test:no-coverage -- __tests__/components/navigation/BottomNavigation.test.tsx __tests__/components/navigation/NavItem.test.tsx`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`

## Notes
- Follow-up to merged PR #2865. No staging merge/deploy performed.