### PR TITLE
[codex] Stop stale auth notification polling

### DIFF
--- a/__tests__/components/auth/SeizeConnectContext.switch-sync.test.tsx
+++ b/__tests__/components/auth/SeizeConnectContext.switch-sync.test.tsx
@@ -284,7 +284,9 @@ describe("SeizeConnectContext switch sync guard", () => {
       expect(mockUseConnectedAccountsUnreadNotifications).toHaveBeenCalledWith([
         inactiveAccount,
       ]);
-      expect(mockUseUnreadNotifications).toHaveBeenCalledWith("alice");
+      expect(mockUseUnreadNotifications).toHaveBeenCalledWith("alice", {
+        enabled: true,
+      });
     });
 
     const unreadMap = JSON.parse(
@@ -346,7 +348,9 @@ describe("SeizeConnectContext switch sync guard", () => {
         activeAccount,
         inactiveAccount,
       ]);
-      expect(mockUseUnreadNotifications).toHaveBeenCalledWith(null);
+      expect(mockUseUnreadNotifications).toHaveBeenCalledWith(null, {
+        enabled: false,
+      });
     });
 
     const unreadMap = JSON.parse(

--- a/__tests__/hooks/useConnectedAccountsUnreadNotifications.test.ts
+++ b/__tests__/hooks/useConnectedAccountsUnreadNotifications.test.ts
@@ -4,6 +4,8 @@ import { renderHook } from "@testing-library/react";
 
 const useQueryMock = jest.fn();
 const getQueryDataMock = jest.fn();
+const commonApiFetchMock = jest.fn();
+const isAuthJwtUsableMock = jest.fn();
 
 jest.mock("@tanstack/react-query", () => ({
   useQuery: (params: unknown) => useQueryMock(params),
@@ -18,13 +20,20 @@ jest.mock("@/hooks/useCapacitor", () => ({
 }));
 
 jest.mock("@/services/api/common-api", () => ({
-  commonApiFetch: jest.fn(),
+  commonApiFetch: (...args: unknown[]) => commonApiFetchMock(...args),
+}));
+
+jest.mock("@/services/auth/auth.utils", () => ({
+  isAuthJwtUsable: (...args: unknown[]) => isAuthJwtUsableMock(...args),
 }));
 
 describe("useConnectedAccountsUnreadNotifications", () => {
   beforeEach(() => {
     useQueryMock.mockReset();
     getQueryDataMock.mockReset();
+    commonApiFetchMock.mockReset();
+    isAuthJwtUsableMock.mockReset();
+    isAuthJwtUsableMock.mockReturnValue(true);
   });
 
   it("uses a separate query key from active identity notifications", () => {
@@ -53,5 +62,76 @@ describe("useConnectedAccountsUnreadNotifications", () => {
         ],
       })
     );
+  });
+
+  it("does not enable polling for accounts without usable JWTs", () => {
+    isAuthJwtUsableMock.mockReturnValue(false);
+    useQueryMock.mockReturnValue({ data: {} });
+
+    renderHook(() =>
+      useConnectedAccountsUnreadNotifications([
+        {
+          address: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          refreshToken: "refresh-token",
+          role: null,
+          jwt: "expired-jwt",
+          profileId: null,
+          profileHandle: "alice",
+        },
+      ])
+    );
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+        queryKey: [
+          QueryKey.CONNECTED_ACCOUNT_UNREAD_NOTIFICATIONS,
+          "connected-account-unread-counts",
+          "v2",
+          [],
+        ],
+      })
+    );
+  });
+
+  it("does not retry unauthorized connected-account notification failures", () => {
+    useQueryMock.mockReturnValue({ data: {} });
+
+    renderHook(() =>
+      useConnectedAccountsUnreadNotifications([
+        {
+          address: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          refreshToken: "refresh-token",
+          role: null,
+          jwt: "jwt-token",
+          profileId: null,
+          profileHandle: "alice",
+        },
+      ])
+    );
+
+    const queryOptions = useQueryMock.mock.calls[0]?.[0];
+    expect(queryOptions.retry(0, { status: 401 })).toBe(false);
+  });
+
+  it("surfaces unauthorized connected-account failures instead of hiding them as successful polling", async () => {
+    commonApiFetchMock.mockRejectedValue({ status: 401 });
+    useQueryMock.mockReturnValue({ data: {} });
+
+    renderHook(() =>
+      useConnectedAccountsUnreadNotifications([
+        {
+          address: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          refreshToken: "refresh-token",
+          role: null,
+          jwt: "jwt-token",
+          profileId: null,
+          profileHandle: "alice",
+        },
+      ])
+    );
+
+    const queryOptions = useQueryMock.mock.calls[0]?.[0];
+    await expect(queryOptions.queryFn()).rejects.toMatchObject({ status: 401 });
   });
 });

--- a/__tests__/hooks/useConnectedAccountsUnreadNotifications.test.ts
+++ b/__tests__/hooks/useConnectedAccountsUnreadNotifications.test.ts
@@ -134,4 +134,26 @@ describe("useConnectedAccountsUnreadNotifications", () => {
     const queryOptions = useQueryMock.mock.calls[0]?.[0];
     await expect(queryOptions.queryFn()).rejects.toMatchObject({ status: 401 });
   });
