### PR TITLE
Record Phase 5 follow-up: orphan dir rescue and cleanup

### DIFF
--- a/ops/workstreams/repo-health-2026-07/branch-triage-ledger.md
+++ b/ops/workstreams/repo-health-2026-07/branch-triage-ledger.md
@@ -51,6 +51,11 @@ presence checks, PR-stack archaeology (gh), and per-cluster subagent review.
 | `tmp/**` (219 files), `.reviewbot-responsiveness/` | Session debris — archived in the branch snapshot only, never to be PRed |
 | `tmp/punk6529bot-browser-auth.json` | SECURITY: contained a live JWT + refresh token; excised from the pushed branch (rewritten `09ef4659c` -> `dac8f5cf1`) and preserved off-repo. History rewrite does NOT invalidate the exposed token (GitHub retains SHA-reachable objects); server-side revocation/rotation of the punk6529bot session + refresh token is REQUIRED and PENDING — owner: repo operator; tracked as an open campaign action in run-log.md. |
 
+Related rescue (Phase 5 follow-up, 2026-07-05): the orphaned
+`-desktop-hardening` clone's uncommitted media-URL-sink hardening was
+secrets-scanned and preserved as `origin/codex/harden-media-url-sinks-for-desktop-sync`
+(`0c88192b9`) before the clone dir was removed.
+
 Snapshot preservation: the full rescue tree (minus the excised credential)
 remains available as branch tip `dac8f5cf1` recorded in
 `.git/branch-cleanup-manifest-2026-07-05.txt` when the branch is deleted.

--- a/ops/workstreams/repo-health-2026-07/run-log.md
+++ b/ops/workstreams/repo-health-2026-07/run-log.md
@@ -100,3 +100,23 @@
   `-pr-followups` (1.6G, on 1a-staging with untracked release-check tests),
   `-rememes-2609-node_modules-partial` (488M, no .git),
   `-native-package-evidence` + `-pr2680` (16K each, no .git).
+
+## 2026-07-05 (Thread B — Phase 5 follow-up: orphan dir cleanup)
+
+- Rescued `D:\repos\6529seize-frontend-desktop-hardening` (standalone clone,
+  1.1G): 8 dirty files of media-URL-sink hardening (new `lib/media/safe-media-url.ts`,
+  open-graph utils, HLS player, sandboxed iframe, audio display + tests)
+  secrets-scanned (clean), committed as `0c88192b9` and pushed as
+  `origin/codex/harden-media-url-sinks-for-desktop-sync` (new remote branch; no
+  other unpushed branches/stashes). Local dir deleted after push verification.
+- Deleted debris dirs: `-rememes-2609-node_modules-partial` (488M, only .pnpm
+  fragments) and `-native-package-evidence` (empty; was held by an orphaned
+  June-23 `git commit`+vim pair whose worktree metadata was pruned on 07-04 —
+  both processes killed). `-pr2680` (empty, 0 bytes) is still held as CWD by an
+  unidentified process among live sessions — deferred rather than blind-killing;
+  delete after the holder exits.
+- `D:\repos\6529seize-frontend-pr-followups` (on `1a-staging`, untracked
+  release-check tests) intentionally untouched — plausibly the external
+  release-tender thread's working dir.
+- Unrelated observation for the record: stale June 21-22 vim/git-rebase orphan
+  processes exist for `D:\repos\6529reviewbot` (different repo, left alone).


### PR DESCRIPTION
## Issue
- The branch-amnesty Phase 5 audit left orphan sibling working dirs for disposition; the coordinator approved rescue+cleanup, which needs recording in the campaign log and triage ledger.

## Fix
- Records-only update documenting the follow-up actions.

## Changes
- `ops/workstreams/repo-health-2026-07/run-log.md`: Phase 5 follow-up entry — desktop-hardening WIP rescued (secrets-scanned, pushed as `codex/harden-media-url-sinks-for-desktop-sync`, dir removed), debris dirs deleted (488M + 1 empty; one empty dir deferred with rationale), pr-followups dir intentionally untouched, unrelated 6529reviewbot orphan processes noted.
- `ops/workstreams/repo-health-2026-07/branch-triage-ledger.md`: one paragraph linking the rescued hardening branch to the snapshot-preservation section.

## Validation
- Docs-only.

## Risk
- Level: Low
- Why: documentation only.
- Rollback: revert the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)