### PR TITLE
Deploy skill: detailed release-post style + Staging E2E workflow as primary validation

### DIFF
--- a/ops/skills/6529-autonomous-manager/SKILL.md
+++ b/ops/skills/6529-autonomous-manager/SKILL.md
@@ -30,6 +30,7 @@ Before planning or editing, read only the context that matters:
 6. Narrower repo-local skills when relevant:
    - `ops/skills/write-prs/SKILL.md` for PR creation, review iteration, and readiness.
    - `ops/skills/deploy-6529/SKILL.md` for merge execution, staging, production, E2E validation, backend coordination, or release coordination.
+   - `ops/skills/post-6529/SKILL.md` for publishing agent-authored posts, replies, edits, or deletions to 6529.io waves.
    - `ops/skills/commit-docs-updater/SKILL.md` for user-facing docs updates from code changes.
    - `ops/skills/sonar-guardrails/SKILL.md` for TypeScript and JavaScript quality-sensitive edits.
    - `ops/skills/react-doctor/SKILL.md` for React, Next.js, hook, routing, or UI state changes.

--- a/ops/skills/README.md
+++ b/ops/skills/README.md
@@ -20,6 +20,8 @@ This folder stores repo-local Codex skills and agent guidance.
   interaction-state, media, and visual evidence standards.
 - [I18n Localization](i18n-localization/SKILL.md): guides progressive
   frontend message extraction, locale formatting, and fallback review.
+- [Post 6529](post-6529/SKILL.md): publishes, verifies, edits, and deletes
+  agent-authored 6529.io wave drops via the punk6529bot helper.
 - [React Doctor](react-doctor/SKILL.md): provides React-focused review and
   troubleshooting guidance.
 - [Sonar Guardrails](sonar-guardrails/SKILL.md): captures Sonar-oriented

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -233,14 +233,10 @@ battery result, production checks) in user-comprehensible terms.
    - a reference example of the expected depth: the 4.68.0 note (drop `6988d363-53f1-4559-8c0a-c5075bcc0742` in the releases wave)
 6. Re-check the latest wave drop before posting so the number did not advance while the deploy was running. If another release note appeared, renumber and adjust the draft.
 7. Post the release note only after production validation is green. Capture the wave drop URL or serial number for closeout evidence.
-8. Posting mechanics for multiline notes via the `punk6529bot` helper: pass
-   content with `--file <path>` (an LF text file), never inline `--text` from
-   PowerShell (everything after the first newline is silently lost). Place
-   `--send` before the content flag. After sending, VERIFY the stored content
-   with `punk6529bot drops get <drop-id> --json` (check parts count and
-   content length) - the "Sent drop" acknowledgment does not prove the body
-   posted. Drops are editable for only 5 minutes; after that, recover a
-   botched post with `drops delete <id> --send --force` and a fresh post.
+8. Publish via the posting contract in `ops/skills/post-6529/SKILL.md` —
+   dry-run first; `--send` before `--file` (LF file for multiline, never
+   inline `--text`); verify the stored content with `drops get <id> --json`;
+   5-minute edit window with delete+repost recovery.
 
 ## Follow The Repo Deployment Overview
 
@@ -260,11 +256,12 @@ punk6529bot waves search --name "follow the repo"
    - incidents, failed gates, fix-forward or rollback decisions, and final state
    - known follow-ups, skipped checks, and remaining risks
 4. Keep the post detailed but safe to publish. Use public GitHub/workflow links when possible, but omit secrets, credentials, cookies, private URLs, raw production data, local paths, hidden prompts, and internal-only exploit or incident details.
-5. Re-check the wave before sending so the overview is not duplicating a newer deploy note. If the local helper is available, dry-run or draft first, then send after the content passes the safety check:
+5. Re-check the wave before sending so the overview is not duplicating a newer deploy note. Publish per the posting contract in `ops/skills/post-6529/SKILL.md` (dry-run, then `--send --file`, then stored-content verification):
 
 ```powershell
-punk6529bot waves post 49f0e595-ec7c-4235-8695-a527f61b69f4 --text "<deployment overview>"
-punk6529bot waves post 49f0e595-ec7c-4235-8695-a527f61b69f4 --text "<deployment overview>" --send
+punk6529bot waves post 49f0e595-ec7c-4235-8695-a527f61b69f4 --file overview.txt
+punk6529bot waves post 49f0e595-ec7c-4235-8695-a527f61b69f4 --send --file overview.txt
+punk6529bot drops get <drop-id> --json
 ```
 
 6. Capture the wave drop URL or serial number for closeout evidence. If no authorized 6529.io posting credential is available, include the exact ready-to-post overview in the closeout and mark the wave publication as blocked.

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -121,12 +121,31 @@ shared lane.
 
 ## Staging E2E
 
