### PR TITLE
Track repo-health 2026-07 campaign state

### DIFF
--- a/ops/workstreams/repo-health-2026-07/README.md
+++ b/ops/workstreams/repo-health-2026-07/README.md
@@ -1,0 +1,40 @@
+# Repo Health Campaign — 2026-07
+
+Mission: close the five structural gaps found in the 2026-07-04 audit. Finish the
+problems, don't just freeze them: ratchets are backstops, burn-down waves drive
+counts to zero, and the ratchet floor lowers automatically as counts drop.
+
+Orchestrated autonomously by a Claude (Fable 5) session; each workstream runs as
+a fresh Fable 5 thread that may fan out to cheaper subagents for mechanical work.
+
+## Workstreams and definition of done
+
+| ID | Workstream | Done means |
+| --- | --- | --- |
+| A | Merge gate | Required PR CI on main (typecheck, lint, tests); debt/coverage ratchets active; Playwright harness runs again (`testHelpers` fixed) |
+| B | Branch amnesty | Dirty tree rescue-committed; the 138-commit `codex/polish-boosted-link-cards` branch triaged and landed-or-archived; merged branches pruned with manifest; stale-unmerged report delivered for sign-off; nightly branch-janitor workflow live |
+| C | One styling system | Zero `bootstrap`/`react-bootstrap` imports; both deps removed from package.json; delegation area migrated to Tailwind |
+| D | One layout | `src/` tree folded into root-level layout; pages-router remnants migrated or deleted (knip-verified); no source file over the agreed line cap; grandfather list empty |
+| E | Dead patterns | Redux fully removed (`@reduxjs/toolkit`, `react-redux`, `next-redux-wrapper` gone); `any` count driven to ~0 with documented exceptions; TODO/FIXME/HACK triaged to near-zero (fixed, ticketed, or deleted) |
+
+## Audit baseline (2026-07-04)
+
+- CI gates: deploy workflows only; PR-time enforcement = lint + build. No typecheck/test gate. No coverage thresholds.
+- Branches: ~1,053 total (`branch -a`), incl. 232 remote `codex/*`; current branch 138 ahead of main, diverged, 116-file dirty tree.
+- Styling: Bootstrap 5 + react-bootstrap + SCSS modules + Tailwind coexist.
+- Layout: stray `src/` tree (13 files) duplicating root dirs; ~134 legacy pages-router files; top file sizes 2,410 / 2,347 / 2,241 lines (drop-forge, CreateDropContent, CollectionDelegation…).
+- Debt counts: 317 `: any`/`as any` (components+hooks); 2,841 TODO/FIXME/HACK across 1,279 files; Redux = 2 slices (`editSlice`, `groupSlice`).
+- E2E: `test:e2e:staging` broken — `Cannot find module '../testHelpers'`.
+
+## Policies (user-approved 2026-07-04)
+
+1. **Merge**: auto-merge campaign PRs once PR CI is green and reviewbot passes. Every merge is reported. Deploys remain manual (staging = `1a-staging` push, prod = manual workflow) — merging main ships nothing.
+2. **Branch prune**: merged branches may be deleted now (manifest first, `.git/branch-cleanup-manifest-*.txt` scheme). Unmerged-stale branches: report for user sign-off before deletion.
+3. **138-commit branch**: triage-then-land-delta. Rescue-commit dirty tree, archive superseded work to manifest, rebase + land novel work as small PRs.
+
+## Conventions (hard rules for all threads)
+
+- Worktrees: sibling dirs `D:/repos/6529seize-frontend-<topic>` — NEVER `.claude/worktrees` (jest finds zero tests under dot-dirs).
+- Commands via repo wrapper: `./bin/6529 run <script>`; plain pnpm is blocked. In fresh worktrees, prepend real pnpm to PATH (bin/ shim shadows it) — see memory/worktree-and-tooling-gotchas.
+- Commits: `git commit -s` (DCO). Small, scoped PRs; reviewbot reviews every PR.
+- Never push to `1a-staging`; never trigger deploy workflows.

--- a/ops/workstreams/repo-health-2026-07/README.md
+++ b/ops/workstreams/repo-health-2026-07/README.md
@@ -34,7 +34,7 @@ a fresh Fable 5 thread that may fan out to cheaper subagents for mechanical work
 
 ## Conventions (hard rules for all threads)
 
