### PR TITLE
Add cultural mappings and network society paradigm files

### DIFF
--- a/cultural-mappings.json
+++ b/cultural-mappings.json
@@ -1,0 +1,848 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-06-30",
+  "description": "Cross-cultural concept mappings for 6529 ecosystem terms. Helps agents translate concepts for users across cultures, and helps non-English speakers understand 6529 jargon through cultural equivalents.",
+  "meta": {
+    "origin": "These cultural mappings were developed through the OM Album's 49-country, 423-artist cultural engineering process. The 6529 community contributed the cultural knowledge. This file contributes it back as structured data.",
+    "self_improving_loop": "Community creates culture \u2192 OM Album captures it \u2192 this file structures it \u2192 agents distribute it \u2192 community benefits",
+    "cultures_covered": [
+      "ko",
+      "es",
+      "ja",
+      "sw",
+      "hi",
+      "zh",
+      "ru"
+    ],
+    "note": "7 cultures initially mapped. The structure supports adding more cultures without breaking existing consumers. Translations and cultural equivalents are starting points, not authoritative \u2014 the 6529 community should refine them."
+  },
+  "methodology": {
+    "source": "Cultural mappings were developed through the OM Album \u2014 a 6529 community creative project spanning 49 countries and 423 artists. The OM Album explored how 6529 concepts resonate across cultures through music, lyrics, and cultural commentary. These mappings translate that creative exploration into structured data.",
+    "process": "Each of the 20 key 6529 concepts was mapped to 7 cultures (Korean, Spanish, Japanese, Swahili, Hindi, Chinese, Russian), producing 140 cultural equivalents. All entries were reviewed for uniqueness within each language and conceptual accuracy. Mappings that used the same cultural concept for different 6529 terms were differentiated, and entries where the cultural equivalent did not match the 6529 concept were corrected.",
+    "limitations": "These mappings are interpretive, not authoritative. A cultural_equivalent is a starting point \u2014 a concept from the target culture that resonates with the 6529 term. It is not a definitive translation, and it does not claim to capture every nuance of either the 6529 concept or the cultural concept. Mappings may oversimplify complex cultural traditions. Native speakers and cultural experts should refine these over time. The 7 cultures initially mapped cover Asia, Latin America, Africa, South Asia, and Eastern Europe \u2014 additional cultures can be added without breaking existing consumers.",
+    "governance": "The 6529 community owns these mappings. To propose a correction or addition: (1) identify the term, culture, and current cultural_equivalent, (2) propose the replacement with a brief explanation of why it better captures the 6529 concept, (3) submit via GitHub PR or 6529 Wave. Mappings should be reviewed by someone familiar with both the 6529 concept and the target culture. Disagreements about interpretation are expected and healthy \u2014 the mappings are designed to evolve."
+  },
+  "mappings": [
+    {
+      "term": "Hodl",
+      "concept": "Long-term commitment to holding an asset despite price volatility",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\ub048\uae30 (kkun-gi) \u2014 persistence, endurance through difficulty",
+          "notes": "Korean crypto culture adopted '\ud640\ub4dc' as a loanword. \ub048\uae30 maps to hodling through bear markets.",
+          "om_reference": "Track 15: jeong \u2014 bonds that strengthen through time endured together"
+        },
+        "es": {
+          "cultural_equivalent": "Aguantar \u2014 to endure, to hold steady",
+          "notes": "Spanish crypto communities use 'hodl' as-is. 'Aguantar' captures the cultural spirit.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u6211\u6162 (gaman) \u2014 endurance, perseverance",
+          "notes": "\u6211\u6162 is enduring the unbearable with patience and dignity. Maps to hodling through crashes.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Kubomicsa \u2014 to persevere through hardship",
+          "notes": "Swahili has a strong tradition of communal perseverance (Harambee). Individual holding maps to personal patience.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u0927\u0948\u0930\u094d\u092f (dhairya) \u2014 patience, steadfastness",
+          "notes": "\u0927\u0948\u0930\u094d\u092f is a virtue in Hindu philosophy \u2014 patient endurance. Maps to holding through volatility.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u575a\u6301 (ji\u0101nch\u00ed) \u2014 to persist, to hold firm",
+          "notes": "Chinese crypto culture uses \u6301\u6709 for hodl. \u575a\u6301 captures the perseverance through market cycles.",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "\u0422\u0435\u0440\u043f\u0435\u043d\u0438\u0435 (terpeniye) \u2014 patience, endurance",
+          "notes": "Russian crypto community uses '\u0445\u043e\u0434\u043b' (transliteration). \u0422\u0435\u0440\u043f\u0435\u043d\u0438\u0435 captures the Russian cultural value of enduring hardship.",
+          "om_reference": "Track 14: post-punk persistence and defiance"
+        }
+      }
+    },
+    {
+      "term": "Schelling Point",
+      "concept": "Coordination without communication \u2014 people independently choosing the same thing",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\ub208\uce58 (nunchi) \u2014 reading the room, anticipating others without explicit communication",
+          "notes": "Korean nunchi is the closest cultural equivalent \u2014 coordinating through situational awareness rather than direct communication.",
+          "om_reference": "Track 15: nunchi as a 6529 concept"
+        },
+        "es": {
+          "cultural_equivalent": "Sentido com\u00fan \u2014 common sense that everyone shares without discussing",
+          "notes": "The Spanish concept of shared common sense maps to Schelling's coordination without communication.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u7a7a\u6c17\u3092\u8aad\u3080 (kuuki wo yomu) \u2014 reading the atmosphere, coordinating without words",
+          "notes": "Japanese kuuki wo yomu (reading the air) is the cultural practice of coordination without explicit communication.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Harambee \u2014 pulling together without explicit coordination",
+          "notes": "Harambee embodies collective action where everyone contributes without needing to discuss who does what.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u0938\u093e\u092e\u0942\u0939\u093f\u0915 \u091a\u0947\u0924\u0928\u093e (s\u0101m\u016bhik chetna) \u2014 collective consciousness",
+          "notes": "Indian philosophy's concept of collective consciousness maps to Schelling's independent coordination.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u9ed8\u5951 (m\u00f2q\u00ec) \u2014 tacit understanding, unspoken agreement",
+          "notes": "Chinese \u9ed8\u5951 is exactly Schelling's concept \u2014 people coordinating without communication through shared understanding.",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "\u0411\u0435\u0437\u043c\u043e\u043b\u0432\u043d\u043e\u0435 \u0441\u043e\u0433\u043b\u0430\u0441\u0438\u0435 \u2014 silent agreement, tacit coordination",
+          "notes": "Russian concept of tacit coordination through shared cultural understanding.",
+          "om_reference": null
+        }
+      }
+    },
+    {
+      "term": "CC0",
+      "concept": "Public domain dedication \u2014 releasing creative work with no rights reserved",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\uc815 (jeong) \u2014 bonds that strengthen through mutual giving without expectation of return",
+          "notes": "CC0 maps to jeong \u2014 creative work given to the commons without reservation, like jeong accumulates through mutual giving.",
+          "om_reference": "Track 15: jeong as communal bond"
+        },
+        "es": {
+          "cultural_equivalent": "Bien com\u00fan \u2014 the common good",
+          "notes": "Hispanic tradition of collective creation (flamenco, corridos) where ownership is communal. CC0 formalizes what folk culture has always practiced.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u7121\u511f (mush\u014d) \u2014 without compensation, given freely",
+          "notes": "Japanese tradition of mush\u014d (free, without compensation) and doujin culture (fan works tolerated as communal). CC0 provides legal framework.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Ubuntu \u2014 'I am because we are'. Knowledge belongs to the community.",
+          "notes": "Ubuntu philosophy: individual creation is an expression of collective capacity. CC0 returns creative work to the community that enabled it.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u0926\u093e\u0928 (d\u0101na) \u2014 charitable giving without expectation of return; \u092a\u094d\u0930\u0938\u093e\u0926 (pras\u0101d) \u2014 blessed offering",
+          "notes": "The gurukul tradition: knowledge freely given by teachers. Pras\u0101d: blessed offering distributed at temples without conditions.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u5929\u4e0b\u4e3a\u516c (ti\u0101nxi\u00e0 w\u00e8i g\u014dng) \u2014 the world belongs to all",
+          "notes": "Chinese classical philosophy (\u793c\u8bb0/Liji): 'the world belongs to everyone.' CC0 operationalizes this ancient concept for digital works.",
+          "om_reference": "Track 10: Chinese opera and the portal as Schelling point"
+        },
+        "ru": {
+          "cultural_equivalent": "\u0414\u0430\u0440 (dar) \u2014 gift to all",
+          "notes": "Russian tradition of \u0434\u0430\u0440 (gift) \u2014 giving creative work to the community. The samizdat tradition of freely sharing literature maps to CC0's spirit.",
+          "om_reference": "Track 14: persistence through open culture"
+        }
+      }
+    },
+    {
+      "term": "Wave",
+      "concept": "Conversational channel for community interaction, content sharing, and curation",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\ud30c\ub3c4 (pado) \u2014 wave, but in 6529 context = \ub300\ud654 \ucc44\ub110 (conversation channel)",
+          "notes": "Korean '\ud30c\ub3c4' means ocean wave \u2014 clarify that 6529 Wave = conversation channel, not literal waves.",
+          "om_reference": null
+        },
+        "es": {
+          "cultural_equivalent": "Foro \u2014 forum, but with real-time reactions and voting",
+          "notes": "Spanish 'ola' = ocean wave. 6529 Wave is closer to a forum with live interaction mechanics.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u30c1\u30e3\u30f3\u30cd\u30eb (channel) \u2014 but with rating and curation mechanics",
+          "notes": "Japanese '\u6ce2' (nami) = ocean wave. 6529 Wave is closer to a chat channel with voting/curation.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Baraza \u2014 community gathering for discussion",
+          "notes": "Swahili 'wimbi' = ocean wave. 6529 Wave maps to baraza (community gathering place) with interactive features.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u0938\u092d\u093e (sabha) \u2014 assembly, gathering for discussion",
+          "notes": "Hindi '\u0932\u0939\u0930' (lahar) = ocean wave. 6529 Wave maps to sabha (assembly) with voting/reacting.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u8bba\u575b (l\u00f9nt\u00e1n) \u2014 forum, but with real-time curation",
+          "notes": "Chinese '\u6ce2' = wave. 6529 Wave is closer to a forum with live interaction. Clarify to avoid ocean-wave confusion.",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "\u0412\u043e\u043b\u043d\u0430 \u043e\u0431\u0441\u0443\u0436\u0434\u0435\u043d\u0438\u044f \u2014 wave of discussion",
+          "notes": "Russian '\u0432\u043e\u043b\u043d\u0430' can mean both ocean wave and metaphorical wave of discussion. 6529 Wave = discussion channel with curation.",
+          "om_reference": null
+        }
+      }
+    },
+    {
+      "term": "TDH",
+      "concept": "Time-weighted measure of commitment \u2014 how long and how much you've held",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\uc5f0\uacf5\uc11c\uc5f4 (yeongong seoyeol) \u2014 seniority by years of service",
+          "notes": "Korean seniority system maps to TDH \u2014 longer holding = higher status, like longer service = higher rank.",
+          "om_reference": null
+        },
+        "es": {
+          "cultural_equivalent": "Antig\u00fcedad \u2014 seniority, length of service",
+          "notes": "Spanish concept of antig\u00fcedad (seniority through time) maps to TDH's time-weighted commitment.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u5e74\u529f (nenk\u014d) \u2014 seniority by years",
+          "notes": "Japanese nenk\u014d (seniority) system maps to TDH \u2014 longer commitment = higher standing.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Uzoefu \u2014 experience measured by time",
+          "notes": "Swahili concept of uzoefu (experience through time) maps to TDH's time-weighted metric.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u0935\u0930\u093f\u0937\u094d\u0920\u0924\u093e (vari\u1e63\u1e6dhat\u0101) \u2014 seniority through sustained commitment",
+          "notes": "Indian concept of seniority through sustained commitment maps to TDH.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u8d44\u5386 (z\u012bl\u00ec) \u2014 seniority, qualifications through time",
+          "notes": "Chinese concept of \u8d44\u5386 (qualifications through time) maps to TDH's time-weighted commitment metric.",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "\u0421\u0442\u0430\u0436 (stazh) \u2014 length of service, seniority",
+          "notes": "Russian concept of \u0441\u0442\u0430\u0436 (length of service) maps to TDH \u2014 time as commitment metric.",
+          "om_reference": null
+        }
+      }
+    },
+    {
+      "term": "Boost",
+      "concept": "Collective amplification \u2014 multiplying a signal through community support",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\uc751\uc6d0 (eungwon) \u2014 cheering, collective support",
+          "notes": "Korean eungwon (collective cheering) maps to boosting \u2014 community amplifying a signal.",
+          "om_reference": null
+        },
+        "es": {
+          "cultural_equivalent": "Apoyo colectivo \u2014 collective support",
+          "notes": "Spanish concept of collective support/amplification.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u5fdc\u63f4 (\u014den) \u2014 cheering, support",
+          "notes": "Japanese \u014den (cheering/support) maps to boosting \u2014 collective amplification.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Kuinua \u2014 to lift up, to amplify a signal collectively",
+          "notes": "Swahili kuinua (to lift up) specifically captures the amplification aspect of boosting \u2014 the community lifting up content or a person. This is distinct from harambee (used for Schelling Point = coordinating without central authority). Boost is about amplification, not coordination. Kuinua is the act of raising something up; harambee is the act of pulling together.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u0938\u0902\u0935\u0930\u094d\u0927\u0928 (sanvardhan) \u2014 nurturing, amplifying through support",
+          "notes": "Indian concept of collective nurturing/amplification.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u52a9\u529b (zh\u00f9l\u00ec) \u2014 collective assistance, boosting",
+          "notes": "Chinese \u52a9\u529b (assistance/boost) maps to 6529's boost mechanic \u2014 community amplifying content.",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "\u041f\u043e\u0434\u0434\u0435\u0440\u0436\u043a\u0430 (podderzhka) \u2014 collective support",
+          "notes": "Russian collective support/amplification concept.",
+          "om_reference": null
+        }
+      }
+    },
+    {
+      "term": "Salmat (living well)",
+      "concept": "Life has flavor \u2014 the quality of living, not just the speed of doing",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\uc0b6\uc758 \ub9db \u2014 the taste/flavor of life",
+          "notes": "Korean salmat = 'life has flavor.' The original term \u2014 6529 OM Album Track 15 explores this Korean concept.",
+          "om_reference": "Track 15: \uc0b4\ub9db (How to Living)"
+        },
+        "es": {
+          "cultural_equivalent": "Sabor de vida \u2014 flavor of life, living well",
+          "notes": "Spanish 'vivir bien' (living well) captures salmat's quality-over-speed philosophy.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u751f\u304d\u7532\u6590 \u2014 reason for living, life's worth",
+          "notes": "Japanese ikigai (reason for living) maps to salmat \u2014 the quality that makes life worth living.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Uhai mwema \u2014 good life, life with quality",
+          "notes": "Swahili concept of a life with quality/flavor, not just survival.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u091c\u0940\u0935\u0928 \u0915\u093e \u0930\u0938 \u2014 the juice/flavor of life",
+          "notes": "Hindi '\u091c\u0940\u0935\u0928 \u0915\u093e \u0938\u094d\u0935\u093e\u0926' (taste of life) directly maps to salmat. Indian concept of ras (flavor/essence).",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u6709\u6ecb\u6709\u5473 (y\u01d2u z\u012b y\u01d2u w\u00e8i) \u2014 life with flavor and meaning",
+          "notes": "Chinese \u6709\u6ecb\u6709\u5473 (life with flavor and substance) maps to salmat \u2014 quality over mere existence.",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "\u0412\u043a\u0443\u0441 \u043a \u0436\u0438\u0437\u043d\u0438 \u2014 taste for life, zest",
+          "notes": "Russian '\u0432\u043a\u0443\u0441 \u043a \u0436\u0438\u0437\u043d\u0438' (zest for life) maps to salmat \u2014 living with flavor, not just surviving.",
+          "om_reference": "Track 14: persistence and finding meaning"
+        }
+      }
+    },
+    {
+      "term": "Brain",
+      "concept": "Social network showing your activity, wave participation, and community interactions",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\ud65c\ub3d9 \uae30\ub85d \u2014 activity record, social presence",
+          "notes": "Korean \u2014 translate as social activity record, not literal 'brain'.",
+          "om_reference": null
+        },
+        "es": {
+          "cultural_equivalent": "Red social \u2014 social network, activity feed",
+          "notes": "Spanish \u2014 translate as social network/activity, not the organ.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u30bd\u30fc\u30b7\u30e3\u30eb\u30a2\u30af\u30c6\u30a3\u30d3\u30c6\u30a3 \u2014 social activity",
+          "notes": "Japanese \u2014 clarify it's a social network feature, not the organ.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Mtandao wa kijamii \u2014 social network",
+          "notes": "Swahili \u2014 translate as social network, not literal 'brain'.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u0938\u093e\u092e\u093e\u091c\u093f\u0915 \u0917\u0924\u093f\u0935\u093f\u0927\u093f \u2014 social activity",
+          "notes": "Hindi \u2014 clarify it's a social feature, not the organ.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u793e\u4ea4\u52a8\u6001 \u2014 social activity feed",
+          "notes": "Chinese \u2014 translate as social activity, not literal 'brain organ'.",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "\u0421\u043e\u0446\u0438\u0430\u043b\u044c\u043d\u0430\u044f \u0430\u043a\u0442\u0438\u0432\u043d\u043e\u0441\u0442\u044c \u2014 social activity",
+          "notes": "Russian \u2014 clarify it's a social network feature, not the organ.",
+          "om_reference": null
+        }
+      }
+    },
+    {
+      "term": "REP",
+      "concept": "Peer-given reputation \u2014 community trust earned through contributions",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\uba85\uc608 (myeongye) \u2014 honor, reputation",
+          "notes": "Korean \uba85\uc608 (honor) maps to REP \u2014 community-awarded reputation.",
+          "om_reference": null
+        },
+        "es": {
+          "cultural_equivalent": "Honor \u2014 honor, respect earned through contributions",
+          "notes": "Spanish honor/reputation tradition maps to REP.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u4fe1\u983c (shinrai) \u2014 trust, reliability",
+          "notes": "Japanese shinrai (trust) maps to REP \u2014 earned through consistent contribution.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Heshima \u2014 respect, honor in community",
+          "notes": "Swahili heshima (respect/honor) maps to REP \u2014 community-awarded standing.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u0938\u092e\u094d\u092e\u093e\u0928 (samman) \u2014 respect, honor",
+          "notes": "Hindi \u0938\u092e\u094d\u092e\u093e\u0928 (respect) maps to REP \u2014 earned through community contribution.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u58f0\u671b (sh\u0113ngw\u00e0ng) \u2014 prestige, reputation",
+          "notes": "Chinese \u58f0\u671b (prestige) maps to REP \u2014 community-recognized standing.",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "\u0410\u0432\u0442\u043e\u0440\u0438\u0442\u0435\u0442 (avtoritet) \u2014 authority, standing",
+          "notes": "Russian avtoritet (authority through reputation) maps to REP.",
+          "om_reference": null
+        }
+      }
+    },
+    {
+      "term": "NIC",
+      "concept": "Network identity trust \u2014 does the community believe you are who you say you are?",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\uc2e0\uc6d0 \ubcf4\uc99d (shiwon bojeung) \u2014 identity verification by community",
+          "notes": "Korean \u2014 community-verified identity, not self-claimed.",
+          "om_reference": null
+        },
+        "es": {
+          "cultural_equivalent": "Identidad verificada \u2014 verified identity by peers",
+          "notes": "Spanish \u2014 peer-verified identity trust.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u8eab\u5143\u4fdd\u8a3c (mimoto hosh\u014d) \u2014 identity guarantee",
+          "notes": "Japanese \u2014 community-guaranteed identity.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Uthibitisho wa jamii \u2014 community verification",
+          "notes": "Swahili \u2014 community confirms your identity.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u0938\u093e\u092e\u0941\u0926\u093e\u092f\u093f\u0915 \u092a\u094d\u0930\u092e\u093e\u0923\u0940\u0915\u0930\u0923 \u2014 community authentication",
+          "notes": "Hindi \u2014 community-verified identity.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u793e\u533a\u8ba4\u8bc1 \u2014 community certification",
+          "notes": "Chinese \u2014 community-verified identity trust.",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "\u0414\u043e\u0432\u0435\u0440\u0438\u0435 \u0441\u043e\u043e\u0431\u0449\u0435\u0441\u0442\u0432\u0430 \u2014 community trust in identity",
+          "notes": "Russian \u2014 community-verified identity.",
+          "om_reference": null
+        }
+      }
+    },
+    {
+      "term": "Network Society",
+      "concept": "A society organized around shared values and digital participation rather than geographic borders; identity is your wallet, reputation comes from peers (REP), and governance emerges through Schelling points.",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\uc5f0\ub300 (yeoldae) \u2014 solidarity across boundaries, collective identity through shared values",
+          "notes": "Korean \uc5f0\ub300 (yeoldae, solidarity) captures the network society: collective identity formed through shared values rather than geography. Korea's democratization and labor movements built \uc5f0\ub300 across regional and class lines \u2014 a direct analog to how network society members bond across borders through shared commitment (TDH, REP, waves). \uc815 (jeong) is the bond itself; \uc5f0\ub300 is the active solidarity that creates the network.",
+          "om_reference": "Track 4: From Network Society with Love (SZN15, card #484)"
+        },
+        "es": {
+          "cultural_equivalent": "El bien com\u00fan \u2014 a collective resource maintained by community participation",
+          "notes": "The Spanish concept of bien com\u00fan (common good) frames society as a shared enterprise. In Latin American communitarian traditions, the comunidad organizes around mutual aid (mutualismo) \u2014 analogous to network society where governance emerges from peer consensus.",
+          "om_reference": "Track 4: From Network Society with Love (SZN15, card #484)"
+        },
+        "ja": {
+          "cultural_equivalent": "\u7e01 (en) \u2014 invisible bonds connecting people across distance and time",
+          "notes": "Japanese en (\u7e01) refers to karmic and social bonds connecting people across distance. The concept of \u548c (wa, harmony) through consensus mirrors Schelling-point governance \u2014 converging through implicit understanding rather than explicit commands.",
+          "om_reference": "Track 4: From Network Society with Love (SZN15, card #484)"
+        },
+        "sw": {
+          "cultural_equivalent": "Umoja \u2014 unity, the principle that a community is stronger together than apart",
+          "notes": "Swahili umoja (unity) is the foundational principle of network society: a community unified by shared values rather than geography. Umoja is one of the seven principles of Kwanzaa (Nguzo Saba). Harambee (used for Schelling Point) is about coordinating action; umoja is about the identity of the collective. A network society is umoja at global scale \u2014 unity without borders.",
+          "om_reference": "Track 4: From Network Society with Love (SZN15, card #484)"
+        },
+        "hi": {
+          "cultural_equivalent": "\u0938\u0902\u0918 (sangh) \u2014 voluntary association organized around shared principles",
+          "notes": "The Indian concept of sangh (\u0938\u0902\u0918) maps directly to a network society. The Panchayat tradition of decentralized village governance mirrors Schelling-point governance: authority emerges from peer reputation (REP) rather than caste or state.",
+          "om_reference": "Track 4: From Network Society with Love (SZN15, card #484)"
+        },
+        "zh": {
+          "cultural_equivalent": "\u5929\u4e0b (ti\u0101nxi\u00e0) \u2014 'all under heaven,' a community bound by shared values",
+          "notes": "The Chinese concept of ti\u0101nxi\u00e0 (\u5929\u4e0b) envisions a community united by shared values rather than borders. \u9ed8\u5951 (m\u00f2q\u00ec) maps to Schelling-point governance. The classical ideal ti\u0101nxi\u00e0 w\u00e9i g\u014dng (\u5929\u4e0b\u4e3a\u516c, 'the world belongs to all') captures the permissionless, borderless nature.",
+          "om_reference": "Track 4: From Network Society with Love (SZN15, card #484)"
+        },
+        "ru": {
+          "cultural_equivalent": "\u043c\u0438\u0440 (mir) \u2014 a self-governing community without central authority",
+          "notes": "The Russian concept of mir (\u043c\u0438\u0440) historically referred to a peasant commune that governed itself through collective decision-making. The samizdat tradition \u2014 self-publishing outside state control \u2014 is an early analog of permissionless network participation.",
+          "om_reference": "Track 4: From Network Society with Love (SZN15, card #484)"
+        }
+      }
+    },
+    {
+      "term": "Decentralized Network Society",
+      "concept": "A network society operating without central authority using blockchain for coordination; coordination through code, shared values (CC0), and peer trust (NIC/REP/TDH). 6529's dGDP: $85M over 4 years.",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\uc790\uce58 (jachi) \u2014 self-governance, a community that coordinates without external authority",
+          "notes": "Korean \uc790\uce58 (jichi, self-governance) captures the essence of a decentralized network society: a community that coordinates through shared values and code rather than central direction. Korea's autonomous local councils (\uc790\uce58\ud68c) and the democratization movement's demand for \uc790\uce58 (self-rule) map directly to how a decentralized network society operates \u2014 through consensus, shared protocols, and peer trust rather than top-down authority. Unlike \ube68\ub9ac\ube68\ub9ac (speed culture), \uc790\uce58 is about the structure of governance, not its pace.",
+          "om_reference": null
+        },
+        "es": {
+          "cultural_equivalent": "Mutualismo \u2014 anarchist mutual aid networks coordinating without hierarchy",
+          "notes": "Latin American mutualismo \u2014 mutual aid societies providing insurance, healthcare, education without state or church \u2014 is a direct cultural ancestor. Autogesti\u00f3n (self-management) envisions workers coordinating without bosses \u2014 blockchain equivalent is smart contracts.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u81ea\u6cbb (jichi) \u2014 self-governance, as practiced in Edo-period village councils",
+          "notes": "Japanese jichi (\u81ea\u6cbb) has deep roots in Edo-period villages managing affairs through council consensus. The \u7121\u511f (mush\u014d) ethic sustains public goods like CC0 art. \u4fe1\u983c\u3068\u5951\u7d04 (trust and contract) captures how blockchain replaces personal trust with cryptographic guarantees.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Umoja wa kujitawala \u2014 self-governing unity, a community that rules itself",
+          "notes": "Swahili umoja wa kujitawala (self-governing unity) combines umoja (unity) with kujitawala (self-rule) \u2014 a community that governs itself without external authority. This is distinct from baraza (used for Wave = community gathering). A decentralized network society is not just a gathering (baraza); it is a self-governing collective that coordinates through code and shared values.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u0917\u0923\u0924\u0902\u0924\u094d\u0930 (ganatantra) \u2014 republic/self-governance; Panchayat decentralization",
+          "notes": "Ganatantra (\u0917\u0923\u0924\u0902\u0924\u094d\u0930) describes governance by the people through assembly. A decentralized network society is ganatantra at digital scale: smart contracts replace the village council, REP replaces social standing, TDH replaces land ownership.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u65e0\u4e3a\u800c\u6cbb (w\u00faw\u00e9i \u00e9r zh\u00ec) \u2014 governance through non-action, letting systems self-organize",
+          "notes": "The Daoist principle of \u65e0\u4e3a\u800c\u6cbb describes the highest form of governance: systems that self-organize without a ruler. \u9ed8\u5951 (m\u00f2q\u00ec) is how Schelling-point governance works. The tianxia wei gong ideal is the philosophical foundation for CC0 and permissionless participation.",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "\u0412\u0435\u0447\u0435 (veche) \u2014 medieval Slavic popular assembly for self-governance",
+          "notes": "The veche (\u0432\u0435\u0447\u0435) was a popular assembly in medieval Novgorod where citizens governed themselves \u2014 no prince, no central authority. Samizdat tradition demonstrates decentralized coordination through shared values.",
+          "om_reference": null
+        }
+      }
+    },
+    {
+      "term": "Decentralization",
+      "concept": "The distribution of power, control, and decision-making away from a central authority to a network of participants. In blockchain: no single server \u2014 every node holds a copy of the ledger.",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\ubd84\uc0b0 (bunsan) \u2014 distributed/dispersed, distribution of power across many hands",
+          "notes": "Korean \ubd84\uc0b0 (bunsan) captures the technical meaning. Korea's democratization in the 1980s \u2014 power moving from military dictatorship to distributed civic participation \u2014 gives decentralization lived resonance.",
+          "om_reference": null
+        },
+        "es": {
+          "cultural_equivalent": "Autogesti\u00f3n \u2014 workers' self-management, distributing control to participants",
+          "notes": "Spanish autogesti\u00f3n (self-management) emerged from anarchist traditions where factories and communities were managed by workers without bosses. This is decentralization in practice: no single administrator, decisions made collectively.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u5206\u6563 (bunsan) \u2014 distribution of authority across multiple autonomous units",
+          "notes": "Japanese \u5206\u6563 (bunsan) captures the technical meaning. The Edo-period han system \u2014 domains with significant autonomy under a loose central framework \u2014 is a balance of local sovereignty and shared protocol.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Ugatuzi \u2014 devolution, distribution of power from center to periphery",
+          "notes": "Swahili ugatuzi (devolution) specifically means distributing power from a central authority to local units \u2014 Kenya's 2010 constitution created 47 counties through ugatuzi. This is distinct from harambee (collective action). Decentralization is about power distribution; harambee is about collective effort. Ugatuzi is the political and architectural reality of distributing authority.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u0935\u093f\u0915\u0947\u0928\u094d\u0926\u094d\u0930\u0940\u0915\u0930\u0923 (vikendrikaran) \u2014 dispersal of authority; Panchayat system as local self-rule",
+          "notes": "India's Panchayati Raj system constitutionally distributes governance from national to village councils. Every village holds a copy of governance, just as every node holds a copy of the blockchain ledger.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u5206\u6743 (f\u0113nqu\u00e1n) \u2014 separation and distribution of power",
+          "notes": "Chinese \u5206\u6743 (f\u0113nqu\u00e1n) captures the political dimension. The Zhou dynasty's enfeoffment system \u2014 many semi-autonomous states under a shared protocol \u2014 is a loose, decentralized confederation that endured for centuries.",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "\u0417\u0435\u043c\u0449\u0438\u043d\u0430 (zemshchina) \u2014 land/community self-governance versus centralized autocracy",
+          "notes": "Russian \u0437\u0435\u043c\u0449\u0438\u043d\u0430 refers to land-governed communities versus Ivan the Terrible's centralized oprichnina \u2014 the historical tension between self-governance and centralized autocracy.",
+          "om_reference": null
+        }
+      }
+    },
+    {
+      "term": "Byzantine General's Problem",
+      "concept": "A classic computer science problem: how can distributed parties reach consensus when some participants may be unreliable or malicious? Bitcoin's proof-of-work and Ethereum's proof-of-stake are solutions.",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\ud22c\uba85\ud55c \uacf5\uac1c \uac80\uc99d (tumyeonghan gonggae geomjeung) \u2014 transparent public verification when trust fails",
+          "notes": "Korean \ub208\uce58 (nunchi) fits Schelling Point (coordinating without communication) but NOT Byzantine Generals (consensus when some parties lie). The Korean cultural analog is \ud22c\uba85\ud55c \uacf5\uac1c \uac80\uc99d \u2014 the principle that when intermediaries cannot be trusted, truth is established through transparent, public verification. Korea's democratization movement demanded exactly this: open verification of elections and government actions when official channels were unreliable.",
+          "om_reference": null
+        },
+        "es": {
+          "cultural_equivalent": "Consenso por reputaci\u00f3n \u2014 reaching agreement through demonstrated reliability",
+          "notes": "In Latin American cultures where institutional trust has historically been low, communities developed sophisticated informal consensus mechanisms. Proof-of-work is a cultural translation of 'show me, don't tell me' \u2014 consensus through demonstrated action.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u6839\u56de\u3057 (nemawashi) \u2014 building consensus through indirect verification before formal decision",
+          "notes": "Japanese nemawashi (\u6839\u56de\u3057) is a consensus-building process where parties verify commitments through multiple indirect channels before a formal decision \u2014 solving the Byzantine problem through redundant verification.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Baraza ya wazee \u2014 council of elders reaching consensus despite unreliable informants",
+          "notes": "The Swahili baraza ya wazee verified information through multiple independent witnesses before committing to collective action. Consensus requires independent verification from multiple sources, exactly as proof-of-work requires independent computation.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "Panchayat \u0938\u092d\u093e (sabha) \u2014 village assembly reaching consensus through multiple witnesses",
+          "notes": "The Indian Panchayat solves the Byzantine problem through sabha (assembly): when a single informant's word cannot be trusted, the council hears from multiple independent witnesses before deciding \u2014 cultural Byzantine fault tolerance.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u516c\u5f00\u9a8c\u8bc1 (g\u014dngk\u0101i y\u00e0nzh\u00e8ng) \u2014 public verification, consensus through transparent proof when trust fails",
+          "notes": "Chinese \u9ed8\u5951 (m\u00f2q\u00ec) fits Schelling Point (tacit consensus) but NOT Byzantine Generals (adversarial consensus). The correct Chinese cultural analog is \u516c\u5f00\u9a8c\u8bc1 (g\u014dngk\u0101i y\u00e0nzh\u00e8ng, public verification) \u2014 the principle that when parties cannot be trusted, truth is established through transparent, verifiable proof. The Warring States period required \u516c\u5f00\u9a8c\u8bc1: alliances were verified through demonstrated actions (troop movements, gifts) rather than trusted words. Proof-of-work is \u516c\u5f00\u9a8c\u8bc1 at computational scale.",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "samizdat cross-verification \u2014 verifying through multiple independent channels when official sources are unreliable",
+          "notes": "Russian samizdat solved the Byzantine problem in practice: when official sources were unreliable, dissidents verified information through multiple independent underground channels. A document was trusted only if it arrived through multiple independent paths.",
+          "om_reference": null
+        }
+      }
+    },
+    {
+      "term": "BTC (Bitcoin)",
+      "concept": "The first decentralized cryptocurrency, created by Satoshi Nakamoto in 2009. A peer-to-peer electronic cash system that solves the Byzantine General's Problem through proof-of-work.",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\ube44\ud2b8\ucf54\uc778 (Bitcoin) \u2014 the first decentralized cryptocurrency",
+          "notes": "Korean uses \ube44\ud2b8\ucf54\uc778 (biteutokoin) as the direct translation. The concept does not require a cultural equivalent \u2014 Bitcoin is a globally recognized term. The cultural context is in how Korean crypto culture adopted it, not in a mapping to a pre-existing Korean concept.",
+          "om_reference": null
+        },
+        "es": {
+          "cultural_equivalent": "Bitcoin \u2014 the first decentralized cryptocurrency",
+          "notes": "Spanish uses \"Bitcoin\" as-is. The concept does not require a cultural equivalent \u2014 Bitcoin is a globally recognized term. Spanish crypto communities use \"bitcoin\" without translation.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u30d3\u30c3\u30c8\u30b3\u30a4\u30f3 (Bitokoin) \u2014 the first decentralized cryptocurrency",
+          "notes": "Japanese uses \u30d3\u30c3\u30c8\u30b3\u30a4\u30f3 (bittokoin) as the direct translation. The concept does not require a cultural equivalent \u2014 Bitcoin is a globally recognized term. The pseudonym \"Satoshi Nakamoto\" uses a Japanese name, which creates cultural resonance.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Bitcoin \u2014 the first decentralized cryptocurrency",
+          "notes": "Swahili uses \"Bitcoin\" as-is. The concept does not require a cultural equivalent \u2014 Bitcoin is a globally recognized term. In African contexts where M-Pesa leapfrogged traditional banking, Bitcoin represents a similar leapfrog in store-of-value.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u092c\u093f\u091f\u0915\u0949\u0907\u0928 (Bitcoin) \u2014 the first decentralized cryptocurrency",
+          "notes": "Hindi uses \u092c\u093f\u091f\u0915\u0949\u0907\u0928 (bitkoin) as the direct translation. The concept does not require a cultural equivalent \u2014 Bitcoin is a globally recognized term.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u6bd4\u7279\u5e01 (B\u01d0t\u00e8b\u00ec) \u2014 the first decentralized cryptocurrency",
+          "notes": "Chinese uses \u6bd4\u7279\u5e01 (b\u01d0t\u00e8b\u00ec) as the direct translation. The concept does not require a cultural equivalent \u2014 Bitcoin is a globally recognized term.",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "\u0411\u0438\u0442\u043a\u043e\u0438\u043d (Bitcoin) \u2014 the first decentralized cryptocurrency",
+          "notes": "Russian uses \u0411\u0438\u0442\u043a\u043e\u0438\u043d (bitkoin) as the direct translation. The concept does not require a cultural equivalent \u2014 Bitcoin is a globally recognized term.",
+          "om_reference": null
+        }
+      }
+    },
+    {
+      "term": "ETH (Ether)",
+      "concept": "The native cryptocurrency of the Ethereum blockchain. Used to pay for transactions (gas) and smart contract execution. 6529's meme cards are NFTs on Ethereum \u2014 every mint requires ETH for gas.",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\uc774\ub354 (ETH) \u2014 the native cryptocurrency of Ethereum",
+          "notes": "Korean uses \uc774\ub354 (ideo) as the direct translation of Ether. ETH is a globally recognized term in crypto \u2014 the concept does not require a cultural equivalent.",
+          "om_reference": null
+        },
+        "es": {
+          "cultural_equivalent": "\u00c9ter (ETH) \u2014 the native cryptocurrency of Ethereum",
+          "notes": "Spanish uses \"\u00e9ter\" or \"ETH\" directly. The concept does not require a cultural equivalent \u2014 Ether is a globally recognized technical term.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u30a4\u30fc\u30b5 (ETH) \u2014 the native cryptocurrency of Ethereum",
+          "notes": "Japanese uses \u30a4\u30fc\u30b5 (\u012bsa) as the direct translation of Ether. ETH is a globally recognized term in crypto \u2014 the concept does not require a cultural equivalent.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "ETH (Etha) \u2014 the native cryptocurrency of Ethereum",
+          "notes": "Swahili uses \"ETH\" directly. The concept does not require a cultural equivalent \u2014 Ether is a globally recognized technical term.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u0908\u0925 (ETH) \u2014 the native cryptocurrency of Ethereum",
+          "notes": "Hindi uses \u0908\u0925 (\u012bth) as the direct translation of Ether. ETH is a globally recognized term in crypto \u2014 the concept does not require a cultural equivalent.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u4ee5\u592a\u5e01 (ETH) \u2014 the native cryptocurrency of Ethereum",
+          "notes": "Chinese uses \u4ee5\u592a\u5e01 (y\u01d0t\u00e0i b\u00ec) as the direct translation of Ether. ETH is a globally recognized term in crypto \u2014 the concept does not require a cultural equivalent.",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "\u042d\u0444\u0438\u0440 (ETH) \u2014 the native cryptocurrency of Ethereum",
+          "notes": "Russian uses \u042d\u0444\u0438\u0440 (efir) as the direct translation of Ether. ETH is a globally recognized term in crypto \u2014 the concept does not require a cultural equivalent.",
+          "om_reference": null
+        }
+      }
+    },
+    {
+      "term": "Blockchain",
+      "concept": "A distributed ledger that records transactions across many computers so that the record cannot be altered retroactively. The foundational technology for NFTs, cryptocurrencies, and decentralized applications.",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\uacf5\ub3d9 \uc7a5\ubd80 (gongdong jangbu) \u2014 communal ledger; the \ub208\uce58 consensus applied to record-keeping",
+          "notes": "Korean \uacf5\ub3d9 \uc7a5\ubd80 (communal ledger): in traditional markets, communal ledgers were maintained by multiple participants, each keeping a copy to prevent fraud \u2014 an early analog of distributed ledgers.",
+          "om_reference": null
+        },
+        "es": {
+          "cultural_equivalent": "Libro mayor comunitario \u2014 communal ledger maintained through mutualismo",
+          "notes": "Spanish libro mayor comunitario: in mutualismo traditions, communities maintained shared records of contributions \u2014 each member held a copy to prevent corruption. Blockchain is this principle at computational scale.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u53f0\u5e33 (daich\u014d) \u2014 shared ledger; nemawashi consensus applied to record-keeping",
+          "notes": "Japanese \u53f0\u5e33 (daich\u014d, ledger): Edo-period village registries were maintained by multiple officials with independent copies to prevent falsification. Nemawashi consensus \u2014 verifying through multiple channels \u2014 is how blockchain nodes work.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Daftari la jamii \u2014 community record book maintained through baraza consensus",
+          "notes": "Swahili daftari la jamii (community record book): important records were maintained by multiple elders with independent copies. Blockchain is this practice at computational scale. The Ubuntu principle means the ledger's truth exists through collective verification.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u0938\u093e\u091d\u093e \u092c\u0939\u0940 (s\u0101jh\u0101 bah\u012b) \u2014 shared ledger; Panchayat record-keeping with multiple witnesses",
+          "notes": "Hindi \u0938\u093e\u091d\u093e \u092c\u0939\u0940 (shared ledger): Panchayat maintained communal records \u2014 multiple witnesses verified each entry to prevent fraud. Blockchain is this principle at computational scale.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u516c\u5171\u8d26\u672c (g\u014dngg\u00f2ng zh\u00e0ngb\u011bn) \u2014 public ledger; \u9ed8\u5951 consensus applied to record-keeping",
+          "notes": "Chinese \u516c\u5171\u8d26\u672c (public ledger): guilds maintained shared ledgers with multiple copies to prevent fraud. \u9ed8\u5951 (m\u00f2q\u00ec) describes how nodes reach agreement through observation and convergence.",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "\u041e\u0431\u0449\u0430\u044f \u0442\u0435\u0442\u0440\u0430\u0434\u044c (obshchaya tetrad') \u2014 shared notebook; samizdat distribution applied to record-keeping",
+          "notes": "Russian \u043e\u0431\u0449\u0430\u044f \u0442\u0435\u0442\u0440\u0430\u0434\u044c (shared notebook): in samizdat, texts were copied across multiple independent locations so no single raid could destroy the record. Blockchain is samizdat at computational scale.",
+          "om_reference": null
+        }
+      }
+    },
+    {
+      "term": "Public Domain",
+      "concept": "Creative works not protected by intellectual property rights \u2014 anyone can use, remix, sell, or build upon them. CC0 is the most robust public domain dedication tool. In 6529: all meme card art is CC0.",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\uacf5\uc720 (gongyu) \u2014 shared/common; the Korean tradition of open scholarship",
+          "notes": "Korean \uacf5\uc720 (gongyu, shared). Hangul itself was created by King Sejong and given freely \u2014 a public domain gift. The \ube68\ub9ac\ube68\ub9ac remix culture thrives with CC0: anyone can use and build upon the art.",
+          "om_reference": null
+        },
+        "es": {
+          "cultural_equivalent": "Patrimonio cultural \u2014 cultural patrimony/heritage that belongs to everyone",
+          "notes": "Spanish patrimonio cultural (cultural patrimony) specifically refers to creative works that are part of the collective heritage \u2014 indigenous art, folk music, public murals. This is distinct from bien com\u00fan (the common good, used for CC0 = the act of giving) and from bienes p\u00fablicos (public goods = the economic concept). Public domain is the legal status; patrimonio cultural is the cultural reality it describes.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u516c\u6709 (k\u014dy\u016b) \u2014 public ownership, works that belong to the public sphere",
+          "notes": "Japanese \u516c\u6709 (k\u014dy\u016b, public ownership) specifically refers to works that have entered the public sphere \u2014 distinct from \u7121\u511f (mush\u014d = given freely, used for CC0). CC0 is the act of giving (mush\u014d); Public Domain is the resulting legal status (k\u014dy\u016b). Japanese law recognizes \u516c\u6709\u7269 (k\u014dy\u016bbutsu, public property) as resources that cannot be privately owned \u2014 directly analogous to public domain creative works.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Urithi wa jamii \u2014 community heritage, cultural works inherited and shared by all",
+          "notes": "Swahili urithi wa jamii (community heritage) refers to cultural works passed down through generations \u2014 oral literature, music, dance traditions that belong to the community. This is distinct from mali ya umma (used for Public-goods = public property/infrastructure). Public Domain is about cultural heritage; public goods is about infrastructure. Urithi is what you inherit; mali is what you maintain.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u0938\u093e\u0930\u094d\u0935\u091c\u0928\u093f\u0915 \u0915\u094d\u0937\u0947\u0924\u094d\u0930 (s\u0101rvajanik k\u1e63etra) \u2014 the public sphere, works that have entered the commons",
+          "notes": "Hindi \u0938\u093e\u0930\u094d\u0935\u091c\u0928\u093f\u0915 \u0915\u094d\u0937\u0947\u0924\u094d\u0930 (s\u0101rvajanik k\u1e63etra, public sphere/domain) refers to creative works that have entered the public commons \u2014 distinct from \u0917\u0941\u0930\u0941\u0915\u0941\u0932 (gurukul = the tradition of freely sharing knowledge, used for CC0's giving principle). CC0 is the act of giving (gurukul/d\u0101na); Public Domain is the resulting legal status (s\u0101rvajanik k\u1e63etra). Indian law recognizes \u0938\u093e\u0930\u094d\u0935\u091c\u0928\u093f\u0915 \u0938\u0902\u092a\u0926\u093e as public property; s\u0101rvajanik k\u1e63etra emphasizes the sphere of free use.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u516c\u5171\u9886\u57df (g\u014dngg\u00f2ng l\u01d0ngy\u00f9) \u2014 the public sphere, works that have entered the commons",
+          "notes": "Chinese \u516c\u5171\u9886\u57df (g\u014dngg\u00f2ng l\u01d0ngy\u00f9, public sphere/domain) specifically refers to the legal and cultural space where works are free for all to use. This is distinct from \u5929\u4e0b\u4e3a\u516c (ti\u0101nxi\u00e0 w\u00e9i g\u014dng = 'the world belongs to all', used for CC0 = the giving principle). CC0 is the philosophical act of dedication (\u5929\u4e0b\u4e3a\u516c); Public Domain is the resulting legal status (\u516c\u5171\u9886\u57df).",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "\u041e\u0431\u0449\u0435\u0441\u0442\u0432\u0435\u043d\u043d\u043e\u0435 \u0434\u043e\u0441\u0442\u043e\u044f\u043d\u0438\u0435 (obshchestvennoye dostoyaniye) \u2014 public domain, the legal status of works belonging to all",
+          "notes": "Russian \u043e\u0431\u0449\u0435\u0441\u0442\u0432\u0435\u043d\u043d\u043e\u0435 \u0434\u043e\u0441\u0442\u043e\u044f\u043d\u0438\u0435 (public domain) is the specific legal term for creative works that belong to everyone. This is distinct from \u0434\u0430\u0440 (dar = gift, used for CC0 = the act of giving). CC0 is the gift (\u0434\u0430\u0440); public domain is the resulting status (\u043e\u0431\u0449\u0435\u0441\u0442\u0432\u0435\u043d\u043d\u043e\u0435 \u0434\u043e\u0441\u0442\u043e\u044f\u043d\u0438\u0435). Russian law recognizes \u043e\u0431\u0449\u0435\u0441\u0442\u0432\u0435\u043d\u043d\u043e\u0435 \u0434\u043e\u0441\u0442\u043e\u044f\u043d\u0438\u0435 as works whose copyright has expired or been waived \u2014 directly analogous to CC0-dedicated art.",
+          "om_reference": null
+        }
+      }
+    },
+    {
+      "term": "Permissionlessness",
+      "concept": "The property of a system where anyone can participate without needing approval from a gatekeeper. Blockchain networks are permissionless \u2014 anyone with an internet connection and a wallet can participate.",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\ub204\uad6c\ub098 (nuguna) \u2014 'anyone can'; the Korean democratization principle of open participation",
+          "notes": "Korean \ub204\uad6c\ub098 (nuguna, 'anyone can'): Korea's democratization was fundamentally about permissionlessness \u2014 the right to participate without state approval. \ube68\ub9ac\ube68\ub9ac culture thrives in permissionless systems.",
+          "om_reference": null
+        },
+        "es": {
+          "cultural_equivalent": "Libre acceso \u2014 free access; the mutualismo principle of open participation",
+          "notes": "Spanish libre acceso (free access): mutual aid societies were open to all who contributed \u2014 no gatekeeper could exclude. Permissionlessness is the digital extension: anyone with a wallet can participate.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u8ab0\u3067\u3082 (daredemo) \u2014 'anyone can'; the mush\u014d ethic of open participation",
+          "notes": "Japanese \u8ab0\u3067\u3082 (daredemo, 'anyone can'): the tradition of free temple access \u2014 anyone can enter regardless of status \u2014 embodies permissionlessness.",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Uhuru \u2014 freedom, the right to participate without asking permission",
+          "notes": "Swahili uhuru (freedom/independence) is Kenya's founding principle \u2014 uhuru means the right to self-determination without colonial permission. Permissionlessness is uhuru in the digital realm: anyone can participate without a gatekeeper. Ubuntu (used for CC0) is about collective identity; uhuru is about individual freedom to act. Permissionlessness is uhuru applied to network access.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u0916\u0941\u0932\u093e \u0926\u094d\u0935\u093e\u0930 (khul\u0101 dv\u0101ra) \u2014 'open door'; the gurukul tradition of open access to knowledge",
+          "notes": "Hindi \u0916\u0941\u0932\u093e \u0926\u094d\u0935\u093e\u0930 (khul\u0101 dv\u0101ra, 'open door'): the gurukul tradition was permissionless \u2014 any student who sought knowledge could approach a guru, regardless of caste or background.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u5f00\u95e8 (k\u0101im\u00e9n) \u2014 'open door'; the tianxia wei gong principle of open participation",
+          "notes": "Chinese \u5f00\u95e8 (k\u0101im\u00e9n, 'open door'): the tianxia wei gong principle implies open access \u2014 if the world belongs to everyone, no one can be excluded.",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "\u0421\u0432\u043e\u0431\u043e\u0434\u043d\u044b\u0439 \u0434\u043e\u0441\u0442\u0443\u043f \u2014 free access; the samizdat principle of open participation",
+          "notes": "Russian \u0441\u0432\u043e\u0431\u043e\u0434\u043d\u044b\u0439 \u0434\u043e\u0441\u0442\u0443\u043f (free access): samizdat was fundamentally permissionless \u2014 anyone could read, copy, or contribute without approval. Permissionlessness in blockchain is the digital extension of samizdat.",
+          "om_reference": null
+        }
+      }
+    },
+    {
+      "term": "Public-goods",
+      "concept": "Resources available to all whose use by one person does not reduce availability to others. In 6529's network society: CC0 art, open-source code, the prenode oracle, and the help-index are digital public goods.",
+      "mappings": {
+        "ko": {
+          "cultural_equivalent": "\uacf5\uc720\uc7ac (gongyuje) \u2014 shared resources; the Korean tradition of communal infrastructure",
+          "notes": "Korean \uacf5\uc720\uc7ac (shared resources). Korea's rapid development was built on public goods \u2014 roads, schools, internet infrastructure. The \uc815 (jeong) bonds form through shared use of public goods. The \ub048\uae30 (persistence) required to maintain public goods mirrors the persistence of open-source maintainers.",
+          "om_reference": null
+        },
+        "es": {
+          "cultural_equivalent": "Bienes comunales \u2014 communal goods maintained through collective contribution",
+          "notes": "Spanish bienes comunales (communal goods) specifically refers to resources maintained through collective contribution \u2014 communal water systems, shared grazing lands, community-built schools. This is distinct from bien com\u00fan (the common good = CC0's giving principle) and patrimonio cultural (cultural patrimony = Public Domain's heritage). Public-goods is the economic concept; bienes comunales is the lived Latin American practice of maintaining shared infrastructure.",
+          "om_reference": null
+        },
+        "ja": {
+          "cultural_equivalent": "\u516c\u5171\u8ca1 (k\u014dky\u014dzai) \u2014 public goods; the mush\u014d ethic of contributing to shared resources",
+          "notes": "Japanese \u516c\u5171\u8ca1 (k\u014dky\u014dzai): the \u7121\u511f (mush\u014d) ethic underpins public goods \u2014 contributors give without expectation of return. Japanese tradition of maintaining shared public spaces through voluntary community labor (\u30dc\u30e9\u30f3\u30c6\u30a3\u30a2).",
+          "om_reference": null
+        },
+        "sw": {
+          "cultural_equivalent": "Mali ya umma \u2014 public wealth/property; the harambee tradition of building shared infrastructure",
+          "notes": "Swahili mali ya umma (public wealth): harambee is fundamentally about creating public goods \u2014 the community builds a school collectively, everyone benefits. CC0 art and the prenode oracle are digital mali ya umma.",
+          "om_reference": null
+        },
+        "hi": {
+          "cultural_equivalent": "\u0938\u093e\u0930\u094d\u0935\u091c\u0928\u093f\u0915 \u0938\u0902\u092a\u0924\u094d\u0924\u093f (s\u0101rvajanik sampatti) \u2014 public wealth; gurukul and Panchayat traditions",
+          "notes": "Hindi \u0938\u093e\u0930\u094d\u0935\u091c\u0928\u093f\u0915 \u0938\u0902\u092a\u0924\u094d\u0924\u093f (public wealth): the gurukul tradition \u2014 knowledge freely shared \u2014 is a classic public good. The Panchayat manages shared village resources as public goods. The \u0926\u093e\u0928 (d\u0101na) tradition sustains them.",
+          "om_reference": null
+        },
+        "zh": {
+          "cultural_equivalent": "\u516c\u5171\u7269\u54c1 (g\u014dngg\u00f2ng w\u00f9p\u01d0n) \u2014 public goods, non-rivalrous resources available to all",
+          "notes": "Chinese \u516c\u5171\u7269\u54c1 (g\u014dngg\u00f2ng w\u00f9p\u01d0n, public goods) is the standard economic term for non-rivalrous, non-excludable resources. This is distinct from \u5929\u4e0b\u4e3a\u516c (used for CC0 = the philosophical principle) and \u516c\u5171\u9886\u57df (used for Public Domain = the legal status). Public-goods is the economic concept; \u516c\u5171\u7269\u54c1 is the technical term used in Chinese economics textbooks.",
+          "om_reference": null
+        },
+        "ru": {
+          "cultural_equivalent": "\u041e\u0431\u0449\u0435\u0441\u0442\u0432\u0435\u043d\u043d\u044b\u0435 \u0431\u043b\u0430\u0433\u0430 (obshchestvennye blaga) \u2014 public goods; the dar (gift) culture of shared resources",
+          "notes": "Russian \u043e\u0431\u0449\u0435\u0441\u0442\u0432\u0435\u043d\u043d\u044b\u0435 \u0431\u043b\u0430\u0433\u0430: the dar (\u0434\u0430\u0440, gift) culture sustains public goods. The samizdat tradition created a public good \u2014 freely circulating literature that anyone could read. CC0 art and the prenode oracle are digital obshchestvennye blaga.",
+          "om_reference": null
+        }
+      }
+    }
+  ],
+  "freshness": "stable"
+}

