### PR TITLE
[codex] Fix active wallet session verification

### DIFF
--- a/__tests__/components/auth/Auth.test.tsx
+++ b/__tests__/components/auth/Auth.test.tsx
@@ -5,6 +5,8 @@ import Auth, { AuthContext, useAuth } from "@/components/auth/Auth";
 import { ReactQueryWrapperContext } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import { mockTitleContextModule } from "@/__tests__/utils/titleTestUtils";
 import { commonApiFetch, commonApiPost } from "@/services/api/common-api";
+import type * as AuthUtilsModule from "@/services/auth/auth.utils";
+import type * as SessionV2Module from "@/services/auth/session-v2.utils";
 
 const mockQueryClient = {
   getQueryData: jest.fn(),
@@ -12,6 +14,43 @@ const mockQueryClient = {
 const mockRouterReplace = jest.fn();
 const mockRouterPush = jest.fn();
 const mockUsePathname = jest.fn(() => "/");
+
+type ReactQueryWrapperContextValue = React.ContextType<
+  typeof ReactQueryWrapperContext
+>;
+
+const createReactQueryWrapperContextValue = (
+  overrides: Partial<ReactQueryWrapperContextValue> = {}
+): ReactQueryWrapperContextValue => ({
+  setProfile: jest.fn(),
+  setWave: jest.fn(),
+  setWavesOverviewPage: jest.fn(),
+  setWaveDrops: jest.fn(),
+  setProfileProxy: jest.fn(),
+  onProfileProxyModify: jest.fn(),
+  onProfileCICModify: jest.fn(),
+  onProfileRepModify: jest.fn(),
+  onProfileEdit: jest.fn(),
+  onProfileStatementAdd: jest.fn(),
+  onProfileStatementRemove: jest.fn(),
+  onIdentityFollowChange: jest.fn(),
+  initProfileRepPage: jest.fn(),
+  initCommunityActivityPage: jest.fn(),
+  waitAndInvalidateDrops: jest.fn(async () => {}),
+  addOptimisticDrop: jest.fn(async () => {}),
+  invalidateDrops: jest.fn(),
+  onGroupRemoved: jest.fn(),
+  onGroupChanged: jest.fn(),
+  onGroupCreate: jest.fn(),
+  onIdentityBulkRate: jest.fn(),
+  onWaveCreated: jest.fn(),
+  onWaveFollowChange: jest.fn(),
+  invalidateAll: jest.fn(),
+  invalidateAuthSensitiveQueries: jest.fn(),
+  invalidateNotifications: jest.fn(),
+  invalidateIdentityTdhStats: jest.fn(),
+  ...overrides,
+});
 
 jest.mock("react-toastify", () => ({
   toast: jest.fn(),
@@ -1632,24 +1671,35 @@ describe("Auth component", () => {
         },
       ];
 
-      const authUtils = require("@/services/auth/auth.utils");
-      const sessionV2 = require("@/services/auth/session-v2.utils");
-      const mockGetAuthJwt = authUtils.getAuthJwt as jest.MockedFunction<any>;
+      const authUtils =
+        require("@/services/auth/auth.utils") as typeof AuthUtilsModule;
+      const sessionV2 =
+        require("@/services/auth/session-v2.utils") as typeof SessionV2Module;
+      const mockGetAuthJwt = authUtils.getAuthJwt as jest.MockedFunction<
+        typeof authUtils.getAuthJwt
+      >;
       const mockGetWalletAddress =
-        authUtils.getWalletAddress as jest.MockedFunction<any>;
+        authUtils.getWalletAddress as jest.MockedFunction<
+          typeof authUtils.getWalletAddress
+        >;
       const mockHasActiveSessionV2Auth =
-        authUtils.hasActiveSessionV2Auth as jest.MockedFunction<any>;
+        authUtils.hasActiveSessionV2Auth as jest.MockedFunction<
+          typeof authUtils.hasActiveSessionV2Auth
+        >;
+      const mockVerifyActiveSessionV2WebSession =
+        sessionV2.verifyActiveSessionV2WebSession as jest.MockedFunction<
+          typeof sessionV2.verifyActiveSessionV2WebSession
+        >;
       mockGetAuthJwt.mockReturnValue("v2-jwt");
       mockGetWalletAddress.mockReturnValue(activeStoredAddress);
-      mockHasActiveSessionV2Auth.mockImplementation(
-        ({ address }: { readonly address: string }) =>
-          address.toLowerCase() === activeStoredAddress.toLowerCase()
+      mockHasActiveSessionV2Auth.mockImplementation(({ address }) =>
+        address.toLowerCase() === activeStoredAddress.toLowerCase()
       );
-      sessionV2.verifyActiveSessionV2WebSession.mockResolvedValue(true);
+      mockVerifyActiveSessionV2WebSession.mockResolvedValue(true);
 
       render(
         <ReactQueryWrapperContext.Provider
-          value={{ invalidateAll: jest.fn() } as any}
+          value={createReactQueryWrapperContextValue()}
         >
           <Auth>
             <SessionUpgradeProbe />
@@ -1665,12 +1715,12 @@ describe("Auth component", () => {
           "true"
         );
       });
-      expect(sessionV2.verifyActiveSessionV2WebSession).toHaveBeenCalledWith({
+      expect(mockVerifyActiveSessionV2WebSession).toHaveBeenCalledWith({
         address: activeStoredAddress,
         abortSignal: undefined,
       });
       const verifiedAddresses =
-        sessionV2.verifyActiveSessionV2WebSession.mock.calls.map(
+        mockVerifyActiveSessionV2WebSession.mock.calls.map(
           ([params]: [{ readonly address: string }]) => params.address
         );
       expect(verifiedAddresses).toContain(activeStoredAddress);

--- a/__tests__/components/auth/Auth.test.tsx
+++ b/__tests__/components/auth/Auth.test.tsx
@@ -1613,6 +1613,70 @@ describe("Auth component", () => {
       expect(mockValidateAuthImmediate).not.toHaveBeenCalled();
     });
 
+    it("verifies the active stored v2 session when the live wallet provider address differs", async () => {
+      const activeStoredAddress = "0x1111111111111111111111111111111111111111";
+      const liveProviderAddress = "0x2222222222222222222222222222222222222222";
+      walletAddress = liveProviderAddress;
+      connectedAccountsOverride = [
+        {
+          address: activeStoredAddress,
+          role: null,
+          isActive: true,
+          isConnected: false,
+        },
+        {
+          address: liveProviderAddress,
+          role: null,
+          isActive: false,
+          isConnected: true,
+        },
+      ];
+
+      const authUtils = require("@/services/auth/auth.utils");
+      const sessionV2 = require("@/services/auth/session-v2.utils");
+      const mockGetAuthJwt = authUtils.getAuthJwt as jest.MockedFunction<any>;
+      const mockGetWalletAddress =
+        authUtils.getWalletAddress as jest.MockedFunction<any>;
+      const mockHasActiveSessionV2Auth =
+        authUtils.hasActiveSessionV2Auth as jest.MockedFunction<any>;
+      mockGetAuthJwt.mockReturnValue("v2-jwt");
+      mockGetWalletAddress.mockReturnValue(activeStoredAddress);
+      mockHasActiveSessionV2Auth.mockImplementation(
+        ({ address }: { readonly address: string }) =>
+          address.toLowerCase() === activeStoredAddress.toLowerCase()
+      );
+      sessionV2.verifyActiveSessionV2WebSession.mockResolvedValue(true);
+
+      render(
+        <ReactQueryWrapperContext.Provider
+          value={{ invalidateAll: jest.fn() } as any}
+        >
+          <Auth>
+            <SessionUpgradeProbe />
+          </Auth>
+        </ReactQueryWrapperContext.Provider>
+      );
+
+      const user = userEvent.setup();
+      await user.click(screen.getByTestId("verify-session"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("session-verify-result")).toHaveTextContent(
+          "true"
+        );
+      });
+      expect(sessionV2.verifyActiveSessionV2WebSession).toHaveBeenCalledWith({
+        address: activeStoredAddress,
+        abortSignal: undefined,
+      });
+      const verifiedAddresses =
+        sessionV2.verifyActiveSessionV2WebSession.mock.calls.map(
+          ([params]: [{ readonly address: string }]) => params.address
+        );
+      expect(verifiedAddresses).toContain(activeStoredAddress);
+      expect(verifiedAddresses).not.toContain(liveProviderAddress);
+    });
+
     it("fails closed when context web-session verification errors without changing upgrade state", async () => {
       const validAddress = "0x1111111111111111111111111111111111111111";
       walletAddress = validAddress;

--- a/components/auth/Auth.tsx
+++ b/components/auth/Auth.tsx
@@ -900,7 +900,7 @@ export default function Auth({
 
   const ensureActiveSessionV2WebSessionForActiveWallet = useCallback(
     async (abortSignal?: AbortSignal): Promise<boolean> => {
-      const walletAddress = address ?? getWalletAddress();
+      const walletAddress = getWalletAddress() ?? address;
       if (!walletAddress || !getAuthJwt()) {
         return false;
       }


### PR DESCRIPTION
## Summary

Fix the v2 web-session verification path used by share/auth upgrade checks so it verifies the app's active stored wallet account before falling back to the live wallet-provider address.

## Root Cause

In multi-account flows, the active app account and the wallet provider's currently connected address can diverge. After authenticating Wallet B, switching the app back to Wallet A could still verify Wallet B's v2 session state, causing Wallet A to incorrectly show the upgrade-auth prompt even though it had just completed v2 auth.

## Changes

- Prefer `getWalletAddress()` over the live provider `address` when verifying the active v2 web session.
- Add a regression test covering an active stored account that differs from the live provider address.

## Validation

- `./bin/6529 run test:no-coverage -- __tests__/components/auth/Auth.test.tsx --runInBand`
- `./bin/6529 exec eslint --no-warn-ignored --max-warnings=0 components/auth/Auth.tsx __tests__/components/auth/Auth.test.tsx`
- `./bin/6529 run typecheck:ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session verification when the wallet provider’s current address differs from the saved connected account.
  * Verification now uses the active wallet address consistently, helping avoid false mismatches during session checks.
  * Added coverage for this scenario to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->