### PR TITLE
Verify session v2 web session before connection sharing

### DIFF
--- a/__tests__/components/auth/Auth.test.tsx
+++ b/__tests__/components/auth/Auth.test.tsx
@@ -64,6 +64,7 @@ jest.mock("@/services/auth/session-v2.utils", () => ({
   getSessionNonce: jest.fn(),
   loginWithSessionV2: jest.fn(),
   persistSessionResponse: jest.fn(),
+  verifyActiveSessionV2WebSession: jest.fn(async () => true),
 }));
 
 // Using jwt-validation.utils instead of direct jwt-decode
@@ -386,6 +387,8 @@ describe("Auth component", () => {
     sessionV2.loginWithSessionV2.mockReset();
     sessionV2.persistSessionResponse.mockReset();
     sessionV2.persistSessionResponse.mockResolvedValue(true);
+    sessionV2.verifyActiveSessionV2WebSession.mockReset();
+    sessionV2.verifyActiveSessionV2WebSession.mockResolvedValue(true);
 
     // Reset useIdentity mock
     mockUseIdentity.mockReturnValue({ profile: null, isLoading: false });
@@ -1549,6 +1552,89 @@ describe("Auth component", () => {
         screen.queryByText("Upgrade Authentication")
       ).not.toBeInTheDocument();
       expect(mockRemoveAuthJwt).not.toHaveBeenCalled();
+    });
+
+    it("marks a connected local v2 session as needing upgrade when the web session is missing", async () => {
+      const validAddress = "0x1111111111111111111111111111111111111111";
+      walletAddress = validAddress;
+      const authUtils = require("@/services/auth/auth.utils");
+      const sessionV2 = require("@/services/auth/session-v2.utils");
+      const mockValidateAuthImmediate =
+        require("@/services/auth/immediate-validation.utils").validateAuthImmediate;
+      const mockGetAuthJwt = authUtils.getAuthJwt as jest.MockedFunction<any>;
+      const mockGetWalletAddress =
+        authUtils.getWalletAddress as jest.MockedFunction<any>;
+      const mockHasActiveSessionV2Auth =
+        authUtils.hasActiveSessionV2Auth as jest.MockedFunction<any>;
+      mockGetAuthJwt.mockReturnValue("v2-jwt");
+      mockGetWalletAddress.mockReturnValue(validAddress);
+      mockHasActiveSessionV2Auth.mockReturnValue(true);
+      sessionV2.verifyActiveSessionV2WebSession.mockResolvedValue(false);
+
+      render(
+        <ReactQueryWrapperContext.Provider
+          value={{ invalidateAll: jest.fn() } as any}
+        >
+          <Auth>
+            <SessionUpgradeProbe />
+          </Auth>
+        </ReactQueryWrapperContext.Provider>
+      );
+
+      await waitFor(() => {
+        expect(sessionV2.verifyActiveSessionV2WebSession).toHaveBeenCalledWith({
+          address: validAddress,
+          abortSignal: expect.objectContaining({ aborted: false }),
+        });
+      });
+      expect(screen.getByTestId("session-upgrade-required")).toHaveTextContent(
+        "true"
+      );
+      expect(
+        screen.queryByText("Upgrade Authentication")
+      ).not.toBeInTheDocument();
+      expect(mockValidateAuthImmediate).not.toHaveBeenCalled();
+    });
+
+    it("marks a disconnected stored v2 session as needing upgrade when the web session is missing", async () => {
+      const validAddress = "0x1111111111111111111111111111111111111111";
+      walletAddress = null;
+      connectionState = "disconnected";
+      canSignActiveWallet = false;
+      const authUtils = require("@/services/auth/auth.utils");
+      const sessionV2 = require("@/services/auth/session-v2.utils");
+      const mockGetAuthJwt = authUtils.getAuthJwt as jest.MockedFunction<any>;
+      const mockGetWalletAddress =
+        authUtils.getWalletAddress as jest.MockedFunction<any>;
+      const mockHasActiveSessionV2Auth =
+        authUtils.hasActiveSessionV2Auth as jest.MockedFunction<any>;
+      mockGetAuthJwt.mockReturnValue("v2-jwt");
+      mockGetWalletAddress.mockReturnValue(validAddress);
+      mockHasActiveSessionV2Auth.mockReturnValue(true);
+      sessionV2.verifyActiveSessionV2WebSession.mockResolvedValue(false);
+
+      render(
+        <ReactQueryWrapperContext.Provider
+          value={{ invalidateAll: jest.fn() } as any}
+        >
+          <Auth>
+            <SessionUpgradeProbe />
+          </Auth>
+        </ReactQueryWrapperContext.Provider>
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId("session-upgrade-required")
+        ).toHaveTextContent("true");
+      });
+      expect(sessionV2.verifyActiveSessionV2WebSession).toHaveBeenCalledWith({
+        address: validAddress,
+        abortSignal: expect.objectContaining({ aborted: false }),
+      });
+      expect(
+        screen.queryByText("Upgrade Authentication")
+      ).not.toBeInTheDocument();
     });
 
     it("allows a disconnected legacy web session to start manual upgrade without a rollout deadline", async () => {

--- a/__tests__/components/auth/Auth.test.tsx
+++ b/__tests__/components/auth/Auth.test.tsx
@@ -2109,6 +2109,48 @@ describe("Auth component", () => {
       ).not.toBeInTheDocument();
     });
 
+    it("dismisses the session upgrade prompt when opening the learn more page", async () => {
+      const validAddress = "0x1111111111111111111111111111111111111111";
+      walletAddress = validAddress;
+      enableAuthMigrationDeadline();
+      const mockValidateAuthImmediate =
+        require("@/services/auth/immediate-validation.utils").validateAuthImmediate;
+      mockValidateAuthImmediate.mockImplementation(async ({ callbacks }) => {
+        callbacks.onSessionUpgradeRequired();
+        return {
+          validationCompleted: true,
+          wasCancelled: false,
+          shouldShowModal: true,
+        };
+      });
+
+      render(
+        <ReactQueryWrapperContext.Provider
+          value={{ invalidateAll: jest.fn() } as any}
+        >
+          <Auth>
+            <div data-testid="auth-component">Auth Component</div>
+          </Auth>
+        </ReactQueryWrapperContext.Provider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Upgrade Authentication")).toBeInTheDocument();
+      });
+
+      const user = userEvent.setup();
+      await user.click(screen.getByText("Learn more about this update"));
+
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        "/about/tech/wallet-authentication"
+      );
+      await waitFor(() => {
+        expect(
+          screen.queryByText("Upgrade Authentication")
+        ).not.toBeInTheDocument();
+      });
+    });
+
     it("keeps session upgrade dismiss reminders scoped to each connected account", async () => {
       const firstAddress = "0x1111111111111111111111111111111111111111";
       const secondAddress = "0x2222222222222222222222222222222222222222";

--- a/__tests__/components/auth/Auth.test.tsx
+++ b/__tests__/components/auth/Auth.test.tsx
@@ -271,14 +271,20 @@ function RequestAuthButton() {
 }
 
 function SessionUpgradeProbe() {
-  const { requestSessionUpgrade, sessionUpgradeRequired } = useAuth();
+  const {
+    ensureActiveSessionV2WebSession,
+    requestSessionUpgrade,
+    sessionUpgradeRequired,
+  } = useAuth();
   const [result, setResult] = React.useState("none");
+  const [verifyResult, setVerifyResult] = React.useState("none");
   return (
     <div>
       <span data-testid="session-upgrade-required">
         {String(sessionUpgradeRequired)}
       </span>
       <span data-testid="session-upgrade-result">{result}</span>
+      <span data-testid="session-verify-result">{verifyResult}</span>
       <button
         type="button"
         onClick={() =>
@@ -289,6 +295,17 @@ function SessionUpgradeProbe() {
         data-testid="request-session-upgrade"
       >
         upgrade
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          void ensureActiveSessionV2WebSession?.().then((success) => {
+            setVerifyResult(String(success));
+          })
+        }
+        data-testid="verify-session"
+      >
+        verify
       </button>
     </div>
   );
@@ -1594,6 +1611,62 @@ describe("Auth component", () => {
         screen.queryByText("Upgrade Authentication")
       ).not.toBeInTheDocument();
       expect(mockValidateAuthImmediate).not.toHaveBeenCalled();
+    });
+
+    it("fails closed when context web-session verification errors without changing upgrade state", async () => {
+      const validAddress = "0x1111111111111111111111111111111111111111";
+      walletAddress = validAddress;
+      const authUtils = require("@/services/auth/auth.utils");
+      const sessionV2 = require("@/services/auth/session-v2.utils");
+      const mockValidateAuthImmediate =
+        require("@/services/auth/immediate-validation.utils").validateAuthImmediate;
+      const mockGetAuthJwt = authUtils.getAuthJwt as jest.MockedFunction<any>;
+      const mockGetWalletAddress =
+        authUtils.getWalletAddress as jest.MockedFunction<any>;
+      const mockHasActiveSessionV2Auth =
+        authUtils.hasActiveSessionV2Auth as jest.MockedFunction<any>;
+      mockGetAuthJwt.mockReturnValue("v2-jwt");
+      mockGetWalletAddress.mockReturnValue(validAddress);
+      mockHasActiveSessionV2Auth.mockReturnValue(true);
+      sessionV2.verifyActiveSessionV2WebSession
+        .mockResolvedValueOnce(true)
+        .mockRejectedValueOnce(new Error("verification failed"));
+      mockValidateAuthImmediate.mockResolvedValue({
+        validationCompleted: true,
+        wasCancelled: false,
+        shouldShowModal: false,
+      });
+
+      render(
+        <ReactQueryWrapperContext.Provider
+          value={{ invalidateAll: jest.fn() } as any}
+        >
+          <Auth>
+            <SessionUpgradeProbe />
+          </Auth>
+        </ReactQueryWrapperContext.Provider>
+      );
+
+      await waitFor(() => {
+        expect(sessionV2.verifyActiveSessionV2WebSession).toHaveBeenCalledTimes(
+          1
+        );
+      });
+
+      const user = userEvent.setup();
+      await user.click(screen.getByTestId("verify-session"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("session-verify-result")).toHaveTextContent(
+          "false"
+        );
+      });
+      expect(screen.getByTestId("session-upgrade-required")).toHaveTextContent(
+        "false"
+      );
+      expect(
+        screen.queryByText("Upgrade Authentication")
+      ).not.toBeInTheDocument();
     });
 
     it("marks a disconnected stored v2 session as needing upgrade when the web session is missing", async () => {

--- a/__tests__/components/header/share/HeaderShare.test.tsx
+++ b/__tests__/components/header/share/HeaderShare.test.tsx
@@ -493,10 +493,32 @@ describe("HeaderShare", () => {
         expect.objectContaining({ aborted: false })
       );
       expect(sessionV2.createConnectionShare).not.toHaveBeenCalled();
+      expect(requestSessionUpgrade).not.toHaveBeenCalled();
 
       await userEvent.click(screen.getByRole("button", { name: "Update" }));
 
       expect(requestSessionUpgrade).toHaveBeenCalledTimes(1);
+    });
+
+    it("fails closed without calling the share endpoint when the web-session verifier is unavailable", async () => {
+      const auth = require("@/components/auth/Auth");
+      const requestSessionUpgrade = jest.fn().mockResolvedValue({
+        success: true,
+      });
+      auth.useAuth.mockReturnValue({
+        requestSessionUpgrade,
+      });
+      const sessionV2 = require("@/services/auth/session-v2.utils");
+
+      renderWithProviders(<HeaderShare />);
+
+      await userEvent.click(screen.getByRole("button", { name: "QR Code" }));
+
+      expect(
+        await screen.findByText("Update Authentication")
+      ).toBeInTheDocument();
+      expect(sessionV2.createConnectionShare).not.toHaveBeenCalled();
+      expect(requestSessionUpgrade).not.toHaveBeenCalled();
     });
 
     it("fails closed without calling the share endpoint when web-session verification errors", async () => {
@@ -516,18 +538,21 @@ describe("HeaderShare", () => {
         .spyOn(console, "error")
         .mockImplementation(() => undefined);
 
-      renderWithProviders(<HeaderShare />);
+      try {
+        renderWithProviders(<HeaderShare />);
 
-      await userEvent.click(screen.getByRole("button", { name: "QR Code" }));
+        await userEvent.click(screen.getByRole("button", { name: "QR Code" }));
 
-      expect(
-        await screen.findByText("Update Authentication")
-      ).toBeInTheDocument();
-      expect(ensureActiveSessionV2WebSession).toHaveBeenCalledWith(
-        expect.objectContaining({ aborted: false })
-      );
-      expect(sessionV2.createConnectionShare).not.toHaveBeenCalled();
-      consoleErrorSpy.mockRestore();
+        expect(
+          await screen.findByText("Update Authentication")
+        ).toBeInTheDocument();
+        expect(ensureActiveSessionV2WebSession).toHaveBeenCalledWith(
+          expect.objectContaining({ aborted: false })
+        );
+        expect(sessionV2.createConnectionShare).not.toHaveBeenCalled();
+      } finally {
+        consoleErrorSpy.mockRestore();
+      }
     });
 
     it("generates connection QR codes from one-time connection share codes even when the local v2 marker is stale", async () => {

--- a/__tests__/components/header/share/HeaderShare.test.tsx
+++ b/__tests__/components/header/share/HeaderShare.test.tsx
@@ -14,6 +14,7 @@ jest.mock("@/hooks/useElectron", () => ({
 }));
 jest.mock("@/components/auth/Auth", () => ({
   useAuth: jest.fn(() => ({
+    ensureActiveSessionV2WebSession: jest.fn(async () => true),
     requestSessionUpgrade: jest.fn(),
   })),
 }));
@@ -170,6 +171,7 @@ describe("HeaderShare", () => {
 
     const auth = require("@/components/auth/Auth");
     auth.useAuth.mockReturnValue({
+      ensureActiveSessionV2WebSession: jest.fn(async () => true),
       requestSessionUpgrade: jest.fn(),
     });
 
@@ -437,6 +439,7 @@ describe("HeaderShare", () => {
         success: true,
       });
       auth.useAuth.mockReturnValue({
+        ensureActiveSessionV2WebSession: jest.fn(async () => true),
         requestSessionUpgrade,
       });
       const sessionV2 = require("@/services/auth/session-v2.utils");
@@ -459,6 +462,37 @@ describe("HeaderShare", () => {
         )
       ).toBeInTheDocument();
       expect(sessionV2.createConnectionShare).toHaveBeenCalledTimes(1);
+
+      await userEvent.click(screen.getByRole("button", { name: "Update" }));
+
+      expect(requestSessionUpgrade).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows an upgrade action without calling the share endpoint when the web session is missing", async () => {
+      const auth = require("@/components/auth/Auth");
+      const requestSessionUpgrade = jest.fn().mockResolvedValue({
+        success: true,
+      });
+      const ensureActiveSessionV2WebSession = jest
+        .fn()
+        .mockResolvedValue(false);
+      auth.useAuth.mockReturnValue({
+        ensureActiveSessionV2WebSession,
+        requestSessionUpgrade,
+      });
+      const sessionV2 = require("@/services/auth/session-v2.utils");
+
+      renderWithProviders(<HeaderShare />);
+
+      await userEvent.click(screen.getByRole("button", { name: "QR Code" }));
+
+      expect(
+        await screen.findByText("Update Authentication")
+      ).toBeInTheDocument();
+      expect(ensureActiveSessionV2WebSession).toHaveBeenCalledWith(
+        expect.objectContaining({ aborted: false })
+      );
+      expect(sessionV2.createConnectionShare).not.toHaveBeenCalled();
 
       await userEvent.click(screen.getByRole("button", { name: "Update" }));
 

--- a/__tests__/components/header/share/HeaderShare.test.tsx
+++ b/__tests__/components/header/share/HeaderShare.test.tsx
@@ -499,6 +499,37 @@ describe("HeaderShare", () => {
       expect(requestSessionUpgrade).toHaveBeenCalledTimes(1);
     });
 
+    it("fails closed without calling the share endpoint when web-session verification errors", async () => {
+      const auth = require("@/components/auth/Auth");
+      const requestSessionUpgrade = jest.fn().mockResolvedValue({
+        success: true,
+      });
+      const ensureActiveSessionV2WebSession = jest
+        .fn()
+        .mockRejectedValue(new Error("verification failed"));
+      auth.useAuth.mockReturnValue({
+        ensureActiveSessionV2WebSession,
+        requestSessionUpgrade,
+      });
+      const sessionV2 = require("@/services/auth/session-v2.utils");
+      const consoleErrorSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+
+      renderWithProviders(<HeaderShare />);
+
+      await userEvent.click(screen.getByRole("button", { name: "QR Code" }));
+
+      expect(
+        await screen.findByText("Update Authentication")
+      ).toBeInTheDocument();
+      expect(ensureActiveSessionV2WebSession).toHaveBeenCalledWith(
+        expect.objectContaining({ aborted: false })
+      );
+      expect(sessionV2.createConnectionShare).not.toHaveBeenCalled();
+      consoleErrorSpy.mockRestore();
+    });
+
     it("generates connection QR codes from one-time connection share codes even when the local v2 marker is stale", async () => {
       const qrcode = require("qrcode");
       const sessionV2 = require("@/services/auth/session-v2.utils");

--- a/__tests__/services/auth/session-v2.utils.test.ts
+++ b/__tests__/services/auth/session-v2.utils.test.ts
@@ -16,6 +16,7 @@ import {
   persistSessionResponse,
   redeemConnectionShare,
   refreshSessionV2,
+  verifyActiveSessionV2WebSession,
 } from "@/services/auth/session-v2.utils";
 
 jest.mock("@capacitor/core", () => ({
@@ -290,6 +291,45 @@ describe("session-v2.utils", () => {
       credentials: "include",
       errorMode: "structured",
     });
+  });
+
+  it("verifies an active web session without rewriting local auth", async () => {
+    const sessionResponse = {
+      client_type: "web",
+      address: "0xabc",
+      role: null,
+      access_token: "access-token",
+      access_token_expires_at: "2026-06-10T00:00:00.000Z",
+    };
+    (commonApiPost as jest.Mock).mockResolvedValueOnce(sessionResponse);
+
+    await expect(
+      verifyActiveSessionV2WebSession({ address: "0xabc" })
+    ).resolves.toBe(true);
+
+    expect(commonApiPost).toHaveBeenCalledWith({
+      endpoint: "auth/session-refresh",
+      body: {
+        client_type: "web",
+        client_address: "0xabc",
+      },
+      signal: undefined,
+      credentials: "include",
+      errorMode: "structured",
+    });
+    expect(setAuthJwt).not.toHaveBeenCalled();
+  });
+
+  it("returns false when the active web session cannot be refreshed", async () => {
+    const unauthorizedError = Object.assign(new Error("Unauthorized"), {
+      status: 401,
+      response: { status: 401 },
+    });
+    (commonApiPost as jest.Mock).mockRejectedValueOnce(unauthorizedError);
+
+    await expect(
+      verifyActiveSessionV2WebSession({ address: "0xabc" })
+    ).resolves.toBe(false);
   });
 
   it("treats unauthorized native refresh as an invalid session", async () => {

--- a/components/auth/Auth.module.scss
+++ b/components/auth/Auth.module.scss
@@ -25,11 +25,11 @@
 }
 
 .signModalTitle {
-  margin: 0;
-  color: #f5f5f5;
-  font-size: clamp(1.1rem, 1.8vw, 1.45rem);
-  font-weight: 600;
-  line-height: 1.2;
+  margin: 0 !important;
+  color: #f5f5f5 !important;
+  font-size: clamp(1.1rem, 1.8vw, 1.45rem) !important;
+  font-weight: 600 !important;
+  line-height: 1.2 !important;
 }
 
 .signModalBody {

--- a/components/auth/Auth.tsx
+++ b/components/auth/Auth.tsx
@@ -64,6 +64,7 @@ import {
   getSessionNonce,
   loginWithSessionV2,
   persistSessionResponse,
+  verifyActiveSessionV2WebSession,
 } from "@/services/auth/session-v2.utils";
 import { logErrorSecurely } from "@/utils/error-sanitizer";
 import { measureMobileLaunchAsync } from "@/utils/monitoring/mobileLaunchTiming";
@@ -115,6 +116,9 @@ type AuthContextType = {
   readonly sessionUpgradeRequired: boolean;
   readonly requestAuth: () => Promise<{ success: boolean }>;
   readonly requestSessionUpgrade?: () => Promise<{ success: boolean }>;
+  readonly ensureActiveSessionV2WebSession?: (
+    abortSignal?: AbortSignal
+  ) => Promise<boolean>;
   readonly setToast: (toast: AppToastInput) => void;
   readonly setActiveProfileProxy: (
     profileProxy: ApiProfileProxy | null
@@ -169,6 +173,10 @@ interface RunImmediateAuthValidationParams {
   readonly setShowSignModal: (show: boolean) => void;
   readonly invalidateAll: () => void;
   readonly reset: () => void;
+  readonly verifyActiveSessionV2WebSession: (
+    address: string,
+    abortSignal: AbortSignal
+  ) => Promise<boolean>;
   readonly authRolloutSettings: AuthRolloutSettings;
 }
 
@@ -313,12 +321,11 @@ const getSessionUpgradeEffectiveDeadline = (
   return getSessionUpgradeGlobalDeadline(settings);
 };
 
-const getManualSessionUpgradePromptStatus =
-  (): SessionUpgradePromptStatus => ({
-    shouldShow: true,
-    canDismiss: true,
-    timeLeftMs: 0,
-  });
+const getManualSessionUpgradePromptStatus = (): SessionUpgradePromptStatus => ({
+  shouldShow: true,
+  canDismiss: true,
+  timeLeftMs: 0,
+});
 
 const getStoredLegacySessionUpgradeAddress = (): string | null => {
   const walletAddress = getWalletAddress();
@@ -471,6 +478,7 @@ const runImmediateAuthValidation = async ({
   setShowSignModal,
   invalidateAll,
   reset,
+  verifyActiveSessionV2WebSession,
   authRolloutSettings,
 }: RunImmediateAuthValidationParams): Promise<void> => {
   if (
@@ -488,7 +496,51 @@ const runImmediateAuthValidation = async ({
   abortControllerRef.current = abortController;
   setAuthLoadingState("validating");
 
+  const markSessionUpgradeRequired = () => {
+    setSessionUpgradeRequired(true);
+    if (!hasSessionUpgradeRollout(authRolloutSettings)) {
+      setSessionUpgradeHasDeadline(false);
+      return;
+    }
+
+    setSessionUpgradeHasDeadline(true);
+    const status = getOrCreateSessionUpgradePromptStatus(
+      currentAddress,
+      authRolloutSettings
+    );
+    setSignModalReason("session-upgrade");
+    setSessionUpgradePromptMode(
+      getSessionUpgradePromptMode(canSignActiveWallet)
+    );
+    setSessionUpgradeTimeLeftMs(status.timeLeftMs);
+    setSessionUpgradeCanDismiss(status.canDismiss);
+    setShowSignModal(status.shouldShow);
+  };
+
   try {
+    if (
+      hasActiveSessionV2Auth({ address: currentAddress }) &&
+      getSessionClientType() === "web"
+    ) {
+      const hasActiveWebSession = await verifyActiveSessionV2WebSession(
+        currentAddress,
+        abortController.signal
+      );
+
+      if (
+        !hasActiveWebSession &&
+        isCurrentValidationOperation({
+          latestAddressRef,
+          activeValidationOperationIdRef,
+          currentAddress,
+          operationId,
+        })
+      ) {
+        markSessionUpgradeRequired();
+        return;
+      }
+    }
+
     const result = await measureMobileLaunchAsync(
       "auth_immediate_validation",
       () =>
@@ -504,26 +556,7 @@ const runImmediateAuthValidation = async ({
           },
           callbacks: {
             onShowSignModal: setShowSignModal,
-            onSessionUpgradeRequired: () => {
-              setSessionUpgradeRequired(true);
-              if (!hasSessionUpgradeRollout(authRolloutSettings)) {
-                setSessionUpgradeHasDeadline(false);
-                return;
-              }
-
-              setSessionUpgradeHasDeadline(true);
-              const status = getOrCreateSessionUpgradePromptStatus(
-                currentAddress,
-                authRolloutSettings
-              );
-              setSignModalReason("session-upgrade");
-              setSessionUpgradePromptMode(
-                getSessionUpgradePromptMode(canSignActiveWallet)
-              );
-              setSessionUpgradeTimeLeftMs(status.timeLeftMs);
-              setSessionUpgradeCanDismiss(status.canDismiss);
-              setShowSignModal(status.shouldShow);
-            },
+            onSessionUpgradeRequired: markSessionUpgradeRequired,
             onInvalidateCache: invalidateAll,
             onReset: reset,
             onRemoveJwt: () => removeAuthJwt(),
@@ -566,6 +599,7 @@ export const AuthContext = createContext<AuthContextType>({
   requestAuth: async () => ({ success: false }),
   sessionUpgradeRequired: false,
   requestSessionUpgrade: async () => ({ success: false }),
+  ensureActiveSessionV2WebSession: async () => false,
   setToast: () => {},
   setActiveProfileProxy: async () => {},
 });
@@ -798,6 +832,55 @@ export default function Auth({
     );
   }, [address, connectedProfile?.id, connectedProfile?.handle]);
 
+  const ensureActiveWebSessionForAddress = useCallback(
+    async (
+      walletAddress: string,
+      abortSignal?: AbortSignal
+    ): Promise<boolean> => {
+      if (!hasActiveSessionV2Auth({ address: walletAddress })) {
+        setSessionUpgradeRequired(true);
+        setSessionUpgradeHasDeadline(false);
+        return false;
+      }
+
+      try {
+        const hasActiveWebSession = await verifyActiveSessionV2WebSession({
+          address: walletAddress,
+          abortSignal,
+        });
+
+        if (!hasActiveWebSession) {
+          setSessionUpgradeRequired(true);
+          setSessionUpgradeHasDeadline(false);
+          return false;
+        }
+
+        setSessionUpgradeRequired(false);
+        return true;
+      } catch (error) {
+        if (!abortSignal?.aborted) {
+          logErrorSecurely("session_v2_web_session_verification", error);
+        }
+        return true;
+      }
+    },
+    []
+  );
+
+  const ensureActiveSessionV2WebSessionForActiveWallet = useCallback(
+    async (abortSignal?: AbortSignal): Promise<boolean> => {
+      const walletAddress = address ?? getWalletAddress();
+      if (!walletAddress || !getAuthJwt()) {
+        setSessionUpgradeRequired(false);
+        setSessionUpgradeHasDeadline(false);
+        return false;
+      }
+
+      return await ensureActiveWebSessionForAddress(walletAddress, abortSignal);
+    },
+    [address, ensureActiveWebSessionForAddress]
+  );
+
   // Immediate authentication effect with race condition prevention
   useEffect(() => {
     if (!enableWalletAuthentication) {
@@ -805,7 +888,7 @@ export default function Auth({
       setShowSignModal(false);
       setAuthLoadingState("idle");
       setSessionUpgradeRequired(false);
-      return;
+      return undefined;
     }
 
     // Clear previous operations when dependencies change
@@ -813,17 +896,24 @@ export default function Auth({
 
     // Don't start validation during transitional states
     if (connectionState === "connecting") {
-      return;
+      return undefined;
     }
 
     if (!address || connectionState !== "connected") {
       setShowSignModal(false);
-      const legacyUpgradeAddress = getStoredLegacySessionUpgradeAddress();
-      setSessionUpgradeRequired(legacyUpgradeAddress !== null);
-      if (legacyUpgradeAddress === null) {
+      const storedAuthAddress = getWalletAddress();
+      if (!storedAuthAddress || !getAuthJwt()) {
+        setSessionUpgradeRequired(false);
         setSessionUpgradeHasDeadline(false);
+        return undefined;
       }
-      return;
+
+      const controller = new AbortController();
+      void ensureActiveWebSessionForAddress(
+        storedAuthAddress,
+        controller.signal
+      );
+      return () => controller.abort();
     }
 
     if (!isAddressAuthorized) {
@@ -832,7 +922,7 @@ export default function Auth({
         setSignModalReason("auth");
         setShowSignModal(true);
       }
-      return;
+      return undefined;
     }
 
     // Clear stale non-upgrade sign modal state when returning to an authorized
@@ -878,12 +968,14 @@ export default function Auth({
       setShowSignModal,
       invalidateAll,
       reset,
+      verifyActiveSessionV2WebSession: ensureActiveWebSessionForAddress,
       authRolloutSettings,
     }).catch((error) => {
       logErrorSecurely("auth_immediate_validation_unhandled", error);
     });
 
     // No cleanup needed - immediate execution prevents stale timeouts
+    return undefined;
   }, [
     address,
     activeProfileProxy,
@@ -894,6 +986,7 @@ export default function Auth({
     hasActiveWalletAddress,
     canSignActiveWallet,
     abortCurrentAuthOperation,
+    ensureActiveWebSessionForAddress,
     invalidateAll,
     reset,
     authRolloutSettings,
@@ -1802,6 +1895,8 @@ export default function Auth({
           isProxy: !!activeProfileProxy,
         }),
         requestSessionUpgrade,
+        ensureActiveSessionV2WebSession:
+          ensureActiveSessionV2WebSessionForActiveWallet,
         setActiveProfileProxy: onActiveProfileProxy,
       }}
     >

--- a/components/auth/Auth.tsx
+++ b/components/auth/Auth.tsx
@@ -832,14 +832,40 @@ export default function Auth({
     );
   }, [address, connectedProfile?.id, connectedProfile?.handle]);
 
+  const verifyActiveWebSessionForAddress = useCallback(
+    async (
+      walletAddress: string,
+      abortSignal?: AbortSignal
+    ): Promise<boolean> => {
+      if (!hasActiveSessionV2Auth({ address: walletAddress })) {
+        return false;
+      }
+
+      try {
+        return await verifyActiveSessionV2WebSession({
+          address: walletAddress,
+          abortSignal,
+        });
+      } catch (error) {
+        if (!abortSignal?.aborted) {
+          logErrorSecurely("session_v2_web_session_verification", error);
+        }
+        return false;
+      }
+    },
+    []
+  );
+
   const ensureActiveWebSessionForAddress = useCallback(
     async (
       walletAddress: string,
       abortSignal?: AbortSignal
     ): Promise<boolean> => {
       if (!hasActiveSessionV2Auth({ address: walletAddress })) {
-        setSessionUpgradeRequired(true);
-        setSessionUpgradeHasDeadline(false);
+        if (!abortSignal?.aborted) {
+          setSessionUpgradeRequired(true);
+          setSessionUpgradeHasDeadline(false);
+        }
         return false;
       }
 
@@ -848,6 +874,10 @@ export default function Auth({
           address: walletAddress,
           abortSignal,
         });
+
+        if (abortSignal?.aborted) {
+          return true;
+        }
 
         if (!hasActiveWebSession) {
           setSessionUpgradeRequired(true);
@@ -871,14 +901,12 @@ export default function Auth({
     async (abortSignal?: AbortSignal): Promise<boolean> => {
       const walletAddress = address ?? getWalletAddress();
       if (!walletAddress || !getAuthJwt()) {
-        setSessionUpgradeRequired(false);
-        setSessionUpgradeHasDeadline(false);
         return false;
       }
 
-      return await ensureActiveWebSessionForAddress(walletAddress, abortSignal);
+      return await verifyActiveWebSessionForAddress(walletAddress, abortSignal);
     },
-    [address, ensureActiveWebSessionForAddress]
+    [address, verifyActiveWebSessionForAddress]
   );
 
   // Immediate authentication effect with race condition prevention

--- a/components/auth/Auth.tsx
+++ b/components/auth/Auth.tsx
@@ -12,6 +12,7 @@ import {
   useRef,
   useState,
 } from "react";
+import type { MouseEvent } from "react";
 import { Button, Modal } from "react-bootstrap";
 import { isAddress } from "viem";
 import type { AppToastInput } from "@/components/utils/toast/AppToast";
@@ -1903,6 +1904,13 @@ export default function Auth({
     }
     void requestAuth();
   };
+  const onSessionUpgradeLearnMore = (
+    event: MouseEvent<HTMLAnchorElement>
+  ) => {
+    event.preventDefault();
+    onCancelSignRequest();
+    router.push("/about/tech/wallet-authentication");
+  };
 
   return (
     <AuthContext.Provider
@@ -1971,7 +1979,10 @@ export default function Auth({
             </ul>
             {isSessionUpgradePrompt && (
               <p className={styles["signModalLearnMore"]}>
-                <Link href="/about/tech/wallet-authentication">
+                <Link
+                  href="/about/tech/wallet-authentication"
+                  onClick={onSessionUpgradeLearnMore}
+                >
                   {t(AUTH_MODAL_LOCALE, "auth.signModal.learnMore")}
                 </Link>
               </p>

--- a/components/header/share/HeaderShare.tsx
+++ b/components/header/share/HeaderShare.tsx
@@ -438,7 +438,7 @@ export function HeaderQRModal({
   const [isVisible, setIsVisible] = useState(show);
 
   const { hasValidWalletAuth } = useSeizeConnectContext();
-  const { requestSessionUpgrade } = useAuth();
+  const { ensureActiveSessionV2WebSession, requestSessionUpgrade } = useAuth();
   const activeWalletAddress = getWalletAddress();
   const hasWalletAddress = Boolean(activeWalletAddress);
 
@@ -661,6 +661,19 @@ export function HeaderQRModal({
 
     try {
       setMobileConnectionShareStatus("loading");
+      if (ensureActiveSessionV2WebSession) {
+        const hasActiveSession =
+          await ensureActiveSessionV2WebSession(signal);
+        if (!hasActiveSession) {
+          terminalConnectionShareFailuresRef.current.set(
+            failureKey,
+            "legacy-auth"
+          );
+          setUnavailableMobileConnectionShare("legacy-auth");
+          return "";
+        }
+      }
+
       const cachedShare = getCachedConnectionShare(
         cachedConnectionShareRef.current,
         addressKey

--- a/components/header/share/HeaderShare.tsx
+++ b/components/header/share/HeaderShare.tsx
@@ -662,8 +662,21 @@ export function HeaderQRModal({
     try {
       setMobileConnectionShareStatus("loading");
       if (ensureActiveSessionV2WebSession) {
-        const hasActiveSession =
-          await ensureActiveSessionV2WebSession(signal);
+        let hasActiveSession = false;
+        try {
+          hasActiveSession = await ensureActiveSessionV2WebSession(signal);
+        } catch (error: unknown) {
+          if (isStaleGeneration() || isAbortError(error, signal)) {
+            return "";
+          }
+
+          console.error("Failed to verify active web session", error);
+        }
+
+        if (isStaleGeneration() || signal?.aborted) {
+          return "";
+        }
+
         if (!hasActiveSession) {
           terminalConnectionShareFailuresRef.current.set(
             failureKey,

--- a/components/header/share/HeaderShare.tsx
+++ b/components/header/share/HeaderShare.tsx
@@ -661,30 +661,30 @@ export function HeaderQRModal({
 
     try {
       setMobileConnectionShareStatus("loading");
-      if (ensureActiveSessionV2WebSession) {
-        let hasActiveSession = false;
-        try {
+      let hasActiveSession = false;
+      try {
+        if (ensureActiveSessionV2WebSession) {
           hasActiveSession = await ensureActiveSessionV2WebSession(signal);
-        } catch (error: unknown) {
-          if (isStaleGeneration() || isAbortError(error, signal)) {
-            return "";
-          }
-
-          console.error("Failed to verify active web session", error);
         }
-
-        if (isStaleGeneration() || signal?.aborted) {
+      } catch (error: unknown) {
+        if (isStaleGeneration() || isAbortError(error, signal)) {
           return "";
         }
 
-        if (!hasActiveSession) {
-          terminalConnectionShareFailuresRef.current.set(
-            failureKey,
-            "legacy-auth"
-          );
-          setUnavailableMobileConnectionShare("legacy-auth");
-          return "";
-        }
+        console.error("Failed to verify active web session", error);
+      }
+
+      if (isStaleGeneration() || signal?.aborted) {
+        return "";
+      }
+
+      if (!hasActiveSession) {
+        terminalConnectionShareFailuresRef.current.set(
+          failureKey,
+          "legacy-auth"
+        );
+        setUnavailableMobileConnectionShare("legacy-auth");
+        return "";
       }
 
       const cachedShare = getCachedConnectionShare(

--- a/services/auth/session-v2.utils.ts
+++ b/services/auth/session-v2.utils.ts
@@ -256,6 +256,28 @@ export async function persistSessionResponse(
   return didPersistAuth;
 }
 
+export async function verifyActiveSessionV2WebSession({
+  address,
+  abortSignal,
+}: {
+  readonly address: string;
+  readonly abortSignal?: AbortSignal | undefined;
+}): Promise<boolean> {
+  if (getSessionClientType() !== "web") {
+    return true;
+  }
+
+  const refreshedSession = await refreshSessionV2({
+    address,
+    abortSignal,
+  });
+  if (!refreshedSession || refreshedSession.client_type !== "web") {
+    return false;
+  }
+
+  return true;
+}
+
 export async function createConnectionShare({
   signal,
 }: {


### PR DESCRIPTION
## Summary
- Verify the active session-v2 web session before trusting the local v2 auth marker.
- Mark auth upgrade required when the web-session cookie is missing or stale.
- Stop connection-share generation before calling the share endpoint when the active web session is unavailable.
- Keep the auth upgrade modal title light against the dark modal surface.
- Make the Learn More link dismiss the upgrade prompt like Remind me later, then navigate to `/about/tech/wallet-authentication`.

## Validation
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run lint:changed`
- `./bin/6529 run test -- __tests__/components/auth/Auth.test.tsx`
- Earlier focused pass: `./bin/6529 run test -- __tests__/services/auth/session-v2.utils.test.ts __tests__/components/auth/Auth.test.tsx __tests__/components/header/share/HeaderShare.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a stronger authentication check before sharing connections, helping ensure users are prompted to refresh access when needed.
  * The “Learn more” link in the authentication upgrade prompt now takes users to the wallet authentication info page.

* **Bug Fixes**
  * Improved handling of expired or missing web sessions so authentication prompts appear more reliably.
  * Added safer failure handling when session verification cannot be completed, reducing unexpected prompt behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->