### PR TITLE
[codex] Delay optional wave startup work

### DIFF
--- a/__tests__/components/waves/drops/WaveDropsAll.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropsAll.test.tsx
@@ -317,8 +317,13 @@ function setupMocks(options: MockSetupOptions = {}) {
   });
 
   // Setup typing mock
-  require("@/hooks/useWaveIsTyping").useWaveIsTyping.mockReturnValue(
-    options.typingMessage ?? null
+  require("@/hooks/useWaveIsTyping").useWaveIsTyping.mockImplementation(
+    (
+      _waveId: string,
+      _myHandle: string | null,
+      _disabled: boolean,
+      typingOptions?: { readonly enabled?: boolean | undefined }
+    ) => (typingOptions?.enabled ? (options.typingMessage ?? "") : "")
   );
 
   require("@/hooks/useWaveBoostedDrops").useWaveBoostedDrops.mockReturnValue({
@@ -377,6 +382,15 @@ function renderComponent(options: RenderOptions = {}) {
     ...render(<WaveDropsAll {...defaultProps} />),
     props: defaultProps,
   };
+}
+
+function flushFirstVisibleDropsPaint() {
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
 }
 
 describe("WaveDropsAll", () => {
@@ -541,6 +555,52 @@ describe("WaveDropsAll", () => {
         boostedDropsDisplayPreference: "hidden",
       });
     });
+
+    it("delays inserted boosted drops until visible drops have painted", () => {
+      const mockDrops = [createMockDrop()];
+      const boostedDrops = [
+        createMockDrop({ id: "boosted-drop", serial_no: 99 }),
+      ];
+      const useWaveBoostedDropsMock =
+        require("@/hooks/useWaveBoostedDrops").useWaveBoostedDrops;
+
+      setupMocks({
+        waveMessages: { drops: mockDrops as any },
+      });
+      useWaveBoostedDropsMock.mockImplementation(
+        ({ enabled }: { readonly enabled?: boolean | undefined }) => ({
+          data: enabled ? boostedDrops : undefined,
+        })
+      );
+
+      renderComponent({ waveId: "test-wave" });
+
+      expect(useWaveBoostedDropsMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          waveId: "test-wave",
+          enabled: false,
+        })
+      );
+      expect(dropsProps).toMatchObject({
+        drops: mockDrops,
+        boostedDrops: undefined,
+        boostedDropsDisplayPreference: "compact",
+      });
+
+      flushFirstVisibleDropsPaint();
+
+      expect(useWaveBoostedDropsMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          waveId: "test-wave",
+          enabled: true,
+        })
+      );
+      expect(dropsProps).toMatchObject({
+        drops: mockDrops,
+        boostedDrops,
+        boostedDropsDisplayPreference: "compact",
+      });
+    });
   });
 
   describe("Virtualized Drop Page Size", () => {
@@ -654,10 +714,30 @@ describe("WaveDropsAll", () => {
         auth: { connectedProfile: { handle: "testuser" } },
         typingMessage: "someone is typing...",
       });
+      const useWaveIsTypingMock =
+        require("@/hooks/useWaveIsTyping").useWaveIsTyping;
 
       renderComponent();
 
+      expect(
+        screen.queryByText("someone is typing...")
+      ).not.toBeInTheDocument();
+      expect(useWaveIsTypingMock).toHaveBeenLastCalledWith(
+        "test-wave-1",
+        "testuser",
+        false,
+        { enabled: false }
+      );
+
+      flushFirstVisibleDropsPaint();
+
       expect(screen.getByText("someone is typing...")).toBeInTheDocument();
+      expect(useWaveIsTypingMock).toHaveBeenLastCalledWith(
+        "test-wave-1",
+        "testuser",
+        false,
+        { enabled: true }
+      );
       expect(screen.getAllByTestId("typing-icon")).toHaveLength(3); // Three dots
     });
 

