### PR TITLE
Align deploy skill with 1a-staging flow

### DIFF
--- a/ops/docs/developer/deployment-bus-process.md
+++ b/ops/docs/developer/deployment-bus-process.md
@@ -356,7 +356,7 @@ Use this order when a release spans frontend and backend:
 11. Deploy frontend production from `origin/main`.
 12. Validate frontend production and the user-visible integrated behavior.
 13. Merge `main` back into `1a-staging` in both repos so staging tracks
-   production plus any intentionally staged ahead-of-main work.
+    production plus any intentionally staged ahead-of-main work.
 
 Prefer compatibility windows:
 

--- a/ops/docs/developer/deployment-bus-process.md
+++ b/ops/docs/developer/deployment-bus-process.md
@@ -28,15 +28,18 @@ The deployment bus turns staging and production into an explicit queue:
 - exact SHAs and included PRs recorded before deploy
 - no overlapping deploys to the same environment
 - shared validation assignments for all included PR owners
-- production only from the same `origin/main` SHA or release set that passed
-  staging
+- staging normally validates feature or release branches on `1a-staging`
+  before those branches merge to `main`
+- production only from `origin/main` after the same release set or equivalent
+  resulting patch set passed staging
+- no promotion path ever merges `1a-staging` into `main`
 - human-owned production approval
 
 ## Current Deployment Facts
 
 Frontend staging:
 
-- Staging uses the `1a-staging` branch.
+- Staging uses the `1a-staging` branch as the integration branch.
 - `.github/workflows/deploy-staging.yml` runs on pushes to `1a-staging` and
   manual dispatch.
 - The workflow uses `concurrency.group: staging-deploy` with
@@ -47,6 +50,11 @@ Frontend staging:
   checkout still matches the expected SHA.
 - `scripts/staging.sh` installs dependencies, builds, restarts the PM2
   `6529seize` process, and saves PM2 state.
+- Normal staging branch movement is feature or release branch to `1a-staging`.
+  This intentionally lets staging test work before it is on production
+  `main`.
+- When `main` changes, merge `main` back into `1a-staging` so staging stays at
+  least as current as production. Do not merge `1a-staging` into `main`.
 
 Frontend production:
 
@@ -65,6 +73,8 @@ Frontend production:
 Backend coordination:
 
 - Backend deploys use `6529seize-backend` and its own `deploy-6529` skill.
+- Backend staging also uses the `1a-staging` branch. Backend production also
+  uses `main`.
 - Backend `.github/workflows/deploy.yml` dispatches one service at a time for
   `environment=staging` or `environment=prod`.
 - Backend releases must identify services and order before deploy.
@@ -177,8 +187,12 @@ Departure policy:
 
 Eligible release set:
 
-- merged to `origin/main`, unless staging is intentionally testing a PR before
-  merge under a documented exception
+- approved for staging by the PR owner, release captain, or human release
+  approver
+- not Draft, unless the PR owner or a human release approver explicitly named
+  the PR and requested staging
+- feature or release source branches are known and branch owners have not asked
+  agents to stop touching them
 - required CI and review bots terminal or explicitly deferred
 - risk and area understood
 - backend dependencies listed with required deploy order
