### PR TITLE
[codex] Restore mobile dock active pill motion

### DIFF
--- a/__tests__/components/navigation/BottomNavigation.test.tsx
+++ b/__tests__/components/navigation/BottomNavigation.test.tsx
@@ -200,6 +200,23 @@ describe("BottomNavigation", () => {
     ).toBe(true);
   });
 
+  it("keeps one active pill mounted while moving it between active items", () => {
+    const { getByTestId, rerender } = render(<BottomNavigation />);
+    const activePill = getByTestId("mobile-dock-active-pill");
+
+    expect(activePill.getAttribute("style")).toContain("left: 50%");
+    expect(activePill).toHaveClass("tw-transition-[left,width,height,opacity]");
+
+    (usePathname as jest.Mock).mockReturnValue("/notifications");
+    rerender(<BottomNavigation />);
+
+    const movedActivePill = getByTestId("mobile-dock-active-pill");
+    expect(movedActivePill).toBe(activePill);
+    expect(movedActivePill.getAttribute("style")).toContain(
+      "left: 92.85714285714286%"
+    );
+  });
+
   it("compacts the floating dock from window scroll", async () => {
     Object.defineProperty(globalThis, "scrollY", {
       configurable: true,

--- a/__tests__/components/navigation/BottomNavigation.test.tsx
+++ b/__tests__/components/navigation/BottomNavigation.test.tsx
@@ -1,7 +1,9 @@
 import { act, fireEvent, render, waitFor } from "@testing-library/react";
 import BottomNavigation from "@/components/navigation/BottomNavigation";
 import NavItem from "@/components/navigation/NavItem";
+import { useAuth } from "@/components/auth/Auth";
 import { useLayout } from "@/components/brain/my-stream/layout/LayoutContext";
+import { useSeizeConnectContext } from "@/components/auth/SeizeConnectContext";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
 import { useWave } from "@/hooks/useWave";
 import { useWaveData } from "@/hooks/useWaveData";
@@ -13,6 +15,10 @@ import {
 jest.mock("@/components/navigation/NavItem", () => ({
   __esModule: true,
   default: jest.fn(() => <div data-testid="nav-item" />),
+}));
+jest.mock("@/components/auth/Auth", () => ({ useAuth: jest.fn() }));
+jest.mock("@/components/auth/SeizeConnectContext", () => ({
+  useSeizeConnectContext: jest.fn(),
 }));
 jest.mock("@/components/brain/my-stream/layout/LayoutContext", () => ({
   useLayout: jest.fn(),
@@ -30,6 +36,8 @@ jest.mock("next/navigation", () => ({
 
 const registerRef = jest.fn();
 (useLayout as jest.Mock).mockReturnValue({ registerRef });
+(useAuth as jest.Mock).mockReturnValue({ connectedProfile: null });
+(useSeizeConnectContext as jest.Mock).mockReturnValue({ address: undefined });
 (useDeviceInfo as jest.Mock).mockReturnValue({ isApp: false });
 (useWaveData as jest.Mock).mockReturnValue({ data: null });
 (useWave as jest.Mock).mockReturnValue({ isDm: false });
@@ -58,6 +66,9 @@ const flushAnimationFrame = async () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
   });
 };
+
+const getExpectedActivePillLeft = (index: number, itemCount = 7) =>
+  `left: ${((index + 0.5) / itemCount) * 100}%`;
 
 const createScrollableElement = ({
   tracked,
@@ -117,6 +128,10 @@ beforeEach(() => {
       }
     });
   (useLayout as jest.Mock).mockReturnValue({ registerRef });
+  (useAuth as jest.Mock).mockReturnValue({ connectedProfile: null });
+  (useSeizeConnectContext as jest.Mock).mockReturnValue({
+    address: undefined,
+  });
   (useDeviceInfo as jest.Mock).mockReturnValue({ isApp: false });
   (useWaveData as jest.Mock).mockReturnValue({ data: null });
   (useWave as jest.Mock).mockReturnValue({ isDm: false });
@@ -204,7 +219,9 @@ describe("BottomNavigation", () => {
     const { getByTestId, rerender } = render(<BottomNavigation />);
     const activePill = getByTestId("mobile-dock-active-pill");
 
-    expect(activePill.getAttribute("style")).toContain("left: 50%");
+    expect(activePill.getAttribute("style")).toContain(
+      getExpectedActivePillLeft(3)
+    );
     expect(activePill).toHaveClass("tw-transition-[left,width,height,opacity]");
 
     (usePathname as jest.Mock).mockReturnValue("/notifications");
@@ -213,8 +230,19 @@ describe("BottomNavigation", () => {
     const movedActivePill = getByTestId("mobile-dock-active-pill");
     expect(movedActivePill).toBe(activePill);
     expect(movedActivePill.getAttribute("style")).toContain(
-      "left: 92.85714285714286%"
+      getExpectedActivePillLeft(6)
     );
+  });
+
+  it("hides the active pill when no dock item matches the route", () => {
+    (usePathname as jest.Mock).mockReturnValue("/my-handle");
+    (useAuth as jest.Mock).mockReturnValue({
+      connectedProfile: { handle: "my-handle", normalised_handle: "my-handle" },
+    });
+
+    const { getByTestId } = render(<BottomNavigation />);
+
+    expect(getByTestId("mobile-dock-active-pill")).toHaveClass("tw-opacity-0");
   });
 
   it("compacts the floating dock from window scroll", async () => {

--- a/components/navigation/BottomNavigation.tsx
+++ b/components/navigation/BottomNavigation.tsx
@@ -20,6 +20,8 @@ import { useWave } from "@/hooks/useWave";
 import { useWaveData } from "@/hooks/useWaveData";
 import { DEFAULT_LOCALE } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
+import { useAuth } from "../auth/Auth";
+import { useSeizeConnectContext } from "../auth/SeizeConnectContext";
 import { useLayout } from "../brain/my-stream/layout/LayoutContext";
 import BellIcon from "../common/icons/BellIcon";
 import ChatBubbleIcon from "../common/icons/ChatBubbleIcon";
@@ -28,8 +30,8 @@ import LogoIcon from "../common/icons/LogoIcon";
 import CollectionsMenuIcon from "../common/icons/CollectionsMenuIcon";
 import UsersIcon from "../common/icons/UsersIcon";
 import WavesIcon from "../common/icons/WavesIcon";
-import { isNavItemActive } from "./isNavItemActive";
 import NavItem from "./NavItem";
+import { getProfileHref, getResolvedNavItemState } from "./navItemState";
 import type { NavItem as NavItemData } from "./navTypes";
 import { getActiveViewFromUrl } from "./ViewContext";
 
@@ -329,6 +331,8 @@ const BottomNavigationResolvedContent: React.FC<
 > = ({ hidden = false, pathname, routeStateKey }) => {
   const { registerRef } = useLayout();
   const { isApp } = useDeviceInfo();
+  const { connectedProfile } = useAuth();
+  const { address } = useSeizeConnectContext();
   // react-doctor-disable-next-line react-doctor/nextjs-no-use-search-params-without-suspense
   const searchParams = useSearchParams();
 
@@ -376,8 +380,21 @@ const BottomNavigationResolvedContent: React.FC<
       ),
     [isApp]
   );
-  const activeItemIndex = navItems.findIndex((item) =>
-    isNavItemActive(item, pathname, searchParams, activeView, isCurrentWaveDm)
+  const profileHref = getProfileHref({
+    address,
+    handle: connectedProfile?.handle,
+    normalisedHandle: connectedProfile?.normalised_handle,
+  });
+  const activeItemIndex = navItems.findIndex(
+    (item) =>
+      getResolvedNavItemState({
+        activeView,
+        isCurrentWaveDm,
+        item,
+        pathname,
+        profileHref,
+        searchParams,
+      }).isActive
   );
   const hasActiveItem = activeItemIndex >= 0;
 

--- a/components/navigation/BottomNavigation.tsx
+++ b/components/navigation/BottomNavigation.tsx
@@ -28,8 +28,10 @@ import LogoIcon from "../common/icons/LogoIcon";
 import CollectionsMenuIcon from "../common/icons/CollectionsMenuIcon";
 import UsersIcon from "../common/icons/UsersIcon";
 import WavesIcon from "../common/icons/WavesIcon";
+import { isNavItemActive } from "./isNavItemActive";
 import NavItem from "./NavItem";
 import type { NavItem as NavItemData } from "./navTypes";
+import { getActiveViewFromUrl } from "./ViewContext";
 
 const items: NavItemData[] = [
   {
@@ -153,9 +155,11 @@ const getTrackedScrollTarget = ({
 
 const useCompactDock = ({
   hidden,
+  resetKey,
   reverseScrollDirection,
 }: {
   readonly hidden: boolean;
+  readonly resetKey: string;
   readonly reverseScrollDirection: boolean;
 }) => {
   const [compact, setCompact] = useState(false);
@@ -164,6 +168,16 @@ const useCompactDock = ({
   );
   const frameRef = useRef<number | null>(null);
   const pendingScrollTargetsRef = useRef<Set<EventTarget>>(new Set());
+
+  useEffect(() => {
+    setCompact(false);
+    previousScrollPositionsRef.current = new WeakMap();
+    pendingScrollTargetsRef.current.clear();
+    if (frameRef.current !== null) {
+      globalThis.cancelAnimationFrame(frameRef.current);
+      frameRef.current = null;
+    }
+  }, [resetKey]);
 
   useEffect(() => {
     if (hidden) {
@@ -268,6 +282,31 @@ const getFloatingNavListClassName = (compact: boolean) =>
     compact ? "tw-gap-0 tw-px-1.5" : "tw-gap-0.5 tw-px-2"
   }`;
 
+const getFloatingActivePillClassName = ({
+  compact,
+  visible,
+}: {
+  readonly compact: boolean;
+  readonly visible: boolean;
+}) => {
+  const sizeClassName = compact
+    ? "tw-h-11 tw-w-[3.75rem] sm:tw-h-12 sm:tw-w-[4.25rem]"
+    : "tw-h-12 tw-w-[4.05rem] sm:tw-h-[3.15rem] sm:tw-w-[4.45rem]";
+  const visibilityClassName = visible ? "tw-opacity-100" : "tw-opacity-0";
+
+  return `tw-pointer-events-none tw-absolute tw-left-1/2 tw-top-1/2 tw-z-0 -tw-translate-x-1/2 -tw-translate-y-1/2 tw-rounded-full tw-bg-white/[0.9] tw-shadow-[inset_0_1px_0_rgba(255,255,255,0.42),0_8px_24px_rgba(255,255,255,0.1)] tw-transition-[left,width,height,opacity] tw-duration-300 tw-ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:tw-transition-none ${sizeClassName} ${visibilityClassName}`;
+};
+
+const getFloatingActivePillStyle = ({
+  activeItemIndex,
+  itemCount,
+}: {
+  readonly activeItemIndex: number;
+  readonly itemCount: number;
+}): React.CSSProperties => ({
+  left: `${((activeItemIndex + 0.5) / itemCount) * 100}%`,
+});
+
 const BottomNavigationFallback: React.FC<BottomNavigationProps> = ({
   hidden = false,
 }) => (
@@ -282,11 +321,12 @@ const BottomNavigationFallback: React.FC<BottomNavigationProps> = ({
 
 interface BottomNavigationResolvedContentProps extends BottomNavigationProps {
   readonly pathname: string;
+  readonly routeStateKey: string;
 }
 
 const BottomNavigationResolvedContent: React.FC<
   BottomNavigationResolvedContentProps
-> = ({ hidden = false, pathname }) => {
+> = ({ hidden = false, pathname, routeStateKey }) => {
   const { registerRef } = useLayout();
   const { isApp } = useDeviceInfo();
   // react-doctor-disable-next-line react-doctor/nextjs-no-use-search-params-without-suspense
@@ -294,10 +334,18 @@ const BottomNavigationResolvedContent: React.FC<
 
   const mobileNavRef = useRef<HTMLDivElement | null>(null);
   const waveIdFromQuery = getActiveWaveIdFromUrl({ pathname, searchParams });
+  const activeView = getActiveViewFromUrl({
+    activeWaveId: waveIdFromQuery,
+    searchParams,
+  });
   const reverseScrollDirection = usesReverseMobileBottomNavigationScroll({
     pathname,
   });
-  const compact = useCompactDock({ hidden, reverseScrollDirection });
+  const compact = useCompactDock({
+    hidden,
+    resetKey: routeStateKey,
+    reverseScrollDirection,
+  });
   const { data: waveData } = useWaveData({
     waveId: waveIdFromQuery,
     onWaveNotFound: () => {},
@@ -328,6 +376,10 @@ const BottomNavigationResolvedContent: React.FC<
       ),
     [isApp]
   );
+  const activeItemIndex = navItems.findIndex((item) =>
+    isNavItemActive(item, pathname, searchParams, activeView, isCurrentWaveDm)
+  );
+  const hasActiveItem = activeItemIndex >= 0;
 
   return (
     <nav
@@ -339,6 +391,18 @@ const BottomNavigationResolvedContent: React.FC<
     >
       <div className={getDockClassName(compact)}>
         <div className={floatingNavInnerClassName}>
+          <div
+            aria-hidden="true"
+            data-testid="mobile-dock-active-pill"
+            className={getFloatingActivePillClassName({
+              compact,
+              visible: hasActiveItem,
+            })}
+            style={getFloatingActivePillStyle({
+              activeItemIndex: hasActiveItem ? activeItemIndex : 0,
+              itemCount: navItems.length,
+            })}
+          />
           <ul className={getFloatingNavListClassName(compact)}>
             {navItems.map((item) => (
               <li
@@ -372,9 +436,9 @@ const BottomNavigationContent: React.FC<BottomNavigationProps> = ({
 
   return (
     <BottomNavigationResolvedContent
-      key={routeStateKey}
       hidden={hidden}
       pathname={pathname}
+      routeStateKey={routeStateKey}
     />
   );
 };

--- a/components/navigation/NavItem.tsx
+++ b/components/navigation/NavItem.tsx
@@ -42,31 +42,9 @@ const getIconSlotClass = ({
   return `tw-relative tw-z-10 tw-flex tw-items-center tw-justify-center tw-transition-transform tw-duration-300 tw-ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:tw-transition-none ${compactClassName}`;
 };
 
-const getActiveNavIndicatorClassName = ({
-  compact,
-  variant,
-}: {
-  readonly compact: boolean;
-  readonly variant: "floating" | "fixed";
-}) => {
-  if (variant === "fixed") {
-    return "tw-absolute tw-left-0 tw-top-0 tw-h-0.5 tw-w-full tw-rounded-full tw-bg-white";
-  }
-
-  const sizeClassName = compact
-    ? "tw-h-11 tw-w-[3.75rem] sm:tw-h-12 sm:tw-w-[4.25rem]"
-    : "tw-h-12 tw-w-[4.05rem] sm:tw-h-[3.15rem] sm:tw-w-[4.45rem]";
-
-  return `tw-absolute tw-left-1/2 tw-top-1/2 tw-z-0 -tw-translate-x-1/2 -tw-translate-y-1/2 tw-rounded-full tw-bg-white/[0.9] tw-shadow-[inset_0_1px_0_rgba(255,255,255,0.42),0_8px_24px_rgba(255,255,255,0.1)] tw-transition-[width,height] tw-duration-300 tw-ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:tw-transition-none ${sizeClassName}`;
-};
-
-const ActiveNavIndicator = ({
-  compact,
-  variant,
-}: {
-  readonly compact: boolean;
-  readonly variant: "floating" | "fixed";
-}) => <div className={getActiveNavIndicatorClassName({ compact, variant })} />;
+const FixedActiveNavIndicator = () => (
+  <div className="tw-absolute tw-left-0 tw-top-0 tw-h-0.5 tw-w-full tw-rounded-full tw-bg-white" />
+);
 
 const getHomeIconSizeClass = ({
   compact,
@@ -205,7 +183,7 @@ const NavItemLinkContent = ({
 
   return (
     <div className={getIconSlotClass({ compact, variant })}>
-      {isActive && <ActiveNavIndicator compact={compact} variant={variant} />}
+      {isActive && variant === "fixed" && <FixedActiveNavIndicator />}
       {IconComponent ? (
         <IconComponent
           className={`tw-relative tw-z-10 ${resolvedIconSizeClass} ${iconTextColorClass}`}

--- a/components/navigation/NavItem.tsx
+++ b/components/navigation/NavItem.tsx
@@ -12,9 +12,9 @@ import { useAuth } from "../auth/Auth";
 import { useSeizeConnectContext } from "../auth/SeizeConnectContext";
 import { useNotificationsContext } from "../notifications/NotificationsContext";
 import { getActiveWaveIdFromUrl } from "@/helpers/navigation.helpers";
-import { isNavItemActive } from "./isNavItemActive";
+import { getProfileHref, getResolvedNavItemState } from "./navItemState";
 import { getActiveViewFromUrl, useViewContext } from "./ViewContext";
-import type { NavItem as NavItemData, ViewKey } from "./navTypes";
+import type { NavItem as NavItemData } from "./navTypes";
 
 interface Props {
   readonly item: NavItemData;
@@ -104,51 +104,6 @@ const getDisabledButtonClassName = (variant: "floating" | "fixed") => {
   return `tw-pointer-events-none tw-relative tw-flex tw-h-full tw-w-full tw-min-w-0 tw-flex-col tw-items-center tw-border-0 tw-bg-transparent tw-opacity-40 tw-transition-colors focus:tw-outline-none ${layoutClassName}`;
 };
 
-const getResolvedProfileState = ({
-  activeView,
-  isCurrentWaveDm,
-  item,
-  pathname,
-  profileHref,
-  searchParams,
-}: {
-  readonly activeView: ViewKey | null;
-  readonly isCurrentWaveDm: boolean;
-  readonly item: NavItemData;
-  readonly pathname: string;
-  readonly profileHref: string | null;
-  readonly searchParams: ReturnType<typeof useSearchParams>;
-}) => {
-  const isProfileItem = item.kind === "route" && item.name === "Profile";
-  const normalizedPathname = pathname.toLowerCase();
-
-  if (isProfileItem && profileHref !== null) {
-    const isProfileActive =
-      activeView === null &&
-      (normalizedPathname === profileHref ||
-        normalizedPathname.startsWith(`${profileHref}/`));
-
-    return {
-      isActive: isProfileActive,
-      resolvedItem: {
-        ...item,
-        href: profileHref,
-      },
-    };
-  }
-
-  return {
-    isActive: isNavItemActive(
-      item,
-      pathname,
-      searchParams,
-      activeView,
-      isCurrentWaveDm
-    ),
-    resolvedItem: item,
-  };
-};
-
 const NavItemLinkContent = ({
   hasUnreadMessages,
   haveUnreadNotifications,
@@ -231,12 +186,11 @@ const NavItemContent = ({
 
   // Add unread notifications logic
   const { connectedProfile } = useAuth();
-  const normalizedConnectedHandle = (
-    connectedProfile?.normalised_handle ?? connectedProfile?.handle
-  )?.toLowerCase();
-  const normalizedConnectedAddress = address?.toLowerCase();
-  const profileSlug = normalizedConnectedHandle ?? normalizedConnectedAddress;
-  const profileHref = profileSlug ? `/${profileSlug}` : null;
+  const profileHref = getProfileHref({
+    address,
+    handle: connectedProfile?.handle,
+    normalisedHandle: connectedProfile?.normalised_handle,
+  });
   const { setTitle } = useTitle();
   const { notifications, haveUnreadNotifications } = useUnreadNotifications(
     item.name === "Notifications" ? (connectedProfile?.handle ?? null) : null
@@ -301,7 +255,7 @@ const NavItemContent = ({
   }
 
   const iconSizeClass = item.iconSizeClass ?? "tw-size-7";
-  const { isActive, resolvedItem } = getResolvedProfileState({
+  const { isActive, resolvedItem } = getResolvedNavItemState({
     activeView,
     isCurrentWaveDm,
     item,

--- a/components/navigation/isNavItemActive.ts
+++ b/components/navigation/isNavItemActive.ts
@@ -1,10 +1,12 @@
 import type { NavItem as NavItemData, ViewKey } from "./navTypes";
 import { getActiveWaveIdFromUrl } from "@/helpers/navigation.helpers";
 
+export type NavSearchParams = Pick<URLSearchParams, "get">;
+
 export const isNavItemActive = (
   item: NavItemData,
   pathname: string,
-  searchParams: URLSearchParams,
+  searchParams: NavSearchParams,
   activeView: ViewKey | null,
   isCurrentWaveDm: boolean
 ): boolean => {

--- a/components/navigation/navItemState.ts
+++ b/components/navigation/navItemState.ts
@@ -1,0 +1,67 @@
+import type { NavSearchParams } from "./isNavItemActive";
+import { isNavItemActive } from "./isNavItemActive";
+import type { NavItem as NavItemData, ViewKey } from "./navTypes";
+
+export const getProfileHref = ({
+  address,
+  handle,
+  normalisedHandle,
+}: {
+  readonly address?: string | null | undefined;
+  readonly handle?: string | null | undefined;
+  readonly normalisedHandle?: string | null | undefined;
+}): string | null => {
+  const normalizedConnectedHandle = (normalisedHandle ?? handle)?.toLowerCase();
+  const normalizedConnectedAddress = address?.toLowerCase();
+  const profileSlug = normalizedConnectedHandle ?? normalizedConnectedAddress;
+
+  return profileSlug ? `/${profileSlug}` : null;
+};
+
+export const getResolvedNavItemState = ({
+  activeView,
+  isCurrentWaveDm,
+  item,
+  pathname,
+  profileHref,
+  searchParams,
+}: {
+  readonly activeView: ViewKey | null;
+  readonly isCurrentWaveDm: boolean;
+  readonly item: NavItemData;
+  readonly pathname: string;
+  readonly profileHref: string | null;
+  readonly searchParams: NavSearchParams;
+}): {
+  readonly isActive: boolean;
+  readonly resolvedItem: NavItemData;
+} => {
+  const isProfileItem = item.kind === "route" && item.name === "Profile";
+  const normalizedPathname = pathname.toLowerCase();
+
+  if (isProfileItem && profileHref !== null) {
+    const isProfileActive =
+      activeView === null &&
+      (normalizedPathname === profileHref ||
+        normalizedPathname.startsWith(`${profileHref}/`));
+
+    return {
+      isActive: isProfileActive,
+      resolvedItem: {
+        ...item,
+        href: profileHref,
+      },
+    };
+  }
+
+  return {
+    isActive: isNavItemActive(
+      item,
+      pathname,
+      searchParams,
+      activeView,
+      isCurrentWaveDm
+    ),
+    resolvedItem: item,
+  };
+};


### PR DESCRIPTION
## Summary
- keep the mobile dock mounted across route/view changes so the active pill can animate between destinations
- move the floating active pill into `BottomNavigation` as a single shared decorative element
- keep fixed nav indicators inside `NavItem` and preserve existing icon color behavior
- share the nav active-state resolver between the floating dock pill and `NavItem`, including connected-profile route resolution, so the visual pill cannot drift from the item active state

## Impact / Risk Review
- **Functionality**: affects mobile bottom navigation presentation only; routing, link href generation, unread indicators, and click handling continue through `NavItem` and `ViewContext`.
- **UX**: restores the intended smooth active-pill motion across dock items while preserving reduced-motion handling and hidden-state behavior.
- **WCAG**: the moving pill remains `aria-hidden`, `pointer-events-none`, and motion-reduce aware; semantic active state remains on the real link via `aria-current`.
- **i18n**: no new user-facing copy or locale-sensitive formatting.
- **Security**: no auth, wallet, signing, token, external fetch, or HTML injection behavior changed; profile href resolution is reused only for nav state/href consistency.
- **Surfaces**: most relevant to web/native mobile dock behavior; Electron/desktop fixed navigation keeps its per-item fixed indicator path.

## Local Validation
- `codex-diff-check`
- `seize run format:changed`
- `seize run lint:changed`
- `seize run typecheck:changed`
- `seize run test:no-coverage -- __tests__/components/navigation/BottomNavigation.test.tsx __tests__/components/navigation/NavItem.test.tsx`

Note: `seize run check:changed` was attempted locally, but this Windows Codex host hits the repo `scripts/quality.js` nested `bin/6529.cmd` path that local AGENTS.md warns against. The equivalent formatter, lint, typecheck, and focused Jest checks above passed through the supported `seize` wrapper.

## Reviewbot Notes
- 6529bot flagged a possible divergence between the shared floating pill active calculation and `NavItem`'s connected-profile active branch.
- Follow-up commit `a2255826` extracts the shared active resolver and adds coverage for no-active-route pill hiding plus less brittle active-pill position assertions.