### PR TITLE
[codex] Harden push registration telemetry

### DIFF
--- a/__tests__/components/notifications/NotificationsContext.test.tsx
+++ b/__tests__/components/notifications/NotificationsContext.test.tsx
@@ -213,13 +213,20 @@ describe("push registration behavior", () => {
     let registrationCallback:
       | ((token: { value: string }) => Promise<void>)
       | null = null;
+    let registrationErrorCallback: ((error: unknown) => void) | null = null;
 
     PushNotifications.addListener.mockImplementation(
-      (event: string, callback: (arg: unknown) => Promise<void>) => {
+      (
+        event: string,
+        callback: (arg: unknown) => void | Promise<void>
+      ) => {
         if (event === "registration") {
           registrationCallback = callback as (token: {
             value: string;
           }) => Promise<void>;
+        }
+        if (event === "registrationError") {
+          registrationErrorCallback = callback as (error: unknown) => void;
         }
         return Promise.resolve();
       }
@@ -236,6 +243,9 @@ describe("push registration behavior", () => {
     await waitFor(() => {
       expect(registrationCallback).not.toBeNull();
     });
+    await waitFor(() => {
+      expect(registrationErrorCallback).not.toBeNull();
+    });
 
     return {
       registrationCallback: registrationCallback as (token: {
@@ -248,6 +258,9 @@ describe("push registration behavior", () => {
         return registrationCallback;
       },
       rerender: renderedHook.rerender,
+      registrationErrorCallback: registrationErrorCallback as (
+        error: unknown
+      ) => void,
     };
   };
 
@@ -485,6 +498,46 @@ describe("push registration behavior", () => {
     expect(sentry.captureException).not.toHaveBeenCalled();
   });
 
+  it("retries object-shaped network-lost token registration errors without capture", async () => {
+    const { commonApiPost } = require("@/services/api/common-api");
+    const sentry = require("@sentry/nextjs");
+    const networkLostError = { error: "The network connection was lost." };
+
+    commonApiPost
+      .mockRejectedValueOnce(networkLostError)
+      .mockResolvedValueOnce({});
+    const { registrationCallback } = await setupRegistrationCallback();
+
+    const setTimeoutSpy = jest.spyOn(global, "setTimeout").mockImplementation(((
+      handler: TimerHandler
+    ) => {
+      if (typeof handler === "function") {
+        handler();
+      }
+      return 0 as unknown as NodeJS.Timeout;
+    }) as typeof global.setTimeout);
+
+    try {
+      await act(async () => {
+        await registrationCallback({ value: "test-token" });
+      });
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+
+    expect(commonApiPost).toHaveBeenCalledTimes(2);
+    expect(sentry.captureException).not.toHaveBeenCalled();
+    expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Push registration attempt failed. Retrying.",
+        data: expect.objectContaining({
+          error_message: "The network connection was lost.",
+          rate_limited: false,
+        }),
+      })
+    );
+  });
+
   it("skips duplicate registration for identical fingerprint", async () => {
     const { commonApiPost } = require("@/services/api/common-api");
     const sentry = require("@sentry/nextjs");
@@ -501,6 +554,61 @@ describe("push registration behavior", () => {
         message: "Push registration skipped (already registered in session).",
       })
     );
+  });
+
+  it("records transient native registration errors as warning breadcrumbs", async () => {
+    const sentry = require("@sentry/nextjs");
+    const nativeError = { error: "The network connection was lost." };
+    const { registrationErrorCallback } = await setupRegistrationCallback();
+
+    act(() => {
+      registrationErrorCallback(nativeError);
+    });
+
+    expect(sentry.captureException).not.toHaveBeenCalled();
+    expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: "warning",
+        message: "Push registration transient error.",
+        data: expect.objectContaining({
+          component: "NotificationsProvider",
+          operation: "pushRegistrationError",
+          retryable: true,
+          error_message: "The network connection was lost.",
+        }),
+      })
+    );
+  });
+
+  it("captures non-transient native registration objects as Error instances", async () => {
+    const sentry = require("@sentry/nextjs");
+    const nativeError = {
+      code: "APNS_ENTITLEMENT_MISSING",
+      error: "Missing APNS entitlement",
+    };
+    const { registrationErrorCallback } = await setupRegistrationCallback();
+
+    act(() => {
+      registrationErrorCallback(nativeError);
+    });
+
+    expect(sentry.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          component: "NotificationsProvider",
+          operation: "pushRegistrationError",
+        }),
+        extra: expect.objectContaining({
+          retryable: false,
+          error_code: "APNS_ENTITLEMENT_MISSING",
+          error_message: "Missing APNS entitlement",
+        }),
+      })
+    );
+    const capturedError = sentry.captureException.mock.calls[0][0] as Error;
+    expect(capturedError).toBeInstanceOf(Error);
+    expect(capturedError.message).toBe("Missing APNS entitlement");
   });
 
   it("captures non-rate-limit push registration errors", async () => {

--- a/components/notifications/NotificationsContext.tsx
+++ b/components/notifications/NotificationsContext.tsx
@@ -87,6 +87,7 @@ const RATE_LIMIT_ERROR_PATTERNS = ["rate limit", "too many requests", "429"];
 const TRANSIENT_ERROR_PATTERNS = [
   "failed to fetch",
   "load failed",
+  "network connection was lost",
   "network request failed",
   "network error",
   "timeout",
@@ -98,26 +99,76 @@ type PushRegistrationFingerprint = {
   profileId: string | null;
 };
 
-const toErrorMessage = (error: unknown): string => {
+type ErrorTelemetryExtra = {
+  error_message: string;
+  error_name?: string;
+  error_code?: string | number;
+  status_code?: number;
+};
+
+const getStringErrorField = (
+  record: Record<string, unknown>,
+  field: string
+): string | null => {
+  const value = record[field];
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  if (value instanceof Error && value.message.trim()) {
+    return value.message.trim();
+  }
+  if (value !== null && typeof value === "object") {
+    const nestedRecord = value as Record<string, unknown>;
+    const nestedMessage = nestedRecord["message"];
+    if (typeof nestedMessage === "string" && nestedMessage.trim()) {
+      return nestedMessage.trim();
+    }
+  }
+  return null;
+};
+
+const toErrorMessage = (
+  error: unknown,
+  fallbackMessage = "Unknown notification error"
+): string => {
   if (error instanceof Error) {
-    return error.message;
+    return error.message.trim() || fallbackMessage;
   }
   if (typeof error === "string") {
-    return error;
+    return error.trim() || fallbackMessage;
   }
-  if (typeof error === "object" && error) {
-    const typedError = error as {
-      message?: unknown;
-      error?: unknown;
-    };
-    if (typeof typedError.message === "string") {
-      return typedError.message;
-    }
-    if (typeof typedError.error === "string") {
-      return typedError.error;
-    }
+  if (error === null || error === undefined) {
+    return fallbackMessage;
   }
-  return String(error);
+  if (typeof error === "object") {
+    const typedError = error as Record<string, unknown>;
+    const extractedMessage =
+      getStringErrorField(typedError, "message") ??
+      getStringErrorField(typedError, "error") ??
+      getStringErrorField(typedError, "reason") ??
+      getStringErrorField(typedError, "localizedDescription") ??
+      getStringErrorField(typedError, "description");
+    if (extractedMessage !== null) {
+      return extractedMessage;
+    }
+    return fallbackMessage;
+  }
+
+  if (
+    typeof error === "number" ||
+    typeof error === "boolean" ||
+    typeof error === "bigint"
+  ) {
+    return String(error);
+  }
+  if (typeof error === "symbol") {
+    const symbolDescription = error.description;
+    return typeof symbolDescription === "string" && symbolDescription.length > 0
+      ? `Symbol(${symbolDescription})`
+      : fallbackMessage;
+  }
+
+  return fallbackMessage;
 };
 
 const parseStatusCode = (status: unknown): number | null => {
@@ -302,11 +353,47 @@ const computePushRegistrationRetryDelayMs = (
   return Math.max(0, Math.round(baseDelay * jitterMultiplier));
 };
 
-const toCaptureExceptionInput = (error: unknown): Error => {
+const extractErrorCode = (error: unknown): string | number | undefined => {
+  if (error === null || typeof error !== "object") {
+    return undefined;
+  }
+
+  const typedError = error as {
+    code?: unknown;
+    errorCode?: unknown;
+  };
+  const errorCode = typedError.code ?? typedError.errorCode;
+  return typeof errorCode === "string" || typeof errorCode === "number"
+    ? errorCode
+    : undefined;
+};
+
+const createErrorTelemetryExtra = (error: unknown): ErrorTelemetryExtra => {
+  const statusCode = extractErrorStatusCode(error);
+  const telemetryExtra: ErrorTelemetryExtra = {
+    error_message: toErrorMessage(error),
+  };
+  if (error instanceof Error) {
+    telemetryExtra.error_name = error.name;
+  }
+  const errorCode = extractErrorCode(error);
+  if (errorCode !== undefined) {
+    telemetryExtra.error_code = errorCode;
+  }
+  if (statusCode !== null) {
+    telemetryExtra.status_code = statusCode;
+  }
+  return telemetryExtra;
+};
+
+const toCaptureExceptionInput = (
+  error: unknown,
+  fallbackMessage?: string
+): Error => {
   if (error instanceof Error) {
     return error;
   }
-  return new Error(toErrorMessage(error));
+  return new Error(toErrorMessage(error, fallbackMessage));
 };
 
 const createPushRegistrationFingerprint = ({
@@ -708,6 +795,7 @@ export const NotificationsProvider: React.FC<{ children: React.ReactNode }> = ({
           const attemptNumber = attempt + 1;
           const statusCode = extractErrorStatusCode(error);
           const unauthorized = isUnauthorizedPushRegistrationError(error);
+          const errorExtra = createErrorTelemetryExtra(error);
           const rateLimited = isRateLimitError(error);
           const retryAfterMs = extractRetryAfterMs(error);
           const hasRetriesLeft =
@@ -730,6 +818,7 @@ export const NotificationsProvider: React.FC<{ children: React.ReactNode }> = ({
               rateLimited,
               statusCode,
               profileId,
+              errorMessage: errorExtra.error_message,
             });
             Sentry.addBreadcrumb({
               category: "notifications",
@@ -742,7 +831,7 @@ export const NotificationsProvider: React.FC<{ children: React.ReactNode }> = ({
                 max_attempts: PUSH_REGISTRATION_TOTAL_ATTEMPTS,
                 delay_ms: delayMs,
                 rate_limited: rateLimited,
-                status_code: statusCode ?? undefined,
+                ...errorExtra,
                 profile_id: profileId ?? undefined,
                 platform: deviceInfo.platform,
               },
@@ -785,6 +874,7 @@ export const NotificationsProvider: React.FC<{ children: React.ReactNode }> = ({
               maxAttempts: PUSH_REGISTRATION_TOTAL_ATTEMPTS,
               statusCode,
               profileId,
+              errorMessage: errorExtra.error_message,
             });
             Sentry.addBreadcrumb({
               category: "notifications",
@@ -796,7 +886,7 @@ export const NotificationsProvider: React.FC<{ children: React.ReactNode }> = ({
                 attempt: attemptNumber,
                 max_attempts: PUSH_REGISTRATION_TOTAL_ATTEMPTS,
                 delay_ms: retryAfterMs ?? undefined,
-                status_code: statusCode ?? undefined,
+                ...errorExtra,
                 profile_id: profileId ?? undefined,
                 platform: deviceInfo.platform,
               },
@@ -813,9 +903,9 @@ export const NotificationsProvider: React.FC<{ children: React.ReactNode }> = ({
             extra: {
               attempt: attemptNumber,
               max_attempts: PUSH_REGISTRATION_TOTAL_ATTEMPTS,
-              status_code: statusCode ?? undefined,
               profile_id: profileId ?? undefined,
               platform: deviceInfo.platform,
+              ...errorExtra,
             },
           });
           return false;
@@ -936,13 +1026,45 @@ export const NotificationsProvider: React.FC<{ children: React.ReactNode }> = ({
 
         await PushNotifications.addListener("registrationError", (error) => {
           isRegisteredRef.current = false;
+          const statusCode = extractErrorStatusCode(error);
+          const errorExtra = createErrorTelemetryExtra(error);
+
+          if (isTransientPushRegistrationError(error)) {
+            console.warn("Transient push registration error", {
+              statusCode,
+              ...errorExtra,
+            });
+            Sentry.addBreadcrumb({
+              category: "notifications",
+              level: "warning",
+              message: "Push registration transient error.",
+              data: {
+                component: "NotificationsProvider",
+                operation: "pushRegistrationError",
+                retryable: true,
+                ...errorExtra,
+              },
+            });
+            return;
+          }
+
           console.error("Push registration error: ", error);
-          Sentry.captureException(error, {
-            tags: {
-              component: "NotificationsProvider",
-              operation: "pushRegistrationError",
-            },
-          });
+          Sentry.captureException(
+            toCaptureExceptionInput(
+              error,
+              "Push notification registration failed"
+            ),
+            {
+              tags: {
+                component: "NotificationsProvider",
+                operation: "pushRegistrationError",
+              },
+              extra: {
+                retryable: false,
+                ...errorExtra,
+              },
+            }
+          );
         });
 
         await PushNotifications.addListener(
@@ -1001,12 +1123,19 @@ export const NotificationsProvider: React.FC<{ children: React.ReactNode }> = ({
       initializationRef.current = initializationKey;
       initializeNotifications(connectedProfile ?? undefined).catch((error) => {
         console.error("Failed to initialize push notifications", error);
-        Sentry.captureException(error, {
-          tags: {
-            component: "NotificationsProvider",
-            operation: "initializeNotifications",
-          },
-        });
+        Sentry.captureException(
+          toCaptureExceptionInput(
+            error,
+            "Failed to initialize push notifications"
+          ),
+          {
+            tags: {
+              component: "NotificationsProvider",
+              operation: "initializeNotifications",
+            },
+            extra: createErrorTelemetryExtra(error),
+          }
+        );
         if (initializationRef.current === initializationKey) {
           initializationRef.current = null;
         }
@@ -1032,12 +1161,19 @@ export const NotificationsProvider: React.FC<{ children: React.ReactNode }> = ({
           await removeDeliveredNotifications(waveNotifications);
         } catch (error) {
           console.error("Error removing wave delivered notifications", error);
-          Sentry.captureException(error, {
-            tags: {
-              component: "NotificationsProvider",
-              operation: "removeWaveDeliveredNotifications",
-            },
-          });
+          Sentry.captureException(
+            toCaptureExceptionInput(
+              error,
+              "Failed to remove wave delivered notifications"
+            ),
+            {
+              tags: {
+                component: "NotificationsProvider",
+                operation: "removeWaveDeliveredNotifications",
+              },
+              extra: createErrorTelemetryExtra(error),
+            }
+          );
         }
       }
     },
@@ -1050,12 +1186,19 @@ export const NotificationsProvider: React.FC<{ children: React.ReactNode }> = ({
         await PushNotifications.removeAllDeliveredNotifications();
       } catch (error) {
         console.error("Error removing all delivered notifications", error);
-        Sentry.captureException(error, {
-          tags: {
-            component: "NotificationsProvider",
-            operation: "removeAllDeliveredNotifications",
-          },
-        });
+        Sentry.captureException(
+          toCaptureExceptionInput(
+            error,
+            "Failed to remove all delivered notifications"
+          ),
+          {
+            tags: {
+              component: "NotificationsProvider",
+              operation: "removeAllDeliveredNotifications",
+            },
+            extra: createErrorTelemetryExtra(error),
+          }
+        );
       }
     }
   }, [isIos]);


### PR DESCRIPTION
## Issue
- Addresses Sentry issue `6529-FRONTEND-4H`, where mobile push registration/native failures could be captured as anonymous object-shaped exceptions with low-value messages such as `[object Object]`.

## Fix
- Normalize native/plugin/API error payloads into real `Error` instances before `Sentry.captureException`.
- Treat known transient push-registration failures, including WebKit/native `The network connection was lost.`, as retryable warning telemetry rather than full exception captures.
- Preserve capture behavior for non-transient native registration errors, with structured extras for message, code, status, and retryability.
- Rebased onto latest `main` after #2913 and preserved its stale/missing push-auth handling plus auth-fingerprint initialization key behavior.

## Changes
- Expanded notification error-message extraction for object-shaped native errors.
- Added structured telemetry extras on push-registration captures and warning breadcrumbs.
- Added focused mocked Capacitor listener coverage for token-registration retries, native `registrationError` transient handling, and non-transient native object capture.

## Validation
- `./bin/6529 run test -- __tests__/components/notifications/NotificationsContext.test.tsx` passed, 20 tests.
- `./bin/6529 run lint:changed` passed.
- `./bin/6529 run lint:diff` passed.
- `./bin/6529 run typecheck:ci` passed.
- `./bin/6529 run react-doctor:diff` exited successfully, but skipped because its diff detection found no changed source files on the committed branch.
- No native/APNS device QA was run. Native behavior is covered by mocked Capacitor `registration` and `registrationError` listener tests because practical APNS/device simulation was not available in this flow.

## Risk
- Level: Low
- Why: scoped to frontend notification telemetry classification; no backend push endpoint, auth contract, or delivery contract changes. Conflict resolution kept #2913's stale-auth/no-usable-auth registration behavior intact.
- Rollback: revert this commit to restore prior capture behavior.

## Review Notes
- Review the retry/no-capture behavior for `The network connection was lost.` and the non-transient native error path that still captures a real `Error` with useful extras.
- The prior sidebar spacing test commits are no longer part of this PR diff because latest `main` already contains those expectations.
