### PR TITLE
Localize clipboard timestamps and surface copy failures in wave drop menu

### DIFF
--- a/__tests__/components/waves/drops/WaveDropActionsCopyText.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropActionsCopyText.test.tsx
@@ -45,7 +45,9 @@ describe("WaveDropActionsCopyText", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Copy text" }));
 
-    expect(writeText).toHaveBeenCalledWith(buildDropClipboardText(drop));
+    expect(writeText).toHaveBeenCalledWith(
+      buildDropClipboardText(drop, "en-US")
+    );
     await waitFor(() => expect(onCopy).toHaveBeenCalled());
   });
 

--- a/__tests__/components/waves/drops/WaveDropMobileMenuCopyLink.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropMobileMenuCopyLink.test.tsx
@@ -128,7 +128,8 @@ describe("WaveDropMobileMenuCopyLink", () => {
     expect(parentClick).not.toHaveBeenCalled();
   });
 
-  it("closes the menu once when clipboard write fails", async () => {
+  it("keeps the menu open and shows failure feedback when clipboard write fails", async () => {
+    jest.useFakeTimers();
     const clipboardWrite = createDeferredClipboardWrite();
     writeText.mockReturnValueOnce(clipboardWrite.promise);
     const onCopy = jest.fn();
@@ -139,20 +140,34 @@ describe("WaveDropMobileMenuCopyLink", () => {
       drop_type: ApiDropType.Chat,
     };
 
-    render(<WaveDropMobileMenuCopyLink drop={drop} onCopy={onCopy} />);
+    try {
+      render(<WaveDropMobileMenuCopyLink drop={drop} onCopy={onCopy} />);
 
-    await userEvent.click(screen.getByRole("button", { name: "Copy link" }));
+      fireEvent.click(screen.getByRole("button", { name: "Copy link" }));
 
-    expect(writeText).toHaveBeenCalledWith("https://base/waves/w1?serialNo=5");
-    expect(onCopy).not.toHaveBeenCalled();
+      expect(writeText).toHaveBeenCalledWith(
+        "https://base/waves/w1?serialNo=5"
+      );
 
-    await act(async () => {
-      clipboardWrite.reject(new Error("Clipboard write failed"));
-      await clipboardWrite.promise.catch(() => undefined);
-    });
+      await act(async () => {
+        clipboardWrite.reject(new Error("Clipboard write failed"));
+        await clipboardWrite.promise.catch(() => undefined);
+      });
 
-    await waitFor(() => expect(onCopy).toHaveBeenCalledTimes(1));
-    expect(screen.getByText("Copy link")).toBeInTheDocument();
+      expect(onCopy).not.toHaveBeenCalled();
+      expect(screen.getAllByText("Copy failed").length).toBeGreaterThan(0);
+      expect(screen.getByRole("status")).toHaveTextContent("Copy failed");
+
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+
+      expect(screen.getByText("Copy link")).toBeInTheDocument();
+      expect(screen.getByRole("status")).toBeEmptyDOMElement();
+      expect(onCopy).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it("disables copy for temporary drops", async () => {

--- a/__tests__/components/waves/drops/WaveDropMobileMenuCopyText.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropMobileMenuCopyText.test.tsx
@@ -37,6 +37,11 @@ const createDrop = (overrides: Record<string, unknown> = {}): any => ({
 });
 
 describe("WaveDropMobileMenuCopyText", () => {
+  const originalClipboardDescriptor = Object.getOwnPropertyDescriptor(
+    navigator,
+    "clipboard"
+  );
+
   beforeEach(() => {
     jest.clearAllMocks();
     writeText.mockReset();
@@ -45,6 +50,18 @@ describe("WaveDropMobileMenuCopyText", () => {
       configurable: true,
       value: { writeText },
     });
+  });
+
+  afterEach(() => {
+    if (originalClipboardDescriptor) {
+      Object.defineProperty(
+        navigator,
+        "clipboard",
+        originalClipboardDescriptor
+      );
+    } else {
+      delete (navigator as { clipboard?: unknown }).clipboard;
+    }
   });
 
   it("copies the drop text with author heading and closes after clipboard success", async () => {
@@ -162,26 +179,45 @@ describe("WaveDropMobileMenuCopyText", () => {
     }
   });
 
-  it("shows failure feedback without closing the menu when the clipboard API is unavailable", async () => {
+  it("shows failure feedback without closing the menu when the clipboard API is unavailable", () => {
+    jest.useFakeTimers();
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: undefined,
     });
     const onCopy = jest.fn();
 
-    render(<WaveDropMobileMenuCopyText drop={createDrop()} onCopy={onCopy} />);
+    try {
+      render(
+        <WaveDropMobileMenuCopyText drop={createDrop()} onCopy={onCopy} />
+      );
 
-    await userEvent.click(screen.getByRole("button", { name: "Copy text" }));
+      fireEvent.click(screen.getByRole("button", { name: "Copy text" }));
 
-    expect(writeText).not.toHaveBeenCalled();
-    expect(onCopy).not.toHaveBeenCalled();
-    expect(screen.getAllByText("Copy failed").length).toBeGreaterThan(0);
-    expect(screen.getByRole("status")).toHaveTextContent("Copy failed");
+      expect(writeText).not.toHaveBeenCalled();
+      expect(onCopy).not.toHaveBeenCalled();
+      expect(screen.getAllByText("Copy failed").length).toBeGreaterThan(0);
+      expect(screen.getByRole("status")).toHaveTextContent("Copy failed");
+
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+
+      expect(screen.getByText("Copy text")).toBeInTheDocument();
+      expect(screen.getByRole("status")).toBeEmptyDOMElement();
+      expect(onCopy).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it("formats the copied timestamp using the browser locale", async () => {
     const drop = createDrop();
     const onCopy = jest.fn();
+    const originalLanguagesDescriptor = Object.getOwnPropertyDescriptor(
+      navigator,
+      "languages"
+    );
     Object.defineProperty(navigator, "languages", {
       configurable: true,
       value: ["de-DE"],
@@ -202,7 +238,15 @@ describe("WaveDropMobileMenuCopyText", () => {
       expect(payload).toContain(`alice (${expectedTime}):`);
       await waitFor(() => expect(onCopy).toHaveBeenCalledTimes(1));
     } finally {
-      delete (navigator as { languages?: unknown }).languages;
+      if (originalLanguagesDescriptor) {
+        Object.defineProperty(
+          navigator,
+          "languages",
+          originalLanguagesDescriptor
+        );
+      } else {
+        delete (navigator as { languages?: unknown }).languages;
+      }
     }
   });
 

--- a/__tests__/components/waves/drops/WaveDropMobileMenuCopyText.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropMobileMenuCopyText.test.tsx
@@ -126,25 +126,84 @@ describe("WaveDropMobileMenuCopyText", () => {
     expect(parentClick).not.toHaveBeenCalled();
   });
 
-  it("closes the menu once when clipboard write fails", async () => {
+  it("keeps the menu open and shows failure feedback when clipboard write fails", async () => {
+    jest.useFakeTimers();
     const clipboardWrite = createDeferredClipboardWrite();
     writeText.mockReturnValueOnce(clipboardWrite.promise);
+    const onCopy = jest.fn();
+
+    try {
+      render(
+        <WaveDropMobileMenuCopyText drop={createDrop()} onCopy={onCopy} />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Copy text" }));
+
+      expect(writeText).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        clipboardWrite.reject(new Error("Clipboard write failed"));
+        await clipboardWrite.promise.catch(() => undefined);
+      });
+
+      expect(onCopy).not.toHaveBeenCalled();
+      expect(screen.getAllByText("Copy failed").length).toBeGreaterThan(0);
+      expect(screen.getByRole("status")).toHaveTextContent("Copy failed");
+
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+
+      expect(screen.getByText("Copy text")).toBeInTheDocument();
+      expect(screen.getByRole("status")).toBeEmptyDOMElement();
+      expect(onCopy).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("shows failure feedback without closing the menu when the clipboard API is unavailable", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
     const onCopy = jest.fn();
 
     render(<WaveDropMobileMenuCopyText drop={createDrop()} onCopy={onCopy} />);
 
     await userEvent.click(screen.getByRole("button", { name: "Copy text" }));
 
-    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText).not.toHaveBeenCalled();
     expect(onCopy).not.toHaveBeenCalled();
+    expect(screen.getAllByText("Copy failed").length).toBeGreaterThan(0);
+    expect(screen.getByRole("status")).toHaveTextContent("Copy failed");
+  });
 
-    await act(async () => {
-      clipboardWrite.reject(new Error("Clipboard write failed"));
-      await clipboardWrite.promise.catch(() => undefined);
+  it("formats the copied timestamp using the browser locale", async () => {
+    const drop = createDrop();
+    const onCopy = jest.fn();
+    Object.defineProperty(navigator, "languages", {
+      configurable: true,
+      value: ["de-DE"],
     });
 
-    await waitFor(() => expect(onCopy).toHaveBeenCalledTimes(1));
-    expect(screen.getByText("Copy text")).toBeInTheDocument();
+    try {
+      render(<WaveDropMobileMenuCopyText drop={drop} onCopy={onCopy} />);
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Text kopieren" })
+      );
+
+      const expectedTime = new Intl.DateTimeFormat("de-DE", {
+        hour: "2-digit",
+        minute: "2-digit",
+      }).format(new Date(drop.created_at));
+      const payload = writeText.mock.calls[0][0] as string;
+      expect(payload).toContain(`alice (${expectedTime}):`);
+      await waitFor(() => expect(onCopy).toHaveBeenCalledTimes(1));
+    } finally {
+      delete (navigator as { languages?: unknown }).languages;
+    }
   });
 
   it("disables copy for temporary drops", async () => {

--- a/__tests__/helpers/waves/drop-clipboard.helpers.test.ts
+++ b/__tests__/helpers/waves/drop-clipboard.helpers.test.ts
@@ -23,9 +23,34 @@ const createDrop = (overrides: Record<string, unknown> = {}): any => ({
 
 describe("buildDropClipboardText", () => {
   it("formats a plain-text message with author heading and content", () => {
-    const text = buildDropClipboardText(createDrop());
+    const text = buildDropClipboardText(createDrop(), "en-US");
 
     expect(text).toMatch(/^alice \(.+\): gm$/);
+  });
+
+  it("formats the heading timestamp using the provided locale", () => {
+    const drop = createDrop();
+    const timeFor = (locale: string) =>
+      new Intl.DateTimeFormat(locale, {
+        hour: "2-digit",
+        minute: "2-digit",
+      }).format(new Date(drop.created_at));
+
+    expect(buildDropClipboardText(drop, "en-US")).toContain(
+      `alice (${timeFor("en-US")}):`
+    );
+    expect(buildDropClipboardText(drop, "de-DE")).toContain(
+      `alice (${timeFor("de-DE")}):`
+    );
+  });
+
+  it("omits the time suffix for invalid timestamps", () => {
+    const text = buildDropClipboardText(
+      createDrop({ created_at: Number.NaN }),
+      "en-US"
+    );
+
+    expect(text).toBe("alice: gm");
   });
 
   it("strips markdown markup in plain format and keeps it in markdown format", () => {
@@ -40,11 +65,11 @@ describe("buildDropClipboardText", () => {
       ],
     });
 
-    const plain = buildDropClipboardText(drop);
+    const plain = buildDropClipboardText(drop, "en-US");
     expect(plain).toContain("hello bold site (https://example.com)");
     expect(plain).not.toContain("**");
 
-    const markdown = buildDropClipboardText(drop, "markdown");
+    const markdown = buildDropClipboardText(drop, "en-US", "markdown");
     expect(markdown).toContain("hello **bold** [site](https://example.com)");
   });
 
@@ -62,7 +87,7 @@ describe("buildDropClipboardText", () => {
       },
     });
 
-    const text = buildDropClipboardText(drop);
+    const text = buildDropClipboardText(drop, "en-US");
 
     expect(text).toContain("Replying to bob");
     expect(text).toContain("original message");
@@ -88,7 +113,7 @@ describe("buildDropClipboardText", () => {
       ],
     });
 
-    const text = buildDropClipboardText(drop);
+    const text = buildDropClipboardText(drop, "en-US");
 
     expect(text).toContain("check this out");
     expect(text).toContain("Quote from carol");
@@ -111,7 +136,7 @@ describe("buildDropClipboardText", () => {
       ],
     });
 
-    const text = buildDropClipboardText(drop);
+    const text = buildDropClipboardText(drop, "en-US");
 
     expect(text).toContain("https://media.example/a.png");
     expect(text).toContain("https://media.example/b.png");
@@ -124,7 +149,7 @@ describe("buildDropClipboardText", () => {
       winning_context: { place: 2 },
     });
 
-    const text = buildDropClipboardText(drop);
+    const text = buildDropClipboardText(drop, "en-US");
 
     expect(text).toContain("Type: WINNER");
     expect(text).toContain("Rank: 2");

--- a/__tests__/i18n/messages.test.ts
+++ b/__tests__/i18n/messages.test.ts
@@ -4,6 +4,7 @@ import {
   formatInteger,
   formatNumber,
   formatRelativeTime,
+  formatTime,
 } from "@/i18n/format";
 import {
   DEFAULT_LOCALE,
@@ -398,6 +399,25 @@ describe("frontend i18n helpers", () => {
     );
     expect(formatRelativeTime("en-US", -1, "day")).toBe("yesterday");
     expect(compareLocalized("en-US", "2", "10")).toBeLessThan(0);
+    const sampleTime = new Date("2024-01-02T13:05:00.000Z");
+    expect(formatTime("en-US", sampleTime)).toMatch(/AM|PM/);
+    expect(formatTime("de-DE", sampleTime)).toMatch(/^\d{2}:\d{2}$/);
+    expect(formatTime("en-US", Number.NaN)).toBe("");
+    expect(formatTime("en-US", null)).toBe("");
+  });
+
+  it("translates the wave drop copy action messages", () => {
+    expect(t("en-US", "waves.drop.actions.copyFailed")).toBe("Copy failed");
+    expect(t("en-GB", "waves.drop.actions.copyFailed")).toBe("Copy failed");
+    expect(t("fr-FR", "waves.drop.actions.copyFailed")).toBe(
+      "Echec de la copie"
+    );
+    expect(t("es-ES", "waves.drop.actions.copyFailed")).toBe(
+      "No se pudo copiar"
+    );
+    expect(t("de-DE", "waves.drop.actions.copyFailed")).toBe(
+      "Kopieren fehlgeschlagen"
+    );
   });
 
   it("keeps file-kind labels distinguishable within each locale", () => {

--- a/components/waves/drops/WaveDropActionsCopyText.tsx
+++ b/components/waves/drops/WaveDropActionsCopyText.tsx
@@ -33,15 +33,16 @@ const WaveDropActionsCopyText: React.FC<WaveDropActionsCopyTextProps> = ({
       | { writeText?: (text: string) => Promise<void> }
       | undefined;
 
-    // Close the menu even when the clipboard API is unavailable or the write
-    // fails — mirrors the mobile copy action's behavior.
+    // The desktop dropdown closes even when the clipboard API is unavailable
+    // or the write fails; unlike the mobile action sheet it has no inline
+    // failure affordance yet.
     if (typeof clipboard?.writeText !== "function") {
       onCopy?.();
       return;
     }
 
     void clipboard
-      .writeText(buildDropClipboardText(drop))
+      .writeText(buildDropClipboardText(drop, locale))
       .then(() => {
         onCopy?.();
       })

--- a/components/waves/drops/WaveDropMobileMenuCopyAction.tsx
+++ b/components/waves/drops/WaveDropMobileMenuCopyAction.tsx
@@ -72,7 +72,8 @@ export default function WaveDropMobileMenuCopyAction({
       | undefined;
 
     if (typeof clipboard?.writeText !== "function") {
-      // Keep the menu open so the user sees the failure and can retry.
+      // Keep the menu open so the user sees the failure instead of a
+      // silent close that looks like success.
       showTransientStatus("failed");
       return;
     }

--- a/components/waves/drops/WaveDropMobileMenuCopyAction.tsx
+++ b/components/waves/drops/WaveDropMobileMenuCopyAction.tsx
@@ -14,6 +14,14 @@ interface WaveDropMobileMenuCopyActionProps {
   readonly onCopy: () => void;
 }
 
+type CopyStatus = "idle" | "copied" | "failed";
+
+const STATUS_LABEL_CLASSES: Record<CopyStatus, string> = {
+  idle: "tw-text-iron-300",
+  copied: "tw-text-primary-400",
+  failed: "tw-text-red",
+};
+
 export default function WaveDropMobileMenuCopyAction({
   labelKey,
   icon,
@@ -21,8 +29,8 @@ export default function WaveDropMobileMenuCopyAction({
   getText,
   onCopy,
 }: WaveDropMobileMenuCopyActionProps) {
-  const [copied, setCopied] = useState(false);
-  const copiedResetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+  const [status, setStatus] = useState<CopyStatus>("idle");
+  const statusResetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null
   );
   const isMountedRef = useRef(true);
@@ -33,11 +41,24 @@ export default function WaveDropMobileMenuCopyAction({
 
     return () => {
       isMountedRef.current = false;
-      if (copiedResetTimeoutRef.current !== null) {
-        globalThis.clearTimeout(copiedResetTimeoutRef.current);
+      if (statusResetTimeoutRef.current !== null) {
+        globalThis.clearTimeout(statusResetTimeoutRef.current);
       }
     };
   }, []);
+
+  const showTransientStatus = (nextStatus: CopyStatus) => {
+    setStatus(nextStatus);
+    if (statusResetTimeoutRef.current !== null) {
+      globalThis.clearTimeout(statusResetTimeoutRef.current);
+    }
+    statusResetTimeoutRef.current = globalThis.setTimeout(() => {
+      if (isMountedRef.current) {
+        setStatus("idle");
+        statusResetTimeoutRef.current = null;
+      }
+    }, 2000);
+  };
 
   const copyToClipboard = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -51,7 +72,8 @@ export default function WaveDropMobileMenuCopyAction({
       | undefined;
 
     if (typeof clipboard?.writeText !== "function") {
-      onCopy();
+      // Keep the menu open so the user sees the failure and can retry.
+      showTransientStatus("failed");
       return;
     }
 
@@ -62,22 +84,22 @@ export default function WaveDropMobileMenuCopyAction({
           return;
         }
 
-        setCopied(true);
+        showTransientStatus("copied");
         onCopy();
-        if (copiedResetTimeoutRef.current !== null) {
-          globalThis.clearTimeout(copiedResetTimeoutRef.current);
-        }
-        copiedResetTimeoutRef.current = globalThis.setTimeout(() => {
-          if (isMountedRef.current) {
-            setCopied(false);
-            copiedResetTimeoutRef.current = null;
-          }
-        }, 2000);
       })
       .catch(() => {
-        onCopy();
+        if (isMountedRef.current) {
+          showTransientStatus("failed");
+        }
       });
   };
+
+  let statusMessage = "";
+  if (status === "copied") {
+    statusMessage = t(locale, "waves.drop.actions.copied");
+  } else if (status === "failed") {
+    statusMessage = t(locale, "waves.drop.actions.copyFailed");
+  }
 
   return (
     <button
@@ -90,18 +112,14 @@ export default function WaveDropMobileMenuCopyAction({
     >
       {icon}
       <span
-        className={`tw-text-base tw-font-semibold ${
-          copied ? "tw-text-primary-400" : "tw-text-iron-300"
-        }`}
+        className={`tw-text-base tw-font-semibold ${STATUS_LABEL_CLASSES[status]}`}
       >
-        {copied
-          ? t(locale, "waves.drop.actions.copied")
-          : t(locale, labelKey)}
+        {statusMessage || t(locale, labelKey)}
       </span>
       {/* role="status" must live outside the label: Chromium drops live-region
           content from the button's name-from-contents computation */}
       <span role="status" className="tw-sr-only">
-        {copied ? t(locale, "waves.drop.actions.copied") : ""}
+        {statusMessage}
       </span>
     </button>
   );

--- a/components/waves/drops/WaveDropMobileMenuCopyText.tsx
+++ b/components/waves/drops/WaveDropMobileMenuCopyText.tsx
@@ -2,6 +2,7 @@
 
 import type { ApiDrop } from "@/generated/models/ApiDrop";
 import { buildDropClipboardText } from "@/helpers/waves/drop-clipboard.helpers";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
 import WaveDropMobileMenuCopyAction from "./WaveDropMobileMenuCopyAction";
 
 interface WaveDropMobileMenuCopyTextProps {
@@ -13,11 +14,13 @@ export default function WaveDropMobileMenuCopyText({
   drop,
   onCopy,
 }: WaveDropMobileMenuCopyTextProps) {
+  const locale = useBrowserLocale();
+
   return (
     <WaveDropMobileMenuCopyAction
       labelKey="waves.drop.actions.copyText"
       disabled={drop.id.startsWith("temp-")}
-      getText={() => buildDropClipboardText(drop)}
+      getText={() => buildDropClipboardText(drop, locale)}
       onCopy={onCopy}
       icon={
         <svg

--- a/components/waves/drops/wave-drops-all/hooks/useWaveDropsClipboard.ts
+++ b/components/waves/drops/wave-drops-all/hooks/useWaveDropsClipboard.ts
@@ -18,6 +18,8 @@ import {
   formatMessage,
   formatMessages,
 } from "@/helpers/waves/drop-clipboard.helpers";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import type { SupportedLocale } from "@/i18n/locales";
 
 interface UseWaveDropsClipboardOptions {
   readonly containerRef: RefObject<HTMLDivElement | null>;
@@ -265,7 +267,8 @@ const buildRangePayload = (
   selectedIds: string[],
   container: HTMLElement,
   messages: ClipboardMessage[],
-  format: ClipboardFormat
+  format: ClipboardFormat,
+  locale: SupportedLocale
 ): string | undefined => {
   const messagesById = new Map(
     messages.map((message) => [message.id, message] as const)
@@ -283,6 +286,7 @@ const buildRangePayload = (
     partialSegments,
     messagesById,
     format,
+    locale,
   });
 
   if (segments.length > 0 || usedPartialHandling) {
@@ -399,6 +403,7 @@ type BuildSegmentsOptions = {
   readonly partialSegments: Map<string, string>;
   readonly messagesById: Map<string, ClipboardMessage>;
   readonly format: ClipboardFormat;
+  readonly locale: SupportedLocale;
 };
 
 const buildSegmentsFromSelection = ({
@@ -406,6 +411,7 @@ const buildSegmentsFromSelection = ({
   partialSegments,
   messagesById,
   format,
+  locale,
 }: BuildSegmentsOptions): string[] => {
   const fullMessageIds = selectedIds.filter((id) => !partialSegments.has(id));
   const totalFullMessages = fullMessageIds.length;
@@ -426,7 +432,8 @@ const buildSegmentsFromSelection = ({
     const segment = formatMessage(
       message,
       format,
-      totalFullMessages === 1
+      totalFullMessages === 1,
+      locale
     );
 
     segments.push(segment);
@@ -439,6 +446,7 @@ export const useWaveDropsClipboard = ({
   containerRef,
   drops,
 }: UseWaveDropsClipboardOptions): void => {
+  const locale = useBrowserLocale();
   const fullDrops = useMemo(
     () =>
       (drops ?? []).filter(
@@ -521,12 +529,14 @@ export const useWaveDropsClipboard = ({
             context.selectedIds,
             container,
             context.messages,
-            formatRef.current
+            formatRef.current,
+            locale
           )
         : undefined;
 
       const payload =
-        rangePayload ?? formatMessages(context.messages, formatRef.current);
+        rangePayload ??
+        formatMessages(context.messages, formatRef.current, locale);
 
       if (!payload) {
         formatRef.current = "plain";
@@ -556,5 +566,5 @@ export const useWaveDropsClipboard = ({
       globalThis.removeEventListener?.("keydown", handleKeyDown);
       container.removeEventListener("copy", handleCopy);
     };
-  }, [clipboardMessages, containerRef]);
+  }, [clipboardMessages, containerRef, locale]);
 };

--- a/helpers/waves/drop-clipboard.helpers.ts
+++ b/helpers/waves/drop-clipboard.helpers.ts
@@ -1,6 +1,8 @@
 import type { ApiDrop } from "@/generated/models/ApiDrop";
 import type { ApiDropMetadata } from "@/generated/models/ApiDropMetadata";
 import { ApiDropType } from "@/generated/models/ApiDropType";
+import { formatTime } from "@/i18n/format";
+import type { SupportedLocale } from "@/i18n/locales";
 
 export type ClipboardFormat = "plain" | "markdown";
 
@@ -551,17 +553,6 @@ export const buildClipboardMessage = (
   };
 };
 
-const formatTimestamp = (timestamp: number): string => {
-  try {
-    return new Intl.DateTimeFormat(undefined, {
-      hour: "2-digit",
-      minute: "2-digit",
-    }).format(new Date(timestamp));
-  } catch {
-    return "";
-  }
-};
-
 type FormatContent = {
   primaryContent: string;
   embedLines: string[];
@@ -627,9 +618,10 @@ const createHeading = (
 export const formatMessage = (
   message: ClipboardMessage,
   format: ClipboardFormat,
-  isSingle: boolean
+  isSingle: boolean,
+  locale: SupportedLocale
 ): string => {
-  const timeLabel = formatTimestamp(message.timestamp);
+  const timeLabel = formatTime(locale, message.timestamp);
   const authorLabel = message.author || "Unknown";
   const formatContent = resolveFormatContent(message, format);
   const heading = createHeading(authorLabel, timeLabel, format, isSingle);
@@ -656,7 +648,8 @@ export const formatMessage = (
 
 export const formatMessages = (
   messages: ClipboardMessage[],
-  format: ClipboardFormat
+  format: ClipboardFormat,
+  locale: SupportedLocale
 ): string => {
   if (messages.length === 0) {
     return "";
@@ -664,7 +657,7 @@ export const formatMessages = (
 
   const isSingle = messages.length === 1;
   const segments = messages.map((message) =>
-    formatMessage(message, format, isSingle)
+    formatMessage(message, format, isSingle, locale)
   );
 
   return segments.join("\n\n");
@@ -672,9 +665,10 @@ export const formatMessages = (
 
 export const buildDropClipboardText = (
   drop: ClipboardDropSource,
+  locale: SupportedLocale,
   format: ClipboardFormat = "plain"
 ): string => {
   const quoteLookup = buildQuoteDropLookup([drop]);
   const message = buildClipboardMessage(drop, quoteLookup);
-  return formatMessage(message, format, true);
+  return formatMessage(message, format, true, locale);
 };

--- a/i18n/format.ts
+++ b/i18n/format.ts
@@ -5,6 +5,10 @@ const SHORT_DATE_FORMAT = {
   month: "short",
   year: "numeric",
 } satisfies Intl.DateTimeFormatOptions;
+const SHORT_TIME_FORMAT = {
+  hour: "2-digit",
+  minute: "2-digit",
+} satisfies Intl.DateTimeFormatOptions;
 const DEFAULT_RELATIVE_TIME_FORMAT_OPTIONS = {
   numeric: "auto",
 } satisfies Intl.RelativeTimeFormatOptions;
@@ -65,6 +69,21 @@ export function formatDate(
   const date = toValidDate(value);
   if (date === null) {
     return "-";
+  }
+
+  return new Intl.DateTimeFormat(locale, options).format(date);
+}
+
+// Returns "" (not "-") so callers rendering optional time suffixes can omit
+// them entirely when the value is invalid.
+export function formatTime(
+  locale: SupportedLocale,
+  value: Date | string | number | null | undefined,
+  options: Intl.DateTimeFormatOptions = SHORT_TIME_FORMAT
+): string {
+  const date = toValidDate(value);
+  if (date === null) {
+    return "";
   }
 
   return new Intl.DateTimeFormat(locale, options).format(date);

--- a/i18n/messages/de-DE.ts
+++ b/i18n/messages/de-DE.ts
@@ -7,6 +7,7 @@ export const DE_DE_MESSAGES = {
   "waves.drop.actions.copyText": "Text kopieren",
   "waves.drop.actions.copyLink": "Link kopieren",
   "waves.drop.actions.copied": "Kopiert!",
+  "waves.drop.actions.copyFailed": "Kopieren fehlgeschlagen",
   "media.video.captions": "Untertitel",
   "media.video.download": "Medien herunterladen",
   "media.video.downloading": "Medien werden heruntergeladen",

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -341,6 +341,7 @@ const WAVE_DROP_ACTIONS_MESSAGES = objectMessages("waves.drop.actions", {
   copyText: "Copy text",
   copyLink: "Copy link",
   copied: "Copied!",
+  copyFailed: "Copy failed",
 } as const);
 
 const USER_COLLECTED_STATS_WALLET_ACTIVITY_MESSAGES = objectMessages(

--- a/i18n/messages/es-ES.ts
+++ b/i18n/messages/es-ES.ts
@@ -7,6 +7,7 @@ export const ES_ES_MESSAGES = {
   "waves.drop.actions.copyText": "Copiar texto",
   "waves.drop.actions.copyLink": "Copiar enlace",
   "waves.drop.actions.copied": "Copiado!",
+  "waves.drop.actions.copyFailed": "No se pudo copiar",
   "media.video.captions": "Subtitulos",
   "media.video.download": "Descargar multimedia",
   "media.video.downloading": "Descargando multimedia",

--- a/i18n/messages/fr-FR.ts
+++ b/i18n/messages/fr-FR.ts
@@ -7,6 +7,7 @@ export const FR_FR_MESSAGES = {
   "waves.drop.actions.copyText": "Copier le texte",
   "waves.drop.actions.copyLink": "Copier le lien",
   "waves.drop.actions.copied": "Copie !",
+  "waves.drop.actions.copyFailed": "Echec de la copie",
   "media.video.captions": "Sous-titres",
   "media.video.download": "Telecharger le media",
   "media.video.downloading": "Telechargement du media",


### PR DESCRIPTION
Two polish items deferred from the PR #3072 review threads (wave drop mobile Copy text, shipped in web 4.69.0).

## 1. Locale-aware clipboard timestamps (i18n lane, `i18n/no-direct-locale-formatting`)

- New `formatTime` helper in `i18n/format.ts` (mirrors `formatDate`, but returns an empty string for invalid values so callers can omit the time suffix entirely — preserving the previous clipboard behavior).
- `drop-clipboard.helpers.ts` no longer calls `Intl.DateTimeFormat(undefined, ...)`; the locale is an explicit required parameter of `formatMessage` / `formatMessages` / `buildDropClipboardText` since the module is pure.
- Both consumers resolve the locale via `useBrowserLocale()`: the desktop copy path (`useWaveDropsClipboard`) and the mobile Copy text action. Desktop and mobile output stay identical.

## 2. Copy-failure feedback (general / WCAG / GLM-swarm lanes)

`WaveDropMobileMenuCopyAction` (shared by Copy text and Copy link) previously called `onCopy()` on both the rejected clipboard write and the missing-API fallback, closing the menu as if the copy had succeeded. Now:

- The menu **stays open** on failure so the user can see the state and retry.
- The label flips to a transient red "Copy failed" for 2s (same timing as the "Copied!" state).
- The failure is announced through the existing `tw-sr-only` `role="status"` region, which stays **outside** the label span (Chromium drops live-region content from the button's name-from-contents computation).
- Considered the `setToast` primitive from `AuthContext`, but the action sheet is a full-screen portal layer and the review thread asked for inline label feedback; this also keeps the failure feedback adjacent to the button that triggered it.

## i18n

New key `waves.drop.actions.copyFailed` in `en-US` with ASCII-safe `fr-FR` / `es-ES` / `de-DE` translations; `en-GB` falls back to `en-US` like the sibling keys.

## Tests

- `drop-clipboard.helpers`: locale-formatted headings (en-US vs de-DE, computed via Intl so TZ-independent), invalid-timestamp fallback, updated signatures.
- `WaveDropMobileMenuCopyText`: failure keeps the menu open + shows/announces/resets "Copy failed"; missing-clipboard-API failure; browser-locale (de-DE) end-to-end timestamp case.
- `i18n/messages`: `formatTime` locale/invalid cases and the new key across all locales.

All 20 tests in the three touched suites pass; `typecheck:ci`, `eslint --max-warnings=0` on changed files, and `knip` are clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Copying wave drop content now respects the browser’s locale for timestamps and formatted text.
  * A new “Copy failed” message appears when clipboard access is unavailable or a copy attempt fails.

* **Bug Fixes**
  * Copy actions now keep the menu open on failure, allowing users to retry.
  * Timestamp display now handles invalid values gracefully by omitting the time.

* **Tests**
  * Expanded coverage for locale-specific formatting, clipboard failure handling, and translated status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->