--- a/__tests__/components/waves/drops/useFirstVisibleDropsPainted.test.tsx
+++ b/__tests__/components/waves/drops/useFirstVisibleDropsPainted.test.tsx
@@ -1,0 +1,152 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { useFirstVisibleDropsPainted } from "@/components/waves/drops/wave-drops-all/hooks/useFirstVisibleDropsPainted";
+
+const flushPaintGate = () => {
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
+  act(() => {
+    jest.runOnlyPendingTimers();
+  });
+};
+
+describe("useFirstVisibleDropsPainted", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("waits for a frame and timeout after visible drops appear", () => {
+    const requestAnimationFrame = jest.fn<
+      ReturnType<typeof window.setTimeout>,
+      [FrameRequestCallback]
+    >((callback) =>
+      window.setTimeout(() => {
+        callback(performance.now());
+      }, 16)
+    );
+    const cancelAnimationFrame = jest.fn<
+      void,
+      [ReturnType<typeof window.setTimeout>]
+    >((id) => {
+      window.clearTimeout(id);
+    });
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+    Object.defineProperty(window, "requestAnimationFrame", {
+      configurable: true,
+      value: requestAnimationFrame,
+    });
+    Object.defineProperty(window, "cancelAnimationFrame", {
+      configurable: true,
+      value: cancelAnimationFrame,
+    });
+
+    try {
+      const { result, rerender } = renderHook(
+        ({ hasVisibleDrops }) => useFirstVisibleDropsPainted(hasVisibleDrops),
+        { initialProps: { hasVisibleDrops: false } }
+      );
+
+      expect(result.current).toBe(false);
+
+      rerender({ hasVisibleDrops: true });
+
+      expect(result.current).toBe(false);
+      expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+
+      flushPaintGate();
+
+      expect(result.current).toBe(true);
+    } finally {
+      Object.defineProperty(window, "requestAnimationFrame", {
+        configurable: true,
+        value: originalRequestAnimationFrame,
+      });
+      Object.defineProperty(window, "cancelAnimationFrame", {
+        configurable: true,
+        value: originalCancelAnimationFrame,
+      });
+    }
+  });
+
+  it("uses a timeout fallback when requestAnimationFrame is unavailable", () => {
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+    Object.defineProperty(window, "requestAnimationFrame", {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(window, "cancelAnimationFrame", {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      const { result } = renderHook(() => useFirstVisibleDropsPainted(true));
+
+      expect(result.current).toBe(false);
+
+      flushPaintGate();
+
+      expect(result.current).toBe(true);
+    } finally {
+      Object.defineProperty(window, "requestAnimationFrame", {
+        configurable: true,
+        value: originalRequestAnimationFrame,
+      });
+      Object.defineProperty(window, "cancelAnimationFrame", {
+        configurable: true,
+        value: originalCancelAnimationFrame,
+      });
+    }
+  });
+
+  it("cleans up scheduled work after unmount", () => {
+    const requestAnimationFrame = jest.fn<
+      ReturnType<typeof window.setTimeout>,
+      [FrameRequestCallback]
+    >((callback) =>
+      window.setTimeout(() => {
+        callback(performance.now());
+      }, 16)
+    );
+    const cancelAnimationFrame = jest.fn<
+      void,
+      [ReturnType<typeof window.setTimeout>]
+    >((id) => {
+      window.clearTimeout(id);
+    });
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+    Object.defineProperty(window, "requestAnimationFrame", {
+      configurable: true,
+      value: requestAnimationFrame,
+    });
+    Object.defineProperty(window, "cancelAnimationFrame", {
+      configurable: true,
+      value: cancelAnimationFrame,
+    });
+
+    try {
+      const { unmount } = renderHook(() => useFirstVisibleDropsPainted(true));
+
+      unmount();
+
+      expect(cancelAnimationFrame).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(window, "requestAnimationFrame", {
+        configurable: true,
+        value: originalRequestAnimationFrame,
+      });
+      Object.defineProperty(window, "cancelAnimationFrame", {
+        configurable: true,
+        value: originalCancelAnimationFrame,
+      });
+    }
+  });
+});

--- a/__tests__/hooks/useWaveIsTyping.test.tsx
+++ b/__tests__/hooks/useWaveIsTyping.test.tsx
@@ -1,28 +1,66 @@
-import { renderHook, act } from '@testing-library/react';
-import { useWaveIsTyping } from '@/hooks/useWaveIsTyping';
-import { WsMessageType } from '@/helpers/Types';
+import { renderHook, act } from "@testing-library/react";
+import { useWaveIsTyping } from "@/hooks/useWaveIsTyping";
+import { WsMessageType } from "@/helpers/Types";
 
 const listeners: any[] = [];
-
-jest.mock('@/hooks/useWaveWebSocket', () => ({
-  useWaveWebSocket: () => ({
-    socket: {
-      addEventListener: (_: string, cb: any) => listeners.push(cb),
-      removeEventListener: jest.fn(),
-    },
-  }),
+const mockAddEventListener = jest.fn((_: string, cb: any) =>
+  listeners.push(cb)
+);
+const mockRemoveEventListener = jest.fn();
+const mockUseWaveWebSocket = jest.fn((waveId: string) => ({
+  socket: waveId
+    ? {
+        addEventListener: mockAddEventListener,
+        removeEventListener: mockRemoveEventListener,
+      }
+    : null,
 }));
 
-test('reports typing status and clears after timeout', () => {
+jest.mock("@/hooks/useWaveWebSocket", () => ({
+  useWaveWebSocket: (waveId: string) => mockUseWaveWebSocket(waveId),
+}));
+
+beforeEach(() => {
+  listeners.length = 0;
+  mockAddEventListener.mockClear();
+  mockRemoveEventListener.mockClear();
+  mockUseWaveWebSocket.mockClear();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+test("reports typing status and clears after timeout", () => {
   jest.useFakeTimers();
-  const { result } = renderHook(() => useWaveIsTyping('wave', null));
+  const { result } = renderHook(() => useWaveIsTyping("wave", null));
 
   act(() => {
-    listeners[0]({ data: JSON.stringify({ type: WsMessageType.USER_IS_TYPING, data: { wave_id: 'wave', profile: { handle: 'A', level: 1 } } }) });
+    listeners[0]({
+      data: JSON.stringify({
+        type: WsMessageType.USER_IS_TYPING,
+        data: { wave_id: "wave", profile: { handle: "A", level: 1 } },
+      }),
+    });
   });
   act(() => jest.advanceTimersByTime(1000));
-  expect(result.current).toContain('A is typing');
+  expect(result.current).toContain("A is typing");
 
   act(() => jest.advanceTimersByTime(6000));
-  expect(result.current).toBe('');
+  expect(result.current).toBe("");
+});
+
+test("skips websocket work while the deferred typing gate is disabled", () => {
+  jest.useFakeTimers();
+  const { result } = renderHook(() =>
+    useWaveIsTyping("wave", null, false, { enabled: false })
+  );
+
+  expect(mockUseWaveWebSocket).toHaveBeenLastCalledWith("");
+  expect(mockAddEventListener).not.toHaveBeenCalled();
+
+  act(() => jest.advanceTimersByTime(2000));
+
+  expect(result.current).toBe("");
+  expect(listeners).toHaveLength(0);
 });

--- a/components/waves/drops/wave-drops-all/hooks/useFirstVisibleDropsPainted.ts
+++ b/components/waves/drops/wave-drops-all/hooks/useFirstVisibleDropsPainted.ts
@@ -12,28 +12,28 @@ export function useFirstVisibleDropsPainted(hasVisibleDrops: boolean): boolean {
       return;
     }
 
-    const requestFrame =
-      typeof window.requestAnimationFrame === "function"
-        ? window.requestAnimationFrame.bind(window)
-        : (callback: FrameRequestCallback) =>
-            window.setTimeout(() => {
-              callback(performance.now());
-            }, 16);
-    const cancelFrame =
-      typeof window.cancelAnimationFrame === "function"
-        ? window.cancelAnimationFrame.bind(window)
-        : window.clearTimeout.bind(window);
-    let timeoutId: number | null = null;
-    const animationFrameId = requestFrame(() => {
-      timeoutId = window.setTimeout(() => {
+    let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
+    const markPainted = () => {
+      timeoutId = globalThis.setTimeout(() => {
         setPainted(true);
       }, 0);
-    });
+    };
+
+    let cancelFrame: () => void;
+    if (typeof globalThis.requestAnimationFrame === "function") {
+      const animationFrameId = globalThis.requestAnimationFrame(markPainted);
+      cancelFrame = () => globalThis.cancelAnimationFrame(animationFrameId);
+    } else {
+      const fallbackTimeoutId = globalThis.setTimeout(() => {
+        markPainted();
+      }, 16);
+      cancelFrame = () => globalThis.clearTimeout(fallbackTimeoutId);
+    }
 
     return () => {
-      cancelFrame(animationFrameId);
+      cancelFrame();
       if (timeoutId !== null) {
-        window.clearTimeout(timeoutId);
+        globalThis.clearTimeout(timeoutId);
       }
     };
   }, [hasVisibleDrops, painted]);

--- a/components/waves/drops/wave-drops-all/hooks/useFirstVisibleDropsPainted.ts
+++ b/components/waves/drops/wave-drops-all/hooks/useFirstVisibleDropsPainted.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useFirstVisibleDropsPainted(hasVisibleDrops: boolean): boolean {
+  const [painted, setPainted] = useState(false);
+
+  useEffect(() => {
+    if (!hasVisibleDrops || painted) {
+      return;
+    }
+
+    const requestFrame =
+      typeof window.requestAnimationFrame === "function"
+        ? window.requestAnimationFrame.bind(window)
+        : // eslint-disable-next-line promise/prefer-await-to-callbacks -- Browser frame scheduling is callback-based.
+          (callback: FrameRequestCallback) =>
+            window.setTimeout(() => {
+              // eslint-disable-next-line promise/prefer-await-to-callbacks -- Browser frame scheduling is callback-based.
+              callback(performance.now());
+            }, 16);
+    const cancelFrame =
+      typeof window.cancelAnimationFrame === "function"
+        ? window.cancelAnimationFrame.bind(window)
+        : window.clearTimeout.bind(window);
+    let timeoutId: number | null = null;
+    const animationFrameId = requestFrame(() => {
+      timeoutId = window.setTimeout(() => {
+        setPainted(true);
+      }, 0);
+    });
+
+    return () => {
+      cancelFrame(animationFrameId);
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [hasVisibleDrops, painted]);
+
+  return painted;
+}

--- a/components/waves/drops/wave-drops-all/hooks/useFirstVisibleDropsPainted.ts
+++ b/components/waves/drops/wave-drops-all/hooks/useFirstVisibleDropsPainted.ts
@@ -1,5 +1,7 @@
 "use client";
 
+/* eslint promise/prefer-await-to-callbacks: "off" -- Browser paint scheduling APIs are callback-based. */
+
 import { useEffect, useState } from "react";
 
 export function useFirstVisibleDropsPainted(hasVisibleDrops: boolean): boolean {
@@ -13,10 +15,8 @@ export function useFirstVisibleDropsPainted(hasVisibleDrops: boolean): boolean {
     const requestFrame =
       typeof window.requestAnimationFrame === "function"
         ? window.requestAnimationFrame.bind(window)
-        : // eslint-disable-next-line promise/prefer-await-to-callbacks -- Browser frame scheduling is callback-based.
-          (callback: FrameRequestCallback) =>
+        : (callback: FrameRequestCallback) =>
             window.setTimeout(() => {
-              // eslint-disable-next-line promise/prefer-await-to-callbacks -- Browser frame scheduling is callback-based.
               callback(performance.now());
             }, 16);
     const cancelFrame =

--- a/components/waves/drops/wave-drops-all/index.tsx
+++ b/components/waves/drops/wave-drops-all/index.tsx
@@ -28,6 +28,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useWaveDropsClipboard } from "./hooks/useWaveDropsClipboard";
 import { useDeferredNewestDrops } from "./hooks/useDeferredNewestDrops";
+import { useFirstVisibleDropsPainted } from "./hooks/useFirstVisibleDropsPainted";
 import { useWaveDropsNotificationRead } from "./hooks/useWaveDropsNotificationRead";
 import { useWaveDropsSerialScroll } from "./hooks/useWaveDropsSerialScroll";
 import { WaveDropsContent } from "./subcomponents/WaveDropsContent";
@@ -98,23 +99,9 @@ const WaveDropsAllInner: React.FC<WaveDropsAllProps> = ({
 
   const { setUnreadDividerSerialNo } = useUnreadDivider();
 
-  const typingMessage = useWaveIsTyping(
-    waveId,
-    connectedProfile?.handle ?? null,
-    isMuted
-  );
-
   const [boostedDropsDisplayPreference] = useBoostedDropsDisplayPreference();
   const shouldRenderInsertedBoostedDrops =
     boostedDropsDisplayPreference !== "hidden";
-  const { data: boostedDrops } = useWaveBoostedDrops({
-    waveId,
-    wave,
-    enabled: shouldRenderInsertedBoostedDrops,
-  });
-  const visibleBoostedDrops = shouldRenderInsertedBoostedDrops
-    ? boostedDrops
-    : undefined;
 
   const scrollBehavior = useScrollBehavior();
   const {
@@ -181,6 +168,26 @@ const WaveDropsAllInner: React.FC<WaveDropsAllProps> = ({
       ),
     };
   }, [renderedWaveMessages, wave]);
+  const hasVisibleDrops =
+    (renderedWaveMessagesWithFullWave?.drops.length ?? 0) > 0;
+  const firstVisibleDropsPainted = useFirstVisibleDropsPainted(hasVisibleDrops);
+
+  const typingMessage = useWaveIsTyping(
+    waveId,
+    connectedProfile?.handle ?? null,
+    isMuted,
+    { enabled: firstVisibleDropsPainted }
+  );
+
+  const { data: boostedDrops } = useWaveBoostedDrops({
+    waveId,
+    wave,
+    enabled: shouldRenderInsertedBoostedDrops && firstVisibleDropsPainted,
+  });
+  const visibleBoostedDrops =
+    shouldRenderInsertedBoostedDrops && firstVisibleDropsPainted
+      ? boostedDrops
+      : undefined;
 
   const {
     serialTarget,

--- a/hooks/useWaveIsTyping.ts
+++ b/hooks/useWaveIsTyping.ts
@@ -36,7 +36,8 @@ function buildTypingString(entries: TypingEntry[]): string {
   if (entries.length === 0) return "";
 
   // Highest-level first.
-  const sorted = entries.sort((a, b) => b.profile.level - a.profile.level);
+  const sorted = [...entries];
+  sorted.sort((a, b) => b.profile.level - a.profile.level);
 
   const names = sorted.map((e) => e.profile.handle);
   const firstName = names[0] ?? "";

--- a/hooks/useWaveIsTyping.ts
+++ b/hooks/useWaveIsTyping.ts
@@ -9,9 +9,16 @@ import type { ApiProfileMin } from "@/generated/models/ApiProfileMin";
 /*  Types                                                             */
 /* ------------------------------------------------------------------ */
 
+type TypingProfile = ApiProfileMin & { readonly handle: string };
+
 interface TypingEntry {
-  profile: ApiProfileMin;
+  profile: TypingProfile;
   lastTypingAt: number; // our local receive time (ms)
+}
+
+interface TypingMessageState {
+  readonly scopeKey: string;
+  readonly message: string;
 }
 
 /* ------------------------------------------------------------------ */
@@ -28,23 +35,66 @@ const CLEANUP_INTERVAL_MS = 1_000; // prune/check once per second
 function buildTypingString(entries: TypingEntry[]): string {
   if (entries.length === 0) return "";
 
-  // Highest‑level first (undefined → 0)
-  const sorted = entries.sort(
-    (a, b) => (b.profile.level ?? 0) - (a.profile.level ?? 0)
-  );
+  // Highest-level first.
+  const sorted = entries.sort((a, b) => b.profile.level - a.profile.level);
 
   const names = sorted.map((e) => e.profile.handle);
+  const firstName = names[0] ?? "";
+  const secondName = names[1] ?? "";
 
   if (names.length === 1) {
-    return `${names[0]} is typing`;
+    return `${firstName} is typing`;
   }
   if (names.length === 2) {
-    return `${names[0]}, ${names[1]} are typing`;
+    return `${firstName}, ${secondName} are typing`;
   }
-  return `${names[0]}, ${names[1]} and ${
+  return `${firstName}, ${secondName} and ${
     names.length - 2
   } more people are typing`;
 }
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const isTypingProfile = (value: unknown): value is TypingProfile =>
+  isRecord(value) && typeof value["handle"] === "string";
+
+type ValidWsTypingMessage = WsTypingMessage & {
+  readonly data: WsTypingMessage["data"] & {
+    readonly profile: TypingProfile;
+  };
+};
+
+const isWsTypingMessage = (value: unknown): value is ValidWsTypingMessage => {
+  if (!isRecord(value) || value["type"] !== WsMessageType.USER_IS_TYPING) {
+    return false;
+  }
+
+  const data = value["data"];
+  if (!isRecord(data)) {
+    return false;
+  }
+
+  return (
+    typeof data["wave_id"] === "string" && isTypingProfile(data["profile"])
+  );
+};
+
+const isWsDropUpdateMessage = (
+  value: unknown
+): value is WsDropUpdateMessage => {
+  if (!isRecord(value) || value["type"] !== WsMessageType.DROP_UPDATE) {
+    return false;
+  }
+
+  const data = value["data"];
+  if (!isRecord(data)) {
+    return false;
+  }
+
+  const author = data["author"];
+  return isRecord(author) && typeof author["handle"] === "string";
+};
 
 /* ------------------------------------------------------------------ */
 /*  Hook                                                              */
@@ -60,38 +110,44 @@ function buildTypingString(entries: TypingEntry[]): string {
 export function useWaveIsTyping(
   waveId: string,
   myHandle: string | null,
-  disabled: boolean = false
+  disabled: boolean = false,
+  options?: { readonly enabled?: boolean | undefined }
 ): string {
-  const { socket } = useWaveWebSocket(disabled ? "" : waveId);
+  const enabled = options?.enabled ?? true;
+  const shouldSubscribe = enabled && !disabled;
+  const { socket } = useWaveWebSocket(shouldSubscribe ? waveId : "");
+  const scopeKey = `${waveId}:${shouldSubscribe ? "subscribed" : "paused"}`;
 
-  const [typingMessage, setTypingMessage] = useState("");
+  const [typingMessageState, setTypingMessageState] =
+    useState<TypingMessageState>({
+      scopeKey,
+      message: "",
+    });
 
   const typersRef = useRef<Map<string, TypingEntry>>(new Map());
 
   useEffect(() => {
     typersRef.current.clear();
-    setTypingMessage("");
-  }, [waveId, disabled]);
+  }, [scopeKey]);
 
   /* ----- 2. Handle incoming USER_IS_TYPING packets ----------------- */
   useEffect(() => {
-    if (!socket) return;
+    if (!shouldSubscribe || !socket) return;
 
     const onMessage = (event: MessageEvent) => {
-      let msg: WsTypingMessage | WsDropUpdateMessage;
+      let msg: unknown;
       try {
-        msg = JSON.parse(event.data);
+        msg = JSON.parse(String(event.data)) as unknown;
       } catch {
         return;
       }
-      if (msg.type === WsMessageType.DROP_UPDATE) {
-        typersRef.current.delete(msg.data?.author.handle ?? "");
+      if (isWsDropUpdateMessage(msg)) {
+        typersRef.current.delete(msg.data.author.handle);
       }
-      if (msg.type !== WsMessageType.USER_IS_TYPING) return;
+      if (!isWsTypingMessage(msg)) return;
       const data = msg.data;
-      if (!data || data.wave_id !== waveId) return;
-      if (data.profile?.handle === myHandle) return; // ignore myself
-      if (!data.profile?.handle) return;
+      if (data.wave_id !== waveId) return;
+      if (data.profile.handle === myHandle) return; // ignore myself
       // Use local clock for freshness (avoids clock‑skew issues)
       typersRef.current.set(data.profile.handle, {
         profile: data.profile,
@@ -102,14 +158,16 @@ export function useWaveIsTyping(
     const currentSocket = socket;
     currentSocket.addEventListener("message", onMessage);
     return () => {
-      if (currentSocket) {
-        currentSocket.removeEventListener("message", onMessage);
-      }
+      currentSocket.removeEventListener("message", onMessage);
     };
-  }, [socket, waveId, myHandle]);
+  }, [socket, waveId, myHandle, shouldSubscribe]);
 
   /* ----- 3. Periodic cleanup + state update ------------------------ */
   useEffect(() => {
+    if (!shouldSubscribe) {
+      return;
+    }
+
     const intervalId = setInterval(() => {
       const now = Date.now();
       // Prune stale typers
@@ -125,11 +183,17 @@ export function useWaveIsTyping(
       );
 
       // Only trigger re‑render if text actually changed
-      setTypingMessage((prev) => (prev === newMessage ? prev : newMessage));
+      setTypingMessageState((prev) =>
+        prev.scopeKey === scopeKey && prev.message === newMessage
+          ? prev
+          : { scopeKey, message: newMessage }
+      );
     }, CLEANUP_INTERVAL_MS);
 
     return () => clearInterval(intervalId);
-  }, []); // stable for entire lifespan
+  }, [scopeKey, shouldSubscribe]);
 
-  return typingMessage;
+  return shouldSubscribe && typingMessageState.scopeKey === scopeKey
+    ? typingMessageState.message
+    : "";
 }

--- a/hooks/useWaveIsTyping.ts
+++ b/hooks/useWaveIsTyping.ts
@@ -57,7 +57,9 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
 const isTypingProfile = (value: unknown): value is TypingProfile =>
-  isRecord(value) && typeof value["handle"] === "string";
+  isRecord(value) &&
+  typeof value["handle"] === "string" &&
+  typeof value["level"] === "number";
 
 type ValidWsTypingMessage = WsTypingMessage & {
   readonly data: WsTypingMessage["data"] & {
@@ -142,7 +144,10 @@ export function useWaveIsTyping(
         return;
       }
       if (isWsDropUpdateMessage(msg)) {
-        typersRef.current.delete(msg.data.author.handle);
+        const authorHandle = msg.data.author.handle;
+        if (authorHandle) {
+          typersRef.current.delete(authorHandle);
+        }
       }
       if (!isWsTypingMessage(msg)) return;
       const data = msg.data;


### PR DESCRIPTION
## Issue
- Mobile Waves startup can begin optional work before the first readable drops have had a chance to paint.
- Boosted-drop fetching and typing presence are useful polish, but they are not required for the initial visible drop list.

## Fix
- Add a local first-visible-drops paint gate in the wave drops list path.
- Delay inserted boosted-drop fetching/rendering until that gate opens.
- Delay typing WebSocket/listener/cleanup work until that gate opens, while preserving muted-wave behavior.

## Changes
- Added `useFirstVisibleDropsPainted` under `wave-drops-all`.
- Wired the gate into `WaveDropsAll` for boosted drops and typing.
- Added an `enabled` option to `useWaveIsTyping` so callers can pause typing work without changing the WebSocket hook itself.
- Tightened typing message parsing with small runtime guards.
- Added focused unit coverage for boosted-drop and typing deferral.

## Validation
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false ./bin/6529 run test -- __tests__/components/waves/drops/WaveDropsAll.test.tsx __tests__/hooks/useWaveIsTyping.test.tsx`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false ./bin/6529 run lint:changed`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false ./bin/6529 run typecheck:changed`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false ./bin/6529 run react-doctor:diff`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false ./bin/6529 run lint:uncommitted:tight`

Note: the local pnpm runtime attempted an automatic dependency verification install before scripts; that path hit the repo secure-install guard, so local script runs used `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false` after dependencies were present. CI should use its normal install path.

## Risk
- Level: Low
- Why: the change only delays optional boosted-drop and typing-presence work until after visible drops paint. It does not alter unread/read, notification, auth, visibility, or message-fetch behavior.
- Rollback: revert the commit to restore eager boosted-drop and typing startup.

## Review Notes
- Please focus on whether the paint gate timing is appropriate and whether typing cleanup semantics remain correct when paused before first paint.
- Clipboard, link previews, markdown image loading, virtual observers, and hidden mobile menus were intentionally left out of this PR.