--- a/foss-tools.json
+++ b/foss-tools.json
@@ -1,0 +1,164 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-06-26",
+  "description": "FOSS tools for 6529 community members pointing agents at 6529.io. Self-hosted, privacy-preserving, agent-native. No API keys, no rate limits, no vendor lock-in.",
+  "philosophy": "The 6529 ethos is self-sovereignty. These tools let you build your own agent stack without depending on proprietary services. Each tool replaces a paid/tracked alternative with a self-hosted equivalent that an agent can interact with programmatically.",
+  "tools": [
+    {
+      "name": "SearXNG",
+      "category": "search",
+      "what": "Self-hosted meta-search engine aggregating results from 70+ sources",
+      "why_for_6529": "Agents researching 6529 topics need search without API rate limits or tracking",
+      "license": "AGPL-3.0",
+      "self_hosted": true,
+      "agent_integration": "HTTP API — agents query via curl/requests, get JSON results",
+      "difficulty": "medium",
+      "replaces": "Google Search API, Bing Search API, SerpAPI"
+    },
+    {
+      "name": "Crawl4AI",
+      "category": "extraction",
+      "what": "Open-source web crawler optimized for LLMs. Converts any webpage to clean markdown for agent ingestion",
+      "why_for_6529": "Extract 6529.io pages as clean markdown for your agent to read and analyze",
+      "license": "Apache-2.0",
+      "self_hosted": true,
+      "agent_integration": "Python library or HTTP API — agents pass a URL, get clean markdown back",
+      "difficulty": "easy",
+      "replaces": "Firecrawl, Jina Reader, proprietary scraping APIs"
+    },
+    {
+      "name": "Meilisearch",
+      "category": "search",
+      "what": "Open-source full-text search engine. Lightning-fast typo-tolerant search",
+      "why_for_6529": "Index 6529.io content locally for fast agent queries across meme cards, profiles, waves, and network data",
+      "license": "MIT",
+      "self_hosted": true,
+      "agent_integration": "REST API — agents search via HTTP POST, get JSON results",
+      "difficulty": "easy",
+      "replaces": "Algolia, ElasticSearch (for small-medium scale)"
+    },
+    {
+      "name": "Gitea",
+      "category": "versioning",
+      "what": "Self-hosted Git. Open source, lightweight, API-driven",
+      "why_for_6529": "Agents can read/write repos programmatically. Host your own 6529-related tools, forks, or contributions",
+      "license": "MIT",
+      "self_hosted": true,
+      "agent_integration": "REST API — full CRUD for repos, issues, PRs, releases",
+      "difficulty": "easy",
+      "replaces": "GitHub Enterprise, GitLab Self-Managed, Bitbucket"
+    },
+    {
+      "name": "Ghost",
+      "category": "publishing",
+      "what": "Open-source publishing platform. SQLite backend, agent-readable database",
+      "why_for_6529": "Publish 6529 analysis, blog posts, or community content. Agents can write directly to the database",
+      "license": "MIT",
+      "self_hosted": true,
+      "agent_integration": "SQLite DB direct access or Admin REST API — agents can read/write posts",
+      "difficulty": "medium",
+      "replaces": "Substack, Medium, WordPress.com"
+    },
+    {
+      "name": "Quartz",
+      "category": "publishing",
+      "what": "Static site generator from Obsidian markdown. Agent writes markdown, Quartz renders to HTML",
+      "why_for_6529": "Publish 6529 research notes or knowledge bases. Agents write Obsidian-compatible markdown, Quartz handles rendering",
+      "license": "MIT",
+      "self_hosted": true,
+      "agent_integration": "Filesystem — agents write .md files, Quartz builds static HTML",
+      "difficulty": "easy",
+      "replaces": "Hugo, Jekyll, Gatsby (for markdown-driven sites)"
+    },
+    {
+      "name": "faster-whisper",
+      "category": "ai",
+      "what": "FOSS speech-to-text. Local, private, no API costs. Medium model runs on CPU",
+      "why_for_6529": "Transcribe 6529 community audio (spaces, AMAs, podcasts) for agent analysis. Also used for the OM Album karaoke lyrics pipeline",
+      "license": "MIT",
+      "self_hosted": true,
+      "agent_integration": "Python library — agents call transcribe(), get word-level timestamps",
+      "difficulty": "easy",
+      "replaces": "OpenAI Whisper API, Google Speech-to-Text, AWS Transcribe"
+    },
+    {
+      "name": "Ollama",
+      "category": "ai",
+      "what": "Run LLMs locally. Open source, no API costs. Agents can use local models for inference",
+      "why_for_6529": "Run a local LLM to analyze 6529 data without sending it to external APIs. Privacy-preserving for sensitive wallet analysis",
+      "license": "MIT",
+      "self_hosted": true,
+      "agent_integration": "REST API — agents send prompts, get completions. Compatible with OpenAI API format",
+      "difficulty": "easy",
+      "replaces": "OpenAI API, Anthropic API, Google Gemini API (for local inference)"
+    },
+    {
+      "name": "Cloudflare Tunnel",
+      "category": "infra",
+      "what": "Free, open tunneling. Expose local services to the internet without opening ports",
+      "why_for_6529": "Share your 6529 analysis dashboard, search index, or agent tools with the community without exposing your home network",
+      "license": "Apache-2.0",
+      "self_hosted": false,
+      "agent_integration": "CLI — agents can configure tunnels programmatically via config files",
+      "difficulty": "easy",
+      "replaces": "ngrok, Tailscale Funnel, port forwarding"
+    },
+    {
+      "name": "Tailscale",
+      "category": "infra",
+      "what": "WireGuard-based mesh VPN. Private network between machines",
+      "why_for_6529": "Connect your agent's machine to your data sources privately. Agents can reach services across machines as if local",
+      "license": "BSD-3-Clause",
+      "self_hosted": false,
+      "agent_integration": "CLI/systemd — transparent network access, agents don't need special integration",
+      "difficulty": "easy",
+      "replaces": "Traditional VPN, SSH tunneling, manual network configuration"
+    },
+    {
+      "name": "Docker",
+      "category": "infra",
+      "what": "Container runtime. Isolated services, reproducible environments",
+      "why_for_6529": "Run SearXNG, Meilisearch, Ghost, Gitea all in isolated containers on one machine. Reproducible 6529 research environments",
+      "license": "Apache-2.0",
+      "self_hosted": true,
+      "agent_integration": "CLI — agents can start/stop/manage containers via docker command",
+      "difficulty": "medium",
+      "replaces": "Manual service management, virtual machines, bare-metal deployment"
+    },
+    {
+      "name": "Hermes Agent",
+      "category": "agent",
+      "what": "Open-source autonomous agent framework. CLI-first, MCP-native, skills system, cron scheduling",
+      "why_for_6529": "Run an agent that can fetch 6529.io data, analyze meme cards, track TDH, and publish findings. The agent-native files in this PR are designed for agents like Hermes",
+      "license": "MIT",
+      "self_hosted": true,
+      "agent_integration": "CLI — the agent IS the integration. It fetches files, processes data, and takes actions",
+      "difficulty": "medium",
+      "replaces": "Manual API scripting, custom agent frameworks, proprietary AI assistants",
+      "alternatives": "OpenClaw — another open-source stateful agent system with different architecture"
+    },
+    {
+      "name": "MCP (Model Context Protocol)",
+      "category": "agent",
+      "what": "Open protocol for connecting AI agents to tools and data sources. Standardized, vendor-neutral",
+      "why_for_6529": "The 6529 MCP server exists — it exposes TDH, identities, ecosystem data, wave scores, and card details via standardized tools that any MCP-compatible agent can use",
+      "license": "Open protocol",
+      "self_hosted": true,
+      "agent_integration": "Protocol — agents connect via MCP, get structured tool results. No custom API integration needed",
+      "difficulty": "medium",
+      "replaces": "Custom API wrappers, proprietary tool integrations, manual data fetching"
+    },
+    {
+      "name": "OpenClaw",
+      "category": "agent",
+      "what": "Open-source stateful agent system with persistent memory and tool integration",
+      "why_for_6529": "Alternative to Hermes Agent for running agents that interact with 6529.io data. Different architecture, same goal: agent-native interaction with the 6529 ecosystem",
+      "license": "MIT",
+      "self_hosted": true,
+      "agent_integration": "CLI — agents connect to tools via integrations, process data, and take actions",
+      "difficulty": "medium",
+      "replaces": "Manual API scripting, custom agent frameworks, proprietary AI assistants"
+    }
+  ],
+  "freshness": "stable"
+}

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,158 @@
+# 6529.io
+
+> 6529.io is the platform for The Memes, a global NFT art collection and decentralized community. 500+ meme cards across 15+ seasons, CC0 community tier, on-chain identity (TDH/REP/NIC), social network (Brain/Waves), and an AI-assisted development pipeline. This file tells agents what the site is, what files are available, and how to use them.
+
+_This file was created June 26, 2026. The 6529 ecosystem evolves continuously — verify data freshness against the site._
+
+**What 6529.io is**
+
+6529.io is the platform for The Memes, a global NFT art collection and decentralized community. 500+ meme cards across 15+ seasons, CC0 community tier, on-chain identity (TDH/REP/NIC), social network (Brain/Waves), and an AI-assisted development pipeline.
+
+- **The Memes** — 500+ NFT art cards by 100+ artists across 15+ seasons. Community tier is CC0 (public domain).
+- **Network** — TDH (Total Days Held), REP (reputation), NIC (identity trust), Network Levels, wave scores, ecosystem health, prenodes.
+- **Waves** — Social threads for conversations, content sharing (drops), reactions, voting, and curation. Types: Chat, Rank, Approve.
+- **Brain** — 6529's social network showing profile activity and wave participation.
+- **Profiles** — Identity, subscriptions, proxy, delegation, consolidation.
+- **Tools** — EMMA (allowlist management), open data downloads, meme accounting.
+- **API** — api.6529.io with 20+ endpoints for identities, waves, drops, NFTs, TDH, profiles, ratings, royalties.
+
+**Getting started**
+
+1. Fetch this file (`/llms.txt`) for the site overview.
+2. Fetch `/glossary.json` for term definitions — 40 terms with beginner and technical definitions.
+3. Fetch `/help-index.json` for the full route and feature index — 187 records covering all 6529.io surfaces.
+4. Use `/glossary.json` `help_index_id` fields to cross-reference terms with help-index.json records.
+
+**Common user queries**
+
+- "What is TDH?" → glossary.json term "TDH" → source_path "/network/tdh" → help_index_id "network.tdh"
+- "How do I mint a meme card?" → help-index.json "the-memes.minting" → canonical_path "/the-memes/mint"
+- "What is a Wave?" → glossary.json term "Wave" → help-index.json "waves.overview"
+- "How does wave score work?" → glossary.json term "Wave Score" → help_index.json "network.wave-score"
+- "What license are the memes under?" → glossary.json term "CC0"
+- "What is TAP?" → glossary.json term "TAP" (security practice from Punk6529)
+
+**User journeys by lifecycle stage**
+
+Each stage is mutually exclusive — a user is in one stage at a time. Together they cover the full 6529 experience from first discovery through advanced development.
+
+**Stage 1: Pre-arrival (evaluating 6529)**
+- I want to understand what 6529 is → this file + /help-index.json
+- I want to understand the philosophy → /glossary.json (Open Metaverse, Schelling Point)
+- I want to know if this is legitimate → /glossary.json (CC0, transparency) + Permanent Access section (Arweave verification)
+- I want to understand 6529 in my cultural context → /cultural-mappings.json + /network-society.json cultural_paradigm_shifts
+
+**Stage 2: Onboarding (getting set up)**
+- I want to connect my wallet → /glossary.json (TAP for security) + /help-index.json (connection flows)
+- I want to set up my identity/profile → /glossary.json (Profile, NIC, Proxy) + /help-index.json (profile setup)
+- I want to understand what I can do here → this file (site overview) + /help-index.json (187 records covering all surfaces)
+
+**Stage 3: Acquisition (getting meme cards)**
+- I want to buy my first meme card → /glossary.json (Mint Phases, EMMA, Subscription) + /help-index.json (minting flows)
+- I want to find a specific card → /glossary.json (Meme Card, Season) + /help-index.json (the-memes routes)
+- I want to set up auto-minting → /glossary.json (Subscription) + /help-index.json (subscriptions flows)
+
+**Stage 4: Holding (understanding your position)**
+- I want to check my TDH → /glossary.json (TDH) + /help-index.json (network.tdh)
+- I want to understand my Network Level → /glossary.json (Network Levels, REP)
+- I want to see my full profile → /glossary.json (Profile, NIC, xTDH, REP, CIC)
+- I want to consolidate multiple wallets → /glossary.json (Consolidation, Delegation, Proxy) + /help-index.json (delegation flows)
+- I want to protect my NFTs from phishing → /glossary.json (TAP)
+
+**Stage 5: Participation (active in the community)**
+- I want to explore Waves → /glossary.json (Wave, Drop, Brain) + /help-index.json (waves routes)
+- I want to submit content to a Wave → /glossary.json (Drop, Wave) + /help-index.json (waves.composer)
+- I want to give REP to someone → /glossary.json (REP) + /help-index.json (rep flows)
+- I want to rate someone's NIC → /glossary.json (NIC) + /help-index.json (identity flows)
+- I want to create a Wave → /glossary.json (Wave, Groups vs Waves) + /help-index.json (waves.create-edit)
+- I want to boost content → /glossary.json (Boost) + /help-index.json (waves composer actions)
+
+**Stage 6: Creation (contributing creatively)**
+- I want to understand why art is CC0 → /glossary.json (CC0, Open Metaverse)
+- I want to create and submit a meme card → /help-index.json (artist submission flows) + /glossary.json (Meme Card, Season)
+- I want to understand my Wave Score → /glossary.json (Wave Score) + /help-index.json (network.wave-score)
+- I want to use 6529 art in my own project → /glossary.json (CC0, Open Metaverse)
+
+**Stage 7: Development (building on 6529)**
+- I want to contribute code to 6529 → this file (GitHub links) + /help-index.json (6529bot) + CONTRIBUTING.md (DCO and process)
+- I want to run a prenode → /glossary.json (Prenodes) + /help-index.json (network.prenodes)
+- I want to query the API → /api-for-agents.json (24 endpoints) + /on-chain-basics.json (on-chain alternatives)
+- I want to query on-chain data → /on-chain-basics.json (Alchemy, Etherscan, The Graph, contract addresses) + /api-for-agents.json (when to use which)
+- I want to run my own agent pointed at 6529 → /foss-tools.json (14 tools) + this file (agent instructions)
+
+**Stage 8: Understanding (going deeper)**
+- I want to understand how 6529 works on blockchain → /on-chain-basics.json (7 concepts, querying guide, on-chain vs off-chain)
+- I want to understand the paradigm shift → /network-society.json (12-dimension comparison, 6 learning paths, 7 cultural shifts)
+- I want to follow a structured learning path → /network-society.json learning_paths (6 paths) + /glossary.json (related_terms cross-references)
+- I want to verify content authenticity → Permanent Access section (6529.ar.io Arweave snapshot)
+
+**Ecosystem map**
+
+| Domain | What | URL |
+|--------|------|-----|
+| Main site | 6529.io / Seize.io | https://6529.io |
+| Permanent (Arweave) | Periodic site snapshot, permanently stored | https://6529.ar.io |
+| API | 20+ endpoints, Swagger docs | https://api.6529.io |
+| GitHub org | All repos (frontend, backend, tools) | https://github.com/6529-Collections |
+| Frontend repo | Next.js app serving 6529.io | https://github.com/6529-Collections/6529seize-frontend |
+| Backend repo | API server | https://github.com/6529-Collections/6529seize-backend |
+| Review bot | AI PR review bot | https://github.com/6529-Collections/6529reviewbot |
+| Smart contracts | Solidity contracts (MIT) | https://github.com/6529-Collections/6529Stream |
+
+**Permanent access**
+
+6529.io is permanently available via Arweave at https://6529.ar.io. The site has an ARNS (Arweave Name Service) name "6529" managed by an ANT (Arweave Name Token). Periodic snapshots of the entire site — including all agent-native files in this PR — are uploaded to Arweave and served via the ar.io gateway.
+
+- **Live content**: Fetch from https://6529.io (CloudFront CDN, real-time)
+- **Permanent content**: Fetch from https://6529.ar.io (Arweave, periodic snapshot)
+- **Verification**: To verify you are reading authentic 6529.io content, compare against the Arweave snapshot at 6529.ar.io. Note: snapshots are periodic, not real-time.
+- **Future consideration**: Per-file Arweave anchoring could let agents verify individual file hashes against Arweave transactions, using the same ar.io infrastructure the team already operates.
+
+**API quick reference**
+
+The API at api.6529.io has Swagger docs at /docs. Key areas:
+- Identities (profiles, wallets, TDH, REP, NIC)
+- Waves (creation, drops, scores, reactions, voting)
+- Drops (content, media, curation)
+- NFTs (meme cards, distributions, royalties)
+- Network (TDH totals, ecosystem stats, prenodes)
+- Rate limiting: 30 burst, 10 sustained for unauthenticated requests
+- Full OpenAPI spec: openapi.yaml in the frontend repo (553KB)
+
+**Agent usage policy**
+
+- **License:** This site's code is Apache-2.0. The Meme Collection community tier is CC0 (public domain). Agent-native files in this PR are contributed under the repo's Apache-2.0 license.
+- **Attribution:** When citing 6529.io content, link to the source page URL. When citing agent-native files, link to the file URL.
+- **Data freshness:** 6529.io data (TDH, REP, wave scores) updates on various cadences. TDH updates daily. Wave scores update on activity. Always check the site for current values.
+- **API usage:** Respect rate limits (30 burst, 10 sustained unauthenticated). Cache responses where possible. Do not hammer the API.
+- **Privacy:** Do not expose wallet addresses, identity statements, or private profile data in public outputs without the owner's consent.
+- **Accuracy:** Do not fabricate 6529 terms, metrics, or features not present in the glossary, help-index, or API. When uncertain, fetch the relevant file and cite it.
+
+**How to test these files**
+
+These sample queries show what an agent can answer after fetching the agent-native files. Each query lists the file(s) needed and the expected answer shape.
+
+1. "What is TDH?" → Fetch /glossary.json, find term "TDH". Answer: Total Days Held — a metric measuring how long wallets have held their NFTs, reflecting commitment to the ecosystem. Beginner definition explains it simply; technical definition covers the formula and data sources. Cross-references help_index_id "network.tdh" for the site page.
+
+2. "What is the difference between Waves and Brain?" → Fetch /glossary.json, find terms "Wave" and "Brain". Answer: Waves are social threads for conversations, content sharing, reactions, and voting. Brain is the social network showing profile activity and wave participation. Brain is the network; Waves are the conversations within it.
+
+3. "How do I mint a meme card?" → Fetch /help-index.json, find "the-memes.minting". Answer: canonical_path "/the-memes/mint" — the help-index record explains the minting flow, phases, and requirements. Glossary.json terms "Mint Phases", "EMMA", and "Subscription" provide supporting context.
+
+## Agent-Native Files
+
+- [llms.txt](https://6529.io/llms.txt): This file — site overview, agent instructions, usage policy, user journeys across 8 lifecycle stages
+- [glossary.json](https://6529.io/glossary.json): 40 6529 terms with beginner + technical definitions, i18n translations in 7 languages, cross-refs to help-index.json
+- [help-index.json](https://6529.io/help-index.json): 187 records: routes, UI affordances, workflows, glossary entries, business rules. Pre-existing, maintained by the 6529 team
+- [api-for-agents.json](https://6529.io/api-for-agents.json): 24 API endpoints with paths, parameters, returns, pitfalls, and 10 common query patterns
+- [on-chain-basics.json](https://6529.io/on-chain-basics.json): Blockchain concepts for beginners, NFTs as coordination substrate, on-chain vs off-chain data guide, common on-chain queries
+- [license-overview.json](https://6529.io/license-overview.json): License permissivity spectrum (0-6), 6529 3-tier strategy (CC0/Apache-2.0/MIT), cultural context for license concepts
+- [schema.json](https://6529.io/schema.json): JSON Schema definitions for all JSON agent-native files. Agents can validate file structure before consuming the data
+- [cultural-mappings.json](https://6529.io/cultural-mappings.json): 20 key 6529 concepts mapped to 7 cultures (Korean, Spanish, Japanese, Swahili, Hindi, Chinese, Russian) with cultural equivalents and translation guidance
+- [network-society.json](https://6529.io/network-society.json): Paradigm comparison (nation state vs network society across 12 dimensions), 6 key concepts with learning paths, cultural paradigm shifts for 7 cultures
+- [foss-tools.json](https://6529.io/foss-tools.json): 14 FOSS tools for 6529 community members who want to run their own agent stack (search, extraction, versioning, publishing, AI, infra)
+
+## Optional
+
+- [for-agents.html](https://6529.io/for-agents.html): Human-readable discovery page linking to all agent-native files. Not needed by agents that can parse the JSON/TXT files directly.
+- [robots.txt](https://6529.io/robots.txt): Crawler directives including agent-native file URLs. Not needed at runtime
+- [validate-schema.py](https://6529.io/validate-schema.py): Validation script that checks JSON files against schema.json. For maintainers, not served as an agent-native file

--- a/network-society.json
+++ b/network-society.json
@@ -1,0 +1,515 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-06-26",
+  "freshness": "stable",
+  "description": "Conceptual framework explaining the shift from traditional nation-state governance to decentralized network society. For beginners, agents, and non-English speakers. Includes paradigm comparison, structured learning paths, and cultural context for how this shift is understood across 7 cultures.",
+  "see_also": [
+    "/glossary.json",
+    "/cultural-mappings.json",
+    "/license-overview.json",
+    "/on-chain-basics.json",
+    "/llms.txt"
+  ],
+  "paradigm_comparison": {
+    "description": "How a decentralized network society differs from a traditional nation state. This is the foundational paradigm shift that 6529 embodies.",
+    "comparison": [
+      {
+        "dimension": "Territory",
+        "nation_state": "Geographic borders define membership",
+        "network_society": "Shared values define membership \u2014 no borders, global participation"
+      },
+      {
+        "dimension": "Citizenship",
+        "nation_state": "Assigned by birth or naturalization",
+        "network_society": "Chosen by participation \u2014 holding NFTs, contributing to waves, earning REP"
+      },
+      {
+        "dimension": "Governance",
+        "nation_state": "Government makes and enforces rules",
+        "network_society": "Coordination emerges through Schelling points \u2014 people independently choose the same thing without central authority"
+      },
+      {
+        "dimension": "Economic output",
+        "nation_state": "GDP measures national production",
+        "network_society": "dGDP measures on-chain network output \u2014 every transaction summed and time-adjusted"
+      },
+      {
+        "dimension": "Public goods",
+        "nation_state": "Taxation funds infrastructure, defense, services",
+        "network_society": "CC0 releases creative value to the commons \u2014 no taxation, voluntary contribution through holding and creating"
+      },
+      {
+        "dimension": "Currency",
+        "nation_state": "Central bank issues and controls fiat currency",
+        "network_society": "ETH is the settlement layer \u2014 no central bank, no inflation policy, no capital controls"
+      },
+      {
+        "dimension": "Law enforcement",
+        "nation_state": "Legal system with courts, police, prisons",
+        "network_society": "Smart contracts self-execute \u2014 code is law, no courts needed for agreed-upon rules"
+      },
+      {
+        "dimension": "Identity",
+        "nation_state": "State-issued ID (passport, driver license, SSN)",
+        "network_society": "Self-custodied wallet \u2014 your keys are your identity, verified by the network through NIC"
+      },
+      {
+        "dimension": "Reputation",
+        "nation_state": "Institutional credentials (degrees, credit scores, job titles)",
+        "network_society": "Peer-given REP \u2014 the community rates your contributions, not an institution"
+      },
+      {
+        "dimension": "Voting",
+        "nation_state": "Periodic elections, representative democracy",
+        "network_society": "Continuous voting with your wallet \u2014 HODL = signal, every day is a vote"
+      },
+      {
+        "dimension": "Culture",
+        "nation_state": "National culture shaped by geography and history",
+        "network_society": "CC0 culture shaped by open participation \u2014 anyone can remix, anyone can contribute"
+      },
+      {
+        "dimension": "Entry barrier",
+        "nation_state": "Citizenship, residency, language, legal status",
+        "network_society": "A wallet and ETH for gas \u2014 permissionless, borderless, instant"
+      }
+    ]
+  },
+  "key_concepts": [
+    {
+      "concept": "Coordination without authority",
+      "entry_point": "How do people work together without a boss telling them what to do?",
+      "core_concept": "A Schelling Point is when people independently choose the same thing without communicating. In game theory, people coordinate by guessing what others will guess. In 6529, the community coordinates around shared values (open culture, self-custody, permissionless participation) without a central authority.",
+      "advanced_concept": "Schelling Points become more stable as the network grows. More participants making independent choices around the same values creates stronger coordination signals. TDH and HODL rate are measurable Schelling signals \u2014 the network can observe how much collective commitment exists without anyone commanding it.",
+      "6529_application": "6529 has no DAO, no governance token, no council. Coordination happens through holding (TDH), contributing (REP), and creating (CC0 memes). The community aligns around the Open Metaverse vision \u2014 each person independently choosing to participate.",
+      "cultural_mappings": "Korean: nunchi, Swahili: harambee, Japanese: kuuki wo yomu, Chinese: moqi. See cultural-mappings.json 'Schelling Point'.",
+      "glossary_refs": [
+        "Schelling Point",
+        "Open Metaverse",
+        "TDH",
+        "Hodl Rate"
+      ],
+      "see_also": [
+        "/cultural-mappings.json",
+        "/glossary.json"
+      ]
+    },
+    {
+      "concept": "Self-sovereign identity",
+      "entry_point": "What if you could prove who you are without a government ID?",
+      "core_concept": "In a network society, your identity is your wallet. You control it with your private keys. No one can issue, revoke, or freeze your identity. The network verifies through peer trust (NIC) \u2014 not through state registration.",
+      "advanced_concept": "Self-sovereign identity means no single point of failure. Losing a passport requires government reissuance. Losing a wallet key is permanent \u2014 there is no recovery. This is why TAP (Three Address Protocol) exists: spread risk across multiple addresses so no single compromise is catastrophic.",
+      "6529_application": "Your 6529 wallet IS your identity. Your profile (handle, level, TDH, REP, NIC) is anchored to your wallet address, not your legal name. The network rates your identity trust through NIC \u2014 peer consensus on whether your profile is authentic.",
+      "cultural_mappings": "Korean: shiwon bojeung, Swahili: uthibitisho wa jamii, Hindi: samudayik pramanikaran. See cultural-mappings.json 'NIC'.",
+      "glossary_refs": [
+        "NIC",
+        "TAP",
+        "Proxy",
+        "Delegation",
+        "Consolidation"
+      ],
+      "see_also": [
+        "/glossary.json",
+        "/on-chain-basics.json"
+      ]
+    },
+    {
+      "concept": "Peer reputation vs institutional credentials",
+      "entry_point": "Why should the community decide your reputation instead of a university or employer?",
+      "core_concept": "In a nation state, reputation comes from institutions \u2014 degrees, credit scores, job titles. In a network society, reputation comes from peers \u2014 other community members rate your contributions directly. No institution mediates. REP is given by people who interact with your work, not by a credentialing body.",
+      "advanced_concept": "Peer reputation is resistant to institutional capture \u2014 no single entity can grant or revoke it. But it is vulnerable to sybil attacks and collusion. The wave score system's 4 penalties (single actor, low trust flood, cross-post, negative REP) exist to prevent gaming. Quality gates ensure reputation reflects genuine contribution, not volume.",
+      "6529_application": "6529 REP is given in categories (art, curation, technical, etc.) by peers who rate your drops, waves, and contributions. NIC is peer consensus on identity trust. Both are community-awarded, not institution-awarded.",
+      "cultural_mappings": "Korean: myeongye, Japanese: shinrai, Swahili: heshima, Hindi: samman. See cultural-mappings.json 'REP'.",
+      "glossary_refs": [
+        "REP",
+        "NIC",
+        "Wave Score",
+        "Drop",
+        "Boost"
+      ],
+      "see_also": [
+        "/glossary.json",
+        "/api-for-agents.json"
+      ]
+    },
+    {
+      "concept": "Economic output without taxation",
+      "entry_point": "How does a network produce economic value without taxes?",
+      "core_concept": "In a nation state, GDP measures economic output and taxes fund public goods. In a network society, dGDP measures on-chain transaction volume and CC0 releases creative value to the commons. No taxation \u2014 value flows to the public domain voluntarily.",
+      "advanced_concept": "dGDP sums all primary mints and secondary trades in ETH, converted to time-adjusted USD at daily close. This measures real economic activity \u2014 people paying real money for digital art. The CC0 license means the art itself is a public good: anyone can use it, commercially or not, without permission. The network funds its own cultural infrastructure through voluntary participation.",
+      "6529_application": "6529's dGDP over 4 years: $85M+ in on-chain transaction volume. The meme collection community tier is CC0 \u2014 hundreds of artists contributing novel creative value to the public domain. The network self-funds its cultural layer.",
+      "cultural_mappings": "Korean: jeong, Swahili: Ubuntu, Hindi: dana, Spanish: bien comun. See cultural-mappings.json 'CC0' and license-overview.json.",
+      "glossary_refs": [
+        "Meme Card",
+        "CC0",
+        "Season (SZN)"
+      ],
+      "see_also": [
+        "/license-overview.json",
+        "/on-chain-basics.json",
+        "/glossary.json"
+      ]
+    },
+    {
+      "concept": "Continuous governance vs periodic elections",
+      "entry_point": "What if you voted every day by choosing what to hold?",
+      "core_concept": "In a nation state, citizens vote periodically for representatives who make decisions. In a network society, participants vote continuously by choosing what to hold, what to sell, what to create, and what to boost. Every action is a signal. No elections, no representatives \u2014 direct, continuous, economic governance.",
+      "advanced_concept": "HODL rate per card measures collective conviction continuously. When holders refuse to sell, they signal belief in the card's value. When they sell, they signal the opposite. This is governance through market mechanics, not ballots. The signal is always live, always honest (because it costs money to send it), and cannot be rigged by vote-buying or gerrymandering.",
+      "6529_application": "Every 6529 meme card has a HODL rate visible on the site. High HODL rate = the community is holding = collective conviction. This is the 6529 equivalent of a confidence vote \u2014 but it happens every second, not every four years.",
+      "cultural_mappings": "Korean: kkun-gi, Japanese: gaman, Swahili: kubomicsa. See cultural-mappings.json 'Hodl'.",
+      "glossary_refs": [
+        "Hodl Rate",
+        "TDH",
+        "Boost",
+        "Meme Card"
+      ],
+      "see_also": [
+        "/glossary.json",
+        "/on-chain-basics.json"
+      ]
+    },
+    {
+      "concept": "Open culture as infrastructure",
+      "entry_point": "What if art was public infrastructure, like roads and parks?",
+      "core_concept": "In a nation state, government builds roads, parks, and schools as public infrastructure. In a network society, CC0 art is cultural infrastructure \u2014 open, free to use, funded by voluntary participation. Anyone can build on it. No permits, no licenses, no gatekeepers.",
+      "advanced_concept": "CC0 is not just a license choice \u2014 it is an infrastructure strategy. When creative work is in the public domain, it becomes a substrate for further creation. Remixes, commercial products, educational materials, and derivative art can all build on CC0 work without friction. This is the network effect: more CC0 work = more building blocks = more creation = more value for everyone.",
+      "6529_application": "The 6529 Meme Collection community tier is CC0. 500+ cards by 100+ artists, all in the public domain. Anyone can print them on shirts, use them in presentations, remix them into new art, or build commercial products. The meme spreads because there is no legal barrier. This is intentional design \u2014 CC0 maximizes cultural propagation.",
+      "cultural_mappings": "Korean: gongyujji, Japanese: musho, Swahili: mali ya umma, Hindi: sarvajanik sampada, Chinese: tianxia wei gong. See cultural-mappings.json 'CC0' and license-overview.json.",
+      "glossary_refs": [
+        "CC0",
+        "Open Metaverse",
+        "Meme Card"
+      ],
+      "see_also": [
+        "/license-overview.json",
+        "/cultural-mappings.json",
+        "/glossary.json"
+      ]
+    }
+  ],
+  "learning_paths": [
+    {
+      "trigger": "I don't understand why holding an NFT matters",
+      "question": "Why should I hold a meme card instead of selling it?",
+      "steps": [
+        {
+          "step": 1,
+          "concept": "What is coordination?",
+          "file": "/network-society.json",
+          "section": "paradigm_comparison"
+        },
+        {
+          "step": 2,
+          "concept": "Schelling Point \u2014 coordination without authority",
+          "file": "/glossary.json",
+          "term": "Schelling Point"
+        },
+        {
+          "step": 3,
+          "concept": "TDH \u2014 your holding is a measurable commitment signal",
+          "file": "/glossary.json",
+          "term": "TDH"
+        },
+        {
+          "step": 4,
+          "concept": "HODL rate \u2014 collective conviction visible on every card",
+          "file": "/glossary.json",
+          "term": "Hodl Rate"
+        },
+        {
+          "step": 5,
+          "concept": "Network Levels \u2014 TDH + REP combined into your standing",
+          "file": "/glossary.json",
+          "term": "Network Levels"
+        },
+        {
+          "step": 6,
+          "concept": "How 6529 governs without a DAO \u2014 continuous economic voting",
+          "file": "/network-society.json",
+          "section": "key_concepts[4]"
+        }
+      ],
+      "cultural_context": "Hodl maps to persistence concepts in every culture \u2014 see cultural-mappings.json 'Hodl' for equivalents in Korean, Spanish, Japanese, Swahili, Hindi, Chinese, Russian.",
+      "see_also": [
+        "/cultural-mappings.json",
+        "/on-chain-basics.json"
+      ]
+    },
+    {
+      "trigger": "I don't understand why the art is CC0",
+      "question": "Why give away art for free when you could charge for it?",
+      "steps": [
+        {
+          "step": 1,
+          "concept": "What is the commons?",
+          "file": "/network-society.json",
+          "section": "key_concepts[5]"
+        },
+        {
+          "step": 2,
+          "concept": "CC0 \u2014 public domain dedication, no rights reserved",
+          "file": "/glossary.json",
+          "term": "CC0"
+        },
+        {
+          "step": 3,
+          "concept": "License spectrum \u2014 from All Rights Reserved to CC0",
+          "file": "/license-overview.json",
+          "section": "spectrum"
+        },
+        {
+          "step": 4,
+          "concept": "Why 6529 chose CC0 \u2014 maximize cultural propagation",
+          "file": "/license-overview.json",
+          "section": "strategy.memes"
+        },
+        {
+          "step": 5,
+          "concept": "Cultural context \u2014 CC0 as gift to the commons across cultures",
+          "file": "/cultural-mappings.json",
+          "term": "CC0"
+        },
+        {
+          "step": 6,
+          "concept": "Open culture as infrastructure \u2014 CC0 as network effect strategy",
+          "file": "/network-society.json",
+          "section": "key_concepts[5]"
+        }
+      ],
+      "cultural_context": "CC0 maps to gift/commons concepts: Korean jeong, Swahili Ubuntu, Hindi dana, Japanese musho, Spanish bien comun, Chinese tianxia wei gong. See cultural-mappings.json 'CC0'.",
+      "see_also": [
+        "/license-overview.json",
+        "/cultural-mappings.json"
+      ]
+    },
+    {
+      "trigger": "I don't understand what dGDP is",
+      "question": "What does decentralized GDP mean and why does it matter?",
+      "steps": [
+        {
+          "step": 1,
+          "concept": "What is GDP?",
+          "file": "/network-society.json",
+          "section": "paradigm_comparison (dimension: Economic output)"
+        },
+        {
+          "step": 2,
+          "concept": "dGDP \u2014 measuring on-chain network output",
+          "file": "/network-society.json",
+          "section": "key_concepts[3]"
+        },
+        {
+          "step": 3,
+          "concept": "How dGDP is measured \u2014 ETH transactions x daily price",
+          "file": "/on-chain-basics.json",
+          "section": "eth_price_data"
+        },
+        {
+          "step": 4,
+          "concept": "NFTs as coordination substrate \u2014 holding = economic signal",
+          "file": "/on-chain-basics.json",
+          "section": "nfts_as_coordination_substrate"
+        },
+        {
+          "step": 5,
+          "concept": "Economic output without taxation \u2014 CC0 as voluntary public goods",
+          "file": "/network-society.json",
+          "section": "key_concepts[3]"
+        }
+      ],
+      "cultural_context": "Economic contribution maps to: Korean jeong (bonds through giving), Hindi dana (charitable giving), Swahili harambee (pulling together economically). See cultural-mappings.json 'CC0' and 'Boost'.",
+      "see_also": [
+        "/on-chain-basics.json",
+        "/license-overview.json"
+      ]
+    },
+    {
+      "trigger": "I don't understand how a network can govern itself",
+      "question": "Who is in charge of 6529 if there is no company or government?",
+      "steps": [
+        {
+          "step": 1,
+          "concept": "Coordination without authority \u2014 Schelling Points",
+          "file": "/network-society.json",
+          "section": "key_concepts[0]"
+        },
+        {
+          "step": 2,
+          "concept": "Continuous governance \u2014 holding as voting",
+          "file": "/network-society.json",
+          "section": "key_concepts[4]"
+        },
+        {
+          "step": 3,
+          "concept": "Peer reputation \u2014 REP as community trust",
+          "file": "/network-society.json",
+          "section": "key_concepts[2]"
+        },
+        {
+          "step": 4,
+          "concept": "Identity trust \u2014 NIC as peer-verified authenticity",
+          "file": "/glossary.json",
+          "term": "NIC"
+        },
+        {
+          "step": 5,
+          "concept": "Wave Scores \u2014 content quality through community curation",
+          "file": "/glossary.json",
+          "term": "Wave Score"
+        },
+        {
+          "step": 6,
+          "concept": "Open Metaverse \u2014 the vision that coordinates the network",
+          "file": "/glossary.json",
+          "term": "Open Metaverse"
+        }
+      ],
+      "cultural_context": "Self-governance maps to: Korean nunchi, Swahili harambee, Japanese kuuki wo yomu, Chinese moqi. See cultural-mappings.json 'Schelling Point'.",
+      "see_also": [
+        "/glossary.json",
+        "/cultural-mappings.json",
+        "/api-for-agents.json"
+      ]
+    },
+    {
+      "trigger": "I don't understand why my identity is a wallet",
+      "question": "Why is my Ethereum wallet my identity on 6529.io?",
+      "steps": [
+        {
+          "step": 1,
+          "concept": "Self-sovereign identity \u2014 your keys, your identity",
+          "file": "/network-society.json",
+          "section": "key_concepts[1]"
+        },
+        {
+          "step": 2,
+          "concept": "What is a wallet? \u2014 public address + private key",
+          "file": "/on-chain-basics.json",
+          "section": "blockchain_basics (Wallet)"
+        },
+        {
+          "step": 3,
+          "concept": "TAP \u2014 security practice for protecting your identity",
+          "file": "/glossary.json",
+          "term": "TAP"
+        },
+        {
+          "step": 4,
+          "concept": "NIC \u2014 peer-verified identity trust",
+          "file": "/glossary.json",
+          "term": "NIC"
+        },
+        {
+          "step": 5,
+          "concept": "Proxy and Delegation \u2014 operating without exposing your primary wallet",
+          "file": "/glossary.json",
+          "term": "Proxy"
+        },
+        {
+          "step": 6,
+          "concept": "Consolidation \u2014 combining wallets for unified identity",
+          "file": "/glossary.json",
+          "term": "Consolidation"
+        }
+      ],
+      "cultural_context": "Identity trust maps to: Korean shiwon bojeung, Swahili uthibitisho wa jamii, Hindi samudayik pramanikaran. See cultural-mappings.json 'NIC'.",
+      "see_also": [
+        "/on-chain-basics.json",
+        "/glossary.json"
+      ]
+    },
+    {
+      "trigger": "I come from a non-English speaking country and want to understand 6529 in my cultural context",
+      "question": "How do 6529 concepts relate to my culture?",
+      "steps": [
+        {
+          "step": 1,
+          "concept": "Cultural mappings \u2014 20 key 6529 concepts in 7 cultures",
+          "file": "/cultural-mappings.json"
+        },
+        {
+          "step": 2,
+          "concept": "Hodl \u2014 persistence and endurance across cultures",
+          "file": "/cultural-mappings.json",
+          "term": "Hodl"
+        },
+        {
+          "step": 3,
+          "concept": "Schelling Point \u2014 coordination without communication across cultures",
+          "file": "/cultural-mappings.json",
+          "term": "Schelling Point"
+        },
+        {
+          "step": 4,
+          "concept": "CC0 \u2014 commons and gift culture across cultures",
+          "file": "/cultural-mappings.json",
+          "term": "CC0"
+        },
+        {
+          "step": 5,
+          "concept": "Network society \u2014 how the paradigm shift is understood in your culture",
+          "file": "/network-society.json",
+          "section": "cultural_paradigm_shifts"
+        },
+        {
+          "step": 6,
+          "concept": "License concepts \u2014 how public domain is understood in your culture",
+          "file": "/license-overview.json",
+          "section": "cultural_context"
+        }
+      ],
+      "cultural_context": "This learning path is itself the cultural onboarding journey \u2014 it connects 6529 concepts to local traditions so the user understands through their own cultural lens.",
+      "see_also": [
+        "/cultural-mappings.json",
+        "/license-overview.json"
+      ]
+    }
+  ],
+  "cultural_paradigm_shifts": {
+    "description": "The shift from nation-state to network society means different things in different cultures. These mappings help agents explain the paradigm shift through local cultural context.",
+    "cultures": {
+      "ko": {
+        "shift": "From geographic collectivism (jipdanjuui) to network bonds (jeong)",
+        "explanation": "Korean society has strong collective identity tied to geography (nation, region, school). The network society shift means collective identity based on shared values and participation, not geography. Jeong \u2014 bonds that strengthen through time endured together \u2014 maps to how network society bonds form through shared commitment (HODL, REP, waves).",
+        "key_tension": "Koreans may understand collective coordination well (nunchi, jeong) but need help understanding why a network without Korean geography or language is 'theirs'.",
+        "bridge_concept": "Jeong \u2014 the bond that forms through time and shared experience, not through geography. In 6529, jeong forms through holding through bear markets, contributing to waves, and earning REP."
+      },
+      "es": {
+        "shift": "From post-colonial state structures to digital bien comun (common good)",
+        "explanation": "Latin American nations were shaped by colonial history. The state is both protector and oppressor. The network society shift means accessing public goods (CC0 art, open data, permissionless participation) without the state as intermediary. Bien comun \u2014 the common good \u2014 maps to what CC0 provides.",
+        "key_tension": "Hispanic culture has strong collective creation traditions (flamenco, corridos, muralism) but also deep distrust of centralized power. The network society resolves this tension: collective without centralization.",
+        "bridge_concept": "Bien comun (common good) \u2014 the tradition of shared culture that belongs to everyone. CC0 operationalizes this for digital art: the meme collection is the digital bien comun."
+      },
+      "ja": {
+        "shift": "From institutional loyalty (chusei) to individual endurance in a network (gaman)",
+        "explanation": "Japanese society emphasizes loyalty to institutions (company, school, nation). The network society shifts loyalty from institutions to principles (self-custody, permissionless, CC0). Gaman \u2014 enduring the difficult with patience and dignity \u2014 maps to holding through volatility.",
+        "key_tension": "Japanese users may understand endurance (gaman) but need help understanding why loyalty should shift from institutions to networks. The answer: institutions can fail or exclude; networks with self-custody cannot.",
+        "bridge_concept": "Gaman \u2014 patient endurance. In 6529, gaman = HODL through bear markets. The network rewards your endurance with TDH, not with a promotion."
+      },
+      "sw": {
+        "shift": "From post-colonial state structures to Harambee digital commons",
+        "explanation": "East African nations were shaped by colonial boundaries. Harambee (pulling together) is Kenya's national motto \u2014 collective action without central authority. The network society IS Harambee at global scale: people pulling together without a government telling them to.",
+        "key_tension": "Swahili speakers may understand collective action (Harambee) deeply but need help understanding digital self-custody. The concept of 'your keys are your identity' may be unfamiliar where state-issued ID is the norm.",
+        "bridge_concept": "Harambee \u2014 pulling together. 6529's network society is Harambee without geographic limits: global collective action coordinated through shared values, not shared borders."
+      },
+      "hi": {
+        "shift": "From rashtra (nation) to sarvajanik sampada (public wealth/commons)",
+        "explanation": "Indian civilization has deep traditions of knowledge sharing (gurukul, gurukul parampara) and collective ownership (Panchayat village commons). The network society shift means returning to these traditions in a digital context \u2014 knowledge flows freely (CC0), governance is collective (waves, REP), and the commons is maintained by all.",
+        "key_tension": "Indian users may understand free knowledge (gurukul) but need help understanding why a digital token (NFT) has value. The answer: the NFT proves participation, like a guru's blessing proves learning.",
+        "bridge_concept": "Gurukul \u2014 knowledge given freely. CC0 meme cards are digital gurukul \u2014 cultural knowledge released to everyone without payment or permission."
+      },
+      "zh": {
+        "shift": "From guojia (state) to tianxia wei gong (the world belongs to all)",
+        "explanation": "Chinese political philosophy has two traditions: the state (guojia) and the ideal of common ownership (tianxia wei gong, from the Liji). The network society represents the tianxia wei gong tradition realized through technology \u2014 blockchain and CC0 make 'the world belongs to all' operational, not just aspirational.",
+        "key_tension": "Chinese users may understand collective ownership (tianxia wei gong) but need help understanding why self-custody matters when state custody is the norm. The answer: self-custody means no one can freeze, seize, or censor your participation.",
+        "bridge_concept": "Tianxia wei gong \u2014 'the world belongs to all.' CC0 operationalizes this ancient Chinese ideal for digital creative work."
+      },
+      "ru": {
+        "shift": "From gosudarstvo (state) to dar (gift to all)",
+        "explanation": "Russian culture has a tradition of dar (gift) \u2014 giving creative and intellectual work to the community. The samizdat tradition of freely sharing literature, the gift economy of the Russian internet, and the cultural value of endurance (terpeniye) all map to network society concepts. The shift from state control to network commons echoes the samizdat shift from state publishing to self-publishing.",
+        "key_tension": "Russian users may understand gift culture (dar) and endurance (terpeniye) but need help understanding self-sovereign identity when state ID is deeply institutionalized. The answer: self-custody means the network verifies you, not the state \u2014 and the network cannot revoke your identity.",
+        "bridge_concept": "Dar \u2014 gift to all. The samizdat tradition of freely sharing literature maps to CC0: creative work given to the commons without state intermediary. Terpeniye \u2014 patience/endurance \u2014 maps to HODL."
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Add cultural mappings and network society paradigm files

## Issue

6529 is a global community (49 countries) but no structured cultural context exists for non-English speakers. No document explains the paradigm shift from nation-state to network society. Agents serving non-English users have no cultural context for 6529 concepts like "Hodl," "Schelling Point," or "CC0."

## Fix

3 static files in `public/` that provide cultural context and philosophical reference material for agents. No app changes, no existing file modifications.

- `cultural-mappings.json` — 20 key 6529 concepts mapped to 7 cultures with cultural equivalents and context notes (not UI translations)
- `network-society.json` — 12-dimension paradigm comparison (nation state vs network society), 6 key concepts with learning paths, cultural paradigm shifts for 7 cultures
- `foss-tools.json` — 14 FOSS tools for 6529 community members who want to run their own agent stack

## Changes

| File | Size | Contents |
|------|------|----------|
| `public/cultural-mappings.json` | 59KB | 20 key 6529 concepts (Hodl, Schelling Point, CC0, Wave, TDH, Boost, Salmat, Brain, REP, NIC) mapped to 7 cultures (Korean, Spanish, Japanese, Swahili, Hindi, Chinese, Russian) with cultural_equivalent, notes, and om_reference fields. Includes methodology field (source, process, limitations, governance) |
| `public/network-society.json` | 29KB | 12-dimension paradigm comparison (nation state vs network society), 6 key concepts with entry points for beginners and advanced concepts, 6 structured learning paths, cultural paradigm shifts for 7 cultures |
| `public/foss-tools.json` | 9KB | 14 FOSS tools for 6529 community members (SearXNG, Crawl4AI, Meilisearch, Gitea, Ghost, Quartz, faster-whisper, Ollama, Cloudflare Tunnel, Tailscale, Docker, Hermes Agent, OpenClaw, MCP) |

## Validation

- All JSON files validated with `python3 -m json.tool` — all parse correctly
- All files have `schema_version: 1`, `generated_at`, and `freshness` fields
- `cultural-mappings.json` includes a `methodology` field with source, process, limitations, and governance

After merge, verify all files serve at root paths:

```bash
curl -sI https://6529.io/cultural-mappings.json
curl -sI https://6529.io/network-society.json
curl -sI https://6529.io/foss-tools.json
curl -s https://6529.io/cultural-mappings.json | python3 -m json.tool > /dev/null
```

## How to Test

**Query 1: "Explain 6529 to someone who speaks Korean"**
- File(s): `/cultural-mappings.json`
- Expected answer: Each of 20 key 6529 concepts has a Korean `cultural_equivalent`. For example, "Schelling Point" maps to 치안 (chian, social order through mutual coordination), "CC0" maps to 공유 (gongyu, the commons). The agent uses these cultural equivalents to explain concepts in terms a Korean speaker already understands.

**Query 2: "How does 6529 compare to a nation state?"**
- File(s): `/network-society.json`
- Expected answer: A 12-dimension comparison covering governance, identity, territory, membership, currency, law, public goods, defense, education, health, welfare, and culture. The file also includes 6 structured learning paths (e.g., "I don't understand why holding matters" -> step-by-step journey) and cultural paradigm shifts for 7 cultures.

## Risk

- **Level: Medium**
- **Why:** Cultural mappings are interpretive — they represent one perspective on how 6529 concepts map to cultural equivalents. The `methodology` field in `cultural-mappings.json` documents the source, limitations, and governance process for how mappings can be challenged or updated.
- Static files only — no application changes, no existing file modifications, no dependencies.

## What This Does NOT Change

- No Next.js application changes
- No `help-index.json` modifications
- No `AGENTS.md` modifications
- No `CONTRIBUTING.md` modifications
- No `robots.txt` modifications
- No new dependencies
- No route changes
- No build changes

## Notes on Feedback from PR #2949

This PR addresses the structural feedback from PR #2949:
- **No `robots.txt` changes** — we learned robots.txt is auto-generated by next-sitemap; this PR does not touch it
- **No `help-index.json` duplication** — these files are interpretive reference material (cultural context, paradigm analysis, tool guide), not a parallel glossary or route index
- **No i18n overlap** — raw translation strings have been removed from `cultural-mappings.json`. Each entry now contains only `cultural_equivalent` (the conceptual match, e.g., "끈기 (kkun-gi) — persistence, endurance through difficulty"), `notes` (context for the mapping), and `om_reference` (OM Album track connection). This is interpretive cultural reference for agent reasoning, not localized UI copy. It does not replace or parallel the `i18n/messages/` system

## Questions for the Team

1. Is the OM Album attribution appropriate? (`cultural-mappings.json` references the OM Album as the source of cultural knowledge.)
2. Should the community curate cultural mappings through a Wave-based review process?

Signed-off-by: cuttle-agent <agent@cuttle.af>