### PR TITLE
Render boosted standalone media URLs as media

### DIFF
--- a/__tests__/components/home/boosted/BoostedDropCardHome.test.tsx
+++ b/__tests__/components/home/boosted/BoostedDropCardHome.test.tsx
@@ -598,6 +598,64 @@ describe("BoostedDropCardHome", () => {
     expect(screen.queryByTestId("content-display")).not.toBeInTheDocument();
   });
 
+  it("renders standalone direct audio URLs as boosted media", () => {
+    const audioUrl = "https://example.com/track.mp3";
+
+    renderWithAuth(
+      <BoostedDropCardHome
+        drop={createDrop({
+          parts: [
+            {
+              content: audioUrl,
+              media: [],
+            },
+          ],
+        })}
+        onClick={jest.fn()}
+        variant="chat"
+        rank={1}
+      />
+    );
+
+    expect(screen.getByTestId("drop-media")).toBeInTheDocument();
+    expect(mockDropListItemContentMedia).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        media_mime_type: "audio/mpeg",
+        media_url: audioUrl,
+      })
+    );
+    expect(mockBoostedDropLinkPreview).not.toHaveBeenCalled();
+  });
+
+  it("renders standalone direct 3D model URLs as boosted media", () => {
+    const modelUrl = "https://example.com/sculpture.glb";
+
+    renderWithAuth(
+      <BoostedDropCardHome
+        drop={createDrop({
+          parts: [
+            {
+              content: modelUrl,
+              media: [],
+            },
+          ],
+        })}
+        onClick={jest.fn()}
+        variant="chat"
+        rank={1}
+      />
+    );
+
+    expect(screen.getByTestId("drop-media")).toBeInTheDocument();
+    expect(mockDropListItemContentMedia).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        media_mime_type: "model/gltf-binary",
+        media_url: modelUrl,
+      })
+    );
+    expect(mockBoostedDropLinkPreview).not.toHaveBeenCalled();
+  });
+
   it("keeps non-media standalone URLs on the boosted link-preview path", () => {
     const articleUrl = "https://example.com/article";
 

--- a/__tests__/components/home/boosted/BoostedDropCardHome.test.tsx
+++ b/__tests__/components/home/boosted/BoostedDropCardHome.test.tsx
@@ -509,6 +509,151 @@ describe("BoostedDropCardHome", () => {
     expect(mockBoostedDropLinkPreview).not.toHaveBeenCalled();
   });
 
+  it("renders standalone direct image URLs as boosted media", () => {
+    const imageUrl = "https://example.com/art.jpg";
+
+    renderWithAuth(
+      <BoostedDropCardHome
+        drop={createDrop({
+          parts: [
+            {
+              content: imageUrl,
+              media: [],
+            },
+          ],
+        })}
+        onClick={jest.fn()}
+        variant="chat"
+        rank={1}
+      />
+    );
+
+    expect(screen.getByTestId("drop-media")).toBeInTheDocument();
+    expect(mockDropListItemContentMedia).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        media_mime_type: "image/jpeg",
+        media_url: imageUrl,
+      })
+    );
+    expect(mockBoostedDropLinkPreview).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("link-preview")).not.toBeInTheDocument();
+  });
+
+  it("renders standalone direct video URLs as boosted media", () => {
+    const videoUrl = "https://example.com/clip.mp4";
+
+    renderWithAuth(
+      <BoostedDropCardHome
+        drop={createDrop({
+          parts: [
+            {
+              content: videoUrl,
+              media: [],
+            },
+          ],
+        })}
+        onClick={jest.fn()}
+        variant="chat"
+        rank={1}
+      />
+    );
+
+    expect(screen.getByTestId("drop-media")).toBeInTheDocument();
+    expect(mockDropListItemContentMedia).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        media_mime_type: "video/mp4",
+        media_url: videoUrl,
+      })
+    );
+    expect(mockBoostedDropLinkPreview).not.toHaveBeenCalled();
+  });
+
+  it("renders captioned markdown images as boosted media when no link preview competes", () => {
+    const imageUrl = "https://example.com/captioned.webp";
+
+    renderWithAuth(
+      <BoostedDropCardHome
+        drop={createDrop({
+          parts: [
+            {
+              content: `Great one\n\n![Captioned](${imageUrl})`,
+              media: [],
+            },
+          ],
+        })}
+        onClick={jest.fn()}
+        variant="chat"
+        rank={1}
+      />
+    );
+
+    expect(screen.getByTestId("drop-media")).toBeInTheDocument();
+    expect(mockDropListItemContentMedia).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        media_mime_type: "image/webp",
+        media_url: imageUrl,
+      })
+    );
+    expect(mockBoostedDropLinkPreview).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("content-display")).not.toBeInTheDocument();
+  });
+
+  it("keeps non-media standalone URLs on the boosted link-preview path", () => {
+    const articleUrl = "https://example.com/article";
+
+    renderWithAuth(
+      <BoostedDropCardHome
+        drop={createDrop({
+          parts: [
+            {
+              content: articleUrl,
+              media: [],
+            },
+          ],
+        })}
+        onClick={jest.fn()}
+        variant="chat"
+        rank={1}
+      />
+    );
+
+    expect(mockBoostedDropLinkPreview).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        href: articleUrl,
+        variant: "chat",
+      })
+    );
+    expect(mockDropListItemContentMedia).not.toHaveBeenCalled();
+  });
+
+  it("keeps standalone webpage URLs on the boosted link-preview path", () => {
+    const pageUrl = "https://example.com/gallery/page.html";
+
+    renderWithAuth(
+      <BoostedDropCardHome
+        drop={createDrop({
+          parts: [
+            {
+              content: pageUrl,
+              media: [],
+            },
+          ],
+        })}
+        onClick={jest.fn()}
+        variant="chat"
+        rank={1}
+      />
+    );
+
+    expect(mockBoostedDropLinkPreview).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        href: pageUrl,
+        variant: "chat",
+      })
+    );
+    expect(mockDropListItemContentMedia).not.toHaveBeenCalled();
+  });
+
   it("does not render supplemental chat content after the lead media", () => {
     renderWithAuth(
       <BoostedDropCardHome

--- a/__tests__/components/home/boosted/extractStandaloneUrl.test.ts
+++ b/__tests__/components/home/boosted/extractStandaloneUrl.test.ts
@@ -1,4 +1,8 @@
-import { removePreviewUrlFromContent } from "@/components/home/boosted/extractStandaloneUrl";
+import {
+  extractFirstMarkdownImage,
+  extractStandaloneUrl,
+  removePreviewUrlFromContent,
+} from "@/components/home/boosted/extractStandaloneUrl";
 
 describe("removePreviewUrlFromContent", () => {
   it("keeps markdown image URLs intact when the preview URL matches", () => {
@@ -7,5 +11,39 @@ describe("removePreviewUrlFromContent", () => {
     const content = `![Seize](${imageUrl})`;
 
     expect(removePreviewUrlFromContent(content, imageUrl)).toBe(content);
+  });
+});
+
+describe("extractStandaloneUrl", () => {
+  it("returns a direct URL when it is the only visible content", () => {
+    expect(extractStandaloneUrl(" https://example.com/art.png ")).toBe(
+      "https://example.com/art.png"
+    );
+  });
+
+  it("ignores markdown links and markdown images", () => {
+    expect(extractStandaloneUrl("[Art](https://example.com/art.png)")).toBe(
+      null
+    );
+    expect(extractStandaloneUrl("![Art](https://example.com/art.png)")).toBe(
+      null
+    );
+  });
+
+  it("returns null when surrounding text is present", () => {
+    expect(extractStandaloneUrl("look https://example.com/art.png")).toBe(null);
+  });
+});
+
+describe("extractFirstMarkdownImage", () => {
+  it("returns the first markdown image even when it has a caption", () => {
+    expect(
+      extractFirstMarkdownImage(
+        "caption\n\n![Art](https://example.com/art.png)"
+      )
+    ).toEqual({
+      alt: "Art",
+      url: "https://example.com/art.png",
+    });
   });
 });

--- a/components/home/boosted/BoostedDropCardHomeContent.tsx
+++ b/components/home/boosted/BoostedDropCardHomeContent.tsx
@@ -16,7 +16,9 @@ import {
 } from "react";
 import BoostedDropLinkPreview from "./BoostedDropLinkPreview";
 import {
+  extractFirstMarkdownImage,
   extractFirstUrl,
+  extractStandaloneUrl,
   extractStandaloneMarkdownImage,
   removePreviewUrlFromContent,
 } from "./extractStandaloneUrl";
@@ -43,17 +45,32 @@ const HOME_PREVIEW_CONTAINER_CLASSES = `tw-relative tw-flex ${HOME_ASPECT_RATIO_
 const HOME_TEXT_CONTAINER_CLASSES = `tw-relative tw-flex ${HOME_ASPECT_RATIO_CLASSES} tw-w-full tw-items-center tw-justify-center tw-overflow-hidden tw-rounded-xl tw-px-6 tw-pb-6 sm:tw-pb-0 tw-pt-4 sm:tw-pt-16 md:tw-pt-12`;
 const CHAT_PREVIEW_WRAPPER_BASE_CLASSES =
   "tw-pointer-events-none tw-relative tw-z-30 tw-grid tw-h-full tw-w-full tw-min-w-0 tw-max-w-full tw-grid-rows-[minmax(0,1fr)_auto] [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto [&_video]:tw-pointer-events-auto";
-const IMAGE_MIME_TYPES_BY_TOKEN: Readonly<Record<string, string>> = {
+const MEDIA_MIME_TYPES_BY_TOKEN: Readonly<Record<string, string>> = {
+  aac: "audio/aac",
   avif: "image/avif",
+  flac: "audio/flac",
   gif: "image/gif",
+  glb: "model/gltf-binary",
+  gltf: "model/gltf+json",
   jpeg: "image/jpeg",
   jpg: "image/jpeg",
+  m4a: "audio/mp4",
+  m4v: "video/mp4",
+  mkv: "video/x-matroska",
+  mov: "video/quicktime",
+  mp3: "audio/mpeg",
+  mp4: "video/mp4",
+  oga: "audio/ogg",
+  ogg: "video/ogg",
+  ogv: "video/ogg",
   png: "image/png",
   svg: "image/svg+xml",
+  wav: "audio/wav",
+  webm: "video/webm",
   webp: "image/webp",
 };
 
-const getImageMimeTypeFromToken = (
+const getMediaMimeTypeFromToken = (
   token: string | null | undefined
 ): string | null => {
   if (!token) {
@@ -61,13 +78,13 @@ const getImageMimeTypeFromToken = (
   }
 
   const normalizedToken = token.toLowerCase().replace(/^\./, "");
-  return IMAGE_MIME_TYPES_BY_TOKEN[normalizedToken] ?? null;
+  return MEDIA_MIME_TYPES_BY_TOKEN[normalizedToken] ?? null;
 };
 
-const getStandaloneMarkdownImageMimeType = (url: string): string => {
+const getMediaMimeTypeFromUrl = (url: string): string | null => {
   try {
     const parsedUrl = new URL(url);
-    const outputMimeType = getImageMimeTypeFromToken(
+    const outputMimeType = getMediaMimeTypeFromToken(
       parsedUrl.searchParams.get("output")
     );
 
@@ -76,21 +93,43 @@ const getStandaloneMarkdownImageMimeType = (url: string): string => {
     }
 
     const extension = parsedUrl.pathname.split(".").pop();
-    const extensionMimeType = getImageMimeTypeFromToken(extension);
+    const extensionMimeType = getMediaMimeTypeFromToken(extension);
 
     if (extensionMimeType) {
       return extensionMimeType;
     }
   } catch {
     const extension = url.split(/[?#]/)[0]?.split(".").pop();
-    const extensionMimeType = getImageMimeTypeFromToken(extension);
+    const extensionMimeType = getMediaMimeTypeFromToken(extension);
 
     if (extensionMimeType) {
       return extensionMimeType;
     }
   }
 
-  return "image/*";
+  return null;
+};
+
+const getMarkdownImageMimeType = (url: string): string =>
+  getMediaMimeTypeFromUrl(url) ?? "image/*";
+
+const getStandaloneDirectMedia = (
+  content: string | null | undefined
+): BoostedDropMediaItem | null => {
+  const standaloneUrl = extractStandaloneUrl(content);
+  if (!standaloneUrl) {
+    return null;
+  }
+
+  const mimeType = getMediaMimeTypeFromUrl(standaloneUrl);
+  if (!mimeType) {
+    return null;
+  }
+
+  return {
+    mime_type: mimeType,
+    url: standaloneUrl,
+  };
 };
 const HOME_PREVIEW_WRAPPER_BASE_CLASSES =
   "tw-pointer-events-none tw-relative tw-z-30 tw-grid tw-h-full tw-w-full tw-min-w-0 tw-max-w-full tw-grid-rows-[minmax(0,1fr)_auto] [&_a]:tw-pointer-events-auto [&_button]:tw-pointer-events-auto [&_video]:tw-pointer-events-auto";
@@ -542,23 +581,36 @@ BoostedDropCardTextSection.displayName = "BoostedDropCardTextSection";
 
 const BoostedDropCardHomeContent = memo(
   ({ part, isChatVariant }: BoostedDropCardHomeContentProps) => {
+    const previewUrl = useMemo(
+      () => extractFirstUrl(part?.content),
+      [part?.content]
+    );
     const standaloneMarkdownImage = useMemo(
       () => extractStandaloneMarkdownImage(part?.content),
+      [part?.content]
+    );
+    const fallbackMarkdownImage = useMemo(
+      () =>
+        standaloneMarkdownImage ??
+        (previewUrl ? null : extractFirstMarkdownImage(part?.content)),
+      [part?.content, previewUrl, standaloneMarkdownImage]
+    );
+    const standaloneDirectMedia = useMemo(
+      () => getStandaloneDirectMedia(part?.content),
       [part?.content]
     );
     const attachedMedia = part?.media[0];
     const media = useMemo(
       () =>
         attachedMedia ??
-        (standaloneMarkdownImage
+        standaloneDirectMedia ??
+        (fallbackMarkdownImage
           ? {
-              mime_type: getStandaloneMarkdownImageMimeType(
-                standaloneMarkdownImage.url
-              ),
-              url: standaloneMarkdownImage.url,
+              mime_type: getMarkdownImageMimeType(fallbackMarkdownImage.url),
+              url: fallbackMarkdownImage.url,
             }
           : undefined),
-      [attachedMedia, standaloneMarkdownImage]
+      [attachedMedia, fallbackMarkdownImage, standaloneDirectMedia]
     );
 
     if (!media) {

--- a/components/home/boosted/BoostedDropCardHomeContent.tsx
+++ b/components/home/boosted/BoostedDropCardHomeContent.tsx
@@ -61,7 +61,8 @@ const MEDIA_MIME_TYPES_BY_TOKEN: Readonly<Record<string, string>> = {
   mp3: "audio/mpeg",
   mp4: "video/mp4",
   oga: "audio/ogg",
-  ogg: "video/ogg",
+  // Bare .ogg is ambiguous; Vorbis audio is the dominant real-world case.
+  ogg: "audio/ogg",
   ogv: "video/ogg",
   png: "image/png",
   svg: "image/svg+xml",

--- a/components/home/boosted/extractStandaloneUrl.ts
+++ b/components/home/boosted/extractStandaloneUrl.ts
@@ -340,6 +340,9 @@ export const extractStandaloneUrl = (
 
 /**
  * Returns the first markdown image found in content.
+ *
+ * Accepts untrimmed content: only the candidate's url/label are used, never
+ * its offsets, so callers must not rely on this for position-based slicing.
  */
 export const extractFirstMarkdownImage = (
   content: string | null | undefined

--- a/components/home/boosted/extractStandaloneUrl.ts
+++ b/components/home/boosted/extractStandaloneUrl.ts
@@ -300,6 +300,73 @@ export const extractFirstUrl = (
 };
 
 /**
+ * Returns a raw standalone URL when it is the only visible content.
+ */
+export const extractStandaloneUrl = (
+  content: string | null | undefined
+): string | null => {
+  if (!content) {
+    return null;
+  }
+
+  const trimmed = content.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const candidates = collectUrlCandidates(trimmed);
+  if (candidates.length !== 1) {
+    return null;
+  }
+
+  const [candidate] = candidates;
+  if (!candidate) {
+    return null;
+  }
+
+  const normalizedUrl = normalizeUrlCandidate(candidate.url);
+  if (!normalizedUrl) {
+    return null;
+  }
+
+  const before = trimmed.slice(0, candidate.index);
+  const after = trimmed.slice(candidate.index + candidate.url.length);
+  if (before.trim() || after.trim()) {
+    return null;
+  }
+
+  return normalizedUrl;
+};
+
+/**
+ * Returns the first markdown image found in content.
+ */
+export const extractFirstMarkdownImage = (
+  content: string | null | undefined
+): MarkdownImage | null => {
+  if (!content) {
+    return null;
+  }
+
+  const imageCandidate = collectMarkdownLinkCandidates(content).find(
+    (candidate) => candidate.isImage
+  );
+  if (!imageCandidate) {
+    return null;
+  }
+
+  const normalizedUrl = normalizeUrlCandidate(imageCandidate.url);
+  if (!normalizedUrl) {
+    return null;
+  }
+
+  return {
+    alt: imageCandidate.label.trim() || "Media",
+    url: normalizedUrl,
+  };
+};
+
+/**
  * Returns a single markdown image when it is the only visible content.
  */
 export const extractStandaloneMarkdownImage = (
@@ -335,15 +402,12 @@ export const extractStandaloneMarkdownImage = (
     return null;
   }
 
-  const normalizedUrl = normalizeUrlCandidate(imageCandidate.url);
-  if (!normalizedUrl) {
+  const markdownImage = extractFirstMarkdownImage(trimmed);
+  if (!markdownImage) {
     return null;
   }
 
-  return {
-    alt: imageCandidate.label.trim() || "Media",
-    url: normalizedUrl,
-  };
+  return markdownImage;
 };
 
 /**

--- a/ops/docs/waves/drop-actions/feature-drop-boosting.md
+++ b/ops/docs/waves/drop-actions/feature-drop-boosting.md
@@ -62,6 +62,54 @@ Sidebar layout and `Trending` shell behavior are documented in
 - When new drops arrive, in-thread boosted cards move upward with the feed; they
   do not stay pinned near the newest message.
 
+## Boosted Card Rendering Contract
+
+Boosted cards are compact card surfaces, but they must not change the meaning or
+primary content type of the original drop.
+
+- A drop that is media-first in the normal thread card must stay media-first when
+  boosted. This includes API media, standalone direct media URLs, and Markdown
+  images that would otherwise collapse into raw text or a tiny thumbnail.
+- A drop that is link-preview-first in the normal thread card must keep a
+  provider-specific preview when boosted when that provider has a specialized
+  card. Current shared preview handlers include GitHub, TikTok, Google
+  Workspace, NFT marketplace links, ENS, Compound, Twitter/X, Wikimedia, Tenor
+  GIFs, Art Blocks, `pepe.wtf`, Farcaster/Warpcast, first-party 6529 links, and
+  generic Open Graph previews.
+- If a boosted surface intentionally uses a smaller variant than the full thread
+  card, the compact variant still needs to preserve the recognizable card type:
+  image as image, video as video, tweet as tweet, collection preview as
+  collection preview, quote/internal link as quote/internal link, and generic URL
+  as link preview.
+- Boosted rendering must not expose Markdown syntax or raw media URLs that the
+  standard drop card would hide. Examples to guard against: `![alt](url)`
+  showing as text, leftover `!alt`, or a direct image URL rendered as a generic
+  metadata card.
+- When more than one rich object competes in a compact boosted card, choose the
+  first high-signal preview path and document any intentional fallback in the
+  relevant feature page or test name.
+
+## Card Visual QA
+
+When changing any card, card preview, media renderer, or Markdown/link handling,
+validate both the normal drop surface and the boosted-card surface across web,
+mobile, and desktop views.
+
+- Web/default view: normal thread card, in-thread boosted card, and sidebar or
+  home boosted card when applicable.
+- Mobile web: normal thread card and in-thread boosted card at a narrow
+  viewport.
+- Desktop web: normal thread card, in-thread boosted card, and any persistent
+  sidebar/home boosted placement.
+- Responsive desktop/tablet widths: confirm text, media actions, badges, and
+  preview controls do not overlap or escape their card bounds.
+- Boosted variants: confirm the card still uses the right content type, keeps
+  action controls usable, and avoids raw Markdown/URL residue.
+- For media and provider previews, verify rendered pixels as well as DOM text:
+  images should load, video/audio/model/html fallbacks should be coherent,
+  provider cards should not collapse into a generic fallback unexpectedly, and
+  console/network errors should be unrelated to the changed card.
+
 ## Edge Cases
 
 - Not connected:


### PR DESCRIPTION
## Issue
- Boosted cards only rendered attached API media or a standalone markdown image; a drop whose content is a direct media URL (`https://.../art.jpg`, `.../clip.mp4`) fell through to a generic link preview, and a captioned markdown image (`text + ![alt](url)`) collapsed to raw text. This work was recovered from an unmerged boosted-card audit and rebased onto current `main`.

## Fix
- Add `extractStandaloneUrl` (raw URL that is the only visible content) and `extractFirstMarkdownImage` (first markdown image even with surrounding caption) to `components/home/boosted/extractStandaloneUrl.ts`, and use them in `BoostedDropCardHomeContent` as fallbacks after attached media: attached media → standalone direct media URL → markdown image.
- Widen the extension→MIME map beyond images to audio (`aac/flac/m4a/mp3/oga/wav`), video (`m4v/mkv/mov/mp4/ogg/ogv/webm`), and 3D models (`glb/gltf`), so `DropListItemContentMedia` renders the right media type.
- Deliberately exclude `.html`: standalone webpage URLs stay on the link-preview path instead of becoming iframe embeds (hardening added during rebase; regression test included).

## Changes
- `components/home/boosted/extractStandaloneUrl.ts`: two new exported extractors; `extractStandaloneMarkdownImage` now delegates to `extractFirstMarkdownImage`.
- `components/home/boosted/BoostedDropCardHomeContent.tsx`: renamed `IMAGE_MIME_TYPES_BY_TOKEN` → `MEDIA_MIME_TYPES_BY_TOKEN`, added `getStandaloneDirectMedia`, new fallback chain in `BoostedDropCardHomeContent`.
- Tests: 5 new cases in `BoostedDropCardHome.test.tsx` (direct image URL, direct video URL, captioned markdown image, non-media URL stays link preview, `.html` URL stays link preview) and extractor unit tests in `extractStandaloneUrl.test.ts`.
- Docs: `ops/docs/waves/drop-actions/feature-drop-boosting.md` gains a Boosted Card Rendering Contract and Card Visual QA checklist.

## Validation
- Patch rebased onto current `main` (both source files unchanged since the audit base, applied cleanly).
- CI (jest, lint, typecheck) runs on this PR; local targeted jest run on the two touched suites is queued behind a fresh dependency install and results will be posted as a follow-up comment.

## Risk
- Level: Low
- Why: scoped to boosted-card rendering fallbacks; attached API media behavior is unchanged (it stays first in the chain); worst case is a boosted card rendering media where a link preview appeared before.
- Rollback: revert this single commit.

## Review Notes
- Please sanity-check the fallback ordering in `BoostedDropCardHomeContent` (`attachedMedia ?? standaloneDirectMedia ?? markdown image`) and the decision to exclude `text/html` from the standalone-URL map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Boosted cards now better recognize standalone media and markdown images, showing the most relevant preview type for links, images, and videos.
  * Direct media URLs can now render as boosted media with the correct media type detected automatically.

* **Bug Fixes**
  * Improved card selection so non-media links continue to show link previews instead of being treated as media.
  * Prevents raw markdown or media URLs from surfacing in boosted card display.

* **Tests**
  * Expanded coverage for media vs. link-preview behavior and standalone content detection.

* **Documentation**
  * Added updated guidance and visual QA checks for boosted card rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->