### PR TITLE
[codex] Move wave row pin to trailing controls

### DIFF
--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
@@ -388,7 +388,7 @@ describe("BrainLeftSidebarWave", () => {
     expect(expandButton.querySelector("svg")).toHaveClass("tw-animate-spin");
   });
 
-  it("places the timestamp below the title and pushes score to the far edge", () => {
+  it("places the timestamp below the title and keeps score and pin in the trailing cluster", () => {
     render(
       <BrainLeftSidebarWave
         wave={{ ...baseWave, waveScore }}
@@ -400,17 +400,20 @@ describe("BrainLeftSidebarWave", () => {
     const timestampWrapper = timestamp.parentElement;
     const textStack = timestampWrapper?.parentElement;
     const metadataRow = textStack?.parentElement;
-    const score = screen
+    const trailingCluster = screen
       .getByText("83")
       .closest("[aria-label]")
       ?.closest(".tw-ml-auto");
+    const pin = screen.getByTestId("pin");
 
     expect(timestamp).toHaveTextContent("123");
     expect(textStack?.children[1]).toBe(timestampWrapper);
-    expect(metadataRow?.children[1]).toBe(score);
+    expect(metadataRow?.children[1]).toBe(trailingCluster);
     expect(timestampWrapper).not.toHaveClass("tw-ml-auto");
     expect(timestampWrapper).not.toHaveClass("-tw-mt-0.5");
-    expect(score).toHaveClass("tw-ml-auto");
+    expect(trailingCluster).toHaveClass("tw-ml-auto");
+    expect(trailingCluster).toHaveClass("tw-items-center");
+    expect(trailingCluster).toContainElement(pin);
   });
 
   it("cancels subwave prefetch when hover intent ends early", () => {

--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
@@ -388,7 +388,7 @@ describe("BrainLeftSidebarWave", () => {
     expect(expandButton.querySelector("svg")).toHaveClass("tw-animate-spin");
   });
 
-  it("places the timestamp below the title and keeps score and pin in the trailing cluster", () => {
+  it("places the timestamp below the title and keeps pin before the far-right score", () => {
     render(
       <BrainLeftSidebarWave
         wave={{ ...baseWave, waveScore }}
@@ -405,6 +405,7 @@ describe("BrainLeftSidebarWave", () => {
       .closest("[aria-label]")
       ?.closest(".tw-ml-auto");
     const pin = screen.getByTestId("pin");
+    const score = screen.getByText("83").closest("[aria-label]");
 
     expect(timestamp).toHaveTextContent("123");
     expect(textStack?.children[1]).toBe(timestampWrapper);
@@ -413,7 +414,8 @@ describe("BrainLeftSidebarWave", () => {
     expect(timestampWrapper).not.toHaveClass("-tw-mt-0.5");
     expect(trailingCluster).toHaveClass("tw-ml-auto");
     expect(trailingCluster).toHaveClass("tw-items-center");
-    expect(trailingCluster).toContainElement(pin);
+    expect(trailingCluster?.firstElementChild).toBe(pin);
+    expect(trailingCluster?.lastElementChild).toContainElement(score);
   });
 
   it("cancels subwave prefetch when hover intent ends early", () => {

--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
@@ -123,11 +123,15 @@ describe("BrainLeftSidebarWavePin", () => {
     expect(removePinnedWave).not.toHaveBeenCalled();
   });
 
-  it("uses a compact row hit target while keeping the icon compact", () => {
+  it("collapses compact desktop row width until hover or keyboard focus", () => {
     setup(false, [], undefined, connectedAuth, true);
     const button = screen.getByRole("button", { name: /pin wave/i });
 
-    expect(button).toHaveClass("tw-size-7");
+    expect(button).toHaveClass("tw-h-7");
+    expect(button).toHaveClass("tw-w-0");
+    expect(button).toHaveClass("group-hover:tw-w-7");
+    expect(button).toHaveClass("group-focus-within:tw-w-7");
+    expect(button).toHaveClass("focus-visible:tw-w-7");
     expect(button.querySelector("svg")).toHaveClass("tw-size-3.5");
   });
 
@@ -150,6 +154,7 @@ describe("BrainLeftSidebarWavePin", () => {
     const button = screen.getByRole("button", { name: /unpin wave/i });
 
     expect(button).toHaveClass("tw-opacity-100");
+    expect(button).toHaveClass("tw-size-7");
   });
 
   it("shows tooltip and does not pin when max limit reached", async () => {

--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
@@ -64,7 +64,8 @@ function setup(
   isPinned = false,
   storedPinned: string[] = [],
   canPinWave = (waveId: string) => isPinned || !storedPinned.includes(waveId),
-  auth: AuthMock = connectedAuth
+  auth: AuthMock = connectedAuth,
+  compact = false
 ) {
   mockedUseMyStream.mockReturnValue({
     waves: { addPinnedWave, removePinnedWave },
@@ -75,7 +76,9 @@ function setup(
     canPinWave: jest.fn().mockImplementation(canPinWave),
   });
   mockedUseAuth.mockReturnValue(auth);
-  return render(<BrainLeftSidebarWavePin waveId="1" isPinned={isPinned} />);
+  return render(
+    <BrainLeftSidebarWavePin waveId="1" isPinned={isPinned} compact={compact} />
+  );
 }
 
 describe("BrainLeftSidebarWavePin", () => {
@@ -114,6 +117,14 @@ describe("BrainLeftSidebarWavePin", () => {
     await user.click(screen.getByRole("button", { name: /pin wave/i }));
     expect(addPinnedWave).toHaveBeenCalledWith("1");
     expect(removePinnedWave).not.toHaveBeenCalled();
+  });
+
+  it("uses a larger compact hit target while keeping the icon compact", () => {
+    setup(false, [], undefined, connectedAuth, true);
+    const button = screen.getByRole("button", { name: /pin wave/i });
+
+    expect(button).toHaveClass("tw-size-8");
+    expect(button.querySelector("svg")).toHaveClass("tw-size-4");
   });
 
   it("shows tooltip and does not pin when max limit reached", async () => {

--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
@@ -161,7 +161,11 @@ describe("BrainLeftSidebarWavePin", () => {
     const user = userEvent.setup();
     const maxList = Array(MAX_PINNED_WAVES).fill("x");
     setup(false, maxList, () => false);
-    await user.click(screen.getByRole("button", { name: /pin wave/i }));
+    const button = screen.getByRole("button", { name: /pin wave/i });
+
+    expect(button).not.toHaveAttribute("data-tooltip-content");
+
+    await user.click(button);
     expect(addPinnedWave).not.toHaveBeenCalled();
     expect(setToast).toHaveBeenCalledWith({
       type: "error",

--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
@@ -84,6 +84,10 @@ function setup(
 describe("BrainLeftSidebarWavePin", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      configurable: true,
+      value: 0,
+    });
     localStorage.clear();
   });
 
@@ -119,12 +123,33 @@ describe("BrainLeftSidebarWavePin", () => {
     expect(removePinnedWave).not.toHaveBeenCalled();
   });
 
-  it("uses a larger compact hit target while keeping the icon compact", () => {
+  it("uses a compact row hit target while keeping the icon compact", () => {
     setup(false, [], undefined, connectedAuth, true);
     const button = screen.getByRole("button", { name: /pin wave/i });
 
-    expect(button).toHaveClass("tw-size-8");
-    expect(button.querySelector("svg")).toHaveClass("tw-size-4");
+    expect(button).toHaveClass("tw-size-7");
+    expect(button.querySelector("svg")).toHaveClass("tw-size-3.5");
+  });
+
+  it("hides pinned desktop controls until row hover or keyboard focus", () => {
+    setup(true, ["1"]);
+    const button = screen.getByRole("button", { name: /unpin wave/i });
+
+    expect(button).toHaveClass("tw-opacity-0");
+    expect(button).toHaveClass("group-hover:tw-opacity-100");
+    expect(button).toHaveClass("group-focus-within:tw-opacity-100");
+    expect(button).toHaveClass("focus-visible:tw-opacity-100");
+  });
+
+  it("keeps pinned touch controls visible", () => {
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      configurable: true,
+      value: 1,
+    });
+    setup(true, ["1"]);
+    const button = screen.getByRole("button", { name: /unpin wave/i });
+
+    expect(button).toHaveClass("tw-opacity-100");
   });
 
   it("shows tooltip and does not pin when max limit reached", async () => {

--- a/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
@@ -257,7 +257,7 @@ describe("ExpandedWave", () => {
     expect(expandButton).toHaveClass("tw-opacity-100");
   });
 
-  it("places the timestamp below the title and keeps score and pin in the trailing cluster", () => {
+  it("places the timestamp below the title and keeps pin before the far-right score", () => {
     renderExpandedWave({
       showPin: true,
       wave: createMockMinimalWave({
@@ -276,6 +276,7 @@ describe("ExpandedWave", () => {
       .closest("[aria-label]")
       ?.closest(".tw-ml-auto");
     const pin = screen.getByTestId("pin");
+    const score = screen.getByText("83").closest("[aria-label]");
 
     expect(textStack?.children[1]).toBe(timestampWrapper);
     expect(metadataRow?.children[1]).toBe(trailingCluster);
@@ -283,7 +284,8 @@ describe("ExpandedWave", () => {
     expect(timestampWrapper).not.toHaveClass("-tw-mt-0.5");
     expect(trailingCluster).toHaveClass("tw-ml-auto");
     expect(trailingCluster).toHaveClass("tw-items-center");
-    expect(trailingCluster).toContainElement(pin);
+    expect(trailingCluster?.firstElementChild).toBe(pin);
+    expect(trailingCluster?.lastElementChild).toContainElement(score);
   });
 
   it("overlaps non-final child rails to avoid visible line gaps", () => {

--- a/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
@@ -257,8 +257,9 @@ describe("ExpandedWave", () => {
     expect(expandButton).toHaveClass("tw-opacity-100");
   });
 
-  it("places the timestamp below the title and pushes score to the far edge", () => {
+  it("places the timestamp below the title and keeps score and pin in the trailing cluster", () => {
     renderExpandedWave({
+      showPin: true,
       wave: createMockMinimalWave({
         id: "1",
         name: "Chat Wave",
@@ -270,16 +271,19 @@ describe("ExpandedWave", () => {
     const timestampWrapper = timestamp.parentElement;
     const textStack = timestampWrapper?.parentElement;
     const metadataRow = textStack?.parentElement;
-    const score = screen
+    const trailingCluster = screen
       .getByText("83")
       .closest("[aria-label]")
       ?.closest(".tw-ml-auto");
+    const pin = screen.getByTestId("pin");
 
     expect(textStack?.children[1]).toBe(timestampWrapper);
-    expect(metadataRow?.children[1]).toBe(score);
+    expect(metadataRow?.children[1]).toBe(trailingCluster);
     expect(timestampWrapper).not.toHaveClass("tw-ml-auto");
     expect(timestampWrapper).not.toHaveClass("-tw-mt-0.5");
-    expect(score).toHaveClass("tw-ml-auto");
+    expect(trailingCluster).toHaveClass("tw-ml-auto");
+    expect(trailingCluster).toHaveClass("tw-items-center");
+    expect(trailingCluster).toContainElement(pin);
   });
 
   it("overlaps non-final child rails to avoid visible line gaps", () => {

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
@@ -225,12 +225,7 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
   const isChildRow = depth === 1;
   const shouldShowExpandControl = canExpand && depth === 0;
   const shouldShowPinButton = showPin && depth === 0;
-  const {
-    rowPaddingClasses,
-    rowGapClasses,
-    linkGapClasses,
-    rowHeightClasses,
-  } =
+  const { rowPaddingClasses, rowGapClasses, linkGapClasses, rowHeightClasses } =
     getSidebarWaveRowLayoutClasses({
       isChildRow,
       variant: "app",
@@ -325,7 +320,7 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
           )}
         </div>
         <div className="tw-min-w-0 tw-flex-1">
-          <div className="tw-flex tw-min-w-0 tw-items-start tw-gap-2">
+          <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
             <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-y-0.5">
               <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1.5">
                 <Link
@@ -355,14 +350,6 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
                     />
                   </span>
                 )}
-                {shouldShowPinButton && (
-                  <BrainLeftSidebarWavePin
-                    waveId={wave.id}
-                    isPinned={!!wave.isPinned}
-                    compact
-                    className="tw-relative tw-z-10 tw-shrink-0"
-                  />
-                )}
               </div>
               {shouldShowDropTime && (
                 <div className="tw-inline-flex tw-min-w-0 tw-items-center tw-whitespace-nowrap tw-text-xs tw-leading-none tw-text-iron-500 tw-transition-colors tw-duration-200 desktop-hover:group-hover:tw-text-iron-400">
@@ -370,15 +357,25 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
                 </div>
               )}
             </div>
-            {hasSummaryScore && (
-              <span className="tw-relative tw-z-10 tw-ml-auto tw-mt-[1px] tw-shrink-0">
-                <WaveTrustSignals
-                  waveRep={wave.waveRep}
-                  waveScore={wave.waveScore}
-                  variant="sidebar-inline"
-                  mode="summary"
-                />
-              </span>
+            {(hasSummaryScore || shouldShowPinButton) && (
+              <div className="tw-relative tw-z-10 tw-ml-auto tw-flex tw-shrink-0 tw-items-center tw-gap-1.5">
+                {hasSummaryScore && (
+                  <WaveTrustSignals
+                    waveRep={wave.waveRep}
+                    waveScore={wave.waveScore}
+                    variant="sidebar-inline"
+                    mode="summary"
+                  />
+                )}
+                {shouldShowPinButton && (
+                  <BrainLeftSidebarWavePin
+                    waveId={wave.id}
+                    isPinned={!!wave.isPinned}
+                    compact
+                    className="tw-shrink-0"
+                  />
+                )}
+              </div>
             )}
           </div>
         </div>

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
@@ -358,21 +358,21 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
               )}
             </div>
             {(hasSummaryScore || shouldShowPinButton) && (
-              <div className="tw-relative tw-z-10 tw-ml-auto tw-flex tw-shrink-0 tw-items-center tw-gap-1.5">
-                {hasSummaryScore && (
-                  <WaveTrustSignals
-                    waveRep={wave.waveRep}
-                    waveScore={wave.waveScore}
-                    variant="sidebar-inline"
-                    mode="summary"
-                  />
-                )}
+              <div className="tw-relative tw-z-10 tw-ml-auto tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
                 {shouldShowPinButton && (
                   <BrainLeftSidebarWavePin
                     waveId={wave.id}
                     isPinned={!!wave.isPinned}
                     compact
                     className="tw-shrink-0"
+                  />
+                )}
+                {hasSummaryScore && (
+                  <WaveTrustSignals
+                    waveRep={wave.waveRep}
+                    waveScore={wave.waveScore}
+                    variant="sidebar-inline"
+                    mode="summary"
                   />
                 )}
               </div>

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
@@ -18,6 +18,11 @@ interface BrainLeftSidebarWavePinProps {
   readonly className?: string | undefined;
 }
 
+interface MaxLimitTooltipRequest {
+  readonly waveId: string;
+  readonly pinnedIdsKey: string;
+}
+
 const WavePinIcon = ({
   className,
   filled,
@@ -52,31 +57,26 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
     usePinnedWavesServer();
   const { setToast, connectedProfile, activeProfileProxy } = useAuth();
   const [isTouchDevice, setIsTouchDevice] = useState(false);
-  const [showMaxLimitTooltip, setShowMaxLimitTooltip] = useState(false);
+  const [maxLimitTooltipRequest, setMaxLimitTooltipRequest] =
+    useState<MaxLimitTooltipRequest | null>(null);
 
   // Check if this specific wave operation is in progress
   const isCurrentlyProcessing = isOperationInProgress(waveId);
+  const pinnedIdsKey = useMemo(() => pinnedIds.join("|"), [pinnedIds]);
   const canPinCurrentWave = useMemo(
     () => canPinWave(waveId),
     [canPinWave, waveId]
   );
-
-  // // Reset tooltip state when pinned state changes
-  useEffect(() => {
-    setShowMaxLimitTooltip(false);
-  }, [isPinned]);
-
-  // Also reset tooltip state when pinnedIds array changes
-  useEffect(() => {
-    if (canPinCurrentWave) {
-      setShowMaxLimitTooltip(false);
-    }
-  }, [pinnedIds, canPinCurrentWave]);
+  const showMaxLimitTooltip =
+    maxLimitTooltipRequest?.waveId === waveId &&
+    maxLimitTooltipRequest.pinnedIdsKey === pinnedIdsKey &&
+    !isPinned &&
+    !canPinCurrentWave;
 
   // Auto-hide tooltip after 3 seconds with proper cleanup
   useEffect(() => {
     if (!showMaxLimitTooltip) return;
-    const timer = setTimeout(() => setShowMaxLimitTooltip(false), 3000);
+    const timer = setTimeout(() => setMaxLimitTooltipRequest(null), 3000);
     return () => clearTimeout(timer);
   }, [showMaxLimitTooltip]);
 
@@ -116,14 +116,14 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
     try {
       if (isPinned) {
         waves.removePinnedWave(waveId);
-        setShowMaxLimitTooltip(false);
+        setMaxLimitTooltipRequest(null);
       } else {
         const canPin = canPinWave(waveId);
 
         if (canPin) {
           waves.addPinnedWave(waveId);
         } else {
-          setShowMaxLimitTooltip(true);
+          setMaxLimitTooltipRequest({ waveId, pinnedIdsKey });
           setToast({
             type: "error",
             message: `Maximum ${MAX_PINNED_WAVES} pinned waves allowed`,
@@ -172,8 +172,8 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
   };
 
   const positionClasses = compact ? "" : "-tw-mr-2 tw-mt-0.5";
-  const sizeClasses = compact ? "tw-size-5" : "tw-size-7 sm:tw-size-6";
-  const iconSizeClasses = compact ? "tw-size-3.5" : "tw-size-4";
+  const sizeClasses = compact ? "tw-size-8" : "tw-size-7 sm:tw-size-6";
+  const iconSizeClasses = "tw-size-4";
 
   return (
     <>

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
@@ -84,17 +84,17 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
   useEffect(() => {
     const checkTouch = () => {
       const hasCoarsePointer =
-        typeof window.matchMedia === "function" &&
-        window.matchMedia("(pointer: coarse)").matches;
+        typeof globalThis.matchMedia === "function" &&
+        globalThis.matchMedia("(pointer: coarse)").matches;
 
       setIsTouchDevice((navigator.maxTouchPoints ?? 0) > 0 || hasCoarsePointer);
     };
 
     checkTouch();
-    window.addEventListener("resize", checkTouch);
+    globalThis.addEventListener("resize", checkTouch);
 
     return () => {
-      window.removeEventListener("resize", checkTouch);
+      globalThis.removeEventListener("resize", checkTouch);
     };
   }, []);
 

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
@@ -142,7 +142,7 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
     }
   };
 
-  // Desktop rows reserve the pin slot and reveal the control on hover or focus.
+  // Desktop rows reveal the pin on hover or focus without reserving idle width.
   const getOpacityClass = () => {
     if (isTouchDevice) return "tw-opacity-100";
     return "tw-opacity-0 group-hover:tw-opacity-100 group-focus-within:tw-opacity-100 focus:tw-opacity-100 focus-visible:tw-opacity-100";
@@ -169,7 +169,12 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
   };
 
   const positionClasses = compact ? "" : "-tw-mr-2 tw-mt-0.5";
-  const sizeClasses = compact ? "tw-size-7" : "tw-size-7 sm:tw-size-6";
+  const getSizeClasses = () => {
+    if (!compact) return "tw-size-7 sm:tw-size-6";
+    if (isTouchDevice) return "tw-size-7";
+    return "tw-h-7 tw-w-0 group-hover:tw-w-7 group-focus-within:tw-w-7 focus:tw-w-7 focus-visible:tw-w-7";
+  };
+  const sizeClasses = getSizeClasses();
   const iconSizeClasses = compact ? "tw-size-3.5" : "tw-size-4";
 
   return (
@@ -177,7 +182,7 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
       <button
         onClick={handleClick}
         disabled={isCurrentlyProcessing}
-        className={`${positionClasses} tw-flex ${sizeClasses} tw-items-center tw-justify-center tw-rounded-md tw-border-0 tw-transition-all tw-duration-200 ${opacityClass} ${getButtonStyles()} ${className ?? ""} ${isCurrentlyProcessing ? "tw-cursor-not-allowed tw-opacity-50" : ""}`}
+        className={`${positionClasses} tw-flex ${sizeClasses} tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-md tw-border-0 tw-transition-all tw-duration-200 ${opacityClass} ${getButtonStyles()} ${className ?? ""} ${isCurrentlyProcessing ? "tw-cursor-not-allowed tw-opacity-50" : ""}`}
         aria-label={getAriaLabel()}
         data-tooltip-id={`wave-pin-${waveId}`}
         data-tooltip-content={tooltipContent}

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
@@ -83,13 +83,11 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
   // Detect touch device on component mount
   useEffect(() => {
     const checkTouch = () => {
-      // Check if device supports touch events
-      setIsTouchDevice(
-        "ontouchstart" in window ||
-          navigator.maxTouchPoints > 0 ||
-          // @ts-ignore: matchMedia may not be available in all environments
-          (window.matchMedia && window.matchMedia("(pointer: coarse)").matches)
-      );
+      const hasCoarsePointer =
+        typeof window.matchMedia === "function" &&
+        window.matchMedia("(pointer: coarse)").matches;
+
+      setIsTouchDevice((navigator.maxTouchPoints ?? 0) > 0 || hasCoarsePointer);
     };
 
     checkTouch();
@@ -144,11 +142,10 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
     }
   };
 
-  // Apply visibility logic: always show pinned waves on desktop, hide unpinned until hover
+  // Desktop rows reserve the pin slot and reveal the control on hover or focus.
   const getOpacityClass = () => {
     if (isTouchDevice) return "tw-opacity-100";
-    if (isPinned) return "tw-opacity-100";
-    return "tw-opacity-0 group-hover:tw-opacity-100";
+    return "tw-opacity-0 group-hover:tw-opacity-100 group-focus-within:tw-opacity-100 focus:tw-opacity-100 focus-visible:tw-opacity-100";
   };
   const opacityClass = getOpacityClass();
 
@@ -162,7 +159,7 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
 
   const getButtonStyles = () => {
     if (isPinned) {
-      return "tw-bg-transparent tw-text-iron-300 desktop-hover:hover:tw-bg-transparent desktop-hover:hover:tw-text-iron-100 active:tw-bg-transparent tw-opacity-100";
+      return "tw-bg-transparent tw-text-iron-300 desktop-hover:hover:tw-bg-transparent desktop-hover:hover:tw-text-iron-100 active:tw-bg-transparent";
     }
     return "tw-bg-transparent tw-text-iron-300 desktop-hover:hover:tw-bg-iron-700 desktop-hover:hover:tw-text-iron-100 active:tw-bg-iron-700";
   };
@@ -172,8 +169,8 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
   };
 
   const positionClasses = compact ? "" : "-tw-mr-2 tw-mt-0.5";
-  const sizeClasses = compact ? "tw-size-8" : "tw-size-7 sm:tw-size-6";
-  const iconSizeClasses = "tw-size-4";
+  const sizeClasses = compact ? "tw-size-7" : "tw-size-7 sm:tw-size-6";
+  const iconSizeClasses = compact ? "tw-size-3.5" : "tw-size-4";
 
   return (
     <>

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
@@ -149,11 +149,14 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
   };
   const opacityClass = getOpacityClass();
 
-  // Ensure tooltip is updated immediately by always checking the current state
+  // Only show max-limit guidance for the keyed request window after a failed pin.
   const getTooltipContent = () => {
     if (isPinned) return "Unpin";
     if (canPinCurrentWave) return "Pin";
-    return `Max ${MAX_PINNED_WAVES} pinned waves. Unpin another wave first.`;
+    if (showMaxLimitTooltip) {
+      return `Max ${MAX_PINNED_WAVES} pinned waves. Unpin another wave first.`;
+    }
+    return null;
   };
   const tooltipContent = getTooltipContent();
 

--- a/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
+++ b/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
@@ -90,12 +90,7 @@ export const ExpandedWave = ({
   const hasSummaryScore = hasWaveTrustSummaryScore(wave.waveScore);
   const shouldShowDropTime = presentLatestDropTimestamp !== null;
   const rowVerticalPaddingClasses = isChildRow ? "tw-py-1.5" : "tw-py-2";
-  const {
-    rowPaddingClasses,
-    rowGapClasses,
-    linkGapClasses,
-    rowHeightClasses,
-  } =
+  const { rowPaddingClasses, rowGapClasses, linkGapClasses, rowHeightClasses } =
     getSidebarWaveRowLayoutClasses({
       isChildRow,
       variant: "web",
@@ -192,7 +187,7 @@ export const ExpandedWave = ({
           )}
         </div>
         <div className="tw-min-w-0 tw-flex-1">
-          <div className="tw-flex tw-min-w-0 tw-items-start tw-gap-2">
+          <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
             <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-y-0.5">
               <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1.5">
                 <Link
@@ -226,14 +221,6 @@ export const ExpandedWave = ({
                     />
                   </span>
                 )}
-                {shouldShowPinButton && (
-                  <BrainLeftSidebarWavePin
-                    waveId={waveId}
-                    isPinned={isPinned}
-                    compact
-                    className="tw-relative tw-z-10 tw-shrink-0"
-                  />
-                )}
               </div>
               {shouldShowDropTime && (
                 <div className="tw-inline-flex tw-min-w-0 tw-items-center tw-whitespace-nowrap tw-text-xs tw-leading-none tw-text-iron-500 tw-transition-colors tw-duration-200 desktop-hover:group-hover:tw-text-iron-400">
@@ -243,15 +230,25 @@ export const ExpandedWave = ({
                 </div>
               )}
             </div>
-            {hasSummaryScore && (
-              <span className="tw-relative tw-z-10 tw-ml-auto tw-mt-[1px] tw-shrink-0">
-                <WaveTrustSignals
-                  waveRep={wave.waveRep}
-                  waveScore={wave.waveScore}
-                  variant="sidebar-inline"
-                  mode="summary"
-                />
-              </span>
+            {(hasSummaryScore || shouldShowPinButton) && (
+              <div className="tw-relative tw-z-10 tw-ml-auto tw-flex tw-shrink-0 tw-items-center tw-gap-1.5">
+                {hasSummaryScore && (
+                  <WaveTrustSignals
+                    waveRep={wave.waveRep}
+                    waveScore={wave.waveScore}
+                    variant="sidebar-inline"
+                    mode="summary"
+                  />
+                )}
+                {shouldShowPinButton && (
+                  <BrainLeftSidebarWavePin
+                    waveId={waveId}
+                    isPinned={isPinned}
+                    compact
+                    className="tw-shrink-0"
+                  />
+                )}
+              </div>
             )}
           </div>
         </div>

--- a/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
+++ b/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
@@ -231,21 +231,21 @@ export const ExpandedWave = ({
               )}
             </div>
             {(hasSummaryScore || shouldShowPinButton) && (
-              <div className="tw-relative tw-z-10 tw-ml-auto tw-flex tw-shrink-0 tw-items-center tw-gap-1.5">
-                {hasSummaryScore && (
-                  <WaveTrustSignals
-                    waveRep={wave.waveRep}
-                    waveScore={wave.waveScore}
-                    variant="sidebar-inline"
-                    mode="summary"
-                  />
-                )}
+              <div className="tw-relative tw-z-10 tw-ml-auto tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
                 {shouldShowPinButton && (
                   <BrainLeftSidebarWavePin
                     waveId={waveId}
                     isPinned={isPinned}
                     compact
                     className="tw-shrink-0"
+                  />
+                )}
+                {hasSummaryScore && (
+                  <WaveTrustSignals
+                    waveRep={wave.waveRep}
+                    waveScore={wave.waveScore}
+                    variant="sidebar-inline"
+                    mode="summary"
                   />
                 )}
               </div>

--- a/components/waves/WaveTrustSignals.tsx
+++ b/components/waves/WaveTrustSignals.tsx
@@ -302,7 +302,7 @@ const getChipLabelClasses = (variant: WaveTrustSignalsVariant): string => {
 
 const getIconClasses = (variant: WaveTrustSignalsVariant): string => {
   if (isInlineSidebarVariant(variant)) {
-    return "tw-size-3 tw-flex-shrink-0 tw-opacity-[0.55]";
+    return "tw-size-3.5 tw-flex-shrink-0 tw-opacity-[0.68]";
   }
 
   if (isInlineHeaderVariant(variant)) {

--- a/components/waves/WaveTrustSignals.tsx
+++ b/components/waves/WaveTrustSignals.tsx
@@ -302,7 +302,7 @@ const getChipLabelClasses = (variant: WaveTrustSignalsVariant): string => {
 
 const getIconClasses = (variant: WaveTrustSignalsVariant): string => {
   if (isInlineSidebarVariant(variant)) {
-    return "tw-size-3.5 tw-flex-shrink-0 tw-opacity-[0.68]";
+    return "tw-size-[13px] tw-flex-shrink-0 tw-opacity-[0.64]";
   }
 
   if (isInlineHeaderVariant(variant)) {

--- a/ops/docs/waves/sidebars/feature-pinned-wave-controls.md
+++ b/ops/docs/waves/sidebars/feature-pinned-wave-controls.md
@@ -17,8 +17,8 @@ Both lists are capped at **20** items. They are independent and do not sync.
   - `/waves/{waveId}`
   - `/messages/{waveId}` (DM route)
 - Left sidebar wave rows in the Waves list (`/waves*` only; DM rows do not show
-  row pin controls). In expanded rows, the control sits at the far right after
-  the wave score.
+  row pin controls). In expanded rows, the control sits beside the wave score
+  in the trailing metadata cluster, with the score at the far right.
 - Native app small-screen (`<1024px`) shortcuts rail above Waves or Messages
   content.
 - Legacy `/waves?wave={waveId}` links redirect to `/waves/{waveId}`.
@@ -49,8 +49,8 @@ Both lists are capped at **20** items. They are independent and do not sync.
 
 - The same control flips label by state (`Pin wave` vs `Unpin wave`).
 - Pin/unpin controls are disabled while that wave request is in progress.
-- In desktop expanded sidebars, unpinned row controls appear on hover at the
-  trailing edge of the row; pinned rows keep the control visible.
+- In desktop expanded sidebars, row pin and unpin controls appear on row hover
+  or keyboard focus; on touch devices, they remain visible.
 - In collapsed web sidebars, row pin controls are hidden.
 - DM lists do not expose row pin controls.
 - When app shortcuts reach 20, opening another thread keeps the newest 20 and

--- a/ops/docs/waves/sidebars/feature-pinned-wave-controls.md
+++ b/ops/docs/waves/sidebars/feature-pinned-wave-controls.md
@@ -49,8 +49,9 @@ Both lists are capped at **20** items. They are independent and do not sync.
 
 - The same control flips label by state (`Pin wave` vs `Unpin wave`).
 - Pin/unpin controls are disabled while that wave request is in progress.
-- In desktop expanded sidebars, row pin and unpin controls appear on row hover
-  or keyboard focus; on touch devices, they remain visible.
+- In desktop expanded sidebars, row pin and unpin controls collapse while idle
+  and appear on row hover or keyboard focus; on touch devices, they remain
+  visible.
 - In collapsed web sidebars, row pin controls are hidden.
 - DM lists do not expose row pin controls.
 - When app shortcuts reach 20, opening another thread keeps the newest 20 and

--- a/ops/docs/waves/sidebars/feature-pinned-wave-controls.md
+++ b/ops/docs/waves/sidebars/feature-pinned-wave-controls.md
@@ -17,7 +17,8 @@ Both lists are capped at **20** items. They are independent and do not sync.
   - `/waves/{waveId}`
   - `/messages/{waveId}` (DM route)
 - Left sidebar wave rows in the Waves list (`/waves*` only; DM rows do not show
-  row pin controls).
+  row pin controls). In expanded rows, the control sits at the far right after
+  the wave score.
 - Native app small-screen (`<1024px`) shortcuts rail above Waves or Messages
   content.
 - Legacy `/waves?wave={waveId}` links redirect to `/waves/{waveId}`.
@@ -48,8 +49,8 @@ Both lists are capped at **20** items. They are independent and do not sync.
 
 - The same control flips label by state (`Pin wave` vs `Unpin wave`).
 - Pin/unpin controls are disabled while that wave request is in progress.
-- In desktop expanded sidebars, unpinned row controls appear on hover; pinned
-  rows keep the control visible.
+- In desktop expanded sidebars, unpinned row controls appear on hover at the
+  trailing edge of the row; pinned rows keep the control visible.
 - In collapsed web sidebars, row pin controls are hidden.
 - DM lists do not expose row pin controls.
 - When app shortcuts reach 20, opening another thread keeps the newest 20 and

--- a/ops/docs/waves/sidebars/feature-wave-list-navigation.md
+++ b/ops/docs/waves/sidebars/feature-wave-list-navigation.md
@@ -55,7 +55,8 @@ Wave and DM rows in the left list control which thread is open.
 - If first unread is known, row navigation can add `divider={serialNo}`.
 - Row pin/unpin and subwave expand/collapse buttons do not trigger row
   navigation.
-- Long wave names truncate before the trailing pin and score controls.
+- Long wave names truncate before the trailing score and visible pin controls;
+  idle desktop rows do not reserve the hidden pin width.
 - Non-touch devices can prefetch an inactive row on hover.
 - Touch devices do not use hover prefetch.
 - Browser-default behavior is kept for modified clicks such as Cmd/Ctrl-click,

--- a/ops/docs/waves/sidebars/feature-wave-list-navigation.md
+++ b/ops/docs/waves/sidebars/feature-wave-list-navigation.md
@@ -8,8 +8,9 @@ Wave and DM rows in the left list control which thread is open.
 - Click the body of the active row to clear selection and return to section
   home.
 - Row pin and subwave expand/collapse buttons remain separate controls.
-- On expanded rows, pin/unpin sits in the trailing metadata cluster after the
-  wave score instead of beside the wave name.
+- On expanded rows, pin/unpin sits in the trailing metadata cluster before the
+  wave score instead of beside the wave name, keeping the score at the far
+  right.
 - Browser back/forward keeps the active row and URL in sync.
 
 ## Location in the Site
@@ -54,7 +55,7 @@ Wave and DM rows in the left list control which thread is open.
 - If first unread is known, row navigation can add `divider={serialNo}`.
 - Row pin/unpin and subwave expand/collapse buttons do not trigger row
   navigation.
-- Long wave names truncate before the trailing score and pin controls.
+- Long wave names truncate before the trailing pin and score controls.
 - Non-touch devices can prefetch an inactive row on hover.
 - Touch devices do not use hover prefetch.
 - Browser-default behavior is kept for modified clicks such as Cmd/Ctrl-click,

--- a/ops/docs/waves/sidebars/feature-wave-list-navigation.md
+++ b/ops/docs/waves/sidebars/feature-wave-list-navigation.md
@@ -8,6 +8,8 @@ Wave and DM rows in the left list control which thread is open.
 - Click the body of the active row to clear selection and return to section
   home.
 - Row pin and subwave expand/collapse buttons remain separate controls.
+- On expanded rows, pin/unpin sits in the trailing metadata cluster after the
+  wave score instead of beside the wave name.
 - Browser back/forward keeps the active row and URL in sync.
 
 ## Location in the Site
@@ -52,6 +54,7 @@ Wave and DM rows in the left list control which thread is open.
 - If first unread is known, row navigation can add `divider={serialNo}`.
 - Row pin/unpin and subwave expand/collapse buttons do not trigger row
   navigation.
+- Long wave names truncate before the trailing score and pin controls.
 - Non-touch devices can prefetch an inactive row on hover.
 - Touch devices do not use hover prefetch.
 - Browser-default behavior is kept for modified clicks such as Cmd/Ctrl-click,

--- a/pr-reports/2888.md
+++ b/pr-reports/2888.md
@@ -5,23 +5,24 @@ Branch: codex/waves-list-pin-right -> main
 Related PRs: None
 
 ## Summary
-Moves the Waves sidebar row pin/unpin action out of the wave-name line and into the trailing metadata cluster, after the wave trust score, so opening a wave and pinning a wave are less likely to be confused on pointer or touch input.
+Moves the Waves sidebar row pin/unpin action out of the wave-name line and into the trailing metadata cluster before the far-right trust score, so opening a wave and pinning a wave are less likely to be confused on pointer or touch input.
 
 ## What Changed
 - Shifted expanded Waves row pin/unpin controls to the far-right score/action area on web and shared row renderers.
+- Ordered row controls as pin/unpin followed by the trust score, keeping the rating anchored at the far right.
+- Matched pinned desktop rows to the unpinned hover behavior while keeping touch devices always-visible and adding keyboard-focus reveal states.
 - Kept subwave expand/collapse beside the wave name while preserving the stretched row link for navigation.
-- Increased the compact pin control hit target while keeping the icon visually compact.
-- Made the inline sidebar shield icon slightly larger for clearer score recognition.
+- Dialed back the compact pin and inline sidebar shield sizes after the first pass while tightening their spacing.
 - Updated focused row tests and sidebar docs for the new placement.
 
 ## Frontend Impact
 - Routes/views: `/waves*` expanded left sidebar rows and related Waves list surfaces that reuse the shared row renderer.
 - Components: `BrainLeftSidebarWave`, `ExpandedWave`, `BrainLeftSidebarWavePin`, and `WaveTrustSignals`.
 - Generated API/client: Not affected.
-- User-visible behavior: wave names remain the main navigation target, while score and pin are grouped at the trailing edge; long names truncate before those controls.
+- User-visible behavior: wave names remain the main navigation target, while pin and score are grouped at the trailing edge; long names truncate before those controls.
 
 ## Config / Env
 None.
 
 ## Release Notes
-Waves list rows now keep pin/unpin at the far right after the score, reducing accidental pin taps when users click or tap a wave name to open chat. The score shield is slightly easier to see, and the pin control has a larger compact hit target.
+Waves list rows now keep pin/unpin just before the far-right score, reducing accidental pin taps when users click or tap a wave name to open chat. Desktop row pin controls reveal on hover or keyboard focus, and touch devices keep them visible.

--- a/pr-reports/2888.md
+++ b/pr-reports/2888.md
@@ -1,0 +1,27 @@
+# PR Report: Move Wave Row Pin to Trailing Controls
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/2888
+Branch: codex/waves-list-pin-right -> main
+Related PRs: None
+
+## Summary
+Moves the Waves sidebar row pin/unpin action out of the wave-name line and into the trailing metadata cluster, after the wave trust score, so opening a wave and pinning a wave are less likely to be confused on pointer or touch input.
+
+## What Changed
+- Shifted expanded Waves row pin/unpin controls to the far-right score/action area on web and shared row renderers.
+- Kept subwave expand/collapse beside the wave name while preserving the stretched row link for navigation.
+- Increased the compact pin control hit target while keeping the icon visually compact.
+- Made the inline sidebar shield icon slightly larger for clearer score recognition.
+- Updated focused row tests and sidebar docs for the new placement.
+
+## Frontend Impact
+- Routes/views: `/waves*` expanded left sidebar rows and related Waves list surfaces that reuse the shared row renderer.
+- Components: `BrainLeftSidebarWave`, `ExpandedWave`, `BrainLeftSidebarWavePin`, and `WaveTrustSignals`.
+- Generated API/client: Not affected.
+- User-visible behavior: wave names remain the main navigation target, while score and pin are grouped at the trailing edge; long names truncate before those controls.
+
+## Config / Env
+None.
+
+## Release Notes
+Waves list rows now keep pin/unpin at the far right after the score, reducing accidental pin taps when users click or tap a wave name to open chat. The score shield is slightly easier to see, and the pin control has a larger compact hit target.

--- a/pr-reports/2888.md
+++ b/pr-reports/2888.md
@@ -11,6 +11,7 @@ Moves the Waves sidebar row pin/unpin action out of the wave-name line and into 
 - Shifted expanded Waves row pin/unpin controls to the far-right score/action area on web and shared row renderers.
 - Ordered row controls as pin/unpin followed by the trust score, keeping the rating anchored at the far right.
 - Matched pinned desktop rows to the unpinned hover behavior while keeping touch devices always-visible and adding keyboard-focus reveal states.
+- Collapsed the hidden desktop pin width so idle rows give more space back to the wave name until hover or focus reveals the pin.
 - Kept subwave expand/collapse beside the wave name while preserving the stretched row link for navigation.
 - Dialed back the compact pin and inline sidebar shield sizes after the first pass while tightening their spacing.
 - Updated focused row tests and sidebar docs for the new placement.
@@ -25,4 +26,4 @@ Moves the Waves sidebar row pin/unpin action out of the wave-name line and into 
 None.
 
 ## Release Notes
-Waves list rows now keep pin/unpin just before the far-right score, reducing accidental pin taps when users click or tap a wave name to open chat. Desktop row pin controls reveal on hover or keyboard focus, and touch devices keep them visible.
+Waves list rows now keep pin/unpin just before the far-right score, reducing accidental pin taps when users click or tap a wave name to open chat. Desktop row pin controls reveal on hover or keyboard focus without shortening idle names, and touch devices keep them visible.


### PR DESCRIPTION
## Summary
Move the Waves sidebar row pin/unpin control out of the wave-name line and into the trailing metadata cluster after the wave trust score. This reduces accidental pin taps when users are trying to open a wave chat.

## What Changed
- Moved expanded row pin/unpin controls to the far-right score/action cluster on web and shared Waves row renderers.
- Increased the compact pin button hit target while keeping the icon compact.
- Slightly enlarged the inline sidebar shield icon so the score marker reads more clearly.
- Updated focused row tests and sidebar docs for the new placement.

## Validation
- `./bin/6529 run test -- __tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx __tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx __tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx`
- `./bin/6529 run check:changed`
- `./bin/6529 run react-doctor:diff`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Row pin/unpin controls now appear in the trailing metadata area before the score, keeping the score aligned to the far right.
  * Pin controls now behave differently on desktop and touch devices: they stay visible on touch and appear on hover or keyboard focus on desktop.

* **Bug Fixes**
  * Improved row spacing and alignment so timestamps, pins, and scores line up more consistently.
  * Long wave names now truncate cleanly without crowding the trailing controls.

* **Documentation**
  * Updated sidebar guidance to reflect the new pin control placement and visibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->