### PR TITLE
[codex] Reduce waves curation masonry image scale

### DIFF
--- a/components/community-curations/CommunityCurationsMasonry.tsx
+++ b/components/community-curations/CommunityCurationsMasonry.tsx
@@ -31,6 +31,7 @@ const MASONRY_COLUMN_WIDTH = 300;
 const MASONRY_GUTTER = 16;
 const INFINITE_SCROLL_ROOT_MARGIN = "1200px 0px";
 const SCROLL_IDLE_DELAY_MS = 120;
+const CURATION_MASONRY_MEDIA_IMAGE_SCALE = ImageScale.AUTOx600;
 const CURATION_CARD_CLASS_NAME =
   "tw-group tw-relative tw-isolate tw-z-0 tw-rounded-xl desktop-hover:hover:tw-z-30 focus-within:tw-z-30";
 const CURATION_CARD_HOVER_FRAME_CLASS_NAME =
@@ -265,7 +266,7 @@ function CommunityCurationsMasonryItem({
           onQuoteClick={navigateToDropWave}
           onDropContentClick={navigateToDropWave}
           footer={<CurationDropFooter drop={drop} />}
-          mediaImageScale={ImageScale.AUTOx1080}
+          mediaImageScale={CURATION_MASONRY_MEDIA_IMAGE_SCALE}
           timestampLayout="inline"
           showInteractions={false}
           inlineAuthorOnDesktop={true}


### PR DESCRIPTION
## Issue
- The `/waves` profile curation masonry was requesting `AUTOx1080` drop media even though the cards render in small masonry columns.
- This made the initial curation feed download larger image derivatives than the visible card size needs.

## Fix
- Lower the CommunityCurations masonry media derivative from `AUTOx1080` to `AUTOx600`.
- Keep the existing lazy/in-view media behavior and masonic rendering unchanged to limit the blast radius.

## Changes
- Added a local `CURATION_MASONRY_MEDIA_IMAGE_SCALE` constant in `components/community-curations/CommunityCurationsMasonry.tsx`.
- Passed that `AUTOx600` scale into the curation masonry `Drop` renderer.

## Validation
- Commit hook ran `format:uncommitted` and tight lint for the changed TSX file; formatting was unchanged and the commit succeeded.
- `git diff --check` passed.
- Local dev server verified at `/waves`.
- Desktop 1440x900 browser QA: curation masonry rendered normally, visible drop media used `/AUTOx600/`, no visible `/AUTOx1080/` drop media, and no horizontal overflow.
- Narrow 390x844 browser QA: `/waves` rendered the mobile waves list normally with no horizontal overflow.
- Live derivative sampling before the change showed representative curation images dropping from about 2.99 MB at `AUTOx1080` to about 0.92 MB at `AUTOx600`, roughly 69% fewer image bytes.

## Risk
- Level: Low
- Why: scoped to the CommunityCurations masonry media scale; no shared media loader, cache, API, routing, or generated files changed.
- Rollback: restore the curation masonry `mediaImageScale` to `ImageScale.AUTOx1080`.

## Review Notes
- Review the visual quality tradeoff for curation masonry cards. `AUTOx600` still covers the observed 300-400px card media widths while materially reducing initial image transfer.
- I intentionally did not change eager/loading behavior because the masonry can have different LCP images by viewport and the current Next 16 docs recommend care around eager/preload for multiple possible LCP candidates.