### PR TITLE
Refine Worth Checking Out score badges

### DIFF
--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -58,6 +58,7 @@ jest.mock(
     WaveAvatar: (props: any) => (
       <div
         data-testid={`preview-avatar-${props.wave.id}`}
+        data-drop-badge-placement={props.dropBadgePlacement}
         data-is-drop-wave={String(props.isDropWave)}
         data-show-new-drops-badge={String(props.showNewDropsBadge)}
         data-show-unread-drops-badge={String(props.showUnreadDropsBadge)}
@@ -433,9 +434,15 @@ it("uses highly rated preview score semantics instead of unread badges", () => {
   expect(
     screen.getByRole("link", { name: "Open Scored Discovery, score 93" })
   ).toBeInTheDocument();
-  expect(screen.getByText("93", { selector: "text" })).toBeInTheDocument();
+  const scoreBadgeText = screen.getByText("93", { selector: "text" });
+  expect(scoreBadgeText).toBeInTheDocument();
+  expect(scoreBadgeText.closest("svg")).toHaveClass("-tw-right-1.5");
   expect(screen.getByText("Score 93")).toBeInTheDocument();
   expect(screen.queryByRole("link", { name: /new messages/ })).toBeNull();
+  expect(screen.getByTestId("preview-avatar-h-score")).toHaveAttribute(
+    "data-drop-badge-placement",
+    "bottom-left"
+  );
   expect(screen.getByTestId("preview-avatar-h-score")).toHaveAttribute(
     "data-show-new-drops-badge",
     "false"

--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -436,7 +436,8 @@ it("uses highly rated preview score semantics instead of unread badges", () => {
   ).toBeInTheDocument();
   const scoreBadgeText = screen.getByText("93", { selector: "text" });
   expect(scoreBadgeText).toBeInTheDocument();
-  expect(scoreBadgeText.closest("svg")).toHaveClass("-tw-right-1.5");
+  expect(scoreBadgeText.closest("svg")).toHaveClass("-tw-bottom-0.5");
+  expect(scoreBadgeText.closest("svg")).toHaveClass("-tw-right-1");
   expect(screen.getByText("Score 93")).toBeInTheDocument();
   expect(screen.queryByRole("link", { name: /new messages/ })).toBeNull();
   expect(screen.getByTestId("preview-avatar-h-score")).toHaveAttribute(

--- a/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
+++ b/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
@@ -144,18 +144,18 @@ const getWaveScoreLabel = (wave: MinimalWave): string | null => {
 
 const getScoreBadgeFontSize = (scoreLabel: string) => {
   if (scoreLabel.length >= 5) {
-    return 5.6;
+    return 5.1;
   }
 
   if (scoreLabel.length === 4) {
-    return 6.4;
+    return 5.9;
   }
 
   if (scoreLabel.length === 3) {
-    return 7.4;
+    return 6.9;
   }
 
-  return 9.2;
+  return 8.5;
 };
 
 export const getFittingPreviewCount = ({
@@ -265,12 +265,12 @@ function HighlyRatedWavePreviewScoreBadge({
     <svg
       aria-hidden="true"
       viewBox="0 0 32 26"
-      className="tw-pointer-events-none tw-absolute -tw-bottom-1.5 -tw-right-1.5 tw-z-10 tw-h-5 tw-w-6 tw-overflow-visible tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)]"
+      className="tw-pointer-events-none tw-absolute -tw-bottom-0.5 -tw-right-1 tw-z-10 tw-h-[18px] tw-w-[22px] tw-overflow-visible tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)]"
     >
       <path
         d="M16 2.15 28 6.15v6.7c0 5.45-4.35 9.5-12 11.2-7.65-1.7-12-5.75-12-11.2v-6.7L16 2.15Z"
         className="tw-fill-iron-800 tw-stroke-iron-950"
-        strokeWidth="2.6"
+        strokeWidth="2.4"
         strokeLinejoin="round"
       />
       <path
@@ -285,7 +285,7 @@ function HighlyRatedWavePreviewScoreBadge({
         dominantBaseline="middle"
         textAnchor="middle"
         fontSize={getScoreBadgeFontSize(scoreLabel)}
-        fontWeight="800"
+        fontWeight="700"
         className="tw-fill-iron-50"
       >
         {scoreLabel}

--- a/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
+++ b/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
@@ -144,18 +144,18 @@ const getWaveScoreLabel = (wave: MinimalWave): string | null => {
 
 const getScoreBadgeFontSize = (scoreLabel: string) => {
   if (scoreLabel.length >= 5) {
-    return 5;
+    return 5.6;
   }
 
   if (scoreLabel.length === 4) {
-    return 5.8;
+    return 6.4;
   }
 
   if (scoreLabel.length === 3) {
-    return 7;
+    return 7.4;
   }
 
-  return 8.8;
+  return 9.2;
 };
 
 export const getFittingPreviewCount = ({
@@ -264,24 +264,24 @@ function HighlyRatedWavePreviewScoreBadge({
   return (
     <svg
       aria-hidden="true"
-      viewBox="0 0 24 28"
-      className="tw-pointer-events-none tw-absolute -tw-bottom-1.5 -tw-left-1.5 tw-z-10 tw-h-6 tw-w-5 tw-overflow-visible tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)]"
+      viewBox="0 0 32 26"
+      className="tw-pointer-events-none tw-absolute -tw-bottom-1.5 -tw-right-1.5 tw-z-10 tw-h-5 tw-w-6 tw-overflow-visible tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)]"
     >
       <path
-        d="M12 1.8 21.4 5.45v7.35c0 6.1-3.7 11.05-9.4 13.4-5.7-2.35-9.4-7.3-9.4-13.4V5.45L12 1.8Z"
+        d="M16 2.15 28 6.15v6.7c0 5.45-4.35 9.5-12 11.2-7.65-1.7-12-5.75-12-11.2v-6.7L16 2.15Z"
         className="tw-fill-iron-800 tw-stroke-iron-950"
-        strokeWidth="2.8"
+        strokeWidth="2.6"
         strokeLinejoin="round"
       />
       <path
-        d="M12 3.9 19.1 6.65v6.1c0 4.95-2.65 8.95-7.1 11-4.45-2.05-7.1-6.05-7.1-11v-6.1L12 3.9Z"
+        d="M16 4.7 25.35 7.75v5.1c0 4.15-3.2 7.15-9.35 8.75-6.15-1.6-9.35-4.6-9.35-8.75v-5.1L16 4.7Z"
         className="tw-fill-none tw-stroke-white/20"
         strokeWidth="1"
         strokeLinejoin="round"
       />
       <text
-        x="12"
-        y="14.2"
+        x="16"
+        y="13.2"
         dominantBaseline="middle"
         textAnchor="middle"
         fontSize={getScoreBadgeFontSize(scoreLabel)}
@@ -338,6 +338,7 @@ function HighlyRatedWavePreviewLink({
       className="tw-group/preview tw-relative tw-flex tw-size-8 tw-flex-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400"
     >
       <WaveAvatar
+        dropBadgePlacement="bottom-left"
         isActive={item.isActive}
         isDropWave={isDropWave}
         showNewDropsBadge={false}
@@ -361,11 +362,11 @@ function HighlyRatedWavePreviewLink({
             <span className="tw-ml-auto tw-inline-flex tw-items-center tw-gap-1 tw-whitespace-nowrap">
               <svg
                 className="tw-size-3 tw-flex-shrink-0 tw-text-iron-400"
-                viewBox="0 0 24 28"
+                viewBox="0 0 32 26"
                 aria-hidden="true"
               >
                 <path
-                  d="M12 2.2 21 5.7v7.1c0 5.9-3.55 10.6-9 12.9-5.45-2.3-9-7-9-12.9V5.7L12 2.2Z"
+                  d="M16 2.4 27.3 6.2v6.65c0 5.25-4.1 9.15-11.3 10.85-7.2-1.7-11.3-5.6-11.3-10.85V6.2L16 2.4Z"
                   fill="none"
                   stroke="currentColor"
                   strokeWidth="2.2"

--- a/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/WaveAvatar.tsx
+++ b/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/WaveAvatar.tsx
@@ -6,6 +6,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 interface WaveAvatarProps {
   readonly isActive: boolean;
   readonly isDropWave: boolean;
+  readonly dropBadgePlacement?: "bottom-left" | "bottom-right" | undefined;
   readonly showNewDropsBadge: boolean;
   readonly showUnreadDropsBadge?: boolean | undefined;
   readonly wave: MinimalWave;
@@ -34,7 +35,26 @@ const MUTED_BADGE_CLASSES =
   "tw-absolute tw-right-[-4px] tw-top-[-4px] tw-flex tw-size-4 tw-items-center tw-justify-center tw-rounded-full tw-bg-red tw-text-white tw-shadow-sm";
 const MUTED_ICON_CLASSES = "tw-size-2.5 tw-flex-shrink-0";
 
+const getDropBadgePlacementClasses = ({
+  isSmall,
+  placement,
+}: {
+  readonly isSmall: boolean;
+  readonly placement: "bottom-left" | "bottom-right";
+}) => {
+  if (placement === "bottom-left") {
+    return isSmall
+      ? "tw-bottom-[-1px] tw-left-[-1px]"
+      : "tw-bottom-[-2px] tw-left-[-2px]";
+  }
+
+  return isSmall
+    ? "tw-bottom-[-1px] tw-right-[-1px]"
+    : "tw-bottom-[-2px] tw-right-[-2px]";
+};
+
 export const WaveAvatar = ({
+  dropBadgePlacement = "bottom-right",
   isActive,
   isDropWave,
   showNewDropsBadge,
@@ -54,9 +74,11 @@ export const WaveAvatar = ({
   const activeRingClasses = isSmall
     ? "tw-opacity-100 tw-ring-1 tw-ring-white/30 tw-ring-offset-1 tw-ring-offset-iron-950"
     : "tw-opacity-100 tw-ring-1 tw-ring-white/30 tw-ring-offset-2 tw-ring-offset-iron-950";
-  const dropBadgeClasses = isSmall
-    ? "tw-absolute tw-bottom-[-1px] tw-right-[-1px] tw-flex tw-size-3.5 tw-items-center tw-justify-center tw-rounded-full tw-bg-iron-950 tw-shadow-lg"
-    : "tw-absolute tw-bottom-[-2px] tw-right-[-2px] tw-flex tw-size-3.5 tw-items-center tw-justify-center tw-rounded-full tw-bg-iron-950 tw-shadow-lg";
+  const dropBadgePlacementClasses = getDropBadgePlacementClasses({
+    isSmall,
+    placement: dropBadgePlacement,
+  });
+  const dropBadgeClasses = `tw-absolute ${dropBadgePlacementClasses} tw-flex tw-size-3.5 tw-items-center tw-justify-center tw-rounded-full tw-bg-iron-950 tw-shadow-lg`;
 
   return (
     <div

--- a/pr-reports/2871.md
+++ b/pr-reports/2871.md
@@ -26,4 +26,4 @@ No config or environment changes.
 Worth Checking Out wave previews now use a wider lower-right score shield and keep trophy/drop markers on the opposite side, improving readability in the compact avatar strip.
 
 ## Risks / Follow-Ups
-Frontend staging deploy completion and deployed-environment smoke checks will be intentionally not awaited per request.
+Frontend staging deploy run https://github.com/6529-Collections/6529seize-frontend/actions/runs/28089864110 was started from staging commit `f8455e7a1`; completion and deployed-environment smoke checks were intentionally not awaited per request.

--- a/pr-reports/2871.md
+++ b/pr-reports/2871.md
@@ -1,0 +1,29 @@
+# PR Report: Worth Checking Out Score Badge Layout
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/2871
+Branch: `codex/worth-score-badge-layout` -> `main`
+Related PRs: Follows https://github.com/6529-Collections/6529seize-frontend/pull/2868
+
+## Summary
+The Worth Checking Out preview score badge now reads less like a tall tag and keeps the recommendation score visible without colliding with the trophy/drop marker.
+
+## What Changed
+- Widened the local score shield SVG used only by the Worth Checking Out preview strip.
+- Moved the score shield to the lower-right of preview avatars.
+- Added a defaulted sidebar avatar prop so this preview can place trophy/drop markers lower-left while all existing avatar callers keep their current lower-right default.
+- Updated focused sidebar preview coverage for the visible score badge and inverted badge placement.
+
+## Frontend Impact
+- Routes/views: Waves sidebar and web/app brain left-sidebar wave discovery surfaces.
+- Components: Highly rated preview strip and shared sidebar wave avatar.
+- Generated API/client: Not affected.
+- User-visible behavior: Worth Checking Out avatars show a wider lower-right score shield, while trophy/drop markers appear lower-left only in that preview strip.
+
+## Config / Env
+No config or environment changes.
+
+## Release Notes
+Worth Checking Out wave previews now use a wider lower-right score shield and keep trophy/drop markers on the opposite side, improving readability in the compact avatar strip.
+
+## Risks / Follow-Ups
+Frontend staging deploy completion and deployed-environment smoke checks will be intentionally not awaited per request.


### PR DESCRIPTION
## Issue
- The previous Worth Checking Out score shield showed the right intent, but the shield read as too tall/vertical in the avatar row.
- Score and trophy/drop badges also competed for the same side of the avatar.

## Fix
- Make the Worth Checking Out score shield wider and less tag-like, then move it to the lower-right of the preview avatar.
- Move the existing trophy/drop marker to lower-left only for this preview strip; the shared avatar default and existing rating UI elsewhere stay unchanged.

## Changes
- Added a defaulted `dropBadgePlacement` prop to the sidebar `WaveAvatar` so existing callers keep bottom-right placement.
- Passed bottom-left trophy/drop placement only from the highly rated Worth Checking Out preview.
- Reworked the local score shield SVG dimensions/path and kept the score visible inside the shield.
- Updated the focused sidebar preview regression test to cover the inverted badge positions.

## Risk
- Level: Low
- Why: Narrow visual/UI behavior change scoped to the Worth Checking Out preview strip plus a backward-compatible avatar prop default.
- Rollback: Revert this PR to return to the merged score-in-shield placement.

## Review Notes
- Please focus on the visual balance of the wider bottom-right score shield beside the bottom-left trophy/drop marker at 32px avatar size.