### PR TITLE
[codex] Reduce mobile wave drop render window

### DIFF
--- a/__tests__/components/waves/drops/WaveDropsAll.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropsAll.test.tsx
@@ -186,6 +186,7 @@ type WaveMessagesMock = {
   isLoading?: boolean | undefined;
   isLoadingNextPage?: boolean | undefined;
   hasNextPage?: boolean | undefined;
+  hasMoreLocal?: boolean | undefined;
   drops?: ApiDrop[] | undefined;
 };
 
@@ -230,6 +231,7 @@ function setupMocks(options: MockSetupOptions = {}) {
     isLoading: false,
     isLoadingNextPage: false,
     hasNextPage: false,
+    hasMoreLocal: false,
     drops: [] as any,
   };
 
@@ -1027,6 +1029,35 @@ describe("WaveDropsAll", () => {
           type: "FULL",
         },
         "target-drop"
+      );
+    });
+
+    it("calls fetchNextPage to reveal cached local drops after server pages are exhausted", async () => {
+      setupMocks({
+        deviceInfo: { isMobileDevice: true },
+        waveMessages: {
+          drops: Array.from({ length: 25 }, (_, i) =>
+            createMockDrop({ id: `drop-${i}` })
+          ),
+          hasNextPage: false,
+          hasMoreLocal: true,
+          isLoading: false,
+          isLoadingNextPage: false,
+        },
+      });
+
+      renderComponent({ waveId: "test-wave", dropId: null });
+
+      await act(async () => {
+        containerProps.onTopIntersection();
+      });
+
+      expect(mockFetchNextPage).toHaveBeenCalledWith(
+        {
+          waveId: "test-wave",
+          type: "FULL",
+        },
+        null
       );
     });
 

--- a/__tests__/components/waves/drops/WaveDropsAll.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropsAll.test.tsx
@@ -502,6 +502,53 @@ describe("WaveDropsAll", () => {
     });
   });
 
