### PR TITLE
Queue main-push coverage runs; record merge-gate wrap-up

### DIFF
--- a/.github/workflows/coverage-floor.yml
+++ b/.github/workflows/coverage-floor.yml
@@ -26,9 +26,12 @@ on:
 permissions:
   contents: read
 
+# PR runs cancel superseded heads; main-push runs queue instead (GitHub keeps
+# only the newest pending run per group), so a busy merge train still gets a
+# completed coverage verdict on its final state instead of a cancel cascade.
 concurrency:
   group: coverage-floor-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   coverage-floor:


### PR DESCRIPTION
## Issue
- During the amnesty merge train (three main pushes in 16 minutes), `cancel-in-progress: true` cancelled two consecutive Coverage Floor runs on main before any produced a verdict — a busy merge period can starve the post-merge coverage gate entirely.

## Fix
- Scope `cancel-in-progress` to `pull_request` events: PR runs still cancel superseded heads, while main-push runs queue (GitHub keeps only the newest pending run per group), so a merge train always ends with one completed run on its final state.

## Changes
- `.github/workflows/coverage-floor.yml`: conditional `cancel-in-progress` + explanatory comment. (Run-log wrap-up entry moved to the follow-up secret-hygiene PR to stop tail-append conflicts with other active campaign threads.)

## Validation
- Repo workflow-security validator: zero findings; prettier clean.
- The expression evaluates `true` for `pull_request` and `false` for `push`/`workflow_dispatch`.
- This PR touches the coverage workflow, so its own `Coverage floor` PR run exercises the change pre-merge (passed on the two previous heads of this PR already).

## Risk
- Level: Low
- Why: one workflow expression; worst case is queued (rather than cancelled) coverage runs on main, bounded to one in-flight + one pending.
- Rollback: revert the commit.

## Review Notes
- Queuing was chosen over unconditional cancel because the floor's purpose is a completed verdict per merge-train endpoint; intermediate states are legitimately skippable.
- The earlier responsiveness-lane finding (`/rememes` 60s timeout in the bot's dev-server harness) is unrelated to this diff — deferral rationale documented in the PR comments; being reported to the campaign orchestrator as a standing perf item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)