### PR TITLE
Keep explicitly set page titles from being clobbered by App Router head commits

### DIFF
--- a/__tests__/components/dynamic-head/DynamicHeadTitle.test.tsx
+++ b/__tests__/components/dynamic-head/DynamicHeadTitle.test.tsx
@@ -1,0 +1,99 @@
+import { render, waitFor } from "@testing-library/react";
+import React from "react";
+
+let mockTitle = "6529.io";
+let mockIsTitleOwned = false;
+let mockPathname = "/network";
+
+jest.mock("@/contexts/TitleContext", () => ({
+  DEFAULT_TITLE: "6529.io",
+  useTitle: () => ({ title: mockTitle, isTitleOwned: mockIsTitleOwned }),
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+}));
+
+import DynamicHeadTitle from "@/components/dynamic-head/DynamicHeadTitle";
+
+const flushObservers = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+describe("DynamicHeadTitle", () => {
+  beforeEach(() => {
+    mockTitle = "6529.io";
+    mockIsTitleOwned = false;
+    mockPathname = "/network";
+  });
+
+  it("re-asserts an owned title after a later head commit overwrites it", async () => {
+    mockTitle = "Network Metrics | Open Data";
+    mockIsTitleOwned = true;
+    document.title = "Network Metrics"; // SSR metadata title
+
+    render(<DynamicHeadTitle />);
+    expect(document.title).toBe("Network Metrics | Open Data");
+
+    // The App Router's metadata commit lands after hydration and would
+    // silently clobber the owned title without the observer.
+    document.title = "Network Metrics";
+    await waitFor(() =>
+      expect(document.title).toBe("Network Metrics | Open Data")
+    );
+  });
+
+  it("lets server metadata win over route-default placeholders", async () => {
+    mockTitle = "Open Data | Tools"; // provider route default, not owned
+    mockIsTitleOwned = false;
+    document.title = "Open Data";
+
+    render(<DynamicHeadTitle />);
+    expect(document.title).toBe("Open Data");
+
+    document.title = "Open Data Updated";
+    await flushObservers();
+    expect(document.title).toBe("Open Data Updated");
+  });
+
+  it("writes a one-shot fallback when the document title is empty", async () => {
+    mockTitle = "Open Data | Tools";
+    mockIsTitleOwned = false;
+    document.title = "";
+
+    render(<DynamicHeadTitle />);
+    expect(document.title).toBe("Open Data | Tools");
+
+    // Not sticky: a later head commit must win for unowned titles.
+    document.title = "Open Data";
+    await flushObservers();
+    expect(document.title).toBe("Open Data");
+  });
+
+  it("owns the default title on the root path", async () => {
+    mockTitle = "6529.io";
+    mockIsTitleOwned = false;
+    mockPathname = "/";
+    document.title = "Something Else";
+
+    render(<DynamicHeadTitle />);
+    expect(document.title).toBe("6529.io");
+
+    document.title = "Something Else";
+    await waitFor(() => expect(document.title).toBe("6529.io"));
+  });
+
+  it("stops re-asserting after unmount", async () => {
+    mockTitle = "Network Metrics | Open Data";
+    mockIsTitleOwned = true;
+    document.title = "Network Metrics";
+
+    const { unmount } = render(<DynamicHeadTitle />);
+    expect(document.title).toBe("Network Metrics | Open Data");
+
+    unmount();
+    document.title = "Network Metrics";
+    await flushObservers();
+    expect(document.title).toBe("Network Metrics");
+  });
+});

--- a/__tests__/components/dynamic-head/DynamicHeadTitle.test.tsx
+++ b/__tests__/components/dynamic-head/DynamicHeadTitle.test.tsx
@@ -3,11 +3,16 @@ import React from "react";
 
 let mockTitle = "6529.io";
 let mockIsTitleOwned = false;
