### PR TITLE
Align and resize Worth Checking Out badge markers

### DIFF
--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -436,8 +436,8 @@ it("uses highly rated preview score semantics instead of unread badges", () => {
   ).toBeInTheDocument();
   const scoreBadgeText = screen.getByText("93", { selector: "text" });
   expect(scoreBadgeText).toBeInTheDocument();
-  expect(scoreBadgeText.closest("svg")).toHaveClass("-tw-bottom-0.5");
-  expect(scoreBadgeText.closest("svg")).toHaveClass("-tw-right-1");
+  expect(scoreBadgeText.closest("svg")).toHaveClass("-tw-bottom-1");
+  expect(scoreBadgeText.closest("svg")).toHaveClass("-tw-right-1.5");
   expect(screen.getByText("Score 93")).toBeInTheDocument();
   expect(screen.queryByRole("link", { name: /new messages/ })).toBeNull();
   expect(screen.getByTestId("preview-avatar-h-score")).toHaveAttribute(

--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -438,6 +438,8 @@ it("uses highly rated preview score semantics instead of unread badges", () => {
   expect(scoreBadgeText).toBeInTheDocument();
   expect(scoreBadgeText.closest("svg")).toHaveClass("-tw-bottom-1");
   expect(scoreBadgeText.closest("svg")).toHaveClass("-tw-right-1.5");
+  expect(scoreBadgeText.closest("svg")).toHaveClass("tw-h-5");
+  expect(scoreBadgeText.closest("svg")).toHaveClass("tw-w-6");
   expect(screen.getByText("Score 93")).toBeInTheDocument();
   expect(screen.queryByRole("link", { name: /new messages/ })).toBeNull();
   expect(screen.getByTestId("preview-avatar-h-score")).toHaveAttribute(

--- a/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
+++ b/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
@@ -265,7 +265,7 @@ function HighlyRatedWavePreviewScoreBadge({
     <svg
       aria-hidden="true"
       viewBox="0 0 32 26"
-      className="tw-pointer-events-none tw-absolute -tw-bottom-0.5 -tw-right-1 tw-z-10 tw-h-[18px] tw-w-[22px] tw-overflow-visible tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)]"
+      className="tw-pointer-events-none tw-absolute -tw-bottom-1 -tw-right-1.5 tw-z-10 tw-h-[18px] tw-w-[22px] tw-overflow-visible tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)]"
     >
       <path
         d="M16 2.15 28 6.15v6.7c0 5.45-4.35 9.5-12 11.2-7.65-1.7-12-5.75-12-11.2v-6.7L16 2.15Z"

--- a/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
+++ b/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
@@ -144,18 +144,18 @@ const getWaveScoreLabel = (wave: MinimalWave): string | null => {
 
 const getScoreBadgeFontSize = (scoreLabel: string) => {
   if (scoreLabel.length >= 5) {
-    return 5.1;
+    return 5.6;
   }
 
   if (scoreLabel.length === 4) {
-    return 5.9;
+    return 6.4;
   }
 
   if (scoreLabel.length === 3) {
-    return 6.9;
+    return 7.4;
   }
 
-  return 8.5;
+  return 9.2;
 };
 
 export const getFittingPreviewCount = ({
@@ -265,7 +265,7 @@ function HighlyRatedWavePreviewScoreBadge({
     <svg
       aria-hidden="true"
       viewBox="0 0 32 26"
-      className="tw-pointer-events-none tw-absolute -tw-bottom-1 -tw-right-1.5 tw-z-10 tw-h-[18px] tw-w-[22px] tw-overflow-visible tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)]"
+      className="tw-pointer-events-none tw-absolute -tw-bottom-1 -tw-right-1.5 tw-z-10 tw-h-5 tw-w-6 tw-overflow-visible tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)]"
     >
       <path
         d="M16 2.15 28 6.15v6.7c0 5.45-4.35 9.5-12 11.2-7.65-1.7-12-5.75-12-11.2v-6.7L16 2.15Z"

--- a/pr-reports/2874.md
+++ b/pr-reports/2874.md
@@ -1,0 +1,24 @@
+# PR Report: Worth Checking Out Badge Marker Alignment
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/2874
+Branch: `codex/align-worth-badge-markers` -> `main`
+Related PRs: Follows https://github.com/6529-Collections/6529seize-frontend/pull/2871
+
+## Summary
+The Worth Checking Out preview strip now aligns the lower-left trophy marker and lower-right score shield on the same compact avatar corner line.
+
+## What Changed
+- Adjusted the local Worth Checking Out score shield offset down and outward.
+- Updated focused sidebar preview coverage for the aligned score badge offsets.
+
+## Frontend Impact
+- Routes/views: Waves sidebar and web/app brain left-sidebar wave discovery surfaces.
+- Components: Highly rated preview strip.
+- Generated API/client: Not affected.
+- User-visible behavior: Worth Checking Out avatars keep the score shield on the lower-right and trophy markers on the lower-left, with the two markers visually aligned.
+
+## Config / Env
+No config or environment changes.
+
+## Release Notes
+Worth Checking Out wave previews now align trophy and score markers more cleanly in the compact avatar strip.

--- a/pr-reports/2874.md
+++ b/pr-reports/2874.md
@@ -5,20 +5,21 @@ Branch: `codex/align-worth-badge-markers` -> `main`
 Related PRs: Follows https://github.com/6529-Collections/6529seize-frontend/pull/2871
 
 ## Summary
-The Worth Checking Out preview strip now aligns the lower-left trophy marker and lower-right score shield on the same compact avatar corner line.
+The Worth Checking Out preview strip now aligns the lower-left trophy marker and lower-right score shield on the same compact avatar corner line, while giving the score shield slightly more presence at full-page scale.
 
 ## What Changed
 - Adjusted the local Worth Checking Out score shield offset down and outward.
+- Increased the local score shield and score text sizing so the rating remains readable in the compact strip.
 - Updated focused sidebar preview coverage for the aligned score badge offsets.
 
 ## Frontend Impact
 - Routes/views: Waves sidebar and web/app brain left-sidebar wave discovery surfaces.
 - Components: Highly rated preview strip.
 - Generated API/client: Not affected.
-- User-visible behavior: Worth Checking Out avatars keep the score shield on the lower-right and trophy markers on the lower-left, with the two markers visually aligned.
+- User-visible behavior: Worth Checking Out avatars keep the larger score shield on the lower-right and trophy markers on the lower-left, with the two markers visually aligned.
 
 ## Config / Env
 No config or environment changes.
 
 ## Release Notes
-Worth Checking Out wave previews now align trophy and score markers more cleanly in the compact avatar strip.
+Worth Checking Out wave previews now align trophy and score markers more cleanly and keep scores easier to read in the compact avatar strip.


### PR DESCRIPTION
## Issue
- Worth Checking Out preview avatars had the trophy marker and score shield visually sitting on different corner lines after the score shield polish.
- From the full-page view, the score shield and number also read too small in the compact strip.

## Fix
- Move the local score shield offset down and outward so it aligns with the lower-left trophy marker.
- Increase the local score shield and score text sizing while keeping the lighter score weight.

## Changes
- Updates only the Worth Checking Out score shield positioning and sizing classes.
- Updates focused sidebar preview coverage for the new score shield offsets and dimensions.
- Updates the PR report for the alignment/readability follow-up.

## Validation
- `./bin/6529 run test -- __tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx`
- `./bin/6529 run lint:single -- components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx __tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx` (component clean; test file is ignored by that single-file config)
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` (no changed source files to scan for the initial class-only diff)

## Risk
- Level: Low
- Why: CSS-only alignment and sizing adjustment scoped to the existing Worth Checking Out score badge plus focused expectation updates.
- Rollback: Revert the badge marker alignment/size commits.

## Review Notes
- Please focus on the visual corner alignment between the trophy marker and score shield, plus whether the larger score shield reads correctly at full-page scale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the compact “Worth Checking Out” preview strip so the score badge and trophy marker align more cleanly.
  * Made score labels easier to read by increasing their size in tighter spaces.

* **Bug Fixes**
  * Adjusted badge placement and sizing for a more consistent appearance in the sidebar preview.

* **Tests**
  * Updated UI coverage to reflect the new badge positioning and sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->