### PR TITLE
[codex] Filter Rabby Mobile RainbowKit Sentry noise

### DIFF
--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -11,6 +11,7 @@ import {
   shouldFilterReactDomInsertBeforeNotFoundError,
   shouldFilterReactDomRemoveChildNotFoundError,
   shouldFilterInjectedWasmCspUnsafeEval,
+  shouldFilterRabbyMobileRainbowKitNotFoundError,
   shouldFilterRabbyMobileUserRejectedRequest,
   shouldFilterSentryRouteParameterizationError,
   shouldFilterTalismanExtensionOnboardingError,
@@ -37,6 +38,10 @@ describe("sentry-client-filters", () => {
     "Error: The provider is disconnected from all chains.\n    at o (chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch/background.js:2:7356292)";
   const rabbyMobileUserRejectedStack =
     "Error: Not Allowed\n    at userRejectedRequest (RabbyMobile://native-bundle/background.js:1:1)";
+  const rabbyMobileUserAgent =
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 RabbyMobile/1.0 RabbyMobileIOS/1.0 Mobile/15E148";
+  const rainbowKitNotFoundMessage = "not found rainbowkit";
+  const originalNavigatorUserAgent = globalThis.navigator.userAgent;
   const reactDomInsertBeforeMessage =
     __testing.REACT_DOM_INSERT_BEFORE_NOT_FOUND_ERROR_MESSAGE;
   const gifPickerTenorUndefinedTagsMessage =
@@ -415,6 +420,36 @@ describe("sentry-client-filters", () => {
       ...overrides,
     }) as TestSentryClientEvent;
 
+  const createRabbyMobileRainbowKitNotFoundEvent = (
+    overrides: TestSentryClientEventOverrides = {}
+  ): TestSentryClientEvent =>
+    ({
+      event_id: "rabby-mobile-rainbowkit-not-found",
+      transaction: "/about/the-memes",
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: rainbowKitNotFoundMessage,
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename: "[native code]",
+                  function: "Promise",
+                  in_app: false,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      ...overrides,
+    }) as TestSentryClientEvent;
+
   const createLowValueNetworkEvent = (
     overrides: TestSentryClientEventOverrides = {}
   ): TestSentryClientEvent => ({
@@ -443,6 +478,17 @@ describe("sentry-client-filters", () => {
       },
     ],
     ...overrides,
+  });
+
+  const setNavigatorUserAgent = (userAgent: string): void => {
+    Object.defineProperty(globalThis.navigator, "userAgent", {
+      value: userAgent,
+      configurable: true,
+    });
+  };
+
+  afterEach(() => {
+    setNavigatorUserAgent(originalNavigatorUserAgent);
   });
 
   const createReactDomInsertBeforeEvent = (
@@ -3522,6 +3568,18 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
+  it("filters exact RabbyMobile RainbowKit lookup errors from the runtime user agent", () => {
+    // Arrange
+    setNavigatorUserAgent(rabbyMobileUserAgent);
+    const event = createRabbyMobileRainbowKitNotFoundEvent();
+
+    // Act
+    const result = shouldFilterRabbyMobileRainbowKitNotFoundError(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
   it("filters injected WebAssembly CSP unsafe-eval errors", () => {
     // Arrange
     const event = createInjectedWasmCspUnsafeEvalEvent();
@@ -3602,6 +3660,50 @@ describe("sentry-client-filters", () => {
 
     // Act
     const result = shouldFilterRabbyMobileUserRejectedRequest(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter RabbyMobile RainbowKit lookup errors with app-owned frames", () => {
+    // Arrange
+    setNavigatorUserAgent(rabbyMobileUserAgent);
+    const event = createRabbyMobileRainbowKitNotFoundEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: rainbowKitNotFoundMessage,
+            stacktrace: {
+              frames: [
+                {
+                  filename: "https://6529.io/_next/static/chunks/app-client.js",
+                  function: "initializeWallet",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterRabbyMobileRainbowKitNotFoundError(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter RainbowKit lookup errors without RabbyMobile context", () => {
+    // Arrange
+    setNavigatorUserAgent(
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile Safari/605.1.15"
+    );
+    const event = createRabbyMobileRainbowKitNotFoundEvent();
+
+    // Act
+    const result = shouldFilterRabbyMobileRainbowKitNotFoundError(event);
 
     // Assert
     expect(result).toBe(false);

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -3695,6 +3695,35 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(false);
   });
 
+  it("does not filter RabbyMobile RainbowKit lookup errors with first-party frame paths", () => {
+    // Arrange
+    setNavigatorUserAgent(rabbyMobileUserAgent);
+    const event = createRabbyMobileRainbowKitNotFoundEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: rainbowKitNotFoundMessage,
+            stacktrace: {
+              frames: [
+                {
+                  filename: "https://6529.io/_next/static/chunks/app-client.js",
+                  function: "initializeWallet",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterRabbyMobileRainbowKitNotFoundError(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
   it("does not filter RainbowKit lookup errors without RabbyMobile context", () => {
     // Arrange
     setNavigatorUserAgent(

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -2274,7 +2274,7 @@ export function shouldFilterRabbyMobileRainbowKitNotFoundError(
     return false;
   }
 
-  return !hasAppOwnedFrame(value?.stacktrace?.frames);
+  return !hasLikelyAppOwnedFrame(value?.stacktrace?.frames);
 }
 
 export function shouldFilterGifPickerTenorCategoriesError(

--- a/utils/sentry-client-filters.ts
+++ b/utils/sentry-client-filters.ts
@@ -1771,10 +1771,16 @@ function getRequestHeaderString(
   return typeof value === "string" ? value : undefined;
 }
 
+function getRuntimeUserAgentString(): string | undefined {
+  const userAgent = globalThis.navigator?.userAgent;
+  return typeof userAgent === "string" ? userAgent : undefined;
+}
+
 function hasRabbyMobileContext(event: SentryClientEvent): boolean {
   const candidates = [
     getContextString(event, "browser", "name"),
     getRequestHeaderString(event, "user-agent"),
+    getRuntimeUserAgentString(),
     getStringValue(event.tags?.["browser"]),
     getStringValue(event.tags?.["browser.name"]),
     getStringValue(event.tags?.["user_agent"]),


### PR DESCRIPTION
## Issue
- Sentry issue `6529-FRONTEND-CM` reports `Error: not found rainbowkit` from Rabby Mobile on `/about/the-memes` with no visible app-owned frame.
- The existing Rabby/RainbowKit filter required exact message and no app-owned frames, but it only looked for Rabby evidence in event-provided context and request headers. Browser client `beforeSend` events can lack the request header shape shown in Sentry UI.

## Fix
- Add the runtime browser user agent as an additional Rabby Mobile context signal in the client filter.
- Preserve the exact-message guard and use the path-aware app-owned-frame guard so app-owned RainbowKit failures, including first-party `_next/static` frames without `in_app`, continue to report.

## Changes
- `utils/sentry-client-filters.ts`: include `globalThis.navigator.userAgent` in Rabby Mobile context detection and preserve likely app-owned frames before filtering.
- `__tests__/utils/sentry-client-filters.test.ts`: cover the latest event shape using runtime UA only, plus negative cases for `in_app` frames, first-party frame paths, and missing Rabby context.

## Validation
- `6529 run test:no-coverage -- __tests__/utils/sentry-client-filters.test.ts`
- `6529 run lint:changed`
- `6529 run typecheck:changed`
- `6529 run test:no-coverage -- __tests__/instrumentation-client.test.ts`
- `git diff --check`
- PR checks on latest head `f001e4113`: App PR CI, CodeQL, DCO, Snyk, SonarCloud, and CodeRabbit passed.

## Risk
- Level: Low
- Why: narrow client-side Sentry filtering change; only applies to exact `not found rainbowkit` errors with Rabby Mobile context and no likely app-owned frames.
- Rollback: revert this PR to remove the runtime user-agent context signal and tests.

## Review Notes
- Codex review P2 was addressed in `f001e4113` by switching to `hasLikelyAppOwnedFrame`; the review thread is resolved.