### PR TITLE
Yield the quick-DM launcher to bottom-docked wave composers

### DIFF
--- a/__tests__/components/CreateDropWaveWrapper.test.tsx
+++ b/__tests__/components/CreateDropWaveWrapper.test.tsx
@@ -43,4 +43,26 @@ describe("CreateDropWaveWrapper", () => {
     const div = screen.getByText("ok").parentElement as HTMLElement;
     expect(div.className).toContain("tw-max-h-[calc(100vh-8.5rem)]");
   });
+
+  it("registers its container as a composer dock while mounted", () => {
+    const {
+      CreateDropWaveWrapper,
+    } = require("@/components/waves/CreateDropWaveWrapper");
+    const {
+      getWaveComposerDockElements,
+    } = require("@/components/waves/WaveComposerDockVisibility");
+
+    expect(getWaveComposerDockElements()).toEqual([]);
+
+    const { unmount } = render(
+      <CreateDropWaveWrapper>
+        <span>ok</span>
+      </CreateDropWaveWrapper>
+    );
+    const container = screen.getByText("ok").parentElement as HTMLElement;
+    expect(getWaveComposerDockElements()).toEqual([container]);
+
+    unmount();
+    expect(getWaveComposerDockElements()).toEqual([]);
+  });
 });

--- a/__tests__/components/waves/WaveComposerDockVisibility.test.ts
+++ b/__tests__/components/waves/WaveComposerDockVisibility.test.ts
@@ -1,0 +1,41 @@
+import { act, renderHook } from "@testing-library/react";
+
+import {
+  getWaveComposerDockElements,
+  registerWaveComposerDock,
+  useWaveComposerDockElements,
+} from "@/components/waves/WaveComposerDockVisibility";
+
+describe("WaveComposerDockVisibility", () => {
+  it("tracks docked elements and ignores duplicate unregisters", () => {
+    const { result } = renderHook(() => useWaveComposerDockElements());
+    expect(result.current).toEqual([]);
+
+    const firstElement = document.createElement("div");
+    const secondElement = document.createElement("div");
+
+    let unregisterFirst: (() => void) | undefined;
+    let unregisterSecond: (() => void) | undefined;
+    act(() => {
+      unregisterFirst = registerWaveComposerDock(firstElement);
+      unregisterSecond = registerWaveComposerDock(secondElement);
+    });
+    expect(result.current).toEqual([firstElement, secondElement]);
+    expect(getWaveComposerDockElements()).toEqual([
+      firstElement,
+      secondElement,
+    ]);
+
+    act(() => {
+      unregisterFirst?.();
+      unregisterFirst?.();
+    });
+    expect(result.current).toEqual([secondElement]);
+
+    act(() => {
+      unregisterSecond?.();
+    });
+    expect(result.current).toEqual([]);
+    expect(getWaveComposerDockElements()).toEqual([]);
+  });
+});

--- a/__tests__/components/waves/WaveComposerDockVisibility.test.ts
+++ b/__tests__/components/waves/WaveComposerDockVisibility.test.ts
@@ -2,9 +2,28 @@ import { act, renderHook } from "@testing-library/react";
 
 import {
   getWaveComposerDockElements,
+  isAnyDockInsideRightEdgeClearance,
   registerWaveComposerDock,
   useWaveComposerDockElements,
 } from "@/components/waves/WaveComposerDockVisibility";
