### PR TITLE
Fix Network Metrics downloads view crossing the RSC boundary and its title

### DIFF
--- a/__tests__/app/open-data/network-metrics.test.tsx
+++ b/__tests__/app/open-data/network-metrics.test.tsx
@@ -26,10 +26,7 @@ jest.mock("@/services/6529api", () => ({
 }));
 
 jest.mock("@/components/providers/metadata", () => ({
-  getAppMetadata: jest.fn().mockReturnValue({
-    title: "Network Metrics",
-    description: "Open Data",
-  }),
+  getAppMetadata: jest.fn((customMetadata) => customMetadata),
 }));
 
 describe("Open Data network metrics page", () => {
@@ -42,7 +39,7 @@ describe("Open Data network metrics page", () => {
 
   it("exposes metadata", async () => {
     await expect(generateMetadata()).resolves.toEqual({
-      title: "Network Metrics",
+      title: "Consolidated Network Metrics | Open Data",
       description: "Open Data",
     });
   });

--- a/__tests__/components/communityDownloads/CommunityDownloadsTDH.test.tsx
+++ b/__tests__/components/communityDownloads/CommunityDownloadsTDH.test.tsx
@@ -1,7 +1,6 @@
 import CommunityDownloadsComponent from "@/components/community-downloads/CommunityDownloadsComponent";
-import CommunityDownloadsTDH, {
-  VIEW,
-} from "@/components/community-downloads/CommunityDownloadsTDH";
+import CommunityDownloadsTDH from "@/components/community-downloads/CommunityDownloadsTDH";
+import { VIEW } from "@/components/community-downloads/views";
 import { TitleProvider } from "@/contexts/TitleContext";
 import { render } from "@testing-library/react";
 

--- a/app/open-data/network-metrics/page.tsx
+++ b/app/open-data/network-metrics/page.tsx
@@ -1,6 +1,5 @@
-import CommunityDownloadsTDH, {
-  VIEW,
-} from "@/components/community-downloads/CommunityDownloadsTDH";
+import CommunityDownloadsTDH from "@/components/community-downloads/CommunityDownloadsTDH";
+import { VIEW } from "@/components/community-downloads/views";
 import { getAppMetadata } from "@/components/providers/metadata";
 import styles from "@/styles/Home.module.css";
 import type { Metadata } from "next";
@@ -15,7 +14,7 @@ export default function ConsolidatedCommunityMetricsDownloads() {
 
 export async function generateMetadata(): Promise<Metadata> {
   return getAppMetadata({
-    title: "Network Metrics",
+    title: "Consolidated Network Metrics | Open Data",
     description: "Open Data",
   });
 }

--- a/components/community-downloads/CommunityDownloadsTDH.tsx
+++ b/components/community-downloads/CommunityDownloadsTDH.tsx
@@ -3,11 +3,7 @@
 import { publicEnv } from "@/config/env";
 import { useSetTitle } from "@/contexts/TitleContext";
 import CommunityDownloadsComponent from "./CommunityDownloadsComponent";
-
-export enum VIEW {
-  CONSOLIDATION,
-  WALLET,
-}
+import { VIEW } from "./views";
 
 interface Props {
   view: VIEW;

--- a/components/community-downloads/views.ts
+++ b/components/community-downloads/views.ts
@@ -1,0 +1,13 @@
+/**
+ * Download view selector for community metrics downloads.
+ *
+ * Lives in its own module (without "use client") so Server Components can
+ * import it and pass real enum values across the RSC boundary. Importing an
+ * enum from a "use client" module in a Server Component yields a client
+ * reference proxy instead of the enum, so member access serializes as
+ * undefined.
+ */
+export enum VIEW {
+  CONSOLIDATION,
+  WALLET,
+}

--- a/tests/network-open-data/network-open-data-api-readonly.spec.ts
+++ b/tests/network-open-data/network-open-data-api-readonly.spec.ts
@@ -127,11 +127,11 @@ test.describe("Network, Open Data, and public API read-only coverage @surface @m
         url.searchParams.get("page") === "1"
     );
 
-    await expect(page).toHaveTitle("Network Metrics | Open Data");
+    await expect(page).toHaveTitle("Consolidated Network Metrics | Open Data");
     await expect(
       page.getByRole("heading", {
         level: 1,
-        name: "Network Metrics Downloads",
+        name: "Consolidated Network Metrics Downloads",
       })
     ).toBeVisible();
     const body = (await response.json()) as { data?: unknown };


### PR DESCRIPTION
## Issue
- The network-open-data read-only E2E pack has exactly one failing desktop test: "Network Metrics downloads route reads public upload metadata" expects the tab title `Network Metrics | Open Data` but the page durably shows `Network Metrics`.
- Two stacked app bugs cause this:
  1. **Enum across the RSC boundary**: `app/open-data/network-metrics/page.tsx` (a Server Component) imported the `VIEW` enum from the `"use client"` module `CommunityDownloadsTDH.tsx`. Every export of a client module becomes a client reference in server context, so `VIEW.CONSOLIDATION` serialized as `undefined` (visible in the RSC payload as `"view":"$undefined"`). The component's `props.view === VIEW.CONSOLIDATION` branch never ran in the real app: the intended "Consolidated" qualifier was silently dropped from the h1 and title (while jsdom unit tests, which have no RSC boundary, kept asserting the intended "Consolidated Network Metrics Downloads" and passing — a false green).
  2. **Streamed metadata clobbers client titles**: since Next 16, the streamed metadata `<title>` is applied after hydration and overwrites titles set via `TitleContext`/`DynamicHeadTitle`. Captured with a MutationObserver on production: t=254ms SSR "Network Metrics" -> t=644ms client sets "Network Metrics | Open Data" -> t=660ms streamed metadata re-inserts "Network Metrics", which sticks. The only durable title is the `generateMetadata` one.

## Fix
- Move `VIEW` to a shared non-client module (`components/community-downloads/views.ts`) so Server Components pass real enum values across the boundary. The page now genuinely renders the consolidated view it always called the API for (`/api/consolidated_uploads` was unaffected because `undefined === VIEW.WALLET` is also false).
- Set the page's `generateMetadata` title to the client-intended final title, `Consolidated Network Metrics | Open Data` — the title both the component author (`useSetTitle(\`${title} | Open Data\`)` with the CONSOLIDATION branch) and the pages-router-era `/open-data/consolidated-network-metrics` page intended. SSR and client now agree, so nothing flickers.
- Update the E2E expectation to the correct exact title and heading, and make the page unit test's metadata mock echo its args instead of hardcoding a stale return.

## Changes
- New `components/community-downloads/views.ts` (enum + rationale comment); `CommunityDownloadsTDH.tsx` imports it; page and unit-test imports updated.
- `app/open-data/network-metrics/page.tsx` metadata title.
- `tests/network-open-data/network-open-data-api-readonly.spec.ts` title + h1 expectations ("Consolidated Network Metrics Downloads" is the restored intended heading; the h1 locator previously matched by substring).
- `__tests__/app/open-data/network-metrics.test.tsx` metadata mock/assertion.

## Validation
- RSC payload now carries `"view":0`; local dev title is `Consolidated Network Metrics | Open Data` stable from first paint (MutationObserver probe, no flicker).
- Local `test:e2e:network-open-data-readonly`: 14/14 green (desktop + mobile) against a local dev server pointed at the production API.
- Jest: all 12 community-downloads/open-data suites green (23 tests).
- `check:changed` (typecheck, format, lint) and `react-doctor:diff` green.
- Note: against production this test stays red until this deploys (production serves the old title); the post-deploy Staging E2E workflow re-verifies automatically.
- Visible behavior change (intended): the page h1 reads "Consolidated Network Metrics Downloads" and the tab/og title carries the "Consolidated" qualifier and section suffix. The Open Data index card ("Network Metrics") is unchanged.

## Risk
- Level: Low
- Why: one enum relocation with no logic change, one metadata title, test alignment; the route serves the same data it always served.
- Rollback: revert the commit.

## Review Notes
- The app-wide client-title-vs-streamed-metadata divergence (every `useSetTitle` suffix silently lost since the Next 16 upgrade) is intentionally NOT addressed here; it is flagged as a separate campaign task with evidence. The sibling PR aligns the two collections-pack routes with the same failure class (`/rememes`, `/nextgen/collection/*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Network Metrics page and related download views to use the new “Consolidated Network Metrics | Open Data” labeling.

* **Bug Fixes**
  * Aligned page metadata, headings, and browser titles so the displayed text is consistent across the app and download route.

* **Tests**
  * Adjusted automated checks to reflect the updated titles and metadata behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->