### PR TITLE
[codex] Defer Quick DM runtime outside eligible desktop sessions

### DIFF
--- a/__tests__/components/messages/quick-dms/QuickDirectMessagesGate.test.tsx
+++ b/__tests__/components/messages/quick-dms/QuickDirectMessagesGate.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+jest.mock("next/dynamic", () => () => {
+  const MockQuickDirectMessages = () => <div data-testid="quick-dm-runtime" />;
+  MockQuickDirectMessages.displayName = "MockQuickDirectMessages";
+  return MockQuickDirectMessages;
+});
+
+jest.mock("@/components/auth/Auth", () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock("@/hooks/useDeviceInfo", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const useAuthMock = require("@/components/auth/Auth").useAuth as jest.Mock;
+const useDeviceInfoMock = require("@/hooks/useDeviceInfo").default as jest.Mock;
+
+const QuickDirectMessagesGate =
+  require("@/components/messages/quick-dms/QuickDirectMessagesGate").default;
+
+const setMatchMedia = (matches: boolean): void => {
+  Object.defineProperty(globalThis.window, "matchMedia", {
+    configurable: true,
+    value: jest.fn((query: string) => ({
+      addEventListener: jest.fn(),
+      addListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+      matches,
+      media: query,
+      onchange: null,
+      removeEventListener: jest.fn(),
+      removeListener: jest.fn(),
+    })),
+  });
+};
+
+const renderGate = () => render(<QuickDirectMessagesGate />);
+
+describe("QuickDirectMessagesGate", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setMatchMedia(true);
+    useAuthMock.mockReturnValue({
+      connectedProfile: { handle: "alice" },
+      showWaves: true,
+    });
+    useDeviceInfoMock.mockReturnValue({
+      isApp: false,
+      isMobileDevice: false,
+    });
+  });
+
+  it("mounts Quick Direct Messages only for eligible desktop sessions", () => {
+    renderGate();
+
+    expect(screen.getByTestId("quick-dm-runtime")).toBeInTheDocument();
+  });
+
+  it.each([
+    ["app sessions", { isApp: true, isMobileDevice: false }, true, true],
+    ["mobile devices", { isApp: false, isMobileDevice: true }, true, true],
+    ["narrow viewports", { isApp: false, isMobileDevice: false }, false, true],
+    [
+      "profiles without handles",
+      { isApp: false, isMobileDevice: false },
+      true,
+      false,
+    ],
+    [
+      "hidden waves",
+      { isApp: false, isMobileDevice: false },
+      true,
+      true,
+      false,
+    ],
+  ])(
+    "does not mount Quick Direct Messages for %s",
+    (_label, deviceInfo, isDesktopViewport, hasHandle, showWaves = true) => {
+      setMatchMedia(isDesktopViewport);
+      useDeviceInfoMock.mockReturnValue(deviceInfo);
+      useAuthMock.mockReturnValue({
+        connectedProfile: hasHandle ? { handle: "alice" } : {},
+        showWaves,
+      });
+
+      renderGate();
+
+      expect(screen.queryByTestId("quick-dm-runtime")).not.toBeInTheDocument();
+    }
+  );
+});

--- a/components/messages/quick-dms/QuickDirectMessagesGate.tsx
+++ b/components/messages/quick-dms/QuickDirectMessagesGate.tsx
@@ -11,30 +11,27 @@ const LazyQuickDirectMessages = dynamic(() => import("./QuickDirectMessages"), {
   ssr: false,
 });
 
