### PR TITLE
Staging E2E hardening: token-metadata read-POST allowlist + wallet-checker budget

### DIFF
--- a/__tests__/playwright/readonlyMutationGuard.test.ts
+++ b/__tests__/playwright/readonlyMutationGuard.test.ts
@@ -125,7 +125,9 @@ describe("Playwright read-only mutation guard", () => {
   it("allows first-party read-only alchemy proxy POST lookups", () => {
     for (const url of [
       "https://api.6529.io/alchemy-proxy/contracts",
+      "https://api.6529.io/alchemy-proxy/token-metadata",
       "https://api.staging.6529.io/alchemy-proxy/contracts",
+      "https://api.staging.6529.io/alchemy-proxy/token-metadata",
     ]) {
       expect(
         decideReadonlyRequest({
@@ -171,6 +173,7 @@ describe("Playwright read-only mutation guard", () => {
       "https://6529.io/api/open-graph",
       "https://6529.io/api/twitter/preview",
       "https://6529.io/api/alchemy/contracts",
+      "https://6529.io/api/alchemy/token-metadata",
     ]) {
       expect(
         decideReadonlyRequest({

--- a/tests/delegation/delegation-readonly.spec.ts
+++ b/tests/delegation/delegation-readonly.spec.ts
@@ -188,11 +188,13 @@ test.describe("Delegation read-only coverage @surface @medium @large @readonly",
     await expect(page.getByText("Checking delegation records...")).toBeHidden({
       timeout: 20000,
     });
+    // The loading indicator may not have appeared yet when the assertion above
+    // runs, so give the delegation lookup the same budget here.
     await expect(
       page.getByText(
         "No delegation, delegation manager, or consolidation records found for this wallet."
       )
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 20000 });
     await expect(
       page.getByRole("heading", { name: "Delegations (0)" })
     ).toBeVisible();

--- a/tests/support/readonlyMutationGuard.ts
+++ b/tests/support/readonlyMutationGuard.ts
@@ -45,6 +45,7 @@ const STAGING_HOSTNAME = "staging.6529.io";
 const PRODUCTION_HOSTNAMES = new Set(["6529.io", "www.6529.io"]);
 const FIRST_PARTY_READONLY_ROUTE_HANDLER_PATHS = new Set([
   "/api/alchemy/contracts",
+  "/api/alchemy/token-metadata",
   "/api/open-graph",
   "/api/twitter/preview",
 ]);
@@ -57,6 +58,7 @@ const FIRST_PARTY_READONLY_API_HOSTS = new Set([
 ]);
 const FIRST_PARTY_READONLY_API_POST_PATHS = new Set([
   "/alchemy-proxy/contracts",
+  "/alchemy-proxy/token-metadata",
 ]);
 
 const IGNORED_EXTERNAL_MUTATION_HOSTS = [


### PR DESCRIPTION
## Why

This PR started as the full fix for the deterministic post-deploy Staging E2E failures ([run 28741346113](https://github.com/6529-Collections/6529seize-frontend/actions/runs/28741346113)). While it was in review, sibling PRs landed the bulk of it on main:

- NextGen ~12px horizontal overflow → #3080 (restored container-fluid gutters)
- Alchemy `contracts` read-POST guard allowlist → #3086
- Collection titles / `Status:` combobox locator → #3082, #3089 (metadata aligned with client titles, killing the title race at the root)
- Mint-page title tolerance → `66491f9ae`

The branch has been rebuilt on current main and now carries **only the two remaining deltas**:

## 1. Guard: allow the `token-metadata` read-POST twin

`POST /api/alchemy/token-metadata` (and its `api.<env>.6529.io/alchemy-proxy/token-metadata` fallback) is the same POST-as-read batch lookup class as the already-allowlisted `contracts` endpoints — `fetchTokenMetadataFromApi` in `hooks/useAlchemyNftQueries.ts` fires it from NFT-rendering surfaces (token-list, NftPicker) and would trip the read-only guard exactly like the `/punk6529/xtdh` contracts flake did. The route handler is a pure read (batched `getNFTMetadataBatch` proxy, POST only to carry the token list). Unit coverage extended; other POSTs on those hosts stay blocked.

## 2. Wallet Checker empty-state budget

If the "Checking delegation records..." indicator hasn't appeared yet when the `toBeHidden` assertion runs, it passes instantly and the empty-state text gets only the default 5s while the delegation lookup is still in flight — the flake signature documented on 2026-07-05. The empty-state assertion now gets the same 20s budget.

## Verification

- Guard unit tests: 16/16.
- delegation / waves-profile / media / network-open-data packs green against staging.6529.io with these exact deltas (run pre-rebuild; both changes byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
