### PR TITLE
Record Thread F milestones and slow-collection-routes scoping

### DIFF
--- a/ops/workstreams/repo-health-2026-07/run-log.md
+++ b/ops/workstreams/repo-health-2026-07/run-log.md
@@ -1,5 +1,64 @@
 # Run Log
 
+## 2026-07-05 (Thread F — collection surfaces quality pass)
+
+- Phase 1 (overflow): root cause pinned with production evidence — the
+  Bootstrap exit ported `<Container fluid>` as `tw-w-full tw-max-w-none`,
+  dropping Bootstrap's intrinsic 12px container padding, so `.row` ports
+  (`-tw-mx-3`) overhang the viewport by 12px. At 1280 that is
+  `scrollWidth - clientWidth` = +11/12 (rows at x=1291/1292, the exact
+  e2e offenders); at 1440 the overhang lands inside the html scroll area
+  (measured -30, zero offenders), which is why the earlier 1440 sweep
+  missed it. Fix = restore `tw-px-3` on the five container-fluid ports
+  (PR #3080). After: 0 overflow at 1280 on all five NextGen routes, 1440
+  unchanged, mobile restored to the pre-migration 24px inset. Swiper
+  needed no fix: `swiper/css` base `overflow: hidden` is imported and
+  working; slide rects in older failure JSON never contributed to
+  scrollWidth.
+- Phase 2 (network-metrics): the one failing desktop test decomposed into
+  two app bugs (PR #3081): the `VIEW` enum imported from a "use client"
+  module serialized as `$undefined` across the RSC boundary (silently
+  dropping the intended "Consolidated" qualifier while jsdom suites
+  false-greened it), and Next 16 streamed metadata overwrites
+  client-set titles ~16ms after hydration (MutationObserver evidence),
+  so only `generateMetadata` titles are durable. Enum moved to a shared
+  module; SSR title set to the intended
+  "Consolidated Network Metrics | Open Data"; e2e + unit tests aligned.
+- Collections-pack residuals unmasked by the overflow fix (PR #3082):
+  `/rememes` and `/nextgen/collection/*` SSR titles aligned with their
+  client-intended titles (same streamed-metadata class), and the
+  collections-list spec locator updated from the Bootstrap-era
+  "Status: ALL" button to the native select shipped in #2965.
+- Local verification: collections pack 20/20 (desktop + mobile),
+  network-open-data pack 14/14, related Jest suites green,
+  react-doctor:diff 100/100. Production packs stay red for the changed
+  expectations until the next deploy (old build serves old titles/markup);
+  the post-deploy Staging E2E workflow re-verifies automatically.
+- Phase 3 (slow routes): measured clean-browser production performance for
+  /rememes /the-memes /meme-lab /network /meme-calendar — all sub-second
+  (TTFB 62-174ms, DCL 119-290ms, load 640-835ms). The 20s/60s harness
+  budget blowouts are measurement artifacts: network-idle waits never
+  settle (RUM/mixpanel beacons + trickling arweave/ipfs media deny a
+  500ms quiet window) and the readonly harness's global route
+  interception disables the HTTP cache under pack load. The historical
+  "ReMemes 60s/empty-title" only reproduced under full-pack load; in
+  isolation it was the title-value bug fixed in #3082. Full measurement
+  table, classification, and recommendations in
+  `slow-collection-routes.md`. No frontend rewrite is justified; slowest
+  backend endpoints (all sub-second) handed off as observability data.
+- App-wide follow-up flagged (out of scope, evidence attached): every
+  `useSetTitle` suffix app-wide is silently lost to streamed metadata
+  since the Next 16 upgrade — spawned as a separate task for scoping.
+- Environment notes for other threads: `quality.js --changed` fails on
+  Windows Node 24 (spawnSync of .cmd without shell) — run
+  `format:changed`/`lint:changed`/`typecheck:changed` directly; in fresh
+  worktrees use `./bin/6529 env prod` (then verify with `env status` —
+  the switcher comments out non-matching managed keys but only appends
+  missing ones, so a local-target `.env` can end up with no active
+  API/WS endpoint) instead of relying on shell-var overrides reaching
+  the client env bake; dev servers watched by piped `head`/`tail` die on
+  SIGPIPE once the pipe closes — redirect to a file instead.
+
 ## 2026-07-05 (Thread D — one layout)
 
 - Phase 0 (inventory) merged as PR #3041 (`layout-unification-plan.md`). Key

--- a/ops/workstreams/repo-health-2026-07/slow-collection-routes.md
+++ b/ops/workstreams/repo-health-2026-07/slow-collection-routes.md
@@ -1,0 +1,76 @@
+# Slow collection routes — measurement and scoping (2026-07-05)
+
+Thread F (collection surfaces) timeboxed investigation of the standing perf item
+from the 2026-07-05 Thread A closeout: reviewbot responsiveness runs flagged
+`/rememes` exceeding a 60s harness timeout and `/the-memes`, `/meme-lab`,
+`/network`, `/meme-calendar` exceeding 20s full-page screenshot budgets, and the
+collections E2E pack showed a ReMemes title timeout.
+
+## Measurements (production, clean headless Chromium 1280x720, 2026-07-05)
+
+Direct navigation, no test harness, empty cache. Wall-clock from navigation
+start. Build `306e55a3d` (4.68.0).
+
+| Route | TTFB | domContentLoaded | load event | Full-page screenshot | Long-task blocking (TBT-ish) | Slowest request |
+| --- | --- | --- | --- | --- | --- | --- |
+| /rememes | 122 ms | 180 ms | 692 ms | 1.3 s | n/a (see note) | `/api/rememes` 644 ms |
+| /the-memes | 147 ms | 206 ms | 740 ms | 0.3 s | 298 ms | `/api/policies/country-check` 601 ms |
+| /meme-lab | 123 ms | 195 ms | 835 ms | 3.8 s | 701 ms | arweave.net media ~1.0-1.1 s each |
+| /network | 62 ms | 119 ms | 640 ms | 0.4 s | 268 ms | `/api/community-members/top` 798 ms |
+| /meme-calendar | 174 ms | 290 ms | 741 ms | 0.1 s | 370 ms | nothing over 140 ms |
+
+Documents fully stream in under 250 ms (~330 KB HTML shells). Hydration
+attaches at ~1.1 s on these pages. Every route is interactive well under 2 s.
+
+## Root causes of the reported timeouts
+
+1. **`networkidle`-style waits never settle on media/telemetry-heavy routes.**
+   `/rememes` did not reach Playwright `networkidle` within 20 s in a clean
+   browser even though it was visually complete at under 1 s: AWS RUM beacons
+   (`dataplane.rum.us-east-1.amazonaws.com`, every few seconds), mixpanel,
+   walletconnect pings, and trickling third-party NFT media (arweave, ipfs
+   gateways) deny the required 500 ms fully-quiet window. Any harness budget
+   built on network-idle (the reviewbot responsiveness runs) blows up on these
+   routes regardless of real user-perceived speed.
+2. **Full-page screenshots are not the bottleneck** — measured 0.1-3.8 s
+   (tallest page: /meme-lab at 8,358 px). The 20 s budget overruns come from
+   the settle-wait before the shot, not the shot.
+3. **The readonly E2E harness intercepts every request**
+   (`tests/support/readonlyMutationGuard.ts` routes `**/*` on remote targets),
+   which disables the browser HTTP cache and serializes request handling
+   through Node. Under a 10-test pack run this amplifies load; the historical
+   "ReMemes 60 s timeout / empty title" only reproduced under full-pack load,
+   never in isolation (3 isolated production runs: title present and stable in
+   under 1 s).
+4. **The durable ReMemes E2E failure was a title bug, not slowness.** The page
+   client sets `"ReMemes | Collections"` (`rememes.documentTitle`) but Next 16
+   streamed metadata re-inserts the SSR `<title>ReMemes</title>` ~16 ms later
+   and wins. Same mechanism on `/open-data/network-metrics` (plus an enum
+   serialized as `undefined` across the RSC boundary suppressing the intended
+   "Consolidated" qualifier). Both fixed in this thread by aligning
+   `generateMetadata` with the intended final title; the app-wide
+   client-title-vs-streamed-metadata divergence is flagged as a separate task.
+
+## Classification
+
+| Item | Class | Action |
+| --- | --- | --- |
+| /rememes, /the-memes, /meme-lab, /network, /meme-calendar page loads | Not slow (sub-second) | None needed |
+| `/api/rememes` 644 ms, `/api/community-members/top` 798 ms, `/api/policies/country-check` ~600 ms | Backend latency, sub-second | Hand off as observability data; not blocking |
+| ReMemes E2E title timeout | Frontend bug (SSR/client title divergence) | Fixed (rememes + network-metrics metadata alignment) |
+| Reviewbot 20 s / 60 s budget overruns | Harness measurement artifact (network-idle waits + cache-disabled interception) | Recommend deterministic waits below |
+| /meme-lab 701 ms main-thread blocking during hydration | Frontend, minor | Optional future item; not user-visible enough to schedule |
+
+## Recommendations
+
+1. Reviewbot responsiveness runs should wait on deterministic conditions
+   (document response + key selector visible), not network idle; or exclude
+   telemetry/beacon hosts and media CDNs (arweave.net, ipfs gateways, RUM,
+   mixpanel, walletconnect) from idle accounting.
+2. Keep the readonly E2E packs' current wait strategy (specific API response +
+   element visibility) — it is already deterministic; the packs go green once
+   the title fixes deploy.
+3. No frontend rewrite is justified by the data. The five routes are fast.
+   If the ~600-800 ms backend endpoints matter for feel, that is a backend
+   owner conversation (`/api/rememes`, `/api/community-members/top`,
+   `/api/policies/country-check`).


### PR DESCRIPTION
## Issue
- The repo-health campaign run-log lacks the Thread F (collection surfaces) milestones, and the slow-collection-routes investigation deliverable needs a home for the user scope decision.

## Fix
- Dated run-log entries covering the NextGen overflow root cause and fix (#3080), the network-metrics RSC-boundary + streamed-metadata diagnosis (#3081), the collections-pack title/locator alignment (#3082), Phase 3 measurements, and environment notes for other threads.
- `ops/workstreams/repo-health-2026-07/slow-collection-routes.md`: production measurement table (all five flagged routes sub-second in a clean browser), root-cause classification of the 20s/60s harness budget blowouts (network-idle waits + cache-disabled interception, not page slowness), and recommendations — no frontend rewrite justified.

## Validation
- Docs-only; `git diff --check` clean; markdown proofread.

## Risk
- Level: Low — campaign state docs only.
- Rollback: revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new run log entry covering recent collection-surface fixes, verification results, and environment notes.
  * Added a performance report summarizing slow collection-route measurements, timeout causes, and recommended wait strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->