### PR TITLE
Fix mobile dock clearance and scroll edge behavior

### DIFF
--- a/__tests__/components/brain/mobile/BrainMobileMessages.test.tsx
+++ b/__tests__/components/brain/mobile/BrainMobileMessages.test.tsx
@@ -1,9 +1,9 @@
-import { render } from '@testing-library/react';
-import React from 'react';
+import { render } from "@testing-library/react";
+import React from "react";
 
 const directMessagesListMock = jest.fn();
 
-jest.mock('@/components/brain/direct-messages/DirectMessagesList', () => ({
+jest.mock("@/components/brain/direct-messages/DirectMessagesList", () => ({
   __esModule: true,
   default: (props: any) => {
     directMessagesListMock(props);
@@ -12,19 +12,19 @@ jest.mock('@/components/brain/direct-messages/DirectMessagesList', () => ({
 }));
 
 const useLayoutMock = jest.fn();
-jest.mock('@/components/brain/my-stream/layout/LayoutContext', () => ({
+jest.mock("@/components/brain/my-stream/layout/LayoutContext", () => ({
   useLayout: () => useLayoutMock(),
 }));
 
-import BrainMobileMessages from '@/components/brain/mobile/BrainMobileMessages';
+import BrainMobileMessages from "@/components/brain/mobile/BrainMobileMessages";
 
-describe('BrainMobileMessages', () => {
+describe("BrainMobileMessages", () => {
   beforeEach(() => {
     directMessagesListMock.mockClear();
-    useLayoutMock.mockReturnValue({ mobileWavesViewStyle: { height: '42px' } });
+    useLayoutMock.mockReturnValue({ mobileWavesViewStyle: { height: "42px" } });
   });
 
-  it('renders and passes scrollContainerRef to DirectMessagesList', () => {
+  it("renders and passes scrollContainerRef to DirectMessagesList", () => {
     const { container } = render(<BrainMobileMessages />);
 
     expect(directMessagesListMock).toHaveBeenCalledTimes(1);
@@ -34,6 +34,9 @@ describe('BrainMobileMessages', () => {
     // ref should point to the rendered div
     expect(scrollContainerRef.current).toBe(rootDiv);
     // style from useLayout should be applied
-    expect(rootDiv).toHaveAttribute('style', 'height: 42px;');
+    expect(rootDiv).toHaveAttribute("style", "height: 42px;");
+    expect(rootDiv).toHaveClass(
+      "tw-pb-[calc(4rem+env(safe-area-inset-bottom,0px))]"
+    );
   });
 });

--- a/__tests__/components/brain/mobile/BrainMobileWaves.test.tsx
+++ b/__tests__/components/brain/mobile/BrainMobileWaves.test.tsx
@@ -40,6 +40,9 @@ test("applies style, forwards scroll ref, and passes the quick-vote opener", () 
   expect(receivedRef).toBeDefined();
   expect(receivedRef.current).not.toBe(container.firstChild);
   expect(receivedRef.current).toContainElement(screen.getByTestId("waves"));
+  expect(receivedRef.current).toHaveClass(
+    "tw-pb-[calc(4rem+env(safe-area-inset-bottom,0px))]"
+  );
 
   fireEvent.click(screen.getByTestId("footer"));
 

--- a/__tests__/components/brain/my-stream/layout/LayoutContext.test.tsx
+++ b/__tests__/components/brain/my-stream/layout/LayoutContext.test.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import {
   LayoutProvider,
   useLayout,
@@ -62,6 +62,36 @@ function TestComponent() {
       <div data-testid="content" style={waveViewStyle}>
         {spaces.contentSpace}
       </div>
+    </>
+  );
+}
+
+function MobileWavesTestComponent() {
+  const { registerRef, mobileWavesViewStyle } = useLayout();
+  const headerRef = useRef<HTMLDivElement>(null);
+  const navRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (headerRef.current) {
+      (headerRef.current as any).getBoundingClientRect = () => ({
+        height: 100,
+      });
+      registerRef("header", headerRef.current);
+    }
+
+    if (navRef.current) {
+      (navRef.current as any).getBoundingClientRect = () => ({
+        height: 80,
+      });
+      registerRef("mobileNav", navRef.current);
+    }
+  }, [registerRef]);
+
+  return (
+    <>
+      <div ref={headerRef} />
+      <div ref={navRef} />
+      <div data-testid="mobile-waves" style={mobileWavesViewStyle} />
     </>
   );
 }
@@ -158,5 +188,25 @@ describe("LayoutProvider", () => {
     // Should not include any capSpace
     expect(content.style.height).not.toContain("- 128px");
     expect(content.style.height).not.toContain("- 20px");
+  });
+
+  it("does not subtract the floating mobile nav from mobile waves list height", async () => {
+    Object.defineProperty(globalThis, "innerHeight", {
+      value: 1000,
+      configurable: true,
+    });
+
+    render(
+      <LayoutProvider>
+        <MobileWavesTestComponent />
+      </LayoutProvider>
+    );
+
+    const content = screen.getByTestId("mobile-waves");
+
+    await waitFor(() => {
+      expect(content.style.maxHeight).toContain("- 100px");
+    });
+    expect(content.style.maxHeight).not.toContain("- 80px");
   });
 });

--- a/__tests__/components/brain/notifications/Notifications.test.tsx
+++ b/__tests__/components/brain/notifications/Notifications.test.tsx
@@ -1,28 +1,28 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
 
 const mutateAsyncMock = jest.fn();
 const requestAuthMock = jest.fn().mockResolvedValue({ success: true });
 const setActiveProfileProxyMock = jest.fn().mockResolvedValue(undefined);
 const setToastMock = jest.fn();
 
-jest.mock('@tanstack/react-query', () => ({
+jest.mock("@tanstack/react-query", () => ({
   useMutation: () => ({ mutateAsync: mutateAsyncMock }),
 }));
 
-jest.mock('next/navigation', () => ({
+jest.mock("next/navigation", () => ({
   useRouter: () => ({ replace: jest.fn() }),
   useSearchParams: () => new URLSearchParams(),
-  usePathname: () => '/notifications',
+  usePathname: () => "/notifications",
 }));
 
 const setTitleMock = jest.fn();
 
-jest.mock('@/components/auth/Auth', () => {
-  const React = require('react');
+jest.mock("@/components/auth/Auth", () => {
+  const React = require("react");
   return {
     AuthContext: React.createContext({
-      connectedProfile: { handle: 'bob', id: '1' },
+      connectedProfile: { handle: "bob", id: "1" },
       activeProfileProxy: null,
       fetchingProfile: false,
       requestAuth: requestAuthMock,
@@ -39,48 +39,52 @@ jest.mock('@/components/auth/Auth', () => {
 });
 
 const invalidateNotifications = jest.fn();
-jest.mock('@/components/react-query-wrapper/ReactQueryWrapper', () => {
-  const React = require('react');
-  return { ReactQueryWrapperContext: React.createContext({ invalidateNotifications }) };
+jest.mock("@/components/react-query-wrapper/ReactQueryWrapper", () => {
+  const React = require("react");
+  return {
+    ReactQueryWrapperContext: React.createContext({ invalidateNotifications }),
+  };
 });
 
-jest.mock('@/components/brain/notifications/NotificationsWrapper', () => ({
+jest.mock("@/components/brain/notifications/NotificationsWrapper", () => ({
   __esModule: true,
   default: () => <div data-testid="wrapper" />,
 }));
 
-jest.mock('@/components/brain/notifications/NotificationsCauseFilter', () => ({
+jest.mock("@/components/brain/notifications/NotificationsCauseFilter", () => ({
   __esModule: true,
   default: () => <div data-testid="filter" />,
 }));
 
-jest.mock('@/components/brain/content/input/BrainContentInput', () => ({
+jest.mock("@/components/brain/content/input/BrainContentInput", () => ({
   __esModule: true,
   default: () => <div data-testid="input" />,
 }));
 
-jest.mock('@/components/brain/my-stream/layout/MyStreamNoItems', () => ({
+jest.mock("@/components/brain/my-stream/layout/MyStreamNoItems", () => ({
   __esModule: true,
   default: () => <div data-testid="no-items" />,
 }));
 
 const useNotificationsQueryMock = jest.fn();
-jest.mock('@/hooks/useNotificationsQuery', () => ({
+jest.mock("@/hooks/useNotificationsQuery", () => ({
   useNotificationsQuery: () => useNotificationsQueryMock(),
 }));
 
-jest.mock('@/components/notifications/NotificationsContext', () => ({
-  useNotificationsContext: () => ({ removeAllDeliveredNotifications: jest.fn() }),
+jest.mock("@/components/notifications/NotificationsContext", () => ({
+  useNotificationsContext: () => ({
+    removeAllDeliveredNotifications: jest.fn(),
+  }),
 }));
 
-jest.mock('@/components/brain/my-stream/layout/LayoutContext', () => ({
-  useLayout: () => ({ notificationsViewStyle: { height: '10px' } }),
+jest.mock("@/components/brain/my-stream/layout/LayoutContext", () => ({
+  useLayout: () => ({ notificationsViewStyle: { height: "10px" } }),
 }));
 
 // Mock TitleContext
-jest.mock('@/contexts/TitleContext', () => ({
+jest.mock("@/contexts/TitleContext", () => ({
   useTitle: () => ({
-    title: 'Test Title',
+    title: "Test Title",
     setTitle: jest.fn(),
     notificationCount: 0,
     setNotificationCount: jest.fn(),
@@ -92,9 +96,9 @@ jest.mock('@/contexts/TitleContext', () => ({
   TitleProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
-import Notifications from '@/components/brain/notifications';
+import Notifications from "@/components/brain/notifications";
 
-describe('Notifications component', () => {
+describe("Notifications component", () => {
   beforeEach(() => {
     mutateAsyncMock.mockClear();
     mutateAsyncMock.mockResolvedValue(undefined);
@@ -107,7 +111,7 @@ describe('Notifications component', () => {
     setToastMock.mockClear();
   });
 
-  it('shows loader when fetching and no items', async () => {
+  it("shows loader when fetching and no items", async () => {
     useNotificationsQueryMock.mockReturnValue({
       items: [],
       isFetching: true,
@@ -122,16 +126,18 @@ describe('Notifications component', () => {
 
     render(<Notifications activeDrop={null} setActiveDrop={jest.fn()} />);
 
-    expect(screen.getByText('Loading notifications...', { selector: 'div' })).toBeInTheDocument();
+    expect(
+      screen.getByText("Loading notifications...", { selector: "div" })
+    ).toBeInTheDocument();
     await waitFor(() => {
       expect(mutateAsyncMock).toHaveBeenCalled();
     });
     // Title is set via TitleContext hooks
   });
 
-  it('renders wrapper with items', async () => {
+  it("renders wrapper with items", async () => {
     useNotificationsQueryMock.mockReturnValue({
-      items: ['a'],
+      items: ["a"],
       isFetching: false,
       isFetchingNextPage: false,
       hasNextPage: false,
@@ -144,13 +150,16 @@ describe('Notifications component', () => {
 
     render(<Notifications activeDrop={null} setActiveDrop={jest.fn()} />);
 
-    expect(screen.getByTestId('wrapper')).toBeInTheDocument();
+    expect(screen.getByTestId("wrapper")).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-mobile-bottom-nav-scroll-target="true"]')
+    ).toHaveClass("tw-pb-[calc(4rem+env(safe-area-inset-bottom,0px))]");
     await waitFor(() => {
       expect(mutateAsyncMock).toHaveBeenCalled();
     });
   });
 
-  it('shows no items component when query done but empty', async () => {
+  it("shows no items component when query done but empty", async () => {
     useNotificationsQueryMock.mockReturnValue({
       items: [],
       isFetching: false,
@@ -165,7 +174,7 @@ describe('Notifications component', () => {
 
     render(<Notifications activeDrop={null} setActiveDrop={jest.fn()} />);
 
-    expect(screen.getByTestId('no-items')).toBeInTheDocument();
+    expect(screen.getByTestId("no-items")).toBeInTheDocument();
     await waitFor(() => {
       expect(mutateAsyncMock).toHaveBeenCalled();
     });

--- a/__tests__/components/common/icons/LogoIcon.test.tsx
+++ b/__tests__/components/common/icons/LogoIcon.test.tsx
@@ -14,6 +14,8 @@ describe("LogoIcon", () => {
     expect(images[0]).toHaveAttribute("aria-hidden", "true");
     expect(images[0]).toHaveClass("tw-opacity-100");
     expect(images[1]).toHaveClass("tw-opacity-0");
+    expect(images[0]).not.toHaveClass("tw-transition-opacity");
+    expect(images[1]).not.toHaveClass("tw-transition-opacity");
   });
 
   it("shows the black logo asset when requested", () => {

--- a/__tests__/components/layout/AppLayout.test.tsx
+++ b/__tests__/components/layout/AppLayout.test.tsx
@@ -198,7 +198,7 @@ describe("AppLayout", () => {
     );
   });
 
-  it("uses visible floating bottom nav spacing on stream list routes", () => {
+  it("lets notification route content own floating bottom nav clearance", () => {
     usePathname.mockReturnValue("/notifications");
 
     const { container } = renderWithProvider(<AppLayout>child</AppLayout>);
@@ -209,7 +209,31 @@ describe("AppLayout", () => {
       "false"
     );
     expect(appWrapper.style.getPropertyValue(bottomReserveProperty)).toBe(
-      "104px"
+      "0px"
+    );
+  });
+
+  it("lets waves and messages routes own floating bottom nav clearance", () => {
+    usePathname.mockReturnValue("/waves");
+
+    const { container, rerender } = renderWithProvider(
+      <AppLayout>child</AppLayout>
+    );
+    const appWrapper = container.firstElementChild as HTMLElement;
+
+    expect(appWrapper.style.getPropertyValue(bottomReserveProperty)).toBe(
+      "0px"
+    );
+
+    usePathname.mockReturnValue("/messages");
+    rerender(
+      <Provider store={store}>
+        <AppLayout>child</AppLayout>
+      </Provider>
+    );
+
+    expect(appWrapper.style.getPropertyValue(bottomReserveProperty)).toBe(
+      "0px"
     );
   });
 
@@ -275,8 +299,15 @@ describe("AppLayout", () => {
 
   it("renders waves or messages view based on the view query param", () => {
     getSearchParams.mockReturnValue(new URLSearchParams("view=waves"));
-    const { rerender } = renderWithProvider(<AppLayout>child</AppLayout>);
+    const { container, rerender } = renderWithProvider(
+      <AppLayout>child</AppLayout>
+    );
+    const appWrapper = container.firstElementChild as HTMLElement;
+
     expect(screen.getByTestId("waves")).toBeInTheDocument();
+    expect(appWrapper.style.getPropertyValue(bottomReserveProperty)).toBe(
+      "0px"
+    );
 
     getSearchParams.mockReturnValue(new URLSearchParams("view=messages"));
     rerender(
@@ -285,6 +316,9 @@ describe("AppLayout", () => {
       </Provider>
     );
     expect(screen.getByTestId("messages")).toBeInTheDocument();
+    expect(appWrapper.style.getPropertyValue(bottomReserveProperty)).toBe(
+      "0px"
+    );
   });
 
   it("uses root view params for app shell content instead of route children", () => {

--- a/__tests__/components/waves/drops/WaveDropsReverseContainer.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropsReverseContainer.test.tsx
@@ -64,6 +64,13 @@ describe("WaveDropsReverseContainer", () => {
     expect(() => fireEvent.scroll(scrollDiv)).not.toThrow();
   });
 
+  it("contains edge overscroll inside the reverse message list", () => {
+    const { container } = setup();
+    const scrollDiv = container.firstChild as HTMLElement;
+
+    expect(scrollDiv).toHaveClass("tw-overscroll-y-contain");
+  });
+
   it("keeps callback ref stable across rerenders and only detaches on unmount", () => {
     const onTopIntersection = jest.fn();
     const callbackRef = jest.fn();

--- a/components/brain/mobile/BrainMobileMessages.tsx
+++ b/components/brain/mobile/BrainMobileMessages.tsx
@@ -4,6 +4,9 @@ import React, { useRef } from "react";
 import DirectMessagesList from "../direct-messages/DirectMessagesList";
 import { useLayout } from "../my-stream/layout/LayoutContext";
 
+const floatingDockClearanceClassName =
+  "tw-pb-[calc(4rem+env(safe-area-inset-bottom,0px))]";
+
 const BrainMobileMessages: React.FC = () => {
   const { mobileWavesViewStyle } = useLayout();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -11,7 +14,7 @@ const BrainMobileMessages: React.FC = () => {
     <div
       data-mobile-bottom-nav-scroll-target="true"
       ref={scrollContainerRef}
-      className="tw-overflow-y-auto tw-scrollbar-thin tw-scrollbar-thumb-iron-500 tw-scrollbar-track-iron-800 desktop-hover:hover:tw-scrollbar-thumb-iron-300 tw-space-y-4 tw-px-2 sm:tw-px-4 md:tw-px-6 tw-pt-2"
+      className={`tw-space-y-4 tw-overflow-y-auto tw-px-2 tw-pt-2 tw-scrollbar-thin tw-scrollbar-track-iron-800 tw-scrollbar-thumb-iron-500 desktop-hover:hover:tw-scrollbar-thumb-iron-300 sm:tw-px-4 md:tw-px-6 ${floatingDockClearanceClassName}`}
       style={mobileWavesViewStyle}
     >
       <DirectMessagesList scrollContainerRef={scrollContainerRef} />

--- a/components/brain/mobile/BrainMobileWaves.tsx
+++ b/components/brain/mobile/BrainMobileWaves.tsx
@@ -7,6 +7,9 @@ import BrainLeftSidebarWaves from "../left-sidebar/waves/BrainLeftSidebarWaves";
 import MemesWaveFooter from "../left-sidebar/waves/MemesWaveFooter";
 import { useLayout } from "../my-stream/layout/LayoutContext";
 
+const floatingDockClearanceClassName =
+  "tw-pb-[calc(4rem+env(safe-area-inset-bottom,0px))]";
+
 interface BrainMobileWavesProps {
   readonly onOpenQuickVote: () => void;
   readonly onPrefetchQuickVote?: (() => void) | undefined;
@@ -19,8 +22,7 @@ const BrainMobileWaves: React.FC<BrainMobileWavesProps> = ({
   const { mobileWavesViewStyle } = useLayout();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   // We'll use the mobileWavesViewStyle for capacitor spacing
-  const scrollContainerClassName =
-    "tw-min-h-0 tw-flex-1 tw-overflow-y-auto tw-scrollbar-thin tw-scrollbar-thumb-iron-500 tw-scrollbar-track-iron-800 desktop-hover:hover:tw-scrollbar-thumb-iron-300 tw-space-y-4 tw-px-2 sm:tw-px-4 md:tw-px-6 tw-pt-2";
+  const scrollContainerClassName = `tw-min-h-0 tw-flex-1 tw-overflow-y-auto tw-scrollbar-thin tw-scrollbar-thumb-iron-500 tw-scrollbar-track-iron-800 desktop-hover:hover:tw-scrollbar-thumb-iron-300 tw-space-y-4 tw-px-2 sm:tw-px-4 md:tw-px-6 tw-pt-2 ${floatingDockClearanceClassName}`;
 
   return (
     <div

--- a/components/brain/my-stream/MyStreamWaveChat.tsx
+++ b/components/brain/my-stream/MyStreamWaveChat.tsx
@@ -218,7 +218,7 @@ const MyStreamWaveChat: React.FC<MyStreamWaveChatProps> = ({
 
   const containerClassName = useMemo(() => {
     const baseStyles =
-      "tw-w-full tw-flex tw-flex-col tw-overflow-y-auto tw-overflow-x-hidden lg:tw-scrollbar-thin tw-scrollbar-thumb-iron-500 tw-scrollbar-track-iron-800 desktop-hover:hover:tw-scrollbar-thumb-iron-300 scroll-shadow";
+      "tw-w-full tw-flex tw-flex-col tw-overflow-y-auto tw-overflow-x-hidden tw-overscroll-y-contain lg:tw-scrollbar-thin tw-scrollbar-thumb-iron-500 tw-scrollbar-track-iron-800 desktop-hover:hover:tw-scrollbar-thumb-iron-300 scroll-shadow";
 
     const heightClass = "tw-flex-grow";
 

--- a/components/brain/my-stream/layout/LayoutContext.tsx
+++ b/components/brain/my-stream/layout/LayoutContext.tsx
@@ -443,7 +443,7 @@ export const LayoutProvider: React.FC<{ children: ReactNode }> = ({
 
   const mobileWavesViewStyle = useMemo<React.CSSProperties>(() => {
     if (!navAdjustedSpaces.measurementsComplete) return {};
-    return calculateHeightStyle(navAdjustedSpaces, 0);
+    return calculateHeightStyle({ ...navAdjustedSpaces, mobileNavSpace: 0 }, 0);
   }, [navAdjustedSpaces]);
 
   const mobileAboutViewStyle = useMemo<React.CSSProperties>(() => {

--- a/components/brain/notifications/index.tsx
+++ b/components/brain/notifications/index.tsx
@@ -96,7 +96,7 @@ export default function Notifications({
           onTopIntersection={handleTopIntersection}
           isFetchingNextPage={isFetchingNextPage}
           hasNextPage={pagination.hasNextPage}
-          bottomPaddingClassName="tw-pb-[calc(5.75rem+env(safe-area-inset-bottom,0px))]"
+          bottomPaddingClassName="tw-pb-[calc(4rem+env(safe-area-inset-bottom,0px))]"
           containerClassName="tw-bg-transparent"
         >
           <NotificationsContent

--- a/components/common/icons/LogoIcon.tsx
+++ b/components/common/icons/LogoIcon.tsx
@@ -12,8 +12,7 @@ const LogoIcon = ({
   const wrapperClassName = className
     ? `tw-relative tw-inline-block tw-align-middle ${className}`
     : "tw-relative tw-inline-block tw-size-6 tw-align-middle";
-  const imageClassName =
-    "tw-absolute tw-inset-0 tw-h-full tw-w-full tw-transition-opacity tw-duration-75 motion-reduce:tw-transition-none";
+  const imageClassName = "tw-absolute tw-inset-0 tw-h-full tw-w-full";
 
   return (
     <span aria-hidden="true" className={wrapperClassName}>

--- a/components/layout/AppLayout.tsx
+++ b/components/layout/AppLayout.tsx
@@ -54,6 +54,24 @@ const streamRouteLoadingReserveVisibleStyle: StreamRouteLoadingReserveStyle = {
     STREAM_ROUTE_LOADING_HEADER_FALLBACK_RESERVE,
 };
 
+const contentOwnsBottomNavClearance = ({
+  activeView,
+  pathname,
+}: {
+  readonly activeView: string | null;
+  readonly pathname: string | null | undefined;
+}): boolean => {
+  if (activeView === "waves" || activeView === "messages") {
+    return true;
+  }
+
+  return (
+    pathname === "/waves" ||
+    pathname === "/messages" ||
+    pathname === "/notifications"
+  );
+};
+
 function WavesQuickVoteView() {
   const quickVote = useMemesQuickVoteDialogController();
 
@@ -116,18 +134,23 @@ function AppLayoutContent({ children }: Props) {
   const isNavVisible =
     !isSingleDropOpen && !isEditingOnMobile && !shouldHideBottomNav;
   const shouldRenderBottomNav = !isSingleDropOpen && !isEditingOnMobile;
+  const shouldUseContentBottomClearance = contentOwnsBottomNavClearance({
+    activeView,
+    pathname,
+  });
   const routeLoadingHeaderReserve = spaces.measurementsComplete
     ? `${spaces.headerSpace}px`
     : STREAM_ROUTE_LOADING_HEADER_FALLBACK_RESERVE;
   const streamRouteLoadingReserveStyle =
     useMemo<StreamRouteLoadingReserveStyle>(
       () => ({
-        [STREAM_ROUTE_LOADING_BOTTOM_RESERVE]: isNavVisible
-          ? BOTTOM_NAV_RESERVE
-          : "0px",
+        [STREAM_ROUTE_LOADING_BOTTOM_RESERVE]:
+          isNavVisible && !shouldUseContentBottomClearance
+            ? BOTTOM_NAV_RESERVE
+            : "0px",
         [STREAM_ROUTE_LOADING_HEADER_RESERVE]: routeLoadingHeaderReserve,
       }),
-      [isNavVisible, routeLoadingHeaderReserve]
+      [isNavVisible, routeLoadingHeaderReserve, shouldUseContentBottomClearance]
     );
   const safeAreaClass =
     !isNavVisible && !isKeyboardVisible
@@ -154,7 +177,9 @@ function AppLayoutContent({ children }: Props) {
         <TouchDeviceHeader />
       </div>
       {activeContent}
-      {isNavVisible && <div className="tw-h-[104px] tw-w-full" />}
+      {isNavVisible && !shouldUseContentBottomClearance && (
+        <div className="tw-h-[104px] tw-w-full" />
+      )}
       {shouldRenderBottomNav && (
         <BottomNavigation hidden={shouldHideBottomNav} />
       )}

--- a/components/waves/drops/WaveDropsReverseContainer.tsx
+++ b/components/waves/drops/WaveDropsReverseContainer.tsx
@@ -74,7 +74,7 @@ export const WaveDropsReverseContainer = forwardRef<
         data-mobile-bottom-nav-scroll-target="true"
         className={`tw-min-h-0 tw-flex-1 ${
           bottomPaddingClassName ?? "tw-pb-6"
-        } no-scrollbar tw-flex tw-flex-col-reverse tw-overflow-y-auto tw-overflow-x-hidden tw-bg-iron-950 tw-scrollbar-track-iron-800 tw-scrollbar-thumb-iron-500 hover:tw-scrollbar-thumb-iron-300 lg:tw-scrollbar-thin ${containerClassName ?? ""}`}
+        } no-scrollbar tw-flex tw-flex-col-reverse tw-overflow-y-auto tw-overflow-x-hidden tw-overscroll-y-contain tw-bg-iron-950 tw-scrollbar-track-iron-800 tw-scrollbar-thumb-iron-500 hover:tw-scrollbar-thumb-iron-300 lg:tw-scrollbar-thin ${containerClassName ?? ""}`}
       >
         <div className="tw-flex tw-flex-col">
           {hasNextPage && isFetchingNextPage && (


### PR DESCRIPTION
## Summary
- Remove the generic app-shell bottom spacer from mobile list routes so `/waves`, `/messages`, and `/notifications` own their dock clearance.
- Keep mobile waves/messages list height from subtracting the floating nav, then add scroll-container bottom clearance instead.
- Reduce notifications reverse-list dock padding to avoid the oversized bottom gap.
- Make the center 6529 dock logo color swap immediate instead of cross-fading through a hard-to-see intermediate state.
- Contain wave chat edge overscroll so the page shell/input are not dragged when the reverse message list is already at its scroll edge.

## Validation
- `./bin/6529 run test -- __tests__/components/common/icons/LogoIcon.test.tsx __tests__/components/waves/drops/WaveDropsReverseContainer.test.tsx`
- `./bin/6529 run check:changed`