### PR TITLE
[codex] Filter MetaMask WebView cyclic JSON noise

### DIFF
--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -2682,7 +2682,7 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(false);
   });
 
-  it("filters MetaMaskMobile route parameterization errors outside waves routes", () => {
+  it("does not filter MetaMaskMobile route parameterization errors outside known route bounds", () => {
     // Arrange
     const event = createSentryRouteParameterizationEvent({
       transaction: "/about",
@@ -2704,7 +2704,7 @@ describe("sentry-client-filters", () => {
     const result = shouldFilterSentryRouteParameterizationError(event);
 
     // Assert
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 
   it("filters MetaMaskMobile route parameterization errors when waves route appears only in navigation breadcrumbs", () => {

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -68,6 +68,8 @@ describe("sentry-client-filters", () => {
   });
   const metaMaskCircularMetaElementMessage =
     "Converting circular structure to JSON --> starting at object with constructor 'HTMLMetaElement' | property '__reactFiber$nkfb4ziusym' -> object with constructor 'ry' --- property 'stateNode' closes the circle";
+  const metaMaskMobileWebViewUserAgent =
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 WebView MetaMaskMobile";
   const wasmCspUnsafeEvalMessage = [
     "Aborted(CompileError: WebAssembly.instantiate(): Compiling or instantiating",
     "WebAssembly module violates the following Content Security policy directive",
@@ -89,6 +91,23 @@ describe("sentry-client-filters", () => {
     },
     ...overrides,
   });
+
+  function withRuntimeUserAgent<T>(userAgent: string, callback: () => T): T {
+    const originalUserAgent = globalThis.navigator.userAgent;
+    Object.defineProperty(globalThis.navigator, "userAgent", {
+      configurable: true,
+      value: userAgent,
+    });
+
+    try {
+      return callback();
+    } finally {
+      Object.defineProperty(globalThis.navigator, "userAgent", {
+        configurable: true,
+        value: originalUserAgent,
+      });
+    }
+  }
 
   const createTwitterConfigEvent = (
     overrides: TestSentryClientEventOverrides = {}
@@ -2467,6 +2486,49 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
+  it("filters MetaMaskMobile WebView route parameterization errors on the memes mint route", () => {
+    // Arrange
+    const event = createSentryRouteParameterizationEvent({
+      transaction: "/the-memes/mint",
+      request: {
+        url: "https://6529.io/the-memes/mint",
+        headers: {
+          "User-Agent": metaMaskMobileWebViewUserAgent,
+        },
+      },
+      contexts: {},
+      tags: {},
+      breadcrumbs: [],
+    });
+
+    // Act
+    const result = shouldFilterSentryRouteParameterizationError(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("uses the runtime user agent for MetaMaskMobile WebView route parameterization errors", () => {
+    // Arrange
+    const event = createSentryRouteParameterizationEvent({
+      transaction: "/the-memes/mint",
+      request: {
+        url: "https://6529.io/the-memes/mint",
+      },
+      contexts: {},
+      tags: {},
+      breadcrumbs: [],
+    });
+
+    // Act
+    const result = withRuntimeUserAgent(metaMaskMobileWebViewUserAgent, () =>
+      shouldFilterSentryRouteParameterizationError(event)
+    );
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
   it("does not filter cyclic JSON errors with app-owned frames", () => {
     // Arrange
     const event = createSentryRouteParameterizationEvent({
@@ -2490,6 +2552,54 @@ describe("sentry-client-filters", () => {
                   filename: "https://6529.io/_next/static/chunks/app-client.js",
                   function: "serializeWaveParams",
                   in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterSentryRouteParameterizationError(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter cyclic JSON errors with app-owned source frames", () => {
+    // Arrange
+    const event = createSentryRouteParameterizationEvent({
+      transaction: "/the-memes/mint",
+      request: {
+        url: "https://6529.io/the-memes/mint",
+        headers: {
+          "User-Agent": metaMaskMobileWebViewUserAgent,
+        },
+      },
+      contexts: {},
+      tags: {},
+      breadcrumbs: [],
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: __testing.sentryRouteParameterizationMessage,
+            mechanism: {
+              type: __testing.sentryRouteParameterizationMechanismType,
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename: "[native code]",
+                  function: "stringify",
+                  in_app: true,
+                },
+                {
+                  filename:
+                    "https://6529.io/_next/static/chunks/app/the-memes/mint/page-1234567890abcdef.js",
+                  function: "submitMint",
                 },
               ],
             },
@@ -2538,7 +2648,7 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(false);
   });
 
-  it("does not filter cyclic JSON errors without navigation breadcrumbs", () => {
+  it("filters cyclic JSON errors without navigation breadcrumbs when MetaMaskMobile WebView context is present", () => {
     // Arrange
     const event = createSentryRouteParameterizationEvent({
       breadcrumbs: [],
@@ -2548,7 +2658,7 @@ describe("sentry-client-filters", () => {
     const result = shouldFilterSentryRouteParameterizationError(event);
 
     // Assert
-    expect(result).toBe(false);
+    expect(result).toBe(true);
   });
 
   it("does not filter cyclic JSON route parameterization errors without MetaMaskMobile WKWebView context", () => {
@@ -2572,7 +2682,7 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(false);
   });
 
-  it("does not filter MetaMaskMobile route parameterization errors outside waves routes", () => {
+  it("filters MetaMaskMobile route parameterization errors outside waves routes", () => {
     // Arrange
     const event = createSentryRouteParameterizationEvent({
       transaction: "/about",
@@ -2594,7 +2704,7 @@ describe("sentry-client-filters", () => {
     const result = shouldFilterSentryRouteParameterizationError(event);
 
     // Assert
-    expect(result).toBe(false);
+    expect(result).toBe(true);
   });
 
   it("filters MetaMaskMobile route parameterization errors when waves route appears only in navigation breadcrumbs", () => {

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -246,6 +246,7 @@ const metaMaskMobileContextTokens = ["metamaskmobile", "metamask mobile"];
 const mobileSafariWebViewContextTokens = [
   "mobile safari ui/wkwebview",
   "wkwebview",
+  "webview",
 ];
 const routeParameterizationContextKeys = ["app", "browser", "device", "os"];
 const routeParameterizationTagKeys = [
@@ -1723,13 +1724,40 @@ function getRouteParameterizationContextValues(
   );
 }
 
+function getRuntimeUserAgent(): string | undefined {
+  try {
+    const userAgent = globalThis.navigator?.userAgent;
+    return typeof userAgent === "string" ? userAgent : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getRouteParameterizationUserAgentValues(
+  event: SentryClientEvent
+): string[] {
+  const candidates = [
+    getRequestHeaderString(event, "user-agent"),
+    getStringValue(event.tags?.["user_agent"]),
+    getStringValue(event.tags?.["userAgent"]),
+    getRuntimeUserAgent(),
+  ];
+
+  return candidates.filter(
+    (value): value is string => typeof value === "string" && value.length > 0
+  );
+}
+
 function matchesContextToken(value: string, tokens: string[]): boolean {
   const normalized = value.toLowerCase();
   return tokens.some((token) => normalized.includes(token));
 }
 
 function hasMetaMaskMobileWebViewContext(event: SentryClientEvent): boolean {
-  const values = getRouteParameterizationContextValues(event);
+  const values = uniqueStrings([
+    ...getRouteParameterizationContextValues(event),
+    ...getRouteParameterizationUserAgentValues(event),
+  ]);
   return (
     values.some((value) =>
       matchesContextToken(value, metaMaskMobileContextTokens)
@@ -2373,14 +2401,11 @@ export function shouldFilterSentryRouteParameterizationError(
   }
 
   const frames = value.stacktrace?.frames;
-  if (hasAppOwnedFrame(frames) || !hasNativeJsonStringifyFrame(frames)) {
+  if (hasLikelyAppOwnedFrame(frames) || !hasNativeJsonStringifyFrame(frames)) {
     return false;
   }
 
-  return (
-    hasRouteParameterizationNavigationSignature(event) &&
-    hasMetaMaskMobileWebViewContext(event)
-  );
+  return hasMetaMaskMobileWebViewContext(event);
 }
 
 export function shouldFilterInjectedWalletCollision(

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -246,8 +246,8 @@ const metaMaskMobileContextTokens = ["metamaskmobile", "metamask mobile"];
 const mobileSafariWebViewContextTokens = [
   "mobile safari ui/wkwebview",
   "wkwebview",
-  "webview",
 ];
+const webViewUserAgentTokens = ["webview", "wkwebview"];
 const routeParameterizationContextKeys = ["app", "browser", "device", "os"];
 const routeParameterizationTagKeys = [
   "app",
@@ -405,6 +405,16 @@ function hasMatchingRoute(
 
 function hasWavesRoute(event: SentryClientEvent): boolean {
   return hasMatchingRoute(event, isWavesRoutePath);
+}
+
+function isRouteParameterizationRoutePath(path: string | null): boolean {
+  return (
+    isWavesRoutePath(path) || isExactRoutePath(path, THE_MEMES_MINT_ROUTE_PATH)
+  );
+}
+
+function hasRouteParameterizationRoute(event: SentryClientEvent): boolean {
+  return hasMatchingRoute(event, isRouteParameterizationRoutePath);
 }
 
 function hasReactDomRemoveChildRoute(event: SentryClientEvent): boolean {
@@ -1620,17 +1630,6 @@ function getBreadcrumbValues(event: SentryClientEvent): SentryBreadcrumb[] {
   return [];
 }
 
-function hasNavigationBreadcrumb(event: SentryClientEvent): boolean {
-  return getBreadcrumbValues(event).some((breadcrumb) => {
-    const data = breadcrumb.data;
-    return (
-      breadcrumb.category === "navigation" &&
-      typeof data?.["from"] === "string" &&
-      typeof data?.["to"] === "string"
-    );
-  });
-}
-
 function hasGifPickerTenorFailureBreadcrumb(event: SentryClientEvent): boolean {
   return getBreadcrumbMessages(event).some((message) =>
     message.includes(gifPickerTenorFailureMessage)
@@ -1680,7 +1679,9 @@ function hasGifPickerTenorBreadcrumbSignature(
   );
 }
 
-function hasWavesNavigationBreadcrumb(event: SentryClientEvent): boolean {
+function hasRouteParameterizationNavigationBreadcrumb(
+  event: SentryClientEvent
+): boolean {
   return getBreadcrumbValues(event).some((breadcrumb) => {
     const data = breadcrumb.data;
     if (
@@ -1692,17 +1693,17 @@ function hasWavesNavigationBreadcrumb(event: SentryClientEvent): boolean {
     }
 
     return [data["from"], data["to"]].some((candidate) =>
-      isWavesRoutePath(getRoutePathFromString(candidate))
+      isRouteParameterizationRoutePath(getRoutePathFromString(candidate))
     );
   });
 }
 
-function hasRouteParameterizationNavigationSignature(
+function hasRouteParameterizationRouteEvidence(
   event: SentryClientEvent
 ): boolean {
   return (
-    hasNavigationBreadcrumb(event) &&
-    (hasWavesRoute(event) || hasWavesNavigationBreadcrumb(event))
+    hasRouteParameterizationRoute(event) ||
+    hasRouteParameterizationNavigationBreadcrumb(event)
   );
 }
 
@@ -1754,17 +1755,22 @@ function matchesContextToken(value: string, tokens: string[]): boolean {
 }
 
 function hasMetaMaskMobileWebViewContext(event: SentryClientEvent): boolean {
-  const values = uniqueStrings([
-    ...getRouteParameterizationContextValues(event),
-    ...getRouteParameterizationUserAgentValues(event),
-  ]);
-  return (
-    values.some((value) =>
+  const contextValues = getRouteParameterizationContextValues(event);
+  if (
+    contextValues.some((value) =>
       matchesContextToken(value, metaMaskMobileContextTokens)
     ) &&
-    values.some((value) =>
+    contextValues.some((value) =>
       matchesContextToken(value, mobileSafariWebViewContextTokens)
     )
+  ) {
+    return true;
+  }
+
+  return getRouteParameterizationUserAgentValues(event).some(
+    (value) =>
+      matchesContextToken(value, metaMaskMobileContextTokens) &&
+      matchesContextToken(value, webViewUserAgentTokens)
   );
 }
 
@@ -2405,7 +2411,10 @@ export function shouldFilterSentryRouteParameterizationError(
     return false;
   }
 
-  return hasMetaMaskMobileWebViewContext(event);
+  return (
+    hasRouteParameterizationRouteEvidence(event) &&
+    hasMetaMaskMobileWebViewContext(event)
+  );
 }
 
 export function shouldFilterInjectedWalletCollision(
@@ -2449,7 +2458,7 @@ export const __testing = {
   sentryRouteParameterizationMechanismType,
   sentryRouteParameterizationMessage,
   hasMetaMaskMobileWebViewContext,
-  hasRouteParameterizationNavigationSignature,
+  hasRouteParameterizationRouteEvidence,
   isCoinbaseWalletLinkWebSocket1006Message,
   isCoinbaseWalletLinkWebSocketPath,
   hasCoinbaseWalletLinkWebSocketFrame,


### PR DESCRIPTION
## Issue
- Sentry is grouping a known third-party/browser instrumentation error as `6529-FRONTEND-CP`: `TypeError: JSON.stringify cannot serialize cyclic structures.`
- The latest observed event is on `/the-memes/mint` in MetaMask Mobile WebView with only native `JSON.stringify` stack evidence, so the existing waves-route/navigation gate misses it.

## Fix
- Broaden the route-parameterization filter only when the event matches the exact native cyclic JSON signature: unhandled `auto.browser.browserapierrors.setTimeout`, native `JSON.stringify`, no likely app-owned frames, bounded route evidence, and MetaMask Mobile WebView context.
- Include `/the-memes/mint` route evidence in addition to existing waves evidence, and include Sentry request/tag user-agent values plus a guarded runtime `navigator.userAgent` fallback for incomplete captured headers.

## Changes
- Added route evidence for exact `/the-memes/mint` while keeping waves route/navigation support.
- Added user-agent candidates to MetaMask Mobile WebView detection, requiring MetaMaskMobile and WebView/WKWebView in the same user-agent string.
- Replaced the narrow `in_app` frame check with the existing likely app-owned frame helper for this filter.
- Added focused tests for `/the-memes/mint`, runtime user-agent fallback, route-bound negatives, and app-owned cyclic JSON negatives.

## Validation
- `./bin/6529 run test:no-coverage -- __tests__/utils/sentry-client-filters.test.ts`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `git diff --check`

## Risk
- Level: Low
- Why: The filter still requires exact message, exact browser API mechanism, unhandled status, native `JSON.stringify`, known route evidence, MetaMask Mobile WebView context, and no likely app-owned frames.
- Rollback: Revert this PR to restore the previous waves/navigation-only gate.

## Review Notes
- Follow-up commit addresses 6529bot general review by bounding the filter to `/waves` or exact `/the-memes/mint` evidence and tightening the WebView UA pairing.