@@ -190,12 +204,21 @@ Staging manifest:
 ```text
 environment: staging
 staging_branch: 1a-staging
+staging_source_ref: <feature branch, release branch, or main sync source>
 staging_deploy_sha: <actual SHA deployed from 1a-staging>
-production_candidate_sha: <origin/main SHA contained in the staging deploy>
+production_target_branch: main
+production_candidate_sha: <origin/main SHA after production merge, when known>
+validated_release_set: <named PRs/branches intended to ship together>
+release_equivalence: <same SHA | same patch set | requires rerun>
 included_prs:
   - number:
     title:
-    merge_sha:
+    source_ref:
+    target_branch:
+    draft_status:
+    owner_clearance:
+    staging_merge_sha:
+    production_merge_sha:
     risk:
     areas:
     validation_owner:
@@ -227,10 +250,14 @@ Until automation exists, the release captain can keep this manifest in the PR
 description, a deployment wave update, or a workstream note. The automation PR
 should make it a durable artifact linked from GitHub Deployment status history.
 
-For production gating, `production_candidate_sha` is the important SHA. If the
-staging branch contains a tree that is not the current `origin/main` production
-candidate, staging can still be useful for exploratory validation, but it does
-not satisfy the production "same SHA passed staging" gate.
+For production gating, `validated_release_set` and `release_equivalence` are
+the important fields. A staging deployment that contains a feature branch before
+it is on `main` can satisfy production only for that same named release set
+after the feature PR merges to `main` and no unrelated unvalidated changes are
+included. Exact SHAs may differ between `1a-staging` and `main`; the release
+captain must verify the resulting patch set, included PRs, and backend ordering
+match what passed staging. If `main` includes additional unvalidated work, rerun
+staging for the new production candidate or hold production.
 
 ## Multi-Agent Staging Validation
 
@@ -267,20 +294,32 @@ That hard gate is intentional for this process proposal.
 
 Before production:
 
-- staging passed for the same ordered frontend/backend release set
-- the production candidate is exactly the current `origin/main` SHA
+- staging passed for the same ordered frontend/backend release set or the same
+  resulting patch set after merge to `main`
+- the production candidate is the current `origin/main` SHA
 - no newer unvalidated commit has landed on `origin/main` after staging passed
 - no production deploy is already active
 - backend production dependencies are deployed and validated first
 - the human release approver accepted the manifest
 
-If `origin/main` advances after staging passed, do not deploy production from
-the older validated SHA. Either:
+If `origin/main` advances after staging passed, do not deploy unvalidated work.
+Either:
 
-- rerun the staging bus for the new `origin/main` SHA, including the additional
+- prove the new head contains only the staging-passed release set plus
+  explicitly approved already-validated work, or
+- rerun the staging bus for the new `origin/main` SHA, including any additional
   PRs in the manifest, or
 - pause merging briefly before final staging validation and production
   promotion.
+
+Promotion path:
+
+1. Merge the approved feature or release PRs to `main`.
+2. Deploy production from `main`.
+3. Merge `main` back into `1a-staging`.
+
+Never merge `1a-staging` into `main`. `1a-staging` may contain work that is
+valid for staging but not approved for production.
 
 Production validation:
 
@@ -303,15 +342,21 @@ Use this order when a release spans frontend and backend:
    changed.
 3. Regenerate or verify the frontend client against the intended backend
    contract before using new API behavior.
-4. Merge and deploy additive backend changes to staging.
+4. Merge the backend feature or release branch to backend `1a-staging`, then
+   deploy the required backend staging services from `1a-staging`.
 5. Validate backend staging, including API or service smoke.
-6. Deploy frontend staging for the candidate that uses the backend behavior.
+6. Merge the frontend feature or release branch to frontend `1a-staging`, then
+   deploy frontend staging for the candidate that uses the backend behavior.
 7. Validate frontend staging and cross-repo behavior together.
-8. Deploy backend production first when frontend production depends on new
+8. When the release set is ready, merge the same backend and frontend PRs to
+   `main` in their repos.
+9. Deploy backend production first when frontend production depends on new
    backend behavior.
-9. Validate backend production.
-10. Deploy frontend production from `origin/main`.
-11. Validate frontend production and the user-visible integrated behavior.
+10. Validate backend production.
+11. Deploy frontend production from `origin/main`.
+12. Validate frontend production and the user-visible integrated behavior.
+13. Merge `main` back into `1a-staging` in both repos so staging tracks
+   production plus any intentionally staged ahead-of-main work.
 
 Prefer compatibility windows:
 

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -5,17 +5,30 @@ description: Merge and deploy 6529 frontend or coordinated frontend/backend rele
 
 # Deploy 6529
 
-Carry an approved 6529 release from PR merge through staging validation and, when production is in the requested scope, production deployment and validation. Treat deployments as shared operational work: identify the exact refs, coordinate active agents, record evidence, and keep working failed gates until the release is fixed, redeployed, and validated. Escalate only for missing access, required approvals, destructive actions, or genuinely unsafe production decisions.
+Carry an approved 6529 release through staging validation and, when production is in the requested scope, production deployment and validation. Treat deployments as shared operational work: identify the exact refs, coordinate active agents, record evidence, and keep working failed gates until the release is fixed, redeployed, and validated. Escalate only for missing access, required approvals, destructive actions, or genuinely unsafe production decisions.
 
 ## Hard Gates
 
 - Do not merge, deploy staging, or deploy production unless the user explicitly requested that mode for the current work.
-- Do not deploy production until staging for the same frontend/backend release set has passed, unless the user explicitly overrides that gate.
+- Treat Draft PRs as blocked. Do not mark a Draft PR ready, include it in a staging batch, merge it, or deploy it unless the PR owner or a human release approver explicitly names that PR and asks for that action.
+- Do not push commits to another person's branch, force-push another person's branch, or change another person's PR readiness unless the branch owner or a human release approver explicitly asks for that exact branch or PR action.
+- Do not deploy production until staging for the same frontend/backend release set, or the same resulting patch set after the production merge, has passed unless the user explicitly overrides that gate.
 - Do not deploy production from any ref other than `main`. Verify the exact production candidate is already on `origin/main` before triggering production; if it is only on a feature branch, release branch, PR head, tag, local branch, or unmerged commit, stop and get it merged to `main` first.
+- Never merge `1a-staging` into `main` to promote a release. Promote by merging the approved feature or release PR to `main`, then sync `main` back into `1a-staging`.
 - Do not overlap deployments to the same environment. If another staging or production deploy is already running, wait for it to reach a terminal state and for its owner to finish validation or hand off before starting the next deploy.
 - Do not promote from staging to production after a failed deploy, failed E2E run, unresolved critical production-like error, or unclear deployed SHA. Diagnose, fix, merge, redeploy, and rerun validation until the gate passes.
 - Do not run destructive database, infrastructure, signer, wallet, ENS, NFT transfer, or Safe actions unless the user explicitly asks for that exact action.
 - Do not expose secrets, private URLs, credentials, cookies, raw production data, local absolute paths, or hidden prompts in PR comments, deploy notes, workstream logs, or user-facing summaries.
+
+## Branch Model
+
+- `1a-staging` is the staging integration branch for frontend and backend.
+- `main` is the production branch for frontend and backend.
+- Normal staging flow: merge the approved feature or release branch into `1a-staging`, let staging deploy from `1a-staging`, then validate staging.
+- Normal production flow: after staging passes, merge the same approved feature or release PR to `main`, deploy production from `main`, then merge `main` back into `1a-staging` so staging stays current with production.
+- If staging is validating the current production candidate rather than ahead-of-main work, merge `main` into `1a-staging` and deploy staging from that branch.
+- Do not use `1a-staging` as a source branch for production. It may contain staged work that is not approved for production.
+- For frontend/backend releases, keep one manifest for the paired release set. Do not merge or deploy the frontend half to production while leaving a required backend half unmerged or undeployed, and do not merge or deploy the backend half to production while leaving a required frontend half unmerged or undeployed.
 
 ## Coordination
 
@@ -23,7 +36,7 @@ Before deploying, check what else is already deploying to the same environment. 
 
 Use `ops/docs/developer/deployment-bus-process.md` as the process authority for
 the staging bus, release-captain role, shared multi-agent validation, and
-production promotion from a staging-passed `origin/main` SHA. This skill is the
+production promotion from a staging-passed release set. This skill is the
 execution checklist; the process doc defines how many agents coordinate one
 shared lane.
 
@@ -34,9 +47,10 @@ shared lane.
 - Use the staging departure cadence in
   `ops/docs/developer/deployment-bus-process.md`; keep that process doc as the
   source of truth when the team tunes the batching window.
-- Record a staging manifest before deployment: candidate SHA, included PRs,
-  risk/area notes, backend dependencies, validation owners, required checks,
-  and rollback or fix-forward notes.
+- Record a staging manifest before deployment: staging source ref, staging
+  SHA, intended production target, included PRs, risk/area notes, backend
+  dependencies, validation owners, required checks, and rollback or fix-forward
+  notes.
 - Use the deployment bus automation primitives when present:
   `ops/scripts/deployment-bus.cjs`,
   `ops/deployment-bus/manifest.v1.schema.json`, workflow manifest artifacts,
@@ -52,22 +66,27 @@ shared lane.
 - After staging deploys, assign each included PR owner a validation slice and
   run a core smoke validation. Production is blocked until required validation
   passes or the failed/held work is excluded from the production candidate.
-- If `origin/main` advances after staging passed, do not deploy the older
-  staging-passed SHA to production. Rerun staging for the new `origin/main` SHA
-  or pause merges before final staging validation and production promotion.
+- If `origin/main` advances after staging passed, do not deploy unvalidated
+  changes. Confirm the new `origin/main` contains only the staging-passed
+  release set plus explicitly approved already-validated changes, or rerun
+  staging for the new production candidate.
 
 ## Preflight
 
 1. Identify the release set:
-   - frontend PRs and target branch
+   - frontend PRs, branch owners, draft/ready state, and target branch
    - backend PRs, migrations, generated API/OpenAPI changes, feature flags, and deploy order
+   - staging source refs for frontend and backend, normally feature branch to `1a-staging`
+   - production target refs for frontend and backend, always `main`
    - expected user-facing behavior to validate
 2. Inspect current deploy docs and workflows before acting:
    - frontend staging: `.github/workflows/deploy-staging.yml`, `scripts/staging.sh`, `bin/6529`
    - frontend production: `.github/workflows/build-upload-deploy-prod.yml`, `bin/ghdeploy`
    - package and wrapper notes: `ops/docs/developer/pnpm-and-socket-firewall.md`
    - backend: when backend is involved, use `ops/skills/deploy-6529/SKILL.md` from the separate repository `6529-Collections/6529seize-backend` as the backend deployment authority. Do not resolve that path inside the frontend repo.
-3. Verify PR readiness before merge:
+3. Verify PR readiness before any staging or production branch movement:
+   - PR is not Draft unless the PR owner or a human release approver explicitly requested this action
+   - branch owner has not asked agents to stop touching the branch or PR
    - agent review complete
    - review bots addressed or explicitly deferred
    - required CI and DCO passing
@@ -75,21 +94,27 @@ shared lane.
    - release risk and rollback/fix-forward plan understood
 4. Use the repo-local `6529` wrapper for frontend project commands in release notes, checked-in docs, CI descriptions, and deploy instructions.
 
-## Merge
+## Branch Movement
 
-1. Confirm the PR is the one the user asked to ship.
+1. Confirm the PR is the one the user asked to stage or ship.
 2. Re-check latest head SHA, approvals, required checks, and unresolved review threads.
-3. Merge using the repo-approved GitHub path and record:
+3. For staging, merge the approved feature or release branch into `1a-staging` and record:
    - PR number
-   - merge commit SHA
-   - target branch
+   - feature or release branch
+   - `1a-staging` merge commit SHA
    - included backend/frontend dependency notes
-4. If merge fails, resolve the merge blocker through the normal PR cycle before deployment. Re-check CI and review state after every fix.
+4. For production, merge the same approved feature or release PR to `main` through the repo-approved GitHub path and record:
+   - PR number
+   - `main` merge commit SHA
+   - equivalence to the staging-validated release set
+   - included backend/frontend dependency notes
+5. After production merge or deploy, merge `main` back into `1a-staging` to keep staging current with production.
+6. If any merge fails, resolve the merge blocker through the normal PR cycle before deployment. Re-check CI and review state after every fix.
 
 ## Staging Deployment
 
 1. Confirm no active staging deploy is already using the lane.
-2. Deploy the exact intended frontend merge commit to staging. Current frontend staging is driven by the `1a-staging` branch and `.github/workflows/deploy-staging.yml`; the workflow runs `./bin/6529 staging` on the staging host through SSM and verifies the deployed SHA. Do not force-push, reset, or replace `1a-staging` over another active candidate without coordination.
+2. Deploy the exact intended frontend staging commit from `1a-staging`. Current frontend staging is driven by the `1a-staging` branch and `.github/workflows/deploy-staging.yml`; the workflow runs `./bin/6529 staging` on the staging host through SSM and verifies the deployed SHA. Do not force-push, reset, or replace `1a-staging` over another active candidate without coordination.
 3. If staging requires backend changes, use the backend `deploy-6529` skill from `6529-Collections/6529seize-backend` to deploy backend staging first when the frontend depends on new API behavior.
 4. Watch the staging workflow to a terminal state. Capture the run URL, GitHub Deployment id/status history, manifest artifact, status, and deployed SHA.
 5. If the staging deploy fails, inspect logs, identify the owner layer, fix through the normal PR cycle, merge the fix, and redeploy staging from the new SHA. Keep iterating until staging deploys cleanly or a safety/access boundary requires user input.
@@ -117,8 +142,8 @@ shared lane.
 ## Production Deployment
 
 1. Proceed to production when the user already asked to take the release through production, such as "take it all the way through prod." Ask only when the current request did not include production deployment.
-2. Reconfirm staging passed for the same SHAs or the same ordered frontend/backend release set.
-3. Verify the production candidate is the current `origin/main` SHA and no newer unvalidated commit landed after staging passed. If `origin/main` advanced, rerun staging for the new release set before production.
+2. Reconfirm staging passed for the same ordered frontend/backend release set. Exact SHAs may differ after the production merge to `main`; verify that the resulting production patch set is equivalent to what passed staging and contains no unvalidated extras.
+3. Verify the production candidate is the current `origin/main` SHA and no newer unvalidated commit landed after staging passed. If `origin/main` advanced with unvalidated changes, rerun staging for the new release set before production.
 4. Confirm no active production deploy is in progress. If one is active or the state is unclear, wait until it finishes and production validation is complete or explicitly handed off.
 5. Deploy backend production before frontend production when frontend depends on new backend behavior. Use the backend `deploy-6529` skill from `6529-Collections/6529seize-backend` for backend service order, validation, and recovery.
 6. Deploy frontend production through the repo-approved path from `main` only, following the hard gate above. Current frontend production deploy is `Web Deploy - PROD` in `.github/workflows/build-upload-deploy-prod.yml`; `bin/ghdeploy` may be used only from a clean, upstream-synced `main` worktree.
@@ -213,6 +238,7 @@ gh run list -R 6529-Collections/6529seize-frontend --workflow deploy-staging.yml
 gh run list -R 6529-Collections/6529seize-frontend --workflow build-upload-deploy-prod.yml -L 10
 gh run watch <run-id> -R 6529-Collections/6529seize-frontend
 gh run view <run-id> -R 6529-Collections/6529seize-frontend --log-failed
+gh pr view <pr-number> -R 6529-Collections/6529seize-frontend --json isDraft,author,headRefName,baseRefName,headRefOid,mergeCommit
 gh workflow run build-upload-deploy-prod.yml --ref main -R 6529-Collections/6529seize-frontend
 6529 run deployment-bus -- summarize-manifest --file deployment-bus-manifest.json
 git fetch --no-tags origin main

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -47,10 +47,10 @@ shared lane.
 - Use the staging departure cadence in
   `ops/docs/developer/deployment-bus-process.md`; keep that process doc as the
   source of truth when the team tunes the batching window.
-- Record a staging manifest before deployment: staging source ref, staging
+- Record a staging manifest summary before deployment: staging source ref, staging
   SHA, intended production target, included PRs, risk/area notes, backend
   dependencies, validation owners, required checks, and rollback or fix-forward
-  notes.
+  notes. Use the process doc for the full manifest schema.
 - Use the deployment bus automation primitives when present:
   `ops/scripts/deployment-bus.cjs`,
   `ops/deployment-bus/manifest.v1.schema.json`, workflow manifest artifacts,


### PR DESCRIPTION
## Issue
- The deploy skill still implied staging candidates are normally already merged to `origin/main`.
- That conflicts with the current 6529 branch model from the team chat: staging should validate ahead-of-main work on `1a-staging`, while production deploys only from `main`.

## Fix
- Make `1a-staging` the normal staging integration branch and `main` the production branch.
- Document the approved flow: feature/release branch to `1a-staging`, validate staging, merge the same release set to `main`, deploy production from `main`, then sync `main` back to `1a-staging`.
- Explicitly forbid promoting by merging `1a-staging` into `main`.

## Changes
- Updates `ops/skills/deploy-6529/SKILL.md` with the branch model, Draft PR guardrails, branch-owner protections, and paired frontend/backend release requirements.
- Updates `ops/docs/developer/deployment-bus-process.md` so the process authority matches the skill and tracks release-set equivalence instead of assuming identical staging and production SHAs.

## Validation
- Ran `codex-diff-check -- ops/skills/deploy-6529/SKILL.md ops/docs/developer/deployment-bus-process.md`.
- Reviewed the diff for stale language around staging-from-main and same-SHA production promotion.

## Risk
- Level: Low
- Why: Documentation and skill guidance only; no runtime code or workflow behavior changes.
- Rollback: Revert this docs/skill commit.

## Review Notes
- Please focus on whether the branch choreography matches the intended 6529 deploy model and whether the Draft PR / branch-owner guardrails are strict enough.