### PR TITLE
[codex] Unbox profile Brain mobile strip

### DIFF
--- a/components/user/brain/UserPageBrainSidebarMobileStrip.tsx
+++ b/components/user/brain/UserPageBrainSidebarMobileStrip.tsx
@@ -127,11 +127,11 @@ export default function UserPageBrainSidebarMobileStrip({
   return (
     <section
       aria-label="Brain waves strip"
-      className="tw-mb-5 lg:tw-hidden"
+      className="tw-mb-4 lg:tw-hidden"
       data-testid="brain-sidebar-mobile-strip"
     >
-      <div className="tw-relative tw-overflow-hidden tw-rounded-xl tw-border tw-border-solid tw-border-white/[0.08] tw-bg-iron-950/70 tw-p-3 tw-shadow-sm">
-        <div className="tw-flex tw-items-end tw-gap-4 tw-overflow-x-auto tw-overflow-y-hidden tw-pb-2 tw-scrollbar-thin tw-scrollbar-track-iron-900 tw-scrollbar-thumb-iron-600 desktop-hover:hover:tw-scrollbar-thumb-iron-400">
+      <div className="tw-relative">
+        <div className="tw-flex tw-items-end tw-gap-4 tw-overflow-x-auto tw-overflow-y-hidden tw-pb-1.5 tw-pr-4 tw-scrollbar-thin tw-scrollbar-track-transparent tw-scrollbar-thumb-iron-700/60 desktop-hover:hover:tw-scrollbar-thumb-iron-500">
           {shouldShowCreatedSection && (
             <div className="tw-flex tw-shrink-0 tw-flex-col tw-gap-2">
               <span className="tw-px-1 tw-text-[10px] tw-font-semibold tw-uppercase tw-tracking-wider tw-text-iron-500">


### PR DESCRIPTION
## Summary
- Removes the framed card treatment from the mobile profile Brain wave strip.
- Keeps the strip compact and scrollable with a thin transparent-track scrollbar and clipped trailing content.
- Preserves links, modal behavior, counts, loading state, and displayed waves.

## Why
The boxed treatment made the mobile Brain strip feel noisy and added unnecessary vertical height. This keeps the scroll affordance while making the module quieter and more 2026-density friendly.

## Validation
- `git diff --check origin/main...HEAD`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` completed; it reported no changed source files to scan on this clean branch.
- Browser checked earlier on the same strip code at mobile and desktop widths: mobile strip remained horizontally scrollable without page overflow; desktop sidebar remained unchanged.

## Note
This PR uses a clean branch from current `main` because the earlier merge branch compared with unrelated merge/format noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the mobile brain waves strip layout for a cleaner, more compact appearance.
  * Adjusted spacing and scrollbar styling for better horizontal scrolling on mobile.
  * Kept the “Created” and “Active In” sections behaving the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->