### PR TITLE
Unify Worth Checking Out score card

### DIFF
--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -10,7 +10,6 @@ import type { UnifiedWavesListWavesHandle } from "@/components/brain/left-sideba
 import UnifiedWavesListWaves from "@/components/brain/left-sidebar/waves/UnifiedWavesListWaves";
 import {
   getFittingPreviewCount,
-  getHighlyRatedPreviewTooltipAlignment,
   getHighlyRatedPreviewWaves,
   getVisibleHighlyRatedPreviewItems,
   type HighlyRatedWavePreviewItem,
@@ -206,24 +205,6 @@ it("calculates how many highly rated preview avatars fit", () => {
       width: 220,
     })
   ).toBe(4);
-});
-
-it("aligns edge preview tooltips inward to avoid sidebar clipping", () => {
-  expect(
-    getHighlyRatedPreviewTooltipAlignment({ index: 0, itemCount: 7 })
-  ).toBe("start");
-  expect(
-    getHighlyRatedPreviewTooltipAlignment({ index: 1, itemCount: 7 })
-  ).toBe("start");
-  expect(
-    getHighlyRatedPreviewTooltipAlignment({ index: 3, itemCount: 7 })
-  ).toBe("center");
-  expect(
-    getHighlyRatedPreviewTooltipAlignment({ index: 5, itemCount: 7 })
-  ).toBe("end");
-  expect(
-    getHighlyRatedPreviewTooltipAlignment({ index: 3, itemCount: 4 })
-  ).toBe("center");
 });
 
 it("keeps the active highly rated preview visible within the capped strip", () => {
@@ -463,13 +444,20 @@ it("uses highly rated preview score semantics instead of unread badges", () => {
   ).toBeInTheDocument();
   const scoreBadgeText = screen.getByText("93", { selector: "text" });
   expect(scoreBadgeText).toBeInTheDocument();
-  expect(scoreBadgeText.closest("button")).toHaveClass("-tw-bottom-1");
-  expect(scoreBadgeText.closest("button")).toHaveClass("-tw-right-1.5");
-  expect(scoreBadgeText.closest("button")).toHaveClass("tw-h-6");
-  expect(scoreBadgeText.closest("button")).toHaveClass("tw-w-7");
+  expect(scoreBadgeText.closest("span")).toHaveClass("-tw-bottom-1");
+  expect(scoreBadgeText.closest("span")).toHaveClass("-tw-right-1.5");
+  expect(scoreBadgeText.closest("span")).toHaveClass("tw-h-6");
+  expect(scoreBadgeText.closest("span")).toHaveClass("tw-w-7");
+  expect(scoreBadgeText.closest("span")).toHaveAttribute("aria-hidden", "true");
   expect(scoreBadgeText.closest("svg")).toHaveClass("tw-h-5");
   expect(scoreBadgeText.closest("svg")).toHaveClass("tw-w-6");
-  fireEvent.click(screen.getByRole("button", { name: "Score 93" }));
+  fireEvent.click(
+    screen.getByRole("link", { name: "Open Scored Discovery, score 93" })
+  );
+  expect(
+    screen.queryByRole("dialog", { name: "Wave score details" })
+  ).not.toBeInTheDocument();
+  fireEvent.click(scoreBadgeText);
   expect(
     screen.getByRole("dialog", { name: "Wave score details" })
   ).toBeInTheDocument();
@@ -496,6 +484,36 @@ it("uses highly rated preview score semantics instead of unread badges", () => {
     "data-is-drop-wave",
     "true"
   );
+});
+
+it("uses no-message copy in the combined highly rated score card", () => {
+  render(
+    <UnifiedWavesListWaves
+      waves={[
+        createMockMinimalWave({
+          id: "h-score-empty",
+          name: "Quiet Discovery",
+          type: ApiWaveType.Rank,
+          sidebarSection: "highly-rated",
+          waveScore: {
+            visibility_score: 88,
+            quality_score: 90,
+            hotness_score: 70,
+            rep_sort_score: 64,
+          } as any,
+        }),
+      ]}
+      onHover={jest.fn()}
+      scrollContainerRef={scrollRef}
+    />
+  );
+
+  fireEvent.click(screen.getByText("88", { selector: "text" }));
+  expect(
+    screen.getByRole("dialog", { name: "Wave score details" })
+  ).toBeInTheDocument();
+  expect(screen.getByText("Quiet Discovery")).toBeInTheDocument();
+  expect(screen.getByText("No messages yet")).toBeInTheDocument();
 });
 
 it("caps highly rated previews at ten without rendering an overflow control", () => {

--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import userEvent from "@testing-library/user-event";
 import {
   act,
   fireEvent,
@@ -442,13 +443,16 @@ it("uses highly rated preview score semantics instead of unread badges", () => {
   expect(
     screen.getByRole("link", { name: "Open Scored Discovery, score 93" })
   ).toBeInTheDocument();
+  const scoreDetailsButton = screen.getByRole("button", {
+    name: "Open Scored Discovery score details, score 93",
+  });
   const scoreBadgeText = screen.getByText("93", { selector: "text" });
   expect(scoreBadgeText).toBeInTheDocument();
-  expect(scoreBadgeText.closest("span")).toHaveClass("-tw-bottom-1");
-  expect(scoreBadgeText.closest("span")).toHaveClass("-tw-right-1.5");
-  expect(scoreBadgeText.closest("span")).toHaveClass("tw-h-6");
-  expect(scoreBadgeText.closest("span")).toHaveClass("tw-w-7");
-  expect(scoreBadgeText.closest("span")).toHaveAttribute("aria-hidden", "true");
+  expect(scoreBadgeText.closest("button")).toBe(scoreDetailsButton);
+  expect(scoreDetailsButton).toHaveClass("-tw-bottom-1");
+  expect(scoreDetailsButton).toHaveClass("-tw-right-1.5");
+  expect(scoreDetailsButton).toHaveClass("tw-h-6");
+  expect(scoreDetailsButton).toHaveClass("tw-w-7");
   expect(scoreBadgeText.closest("svg")).toHaveClass("tw-h-5");
   expect(scoreBadgeText.closest("svg")).toHaveClass("tw-w-6");
   fireEvent.click(
@@ -457,7 +461,7 @@ it("uses highly rated preview score semantics instead of unread badges", () => {
   expect(
     screen.queryByRole("dialog", { name: "Wave score details" })
   ).not.toBeInTheDocument();
-  fireEvent.click(scoreBadgeText);
+  fireEvent.click(scoreDetailsButton);
   expect(
     screen.getByRole("dialog", { name: "Wave score details" })
   ).toBeInTheDocument();
@@ -508,12 +512,52 @@ it("uses no-message copy in the combined highly rated score card", () => {
     />
   );
 
-  fireEvent.click(screen.getByText("88", { selector: "text" }));
+  fireEvent.click(
+    screen.getByRole("button", {
+      name: "Open Quiet Discovery score details, score 88",
+    })
+  );
   expect(
     screen.getByRole("dialog", { name: "Wave score details" })
   ).toBeInTheDocument();
   expect(screen.getByText("Quiet Discovery")).toBeInTheDocument();
   expect(screen.getByText("No messages yet")).toBeInTheDocument();
+});
+
+it("opens the combined highly rated score card from keyboard score activation", async () => {
+  const user = userEvent.setup();
+  render(
+    <UnifiedWavesListWaves
+      waves={[
+        createMockMinimalWave({
+          id: "h-score-keyboard",
+          name: "Keyboard Discovery",
+          type: ApiWaveType.Rank,
+          sidebarSection: "highly-rated",
+          waveScore: {
+            visibility_score: 86,
+            quality_score: 90,
+            hotness_score: 70,
+            rep_sort_score: 64,
+          } as any,
+        }),
+      ]}
+      onHover={jest.fn()}
+      scrollContainerRef={scrollRef}
+    />
+  );
+
+  screen
+    .getByRole("button", {
+      name: "Open Keyboard Discovery score details, score 86",
+    })
+    .focus();
+  await user.keyboard("{Enter}");
+
+  expect(
+    await screen.findByRole("dialog", { name: "Wave score details" })
+  ).toBeInTheDocument();
+  expect(screen.getByText("Keyboard Discovery")).toBeInTheDocument();
 });
 
 it("caps highly rated previews at ten without rendering an overflow control", () => {

--- a/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx
@@ -429,6 +429,8 @@ it("renders announcement, highly rated preview, pinned, and one filterable botto
 });
 
 it("uses highly rated preview score semantics instead of unread badges", () => {
+  const latestDropTimestamp = Date.now() - 60 * 60 * 1000;
+
   render(
     <UnifiedWavesListWaves
       waves={[
@@ -440,7 +442,7 @@ it("uses highly rated preview score semantics instead of unread badges", () => {
           unreadDropsCount: 24,
           newDropsCount: {
             count: 99,
-            latestDropTimestamp: 123,
+            latestDropTimestamp,
             firstUnreadSerialNo: 42,
           },
           waveScore: {
@@ -471,6 +473,9 @@ it("uses highly rated preview score semantics instead of unread badges", () => {
   expect(
     screen.getByRole("dialog", { name: "Wave score details" })
   ).toBeInTheDocument();
+  expect(screen.getByText("Scored Discovery")).toBeInTheDocument();
+  expect(screen.getByText("Last message")).toBeInTheDocument();
+  expect(screen.getByText("1h")).toBeInTheDocument();
   expect(screen.getByText("Quality")).toBeInTheDocument();
   expect(screen.getByText("Hotness")).toBeInTheDocument();
   expect(screen.getByText("Wave REP")).toBeInTheDocument();

--- a/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
+++ b/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
@@ -19,14 +19,6 @@ const PREVIEW_TOUCH_THUMBNAIL_WIDTH_PX = 44;
 const PREVIEW_GAP_PX = 6;
 const PREVIEW_TOUCH_GAP_PX = 8;
 type PreviewTooltipAlignment = "start" | "center" | "end";
-const PREVIEW_TOOLTIP_ALIGNMENT_CLASSNAMES: Record<
-  PreviewTooltipAlignment,
-  string
-> = {
-  start: "tw-left-0 tw-translate-x-0",
-  center: "tw-left-1/2 -tw-translate-x-1/2",
-  end: "tw-right-0 tw-translate-x-0",
-};
 
 export interface HighlyRatedWavePreviewItem {
   readonly wave: MinimalWave;
@@ -161,6 +153,13 @@ const getScoreBadgeFontSize = (scoreLabel: string) => {
   return 9.2;
 };
 
+const getLatestDropTimestamp = (wave: MinimalWave): number | null =>
+  wave.newDropsCount.latestDropTimestamp !== null &&
+  wave.newDropsCount.latestDropTimestamp !== 0 &&
+  Number.isFinite(wave.newDropsCount.latestDropTimestamp)
+    ? wave.newDropsCount.latestDropTimestamp
+    : null;
+
 export const getFittingPreviewCount = ({
   isTouchPreview = false,
   itemCount,
@@ -263,85 +262,68 @@ function HighlyRatedWavePreviewScoreBadge({
   isTouchPreview,
   onMouseEnter,
   scoreLabel,
-  wave,
 }: {
   readonly isTouchPreview: boolean;
   readonly onMouseEnter?: (() => void) | undefined;
   readonly scoreLabel: string | null;
-  readonly wave: MinimalWave;
 }) {
   if (scoreLabel === null) {
     return null;
   }
 
   return (
-    <WaveScoreSummaryHoverCard
-      closeOnContentClick
-      stopClickPropagation
-      triggerDisplay="inline-flex"
-      waveRep={wave.waveRep}
-      waveScore={wave.waveScore}
+    <button
+      type="button"
+      aria-label={t(SIDEBAR_LOCALE, "waves.sidebar.highlyRatedPreviewScore", {
+        score: scoreLabel,
+      })}
+      onMouseEnter={onMouseEnter}
+      className={`tw-absolute ${isTouchPreview ? "-tw-bottom-1.5 -tw-right-2" : "-tw-bottom-1 -tw-right-1.5"} tw-z-20 tw-inline-flex tw-h-6 tw-w-7 tw-items-center tw-justify-center tw-overflow-visible tw-border-0 tw-bg-transparent tw-p-0 tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-1 focus-visible:tw-outline-primary-400`}
     >
-      <button
-        type="button"
-        aria-label={t(SIDEBAR_LOCALE, "waves.sidebar.highlyRatedPreviewScore", {
-          score: scoreLabel,
-        })}
-        onMouseEnter={onMouseEnter}
-        className={`tw-absolute ${isTouchPreview ? "-tw-bottom-1.5 -tw-right-2" : "-tw-bottom-1 -tw-right-1.5"} tw-z-20 tw-inline-flex tw-h-6 tw-w-7 tw-items-center tw-justify-center tw-overflow-visible tw-border-0 tw-bg-transparent tw-p-0 tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-1 focus-visible:tw-outline-primary-400`}
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 32 26"
+        className={`tw-pointer-events-none ${isTouchPreview ? "tw-h-6 tw-w-7" : "tw-h-5 tw-w-6"} tw-overflow-visible`}
       >
-        <svg
-          aria-hidden="true"
-          viewBox="0 0 32 26"
-          className={`tw-pointer-events-none ${isTouchPreview ? "tw-h-6 tw-w-7" : "tw-h-5 tw-w-6"} tw-overflow-visible`}
+        <path
+          d="M16 2.15 28 6.15v6.7c0 5.45-4.35 9.5-12 11.2-7.65-1.7-12-5.75-12-11.2v-6.7L16 2.15Z"
+          className="tw-fill-iron-800 tw-stroke-iron-950"
+          strokeWidth="2.4"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M16 4.7 25.35 7.75v5.1c0 4.15-3.2 7.15-9.35 8.75-6.15-1.6-9.35-4.6-9.35-8.75v-5.1L16 4.7Z"
+          className="tw-fill-none tw-stroke-white/20"
+          strokeWidth="1"
+          strokeLinejoin="round"
+        />
+        <text
+          x="16"
+          y="13.2"
+          dominantBaseline="middle"
+          textAnchor="middle"
+          fontSize={getScoreBadgeFontSize(scoreLabel)}
+          fontWeight="700"
+          className="tw-fill-iron-50"
         >
-          <path
-            d="M16 2.15 28 6.15v6.7c0 5.45-4.35 9.5-12 11.2-7.65-1.7-12-5.75-12-11.2v-6.7L16 2.15Z"
-            className="tw-fill-iron-800 tw-stroke-iron-950"
-            strokeWidth="2.4"
-            strokeLinejoin="round"
-          />
-          <path
-            d="M16 4.7 25.35 7.75v5.1c0 4.15-3.2 7.15-9.35 8.75-6.15-1.6-9.35-4.6-9.35-8.75v-5.1L16 4.7Z"
-            className="tw-fill-none tw-stroke-white/20"
-            strokeWidth="1"
-            strokeLinejoin="round"
-          />
-          <text
-            x="16"
-            y="13.2"
-            dominantBaseline="middle"
-            textAnchor="middle"
-            fontSize={getScoreBadgeFontSize(scoreLabel)}
-            fontWeight="700"
-            className="tw-fill-iron-50"
-          >
-            {scoreLabel}
-          </text>
-        </svg>
-      </button>
-    </WaveScoreSummaryHoverCard>
+          {scoreLabel}
+        </text>
+      </svg>
+    </button>
   );
 }
 
 function HighlyRatedWavePreviewLink({
   isTouchPreview,
   item,
-  tooltipAlignment,
 }: {
   readonly isTouchPreview: boolean;
   readonly item: HighlyRatedWavePreviewItem;
-  readonly tooltipAlignment: PreviewTooltipAlignment;
 }) {
   const { wave } = item;
   const isDropWave = wave.type !== ApiWaveType.Chat;
   const scoreLabel = getWaveScoreLabel(wave);
-  const latestDropTimestamp =
-    wave.newDropsCount.latestDropTimestamp !== null &&
-    wave.newDropsCount.latestDropTimestamp !== 0 &&
-    Number.isFinite(wave.newDropsCount.latestDropTimestamp)
-      ? wave.newDropsCount.latestDropTimestamp
-      : null;
+  const latestDropTimestamp = getLatestDropTimestamp(wave);
   const linkLabel =
     scoreLabel === null
       ? t(
@@ -359,70 +341,63 @@ function HighlyRatedWavePreviewLink({
             score: scoreLabel,
           }
         );
+  const handleLinkClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    item.onClick(event);
+    event.stopPropagation();
+  };
 
   return (
-    <span
-      className={`tw-relative tw-flex ${isTouchPreview ? "tw-size-11" : "tw-size-8"} tw-flex-shrink-0 tw-items-center tw-justify-center`}
+    <WaveScoreSummaryHoverCard
+      closeOnContentClick
+      stopClickPropagation
+      summaryHeader={{
+        title: wave.name,
+        meta:
+          latestDropTimestamp === null ? (
+            <span>
+              {t(SIDEBAR_LOCALE, "waves.score.summary.noMessagesYet")}
+            </span>
+          ) : (
+            <>
+              <span>
+                {t(SIDEBAR_LOCALE, "waves.score.summary.lastMessage")}
+              </span>
+              <BrainLeftSidebarWaveDropTime time={latestDropTimestamp} />
+            </>
+          ),
+      }}
+      triggerDisplay="inline-flex"
+      waveRep={wave.waveRep}
+      waveScore={wave.waveScore}
     >
-      <Link
-        href={item.href}
-        prefetch={false}
-        aria-label={linkLabel}
-        onClick={item.onClick}
-        {...(item.onMouseEnter ? { onMouseEnter: item.onMouseEnter } : {})}
-        className={`tw-group/preview tw-flex ${isTouchPreview ? "tw-size-11" : "tw-size-8"} tw-items-center tw-justify-center tw-rounded-full tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400`}
+      <span
+        className={`tw-relative tw-flex ${isTouchPreview ? "tw-size-11" : "tw-size-8"} tw-flex-shrink-0 tw-items-center tw-justify-center`}
       >
-        <WaveAvatar
-          dropBadgePlacement="bottom-left"
-          isActive={item.isActive}
-          isDropWave={isDropWave}
-          showNewDropsBadge={false}
-          showUnreadDropsBadge={false}
-          size={isTouchPreview ? "lg" : "default"}
-          wave={wave}
-        />
-        <span
-          className={`tw-pointer-events-none tw-absolute ${isTouchPreview ? "tw-top-12" : "tw-top-10"} tw-z-30 tw-hidden tw-w-48 tw-rounded-md tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-px-2.5 tw-py-2 tw-text-left tw-shadow-xl group-hover/preview:tw-block group-focus-visible/preview:tw-block ${PREVIEW_TOOLTIP_ALIGNMENT_CLASSNAMES[tooltipAlignment]}`}
+        <Link
+          href={item.href}
+          prefetch={false}
+          aria-label={linkLabel}
+          onClick={handleLinkClick}
+          {...(item.onMouseEnter ? { onMouseEnter: item.onMouseEnter } : {})}
+          className={`tw-group/preview tw-flex ${isTouchPreview ? "tw-size-11" : "tw-size-8"} tw-items-center tw-justify-center tw-rounded-full tw-no-underline focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400`}
         >
-          <span className="tw-block tw-truncate tw-text-xs tw-font-semibold tw-text-iron-100">
-            {wave.name}
-          </span>
-          <span className="tw-mt-1 tw-flex tw-items-center tw-gap-2 tw-text-[11px] tw-text-iron-400">
-            {latestDropTimestamp !== null && (
-              <span className="tw-whitespace-nowrap">
-                <BrainLeftSidebarWaveDropTime time={latestDropTimestamp} />
-              </span>
-            )}
-            {scoreLabel !== null && (
-              <span className="tw-ml-auto tw-inline-flex tw-items-center tw-gap-1 tw-whitespace-nowrap">
-                <svg
-                  className="tw-size-3 tw-flex-shrink-0 tw-text-iron-400"
-                  viewBox="0 0 32 26"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="M16 2.4 27.3 6.2v6.65c0 5.25-4.1 9.15-11.3 10.85-7.2-1.7-11.3-5.6-11.3-10.85V6.2L16 2.4Z"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2.2"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-                {t(SIDEBAR_LOCALE, "waves.sidebar.highlyRatedPreviewScore", {
-                  score: scoreLabel,
-                })}
-              </span>
-            )}
-          </span>
-        </span>
-      </Link>
-      <HighlyRatedWavePreviewScoreBadge
-        isTouchPreview={isTouchPreview}
-        onMouseEnter={item.onMouseEnter}
-        scoreLabel={scoreLabel}
-        wave={wave}
-      />
-    </span>
+          <WaveAvatar
+            dropBadgePlacement="bottom-left"
+            isActive={item.isActive}
+            isDropWave={isDropWave}
+            showNewDropsBadge={false}
+            showUnreadDropsBadge={false}
+            size={isTouchPreview ? "lg" : "default"}
+            wave={wave}
+          />
+        </Link>
+        <HighlyRatedWavePreviewScoreBadge
+          isTouchPreview={isTouchPreview}
+          onMouseEnter={item.onMouseEnter}
+          scoreLabel={scoreLabel}
+        />
+      </span>
+    </WaveScoreSummaryHoverCard>
   );
 }
 
@@ -496,15 +471,11 @@ export function HighlyRatedWavesToggle({
         ref={previewStripRef}
         className={`tw-flex tw-min-w-0 tw-items-center tw-justify-between ${isTouchPreview ? "tw-gap-x-2" : "tw-gap-x-1.5"}`}
       >
-        {visiblePreviewItems.map((item, index) => (
+        {visiblePreviewItems.map((item) => (
           <HighlyRatedWavePreviewLink
             isTouchPreview={isTouchPreview}
             key={item.wave.id}
             item={item}
-            tooltipAlignment={getHighlyRatedPreviewTooltipAlignment({
-              index,
-              itemCount: visiblePreviewItems.length,
-            })}
           />
         ))}
       </div>

--- a/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
+++ b/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
@@ -240,11 +240,15 @@ export const getVisibleHighlyRatedPreviewItems = ({
 };
 
 function HighlyRatedWavePreviewScoreBadge({
+  ariaLabel,
   isTouchPreview,
+  onClick,
   onMouseEnter,
   scoreLabel,
 }: {
+  readonly ariaLabel: string;
   readonly isTouchPreview: boolean;
+  readonly onClick: () => void;
   readonly onMouseEnter?: (() => void) | undefined;
   readonly scoreLabel: string | null;
 }) {
@@ -253,10 +257,12 @@ function HighlyRatedWavePreviewScoreBadge({
   }
 
   return (
-    <span
-      aria-hidden="true"
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      onClick={onClick}
       onMouseEnter={onMouseEnter}
-      className={`tw-absolute ${isTouchPreview ? "-tw-bottom-1.5 -tw-right-2" : "-tw-bottom-1 -tw-right-1.5"} tw-z-20 tw-inline-flex tw-h-6 tw-w-7 tw-cursor-help tw-items-center tw-justify-center tw-overflow-visible tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)]`}
+      className={`tw-absolute ${isTouchPreview ? "-tw-bottom-1.5 -tw-right-2" : "-tw-bottom-1 -tw-right-1.5"} tw-z-20 tw-inline-flex tw-h-6 tw-w-7 tw-cursor-help tw-appearance-none tw-items-center tw-justify-center tw-overflow-visible tw-border-0 tw-bg-transparent tw-p-0 tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-1 focus-visible:tw-outline-primary-400`}
     >
       <svg
         aria-hidden="true"
@@ -287,7 +293,7 @@ function HighlyRatedWavePreviewScoreBadge({
           {scoreLabel}
         </text>
       </svg>
-    </span>
+    </button>
   );
 }
 
@@ -319,13 +325,22 @@ function HighlyRatedWavePreviewLink({
             score: scoreLabel,
           }
         );
+  const scoreDetailsLabel =
+    scoreLabel === null
+      ? null
+      : t(SIDEBAR_LOCALE, "waves.score.summary.openDetailsAriaLabel", {
+          waveName: wave.name,
+          score: scoreLabel,
+        });
   const handleLinkClick = (event: MouseEvent<HTMLAnchorElement>) => {
-    const shouldKeepClickOnLink =
-      event.defaultPrevented || isModifiedAnchorClick(event);
     item.onClick(event);
-    if (shouldKeepClickOnLink || event.defaultPrevented) {
+    if (event.defaultPrevented || isModifiedAnchorClick(event)) {
       event.stopPropagation();
     }
+  };
+  const handleScoreBadgeClick = () => {
+    // Keep the click bubbling into WaveScoreSummaryHoverCard so touch, mouse, and keyboard use the shared card state.
+    item.onMouseEnter?.();
   };
 
   return (
@@ -373,11 +388,15 @@ function HighlyRatedWavePreviewLink({
             wave={wave}
           />
         </Link>
-        <HighlyRatedWavePreviewScoreBadge
-          isTouchPreview={isTouchPreview}
-          onMouseEnter={item.onMouseEnter}
-          scoreLabel={scoreLabel}
-        />
+        {scoreDetailsLabel !== null && (
+          <HighlyRatedWavePreviewScoreBadge
+            ariaLabel={scoreDetailsLabel}
+            isTouchPreview={isTouchPreview}
+            onClick={handleScoreBadgeClick}
+            onMouseEnter={item.onMouseEnter}
+            scoreLabel={scoreLabel}
+          />
+        )}
       </span>
     </WaveScoreSummaryHoverCard>
   );

--- a/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
+++ b/components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx
@@ -18,7 +18,6 @@ const PREVIEW_THUMBNAIL_WIDTH_PX = 32;
 const PREVIEW_TOUCH_THUMBNAIL_WIDTH_PX = 44;
 const PREVIEW_GAP_PX = 6;
 const PREVIEW_TOUCH_GAP_PX = 8;
-type PreviewTooltipAlignment = "start" | "center" | "end";
 
 export interface HighlyRatedWavePreviewItem {
   readonly wave: MinimalWave;
@@ -240,24 +239,6 @@ export const getVisibleHighlyRatedPreviewItems = ({
   ];
 };
 
-export const getHighlyRatedPreviewTooltipAlignment = ({
-  index,
-  itemCount,
-}: {
-  readonly index: number;
-  readonly itemCount: number;
-}): PreviewTooltipAlignment => {
-  if (index <= 1) {
-    return "start";
-  }
-
-  if (itemCount >= 5 && index >= itemCount - 2) {
-    return "end";
-  }
-
-  return "center";
-};
-
 function HighlyRatedWavePreviewScoreBadge({
   isTouchPreview,
   onMouseEnter,
@@ -272,13 +253,10 @@ function HighlyRatedWavePreviewScoreBadge({
   }
 
   return (
-    <button
-      type="button"
-      aria-label={t(SIDEBAR_LOCALE, "waves.sidebar.highlyRatedPreviewScore", {
-        score: scoreLabel,
-      })}
+    <span
+      aria-hidden="true"
       onMouseEnter={onMouseEnter}
-      className={`tw-absolute ${isTouchPreview ? "-tw-bottom-1.5 -tw-right-2" : "-tw-bottom-1 -tw-right-1.5"} tw-z-20 tw-inline-flex tw-h-6 tw-w-7 tw-items-center tw-justify-center tw-overflow-visible tw-border-0 tw-bg-transparent tw-p-0 tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)] focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-1 focus-visible:tw-outline-primary-400`}
+      className={`tw-absolute ${isTouchPreview ? "-tw-bottom-1.5 -tw-right-2" : "-tw-bottom-1 -tw-right-1.5"} tw-z-20 tw-inline-flex tw-h-6 tw-w-7 tw-cursor-help tw-items-center tw-justify-center tw-overflow-visible tw-drop-shadow-[0_5px_9px_rgba(0,0,0,0.50)]`}
     >
       <svg
         aria-hidden="true"
@@ -309,7 +287,7 @@ function HighlyRatedWavePreviewScoreBadge({
           {scoreLabel}
         </text>
       </svg>
-    </button>
+    </span>
   );
 }
 
@@ -342,8 +320,12 @@ function HighlyRatedWavePreviewLink({
           }
         );
   const handleLinkClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    const shouldKeepClickOnLink =
+      event.defaultPrevented || isModifiedAnchorClick(event);
     item.onClick(event);
-    event.stopPropagation();
+    if (shouldKeepClickOnLink || event.defaultPrevented) {
+      event.stopPropagation();
+    }
   };
 
   return (

--- a/components/waves/WaveTrustSignals.tsx
+++ b/components/waves/WaveTrustSignals.tsx
@@ -18,6 +18,10 @@ type WaveTrustSignalsVariant =
   | "sidebar-inline"
   | "header-inline";
 type WaveTrustSignalsMode = "details" | "summary";
+interface WaveScoreSummaryHeader {
+  readonly title: ReactNode;
+  readonly meta?: ReactNode | undefined;
+}
 
 interface WaveTrustSignalsProps {
   readonly waveRep?: ApiWaveRepSummary | null | undefined;
@@ -484,6 +488,7 @@ const buildRepDetails = ({
 
 function WaveScoreSummaryPopoverContent({
   learnMoreHref,
+  summaryHeader,
   visibilityScore,
   qualityScore,
   hotnessScore,
@@ -491,6 +496,7 @@ function WaveScoreSummaryPopoverContent({
   waveRep,
 }: {
   readonly learnMoreHref?: string | undefined;
+  readonly summaryHeader?: WaveScoreSummaryHeader | undefined;
   readonly visibilityScore: string;
   readonly qualityScore: string | null;
   readonly hotnessScore: string | null;
@@ -543,7 +549,21 @@ function WaveScoreSummaryPopoverContent({
   ];
 
   return (
-    <div className="tw-w-48 tw-bg-transparent tw-text-left tw-text-[11px] tw-leading-4 tw-text-iron-300">
+    <div
+      className={`${summaryHeader === undefined ? "tw-w-48" : "tw-w-64"} tw-bg-transparent tw-text-left tw-text-[11px] tw-leading-4 tw-text-iron-300`}
+    >
+      {summaryHeader !== undefined && (
+        <div className="tw-mb-2 tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-white/10 tw-pb-2">
+          <div className="tw-truncate tw-text-sm tw-font-semibold tw-leading-5 tw-text-white">
+            {summaryHeader.title}
+          </div>
+          {summaryHeader.meta !== undefined && (
+            <div className="tw-mt-0.5 tw-flex tw-items-center tw-gap-1.5 tw-text-[11px] tw-leading-4 tw-text-iron-400">
+              {summaryHeader.meta}
+            </div>
+          )}
+        </div>
+      )}
       <div className="tw-flex tw-items-baseline tw-justify-between tw-gap-3">
         <span className="tw-font-semibold tw-text-white">
           {t(WAVE_TRUST_LOCALE, "waves.score.summary.title")}
@@ -586,6 +606,7 @@ export function WaveScoreSummaryHoverCard({
   closeOnContentClick,
   learnMoreHref,
   stopClickPropagation,
+  summaryHeader,
   triggerDisplay,
   waveRep,
   waveScore,
@@ -594,6 +615,7 @@ export function WaveScoreSummaryHoverCard({
   readonly closeOnContentClick?: boolean | undefined;
   readonly learnMoreHref?: string | undefined;
   readonly stopClickPropagation?: boolean | undefined;
+  readonly summaryHeader?: WaveScoreSummaryHeader | undefined;
   readonly triggerDisplay?: "contents" | "inline-flex" | undefined;
   readonly waveRep: ApiWaveRepSummary | null | undefined;
   readonly waveScore: ApiWaveScore | null | undefined;
@@ -623,6 +645,7 @@ export function WaveScoreSummaryHoverCard({
       content={
         <WaveScoreSummaryPopoverContent
           learnMoreHref={learnMoreHref}
+          summaryHeader={summaryHeader}
           visibilityScore={visibilityScore}
           qualityScore={qualityScore}
           hotnessScore={hotnessScore}

--- a/components/waves/WaveTrustSignals.tsx
+++ b/components/waves/WaveTrustSignals.tsx
@@ -19,7 +19,7 @@ type WaveTrustSignalsVariant =
   | "header-inline";
 type WaveTrustSignalsMode = "details" | "summary";
 interface WaveScoreSummaryHeader {
-  readonly title: ReactNode;
+  readonly title: string;
   readonly meta?: ReactNode | undefined;
 }
 
@@ -554,7 +554,10 @@ function WaveScoreSummaryPopoverContent({
     >
       {summaryHeader !== undefined && (
         <div className="tw-mb-2 tw-border-x-0 tw-border-b tw-border-t-0 tw-border-solid tw-border-white/10 tw-pb-2">
-          <div className="tw-truncate tw-text-sm tw-font-semibold tw-leading-5 tw-text-white">
+          <div
+            className="tw-truncate tw-text-sm tw-font-semibold tw-leading-5 tw-text-white"
+            title={summaryHeader.title}
+          >
             {summaryHeader.title}
           </div>
           {summaryHeader.meta !== undefined && (

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -409,6 +409,7 @@ const WAVE_SCORE_SUMMARY_MESSAGES = objectMessages("waves.score.summary", {
   waveRep: "Wave REP",
   learnMore: "Learn more",
   detailsAriaLabel: "Wave score details",
+  openDetailsAriaLabel: "Open {waveName} score details, score {score}",
   scoreAria: "Wave score {visibilityScore}",
   qualityAria: "Quality {qualityScore}, 65% of visibility",
   hotnessAria: "Hotness {hotnessScore}, gated, 35% of visibility",

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -419,6 +419,8 @@ const WAVE_SCORE_SUMMARY_MESSAGES = objectMessages("waves.score.summary", {
   hotnessValue: "{hotnessScore} / 35% gated",
   repRawAndScoreValue: "{rawRep} / score {repSortScore}",
   repScoreValue: "score {repSortScore}",
+  lastMessage: "Last message",
+  noMessagesYet: "No messages yet",
 } as const);
 
 const WAVE_SCORE_DETAILS_MESSAGES = objectMessages("waves.score.details", {


### PR DESCRIPTION
## Issue
- Worth Checking Out preview bubbles had two hover targets: the avatar/link showed wave name and recency, while the score badge showed the score breakdown.
- The split made it unclear which card would open, especially around the overlapping avatar and score badge area.

## Fix
- Reuse the existing Wave Score hover card as the single card for Worth Checking Out previews.
- Add an optional header to the score card so the same popover can show the wave name and last-message recency above the existing score breakdown.
- Keep the wave link click isolated from the card click handler, while keeping the score badge as the explicit click target for touch/mobile use.

## Changes
- Removed the separate inline avatar tooltip from the Worth Checking Out preview bubble.
- Wrapped the whole preview bubble in the score hover card so desktop hover anywhere on the bubble opens the unified card.
- Added message-backed labels for the score-card header metadata.
- Extended the focused left-sidebar wave list test to assert wave name, last-message recency, and score breakdown in the same card.

## Validation
- `6529 run test -- __tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx --runInBand`
- `6529 exec eslint --no-warn-ignored --max-warnings=0 components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx components/waves/WaveTrustSignals.tsx i18n/messages/en-US.ts __tests__/components/brain/left-sidebar/waves/UnifiedWavesListWaves.test.tsx`
- `6529 run lint:changed`
- `6529 run typecheck:changed`
- `6529 run check:changed`
- `6529 run react-doctor:diff` exited successfully; the tool reported no changed source files for its own diff scan.
- Local Playwright browser smoke was attempted against `/waves`, but the local dev session redirected to `/access` because no local `STAGING_API_KEY`/access session was available. The target Worth Checking Out strip was not visually inspected in-browser.

## Risk
- Level: Low
- Why: Frontend-only popover composition change, no API/data-shape changes, no backend deployment dependency.
- Rollback: Revert this PR to restore the prior split avatar tooltip and score popover behavior.

## Review Notes
- UI pattern reused: existing `WaveScoreSummaryHoverCard`, Tailwind `tw-` sidebar/avatar patterns, and existing last-drop timestamp component.
- Deployment order: no backend change required; frontend can deploy independently. For staging, merge this branch to `1a-staging` after PR checks/bots are handled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the wave score preview with clearer score details, including a dedicated details button and keyboard support.
  * Added richer score summary content, showing the latest activity time or a “No messages yet” state when applicable.

* **Bug Fixes**
  * Updated hover and click behavior so score details open more reliably across mouse and keyboard interactions.
  * Refined tooltip and preview behavior for more consistent display and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->