### PR TITLE
Add API reference and on-chain guide for agents

### DIFF
--- a/api-for-agents.json
+++ b/api-for-agents.json
@@ -1,0 +1,407 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-06-26",
+  "description": "Curated API endpoint map for 6529.io. Distilled from the 6529 MCP server skill and backend source code. Not a replacement for the full OpenAPI spec (553KB in the repo) — this is a curated entry point for agents to discover what queries are possible and how to make them.",
+  "base_url": "https://api.6529.io",
+  "headers_required": {
+    "Origin": "https://6529.io",
+    "Referer": "https://6529.io/"
+  },
+  "rate_limits": {
+    "burst": 30,
+    "sustained": 10,
+    "unit": "requests per minute (unauthenticated)",
+    "recommended_delay": "0.5s between requests for bulk queries",
+    "backoff_on_429": "10 seconds",
+    "note": "Authenticated requests may have higher limits. Check api.6529.io/docs for current limits."
+  },
+  "swagger_docs": "https://api.6529.io/docs",
+  "openapi_spec": "openapi.yaml in github.com/6529-Collections/6529seize-frontend (553KB, not served publicly)",
+  "oracle_base_url": "https://your-prenode-oracle.example.com",
+  "oracle_note": "The prenode oracle is a community-run data source for TDH and card data. It is separate from api.6529.io and has its own rate limits (~60 rapid requests before 429).",
+  "endpoints": [
+    {
+      "category": "identities",
+      "path": "/api/identities/by-wallet/{address}",
+      "method": "GET",
+      "what": "Map any Ethereum wallet address to full 6529.io identity profile",
+      "returns": "id, handle, normalised_handle, cic, rep, tdh, tdh_rate, xtdh, xtdh_rate, level, display (ENS), primary_wallet, pfp, banner1, banner2, wallets[], classification, sub_classification, consolidation_key, is_wave_creator, profile_wave_id, artist_of_prevote_cards[], winner_main_stage_drop_ids",
+      "example": "GET /api/identities/by-wallet/0x0000000000000000000000000000000000000001",
+      "agent_use_case": "Look up someone's 6529 profile from their wallet address",
+      "pitfalls": [
+        "Use 0.5s delay between bulk requests",
+        "Handle 429 with 10s backoff",
+        "Some fields like artist_of_prevote_cards can be stale — cross-reference with card-snapshot data"
+      ]
+    },
+    {
+      "category": "identities",
+      "path": "/api/identities/{handle}",
+      "method": "GET",
+      "what": "Get identity profile by handle (e.g. punk6529)",
+      "returns": "Same fields as by-wallet endpoint",
+      "example": "GET /api/identities/punk6529",
+      "agent_use_case": "Look up someone's 6529 profile from their handle",
+      "pitfalls": [
+        "Some old identity endpoints (e.g. /api/6529Profile/) return 404 — use /api/identities/ pattern"
+      ]
+    },
+    {
+      "category": "profiles",
+      "path": "/api/profiles/{identity}",
+      "method": "GET",
+      "what": "Get profile data by identity key",
+      "returns": "Profile details including display info, wallet data, and profile-level metrics",
+      "example": "GET /api/profiles/punk6529",
+      "agent_use_case": "Get detailed profile information beyond what identities endpoint returns",
+      "pitfalls": []
+    },
+    {
+      "category": "profiles",
+      "path": "/api/profiles/{handle}/wave",
+      "method": "GET",
+      "what": "Get a profile's wave ID and curation ID",
+      "returns": "{profile_wave_id, profile_curation_id}",
+      "example": "GET /api/profiles/example-handle/wave",
+      "agent_use_case": "Find someone's wave to audit their wave score",
+      "pitfalls": [
+        "Returns null if the user hasn't created a wave"
+      ]
+    },
+    {
+      "category": "profiles",
+      "path": "/api/profiles/{handle}/availability",
+      "method": "GET",
+      "what": "Check if a handle is available",
+      "returns": "Availability status",
+      "example": "GET /api/profiles/newuser/availability",
+      "agent_use_case": "Check handle availability before suggesting a profile name",
+      "pitfalls": []
+    },
+    {
+      "category": "rep",
+      "path": "/api/profile-rep/overview",
+      "method": "GET",
+      "what": "REP overview across the network",
+      "returns": "REP category overview data",
+      "example": "GET /api/profile-rep/overview",
+      "agent_use_case": "Understand REP distribution across categories",
+      "pitfalls": []
+    },
+    {
+      "category": "rep",
+      "path": "/api/profile-rep/categories",
+      "method": "GET",
+      "what": "List all REP categories",
+      "returns": "Array of category objects with names and metadata",
+      "example": "GET /api/profile-rep/categories",
+      "agent_use_case": "Discover what REP categories exist in the 6529 network",
+      "pitfalls": []
+    },
+    {
+      "category": "rep",
+      "path": "/api/profile-rep/ratings/received",
+      "method": "GET",
+      "what": "Get REP ratings received by a profile",
+      "returns": "Array of ratings with rater, category, amount, timestamp",
+      "example": "GET /api/profile-rep/ratings/received?identity=punk6529",
+      "agent_use_case": "See who has given REP to a profile and in which categories",
+      "pitfalls": [
+        "May require authentication or identity parameter"
+      ]
+    },
+    {
+      "category": "rep",
+      "path": "/api/profile-rep/ratings/by-rater",
+      "method": "GET",
+      "what": "Get REP ratings given by a profile",
+      "returns": "Array of ratings with recipient, category, amount, timestamp",
+      "example": "GET /api/profile-rep/ratings/by-rater?identity=punk6529",
+      "agent_use_case": "See who a profile has given REP to",
+      "pitfalls": [
+        "May require authentication or identity parameter"
+      ]
+    },
+    {
+      "category": "tdh",
+      "path": "/api/tdh/consolidated_metrics",
+      "method": "GET",
+      "what": "Paginated list of ALL ecosystem wallets with identity and TDH data",
+      "returns": "count, data[] with handle, level, rep_score, cic_score, tdh, boosted_tdh, unboosted_tdh, balance, unique_memes, memes_cards_sets, consolidation_key, pfp_url, consolidation_display, day_change",
+      "example": "GET /api/tdh/consolidated_metrics?page=1&pageSize=50",
+      "agent_use_case": "Get the full TDH leaderboard or benchmark multiple wallets",
+      "pitfalls": [
+        "~17,934 wallets total",
+        "50-100 per page",
+        "Use 0.5s delay between page fetches"
+      ]
+    },
+    {
+      "category": "tdh",
+      "path": "/api/tdh/nft/{contract}/{token_id}",
+      "method": "GET",
+      "what": "Get per-NFT holder data with full identity",
+      "returns": "data[] with token_id, contract, balance, consolidation_key, tdh, boost, boosted_tdh, tdh_rank, handle, pfp_url, rep_score, cic_score, primary_wallet, xtdh, consolidation_display, total_balance, total_tdh, level",
+      "example": "GET /api/tdh/nft/0x33FD426905F149f8376e227d0C9D3340AaD17aF1/401",
+      "agent_use_case": "Find who holds a specific meme card or gradient, with their full identity",
+      "pitfalls": [
+        "Meme contract: 0x33FD426905F149f8376e227d0C9D3340AaD17aF1",
+        "Gradient contract: 0x0c58ef43ff3032005e472cb5709f8908acb00205"
+      ]
+    },
+    {
+      "category": "collection",
+      "path": "/api/collected-stats/{handle_or_wallet}",
+      "method": "GET",
+      "what": "Per-season collection depth for a profile",
+      "returns": "boost, memes_balance, unique_memes, gradients_balance, nextgen_balance, seasons[] with per-season sets_held, partial_set_unique_cards_held, total_cards_held, total_cards_in_season",
+      "example": "GET /api/collected-stats/punk6529",
+      "agent_use_case": "See how many season sets a collector has completed and their collection depth",
+      "pitfalls": []
+    },
+    {
+      "category": "nfts",
+      "path": "/api/nfts",
+      "method": "GET",
+      "what": "Per-card market data (price, volume, hodl rate, supply)",
+      "returns": "Array of card objects: mint_price, supply, floor_price, market_cap, total_volume, total_volume_last_24_hours, total_volume_last_7_days, total_volume_last_1_month, highest_offer, hodl_rate, mint_date",
+      "example": "GET /api/nfts?contract=0x33FD426905F149f8376e227d0C9D3340AaD17aF1&page=1",
+      "agent_use_case": "Get market data for all meme cards — volume, floor prices, hodl rates",
+      "pitfalls": [
+        "101 cards per page",
+        "6 pages for 512 cards",
+        "Mint price is 0.06529 ETH standard, 0 for free mints"
+      ]
+    },
+    {
+      "category": "royalties",
+      "path": "/api/royalties/collection/{collection_type}",
+      "method": "GET",
+      "what": "Per-card royalty and proceeds data",
+      "returns": "Array of {token_id, contract, name, artist, thumbnail, volume, proceeds, artist_split, artist_take}",
+      "example": "GET /api/royalties/collection/memes",
+      "agent_use_case": "See how much each card has generated in secondary volume and primary proceeds",
+      "pitfalls": [
+        "collection_type='memes' works; others may not"
+      ]
+    },
+    {
+      "category": "activity",
+      "path": "/api/aggregated-activity",
+      "method": "GET",
+      "what": "Per-holder purchase/sale/transfer history",
+      "returns": "data[] with primary_purchases_count/value, secondary_purchases_count/value, sales_count/value, transfers_in/out, airdrops, burns",
+      "example": "GET /api/aggregated-activity?consolidation_key={ckey}&pageSize=100",
+      "agent_use_case": "Track a collector's full transaction history (buys, sells, transfers)",
+      "pitfalls": [
+        "CRITICAL: Returns ALL wallets that interacted WITH the given consolidation_key, sorted by volume. The first entry is punk6529 (most active), NOT the queried holder. Search data[] for matching consolidation_key to find the holder's own activity.",
+        "Less active holders may need up to 5 pages",
+        "26K+ entries per holder — pagination is expensive"
+      ]
+    },
+    {
+      "category": "waves",
+      "path": "/api/waves/{waveId}",
+      "method": "GET",
+      "what": "Get wave data including score breakdown",
+      "returns": "Wave metadata, score components, penalties, safety multiplier, quality gate, visibility tier, wave REP, formula constants",
+      "example": "GET /api/waves/{waveId}",
+      "agent_use_case": "Audit a wave's discovery score and understand why it's visible or demoted",
+      "pitfalls": [
+        "Need the wave UUID, not the name — use wave search or profile wave endpoint to get it"
+      ]
+    },
+    {
+      "category": "waves",
+      "path": "/api/waves/{waveId}/leaderboard",
+      "method": "GET",
+      "what": "Get ranked PARTICIPATORY drops (art submissions) with full author profiles, ratings, media, and content",
+      "returns": "Array of ranked drops with rank, rating, top_raters, reactions, media URLs, author profiles, content",
+      "example": "GET /api/waves/{waveId}/leaderboard",
+      "agent_use_case": "Get the actual art submissions and their rankings from a wave",
+      "pitfalls": [
+        "Use /leaderboard for art submissions, NOT /drops (which returns CHAT messages only)",
+        "Art submissions have drop_type 'PARTICIPATORY'; chat messages have drop_type 'CHAT'"
+      ]
+    },
+    {
+      "category": "waves",
+      "path": "/api/waves/{waveId}/drops",
+      "method": "GET",
+      "what": "Get CHAT drops (messages) from a wave's community feed",
+      "returns": "Array of chat message drops with content, author, reactions",
+      "example": "GET /api/waves/{waveId}/drops?sort=newest",
+      "agent_use_case": "Read the conversation in a wave's chat feed",
+      "pitfalls": [
+        "Returns CHAT drops only, not PARTICIPATORY art submissions. Use /leaderboard for art."
+      ]
+    },
+    {
+      "category": "waves",
+      "path": "/api/drops/{dropUUID}",
+      "method": "GET",
+      "what": "Get full content of a single drop by UUID",
+      "returns": "Full drop JSON: content, media, author, rank, rating, top_raters, reactions, is_signed, drop_type",
+      "example": "GET /api/drops/{dropUUID}",
+      "agent_use_case": "Read the full content of a specific drop when you have its UUID",
+      "pitfalls": []
+    },
+    {
+      "category": "oracle",
+      "path": "/oracle/tdh/total",
+      "method": "GET",
+      "base_url_override": "https://your-prenode-oracle.example.com",
+      "what": "Ecosystem-wide TDH totals",
+      "returns": "Total TDH, memes/gradients/nextgen breakdown, merkle root, block number",
+      "example": "GET https://your-prenode-oracle.example.com/oracle/tdh/total",
+      "agent_use_case": "Get the current total TDH across the entire 6529 ecosystem",
+      "pitfalls": [
+        "Oracle is community-run — may be temporarily unavailable"
+      ]
+    },
+    {
+      "category": "oracle",
+      "path": "/oracle/tdh/above/{value}/entries",
+      "method": "GET",
+      "base_url_override": "https://your-prenode-oracle.example.com",
+      "what": "TDH leaderboard above a threshold",
+      "returns": "Array of {consolidation_key, tdh, addresses[]}",
+      "example": "GET https://your-prenode-oracle.example.com/oracle/tdh/above/1000000/entries",
+      "agent_use_case": "Get all wallets above a TDH threshold for benchmarking",
+      "pitfalls": [
+        "Returns ~244 entries for TDH > 1,000,000"
+      ]
+    },
+    {
+      "category": "oracle",
+      "path": "/oracle/address/{address}/breakdown",
+      "method": "GET",
+      "base_url_override": "https://your-prenode-oracle.example.com",
+      "what": "Full TDH breakdown for a wallet: memes, gradients, nextgen, per-season",
+      "returns": "memes_balance, memes[], gradients_balance, gradients[], nextgen_balance, nextgen[], block, merkle_root",
+      "example": "GET https://your-prenode-oracle.example.com/oracle/address/0x0000000000000000000000000000000000000001/breakdown",
+      "agent_use_case": "Get detailed TDH breakdown showing which collections contribute to a wallet's TDH",
+      "pitfalls": [
+        "gradients and gradients_balance are at TOP LEVEL of response, NOT nested under a 'breakdown' key",
+        "Oracle returns 429 after ~60 rapid requests — use 0.5-1s delay"
+      ]
+    },
+    {
+      "category": "oracle",
+      "path": "/oracle/nfts/{contract}/{id}",
+      "method": "GET",
+      "base_url_override": "https://your-prenode-oracle.example.com",
+      "what": "Single NFT metadata (TDH, mint_date, edition_size)",
+      "returns": "NFT metadata with TDH data",
+      "example": "GET https://your-prenode-oracle.example.com/oracle/nfts/0x33FD426905F149f8376e227d0C9D3340AaD17aF1/401",
+      "agent_use_case": "Get TDH and metadata for a specific meme card or gradient",
+      "pitfalls": []
+    },
+    {
+      "category": "oracle",
+      "path": "/oracle/cards",
+      "method": "GET",
+      "base_url_override": "https://your-prenode-oracle.example.com",
+      "what": "Card snapshot data for all meme cards",
+      "returns": "Array of card objects with TDH, rank, artist, season, supply, mint date",
+      "example": "GET https://your-prenode-oracle.example.com/oracle/cards",
+      "agent_use_case": "Get all meme card data in one request for local indexing",
+      "pitfalls": [
+        "Large response — may be slow",
+        "Not auto-regenerated — check freshness"
+      ]
+    }
+  ],
+  "common_queries": [
+    {
+      "question": "What is someone's TDH?",
+      "primary": "GET /api/identities/by-wallet/{address} → tdh field",
+      "alternative": "GET https://your-prenode-oracle.example.com/oracle/address/{address} for just TDH",
+      "full_breakdown": "GET https://your-prenode-oracle.example.com/oracle/address/{address}/breakdown for per-collection TDH",
+      "see_also": [
+        "For on-chain alternatives (direct Ethereum queries), see /on-chain-basics.json"
+      ]
+    },
+    {
+      "question": "List all meme cards",
+      "primary": "GET /api/nfts?contract=0x33FD426905F149f8376e227d0C9D3340AaD17aF1&page={N}",
+      "note": "101 cards per page, 6 pages for 512 cards. Each card has market data (volume, floor, hodl rate).",
+      "see_also": [
+        "For on-chain alternatives (direct Ethereum queries), see /on-chain-basics.json"
+      ]
+    },
+    {
+      "question": "Who holds a specific meme card?",
+      "primary": "GET /api/tdh/nft/{contract}/{token_id}",
+      "returns": "Current holder's handle, level, REP, CIC, TDH, xTDH",
+      "see_also": [
+        "For on-chain alternatives (direct Ethereum queries), see /on-chain-basics.json"
+      ]
+    },
+    {
+      "question": "What is someone's wave score?",
+      "steps": [
+        "GET /api/profiles/{handle}/wave → get profile_wave_id",
+        "GET /api/waves/{waveId} → full score breakdown"
+      ],
+      "note": "Wave score includes 5 quality components, 4 penalties, safety multiplier, quality gate, and visibility tier.",
+      "see_also": null
+    },
+    {
+      "question": "What art was submitted to a wave?",
+      "primary": "GET /api/waves/{waveId}/leaderboard",
+      "note": "Use /leaderboard NOT /drops. /drops returns chat messages only. /leaderboard returns PARTICIPATORY art submissions with rankings, ratings, and media.",
+      "see_also": null
+    },
+    {
+      "question": "What are the total ecosystem TDH stats?",
+      "primary": "GET https://your-prenode-oracle.example.com/oracle/tdh/total",
+      "alternative": "GET /api/tdh/consolidated_metrics?page=1&pageSize=1 → count field gives total wallets",
+      "see_also": null
+    },
+    {
+      "question": "How much volume has a card generated?",
+      "primary": "GET /api/royalties/collection/memes → find card by token_id",
+      "returns": "volume (secondary), proceeds (primary), artist_split, artist_take",
+      "see_also": null
+    },
+    {
+      "question": "What seasons has someone collected?",
+      "primary": "GET /api/collected-stats/{handle_or_wallet}",
+      "returns": "Per-season sets_held, total_cards_held, total_cards_in_season — shows collection completeness",
+      "see_also": null
+    },
+    {
+      "question": "What is someone's full transaction history?",
+      "primary": "GET /api/aggregated-activity?consolidation_key={ckey}&pageSize=100",
+      "pitfall": "Returns ALL wallets that interacted WITH the ckey, sorted by volume. Search data[] for matching consolidation_key to find the holder's OWN activity.",
+      "see_also": null
+    },
+    {
+      "question": "Who are the top TDH holders?",
+      "primary": "GET https://your-prenode-oracle.example.com/oracle/tdh/above/{threshold}/entries",
+      "alternative": "GET /api/tdh/consolidated_metrics?page=1&pageSize=100 (sorted by TDH)",
+      "see_also": null
+    }
+  ],
+  "contracts": {
+    "memes": "0x33FD426905F149f8376e227d0C9D3340AaD17aF1",
+    "gradients": "0x0c58ef43ff3032005e472cb5709f8908acb00205",
+    "note": "Meme contract has 512+ tokens. Gradient contract has 101 tokens (minted Oct 2021)."
+  },
+  "source_code": {
+    "backend_repo": "https://github.com/6529-Collections/6529seize-backend",
+    "route_files": "Search for *.routes.ts in src/api-serverless/src/ to find all endpoints",
+    "key_route_files": [
+      "identities/identities.routes.ts",
+      "profiles/profiles.routes.ts",
+      "profiles/profile-rep.routes.ts",
+      "waves/waves.routes.ts",
+      "drops/drops.routes.ts",
+      "ratings/ratings.routes.ts",
+      "nft-owners/api.nft-owners.routes.ts",
+      "royalties/royalties.routes.ts"
+    ]
+  },
+  "freshness": "versioned"
+}

