### PR TITLE
[codex] Limit notifications dock clearance to app

### DIFF
--- a/__tests__/components/brain/notifications/Notifications.test.tsx
+++ b/__tests__/components/brain/notifications/Notifications.test.tsx
@@ -106,7 +106,9 @@ jest.mock("@/contexts/TitleContext", () => ({
   TitleProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
-import Notifications from "@/components/brain/notifications";
+import Notifications, {
+  floatingDockClearanceClassName,
+} from "@/components/brain/notifications";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
 
 const useDeviceInfoMock = useDeviceInfo as jest.MockedFunction<
@@ -119,6 +121,20 @@ const getDefaultDeviceInfo = () => ({
   isAppleMobile: false,
   isMobileDevice: false,
 });
+
+const mockSuccessfulNotificationsQuery = () => {
+  useNotificationsQueryMock.mockReturnValue({
+    items: ["a"],
+    isFetching: false,
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    fetchNextPage: jest.fn().mockResolvedValue(undefined),
+    refetch: jest.fn().mockResolvedValue(undefined),
+    isInitialQueryDone: true,
+    isSuccess: true,
+    error: null,
+  });
+};
 
 describe("Notifications component", () => {
   beforeEach(() => {
@@ -159,24 +175,32 @@ describe("Notifications component", () => {
   });
 
   it("renders wrapper with items", async () => {
-    useNotificationsQueryMock.mockReturnValue({
-      items: ["a"],
-      isFetching: false,
-      isFetchingNextPage: false,
-      hasNextPage: false,
-      fetchNextPage: jest.fn().mockResolvedValue(undefined),
-      refetch: jest.fn().mockResolvedValue(undefined),
-      isInitialQueryDone: true,
-      isSuccess: true,
-      error: null,
-    });
+    mockSuccessfulNotificationsQuery();
 
     render(<Notifications activeDrop={null} setActiveDrop={jest.fn()} />);
 
     expect(screen.getByTestId("wrapper")).toBeInTheDocument();
     expect(
       document.querySelector('[data-mobile-bottom-nav-scroll-target="true"]')
-    ).toHaveClass("tw-pb-6");
+    ).not.toHaveClass(floatingDockClearanceClassName);
+    await waitFor(() => {
+      expect(mutateAsyncMock).toHaveBeenCalled();
+    });
+  });
+
+  it("does not add floating dock clearance on mobile web", async () => {
+    useDeviceInfoMock.mockReturnValue({
+      ...getDefaultDeviceInfo(),
+      hasTouchScreen: true,
+      isMobileDevice: true,
+    });
+    mockSuccessfulNotificationsQuery();
+
+    render(<Notifications activeDrop={null} setActiveDrop={jest.fn()} />);
+
+    expect(
+      document.querySelector('[data-mobile-bottom-nav-scroll-target="true"]')
+    ).not.toHaveClass(floatingDockClearanceClassName);
     await waitFor(() => {
       expect(mutateAsyncMock).toHaveBeenCalled();
     });
@@ -189,23 +213,13 @@ describe("Notifications component", () => {
       isApp: true,
       isMobileDevice: true,
     });
-    useNotificationsQueryMock.mockReturnValue({
-      items: ["a"],
-      isFetching: false,
-      isFetchingNextPage: false,
-      hasNextPage: false,
-      fetchNextPage: jest.fn().mockResolvedValue(undefined),
-      refetch: jest.fn().mockResolvedValue(undefined),
-      isInitialQueryDone: true,
-      isSuccess: true,
-      error: null,
-    });
+    mockSuccessfulNotificationsQuery();
 
     render(<Notifications activeDrop={null} setActiveDrop={jest.fn()} />);
 
     expect(
       document.querySelector('[data-mobile-bottom-nav-scroll-target="true"]')
-    ).toHaveClass("tw-pb-[calc(4rem+env(safe-area-inset-bottom,0px))]");
+    ).toHaveClass(floatingDockClearanceClassName);
     await waitFor(() => {
       expect(mutateAsyncMock).toHaveBeenCalled();
     });

--- a/__tests__/components/brain/notifications/Notifications.test.tsx
+++ b/__tests__/components/brain/notifications/Notifications.test.tsx
@@ -106,9 +106,8 @@ jest.mock("@/contexts/TitleContext", () => ({
   TitleProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
-import Notifications, {
-  floatingDockClearanceClassName,
-} from "@/components/brain/notifications";
+import Notifications from "@/components/brain/notifications";
+import { floatingDockClearanceClassName } from "@/components/brain/notifications/notifications.constants";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
 
 const useDeviceInfoMock = useDeviceInfo as jest.MockedFunction<

--- a/__tests__/components/brain/notifications/Notifications.test.tsx
+++ b/__tests__/components/brain/notifications/Notifications.test.tsx
@@ -81,6 +81,16 @@ jest.mock("@/components/brain/my-stream/layout/LayoutContext", () => ({
   useLayout: () => ({ notificationsViewStyle: { height: "10px" } }),
 }));
 
+jest.mock("@/hooks/useDeviceInfo", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    hasTouchScreen: false,
+    isApp: false,
+    isAppleMobile: false,
+    isMobileDevice: false,
+  })),
+}));
+
 // Mock TitleContext
 jest.mock("@/contexts/TitleContext", () => ({
   useTitle: () => ({
@@ -97,6 +107,18 @@ jest.mock("@/contexts/TitleContext", () => ({
 }));
 
 import Notifications from "@/components/brain/notifications";
+import useDeviceInfo from "@/hooks/useDeviceInfo";
+
+const useDeviceInfoMock = useDeviceInfo as jest.MockedFunction<
+  typeof useDeviceInfo
+>;
+
+const getDefaultDeviceInfo = () => ({
+  hasTouchScreen: false,
+  isApp: false,
+  isAppleMobile: false,
+  isMobileDevice: false,
+});
 
 describe("Notifications component", () => {
   beforeEach(() => {
@@ -109,6 +131,7 @@ describe("Notifications component", () => {
     setActiveProfileProxyMock.mockClear();
     setActiveProfileProxyMock.mockResolvedValue(undefined);
     setToastMock.mockClear();
+    useDeviceInfoMock.mockReturnValue(getDefaultDeviceInfo());
   });
 
   it("shows loader when fetching and no items", async () => {
@@ -151,6 +174,35 @@ describe("Notifications component", () => {
     render(<Notifications activeDrop={null} setActiveDrop={jest.fn()} />);
 
     expect(screen.getByTestId("wrapper")).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-mobile-bottom-nav-scroll-target="true"]')
+    ).toHaveClass("tw-pb-6");
+    await waitFor(() => {
+      expect(mutateAsyncMock).toHaveBeenCalled();
+    });
+  });
+
+  it("keeps floating dock clearance in the Capacitor app", async () => {
+    useDeviceInfoMock.mockReturnValue({
+      ...getDefaultDeviceInfo(),
+      hasTouchScreen: true,
+      isApp: true,
+      isMobileDevice: true,
+    });
+    useNotificationsQueryMock.mockReturnValue({
+      items: ["a"],
+      isFetching: false,
+      isFetchingNextPage: false,
+      hasNextPage: false,
+      fetchNextPage: jest.fn().mockResolvedValue(undefined),
+      refetch: jest.fn().mockResolvedValue(undefined),
+      isInitialQueryDone: true,
+      isSuccess: true,
+      error: null,
+    });
+
+    render(<Notifications activeDrop={null} setActiveDrop={jest.fn()} />);
+
     expect(
       document.querySelector('[data-mobile-bottom-nav-scroll-target="true"]')
     ).toHaveClass("tw-pb-[calc(4rem+env(safe-area-inset-bottom,0px))]");

--- a/components/brain/notifications/index.tsx
+++ b/components/brain/notifications/index.tsx
@@ -13,6 +13,7 @@ import { useNotificationsScroll } from "./hooks/useNotificationsScroll";
 import NotificationsContent from "./subcomponents/NotificationsContent";
 import { WaveDropsReverseContainer } from "@/components/waves/drops/WaveDropsReverseContainer";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
+import { floatingDockClearanceClassName } from "./notifications.constants";
 
 interface NotificationsProps {
   readonly activeDrop: ActiveDropState | null;
@@ -41,9 +42,6 @@ const compareNotificationCause = (
 ): number =>
   NOTIFICATION_CAUSE_PRIORITY[firstCause] -
   NOTIFICATION_CAUSE_PRIORITY[secondCause];
-
-export const floatingDockClearanceClassName =
-  "tw-pb-[calc(4rem+env(safe-area-inset-bottom,0px))]";
 
 export default function Notifications({
   activeDrop,

--- a/components/brain/notifications/index.tsx
+++ b/components/brain/notifications/index.tsx
@@ -42,7 +42,7 @@ const compareNotificationCause = (
   NOTIFICATION_CAUSE_PRIORITY[firstCause] -
   NOTIFICATION_CAUSE_PRIORITY[secondCause];
 
-const floatingDockClearanceClassName =
+export const floatingDockClearanceClassName =
   "tw-pb-[calc(4rem+env(safe-area-inset-bottom,0px))]";
 
 export default function Notifications({

--- a/components/brain/notifications/index.tsx
+++ b/components/brain/notifications/index.tsx
@@ -12,6 +12,7 @@ import { useNotificationsController } from "./hooks/useNotificationsController";
 import { useNotificationsScroll } from "./hooks/useNotificationsScroll";
 import NotificationsContent from "./subcomponents/NotificationsContent";
 import { WaveDropsReverseContainer } from "@/components/waves/drops/WaveDropsReverseContainer";
+import useDeviceInfo from "@/hooks/useDeviceInfo";
 
 interface NotificationsProps {
   readonly activeDrop: ActiveDropState | null;
@@ -41,10 +42,14 @@ const compareNotificationCause = (
   NOTIFICATION_CAUSE_PRIORITY[firstCause] -
   NOTIFICATION_CAUSE_PRIORITY[secondCause];
 
+const floatingDockClearanceClassName =
+  "tw-pb-[calc(4rem+env(safe-area-inset-bottom,0px))]";
+
 export default function Notifications({
   activeDrop,
   setActiveDrop,
 }: NotificationsProps) {
+  const { isApp } = useDeviceInfo();
   const {
     activeFilter,
     setActiveFilter,
@@ -96,7 +101,9 @@ export default function Notifications({
           onTopIntersection={handleTopIntersection}
           isFetchingNextPage={isFetchingNextPage}
           hasNextPage={pagination.hasNextPage}
-          bottomPaddingClassName="tw-pb-[calc(4rem+env(safe-area-inset-bottom,0px))]"
+          bottomPaddingClassName={
+            isApp ? floatingDockClearanceClassName : undefined
+          }
           containerClassName="tw-bg-transparent"
         >
           <NotificationsContent

--- a/components/brain/notifications/notifications.constants.ts
+++ b/components/brain/notifications/notifications.constants.ts
@@ -1,0 +1,2 @@
+export const floatingDockClearanceClassName =
+  "tw-pb-[calc(4rem+env(safe-area-inset-bottom,0px))]";


### PR DESCRIPTION
## Issue
Desktop notifications inherited the mobile floating dock bottom clearance, leaving an unnecessary gap at the bottom of the notifications list.

## Fix
Only apply the floating dock clearance to the notifications reverse-scroll container when running inside the Capacitor app. Desktop and non-app web now use the normal reverse-list padding.

## Changes
- Gate notifications floating dock clearance on `useDeviceInfo().isApp`.
- Update notifications tests to cover default web spacing and Capacitor app dock clearance.

## Validation
- `./bin/6529 run test -- __tests__/components/brain/notifications/Notifications.test.tsx`
- `./bin/6529 run check:changed`

## Risk
- Level: Low
- Scope: notifications list bottom spacing only.
- Rollback: revert this PR to restore unconditional mobile dock clearance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification layout on mobile app contexts so the bottom spacing adapts correctly and content no longer overlaps the floating dock.
  * Updated notification behavior across device types to better match touch-enabled app experiences.
* **Tests**
  * Expanded test coverage for mobile and app-based notification rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->