### PR TITLE
Treat hybrid touch laptops as desktop via shared touch-first detection

### DIFF
--- a/__tests__/components/ChatItemHrefButtons.test.tsx
+++ b/__tests__/components/ChatItemHrefButtons.test.tsx
@@ -2,20 +2,20 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ChatItemHrefButtons from "@/components/waves/ChatItemHrefButtons";
 import { LinkPreviewProvider } from "@/components/waves/LinkPreviewContext";
-import useHasTouchInput from "@/hooks/useHasTouchInput";
+import useIsTouchDevice from "@/hooks/useIsTouchDevice";
 import useIsMobileDevice from "@/hooks/isMobileDevice";
 
-jest.mock("@/hooks/useHasTouchInput");
+jest.mock("@/hooks/useIsTouchDevice");
 jest.mock("@/hooks/isMobileDevice");
 
 const writeText = jest.fn().mockResolvedValue(undefined);
 
-const useHasTouchInputMock = useHasTouchInput as jest.Mock;
+const useIsTouchDeviceMock = useIsTouchDevice as jest.Mock;
 const useIsMobileDeviceMock = useIsMobileDevice as jest.Mock;
 
 describe("ChatItemHrefButtons", () => {
   beforeEach(() => {
-    useHasTouchInputMock.mockReturnValue(false);
+    useIsTouchDeviceMock.mockReturnValue(false);
     useIsMobileDeviceMock.mockReturnValue(false);
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
@@ -452,7 +452,7 @@ describe("ChatItemHrefButtons", () => {
   });
 
   it("keeps the overlay trigger visible on touch devices", () => {
-    useHasTouchInputMock.mockReturnValue(true);
+    useIsTouchDeviceMock.mockReturnValue(true);
 
     render(
       <div className="tw-group/link-card tw-relative">

--- a/__tests__/components/providers/LayoutWrapper.test.tsx
+++ b/__tests__/components/providers/LayoutWrapper.test.tsx
@@ -107,6 +107,15 @@ describe("LayoutWrapper layout selection", () => {
     expect(screen.getByTestId("small-screen-layout")).toBeInTheDocument();
   });
 
+  it("uses SmallScreenLayout for touch-first tablets between the small and tablet breakpoints", () => {
+    // 900px: wider than the small-screen cutoff (750) but inside the tablet
+    // viewport (<1024) — exercises the isTouchTabletViewport OR-branch.
+    setDeviceInfo({ hasTouchScreen: true });
+    setViewportWidth(900);
+    renderLayout();
+    expect(screen.getByTestId("small-screen-layout")).toBeInTheDocument();
+  });
+
   it("keeps SmallScreenLayout for phone user agents even with a mouse attached", () => {
     // A mouse gives the phone a fine pointer, so touch-first detection turns
     // false — the mobile UA must still pin the phone to the small layout.

--- a/__tests__/components/providers/LayoutWrapper.test.tsx
+++ b/__tests__/components/providers/LayoutWrapper.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from "@testing-library/react";
+import LayoutWrapper from "@/components/providers/LayoutWrapper";
+import useDeviceInfo from "@/hooks/useDeviceInfo";
+import useIsMobileScreen from "@/hooks/isMobileScreen";
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/",
+}));
+
+jest.mock("@/components/layout/WebLayout", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="web-layout">{children}</div>
+  ),
+}));
+
+jest.mock("@/components/layout/SmallScreenLayout", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="small-screen-layout">{children}</div>
+  ),
+}));
+
+jest.mock("@/components/layout/MobileLayout", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="mobile-layout">{children}</div>
+  ),
+}));
+
+jest.mock("@/components/footer/FooterWrapper", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/contexts/RefreshContext", () => ({
+  useGlobalRefresh: () => ({ refreshKey: 0 }),
+}));
+
+jest.mock("@/utils/monitoring/mobileLaunchTiming", () => ({
+  markMobileLaunchStep: jest.fn(),
+  scheduleMobileLaunchFlush: jest.fn(),
+}));
+
+jest.mock("@/hooks/useDeviceInfo");
+jest.mock("@/hooks/isMobileScreen");
+
+const useDeviceInfoMock = useDeviceInfo as jest.Mock;
+const useIsMobileScreenMock = useIsMobileScreen as jest.Mock;
+
+function setDeviceInfo({
+  isApp = false,
+  hasTouchScreen = false,
+  isMobileDevice = false,
+} = {}) {
+  useDeviceInfoMock.mockReturnValue({
+    isApp,
+    hasTouchScreen,
+    isMobileDevice,
+    isAppleMobile: false,
+  });
+}
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+  useIsMobileScreenMock.mockReturnValue(width <= 750);
+}
+
+function renderLayout() {
+  return render(
+    <LayoutWrapper>
+      <div data-testid="content" />
+    </LayoutWrapper>
+  );
+}
+
+describe("LayoutWrapper layout selection", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("uses WebLayout on a wide desktop without touch", () => {
+    setDeviceInfo();
+    setViewportWidth(1440);
+    renderLayout();
+    expect(screen.getByTestId("web-layout")).toBeInTheDocument();
+  });
+
+  it("keeps WebLayout on hybrid touch laptops in narrow windows (Surface regression)", () => {
+    // Touch-first detection reports false for hybrids and the UA is not
+    // mobile, so even a snapped/narrow window must stay on the web layout.
+    setDeviceInfo({ hasTouchScreen: false, isMobileDevice: false });
+    setViewportWidth(950);
+    renderLayout();
+    expect(screen.getByTestId("web-layout")).toBeInTheDocument();
+    expect(screen.queryByTestId("small-screen-layout")).not.toBeInTheDocument();
+  });
+
+  it("uses SmallScreenLayout for touch-first devices at narrow widths", () => {
+    setDeviceInfo({ hasTouchScreen: true });
+    setViewportWidth(390);
+    renderLayout();
+    expect(screen.getByTestId("small-screen-layout")).toBeInTheDocument();
+  });
+
+  it("keeps SmallScreenLayout for phone user agents even with a mouse attached", () => {
+    // A mouse gives the phone a fine pointer, so touch-first detection turns
+    // false — the mobile UA must still pin the phone to the small layout.
+    setDeviceInfo({ hasTouchScreen: false, isMobileDevice: true });
+    setViewportWidth(390);
+    renderLayout();
+    expect(screen.getByTestId("small-screen-layout")).toBeInTheDocument();
+    expect(screen.queryByTestId("web-layout")).not.toBeInTheDocument();
+  });
+
+  it("uses WebLayout for mobile user agents on wide viewports", () => {
+    setDeviceInfo({ isMobileDevice: true });
+    setViewportWidth(1440);
+    renderLayout();
+    expect(screen.getByTestId("web-layout")).toBeInTheDocument();
+  });
+
+  it("always uses MobileLayout inside the native app", () => {
+    setDeviceInfo({ isApp: true, hasTouchScreen: true, isMobileDevice: true });
+    setViewportWidth(390);
+    renderLayout();
+    expect(screen.getByTestId("mobile-layout")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/waves/drops/WaveDrop.test.tsx
+++ b/__tests__/components/waves/drops/WaveDrop.test.tsx
@@ -322,7 +322,9 @@ describe("WaveDrop", () => {
     await waitFor(() => expect(mobileMenuProps?.isOpen).toBe(true));
   });
 
-  it("keeps touch entry in compact touch layouts even when hover is available", () => {
+  it("keeps hybrid touchscreen laptops on desktop interactions even in compact layouts", () => {
+    // Regression: a Windows touch laptop in a snapped/narrow window must NOT
+    // switch to the touch sheet — it still has hover input.
     isMobileMock.mockReturnValue(false);
     hasTouchInputMock.mockReturnValue(true);
     isTouchDeviceMock.mockReturnValue(false);
@@ -346,20 +348,20 @@ describe("WaveDrop", () => {
       />
     );
 
-    expect(screen.queryByTestId("actions")).not.toBeInTheDocument();
+    expect(screen.getByTestId("actions")).toBeInTheDocument();
     expect(getLastMockProps(mockWaveDropHeader)).toEqual(
-      expect.objectContaining({ showActionsButton: true })
+      expect.objectContaining({ showActionsButton: false })
     );
     expect(getLastMockProps(mockWaveDropContent)).toEqual(
-      expect.objectContaining({ hasTouch: true })
+      expect.objectContaining({ hasTouch: false })
     );
   });
 
-  it("clears an open touch sheet when the layout switches to desktop hover mode", async () => {
+  it("clears an open touch sheet when hover input appears at desktop width", async () => {
     isMobileMock.mockReturnValue(false);
     hasTouchInputMock.mockReturnValue(true);
-    isTouchDeviceMock.mockReturnValue(false);
-    setHoverSupport(true);
+    isTouchDeviceMock.mockReturnValue(true);
+    setHoverSupport(false);
     setViewportWidth(800);
 
     renderWithEditingDropProvider(
@@ -388,6 +390,8 @@ describe("WaveDrop", () => {
     await waitFor(() => expect(mobileMenuProps?.isOpen).toBe(true));
 
     act(() => {
+      // e.g. iPad gaining a trackpad: hover appears and the viewport widens.
+      setHoverSupport(true);
       setViewportWidth(1440);
     });
 

--- a/__tests__/helpers/touch-first.helpers.test.ts
+++ b/__tests__/helpers/touch-first.helpers.test.ts
@@ -1,0 +1,197 @@
+import {
+  hasFinePointerCapability,
+  hasHoverCapability,
+  hasTouchCapability,
+  isTouchFirstEnvironment,
+  subscribeToTouchFirstChanges,
+} from "@/helpers/touch-first.helpers";
+
+type QueryMatches = Record<string, boolean>;
+
+interface MockMediaQueryList {
+  matches: boolean;
+  media: string;
+  addEventListener?: jest.Mock;
+  removeEventListener?: jest.Mock;
+  addListener?: jest.Mock;
+  removeListener?: jest.Mock;
+}
+
+const createdMqls: MockMediaQueryList[] = [];
+
+function defineMatchMedia(queryMatches: QueryMatches) {
+  createdMqls.length = 0;
+  Object.defineProperty(globalThis, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: jest.fn((query: string) => {
+      const mql: MockMediaQueryList = {
+        matches: queryMatches[query] ?? false,
+        media: query,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      };
+      createdMqls.push(mql);
+      return mql;
+    }),
+  });
+}
+
+function defineMaxTouchPoints(value: number) {
+  Object.defineProperty(globalThis.navigator, "maxTouchPoints", {
+    configurable: true,
+    value,
+  });
+}
+
+describe("touch-first helpers", () => {
+  const originalMatchMedia = globalThis.matchMedia;
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+    defineMaxTouchPoints(0);
+  });
+
+  describe("isTouchFirstEnvironment", () => {
+    it("is false on a Windows touch laptop (touch + trackpad + hover)", () => {
+      // Surface-style hybrid: 10 touch points but a fine pointer and hover.
+      defineMaxTouchPoints(10);
+      defineMatchMedia({
+        "(any-pointer: fine)": true,
+        "(pointer: fine)": true,
+        "(any-hover: hover)": true,
+        "(hover: hover)": true,
+        "(any-pointer: coarse)": true,
+      });
+
+      expect(isTouchFirstEnvironment()).toBe(false);
+    });
+
+    it("is false when the browser mis-reports a coarse primary pointer but a fine pointer exists", () => {
+      // Known Chromium-on-Windows quirk (tablet posture): primary pointer
+      // flips to coarse while the trackpad is still available.
+      defineMaxTouchPoints(10);
+      defineMatchMedia({
+        "(any-pointer: fine)": true,
+        "(pointer: fine)": false,
+        "(any-hover: hover)": true,
+        "(hover: hover)": false,
+        "(any-pointer: coarse)": true,
+      });
+
+      expect(isTouchFirstEnvironment()).toBe(false);
+    });
+
+    it("is true on a phone (touch only, no hover)", () => {
+      defineMaxTouchPoints(5);
+      defineMatchMedia({ "(any-pointer: coarse)": true });
+
+      expect(isTouchFirstEnvironment()).toBe(true);
+    });
+
+    it("is true on touch-only devices that expose only a coarse pointer", () => {
+      defineMaxTouchPoints(0);
+      defineMatchMedia({ "(any-pointer: coarse)": true });
+
+      expect(isTouchFirstEnvironment()).toBe(true);
+    });
+
+    it("is false on a mouse-only desktop", () => {
+      defineMaxTouchPoints(0);
+      defineMatchMedia({
+        "(any-pointer: fine)": true,
+        "(any-hover: hover)": true,
+      });
+
+      expect(isTouchFirstEnvironment()).toBe(false);
+    });
+
+    it("honors an observed touchstart when capabilities are hidden", () => {
+      defineMaxTouchPoints(0);
+      defineMatchMedia({});
+
+      expect(isTouchFirstEnvironment()).toBe(false);
+      expect(isTouchFirstEnvironment({ touchDetected: true })).toBe(true);
+    });
+
+    it("is false when matchMedia is unavailable and there is no touch", () => {
+      defineMaxTouchPoints(0);
+      Object.defineProperty(globalThis, "matchMedia", {
+        configurable: true,
+        writable: true,
+        value: undefined,
+      });
+
+      expect(isTouchFirstEnvironment()).toBe(false);
+    });
+  });
+
+  describe("capability helpers", () => {
+    it("detects fine pointers from either primary or any-pointer queries", () => {
+      defineMatchMedia({ "(pointer: fine)": true });
+      expect(hasFinePointerCapability()).toBe(true);
+
+      defineMatchMedia({ "(any-pointer: fine)": true });
+      expect(hasFinePointerCapability()).toBe(true);
+
+      defineMatchMedia({});
+      expect(hasFinePointerCapability()).toBe(false);
+    });
+
+    it("detects hover from either primary or any-hover queries", () => {
+      defineMatchMedia({ "(hover: hover)": true });
+      expect(hasHoverCapability()).toBe(true);
+
+      defineMatchMedia({ "(any-hover: hover)": true });
+      expect(hasHoverCapability()).toBe(true);
+
+      defineMatchMedia({});
+      expect(hasHoverCapability()).toBe(false);
+    });
+
+    it("detects touch via maxTouchPoints", () => {
+      defineMatchMedia({});
+      defineMaxTouchPoints(10);
+      expect(hasTouchCapability()).toBe(true);
+
+      defineMaxTouchPoints(0);
+      expect(hasTouchCapability()).toBe(false);
+    });
+  });
+
+  describe("subscribeToTouchFirstChanges", () => {
+    it("subscribes and unsubscribes from capability media queries", () => {
+      defineMatchMedia({});
+      const onChange = jest.fn();
+
+      const unsubscribe = subscribeToTouchFirstChanges(onChange);
+      expect(createdMqls.length).toBeGreaterThan(0);
+      for (const mql of createdMqls) {
+        expect(mql.addEventListener).toHaveBeenCalledWith("change", onChange);
+      }
+
+      unsubscribe();
+      for (const mql of createdMqls) {
+        expect(mql.removeEventListener).toHaveBeenCalledWith(
+          "change",
+          onChange
+        );
+      }
+    });
+
+    it("is a no-op without matchMedia", () => {
+      Object.defineProperty(globalThis, "matchMedia", {
+        configurable: true,
+        writable: true,
+        value: undefined,
+      });
+
+      const unsubscribe = subscribeToTouchFirstChanges(jest.fn());
+      expect(() => unsubscribe()).not.toThrow();
+    });
+  });
+});

--- a/__tests__/helpers/touch-first.helpers.test.ts
+++ b/__tests__/helpers/touch-first.helpers.test.ts
@@ -157,6 +157,22 @@ describe("touch-first helpers", () => {
       expect(isTouchFirstEnvironment()).toBe(true);
     });
 
+    it("keeps Android tablets on desktop via the UA fallback when client hints are unavailable", () => {
+      // Tablet UAs omit "Mobile"; the phone fallback must not match them.
+      defineMaxTouchPoints(5);
+      defineMatchMedia({
+        "(any-pointer: fine)": true,
+        "(any-hover: hover)": true,
+        "(any-pointer: coarse)": true,
+      });
+      defineUserAgentData(undefined);
+      defineUserAgent(
+        "Mozilla/5.0 (Linux; Android 15; Pixel Tablet) AppleWebKit/537.36 Chrome/126 Safari/537.36"
+      );
+
+      expect(isTouchFirstEnvironment()).toBe(false);
+    });
+
     it("keeps tablets with a trackpad on desktop when client hints say not mobile", () => {
       // Android tablet UAs still contain "Android", but client hints report
       // mobile=false — the tablet+trackpad combo must stay desktop.

--- a/__tests__/helpers/touch-first.helpers.test.ts
+++ b/__tests__/helpers/touch-first.helpers.test.ts
@@ -44,8 +44,27 @@ function defineMaxTouchPoints(value: number) {
   });
 }
 
+function defineUserAgent(value: string) {
+  Object.defineProperty(globalThis.navigator, "userAgent", {
+    configurable: true,
+    value,
+  });
+}
+
+function defineUserAgentData(mobile: boolean | undefined) {
+  if (mobile === undefined) {
+    Reflect.deleteProperty(globalThis.navigator, "userAgentData");
+    return;
+  }
+  Object.defineProperty(globalThis.navigator, "userAgentData", {
+    configurable: true,
+    value: { mobile },
+  });
+}
+
 describe("touch-first helpers", () => {
   const originalMatchMedia = globalThis.matchMedia;
+  const originalUserAgent = globalThis.navigator.userAgent;
 
   afterEach(() => {
     Object.defineProperty(globalThis, "matchMedia", {
@@ -54,6 +73,8 @@ describe("touch-first helpers", () => {
       value: originalMatchMedia,
     });
     defineMaxTouchPoints(0);
+    defineUserAgent(originalUserAgent);
+    defineUserAgentData(undefined);
   });
 
   describe("isTouchFirstEnvironment", () => {
@@ -106,6 +127,49 @@ describe("touch-first helpers", () => {
         "(any-pointer: fine)": true,
         "(any-hover: hover)": true,
       });
+
+      expect(isTouchFirstEnvironment()).toBe(false);
+    });
+
+    it("keeps phones touch-first when a paired mouse adds hover and a fine pointer", () => {
+      defineMaxTouchPoints(5);
+      defineMatchMedia({
+        "(any-pointer: fine)": true,
+        "(any-hover: hover)": true,
+        "(any-pointer: coarse)": true,
+      });
+      defineUserAgentData(true);
+
+      expect(isTouchFirstEnvironment()).toBe(true);
+    });
+
+    it("keeps stylus phones touch-first via the user-agent fallback", () => {
+      defineMaxTouchPoints(5);
+      defineMatchMedia({
+        "(any-hover: hover)": true,
+        "(any-pointer: coarse)": true,
+      });
+      defineUserAgentData(undefined);
+      defineUserAgent(
+        "Mozilla/5.0 (Linux; Android 15; SM-S928B) AppleWebKit/537.36 Chrome/126 Mobile Safari/537.36"
+      );
+
+      expect(isTouchFirstEnvironment()).toBe(true);
+    });
+
+    it("keeps tablets with a trackpad on desktop when client hints say not mobile", () => {
+      // Android tablet UAs still contain "Android", but client hints report
+      // mobile=false — the tablet+trackpad combo must stay desktop.
+      defineMaxTouchPoints(5);
+      defineMatchMedia({
+        "(any-pointer: fine)": true,
+        "(any-hover: hover)": true,
+        "(any-pointer: coarse)": true,
+      });
+      defineUserAgentData(false);
+      defineUserAgent(
+        "Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 Chrome/126 Safari/537.36"
+      );
 
       expect(isTouchFirstEnvironment()).toBe(false);
     });

--- a/__tests__/hooks/useDeviceInfo.test.ts
+++ b/__tests__/hooks/useDeviceInfo.test.ts
@@ -166,4 +166,16 @@ describe("useDeviceInfo", () => {
     const { result } = renderHook(() => useDeviceInfo());
     expect(result.current.hasTouchScreen).toBe(true);
   });
+
+  it("keeps hasTouchScreen true for phones that pair a mouse (hover + fine pointer)", () => {
+    // A Bluetooth mouse on a phone adds hover and a fine pointer, but the
+    // mobile UA keeps the device touch-first.
+    capacitorMock.mockReturnValue({ isCapacitor: false });
+    defineUserAgent("iPhone");
+    defineMaxTouchPoints(5);
+    defineMatchMedia({ finePointer: true, hover: true });
+    const { result } = renderHook(() => useDeviceInfo());
+    expect(result.current.hasTouchScreen).toBe(true);
+    expect(result.current.isMobileDevice).toBe(true);
+  });
 });

--- a/__tests__/hooks/useDeviceInfo.test.ts
+++ b/__tests__/hooks/useDeviceInfo.test.ts
@@ -9,30 +9,49 @@ const capacitorMock = require("@/hooks/useCapacitor").default as jest.Mock;
 
 let touchStartHandler: EventListener | null = null;
 
-function defineMatchMedia(pointerFine = true, width = false) {
+interface MatchMediaOptions {
+  readonly finePointer?: boolean;
+  readonly hover?: boolean;
+  readonly narrowWidth?: boolean;
+}
+
+function defineMatchMedia({
+  finePointer = false,
+  hover = false,
+  narrowWidth = false,
+}: MatchMediaOptions = {}) {
   Object.defineProperty(globalThis, "matchMedia", {
     writable: true,
     value: jest.fn((query: string) => {
-      if (query === "(pointer: fine)") {
-        return {
-          matches: pointerFine,
-          addEventListener: jest.fn(),
-          removeEventListener: jest.fn(),
-        };
-      }
-      if (query === "(max-width: 768px)") {
-        return {
-          matches: width,
-          addEventListener: jest.fn(),
-          removeEventListener: jest.fn(),
-        };
+      let matches = false;
+      if (query === "(pointer: fine)" || query === "(any-pointer: fine)") {
+        matches = finePointer;
+      } else if (query === "(hover: hover)" || query === "(any-hover: hover)") {
+        matches = hover;
+      } else if (query === "(max-width: 768px)") {
+        matches = narrowWidth;
       }
       return {
-        matches: false,
+        matches,
+        media: query,
         addEventListener: jest.fn(),
         removeEventListener: jest.fn(),
       };
     }),
+  });
+}
+
+function defineMaxTouchPoints(value: number) {
+  Object.defineProperty(globalThis.navigator, "maxTouchPoints", {
+    value,
+    configurable: true,
+  });
+}
+
+function defineUserAgent(value: string) {
+  Object.defineProperty(globalThis.navigator, "userAgent", {
+    value,
+    configurable: true,
   });
 }
 
@@ -55,15 +74,9 @@ describe("useDeviceInfo", () => {
   });
 
   it("detects classic mobile user agent", () => {
-    Object.defineProperty(globalThis.navigator, "userAgent", {
-      value: "iPhone",
-      configurable: true,
-    });
-    Object.defineProperty(globalThis.navigator, "maxTouchPoints", {
-      value: 5,
-      configurable: true,
-    });
-    defineMatchMedia(false, false);
+    defineUserAgent("iPhone");
+    defineMaxTouchPoints(5);
+    defineMatchMedia();
     const { result } = renderHook(() => useDeviceInfo());
     expect(result.current.isMobileDevice).toBe(true);
     expect(result.current.isAppleMobile).toBe(true);
@@ -73,15 +86,9 @@ describe("useDeviceInfo", () => {
 
   it("detects capacitor mobile with desktop UA", () => {
     capacitorMock.mockReturnValue({ isCapacitor: true });
-    Object.defineProperty(globalThis.navigator, "userAgent", {
-      value: "Macintosh",
-      configurable: true,
-    });
-    Object.defineProperty(globalThis.navigator, "maxTouchPoints", {
-      value: 5,
-      configurable: true,
-    });
-    defineMatchMedia(false, true);
+    defineUserAgent("Macintosh");
+    defineMaxTouchPoints(5);
+    defineMatchMedia({ narrowWidth: true });
     const { result } = renderHook(() => useDeviceInfo());
     expect(result.current.isMobileDevice).toBe(true);
     expect(result.current.isApp).toBe(true);
@@ -91,32 +98,53 @@ describe("useDeviceInfo", () => {
 
   it("returns false for desktop without touch", () => {
     capacitorMock.mockReturnValue({ isCapacitor: false });
-    Object.defineProperty(globalThis.navigator, "userAgent", {
-      value: "Mozilla/5.0",
-      configurable: true,
-    });
-    Object.defineProperty(globalThis.navigator, "maxTouchPoints", {
-      value: 0,
-      configurable: true,
-    });
-    defineMatchMedia(true, false);
+    defineUserAgent("Mozilla/5.0");
+    defineMaxTouchPoints(0);
+    defineMatchMedia({ finePointer: true, hover: true });
     const { result } = renderHook(() => useDeviceInfo());
     expect(result.current.isMobileDevice).toBe(false);
     expect(result.current.hasTouchScreen).toBe(false);
     expect(result.current.isAppleMobile).toBe(false);
   });
 
-  it("hasTouchScreen becomes true on hybrid device after touch even with fine pointer", () => {
+  it("treats a Windows touch laptop (touch + fine pointer + hover) as desktop", () => {
+    // Regression: Surface-style hybrids advertise 10 touch points but have a
+    // trackpad/mouse — they must NOT be classified as touch-first.
     capacitorMock.mockReturnValue({ isCapacitor: false });
-    Object.defineProperty(globalThis.navigator, "userAgent", {
-      value: "Mozilla/5.0",
-      configurable: true,
+    defineUserAgent(
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/126 Safari/537.36"
+    );
+    defineMaxTouchPoints(10);
+    defineMatchMedia({ finePointer: true, hover: true });
+    const { result } = renderHook(() => useDeviceInfo());
+    expect(result.current.hasTouchScreen).toBe(false);
+    expect(result.current.isMobileDevice).toBe(false);
+    expect(result.current.isAppleMobile).toBe(false);
+  });
+
+  it("keeps hasTouchScreen false on hybrid devices even after a touch event", () => {
+    capacitorMock.mockReturnValue({ isCapacitor: false });
+    defineUserAgent("Mozilla/5.0");
+    defineMaxTouchPoints(10);
+    defineMatchMedia({ finePointer: true, hover: true });
+    const { result } = renderHook(() => useDeviceInfo());
+
+    expect(result.current.hasTouchScreen).toBe(false);
+
+    act(() => {
+      if (touchStartHandler) {
+        touchStartHandler(new Event("touchstart"));
+      }
     });
-    Object.defineProperty(globalThis.navigator, "maxTouchPoints", {
-      value: 0,
-      configurable: true,
-    });
-    defineMatchMedia(true, false);
+
+    expect(result.current.hasTouchScreen).toBe(false);
+  });
+
+  it("hasTouchScreen becomes true after touch on devices without fine pointer or hover", () => {
+    capacitorMock.mockReturnValue({ isCapacitor: false });
+    defineUserAgent("Mozilla/5.0");
+    defineMaxTouchPoints(0);
+    defineMatchMedia();
     const { result } = renderHook(() => useDeviceInfo());
 
     expect(result.current.hasTouchScreen).toBe(false);
@@ -130,17 +158,11 @@ describe("useDeviceInfo", () => {
     expect(result.current.hasTouchScreen).toBe(true);
   });
 
-  it("hasTouchScreen is true when maxTouchPoints > 0 even without touch event", () => {
+  it("hasTouchScreen is true when maxTouchPoints > 0 and no fine pointer or hover", () => {
     capacitorMock.mockReturnValue({ isCapacitor: false });
-    Object.defineProperty(globalThis.navigator, "userAgent", {
-      value: "Mozilla/5.0",
-      configurable: true,
-    });
-    Object.defineProperty(globalThis.navigator, "maxTouchPoints", {
-      value: 5,
-      configurable: true,
-    });
-    defineMatchMedia(true, false);
+    defineUserAgent("Mozilla/5.0");
+    defineMaxTouchPoints(5);
+    defineMatchMedia();
     const { result } = renderHook(() => useDeviceInfo());
     expect(result.current.hasTouchScreen).toBe(true);
   });

--- a/__tests__/hooks/useDropActionInteractionMode.test.tsx
+++ b/__tests__/hooks/useDropActionInteractionMode.test.tsx
@@ -92,10 +92,25 @@ describe("useDropActionInteractionMode", () => {
     );
   });
 
-  it("uses the touch sheet instead of desktop actions on compact touch devices with hover", () => {
+  it("keeps desktop actions on compact-width hybrid touch devices with hover (e.g. Windows touch laptops)", () => {
     hasTouchInputMock.mockReturnValue(true);
     setViewportWidth(800);
     setHoverSupport(true);
+
+    const { result } = renderHook(() => useDropActionInteractionMode());
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        canUseDesktopHoverActions: true,
+        canUseTouchActionSheet: false,
+      })
+    );
+  });
+
+  it("uses the touch sheet on compact-width touch devices without hover", () => {
+    hasTouchInputMock.mockReturnValue(true);
+    setViewportWidth(800);
+    setHoverSupport(false);
 
     const { result } = renderHook(() => useDropActionInteractionMode());
 

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
@@ -9,6 +9,7 @@ import {
   MAX_PINNED_WAVES,
 } from "@/hooks/usePinnedWavesServer";
 import { getToastErrorDetails } from "@/helpers/toast.helpers";
+import { isTouchFirstEnvironment } from "@/helpers/touch-first.helpers";
 import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
 
 interface BrainLeftSidebarWavePinProps {
@@ -80,14 +81,11 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
     return () => clearTimeout(timer);
   }, [showMaxLimitTooltip]);
 
-  // Detect touch device on component mount
+  // Detect touch-first devices on component mount (hybrid touch laptops
+  // keep the desktop hover behavior).
   useEffect(() => {
     const checkTouch = () => {
-      const hasCoarsePointer =
-        typeof globalThis.matchMedia === "function" &&
-        globalThis.matchMedia("(pointer: coarse)").matches;
-
-      setIsTouchDevice((navigator.maxTouchPoints ?? 0) > 0 || hasCoarsePointer);
+      setIsTouchDevice(isTouchFirstEnvironment());
     };
 
     checkTouch();

--- a/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
+++ b/components/brain/left-sidebar/waves/BrainLeftSidebarWavePin.tsx
@@ -9,8 +9,8 @@ import {
   MAX_PINNED_WAVES,
 } from "@/hooks/usePinnedWavesServer";
 import { getToastErrorDetails } from "@/helpers/toast.helpers";
-import { isTouchFirstEnvironment } from "@/helpers/touch-first.helpers";
 import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
+import useIsTouchDevice from "@/hooks/useIsTouchDevice";
 
 interface BrainLeftSidebarWavePinProps {
   readonly waveId: string;
@@ -57,7 +57,7 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
   const { pinnedIds, isOperationInProgress, canPinWave } =
     usePinnedWavesServer();
   const { setToast, connectedProfile, activeProfileProxy } = useAuth();
-  const [isTouchDevice, setIsTouchDevice] = useState(false);
+  const isTouchDevice = useIsTouchDevice();
   const [maxLimitTooltipRequest, setMaxLimitTooltipRequest] =
     useState<MaxLimitTooltipRequest | null>(null);
 
@@ -80,21 +80,6 @@ const BrainLeftSidebarWavePin: React.FC<BrainLeftSidebarWavePinProps> = ({
     const timer = setTimeout(() => setMaxLimitTooltipRequest(null), 3000);
     return () => clearTimeout(timer);
   }, [showMaxLimitTooltip]);
-
-  // Detect touch-first devices on component mount (hybrid touch laptops
-  // keep the desktop hover behavior).
-  useEffect(() => {
-    const checkTouch = () => {
-      setIsTouchDevice(isTouchFirstEnvironment());
-    };
-
-    checkTouch();
-    globalThis.addEventListener("resize", checkTouch);
-
-    return () => {
-      globalThis.removeEventListener("resize", checkTouch);
-    };
-  }, []);
 
   if (!connectedProfile?.handle || activeProfileProxy) {
     return null;

--- a/components/brain/left-sidebar/waves/memes-quick-vote/MemesQuickVoteActionBar.tsx
+++ b/components/brain/left-sidebar/waves/memes-quick-vote/MemesQuickVoteActionBar.tsx
@@ -2,7 +2,7 @@
 
 import MemesWaveZapIcon from "@/components/brain/left-sidebar/waves/MemesWaveZapIcon";
 import { formatNumberWithCommas } from "@/helpers/Helpers";
-import useHasTouchInput from "@/hooks/useHasTouchInput";
+import useIsTouchDevice from "@/hooks/useIsTouchDevice";
 import clsx from "clsx";
 import { useEffect, useRef } from "react";
 import MemesQuickVoteCustomAmountRow from "./MemesQuickVoteCustomAmountRow";
@@ -47,7 +47,7 @@ export default function MemesQuickVoteActionBar({
   onSkip,
   onVoteAmount,
 }: MemesQuickVoteActionBarProps) {
-  const hasTouchInput = useHasTouchInput();
+  const isTouchDevice = useIsTouchDevice();
   const hasQuickAmounts = quickAmounts.length > 0;
   const isCustomRowVisible = !hasQuickAmounts || isCustomOpen;
   const customInputRef = useRef<HTMLInputElement | null>(null);
@@ -67,7 +67,7 @@ export default function MemesQuickVoteActionBar({
     const justOpenedCustomRow = !wasCustomRowVisible && isCustomRowVisible;
 
     if (
-      hasTouchInput ||
+      isTouchDevice ||
       !hasQuickAmounts ||
       !justOpenedCustomRow ||
       isSubmitting
@@ -76,7 +76,7 @@ export default function MemesQuickVoteActionBar({
     }
 
     customInputRef.current?.focus();
-  }, [hasQuickAmounts, hasTouchInput, isCustomRowVisible, isSubmitting]);
+  }, [hasQuickAmounts, isTouchDevice, isCustomRowVisible, isSubmitting]);
 
   const handleToggleCustom = () => {
     if (isSubmitting) {

--- a/components/layout/sidebar/WebSidebar.tsx
+++ b/components/layout/sidebar/WebSidebar.tsx
@@ -10,6 +10,7 @@ import CommonAnimationOpacity from "@/components/utils/animation/CommonAnimation
 import CommonAnimationWrapper from "@/components/utils/animation/CommonAnimationWrapper";
 import HeaderSearchModal from "@/components/header/header-search/HeaderSearchModal";
 import { useUnreadNotifications } from "@/hooks/useUnreadNotifications";
+import useIsTouchDevice from "@/hooks/useIsTouchDevice";
 import { useIdentity } from "../../../hooks/useIdentity";
 import { useAuth } from "../../auth/Auth";
 import { useSeizeConnectContext } from "../../auth/SeizeConnectContext";
@@ -56,7 +57,7 @@ function WebSidebar({
     return null;
   }, [connectedProfile?.handle, address]);
 
-  const [isTouchScreen, setIsTouchScreen] = useState(false);
+  const isTouchScreen = useIsTouchDevice();
   const [isSearchOpen, setIsSearchOpen] = useState(false);
 
   const showDesktopSearch = !isMobile;
@@ -76,43 +77,6 @@ function WebSidebar({
     },
     { event: "keydown" }
   );
-
-  useEffect(() => {
-    const { window: browserWindow } = globalThis as typeof globalThis & {
-      window?: Window | undefined;
-    };
-    if (
-      browserWindow === undefined ||
-      typeof browserWindow.matchMedia !== "function"
-    ) {
-      setIsTouchScreen(false);
-      return;
-    }
-
-    const coarsePointerQuery = browserWindow.matchMedia("(pointer: coarse)");
-    const handlePointerChange = (event: MediaQueryListEvent) => {
-      setIsTouchScreen(event.matches);
-    };
-
-    setIsTouchScreen(coarsePointerQuery.matches);
-
-    if (typeof coarsePointerQuery.addEventListener === "function") {
-      coarsePointerQuery.addEventListener("change", handlePointerChange);
-      return () =>
-        coarsePointerQuery.removeEventListener("change", handlePointerChange);
-    }
-
-    if ("onchange" in coarsePointerQuery) {
-      const originalHandler = coarsePointerQuery.onchange;
-      coarsePointerQuery.onchange = handlePointerChange;
-      return () => {
-        if (coarsePointerQuery.onchange === handlePointerChange) {
-          coarsePointerQuery.onchange = originalHandler ?? null;
-        }
-      };
-    }
-    return;
-  }, []);
 
   // Close sidebar on route change when on mobile
   const prevPathnameRef = useRef(pathname);

--- a/components/leaderboard/Leaderboard.module.css
+++ b/components/leaderboard/Leaderboard.module.css
@@ -227,8 +227,9 @@
   display: none;
 }
 
+/* hover: none keeps hybrid touch laptops on the desktop toolbar */
 @media only screen and (max-width: 760px),
-  (pointer: coarse) and (max-width: 900px) {
+  (pointer: coarse) and (hover: none) and (max-width: 900px) {
   .networkHeader {
     gap: 1rem;
   }

--- a/components/profile-activity/list/items/utils/ProfileActivityLogItemValueWithCopy.tsx
+++ b/components/profile-activity/list/items/utils/ProfileActivityLogItemValueWithCopy.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { Tooltip } from "react-tooltip";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useCopyToClipboard } from "react-use";
 import CopyIcon from "@/components/utils/icons/CopyIcon";
 import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
+import useIsTouchDevice from "@/hooks/useIsTouchDevice";
 
 export default function ProfileActivityLogItemValueWithCopy({
   title,
@@ -13,10 +14,7 @@ export default function ProfileActivityLogItemValueWithCopy({
   readonly title: string;
   readonly value: string;
 }) {
-  const [isTouchScreen, setIsTouchScreen] = useState(false);
-  useEffect(() => {
-    setIsTouchScreen(window.matchMedia("(pointer: coarse)").matches);
-  }, []);
+  const isTouchScreen = useIsTouchDevice();
 
   const [_, copyToClipboard] = useCopyToClipboard();
 

--- a/components/providers/LayoutWrapper.tsx
+++ b/components/providers/LayoutWrapper.tsx
@@ -50,7 +50,7 @@ export default function LayoutWrapper({
 }: {
   readonly children: ReactNode;
 }) {
-  const { isApp, hasTouchScreen } = useDeviceInfo();
+  const { isApp, hasTouchScreen, isMobileDevice } = useDeviceInfo();
   const { refreshKey } = useGlobalRefresh();
   const isSmallScreen = useIsMobileScreen();
   const isTouchTabletViewport = useSyncExternalStore(
@@ -85,8 +85,12 @@ export default function LayoutWrapper({
   let LayoutComponent: ComponentType<{ readonly children: ReactNode }> =
     WebLayout;
 
+  // hasTouchScreen covers touch-first hardware; isMobileDevice (UA-based)
+  // keeps phones on the small layout even when a mouse or trackpad is
+  // attached. Hybrid touch laptops match neither, so they stay on WebLayout.
   const isSmallLayout =
-    hasTouchScreen && (isSmallScreen || isTouchTabletViewport);
+    (hasTouchScreen || isMobileDevice) &&
+    (isSmallScreen || isTouchTabletViewport);
 
   if (isApp) {
     LayoutComponent = MobileLayout;

--- a/components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddressesItem.tsx
+++ b/components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddressesItem.tsx
@@ -15,6 +15,7 @@ import type { ApiWallet } from "@/generated/models/ApiWallet";
 import { getTransactionLink } from "@/helpers/Helpers";
 import { getToastErrorDetails } from "@/helpers/toast.helpers";
 import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
+import useIsTouchDevice from "@/hooks/useIsTouchDevice";
 import { ChevronDownIcon } from "@heroicons/react/24/outline";
 import { useEffect, useRef, useState } from "react";
 import { Tooltip } from "react-tooltip";
@@ -110,10 +111,7 @@ export default function UserPageIdentityStatementsConsolidatedAddressesItem({
     };
   }, []);
 
-  const [isTouchScreen, setIsTouchScreen] = useState(false);
-  useEffect(() => {
-    setIsTouchScreen(window.matchMedia("(pointer: coarse)").matches);
-  }, []);
+  const isTouchScreen = useIsTouchDevice();
 
   const [assigningPrimary, setAssigningPrimary] = useState(false);
   const [statusMessage, setStatusMessage] = useState<any>();

--- a/components/user/identity/statements/utils/UserPageIdentityDeleteStatementButton.tsx
+++ b/components/user/identity/statements/utils/UserPageIdentityDeleteStatementButton.tsx
@@ -5,7 +5,8 @@ import CommonAnimationWrapper from "@/components/utils/animation/CommonAnimation
 import type { CicStatement } from "@/entities/IProfile";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
-import { useEffect, useState } from "react";
+import useIsTouchDevice from "@/hooks/useIsTouchDevice";
+import { useState } from "react";
 import { Tooltip } from "react-tooltip";
 import UserPageIdentityDeleteStatementModal from "./UserPageIdentityDeleteStatementModal";
 export default function UserPageIdentityDeleteStatementButton({
@@ -17,10 +18,7 @@ export default function UserPageIdentityDeleteStatementButton({
 }) {
   const [isDeleteStatementOpen, setIsDeleteStatementOpen] =
     useState<boolean>(false);
-  const [isTouchScreen, setIsTouchScreen] = useState(false);
-  useEffect(() => {
-    setIsTouchScreen(window.matchMedia("(pointer: coarse)").matches);
-  }, []);
+  const isTouchScreen = useIsTouchDevice();
   const tooltipId = `delete-statement-${statement.statement_group}-${statement.statement_type}`;
   const showTooltip = !isTouchScreen && !isDeleteStatementOpen;
 

--- a/components/user/identity/statements/utils/UserPageIdentityStatementsStatement.tsx
+++ b/components/user/identity/statements/utils/UserPageIdentityStatementsStatement.tsx
@@ -7,7 +7,8 @@ import type { CicStatement } from "@/entities/IProfile";
 import type { ApiIdentity } from "@/generated/models/ApiIdentity";
 import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
 import { STATEMENT_META } from "@/helpers/Types";
-import { useEffect, useState } from "react";
+import useIsTouchDevice from "@/hooks/useIsTouchDevice";
+import { useState } from "react";
 import { Tooltip } from "react-tooltip";
 import { useCopyToClipboard } from "react-use";
 import UserPageIdentityDeleteStatementButton from "./UserPageIdentityDeleteStatementButton";
@@ -33,10 +34,7 @@ export default function UserPageIdentityStatementsStatement({
   };
 
   const canOpen = STATEMENT_META[statement.statement_type].canOpenStatement;
-  const [isTouchScreen, setIsTouchScreen] = useState(false);
-  useEffect(() => {
-    setIsTouchScreen(window.matchMedia("(pointer: coarse)").matches);
-  }, []);
+  const isTouchScreen = useIsTouchDevice();
 
   return (
     <li className="tw-group hover:tw-bg-white/[0.02] tw-pl-0.5 tw-py-4 tw-transition-colors tw-duration-200 tw-ease-out tw-border-b tw-border-solid tw-border-white/[0.06] tw-border-t-0 tw-border-x-0 last:tw-border-b-0">

--- a/components/utils/select/dropdown/CommonDropdownItemsMobileWrapper.tsx
+++ b/components/utils/select/dropdown/CommonDropdownItemsMobileWrapper.tsx
@@ -9,7 +9,7 @@ import {
 } from "@headlessui/react";
 import type { ReactNode } from "react";
 import { Fragment } from "react";
-import useHasTouchInput from "@/hooks/useHasTouchInput";
+import useIsTouchDevice from "@/hooks/useIsTouchDevice";
 
 export default function CommonDropdownItemsMobileWrapper({
   isOpen,
@@ -28,8 +28,8 @@ export default function CommonDropdownItemsMobileWrapper({
   readonly onAfterLeave?: (() => void) | undefined;
   readonly children: ReactNode;
 }) {
-  const hasTouchInput = useHasTouchInput();
-  const shouldHideOnDesktopHover = hideOnDesktopHover && !hasTouchInput;
+  const isTouchDevice = useIsTouchDevice();
+  const shouldHideOnDesktopHover = hideOnDesktopHover && !isTouchDevice;
 
   return (
     <Transition show={isOpen} as={Fragment}>

--- a/components/waves/ChatItemHrefButtons.tsx
+++ b/components/waves/ChatItemHrefButtons.tsx
@@ -18,7 +18,7 @@ import {
 } from "react";
 
 import CommonDropdownItemsDefaultWrapper from "@/components/utils/select/dropdown/CommonDropdownItemsDefaultWrapper";
-import useHasTouchInput from "@/hooks/useHasTouchInput";
+import useIsTouchDevice from "@/hooks/useIsTouchDevice";
 import useIsMobileDevice from "@/hooks/isMobileDevice";
 
 import { useLinkPreviewContext } from "./LinkPreviewContext";
@@ -144,7 +144,7 @@ export default function ChatItemHrefButtons({
   layout?: ChatItemHrefButtonsLayout | undefined;
 }) {
   const { previewToggle, onCardActionsActiveChange } = useLinkPreviewContext();
-  const hasTouchInput = useHasTouchInput();
+  const isTouchDevice = useIsTouchDevice();
   const isMobileDevice = useIsMobileDevice();
   const [copied, setCopied] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -165,7 +165,7 @@ export default function ChatItemHrefButtons({
   const showPreviewToggle = Boolean(previewToggle && !previewToggle.isHidden);
   const isOverlay = layout === "overlay";
   const showPersistentOverlayTrigger =
-    isOverlay && (hasTouchInput || isMobileDevice);
+    isOverlay && (isTouchDevice || isMobileDevice);
   const isPreviewToggleDisabled = Boolean(
     previewToggle && (previewToggle.isLoading || !previewToggle.canToggle)
   );

--- a/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes.tsx
+++ b/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import { Tooltip } from "react-tooltip";
 import type { ApiDrop } from "@/generated/models/ApiDrop";
 import { useWaveRankReward } from "@/hooks/waves/useWaveRankReward";
+import { isTouchFirstEnvironment } from "@/helpers/touch-first.helpers";
 import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
 
 interface WaveSmallLeaderboardItemOutcomesProps {
@@ -15,9 +16,7 @@ interface WaveSmallLeaderboardItemOutcomesProps {
 const WaveSmallLeaderboardItemOutcomesContent: React.FC<
   WaveSmallLeaderboardItemOutcomesProps
 > = ({ drop, isMobile: _isMobile = false }) => {
-  const [isTouch] = useState(
-    () => typeof globalThis !== "undefined" && "ontouchstart" in globalThis
-  );
+  const [isTouch] = useState(() => isTouchFirstEnvironment());
   const [isOpen, setIsOpen] = useState(false);
 
   const handleClick = (e: React.MouseEvent) => {

--- a/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes.tsx
+++ b/components/waves/small-leaderboard/WaveSmallLeaderboardItemOutcomes.tsx
@@ -4,8 +4,8 @@ import React, { useState } from "react";
 import { Tooltip } from "react-tooltip";
 import type { ApiDrop } from "@/generated/models/ApiDrop";
 import { useWaveRankReward } from "@/hooks/waves/useWaveRankReward";
-import { isTouchFirstEnvironment } from "@/helpers/touch-first.helpers";
 import { TOOLTIP_STYLES } from "@/helpers/tooltip.helpers";
+import useIsTouchDevice from "@/hooks/useIsTouchDevice";
 
 interface WaveSmallLeaderboardItemOutcomesProps {
   readonly drop: ApiDrop;
@@ -16,7 +16,7 @@ interface WaveSmallLeaderboardItemOutcomesProps {
 const WaveSmallLeaderboardItemOutcomesContent: React.FC<
   WaveSmallLeaderboardItemOutcomesProps
 > = ({ drop, isMobile: _isMobile = false }) => {
-  const [isTouch] = useState(() => isTouchFirstEnvironment());
+  const isTouch = useIsTouchDevice();
   const [isOpen, setIsOpen] = useState(false);
 
   const handleClick = (e: React.MouseEvent) => {

--- a/components/waves/specs/WaveSettingRow.tsx
+++ b/components/waves/specs/WaveSettingRow.tsx
@@ -3,6 +3,7 @@
 import PencilIcon, {
   PencilIconSize,
 } from "@/components/utils/icons/PencilIcon";
+import { isTouchFirstEnvironment } from "@/helpers/touch-first.helpers";
 import type { ReactNode } from "react";
 import {
   useCallback,
@@ -34,7 +35,12 @@ const shouldUseBottomSheet = () => {
     return false;
   }
 
-  return globalThis.matchMedia("(max-width: 767px), (pointer: coarse)").matches;
+  // Small viewports or touch-first devices get the sheet; hybrid touch
+  // laptops (fine pointer/hover available) keep the desktop popover.
+  return (
+    globalThis.matchMedia("(max-width: 767px)").matches ||
+    isTouchFirstEnvironment()
+  );
 };
 
 const isInsideElement = (

--- a/helpers/touch-first.helpers.ts
+++ b/helpers/touch-first.helpers.ts
@@ -72,10 +72,35 @@ export const hasTouchCapability = (): boolean => {
   return getMediaQueryList(COARSE_POINTER_QUERY)?.matches ?? false;
 };
 
+const MOBILE_USER_AGENT_REGEX =
+  /Android|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i;
+
+/**
+ * Phone signal from client hints or the user agent. Client hints win when
+ * present: Android tablets report `userAgentData.mobile === false`, so a
+ * tablet with a trackpad still gets the desktop experience.
+ */
+const isMobileUserAgent = (): boolean => {
+  const nav = (globalThis as typeof globalThis & { navigator?: Navigator })
+    .navigator as
+    | (Navigator & { userAgentData?: { mobile?: boolean } })
+    | undefined;
+  if (!nav) {
+    return false;
+  }
+  const uaDataMobile = nav.userAgentData?.mobile;
+  if (typeof uaDataMobile === "boolean") {
+    return uaDataMobile;
+  }
+  return MOBILE_USER_AGENT_REGEX.test(nav.userAgent);
+};
+
 /**
  * True only for devices whose primary interaction is touch (phones/tablets).
- * `touchDetected` lets callers feed in an observed `touchstart` for devices
- * that hide their touch capability until first use.
+ * Phones stay touch-first even when a paired mouse or hovering stylus adds a
+ * fine pointer or hover capability; hybrids (touch laptops) are identified by
+ * capabilities alone. `touchDetected` lets callers feed in an observed
+ * `touchstart` for devices that hide their touch capability until first use.
  */
 export const isTouchFirstEnvironment = (options?: {
   readonly touchDetected?: boolean;
@@ -83,6 +108,9 @@ export const isTouchFirstEnvironment = (options?: {
   const touchCapable = (options?.touchDetected ?? false) || hasTouchCapability();
   if (!touchCapable) {
     return false;
+  }
+  if (isMobileUserAgent()) {
+    return true;
   }
   return !hasFinePointerCapability() && !hasHoverCapability();
 };

--- a/helpers/touch-first.helpers.ts
+++ b/helpers/touch-first.helpers.ts
@@ -1,0 +1,119 @@
+/**
+ * Shared "touch-first" device classification.
+ *
+ * A device is touch-first when touch is its PRIMARY interaction model:
+ * touch input exists AND there is no fine pointer (mouse/trackpad) AND no
+ * hover-capable input. Phones and tablets are touch-first; hybrid devices
+ * such as Windows touch-screen laptops (Surface) and touch monitors attached
+ * to desktops are NOT — they must get the desktop experience.
+ *
+ * Every mobile/touch UI decision in the app must go through this module (or
+ * the hooks built on it: useIsTouchDevice, useDeviceInfo) instead of checking
+ * `navigator.maxTouchPoints`, `"ontouchstart" in window` or
+ * `matchMedia("(pointer: coarse)")` directly — those are true on hybrid
+ * laptops and misclassify them as mobile.
+ */
+
+type MatchMediaWindow = typeof globalThis & {
+  matchMedia?: (query: string) => MediaQueryList;
+};
+
+const FINE_POINTER_QUERIES = [
+  "(any-pointer: fine)",
+  "(pointer: fine)",
+] as const;
+
+const HOVER_QUERIES = ["(any-hover: hover)", "(hover: hover)"] as const;
+
+const COARSE_POINTER_QUERY = "(any-pointer: coarse)";
+
+/** Media queries whose changes can flip the touch-first classification. */
+const TOUCH_FIRST_MEDIA_QUERIES = [
+  ...FINE_POINTER_QUERIES,
+  ...HOVER_QUERIES,
+  COARSE_POINTER_QUERY,
+] as const;
+
+const getMediaQueryList = (query: string): MediaQueryList | null => {
+  const win = globalThis as MatchMediaWindow;
+  if (typeof win.matchMedia !== "function") {
+    return null;
+  }
+  try {
+    return win.matchMedia(query);
+  } catch {
+    return null;
+  }
+};
+
+const someQueryMatches = (queries: readonly string[]): boolean =>
+  queries.some((query) => getMediaQueryList(query)?.matches ?? false);
+
+/** A mouse or trackpad (or similar precise pointer) is available. */
+export const hasFinePointerCapability = (): boolean =>
+  someQueryMatches(FINE_POINTER_QUERIES);
+
+/** Some input can hover (mouse, trackpad, stylus with hover). */
+export const hasHoverCapability = (): boolean =>
+  someQueryMatches(HOVER_QUERIES);
+
+/**
+ * Touch input exists at all (says nothing about it being primary).
+ * Note: intentionally NOT `"ontouchstart" in window` — some engines (and
+ * jsdom) expose that handler without touch hardware.
+ */
+export const hasTouchCapability = (): boolean => {
+  const nav = (globalThis as typeof globalThis & { navigator?: Navigator })
+    .navigator as (Navigator & { msMaxTouchPoints?: number }) | undefined;
+  const maxTouchPoints = nav?.maxTouchPoints ?? nav?.msMaxTouchPoints ?? 0;
+  if (maxTouchPoints > 0) {
+    return true;
+  }
+  return getMediaQueryList(COARSE_POINTER_QUERY)?.matches ?? false;
+};
+
+/**
+ * True only for devices whose primary interaction is touch (phones/tablets).
+ * `touchDetected` lets callers feed in an observed `touchstart` for devices
+ * that hide their touch capability until first use.
+ */
+export const isTouchFirstEnvironment = (options?: {
+  readonly touchDetected?: boolean;
+}): boolean => {
+  const touchCapable = (options?.touchDetected ?? false) || hasTouchCapability();
+  if (!touchCapable) {
+    return false;
+  }
+  return !hasFinePointerCapability() && !hasHoverCapability();
+};
+
+/**
+ * Re-runs `onChange` whenever a capability media query flips (mouse plugged
+ * in/out, convertible posture change). Returns an unsubscribe function.
+ */
+export const subscribeToTouchFirstChanges = (
+  onChange: () => void
+): (() => void) => {
+  const unsubscribers: Array<() => void> = [];
+
+  for (const query of TOUCH_FIRST_MEDIA_QUERIES) {
+    const mediaQueryList = getMediaQueryList(query);
+    if (
+      !mediaQueryList ||
+      typeof mediaQueryList.addEventListener !== "function"
+    ) {
+      continue;
+    }
+
+    mediaQueryList.addEventListener("change", onChange);
+    unsubscribers.push(() =>
+      mediaQueryList.removeEventListener("change", onChange)
+    );
+  }
+
+  return () => {
+    for (const unsubscribe of unsubscribers) {
+      unsubscribe();
+    }
+  };
+};

--- a/helpers/touch-first.helpers.ts
+++ b/helpers/touch-first.helpers.ts
@@ -72,8 +72,10 @@ export const hasTouchCapability = (): boolean => {
   return getMediaQueryList(COARSE_POINTER_QUERY)?.matches ?? false;
 };
 
+// "Android.*Mobile" keeps Android tablets (which omit "Mobile" from the UA)
+// out of the phone fallback when client hints are unavailable.
 const MOBILE_USER_AGENT_REGEX =
-  /Android|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i;
+  /iPhone|iPod|BlackBerry|IEMobile|Opera Mini|Android.*Mobile/i;
 
 /**
  * Phone signal from client hints or the user agent. Client hints win when

--- a/hooks/useDeviceInfo.ts
+++ b/hooks/useDeviceInfo.ts
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useEffect, useRef } from "react";
 import {
+  hasTouchCapability,
   isTouchFirstEnvironment,
   subscribeToTouchFirstChanges,
 } from "@/helpers/touch-first.helpers";
@@ -43,15 +44,13 @@ export default function useDeviceInfo(): DeviceInfo {
         matchMedia: (query: string) => MediaQueryList;
       };
       const nav = navigator as Navigator & {
-        msMaxTouchPoints?: number | undefined;
         userAgentData?: { mobile?: boolean | undefined } | undefined;
         standalone?: boolean | undefined;
       };
 
-      const maxTouchPoints = nav.maxTouchPoints ?? nav.msMaxTouchPoints ?? 0;
       // Raw capability — true when touch input exists at all. Only used for
       // UA disambiguation (iPads pretending to be Macs) — never for UI mode.
-      const hasTouchInput = touchDetected || maxTouchPoints > 0;
+      const hasTouchInput = touchDetected || hasTouchCapability();
       const hasTouchScreen = isTouchFirstEnvironment({ touchDetected });
 
       const ua = nav.userAgent;

--- a/hooks/useDeviceInfo.ts
+++ b/hooks/useDeviceInfo.ts
@@ -49,8 +49,8 @@ export default function useDeviceInfo(): DeviceInfo {
       };
 
       const maxTouchPoints = nav.maxTouchPoints ?? nav.msMaxTouchPoints ?? 0;
-      // Raw capability: any touch input at all. Only used for UA
-      // disambiguation (iPads pretending to be Macs) — never for UI mode.
+      // Raw capability — true when touch input exists at all. Only used for
+      // UA disambiguation (iPads pretending to be Macs) — never for UI mode.
       const hasTouchInput = touchDetected || maxTouchPoints > 0;
       // Touch-first: touch without mouse/trackpad/hover. Windows touch
       // laptops have a fine pointer and hover, so they stay desktop.

--- a/hooks/useDeviceInfo.ts
+++ b/hooks/useDeviceInfo.ts
@@ -2,8 +2,7 @@
 
 import { useState, useCallback, useEffect, useRef } from "react";
 import {
-  hasFinePointerCapability,
-  hasHoverCapability,
+  isTouchFirstEnvironment,
   subscribeToTouchFirstChanges,
 } from "@/helpers/touch-first.helpers";
 import useCapacitor from "./useCapacitor";
@@ -11,10 +10,11 @@ import useCapacitor from "./useCapacitor";
 interface DeviceInfo {
   readonly isMobileDevice: boolean;
   /**
-   * Touch-first device: touch input exists AND there is no fine pointer
-   * (mouse/trackpad) and no hover support. Hybrid touch-screen laptops
-   * (e.g. Windows Surface) are NOT touch-first — they get the desktop
-   * experience. Use this for choosing touch vs desktop affordances.
+   * Touch-first device (see helpers/touch-first.helpers.ts): phones and
+   * tablets, including phones with a paired mouse or hovering stylus.
+   * Hybrid touch-screen laptops (e.g. Windows Surface) are NOT touch-first —
+   * they get the desktop experience. Use this for choosing touch vs desktop
+   * affordances.
    */
   readonly hasTouchScreen: boolean;
   readonly isApp: boolean;
@@ -52,10 +52,7 @@ export default function useDeviceInfo(): DeviceInfo {
       // Raw capability — true when touch input exists at all. Only used for
       // UA disambiguation (iPads pretending to be Macs) — never for UI mode.
       const hasTouchInput = touchDetected || maxTouchPoints > 0;
-      // Touch-first: touch without mouse/trackpad/hover. Windows touch
-      // laptops have a fine pointer and hover, so they stay desktop.
-      const hasTouchScreen =
-        hasTouchInput && !hasFinePointerCapability() && !hasHoverCapability();
+      const hasTouchScreen = isTouchFirstEnvironment({ touchDetected });
 
       const ua = nav.userAgent;
       const uaDataMobile = nav.userAgentData?.mobile;

--- a/hooks/useDeviceInfo.ts
+++ b/hooks/useDeviceInfo.ts
@@ -1,10 +1,21 @@
 "use client";
 
 import { useState, useCallback, useEffect, useRef } from "react";
+import {
+  hasFinePointerCapability,
+  hasHoverCapability,
+  subscribeToTouchFirstChanges,
+} from "@/helpers/touch-first.helpers";
 import useCapacitor from "./useCapacitor";
 
 interface DeviceInfo {
   readonly isMobileDevice: boolean;
+  /**
+   * Touch-first device: touch input exists AND there is no fine pointer
+   * (mouse/trackpad) and no hover support. Hybrid touch-screen laptops
+   * (e.g. Windows Surface) are NOT touch-first — they get the desktop
+   * experience. Use this for choosing touch vs desktop affordances.
+   */
   readonly hasTouchScreen: boolean;
   readonly isApp: boolean;
   readonly isAppleMobile: boolean;
@@ -38,13 +49,19 @@ export default function useDeviceInfo(): DeviceInfo {
       };
 
       const maxTouchPoints = nav.maxTouchPoints ?? nav.msMaxTouchPoints ?? 0;
-      const hasTouchScreen = touchDetected || maxTouchPoints > 0;
+      // Raw capability: any touch input at all. Only used for UA
+      // disambiguation (iPads pretending to be Macs) — never for UI mode.
+      const hasTouchInput = touchDetected || maxTouchPoints > 0;
+      // Touch-first: touch without mouse/trackpad/hover. Windows touch
+      // laptops have a fine pointer and hover, so they stay desktop.
+      const hasTouchScreen =
+        hasTouchInput && !hasFinePointerCapability() && !hasHoverCapability();
 
       const ua = nav.userAgent;
       const uaDataMobile = nav.userAgentData?.mobile;
       const classicMobile =
         /Android|iPhone|iPod|BlackBerry|IEMobile|Opera Mini/i.test(ua);
-      const iPadDesktopUA = ua.includes("Macintosh") && hasTouchScreen;
+      const iPadDesktopUA = ua.includes("Macintosh") && hasTouchInput;
       const appleMobile = /(iPhone|iPad|iPod)/i.test(ua) || iPadDesktopUA;
       const widthMobile =
         win.matchMedia?.("(max-width: 768px)")?.matches ?? false;
@@ -97,11 +114,18 @@ export default function useDeviceInfo(): DeviceInfo {
       globalThis.addEventListener("touchstart", onceTouch, { passive: true });
     }
 
+    // Pointer/hover capabilities change when a mouse is (un)plugged or a
+    // convertible flips posture — keep the classification in sync.
+    const unsubscribeCapabilityChanges = subscribeToTouchFirstChanges(update);
+
+    update();
+
     return () => {
       if (hasEventListenerApi) {
         globalThis.removeEventListener("resize", update);
         globalThis.removeEventListener("touchstart", onceTouch);
       }
+      unsubscribeCapabilityChanges();
     };
   }, [getInfo]);
 

--- a/hooks/useDropActionInteractionMode.ts
+++ b/hooks/useDropActionInteractionMode.ts
@@ -82,7 +82,10 @@ export default function useDropActionInteractionMode(): DropActionInteractionMod
   const hasTouchInput = useHasTouchInput();
   const hasHoverActionInput = useHasHoverInput();
   const isMobileLayoutViewport = useIsMobileLayoutViewport();
-  const hasTouchActionInput = isMobileDevice || isTouchDevice || hasTouchInput;
+  // Raw touch capability only counts when no hover input exists — otherwise
+  // hybrid devices (touch-screen laptops) would lose desktop hover actions.
+  const hasTouchActionInput =
+    isMobileDevice || isTouchDevice || (hasTouchInput && !hasHoverActionInput);
   const canUseTouchActionSheet =
     hasTouchActionInput && (isMobileLayoutViewport || !hasHoverActionInput);
 

--- a/hooks/useIsTouchDevice.ts
+++ b/hooks/useIsTouchDevice.ts
@@ -1,55 +1,74 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useRef, useSyncExternalStore } from "react";
+import {
+  hasFinePointerCapability,
+  hasHoverCapability,
+  hasTouchCapability,
+  isTouchFirstEnvironment,
+  subscribeToTouchFirstChanges,
+} from "@/helpers/touch-first.helpers";
 
+/**
+ * True only when the device is touch-first (phone/tablet). Hybrid devices
+ * (touchscreen + trackpad/mouse, e.g. Windows Surface laptops) report a fine
+ * pointer or hover support and are classified as NOT touch, even after the
+ * user touches the screen.
+ */
 export default function useIsTouchDevice(): boolean {
-  const [isTouchDevice, setIsTouchDevice] = useState(false);
+  const touchDetectedRef = useRef(false);
 
-  useEffect(() => {
-    if (typeof globalThis === "undefined") {
-      return;
-    }
+  const subscribe = useCallback((onStoreChange: () => void) => {
+    // Capability media queries flip when a mouse is (un)plugged or a
+    // convertible changes posture.
+    const unsubscribeCapabilities = subscribeToTouchFirstChanges(onStoreChange);
 
-    const win = globalThis as typeof globalThis & {
-      matchMedia?: (query: string) => MediaQueryList;
-    };
+    let touchListenerAttached = false;
 
-    const nav = globalThis.navigator as Navigator | undefined;
-    const maxTouchPoints = nav?.maxTouchPoints ?? 0;
-
-    // Prefer "any-*" media queries so hybrid devices (touchscreen + trackpad/mouse)
-    // aren't misclassified as touch-only when the primary pointer is coarse.
-    const hasAnyFinePointer = win.matchMedia?.("(any-pointer: fine)")?.matches ?? false;
-    const hasPrimaryFinePointer = win.matchMedia?.("(pointer: fine)")?.matches ?? false;
-    const hasFinePointer = hasAnyFinePointer || hasPrimaryFinePointer;
-
-    const hasAnyHover = win.matchMedia?.("(any-hover: hover)")?.matches ?? false;
-    const hasPrimaryHover = win.matchMedia?.("(hover: hover)")?.matches ?? false;
-    const hasHover = hasAnyHover || hasPrimaryHover;
-
-    if (hasFinePointer || hasHover) {
-      setIsTouchDevice(false);
-      return;
-    }
-
-    // If there's no fine pointer and the device advertises touch points, treat it
-    // as touch (important for first-touch interactions like long-press menus).
-    if (maxTouchPoints > 0) {
-      setIsTouchDevice(true);
-      return;
-    }
-
-    const onTouchStart = () => {
-      setIsTouchDevice(true);
+    const detachTouchListener = () => {
+      if (!touchListenerAttached) {
+        return;
+      }
+      touchListenerAttached = false;
       globalThis.removeEventListener("touchstart", onTouchStart);
     };
 
-    globalThis.addEventListener("touchstart", onTouchStart, { passive: true });
+    function onTouchStart() {
+      touchDetectedRef.current = true;
+      detachTouchListener();
+      onStoreChange();
+    }
+
+    // Some devices advertise no capabilities at all until the first touch —
+    // wait for it (important for first-touch interactions like long-press).
+    const shouldAwaitFirstTouch =
+      !touchDetectedRef.current &&
+      !hasTouchCapability() &&
+      !hasFinePointerCapability() &&
+      !hasHoverCapability();
+
+    if (
+      shouldAwaitFirstTouch &&
+      typeof globalThis.addEventListener === "function"
+    ) {
+      touchListenerAttached = true;
+      globalThis.addEventListener("touchstart", onTouchStart, {
+        passive: true,
+      });
+    }
 
     return () => {
-      globalThis.removeEventListener("touchstart", onTouchStart);
+      unsubscribeCapabilities();
+      detachTouchListener();
     };
   }, []);
 
-  return isTouchDevice;
+  const getSnapshot = useCallback(
+    () => isTouchFirstEnvironment({ touchDetected: touchDetectedRef.current }),
+    []
+  );
+
+  const getServerSnapshot = useCallback(() => false, []);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/hooks/useSidebarController.ts
+++ b/hooks/useSidebarController.ts
@@ -7,6 +7,7 @@ import {
   SIDEBAR_MOBILE_BREAKPOINT,
 } from "../constants/sidebar";
 import { safeSessionStorage } from "../helpers/safeSessionStorage";
+import useIsTouchDevice from "./useIsTouchDevice";
 
 const getBrowserWindow = () => {
   const { window: browserWindow } = globalThis as typeof globalThis & {
@@ -44,14 +45,15 @@ export function useSidebarController() {
     () => createMediaQuery(`(max-width: ${SIDEBAR_BREAKPOINT - 0.02}px)`),
     [createMediaQuery]
   );
-  const coarseMql = useMemo(() => createMediaQuery("(pointer: coarse)"), [createMediaQuery]);
   const mobileWidthMql = useMemo(
     () => createMediaQuery(`(max-width: ${SIDEBAR_MOBILE_BREAKPOINT - 0.02}px)`),
     [createMediaQuery]
   );
 
   const [isNarrow, setIsNarrow] = useState(() => narrowMql?.matches ?? false);
-  const [isTouchScreen, setIsTouchScreen] = useState(() => coarseMql?.matches ?? false);
+  // Touch-first (no mouse/trackpad/hover), NOT merely "has a touch screen" —
+  // hybrid touch laptops must keep the desktop sidebar behavior.
+  const isTouchScreen = useIsTouchDevice();
   const [isMobileWidth, setIsMobileWidth] = useState(() => mobileWidthMql?.matches ?? false);
 
   const lastIsNarrowRef = useRef(isNarrow);
@@ -112,16 +114,6 @@ export function useSidebarController() {
     narrowMql.addEventListener("change", handleChange);
     return () => narrowMql.removeEventListener("change", handleChange);
   }, [narrowMql]);
-
-  useEffect(() => {
-    if (!coarseMql) {
-      return;
-    }
-    const handleChange = (event: MediaQueryListEvent) => setIsTouchScreen(event.matches);
-    setIsTouchScreen(coarseMql.matches);
-    coarseMql.addEventListener("change", handleChange);
-    return () => coarseMql.removeEventListener("change", handleChange);
-  }, [coarseMql]);
 
   useEffect(() => {
     if (!mobileWidthMql) {

--- a/utils/monitoring/mobileLaunchTiming.ts
+++ b/utils/monitoring/mobileLaunchTiming.ts
@@ -407,7 +407,11 @@ function isLikelyMobileWeb(): boolean {
     return false;
   }
 
-  return window.matchMedia("(pointer: coarse) and (max-width: 900px)").matches;
+  // "hover: none" keeps hybrid touch laptops (coarse-capable but with a
+  // mouse/trackpad) out of the mobile-web telemetry bucket.
+  return window.matchMedia(
+    "(pointer: coarse) and (hover: none) and (max-width: 900px)"
+  ).matches;
 }
 
 function getCurrentPathname(): string {

--- a/utils/monitoring/mobileLaunchTiming.ts
+++ b/utils/monitoring/mobileLaunchTiming.ts
@@ -409,7 +409,7 @@ function isLikelyMobileWeb(): boolean {
 
   // "hover: none" keeps hybrid touch laptops (coarse-capable but with a
   // mouse/trackpad) out of the mobile-web telemetry bucket.
-  return window.matchMedia(
+  return globalThis.matchMedia(
     "(pointer: coarse) and (hover: none) and (max-width: 900px)"
   ).matches;
 }


### PR DESCRIPTION
## Issue
- Windows touch-screen laptops (e.g. Surface) were permanently classified as mobile: any window narrower than 1024px switched the whole app to `SmallScreenLayout`, and even at full width drops lost hover actions, tooltips were suppressed, long-press/bottom-sheet menus appeared, and interactive artwork was tap-gated.
- Root cause: `useDeviceInfo.hasTouchScreen` was raw `maxTouchPoints > 0`, plus ~10 components ran their own `(pointer: coarse)` / `maxTouchPoints` / `ontouchstart` checks. Detection was decentralized, so earlier partial fixes (e.g. `useIsTouchDevice`) never fixed the whole surface.

## Fix
- New `helpers/touch-first.helpers.ts` is the single sanctioned definition: a device is *touch-first* only when touch exists AND there is no fine pointer (`any-pointer: fine`) AND no hover support (`any-hover: hover`). Hybrids (touch + trackpad/mouse) therefore get the desktop experience; phones/tablets keep the touch experience.
- `useIsTouchDevice` rebuilt on `useSyncExternalStore` with live capability-change subscriptions (mouse plug/unplug, convertible posture flips update without reload).
- `useDeviceInfo.hasTouchScreen` now means touch-first (raw capability retained internally only for iPad-desktop-UA detection), which corrects `LayoutWrapper` and ~30 consumers at once.
- All standalone detection sites converted to the shared helpers: sidebar controller, WebSidebar, WaveSettingRow, wave pin, small-leaderboard outcomes, profile statements (4), chat link buttons, dropdown sheet wrapper, quick-vote bar, launch telemetry, leaderboard CSS.
- Phone hardening: `LayoutWrapper` small layout requires `(hasTouchScreen || isMobileDevice)` — a phone with a mouse attached stays on the mobile layout via its UA even though touch-first flips false. Android tablets report `userAgentData.mobile=false`, so tablet+trackpad correctly gets desktop.

## Changes
- New: `helpers/touch-first.helpers.ts`, tests for it, and a `LayoutWrapper` layout-decision test matrix.
- Behavior change for hybrid devices only: desktop layout/affordances at every width. Pure touch devices and the Capacitor app (`isApp` → `MobileLayout`) are unchanged.
- Tests that encoded the old hybrid behavior were deliberately flipped (`useDeviceInfo`, `useDropActionInteractionMode`, `WaveDrop`, `ChatItemHrefButtons`).

## Validation
- `jest`: 96+ affected suites green, including new regression cases (hybrid + narrow window → WebLayout; phone UA + mouse → SmallScreenLayout).
- `typecheck:ci` and default-config eslint on all touched files: clean.
- Playwright against a local dev server: Surface profile (maxTouchPoints=10 + fine pointer + hover + coarse) at 950px and 1600px → desktop layout; plain-desktop control → desktop; phone profile → small-screen layout.
- Not tested: real convertible posture flips (Windows slate mode) — covered by design via media-query change subscriptions; residual risk is a device staying on desktop UI in tablet posture if the OS keeps the touchpad enumerated, which is benign.

## Risk
- Level: Medium
- Why: touches the app-wide layout selector and shared interaction-mode hooks; blast radius is UI-mode selection. Logic is centralized, unit-tested per device profile, and verified in a running app. No data, auth, or API changes.
- Rollback: revert this single commit; no migrations or config involved.

## Review Notes
- The semantic change of `hasTouchScreen` (capability → touch-first) is intentional and documented in the interface JSDoc; all consumers want touch-first semantics.
- `useHasTouchInput` intentionally remains raw capability but is hover-guarded at its only decision site (`useDropActionInteractionMode`).
- `(any-hover: none) and (any-pointer: coarse)` CSS in globals/tailwind was already hybrid-safe and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touch vs. hover handling on hybrid touch laptops and compact viewports, fixing when tooltips, overlays, and action interactions appear.
  * Updated responsive layout behavior so the correct sidebar and wave/UI layouts render for touch-first devices, mobile-web, and native-app scenarios.
  * Refined small-screen and coarse-pointer styling to better match expected touch behavior.
* **Refactor**
  * Standardized touch-device detection across the app for consistent UI behavior.
* **Tests**
  * Expanded coverage for touch-first, hybrid, and breakpoint edge cases to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->