--- a/license-overview.json
+++ b/license-overview.json
@@ -1,0 +1,310 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-06-26",
+  "description": "License permissivity spectrum and 6529's licensing strategy with cultural context for internationalization.",
+  "spectrum": [
+    {
+      "level": 0,
+      "license": "All Rights Reserved",
+      "description": "Default copyright. No reuse without explicit permission from the rights holder.",
+      "who_uses_this": "Traditional media, corporate content, default state of any unlicensed creative work"
+    },
+    {
+      "level": 1,
+      "license": "CC BY-NC-ND",
+      "description": "Creative Commons with attribution, no commercial use, no derivatives. Most restrictive CC license.",
+      "who_uses_this": "Artists who want attribution and control over modifications and commercial use"
+    },
+    {
+      "level": 2,
+      "license": "CC BY-SA",
+      "description": "Creative Commons share-alike. Derivatives must use the same license. Copyleft for creative works.",
+      "who_uses_this": "Wikipedia, open educational resources, some open art projects"
+    },
+    {
+      "level": 3,
+      "license": "GPL-3.0",
+      "description": "Strong copyleft software license. Derivatives must also be open source under GPL.",
+      "who_uses_this": "Linux kernel, many FOSS projects"
+    },
+    {
+      "level": 4,
+      "license": "Apache-2.0",
+      "description": "Permissive software license with patent protection clause. Contributors grant patent rights to users.",
+      "who_uses_this": "6529 production code repos, many enterprise open-source projects"
+    },
+    {
+      "level": 5,
+      "license": "MIT",
+      "description": "Most permissive software license. Do anything, just keep the copyright notice. No patent protection.",
+      "who_uses_this": "6529 standalone tool/bot repos, many developer tools, React, .NET"
+    },
+    {
+      "level": 6,
+      "license": "CC0",
+      "description": "Public domain dedication. No rights reserved. Anyone can use, remix, commercialize, or build on the work without any restriction or attribution requirement.",
+      "who_uses_this": "6529 Meme Collection community tier, 1939 color engine, public domain archives"
+    }
+  ],
+  "strategy": {
+    "memes": {
+      "license": "CC0",
+      "repos": [
+        "6529 Meme Collection community tier"
+      ],
+      "why": "Releasing novel creative value into the public domain is an intentional design choice. CC0 memes maximize cultural propagation — anyone can use, remix, commercialize, or build on them without friction. The meme spreads because there is no legal barrier. This is the network effects strategy: value flows out, adoption flows in.",
+      "source": "https://6529.io/about/license"
+    },
+    "production_code": {
+      "license": "Apache-2.0",
+      "repos": [
+        "6529seize-frontend",
+        "6529seize-backend",
+        "6529seize-admin",
+        "nextgen",
+        "Janus",
+        "6529-Prenode"
+      ],
+      "why": "Production code uses Apache-2.0 for the patent protection clause — contributors grant patent rights to users. This protects the ecosystem from patent trolls while remaining permissive. The patent grant is a formal trust framework: you give permission, but with legal guardrails.",
+      "source": "https://github.com/6529-Collections/6529seize-frontend/blob/main/LICENSE"
+    },
+    "agent_skills": {
+      "license": "Apache-2.0",
+      "repos": [
+        "6529seize-frontend/ops/skills/ (11 repo-local skills)"
+      ],
+      "why": "Repo-local agent skills inherit the parent repo's Apache-2.0 license. They are part of the production codebase, not standalone tools. The patent clause protects both the skill authors and the users of those skills.",
+      "source": "https://github.com/6529-Collections/6529seize-frontend/tree/main/ops/skills"
+    },
+    "standalone_tools": {
+      "license": "MIT",
+      "repos": [
+        "6529Stream (Solidity contracts)",
+        "6529reviewbot (AI PR review bot)",
+        "nftdelegation (delegation contract)",
+        "ai-code-review-action (code review action)"
+      ],
+      "why": "Standalone tools and bots use MIT — the most permissive software license. Anyone can copy, modify, commercialize without restriction. Maximum adoption with minimal friction. No patent overhead for utility tools.",
+      "source": "https://github.com/6529-Collections"
+    },
+    "unlicensed": {
+      "license": "No license file (default copyright)",
+      "repos": [
+        "thememecards",
+        "gradient",
+        "6529-core",
+        "allowlist-lib",
+        "allowlist-api",
+        "6529node"
+      ],
+      "why": "Documentation and configuration repos without a license file. These repos may benefit from adopting a license for clarity.",
+      "source": "https://github.com/6529-Collections"
+    }
+  },
+  "cultural_context": {
+    "description": "How cultures understand the license spectrum — from control to freedom. These mappings help agents translate license concepts for non-English speakers and contextualize CC0 within local traditions of shared property and gift culture.",
+    "cultures": {
+      "ko": {
+        "language": "Korean",
+        "translations": {
+          "All Rights Reserved": "모든 권리 보유 (modeun gwolli boyu)",
+          "Copyright": "저작권 (jeojakgwon)",
+          "Open Source": "오픈소스 (open source)",
+          "Public Domain": "퍼블릭 도메인 (public domain) / 공유지 (gongyujji)",
+          "Creative Commons": "크리에이티브 커먼즈 (creative commons)",
+          "CC0": "CC0 (공유지 헌정 — gongyujji heonjeong)",
+          "Permissive License": "관대한 라이선스 (gandaehan license)",
+          "Copyleft": "카피레프트 (copyleft)",
+          "Patent Protection": "특허 보호 (teukyeo boho)"
+        },
+        "cultural_equivalents": {
+          "CC0_public_domain": {
+            "concept": "공유지 (gongyujji) — shared commons",
+            "mapping": "CC0 maps to the traditional Korean concept of jeong (정) — bonds that strengthen through shared experience. Just as jeong accumulates through mutual giving without expectation of return, CC0 releases creative work to the commons without reservation.",
+            "notes": "The Korean concept of 누리 (nuri) means 'world' or 'shared space' — the digital commons. CC0 work enters the nuri for anyone to use. The hanok (traditional house) principle of openness to the community also maps here."
+          },
+          "Apache_patent_protection": {
+            "concept": "신뢰 (sinroe) — trust with structure",
+            "mapping": "Apache-2.0's patent clause maps to Korea's corporate culture of formal trust frameworks (계약서, gyeyakseo) — you give permission but with legal protections in place. Not pure generosity — generosity with guardrails.",
+            "notes": "Korean business culture values formal agreements even among allies. Apache-2.0's patent grant is like a 계약서 (contract) that protects both sides."
+          },
+          "MIT_max_adoption": {
+            "concept": "선물 (seonmul) — gift",
+            "mapping": "MIT maps to the Korean gift-giving tradition — you give something useful with minimal strings attached. The receiver can use it however they want. Like a graduation gift: take it and build your future.",
+            "notes": "Korean gift culture (선물 문화) emphasizes usefulness and lack of obligation. MIT's 'do anything, just keep the notice' is the closest license equivalent."
+          },
+          "copyleft_share_alike": {
+            "concept": "한길 (hangil) — the same path",
+            "mapping": "GPL/CC-BY-SA maps to the Korean community work ethic (협동, hyeopdong) — if you benefit from collective effort, you must contribute back equally. The 'share-alike' principle resonates with Korean notions of mutual obligation.",
+            "notes": "Korean 농협 (Nonghyup, agricultural cooperative) tradition: what you take from the commons, you must give back proportionally."
+          }
+        },
+        "ip_attitude": "South Korea has strong IP laws (KIPO) and is a signatory to major IP treaties. However, Korean digital culture has a strong tradition of 공유 (gongyu, sharing) — Naver cafes, DC Inside galleries, and fan communities operate on sharing norms. The tension between formal IP law and informal sharing culture is ongoing.",
+        "traditional_commons": "Jeul (즐) — communal joy through shared experience. Nongak (농악) — farmers' music performed collectively, no single owner. Pansori — oral tradition passed down through generations, owned by no one. Madang (마당) — the open courtyard where community gathered, belonged to everyone.",
+        "sensitivity_notes": "Avoid equating CC0 with 'free' without context — Korean speakers may interpret 'free' as 무료 (no cost) rather than 자유 (freedom). Use '공유지 헌정' (dedicated to commons) to clarify."
+      },
+      "es": {
+        "language": "Spanish",
+        "translations": {
+          "All Rights Reserved": "Todos los derechos reservados",
+          "Copyright": "Derechos de autor",
+          "Open Source": "Código abierto / Software libre",
+          "Public Domain": "Dominio público",
+          "Creative Commons": "Creative Commons",
+          "CC0": "CC0 (Dominio público dedicado)",
+          "Permissive License": "Licencia permisiva",
+          "Copyleft": "Copyleft / Licencia viral",
+          "Patent Protection": "Protección de patentes"
+        },
+        "cultural_equivalents": {
+          "CC0_public_domain": {
+            "concept": "Bien común — the common good",
+            "mapping": "CC0 maps to the Spanish/Latin American concept of bien común (common good) and the tradition of copyleft in Latin America (Brazil's Lula government adopted open source nationally). The Mexican corrido tradition — songs that belong to everyone and evolve through collective retelling — is a cultural precursor to CC0.",
+            "notes": "Hispanic culture has a strong tradition of collective creation: flamenco (recognized by UNESCO as intangible cultural heritage), corridos, rancheras — these are cultural forms no single person owns. CC0 formalizes what folk culture has always practiced."
+          },
+          "Apache_patent_protection": {
+            "concept": "Compromiso formal — formal commitment",
+            "mapping": "Apache-2.0's patent clause maps to the Hispanic concept of compromiso (formal commitment) — you give your word, but with legal backing. In Latin American business culture, contracts reinforce personal trust rather than replacing it.",
+            "notes": "The Apache patent grant is like a escritura pública (notarized document) — trust reinforced by formal structure."
+          },
+          "MIT_max_adoption": {
+            "concept": "Regalo — gift",
+            "mapping": "MIT maps to the Hispanic tradition of regalo (gift) — given freely, received with gratitude, used as the recipient sees fit. Like a birthday gift: once given, the giver doesn't control how it's used.",
+            "notes": "Hispanic gift culture (cultura del regalo) is about generosity without conditions. MIT's permissiveness feels natural in this cultural context."
+          },
+          "copyleft_share_alike": {
+            "concept": "Reciprocidad — reciprocity",
+            "mapping": " GPL/CC-BY-SA maps to the Andean concept of reciprocidad (reciprocity) — if you receive from the community, you must give back equally. The Inca principle of ayni (today for you, tomorrow for me) is the original share-alike.",
+            "notes": "Latin American indigenous traditions (ayni, minga) embody the share-alike principle: collective labor where everyone contributes and everyone benefits proportionally."
+          }
+        },
+        "ip_attitude": "Spain and Latin America have modern IP laws but enforcement varies widely. Hispanic culture has a strong tradition of collective creation — flamenco, corridos, muralism — where 'ownership' is communal. Open source adoption in Latin America is high (Brazil, Argentina, Mexico all have strong FOSS communities). The term 'software libre' emphasizes freedom over cost.",
+        "traditional_commons": "Los bienes comunales (communal lands) — in Spain and Latin America, traditional commons like montes vecinales (neighborhood forests) are collectively owned and managed. Flamenco palmas (handclap rhythms) — no one owns a rhythm. Corridos — folk songs that evolve through collective performance.",
+        "sensitivity_notes": "Distinguish between 'gratis' (free as in beer) and 'libre' (free as in freedom) — this distinction is well-established in Hispanic FOSS culture. Use 'libertad' not 'gratis' when discussing CC0."
+      },
+      "ja": {
+        "language": "Japanese",
+        "translations": {
+          "All Rights Reserved": "全著作権留保 (zen chosakuken ryūho)",
+          "Copyright": "著作権 (chosakuken)",
+          "Open Source": "オープンソース (ōpun sōsu)",
+          "Public Domain": "パブリックドメイン (public domain) / 著作権切れ (chosakuken-gire)",
+          "Creative Commons": "クリエイティブ・コモンズ (creative commons)",
+          "CC0": "CC0 (パブリックドメイン提供 — public domain teikyō)",
+          "Permissive License": "寛容なライセンス (kan'yō na license)",
+          "Copyleft": "コピーレフト (copyleft)",
+          "Patent Protection": "特許保護 (tokkyo hogo)"
+        },
+        "cultural_equivalents": {
+          "CC0_public_domain": {
+            "concept": "公有 (kōyū) — public ownership / 無償 (mushō) — without compensation",
+            "mapping": "CC0 maps to the Japanese concept of 公有 (kōyū, public ownership) and the tradition of 無償 (mushō, without compensation) in Japanese culture. Traditional crafts like 着物 (kimono) patterns and 書道 (shodō, calligraphy) strokes are part of a shared cultural vocabulary that no single creator owns. The concept of 我慢 (gaman, endurance) — contributing to collective harmony without expecting individual reward — also maps here.",
+            "notes": "Japan's doujin (同人) culture operates in a gray zone between copyright and communal sharing — fan works are technically infringing but culturally tolerated. CC0 provides a legal framework for what doujin culture has always practiced informally."
+          },
+          "Apache_patent_protection": {
+            "concept": "信頼と契約 (shinrai to keiyaku) — trust and contract",
+            "mapping": "Apache-2.0 maps to Japanese business culture's combination of 信頼 (shinrai, trust) and 契約 (keiyaku, formal contract). Japanese business relationships are trust-first but always backed by formal agreements. The patent clause is like a 誓約書 (seikasho, pledge document).",
+            "notes": "Japanese corporate culture values formal commitment. Apache-2.0's patent grant provides the legal structure that Japanese business practice expects."
+          },
+          "MIT_max_adoption": {
+            "concept": "贈り物 (okurimono) — gift / お返し (okaeshi) — return gift",
+            "mapping": "MIT maps to the Japanese concept of 贈り物 (okurimono, gift) within the tradition of 義理 (giri, social obligation). A gift is given freely, but Japanese culture expects acknowledgment (お礼, orei). MIT's requirement to 'keep the notice' maps naturally to the orei expectation.",
+            "notes": "Japanese gift culture (贈答文化, shōtō bunka) is highly ritualized — the gift itself is unrestricted, but acknowledgment is culturally mandatory. MIT's 'keep the notice' requirement fits this pattern perfectly."
+          },
+          "copyleft_share_alike": {
+            "concept": "共存共栄 (kyōson kyōei) — coexistence and mutual prosperity",
+            "mapping": "GPL/CC-BY-SA maps to the Japanese concept of 共存共栄 (coexistence and mutual prosperity) — if you benefit from the ecosystem, you must contribute back to sustain it. Like a Japanese moss garden (苔庭, kokeniwa): everyone tends it, everyone enjoys it, but nobody owns it exclusively.",
+            "notes": "Japan's 均等 (kintō, equality/balance) principle in community organizations — everyone contributes proportionally. Share-alike resonates with this."
+          }
+        },
+        "ip_attitude": "Japan has extremely strong IP laws (one of the world's most aggressive enforcers). However, Japanese culture has a paradoxical relationship with copying: 山寨 (san-zai, imitation) is historically respected as a form of learning. The doujin (self-published fan comics) market generates billions annually in technically-infringing works. Open source adoption is high in Japanese tech.",
+        "traditional_commons": "入会地 (iriaichi) — traditional communal lands where villagers shared grazing and forest rights. 寄付 (kifu) — donation to temples that becomes communal property. 伝統工芸 (dentō kōgei) — traditional crafts where techniques are shared across guilds without individual ownership.",
+        "sensitivity_notes": "Avoid 著作権切れ (chosakuken-gire, literally 'copyright expired') for CC0 — it implies passivity or neglect. Use パブリックドメイン提供 (public domain dedication) to emphasize intentional choice, matching 6529's framing of CC0 as deliberate."
+      },
+      "sw": {
+        "language": "Swahili",
+        "translations": {
+          "All Rights Reserved": "Haki zote zimehifadhiwa",
+          "Copyright": "Hakimiliki / Hakimiliki ya mwandishi",
+          "Open Source": "Chanzo wazi / Open source",
+          "Public Domain": "Mali ya umma / Public domain",
+          "Creative Commons": "Creative Commons",
+          "CC0": "CC0 (Mali ya umma bila masharti)",
+          "Permissive License": "Leseni yenye ruhusa pana",
+          "Copyleft": "Copyleft",
+          "Patent Protection": "Ulinda wa patent"
+        },
+        "cultural_equivalents": {
+          "CC0_public_domain": {
+            "concept": "Mali ya umma — wealth of the community / Ubuntu",
+            "mapping": "CC0 maps to the Swahili/East African concept of mali ya umma (public wealth) and the Ubuntu philosophy ('I am because we are'). In Ubuntu, knowledge and creativity belong to the community — individual creation is an expression of collective capacity. CC0 formalizes this: creative work returns to the community that enabled it.",
+            "notes": "The Kiswahili proverb 'Kidole kimoja hakivunji chawa' (one finger cannot crush a louse) — collective action requires collective resources. CC0 makes creative work available for collective use."
+          },
+          "Apache_patent_protection": {
+            "concept": "Mkataba — formal agreement",
+            "mapping": "Apache-2.0 maps to the East African concept of mkataba (formal contract). In Kenyan and Tanzanian business culture, verbal agreements (mazungumzo) establish trust, but mkataba formalizes it. Apache's patent clause is the mkataba that makes trust enforceable.",
+            "notes": "East African business culture values formal agreements alongside personal relationships. Apache-2.0's patent grant provides both."
+          },
+          "MIT_max_adoption": {
+            "concept": "Zawadi — gift",
+            "mapping": "MIT maps to the Swahili concept of zawadi (gift) — given without conditions, received with gratitude. In East African culture, a zawadi is a mark of generosity. The giver doesn't control how it's used. Like Harambee contributions: once given, they belong to the community.",
+            "notes": "Zawadi in Swahili culture carries the weight of generosity and community bond. MIT's permissiveness aligns with this — take it, use it, don't forget where it came from (keep the notice)."
+          },
+          "copyleft_share_alike": {
+            "concept": "Harambee — pull together / Chama — mutual aid group",
+            "mapping": "GPL/CC-BY-SA maps to the Swahili concept of Harambee ('all pull together') — Kenya's national motto. If you benefit from the community's collective effort, you must contribute back equally. The Chama (savings/mutual aid group) tradition embodies share-alike: everyone puts in, everyone takes out proportionally.",
+            "notes": "Harambee is literally on Kenya's coat of arms. Share-alike licensing maps to this fundamental East African principle of mutual contribution."
+          }
+        },
+        "ip_attitude": "East African countries have modern IP laws (Kenya Copyright Board, Tanzania Copyright Society) but enforcement is limited. Traditional knowledge systems emphasize communal ownership — folklore, music, and oral traditions are collectively owned. Open source and open data movements are growing in Kenya's tech hubs (Nairobi's 'Silicon Savannah'). The concept of 'ubuntu licensing' — sharing because community enables you — is gaining traction.",
+        "traditional_commons": "Ushamba (communal grazing land) — pastoralist communities share rangelands without individual ownership. Ngoma (traditional drumming/dance) — rhythms and songs belong to the community, not individuals. Methali (Swahili proverbs) — collective wisdom owned by no one. Harambee — collective fundraising for community projects (schools, wells).",
+        "sensitivity_notes": "The word 'huru' (free) in Swahili can mean 'free of cost' or 'free of constraint' — like English, this ambiguity exists. Use 'mali ya umma bila masharti' (public wealth without conditions) for CC0 to be precise."
+      },
+      "hi": {
+        "language": "Hindi",
+        "translations": {
+          "All Rights Reserved": "सर्वाधिकार सुरक्षित (sarvādhikār surakṣit)",
+          "Copyright": "कॉपीराइट / सर्वाधिकार (sarvādhikār)",
+          "Open Source": "ओपन सोर्स / मुक्त स्रोत (mukta srota)",
+          "Public Domain": "सार्वजनिक संपदा (sārvajanik sampadā) / Public domain",
+          "Creative Commons": "क्रिएटिव कॉमन्स / Creative Commons",
+          "CC0": "CC0 (सार्वजनिक संपदा समर्पण — sārvajanik sampadā samarpaṇ)",
+          "Permissive License": "अनुमतिप्रद लाइसेंस (anumati-prad license)",
+          "Copyleft": "कॉपीलेफ्ट (copyleft)",
+          "Patent Protection": "पेटेंट सुरक्षा (patent surakṣā)"
+        },
+        "cultural_equivalents": {
+          "CC0_public_domain": {
+            "concept": "सार्वजनिक संपदा (sārvajanik sampadā) — public wealth / गुरुकुल (gurukul) tradition",
+            "mapping": "CC0 maps to the Indian concept of सार्वजनिक संपदा (public wealth) and the ancient गुरुकुल (gurukul, guru's school) tradition where knowledge was freely given by teachers to students without expectation of payment. The Sanskrit concept of दान (dāna, charitable giving) — giving without expectation of return — is the spiritual equivalent of CC0. The Buddha's teachings and ancient texts like the Vedas were never 'owned' — they were passed freely.",
+            "notes": "India's open knowledge movement draws from this tradition — the National Knowledge Commission and initiatives like Open Government Data India. CC0 aligns with the dharmic principle that knowledge, once created, should flow freely."
+          },
+          "Apache_patent_protection": {
+            "concept": "लिखित समझौता (likhit samjhautā) — written agreement",
+            "mapping": "Apache-2.0 maps to the Indian business concept of लिखित समझौता (written agreement). In Indian business culture, verbal agreements establish विश्वास (vishvas, trust), but formal documents provide कानूनी सुरक्षा (legal protection). The patent clause is the formal layer over trust.",
+            "notes": "India's IT industry relies heavily on formal contracts alongside relationship-based trust. Apache-2.0's dual nature (permissive + protective) maps to this Indian business practice."
+          },
+          "MIT_max_adoption": {
+            "concept": "उपहार (upahār) — gift / प्रसाद (prasād) — blessing/offering",
+            "mapping": "MIT maps to the Hindu/Buddhist/Jain concept of प्रसाद (prasād) — a blessed offering given freely to all. Prasād is distributed at temples without conditions — take it, use it, benefit from it. The giver does not control how prasād is used. MIT's 'keep the notice' maps to the cultural expectation of acknowledging the source (गुरु, guru).",
+            "notes": "Prasād is one of India's most universal cultural concepts — offered at every Hindu temple, freely given, unconditionally received. MIT's minimal requirement (acknowledge origin) aligns with the guru-shishya (teacher-student) acknowledgment tradition."
+          },
+          "copyleft_share_alike": {
+            "concept": "सहकारिता (sahakāritā) — cooperation / चौपाल (chaupāl) — community gathering",
+            "mapping": "GPL/CC-BY-SA maps to the Indian concept of सहकारिता (cooperation) and the village चौपाल (chaupāl, community gathering space) — shared resources maintained collectively. The choupal belongs to everyone; everyone must maintain it. If you use the shared well, you must help repair it.",
+            "notes": "India's cooperative movement (अमूल/Amul dairy cooperative, sugar cooperatives) embodies share-alike — collective input, proportional output. The Panchayat (village council) tradition manages commons through collective obligation."
+          }
+        },
+        "ip_attitude": "India has modern IP laws (Copyright Act 1957, updated 2012) but enforcement is notoriously uneven. Indian culture has a complex relationship with copying — the term 'jugaad' (frugal innovation) often involves adapting existing ideas. India's pharmaceutical industry historically used compulsory licensing for medicines. Open source adoption is very high in India's IT sector (Bangalore, Hyderabad). The concept of 'मुफ्त' (muft, free) vs 'आज़ाद' (āzād, free/independent) mirrors the English gratis/libre distinction.",
+        "traditional_commons": "गाँव का चौबहरा (gaon ka chaubata) — village commons. बरगद का पेड़ (bargad ka ped) — the banyan tree under which villagers gather — a shared space owned by no one. सरोवर (sarovar) — community ponds maintained collectively. गुरुकुल — ancient education where knowledge flowed freely from guru to shishya. Manuscript traditions where texts were copied and shared across temples and monasteries without ownership claims.",
+        "sensitivity_notes": "Use आज़ाद (āzād, free as in freedom) rather than मुफ्त (muft, free as in cost) when discussing open source. For CC0, 'सार्वजनिक संपदा समर्पण' (public wealth dedication) is clearer than direct translation of 'public domain.' Avoid equating CC0 with 'ज़ेरो कॉस्ट' (zero cost) — it's about freedom, not price."
+      }
+    }
+  },
+  "design_principle": {
+    "principle": "License choice is not a legal afterthought in 6529 — it is a design decision with strategic intent.",
+    "spectrum_mapping": "More permissive = more propagation = more network effects. The spectrum from All Rights Reserved to CC0 maps to a spectrum from control to freedom, and 6529 consistently chooses the freedom end.",
+    "three_tiers": "CC0 = cultural layer (memes) — maximize propagation. Apache-2.0 = platform layer (code + skills) — patent protection. MIT = tool layer (standalone bots) — maximum adoption."
+  },
+  "freshness": "stable"
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,152 @@
+# 6529.io
+
+> 6529.io is the platform for The Memes, a global NFT art collection and decentralized community. 500+ meme cards across 15+ seasons, CC0 community tier, on-chain identity (TDH/REP/NIC), social network (Brain/Waves), and an AI-assisted development pipeline. This file tells agents what the site is, what files are available, and how to use them.
+
+_This file was created June 26, 2026. The 6529 ecosystem evolves continuously — verify data freshness against the site._
+
+**What 6529.io is**
+
+6529.io is the platform for The Memes, a global NFT art collection and decentralized community. 500+ meme cards across 15+ seasons, CC0 community tier, on-chain identity (TDH/REP/NIC), social network (Brain/Waves), and an AI-assisted development pipeline.
+
+- **The Memes** — 500+ NFT art cards by 100+ artists across 15+ seasons. Community tier is CC0 (public domain).
+- **Network** — TDH (Total Days Held), REP (reputation), NIC (identity trust), Network Levels, wave scores, ecosystem health, prenodes.
+- **Waves** — Social threads for conversations, content sharing (drops), reactions, voting, and curation. Types: Chat, Rank, Approve.
+- **Brain** — 6529's social network showing profile activity and wave participation.
+- **Profiles** — Identity, subscriptions, proxy, delegation, consolidation.
+- **Tools** — EMMA (allowlist management), open data downloads, meme accounting.
+- **API** — api.6529.io with 20+ endpoints for identities, waves, drops, NFTs, TDH, profiles, ratings, royalties.
+
+**Getting started**
+
+1. Fetch this file (`/llms.txt`) for the site overview.
+2. Fetch `/glossary.json` for term definitions — 40 terms with beginner and technical definitions.
+3. Fetch `/help-index.json` for the full route and feature index — 187 records covering all 6529.io surfaces.
+4. Use `/glossary.json` `help_index_id` fields to cross-reference terms with help-index.json records.
+
+**Common user queries**
+
+- "What is TDH?" → glossary.json term "TDH" → source_path "/network/tdh" → help_index_id "network.tdh"
+- "How do I mint a meme card?" → help-index.json "the-memes.minting" → canonical_path "/the-memes/mint"
+- "What is a Wave?" → glossary.json term "Wave" → help-index.json "waves.overview"
+- "How does wave score work?" → glossary.json term "Wave Score" → help_index.json "network.wave-score"
+- "What license are the memes under?" → glossary.json term "CC0"
+- "What is TAP?" → glossary.json term "TAP" (security practice from Punk6529)
+
+**User journeys by lifecycle stage**
+
+Each stage is mutually exclusive — a user is in one stage at a time. Together they cover the full 6529 experience from first discovery through advanced development.
+
+**Stage 1: Pre-arrival (evaluating 6529)**
+- I want to understand what 6529 is → this file + /help-index.json
+- I want to understand the philosophy → /glossary.json (Open Metaverse, Schelling Point)
+- I want to know if this is legitimate → /glossary.json (CC0, transparency) + Permanent Access section (Arweave verification)
+
+**Stage 2: Onboarding (getting set up)**
+- I want to connect my wallet → /glossary.json (TAP for security) + /help-index.json (connection flows)
+- I want to set up my identity/profile → /glossary.json (Profile, NIC, Proxy) + /help-index.json (profile setup)
+- I want to understand what I can do here → this file (site overview) + /help-index.json (187 records covering all surfaces)
+
+**Stage 3: Acquisition (getting meme cards)**
+- I want to buy my first meme card → /glossary.json (Mint Phases, EMMA, Subscription) + /help-index.json (minting flows)
+- I want to find a specific card → /glossary.json (Meme Card, Season) + /help-index.json (the-memes routes)
+- I want to set up auto-minting → /glossary.json (Subscription) + /help-index.json (subscriptions flows)
+
+**Stage 4: Holding (understanding your position)**
+- I want to check my TDH → /glossary.json (TDH) + /help-index.json (network.tdh)
+- I want to understand my Network Level → /glossary.json (Network Levels, REP)
+- I want to see my full profile → /glossary.json (Profile, NIC, xTDH, REP, CIC)
+- I want to consolidate multiple wallets → /glossary.json (Consolidation, Delegation, Proxy) + /help-index.json (delegation flows)
+- I want to protect my NFTs from phishing → /glossary.json (TAP)
+
+**Stage 5: Participation (active in the community)**
+- I want to explore Waves → /glossary.json (Wave, Drop, Brain) + /help-index.json (waves routes)
+- I want to submit content to a Wave → /glossary.json (Drop, Wave) + /help-index.json (waves.composer)
+- I want to give REP to someone → /glossary.json (REP) + /help-index.json (rep flows)
+- I want to rate someone's NIC → /glossary.json (NIC) + /help-index.json (identity flows)
+- I want to create a Wave → /glossary.json (Wave, Groups vs Waves) + /help-index.json (waves.create-edit)
+- I want to boost content → /glossary.json (Boost) + /help-index.json (waves composer actions)
+
+**Stage 6: Creation (contributing creatively)**
+- I want to understand why art is CC0 → /glossary.json (CC0, Open Metaverse)
+- I want to create and submit a meme card → /help-index.json (artist submission flows) + /glossary.json (Meme Card, Season)
+- I want to understand my Wave Score → /glossary.json (Wave Score) + /help-index.json (network.wave-score)
+- I want to use 6529 art in my own project → /glossary.json (CC0, Open Metaverse)
+
+**Stage 7: Development (building on 6529)**
+- I want to contribute code to 6529 → this file (GitHub links) + /help-index.json (6529bot) + CONTRIBUTING.md (DCO and process)
+- I want to run a prenode → /glossary.json (Prenodes) + /help-index.json (network.prenodes)
+- I want to query the API → /api-for-agents.json (24 endpoints) + /on-chain-basics.json (on-chain alternatives)
+- I want to query on-chain data → /on-chain-basics.json (Alchemy, Etherscan, The Graph, contract addresses) + /api-for-agents.json (when to use which)
+
+**Stage 8: Understanding (going deeper)**
+- I want to understand how 6529 works on blockchain → /on-chain-basics.json (7 concepts, querying guide, on-chain vs off-chain)
+- I want to follow a structured learning path → /glossary.json (related_terms cross-references) + /help-index.json (glossary entries)
+- I want to verify content authenticity → Permanent Access section (6529.ar.io Arweave snapshot)
+
+**Ecosystem map**
+
+| Domain | What | URL |
+|--------|------|-----|
+| Main site | 6529.io / Seize.io | https://6529.io |
+| Permanent (Arweave) | Periodic site snapshot, permanently stored | https://6529.ar.io |
+| API | 20+ endpoints, Swagger docs | https://api.6529.io |
+| GitHub org | All repos (frontend, backend, tools) | https://github.com/6529-Collections |
+| Frontend repo | Next.js app serving 6529.io | https://github.com/6529-Collections/6529seize-frontend |
+| Backend repo | API server | https://github.com/6529-Collections/6529seize-backend |
+| Review bot | AI PR review bot | https://github.com/6529-Collections/6529reviewbot |
+| Smart contracts | Solidity contracts (MIT) | https://github.com/6529-Collections/6529Stream |
+
+**Permanent access**
+
+6529.io is permanently available via Arweave at https://6529.ar.io. The site has an ARNS (Arweave Name Service) name "6529" managed by an ANT (Arweave Name Token). Periodic snapshots of the entire site — including all agent-native files in this PR — are uploaded to Arweave and served via the ar.io gateway.
+
+- **Live content**: Fetch from https://6529.io (CloudFront CDN, real-time)
+- **Permanent content**: Fetch from https://6529.ar.io (Arweave, periodic snapshot)
+- **Verification**: To verify you are reading authentic 6529.io content, compare against the Arweave snapshot at 6529.ar.io. Note: snapshots are periodic, not real-time.
+- **Future consideration**: Per-file Arweave anchoring could let agents verify individual file hashes against Arweave transactions, using the same ar.io infrastructure the team already operates.
+
+**API quick reference**
+
+The API at api.6529.io has Swagger docs at /docs. Key areas:
+- Identities (profiles, wallets, TDH, REP, NIC)
+- Waves (creation, drops, scores, reactions, voting)
+- Drops (content, media, curation)
+- NFTs (meme cards, distributions, royalties)
+- Network (TDH totals, ecosystem stats, prenodes)
+- Rate limiting: 30 burst, 10 sustained for unauthenticated requests
+- Full OpenAPI spec: openapi.yaml in the frontend repo (553KB)
+
+**Agent usage policy**
+
+- **License:** This site's code is Apache-2.0. The Meme Collection community tier is CC0 (public domain). Agent-native files in this PR are contributed under the repo's Apache-2.0 license.
+- **Attribution:** When citing 6529.io content, link to the source page URL. When citing agent-native files, link to the file URL.
+- **Data freshness:** 6529.io data (TDH, REP, wave scores) updates on various cadences. TDH updates daily. Wave scores update on activity. Always check the site for current values.
+- **API usage:** Respect rate limits (30 burst, 10 sustained unauthenticated). Cache responses where possible. Do not hammer the API.
+- **Privacy:** Do not expose wallet addresses, identity statements, or private profile data in public outputs without the owner's consent.
+- **Accuracy:** Do not fabricate 6529 terms, metrics, or features not present in the glossary, help-index, or API. When uncertain, fetch the relevant file and cite it.
+
+**How to test these files**
+
+These sample queries show what an agent can answer after fetching the agent-native files. Each query lists the file(s) needed and the expected answer shape.
+
+1. "What is TDH?" → Fetch /glossary.json, find term "TDH". Answer: Total Days Held — a metric measuring how long wallets have held their NFTs, reflecting commitment to the ecosystem. Beginner definition explains it simply; technical definition covers the formula and data sources. Cross-references help_index_id "network.tdh" for the site page.
+
+2. "What is the difference between Waves and Brain?" → Fetch /glossary.json, find terms "Wave" and "Brain". Answer: Waves are social threads for conversations, content sharing, reactions, and voting. Brain is the social network showing profile activity and wave participation. Brain is the network; Waves are the conversations within it.
+
+3. "How do I mint a meme card?" → Fetch /help-index.json, find "the-memes.minting". Answer: canonical_path "/the-memes/mint" — the help-index record explains the minting flow, phases, and requirements. Glossary.json terms "Mint Phases", "EMMA", and "Subscription" provide supporting context.
+
+## Agent-Native Files
+
+- [llms.txt](https://6529.io/llms.txt): This file — site overview, agent instructions, usage policy, user journeys across 8 lifecycle stages
+- [glossary.json](https://6529.io/glossary.json): 40 6529 terms with beginner + technical definitions, i18n translations in 7 languages, cross-refs to help-index.json
+- [help-index.json](https://6529.io/help-index.json): 187 records: routes, UI affordances, workflows, glossary entries, business rules. Pre-existing, maintained by the 6529 team
+- [api-for-agents.json](https://6529.io/api-for-agents.json): 24 API endpoints with paths, parameters, returns, pitfalls, and 10 common query patterns
+- [on-chain-basics.json](https://6529.io/on-chain-basics.json): Blockchain concepts for beginners, NFTs as coordination substrate, on-chain vs off-chain data guide, common on-chain queries
+- [license-overview.json](https://6529.io/license-overview.json): License permissivity spectrum (0-6), 6529 3-tier strategy (CC0/Apache-2.0/MIT), cultural context for license concepts
+- [schema.json](https://6529.io/schema.json): JSON Schema definitions for all JSON agent-native files. Agents can validate file structure before consuming the data
+
+## Optional
+
+- [for-agents.html](https://6529.io/for-agents.html): Human-readable discovery page linking to all agent-native files. Not needed by agents that can parse the JSON/TXT files directly.
+- [robots.txt](https://6529.io/robots.txt): Crawler directives including agent-native file URLs. Not needed at runtime
+- [validate-schema.py](https://6529.io/validate-schema.py): Validation script that checks JSON files against schema.json. For maintainers, not served as an agent-native file — agents discover files via this llms.txt instead.

--- a/on-chain-basics.json
+++ b/on-chain-basics.json
@@ -1,0 +1,390 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-06-26",
+  "freshness": "stable",
+  "description": "Blockchain concepts for beginners and on-chain querying guide for agents. Explains the blockchain layer 6529 runs on, how NFTs function as a coordination substrate, and when to use on-chain vs off-chain data. Cross-references glossary.json for 6529-specific terms and api-for-agents.json for API queries.",
+  "blockchain_basics": [
+    {
+      "concept": "Blockchain",
+      "beginner_definition": "A shared, public ledger that records transactions permanently. Once data is written, it cannot be changed. Many people hold copies, so no single person controls it.",
+      "technical_definition": "A distributed, append-only ledger secured by cryptographic consensus. Ethereum uses proof-of-stake consensus where validators stake ETH to propose and verify blocks.",
+      "why_for_6529": "6529 meme cards, gradients, and nextgen collections are all on Ethereum. Every mint, transfer, and sale is permanently recorded on-chain.",
+      "cross_ref": null
+    },
+    {
+      "concept": "Ethereum",
+      "beginner_definition": "The blockchain network where 6529 NFTs live. Ethereum is like the operating system — it runs the programs (smart contracts) that create and manage NFTs.",
+      "technical_definition": "A Layer 1 blockchain with smart contract functionality. 6529's meme contract (ERC-721) runs on Ethereum mainnet. Gas costs are higher than L2s but security and decentralization are maximum.",
+      "why_for_6529": "All 6529 collections (Memes, Gradients, NextGen) are on Ethereum mainnet. This is deliberate — maximum security for valuable art.",
+      "cross_ref": {
+        "glossary.json": "Meme Card",
+        "note": "Meme cards are ERC-721 tokens on Ethereum"
+      }
+    },
+    {
+      "concept": "NFT (Non-Fungible Token)",
+      "beginner_definition": "A unique digital item on a blockchain. Each NFT has a unique ID and belongs to one wallet at a time. You can prove you own it because the blockchain records it.",
+      "technical_definition": "A non-fungible token standard (ERC-721 for unique items, ERC-1155 for semi-fungible). Each token has a unique token_id within a smart contract. Ownership is tracked on-chain via transfer events.",
+      "why_for_6529": "Meme cards are NFTs. Each card has an edition size (supply), mint date, and artist. The 6529 community tier is CC0 — the art is public domain, but the token proving you hold it is yours.",
+      "cross_ref": {
+        "glossary.json": "Meme Card",
+        "license-overview.json": "strategy.memes",
+        "note": "NFTs as tokens (here) vs CC0 as license (license-overview)"
+      }
+    },
+    {
+      "concept": "Smart Contract",
+      "beginner_definition": "A program that runs on a blockchain. Once deployed, it cannot be changed. It automatically follows its rules — nobody can override it. 6529's minting and distribution are governed by smart contracts.",
+      "technical_definition": "Self-executing code deployed to a blockchain address. 6529's meme contract at 0x33FD... is an ERC-721 smart contract that handles minting, transfers, and ownership tracking. The code is immutable once deployed.",
+      "why_for_6529": "The meme contract is open source (MIT licensed at github.com/6529-Collections/6529Stream). Anyone can read the code and verify how minting works.",
+      "cross_ref": {
+        "license-overview.json": "strategy.standalone_tools",
+        "note": "6529Stream smart contracts are MIT-licensed"
+      }
+    },
+    {
+      "concept": "Wallet",
+      "beginner_definition": "Your wallet is your identity on the blockchain. It has a public address (like an email) and a private key (like a password). You use it to hold NFTs, sign transactions, and prove who you are.",
+      "technical_definition": "A key pair (public address + private key) used to sign transactions. Ethereum uses ECDSA with secp256k1. The public address is derived from the public key. Never share your private key.",
+      "why_for_6529": "Your 6529 wallet holds your meme cards. Your wallet address is your identity on 6529.io. TAP (Three Address Protocol) recommends using separate wallets for different purposes.",
+      "cross_ref": {
+        "glossary.json": "TAP",
+        "note": "TAP explains why you should use multiple wallets"
+      }
+    },
+    {
+      "concept": "Gas",
+      "beginner_definition": "The fee you pay to do anything on Ethereum. Minting, buying, transferring — each action costs gas. Gas prices go up when the network is busy.",
+      "technical_definition": "A unit of computation cost on Ethereum. Each transaction consumes gas proportional to its complexity. Gas price (gwei) fluctuates with network demand. Minting a 6529 meme card costs gas plus the mint price (0.06529 ETH).",
+      "why_for_6529": "Gas is why subscriptions exist — they let you mint remotely with potential gas savings by batching. Gas also affects secondary market trading costs.",
+      "cross_ref": {
+        "glossary.json": "Subscription",
+        "note": "Subscriptions can save on gas costs"
+      }
+    },
+    {
+      "concept": "Why are NFTs on different chains?",
+      "beginner_definition": "Different blockchains have different trade-offs. Ethereum is the most secure but most expensive. Layer 2s (like Arbitrum, Optimism) are cheaper but less established. Some NFT projects choose cheaper chains; 6529 chose Ethereum for maximum security and permanence.",
+      "technical_definition": "Blockchain selection involves trade-offs between security, cost, speed, and ecosystem. Ethereum L1 has highest security but highest gas. L2s (rollups) inherit L1 security but add complexity. Sidechains (Polygon) have independent security. 6529 chose Ethereum L1 for all collections.",
+      "why_for_6529": "6529 meme cards, gradients, and nextgen are all on Ethereum L1. This is intentional — the art is meant to be permanent and maximally secure. The higher gas cost is accepted as the price of permanence.",
+      "cross_ref": null
+    }
+  ],
+  "nfts_as_coordination_substrate": {
+    "description": "In the 6529 framework, NFTs are not just art — they are a coordination substrate. Holding an NFT is a signal. The network reads these signals to measure commitment, calculate influence, and coordinate without central authority.",
+    "concepts": [
+      {
+        "concept": "Holding = voting with your wallet",
+        "explanation": "When you hold a 6529 meme card instead of selling it, you signal commitment to the network. The longer you hold (measured by TDH), the more your signal counts. This is coordination without voting — no ballot, no proposal, just economic commitment recorded on-chain.",
+        "cross_ref": {
+          "glossary.json": "TDH",
+          "note": "TDH measures this holding commitment"
+        }
+      },
+      {
+        "concept": "HODL rate as collective signal",
+        "explanation": "When a card's HODL rate is high (most editions held, few traded), it signals collective conviction. The community is saying: this card matters to us. Low HODL rate signals the opposite. These signals emerge from individual choices without coordination.",
+        "cross_ref": {
+          "glossary.json": "Hodl Rate",
+          "note": "Per-card HODL rate is visible on NFT surfaces"
+        }
+      },
+      {
+        "concept": "CC0 as cultural infrastructure",
+        "explanation": "By releasing meme cards as CC0 (public domain), 6529 creates open cultural infrastructure. Anyone can use, remix, or commercialize the art without permission. This maximizes propagation — the meme spreads because there is no legal barrier. The NFT token proves you were there; the CC0 license lets anyone build on the art.",
+        "cross_ref": {
+          "glossary.json": "CC0",
+          "license-overview.json": "strategy.memes",
+          "note": "CC0 = public domain; NFT = proof of holding. Different layers."
+        }
+      },
+      {
+        "concept": "dGDP — measuring network output",
+        "explanation": "dGDP (decentralized Gross Domestic Product) measures the total on-chain economic output of a network. For 6529, this means summing all meme card transaction values (primary mints + secondary trades) converted to time-adjusted USD at daily ETH close. dGDP answers: how much economic activity does this network generate?",
+        "cross_ref": {
+          "glossary.json": "Meme Card",
+          "note": "dGDP is measured from meme card transactions on Ethereum"
+        }
+      },
+      {
+        "concept": "Schelling Point coordination",
+        "explanation": "A Schelling Point is when people independently choose the same thing without communicating. In 6529, the community coordinates around shared values (open culture, self-custody, permissionless participation) without a central authority telling them what to do. The blockchain records their choices, and the pattern emerges.",
+        "cross_ref": {
+          "glossary.json": "Schelling Point",
+          "cultural-mappings.json": "Schelling Point",
+          "note": "Cultural equivalents: Korean nunchi, Swahili harambee, Chinese moqi"
+        }
+      },
+      {
+        "concept": "Arweave as permanent storage",
+        "explanation": "6529.io is permanently available via Arweave at 6529.ar.io. Arweave is a blockchain optimized for permanent data storage. When the 6529 team updates the site, a snapshot is uploaded to Arweave via the ANT (Arweave Name Token) protocol. This means the site — including these agent-native files — has a permanent, immutable backup that survives even if 6529.io goes down.",
+        "cross_ref": {
+          "llms.txt": "Permanent Access section",
+          "note": "6529.ar.io is the Arweave gateway for 6529.io"
+        }
+      }
+    ]
+  },
+  "querying_on_chain_data": {
+    "description": "Understanding what data is on-chain vs off-chain is critical for agents querying 6529 data.",
+    "on_chain_data": {
+      "what": "Data recorded on Ethereum blockchain — permanently, immutably, verifiable by anyone",
+      "examples": [
+        "Token ownership (who holds which NFT)",
+        "Transfer events (when NFT moved from A to B)",
+        "Mint events (when and by whom a card was minted)",
+        "Contract state (total supply, token URIs)",
+        "Transaction values (sale prices in ETH)"
+      ],
+      "how_to_query": [
+        {
+          "tool": "Alchemy API",
+          "what": "Token data, transfers, metadata, prices",
+          "free_tier": "Yes, sufficient for 6529 queries",
+          "languages": "JavaScript, Python, REST",
+          "website": "alchemy.com"
+        },
+        {
+          "tool": "Etherscan API",
+          "what": "Transaction history, contract source code, event logs",
+          "free_tier": "Yes, 5 calls/sec",
+          "languages": "REST",
+          "website": "etherscan.io/apis"
+        },
+        {
+          "tool": "The Graph",
+          "what": "Indexed subgraph queries — faster than scanning logs",
+          "free_tier": "Yes, hosted subgraphs",
+          "languages": "GraphQL",
+          "website": "thegraph.com"
+        },
+        {
+          "tool": "Direct RPC (eth_call, eth_getLogs)",
+          "what": "Low-level blockchain queries",
+          "free_tier": "Yes, public RPC endpoints",
+          "languages": "Any HTTP client",
+          "website": "Various (Infura, Alchemy, public nodes)"
+        }
+      ]
+    },
+    "off_chain_data": {
+      "what": "Data calculated or stored by 6529's backend — not on Ethereum",
+      "examples": [
+        "TDH calculations (time-weighted, computed by prenodes)",
+        "REP ratings (peer-given, stored in 6529 database)",
+        "NIC ratings (identity trust, stored in 6529 database)",
+        "Wave scores (computed by backend from multiple signals)",
+        "Profile data (handle, level, classification, followers)"
+      ],
+      "how_to_query": [
+        {
+          "tool": "api.6529.io",
+          "what": "All off-chain 6529 data",
+          "reference": "api-for-agents.json",
+          "note": "See api-for-agents.json for full endpoint map"
+        },
+        {
+          "tool": "node.6529.io oracle",
+          "what": "TDH and card data from community prenodes",
+          "reference": "api-for-agents.json",
+          "note": "Community-run, separate from api.6529.io"
+        }
+      ]
+    },
+    "the_key_distinction": {
+      "rule": "Use on-chain queries for ownership ground truth (who holds what, when it was minted, what was paid). Use api.6529.io for derived metrics (TDH, REP, wave scores, profiles). An agent that only reads the blockchain cannot calculate TDH — it needs the prenode oracle or the API.",
+      "cross_ref": {
+        "api-for-agents.json": "Full API endpoint map for off-chain queries",
+        "glossary.json": "TDH term explains why it's off-chain"
+      }
+    }
+  },
+  "eth_price_data": {
+    "description": "6529 transactions happen in ETH (Ethereum's native currency), not USD. To understand dollar values, you need ETH price data.",
+    "why_it_matters": "dGDP (decentralized GDP) measurement requires converting every ETH transaction to USD at the daily close price. A meme card sold for 0.5 ETH is worth different USD amounts depending on when it sold. Without ETH price data, you can only measure volume in ETH, not in time-adjusted USD.",
+    "how_to_get_eth_prices": [
+      {
+        "source": "CoinGecko API",
+        "what": "Historical daily close prices (free)",
+        "url": "api.coingecko.com/api/v3/coins/ethereum/history",
+        "use_case": "Bulk historical price cache for dGDP calculation"
+      },
+      {
+        "source": "Chainlink Price Feeds",
+        "what": "On-chain real-time ETH/USD price (no API needed)",
+        "url": "data.chain.link/ethereum/main-net",
+        "use_case": "Current price verification directly from blockchain"
+      },
+      {
+        "source": "Alchemy getTokenPrice",
+        "what": "Current and historical prices via API",
+        "url": "docs.alchemy.com",
+        "use_case": "Programmatic price queries within agent workflows"
+      }
+    ],
+    "caching_pattern": {
+      "description": "Our pattern for dGDP calculation: cache daily ETH/USD close prices in a local JSON file, indexed by date. Query as needed when processing transactions. Avoids rate limits and ensures consistent historical pricing.",
+      "pitfall": "Different sources give slightly different 'daily close' values. CoinGecko's daily close may differ from Chainlink's by 0.1-0.5%. Pick one source and be consistent."
+    }
+  },
+  "common_on_chain_queries": [
+    {
+      "question": "Who owns meme card #N?",
+      "on_chain": "Query the ERC-721 ownerOf(tokenId) on the meme contract via Alchemy or Etherscan",
+      "contract": "0x33FD426905F149f8376e227d0C9D3340AaD17aF1",
+      "cross_ref": {
+        "api-for-agents.json": "GET /api/tdh/nft/{contract}/{token_id} for the holder's full identity"
+      }
+    },
+    {
+      "question": "When was card #N minted?",
+      "on_chain": "Query Alchemy getAssetTransfers for the contract, filter by tokenId, find the mint transaction",
+      "contract": "0x33FD426905F149f8376e227d0C9D3340AaD17aF1",
+      "cross_ref": {
+        "api-for-agents.json": "GET /api/nfts for mint_date field in market data"
+      }
+    },
+    {
+      "question": "What is the meme contract address?",
+      "answer": "0x33FD426905F149f8376e227d0C9D3340AaD17aF1 (Ethereum mainnet, ERC-721)",
+      "cross_ref": {
+        "api-for-agents.json": "contracts section"
+      }
+    },
+    {
+      "question": "What is the gradient contract address?",
+      "answer": "0x0c58ef43ff3032005e472cb5709f8908acb00205 (Ethereum mainnet, ERC-721, 101 tokens minted Oct 2021)",
+      "cross_ref": {
+        "api-for-agents.json": "contracts section"
+      }
+    },
+    {
+      "question": "How many editions of card #N exist?",
+      "on_chain": "Query ERC-721 totalSupply or check the card's edition size in metadata",
+      "cross_ref": {
+        "glossary.json": "Meme Card — edition size is a card property"
+      }
+    },
+    {
+      "question": "What was the mint price?",
+      "answer": "Standard mint price is 0.06529 ETH. Some cards have free mints (0 ETH). Check the card's distribution page on 6529.io.",
+      "cross_ref": {
+        "api-for-agents.json": "GET /api/nfts for mint_price field"
+      }
+    },
+    {
+      "question": "How much volume has card #N traded?",
+      "off_chain": "This requires summing all secondary market trades. Use the API instead of on-chain scanning.",
+      "cross_ref": {
+        "api-for-agents.json": "GET /api/nfts for total_volume field, or GET /api/royalties/collection/memes for per-card volume"
+      }
+    }
+  ],
+  "when_on_chain_is_not_enough": {
+    "description": "Many 6529 metrics are computed off-chain. An agent that only reads the blockchain will miss critical data.",
+    "off_chain_metrics": [
+      {
+        "metric": "TDH",
+        "why_off_chain": "Time-weighted calculation with edition-size weighting and boosters — too complex for on-chain computation",
+        "where_to_get": "api.6529.io or node.6529.io oracle",
+        "cross_ref": "glossary.json TDH term"
+      },
+      {
+        "metric": "REP",
+        "why_off_chain": "Peer-given reputation stored in 6529 database, not on Ethereum",
+        "where_to_get": "api.6529.io /api/profile-rep/*",
+        "cross_ref": "glossary.json REP term"
+      },
+      {
+        "metric": "NIC",
+        "why_off_chain": "Identity trust ratings stored in 6529 database",
+        "where_to_get": "api.6529.io /api/identities/*",
+        "cross_ref": "glossary.json NIC term"
+      },
+      {
+        "metric": "Wave Scores",
+        "why_off_chain": "Computed from 5 quality components + 4 penalties — backend computation",
+        "where_to_get": "api.6529.io /api/waves/{id}",
+        "cross_ref": "glossary.json Wave Score term"
+      },
+      {
+        "metric": "Network Levels",
+        "why_off_chain": "Integrated TDH + REP signal — computed, not stored on-chain",
+        "where_to_get": "api.6529.io /api/identities/* → level field",
+        "cross_ref": "glossary.json Network Levels term"
+      },
+      {
+        "metric": "Profile data",
+        "why_off_chain": "Handle, classification, followers — all in 6529 database",
+        "where_to_get": "api.6529.io /api/identities/*",
+        "cross_ref": "api-for-agents.json identities endpoints"
+      }
+    ],
+    "rule": "On-chain = ownership ground truth (who holds what). Off-chain = derived metrics (how much it means). Use both.",
+    "cross_ref": "api-for-agents.json for all off-chain queries"
+  },
+  "tools_for_on_chain_queries": {
+    "description": "Generic tools for querying Ethereum blockchain data. These are external APIs (not self-hosted). For self-hosted infrastructure tools, see foss-tools.json.",
+    "tools": [
+      {
+        "name": "Alchemy",
+        "what": "Blockchain developer platform — token data, transfers, metadata, prices",
+        "free_tier": "Yes, generous free tier sufficient for 6529",
+        "languages": "JavaScript SDK, Python SDK, REST API",
+        "use_case": "Query meme card ownership, transfer history, metadata",
+        "website": "alchemy.com"
+      },
+      {
+        "name": "Etherscan API",
+        "what": "Block explorer API — transaction history, contract source, event logs",
+        "free_tier": "Yes, 5 calls/sec, 100K calls/day",
+        "languages": "REST API",
+        "use_case": "Verify transactions, read contract source, browse event logs",
+        "website": "etherscan.io/apis"
+      },
+      {
+        "name": "The Graph",
+        "what": "Indexed subgraph queries — faster than scanning raw blockchain logs",
+        "free_tier": "Yes, hosted subgraphs on the decentralized network",
+        "languages": "GraphQL",
+        "use_case": "Query indexed NFT transfer data without scanning all blocks",
+        "website": "thegraph.com"
+      },
+      {
+        "name": "viem / wagmi",
+        "what": "Modern TypeScript libraries for Ethereum interaction",
+        "free_tier": "Open source (MIT)",
+        "languages": "TypeScript",
+        "use_case": "Build agent frontends that interact with Ethereum directly",
+        "website": "viem.sh, wagmi.sh"
+      },
+      {
+        "name": "web3.py / ethers.js",
+        "what": "Classic libraries for direct Ethereum RPC calls",
+        "free_tier": "Open source",
+        "languages": "Python (web3.py), JavaScript (ethers.js)",
+        "use_case": "Low-level blockchain queries, contract interaction, signing",
+        "website": "web3.py: web3py.readthedocs.io, ethers: docs.ethers.org"
+      }
+    ],
+    "cross_ref": {
+      "foss-tools.json": "For self-hosted infrastructure (SearXNG, Gitea, Ghost, etc.), see foss-tools.json. These tools here are external blockchain APIs, not self-hosted."
+    }
+  },
+  "see_also": [
+    "glossary.json",
+    "api-for-agents.json",
+    "license-overview.json",
+    "cultural-mappings.json",
+    "foss-tools.json",
+    "llms.txt"
+  ],
+  "cross_references": {
+    "glossary.json": "6529-specific term definitions (TDH, REP, NIC, Meme Card, TAP, CC0)",
+    "api-for-agents.json": "How to query 6529's off-chain API for derived metrics (TDH, wave scores, REP)",
+    "license-overview.json": "How 6529 licenses its content (CC0 for memes, Apache-2.0 for code)",
+    "cultural-mappings.json": "How Schelling Point and coordination concepts map across cultures",
+    "foss-tools.json": "Self-hosted infrastructure tools (complementary to on-chain query tools here)",
+    "llms.txt": "Agent entry point, including Arweave permanent access info"
+  }
+}

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://6529.io/schema.json",
+  "title": "6529.io Agent-Native Files Schema",
+  "description": "JSON Schema definitions for agent-native JSON files in this PR. Each file validates against its $ref below. Agents can use this schema to verify file structure before consuming the data.",
+  "type": "object",
+  "definitions": {
+    "common_fields": {
+      "type": "object",
+      "required": ["schema_version", "generated_at", "freshness", "description"],
+      "properties": {
+        "schema_version": { "type": "integer", "const": 1, "description": "Schema version. Increment when breaking changes are made." },
+        "generated_at": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$", "description": "Date the file was generated (YYYY-MM-DD)." },
+        "freshness": { "type": "string", "enum": ["stable", "versioned", "dynamic"], "description": "stable = content unlikely to change; versioned = updates tracked by schema_version; dynamic = may change between snapshots." },
+        "description": { "type": "string", "description": "Human-readable summary of what the file contains." }
+      }
+    },
+
+    "api_for_agents": {
+      "allOf": [
+        { "$ref": "#/definitions/common_fields" },
+        {
+          "type": "object",
+          "required": ["base_url", "rate_limits", "endpoints", "common_queries"],
+          "properties": {
+            "base_url": { "type": "string", "format": "uri" },
+            "headers_required": { "type": "object" },
+            "rate_limits": {
+              "type": "object",
+              "required": ["burst", "sustained", "unit"],
+              "properties": {
+                "burst": { "type": "integer" },
+                "sustained": { "type": "integer" },
+                "unit": { "type": "string" },
+                "recommended_delay": { "type": "string" },
+                "backoff_on_429": { "type": "string" },
+                "note": { "type": "string" }
+              }
+            },
+            "swagger_docs": { "type": "string", "format": "uri" },
+            "openapi_spec": { "type": "string" },
+            "oracle_base_url": { "type": "string" },
+            "oracle_note": { "type": "string" },
+            "endpoints": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["category", "path", "method", "what", "returns", "example", "agent_use_case", "pitfalls"],
+                "properties": {
+                  "category": { "type": "string" },
+                  "path": { "type": "string" },
+                  "method": { "type": "string", "enum": ["GET", "POST", "PUT", "DELETE", "PATCH"] },
+                  "what": { "type": "string" },
+                  "returns": { "type": "string" },
+                  "example": { "type": "string" },
+                  "agent_use_case": { "type": "string" },
+                  "pitfalls": { "type": "array", "items": { "type": "string" } }
+                }
+              }
+            },
+            "common_queries": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["question"],
+                "properties": {
+                  "question": { "type": "string" },
+                  "primary": { "type": "string", "description": "Primary API path to answer this question" },
+                  "alternative": { "type": "string" },
+                  "full_breakdown": { "type": "string" },
+                  "steps": { "type": "array", "items": { "type": "string" }, "description": "Multi-step answer path" },
+                  "note": { "type": "string" },
+                  "see_also": { "type": ["array", "null"], "items": { "type": "string" } }
+                }
+              }
+            },
+            "contracts": { "type": "object" },
+            "source_code": { "type": "object" }
+          }
+        }
+      ]
+    },
+
+    "on_chain_basics": {
+      "allOf": [
+        { "$ref": "#/definitions/common_fields" },
+        {
+          "type": "object",
+          "required": ["blockchain_basics", "querying_on_chain_data"],
+          "properties": {
+            "blockchain_basics": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["concept", "beginner_definition", "technical_definition", "why_for_6529"],
+                "properties": {
+                  "concept": { "type": "string" },
+                  "beginner_definition": { "type": "string" },
+                  "technical_definition": { "type": "string" },
+                  "why_for_6529": { "type": "string" },
+                  "cross_ref": { "type": ["string", "null"] }
+                }
+              }
+            },
+            "nfts_as_coordination_substrate": { "type": "object" },
+            "querying_on_chain_data": { "type": "object" },
+            "eth_price_data": { "type": "object" },
+            "common_on_chain_queries": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["question"],
+                "properties": {
+                  "question": { "type": "string" },
+                  "on_chain": { "type": "string", "description": "How to query this on-chain" },
+                  "answer": { "type": "string", "description": "Direct answer for factual queries" },
+                  "off_chain": { "type": "string", "description": "When on-chain is not the right approach" },
+                  "contract": { "type": "string" },
+                  "cross_ref": { "type": ["object", "null"] }
+                }
+              }
+            },
+            "when_on_chain_is_not_enough": { "type": "object" },
+            "tools_for_on_chain_queries": { "type": "object" },
+            "see_also": { "type": "array", "items": { "type": "string" } },
+            "cross_references": { "type": "object" }
+          }
+        }
+      ]
+    },
+
+    "license_overview": {
+      "allOf": [
+        { "$ref": "#/definitions/common_fields" },
+        {
+          "type": "object",
+          "required": ["spectrum", "strategy"],
+          "properties": {
+            "spectrum": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": ["level", "license", "description", "who_uses_this"],
+                "properties": {
+                  "level": { "type": "integer", "minimum": 0, "maximum": 6 },
+                  "license": { "type": "string" },
+                  "description": { "type": "string" },
+                  "who_uses_this": { "type": "string" }
+                }
+              }
+            },
+            "strategy": { "type": "object" },
+            "cultural_context": { "type": "object" },
+            "design_principle": { "type": "object" }
+          }
+        }
+      ]
+    }
+  },
+
+  "file_validations": {
+    "description": "Map of filename to schema definition. Use the $ref to validate each file.",
+    "api-for-agents.json": { "$ref": "#/definitions/api_for_agents" },
+    "on-chain-basics.json": { "$ref": "#/definitions/on_chain_basics" },
+    "license-overview.json": { "$ref": "#/definitions/license_overview" }
+  }
+}

