### PR TITLE
Align every route's metadata title with the client-intended title

### DIFF
--- a/__tests__/app/collectionMetadataPages.test.tsx
+++ b/__tests__/app/collectionMetadataPages.test.tsx
@@ -34,19 +34,19 @@ describe("collection landing metadata", () => {
       alt: "The Memes collection social card",
       generateMetadata: generateTheMemesMetadata,
       slug: "the-memes",
-      title: "The Memes",
+      title: "The Memes | Collections",
     },
     {
       alt: "Meme Lab collection social card",
       generateMetadata: generateMemeLabMetadata,
       slug: "meme-lab",
-      title: "Meme Lab",
+      title: "Meme Lab | Collections",
     },
     {
       alt: "6529 Gradient collection social card",
       generateMetadata: generateGradientMetadata,
       slug: "6529-gradient",
-      title: "6529 Gradient",
+      title: "6529 Gradient | Collections",
     },
   ])("uses branded collection card metadata for $title", async (route) => {
     const metadata = await route.generateMetadata();

--- a/__tests__/app/emmaPage.test.tsx
+++ b/__tests__/app/emmaPage.test.tsx
@@ -28,7 +28,7 @@ describe("EMMA page", () => {
 
   it("exports metadata", async () => {
     const metadata = await generateMetadata();
-    expect(metadata.title).toBe("EMMA");
+    expect(metadata.title).toBe("EMMA | Tools");
     expect(metadata.description).toBe("Tools | 6529.io");
   });
 });

--- a/__tests__/app/network/levels.test.tsx
+++ b/__tests__/app/network/levels.test.tsx
@@ -57,11 +57,11 @@ describe("LevelsPage (App Router)", () => {
     const { generateMetadata } = require("@/app/network/levels/page");
     const metadata = await generateMetadata();
     expect(metadata).toMatchObject({
-      title: "Levels",
+      title: "Levels | Network",
       description: expect.stringContaining("Network"),
       twitter: { card: "summary" },
       openGraph: {
-        title: "Levels",
+        title: "Levels | Network",
         description: expect.stringContaining("Network"),
         images: ["https://test.6529.io/6529io.png"],
       },

--- a/__tests__/app/networkPages.test.tsx
+++ b/__tests__/app/networkPages.test.tsx
@@ -133,25 +133,25 @@ describe("network pages render", () => {
 
   it("generates metadata for Groups page", async () => {
     const metadata = await generateGroupsMetadata();
-    expect(metadata.title).toEqual("Groups");
+    expect(metadata.title).toEqual("Groups | Network");
     expect(metadata.description).toEqual("Network | 6529.io");
   });
 
   it("generates metadata for TDH page", async () => {
     const metadata = await generateTDHMetadata();
-    expect(metadata.title).toEqual("TDH");
+    expect(metadata.title).toEqual("TDH | Network");
     expect(metadata.description).toEqual("Network | 6529.io");
   });
 
   it("generates metadata for Definitions page", async () => {
     const metadata = await generateDefinitionsMetadata();
-    expect(metadata.title).toEqual("Definitions");
+    expect(metadata.title).toEqual("Definitions | Network");
     expect(metadata.description).toEqual("Network | 6529.io");
   });
 
   it("generates metadata for Wave Score page", async () => {
     const metadata = await generateWaveScoreMetadata();
-    expect(metadata.title).toEqual("Wave Score");
+    expect(metadata.title).toEqual("Wave Score | Network");
     expect(metadata.description).toEqual(
       "Network wave score formula and calculator | 6529.io"
     );

--- a/__tests__/app/nft-activity.test.tsx
+++ b/__tests__/app/nft-activity.test.tsx
@@ -97,7 +97,7 @@ describe("NFTActivityPage", () => {
   it("has correct metadata", async () => {
     const metadata = await generateMetadata();
     expect(metadata).toMatchObject({
-      title: "NFT Activity",
+      title: "NFT Activity | Network",
       description: "Network | 6529.io",
     });
   });

--- a/__tests__/app/prenodesPage.test.tsx
+++ b/__tests__/app/prenodesPage.test.tsx
@@ -32,7 +32,7 @@ describe("prenodes page", () => {
 
   it("has correct metadata", async () => {
     const metadata = await generateMetadata();
-    expect(metadata.title).toEqual("Prenodes");
+    expect(metadata.title).toEqual("Prenodes | Network");
     expect(metadata.description).toEqual("Network | 6529.io");
   });
 });

--- a/__tests__/app/rememesMetadataPages.test.tsx
+++ b/__tests__/app/rememesMetadataPages.test.tsx
@@ -62,7 +62,7 @@ describe("ReMemes metadata", () => {
     const image = getSocialImage(metadata);
     const url = new URL(image.url);
 
-    expect(metadata.title).toBe("ReMemes | Add");
+    expect(metadata.title).toBe("Add ReMemes | Collections");
     expect(metadata.twitter?.card).toBe("summary_large_image");
     expect(image).toMatchObject({
       alt: "Add ReMeme social card",

--- a/__tests__/app/tools/app-wallets/address.test.tsx
+++ b/__tests__/app/tools/app-wallets/address.test.tsx
@@ -29,7 +29,7 @@ describe("App Wallet page", () => {
     const meta = await generateMetadata({
       params: Promise.resolve({ "app-wallet-address": "0xdef" }),
     });
-    expect(meta.title).toEqual("fmt-0xdef | App Wallets");
+    expect(meta.title).toEqual("fmt-0xdef | App Wallets | 6529.io");
     expect(meta.description).toEqual("Tools | 6529.io");
   });
 });

--- a/__tests__/app/tools/app-wallets/import-wallet.test.tsx
+++ b/__tests__/app/tools/app-wallets/import-wallet.test.tsx
@@ -44,7 +44,7 @@ describe("Import App Wallet Page", () => {
 
   it("exposes metadata", async () => {
     const metadata = await generateMetadata();
-    expect(metadata.title).toEqual("App Wallets | Import");
+    expect(metadata.title).toEqual("Import App Wallet | Tools");
     expect(metadata.description).toEqual("Tools | 6529.io");
   });
 });

--- a/__tests__/app/tools/block-finder/page.test.tsx
+++ b/__tests__/app/tools/block-finder/page.test.tsx
@@ -31,7 +31,7 @@ describe("tools/block-finder/page.tsx (server)", () => {
     );
     const md = await generateMetadata();
     expect(getAppMetadata).toHaveBeenCalledWith({
-      title: "Block Finder",
+      title: "Block Finder | Tools",
       description: "Tools",
     });
     expect(md).toEqual({

--- a/__tests__/app/tools/subscriptions-report.test.tsx
+++ b/__tests__/app/tools/subscriptions-report.test.tsx
@@ -219,7 +219,7 @@ describe("Subscriptions report page", () => {
 
   it("exposes metadata", async () => {
     const metadata = await generateMetadata();
-    expect(metadata.title).toEqual("Subscriptions Report");
+    expect(metadata.title).toEqual("Subscriptions Report | Tools");
     expect(metadata.description).toEqual("Tools | 6529.io");
   });
 });

--- a/app/6529-gradient/page.tsx
+++ b/app/6529-gradient/page.tsx
@@ -29,7 +29,7 @@ export default function GradientsPage() {
 export async function generateMetadata(): Promise<Metadata> {
   return getAppMetadata(
     getLargeSocialCardMetadata({
-      title: "6529 Gradient",
+      title: "6529 Gradient | Collections",
       description: "Collections",
       ogImage: getCollectionSocialCardImagePath("6529-gradient"),
       ogImageAlt: "6529 Gradient collection social card",

--- a/app/about/[section]/page.tsx
+++ b/app/about/[section]/page.tsx
@@ -1,13 +1,15 @@
 import styles from "@/styles/Home.module.css";
 
 import About from "@/components/about/About";
+import { getAboutSectionDocumentTitle } from "@/components/about/about.routes";
 import {
   AboutCol as Col,
   AboutContainer as Container,
   AboutRow as Row,
 } from "@/components/about/AboutLayout";
 import { getAppMetadata } from "@/components/providers/metadata";
-import { capitalizeEveryWord } from "@/helpers/Helpers";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import { AboutSection } from "@/types/enums";
 import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
@@ -53,10 +55,15 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     section &&
     Object.values(AboutSection).includes(section as AboutSection)
   ) {
-    const sectionTitle = capitalizeEveryWord(section.replaceAll("-", " "));
+    const sectionTitle = getAboutSectionDocumentTitle(
+      section as AboutSection,
+      DEFAULT_LOCALE
+    );
 
     return getAppMetadata({
-      title: sectionTitle,
+      title: t(DEFAULT_LOCALE, "about.contents.documentTitle", {
+        section: sectionTitle,
+      }),
       description: "About",
     });
   }

--- a/app/consolidation-mapping-tool/page.tsx
+++ b/app/consolidation-mapping-tool/page.tsx
@@ -8,7 +8,7 @@ export default function ConsolidationMappingToolPage() {
 
 export async function generateMetadata(): Promise<Metadata> {
   return getAppMetadata({
-    title: "Consolidation Mapping Tool",
+    title: "Consolidation Mapping Tool | Tools",
     description: "Tools",
   });
 }

--- a/app/delegation-mapping-tool/page.tsx
+++ b/app/delegation-mapping-tool/page.tsx
@@ -7,5 +7,5 @@ export default function DelegationMappingToolPage() {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({ title: 'Delegation Mapping Tool', description: 'Tools' });
+  return getAppMetadata({ title: 'Delegation Mapping Tool | Tools', description: 'Tools' });
 }

--- a/app/dispute-resolution/page.tsx
+++ b/app/dispute-resolution/page.tsx
@@ -7,5 +7,5 @@ export default function DisputeResolutionPage() {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({ title: 'Dispute Resolution' });
+  return getAppMetadata({ title: 'Dispute Resolution | 6529.io' });
 }

--- a/app/emma/page.tsx
+++ b/app/emma/page.tsx
@@ -68,5 +68,5 @@ export default function DistributionPlanTool() {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({ title: "EMMA", description: "Tools" });
+  return getAppMetadata({ title: "EMMA | Tools", description: "Tools" });
 }

--- a/app/meme-lab/page.tsx
+++ b/app/meme-lab/page.tsx
@@ -55,7 +55,7 @@ export async function generateMetadata({
 
   return getAppMetadata(
     getLargeSocialCardMetadata({
-      title: t(locale, "memeLab.title"),
+      title: t(locale, "memeLab.documentTitle"),
       ogImage: getCollectionSocialCardImagePath("meme-lab"),
       ogImageAlt: "Meme Lab collection social card",
       description: t(locale, "memeLab.description.collections"),

--- a/app/messages/[wave]/page.tsx
+++ b/app/messages/[wave]/page.tsx
@@ -17,7 +17,7 @@ import {
 import MessagesPageClient from "../page.client";
 
 export const metadata = getAppMetadata({
-  title: "Messages",
+  title: "Messages | Brain",
   description: "Direct Messages",
 });
 

--- a/app/network/activity/page.tsx
+++ b/app/network/activity/page.tsx
@@ -29,7 +29,7 @@ export default async function CommunityActivityPage() {
 
 export const generateMetadata = async () => {
   return getAppMetadata({
-    title: "Activity",
+    title: "Activity | Network",
     description: "Network",
   });
 };

--- a/app/network/definitions/page.tsx
+++ b/app/network/definitions/page.tsx
@@ -7,7 +7,7 @@ export default function Definitions() {
 
 export const generateMetadata = async () => {
   return getAppMetadata({
-    title: "Definitions",
+    title: "Definitions | Network",
     description: "Network",
   });
 };

--- a/app/network/groups/page.tsx
+++ b/app/network/groups/page.tsx
@@ -13,7 +13,7 @@ export default function GroupsPage() {
 
 export const generateMetadata = async () => {
   return getAppMetadata({
-    title: "Groups",
+    title: "Groups | Network",
     description: "Network",
   });
 };

--- a/app/network/health/network-tdh/page.tsx
+++ b/app/network/health/network-tdh/page.tsx
@@ -17,7 +17,7 @@ export default function CommunityStatsPage() {
 
 export const generateMetadata = () => {
   return getAppMetadata({
-    title: "Stats",
+    title: "Stats | Network",
     description: "Network",
   });
 };

--- a/app/network/levels/page.tsx
+++ b/app/network/levels/page.tsx
@@ -7,7 +7,7 @@ export default function Levels() {
 
 export const generateMetadata = async () => {
   return getAppMetadata({
-    title: "Levels",
+    title: "Levels | Network",
     description: "Network",
   });
 };

--- a/app/network/prenodes/page.tsx
+++ b/app/network/prenodes/page.tsx
@@ -14,7 +14,7 @@ export default function PrenodesPage() {
 
 export const generateMetadata = () => {
   return getAppMetadata({
-    title: "Prenodes",
+    title: "Prenodes | Network",
     description: "Network",
   });
 };

--- a/app/network/tdh/historic-boosts/page.tsx
+++ b/app/network/tdh/historic-boosts/page.tsx
@@ -7,7 +7,7 @@ export default function TDHHistory() {
 
 export const generateMetadata = async () => {
   return getAppMetadata({
-    title: "TDH Historic Boosts",
+    title: "TDH Historic Boosts | Network",
     description: "Network",
   });
 };

--- a/app/network/tdh/page.tsx
+++ b/app/network/tdh/page.tsx
@@ -7,7 +7,7 @@ export default function TDH() {
 
 export const generateMetadata = async () => {
   return getAppMetadata({
-    title: "TDH",
+    title: "TDH | Network",
     description: "Network",
   });
 };

--- a/app/network/wave-score/page.tsx
+++ b/app/network/wave-score/page.tsx
@@ -25,7 +25,7 @@ export default async function NetworkWaveScorePage({
 
 export function generateMetadata(): Metadata {
   return getAppMetadata({
-    title: "Wave Score",
+    title: "Wave Score | Network",
     description: "Network wave score formula and calculator",
   });
 }

--- a/app/network/xtdh/page.tsx
+++ b/app/network/xtdh/page.tsx
@@ -7,7 +7,7 @@ export default function XTDH() {
 
 export const generateMetadata = () => {
   return getAppMetadata({
-    title: "xTDH Overview",
+    title: "xTDH Overview | Network",
     description: "Network",
   });
 };

--- a/app/nextgen/[[...view]]/NextGenPageClient.tsx
+++ b/app/nextgen/[[...view]]/NextGenPageClient.tsx
@@ -26,7 +26,7 @@ export default function NextGenPageClient({
   const [view, setView] = useState<NextgenView | undefined>(initialView);
 
   useEffect(() => {
-    setTitle("NextGen " + (view ?? ""));
+    setTitle(view ? `NextGen ${view}` : "NextGen");
   }, [setTitle, view]);
 
   const updateView = (newView?: NextgenView) => {

--- a/app/nft-activity/page.tsx
+++ b/app/nft-activity/page.tsx
@@ -7,5 +7,5 @@ export default function NFTActivityPage() {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({ title: 'NFT Activity', description: 'Network' });
+  return getAppMetadata({ title: 'NFT Activity | Network', description: 'Network' });
 }

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -44,7 +44,7 @@ export default async function NotificationsPage() {
 
 export async function generateMetadata(): Promise<Metadata> {
   return getAppMetadata({
-    title: "Notifications | My Stream",
+    title: "Notifications | My Stream | Brain",
     description: "Brain",
   });
 }

--- a/app/open-data/6529bot/page.tsx
+++ b/app/open-data/6529bot/page.tsx
@@ -16,7 +16,7 @@ export default async function ReviewbotUsagePage() {
 
 export async function generateMetadata(): Promise<Metadata> {
   return getAppMetadata({
-    title: "6529bot Usage",
+    title: "6529bot Usage | Open Data",
     description: "Open Data",
   });
 }

--- a/app/open-data/meme-subscriptions/page.tsx
+++ b/app/open-data/meme-subscriptions/page.tsx
@@ -13,7 +13,7 @@ export default function MemeSubscriptions() {
 
 export async function generateMetadata(): Promise<Metadata> {
   return getAppMetadata({
-    title: "Meme Subscriptions",
+    title: "Meme Subscriptions | Open Data",
     description: "Open Data",
   });
 }

--- a/app/open-data/rememes/page.tsx
+++ b/app/open-data/rememes/page.tsx
@@ -13,7 +13,7 @@ export default function RememesDownloads() {
 
 export async function generateMetadata(): Promise<Metadata> {
   return getAppMetadata({
-    title: "Rememes",
+    title: "Rememes | Open Data",
     description: "Open Data",
   });
 }

--- a/app/open-data/royalties/page.tsx
+++ b/app/open-data/royalties/page.tsx
@@ -13,7 +13,7 @@ export default function RoyaltiesDownloads() {
 
 export async function generateMetadata(): Promise<Metadata> {
   return getAppMetadata({
-    title: "Royalties",
+    title: "Royalties | Open Data",
     description: "Open Data",
   });
 }

--- a/app/open-data/team/page.tsx
+++ b/app/open-data/team/page.tsx
@@ -13,7 +13,7 @@ export default function TeamDownloads() {
 
 export async function generateMetadata(): Promise<Metadata> {
   return getAppMetadata({
-    title: "Team",
+    title: "Team | Open Data",
     description: "Open Data",
   });
 }

--- a/app/rememes/add/page.tsx
+++ b/app/rememes/add/page.tsx
@@ -18,7 +18,7 @@ export default function ReMemesAddPage() {
 export async function generateMetadata(): Promise<Metadata> {
   return getAppMetadata(
     getLargeSocialCardMetadata({
-      title: "ReMemes | Add",
+      title: "Add ReMemes | Collections",
       description: "Collections",
       ogImage: getCollectionSocialCardImagePath("rememes", {
         subtitle: "Submit a community remix or derivative",

--- a/app/the-memes/page.tsx
+++ b/app/the-memes/page.tsx
@@ -57,7 +57,7 @@ export async function generateMetadata({
 
   return getAppMetadata(
     getLargeSocialCardMetadata({
-      title: "The Memes",
+      title: t(locale, "theMemes.documentTitle"),
       ogImage: getCollectionSocialCardImagePath("the-memes"),
       ogImageAlt: "The Memes collection social card",
       description: t(locale, "theMemes.description.collections"),

--- a/app/tools/app-wallets/[app-wallet-address]/page.tsx
+++ b/app/tools/app-wallets/[app-wallet-address]/page.tsx
@@ -19,7 +19,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { "app-wallet-address": address } = await params;
   return getAppMetadata({
-    title: `${formatAddress(address)} | App Wallets`,
+    title: `${formatAddress(address)} | App Wallets | 6529.io`,
     description: "Tools",
   });
 }

--- a/app/tools/app-wallets/import-wallet/page.tsx
+++ b/app/tools/app-wallets/import-wallet/page.tsx
@@ -8,7 +8,7 @@ export default function AppWalletImportPage() {
 
 export async function generateMetadata(): Promise<Metadata> {
   return getAppMetadata({
-    title: "App Wallets | Import",
+    title: "Import App Wallet | Tools",
     description: "Tools",
   });
 }

--- a/app/tools/app-wallets/page.tsx
+++ b/app/tools/app-wallets/page.tsx
@@ -7,5 +7,5 @@ export default function AppWalletsPage() {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
-  return getAppMetadata({ title: "App Wallets", description: "Tools" });
+  return getAppMetadata({ title: "App Wallets | Tools", description: "Tools" });
 }

--- a/app/tools/block-finder/page.tsx
+++ b/app/tools/block-finder/page.tsx
@@ -8,7 +8,7 @@ export default function BlockFinderPage() {
 
 export async function generateMetadata(): Promise<Metadata> {
   return getAppMetadata({
-    title: "Block Finder",
+    title: "Block Finder | Tools",
     description: "Tools",
   });
 }

--- a/app/tools/subscriptions-report/page.tsx
+++ b/app/tools/subscriptions-report/page.tsx
@@ -8,7 +8,7 @@ export default function SubscriptionsReportPage() {
 
 export async function generateMetadata(): Promise<Metadata> {
   return getAppMetadata({
-    title: "Subscriptions Report",
+    title: "Subscriptions Report | Tools",
     description: "Tools",
   });
 }

--- a/app/waves/waves-page.shared.tsx
+++ b/app/waves/waves-page.shared.tsx
@@ -275,7 +275,7 @@ export async function buildWavesMetadata(
 ): Promise<Metadata> {
   if (waveId === null) {
     return getAppMetadata({
-      title: "Waves",
+      title: "Waves | Brain",
       description: "Browse and explore waves",
     });
   }

--- a/components/about/about.routes.ts
+++ b/components/about/about.routes.ts
@@ -240,6 +240,7 @@ const ABOUT_SECTION_LABEL_KEYS = new Map<AboutSection, MessageKey>(
 
 const ABOUT_SECTION_DOCUMENT_TITLE_KEYS = new Map<AboutSection, MessageKey>([
   [AboutSection.GRADIENTS, "about.contents.documentTitles.gradient"],
+  [AboutSection.MEMES, "about.contents.documentTitles.memes"],
 ]);
 
 function normalizeVisibilityOptions(

--- a/i18n/messages/about.en-US.json
+++ b/i18n/messages/about.en-US.json
@@ -7,6 +7,7 @@
   "about.contents.currentItemAriaLabel": "{page}, current page",
   "about.contents.itemAriaLabel": "Go to page: {page}",
   "about.contents.documentTitles.gradient": "6529 Gradient",
+  "about.contents.documentTitles.memes": "The Memes",
   "about.contents.groups.about6529": "About 6529",
   "about.contents.groups.collectionsMinting": "Collections & Minting",
   "about.contents.groups.networkReputation": "Network & Reputation",

--- a/tests/collections/nextgen-collections-readonly.spec.ts
+++ b/tests/collections/nextgen-collections-readonly.spec.ts
@@ -225,7 +225,7 @@ test.describe("NextGen and collections read-only coverage @surface @medium @larg
   }, testInfo) => {
     await gotoReady(page, "/the-memes");
 
-    await expect(page).toHaveTitle("The Memes");
+    await expect(page).toHaveTitle("The Memes | Collections");
     await expectCollectionTitle(page, testInfo.project.name, "The Memes");
     await expect(
       page.getByRole("region", { name: "Meme sorting" })
@@ -242,7 +242,7 @@ test.describe("NextGen and collections read-only coverage @surface @medium @larg
   }, testInfo) => {
     await gotoReady(page, "/meme-lab");
 
-    await expect(page).toHaveTitle("Meme Lab");
+    await expect(page).toHaveTitle("Meme Lab | Collections");
     await expectCollectionTitle(page, testInfo.project.name, "Meme Lab");
     await expect(
       page.getByRole("region", { name: "Meme Lab sorting" })
@@ -259,7 +259,7 @@ test.describe("NextGen and collections read-only coverage @surface @medium @larg
   }, testInfo) => {
     await gotoReady(page, "/6529-gradient?sort=id&sort_dir=asc");
 
-    await expect(page).toHaveTitle(/^6529 Gradient(?: \| Collections)?$/);
+    await expect(page).toHaveTitle("6529 Gradient | Collections");
     await expectCollectionTitle(page, testInfo.project.name, "6529 Gradient");
     await expect(
       page.getByRole("region", { name: "Gradient sorting" })

--- a/tests/pages/about.spec.ts
+++ b/tests/pages/about.spec.ts
@@ -28,7 +28,7 @@ test.describe("About Pages @smoke @medium @large", () => {
   test("should load the about/the-memes page", async ({ page }) => {
     await page.goto("/about/the-memes", { waitUntil: "domcontentloaded" });
     await waitForRouteReady(page);
-    await expect(page).toHaveTitle("The Memes");
+    await expect(page).toHaveTitle("The Memes | About");
     await expectNoHorizontalOverflow(page);
     const text = page.getByText("large edition, CCO (public domain) NFTs");
     await expect(text).toBeVisible();
@@ -37,7 +37,7 @@ test.describe("About Pages @smoke @medium @large", () => {
   test("should display AboutGradients Page", async ({ page }) => {
     await page.goto("/about/6529-gradient", { waitUntil: "domcontentloaded" });
     await waitForRouteReady(page);
-    await expect(page).toHaveTitle("6529 Gradient");
+    await expect(page).toHaveTitle("6529 Gradient | About");
     await expectNoHorizontalOverflow(page);
 
     const gradients = page.locator('[src="/gradients-preview.png"]');
@@ -50,7 +50,7 @@ test.describe("About Pages @smoke @medium @large", () => {
   test("should display AboutSubscriptions Page", async ({ page }) => {
     await page.goto("/about/subscriptions", { waitUntil: "domcontentloaded" });
     await waitForRouteReady(page);
-    await expect(page).toHaveTitle("Subscriptions");
+    await expect(page).toHaveTitle("Subscriptions | About");
     await expectNoHorizontalOverflow(page);
 
     // Look for the specific paragraph containing "Remote Minting"

--- a/tests/pages/about.spec.ts
+++ b/tests/pages/about.spec.ts
@@ -50,7 +50,7 @@ test.describe("About Pages @smoke @medium @large", () => {
   test("should display AboutSubscriptions Page", async ({ page }) => {
     await page.goto("/about/subscriptions", { waitUntil: "domcontentloaded" });
     await waitForRouteReady(page);
-    await expect(page).toHaveTitle("Subscriptions | About");
+    await expect(page).toHaveTitle("Subscription Minting | About");
     await expectNoHorizontalOverflow(page);
 
     // Look for the specific paragraph containing "Remote Minting"

--- a/tests/pages/access.spec.ts
+++ b/tests/pages/access.spec.ts
@@ -6,7 +6,7 @@ test.describe("Access Page", () => {
   });
 
   test("should load with correct title and input state", async ({ page }) => {
-    await expect(page).toHaveTitle("Access Page | 6529.io");
+    await expect(page).toHaveTitle("Access Page");
   });
 
   test("should show input as disabled when logged in", async ({ page }) => {

--- a/tests/pages/buidl.spec.ts
+++ b/tests/pages/buidl.spec.ts
@@ -6,7 +6,7 @@ test.describe("BUIDL Page", () => {
   });
 
   test("should load with correct title and heading", async ({ page }) => {
-    await expect(page).toHaveTitle("BUIDL | 6529.io");
+    await expect(page).toHaveTitle("BUIDL");
 
     const heading = page.locator("h4");
     await expect(heading).toContainText("We are going to BUIDL together");

--- a/tests/pages/consolidation-mapping-tool.spec.ts
+++ b/tests/pages/consolidation-mapping-tool.spec.ts
@@ -6,7 +6,7 @@ test.describe("Consolidation Mapping Tool Page", () => {
   });
 
   test("should load with correct title and heading", async ({ page }) => {
-    await expect(page).toHaveTitle("Consolidation Mapping Tool | 6529.io");
+    await expect(page).toHaveTitle("Consolidation Mapping Tool | Tools");
 
     const heading = page.locator("h1");
     await expect(heading).toContainText("Consolidation Mapping Tool");

--- a/tests/pages/delegation-mapping-tool.spec.ts
+++ b/tests/pages/delegation-mapping-tool.spec.ts
@@ -6,7 +6,7 @@ test.describe("Delegation Mapping Tool Page", () => {
   });
 
   test("should load with correct title and heading", async ({ page }) => {
-    await expect(page).toHaveTitle("Delegation Mapping Tool | 6529.io");
+    await expect(page).toHaveTitle("Delegation Mapping Tool | Tools");
 
     const heading = page.locator("h1");
     await expect(heading).toContainText("Delegation Mapping Tool");

--- a/tests/pages/meme-accounting.spec.ts
+++ b/tests/pages/meme-accounting.spec.ts
@@ -6,7 +6,7 @@ test.describe("Meme Accounting Page", () => {
   });
 
   test("should load with correct title and heading", async ({ page }) => {
-    await expect(page).toHaveTitle("Meme Accounting | 6529.io");
+    await expect(page).toHaveTitle("Meme Accounting - The Memes");
 
     const heading = page.locator("h1");
     await expect(heading).toContainText("Meme Accounting");

--- a/tests/pages/meme-gas.spec.ts
+++ b/tests/pages/meme-gas.spec.ts
@@ -6,7 +6,7 @@ test.describe("Meme Gas Page", () => {
   });
 
   test("should load with correct title and heading", async ({ page }) => {
-    await expect(page).toHaveTitle("Meme Gas | 6529.io");
+    await expect(page).toHaveTitle("Meme Gas - The Memes");
 
     const heading = page.locator("h1");
     await expect(heading).toContainText("Meme Gas");

--- a/tests/pages/network-activity.spec.ts
+++ b/tests/pages/network-activity.spec.ts
@@ -6,7 +6,7 @@ test.describe("Network Activity Page", () => {
   });
 
   test("should load with correct title and heading", async ({ page }) => {
-    await expect(page).toHaveTitle("Network Activity | 6529.io");
+    await expect(page).toHaveTitle("Activity | Network");
 
     const heading = page.locator("h1");
     await expect(heading).toContainText("Network Activity");

--- a/tests/pages/network.spec.ts
+++ b/tests/pages/network.spec.ts
@@ -6,7 +6,7 @@ test.describe("Network Page", () => {
   });
 
   test("should load with correct title and heading", async ({ page }) => {
-    await expect(page).toHaveTitle("Network | 6529.io");
+    await expect(page).toHaveTitle("Network");
 
     const heading = page.locator("h1");
     await expect(heading).toContainText("Network");

--- a/tests/pages/nft-activity.spec.ts
+++ b/tests/pages/nft-activity.spec.ts
@@ -6,7 +6,7 @@ test.describe("NFT Activity Page", () => {
   });
 
   test("should load with correct title and heading", async ({ page }) => {
-    await expect(page).toHaveTitle("NFT Activity | 6529.io");
+    await expect(page).toHaveTitle("NFT Activity | Network");
 
     const heading = page.locator("h1");
     await expect(heading).toContainText("NFT Activity");

--- a/tests/pages/restricted.spec.ts
+++ b/tests/pages/restricted.spec.ts
@@ -6,7 +6,7 @@ test.describe("Restricted Page", () => {
   });
 
   test("should load with correct title and input state", async ({ page }) => {
-    await expect(page).toHaveTitle("Restricted | 6529.io");
+    await expect(page).toHaveTitle("Restricted");
 
     const input = page.locator('input[type="text"]');
     await expect(input).toBeVisible();

--- a/tests/pages/the-memes.spec.ts
+++ b/tests/pages/the-memes.spec.ts
@@ -15,7 +15,7 @@ test.describe("The Memes Page @smoke @medium @large", () => {
   test("should load with correct title and heading", async ({
     page,
   }, testInfo) => {
-    await expect(page).toHaveTitle("The Memes");
+    await expect(page).toHaveTitle("The Memes | Collections");
     await expectNoHorizontalOverflow(page);
 
     if (isMobileSurfaceProject(testInfo.project.name)) {


### PR DESCRIPTION
## Problem

Since the Next 16 upgrade, the App Router streams the route's server metadata `<title>` after hydration and it overwrites titles already written from `TitleContext` (traced with a `<title>` MutationObserver on production: SSR "Network Metrics" at t=254ms → client "…| Open Data" at t=644ms → streamed metadata re-inserts "Network Metrics" at t=660ms, which sticks). Every route whose `generateMetadata` title differed from its client `useSetTitle` title ended up showing the bare SSR string in the tab.

#3077 fixes the *mechanism* (client-owned titles re-assert via MutationObserver); #3081 fixed the single worst route. This PR fixes the *data* app-wide: every static route's `generateMetadata` now emits the final intended title — section suffix included — so SSR, SEO/social cards, and the client agree, and `TitleContext` remains meaningful only for genuinely dynamic titles (wave unread counts, NFT names, notification counts).

## What changed

Audited all ~50 `useSetTitle`/`setTitle` call sites and mapped them to routes. For every static mismatch, the SSR title now equals the client title:

- **Open Data**: `Meme Subscriptions`, `Team`, `Royalties`, `Rememes`, `6529bot Usage` — all `… | Open Data` (network-metrics already landed via #3081)
- **Network**: `Stats`, `Groups`, `Prenodes`, `Wave Score`, `xTDH Overview`, `TDH`, `TDH Historic Boosts`, `Levels`, `Definitions`, `Activity`, `NFT Activity` — all `… | Network`
- **Tools**: `Subscriptions Report`, `Block Finder`, `App Wallets` (list, `Import App Wallet`, address detail incl. `| 6529.io`), `EMMA`, both mapping tools, `Dispute Resolution | 6529.io`
- **Collections**: `/the-memes` and `/meme-lab` now use their i18n `documentTitle` keys (`… | Collections`), `/rememes/add` → `Add ReMemes | Collections`, `/6529-gradient` → `6529 Gradient | Collections` (`/rememes` itself landed via #3082)
- **Brain**: `/notifications` → `Notifications | My Stream | Brain`, `/waves` index → `Waves | Brain`, `/messages/[wave]` → `Messages | Brain`
- **About sections**: `generateMetadata` now composes the same `{section} | About` i18n title as the client (was `capitalizeEveryWord(slug)`, which silently diverged from what the client tried to set); added a `documentTitles.memes` override mirroring the existing gradient one so `/about/the-memes` reads `The Memes | About` rather than `About The Memes | About`
- **NextGen**: the landing client no longer emits a trailing-space `"NextGen "` title when no view is active

Verified already-aligned, no change needed: `/network`, `/network/health`, `/open-data`, `/tools`, `/tools/api`, `/about`, all delegation routes (SSR already uses `getDelegationAppTitle`), NextGen admin, meme-gas/meme-accounting (focus-composed), `/join`, `/accept-connection-sharing`, `/restricted`, `/buidl`, `/access`.

## Test updates

- **Playwright**: title assertions updated to the canonical strings. Several specs had codified the post-Next-16 clobbered SSR titles (`"The Memes"`, `"Meme Lab"`) and several asserted stale `| 6529.io` suffixes that matched *neither* the SSR nor the client value (`"BUIDL | 6529.io"`, `"Network Activity | 6529.io"`, `"Meme Gas | 6529.io"`, …) — those tests fail on main today.
- **Jest**: 12 suites asserting the old `generateMetadata` titles updated.

## Verification

- Jest: 225 suites / 1188 tests green (app, pages, contexts, about, community-downloads, sidebar) at the rebased head.
- `typecheck:ci` green.
- SSR `<title>` sweep of 49 affected/adjacent routes on a local dev serve: **49/49** match the canonical titles (baseline on main: 16/49).
- Post-hydration MutationObserver probe (6s/route): `/open-data/network-metrics`, `/the-memes`, `/open-data/rememes`, `/about/the-memes`, `/network/tdh`, `/notifications` all settle on the canonical title — with SSR and client strings identical there is nothing left for the streamed-metadata commit to clobber.
- Playwright `tests/pages` + home pack, local: **21 passed / 11 failed** on this branch vs **12 passed / 20 failed** on main baseline — the branch fixes 9 title tests; every remaining failure also fails on main and is environment-shaped (api.6529.io 429 rate-limiting of the local dev serve, data-dependent gradient/table waits, the 404-meta spec, the access-gate redirect).

## Relationship to #3077

Complementary; suggest merging this first. With titles aligned, #3077's client re-assertion no longer flips any e2e expectations (today it would break `the-memes.spec`-style assertions on staging: client-owned titles like `The Memes | Collections` beat specs asserting the bare SSR strings). After both land, dynamic titles (wave unread counts, mint pages, NFT detail) are protected by #3077 and every static title is already correct at SSR time. One nit for that PR: its body cites `/open-data/network-metrics → "Network Metrics | Open Data"`, but since #3081 the client sets `Consolidated Network Metrics | Open Data` — the pack spec now asserts the latter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
