### PR TITLE
Open quick DM header button to active conversation

### DIFF
--- a/components/messages/quick-dms/QuickDirectMessages.tsx
+++ b/components/messages/quick-dms/QuickDirectMessages.tsx
@@ -234,6 +234,7 @@ const QuickDmPanelHeader = ({
   avatar,
   hasBackUnreadIndicator = false,
   locale,
+  openAllHref,
   title,
   onBack,
   onClose,
@@ -242,6 +243,7 @@ const QuickDmPanelHeader = ({
   readonly avatar?: React.ReactNode;
   readonly hasBackUnreadIndicator?: boolean;
   readonly locale: SupportedLocale;
+  readonly openAllHref?: string | undefined;
   readonly title: string;
   readonly onBack?: (() => void) | undefined;
   readonly onClose: () => void;
@@ -268,12 +270,14 @@ const QuickDmPanelHeader = ({
         {title}
       </h2>
     </div>
-    {onOpenAll && (
+    {onOpenAll && openAllHref && (
       <Link
-        href={getMessagesBaseRoute(false)}
+        href={openAllHref}
         onClick={onOpenAll}
-        aria-label={t(locale, "quickDm.openAllAriaLabel")}
-        title={t(locale, "quickDm.openAll")}
+        aria-label={t(locale, "quickDm.openConversationAriaLabel", {
+          name: title,
+        })}
+        title={t(locale, "quickDm.openConversation")}
         className="tw-inline-flex tw-size-8 tw-items-center tw-justify-center tw-rounded-lg tw-text-iron-300 tw-transition hover:tw-bg-white/10 hover:tw-text-white focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400"
       >
         <ArrowTopRightOnSquareIcon className="tw-size-4" aria-hidden="true" />
@@ -575,6 +579,7 @@ const QuickDmChat = ({
         locale={locale}
         title={title || t(locale, "quickDm.chatTitleFallback")}
         avatar={avatar ? <QuickDmHeaderAvatar avatar={avatar} /> : undefined}
+        openAllHref={getMessagePathRoute(waveId)}
         onBack={onBack}
         onClose={onClose}
         onOpenAll={onOpenAll}


### PR DESCRIPTION
## Summary
- Change the quick DM chat header external/open button to link to the active DM route (`/messages/<waveId>`) instead of the generic messages inbox
- Keep the list panel Show all link pointing at `/messages`
- Update the button tooltip/accessibility label to describe opening the conversation

## Validation
- `./bin/6529 exec prettier --check components/messages/quick-dms/QuickDirectMessages.tsx`
- `./bin/6529 exec eslint --no-warn-ignored --max-warnings=0 components/messages/quick-dms/QuickDirectMessages.tsx`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * “Open all” links in quick direct messages now navigate to the specific conversation path when available.
  * The link is shown only when both the action and destination are provided, improving consistency in the chat header.
  * Accessibility labels and titles now reflect the current conversation name for clearer context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->