### PR TITLE
Burn down any_casts 45 -> 21: type the remaining delegation form components

### DIFF
--- a/components/delegation/NewConsolidation.tsx
+++ b/components/delegation/NewConsolidation.tsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 import type { DelegationCollection } from "./delegation-constants";
 import { CONSOLIDATION_USE_CASE } from "./delegation-constants";
 import { getGasError } from "./delegation-shared";
+import type { DelegationToastState } from "./DelegationToast";
 import styles from "./Delegation.module.css";
 import {
   DelegationAddressDisabledInput,
@@ -32,8 +33,8 @@ interface Props {
       }
     | undefined;
   ens: string | null | undefined;
-  onHide(): any;
-  onSetToast(toast: any): any;
+  onHide(): void;
+  onSetToast(toast: DelegationToastState): void;
 }
 
 export default function NewConsolidationComponent(props: Readonly<Props>) {
@@ -62,7 +63,7 @@ export default function NewConsolidationComponent(props: Readonly<Props>) {
           validate().length === 0
             ? "registerDelegationAddressUsingSubDelegation"
             : undefined,
-        onSettled(data: any, error: any) {
+        onSettled(data: unknown, error: Error | null) {
           if (data) {
             setGasError(undefined);
           }
@@ -85,7 +86,7 @@ export default function NewConsolidationComponent(props: Readonly<Props>) {
         ],
         functionName:
           validate().length === 0 ? "registerDelegationAddress" : undefined,
-        onSettled(data: any, error: any) {
+        onSettled(data: unknown, error: Error | null) {
           if (data) {
             setGasError(undefined);
           }

--- a/components/delegation/NewSubDelegation.tsx
+++ b/components/delegation/NewSubDelegation.tsx
@@ -8,6 +8,7 @@ import { isValidEthAddress } from "@/helpers/Helpers";
 import type { DelegationCollection } from "./delegation-constants";
 import { SUB_DELEGATION_USE_CASE } from "./delegation-constants";
 import { getGasError } from "./delegation-shared";
+import type { DelegationToastState } from "./DelegationToast";
 import styles from "./Delegation.module.css";
 import {
   DelegationAddressDisabledInput,
@@ -30,8 +31,8 @@ interface Props {
       }
     | undefined;
   ens: string | null | undefined;
-  onHide(): any;
-  onSetToast(toast: any): any;
+  onHide(): void;
+  onSetToast(toast: DelegationToastState): void;
 }
 
 export default function NewSubDelegationComponent(props: Readonly<Props>) {
@@ -60,7 +61,7 @@ export default function NewSubDelegationComponent(props: Readonly<Props>) {
           validate().length === 0
             ? "registerDelegationAddressUsingSubDelegation"
             : undefined,
-        onSettled(data: any, error: any) {
+        onSettled(data: unknown, error: Error | null) {
           if (data) {
             setGasError(undefined);
           }
@@ -83,7 +84,7 @@ export default function NewSubDelegationComponent(props: Readonly<Props>) {
         ],
         functionName:
           validate().length === 0 ? "registerDelegationAddress" : undefined,
-        onSettled(data: any, error: any) {
+        onSettled(data: unknown, error: Error | null) {
           if (data) {
             setGasError(undefined);
           }

--- a/components/delegation/RevokeDelegationWithSub.tsx
+++ b/components/delegation/RevokeDelegationWithSub.tsx
@@ -10,6 +10,7 @@ import { isValidEthAddress } from "@/helpers/Helpers";
 import type { DelegationCollection } from "./delegation-constants";
 import { ALL_USE_CASES } from "./delegation-constants";
 import { getGasError } from "./delegation-shared";
+import type { DelegationToastState } from "./DelegationToast";
 import {
   DelegationAddressDisabledInput,
   DelegationCloseButton,
@@ -29,8 +30,8 @@ interface Props {
   originalDelegator: string;
   collection: DelegationCollection;
   showAddMore: boolean;
-  onHide(): any;
-  onSetToast(toast: any): any;
+  onHide(): void;
+  onSetToast(toast: DelegationToastState): void;
 }
 
 export default function RevokeDelegationWithSubComponent(
@@ -65,7 +66,7 @@ export default function RevokeDelegationWithSubComponent(
       validate().length === 0
         ? "revokeDelegationAddressUsingSubdelegation"
         : undefined,
-    onSettled(data: any, error: any) {
+    onSettled(data: unknown, error: Error | null) {
       if (data) {
         setGasError(undefined);
       }

--- a/components/delegation/UpdateDelegation.tsx
+++ b/components/delegation/UpdateDelegation.tsx
@@ -14,6 +14,7 @@ import {
   SUB_DELEGATION_USE_CASE,
 } from "./delegation-constants";
 import { getGasError } from "./delegation-shared";
+import type { DelegationToastState } from "./DelegationToast";
 import {
   DelegationAddressDisabledInput,
   DelegationCloseButton,
@@ -34,8 +35,8 @@ interface Props {
   collection: DelegationCollection;
   showCancel: boolean;
   showAddMore: boolean;
-  onHide(): any;
-  onSetToast(toast: any): any;
+  onHide(): void;
+  onSetToast(toast: DelegationToastState): void;
 }
 
 export default function UpdateDelegationComponent(props: Readonly<Props>) {
@@ -84,7 +85,7 @@ export default function UpdateDelegationComponent(props: Readonly<Props>) {
     ],
     functionName:
       validate().length === 0 ? "updateDelegationAddress" : undefined,
-    onSettled(data: any, error: any) {
+    onSettled(data: unknown, error: Error | null) {
       if (data) {
         setGasError(undefined);
       }

--- a/ops/workstreams/repo-health-2026-07/run-log.md
+++ b/ops/workstreams/repo-health-2026-07/run-log.md
@@ -337,3 +337,13 @@ useDownloader.test.ts` failed to LOAD on main (its bare `@capacitor/core` mock
 - Pre-existing latent bug found while typing (NOT fixed here, behavior
   preserved): the CollectionDelegation use-case lock UI reads wagmi
   multicall envelopes as booleans instead of `.result` — issue #3078.
+
+## 2026-07-05 (Thread G — any burn-down tail, wave 2b)
+
+- Delegation any-tail slice 2 of 3: NewConsolidation, NewSubDelegation,
+  RevokeDelegationWithSub, UpdateDelegation receive the identical
+  mechanical treatment slice 1 gave their siblings (onHide/onSetToast
+  props -> void/DelegationToastState, inert onSettled annotations ->
+  unknown/Error | null). Clone edits produced by a Sonnet work packet
+  under a strict per-line spec, reviewed hunk-by-hunk before commit.
+  `any_casts` 45 -> 21.

--- a/scripts/debt-ratchet-baseline.json
+++ b/scripts/debt-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "max_source_file_lines": 800,
   "counts": {
-    "any_casts": 45,
+    "any_casts": 21,
     "todo_comments": 0,
     "oversized_files": 89,
     "bootstrap_imports": 0,


### PR DESCRIPTION
## Issue
- Repo-health campaign, workstream E tail — slice 2 of 3 of the delegation `any` burn-down (slice 1: the write-config path PR). The four remaining delegation form components still carry the untyped callback props and legacy `onSettled` annotations their siblings just shed.

## Fix
- Apply the identical mechanical treatment to `NewConsolidation`, `NewSubDelegation`, `RevokeDelegationWithSub`, and `UpdateDelegation`: `onHide(): any` -> `void`, `onSetToast(toast: any): any` -> `(toast: DelegationToastState): void`, `onSettled(data: any, error: any)` -> `(data: unknown, error: Error | null)`.

## Changes
- Four files under `components/delegation/`, type annotations only; no runtime change. The `onSettled` callbacks remain inert under wagmi v2 (see slice 1) and are typed, not removed.
- Ratchet baseline: `any_casts` 45 -> 21.

## Validation
- `tsc --noEmit -p tsconfig.typecheck.json` green at this branch state.
- Full Jest suite green at this branch state; all four components' suites pass unchanged (no fixture updates needed).
- `lint:changed` clean; `node scripts/debt-ratchet.cjs` passes with the lowered baseline.

## Risk
- Level: Low
- Why: annotation-only diff in already-tested components; prop-type tightening is compile-time only.
- Rollback: revert the merge commit.

## Review Notes
- Diff is intentionally uniform with slice 1's NewDelegation/NewAssignPrimaryAddress hunks; reviewing one file reviews all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type safety in delegation flows, reducing the chance of toast or error-handling issues.
  * Kept existing success/failure behavior intact while making callback handling more precise.

* **Chores**
  * Continued reducing overall use of loose typing in the codebase.
  * Updated project tracking metrics to reflect the lower number of unsafe casts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->