### PR TITLE
[codex] Add local agent login bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,10 @@ CLAUDE.md
 .agent
 
 .direnv/
+
+# Local agent-login wallet material and emitted auth payloads
+ops/skills/6529-agent-login/accounts.json
+ops/skills/6529-agent-login/*.payload.json
+ops/skills/6529-agent-login/*storage-state*.json
+ops/skills/6529-agent-login/*agent-login*.json
+ops/skills/6529-agent-login/*agent-login*.js

--- a/__tests__/components/auth/SeizeConnectContext.addAccount.test.tsx
+++ b/__tests__/components/auth/SeizeConnectContext.addAccount.test.tsx
@@ -73,6 +73,8 @@ jest.mock("@/hooks/useUnreadNotifications", () => ({
 jest.mock("@/services/auth/auth.utils", () => ({
   WALLET_ACCOUNTS_UPDATED_EVENT: "6529-wallet-accounts-updated",
   canStoreAnotherWalletAccount: jest.fn(() => true),
+  clearAgentLoginActiveAddress: jest.fn(),
+  getAgentLoginActiveAddress: jest.fn(() => null),
   getConnectedWalletAccounts: jest.fn(() => [
     {
       address: ACTIVE_ADDRESS,

--- a/__tests__/components/auth/SeizeConnectContext.switch-sync.test.tsx
+++ b/__tests__/components/auth/SeizeConnectContext.switch-sync.test.tsx
@@ -48,6 +48,8 @@ jest.mock("@/hooks/useUnreadNotifications", () => ({
 
 jest.mock("@/services/auth/auth.utils", () => ({
   canStoreAnotherWalletAccount: jest.fn(() => true),
+  clearAgentLoginActiveAddress: jest.fn(),
+  getAgentLoginActiveAddress: jest.fn(() => null),
   getConnectedWalletAccounts: jest.fn(() => []),
   getWalletAddress: jest.fn(() => null),
   isAuthAddressAuthorized: jest.fn(

--- a/__tests__/components/auth/SeizeConnectContext.test.tsx
+++ b/__tests__/components/auth/SeizeConnectContext.test.tsx
@@ -61,6 +61,8 @@ jest.mock("@/hooks/useUnreadNotifications", () => ({
 // Mock auth utils
 jest.mock("@/services/auth/auth.utils", () => ({
   canStoreAnotherWalletAccount: jest.fn(() => true),
+  clearAgentLoginActiveAddress: jest.fn(),
+  getAgentLoginActiveAddress: jest.fn(() => null),
   getConnectedWalletAccounts: jest.fn(() => []),
   getWalletAddress: jest.fn(() => null),
   isAuthAddressAuthorized: jest.fn(

--- a/__tests__/services/auth.utils.test.ts
+++ b/__tests__/services/auth.utils.test.ts
@@ -1,8 +1,11 @@
 import { safeLocalStorage } from "@/helpers/safeLocalStorage";
 import {
+  AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY,
   AUTH_TOKEN_CHANGED_EVENT,
   canStoreAnotherWalletAccount,
   clearAllWalletAuth,
+  clearAgentLoginActiveAddress,
+  getAgentLoginActiveAddress,
   getConnectedWalletAccounts,
   getAuthJwt,
   getRefreshToken,
@@ -12,6 +15,7 @@ import {
   isAuthAddressAuthorized,
   PROFILE_SWITCHED_EVENT,
   removeAuthJwt,
+  setAgentLoginActiveAddress,
   setActiveWalletAccount,
   setAuthJwt,
   syncConnectedWalletProfile,
@@ -243,6 +247,62 @@ describe("auth.utils", () => {
 
     expect(hasActiveSessionV2Auth({ address: "0xaaa" })).toBe(true);
     expect(hasActiveSessionV2Auth({ address: "0xbbb" })).toBe(false);
+  });
+
+  it("returns the active agent-login address only when the marker matches session v2 auth", () => {
+    setupStorageMocks();
+    (jwtDecode as jest.Mock).mockReturnValue({ exp: 86400 * 2 });
+    jest.spyOn(Date, "now").mockReturnValue(0);
+
+    setAuthJwt("0xAaA", "jwt-a", null, "role-a", {
+      authSessionVersion: "v2",
+    });
+    setAgentLoginActiveAddress("0xaaa");
+
+    expect(getAgentLoginActiveAddress()).toBe("0xAaA");
+
+    setAgentLoginActiveAddress("0xbbb");
+
+    expect(getAgentLoginActiveAddress()).toBeNull();
+  });
+
+  it("does not return an agent-login address for unmarked session v2 auth", () => {
+    setupStorageMocks();
+    (jwtDecode as jest.Mock).mockReturnValue({ exp: 86400 * 2 });
+    jest.spyOn(Date, "now").mockReturnValue(0);
+
+    setAuthJwt("0xAaA", "jwt-a", null, "role-a", {
+      authSessionVersion: "v2",
+    });
+
+    expect(getAgentLoginActiveAddress()).toBeNull();
+  });
+
+  it("clears the agent-login marker when the active account changes", () => {
+    const storage = setupStorageMocks();
+    (jwtDecode as jest.Mock).mockReturnValue({ exp: 86400 * 2 });
+    jest.spyOn(Date, "now").mockReturnValue(0);
+
+    setAuthJwt("0xAaA", "jwt-a", null, "role-a", {
+      authSessionVersion: "v2",
+    });
+    setAgentLoginActiveAddress("0xAaA");
+
+    setAuthJwt("0xBbB", "jwt-b", null, "role-b", {
+      authSessionVersion: "v2",
+    });
+
+    expect(storage.get(AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY)).toBeUndefined();
+    expect(getAgentLoginActiveAddress()).toBeNull();
+  });
+
+  it("clears the explicit agent-login marker", () => {
+    const storage = setupStorageMocks();
+
+    setAgentLoginActiveAddress("0xAaA");
+    clearAgentLoginActiveAddress();
+
+    expect(storage.get(AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY)).toBeUndefined();
   });
 
   it("getStagingAuth returns cookie or env", () => {

--- a/app/tools/agent-login/page.client.tsx
+++ b/app/tools/agent-login/page.client.tsx
@@ -7,21 +7,15 @@ import {
   type FormEvent,
 } from "react";
 import { getAddress, isAddress } from "viem";
-import { AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY } from "@/services/auth/auth.utils";
+import {
+  AUTH_STORAGE_KEYS,
+  AUTH_TOKEN_CHANGED_EVENT,
+  PROFILE_SWITCHED_EVENT,
+  WALLET_ACCOUNTS_UPDATED_EVENT,
+  type ConnectedWalletAccount,
+} from "@/services/auth/auth.utils";
 
-const STORAGE_KEYS = {
-  accounts: "6529-wallet-accounts",
-  activeAddress: "6529-wallet-active-address",
-  legacyAddress: "6529-wallet-address",
-  legacyRefreshToken: "6529-wallet-refresh-token",
-  legacyRole: "6529-wallet-role",
-  agentLoginActiveAddress: AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY,
-  authCookie: "wallet-auth",
-} as const;
-
-const WALLET_ACCOUNTS_UPDATED_EVENT = "6529-wallet-accounts-updated";
-const AUTH_TOKEN_CHANGED_EVENT = "6529-auth-token-changed";
-const PROFILE_SWITCHED_EVENT = "6529-profile-switched";
+const STORAGE_KEYS = AUTH_STORAGE_KEYS;
 
 type Status = {
   readonly kind: "idle" | "success" | "error";
@@ -40,13 +34,10 @@ type AgentLoginPayload = {
   };
 };
 
-type StoredWalletAccount = {
-  readonly address: string;
+type AgentLoginStoredWalletAccount = ConnectedWalletAccount & {
   readonly refreshToken: null;
-  readonly role: string | null;
   readonly jwt: string;
   readonly profileId: null;
-  readonly profileHandle: string | null;
   readonly authSessionVersion: "v2";
 };
 
@@ -232,7 +223,7 @@ function dispatchAuthEvents(): void {
 }
 
 function applyLoginPayload(payload: AgentLoginPayload): void {
-  const account: StoredWalletAccount = {
+  const account: AgentLoginStoredWalletAccount = {
     address: payload.session.address,
     refreshToken: null,
     role: payload.session.role,

--- a/app/tools/agent-login/page.client.tsx
+++ b/app/tools/agent-login/page.client.tsx
@@ -1,0 +1,427 @@
+"use client";
+
+import {
+  useEffect,
+  useState,
+  type CSSProperties,
+  type FormEvent,
+} from "react";
+
+const STORAGE_KEYS = {
+  accounts: "6529-wallet-accounts",
+  activeAddress: "6529-wallet-active-address",
+  legacyAddress: "6529-wallet-address",
+  legacyRefreshToken: "6529-wallet-refresh-token",
+  legacyRole: "6529-wallet-role",
+  authCookie: "wallet-auth",
+} as const;
+
+const WALLET_ACCOUNTS_UPDATED_EVENT = "6529-wallet-accounts-updated";
+const AUTH_TOKEN_CHANGED_EVENT = "6529-auth-token-changed";
+const PROFILE_SWITCHED_EVENT = "6529-profile-switched";
+
+type Status = {
+  readonly kind: "idle" | "success" | "error";
+  readonly message: string;
+};
+
+type AgentLoginPayload = {
+  readonly account: {
+    readonly profileHandle: string | null;
+  };
+  readonly session: {
+    readonly address: string;
+    readonly role: string | null;
+    readonly accessToken: string;
+    readonly accessTokenExpiresAt: string | null;
+  };
+};
+
+type StoredWalletAccount = {
+  readonly address: string;
+  readonly refreshToken: null;
+  readonly role: string | null;
+  readonly jwt: string;
+  readonly profileId: null;
+  readonly profileHandle: string | null;
+  readonly authSessionVersion: "v2";
+};
+
+const styles = {
+  main: {
+    minHeight: "100vh",
+    background: "#101418",
+    color: "#f7fafc",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "32px 16px",
+  },
+  panel: {
+    width: "min(720px, 100%)",
+    border: "1px solid #2f3b45",
+    borderRadius: 8,
+    background: "#161c22",
+    padding: 24,
+    boxShadow: "0 24px 60px rgb(0 0 0 / 28%)",
+  },
+  title: {
+    fontSize: 22,
+    lineHeight: 1.25,
+    margin: "0 0 8px",
+  },
+  copy: {
+    color: "#b7c1cc",
+    fontSize: 14,
+    lineHeight: 1.5,
+    margin: "0 0 18px",
+  },
+  label: {
+    display: "block",
+    fontSize: 13,
+    color: "#d8e0e8",
+    marginBottom: 8,
+  },
+  textarea: {
+    width: "100%",
+    minHeight: 220,
+    boxSizing: "border-box",
+    resize: "vertical",
+    borderRadius: 6,
+    border: "1px solid #44525f",
+    background: "#0d1116",
+    color: "#edf3f8",
+    fontFamily:
+      'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace',
+    fontSize: 13,
+    lineHeight: 1.45,
+    padding: 12,
+    outline: "none",
+  },
+  actions: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: 10,
+    marginTop: 14,
+  },
+  button: {
+    border: "1px solid #556573",
+    borderRadius: 6,
+    background: "#f7fafc",
+    color: "#101418",
+    minHeight: 38,
+    padding: "0 14px",
+    fontWeight: 700,
+    cursor: "pointer",
+  },
+  secondaryButton: {
+    border: "1px solid #556573",
+    borderRadius: 6,
+    background: "transparent",
+    color: "#f7fafc",
+    minHeight: 38,
+    padding: "0 14px",
+    fontWeight: 700,
+    cursor: "pointer",
+  },
+  disabledButton: {
+    cursor: "not-allowed",
+    opacity: 0.55,
+  },
+  status: {
+    minHeight: 22,
+    marginTop: 14,
+    fontSize: 13,
+    lineHeight: 1.45,
+  },
+  success: {
+    color: "#79e6a8",
+  },
+  error: {
+    color: "#ff9d9d",
+  },
+} satisfies Record<string, CSSProperties>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function getRecord(value: unknown, name: string): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error(`${name} must be an object.`);
+  }
+  return value;
+}
+
+function getRequiredString(
+  record: Record<string, unknown>,
+  key: string
+): string {
+  const value = record[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${key} must be a non-empty string.`);
+  }
+  return value.trim();
+}
+
+function getOptionalString(
+  record: Record<string, unknown>,
+  key: string
+): string | null {
+  const value = record[key];
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function parseAgentLoginPayload(rawPayload: string): AgentLoginPayload {
+  const parsed = getRecord(JSON.parse(rawPayload), "Payload");
+  const account = getRecord(parsed["account"], "account");
+  const session = getRecord(parsed["session"], "session");
+
+  return {
+    account: {
+      profileHandle: getOptionalString(account, "profileHandle"),
+    },
+    session: {
+      address: getRequiredString(session, "address"),
+      role: getOptionalString(session, "role"),
+      accessToken: getRequiredString(session, "accessToken"),
+      accessTokenExpiresAt: getOptionalString(session, "accessTokenExpiresAt"),
+    },
+  };
+}
+
+function clearStoredRoleKeys(): void {
+  for (let index = localStorage.length - 1; index >= 0; index -= 1) {
+    const key = localStorage.key(index);
+    if (key?.startsWith("auth-role-")) {
+      localStorage.removeItem(key);
+    }
+  }
+}
+
+function getCookieExpiresAttribute(expiresAt: string | null): string {
+  if (!expiresAt) {
+    return "";
+  }
+
+  const timestamp = Date.parse(expiresAt);
+  if (!Number.isFinite(timestamp)) {
+    return "";
+  }
+
+  return `; expires=${new Date(timestamp).toUTCString()}`;
+}
+
+function getSecureCookieAttribute(): string {
+  return window.location.protocol === "https:" ? "; Secure" : "";
+}
+
+function dispatchAuthEvents(): void {
+  window.dispatchEvent(new CustomEvent(WALLET_ACCOUNTS_UPDATED_EVENT));
+  window.dispatchEvent(new CustomEvent(AUTH_TOKEN_CHANGED_EVENT));
+  window.dispatchEvent(new CustomEvent(PROFILE_SWITCHED_EVENT));
+}
+
+function applyLoginPayload(payload: AgentLoginPayload): void {
+  const account: StoredWalletAccount = {
+    address: payload.session.address,
+    refreshToken: null,
+    role: payload.session.role,
+    jwt: payload.session.accessToken,
+    profileId: null,
+    profileHandle: payload.account.profileHandle,
+    authSessionVersion: "v2",
+  };
+
+  clearStoredRoleKeys();
+  localStorage.setItem(STORAGE_KEYS.accounts, JSON.stringify([account]));
+  localStorage.setItem(STORAGE_KEYS.activeAddress, account.address);
+  localStorage.setItem(STORAGE_KEYS.legacyAddress, account.address);
+  localStorage.removeItem(STORAGE_KEYS.legacyRefreshToken);
+
+  if (account.role) {
+    localStorage.setItem(STORAGE_KEYS.legacyRole, account.role);
+    localStorage.setItem(
+      `auth-role-${account.address.toLowerCase()}`,
+      account.role
+    );
+  } else {
+    localStorage.removeItem(STORAGE_KEYS.legacyRole);
+  }
+
+  document.cookie = `${STORAGE_KEYS.authCookie}=${encodeURIComponent(
+    account.jwt
+  )}; path=/; SameSite=Strict${getCookieExpiresAttribute(
+    payload.session.accessTokenExpiresAt
+  )}${getSecureCookieAttribute()}`;
+  dispatchAuthEvents();
+}
+
+function clearAuthState(): void {
+  localStorage.removeItem(STORAGE_KEYS.accounts);
+  localStorage.removeItem(STORAGE_KEYS.activeAddress);
+  localStorage.removeItem(STORAGE_KEYS.legacyAddress);
+  localStorage.removeItem(STORAGE_KEYS.legacyRefreshToken);
+  localStorage.removeItem(STORAGE_KEYS.legacyRole);
+  clearStoredRoleKeys();
+  document.cookie = `${
+    STORAGE_KEYS.authCookie
+  }=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Strict${getSecureCookieAttribute()}`;
+  dispatchAuthEvents();
+}
+
+function shortAddress(address: string): string {
+  return address.length > 12
+    ? `${address.slice(0, 6)}...${address.slice(-4)}`
+    : address;
+}
+
+function getCurrentAuthStatus(): Status {
+  try {
+    const activeAddress = localStorage.getItem(STORAGE_KEYS.activeAddress);
+    const rawAccounts = localStorage.getItem(STORAGE_KEYS.accounts);
+
+    if (!activeAddress || !rawAccounts) {
+      return {
+        kind: "idle",
+        message: "No active agent auth.",
+      };
+    }
+
+    const parsedAccounts: unknown = JSON.parse(rawAccounts);
+    if (!Array.isArray(parsedAccounts)) {
+      return {
+        kind: "error",
+        message: "Stored agent auth is unreadable.",
+      };
+    }
+
+    const activeAccount = parsedAccounts
+      .filter(isRecord)
+      .find((account) => account["address"] === activeAddress);
+    const hasToken =
+      typeof activeAccount?.["jwt"] === "string" &&
+      activeAccount["jwt"].trim().length > 0;
+
+    return {
+      kind: hasToken ? "success" : "error",
+      message: hasToken
+        ? `Current account: ${shortAddress(activeAddress)}.`
+        : `Current account: ${shortAddress(activeAddress)} is missing a token.`,
+    };
+  } catch {
+    return {
+      kind: "error",
+      message: "Stored agent auth is unreadable.",
+    };
+  }
+}
+
+function redirectHomeSoon(): void {
+  window.setTimeout(() => {
+    window.location.assign("/");
+  }, 250);
+}
+
+export default function AgentLoginClient() {
+  const [rawPayload, setRawPayload] = useState("");
+  const [status, setStatus] = useState<Status>({
+    kind: "idle",
+    message: "",
+  });
+  const canApply = rawPayload.trim().length > 0;
+
+  useEffect(() => {
+    setStatus(getCurrentAuthStatus());
+  }, []);
+
+  const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    try {
+      const payload = parseAgentLoginPayload(rawPayload);
+      applyLoginPayload(payload);
+      setRawPayload("");
+      setStatus({
+        kind: "success",
+        message: `Logged in as ${shortAddress(payload.session.address)}. Redirecting...`,
+      });
+      redirectHomeSoon();
+    } catch (error) {
+      setStatus({
+        kind: "error",
+        message:
+          error instanceof Error ? error.message : "Could not apply login.",
+      });
+    }
+  };
+
+  const onLogout = () => {
+    clearAuthState();
+    setRawPayload("");
+    setStatus({
+      kind: "success",
+      message: "Logged out. Redirecting...",
+    });
+    redirectHomeSoon();
+  };
+
+  return (
+    <main style={styles.main}>
+      <section aria-labelledby="agent-login-title" style={styles.panel}>
+        <h1 id="agent-login-title" style={styles.title}>
+          Agent Login
+        </h1>
+        <p style={styles.copy}>
+          Paste a local agent login JSON payload. Tokens stay in this browser
+          origin and are not sent to another route.
+        </p>
+        <form onSubmit={onSubmit}>
+          <label htmlFor="agent-login-payload" style={styles.label}>
+            Login payload
+          </label>
+          <textarea
+            id="agent-login-payload"
+            autoCapitalize="off"
+            autoComplete="off"
+            autoCorrect="off"
+            spellCheck={false}
+            value={rawPayload}
+            onChange={(event) => setRawPayload(event.target.value)}
+            placeholder='{"account": {...}, "session": {...}}'
+            style={styles.textarea}
+          />
+          <div style={styles.actions}>
+            <button
+              type="submit"
+              disabled={!canApply}
+              style={{
+                ...styles.button,
+                ...(!canApply ? styles.disabledButton : undefined),
+              }}>
+              Apply
+            </button>
+            <button
+              type="button"
+              onClick={onLogout}
+              style={styles.secondaryButton}>
+              Logout
+            </button>
+          </div>
+        </form>
+        <div
+          aria-live="polite"
+          role="status"
+          style={{
+            ...styles.status,
+            ...(status.kind === "success" ? styles.success : undefined),
+            ...(status.kind === "error" ? styles.error : undefined),
+          }}>
+          {status.message}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/tools/agent-login/page.client.tsx
+++ b/app/tools/agent-login/page.client.tsx
@@ -6,6 +6,7 @@ import {
   type CSSProperties,
   type FormEvent,
 } from "react";
+import { getAddress, isAddress } from "viem";
 import { AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY } from "@/services/auth/auth.utils";
 
 const STORAGE_KEYS = {
@@ -98,7 +99,6 @@ const styles = {
     fontSize: 13,
     lineHeight: 1.45,
     padding: 12,
-    outline: "none",
   },
   actions: {
     display: "flex",
@@ -180,13 +180,18 @@ function parseAgentLoginPayload(rawPayload: string): AgentLoginPayload {
   const parsed = getRecord(JSON.parse(rawPayload), "Payload");
   const account = getRecord(parsed["account"], "account");
   const session = getRecord(parsed["session"], "session");
+  const sessionAddress = getRequiredString(session, "address");
+
+  if (!isAddress(sessionAddress)) {
+    throw new Error("address must be a valid Ethereum address.");
+  }
 
   return {
     account: {
       profileHandle: getOptionalString(account, "profileHandle"),
     },
     session: {
-      address: getRequiredString(session, "address"),
+      address: getAddress(sessionAddress),
       role: getOptionalString(session, "role"),
       accessToken: getRequiredString(session, "accessToken"),
       accessTokenExpiresAt: getOptionalString(session, "accessTokenExpiresAt"),
@@ -311,7 +316,11 @@ function getCurrentAuthStatus(): Status {
 
     const activeAccount = parsedAccounts
       .filter(isRecord)
-      .find((account) => account["address"] === activeAddress);
+      .find(
+        (account) =>
+          typeof account["address"] === "string" &&
+          account["address"].toLowerCase() === activeAddress.toLowerCase()
+      );
     const hasToken =
       typeof activeAccount?.["jwt"] === "string" &&
       activeAccount["jwt"].trim().length > 0;

--- a/app/tools/agent-login/page.client.tsx
+++ b/app/tools/agent-login/page.client.tsx
@@ -222,13 +222,13 @@ function getCookieExpiresAttribute(expiresAt: string | null): string {
 }
 
 function getSecureCookieAttribute(): string {
-  return window.location.protocol === "https:" ? "; Secure" : "";
+  return globalThis.location.protocol === "https:" ? "; Secure" : "";
 }
 
 function dispatchAuthEvents(): void {
-  window.dispatchEvent(new CustomEvent(WALLET_ACCOUNTS_UPDATED_EVENT));
-  window.dispatchEvent(new CustomEvent(AUTH_TOKEN_CHANGED_EVENT));
-  window.dispatchEvent(new CustomEvent(PROFILE_SWITCHED_EVENT));
+  globalThis.dispatchEvent(new CustomEvent(WALLET_ACCOUNTS_UPDATED_EVENT));
+  globalThis.dispatchEvent(new CustomEvent(AUTH_TOKEN_CHANGED_EVENT));
+  globalThis.dispatchEvent(new CustomEvent(PROFILE_SWITCHED_EVENT));
 }
 
 function applyLoginPayload(payload: AgentLoginPayload): void {
@@ -340,8 +340,8 @@ function getCurrentAuthStatus(): Status {
 }
 
 function redirectHomeSoon(): void {
-  window.setTimeout(() => {
-    window.location.assign("/");
+  globalThis.setTimeout(() => {
+    globalThis.location.assign("/");
   }, 250);
 }
 
@@ -351,7 +351,7 @@ export default function AgentLoginClient() {
     kind: "idle",
     message: "",
   });
-  const canApply = rawPayload.trim().length > 0;
+  const isApplyDisabled = rawPayload.trim().length === 0;
 
   useEffect(() => {
     setStatus(getCurrentAuthStatus());
@@ -416,10 +416,10 @@ export default function AgentLoginClient() {
           <div style={styles.actions}>
             <button
               type="submit"
-              disabled={!canApply}
+              disabled={isApplyDisabled}
               style={{
                 ...styles.button,
-                ...(!canApply ? styles.disabledButton : undefined),
+                ...(isApplyDisabled ? styles.disabledButton : undefined),
               }}>
               Apply
             </button>

--- a/app/tools/agent-login/page.client.tsx
+++ b/app/tools/agent-login/page.client.tsx
@@ -6,6 +6,7 @@ import {
   type CSSProperties,
   type FormEvent,
 } from "react";
+import { AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY } from "@/services/auth/auth.utils";
 
 const STORAGE_KEYS = {
   accounts: "6529-wallet-accounts",
@@ -13,6 +14,7 @@ const STORAGE_KEYS = {
   legacyAddress: "6529-wallet-address",
   legacyRefreshToken: "6529-wallet-refresh-token",
   legacyRole: "6529-wallet-role",
+  agentLoginActiveAddress: AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY,
   authCookie: "wallet-auth",
 } as const;
 
@@ -239,6 +241,7 @@ function applyLoginPayload(payload: AgentLoginPayload): void {
   localStorage.setItem(STORAGE_KEYS.accounts, JSON.stringify([account]));
   localStorage.setItem(STORAGE_KEYS.activeAddress, account.address);
   localStorage.setItem(STORAGE_KEYS.legacyAddress, account.address);
+  localStorage.setItem(STORAGE_KEYS.agentLoginActiveAddress, account.address);
   localStorage.removeItem(STORAGE_KEYS.legacyRefreshToken);
 
   if (account.role) {
@@ -265,6 +268,7 @@ function clearAuthState(): void {
   localStorage.removeItem(STORAGE_KEYS.legacyAddress);
   localStorage.removeItem(STORAGE_KEYS.legacyRefreshToken);
   localStorage.removeItem(STORAGE_KEYS.legacyRole);
+  localStorage.removeItem(STORAGE_KEYS.agentLoginActiveAddress);
   clearStoredRoleKeys();
   document.cookie = `${
     STORAGE_KEYS.authCookie
@@ -281,9 +285,16 @@ function shortAddress(address: string): string {
 function getCurrentAuthStatus(): Status {
   try {
     const activeAddress = localStorage.getItem(STORAGE_KEYS.activeAddress);
+    const agentLoginAddress = localStorage.getItem(
+      STORAGE_KEYS.agentLoginActiveAddress
+    );
     const rawAccounts = localStorage.getItem(STORAGE_KEYS.accounts);
 
-    if (!activeAddress || !rawAccounts) {
+    if (
+      !activeAddress ||
+      !rawAccounts ||
+      agentLoginAddress?.toLowerCase() !== activeAddress.toLowerCase()
+    ) {
       return {
         kind: "idle",
         message: "No active agent auth.",

--- a/app/tools/agent-login/page.tsx
+++ b/app/tools/agent-login/page.tsx
@@ -1,0 +1,59 @@
+import { getAppMetadata } from "@/components/providers/metadata";
+import { getNodeEnv } from "@/config/env";
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+import AgentLoginClient from "./page.client";
+
+const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+
+function getHostnameFromHostHeader(hostHeader: string | null): string | null {
+  const firstHost = hostHeader?.split(",")[0]?.trim().toLowerCase();
+  if (!firstHost) {
+    return null;
+  }
+
+  if (firstHost.startsWith("[")) {
+    const closingBracketIndex = firstHost.indexOf("]");
+    return closingBracketIndex > 1
+      ? firstHost.slice(1, closingBracketIndex)
+      : null;
+  }
+
+  return firstHost.split(":")[0] || null;
+}
+
+function isLocalHostname(hostname: string): boolean {
+  return LOCAL_HOSTNAMES.has(hostname) || hostname.endsWith(".local");
+}
+
+function isDevLikeRuntime(): boolean {
+  const nodeEnv = getNodeEnv();
+  return nodeEnv === "development" || nodeEnv === "test" || nodeEnv === "local";
+}
+
+export default async function AgentLoginPage() {
+  const headersList = await headers();
+  const hostname = getHostnameFromHostHeader(
+    headersList.get("host") ?? headersList.get("x-forwarded-host")
+  );
+
+  if (!hostname || !isLocalHostname(hostname) || !isDevLikeRuntime()) {
+    notFound();
+  }
+
+  return <AgentLoginClient />;
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    ...getAppMetadata({
+      title: "Agent Login",
+      description: "Local agent login",
+    }),
+    robots: {
+      index: false,
+      follow: false,
+    },
+  };
+}

--- a/components/auth/SeizeConnectContext.tsx
+++ b/components/auth/SeizeConnectContext.tsx
@@ -557,6 +557,23 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
 
     // Use debounced state update to prevent race conditions
     debounceTimeoutRef.current = setTimeout(() => {
+      if (
+        agentLoginImpersonatedAddress &&
+        account.address &&
+        account.isConnected &&
+        isAddress(account.address)
+      ) {
+        const checksummedConnectedAddress = getAddress(account.address);
+        clearAgentLoginActiveAddress();
+        const isAlreadyConnected =
+          walletState.status === "connected" &&
+          walletState.address === checksummedConnectedAddress;
+        if (!isAlreadyConnected) {
+          setConnected(checksummedConnectedAddress);
+        }
+        return;
+      }
+
       if (impersonatedAddress) {
         const isAlreadyConnected =
           walletState.status === "connected" &&
@@ -727,6 +744,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     setConnected,
     setDisconnected,
     setConnecting,
+    agentLoginImpersonatedAddress,
     impersonatedAddress,
     isAddingConnectedAccount,
   ]);

--- a/components/auth/SeizeConnectContext.tsx
+++ b/components/auth/SeizeConnectContext.tsx
@@ -22,10 +22,11 @@ import { getNodeEnv, publicEnv } from "@/config/env";
 import { MAX_CONNECTED_PROFILES } from "@/constants/constants";
 import {
   canStoreAnotherWalletAccount,
+  clearAgentLoginActiveAddress,
   type ConnectedWalletAccount,
+  getAgentLoginActiveAddress,
   getConnectedWalletAccounts,
   getWalletAddress,
-  hasActiveSessionV2Auth,
   isAuthAddressAuthorized,
   removeAuthJwt,
   setActiveWalletAccount,
@@ -494,15 +495,14 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     isAddress(publicEnv.DEV_MODE_WALLET_ADDRESS)
       ? getAddress(publicEnv.DEV_MODE_WALLET_ADDRESS)
       : undefined;
-  const agentLoginWalletAddress = getWalletAddress();
+  const agentLoginActiveAddress = getAgentLoginActiveAddress();
   const agentLoginImpersonatedAddress =
     isDevLikeEnv &&
     isLocalHost &&
     publicEnv.USE_DEV_AUTH !== "true" &&
-    agentLoginWalletAddress &&
-    isAddress(agentLoginWalletAddress) &&
-    hasActiveSessionV2Auth({ address: agentLoginWalletAddress })
-      ? getAddress(agentLoginWalletAddress)
+    agentLoginActiveAddress &&
+    isAddress(agentLoginActiveAddress)
+      ? getAddress(agentLoginActiveAddress)
       : undefined;
   const impersonatedAddress =
     agentLoginImpersonatedAddress ?? devAuthImpersonatedAddress;
@@ -574,6 +574,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
         isAddress(account.address)
       ) {
         const checksummedConnectedAddress = getAddress(account.address);
+        clearAgentLoginActiveAddress();
         const isAlreadyConnected =
           walletState.status === "connected" &&
           walletState.address === checksummedConnectedAddress;
@@ -591,6 +592,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
         isAddress(account.address)
       ) {
         const checksummedConnectedAddress = getAddress(account.address);
+        clearAgentLoginActiveAddress();
         const isKnownStoredAccount = storedConnectedAccounts.some(
           (storedAccount) =>
             normalizeAddress(storedAccount.address) ===
@@ -689,6 +691,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
         }
 
         const checksummedAddress = getAddress(account.address);
+        clearAgentLoginActiveAddress();
         const isAlreadyConnected =
           walletState.status === "connected" &&
           walletState.address === checksummedAddress;
@@ -1002,6 +1005,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
 
       // Normalize address to checksummed format for consistency
       const checksummedAddress = getAddress(address);
+      clearAgentLoginActiveAddress();
       setConnected(checksummedAddress);
       refreshStoredConnectedAccounts();
     },

--- a/components/auth/SeizeConnectContext.tsx
+++ b/components/auth/SeizeConnectContext.tsx
@@ -25,6 +25,7 @@ import {
   type ConnectedWalletAccount,
   getConnectedWalletAccounts,
   getWalletAddress,
+  hasActiveSessionV2Auth,
   isAuthAddressAuthorized,
   removeAuthJwt,
   setActiveWalletAccount,
@@ -485,7 +486,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
       globalThis.window.location.hostname === "127.0.0.1" ||
       globalThis.window.location.hostname === "::1" ||
       globalThis.window.location.hostname.endsWith(".local"));
-  const impersonatedAddress =
+  const devAuthImpersonatedAddress =
     isDevLikeEnv &&
     isLocalHost &&
     publicEnv.USE_DEV_AUTH === "true" &&
@@ -493,6 +494,18 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     isAddress(publicEnv.DEV_MODE_WALLET_ADDRESS)
       ? getAddress(publicEnv.DEV_MODE_WALLET_ADDRESS)
       : undefined;
+  const agentLoginWalletAddress = getWalletAddress();
+  const agentLoginImpersonatedAddress =
+    isDevLikeEnv &&
+    isLocalHost &&
+    publicEnv.USE_DEV_AUTH !== "true" &&
+    agentLoginWalletAddress &&
+    isAddress(agentLoginWalletAddress) &&
+    hasActiveSessionV2Auth({ address: agentLoginWalletAddress })
+      ? getAddress(agentLoginWalletAddress)
+      : undefined;
+  const impersonatedAddress =
+    agentLoginImpersonatedAddress ?? devAuthImpersonatedAddress;
 
   const refreshStoredConnectedAccounts = useCallback(() => {
     setStoredConnectedAccounts(getConnectedWalletAccounts());

--- a/components/auth/SeizeConnectContext.tsx
+++ b/components/auth/SeizeConnectContext.tsx
@@ -495,13 +495,13 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     isAddress(publicEnv.DEV_MODE_WALLET_ADDRESS)
       ? getAddress(publicEnv.DEV_MODE_WALLET_ADDRESS)
       : undefined;
-  const agentLoginActiveAddress = getAgentLoginActiveAddress();
+  const canUseAgentLoginImpersonation =
+    isDevLikeEnv && isLocalHost && publicEnv.USE_DEV_AUTH !== "true";
+  const agentLoginActiveAddress = canUseAgentLoginImpersonation
+    ? getAgentLoginActiveAddress()
+    : null;
   const agentLoginImpersonatedAddress =
-    isDevLikeEnv &&
-    isLocalHost &&
-    publicEnv.USE_DEV_AUTH !== "true" &&
-    agentLoginActiveAddress &&
-    isAddress(agentLoginActiveAddress)
+    agentLoginActiveAddress && isAddress(agentLoginActiveAddress)
       ? getAddress(agentLoginActiveAddress)
       : undefined;
   const impersonatedAddress =

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -14,6 +14,7 @@
     "entry": [
       "scripts/**/*.{ts,js,cjs,mjs}",  // local CLIs used via package.json scripts
       "bin/**/*.mjs",                // repo-local Node CLIs launched from shell helpers
