### PR TITLE
[codex] Split selected wave chat extras

### DIFF
--- a/__tests__/components/brain/my-stream/MyStreamWaveChat.test.tsx
+++ b/__tests__/components/brain/my-stream/MyStreamWaveChat.test.tsx
@@ -39,6 +39,49 @@ const setDocumentVisibilityState = (state: DocumentVisibilityState) => {
   });
 };
 
+jest.mock("next/dynamic", () => ({
+  __esModule: true,
+  default: (loader: () => unknown) => {
+    const loaderSource = loader.toString();
+
+    if (loaderSource.includes("@/components/waves/gallery")) {
+      return require("@/components/waves/gallery").WaveGallery;
+    }
+
+    if (loaderSource.includes("@/components/waves/PrivilegedDropCreator")) {
+      return require("@/components/waves/PrivilegedDropCreator").default;
+    }
+
+    if (loaderSource.includes("./WaveChatSubmitDropModal")) {
+      return require("@/components/brain/my-stream/WaveChatSubmitDropModal")
+        .WaveChatSubmitDropModal;
+    }
+
+    if (
+      loaderSource.includes(
+        "@/components/waves/leaderboard/create/WaveDropCreate"
+      )
+    ) {
+      return require("@/components/waves/leaderboard/create/WaveDropCreate")
+        .WaveDropCreate;
+    }
+
+    if (
+      loaderSource.includes(
+        "@/components/waves/leaderboard/create/WaveLeaderboardCurationDropModal"
+      )
+    ) {
+      return require(
+        "@/components/waves/leaderboard/create/WaveLeaderboardCurationDropModal"
+      ).WaveLeaderboardCurationDropModal;
+    }
+
+    throw new Error(
+      `Unexpected next/dynamic import in MyStreamWaveChat test: ${loaderSource}`
+    );
+  },
+}));
+
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ replace: replaceMock }),
   useSearchParams: () => searchParamsMock,

--- a/components/brain/my-stream/MyStreamWaveChat.tsx
+++ b/components/brain/my-stream/MyStreamWaveChat.tsx
@@ -1,15 +1,10 @@
 "use client";
 
 import { useAuth } from "@/components/auth/Auth";
+import { useNotificationsContext } from "@/components/notifications/NotificationsContext";
 import { CreateDropWaveWrapper } from "@/components/waves/CreateDropWaveWrapper";
 import { WaveDropsAllWithoutProvider } from "@/components/waves/drops/wave-drops-all";
