### PR TITLE
Prevent share modal close auth flash

### DIFF
--- a/__tests__/components/header/share/HeaderShare.test.tsx
+++ b/__tests__/components/header/share/HeaderShare.test.tsx
@@ -635,6 +635,34 @@ describe("HeaderShare", () => {
       ).not.toBeInTheDocument();
     });
 
+    it("keeps the connection QR visible while the share modal closes", async () => {
+      const sessionV2 = require("@/services/auth/session-v2.utils");
+      sessionV2.createConnectionShare.mockResolvedValue({
+        connection_share_code: "closing-share-code",
+        expires_at: new Date(Date.now() + 300_000).toISOString(),
+        address: "0x1234567890123456789012345678901234567890",
+        role: null,
+        target_client_type: "native",
+        deep_link_path:
+          "/accept-connection-sharing?connection_share_code=closing-share-code",
+      });
+
+      renderWithProviders(<HeaderShare />);
+
+      await userEvent.click(screen.getByRole("button", { name: "QR Code" }));
+
+      expect(
+        await screen.findByTitle(/closing-share-code/)
+      ).toBeInTheDocument();
+
+      await userEvent.click(screen.getByLabelText("Close share modal"));
+
+      expect(screen.getByTitle(/closing-share-code/)).toBeInTheDocument();
+      expect(
+        screen.queryByText("Update Authentication")
+      ).not.toBeInTheDocument();
+    });
+
     it("uses an existing legacy refresh token for 6529 Desktop connection sharing", async () => {
       const sessionV2 = require("@/services/auth/session-v2.utils");
       mockAuthUtils.getRefreshToken.mockReturnValue(

--- a/__tests__/components/header/share/HeaderShare.test.tsx
+++ b/__tests__/components/header/share/HeaderShare.test.tsx
@@ -2,7 +2,12 @@ import HeaderShare from "@/components/header/share/HeaderShare";
 import useIsMobileDevice from "@/hooks/isMobileDevice";
 import useCapacitor from "@/hooks/useCapacitor";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
@@ -661,6 +666,45 @@ describe("HeaderShare", () => {
       expect(
         screen.queryByText("Update Authentication")
       ).not.toBeInTheDocument();
+    });
+
+    it("clears the closing QR snapshot before the share modal opens again", async () => {
+      const sessionV2 = require("@/services/auth/session-v2.utils");
+      sessionV2.createConnectionShare
+        .mockResolvedValueOnce({
+          connection_share_code: "snapshot-share-code",
+          expires_at: new Date(Date.now() + 300_000).toISOString(),
+          address: "0x1234567890123456789012345678901234567890",
+          role: null,
+          target_client_type: "native",
+          deep_link_path:
+            "/accept-connection-sharing?connection_share_code=snapshot-share-code",
+        })
+        .mockImplementationOnce(() => createPendingPromise());
+
+      renderWithProviders(<HeaderShare />);
+
+      const shareButton = screen.getByRole("button", { name: "QR Code" });
+      await userEvent.click(shareButton);
+
+      expect(
+        await screen.findByTitle(/snapshot-share-code/)
+      ).toBeInTheDocument();
+
+      await userEvent.click(screen.getByLabelText("Close share modal"));
+      await waitForElementToBeRemoved(() =>
+        screen.queryByTestId("header-share-modal")
+      );
+
+      await userEvent.click(shareButton);
+
+      await waitFor(() =>
+        expect(sessionV2.createConnectionShare).toHaveBeenCalledTimes(2)
+      );
+      expect(
+        screen.queryByTitle(/snapshot-share-code/)
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("Preparing Connection")).toBeInTheDocument();
     });
 
     it("uses an existing legacy refresh token for 6529 Desktop connection sharing", async () => {

--- a/__tests__/services/auth.utils.test.ts
+++ b/__tests__/services/auth.utils.test.ts
@@ -245,6 +245,24 @@ describe("auth.utils", () => {
     expect(hasActiveSessionV2Auth({ address: "0xbbb" })).toBe(false);
   });
 
+  it("tracks session v2 auth per stored account instead of only the active account", () => {
+    setupStorageMocks();
+    (jwtDecode as jest.Mock).mockReturnValue({ exp: 86400 * 2 });
+    jest.spyOn(Date, "now").mockReturnValue(0);
+
+    setAuthJwt("0xAaA", "jwt-a", null, "role-a", {
+      authSessionVersion: "v2",
+    });
+    setAuthJwt("0xBbB", "jwt-b", null, "role-b", {
+      authSessionVersion: "v2",
+    });
+
+    expect(getWalletAddress()).toBe("0xBbB");
+    expect(hasActiveSessionV2Auth({ address: "0xaaa" })).toBe(true);
+    expect(hasActiveSessionV2Auth({ address: "0xbbb" })).toBe(true);
+    expect(hasActiveSessionV2Auth({ address: "0xccc" })).toBe(false);
+  });
+
   it("getStagingAuth returns cookie or env", () => {
     const { publicEnv } = require("@/config/env");
     (Cookies.get as jest.Mock).mockReturnValueOnce("c");

--- a/__tests__/services/auth/jwt-validation.utils.test.ts
+++ b/__tests__/services/auth/jwt-validation.utils.test.ts
@@ -194,6 +194,33 @@ describe("jwt-validation.utils", () => {
     expect(syncWalletRoleWithServer).toHaveBeenCalledWith(null, "0x123");
   });
 
+  it("refreshes the wallet being validated instead of another active stored account", async () => {
+    const refreshedSession = {
+      client_type: "native" as const,
+      address: "0x123",
+      role: null,
+      access_token: "fresh-access-token",
+      access_token_expires_at: "2026-06-10T00:00:00.000Z",
+      native_refresh_token: "new-native-refresh-token",
+      refresh_token_expires_at: "2026-07-10T00:00:00.000Z",
+    };
+    mockedGetWalletAddress.mockReturnValue("0x456");
+    mockedJwtDecode
+      .mockReturnValueOnce(expiredPayload)
+      .mockReturnValueOnce({ ...expiredPayload, role: null });
+    mockedRefreshSessionV2.mockResolvedValue(refreshedSession);
+
+    await expect(validateJwt(validParams)).resolves.toEqual({
+      isValid: true,
+      wasCancelled: false,
+    });
+    expect(mockedRefreshSessionV2).toHaveBeenCalledWith({
+      address: "0x123",
+      abortSignal: validParams.abortSignal,
+    });
+    expect(mockedPersistSessionResponse).toHaveBeenCalledWith(refreshedSession);
+  });
+
   it("decodes the refreshed access token before persisting a rotated session", async () => {
     const refreshedSession = {
       client_type: "web" as const,

--- a/components/header/share/HeaderShare.tsx
+++ b/components/header/share/HeaderShare.tsx
@@ -7,7 +7,13 @@ import { ShareIcon } from "@heroicons/react/24/outline";
 import yaml from "js-yaml";
 import Image from "next/image";
 import { usePathname, useSearchParams } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Tooltip } from "react-tooltip";
 import { useAuth } from "@/components/auth/Auth";
@@ -55,6 +61,10 @@ type TerminalConnectionShareStatus = Extract<
   ConnectionShareStatus,
   "legacy-auth" | "error"
 >;
+type DisplayContent = {
+  readonly content: ReactNode;
+  readonly url: string;
+};
 
 function isAbortError(error: unknown, signal?: AbortSignal): boolean {
   return (
@@ -475,6 +485,7 @@ export function HeaderQRModal({
   const connectionShareAbortRef = useRef<AbortController | null>(null);
   const shareGenerationIdRef = useRef(0);
   const cachedConnectionShareRef = useRef<CachedConnectionShare | null>(null);
+  const visibleDisplayContentRef = useRef<DisplayContent | null>(null);
   const terminalConnectionShareFailuresRef = useRef<
     Map<string, TerminalConnectionShareStatus>
   >(new Map());
@@ -901,7 +912,10 @@ export function HeaderQRModal({
     }
 
     setIsVisible(false);
-    const timeout = setTimeout(() => setShouldRender(false), 200);
+    const timeout = setTimeout(() => {
+      visibleDisplayContentRef.current = null;
+      setShouldRender(false);
+    }, 200);
     return () => clearTimeout(timeout);
   }, [show]);
 
@@ -1176,7 +1190,7 @@ export function HeaderQRModal({
     };
   };
 
-  const getDisplayContent = () => {
+  const getCurrentDisplayContent = (): DisplayContent => {
     if (activeTab === Mode.NAVIGATE) {
       return getNavigateContent();
     }
@@ -1186,6 +1200,18 @@ export function HeaderQRModal({
     }
 
     return getAppsContent();
+  };
+
+  const getDisplayContent = (): DisplayContent => {
+    if (!show && visibleDisplayContentRef.current) {
+      return visibleDisplayContentRef.current;
+    }
+
+    const displayContent = getCurrentDisplayContent();
+    if (show) {
+      visibleDisplayContentRef.current = displayContent;
+    }
+    return displayContent;
   };
 
   function printImage() {

--- a/components/header/share/HeaderShare.tsx
+++ b/components/header/share/HeaderShare.tsx
@@ -868,6 +868,7 @@ export function HeaderQRModal({
       return;
     }
 
+    visibleDisplayContentRef.current = null;
     connectionShareAbortRef.current?.abort();
     const controller = new AbortController();
     connectionShareAbortRef.current = controller;

--- a/services/auth/auth.utils.ts
+++ b/services/auth/auth.utils.ts
@@ -474,10 +474,15 @@ export const hasActiveSessionV2Auth = ({
 }: {
   readonly address: string;
 }): boolean => {
-  const activeAccount = getActiveAccountFromAccounts(getStoredAccounts());
+  const normalizedAddress = normalizeAddress(address);
+  const storedAccount =
+    getStoredAccounts().find(
+      (account) => normalizeAddress(account.address) === normalizedAddress
+    ) ?? null;
+
   return (
-    activeAccount?.authSessionVersion === "v2" &&
-    normalizeAddress(activeAccount.address) === normalizeAddress(address)
+    storedAccount?.authSessionVersion === "v2" &&
+    normalizeAddress(storedAccount.address) === normalizedAddress
   );
 };
 

--- a/services/auth/jwt-validation.utils.ts
+++ b/services/auth/jwt-validation.utils.ts
@@ -1,6 +1,5 @@
 import { jwtDecode } from "jwt-decode";
 import {
-  getWalletAddress,
   getWalletRole,
   hasActiveSessionV2Auth,
   syncWalletRoleWithServer,
@@ -202,20 +201,18 @@ const handleTokenRefresh = async ({
   abortSignal: AbortSignal;
   activeProfileProxy?: ApiProfileProxy | null | undefined;
 }): Promise<ValidateJwtResult> => {
-  const walletAddress = getWalletAddress();
-
   // Check for cancellation before proceeding
   if (abortSignal.aborted) {
     return CANCELLED_JWT_RESULT;
   }
 
   try {
-    if (!walletAddress) {
+    if (!wallet) {
       return INVALID_JWT_RESULT;
     }
 
     const refreshedSession = await refreshSessionV2({
-      address: walletAddress,
+      address: wallet,
       abortSignal,
     });
 


### PR DESCRIPTION
## Issue
- Closing the connection share modal after a QR code was ready could briefly redraw the body as the authentication update notice during the close animation.
- Multi-account session-v2 checks could treat v2 auth as active-account-only and refresh the wrong stored wallet, causing false upgrade prompts or destructive invalid-session handling in shared/native account flows.

## Fix
- Preserve the currently visible modal body while the dialog is animating closed.
- Continue aborting/clearing the underlying one-time connection share state on close so reopening mints a fresh share code.
- Make session-v2 marker checks address-specific across stored connected accounts.
- Refresh the wallet being validated instead of reading the globally active wallet address during JWT validation.

## Changes
- Added a display snapshot for `HeaderQRModal` that is used only while `show` is false and the dialog remains mounted for its exit transition.
- Added regression coverage for closing a ready connection-share QR without flashing the update-auth notice.
- Added regression coverage for non-active stored v2 accounts and validated-wallet refresh targeting.

## Validation
- `6529 run test -- __tests__/components/header/share/HeaderShare.test.tsx __tests__/services/auth.utils.test.ts __tests__/services/auth/jwt-validation.utils.test.ts --runInBand --forceExit` reported PASS for all three files, then the Jest process stayed open and was stopped manually.
- `6529 run lint:diff`
- `6529 run lint:changed`
- `6529 run typecheck`
- `6529 run typecheck:changed`
- `6529 run react-doctor:diff`
- `git diff --check`

## Risk
- Level: Medium
- Why: The modal fix is component-local and low risk. The auth fix is small but touches session validation; it should reduce false multi-account failures without changing token formats or API contracts.
- Rollback: Revert this PR to restore the previous modal close rendering and active-account-only v2 validation behavior.

## Review Notes
- Focus on the close animation path and the multi-account auth path where a stored account is authenticated with v2 but is not currently active.
- The share-code lifecycle remains unchanged: close still clears one-time share state, and reopen mints a fresh code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection-sharing behavior so the QR code stays visible after closing the share modal and resets correctly when reopened.
  * Fixed session checks so authentication is verified against the specific wallet account being used, not just the currently active one.
  * Improved JWT refresh handling to ensure the correct wallet is refreshed during sign-in/session validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->