### PR TITLE
[codex] Filter Coinbase WalletLink websocket 1006 noise

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -495,6 +495,38 @@ describe("instrumentation-client", () => {
     expect(result).toBeNull();
   });
 
+  it("drops raw AppKit Coinbase websocket 1006 unhandled rejections", () => {
+    const beforeSend = loadBeforeSend();
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "Error: websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "https://dnclu2fna0b2b.cloudfront.net/_next/static/chunks/app/layout-123.js",
+                  function: "e",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      breadcrumbs: createAppKitCoinbaseBreadcrumbs(),
+    };
+
+    const result = beforeSend(event);
+
+    expect(result).toBeNull();
+  });
+
   it("keeps exact Talisman onboarding errors with app-owned frames", () => {
     const beforeSend = loadBeforeSend();
     const event = {

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -2872,6 +2872,80 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
+  it("filters raw AppKit Coinbase websocket 1006 unhandled rejections before source-map symbolication", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "Error: websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "https://dnclu2fna0b2b.cloudfront.net/_next/static/chunks/app/layout-123.js",
+                  function: "e",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      breadcrumbs: createAppKitCoinbaseBreadcrumbs(),
+    });
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("filters Coinbase WalletLink websocket 1006 errors from serialized raw stacks", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "Error: websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "https://dnclu2fna0b2b.cloudfront.net/_next/static/chunks/app/layout-123.js",
+                  function: "e",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      extra: {
+        __serialized__: {
+          message: "websocket error 1006:",
+          stack:
+            "Error: websocket error 1006:\n    at webSocket.onclose (node_modules/.pnpm/@coinbase+wallet-sdk@3.9.3/node_modules/@coinbase/wallet-sdk/dist/relay/walletlink/connection/WalletLinkWebSocket.js:52:28)",
+        },
+      },
+    });
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
   it("does not filter app-owned websocket 1006 errors", () => {
     // Arrange
     const event = createCoinbaseWalletLinkWebSocketEvent({
@@ -2931,6 +3005,40 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(false);
   });
 
+  it("does not filter app-owned websocket 1006 unhandled rejections with close-handler function names", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "webpack-internal:///(app-pages-browser)/./services/websocket/WebSocketProvider.tsx",
+                  function: "webSocket.onclose",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
   it("does not filter no-frame websocket 1006 errors when the original exception stack is app-owned", () => {
     // Arrange
     const event = createCoinbaseWalletLinkWebSocketEvent({
@@ -2957,6 +3065,43 @@ describe("sentry-client-filters", () => {
     const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event, {
       originalException: error,
     });
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter no-frame websocket 1006 errors when the serialized stack is app-owned", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "Error: websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [],
+            },
+          },
+        ],
+      },
+      breadcrumbs: createAppKitCoinbaseBreadcrumbs(),
+      extra: {
+        __serialized__: {
+          message: "websocket error 1006:",
+          stack: [
+            "Error: websocket error 1006:",
+            "    at connect (webpack-internal:///(app-pages-browser)/./services/websocket/WebSocketProvider.tsx:10:1)",
+          ].join("\n"),
+        },
+      },
+    });
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
 
     // Assert
     expect(result).toBe(false);

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -2946,6 +2946,43 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
+  it("filters AppKit Coinbase websocket 1006 errors when vendor stacks only contain incidental app path tokens", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "Error: websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [],
+            },
+          },
+        ],
+      },
+      breadcrumbs: createAppKitCoinbaseBreadcrumbs(),
+      extra: {
+        __serialized__: {
+          message: "websocket error 1006:",
+          stack: [
+            "Error: websocket error 1006:",
+            "    at onClose (https://wallet.example.invalid/vendor/(services/relay.js:1:1)",
+          ].join("\n"),
+        },
+      },
+    });
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
   it("does not filter app-owned websocket 1006 errors", () => {
     // Arrange
     const event = createCoinbaseWalletLinkWebSocketEvent({

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -1368,6 +1368,17 @@ function getHintExceptionStack(hint?: SentryEventHint): string {
   if (exception instanceof Error && typeof exception.stack === "string") {
     return exception.stack;
   }
+  if (isRecord(exception) && typeof exception["stack"] === "string") {
+    return exception["stack"];
+  }
+  return "";
+}
+
+function getSerializedExceptionStack(event: SentryClientEvent): string {
+  const serialized = event.extra?.["__serialized__"];
+  if (isRecord(serialized) && typeof serialized["stack"] === "string") {
+    return serialized["stack"];
+  }
   return "";
 }
 
@@ -1404,7 +1415,9 @@ function hasAppOwnedStackEvidence(
 }
 
 function isCoinbaseWalletLinkWebSocket1006Message(value: string): boolean {
-  return coinbaseWalletLinkWebSocket1006Pattern.test(value.trim());
+  return coinbaseWalletLinkWebSocket1006Pattern.test(
+    normalizeErrorPrefix(value)
+  );
 }
 
 function isCoinbaseWalletLinkWebSocketPath(path: string | undefined): boolean {
@@ -1449,6 +1462,24 @@ function hasCoinbaseWalletLinkWebSocketCloseStack(
   hint?: SentryEventHint
 ): boolean {
   return getHintExceptionStack(hint).includes(
+    coinbaseWalletLinkWebSocketCloseFunction
+  );
+}
+
+function hasCoinbaseWalletLinkWebSocketSerializedStack(
+  event: SentryClientEvent
+): boolean {
+  const stack = getSerializedExceptionStack(event);
+  return (
+    stack.includes(coinbaseWalletLinkWebSocketFile) &&
+    coinbaseWalletSdkPathTokens.some((token) => stack.includes(token))
+  );
+}
+
+function hasCoinbaseWalletLinkWebSocketSerializedCloseStack(
+  event: SentryClientEvent
+): boolean {
+  return getSerializedExceptionStack(event).includes(
     coinbaseWalletLinkWebSocketCloseFunction
   );
 }
@@ -1570,13 +1601,70 @@ function hasThirdPartyWalletAppKitBreadcrumbSignature(
 
 function hasWalletLinkWebSocketUnhandledRejectionSignature(
   value: SentryExceptionValue | undefined,
+  event: SentryClientEvent,
   hint?: SentryEventHint
 ): boolean {
   return (
     value?.mechanism?.type === browserUnhandledRejectionMechanism &&
     value.mechanism.handled === false &&
     (hasCoinbaseWalletLinkWebSocketCloseFunction(value.stacktrace?.frames) ||
-      hasCoinbaseWalletLinkWebSocketCloseStack(hint))
+      hasCoinbaseWalletLinkWebSocketCloseStack(hint) ||
+      hasCoinbaseWalletLinkWebSocketSerializedCloseStack(event))
+  );
+}
+
+function hasBrowserUnhandledRejectionMechanism(
+  value: SentryExceptionValue | undefined
+): boolean {
+  return (
+    value?.mechanism?.type === browserUnhandledRejectionMechanism &&
+    value.mechanism.handled === false
+  );
+}
+
+function hasAppOwnedWalletLinkWebSocket1006Evidence(
+  event: SentryClientEvent,
+  value: SentryExceptionValue | undefined,
+  hint?: SentryEventHint
+): boolean {
+  const frames = value?.stacktrace?.frames;
+  return (
+    hasAppOwnedFrame(frames) ||
+    hasAppOwnedSourceFrame(frames) ||
+    hasAppOwnedSourceStackValue(getHintExceptionStack(hint)) ||
+    hasAppOwnedSourceStackValue(getSerializedExceptionStack(event))
+  );
+}
+
+function hasAppOwnedSourceStackValue(value: string): boolean {
+  if (value.length === 0) {
+    return false;
+  }
+
+  return appOwnedFramePathPrefixes.some(
+    (prefix) =>
+      value.includes(`webpack-internal:///(app-pages-browser)/./${prefix}`) ||
+      value.includes(`webpack-internal:///(app-pages-browser)/${prefix}`) ||
+      value.includes(`webpack://_n_e/./${prefix}`) ||
+      value.includes(`app:///${prefix}`) ||
+      value.startsWith(prefix) ||
+      value.includes(`(${prefix}`) ||
+      value.includes(` ${prefix}`) ||
+      value.includes(`\t${prefix}`)
+  );
+}
+
+function hasThirdPartyWalletLinkWebSocket1006Evidence(
+  event: SentryClientEvent,
+  value: SentryExceptionValue | undefined,
+  hint?: SentryEventHint
+): boolean {
+  return (
+    hasCoinbaseWalletLinkWebSocketFrame(value?.stacktrace?.frames) ||
+    hasCoinbaseWalletLinkWebSocketStack(hint) ||
+    hasCoinbaseWalletLinkWebSocketSerializedStack(event) ||
+    hasWalletLinkWebSocketUnhandledRejectionSignature(value, event, hint) ||
+    hasThirdPartyWalletAppKitBreadcrumbSignature(event)
   );
 }
 
@@ -2324,14 +2412,31 @@ export function shouldFilterCoinbaseWalletLinkWebSocket1006(
     return false;
   }
 
-  return (
+  const hasExplicitCoinbaseWalletLinkStack =
     hasCoinbaseWalletLinkWebSocketFrame(value?.stacktrace?.frames) ||
     hasCoinbaseWalletLinkWebSocketStack(hint) ||
-    hasWalletLinkWebSocketUnhandledRejectionSignature(value, hint) ||
-    (!hasAppOwnedFrame(value?.stacktrace?.frames) &&
-      !hasAppOwnedSourceFrame(value?.stacktrace?.frames) &&
-      !hasAppOwnedSourceStack(hint) &&
-      hasThirdPartyWalletAppKitBreadcrumbSignature(event))
+    hasCoinbaseWalletLinkWebSocketSerializedStack(event);
+
+  if (hasExplicitCoinbaseWalletLinkStack) {
+    return true;
+  }
+
+  const hasAppOwnedEvidence = hasAppOwnedWalletLinkWebSocket1006Evidence(
+    event,
+    value,
+    hint
+  );
+  if (
+    hasWalletLinkWebSocketUnhandledRejectionSignature(value, event, hint) &&
+    !hasAppOwnedEvidence
+  ) {
+    return true;
+  }
+
+  return (
+    hasBrowserUnhandledRejectionMechanism(value) &&
+    !hasAppOwnedEvidence &&
+    hasThirdPartyWalletLinkWebSocket1006Evidence(event, value, hint)
   );
 }
 

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -1486,6 +1486,8 @@ function hasCoinbaseWalletLinkWebSocketSerializedCloseStack(
 
 function normalizeStackPath(value: string): string {
   const webpackPrefix = "webpack-internal:///";
+  const webpackSourcePrefix = "webpack://_n_e/./";
+  const appUriPrefix = "app:///";
   let normalized = value;
 
   if (normalized.startsWith(webpackPrefix)) {
@@ -1499,6 +1501,12 @@ function normalizeStackPath(value: string): string {
     if (normalized.startsWith("./")) {
       normalized = normalized.slice(2);
     }
+  }
+  if (normalized.startsWith(webpackSourcePrefix)) {
+    normalized = normalized.slice(webpackSourcePrefix.length);
+  }
+  if (normalized.startsWith(appUriPrefix)) {
+    normalized = normalized.slice(appUriPrefix.length);
   }
 
   while (normalized.startsWith("/")) {
@@ -1636,17 +1644,34 @@ function hasAppOwnedSourceStackValue(value: string): boolean {
     return false;
   }
 
-  return appOwnedFramePathPrefixes.some(
-    (prefix) =>
-      value.includes(`webpack-internal:///(app-pages-browser)/./${prefix}`) ||
-      value.includes(`webpack-internal:///(app-pages-browser)/${prefix}`) ||
-      value.includes(`webpack://_n_e/./${prefix}`) ||
-      value.includes(`app:///${prefix}`) ||
-      value.startsWith(prefix) ||
-      value.includes(`(${prefix}`) ||
-      value.includes(` ${prefix}`) ||
-      value.includes(`\t${prefix}`)
-  );
+  return getStackFramePathCandidates(value).some(isAppOwnedStackPath);
+}
+
+function getStackFramePathCandidates(value: string): string[] {
+  return value
+    .split("\n")
+    .map(getStackFramePathCandidate)
+    .filter((candidate): candidate is string => !!candidate);
+}
+
+function getStackFramePathCandidate(line: string): string | null {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  if (!trimmed.startsWith("at ")) {
+    return trimmed;
+  }
+
+  const wrapperStart = trimmed.indexOf(" (");
+  if (wrapperStart >= 0 && trimmed.endsWith(")")) {
+    return trimmed.slice(wrapperStart + 2, -1);
+  }
+
+  const withoutAt = trimmed.slice("at ".length).trim();
+  const firstSpace = withoutAt.indexOf(" ");
+  return firstSpace >= 0 ? withoutAt.slice(firstSpace + 1).trim() : withoutAt;
 }
 
 function hasThirdPartyWalletLinkWebSocket1006Evidence(
@@ -1658,7 +1683,6 @@ function hasThirdPartyWalletLinkWebSocket1006Evidence(
     hasCoinbaseWalletLinkWebSocketFrame(value?.stacktrace?.frames) ||
     hasCoinbaseWalletLinkWebSocketStack(hint) ||
     hasCoinbaseWalletLinkWebSocketSerializedStack(event) ||
-    hasWalletLinkWebSocketUnhandledRejectionSignature(value, event, hint) ||
     hasThirdPartyWalletAppKitBreadcrumbSignature(event)
   );
 }

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -1530,11 +1530,6 @@ function hasAppOwnedSourceFrame(
   );
 }
 
-function hasAppOwnedSourceStack(hint?: SentryEventHint): boolean {
-  const stack = getHintExceptionStack(hint);
-  return appOwnedFramePathPrefixes.some((prefix) => stack.includes(prefix));
-}
-
 function addBreadcrumbSignatureValues(
   value: unknown,
   values: string[],


### PR DESCRIPTION
## Issue
- Sentry issue `6529-FRONTEND-N` reports `Error: websocket error 1006:` from Coinbase Wallet SDK / WalletLink websocket close handling.
- The existing filter still allowed a raw client-side event shape through before source-map display exposed the Coinbase/WalletLink frames clearly.

## Fix
- Normalize `Error: websocket error 1006:` message prefixes before matching the exact websocket 1006 noise signature.
- Expand WalletLink/Coinbase evidence extraction to include raw serialized stacks and object-shaped hint stacks.
- Keep the broad AppKit/Coinbase fallback limited to unhandled browser promise rejections with no explicit app-owned frame or source-stack evidence.

## Changes
- Updated `shouldFilterCoinbaseWalletLinkWebSocket1006` to separate explicit Coinbase/WalletLink stack evidence from the stricter raw-event fallback.
- Added focused Sentry filter tests for raw pre-symbolication AppKit/Coinbase chunk-frame events and serialized WalletLink stacks.
- Added negative tests for app-owned websocket close handlers and app-owned serialized stacks.
- Added instrumentation `beforeSend` coverage for the raw AppKit/Coinbase event shape.

## Validation
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false ./bin/6529 exec jest __tests__/utils/sentry-client-filters.test.ts __tests__/instrumentation-client.test.ts --silent --verbose=false --coverage=false`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false ./bin/6529 run lint:changed`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false ./bin/6529 run typecheck:changed`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false ./bin/6529 run react-doctor:diff`
- `git diff --check`

## Risk
- Level: Low
- Why: change is limited to client Sentry event filtering for one exact error message and related tests.
- Rollback: revert this PR to restore the previous Sentry filtering behavior.

## Review Notes
- Please focus on whether the fallback remains strict enough: exact websocket 1006 message, browser unhandled rejection, no app-owned source evidence, and Coinbase/WalletLink/AppKit evidence.