### PR TITLE
Pause videos from playback surface clicks

### DIFF
--- a/__tests__/components/drops/view/item/content/media/DropListItemContentMediaVideo.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/DropListItemContentMediaVideo.test.tsx
@@ -50,6 +50,7 @@ describe("DropListItemContentMediaVideo", () => {
 
     // Mock HTMLVideoElement.play to return a promise
     Object.defineProperty(HTMLVideoElement.prototype, "play", {
+      configurable: true,
       writable: true,
       value: jest.fn().mockResolvedValue(undefined),
     });
@@ -106,6 +107,7 @@ describe("DropListItemContentMediaVideo", () => {
 
     const playSpy = jest.fn().mockResolvedValue(undefined);
     Object.defineProperty(HTMLVideoElement.prototype, "play", {
+      configurable: true,
       writable: true,
       value: playSpy,
     });
@@ -127,6 +129,7 @@ describe("DropListItemContentMediaVideo", () => {
     const pauseSpy = jest.fn();
     Object.defineProperty(HTMLVideoElement.prototype, "pause", {
       configurable: true,
+      writable: true,
       value: pauseSpy,
     });
 
@@ -154,6 +157,7 @@ describe("DropListItemContentMediaVideo", () => {
     const pauseSpy = jest.fn();
     Object.defineProperty(HTMLVideoElement.prototype, "pause", {
       configurable: true,
+      writable: true,
       value: pauseSpy,
     });
     Object.defineProperty(document, "fullscreenElement", {
@@ -290,5 +294,57 @@ describe("DropListItemContentMediaVideo", () => {
         dialogTitle: "Save video",
       })
     );
+  });
+
+  it("pauses video-surface clicks without starting paused videos", () => {
+    const ref = {
+      current: document.createElement("div"),
+    } as React.RefObject<HTMLDivElement>;
+    mockUseInView.mockReturnValue([ref, true]);
+    mockUseOptimizedVideo.mockReturnValue({
+      playableUrl: "foo.mp4",
+      isHls: false,
+    });
+
+    const playSpy = jest.fn().mockResolvedValue(undefined);
+    const pauseSpy = jest.fn();
+    Object.defineProperty(HTMLVideoElement.prototype, "play", {
+      configurable: true,
+      writable: true,
+      value: playSpy,
+    });
+    Object.defineProperty(HTMLVideoElement.prototype, "pause", {
+      configurable: true,
+      writable: true,
+      value: pauseSpy,
+    });
+
+    const { container } = render(
+      <DropListItemContentMediaVideo src="foo.mp4" />
+    );
+    const video = container.querySelector("video");
+    if (!video) {
+      throw new Error("Expected video element to render");
+    }
+
+    let paused = false;
+    Object.defineProperty(video, "paused", {
+      configurable: true,
+      get: () => paused,
+    });
+
+    const playCallsBeforeClick = playSpy.mock.calls.length;
+    const pauseCallsBeforeClick = pauseSpy.mock.calls.length;
+
+    fireEvent.click(video);
+
+    expect(pauseSpy).toHaveBeenCalledTimes(pauseCallsBeforeClick + 1);
+    expect(playSpy).toHaveBeenCalledTimes(playCallsBeforeClick);
+
+    paused = true;
+    fireEvent.click(video);
+
+    expect(pauseSpy).toHaveBeenCalledTimes(pauseCallsBeforeClick + 1);
+    expect(playSpy).toHaveBeenCalledTimes(playCallsBeforeClick);
   });
 });

--- a/__tests__/components/drops/view/item/content/media/MediaDisplayVideo.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/MediaDisplayVideo.test.tsx
@@ -122,20 +122,26 @@ describe("MediaDisplayVideo", () => {
     );
   });
 
-  it("does not add playback toggles from ambient video clicks", async () => {
+  it("pauses ambient video clicks without starting paused videos", async () => {
     const user = userEvent.setup();
     const { container } = render(<MediaDisplayVideo src="foo.mp4" />);
     const video = container.querySelector("video") as HTMLVideoElement;
-    Object.defineProperty(video, "paused", { writable: true, value: true });
+    let paused = false;
+    Object.defineProperty(video, "paused", {
+      configurable: true,
+      get: () => paused,
+    });
 
     const playCallsBeforeClick = playMock.mock.calls.length;
     const pauseCallsBeforeClick = pauseMock.mock.calls.length;
 
     await user.click(video);
     expect(playMock).toHaveBeenCalledTimes(playCallsBeforeClick);
+    expect(pauseMock).toHaveBeenCalledTimes(pauseCallsBeforeClick + 1);
 
-    (video as any).paused = false;
+    paused = true;
     await user.click(video);
-    expect(pauseMock).toHaveBeenCalledTimes(pauseCallsBeforeClick);
+    expect(playMock).toHaveBeenCalledTimes(playCallsBeforeClick);
+    expect(pauseMock).toHaveBeenCalledTimes(pauseCallsBeforeClick + 1);
   });
 });

--- a/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
@@ -440,7 +440,6 @@ describe("SeizeVideoPlayer", () => {
     expect(HTMLMediaElement.prototype.pause).toHaveBeenCalledTimes(
       pauseCallsBeforeClick + 1
     );
-    fireEvent.pause(video);
     expect(screen.getByRole("button", { name: "Play video" })).toBeVisible();
 
     paused = true;
@@ -451,6 +450,35 @@ describe("SeizeVideoPlayer", () => {
 
     expect(HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(
       playCallsBeforeClick
+    );
+  });
+
+  it("does not pause ended videos from video clicks", () => {
+    let paused = false;
+    const { container } = render(
+      <SeizeVideoPlayer src="https://example.com/video.mp4" autoPlay={false} />
+    );
+    const video = container.querySelector("video");
+    if (!video) {
+      throw new Error("Expected video element to render");
+    }
+    Object.defineProperty(video, "paused", {
+      configurable: true,
+      get: () => paused,
+    });
+    Object.defineProperty(video, "ended", {
+      configurable: true,
+      value: true,
+    });
+    fireEvent.play(video);
+
+    const pauseCallsBeforeClick = jest.mocked(HTMLMediaElement.prototype.pause)
+      .mock.calls.length;
+
+    fireEvent.click(video);
+
+    expect(HTMLMediaElement.prototype.pause).toHaveBeenCalledTimes(
+      pauseCallsBeforeClick
     );
   });
 

--- a/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
@@ -417,7 +417,7 @@ describe("SeizeVideoPlayer", () => {
     expect(muteButton.parentElement).toHaveClass("tw-right-3");
   });
 
-  it("toggles minimal playback from video clicks", () => {
+  it("pauses minimal playback from video clicks without starting playback", () => {
     let paused = false;
     const { container } = render(
       <SeizeVideoPlayer src="https://example.com/video.mp4" autoPlay={false} />
@@ -448,7 +448,7 @@ describe("SeizeVideoPlayer", () => {
     fireEvent.click(video);
 
     expect(HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(
-      playCallsBeforeClick + 1
+      playCallsBeforeClick
     );
   });
 

--- a/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
+++ b/__tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx
@@ -440,6 +440,8 @@ describe("SeizeVideoPlayer", () => {
     expect(HTMLMediaElement.prototype.pause).toHaveBeenCalledTimes(
       pauseCallsBeforeClick + 1
     );
+    fireEvent.pause(video);
+    expect(screen.getByRole("button", { name: "Play video" })).toBeVisible();
 
     paused = true;
     const playCallsBeforeClick = jest.mocked(HTMLMediaElement.prototype.play)

--- a/components/drops/view/item/content/media/DropListItemContentMediaVideo.tsx
+++ b/components/drops/view/item/content/media/DropListItemContentMediaVideo.tsx
@@ -133,9 +133,6 @@ function DropListItemContentMediaVideo({
         onOpen={openMedia}
         openLabel={openLabel}
         isDownloading={isDownloading}
-        onVideoClick={(event) => {
-          event.preventDefault();
-        }}
       />
     </div>
   );

--- a/components/drops/view/item/content/media/MediaDisplayVideo.tsx
+++ b/components/drops/view/item/content/media/MediaDisplayVideo.tsx
@@ -127,9 +127,6 @@ const MediaDisplayVideo: React.FC<Props> = ({
         onOpen={showControls ? openMedia : undefined}
         openLabel={showControls ? openLabel : undefined}
         isDownloading={isDownloading}
-        onVideoClick={(event) => {
-          event.preventDefault();
-        }}
       />
     </div>
   );

--- a/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
+++ b/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
@@ -798,6 +798,18 @@ export default function SeizeVideoPlayer({
     updateProgress();
   }
 
+  function pauseCurrentVideo() {
+    const video = internalVideoRef.current;
+    if (!video || video.paused || video.ended) {
+      return;
+    }
+
+    if (playerOwnsAutoplay) {
+      setUserPausedAutoplaySrc(directSrc ?? null);
+    }
+    video.pause();
+  }
+
   function togglePlayback() {
     const video = internalVideoRef.current;
     if (!video) return;
@@ -811,10 +823,7 @@ export default function SeizeVideoPlayer({
       return;
     }
 
-    if (playerOwnsAutoplay) {
-      setUserPausedAutoplaySrc(directSrc ?? null);
-    }
-    video.pause();
+    pauseCurrentVideo();
   }
 
   function seekToProgress(nextProgress: number) {
@@ -897,13 +906,7 @@ export default function SeizeVideoPlayer({
     }
 
     event.preventDefault();
-    const video = internalVideoRef.current;
-    if (video && !video.paused && !video.ended) {
-      if (playerOwnsAutoplay) {
-        setUserPausedAutoplaySrc(directSrc ?? null);
-      }
-      video.pause();
-    }
+    pauseCurrentVideo();
     revealControls();
   }
 

--- a/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
+++ b/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
@@ -808,6 +808,7 @@ export default function SeizeVideoPlayer({
       setUserPausedAutoplaySrc(directSrc ?? null);
     }
     video.pause();
+    handlePause();
   }
 
   function togglePlayback() {

--- a/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
+++ b/components/drops/view/item/content/media/SeizeVideoPlayer.tsx
@@ -897,7 +897,13 @@ export default function SeizeVideoPlayer({
     }
 
     event.preventDefault();
-    togglePlayback();
+    const video = internalVideoRef.current;
+    if (video && !video.paused && !video.ended) {
+      if (playerOwnsAutoplay) {
+        setUserPausedAutoplaySrc(directSrc ?? null);
+      }
+      video.pause();
+    }
     revealControls();
   }
 


### PR DESCRIPTION
## Issue
- Video playback could only be paused through the explicit pause button. Users should also be able to pause by clicking the video surface itself, while concrete controls keep their current behavior.

## Fix
- Changed the shared minimal-controls video click handler to pause only when the video is currently playing.
- Left play behavior on the existing play controls, so clicking a paused video surface does not start playback.

## Changes
- Removed wrapper-level click vetoes that blocked shared video-surface pause behavior for drop/list media videos.
- Kept custom controls and timeline interactions isolated through their existing event handling.
- Updated focused media-player tests for pause-only surface clicks and resettable media method mocks.

## Validation
- `./bin/6529 run test -- --runTestsByPath __tests__/components/drops/view/item/content/media/SeizeVideoPlayer.test.tsx __tests__/components/drops/view/item/content/media/MediaDisplayVideo.test.tsx __tests__/components/drops/view/item/content/media/DropListItemContentMediaVideo.test.tsx`
- `./bin/6529 run lint:diff`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run check:changed`
- `./bin/6529 run react-doctor:diff` scanned the six touched files before commit and returned 98/100 with existing size/state-count warnings in `SeizeVideoPlayer`.

## Risk
- Level: Low
- Why: scoped to shared frontend video click behavior and tests; no API, auth, data, generated model, or deployment config changes.
- Rollback: revert this PR to restore the previous button-only pause behavior.

## Review Notes
- Please focus on the pause-only semantics: playing video surface click should pause; paused video surface click should not play; explicit play/pause controls should still work.
- UI/UX and accessibility impact is behavioral only: no visual styling changed, semantic button controls remain unchanged, and concrete controls continue to own their pointer events.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Video clicks now pause playback instead of accidentally resuming or toggling it in some cases.
  * Clicking a video that is already paused no longer triggers extra playback behavior.
  * Fullscreen-related video interactions now behave more consistently after exiting fullscreen.
* **Tests**
  * Updated and expanded video interaction coverage to reflect the revised click and pause behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->