-- Worktrees: sibling dirs `D:/repos/6529seize-frontend-<topic>` — NEVER `.claude/worktrees` (jest finds zero tests under dot-dirs).
+- Worktrees: sibling dirs `<repo-parent>/6529seize-frontend-<topic>` — NEVER `.claude/worktrees` (jest finds zero tests under dot-dirs).
 - Commands via repo wrapper: `./bin/6529 run <script>`; plain pnpm is blocked. In fresh worktrees, prepend real pnpm to PATH (bin/ shim shadows it) — see memory/worktree-and-tooling-gotchas.
 - Commits: `git commit -s` (DCO). Small, scoped PRs; reviewbot reviews every PR.
 - Never push to `1a-staging`; never trigger deploy workflows.

--- a/ops/workstreams/repo-health-2026-07/active-context.md
+++ b/ops/workstreams/repo-health-2026-07/active-context.md
@@ -1,0 +1,25 @@
+# Active Context
+
+## Resume first
+
+Read this after compaction or session handoff. Orchestrator session memory:
+`C:\Users\Administrator\.claude\projects\D--repos-6529seize-frontend\memory\repo-health-campaign-2026-07.md`
+
+## Wave state
+
+- Wave 1 (launched 2026-07-04): Thread A (merge gate) + Thread B (branch amnesty). Thread ids in run-log.md.
+- Wave 2 (blocked on A's gate + B's rescue): Thread C (styling), Thread D (layout/splits), Thread E (dead patterns).
+- Wave 3: burn-down loops until every ratchet metric hits its target, then remove grandfather lists.
+
+## Sequencing constraints
+
+- A merges first: its PR CI + ratchet is the gate everything else lands through.
+- B rescue-commits the primary tree before anything else; B is the ONLY thread allowed to touch the primary checkout.
+- C waits for B to land/archive the delegation-heavy dirty-tree work before migrating `components/delegation/`.
+- C, D, E partition by directory ownership to avoid conflicts; orchestrator staggers merges.
+
+## Escalation triggers (back to user)
+
+- Stale-unmerged branch deletion (needs sign-off on B's report).
+- Any deploy decision.
+- Any destructive action outside approved policy scope.

--- a/ops/workstreams/repo-health-2026-07/active-context.md
+++ b/ops/workstreams/repo-health-2026-07/active-context.md
@@ -3,7 +3,8 @@
 ## Resume first
 
 Read this after compaction or session handoff. Orchestrator session memory:
-`C:\Users\Administrator\.claude\projects\D--repos-6529seize-frontend\memory\repo-health-campaign-2026-07.md`
+`repo-health-campaign-2026-07.md` in the operator's Claude project auto-memory
+for this repo (machine-local; not tracked in the repository).
 
 ## Wave state
 

--- a/ops/workstreams/repo-health-2026-07/run-log.md
+++ b/ops/workstreams/repo-health-2026-07/run-log.md
@@ -1,0 +1,36 @@
+# Run Log
+
+## 2026-07-04
+
+- Audit completed (Explore agent + orchestrator): see README baseline section.
+- User approved campaign + policies (merge: auto-merge when green; prune: merged now / stale report; 138-commit branch: triage-then-land-delta).
+- Campaign state dir created (untracked in primary checkout; Thread A commits it in its first PR; Thread B excludes it from the rescue snapshot).
+- Wave 1 threads launched: Thread A (merge gate) and Thread B (branch amnesty), both fresh Fable 5 background threads managed by the orchestrator session. Thread ids are session-internal; cross-session resume goes through this state dir, not thread ids.
+
+## 2026-07-04 (Thread B — branch amnesty)
+
+- Phase 1 complete: dirty tree (117 status entries / 454 staged paths) rescue-committed on `codex/polish-boosted-link-cards` as `09ef4659c` ("WIP rescue snapshot: pre-campaign dirty tree (2026-07-04)"), signed off, pushed to origin as new remote branch (backup). Primary tree clean; campaign dir left untracked per convention.
+
+## 2026-07-04 (Thread A — merge gate)
+
+- Worktree `D:/repos/6529seize-frontend-ci` created on `ci/pr-gate` from `origin/main` (6af669907).
+- Audit correction: the merge-gate baseline is stale. `origin/main` already ships
+  `.github/workflows/app-pr-ci.yml` — a risk-plan-driven PR CI (jobs: "Plan risk and
+  security checks" + "Installed app checks") covering secret scan, workflow security
+  review, knip, `lint:changed`, `typecheck:changed`, `typecheck:playwright`, related
+  Jest, conditional production build, and conditional Playwright smoke/critical-shell
+  packs. It landed via the frontend-a11y-i18n testing-improvement workstream.
+- `tests/testHelpers.ts` exists on `origin/main` with a full `tests/support/` harness;
+  the "Cannot find module '../testHelpers'" break may already be repaired — local
+  verification pending.
+- Real gap found: ruleset 18018081 ("main maintainer review and merge policy")
+  requires only `DCO` and `security/snyk (6529)` status checks — the PR CI jobs are
+  NOT required, so red CI does not block merges. Plan: require the two app-pr-ci job
+  names (plus the debt ratchet once it lands) in the ruleset instead of authoring a
+  duplicate workflow.
+- Measured app-pr-ci wall times (last 8 runs): ~13–15 min typical, 26–27 min when the
+  build + Playwright packs are required. A separate always-on full-suite job would
+  roughly double PR latency; keeping the risk-plan conditionality.
+- Adjusted Thread A deliverables: PR 1 = campaign state dir (this PR); PR 2 = debt
+  ratchet (script + baseline + install-free CI job); PR 3 = coverage floor on main
+  pushes; PR 4 = e2e harness verify/fix; then ruleset update for required checks.

--- a/ops/workstreams/repo-health-2026-07/run-log.md
+++ b/ops/workstreams/repo-health-2026-07/run-log.md
@@ -13,7 +13,7 @@
 
 ## 2026-07-04 (Thread A — merge gate)
 
-- Worktree `D:/repos/6529seize-frontend-ci` created on `ci/pr-gate` from `origin/main` (6af669907).
+- Sibling worktree `6529seize-frontend-ci` created on `ci/pr-gate` from `origin/main` (6af669907).
 - Audit correction: the merge-gate baseline is stale. `origin/main` already ships
   `.github/workflows/app-pr-ci.yml` — a risk-plan-driven PR CI (jobs: "Plan risk and
   security checks" + "Installed app checks") covering secret scan, workflow security


### PR DESCRIPTION
## Issue
- The repo-health 2026-07 campaign (user-approved 2026-07-04) coordinates several worktree threads (merge gate, branch amnesty, styling, layout, dead patterns), but its shared state directory only existed untracked on one machine. Threads and future sessions need a tracked, reviewable coordination point.

## Fix
- Commit `ops/workstreams/repo-health-2026-07/` (mission README, active context, run log) following the existing `ops/workstreams/<name>/` convention, and record Thread A's merge-gate findings in the run log.

## Changes
- New: `ops/workstreams/repo-health-2026-07/README.md` — mission, workstream table, audit baseline, user-approved policies, conventions.
- New: `ops/workstreams/repo-health-2026-07/active-context.md` — wave state and sequencing constraints.
- New: `ops/workstreams/repo-health-2026-07/run-log.md` — dated milestones, including an audit correction: `main` already ships risk-plan PR CI (`app-pr-ci.yml`); the remaining merge-gate gap is that the main ruleset requires only `DCO` and `security/snyk (6529)`, so PR CI results do not yet block merges.

## Validation
- Docs-only change; no runtime code touched. Markdown reviewed for accuracy against the current ruleset and workflow list.
- Expect the PR CI plan lane to classify this as docs-only (no install lane).

## Risk
- Level: Low
- Why: adds documentation under `ops/`; no build, runtime, or CI behavior changes.
- Rollback: revert the commit.

## Review Notes
- The run log corrects two stale audit claims (PR CI existence, `pages/` remnants) — flag anything else that reads stale.
- Follow-up PRs in this series: debt ratchet (script + baseline + CI job), coverage floor on main pushes, e2e harness verification, then required-status-check ruleset update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)