+
+const elementWithRect = (rect: Partial<DOMRect>): HTMLElement => {
+  const element = document.createElement("div");
+  element.getBoundingClientRect = () =>
+    ({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      bottom: 0,
+      right: 0,
+      width: 0,
+      height: 0,
+      toJSON: () => ({}),
+      ...rect,
+    }) as DOMRect;
+  return element;
+};
 
 describe("WaveComposerDockVisibility", () => {
   it("tracks docked elements and ignores duplicate unregisters", () => {
@@ -37,5 +56,54 @@ describe("WaveComposerDockVisibility", () => {
     });
     expect(result.current).toEqual([]);
     expect(getWaveComposerDockElements()).toEqual([]);
+  });
+
+  describe("isAnyDockInsideRightEdgeClearance", () => {
+    const viewportWidth = 1280;
+    const clearancePx = 88;
+
+    beforeEach(() => {
+      Object.defineProperty(globalThis.window, "innerWidth", {
+        configurable: true,
+        value: viewportWidth,
+      });
+    });
+
+    it("flags a dock whose right edge is inside the clearance strip", () => {
+      const covering = elementWithRect({
+        width: 1000,
+        height: 60,
+        right: viewportWidth - clearancePx + 1,
+      });
+      expect(isAnyDockInsideRightEdgeClearance([covering], clearancePx)).toBe(
+        true
+      );
+    });
+
+    it("ignores docks that stop at or before the clearance boundary", () => {
+      const clear = elementWithRect({
+        width: 1000,
+        height: 60,
+        right: viewportWidth - clearancePx,
+      });
+      expect(isAnyDockInsideRightEdgeClearance([clear], clearancePx)).toBe(
+        false
+      );
+    });
+
+    it("ignores zero-size docks such as a collapsed drop-chat panel", () => {
+      const collapsed = elementWithRect({
+        width: 0,
+        height: 0,
+        right: viewportWidth,
+      });
+      expect(
+        isAnyDockInsideRightEdgeClearance([collapsed], clearancePx)
+      ).toBe(false);
+    });
+
+    it("returns false with no docks registered", () => {
+      expect(isAnyDockInsideRightEdgeClearance([], clearancePx)).toBe(false);
+    });
   });
 });

--- a/components/messages/quick-dms/QuickDirectMessages.tsx
+++ b/components/messages/quick-dms/QuickDirectMessages.tsx
@@ -3,6 +3,7 @@
 import { useAuth } from "@/components/auth/Auth";
 import CreateDirectMessageModal from "@/components/waves/create-dm/CreateDirectMessageModal";
 import { useWaveDropsScrollControlsVisible } from "@/components/waves/drops/WaveDropsScrollControlsVisibility";
+import { useWaveComposerDockElements } from "@/components/waves/WaveComposerDockVisibility";
 import { SIDEBAR_MOBILE_BREAKPOINT } from "@/constants/sidebar";
 import { useMyStream } from "@/contexts/wave/MyStreamContext";
 import { useBrowserLocale } from "@/hooks/useBrowserLocale";
