### PR TITLE
[codex] Stabilize waves media scroll

### DIFF
--- a/__tests__/components/waves/drops/WaveDropPartContentMedias.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropPartContentMedias.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from "@testing-library/react";
 import React from "react";
 import WaveDropPartContentMedias from "@/components/waves/drops/WaveDropPartContentMedias";
 import { ApiDropMediaStatus } from "@/generated/models/ApiDropMediaStatus";
+import DropContext from "@/components/waves/drops/DropContext";
+import { DropLocation } from "@/components/waves/drops/drop.types";
 
 jest.mock("@/components/drops/view/item/content/media/MediaDisplay", () => ({
   __esModule: true,
@@ -137,6 +139,28 @@ describe("WaveDropPartContentMedias", () => {
     expect(image.parentElement).not.toHaveClass("tw-h-64");
     expect(video).toHaveAttribute("data-fill-video-container", "false");
     expect(video.parentElement).not.toHaveClass("tw-h-64");
+  });
+
+  it("reserves full-width media height when the drop context requests stable media layout", () => {
+    render(
+      <DropContext.Provider
+        value={{
+          drop: null,
+          location: DropLocation.MY_STREAM,
+          reserveMediaHeight: true,
+        }}
+      >
+        <WaveDropPartContentMedias activePart={basePart} fullWidthMedia />
+      </DropContext.Provider>
+    );
+
+    const image = screen.getByTestId("wave-image-media");
+    const video = screen.getByTestId("drop-media");
+
+    expect(image).toHaveAttribute("data-fill-container", "true");
+    expect(image.parentElement).toHaveClass("tw-h-64", "tw-w-full");
+    expect(video).toHaveAttribute("data-fill-video-container", "true");
+    expect(video.parentElement).toHaveClass("tw-h-64", "tw-w-full");
   });
 
   it("uses custom reserved height classes for normal image media only", () => {

--- a/components/community-curations/CommunityCurationsMasonry.tsx
+++ b/components/community-curations/CommunityCurationsMasonry.tsx
@@ -271,6 +271,7 @@ function CommunityCurationsMasonryItem({
           inlineAuthorOnDesktop={true}
           fullWidthMedia={true}
           fullWidthLinkPreviews={true}
+          reserveMediaHeight={true}
           showVideoFullscreen={false}
         />
       </WaveDropQuoteDisplayProvider>

--- a/components/waves/drops/Drop.tsx
+++ b/components/waves/drops/Drop.tsx
@@ -46,6 +46,7 @@ interface DropProps {
   readonly mediaImageScale?: ImageScale | undefined;
   readonly fullWidthMedia?: boolean | undefined;
   readonly fullWidthLinkPreviews?: boolean | undefined;
+  readonly reserveMediaHeight?: boolean | undefined;
   readonly showVideoFullscreen?: boolean | undefined;
   readonly winningThreshold?: number | null | undefined;
   readonly winningThresholdMinDurationMs?: number | null | undefined;
@@ -80,6 +81,7 @@ export default function Drop({
   mediaImageScale,
   fullWidthMedia,
   fullWidthLinkPreviews,
+  reserveMediaHeight,
   showVideoFullscreen = true,
   winningThreshold,
   winningThresholdMinDurationMs,
@@ -188,8 +190,8 @@ export default function Drop({
   };
 
   const memoizedValue = useMemo(
-    () => ({ drop, location, showVideoFullscreen }),
-    [drop, location, showVideoFullscreen]
+    () => ({ drop, location, reserveMediaHeight, showVideoFullscreen }),
+    [drop, location, reserveMediaHeight, showVideoFullscreen]
   );
 
   return (

--- a/components/waves/drops/DropContext.tsx
+++ b/components/waves/drops/DropContext.tsx
@@ -7,6 +7,7 @@ import type { DropLocation } from "./drop.types";
 interface DropContextType {
   drop: ExtendedDrop | null;
   location: DropLocation;
+  reserveMediaHeight?: boolean | undefined;
   showVideoFullscreen?: boolean | undefined;
 }
 

--- a/components/waves/drops/WaveDropPartContentMedias.tsx
+++ b/components/waves/drops/WaveDropPartContentMedias.tsx
@@ -12,6 +12,7 @@ import CircleLoader, {
 } from "@/components/distribution-plan-tool/common/CircleLoader";
 import { t } from "@/i18n/messages";
 import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { useOptionalDropContext } from "./DropContext";
 
 function isRenderableMedia(mimeType: string, url: string): boolean {
   return (
@@ -26,9 +27,7 @@ function isRenderableMedia(mimeType: string, url: string): boolean {
   );
 }
 
-function isImageMediaProcessing(
-  media: ApiDropPart["media"][number]
-): boolean {
+function isImageMediaProcessing(media: ApiDropPart["media"][number]): boolean {
   return (
     media.mime_type.includes("image") &&
     (media.media_status === ApiDropMediaStatus.Uploading ||
@@ -75,6 +74,8 @@ const WaveDropPartContentMedias: React.FC<WaveDropPartContentMediasProps> = ({
   mediaContainerHeightClassName = "tw-h-64",
   fullWidthMedia = false,
 }) => {
+  const dropContext = useOptionalDropContext();
+
   if (!activePart.media.length) {
     return null;
   }
@@ -142,12 +143,19 @@ const WaveDropPartContentMedias: React.FC<WaveDropPartContentMediasProps> = ({
     i: number,
     groupedImage = false
   ) => {
+    const reserveFullWidthMediaHeight =
+      fullWidthMedia && Boolean(dropContext?.reserveMediaHeight);
     const useNaturalHeightImage =
-      fullWidthMedia && media.mime_type.includes("image");
+      fullWidthMedia &&
+      media.mime_type.includes("image") &&
+      !reserveFullWidthMediaHeight;
     const useImageReservedHeight =
-      !fullWidthMedia && media.mime_type.includes("image");
-    const useVideoReservedHeight = false;
-    const useNaturalHeightVideo = media.mime_type.includes("video");
+      media.mime_type.includes("image") &&
+      (!fullWidthMedia || reserveFullWidthMediaHeight);
+    const useVideoReservedHeight =
+      media.mime_type.includes("video") && reserveFullWidthMediaHeight;
+    const useNaturalHeightVideo =
+      media.mime_type.includes("video") && !useVideoReservedHeight;
     const galleryItemId = media.mime_type.includes("image")
       ? getDropImageGalleryItemId("media", i, media.url)
       : undefined;
@@ -179,7 +187,9 @@ const WaveDropPartContentMedias: React.FC<WaveDropPartContentMediasProps> = ({
         <WaveDropPartContentMediaImage
           src={media.url}
           imageScale={imageScale}
-          imageObjectPosition={useImageReservedHeight ? "left top" : "center"}
+          imageObjectPosition={
+            useImageReservedHeight && !fullWidthMedia ? "left top" : "center"
+          }
           galleryItemId={galleryItemId}
           fillContainer={useImageReservedHeight}
         />


### PR DESCRIPTION
## Issue
- The `/waves` profile-waves masonry feed could visibly jump while scrolling when full-width media, especially video, changed measured height after loading.

## Fix
- Add a contextual `reserveMediaHeight` option for drops.
- Enable it for the profile-waves masonry cards so full-width image and video media reserve the fixed media container height used by stable drop layouts.

## Changes
- Propagate `reserveMediaHeight` through `DropContext` and `Drop`.
- Enable the stable media layout only in `CommunityCurationsMasonry`.
- Keep default full-width media behavior intrinsic outside that context.
- Add focused media-rendering tests for the stable full-width media path.

## Validation
- `./bin/6529 run test -- __tests__/components/waves/drops/WaveDropPartContentMedias.test.tsx`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run typecheck:ci`
- Browser QA on `/waves`: scrolled to bottom, back to top, and down again. After the feed materialized, the top video measured `362 x 256` with parent and grandparent also `362 x 256`; a no-input wait kept `scrollTop` and `scrollHeight` unchanged.
- `./bin/6529 run react-doctor:diff` was invoked, but the repo script compared the current branch name to `HEAD` after the commit and found no changed source files to scan.

## Risk
- Level: Low
- Why: The behavior is scoped to profile-waves masonry cards and preserves intrinsic full-width media behavior elsewhere.
- Rollback: Revert the single commit to restore previous media sizing.

## Review Notes
- Please focus on the media sizing branch in `WaveDropPartContentMedias` and the limited opt-in from `CommunityCurationsMasonry`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to reserve media height for drop content, helping full-width images and videos keep a more stable layout.
  * Updated community curations cards to use the new reserved-height behavior for media.
* **Bug Fixes**
  * Improved media rendering so images and videos consistently switch between natural and reserved sizing based on layout context.
  * Added coverage for the new media-height behavior to verify the expected layout classes and fill states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->