### PR TITLE
[codex] Downgrade known push registration IID errors

### DIFF
--- a/__tests__/components/notifications/NotificationsContext.test.tsx
+++ b/__tests__/components/notifications/NotificationsContext.test.tsx
@@ -577,6 +577,38 @@ describe("push registration behavior", () => {
     );
   });
 
+  it("records known low-value native registration errors as info breadcrumbs", async () => {
+    const sentry = require("@sentry/nextjs");
+    const nativeError = {
+      domain: "com.google.iid",
+      code: -25291,
+      localizedDescription:
+        "The operation couldn't be completed. (com.google.iid error -25291.)",
+    };
+    const { registrationErrorCallback } = await setupRegistrationCallback();
+
+    act(() => {
+      registrationErrorCallback(nativeError);
+    });
+
+    expect(sentry.captureException).not.toHaveBeenCalled();
+    expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: "info",
+        message: "Push registration low-value native error.",
+        data: expect.objectContaining({
+          component: "NotificationsProvider",
+          operation: "pushRegistrationError",
+          retryable: false,
+          known_low_value: true,
+          error_code: -25291,
+          error_message:
+            "The operation couldn't be completed. (com.google.iid error -25291.)",
+        }),
+      })
+    );
+  });
+
   it("captures non-transient native registration objects as Error instances", async () => {
     const sentry = require("@sentry/nextjs");
     const nativeError = {

--- a/__tests__/components/notifications/NotificationsContext.test.tsx
+++ b/__tests__/components/notifications/NotificationsContext.test.tsx
@@ -579,11 +579,37 @@ describe("push registration behavior", () => {
 
   it("records known low-value native registration errors as info breadcrumbs", async () => {
     const sentry = require("@sentry/nextjs");
+    const nativeError = new Error(
+      "The operation couldn't be completed. (com.google.iid error -25291.)"
+    );
+    const { registrationErrorCallback } = await setupRegistrationCallback();
+
+    act(() => {
+      registrationErrorCallback(nativeError);
+    });
+
+    expect(sentry.captureException).not.toHaveBeenCalled();
+    expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: "info",
+        message: "Push registration low-value native error.",
+        data: expect.objectContaining({
+          component: "NotificationsProvider",
+          operation: "pushRegistrationError",
+          retryable: false,
+          known_low_value: true,
+          error_message:
+            "The operation couldn't be completed. (com.google.iid error -25291.)",
+        }),
+      })
+    );
+  });
+
+  it("records low-value native registration errors by domain and code", async () => {
+    const sentry = require("@sentry/nextjs");
     const nativeError = {
       domain: "com.google.iid",
       code: -25291,
-      localizedDescription:
-        "The operation couldn't be completed. (com.google.iid error -25291.)",
     };
     const { registrationErrorCallback } = await setupRegistrationCallback();
 
@@ -602,8 +628,7 @@ describe("push registration behavior", () => {
           retryable: false,
           known_low_value: true,
           error_code: -25291,
-          error_message:
-            "The operation couldn't be completed. (com.google.iid error -25291.)",
+          error_message: "Unknown notification error",
         }),
       })
     );

--- a/components/notifications/NotificationsContext.tsx
+++ b/components/notifications/NotificationsContext.tsx
@@ -92,6 +92,11 @@ const TRANSIENT_ERROR_PATTERNS = [
   "network error",
   "timeout",
 ];
+const LOW_VALUE_PUSH_REGISTRATION_ERROR_PATTERNS = [
+  "com.google.iid error -25291",
+];
+const LOW_VALUE_PUSH_REGISTRATION_ERROR_DOMAIN = "com.google.iid";
+const LOW_VALUE_PUSH_REGISTRATION_ERROR_CODES = new Set(["-25291"]);
 
 type PushRegistrationFingerprint = {
   deviceId: string;
@@ -366,6 +371,30 @@ const extractErrorCode = (error: unknown): string | number | undefined => {
   return typeof errorCode === "string" || typeof errorCode === "number"
     ? errorCode
     : undefined;
+};
+
+const isKnownLowValuePushRegistrationError = (error: unknown): boolean => {
+  const normalizedMessage = toErrorMessage(error).toLowerCase();
+  const normalizedErrorCode = String(extractErrorCode(error) ?? "")
+    .trim()
+    .toLowerCase();
+  const errorRecord = toRecord(error);
+  const normalizedErrorDomain =
+    errorRecord !== null
+      ? getStringErrorField(errorRecord, "domain")?.toLowerCase() ?? ""
+      : "";
+
+  const matchesKnownPattern = LOW_VALUE_PUSH_REGISTRATION_ERROR_PATTERNS.some(
+    (pattern) =>
+      normalizedMessage.includes(pattern) ||
+      normalizedErrorCode.includes(pattern)
+  );
+
+  return (
+    matchesKnownPattern ||
+    (normalizedErrorDomain === LOW_VALUE_PUSH_REGISTRATION_ERROR_DOMAIN &&
+      LOW_VALUE_PUSH_REGISTRATION_ERROR_CODES.has(normalizedErrorCode))
+  );
 };
 
 const createErrorTelemetryExtra = (error: unknown): ErrorTelemetryExtra => {
@@ -1028,6 +1057,26 @@ export const NotificationsProvider: React.FC<{ children: React.ReactNode }> = ({
           isRegisteredRef.current = false;
           const statusCode = extractErrorStatusCode(error);
           const errorExtra = createErrorTelemetryExtra(error);
+
+          if (isKnownLowValuePushRegistrationError(error)) {
+            console.warn("Known low-value push registration error", {
+              statusCode,
+              ...errorExtra,
+            });
+            Sentry.addBreadcrumb({
+              category: "notifications",
+              level: "info",
+              message: "Push registration low-value native error.",
+              data: {
+                component: "NotificationsProvider",
+                operation: "pushRegistrationError",
+                retryable: false,
+                known_low_value: true,
+                ...errorExtra,
+              },
+            });
+            return;
+          }
 
           if (isTransientPushRegistrationError(error)) {
             console.warn("Transient push registration error", {

--- a/components/notifications/NotificationsContext.tsx
+++ b/components/notifications/NotificationsContext.tsx
@@ -96,7 +96,7 @@ const LOW_VALUE_PUSH_REGISTRATION_ERROR_PATTERNS = [
   "com.google.iid error -25291",
 ];
 const LOW_VALUE_PUSH_REGISTRATION_ERROR_DOMAIN = "com.google.iid";
-const LOW_VALUE_PUSH_REGISTRATION_ERROR_CODES = new Set(["-25291"]);
+const LOW_VALUE_PUSH_REGISTRATION_ERROR_CODE_STRINGS = new Set(["-25291"]);
 
 type PushRegistrationFingerprint = {
   deviceId: string;
@@ -381,19 +381,17 @@ const isKnownLowValuePushRegistrationError = (error: unknown): boolean => {
   const errorRecord = toRecord(error);
   const normalizedErrorDomain =
     errorRecord !== null
-      ? getStringErrorField(errorRecord, "domain")?.toLowerCase() ?? ""
+      ? (getStringErrorField(errorRecord, "domain")?.toLowerCase() ?? "")
       : "";
 
   const matchesKnownPattern = LOW_VALUE_PUSH_REGISTRATION_ERROR_PATTERNS.some(
-    (pattern) =>
-      normalizedMessage.includes(pattern) ||
-      normalizedErrorCode.includes(pattern)
+    (pattern) => normalizedMessage.includes(pattern)
   );
 
   return (
     matchesKnownPattern ||
     (normalizedErrorDomain === LOW_VALUE_PUSH_REGISTRATION_ERROR_DOMAIN &&
-      LOW_VALUE_PUSH_REGISTRATION_ERROR_CODES.has(normalizedErrorCode))
+      LOW_VALUE_PUSH_REGISTRATION_ERROR_CODE_STRINGS.has(normalizedErrorCode))
   );
 };
 

--- a/components/notifications/NotificationsContext.tsx
+++ b/components/notifications/NotificationsContext.tsx
@@ -380,9 +380,9 @@ const isKnownLowValuePushRegistrationError = (error: unknown): boolean => {
     .toLowerCase();
   const errorRecord = toRecord(error);
   const normalizedErrorDomain =
-    errorRecord !== null
-      ? (getStringErrorField(errorRecord, "domain")?.toLowerCase() ?? "")
-      : "";
+    errorRecord === null
+      ? ""
+      : (getStringErrorField(errorRecord, "domain")?.toLowerCase() ?? "");
 
   const matchesKnownPattern = LOW_VALUE_PUSH_REGISTRATION_ERROR_PATTERNS.some(
     (pattern) => normalizedMessage.includes(pattern)


### PR DESCRIPTION
## Issue
- Sentry issue `6529-FRONTEND-DY` reports handled `pushRegistrationError` events from `NotificationsProvider` for native Capacitor push registration failures matching `com.google.iid error -25291` on `/notifications`.
- This native IID failure is noisy and not actionable as a high-priority frontend error, while unknown native registration failures should still be captured.

## Fix
- Add a separate known-low-value native push registration predicate for the IID `-25291` failure.
- Breadcrumb that case at info level instead of calling `Sentry.captureException`.
- Keep the existing transient/retryable breadcrumb behavior separate and preserve Sentry error capture for unknown non-transient native registration failures.

## Changes
- Added `isKnownLowValuePushRegistrationError` in `NotificationsContext.tsx`.
- Updated the `registrationError` listener to handle the known IID failure before transient and unknown-failure handling.
- Added a focused unit test proving the IID `-25291` native error creates an info breadcrumb and does not capture an exception.

## Validation
- `PATH=/opt/homebrew/bin:$PATH ./bin/6529 run test -- __tests__/components/notifications/NotificationsContext.test.tsx`
- `PATH=/opt/homebrew/bin:$PATH ./bin/6529 run lint:changed`
- `PATH=/opt/homebrew/bin:$PATH ./bin/6529 run typecheck:changed`
- `PATH=/opt/homebrew/bin:$PATH ./bin/6529 run react-doctor:diff`
- `git diff --check`

React Doctor completed with exit 0 and reported pre-existing warnings about the large `NotificationsProvider` component and sequential native setup awaits; neither is changed by this telemetry-only fix.

## Risk
- Level: Low
- Why: The change is limited to telemetry classification for one known native registration failure. Push registration flow, backend registration, unauthorized handling, retryable failures, and unknown native failure capture remain intact.
- Rollback: Revert the PR to restore the previous capture behavior.

## Review Notes
- Please focus on whether the IID `-25291` match is scoped narrowly enough and whether the breadcrumb fields are useful for future triage without opening high-priority Sentry issues.