### PR TITLE
[codex] Hide wave row pins after hover leaves

### DIFF
--- a/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
+++ b/__tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx
@@ -123,26 +123,28 @@ describe("BrainLeftSidebarWavePin", () => {
     expect(removePinnedWave).not.toHaveBeenCalled();
   });
 
-  it("collapses compact desktop row width until hover or keyboard focus", () => {
+  it("collapses compact desktop row width until row hover or direct keyboard focus", () => {
     setup(false, [], undefined, connectedAuth, true);
     const button = screen.getByRole("button", { name: /pin wave/i });
 
     expect(button).toHaveClass("tw-h-7");
     expect(button).toHaveClass("tw-w-0");
-    expect(button).toHaveClass("group-hover:tw-w-7");
-    expect(button).toHaveClass("group-focus-within:tw-w-7");
+    expect(button).toHaveClass("desktop-hover:group-hover:tw-w-7");
     expect(button).toHaveClass("focus-visible:tw-w-7");
+    expect(button).not.toHaveClass("group-focus-within:tw-w-7");
+    expect(button).not.toHaveClass("focus:tw-w-7");
     expect(button.querySelector("svg")).toHaveClass("tw-size-3.5");
   });
 
-  it("hides pinned desktop controls until row hover or keyboard focus", () => {
+  it("hides pinned desktop controls until row hover or direct keyboard focus", () => {
     setup(true, ["1"]);
     const button = screen.getByRole("button", { name: /unpin wave/i });
 
     expect(button).toHaveClass("tw-opacity-0");
-    expect(button).toHaveClass("group-hover:tw-opacity-100");
-    expect(button).toHaveClass("group-focus-within:tw-opacity-100");
+    expect(button).toHaveClass("desktop-hover:group-hover:tw-opacity-100");
     expect(button).toHaveClass("focus-visible:tw-opacity-100");
+    expect(button).not.toHaveClass("group-focus-within:tw-opacity-100");
+    expect(button).not.toHaveClass("focus:tw-opacity-100");
   });
 
   it("keeps pinned touch controls visible", () => {

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
@@ -142,10 +142,10 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
     }
   };
 
-  // Desktop rows reveal the pin on hover or focus without reserving idle width.
+  // Desktop rows reveal the pin on row hover or direct keyboard focus.
   const getOpacityClass = () => {
     if (isTouchDevice) return "tw-opacity-100";
-    return "tw-opacity-0 group-hover:tw-opacity-100 group-focus-within:tw-opacity-100 focus:tw-opacity-100 focus-visible:tw-opacity-100";
+    return "tw-opacity-0 desktop-hover:group-hover:tw-opacity-100 focus-visible:tw-opacity-100";
   };
   const opacityClass = getOpacityClass();
 
@@ -175,7 +175,7 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
   const getSizeClasses = () => {
     if (!compact) return "tw-size-7 sm:tw-size-6";
     if (isTouchDevice) return "tw-size-7";
-    return "tw-h-7 tw-w-0 group-hover:tw-w-7 group-focus-within:tw-w-7 focus:tw-w-7 focus-visible:tw-w-7";
+    return "tw-h-7 tw-w-0 desktop-hover:group-hover:tw-w-7 focus-visible:tw-w-7";
   };
   const sizeClasses = getSizeClasses();
   const iconSizeClasses = compact ? "tw-size-3.5" : "tw-size-4";

--- a/ops/docs/waves/sidebars/feature-pinned-wave-controls.md
+++ b/ops/docs/waves/sidebars/feature-pinned-wave-controls.md
@@ -50,8 +50,8 @@ Both lists are capped at **20** items. They are independent and do not sync.
 - The same control flips label by state (`Pin wave` vs `Unpin wave`).
 - Pin/unpin controls are disabled while that wave request is in progress.
 - In desktop expanded sidebars, row pin and unpin controls collapse while idle
-  and appear on row hover or keyboard focus; on touch devices, they remain
-  visible.
+  and appear on row hover or direct keyboard focus on the pin control; on touch
+  devices, they remain visible.
 - In collapsed web sidebars, row pin controls are hidden.
 - DM lists do not expose row pin controls.
 - When app shortcuts reach 20, opening another thread keeps the newest 20 and


### PR DESCRIPTION
## Issue
- Desktop wave-row pin controls could stay visible after selecting or focusing a row because the row `focus-within` state revealed the pin even after hover ended.

## Fix
- Reveal desktop row pins on row hover, or when the pin control itself receives keyboard focus.
- Keep touch-device pin controls always visible.

## Changes
- Removed row `focus-within` and mouse `focus` reveal classes from `BrainLeftSidebarWavePin`.
- Updated focused pin visibility tests to cover row-hover/direct-focus behavior.
- Updated the pinned-wave sidebar docs to match the intended desktop behavior.

## Validation
- `6529 run test -- __tests__/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.test.tsx`
- `6529 run lint:changed`
- `6529 run typecheck:changed`
- `6529 exec react-doctor . --project 6529seize --verbose --offline --diff=origin/main`
- `git diff --check origin/main...HEAD`

## Risk
- Level: Low
- Why: Scoped to the wave-row pin control visibility classes and related tests/docs.
- Rollback: Revert this commit to restore the previous row focus-within reveal behavior.

## Review Notes
- Please check the desktop selected-row case: after mouse leaves the active row, the pin should hide again. Touch devices should still show the pin.