### PR TITLE
[codex] Instrument mobile launch timing

### DIFF
--- a/__tests__/components/app-wallets/AppWalletsContext.methods.test.tsx
+++ b/__tests__/components/app-wallets/AppWalletsContext.methods.test.tsx
@@ -67,6 +67,7 @@ jest.mock("@/utils/monitoring/mobileLaunchTiming", () => ({
   measureMobileLaunchAsync: jest.fn(
     async (_stepName: string, task: () => unknown) => await task()
   ),
+  setMobileLaunchContext: jest.fn(),
 }));
 
 describe("AppWalletsContext methods", () => {

--- a/__tests__/components/providers/WagmiSetup.test.tsx
+++ b/__tests__/components/providers/WagmiSetup.test.tsx
@@ -1236,7 +1236,11 @@ describe("WagmiSetup Security Tests", () => {
       expect(mockValidateWalletSafely).toHaveBeenCalledWith(validWallet);
       expect(mockValidateWalletSafely).toHaveBeenCalledWith(invalidWallet);
       expect(mockLogErrorSecurely).toHaveBeenCalledWith(
-        `[WagmiSetup] Skipping invalid app-wallet connector ${invalidWallet.address}`,
+        "[WagmiSetup] Skipping invalid app-wallet connector",
+        expect.any(Error)
+      );
+      expect(mockLogErrorSecurely).not.toHaveBeenCalledWith(
+        expect.stringContaining(invalidWallet.address),
         expect.any(Error)
       );
       expect(mockSetToast).not.toHaveBeenCalledWith(

--- a/__tests__/utils/monitoring/mobileLaunchTiming.test.ts
+++ b/__tests__/utils/monitoring/mobileLaunchTiming.test.ts
@@ -58,6 +58,16 @@ async function loadMobileLaunchTiming({
   return { timing, sentry };
 }
 
+function flushLaunchTiming(
+  timing: MobileLaunchTimingModule,
+  reason: Parameters<
+    MobileLaunchTimingModule["scheduleMobileLaunchFlush"]
+  >[0] = "manual"
+): void {
+  timing.scheduleMobileLaunchFlush(reason, 0);
+  jest.advanceTimersByTime(0);
+}
+
 describe("mobileLaunchTiming", () => {
   beforeEach(() => {
     currentNow = 0;
@@ -81,7 +91,7 @@ describe("mobileLaunchTiming", () => {
 
     timing.startMobileLaunchTiming();
     currentNow = 100;
-    timing.flushMobileLaunchTiming("manual");
+    flushLaunchTiming(timing, "manual");
 
     expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -106,8 +116,8 @@ describe("mobileLaunchTiming", () => {
 
     timing.startMobileLaunchTiming();
     currentNow = 100;
-    timing.flushMobileLaunchTiming("manual");
-    timing.flushMobileLaunchTiming("manual");
+    flushLaunchTiming(timing, "manual");
+    flushLaunchTiming(timing, "manual");
 
     expect(sentry.logger.info).toHaveBeenCalledTimes(1);
     expect(sentry.logger.warn).not.toHaveBeenCalled();
@@ -128,7 +138,7 @@ describe("mobileLaunchTiming", () => {
       wallet_connection_state: "connected",
     });
     currentNow = 400;
-    timing.flushMobileLaunchTiming("manual");
+    flushLaunchTiming(timing, "manual");
 
     expect(sentry.logger.info).toHaveBeenCalledWith(
       "mobile_launch_timing",
@@ -155,7 +165,7 @@ describe("mobileLaunchTiming", () => {
     currentNow = 650;
     timing.markMobileLaunchStep("first_useful_app_shell");
     currentNow = 900;
-    timing.flushMobileLaunchTiming("manual");
+    flushLaunchTiming(timing, "manual");
 
     expect(sentry.logger.info).toHaveBeenCalledWith(
       "mobile_launch_timing",
@@ -199,7 +209,7 @@ describe("mobileLaunchTiming", () => {
     timing.startMobileLaunchTiming();
     currentNow = 3000;
     timing.markMobileLaunchStep("first_useful_app_shell");
-    timing.flushMobileLaunchTiming("shell_paint");
+    flushLaunchTiming(timing, "shell_paint");
 
     expect(sentry.logger.warn).toHaveBeenCalledTimes(1);
     expect(sentry.logger.warn).toHaveBeenCalledWith(
@@ -220,7 +230,7 @@ describe("mobileLaunchTiming", () => {
     globalThis.history.pushState({}, "", "/alice?jwt=secret");
     timing.startMobileLaunchTiming();
     currentNow = 3000;
-    timing.flushMobileLaunchTiming("shell_paint");
+    flushLaunchTiming(timing, "shell_paint");
 
     expect(sentry.logger.warn).toHaveBeenCalledWith(
       "mobile_launch_timing",
@@ -236,7 +246,7 @@ describe("mobileLaunchTiming", () => {
 
     first.timing.startMobileLaunchTiming();
     currentNow = 100;
-    first.timing.flushMobileLaunchTiming("shell_paint");
+    flushLaunchTiming(first.timing, "shell_paint");
 
     expect(first.sentry.logger.info).not.toHaveBeenCalled();
     expect(first.sentry.logger.warn).not.toHaveBeenCalled();
@@ -247,7 +257,7 @@ describe("mobileLaunchTiming", () => {
 
     second.timing.startMobileLaunchTiming();
     currentNow = 100;
-    second.timing.flushMobileLaunchTiming("shell_paint");
+    flushLaunchTiming(second.timing, "shell_paint");
 
     expect(second.sentry.logger.info).toHaveBeenCalledTimes(1);
     expect(second.sentry.logger.warn).not.toHaveBeenCalled();
@@ -316,7 +326,7 @@ describe("mobileLaunchTiming", () => {
     }
 
     currentNow = 3500;
-    timing.flushMobileLaunchTiming("shell_paint");
+    flushLaunchTiming(timing, "shell_paint");
 
     expect(sentry.logger.warn).toHaveBeenCalledWith(
       "mobile_launch_timing",
@@ -364,7 +374,7 @@ describe("mobileLaunchTiming", () => {
     });
 
     currentNow = 3500;
-    timing.flushMobileLaunchTiming("shell_paint");
+    flushLaunchTiming(timing, "shell_paint");
 
     expect(sentry.logger.warn).toHaveBeenCalledWith(
       "mobile_launch_timing",

--- a/__tests__/utils/monitoring/mobileLaunchTiming.test.ts
+++ b/__tests__/utils/monitoring/mobileLaunchTiming.test.ts
@@ -68,6 +68,18 @@ function flushLaunchTiming(
   jest.advanceTimersByTime(0);
 }
 
+function mockCryptoSample(value: number): void {
+  const cryptoSample = Math.floor(value * 0x100000000);
+  jest
+    .spyOn(globalThis.crypto, "getRandomValues")
+    .mockImplementation((array) => {
+      if (array instanceof Uint32Array && array.length > 0) {
+        array[0] = cryptoSample;
+      }
+      return array;
+    });
+}
+
 describe("mobileLaunchTiming", () => {
   beforeEach(() => {
     currentNow = 0;
@@ -75,7 +87,7 @@ describe("mobileLaunchTiming", () => {
     jest.spyOn(globalThis.performance, "now").mockImplementation(() => {
       return currentNow;
     });
-    jest.spyOn(Math, "random").mockReturnValue(0.99);
+    mockCryptoSample(0.99);
     globalThis.history.pushState({}, "", "/waves/123?wallet=secret");
   });
 
@@ -86,7 +98,7 @@ describe("mobileLaunchTiming", () => {
   });
 
   it("starts web launches outside Capacitor", async () => {
-    jest.spyOn(Math, "random").mockReturnValue(0.01);
+    mockCryptoSample(0.01);
     const { timing, sentry } = await loadMobileLaunchTiming({ native: false });
 
     timing.startMobileLaunchTiming();
@@ -111,7 +123,7 @@ describe("mobileLaunchTiming", () => {
   });
 
   it("flushes once", async () => {
-    jest.spyOn(Math, "random").mockReturnValue(0.01);
+    mockCryptoSample(0.01);
     const { timing, sentry } = await loadMobileLaunchTiming();
 
     timing.startMobileLaunchTiming();
@@ -251,7 +263,7 @@ describe("mobileLaunchTiming", () => {
     expect(first.sentry.logger.info).not.toHaveBeenCalled();
     expect(first.sentry.logger.warn).not.toHaveBeenCalled();
 
-    jest.spyOn(Math, "random").mockReturnValue(0.01);
+    mockCryptoSample(0.01);
     globalThis.history.pushState({}, "", "/about");
     const second = await loadMobileLaunchTiming();
 

--- a/__tests__/utils/monitoring/mobileLaunchTiming.test.ts
+++ b/__tests__/utils/monitoring/mobileLaunchTiming.test.ts
@@ -75,16 +75,29 @@ describe("mobileLaunchTiming", () => {
     jest.resetModules();
   });
 
-  it("does not start outside Capacitor", async () => {
+  it("starts web launches outside Capacitor", async () => {
+    jest.spyOn(Math, "random").mockReturnValue(0.01);
     const { timing, sentry } = await loadMobileLaunchTiming({ native: false });
 
     timing.startMobileLaunchTiming();
-    currentNow = 4000;
+    currentNow = 100;
     timing.flushMobileLaunchTiming("manual");
 
-    expect(sentry.addBreadcrumb).not.toHaveBeenCalled();
+    expect(sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: "mobile_launch",
+        message: "start",
+      })
+    );
     expect(sentry.logger.warn).not.toHaveBeenCalled();
-    expect(sentry.logger.info).not.toHaveBeenCalled();
+    expect(sentry.logger.info).toHaveBeenCalledWith(
+      "mobile_launch_timing",
+      expect.objectContaining({
+        platform: "web_desktop",
+        route_family: "/waves/[wave]",
+        sample_rate: 0.05,
+      })
+    );
   });
 
   it("flushes once", async () => {
@@ -98,6 +111,67 @@ describe("mobileLaunchTiming", () => {
 
     expect(sentry.logger.info).toHaveBeenCalledTimes(1);
     expect(sentry.logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("adds safe launch context and flat milestone attributes", async () => {
+    const { timing, sentry } = await loadMobileLaunchTiming();
+
+    timing.startMobileLaunchTiming();
+    currentNow = 120;
+    timing.markMobileLaunchStep("wagmi_children_unblocked");
+    currentNow = 200;
+    timing.markMobileLaunchStep("first_useful_app_shell");
+    timing.setMobileLaunchContext({
+      app_wallet_count_bucket: "2_5",
+      app_wallets_state: "supported_with_wallets",
+      auth_state: "authenticated_profile",
+      wallet_connection_state: "connected",
+    });
+    currentNow = 400;
+    timing.flushMobileLaunchTiming("manual");
+
+    expect(sentry.logger.info).toHaveBeenCalledWith(
+      "mobile_launch_timing",
+      expect.objectContaining({
+        context: {
+          app_wallet_count_bucket: "2_5",
+          app_wallets_state: "supported_with_wallets",
+          auth_state: "authenticated_profile",
+          wallet_connection_state: "connected",
+        },
+        provider_gate_ms: 120,
+        shell_after_wagmi_ms: 80,
+        step_first_useful_app_shell_ms: 200,
+        step_wagmi_children_unblocked_ms: 120,
+      })
+    );
+  });
+
+  it("lets a waves content flush replace a scheduled shell flush", async () => {
+    const { timing, sentry } = await loadMobileLaunchTiming();
+
+    timing.startMobileLaunchTiming();
+    currentNow = 50;
+    timing.scheduleMobileLaunchFlush("shell_paint", 5000);
+    currentNow = 100;
+    timing.markMobileLaunchStep("waves_first_content_visible");
+    timing.scheduleMobileLaunchFlush("waves_content_visible", 250);
+    currentNow = 350;
+    jest.advanceTimersByTime(250);
+
+    expect(sentry.logger.info).toHaveBeenCalledTimes(1);
+    expect(sentry.logger.info).toHaveBeenCalledWith(
+      "mobile_launch_timing",
+      expect.objectContaining({
+        flush_reason: "waves_content_visible",
+        step_waves_first_content_visible_ms: 100,
+        total_ms: 350,
+      })
+    );
+
+    jest.advanceTimersByTime(5000);
+
+    expect(sentry.logger.info).toHaveBeenCalledTimes(1);
   });
 
   it("logs slow launches as warnings without sampling", async () => {
@@ -138,6 +212,7 @@ describe("mobileLaunchTiming", () => {
   });
 
   it("samples normal launches at five percent", async () => {
+    globalThis.history.pushState({}, "", "/about");
     const first = await loadMobileLaunchTiming();
 
     first.timing.startMobileLaunchTiming();
@@ -148,6 +223,7 @@ describe("mobileLaunchTiming", () => {
     expect(first.sentry.logger.warn).not.toHaveBeenCalled();
 
     jest.spyOn(Math, "random").mockReturnValue(0.01);
+    globalThis.history.pushState({}, "", "/about");
     const second = await loadMobileLaunchTiming();
 
     second.timing.startMobileLaunchTiming();

--- a/__tests__/utils/monitoring/mobileLaunchTiming.test.ts
+++ b/__tests__/utils/monitoring/mobileLaunchTiming.test.ts
@@ -147,6 +147,25 @@ describe("mobileLaunchTiming", () => {
     );
   });
 
+  it("measures elapsed time from the launch timing start baseline", async () => {
+    const { timing, sentry } = await loadMobileLaunchTiming();
+
+    currentNow = 500;
+    timing.startMobileLaunchTiming();
+    currentNow = 650;
+    timing.markMobileLaunchStep("first_useful_app_shell");
+    currentNow = 900;
+    timing.flushMobileLaunchTiming("manual");
+
+    expect(sentry.logger.info).toHaveBeenCalledWith(
+      "mobile_launch_timing",
+      expect.objectContaining({
+        step_first_useful_app_shell_ms: 150,
+        total_ms: 400,
+      })
+    );
+  });
+
   it("lets a waves content flush replace a scheduled shell flush", async () => {
     const { timing, sentry } = await loadMobileLaunchTiming();
 

--- a/components/app-wallets/AppWalletsContext.tsx
+++ b/components/app-wallets/AppWalletsContext.tsx
@@ -16,7 +16,11 @@ import {
 } from "./app-wallet-helpers";
 import { Time } from "@/helpers/time";
 import useCapacitor from "@/hooks/useCapacitor";
-import { measureMobileLaunchAsync } from "@/utils/monitoring/mobileLaunchTiming";
+import {
+  measureMobileLaunchAsync,
+  setMobileLaunchContext,
+  type MobileLaunchAppWalletCountBucket,
+} from "@/utils/monitoring/mobileLaunchTiming";
 
 export const APP_WALLET_MNEMONIC_UNAVAILABLE = "N/A";
 
@@ -57,6 +61,21 @@ const WALLET_KEY_PREFIX = "app-wallet_";
 
 const isSameAddress = (a: string, b: string): boolean =>
   a.toLowerCase() === b.toLowerCase();
+
+const getAppWalletCountBucket = (
+  count: number
+): MobileLaunchAppWalletCountBucket => {
+  if (count <= 0) {
+    return "0";
+  }
+  if (count === 1) {
+    return "1";
+  }
+  if (count <= 5) {
+    return "2_5";
+  }
+  return "6_plus";
+};
 
 const isV2Wallet = (wallet: AppWallet): boolean =>
   wallet.encryption_version === 2 &&
@@ -128,7 +147,8 @@ export const AppWalletsProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [appWalletsSupported]);
 
   useEffect(() => {
-    let cancelled = false;
+    const cancellation = { cancelled: false };
+    const isCancelled = () => cancellation.cancelled;
 
     const initialize = async () => {
       let supported = false;
@@ -144,13 +164,17 @@ export const AppWalletsProvider: React.FC<{ children: React.ReactNode }> = ({
         }
       }
 
-      if (cancelled) {
+      if (isCancelled()) {
         return;
       }
 
       setAppWalletsSupported(supported);
 
       if (!supported) {
+        setMobileLaunchContext({
+          app_wallet_count_bucket: "0",
+          app_wallets_state: "unsupported",
+        });
         setAppWallets([]);
         setFetchingAppWallets(false);
         return;
@@ -162,18 +186,23 @@ export const AppWalletsProvider: React.FC<{ children: React.ReactNode }> = ({
         getAllWallets
       );
 
-      if (cancelled) {
+      if (isCancelled()) {
         return;
       }
 
+      setMobileLaunchContext({
+        app_wallet_count_bucket: getAppWalletCountBucket(wallets.length),
+        app_wallets_state:
+          wallets.length > 0 ? "supported_with_wallets" : "supported_empty",
+      });
       setAppWallets(wallets);
       setFetchingAppWallets(false);
     };
 
-    initialize();
+    void initialize();
 
     return () => {
-      cancelled = true;
+      cancellation.cancelled = true;
     };
   }, [isCapacitor]);
 
@@ -260,7 +289,7 @@ export const AppWalletsProvider: React.FC<{ children: React.ReactNode }> = ({
         const valueResult = await SecureStoragePlugin.get({ key });
         const wallet = JSON.parse(valueResult.value) as AppWallet;
 
-        if (!wallet || !isSameAddress(wallet.address, address)) {
+        if (!isSameAddress(wallet.address, address)) {
           return false;
         }
 

--- a/components/auth/AuthLaunchTimingReporter.tsx
+++ b/components/auth/AuthLaunchTimingReporter.tsx
@@ -73,6 +73,32 @@ function getMobileLaunchAuthState({
   return "anonymous";
 }
 
+function isMobileLaunchAuthReady({
+  authState,
+  walletConnectionState,
+}: {
+  readonly authState: MobileLaunchAuthState;
+  readonly walletConnectionState:
+    | "initializing"
+    | "disconnected"
+    | "connecting"
+    | "connected"
+    | "error";
+}): boolean {
+  if (authState === "initializing") {
+    return false;
+  }
+
+  if (authState === "anonymous") {
+    return (
+      walletConnectionState === "disconnected" ||
+      walletConnectionState === "error"
+    );
+  }
+
+  return true;
+}
+
 export default function AuthLaunchTimingReporter({
   enableWalletAuthentication,
 }: {
@@ -102,7 +128,12 @@ export default function AuthLaunchTimingReporter({
       wallet_connection_state: connectionState,
     });
 
-    if (authState !== "initializing") {
+    if (
+      isMobileLaunchAuthReady({
+        authState,
+        walletConnectionState: connectionState,
+      })
+    ) {
       markMobileLaunchStep("auth_ready");
     }
   }, [

--- a/components/auth/AuthLaunchTimingReporter.tsx
+++ b/components/auth/AuthLaunchTimingReporter.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect } from "react";
+import { getAuthJwt, getWalletAddress } from "@/services/auth/auth.utils";
+import {
+  markMobileLaunchStep,
+  setMobileLaunchContext,
+  type MobileLaunchAuthState,
+} from "@/utils/monitoring/mobileLaunchTiming";
+import { useAuth } from "./Auth";
+import { useSeizeConnectContext } from "./SeizeConnectContext";
+
+const hasStoredAuthState = (): boolean => {
+  try {
+    return Boolean(getWalletAddress() && getAuthJwt());
+  } catch {
+    return false;
+  }
+};
+
+function getMobileLaunchAuthState({
+  activeProxy,
+  connectedProfile,
+  enableWalletAuthentication,
+  fetchingProfile,
+  hasValidWalletAuth,
+  walletAddress,
+  walletConnectionState,
+}: {
+  readonly activeProxy: boolean;
+  readonly connectedProfile: boolean;
+  readonly enableWalletAuthentication: boolean;
+  readonly fetchingProfile: boolean;
+  readonly hasValidWalletAuth: boolean;
+  readonly walletAddress: string | undefined;
+  readonly walletConnectionState:
+    | "initializing"
+    | "disconnected"
+    | "connecting"
+    | "connected"
+    | "error";
+}): MobileLaunchAuthState {
+  if (!enableWalletAuthentication) {
+    return "wallet_auth_disabled";
+  }
+
+  if (
+    walletConnectionState === "initializing" ||
+    walletConnectionState === "connecting" ||
+    (Boolean(walletAddress) && fetchingProfile)
+  ) {
+    return "initializing";
+  }
+
+  if (connectedProfile && hasValidWalletAuth) {
+    return activeProxy
+      ? "authenticated_proxy_profile"
+      : "authenticated_profile";
+  }
+
+  if (walletAddress && hasValidWalletAuth) {
+    return "authorized_wallet_no_profile";
+  }
+
+  if (walletAddress) {
+    return "connected_wallet_needs_auth";
+  }
+
+  if (hasStoredAuthState()) {
+    return "stored_auth_disconnected";
+  }
+
+  return "anonymous";
+}
+
+export default function AuthLaunchTimingReporter({
+  enableWalletAuthentication,
+}: {
+  readonly enableWalletAuthentication: boolean;
+}) {
+  const { activeProfileProxy, connectedProfile, fetchingProfile } = useAuth();
+  const { address, connectionState, hasValidWalletAuth } =
+    useSeizeConnectContext();
+
+  useEffect(() => {
+    markMobileLaunchStep("auth_provider_mounted");
+  }, []);
+
+  useEffect(() => {
+    const authState = getMobileLaunchAuthState({
+      activeProxy: Boolean(activeProfileProxy),
+      connectedProfile: Boolean(connectedProfile?.handle),
+      enableWalletAuthentication,
+      fetchingProfile,
+      hasValidWalletAuth,
+      walletAddress: address,
+      walletConnectionState: connectionState,
+    });
+
+    setMobileLaunchContext({
+      auth_state: authState,
+      wallet_connection_state: connectionState,
+    });
+
+    if (authState !== "initializing") {
+      markMobileLaunchStep("auth_ready");
+    }
+  }, [
+    activeProfileProxy,
+    address,
+    connectedProfile?.handle,
+    connectionState,
+    enableWalletAuthentication,
+    fetchingProfile,
+    hasValidWalletAuth,
+  ]);
+
+  return null;
+}

--- a/components/providers/LayoutWrapper.tsx
+++ b/components/providers/LayoutWrapper.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import FooterWrapper from "@/components/footer/FooterWrapper";
 import MobileLayout from "@/components/layout/MobileLayout";
@@ -13,10 +13,37 @@ import { useGlobalRefresh } from "@/contexts/RefreshContext";
 import useIsMobileScreen from "@/hooks/isMobileScreen";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
 import {
-  flushMobileLaunchTiming,
   markMobileLaunchStep,
+  scheduleMobileLaunchFlush,
 } from "@/utils/monitoring/mobileLaunchTiming";
 import type { ComponentType, ReactNode } from "react";
+
+const getTouchTabletViewportSnapshot = (): boolean => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return window.innerWidth < SIDEBAR_MOBILE_BREAKPOINT;
+};
+
+const getTouchTabletViewportServerSnapshot = (): boolean => false;
+
+const subscribeTouchTabletViewport = (
+  onStoreChange: () => void
+): (() => void) => {
+  if (typeof window === "undefined") {
+    return () => undefined;
+  }
+
+  const mediaQuery = window.matchMedia(
+    `(max-width: ${SIDEBAR_MOBILE_BREAKPOINT - 0.02}px)`
+  );
+
+  mediaQuery.addEventListener("change", onStoreChange);
+  return () => {
+    mediaQuery.removeEventListener("change", onStoreChange);
+  };
+};
 
 export default function LayoutWrapper({
   children,
@@ -26,58 +53,20 @@ export default function LayoutWrapper({
   const { isApp, hasTouchScreen } = useDeviceInfo();
   const { refreshKey } = useGlobalRefresh();
   const isSmallScreen = useIsMobileScreen();
-  const [isTouchTabletViewport, setIsTouchTabletViewport] = useState(() => {
-    if (globalThis.window === undefined) {
-      return false;
-    }
-    return globalThis.window.innerWidth < SIDEBAR_MOBILE_BREAKPOINT;
-  });
+  const isTouchTabletViewport = useSyncExternalStore(
+    subscribeTouchTabletViewport,
+    getTouchTabletViewportSnapshot,
+    getTouchTabletViewportServerSnapshot
+  );
   const pathname = usePathname();
 
-  useEffect(() => {
-    if (!hasTouchScreen) {
-      setIsTouchTabletViewport(false);
-      return;
-    }
-
-    const browserWindow = globalThis.window;
-    if (browserWindow === undefined) {
-      setIsTouchTabletViewport(false);
-      return;
-    }
-
-    const mediaQuery = browserWindow.matchMedia(
-      `(max-width: ${SIDEBAR_MOBILE_BREAKPOINT - 0.02}px)`
-    );
-
-    setIsTouchTabletViewport(mediaQuery.matches);
-    const listener = (event: MediaQueryListEvent) => {
-      setIsTouchTabletViewport(event.matches);
-    };
-
-    if (typeof mediaQuery.addEventListener === "function") {
-      mediaQuery.addEventListener("change", listener);
-      return () => {
-        mediaQuery.removeEventListener?.("change", listener);
-      };
-    }
-
-    const previousOnChange = mediaQuery.onchange;
-    mediaQuery.onchange = listener;
-    return () => {
-      if (mediaQuery.onchange === listener) {
-        mediaQuery.onchange = previousOnChange ?? null;
-      }
-    };
-  }, [hasTouchScreen]);
-
   const isAccessOrRestricted =
-    pathname?.startsWith("/access") || pathname?.startsWith("/restricted");
+    pathname.startsWith("/access") || pathname.startsWith("/restricted");
 
   useEffect(() => {
     const flushAfterPaint = () => {
       markMobileLaunchStep("first_useful_app_shell");
-      flushMobileLaunchTiming("shell_paint");
+      scheduleMobileLaunchFlush("shell_paint", 5000);
     };
 
     if (typeof globalThis.requestAnimationFrame === "function") {

--- a/components/providers/Providers.tsx
+++ b/components/providers/Providers.tsx
@@ -1,5 +1,6 @@
 import { AppWalletsProvider } from "@/components/app-wallets/AppWalletsContext";
 import Auth from "@/components/auth/Auth";
+import AuthLaunchTimingReporter from "@/components/auth/AuthLaunchTimingReporter";
 import { SeizeConnectProvider } from "@/components/auth/SeizeConnectContext";
 import { CookieConsentProvider } from "@/components/cookies/CookieConsentContext";
 import { EULAConsentProvider } from "@/components/eula/EULAConsentContext";
@@ -69,6 +70,11 @@ export default function Providers({
                       <Auth
                         enableWalletAuthentication={enableWalletAuthentication}
                       >
+                        <AuthLaunchTimingReporter
+                          enableWalletAuthentication={
+                            enableWalletAuthentication
+                          }
+                        />
                         <WaveEligibilityProvider>
                           <NotificationsProvider>
                             <CookieConsentProvider

--- a/components/providers/WagmiSetup.tsx
+++ b/components/providers/WagmiSetup.tsx
@@ -50,6 +50,11 @@ type InjectAppWalletConnectorsInput = {
   readonly setToast: (toast: AppToastInput) => void;
 };
 
+type AppKitAdapterManagerPublicShape = Pick<
+  AppKitAdapterManager,
+  "cleanup" | "createAdapterWithCache" | "shouldRecreateAdapter"
+>;
+
 /**
  * Installs a defensive wrapper around `window.ethereum` (EIP-1193 provider).
  *
@@ -103,9 +108,9 @@ function installSafeEthereumProxy(): void {
     let hasLoggedProxyGetError = false;
     const ethereumTarget = ethereum;
     const proxy = new Proxy(ethereumTarget, {
-      get(target, prop, receiver): unknown {
+      get(target, prop): unknown {
         try {
-          const value: unknown = Reflect.get(target, prop, receiver);
+          const value: unknown = Reflect.get(target, prop, target);
           if (typeof value === "function") {
             const method = value as (
               this: unknown,
@@ -158,11 +163,30 @@ function canAssignProperty(descriptor: PropertyDescriptor): boolean {
 }
 
 function assertAppKitAdapterManager(value: unknown): AppKitAdapterManager {
-  if (!(value instanceof AppKitAdapterManager)) {
+  if (!isAppKitAdapterManager(value)) {
     throw new AppKitValidationError("Internal API failed");
   }
 
   return value;
+}
+
+function isAppKitAdapterManager(value: unknown): value is AppKitAdapterManager {
+  if (
+    value === null ||
+    (typeof value !== "object" && typeof value !== "function")
+  ) {
+    return false;
+  }
+
+  const candidate = value as Partial<
+    Record<keyof AppKitAdapterManagerPublicShape, unknown>
+  >;
+
+  return (
+    typeof candidate.cleanup === "function" &&
+    typeof candidate.createAdapterWithCache === "function" &&
+    typeof candidate.shouldRecreateAdapter === "function"
+  );
 }
 
 function initializeAdapterWhenNeeded({
@@ -232,7 +256,7 @@ function injectAppWalletConnectors({
         return [setupConnector];
       } catch (error) {
         logErrorSecurely(
-          `[WagmiSetup] Skipping invalid app-wallet connector ${wallet.address}`,
+          "[WagmiSetup] Skipping invalid app-wallet connector",
           error
         );
         return [];

--- a/components/providers/WagmiSetup.tsx
+++ b/components/providers/WagmiSetup.tsx
@@ -136,6 +136,14 @@ function canAssignProperty(descriptor: PropertyDescriptor): boolean {
   return descriptor.writable !== false;
 }
 
+function assertAppKitAdapterManager(value: unknown): AppKitAdapterManager {
+  if (!(value instanceof AppKitAdapterManager)) {
+    throw new AppKitValidationError("Internal API failed");
+  }
+
+  return value;
+}
+
 export default function WagmiSetup({
   children,
 }: {
@@ -179,7 +187,7 @@ export default function WagmiSetup({
 
       const config: AppKitInitializationConfig = {
         wallets,
-        adapterManager,
+        adapterManager: assertAppKitAdapterManager(adapterManager),
         isCapacitor,
         chains,
       };

--- a/components/providers/WagmiSetup.tsx
+++ b/components/providers/WagmiSetup.tsx
@@ -46,18 +46,19 @@ import type { Chain } from "viem";
  * This runs once per page load and only touches `window.ethereum`.
  */
 function installSafeEthereumProxy(): void {
-  if (globalThis.window === undefined) return;
+  if (typeof window === "undefined") return;
 
   const w = globalThis as unknown as {
-    ethereum?: unknown | undefined;
+    ethereum?: unknown;
     __6529_safeEthereumProxyInstalled?: boolean | undefined;
   };
 
-  if (w.__6529_safeEthereumProxyInstalled) return;
+  if (w.__6529_safeEthereumProxyInstalled === true) return;
 
   const ethereum = w.ethereum;
   if (
-    !ethereum ||
+    ethereum === undefined ||
+    ethereum === null ||
     (typeof ethereum !== "object" && typeof ethereum !== "function")
   ) {
     w.__6529_safeEthereumProxyInstalled = true;
@@ -79,12 +80,17 @@ function installSafeEthereumProxy(): void {
 
   try {
     let hasLoggedProxyGetError = false;
-    const proxy = new Proxy(ethereum, {
-      get(target, prop) {
+    const ethereumTarget = ethereum;
+    const proxy = new Proxy(ethereumTarget, {
+      get(target, prop, receiver): unknown {
         try {
-          const value = Reflect.get(target, prop);
+          const value: unknown = Reflect.get(target, prop, receiver);
           if (typeof value === "function") {
-            return value.bind(target);
+            const method = value as (
+              this: unknown,
+              ...args: unknown[]
+            ) => unknown;
+            return method.bind(target);
           }
           return value;
         } catch (error) {
@@ -144,10 +150,10 @@ export default function WagmiSetup({
   const [currentAdapter, setCurrentAdapter] = useState<WagmiAdapter | null>(
     null
   );
-  const [isMounted, setIsMounted] = useState(false);
 
   // Track processed wallets by address for efficient comparison
   const processedWallets = useRef<Set<string>>(new Set());
+  const isInitializingRef = useRef(false);
 
   // Memoize platform detection to avoid repeated calls
   const isCapacitor = useMemo(() => {
@@ -163,22 +169,9 @@ export default function WagmiSetup({
     [appWalletPasswordModal.requestPassword]
   );
 
-  // Handle client-side mounting for App Router
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
-
-  // Prevent concurrent initialization attempts
-  const [isInitializing, setIsInitializing] = useState(false);
-
   // Create adapter with essential configuration only
   const initializeAppKitWithWallets = useCallback(
     (wallets: AppWallet[]) => {
-      // Basic validation - let util handle detailed validation
-      if (!adapterManager) {
-        throw new AppKitValidationError("Internal API failed");
-      }
-
       const chains: Chain[] = [mainnet];
       if (enableTestnet) {
         chains.push(sepolia);
@@ -186,7 +179,7 @@ export default function WagmiSetup({
 
       const config: AppKitInitializationConfig = {
         wallets,
-        adapterManager: adapterManager as AppKitAdapterManager,
+        adapterManager,
         isCapacitor,
         chains,
       };
@@ -199,19 +192,22 @@ export default function WagmiSetup({
   // Initialize AppKit with fail-fast approach
   const setupAppKitAdapter = useCallback(
     async (wallets: AppWallet[]) => {
-      if (isInitializing) {
+      if (isInitializingRef.current) {
         throw new AppKitValidationError("Internal API failed");
       }
 
-      setIsInitializing(true);
+      isInitializingRef.current = true;
 
       try {
+        markMobileLaunchStep("wagmi_init_start");
         const result = await measureMobileLaunchAsync("wagmi_appkit_init", () =>
           initializeAppKitWithWallets(wallets)
         );
+        markMobileLaunchStep("wagmi_adapter_created");
         await measureMobileLaunchAsync("wagmi_adapter_ready", async () => {
           await (result.ready ?? Promise.resolve());
         });
+        markMobileLaunchStep("wagmi_ready");
         setCurrentAdapter(result.adapter);
       } catch (error) {
         logErrorSecurely("[WagmiSetup] AppKit initialization failed", error);
@@ -222,29 +218,32 @@ export default function WagmiSetup({
         });
         throw error; // FAIL-FAST: Re-throw to prevent app from continuing in broken state
       } finally {
-        setIsInitializing(false);
+        isInitializingRef.current = false;
       }
     },
-    [isInitializing, initializeAppKitWithWallets, setToast]
+    [initializeAppKitWithWallets, setToast]
   );
 
+  /* eslint-disable react-you-might-not-need-an-effect/no-event-handler -- These effects synchronize imperative AppKit/Wagmi systems and launch telemetry with React state. */
   // Initialize adapter eagerly on mount with empty wallets
   useEffect(() => {
-    if (isMounted && !currentAdapter && !isInitializing) {
-      installSafeEthereumProxy();
-      // Prevent unhandled promise rejections during eager initialization.
-      // Fail-fast behavior is preserved by leaving `currentAdapter` unset.
-      setupAppKitAdapter([]).catch(() => undefined);
+    if (currentAdapter !== null || isInitializingRef.current) {
+      return;
     }
-  }, [isMounted, currentAdapter, isInitializing]); // setupAppKitAdapter intentionally excluded to prevent loops
+
+    installSafeEthereumProxy();
+    // Prevent unhandled promise rejections during eager initialization.
+    // Fail-fast behavior is preserved by leaving `currentAdapter` unset.
+    void setupAppKitAdapter([]).catch(() => undefined);
+  }, [currentAdapter, setupAppKitAdapter]);
 
   useEffect(() => {
-    if (!isMounted || !currentAdapter) {
+    if (currentAdapter === null) {
       return;
     }
 
     markMobileLaunchStep("wagmi_children_unblocked");
-  }, [isMounted, currentAdapter]);
+  }, [currentAdapter]);
 
   // Inject wallet connectors dynamically using hooks (simplified approach)
   useEffect(() => {
@@ -262,31 +261,29 @@ export default function WagmiSetup({
 
     try {
       // Create connectors for current wallets
-      const connectors = appWallets
-        .flatMap((wallet) => {
-          try {
-            validateWalletSafely(wallet);
-            const connector = createAppWalletConnector(
-              Array.from(currentAdapter.wagmiConfig.chains),
-              { appWallet: wallet },
-              () =>
-                appWalletPasswordModal.requestPassword(
-                  wallet.address,
-                  wallet.address_hashed
-                )
-            );
-            const setupConnector =
-              currentAdapter.wagmiConfig._internal.connectors.setup(connector);
-            return setupConnector ? [setupConnector] : [];
-          } catch (error) {
-            logErrorSecurely(
-              `[WagmiSetup] Skipping invalid app-wallet connector ${wallet.address}`,
-              error
-            );
-            return [];
-          }
-        })
-        .filter((connector) => connector !== null);
+      const connectors = appWallets.flatMap((wallet) => {
+        try {
+          validateWalletSafely(wallet);
+          const connector = createAppWalletConnector(
+            Array.from(currentAdapter.wagmiConfig.chains),
+            { appWallet: wallet },
+            () =>
+              appWalletPasswordModal.requestPassword(
+                wallet.address,
+                wallet.address_hashed
+              )
+          );
+          const setupConnector =
+            currentAdapter.wagmiConfig._internal.connectors.setup(connector);
+          return [setupConnector];
+        } catch (error) {
+          logErrorSecurely(
+            `[WagmiSetup] Skipping invalid app-wallet connector ${wallet.address}`,
+            error
+          );
+          return [];
+        }
+      });
 
       // Get existing non-app-wallet connectors
       const existingConnectors = currentAdapter.wagmiConfig.connectors.filter(
@@ -311,9 +308,10 @@ export default function WagmiSetup({
       // Don't throw here - let the component continue but notify the user
     }
   }, [currentAdapter, appWallets, appWalletPasswordModal, setToast]);
+  /* eslint-enable react-you-might-not-need-an-effect/no-event-handler */
 
   // Show loading state until fully initialized
-  if (!isMounted || !currentAdapter) {
+  if (currentAdapter === null) {
     return null;
   }
 

--- a/components/providers/WagmiSetup.tsx
+++ b/components/providers/WagmiSetup.tsx
@@ -8,6 +8,7 @@ import type { AppWallet } from "@/components/app-wallets/AppWalletsContext";
 import { useAppWallets } from "@/components/app-wallets/AppWalletsContext";
 import { useAuth } from "@/components/auth/Auth";
 import { AppKitAdapterManager } from "@/components/providers/AppKitAdapterManager";
+import type { AppToastInput } from "@/components/utils/toast/AppToast";
 import { publicEnv } from "@/config/env";
 import { useAppWalletPasswordModal } from "@/hooks/useAppWalletPasswordModal";
 import { AppKitValidationError } from "@/src/errors/appkit-initialization";
@@ -28,6 +29,26 @@ import {
 } from "@/wagmiConfig/wagmiAppWalletConnector";
 import type { WagmiAdapter } from "@reown/appkit-adapter-wagmi";
 import type { Chain } from "viem";
+
+type MutableRef<T> = {
+  current: T;
+};
+
+type SetupAppKitAdapter = (wallets: AppWallet[]) => Promise<void>;
+
+type InitializeAdapterInput = {
+  readonly currentAdapter: WagmiAdapter | null;
+  readonly isInitializingRef: MutableRef<boolean>;
+  readonly setupAppKitAdapter: SetupAppKitAdapter;
+};
+
+type InjectAppWalletConnectorsInput = {
+  readonly currentAdapter: WagmiAdapter | null;
+  readonly appWallets: readonly AppWallet[];
+  readonly appWalletPasswordModal: ReturnType<typeof useAppWalletPasswordModal>;
+  readonly processedWallets: MutableRef<Set<string>>;
+  readonly setToast: (toast: AppToastInput) => void;
+};
 
 /**
  * Installs a defensive wrapper around `window.ethereum` (EIP-1193 provider).
@@ -144,6 +165,104 @@ function assertAppKitAdapterManager(value: unknown): AppKitAdapterManager {
   return value;
 }
 
+function initializeAdapterWhenNeeded({
+  currentAdapter,
+  isInitializingRef,
+  setupAppKitAdapter,
+}: InitializeAdapterInput): void {
+  if (currentAdapter !== null || isInitializingRef.current) {
+    return;
+  }
+
+  installSafeEthereumProxy();
+  // Prevent unhandled promise rejections during eager initialization.
+  // Fail-fast behavior is preserved by leaving `currentAdapter` unset.
+  void setupAppKitAdapter([]).catch(() => undefined);
+}
+
+function markAdapterReadyForLaunchTiming(
+  currentAdapter: WagmiAdapter | null
+): void {
+  if (currentAdapter === null) {
+    return;
+  }
+
+  markMobileLaunchStep("wagmi_children_unblocked");
+}
+
+function injectAppWalletConnectors({
+  currentAdapter,
+  appWallets,
+  appWalletPasswordModal,
+  processedWallets,
+  setToast,
+}: InjectAppWalletConnectorsInput): void {
+  if (currentAdapter === null) {
+    return;
+  }
+
+  // Check if wallets have actually changed to prevent unnecessary re-injection
+  const currentAddresses = new Set(appWallets.map((w) => w.address));
+  const addressesEqual =
+    processedWallets.current.size === currentAddresses.size &&
+    Array.from(processedWallets.current).every((addr) =>
+      currentAddresses.has(addr)
+    );
+
+  if (addressesEqual) {
+    return;
+  }
+
+  try {
+    // Create connectors for current wallets
+    const connectors = appWallets.flatMap((wallet) => {
+      try {
+        validateWalletSafely(wallet);
+        const connector = createAppWalletConnector(
+          Array.from(currentAdapter.wagmiConfig.chains),
+          { appWallet: wallet },
+          () =>
+            appWalletPasswordModal.requestPassword(
+              wallet.address,
+              wallet.address_hashed
+            )
+        );
+        const setupConnector =
+          currentAdapter.wagmiConfig._internal.connectors.setup(connector);
+        return [setupConnector];
+      } catch (error) {
+        logErrorSecurely(
+          `[WagmiSetup] Skipping invalid app-wallet connector ${wallet.address}`,
+          error
+        );
+        return [];
+      }
+    });
+
+    // Get existing non-app-wallet connectors
+    const existingConnectors = currentAdapter.wagmiConfig.connectors.filter(
+      (c) => c.id !== APP_WALLET_CONNECTOR_TYPE
+    );
+
+    // Update connector state with fail-fast approach
+    currentAdapter.wagmiConfig._internal.connectors.setState([
+      ...connectors,
+      ...existingConnectors,
+    ]);
+
+    // Update processed wallets tracking
+    processedWallets.current = currentAddresses;
+  } catch (error) {
+    logErrorSecurely("[WagmiSetup] Connector injection failed", error);
+    const userMessage = sanitizeErrorForUser(error);
+    setToast({
+      message: userMessage,
+      type: "error",
+    });
+    // Don't throw here - let the component continue but notify the user
+  }
+}
+
 export default function WagmiSetup({
   children,
 }: {
@@ -232,91 +351,29 @@ export default function WagmiSetup({
     [initializeAppKitWithWallets, setToast]
   );
 
-  /* eslint-disable react-you-might-not-need-an-effect/no-event-handler -- These effects synchronize imperative AppKit/Wagmi systems and launch telemetry with React state. */
   // Initialize adapter eagerly on mount with empty wallets
   useEffect(() => {
-    if (currentAdapter !== null || isInitializingRef.current) {
-      return;
-    }
-
-    installSafeEthereumProxy();
-    // Prevent unhandled promise rejections during eager initialization.
-    // Fail-fast behavior is preserved by leaving `currentAdapter` unset.
-    void setupAppKitAdapter([]).catch(() => undefined);
+    initializeAdapterWhenNeeded({
+      currentAdapter,
+      isInitializingRef,
+      setupAppKitAdapter,
+    });
   }, [currentAdapter, setupAppKitAdapter]);
 
   useEffect(() => {
-    if (currentAdapter === null) {
-      return;
-    }
-
-    markMobileLaunchStep("wagmi_children_unblocked");
+    markAdapterReadyForLaunchTiming(currentAdapter);
   }, [currentAdapter]);
 
   // Inject wallet connectors dynamically using hooks (simplified approach)
   useEffect(() => {
-    if (!currentAdapter) return;
-
-    // Check if wallets have actually changed to prevent unnecessary re-injection
-    const currentAddresses = new Set(appWallets.map((w) => w.address));
-    const addressesEqual =
-      processedWallets.current.size === currentAddresses.size &&
-      Array.from(processedWallets.current).every((addr) =>
-        currentAddresses.has(addr)
-      );
-
-    if (addressesEqual) return;
-
-    try {
-      // Create connectors for current wallets
-      const connectors = appWallets.flatMap((wallet) => {
-        try {
-          validateWalletSafely(wallet);
-          const connector = createAppWalletConnector(
-            Array.from(currentAdapter.wagmiConfig.chains),
-            { appWallet: wallet },
-            () =>
-              appWalletPasswordModal.requestPassword(
-                wallet.address,
-                wallet.address_hashed
-              )
-          );
-          const setupConnector =
-            currentAdapter.wagmiConfig._internal.connectors.setup(connector);
-          return [setupConnector];
-        } catch (error) {
-          logErrorSecurely(
-            `[WagmiSetup] Skipping invalid app-wallet connector ${wallet.address}`,
-            error
-          );
-          return [];
-        }
-      });
-
-      // Get existing non-app-wallet connectors
-      const existingConnectors = currentAdapter.wagmiConfig.connectors.filter(
-        (c) => c.id !== APP_WALLET_CONNECTOR_TYPE
-      );
-
-      // Update connector state with fail-fast approach
-      currentAdapter.wagmiConfig._internal.connectors.setState([
-        ...connectors,
-        ...existingConnectors,
-      ]);
-
-      // Update processed wallets tracking
-      processedWallets.current = currentAddresses;
-    } catch (error) {
-      logErrorSecurely("[WagmiSetup] Connector injection failed", error);
-      const userMessage = sanitizeErrorForUser(error);
-      setToast({
-        message: userMessage,
-        type: "error",
-      });
-      // Don't throw here - let the component continue but notify the user
-    }
+    injectAppWalletConnectors({
+      currentAdapter,
+      appWallets,
+      appWalletPasswordModal,
+      processedWallets,
+      setToast,
+    });
   }, [currentAdapter, appWallets, appWalletPasswordModal, setToast]);
-  /* eslint-enable react-you-might-not-need-an-effect/no-event-handler */
 
   // Show loading state until fully initialized
   if (currentAdapter === null) {

--- a/components/waves/layout/WavesLayout.tsx
+++ b/components/waves/layout/WavesLayout.tsx
@@ -23,6 +23,8 @@ const WAVES_CONTENT_STATE_PUBLIC = "not-authenticated";
 const WAVES_CONTENT_STATE_READY = "ready";
 const WAVES_CONTENT_STATE_LOADING = "loading";
 const WAVES_CONTENT_STATE_MEASURING = "measuring";
+const WAVES_CONTENT_STATE_NEEDS_PROFILE = "needs-profile";
+const WAVES_CONTENT_STATE_NOT_AVAILABLE = "not-available";
 
 function WavesBranchLoadingFallback() {
   return <div className="tw-flex tw-min-h-screen tw-flex-1 tw-bg-black" />;
@@ -37,7 +39,7 @@ const WavesDesktop = dynamic<WavesBranchProps>(
 
 function getConnectPrompt(contentState: WavesContentState): ReactNode {
   switch (contentState) {
-    case "needs-profile":
+    case WAVES_CONTENT_STATE_NEEDS_PROFILE:
       return (
         <>
           <h1 className="tw-text-xl tw-font-bold">
@@ -46,7 +48,7 @@ function getConnectPrompt(contentState: WavesContentState): ReactNode {
           <UserSetUpProfileCta />
         </>
       );
-    case "not-available":
+    case WAVES_CONTENT_STATE_NOT_AVAILABLE:
       return (
         <h1 className="tw-text-xl tw-font-bold">
           This content is not available.
@@ -59,6 +61,15 @@ function getConnectPrompt(contentState: WavesContentState): ReactNode {
     default:
       return null;
   }
+}
+
+function isResolvedWavesContentState(contentState: WavesContentState): boolean {
+  return (
+    contentState === WAVES_CONTENT_STATE_READY ||
+    contentState === WAVES_CONTENT_STATE_PUBLIC ||
+    contentState === WAVES_CONTENT_STATE_NEEDS_PROFILE ||
+    contentState === WAVES_CONTENT_STATE_NOT_AVAILABLE
+  );
 }
 
 function getWavesContent({
@@ -142,12 +153,7 @@ function WavesLayoutContent({ children }: { readonly children: ReactNode }) {
   }, [hasVisibleLaunchContent]);
 
   useEffect(() => {
-    if (
-      contentState !== "ready" &&
-      contentState !== "not-authenticated" &&
-      contentState !== "needs-profile" &&
-      contentState !== "not-available"
-    ) {
+    if (!isResolvedWavesContentState(contentState)) {
       return;
     }
 

--- a/components/waves/layout/WavesLayout.tsx
+++ b/components/waves/layout/WavesLayout.tsx
@@ -15,6 +15,15 @@ type WavesBranchProps = {
   readonly children: ReactNode;
 };
 
+type WavesContentState = ReturnType<
+  typeof useAuthenticatedContent
+>["contentState"];
+
+const WAVES_CONTENT_STATE_PUBLIC = "not-authenticated";
+const WAVES_CONTENT_STATE_READY = "ready";
+const WAVES_CONTENT_STATE_LOADING = "loading";
+const WAVES_CONTENT_STATE_MEASURING = "measuring";
+
 function WavesBranchLoadingFallback() {
   return <div className="tw-flex tw-min-h-screen tw-flex-1 tw-bg-black" />;
 }
@@ -26,9 +35,7 @@ const WavesDesktop = dynamic<WavesBranchProps>(
   }
 );
 
-function getConnectPrompt(
-  contentState: ReturnType<typeof useAuthenticatedContent>["contentState"]
-): ReactNode {
+function getConnectPrompt(contentState: WavesContentState): ReactNode {
   switch (contentState) {
     case "needs-profile":
       return (
@@ -45,10 +52,10 @@ function getConnectPrompt(
           This content is not available.
         </h1>
       );
-    case "loading":
-    case "measuring":
-    case "not-authenticated":
-    case "ready":
+    case WAVES_CONTENT_STATE_LOADING:
+    case WAVES_CONTENT_STATE_MEASURING:
+    case WAVES_CONTENT_STATE_PUBLIC:
+    case WAVES_CONTENT_STATE_READY:
     default:
       return null;
   }
@@ -92,18 +99,21 @@ function WavesLayoutContent({ children }: { readonly children: ReactNode }) {
     "tw-relative tw-flex tw-flex-col tw-flex-1 tailwind-scope";
   const connectPrompt = getConnectPrompt(contentState);
   const shouldRenderWavesContent =
-    contentState === "ready" ||
-    contentState === "not-authenticated" ||
-    contentState === "loading" ||
-    contentState === "measuring";
+    contentState === WAVES_CONTENT_STATE_READY ||
+    contentState === WAVES_CONTENT_STATE_PUBLIC ||
+    contentState === WAVES_CONTENT_STATE_LOADING ||
+    contentState === WAVES_CONTENT_STATE_MEASURING;
+  const hasUsefulWavesContent =
+    contentState === WAVES_CONTENT_STATE_READY ||
+    contentState === WAVES_CONTENT_STATE_PUBLIC;
   const hasVisibleLaunchContent =
-    shouldRenderWavesContent || connectPrompt !== null;
+    hasUsefulWavesContent || connectPrompt !== null;
 
   let content: ReactNode = null;
 
   if (shouldRenderWavesContent) {
     content = getWavesContent({
-      children: contentState === "loading" ? null : children,
+      children: contentState === WAVES_CONTENT_STATE_LOADING ? null : children,
       containerClassName,
       isApp,
     });

--- a/components/waves/layout/WavesLayout.tsx
+++ b/components/waves/layout/WavesLayout.tsx
@@ -4,6 +4,10 @@ import dynamic from "next/dynamic";
 import { useEffect, type ReactNode } from "react";
 import { useAuthenticatedContent } from "../../../hooks/useAuthenticatedContent";
 import useDeviceInfo from "../../../hooks/useDeviceInfo";
+import {
+  markMobileLaunchStep,
+  scheduleMobileLaunchFlush,
+} from "../../../utils/monitoring/mobileLaunchTiming";
 import UserSetUpProfileCta from "../../user/utils/set-up-profile/UserSetUpProfileCta";
 import WavesMobile from "../WavesMobile";
 
@@ -15,9 +19,12 @@ function WavesBranchLoadingFallback() {
   return <div className="tw-flex tw-min-h-screen tw-flex-1 tw-bg-black" />;
 }
 
-const WavesDesktop = dynamic<WavesBranchProps>(() => import("../WavesDesktop"), {
-  loading: () => <WavesBranchLoadingFallback />,
-});
+const WavesDesktop = dynamic<WavesBranchProps>(
+  () => import("../WavesDesktop"),
+  {
+    loading: () => <WavesBranchLoadingFallback />,
+  }
+);
 
 function getConnectPrompt(
   contentState: ReturnType<typeof useAuthenticatedContent>["contentState"]
@@ -89,6 +96,8 @@ function WavesLayoutContent({ children }: { readonly children: ReactNode }) {
     contentState === "not-authenticated" ||
     contentState === "loading" ||
     contentState === "measuring";
+  const hasVisibleLaunchContent =
+    shouldRenderWavesContent || connectPrompt !== null;
 
   let content: ReactNode = null;
 
@@ -108,6 +117,32 @@ function WavesLayoutContent({ children }: { readonly children: ReactNode }) {
         </div>
       );
   }
+
+  useEffect(() => {
+    markMobileLaunchStep("waves_layout_mounted");
+  }, []);
+
+  useEffect(() => {
+    if (!hasVisibleLaunchContent) {
+      return;
+    }
+
+    markMobileLaunchStep("waves_first_content_visible");
+    scheduleMobileLaunchFlush("waves_content_visible", 250);
+  }, [hasVisibleLaunchContent]);
+
+  useEffect(() => {
+    if (
+      contentState !== "ready" &&
+      contentState !== "not-authenticated" &&
+      contentState !== "needs-profile" &&
+      contentState !== "not-available"
+    ) {
+      return;
+    }
+
+    markMobileLaunchStep("waves_content_state_resolved");
+  }, [contentState]);
 
   return (
     <div className="tailwind-scope tw-flex tw-flex-col tw-overflow-hidden tw-bg-black">

--- a/utils/monitoring/mobileLaunchTiming.ts
+++ b/utils/monitoring/mobileLaunchTiming.ts
@@ -318,7 +318,7 @@ function nowMs(): number {
 }
 
 function getLaunchStartedAtMs(): number {
-  return 0;
+  return nowMs();
 }
 
 function elapsedSinceStart(state: LaunchState): number {
@@ -331,7 +331,7 @@ function roundMs(value: number): number {
 
 function createLaunchId(): string {
   try {
-    return crypto.randomUUID();
+    return globalThis.crypto.randomUUID();
   } catch {
     return `launch-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
   }

--- a/utils/monitoring/mobileLaunchTiming.ts
+++ b/utils/monitoring/mobileLaunchTiming.ts
@@ -33,14 +33,14 @@ export type MobileLaunchAuthState =
   | "stored_auth_disconnected"
   | "wallet_auth_disabled";
 
-export type MobileLaunchWalletConnectionState =
+type MobileLaunchWalletConnectionState =
   | "initializing"
   | "disconnected"
   | "connecting"
   | "connected"
   | "error";
 
-export type MobileLaunchAppWalletsState =
+type MobileLaunchAppWalletsState =
   | "supported_empty"
   | "supported_with_wallets"
   | "unsupported";
@@ -75,7 +75,7 @@ type DeviceInfoAttrs = {
   readonly web_view_version?: string;
 };
 
-export type MobileLaunchContext = {
+type MobileLaunchContext = {
   readonly app_wallet_count_bucket?: MobileLaunchAppWalletCountBucket;
   readonly app_wallets_state?: MobileLaunchAppWalletsState;
   readonly auth_state?: MobileLaunchAuthState;
@@ -259,7 +259,7 @@ export function scheduleMobileLaunchFlush(
   );
 }
 
-export function flushMobileLaunchTiming(reason: FlushReason = "manual"): void {
+function flushMobileLaunchTiming(reason: FlushReason = "manual"): void {
   const state = getActiveState();
   if (!state) {
     return;

--- a/utils/monitoring/mobileLaunchTiming.ts
+++ b/utils/monitoring/mobileLaunchTiming.ts
@@ -8,13 +8,44 @@ import {
 
 const SLOW_LAUNCH_MS = 3000;
 const NORMAL_SAMPLE_RATE = 0.05;
+const FOCUSED_ROUTE_SAMPLE_RATE = 1;
 const TIMEOUT_FLUSH_MS = 15000;
 const MAX_API_CALLS = 10;
 const SLOWEST_API_CALLS = 5;
 
-type FlushReason = "shell_paint" | "timeout" | "pagehide" | "error" | "manual";
+type FlushReason =
+  | "shell_paint"
+  | "waves_content_visible"
+  | "timeout"
+  | "pagehide"
+  | "error"
+  | "manual";
 
 type ApiStatus = number | "aborted" | "network_error" | "unknown";
+
+export type MobileLaunchAuthState =
+  | "anonymous"
+  | "authenticated_profile"
+  | "authenticated_proxy_profile"
+  | "authorized_wallet_no_profile"
+  | "connected_wallet_needs_auth"
+  | "initializing"
+  | "stored_auth_disconnected"
+  | "wallet_auth_disabled";
+
+export type MobileLaunchWalletConnectionState =
+  | "initializing"
+  | "disconnected"
+  | "connecting"
+  | "connected"
+  | "error";
+
+export type MobileLaunchAppWalletsState =
+  | "supported_empty"
+  | "supported_with_wallets"
+  | "unsupported";
+
+export type MobileLaunchAppWalletCountBucket = "0" | "1" | "2_5" | "6_plus";
 
 type StepTiming = {
   readonly offset_ms: number;
@@ -44,6 +75,13 @@ type DeviceInfoAttrs = {
   readonly web_view_version?: string;
 };
 
+export type MobileLaunchContext = {
+  readonly app_wallet_count_bucket?: MobileLaunchAppWalletCountBucket;
+  readonly app_wallets_state?: MobileLaunchAppWalletsState;
+  readonly auth_state?: MobileLaunchAuthState;
+  readonly wallet_connection_state?: MobileLaunchWalletConnectionState;
+};
+
 type LaunchState = {
   readonly launchId: string;
   readonly startedAtMs: number;
@@ -51,8 +89,10 @@ type LaunchState = {
   readonly appVersion: string;
   readonly steps: Record<string, StepTiming>;
   readonly apiCalls: CapturedApiTiming[];
+  context: MobileLaunchContext;
   apiTotalCount: number;
   deviceInfo?: DeviceInfoAttrs;
+  scheduledFlushId?: ReturnType<typeof setTimeout>;
   timeoutId?: ReturnType<typeof setTimeout>;
   flushed: boolean;
 };
@@ -65,6 +105,15 @@ type ApiRequestTimingInput = {
   readonly durationMs: number;
 };
 
+type BuildLaunchAttributesInput = {
+  readonly state: LaunchState;
+  readonly totalMs: number;
+  readonly slow: boolean;
+  readonly reason: FlushReason;
+  readonly routeFamily: string;
+  readonly sampleRate: number;
+};
+
 let launchState: LaunchState | null = null;
 
 export function startMobileLaunchTiming(): void {
@@ -72,15 +121,16 @@ export function startMobileLaunchTiming(): void {
     return;
   }
 
-  if (globalThis.window === undefined || !Capacitor.isNativePlatform()) {
+  if (typeof window === "undefined") {
     return;
   }
 
-  const startedAtMs = nowMs();
+  const isNative = isNativeCapacitorPlatform();
+  const startedAtMs = getLaunchStartedAtMs();
   launchState = {
     launchId: createLaunchId(),
     startedAtMs,
-    platform: Capacitor.getPlatform(),
+    platform: getLaunchPlatform(isNative),
     appVersion: publicEnv.VERSION ?? "unknown",
     steps: {
       start: {
@@ -88,13 +138,16 @@ export function startMobileLaunchTiming(): void {
       },
     },
     apiCalls: [],
+    context: {},
     apiTotalCount: 0,
     flushed: false,
   };
 
   addStepBreadcrumb("start", 0);
   registerFlushHandlers();
-  void captureDeviceInfo().catch(() => undefined);
+  if (isNative) {
+    void captureDeviceInfo().catch(() => undefined);
+  }
 }
 
 export function markMobileLaunchStep(stepName: string): void {
@@ -167,6 +220,45 @@ export function recordMobileLaunchApiRequest(
   }
 }
 
+export function setMobileLaunchContext(context: MobileLaunchContext): void {
+  const state = getActiveState();
+  if (!state) {
+    return;
+  }
+
+  state.context = {
+    ...state.context,
+    ...context,
+  };
+}
+
+export function scheduleMobileLaunchFlush(
+  reason: FlushReason = "manual",
+  delayMs = 0
+): void {
+  const state = getActiveState();
+  if (!state) {
+    return;
+  }
+
+  if (state.scheduledFlushId !== undefined) {
+    clearTimeout(state.scheduledFlushId);
+  }
+
+  state.scheduledFlushId = setTimeout(
+    () => {
+      const activeState = getActiveState();
+      if (!activeState) {
+        return;
+      }
+
+      delete activeState.scheduledFlushId;
+      flushMobileLaunchTiming(reason);
+    },
+    Math.max(0, delayMs)
+  );
+}
+
 export function flushMobileLaunchTiming(reason: FlushReason = "manual"): void {
   const state = getActiveState();
   if (!state) {
@@ -174,6 +266,10 @@ export function flushMobileLaunchTiming(reason: FlushReason = "manual"): void {
   }
 
   state.flushed = true;
+  if (state.scheduledFlushId !== undefined) {
+    clearTimeout(state.scheduledFlushId);
+    delete state.scheduledFlushId;
+  }
   if (state.timeoutId !== undefined) {
     clearTimeout(state.timeoutId);
     delete state.timeoutId;
@@ -182,13 +278,22 @@ export function flushMobileLaunchTiming(reason: FlushReason = "manual"): void {
   const totalMs = roundMs(elapsedSinceStart(state));
   const slow = totalMs >= SLOW_LAUNCH_MS;
   const warn = slow || reason === "timeout" || reason === "error";
-  const shouldLog = warn || Math.random() < NORMAL_SAMPLE_RATE;
+  const routeFamily = sanitizeRouteFamily(getCurrentPathname());
+  const sampleRate = getSampleRate(routeFamily, state.platform);
+  const shouldLog = warn || Math.random() < sampleRate;
 
   if (!shouldLog) {
     return;
   }
 
-  const attrs = buildLaunchAttributes(state, totalMs, slow, reason);
+  const attrs = buildLaunchAttributes({
+    state,
+    totalMs,
+    slow,
+    reason,
+    routeFamily,
+    sampleRate,
+  });
   if (warn) {
     Sentry.logger.warn("mobile_launch_timing", attrs);
     return;
@@ -205,10 +310,15 @@ function getActiveState(): LaunchState | null {
 }
 
 function nowMs(): number {
-  if (globalThis.performance?.now) {
-    return globalThis.performance.now();
+  if (typeof performance === "undefined") {
+    return Date.now();
   }
-  return Date.now();
+
+  return performance.now();
+}
+
+function getLaunchStartedAtMs(): number {
+  return 0;
 }
 
 function elapsedSinceStart(state: LaunchState): number {
@@ -220,19 +330,72 @@ function roundMs(value: number): number {
 }
 
 function createLaunchId(): string {
-  if (globalThis.crypto?.randomUUID) {
-    return globalThis.crypto.randomUUID();
+  try {
+    return crypto.randomUUID();
+  } catch {
+    return `launch-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
   }
-  return `launch-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function isNativeCapacitorPlatform(): boolean {
+  try {
+    return Capacitor.isNativePlatform();
+  } catch {
+    return false;
+  }
+}
+
+function getLaunchPlatform(isNative: boolean): string {
+  if (isNative) {
+    const platform = sanitizeShortValue(getNativePlatform());
+    return platform ? `capacitor_${platform}` : "capacitor_unknown";
+  }
+
+  return isLikelyMobileWeb() ? "web_mobile" : "web_desktop";
+}
+
+function getNativePlatform(): string | undefined {
+  try {
+    return Capacitor.getPlatform();
+  } catch {
+    return undefined;
+  }
+}
+
+function isLikelyMobileWeb(): boolean {
+  const navigatorWithUserAgentData = globalThis.navigator as
+    | (Navigator & { readonly userAgentData?: { readonly mobile?: boolean } })
+    | undefined;
+
+  if (navigatorWithUserAgentData?.userAgentData?.mobile === true) {
+    return true;
+  }
+
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return false;
+  }
+
+  return window.matchMedia("(pointer: coarse) and (max-width: 900px)").matches;
+}
+
+function getCurrentPathname(): string {
+  if (typeof window === "undefined") {
+    return "/";
+  }
+
+  return window.location.pathname || "/";
 }
 
 function registerFlushHandlers(): void {
   const state = launchState;
-  const browserWindow = globalThis.window;
-  if (!state || browserWindow === undefined) {
+  if (!state || typeof window === "undefined") {
     return;
   }
 
+  const browserWindow = window;
   state.timeoutId = setTimeout(() => {
     flushMobileLaunchTiming("timeout");
   }, TIMEOUT_FLUSH_MS);
@@ -328,24 +491,127 @@ function addStepBreadcrumb(stepName: string, offsetMs: number): void {
   });
 }
 
-function buildLaunchAttributes(
-  state: LaunchState,
-  totalMs: number,
-  slow: boolean,
-  reason: FlushReason
-): Record<string, unknown> {
+function buildLaunchAttributes({
+  state,
+  totalMs,
+  slow,
+  reason,
+  routeFamily,
+  sampleRate,
+}: BuildLaunchAttributesInput): Record<string, unknown> {
+  const context =
+    Object.keys(state.context).length > 0 ? { context: state.context } : {};
+
   return {
     launch_id: state.launchId,
     total_ms: totalMs,
     platform: state.platform,
     app_version: state.appVersion,
-    route_family: sanitizeRouteFamily(globalThis.location?.pathname ?? "/"),
+    route_family: routeFamily,
+    sample_rate: sampleRate,
     slow,
     flush_reason: reason,
+    ...buildMilestoneAttributes(state),
+    ...context,
     steps: state.steps,
     api: buildApiSummary(state),
     ...(state.deviceInfo ? { device: state.deviceInfo } : {}),
   };
+}
+
+function getSampleRate(routeFamily: string, platform: string): number {
+  if (isFocusedLaunchRoute(routeFamily) && platform !== "web_desktop") {
+    return FOCUSED_ROUTE_SAMPLE_RATE;
+  }
+
+  return NORMAL_SAMPLE_RATE;
+}
+
+function isFocusedLaunchRoute(routeFamily: string): boolean {
+  return (
+    routeFamily === "/waves" ||
+    routeFamily === "/waves/[wave]" ||
+    routeFamily === "/waves/create" ||
+    routeFamily === "/messages" ||
+    routeFamily === "/messages/[wave]" ||
+    routeFamily === "/messages/create"
+  );
+}
+
+function buildMilestoneAttributes(
+  state: LaunchState
+): Record<string, number | string> {
+  const attrs: Record<string, number | string> = {};
+  addStepOffsetAttr(attrs, state, "root_layout_reporter_mounted");
+  addStepOffsetAttr(attrs, state, "wagmi_capacitor_detected");
+  addStepOffsetAttr(attrs, state, "wagmi_init_start");
+  addStepOffsetAttr(attrs, state, "wagmi_adapter_created");
+  addStepOffsetAttr(attrs, state, "wagmi_ready");
+  addStepOffsetAttr(attrs, state, "wagmi_children_unblocked");
+  addStepOffsetAttr(attrs, state, "auth_provider_mounted");
+  addStepOffsetAttr(attrs, state, "auth_ready");
+  addStepOffsetAttr(attrs, state, "first_useful_app_shell");
+  addStepOffsetAttr(attrs, state, "waves_layout_mounted");
+  addStepOffsetAttr(attrs, state, "waves_first_content_visible");
+  addStepOffsetAttr(attrs, state, "waves_content_state_resolved");
+  addStepDurationAttr(attrs, state, "wagmi_appkit_init");
+  addStepDurationAttr(attrs, state, "wagmi_adapter_ready");
+  addStepDurationAttr(attrs, state, "auth_immediate_validation");
+  addStepDurationAttr(attrs, state, "app_wallets_secure_storage_support_check");
+  addStepDurationAttr(attrs, state, "app_wallets_load");
+
+  const wagmiUnblockedMs = getStepOffsetMs(state, "wagmi_children_unblocked");
+  const shellMs = getStepOffsetMs(state, "first_useful_app_shell");
+  const wavesContentMs = getStepOffsetMs(state, "waves_first_content_visible");
+
+  if (wagmiUnblockedMs !== undefined) {
+    attrs["provider_gate_ms"] = wagmiUnblockedMs;
+  }
+
+  if (shellMs !== undefined && wagmiUnblockedMs !== undefined) {
+    attrs["shell_after_wagmi_ms"] = roundMs(shellMs - wagmiUnblockedMs);
+  }
+
+  if (wavesContentMs !== undefined && wagmiUnblockedMs !== undefined) {
+    attrs["waves_after_wagmi_ms"] = roundMs(wavesContentMs - wagmiUnblockedMs);
+  }
+
+  return attrs;
+}
+
+function addStepOffsetAttr(
+  attrs: Record<string, number | string>,
+  state: LaunchState,
+  stepName: string
+): void {
+  const offsetMs = getStepOffsetMs(state, stepName);
+  if (offsetMs === undefined) {
+    return;
+  }
+
+  attrs[`step_${stepName}_ms`] = offsetMs;
+}
+
+function addStepDurationAttr(
+  attrs: Record<string, number | string>,
+  state: LaunchState,
+  stepName: string
+): void {
+  const durationMs = state.steps[stepName]?.duration_ms;
+  const status = state.steps[stepName]?.status;
+  if (durationMs !== undefined) {
+    attrs[`duration_${stepName}_ms`] = durationMs;
+  }
+  if (status !== undefined) {
+    attrs[`status_${stepName}`] = status;
+  }
+}
+
+function getStepOffsetMs(
+  state: LaunchState,
+  stepName: string
+): number | undefined {
+  return state.steps[stepName]?.offset_ms;
 }
 
 function buildApiSummary(state: LaunchState): Record<string, unknown> {

--- a/utils/monitoring/mobileLaunchTiming.ts
+++ b/utils/monitoring/mobileLaunchTiming.ts
@@ -115,6 +115,7 @@ type BuildLaunchAttributesInput = {
 };
 
 let launchState: LaunchState | null = null;
+let fallbackLaunchIdCounter = 0;
 
 export function startMobileLaunchTiming(): void {
   if (launchState !== null) {
@@ -280,7 +281,7 @@ function flushMobileLaunchTiming(reason: FlushReason = "manual"): void {
   const warn = slow || reason === "timeout" || reason === "error";
   const routeFamily = sanitizeRouteFamily(getCurrentPathname());
   const sampleRate = getSampleRate(routeFamily, state.platform);
-  const shouldLog = warn || Math.random() < sampleRate;
+  const shouldLog = warn || shouldSampleLaunch(sampleRate);
 
   if (!shouldLog) {
     return;
@@ -333,7 +334,31 @@ function createLaunchId(): string {
   try {
     return globalThis.crypto.randomUUID();
   } catch {
-    return `launch-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    // Fall through to the deterministic fallback below.
+  }
+
+  fallbackLaunchIdCounter += 1;
+  return `launch-${Date.now()}-${fallbackLaunchIdCounter}`;
+}
+
+function shouldSampleLaunch(sampleRate: number): boolean {
+  if (sampleRate >= 1) {
+    return true;
+  }
+  if (sampleRate <= 0) {
+    return false;
+  }
+
+  return getCryptoRandomUnit() < sampleRate;
+}
+
+function getCryptoRandomUnit(): number {
+  try {
+    const values = new Uint32Array(1);
+    globalThis.crypto.getRandomValues(values);
+    return (values[0] ?? 0) / 0x100000000;
+  } catch {
+    return 1;
   }
 }
 


### PR DESCRIPTION
## Issue
- Mobile `/waves` first-load work needs production timing data before we make riskier provider/bootstrap changes.
- Wagmi/AppKit, app-wallet loading, auth validation, shell paint, and waves-content visibility can all affect perceived launch time, but we did not have one compact timing event to compare them in production.

## Fix
- Add sampled Sentry launch timing instrumentation for mobile-focused routes, with focused sampling for waves/messages routes and low sampling elsewhere.
- Record sanitized timing milestones and coarse state buckets only, avoiding wallet addresses, tokens, signatures, cookies, local storage values, RPC details, or user content.

## Changes
- Add mobile launch timing utilities for milestones, measured async steps, API summaries, route families, sampling, and safe Sentry logging.
- Report provider/auth/app-wallet/Wagmi/AppKit/shell/waves-content milestones from the existing providers and waves layout.
- Add a small auth reporter component so auth timing context is collected without growing the main auth component further.
- Add focused unit coverage for launch timing sanitization, sampling, flush behavior, and API timing summaries.

## Validation
- `6529 run test -- __tests__/utils/monitoring/mobileLaunchTiming.test.ts`
- `6529 run typecheck:ci`
- `6529 run lint:diff`
- `6529 run lint:uncommitted:tight`
- `6529 run react-doctor:diff` returned 99/100 with one existing-style warning in the app-wallet effect.
- `6529 run build`
- Desktop Chrome smoke: `/waves` rendered non-blank with wave list content. I did not sign wallet/auth prompts.
- iOS simulator smoke through the native shell: home rendered, bottom `Waves` nav tapped, `/waves` rendered with the all-waves list.

## Risk
- Level: Medium
- Why: touches shared providers and auth/wallet-adjacent timing paths, but only adds telemetry and strict-lint cleanup. Sensitive values are bucketed or sanitized before logging.
- Rollback: revert the PR or disable/adjust sampling in the timing utility if Sentry volume or event shape is wrong.

## Review Notes
- Please focus on privacy of emitted attributes, whether the timing milestones are placed at the right provider boundaries, and whether the sampling volume is appropriate for production observation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer mobile launch monitoring across app, including auth state reporting and app-wallet support status (supported/unsupported, with wallet count bucketing).
  * Enhanced content-visibility telemetry for Waves, including “first content visible” and delayed “content visible” signals.
* **Bug Fixes**
  * Improved mobile launch timing capture for web launches and standardized flush behavior to ensure the latest scheduled event is reported once.
  * Improved wallet/auth initialization flow to avoid incomplete state updates and ensure correct timing attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->