### PR TITLE
Remove stale eslint disable comments

### DIFF
--- a/components/6529Gradient/GradientPage.tsx
+++ b/components/6529Gradient/GradientPage.tsx
@@ -487,7 +487,6 @@ export default function GradientPageComponent({ id }: { readonly id: string }) {
   useEffect(() => {
     const abortController = new AbortController();
     const initialUrlNfts = `${publicEnv.API_ENDPOINT}/api/nfts/gradients?&page_size=101`;
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fetchNfts(initialUrlNfts, [], abortController.signal);
     return () => abortController.abort();
   }, [fetchNfts]);
@@ -521,7 +520,6 @@ export default function GradientPageComponent({ id }: { readonly id: string }) {
       }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     fetchTransactions();
 
     return () => abortController.abort();

--- a/components/allowlist-tool/allowlist-tool.types.ts
+++ b/components/allowlist-tool/allowlist-tool.types.ts
@@ -126,7 +126,6 @@ export enum AllowlistOperationCode {
 
 export interface AllowlistOperationBase {
   readonly code: AllowlistOperationCode;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly params: Record<string, any>;
 }
 

--- a/components/common/profile/ProfileAvatar.tsx
+++ b/components/common/profile/ProfileAvatar.tsx
@@ -38,7 +38,6 @@ export default function ProfileAvatar({
           <div className="tw-flex tw-h-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-lg tw-text-center">
             {pfpUrl ? (
               // Profile avatars can come from arbitrary remote hosts, so this stays unoptimized.
-              // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={getScaledImageUri(pfpUrl, ImageScale.W_AUTO_H_50)}
                 alt={alt}

--- a/components/drops/view/part/dropPartMarkdown/content.tsx
+++ b/components/drops/view/part/dropPartMarkdown/content.tsx
@@ -197,7 +197,6 @@ const containsOnlyNativeEmojis = (str: string): boolean => {
 };
 
 const CustomEmojiImage = ({ alt, bigEmoji, src }: CustomEmojiImageProps) => (
-  // eslint-disable-next-line @next/next/no-img-element -- Emoji markdown tokens have dynamic inline dimensions.
   <img
     src={src}
     alt={alt}

--- a/components/react-query-wrapper/utils/toggleWaveFollowing.ts
+++ b/components/react-query-wrapper/utils/toggleWaveFollowing.ts
@@ -3,7 +3,6 @@ import type { QueryClient } from "@tanstack/react-query";
 import { WAVE_DEFAULT_SUBSCRIPTION_ACTIONS } from "./query-utils";
 import type { ApiWave } from "@/generated/models/ApiWave";
 import type { SidebarWave, SidebarWavesPage } from "@/types/waves.types";
-// eslint-disable-next-line import/no-cycle -- QueryKey is canonical in ReactQueryWrapper until the enum is split out.
 import { QueryKey } from "../ReactQueryWrapper";
 
 type SidebarWaveQueryKey =

--- a/components/user/rep/RepContributorsDialog.tsx
+++ b/components/user/rep/RepContributorsDialog.tsx
@@ -147,7 +147,6 @@ function RepContributorRow({
           <div className="tw-flex tw-h-8 tw-w-8 tw-flex-shrink-0 tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-full tw-bg-iron-900 tw-ring-1 tw-ring-white/10">
             {contributor.pfpUrl ? (
               // Profile avatars can come from arbitrary remote hosts, so this stays unoptimized.
-              // eslint-disable-next-line @next/next/no-img-element
               <img
                 src={getScaledImageUri(
                   contributor.pfpUrl,

--- a/components/utils/input/profile-search/CommonProfileSearchItem.tsx
+++ b/components/utils/input/profile-search/CommonProfileSearchItem.tsx
@@ -51,7 +51,6 @@ export default function CommonProfileSearchItem({
                 <div className="tw-h-full tw-w-full tw-max-w-full">
                   <div className="tw-flex tw-h-full tw-items-center tw-justify-center tw-text-center">
                     {/* Keep img here because this lightweight search dropdown behaves like a typeahead. */}
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={getScaledImageUri(
                         profile.pfp,

--- a/components/waves/drops/participation/ratings/ParticipationDropRatingsVoterSection.tsx
+++ b/components/waves/drops/participation/ratings/ParticipationDropRatingsVoterSection.tsx
@@ -38,7 +38,6 @@ export default function ParticipationDropRatingsVoterSection({
                 >
                   <Link href={`/${raterLabel}`}>
                     {/* Voter avatars can come from arbitrary remote hosts, so this stays unoptimized. */}
-                    {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={getScaledImageUri(
                         rater.profile.pfp,

--- a/components/waves/drops/wave-drops-all/hooks/useDeferredNewestDrops.ts
+++ b/components/waves/drops/wave-drops-all/hooks/useDeferredNewestDrops.ts
@@ -258,7 +258,6 @@ export function useDeferredNewestDrops({
     };
 
     if (session !== nextSession) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- This commits the derived session before the next paint so deferred-drop capture stays in sync with the current render inputs.
       setSession(nextSession);
     }
   }, [isAppleMobile, latestSerialNo, session, shouldPinToBottom, waveId]);

--- a/components/waves/winners/drops/header/WaveWinnersDropHeaderAuthorPfp.tsx
+++ b/components/waves/winners/drops/header/WaveWinnersDropHeaderAuthorPfp.tsx
@@ -19,7 +19,6 @@ export default function WaveWinnersDropHeaderAuthorPfp({
           <div className="tw-h-full tw-w-full tw-max-w-full tw-overflow-hidden tw-rounded-lg tw-bg-iron-900 tw-ring-1 tw-ring-white/10">
             <div className="tw-flex tw-h-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-lg tw-text-center">
               {/* Winner avatars can come from arbitrary remote hosts, so this stays unoptimized. */}
-              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={winner.drop.author.pfp}
                 alt="Profile picture"

--- a/components/waves/winners/drops/header/WaveWinnersDropHeaderVoter.tsx
+++ b/components/waves/winners/drops/header/WaveWinnersDropHeaderVoter.tsx
@@ -30,7 +30,6 @@ export default function WaveWinnersDropHeaderVoter({
         <Link href={`/${voterLabel}`}>
           {voter.profile.pfp ? (
             // Winner voter avatars can come from arbitrary remote hosts, so this stays unoptimized.
-            // eslint-disable-next-line @next/next/no-img-element
             <img
               src={getScaledImageUri(voter.profile.pfp, ImageScale.W_AUTO_H_50)}
               alt={`${voterLabel}'s Profile`}

--- a/hooks/useObjectUrl.ts
+++ b/hooks/useObjectUrl.ts
@@ -42,7 +42,6 @@ export function useObjectUrls(
         const emptyUrls = new Map<Blob, string>();
         latestUrlBySource.current = emptyUrls;
         // Object URLs must be created after commit; this state publishes the ready URLs.
-        // eslint-disable-next-line react-hooks/set-state-in-effect
         setUrlBySource(emptyUrls);
       }
       return;
@@ -72,7 +71,6 @@ export function useObjectUrls(
       const resolvedUrls = nextUrls;
       latestUrlBySource.current = resolvedUrls;
       // Object URLs must be created after commit; this state publishes the ready URLs.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setUrlBySource(resolvedUrls);
     }
   }, [sources, urlBySource]);

--- a/next-sitemap.build.cjs
+++ b/next-sitemap.build.cjs
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 require("tsx/cjs");
 
 const sitemapConfig = require("./next-sitemap.config.ts");

--- a/ops/scripts/publish-delegation-docs-content.mjs
+++ b/ops/scripts/publish-delegation-docs-content.mjs
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-/* eslint-disable security/detect-non-literal-fs-filename -- all filesystem paths are constrained to this repo before use */
 
 import { createHash } from "node:crypto";
 import { createReadStream } from "node:fs";


### PR DESCRIPTION
## Issue
- A post-merge App PR CI run failed in `lint:changed` because ESLint found unused `eslint-disable` directives and the job runs with `--max-warnings=0`.
- The directives were stale suppressions, not functional code requirements.

## Fix
- Removed the 16 unused `eslint-disable` comments reported by the failed job.
- Preserved nearby explanatory comments where they still document why raw images or effect state updates are intentional.

## Changes
- Comment-only cleanup across the files reported by the failed lint job.
- No runtime behavior changes.

## Validation
- `./bin/6529 run lint:changed`

## Risk
- Level: Low
- Why: The change only removes unused lint suppression comments.
- Rollback: Revert this PR if a downstream lint configuration unexpectedly requires a suppression again.

## Review Notes
- Review can focus on confirming the diff is limited to stale lint directive removal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up lint suppression comments across several components and scripts.
  * Improved script startup and command-line readiness for sitemap generation and documentation publishing.
* **Style**
  * Kept image/avatar rendering behavior the same while removing outdated inline ESLint exceptions.
  * Removed a few stale explanatory comments without changing app behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->