+let mockTitlePathname: string | null = "/network";
 let mockPathname = "/network";
 
 jest.mock("@/contexts/TitleContext", () => ({
   DEFAULT_TITLE: "6529.io",
-  useTitle: () => ({ title: mockTitle, isTitleOwned: mockIsTitleOwned }),
+  useTitle: () => ({
+    title: mockTitle,
+    isTitleOwned: mockIsTitleOwned,
+    titlePathname: mockTitlePathname,
+  }),
 }));
 
 jest.mock("next/navigation", () => ({
@@ -29,12 +34,15 @@ describe("DynamicHeadTitle", () => {
   beforeEach(() => {
     mockTitle = "6529.io";
     mockIsTitleOwned = false;
+    mockTitlePathname = "/network";
     mockPathname = "/network";
   });
 
   it("re-asserts an owned title after a later head commit overwrites it", async () => {
     mockTitle = "Network Metrics | Open Data";
     mockIsTitleOwned = true;
+    mockTitlePathname = "/open-data/network-metrics";
+    mockPathname = "/open-data/network-metrics";
     document.title = "Network Metrics"; // SSR metadata title
 
     render(<DynamicHeadTitle />);
@@ -51,6 +59,8 @@ describe("DynamicHeadTitle", () => {
   it("lets server metadata win over route-default placeholders", async () => {
     mockTitle = "Open Data | Tools"; // provider route default, not owned
     mockIsTitleOwned = false;
+    mockTitlePathname = "/open-data";
+    mockPathname = "/open-data";
     document.title = "Open Data";
 
     render(<DynamicHeadTitle />);
@@ -64,6 +74,8 @@ describe("DynamicHeadTitle", () => {
   it("writes a one-shot fallback when the document title is empty", async () => {
     mockTitle = "Open Data | Tools";
     mockIsTitleOwned = false;
+    mockTitlePathname = "/open-data";
+    mockPathname = "/open-data";
     document.title = "";
 
     render(<DynamicHeadTitle />);
@@ -78,6 +90,7 @@ describe("DynamicHeadTitle", () => {
   it("owns the default title on the root path", async () => {
     mockTitle = "6529.io";
     mockIsTitleOwned = false;
+    mockTitlePathname = "/";
     mockPathname = "/";
     document.title = "Something Else";
 
@@ -88,30 +101,42 @@ describe("DynamicHeadTitle", () => {
     await waitFor(() => expect(document.title).toBe("6529.io"));
   });
 
-  it("releases the title to the next route's metadata on navigation", async () => {
+  it("never writes route defaults across a route change, whichever side of the metadata commit", async () => {
+    // Owned title on the source route.
     mockTitle = "Network Metrics | Open Data";
     mockIsTitleOwned = true;
+    mockTitlePathname = "/open-data/network-metrics";
+    mockPathname = "/open-data/network-metrics";
     document.title = "Network Metrics";
 
     const view = render(<DynamicHeadTitle />);
     expect(document.title).toBe("Network Metrics | Open Data");
 
-    // Client-side navigation: ownership evaporates in the same render
-    // (pathname-keyed), before the provider's reset effect would run.
-    mockTitle = "Open Data | Tools";
+    // Navigation render: ownership evaporates render-time; the context text
+    // still belongs to the previous route (titlePathname lags pathname).
     mockIsTitleOwned = false;
     mockPathname = "/open-data";
     view.rerender(<DynamicHeadTitle />);
-
-    // The next route's metadata commit must win without a fight.
-    document.title = "Open Data";
     await flushObservers();
+    expect(document.title).toBe("Network Metrics | Open Data"); // untouched
+
+    // Metadata commit for the new route lands BEFORE the provider reset.
+    document.title = "Open Data";
+
+    // Provider reset render: context becomes consistent for the new route.
+    mockTitle = "Open Data | Tools";
+    mockTitlePathname = "/open-data";
+    view.rerender(<DynamicHeadTitle />);
+    await flushObservers();
+    // The route-default placeholder must not clobber the committed metadata.
     expect(document.title).toBe("Open Data");
   });
 
   it("restores the new context title once when ownership is released on the same pathname", async () => {
     mockTitle = "Wave One | Brain";
     mockIsTitleOwned = true;
+    mockTitlePathname = "/messages";
+    mockPathname = "/messages";
     document.title = "Messages";
 
     const view = render(<DynamicHeadTitle />);
@@ -133,6 +158,8 @@ describe("DynamicHeadTitle", () => {
   it("keeps owning the title when the head commit replaces the <title> node", async () => {
     mockTitle = "Network Metrics | Open Data";
     mockIsTitleOwned = true;
+    mockTitlePathname = "/open-data/network-metrics";
+    mockPathname = "/open-data/network-metrics";
     document.title = "Network Metrics";
 
     render(<DynamicHeadTitle />);
@@ -150,6 +177,8 @@ describe("DynamicHeadTitle", () => {
   it("stops re-asserting after unmount", async () => {
     mockTitle = "Network Metrics | Open Data";
     mockIsTitleOwned = true;
+    mockTitlePathname = "/open-data/network-metrics";
+    mockPathname = "/open-data/network-metrics";
     document.title = "Network Metrics";
 
     const { unmount } = render(<DynamicHeadTitle />);

--- a/__tests__/components/dynamic-head/DynamicHeadTitle.test.tsx
+++ b/__tests__/components/dynamic-head/DynamicHeadTitle.test.tsx
@@ -16,7 +16,12 @@ jest.mock("next/navigation", () => ({
 
 import DynamicHeadTitle from "@/components/dynamic-head/DynamicHeadTitle";
 
+// MutationObserver callbacks are microtask-scheduled; flush microtasks and
+// two macrotask ticks so negative assertions are deterministic.
 const flushObservers = async () => {
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await Promise.resolve();
   await new Promise((resolve) => setTimeout(resolve, 0));
 };
 
@@ -81,6 +86,65 @@ describe("DynamicHeadTitle", () => {
 
     document.title = "Something Else";
     await waitFor(() => expect(document.title).toBe("6529.io"));
+  });
+
+  it("releases the title to the next route's metadata on navigation", async () => {
+    mockTitle = "Network Metrics | Open Data";
+    mockIsTitleOwned = true;
+    document.title = "Network Metrics";
+
+    const view = render(<DynamicHeadTitle />);
+    expect(document.title).toBe("Network Metrics | Open Data");
+
+    // Client-side navigation: ownership evaporates in the same render
+    // (pathname-keyed), before the provider's reset effect would run.
+    mockTitle = "Open Data | Tools";
+    mockIsTitleOwned = false;
+    mockPathname = "/open-data";
+    view.rerender(<DynamicHeadTitle />);
+
+    // The next route's metadata commit must win without a fight.
+    document.title = "Open Data";
+    await flushObservers();
+    expect(document.title).toBe("Open Data");
+  });
+
+  it("restores the new context title once when ownership is released on the same pathname", async () => {
+    mockTitle = "Wave One | Brain";
+    mockIsTitleOwned = true;
+    document.title = "Messages";
+
+    const view = render(<DynamicHeadTitle />);
+    expect(document.title).toBe("Wave One | Brain");
+
+    // Leaving a wave without a pathname change: no metadata commit fires,
+    // so the context's route-default reset must reach document.title.
+    mockTitle = "Messages | Brain";
+    mockIsTitleOwned = false;
+    view.rerender(<DynamicHeadTitle />);
+    expect(document.title).toBe("Messages | Brain");
+
+    // But it is not sticky: a later external write stands.
+    document.title = "External";
+    await flushObservers();
+    expect(document.title).toBe("External");
+  });
+
+  it("keeps owning the title when the head commit replaces the <title> node", async () => {
+    mockTitle = "Network Metrics | Open Data";
+    mockIsTitleOwned = true;
+    document.title = "Network Metrics";
+
+    render(<DynamicHeadTitle />);
+    expect(document.title).toBe("Network Metrics | Open Data");
+
+    // Simulate a head commit that swaps the <title> element entirely.
+    const replacement = document.createElement("title");
+    replacement.textContent = "Network Metrics";
+    document.querySelector("title")?.replaceWith(replacement);
+    await waitFor(() =>
+      expect(document.title).toBe("Network Metrics | Open Data")
+    );
   });
 
   it("stops re-asserting after unmount", async () => {

--- a/__tests__/components/dynamic-head/DynamicHeadTitle.test.tsx
+++ b/__tests__/components/dynamic-head/DynamicHeadTitle.test.tsx
@@ -174,6 +174,28 @@ describe("DynamicHeadTitle", () => {
     );
   });
 
+  it("does not let a stale observer fight the next route's metadata commit", async () => {
+    mockTitle = "Wave One | Brain";
+    mockIsTitleOwned = true;
+    mockTitlePathname = "/messages";
+    mockPathname = "/messages";
+    document.title = "Messages";
+
+    render(<DynamicHeadTitle />);
+    expect(document.title).toBe("Wave One | Brain");
+
+    // SPA navigation: the browser location moves before the next route's
+    // head commit lands, while this observer's cleanup is still pending.
+    window.history.pushState({}, "", "/tools/api");
+    try {
+      document.title = "API";
+      await flushObservers();
+      expect(document.title).toBe("API");
+    } finally {
+      window.history.pushState({}, "", "/");
+    }
+  });
+
   it("stops re-asserting after unmount", async () => {
     mockTitle = "Network Metrics | Open Data";
     mockIsTitleOwned = true;

--- a/__tests__/contexts/TitleContext.ownership.test.tsx
+++ b/__tests__/contexts/TitleContext.ownership.test.tsx
@@ -22,21 +22,28 @@ jest.mock("@/config/env", () => ({
 import {
   TitleProvider,
   useSetTitle,
+  useSetWaveData,
   useTitle,
 } from "@/contexts/TitleContext";
 
 function TitleReporter() {
-  const { title, isTitleOwned } = useTitle();
+  const { title, isTitleOwned, titlePathname } = useTitle();
   return (
     <div>
       <span data-testid="title">{title}</span>
       <span data-testid="owned">{String(isTitleOwned)}</span>
+      <span data-testid="title-pathname">{titlePathname}</span>
     </div>
   );
 }
 
 function ExplicitTitleSetter({ pageTitle }: { readonly pageTitle: string }) {
   useSetTitle(pageTitle);
+  return null;
+}
+
+function WaveDataSetter() {
+  useSetWaveData({ name: "Wave One", newItemsCount: 0 });
   return null;
 }
 
@@ -86,5 +93,49 @@ describe("TitleProvider ownership", () => {
     );
     expect(screen.getByTestId("owned").textContent).toBe("false");
     expect(screen.getByTestId("title").textContent).toBe("Network");
+  });
+
+  it("a mounted setter re-claims after the pathname-change reset", () => {
+    const view = render(
+      <TitleProvider>
+        <ExplicitTitleSetter pageTitle="Downloads | Open Data" />
+        <TitleReporter />
+      </TitleProvider>
+    );
+    expect(screen.getByTestId("owned").textContent).toBe("true");
+    expect(screen.getByTestId("title-pathname").textContent).toBe(
+      "/open-data/network-metrics"
+    );
+
+    // The setter survives the navigation: the provider's reset effect clears
+    // the old claim, then the setter's effect re-claims for the new route.
+    act(() => {
+      mockNavigation.pathname = "/network";
+    });
+    view.rerender(
+      <TitleProvider>
+        <ExplicitTitleSetter pageTitle="Downloads | Network" />
+        <TitleReporter />
+      </TitleProvider>
+    );
+    expect(screen.getByTestId("owned").textContent).toBe("true");
+    expect(screen.getByTestId("title").textContent).toBe(
+      "Downloads | Network"
+    );
+    expect(screen.getByTestId("title-pathname").textContent).toBe("/network");
+  });
+
+  it("wave data owns the title on wave routes", () => {
+    mockNavigation.pathname = "/messages";
+    mockNavigation.searchParams = new URLSearchParams("wave=wave-1");
+
+    render(
+      <TitleProvider>
+        <WaveDataSetter />
+        <TitleReporter />
+      </TitleProvider>
+    );
+    expect(screen.getByTestId("owned").textContent).toBe("true");
+    expect(screen.getByTestId("title").textContent).toBe("Wave One | Brain");
   });
 });

--- a/__tests__/contexts/TitleContext.ownership.test.tsx
+++ b/__tests__/contexts/TitleContext.ownership.test.tsx
@@ -1,0 +1,90 @@
+import { act, render, screen } from "@testing-library/react";
+import React from "react";
+
+const mockNavigation = {
+  pathname: "/open-data/network-metrics",
+  searchParams: new URLSearchParams(),
+};
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockNavigation.pathname,
+  useSearchParams: () => mockNavigation.searchParams,
+}));
+
+jest.mock("@/contexts/wave/MyStreamContext", () => ({
+  useMyStreamOptional: () => null,
+}));
+
+jest.mock("@/config/env", () => ({
+  publicEnv: { BASE_ENDPOINT: "https://6529.io" },
+}));
+
+import {
+  TitleProvider,
+  useSetTitle,
+  useTitle,
+} from "@/contexts/TitleContext";
+
+function TitleReporter() {
+  const { title, isTitleOwned } = useTitle();
+  return (
+    <div>
+      <span data-testid="title">{title}</span>
+      <span data-testid="owned">{String(isTitleOwned)}</span>
+    </div>
+  );
+}
+
+function ExplicitTitleSetter({ pageTitle }: { readonly pageTitle: string }) {
+  useSetTitle(pageTitle);
+  return null;
+}
+
+describe("TitleProvider ownership", () => {
+  beforeEach(() => {
+    mockNavigation.pathname = "/open-data/network-metrics";
+    mockNavigation.searchParams = new URLSearchParams();
+  });
+
+  it("route defaults are not owned; explicit titles are", () => {
+    const view = render(
+      <TitleProvider>
+        <TitleReporter />
+      </TitleProvider>
+    );
+    expect(screen.getByTestId("owned").textContent).toBe("false");
+    expect(screen.getByTestId("title").textContent).toBe("Open Data | Tools");
+
+    view.rerender(
+      <TitleProvider>
+        <ExplicitTitleSetter pageTitle="Network Metrics | Open Data" />
+        <TitleReporter />
+      </TitleProvider>
+    );
+    expect(screen.getByTestId("owned").textContent).toBe("true");
+    expect(screen.getByTestId("title").textContent).toBe(
+      "Network Metrics | Open Data"
+    );
+  });
+
+  it("ownership resets when the pathname changes", () => {
+    const view = render(
+      <TitleProvider>
+        <ExplicitTitleSetter pageTitle="Network Metrics | Open Data" />
+        <TitleReporter />
+      </TitleProvider>
+    );
+    expect(screen.getByTestId("owned").textContent).toBe("true");
+
+    act(() => {
+      mockNavigation.pathname = "/network";
+    });
+    view.rerender(
+      <TitleProvider>
+        <TitleReporter />
+      </TitleProvider>
+    );
+    expect(screen.getByTestId("owned").textContent).toBe("false");
+    expect(screen.getByTestId("title").textContent).toBe("Network");
+  });
+});

--- a/__tests__/contexts/TitleContext.test.tsx
+++ b/__tests__/contexts/TitleContext.test.tsx
@@ -77,6 +77,12 @@ describe("TitleContext", () => {
     await waitFor(() => {
       expect(screen.getByText("Memes Minting Calendar")).toBeInTheDocument();
     });
+
+    // Across a route change the context leaves document.title to the new
+    // route's server metadata commit (jsdom has no App Router, so simulate
+    // it: /meme-calendar's metadata title is "Memes Minting Calendar"); the
+    // context must not fight it afterwards.
+    document.title = "Memes Minting Calendar";
     await waitFor(() => {
       expect(document.title).toBe("Memes Minting Calendar");
     });

--- a/components/dynamic-head/DynamicHeadTitle.tsx
+++ b/components/dynamic-head/DynamicHeadTitle.tsx
@@ -5,26 +5,35 @@ import { usePathname } from "next/navigation";
 import { useEffect, useRef } from "react";
 
 export default function DynamicHeadTitle() {
-  const { title, isTitleOwned } = useTitle();
+  const { title, isTitleOwned, titlePathname } = useTitle();
   const pathname = usePathname();
   const shouldApplyDefaultTitle = pathname === "/" && title === DEFAULT_TITLE;
-  const previousTitleRef = useRef<string | null>(null);
+  const isTitleForCurrentRoute = titlePathname === pathname;
+  const previousObservationRef = useRef<{
+    title: string;
+    pathname: string | null;
+  } | null>(null);
 
   useEffect(() => {
-    const previousTitle = previousTitleRef.current;
-    previousTitleRef.current = title;
+    const previousObservation = previousObservationRef.current;
+    if (isTitleForCurrentRoute) {
+      previousObservationRef.current = { title, pathname };
+    }
 
     // Route-default placeholders must not beat the route's server metadata
-    // title on load; only explicitly claimed titles (useSetTitle/wave data)
-    // or the root path own document.title. Unowned titles still get a
-    // one-shot write when the context transitions (e.g. leaving a wave on
-    // the same pathname, where no metadata commit fires) or when the
-    // document title is empty — without stickiness, so any later metadata
-    // commit wins.
+    // title; only explicitly claimed titles (useSetTitle/wave data) or the
+    // root path own document.title. Unowned titles get a one-shot write only
+    // for same-pathname context transitions (e.g. leaving a wave, where no
+    // metadata commit fires) or an empty document title — never across a
+    // route change, where the new route's metadata commit must win, and
+    // never with stickiness.
     if (!isTitleOwned && !shouldApplyDefaultTitle) {
-      const contextTitleChanged =
-        previousTitle !== null && previousTitle !== title;
-      if (!document.title || contextTitleChanged) {
+      const isSameRouteTransition =
+        isTitleForCurrentRoute &&
+        previousObservation !== null &&
+        previousObservation.pathname === pathname &&
+        previousObservation.title !== title;
+      if (!document.title || isSameRouteTransition) {
         document.title = title;
       }
       return;
@@ -73,7 +82,13 @@ export default function DynamicHeadTitle() {
       headObserver.disconnect();
       textObserver.disconnect();
     };
-  }, [isTitleOwned, shouldApplyDefaultTitle, title]);
+  }, [
+    isTitleForCurrentRoute,
+    isTitleOwned,
+    pathname,
+    shouldApplyDefaultTitle,
+    title,
+  ]);
 
   return null;
 }

--- a/components/dynamic-head/DynamicHeadTitle.tsx
+++ b/components/dynamic-head/DynamicHeadTitle.tsx
@@ -2,20 +2,29 @@
 
 import { DEFAULT_TITLE, useTitle } from "@/contexts/TitleContext";
 import { usePathname } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 export default function DynamicHeadTitle() {
   const { title, isTitleOwned } = useTitle();
   const pathname = usePathname();
   const shouldApplyDefaultTitle = pathname === "/" && title === DEFAULT_TITLE;
+  const previousTitleRef = useRef<string | null>(null);
 
   useEffect(() => {
+    const previousTitle = previousTitleRef.current;
+    previousTitleRef.current = title;
+
     // Route-default placeholders must not beat the route's server metadata
-    // title; only explicitly claimed titles (useSetTitle/wave data) or the
-    // root path own document.title. An empty title gets a one-shot fallback
-    // write without stickiness.
+    // title on load; only explicitly claimed titles (useSetTitle/wave data)
+    // or the root path own document.title. Unowned titles still get a
+    // one-shot write when the context transitions (e.g. leaving a wave on
+    // the same pathname, where no metadata commit fires) or when the
+    // document title is empty — without stickiness, so any later metadata
+    // commit wins.
     if (!isTitleOwned && !shouldApplyDefaultTitle) {
-      if (!document.title) {
+      const contextTitleChanged =
+        previousTitle !== null && previousTitle !== title;
+      if (!document.title || contextTitleChanged) {
         document.title = title;
       }
       return;
@@ -23,24 +32,47 @@ export default function DynamicHeadTitle() {
 
     document.title = title;
 
+    const head = document.head;
+    if (!head) {
+      return;
+    }
+
     // The App Router commits the route's server metadata <title> after
     // hydration/streaming settles, silently overwriting titles set from
-    // TitleContext before that point (e.g. useSetTitle on mount). Watch the
-    // head (the commit may also replace the <title> node itself) and
-    // re-assert until this effect is replaced or the context stops owning
-    // the title.
-    const observer = new MutationObserver(() => {
+    // TitleContext before that point (e.g. useSetTitle on mount). Re-assert
+    // owned titles: a text observer scoped to the <title> node catches
+    // overwrites, and a shallow head observer re-arms it when the commit
+    // replaces the node itself.
+    const reassertTitle = () => {
       if (document.title !== title) {
         document.title = title;
       }
-    });
-    observer.observe(document.head, {
-      characterData: true,
-      childList: true,
-      subtree: true,
-    });
+    };
 
-    return () => observer.disconnect();
+    const textObserver = new MutationObserver(reassertTitle);
+    const observeTitleNode = () => {
+      const titleElement = head.querySelector("title");
+      if (titleElement) {
+        textObserver.observe(titleElement, {
+          characterData: true,
+          childList: true,
+          subtree: true,
+        });
+      }
+    };
+    observeTitleNode();
+
+    const headObserver = new MutationObserver(() => {
+      textObserver.disconnect();
+      observeTitleNode();
+      reassertTitle();
+    });
+    headObserver.observe(head, { childList: true });
+
+    return () => {
+      headObserver.disconnect();
+      textObserver.disconnect();
+    };
   }, [isTitleOwned, shouldApplyDefaultTitle, title]);
 
   return null;

--- a/components/dynamic-head/DynamicHeadTitle.tsx
+++ b/components/dynamic-head/DynamicHeadTitle.tsx
@@ -52,7 +52,17 @@ export default function DynamicHeadTitle() {
     // owned titles: a text observer scoped to the <title> node catches
     // overwrites, and a shallow head observer re-arms it when the commit
     // replaces the node itself.
+    //
+    // MutationObserver callbacks are microtasks and can fire between an SPA
+    // navigation's head commit and this effect's cleanup, so a stale
+    // observer would re-assert the previous route's title over the new
+    // route's metadata. Bail once the live location moves off the pathname
+    // this observation was armed for.
+    const ownedLocationPathname = window.location.pathname;
     const reassertTitle = () => {
+      if (window.location.pathname !== ownedLocationPathname) {
+        return;
+      }
       if (document.title !== title) {
         document.title = title;
       }

--- a/components/dynamic-head/DynamicHeadTitle.tsx
+++ b/components/dynamic-head/DynamicHeadTitle.tsx
@@ -5,15 +5,43 @@ import { usePathname } from "next/navigation";
 import { useEffect } from "react";
 
 export default function DynamicHeadTitle() {
-  const { title } = useTitle();
+  const { title, isTitleOwned } = useTitle();
   const pathname = usePathname();
   const shouldApplyDefaultTitle = pathname === "/" && title === DEFAULT_TITLE;
 
   useEffect(() => {
-    if (!document.title || title !== DEFAULT_TITLE || shouldApplyDefaultTitle) {
-      document.title = title;
+    // Route-default placeholders must not beat the route's server metadata
+    // title; only explicitly claimed titles (useSetTitle/wave data) or the
+    // root path own document.title. An empty title gets a one-shot fallback
+    // write without stickiness.
+    if (!isTitleOwned && !shouldApplyDefaultTitle) {
+      if (!document.title) {
+        document.title = title;
+      }
+      return;
     }
-  }, [shouldApplyDefaultTitle, title]);
+
+    document.title = title;
+
+    // The App Router commits the route's server metadata <title> after
+    // hydration/streaming settles, silently overwriting titles set from
+    // TitleContext before that point (e.g. useSetTitle on mount). Watch the
+    // head (the commit may also replace the <title> node itself) and
+    // re-assert until this effect is replaced or the context stops owning
+    // the title.
+    const observer = new MutationObserver(() => {
+      if (document.title !== title) {
+        document.title = title;
+      }
+    });
+    observer.observe(document.head, {
+      characterData: true,
+      childList: true,
+      subtree: true,
+    });
+
+    return () => observer.disconnect();
+  }, [isTitleOwned, shouldApplyDefaultTitle, title]);
 
   return null;
 }

--- a/contexts/TitleContext.tsx
+++ b/contexts/TitleContext.tsx
@@ -15,6 +15,10 @@ import { useMyStreamOptional } from "./wave/MyStreamContext";
 
 type TitleContextType = {
   title: string;
+  // True when a page explicitly claimed the title (setTitle/wave data), as
+  // opposed to the provider's route-default placeholder. Only owned titles
+  // may overwrite the route's server metadata <title>.
+  isTitleOwned: boolean;
   setTitle: (title: string) => void;
   notificationCount: number;
   setNotificationCount: (count: number) => void;
@@ -81,6 +85,7 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
   const [title, setTitle] = useState<string>(() =>
     getDefaultTitleForRoute(pathname)
   );
+  const [hasExplicitTitle, setHasExplicitTitle] = useState(false);
   const [notificationCount, setNotificationCount] = useState<number>(0);
   const [waveData, setWaveData] = useState<{
     name: string;
@@ -113,6 +118,7 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
 
     if (pathnameChanged) {
       setTitle(getDefaultTitleForRoute(pathname));
+      setHasExplicitTitle(false);
       setWaveData(null);
       return;
     }
@@ -127,6 +133,7 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
       (!currentWaveInUrl || previousWaveInUrl !== currentWaveInUrl)
     ) {
       setTitle(getDefaultTitleForRoute(pathname));
+      setHasExplicitTitle(false);
       setWaveData(null);
     }
   }, [pathname, searchParams]);
@@ -134,6 +141,7 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
   const updateTitle = (newTitle: string) => {
     if (routeRef.current === pathname) {
       setTitle(newTitle);
+      setHasExplicitTitle(true);
     }
   };
 
@@ -157,6 +165,9 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
     return title;
   }, [isWaveRoute, waveParam, waveData, title, notificationCount]);
 
+  const isTitleOwned =
+    hasExplicitTitle || Boolean(isWaveRoute && waveParam && waveData);
+
   // Memoize the context value to prevent unnecessary re-renders
   const contextValue = useMemo(() => {
     let notificationText = "";
@@ -170,12 +181,13 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
       : computedTitle;
     return {
       title: finalTitle,
+      isTitleOwned,
       setTitle: updateTitle,
       notificationCount,
       setNotificationCount,
       setWaveData,
     };
-  }, [computedTitle, notificationCount]);
+  }, [computedTitle, isTitleOwned, notificationCount]);
 
   return (
     <TitleContext.Provider value={contextValue}>

--- a/contexts/TitleContext.tsx
+++ b/contexts/TitleContext.tsx
@@ -19,6 +19,10 @@ type TitleContextType = {
   // opposed to the provider's route-default placeholder. Only owned titles
   // may overwrite the route's server metadata <title>.
   isTitleOwned: boolean;
+  // Pathname the current title text was computed for. During a navigation
+  // there is a render window where the text still belongs to the previous
+  // route; consumers must not act on it for the new route until they match.
+  titlePathname: string | null;
   setTitle: (title: string) => void;
   notificationCount: number;
   setNotificationCount: (count: number) => void;
@@ -85,6 +89,8 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
   const [title, setTitle] = useState<string>(() =>
     getDefaultTitleForRoute(pathname)
   );
+  // Pathname the current title text was computed for.
+  const [titlePathname, setTitlePathname] = useState<string | null>(pathname);
   // Pathname the explicit title was claimed for: ownership evaporates in the
   // same render as a navigation, before any effect-based reset runs.
   const [explicitTitlePathname, setExplicitTitlePathname] = useState<
@@ -122,6 +128,7 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
 
     if (pathnameChanged) {
       setTitle(getDefaultTitleForRoute(pathname));
+      setTitlePathname(pathname);
       setExplicitTitlePathname(null);
       setWaveData(null);
       return;
@@ -137,6 +144,7 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
       (!currentWaveInUrl || previousWaveInUrl !== currentWaveInUrl)
     ) {
       setTitle(getDefaultTitleForRoute(pathname));
+      setTitlePathname(pathname);
       setExplicitTitlePathname(null);
       setWaveData(null);
     }
@@ -145,6 +153,7 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
   const updateTitle = (newTitle: string) => {
     if (routeRef.current === pathname) {
       setTitle(newTitle);
+      setTitlePathname(pathname);
       setExplicitTitlePathname(pathname);
     }
   };
@@ -187,12 +196,13 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
     return {
       title: finalTitle,
       isTitleOwned,
+      titlePathname,
       setTitle: updateTitle,
       notificationCount,
       setNotificationCount,
       setWaveData,
     };
-  }, [computedTitle, isTitleOwned, notificationCount]);
+  }, [computedTitle, isTitleOwned, notificationCount, titlePathname]);
 
   return (
     <TitleContext.Provider value={contextValue}>

--- a/contexts/TitleContext.tsx
+++ b/contexts/TitleContext.tsx
@@ -85,7 +85,11 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
   const [title, setTitle] = useState<string>(() =>
     getDefaultTitleForRoute(pathname)
   );
-  const [hasExplicitTitle, setHasExplicitTitle] = useState(false);
+  // Pathname the explicit title was claimed for: ownership evaporates in the
+  // same render as a navigation, before any effect-based reset runs.
+  const [explicitTitlePathname, setExplicitTitlePathname] = useState<
+    string | null
+  >(null);
   const [notificationCount, setNotificationCount] = useState<number>(0);
   const [waveData, setWaveData] = useState<{
     name: string;
@@ -118,7 +122,7 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
 
     if (pathnameChanged) {
       setTitle(getDefaultTitleForRoute(pathname));
-      setHasExplicitTitle(false);
+      setExplicitTitlePathname(null);
       setWaveData(null);
       return;
     }
@@ -133,7 +137,7 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
       (!currentWaveInUrl || previousWaveInUrl !== currentWaveInUrl)
     ) {
       setTitle(getDefaultTitleForRoute(pathname));
-      setHasExplicitTitle(false);
+      setExplicitTitlePathname(null);
       setWaveData(null);
     }
   }, [pathname, searchParams]);
@@ -141,7 +145,7 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
   const updateTitle = (newTitle: string) => {
     if (routeRef.current === pathname) {
       setTitle(newTitle);
-      setHasExplicitTitle(true);
+      setExplicitTitlePathname(pathname);
     }
   };
 
@@ -166,7 +170,8 @@ export const TitleProvider: React.FC<{ children: React.ReactNode }> = ({
   }, [isWaveRoute, waveParam, waveData, title, notificationCount]);
 
   const isTitleOwned =
-    hasExplicitTitle || Boolean(isWaveRoute && waveParam && waveData);
+    (explicitTitlePathname !== null && explicitTitlePathname === pathname) ||
+    Boolean(isWaveRoute && waveParam && waveData);
 
   // Memoize the context value to prevent unnecessary re-renders
   const contextValue = useMemo(() => {


### PR DESCRIPTION
## Problem

The post-deploy **Staging E2E** workflow (added today in #3071) has never gone green: `Network Metrics downloads route reads public upload metadata` fails `toHaveTitle("Network Metrics | Open Data")` — **against production too** — and `renders The Memes mint page read-only` fails on staging.

Root cause (traced with a `<title>` MutationObserver on a live page): the App Router commits the route's server metadata `<title>` after hydration settles, and that commit **overwrites** `document.title` values already written from `TitleContext`:

```
"Network Metrics"                    <- SSR metadata
"Network Metrics | Open Data"        <- useSetTitle enrichment applies
"Network Metrics"                    <- head commit clobbers it back (final)
```

Pages that set their title on mount (`useSetTitle`) lose deterministically; pages that set it after a data fetch (The Memes mint) win or lose per environment timing — which is exactly the staging-vs-production split the packs showed.

## Fix

- `TitleContext` now tracks **ownership**: titles claimed via `setTitle`/wave data own `document.title`; the provider's route-default placeholders do not (server metadata must keep winning there, e.g. `/open-data` → "Open Data").
- `DynamicHeadTitle` re-asserts owned titles via a `MutationObserver` on `document.head` (covers both text overwrites and `<title>` node replacement) and releases ownership on route change. Unowned titles get at most a one-shot fallback write when `document.title` is empty.

## Verification

- Live dev serve: `/open-data/network-metrics` → **"Network Metrics | Open Data"** (previously clobbered), `/open-data` → "Open Data", `/network` → "Network" — all matching the staging pack assertions.
- New unit tests: owned-title re-assertion, unowned passthrough (metadata wins), empty-title one-shot fallback, root-path default, unmount cleanup, and provider ownership lifecycle across route changes.
- `typecheck:ci` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added title ownership tracking to preserve the browser tab title correctly across route changes, wave-derived titles, and metadata commits.
  * Exposed `isTitleOwned` and `titlePathname` to improve route-aware title behavior.

* **Bug Fixes**
  * Improved dynamic title handling to prevent unwanted overwrites when unowned, while still respecting server metadata and root-path defaults.
  * Added resilient reassertion when the `<title>` element is replaced.

* **Tests**
  * Expanded Jest/RTL coverage for ownership transitions, release semantics across renders/pathnames, DOM replacement, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->