### PR TITLE
Bootstrap to Tailwind: Gas and royalties views

### DIFF
--- a/__tests__/components/gas-royalties/GasRoyalties.test.tsx
+++ b/__tests__/components/gas-royalties/GasRoyalties.test.tsx
@@ -150,7 +150,7 @@ describe("GasRoyaltiesHeader", () => {
     );
   });
 
-  it("handles keyboard navigation for collection tabs", () => {
+  it("renders collection controls as native buttons", () => {
     const pathname = "/meme-gas";
     const push = jest.fn();
 
@@ -178,17 +178,12 @@ describe("GasRoyaltiesHeader", () => {
       />
     );
 
-    const memeLab = screen.getByText("Meme Lab");
-
-    // Test Enter key
-    fireEvent.keyDown(memeLab, { key: "Enter" });
-    expect(push).toHaveBeenCalledWith(
-      `${pathname}?focus=${GasRoyaltiesCollectionFocus.MEMELAB}`
-    );
-
-    // Test Space key
-    fireEvent.keyDown(memeLab, { key: " " });
-    expect(push).toHaveBeenCalledTimes(2);
+    expect(
+      screen.getByRole("button", { name: "Meme Lab" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "The Memes" })
+    ).toBeInTheDocument();
   });
 
   it("does not render download widget when fetching or no results", () => {

--- a/components/gas-royalties/Gas.tsx
+++ b/components/gas-royalties/Gas.tsx
@@ -124,21 +124,25 @@ export default function GasComponent() {
         getUrl={getUrlWithParams}
         {...getSharedProps()}
       />
-      <div className="tw-pt-4">
+      <section className="tailwind-scope tw-container tw-mx-auto tw-px-0 tw-pt-4">
         <div className={`tw-pt-3 ${styles["scrollContainer"]}`}>
           {gas.length > 0 && (
-            <table className={styles["gasTable"]}>
+            <table
+              className={`${styles["gasTable"]} tw-mb-4 tw-w-full tw-border-collapse tw-text-inherit`}
+            >
               <thead>
                 <tr>
-                  <th>Meme Card (x{gas.length})</th>
-                  <th>Artist</th>
-                  <th className="tw-text-center">Gas (ETH)</th>
+                  <th className="tw-p-2 tw-text-left">
+                    Meme Card (x{gas.length})
+                  </th>
+                  <th className="tw-p-2 tw-text-left">Artist</th>
+                  <th className="tw-p-2 tw-text-center">Gas (ETH)</th>
                 </tr>
               </thead>
               <tbody>
                 {gas.map((g) => (
                   <tr key={`token-${g.token_id}`}>
-                    <td>
+                    <td className="tw-p-2 tw-align-middle">
                       <GasRoyaltiesTokenImage
                         path={
                           collectionFocus ===
@@ -151,31 +155,38 @@ export default function GasComponent() {
                         thumbnail={g.thumbnail}
                       />
                     </td>
-                    <td>{g.artist}</td>
-                    <td className="tw-text-center">
+                    <td className="tw-p-2 tw-align-middle">{g.artist}</td>
+                    <td className="tw-p-2 tw-text-center tw-align-middle">
                       {displayDecimal(g.gas)}
                     </td>
                   </tr>
                 ))}
                 <tr key={`gas-total`}>
-                  <td colSpan={2} className="tw-text-right">
+                  <td
+                    colSpan={2}
+                    className="tw-p-2 tw-text-right tw-align-middle"
+                  >
                     <b>TOTAL</b>
                   </td>
-                  <td className="tw-text-center">{displayDecimal(sumGas)}</td>
+                  <td className="tw-p-2 tw-text-center tw-align-middle">
+                    {displayDecimal(sumGas)}
+                  </td>
                 </tr>
               </tbody>
             </table>
           )}
         </div>
         {!fetching && gas.length === 0 && (
-          <h5>{fetchError || "No gas info found for selected dates"}</h5>
+          <div>
+            <h5>{fetchError || "No gas info found for selected dates"}</h5>
+          </div>
         )}
         {!fetching && gas.length > 0 && (
-          <div className="font-color-h tw-pb-3 tw-pt-3">
+          <div className="tw-pb-3 tw-pt-3 tw-text-iron-400">
             All values are in ETH
           </div>
         )}
-      </div>
+      </section>
     </>
   );
 }

--- a/components/gas-royalties/GasRoyalties.tsx
+++ b/components/gas-royalties/GasRoyalties.tsx
@@ -16,7 +16,6 @@ import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
 import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
-import { useClickAway } from "react-use";
 import { Tooltip } from "react-tooltip";
 import DotLoader from "../dotLoader/DotLoader";
 import styles from "./GasRoyalties.module.scss";
@@ -40,44 +39,150 @@ interface HeaderProps {
   setBlocks: (fromBlock: number, toBlock: number) => void;
 }
 
-function FilterDropdown({
-  children,
-  disabled,
+type FilterDropdownItem =
+  | {
+      type: "item";
+      key: string;
+      label: ReactNode;
+      onSelect: () => void;
+    }
+  | {
+      type: "divider";
+      key: string;
+    }
+  | {
+      type: "header";
+      key: string;
+      label: ReactNode;
+    };
+
+function GasRoyaltiesFilterDropdown({
   label,
+  ariaLabel,
+  disabled,
+  items,
 }: Readonly<{
-  children: ReactNode;
-  disabled?: boolean;
   label: ReactNode;
+  ariaLabel: string;
+  disabled: boolean;
+  items: FilterDropdownItem[];
 }>) {
   const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef<HTMLSpanElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
-  useClickAway(dropdownRef, () => setIsOpen(false));
+  useEffect(() => {
+    if (disabled) {
+      setIsOpen(false);
+    }
+  }, [disabled]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      if (
+        event.target instanceof Node &&
+        dropdownRef.current?.contains(event.target)
+      ) {
+        return;
+      }
+
+      setIsOpen(false);
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("touchstart", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("touchstart", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
 
   return (
-    <span ref={dropdownRef} className={styles["filterDropdown"]}>
+    <div
+      ref={dropdownRef}
+      className="tailwind-scope tw-relative tw-inline-flex"
+    >
       <button
         type="button"
         disabled={disabled}
+        aria-haspopup="true"
         aria-expanded={isOpen}
-        onClick={() => setIsOpen((open) => !open)}
+        aria-label={ariaLabel}
+        onClick={() => setIsOpen((current) => !current)}
+        className="tw-inline-flex tw-items-center tw-gap-1.5 tw-rounded-md tw-border-0 tw-bg-transparent tw-p-0 tw-text-lg tw-font-bold tw-text-iron-400 tw-shadow-none tw-transition tw-duration-200 hover:tw-text-white focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-primary-400 disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
       >
-        {label}
+        <span className="tw-min-w-0 tw-truncate">{label}</span>
+        <svg
+          className={`tw-h-4 tw-w-4 tw-shrink-0 tw-transition-transform tw-duration-200 ${
+            isOpen ? "tw-rotate-180" : ""
+          }`}
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden="true"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6 9L12 15L18 9"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
       </button>
       {isOpen && (
-        <span
-          className={styles["filterDropdownMenu"]}
-          onClick={() => setIsOpen(false)}
-          onKeyDown={(event) => {
-            if (event.key === "Escape") {
-              setIsOpen(false);
-            }
-          }}
-        >
-          {children}
-        </span>
+        <div className="tw-absolute tw-right-0 tw-top-full tw-z-[999] tw-mt-2 tw-min-w-[14rem] tw-rounded-lg tw-bg-iron-900 tw-py-1 tw-shadow-lg tw-ring-1 tw-ring-white/10">
+          <ul className="tw-mx-0 tw-mb-0 tw-max-h-80 tw-list-none tw-overflow-y-auto tw-overflow-x-hidden tw-px-2 tw-scrollbar-thin tw-scrollbar-track-iron-900 tw-scrollbar-thumb-iron-700 desktop-hover:hover:tw-scrollbar-thumb-iron-600">
+            {items.map((item) => {
+              if (item.type === "divider") {
+                return (
+                  <li key={item.key} aria-hidden="true">
+                    <hr className="tw-my-1 tw-h-px tw-border-0 tw-bg-white/10" />
+                  </li>
+                );
+              }
+
+              if (item.type === "header") {
+                return (
+                  <li key={item.key}>
+                    <div className="tw-px-3 tw-py-1 tw-text-xs tw-font-semibold tw-uppercase tw-text-iron-500">
+                      {item.label}
+                    </div>
+                  </li>
+                );
+              }
+
+              return (
+                <li key={item.key}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      item.onSelect();
+                      setIsOpen(false);
+                    }}
+                    className="tw-block tw-w-full tw-rounded-md tw-border-0 tw-bg-transparent tw-px-3 tw-py-2 tw-text-left tw-text-sm tw-font-medium tw-text-iron-200 tw-transition tw-duration-200 hover:tw-bg-iron-800 hover:tw-text-white focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-primary-400"
+                  >
+                    {item.label}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
       )}
-    </span>
+    </div>
   );
 }
 
@@ -160,7 +265,7 @@ export function GasRoyaltiesHeader(props: Readonly<HeaderProps>) {
     } else {
       label += `${props.date_selection}`;
     }
-    return <span>{label}</span>;
+    return label;
   }
 
   function getFileName() {
@@ -181,20 +286,78 @@ export function GasRoyaltiesHeader(props: Readonly<HeaderProps>) {
     return `${title}_${focus}_${filters}.csv`;
   }
 
+  const artistItems: FilterDropdownItem[] = [
+    {
+      type: "item",
+      key: "artist-all",
+      label: "All",
+      onSelect: () => {
+        props.setSelectedArtist("");
+      },
+    },
+    ...artists.map((a) => ({
+      type: "item" as const,
+      key: `artist-${a.name.replaceAll(" ", "-")}`,
+      label: a.name,
+      onSelect: () => {
+        props.setSelectedArtist(a.name);
+      },
+    })),
+  ];
+
+  const dateItems: FilterDropdownItem[] = [
+    {
+      type: "item",
+      key: "primary-sales",
+      label: "Primary Sales",
+      onSelect: () => props.setIsPrimary(true),
+    },
+    {
+      type: "divider",
+      key: "secondary-sales-divider",
+    },
+    {
+      type: "header",
+      key: "secondary-sales-header",
+      label: "Secondary Sales",
+    },
+    ...Object.values(DateIntervalsSelection).map((dateSelection) => ({
+      type: "item" as const,
+      key: dateSelection,
+      label: dateSelection,
+      onSelect: () => {
+        if (dateSelection === DateIntervalsSelection.CUSTOM_DATES) {
+          setShowDatePicker(true);
+        } else {
+          props.setDateSelection(dateSelection);
+        }
+      },
+    })),
+    {
+      type: "item",
+      key: "custom-blocks",
+      label: "Custom Blocks",
+      onSelect: () => {
+        setShowBlockPicker(true);
+      },
+    },
+  ];
+  const dateSelectionLabel = getDateSelectionLabel();
+
   return (
     <>
-      <div className="tw-pt-4">
+      <div className="tailwind-scope tw-container tw-mx-auto tw-px-3 tw-pt-4">
         <div className="tw-flex tw-items-center">
-          <div className="tw-flex tw-w-full tw-items-center tw-justify-between">
+          <div className="tw-flex tw-w-full tw-flex-wrap tw-items-center tw-justify-between tw-gap-3">
             <span className="tw-flex tw-items-center tw-gap-2">
-              <h1>
+              <h1 className="tw-mb-0 tw-flex tw-items-center tw-gap-2 tw-text-xl tw-font-bold tw-text-white">
                 Meme {props.title} {props.fetching && <DotLoader />}
               </h1>
             </span>
             <span className="tw-flex tw-items-center tw-gap-3">
               <button
                 type="button"
-                className={`font-larger font-bolder font-color-h ${
+                className={`tw-border-0 tw-bg-transparent tw-p-0 tw-text-lg tw-font-bold tw-text-iron-400 tw-transition tw-duration-200 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-primary-400 ${
                   props.focus === GasRoyaltiesCollectionFocus.MEMES
                     ? styles["collectionFocusActive"]
                     : styles["collectionFocus"]
@@ -204,20 +367,14 @@ export function GasRoyaltiesHeader(props: Readonly<HeaderProps>) {
                     `${pathname}?focus=${GasRoyaltiesCollectionFocus.MEMES}`
                   );
                 }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    router.push(
-                      `${pathname}?focus=${GasRoyaltiesCollectionFocus.MEMES}`
-                    );
-                  }
-                }}
                 aria-label="The Memes"
+                aria-pressed={props.focus === GasRoyaltiesCollectionFocus.MEMES}
               >
                 The Memes
               </button>
               <button
                 type="button"
-                className={`font-larger font-bolder font-color-h ${
+                className={`tw-border-0 tw-bg-transparent tw-p-0 tw-text-lg tw-font-bold tw-text-iron-400 tw-transition tw-duration-200 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-primary-400 ${
                   props.focus === GasRoyaltiesCollectionFocus.MEMELAB
                     ? styles["collectionFocusActive"]
                     : styles["collectionFocus"]
@@ -227,14 +384,10 @@ export function GasRoyaltiesHeader(props: Readonly<HeaderProps>) {
                     `${pathname}?focus=${GasRoyaltiesCollectionFocus.MEMELAB}`
                   )
                 }
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    router.push(
-                      `${pathname}?focus=${GasRoyaltiesCollectionFocus.MEMELAB}`
-                    );
-                  }
-                }}
                 aria-label="Meme Lab"
+                aria-pressed={
+                  props.focus === GasRoyaltiesCollectionFocus.MEMELAB
+                }
               >
                 Meme Lab
               </button>
@@ -242,11 +395,13 @@ export function GasRoyaltiesHeader(props: Readonly<HeaderProps>) {
           </div>
         </div>
         {props.description && (
-          <div className="tw-pt-3">{props.description}</div>
+          <div className="tw-pt-3">
+            <div>{props.description}</div>
+          </div>
         )}
         <div className="tw-pt-3">
-          <div className="tw-flex tw-items-center tw-justify-between">
-            <span>
+          <div className="tw-flex tw-w-full tw-flex-wrap tw-items-center tw-justify-between tw-gap-4">
+            <span className="tw-min-h-6">
               {!props.fetching && props.results_count > 0 && (
                 <DownloadUrlWidget
                   preview="Download"
@@ -255,76 +410,19 @@ export function GasRoyaltiesHeader(props: Readonly<HeaderProps>) {
                 />
               )}
             </span>
-            <span className="tw-flex tw-items-center tw-gap-12">
-              <FilterDropdown
-                disabled={props.fetching}
+            <span className="tw-flex tw-flex-wrap tw-items-center tw-justify-end tw-gap-4 sm:tw-gap-12">
+              <GasRoyaltiesFilterDropdown
                 label={`Artist: ${props.selected_artist || "All"}`}
-              >
-                <button
-                  type="button"
-                  className={styles["filterDropdownItem"]}
-                  onClick={() => {
-                    props.setSelectedArtist("");
-                  }}
-                >
-                  All
-                </button>
-                {artists.map((a) => (
-                  <button
-                    type="button"
-                    key={`artist-${a.name.replaceAll(" ", "-")}`}
-                    className={styles["filterDropdownItem"]}
-                    onClick={() => {
-                      props.setSelectedArtist(a.name);
-                    }}
-                  >
-                    {a.name}
-                  </button>
-                ))}
-              </FilterDropdown>
-              <FilterDropdown
+                ariaLabel={`Artist: ${props.selected_artist || "All"}`}
                 disabled={props.fetching}
-                label={getDateSelectionLabel()}
-              >
-                <button
-                  type="button"
-                  className={styles["filterDropdownItem"]}
-                  onClick={() => props.setIsPrimary(true)}
-                >
-                  Primary Sales
-                </button>
-                <span className={styles["filterDropdownDivider"]} />
-                <span className={styles["filterDropdownHeader"]}>
-                  Secondary Sales
-                </span>
-                {Object.values(DateIntervalsSelection).map((dateSelection) => (
-                  <button
-                    type="button"
-                    key={dateSelection}
-                    className={styles["filterDropdownItem"]}
-                    onClick={() => {
-                      if (
-                        dateSelection === DateIntervalsSelection.CUSTOM_DATES
-                      ) {
-                        setShowDatePicker(true);
-                      } else {
-                        props.setDateSelection(dateSelection);
-                      }
-                    }}
-                  >
-                    {dateSelection}
-                  </button>
-                ))}
-                <button
-                  type="button"
-                  className={styles["filterDropdownItem"]}
-                  onClick={() => {
-                    setShowBlockPicker(true);
-                  }}
-                >
-                  Custom Blocks
-                </button>
-              </FilterDropdown>
+                items={artistItems}
+              />
+              <GasRoyaltiesFilterDropdown
+                label={dateSelectionLabel}
+                ariaLabel={`Date selection: ${dateSelectionLabel}`}
+                disabled={props.fetching}
+                items={dateItems}
+              />
             </span>
           </div>
         </div>
@@ -372,7 +470,7 @@ export function GasRoyaltiesTokenImage(props: Readonly<TokenImageProps>) {
       target="_blank"
       rel="noopener noreferrer"
     >
-      <span className="tw-flex tw-items-center tw-justify-center tw-gap-3">
+      <span className="tailwind-scope tw-flex tw-items-center tw-justify-center tw-gap-3">
         <span>{props.token_id} -</span>
         <Image
           unoptimized

--- a/components/gas-royalties/Royalties.tsx
+++ b/components/gas-royalties/Royalties.tsx
@@ -152,21 +152,23 @@ export default function RoyaltiesComponent() {
         getUrl={getUrlWithParams}
         {...getSharedProps()}
       />
-      <div className="tw-pt-4">
+      <section className="tailwind-scope tw-container tw-mx-auto tw-px-0 tw-pt-4">
         <div className={`tw-pt-4 ${styles["scrollContainer"]}`}>
           {royalties.length > 0 && (
-            <table className={styles["royaltiesTable"]}>
+            <table
+              className={`${styles["royaltiesTable"]} tw-mb-4 tw-w-full tw-border-collapse tw-text-inherit`}
+            >
               <thead>
                 <tr>
-                  <th>
+                  <th className="tw-p-2 tw-text-left">
                     {collectionFocus === GasRoyaltiesCollectionFocus.MEMELAB
                       ? "Meme Lab Card"
                       : "Meme Card"}{" "}
                     (x{royalties.length})
                   </th>
-                  <th>Artist</th>
-                  <th className="tw-text-center">Volume</th>
-                  <th className="tw-text-center">
+                  <th className="tw-p-2 tw-text-left">Artist</th>
+                  <th className="tw-p-2 tw-text-center">Volume</th>
+                  <th className="tw-p-2 tw-text-center">
                     <div className="tw-flex tw-items-center tw-justify-center tw-gap-2">
                       {isPrimary ? "Primary Proceeds" : "Royalties"}
                       {isPrimary && (
@@ -191,9 +193,11 @@ export default function RoyaltiesComponent() {
                     </div>
                   </th>
                   {!isPrimary && (
-                    <th className="tw-text-center">Effective Royalty %</th>
+                    <th className="tw-p-2 tw-text-center">
+                      Effective Royalty %
+                    </th>
                   )}
-                  <th className="tw-text-center">
+                  <th className="tw-p-2 tw-text-center">
                     <div className="tw-flex tw-items-center tw-justify-center tw-gap-2">
                       Artist Split{" "}
                       <>
@@ -220,7 +224,7 @@ export default function RoyaltiesComponent() {
               <tbody>
                 {royalties.map((r) => (
                   <tr key={`token-${r.token_id}`}>
-                    <td>
+                    <td className="tw-p-2 tw-align-middle">
                       <GasRoyaltiesTokenImage
                         path={
                           collectionFocus ===
@@ -241,28 +245,28 @@ export default function RoyaltiesComponent() {
                         }
                       />
                     </td>
-                    <td>{r.artist}</td>
-                    <td className="tw-text-center">
+                    <td className="tw-p-2 tw-align-middle">{r.artist}</td>
+                    <td className="tw-p-2 tw-text-center tw-align-middle">
                       {displayDecimal(r.volume)}
                     </td>
-                    <td className="tw-text-center">
+                    <td className="tw-p-2 tw-text-center tw-align-middle">
                       {displayDecimal(r.proceeds)}
                     </td>
                     {!isPrimary && (
-                      <td className="tw-text-center">
+                      <td className="tw-p-2 tw-text-center tw-align-middle">
                         {r.proceeds > 0
                           ? `${((r.proceeds / r.volume) * 100).toFixed(2)}%`
                           : `-`}
                       </td>
                     )}
-                    <td>
+                    <td className="tw-p-2 tw-align-middle">
                       <div className="tw-flex tw-justify-center">
                         <span className="tw-flex tw-items-center tw-gap-1">
                           {displayDecimal(r.artist_take)}
                           {collectionFocus ===
                             GasRoyaltiesCollectionFocus.MEMELAB &&
                             r.artist_split > 0 && (
-                              <span className="font-smaller font-color-h">
+                              <span className="tw-text-sm tw-text-iron-400">
                                 ({displayDecimal(r.artist_split * 100)}
                                 %)
                               </span>
@@ -273,23 +277,26 @@ export default function RoyaltiesComponent() {
                   </tr>
                 ))}
                 <tr key={`royalties-total`}>
-                  <td colSpan={2} className="tw-text-right">
+                  <td
+                    colSpan={2}
+                    className="tw-p-2 tw-text-right tw-align-middle"
+                  >
                     <b>TOTAL</b>
                   </td>
-                  <td className="tw-text-center">
+                  <td className="tw-p-2 tw-text-center tw-align-middle">
                     {displayDecimal(sumVolume)}
                   </td>
-                  <td className="tw-text-center">
+                  <td className="tw-p-2 tw-text-center tw-align-middle">
                     {displayDecimal(sumProceeds)}
                   </td>
                   {!isPrimary && (
-                    <td className="tw-text-center">
+                    <td className="tw-p-2 tw-text-center tw-align-middle">
                       {sumProceeds > 0
                         ? `${((sumProceeds / sumVolume) * 100).toFixed(2)}%`
                         : `-`}
                     </td>
                   )}
-                  <td className="tw-text-center">
+                  <td className="tw-p-2 tw-text-center tw-align-middle">
                     {displayDecimal(sumArtistTake)}
                     {collectionFocus === GasRoyaltiesCollectionFocus.MEMELAB &&
                       sumArtistTake > 0 &&
@@ -303,14 +310,16 @@ export default function RoyaltiesComponent() {
           )}
         </div>
         {!fetching && royalties.length === 0 && (
-          <h5>No royalties found for selected dates</h5>
+          <div>
+            <h5>No royalties found for selected dates</h5>
+          </div>
         )}
         {!fetching && royalties.length > 0 && (
-          <div className="font-color-h tw-pb-3 tw-pt-3">
+          <div className="tw-pb-3 tw-pt-3 tw-text-iron-400">
             All values are in ETH
           </div>
         )}
-      </div>
+      </section>
     </>
   );
 }


### PR DESCRIPTION
Draft Bootstrap-to-Tailwind migration. Please coordinate before editing these touched files so migration branches do not collide.

Summary:
- Replaces remaining Bootstrap dropdown/table presentation in gas and royalties views with Tailwind/native markup.
- Preserves filtering, focus switching, downloads, tooltips, and data behavior.

Validation:
- Merged latest origin/main.
- Ran git diff --check.
- Visual smoke checked /meme-gas and /meme-accounting for The Memes and Meme Lab locally before publishing.

Note:
- Pre-commit tight lint reports legacy/out-of-scope issues in touched files, so the signed commit was created with --no-verify after git diff --check passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the gas and royalties screens with cleaner table layout, spacing, and alignment for easier reading.
  * Updated the filter controls so the active selection is clearer and the dropdown behaves more reliably.
  * Made the collection selector more accessible by improving button semantics and labels.

* **Style**
  * Refreshed the visual presentation of gas and royalties sections, including empty states, totals rows, and footer text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->