### PR TITLE
Add Genesis Sets to Help6529 corpus

### DIFF
--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -704,7 +704,9 @@
         "definitions",
         "network definitions",
         "tdh definitions",
-        "network glossary"
+        "network glossary",
+        "genesis set",
+        "genesis sets"
       ],
       "keywords": [
         "definitions",
@@ -713,6 +715,7 @@
         "unique",
         "memes",
         "sets",
+        "genesis",
         "tdh",
         "purchases",
         "sales",
@@ -720,6 +723,7 @@
       ],
       "facts": [
         "Network definitions explain Cards Collected, Unique Memes, Meme Sets, TDH variants, purchases, sales, transfers, and related Network metrics.",
+        "Genesis Sets are complete sets of the first three Meme NFTs.",
         "Use the definitions page when users ask what a Network metric means.",
         "For a single TDH explanation, point users to the TDH page."
       ],

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -704,7 +704,9 @@
         "definitions",
         "network definitions",
         "tdh definitions",
-        "network glossary"
+        "network glossary",
+        "genesis set",
+        "genesis sets"
       ],
       "keywords": [
         "definitions",
@@ -713,6 +715,7 @@
         "unique",
         "memes",
         "sets",
+        "genesis",
         "tdh",
         "purchases",
         "sales",
@@ -720,6 +723,7 @@
       ],
       "facts": [
         "Network definitions explain Cards Collected, Unique Memes, Meme Sets, TDH variants, purchases, sales, transfers, and related Network metrics.",
+        "Genesis Sets are complete sets of the first three Meme NFTs.",
         "Use the definitions page when users ask what a Network metric means.",
         "For a single TDH explanation, point users to the TDH page."
       ],


### PR DESCRIPTION
## Summary
- Add `genesis set` / `genesis sets` aliases to the Network Definitions help record.
- Add the explicit Genesis Sets definition from the Network Definitions page.
- Regenerate `public/help-index.json` from the source corpus.

## Validation
- `./bin/6529 run help-index:sync`