### PR TITLE
Run staging E2E packs automatically after staging deploys

### DIFF
--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -16,14 +16,27 @@ concurrency:
 jobs:
   staging-packs:
     name: Staging E2E packs
+    # Trust gate: this job holds a secret and executes checked-out code, so
+    # workflow_run triggers must come from this repository's own 1a-staging
+    # branch (staging deploys are push-triggered; forks cannot push there).
+    # The explicit head_repository/head_branch conditions keep that invariant
+    # enforced even if the upstream deploy workflow's triggers ever change.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_repository.full_name == github.repository &&
+        github.event.workflow_run.head_branch == '1a-staging'
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 90
     env:
       PLAYWRIGHT_STAGING_ACCESS_CODE: ${{ secrets.PLAYWRIGHT_STAGING_ACCESS_CODE }}
     steps:
+      # workflow_run: the exact SHA the staging deploy shipped. Manual
+      # dispatch falls back to the branch tip, which may differ from what is
+      # currently deployed to staging — fine for ad-hoc reruns, but prefer
+      # letting the deploy trigger this workflow for deployed-SHA fidelity.
       - name: Check out the deployed ref
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -78,12 +91,24 @@ jobs:
           failed=0
           echo "## Staging E2E packs" >> "$GITHUB_STEP_SUMMARY"
           for pack in "${packs[@]}"; do
-            if ./bin/6529 run "$pack"; then
+            log="$(mktemp)"
+            if ./bin/6529 run "$pack" 2>&1 | tee "$log"; then
               echo "- :white_check_mark: \`$pack\`" >> "$GITHUB_STEP_SUMMARY"
             else
               failed=1
-              echo "- :x: \`$pack\`" >> "$GITHUB_STEP_SUMMARY"
+              {
+                echo "- :x: \`$pack\`"
+                echo ""
+                echo "<details><summary>Last 25 log lines for \`$pack\`</summary>"
+                echo ""
+                echo '```'
+                tail -25 "$log"
+                echo '```'
+                echo ""
+                echo "</details>"
+              } >> "$GITHUB_STEP_SUMMARY"
             fi
+            rm -f "$log"
           done
           exit "$failed"
 

--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -1,0 +1,99 @@
+name: Staging E2E
+
+on:
+  workflow_run:
+    workflows: ["Web Deploy - STAGING"]
+    types: [completed]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: staging-e2e
+  cancel-in-progress: true
+
+jobs:
+  staging-packs:
+    name: Staging E2E packs
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      PLAYWRIGHT_STAGING_ACCESS_CODE: ${{ secrets.PLAYWRIGHT_STAGING_ACCESS_CODE }}
+    steps:
+      - name: Check out the deployed ref
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          persist-credentials: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+
+      - name: Activate pinned pnpm
+        run: |
+          corepack enable pnpm
+          corepack prepare "$(node -p 'require("./package.json").packageManager')" --activate
+          pnpm --version
+
+      - name: Install Socket Firewall
+        id: socket_firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall
+
+      - name: Assert npm lockfile is absent
+        run: ./bin/6529 guard:no-package-lock
+
+      - name: Install dependencies
+        env:
+          SFW_BIN: ${{ steps.socket_firewall.outputs.firewall-path-binary }}
+        run: ./bin/6529 install:frozen
+
+      - name: Install Playwright browser
+        run: ./bin/6529 exec playwright install --with-deps chromium
+
+      - name: Run staging packs against staging.6529.io
+        run: |
+          set -uo pipefail
+          packs=(
+            test:e2e:staging:smoke
+            test:e2e:staging
+            test:e2e:staging:social-readonly
+            test:e2e:staging:public-groups-tools-readonly
+            test:e2e:staging:delegation-readonly
+            test:e2e:staging:collections-readonly
+            test:e2e:staging:admin-guards-readonly
+            test:e2e:staging:public-content-readonly
+            test:e2e:staging:profile-deep-links-readonly
+            test:e2e:staging:search-waves-readonly
+            test:e2e:staging:media-readonly
+            test:e2e:staging:network-open-data-readonly
+          )
+          failed=0
+          echo "## Staging E2E packs" >> "$GITHUB_STEP_SUMMARY"
+          for pack in "${packs[@]}"; do
+            if ./bin/6529 run "$pack"; then
+              echo "- :white_check_mark: \`$pack\`" >> "$GITHUB_STEP_SUMMARY"
+            else
+              failed=1
+              echo "- :x: \`$pack\`" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+          exit "$failed"
+
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: staging-e2e-artifacts
+          path: |
+            test-results/
+            playwright-report/
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
Closes the gap found during the Redux deploy train: staging is access-gated, the Playwright staging packs existed but nothing ran them, and the access code lived only on one machine.

## What
- `PLAYWRIGHT_STAGING_ACCESS_CODE` added as a repo secret (value validated against the staging gate — HTTP 200 on a gated route — before storing; the e2e harness already redacts it from artifacts).
- New `Staging E2E` workflow: triggers on successful **Web Deploy - STAGING** runs (+ manual dispatch), checks out the deployed SHA, installs via the standard Socket-Firewall/pnpm path, and runs all 12 staging packs with a per-pack step summary. Runs every pack even after a failure; uploads Playwright artifacts on failure.
- Least-privilege: `contents: read`, no credential persistence, actions pinned by SHA (mirrors app-pr-ci).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated staging end-to-end test run that triggers after successful staging deployments and can also be started manually.
  * Enhanced test reporting with clear per-pack success/failure summaries and improved failure details.
* **CI/CD**
  * When staging E2E fails, the test results and Playwright report are uploaded as artifacts for easier troubleshooting (retained for 7 days).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->