-const getDesktopViewportSnapshot = (): boolean => {
-  if (
-    typeof globalThis.window === "undefined" ||
-    typeof globalThis.window.matchMedia !== "function"
-  ) {
-    return false;
-  }
+const DESKTOP_VIEWPORT_QUERY = `(min-width: ${SIDEBAR_MOBILE_BREAKPOINT}px)`;
 
-  return globalThis.window.matchMedia(
-    `(min-width: ${SIDEBAR_MOBILE_BREAKPOINT}px)`
-  ).matches;
+type BrowserWindowWithOptionalMatchMedia = {
+  matchMedia?: Window["matchMedia"];
+};
+
+const getBrowserWindow = (): BrowserWindowWithOptionalMatchMedia | undefined =>
+  (globalThis as { window?: BrowserWindowWithOptionalMatchMedia }).window;
+
+const getDesktopViewportSnapshot = (): boolean => {
+  return (
+    getBrowserWindow()?.matchMedia?.(DESKTOP_VIEWPORT_QUERY).matches ?? false
+  );
 };
 
 const subscribeDesktopViewport = (onStoreChange: () => void): (() => void) => {
-  if (
-    typeof globalThis.window === "undefined" ||
-    typeof globalThis.window.matchMedia !== "function"
-  ) {
+  const mediaQuery = getBrowserWindow()?.matchMedia?.(DESKTOP_VIEWPORT_QUERY);
+
+  if (mediaQuery === undefined) {
     return () => undefined;
   }
-
-  const mediaQuery = globalThis.window.matchMedia(
-    `(min-width: ${SIDEBAR_MOBILE_BREAKPOINT}px)`
-  );
 
   mediaQuery.addEventListener("change", onStoreChange);
   return () => mediaQuery.removeEventListener("change", onStoreChange);

--- a/components/messages/quick-dms/QuickDirectMessagesGate.tsx
+++ b/components/messages/quick-dms/QuickDirectMessagesGate.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { SIDEBAR_MOBILE_BREAKPOINT } from "@/constants/sidebar";
+import { useAuth } from "@/components/auth/Auth";
+import useDeviceInfo from "@/hooks/useDeviceInfo";
+import dynamic from "next/dynamic";
+import { useSyncExternalStore } from "react";
+
+const LazyQuickDirectMessages = dynamic(() => import("./QuickDirectMessages"), {
+  loading: () => null,
+  ssr: false,
+});
+
+const getDesktopViewportSnapshot = (): boolean => {
+  if (
+    typeof globalThis.window === "undefined" ||
+    typeof globalThis.window.matchMedia !== "function"
+  ) {
+    return false;
+  }
+
+  return globalThis.window.matchMedia(
+    `(min-width: ${SIDEBAR_MOBILE_BREAKPOINT}px)`
+  ).matches;
+};
+
+const subscribeDesktopViewport = (onStoreChange: () => void): (() => void) => {
+  if (
+    typeof globalThis.window === "undefined" ||
+    typeof globalThis.window.matchMedia !== "function"
+  ) {
+    return () => undefined;
+  }
+
+  const mediaQuery = globalThis.window.matchMedia(
+    `(min-width: ${SIDEBAR_MOBILE_BREAKPOINT}px)`
+  );
+
+  mediaQuery.addEventListener("change", onStoreChange);
+  return () => mediaQuery.removeEventListener("change", onStoreChange);
+};
+
+const useCanMountQuickDirectMessages = (): boolean => {
+  const { connectedProfile, showWaves } = useAuth();
+  const { isApp, isMobileDevice } = useDeviceInfo();
+  const isDesktopViewport = useSyncExternalStore(
+    subscribeDesktopViewport,
+    getDesktopViewportSnapshot,
+    () => false
+  );
+
+  return Boolean(
+    !isApp &&
+    !isMobileDevice &&
+    isDesktopViewport &&
+    connectedProfile?.handle &&
+    showWaves
+  );
+};
+
+export default function QuickDirectMessagesGate() {
+  const canMountQuickDirectMessages = useCanMountQuickDirectMessages();
+
+  if (!canMountQuickDirectMessages) {
+    return null;
+  }
+
+  return <LazyQuickDirectMessages />;
+}

--- a/components/providers/Providers.tsx
+++ b/components/providers/Providers.tsx
@@ -4,7 +4,7 @@ import { SeizeConnectProvider } from "@/components/auth/SeizeConnectContext";
 import { CookieConsentProvider } from "@/components/cookies/CookieConsentContext";
 import { EULAConsentProvider } from "@/components/eula/EULAConsentContext";
 import { IpfsProvider } from "@/components/ipfs/IPFSContext";
-import QuickDirectMessages from "@/components/messages/quick-dms/QuickDirectMessages";
+import QuickDirectMessagesGate from "@/components/messages/quick-dms/QuickDirectMessagesGate";
 import { NotificationsProvider } from "@/components/notifications/NotificationsContext";
 import ReactQueryWrapper from "@/components/react-query-wrapper/ReactQueryWrapper";
 import NewVersionToast from "@/components/utils/NewVersionToast";
@@ -81,7 +81,7 @@ export default function Providers({
                                     {enableMyStream ? (
                                       <MyStreamProvider>
                                         {sharedProviders}
-                                        <QuickDirectMessages />
+                                        <QuickDirectMessagesGate />
                                       </MyStreamProvider>
                                     ) : (
                                       sharedProviders


### PR DESCRIPTION
## Issue
- Quick Direct Messages was imported and mounted from the global provider tree, so its runtime could enter initial page loads even when mobile or app users could never use the desktop-only UI.

## Fix
- Replace the direct provider mount with a small client gate that checks auth/profile, Waves visibility, app/mobile device state, and desktop viewport eligibility before dynamically importing Quick Direct Messages.

## Changes
- Add `QuickDirectMessagesGate` as the only provider-level Quick DM component.
- Dynamically import `QuickDirectMessages` only when Quick DM can actually render for an authenticated desktop user.
- Preserve the existing provider graph and desktop Quick DM behavior.

## Validation
- `git diff --check`
- `6529 run lint:changed`
- `6529 run typecheck:changed`
- `6529 run react-doctor:diff`
- Browser QA against a local app pointed at staging:
  - Mobile `/waves`: Waves loaded, no Quick DM UI, no Quick DM chunk, no console errors.
  - Mobile authenticated route: no Quick DM UI/chunk and auth remained intact.
  - Desktop authenticated `/waves`: Quick DM opened list, opened a DM chat, and closed without console errors.
  - Desktop unauthenticated `/waves`: no Quick DM UI/chunk and no auth errors.
  - Existing desktop DM list/view refresh worked from both QA profiles.
- iOS Capacitor simulator QA against `/waves`: Waves loaded, Quick DM stayed hidden, and no app-specific error screen appeared.

Not fully verified: a fresh unread-badge transition. A staging DM post appeared optimistically but did not persist after reload, so I treated that path as partial manual coverage while preserving the code paths that own unread behavior.

## Risk
- Level: Low
- Why: The change is scoped to the provider-level Quick DM mount and only defers an existing desktop-only runtime behind the same eligibility conditions needed to render it.
- Rollback: Revert the provider import/render swap and remove the gate component.

## Review Notes
- Please focus on the client boundary and whether the gate conditions correctly avoid loading the heavy Quick DM runtime on mobile/app/unauthenticated sessions while preserving desktop behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Quick direct messages now appear only in supported desktop contexts, improving the experience across devices.
  * The messages view is now loaded only when needed, helping keep the app lighter at startup.

* **Bug Fixes**
  * Prevents quick direct messages from showing in unsupported situations such as mobile, in-app, or unauthenticated states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->