### PR TITLE
Keep Lexical out of grouped dependabot runtime updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,18 @@ updates:
     labels:
       - "dependencies"
       - "dependabot"
+    # Lexical is 0.x, so a "minor" bump behaves like a major and breaks the
+    # drop composer (e.g. 0.14 -> 0.46 changed the LexicalErrorBoundary export
+    # and broke the build in PR #3015). Keep the whole family out of the grouped
+    # runtime PRs and stop dependabot proposing the breaking 0.x jumps; the
+    # upgrade needs a dedicated, hand-tested migration instead.
+    ignore:
+      - dependency-name: "lexical"
+        update-types:
+          - "version-update:semver-minor"
+      - dependency-name: "@lexical/*"
+        update-types:
+          - "version-update:semver-minor"
     groups:
       dev-patch:
         dependency-type: "development"
@@ -23,9 +35,15 @@ updates:
           - "minor"
       runtime-patch:
         dependency-type: "production"
+        exclude-patterns:
+          - "lexical"
+          - "@lexical/*"
         update-types:
           - "patch"
       runtime-minor:
         dependency-type: "production"
+        exclude-patterns:
+          - "lexical"
+          - "@lexical/*"
         update-types:
           - "minor"


### PR DESCRIPTION
## Issue
Lexical is 0.x, so dependabot treats its breaking releases as "minor". The 0.14 -> 0.46 bump changed the `LexicalErrorBoundary` export from default to named and broke the composer build, which failed the entire `runtime-minor` group PR (#3015) and blocked all 16 other updates in that group.

## Fix
- Exclude `lexical` and `@lexical/*` from the `runtime-minor` and `runtime-patch` groups so the grouped runtime PRs build cleanly.
- Ignore the lexical family's `version-update:semver-minor` bumps so dependabot stops re-proposing the breaking 0.x jumps. The Lexical upgrade needs a dedicated, hand-tested migration.

## Risk
Low — CI/dependabot config only, no app code.

## Follow-up
The actual Lexical upgrade (and the coordinated @reown/appkit + @wagmi/core bump from the closed #2986) remain separate manual efforts.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update rules to avoid automatic Lexical 0.x version bumps that could introduce breaking changes.
  * Adjusted grouped update behavior so Lexical packages are excluded from routine runtime patch and minor upgrade proposals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->