-1. Run the strongest deployed-staging validation available. Inspect package scripts and Playwright config before assuming a target-specific command exists.
-2. If available, start with the read-only deployed staging smoke pack:
-   `6529 run test:e2e:staging`. It points Playwright at
-   `https://staging.6529.io` and skips the local web server. Add
-   release-specific Playwright or browser checks for changed behavior.
-3. If a staging E2E script does not exist in a future worktree, use Playwright or browser automation against `https://staging.6529.io` for the release-critical flows and record that no dedicated staging E2E script exists.
+1. PRIMARY PATH (since 2026-07-05): the `Staging E2E` workflow
+   (`.github/workflows/staging-e2e.yml`) triggers automatically after every
+   successful `Web Deploy - STAGING` run and executes all 12 staging Playwright
+   packs (~160 read-only browser tests, desktop + mobile) against
+   `https://staging.6529.io`, authenticated via the
+   `PLAYWRIGHT_STAGING_ACCESS_CODE` repo secret. Find the run for the deployed
+   SHA and read its per-pack step summary (failing packs attach log tails):
+
+```bash
+gh run list -R 6529-Collections/6529seize-frontend --workflow staging-e2e.yml -L 3
+```
+
+   Re-run via `workflow_dispatch` when needed, noting that dispatch runs test
+   the branch tip, not necessarily the deployed SHA.
+2. Local fallback and targeted reruns: the `test:e2e:staging*` scripts in
+   package.json run individual packs directly against staging with
+   `STAGING_AUTH=<access code>` (or `PLAYWRIGHT_STAGING_ACCESS_CODE`) in the
+   environment; without the code, gated pages redirect to `/access`. Add
+   release-specific Playwright or browser checks for changed behavior beyond
+   the packs.
+3. When a staging pack fails, run the SAME pack against production
+   (`test:e2e:production:*`) before deciding the fix loop: an identical
+   failure signature on the currently-deployed production build means a
+   pre-existing issue (document it, track it, do not block promotion on it);
+   a staging-only failure means a release regression (block and fix).
 4. Cover the changed behavior plus core smoke:
    - page loads and navigation for touched routes
    - wallet/auth-sensitive paths when relevant, using approved test identity only

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -179,24 +179,49 @@ Publish public release notes after production is deployed and production validat
    - small fix, copy change, narrow polish, or follow-up to an existing release: bump the patch number, e.g. `4.38.0` to `4.38.1`
    - broad site-wide, platform, or intentionally breaking release: bump the major number and reset minor/patch, e.g. `4.38.0` to `5.0.0`
    - when unsure whether a change deserves a minor or patch bump, prefer the smaller patch bump unless the release adds a clear new user-facing capability
