### PR TITLE
Burn down any_casts 358 -> 65: type the NextGen contract layer, platform utils, and component scatter

### DIFF
--- a/abis/abis.ts
+++ b/abis/abis.ts
@@ -719,7 +719,7 @@ export const DELEGATION_ABI = [
   },
 ];
 
-export const NEXTGEN_CORE_ABI = [
+export const NEXTGEN_CORE_ABI: Abi = [
   {
     inputs: [
       {
@@ -2278,7 +2278,7 @@ export const NEXTGEN_CORE_ABI = [
   },
 ];
 
-export const NEXTGEN_MINTER_ABI = [
+export const NEXTGEN_MINTER_ABI: Abi = [
   {
     inputs: [
       { internalType: "address", name: "_gencore", type: "address" },
@@ -2732,7 +2732,7 @@ export const NEXTGEN_MINTER_ABI = [
   },
 ];
 
-export const NEXTGEN_ADMIN_ABI = [
+export const NEXTGEN_ADMIN_ABI: Abi = [
   { inputs: [], stateMutability: "nonpayable", type: "constructor" },
   {
     anonymous: false,

--- a/app/access/page.client.tsx
+++ b/app/access/page.client.tsx
@@ -21,9 +21,11 @@ export default function AccessPage() {
       const apiAuth = getStagingAuth();
       fetch(`${publicEnv.API_ENDPOINT}/api/`, {
         headers: apiAuth ? { "x-6529-auth": apiAuth } : {},
-      }).then((r: any) => {
-        r.json().then((response: any) => {
-          setImage(response.image);
+      }).then((r: Response) => {
+        r.json().then((response: { image?: string | undefined }) => {
+          if (response.image) {
+            setImage(response.image);
+          }
         });
         if (r.status !== 401) {
           router.push("/");
@@ -38,7 +40,7 @@ export default function AccessPage() {
     const pass = target.value;
     fetch(`${publicEnv.API_ENDPOINT}/api/`, {
       headers: { "x-6529-auth": pass },
-    }).then((r: any) => {
+    }).then((r: Response) => {
       if (r.status === 401) {
         alert("Access Denied!");
       } else {

--- a/app/api/open-graph/compound/service.ts
+++ b/app/api/open-graph/compound/service.ts
@@ -67,7 +67,9 @@ type CompoundTarget =
 const TX_HASH_LENGTH = 66;
 
 function isPossibleTxHash(value: string): value is Hash {
-  return value.startsWith("0x") && value.length === TX_HASH_LENGTH && isHex(value);
+  return (
+    value.startsWith("0x") && value.length === TX_HASH_LENGTH && isHex(value)
+  );
 }
 
 function normalizeAddress(value: string): Address | null {
@@ -224,21 +226,25 @@ async function fetchV2MarketState(
       { address: cToken, abi: cTokenAbi, functionName: "totalReserves" },
       { address: cToken, abi: cTokenAbi, functionName: "totalSupply" },
       { address: cToken, abi: cTokenAbi, functionName: "cash" },
-      { address: cToken, abi: cTokenAbi, functionName: "reserveFactorMantissa" },
+      {
+        address: cToken,
+        abi: cTokenAbi,
+        functionName: "reserveFactorMantissa",
+      },
       { address: cToken, abi: cTokenAbi, functionName: "supplyRatePerBlock" },
       { address: cToken, abi: cTokenAbi, functionName: "borrowRatePerBlock" },
     ],
   });
 
   const cTokenDecimalsRaw = marketResults[0] as number;
-  const exchangeRateStored = marketResults[1] ;
-  const totalBorrows = marketResults[2] ;
-  const totalReserves = marketResults[3] ;
-  const totalSupply = marketResults[4] ;
-  const cash = marketResults[5] ;
-  const reserveFactorMantissa = marketResults[6] ;
-  const supplyRatePerBlock = marketResults[7] ;
-  const borrowRatePerBlock = marketResults[8] ;
+  const exchangeRateStored = marketResults[1];
+  const totalBorrows = marketResults[2];
+  const totalReserves = marketResults[3];
+  const totalSupply = marketResults[4];
+  const cash = marketResults[5];
+  const reserveFactorMantissa = marketResults[6];
+  const supplyRatePerBlock = marketResults[7];
+  const borrowRatePerBlock = marketResults[8];
 
   const [_, collateralFactorMantissa] = await publicClient.readContract({
     address: compoundRegistry.comptroller as Address,
@@ -268,8 +274,14 @@ async function fetchV2MarketState(
 
   const cTokenDecimals = Number(cTokenDecimalsRaw ?? 0);
   const underlyingDecimals = market.underlying.decimals;
-  const exchangeRateScale = getExchangeRateScale(underlyingDecimals, cTokenDecimals);
-  const tvlUnderlying = (cash ?? BIGINT_ZERO) + (totalBorrows ?? BIGINT_ZERO) - (totalReserves ?? BIGINT_ZERO);
+  const exchangeRateScale = getExchangeRateScale(
+    underlyingDecimals,
+    cTokenDecimals
+  );
+  const tvlUnderlying =
+    (cash ?? BIGINT_ZERO) +
+    (totalBorrows ?? BIGINT_ZERO) -
+    (totalReserves ?? BIGINT_ZERO);
 
   const supplyApy = calculateApyFromRatePerBlock(supplyRatePerBlock);
   const borrowApy = calculateApyFromRatePerBlock(borrowRatePerBlock);
@@ -293,8 +305,7 @@ async function fetchV2MarketState(
   let tvlUsd: string | undefined;
 
   if (underlyingPrice && underlyingPrice > BIGINT_ZERO) {
-    const tvlUsdScaled =
-      (tvlUnderlying * underlyingPrice) / pow10BigInt(18);
+    const tvlUsdScaled = (tvlUnderlying * underlyingPrice) / pow10BigInt(18);
     tvlUsd = formatUnitsWithPrecision(tvlUsdScaled, 18, 2);
   }
 
@@ -309,7 +320,7 @@ async function fetchV2MarketState(
     totalSupply: totalSupply ?? BIGINT_ZERO,
     cash: cash ?? BIGINT_ZERO,
     reserveFactorMantissa: reserveFactorMantissa ?? BIGINT_ZERO,
-    collateralFactorMantissa: collateralFactorMantissa ,
+    collateralFactorMantissa: collateralFactorMantissa,
     underlyingPrice: underlyingPrice ?? null,
     metrics: {
       supplyApy,
@@ -341,7 +352,7 @@ async function fetchV3MarketState(
 
   const decimalsRaw = marketCoreResults[0] as number;
   const totalsBasic = marketCoreResults[1] as unknown;
-  const utilizationRaw = marketCoreResults[2] ;
+  const utilizationRaw = marketCoreResults[2];
   const numAssetsRaw = marketCoreResults[3] as number;
   const priceFeedAddress = marketCoreResults[4] as Address;
 
@@ -366,22 +377,23 @@ async function fetchV3MarketState(
   });
 
   const decimals = Number(decimalsRaw ?? 0);
-  const {
-    totalSupplyBase,
-    totalBorrowBase,
-  } = totalsBasic as {
+  const { totalSupplyBase, totalBorrowBase } = totalsBasic as {
     totalSupplyBase: bigint;
     totalBorrowBase: bigint;
   };
 
   const numAssets = Number(numAssetsRaw ?? 0);
   const collaterals: V3CollateralInfo[] = [];
-  const collateralCalls = Array.from({ length: numAssets }, (_, index) => ({
-    address: comet,
-    abi: cometAbi,
-    functionName: "getAssetInfo",
-    args: [BigInt(index)],
-  } as const));
+  const collateralCalls = Array.from(
+    { length: numAssets },
+    (_, index) =>
+      ({
+        address: comet,
+        abi: cometAbi,
+        functionName: "getAssetInfo",
+        args: [BigInt(index)],
+      }) as const
+  );
 
   if (collateralCalls.length > 0) {
     const collateralResults = await publicClient.multicall({
@@ -432,7 +444,7 @@ async function fetchV3MarketState(
               ],
             });
 
-            const priceValue = priceResults[0] ;
+            const priceValue = priceResults[0];
             const priceDecimals = Number(priceResults[1] ?? 8);
             if (priceValue && priceValue > BIGINT_ZERO) {
               usdPrice = formatUnitsWithPrecision(priceValue, priceDecimals, 6);
@@ -485,7 +497,7 @@ async function fetchV3MarketState(
           },
         ],
       });
-      basePrice = basePriceResults[0] ;
+      basePrice = basePriceResults[0];
       basePriceDecimals = Number(basePriceResults[1] ?? 8);
     } catch {
       basePrice = null;
@@ -493,8 +505,8 @@ async function fetchV3MarketState(
     }
   }
 
-  const supplyApy = calculateApyFromRatePerSecond(supplyRate );
-  const borrowApy = calculateApyFromRatePerSecond(borrowRate );
+  const supplyApy = calculateApyFromRatePerSecond(supplyRate);
+  const borrowApy = calculateApyFromRatePerSecond(borrowRate);
   const utilization = formatMantissa(utilizationValue);
   const totalSupplyBaseDisplay = formatUnitsWithPrecision(
     totalSupplyBase,
@@ -517,9 +529,9 @@ async function fetchV3MarketState(
   return {
     config: market,
     decimals,
-    supplyRate: supplyRate ,
-    borrowRate: borrowRate ,
-    utilization: utilizationRaw ,
+    supplyRate: supplyRate,
+    borrowRate: borrowRate,
+    utilization: utilizationRaw,
     totalSupplyBase,
     totalBorrowBase,
     basePrice,
@@ -589,7 +601,9 @@ function buildV3MarketResponse(state: V3MarketState): LinkPreviewResponse {
 
 async function fetchV2Account(address: Address): Promise<LinkPreviewResponse> {
   const markets = Array.from(v2MarketsByAddress.values());
-  const states = await Promise.all(markets.map((market) => fetchV2MarketState(market)));
+  const states = await Promise.all(
+    markets.map((market) => fetchV2MarketState(market))
+  );
 
   const positionsRaw = await Promise.all(
     states.map(async (state) => {
@@ -597,7 +611,12 @@ async function fetchV2Account(address: Address): Promise<LinkPreviewResponse> {
       const [balanceResult, borrowResult] = await publicClient.multicall({
         allowFailure: false,
         contracts: [
-          { address: cToken, abi: cTokenAbi, functionName: "balanceOf", args: [address] },
+          {
+            address: cToken,
+            abi: cTokenAbi,
+            functionName: "balanceOf",
+            args: [address],
+          },
           {
             address: cToken,
             abi: cTokenAbi,
@@ -607,16 +626,15 @@ async function fetchV2Account(address: Address): Promise<LinkPreviewResponse> {
         ],
       });
 
-      const balance = balanceResult ;
-      const borrowBalance = borrowResult ;
+      const balance = balanceResult;
+      const borrowBalance = borrowResult;
       const exchangeRateScale = getExchangeRateScale(
         state.config.underlying.decimals,
         state.cTokenDecimals
       );
 
       const supplyUnderlyingRaw =
-        (balance * state.exchangeRateStored) /
-        pow10BigInt(exchangeRateScale);
+        (balance * state.exchangeRateStored) / pow10BigInt(exchangeRateScale);
       const supplyDisplay = formatUnitsWithPrecision(
         supplyUnderlyingRaw,
         state.config.underlying.decimals,
@@ -642,7 +660,8 @@ async function fetchV2Account(address: Address): Promise<LinkPreviewResponse> {
         borrowApy: state.metrics.borrowApy,
         collateralFactor: state.metrics.collateralFactor,
         usdPrice: usdPrice ?? undefined,
-        hasPosition: supplyUnderlyingRaw > BIGINT_ZERO || borrowBalance > BIGINT_ZERO,
+        hasPosition:
+          supplyUnderlyingRaw > BIGINT_ZERO || borrowBalance > BIGINT_ZERO,
       };
     })
   );
@@ -658,10 +677,10 @@ async function fetchV2Account(address: Address): Promise<LinkPreviewResponse> {
     args: [address],
   });
 
-  const liquidityUsd = formatUnitsWithPrecision(liquidityRaw , 18, 2);
-  const shortfallUsd = formatUnitsWithPrecision(shortfallRaw , 18, 2);
-  const liquidityValue = liquidityRaw ;
-  const shortfallValue = shortfallRaw ;
+  const liquidityUsd = formatUnitsWithPrecision(liquidityRaw, 18, 2);
+  const shortfallUsd = formatUnitsWithPrecision(shortfallRaw, 18, 2);
+  const liquidityValue = liquidityRaw;
+  const shortfallValue = shortfallRaw;
 
   let healthLabel = "safe";
   if (shortfallValue > BIGINT_ZERO) {
@@ -708,12 +727,31 @@ async function fetchV2Account(address: Address): Promise<LinkPreviewResponse> {
   } as LinkPreviewResponse;
 }
 
+type V3CollateralEntry = {
+  readonly asset: string;
+  readonly amount: string;
+  readonly usdPrice?: string | undefined;
+  readonly collateralFactor: string;
+};
+
+type V3AccountPosition = {
+  readonly comet: Address;
+  readonly baseSymbol: string;
+  readonly supplyBase: string;
+  readonly borrowBase: string;
+  readonly collateral: V3CollateralEntry[];
+  readonly supplyApy: string;
+  readonly borrowApy: string;
+};
+
 async function fetchV3Account(address: Address): Promise<{
-  readonly v3Positions: any[];
+  readonly v3Positions: V3AccountPosition[];
   readonly v3Rewards?: string | undefined;
 }> {
   const markets = Array.from(v3MarketsByAddress.values());
-  const states = await Promise.all(markets.map((market) => fetchV3MarketState(market)));
+  const states = await Promise.all(
+    markets.map((market) => fetchV3MarketState(market))
+  );
 
   const v3Positions = await Promise.all(
     states.map(async (state) => {
@@ -721,12 +759,22 @@ async function fetchV3Account(address: Address): Promise<{
       const [balanceResult, borrowResult] = await publicClient.multicall({
         allowFailure: false,
         contracts: [
-          { address: comet, abi: cometAbi, functionName: "balanceOf", args: [address] },
-          { address: comet, abi: cometAbi, functionName: "borrowBalanceOf", args: [address] },
+          {
+            address: comet,
+            abi: cometAbi,
+            functionName: "balanceOf",
+            args: [address],
+          },
+          {
+            address: comet,
+            abi: cometAbi,
+            functionName: "borrowBalanceOf",
+            args: [address],
+          },
         ],
       });
 
-      const baseSupplyRaw = balanceResult ;
+      const baseSupplyRaw = balanceResult;
       const baseSupply = formatUnitsWithPrecision(
         baseSupplyRaw,
         state.config.base.decimals,
@@ -735,7 +783,7 @@ async function fetchV3Account(address: Address): Promise<{
       let baseBorrow = "0";
       let baseBorrowRaw = BIGINT_ZERO;
       try {
-        baseBorrowRaw = borrowResult ;
+        baseBorrowRaw = borrowResult;
         baseBorrow = formatUnitsWithPrecision(
           baseBorrowRaw,
           state.config.base.decimals,
@@ -780,7 +828,9 @@ async function fetchV3Account(address: Address): Promise<{
         }));
 
       const hasPosition =
-        baseSupplyRaw > BIGINT_ZERO || baseBorrowRaw > BIGINT_ZERO || collateralEntries.length > 0;
+        baseSupplyRaw > BIGINT_ZERO ||
+        baseBorrowRaw > BIGINT_ZERO ||
+        collateralEntries.length > 0;
 
       return {
         comet: getAddress(state.config.address),
@@ -802,28 +852,39 @@ async function fetchV3Account(address: Address): Promise<{
   };
 }
 
-async function fetchCompoundAccount(address: Address): Promise<LinkPreviewResponse> {
+type CompoundAccountResponse = LinkPreviewResponse & {
+  positions: { v2: unknown; v3: unknown };
+  rewards?: { [key: string]: unknown } | undefined;
+};
+
+async function fetchCompoundAccount(
+  address: Address
+): Promise<LinkPreviewResponse> {
   const [v2Response, v3Response] = await Promise.all([
     fetchV2Account(address),
     fetchV3Account(address),
   ]);
 
-  const combined = v2Response as any;
+  const combined = v2Response as CompoundAccountResponse;
   combined.positions.v3 = v3Response.v3Positions;
   if (!combined.rewards) {
     combined.rewards = {};
   }
-  combined.rewards.v3Claimable = v3Response.v3Rewards ?? "0";
+  combined.rewards["v3Claimable"] = v3Response.v3Rewards ?? "0";
   return combined;
 }
 
-function decodeV2Event(log: { address: Address; data: `0x${string}`; topics: readonly `0x${string}`[] }) {
+function decodeV2Event(log: {
+  address: Address;
+  data: `0x${string}`;
+  topics: readonly `0x${string}`[];
+}) {
   try {
-    const topics =
-      (log.topics.length === 0
+    const topics = (
+      log.topics.length === 0
         ? []
-        : ([...log.topics] as [`0x${string}`, ...`0x${string}`[]])) as
-      [] | [`0x${string}`, ...`0x${string}`[]];
+        : ([...log.topics] as [`0x${string}`, ...`0x${string}`[]])
+    ) as [] | [`0x${string}`, ...`0x${string}`[]];
     return decodeEventLog({
       abi: cTokenAbi,
       data: log.data,
@@ -834,13 +895,17 @@ function decodeV2Event(log: { address: Address; data: `0x${string}`; topics: rea
   }
 }
 
-function decodeV3Event(log: { address: Address; data: `0x${string}`; topics: readonly `0x${string}`[] }) {
+function decodeV3Event(log: {
+  address: Address;
+  data: `0x${string}`;
+  topics: readonly `0x${string}`[];
+}) {
   try {
-    const topics =
-      (log.topics.length === 0
+    const topics = (
+      log.topics.length === 0
         ? []
-        : ([...log.topics] as [`0x${string}`, ...`0x${string}`[]])) as
-      [] | [`0x${string}`, ...`0x${string}`[]];
+        : ([...log.topics] as [`0x${string}`, ...`0x${string}`[]])
+    ) as [] | [`0x${string}`, ...`0x${string}`[]];
     return decodeEventLog({
       abi: cometAbi,
       data: log.data,
@@ -853,9 +918,13 @@ function decodeV3Event(log: { address: Address; data: `0x${string}`; topics: rea
 
 async function decodeCompoundTx(hash: Hash): Promise<LinkPreviewResponse> {
   const transaction = await publicClient.getTransaction({ hash });
-  const { receipt, status, blockNumber } = await getTransactionReceiptDetails(hash);
+  const { receipt, status, blockNumber } =
+    await getTransactionReceiptDetails(hash);
   const participants = extractTransactionParticipants(transaction);
-  const summary = buildCompoundSummaryFromLogs(receipt?.logs ?? [], participants);
+  const summary = buildCompoundSummaryFromLogs(
+    receipt?.logs ?? [],
+    participants
+  );
 
   return {
     type: "compound.tx",
@@ -870,7 +939,9 @@ async function decodeCompoundTx(hash: Hash): Promise<LinkPreviewResponse> {
   } as LinkPreviewResponse;
 }
 
-type PublicClientReceipt = Awaited<ReturnType<typeof publicClient.getTransactionReceipt>>;
+type PublicClientReceipt = Awaited<
+  ReturnType<typeof publicClient.getTransactionReceipt>
+>;
 
 type ReceiptDetails = {
   readonly receipt: PublicClientReceipt | null;
@@ -904,7 +975,9 @@ type TxParticipants = {
   readonly to?: Address | undefined;
 };
 
-async function getTransactionReceiptDetails(hash: Hash): Promise<ReceiptDetails> {
+async function getTransactionReceiptDetails(
+  hash: Hash
+): Promise<ReceiptDetails> {
   try {
     const receipt = await publicClient.getTransactionReceipt({ hash });
     return {
@@ -940,7 +1013,8 @@ function buildCompoundSummaryFromLogs(
   participants: TxParticipants
 ): CompoundTransactionSummary | null {
   for (const log of logs) {
-    const summary = buildV2Summary(log, participants) ?? buildV3Summary(log, participants);
+    const summary =
+      buildV2Summary(log, participants) ?? buildV3Summary(log, participants);
     if (summary) {
       return summary;
     }
@@ -992,7 +1066,11 @@ function buildV2Summary(
   const amountRaw = decoded.args[
     config.amountKey as keyof typeof decoded.args
   ] as bigint;
-  const amount = formatUnitsWithPrecision(amountRaw, market.underlying.decimals, 6);
+  const amount = formatUnitsWithPrecision(
+    amountRaw,
+    market.underlying.decimals,
+    6
+  );
   return createCompoundSummary({
     version: "v2",
     action: config.action,
@@ -1063,7 +1141,10 @@ function createCompoundSummary(options: {
   };
 }
 
-function detectAppCompoundAccount(url: URL, pathname: string): CompoundTarget | null {
+function detectAppCompoundAccount(
+  url: URL,
+  pathname: string
+): CompoundTarget | null {
   if (!pathname.startsWith("/account")) {
     return null;
   }
@@ -1092,7 +1173,10 @@ function detectAppCompoundMarket(pathname: string): CompoundTarget | null {
   return null;
 }
 
-function detectAppCompoundTarget(url: URL, pathname: string): CompoundTarget | null {
+function detectAppCompoundTarget(
+  url: URL,
+  pathname: string
+): CompoundTarget | null {
   const account = detectAppCompoundAccount(url, pathname);
   if (account) {
     return account;
@@ -1139,7 +1223,9 @@ function detectEtherscanMarket(pathname: string): CompoundTarget | null {
   return null;
 }
 
-function detectEtherscanCompoundTarget(pathname: string): CompoundTarget | null {
+function detectEtherscanCompoundTarget(
+  pathname: string
+): CompoundTarget | null {
   const txTarget = detectEtherscanTx(pathname);
   if (txTarget) {
     return txTarget;
@@ -1204,7 +1290,8 @@ export function createCompoundPlan(url: URL): PreviewPlan | null {
       cacheKey: `compound:tx:${target.hash.toLowerCase()}`,
       execute: async () => {
         const data = await decodeCompoundTx(target.hash);
-        const ttl = data["status"] === "pending" ? TX_TTL_PENDING_MS : TX_TTL_SUCCESS_MS;
+        const ttl =
+          data["status"] === "pending" ? TX_TTL_PENDING_MS : TX_TTL_SUCCESS_MS;
         return { data, ttl };
       },
     };

--- a/app/api/open-graph/ens.ts
+++ b/app/api/open-graph/ens.ts
@@ -141,7 +141,7 @@ function normalizeEnsName(name: string): {
     console.error("normalizeEnsName error", error);
     const record = error as { message?: unknown } | null;
     let message = "Invalid ENS name provided";
-    if (record?.message) {
+    if (typeof record?.message === "string" && record.message) {
       message = `${message}: ${record.message}`;
     }
     throw new EnsPreviewError(400, message);

--- a/app/api/open-graph/ens.ts
+++ b/app/api/open-graph/ens.ts
@@ -137,11 +137,12 @@ function normalizeEnsName(name: string): {
     const normalized = ens_normalize(name);
     const display = toUnicode(normalized);
     return { normalized, display };
-  } catch (error: any) {
+  } catch (error) {
     console.error("normalizeEnsName error", error);
+    const record = error as { message?: unknown } | null;
     let message = "Invalid ENS name provided";
-    if (error?.message) {
-      message = `${message}: ${error.message}`;
+    if (record?.message) {
+      message = `${message}: ${record.message}`;
     }
     throw new EnsPreviewError(400, message);
   }

--- a/app/api/pepe/resolve/route.ts
+++ b/app/api/pepe/resolve/route.ts
@@ -131,7 +131,7 @@ function isCounterpartyAssetCode(value: string): boolean {
 }
 
 type ScrapeNextDataResult = {
-  nextData: any | null;
+  nextData: unknown | null;
   metaImages: string[];
 };
 
@@ -759,9 +759,13 @@ async function resolveAsset(slug: string): Promise<AssetPreview> {
   let bestAskSats: number | undefined;
   if (Array.isArray(dispensersOpen?.data)) {
     const satsValues = dispensersOpen.data
-      .map((entry: any) =>
-        Number(entry?.satoshi_price ?? entry?.satoshirate ?? 0)
-      )
+      .map((entry: unknown) => {
+        const record = entry as {
+          satoshi_price?: unknown;
+          satoshirate?: unknown;
+        } | null;
+        return Number(record?.satoshi_price ?? record?.satoshirate ?? 0);
+      })
       .filter((value: number) => Number.isFinite(value) && value > 0);
     if (satsValues.length) {
       bestAskSats = Math.min(...satsValues);

--- a/app/nextgen/collection/[collection]/page-utils.ts
+++ b/app/nextgen/collection/[collection]/page-utils.ts
@@ -18,7 +18,7 @@ export async function fetchCollection(
     endpoint: `nextgen/collections/${parsedId}`,
     headers: headers,
   }).catch(() => null);
-  return isEmptyObject(collection) ? null : collection;
+  return collection === null || isEmptyObject(collection) ? null : collection;
 }
 
 export function getCollectionView(view: string): NextgenCollectionView {

--- a/app/restricted/page.client.tsx
+++ b/app/restricted/page.client.tsx
@@ -17,19 +17,26 @@ export default function RestrictedPage() {
       const apiAuth = getStagingAuth();
       fetch(`${publicEnv.API_ENDPOINT}/api/`, {
         headers: apiAuth ? { "x-6529-auth": apiAuth } : {},
-      }).then((r: any) => {
-        r.json().then((response: any) => {
-          setImage(response.image);
-          if (r.status === 403) {
-            const country = response.country;
-            const msg = `Access from your country ${
-              country ? "(" + country + ") " : ""
-            }is restricted`;
-            setMessage(msg);
-          } else {
-            setMessage("Go to 6529.io");
+      }).then((r: Response) => {
+        r.json().then(
+          (response: {
+            image?: string | undefined;
+            country?: string | undefined;
+          }) => {
+            if (response.image) {
+              setImage(response.image);
+            }
+            if (r.status === 403) {
+              const country = response.country;
+              const msg = `Access from your country ${
+                country ? "(" + country + ") " : ""
+              }is restricted`;
+              setMessage(msg);
+            } else {
+              setMessage("Go to 6529.io");
+            }
           }
-        });
+        );
       });
     }
   }, [image]);

--- a/components/app-wallets/AppWalletModal.tsx
+++ b/components/app-wallets/AppWalletModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 import styles from "./AppWallet.module.css";
-import type { ReactNode, RefObject } from "react";
+import type { KeyboardEvent, ReactNode, RefObject } from "react";
 import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import clsx from "clsx";
@@ -316,7 +316,7 @@ export function CreateAppWalletModal(
         placeholder="******"
         value={walletPass}
         className={styles["newWalletInput"]}
-        onChange={(e: any) => {
+        onChange={(e) => {
           const value = e.target.value;
           if (/^\S*$/.test(value)) {
             setWalletPass(value);
@@ -392,7 +392,7 @@ export function UnlockAppWalletModal(
     onHide();
   }, [onHide]);
 
-  const handleKeyPress = (e: any) => {
+  const handleKeyPress = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter" && canUnlock) {
       handleUnlock();
     }

--- a/components/block-picker/BlockPickerDateSelect.tsx
+++ b/components/block-picker/BlockPickerDateSelect.tsx
@@ -10,7 +10,7 @@ export default function BlockPickerDateSelect({
   setTime: (time: string) => void;
 }) {
   return (
-    <div className="tw-gap-x-4 tw-flex tw-w-full">
+    <div className="tw-flex tw-w-full tw-gap-x-4">
       <div className="tw-w-full">
         <label className="tw-block tw-text-sm tw-font-normal tw-leading-5 tw-text-iron-100">
           Select date
@@ -24,8 +24,8 @@ export default function BlockPickerDateSelect({
             required
             min={new Date().toISOString().slice(0, 10)}
             onChange={(e) => setDate(e.target.value)}
-            onClick={(e: any) => e.target.showPicker()}
-            className="tw-cursor-pointer tw-form-input tw-block tw-w-full tw-rounded-lg tw-border-0 tw-py-3 tw-px-3 tw-bg-iron-700/40 tw-text-white tw-font-light tw-caret-primary-400 tw-shadow-sm tw-ring-1 tw-ring-inset tw-ring-iron-700/40 placeholder:tw-text-iron-500  focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-primary-400 hover:tw-ring-iron-700 tw-text-base sm:tw-leading-6 tw-transition tw-duration-300 tw-ease-out"
+            onClick={(e) => e.currentTarget.showPicker()}
+            className="tw-form-input tw-block tw-w-full tw-cursor-pointer tw-rounded-lg tw-border-0 tw-bg-iron-700/40 tw-px-3 tw-py-3 tw-text-base tw-font-light tw-text-white tw-caret-primary-400 tw-shadow-sm tw-ring-1 tw-ring-inset tw-ring-iron-700/40 tw-transition tw-duration-300 tw-ease-out placeholder:tw-text-iron-500 hover:tw-ring-iron-700 focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-primary-400 sm:tw-leading-6"
           />
         </div>
       </div>
@@ -43,8 +43,8 @@ export default function BlockPickerDateSelect({
             required
             disabled={!date}
             onChange={(e) => setTime(e.target.value)}
-            onClick={(e: any) => e.target.showPicker()}
-            className="tw-cursor-pointer tw-form-input tw-block tw-w-full tw-rounded-lg tw-border-0 tw-py-3 tw-px-3 tw-bg-iron-700/40 tw-text-white tw-font-light tw-caret-primary-400 tw-shadow-sm tw-ring-1 tw-ring-inset tw-ring-iron-700/40 placeholder:tw-text-iron-500  focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-primary-400 hover:tw-ring-iron-700 tw-text-base sm:tw-leading-6 tw-transition tw-duration-300 tw-ease-out"
+            onClick={(e) => e.currentTarget.showPicker()}
+            className="tw-form-input tw-block tw-w-full tw-cursor-pointer tw-rounded-lg tw-border-0 tw-bg-iron-700/40 tw-px-3 tw-py-3 tw-text-base tw-font-light tw-text-white tw-caret-primary-400 tw-shadow-sm tw-ring-1 tw-ring-inset tw-ring-iron-700/40 tw-transition tw-duration-300 tw-ease-out placeholder:tw-text-iron-500 hover:tw-ring-iron-700 focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-primary-400 sm:tw-leading-6"
           />
         </div>
       </div>

--- a/components/distribution-plan-tool/build-phases/build-phase/form/BuildPhaseFormConfigModal.tsx
+++ b/components/distribution-plan-tool/build-phases/build-phase/form/BuildPhaseFormConfigModal.tsx
@@ -3,7 +3,8 @@
 import type {
   AllowlistOperation,
   AllowlistOperationBase,
-  DistributionPlanSearchContractMetadataResult} from "@/components/allowlist-tool/allowlist-tool.types";
+  DistributionPlanSearchContractMetadataResult,
+} from "@/components/allowlist-tool/allowlist-tool.types";
 import {
   AllowlistOperationCode,
   Pool,
@@ -153,7 +154,7 @@ export default function BuildPhaseFormConfigModal({
         return null;
       }
 
-      return new Set(tokens.map((t: any) => t.owner)).size;
+      return new Set(tokens.map((t: { owner: string }) => t.owner)).size;
     };
 
     const pools = operations
@@ -436,10 +437,7 @@ export default function BuildPhaseFormConfigModal({
     ops,
     distributionPlanId,
   }: {
-    ops: {
-      code: AllowlistOperationCode;
-      params: any;
-    }[];
+    ops: AllowlistOperationBase[];
     distributionPlanId: string;
   }): Promise<{ success: boolean }> => {
     const endpoint = `/allowlists/${distributionPlanId}/operations/batch`;

--- a/components/distribution-plan-tool/build-phases/build-phase/form/component-config/snapshots-table/FinalizeSnapshotsTableExcludedSnapshotsTooltip.tsx
+++ b/components/distribution-plan-tool/build-phases/build-phase/form/component-config/snapshots-table/FinalizeSnapshotsTableExcludedSnapshotsTooltip.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import type {
-    AllowlistOperation} from "@/components/allowlist-tool/allowlist-tool.types";
+import type { AllowlistOperation } from "@/components/allowlist-tool/allowlist-tool.types";
 import {
-    AllowlistOperationCode,
-    Pool,
+  AllowlistOperationCode,
+  Pool,
 } from "@/components/allowlist-tool/allowlist-tool.types";
 import DistributionPlanTableBodyWrapper from "@/components/distribution-plan-tool/common/DistributionPlanTableBodyWrapper";
 import DistributionPlanTableHeaderWrapper from "@/components/distribution-plan-tool/common/DistributionPlanTableHeaderWrapper";
@@ -57,8 +56,9 @@ export default function FinalizeSnapshotsTableExcludedSnapshotsTooltip({
     id: operation.params["id"],
     name: operation.params["name"],
     type: "Custom Snapshot",
-    walletsCount: new Set(operation.params["tokens"].map((t: any) => t.owner))
-      .size,
+    walletsCount: new Set(
+      operation.params["tokens"].map((t: { owner: string }) => t.owner)
+    ).size,
     tokensCount: operation.params["tokens"].length,
   });
 
@@ -89,26 +89,26 @@ export default function FinalizeSnapshotsTableExcludedSnapshotsTooltip({
       <DistributionPlanTableHeaderWrapper>
         <th
           scope="col"
-          className="tw-py-3 tw-pl-4 tw-pr-3 tw-whitespace-nowrap tw-text-left 
-      tw-text-[0.6875rem] tw-leading-[1.125rem] tw-font-medium tw-text-iron-400 tw-uppercase tw-tracking-[0.25px] sm:tw-pl-6">
+          className="tw-whitespace-nowrap tw-py-3 tw-pl-4 tw-pr-3 tw-text-left tw-text-[0.6875rem] tw-font-medium tw-uppercase tw-leading-[1.125rem] tw-tracking-[0.25px] tw-text-iron-400 sm:tw-pl-6"
+        >
           Name
         </th>
         <th
           scope="col"
-          className="tw-px-3 tw-py-3 tw-whitespace-nowrap tw-text-left tw-text-[0.6875rem] tw-leading-[1.125rem] tw-font-medium tw-text-iron-400 tw-uppercase 
-      tw-tracking-[0.25px]">
+          className="tw-whitespace-nowrap tw-px-3 tw-py-3 tw-text-left tw-text-[0.6875rem] tw-font-medium tw-uppercase tw-leading-[1.125rem] tw-tracking-[0.25px] tw-text-iron-400"
+        >
           Type
         </th>
         <th
           scope="col"
-          className="tw-px-3 tw-py-3 tw-whitespace-nowrap tw-text-left tw-text-[0.6875rem] tw-leading-[1.125rem] tw-font-medium tw-text-iron-400 tw-uppercase 
-      tw-tracking-[0.25px]">
+          className="tw-whitespace-nowrap tw-px-3 tw-py-3 tw-text-left tw-text-[0.6875rem] tw-font-medium tw-uppercase tw-leading-[1.125rem] tw-tracking-[0.25px] tw-text-iron-400"
+        >
           Wallets
         </th>
         <th
           scope="col"
-          className="tw-pl-3 tw-pr-4 tw-py-3 tw-whitespace-nowrap tw-text-left 
-      tw-text-[0.6875rem] tw-leading-[1.125rem] tw-font-medium tw-text-iron-400 tw-uppercase tw-tracking-[0.25px]">
+          className="tw-whitespace-nowrap tw-py-3 tw-pl-3 tw-pr-4 tw-text-left tw-text-[0.6875rem] tw-font-medium tw-uppercase tw-leading-[1.125rem] tw-tracking-[0.25px] tw-text-iron-400"
+        >
           Tokens
         </th>
       </DistributionPlanTableHeaderWrapper>

--- a/components/distribution-plan-tool/build-phases/build-phase/form/component-config/snapshots-table/FinalizeSnapshotsTableSnapshotTooltipCustomSnapshot.tsx
+++ b/components/distribution-plan-tool/build-phases/build-phase/form/component-config/snapshots-table/FinalizeSnapshotsTableSnapshotTooltipCustomSnapshot.tsx
@@ -35,7 +35,9 @@ export default function FinalizeSnapshotsTableSnapshotTooltipCustomSnapshot({
     {
       name: "Wallets count",
       value:
-        new Set(customPool?.params["tokens"].map((t: any) => t.owner)).size ?? "",
+        new Set(
+          customPool?.params["tokens"].map((t: { owner: string }) => t.owner)
+        ).size ?? "",
     },
     {
       name: "Tokens count",

--- a/components/distribution-plan-tool/create-custom-snapshots/CreateCustomSnapshots.tsx
+++ b/components/distribution-plan-tool/create-custom-snapshots/CreateCustomSnapshots.tsx
@@ -2,15 +2,12 @@
 
 import { useContext, useEffect, useState } from "react";
 import {
-    DistributionPlanToolContext,
-    DistributionPlanToolStep,
+  DistributionPlanToolContext,
+  DistributionPlanToolStep,
 } from "../DistributionPlanToolContext";
 
-import type {
-    AllowlistCustomTokenPool} from "@/components/allowlist-tool/allowlist-tool.types";
-import {
-    AllowlistOperationCode,
-} from "@/components/allowlist-tool/allowlist-tool.types";
+import type { AllowlistCustomTokenPool } from "@/components/allowlist-tool/allowlist-tool.types";
+import { AllowlistOperationCode } from "@/components/allowlist-tool/allowlist-tool.types";
 import AllowlistToolCsvIcon from "@/components/allowlist-tool/icons/AllowlistToolCsvIcon";
 import DistributionPlanEmptyTablePlaceholder from "../common/DistributionPlanEmptyTablePlaceholder";
 import DistributionPlanNextStepBtn from "../common/DistributionPlanNextStepBtn";
@@ -42,7 +39,9 @@ export default function CreateCustomSnapshots() {
         allowlistId: distributionPlan.id,
         name: o.params["name"],
         description: o.params["description"],
-        walletsCount: new Set(o.params["tokens"].map((t: any) => t.owner)).size,
+        walletsCount: new Set(
+          o.params["tokens"].map((t: { owner: string }) => t.owner)
+        ).size,
         tokensCount: o.params["tokens"].length,
       }))
     );
@@ -101,12 +100,14 @@ export default function CreateCustomSnapshots() {
       <StepHeader step={DistributionPlanToolStep.CREATE_CUSTOM_SNAPSHOT} />
       <div
         onClick={downloadExampleCsv}
-        className="tw-group tw-mt-4 tw-cursor-pointer tw-items-center tw-font-light tw-text-sm tw-text-iron-400 hover:tw-text-iron-50 tw-inline-flex tw-gap-x-2 tw-transition-all tw-duration-300 tw-ease-out">
+        className="tw-group tw-mt-4 tw-inline-flex tw-cursor-pointer tw-items-center tw-gap-x-2 tw-text-sm tw-font-light tw-text-iron-400 tw-transition-all tw-duration-300 tw-ease-out hover:tw-text-iron-50"
+      >
         Download example CSV file
         <button
           type="button"
-          className="-tw-mt-0.5 tw-group tw-rounded-full tw-group tw-flex tw-items-center tw-justify-center tw-h-8 tw-w-8 tw-text-xs tw-font-medium tw-border-none tw-ring-1 tw-ring-inset tw-text-iron-400 tw-bg-iron-400/10 tw-ring-iron-400/20 group-hover:tw-bg-iron-400/20 tw-ease-out tw-transition tw-duration-300">
-          <div className="tw-h-3.5 tw-w-3.5 tw-flex tw-items-center tw-justify-center">
+          className="tw-group -tw-mt-0.5 tw-flex tw-h-8 tw-w-8 tw-items-center tw-justify-center tw-rounded-full tw-border-none tw-bg-iron-400/10 tw-text-xs tw-font-medium tw-text-iron-400 tw-ring-1 tw-ring-inset tw-ring-iron-400/20 tw-transition tw-duration-300 tw-ease-out group-hover:tw-bg-iron-400/20"
+        >
+          <div className="tw-flex tw-h-3.5 tw-w-3.5 tw-items-center tw-justify-center">
             <AllowlistToolCsvIcon />
           </div>
         </button>

--- a/components/downloadUrlWidget/DownloadUrlWidget.tsx
+++ b/components/downloadUrlWidget/DownloadUrlWidget.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export default function DownloadUrlWidget(props: Readonly<Props>) {
   const apiAuth = getStagingAuth();
-  let headers: any = {};
+  const headers: Record<string, string> = {};
   if (apiAuth) {
     headers["x-6529-auth"] = apiAuth;
   }

--- a/components/drops/view/Drops.tsx
+++ b/components/drops/view/Drops.tsx
@@ -17,6 +17,16 @@ import DropsList from "./DropsList";
 
 const REQUEST_SIZE = 10;
 
+type WaveWithChatScope = {
+  readonly chat?: {
+    readonly scope?: {
+      readonly group?: {
+        readonly is_direct_message?: boolean | undefined;
+      } | null;
+    } | null;
+  } | null;
+};
+
 export default function Drops() {
   const router = useRouter();
   const { isApp } = useDeviceInfo();
@@ -137,9 +147,9 @@ export default function Drops() {
   }, [drops]);
 
   const navigateToDropWave = (drop: Pick<ApiDrop, "wave" | "serial_no">) => {
-    const waveInfo = drop.wave as any;
+    const waveInfo = drop.wave as WaveWithChatScope;
     const isDirectMessage =
-      waveInfo?.chat?.scope?.group?.is_direct_message ?? false;
+      waveInfo.chat?.scope?.group?.is_direct_message ?? false;
     router.push(
       getWaveRoute({
         waveId: drop.wave.id,

--- a/components/drops/view/part/DropPartContent.tsx
+++ b/components/drops/view/part/DropPartContent.tsx
@@ -3,6 +3,7 @@
 import React, { useMemo } from "react";
 import DropPartMarkdown from "./DropPartMarkdown";
 import DropListItemContentMedia from "../item/content/media/DropListItemContentMedia";
+import type { ApiDrop } from "@/generated/models/ApiDrop";
 import type { ApiDropMentionedUser } from "@/generated/models/ApiDropMentionedUser";
 import type { ApiDropGroupMention } from "@/generated/models/ApiDropGroupMention";
 import type { MentionedWave } from "@/entities/IDrop";
@@ -19,7 +20,7 @@ interface DropPartContentProps {
   readonly mentionedWaves: MentionedWave[];
   readonly referencedNfts: ApiDropReferencedNFT[];
   readonly partContent: string | null;
-  readonly onQuoteClick: (drop: any) => void;
+  readonly onQuoteClick: (drop: ApiDrop) => void;
   readonly currentDropId?: string | undefined;
   readonly partMedias: Array<{
     mimeType: string;

--- a/components/drops/view/part/DropPartMarkdownWithPropLogger.tsx
+++ b/components/drops/view/part/DropPartMarkdownWithPropLogger.tsx
@@ -2,12 +2,14 @@ import React from "react";
 import type { DropPartMarkdownProps } from "./DropPartMarkdown";
 import DropPartMarkdown from "./DropPartMarkdown";
 
-function areArraysEqual(arr1: any[], arr2: any[]): boolean {
+function areArraysEqual(arr1: unknown[], arr2: unknown[]): boolean {
   if (arr1.length !== arr2.length) return false;
   for (let i = 0; i < arr1.length; i++) {
-    if (Array.isArray(arr1[i]) && Array.isArray(arr2[i])) {
-      if (!areArraysEqual(arr1[i], arr2[i])) return false;
-    } else if (arr1[i] !== arr2[i]) {
+    const item1 = arr1[i];
+    const item2 = arr2[i];
+    if (Array.isArray(item1) && Array.isArray(item2)) {
+      if (!areArraysEqual(item1, item2)) return false;
+    } else if (item1 !== item2) {
       return false;
     }
   }

--- a/components/groups/page/create/config/wallets/CreateGroupWalletsUpload.tsx
+++ b/components/groups/page/create/config/wallets/CreateGroupWalletsUpload.tsx
@@ -73,25 +73,26 @@ export default function CreateGroupWalletsUpload({
 
   return (
     <div>
-      <div className="tw-p-3 sm:tw-p-5 tw-bg-iron-950 tw-rounded-xl tw-shadow tw-border tw-border-solid tw-border-iron-800">
-        <p className="tw-mb-0 tw-text-base sm:tw-text-lg tw-font-semibold tw-text-iron-50">
+      <div className="tw-rounded-xl tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-950 tw-p-3 tw-shadow sm:tw-p-5">
+        <p className="tw-mb-0 tw-text-base tw-font-semibold tw-text-iron-50 sm:tw-text-lg">
           Add wallets manually
         </p>
         <label
-          className="tw-group tw-mt-2 sm:tw-mt-3
-        tw-bg-iron-900 tw-border-iron-650 tw-flex tw-flex-col tw-items-center tw-justify-center tw-w-full tw-h-32 tw-border-2 tw-border-dashed tw-rounded-lg tw-cursor-pointer hover:tw-border-iron-600 hover:tw-bg-iron-800 tw-transition tw-duration-300 tw-ease-out"
+          className="tw-group tw-mt-2 tw-flex tw-h-32 tw-w-full tw-cursor-pointer tw-flex-col tw-items-center tw-justify-center tw-rounded-lg tw-border-2 tw-border-dashed tw-border-iron-650 tw-bg-iron-900 tw-transition tw-duration-300 tw-ease-out hover:tw-border-iron-600 hover:tw-bg-iron-800 sm:tw-mt-3"
           onDrop={handleDrop}
           onDragOver={handleDragOver}
-          onDragEnter={handleDragEnter}>
+          onDragEnter={handleDragEnter}
+        >
           <div className="tw-flex tw-flex-col tw-items-center tw-justify-center tw-p-5 lg:tw-p-6">
-            <div className="tw-flex tw-h-10 tw-w-10 tw-items-center tw-justify-center tw-rounded-lg tw-bg-iron-950 tw-border tw-border-solid tw-border-iron-700 tw-transition tw-duration-300 tw-ease-out">
-              <div className="tw-flex tw-items-center tw-justify-center tw-flex-shrink-0 tw-h-5 tw-w-5 tw-text-iron-50">
+            <div className="tw-flex tw-h-10 tw-w-10 tw-items-center tw-justify-center tw-rounded-lg tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-transition tw-duration-300 tw-ease-out">
+              <div className="tw-flex tw-h-5 tw-w-5 tw-flex-shrink-0 tw-items-center tw-justify-center tw-text-iron-50">
                 <svg
-                  className="tw-flex-shrink-0 tw-h-5 tw-w-5 tw-text-iron-300"
+                  className="tw-h-5 tw-w-5 tw-flex-shrink-0 tw-text-iron-300"
                   viewBox="0 0 24 24"
                   fill="none"
                   aria-hidden="true"
-                  xmlns="http://www.w3.org/2000/svg">
+                  xmlns="http://www.w3.org/2000/svg"
+                >
                   <path
                     d="M4 16.2422C2.79401 15.435 2 14.0602 2 12.5C2 10.1564 3.79151 8.23129 6.07974 8.01937C6.54781 5.17213 9.02024 3 12 3C14.9798 3 17.4522 5.17213 17.9203 8.01937C20.2085 8.23129 22 10.1564 22 12.5C22 14.0602 21.206 15.435 20 16.2422M8 16L12 12M12 12L16 16M12 12V21"
                     stroke="currentColor"
@@ -102,7 +103,7 @@ export default function CreateGroupWalletsUpload({
                 </svg>
               </div>
             </div>
-            <p className="tw-mt-4 tw-mb-0 tw-text-sm tw-text-center tw-text-balance tw-text-iron-500">
+            <p className="tw-mb-0 tw-mt-4 tw-text-balance tw-text-center tw-text-sm tw-text-iron-500">
               Drag and drop your CSV file here, or click to select a file
             </p>
           </div>
@@ -112,15 +113,15 @@ export default function CreateGroupWalletsUpload({
             type="file"
             className="tw-hidden"
             accept="text/csv"
-            onChange={(e: any) => {
-              if (e.target.files) {
-                const file = e.target.files[0];
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) {
                 onFileChange(file);
               }
             }}
           />
         </label>
-        <div className="tw-mt-4 tw-gap-y-2 tw-w-full tw-flex tw-flex-col sm:tw-flex-row sm:tw-items-center tw-justify-between">
+        <div className="tw-mt-4 tw-flex tw-w-full tw-flex-col tw-justify-between tw-gap-y-2 sm:tw-flex-row sm:tw-items-center">
           <GroupCreateWalletsCount
             walletsCount={wallets?.length ?? null}
             loading={false}

--- a/components/ipfs/IPFSService.ts
+++ b/components/ipfs/IPFSService.ts
@@ -24,8 +24,11 @@ class IpfsService {
       await axios.post(
         `${this.apiEndpoint}/api/v0/files/mkdir?arg=/${this.mfsPath}&parents=true`
       );
-    } catch (error: any) {
-      console.error("Failed to configure MFS:", error.message);
+    } catch (error) {
+      console.error(
+        "Failed to configure MFS:",
+        (error as { message?: unknown })?.message
+      );
       throw error;
     }
   }
@@ -67,8 +70,11 @@ class IpfsService {
       await this.validateFileName(cid, file);
 
       return cid;
-    } catch (error: any) {
-      console.error("Failed to add file to IPFS or MFS:", error.message);
+    } catch (error) {
+      console.error(
+        "Failed to add file to IPFS or MFS:",
+        (error as { message?: unknown })?.message
+      );
       throw error;
     }
   }

--- a/components/layout/sidebar/WebSidebarUser.tsx
+++ b/components/layout/sidebar/WebSidebarUser.tsx
@@ -21,10 +21,11 @@ import {
 import { useIsMobileDeviceStatus } from "@/hooks/isMobileDevice";
 import useCapacitor from "@/hooks/useCapacitor";
 import { useIdentity } from "@/hooks/useIdentity";
+import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 
 interface WebSidebarUserProps {
   readonly isCollapsed: boolean;
-  readonly profile: any;
+  readonly profile: ApiIdentity | null;
 }
 
 function WebSidebarUser({

--- a/components/leaderboard/Leaderboard.tsx
+++ b/components/leaderboard/Leaderboard.tsx
@@ -190,8 +190,10 @@ export default function Leaderboard(
   }, [content, collector]);
 
   useEffect(() => {
-    fetchUrl(`${publicEnv.API_ENDPOINT}/api/blocks?page_size=${1}`)
-      .then((response: ApiBlocksPage) => {
+    fetchUrl<ApiBlocksPage>(
+      `${publicEnv.API_ENDPOINT}/api/blocks?page_size=${1}`
+    )
+      .then((response) => {
         if (response.data.length > 0) {
           const latestTDH = {
             block: response.data[0]?.block_number!,

--- a/components/leaderboard/NFTLeaderboard.tsx
+++ b/components/leaderboard/NFTLeaderboard.tsx
@@ -6,6 +6,7 @@ import { cicToType, numberWithCommas } from "@/helpers/Helpers";
 import Pagination from "../pagination/Pagination";
 import { SortDirection } from "@/entities/ISort";
 import type { CICType } from "@/entities/IProfile";
+import type { DBResponse } from "@/entities/IDBResponse";
 import { LeaderboardCollector } from "./LeaderboardCollector";
 import {
   SearchModalDisplay,
@@ -39,12 +40,7 @@ export async function fetchNftTdhResults(
   sort_direction: string
 ) {
   const url = `tdh/nft`;
-  const results = await commonApiFetch<{
-    count: number;
-    page: number;
-    next: any;
-    data: NftTDH[];
-  }>({
+  const results = await commonApiFetch<DBResponse<NftTDH>>({
     endpoint: `${url}/${contract}/${nftId}?${walletFilter}&page_size=${PAGE_SIZE}&page=${page}&sort=${sort}&sort_direction=${sort_direction}`,
   });
   results.data.forEach((lead: NftTDH) => {

--- a/components/leaderboard/leaderboard_helpers.ts
+++ b/components/leaderboard/leaderboard_helpers.ts
@@ -2,6 +2,7 @@
 
 import { publicEnv } from "@/config/env";
 import { useCallback, useEffect, useState } from "react";
+import type { DBResponse } from "@/entities/IDBResponse";
 import type { CICType } from "@/entities/IProfile";
 import type { SortDirection } from "@/entities/ISort";
 import type { ApiConsolidatedTdhMetrics } from "@/generated/models/ApiConsolidatedTdhMetrics";
@@ -89,7 +90,7 @@ export function getLeaderboardDownloadFileName(
   return `${csvFileName}.csv`;
 }
 
-async function fetchLeaderboardData<T>(
+async function fetchLeaderboardData<T extends LeaderboardItem>(
   endpoint: string,
   pageSize: number,
   page: number,
@@ -144,16 +145,11 @@ async function fetchLeaderboardData<T>(
   }
 
   const url = `${endpoint}?${params.toString()}`;
-  const response = await commonApiFetch<{
-    count: number;
-    page: number;
-    next: any;
-    data: T[];
-  }>({
+  const response = await commonApiFetch<DBResponse<T>>({
     endpoint: url,
   });
-  response.data.forEach((lead: any) => {
-    lead.cic_type = cicToType(lead.cic_score);
+  response.data.forEach((lead: T) => {
+    lead.cic_type = cicToType(Number(lead.cic_score));
   });
   return {
     count: response.count,

--- a/components/levels/ProgressChart.tsx
+++ b/components/levels/ProgressChart.tsx
@@ -10,6 +10,9 @@ import {
   Filler,
   Tooltip,
   LogarithmicScale,
+  type ActiveElement,
+  type ChartEvent,
+  type TooltipItem,
 } from "chart.js";
 import levels from "@/constants/levels.json";
 import { useEffect, useState } from "react";
@@ -74,15 +77,16 @@ export default function ProgressChart() {
       legend: { display: false },
       tooltip: {
         callbacks: {
-          label: (ctx: any) =>
-            `Level ${ctx.label}: ${ctx.parsed.y.toLocaleString()} TDH+Rep`,
+          label: (ctx: TooltipItem<"line">) =>
+            `Level ${ctx.label}: ${(ctx.parsed.y ?? 0).toLocaleString()} TDH+Rep`,
         },
       },
     },
     animation: prefersReducedMotion ? (false as const) : undefined,
-    onHover: (_: any, activeElements: any[]) => {
-      if (activeElements.length > 0) {
-        const idx = activeElements[0].index;
+    onHover: (_: ChartEvent, activeElements: ActiveElement[]) => {
+      const firstActiveElement = activeElements[0];
+      if (firstActiveElement) {
+        const idx = firstActiveElement.index;
         const level = (levels as LevelData[])[idx]?.level;
         window.dispatchEvent(
           new CustomEvent("level-hover", { detail: { level } })

--- a/components/manifold-minting/ManifoldMinting.tsx
+++ b/components/manifold-minting/ManifoldMinting.tsx
@@ -53,14 +53,14 @@ import type {
   ArweaveMetadata,
   ManifoldMintMetadata,
 } from "./manifold-mint-metadata";
-import type { Chain } from "viem";
+import type { Abi, Chain } from "viem";
 import WalletConnectBalance from "@/components/wallet-connect-balance/WalletConnectBalance";
 
 interface Props {
   title: string;
   contract: string;
   chain: Chain;
-  abi: any;
+  abi: Abi;
   mint_date: Time;
   mintMetadata: ManifoldMintMetadata;
   standalone?: boolean;
@@ -380,15 +380,15 @@ export default function ManifoldMinting(props: Readonly<Props>) {
   const descriptionRef = useRef<HTMLDivElement>(null);
 
   const manifoldClaimState = useManifoldClaim({
-      chainId: props.chain.id,
-      contract: props.contract,
-      proxy: MANIFOLD_LAZY_CLAIM_CONTRACT,
-      abi: props.abi,
-      identifier: props.mintMetadata.tokenId,
-      onError: () => {
-        setIsError(true);
-      },
-    });
+    chainId: props.chain.id,
+    contract: props.contract,
+    proxy: MANIFOLD_LAZY_CLAIM_CONTRACT,
+    abi: props.abi,
+    identifier: props.mintMetadata.tokenId,
+    onError: () => {
+      setIsError(true);
+    },
+  });
   const manifoldClaim = manifoldClaimState?.claim;
   const isManifoldClaimFetching = manifoldClaimState?.isFetching ?? false;
 

--- a/components/manifold-minting/ManifoldMintingWidget.tsx
+++ b/components/manifold-minting/ManifoldMintingWidget.tsx
@@ -22,9 +22,18 @@ import { getMemesMintingProofsByAddress } from "@/services/api/memes-minting-cla
 import { useSeizeConnectContext } from "../auth/SeizeConnectContext";
 import DotLoader from "../dotLoader/DotLoader";
 import ManifoldMintingConnect from "./ManifoldMintingConnect";
-import { isAddress, type Chain } from "viem";
+import {
+  isAddress,
+  type Abi,
+  type Chain,
+  type ContractFunctionParameters,
+} from "viem";
 
 const MINT_PROXY_FUNCTION_NAME = "mintProxy";
+
+type ReadContractCall = ContractFunctionParameters & {
+  readonly chainId?: number | undefined;
+};
 
 function normalizeMintCount(value: number | string | null | undefined): number {
   const parsed =
@@ -70,7 +79,7 @@ export default function ManifoldMintingWidget(
   props: Readonly<{
     contract: string;
     chain: Chain;
-    abi: any;
+    abi: Abi;
     claim: ManifoldClaim;
     local_timezone: boolean;
     hideConnect?: boolean;
@@ -159,7 +168,7 @@ export default function ManifoldMintingWidget(
   ]);
 
   function getReadContractsParams() {
-    const params: any = [];
+    const params: ReadContractCall[] = [];
     merkleProofs.forEach((mp) => {
       params.push({
         address: MANIFOLD_LAZY_CLAIM_CONTRACT as `0x${string}`,
@@ -234,7 +243,7 @@ export default function ManifoldMintingWidget(
       connectedAddress.address,
       mintForAddress
     );
-    const args: any[] = [props.contract, props.claim.instanceId];
+    const args: unknown[] = [props.contract, props.claim.instanceId];
     const mintArgs = getMintArgsList(isProxy);
 
     args.push(...mintArgs, mintForAddress);

--- a/components/mapping-tools/ConsolidationMappingTool.tsx
+++ b/components/mapping-tools/ConsolidationMappingTool.tsx
@@ -4,14 +4,13 @@ import { publicEnv } from "@/config/env";
 import type { Consolidation } from "@/entities/IDelegation";
 import { areEqualAddresses } from "@/helpers/Helpers";
 import { fetchAllPages } from "@/services/6529api";
+import csvParser from "csv-parser";
 import { useEffect, useState } from "react";
 import {
   MappingToolSubmitButton,
   MappingToolUpload,
 } from "./MappingToolControls";
 import styles from "./MappingTool.module.css";
-
-const csvParser = require("csv-parser");
 
 interface ConsolidationData {
   address: string;
@@ -22,7 +21,7 @@ interface ConsolidationData {
 }
 
 export default function ConsolidationMappingTool() {
-  const [file, setFile] = useState<any>();
+  const [file, setFile] = useState<File | undefined>();
   const [processing, setProcessing] = useState(false);
   const [consolidations, setConsolidations] = useState<Consolidation[]>([]);
 
@@ -85,22 +84,22 @@ export default function ConsolidationMappingTool() {
           let isFirstRow = true;
 
           const parser = csvParser({ headers: true })
-            .on("data", (row: any) => {
+            .on("data", (row: Record<string, string>) => {
               if (isFirstRow) {
                 isFirstRow = false;
               } else {
-                const address = row["_0"];
-                const token_id = Number.parseInt(row["_1"], 10);
-                const balance = Number.parseInt(row["_2"], 10);
-                const contract = row["_3"];
-                const name = row["_4"];
+                const address = row["_0"]!;
+                const token_id = Number.parseInt(row["_1"]!, 10);
+                const balance = Number.parseInt(row["_2"]!, 10);
+                const contract = row["_3"]!;
+                const name = row["_4"]!;
                 results.push({ address, token_id, balance, contract, name });
               }
             })
             .on("end", () => {
               setCsvData(results);
             })
-            .on("error", (err: any) => {
+            .on("error", (err: Error) => {
               console.error(err);
             });
 
@@ -108,7 +107,9 @@ export default function ConsolidationMappingTool() {
           parser.end();
         };
 
-        reader.readAsText(file);
+        if (file) {
+          reader.readAsText(file);
+        }
       });
     }
     if (processing) {

--- a/components/mapping-tools/DelegationMappingTool.tsx
+++ b/components/mapping-tools/DelegationMappingTool.tsx
@@ -9,6 +9,7 @@ import { DELEGATION_ALL_ADDRESS, MEMES_CONTRACT } from "@/constants/constants";
 import type { Delegation } from "@/entities/IDelegation";
 import { areEqualAddresses } from "@/helpers/Helpers";
 import { fetchAllPages } from "@/services/6529api";
+import csvParser from "csv-parser";
 import { useEffect, useState } from "react";
 import {
   MappingToolSubmitButton,
@@ -16,16 +17,14 @@ import {
 } from "./MappingToolControls";
 import styles from "./MappingTool.module.css";
 
-const csvParser = require("csv-parser");
-
 export default function DelegationMappingTool() {
-  const [file, setFile] = useState<any>();
+  const [file, setFile] = useState<File | undefined>();
   const [collection, setCollection] = useState<string>("0");
   const [useCase, setUseCase] = useState<number>(0);
   const [processing, setProcessing] = useState(false);
   const [delegations, setDelegations] = useState<Delegation[]>([]);
 
-  const [csvData, setCsvData] = useState<any[]>([]);
+  const [csvData, setCsvData] = useState<string[]>([]);
   function submit() {
     setProcessing(true);
   }
@@ -64,16 +63,16 @@ export default function DelegationMappingTool() {
 
         reader.onload = async () => {
           const data = reader.result;
-          const results: any[] = [];
+          const results: string[] = [];
 
           const parser = csvParser({ headers: true })
-            .on("data", (row: any) => {
-              results.push(row["_0"]);
+            .on("data", (row: Record<string, string>) => {
+              results.push(row["_0"]!);
             })
             .on("end", () => {
               setCsvData(results);
             })
-            .on("error", (err: any) => {
+            .on("error", (err: Error) => {
               console.error(err);
             });
 
@@ -81,7 +80,9 @@ export default function DelegationMappingTool() {
           parser.end();
         };
 
-        reader.readAsText(file);
+        if (file) {
+          reader.readAsText(file);
+        }
       });
     }
     if (processing) {

--- a/components/monitoring/AwsRumProvider.tsx
+++ b/components/monitoring/AwsRumProvider.tsx
@@ -13,7 +13,6 @@ export default function AwsRumProvider({
   children,
 }: Readonly<AwsRumProviderProps>) {
   useEffect(() => {
-
     // Skip initialization in development mode to avoid noise
     if (publicEnv.NODE_ENV === "development") {
       console.warn("AWS RUM: Skipped initialization in development mode");
@@ -60,8 +59,7 @@ export default function AwsRumProvider({
         config
       );
       // Optional: Store the instance globally for manual tracking if needed
-      (window as any).awsRum = awsRum;
-
+      (window as typeof window & { awsRum?: AwsRum }).awsRum = awsRum;
     } catch (error) {
       // Silently handle errors to prevent breaking the application
       console.warn("AWS RUM: Failed to initialize", error);

--- a/components/nextGen/NextGenContractWriteStatus.tsx
+++ b/components/nextGen/NextGenContractWriteStatus.tsx
@@ -4,6 +4,7 @@ import { NULL_MERKLE } from "@/constants/constants";
 import { areEqualAddresses, getTransactionLink } from "@/helpers/Helpers";
 import { sanitizeErrorForUser } from "@/utils/error-sanitizer";
 import Link from "next/link";
+import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { useWaitForTransactionReceipt } from "wagmi";
 import DotLoader from "../dotLoader/DotLoader";
@@ -15,7 +16,7 @@ const TRANSFER_EVENT =
 interface Props {
   hash?: `0x${string}` | undefined;
   isLoading: boolean;
-  error: any;
+  error: unknown;
   onSuccess?: (() => void) | undefined;
 }
 
@@ -57,16 +58,19 @@ export default function NextGenContractWriteStatus(props: Readonly<Props>) {
     }
   }, [waitContractWrite.isSuccess]);
 
-  function getError() {
-    const error = props.error;
-    if (error.shortMessage) {
-      return error.shortMessage;
+  function getError(): ReactNode {
+    const error = props.error as
+      | { shortMessage?: unknown; details?: unknown; message?: unknown }
+      | null
+      | undefined;
+    if (error?.shortMessage) {
+      return error.shortMessage as ReactNode;
     }
-    if (error.details) {
-      return error.details;
+    if (error?.details) {
+      return error.details as ReactNode;
     }
-    if (error.message) {
-      return error.message;
+    if (error?.message) {
+      return error.message as ReactNode;
     }
     return sanitizeErrorForUser(props.error);
   }

--- a/components/nextGen/admin/NextGenAdmin.tsx
+++ b/components/nextGen/admin/NextGenAdmin.tsx
@@ -285,7 +285,7 @@ export default function NextGenAdmin() {
   function printCreateCollection() {
     return (
       (isGlobalAdmin() ||
-        (createCollectionFunctionAdmin.data as any) === true) && (
+        createCollectionFunctionAdmin.data === true) && (
         <Button
           className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
           onClick={() => setGlobalFocus(GlobalFocus.CREATE_COLLECTION)}
@@ -299,7 +299,7 @@ export default function NextGenAdmin() {
   function printAirdropTokens() {
     return (
       (isGlobalAdmin() ||
-        (airdropTokensFunctionAdmin.data as any) === true) && (
+        airdropTokensFunctionAdmin.data === true) && (
         <Button
           className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
           onClick={() => setGlobalFocus(GlobalFocus.AIRDROP_TOKENS)}
@@ -313,7 +313,7 @@ export default function NextGenAdmin() {
   function printUpdateImagesAttributes() {
     return (
       (isGlobalAdmin() ||
-        (updateImagesAttributesFunctionAdmin.data as any) === true) && (
+        updateImagesAttributesFunctionAdmin.data === true) && (
         <Button
           className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
           onClick={() => setGlobalFocus(GlobalFocus.UPDATE_IMAGES_ATTRIBUTES)}
@@ -327,7 +327,7 @@ export default function NextGenAdmin() {
   function printSetFinalSupply() {
     return (
       (isGlobalAdmin() ||
-        (setFinalSupplyFunctionAdmin.data as any) === true) && (
+        setFinalSupplyFunctionAdmin.data === true) && (
         <Button
           className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
           onClick={() => setGlobalFocus(GlobalFocus.SET_FINAL_SUPPLY)}
@@ -341,7 +341,7 @@ export default function NextGenAdmin() {
   function printInitBurn() {
     return (
       (isGlobalAdmin() ||
-        (initializeBurnFunctionAdmin.data as any) === true) && (
+        initializeBurnFunctionAdmin.data === true) && (
         <Button
           className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
           onClick={() => setGlobalFocus(GlobalFocus.INITIALIZE_BURN)}
@@ -355,7 +355,7 @@ export default function NextGenAdmin() {
   function printInitExternalBurnSwap() {
     return (
       (isGlobalAdmin() ||
-        (initializeExternalBurnSwapFunctionAdmin.data as any) === true) && (
+        initializeExternalBurnSwapFunctionAdmin.data === true) && (
         <Button
           className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
           onClick={() =>
@@ -371,7 +371,7 @@ export default function NextGenAdmin() {
   function printMintAuction() {
     return (
       (isGlobalAdmin() ||
-        (mintAndAuctionFunctionAdmin.data as any) === true) && (
+        mintAndAuctionFunctionAdmin.data === true) && (
         <Button
           className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
           onClick={() => setGlobalFocus(GlobalFocus.MINT_AND_AUCTION)}
@@ -385,13 +385,13 @@ export default function NextGenAdmin() {
   function printAdminCollectionActions() {
     return (
       (isGlobalAdmin() ||
-        (createCollectionFunctionAdmin.data as any) === true ||
-        (airdropTokensFunctionAdmin.data as any) === true ||
-        (updateImagesAttributesFunctionAdmin.data as any) === true ||
-        (setFinalSupplyFunctionAdmin.data as any) === true ||
-        (initializeBurnFunctionAdmin.data as any) === true ||
-        (mintAndAuctionFunctionAdmin.data as any) === true ||
-        (initializeExternalBurnSwapFunctionAdmin.data as any) === true) && (
+        createCollectionFunctionAdmin.data === true ||
+        airdropTokensFunctionAdmin.data === true ||
+        updateImagesAttributesFunctionAdmin.data === true ||
+        setFinalSupplyFunctionAdmin.data === true ||
+        initializeBurnFunctionAdmin.data === true ||
+        mintAndAuctionFunctionAdmin.data === true ||
+        initializeExternalBurnSwapFunctionAdmin.data === true) && (
         <>
           <Row className="tw-pt-6">
             <Col xs={12}>
@@ -449,7 +449,7 @@ export default function NextGenAdmin() {
 
   function printSetSplits() {
     return (
-      (isGlobalAdmin() || (setSplitsFunctionAdmin.data as any) === true) && (
+      (isGlobalAdmin() || setSplitsFunctionAdmin.data === true) && (
         <Button
           className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
           onClick={() =>
@@ -465,8 +465,7 @@ export default function NextGenAdmin() {
   function printProposePrimary() {
     return (
       (isGlobalAdmin() ||
-        (proposePrimaryAddressesAndPercentagesFunctionAdmin.data as any) ===
-          true) && (
+        proposePrimaryAddressesAndPercentagesFunctionAdmin.data === true) && (
         <Button
           className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
           onClick={() =>
@@ -484,8 +483,7 @@ export default function NextGenAdmin() {
   function printProposeSecondary() {
     return (
       (isGlobalAdmin() ||
-        (proposeSecondaryAddressesAndPercentagesFunctionAdmin.data as any) ===
-          true) && (
+        proposeSecondaryAddressesAndPercentagesFunctionAdmin.data === true) && (
         <Button
           className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
           onClick={() =>
@@ -503,7 +501,7 @@ export default function NextGenAdmin() {
   function printAcceptAddressesAndPercentages() {
     return (
       (isGlobalAdmin() ||
-        (acceptAddressesAndPercentagesFunctionAdmin.data as any) === true) && (
+        acceptAddressesAndPercentagesFunctionAdmin.data === true) && (
         <Button
           className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
           onClick={() =>
@@ -518,7 +516,7 @@ export default function NextGenAdmin() {
 
   function printPayArtist() {
     return (
-      (isGlobalAdmin() || (payArtistFunctionAdmin.data as any) === true) && (
+      (isGlobalAdmin() || payArtistFunctionAdmin.data === true) && (
         <Button
           className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
           onClick={() => setGlobalFocus(GlobalFocus.PAY_ARTIST)}
@@ -532,13 +530,11 @@ export default function NextGenAdmin() {
   function printPayActions() {
     return (
       (isGlobalAdmin() ||
-        (setSplitsFunctionAdmin.data as any) === true ||
-        (proposePrimaryAddressesAndPercentagesFunctionAdmin.data as any) ===
-          true ||
-        (proposeSecondaryAddressesAndPercentagesFunctionAdmin.data as any) ===
-          true ||
-        (acceptAddressesAndPercentagesFunctionAdmin.data as any) === true ||
-        (payArtistFunctionAdmin.data as any) === true) && (
+        setSplitsFunctionAdmin.data === true ||
+        proposePrimaryAddressesAndPercentagesFunctionAdmin.data === true ||
+        proposeSecondaryAddressesAndPercentagesFunctionAdmin.data === true ||
+        acceptAddressesAndPercentagesFunctionAdmin.data === true ||
+        payArtistFunctionAdmin.data === true) && (
         <>
           <Row className="tw-pt-6">
             <Col xs={12}>
@@ -594,20 +590,18 @@ export default function NextGenAdmin() {
   function printGlobal() {
     if (
       !isGlobalAdmin() &&
-      (createCollectionFunctionAdmin.data as any) === false &&
-      (airdropTokensFunctionAdmin.data as any) === false &&
-      (setSplitsFunctionAdmin.data as any) === false &&
-      (updateImagesAttributesFunctionAdmin.data as any) === false &&
-      (setFinalSupplyFunctionAdmin.data as any) === false &&
-      (initializeBurnFunctionAdmin.data as any) === false &&
-      (proposePrimaryAddressesAndPercentagesFunctionAdmin.data as any) ===
-        false &&
-      (proposeSecondaryAddressesAndPercentagesFunctionAdmin.data as any) ===
-        false &&
-      (acceptAddressesAndPercentagesFunctionAdmin.data as any) === false &&
-      (payArtistFunctionAdmin.data as any) === false &&
-      (mintAndAuctionFunctionAdmin.data as any) === false &&
-      (initializeExternalBurnSwapFunctionAdmin.data as any) === false
+      createCollectionFunctionAdmin.data === false &&
+      airdropTokensFunctionAdmin.data === false &&
+      setSplitsFunctionAdmin.data === false &&
+      updateImagesAttributesFunctionAdmin.data === false &&
+      setFinalSupplyFunctionAdmin.data === false &&
+      initializeBurnFunctionAdmin.data === false &&
+      proposePrimaryAddressesAndPercentagesFunctionAdmin.data === false &&
+      proposeSecondaryAddressesAndPercentagesFunctionAdmin.data === false &&
+      acceptAddressesAndPercentagesFunctionAdmin.data === false &&
+      payArtistFunctionAdmin.data === false &&
+      mintAndAuctionFunctionAdmin.data === false &&
+      initializeExternalBurnSwapFunctionAdmin.data === false
     ) {
       return printAdminRestrictionMessage();
     }
@@ -679,7 +673,7 @@ export default function NextGenAdmin() {
           </>
         )}
         {(isGlobalAdmin() ||
-          (addRandomizerFunctionAdmin.data as any) === true) && (
+          addRandomizerFunctionAdmin.data === true) && (
           <>
             <Row className="tw-pt-6">
               <Col xs={12}>
@@ -692,7 +686,7 @@ export default function NextGenAdmin() {
                 className="tw-flex tw-flex-wrap tw-items-center tw-gap-4 tw-pt-2"
               >
                 {(isGlobalAdmin() ||
-                  (addRandomizerFunctionAdmin.data as any) === true) && (
+                  addRandomizerFunctionAdmin.data === true) && (
                   <Button
                     className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
                     onClick={() => setGlobalFocus(GlobalFocus.ADD_RANDOMIZER)}
@@ -719,9 +713,9 @@ export default function NextGenAdmin() {
     return (
       (isGlobalAdmin() ||
         isWalletCollectionAdmin ||
-        (setDataFunctionAdmin.data as any) === true ||
-        (setCostsFunctionAdmin.data as any) === true ||
-        (setPhasesFunctionAdmin.data as any) === true) && (
+        setDataFunctionAdmin.data === true ||
+        setCostsFunctionAdmin.data === true ||
+        setPhasesFunctionAdmin.data === true) && (
         <>
           <Row className="tw-pt-6">
             <Col xs={12}>
@@ -735,7 +729,7 @@ export default function NextGenAdmin() {
             >
               {(isGlobalAdmin() ||
                 isWalletCollectionAdmin ||
-                (setDataFunctionAdmin.data as any) === true) && (
+                setDataFunctionAdmin.data === true) && (
                 <Button
                   className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
                   onClick={() => setCollectionFocus(CollectionFocus.SET_DATA)}
@@ -745,7 +739,7 @@ export default function NextGenAdmin() {
               )}
               {(isGlobalAdmin() ||
                 isWalletCollectionAdmin ||
-                (setCostsFunctionAdmin.data as any) === true) && (
+                setCostsFunctionAdmin.data === true) && (
                 <Button
                   className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
                   onClick={() => setCollectionFocus(CollectionFocus.SET_COSTS)}
@@ -755,7 +749,7 @@ export default function NextGenAdmin() {
               )}
               {(isGlobalAdmin() ||
                 isWalletCollectionAdmin ||
-                (setPhasesFunctionAdmin.data as any) === true) && (
+                setPhasesFunctionAdmin.data === true) && (
                 <>
                   <Button
                     className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
@@ -802,8 +796,8 @@ export default function NextGenAdmin() {
     return (
       (isGlobalAdmin() ||
         isWalletCollectionAdmin ||
-        (updateInfoFunctionAdmin.data as any) === true ||
-        (changeMetadataViewFunctionAdmin.data as any) === true) && (
+        updateInfoFunctionAdmin.data === true ||
+        changeMetadataViewFunctionAdmin.data === true) && (
         <>
           <Row className="tw-pt-6">
             <Col xs={12}>
@@ -817,7 +811,7 @@ export default function NextGenAdmin() {
             >
               {(isGlobalAdmin() ||
                 isWalletCollectionAdmin ||
-                (updateInfoFunctionAdmin.data as any) === true) && (
+                updateInfoFunctionAdmin.data === true) && (
                 <Button
                   className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
                   onClick={() =>
@@ -829,7 +823,7 @@ export default function NextGenAdmin() {
               )}
               {(isGlobalAdmin() ||
                 isWalletCollectionAdmin ||
-                (updateInfoFunctionAdmin.data as any) === true) && (
+                updateInfoFunctionAdmin.data === true) && (
                 <Button
                   className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
                   onClick={() =>
@@ -841,7 +835,7 @@ export default function NextGenAdmin() {
               )}
               {(isGlobalAdmin() ||
                 isWalletCollectionAdmin ||
-                (updateInfoFunctionAdmin.data as any) === true) && (
+                updateInfoFunctionAdmin.data === true) && (
                 <Button
                   className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
                   onClick={() =>
@@ -853,7 +847,7 @@ export default function NextGenAdmin() {
               )}
               {(isGlobalAdmin() ||
                 isWalletCollectionAdmin ||
-                (changeMetadataViewFunctionAdmin.data as any) === true) && (
+                changeMetadataViewFunctionAdmin.data === true) && (
                 <Button
                   className="tw-rounded-none tw-border-0 tw-bg-white tw-px-5 tw-py-1.5 tw-font-bold tw-text-black hover:tw-bg-[rgb(215,215,215)] disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
                   onClick={() =>
@@ -899,11 +893,11 @@ export default function NextGenAdmin() {
     if (
       !isGlobalAdmin() &&
       !isWalletCollectionAdmin &&
-      (setDataFunctionAdmin.data as any) === false &&
-      (setCostsFunctionAdmin.data as any) === false &&
-      (setPhasesFunctionAdmin.data as any) === false &&
-      (updateInfoFunctionAdmin.data as any) === false &&
-      (changeMetadataViewFunctionAdmin.data as any) === false
+      setDataFunctionAdmin.data === false &&
+      setCostsFunctionAdmin.data === false &&
+      setPhasesFunctionAdmin.data === false &&
+      updateInfoFunctionAdmin.data === false &&
+      changeMetadataViewFunctionAdmin.data === false
     ) {
       return printAdminRestrictionMessage();
     }
@@ -1014,7 +1008,7 @@ export default function NextGenAdmin() {
   }
 
   function isGlobalAdmin() {
-    return (globalAdmin.data as any) === true;
+    return globalAdmin.data === true;
   }
 
   return (

--- a/components/nextGen/admin/NextGenAdminAcceptAddressesAndPercentages.tsx
+++ b/components/nextGen/admin/NextGenAdminAcceptAddressesAndPercentages.tsx
@@ -89,7 +89,8 @@ export default function NextGenAdminAcceptAddressesAndPercentages(
   });
 
   useEffect(() => {
-    const d = primaryRead.data as readonly unknown[];
+    const d = primaryRead.data as readonly unknown[] | undefined;
+    if (!d) return;
     setPrimary1({
       address: String(d[0]),
       percentage: `${d[3]} %`,
@@ -117,7 +118,8 @@ export default function NextGenAdminAcceptAddressesAndPercentages(
   });
 
   useEffect(() => {
-    const d = secondaryRead.data as readonly unknown[];
+    const d = secondaryRead.data as readonly unknown[] | undefined;
+    if (!d) return;
     setSecondary1({
       address: String(d[0]),
       percentage: `${d[3]} %`,

--- a/components/nextGen/admin/NextGenAdminAcceptAddressesAndPercentages.tsx
+++ b/components/nextGen/admin/NextGenAdminAcceptAddressesAndPercentages.tsx
@@ -89,20 +89,20 @@ export default function NextGenAdminAcceptAddressesAndPercentages(
   });
 
   useEffect(() => {
-    const d = primaryRead.data as any[];
+    const d = primaryRead.data as readonly unknown[];
     setPrimary1({
-      address: d[0],
+      address: String(d[0]),
       percentage: `${d[3]} %`,
     });
     setPrimary2({
-      address: d[1],
+      address: String(d[1]),
       percentage: `${d[4]} %`,
     });
     setPrimary3({
-      address: d[2],
+      address: String(d[2]),
       percentage: `${d[5]} %`,
     });
-    setPrimaryStatus(d[6]);
+    setPrimaryStatus(d[6] as boolean);
   }, [primaryRead.data]);
 
   const secondaryRead = useReadContract({
@@ -117,20 +117,20 @@ export default function NextGenAdminAcceptAddressesAndPercentages(
   });
 
   useEffect(() => {
-    const d = secondaryRead.data as any[];
+    const d = secondaryRead.data as readonly unknown[];
     setSecondary1({
-      address: d[0],
+      address: String(d[0]),
       percentage: `${d[3]} %`,
     });
     setSecondary2({
-      address: d[1],
+      address: String(d[1]),
       percentage: `${d[4]} %`,
     });
     setSecondary3({
-      address: d[2],
+      address: String(d[2]),
       percentage: `${d[5]} %`,
     });
-    setSecondaryStatus(d[6]);
+    setSecondaryStatus(d[6] as boolean);
   }, [secondaryRead.data]);
 
   const contractWrite = useMinterContractWrite(

--- a/components/nextGen/admin/NextGenAdminAcceptAddressesAndPercentages.tsx
+++ b/components/nextGen/admin/NextGenAdminAcceptAddressesAndPercentages.tsx
@@ -55,8 +55,8 @@ export default function NextGenAdminAcceptAddressesAndPercentages(
   );
 
   const collectionIds = getCollectionIdsForAddress(
-    (globalAdmin.data as any) === true,
-    (functionAdmin.data as any) === true,
+    globalAdmin.data === true,
+    functionAdmin.data === true,
     collectionAdmin?.data,
     parsedCollectionIndex
   );

--- a/components/nextGen/admin/NextGenAdminAddRandomizer.tsx
+++ b/components/nextGen/admin/NextGenAdminAddRandomizer.tsx
@@ -47,8 +47,8 @@ export default function NextGenAdminUpdateRandomizer(props: Readonly<Props>) {
   );
 
   const collectionIds = getCollectionIdsForAddress(
-    (globalAdmin.data as any) === true,
-    (functionAdmin.data as any) === true,
+    globalAdmin.data === true,
+    functionAdmin.data === true,
     collectionAdmin.data,
     parsedCollectionIndex
   );

--- a/components/nextGen/admin/NextGenAdminAirdropTokens.tsx
+++ b/components/nextGen/admin/NextGenAdminAirdropTokens.tsx
@@ -43,8 +43,8 @@ export default function NextGenAdminAirdropTokens(props: Readonly<Props>) {
   );
 
   const collectionIds = getCollectionIdsForAddress(
-    (globalAdmin.data as any) === true,
-    (functionAdmin.data as any) === true,
+    globalAdmin.data === true,
+    functionAdmin.data === true,
     collectionAdmin.data,
     parsedCollectionIndex
   );

--- a/components/nextGen/admin/NextGenAdminArtistSignCollection.tsx
+++ b/components/nextGen/admin/NextGenAdminArtistSignCollection.tsx
@@ -127,7 +127,7 @@ export default function NextGenAdminArtistSignCollection(
                   rows={3}
                   placeholder="signature..."
                   value={signature}
-                  onChange={(e: any) => {
+                  onChange={(e) => {
                     setSignature(e.target.value);
                   }}
                 />

--- a/components/nextGen/admin/NextGenAdminChangeMetadataView.tsx
+++ b/components/nextGen/admin/NextGenAdminChangeMetadataView.tsx
@@ -74,7 +74,7 @@ export default function NextGenAdminChangeMetadataView(props: Readonly<Props>) {
   });
 
   useEffect(() => {
-    setStatus(metadataRead.data as any);
+    setStatus(metadataRead.data as boolean);
   }, [metadataRead.data]);
 
   const contractWrite = useCoreContractWrite("updateBaseURI", () => {

--- a/components/nextGen/admin/NextGenAdminChangeMetadataView.tsx
+++ b/components/nextGen/admin/NextGenAdminChangeMetadataView.tsx
@@ -49,8 +49,8 @@ export default function NextGenAdminChangeMetadataView(props: Readonly<Props>) {
   );
 
   const collectionIds = getCollectionIdsForAddress(
-    (globalAdmin.data as any) === true,
-    (functionAdmin.data as any) === true,
+    globalAdmin.data === true,
+    functionAdmin.data === true,
     collectionAdmin.data,
     parsedCollectionIndex
   );

--- a/components/nextGen/admin/NextGenAdminInitializeBurn.tsx
+++ b/components/nextGen/admin/NextGenAdminInitializeBurn.tsx
@@ -94,7 +94,7 @@ export default function NextGenAdminInitializeBurn(props: Readonly<Props>) {
   });
 
   useEffect(() => {
-    setStatus(burnRead.data as any);
+    setStatus(burnRead.data as boolean);
   }, [burnRead.data]);
 
   useEffect(() => {

--- a/components/nextGen/admin/NextGenAdminInitializeBurn.tsx
+++ b/components/nextGen/admin/NextGenAdminInitializeBurn.tsx
@@ -66,8 +66,8 @@ export default function NextGenAdminInitializeBurn(props: Readonly<Props>) {
   );
 
   const collectionIds = getCollectionIdsForAddress(
-    (globalAdmin.data as any) === true,
-    (functionAdmin.data as any) === true,
+    globalAdmin.data === true,
+    functionAdmin.data === true,
     collectionAdmin.data,
     parsedCollectionIndex
   );

--- a/components/nextGen/admin/NextGenAdminInitializeExternalBurnSwap.tsx
+++ b/components/nextGen/admin/NextGenAdminInitializeExternalBurnSwap.tsx
@@ -63,8 +63,8 @@ export default function NextGenAdminInitializeExternalBurnSwap(
   );
 
   const collectionIds = getCollectionIdsForAddress(
-    (globalAdmin.data as any) === true,
-    (functionAdmin.data as any) === true,
+    globalAdmin.data === true,
+    functionAdmin.data === true,
     collectionAdmin.data,
     parsedCollectionIndex
   );

--- a/components/nextGen/admin/NextGenAdminMintAndAuction.tsx
+++ b/components/nextGen/admin/NextGenAdminMintAndAuction.tsx
@@ -45,8 +45,8 @@ export default function NextGenAdminMintAndAuction(props: Readonly<Props>) {
   );
 
   const collectionIds = getCollectionIdsForAddress(
-    (globalAdmin.data as any) === true,
-    (functionAdmin.data as any) === true,
+    globalAdmin.data === true,
+    functionAdmin.data === true,
     collectionAdmin.data,
     parsedCollectionIndex
   );

--- a/components/nextGen/admin/NextGenAdminPayArtist.tsx
+++ b/components/nextGen/admin/NextGenAdminPayArtist.tsx
@@ -45,8 +45,8 @@ export default function NextGenAdminPayArtist(props: Readonly<Props>) {
   );
 
   const collectionIds = getCollectionIdsForAddress(
-    (globalAdmin.data as any) === true,
-    (functionAdmin.data as any) === true,
+    globalAdmin.data === true,
+    functionAdmin.data === true,
     collectionAdmin.data,
     parsedCollectionIndex
   );

--- a/components/nextGen/admin/NextGenAdminProposeAddressesAndPercentages.tsx
+++ b/components/nextGen/admin/NextGenAdminProposeAddressesAndPercentages.tsx
@@ -59,8 +59,8 @@ export default function NextGenAdminProposeAddressesAndPercentages(
   const collectionIndex = useCollectionIndex();
   const parsedCollectionIndex = useParsedCollectionIndex(collectionIndex);
   const collectionIds = getCollectionIdsForAddress(
-    (globalAdmin.data as any) === true,
-    (functionAdmin.data as any) === true,
+    globalAdmin.data === true,
+    functionAdmin.data === true,
     undefined,
     parsedCollectionIndex
   );

--- a/components/nextGen/admin/NextGenAdminRegisterAdmin.tsx
+++ b/components/nextGen/admin/NextGenAdminRegisterAdmin.tsx
@@ -161,7 +161,7 @@ export default function NextGenAdminRegisterAdmin(props: Readonly<Props>) {
                   as="select"
                   multiple
                   value={selectors}
-                  onChange={(e: any) => {
+                  onChange={(e) => {
                     if (selectors.includes(e.target.value)) {
                       setSelectors((selectors) =>
                         selectors.filter(

--- a/components/nextGen/admin/NextGenAdminRegisterAdmin.tsx
+++ b/components/nextGen/admin/NextGenAdminRegisterAdmin.tsx
@@ -77,7 +77,7 @@ export default function NextGenAdminRegisterAdmin(props: Readonly<Props>) {
   const collectionIndex = useCollectionIndex();
   const parsedCollectionIndex = useParsedCollectionIndex(collectionIndex);
   const collectionIds = getCollectionIdsForAddress(
-    (globalAdmin.data as any) === true,
+    globalAdmin.data === true,
     false,
     undefined,
     parsedCollectionIndex

--- a/components/nextGen/admin/NextGenAdminSetCosts.tsx
+++ b/components/nextGen/admin/NextGenAdminSetCosts.tsx
@@ -47,8 +47,8 @@ export default function NextGenAdminSetCosts(props: Readonly<Props>) {
   );
 
   const collectionIds = getCollectionIdsForAddress(
-    (globalAdmin.data as any) === true,
-    (functionAdmin.data as any) === true,
+    globalAdmin.data === true,
+    functionAdmin.data === true,
     collectionAdmin.data,
     parsedCollectionIndex
   );

--- a/components/nextGen/admin/NextGenAdminSetCosts.tsx
+++ b/components/nextGen/admin/NextGenAdminSetCosts.tsx
@@ -165,7 +165,7 @@ export default function NextGenAdminSetCosts(props: Readonly<Props>) {
                 type="integer"
                 placeholder="Cost in wei"
                 value={collectionStartCost}
-                onChange={(e: any) => setCollectionStartCost(e.target.value)}
+                onChange={(e) => setCollectionStartCost(e.target.value)}
               />
             </Form.Group>
             <Form.Group className="tw-mb-4">
@@ -174,7 +174,7 @@ export default function NextGenAdminSetCosts(props: Readonly<Props>) {
                 type="integer"
                 placeholder="Cost in wei"
                 value={collectionEndCost}
-                onChange={(e: any) => setCollectionEndCost(e.target.value)}
+                onChange={(e) => setCollectionEndCost(e.target.value)}
               />
             </Form.Group>
             <Form.Group className="tw-mb-4">
@@ -185,7 +185,7 @@ export default function NextGenAdminSetCosts(props: Readonly<Props>) {
                 type="integer"
                 placeholder="either % or in wei"
                 value={rate}
-                onChange={(e: any) => setRate(e.target.value)}
+                onChange={(e) => setRate(e.target.value)}
               />
             </Form.Group>
             <Form.Group className="tw-mb-4">
@@ -196,7 +196,7 @@ export default function NextGenAdminSetCosts(props: Readonly<Props>) {
                 type="integer"
                 placeholder="unix epoch time eg. 86400 (seconds in a day)"
                 value={timePeriod}
-                onChange={(e: any) => setTimePeriod(e.target.value)}
+                onChange={(e) => setTimePeriod(e.target.value)}
               />
             </Form.Group>
             <Form.Group className="tw-mb-4">
@@ -205,7 +205,7 @@ export default function NextGenAdminSetCosts(props: Readonly<Props>) {
                 type="integer"
                 placeholder="1. Fixed Price, 2. Exponential/Linear decrease, 3. Periodic Sale"
                 value={salesOption}
-                onChange={(e: any) => setSalesOption(e.target.value)}
+                onChange={(e) => setSalesOption(e.target.value)}
               />
             </Form.Group>
             <Form.Group className="tw-mb-4">
@@ -214,7 +214,7 @@ export default function NextGenAdminSetCosts(props: Readonly<Props>) {
                 type="integer"
                 placeholder="0x..."
                 value={delegationAddress}
-                onChange={(e: any) => setDelegationAddress(e.target.value)}
+                onChange={(e) => setDelegationAddress(e.target.value)}
               />
             </Form.Group>
             {!loading && errors.length > 0 && printAdminErrors(errors)}

--- a/components/nextGen/admin/NextGenAdminSetData.tsx
+++ b/components/nextGen/admin/NextGenAdminSetData.tsx
@@ -47,8 +47,8 @@ export default function NextGenAdminSetData(props: Readonly<Props>) {
   );
 
   const collectionIds = getCollectionIdsForAddress(
-    (globalAdmin.data as any) === true,
-    (functionAdmin.data as any) === true,
+    globalAdmin.data === true,
+    functionAdmin.data === true,
     collectionAdmin.data,
     parsedCollectionIndex
   );

--- a/components/nextGen/admin/NextGenAdminSetFinalSupply.tsx
+++ b/components/nextGen/admin/NextGenAdminSetFinalSupply.tsx
@@ -44,8 +44,8 @@ export default function NextGenAdminSetFinalSupply(props: Readonly<Props>) {
   );
 
   const collectionIds = getCollectionIdsForAddress(
-    (globalAdmin.data as any) === true,
-    (functionAdmin.data as any) === true,
+    globalAdmin.data === true,
+    functionAdmin.data === true,
     collectionAdmin.data,
     parsedCollectionIndex
   );

--- a/components/nextGen/admin/NextGenAdminSetPhases.tsx
+++ b/components/nextGen/admin/NextGenAdminSetPhases.tsx
@@ -257,7 +257,7 @@ export default function NextGenAdminSetPhases(props: Readonly<Props>) {
                 type="integer"
                 placeholder="Unix epoch time"
                 value={publicStartTime}
-                onChange={(e: any) => setPublicStartTime(e.target.value)}
+                onChange={(e) => setPublicStartTime(e.target.value)}
               />
             </Form.Group>
             <Form.Group className="tw-mb-4">
@@ -266,7 +266,7 @@ export default function NextGenAdminSetPhases(props: Readonly<Props>) {
                 type="integer"
                 placeholder="Unix epoch time"
                 value={publicEndTime}
-                onChange={(e: any) => setPublicEndTime(e.target.value)}
+                onChange={(e) => setPublicEndTime(e.target.value)}
               />
             </Form.Group>
             {!loading && errors.length > 0 && printAdminErrors(errors)}

--- a/components/nextGen/admin/NextGenAdminSetPhases.tsx
+++ b/components/nextGen/admin/NextGenAdminSetPhases.tsx
@@ -52,8 +52,8 @@ export default function NextGenAdminSetPhases(props: Readonly<Props>) {
   );
 
   const collectionIds = getCollectionIdsForAddress(
-    (globalAdmin.data as any) === true,
-    (functionAdmin.data as any) === true,
+    globalAdmin.data === true,
+    functionAdmin.data === true,
     collectionAdmin.data,
     parsedCollectionIndex
   );

--- a/components/nextGen/admin/NextGenAdminSetSplits.tsx
+++ b/components/nextGen/admin/NextGenAdminSetSplits.tsx
@@ -45,8 +45,8 @@ export default function NextGenAdminSetSplits(props: Readonly<Props>) {
   const collectionIndex = useCollectionIndex();
   const parsedCollectionIndex = useParsedCollectionIndex(collectionIndex);
   const collectionIds = getCollectionIdsForAddress(
-    (globalAdmin.data as any) === true,
-    (functionAdmin.data as any) === true,
+    globalAdmin.data === true,
+    functionAdmin.data === true,
     undefined,
     parsedCollectionIndex
   );

--- a/components/nextGen/admin/NextGenAdminShared.tsx
+++ b/components/nextGen/admin/NextGenAdminShared.tsx
@@ -380,7 +380,7 @@ export function NextGenAdminTextFormGroup(
         type="text"
         placeholder={`...${props.title}`}
         value={props.value}
-        onChange={(e: any) => props.setValue(e.target.value)}
+        onChange={(e) => props.setValue(e.target.value)}
       />
     </Form.Group>
   );

--- a/components/nextGen/admin/NextGenAdminUpdateCollection.tsx
+++ b/components/nextGen/admin/NextGenAdminUpdateCollection.tsx
@@ -59,8 +59,8 @@ export default function NextGenAdminUpdateCollection(props: Readonly<Props>) {
   );
 
   const collectionIds = getCollectionIdsForAddress(
-    (globalAdmin.data as any) === true,
-    (functionAdmin.data as any) === true,
+    globalAdmin.data === true,
+    functionAdmin.data === true,
     collectionAdmin.data,
     parsedCollectionIndex
   );

--- a/components/nextGen/admin/NextGenAdminUpdateCollection.tsx
+++ b/components/nextGen/admin/NextGenAdminUpdateCollection.tsx
@@ -305,9 +305,10 @@ export default function NextGenAdminUpdateCollection(props: Readonly<Props>) {
                   value={scriptIndex}
                   onChange={(e) => {
                     const i = e.target.value;
+                    const index = Number(i);
                     setScriptIndex(i);
-                    if (existingScripts.length > Number(i)) {
-                      setScripts([existingScripts[i as unknown as number]!]);
+                    if (existingScripts.length > index) {
+                      setScripts([existingScripts[index]!]);
                     } else {
                       setScripts([]);
                     }

--- a/components/nextGen/admin/NextGenAdminUpdateCollection.tsx
+++ b/components/nextGen/admin/NextGenAdminUpdateCollection.tsx
@@ -105,7 +105,7 @@ export default function NextGenAdminUpdateCollection(props: Readonly<Props>) {
   });
 
   function getParams() {
-    const params: any[] = [];
+    const params: (string | number | string[])[] = [];
     params.push(collectionID);
     params.push(collectionName);
     params.push(artist);
@@ -176,7 +176,7 @@ export default function NextGenAdminUpdateCollection(props: Readonly<Props>) {
   }
 
   function validateUpdateInfoInputs(errors: string[]): void {
-    const requiredFields: { value: any; message: string }[] = [
+    const requiredFields: { value: string; message: string }[] = [
       { value: collectionName, message: "Collection name is required" },
       { value: artist, message: "Artist is required" },
       { value: description, message: "Description is required" },
@@ -303,11 +303,11 @@ export default function NextGenAdminUpdateCollection(props: Readonly<Props>) {
                   type="text"
                   placeholder="...index"
                   value={scriptIndex}
-                  onChange={(e: any) => {
+                  onChange={(e) => {
                     const i = e.target.value;
                     setScriptIndex(i);
-                    if (existingScripts.length > i) {
-                      setScripts([existingScripts[i]!]);
+                    if (existingScripts.length > Number(i)) {
+                      setScripts([existingScripts[i as unknown as number]!]);
                     } else {
                       setScripts([]);
                     }

--- a/components/nextGen/admin/NextGenAdminUploadAL.tsx
+++ b/components/nextGen/admin/NextGenAdminUploadAL.tsx
@@ -61,8 +61,8 @@ export default function NextGenAdminUploadAL(props: Readonly<Props>) {
     parsedCollectionIndex
   );
   const collectionIds = getCollectionIdsForAddress(
-    (globalAdmin.data as any) === true,
-    (functionAdmin.data as any) === true,
+    globalAdmin.data === true,
+    functionAdmin.data === true,
     collectionAdmin.data,
     parsedCollectionIndex
   );

--- a/components/nextGen/admin/NextGenAdminUploadAL.tsx
+++ b/components/nextGen/admin/NextGenAdminUploadAL.tsx
@@ -227,7 +227,7 @@ export default function NextGenAdminUploadAL(props: Readonly<Props>) {
                 type="string"
                 placeholder="...Phase name"
                 value={phaseName}
-                onChange={(e: any) => setPhaseName(e.target.value)}
+                onChange={(e) => setPhaseName(e.target.value)}
               />
             </Form.Group>
             <Form.Group className="tw-mb-4">
@@ -235,7 +235,7 @@ export default function NextGenAdminUploadAL(props: Readonly<Props>) {
                 type="file"
                 accept={".csv"}
                 value={allowlistFile ? allowlistFile.fileName : ""}
-                onChange={(e: any) => {
+                onChange={(e) => {
                   if (e.target.files) {
                     const f = e.target.files[0];
                     setAllowlistFile(f);
@@ -249,7 +249,7 @@ export default function NextGenAdminUploadAL(props: Readonly<Props>) {
                 type="integer"
                 placeholder="Unix epoch time"
                 value={allowlistStartTime}
-                onChange={(e: any) => setAllowlistStartTime(e.target.value)}
+                onChange={(e) => setAllowlistStartTime(e.target.value)}
               />
             </Form.Group>
             <Form.Group className="tw-mb-4">
@@ -258,7 +258,7 @@ export default function NextGenAdminUploadAL(props: Readonly<Props>) {
                 type="integer"
                 placeholder="Unix epoch time"
                 value={allowlistEndTime}
-                onChange={(e: any) => setAllowlistEndTime(e.target.value)}
+                onChange={(e) => setAllowlistEndTime(e.target.value)}
               />
             </Form.Group>
             <Form.Group className="tw-mb-4">
@@ -267,7 +267,7 @@ export default function NextGenAdminUploadAL(props: Readonly<Props>) {
                 type="integer"
                 placeholder="...0.06529"
                 value={mintPrice}
-                onChange={(e: any) => setMintPrice(e.target.value)}
+                onChange={(e) => setMintPrice(e.target.value)}
               />
             </Form.Group>
             {!uploading && errors.length > 0 && printAdminErrors(errors)}

--- a/components/nextGen/collections/NextGenArtists.tsx
+++ b/components/nextGen/collections/NextGenArtists.tsx
@@ -17,9 +17,11 @@ export default function NextGenArtists() {
     let url = `${publicEnv.API_ENDPOINT}/api/nextgen/collections`;
     fetchUrl(url).then((response: DBResponse) => {
       setArtistCollections(
-        response.data.reduce((acc, collection) => {
+        response.data.reduce<
+          { address: string; collections: NextGenCollection[] }[]
+        >((acc, collection) => {
           if (
-            !acc.find((a: any) =>
+            !acc.find((a) =>
               areEqualAddresses(a.address, collection.artist_address)
             )
           ) {
@@ -43,8 +45,8 @@ export default function NextGenArtists() {
   }, []);
 
   return (
-    <div className="!tw-p-0 tw-pt-6 tw-pb-6 tw-mx-auto tw-w-full tw-px-3 max-[1100px]:tw-max-w-[950px] min-[1101px]:tw-max-w-[960px] min-[1200px]:tw-max-w-[1050px] min-[1300px]:tw-max-w-[1150px] min-[1400px]:tw-max-w-[1250px] min-[1500px]:tw-max-w-[1280px]">
-      <div className="tw-pb-4 -tw-mx-3 tw-flex tw-flex-wrap">
+    <div className="tw-mx-auto tw-w-full !tw-p-0 tw-px-3 tw-pb-6 tw-pt-6 max-[1100px]:tw-max-w-[950px] min-[1101px]:tw-max-w-[960px] min-[1200px]:tw-max-w-[1050px] min-[1300px]:tw-max-w-[1150px] min-[1400px]:tw-max-w-[1250px] min-[1500px]:tw-max-w-[1280px]">
+      <div className="-tw-mx-3 tw-flex tw-flex-wrap tw-pb-4">
         <div className="tw-relative tw-w-full tw-shrink-0 tw-grow tw-basis-0 tw-px-3">
           <h1>Artists</h1>
         </div>

--- a/components/nextGen/collections/NextGenNavigationHeader.tsx
+++ b/components/nextGen/collections/NextGenNavigationHeader.tsx
@@ -6,6 +6,7 @@ import CollectionsDropdown from "@/components/collections-dropdown/CollectionsDr
 import { LFGButton } from "@/components/lfg-slideshow/LFGSlideshow";
 import { NextgenView } from "@/types/enums";
 import Image from "next/image";
+import type { CSSProperties } from "react";
 import { useSyncExternalStore } from "react";
 
 const MOBILE_HEADER_MAX_WIDTH = 750;
@@ -41,7 +42,10 @@ export default function NextGenNavigationHeader(
   const isStackedHeader = headerViewportWidth <= STACKED_HEADER_MAX_WIDTH;
 
   function printView(v: NextgenView | undefined) {
-    let styles: any = { borderBottom: "1px solid white", cursor: "default" };
+    let styles: CSSProperties = {
+      borderBottom: "1px solid white",
+      cursor: "default",
+    };
     if (!props.setView || (!v && props.view) || (v && v !== props.view)) {
       styles = {};
     }

--- a/components/nextGen/collections/NextGenTokenList.tsx
+++ b/components/nextGen/collections/NextGenTokenList.tsx
@@ -71,7 +71,7 @@ export default function NextGenTokenList(props: Readonly<Props>) {
     commonApiFetch<{
       count: number;
       page: number;
-      next: any;
+      next: unknown;
       data: NextGenToken[];
     }>({
       endpoint: endpoint,
@@ -149,7 +149,7 @@ export default function NextGenTokenList(props: Readonly<Props>) {
   }, [props.sort, props.show_normalised, props.show_trait_count]);
 
   return (
-    <div className="!tw-p-0 tw-mx-auto tw-w-full tw-px-3 max-[1100px]:tw-max-w-[950px] min-[1101px]:tw-max-w-[960px] min-[1200px]:tw-max-w-[1050px] min-[1300px]:tw-max-w-[1150px] min-[1400px]:tw-max-w-[1250px] min-[1500px]:tw-max-w-[1280px]">
+    <div className="tw-mx-auto tw-w-full !tw-p-0 tw-px-3 max-[1100px]:tw-max-w-[950px] min-[1101px]:tw-max-w-[960px] min-[1200px]:tw-max-w-[1050px] min-[1300px]:tw-max-w-[1150px] min-[1400px]:tw-max-w-[1250px] min-[1500px]:tw-max-w-[1280px]">
       <div className="-tw-mx-3 tw-flex tw-flex-wrap">
         {(() => {
           if (tokensLoaded) {
@@ -157,7 +157,7 @@ export default function NextGenTokenList(props: Readonly<Props>) {
               return tokens.map((t) => (
                 <div
                   key={getRandomObjectId()}
-                  className="tw-pt-4 tw-pb-4 tw-relative tw-w-1/2 tw-shrink-0 tw-grow-0 tw-basis-auto tw-px-3 min-[576px]:tw-w-1/3 min-[576px]:tw-shrink-0 min-[576px]:tw-grow-0 min-[576px]:tw-basis-auto md:tw-w-1/3 md:tw-shrink-0 md:tw-grow-0 md:tw-basis-auto"
+                  className="tw-relative tw-w-1/2 tw-shrink-0 tw-grow-0 tw-basis-auto tw-px-3 tw-pb-4 tw-pt-4 min-[576px]:tw-w-1/3 min-[576px]:tw-shrink-0 min-[576px]:tw-grow-0 min-[576px]:tw-basis-auto md:tw-w-1/3 md:tw-shrink-0 md:tw-grow-0 md:tw-basis-auto"
                   style={{ maxWidth: "100%" }}
                 >
                   <NextGenTokenImage
@@ -177,14 +177,14 @@ export default function NextGenTokenList(props: Readonly<Props>) {
               ));
             } else {
               return (
-                <div className="tw-pt-2 tw-pb-2 tw-relative tw-w-full tw-shrink-0 tw-grow tw-basis-0 tw-px-3">
+                <div className="tw-relative tw-w-full tw-shrink-0 tw-grow tw-basis-0 tw-px-3 tw-pb-2 tw-pt-2">
                   No results found
                 </div>
               );
             }
           } else {
             return (
-              <div className="tw-pt-2 tw-pb-2 tw-relative tw-w-full tw-shrink-0 tw-grow tw-basis-0 tw-px-3">
+              <div className="tw-relative tw-w-full tw-shrink-0 tw-grow tw-basis-0 tw-px-3 tw-pb-2 tw-pt-2">
                 <DotLoader />
               </div>
             );
@@ -192,7 +192,7 @@ export default function NextGenTokenList(props: Readonly<Props>) {
         })()}
       </div>
       {totalResults > pageSize && tokensLoaded && props.show_pagination && (
-        <div className="tw-text-center tw-pt-6 tw-pb-6 -tw-mx-3 tw-flex tw-flex-wrap">
+        <div className="-tw-mx-3 tw-flex tw-flex-wrap tw-pb-6 tw-pt-6 tw-text-center">
           <Pagination
             page={page}
             pageSize={pageSize}

--- a/components/nextGen/collections/NextGenTokenOnChain.tsx
+++ b/components/nextGen/collections/NextGenTokenOnChain.tsx
@@ -81,7 +81,7 @@ export default function NextGenTokenOnChain(props: Readonly<Props>) {
   });
 
   useEffect(() => {
-    const data = ownerRead.data as any;
+    const data = ownerRead.data as `0x${string}` | undefined;
     if (data) {
       setOwner(data);
     }

--- a/components/nextGen/collections/collectionParts/NextGenCollectionHeader.tsx
+++ b/components/nextGen/collections/collectionParts/NextGenCollectionHeader.tsx
@@ -364,7 +364,7 @@ export function NextGenMintCounts(
   }, [collectionMintCount.isFetching]);
 
   useEffect(() => {
-    const mintC = parseInt(collectionMintCount.data as any);
+    const mintC = parseInt(String(collectionMintCount.data));
     setMintCount(mintC);
     const avail = props.collection.total_supply - mintC;
     setAvailable(avail);

--- a/components/nextGen/collections/collectionParts/NextGenCollectionProvenance.tsx
+++ b/components/nextGen/collections/collectionParts/NextGenCollectionProvenance.tsx
@@ -19,6 +19,7 @@ import { faExternalLinkSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Image from "next/image";
 import Link from "next/link";
+import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 import styles from "../NextGen.module.css";
 import {
@@ -45,7 +46,7 @@ export default function NextGenCollectionProvenance(props: Readonly<Props>) {
     commonApiFetch<{
       count: number;
       page: number;
-      next: any;
+      next: unknown;
       data: NextGenLog[];
     }>({
       endpoint: `nextgen/collections/${props.collection.id}/logs?page_size=${PAGE_SIZE}&page=${mypage}`,
@@ -164,7 +165,7 @@ export function NextGenCollectionProvenanceRow(
           </>
         );
 
-        let fromTo: any;
+        let fromTo: ReactNode;
         if (isTransaction) {
           fromTo = (
             <span className="tw-flex tw-gap-1">

--- a/components/nextGen/collections/collectionParts/hooks/useSlideshowAutoplay.ts
+++ b/components/nextGen/collections/collectionParts/hooks/useSlideshowAutoplay.ts
@@ -1,10 +1,11 @@
 import type { RefObject } from "react";
 import { useEffect, useState } from "react";
+import type SwiperClass from "swiper";
 import { useIntersectionObserver } from "@/hooks/scroll/useIntersectionObserver";
 
 interface UseSlideshowAutoplayReturn {
   isInViewport: boolean;
-  setSwiperInstance: (swiper: any) => void;
+  setSwiperInstance: (swiper: SwiperClass) => void;
 }
 
 export function useSlideshowAutoplay(

--- a/components/nextGen/collections/collectionParts/hooks/useTokenSlideshow.ts
+++ b/components/nextGen/collections/collectionParts/hooks/useTokenSlideshow.ts
@@ -28,13 +28,13 @@ export function useTokenSlideshow(
     commonApiFetch<{
       count: number;
       page: number;
-      next: any;
+      next: unknown;
       data: NextGenToken[];
     }>({
       endpoint: `nextgen/collections/${collectionId}/tokens?page_size=${FETCH_SIZE}&page=${currentPage}&sort=random`,
     }).then((response) => {
       setAllTokens((prev) => [...prev, ...response.data]);
-      setHasMoreOnServer(response.next);
+      setHasMoreOnServer(Boolean(response.next));
       setIsLoading(false);
     });
   }, [collectionId, currentPage]);

--- a/components/nextGen/collections/collectionParts/mint/NextGenCollectionMint.tsx
+++ b/components/nextGen/collections/collectionParts/mint/NextGenCollectionMint.tsx
@@ -31,9 +31,9 @@ export default function NextGenCollectionMint(props: Readonly<Props>) {
   });
 
   useEffect(() => {
-    const data = burnAmountRead.data as any;
+    const data = burnAmountRead.data;
     if (data) {
-      setBurnAmount(parseInt(data));
+      setBurnAmount(parseInt(String(data)));
     }
   }, [burnAmountRead.data]);
 
@@ -49,9 +49,9 @@ export default function NextGenCollectionMint(props: Readonly<Props>) {
   });
 
   useEffect(() => {
-    const data = mintPriceRead.data as any;
-    if (!isNaN(parseInt(data))) {
-      setMintPrice(parseInt(data));
+    const data = mintPriceRead.data;
+    if (!isNaN(parseInt(String(data)))) {
+      setMintPrice(parseInt(String(data)));
     }
   }, [mintPriceRead.data]);
 

--- a/components/nextGen/collections/collectionParts/mint/NextGenCollectionMint.tsx
+++ b/components/nextGen/collections/collectionParts/mint/NextGenCollectionMint.tsx
@@ -33,7 +33,7 @@ export default function NextGenCollectionMint(props: Readonly<Props>) {
   useEffect(() => {
     const data = burnAmountRead.data;
     if (data) {
-      setBurnAmount(parseInt(String(data)));
+      setBurnAmount(parseInt((data as bigint).toString()));
     }
   }, [burnAmountRead.data]);
 

--- a/components/nextGen/collections/collectionParts/mint/NextGenMint.tsx
+++ b/components/nextGen/collections/collectionParts/mint/NextGenMint.tsx
@@ -32,6 +32,7 @@ import { fetchUrl } from "@/services/6529api";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import type { Abi } from "viem";
 import { useReadContract, useReadContracts } from "wagmi";
 import {
   NextGenCountdown,
@@ -101,7 +102,7 @@ export default function NextGenMint(props: Readonly<Props>) {
     contracts: [
       {
         address: DELEGATION_CONTRACT.contract,
-        abi: DELEGATION_ABI as any,
+        abi: DELEGATION_ABI as Abi,
         chainId: DELEGATION_CONTRACT.chain_id,
         functionName: "retrieveDelegators",
         args: [
@@ -112,7 +113,7 @@ export default function NextGenMint(props: Readonly<Props>) {
       },
       {
         address: DELEGATION_CONTRACT.contract,
-        abi: DELEGATION_ABI as any,
+        abi: DELEGATION_ABI as Abi,
         chainId: DELEGATION_CONTRACT.chain_id,
         functionName: "retrieveDelegators",
         args: [
@@ -123,7 +124,7 @@ export default function NextGenMint(props: Readonly<Props>) {
       },
       {
         address: DELEGATION_CONTRACT.contract,
-        abi: DELEGATION_ABI as any,
+        abi: DELEGATION_ABI as Abi,
         chainId: DELEGATION_CONTRACT.chain_id,
         functionName: "retrieveDelegators",
         args: [
@@ -134,7 +135,7 @@ export default function NextGenMint(props: Readonly<Props>) {
       },
       {
         address: DELEGATION_CONTRACT.contract,
-        abi: DELEGATION_ABI as any,
+        abi: DELEGATION_ABI as Abi,
         chainId: DELEGATION_CONTRACT.chain_id,
         functionName: "retrieveDelegators",
         args: [
@@ -154,12 +155,11 @@ export default function NextGenMint(props: Readonly<Props>) {
   });
 
   useEffect(() => {
-    const data = delegationsRead.data as any;
+    const data = delegationsRead.data;
     if (data) {
       const del: string[] = [];
-      const d = data as any[];
-      d.forEach((r) => {
-        r.result.forEach((a: string) => del.push(a));
+      data.forEach((r) => {
+        (r.result as string[]).forEach((a) => del.push(a));
       });
       setDelegators(del);
     }
@@ -182,9 +182,9 @@ export default function NextGenMint(props: Readonly<Props>) {
   });
 
   useEffect(() => {
-    const data = addressMintCountAirdropRead.data as any;
+    const data = addressMintCountAirdropRead.data;
     if (data) {
-      const air = parseInt(data);
+      const air = parseInt(String(data));
       setAddressMintCounts((amc) => {
         amc.airdrop = air;
         amc.total = amc.airdrop + amc.allowlist + amc.public;
@@ -199,9 +199,9 @@ export default function NextGenMint(props: Readonly<Props>) {
   });
 
   useEffect(() => {
-    const data = addressMintCountMintedALRead.data as any;
+    const data = addressMintCountMintedALRead.data;
     if (data) {
-      const allow = parseInt(data);
+      const allow = parseInt(String(data));
       setAddressMintCounts((amc) => {
         amc.allowlist = allow;
         amc.total = amc.airdrop + amc.allowlist + amc.public;
@@ -216,9 +216,9 @@ export default function NextGenMint(props: Readonly<Props>) {
   });
 
   useEffect(() => {
-    const data = addressMintCountMintedPublicRead.data as any;
+    const data = addressMintCountMintedPublicRead.data;
     if (data) {
-      const pub = parseInt(data);
+      const pub = parseInt(String(data));
       setAddressMintCounts((amc) => {
         amc.public = pub;
         amc.total = amc.airdrop + amc.allowlist + amc.public;

--- a/components/nextGen/collections/collectionParts/mint/NextGenMint.tsx
+++ b/components/nextGen/collections/collectionParts/mint/NextGenMint.tsx
@@ -184,7 +184,7 @@ export default function NextGenMint(props: Readonly<Props>) {
   useEffect(() => {
     const data = addressMintCountAirdropRead.data;
     if (data) {
-      const air = parseInt(String(data));
+      const air = parseInt((data as bigint).toString());
       setAddressMintCounts((amc) => {
         amc.airdrop = air;
         amc.total = amc.airdrop + amc.allowlist + amc.public;
@@ -201,7 +201,7 @@ export default function NextGenMint(props: Readonly<Props>) {
   useEffect(() => {
     const data = addressMintCountMintedALRead.data;
     if (data) {
-      const allow = parseInt(String(data));
+      const allow = parseInt((data as bigint).toString());
       setAddressMintCounts((amc) => {
         amc.allowlist = allow;
         amc.total = amc.airdrop + amc.allowlist + amc.public;
@@ -218,7 +218,7 @@ export default function NextGenMint(props: Readonly<Props>) {
   useEffect(() => {
     const data = addressMintCountMintedPublicRead.data;
     if (data) {
-      const pub = parseInt(String(data));
+      const pub = parseInt((data as bigint).toString());
       setAddressMintCounts((amc) => {
         amc.public = pub;
         amc.total = amc.airdrop + amc.allowlist + amc.public;

--- a/components/nextGen/collections/collectionParts/mint/NextGenMintWidget.tsx
+++ b/components/nextGen/collections/collectionParts/mint/NextGenMintWidget.tsx
@@ -36,8 +36,8 @@ import { useChainId, useEnsAddress, useEnsName, useWriteContract } from "wagmi";
 import { Spinner } from "./NextGenMint";
 import { NextGenMintErrors, NextGenMintingFor } from "./NextGenMintShared";
 
-export function getJsonData(keccak: string, data: string) {
-  const parsed = JSON.parse(data);
+export function getJsonData(keccak: string, data: unknown) {
+  const parsed = JSON.parse(String(data));
   const results: any[] = [];
   Object.entries(parsed).forEach(([key, value]) => {
     results.push({

--- a/components/nextGen/collections/collectionParts/mint/NextGenMintWidget.tsx
+++ b/components/nextGen/collections/collectionParts/mint/NextGenMintWidget.tsx
@@ -30,6 +30,7 @@ import {
 import { fetchUrl } from "@/services/6529api";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { Tooltip } from "react-tooltip";
 import { useChainId, useEnsAddress, useEnsName, useWriteContract } from "wagmi";
@@ -38,7 +39,7 @@ import { NextGenMintErrors, NextGenMintingFor } from "./NextGenMintShared";
 
 export function getJsonData(keccak: string, data: unknown) {
   const parsed = JSON.parse(String(data));
-  const results: any[] = [];
+  const results: { key: string; value: unknown }[] = [];
   Object.entries(parsed).forEach(([key, value]) => {
     results.push({
       key,
@@ -49,7 +50,7 @@ export function getJsonData(keccak: string, data: unknown) {
     <ul className="tw-mb-0">
       {results.map((r) => (
         <li key={`ul-${keccak}-${r.key}-${r.value}`}>
-          {capitalizeFirstChar(r.key)}: {r.value}
+          {capitalizeFirstChar(r.key)}: {r.value as ReactNode}
         </li>
       ))}
     </ul>
@@ -543,7 +544,7 @@ export default function NextGenMintWidget(props: Readonly<Props>) {
                   currentProof.proof.spots <= 0) ||
                 disableMint()
               }
-              onChange={(e: any) => {
+              onChange={(e) => {
                 setMintCount(parseInt(e.currentTarget.value));
               }}
             >

--- a/components/nextGen/collections/collectionParts/mint/NextgenCollectionMintingPlan.tsx
+++ b/components/nextGen/collections/collectionParts/mint/NextgenCollectionMintingPlan.tsx
@@ -78,7 +78,7 @@ export default function NextgenCollectionMintingPlan(props: Readonly<Props>) {
     commonApiFetch<{
       count: number;
       page: number;
-      next: any;
+      next: unknown;
       data: NextgenAllowlist[];
     }>({
       endpoint: `nextgen/${props.collection.id}/allowlist_merkle/${

--- a/components/nextGen/collections/nextgenToken/NextGenTokenArt.tsx
+++ b/components/nextGen/collections/nextgenToken/NextGenTokenArt.tsx
@@ -86,11 +86,11 @@ export default function NextGenTokenArt(props: Readonly<Props>) {
   const [zoomScale, setZoomScale] = useState(1);
   const [showZoomControls, setShowZoomControls] = useState(false);
 
-  const tokenImageRef = useRef(null);
+  const tokenImageRef = useRef<HTMLDivElement>(null);
   const downloadMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const handleKeyDown = (event: any) => {
+    const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         setShowLightbox(false);
         setShowBlackbox(false);
@@ -399,9 +399,10 @@ export default function NextGenTokenArt(props: Readonly<Props>) {
   const toggleFullScreen = () => {
     if (tokenImageRef.current) {
       if (!document.fullscreenElement) {
-        (tokenImageRef.current as any).requestFullscreen().catch((err: any) => {
+        tokenImageRef.current.requestFullscreen().catch((err: unknown) => {
+          const error = err as { message?: unknown; name?: unknown };
           alert(
-            `Error attempting to enable full-screen mode: ${err.message} (${err.name})`
+            `Error attempting to enable full-screen mode: ${error.message} (${error.name})`
           );
         });
       } else {

--- a/components/nextGen/collections/nextgenToken/NextGenTokenProvenance.tsx
+++ b/components/nextGen/collections/nextgenToken/NextGenTokenProvenance.tsx
@@ -35,7 +35,7 @@ export default function NextGenTokenProvenance(props: Readonly<Props>) {
     commonApiFetch<{
       count: number;
       page: number;
-      next: any;
+      next: unknown;
       data: Transaction[];
     }>({
       endpoint: `nextgen/tokens/${props.token_id}/transactions?page_size=${PAGE_SIZE}&page=${mypage}`,
@@ -55,7 +55,7 @@ export default function NextGenTokenProvenance(props: Readonly<Props>) {
     commonApiFetch<{
       count: number;
       page: number;
-      next: any;
+      next: unknown;
       data: NextGenLog[];
     }>({
       endpoint: `nextgen/collections/${props.collection.id}/logs/${props.token_id}?page_size=${PAGE_SIZE}&page=${mypage}`,

--- a/components/nextGen/nextgen_contracts.ts
+++ b/components/nextGen/nextgen_contracts.ts
@@ -4,13 +4,14 @@ import {
   NEXTGEN_MINTER_ABI,
 } from "@/abis/abis";
 import { publicEnv } from "@/config/env";
+import type { Abi } from "viem";
 import { goerli, mainnet, sepolia } from "viem/chains";
 
 export interface NextGenContract {
   [goerli.id]: string;
   [sepolia.id]: string;
   [mainnet.id]: string;
-  abi: any;
+  abi: Abi;
 }
 
 function getNextGenChainId() {

--- a/components/nextGen/nextgen_entities.ts
+++ b/components/nextGen/nextgen_entities.ts
@@ -56,7 +56,7 @@ export enum AllowlistType {
 export interface CollectionWithMerkle {
   collection_id: number;
   merkle_root: string;
-  merkle_tree: any;
+  merkle_tree: unknown;
   al_type: AllowlistType;
   phase: string;
   burn_collection: string;
@@ -69,7 +69,7 @@ export interface CollectionWithMerkle {
 
 export interface ProofResponseBurn {
   keccak: string;
-  info: any;
+  info: unknown;
   proof: string[];
 }
 

--- a/components/nextGen/nextgen_helpers.ts
+++ b/components/nextGen/nextgen_helpers.ts
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { formatNameForUrl, normalizeNextgenTokenID } from "@/helpers/nextgen-utils";
 import { goerli, mainnet, sepolia } from "viem/chains";
+import type { Abi } from "viem";
 import { useReadContract, useReadContracts, useWriteContract } from "wagmi";
 import { areEqualAddresses } from "@/helpers/Helpers";
 import { useSeizeConnectContext } from "../auth/SeizeConnectContext";
@@ -61,16 +62,26 @@ export function useCollectionIndex() {
   });
 }
 
-export function useParsedCollectionIndex(collectionIndex: any) {
+export function useParsedCollectionIndex(
+  collectionIndex: { data?: unknown } | undefined
+) {
   const collectionIndexData = collectionIndex?.data;
-  return collectionIndexData ? parseInt(collectionIndexData.toString()) : 0;
+  return collectionIndexData ? parseInt(String(collectionIndexData)) : 0;
+}
+
+interface NextGenReadParams {
+  address: `0x${string}`;
+  abi: Abi;
+  chainId: number;
+  functionName: string;
+  args: (string | number)[];
 }
 
 function getCollectionAdminReadParams(
   collectionIndex: number,
   address: string
 ) {
-  const params: any = [];
+  const params: NextGenReadParams[] = [];
   for (let i = 1; i <= collectionIndex - 1; i++) {
     params.push({
       address: NEXTGEN_ADMIN[NEXTGEN_CHAIN_ID] as `0x${string}`,
@@ -89,12 +100,16 @@ export function useCollectionAdmin(address: string, collectionIndex: number) {
   });
 }
 
-export function isCollectionAdmin(collectionAdmin: any) {
-  return collectionAdmin?.data?.some((d: any) => d.result === true);
+type ContractReadResults =
+  | { data?: readonly { result?: unknown }[] | undefined }
+  | undefined;
+
+export function isCollectionAdmin(collectionAdmin: ContractReadResults) {
+  return collectionAdmin?.data?.some((d) => d.result === true);
 }
 
 function getCollectionArtistReadParams(collectionIndex: number) {
-  const params: any = [];
+  const params: NextGenReadParams[] = [];
   for (let i = 1; i <= collectionIndex - 1; i++) {
     params.push({
       address: NEXTGEN_CORE[NEXTGEN_CHAIN_ID] as `0x${string}`,
@@ -113,8 +128,11 @@ export function useCollectionArtist(collectionIndex: number) {
   });
 }
 
-export function isCollectionArtist(address: string, collectionArtists: any) {
-  return collectionArtists?.data?.some((a: any) =>
+export function isCollectionArtist(
+  address: string,
+  collectionArtists: ContractReadResults
+) {
+  return collectionArtists?.data?.some((a) =>
     areEqualAddresses(address, a.result)
   );
 }
@@ -122,7 +140,10 @@ export function isCollectionArtist(address: string, collectionArtists: any) {
 export function getCollectionIdsForAddress(
   globalAdmin: boolean,
   functionAdmin: boolean,
-  collectionAdmin: any,
+  // Callers pass either the whole useReadContracts result or its `.data`
+  // array. The array form has no `.data`, so (as before this was typed) it
+  // contributes no collection ids; only the result-object form does.
+  collectionAdmin: ContractReadResults | readonly { result?: unknown }[],
   collectionIndex: number
 ) {
   const collectionIndexArray: string[] = [];
@@ -130,8 +151,12 @@ export function getCollectionIdsForAddress(
     for (let i = 1; i <= collectionIndex - 1; i++) {
       collectionIndexArray.push(i.toString());
     }
-  } else if (collectionAdmin?.data) {
-    collectionAdmin.data.forEach((d: any, i: number) => {
+  } else if (
+    collectionAdmin &&
+    "data" in collectionAdmin &&
+    collectionAdmin.data
+  ) {
+    collectionAdmin.data.forEach((d, i) => {
       if (d.result === true) {
         collectionIndexArray.push((i + 1).toString());
       }
@@ -143,7 +168,7 @@ export function getCollectionIdsForAddress(
 
 export function useCollectionPhases(
   collection: number | string,
-  callback: (data: any) => void,
+  callback: (data: PhaseTimes) => void,
   watch: boolean = false
 ) {
   const { data, error, isLoading } = useReadContract({
@@ -159,7 +184,7 @@ export function useCollectionPhases(
 
   useEffect(() => {
     if (data) {
-      callback(extractPhases(data as any[]));
+      callback(extractPhases(data as readonly unknown[]));
     }
   }, [data, callback]);
 
@@ -168,7 +193,7 @@ export function useCollectionPhases(
 
 export function useCollectionAdditionalData(
   collection: number | string,
-  callback: (data: any) => void,
+  callback: (data: AdditionalData) => void,
   watch: boolean = false
 ) {
   const { data, error, isLoading } = useReadContract({
@@ -184,14 +209,14 @@ export function useCollectionAdditionalData(
 
   useEffect(() => {
     if (data) {
-      const d = data as any[];
+      const d = data as readonly unknown[];
       const ad: AdditionalData = {
-        artist_address: d[0],
-        max_purchases: parseInt(d[1]),
-        circulation_supply: parseInt(d[2]),
-        total_supply: parseInt(d[3]),
-        final_supply_after_mint: parseInt(d[4]),
-        randomizer: d[5],
+        artist_address: String(d[0]),
+        max_purchases: parseInt(String(d[1])),
+        circulation_supply: parseInt(String(d[2])),
+        total_supply: parseInt(String(d[3])),
+        final_supply_after_mint: parseInt(String(d[4])),
+        randomizer: String(d[5]),
       };
       callback(ad);
     }
@@ -202,7 +227,7 @@ export function useCollectionAdditionalData(
 
 export function useCollectionInfo(
   collection: number | string,
-  callback: (data: any) => void,
+  callback: (data: Info) => void,
   watch: boolean = false
 ) {
   const { data, error, isLoading } = useReadContract({
@@ -218,15 +243,15 @@ export function useCollectionInfo(
 
   useEffect(() => {
     if (data) {
-      const d = data as any[];
+      const d = data as readonly unknown[];
       if (d.some((e) => e)) {
         const i1: Info = {
-          name: d[0],
-          artist: d[1],
-          description: d[2],
-          website: d[3],
-          licence: d[4],
-          base_uri: d[5],
+          name: String(d[0]),
+          artist: String(d[1]),
+          description: String(d[2]),
+          website: String(d[3]),
+          licence: String(d[4]),
+          base_uri: String(d[5]),
         };
         callback(i1);
       }
@@ -238,7 +263,7 @@ export function useCollectionInfo(
 
 export function useCollectionLibraryAndScript(
   collection: number | string,
-  callback: (data: any) => void,
+  callback: (data: LibraryScript) => void,
   watch: boolean = false
 ) {
   const { data, error, isLoading } = useReadContract({
@@ -254,11 +279,11 @@ export function useCollectionLibraryAndScript(
 
   useEffect(() => {
     if (data) {
-      const d = data as any[];
+      const d = data as readonly unknown[];
       const ls: LibraryScript = {
-        library: d[0],
-        dependency_script: d[1],
-        script: d[2],
+        library: String(d[0]),
+        dependency_script: String(d[1]),
+        script: d[2] as string[],
       };
       callback(ls);
     }
@@ -269,7 +294,7 @@ export function useCollectionLibraryAndScript(
 
 export function useCollectionCosts(
   collection: number | string,
-  callback: (data: any) => void,
+  callback: (data: MintingDetails) => void,
   watch: boolean = false
 ) {
   const { data, error, isLoading } = useReadContract({
@@ -286,14 +311,14 @@ export function useCollectionCosts(
 
   useEffect(() => {
     if (data) {
-      const d = data as any[];
+      const d = data as readonly unknown[];
       const md: MintingDetails = {
-        mint_cost: parseInt(d[1]),
-        end_mint_cost: parseInt(d[1]),
-        rate: parseInt(d[2]),
-        time_period: parseInt(d[3]),
-        sales_option: parseInt(d[4]),
-        del_address: d[5],
+        mint_cost: parseInt(String(d[1])),
+        end_mint_cost: parseInt(String(d[1])),
+        rate: parseInt(String(d[2])),
+        time_period: parseInt(String(d[3])),
+        sales_option: parseInt(String(d[4])),
+        del_address: String(d[5]),
       };
       callback(md);
     }
@@ -333,11 +358,11 @@ export function getStatusFromDates(startTime: number, endTime: number) {
   return Status.UNAVAILABLE;
 }
 
-function extractPhases(d: any[]) {
-  const al_start = parseInt(d[0]);
-  const al_end = parseInt(d[1]);
-  const public_start = parseInt(d[3]);
-  const public_end = parseInt(d[4]);
+function extractPhases(d: readonly unknown[]) {
+  const al_start = parseInt(String(d[0]));
+  const al_end = parseInt(String(d[1]));
+  const public_start = parseInt(String(d[3]));
+  const public_end = parseInt(String(d[4]));
 
   const alStatus = getStatusFromDates(al_start, al_end);
   const publicStatus = getStatusFromDates(public_start, public_end);
@@ -345,7 +370,7 @@ function extractPhases(d: any[]) {
   const phases: PhaseTimes = {
     allowlist_start_time: al_start,
     allowlist_end_time: al_end,
-    merkle_root: d[2],
+    merkle_root: String(d[2]),
     public_start_time: public_start,
     public_end_time: public_end,
     al_status: alStatus,

--- a/components/nextGen/nextgen_helpers.ts
+++ b/components/nextGen/nextgen_helpers.ts
@@ -66,7 +66,9 @@ export function useParsedCollectionIndex(
   collectionIndex: { data?: unknown } | undefined
 ) {
   const collectionIndexData = collectionIndex?.data;
-  return collectionIndexData ? parseInt(String(collectionIndexData)) : 0;
+  return collectionIndexData
+    ? parseInt((collectionIndexData as bigint).toString())
+    : 0;
 }
 
 interface NextGenReadParams {

--- a/components/nft-attributes/NFTAttributes.tsx
+++ b/components/nft-attributes/NFTAttributes.tsx
@@ -7,7 +7,7 @@ export default function NFTAttributes(
 ) {
   return (
     <div className="tw-grid tw-grid-cols-2 sm:tw-grid-cols-4 md:tw-grid-cols-6 lg:tw-grid-cols-6">
-      {props.attributes.map((a: any) => (
+      {props.attributes.map((a) => (
         <div key={a.trait_type} className="tw-py-2">
           <div className="tw-px-3">
             <div className="tw-overflow-hidden tw-text-ellipsis tw-whitespace-nowrap tw-rounded-md tw-border tw-border-solid tw-border-white tw-py-2 tw-text-center">
@@ -17,7 +17,7 @@ export default function NFTAttributes(
               <br />
               <span
                 className="tw-whitespace-nowrap tw-text-[15px] tw-font-bold"
-                title={a.value}
+                title={String(a.value)}
               >
                 {a.value}
               </span>

--- a/components/nft-image/declarations.d.ts
+++ b/components/nft-image/declarations.d.ts
@@ -3,9 +3,12 @@ declare namespace JSX {
     "model-viewer": ModelViewerElementAttributes;
   }
 
-  interface ModelViewerElementAttributes
-    extends React.HTMLAttributes<HTMLElement> {
-    ref?: React.RefObject<any> | React.MutableRefObject<any> | ((instance: any) => void) | null;
+  interface ModelViewerElementAttributes extends React.HTMLAttributes<HTMLElement> {
+    ref?:
+      | React.RefObject<HTMLElement | null>
+      | React.MutableRefObject<HTMLElement | null>
+      | ((instance: HTMLElement | null) => void)
+      | null;
     src?: string;
     alt?: string;
     "auto-rotate"?: boolean;

--- a/components/nft-picker/index.tsx
+++ b/components/nft-picker/index.tsx
@@ -3,7 +3,12 @@
 import { useRef, useId, useMemo, useEffect, useState } from "react";
 import clsx from "clsx";
 
-import type { NftPickerProps, Suggestion, SupportedChain } from "./types";
+import type {
+  NftPickerProps,
+  ParseError,
+  Suggestion,
+  SupportedChain,
+} from "./types";
 import { mapSuggestionToOverview } from "./utils/mappers";
 import {
   BIGINT_ONE,
@@ -31,7 +36,7 @@ const DEFAULT_CHAIN: SupportedChain = "ethereum";
 type MaxSelectedCountValidationSource = "add-input" | "text-editor";
 
 function ensureChain(value?: string): SupportedChain {
-  return (value as any) ?? DEFAULT_CHAIN;
+  return (value as SupportedChain | undefined) ?? DEFAULT_CHAIN;
 }
 
 function countRanges(
@@ -332,7 +337,7 @@ export function NftPicker(props: Readonly<NftPickerProps>) {
       setIsEditingText(false);
     } catch (error) {
       if (Array.isArray(error)) {
-        setParseErrors(error as any);
+        setParseErrors(error as ParseError[]);
       }
     }
   };

--- a/components/nft-transfer/TransferModal.tsx
+++ b/components/nft-transfer/TransferModal.tsx
@@ -19,7 +19,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Link from "next/link";
 import { createPortal } from "react-dom";
-import type { Address, PublicClient } from "viem";
+import type { Address, PublicClient, WalletClient } from "viem";
 import { isAddress, type WriteContractParameters } from "viem";
 import { useAccount, usePublicClient, useWalletClient } from "wagmi";
 
@@ -110,8 +110,10 @@ const waitForPaint = async () => {
   await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 };
 
-function hasWriteContract(client: any): client is WalletClientWithWrite {
-  return client && typeof client.writeContract === "function";
+function hasWriteContract(
+  client: WalletClient | undefined
+): client is WalletClient & WalletClientWithWrite {
+  return !!client && typeof client.writeContract === "function";
 }
 
 function computeFlowTitle(
@@ -264,7 +266,6 @@ function SelectedSummaryList({
     </div>
   );
 }
-
 
 function TxStatusList({
   txs,
@@ -857,8 +858,13 @@ export default function TransferModal({
             )
           );
           await waitForPaint();
-        } catch (e: any) {
+        } catch (e) {
           console.error("Error in batch 1155 transfer", e);
+          const record = e as {
+            details?: unknown;
+            shortMessage?: unknown;
+            message?: unknown;
+          } | null;
           setTxs((prev) =>
             prev.map((te) =>
               te.id === `${key}-batch`
@@ -866,7 +872,8 @@ export default function TransferModal({
                     ...te,
                     state: "error",
                     error: String(
-                      e?.details ?? (e?.shortMessage || e?.message || e)
+                      record?.details ??
+                        (record?.shortMessage || record?.message || e)
                     ),
                   }
                 : te
@@ -915,21 +922,31 @@ export default function TransferModal({
                 )
               );
               await waitForPaint();
-            } catch (e: any) {
+            } catch (e) {
               console.error("Error in 721 transfer", e);
+              const record = e as {
+                shortMessage?: unknown;
+                message?: unknown;
+              } | null;
               setTxs((prev) =>
                 prev.map((te) =>
                   te.id === tid
                     ? {
                         ...te,
                         state: "error",
-                        error: String(e?.shortMessage || e?.message || e),
+                        error: String(
+                          record?.shortMessage || record?.message || e
+                        ),
                       }
                     : te
                 )
               );
             }
-          } catch (error: any) {
+          } catch (error) {
+            const record = error as {
+              shortMessage?: unknown;
+              message?: unknown;
+            } | null;
             setTxs((prev) =>
               prev.map((te) =>
                 te.id === tid
@@ -937,7 +954,7 @@ export default function TransferModal({
                       ...te,
                       state: "error",
                       error: String(
-                        error?.shortMessage || error?.message || error
+                        record?.shortMessage || record?.message || error
                       ),
                     }
                   : te

--- a/components/pagination/Pagination.tsx
+++ b/components/pagination/Pagination.tsx
@@ -13,13 +13,13 @@ interface Props {
   page: number;
   pageSize: number;
   totalResults: number;
-  setPage(page: number): any;
+  setPage(page: number): void;
 }
 
 export interface Paginated<T> {
   count: number;
   page: number;
-  next: any;
+  next: unknown;
   data: T[];
 }
 

--- a/components/rememes/RememeAddComponent.tsx
+++ b/components/rememes/RememeAddComponent.tsx
@@ -158,8 +158,9 @@ export default function RememeAddComponent(props: Readonly<Props>) {
             references.map((r) => r.id)
           );
         }
-      } catch (e: any) {
-        setVerificationErrors([e.message]);
+      } catch (e) {
+        const record = e as { message?: unknown } | null;
+        setVerificationErrors([String(record?.message)]);
       }
     } else {
       setVerificationErrors(["Invalid token ID(s)"]);

--- a/components/the-memes/ArtistProfileHandle.tsx
+++ b/components/the-memes/ArtistProfileHandle.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import type { ReactNode } from "react";
 import type { BaseNFT } from "@/entities/INFT";
 
 export default function ArtistProfileHandle(
@@ -8,15 +9,15 @@ export default function ArtistProfileHandle(
 ) {
   if (props.nft.artist_seize_handle) {
     const handles = props.nft.artist_seize_handle.split(",");
-    const handleElements = handles.reduce((acc: any, handle, index) => {
-      handle = handle.trim();
+    const handleElements = handles.reduce<ReactNode[]>((acc, handle, index) => {
+      const trimmedHandle = handle.trim();
       acc.push(
         <Link
-          href={`/${handle}`}
-          key={handle}
+          href={`/${trimmedHandle}`}
+          key={trimmedHandle}
           className="tw-no-underline"
         >
-          {handle}
+          {trimmedHandle}
         </Link>
       );
       if (index < handles.length - 1) {

--- a/components/timeline/Timeline.tsx
+++ b/components/timeline/Timeline.tsx
@@ -41,12 +41,10 @@ export default function Timeline(props: Readonly<Props>) {
   };
 
   const getType = () => {
-    if (props.nft.metadata.animation_details?.format === "HTML") {
+    const format = props.nft.metadata?.animation_details?.format;
+    if (format === "HTML") {
       return MediaType.HTML;
-    } else if (
-      props.nft.metadata.animation_details?.format === "MP4" ||
-      props.nft.metadata.animation_details?.format === "MOV"
-    ) {
+    } else if (format === "MP4" || format === "MOV") {
       return MediaType.VIDEO;
     } else {
       return MediaType.IMAGE;

--- a/components/timeline/Timeline.tsx
+++ b/components/timeline/Timeline.tsx
@@ -70,7 +70,7 @@ export default function Timeline(props: Readonly<Props>) {
     return ["animation_url", "image_url"].includes(key);
   };
 
-  function printAttribute(label: string, value: any, fullWidth?: boolean) {
+  function printAttribute(label: string, value: string, fullWidth?: boolean) {
     const displayValue = String(numberWithCommasFromString(value));
 
     return (
@@ -87,7 +87,7 @@ export default function Timeline(props: Readonly<Props>) {
     );
   }
 
-  function printFromToFields(from: any, to: any) {
+  function printFromToFields(from: string, to: string) {
     if (from && to) {
       return (
         <>
@@ -104,7 +104,7 @@ export default function Timeline(props: Readonly<Props>) {
     return printAttribute(label, nonUndefined, true);
   }
 
-  function printLink(label: string, value: any) {
+  function printLink(label: string, value: string) {
     return (
       <div className={FULL_WIDTH_COLUMN_CLASS_NAME}>
         <b>{label}:</b>{" "}
@@ -115,7 +115,7 @@ export default function Timeline(props: Readonly<Props>) {
     );
   }
 
-  function printFromToUrls(from: any, to: any) {
+  function printFromToUrls(from: string, to: string) {
     if (from && to) {
       return (
         <>
@@ -132,7 +132,7 @@ export default function Timeline(props: Readonly<Props>) {
     return printLink(label, nonUndefined);
   }
 
-  function printImage(label: string, value: any) {
+  function printImage(label: string, value: string) {
     return (
       <div
         className={`${FLEX_COLUMN_CLASS_NAME} tw-flex tw-flex-col tw-items-start tw-gap-1`}
@@ -148,7 +148,7 @@ export default function Timeline(props: Readonly<Props>) {
     );
   }
 
-  function printFromToImages(from: any, to: any) {
+  function printFromToImages(from: string, to: string) {
     if (from && to) {
       return (
         <>
@@ -165,7 +165,7 @@ export default function Timeline(props: Readonly<Props>) {
     return printImage(label, nonUndefined);
   }
 
-  function printAnimation(label: string, value: any) {
+  function printAnimation(label: string, value: string) {
     return (
       <div
         className={`${FLEX_COLUMN_CLASS_NAME} tw-flex tw-flex-col tw-items-start tw-gap-1`}
@@ -181,7 +181,7 @@ export default function Timeline(props: Readonly<Props>) {
     );
   }
 
-  function printFromToAnimation(from: any, to: any) {
+  function printFromToAnimation(from: string, to: string) {
     if (from && to) {
       return (
         <>
@@ -198,7 +198,7 @@ export default function Timeline(props: Readonly<Props>) {
     return printAnimation(label, nonUndefined);
   }
 
-  function printContent(change: { key: string; from: any; to: any }) {
+  function printContent(change: { key: string; from: string; to: string }) {
     let content;
     if (isImage(change.key)) {
       content = printFromToImages(change.from, change.to);

--- a/components/token-list/components/GridRow.tsx
+++ b/components/token-list/components/GridRow.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties, ReactNode } from "react";
+import type { UseQueryResult } from "@tanstack/react-query";
 import type { TokenMetadata } from "@/components/nft-picker/NftPicker.types";
 import type { TokenListAction, TokenWindowEntry } from "../types";
 import { TokenThumbnail } from "./TokenThumbnail";
@@ -6,7 +7,7 @@ import { TokenThumbnail } from "./TokenThumbnail";
 type GridRowProps = Readonly<{
   tokens: TokenWindowEntry[];
   metadataMap: Map<string, TokenMetadata>;
-  metadataQuery: any;
+  metadataQuery: UseQueryResult<TokenMetadata[], Error>;
   renderTokenExtra?:
     | ((tokenId: bigint, metadata?: TokenMetadata) => ReactNode)
     | undefined
@@ -41,7 +42,7 @@ export function GridRow({
         return (
           <div
             key={token.decimalId}
-            className="tw-flex tw-flex-col tw-rounded-lg tw-overflow-hidden"
+            className="tw-flex tw-flex-col tw-overflow-hidden tw-rounded-lg"
           >
             <div className="tw-aspect-square tw-w-full tw-overflow-hidden tw-bg-iron-900">
               <TokenThumbnail
@@ -51,7 +52,7 @@ export function GridRow({
                 hasError={hasMetadataError}
               />
             </div>
-            <div className="tw-flex tw-flex-col tw-p-3 tw-gap-3">
+            <div className="tw-flex tw-flex-col tw-gap-3 tw-p-3">
               <div className="tw-flex tw-items-center tw-justify-between tw-text-xs tw-text-iron-400">
                 <span className="tw-truncate">
                   {metadata?.collectionName ?? "Collection"}
@@ -60,10 +61,10 @@ export function GridRow({
               </div>
 
               <div className="tw-flex tw-items-center tw-justify-between tw-gap-2">
-                <div className="tw-font-medium tw-text-white tw-truncate">
+                <div className="tw-truncate tw-font-medium tw-text-white">
                   {metadata?.name ?? `Token #${token.decimalId}`}
                 </div>
-                <div className="tw-flex tw-gap-1 tw-text-xs tw-shrink-0">
+                <div className="tw-flex tw-shrink-0 tw-gap-1 tw-text-xs">
                   <span className="tw-text-iron-400">xTDH</span>
                   <span className="tw-text-white">
                     {Math.floor((token.xtdh ?? 0) * 10) / 10}

--- a/components/user/collected/filters/user-page-collected-filters.helpers.ts
+++ b/components/user/collected/filters/user-page-collected-filters.helpers.ts
@@ -1,7 +1,4 @@
-import {
-  CollectedCollectionType,
-  CollectionSort,
-} from "@/entities/IProfile";
+import { CollectedCollectionType, CollectionSort } from "@/entities/IProfile";
 
 interface CollectedCollectionMeta {
   readonly label: string;
@@ -88,5 +85,5 @@ export const COLLECTED_COLLECTIONS_META: Record<
   },
 };
 
-export const convertAddressToLowerCase = (address: any) =>
+export const convertAddressToLowerCase = (address: unknown) =>
   typeof address === "string" && address.length ? address.toLowerCase() : null;

--- a/components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddressesItem.tsx
+++ b/components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddressesItem.tsx
@@ -125,8 +125,9 @@ export default function UserPageIdentityStatementsConsolidatedAddressesItem({
     hash: writeDelegation.data,
   });
 
-  function getError(e: any) {
-    return e.message.split("Request Arguments")[0];
+  function getError(e: unknown) {
+    const record = e as { message?: unknown } | null;
+    return String(record?.message).split("Request Arguments")[0];
   }
 
   useEffect(() => {

--- a/components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddressesItem.tsx
+++ b/components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddressesItem.tsx
@@ -127,7 +127,9 @@ export default function UserPageIdentityStatementsConsolidatedAddressesItem({
 
   function getError(e: unknown) {
     const record = e as { message?: unknown } | null;
-    return String(record?.message).split("Request Arguments")[0];
+    const message =
+      typeof record?.message === "string" ? record.message : "";
+    return message.split("Request Arguments")[0];
   }
 
   useEffect(() => {

--- a/components/user/proxy/create/target/ProxyCreateTargetSearch.tsx
+++ b/components/user/proxy/create/target/ProxyCreateTargetSearch.tsx
@@ -11,7 +11,7 @@ import { AuthContext } from "@/components/auth/Auth";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 
 const MIN_SEARCH_LENGTH = 3;
-function classNames(...classes: any) {
+function classNames(...classes: unknown[]) {
   return classes.filter(Boolean).join(" ");
 }
 
@@ -87,25 +87,27 @@ export default function ProxyCreateTargetSearch({
               <img
                 src={profileProxy.granted_to.pfp}
                 alt="Profile picture"
-                className="tw-flex-shrink-0 tw-h-6 tw-w-6 tw-flex-none tw-rounded-lg tw-bg-iron-800 tw-ring-1 tw-ring-white/30"
+                className="tw-h-6 tw-w-6 tw-flex-none tw-flex-shrink-0 tw-rounded-lg tw-bg-iron-800 tw-ring-1 tw-ring-white/30"
               />
             ) : (
-              <div className="tw-flex-shrink-0 tw-h-6 tw-w-6 tw-flex-none tw-rounded-lg tw-bg-iron-800 tw-ring-1 tw-ring-white/30"></div>
+              <div className="tw-h-6 tw-w-6 tw-flex-none tw-flex-shrink-0 tw-rounded-lg tw-bg-iron-800 tw-ring-1 tw-ring-white/30"></div>
             )}
-            <span className="tw-font-semibold tw-text-iron-50 tw-text-base">
+            <span className="tw-text-base tw-font-semibold tw-text-iron-50">
               {profileProxy.granted_to.handle}
             </span>
             <button
               type="button"
               aria-label="Remove selected profile"
               onClick={() => onTargetSelect(null)}
-              className="tw-bg-transparent tw-h-8 tw-w-8 tw-flex tw-items-center tw-justify-center tw-rounded-full tw-border-0 focus:tw-outline-none hover:tw-bg-iron-800 tw-transition tw-duration-300 tw-ease-out">
+              className="tw-flex tw-h-8 tw-w-8 tw-items-center tw-justify-center tw-rounded-full tw-border-0 tw-bg-transparent tw-transition tw-duration-300 tw-ease-out hover:tw-bg-iron-800 focus:tw-outline-none"
+            >
               <svg
-                className="tw-flex-shrink-0 tw-h-5 tw-w-5 tw-text-red"
+                className="tw-h-5 tw-w-5 tw-flex-shrink-0 tw-text-red"
                 viewBox="0 0 24 24"
                 fill="none"
                 aria-hidden="true"
-                xmlns="http://www.w3.org/2000/svg">
+                xmlns="http://www.w3.org/2000/svg"
+              >
                 <path
                   d="M18 6L6 18M6 6L18 18"
                   stroke="currentColor"
@@ -120,24 +122,28 @@ export default function ProxyCreateTargetSearch({
       ) : (
         <div className="tw-relative tw-mt-4 tw-max-w-xs">
           <Combobox.Input
-            className="tw-form-input tw-block tw-w-80 tw-rounded-lg tw-border-0 tw-py-3 tw-pl-11 tw-pr-4 tw-bg-iron-900 tw-text-iron-50 tw-font-normal tw-caret-primary-400 tw-shadow-sm tw-ring-1 tw-ring-inset tw-ring-iron-700 hover:tw-ring-iron-600 placeholder:tw-text-iron-500 focus:tw-outline-none focus:tw-bg-iron-900 active:tw-fill-none focus:tw-ring-1 focus:tw-ring-inset  focus:tw-ring-primary-400 tw-text-base sm:text-sm tw-transition tw-duration-300 tw-ease-out"
+            className="sm:text-sm tw-form-input tw-block tw-w-80 tw-rounded-lg tw-border-0 tw-bg-iron-900 tw-py-3 tw-pl-11 tw-pr-4 tw-text-base tw-font-normal tw-text-iron-50 tw-caret-primary-400 tw-shadow-sm tw-ring-1 tw-ring-inset tw-ring-iron-700 tw-transition tw-duration-300 tw-ease-out placeholder:tw-text-iron-500 hover:tw-ring-iron-600 focus:tw-bg-iron-900 focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-primary-400 active:tw-fill-none"
             placeholder="Search profile"
             autoComplete="off"
             onChange={(event) => setQuery(event.target.value)}
-            displayValue={(person: any) => person?.handle}
+            displayValue={(person: CommunityMemberMinimal | null) =>
+              person?.handle ?? ""
+            }
           />
           <svg
             className="tw-pointer-events-none tw-absolute tw-left-4 tw-top-3.5 tw-h-5 tw-w-5 tw-text-iron-300"
             viewBox="0 0 20 20"
             fill="currentColor"
-            aria-hidden="true">
+            aria-hidden="true"
+          >
             <path
               fillRule="evenodd"
               d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
-              clipRule="evenodd"></path>
+              clipRule="evenodd"
+            ></path>
           </svg>
           {!!filteredProfiles.length && (
-            <Combobox.Options className="tw-list-none tw-px-2 tw-absolute tw-z-10 tw-mt-1 tw-max-h-56 tw-w-full tw-overflow-auto tw-rounded-md tw-bg-iron-800 tw-py-1 tw-text-base tw-shadow-lg tw-ring-1 tw-ring-white/10 tw-ring-opacity-5 focus:tw-outline-none sm:tw-text-sm">
+            <Combobox.Options className="tw-absolute tw-z-10 tw-mt-1 tw-max-h-56 tw-w-full tw-list-none tw-overflow-auto tw-rounded-md tw-bg-iron-800 tw-px-2 tw-py-1 tw-text-base tw-shadow-lg tw-ring-1 tw-ring-white/10 tw-ring-opacity-5 focus:tw-outline-none sm:tw-text-sm">
               {filteredProfiles.map((profile) => (
                 <Combobox.Option
                   key={profile.handle}
@@ -145,12 +151,13 @@ export default function ProxyCreateTargetSearch({
                   disabled={loading}
                   className={({ active }) =>
                     classNames(
-                      "tw-relative tw-cursor-pointer tw-select-none tw-rounded-lg tw-py-2 tw-px-2 tw-transition tw-duration-300 tw-ease-out",
+                      "tw-relative tw-cursor-pointer tw-select-none tw-rounded-lg tw-px-2 tw-py-2 tw-transition tw-duration-300 tw-ease-out",
                       active
-                        ? "tw-bg-iron-700 tw-text-iron-50 tw-font-medium"
+                        ? "tw-bg-iron-700 tw-font-medium tw-text-iron-50"
                         : ""
                     )
-                  }>
+                  }
+                >
                   {({ selected }) => (
                     <div className="tw-flex tw-items-center">
                       {profile.pfp ? (
@@ -160,13 +167,14 @@ export default function ProxyCreateTargetSearch({
                           className="tw-h-6 tw-w-6 tw-flex-shrink-0 tw-rounded-full"
                         />
                       ) : (
-                        <div className="tw-flex-shrink-0 tw-h-6 tw-w-6 tw-flex-none tw-rounded-lg tw-bg-iron-800 tw-ring-1 tw-ring-white/30"></div>
+                        <div className="tw-h-6 tw-w-6 tw-flex-none tw-flex-shrink-0 tw-rounded-lg tw-bg-iron-800 tw-ring-1 tw-ring-white/30"></div>
                       )}
                       <span
                         className={classNames(
                           "tw-ml-3 tw-truncate",
                           selected && "tw-font-semibold"
-                        )}>
+                        )}
+                      >
                         {profile.handle}
                       </span>
                     </div>

--- a/components/user/subscriptions/UserPageSubscriptionsEditionPreference.tsx
+++ b/components/user/subscriptions/UserPageSubscriptionsEditionPreference.tsx
@@ -64,7 +64,7 @@ export default function UserPageSubscriptionsEditionPreference(
           : "One edition is included.",
       });
       props.refresh();
-    } catch (e: any) {
+    } catch (e) {
       setToast({
         type: "error",
         title: "Couldn't update edition preference.",

--- a/components/user/subscriptions/UserPageSubscriptionsMode.tsx
+++ b/components/user/subscriptions/UserPageSubscriptionsMode.tsx
@@ -61,7 +61,7 @@ export default function UserPageSubscriptionsMode(
         type: "success",
       });
       props.refresh();
-    } catch (e: any) {
+    } catch (e) {
       setIsUpdating(false);
       setToast({
         type: "error",

--- a/components/waves/drop/SingleWaveDropTraits.tsx
+++ b/components/waves/drop/SingleWaveDropTraits.tsx
@@ -443,7 +443,7 @@ export const SingleWaveDropTraits: React.FC<SingleWaveDropTraitsProps> = ({
       "pointsSpeed",
     ];
 
-    const items: { label: string; value: any }[] = [];
+    const items: { label: string; value: string | number | boolean }[] = [];
 
     // First add items in priority order
     priorityKeys.forEach((key) => {

--- a/components/waves/drops/EditDropLexical.tsx
+++ b/components/waves/drops/EditDropLexical.tsx
@@ -150,8 +150,8 @@ const convertCodeNodesToFences = (root: RootNode) => {
 };
 
 function reconstructSplitMention(
-  currentNode: any,
-  nextNode: any,
+  currentNode: TextNode,
+  nextNode: TextNode,
   mentionStart: RegExpMatchArray,
   mentionEnd: RegExpMatchArray
 ) {
@@ -192,8 +192,8 @@ function reconstructSplitMention(
 }
 
 function reconstructSplitWaveMention(
-  currentNode: any,
-  nextNode: any,
+  currentNode: TextNode,
+  nextNode: TextNode,
   mentionStart: RegExpMatchArray,
   mentionEnd: RegExpMatchArray
 ) {
@@ -236,9 +236,12 @@ function processSplitMentions(textNodes: Array<TextNode>): boolean {
   for (let i = 0; i < textNodes.length - 1; i++) {
     const currentNode = textNodes[i];
     const nextNode = textNodes[i + 1];
+    if (!currentNode || !nextNode) {
+      continue;
+    }
 
-    const currentText = currentNode?.getTextContent();
-    const nextText = nextNode?.getTextContent();
+    const currentText = currentNode.getTextContent();
+    const nextText = nextNode.getTextContent();
 
     const mentionStart = currentText?.match(/@\[\w*$/);
     const mentionEnd = nextText?.match(/^\w*\]/);

--- a/components/waves/memes/file-upload/hooks/useFileUploader.ts
+++ b/components/waves/memes/file-upload/hooks/useFileUploader.ts
@@ -2,6 +2,7 @@
 
 import type React from "react";
 import { useCallback, useReducer } from "react";
+import type { TypeOptions } from "react-toastify";
 import {
   fileUploaderReducer,
   initialFileUploaderState,
@@ -38,7 +39,10 @@ interface UseFileUploaderProps {
   setUploaded: (uploaded: boolean) => void;
   /** Callback to show toast notifications */
   showToast?:
-    | ((toast: { type: any; message: string | React.ReactNode }) => void)
+    | ((toast: {
+        type: TypeOptions;
+        message: string | React.ReactNode;
+      }) => void)
     | undefined
     | undefined;
 }
@@ -124,7 +128,7 @@ const useFileUploader = ({
 
           if (showToast) {
             showToast({
-              type: "error" as any, // Cast to any to avoid TypeScript errors
+              type: "error",
               message: errorMessage,
             });
           }
@@ -138,7 +142,7 @@ const useFileUploader = ({
         // Show toast for better user feedback
         if (showToast) {
           showToast({
-            type: "error" as any, // Cast to any to avoid TypeScript errors
+            type: "error",
             message: errorMessage,
           });
         }

--- a/components/waves/memes/submission/steps/ArtworkStep.tsx
+++ b/components/waves/memes/submission/steps/ArtworkStep.tsx
@@ -47,7 +47,7 @@ function getSubmitButtonTooltip(
     // This helps the user understand what's missing
     for (const field of Object.keys(traits) as Array<keyof TraitsData>) {
       // Skip read-only fields
-      if (READ_ONLY_FIELDS.includes(field as any)) continue;
+      if ((READ_ONLY_FIELDS as readonly string[]).includes(field)) continue;
 
       const value = traits[field];
       const fieldName = field.replace(/([A-Z])/g, " $1").toLowerCase();
@@ -100,7 +100,7 @@ function checkFormCompleteness(
   // Check every field in TraitsData
   for (const field of Object.keys(traits) as Array<keyof TraitsData>) {
     // Skip read-only fields that are pre-populated
-    if (READ_ONLY_FIELDS.includes(field as any)) continue;
+    if ((READ_ONLY_FIELDS as readonly string[]).includes(field)) continue;
 
     const value = traits[field];
 

--- a/contexts/wave/WaveEligibilityContext.tsx
+++ b/contexts/wave/WaveEligibilityContext.tsx
@@ -12,7 +12,7 @@ import { commonApiFetch } from "@/services/api/common-api";
 import type { ApiWave } from "@/generated/models/ApiWave";
 import type { ChatRestriction } from "@/hooks/useDropPriviledges";
 
-interface WaveEligibility {
+export interface WaveEligibility {
   authenticated_user_eligible_to_chat: boolean;
   authenticated_user_chat_restriction?: ChatRestriction | null;
   authenticated_user_eligible_to_vote: boolean;

--- a/contexts/wave/utils/wave-messages-utils.ts
+++ b/contexts/wave/utils/wave-messages-utils.ts
@@ -6,6 +6,7 @@ import type { Drop } from "@/helpers/waves/drop.helpers";
 import { DropSize, getStableDropKey } from "@/helpers/waves/drop.helpers";
 import { commonApiFetchWithRetry } from "@/services/api/common-api";
 import { fetchWaveDropsFeedV2 } from "@/services/api/wave-drops-v2-api";
+import type { WaveEligibility } from "../WaveEligibilityContext";
 import type { WaveMessagesUpdate } from "../hooks/types";
 
 /**
@@ -20,7 +21,10 @@ export async function fetchWaveMessages(
   waveId: string,
   serialNo: number | null,
   signal?: AbortSignal,
-  updateEligibility?: (waveId: string, eligibility: any) => void
+  updateEligibility?: (
+    waveId: string,
+    eligibility: Partial<WaveEligibility>
+  ) => void
 ): Promise<ApiDrop[] | null> {
   try {
     const data = await fetchWaveDropsFeedV2({
@@ -308,7 +312,10 @@ export async function fetchNewestWaveMessages(
   sinceSerialNo: number | null,
   limit: number,
   signal?: AbortSignal,
-  updateEligibility?: (waveId: string, eligibility: any) => void
+  updateEligibility?: (
+    waveId: string,
+    eligibility: Partial<WaveEligibility>
+  ) => void
 ): Promise<{ drops: ApiDrop[] | null; highestSerialNo: number | null }> {
   try {
     const data = await fetchWaveDropsFeedV2({

--- a/entities/IDBResponse.ts
+++ b/entities/IDBResponse.ts
@@ -1,6 +1,6 @@
 export interface DBResponse<T = any> {
   count: number;
   page: number;
-  next: any;
+  next: unknown;
   data: T[];
 }

--- a/entities/INFT.ts
+++ b/entities/INFT.ts
@@ -1,4 +1,4 @@
-export interface NFTMetadataMediaDetails {
+interface NFTMetadataMediaDetails {
   readonly format?: string | null | undefined;
   readonly width?: number | null | undefined;
   readonly height?: number | null | undefined;

--- a/entities/INFT.ts
+++ b/entities/INFT.ts
@@ -1,3 +1,23 @@
+export interface NFTMetadataMediaDetails {
+  readonly format?: string | null | undefined;
+  readonly width?: number | null | undefined;
+  readonly height?: number | null | undefined;
+  readonly [key: string]: unknown;
+}
+
+/**
+ * Token-metadata JSON blob attached to an NFT. Only the fields the app
+ * actually reads are declared; everything else stays index-signature-typed.
+ */
+export interface NFTTokenMetadata {
+  readonly name?: string | undefined;
+  readonly image?: string | undefined;
+  readonly animation?: string | undefined;
+  readonly animation_details?: NFTMetadataMediaDetails | null | undefined;
+  readonly image_details?: NFTMetadataMediaDetails | null | undefined;
+  readonly [key: string]: unknown;
+}
+
 export interface BaseNFT {
   id: number;
   contract: string;
@@ -18,7 +38,7 @@ export interface BaseNFT {
   image: string;
   compressed_animation?: string | undefined;
   animation: string;
-  metadata?: any | undefined;
+  metadata?: NFTTokenMetadata | undefined;
   market_cap: number;
   floor_price: number;
   total_volume_last_24_hours: number;
@@ -134,7 +154,7 @@ export interface Rememe {
   image: string;
   animation: string;
   meme_references: number[];
-  metadata: any;
+  metadata: NFTTokenMetadata;
   contract_opensea_data: {
     imageUrl: string;
     discordUrl: string;

--- a/entities/IReservoir.ts
+++ b/entities/IReservoir.ts
@@ -74,7 +74,7 @@ interface ReservoirTokensResponseTokenToken {
   rarityRank: number;
   collection: ReservoirTokensResponseCollection;
   owner: string;
-  mintStages: any[];
+  mintStages: unknown[];
 }
 
 interface ReservoirTokensResponseCollection {

--- a/generated/models/ApiIdentityMuteState.ts
+++ b/generated/models/ApiIdentityMuteState.ts
@@ -11,6 +11,8 @@
  * Do not edit the class manually.
  */
 
+import { HttpFile } from '../http/http';
+
 export class ApiIdentityMuteState {
     'muted': boolean;
 

--- a/generated/models/ApiIdentityMuteState.ts
+++ b/generated/models/ApiIdentityMuteState.ts
@@ -11,8 +11,6 @@
  * Do not edit the class manually.
  */
 
-import { HttpFile } from '../http/http';
-
 export class ApiIdentityMuteState {
     'muted': boolean;
 

--- a/helpers/Helpers.ts
+++ b/helpers/Helpers.ts
@@ -196,8 +196,8 @@ export function getDateDisplay(date: Date) {
 }
 
 export function areEqualAddresses(w1: unknown, w2: unknown): boolean {
-  if (w1 && w2) {
-    return String(w1).toUpperCase() === String(w2).toUpperCase();
+  if (typeof w1 === "string" && typeof w2 === "string" && w1 && w2) {
+    return w1.toUpperCase() === w2.toUpperCase();
   }
   return false;
 }

--- a/helpers/Helpers.ts
+++ b/helpers/Helpers.ts
@@ -78,14 +78,14 @@ function isNumeric(str: string) {
   return /^[+-]?(\d+(\.\d*)?|\.\d+)$/.test(str);
 }
 
-export function numberWithCommasFromString(x: any) {
-  x = x.toString();
-  if (!x || !isNumeric(x) || isNaN(parseFloat(x))) return x;
-  if (x.includes(" ") || x.includes(",")) return x;
-  const cleanedInput = x.replaceAll(/[^\d.-]/g, "");
-  if (!/^-?\d+(\.\d+)?$/.test(cleanedInput)) return x;
+export function numberWithCommasFromString(x: string | number) {
+  const str = x.toString();
+  if (!str || !isNumeric(str) || isNaN(parseFloat(str))) return str;
+  if (str.includes(" ") || str.includes(",")) return str;
+  const cleanedInput = str.replaceAll(/[^\d.-]/g, "");
+  if (!/^-?\d+(\.\d+)?$/.test(cleanedInput)) return str;
   const num = parseFloat(cleanedInput);
-  if (isNaN(num)) return x;
+  if (isNaN(num)) return str;
   return numberWithCommas(num);
 }
 
@@ -195,16 +195,24 @@ export function getDateDisplay(date: Date) {
   return `${days.toLocaleString()} days ago`;
 }
 
-export function areEqualAddresses(w1: any, w2: any) {
+export function areEqualAddresses(w1: unknown, w2: unknown): boolean {
   if (w1 && w2) {
-    return w1.toUpperCase() === w2.toUpperCase();
+    return String(w1).toUpperCase() === String(w2).toUpperCase();
   }
   return false;
 }
 
 export const fullScreenSupported = (): boolean => {
-  const doc: any = document;
-  const el: any = doc.body;
+  const doc = document as Document & {
+    readonly mozCancelFullScreen?: unknown;
+    readonly webkitExitFullscreen?: unknown;
+    readonly msExitFullscreen?: unknown;
+  };
+  const el = doc.body as HTMLElement & {
+    readonly mozRequestFullScreen?: unknown;
+    readonly webkitRequestFullscreen?: unknown;
+    readonly msRequestFullscreen?: unknown;
+  };
   const check =
     typeof el.requestFullscreen !== "undefined" ||
     typeof el.mozRequestFullScreen !== "undefined" ||
@@ -360,7 +368,7 @@ export function parseIpfsUrlToGateway(url: string) {
   );
 }
 
-export function isEmptyObject(obj: any) {
+export function isEmptyObject(obj: object) {
   return Object.keys(obj).length === 0 && obj.constructor === Object;
 }
 
@@ -394,8 +402,8 @@ export function parseEmojis(s: string) {
   });
 }
 
-function isValidDate(date?: any): date is Date {
-  return date && !isNaN(new Date(date).getTime());
+function isValidDate(date?: Date): date is Date {
+  return !!date && !isNaN(new Date(date).getTime());
 }
 
 export function printMintDate(date?: Date) {

--- a/hooks/useAppWalletPasswordModal.tsx
+++ b/hooks/useAppWalletPasswordModal.tsx
@@ -10,7 +10,7 @@ export const useAppWalletPasswordModal = (
 ) => {
   const [isOpen, setIsOpen] = useState(false);
   const [resolve, setResolve] = useState<(password: string) => void>();
-  const [reject, setReject] = useState<(reason?: any) => void>();
+  const [reject, setReject] = useState<(reason?: unknown) => void>();
 
   const [address, setAddress] = useState("");
   const [addressHashed, setAddressHashed] = useState("");

--- a/hooks/useHlsPlayer.ts
+++ b/hooks/useHlsPlayer.ts
@@ -198,7 +198,7 @@ export function useHlsPlayer({
   ) {
     try {
       const mod = await import("hls.js");
-      const HlsConstructor = mod.default; // typed import (no "as any")
+      const HlsConstructor = mod.default; // typed import, no unsafe cast
       if (!isCurrentSetup(setupVersion, videoEl)) {
         return;
       }

--- a/hooks/useManifoldClaim.ts
+++ b/hooks/useManifoldClaim.ts
@@ -331,7 +331,7 @@ function buildClaimFromReadData({
   return {
     identifier,
     instanceId,
-    location: String(claimData.location ?? ""),
+    location: (claimData.location ?? "") as string,
     total: Number(claimData.total),
     totalMax: Number(claimData.totalMax),
     remaining,

--- a/hooks/useManifoldClaim.ts
+++ b/hooks/useManifoldClaim.ts
@@ -231,6 +231,26 @@ export interface ManifoldClaim {
 }
 
 type ManifoldClaimReadMethod = "getClaimForToken" | "getClaim";
+
+/**
+ * Loosely-decoded contract read payload. Every field is validated or
+ * coerced (Number/String/parse helpers) before use, so values stay unknown.
+ */
+interface ManifoldClaimReadValues {
+  readonly startDate?: unknown;
+  readonly endDate?: unknown;
+  readonly cost?: unknown;
+  readonly merkleRoot?: unknown;
+  readonly tokenId?: unknown;
+  readonly paymentReceiver?: unknown;
+  readonly erc20?: unknown;
+  readonly signingAddress?: unknown;
+  readonly total?: unknown;
+  readonly totalMax?: unknown;
+  readonly location?: unknown;
+  readonly walletMax?: unknown;
+  readonly storageProtocol?: unknown;
+}
 interface UseManifoldClaimResult {
   claim: ManifoldClaim | undefined;
   isFetching: boolean;
@@ -269,11 +289,16 @@ function buildClaimFromReadData({
     start: number
   ) => MemePhase | undefined;
 }): ManifoldClaim | undefined {
-  const readData = data as any;
-  const claimData =
+  const readData = data as {
+    readonly claim?: unknown;
+    readonly instanceId?: unknown;
+    readonly [index: number]: unknown;
+  };
+  const claimData = (
     readMethod === "getClaimForToken"
       ? (readData.claim ?? readData[1])
-      : readData;
+      : readData
+  ) as ManifoldClaimReadValues | null | undefined;
 
   if (!claimData) {
     return undefined;

--- a/hooks/useNFTCollections.ts
+++ b/hooks/useNFTCollections.ts
@@ -81,7 +81,7 @@ export function useNFTCollections(initialCollections?: {
     commonApiFetch<{
       count: number;
       page: number;
-      next: any;
+      next: unknown;
       data: NextGenCollection[];
     }>({
       endpoint: `nextgen/collections`,

--- a/hooks/useNotificationsQuery.tsx
+++ b/hooks/useNotificationsQuery.tsx
@@ -132,10 +132,13 @@ export function useNotificationsQuery({
       return undefined;
     },
     retry: (failureCount, error: unknown) => {
+      const record = error as {
+        status?: unknown;
+        response?: { status?: unknown };
+        cause?: { status?: unknown };
+      } | null;
       const status =
-        (error as any)?.status ??
-        (error as any)?.response?.status ??
-        (error as any)?.cause?.status;
+        record?.status ?? record?.response?.status ?? record?.cause?.status;
       if (status === 401) return false;
       if (typeof error === "string" && /unauthorized/i.test(error))
         return false;

--- a/hooks/useWaveData.ts
+++ b/hooks/useWaveData.ts
@@ -29,10 +29,10 @@ export const useWaveData = ({
     enabled: !!waveId,
     refetchInterval,
     retry: (failureCount, error) => {
-      if ((error as any)?.message === "Attempted fetch with null waveId") {
+      if (error?.message === "Attempted fetch with null waveId") {
         return false; // Don't retry our artificial error
       }
-      if ((error as any) === `Wave ${waveId} not found`) {
+      if ((error as unknown) === `Wave ${waveId} not found`) {
         onWaveNotFound();
         return false;
       }

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -53,6 +53,9 @@
       "tests/**": ["files", "exports", "types"],
       ".deepsec/deepsec.config.ts": ["unlisted", "exports"],
       "generated/**": ["exports", "types", "enumMembers"], // ignore only these issue kinds
+      // Backend operation-code catalog; several codes are intentionally
+      // declared before the tool implements them (see inline comments).
+      "components/allowlist-tool/allowlist-tool.types.ts": ["enumMembers"],
       "components/brain/left-sidebar/waves/HighlyRatedWavesToggle.tsx": [
         "exports",
         "types"

--- a/lib/storage/idb-keyval.ts
+++ b/lib/storage/idb-keyval.ts
@@ -6,10 +6,10 @@ type StoreFn = <T>(
 type RequestLike<T = unknown> = {
   result?: T | undefined;
   error?: unknown | undefined;
-  onsuccess: ((this: any, ev: Event) => any) | null;
-  onerror: ((this: any, ev: Event) => any) | null;
-  oncomplete?: ((this: any, ev: Event) => any) | null | undefined;
-  onabort?: ((this: any, ev: Event) => any) | null | undefined;
+  onsuccess: ((this: unknown, ev: Event) => unknown) | null;
+  onerror: ((this: unknown, ev: Event) => unknown) | null;
+  oncomplete?: ((this: unknown, ev: Event) => unknown) | null | undefined;
+  onabort?: ((this: unknown, ev: Event) => unknown) | null | undefined;
 };
 
 function extractErrorMessage(error: unknown): string {
@@ -17,7 +17,8 @@ function extractErrorMessage(error: unknown): string {
   if (typeof error === "string") return error;
   if (error instanceof Error) return error.message;
   if (typeof error === "object") {
-    const maybeMessage = (error as any)?.message ?? (error as any)?.error;
+    const record = error as Record<string, unknown>;
+    const maybeMessage = record["message"] ?? record["error"];
     if (maybeMessage) return String(maybeMessage);
     try {
       return JSON.stringify(error);
@@ -38,7 +39,8 @@ function extractErrorMessage(error: unknown): string {
 function extractErrorName(error: unknown): string {
   if (error == null) return "";
   if (error instanceof Error) return error.name;
-  return (error as any)?.name ?? (error as any)?.constructor?.name ?? "";
+  const record = error as { name?: unknown; constructor?: { name?: unknown } };
+  return String(record?.name ?? record?.constructor?.name ?? "");
 }
 
 function isDatabaseClosingError(error: unknown): boolean {
@@ -53,7 +55,9 @@ function isDatabaseClosingError(error: unknown): boolean {
   );
 }
 
-export function promisifyRequest<T = unknown>(request: RequestLike<T>): Promise<T> {
+export function promisifyRequest<T = unknown>(
+  request: RequestLike<T>
+): Promise<T> {
   return new Promise((resolve, reject) => {
     request.oncomplete = request.onsuccess = () => resolve(request.result as T);
     request.onabort = request.onerror = () => reject(request.error);
@@ -64,7 +68,9 @@ const dbPromiseCache = new Map<string, Promise<IDBDatabase>>();
 
 function openDatabase(dbName: string, storeName: string): Promise<IDBDatabase> {
   if (typeof indexedDB === "undefined") {
-    return Promise.reject(new Error("IndexedDB is not available in this environment."));
+    return Promise.reject(
+      new Error("IndexedDB is not available in this environment.")
+    );
   }
 
   const request = indexedDB.open(dbName);
@@ -74,7 +80,9 @@ function openDatabase(dbName: string, storeName: string): Promise<IDBDatabase> {
       db.createObjectStore(storeName);
     }
   };
-  return promisifyRequest<IDBDatabase>(request as unknown as RequestLike<IDBDatabase>);
+  return promisifyRequest<IDBDatabase>(
+    request as unknown as RequestLike<IDBDatabase>
+  );
 }
 
 function getCacheKey(dbName: string, storeName: string): string {
@@ -247,7 +255,11 @@ export function update<T = unknown>(
           try {
             store.put(updater(request.result), key);
             settled = true;
-            resolve(promisifyRequest<void>(transaction as unknown as RequestLike<void>));
+            resolve(
+              promisifyRequest<void>(
+                transaction as unknown as RequestLike<void>
+              )
+            );
           } catch (err) {
             rejectOnce(err);
           }
@@ -256,10 +268,7 @@ export function update<T = unknown>(
   );
 }
 
-export function del(
-  key: IDBValidKey,
-  customStore?: StoreFn
-): Promise<void> {
+export function del(key: IDBValidKey, customStore?: StoreFn): Promise<void> {
   const useStore = customStore ?? defaultGetStore();
   return useStore("readwrite", (store) => {
     store.delete(key);
@@ -301,7 +310,9 @@ function eachCursor(
     callback(this.result);
     this.result.continue();
   };
-  return promisifyRequest<void>(store.transaction as unknown as RequestLike<void>);
+  return promisifyRequest<void>(
+    store.transaction as unknown as RequestLike<void>
+  );
 }
 
 export function keys(customStore?: StoreFn): Promise<IDBValidKey[]> {
@@ -323,7 +334,9 @@ export function values<T = unknown>(customStore?: StoreFn): Promise<T[]> {
   const useStore = customStore ?? defaultGetStore();
   return useStore("readonly", (store) => {
     if (store.getAll) {
-      return promisifyRequest<T[]>(store.getAll() as unknown as RequestLike<T[]>);
+      return promisifyRequest<T[]>(
+        store.getAll() as unknown as RequestLike<T[]>
+      );
     }
     const items: T[] = [];
     return eachCursor(store, (cursor) => items.push(cursor.value as T)).then(

--- a/lib/storage/idb-keyval.ts
+++ b/lib/storage/idb-keyval.ts
@@ -19,7 +19,7 @@ function extractErrorMessage(error: unknown): string {
   if (typeof error === "object") {
     const record = error as Record<string, unknown>;
     const maybeMessage = record["message"] ?? record["error"];
-    if (maybeMessage) return String(maybeMessage);
+    if (typeof maybeMessage === "string" && maybeMessage) return maybeMessage;
     try {
       return JSON.stringify(error);
     } catch {
@@ -40,7 +40,8 @@ function extractErrorName(error: unknown): string {
   if (error == null) return "";
   if (error instanceof Error) return error.name;
   const record = error as { name?: unknown; constructor?: { name?: unknown } };
-  return String(record?.name ?? record?.constructor?.name ?? "");
+  const name = record?.name ?? record?.constructor?.name;
+  return typeof name === "string" ? name : "";
 }
 
 function isDatabaseClosingError(error: unknown): boolean {

--- a/ops/workstreams/repo-health-2026-07/any-exceptions.md
+++ b/ops/workstreams/repo-health-2026-07/any-exceptions.md
@@ -1,0 +1,22 @@
+# `any` exceptions ledger
+
+Sites that keep `: any` / `as any` deliberately, with one-line justifications.
+Everything not listed here is expected to stay at zero; the debt-ratchet
+baseline (`scripts/debt-ratchet-baseline.json`, metric `any_casts`) is the
+enforcement backstop.
+
+## Permanent exceptions
+
+| Site | Count | Justification |
+| --- | --- | --- |
+| `wagmiConfig/wagmiAppWalletConnector.ts` | 3 | wagmi `createConnector`'s `connect()` return type is conditional on the `withCapabilities` parameter; expressing it without `any` requires `as unknown as` double-casts that add no safety. Runtime shape matches the wagmi v2 connector contract. |
+
+## Deferred to other workstreams (not exceptions)
+
+- `components/delegation/**` (~60 sites at last count): owned by the styling
+  workstream (Thread C), which is rewriting these files; typing them here
+  would churn against that migration.
+- `src/types/window.d.ts` (1 site): the `src/` tree is being folded by the
+  layout workstream (Thread D); the file moves or dies there.
+
+Counts and per-file locations: `node scripts/debt-ratchet.cjs --details any_casts`.

--- a/ops/workstreams/repo-health-2026-07/any-exceptions.md
+++ b/ops/workstreams/repo-health-2026-07/any-exceptions.md
@@ -22,7 +22,7 @@ enforcement backstop.
 - `components/delegation/**` (~60 sites at last count): owned by the styling
   workstream (Thread C), which is rewriting these files; typing them here
   would churn against that migration.
-- `src/types/window.d.ts` (1 site): the `src/` tree is being folded by the
-  layout workstream (Thread D); the file moves or dies there.
+- `src/types/window.d.ts` was listed here until the layout workstream's
+  `src/` fold removed the file (resolved 2026-07-05).
 
 Counts and per-file locations: `node scripts/debt-ratchet.cjs --details any_casts`.

--- a/ops/workstreams/repo-health-2026-07/any-exceptions.md
+++ b/ops/workstreams/repo-health-2026-07/any-exceptions.md
@@ -10,7 +10,12 @@ enforcement backstop.
 | Site | Count | Justification |
 | --- | --- | --- |
 | `wagmiConfig/wagmiAppWalletConnector.ts` | 3 | wagmi `createConnector`'s `connect()` return type is conditional on the `withCapabilities` parameter; expressing it without `any` requires `as unknown as` double-casts that add no safety. Runtime shape matches the wagmi v2 connector contract. |
-| `app/blog/disney-deekay-their-secret-to-animation/page.tsx` | 1 | Regex false positive: the ratchet's textual `\bas\s+any\b` matches the prose "…as powerfully as any great art can" inside JSX copy. No TypeScript cast exists in the file; editorial copy is not changed to satisfy a counter. |
+
+## Scan false positives (not `any` usages)
+
+| Site | Count | Explanation |
+| --- | --- | --- |
+| `app/blog/disney-deekay-their-secret-to-animation/page.tsx` | 1 | The ratchet's textual `\bas\s+any\b` matches the prose "…as powerfully as any great art can" inside JSX copy. No TypeScript cast exists in the file; editorial copy is not changed to satisfy a counter. |
 
 ## Deferred to other workstreams (not exceptions)
 

--- a/ops/workstreams/repo-health-2026-07/any-exceptions.md
+++ b/ops/workstreams/repo-health-2026-07/any-exceptions.md
@@ -10,6 +10,7 @@ enforcement backstop.
 | Site | Count | Justification |
 | --- | --- | --- |
 | `wagmiConfig/wagmiAppWalletConnector.ts` | 3 | wagmi `createConnector`'s `connect()` return type is conditional on the `withCapabilities` parameter; expressing it without `any` requires `as unknown as` double-casts that add no safety. Runtime shape matches the wagmi v2 connector contract. |
+| `app/blog/disney-deekay-their-secret-to-animation/page.tsx` | 1 | Regex false positive: the ratchet's textual `\bas\s+any\b` matches the prose "…as powerfully as any great art can" inside JSX copy. No TypeScript cast exists in the file; editorial copy is not changed to satisfy a counter. |
 
 ## Deferred to other workstreams (not exceptions)
 

--- a/ops/workstreams/repo-health-2026-07/run-log.md
+++ b/ops/workstreams/repo-health-2026-07/run-log.md
@@ -221,7 +221,7 @@ useDownloader.test.ts` failed to LOAD on main (its bare `@capacitor/core` mock
   annotated); ~90 cargo-cult `(x.data as any) === true|false` casts dropped
   by script; the remaining 51 nextGen sites + platform layer (helpers/lib/
   services/hooks/entities) + component scatter typed precisely.
-  `any_casts` baseline 358 -> (final count in PR). Exceptions ledger:
+  `any_casts` baseline 358 -> 65. Exceptions ledger:
   `any-exceptions.md` (wagmi connector conditional return, 3 sites).
   Delegation (~60 sites) deferred to Thread C's rewrite; `src/` d.ts to
   Thread D.

--- a/ops/workstreams/repo-health-2026-07/run-log.md
+++ b/ops/workstreams/repo-health-2026-07/run-log.md
@@ -206,3 +206,28 @@ useDownloader.test.ts` failed to LOAD on main (its bare `@capacitor/core` mock
   `/meme-lab`, `/network`, `/meme-calendar` repeatedly blow the 20s full-page
   screenshot budget — slow collection-route data fetches predate this
   workstream and deserve an owner.
+
+## 2026-07-05 (Thread E — dead patterns)
+
+- Redux removal (PR #3047): all 13 slice consumers migrated to two new
+  focused contexts (`EditingDropContext`, `ActiveGroupContext`) mounted in
+  `Providers`; `store/` + `StoreSetup` deleted; `@reduxjs/toolkit`,
+  `react-redux`, `next-redux-wrapper` dropped from package.json + lockfile.
+  Ratchet `redux_imports` 21 -> 0. Full suite 1959/11047 green, typecheck,
+  lint, prod build green. Knip forced the consumer-migration and removal
+  commits into one PR (dead slice exports fail the gate between them).
+- `any` burn-down wave 1 (PR pending on `cleanup/any-nextgen`): NextGen
+  contract layer typed at the root (`NextGenContract.abi: any -> Abi`, ABIs
+  annotated); ~90 cargo-cult `(x.data as any) === true|false` casts dropped
+  by script; the remaining 51 nextGen sites + platform layer (helpers/lib/
+  services/hooks/entities) + component scatter typed precisely.
+  `any_casts` baseline 358 -> (final count in PR). Exceptions ledger:
+  `any-exceptions.md` (wagmi connector conditional return, 3 sites).
+  Delegation (~60 sites) deferred to Thread C's rewrite; `src/` d.ts to
+  Thread D.
+- TODO triage recount: the audit's 2,841 figure does not reproduce under a
+  word-boundary count. Actual repo-wide `\b(TODO|FIXME|HACK)\b` outside
+  node_modules/generated: 22, of which 6 in ratchet-scanned source (4 are
+  "remove after codemod" re-export shims, 1 secure-logging work item,
+  1 stale API-shape comment). Triage PR follows: shims completed+deleted,
+  work items become consolidated GitHub issues, stale comment deleted.

--- a/scripts/debt-ratchet-baseline.json
+++ b/scripts/debt-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "max_source_file_lines": 800,
   "counts": {
-    "any_casts": 357,
+    "any_casts": 64,
     "todo_comments": 6,
     "oversized_files": 139,
     "bootstrap_imports": 0,

--- a/services/6529api.ts
+++ b/services/6529api.ts
@@ -77,7 +77,7 @@ export async function fetchAllPages<T>(
   return all;
 }
 
-function getNextUrl(currentUrl: string, next?: string | boolean): string {
+function getNextUrl(currentUrl: string, next?: unknown): string {
   if (!next) return "";
 
   if (typeof next === "string") {

--- a/services/6529api.ts
+++ b/services/6529api.ts
@@ -101,7 +101,7 @@ function getNextUrl(currentUrl: string, next?: string | boolean): string {
   }
 }
 
-export async function postData(url: string, body: any, init?: RequestInit) {
+export async function postData(url: string, body: unknown, init?: RequestInit) {
   const requestStartedAtMs = getRequestTimingNow();
   let status: number | "network_error" | "unknown" = "unknown";
 

--- a/services/api/upload-error.ts
+++ b/services/api/upload-error.ts
@@ -1,7 +1,6 @@
 import type { AxiosError } from "axios";
 
-const NETWORK_HINT =
-  "Can't reach image upload server. Please try again.";
+const NETWORK_HINT = "Can't reach image upload server. Please try again.";
 const BLOCKED_HINT =
   "Upload was blocked by the server (403). Please try again later.";
 const TOO_LARGE_HINT = "Image is too large; max 2MB.";
@@ -29,7 +28,8 @@ export function getUploadErrorMessage(error: unknown): string {
     if (status === 413) return TOO_LARGE_HINT;
 
     let serverMsg: string | null = null;
-    const dataError = (error.response?.data as any)?.error;
+    const dataError = (error.response?.data as { error?: unknown } | undefined)
+      ?.error;
     if (typeof dataError === "string") {
       serverMsg = dataError;
     } else if (dataError && typeof dataError === "object") {

--- a/services/distribution-plan-api.ts
+++ b/services/distribution-plan-api.ts
@@ -68,7 +68,7 @@ export const distributionPlanApiPost = async <T>({
   body,
 }: {
   endpoint: string;
-  body: any;
+  body: unknown;
 }): Promise<{
   readonly success: boolean;
   readonly data: T | null;

--- a/utils/appkit-initialization.utils.ts
+++ b/utils/appkit-initialization.utils.ts
@@ -35,7 +35,7 @@ interface AppKitInitializationResult {
 /**
  * Debug logger helper to reduce conditional complexity
  */
-function debugLog(message: string, ...args: any[]): void {
+function debugLog(message: string, ...args: unknown[]): void {
   if (publicEnv.NODE_ENV === "development") {
     console.warn(`[AppKitInitialization] ${message}`, ...args);
   }

--- a/utils/drop-hasher.ts
+++ b/utils/drop-hasher.ts
@@ -32,7 +32,14 @@ export class DropHasher {
     }
 
     const record = obj as Record<string, unknown>;
-    const keys = Object.keys(record).sort();
+    // Deliberately locale-independent: this feeds drop signature hashing,
+    // so key order must be stable across environments (UTF-16 code units,
+    // same ordering the default Array#sort applies to strings).
+    const keys = Object.keys(record).sort((a, b) => {
+      if (a < b) return -1;
+      if (a > b) return 1;
+      return 0;
+    });
     const keyValuePairs = keys
       .filter((key) => record[key] !== undefined)
       .map((key) => {

--- a/utils/drop-hasher.ts
+++ b/utils/drop-hasher.ts
@@ -9,19 +9,19 @@ export class DropHasher {
     drop: ApiCreateDropRequest;
     termsOfService: string | null;
   }): string {
-    const obj: any = {
+    const obj: Record<string, unknown> = {
       ...drop,
     };
     if (termsOfService) {
-      obj.terms_of_service = termsOfService;
+      obj["terms_of_service"] = termsOfService;
     }
-    delete obj.signature;
-    delete obj.signature_message;
+    delete obj["signature"];
+    delete obj["signature_message"];
     const serialisedObj = this.canonicalJSONStringify(obj);
     return sha256(serialisedObj);
   }
 
-  private canonicalJSONStringify(obj: any): string {
+  private canonicalJSONStringify(obj: unknown): string {
     if (typeof obj !== "object" || obj === null) {
       return JSON.stringify(obj);
     }
@@ -31,11 +31,12 @@ export class DropHasher {
       return `[${items.join(",")}]`;
     }
 
-    const keys = Object.keys(obj).sort();
+    const record = obj as Record<string, unknown>;
+    const keys = Object.keys(record).sort();
     const keyValuePairs = keys
-      .filter((key) => obj[key] !== undefined)
+      .filter((key) => record[key] !== undefined)
       .map((key) => {
-        const valueString = this.canonicalJSONStringify(obj[key]);
+        const valueString = this.canonicalJSONStringify(record[key]);
         return `${JSON.stringify(key)}:${valueString}`;
       });
     return `{${keyValuePairs.join(",")}}`;

--- a/utils/error-sanitizer.ts
+++ b/utils/error-sanitizer.ts
@@ -74,7 +74,8 @@ export const isIndexedDBError = (error: unknown): boolean => {
   } else if (typeof error === "string") {
     errorMessage = error;
   } else if (typeof error === "object") {
-    const msg = (error as any)?.message ?? (error as any)?.error;
+    const record = error as Record<string, unknown>;
+    const msg = record["message"] ?? record["error"];
 
     if (msg) {
       errorMessage = String(msg);
@@ -92,7 +93,10 @@ export const isIndexedDBError = (error: unknown): boolean => {
   const errorName =
     error instanceof Error
       ? error.name
-      : (error as any)?.constructor?.name || "";
+      : String(
+          (error as { constructor?: { name?: unknown } })?.constructor?.name ??
+            ""
+        );
 
   const indexedDBPatterns = [
     /indexed\s*database/i,
@@ -114,7 +118,7 @@ export const isIndexedDBError = (error: unknown): boolean => {
  * Handles adapter-specific error messages
  */
 const getAdapterErrorMessage = (error: Error): string | null => {
-  const errorName = (error as any)?.constructor?.name;
+  const errorName = error?.constructor?.name ?? "";
 
   if (
     !["AdapterError", "AdapterCacheError", "AdapterCleanupError"].includes(
@@ -161,8 +165,9 @@ const extractErrorMessage = (
 
   if (typeof error === "object") {
     try {
+      const record = error as Record<string, unknown>;
       const errorString = JSON.stringify(error);
-      const message = (error as any).message || (error as any).error || "";
+      const message = String(record["message"] || record["error"] || "");
       return { message, errorString };
     } catch {
       return { message: "", errorString: "Complex error object" };

--- a/utils/error-sanitizer.ts
+++ b/utils/error-sanitizer.ts
@@ -77,8 +77,8 @@ export const isIndexedDBError = (error: unknown): boolean => {
     const record = error as Record<string, unknown>;
     const msg = record["message"] ?? record["error"];
 
-    if (msg) {
-      errorMessage = String(msg);
+    if (typeof msg === "string" && msg) {
+      errorMessage = msg;
     } else {
       try {
         errorMessage = JSON.stringify(error);
@@ -90,13 +90,14 @@ export const isIndexedDBError = (error: unknown): boolean => {
     errorMessage = `[non-string error: ${typeof error}]`;
   }
 
+  const rawErrorName = (error as { constructor?: { name?: unknown } })
+    ?.constructor?.name;
   const errorName =
     error instanceof Error
       ? error.name
-      : String(
-          (error as { constructor?: { name?: unknown } })?.constructor?.name ??
-            ""
-        );
+      : typeof rawErrorName === "string"
+        ? rawErrorName
+        : "";
 
   const indexedDBPatterns = [
     /indexed\s*database/i,
@@ -167,7 +168,7 @@ const extractErrorMessage = (
     try {
       const record = error as Record<string, unknown>;
       const errorString = JSON.stringify(error);
-      const message = String(record["message"] || record["error"] || "");
+      const message = (record["message"] || record["error"] || "") as string;
       return { message, errorString };
     } catch {
       return { message: "", errorString: "Complex error object" };

--- a/utils/error-sanitizer.ts
+++ b/utils/error-sanitizer.ts
@@ -168,7 +168,8 @@ const extractErrorMessage = (
     try {
       const record = error as Record<string, unknown>;
       const errorString = JSON.stringify(error);
-      const message = (record["message"] || record["error"] || "") as string;
+      const rawMessage = record["message"] || record["error"] || "";
+      const message = typeof rawMessage === "string" ? rawMessage : "";
       return { message, errorString };
     } catch {
       return { message: "", errorString: "Complex error object" };


### PR DESCRIPTION
## Issue
- The debt ratchet's `any_casts` metric sat at 358 (`: any` / `as any` in shippable TS source). Most sites cluster around one root cause: `NextGenContract.abi: any` poisoning every wagmi read downstream, plus scattered untyped error handling, event handlers, and API decode sites. Part of the repo-health dead-patterns workstream.

## Fix
Six commits, root cause first:
1. **NextGen contract layer** — annotate the three NextGen ABIs with viem's `Abi` (house pattern already used by `MEMES_MANIFOLD_PROXY_ABI`), type `NextGenContract.abi`, type every read hook and callback in `nextgen_helpers.ts` precisely (PhaseTimes/AdditionalData/Info/LibraryScript/MintingDetails), then drop ~90 now-redundant `(x.data as any) === true|false` casts across the admin components.
2. **Remaining nextGen sites (51 -> 0)** — event handlers via inference, tuple decodes as `readonly unknown[]` with behavior-identical coercions, `DELEGATION_ABI` casts narrowed `any -> Abi`, precise local shapes (CSSProperties/ReactNode/SwiperClass).
3. **Platform layer** — helpers (`areEqualAddresses`, `isEmptyObject`, fullscreen vendor members), idb-keyval, error-sanitizer, upload-error, drop-hasher, wave-eligibility callbacks, useManifoldClaim decode record, entities (`NFTTokenMetadata` for NFT/Rememe metadata blobs, `DBResponse.next: unknown`).
4. **Timeline** — `any` params were already-declared `string` on the NFTHistory entity; propagated.
5. **Component/app scatter (44 files)** — nft-transfer, lexical edit reconstruction, manifold minting, mapping tools (typed csv-parser imports), distribution plan, pagination, open-graph/pepe services, user pages, model-viewer declaration.
6. **no-base-to-string cleanup** — the sweep's `String(unknown)` coercions tripped the lint rule (blind to the old any-typed versions doing the same); replaced with typeof narrowing / bigint assertions for uint256 reads.

## Changes
- `any_casts` ratchet baseline: **358 -> 65**. The remainder is fully accounted in `ops/workstreams/repo-health-2026-07/any-exceptions.md`: 3 documented exceptions (wagmi `createConnector` conditional return), 1 regex false positive (blog prose "as any"), ~60 deferred to the delegation rewrite (Thread C), 1 deferred to the `src/` fold (Thread D).
- One latent type bug surfaced and fixed: `LibraryScript.script` tuple slot was silently `any`, actually `string[]`.
- Intentional micro-fixes (disclosed): `fetchCollection` returns null instead of crashing when the nextgen collection fetch failed; a few unguarded error-crash paths now degrade to defaults — no happy-path behavior changes anywhere.
- Run-log + exceptions ledger under `ops/workstreams/repo-health-2026-07/`.

## Validation
- Full jest suite green on this branch (1959+ suites; targeted re-runs after every stage: 72/354 nextGen, 138/1486 platform, 1163/5723 scatter, 68/841 post-lint-fix)
- `tsc` (strict, incl. noUncheckedIndexedAccess/exactOptionalPropertyTypes/noPropertyAccessFromIndexSignature): green
- eslint over all 140 changed files: green; knip: green; debt ratchet: green with lowered baseline
- No runtime edits except the disclosed behavior-identical coercions and micro-fixes above

## Risk
- Level: Medium (large surface) mitigated by mechanical patterns
- Why: types-only by policy; every stage validated independently; contract-read coercions (`String`/`Number`/`bigint.toString`) are runtime-identical for viem's decoded values
- Rollback: revert the merge commit

## Review Notes
- `components/delegation/**` intentionally untouched (owned by the styling workstream's rewrite).
- `NextGenAdminUpdateCollection.tsx` keeps a deliberate `i as unknown as number` string-key array lookup to preserve exact legacy semantics for non-canonical numeric input; commented in the diff discussion if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability across login, access, restricted, and upload flows by handling response and error data more safely.
  * Fixed several cases where missing or empty data could cause incorrect loading, display, or navigation behavior.

* **Refactor**
  * Strengthened type handling across many app areas for more consistent behavior and fewer runtime issues.
  * Updated wallet, leaderboard, NFT, NextGen, and wave-related flows for safer data parsing and rendering.

* **Style**
  * Refreshed some form, table, picker, and list layouts for cleaner spacing and input behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->