### PR TITLE
Allow first-party alchemy read-proxy POSTs in the readonly E2E guard

### DIFF
--- a/__tests__/playwright/readonlyMutationGuard.test.ts
+++ b/__tests__/playwright/readonlyMutationGuard.test.ts
@@ -122,10 +122,55 @@ describe("Playwright read-only mutation guard", () => {
     });
   });
 
+  it("allows first-party read-only alchemy proxy POST lookups", () => {
+    for (const url of [
+      "https://api.6529.io/alchemy-proxy/contracts",
+      "https://api.staging.6529.io/alchemy-proxy/contracts",
+    ]) {
+      expect(
+        decideReadonlyRequest({
+          baseURL: "https://staging.6529.io",
+          method: "POST",
+          readonly: true,
+          url,
+        })
+      ).toMatchObject({
+        action: "allow",
+        reason: "first-party-readonly-api-proxy",
+      });
+    }
+
+    // Same read-proxy path on an unrelated host stays blocked.
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://staging.6529.io",
+        method: "POST",
+        readonly: true,
+        url: "https://example.com/alchemy-proxy/contracts",
+      })
+    ).toMatchObject({
+      action: "block",
+      reason: "non-allowlisted-mutation",
+    });
+
+    // Other POSTs on the first-party API host remain blocked.
+    expect(
+      decideReadonlyRequest({
+        baseURL: "https://staging.6529.io",
+        method: "POST",
+        readonly: true,
+        url: "https://api.staging.6529.io/drops",
+      })
+    ).toMatchObject({
+      action: "block",
+    });
+  });
+
   it("allows same-origin read-only route handler POST lookups", () => {
     for (const url of [
       "https://6529.io/api/open-graph",
       "https://6529.io/api/twitter/preview",
+      "https://6529.io/api/alchemy/contracts",
     ]) {
       expect(
         decideReadonlyRequest({

--- a/tests/support/readonlyMutationGuard.ts
+++ b/tests/support/readonlyMutationGuard.ts
@@ -44,8 +44,19 @@ const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 const STAGING_HOSTNAME = "staging.6529.io";
 const PRODUCTION_HOSTNAMES = new Set(["6529.io", "www.6529.io"]);
 const FIRST_PARTY_READONLY_ROUTE_HANDLER_PATHS = new Set([
+  "/api/alchemy/contracts",
   "/api/open-graph",
   "/api/twitter/preview",
+]);
+
+// First-party API endpoints that use POST purely to carry a read query
+// (e.g. batched contract-metadata lookups). Semantically reads, never writes.
+const FIRST_PARTY_READONLY_API_HOSTS = new Set([
+  "api.6529.io",
+  "api.staging.6529.io",
+]);
+const FIRST_PARTY_READONLY_API_POST_PATHS = new Set([
+  "/alchemy-proxy/contracts",
 ]);
 
 const IGNORED_EXTERNAL_MUTATION_HOSTS = [
@@ -221,6 +232,14 @@ function isFirstPartyReadonlyRouteHandler(
   );
 }
 
+function isFirstPartyReadonlyApiProxy(method: string, url: URL) {
+  return (
+    method === "POST" &&
+    FIRST_PARTY_READONLY_API_HOSTS.has(url.hostname) &&
+    FIRST_PARTY_READONLY_API_POST_PATHS.has(url.pathname)
+  );
+}
+
 function isNextDevInspectorEndpoint(url: URL, baseURL?: string) {
   return (
     isSameOrigin(url, baseURL) &&
@@ -365,6 +384,10 @@ export function decideReadonlyRequest({
 
   if (isFirstPartyReadonlyRouteHandler(upperMethod, parsed, baseURL)) {
     return { action: "allow", reason: "first-party-readonly-route-handler" };
+  }
+
+  if (isFirstPartyReadonlyApiProxy(upperMethod, parsed)) {
+    return { action: "allow", reason: "first-party-readonly-api-proxy" };
   }
 
   if (isNextDevInspectorEndpoint(parsed, baseURL)) {


### PR DESCRIPTION
## Issue
- The `Staging E2E` workflow (introduced today) has never gone green: the `waves-profile-readonly` pack deterministically fails on `/punk6529/xtdh` with "Read-only Playwright run blocked 2 mutation request(s)" — 3/3 retries, both desktop and mobile projects, and on runs both before and after unrelated staging deploys (evidence: runs 28741346113 and 28743063682).
- The blocked requests are `POST /api/alchemy/contracts` (Next route handler) and `POST https://api.<env>.6529.io/alchemy-proxy/contracts` — batched contract-metadata lookups that use POST only to carry the address list. Read semantics, no writes (the route handler is a cached read proxy).

## Fix
- Add `/api/alchemy/contracts` to the existing same-origin `FIRST_PARTY_READONLY_ROUTE_HANDLER_PATHS` allowlist.
- Add a narrowly-scoped first-party API allowlist (`api.6529.io` / `api.staging.6529.io` + `/alchemy-proxy/contracts` only) with its own decision reason, placed alongside the route-handler rule. All other POSTs on those hosts remain blocked.

## Validation
- `__tests__/playwright/readonlyMutationGuard.test.ts`: 16 tests pass, including new cases for both allowed endpoints, a same-path-different-host block, and a different-path-same-host block.
- eslint clean on both files.

## Risk
- Level: Low
- Why: test-support only; no app code. Worst case is under-blocking exactly two named read endpoints in readonly E2E runs.
- Rollback: revert the commit.

## Review Notes
- This unblocks the staging→production lane for PR #3075 (currently held on this pre-existing failure per the deployment-bus process).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Read-only mode now permits specific first-party contract lookup POST requests to approved API endpoints.
  * Requests to the same path on non-approved hosts remain blocked as expected.
  * Added test coverage for the new allowlisted request behavior, including the relevant same-origin route case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->