### PR TITLE
[codex] Use ZXing for Android QR scanner

### DIFF
--- a/__tests__/components/header/share/HeaderQRScanner.test.tsx
+++ b/__tests__/components/header/share/HeaderQRScanner.test.tsx
@@ -19,11 +19,10 @@ jest.mock("next/image", () => ({
 }));
 jest.mock("@capacitor/barcode-scanner", () => ({
   CapacitorBarcodeScanner: { scanBarcode: jest.fn() },
-  CapacitorBarcodeScannerAndroidScanningLibrary: { MLKIT: "mlkit" },
+  CapacitorBarcodeScannerAndroidScanningLibrary: { ZXING: "zxing" },
   CapacitorBarcodeScannerCameraDirection: { BACK: 1 },
   CapacitorBarcodeScannerScanOrientation: { ADAPTIVE: 3 },
   CapacitorBarcodeScannerTypeHint: { QR_CODE: 0 },
-  CapacitorBarcodeScannerTypeHintALLOption: { ALL: 17 },
 }));
 
 const mockedCapacitor = useCapacitor as jest.Mock;
@@ -94,13 +93,13 @@ describe("HeaderQRScanner", () => {
 
     await waitFor(() => expect(push).toHaveBeenCalledWith("/profile"));
     expect(CapacitorBarcodeScanner.scanBarcode).toHaveBeenCalledWith({
-      hint: 17,
+      hint: 0,
       scanInstructions: t("en-US", "qrScanner.instructions"),
       scanButton: false,
       cameraDirection: 1,
       scanOrientation: 3,
       android: {
-        scanningLibrary: "mlkit",
+        scanningLibrary: "zxing",
       },
     });
   });

--- a/components/header/share/HeaderQRScanner.tsx
+++ b/components/header/share/HeaderQRScanner.tsx
@@ -14,7 +14,6 @@ import {
   type CapacitorBarcodeScannerOptions,
   CapacitorBarcodeScannerScanOrientation,
   CapacitorBarcodeScannerTypeHint,
-  CapacitorBarcodeScannerTypeHintALLOption,
 } from "@capacitor/barcode-scanner";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
@@ -28,9 +27,7 @@ function getScannerOptions(
   scanInstructions: string
 ): CapacitorBarcodeScannerOptions {
   const scannerOptions: CapacitorBarcodeScannerOptions = {
-    hint: isAndroid
-      ? CapacitorBarcodeScannerTypeHintALLOption.ALL
-      : CapacitorBarcodeScannerTypeHint.QR_CODE,
+    hint: CapacitorBarcodeScannerTypeHint.QR_CODE,
     scanInstructions,
     scanButton: false,
     cameraDirection: CapacitorBarcodeScannerCameraDirection.BACK,
@@ -44,7 +41,7 @@ function getScannerOptions(
   return {
     ...scannerOptions,
     android: {
-      scanningLibrary: CapacitorBarcodeScannerAndroidScanningLibrary.MLKIT,
+      scanningLibrary: CapacitorBarcodeScannerAndroidScanningLibrary.ZXING,
     },
   };
 }


### PR DESCRIPTION
## Summary
- Switch Android in-app QR scans back to the QR_CODE hint and force the ZXing Android scanner backend.
- Keep iOS scanner behavior unchanged.
- Update the Android scanner-options test to cover the ZXing configuration.

## Root Cause / Rationale
The Android scanner was using the broader `ALL` hint with the ML Kit backend. The installed Capacitor barcode scanner package documents ZXing as the Android library with broad format support, and this app only needs QR codes here, so the Android path now uses the narrower QR-only detector with ZXing.

The Android system camera showing the raw `mobile6529://...` custom-scheme value is normal OS behavior for custom schemes. A proper Android "open in 6529Mobile" experience would require Android App Links/native intent-filter setup plus `assetlinks.json` with the mobile package/signing fingerprint; I did not change the QR payload here because the existing custom-scheme QR is what gives iPhone its current direct app-open behavior.

## Validation
- `./bin/6529 run test -- __tests__/components/header/share/HeaderQRScanner.test.tsx --runInBand`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff`
- `./bin/6529 run check:changed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the QR scanner’s Android behavior to use a more consistent scanning setup.
  * Updated the scan flow so QR scanning now uses the standard QR mode across supported devices, helping avoid mismatched scan results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->