+      "ops/skills/**/scripts/**/*.{js,cjs,mjs}", // repo-local skill CLIs invoked by SKILL.md instructions
       "app/**/route.{ts,tsx}",         // Next App Router route handlers (if used)
       "standalone/standalone-memes-mint/src/app/layout.tsx",
       "standalone/standalone-memes-mint/src/app/page.tsx",

--- a/ops/skills/6529-agent-login/SKILL.md
+++ b/ops/skills/6529-agent-login/SKILL.md
@@ -87,6 +87,7 @@ Use that file as a Playwright browser context storage state. It writes:
 - `6529-wallet-accounts`
 - `6529-wallet-active-address`
 - `6529-wallet-address`
+- `6529-agent-login-active-address`
 - role keys when present
 
 It follows the storage shape used by `services/auth/auth.utils.ts`.

--- a/ops/skills/6529-agent-login/SKILL.md
+++ b/ops/skills/6529-agent-login/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: 6529-agent-login
+description: Manage local 6529 browser-agent test logins for this repo without committing wallet secrets. Use when Codex needs to claim or create a local test wallet, log a local 6529 dev-server browser session in or out, switch between seeded QA accounts, or inject 6529 wallet auth state for Playwright, Chrome, or the Codex in-app Browser.
+---
+
+# 6529 Agent Login
+
+## Overview
+
+Use this skill to log browser agents into a local 6529 frontend without adding
+wallet code to the app. The helper script keeps test wallet keys outside the
+repo by default, performs the normal session-v2 API login, and emits either a
+Playwright storage-state file, browser JavaScript, or a JSON payload for the
+development-only `/tools/agent-login` bridge route.
+
+Do not use this for production accounts unless the user explicitly provides a
+dedicated test key. Do not commit account pool files, private keys, emitted JSON
+payloads, storage-state files, cookies, access tokens, or generated login
+scripts.
+
+## Helper
+
+From the repository root, use:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs <command>
+```
+
+The helper defaults to:
+
+- account pool: `~/.codex/6529-agent-login/accounts.json`
+- repo env source: current working directory, or `--repo /path/to/6529seize-frontend`
+- API endpoint: `API_ENDPOINT` from repo `.env`, or `--api https://...`
+- local browser origin for storage-state output: `BASE_ENDPOINT`, or `http://localhost:3001`
+
+The helper resolves `ethers` from the repo's `node_modules`; pass `--repo` when
+running outside the frontend repo.
+
+Use `--state /path/to/accounts.json` only for a developer-local account pool.
+Never point `--state` at a tracked file.
+
+## Account Pool
+
+List accounts:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs list
+```
+
+Create a throwaway wallet:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs create --id agent-a --label "Agent A"
+```
+
+Import a seeded test account:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs import --id seeded-a --private-key 0x...
+```
+
+Claim an account for one thread:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs claim --client-id thread-a --id seeded-a
+```
+
+Use a stable `--client-id` per Codex thread. This makes parallel threads avoid
+claiming the same account.
+
+## Browser Login
+
+Start or locate a local 6529 dev server first. Then run:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs login \
+  --client-id thread-a \
+  --id seeded-a \
+  --base-url http://localhost:3001 \
+  --format storage-state \
+  > /tmp/6529-agent-storage-state.json
+```
+
+Use that file as a Playwright browser context storage state. It writes:
+
+- `wallet-auth` cookie
+- `6529-wallet-accounts`
+- `6529-wallet-active-address`
+- `6529-wallet-address`
+- role keys when present
+
+It follows the storage shape used by `services/auth/auth.utils.ts`.
+
+For an already-open browser page that supports page JavaScript with real
+`localStorage` and `document.cookie`, emit a script instead:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs login \
+  --client-id thread-a \
+  --id seeded-a \
+  --format browser-script \
+  > /tmp/6529-agent-login.js
+```
+
+Evaluate the generated script in the page and reload. This works with normal
+Playwright or Chrome automation contexts that expose browser storage APIs.
+
+## Codex In-App Browser Login
+
+The Codex in-app Browser cannot directly evaluate scripts that write
+`localStorage` and `document.cookie`. When the local repo includes the
+development-only bridge route, use `http://localhost:3001/tools/agent-login`
+instead.
+
+Generate a JSON payload:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs login \
+  --client-id thread-a \
+  --id seeded-a \
+  --format json \
+  > /tmp/6529-agent-login.json
+```
+
+Open `/tools/agent-login` in the in-app Browser, paste the JSON into the
+`Login payload` textarea, and click `Apply`. The page writes the same wallet
+auth cookie and localStorage keys as the helper's browser script, marks the
+active account as agent-owned for the local bridge, then redirects home. Return
+to `/tools/agent-login` to see the active short wallet address or click
+`Logout`.
+
+Throwaway wallets authenticate but may not have a 6529 profile or role, so some
+profile-only UI can still ask for setup or signing. Use seeded accounts with
+profiles for normal logged-in product QA.
+
+For production or staging 6529 APIs, the helper automatically sends the
+first-party `Origin` header required by wallet auth. Override with `--origin`
+only when a different API requires it.
+
+## Logout
+
+Generate and evaluate a logout script, then reload:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs logout \
+  --format browser-script \
+  > /tmp/6529-agent-logout.js
+```
+
+For the in-app Browser, open `/tools/agent-login` and click `Logout`.
+
+## Switching Accounts
+
+Switch by logging in with another claimed account and evaluating the new browser
+script:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs login \
+  --client-id thread-a \
+  --id seeded-b \
+  --format browser-script \
+  > /tmp/6529-agent-login.js
+```
+
+Reload after injection so React Query and auth providers restart from the new
+active wallet state.
+
+## Local Secret Storage
+
+The shared skill and helper live in the repo. Wallet material does not.
+
+Preferred local account pool:
+
+```text
+~/.codex/6529-agent-login/accounts.json
+```
+
+This path survives worktree changes and branch switches while staying outside
+Git. If a developer chooses a repo-local account pool for temporary work, keep
+it under `.codex/` or pass `--state`, and confirm it is ignored before adding
+files.
+
+## Limits
+
+This bypasses the wallet connect modal. It is good for app QA after login. It is
+not a test of MetaMask, Reown/AppKit wallet selection, or signature modal UX.

--- a/ops/skills/6529-agent-login/SKILL.md
+++ b/ops/skills/6529-agent-login/SKILL.md
@@ -18,6 +18,10 @@ dedicated test key. Do not commit account pool files, private keys, emitted JSON
 payloads, storage-state files, cookies, access tokens, or generated login
 scripts.
 
+If the configured API endpoint is production and the QA task will create
+profiles, direct messages, drops, or other persistent data, get explicit user
+confirmation before performing those browser actions.
+
 ## Helper
 
 From the repository root, use:
@@ -40,6 +44,9 @@ Use `--state /path/to/accounts.json` only for a developer-local account pool.
 Never point `--state` at a tracked file.
 
 ## Account Pool
+
+Use `accounts.example.json` as a shape reference only. Do not fill that file, or
+any other tracked file under `ops/`, with real private keys.
 
 List accounts:
 
@@ -170,18 +177,51 @@ active wallet state.
 
 The shared skill and helper live in the repo. Wallet material does not.
 
-Preferred local account pool:
+Preferred local account pool for real local test wallet keys:
 
 ```text
 ~/.codex/6529-agent-login/accounts.json
 ```
 
 This path survives worktree changes and branch switches while staying outside
-Git. If a developer chooses a repo-local account pool for temporary work, keep
-it under `.codex/` or pass `--state`, and confirm it is ignored before adding
-files.
+Git. It is the default for the helper and should be used for seeded local QA
+wallet pools.
+
+If a developer intentionally chooses repo-associated local state, prefer:
+
+```text
+.codex/6529-agent-login/accounts.json
+```
+
+That path is ignored by Git and follows the repo's local agent-state convention.
+Avoid putting real wallet keys under `ops/skills/6529-agent-login/`; the
+repo-local ignores there are a last line of defense for accidental outputs, not
+the preferred storage location.
+
+## Validation
+
+For skill or helper changes, use focused checks:
+
+```bash
+node ops/skills/6529-agent-login/scripts/agent-login.mjs help
+node ops/skills/6529-agent-login/scripts/agent-login.mjs list
+git status --short
+```
+
+Before closing a login QA task, confirm no wallet material or emitted auth
+payloads were added to tracked files.
+
+Useful evidence to report:
+
+- account ids, short addresses, and handles used
+- browser route used for login or logout
+- local wallet-state path touched
+- visible UI proof of the authenticated account or action
+- repo dirty state and tracked-secret check result
 
 ## Limits
 
 This bypasses the wallet connect modal. It is good for app QA after login. It is
 not a test of MetaMask, Reown/AppKit wallet selection, or signature modal UX.
+It is also not a shortcut for creating messages, drops, profiles, or other app
+data directly through APIs when the task requires real UI coverage.

--- a/ops/skills/6529-agent-login/accounts.example.json
+++ b/ops/skills/6529-agent-login/accounts.example.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "accounts": [
+    {
+      "id": "seeded-a",
+      "label": "Seeded QA A",
+      "address": "0x0000000000000000000000000000000000000000",
+      "privateKey": "0xREPLACE_WITH_DEDICATED_TEST_PRIVATE_KEY",
+      "capabilities": [],
+      "profileHandle": "optional-profile-handle",
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "leases": []
+}

--- a/ops/skills/6529-agent-login/agents/openai.yaml
+++ b/ops/skills/6529-agent-login/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "6529 Agent Login"
+  short_description: "Login helpers for local 6529 agents"
+  default_prompt: "Use $6529-agent-login to log a local browser agent into 6529 with a test wallet."

--- a/ops/skills/6529-agent-login/agents/openai.yaml
+++ b/ops/skills/6529-agent-login/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "6529 Agent Login"
-  short_description: "Login helpers for local 6529 agents"
+  short_description: "Manage local 6529 test-wallet browser logins without committing wallet secrets."
   default_prompt: "Use $6529-agent-login to log a local browser agent into 6529 with a test wallet."

--- a/ops/skills/6529-agent-login/scripts/agent-login.mjs
+++ b/ops/skills/6529-agent-login/scripts/agent-login.mjs
@@ -791,6 +791,10 @@ async function main() {
 try {
   await main();
 } catch (error) {
-  console.error("Agent login command failed.");
+  if (error instanceof Error && error.name === "AbortError") {
+    console.error("Agent login command aborted.");
+  } else {
+    console.error("Agent login command failed.");
+  }
   process.exitCode = 1;
 }

--- a/ops/skills/6529-agent-login/scripts/agent-login.mjs
+++ b/ops/skills/6529-agent-login/scripts/agent-login.mjs
@@ -165,7 +165,7 @@ function parseEnvFile(filePath, target) {
     ) {
       value = value.slice(1, -1);
     }
-    target[key] = value.replaceAll("\\n", "\n");
+    target[key] = value.replaceAll(String.raw`\n`, "\n");
   }
 }
 
@@ -791,6 +791,6 @@ async function main() {
 try {
   await main();
 } catch (error) {
-  console.error(error instanceof Error ? error.message : String(error));
+  console.error("Agent login command failed.");
   process.exitCode = 1;
 }

--- a/ops/skills/6529-agent-login/scripts/agent-login.mjs
+++ b/ops/skills/6529-agent-login/scripts/agent-login.mjs
@@ -23,8 +23,10 @@ const STORAGE_KEYS = {
   legacyAddress: "6529-wallet-address",
   legacyRefreshToken: "6529-wallet-refresh-token",
   legacyRole: "6529-wallet-role",
+  agentLoginActiveAddress: "6529-agent-login-active-address",
   authCookie: "wallet-auth",
 };
+const FETCH_TIMEOUT_MS = 15_000;
 
 function parseArgs(argv) {
   const args = { _: [] };
@@ -386,24 +388,36 @@ function requireString(value, name) {
 }
 
 async function fetchJson(url, options) {
-  const response = await fetch(url, options);
-  const text = await response.text();
-  let body = null;
-  if (text) {
-    try {
-      body = JSON.parse(text);
-    } catch {
-      body = text;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    let body = null;
+    if (text) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = text;
+      }
     }
+    if (!response.ok) {
+      const message =
+        body && typeof body === "object"
+          ? body.error || body.message || JSON.stringify(body)
+          : body || response.statusText;
+      throw new Error(`API request failed (${response.status}): ${message}`);
+    }
+    return body;
+  } finally {
+    clearTimeout(timeout);
   }
-  if (!response.ok) {
-    const message =
-      body && typeof body === "object"
-        ? body.error || body.message || JSON.stringify(body)
-        : body || response.statusText;
-    throw new Error(`API request failed (${response.status}): ${message}`);
-  }
-  return body;
 }
 
 function buildApiHeaders(env) {
@@ -482,6 +496,7 @@ function buildLoginBrowserScript(payload) {
   localStorage.setItem(${JSON.stringify(STORAGE_KEYS.accounts)}, JSON.stringify([account]));
   localStorage.setItem(${JSON.stringify(STORAGE_KEYS.activeAddress)}, account.address);
   localStorage.setItem(${JSON.stringify(STORAGE_KEYS.legacyAddress)}, account.address);
+  localStorage.setItem(${JSON.stringify(STORAGE_KEYS.agentLoginActiveAddress)}, account.address);
   localStorage.removeItem(${JSON.stringify(STORAGE_KEYS.legacyRefreshToken)});
   if (account.role) {
     localStorage.setItem(${JSON.stringify(STORAGE_KEYS.legacyRole)}, account.role);
@@ -527,6 +542,10 @@ function buildLocalStorageEntries(payload) {
     },
     {
       name: STORAGE_KEYS.legacyAddress,
+      value: account.address,
+    },
+    {
+      name: STORAGE_KEYS.agentLoginActiveAddress,
       value: account.address,
     },
   ];

--- a/ops/skills/6529-agent-login/scripts/agent-login.mjs
+++ b/ops/skills/6529-agent-login/scripts/agent-login.mjs
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+/* eslint-disable security/detect-non-literal-fs-filename -- This local-only skill CLI intentionally reads and writes user-selected account-state and env files. */
+
 import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";

--- a/ops/skills/6529-agent-login/scripts/agent-login.mjs
+++ b/ops/skills/6529-agent-login/scripts/agent-login.mjs
@@ -198,7 +198,19 @@ function redactSecretText(value) {
       "[redacted-jwt]"
     )
     .replace(
-      /(access[_-]?token|refresh[_-]?token|jwt|private[_-]?key|client[_-]?signature|server[_-]?signature|authorization)(["']?\s*[:=]\s*["']?)[^"',\s}]+/gi,
+      /(access[_-]?token|refresh[_-]?token)(["']?\s*[:=]\s*["']?)[^"',\s}]+/gi,
+      "$1$2[redacted]"
+    )
+    .replace(
+      /(jwt|authorization)(["']?\s*[:=]\s*["']?)[^"',\s}]+/gi,
+      "$1$2[redacted]"
+    )
+    .replace(
+      /(private[_-]?key)(["']?\s*[:=]\s*["']?)[^"',\s}]+/gi,
+      "$1$2[redacted]"
+    )
+    .replace(
+      /((?:client|server)[_-]?signature)(["']?\s*[:=]\s*["']?)[^"',\s}]+/gi,
       "$1$2[redacted]"
     );
 }

--- a/ops/skills/6529-agent-login/scripts/agent-login.mjs
+++ b/ops/skills/6529-agent-login/scripts/agent-login.mjs
@@ -189,15 +189,20 @@ function normalizeApiBase(value) {
   return withoutSlash.endsWith("/api") ? withoutSlash : `${withoutSlash}/api`;
 }
 
+function is6529Host(hostname) {
+  return hostname === "6529.io" || hostname.endsWith(".6529.io");
+}
+
 function inferFirstPartyOrigin(apiEndpoint) {
   try {
     const hostname = new URL(String(apiEndpoint)).hostname;
-    if (hostname.includes("staging") && hostname.endsWith("6529.io")) {
+    if (!is6529Host(hostname)) {
+      return null;
+    }
+    if (hostname.split(".").includes("staging")) {
       return "https://staging.6529.io";
     }
-    if (hostname.endsWith("6529.io")) {
-      return "https://6529.io";
-    }
+    return "https://6529.io";
   } catch {}
   return null;
 }

--- a/ops/skills/6529-agent-login/scripts/agent-login.mjs
+++ b/ops/skills/6529-agent-login/scripts/agent-login.mjs
@@ -101,7 +101,7 @@ function loadState(statePath) {
     throw new Error(`Unsupported account pool version: ${parsed.version}`);
   }
   if (!Array.isArray(parsed.accounts) || !Array.isArray(parsed.leases)) {
-    throw new Error("Invalid account pool file");
+    throw new TypeError("Invalid account pool file");
   }
   return parsed;
 }
@@ -133,7 +133,12 @@ function randomId(prefix = "agent") {
 }
 
 function normalizeCapabilities(value) {
-  const values = Array.isArray(value) ? value : value ? [value] : [];
+  let values = [];
+  if (Array.isArray(value)) {
+    values = value;
+  } else if (value) {
+    values = [value];
+  }
   return Array.from(
     new Set(
       values
@@ -149,7 +154,7 @@ function parseEnvFile(filePath, target) {
   for (const line of lines) {
     const trimmed = line.trim();
     if (!trimmed || trimmed.startsWith("#")) continue;
-    const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    const match = trimmed.match(/^([A-Za-z_]\w*)=(.*)$/);
     if (!match) continue;
     const key = match[1];
     if (target[key] !== undefined) continue;
@@ -160,7 +165,7 @@ function parseEnvFile(filePath, target) {
     ) {
       value = value.slice(1, -1);
     }
-    target[key] = value.replace(/\\n/g, "\n");
+    target[key] = value.replaceAll("\\n", "\n");
   }
 }
 
@@ -185,7 +190,10 @@ function normalizeApiBase(value) {
   if (!value) {
     throw new Error("Missing API endpoint. Pass --api or set API_ENDPOINT.");
   }
-  const withoutSlash = String(value).replace(/\/+$/, "");
+  let withoutSlash = String(value);
+  while (withoutSlash.endsWith("/")) {
+    withoutSlash = withoutSlash.slice(0, -1);
+  }
   return withoutSlash.endsWith("/api") ? withoutSlash : `${withoutSlash}/api`;
 }
 
@@ -764,24 +772,25 @@ async function main() {
       ethers,
     });
 
-    writeOutput(
-      format === "browser-script"
-        ? buildLoginBrowserScript(payload)
-        : format === "storage-state" || format === "playwright-storage"
-          ? buildPlaywrightStorageState(
-              payload,
-              args["base-url"] || env.BASE_ENDPOINT || "http://localhost:3001"
-            )
-          : payload,
-      format
-    );
+    let output = payload;
+    if (format === "browser-script") {
+      output = buildLoginBrowserScript(payload);
+    } else if (format === "storage-state" || format === "playwright-storage") {
+      output = buildPlaywrightStorageState(
+        payload,
+        args["base-url"] || env.BASE_ENDPOINT || "http://localhost:3001"
+      );
+    }
+    writeOutput(output, format);
     return;
   }
 
   throw new Error(`Unknown command: ${command}`);
 }
 
-main().catch((error) => {
+try {
+  await main();
+} catch (error) {
   console.error(error instanceof Error ? error.message : String(error));
   process.exitCode = 1;
-});
+}

--- a/ops/skills/6529-agent-login/scripts/agent-login.mjs
+++ b/ops/skills/6529-agent-login/scripts/agent-login.mjs
@@ -190,6 +190,19 @@ function loadEthers(repoRoot) {
   return requireFromRepo("ethers");
 }
 
+function redactSecretText(value) {
+  return String(value)
+    .replace(/\b0x[a-fA-F0-9]{64,}\b/g, "0x[redacted]")
+    .replace(
+      /\b[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b/g,
+      "[redacted-jwt]"
+    )
+    .replace(
+      /(access[_-]?token|refresh[_-]?token|jwt|private[_-]?key|client[_-]?signature|server[_-]?signature|authorization)(["']?\s*[:=]\s*["']?)[^"',\s}]+/gi,
+      "$1$2[redacted]"
+    );
+}
+
 function normalizeApiBase(value) {
   if (!value) {
     throw new Error("Missing API endpoint. Pass --api or set API_ENDPOINT.");
@@ -632,9 +645,6 @@ async function main() {
   const command = args._[0] || "help";
   const format = String(args.format || "json");
   const statePath = path.resolve(String(args.state || DEFAULT_STATE_PATH));
-  const repoRoot = resolveRepoRoot(args);
-  const env = loadRepoEnv(repoRoot);
-  const ethers = loadEthers(repoRoot);
 
   if (command === "help") {
     writeOutput(
@@ -686,6 +696,8 @@ async function main() {
   }
 
   if (command === "create" || command === "import") {
+    const repoRoot = resolveRepoRoot(args);
+    const ethers = loadEthers(repoRoot);
     const account = withStateLock(statePath, (state) =>
       addAccount(
         state,
@@ -716,6 +728,8 @@ async function main() {
   }
 
   if (command === "claim") {
+    const repoRoot = resolveRepoRoot(args);
+    const ethers = loadEthers(repoRoot);
     let redacted;
     withStateLock(statePath, (state) => {
       const account = claimAccount(
@@ -740,6 +754,8 @@ async function main() {
   }
 
   if (command === "release") {
+    const repoRoot = resolveRepoRoot(args);
+    const ethers = loadEthers(repoRoot);
     const released = withStateLock(statePath, (state) =>
       releaseAccount(
         state,
@@ -756,6 +772,9 @@ async function main() {
   }
 
   if (command === "login") {
+    const repoRoot = resolveRepoRoot(args);
+    const env = loadRepoEnv(repoRoot);
+    const ethers = loadEthers(repoRoot);
     let account;
     withStateLock(statePath, (state) => {
       account = claimAccount(
@@ -814,6 +833,10 @@ try {
 } catch (error) {
   if (error instanceof Error && error.name === "AbortError") {
     console.error("Agent login command aborted.");
+  } else if (error instanceof Error) {
+    console.error(
+      `Agent login command failed: ${redactSecretText(error.message)}`
+    );
   } else {
     console.error("Agent login command failed.");
   }

--- a/ops/skills/6529-agent-login/scripts/agent-login.mjs
+++ b/ops/skills/6529-agent-login/scripts/agent-login.mjs
@@ -1,0 +1,782 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const DEFAULT_STATE_PATH = path.join(
+  os.homedir(),
+  ".codex",
+  "6529-agent-login",
+  "accounts.json"
+);
+const DEFAULT_TTL_MS = 60 * 60 * 1000;
+const STATE_VERSION = 1;
+
+const STORAGE_KEYS = {
+  accounts: "6529-wallet-accounts",
+  activeAddress: "6529-wallet-active-address",
+  legacyAddress: "6529-wallet-address",
+  legacyRefreshToken: "6529-wallet-refresh-token",
+  legacyRole: "6529-wallet-role",
+  authCookie: "wallet-auth",
+};
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (!value.startsWith("--")) {
+      args._.push(value);
+      continue;
+    }
+    const key = value.slice(2);
+    const next = argv[index + 1];
+    if (!next || next.startsWith("--")) {
+      args[key] = true;
+      continue;
+    }
+    args[key] = next;
+    index += 1;
+  }
+  return args;
+}
+
+function sleepSync(ms) {
+  const buffer = new SharedArrayBuffer(4);
+  const view = new Int32Array(buffer);
+  Atomics.wait(view, 0, 0, ms);
+}
+
+function withStateLock(statePath, fn) {
+  const lockPath = `${statePath}.lock`;
+  fs.mkdirSync(path.dirname(statePath), { recursive: true, mode: 0o700 });
+
+  let locked = false;
+  const deadline = Date.now() + 5000;
+  while (!locked) {
+    try {
+      fs.writeFileSync(lockPath, String(process.pid), {
+        flag: "wx",
+        mode: 0o600,
+      });
+      locked = true;
+    } catch (error) {
+      if (error?.code !== "EEXIST" || Date.now() > deadline) {
+        throw error;
+      }
+      sleepSync(50);
+    }
+  }
+
+  try {
+    const state = loadState(statePath);
+    pruneExpiredLeases(state);
+    const result = fn(state);
+    saveState(statePath, state);
+    return result;
+  } finally {
+    try {
+      fs.unlinkSync(lockPath);
+    } catch {}
+  }
+}
+
+function emptyState() {
+  return {
+    version: STATE_VERSION,
+    accounts: [],
+    leases: [],
+  };
+}
+
+function loadState(statePath) {
+  if (!fs.existsSync(statePath)) {
+    return emptyState();
+  }
+  const parsed = JSON.parse(fs.readFileSync(statePath, "utf8"));
+  if (parsed.version !== STATE_VERSION) {
+    throw new Error(`Unsupported account pool version: ${parsed.version}`);
+  }
+  if (!Array.isArray(parsed.accounts) || !Array.isArray(parsed.leases)) {
+    throw new Error("Invalid account pool file");
+  }
+  return parsed;
+}
+
+function saveState(statePath, state) {
+  const tempPath = `${statePath}.${process.pid}.${Date.now()}.tmp`;
+  fs.mkdirSync(path.dirname(statePath), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  fs.renameSync(tempPath, statePath);
+  try {
+    fs.chmodSync(statePath, 0o600);
+  } catch {}
+}
+
+function normalizeId(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function randomId(prefix = "agent") {
+  return `${prefix}-${crypto.randomBytes(4).toString("hex")}`;
+}
+
+function normalizeCapabilities(value) {
+  const values = Array.isArray(value) ? value : value ? [value] : [];
+  return Array.from(
+    new Set(
+      values
+        .map((capability) => String(capability || "").trim())
+        .filter(Boolean)
+    )
+  ).sort((a, b) => a.localeCompare(b));
+}
+
+function parseEnvFile(filePath, target) {
+  if (!fs.existsSync(filePath)) return;
+  const lines = fs.readFileSync(filePath, "utf8").split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const match = trimmed.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!match) continue;
+    const key = match[1];
+    if (target[key] !== undefined) continue;
+    let value = match[2] ?? "";
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    target[key] = value.replace(/\\n/g, "\n");
+  }
+}
+
+function loadRepoEnv(repoRoot) {
+  const env = { ...process.env };
+  const nodeEnv = env.NODE_ENV || "development";
+  parseEnvFile(path.join(repoRoot, `.env.${nodeEnv}`), env);
+  parseEnvFile(path.join(repoRoot, ".env"), env);
+  return env;
+}
+
+function resolveRepoRoot(args) {
+  return path.resolve(String(args.repo || process.cwd()));
+}
+
+function loadEthers(repoRoot) {
+  const requireFromRepo = createRequire(path.join(repoRoot, "package.json"));
+  return requireFromRepo("ethers");
+}
+
+function normalizeApiBase(value) {
+  if (!value) {
+    throw new Error("Missing API endpoint. Pass --api or set API_ENDPOINT.");
+  }
+  const withoutSlash = String(value).replace(/\/+$/, "");
+  return withoutSlash.endsWith("/api") ? withoutSlash : `${withoutSlash}/api`;
+}
+
+function inferFirstPartyOrigin(apiEndpoint) {
+  try {
+    const hostname = new URL(String(apiEndpoint)).hostname;
+    if (hostname.includes("staging") && hostname.endsWith("6529.io")) {
+      return "https://staging.6529.io";
+    }
+    if (hostname.endsWith("6529.io")) {
+      return "https://6529.io";
+    }
+  } catch {}
+  return null;
+}
+
+function accountForOutput(account, state) {
+  const lease = state.leases.find((entry) => entry.accountId === account.id);
+  return {
+    id: account.id,
+    label: account.label,
+    address: account.address,
+    capabilities: account.capabilities || [],
+    profileHandle: account.profileHandle || null,
+    createdAt: account.createdAt,
+    lease: lease
+      ? {
+          clientId: lease.clientId,
+          claimedAt: lease.claimedAt,
+          expiresAt: lease.expiresAt,
+        }
+      : null,
+  };
+}
+
+function findAccount(state, { id, address }, ethers) {
+  if (id) {
+    return state.accounts.find((account) => account.id === id) || null;
+  }
+  if (address) {
+    const checksummed = ethers.getAddress(address);
+    return (
+      state.accounts.find(
+        (account) => ethers.getAddress(account.address) === checksummed
+      ) || null
+    );
+  }
+  return null;
+}
+
+function addAccount(state, params, ethers) {
+  const wallet = params.privateKey
+    ? new ethers.Wallet(params.privateKey)
+    : ethers.Wallet.createRandom();
+  const id =
+    normalizeId(params.id) || randomId(params.privateKey ? "seeded" : "agent");
+  if (state.accounts.some((account) => account.id === id)) {
+    throw new Error(`Account id already exists: ${id}`);
+  }
+  const address = ethers.getAddress(wallet.address);
+  if (
+    state.accounts.some(
+      (account) => ethers.getAddress(account.address) === address
+    )
+  ) {
+    throw new Error(`Account address already exists: ${address}`);
+  }
+
+  const account = {
+    id,
+    label: String(params.label || id),
+    address,
+    privateKey: wallet.privateKey,
+    capabilities: normalizeCapabilities(params.capabilities),
+    profileHandle: params.profileHandle ? String(params.profileHandle) : null,
+    createdAt: new Date().toISOString(),
+  };
+  state.accounts.push(account);
+  return account;
+}
+
+function accountMatchesCapabilities(account, requestedCapabilities) {
+  if (requestedCapabilities.length === 0) return true;
+  const accountCapabilities = new Set(account.capabilities || []);
+  return requestedCapabilities.every((capability) =>
+    accountCapabilities.has(capability)
+  );
+}
+
+function pruneExpiredLeases(state) {
+  const now = Date.now();
+  state.leases = state.leases.filter((lease) => lease.expiresAt > now);
+}
+
+function claimAccount(state, params, ethers) {
+  const clientId = requireString(params.clientId, "client-id");
+  const requestedCapabilities = normalizeCapabilities(params.capabilities);
+  let account = findAccount(state, params, ethers);
+
+  if (!account) {
+    const existingLease = state.leases.find(
+      (lease) => lease.clientId === clientId
+    );
+    account = existingLease
+      ? state.accounts.find(
+          (candidate) =>
+            candidate.id === existingLease.accountId &&
+            accountMatchesCapabilities(candidate, requestedCapabilities)
+        ) || null
+      : null;
+  }
+
+  if (!account) {
+    account =
+      state.accounts.find((candidate) => {
+        if (!accountMatchesCapabilities(candidate, requestedCapabilities)) {
+          return false;
+        }
+        const lease = state.leases.find(
+          (entry) => entry.accountId === candidate.id
+        );
+        return !lease || lease.clientId === clientId;
+      }) || null;
+  }
+
+  if (!account && params.createIfNeeded !== false) {
+    account = addAccount(
+      state,
+      {
+        id: params.id,
+        label: params.label || `Auto ${clientId}`,
+        capabilities: requestedCapabilities,
+        profileHandle: params.profileHandle,
+      },
+      ethers
+    );
+  }
+
+  if (!account) {
+    throw new Error("No available account matches this claim");
+  }
+
+  const existingAccountLease = state.leases.find(
+    (lease) => lease.accountId === account.id
+  );
+  if (existingAccountLease && existingAccountLease.clientId !== clientId) {
+    throw new Error(
+      `Account ${account.id} is leased to ${existingAccountLease.clientId}`
+    );
+  }
+
+  const ttlMs = Number.isFinite(Number(params.ttlMs))
+    ? Math.max(10_000, Math.min(Number(params.ttlMs), 24 * 60 * 60 * 1000))
+    : DEFAULT_TTL_MS;
+  const now = Date.now();
+  state.leases = state.leases.filter((lease) => lease.accountId !== account.id);
+  state.leases.push({
+    accountId: account.id,
+    clientId,
+    claimedAt: now,
+    expiresAt: now + ttlMs,
+  });
+  return account;
+}
+
+function releaseAccount(state, params, ethers) {
+  const clientId = requireString(params.clientId, "client-id");
+  const account = findAccount(state, params, ethers);
+  const before = state.leases.length;
+  state.leases = state.leases.filter((lease) => {
+    if (lease.clientId !== clientId) return true;
+    if (!account) return false;
+    return lease.accountId !== account.id;
+  });
+  return before - state.leases.length;
+}
+
+function requireString(value, name) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Missing required --${name}`);
+  }
+  return value.trim();
+}
+
+async function fetchJson(url, options) {
+  const response = await fetch(url, options);
+  const text = await response.text();
+  let body = null;
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = text;
+    }
+  }
+  if (!response.ok) {
+    const message =
+      body && typeof body === "object"
+        ? body.error || body.message || JSON.stringify(body)
+        : body || response.statusText;
+    throw new Error(`API request failed (${response.status}): ${message}`);
+  }
+  return body;
+}
+
+function buildApiHeaders(env) {
+  return {
+    accept: "application/json",
+    ...(env.ORIGIN ? { origin: env.ORIGIN } : {}),
+    ...(env.STAGING_API_KEY ? { "x-6529-auth": env.STAGING_API_KEY } : {}),
+  };
+}
+
+async function loginWithAccount({ account, apiBase, env, role, ethers }) {
+  const wallet = new ethers.Wallet(account.privateKey);
+  const address = ethers.getAddress(wallet.address);
+  const nonceUrl = new URL(`${apiBase}/auth/session-nonce`);
+  nonceUrl.searchParams.set("signer_address", address);
+  nonceUrl.searchParams.set("client_type", "web");
+  nonceUrl.searchParams.set("chain_id", "1");
+
+  const nonce = await fetchJson(nonceUrl, {
+    method: "GET",
+    headers: buildApiHeaders(env),
+  });
+  if (!nonce?.signable_message || !nonce?.server_signature) {
+    throw new Error("Nonce response did not include signable_message");
+  }
+
+  const clientSignature = await wallet.signMessage(nonce.signable_message);
+  const loginBody = {
+    client_type: "web",
+    server_signature: nonce.server_signature,
+    client_signature: clientSignature,
+    client_address: address,
+    ...(role ? { role } : {}),
+  };
+  const session = await fetchJson(`${apiBase}/auth/session-login`, {
+    method: "POST",
+    headers: {
+      ...buildApiHeaders(env),
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(loginBody),
+  });
+  if (!session?.access_token) {
+    throw new Error("Login response did not include access_token");
+  }
+
+  return {
+    account: {
+      id: account.id,
+      label: account.label,
+      address,
+      profileHandle: account.profileHandle || null,
+    },
+    session: {
+      address: session.address || address,
+      role: session.role ?? null,
+      accessToken: session.access_token,
+      accessTokenExpiresAt: session.access_token_expires_at ?? null,
+      clientType: session.client_type ?? "web",
+    },
+  };
+}
+
+function buildLoginBrowserScript(payload) {
+  return `(() => {
+  const payload = ${JSON.stringify(payload)};
+  const account = {
+    address: payload.session.address,
+    refreshToken: null,
+    role: payload.session.role,
+    jwt: payload.session.accessToken,
+    profileId: null,
+    profileHandle: payload.account.profileHandle,
+    authSessionVersion: "v2",
+  };
+  localStorage.setItem(${JSON.stringify(STORAGE_KEYS.accounts)}, JSON.stringify([account]));
+  localStorage.setItem(${JSON.stringify(STORAGE_KEYS.activeAddress)}, account.address);
+  localStorage.setItem(${JSON.stringify(STORAGE_KEYS.legacyAddress)}, account.address);
+  localStorage.removeItem(${JSON.stringify(STORAGE_KEYS.legacyRefreshToken)});
+  if (account.role) {
+    localStorage.setItem(${JSON.stringify(STORAGE_KEYS.legacyRole)}, account.role);
+    localStorage.setItem("auth-role-" + account.address.toLowerCase(), account.role);
+  } else {
+    localStorage.removeItem(${JSON.stringify(STORAGE_KEYS.legacyRole)});
+    localStorage.removeItem("auth-role-" + account.address.toLowerCase());
+  }
+  document.cookie = ${JSON.stringify(STORAGE_KEYS.authCookie)} + "=" + encodeURIComponent(account.jwt) + "; path=/; SameSite=Strict";
+  window.dispatchEvent(new CustomEvent("6529-wallet-accounts-updated"));
+  window.dispatchEvent(new CustomEvent("6529-auth-token-changed"));
+  window.dispatchEvent(new CustomEvent("6529-profile-switched"));
+  return {
+    ok: true,
+    address: account.address,
+    accountId: payload.account.id,
+  };
+})();`;
+}
+
+function buildStoredAccount(payload) {
+  return {
+    address: payload.session.address,
+    refreshToken: null,
+    role: payload.session.role,
+    jwt: payload.session.accessToken,
+    profileId: null,
+    profileHandle: payload.account.profileHandle,
+    authSessionVersion: "v2",
+  };
+}
+
+function buildLocalStorageEntries(payload) {
+  const account = buildStoredAccount(payload);
+  const entries = [
+    {
+      name: STORAGE_KEYS.accounts,
+      value: JSON.stringify([account]),
+    },
+    {
+      name: STORAGE_KEYS.activeAddress,
+      value: account.address,
+    },
+    {
+      name: STORAGE_KEYS.legacyAddress,
+      value: account.address,
+    },
+  ];
+
+  if (account.role) {
+    entries.push(
+      {
+        name: STORAGE_KEYS.legacyRole,
+        value: account.role,
+      },
+      {
+        name: `auth-role-${account.address.toLowerCase()}`,
+        value: account.role,
+      }
+    );
+  }
+
+  return entries;
+}
+
+function normalizeOrigin(value) {
+  const url = new URL(String(value || "http://localhost:3001"));
+  return url.origin;
+}
+
+function getCookieExpires(payload) {
+  const expiresAt = Date.parse(
+    String(payload.session.accessTokenExpiresAt || "")
+  );
+  return Number.isFinite(expiresAt) ? Math.floor(expiresAt / 1000) : -1;
+}
+
+function buildPlaywrightStorageState(payload, baseUrl) {
+  const origin = normalizeOrigin(baseUrl);
+  const url = new URL(origin);
+  return {
+    cookies: [
+      {
+        name: STORAGE_KEYS.authCookie,
+        value: payload.session.accessToken,
+        domain: url.hostname,
+        path: "/",
+        expires: getCookieExpires(payload),
+        httpOnly: false,
+        secure: url.protocol === "https:",
+        sameSite: "Strict",
+      },
+    ],
+    origins: [
+      {
+        origin,
+        localStorage: buildLocalStorageEntries(payload),
+      },
+    ],
+  };
+}
+
+function buildLogoutBrowserScript() {
+  return `(() => {
+  const keys = ${JSON.stringify(Object.values(STORAGE_KEYS).filter((key) => key !== STORAGE_KEYS.authCookie))};
+  for (const key of keys) localStorage.removeItem(key);
+  for (const key of Object.keys(localStorage)) {
+    if (key.startsWith("auth-role-")) localStorage.removeItem(key);
+  }
+  document.cookie = ${JSON.stringify(STORAGE_KEYS.authCookie)} + "=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Strict";
+  window.dispatchEvent(new CustomEvent("6529-wallet-accounts-updated"));
+  window.dispatchEvent(new CustomEvent("6529-auth-token-changed"));
+  window.dispatchEvent(new CustomEvent("6529-profile-switched"));
+  return { ok: true };
+})();`;
+}
+
+function writeOutput(value, format) {
+  if (format === "quiet") return;
+  if (format === "browser-script") {
+    process.stdout.write(`${value}\n`);
+    return;
+  }
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const command = args._[0] || "help";
+  const format = String(args.format || "json");
+  const statePath = path.resolve(String(args.state || DEFAULT_STATE_PATH));
+  const repoRoot = resolveRepoRoot(args);
+  const env = loadRepoEnv(repoRoot);
+  const ethers = loadEthers(repoRoot);
+
+  if (command === "help") {
+    writeOutput(
+      {
+        commands: [
+          "list",
+          "create",
+          "import",
+          "claim",
+          "release",
+          "login",
+          "logout",
+        ],
+        formats: [
+          "json",
+          "browser-script",
+          "storage-state",
+          "playwright-storage",
+          "quiet",
+        ],
+        statePath,
+      },
+      format
+    );
+    return;
+  }
+
+  if (command === "logout") {
+    writeOutput(
+      format === "browser-script" ? buildLogoutBrowserScript() : { ok: true },
+      format
+    );
+    return;
+  }
+
+  if (command === "list") {
+    const state = loadState(statePath);
+    pruneExpiredLeases(state);
+    writeOutput(
+      {
+        statePath,
+        accounts: state.accounts.map((account) =>
+          accountForOutput(account, state)
+        ),
+      },
+      format
+    );
+    return;
+  }
+
+  if (command === "create" || command === "import") {
+    const account = withStateLock(statePath, (state) =>
+      addAccount(
+        state,
+        {
+          id: args.id,
+          label: args.label,
+          privateKey:
+            command === "import"
+              ? requireString(args["private-key"], "private-key")
+              : undefined,
+          capabilities: normalizeCapabilities(args.capability),
+          profileHandle: args.handle,
+        },
+        ethers
+      )
+    );
+    writeOutput(
+      {
+        account: {
+          id: account.id,
+          label: account.label,
+          address: account.address,
+        },
+      },
+      format
+    );
+    return;
+  }
+
+  if (command === "claim") {
+    let redacted;
+    withStateLock(statePath, (state) => {
+      const account = claimAccount(
+        state,
+        {
+          clientId: args["client-id"] || args.clientId,
+          id: args.id,
+          address: args.address,
+          label: args.label,
+          capabilities: normalizeCapabilities(args.capability),
+          profileHandle: args.handle,
+          createIfNeeded: args.create !== "false",
+          ttlMs: args.ttlMs,
+        },
+        ethers
+      );
+      redacted = accountForOutput(account, state);
+      return account;
+    });
+    writeOutput({ account: redacted }, format);
+    return;
+  }
+
+  if (command === "release") {
+    const released = withStateLock(statePath, (state) =>
+      releaseAccount(
+        state,
+        {
+          clientId: args["client-id"] || args.clientId,
+          id: args.id,
+          address: args.address,
+        },
+        ethers
+      )
+    );
+    writeOutput({ released }, format);
+    return;
+  }
+
+  if (command === "login") {
+    let account;
+    withStateLock(statePath, (state) => {
+      account = claimAccount(
+        state,
+        {
+          clientId: args["client-id"] || args.clientId,
+          id: args.id,
+          address: args.address,
+          label: args.label,
+          capabilities: normalizeCapabilities(args.capability),
+          profileHandle: args.handle,
+          createIfNeeded: args.create !== "false",
+          ttlMs: args.ttlMs,
+        },
+        ethers
+      );
+      return account;
+    });
+
+    const apiEndpoint = args.api || env.API_ENDPOINT;
+    const apiBase = normalizeApiBase(apiEndpoint);
+    const payload = await loginWithAccount({
+      account,
+      apiBase,
+      env: {
+        STAGING_API_KEY: args["staging-auth"] || env.STAGING_API_KEY,
+        ORIGIN:
+          args.origin ||
+          env.AGENT_LOGIN_ORIGIN ||
+          inferFirstPartyOrigin(apiEndpoint) ||
+          args["base-url"] ||
+          env.BASE_ENDPOINT,
+      },
+      role: args.role,
+      ethers,
+    });
+
+    writeOutput(
+      format === "browser-script"
+        ? buildLoginBrowserScript(payload)
+        : format === "storage-state" || format === "playwright-storage"
+          ? buildPlaywrightStorageState(
+              payload,
+              args["base-url"] || env.BASE_ENDPOINT || "http://localhost:3001"
+            )
+          : payload,
+      format
+    );
+    return;
+  }
+
+  throw new Error(`Unknown command: ${command}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/ops/skills/README.md
+++ b/ops/skills/README.md
@@ -6,6 +6,8 @@ This folder stores repo-local Codex skills and agent guidance.
 
 ## Repo-Local Skills
 
+- [6529 Agent Login](6529-agent-login/SKILL.md): manages local
+  browser-agent test wallet logins without committing wallet secrets.
 - [6529 Autonomous Manager](6529-autonomous-manager/SKILL.md): owns scoped
   6529 frontend workstreams from instruction to validated closeout.
 - [Commit Docs Updater](commit-docs-updater/SKILL.md):

--- a/services/auth/auth.utils.ts
+++ b/services/auth/auth.utils.ts
@@ -18,6 +18,15 @@ const WALLET_ACCOUNTS_STORAGE_KEY = "6529-wallet-accounts";
 const WALLET_ACTIVE_ADDRESS_STORAGE_KEY = "6529-wallet-active-address";
 export const AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY =
   "6529-agent-login-active-address";
+export const AUTH_STORAGE_KEYS = {
+  accounts: WALLET_ACCOUNTS_STORAGE_KEY,
+  activeAddress: WALLET_ACTIVE_ADDRESS_STORAGE_KEY,
+  legacyAddress: WALLET_ADDRESS_STORAGE_KEY,
+  legacyRefreshToken: WALLET_REFRESH_TOKEN_STORAGE_KEY,
+  legacyRole: WALLET_ROLE_STORAGE_KEY,
+  agentLoginActiveAddress: AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY,
+  authCookie: WALLET_AUTH_COOKIE,
+} as const;
 
 export interface ConnectedWalletAccount {
   readonly address: string;

--- a/services/auth/auth.utils.ts
+++ b/services/auth/auth.utils.ts
@@ -16,6 +16,8 @@ const WALLET_REFRESH_TOKEN_STORAGE_KEY = "6529-wallet-refresh-token";
 const WALLET_ROLE_STORAGE_KEY = "6529-wallet-role";
 const WALLET_ACCOUNTS_STORAGE_KEY = "6529-wallet-accounts";
 const WALLET_ACTIVE_ADDRESS_STORAGE_KEY = "6529-wallet-active-address";
+export const AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY =
+  "6529-agent-login-active-address";
 
 export interface ConnectedWalletAccount {
   readonly address: string;
@@ -44,6 +46,24 @@ const getAddressRoleStorageKey = (address: string): string => {
 };
 
 const normalizeAddress = (address: string): string => address.toLowerCase();
+
+const clearAgentLoginMarkerIfAddressChanged = (
+  activeAddress: string | null
+): void => {
+  const agentLoginAddress = safeLocalStorage.getItem(
+    AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY
+  );
+  if (!agentLoginAddress) {
+    return;
+  }
+
+  if (
+    !activeAddress ||
+    normalizeAddress(agentLoginAddress) !== normalizeAddress(activeAddress)
+  ) {
+    safeLocalStorage.removeItem(AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY);
+  }
+};
 
 export const isAuthAddressAuthorized = ({
   address,
@@ -326,6 +346,7 @@ const persistAccountsWithActive = (
 ): void => {
   writeAccountsToStorage(accounts);
   setActiveAddressInStorage(activeAddress);
+  clearAgentLoginMarkerIfAddressChanged(activeAddress);
 
   const activeAccount =
     activeAddress === null
@@ -479,6 +500,33 @@ export const hasActiveSessionV2Auth = ({
     activeAccount?.authSessionVersion === "v2" &&
     normalizeAddress(activeAccount.address) === normalizeAddress(address)
   );
+};
+
+export const setAgentLoginActiveAddress = (address: string): void => {
+  safeLocalStorage.setItem(AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY, address);
+};
+
+export const clearAgentLoginActiveAddress = (): void => {
+  safeLocalStorage.removeItem(AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY);
+};
+
+export const getAgentLoginActiveAddress = (): string | null => {
+  const agentLoginAddress = safeLocalStorage.getItem(
+    AGENT_LOGIN_ACTIVE_ADDRESS_STORAGE_KEY
+  );
+  if (!agentLoginAddress) {
+    return null;
+  }
+
+  const activeAccount = getActiveAccountFromAccounts(getStoredAccounts());
+  if (
+    activeAccount?.authSessionVersion !== "v2" ||
+    normalizeAddress(activeAccount.address) !== normalizeAddress(agentLoginAddress)
+  ) {
+    return null;
+  }
+
+  return activeAccount.address;
 };
 
 export const getRefreshToken = () => {


### PR DESCRIPTION
## Summary
- add the local /tools/agent-login bridge for browser-agent QA logins
- mark agent-login auth with an explicit localStorage key
- make localhost connected-wallet fallback depend on that explicit marker
- clear the agent-login marker when a real wallet connection is accepted

## Validation
- git diff --check
- in-app browser auth round: agent A login, logout, agent B login, switch back to agent A, profile name update
- local lint/typecheck hooks were blocked by the repo wrapper invoking pnpm install in this worktree; PR checks should be treated as source of truth

## Notes
- the bridge is for local QA only
- normal real wallet connection clears agent-login ownership of the connected-wallet fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local-only “Agent Login” page that accepts a pasted JSON payload, applies auth via browser storage and an auth cookie, and shows live status.
  * Introduced a 6529 Agent Login repo-local skill/CLI with an account pool plus setup documentation.
* **Bug Fixes**
  * Improved agent-login (session v2) marker handling: it’s only used when valid and is cleared/updated as the active account changes.
* **Tests / Chores**
  * Expanded auth/context and auth-utils tests for agent-login marker behavior.
  * Updated tooling analysis, added repo ignore patterns for generated artifacts, and added agent-login example account seed data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->