+
+  it("blocks connected-account fetches when the JWT expires between renders", async () => {
+    isAuthJwtUsableMock.mockReturnValueOnce(true).mockReturnValueOnce(false);
+    useQueryMock.mockReturnValue({ data: {} });
+
+    renderHook(() =>
+      useConnectedAccountsUnreadNotifications([
+        {
+          address: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          refreshToken: "refresh-token",
+          role: null,
+          jwt: "jwt-token",
+          profileId: null,
+          profileHandle: "alice",
+        },
+      ])
+    );
+
+    const queryOptions = useQueryMock.mock.calls[0]?.[0];
+    await expect(queryOptions.queryFn()).rejects.toMatchObject({ status: 401 });
+    expect(commonApiFetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/hooks/useUnreadNotifications.test.ts
+++ b/__tests__/hooks/useUnreadNotifications.test.ts
@@ -51,15 +51,19 @@ describe("useUnreadNotifications", () => {
   });
 
   it("does not start polling when caller disables the hook", () => {
-    useQueryMock.mockReturnValue({ data: undefined });
+    useQueryMock.mockReturnValue({ data: { unread_count: 2 } });
 
-    renderHook(() => useUnreadNotifications("bob", { enabled: false }));
+    const { result } = renderHook(() =>
+      useUnreadNotifications("bob", { enabled: false })
+    );
 
     expect(useQueryMock).toHaveBeenCalledWith(
       expect.objectContaining({
         enabled: false,
       })
     );
+    expect(result.current.notifications).toBeUndefined();
+    expect(result.current.haveUnreadNotifications).toBe(false);
   });
 
   it("does not start polling when the active auth token is missing or expired", () => {
@@ -82,6 +86,7 @@ describe("useUnreadNotifications", () => {
 
     const queryOptions = useQueryMock.mock.calls[0]?.[0];
     expect(queryOptions.retry(0, { status: 401 })).toBe(false);
+    expect(queryOptions.retry(0, new Error("temporary failure"))).toBe(true);
   });
 
   it("blocks polling before fetch when the token expires between renders", async () => {

--- a/__tests__/hooks/useUnreadNotifications.test.ts
+++ b/__tests__/hooks/useUnreadNotifications.test.ts
@@ -3,6 +3,9 @@ import { useUnreadNotifications } from "@/hooks/useUnreadNotifications";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 
 const useQueryMock = jest.fn();
+const commonApiFetchMock = jest.fn();
+const getAuthJwtMock = jest.fn();
+const isAuthJwtUsableMock = jest.fn();
 jest.mock("@tanstack/react-query", () => ({
   useQuery: (...args: any[]) => useQueryMock(...args),
 }));
@@ -12,11 +15,23 @@ jest.mock("@/hooks/useCapacitor", () => ({
   default: () => ({ isCapacitor: false }),
 }));
 
-jest.mock("@/services/api/common-api", () => ({ commonApiFetch: jest.fn() }));
+jest.mock("@/services/api/common-api", () => ({
+  commonApiFetch: (...args: unknown[]) => commonApiFetchMock(...args),
+}));
+
+jest.mock("@/services/auth/auth.utils", () => ({
+  getAuthJwt: () => getAuthJwtMock(),
+  isAuthJwtUsable: (...args: unknown[]) => isAuthJwtUsableMock(...args),
+}));
 
 describe("useUnreadNotifications", () => {
   beforeEach(() => {
     useQueryMock.mockReset();
+    commonApiFetchMock.mockReset();
+    getAuthJwtMock.mockReset();
+    isAuthJwtUsableMock.mockReset();
+    getAuthJwtMock.mockReturnValue("valid-jwt");
+    isAuthJwtUsableMock.mockReturnValue(true);
   });
 
   it("returns unread when notifications have count", () => {
@@ -33,6 +48,51 @@ describe("useUnreadNotifications", () => {
     );
     expect(result.current.haveUnreadNotifications).toBe(true);
     expect(result.current.notifications).toEqual({ unread_count: 2 });
+  });
+
+  it("does not start polling when caller disables the hook", () => {
+    useQueryMock.mockReturnValue({ data: undefined });
+
+    renderHook(() => useUnreadNotifications("bob", { enabled: false }));
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+      })
+    );
+  });
+
+  it("does not start polling when the active auth token is missing or expired", () => {
+    isAuthJwtUsableMock.mockReturnValue(false);
+    useQueryMock.mockReturnValue({ data: undefined });
+
+    renderHook(() => useUnreadNotifications("bob"));
+
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+      })
+    );
+  });
+
+  it("does not retry unauthorized notification failures", () => {
+    useQueryMock.mockReturnValue({ data: undefined });
+
+    renderHook(() => useUnreadNotifications("bob"));
+
+    const queryOptions = useQueryMock.mock.calls[0]?.[0];
+    expect(queryOptions.retry(0, { status: 401 })).toBe(false);
+  });
+
+  it("blocks polling before fetch when the token expires between renders", async () => {
+    isAuthJwtUsableMock.mockReturnValueOnce(true).mockReturnValueOnce(false);
+    useQueryMock.mockReturnValue({ data: undefined });
+
+    renderHook(() => useUnreadNotifications("bob"));
+
+    const queryOptions = useQueryMock.mock.calls[0]?.[0];
+    await expect(queryOptions.queryFn()).rejects.toMatchObject({ status: 401 });
+    expect(commonApiFetchMock).not.toHaveBeenCalled();
   });
 
   it("returns false when no unread notifications", () => {

--- a/components/auth/SeizeConnectContext.tsx
+++ b/components/auth/SeizeConnectContext.tsx
@@ -1266,7 +1266,7 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     useConnectedAccountsUnreadNotifications(jwtPollingStoredConnectedAccounts);
 
   const { notifications: activeUnreadNotifications } = useUnreadNotifications(
-    activeStoredAccount?.profileHandle ?? null,
+    hasValidWalletAuth ? (activeStoredAccount?.profileHandle ?? null) : null,
     { enabled: hasValidWalletAuth }
   );
 

--- a/components/auth/SeizeConnectContext.tsx
+++ b/components/auth/SeizeConnectContext.tsx
@@ -1266,7 +1266,8 @@ export const SeizeConnectProvider: React.FC<{ children: React.ReactNode }> = ({
     useConnectedAccountsUnreadNotifications(jwtPollingStoredConnectedAccounts);
 
   const { notifications: activeUnreadNotifications } = useUnreadNotifications(
-    activeStoredAccount?.profileHandle ?? null
+    activeStoredAccount?.profileHandle ?? null,
+    { enabled: hasValidWalletAuth }
   );
 
   const connectedAccountUnreadNotifications = useMemo(() => {

--- a/components/brain/mobile/BrainMobileTabs.tsx
+++ b/components/brain/mobile/BrainMobileTabs.tsx
@@ -11,7 +11,6 @@ import { ArrowLeftIcon, PlusIcon } from "@heroicons/react/24/solid";
 import { useUnreadIndicator } from "@/hooks/useUnreadIndicator";
 import { useUnreadNotifications } from "@/hooks/useUnreadNotifications";
 import { useAuth } from "@/components/auth/Auth";
-import { useSeizeConnectContext } from "@/components/auth/SeizeConnectContext";
 import { getWaveHomeRoute } from "../../../helpers/navigation.helpers";
 import { useWaveCurations } from "@/hooks/waves/useWaveCurations";
 import MyStreamWaveCurationCreateDialog from "../my-stream/tabs/MyStreamWaveCurationCreateDialog";
@@ -70,8 +69,8 @@ const BrainMobileTabs: React.FC<BrainMobileTabsProps> = ({
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { registerRef } = useLayout();
-  const { connectedProfile } = useAuth();
-  const { hasValidWalletAuth } = useSeizeConnectContext();
+  const { connectedProfile, isAuthenticated } = useAuth();
+  const hasValidNotificationAuth = isAuthenticated === true;
   const hasAuthenticatedProfile = Boolean(connectedProfile?.handle);
   const [isCreateCurationOpen, setIsCreateCurationOpen] = useState(false);
   const shouldShowCurationTabs = Boolean(isApp && waveActive && wave?.id);
@@ -115,8 +114,8 @@ const BrainMobileTabs: React.FC<BrainMobileTabsProps> = ({
 
   // Get unread notifications using the dedicated hook
   const { haveUnreadNotifications } = useUnreadNotifications(
-    hasValidWalletAuth ? (connectedProfile?.handle ?? null) : null,
-    { enabled: hasValidWalletAuth }
+    hasValidNotificationAuth ? (connectedProfile?.handle ?? null) : null,
+    { enabled: hasValidNotificationAuth }
   );
 
   const scrollActiveButtonIntoView = useCallback(

--- a/components/brain/mobile/BrainMobileTabs.tsx
+++ b/components/brain/mobile/BrainMobileTabs.tsx
@@ -11,6 +11,7 @@ import { ArrowLeftIcon, PlusIcon } from "@heroicons/react/24/solid";
 import { useUnreadIndicator } from "@/hooks/useUnreadIndicator";
 import { useUnreadNotifications } from "@/hooks/useUnreadNotifications";
 import { useAuth } from "@/components/auth/Auth";
+import { useSeizeConnectContext } from "@/components/auth/SeizeConnectContext";
 import { getWaveHomeRoute } from "../../../helpers/navigation.helpers";
 import { useWaveCurations } from "@/hooks/waves/useWaveCurations";
 import MyStreamWaveCurationCreateDialog from "../my-stream/tabs/MyStreamWaveCurationCreateDialog";
@@ -70,6 +71,7 @@ const BrainMobileTabs: React.FC<BrainMobileTabsProps> = ({
   const searchParams = useSearchParams();
   const { registerRef } = useLayout();
   const { connectedProfile } = useAuth();
+  const { hasValidWalletAuth } = useSeizeConnectContext();
   const hasAuthenticatedProfile = Boolean(connectedProfile?.handle);
   const [isCreateCurationOpen, setIsCreateCurationOpen] = useState(false);
   const shouldShowCurationTabs = Boolean(isApp && waveActive && wave?.id);
@@ -113,7 +115,8 @@ const BrainMobileTabs: React.FC<BrainMobileTabsProps> = ({
 
   // Get unread notifications using the dedicated hook
   const { haveUnreadNotifications } = useUnreadNotifications(
-    connectedProfile?.handle ?? null
+    connectedProfile?.handle ?? null,
+    { enabled: hasValidWalletAuth }
   );
 
   const scrollActiveButtonIntoView = useCallback(

--- a/components/brain/mobile/BrainMobileTabs.tsx
+++ b/components/brain/mobile/BrainMobileTabs.tsx
@@ -115,7 +115,7 @@ const BrainMobileTabs: React.FC<BrainMobileTabsProps> = ({
 
   // Get unread notifications using the dedicated hook
   const { haveUnreadNotifications } = useUnreadNotifications(
-    connectedProfile?.handle ?? null,
+    hasValidWalletAuth ? (connectedProfile?.handle ?? null) : null,
     { enabled: hasValidWalletAuth }
   );
 

--- a/components/layout/sidebar/WebSidebar.tsx
+++ b/components/layout/sidebar/WebSidebar.tsx
@@ -47,7 +47,7 @@ function WebSidebar({
     initialProfile: null,
   });
   const { haveUnreadNotifications } = useUnreadNotifications(
-    connectedProfile?.handle ?? null,
+    hasValidWalletAuth ? (connectedProfile?.handle ?? null) : null,
     { enabled: hasValidWalletAuth }
   );
   const profilePath = useMemo(() => {

--- a/components/layout/sidebar/WebSidebar.tsx
+++ b/components/layout/sidebar/WebSidebar.tsx
@@ -40,14 +40,15 @@ function WebSidebar({
 }: WebSidebarProps) {
   const navRef = useRef<{ closeSubmenu: () => void }>(null);
   const pathname = usePathname();
-  const { address } = useSeizeConnectContext();
+  const { address, hasValidWalletAuth } = useSeizeConnectContext();
   const { connectedProfile } = useAuth();
   const { profile } = useIdentity({
     handleOrWallet: address || "",
     initialProfile: null,
   });
   const { haveUnreadNotifications } = useUnreadNotifications(
-    connectedProfile?.handle ?? null
+    connectedProfile?.handle ?? null,
+    { enabled: hasValidWalletAuth }
   );
   const profilePath = useMemo(() => {
     if (connectedProfile?.handle) return `/${connectedProfile.handle}`;

--- a/components/navigation/NavItem.tsx
+++ b/components/navigation/NavItem.tsx
@@ -182,7 +182,7 @@ const NavItemContent = ({
 
   const { name } = item;
   const { icon } = item;
-  const { address, seizeConnect } = useSeizeConnectContext();
+  const { address, seizeConnect, hasValidWalletAuth } = useSeizeConnectContext();
 
   // Add unread notifications logic
   const { connectedProfile } = useAuth();
@@ -193,7 +193,8 @@ const NavItemContent = ({
   });
   const { setTitle } = useTitle();
   const { notifications, haveUnreadNotifications } = useUnreadNotifications(
-    item.name === "Notifications" ? (connectedProfile?.handle ?? null) : null
+    item.name === "Notifications" ? (connectedProfile?.handle ?? null) : null,
+    { enabled: hasValidWalletAuth }
   );
 
   // Add unread messages logic

--- a/components/navigation/NavItem.tsx
+++ b/components/navigation/NavItem.tsx
@@ -193,7 +193,9 @@ const NavItemContent = ({
   });
   const { setTitle } = useTitle();
   const { notifications, haveUnreadNotifications } = useUnreadNotifications(
-    item.name === "Notifications" ? (connectedProfile?.handle ?? null) : null,
+    item.name === "Notifications" && hasValidWalletAuth
+      ? (connectedProfile?.handle ?? null)
+      : null,
     { enabled: hasValidWalletAuth }
   );
 

--- a/components/react-query-wrapper/utils/query-utils.ts
+++ b/components/react-query-wrapper/utils/query-utils.ts
@@ -40,3 +40,60 @@ export const getDefaultQueryRetry = (errorCallback?: () => void) => {
     },
   };
 };
+
+type QueryErrorWithStatus = {
+  readonly status?: unknown;
+  readonly response?: {
+    readonly status?: unknown;
+  };
+  readonly cause?: {
+    readonly status?: unknown;
+  };
+};
+
+export const getQueryErrorStatus = (error: unknown): number | null => {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+
+  const statusError = error as QueryErrorWithStatus;
+  const status =
+    statusError.status ??
+    statusError.response?.status ??
+    statusError.cause?.status;
+
+  return typeof status === "number" ? status : null;
+};
+
+export const isUnauthorizedQueryError = (error: unknown): boolean => {
+  if (getQueryErrorStatus(error) === 401) {
+    return true;
+  }
+
+  if (typeof error === "string") {
+    return /unauthorized/i.test(error);
+  }
+
+  return error instanceof Error && /unauthorized/i.test(error.message);
+};
+
+export const getAuthAwareQueryRetry = (errorCallback?: () => void) => {
+  return {
+    retry: (failureCount: number, error: unknown) => {
+      if (isUnauthorizedQueryError(error)) {
+        errorCallback?.();
+        return false;
+      }
+
+      if (failureCount >= 3) {
+        errorCallback?.();
+        return false;
+      }
+
+      return true;
+    },
+    retryDelay: (failureCount: number) => {
+      return failureCount * 1000;
+    },
+  };
+};

--- a/components/react-query-wrapper/utils/query-utils.ts
+++ b/components/react-query-wrapper/utils/query-utils.ts
@@ -66,34 +66,5 @@ const getQueryErrorStatus = (error: unknown): number | null => {
 };
 
 export const isUnauthorizedQueryError = (error: unknown): boolean => {
-  if (getQueryErrorStatus(error) === 401) {
-    return true;
-  }
-
-  if (typeof error === "string") {
-    return /unauthorized/i.test(error);
-  }
-
-  return error instanceof Error && /unauthorized/i.test(error.message);
-};
-
-export const getAuthAwareQueryRetry = (errorCallback?: () => void) => {
-  return {
-    retry: (failureCount: number, error: unknown) => {
-      if (isUnauthorizedQueryError(error)) {
-        errorCallback?.();
-        return false;
-      }
-
-      if (failureCount >= 3) {
-        errorCallback?.();
-        return false;
-      }
-
-      return true;
-    },
-    retryDelay: (failureCount: number) => {
-      return failureCount * 1000;
-    },
-  };
+  return getQueryErrorStatus(error) === 401;
 };

--- a/components/react-query-wrapper/utils/query-utils.ts
+++ b/components/react-query-wrapper/utils/query-utils.ts
@@ -51,7 +51,7 @@ type QueryErrorWithStatus = {
   };
 };
 
-export const getQueryErrorStatus = (error: unknown): number | null => {
+const getQueryErrorStatus = (error: unknown): number | null => {
   if (typeof error !== "object" || error === null) {
     return null;
   }

--- a/hooks/useConnectedAccountsUnreadNotifications.ts
+++ b/hooks/useConnectedAccountsUnreadNotifications.ts
@@ -3,15 +3,13 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
-import {
-  getAuthAwareQueryRetry,
-  isUnauthorizedQueryError,
-} from "@/components/react-query-wrapper/utils/query-utils";
+import { isUnauthorizedQueryError } from "@/components/react-query-wrapper/utils/query-utils";
 import type { ApiNotificationsResponseV2 } from "@/generated/models/ApiNotificationsResponseV2";
 import {
   isAuthJwtUsable,
   type ConnectedWalletAccount,
 } from "@/services/auth/auth.utils";
+import { getAuthTokenFingerprint } from "@/services/auth/auth-token-fingerprint";
 import { commonApiFetch } from "@/services/api/common-api";
 import useCapacitor from "./useCapacitor";
 
@@ -21,12 +19,64 @@ const POLL_INTERVAL_MS = 15000;
 
 const toAddressKey = (address: string): string => address.toLowerCase();
 
-const getTokenFingerprint = (jwt: string): string => {
-  let hash = 0;
-  for (let index = 0; index < jwt.length; index += 1) {
-    hash = (hash * 31 + jwt.charCodeAt(index)) >>> 0;
+type UnauthorizedConnectedAccountFailure = {
+  readonly addressKey: string;
+  readonly jwtFingerprint: string;
+};
+
+type ConnectedAccountAuthPollingError = Error & {
+  readonly status: 401;
+  readonly unauthorizedFailures: readonly UnauthorizedConnectedAccountFailure[];
+  readonly cause?: unknown;
+};
+
+const createConnectedAccountAuthPollingError = (
+  unauthorizedFailures: readonly UnauthorizedConnectedAccountFailure[],
+  cause?: unknown
+): ConnectedAccountAuthPollingError => {
+  const error = new Error(
+    "Connected account unread notification polling requires valid auth"
+  ) as ConnectedAccountAuthPollingError;
+  Object.defineProperty(error, "status", {
+    value: 401,
+    enumerable: true,
+  });
+  Object.defineProperty(error, "unauthorizedFailures", {
+    value: unauthorizedFailures,
+    enumerable: true,
+  });
+  if (cause !== undefined) {
+    Object.defineProperty(error, "cause", {
+      value: cause,
+      enumerable: false,
+    });
   }
-  return `${jwt.length}:${hash.toString(36)}`;
+  return error;
+};
+
+const getUnauthorizedFailuresFromError = (
+  error: unknown
+): readonly UnauthorizedConnectedAccountFailure[] => {
+  if (!isUnauthorizedQueryError(error)) {
+    return [];
+  }
+  if (typeof error !== "object" || error === null) {
+    return [];
+  }
+
+  const failures = (error as { readonly unauthorizedFailures?: unknown })
+    .unauthorizedFailures;
+  return Array.isArray(failures)
+    ? failures.filter(
+        (failure): failure is UnauthorizedConnectedAccountFailure =>
+          typeof failure === "object" &&
+          failure !== null &&
+          typeof (failure as UnauthorizedConnectedAccountFailure).addressKey ===
+            "string" &&
+          typeof (failure as UnauthorizedConnectedAccountFailure)
+            .jwtFingerprint === "string"
+      )
+    : [];
 };
 
 const clampUnreadCount = (count: number | null | undefined): number => {
@@ -42,15 +92,34 @@ const fetchUnreadCountForAccount = async (
   if (!account.jwt) {
     return 0;
   }
+  const addressKey = toAddressKey(account.address);
+  const jwtFingerprint = getAuthTokenFingerprint(account.jwt);
 
-  const notifications = await commonApiFetch<ApiNotificationsResponseV2>({
-    endpoint: "v2/notifications",
-    params: { limit: "1" },
-    headers: {
-      Authorization: `Bearer ${account.jwt}`,
-    },
-  });
-  return clampUnreadCount(notifications.unread_count);
+  if (!isAuthJwtUsable(account.jwt)) {
+    throw createConnectedAccountAuthPollingError([
+      { addressKey, jwtFingerprint },
+    ]);
+  }
+
+  try {
+    const notifications = await commonApiFetch<ApiNotificationsResponseV2>({
+      endpoint: "v2/notifications",
+      params: { limit: "1" },
+      headers: {
+        Authorization: `Bearer ${account.jwt}`,
+      },
+      errorMode: "structured",
+    });
+    return clampUnreadCount(notifications.unread_count);
+  } catch (error) {
+    if (isUnauthorizedQueryError(error)) {
+      throw createConnectedAccountAuthPollingError(
+        [{ addressKey, jwtFingerprint }],
+        error
+      );
+    }
+    throw error;
+  }
 };
 
 export function useConnectedAccountsUnreadNotifications(
@@ -74,7 +143,7 @@ export function useConnectedAccountsUnreadNotifications(
 
         return (
           unauthorizedJwtFingerprintByAddress[toAddressKey(account.address)] !==
-          getTokenFingerprint(jwt)
+          getAuthTokenFingerprint(jwt)
         );
       }),
     [accounts, unauthorizedJwtFingerprintByAddress]
@@ -101,7 +170,7 @@ export function useConnectedAccountsUnreadNotifications(
       const nextCounts: Record<string, number> = {};
       const unauthorizedFailures: {
         readonly addressKey: string;
-        readonly jwt: string;
+        readonly jwtFingerprint: string;
         readonly error: unknown;
       }[] = [];
 
@@ -123,9 +192,21 @@ export function useConnectedAccountsUnreadNotifications(
         }
 
         if (account.jwt && isUnauthorizedQueryError(result.reason)) {
+          const nestedUnauthorizedFailures =
+            getUnauthorizedFailuresFromError(result.reason);
+          if (nestedUnauthorizedFailures.length > 0) {
+            nestedUnauthorizedFailures.forEach((failure) => {
+              unauthorizedFailures.push({
+                ...failure,
+                error: result.reason,
+              });
+            });
+            return;
+          }
+
           unauthorizedFailures.push({
             addressKey,
-            jwt: getTokenFingerprint(account.jwt),
+            jwtFingerprint: getAuthTokenFingerprint(account.jwt),
             error: result.reason,
           });
           return;
@@ -139,14 +220,13 @@ export function useConnectedAccountsUnreadNotifications(
 
       const firstUnauthorizedFailure = unauthorizedFailures[0];
       if (firstUnauthorizedFailure) {
-        setUnauthorizedJwtFingerprintByAddress((previous) => {
-          const next = { ...previous };
-          for (const failure of unauthorizedFailures) {
-            next[failure.addressKey] = failure.jwt;
-          }
-          return next;
-        });
-        throw firstUnauthorizedFailure.error;
+        throw createConnectedAccountAuthPollingError(
+          unauthorizedFailures.map(({ addressKey, jwtFingerprint }) => ({
+            addressKey,
+            jwtFingerprint,
+          })),
+          firstUnauthorizedFailure.error
+        );
       }
 
       return nextCounts;
@@ -157,7 +237,31 @@ export function useConnectedAccountsUnreadNotifications(
     refetchOnMount: true,
     refetchOnReconnect: true,
     refetchIntervalInBackground: !isCapacitor,
-    ...getAuthAwareQueryRetry(),
+    retry: (failureCount: number, error: unknown) => {
+      const unauthorizedFailures = getUnauthorizedFailuresFromError(error);
+      if (unauthorizedFailures.length > 0) {
+        setUnauthorizedJwtFingerprintByAddress((previous) => {
+          let didChange = false;
+          const next = { ...previous };
+          for (const failure of unauthorizedFailures) {
+            if (next[failure.addressKey] !== failure.jwtFingerprint) {
+              next[failure.addressKey] = failure.jwtFingerprint;
+              didChange = true;
+            }
+          }
+          return didChange ? next : previous;
+        });
+        return false;
+      }
+      if (isUnauthorizedQueryError(error)) {
+        return false;
+      }
+
+      return failureCount < 3;
+    },
+    retryDelay: (failureCount: number) => {
+      return failureCount * 1000;
+    },
   });
 
   return data ?? {};

--- a/hooks/useConnectedAccountsUnreadNotifications.ts
+++ b/hooks/useConnectedAccountsUnreadNotifications.ts
@@ -1,10 +1,17 @@
 "use client";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
-import { getDefaultQueryRetry } from "@/components/react-query-wrapper/utils/query-utils";
+import {
+  getAuthAwareQueryRetry,
+  isUnauthorizedQueryError,
+} from "@/components/react-query-wrapper/utils/query-utils";
 import type { ApiNotificationsResponseV2 } from "@/generated/models/ApiNotificationsResponseV2";
-import type { ConnectedWalletAccount } from "@/services/auth/auth.utils";
+import {
+  isAuthJwtUsable,
+  type ConnectedWalletAccount,
+} from "@/services/auth/auth.utils";
 import { commonApiFetch } from "@/services/api/common-api";
 import useCapacitor from "./useCapacitor";
 
@@ -13,6 +20,14 @@ type ConnectedAccountUnreadCounts = Readonly<Record<string, number>>;
 const POLL_INTERVAL_MS = 15000;
 
 const toAddressKey = (address: string): string => address.toLowerCase();
+
+const getTokenFingerprint = (jwt: string): string => {
+  let hash = 0;
+  for (let index = 0; index < jwt.length; index += 1) {
+    hash = (hash * 31 + jwt.charCodeAt(index)) >>> 0;
+  }
+  return `${jwt.length}:${hash.toString(36)}`;
+};
 
 const clampUnreadCount = (count: number | null | undefined): number => {
   if (typeof count !== "number" || Number.isNaN(count) || count <= 0) {
@@ -43,28 +58,54 @@ export function useConnectedAccountsUnreadNotifications(
 ): ConnectedAccountUnreadCounts {
   const { isCapacitor } = useCapacitor();
   const queryClient = useQueryClient();
+  const [
+    unauthorizedJwtFingerprintByAddress,
+    setUnauthorizedJwtFingerprintByAddress,
+  ] = useState<
+    Readonly<Record<string, string>>
+  >({});
+  const pollableAccounts = useMemo(
+    () =>
+      accounts.filter((account) => {
+        const jwt = account.jwt;
+        if (typeof jwt !== "string" || !isAuthJwtUsable(jwt)) {
+          return false;
+        }
+
+        return (
+          unauthorizedJwtFingerprintByAddress[toAddressKey(account.address)] !==
+          getTokenFingerprint(jwt)
+        );
+      }),
+    [accounts, unauthorizedJwtFingerprintByAddress]
+  );
   const queryKey = [
     QueryKey.CONNECTED_ACCOUNT_UNREAD_NOTIFICATIONS,
     "connected-account-unread-counts",
     "v2",
-    accounts.map((account) => toAddressKey(account.address)),
+    pollableAccounts.map((account) => toAddressKey(account.address)),
   ] as const;
 
   const { data } = useQuery<ConnectedAccountUnreadCounts>({
     queryKey,
     queryFn: async () => {
-      if (accounts.length === 0) {
+      if (pollableAccounts.length === 0) {
         return {};
       }
 
       const previousCounts =
         queryClient.getQueryData<ConnectedAccountUnreadCounts>(queryKey) ?? {};
       const results = await Promise.allSettled(
-        accounts.map((account) => fetchUnreadCountForAccount(account))
+        pollableAccounts.map((account) => fetchUnreadCountForAccount(account))
       );
       const nextCounts: Record<string, number> = {};
+      const unauthorizedFailures: {
+        readonly addressKey: string;
+        readonly jwt: string;
+        readonly error: unknown;
+      }[] = [];
 
-      accounts.forEach((account, index) => {
+      pollableAccounts.forEach((account, index) => {
         const addressKey = toAddressKey(account.address);
         const result = results[index];
 
@@ -81,21 +122,42 @@ export function useConnectedAccountsUnreadNotifications(
           return;
         }
 
+        if (account.jwt && isUnauthorizedQueryError(result.reason)) {
+          unauthorizedFailures.push({
+            addressKey,
+            jwt: getTokenFingerprint(account.jwt),
+            error: result.reason,
+          });
+          return;
+        }
+
         const previousCount = previousCounts[addressKey];
         if (typeof previousCount === "number") {
           nextCounts[addressKey] = previousCount;
         }
       });
 
+      const firstUnauthorizedFailure = unauthorizedFailures[0];
+      if (firstUnauthorizedFailure) {
+        setUnauthorizedJwtFingerprintByAddress((previous) => {
+          const next = { ...previous };
+          for (const failure of unauthorizedFailures) {
+            next[failure.addressKey] = failure.jwt;
+          }
+          return next;
+        });
+        throw firstUnauthorizedFailure.error;
+      }
+
       return nextCounts;
     },
-    enabled: accounts.length > 0,
+    enabled: pollableAccounts.length > 0,
     refetchInterval: POLL_INTERVAL_MS,
     refetchOnWindowFocus: true,
     refetchOnMount: true,
     refetchOnReconnect: true,
     refetchIntervalInBackground: !isCapacitor,
-    ...getDefaultQueryRetry(),
+    ...getAuthAwareQueryRetry(),
   });
 
   return data ?? {};

--- a/hooks/useUnreadNotifications.ts
+++ b/hooks/useUnreadNotifications.ts
@@ -1,42 +1,60 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import type { ApiNotificationsResponseV2 } from "@/generated/models/ApiNotificationsResponseV2";
 import { commonApiFetch } from "@/services/api/common-api";
 import useCapacitor from "./useCapacitor";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
-import {
-  getAuthAwareQueryRetry,
-  isUnauthorizedQueryError,
-} from "@/components/react-query-wrapper/utils/query-utils";
+import { isUnauthorizedQueryError } from "@/components/react-query-wrapper/utils/query-utils";
 import { getAuthJwt, isAuthJwtUsable } from "@/services/auth/auth.utils";
+import { getAuthTokenFingerprint } from "@/services/auth/auth-token-fingerprint";
 
 interface UseUnreadNotificationsOptions {
   readonly enabled?: boolean | undefined;
 }
 
-const createMissingAuthError = (): Error & { readonly status: 401 } => {
-  const error = new Error("Unread notification polling requires valid auth") as
-    | Error
-    | (Error & { status: 401 });
+type AuthPollingError = Error & {
+  readonly status: 401;
+  readonly authPollingKey: string;
+  readonly cause?: unknown;
+};
+
+const createAuthPollingError = (
+  authPollingKey: string,
+  cause?: unknown
+): AuthPollingError => {
+  const error = new Error(
+    "Unread notification polling requires valid auth"
+  ) as AuthPollingError;
   Object.defineProperty(error, "status", {
     value: 401,
     enumerable: true,
   });
-  return error as Error & { readonly status: 401 };
+  Object.defineProperty(error, "authPollingKey", {
+    value: authPollingKey,
+    enumerable: true,
+  });
+  if (cause !== undefined) {
+    Object.defineProperty(error, "cause", {
+      value: cause,
+      enumerable: false,
+    });
+  }
+  return error;
 };
 
-const getTokenFingerprint = (jwt: string | null): string => {
-  if (!jwt) {
-    return "none";
+const getAuthPollingKeyFromError = (error: unknown): string | null => {
+  if (!isUnauthorizedQueryError(error)) {
+    return null;
+  }
+  if (typeof error !== "object" || error === null) {
+    return null;
   }
 
-  let hash = 0;
-  for (let index = 0; index < jwt.length; index += 1) {
-    hash = (hash * 31 + jwt.charCodeAt(index)) >>> 0;
-  }
-  return `${jwt.length}:${hash.toString(36)}`;
+  const authPollingKey = (error as { readonly authPollingKey?: unknown })
+    .authPollingKey;
+  return typeof authPollingKey === "string" ? authPollingKey : null;
 };
 
 export function useUnreadNotifications(
@@ -46,7 +64,7 @@ export function useUnreadNotifications(
   const { isCapacitor } = useCapacitor();
   const authJwt = getAuthJwt();
   const hasUsableAuthJwt = isAuthJwtUsable(authJwt);
-  const authPollingKey = `${handle ?? ""}:${getTokenFingerprint(authJwt)}`;
+  const authPollingKey = `${handle ?? ""}:${getAuthTokenFingerprint(authJwt)}`;
   const [blockedAuthPollingKey, setBlockedAuthPollingKey] = useState<
     string | null
   >(null);
@@ -64,8 +82,7 @@ export function useUnreadNotifications(
     ],
     queryFn: async () => {
       if (!isAuthJwtUsable(getAuthJwt())) {
-        setBlockedAuthPollingKey(authPollingKey);
-        throw createMissingAuthError();
+        throw createAuthPollingError(authPollingKey);
       }
 
       try {
@@ -74,10 +91,11 @@ export function useUnreadNotifications(
           params: {
             limit: "1",
           },
+          errorMode: "structured",
         });
       } catch (error) {
         if (isUnauthorizedQueryError(error)) {
-          setBlockedAuthPollingKey(authPollingKey);
+          throw createAuthPollingError(authPollingKey, error);
         }
         throw error;
       }
@@ -88,14 +106,28 @@ export function useUnreadNotifications(
     refetchOnMount: true,
     refetchOnReconnect: true,
     refetchIntervalInBackground: !isCapacitor,
-    ...getAuthAwareQueryRetry(),
+    retry: (failureCount: number, error: unknown) => {
+      const blockedKey = getAuthPollingKeyFromError(error);
+      if (blockedKey) {
+        setBlockedAuthPollingKey((previous) =>
+          previous === blockedKey ? previous : blockedKey
+        );
+        return false;
+      }
+      if (isUnauthorizedQueryError(error)) {
+        return false;
+      }
+
+      return failureCount < 3;
+    },
+    retryDelay: (failureCount: number) => {
+      return failureCount * 1000;
+    },
   });
 
-  const [haveUnreadNotifications, setHaveUnreadNotifications] = useState(false);
+  const effectiveNotifications = isEnabled ? notifications : undefined;
+  const haveUnreadNotifications =
+    (effectiveNotifications?.unread_count ?? 0) > 0;
 
-  useEffect(() => {
-    setHaveUnreadNotifications(!!notifications?.unread_count);
-  }, [notifications]);
-
-  return { notifications, haveUnreadNotifications };
+  return { notifications: effectiveNotifications, haveUnreadNotifications };
 }

--- a/hooks/useUnreadNotifications.ts
+++ b/hooks/useUnreadNotifications.ts
@@ -6,29 +6,89 @@ import type { ApiNotificationsResponseV2 } from "@/generated/models/ApiNotificat
 import { commonApiFetch } from "@/services/api/common-api";
 import useCapacitor from "./useCapacitor";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
-import { getDefaultQueryRetry } from "@/components/react-query-wrapper/utils/query-utils";
-export function useUnreadNotifications(handle: string | null) {
+import {
+  getAuthAwareQueryRetry,
+  isUnauthorizedQueryError,
+} from "@/components/react-query-wrapper/utils/query-utils";
+import { getAuthJwt, isAuthJwtUsable } from "@/services/auth/auth.utils";
+
+interface UseUnreadNotificationsOptions {
+  readonly enabled?: boolean | undefined;
+}
+
+const createMissingAuthError = (): Error & { readonly status: 401 } => {
+  const error = new Error("Unread notification polling requires valid auth") as
+    | Error
+    | (Error & { status: 401 });
+  Object.defineProperty(error, "status", {
+    value: 401,
+    enumerable: true,
+  });
+  return error as Error & { readonly status: 401 };
+};
+
+const getTokenFingerprint = (jwt: string | null): string => {
+  if (!jwt) {
+    return "none";
+  }
+
+  let hash = 0;
+  for (let index = 0; index < jwt.length; index += 1) {
+    hash = (hash * 31 + jwt.charCodeAt(index)) >>> 0;
+  }
+  return `${jwt.length}:${hash.toString(36)}`;
+};
+
+export function useUnreadNotifications(
+  handle: string | null,
+  options: UseUnreadNotificationsOptions = {}
+) {
   const { isCapacitor } = useCapacitor();
+  const authJwt = getAuthJwt();
+  const hasUsableAuthJwt = isAuthJwtUsable(authJwt);
+  const authPollingKey = `${handle ?? ""}:${getTokenFingerprint(authJwt)}`;
+  const [blockedAuthPollingKey, setBlockedAuthPollingKey] = useState<
+    string | null
+  >(null);
+  const isAuthPollingBlocked = blockedAuthPollingKey === authPollingKey;
+  const isEnabled =
+    !!handle &&
+    options.enabled !== false &&
+    hasUsableAuthJwt &&
+    !isAuthPollingBlocked;
 
   const { data: notifications } = useQuery<ApiNotificationsResponseV2>({
     queryKey: [
       QueryKey.IDENTITY_NOTIFICATIONS,
       { identity: handle, limit: "1", version: "v2" },
     ],
-    queryFn: async () =>
-      await commonApiFetch<ApiNotificationsResponseV2>({
-        endpoint: `v2/notifications`,
-        params: {
-          limit: "1",
-        },
-      }),
-    enabled: !!handle,
+    queryFn: async () => {
+      if (!isAuthJwtUsable(getAuthJwt())) {
+        setBlockedAuthPollingKey(authPollingKey);
+        throw createMissingAuthError();
+      }
+
+      try {
+        return await commonApiFetch<ApiNotificationsResponseV2>({
+          endpoint: `v2/notifications`,
+          params: {
+            limit: "1",
+          },
+        });
+      } catch (error) {
+        if (isUnauthorizedQueryError(error)) {
+          setBlockedAuthPollingKey(authPollingKey);
+        }
+        throw error;
+      }
+    },
+    enabled: isEnabled,
     refetchInterval: 30000,
     refetchOnWindowFocus: true,
     refetchOnMount: true,
     refetchOnReconnect: true,
     refetchIntervalInBackground: !isCapacitor,
-    ...getDefaultQueryRetry(),
+    ...getAuthAwareQueryRetry(),
   });
 
   const [haveUnreadNotifications, setHaveUnreadNotifications] = useState(false);

--- a/services/api/common-api.ts
+++ b/services/api/common-api.ts
@@ -344,6 +344,7 @@ export const commonApiFetch = async <T, U = Record<string, string>>(param: {
   headers?: Record<string, string> | undefined;
   params?: U | undefined;
   signal?: AbortSignal | undefined;
+  errorMode?: ApiErrorMode | undefined;
 }): Promise<T> => {
   const url = buildUrl(
     param.endpoint,
@@ -362,6 +363,7 @@ export const commonApiFetch = async <T, U = Record<string, string>>(param: {
     method: "GET",
     headers: getHeaders(param.headers, false),
     signal: param.signal,
+    errorMode: param.errorMode ?? "legacy-string",
   });
 };
 

--- a/services/auth/auth-token-fingerprint.ts
+++ b/services/auth/auth-token-fingerprint.ts
@@ -1,0 +1,13 @@
+export const getAuthTokenFingerprint = (
+  jwt: string | null | undefined
+): string => {
+  if (!jwt) {
+    return "none";
+  }
+
+  let hash = 0;
+  for (let index = 0; index < jwt.length; index += 1) {
+    hash = (hash * 31 + jwt.charCodeAt(index)) >>> 0;
+  }
+  return `${jwt.length}:${hash.toString(36)}`;
+};

--- a/services/auth/auth.utils.ts
+++ b/services/auth/auth.utils.ts
@@ -50,6 +50,21 @@ const getJwtExpiration = (jwt: string): number => {
   return decodedJwt.exp;
 };
 
+export const isAuthJwtUsable = (
+  jwt: string | null | undefined,
+  nowSeconds = Date.now() / 1000
+): boolean => {
+  if (!jwt) {
+    return false;
+  }
+
+  try {
+    return getJwtExpiration(jwt) > nowSeconds;
+  } catch {
+    return false;
+  }
+};
+
 const getAddressRoleStorageKey = (address: string): string => {
   return `auth-role-${address.toLowerCase()}`;
 };


### PR DESCRIPTION
## Issue
- AWS RUM showed repeated 4xx noise around notification polling when browser state can retain stale wallet/profile data after auth expires or disappears.
- The active unread-notification hook was enabled by profile handle alone, and connected-account polling could keep trying stored JWTs even when they were expired or unauthorized.

## Fix
- Gate unread notification polling on a usable non-expired auth JWT before starting the query.
- Stop React Query retries for `401`/unauthorized notification responses.
- Block repeated polling for the same failed auth token fingerprint until auth state changes.
- Filter connected-account unread polling to accounts with usable JWTs, and surface unauthorized connected-account failures instead of silently treating them as successful polling.

## Changes
- Added auth-aware query retry helpers for status/unauthorized detection.
- Added JWT usability validation in auth utilities.
- Updated active unread notification callers to pass the existing wallet-auth gate.
- Added focused hook tests for expired auth, disabled polling, no 401 retry, and connected-account unauthorized handling.

## Validation
- `./bin/6529 run test -- __tests__/hooks/useUnreadNotifications.test.ts __tests__/hooks/useConnectedAccountsUnreadNotifications.test.ts`
- `./bin/6529 run lint:diff`
- `./bin/6529 run typecheck:ci`
- `./bin/6529 run react-doctor:diff` passed with existing warnings in large components and existing `useSearchParams` usage.
- Desktop browser QA on local dev against staging endpoints: injected an expired stored wallet/profile state through the local agent-login bridge, waited longer than the 30s active notification polling interval, and observed no notification/session-refresh/401 noise. Cleared the fake auth state afterward.

Not fully tested: positive logged-in staging notification-badge QA, because the local agent-login helper returned 401 against the staging API for the available throwaway account. A seeded staging profile/access setup is needed for that end-to-end check.

## Risk
- Level: Medium
- Why: touches auth-sensitive notification polling and connected-account unread counts. The change is narrow and covered by focused tests, but valid multi-profile unread badge behavior should get reviewer attention.
- Rollback: revert this PR to restore previous polling behavior.

## Review Notes
- Please focus on whether the JWT usability gate is appropriate for all notification badge surfaces and whether connected-account unauthorized handling should also trigger account cleanup in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added auth-aware unread notification polling control, including an `enabled` option for unread notification hooks and gating based on wallet/notification auth validity.

* **Bug Fixes**
  * Improved handling of unauthorized (401) notification failures: polling is halted when auth becomes unusable or unauthorized, and retries are suppressed accordingly.
  * Connected-account unread counts now fetch only eligible accounts and reduce unstable indicator updates during auth transitions.

* **Tests**
  * Expanded hook test coverage for JWT usability changes, polling enablement/disablement, and 401 retry/polling-stop behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->