### PR TITLE
Remove dead next/head usages from App Router code

### DIFF
--- a/app/sentry-example-page/page.tsx
+++ b/app/sentry-example-page/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Head from "next/head";
 import * as Sentry from "@sentry/nextjs";
 import { useState, useEffect } from "react";
 
@@ -25,11 +24,6 @@ export default function Page() {
 
   return (
     <div>
-      <Head>
-        <title>sentry-example-page</title>
-        <meta name="description" content="Test Sentry for your Next.js app!" />
-      </Head>
-
       <main>
         <div className="flex-spacer" />
         <svg height="40" width="40" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/components/messages/layout/MessagesLayout.tsx
+++ b/components/messages/layout/MessagesLayout.tsx
@@ -2,7 +2,6 @@
 
 import type { ReactNode } from "react";
 import { useMemo } from "react";
-import Head from "next/head";
 import UserSetUpProfileCta from "../../user/utils/set-up-profile/UserSetUpProfileCta";
 import MessagesDesktop from "../MessagesDesktop";
 import MessagesMobile from "../MessagesMobile";
@@ -78,14 +77,9 @@ function MessagesLayoutContent({ children }: { readonly children: ReactNode }) {
   }, [contentState, connectPrompt, containerClassName, children, isApp]);
 
   return (
-    <>
-      <Head>
-        <style>{`body { overflow: hidden !important; }`}</style>
-      </Head>
-      <div className="tailwind-scope tw-flex tw-flex-col tw-bg-black">
-        {content}
-      </div>
-    </>
+    <div className="tailwind-scope tw-flex tw-flex-col tw-bg-black">
+      {content}
+    </div>
   );
 }
 


### PR DESCRIPTION
## Issue
- Two files still import `next/head`, a Pages Router API that renders nothing in the App Router (shipped Next docs: `02-pages/04-api-reference/01-components/head.md`; the app-router migration guide replaces it with the metadata API). They are the last pages-router-era idioms in the tree — repo-health Thread D, Phase 2 (plan: `ops/workstreams/repo-health-2026-07/layout-unification-plan.md`).

## Fix
- Delete both dead `<Head>` blocks and their imports. Zero `next/head` imports remain repo-wide.

## Changes
- `components/messages/layout/MessagesLayout.tsx`: removed the no-op `<Head><style>body { overflow: hidden !important; }</style></Head>` and the now-redundant fragment wrapper. If a body scroll lock is ever actually wanted on `/messages`, the repo's working pattern is the `document.body.style.overflow` effect (see `WaveChatSubmitDropModal`); intentionally not added here to keep the change behavior-preserving.
- `app/sentry-example-page/page.tsx`: removed the no-op `<Head><title>/<meta description></Head>` block from the Sentry wizard scaffold page.

## Validation
- Live-browser evidence (Playwright against the local dev server), before the change: on `/messages` with the layout mounted, no `overflow: hidden !important` style exists anywhere in the DOM and `getComputedStyle(document.body).overflow === "auto"`; on `/sentry-example-page`, `document.title` stays `6529.io` and the description meta is absent. After the change: identical values for every observed signal — the removed code provably never took effect.
- `6529 run lint:changed` exit 0; `6529 run typecheck:changed` passed (2 files); targeted jest `__tests__/components/MessagesLayout.test.tsx` 2/2 passed; `6529 run react-doctor:diff` over the diff: 100/100, no issues.
- Note: `6529 run check:changed`'s format step fails in this environment for any diff (its `bash -lc` login shell drops `node_modules/.bin` from PATH — `xargs: prettier: No such file or directory`); lint/typecheck lanes above are the CI-equivalent checks.

## Risk
- Level: Low
- Why: removes code that demonstrably renders nothing; two files; behavior parity captured before/after in a real browser.
- Rollback: revert the merge commit.

## Review Notes
- This closes the pages-router ledger from the Phase 0 inventory: no `pages/` dir (removed in #1378), 0 `next/router`/GSSP/GSP/GIP/`NextPage`/`AppProps` usages, ratchet `pages_router_files` = 0, and now 0 `next/head` imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)