### PR TITLE
[codex] Use masked 6529 dock logo

### DIFF
--- a/__tests__/components/common/icons/LogoIcon.test.tsx
+++ b/__tests__/components/common/icons/LogoIcon.test.tsx
@@ -2,29 +2,18 @@ import { render } from "@testing-library/react";
 import LogoIcon from "@/components/common/icons/LogoIcon";
 
 describe("LogoIcon", () => {
-  it("preloads both logo assets with a custom wrapper class", () => {
+  it("renders one current-color masked logo with a custom wrapper class", () => {
     const { container } = render(<LogoIcon className="brand" />);
     const wrapper = container.querySelector("span");
     const images = container.querySelectorAll("img");
 
     expect(wrapper).toHaveClass("brand");
-    expect(images).toHaveLength(2);
-    expect(images[0]).toHaveAttribute("src", "/6529.svg");
-    expect(images[1]).toHaveAttribute("src", "/6529-black.svg");
-    expect(images[0]).toHaveAttribute("aria-hidden", "true");
-    expect(images[0]).toHaveClass("tw-opacity-100");
-    expect(images[1]).toHaveClass("tw-opacity-0");
-    expect(images[0]).not.toHaveClass("tw-transition-opacity");
-    expect(images[1]).not.toHaveClass("tw-transition-opacity");
-  });
-
-  it("shows the black logo asset when requested", () => {
-    const { container } = render(<LogoIcon color="black" />);
-    const images = container.querySelectorAll("img");
-
-    expect(images[0]).toHaveAttribute("src", "/6529.svg");
-    expect(images[1]).toHaveAttribute("src", "/6529-black.svg");
-    expect(images[0]).toHaveClass("tw-opacity-0");
-    expect(images[1]).toHaveClass("tw-opacity-100");
+    expect(wrapper).toHaveClass("tw-bg-current");
+    expect(wrapper).toHaveAttribute("aria-hidden", "true");
+    expect(wrapper?.getAttribute("style")).toContain(
+      "mask-image: url('/6529.svg')"
+    );
+    expect(wrapper?.getAttribute("style")).not.toContain("6529-black.svg");
+    expect(images).toHaveLength(0);
   });
 });

--- a/__tests__/components/navigation/NavItem.test.tsx
+++ b/__tests__/components/navigation/NavItem.test.tsx
@@ -11,6 +11,7 @@ import { isNavItemActive } from "@/components/navigation/isNavItemActive";
 import { useWaveData } from "@/hooks/useWaveData";
 import { useWave } from "@/hooks/useWave";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import LogoIcon from "@/components/common/icons/LogoIcon";
 
 const mockUseLinkStatus = jest.fn(() => ({ pending: false }));
 
@@ -269,6 +270,22 @@ describe("NavItem notifications", () => {
     const { queryByTestId } = render(<NavItem item={item} />);
 
     expect(queryByTestId("nav-item-pending-indicator")).not.toBeInTheDocument();
+  });
+
+  it("colors the home logo through the active nav text color", () => {
+    (isNavItemActive as jest.Mock).mockReturnValue(true);
+    const item = {
+      kind: "route",
+      name: "Home",
+      href: "/",
+      icon: "/6529.svg",
+      iconComponent: LogoIcon,
+    } as any;
+
+    const { container } = render(<NavItem item={item} />);
+    const logo = container.querySelector("span[aria-hidden='true']");
+
+    expect(logo).toHaveClass("tw-text-black");
   });
 
   it("renders disabled item when disabled flag set", () => {

--- a/__tests__/components/navigation/NavItem.test.tsx
+++ b/__tests__/components/navigation/NavItem.test.tsx
@@ -288,6 +288,39 @@ describe("NavItem notifications", () => {
     expect(logo).toHaveClass("tw-text-black");
   });
 
+  it("keeps inactive floating home logo white", () => {
+    const item = {
+      kind: "route",
+      name: "Home",
+      href: "/",
+      icon: "/6529.svg",
+      iconComponent: LogoIcon,
+    } as any;
+
+    const { container } = render(<NavItem item={item} />);
+    const logo = container.querySelector("span[aria-hidden='true']");
+
+    expect(logo).toHaveClass("tw-text-white");
+    expect(logo).not.toHaveClass("tw-text-iron-300");
+  });
+
+  it("keeps fixed home logo white even when active", () => {
+    (isNavItemActive as jest.Mock).mockReturnValue(true);
+    const item = {
+      kind: "route",
+      name: "Home",
+      href: "/",
+      icon: "/6529.svg",
+      iconComponent: LogoIcon,
+    } as any;
+
+    const { container } = render(<NavItem item={item} variant="fixed" />);
+    const logo = container.querySelector("span[aria-hidden='true']");
+
+    expect(logo).toHaveClass("tw-text-white");
+    expect(logo).not.toHaveClass("tw-text-iron-500");
+  });
+
   it("renders disabled item when disabled flag set", () => {
     (useUnreadNotifications as jest.Mock).mockReturnValue({});
     const item = { name: "Feed", icon: "/i", disabled: true } as any;

--- a/components/common/icons/LogoIcon.tsx
+++ b/components/common/icons/LogoIcon.tsx
@@ -1,46 +1,31 @@
-import Image from "next/image";
+import type { CSSProperties } from "react";
 
-type LogoIconColor = "white" | "black";
+const logoMaskStyle = {
+  WebkitMaskImage: "url('/6529.svg')",
+  maskImage: "url('/6529.svg')",
+  WebkitMaskPosition: "center",
+  maskPosition: "center",
+  WebkitMaskRepeat: "no-repeat",
+  maskRepeat: "no-repeat",
+  WebkitMaskSize: "contain",
+  maskSize: "contain",
+} satisfies CSSProperties;
 
 const LogoIcon = ({
   className,
-  color = "white",
 }: {
   readonly className?: string | undefined;
-  readonly color?: LogoIconColor | undefined;
 }) => {
   const wrapperClassName = className
-    ? `tw-relative tw-inline-block tw-align-middle ${className}`
-    : "tw-relative tw-inline-block tw-size-6 tw-align-middle";
-  const imageClassName = "tw-absolute tw-inset-0 tw-h-full tw-w-full";
+    ? `tw-inline-block tw-bg-current tw-align-middle ${className}`
+    : "tw-inline-block tw-size-6 tw-bg-current tw-align-middle";
 
   return (
-    <span aria-hidden="true" className={wrapperClassName}>
-      <Image
-        alt=""
-        aria-hidden="true"
-        className={`${imageClassName} ${
-          color === "black" ? "tw-opacity-0" : "tw-opacity-100"
-        }`}
-        draggable={false}
-        height={192}
-        unoptimized
-        width={192}
-        src="/6529.svg"
-      />
-      <Image
-        alt=""
-        aria-hidden="true"
-        className={`${imageClassName} ${
-          color === "black" ? "tw-opacity-100" : "tw-opacity-0"
-        }`}
-        draggable={false}
-        height={192}
-        unoptimized
-        width={192}
-        src="/6529-black.svg"
-      />
-    </span>
+    <span
+      aria-hidden="true"
+      className={wrapperClassName}
+      style={logoMaskStyle}
+    />
   );
 };
 

--- a/components/navigation/NavItem.tsx
+++ b/components/navigation/NavItem.tsx
@@ -85,15 +85,29 @@ const getHomeIconSizeClass = ({
 const getInactiveIconTextColorClass = (isHighlighted: boolean) =>
   isHighlighted ? "tw-text-white" : "tw-text-iron-300";
 
+const getHomeIconTextColorClass = ({
+  isActive,
+  variant,
+}: {
+  readonly isActive: boolean;
+  readonly variant: "floating" | "fixed";
+}) => (variant === "floating" && isActive ? "tw-text-black" : "tw-text-white");
+
 const getIconTextColorClass = ({
   isActive,
   isHighlighted,
+  item,
   variant,
 }: {
   readonly isActive: boolean;
   readonly isHighlighted: boolean;
+  readonly item: NavItemData;
   readonly variant: "floating" | "fixed";
 }) => {
+  if (item.name === "Home") {
+    return getHomeIconTextColorClass({ isActive, variant });
+  }
+
   if (variant === "fixed") {
     return isHighlighted ? "tw-text-white" : "tw-text-iron-500";
   }
@@ -181,6 +195,7 @@ const NavItemLinkContent = ({
   const iconTextColorClass = getIconTextColorClass({
     isActive,
     isHighlighted,
+    item,
     variant,
   });
   const resolvedIconSizeClass =

--- a/components/navigation/NavItem.tsx
+++ b/components/navigation/NavItem.tsx
@@ -14,7 +14,7 @@ import { useNotificationsContext } from "../notifications/NotificationsContext";
 import { getActiveWaveIdFromUrl } from "@/helpers/navigation.helpers";
 import { isNavItemActive } from "./isNavItemActive";
 import { getActiveViewFromUrl, useViewContext } from "./ViewContext";
-import type { NavIconColor, NavItem as NavItemData, ViewKey } from "./navTypes";
+import type { NavItem as NavItemData, ViewKey } from "./navTypes";
 
 interface Props {
   readonly item: NavItemData;
@@ -88,18 +88,12 @@ const getInactiveIconTextColorClass = (isHighlighted: boolean) =>
 const getIconTextColorClass = ({
   isActive,
   isHighlighted,
-  item,
   variant,
 }: {
   readonly isActive: boolean;
   readonly isHighlighted: boolean;
-  readonly item: NavItemData;
   readonly variant: "floating" | "fixed";
 }) => {
-  if (item.name === "Home") {
-    return "";
-  }
-
   if (variant === "fixed") {
     return isHighlighted ? "tw-text-white" : "tw-text-iron-500";
   }
@@ -184,12 +178,9 @@ const NavItemLinkContent = ({
 }) => {
   const isHighlighted = isActive;
   const IconComponent = item.iconComponent;
-  const activeIconColor: NavIconColor =
-    isActive && variant === "floating" ? "black" : "white";
   const iconTextColorClass = getIconTextColorClass({
     isActive,
     isHighlighted,
-    item,
     variant,
   });
   const resolvedIconSizeClass =
@@ -203,7 +194,6 @@ const NavItemLinkContent = ({
       {IconComponent ? (
         <IconComponent
           className={`tw-relative tw-z-10 ${resolvedIconSizeClass} ${iconTextColorClass}`}
-          color={activeIconColor}
         />
       ) : (
         <Image

--- a/components/navigation/navTypes.ts
+++ b/components/navigation/navTypes.ts
@@ -1,11 +1,9 @@
 import type React from "react";
 
 export type ViewKey = "waves" | "messages";
-export type NavIconColor = "white" | "black";
 
 type NavIconComponent = React.ComponentType<{
   className?: string | undefined;
-  color?: NavIconColor | undefined;
 }>;
 
 type RouteNavItem = {


### PR DESCRIPTION
## Issue
The centered 6529 dock logo still flashed during unrelated floating-nav active-pill movement because it rendered as swapped image assets instead of behaving like the other current-color icons.

## Fix
- Render `LogoIcon` as a single current-color CSS mask using `/6529.svg`.
- Remove the black logo asset from the dock rendering path.
- Let Home use the same active/inactive text-color classes as the other nav icons.
- Update tests to cover the single masked logo and active Home color.

## Validation
- `./bin/6529 run test -- __tests__/components/common/icons/LogoIcon.test.tsx __tests__/components/navigation/NavItem.test.tsx`
- `./bin/6529 run check:changed`
- `./bin/6529 run react-doctor:diff` (completed, but reported no changed source files to scan)