-4. Draft the release note in plain user-facing language. Recommended shape:
+4. Draft the release note in plain user-facing language, at a DETAILED level
+   (owner direction, 2026-07-05: vague category summaries like "localization
+   polish and under-the-hood cleanup" are not useful). Required shape:
 
 ```text
-4.39.0: Short summary of the release
+4.39.0: Title naming the release's actual themes, not generic words
 
-- What users can now do or see
-- Important changed behavior
-- Fixes that matter to users or operators
+<Theme heading> (visible now):
+- Name the specific surfaces changed (exact pages, routes, components in
+  product terms: "profile header identity block, stats row, About editor,
+  followers list" - never just "profile pages improved")
+- State the concrete behavior change and any review-driven fixes included
+
+<Theme heading> (under the hood):
+- What was removed/added/replaced and why it is safe, with concrete numbers
+  where they exist (pages rebuilt, casts removed, dependencies dropped,
+  tests added)
+
+Known issues shipped as-is: list each transparently with its status
+("fix in progress", "scheduled") - omit the section only when empty.
+
+Validation: one line on what was run and the result (suite green, staging
+battery result, production checks) in user-comprehensible terms.
 ```
 
 5. Write the note from production reality, not PR internals:
-   - mention visible behavior, affected pages, and operationally relevant changes
-   - avoid raw PR numbers, commit SHAs, implementation trivia, private links, secrets, local paths, hidden prompts, unreleased follow-ups, or internal-only risk notes
-   - keep it concise; combine tiny changes under one clear bullet
+   - name specific visible behavior, affected pages, and operationally relevant changes; give concrete counts where they exist
+   - avoid raw PR numbers, commit SHAs, implementation trivia, private links, secrets, local paths, hidden prompts, or internal-only risk notes (that layer belongs in the Follow The Repo overview)
+   - do not disclose unremediated security specifics (e.g. an unrotated credential); "secret scanning added" is fine, the incident behind it is not, until remediation is complete
+   - group many small changes under clear theme headings rather than dropping them; detail beats brevity, but every line must carry information
    - include screenshots or links only when they help users understand the change and are safe to publish
    - if the release contains backend and frontend work, describe the product behavior rather than the service boundary
+   - a reference example of the expected depth: the 4.68.0 note (drop `6988d363-53f1-4559-8c0a-c5075bcc0742` in the releases wave)
 6. Re-check the latest wave drop before posting so the number did not advance while the deploy was running. If another release note appeared, renumber and adjust the draft.
 7. Post the release note only after production validation is green. Capture the wave drop URL or serial number for closeout evidence.
+8. Posting mechanics for multiline notes via the `punk6529bot` helper: pass
+   content with `--file <path>` (an LF text file), never inline `--text` from
+   PowerShell (everything after the first newline is silently lost). Place
+   `--send` before the content flag. After sending, VERIFY the stored content
+   with `punk6529bot drops get <drop-id> --json` (check parts count and
+   content length) - the "Sent drop" acknowledgment does not prove the body
+   posted. Drops are editable for only 5 minutes; after that, recover a
+   botched post with `drops delete <id> --send --force` and a fresh post.
 
 ## Follow The Repo Deployment Overview
 
@@ -209,7 +234,7 @@ After production validation passes, post a detailed deployment overview to the `
 punk6529bot waves search --name "follow the repo"
 ```
 
-3. Draft the overview from deployed production reality. Unlike the public release note, this repo-facing overview should include public PR links and SHAs. Include:
+3. Draft the overview from deployed production reality, at LEAST as detailed as the public release note. Unlike the public release note, this repo-facing overview should include public PR links and SHAs. Include:
    - what user-facing and operator-facing changes were deployed
    - frontend and backend PRs, merge SHAs, production deployed SHA/version label, and deploy run links
    - staging and production validation performed, including E2E or smoke results

--- a/ops/skills/post-6529/SKILL.md
+++ b/ops/skills/post-6529/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: post-6529
+description: Post, reply, edit, delete, and verify 6529.io wave drops agentically via the punk6529bot helper CLI. Use whenever an agent publishes to a 6529.io wave — release notes, deployment overviews, status updates, corrections, or threaded replies — or needs @-mentions, multiline content, stored-content verification, or recovery from a botched post. Covers authorization checks, dry-run/send flow, --file content passing, the 5-minute edit window, and delete+repost recovery. Not for GitHub PRs/issues (write-prs) or in-app UI testing of waves.
+---
+
+# Post 6529
+
+Publish agent-authored content to 6529.io waves correctly on the first try, verify what actually got stored, and recover cleanly when it did not. Every rule below was earned by a real production failure.
+
+## Authorization
+
+- Use a posting credential the current operator personally controls or explicitly approved. The `punk6529bot` helper CLI (WinGet-installed) with its stored credential is the sanctioned local path. Never request raw credentials, expose tokens, or use another person's account.
+- Confirm identity before posting: `punk6529bot auth` and `punk6529bot whoami` (shows signer, JWT expiry, profile, and posting handle).
+- If no authorized credential is available, deliver the exact ready-to-post content in your closeout and mark publication as blocked. Do not improvise access.
+
+## The Posting Contract
+
+1. **Dry-run first.** Omitting `--send` prints the payload without publishing. Inspect the payload's `parts` and `content` before sending anything non-trivial.
+2. **`--send` comes BEFORE content flags** (`--send --file note.txt`). A trailing `--send` is silently swallowed into the content and the CLI dry-runs while you believe you published.
+3. **Multiline content goes via `--file <path>`** — a plain text file with LF endings. Never pass multiline content inline with `--text`: shell argument passing (PowerShell especially) truncates everything after the first newline, and only the title line posts.
+4. **Verify stored content after every send:** `punk6529bot drops get <drop-id> --json` — check parts count, total content length, and that the tail text matches your file's last line. The "Sent drop `<id>`" acknowledgment proves delivery, not content.
+5. **Judge by output, not exit code.** The CLI exits 255 as a normal informational exit under non-interactive harnesses.
+
+## Mentions and wave targeting
+
+- @-mentions must use `@[handle]` (square brackets) to render and notify. Plain `@handle` does neither.
+- Resolve wave ids immediately before posting: `punk6529bot waves search --name "<wave name>"`. Do not trust cached or documented ids — waves can move.
+- Re-read the wave right before sending (`waves read <wave-id> --limit 3`) to avoid duplication and, for numbered posts like release notes, to confirm the sequence has not advanced while you worked.
+
+## Replies, edits, deletion, recovery
+
+- Reply in-thread: `punk6529bot waves reply <wave-id> --reply-to <drop-id> --send --file <path>`.
+- Edit: `punk6529bot drops edit <drop-id|--last> --send --force --file <path>` — allowed only within **5 minutes** of posting; the server rejects later edits ("Drop can't be edited after 5m").
+- Past the edit window, deletion still works: `punk6529bot drops delete <drop-id> --send --force`. Recover a botched post with delete + fresh post when the drop has no replies or reactions yet; prefer a threaded reply correction when engagement already exists.
+- Treat every post as public and effectively permanent: deletion removes the drop, but assume content may have been read, cached, or indexed. Never post secrets, credentials, private URLs, machine-local paths, hidden prompts, or unremediated security specifics ("secret scanning added" is fine; the incident behind it is not, until remediation completes).
+
+## Content style
+
+- Release notes and deployment overviews follow the style contract in `ops/skills/deploy-6529/SKILL.md`: detailed, named surfaces, concrete numbers, known-issues-shipped-as-is, and a validation line. Vague category summaries are rejected (owner direction, 2026-07-05).
+- When the operator wants review before publication, use the drafts flow: `drafts create --wave <id> --file <path>`, `drafts show <draft-id>`, `drafts send <draft-id> --send`.
+
+## Command reference
+
+```text
+punk6529bot auth | whoami                       # identity + JWT expiry
+punk6529bot waves search --name "<term>"        # resolve wave id
+punk6529bot waves read <wave-id> --limit N      # read latest drops
+punk6529bot waves post <wave-id> --send --file <path>
+punk6529bot waves reply <wave-id> --reply-to <drop-id> --send --file <path>
+punk6529bot drops get <drop-id> --json          # VERIFY stored content
+punk6529bot drops edit <drop-id> --send --force --file <path>   # <5 min only
+punk6529bot drops delete <drop-id> --send --force               # any age
+punk6529bot history --limit N                   # this CLI's send log
+```
+
+## Post-publish checklist
+
+- `drops get <id> --json`: parts count and content length match the source file; tail text is the file's final line.
+- `waves read <wave-id> --limit 1`: the drop renders with title and body.
+- Capture the drop id / wave URL for closeout evidence.


### PR DESCRIPTION
Two owner-directed skill updates from the 4.68.0 release retrospective:

1. **Release-post style** (owner direction 2026-07-05): detailed notes required — named surfaces, concrete numbers, theme grouping, known-issues-shipped-as-is section, validation line; the corrected 4.68.0 drop is the reference example. Plus punk6529bot multiline mechanics (--send --file, stored-content verification, 5-minute edit window recovery) learned when the first posts silently truncated to their title lines.

2. **Staging E2E section modernized**: primary path is now the auto-triggered `Staging E2E` workflow (12 packs / ~160 tests per staging deploy, per-pack step summaries) instead of manual script runs; local packs with the access code are the fallback; adds the pre-existing-vs-regression classification technique (same pack against production) that kept the 4.68.0 train from being wrongly blocked on collections failures that predate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Rewrote the Staging E2E runbook with clearer automatic runs, targeted rerun guidance, SHA-based run discovery, per-pack summaries, and a safer staging failure decision flow.
  * Expanded release note drafting guidance into a strict theme-based template, including known-issues statuses and validation outcomes.
  * Strengthened release note posting instructions with required file-based publishing, corrected command sequencing, and stored-content verification.
  * Added a new “Post 6529” procedural skill and updated the repo skills index/load order to support publishing, editing, and recovery flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->