+  describe("Virtualized Drop Page Size", () => {
+    it("uses a smaller virtual page size for mobile all-drops views", () => {
+      setupMocks({
+        deviceInfo: { isMobileDevice: true },
+      });
+
+      renderComponent();
+
+      expect(useVirtualizedWaveDropsMock).toHaveBeenLastCalledWith(
+        "test-wave-1",
+        null,
+        undefined,
+        25
+      );
+    });
+
+    it("keeps the default virtual page size for desktop all-drops views", () => {
+      setupMocks({
+        deviceInfo: { isMobileDevice: false },
+      });
+
+      renderComponent();
+
+      expect(useVirtualizedWaveDropsMock).toHaveBeenLastCalledWith(
+        "test-wave-1",
+        null,
+        undefined,
+        50
+      );
+    });
+
+    it("keeps the default virtual page size for mobile drop-scoped views", () => {
+      setupMocks({
+        deviceInfo: { isMobileDevice: true },
+      });
+
+      renderComponent({ dropId: "target-drop" });
+
+      expect(useVirtualizedWaveDropsMock).toHaveBeenLastCalledWith(
+        "test-wave-1",
+        "target-drop",
+        undefined,
+        50
+      );
+    });
+  });
+
   describe("Typing Indicator", () => {
     it("displays typing message when user is typing", () => {
       setupMocks({
@@ -895,6 +942,25 @@ describe("WaveDropsAll", () => {
       });
 
       expect(containerProps.hasNextPage).toBe(false);
+    });
+
+    it("keeps hasNextPage enabled at the pagination threshold", async () => {
+      setupMocks({
+        waveMessages: {
+          drops: Array.from({ length: 25 }, (_, i) =>
+            createMockDrop({ id: `drop-${i}` })
+          ),
+          hasNextPage: true,
+        },
+      });
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("reverse-container")).toBeInTheDocument();
+      });
+
+      expect(containerProps.hasNextPage).toBe(true);
     });
 
     it("calls fetchNextPage when top intersection is triggered", async () => {

--- a/__tests__/components/waves/drops/WaveDropsAll.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropsAll.test.tsx
@@ -886,6 +886,7 @@ describe("WaveDropsAll", () => {
   describe("Virtualization and Pagination", () => {
     it("passes pagination props to reverse container", async () => {
       setupMocks({
+        deviceInfo: { isMobileDevice: true },
         waveMessages: {
           drops: Array.from({ length: 30 }, (_, i) =>
             createMockDrop({ id: `drop-${i}` })
@@ -944,10 +945,51 @@ describe("WaveDropsAll", () => {
       expect(containerProps.hasNextPage).toBe(false);
     });
 
-    it("keeps hasNextPage enabled at the pagination threshold", async () => {
+    it("keeps hasNextPage enabled at the mobile pagination threshold", async () => {
       setupMocks({
+        deviceInfo: { isMobileDevice: true },
         waveMessages: {
           drops: Array.from({ length: 25 }, (_, i) =>
+            createMockDrop({ id: `drop-${i}` })
+          ),
+          hasNextPage: true,
+        },
+      });
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("reverse-container")).toBeInTheDocument();
+      });
+
+      expect(containerProps.hasNextPage).toBe(true);
+    });
+
+    it("keeps desktop pagination gated until the desktop page size is rendered", async () => {
+      setupMocks({
+        deviceInfo: { isMobileDevice: false },
+        waveMessages: {
+          drops: Array.from({ length: 30 }, (_, i) =>
+            createMockDrop({ id: `drop-${i}` })
+          ),
+          hasNextPage: true,
+        },
+      });
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("reverse-container")).toBeInTheDocument();
+      });
+
+      expect(containerProps.hasNextPage).toBe(false);
+    });
+
+    it("keeps hasNextPage enabled at the desktop pagination threshold", async () => {
+      setupMocks({
+        deviceInfo: { isMobileDevice: false },
+        waveMessages: {
+          drops: Array.from({ length: 50 }, (_, i) =>
             createMockDrop({ id: `drop-${i}` })
           ),
           hasNextPage: true,

--- a/__tests__/components/waves/drops/WaveDropsAll.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropsAll.test.tsx
@@ -549,6 +549,63 @@ describe("WaveDropsAll", () => {
         50
       );
     });
+
+    it("keeps the virtual page size stable when device info changes in the same all-drops view", () => {
+      setupMocks({
+        deviceInfo: { isMobileDevice: true },
+      });
+
+      const renderResult = renderComponent();
+      const { props } = renderResult;
+
+      expect(useVirtualizedWaveDropsMock).toHaveBeenLastCalledWith(
+        "test-wave-1",
+        null,
+        undefined,
+        25
+      );
+
+      require("@/hooks/useDeviceInfo").default.mockReturnValue({
+        isAppleMobile: false,
+        isMobileDevice: false,
+        hasTouchScreen: false,
+        isApp: false,
+      });
+
+      renderResult.rerender(<WaveDropsAll {...props} />);
+
+      expect(useVirtualizedWaveDropsMock).toHaveBeenLastCalledWith(
+        "test-wave-1",
+        null,
+        undefined,
+        25
+      );
+    });
+
+    it("recomputes the virtual page size when the drop scope changes", () => {
+      setupMocks({
+        deviceInfo: { isMobileDevice: true },
+      });
+
+      const renderResult = renderComponent();
+      const { props } = renderResult;
+
+      expect(useVirtualizedWaveDropsMock).toHaveBeenLastCalledWith(
+        "test-wave-1",
+        null,
+        undefined,
+        25
+      );
+
+      renderResult.rerender(<WaveDropsAll {...props} dropId="target-drop" />);
+
+      expect(useVirtualizedWaveDropsMock).toHaveBeenLastCalledWith(
+        "test-wave-1",
+        "target-drop",
+        undefined,
+        50
+      );
+    });
   });
 
   describe("Typing Indicator", () => {

--- a/__tests__/components/waves/drops/WaveDropsReverseContainer.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropsReverseContainer.test.tsx
@@ -10,7 +10,10 @@ const mockUseIntersectionObserver =
     typeof useIntersectionObserver
   >;
 
-function setup({ ref = React.createRef<HTMLDivElement>() } = {}) {
+function setup({
+  ref = React.createRef<HTMLDivElement>(),
+  hasNextPage = true,
+} = {}) {
   const onTopIntersection = jest.fn();
 
   const utils = render(
@@ -18,7 +21,7 @@ function setup({ ref = React.createRef<HTMLDivElement>() } = {}) {
       ref={ref}
       onTopIntersection={onTopIntersection}
       isFetchingNextPage={false}
-      hasNextPage={true}
+      hasNextPage={hasNextPage}
     >
       <div>child</div>
     </WaveDropsReverseContainer>
@@ -47,6 +50,19 @@ describe("WaveDropsReverseContainer", () => {
     expect(firstOptions.root).toBeNull();
     expect(firstEnabled).toBe(false);
     expect(lastOptions.root).toBe(scrollDiv);
+    expect(lastEnabled).toBe(true);
+
+    lastCallback({ isIntersecting: true } as IntersectionObserverEntry);
+
+    expect(onTopIntersection).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the top intersection callback active when hasNextPage is false", () => {
+    const { onTopIntersection } = setup({ hasNextPage: false });
+
+    const [, , lastCallback, lastEnabled] =
+      mockUseIntersectionObserver.mock.calls.at(-1)!;
+
     expect(lastEnabled).toBe(true);
 
     lastCallback({ isIntersecting: true } as IntersectionObserverEntry);

--- a/components/waves/drops/wave-drops-all/index.tsx
+++ b/components/waves/drops/wave-drops-all/index.tsx
@@ -236,7 +236,7 @@ const WaveDropsAllInner: React.FC<WaveDropsAllProps> = ({
 
   const canFetchMoreDrops =
     !!waveMessages &&
-    waveMessages.hasNextPage &&
+    (waveMessages.hasMoreLocal || waveMessages.hasNextPage) &&
     !waveMessages.isLoading &&
     !waveMessages.isLoadingNextPage;
 

--- a/components/waves/drops/wave-drops-all/index.tsx
+++ b/components/waves/drops/wave-drops-all/index.tsx
@@ -32,6 +32,8 @@ import { useWaveDropsSerialScroll } from "./hooks/useWaveDropsSerialScroll";
 import { WaveDropsContent } from "./subcomponents/WaveDropsContent";
 
 const EMPTY_DROPS: Drop[] = [];
+const DEFAULT_VIRTUALIZED_DROPS_PAGE_SIZE = 50;
+const MOBILE_ALL_DROPS_VIRTUALIZED_PAGE_SIZE = 25;
 
 interface WaveDropsAllProps {
   readonly waveId: string;
@@ -77,11 +79,15 @@ const WaveDropsAllInner: React.FC<WaveDropsAllProps> = ({
   const router = useRouter();
   const { removeWaveDeliveredNotifications } = useNotificationsContext();
   const { connectedProfile } = useAuth();
-  const { isAppleMobile } = useDeviceInfo();
+  const { isAppleMobile, isMobileDevice } = useDeviceInfo();
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const virtualizedDropsPageSize =
+    isMobileDevice && dropId === null
+      ? MOBILE_ALL_DROPS_VIRTUALIZED_PAGE_SIZE
+      : DEFAULT_VIRTUALIZED_DROPS_PAGE_SIZE;
 
   const { waveMessages, fetchNextPage, waitAndRevealDrop } =
-    useVirtualizedWaveDrops(waveId, dropId, wave);
+    useVirtualizedWaveDrops(waveId, dropId, wave, virtualizedDropsPageSize);
 
   const { setUnreadDividerSerialNo } = useUnreadDivider();
 

--- a/components/waves/drops/wave-drops-all/index.tsx
+++ b/components/waves/drops/wave-drops-all/index.tsx
@@ -81,6 +81,8 @@ const WaveDropsAllInner: React.FC<WaveDropsAllProps> = ({
   const { connectedProfile } = useAuth();
   const { isAppleMobile, isMobileDevice } = useDeviceInfo();
   const containerRef = useRef<HTMLDivElement | null>(null);
+  // Render-window reduction applies to all mobile webviews; isAppleMobile below
+  // only gates the iOS-specific newest-drop deferral behavior.
   const virtualizedDropsPageSize =
     isMobileDevice && dropId === null
       ? MOBILE_ALL_DROPS_VIRTUALIZED_PAGE_SIZE
@@ -295,6 +297,7 @@ const WaveDropsAllInner: React.FC<WaveDropsAllProps> = ({
         scrollContainerCallbackRef={scrollContainerCallbackRef}
         bottomAnchorRef={bottomAnchorRef}
         bottomAnchorCallbackRef={bottomAnchorCallbackRef}
+        paginationThreshold={virtualizedDropsPageSize}
         onTopIntersection={handleTopIntersection}
         onReply={onReply}
         queueSerialTarget={queueSerialTarget}

--- a/components/waves/drops/wave-drops-all/index.tsx
+++ b/components/waves/drops/wave-drops-all/index.tsx
@@ -24,7 +24,7 @@ import { useWaveBoostedDrops } from "@/hooks/useWaveBoostedDrops";
 import { useWaveIsTyping } from "@/hooks/useWaveIsTyping";
 import type { ActiveDropState } from "@/types/dropInteractionTypes";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useWaveDropsClipboard } from "./hooks/useWaveDropsClipboard";
 import { useDeferredNewestDrops } from "./hooks/useDeferredNewestDrops";
 import { useWaveDropsNotificationRead } from "./hooks/useWaveDropsNotificationRead";
@@ -34,6 +34,11 @@ import { WaveDropsContent } from "./subcomponents/WaveDropsContent";
 const EMPTY_DROPS: Drop[] = [];
 const DEFAULT_VIRTUALIZED_DROPS_PAGE_SIZE = 50;
 const MOBILE_ALL_DROPS_VIRTUALIZED_PAGE_SIZE = 25;
+
+const getVirtualizedDropsPageSize = (isMobileAllDropsView: boolean): number =>
+  isMobileAllDropsView
+    ? MOBILE_ALL_DROPS_VIRTUALIZED_PAGE_SIZE
+    : DEFAULT_VIRTUALIZED_DROPS_PAGE_SIZE;
 
 interface WaveDropsAllProps {
   readonly waveId: string;
@@ -83,10 +88,9 @@ const WaveDropsAllInner: React.FC<WaveDropsAllProps> = ({
   const containerRef = useRef<HTMLDivElement | null>(null);
   // Render-window reduction applies to all mobile webviews; isAppleMobile below
   // only gates the iOS-specific newest-drop deferral behavior.
-  const virtualizedDropsPageSize =
-    isMobileDevice && dropId === null
-      ? MOBILE_ALL_DROPS_VIRTUALIZED_PAGE_SIZE
-      : DEFAULT_VIRTUALIZED_DROPS_PAGE_SIZE;
+  const [virtualizedDropsPageSize] = useState(() =>
+    getVirtualizedDropsPageSize(isMobileDevice && dropId === null)
+  );
 
   const { waveMessages, fetchNextPage, waitAndRevealDrop } =
     useVirtualizedWaveDrops(waveId, dropId, wave, virtualizedDropsPageSize);
@@ -354,7 +358,7 @@ const WaveDropsAll: React.FC<WaveDropsAllProps> = ({
       key={`unread-divider-${waveId}`}
     >
       <WaveDropsAllInner
-        key={waveId}
+        key={`${waveId}:${dropId ?? ""}`}
         waveId={waveId}
         wave={wave}
         dropId={dropId}

--- a/components/waves/drops/wave-drops-all/subcomponents/WaveDropsContent.tsx
+++ b/components/waves/drops/wave-drops-all/subcomponents/WaveDropsContent.tsx
@@ -22,6 +22,7 @@ interface WaveDropsContentProps {
   readonly scrollContainerCallbackRef?: Ref<HTMLDivElement> | undefined;
   readonly bottomAnchorRef: RefObject<HTMLDivElement | null>;
   readonly bottomAnchorCallbackRef?: Ref<HTMLDivElement> | undefined;
+  readonly paginationThreshold: number;
   readonly onTopIntersection: () => void;
   readonly onReply: ({
     drop,
@@ -61,6 +62,7 @@ export const WaveDropsContent: React.FC<WaveDropsContentProps> = ({
   scrollContainerCallbackRef,
   bottomAnchorRef,
   bottomAnchorCallbackRef,
+  paginationThreshold,
   onTopIntersection,
   onReply,
   queueSerialTarget,
@@ -121,6 +123,7 @@ export const WaveDropsContent: React.FC<WaveDropsContentProps> = ({
         scrollContainerCallbackRef={scrollContainerCallbackRef}
         bottomAnchorRef={bottomAnchorRef}
         bottomAnchorCallbackRef={bottomAnchorCallbackRef}
+        paginationThreshold={paginationThreshold}
         onTopIntersection={onTopIntersection}
         onReply={onReply}
         queueSerialTarget={queueSerialTarget}

--- a/components/waves/drops/wave-drops-all/subcomponents/WaveDropsMessageListSection.tsx
+++ b/components/waves/drops/wave-drops-all/subcomponents/WaveDropsMessageListSection.tsx
@@ -18,6 +18,7 @@ interface WaveDropsMessageListSectionProps {
   readonly scrollContainerCallbackRef?: Ref<HTMLDivElement> | undefined;
   readonly bottomAnchorRef: RefObject<HTMLDivElement | null>;
   readonly bottomAnchorCallbackRef?: Ref<HTMLDivElement> | undefined;
+  readonly paginationThreshold: number;
   readonly onTopIntersection: () => void;
   readonly onReply: ({
     drop,
@@ -51,8 +52,6 @@ interface WaveDropsMessageListSectionProps {
   readonly isVotingControlsLocked?: boolean | undefined;
 }
 
-const MIN_DROPS_FOR_PAGINATION = 25;
-
 export const WaveDropsMessageListSection: React.FC<
   WaveDropsMessageListSectionProps
 > = ({
@@ -62,6 +61,7 @@ export const WaveDropsMessageListSection: React.FC<
   scrollContainerCallbackRef,
   bottomAnchorRef,
   bottomAnchorCallbackRef,
+  paginationThreshold,
   onTopIntersection,
   onReply,
   queueSerialTarget,
@@ -90,7 +90,7 @@ export const WaveDropsMessageListSection: React.FC<
 }) => {
   const hasNextPage =
     !!waveMessages?.hasNextPage &&
-    waveMessages.drops.length >= MIN_DROPS_FOR_PAGINATION;
+    waveMessages.drops.length >= paginationThreshold;
 
   const containerRef = scrollContainerCallbackRef ?? scrollContainerRef;
   const anchorRef = bottomAnchorCallbackRef ?? bottomAnchorRef;


### PR DESCRIPTION
## Summary
- use a smaller virtualized render window for mobile all-drops selected-wave views
- keep desktop and drop-scoped views on the existing 50-drop render window
- add focused coverage for mobile, desktop, drop-scoped, and pagination-threshold behavior

## Why
Initial selected-wave mobile renders can do more full-drop work than needed. The fetch size stays unchanged, but mobile all-drops views now hydrate/render a smaller first virtual window.

## Validation
- `git diff --check`
- `./bin/6529 run test -- __tests__/components/waves/drops/WaveDropsAll.test.tsx`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff`
- iOS simulator first-render QA on staging-backed `PRXT WAVE` (>25 drops)
- real iPhone Appium/XCUITest QA on staging-backed `PRXT WAVE` with `drops_count: 81`; verified initial render and real touch scrolling

## Risk
Low. This only changes the client-side virtual render page size for mobile all-drops selected-wave views. It does not change API fetch limits, auth, wallet, tokens, cookies, CSP, upload validation, URL parsing, external fetch behavior, websocket, notifications, Sentry/privacy, or route semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved wave drop pagination to better match device size, including a smaller page size on mobile for “all drops” views.
  * Added support for showing locally cached drops after server pagination runs out.

* **Bug Fixes**
  * Refined pagination behavior so loading more content works at the correct thresholds on mobile and desktop.
  * Ensured top-intersection loading remains active when local drops exist, even when server pagination is exhausted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->