### PR TITLE
Burn down any_casts 64 -> 45: type the delegation write-config path

### DIFF
--- a/__tests__/components/delegation/DelegationSubmitGroups.test.tsx
+++ b/__tests__/components/delegation/DelegationSubmitGroups.test.tsx
@@ -57,7 +57,7 @@ describe("DelegationSubmitGroups", () => {
     render(
       <DelegationSubmitGroups
         title="T"
-        writeParams={{ foo: "bar" }}
+        writeParams={{ foo: "bar", functionName: "registerDelegationAddress" }}
         showCancel={true}
         gasError={undefined}
         validate={() => []}
@@ -67,11 +67,32 @@ describe("DelegationSubmitGroups", () => {
     );
     expect(screen.getByText("Cancel")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Submit" }));
-    expect(mockWriteContract).toHaveBeenCalledWith({ foo: "bar" });
+    expect(mockWriteContract).toHaveBeenCalledWith({
+      foo: "bar",
+      functionName: "registerDelegationAddress",
+    });
     expect(onSetToast).toHaveBeenCalledWith({
       title: "T",
       message: "Confirm in your wallet...",
     });
+  });
+
+  it("does not submit while writeParams lack a functionName", () => {
+    const onSetToast = jest.fn();
+    render(
+      <DelegationSubmitGroups
+        title="T"
+        writeParams={{ foo: "bar", functionName: undefined }}
+        showCancel={false}
+        gasError={undefined}
+        validate={() => []}
+        onHide={jest.fn()}
+        onSetToast={onSetToast}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Submit" }));
+    expect(mockWriteContract).not.toHaveBeenCalled();
+    expect(onSetToast).not.toHaveBeenCalled();
   });
 
   it("shows receipt errors instead of success toast", () => {

--- a/abis/abis.ts
+++ b/abis/abis.ts
@@ -1,6 +1,6 @@
 import type { Abi } from "viem";
 
-export const DELEGATION_ABI = [
+export const DELEGATION_ABI: Abi = [
   { inputs: [], stateMutability: "nonpayable", type: "constructor" },
   {
     anonymous: false,

--- a/components/delegation/DelegationFormParts.tsx
+++ b/components/delegation/DelegationFormParts.tsx
@@ -20,6 +20,7 @@ import { Tooltip } from "react-tooltip";
 import { useWaitForTransactionReceipt, useWriteContract } from "wagmi";
 import type { DelegationCollection } from "./delegation-constants";
 import { SUPPORTED_COLLECTIONS } from "./delegation-constants";
+import type { DelegationWriteParams } from "./delegation-shared";
 import { useOrignalDelegatorEnsResolution } from "./delegation-shared";
 import styles from "./Delegation.module.css";
 
@@ -353,7 +354,7 @@ export function DelegationFormDelegateAddressFormGroup(
 export function DelegationSubmitGroups(
   props: Readonly<{
     title: string;
-    writeParams: any;
+    writeParams: DelegationWriteParams;
     showCancel: boolean;
     gasError?: string | undefined;
     validate: () => string[];
@@ -390,7 +391,13 @@ export function DelegationSubmitGroups(
       setErrors(newErrors);
       window.scrollBy(0, 100);
     } else {
-      writeDelegation.writeContract(writeParams);
+      const { functionName } = writeParams;
+      if (!functionName) {
+        // Unreachable: submission is gated by the same validate() predicate
+        // the form components use to decide whether functionName is set.
+        return;
+      }
+      writeDelegation.writeContract({ ...writeParams, functionName });
       onSetToast({
         title,
         message: "Confirm in your wallet...",

--- a/components/delegation/DelegationToast.tsx
+++ b/components/delegation/DelegationToast.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import styles from "./Delegation.module.css";
 
-interface DelegationToastState {
+export interface DelegationToastState {
   title: string;
   message?: ReactNode;
 }

--- a/components/delegation/NewAssignPrimaryAddress.tsx
+++ b/components/delegation/NewAssignPrimaryAddress.tsx
@@ -16,6 +16,7 @@ import { useQuery } from "@tanstack/react-query";
 import type { DelegationCollection } from "./delegation-constants";
 import { PRIMARY_ADDRESS_USE_CASE } from "./delegation-constants";
 import { getGasError } from "./delegation-shared";
+import type { DelegationToastState } from "./DelegationToast";
 import {
   DelegationAddressDisabledInput,
   DelegationCloseButton,
@@ -36,10 +37,10 @@ interface Props {
       }
     | undefined;
   ens: string | null | undefined;
-  onHide(): any;
+  onHide(): void;
   new_primary_address_query?: string | undefined;
-  setNewPrimaryAddressQuery?(query: string): any;
-  onSetToast(toast: any): any;
+  setNewPrimaryAddressQuery?(query: string): void;
+  onSetToast(toast: DelegationToastState): void;
 }
 
 export default function NewAssignPrimaryAddress(props: Readonly<Props>) {
@@ -77,7 +78,7 @@ export default function NewAssignPrimaryAddress(props: Readonly<Props>) {
           validate().length === 0
             ? "registerDelegationAddressUsingSubDelegation"
             : undefined,
-        onSettled(data: any, error: any) {
+        onSettled(data: unknown, error: Error | null) {
           if (data) {
             setGasError(undefined);
           }
@@ -100,7 +101,7 @@ export default function NewAssignPrimaryAddress(props: Readonly<Props>) {
         ],
         functionName:
           validate().length === 0 ? "registerDelegationAddress" : undefined,
-        onSettled(data: any, error: any) {
+        onSettled(data: unknown, error: Error | null) {
           if (data) {
             setGasError(undefined);
           }

--- a/components/delegation/NewDelegation.tsx
+++ b/components/delegation/NewDelegation.tsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 import type { DelegationCollection } from "./delegation-constants";
 import { DELEGATION_USE_CASES } from "./delegation-constants";
 import { getGasError } from "./delegation-shared";
+import type { DelegationToastState } from "./DelegationToast";
 import styles from "./Delegation.module.css";
 import {
   DelegationAddressDisabledInput,
@@ -37,11 +38,11 @@ interface Props {
     | undefined;
   ens: string | null | undefined;
   collection_query?: string | undefined;
-  setCollectionQuery?(collection: string): any;
+  setCollectionQuery?(collection: string): void;
   use_case_query?: number | undefined;
-  setUseCaseQuery?(useCase: number): any;
-  onHide(): any;
-  onSetToast(toast: any): any;
+  setUseCaseQuery?(useCase: number): void;
+  onHide(): void;
+  onSetToast(toast: DelegationToastState): void;
 }
 
 export default function NewDelegationComponent(props: Readonly<Props>) {
@@ -84,7 +85,7 @@ export default function NewDelegationComponent(props: Readonly<Props>) {
           validate().length === 0
             ? "registerDelegationAddressUsingSubDelegation"
             : undefined,
-        onSettled(data: any, error: any) {
+        onSettled(data: unknown, error: Error | null) {
           if (data) {
             setGasError(undefined);
           }
@@ -109,7 +110,7 @@ export default function NewDelegationComponent(props: Readonly<Props>) {
         ],
         functionName:
           validate().length === 0 ? "registerDelegationAddress" : undefined,
-        onSettled(data: any, error: any) {
+        onSettled(data: unknown, error: Error | null) {
           if (data) {
             setGasError(undefined);
           }

--- a/components/delegation/delegation-shared.ts
+++ b/components/delegation/delegation-shared.ts
@@ -1,5 +1,20 @@
 import { DELEGATION_CONTRACT } from "@/constants/constants";
+import type { Abi } from "viem";
 import { useEnsName } from "wagmi";
+
+/**
+ * Contract-write config assembled by the delegation form components and
+ * executed by `DelegationSubmitGroups`. `functionName` is `undefined` while
+ * the form fails validation; submission is gated on the same `validate()`
+ * predicate, so it is always defined by the time the write is sent.
+ */
+export interface DelegationWriteParams {
+  readonly address: `0x${string}`;
+  readonly abi: Abi;
+  readonly chainId: number;
+  readonly functionName: string | undefined;
+  readonly args: readonly unknown[];
+}
 
 export function useOrignalDelegatorEnsResolution(
   props: Readonly<{
@@ -21,7 +36,7 @@ const DELEGATION_NETWORK_ERROR = `Switch to ${
 const DELEGATION_LOCKED_ERROR =
   "CANNOT ESTIMATE GAS - This can be caused by locked collections/use-cases";
 
-export function getGasError(error: any) {
+export function getGasError(error: Error) {
   if (error.message.includes("Chain mismatch")) {
     return DELEGATION_NETWORK_ERROR;
   } else {

--- a/ops/workstreams/repo-health-2026-07/run-log.md
+++ b/ops/workstreams/repo-health-2026-07/run-log.md
@@ -321,3 +321,19 @@ useDownloader.test.ts` failed to LOAD on main (its bare `@capacitor/core` mock
 - Non-source TODO mentions that remain are intentional: skill docs that
   document TODO conventions, the campaign docs, and the ratchet's own
   detection patterns/fixtures.
+
+## 2026-07-05 (Thread G — any burn-down tail, wave 2a)
+
+- Delegation any-tail slice 1 of 3: the write-config path. DELEGATION_ABI
+  annotated `: Abi` at the source (NextGen-ABI precedent from #3052), new
+  `DelegationWriteParams` in delegation-shared typed into
+  `DelegationSubmitGroups.writeParams` (with a functionName narrowing
+  guard on the already-validate()-gated submit), `getGasError` takes
+  `Error`, `DelegationToastState` exported and used by NewDelegation +
+  NewAssignPrimaryAddress props; legacy inert `onSettled(data, error)`
+  annotations typed `unknown`/`Error | null`. `any_casts` 64 -> 45.
+- Rode along per ratchet protocol: `oversized_files` 90 -> 89
+  (useWaveDropsClipboard.ts healed by #3072; --update shrank the list).
+- Pre-existing latent bug found while typing (NOT fixed here, behavior
+  preserved): the CollectionDelegation use-case lock UI reads wagmi
+  multicall envelopes as booleans instead of `.result` — issue #3078.

--- a/scripts/debt-ratchet-baseline.json
+++ b/scripts/debt-ratchet-baseline.json
@@ -2,9 +2,9 @@
   "schema_version": 1,
   "max_source_file_lines": 800,
   "counts": {
-    "any_casts": 64,
+    "any_casts": 45,
     "todo_comments": 0,
-    "oversized_files": 90,
+    "oversized_files": 89,
     "bootstrap_imports": 0,
     "redux_imports": 0,
     "pages_router_files": 0
@@ -89,7 +89,6 @@
     "components/waves/discovery/WaveScoreTransparencyPage.tsx",
     "components/waves/drops/WaveDrop.tsx",
     "components/waves/drops/WaveDropReactions.tsx",
-    "components/waves/drops/wave-drops-all/hooks/useWaveDropsClipboard.ts",
     "components/waves/github/GithubLinkPreview.tsx",
     "contexts/wave/hooks/useWaveRealtimeUpdater.ts",
     "helpers/Helpers.ts",


### PR DESCRIPTION
## Issue
- Repo-health campaign, workstream E tail: `components/delegation/**` carries ~60 of the 64 remaining ratchet-counted `any` sites. They were deferred by the earlier NextGen typing wave (#3052) to an expected delegation rewrite that turned out unnecessary, so they need direct typing. This is slice 1 of 3: the contract-write config path shared by the delegation forms.

## Fix
- Type the seam instead of the symptoms: `DELEGATION_ABI` is annotated `: Abi` at the source (the same treatment #3052 gave the NextGen ABIs), a new `DelegationWriteParams` interface in `delegation-shared.ts` models the write config the form components assemble, and `DelegationSubmitGroups` consumes it instead of `writeParams: any`.

## Changes
- `abis/abis.ts`: `DELEGATION_ABI: Abi`. Existing `DELEGATION_ABI as Abi` casts elsewhere (NextGenMint) become no-ops and are deliberately left untouched — those files belong to a concurrent workstream.
- `components/delegation/delegation-shared.ts`: `DelegationWriteParams`; `getGasError(error: any)` -> `getGasError(error: Error)`.
- `components/delegation/DelegationFormParts.tsx`: `writeParams: DelegationWriteParams`; the submit handler narrows `functionName` before `writeContract` — submission was already gated by the same `validate()` predicate that decides whether `functionName` is set, so the new early-return is not reachable in production flows.
- `components/delegation/DelegationToast.tsx`: `DelegationToastState` exported.
- `NewDelegation.tsx` / `NewAssignPrimaryAddress.tsx`: callback props typed (`void`, `DelegationToastState`); the legacy `onSettled(data: any, error: any)` annotations inside the write configs become `(data: unknown, error: Error | null)`. Note these callbacks are inert under wagmi v2 (mutation callbacks are the second argument of `writeContract`, not part of the variables object); they are typed, not removed, to keep this PR behavior-preserving.
- `__tests__/.../DelegationSubmitGroups.test.tsx`: the valid-submit fixture now carries a `functionName` like every production caller; a new test pins the no-`functionName` no-op contract.
- Ratchet baseline: `any_casts` 64 -> 45. `oversized_files` 90 -> 89 rides along per the stale-baseline protocol (`useWaveDropsClipboard.ts` healed by #3072; `--update` shrank the grandfather list).

## Validation
- `tsc --noEmit -p tsconfig.typecheck.json` green at this branch state.
- Full Jest suite green at this branch state (numbers in PR comment/CI); the delegation suites plus the stacked follow-up slices were also green together locally.
- `lint:changed` clean; `node scripts/debt-ratchet.cjs` passes with the lowered baseline.

## Risk
- Level: Low
- Why: type-only edits plus one unreachable guard in a wallet flow; no runtime object shapes change (the write config object still carries its legacy fields through the spread).
- Rollback: revert the merge commit.

## Review Notes
- The inert-`onSettled` finding and the pre-existing lock-status envelope reads discovered during this work are tracked in issue #3078 rather than fixed here; slices 2 and 3 (follow-up PRs) finish the remaining delegation `any` sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Delegation submissions now include the selected action when sent, and submissions are skipped when that action isn’t available.
  - Toast and error handling in delegation flows is more consistent, helping prevent unexpected failures.

- **Chores**
  - Improved internal typing and validation around delegation features for better reliability.
  - Updated supporting tests to cover the new submission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->