### PR TITLE
Fix My Votes leaderboard sort direction

### DIFF
--- a/__tests__/hooks/useWaveDropsLeaderboard.extra.test.ts
+++ b/__tests__/hooks/useWaveDropsLeaderboard.extra.test.ts
@@ -85,6 +85,30 @@ describe("useWaveDropsLeaderboard extra", () => {
     expect(call.queryKey[1].sort).toBe(WaveDropsLeaderboardSort.CREATED_AT);
   });
 
+  it("requests my realtime votes in descending order", async () => {
+    renderHook(() =>
+      useWaveDropsLeaderboard({
+        waveId: "2",
+        sort: WaveDropsLeaderboardSort.MY_REALTIME_VOTE,
+      })
+    );
+
+    const call = getMainQueryOptions();
+    expect(call.queryKey[1].sort_direction).toBe("DESC");
+
+    await call.queryFn({ pageParam: null });
+
+    expect(commonApiFetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: "v2/waves/2/leaderboard",
+        params: expect.objectContaining({
+          sort: WaveDropsLeaderboardSort.MY_REALTIME_VOTE,
+          sort_direction: "DESC",
+        }),
+      })
+    );
+  });
+
   it("does not prefetch or start a polling query on mount", () => {
     renderHook(() => useWaveDropsLeaderboard({ waveId: "2" }));
 

--- a/hooks/useWaveDropsLeaderboard.ts
+++ b/hooks/useWaveDropsLeaderboard.ts
@@ -43,7 +43,7 @@ const SORT_DIRECTION_MAP: Record<
   [WaveDropsLeaderboardSort.REALTIME_VOTE]: "DESC",
   [WaveDropsLeaderboardSort.RATING_PREDICTION]: "DESC",
   [WaveDropsLeaderboardSort.TREND]: "DESC",
-  [WaveDropsLeaderboardSort.MY_REALTIME_VOTE]: undefined,
+  [WaveDropsLeaderboardSort.MY_REALTIME_VOTE]: "DESC",
   [WaveDropsLeaderboardSort.CREATED_AT]: "DESC",
 };
 


### PR DESCRIPTION
## Issue
- The My Votes tab requested `sort=MY_REALTIME_VOTE` without an explicit `sort_direction`, so the API defaulted to ascending and showed the user's lowest-voted drops first.

## Fix
- Send `sort_direction=DESC` for `MY_REALTIME_VOTE`, matching the expected highest-to-lowest vote order in My Votes.

## Changes
- Updated the wave drops leaderboard hook sort-direction map.
- Added a focused hook test that verifies My Votes requests `sort_direction=DESC` and includes that direction in the React Query key.
- Frontend-only change; no backend/API contract change required.

## Validation
- `./bin/6529 run test -- __tests__/hooks/useWaveDropsLeaderboard.extra.test.ts`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run check:changed`
- `./bin/6529 run react-doctor:diff` before commit scanned the two changed source files and reported no issues; after commit the wrapper had no uncommitted diff to scan.

## Risk
- Level: Low
- Why: Narrow request-parameter change for one existing sort mode, covered by a focused hook test.
- Rollback: Revert this commit to restore the previous API request behavior.

## Review Notes
- Please verify the My Votes tab now requests `sort_direction=DESC` with `sort=MY_REALTIME_VOTE`.
