### PR TITLE
TODO triage to zero: complete codemod shims, ticket the real work

### DIFF
--- a/__tests__/components/nft-picker/NftPicker.test.tsx
+++ b/__tests__/components/nft-picker/NftPicker.test.tsx
@@ -2,11 +2,11 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 
-import { NftPicker } from "@/components/nft-picker/NftPicker";
+import { NftPicker } from "@/components/nft-picker";
 import type {
   ContractOverview,
   NftPickerProps,
-} from "@/components/nft-picker/NftPicker.types";
+} from "@/components/nft-picker/types";
 import {
   useCollectionSearch,
   useContractOverviewQuery,

--- a/__tests__/components/nft-picker/NftPicker.utils.test.ts
+++ b/__tests__/components/nft-picker/NftPicker.utils.test.ts
@@ -11,9 +11,9 @@ import {
   sortAndDedupIds,
   toCanonicalRanges,
   tryToNumberArray,
-} from "@/components/nft-picker/NftPicker.utils";
+} from "@/components/nft-picker/utils";
 
-import type { TokenRange } from "@/components/nft-picker/NftPicker.types";
+import type { TokenRange } from "@/components/nft-picker/types";
 
 describe("NftPicker.utils", () => {
   describe("parseTokenExpressionToBigints", () => {
@@ -59,8 +59,7 @@ describe("NftPicker.utils", () => {
     });
 
     it("throws parse errors for invalid segments", () => {
-      expect(() => parseTokenExpressionToBigints("1,foo"))
-        .toThrow();
+      expect(() => parseTokenExpressionToBigints("1,foo")).toThrow();
       try {
         parseTokenExpressionToBigints("1,foo");
       } catch (error) {
@@ -71,13 +70,15 @@ describe("NftPicker.utils", () => {
     });
 
     it("throws a parse error when a single range exceeds the enumeration ceiling", () => {
-      expect(() => parseTokenExpressionToRanges("0-10000"))
-        .toThrow();
+      expect(() => parseTokenExpressionToRanges("0-10000")).toThrow();
       try {
         parseTokenExpressionToRanges("0-10000");
       } catch (error) {
         expect(Array.isArray(error)).toBe(true);
-        const errors = error as { code?: string | undefined; message: string }[];
+        const errors = error as {
+          code?: string | undefined;
+          message: string;
+        }[];
         expect(errors[0]?.code).toBe("range-too-large");
         expect(errors[0]?.message).toContain("exceeding the limit");
       }
@@ -90,7 +91,10 @@ describe("NftPicker.utils", () => {
         parseTokenExpressionToBigints(input);
       } catch (error) {
         expect(Array.isArray(error)).toBe(true);
-        const errors = error as { code?: string | undefined; message: string }[];
+        const errors = error as {
+          code?: string | undefined;
+          message: string;
+        }[];
         expect(errors[0]?.code).toBe("range-too-large");
         expect(errors[0]?.message).toContain(MAX_ENUMERATION.toString());
       }
@@ -98,13 +102,7 @@ describe("NftPicker.utils", () => {
   });
 
   it("sorts and deduplicates token ids", () => {
-    const result = sortAndDedupIds([
-      5n,
-      3n,
-      3n,
-      4n,
-      1n,
-    ]);
+    const result = sortAndDedupIds([5n, 3n, 3n, 4n, 1n]);
     expect(result).toEqual([1n, 3n, 4n, 5n]);
   });
 

--- a/__tests__/components/user/xtdh/granted-list/UserPageXtdhGrantedListContent.test.tsx
+++ b/__tests__/components/user/xtdh/granted-list/UserPageXtdhGrantedListContent.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { UserPageXtdhGrantedListContent } from "@/components/user/xtdh/granted-list/UserPageXtdhGrantedListContent";
+import UserPageXtdhGrantedListContent from "@/components/user/xtdh/granted-list";
 import type { ApiXTdhGrant } from "@/generated/models/ApiXTdhGrant";
 
 describe("UserPageXtdhGrantedListContent", () => {
@@ -15,10 +15,7 @@ describe("UserPageXtdhGrantedListContent", () => {
 
   it("shows filter-specific empty state when a status filter is active", () => {
     render(
-      <UserPageXtdhGrantedListContent
-        {...baseProps}
-        statuses={["PENDING"]}
-      />
+      <UserPageXtdhGrantedListContent {...baseProps} statuses={["PENDING"]} />
     );
 
     expect(screen.getByText("No grants found")).toBeInTheDocument();
@@ -26,10 +23,7 @@ describe("UserPageXtdhGrantedListContent", () => {
 
   it("falls back to the default empty state when no status filter is applied", () => {
     render(
-      <UserPageXtdhGrantedListContent
-        {...baseProps}
-        statuses={["ALL"]}
-      />
+      <UserPageXtdhGrantedListContent {...baseProps} statuses={["ALL"]} />
     );
 
     expect(screen.getByText("No grants yet")).toBeInTheDocument();

--- a/__tests__/components/user/xtdh/granted-list/subcomponents/GrantTokensDisclosure.test.tsx
+++ b/__tests__/components/user/xtdh/granted-list/subcomponents/GrantTokensDisclosure.test.tsx
@@ -1,27 +1,30 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { GrantTokensDisclosure } from "@/components/user/xtdh/granted-list/subcomponents/UserPageXtdhGrantListItem/subcomponents/GrantTokensDisclosure";
-import { SupportedChain } from "@/components/nft-picker/NftPicker.types";
+import { SupportedChain } from "@/components/nft-picker/types";
 
 // Mock the hook
-jest.mock("@/components/user/xtdh/granted-list/subcomponents/UserPageXtdhGrantListItem/hooks/useGrantTokensDisclosure", () => ({
-  useGrantTokensDisclosure: jest.fn(() => ({
-    isOpen: false,
-    panelId: "panel-id",
-    toggleOpen: jest.fn(),
-    disclosureState: {
-      showInitialLoading: false,
-      showInitialError: false,
-      tokenRanges: [],
-      errorMessage: "",
-      onRetry: jest.fn(),
-      contractAddress: null,
-      chain: null,
-      grantId: "grant-id",
-      onEndReached: jest.fn(),
-      isFetchingNextPage: false,
-    }
-  })),
-}));
+jest.mock(
+  "@/components/user/xtdh/granted-list/subcomponents/UserPageXtdhGrantListItem/hooks/useGrantTokensDisclosure",
+  () => ({
+    useGrantTokensDisclosure: jest.fn(() => ({
+      isOpen: false,
+      panelId: "panel-id",
+      toggleOpen: jest.fn(),
+      disclosureState: {
+        showInitialLoading: false,
+        showInitialError: false,
+        tokenRanges: [],
+        errorMessage: "",
+        onRetry: jest.fn(),
+        contractAddress: null,
+        chain: null,
+        grantId: "grant-id",
+        onEndReached: jest.fn(),
+        isFetchingNextPage: false,
+      },
+    })),
+  })
+);
 
 import { useGrantTokensDisclosure } from "@/components/user/xtdh/granted-list/subcomponents/UserPageXtdhGrantListItem/hooks/useGrantTokensDisclosure";
 
@@ -56,7 +59,7 @@ describe("GrantTokensDisclosure", () => {
         grantId: "grant-id",
         onEndReached: jest.fn(),
         isFetchingNextPage: false,
-      }
+      },
     });
 
     render(
@@ -88,7 +91,7 @@ describe("GrantTokensDisclosure", () => {
         grantId: "grant-id",
         onEndReached: jest.fn(),
         isFetchingNextPage: false,
-      }
+      },
     });
 
     render(

--- a/__tests__/components/user/xtdh/granted-list/subcomponents/GrantTokensDisclosure.test.tsx
+++ b/__tests__/components/user/xtdh/granted-list/subcomponents/GrantTokensDisclosure.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { GrantTokensDisclosure } from "@/components/user/xtdh/granted-list/subcomponents/UserPageXtdhGrantListItem/subcomponents/GrantTokensDisclosure";
-import { SupportedChain } from "@/components/nft-picker/types";
 
 // Mock the hook
 jest.mock(

--- a/__tests__/components/waves/create-wave/voting/MemeCardSetPicker.test.tsx
+++ b/__tests__/components/waves/create-wave/voting/MemeCardSetPicker.test.tsx
@@ -10,7 +10,7 @@ jest.mock("@/services/api/common-api", () => ({
   commonApiFetch: jest.fn(),
 }));
 
-jest.mock("@/components/nft-picker/NftPicker", () => {
+jest.mock("@/components/nft-picker", () => {
   const { MEMES_CONTRACT } = jest.requireActual("@/constants/constants");
   const nonMemeContract = "0x0000000000000000000000000000000000000001";
 

--- a/components/nft-picker/NftPicker.tsx
+++ b/components/nft-picker/NftPicker.tsx
@@ -1,2 +1,0 @@
-// TODO: remove after codemod
-export { NftPicker } from "./index";

--- a/components/nft-picker/NftPicker.types.ts
+++ b/components/nft-picker/NftPicker.types.ts
@@ -1,2 +1,0 @@
-// TODO: remove after codemod
-export type * from "./types";

--- a/components/nft-picker/NftPicker.utils.ts
+++ b/components/nft-picker/NftPicker.utils.ts
@@ -1,2 +1,0 @@
-// TODO: remove after codemod
-export * from "./utils";

--- a/components/token-list/components/GridRow.tsx
+++ b/components/token-list/components/GridRow.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties, ReactNode } from "react";
 import type { UseQueryResult } from "@tanstack/react-query";
-import type { TokenMetadata } from "@/components/nft-picker/NftPicker.types";
+import type { TokenMetadata } from "@/components/nft-picker/types";
 import type { TokenListAction, TokenWindowEntry } from "../types";
 import { TokenThumbnail } from "./TokenThumbnail";
 

--- a/components/token-list/components/TokenRow.tsx
+++ b/components/token-list/components/TokenRow.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 import type { CSSProperties, ReactNode } from "react";
-import type { TokenMetadata } from "@/components/nft-picker/NftPicker.types";
+import type { TokenMetadata } from "@/components/nft-picker/types";
 import type { TokenListAction, TokenWindowEntry } from "../types";
 import { TokenThumbnail } from "./TokenThumbnail";
 

--- a/components/token-list/components/TokenThumbnail.tsx
+++ b/components/token-list/components/TokenThumbnail.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 import type { ReactNode } from "react";
 import Spinner from "@/components/utils/Spinner";
-import type { TokenMetadata } from "@/components/nft-picker/NftPicker.types";
+import type { TokenMetadata } from "@/components/nft-picker/types";
 
 type TokenThumbnailProps = Readonly<{
   metadata?: TokenMetadata | undefined;
@@ -10,7 +10,12 @@ type TokenThumbnailProps = Readonly<{
   hasError: boolean;
 }>;
 
-export function TokenThumbnail({ metadata, decimalId, isLoading, hasError }: Readonly<TokenThumbnailProps>) {
+export function TokenThumbnail({
+  metadata,
+  decimalId,
+  isLoading,
+  hasError,
+}: Readonly<TokenThumbnailProps>) {
   let content: ReactNode;
 
   if (metadata?.imageUrl) {
@@ -37,7 +42,7 @@ export function TokenThumbnail({ metadata, decimalId, isLoading, hasError }: Rea
     content = (
       <div
         aria-label="Failed to load thumbnail"
-        className="tw-flex tw-h-full tw-w-full tw-flex-col tw-items-center tw-justify-center tw-text-[10px] tw-font-medium tw-leading-tight tw-text-red-300"
+        className="tw-text-red-300 tw-flex tw-h-full tw-w-full tw-flex-col tw-items-center tw-justify-center tw-text-[10px] tw-font-medium tw-leading-tight"
       >
         <span>Load</span>
         <span>Error</span>

--- a/components/token-list/hooks/useTokenMetadataWindow.ts
+++ b/components/token-list/hooks/useTokenMetadataWindow.ts
@@ -1,6 +1,9 @@
 import { useMemo } from "react";
 import { useTokenMetadataQuery } from "@/hooks/useAlchemyNftQueries";
-import type { SupportedChain, TokenMetadata } from "@/components/nft-picker/NftPicker.types";
+import type {
+  SupportedChain,
+  TokenMetadata,
+} from "@/components/nft-picker/types";
 import { EMPTY_METADATA_MAP } from "../utils";
 import type { TokenWindowEntry } from "../types";
 
@@ -20,9 +23,7 @@ export function useTokenMetadataWindow({
     [windowTokens]
   );
   const canLoadMetadata = Boolean(
-    contractAddress &&
-    chain &&
-    decimalTokenIds.length > 0
+    contractAddress && chain && decimalTokenIds.length > 0
   );
 
   const metadataQuery = useTokenMetadataQuery({

--- a/components/token-list/hooks/useVisibleTokenWindow.ts
+++ b/components/token-list/hooks/useVisibleTokenWindow.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
-import { expandRangesWindow } from "@/components/nft-picker/NftPicker.utils";
-import type { TokenRange } from "@/components/nft-picker/NftPicker.types";
+import { expandRangesWindow } from "@/components/nft-picker/utils";
+import type { TokenRange } from "@/components/nft-picker/types";
 import { toDecimalString } from "../utils";
 import type { TokenWindowEntry } from "../types";
 
@@ -24,10 +24,12 @@ export function useVisibleTokenWindow(
     }
 
     const windowSize = lastTokenIndex - firstTokenIndex + 1;
-    return expandRangesWindow(ranges, firstTokenIndex, windowSize).map((tokenId) => ({
-      tokenId,
-      decimalId: toDecimalString(tokenId),
-      xtdh: 0, // Default to 0 for ranges
-    }));
+    return expandRangesWindow(ranges, firstTokenIndex, windowSize).map(
+      (tokenId) => ({
+        tokenId,
+        decimalId: toDecimalString(tokenId),
+        xtdh: 0, // Default to 0 for ranges
+      })
+    );
   }, [ranges, firstTokenIndex, lastTokenIndex, tokens]);
 }

--- a/components/token-list/types.ts
+++ b/components/token-list/types.ts
@@ -3,7 +3,7 @@ import type {
   SupportedChain,
   TokenMetadata,
   TokenRange,
-} from "@/components/nft-picker/NftPicker.types";
+} from "@/components/nft-picker/types";
 
 export type TokenListAction = {
   label: string;

--- a/components/token-list/utils.ts
+++ b/components/token-list/utils.ts
@@ -1,7 +1,4 @@
-import type {
-  TokenMetadata,
-  TokenRange,
-} from "@/components/nft-picker/NftPicker.types";
+import type { TokenMetadata, TokenRange } from "@/components/nft-picker/types";
 
 export const ROW_HEIGHT = 72;
 export const GRID_ROW_HEIGHT = 380; // Taller rows for grid items

--- a/components/user/xtdh/UserPageXtdhGrantSelection.tsx
+++ b/components/user/xtdh/UserPageXtdhGrantSelection.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { NftPicker } from "@/components/nft-picker/NftPicker";
+import { NftPicker } from "@/components/nft-picker";
 import type {
   ContractOverview,
   NftPickerChange,
-} from "@/components/nft-picker/NftPicker.types";
+} from "@/components/nft-picker/types";
 
 export default function UserPageXtdhGrantSelection({
   onContractChange,

--- a/components/user/xtdh/UserPageXtdhGrantSubmit.tsx
+++ b/components/user/xtdh/UserPageXtdhGrantSubmit.tsx
@@ -4,7 +4,7 @@ import type {
   ContractOverview,
   NftPickerChange,
   NftPickerSelectionError,
-} from "@/components/nft-picker/NftPicker.types";
+} from "@/components/nft-picker/types";
 import { formatNumberWithCommas } from "@/helpers/Helpers";
 
 interface UserPageXtdhGrantSubmitProps {

--- a/components/user/xtdh/UserPageXtdhGrantSummary.tsx
+++ b/components/user/xtdh/UserPageXtdhGrantSummary.tsx
@@ -3,7 +3,7 @@ import type {
   NftPickerChange,
   NftPickerSelection,
   NftPickerSelectionError,
-} from "@/components/nft-picker/NftPicker.types";
+} from "@/components/nft-picker/types";
 import {
   formatDateTime,
   formatTdhRatePerToken,

--- a/components/user/xtdh/UserPageXtdhGrantedList.tsx
+++ b/components/user/xtdh/UserPageXtdhGrantedList.tsx
@@ -7,7 +7,7 @@ import {
   ReactQueryWrapperContext,
 } from "@/components/react-query-wrapper/ReactQueryWrapper";
 
-import { UserPageXtdhGrantedListContent } from "@/components/user/xtdh/granted-list/UserPageXtdhGrantedListContent";
+import UserPageXtdhGrantedListContent from "@/components/user/xtdh/granted-list";
 import { UserPageXtdhGrantedListTabs } from "@/components/user/xtdh/user-page-xtdh-granted-list/components/UserPageXtdhGrantedListTabs";
 import { UserPageXtdhGrantedListSubFilters } from "@/components/user/xtdh/user-page-xtdh-granted-list/components/UserPageXtdhGrantedListSubFilters";
 import { getApiParamsFromFilters } from "@/components/user/xtdh/user-page-xtdh-granted-list/constants";

--- a/components/user/xtdh/granted-list/UserPageXtdhGrantedListContent.tsx
+++ b/components/user/xtdh/granted-list/UserPageXtdhGrantedListContent.tsx
@@ -1,4 +1,0 @@
-// Re-export to preserve existing imports during the move.
-// TODO: remove after codemod; prefer direct imports from components/user/xtdh/granted-list/index
-export { default as UserPageXtdhGrantedListContent } from "./index";
-export * from "./index";

--- a/components/user/xtdh/granted-list/subcomponents/UserPageXtdhGrantListItem/subcomponents/GrantTokensDisclosure.tsx
+++ b/components/user/xtdh/granted-list/subcomponents/UserPageXtdhGrantListItem/subcomponents/GrantTokensDisclosure.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
 
-import type { SupportedChain } from "@/components/nft-picker/NftPicker.types";
+import type { SupportedChain } from "@/components/nft-picker/types";
 import { VirtualizedTokenList } from "@/components/token-list/VirtualizedTokenList";
 import Spinner from "@/components/utils/Spinner";
 
@@ -20,7 +20,6 @@ interface GrantTokensDisclosureProps {
   readonly grantId: string;
   readonly tokensCount: number | null;
   readonly tokensCountLabel: string;
-
 }
 
 export function GrantTokensDisclosure({
@@ -29,7 +28,6 @@ export function GrantTokensDisclosure({
   grantId,
   tokensCount,
   tokensCountLabel,
-
 }: Readonly<GrantTokensDisclosureProps>) {
   const { isOpen, panelId, toggleOpen, disclosureState } =
     useGrantTokensDisclosure({
@@ -50,7 +48,7 @@ export function GrantTokensDisclosure({
       <button
         type="button"
         className={clsx(
-          "tw-group tw-flex tw-w-full tw-items-center tw-justify-center tw-gap-2 tw-rounded-lg tw-border-none tw-px-4 tw-py-3 tw-transition-colors tw-duration-200 tw-appearance-none focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950 desktop-hover:hover:tw-bg-iron-900",
+          "tw-group tw-flex tw-w-full tw-appearance-none tw-items-center tw-justify-center tw-gap-2 tw-rounded-lg tw-border-none tw-px-4 tw-py-3 tw-transition-colors tw-duration-200 focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-400 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-iron-950 desktop-hover:hover:tw-bg-iron-900",
           isOpen ? "tw-bg-iron-900" : "tw-bg-iron-900/30"
         )}
         onClick={toggleOpen}
@@ -83,29 +81,25 @@ export function GrantTokensDisclosure({
   );
 }
 
-function renderGrantTokensDisclosureBody(
-  {
-    showInitialLoading,
-    showInitialError,
-    tokenRanges,
-    tokens,
-    errorMessage,
-    onRetry,
-    contractAddress,
-    chain,
-    grantId,
-    onEndReached,
-    isFetchingNextPage,
-  }: GrantTokensDisclosureState,
-): ReactNode {
+function renderGrantTokensDisclosureBody({
+  showInitialLoading,
+  showInitialError,
+  tokenRanges,
+  tokens,
+  errorMessage,
+  onRetry,
+  contractAddress,
+  chain,
+  grantId,
+  onEndReached,
+  isFetchingNextPage,
+}: GrantTokensDisclosureState): ReactNode {
   if (showInitialLoading) {
     return <GrantTokensLoadingState />;
   }
 
   if (showInitialError) {
-    return (
-      <GrantTokensErrorState message={errorMessage} onRetry={onRetry} />
-    );
+    return <GrantTokensErrorState message={errorMessage} onRetry={onRetry} />;
   }
 
   if (tokenRanges.length === 0) {
@@ -149,11 +143,11 @@ function GrantTokensErrorState({
   onRetry,
 }: Readonly<{ message: string; onRetry: () => void }>) {
   return (
-    <div className="tw-rounded-lg tw-border tw-border-red-500/40 tw-bg-red-500/5 tw-p-4">
-      <p className="tw-m-0 tw-text-sm tw-text-red-300">{message}</p>
+    <div className="tw-border-red-500/40 tw-bg-red-500/5 tw-rounded-lg tw-border tw-p-4">
+      <p className="tw-text-red-300 tw-m-0 tw-text-sm">{message}</p>
       <button
         type="button"
-        className="tw-mt-3 tw-rounded-md tw-border tw-border-red-500/60 tw-bg-transparent tw-px-3 tw-py-1.5 tw-text-sm tw-font-semibold tw-text-red-200 desktop-hover:hover:tw-bg-red-500/10"
+        className="tw-border-red-500/60 tw-text-red-200 desktop-hover:hover:tw-bg-red-500/10 tw-mt-3 tw-rounded-md tw-border tw-bg-transparent tw-px-3 tw-py-1.5 tw-text-sm tw-font-semibold"
         onClick={onRetry}
       >
         Retry
@@ -164,7 +158,7 @@ function GrantTokensErrorState({
 
 function GrantTokensEmptyState() {
   return (
-    <div className="tw-rounded-lg tw-border tw-border-iron-800 tw-bg-iron-925 tw-p-4">
+    <div className="tw-bg-iron-925 tw-rounded-lg tw-border tw-border-iron-800 tw-p-4">
       <p className="tw-m-0 tw-text-sm tw-text-iron-300">
         No specific token IDs were returned for this grant.
       </p>

--- a/components/user/xtdh/granted-list/subcomponents/UserPageXtdhGrantListItem/subcomponents/GrantTokensPanel.tsx
+++ b/components/user/xtdh/granted-list/subcomponents/UserPageXtdhGrantListItem/subcomponents/GrantTokensPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { SupportedChain } from "@/components/nft-picker/NftPicker.types";
+import type { SupportedChain } from "@/components/nft-picker/types";
 
 import type { TokenPanelState } from "../types";
 

--- a/components/user/xtdh/granted-list/subcomponents/UserPageXtdhGrantListItem/types.ts
+++ b/components/user/xtdh/granted-list/subcomponents/UserPageXtdhGrantListItem/types.ts
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import type { TokenRange } from "@/components/nft-picker/NftPicker.types";
+import type { TokenRange } from "@/components/nft-picker/types";
 import type { ApiXTdhGrant } from "@/generated/models/ApiXTdhGrant";
 
 import type { ContractOverview, SupportedChain } from "@/types/nft";

--- a/components/user/xtdh/granted-list/subcomponents/UserPageXtdhGrantListItem/utils/grantTokens.ts
+++ b/components/user/xtdh/granted-list/subcomponents/UserPageXtdhGrantListItem/utils/grantTokens.ts
@@ -1,6 +1,6 @@
 import { getNodeEnv } from "@/config/env";
-import type { TokenRange } from "@/components/nft-picker/NftPicker.types";
-import { toCanonicalRanges } from "@/components/nft-picker/NftPicker.utils";
+import type { TokenRange } from "@/components/nft-picker/types";
+import { toCanonicalRanges } from "@/components/nft-picker/utils";
 
 const DEFAULT_GRANT_TOKENS_ERROR_MESSAGE =
   "We couldn't load the granted tokens right now. Please try again.";

--- a/components/user/xtdh/user-page-xtdh-grant/types.ts
+++ b/components/user/xtdh/user-page-xtdh-grant/types.ts
@@ -2,7 +2,7 @@ import type {
   ContractOverview,
   NftPickerChange,
   NftPickerSelection,
-} from "@/components/nft-picker/NftPicker.types";
+} from "@/components/nft-picker/types";
 
 interface UserPageXtdhGrantFormState {
   contract: ContractOverview | null;

--- a/components/waves/create-wave/voting/MemeCardSetPicker.tsx
+++ b/components/waves/create-wave/voting/MemeCardSetPicker.tsx
@@ -2,8 +2,8 @@
 
 import { type ReactNode, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { NftPicker } from "@/components/nft-picker/NftPicker";
-import type { NftPickerChange } from "@/components/nft-picker/NftPicker.types";
+import { NftPicker } from "@/components/nft-picker";
+import type { NftPickerChange } from "@/components/nft-picker/types";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
 import type { NFTSearchResult } from "@/components/header/header-search/HeaderSearchModalItem";
 import { MEMES_CONTRACT } from "@/constants/constants";

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -404,7 +404,7 @@ export const baseRules = deepFreezeRuleConfig({
   "tailwindcss/enforces-negative-arbitrary-values": "error", // Use -top-[5px] not top-[-5px]
   "tailwindcss/enforces-shorthand": "off",
   "tailwindcss/no-arbitrary-value": "off", // Allow arbitrary values like w-[123px]
-  "tailwindcss/no-custom-classname": "off", // TODO: enable later
+  "tailwindcss/no-custom-classname": "off", // enabling tracked in issue #3053
   "tailwindcss/no-contradicting-classname": "off",
   "tailwindcss/no-unnecessary-arbitrary-value": "off",
 

--- a/helpers/waves/create-wave.helpers.ts
+++ b/helpers/waves/create-wave.helpers.ts
@@ -427,8 +427,7 @@ export const getCreateNewWaveBody = ({
   readonly parentWaveId?: string | null | undefined;
 }): ApiCreateNewWave => {
   const endDate = getCreateWaveEndDate({ config });
-  const supportsParticipationTerms =
-    config.overview.type !== ApiWaveType.Chat;
+  const supportsParticipationTerms = config.overview.type !== ApiWaveType.Chat;
   const participationTerms = supportsParticipationTerms
     ? normalizeWaveCustomRules(config.drops.terms)
     : null;
@@ -511,7 +510,6 @@ export const getCreateNewWaveBody = ({
         config.overview.type === ApiWaveType.Approve
           ? (config.approval.thresholdTimeMs ?? 0)
           : null,
-      // TODO - should be in outcomes
       max_winners: getApproveMaxWinners({ config }),
       max_votes_per_identity_to_drop:
         config.overview.type === ApiWaveType.Chat

--- a/ops/workstreams/repo-health-2026-07/run-log.md
+++ b/ops/workstreams/repo-health-2026-07/run-log.md
@@ -267,6 +267,7 @@ useDownloader.test.ts` failed to LOAD on main (its bare `@capacitor/core` mock
   "remove after codemod" re-export shims, 1 secure-logging work item,
   1 stale API-shape comment). Triage PR follows: shims completed+deleted,
   work items become consolidated GitHub issues, stale comment deleted.
+
 ## 2026-07-05 (orchestrator — Redux verification + production deploy train)
 
 - User mandate: full E2E verification of the Redux removal (#3047), bot-iterated
@@ -305,3 +306,18 @@ useDownloader.test.ts` failed to LOAD on main (its bare `@capacitor/core` mock
   (clipboard/copy-text feature); orchestrator records moved to disposable
   worktrees — do not branch-switch the primary checkout while that work is
   live.
+
+## 2026-07-05 (Thread E — TODO triage complete)
+
+- Ratchet `todo_comments` 6 -> 0. Disposition: 4 "remove after codemod"
+  re-export shims completed (importers migrated to the real modules;
+  shims deleted: nft-picker NftPicker/NftPicker.types/NftPicker.utils,
+  xtdh granted-list UserPageXtdhGrantedListContent); 2 real work items
+  consolidated into issue #3053 (error-sanitizer secure-logging
+  integration, tailwindcss/no-custom-classname enablement) with the
+  in-code comments now referencing the issue; 1 stale API-shape comment
+  deleted (create-wave max_winners placement is fixed by the generated
+  API contract, not frontend-actionable).
+- Non-source TODO mentions that remain are intentional: skill docs that
+  document TODO conventions, the campaign docs, and the ratchet's own
+  detection patterns/fixtures.

--- a/scripts/debt-ratchet-baseline.json
+++ b/scripts/debt-ratchet-baseline.json
@@ -3,7 +3,7 @@
   "max_source_file_lines": 800,
   "counts": {
     "any_casts": 64,
-    "todo_comments": 6,
+    "todo_comments": 0,
     "oversized_files": 90,
     "bootstrap_imports": 0,
     "redux_imports": 0,

--- a/utils/error-sanitizer.ts
+++ b/utils/error-sanitizer.ts
@@ -287,8 +287,9 @@ export const logErrorSecurely = (context: string, error: unknown): void => {
   // Instead, log a sanitized version
   const sanitizedMessage = sanitizeErrorForUser(error);
 
-  // TODO: Integrate with secure logging service (e.g., Sentry, DataDog, CloudWatch)
-  // For now, we'll use console.error with sanitized data only
+  // Forwarding the sanitized payload to a monitoring service is tracked in
+  // https://github.com/6529-Collections/6529seize-frontend/issues/3053
+  // For now, we use console.error with sanitized data only
   if (publicEnv.NODE_ENV !== "test") {
     // Avoid console spam in tests
     console.error(`[${timestamp}] [${context}] Error:`, sanitizedMessage);


### PR DESCRIPTION
## Issue
- The debt ratchet's `todo_comments` metric stood at 6. Triage per the dead-patterns workstream: fix what is finishable, ticket what needs real work, delete what is stale. (The 2026-07-04 audit's 2,841 figure did not reproduce under the ratchet's word-boundary definition; 6 was the real count in shippable source.)

## Fix
Disposition of all six markers:
- **4 fixed — codemod completed.** The four "TODO: remove after codemod" re-export shims are now removable because every importer has been migrated to the real modules: `components/nft-picker/NftPicker{,.types,.utils}` -> `components/nft-picker/{index,types,utils}` and `components/user/xtdh/granted-list/UserPageXtdhGrantedListContent` -> the granted-list index (named import switched to the index's default export). 22 importers rewritten, 4 shim files deleted.
- **2 ticketed.** The error-sanitizer secure-logging integration and the `tailwindcss/no-custom-classname` enablement are real work items -> consolidated tracking issue #3053; the in-code comments now reference the issue instead of carrying a bare TODO.
- **1 deleted (stale).** `create-wave.helpers` "should be in outcomes": `max_winners` placement is dictated by the generated API contract, so the comment was not actionable in this repo.

## Changes
- 22 import-path rewrites (token-list, xtdh, MemeCardSetPicker, nft-picker tests), 4 file deletions
- `utils/error-sanitizer.ts`, `eslint.config.mjs`: TODO comments replaced with issue #3053 references
- `helpers/waves/create-wave.helpers.ts`: stale comment removed (no code change)
- Ratchet baseline: `todo_comments` 6 -> 0; run-log entry added

## Validation
- Full jest suite green on this branch (1959 suites / 11048 tests)
- `tsc` strict: green; knip: green (no dangling module refs after shim deletion); debt ratchet green with the lowered baseline
- Targeted suites over every rewritten import area: 120 suites / 790 tests green

## Risk
- Level: Low
- Why: import-path swaps with identical export surfaces (verified per-name before rewrite); comment-only changes otherwise
- Rollback: revert the merge commit

## Review Notes
- The granted-list consumers previously imported a named re-export; the target index only default-exports, so those two imports became default imports (same component, same JSX usage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized NFT picker and related type utility imports across the app (token list, grant flows, and voting UI).
  * Removed redundant component/type export shims and updated a few UI class ordering/formatting details without changing behavior.
* **Chores**
  * Cleaned up repository TODO tracking and updated maintenance-related notes (lint/comment/documentation).
* **Tests**
  * Updated unit tests and mocks to use the revised module entry points and adjusted assertion formatting to match existing expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->