### PR TITLE
Fix auth session refresh storms

### DIFF
--- a/__tests__/services/auth/session-v2.utils.test.ts
+++ b/__tests__/services/auth/session-v2.utils.test.ts
@@ -8,6 +8,7 @@ import {
   setNativeRefreshToken,
 } from "@/services/auth/native-refresh-token-storage";
 import {
+  __resetSessionRefreshStateForTests,
   createConnectionShare,
   createLegacyDesktopConnectionShare,
   getSessionNonce,
@@ -47,6 +48,7 @@ jest.mock("@/services/auth/native-refresh-token-storage", () => ({
 
 describe("session-v2.utils", () => {
   beforeEach(() => {
+    __resetSessionRefreshStateForTests();
     jest.resetAllMocks();
     (Capacitor.isNativePlatform as jest.Mock).mockReturnValue(false);
     (commonApiFetch as jest.Mock).mockResolvedValue(undefined);
@@ -269,6 +271,7 @@ describe("session-v2.utils", () => {
       signal: undefined,
       credentials: "include",
       errorMode: "structured",
+      includeWalletAuth: false,
     });
   });
 
@@ -290,7 +293,187 @@ describe("session-v2.utils", () => {
       signal: undefined,
       credentials: "include",
       errorMode: "structured",
+      includeWalletAuth: false,
     });
+  });
+
+  it("shares concurrent refreshes for the same web session context", async () => {
+    const sessionResponse = {
+      client_type: "web",
+      address: "0xabc",
+      role: null,
+      access_token: "access-token",
+      access_token_expires_at: "2026-06-10T00:00:00.000Z",
+    };
+    let resolveRefresh:
+      | ((response: typeof sessionResponse) => void)
+      | undefined = undefined;
+    const refreshPromise = new Promise<typeof sessionResponse>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    (commonApiPost as jest.Mock).mockReturnValueOnce(refreshPromise);
+
+    const firstRefresh = refreshSessionV2({ address: "0xabc" });
+    const secondRefresh = refreshSessionV2({ address: "0xABC" });
+
+    expect(commonApiPost).toHaveBeenCalledTimes(1);
+    expect(resolveRefresh).toBeDefined();
+    resolveRefresh?.(sessionResponse);
+
+    await expect(firstRefresh).resolves.toBe(sessionResponse);
+    await expect(secondRefresh).resolves.toBe(sessionResponse);
+  });
+
+  it("keeps a shared refresh alive when one consumer aborts", async () => {
+    const abortController = new AbortController();
+    const sessionResponse = {
+      client_type: "web",
+      address: "0xabc",
+      role: null,
+      access_token: "access-token",
+      access_token_expires_at: "2026-06-10T00:00:00.000Z",
+    };
+    let resolveRefresh:
+      | ((response: typeof sessionResponse) => void)
+      | undefined = undefined;
+    let internalSignal: AbortSignal | undefined = undefined;
+    const refreshPromise = new Promise<typeof sessionResponse>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    (commonApiPost as jest.Mock).mockImplementationOnce(
+      ({ signal }: { readonly signal?: AbortSignal | undefined }) => {
+        internalSignal = signal;
+        return refreshPromise;
+      }
+    );
+
+    const abortingRefresh = refreshSessionV2({
+      address: "0xabc",
+      abortSignal: abortController.signal,
+    });
+    const waitingRefresh = refreshSessionV2({ address: "0xABC" });
+
+    expect(commonApiPost).toHaveBeenCalledTimes(1);
+    abortController.abort();
+
+    await expect(abortingRefresh).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    expect(internalSignal?.aborted).toBe(false);
+
+    expect(resolveRefresh).toBeDefined();
+    resolveRefresh?.(sessionResponse);
+    await expect(waitingRefresh).resolves.toBe(sessionResponse);
+    expect(commonApiPost).toHaveBeenCalledTimes(1);
+  });
+
+  it("cooldowns failed web refreshes for the same session context", async () => {
+    const unauthorizedError = Object.assign(new Error("Unauthorized"), {
+      status: 401,
+      response: { status: 401 },
+    });
+    (commonApiPost as jest.Mock).mockRejectedValueOnce(unauthorizedError);
+
+    await expect(refreshSessionV2({ address: "0xabc" })).resolves.toBeNull();
+    await expect(refreshSessionV2({ address: "0xABC" })).resolves.toBeNull();
+
+    expect(commonApiPost).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears a failed refresh cooldown after successful auth persistence", async () => {
+    const unauthorizedError = Object.assign(new Error("Unauthorized"), {
+      status: 401,
+      response: { status: 401 },
+    });
+    const sessionResponse = {
+      client_type: "web",
+      address: "0xabc",
+      role: null,
+      access_token: "access-token",
+      access_token_expires_at: "2026-06-10T00:00:00.000Z",
+    };
+    (commonApiPost as jest.Mock)
+      .mockRejectedValueOnce(unauthorizedError)
+      .mockResolvedValueOnce(sessionResponse);
+
+    await expect(refreshSessionV2({ address: "0xabc" })).resolves.toBeNull();
+    await expect(persistSessionResponse(sessionResponse)).resolves.toBe(true);
+    await expect(refreshSessionV2({ address: "0xABC" })).resolves.toBe(
+      sessionResponse
+    );
+
+    expect(commonApiPost).toHaveBeenCalledTimes(2);
+  });
+
+  it("delays transport failure retries without replaying a stale error", async () => {
+    jest.useFakeTimers();
+    const networkError = new Error("Failed to fetch");
+    const sessionResponse = {
+      client_type: "web",
+      address: "0xabc",
+      role: null,
+      access_token: "access-token",
+      access_token_expires_at: "2026-06-10T00:00:00.000Z",
+    };
+    (commonApiPost as jest.Mock)
+      .mockRejectedValueOnce(networkError)
+      .mockResolvedValueOnce(sessionResponse);
+
+    try {
+      await expect(refreshSessionV2({ address: "0xabc" })).rejects.toThrow(
+        "Failed to fetch"
+      );
+
+      const retriedRefresh = refreshSessionV2({ address: "0xABC" });
+      expect(commonApiPost).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(250);
+      await expect(retriedRefresh).resolves.toBe(sessionResponse);
+      expect(commonApiPost).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("starts a new refresh immediately after the previous caller aborts", async () => {
+    const abortController = new AbortController();
+    const sessionResponse = {
+      client_type: "web",
+      address: "0xabc",
+      role: null,
+      access_token: "access-token",
+      access_token_expires_at: "2026-06-10T00:00:00.000Z",
+    };
+
+    (commonApiPost as jest.Mock)
+      .mockImplementationOnce(
+        ({ signal }: { readonly signal?: AbortSignal | undefined }) =>
+          new Promise((_resolve, reject) => {
+            signal?.addEventListener(
+              "abort",
+              () => reject(new DOMException("aborted", "AbortError")),
+              { once: true }
+            );
+          })
+      )
+      .mockResolvedValueOnce(sessionResponse);
+
+    const abortedRefresh = refreshSessionV2({
+      address: "0xabc",
+      abortSignal: abortController.signal,
+    });
+
+    expect(commonApiPost).toHaveBeenCalledTimes(1);
+    abortController.abort();
+
+    await expect(abortedRefresh).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    await expect(refreshSessionV2({ address: "0xABC" })).resolves.toBe(
+      sessionResponse
+    );
+
+    expect(commonApiPost).toHaveBeenCalledTimes(2);
   });
 
   it("verifies an active web session and persists the refreshed auth", async () => {
@@ -316,6 +499,7 @@ describe("session-v2.utils", () => {
       signal: undefined,
       credentials: "include",
       errorMode: "structured",
+      includeWalletAuth: false,
     });
     expect(setAuthJwt).toHaveBeenCalledWith(
       "0xabc",
@@ -390,6 +574,7 @@ describe("session-v2.utils", () => {
       signal: undefined,
       credentials: "include",
       errorMode: "structured",
+      includeWalletAuth: false,
     });
   });
 

--- a/__tests__/services/common-api.test.ts
+++ b/__tests__/services/common-api.test.ts
@@ -97,6 +97,33 @@ describe("commonApiPost", () => {
     expect(result).toEqual({ res: 1 });
   });
 
+  it("can omit wallet authorization while preserving staging auth", async () => {
+    (getStagingAuth as jest.Mock).mockReturnValue("a");
+    (getAuthJwt as jest.Mock).mockReturnValue("stale-jwt");
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ res: 1 }),
+    });
+
+    await commonApiPost<{ v: number }, { res: number }>({
+      endpoint: "e",
+      body: { v: 1 },
+      includeWalletAuth: false,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.test.6529.io/api/e",
+      expect.objectContaining({
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-6529-auth": "a",
+        },
+        body: JSON.stringify({ v: 1 }),
+      })
+    );
+  });
+
   it("rejects on error", async () => {
     (getStagingAuth as jest.Mock).mockReturnValue(null);
     (getAuthJwt as jest.Mock).mockReturnValue(null);

--- a/__tests__/services/common-api.test.ts
+++ b/__tests__/services/common-api.test.ts
@@ -111,6 +111,7 @@ describe("commonApiPost", () => {
       includeWalletAuth: false,
     });
 
+    expect(getAuthJwt).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.test.6529.io/api/e",
       expect.objectContaining({

--- a/services/api/common-api.ts
+++ b/services/api/common-api.ts
@@ -17,10 +17,11 @@ type StructuredApiError = Error & {
 
 const getHeaders = (
   headers?: Record<string, string>,
-  contentType: boolean = true
+  contentType: boolean = true,
+  includeWalletAuth: boolean = true
 ) => {
   const apiAuth = getStagingAuth();
-  const walletAuth = getAuthJwt();
+  const walletAuth = includeWalletAuth ? getAuthJwt() : null;
   return {
     ...(contentType ? { "Content-Type": "application/json" } : {}),
     ...(apiAuth ? { "x-6529-auth": apiAuth } : {}),
@@ -345,6 +346,7 @@ export const commonApiFetch = async <T, U = Record<string, string>>(param: {
   params?: U | undefined;
   signal?: AbortSignal | undefined;
   errorMode?: ApiErrorMode | undefined;
+  includeWalletAuth?: boolean | undefined;
 }): Promise<T> => {
   const url = buildUrl(
     param.endpoint,
@@ -361,7 +363,11 @@ export const commonApiFetch = async <T, U = Record<string, string>>(param: {
   return executeApiRequest<T>({
     url,
     method: "GET",
-    headers: getHeaders(param.headers, false),
+    headers: getHeaders(
+      param.headers,
+      false,
+      param.includeWalletAuth !== false
+    ),
     signal: param.signal,
     errorMode: param.errorMode ?? "legacy-string",
   });
@@ -404,6 +410,7 @@ export const commonApiFetchWithRetry = async <
   readonly headers?: Record<string, string> | undefined;
   readonly params?: U | undefined;
   readonly signal?: AbortSignal | undefined;
+  readonly includeWalletAuth?: boolean | undefined;
   readonly retryOptions?: RetryOptions | undefined;
 }): Promise<T> => {
   const { retryOptions, ...fetchParams } = param;
@@ -494,6 +501,7 @@ export const commonApiPost = async <T, U, Z = Record<string, string>>(param: {
   errorMode?: ApiErrorMode | undefined;
   credentials?: RequestCredentials | undefined;
   parseJson?: boolean | undefined;
+  includeWalletAuth?: boolean | undefined;
 }): Promise<U> => {
   const url = buildUrl(
     param.endpoint,
@@ -503,7 +511,7 @@ export const commonApiPost = async <T, U, Z = Record<string, string>>(param: {
   return executeApiRequest<U>({
     url,
     method: "POST",
-    headers: getHeaders(param.headers, true),
+    headers: getHeaders(param.headers, true, param.includeWalletAuth !== false),
     body: JSON.stringify(param.body),
     signal: param.signal,
     parseJson: param.parseJson ?? true,

--- a/services/auth/session-v2.utils.ts
+++ b/services/auth/session-v2.utils.ts
@@ -532,13 +532,13 @@ export async function persistSessionResponse(
     throw error;
   }
 
-  if (!didPersistAuth) {
-    await rollbackUnpersistedSession(response, didPersistNativeRefreshToken);
-  } else {
+  if (didPersistAuth) {
     clearSessionRefreshFailureForSession(response);
+    return true;
   }
 
-  return didPersistAuth;
+  await rollbackUnpersistedSession(response, didPersistNativeRefreshToken);
+  return false;
 }
 
 export async function verifyActiveSessionV2WebSession({

--- a/services/auth/session-v2.utils.ts
+++ b/services/auth/session-v2.utils.ts
@@ -39,24 +39,9 @@ interface SessionNativeResponse {
 
 type SessionLoginResponse = SessionWebResponse | SessionNativeResponse;
 type SessionRefreshResponse = SessionWebResponse | SessionNativeResponse;
-type SessionRefreshFailureCooldown =
-  | {
-      readonly type: "empty";
-      readonly expiresAtMs: number;
-    }
-  | {
-      readonly type: "error";
-      readonly expiresAtMs: number;
-      readonly error: unknown;
-    };
-type SessionRefreshFailure =
-  | {
-      readonly type: "empty";
-    }
-  | {
-      readonly type: "error";
-      readonly error: unknown;
-    };
+type SessionRefreshFailureCooldown = {
+  readonly expiresAtMs: number;
+};
 type SessionRefreshInFlight = {
   readonly controller: AbortController;
   readonly promise: Promise<SessionRefreshResponse | null>;
@@ -152,17 +137,26 @@ function getActiveFailureCooldown(
 }
 
 function rememberSessionRefreshFailure(
-  key: string,
-  failure: SessionRefreshFailure
+  key: string
 ): void {
   sessionRefreshFailureCooldowns.set(key, {
-    ...failure,
     expiresAtMs: Date.now() + SESSION_REFRESH_FAILURE_COOLDOWN_MS,
   });
 }
 
 function clearSessionRefreshFailure(key: string): void {
   sessionRefreshFailureCooldowns.delete(key);
+}
+
+function clearSessionRefreshFailureForSession(
+  response: SessionLoginResponse | SessionRefreshResponse
+): void {
+  clearSessionRefreshFailure(
+    getSessionRefreshKey({
+      address: response.address,
+      clientType: response.client_type,
+    })
+  );
 }
 
 function settleSessionRefreshConsumer(
@@ -286,17 +280,21 @@ export async function loginWithSessionV2({
   readonly role: string | null;
 }): Promise<SessionLoginResponse> {
   const roleBody = role === null ? {} : { role };
-  return await commonApiPost<SessionLoginRequest, SessionLoginResponse>({
-    endpoint: "auth/session-login",
-    body: {
-      client_type: getSessionClientType(),
-      server_signature: serverSignature,
-      client_signature: clientSignature,
-      client_address: signerAddress,
-      ...roleBody,
-    },
-    credentials: getSessionCredentialsMode(),
-  });
+  const response = await commonApiPost<SessionLoginRequest, SessionLoginResponse>(
+    {
+      endpoint: "auth/session-login",
+      body: {
+        client_type: getSessionClientType(),
+        server_signature: serverSignature,
+        client_signature: clientSignature,
+        client_address: signerAddress,
+        ...roleBody,
+      },
+      credentials: getSessionCredentialsMode(),
+    }
+  );
+  clearSessionRefreshFailureForSession(response);
+  return response;
 }
 
 async function executeSessionRefreshV2({
@@ -329,7 +327,7 @@ async function executeSessionRefreshV2({
           native_refresh_token: nativeRefreshToken,
         },
         signal: abortSignal,
-        credentials: "include",
+        credentials: getSessionCredentialsMode(),
         errorMode: "structured",
         includeWalletAuth: false,
       });
@@ -355,7 +353,7 @@ async function executeSessionRefreshV2({
         client_address: address,
       },
       signal: abortSignal,
-      credentials: "include",
+      credentials: getSessionCredentialsMode(),
       errorMode: "structured",
       includeWalletAuth: false,
     });
@@ -382,11 +380,8 @@ export async function refreshSessionV2({
   const key = getSessionRefreshKey({ address, clientType });
   const cooldown = getActiveFailureCooldown(key);
 
-  if (cooldown?.type === "empty") {
+  if (cooldown) {
     return null;
-  }
-  if (cooldown?.type === "error") {
-    throw cooldown.error;
   }
 
   let existingEntry = sessionRefreshInFlight.get(key);
@@ -424,12 +419,11 @@ export async function refreshSessionV2({
         return;
       }
 
-      rememberSessionRefreshFailure(key, { type: "empty" });
+      rememberSessionRefreshFailure(key);
     } catch (error: unknown) {
       if (isAbortError(error)) {
         return;
       }
-      rememberSessionRefreshFailure(key, { type: "error", error });
     } finally {
       if (sessionRefreshInFlight.get(key) === entry) {
         sessionRefreshInFlight.delete(key);
@@ -484,6 +478,8 @@ export async function persistSessionResponse(
 
   if (!didPersistAuth) {
     await rollbackUnpersistedSession(response, didPersistNativeRefreshToken);
+  } else {
+    clearSessionRefreshFailureForSession(response);
   }
 
   return didPersistAuth;

--- a/services/auth/session-v2.utils.ts
+++ b/services/auth/session-v2.utils.ts
@@ -39,6 +39,29 @@ interface SessionNativeResponse {
 
 type SessionLoginResponse = SessionWebResponse | SessionNativeResponse;
 type SessionRefreshResponse = SessionWebResponse | SessionNativeResponse;
+type SessionRefreshFailureCooldown =
+  | {
+      readonly type: "empty";
+      readonly expiresAtMs: number;
+    }
+  | {
+      readonly type: "error";
+      readonly expiresAtMs: number;
+      readonly error: unknown;
+    };
+type SessionRefreshFailure =
+  | {
+      readonly type: "empty";
+    }
+  | {
+      readonly type: "error";
+      readonly error: unknown;
+    };
+type SessionRefreshInFlight = {
+  readonly controller: AbortController;
+  readonly promise: Promise<SessionRefreshResponse | null>;
+  activeConsumers: number;
+};
 
 type ApiStatusError = {
   readonly status?: unknown;
@@ -72,6 +95,13 @@ interface RedeemConnectionShareResponse {
   readonly refresh_token_expires_at: string;
 }
 
+const SESSION_REFRESH_FAILURE_COOLDOWN_MS = 2000;
+const sessionRefreshInFlight = new Map<string, SessionRefreshInFlight>();
+const sessionRefreshFailureCooldowns = new Map<
+  string,
+  SessionRefreshFailureCooldown
+>();
+
 export function getSessionClientType(): AuthSessionClientType {
   return Capacitor.isNativePlatform() ? "native" : "web";
 }
@@ -83,6 +113,121 @@ function isUnauthorizedApiError(error: unknown): boolean {
 
   const statusError = error as ApiStatusError;
   return statusError.status === 401 || statusError.response?.status === 401;
+}
+
+function getSessionRefreshKey({
+  address,
+  clientType,
+}: {
+  readonly address: string;
+  readonly clientType: AuthSessionClientType;
+}): string {
+  return `${clientType}:${address.trim().toLowerCase()}`;
+}
+
+function createAbortError(): DOMException {
+  return new DOMException("Session refresh aborted", "AbortError");
+}
+
+const isAbortError = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  "name" in error &&
+  error.name === "AbortError";
+
+function getActiveFailureCooldown(
+  key: string
+): SessionRefreshFailureCooldown | null {
+  const cooldown = sessionRefreshFailureCooldowns.get(key);
+  if (!cooldown) {
+    return null;
+  }
+
+  if (cooldown.expiresAtMs <= Date.now()) {
+    sessionRefreshFailureCooldowns.delete(key);
+    return null;
+  }
+
+  return cooldown;
+}
+
+function rememberSessionRefreshFailure(
+  key: string,
+  failure: SessionRefreshFailure
+): void {
+  sessionRefreshFailureCooldowns.set(key, {
+    ...failure,
+    expiresAtMs: Date.now() + SESSION_REFRESH_FAILURE_COOLDOWN_MS,
+  });
+}
+
+function clearSessionRefreshFailure(key: string): void {
+  sessionRefreshFailureCooldowns.delete(key);
+}
+
+function settleSessionRefreshConsumer(
+  entry: SessionRefreshInFlight,
+  key: string
+): void {
+  entry.activeConsumers = Math.max(0, entry.activeConsumers - 1);
+  if (
+    entry.activeConsumers === 0 &&
+    sessionRefreshInFlight.get(key) === entry
+  ) {
+    sessionRefreshInFlight.delete(key);
+    entry.controller.abort();
+  }
+}
+
+async function withCallerAbort<T>({
+  entry,
+  key,
+  abortSignal,
+}: {
+  readonly entry: SessionRefreshInFlight;
+  readonly key: string;
+  readonly abortSignal?: AbortSignal | undefined;
+}): Promise<T> {
+  if (!abortSignal) {
+    return (await entry.promise) as T;
+  }
+
+  if (abortSignal.aborted) {
+    settleSessionRefreshConsumer(entry, key);
+    throw createAbortError();
+  }
+
+  let didSettle = false;
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      if (didSettle) {
+        return;
+      }
+      didSettle = true;
+      abortSignal.removeEventListener("abort", onAbort);
+      settleSessionRefreshConsumer(entry, key);
+      reject(createAbortError());
+    };
+
+    abortSignal.addEventListener("abort", onAbort, { once: true });
+    void entry.promise
+      .then((value) => {
+        if (didSettle) {
+          return;
+        }
+        didSettle = true;
+        abortSignal.removeEventListener("abort", onAbort);
+        resolve(value as T);
+      })
+      .catch((error: unknown) => {
+        if (didSettle) {
+          return;
+        }
+        didSettle = true;
+        abortSignal.removeEventListener("abort", onAbort);
+        reject(error);
+      });
+  });
 }
 
 function getSessionCredentialsMode(): RequestCredentials {
@@ -154,14 +299,15 @@ export async function loginWithSessionV2({
   });
 }
 
-export async function refreshSessionV2({
+async function executeSessionRefreshV2({
   address,
   abortSignal,
+  clientType,
 }: {
   readonly address: string;
   readonly abortSignal?: AbortSignal | undefined;
+  readonly clientType: AuthSessionClientType;
 }): Promise<SessionRefreshResponse | null> {
-  const clientType = getSessionClientType();
   if (clientType === "native") {
     const nativeRefreshToken = await getNativeRefreshToken(address);
     if (!nativeRefreshToken) {
@@ -185,6 +331,7 @@ export async function refreshSessionV2({
         signal: abortSignal,
         credentials: "include",
         errorMode: "structured",
+        includeWalletAuth: false,
       });
     } catch (error: unknown) {
       if (isUnauthorizedApiError(error)) {
@@ -210,6 +357,7 @@ export async function refreshSessionV2({
       signal: abortSignal,
       credentials: "include",
       errorMode: "structured",
+      includeWalletAuth: false,
     });
   } catch (error: unknown) {
     if (isUnauthorizedApiError(error)) {
@@ -217,6 +365,91 @@ export async function refreshSessionV2({
     }
     throw error;
   }
+}
+
+export async function refreshSessionV2({
+  address,
+  abortSignal,
+}: {
+  readonly address: string;
+  readonly abortSignal?: AbortSignal | undefined;
+}): Promise<SessionRefreshResponse | null> {
+  if (abortSignal?.aborted) {
+    throw createAbortError();
+  }
+
+  const clientType = getSessionClientType();
+  const key = getSessionRefreshKey({ address, clientType });
+  const cooldown = getActiveFailureCooldown(key);
+
+  if (cooldown?.type === "empty") {
+    return null;
+  }
+  if (cooldown?.type === "error") {
+    throw cooldown.error;
+  }
+
+  let existingEntry = sessionRefreshInFlight.get(key);
+  if (existingEntry?.controller.signal.aborted) {
+    sessionRefreshInFlight.delete(key);
+    existingEntry = undefined;
+  }
+
+  if (existingEntry) {
+    existingEntry.activeConsumers += 1;
+    return await withCallerAbort<SessionRefreshResponse | null>({
+      entry: existingEntry,
+      key,
+      abortSignal,
+    });
+  }
+
+  const controller = new AbortController();
+  const entry: SessionRefreshInFlight = {
+    controller,
+    activeConsumers: 1,
+    promise: executeSessionRefreshV2({
+      address,
+      abortSignal: abortSignal ? controller.signal : undefined,
+      clientType,
+    }),
+  };
+  sessionRefreshInFlight.set(key, entry);
+
+  void (async () => {
+    try {
+      const response = await entry.promise;
+      if (response) {
+        clearSessionRefreshFailure(key);
+        return;
+      }
+
+      rememberSessionRefreshFailure(key, { type: "empty" });
+    } catch (error: unknown) {
+      if (isAbortError(error)) {
+        return;
+      }
+      rememberSessionRefreshFailure(key, { type: "error", error });
+    } finally {
+      if (sessionRefreshInFlight.get(key) === entry) {
+        sessionRefreshInFlight.delete(key);
+      }
+    }
+  })();
+
+  return await withCallerAbort<SessionRefreshResponse | null>({
+    entry,
+    key,
+    abortSignal,
+  });
+}
+
+export function __resetSessionRefreshStateForTests(): void {
+  for (const entry of sessionRefreshInFlight.values()) {
+    entry.controller.abort();
+  }
+  sessionRefreshInFlight.clear();
+  sessionRefreshFailureCooldowns.clear();
 }
 
 export async function persistSessionResponse(
@@ -271,7 +504,7 @@ export async function verifyActiveSessionV2WebSession({
     address,
     abortSignal,
   });
-  if (!refreshedSession || refreshedSession.client_type !== "web") {
+  if (refreshedSession?.client_type !== "web") {
     return false;
   }
 

--- a/services/auth/session-v2.utils.ts
+++ b/services/auth/session-v2.utils.ts
@@ -39,9 +39,15 @@ interface SessionNativeResponse {
 
 type SessionLoginResponse = SessionWebResponse | SessionNativeResponse;
 type SessionRefreshResponse = SessionWebResponse | SessionNativeResponse;
-type SessionRefreshFailureCooldown = {
-  readonly expiresAtMs: number;
-};
+type SessionRefreshFailureCooldown =
+  | {
+      readonly type: "empty";
+      readonly expiresAtMs: number;
+    }
+  | {
+      readonly type: "retry";
+      readonly expiresAtMs: number;
+    };
 type SessionRefreshInFlight = {
   readonly controller: AbortController;
   readonly promise: Promise<SessionRefreshResponse | null>;
@@ -80,7 +86,8 @@ interface RedeemConnectionShareResponse {
   readonly refresh_token_expires_at: string;
 }
 
-const SESSION_REFRESH_FAILURE_COOLDOWN_MS = 2000;
+const SESSION_REFRESH_EMPTY_FAILURE_COOLDOWN_MS = 2000;
+const SESSION_REFRESH_RETRY_COOLDOWN_MS = 250;
 const sessionRefreshInFlight = new Map<string, SessionRefreshInFlight>();
 const sessionRefreshFailureCooldowns = new Map<
   string,
@@ -137,10 +144,16 @@ function getActiveFailureCooldown(
 }
 
 function rememberSessionRefreshFailure(
-  key: string
+  key: string,
+  type: SessionRefreshFailureCooldown["type"]
 ): void {
   sessionRefreshFailureCooldowns.set(key, {
-    expiresAtMs: Date.now() + SESSION_REFRESH_FAILURE_COOLDOWN_MS,
+    type,
+    expiresAtMs:
+      Date.now() +
+      (type === "empty"
+        ? SESSION_REFRESH_EMPTY_FAILURE_COOLDOWN_MS
+        : SESSION_REFRESH_RETRY_COOLDOWN_MS),
   });
 }
 
@@ -157,6 +170,42 @@ function clearSessionRefreshFailureForSession(
       clientType: response.client_type,
     })
   );
+}
+
+async function waitForSessionRefreshRetryCooldown({
+  cooldown,
+  abortSignal,
+}: {
+  readonly cooldown: SessionRefreshFailureCooldown;
+  readonly abortSignal?: AbortSignal | undefined;
+}): Promise<void> {
+  const delayMs = Math.max(0, cooldown.expiresAtMs - Date.now());
+  if (delayMs === 0) {
+    return;
+  }
+  if (abortSignal?.aborted) {
+    throw createAbortError();
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined = undefined;
+    const cleanup = () => {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+      abortSignal?.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
+      reject(createAbortError());
+    };
+
+    timeoutId = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, delayMs);
+    abortSignal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 function settleSessionRefreshConsumer(
@@ -380,8 +429,14 @@ export async function refreshSessionV2({
   const key = getSessionRefreshKey({ address, clientType });
   const cooldown = getActiveFailureCooldown(key);
 
-  if (cooldown) {
+  if (cooldown?.type === "empty") {
     return null;
+  }
+  if (cooldown?.type === "retry") {
+    await waitForSessionRefreshRetryCooldown({ cooldown, abortSignal });
+    if (sessionRefreshFailureCooldowns.get(key) === cooldown) {
+      sessionRefreshFailureCooldowns.delete(key);
+    }
   }
 
   let existingEntry = sessionRefreshInFlight.get(key);
@@ -419,11 +474,12 @@ export async function refreshSessionV2({
         return;
       }
 
-      rememberSessionRefreshFailure(key);
+      rememberSessionRefreshFailure(key, "empty");
     } catch (error: unknown) {
       if (isAbortError(error)) {
         return;
       }
+      rememberSessionRefreshFailure(key, "retry");
     } finally {
       if (sessionRefreshInFlight.get(key) === entry) {
         sessionRefreshInFlight.delete(key);


### PR DESCRIPTION
## Issue

Mobile `/waves` RUM showed `auth/session-refresh` dominating failed requests and repeated refresh attempts. The refresh request could also carry the current stale wallet JWT `Authorization` header, which is not needed for cookie/native refresh-token based session refresh.

## Fix

- Added an explicit common API option to opt out of wallet auth headers per request.
- Used that option for the session refresh path while preserving base URL handling, staging auth, credentials, structured errors, native refresh-token behavior, and abort support.
- Added a narrow single-flight and short failure cooldown in the session-v2 refresh layer so repeated auth/provider/storage churn cannot issue many parallel or immediate repeated refresh calls for the same address/client context.
- Treated aborts as cancellation instead of refresh failure, and ensured a new caller does not join an already-aborted refresh entry.

## Validation

- `pnpm_config_verify_deps_before_run=false ./bin/6529 run test -- __tests__/services/common-api.test.ts __tests__/services/auth/session-v2.utils.test.ts`
- `pnpm_config_verify_deps_before_run=false ./bin/6529 run lint:changed`
- `pnpm_config_verify_deps_before_run=false ./bin/6529 run typecheck:changed`
- `pnpm_config_verify_deps_before_run=false ./bin/6529 run typecheck:ci`
- `git diff --check`
- Local staging-backed `/waves` browser smoke with agent login.
- Playwright network capture forced stale stored JWT and verified `POST /api/auth/session-refresh` omitted `Authorization` while preserving staging auth and credentials behavior.

## Risk

Auth-session blast radius is meaningful but the change is localized to the common API header opt-out and session-v2 refresh gating. The main affected flows are wallet session refresh, disconnected stored-session restore, native refresh-token validation, profile/proxy validation through active-session checks, and profile switching. Real mobile-device QA was intentionally not run.

## Review Notes

Please focus review on the `includeWalletAuth` opt-out semantics, refresh single-flight/cooldown behavior, abort cancellation handling, and the tests covering duplicate refresh and abort retry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session refresh now deduplicates concurrent callers by sharing a single in-progress refresh per client/address context.
* **Bug Fixes**
  * Refresh and other API requests can now omit wallet authorization while still sending the staging auth header.
  * Added cooldown/rate-limiting for repeated unauthorized (401) refresh failures, with cooldown cleared after successful session persistence; retried appropriately after transport failures and after aborted in-flight refreshes.
  * Web active-session verification more reliably returns `false` when the refreshed session isn’t for the web client.
* **Tests**
  * Expanded coverage for deduping, abort behavior, cooldown timing, and header inclusion/exclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->