### PR TITLE
Burn down any_casts 21 -> 4: type the delegation read path; workstream E complete

### DIFF
--- a/components/delegation/CollectionDelegation.tsx
+++ b/components/delegation/CollectionDelegation.tsx
@@ -49,6 +49,7 @@ import {
   getReadParams,
   type ContractDelegation,
   type ContractWalletDelegation,
+  type DelegationReadParams,
 } from "./CollectionDelegation.utils";
 import type { DelegationCollection } from "./delegation-constants";
 import { DelegationToast, useDelegationToast } from "./DelegationToast";
@@ -73,7 +74,7 @@ import RevokeDelegationWithSubComponent from "./RevokeDelegationWithSub";
 import UpdateDelegationComponent from "./UpdateDelegation";
 
 interface Props {
-  setSection(section: DelegationCenterSection): any;
+  setSection(section: DelegationCenterSection): void;
   collection: DelegationCollection;
 }
 
@@ -148,7 +149,7 @@ function getConsolidationReadParams(
   collection: `0x${string}` | string | undefined,
   consolidationAddresses: ContractDelegation
 ) {
-  const params: any = [];
+  const params: DelegationReadParams[] = [];
   if (consolidationAddresses) {
     consolidationAddresses.wallets.map((ca) =>
       params.push({
@@ -1738,9 +1739,12 @@ export default function CollectionDelegationComponent(props: Readonly<Props>) {
             <div className="tw-flex tw-w-full tw-items-center tw-px-3 tw-pb-2 tw-pt-2 md:tw-w-2/3">
               {!useCaseLockStatusesGlobal.data ||
               (useCaseLockStatusesGlobal?.data &&
+                // Double cast preserves the existing comparison against the
+                // multicall envelope object (issue #3078 tracks reading
+                // `.result` here); typing it honestly would change behavior.
                 (useCaseLockStatusesGlobal?.data[
                   lockUseCaseIndex
-                ] as any as boolean) === false) ? (
+                ] as unknown as boolean) === false) ? (
                 <button
                   className={`${styles["lockUseCaseBtn"]}`}
                   onClick={() => {

--- a/components/delegation/CollectionDelegation.utils.ts
+++ b/components/delegation/CollectionDelegation.utils.ts
@@ -1,5 +1,7 @@
 import { DELEGATION_ABI } from "@/abis/abis";
 import { DELEGATION_CONTRACT, NEVER_DATE } from "@/constants/constants";
+import type { Abi } from "viem";
+import type { DelegationUseCase } from "./delegation-constants";
 import {
   CONSOLIDATION_USE_CASE,
   DELEGATION_USE_CASES,
@@ -12,16 +14,41 @@ export interface ContractWalletDelegation {
   fetched?: boolean | undefined;
   expiry?: string | undefined;
   all?: boolean | undefined;
-  tokens?: number | undefined;
+  tokens?: number | bigint | undefined;
 }
 
 export interface ContractDelegation {
-  useCase: any;
+  useCase: DelegationUseCase;
   wallets: ContractWalletDelegation[];
 }
 
-function formatExpiry(myDate: any) {
-  const date = new Date(parseInt(myDate) * 1000);
+/**
+ * One entry of a `useReadContracts` `contracts` array targeting the
+ * delegation contract.
+ */
+export interface DelegationReadParams {
+  readonly address: `0x${string}`;
+  readonly abi: Abi;
+  readonly chainId: number;
+  readonly functionName: string;
+  readonly args: readonly (string | number | undefined)[];
+}
+
+/**
+ * Decoded result tuple of the delegation contract's
+ * `retrieve...TokensIDsandExpiredDates` functions:
+ * [wallets, expiry timestamps, all-tokens flags, token ids].
+ * viem decodes `uint256` as `bigint` at runtime; unit fixtures use numbers.
+ */
+type DelegationsResultTuple = readonly [
+  readonly string[],
+  readonly (number | bigint)[],
+  readonly boolean[],
+  readonly (number | bigint)[],
+];
+
+function formatExpiry(myDate: number) {
+  const date = new Date(myDate * 1000);
   const year = date.getUTCFullYear();
   const month = String(date.getUTCMonth() + 1).padStart(2, "0");
   const day = String(date.getUTCDate()).padStart(2, "0");
@@ -32,9 +59,9 @@ export function getParams(
   address: string | undefined,
   collection: string | undefined,
   functionName: string,
-  useCases: any[]
+  useCases: readonly Pick<DelegationUseCase, "use_case">[]
 ) {
-  const params: any = [];
+  const params: DelegationReadParams[] = [];
   useCases.map((uc) => {
     params.push({
       address: DELEGATION_CONTRACT.contract,
@@ -72,7 +99,7 @@ export function getReadParams(
   address: string | undefined,
   collection: string | undefined,
   functionName: string,
-  useCases?: any[]
+  useCases?: readonly Pick<DelegationUseCase, "use_case">[]
 ) {
   if (!useCases) {
     useCases = DELEGATION_USE_CASES;
@@ -80,9 +107,9 @@ export function getReadParams(
   return getParams(address, collection, functionName, useCases);
 }
 
-export function getDelegationsFromData(data: any) {
+export function getDelegationsFromData(data: readonly { result?: unknown }[]) {
   const myDelegations: ContractDelegation[] = [];
-  data.map((d: any, index: number) => {
+  data.map((d, index) => {
     const walletDelegations: ContractWalletDelegation[] = [];
     let useCase = null;
     if (DELEGATION_USE_CASES.length > index) {
@@ -96,9 +123,11 @@ export function getDelegationsFromData(data: any) {
     }
 
     if (useCase && d.result) {
-      const delegationsArray = d.result as any[];
+      const delegationsArray = d.result as DelegationsResultTuple;
       delegationsArray[0].map((wallet: string, i: number) => {
-        const myDate = delegationsArray[1][i];
+        // Number() keeps bigint/number comparisons uniform; expiries are far
+        // below Number.MAX_SAFE_INTEGER, so the conversion is lossless.
+        const myDate = Number(delegationsArray[1][i]);
         let myDateDisplay = "";
         if (useCase.use_case >= PRIMARY_ADDRESS_USE_CASE.use_case) {
           myDateDisplay = `active - non-expiring`;

--- a/components/delegation/DelegationCenter.tsx
+++ b/components/delegation/DelegationCenter.tsx
@@ -18,7 +18,7 @@ import { useEffect, useEffectEvent, useState } from "react";
 import { SUPPORTED_COLLECTIONS } from "./delegation-constants";
 
 interface Props {
-  setSection(section: DelegationCenterSection): any;
+  setSection(section: DelegationCenterSection): void;
 }
 
 export default function DelegationCenterComponent(props: Readonly<Props>) {

--- a/components/delegation/DelegationCenterMenu.tsx
+++ b/components/delegation/DelegationCenterMenu.tsx
@@ -54,13 +54,13 @@ const DELEGATION_MENU_ITEMS: ReadonlyArray<{
 interface Props {
   section: DelegationCenterSection;
   path?: string[] | undefined;
-  setActiveSection(section: DelegationCenterSection): any;
+  setActiveSection(section: DelegationCenterSection): void;
   address_query: string;
-  setAddressQuery(address: string): any;
+  setAddressQuery(address: string): void;
   collection_query: string;
-  setCollectionQuery(collection: string): any;
+  setCollectionQuery(collection: string): void;
   use_case_query: number;
-  setUseCaseQuery(use_case: number): any;
+  setUseCaseQuery(use_case: number): void;
 }
 
 export default function DelegationCenterMenu(props: Readonly<Props>) {

--- a/components/delegation/delegation-constants.ts
+++ b/components/delegation/delegation-constants.ts
@@ -14,6 +14,11 @@ export interface DelegationCollection {
   readonly preview: string;
 }
 
+export interface DelegationUseCase {
+  readonly use_case: number;
+  readonly display: string;
+}
+
 export const ANY_COLLECTION_PATH = "any-collection";
 
 export const ANY_COLLECTION: DelegationCollection = {

--- a/components/delegation/walletChecker/WalletChecker.tsx
+++ b/components/delegation/walletChecker/WalletChecker.tsx
@@ -85,7 +85,7 @@ function CheckedWalletAddress(
 export default function WalletCheckerComponent(
   props: Readonly<{
     address_query: string;
-    setAddressQuery(address: string): any;
+    setAddressQuery(address: string): void;
   }>
 ) {
   const { address_query, setAddressQuery } = props;

--- a/ops/workstreams/repo-health-2026-07/any-exceptions.md
+++ b/ops/workstreams/repo-health-2026-07/any-exceptions.md
@@ -5,6 +5,8 @@ Everything not listed here is expected to stay at zero; the debt-ratchet
 baseline (`scripts/debt-ratchet-baseline.json`, metric `any_casts`) is the
 enforcement backstop.
 
+Current floor: `any_casts` = 4 (3 permanent + 1 scan false positive).
+
 ## Permanent exceptions
 
 | Site | Count | Justification |
@@ -17,12 +19,26 @@ enforcement backstop.
 | --- | --- | --- |
 | `app/blog/disney-deekay-their-secret-to-animation/page.tsx` | 1 | The ratchet's textual `\bas\s+any\b` matches the prose "…as powerfully as any great art can" inside JSX copy. No TypeScript cast exists in the file; editorial copy is not changed to satisfy a counter. |
 
-## Deferred to other workstreams (not exceptions)
+## Resolved deferrals (history)
 
-- `components/delegation/**` (~60 sites at last count): owned by the styling
-  workstream (Thread C), which is rewriting these files; typing them here
-  would churn against that migration.
-- `src/types/window.d.ts` was listed here until the layout workstream's
-  `src/` fold removed the file (resolved 2026-07-05).
+- `components/delegation/**` (60 sites): typed directly by the Thread G
+  any-tail wave (2026-07-05, three PRs: write-config path, form-component
+  clones, read path) once Thread C's styling verification showed no
+  delegation rewrite was coming. One behavior-preserving double cast
+  (`as unknown as boolean`, counts as zero `any`) remains in
+  `CollectionDelegation.tsx` over the multicall envelope comparison whose
+  underlying `.result` misread is tracked in issue #3078.
+- `src/types/window.d.ts`: removed with the layout workstream's `src/`
+  fold (resolved 2026-07-05).
+
+## Known scanner blind spot (for future calibration)
+
+The ratchet regex counts `: any` and `as any` only; generic type arguments
+like `useState<any>()` are invisible to it. A handful of such generics
+remain in `components/delegation/CollectionDelegation.tsx`
+(`revokeDelegationParams`, `batchRevokeDelegationParams`, three
+`useState<any[]>` key arrays). They are outside the metric and were left
+untouched by the typing wave; tighten them opportunistically when that
+file is next split (Thread D owns the split).
 
 Counts and per-file locations: `node scripts/debt-ratchet.cjs --details any_casts`.

--- a/ops/workstreams/repo-health-2026-07/run-log.md
+++ b/ops/workstreams/repo-health-2026-07/run-log.md
@@ -406,3 +406,28 @@ useDownloader.test.ts` failed to LOAD on main (its bare `@capacitor/core` mock
   unknown/Error | null). Clone edits produced by a Sonnet work packet
   under a strict per-line spec, reviewed hunk-by-hunk before commit.
   `any_casts` 45 -> 21.
+
+## 2026-07-05 (Thread G — any burn-down tail complete; workstream E COMPLETE)
+
+- Delegation any-tail slice 3 of 3: the read path. `DelegationUseCase`
+  types the use-case constants' consumers; `DelegationReadParams` types
+  the `useReadContracts` param builders (`getParams`/`getReadParams`/
+  consolidation reader); `getDelegationsFromData` takes the minimal
+  multicall envelope shape and narrows results to a typed 4-tuple, with
+  expiries normalized via `Number()` so viem's runtime bigints and the
+  fixtures' numbers share one code path; `tokens` widened to
+  `number | bigint` to match uint256 decoding. Center/menu/wallet-checker
+  callbacks typed `void`. The lock-status envelope comparison keeps its
+  exact (pre-existing, latently buggy — issue #3078) behavior under an
+  `as unknown as boolean` double cast. `any_casts` 21 -> 4.
+- Final state: `any_casts` = 4 = the exceptions ledger exactly (3
+  permanent wagmi connector sites + 1 blog-prose scan false positive);
+  ledger rewritten to enumerate kept sites, record the resolved
+  delegation deferral, and note the scanner's generic-argument blind
+  spot (`useState<any>` is invisible to the regex; a handful remain in
+  CollectionDelegation.tsx for Thread D's split to absorb).
+- Workstream E definition of done met: Redux removed (#3047, deps gone),
+  `any` driven to documented exceptions only (358 -> 64 by Thread E's
+  #3052, 64 -> 4 by Thread G's three-slice tail), TODO/FIXME/HACK at 0
+  in ratchet scope (#3056: 4 shims completed, 2 items ticketed as #3053,
+  1 stale comment deleted). Ratchet backstops all three metrics.

--- a/scripts/debt-ratchet-baseline.json
+++ b/scripts/debt-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "max_source_file_lines": 800,
   "counts": {
-    "any_casts": 21,
+    "any_casts": 4,
     "todo_comments": 0,
     "oversized_files": 89,
     "bootstrap_imports": 0,


### PR DESCRIPTION
## Issue
- Repo-health campaign, workstream E tail — slice 3 of 3 of the delegation `any` burn-down. The read path (use-case constants, `useReadContracts` param builders, multicall result parsing) plus the last untyped callback props. Landing this drives `any_casts` to the ledgered floor and completes workstream E.

## Fix
- Give the read path its real domain types: a `DelegationUseCase` interface for the use-case constants, `DelegationReadParams` for the `useReadContracts` entries `getParams`/`getReadParams`/`getConsolidationReadParams` build, and a `DelegationsResultTuple` for the decoded `retrieve...TokensIDsandExpiredDates` results.

## Changes
- `delegation-constants.ts`: `DelegationUseCase` interface (constants keep their inferred literal shapes; the reserved use cases also carry `index`).
- `CollectionDelegation.utils.ts`: `ContractDelegation.useCase` typed; `getParams`/`getReadParams` take `Pick<DelegationUseCase, "use_case">[]` (the only field they read) and return `DelegationReadParams[]`; `getDelegationsFromData` accepts the multicall envelope shape it actually reads (`{ result?: unknown }`) and narrows each result to `DelegationsResultTuple`. Expiry values are normalized through `Number()` so bigint (viem runtime) and number (test fixtures) take identical code paths — lossless for timestamp-scale values; `ContractWalletDelegation.tokens` widens to `number | bigint` to match uint256 decoding.
- `CollectionDelegation.tsx`: consolidation read params typed; `setSection` prop `void`; the lock-status envelope comparison keeps its exact behavior under an `as unknown as boolean` double cast — the underlying pre-existing `.result` misread is tracked in issue #3078, and fixing it is a behavior change this typing PR must not make.
- `DelegationCenter.tsx` / `DelegationCenterMenu.tsx` / `walletChecker/WalletChecker.tsx`: callback props typed `void`.
- Exceptions ledger (`ops/workstreams/repo-health-2026-07/any-exceptions.md`) rewritten to enumerate the final kept sites; run log marks workstream E COMPLETE.
- Ratchet baseline: `any_casts` 21 -> 4 (3 ledgered wagmi connector sites + 1 blog-prose scan false positive).

## Validation
- `tsc --noEmit -p tsconfig.typecheck.json` green.
- Full Jest suite green at this branch state, including `CollectionDelegation.utils.test.ts` (its fixtures exercise the number path of the tuple typing) and the delegation component suites.
- `lint:changed` clean; `node scripts/debt-ratchet.cjs` passes with the lowered baseline.

## Risk
- Level: Low
- Why: type-only; the single expression change (`parseInt(x)` -> `Number(x)` inside `formatExpiry`, fed by the same values) is equivalent for all integer inputs the contract can produce, and the delegation suites pin the rendered output.
- Rollback: revert the merge commit.

## Review Notes
- `getDelegationsFromData`'s parameter is deliberately the minimal structural shape (`{ result?: unknown }`) rather than wagmi's full result type: it is what the function reads, it stays assignable across wagmi minor-version type churn, and the unit fixtures construct exactly that shape.
- Issue #3078 documents the latent lock-status UI bug (multicall envelopes read as booleans) found while typing; this PR preserves that behavior byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delegation and wallet checking reliability by tightening type handling and preserving existing UI behavior.
  * Reduced risk of data parsing issues in delegation views, including expiry and token value handling.

* **Chores**
  * Updated internal quality tracking and baseline metrics for safer future maintenance.
  * Refined callback and parameter typings across delegation screens without changing the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->