-import { WaveGallery } from "@/components/waves/gallery";
-import { WaveLeaderboardCurationDropModal } from "@/components/waves/leaderboard/create/WaveLeaderboardCurationDropModal";
-import { WaveDropCreate } from "@/components/waves/leaderboard/create/WaveDropCreate";
-import PrivilegedDropCreator, {
-  DropMode,
-} from "@/components/waves/PrivilegedDropCreator";
-import { useNotificationsContext } from "@/components/notifications/NotificationsContext";
+import { DropMode } from "@/components/waves/dropComposer.types";
 import {
   UnreadDividerProvider,
   useUnreadDivider,
@@ -33,6 +28,7 @@ import {
   ACCEPTED_FILE_TYPE_LABELS,
   isSupportedUploadFile,
 } from "@/services/uploads/mediaUploadMimeType";
+import dynamic from "next/dynamic";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import React, {
   useCallback,
@@ -44,7 +40,6 @@ import React, {
 import { useSelector } from "react-redux";
 import { useLayout } from "./layout/LayoutContext";
 import { useWaveChatLeaveCleanup } from "./useWaveChatLeaveCleanup";
-import { WaveChatSubmitDropModal } from "./WaveChatSubmitDropModal";
 import type {
   ChatSubmitDropAction,
   ChatSubmitDropState,
@@ -72,8 +67,92 @@ interface WaveChatLeaveHandlerProps {
   readonly waveId: string;
 }
 
+interface WaveGalleryProps {
+  readonly wave: ApiWave;
+  readonly onDropClick: (drop: ExtendedDrop) => void;
+}
+
+interface PrivilegedDropCreatorProps {
+  readonly activeDrop: ActiveDropState | null;
+  readonly onCancelReplyQuote: () => void;
+  readonly onDropAddedToQueue: () => void;
+  readonly wave: ApiWave;
+  readonly dropId: string | null;
+  readonly fixedDropMode: DropMode;
+  readonly externalAttachmentDrop?:
+    | {
+        readonly token: number;
+        readonly files: File[];
+      }
+    | null
+    | undefined;
+  readonly onExternalAttachmentDropConsumed?: (() => void) | undefined;
+  readonly onSubmitCurationUrl?: ((url: string) => void) | undefined;
+  readonly canSubmitCurationUrl?: boolean | undefined;
+  readonly curationUrlSubmitRestrictionMessage?: string | null | undefined;
+  readonly termsSignatureFlowEnabled?: boolean | undefined;
+}
+
+interface WaveChatSubmitDropModalProps {
+  readonly isOpen: boolean;
+  readonly wave: ApiWave;
+  readonly title: string;
+  readonly onClose: () => void;
+  readonly initialCurationUrl?: string | null | undefined;
+}
+
+interface WaveDropCreateProps {
+  readonly wave: ApiWave;
+  readonly onCancel?: (() => void) | undefined;
+  readonly onSuccess: () => void;
+  readonly isModalContent?: boolean | undefined;
+  readonly onExitFixedDropMode?: (() => void) | undefined;
+}
+
+interface WaveLeaderboardCurationDropModalProps {
+  readonly isOpen: boolean;
+  readonly wave: ApiWave;
+  readonly onClose: () => void;
+  readonly initialUrl?: string | null | undefined;
+}
+
 const MAX_UNSUPPORTED_FILE_NAMES_IN_TOAST = 3;
 const noop = () => {};
+
+const WaveGallery = dynamic<WaveGalleryProps>(
+  () => import("@/components/waves/gallery").then((mod) => mod.WaveGallery),
+  { loading: () => null }
+);
+
+const PrivilegedDropCreator = dynamic<PrivilegedDropCreatorProps>(
+  () => import("@/components/waves/PrivilegedDropCreator"),
+  { loading: () => null }
+);
+
+const WaveChatSubmitDropModal = dynamic<WaveChatSubmitDropModalProps>(
+  () =>
+    import("./WaveChatSubmitDropModal").then(
+      (mod) => mod.WaveChatSubmitDropModal
+    ),
+  { loading: () => null }
+);
+
+const WaveDropCreate = dynamic<WaveDropCreateProps>(
+  () =>
+    import("@/components/waves/leaderboard/create/WaveDropCreate").then(
+      (mod) => mod.WaveDropCreate
+    ),
+  { loading: () => null }
+);
+
+const WaveLeaderboardCurationDropModal =
+  dynamic<WaveLeaderboardCurationDropModalProps>(
+    () =>
+      import(
+        "@/components/waves/leaderboard/create/WaveLeaderboardCurationDropModal"
+      ).then((mod) => mod.WaveLeaderboardCurationDropModal),
+    { loading: () => null }
+  );
 
 const WaveChatLeaveHandler: React.FC<WaveChatLeaveHandlerProps> = ({
   enabled,


### PR DESCRIPTION
## Issue
- Selected-wave chat pulled several heavy, modal-oriented extras into the initial client path even when users only needed to read the chat.

## Fix
- Split gallery, privileged drop creation, submit-drop modal, fixed drop creation, and curation submit modal behind dynamic imports so they load only when their UI path is used.
- Keep `CreateDropWaveWrapper` eager so the existing chat composition boundary, auth behavior, upload validation, and query/cache boundaries remain unchanged.

## Changes
- Added typed dynamic component wrappers in `MyStreamWaveChat` for the deferred extras.
- Updated the focused Jest test with a scoped `next/dynamic` mock so the existing behavior assertions still exercise the component tree synchronously.

## Validation
- `git diff --cached --check`
- `git diff --check`
- `./bin/6529 run test -- __tests__/components/brain/my-stream/MyStreamWaveChat.test.tsx`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` exited 0 with non-blocking warnings for the existing large component and router navigation pattern.
- Desktop browser QA on local selected-wave chat: chat load, drops, composer draft, gallery view, modal close behavior, and eligible curation surfaces checked.
- Real iOS simulator QA against local frontend: selected wave loaded, drops rendered, gallery lazy-loaded, authenticated composer accepted and cleared a draft without posting, and submit-drop modal opened/closed.

Not fully exercised: file upload chooser, quote/reply submission, and quorum/curation submit completion were limited by safe QA boundaries and available wave/account eligibility.

## Risk
- Level: Medium
- Why: The change affects selected-wave chat loading boundaries, but keeps runtime behavior, auth, upload validation, APIs, query keys, and security-sensitive code paths unchanged.
- Rollback: Revert this commit to restore eager imports.

## Review Notes
- Please focus on dynamic import typing, modal/gallery loading behavior, and preserving the existing chat submission/upload boundaries.
