### PR TITLE
[codex] Smooth mobile dock pill transitions

### DIFF
--- a/__tests__/components/navigation/BottomNavigation.test.tsx
+++ b/__tests__/components/navigation/BottomNavigation.test.tsx
@@ -67,56 +67,16 @@ const flushAnimationFrame = async () => {
   });
 };
 
-const createRect = ({
-  left,
-  width,
+const expectActivePillLayoutCalc = ({
+  compact = false,
+  style,
 }: {
-  readonly left: number;
-  readonly width: number;
-}): DOMRect =>
-  ({
-    bottom: 64,
-    height: 64,
-    left,
-    right: left + width,
-    top: 0,
-    width,
-    x: left,
-    y: 0,
-    toJSON: () => ({}),
-  }) as DOMRect;
-
-const mockFloatingDockGeometry = () => {
-  const innerLeft = 40;
-  const itemWidth = 88;
-  const itemLefts = Array.from(
-    { length: 7 },
-    (_unused, index) => 52 + index * 96
-  );
-
-  jest
-    .spyOn(HTMLElement.prototype, "getBoundingClientRect")
-    .mockImplementation(function getBoundingClientRect() {
-      const element = this as HTMLElement;
-      if (element.getAttribute("data-testid") === "mobile-dock-inner") {
-        return createRect({ left: innerLeft, width: 704 });
-      }
-
-      const itemIndex = element.getAttribute("data-mobile-dock-item-index");
-      if (itemIndex !== null) {
-        return createRect({
-          left: itemLefts[Number(itemIndex)] ?? 0,
-          width: itemWidth,
-        });
-      }
-
-      return createRect({ left: 0, width: 0 });
-    });
-
-  return {
-    getExpectedMeasuredLeft: (index: number) =>
-      itemLefts[index]! - innerLeft + itemWidth / 2,
-  };
+  readonly compact?: boolean;
+  readonly style: string | null;
+}) => {
+  expect(style).toContain("left: calc(");
+  expect(style).toContain("100%");
+  expect(style).toContain(compact ? "0.625rem" : "1rem");
 };
 
 const createScrollableElement = ({
@@ -265,13 +225,11 @@ describe("BottomNavigation", () => {
   });
 
   it("keeps one active pill mounted while moving it between active items", () => {
-    const { getExpectedMeasuredLeft } = mockFloatingDockGeometry();
     const { getByTestId, rerender } = render(<BottomNavigation />);
     const activePill = getByTestId("mobile-dock-active-pill");
+    const initialStyle = activePill.getAttribute("style");
 
-    expect(activePill.getAttribute("style")).toContain(
-      `left: ${getExpectedMeasuredLeft(3)}px`
-    );
+    expectActivePillLayoutCalc({ style: initialStyle });
     expect(activePill).toHaveClass("tw-transition-[left,width,height,opacity]");
 
     (usePathname as jest.Mock).mockReturnValue("/notifications");
@@ -279,9 +237,10 @@ describe("BottomNavigation", () => {
 
     const movedActivePill = getByTestId("mobile-dock-active-pill");
     expect(movedActivePill).toBe(activePill);
-    expect(movedActivePill.getAttribute("style")).toContain(
-      `left: ${getExpectedMeasuredLeft(6)}px`
-    );
+    expect(movedActivePill.getAttribute("style")).not.toBe(initialStyle);
+    expectActivePillLayoutCalc({
+      style: movedActivePill.getAttribute("style"),
+    });
   });
 
   it("hides the active pill when no dock item matches the route", () => {
@@ -302,7 +261,7 @@ describe("BottomNavigation", () => {
       writable: true,
     });
 
-    render(<BottomNavigation />);
+    const { getByTestId } = render(<BottomNavigation />);
 
     act(() => {
       globalThis.scrollY = 24;
@@ -315,6 +274,13 @@ describe("BottomNavigation", () => {
           return props.variant === "floating" && props.compact === true;
         })
       ).toBe(true);
+    });
+
+    const activePill = getByTestId("mobile-dock-active-pill");
+    expect(activePill).toHaveClass("tw-h-10", "tw-w-12");
+    expectActivePillLayoutCalc({
+      compact: true,
+      style: activePill.getAttribute("style"),
     });
   });
 

--- a/components/navigation/BottomNavigation.tsx
+++ b/components/navigation/BottomNavigation.tsx
@@ -5,7 +5,6 @@ import React, {
   Suspense,
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -293,7 +292,7 @@ const getFloatingActivePillClassName = ({
   readonly visible: boolean;
 }) => {
   const sizeClassName = compact
-    ? "tw-h-11 tw-w-[3.5rem] sm:tw-h-12 sm:tw-w-16"
+    ? "tw-h-10 tw-w-12 sm:tw-h-11 sm:tw-w-14"
     : "tw-h-12 tw-w-[3.65rem] sm:tw-h-[3.15rem] sm:tw-w-[4.05rem]";
   const visibilityClassName = visible ? "tw-opacity-100" : "tw-opacity-0";
 
@@ -304,24 +303,19 @@ const getFloatingActivePillStyle = ({
   activeItemIndex,
   compact,
   itemCount,
-  measuredLeft,
 }: {
   readonly activeItemIndex: number;
   readonly compact: boolean;
   readonly itemCount: number;
-  readonly measuredLeft: number | null;
 }): React.CSSProperties => ({
-  left:
-    measuredLeft === null
-      ? getFloatingActivePillFallbackLeft({
-          activeItemIndex,
-          compact,
-          itemCount,
-        })
-      : `${measuredLeft}px`,
+  left: getFloatingActivePillLeft({
+    activeItemIndex,
+    compact,
+    itemCount,
+  }),
 });
 
-const getFloatingActivePillFallbackLeft = ({
+const getFloatingActivePillLeft = ({
   activeItemIndex,
   compact,
   itemCount,
@@ -367,9 +361,6 @@ const BottomNavigationResolvedContent: React.FC<
   const searchParams = useSearchParams();
 
   const mobileNavRef = useRef<HTMLDivElement | null>(null);
-  const floatingNavInnerRef = useRef<HTMLDivElement | null>(null);
-  const navItemRefs = useRef<(HTMLLIElement | null)[]>([]);
-  const [activePillLeft, setActivePillLeft] = useState<number | null>(null);
   const waveIdFromQuery = getActiveWaveIdFromUrl({ pathname, searchParams });
   const activeView = getActiveViewFromUrl({
     activeWaveId: waveIdFromQuery,
@@ -392,12 +383,6 @@ const BottomNavigationResolvedContent: React.FC<
   const setMobileNavRef = useCallback((node: HTMLDivElement | null) => {
     mobileNavRef.current = node;
   }, []);
-  const setNavItemRef = useCallback(
-    (index: number, node: HTMLLIElement | null) => {
-      navItemRefs.current[index] = node;
-    },
-    []
-  );
 
   useEffect(() => {
     registerRef("mobileNav", hidden ? null : mobileNavRef.current);
@@ -436,67 +421,6 @@ const BottomNavigationResolvedContent: React.FC<
       }).isActive
   );
   const hasActiveItem = activeItemIndex >= 0;
-  const updateActivePillLayout = useCallback(() => {
-    if (!hasActiveItem) {
-      setActivePillLeft(null);
-      return;
-    }
-
-    const innerElement = floatingNavInnerRef.current;
-    const activeItemElement = navItemRefs.current[activeItemIndex] ?? null;
-    if (innerElement === null || activeItemElement === null) {
-      setActivePillLeft(null);
-      return;
-    }
-
-    const innerRect = innerElement.getBoundingClientRect();
-    const activeItemRect = activeItemElement.getBoundingClientRect();
-    if (innerRect.width <= 0 || activeItemRect.width <= 0) {
-      setActivePillLeft(null);
-      return;
-    }
-
-    const nextLeft =
-      activeItemRect.left - innerRect.left + activeItemRect.width / 2;
-    setActivePillLeft((currentLeft) =>
-      currentLeft !== null && Math.abs(currentLeft - nextLeft) < 0.5
-        ? currentLeft
-        : nextLeft
-    );
-  }, [activeItemIndex, hasActiveItem]);
-
-  useLayoutEffect(() => {
-    navItemRefs.current.length = navItems.length;
-    updateActivePillLayout();
-  }, [compact, navItems.length, updateActivePillLayout]);
-
-  useEffect(() => {
-    if (!hasActiveItem) {
-      return;
-    }
-
-    const handleResize = () => updateActivePillLayout();
-    globalThis.addEventListener("resize", handleResize);
-
-    const resizeObserver =
-      typeof ResizeObserver === "undefined"
-        ? null
-        : new ResizeObserver(handleResize);
-    const innerElement = floatingNavInnerRef.current;
-    if (innerElement !== null) {
-      resizeObserver?.observe(innerElement);
-    }
-    navItemRefs.current.forEach((itemElement) => {
-      if (itemElement !== null) {
-        resizeObserver?.observe(itemElement);
-      }
-    });
-
-    return () => {
-      globalThis.removeEventListener("resize", handleResize);
-      resizeObserver?.disconnect();
-    };
-  }, [compact, hasActiveItem, navItems.length, updateActivePillLayout]);
 
   return (
     <nav
@@ -507,11 +431,7 @@ const BottomNavigationResolvedContent: React.FC<
       inert={hidden}
     >
       <div className={getDockClassName(compact)}>
-        <div
-          ref={floatingNavInnerRef}
-          data-testid="mobile-dock-inner"
-          className={floatingNavInnerClassName}
-        >
+        <div className={floatingNavInnerClassName}>
           <div
             aria-hidden="true"
             data-testid="mobile-dock-active-pill"
@@ -523,15 +443,12 @@ const BottomNavigationResolvedContent: React.FC<
               activeItemIndex: hasActiveItem ? activeItemIndex : 0,
               compact,
               itemCount: navItems.length,
-              measuredLeft: activePillLeft,
             })}
           />
           <ul className={getFloatingNavListClassName(compact)}>
-            {navItems.map((item, index) => (
+            {navItems.map((item) => (
               <li
                 key={item.name}
-                ref={(node) => setNavItemRef(index, node)}
-                data-mobile-dock-item-index={index}
                 className="tw-flex tw-h-full tw-min-w-0 tw-flex-1 tw-items-center tw-justify-center"
               >
                 <NavItem


### PR DESCRIPTION
## Issue
- The floating mobile dock active pill could briefly appear offset or oversized while the dock changed between expanded and compact states during scroll.

## Fix
- Position the active pill with the same deterministic flex-track formula used by the dock layout instead of late JS-measured pixel offsets.
- Trim the compact active pill size so it fits the compact dock without looking bloated.

## Changes
- Removed the active pill resize observer / DOM measurement loop.
- Kept the active pill on a responsive `calc(...)` left position so it follows dock width changes throughout the transition.
- Updated BottomNavigation tests to cover the layout-based active pill position and compact sizing.

## Validation
- `./bin/6529 run test -- __tests__/components/navigation/BottomNavigation.test.tsx __tests__/components/navigation/NavItem.test.tsx`
- `./bin/6529 run check:changed`

## Risk
- Level: Low
- Why: scoped to the mobile bottom navigation pill positioning and sizing; no route, data, or API behavior changes.
- Rollback: revert this PR to restore the prior measured-position behavior.

## Review Notes
- Please sanity-check compact dock active states, especially Home/Network and first/last items while scrolling between expanded and compact dock states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the bottom navigation active indicator so its position and size update more consistently when switching items or entering compact dock mode.
  * Reduced reliance on measured layout changes, which may make the active pill behavior more stable during scrolling and route changes.

* **Tests**
  * Updated navigation tests to verify the active indicator’s visible style and reuse behavior more directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->