### PR TITLE
[codex] Fix waves sidebar spacing

### DIFF
--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
@@ -254,7 +254,7 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
       {isChildRow && (
         <span
           aria-hidden="true"
-          className={`tw-absolute -tw-top-1 tw-left-14 tw-w-px tw-bg-iron-700/60 md:tw-left-[52px] ${
+          className={`tw-absolute -tw-top-1 tw-left-[35.5px] tw-w-px tw-bg-iron-700/60 ${
             isLastSubwave ? "tw-bottom-4" : "-tw-bottom-1"
           }`}
         />
@@ -321,8 +321,8 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
         </div>
         <div className="tw-min-w-0 tw-flex-1">
           <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
-            <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-y-0.5">
-              <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1.5">
+            <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-y-1">
+              <div className="-tw-mt-0.5 tw-flex tw-min-w-0 tw-items-center tw-gap-1.5">
                 <Link
                   href={href}
                   prefetch={false}
@@ -352,7 +352,7 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
                 )}
               </div>
               {shouldShowDropTime && (
-                <div className="tw-inline-flex tw-min-w-0 tw-items-center tw-whitespace-nowrap tw-text-xs tw-leading-none tw-text-iron-500 tw-transition-colors tw-duration-200 desktop-hover:group-hover:tw-text-iron-400">
+                <div className="tw-inline-flex tw-min-w-0 tw-items-center tw-whitespace-nowrap tw-text-xs tw-leading-tight tw-text-iron-500 tw-transition-colors tw-duration-200 desktop-hover:group-hover:tw-text-iron-400">
                   <BrainLeftSidebarWaveDropTime time={latestDropTimestamp} />
                 </div>
               )}

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWave.tsx
@@ -225,11 +225,16 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
   const isChildRow = depth === 1;
   const shouldShowExpandControl = canExpand && depth === 0;
   const shouldShowPinButton = showPin && depth === 0;
-  const { rowPaddingClasses, rowGapClasses, linkGapClasses, rowHeightClasses } =
-    getSidebarWaveRowLayoutClasses({
-      isChildRow,
-      variant: "app",
-    });
+  const {
+    rowPaddingClasses,
+    rowGapClasses,
+    linkGapClasses,
+    rowHeightClasses,
+    guideLineOffsetClasses,
+  } = getSidebarWaveRowLayoutClasses({
+    isChildRow,
+    variant: "app",
+  });
   const avatarSizeClasses = isChildRow ? "tw-size-7" : "tw-size-8";
   const activeRingClasses = isChildRow
     ? "tw-ring-1 tw-ring-offset-1 tw-ring-offset-iron-900 tw-ring-primary-400"
@@ -254,7 +259,7 @@ const BrainLeftSidebarWave: React.FC<BrainLeftSidebarWaveProps> = ({
       {isChildRow && (
         <span
           aria-hidden="true"
-          className={`tw-absolute -tw-top-1 tw-left-[35.5px] tw-w-px tw-bg-iron-700/60 ${
+          className={`tw-absolute -tw-top-1 ${guideLineOffsetClasses} tw-w-px tw-bg-iron-700/60 ${
             isLastSubwave ? "tw-bottom-4" : "-tw-bottom-1"
           }`}
         />

--- a/components/brain/left-sidebar/waves/sidebarWaveRowLayout.ts
+++ b/components/brain/left-sidebar/waves/sidebarWaveRowLayout.ts
@@ -19,7 +19,7 @@ const CHILD_ROW_HEIGHT_CLASSES = "tw-h-full tw-min-h-[54px]";
 const rowLayoutByVariant = {
   app: {
     child: {
-      rowPaddingClasses: "tw-pl-[82px] tw-pr-5 md:tw-pl-[78px]",
+      rowPaddingClasses: "tw-pl-[74px] tw-pr-5 md:tw-pl-[70px]",
       rowGapClasses: "tw-gap-x-2",
       linkGapClasses: "tw-space-x-2",
       rowHeightClasses: CHILD_ROW_HEIGHT_CLASSES,
@@ -33,7 +33,7 @@ const rowLayoutByVariant = {
   },
   web: {
     child: {
-      rowPaddingClasses: "tw-pl-[82px] tw-pr-5 md:tw-pl-[70px]",
+      rowPaddingClasses: "tw-pl-[74px] tw-pr-5 md:tw-pl-[66px]",
       rowGapClasses: "tw-gap-x-2",
       linkGapClasses: "tw-space-x-2",
       rowHeightClasses: CHILD_ROW_HEIGHT_CLASSES,

--- a/components/brain/left-sidebar/waves/sidebarWaveRowLayout.ts
+++ b/components/brain/left-sidebar/waves/sidebarWaveRowLayout.ts
@@ -10,11 +10,13 @@ interface SidebarWaveRowLayoutClasses {
   readonly rowGapClasses: string;
   readonly linkGapClasses: string;
   readonly rowHeightClasses: string;
+  readonly guideLineOffsetClasses: string;
 }
 
 const DEFAULT_LINK_GAP_CLASSES = "tw-space-x-3";
 const DEFAULT_ROW_HEIGHT_CLASSES = "tw-h-full tw-min-h-[62px]";
 const CHILD_ROW_HEIGHT_CLASSES = "tw-h-full tw-min-h-[54px]";
+const CHILD_GUIDE_LINE_OFFSET_CLASSES = "tw-left-[35.5px]";
 
 const rowLayoutByVariant = {
   app: {
@@ -23,12 +25,14 @@ const rowLayoutByVariant = {
       rowGapClasses: "tw-gap-x-2",
       linkGapClasses: "tw-space-x-2",
       rowHeightClasses: CHILD_ROW_HEIGHT_CLASSES,
+      guideLineOffsetClasses: CHILD_GUIDE_LINE_OFFSET_CLASSES,
     },
     default: {
       rowPaddingClasses: "tw-px-5",
       rowGapClasses: "tw-gap-x-4",
       linkGapClasses: DEFAULT_LINK_GAP_CLASSES,
       rowHeightClasses: DEFAULT_ROW_HEIGHT_CLASSES,
+      guideLineOffsetClasses: "",
     },
   },
   web: {
@@ -37,12 +41,14 @@ const rowLayoutByVariant = {
       rowGapClasses: "tw-gap-x-2",
       linkGapClasses: "tw-space-x-2",
       rowHeightClasses: CHILD_ROW_HEIGHT_CLASSES,
+      guideLineOffsetClasses: CHILD_GUIDE_LINE_OFFSET_CLASSES,
     },
     default: {
       rowPaddingClasses: "tw-px-5",
       rowGapClasses: "tw-gap-x-4",
       linkGapClasses: DEFAULT_LINK_GAP_CLASSES,
       rowHeightClasses: DEFAULT_ROW_HEIGHT_CLASSES,
+      guideLineOffsetClasses: "",
     },
   },
 } as const satisfies Record<

--- a/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
+++ b/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
@@ -155,7 +155,7 @@ export const ExpandedWave = ({
       {isChildRow && (
         <span
           aria-hidden="true"
-          className={`tw-absolute -tw-top-1 tw-left-14 tw-w-px tw-bg-iron-700/60 md:tw-left-11 ${
+          className={`tw-absolute -tw-top-1 tw-left-[35.5px] tw-w-px tw-bg-iron-700/60 ${
             isLastSubwave ? "tw-bottom-4" : "-tw-bottom-1"
           }`}
         />
@@ -188,8 +188,8 @@ export const ExpandedWave = ({
         </div>
         <div className="tw-min-w-0 tw-flex-1">
           <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
-            <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-y-0.5">
-              <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1.5">
+            <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-y-1">
+              <div className="-tw-mt-0.5 tw-flex tw-min-w-0 tw-items-center tw-gap-1.5">
                 <Link
                   href={href}
                   prefetch={false}
@@ -223,7 +223,7 @@ export const ExpandedWave = ({
                 )}
               </div>
               {shouldShowDropTime && (
-                <div className="tw-inline-flex tw-min-w-0 tw-items-center tw-whitespace-nowrap tw-text-xs tw-leading-none tw-text-iron-500 tw-transition-colors tw-duration-200 desktop-hover:group-hover:tw-text-iron-400">
+                <div className="tw-inline-flex tw-min-w-0 tw-items-center tw-whitespace-nowrap tw-text-xs tw-leading-tight tw-text-iron-500 tw-transition-colors tw-duration-200 desktop-hover:group-hover:tw-text-iron-400">
                   <BrainLeftSidebarWaveDropTime
                     time={presentLatestDropTimestamp}
                   />

--- a/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
+++ b/components/brain/left-sidebar/web/WebBrainLeftSidebarWave/subcomponents/ExpandedWave.tsx
@@ -90,11 +90,16 @@ export const ExpandedWave = ({
   const hasSummaryScore = hasWaveTrustSummaryScore(wave.waveScore);
   const shouldShowDropTime = presentLatestDropTimestamp !== null;
   const rowVerticalPaddingClasses = isChildRow ? "tw-py-1.5" : "tw-py-2";
-  const { rowPaddingClasses, rowGapClasses, linkGapClasses, rowHeightClasses } =
-    getSidebarWaveRowLayoutClasses({
-      isChildRow,
-      variant: "web",
-    });
+  const {
+    rowPaddingClasses,
+    rowGapClasses,
+    linkGapClasses,
+    rowHeightClasses,
+    guideLineOffsetClasses,
+  } = getSidebarWaveRowLayoutClasses({
+    isChildRow,
+    variant: "web",
+  });
   const subwavePrefetchTimerRef = useRef<ReturnType<
     typeof globalThis.setTimeout
   > | null>(null);
@@ -155,7 +160,7 @@ export const ExpandedWave = ({
       {isChildRow && (
         <span
           aria-hidden="true"
-          className={`tw-absolute -tw-top-1 tw-left-[35.5px] tw-w-px tw-bg-iron-700/60 ${
+          className={`tw-absolute -tw-top-1 ${guideLineOffsetClasses} tw-w-px tw-bg-iron-700/60 ${
             isLastSubwave ? "tw-bottom-4" : "-tw-bottom-1"
           }`}
         />

--- a/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.tsx
+++ b/components/brain/left-sidebar/web/WebUnifiedWavesListWaves.tsx
@@ -316,7 +316,7 @@ function WebProfileFeedShortcut({
 
   return (
     <div
-      className={`tw-group tw-flex tw-items-center tw-gap-x-4 tw-px-5 tw-py-2 tw-transition-all tw-duration-200 tw-ease-out ${
+      className={`tw-group tw-mt-2 tw-flex tw-items-center tw-gap-x-4 tw-px-5 tw-py-2 tw-transition-all tw-duration-200 tw-ease-out ${
         isActive
           ? "tw-bg-iron-700/60 desktop-hover:hover:tw-bg-iron-700/70"
           : "desktop-hover:hover:tw-bg-iron-800/80"


### PR DESCRIPTION
## Issue
- The waves left sidebar felt visually cramped: subwave timestamps sat awkwardly against titles, child rows needed better horizontal rhythm, the active Profile Waves Feed row touched the create button, and the subwave guide line was not centered under the parent wave avatar.

## Fix
- Tuned the existing Tailwind sidebar row spacing without introducing new layout primitives.
- Centered the subwave guide line on the parent avatar's visual center using the rendered row geometry.

## Changes
- Adjusted child wave row padding for the app and web sidebar variants.
- Added a small title offset and timestamp line-height tweak so title/date spacing reads more balanced.
- Added top spacing to the expanded Profile Waves Feed shortcut when active.
- Repositioned subwave guide lines so their visual center aligns with the parent avatar center across desktop and narrow widths.

## Validation
- `git diff --check`
- `./bin/6529 run lint:uncommitted:tight`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff`
- Browser geometry check on `/waves`: desktop 1206px avatar center 116, guide center 116.
- Browser geometry check on `/waves`: narrow 620px avatar center 116, guide center 116.

## Risk
- Level: Low
- Why: visual-only Tailwind class changes scoped to the waves left sidebar.
- Rollback: revert the sidebar spacing commit.

## Review Notes
- React Doctor still reports existing warnings for `WebUnifiedWavesListWaves` size and inline `renderWaveRow()`. This PR does not add new structural patterns there; it only changes spacing classes in the touched sidebar surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alignment and spacing in the left sidebar wave layout for child rows and expanded views.
  * Adjusted the guide line positioning so it follows shared layout settings more consistently.
  * Refined text spacing and line height for drop-time labels to improve readability.
  * Made a small spacing update in the web sidebar list for better visual balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->