### PR TITLE
Avoid passive v2 session refresh on auth validation

### DIFF
--- a/__tests__/components/auth/Auth.test.tsx
+++ b/__tests__/components/auth/Auth.test.tsx
@@ -1724,7 +1724,7 @@ describe("Auth component", () => {
       expect(verifiedAddresses).not.toContain(liveProviderAddress);
     });
 
-    it("fails closed when context web-session verification errors without changing upgrade state", async () => {
+    it("does not change session upgrade state when context web-session verification errors", async () => {
       const validAddress = "0x1111111111111111111111111111111111111111";
       walletAddress = validAddress;
       const authUtils = require("@/services/auth/auth.utils");

--- a/__tests__/components/auth/Auth.test.tsx
+++ b/__tests__/components/auth/Auth.test.tsx
@@ -1610,7 +1610,7 @@ describe("Auth component", () => {
       expect(mockRemoveAuthJwt).not.toHaveBeenCalled();
     });
 
-    it("marks a connected local v2 session as needing upgrade when the web session is missing", async () => {
+    it("does not rotate a connected local v2 web session during immediate validation", async () => {
       const validAddress = "0x1111111111111111111111111111111111111111";
       walletAddress = validAddress;
       const authUtils = require("@/services/auth/auth.utils");
@@ -1638,18 +1638,15 @@ describe("Auth component", () => {
       );
 
       await waitFor(() => {
-        expect(sessionV2.verifyActiveSessionV2WebSession).toHaveBeenCalledWith({
-          address: validAddress,
-          abortSignal: expect.objectContaining({ aborted: false }),
-        });
+        expect(mockValidateAuthImmediate).toHaveBeenCalled();
       });
       expect(screen.getByTestId("session-upgrade-required")).toHaveTextContent(
-        "true"
+        "false"
       );
       expect(
         screen.queryByText("Upgrade Authentication")
       ).not.toBeInTheDocument();
-      expect(mockValidateAuthImmediate).not.toHaveBeenCalled();
+      expect(sessionV2.verifyActiveSessionV2WebSession).not.toHaveBeenCalled();
     });
 
     it("verifies the active stored v2 session when the live wallet provider address differs", async () => {
@@ -1742,9 +1739,9 @@ describe("Auth component", () => {
       mockGetAuthJwt.mockReturnValue("v2-jwt");
       mockGetWalletAddress.mockReturnValue(validAddress);
       mockHasActiveSessionV2Auth.mockReturnValue(true);
-      sessionV2.verifyActiveSessionV2WebSession
-        .mockResolvedValueOnce(true)
-        .mockRejectedValueOnce(new Error("verification failed"));
+      sessionV2.verifyActiveSessionV2WebSession.mockRejectedValueOnce(
+        new Error("verification failed")
+      );
       mockValidateAuthImmediate.mockResolvedValue({
         validationCompleted: true,
         wasCancelled: false,
@@ -1762,9 +1759,7 @@ describe("Auth component", () => {
       );
 
       await waitFor(() => {
-        expect(sessionV2.verifyActiveSessionV2WebSession).toHaveBeenCalledTimes(
-          1
-        );
+        expect(mockValidateAuthImmediate).toHaveBeenCalled();
       });
 
       const user = userEvent.setup();
@@ -1783,7 +1778,7 @@ describe("Auth component", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("marks a disconnected stored v2 session as needing upgrade when the web session is missing", async () => {
+    it("does not rotate a disconnected stored v2 web session during passive validation", async () => {
       const validAddress = "0x1111111111111111111111111111111111111111";
       walletAddress = null;
       connectionState = "disconnected";
@@ -1813,12 +1808,9 @@ describe("Auth component", () => {
       await waitFor(() => {
         expect(
           screen.getByTestId("session-upgrade-required")
-        ).toHaveTextContent("true");
+        ).toHaveTextContent("false");
       });
-      expect(sessionV2.verifyActiveSessionV2WebSession).toHaveBeenCalledWith({
-        address: validAddress,
-        abortSignal: expect.objectContaining({ aborted: false }),
-      });
+      expect(sessionV2.verifyActiveSessionV2WebSession).not.toHaveBeenCalled();
       expect(
         screen.queryByText("Upgrade Authentication")
       ).not.toBeInTheDocument();

--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWave.test.tsx
@@ -461,15 +461,15 @@ describe("BrainLeftSidebarWave", () => {
     expect(
       screen.queryByRole("button", { name: "Expand Chat Wave subwaves" })
     ).not.toBeInTheDocument();
-    expect(getWaveRow()).toHaveClass("tw-pl-[82px]");
-    expect(getWaveRow()).toHaveClass("md:tw-pl-[78px]");
+    expect(getWaveRow()).toHaveClass("tw-pl-[74px]");
+    expect(getWaveRow()).toHaveClass("md:tw-pl-[70px]");
     expect(screen.getByTestId("wave-picture").parentElement).toHaveClass(
       "tw-size-7"
     );
     const rail = getWaveRow().querySelector(".tw-w-px");
     expect(rail).not.toBeNull();
-    expect(rail).toHaveClass("tw-left-14");
-    expect(rail).toHaveClass("md:tw-left-[52px]");
+    expect(rail).toHaveClass("tw-left-[35.5px]");
+    expect(rail).not.toHaveClass("md:tw-left-[52px]");
     expect(rail).toHaveClass("-tw-top-1");
     expect(rail).toHaveClass("tw-bottom-4");
     expect(getWaveRow()).toHaveClass("tw-items-center");

--- a/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
+++ b/__tests__/components/brain/left-sidebar/web/ExpandedWave.test.tsx
@@ -223,15 +223,15 @@ describe("ExpandedWave", () => {
     expect(
       screen.queryByRole("button", { name: "Expand Chat Wave subwaves" })
     ).not.toBeInTheDocument();
-    expect(getWaveRow()).toHaveClass("tw-pl-[82px]");
-    expect(getWaveRow()).toHaveClass("md:tw-pl-[70px]");
+    expect(getWaveRow()).toHaveClass("tw-pl-[74px]");
+    expect(getWaveRow()).toHaveClass("md:tw-pl-[66px]");
     expect(screen.getByTestId("wave-picture").parentElement).toHaveClass(
       "tw-size-7"
     );
     const rail = getWaveRow().querySelector(".tw-w-px");
     expect(rail).not.toBeNull();
-    expect(rail).toHaveClass("tw-left-14");
-    expect(rail).toHaveClass("md:tw-left-11");
+    expect(rail).toHaveClass("tw-left-[35.5px]");
+    expect(rail).not.toHaveClass("md:tw-left-11");
     expect(rail).toHaveClass("-tw-top-1");
     expect(rail).toHaveClass("tw-bottom-4");
     expect(getWaveRow()).toHaveClass("tw-items-center");

--- a/components/auth/Auth.tsx
+++ b/components/auth/Auth.tsx
@@ -174,10 +174,6 @@ interface RunImmediateAuthValidationParams {
   readonly setShowSignModal: (show: boolean) => void;
   readonly invalidateAll: () => void;
   readonly reset: () => void;
-  readonly verifyActiveSessionV2WebSession: (
-    address: string,
-    abortSignal: AbortSignal
-  ) => Promise<boolean>;
   readonly authRolloutSettings: AuthRolloutSettings;
 }
 
@@ -479,7 +475,6 @@ const runImmediateAuthValidation = async ({
   setShowSignModal,
   invalidateAll,
   reset,
-  verifyActiveSessionV2WebSession,
   authRolloutSettings,
 }: RunImmediateAuthValidationParams): Promise<void> => {
   if (
@@ -519,29 +514,6 @@ const runImmediateAuthValidation = async ({
   };
 
   try {
-    if (
-      hasActiveSessionV2Auth({ address: currentAddress }) &&
-      getSessionClientType() === "web"
-    ) {
-      const hasActiveWebSession = await verifyActiveSessionV2WebSession(
-        currentAddress,
-        abortController.signal
-      );
-
-      if (
-        !hasActiveWebSession &&
-        isCurrentValidationOperation({
-          latestAddressRef,
-          activeValidationOperationIdRef,
-          currentAddress,
-          operationId,
-        })
-      ) {
-        markSessionUpgradeRequired();
-        return;
-      }
-    }
-
     const result = await measureMobileLaunchAsync(
       "auth_immediate_validation",
       () =>
@@ -857,47 +829,6 @@ export default function Auth({
     []
   );
 
-  const ensureActiveWebSessionForAddress = useCallback(
-    async (
-      walletAddress: string,
-      abortSignal?: AbortSignal
-    ): Promise<boolean> => {
-      if (!hasActiveSessionV2Auth({ address: walletAddress })) {
-        if (!abortSignal?.aborted) {
-          setSessionUpgradeRequired(true);
-          setSessionUpgradeHasDeadline(false);
-        }
-        return false;
-      }
-
-      try {
-        const hasActiveWebSession = await verifyActiveSessionV2WebSession({
-          address: walletAddress,
-          abortSignal,
-        });
-
-        if (abortSignal?.aborted) {
-          return true;
-        }
-
-        if (!hasActiveWebSession) {
-          setSessionUpgradeRequired(true);
-          setSessionUpgradeHasDeadline(false);
-          return false;
-        }
-
-        setSessionUpgradeRequired(false);
-        return true;
-      } catch (error) {
-        if (!abortSignal?.aborted) {
-          logErrorSecurely("session_v2_web_session_verification", error);
-        }
-        return true;
-      }
-    },
-    []
-  );
-
   const ensureActiveSessionV2WebSessionForActiveWallet = useCallback(
     async (abortSignal?: AbortSignal): Promise<boolean> => {
       const walletAddress = getWalletAddress() ?? address;
@@ -937,12 +868,14 @@ export default function Auth({
         return undefined;
       }
 
-      const controller = new AbortController();
-      void ensureActiveWebSessionForAddress(
-        storedAuthAddress,
-        controller.signal
-      );
-      return () => controller.abort();
+      if (!hasActiveSessionV2Auth({ address: storedAuthAddress })) {
+        setSessionUpgradeRequired(true);
+        setSessionUpgradeHasDeadline(false);
+      } else {
+        setSessionUpgradeRequired(false);
+        setSessionUpgradeHasDeadline(false);
+      }
+      return undefined;
     }
 
     if (!isAddressAuthorized) {
@@ -997,7 +930,6 @@ export default function Auth({
       setShowSignModal,
       invalidateAll,
       reset,
-      verifyActiveSessionV2WebSession: ensureActiveWebSessionForAddress,
       authRolloutSettings,
     }).catch((error) => {
       logErrorSecurely("auth_immediate_validation_unhandled", error);
@@ -1015,7 +947,6 @@ export default function Auth({
     hasActiveWalletAddress,
     canSignActiveWallet,
     abortCurrentAuthOperation,
-    ensureActiveWebSessionForAddress,
     invalidateAll,
     reset,
     authRolloutSettings,

--- a/components/auth/Auth.tsx
+++ b/components/auth/Auth.tsx
@@ -868,13 +868,14 @@ export default function Auth({
         return undefined;
       }
 
-      if (!hasActiveSessionV2Auth({ address: storedAuthAddress })) {
-        setSessionUpgradeRequired(true);
-        setSessionUpgradeHasDeadline(false);
-      } else {
-        setSessionUpgradeRequired(false);
-        setSessionUpgradeHasDeadline(false);
-      }
+      // Passive disconnected validation must not call session-refresh: that
+      // endpoint rotates the web session cookie and can race during reload.
+      // Explicit actions, such as connection sharing, still verify server
+      // session state before proceeding.
+      setSessionUpgradeHasDeadline(false);
+      setSessionUpgradeRequired(
+        !hasActiveSessionV2Auth({ address: storedAuthAddress })
+      );
       return undefined;
     }
 


### PR DESCRIPTION
## Summary
- stop passive auth validation from rotating the v2 web session refresh cookie
- keep explicit v2 web-session verification available for share-code flows
- update Auth tests around passive validation behavior

## Validation
- ./bin/6529 run test:no-coverage -- __tests__/components/auth/Auth.test.tsx --runInBand