### PR TITLE
Fix Manifold preview image originals

### DIFF
--- a/__tests__/components/waves/marketplace/common.test.ts
+++ b/__tests__/components/waves/marketplace/common.test.ts
@@ -532,6 +532,27 @@ describe("primeMarketplacePreviewCacheFromNftLinks", () => {
     });
   });
 
+  it("normalizes Manifold original media_uri image extensions to lowercase", () => {
+    const queryClient = createTestQueryClient();
+    const href = "https://manifold.xyz/@artist/id/125";
+    const mediaUri =
+      "https://assets.manifold.xyz/original/f7858d47e672a94c82e37cfe602f5bd8ed3a722167f8321f85ebab276b88b184.PNG";
+
+    primeMarketplacePreviewCacheFromNftLinks({
+      queryClient,
+      nftLinks: [createNftLinkWithMediaUri({ href, mediaUri })],
+    });
+
+    const seeded = queryClient.getQueryData<MarketplacePreviewData>(
+      getMarketplacePreviewQueryKey(href, "default")
+    );
+
+    expect(seeded?.media).toEqual({
+      url: "https://assets.manifold.xyz/optimized/f7858d47e672a94c82e37cfe602f5bd8ed3a722167f8321f85ebab276b88b184/w_800.png",
+      mimeType: "image/png",
+    });
+  });
+
   it("keeps Manifold original media_uri videos unchanged", () => {
     const queryClient = createTestQueryClient();
     const href = "https://manifold.xyz/@artist/id/124";

--- a/__tests__/components/waves/marketplace/common.test.ts
+++ b/__tests__/components/waves/marketplace/common.test.ts
@@ -1,6 +1,7 @@
 import { createTestQueryClient } from "../../../utils/reactQuery";
 import {
   deriveMarketplaceDataHealth,
+  mergeOpenGraphFallback,
   patchFromMediaLinkUpdate,
   primeMarketplacePreviewCacheFromNftLinks,
   type MarketplacePreviewData,
@@ -506,6 +507,81 @@ describe("primeMarketplacePreviewCacheFromNftLinks", () => {
 
     expect(seeded?.media).toEqual({
       url: mediaUri,
+      mimeType: "image/png",
+    });
+  });
+
+  it("normalizes Manifold original media_uri images to optimized previews", () => {
+    const queryClient = createTestQueryClient();
+    const href = "https://manifold.xyz/@artist/id/123";
+    const mediaUri =
+      "https://assets.manifold.xyz/original/f7858d47e672a94c82e37cfe602f5bd8ed3a722167f8321f85ebab276b88b184.jpg";
+
+    primeMarketplacePreviewCacheFromNftLinks({
+      queryClient,
+      nftLinks: [createNftLinkWithMediaUri({ href, mediaUri })],
+    });
+
+    const seeded = queryClient.getQueryData<MarketplacePreviewData>(
+      getMarketplacePreviewQueryKey(href, "default")
+    );
+
+    expect(seeded?.media).toEqual({
+      url: "https://assets.manifold.xyz/optimized/f7858d47e672a94c82e37cfe602f5bd8ed3a722167f8321f85ebab276b88b184/w_800.jpg",
+      mimeType: "image/jpeg",
+    });
+  });
+
+  it("keeps Manifold original media_uri videos unchanged", () => {
+    const queryClient = createTestQueryClient();
+    const href = "https://manifold.xyz/@artist/id/124";
+    const mediaUri =
+      "https://assets.manifold.xyz/original/f7858d47e672a94c82e37cfe602f5bd8ed3a722167f8321f85ebab276b88b184.mp4";
+
+    primeMarketplacePreviewCacheFromNftLinks({
+      queryClient,
+      nftLinks: [createNftLinkWithMediaUri({ href, mediaUri })],
+    });
+
+    const seeded = queryClient.getQueryData<MarketplacePreviewData>(
+      getMarketplacePreviewQueryKey(href, "default")
+    );
+
+    expect(seeded?.media).toEqual({
+      url: mediaUri,
+      mimeType: "video/mp4",
+    });
+  });
+
+  it("normalizes Manifold original Open Graph images to optimized previews", () => {
+    const current: MarketplacePreviewData = {
+      href: "https://manifold.xyz/@artist/id/123",
+      canonicalId: "manifold:claim:123",
+      platform: "MANIFOLD",
+      title: null,
+      description: null,
+      media: null,
+      price: null,
+      priceCurrency: null,
+      lastErrorMessage: null,
+      lastSuccessfullyUpdatedMs: null,
+      failedSinceMs: null,
+    };
+
+    const merged = mergeOpenGraphFallback({
+      href: current.href,
+      mode: "default",
+      current,
+      linkPreview: {
+        image: {
+          url: "https://assets.manifold.xyz/original/f7858d47e672a94c82e37cfe602f5bd8ed3a722167f8321f85ebab276b88b184.png",
+          type: "image/png",
+        },
+      },
+    });
+
+    expect(merged.media).toEqual({
+      url: "https://assets.manifold.xyz/optimized/f7858d47e672a94c82e37cfe602f5bd8ed3a722167f8321f85ebab276b88b184/w_800.png",
       mimeType: "image/png",
     });
   });

--- a/__tests__/services/api/link-preview-api.test.ts
+++ b/__tests__/services/api/link-preview-api.test.ts
@@ -200,6 +200,39 @@ describe("fetchLinkPreview", () => {
     );
   });
 
+  it("preserves null image arrays while normalizing batch response images", async () => {
+    const preview: LinkPreviewResponse = {
+      requestUrl: "https://manifold.xyz/@artist/id/123",
+      title: "Manifold listing",
+      image: {
+        url: "https://assets.manifold.xyz/original/f7858d47e672a94c82e37cfe602f5bd8ed3a722167f8321f85ebab276b88b184.JPEG",
+      },
+      images: null,
+    };
+    fetchMock.mockResolvedValueOnce(
+      createResponse({
+        results: {
+          "https://manifold.xyz/@artist/id/123": preview,
+        },
+        errors: {},
+      })
+    );
+
+    const { fetchLinkPreview } = await loadApi();
+    const request = fetchLinkPreview("https://manifold.xyz/@artist/id/123");
+
+    jest.runOnlyPendingTimers();
+
+    await expect(request).resolves.toEqual(
+      expect.objectContaining({
+        image: {
+          url: "https://assets.manifold.xyz/optimized/f7858d47e672a94c82e37cfe602f5bd8ed3a722167f8321f85ebab276b88b184/w_800.jpg",
+        },
+        images: null,
+      })
+    );
+  });
+
   it("splits same-tick calls into POST chunks of 5 urls", async () => {
     const urls = [
       "https://one.example/article",

--- a/__tests__/services/api/link-preview-api.test.ts
+++ b/__tests__/services/api/link-preview-api.test.ts
@@ -151,6 +151,55 @@ describe("fetchLinkPreview", () => {
     expect(getFetchSignal(0).aborted).toBe(false);
   });
 
+  it("normalizes Manifold original images in batch responses", async () => {
+    const preview: LinkPreviewResponse = {
+      requestUrl: "https://manifold.xyz/@serhiikovbasyuk",
+      title: "Serhii Kovbasyuk | Manifold",
+      image: {
+        url: "https://assets.manifold.xyz/original/8e55d2cffbeebf1ef17e8013ae10658068efc83344b3b2b28aab060df502efe3.jpg",
+        secureUrl:
+          "https://assets.manifold.xyz/original/8e55d2cffbeebf1ef17e8013ae10658068efc83344b3b2b28aab060df502efe3.jpg",
+      },
+      images: [
+        {
+          url: "https://assets.manifold.xyz/original/8e55d2cffbeebf1ef17e8013ae10658068efc83344b3b2b28aab060df502efe3.jpg",
+          secureUrl:
+            "https://assets.manifold.xyz/original/8e55d2cffbeebf1ef17e8013ae10658068efc83344b3b2b28aab060df502efe3.jpg",
+        },
+      ],
+    };
+    fetchMock.mockResolvedValueOnce(
+      createResponse({
+        results: {
+          "https://manifold.xyz/@serhiikovbasyuk": preview,
+        },
+        errors: {},
+      })
+    );
+
+    const { fetchLinkPreview } = await loadApi();
+    const request = fetchLinkPreview("https://manifold.xyz/@serhiikovbasyuk");
+
+    jest.runOnlyPendingTimers();
+
+    await expect(request).resolves.toEqual(
+      expect.objectContaining({
+        image: {
+          url: "https://assets.manifold.xyz/optimized/8e55d2cffbeebf1ef17e8013ae10658068efc83344b3b2b28aab060df502efe3/w_800.jpg",
+          secureUrl:
+            "https://assets.manifold.xyz/optimized/8e55d2cffbeebf1ef17e8013ae10658068efc83344b3b2b28aab060df502efe3/w_800.jpg",
+        },
+        images: [
+          {
+            url: "https://assets.manifold.xyz/optimized/8e55d2cffbeebf1ef17e8013ae10658068efc83344b3b2b28aab060df502efe3/w_800.jpg",
+            secureUrl:
+              "https://assets.manifold.xyz/optimized/8e55d2cffbeebf1ef17e8013ae10658068efc83344b3b2b28aab060df502efe3/w_800.jpg",
+          },
+        ],
+      })
+    );
+  });
+
   it("splits same-tick calls into POST chunks of 5 urls", async () => {
     const urls = [
       "https://one.example/article",
@@ -450,6 +499,32 @@ describe("fetchLinkPreview", () => {
     );
     expect(getFetchSignal(1).aborted).toBe(false);
     expect(getFetchSignal(2).aborted).toBe(false);
+  });
+
+  it("normalizes Manifold original images in single GET fallback responses", async () => {
+    const preview: LinkPreviewResponse = {
+      requestUrl: "https://manifold.xyz/@artist/id/123",
+      title: "Manifold listing",
+      image: {
+        url: "https://assets.manifold.xyz/original/f7858d47e672a94c82e37cfe602f5bd8ed3a722167f8321f85ebab276b88b184.png",
+      },
+    };
+    fetchMock
+      .mockRejectedValueOnce(new Error("batch unavailable"))
+      .mockResolvedValueOnce(createResponse(preview));
+
+    const { fetchLinkPreview } = await loadApi();
+    const request = fetchLinkPreview("https://manifold.xyz/@artist/id/123");
+
+    jest.runOnlyPendingTimers();
+
+    await expect(request).resolves.toEqual(
+      expect.objectContaining({
+        image: {
+          url: "https://assets.manifold.xyz/optimized/f7858d47e672a94c82e37cfe602f5bd8ed3a722167f8321f85ebab276b88b184/w_800.png",
+        },
+      })
+    );
   });
 
   it("aborts timed-out single GET fallback requests", async () => {

--- a/components/waves/marketplace/common.ts
+++ b/components/waves/marketplace/common.ts
@@ -2,6 +2,7 @@ import type { ApiDropNftLink } from "@/generated/models/ApiDropNftLink";
 import { ApiNftLinkMediaPreviewStatusEnum } from "@/generated/models/ApiNftLinkMediaPreview";
 import { getTimeAgo } from "@/helpers/Helpers";
 import type { WsMediaLinkUpdatedData } from "@/helpers/Types";
+import { getManifoldPreviewImageUrl } from "@/lib/link-preview/manifoldMedia";
 import { asNonEmptyString } from "@/lib/text/nonEmptyString";
 import { matchesDomainOrSubdomain } from "@/lib/url/domains";
 import type { LinkPreviewResponse } from "@/services/api/link-preview-api";
@@ -202,7 +203,7 @@ const toPickedMedia = (candidate: MediaCandidate): PickedMedia | undefined => {
     return undefined;
   }
 
-  const url = urlCandidate.trim();
+  const url = getManifoldPreviewImageUrl(urlCandidate.trim());
   const mimeType =
     asNonEmptyString(candidate.type) ?? inferMimeTypeFromUrl(url) ?? "image/*";
 
@@ -218,9 +219,11 @@ const pickMediaFromUrl = (value: unknown): PickedMedia | undefined => {
     return undefined;
   }
 
+  const previewUrl = getManifoldPreviewImageUrl(url);
+
   return {
-    url,
-    mimeType: inferMimeTypeFromUrl(url) ?? "image/*",
+    url: previewUrl,
+    mimeType: inferMimeTypeFromUrl(previewUrl) ?? "image/*",
   };
 };
 
@@ -253,12 +256,14 @@ const pickWsMediaPreview = (
     return undefined;
   }
 
+  const previewUrl = getManifoldPreviewImageUrl(url);
+
   return {
-    url,
+    url: previewUrl,
     mimeType:
       asNonEmptyString(preview?.mime_type) ??
       asNonEmptyString(update.media_preview_mime_type) ??
-      inferMimeTypeFromUrl(url) ??
+      inferMimeTypeFromUrl(previewUrl) ??
       "image/*",
   };
 };
@@ -313,11 +318,13 @@ const pickNftLinkMediaPreview = (
     return undefined;
   }
 
+  const previewUrl = getManifoldPreviewImageUrl(url);
+
   return {
-    url,
+    url: previewUrl,
     mimeType:
       asNonEmptyString(preview.mime_type) ??
-      inferMimeTypeFromUrl(url) ??
+      inferMimeTypeFromUrl(previewUrl) ??
       "image/*",
   };
 };

--- a/components/waves/marketplace/common.ts
+++ b/components/waves/marketplace/common.ts
@@ -193,6 +193,18 @@ const inferMimeTypeFromUrl = (url: string): string | undefined => {
   }
 };
 
+const buildPickedMediaFromUrl = (
+  url: string,
+  explicitMimeType?: string
+): PickedMedia => {
+  const previewUrl = getManifoldPreviewImageUrl(url);
+
+  return {
+    url: previewUrl,
+    mimeType: explicitMimeType ?? inferMimeTypeFromUrl(previewUrl) ?? "image/*",
+  };
+};
+
 const toPickedMedia = (candidate: MediaCandidate): PickedMedia | undefined => {
   if (!candidate) {
     return undefined;
@@ -203,14 +215,10 @@ const toPickedMedia = (candidate: MediaCandidate): PickedMedia | undefined => {
     return undefined;
   }
 
-  const url = getManifoldPreviewImageUrl(urlCandidate.trim());
-  const mimeType =
-    asNonEmptyString(candidate.type) ?? inferMimeTypeFromUrl(url) ?? "image/*";
-
-  return {
-    url,
-    mimeType,
-  };
+  return buildPickedMediaFromUrl(
+    urlCandidate.trim(),
+    asNonEmptyString(candidate.type)
+  );
 };
 
 const pickMediaFromUrl = (value: unknown): PickedMedia | undefined => {
@@ -219,12 +227,7 @@ const pickMediaFromUrl = (value: unknown): PickedMedia | undefined => {
     return undefined;
   }
 
-  const previewUrl = getManifoldPreviewImageUrl(url);
-
-  return {
-    url: previewUrl,
-    mimeType: inferMimeTypeFromUrl(previewUrl) ?? "image/*",
-  };
+  return buildPickedMediaFromUrl(url);
 };
 
 const asWsMediaPreviewCandidate = (
@@ -256,16 +259,11 @@ const pickWsMediaPreview = (
     return undefined;
   }
 
-  const previewUrl = getManifoldPreviewImageUrl(url);
-
-  return {
-    url: previewUrl,
-    mimeType:
-      asNonEmptyString(preview?.mime_type) ??
-      asNonEmptyString(update.media_preview_mime_type) ??
-      inferMimeTypeFromUrl(previewUrl) ??
-      "image/*",
-  };
+  return buildPickedMediaFromUrl(
+    url,
+    asNonEmptyString(preview?.mime_type) ??
+      asNonEmptyString(update.media_preview_mime_type)
+  );
 };
 
 const pickWsMediaLinkUpdatedMedia = ({
@@ -318,15 +316,7 @@ const pickNftLinkMediaPreview = (
     return undefined;
   }
 
-  const previewUrl = getManifoldPreviewImageUrl(url);
-
-  return {
-    url: previewUrl,
-    mimeType:
-      asNonEmptyString(preview.mime_type) ??
-      inferMimeTypeFromUrl(previewUrl) ??
-      "image/*",
-  };
+  return buildPickedMediaFromUrl(url, asNonEmptyString(preview.mime_type));
 };
 
 const pickNftLinkMedia = (

--- a/lib/link-preview/manifoldMedia.ts
+++ b/lib/link-preview/manifoldMedia.ts
@@ -17,8 +17,8 @@ export const getManifoldPreviewImageUrl = (url: string): string => {
       return url;
     }
 
-    const extension =
-      extensionCandidate.toLowerCase() === "jpeg" ? "jpg" : extensionCandidate;
+    const lowerExtension = extensionCandidate.toLowerCase();
+    const extension = lowerExtension === "jpeg" ? "jpg" : lowerExtension;
     parsed.pathname = `/optimized/${assetId}/w_${MANIFOLD_PREVIEW_IMAGE_WIDTH}.${extension}`;
     return parsed.toString();
   } catch {

--- a/lib/link-preview/manifoldMedia.ts
+++ b/lib/link-preview/manifoldMedia.ts
@@ -1,0 +1,27 @@
+const MANIFOLD_ASSETS_HOST = "assets.manifold.xyz";
+const MANIFOLD_PREVIEW_IMAGE_WIDTH = 800;
+
+export const getManifoldPreviewImageUrl = (url: string): string => {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname.toLowerCase() !== MANIFOLD_ASSETS_HOST) {
+      return url;
+    }
+
+    const match = /^\/original\/([^/]+)\.(jpe?g|png|webp)$/i.exec(
+      parsed.pathname
+    );
+    const assetId = match?.[1];
+    const extensionCandidate = match?.[2];
+    if (!assetId || !extensionCandidate) {
+      return url;
+    }
+
+    const extension =
+      extensionCandidate.toLowerCase() === "jpeg" ? "jpg" : extensionCandidate;
+    parsed.pathname = `/optimized/${assetId}/w_${MANIFOLD_PREVIEW_IMAGE_WIDTH}.${extension}`;
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+};

--- a/services/api/link-preview-api.ts
+++ b/services/api/link-preview-api.ts
@@ -1,6 +1,7 @@
 import LruTtlCache from "@/lib/cache/lruTtl";
 import type { EnsPreview } from "@/components/waves/ens/types";
 import type { ExternalFileKind } from "@/lib/link-preview/fileKinds";
+import { getManifoldPreviewImageUrl } from "@/lib/link-preview/manifoldMedia";
 import { matchesDomainOrSubdomain } from "@/lib/url/domains";
 
 export interface LinkPreviewMedia {
@@ -234,6 +235,88 @@ const hasOwnRecordKey = <T>(
 ): record is Record<string, T | undefined> =>
   record !== undefined && Object.hasOwn(record, key);
 
+const normalizeLinkPreviewMedia = (
+  media: LinkPreviewMedia | null | undefined
+): LinkPreviewMedia | null | undefined => {
+  if (media === null || media === undefined) {
+    return media;
+  }
+
+  const normalizedUrl =
+    typeof media.url === "string"
+      ? getManifoldPreviewImageUrl(media.url)
+      : media.url;
+  const normalizedSecureUrl =
+    typeof media.secureUrl === "string"
+      ? getManifoldPreviewImageUrl(media.secureUrl)
+      : media.secureUrl;
+
+  if (normalizedUrl === media.url && normalizedSecureUrl === media.secureUrl) {
+    return media;
+  }
+
+  return {
+    ...media,
+    url: normalizedUrl,
+    secureUrl: normalizedSecureUrl,
+  };
+};
+
+const normalizeLinkPreviewResponse = (
+  preview: LinkPreviewResponse
+): LinkPreviewResponse => {
+  const normalizedImage = normalizeLinkPreviewMedia(preview.image);
+  const normalizedImages =
+    preview.images === null || preview.images === undefined
+      ? preview.images
+      : preview.images.map(
+          (image) => normalizeLinkPreviewMedia(image) ?? image
+        );
+  const imageChanged = normalizedImage !== preview.image;
+  const imagesChanged =
+    normalizedImages !== undefined &&
+    normalizedImages.some((image, index) => image !== preview.images?.[index]);
+
+  if (!imageChanged && !imagesChanged) {
+    return preview;
+  }
+
+  return {
+    ...preview,
+    image: normalizedImage,
+    images: normalizedImages,
+  };
+};
+
+const normalizeOpenGraphBatchResponse = (
+  response: OpenGraphBatchResponse
+): OpenGraphBatchResponse => {
+  if (response.results === undefined) {
+    return response;
+  }
+
+  let didChange = false;
+  const normalizedResults: Record<string, LinkPreviewResponse | undefined> = {};
+
+  for (const [url, preview] of Object.entries(response.results)) {
+    const normalizedPreview =
+      preview === undefined ? undefined : normalizeLinkPreviewResponse(preview);
+    normalizedResults[url] = normalizedPreview;
+    if (normalizedPreview !== preview) {
+      didChange = true;
+    }
+  }
+
+  if (!didChange) {
+    return response;
+  }
+
+  return {
+    ...response,
+    results: normalizedResults,
+  };
+};
+
 type PendingLinkPreviewRequest = {
   readonly url: string;
   readonly cacheKey: string;
@@ -335,25 +418,32 @@ const fetchSingleLinkPreview = async (
 ): Promise<LinkPreviewResponse> => {
   const params = new URLSearchParams({ url: normalizedUrl });
 
-  return fetchLinkPreviewMetadata<LinkPreviewResponse>(
+  const preview = await fetchLinkPreviewMetadata<LinkPreviewResponse>(
     `/api/open-graph?${params.toString()}`,
     {
       headers: { Accept: "application/json" },
     }
   );
+
+  return normalizeLinkPreviewResponse(preview);
 };
 
 const fetchLinkPreviewBatch = async (
   urls: readonly string[]
 ): Promise<OpenGraphBatchResponse> => {
-  return fetchLinkPreviewMetadata<OpenGraphBatchResponse>("/api/open-graph", {
-    method: "POST",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ urls }),
-  });
+  const response = await fetchLinkPreviewMetadata<OpenGraphBatchResponse>(
+    "/api/open-graph",
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ urls }),
+    }
+  );
+
+  return normalizeOpenGraphBatchResponse(response);
 };
 
 const chunkRequests = (

--- a/services/api/link-preview-api.ts
+++ b/services/api/link-preview-api.ts
@@ -274,7 +274,7 @@ const normalizeLinkPreviewResponse = (
         );
   const imageChanged = normalizedImage !== preview.image;
   const imagesChanged =
-    normalizedImages !== undefined &&
+    Array.isArray(normalizedImages) &&
     normalizedImages.some((image, index) => image !== preview.images?.[index]);
 
   if (!imageChanged && !imagesChanged) {


### PR DESCRIPTION
## Issue
- `/waves` could load full-size Manifold `assets.manifold.xyz/original/...` images in feed link previews.
- Browser QA reproduced a generic Manifold Open Graph card loading a 20.2 MB original image.

## Fix
- Normalize Manifold original image URLs to `assets.manifold.xyz/optimized/.../w_800...` before preview cards render them.
- Apply the normalization in the shared Open Graph client and marketplace preview media selection so both generic link cards and marketplace cards use the smaller preview image.
- Leave non-image media, including video URLs, unchanged.

## Changes
- Added `lib/link-preview/manifoldMedia.ts` for shared Manifold preview URL normalization.
- Updated `services/api/link-preview-api.ts` to normalize batch and single Open Graph responses.
- Updated `components/waves/marketplace/common.ts` to reuse the shared normalizer for NFT-link, websocket, and Open Graph marketplace media.
- Added focused tests for generic link previews, marketplace previews, and video non-rewrite behavior.

## Validation
- `SEIZE_SECURE_INSTALL=1 ./bin/6529 run test -- __tests__/services/api/link-preview-api.test.ts __tests__/components/waves/marketplace/common.test.ts`
- `SEIZE_SECURE_INSTALL=1 ./bin/6529 run lint:changed`
- `SEIZE_SECURE_INSTALL=1 ./bin/6529 run typecheck:changed`
- `SEIZE_SECURE_INSTALL=1 ./bin/6529 run lint:diff`
- `git diff --check`
- Browser QA on local `/waves`: reproduced the 20.2 MB Manifold original request, then verified the page requested `assets.manifold.xyz/optimized/.../w_800.jpg` with no Manifold `/original/` image requests. Final cache-disabled run loaded the image successfully at 800x1199 with a 125,165-byte response.
- `SEIZE_SECURE_INSTALL=1 ./bin/6529 run check:changed` was attempted; it failed in the repo's existing Knip dead-code scan on unrelated `ops/scripts`, `standalone`, and `scripts/dependency-risk-gate.cjs` items after changed-file typecheck passed.

## Risk
- Level: Low
- Why: URL rewrite is limited to Manifold CDN image originals with image extensions. Non-Manifold URLs and non-image Manifold media keep their original URLs.
- Rollback: Revert the helper and call sites to return provider URLs unchanged.

## Review Notes
- Please focus on the shared Open Graph normalization path and the Manifold video non-rewrite guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Manifold image links in link previews are now rewritten to use optimized preview URLs (including extension and sizing normalization) instead of the original asset URLs.
  * The same normalization is applied consistently across both batch and fallback preview fetch paths.
  * Open Graph fallback images now resolve to the corresponding optimized preview URLs with the correct mime type; video media remains unchanged.
  * Media selection now derives the proper mime type when handling Manifold preview links.
* **Tests**
  * Expanded coverage for Manifold image/video normalization and Open Graph fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->