### PR TITLE
[codex] Lazy-load emoji runtime data

### DIFF
--- a/__tests__/components/DefaultWinnerDrop.test.tsx
+++ b/__tests__/components/DefaultWinnerDrop.test.tsx
@@ -1,6 +1,7 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import DefaultWinnerDrop from "@/components/waves/drops/winner/DefaultWinnerDrop";
+import { EmojiProvider } from "@/contexts/EmojiContext";
 import React from "react";
 
 jest.mock("next/navigation", () => ({
@@ -52,6 +53,9 @@ jest.mock("@/hooks/useIsTouchDevice", () => ({
   __esModule: true,
   default: (...args: any[]) => mockUseIsTouchDevice(...args),
 }));
+
+const renderWithEmojiProvider = (ui: React.ReactElement) =>
+  render(ui, { wrapper: EmojiProvider });
 
 const HOVER_INPUT_MEDIA_QUERIES = new Set([
   "(any-hover: hover)",
@@ -108,7 +112,7 @@ describe("DefaultWinnerDrop", () => {
     const onReply = jest.fn();
     setHoverSupport(true);
 
-    render(
+    renderWithEmojiProvider(
       <DefaultWinnerDrop
         drop={drop}
         previousDrop={null}
@@ -129,7 +133,7 @@ describe("DefaultWinnerDrop", () => {
   });
 
   it("renders identity and filtered metadata when provided", () => {
-    const { container } = render(
+    const { container } = renderWithEmojiProvider(
       <DefaultWinnerDrop
         drop={{
           ...drop,
@@ -165,7 +169,7 @@ describe("DefaultWinnerDrop", () => {
   });
 
   it("renders vote details through the shared ratings row when there are raters", () => {
-    render(
+    renderWithEmojiProvider(
       <DefaultWinnerDrop
         drop={{ ...drop, raters_count: 4 }}
         previousDrop={null}
@@ -197,7 +201,7 @@ describe("DefaultWinnerDrop", () => {
       maxEmbedDepth: 4,
     };
 
-    render(
+    renderWithEmojiProvider(
       <DefaultWinnerDrop
         drop={drop}
         previousDrop={null}
@@ -225,7 +229,7 @@ describe("DefaultWinnerDrop", () => {
     setViewportWidth(1440);
     setHoverSupport(false);
 
-    const { rerender } = render(
+    const { rerender } = renderWithEmojiProvider(
       <DefaultWinnerDrop
         drop={drop}
         previousDrop={null}
@@ -290,7 +294,7 @@ describe("DefaultWinnerDrop", () => {
       />
     );
 
-    const { rerender } = render(renderDrop());
+    const { rerender } = renderWithEmojiProvider(renderDrop());
     const onLongPress = mockWaveDropContent.mock.calls.at(-1)?.[0]?.onLongPress;
 
     act(() => {
@@ -316,7 +320,7 @@ describe("DefaultWinnerDrop", () => {
     setViewportWidth(1440);
     setHoverSupport(false);
 
-    render(
+    renderWithEmojiProvider(
       <DefaultWinnerDrop
         drop={drop}
         previousDrop={null}

--- a/__tests__/components/drops/create/lexical/plugins/emoji/EmojiPlugin.test.tsx
+++ b/__tests__/components/drops/create/lexical/plugins/emoji/EmojiPlugin.test.tsx
@@ -1,22 +1,24 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import EmojiPlugin, { EMOJI_MATCH_REGEX } from '@/components/drops/create/lexical/plugins/emoji/EmojiPlugin';
-import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext';
-import { useEmoji } from '@/contexts/EmojiContext';
+import React from "react";
+import { render } from "@testing-library/react";
+import EmojiPlugin, {
+  EMOJI_MATCH_REGEX,
+} from "@/components/drops/create/lexical/plugins/emoji/EmojiPlugin";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { useEmoji } from "@/contexts/EmojiContext";
 
-jest.mock('@lexical/react/LexicalComposerContext', () => ({
+jest.mock("@lexical/react/LexicalComposerContext", () => ({
   useLexicalComposerContext: jest.fn(),
 }));
 
-jest.mock('@/components/drops/create/lexical/nodes/EmojiNode', () => ({
+jest.mock("@/components/drops/create/lexical/nodes/EmojiNode", () => ({
   EmojiNode: class {},
 }));
 
-jest.mock('@/contexts/EmojiContext', () => ({
+jest.mock("@/contexts/EmojiContext", () => ({
   useEmoji: jest.fn(),
 }));
 
-jest.mock('lexical', () => {
+jest.mock("lexical", () => {
   class MockTextNode {
     private text: string;
 
@@ -37,7 +39,7 @@ jest.mock('lexical', () => {
     remove() {}
 
     getKey() {
-      return 'key';
+      return "key";
     }
   }
 
@@ -62,28 +64,50 @@ beforeEach(() => {
   useEmojiMock.mockReturnValue({
     emojiMap: [
       {
-        id: 'custom',
-        name: 'custom',
-        category: 'custom',
-        emojis: [{ id: 'smile', name: 'Smile', keywords: 'happy', skins: [{ src: '' }] }],
+        id: "custom",
+        name: "custom",
+        category: "custom",
+        emojis: [
+          {
+            id: "smile",
+            name: "Smile",
+            keywords: "happy",
+            skins: [{ src: "" }],
+          },
+        ],
       },
     ],
     loading: false,
     categories: [],
     categoryIcons: {},
+    emojiData: null,
     findNativeEmoji: jest.fn(() => null),
-    findCustomEmoji: jest.fn((id: string) => (id.replaceAll(':', '') === 'smile' ? { id: 'smile', name: 'Smile', keywords: 'happy', skins: [{ src: '' }] } : null)),
+    findCustomEmoji: jest.fn((id: string) =>
+      id.replaceAll(":", "") === "smile"
+        ? {
+            id: "smile",
+            name: "Smile",
+            keywords: "happy",
+            skins: [{ src: "" }],
+          }
+        : null
+    ),
+    loadCustomEmojis: jest.fn(() => Promise.resolve([])),
+    loadNativeEmojis: jest.fn(() => Promise.resolve(null)),
+    loadEmojiData: jest.fn(() => Promise.resolve()),
   });
 });
 
-describe('EmojiPlugin', () => {
-  it('matches emoji regex correctly', () => {
-    const text = 'say :smile: and :joy:';
-    const matches = Array.from(text.matchAll(EMOJI_MATCH_REGEX)).map((match) => match[1]);
-    expect(matches).toEqual(['smile', 'joy']);
+describe("EmojiPlugin", () => {
+  it("matches emoji regex correctly", () => {
+    const text = "say :smile: and :joy:";
+    const matches = Array.from(text.matchAll(EMOJI_MATCH_REGEX)).map(
+      (match) => match[1]
+    );
+    expect(matches).toEqual(["smile", "joy"]);
   });
 
-  it('calls update when emoji text detected', () => {
+  it("calls update when emoji text detected", () => {
     let listener: (text: string) => void = () => undefined;
     const update = jest.fn((callback: () => void) => callback());
     const editor = {
@@ -99,11 +123,11 @@ describe('EmojiPlugin', () => {
 
     expect(update).toHaveBeenCalledTimes(1);
 
-    listener('hello :smile:');
+    listener("hello :smile:");
     expect(update).toHaveBeenCalledTimes(2);
   });
 
-  it('does not update when listener text has no colon', () => {
+  it("does not update when listener text has no colon", () => {
     const update = jest.fn((callback: () => void) => callback());
     const register = jest.fn(() => () => undefined);
 
@@ -117,13 +141,13 @@ describe('EmojiPlugin', () => {
     render(<EmojiPlugin />);
 
     const listener = register.mock.calls[0][0] as (text: string) => void;
-    listener('nothing');
+    listener("nothing");
 
     expect(update).toHaveBeenCalledTimes(1);
   });
 
-  it('regex captures id including surrounding colons', () => {
-    const match = ':smile:'.match(EMOJI_MATCH_REGEX);
-    expect(match?.[0]).toBe(':smile:');
+  it("regex captures id including surrounding colons", () => {
+    const match = ":smile:".match(EMOJI_MATCH_REGEX);
+    expect(match?.[0]).toBe(":smile:");
   });
 });

--- a/__tests__/components/waves/CreateDropEmojiPicker.test.tsx
+++ b/__tests__/components/waves/CreateDropEmojiPicker.test.tsx
@@ -69,11 +69,15 @@ describe("CreateDropEmojiPicker", () => {
     // Emoji context defaults (unused here)
     mockUseEmoji.mockReturnValue({
       emojiMap: [],
+      emojiData: {},
       categories: [],
       categoryIcons: {},
       loading: false,
       findNativeEmoji: jest.fn(),
       findCustomEmoji: jest.fn(),
+      loadCustomEmojis: jest.fn(() => Promise.resolve([])),
+      loadNativeEmojis: jest.fn(() => Promise.resolve({})),
+      loadEmojiData: jest.fn(() => Promise.resolve()),
     });
     // Default to desktop
     mockUseIsMobile.mockReturnValue(false);
@@ -148,6 +152,33 @@ describe("CreateDropEmojiPicker", () => {
     expect(screen.queryByTestId("picker")).toBeNull();
   });
 
+  it("shows an unavailable status when native emoji data cannot load", async () => {
+    mockUseEmoji.mockReturnValue({
+      emojiMap: [],
+      emojiData: null,
+      categories: [],
+      categoryIcons: {},
+      loading: false,
+      findNativeEmoji: jest.fn(),
+      findCustomEmoji: jest.fn(),
+      loadCustomEmojis: jest.fn(() => Promise.resolve([])),
+      loadNativeEmojis: jest.fn(() => Promise.resolve(null)),
+      loadEmojiData: jest.fn(() => Promise.resolve()),
+    });
+
+    render(<CreateDropEmojiPicker />);
+    const toggleButton = screen.getByRole("button", { hidden: true });
+
+    fireEvent.click(toggleButton);
+
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Emoji picker is unavailable."
+      )
+    );
+    expect(screen.queryByTestId("picker")).toBeNull();
+  });
+
   it("closes an open picker when disabled and keeps it closed when re-enabled", async () => {
     const { rerender } = render(<CreateDropEmojiPicker />);
     const toggleButton = screen.getByRole("button", { hidden: true });
@@ -181,7 +212,7 @@ describe("CreateDropEmojiPicker", () => {
     expect(mobileDialog).toBeInTheDocument();
 
     // Emoji pick action
-    const picker = screen.getByTestId("picker");
+    const picker = await screen.findByTestId("picker");
     fireEvent.click(picker);
     expect(fakeEditor.update).toHaveBeenCalled();
     await waitFor(() =>

--- a/__tests__/components/waves/drops/WaveDropActionsAddReaction.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropActionsAddReaction.test.tsx
@@ -17,6 +17,11 @@ const mobileWrapperDialogMock = jest.fn(
       </div>
     ) : null
 );
+const mockLoadCustomEmojis = jest.fn(() => Promise.resolve([]));
+const mockLoadNativeEmojis = jest.fn(() => Promise.resolve({}));
+const mockLoadEmojiData = jest.fn(() => Promise.resolve());
+const mockFindNativeEmoji = jest.fn();
+const mockFindCustomEmoji = jest.fn();
 
 jest.mock("@/contexts/wave/MyStreamContext", () => ({
   useMyStream: jest.fn(() => ({
@@ -90,11 +95,15 @@ jest.mock("@emoji-mart/data", () => ({
 jest.mock("@/contexts/EmojiContext", () => ({
   useEmoji: jest.fn(() => ({
     emojiMap: [],
+    emojiData: {},
     categories: [],
     categoryIcons: {},
     loading: false,
-    findNativeEmoji: jest.fn(),
-    findCustomEmoji: jest.fn(),
+    findNativeEmoji: mockFindNativeEmoji,
+    findCustomEmoji: mockFindCustomEmoji,
+    loadCustomEmojis: mockLoadCustomEmojis,
+    loadNativeEmojis: mockLoadNativeEmojis,
+    loadEmojiData: mockLoadEmojiData,
   })),
 }));
 

--- a/__tests__/components/waves/drops/WaveDropReactions.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropReactions.test.tsx
@@ -53,6 +53,7 @@ jest.mock(
 );
 
 jest.mock("@tanstack/react-query", () => ({
+  useQuery: jest.fn(),
   useQueryClient: jest.fn(() => ({
     getQueryCache: jest.fn(() => ({ findAll: mockQueryCacheFindAll })),
     setQueryData: mockSetQueryData,
@@ -144,6 +145,7 @@ const createEmojiContextValue = (
   findNativeEmoji: (id: string) => NativeEmojiMock | null = () => null
 ) => ({
   emojiMap,
+  emojiData: {},
   loading: false,
   categories: [],
   categoryIcons: {},
@@ -158,6 +160,9 @@ const createEmojiContextValue = (
     }
     return null;
   },
+  loadCustomEmojis: jest.fn(() => Promise.resolve(emojiMap)),
+  loadNativeEmojis: jest.fn(() => Promise.resolve({})),
+  loadEmojiData: jest.fn(() => Promise.resolve()),
 });
 
 const createMockDrop = (overrides: Record<string, unknown> = {}) => ({

--- a/__tests__/contexts/EmojiContext.test.tsx
+++ b/__tests__/contexts/EmojiContext.test.tsx
@@ -1,12 +1,29 @@
 import React from "react";
-import { render, renderHook, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { EmojiProvider, useEmoji } from "@/contexts/EmojiContext";
 
 // Mock fetch
 global.fetch = jest.fn();
 
-// Mock @emoji-mart/data
 jest.mock("@emoji-mart/data", () => ({
+  __esModule: true,
+  default: {
+    emojis: {
+      smile: {
+        id: "smile",
+        name: "Smile",
+        keywords: "smiling face",
+        skins: [{ native: "😊" }],
+      },
+    },
+  },
   emojis: {
     smile: {
       id: "smile",
@@ -19,11 +36,20 @@ jest.mock("@emoji-mart/data", () => ({
 
 // Test component to consume the context
 const TestComponent = () => {
-  const { emojiMap, loading, categories, categoryIcons, findNativeEmoji } =
-    useEmoji();
+  const {
+    emojiMap,
+    loading,
+    categories,
+    categoryIcons,
+    findNativeEmoji,
+    loadEmojiData,
+  } = useEmoji();
 
   return (
     <div>
+      <button type="button" onClick={() => void loadEmojiData()}>
+        Load emoji
+      </button>
       <div data-testid="loading">{loading ? "loading" : "loaded"}</div>
       <div data-testid="categories">{categories.join(",")}</div>
       <div data-testid="categoryIcons">
@@ -39,10 +65,11 @@ const TestComponent = () => {
 
 describe("EmojiContext", () => {
   beforeEach(() => {
+    globalThis.__resetEmojiContextCachesForTests?.();
     jest.resetAllMocks();
   });
 
-  it("provides default values and fetches emojis successfully", async () => {
+  it("provides defaults and loads emojis on demand", async () => {
     const fakeEmojiList = JSON.stringify(["smile", "grin"]);
     (fetch as jest.Mock).mockResolvedValueOnce({
       ok: true,
@@ -55,24 +82,37 @@ describe("EmojiContext", () => {
       </EmojiProvider>
     );
 
-    expect(screen.getByTestId("loading").textContent).toBe("loading");
+    expect(fetch).not.toHaveBeenCalled();
+    expect(screen.getByTestId("loading").textContent).toBe("loaded");
+    expect(screen.getByTestId("emojiMap").textContent).toBe("0");
+    expect(screen.getByTestId("nativeEmoji").textContent).toBe("");
 
-    // Wait for fetch to complete
-    await waitFor(() =>
-      expect(screen.getByTestId("loading").textContent).toBe("loaded")
-    );
-    expect(screen.getByTestId("emojiMap").textContent).toBe("1");
+    fireEvent.click(screen.getByRole("button", { name: /load emoji/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("nativeEmoji").textContent).toBe("😊");
+      expect(screen.getByTestId("emojiMap").textContent).toBe("1");
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("loading").textContent).toBe("loaded");
     expect(screen.getByTestId("categories").textContent).toContain("6529");
     expect(screen.getByTestId("categoryIcons").textContent).toContain("6529");
-    expect(screen.getByTestId("nativeEmoji").textContent).toBe("😊");
   });
 
-  it("handles fetch failure gracefully", async () => {
-    (fetch as jest.Mock).mockResolvedValueOnce({
-      ok: false,
-    });
+  it("handles fetch failure gracefully and retries later", async () => {
+    const fakeEmojiList = JSON.stringify(["retry_smile"]);
+    (fetch as jest.Mock)
+      .mockResolvedValueOnce({
+        ok: false,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => JSON.parse(fakeEmojiList),
+      });
 
-    console.error = jest.fn(); // suppress expected error logs
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
 
     render(
       <EmojiProvider>
@@ -80,12 +120,21 @@ describe("EmojiContext", () => {
       </EmojiProvider>
     );
 
-    expect(screen.getByTestId("loading").textContent).toBe("loading");
+    expect(fetch).not.toHaveBeenCalled();
 
-    await waitFor(() =>
-      expect(screen.getByTestId("loading").textContent).toBe("loaded")
-    );
+    fireEvent.click(screen.getByRole("button", { name: /load emoji/i }));
+
+    await waitFor(() => expect(consoleErrorSpy).toHaveBeenCalled());
+    expect(fetch).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId("emojiMap").textContent).toBe("0");
+
+    fireEvent.click(screen.getByRole("button", { name: /load emoji/i }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(screen.getByTestId("emojiMap").textContent).toBe("1");
+    });
+    consoleErrorSpy.mockRestore();
   });
 
   it("throws error if useEmoji is used outside of provider", () => {
@@ -99,14 +148,13 @@ describe("EmojiContext", () => {
     );
   });
 
-  it("findNativeEmoji returns null if emoji not found", () => {
-    const fakeEmojiData = {
-      emojis: {},
-    };
-    jest.doMock("@emoji-mart/data", () => fakeEmojiData);
-
+  it("findNativeEmoji returns null if emoji not found", async () => {
     const { result } = renderHook(() => useEmoji(), {
       wrapper: ({ children }) => <EmojiProvider>{children}</EmojiProvider>,
+    });
+
+    await act(async () => {
+      await result.current.loadNativeEmojis();
     });
 
     const native = result.current.findNativeEmoji("nonexistent");

--- a/__tests__/playwright/readonlyMutationGuard.test.ts
+++ b/__tests__/playwright/readonlyMutationGuard.test.ts
@@ -227,6 +227,18 @@ describe("Playwright read-only mutation guard", () => {
         baseURL: "https://staging.6529.io",
         method: "POST",
         readonly: true,
+        url: "https://region1.google-analytics.com/g/collect?v=2",
+      })
+    ).toMatchObject({
+      action: "abort",
+      reason: "ignored-external-sdk-endpoint",
+    });
+
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://staging.6529.io",
+        method: "POST",
+        readonly: true,
         url: "https://www.googletagmanager.com/td?cid=redacted",
       })
     ).toMatchObject({

--- a/components/drops/create/lexical/nodes/EmojiNode.tsx
+++ b/components/drops/create/lexical/nodes/EmojiNode.tsx
@@ -3,10 +3,10 @@ import type {
   Spread,
   LexicalEditor,
   EditorConfig,
-  NodeKey} from "lexical";
-import {
-  DecoratorNode
+  NodeKey,
 } from "lexical";
+import { DecoratorNode } from "lexical";
+import Image from "next/image";
 import { createElement, type JSX } from "react";
 import { useEmoji } from "@/contexts/EmojiContext";
 
@@ -41,8 +41,7 @@ export class EmojiNode extends DecoratorNode<JSX.Element> {
   }
 
   override createDOM(_config: EditorConfig): HTMLElement {
-    const span = document.createElement("span");
-    return span;
+    return document.createElement("span");
   }
 
   override updateDOM(
@@ -86,5 +85,21 @@ const EmojiComponent = ({ emojiId }: { emojiId: string }) => {
     return <span>{`:${emojiId}:`}</span>;
   }
 
-  return <img src={emoji.skins[0]?.src} alt={emojiId} className="emoji-node" />;
+  const emojiSrc = emoji.skins[0]?.src;
+  if (!emojiSrc) {
+    return <span>{`:${emojiId}:`}</span>;
+  }
+
+  const emojiLabel = emojiId.replaceAll("_", " ");
+
+  return (
+    <Image
+      src={emojiSrc}
+      alt={emojiLabel}
+      width={20}
+      height={20}
+      unoptimized
+      className="emoji-node"
+    />
+  );
 };

--- a/components/drops/create/lexical/plugins/emoji/EmojiPlugin.ts
+++ b/components/drops/create/lexical/plugins/emoji/EmojiPlugin.ts
@@ -17,111 +17,184 @@ import { useEmoji } from "@/contexts/EmojiContext";
 const EMOJI_TEST_REGEX = /:(\w+)/;
 export const EMOJI_MATCH_REGEX = /:(\w+):/g;
 
+type EmojiMatch = {
+  readonly matchText: string;
+  readonly emojiId: string;
+  readonly startIndex: number;
+  readonly endIndex: number;
+};
+
+type SelectionSnapshot = {
+  readonly anchorNodeKey: string | null;
+  readonly anchorOffset: number;
+};
+
+type ReplacementNodes = {
+  readonly nodes: (TextNode | EmojiNode)[];
+  readonly cursorNode: TextNode | null;
+};
+
+const getSelectionSnapshot = (): SelectionSnapshot => {
+  const selection = $getSelection();
+
+  if (!$isRangeSelection(selection)) {
+    return { anchorNodeKey: null, anchorOffset: 0 };
+  }
+
+  const anchorNode = selection.anchor.getNode();
+  return {
+    anchorNodeKey: anchorNode.getKey(),
+    anchorOffset: selection.anchor.offset,
+  };
+};
+
+const getEmojiMatches = (textContent: string): EmojiMatch[] =>
+  Array.from(textContent.matchAll(EMOJI_MATCH_REGEX), (match) => ({
+    matchText: match[0],
+    emojiId: match[1] ?? "",
+    startIndex: match.index,
+    endIndex: match.index + match[0].length,
+  }));
+
+const shouldPlaceCursorAfterEmoji = ({
+  match,
+  node,
+  selection,
+}: {
+  readonly match: EmojiMatch;
+  readonly node: TextNode;
+  readonly selection: SelectionSnapshot;
+}): boolean =>
+  selection.anchorNodeKey === node.getKey() &&
+  selection.anchorOffset >= match.startIndex &&
+  selection.anchorOffset <= match.endIndex;
+
+const appendTrailingText = ({
+  lastIndex,
+  nodes,
+  textContent,
+}: {
+  readonly lastIndex: number;
+  readonly nodes: (TextNode | EmojiNode)[];
+  readonly textContent: string;
+}) => {
+  if (lastIndex >= textContent.length) {
+    return;
+  }
+
+  const afterText = textContent.slice(lastIndex);
+  const lastCreated = nodes.at(-1);
+  if (lastCreated instanceof TextNode) {
+    lastCreated.setTextContent(lastCreated.getTextContent() + afterText);
+    return;
+  }
+
+  nodes.push(new TextNode(afterText));
+};
+
+const createReplacementNodes = ({
+  isEmojiIdValid,
+  matches,
+  node,
+  selection,
+  textContent,
+}: {
+  readonly isEmojiIdValid: (emojiId: string) => boolean;
+  readonly matches: EmojiMatch[];
+  readonly node: TextNode;
+  readonly selection: SelectionSnapshot;
+  readonly textContent: string;
+}): ReplacementNodes | null => {
+  let lastIndex = 0;
+  const nodes: (TextNode | EmojiNode)[] = [];
+  let cursorNode: TextNode | null = null;
+
+  for (const match of matches) {
+    if (match.startIndex > lastIndex) {
+      const beforeText = textContent.slice(lastIndex, match.startIndex);
+      if (beforeText.length > 0) {
+        nodes.push(new TextNode(beforeText));
+      }
+    }
+
+    if (!isEmojiIdValid(match.emojiId)) {
+      nodes.push(new TextNode(match.matchText));
+      return null;
+    }
+
+    nodes.push(new EmojiNode(match.emojiId));
+
+    const trailingTextNode = new TextNode(" ");
+    nodes.push(trailingTextNode);
+
+    if (shouldPlaceCursorAfterEmoji({ match, node, selection })) {
+      cursorNode = trailingTextNode;
+    }
+
+    lastIndex = match.endIndex;
+  }
+
+  appendTrailingText({ lastIndex, nodes, textContent });
+
+  return { nodes, cursorNode };
+};
+
+const replaceTextNode = (
+  node: TextNode,
+  replacementNodes: readonly (TextNode | EmojiNode)[]
+) => {
+  let previousNode: TextNode | EmojiNode = node;
+  for (const replacementNode of replacementNodes) {
+    previousNode.insertAfter(replacementNode);
+    previousNode = replacementNode;
+  }
+
+  node.remove();
+};
+
+const restoreCursor = (cursorNode: TextNode | null) => {
+  if (cursorNode === null) {
+    return;
+  }
+
+  const cursorTextNodeKey = cursorNode.getKey();
+  const newSelection = $createRangeSelection();
+  newSelection.anchor.set(cursorTextNodeKey, 0, "text");
+  newSelection.focus.set(cursorTextNodeKey, 0, "text");
+  $setSelection(newSelection);
+};
+
 function transformEmojiTextToNode(
   editor: LexicalEditor,
   isEmojiIdValid: (emojiId: string) => boolean
 ) {
   editor.update(() => {
-    const selectionBefore = $getSelection();
-    let anchorNodeKey: string | null = null;
-    let anchorOffset = 0;
+    const selection = getSelectionSnapshot();
 
-    if ($isRangeSelection(selectionBefore)) {
-      const anchorNode = selectionBefore.anchor.getNode();
-      anchorNodeKey = anchorNode.getKey();
-      anchorOffset = selectionBefore.anchor.offset;
-    }
-
-    const root = $getRoot();
-    const textNodes = root.getAllTextNodes();
-
-    for (const node of textNodes) {
+    for (const node of $getRoot().getAllTextNodes()) {
       const textContent = node.getTextContent();
       if (!EMOJI_TEST_REGEX.test(textContent)) {
         continue;
       }
 
-      const matches = Array.from(textContent.matchAll(EMOJI_MATCH_REGEX)).map(
-        (match) => ({
-          matchText: match[0],
-          emojiId: match[1],
-          startIndex: match.index!,
-          endIndex: match.index! + match[0].length,
-        })
-      );
-
-      if (matches.length === 0) {
+      const matches = getEmojiMatches(textContent);
+      if (!matches.some(({ emojiId }) => isEmojiIdValid(emojiId))) {
         return;
       }
 
-      const hasValidEmoji = matches.some(({ emojiId }) =>
-        isEmojiIdValid(emojiId!)
-      );
-
-      if (!hasValidEmoji) {
+      const replacement = createReplacementNodes({
+        isEmojiIdValid,
+        matches,
+        node,
+        selection,
+        textContent,
+      });
+      if (replacement === null) {
         return;
       }
 
-      let lastIndex = 0;
-      const newNodes: (TextNode | EmojiNode)[] = [];
-      let cursorNode: TextNode | null = null;
-
-      for (const { matchText, emojiId, startIndex, endIndex } of matches) {
-        if (startIndex > lastIndex) {
-          const beforeStr = textContent.slice(lastIndex, startIndex);
-          if (beforeStr.length > 0) {
-            newNodes.push(new TextNode(beforeStr));
-          }
-        }
-
-        if (!isEmojiIdValid(emojiId!)) {
-          newNodes.push(new TextNode(matchText));
-          lastIndex = endIndex;
-          return;
-        }
-
-        const emojiNode = new EmojiNode(emojiId!);
-        newNodes.push(emojiNode);
-
-        const trailingTextNode = new TextNode(" ");
-        newNodes.push(trailingTextNode);
-
-        if (
-          anchorNodeKey === node.getKey() &&
-          anchorOffset >= startIndex &&
-          anchorOffset <= endIndex
-        ) {
-          cursorNode = trailingTextNode;
-        }
-
-        lastIndex = endIndex;
-      }
-
-      if (lastIndex < textContent.length) {
-        const afterStr = textContent.slice(lastIndex);
-        const lastCreated = newNodes.at(-1);
-        if (lastCreated instanceof TextNode) {
-          lastCreated.setTextContent(lastCreated.getTextContent() + afterStr);
-        } else {
-          newNodes.push(new TextNode(afterStr));
-        }
-      }
-
-      let prev: TextNode | EmojiNode = node;
-      for (const newNode of newNodes) {
-        prev.insertAfter(newNode);
-        prev = newNode;
-      }
-
-      node.remove();
-
-      if (cursorNode) {
-        const cursorTextNodeKey = (cursorNode as TextNode).getKey();
-        const newSelection = $createRangeSelection();
-        newSelection.anchor.set(cursorTextNodeKey, 0, "text");
-        newSelection.focus.set(cursorTextNodeKey, 0, "text");
-        $setSelection(newSelection);
-      }
+      replaceTextNode(node, replacement.nodes);
+      restoreCursor(replacement.cursorNode);
     }
   });
 }
@@ -132,7 +205,7 @@ const EmojiPlugin = ({
   readonly disabled?: boolean | undefined;
 }) => {
   const [editor] = useLexicalComposerContext();
-  const { emojiMap, findNativeEmoji } = useEmoji();
+  const { emojiMap, findNativeEmoji, loadEmojiData } = useEmoji();
 
   const customEmojiIds = useMemo(() => {
     const ids = new Set<string>();
@@ -160,6 +233,8 @@ const EmojiPlugin = ({
       return;
     }
 
+    void loadEmojiData();
+
     transformEmojiTextToNode(editor, isEmojiIdValid);
 
     return editor.registerTextContentListener((textContent) => {
@@ -167,7 +242,7 @@ const EmojiPlugin = ({
         transformEmojiTextToNode(editor, isEmojiIdValid);
       }
     });
-  }, [disabled, editor, isEmojiIdValid]);
+  }, [disabled, editor, isEmojiIdValid, loadEmojiData]);
 
   return null;
 };

--- a/components/drops/view/part/DropPartMarkdown.tsx
+++ b/components/drops/view/part/DropPartMarkdown.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import {
-  Children,
+  createElement,
   memo,
   useEffect,
   useLayoutEffect,
@@ -49,6 +49,7 @@ import { isSafeMarkdownImageSrc } from "./dropPartMarkdown/linkUtils";
 const BreakComponent = () => <br />;
 
 const EMPTY_MENTIONED_GROUPS: ApiDropGroupMention[] = [];
+const EMOJI_SHORTCODE_REGEX = /:\w+:/;
 
 const mergeClassNames = (...classes: Array<string | undefined>): string =>
   classes.filter(Boolean).join(" ");
@@ -109,29 +110,8 @@ const CodeBlockRenderer = ({
 }: MarkdownCodeProps) => {
   const codeRef = useRef<HTMLElement>(null);
 
-  const codeText = useMemo(() => {
-    return Children.toArray(children)
-      .map((child) => {
-        if (typeof child === "string" || typeof child === "number") {
-          return child;
-        }
-
-        return "";
-      })
-      .join("");
-  }, [children]);
-
-  const language = useMemo(() => {
-    const match =
-      typeof className === "string"
-        ? /language-([\w+-]+)/.exec(className)
-        : null;
-
-    return match?.[1] ?? null;
-  }, [className]);
-
   useEffect(() => {
-    if (globalThis.window === undefined) {
+    if (typeof globalThis.window === "undefined") {
       return;
     }
 
@@ -140,14 +120,20 @@ const CodeBlockRenderer = ({
       return;
     }
 
-    if (!codeText || codeText.trim() === "") {
+    if (element.textContent.trim() === "") {
       return;
     }
 
-    highlightCodeElement(element, language).catch((error) => {
-      console.error("[DropPartMarkdown] Failed to highlight code", error);
-    });
-  }, [codeText, language]);
+    const language = /language-([\w+-]+)/.exec(element.className)?.[1] ?? null;
+
+    void (async () => {
+      try {
+        await highlightCodeElement(element, language);
+      } catch (error: unknown) {
+        console.error("[DropPartMarkdown] Failed to highlight code", error);
+      }
+    })();
+  });
 
   return (
     <code
@@ -185,11 +171,7 @@ const createMarkdownComponents = ({
         className: mergeClassNames(headingClassName, className),
       };
 
-      return (
-        <TagComponent {...(mergedProps as any)}>
-          {customRenderer(children)}
-        </TagComponent>
-      );
+      return createElement(TagComponent, mergedProps, customRenderer(children));
     };
 
     HeadingRenderer.displayName = `MarkdownHeading(${
@@ -238,11 +220,11 @@ const createMarkdownComponents = ({
     h3: createHeadingRenderer("h3"),
     h4: createHeadingRenderer("h4"),
     h5: createHeadingRenderer("h5"),
-    ...(renderParagraph ? { p: renderParagraph } : {}),
+    ...(renderParagraph !== undefined ? { p: renderParagraph } : {}),
     li: ListItemRenderer,
     code: CodeRenderer,
-    ...(renderAnchor ? { a: renderAnchor } : {}),
-    ...(renderImage ? { img: renderImage } : {}),
+    ...(renderAnchor !== undefined ? { a: renderAnchor } : {}),
+    ...(renderImage !== undefined ? { img: renderImage } : {}),
     br: BreakComponent,
     blockquote: BlockQuoteRenderer,
   } satisfies Components;
@@ -293,9 +275,17 @@ function DropPartMarkdown({
 }: DropPartMarkdownProps) {
   const queryClient = useQueryClient();
   const isMobile = useIsMobileScreen();
-  const { emojiMap, findNativeEmoji } = useEmoji();
+  const { emojiMap, findNativeEmoji, loadEmojiData } = useEmoji();
   const seizeSettings = useSeizeSettingsOptional();
   const { variant: linkPreviewVariant } = useLinkPreviewContext();
+
+  useEffect(() => {
+    if (!partContent || !EMOJI_SHORTCODE_REGEX.test(partContent)) {
+      return;
+    }
+
+    void loadEmojiData();
+  }, [loadEmojiData, partContent]);
 
   useLayoutEffect(() => {
     primeMarketplacePreviewCacheFromNftLinks({
@@ -309,6 +299,7 @@ function DropPartMarkdown({
       case "sm":
         return isMobile ? "tw-text-xs" : "tw-text-sm";
       case "md":
+      case undefined:
       default:
         return "tw-text-md";
     }

--- a/components/waves/CreateDropEmojiPicker.tsx
+++ b/components/waves/CreateDropEmojiPicker.tsx
@@ -3,14 +3,12 @@
 import type { FC } from "react";
 import { useState, useRef, useEffect } from "react";
 import { createPortal } from "react-dom";
-import Picker from "@emoji-mart/react";
-import data from "@emoji-mart/data";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { $createTextNode, $insertNodes } from "lexical";
 import MobileWrapperDialog from "../mobile-wrapper-dialog/MobileWrapperDialog";
 import useIsMobileScreen from "@/hooks/isMobileScreen";
-import { useEmoji } from "@/contexts/EmojiContext";
 import { useCreateDropEmojiPickerLayer } from "./CreateDropEmojiPickerLayerContext";
+import LazyEmojiPicker, { type EmojiPickerSelection } from "./LazyEmojiPicker";
 
 interface CreateDropEmojiPickerProps {
   disabled?: boolean | undefined;
@@ -29,8 +27,6 @@ const CreateDropEmojiPickerContent: FC<CreateDropEmojiPickerContentProps> = ({
   const isMobile = useIsMobileScreen();
   const { desktopZIndex, mobileZIndexClassName } =
     useCreateDropEmojiPickerLayer();
-
-  const { emojiMap, categories, categoryIcons } = useEmoji();
 
   const [editor] = useLexicalComposerContext();
   const [showPicker, setShowPicker] = useState(false);
@@ -77,10 +73,7 @@ const CreateDropEmojiPickerContent: FC<CreateDropEmojiPickerContentProps> = ({
     setShowPicker(true);
   };
 
-  const addEmoji = (emoji: {
-    native?: string | undefined;
-    id?: string | undefined;
-  }) => {
+  const addEmoji = (emoji: EmojiPickerSelection) => {
     if (disabled) {
       setShowPicker(false);
       return;
@@ -171,14 +164,7 @@ const CreateDropEmojiPickerContent: FC<CreateDropEmojiPickerContentProps> = ({
               }}
               className="tw-rounded-lg tw-border tw-bg-iron-800 tw-p-[1px] tw-shadow-lg"
             >
-              <Picker
-                theme="dark"
-                data={data}
-                onEmojiSelect={addEmoji}
-                custom={emojiMap}
-                categories={categories}
-                categoryIcons={categoryIcons}
-              />
+              <LazyEmojiPicker onEmojiSelect={addEmoji} />
             </div>,
             document.body
           )}
@@ -194,14 +180,7 @@ const CreateDropEmojiPickerContent: FC<CreateDropEmojiPickerContentProps> = ({
             className="tw-flex tw-h-full tw-w-full tw-items-center tw-justify-center"
             onTouchMove={(e) => e.stopPropagation()}
           >
-            <Picker
-              theme="dark"
-              data={data}
-              onEmojiSelect={addEmoji}
-              custom={emojiMap}
-              categories={categories}
-              categoryIcons={categoryIcons}
-            />
+            <LazyEmojiPicker onEmojiSelect={addEmoji} />
           </div>
         </MobileWrapperDialog>
       )}

--- a/components/waves/LazyEmojiPicker.tsx
+++ b/components/waves/LazyEmojiPicker.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useState, type ComponentType } from "react";
+
+import {
+  useEmoji,
+  type EmojiCategory,
+  type EmojiMartData,
+} from "@/contexts/EmojiContext";
+
+export interface EmojiPickerSelection {
+  native?: string | undefined;
+  id?: string | undefined;
+}
+
+interface EmojiMartPickerProps {
+  readonly theme: "dark";
+  readonly data: EmojiMartData;
+  readonly onEmojiSelect: (emoji: EmojiPickerSelection) => void;
+  readonly custom: EmojiCategory[];
+  readonly categories: string[];
+  readonly categoryIcons: Record<string, { src: string }>;
+}
+
+interface LazyEmojiPickerProps {
+  readonly onEmojiSelect: (emoji: EmojiPickerSelection) => void;
+}
+
+type EmojiMartPickerComponent = ComponentType<EmojiMartPickerProps>;
+type EmojiPickerLoadStatus = "loading" | "ready" | "error";
+interface EmojiPickerLoadState {
+  readonly Picker: EmojiMartPickerComponent | null;
+  readonly status: EmojiPickerLoadStatus;
+}
+
+let emojiMartPickerPromise: Promise<EmojiMartPickerComponent> | null = null;
+
+const loadEmojiMartPicker = async (): Promise<EmojiMartPickerComponent> => {
+  emojiMartPickerPromise ??= (async () => {
+    try {
+      const emojiMartReactModule = await import("@emoji-mart/react");
+      return emojiMartReactModule.default as EmojiMartPickerComponent;
+    } catch (error) {
+      emojiMartPickerPromise = null;
+      throw error;
+    }
+  })();
+
+  return emojiMartPickerPromise;
+};
+
+export default function LazyEmojiPicker({
+  onEmojiSelect,
+}: LazyEmojiPickerProps) {
+  const {
+    categories,
+    categoryIcons,
+    emojiMap,
+    emojiData,
+    loadCustomEmojis,
+    loadNativeEmojis,
+  } = useEmoji();
+  const [pickerLoadState, setPickerLoadState] = useState<EmojiPickerLoadState>({
+    Picker: null,
+    status: "loading",
+  });
+
+  useEffect(() => {
+    const loadState = { cancelled: false };
+
+    void (async () => {
+      try {
+        const [nativeEmojiData, PickerComponent] = await Promise.all([
+          loadNativeEmojis(),
+          loadCustomEmojis().then(() => loadEmojiMartPicker()),
+        ]);
+        if (!loadState.cancelled) {
+          setPickerLoadState(
+            nativeEmojiData
+              ? { Picker: PickerComponent, status: "ready" }
+              : { Picker: null, status: "error" }
+          );
+        }
+      } catch (error) {
+        if (!loadState.cancelled) {
+          setPickerLoadState({ Picker: null, status: "error" });
+        }
+        console.error("Error loading emoji picker:", error);
+      }
+    })();
+
+    return () => {
+      loadState.cancelled = true;
+    };
+  }, [loadCustomEmojis, loadNativeEmojis]);
+
+  const Picker = pickerLoadState.Picker;
+
+  if (!Picker || !emojiData) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="tw-p-3 tw-text-sm tw-text-iron-300"
+      >
+        {pickerLoadState.status === "error"
+          ? "Emoji picker is unavailable."
+          : "Loading emoji picker..."}
+      </div>
+    );
+  }
+
+  return (
+    <Picker
+      theme="dark"
+      data={emojiData}
+      onEmojiSelect={onEmojiSelect}
+      custom={emojiMap}
+      categories={categories}
+      categoryIcons={categoryIcons}
+    />
+  );
+}

--- a/components/waves/drops/WaveDropActionsAddReaction.tsx
+++ b/components/waves/drops/WaveDropActionsAddReaction.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import MobileWrapperDialog from "@/components/mobile-wrapper-dialog/MobileWrapperDialog";
-import { useEmoji } from "@/contexts/EmojiContext";
+import LazyEmojiPicker, {
+  type EmojiPickerSelection,
+} from "@/components/waves/LazyEmojiPicker";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import { useDropReaction } from "@/hooks/drops/useDropReaction";
-import data from "@emoji-mart/data";
-import Picker from "@emoji-mart/react";
 import React, { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Tooltip } from "react-tooltip";
@@ -33,13 +33,9 @@ const WaveDropActionsAddReaction: React.FC<{
   const [showPicker, setShowPicker] = useState(false);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
   const pickerContainerRef = useRef<HTMLDivElement | null>(null);
-  const { emojiMap, categories, categoryIcons } = useEmoji();
   const desktopIconSizeClass = size === "compact" ? "tw-size-4" : "tw-size-5";
 
-  const handleEmojiSelect = (emoji: {
-    native?: string | undefined;
-    id?: string | undefined;
-  }) => {
+  const handleEmojiSelect = (emoji: EmojiPickerSelection) => {
     const emojiText = `:${emoji.id ?? ""}:`;
     setShowPicker(false);
     void react(emojiText);
@@ -178,14 +174,7 @@ const WaveDropActionsAddReaction: React.FC<{
               ref={pickerContainerRef}
               className="tw-rounded-lg tw-bg-iron-800 tw-p-px tw-shadow-lg"
             >
-              <Picker
-                theme="dark"
-                data={data}
-                onEmojiSelect={handleEmojiSelect}
-                custom={emojiMap}
-                categories={categories}
-                categoryIcons={categoryIcons}
-              />
+              <LazyEmojiPicker onEmojiSelect={handleEmojiSelect} />
             </div>
           </div>,
           document.body
@@ -202,14 +191,7 @@ const WaveDropActionsAddReaction: React.FC<{
             className="tw-flex tw-size-full tw-items-center tw-justify-center"
             onTouchMove={(e) => e.stopPropagation()}
           >
-            <Picker
-              theme="dark"
-              data={data}
-              onEmojiSelect={handleEmojiSelect}
-              custom={emojiMap}
-              categories={categories}
-              categoryIcons={categoryIcons}
-            />
+            <LazyEmojiPicker onEmojiSelect={handleEmojiSelect} />
           </div>
         </MobileWrapperDialog>
       )}

--- a/components/waves/drops/WaveDropActionsQuickReact.tsx
+++ b/components/waves/drops/WaveDropActionsQuickReact.tsx
@@ -11,10 +11,16 @@ import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
 import type { ExtendedDrop } from "@/helpers/waves/drop.helpers";
 import { useDropReaction } from "@/hooks/drops/useDropReaction";
 import Image from "next/image";
-import React, { useCallback, useMemo, useSyncExternalStore } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useSyncExternalStore,
+} from "react";
 import { Tooltip } from "react-tooltip";
 
 const MAX_QUICK_REACTIONS = 3;
+const DEFAULT_QUICK_REACTION_ID = "+1";
 
 const WaveDropActionsQuickReact: React.FC<{
   readonly drop: ExtendedDrop;
@@ -27,17 +33,13 @@ const WaveDropActionsQuickReact: React.FC<{
   });
 
   // Subscribe to localStorage changes (hydration-safe)
-  const reactionSnapshot = useSyncExternalStore(
+  useSyncExternalStore(
     subscribeToReactionStore,
     getReactionSnapshot,
     getReactionSnapshotServer
   );
 
-  // Derive top reactions; re-computes when the store changes
-  const topReactionCodes = useMemo(
-    () => getTopReactions(MAX_QUICK_REACTIONS),
-    [reactionSnapshot]
-  );
+  const topReactionCodes = getTopReactions(MAX_QUICK_REACTIONS);
 
   const buttons = topReactionCodes.map((code) => (
     <QuickReactButton
@@ -68,15 +70,24 @@ const QuickReactButton: React.FC<{
   readonly onReact: (code: string) => void;
   readonly isMobile?: boolean;
 }> = ({ reactionCode, dropId, canReact, onReact, isMobile = false }) => {
-  const { emojiMap, findNativeEmoji } = useEmoji();
+  const { emojiMap, findNativeEmoji, loadEmojiData } = useEmoji();
 
   const emojiId = useMemo(
     () => reactionCode.replaceAll(":", ""),
     [reactionCode]
   );
 
+  useEffect(() => {
+    if (emojiId === DEFAULT_QUICK_REACTION_ID) {
+      return;
+    }
+
+    void loadEmojiData();
+  }, [emojiId, loadEmojiData]);
+
   const emojiSize = isMobile ? "tw-size-7" : "tw-size-5";
   const textSize = isMobile ? "tw-text-[1.625rem]" : "tw-text-[1.25rem]";
+  const emojiLabel = useMemo(() => emojiId.replaceAll("_", " "), [emojiId]);
 
   const emojiNode = useMemo(() => {
     const fallback = (
@@ -99,7 +110,7 @@ const QuickReactButton: React.FC<{
         <div className={`tw-relative ${emojiSize}`}>
           <Image
             src={customSrc}
-            alt={emojiId}
+            alt={emojiLabel}
             fill
             sizes={isMobile ? "28px" : "20px"}
             unoptimized
@@ -121,7 +132,15 @@ const QuickReactButton: React.FC<{
     }
 
     return fallback;
-  }, [emojiId, emojiMap, findNativeEmoji, emojiSize, textSize]);
+  }, [
+    emojiId,
+    emojiLabel,
+    emojiMap,
+    findNativeEmoji,
+    emojiSize,
+    isMobile,
+    textSize,
+  ]);
 
   const handleClick = useCallback(() => {
     onReact(reactionCode);

--- a/components/waves/drops/WaveDropReactions.tsx
+++ b/components/waves/drops/WaveDropReactions.tsx
@@ -23,7 +23,7 @@ import useLongPressInteraction from "@/hooks/useLongPressInteraction";
 import { commonApiDelete, commonApiPost } from "@/services/api/common-api";
 import { fetchDropByIdBatched } from "@/services/api/drop-api";
 import { useWebsocketStatus } from "@/services/websocket/useWebSocketMessage";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import clsx from "clsx";
 import Image from "next/image";
 import Link from "next/link";
@@ -214,6 +214,7 @@ function ReactionTooltipContent({
 }
 
 const WaveDropReactions: React.FC<WaveDropReactionsProps> = ({ drop }) => {
+  const { emojiMap, findNativeEmoji, loadEmojiData } = useEmoji();
   const [dialogReaction, setDialogReaction] = useState<string | null>(null);
   const [detailedReactionsState, setDetailedReactionsState] =
     useState<DetailedReactionsState | null>(null);
@@ -230,7 +231,7 @@ const WaveDropReactions: React.FC<WaveDropReactionsProps> = ({ drop }) => {
       ? detailedReactionsState.reactions
       : null;
   const detailsLoading = detailsLoadingDropId === drop.id;
-  const dropReactions = drop.reactions ?? [];
+  const dropReactions = drop.reactions;
 
   const reactionsWithDetails = useMemo(() => {
     if (!detailedReactions) {
@@ -260,6 +261,13 @@ const WaveDropReactions: React.FC<WaveDropReactionsProps> = ({ drop }) => {
       };
     });
   }, [detailedReactions, dropReactions]);
+
+  useQuery({
+    queryKey: ["emoji-data", "wave-reactions"],
+    queryFn: () => loadEmojiData().then(() => null),
+    enabled: reactionsWithDetails.length > 0,
+    staleTime: Infinity,
+  });
 
   const loadReactionDetails = useCallback(() => {
     if (detailedReactions) {
@@ -308,6 +316,8 @@ const WaveDropReactions: React.FC<WaveDropReactionsProps> = ({ drop }) => {
         <WaveDropReaction
           key={`${reaction.reaction}-${getReactionCount(reaction)}`}
           drop={drop}
+          emojiMap={emojiMap}
+          findNativeEmoji={findNativeEmoji}
           reaction={reaction}
           onOpenDetailDialog={handleOpenDialog}
           onLoadDetails={loadReactionDetails}
@@ -328,6 +338,8 @@ const WaveDropReactions: React.FC<WaveDropReactionsProps> = ({ drop }) => {
 
 function WaveDropReaction({
   drop,
+  emojiMap,
+  findNativeEmoji,
   reaction,
   onOpenDetailDialog,
   onLoadDetails,
@@ -335,6 +347,8 @@ function WaveDropReaction({
   isTouchDevice,
 }: {
   readonly drop: ApiDrop;
+  readonly emojiMap: ReturnType<typeof useEmoji>["emojiMap"];
+  readonly findNativeEmoji: ReturnType<typeof useEmoji>["findNativeEmoji"];
   readonly reaction: ApiDropReaction;
   readonly onOpenDetailDialog: (reactionKey: string) => void;
   readonly onLoadDetails: () => Promise<void> | null;
@@ -342,7 +356,6 @@ function WaveDropReaction({
   readonly isTouchDevice: boolean;
 }) {
   const { setToast, connectedProfile } = useAuth();
-  const { emojiMap, findNativeEmoji } = useEmoji();
   const { applyOptimisticDropUpdate } = useMyStream();
   const queryClient = useQueryClient();
   const websocketStatus = useWebsocketStatus();
@@ -395,7 +408,7 @@ function WaveDropReaction({
     [touchHandlers]
   );
 
-  const [total, setTotal] = useState(getReactionCount(reaction));
+  const [total, setTotal] = useState(() => getReactionCount(reaction));
   const [selected, setSelected] = useState(
     reaction.reaction === drop.context_profile_context?.reaction
   );
@@ -429,13 +442,9 @@ function WaveDropReaction({
       return;
     }
 
-    if (reaction.profiles === prevProfilesRef.current) {
-      const timeoutId = setTimeout(() => {
-        setTotal((current) => (current === nextTotal ? current : nextTotal));
-      }, 0);
-      return () => clearTimeout(timeoutId);
+    if (reaction.profiles !== prevProfilesRef.current) {
+      prevProfilesRef.current = reaction.profiles;
     }
-    prevProfilesRef.current = reaction.profiles;
 
     const timeoutId = setTimeout(() => {
       setTotal((current) => (current === nextTotal ? current : nextTotal));
@@ -460,17 +469,12 @@ function WaveDropReaction({
     return () => clearTimeout(timeout);
   }, [animate]);
 
-  // derive emoji ID
   const emojiId = useMemo(
     () => reaction.reaction.replaceAll(":", ""),
     [reaction.reaction]
   );
-  const tooltipId = useMemo(
-    () => buildTooltipId("reaction", drop.id, emojiId),
-    [drop.id, emojiId]
-  );
+  const tooltipId = buildTooltipId("reaction", drop.id, emojiId);
 
-  // small + tooltip emoji nodes
   const waveId = drop.wave.id;
 
   const { emojiNode, emojiNodeTooltip } = useMemo(() => {
@@ -485,7 +489,7 @@ function WaveDropReaction({
           <div className="tw-relative tw-size-4">
             <Image
               src={customSrc}
-              alt={emojiId}
+              alt={emojiId.replaceAll("_", " ")}
               fill
               sizes="16px"
               unoptimized
@@ -497,7 +501,7 @@ function WaveDropReaction({
           <div className="tw-relative tw-size-8">
             <Image
               src={customSrc}
-              alt={emojiId}
+              alt={emojiId.replaceAll("_", " ")}
               fill
               sizes="32px"
               unoptimized

--- a/contexts/EmojiContext.tsx
+++ b/contexts/EmojiContext.tsx
@@ -4,11 +4,10 @@ import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useState,
+  type ReactNode,
 } from "react";
-import data from "@emoji-mart/data";
 
 import { getProfileCmsAssetProxyUrl } from "@/lib/profile-cms/runtime/mediaProxy";
 
@@ -23,84 +22,218 @@ interface BaseEmoji {
   keywords: string;
 }
 
-interface NativeEmoji extends BaseEmoji {
+export interface NativeEmoji extends BaseEmoji {
   skins: { native: string }[];
 }
 
-interface Emoji extends BaseEmoji {
+export interface Emoji extends BaseEmoji {
   skins: { src: string }[];
 }
 
+export type EmojiCategory = {
+  id: string;
+  name: string;
+  category: string;
+  emojis: Emoji[];
+};
+
+export type EmojiMartData = Record<string, unknown> & {
+  emojis?: Record<string, NativeEmoji>;
+};
+
 interface EmojiContextType {
-  emojiMap: { id: string; name: string; category: string; emojis: Emoji[] }[];
+  emojiMap: EmojiCategory[];
   loading: boolean;
   categories: string[];
   categoryIcons: Record<string, { src: string }>;
+  emojiData: EmojiMartData | null;
   findNativeEmoji: (emojiId: string) => NativeEmoji | null;
   findCustomEmoji: (emojiId: string) => Emoji | null;
+  loadCustomEmojis: () => Promise<EmojiCategory[]>;
+  loadNativeEmojis: () => Promise<EmojiMartData | null>;
+  loadEmojiData: () => Promise<void>;
 }
 
 const EmojiContext = createContext<EmojiContextType | undefined>(undefined);
 
-export const EmojiProvider = ({ children }: { children: React.ReactNode }) => {
-  const [emojiMap, setEmojiMap] = useState<EmojiContextType["emojiMap"]>([]);
-  const [loading, setLoading] = useState(true);
+const EMOJI_CATEGORIES = [
+  "frequent",
+  "6529",
+  "people",
+  "nature",
+  "foods",
+  "activity",
+  "places",
+  "objects",
+  "symbols",
+  "flags",
+];
 
-  const categories = [
-    "frequent",
-    "6529",
-    "people",
-    "nature",
-    "foods",
-    "activity",
-    "places",
-    "objects",
-    "symbols",
-    "flags",
-  ];
+const EMOJI_CATEGORY_ICONS = {
+  "6529": {
+    src: getProfileCmsAssetProxyUrl(`${EMOJI_CDN_BASE}/6529white.webp`),
+  },
+};
 
-  const categoryIcons = {
-    "6529": {
-      src: getProfileCmsAssetProxyUrl(`${EMOJI_CDN_BASE}/6529white.webp`),
+let customEmojiMapCache: EmojiCategory[] | null = null;
+let customEmojiMapPromise: Promise<EmojiCategory[]> | null = null;
+let nativeEmojiDataCache: EmojiMartData | null = null;
+let nativeEmojiDataPromise: Promise<EmojiMartData | null> | null = null;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object";
+
+const mapCustomEmojiList = (emojiList: readonly string[]): EmojiCategory[] => {
+  const mappedEmojis = emojiList.map((id) => ({
+    id,
+    name: id,
+    keywords: id.replaceAll("_", " "),
+    skins: [
+      {
+        src: getProfileCmsAssetProxyUrl(`${EMOJI_CDN_BASE}/${id}.webp`),
+      },
+    ],
+  }));
+
+  return [
+    {
+      id: "6529",
+      name: "6529",
+      category: "6529",
+      emojis: mappedEmojis,
     },
-  };
+  ];
+};
 
-  useEffect(() => {
-    const fetchEmojis = async () => {
-      try {
-        const response = await fetch(S3_EMOJI_URL);
-        if (!response.ok) throw new Error("Failed to load emoji list");
+const fetchCustomEmojiMap = async (): Promise<EmojiCategory[]> => {
+  if (customEmojiMapCache !== null) {
+    return customEmojiMapCache;
+  }
 
-        const emojiList: string[] = await response.json();
+  customEmojiMapPromise ??= (async () => {
+    try {
+      const response = await fetch(S3_EMOJI_URL);
+      if (!response.ok) throw new Error("Failed to load emoji list");
 
-        const mappedEmojis = emojiList.map((id) => ({
-          id,
-          name: id,
-          keywords: id.replaceAll("_", " "),
-          skins: [
-            {
-              src: getProfileCmsAssetProxyUrl(`${EMOJI_CDN_BASE}/${id}.webp`),
-            },
-          ],
-        }));
+      const emojiList: unknown = await response.json();
+      const emojiIds = Array.isArray(emojiList)
+        ? emojiList.filter((id): id is string => typeof id === "string")
+        : [];
 
-        setEmojiMap([
-          {
-            id: "6529",
-            name: "6529",
-            category: "6529",
-            emojis: mappedEmojis,
-          },
-        ]);
-      } catch (error) {
-        console.error("Error fetching emoji list:", error);
-      } finally {
-        setLoading(false);
-      }
-    };
+      const loadedEmojiMap = mapCustomEmojiList(emojiIds);
+      customEmojiMapCache = loadedEmojiMap;
+      return loadedEmojiMap;
+    } catch (error) {
+      console.error("Error fetching emoji list:", error);
+      return [];
+    } finally {
+      customEmojiMapPromise = null;
+    }
+  })();
 
-    fetchEmojis();
+  return customEmojiMapPromise;
+};
+
+const getEmojiMartDataFromModule = (module: unknown): EmojiMartData | null => {
+  const defaultExport = isRecord(module) ? module["default"] : undefined;
+  const candidate =
+    isRecord(module) && isRecord(defaultExport) ? defaultExport : module;
+
+  if (!isRecord(candidate)) {
+    return null;
+  }
+
+  const emojis = candidate["emojis"];
+  if (emojis !== undefined && !isRecord(emojis)) {
+    return null;
+  }
+
+  return candidate as EmojiMartData;
+};
+
+const importNativeEmojiData = async (): Promise<EmojiMartData | null> => {
+  if (nativeEmojiDataCache !== null) {
+    return nativeEmojiDataCache;
+  }
+
+  nativeEmojiDataPromise ??= (async () => {
+    try {
+      const emojiMartDataModule = await import("@emoji-mart/data");
+      const loadedEmojiData = getEmojiMartDataFromModule(emojiMartDataModule);
+      nativeEmojiDataCache = loadedEmojiData;
+      return loadedEmojiData;
+    } catch (error) {
+      console.error("Error loading emoji data:", error);
+      return null;
+    } finally {
+      nativeEmojiDataPromise = null;
+    }
+  })();
+
+  return nativeEmojiDataPromise;
+};
+
+const resetEmojiContextCachesForTests = () => {
+  customEmojiMapCache = null;
+  customEmojiMapPromise = null;
+  nativeEmojiDataCache = null;
+  nativeEmojiDataPromise = null;
+};
+
+declare global {
+  var __resetEmojiContextCachesForTests: (() => void) | undefined;
+}
+
+if ("expect" in globalThis && "afterEach" in globalThis) {
+  globalThis.__resetEmojiContextCachesForTests =
+    resetEmojiContextCachesForTests;
+}
+
+export const EmojiProvider = ({ children }: { children: ReactNode }) => {
+  const [emojiMap, setEmojiMap] = useState<EmojiCategory[]>(
+    () => customEmojiMapCache ?? []
+  );
+  const [emojiData, setEmojiData] = useState<EmojiMartData | null>(
+    () => nativeEmojiDataCache
+  );
+  const [customEmojiLoading, setCustomEmojiLoading] = useState(false);
+  const [nativeEmojiLoading, setNativeEmojiLoading] = useState(false);
+
+  const loadCustomEmojis = useCallback(async () => {
+    if (customEmojiMapCache !== null) {
+      setEmojiMap(customEmojiMapCache);
+      return customEmojiMapCache;
+    }
+
+    setCustomEmojiLoading(true);
+    try {
+      const loadedEmojiMap = await fetchCustomEmojiMap();
+      setEmojiMap(loadedEmojiMap);
+      return loadedEmojiMap;
+    } finally {
+      setCustomEmojiLoading(false);
+    }
   }, []);
+
+  const loadNativeEmojis = useCallback(async () => {
+    if (nativeEmojiDataCache !== null) {
+      setEmojiData(nativeEmojiDataCache);
+      return nativeEmojiDataCache;
+    }
+
+    setNativeEmojiLoading(true);
+    try {
+      const loadedEmojiData = await importNativeEmojiData();
+      setEmojiData(loadedEmojiData);
+      return loadedEmojiData;
+    } finally {
+      setNativeEmojiLoading(false);
+    }
+  }, []);
+
+  const loadEmojiData = useCallback(async () => {
+    await Promise.all([loadCustomEmojis(), loadNativeEmojis()]);
+  }, [loadCustomEmojis, loadNativeEmojis]);
 
   const customEmojiIndex = useMemo(() => {
     const index = new Map<string, Emoji>();
@@ -113,43 +246,42 @@ export const EmojiProvider = ({ children }: { children: React.ReactNode }) => {
   }, [emojiMap]);
 
   const findCustomEmoji = useCallback(
-    (emojiId: string) => customEmojiIndex.get(emojiId.replaceAll(":", "")) || null,
+    (emojiId: string) =>
+      customEmojiIndex.get(emojiId.replaceAll(":", "")) ?? null,
     [customEmojiIndex]
   );
-
-  const nativeEmojiCache = useMemo(() => new Map<string, NativeEmoji | null>(), []);
 
   const findNativeEmoji = useCallback(
     (emojiId: string) => {
       const normalizedId = emojiId.replaceAll(":", "");
-      if (nativeEmojiCache.has(normalizedId)) {
-        return nativeEmojiCache.get(normalizedId) ?? null;
-      }
-
-      const emoji = (data as any).emojis?.[normalizedId] as NativeEmoji | undefined;
-      const result = emoji ?? null;
-      nativeEmojiCache.set(normalizedId, result);
-      return result;
+      return emojiData?.emojis?.[normalizedId] ?? null;
     },
-    [nativeEmojiCache]
+    [emojiData]
   );
 
   const value = useMemo(
     () => ({
       emojiMap,
-      loading,
-      categories,
-      categoryIcons,
+      loading: customEmojiLoading || nativeEmojiLoading,
+      categories: EMOJI_CATEGORIES,
+      categoryIcons: EMOJI_CATEGORY_ICONS,
+      emojiData,
       findNativeEmoji,
       findCustomEmoji,
+      loadCustomEmojis,
+      loadNativeEmojis,
+      loadEmojiData,
     }),
     [
       emojiMap,
-      loading,
-      categories,
-      categoryIcons,
+      customEmojiLoading,
+      nativeEmojiLoading,
+      emojiData,
       findNativeEmoji,
       findCustomEmoji,
+      loadCustomEmojis,
+      loadNativeEmojis,
+      loadEmojiData,
     ]
   );
 

--- a/helpers/reactions/reactionHistory.ts
+++ b/helpers/reactions/reactionHistory.ts
@@ -1,5 +1,3 @@
-import { FrequentlyUsed, Store } from "emoji-mart";
-
 const STORAGE_KEY = "emoji-mart.frequently";
 const DEFAULT_REACTION = ":+1:";
 
@@ -11,14 +9,64 @@ function emitChange() {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+function readReactionStore(): Record<string, number> | null {
+  if (typeof globalThis.localStorage === "undefined") {
+    return null;
+  }
+
+  let rawStore: string | null;
+  try {
+    rawStore = globalThis.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  if (!rawStore) {
+    return null;
+  }
+
+  try {
+    const parsedStore: unknown = JSON.parse(rawStore);
+    if (!isRecord(parsedStore)) {
+      return null;
+    }
+
+    const entries = Object.entries(parsedStore).filter(
+      (entry): entry is [string, number] =>
+        typeof entry[0] === "string" &&
+        typeof entry[1] === "number" &&
+        Number.isFinite(entry[1])
+    );
+
+    return Object.fromEntries(entries);
+  } catch {
+    return null;
+  }
+}
+
+function writeReactionStore(store: Record<string, number>): void {
+  if (typeof globalThis.localStorage === "undefined") {
+    return;
+  }
+
+  try {
+    globalThis.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {}
+}
+
 export function recordReaction(emoji: string): void {
   const id = emoji.replaceAll(":", "");
-  FrequentlyUsed.add({ id });
+  const store = readReactionStore() ?? {};
+  store[id] = (store[id] ?? 0) + 1;
+  writeReactionStore(store);
   emitChange();
 }
 
 export function getTopReactions(limit: number): string[] {
-  const freq = Store.get("frequently") as Record<string, number> | null;
+  const freq = readReactionStore();
   if (!freq) return [DEFAULT_REACTION];
 
   const sorted = Object.entries(freq)
@@ -45,7 +93,15 @@ export function subscribeToReactionStore(
 }
 
 export function getReactionSnapshot(): string {
-  return localStorage.getItem(STORAGE_KEY) ?? "";
+  if (typeof globalThis.localStorage === "undefined") {
+    return "";
+  }
+
+  try {
+    return globalThis.localStorage.getItem(STORAGE_KEY) ?? "";
+  } catch {
+    return "";
+  }
 }
 
 export function getReactionSnapshotServer(): string {

--- a/tests/support/readonlyMutationGuard.ts
+++ b/tests/support/readonlyMutationGuard.ts
@@ -55,6 +55,7 @@ const IGNORED_EXTERNAL_MUTATION_HOSTS = [
 ];
 const GOOGLE_COLLECT_HOSTS = new Set([
   "analytics.google.com",
+  "region1.google-analytics.com",
   "www.google-analytics.com",
   "www.google.com",
 ]);


### PR DESCRIPTION
## Issue
- `EmojiProvider` is mounted globally, but it eagerly imported the full native emoji data and fetched the custom emoji list during app bootstrap.
- That work affected routes that do not open emoji UI, including mobile `/waves` first load.

## Fix
- Move native emoji data behind an on-demand dynamic import.
- Move custom emoji list fetch behind explicit `loadCustomEmojis` / `loadEmojiData` calls with module-level caching.
- Lazy-load `@emoji-mart/react` and render the picker only after picker/runtime data is ready.
- Keep shortcode/native/custom emoji display paths functional by requesting emoji data only where emoji rendering or UI needs it.

## Changes
- Added `LazyEmojiPicker` for composers and reaction pickers.
- Extended `EmojiContext` with cached async loaders while preserving synchronous lookup helpers.
- Removed direct `emoji-mart` runtime access from reaction history helpers.
- Updated markdown, lexical, composer, picker, quick-reaction, and reaction rendering paths to use the lazy context data.
- Updated focused emoji and reaction tests for the async loading path.

## Validation
- `git diff --check`
- `./bin/6529 run format:uncommitted`
- `./bin/6529 run lint:uncommitted:tight`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff` (passes with one non-blocking pre-existing long-component warning for `WaveDropReaction`)
- `./bin/6529 run test -- __tests__/contexts/EmojiContext.test.tsx __tests__/components/waves/CreateDropEmojiPicker.test.tsx __tests__/components/waves/drops/WaveDropActionsAddReaction.test.tsx __tests__/components/drops/create/lexical/nodes/EmojiNode.test.tsx __tests__/components/waves/drops/WaveDropReactions.test.tsx`
- Desktop browser QA on staging-backed local app: composer picker opens, native search/insert works, custom emoji insert/render works, existing emoji messages render, repeated picker opens reuse data.
- iOS simulator QA on staging-backed local app: `/waves` first load had no emoji-related errors before composer use, wave chat rendered existing native/custom emoji, picker opened, native search/insert worked, custom emoji inserted, repeated open/close reused data.

## Risk
- Level: Medium
- Why: The change touches shared emoji lookup/rendering paths used by composers, markdown, reactions, and lexical nodes.
- Rollback: Revert this PR to restore eager emoji runtime/data loading.

## Review Notes
- Please focus on fallback behavior when emoji data import or custom emoji fetch fails.
- Custom emoji network fetch remains cached after the first request and is no longer started by provider mount.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emoji loading is now on-demand, with a dedicated lazy-loaded picker that fetches data only when needed.
  * Reactions, quick reactions, and wave reaction flows now use richer emoji datasets for improved display.
  * Markdown now detects emoji shortcodes and loads emoji support automatically.

* **Bug Fixes**
  * Improved emoji picker behavior with clearer unavailable/loading status messaging.
  * Enhanced emoji rendering and replacement in editor content and reaction UI.
  * Improved emoji reaction history persistence and top-reaction fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->