### PR TITLE
Hide quick DM create action in chat

### DIFF
--- a/components/messages/quick-dms/QuickDirectMessages.tsx
+++ b/components/messages/quick-dms/QuickDirectMessages.tsx
@@ -306,7 +306,6 @@ export default function QuickDirectMessages() {
               locale={locale}
               onBack={openList}
               onClose={close}
-              onCreateDirectMessage={createDirectMessageAction}
               onOpenAll={openAll}
             />
           </Suspense>

--- a/components/messages/quick-dms/QuickDmChat.tsx
+++ b/components/messages/quick-dms/QuickDmChat.tsx
@@ -33,7 +33,6 @@ interface QuickDmChatProps {
   readonly locale: SupportedLocale;
   readonly onBack: () => void;
   readonly onClose: () => void;
-  readonly onCreateDirectMessage?: (() => void) | undefined;
   readonly onOpenAll: () => void;
   readonly waveId: string;
 }
@@ -49,7 +48,6 @@ export const QuickDmChat = ({
   locale,
   onBack,
   onClose,
-  onCreateDirectMessage,
   onOpenAll,
   waveId,
 }: QuickDmChatProps) => {
@@ -164,7 +162,6 @@ export const QuickDmChat = ({
         openAllHref={getMessagePathRoute(waveId)}
         onBack={onBack}
         onClose={onClose}
-        onCreateDirectMessage={onCreateDirectMessage}
         onOpenAll={onOpenAll}
       />
       <div className="tw-min-h-0 tw-flex-1">{chatContent}</div>


### PR DESCRIPTION
## Issue
- The quick DM create icon appears in both the quick-DM list panel and an open one-on-one DM chat. It should only be available from the list view.

## Fix
- Stop passing the create-DM handler into `QuickDmChat`, while leaving `QuickDmListPanel` unchanged.
- The shared quick-DM header still renders the icon whenever a caller supplies `onCreateDirectMessage`; chat no longer supplies it.

## Changes
- Removed the create-DM prop from the chat component API.
- Removed the parent prop forwarding for the chat render path.

## Validation
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff`
- `git diff --check`

## Risk
- Level: Low
- Why: scoped client UI prop removal; no API, storage, auth, or data-shape changes.
- Rollback: revert this PR to restore the previous header action in chat.

## Review Notes
- The list panel still receives `onCreateDirectMessage`, so the paper-airplane icon remains visible there. The chat panel no longer receives it, so the same shared header omits the icon when a concrete DM is open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the Quick Direct Messages experience so the “create direct message” action is now handled from the list view instead of within the chat view.
  * Simplified the chat screen controls by removing an unavailable in-chat action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->