@@ -38,6 +39,11 @@ const QUICK_DM_PANEL_POSITION_CLASS = `${QUICK_DM_BASE_POSITION_CLASS} tw-bottom
 const QUICK_DM_LAUNCHER_BASE_POSITION_CLASS = `${QUICK_DM_BASE_POSITION_CLASS} tw-transition-[bottom] tw-duration-200 tw-ease-out motion-reduce:tw-transition-none`;
 const QUICK_DM_LAUNCHER_RESTING_POSITION_CLASS = "tw-bottom-24 xl:tw-bottom-6";
 const QUICK_DM_LAUNCHER_LIFTED_POSITION_CLASS = "tw-bottom-32 xl:tw-bottom-32";
+// Right inset (tw-right-6) + launcher diameter (tw-size-14) + breathing room.
+// When a bottom-docked wave composer extends into that strip, any fixed
+// bottom-right spot would cover its Post button or the newest drop's hover
+// actions and swallow pointer clicks, so the launcher yields instead.
+const QUICK_DM_LAUNCHER_CLEARANCE_PX = 88;
 
 const getDesktopViewportSnapshot = (): boolean => {
   if (typeof window === "undefined") {
@@ -79,6 +85,8 @@ export default function QuickDirectMessages() {
   const { directMessages, registerWave, requestDirectMessagesList } =
     useMyStream();
   const shouldLiftLauncher = useWaveDropsScrollControlsVisible();
+  const dockedComposers = useWaveComposerDockElements();
+  const [isLauncherZoneCovered, setIsLauncherZoneCovered] = useState(false);
   const [state, setState] = useState<QuickDmState>(() => readStoredState());
   const [isCreateDirectMessageOpen, setIsCreateDirectMessageOpen] =
     useState(false);
@@ -114,6 +122,38 @@ export default function QuickDirectMessages() {
   );
 
   useEffect(() => requestDirectMessagesList(), [requestDirectMessagesList]);
+
+  useEffect(() => {
+    const measureLauncherZone = () => {
+      setIsLauncherZoneCovered(
+        dockedComposers.some((composer) => {
+          const rect = composer.getBoundingClientRect();
+          return (
+            rect.width > 0 &&
+            rect.height > 0 &&
+            globalThis.window.innerWidth - rect.right <
+              QUICK_DM_LAUNCHER_CLEARANCE_PX
+          );
+        })
+      );
+    };
+
+    measureLauncherZone();
+    if (dockedComposers.length === 0) {
+      return;
+    }
+
+    // Width changes (sidebar toggles, layout shifts) re-run the measurement;
+    // viewport resizes are caught by the window listener.
+    const observer = new ResizeObserver(measureLauncherZone);
+    dockedComposers.forEach((composer) => observer.observe(composer));
+    globalThis.window.addEventListener("resize", measureLauncherZone);
+
+    return () => {
+      observer.disconnect();
+      globalThis.window.removeEventListener("resize", measureLauncherZone);
+    };
+  }, [dockedComposers]);
 
   const setAndStoreState = useCallback((nextState: QuickDmState) => {
     setState(nextState);
@@ -247,6 +287,10 @@ export default function QuickDirectMessages() {
     : undefined;
 
   if (state.view === "closed") {
+    if (isLauncherZoneCovered) {
+      return createDirectMessageModal;
+    }
+
     const launcherPositionClassName = `${QUICK_DM_LAUNCHER_BASE_POSITION_CLASS} ${
       shouldLiftLauncher
         ? QUICK_DM_LAUNCHER_LIFTED_POSITION_CLASS

--- a/components/messages/quick-dms/QuickDirectMessages.tsx
+++ b/components/messages/quick-dms/QuickDirectMessages.tsx
@@ -19,6 +19,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
+import { useDebouncedCallback } from "use-debounce";
 import { QuickDmChat } from "./QuickDmChat";
 import { QuickDmListPanel } from "./QuickDmListPanel";
 import { QuickDmLoadingRows } from "./QuickDmPanelPieces";
@@ -123,21 +124,27 @@ export default function QuickDirectMessages() {
 
   useEffect(() => requestDirectMessagesList(), [requestDirectMessagesList]);
 
-  useEffect(() => {
-    const measureLauncherZone = () => {
-      setIsLauncherZoneCovered(
-        dockedComposers.some((composer) => {
-          const rect = composer.getBoundingClientRect();
-          return (
-            rect.width > 0 &&
-            rect.height > 0 &&
-            globalThis.window.innerWidth - rect.right <
-              QUICK_DM_LAUNCHER_CLEARANCE_PX
-          );
-        })
-      );
-    };
+  const measureLauncherZone = useCallback(() => {
+    setIsLauncherZoneCovered(
+      dockedComposers.some((composer) => {
+        const rect = composer.getBoundingClientRect();
+        return (
+          rect.width > 0 &&
+          rect.height > 0 &&
+          globalThis.window.innerWidth - rect.right <
+            QUICK_DM_LAUNCHER_CLEARANCE_PX
+        );
+      })
+    );
+  }, [dockedComposers]);
+  const debouncedMeasureLauncherZone = useDebouncedCallback(
+    measureLauncherZone,
+    100
+  );
 
+  useEffect(() => {
+    // Immediate measurement so dock changes take effect without a flash;
+    // resize streams below go through the debounced path.
     measureLauncherZone();
     if (dockedComposers.length === 0) {
       return;
@@ -145,15 +152,19 @@ export default function QuickDirectMessages() {
 
     // Width changes (sidebar toggles, layout shifts) re-run the measurement;
     // viewport resizes are caught by the window listener.
-    const observer = new ResizeObserver(measureLauncherZone);
+    const observer = new ResizeObserver(debouncedMeasureLauncherZone);
     dockedComposers.forEach((composer) => observer.observe(composer));
-    globalThis.window.addEventListener("resize", measureLauncherZone);
+    globalThis.window.addEventListener("resize", debouncedMeasureLauncherZone);
 
     return () => {
       observer.disconnect();
-      globalThis.window.removeEventListener("resize", measureLauncherZone);
+      globalThis.window.removeEventListener(
+        "resize",
+        debouncedMeasureLauncherZone
+      );
+      debouncedMeasureLauncherZone.cancel();
     };
-  }, [dockedComposers]);
+  }, [dockedComposers, measureLauncherZone, debouncedMeasureLauncherZone]);
 
   const setAndStoreState = useCallback((nextState: QuickDmState) => {
     setState(nextState);

--- a/components/messages/quick-dms/QuickDirectMessages.tsx
+++ b/components/messages/quick-dms/QuickDirectMessages.tsx
@@ -3,7 +3,10 @@
 import { useAuth } from "@/components/auth/Auth";
 import CreateDirectMessageModal from "@/components/waves/create-dm/CreateDirectMessageModal";
 import { useWaveDropsScrollControlsVisible } from "@/components/waves/drops/WaveDropsScrollControlsVisibility";
-import { useWaveComposerDockElements } from "@/components/waves/WaveComposerDockVisibility";
+import {
+  isAnyDockInsideRightEdgeClearance,
+  useWaveComposerDockElements,
+} from "@/components/waves/WaveComposerDockVisibility";
 import { SIDEBAR_MOBILE_BREAKPOINT } from "@/constants/sidebar";
 import { useMyStream } from "@/contexts/wave/MyStreamContext";
 import { useBrowserLocale } from "@/hooks/useBrowserLocale";
@@ -45,6 +48,11 @@ const QUICK_DM_LAUNCHER_LIFTED_POSITION_CLASS = "tw-bottom-32 xl:tw-bottom-32";
 // bottom-right spot would cover its Post button or the newest drop's hover
 // actions and swallow pointer clicks, so the launcher yields instead.
 const QUICK_DM_LAUNCHER_CLEARANCE_PX = 88;
+// Pointer-inert but still keyboard/screen-reader reachable: tabbing to the
+// suppressed launcher reveals it (at the lifted offset, clear of the
+// composer's Post button) so quick DMs never lose their entry point.
+const QUICK_DM_LAUNCHER_SUPPRESSED_CLASS =
+  "tw-pointer-events-none tw-opacity-0 focus-within:tw-pointer-events-auto focus-within:tw-opacity-100";
 
 const getDesktopViewportSnapshot = (): boolean => {
   if (typeof window === "undefined") {
@@ -125,16 +133,15 @@ export default function QuickDirectMessages() {
   useEffect(() => requestDirectMessagesList(), [requestDirectMessagesList]);
 
   const measureLauncherZone = useCallback(() => {
+    if (typeof globalThis.window === "undefined") {
+      return;
+    }
+
     setIsLauncherZoneCovered(
-      dockedComposers.some((composer) => {
-        const rect = composer.getBoundingClientRect();
-        return (
-          rect.width > 0 &&
-          rect.height > 0 &&
-          globalThis.window.innerWidth - rect.right <
-            QUICK_DM_LAUNCHER_CLEARANCE_PX
-        );
-      })
+      isAnyDockInsideRightEdgeClearance(
+        dockedComposers,
+        QUICK_DM_LAUNCHER_CLEARANCE_PX
+      )
     );
   }, [dockedComposers]);
   const debouncedMeasureLauncherZone = useDebouncedCallback(
@@ -143,6 +150,12 @@ export default function QuickDirectMessages() {
   );
 
   useEffect(() => {
+    // Hidden instances (mobile, logged out, waves disabled) render nothing,
+    // so they skip measuring and never attach observers.
+    if (!isVisible) {
+      return;
+    }
+
     // Immediate measurement so dock changes take effect without a flash;
     // resize streams below go through the debounced path.
     measureLauncherZone();
@@ -164,7 +177,12 @@ export default function QuickDirectMessages() {
       );
       debouncedMeasureLauncherZone.cancel();
     };
-  }, [dockedComposers, measureLauncherZone, debouncedMeasureLauncherZone]);
+  }, [
+    dockedComposers,
+    isVisible,
+    measureLauncherZone,
+    debouncedMeasureLauncherZone,
+  ]);
 
   const setAndStoreState = useCallback((nextState: QuickDmState) => {
     setState(nextState);
@@ -298,14 +316,14 @@ export default function QuickDirectMessages() {
     : undefined;
 
   if (state.view === "closed") {
-    if (isLauncherZoneCovered) {
-      return createDirectMessageModal;
-    }
-
-    const launcherPositionClassName = `${QUICK_DM_LAUNCHER_BASE_POSITION_CLASS} ${
-      shouldLiftLauncher
+    // While the launcher zone is covered it reveals at the lifted offset on
+    // focus, clear of the docked composer's Post button.
+    const launcherOffsetClassName =
+      shouldLiftLauncher || isLauncherZoneCovered
         ? QUICK_DM_LAUNCHER_LIFTED_POSITION_CLASS
-        : QUICK_DM_LAUNCHER_RESTING_POSITION_CLASS
+        : QUICK_DM_LAUNCHER_RESTING_POSITION_CLASS;
+    const launcherPositionClassName = `${QUICK_DM_LAUNCHER_BASE_POSITION_CLASS} ${launcherOffsetClassName}${
+      isLauncherZoneCovered ? ` ${QUICK_DM_LAUNCHER_SUPPRESSED_CLASS}` : ""
     }`;
 
     return (

--- a/components/waves/CreateDropWaveWrapper.tsx
+++ b/components/waves/CreateDropWaveWrapper.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useCallback, useMemo, useRef } from "react";
 import useCapacitor from "@/hooks/useCapacitor";
 import { useDebouncedCallback } from "use-debounce";
+import { registerWaveComposerDock } from "./WaveComposerDockVisibility";
 
 export enum CreateDropWaveWrapperContext {
   WAVE_CHAT = "WAVE_CHAT",
@@ -75,6 +76,15 @@ export function CreateDropWaveWrapper({
 
   const shouldObserve = context !== CreateDropWaveWrapperContext.SINGLE_DROP;
   useResizeObserver(containerRef, fixedBottomRef, shouldObserve);
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) {
+      return;
+    }
+
+    return registerWaveComposerDock(element);
+  }, []);
 
   const containerClassName = useMemo(() => {
     if (capacitor.isIos) {

--- a/components/waves/CreateDropWaveWrapper.tsx
+++ b/components/waves/CreateDropWaveWrapper.tsx
@@ -77,6 +77,10 @@ export function CreateDropWaveWrapper({
   const shouldObserve = context !== CreateDropWaveWrapperContext.SINGLE_DROP;
   useResizeObserver(containerRef, fixedBottomRef, shouldObserve);
 
+  // Registration is deliberately unconditional (unlike shouldObserve):
+  // the SINGLE_DROP chat panel also docks at the viewport's right edge on
+  // desktop, and its collapsed w-0 state is excluded by the consumer's
+  // zero-size rect check.
   useEffect(() => {
     const element = containerRef.current;
     if (!element) {

--- a/components/waves/WaveComposerDockVisibility.ts
+++ b/components/waves/WaveComposerDockVisibility.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+type VisibilityListener = () => void;
+
+const EMPTY_DOCK_ELEMENTS: readonly HTMLElement[] = [];
+
+const listeners = new Set<VisibilityListener>();
+// Bottom-docked wave composer containers currently on screen. Overlays that
+// float in the bottom-right corner (the quick-DM launcher) measure these to
+// decide whether their spot would cover composer controls.
+const dockElements = new Set<HTMLElement>();
+let dockElementsSnapshot: readonly HTMLElement[] = EMPTY_DOCK_ELEMENTS;
+
+const emitDockChange = () => {
+  dockElementsSnapshot =
+    dockElements.size === 0 ? EMPTY_DOCK_ELEMENTS : Array.from(dockElements);
+  listeners.forEach((listener) => listener());
+};
+
+const subscribe = (listener: VisibilityListener): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+const getSnapshot = (): readonly HTMLElement[] => dockElementsSnapshot;
+
+const getServerSnapshot = (): readonly HTMLElement[] => EMPTY_DOCK_ELEMENTS;
+
+export const registerWaveComposerDock = (element: HTMLElement): (() => void) => {
+  dockElements.add(element);
+  emitDockChange();
+
+  return () => {
+    if (dockElements.delete(element)) {
+      emitDockChange();
+    }
+  };
+};
+
+export const getWaveComposerDockElements = (): readonly HTMLElement[] =>
+  dockElementsSnapshot;
+
+// Snapshot identity changes whenever a composer dock mounts or unmounts.
+export const useWaveComposerDockElements = (): readonly HTMLElement[] =>
+  useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);

--- a/components/waves/WaveComposerDockVisibility.ts
+++ b/components/waves/WaveComposerDockVisibility.ts
@@ -44,6 +44,21 @@ export const registerWaveComposerDock = (element: HTMLElement): (() => void) => 
 export const getWaveComposerDockElements = (): readonly HTMLElement[] =>
   dockElementsSnapshot;
 
+// True when any visible dock extends into the right-edge strip that a fixed
+// bottom-right overlay of the given clearance would occupy.
+export const isAnyDockInsideRightEdgeClearance = (
+  docks: readonly HTMLElement[],
+  clearancePx: number
+): boolean =>
+  docks.some((dock) => {
+    const rect = dock.getBoundingClientRect();
+    return (
+      rect.width > 0 &&
+      rect.height > 0 &&
+      globalThis.window.innerWidth - rect.right < clearancePx
+    );
+  });
+
 // Snapshot identity changes whenever a composer dock mounts or unmounts.
 export const useWaveComposerDockElements = (): readonly HTMLElement[] =>
   useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);

--- a/tests/social/wave-edit-drop-sandbox.spec.ts
+++ b/tests/social/wave-edit-drop-sandbox.spec.ts
@@ -45,9 +45,9 @@ test.describe("Wave drop edit local sandbox @auth @medium @local-only", () => {
       .getByRole("textbox", { name: "Write a chat message" })
       .last();
     await composer.fill(SANDBOX_CHAT_DROP_CONTENT);
-    // Enter submits the chat composer; the floating quick-DM button overlays
-    // the Post button at this viewport, so the keyboard path is the stable one.
-    await composer.press("Enter");
+    // Real pointer click on purpose: regression coverage for the quick-DM
+    // launcher overlaying the Post button (WaveComposerDockVisibility).
+    await page.getByRole("button", { name: "Post" }).last().click();
 
     const submittedDrop = page.locator('[data-serial-no="2"]');
     await expect(submittedDrop).toBeVisible({

--- a/tests/social/waves-composer-sandbox.spec.ts
+++ b/tests/social/waves-composer-sandbox.spec.ts
@@ -109,17 +109,12 @@ test.describe("Waves composer local sandbox @auth @medium @local-only", () => {
       page.getByRole("button", { name: "Post" }).last()
     ).toBeEnabled();
 
-    // Programmatic click: the floating quick-DM button can overlay the Post
-    // button at some viewports and intercept a pointer click (same idiom as
-    // showDropActionsIfCollapsed).
-    await page
-      .getByRole("button", { name: "Post" })
-      .last()
-      .evaluate((element) => {
-        if (element instanceof HTMLElement) {
-          element.click();
-        }
-      });
+    // The quick-DM launcher yields to the docked composer at this viewport
+    // (WaveComposerDockVisibility), so a real pointer click must land on Post.
+    await expect(
+      page.getByRole("button", { name: /Open quick direct messages/ })
+    ).toBeHidden();
+    await page.getByRole("button", { name: "Post" }).last().click();
 
     await expect
       .poll(

--- a/tests/social/waves-composer-sandbox.spec.ts
+++ b/tests/social/waves-composer-sandbox.spec.ts
@@ -110,10 +110,15 @@ test.describe("Waves composer local sandbox @auth @medium @local-only", () => {
     ).toBeEnabled();
 
     // The quick-DM launcher yields to the docked composer at this viewport
-    // (WaveComposerDockVisibility), so a real pointer click must land on Post.
-    await expect(
-      page.getByRole("button", { name: /Open quick direct messages/ })
-    ).toBeHidden();
+    // (WaveComposerDockVisibility): pointer-inert (keyboard/screen-reader
+    // reachable) so the real pointer click below must land on Post.
+    if ((page.viewportSize()?.width ?? 0) >= 1024) {
+      await expect(
+        page.getByRole("button", { name: /Open quick direct messages/ })
+      ).toHaveCSS("pointer-events", "none", {
+        timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
+      });
+    }
     await page.getByRole("button", { name: "Post" }).last().click();
 
     await expect

--- a/tests/social/waves-composer-sandbox.spec.ts
+++ b/tests/social/waves-composer-sandbox.spec.ts
@@ -109,10 +109,14 @@ test.describe("Waves composer local sandbox @auth @medium @local-only", () => {
       page.getByRole("button", { name: "Post" }).last()
     ).toBeEnabled();
 
-    // The quick-DM launcher yields to the docked composer at this viewport
+    // Inside the covered band (1280-1455px wide, right sidebar closed) the
+    // quick-DM launcher yields to the docked composer
     // (WaveComposerDockVisibility): pointer-inert (keyboard/screen-reader
-    // reachable) so the real pointer click below must land on Post.
-    if ((page.viewportSize()?.width ?? 0) >= 1024) {
+    // reachable) so the real pointer click below must land on Post. The
+    // desktop project's 1280x720 viewport sits in that band; mobile projects
+    // never render the launcher.
+    const viewportWidth = page.viewportSize()?.width ?? 0;
+    if (viewportWidth >= 1280 && viewportWidth <= 1455) {
       await expect(
         page.getByRole("button", { name: /Open quick direct messages/ })
       ).toHaveCSS("pointer-events", "none", {


### PR DESCRIPTION
## Problem

The floating quick-DM launcher (`aria-label "Open quick direct messages"`, fixed `right-6 xl:bottom-6 z-[70]`) sits directly on top of the wave composer's **Post** button at common desktop viewports and intercepts real pointer clicks on `/waves/<id>` (and `/messages/<id>`) pages.

Measured overlap envelope (Chromium, sandbox wave, right sidebar closed — the default state):

| Viewport | Overlap with Post | Post center click |
|---|---|---|
| 1280x720 | 55x28 px | **intercepted by launcher** |
| 1366x768 | 56x28 px | **intercepted by launcher** |
| 1440x900 | 20x28 px (right edge of button) | lands, but right-half clicks intercepted |
| ≥1536 wide | none (free gutter) | lands |
| <1280 wide | none (launcher rests at `bottom-24`) | lands |
| any width, right sidebar open | none (composer shifts 352px left) | lands |

`tests/social/waves-composer-sandbox.spec.ts` and `tests/social/wave-edit-drop-sandbox.spec.ts` had worked around this with programmatic `element.click()` / `Enter` submits; CodeRabbit flagged the workaround on PR #3070.

## Why not just move the launcher up

First attempt lifted the launcher to `bottom-24` on wave pages — the edit-drop spec immediately caught the launcher swallowing the **Edit** hover action of the newest drop instead. At 1280–1455px the chat column reaches the viewport's right edge, so *every* fixed bottom-right offset covers some interactive chat control (composer row → newest drop's hover toolbar → scroll pills). Vertical repositioning only relocates the dead zone.

## Fix

The launcher yields to the composer based on real geometry, without losing keyboard/screen-reader access:

- `CreateDropWaveWrapper` registers its container element in a new `WaveComposerDockVisibility` registry (same pattern as `WaveDropsScrollControlsVisibility`). Covers wave chat and the drop-detail overlay chat (whose desktop variant is an in-flow 400px right panel under the launcher; its collapsed `w-0` state is excluded by a zero-size check).
- `QuickDirectMessages` measures registered composers (debounced `ResizeObserver` + window `resize`): if a docked composer extends into the launcher's corner strip (< 88px free gutter = `right-6` inset + `size-14` diameter + margin), the launcher becomes **pointer-inert instead of unmounting**: `pointer-events-none` + `opacity-0` on its fixed container, revealed via `focus-within` at the lifted offset. Pointer clicks pass through to Post; tabbing to the launcher shows it (clear of the Post button) so quick DMs stay reachable for keyboard and screen-reader users (WCAG 2.1.1).
- Suppression updates live: right sidebar toggles, viewport resizes, navigating on/off waves. Non-composer pages and ≥1536px wave pages are pixel-identical to before. Hidden component instances (mobile, logged out) skip the measurement entirely.

## Tests

- Restored **real `.click()`** on Post in both sandbox specs (plus an assertion that the launcher computes `pointer-events: none` at the covered viewport) — these fail if anything overlays the composer again. The edit-drop spec's real Edit-hover click also guards the "just lift it" regression.
- Unit tests: registry semantics, wrapper registration lifecycle, and the pure clearance predicate `isAnyDockInsideRightEdgeClearance` (inside strip / at boundary / zero-size collapsed panel / empty).
- Verified live at 1024/1280/1366/1440/1536/1920 widths x {sidebar closed, open, re-closed}: Post trial clicks land everywhere, `elementFromPoint` at Post center always resolves to Post, focus reveals the suppressed launcher (`pointer-events: auto`, `opacity: 1`, lifted offset) and blur re-suppresses it.
- `test:e2e:composer-sandbox` 10/10, `test:e2e:edit-drop-sandbox` 2/2, `typecheck:ci` clean, eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wave-composer “dock visibility” tracking to coordinate launcher/layout behavior based on measured dock overlap.
* **Bug Fixes**
  * Improved quick direct message launcher behavior when composer docks are present—automatically lifting or suppressing the launcher when the launcher zone is covered, and updating on resize.
* **Tests**
  * Added/expanded coverage for dock registration/unregistration and right-edge clearance logic, plus updated sandbox specs to use real Post-button clicks to better reflect production interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->