### PR TITLE
[codex] Make dev origins configurable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -31,6 +31,10 @@ MOBILE_APP_SCHEME=
 # 6529 CORE SCHEME
 CORE_SCHEME=core6529
 
+# NEXT.JS DEVELOPMENT ORIGINS (optional, comma-separated)
+# For machine-specific LAN hosts, set this in .env.development.local.
+NEXT_ALLOWED_DEV_ORIGINS=
+
 # IPFS ENDPOINTS
 IPFS_API_ENDPOINT=
 IPFS_GATEWAY_ENDPOINT=

--- a/config/nextConfig.ts
+++ b/config/nextConfig.ts
@@ -17,6 +17,15 @@ const SASS_LOAD_PATHS = [
 const BOOTSTRAP_PROGRESS_PARTIAL =
   "./node_modules/bootstrap/scss/_progress.scss";
 
+function getAllowedDevOrigins(): string[] {
+  return (
+    process.env["NEXT_ALLOWED_DEV_ORIGINS"]
+      ?.split(",")
+      .map((origin) => origin.trim())
+      .filter(Boolean) ?? []
+  );
+}
+
 export function sharedConfig(
   publicEnv: PublicEnv,
   assetPrefix: string
@@ -37,7 +46,7 @@ export function sharedConfig(
         "import",
       ],
     },
-    allowedDevOrigins: ["172.20.10.3", "192.168.1.77"],
+    allowedDevOrigins: getAllowedDevOrigins(),
     images: {
       loader: "default",
       remotePatterns: [


### PR DESCRIPTION
## What changed

- Replaced hard-coded `allowedDevOrigins` LAN IPs with a `NEXT_ALLOWED_DEV_ORIGINS` environment variable parser.
- Documented `NEXT_ALLOWED_DEV_ORIGINS` in `.env.sample` for local development use.

## Why

`allowedDevOrigins` is useful for device testing, such as opening the local dev server from an iPhone, but developer-specific LAN IPs should not live in tracked Next config.

## Impact

Developers who need LAN device testing can set a comma-separated value in an ignored local env file, for example `.env.development.local`. The shared config no longer exposes personal IP addresses.

## Validation

- `git diff --check`
- `./bin/6529 run typecheck:ci`
- Started `./bin/6529 run dev` and confirmed Next loaded `.env.development.local` and advertised the LAN URL.

## Review notes

- The local `.env.development.local` file with the machine-specific IP is intentionally ignored and not part of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional support for configuring allowed development origins via an environment variable.
  * Updated the sample environment file with guidance for setting machine-specific LAN hosts locally.

* **Bug Fixes**
  * Removed the need for a fixed list of development IP addresses by letting the app read allowed origins from configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->