### PR TITLE
Fix E2E locators for the navigation IA and staging title

### DIFF
--- a/tests/home/home.spec.ts
+++ b/tests/home/home.spec.ts
@@ -12,7 +12,8 @@ test.describe("Home Page @smoke @medium @large", () => {
   });
 
   test("should display the home landing content", async ({ page }) => {
-    await expect(page).toHaveTitle("6529.io");
+    // Prod serves "6529.io"; staging serves "6529 Staging".
+    await expect(page).toHaveTitle(/^6529(\.io| Staging)$/);
     await expectNoHorizontalOverflow(page);
 
     await expect(page.getByText(/^(Latest|Next) Drop$/)).toBeVisible();

--- a/tests/surfaces/core-surfaces.spec.ts
+++ b/tests/surfaces/core-surfaces.spec.ts
@@ -13,7 +13,7 @@ import {
 } from "../support/surfaceSimulation";
 
 const NAVIGATION_TIMEOUT_MS = 15000;
-const WAVE_SCORE_RESULT = /Wave Score.*About.*Network Data/i;
+const WAVE_SCORE_RESULT = /Wave Score.*About.*Network & Reputation/i;
 const WAVE_SCORE_HEADING = "Wave score transparency";
 const REQUIRED_DELEGATION_ACTIONS = [
   "Register Delegation",
@@ -98,8 +98,8 @@ test.describe("Core app surface coverage @surface @medium @large", () => {
     await gotoReady(page, "/");
 
     const nav = page.getByRole("navigation", { name: "Desktop navigation" });
-    await nav.getByRole("button", { name: "About" }).click();
-    await nav.getByRole("button", { name: "Network Data" }).click();
+    await nav.getByRole("button", { name: "About", exact: true }).click();
+    await nav.getByRole("button", { name: "Network & Reputation" }).click();
     await nav.getByRole("link", { name: "TDH", exact: true }).click();
 
     await expect(page).toHaveURL(/\/network\/tdh$/);
@@ -186,7 +186,7 @@ test.describe("Core app surface coverage @surface @medium @large", () => {
     await expectLinkHref(page, "Definitions", "/network/definitions");
     await expectLinkHref(
       page,
-      "View Network Stats",
+      "View Network TDH Stats",
       "/network/health/network-tdh"
     );
     await expectLinkHref(page, "View Levels", "/network/levels");


### PR DESCRIPTION
## Issue
Six surface/home E2E checks had drifted from the shipped navigation IA and were failing on **both production and staging** (i.e. pre-existing, not from any recent feature work — confirmed by baselining prod before the latest release):
- `desktop sidebar navigates About Network Data to TDH`: `getByRole('button', { name: 'About' })` matched both the top-level "About" section and the new "About 6529" group (strict-mode violation), and the sub-group is now "Network & Reputation", not "Network Data".
- `desktop/mobile header search opens the Wave Score page`: the result breadcrumb is now "About • Network & Reputation".
- `TDH explainer links to network reference pages`: the link is labelled "View Network TDH Stats".
- `home landing content`: asserted `toHaveTitle('6529.io')`, but staging serves "6529 Staging".

## Fix
- About sidebar: `{ name: 'About', exact: true }` then `Network & Reputation`.
- Wave Score search regex → `/Wave Score.*About.*Network & Reputation/i`.
- TDH reference link → "View Network TDH Stats".
- Home title → `/^6529(\.io| Staging)$/` (environment-aware).

## Validation
Ran the affected suites against both environments: **16/16 passed on https://6529.io and 16/16 on https://staging.6529.io** (staging exercises the "6529 Staging" title branch and the access gate).

## Risk
Low — test-only changes; no app code.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated page and navigation checks to handle environment-specific titles and current menu/link labels, improving test reliability across staging and production-like environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->