### PR TITLE
Align collection page titles and a stale E2E locator with current UI

### DIFF
--- a/__tests__/app/nextgenMetadataPages.test.tsx
+++ b/__tests__/app/nextgenMetadataPages.test.tsx
@@ -211,7 +211,7 @@ describe("NextGen metadata", () => {
     const image = getSocialImage(metadata);
     const url = new URL(image.url);
 
-    expect(metadata.title).toBe("Pebbles | Rarity");
+    expect(metadata.title).toBe("Pebbles | Rarity | NextGen");
     expect(metadata.twitter?.card).toBe("summary_large_image");
     expect(image).toMatchObject({
       alt: "Pebbles | Rarity social card",

--- a/__tests__/app/rememes/index.test.tsx
+++ b/__tests__/app/rememes/index.test.tsx
@@ -93,7 +93,7 @@ describe("ReMemes page", () => {
     const meta = await generateMetadata({
       searchParams: Promise.resolve({}),
     });
-    expect(meta.title).toBe("ReMemes");
+    expect(meta.title).toBe("ReMemes | Collections");
     expect(meta.description).toContain("Collections");
     const images = Array.isArray(meta.openGraph?.images)
       ? meta.openGraph?.images

--- a/__tests__/app/rememesMetadataPages.test.tsx
+++ b/__tests__/app/rememesMetadataPages.test.tsx
@@ -46,7 +46,7 @@ describe("ReMemes metadata", () => {
     const image = getSocialImage(metadata);
     const url = new URL(image.url);
 
-    expect(metadata.title).toBe("ReMemes");
+    expect(metadata.title).toBe("ReMemes | Collections");
     expect(metadata.twitter?.card).toBe("summary_large_image");
     expect(image).toMatchObject({
       alt: "ReMemes collection social card",

--- a/app/nextgen/collection/[collection]/[[...view]]/page.tsx
+++ b/app/nextgen/collection/[collection]/[[...view]]/page.tsx
@@ -31,6 +31,7 @@ export async function generateMetadata({
   }
   return getNextgenCollectionMetadata({
     collection: resolvedCollection,
+    documentTitle: `${title} | NextGen`,
     title,
   });
 }

--- a/app/nextgen/collection/[collection]/page-utils.ts
+++ b/app/nextgen/collection/[collection]/page-utils.ts
@@ -52,16 +52,18 @@ export function getContentViewKeyByValue(value: string): string {
 
 export function getNextgenCollectionMetadata({
   collection,
+  documentTitle,
   subtitle,
   title,
 }: {
   readonly collection: NextGenCollection;
+  readonly documentTitle?: string | undefined;
   readonly subtitle?: string | undefined;
   readonly title: string;
 }): Metadata {
   return getAppMetadata(
     getLargeSocialCardMetadata({
-      title,
+      title: documentTitle ?? title,
       description: "NextGen",
       ogImage: getCollectionSocialCardImagePath("nextgen", {
         image: collection.banner || collection.image,

--- a/app/rememes/page.tsx
+++ b/app/rememes/page.tsx
@@ -54,7 +54,7 @@ export async function generateMetadata({
 
   return getAppMetadata(
     getLargeSocialCardMetadata({
-      title: t(locale, "rememes.title"),
+      title: t(locale, "rememes.documentTitle"),
       description: t(locale, "rememes.description.collections"),
       ogImage: getCollectionSocialCardImagePath("rememes"),
       ogImageAlt: "ReMemes collection social card",

--- a/tests/collections/nextgen-collections-readonly.spec.ts
+++ b/tests/collections/nextgen-collections-readonly.spec.ts
@@ -155,9 +155,9 @@ test.describe("NextGen and collections read-only coverage @surface @medium @larg
     await expect(
       page.getByRole("heading", { level: 1, name: "Collections" })
     ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Status: ALL" })
-    ).toBeVisible();
+    const statusFilter = page.getByRole("combobox", { name: "Status:" });
+    await expect(statusFilter).toBeVisible();
+    await expect(statusFilter).toHaveValue("ALL");
     await expectCardsOrEmpty(
       page,
       page.locator('main a[href*="/nextgen/collection/"]'),


### PR DESCRIPTION
## Issue
- With the NextGen overflow fix in place (#3080), the collections read-only pack surfaces three residual failures that were previously masked by the overflow assertion aborting the tests early, or by production's older build:
  1. `/rememes`: test expects tab title `ReMemes | Collections`; the page durably shows `ReMemes`.
  2. `/nextgen/collection/pebbles`: test expects `/Pebbles.*NextGen/`; the page durably shows `Pebbles`.
  3. The collections-list test targets a `Status: ALL` **button** that no longer exists — #2965 replaced the Bootstrap dropdown with a native `<select>`; the test only passes against production because production still serves the pre-#2965 build.
- The two title failures are the same class as #3081: since Next 16, streamed metadata re-inserts the SSR `<title>` after hydration and overwrites the client-set `TitleContext` titles, so the client-intended titles (`rememes.documentTitle` = "ReMemes | Collections"; `<name>[ | <view>] | NextGen` in `NextGenCollection.tsx`) never stick.

## Fix
- `/rememes`: use the existing `rememes.documentTitle` i18n message in `generateMetadata` (locale-aware with en-US fallback), so SSR emits exactly what the client sets and the title is correct and stable from first paint.
- `/nextgen/collection/[collection]`: add an optional `documentTitle` to `getNextgenCollectionMetadata` and pass `<title> | NextGen` from the page. The tab/og title now matches the client-set title while the social-card image strings (card title/subtitle/alt) remain unchanged.
- Collections-list spec: target the labeled combobox (`getByRole("combobox", { name: "Status:" })`) and assert its value is `ALL`, matching the current accessible markup.

## Changes
- `app/rememes/page.tsx` (metadata title message key).
- `app/nextgen/collection/[collection]/[[...view]]/page.tsx` + `app/nextgen/collection/[collection]/page-utils.ts` (`documentTitle` pass-through).
- `tests/collections/nextgen-collections-readonly.spec.ts` (Status filter locator).
- `__tests__/app/nextgenMetadataPages.test.tsx` (collection view page title expectation now includes the `| NextGen` suffix; card strings unchanged).

## Validation
- Local `test:e2e:collections-readonly`: 20/20 green (web-desktop-chromium + web-mobile-chromium) against a local dev server pointed at the production API, combined with #3080 and #3081.
- Local SSR titles verified stable from first paint via MutationObserver probes (`ReMemes | Collections`, `Pebbles | NextGen`).
- Jest `__tests__/app/nextgenMetadataPages.test.tsx` 6/6 green.
- `check:changed` and `react-doctor:diff` green.
- Note: the updated title/locator expectations go red against production until the next deploy (old build serves old titles/markup); the post-deploy Staging E2E workflow re-verifies automatically.

## Risk
- Level: Low
- Why: two metadata titles, one optional helper parameter, test alignment; no data or logic changes.
- Rollback: revert the commit.

## Review Notes
- og:title for the collection view pages now carries the `| NextGen` suffix (it equals the document title by design); the rendered social-card image text is untouched. If reviewers prefer suffix-free og titles, the `documentTitle` parameter makes that a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated NextGen collection and ReMemes page/social preview metadata titles to include the expected “| NextGen” and consistent branding.
  * Refined the NextGen collections status filter test assertions to confirm the current status is reflected correctly in the selector.
* **Tests**
  * Updated automated checks to match the new metadata title values and the revised status filter UI expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->