### PR TITLE
Refresh wave unread state after notification reads

### DIFF
--- a/__tests__/components/react-query-wrapper/ReactQueryWrapper.test.tsx
+++ b/__tests__/components/react-query-wrapper/ReactQueryWrapper.test.tsx
@@ -178,6 +178,9 @@ describe("ReactQueryWrapper context", () => {
     expect(client.invalidateQueries).toHaveBeenCalledWith({
       queryKey: [QueryKey.CONNECTED_ACCOUNT_UNREAD_NOTIFICATIONS],
     });
+    expect(client.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [QueryKey.WAVES_V2],
+    });
   });
 });
 

--- a/components/react-query-wrapper/ReactQueryWrapper.tsx
+++ b/components/react-query-wrapper/ReactQueryWrapper.tsx
@@ -1114,6 +1114,11 @@ const createReactQueryContextValue = (
         queryKey: [QueryKey.CONNECTED_ACCOUNT_UNREAD_NOTIFICATIONS],
       })
       .catch(() => undefined);
+    queryClient
+      .invalidateQueries({
+        queryKey: [QueryKey.WAVES_V2],
+      })
+      .catch(() => undefined);
   };
 
   const invalidateIdentityTdhStats = ({ identity }: { identity: string }) => {

--- a/components/react-query-wrapper/ReactQueryWrapper.tsx
+++ b/components/react-query-wrapper/ReactQueryWrapper.tsx
@@ -982,6 +982,14 @@ const createReactQueryContextValue = (
     });
   };
 
+  const invalidateWavesV2 = () => {
+    queryClient
+      .invalidateQueries({
+        queryKey: [QueryKey.WAVES_V2],
+      })
+      .catch(() => undefined);
+  };
+
   const invalidateAllWaves = () => {
     queryClient.invalidateQueries({
       queryKey: [QueryKey.WAVES_OVERVIEW],
@@ -989,11 +997,7 @@ const createReactQueryContextValue = (
     queryClient.invalidateQueries({
       queryKey: [QueryKey.WAVES_OVERVIEW_PUBLIC],
     });
-    queryClient
-      .invalidateQueries({
-        queryKey: [QueryKey.WAVES_V2],
-      })
-      .catch(() => undefined);
+    invalidateWavesV2();
     queryClient
       .invalidateQueries({
         queryKey: [QueryKey.WAVE_SUBWAVES],
@@ -1114,11 +1118,7 @@ const createReactQueryContextValue = (
         queryKey: [QueryKey.CONNECTED_ACCOUNT_UNREAD_NOTIFICATIONS],
       })
       .catch(() => undefined);
-    queryClient
-      .invalidateQueries({
-        queryKey: [QueryKey.WAVES_V2],
-      })
-      .catch(() => undefined);
+    invalidateWavesV2();
   };
 
   const invalidateIdentityTdhStats = ({ identity }: { identity: string }) => {


### PR DESCRIPTION
## Issue
- After a wave or DM is marked read, notification queries refresh but the waves V2 list can keep stale `unreadDropsCount`, so the left nav and quick-DM widget can drift from notification state.

## Fix
- Invalidate the waves V2 list whenever notification state is invalidated after read mutations.

## Changes
- Added `QueryKey.WAVES_V2` invalidation to the shared `invalidateNotifications` helper.
- No user-facing copy or UI layout changes.
- No help docs update needed; this is cache synchronization for existing behavior.

## Validation
- `6529 run lint:changed`
- `6529 run typecheck:changed`
- `6529 run react-doctor:diff`
- `6529 run check:changed` passed before cleanup of unrelated formatter output; final status contains only the intended ReactQueryWrapper change.

## Risk
- Level: Low
- Why: Adds one extra waves-list query invalidation after notification invalidation. It does not change API contracts or rendering behavior directly.
- Rollback: Revert this PR and redeploy frontend.

## Review Notes
- Backend PR with corrected unread-count semantics must be staged and deployed before this frontend PR is staged/deployed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Notifications now refresh more reliably by clearing an additional cached data set when updates occur.
  - Improved consistency of notification-related updates across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->