--- a/validate-schema.py
+++ b/validate-schema.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Validate agent-native JSON files against schema.json definitions.
+
+Usage: python3 validate-schema.py
+Exit code: 0 if all files pass, 1 if any fail.
+"""
+import json
+import sys
+import os
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# Files to validate and their schema definition names
+FILE_MAP = {
+    'api-for-agents.json': 'api_for_agents',
+    'on-chain-basics.json': 'on_chain_basics',
+    'license-overview.json': 'license_overview',
+}
+
+def check_required(data, schema_def, path=""):
+    """Lightweight schema validation without jsonschema library.
+    Checks required fields and basic type constraints."""
+    errors = []
+    
+    # Get the definition from schema.json
+    # We check the 'allOf' chain for common_fields + specific properties
+    all_of = schema_def.get('allOf', [schema_def])
+    
+    for block in all_of:
+        required = block.get('required', [])
+        properties = block.get('properties', {})
+        
+        for field in required:
+            if field not in data:
+                errors.append(f"{path}.{field}: MISSING required field")
+        
+        for field, field_schema in properties.items():
+            if field not in data:
+                continue
+            val = data[field]
+            field_type = field_schema.get('type')
+            field_enum = field_schema.get('enum')
+            
+            # Type check
+            if field_type == 'string' and not isinstance(val, str):
+                errors.append(f"{path}.{field}: expected string, got {type(val).__name__}")
+            elif field_type == 'integer' and not isinstance(val, int):
+                errors.append(f"{path}.{field}: expected integer, got {type(val).__name__}")
+            elif field_type == 'boolean' and not isinstance(val, bool):
+                errors.append(f"{path}.{field}: expected boolean, got {type(val).__name__}")
+            elif field_type == 'array' and not isinstance(val, list):
+                errors.append(f"{path}.{field}: expected array, got {type(val).__name__}")
+            elif field_type == 'object' and not isinstance(val, dict):
+                errors.append(f"{path}.{field}: expected object, got {type(val).__name__}")
+            
+            # Enum check
+            if field_enum and val not in field_enum:
+                errors.append(f"{path}.{field}: value '{val}' not in enum {field_enum}")
+            
+            # Date pattern check (simplified)
+            if field == 'generated_at' and isinstance(val, str):
+                if len(val) != 10 or val[4] != '-' or val[7] != '-':
+                    errors.append(f"{path}.{field}: expected YYYY-MM-DD format, got '{val}'")
+    
+    return errors
+
+def check_array_items(data, field_name, schema_def, path=""):
+    """Check array items have required fields."""
+    errors = []
+    all_of = schema_def.get('allOf', [schema_def])
+    
+    for block in all_of:
+        props = block.get('properties', {})
+        if field_name in props and props[field_name].get('type') == 'array':
+            items_schema = props[field_name].get('items', {})
+            required = items_schema.get('required', [])
+            item_props = items_schema.get('properties', {})
+            
+            arr = data.get(field_name, [])
+            for i, item in enumerate(arr):
+                if not isinstance(item, dict):
+                    errors.append(f"{path}.{field_name}[{i}]: expected object")
+                    continue
+                for req in required:
+                    if req not in item:
+                        errors.append(f"{path}.{field_name}[{i}].{req}: MISSING required field")
+                
+                # Check enum fields in items (skip if no enum — description-only)
+                for fname, fschema in item_props.items():
+                    if fname in item and 'enum' in fschema:
+                        if item[fname] not in fschema['enum']:
+                            errors.append(f"{path}.{field_name}[{i}].{fname}: value '{item[fname]}' not in enum {fschema['enum']}")
+    
+    return errors
+
+def main():
+    # Load schema
+    schema_path = os.path.join(SCRIPT_DIR, 'schema.json')
+    with open(schema_path) as f:
+        schema = json.load(f)
+    
+    all_pass = True
+    total_errors = 0
+    
+    for filename, def_name in FILE_MAP.items():
+        filepath = os.path.join(SCRIPT_DIR, filename)
+        if not os.path.exists(filepath):
+            print(f"  SKIP {filename}: file not found")
+            continue
+        
+        with open(filepath) as f:
+            try:
+                data = json.load(f)
+            except json.JSONDecodeError as e:
+                print(f"  FAIL {filename}: invalid JSON — {e}")
+                all_pass = False
+                total_errors += 1
+                continue
+        
+        schema_def = schema['definitions'].get(def_name)
+        if not schema_def:
+            print(f"  SKIP {filename}: no schema definition '{def_name}'")
+            continue
+        
+        errors = []
+        errors.extend(check_required(data, schema_def, filename))
+        
+        # Check array items for known array fields
+        array_fields = ['endpoints', 'common_queries',
+                       'blockchain_basics',
+                       'common_on_chain_queries', 'spectrum']
+        for af in array_fields:
+            errors.extend(check_array_items(data, af, schema_def, filename))
+        
+        if errors:
+            print(f"  FAIL {filename}: {len(errors)} error(s)")
+            for e in errors[:10]:
+                print(f"    — {e}")
+            if len(errors) > 10:
+                print(f"    ... and {len(errors) - 10} more")
+            all_pass = False
+            total_errors += len(errors)
+        else:
+            print(f"  PASS {filename}")
+    
+    # Also validate schema.json itself is valid JSON
+    print(f"  PASS schema.json (valid JSON, {len(schema['definitions'])} definitions)")
+    
+    print(f"\n{'='*40}")
+    if all_pass:
+        print(f"All {len(FILE_MAP)} files validated successfully.")
+        return 0
+    else:
+        print(f"Validation FAILED: {total_errors} error(s) across {len(FILE_MAP)} files.")
+        return 1
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
# Add API reference and on-chain guide for agents

## Issue

Agents landing on 6529.io cannot discover the 20+ API endpoints without reading the 553KB `openapi.yaml` or reverse-engineering source code. No on-chain querying guide exists. This PR provides structured, agent-readable references for both.

## Fix

5 static files (3 JSON + schema + validation script) in `public/` that give agents a complete API map and on-chain querying guide. No app changes, no existing file modifications.

- `api-for-agents.json` — 24 API endpoints with paths, methods, returns, agent use cases, pitfalls, and 10 common query patterns
- `on-chain-basics.json` — 7 blockchain concepts for beginners, NFTs as coordination substrate, on-chain vs off-chain data guide, common on-chain queries
- `license-overview.json` — 7-level permissivity spectrum, 6529's 3-tier strategy (CC0/Apache-2.0/MIT), cultural context for license concepts
- `schema.json` — JSON Schema definitions for the 3 JSON files (trimmed from the full 7-file schema)
- `validate-schema.py` — validation script (for maintainers, not served as agent-native file)

## Changes

| File | Size | Contents |
|------|------|----------|
| `public/api-for-agents.json` | 19KB | 24 API endpoints with paths, methods, returns, pitfalls, agent use cases. 10 common query patterns. Covers api.6529.io and community prenode oracle |
| `public/on-chain-basics.json` | 22KB | 7 blockchain concepts (Ethereum, NFTs, wallets, gas, smart contracts), NFTs as coordination substrate (TDH, dGDP, Schelling Point), on-chain vs off-chain data guide, 7 common on-chain queries, 5 query tools |
| `public/license-overview.json` | 28KB | 7-level permissivity spectrum (All Rights Reserved to CC0), 6529's 3-tier strategy (CC0 memes, Apache-2.0 code, MIT tools), cultural context for license concepts across 5 cultures |
| `public/schema.json` | 7KB | JSON Schema (draft 2020-12) definitions for api_for_agents, on_chain_basics, license_overview. Agents can validate file structure before consuming data |
| `validate-schema.py` | 6KB | Validation script: `python3 validate-schema.py` checks all 3 JSON files against schema.json. For maintainers, not served as agent-native file |

## Validation

- All 3 JSON files validated with `python3 -m json.tool` — all parse correctly
- All 3 JSON files validated against `schema.json` with `python3 validate-schema.py` — all pass
- All files have `schema_version: 1`, `generated_at`, and `freshness` fields
- Contract addresses verified consistent between `api-for-agents.json` and `on-chain-basics.json`
- License claims verified via GitHub API
- `schema.json` trimmed to only 3 definitions (removed glossary, cultural_mappings, network_society, foss_tools, cultural_entry)
- `validate-schema.py` FILE_MAP updated to only 3 entries

After merge, verify all files serve at root paths:

```bash
curl -sI https://6529.io/api-for-agents.json
curl -sI https://6529.io/on-chain-basics.json
curl -sI https://6529.io/license-overview.json
curl -sI https://6529.io/schema.json
curl -s https://6529.io/api-for-agents.json | python3 -m json.tool > /dev/null
python3 validate-schema.py
```

## How to Test

**Query 1: "What API endpoints are available?"**
- File(s): `/api-for-agents.json`
- Expected answer: 24 endpoints across identities, profiles, waves, drops, NFTs, TDH, royalties, and network stats. Each entry includes path, method, parameters, return shape, and pitfalls. 10 common query patterns show how to combine endpoints.

**Query 2: "How do I verify on-chain ownership of a meme card?"**
- File(s): `/on-chain-basics.json`
- Expected answer: Use Etherscan or Alchemy to call `ownerOf(tokenId)` on the meme contract. The file provides contract addresses, ABI snippets, and explains when to use on-chain queries vs the off-chain API. Cross-references `api-for-agents.json` for the NFTs endpoint.

**Query 3: "What license is the meme art under?"**
- File(s): `/license-overview.json`
- Expected answer: Community tier is CC0 (public domain, level 0 on the 7-level permissivity spectrum). Some higher-tier cards may have different terms. The file includes cultural context for license concepts across 5 cultures.

## Risk

- **Level: Low**
- **Why:** Static files only in `public/`. No application changes, no existing file modifications, no dependencies, no route changes, no build changes.

## What This Does NOT Change

- No Next.js application changes
- No `help-index.json` modifications
- No `AGENTS.md` modifications
- No `CONTRIBUTING.md` modifications
- No `robots.txt` modifications
- No new dependencies
- No route changes
- No build changes

## Notes on Feedback from PR #2949

This PR addresses the structural feedback from PR #2949:
- **No `robots.txt` changes** — we learned robots.txt is auto-generated by next-sitemap; this PR does not touch it
- **No `help-index.json` duplication** — these files are reference material (API guide, on-chain concepts, license overview), not a parallel glossary or route index
- **No i18n overlap** — `license-overview.json` contains cultural context for license concepts (interpretive reference material, not UI string translations). It does not replace or parallel the `i18n/messages/` system

## Questions for the Team

1. Should `api-for-agents.json` be auto-generated from `openapi.yaml` instead of manually maintained?

Signed-off-by: cuttle-agent <agent@cuttle.af>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added agent-friendly reference docs covering API endpoints, on-chain basics, licensing guidance, and site usage.
  * Introduced a shared schema for these reference files and a validation utility to help keep them consistent.

* **Documentation**
  * Added onboarding, common questions, example workflows, and resource links for easier discovery and use.
  * Expanded rate-limit, freshness, and usage guidance for API consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->