### PR TITLE
Align profile CMS builder adapter with the real backend contract

### DIFF
--- a/__tests__/components/profile-cms-builder/ProfileCmsBuilder.test.tsx
+++ b/__tests__/components/profile-cms-builder/ProfileCmsBuilder.test.tsx
@@ -11,13 +11,18 @@ import type { ReactNode } from "react";
 
 import { useAuth } from "@/components/auth/Auth";
 import ProfileCmsBuilder from "@/components/profile-cms-builder/ProfileCmsBuilder";
-import { commonApiPost } from "@/services/api/common-api";
+import {
+  buildCmsPackageCandidate,
+  createDefaultCmsBuilderState,
+} from "@/lib/profile-cms/builder/package";
+import { commonApiFetch, commonApiPost } from "@/services/api/common-api";
 
 jest.mock("@/components/auth/Auth", () => ({
   useAuth: jest.fn(),
 }));
 
 jest.mock("@/services/api/common-api", () => ({
+  commonApiFetch: jest.fn(),
   commonApiPost: jest.fn(),
 }));
 
@@ -46,6 +51,7 @@ jest.mock("next/navigation", () => ({
 
 const useAuthMock = useAuth as jest.Mock;
 const commonApiPostMock = commonApiPost as jest.Mock;
+const commonApiFetchMock = commonApiFetch as jest.Mock;
 const createObjectUrlMock = jest.fn(() => "blob:cms-export");
 const revokeObjectUrlMock = jest.fn();
 const NativeBlob = globalThis.Blob;
@@ -315,10 +321,10 @@ describe("ProfileCmsBuilder", () => {
 
     expect(commonApiPostMock).not.toHaveBeenCalled();
     expect(
-      screen.getByText(
+      screen.getAllByText(
         "Connect as this profile before using backend builder actions."
-      )
-    ).toBeInTheDocument();
+      ).length
+    ).toBeGreaterThan(0);
   });
 
   it("keeps publish honest when backend writes are disabled", async () => {
@@ -371,10 +377,10 @@ describe("ProfileCmsBuilder", () => {
 
     expect(commonApiPostMock).not.toHaveBeenCalled();
     expect(
-      screen.getByText(
+      screen.getAllByText(
         "Connect as this profile before using backend builder actions."
-      )
-    ).toBeInTheDocument();
+      ).length
+    ).toBeGreaterThan(0);
   });
 
   it("blocks server validation unless the connected profile owns the target", async () => {
@@ -397,13 +403,99 @@ describe("ProfileCmsBuilder", () => {
 
     expect(commonApiPostMock).not.toHaveBeenCalled();
     expect(
-      screen.getByText(
+      screen.getAllByText(
         "Connect as this profile before using backend builder actions."
-      )
-    ).toBeInTheDocument();
+      ).length
+    ).toBeGreaterThan(0);
     expect(
       screen.getByText("profile-cms/packages/validate")
     ).toBeInTheDocument();
+  });
+
+  it("lists saved drafts and loads one back into the editor", async () => {
+    const user = userEvent.setup();
+    process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
+    useAuthMock.mockReturnValue({
+      activeProfileProxy: null,
+      connectedProfile: { id: "profile-punk6529" },
+    });
+    const storedPackage = buildCmsPackageCandidate(
+      {
+        ...createDefaultCmsBuilderState("punk6529"),
+        siteTitle: "Restored site",
+        pageTitle: "Restored homepage",
+      },
+      new Date("2026-06-18T00:00:00.000Z")
+    );
+    const record = {
+      id: "draft-123",
+      package: storedPackage,
+      profile_id: "profile-punk6529",
+      profile_handle: "punk6529",
+      package_id: "pkg-punk6529-builder-mvp",
+      version: 3,
+      status: "draft",
+      package_hash: storedPackage.integrity.package_hash,
+      payload_hash: storedPackage.integrity.payload_hash,
+      updated_at: 1750204800000,
+      created_at: 1750204700000,
+    };
+    commonApiFetchMock.mockImplementation(
+      ({ endpoint }: { readonly endpoint: string }) =>
+        endpoint === "profile-cms/profiles/profile-punk6529/packages"
+          ? Promise.resolve([record])
+          : Promise.resolve(record)
+    );
+
+    render(
+      <ProfileCmsBuilder
+        handle="punk6529"
+        profileId="profile-punk6529"
+        title="Profile CMS builder"
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Refresh drafts" }));
+
+    expect(commonApiFetchMock).toHaveBeenCalledWith({
+      endpoint: "profile-cms/profiles/profile-punk6529/packages",
+    });
+    expect(await screen.findByText(/Version 3/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Load" }));
+
+    expect(commonApiFetchMock).toHaveBeenCalledWith({
+      endpoint: "profile-cms/packages/draft-123",
+    });
+    await waitFor(() =>
+      expect(screen.getByLabelText("Site title")).toHaveValue("Restored site")
+    );
+    expect(screen.getByText("draft-123")).toBeInTheDocument();
+  });
+
+  it("keeps the drafts panel honest while the builder API flag is disabled", async () => {
+    useAuthMock.mockReturnValue({
+      activeProfileProxy: null,
+      connectedProfile: { id: "profile-punk6529" },
+    });
+
+    render(
+      <ProfileCmsBuilder
+        handle="punk6529"
+        profileId="profile-punk6529"
+        title="Profile CMS builder"
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Refresh drafts" })
+    ).toBeDisabled();
+    expect(
+      screen.getByText(
+        "Builder API writes are not enabled in this frontend environment."
+      )
+    ).toBeInTheDocument();
+    expect(commonApiFetchMock).not.toHaveBeenCalled();
   });
 
   it("requests a fixture wallet snapshot and previews the generated gallery", async () => {
@@ -488,7 +580,7 @@ describe("ProfileCmsBuilder", () => {
       connectedProfile: { id: "profile-punk6529" },
     });
     let resolvePost:
-      | ((value: { draft_id: string; package_hash: string }) => void)
+      | ((value: { id: string; package_hash: string }) => void)
       | undefined;
     commonApiPostMock.mockImplementation(
       () =>
@@ -509,7 +601,7 @@ describe("ProfileCmsBuilder", () => {
     await user.clear(screen.getByLabelText("Page title"));
     await user.type(screen.getByLabelText("Page title"), "Changed draft");
     await act(async () => {
-      resolvePost?.({ draft_id: "draft-1", package_hash: "hash-1" });
+      resolvePost?.({ id: "draft-1", package_hash: "hash-1" });
     });
 
     expect(screen.queryByText("Draft saved.")).not.toBeInTheDocument();

--- a/__tests__/components/profile-cms-builder/ProfileCmsBuilder.test.tsx
+++ b/__tests__/components/profile-cms-builder/ProfileCmsBuilder.test.tsx
@@ -473,6 +473,51 @@ describe("ProfileCmsBuilder", () => {
     expect(screen.getByText("draft-123")).toBeInTheDocument();
   });
 
+  it("surfaces a load failure when a saved draft cannot be fetched", async () => {
+    const user = userEvent.setup();
+    process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
+    useAuthMock.mockReturnValue({
+      activeProfileProxy: null,
+      connectedProfile: { id: "profile-punk6529" },
+    });
+    const record = {
+      id: "draft-123",
+      package: { schema: "not-a-cms-package" },
+      profile_id: "profile-punk6529",
+      profile_handle: "punk6529",
+      package_id: "pkg-punk6529-builder-mvp",
+      version: 3,
+      status: "draft",
+      package_hash: "sha256:abc",
+      payload_hash: "sha256:def",
+      updated_at: 1750204800000,
+      created_at: 1750204700000,
+    };
+    commonApiFetchMock.mockImplementation(
+      ({ endpoint }: { readonly endpoint: string }) =>
+        endpoint === "profile-cms/profiles/profile-punk6529/packages"
+          ? Promise.resolve([record])
+          : Promise.reject(new Error("request_failed"))
+    );
+
+    render(
+      <ProfileCmsBuilder
+        handle="punk6529"
+        profileId="profile-punk6529"
+        title="Profile CMS builder"
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Refresh drafts" }));
+    expect(await screen.findByText(/Version 3/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Load" }));
+
+    expect(
+      await screen.findByText("This draft could not be loaded into the editor.")
+    ).toBeInTheDocument();
+  });
+
   it("keeps the drafts panel honest while the builder API flag is disabled", async () => {
     useAuthMock.mockReturnValue({
       activeProfileProxy: null,

--- a/__tests__/lib/profile-cms/builder/api.test.ts
+++ b/__tests__/lib/profile-cms/builder/api.test.ts
@@ -1,15 +1,24 @@
 import {
+  getProfileCmsPackageById,
+  listProfileCmsPackagesForProfile,
+  PROFILE_CMS_BUILDER_PACKAGES_ENDPOINT,
+  PROFILE_CMS_BUILDER_VALIDATE_ENDPOINT,
   PROFILE_CMS_GALLERY_SNAPSHOT_ENDPOINT,
   requestProfileCmsGallerySnapshot,
+  runProfileCmsBuilderAction,
 } from "@/lib/profile-cms/builder/api";
 import { parseWalletGallerySources } from "@/lib/profile-cms/builder/gallery";
-import { commonApiPost } from "@/services/api/common-api";
+import { createDefaultCmsBuilderState } from "@/lib/profile-cms/builder/package";
+import { validateCmsBuilderState } from "@/lib/profile-cms/builder/package";
+import { commonApiFetch, commonApiPost } from "@/services/api/common-api";
 
 jest.mock("@/services/api/common-api", () => ({
   commonApiPost: jest.fn(),
+  commonApiFetch: jest.fn(),
 }));
 
 const commonApiPostMock = commonApiPost as jest.Mock;
+const commonApiFetchMock = commonApiFetch as jest.Mock;
 
 describe("profile CMS builder API adapter", () => {
   beforeEach(() => {
@@ -18,93 +27,430 @@ describe("profile CMS builder API adapter", () => {
     delete process.env["NEXT_PUBLIC_PROFILE_CMS_BUILDER_API_ENABLED"];
   });
 
-  it("uses the fixture snapshot fallback while backend gallery API is disabled", async () => {
-    const sources = parseWalletGallerySources("punk6529.eth").sources;
+  describe("wallet gallery snapshot", () => {
+    it("uses the fixture snapshot fallback while the backend gallery API is disabled", async () => {
+      const sources = parseWalletGallerySources("punk6529.eth").sources;
 
-    const snapshot = await requestProfileCmsGallerySnapshot({
-      handle: "punk6529",
-      profileId: "profile-punk6529",
-      sources,
+      const snapshot = await requestProfileCmsGallerySnapshot({
+        handle: "punk6529",
+        sources,
+      });
+
+      expect(commonApiPostMock).not.toHaveBeenCalled();
+      expect(snapshot.source).toBe("fixture");
+      expect(snapshot.assets).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "work-memes-1" }),
+        ])
+      );
     });
 
-    expect(commonApiPostMock).not.toHaveBeenCalled();
-    expect(snapshot.source).toBe("fixture");
-    expect(snapshot.assets).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: "work-memes-1" })])
-    );
-  });
+    it("posts to the real backend endpoint and normalizes the snake_case response", async () => {
+      process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
+      const sources = parseWalletGallerySources("punk6529.eth").sources;
 
-  it("posts the expected backend snapshot contract when the API is enabled", async () => {
-    process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
-    const sources = parseWalletGallerySources("punk6529.eth").sources;
-    commonApiPostMock.mockResolvedValue({
-      snapshot_id: "snapshot-1",
-      source: "backend",
-      wallets: [
-        {
-          kind: "ens",
-          input: "punk6529.eth",
-          normalized: "punk6529.eth",
-        },
-      ],
-      captured_at: "2026-06-18T00:00:00.000Z",
-      block_number: 23000000,
-      assets: [
-        {
-          id: "asset-1",
-          title: "Backend Work",
-          collection_id: "collection-1",
-          collection_name: "Backend Collection",
-          contract: "0x33fd426905f149f8376e227d0c9d3340aad17af1",
-          token_id: "1",
-          chain_id: 1,
-          owner: "0xf58fE66AF1A8C792Cd64D8d706edDabAdFCB2FD0",
-          image_uri: "ipfs://backend/work.png",
-          media_state: "ready",
-        },
-      ],
-    });
-
-    const snapshot = await requestProfileCmsGallerySnapshot({
-      handle: "punk6529",
-      profileId: "profile-punk6529",
-      sources,
-    });
-
-    expect(commonApiPostMock).toHaveBeenCalledWith({
-      endpoint: PROFILE_CMS_GALLERY_SNAPSHOT_ENDPOINT,
-      body: {
-        profile_id: "profile-punk6529",
+      // Realistic backend-shaped fixture: matches
+      // ApiProfileCmsWalletGallerySnapshot from
+      // 6529seize-backend/src/api-serverless/src/generated/models, produced
+      // by ProfileCmsWalletGalleryApiService#createSnapshot.
+      commonApiPostMock.mockResolvedValue({
+        generated_at: 1750204800000,
+        source: "indexed_ownership",
+        block_reference: 23000000,
         wallets: [
           {
-            kind: "ens",
             input: "punk6529.eth",
-            normalized: "punk6529.eth",
+            address: "0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+            ens: "punk6529.eth",
+            display: "punk6529.eth",
+            status: "resolved",
+            reason: null,
           },
         ],
-      },
-      errorMode: "structured",
+        assets: [
+          {
+            contract: "0x33FD426905F149f8376e227d0C9D3340AaD17af1",
+            token_id: 12,
+            balance: 1,
+            owner_wallet: "0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+            owner_display: "punk6529.eth",
+            collection: "The Memes by 6529",
+            collection_key: "MEMES",
+            name: "The Memes #12",
+            description: "A meme card.",
+            artist: "An Artist",
+            artist_seize_handle: "anartist",
+            token_type: "ERC1155",
+            media: {
+              image: "https://media.6529.io/memes/12.png",
+              image_preview: null,
+              thumbnail: null,
+              animation: null,
+              animation_preview: null,
+              mime_type: "image/png",
+            },
+            metadata: { name: "The Memes #12" },
+            flags: { spam: false, excluded: false, exclusion_reason: null },
+          },
+          {
+            contract: "0x33FD426905F149f8376e227d0C9D3340AaD17af1",
+            token_id: 13,
+            balance: 1,
+            owner_wallet: "0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+            owner_display: null,
+            collection: "The Memes by 6529",
+            collection_key: "MEMES",
+            name: "The Memes #13",
+            description: null,
+            artist: null,
+            artist_seize_handle: null,
+            token_type: "ERC1155",
+            media: {
+              image: null,
+              image_preview: null,
+              thumbnail: null,
+              animation: null,
+              animation_preview: null,
+              mime_type: null,
+            },
+            metadata: null,
+            flags: { spam: false, excluded: false, exclusion_reason: null },
+          },
+        ],
+        excluded_assets: [
+          {
+            contract: "0x0000000000000000000000000000000000dead",
+            token_id: 1,
+            owner_wallet: "0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+            reason: "contract_excluded",
+          },
+        ],
+        totals: {
+          requested_wallets: 1,
+          resolved_wallets: 1,
+          unresolved_wallets: 0,
+          indexed_assets: 2,
+          visible_assets: 2,
+          excluded_assets: 1,
+          spam_assets: 0,
+          truncated: false,
+        },
+      });
+
+      const snapshot = await requestProfileCmsGallerySnapshot({
+        handle: "punk6529",
+        sources,
+      });
+
+      expect(commonApiPostMock).toHaveBeenCalledWith({
+        endpoint: PROFILE_CMS_GALLERY_SNAPSHOT_ENDPOINT,
+        body: { wallets: ["punk6529.eth"] },
+        errorMode: "structured",
+      });
+      expect(PROFILE_CMS_GALLERY_SNAPSHOT_ENDPOINT).toBe(
+        "profile-cms/wallet-gallery/snapshot"
+      );
+
+      expect(snapshot.source).toBe("backend");
+      expect(snapshot.blockNumber).toBe(23000000);
+      expect(snapshot.capturedAt).toBe(new Date(1750204800000).toISOString());
+      expect(snapshot.assets).toHaveLength(2);
+      expect(snapshot.assets[0]).toEqual(
+        expect.objectContaining({
+          id: "0x33fd426905f149f8376e227d0c9d3340aad17af1:12:0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+          title: "The Memes #12",
+          collectionId: "MEMES",
+          collectionName: "The Memes by 6529",
+          tokenId: "12",
+          owner: "0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+          imageUri: "https://media.6529.io/memes/12.png",
+          mediaState: "ready",
+          altText: "The Memes #12",
+          flags: { spam: false, excluded: false },
+        })
+      );
+      expect(snapshot.assets[1]).toEqual(
+        expect.objectContaining({
+          mediaState: "missing",
+          altText: "The Memes #13",
+        })
+      );
+      expect(snapshot.assets[1]?.imageUri).toBeUndefined();
+
+      expect(snapshot.collections).toHaveLength(1);
+      expect(snapshot.collections[0]).toEqual(
+        expect.objectContaining({
+          id: "MEMES",
+          name: "The Memes by 6529",
+          assetIds: [
+            "0x33fd426905f149f8376e227d0c9d3340aad17af1:12:0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+            "0x33fd426905f149f8376e227d0c9d3340aad17af1:13:0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+          ],
+        })
+      );
+
+      expect(snapshot.excludedAssets).toEqual([
+        {
+          contract: "0x0000000000000000000000000000000000dead",
+          tokenId: "1",
+          owner: "0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+          reason: "contract_excluded",
+        },
+      ]);
+      expect(snapshot.totals).toEqual({
+        requestedWallets: 1,
+        resolvedWallets: 1,
+        unresolvedWallets: 0,
+        indexedAssets: 2,
+        visibleAssets: 2,
+        excludedAssets: 1,
+        spamAssets: 0,
+        truncated: false,
+      });
     });
-    expect(snapshot).toEqual(
-      expect.objectContaining({
-        snapshotId: "snapshot-1",
-        source: "backend",
-        blockNumber: 23000000,
-      })
-    );
-    expect(snapshot.assets[0]).toEqual(
-      expect.objectContaining({
-        id: "asset-1",
-        imageUri: "ipfs://backend/work.png",
-      })
-    );
-    expect(snapshot.collections[0]).toEqual(
-      expect.objectContaining({
-        id: "collection-1",
-        name: "Backend Collection",
-        slug: "collection-1",
-        assetIds: ["asset-1"],
-      })
-    );
+  });
+
+  describe("draft lifecycle", () => {
+    it("saves a draft against the real packages endpoint and returns the backend id/hash", async () => {
+      process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
+      const state = createDefaultCmsBuilderState("punk6529");
+      const { cmsPackage } = validateCmsBuilderState(state);
+      commonApiPostMock.mockResolvedValue({
+        id: "draft-123",
+        profile_id: "profile-punk6529",
+        profile_handle: "punk6529",
+        package_id: "pkg-punk6529-builder-mvp",
+        version: 1,
+        status: "draft",
+        package_hash: cmsPackage.integrity.package_hash,
+        payload_hash: cmsPackage.integrity.payload_hash,
+        updated_at: 1750204800000,
+        created_at: 1750204800000,
+      });
+
+      const result = await runProfileCmsBuilderAction({
+        action: "save_draft",
+        cmsPackage,
+        profileId: "profile-punk6529",
+      });
+
+      expect(PROFILE_CMS_BUILDER_PACKAGES_ENDPOINT).toBe(
+        "profile-cms/packages"
+      );
+      expect(commonApiPostMock).toHaveBeenCalledWith({
+        endpoint: "profile-cms/packages",
+        body: { profile_id: "profile-punk6529", cms_package: cmsPackage },
+        errorMode: "structured",
+      });
+      expect(result).toEqual(
+        expect.objectContaining({
+          ok: true,
+          code: "draft_saved",
+          draftId: "draft-123",
+          packageHash: cmsPackage.integrity.package_hash,
+        })
+      );
+    });
+
+    it("posts server validation against the real validate endpoint", async () => {
+      process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
+      const state = createDefaultCmsBuilderState("punk6529");
+      const { cmsPackage } = validateCmsBuilderState(state);
+      commonApiPostMock.mockResolvedValue({
+        schema: "6529.cms.validation_result.v1",
+        valid: true,
+        checked_at: "2026-06-18T00:00:00.000Z",
+        issues: [],
+        target: {
+          package_hash: cmsPackage.integrity.package_hash,
+        },
+      });
+
+      const result = await runProfileCmsBuilderAction({
+        action: "validate",
+        cmsPackage,
+        profileId: "profile-punk6529",
+      });
+
+      expect(PROFILE_CMS_BUILDER_VALIDATE_ENDPOINT).toBe(
+        "profile-cms/packages/validate"
+      );
+      expect(commonApiPostMock).toHaveBeenCalledWith({
+        endpoint: "profile-cms/packages/validate",
+        body: {
+          cms_package: cmsPackage,
+          allow_fixture_signatures: true,
+          allow_fixture_storage: true,
+          enforce_hashes: true,
+        },
+        errorMode: "structured",
+      });
+      expect(result).toEqual(
+        expect.objectContaining({
+          ok: true,
+          code: "server_validation_completed",
+          packageHash: cmsPackage.integrity.package_hash,
+        })
+      );
+    });
+
+    it("keeps publish hard-blocked regardless of the API-enabled flag", async () => {
+      process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
+      const state = createDefaultCmsBuilderState("punk6529");
+      const { cmsPackage } = validateCmsBuilderState(state);
+
+      const result = await runProfileCmsBuilderAction({
+        action: "publish",
+        cmsPackage,
+        draftId: "draft-123",
+        profileId: "profile-punk6529",
+      });
+
+      expect(commonApiPostMock).not.toHaveBeenCalled();
+      expect(result).toEqual(
+        expect.objectContaining({
+          ok: false,
+          code: "publish_requires_signed_storage",
+          expectedEndpoint: "profile-cms/packages/draft-123/publish",
+        })
+      );
+    });
+
+    it("reports invalid server validation results instead of pretending success", async () => {
+      process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
+      const state = createDefaultCmsBuilderState("punk6529");
+      const { cmsPackage } = validateCmsBuilderState(state);
+      commonApiPostMock.mockResolvedValue({
+        schema: "6529.cms.validation_result.v1",
+        valid: false,
+        checked_at: "2026-06-18T00:00:00.000Z",
+        issues: [
+          {
+            severity: "error",
+            code: "package.hash_mismatch",
+            message: "Package hash mismatch.",
+            path: "/integrity/package_hash",
+          },
+        ],
+      });
+
+      const result = await runProfileCmsBuilderAction({
+        action: "validate",
+        cmsPackage,
+        profileId: "profile-punk6529",
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          ok: true,
+          code: "server_validation_invalid",
+        })
+      );
+    });
+
+    it("lists saved packages for a profile from the real profile packages endpoint", async () => {
+      process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
+      commonApiFetchMock.mockResolvedValue([
+        {
+          id: "draft-123",
+          package: { schema: "6529.cms.package.v1" },
+          profile_id: "profile-punk6529",
+          profile_handle: "punk6529",
+          package_id: "pkg-punk6529-builder-mvp",
+          version: 2,
+          status: "draft",
+          package_hash: "sha256:abc",
+          payload_hash: "sha256:def",
+          updated_at: 1750204800000,
+          created_at: 1750204700000,
+        },
+      ]);
+
+      const records =
+        await listProfileCmsPackagesForProfile("profile-punk6529");
+
+      expect(commonApiFetchMock).toHaveBeenCalledWith({
+        endpoint: "profile-cms/profiles/profile-punk6529/packages",
+      });
+      expect(records).toEqual([
+        {
+          id: "draft-123",
+          profileId: "profile-punk6529",
+          profileHandle: "punk6529",
+          packageId: "pkg-punk6529-builder-mvp",
+          version: 2,
+          status: "draft",
+          packageHash: "sha256:abc",
+          payloadHash: "sha256:def",
+          updatedAt: new Date(1750204800000).toISOString(),
+          createdAt: new Date(1750204700000).toISOString(),
+        },
+      ]);
+    });
+
+    it("gets a single package by id and validates its stored V1 payload", async () => {
+      process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
+      const state = createDefaultCmsBuilderState("punk6529");
+      const { cmsPackage } = validateCmsBuilderState(state);
+      commonApiFetchMock.mockResolvedValue({
+        id: "draft-123",
+        package: cmsPackage,
+        profile_id: "profile-punk6529",
+        profile_handle: "punk6529",
+        package_id: "pkg-punk6529-builder-mvp",
+        version: 1,
+        status: "published",
+        package_hash: cmsPackage.integrity.package_hash,
+        payload_hash: cmsPackage.integrity.payload_hash,
+        updated_at: 1750204800000,
+        created_at: 1750204700000,
+        published_at: 1750204900000,
+      });
+
+      const record = await getProfileCmsPackageById("draft-123");
+
+      expect(commonApiFetchMock).toHaveBeenCalledWith({
+        endpoint: "profile-cms/packages/draft-123",
+      });
+      expect(record).toEqual(
+        expect.objectContaining({
+          id: "draft-123",
+          status: "published",
+          publishedAt: new Date(1750204900000).toISOString(),
+          cmsPackage,
+        })
+      );
+    });
+
+    it("rejects stored packages that fail local V1 validation on load", async () => {
+      process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
+      commonApiFetchMock.mockResolvedValue({
+        id: "draft-123",
+        package: { schema: "not-a-cms-package" },
+        profile_id: "profile-punk6529",
+        profile_handle: "punk6529",
+        package_id: "pkg-punk6529-builder-mvp",
+        version: 1,
+        status: "draft",
+        package_hash: "sha256:abc",
+        payload_hash: "sha256:def",
+        updated_at: 1750204800000,
+        created_at: 1750204700000,
+      });
+
+      await expect(getProfileCmsPackageById("draft-123")).rejects.toThrow(
+        "invalid_profile_cms_package"
+      );
+    });
+
+    it("refuses draft list/load reads while the builder API flag is disabled", async () => {
+      await expect(
+        listProfileCmsPackagesForProfile("profile-punk6529")
+      ).rejects.toThrow("profile_cms_builder_api_disabled");
+      await expect(getProfileCmsPackageById("draft-123")).rejects.toThrow(
+        "profile_cms_builder_api_disabled"
+      );
+      expect(commonApiFetchMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/__tests__/lib/profile-cms/builder/api.test.ts
+++ b/__tests__/lib/profile-cms/builder/api.test.ts
@@ -316,22 +316,25 @@ describe("profile CMS builder API adapter", () => {
       );
     });
 
-    it("reports invalid server validation results instead of pretending success", async () => {
+    it("models a rejected server validation as a failure that still carries the target", async () => {
       process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
       const state = createDefaultCmsBuilderState("punk6529");
       const { cmsPackage } = validateCmsBuilderState(state);
+      const issue = {
+        severity: "error",
+        code: "package.hash_mismatch",
+        message: "Package hash mismatch.",
+        path: "/integrity/package_hash",
+      };
       commonApiPostMock.mockResolvedValue({
         schema: "6529.cms.validation_result.v1",
         valid: false,
         checked_at: "2026-06-18T00:00:00.000Z",
-        issues: [
-          {
-            severity: "error",
-            code: "package.hash_mismatch",
-            message: "Package hash mismatch.",
-            path: "/integrity/package_hash",
-          },
-        ],
+        issues: [issue],
+        target: {
+          package_hash: cmsPackage.integrity.package_hash,
+          draft_id: "draft-from-validate",
+        },
       });
 
       const result = await runProfileCmsBuilderAction({
@@ -340,12 +343,15 @@ describe("profile CMS builder API adapter", () => {
         profileId: "profile-punk6529",
       });
 
-      expect(result).toEqual(
-        expect.objectContaining({
-          ok: true,
-          code: "server_validation_invalid",
-        })
-      );
+      expect(result).toEqual({
+        ok: false,
+        action: "validate",
+        code: "server_validation_invalid",
+        expectedEndpoint: "profile-cms/packages/validate",
+        draftId: "draft-from-validate",
+        packageHash: cmsPackage.integrity.package_hash,
+        serverIssues: [issue],
+      });
     });
 
     it("lists saved packages for a profile from the real profile packages endpoint", async () => {

--- a/__tests__/lib/profile-cms/builder/gallery-normalize.test.ts
+++ b/__tests__/lib/profile-cms/builder/gallery-normalize.test.ts
@@ -248,6 +248,42 @@ describe("wallet gallery snapshot normalization", () => {
     expect(snapshot.warnings).toEqual(["backend_snapshot_unresolved_wallets"]);
   });
 
+  it("maps a resolved ENS wallet to its address and skips unresolved inputs", () => {
+    const snapshot = normalizeWalletGallerySnapshotResponse(
+      buildBackendSnapshot({
+        wallets: [
+          {
+            input: "punk6529.eth",
+            address: "0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+            ens: "punk6529.eth",
+            display: "punk6529.eth",
+            status: "resolved",
+            reason: null,
+          },
+          {
+            input: "not-a-wallet",
+            address: null,
+            ens: null,
+            display: null,
+            status: "unresolved",
+            reason: "unresolvable_input",
+          },
+        ],
+      }),
+      REQUESTED_SOURCES
+    );
+
+    // The resolved ENS source becomes kind "address" so package generation
+    // can pick profile.primary_wallet; the ENS string stays on `input`.
+    expect(snapshot.wallets).toEqual([
+      {
+        kind: "address",
+        input: "punk6529.eth",
+        normalized: "0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+      },
+    ]);
+  });
+
   it("falls back to the requested wallet sources when the backend cannot resolve any wallet", () => {
     const snapshot = normalizeWalletGallerySnapshotResponse(
       buildBackendSnapshot({

--- a/__tests__/lib/profile-cms/builder/gallery-normalize.test.ts
+++ b/__tests__/lib/profile-cms/builder/gallery-normalize.test.ts
@@ -1,0 +1,270 @@
+import type { ApiProfileCmsWalletGallerySnapshot } from "@/generated/models/ApiProfileCmsWalletGallerySnapshot";
+import { normalizeWalletGallerySnapshotResponse } from "@/lib/profile-cms/builder/gallery-normalize";
+import type { WalletGallerySource } from "@/lib/profile-cms/builder/gallery";
+
+// Realistic backend-shaped response: mirrors
+// ApiProfileCmsWalletGallerySnapshot generated from
+// 6529seize-backend/src/api-serverless/src/profile-cms/wallet-gallery.api.service.ts.
+function buildBackendSnapshot(
+  overrides: Partial<ApiProfileCmsWalletGallerySnapshot> = {}
+): ApiProfileCmsWalletGallerySnapshot {
+  return {
+    generated_at: 1750204800000,
+    source: "indexed_ownership",
+    block_reference: 23000000,
+    wallets: [
+      {
+        input: "punk6529.eth",
+        address: "0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+        ens: "punk6529.eth",
+        display: "punk6529.eth",
+        status: "resolved",
+        reason: null,
+      },
+    ],
+    assets: [
+      {
+        contract: "0x33FD426905F149f8376e227d0C9D3340AaD17af1",
+        token_id: 1,
+        balance: 1,
+        owner_wallet: "0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+        owner_display: "punk6529.eth",
+        collection: "The Memes by 6529",
+        collection_key: "MEMES",
+        name: "The Memes #1",
+        description: "A meme card.",
+        artist: "An Artist",
+        artist_seize_handle: "anartist",
+        token_type: "ERC1155",
+        media: {
+          image: "https://media.6529.io/memes/1.png",
+          image_preview: null,
+          thumbnail: null,
+          animation: null,
+          animation_preview: null,
+          mime_type: "image/png",
+        },
+        metadata: { name: "The Memes #1" },
+        flags: { spam: false, excluded: false, exclusion_reason: null },
+      },
+    ],
+    excluded_assets: [],
+    totals: {
+      requested_wallets: 1,
+      resolved_wallets: 1,
+      unresolved_wallets: 0,
+      indexed_assets: 1,
+      visible_assets: 1,
+      excluded_assets: 0,
+      spam_assets: 0,
+      truncated: false,
+    },
+    ...overrides,
+  } as ApiProfileCmsWalletGallerySnapshot;
+}
+
+const REQUESTED_SOURCES: readonly WalletGallerySource[] = [
+  { kind: "ens", input: "punk6529.eth", normalized: "punk6529.eth" },
+];
+
+describe("wallet gallery snapshot normalization", () => {
+  it("normalizes snake_case backend assets into the camelCase FE review model", () => {
+    const snapshot = normalizeWalletGallerySnapshotResponse(
+      buildBackendSnapshot(),
+      REQUESTED_SOURCES
+    );
+
+    expect(snapshot.source).toBe("backend");
+    expect(snapshot.blockNumber).toBe(23000000);
+    expect(snapshot.capturedAt).toBe(new Date(1750204800000).toISOString());
+    expect(snapshot.assets).toEqual([
+      expect.objectContaining({
+        id: "0x33fd426905f149f8376e227d0c9d3340aad17af1:1:0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+        title: "The Memes #1",
+        collectionId: "MEMES",
+        collectionName: "The Memes by 6529",
+        contract: "0x33FD426905F149f8376e227d0C9D3340AaD17af1",
+        tokenId: "1",
+        chainId: 1,
+        owner: "0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+        imageUri: "https://media.6529.io/memes/1.png",
+        mimeType: "image/png",
+        mediaState: "ready",
+        altText: "The Memes #1",
+        flags: { spam: false, excluded: false },
+      }),
+    ]);
+  });
+
+  it("marks assets with no indexed media at all as missing and drops imageUri", () => {
+    const snapshot = normalizeWalletGallerySnapshotResponse(
+      buildBackendSnapshot({
+        assets: [
+          {
+            ...buildBackendSnapshot().assets[0],
+            media: {
+              image: null,
+              image_preview: null,
+              thumbnail: null,
+              animation: null,
+              animation_preview: null,
+              mime_type: null,
+            },
+          },
+        ],
+      }),
+      REQUESTED_SOURCES
+    );
+
+    expect(snapshot.assets[0]?.mediaState).toBe("missing");
+    expect(snapshot.assets[0]?.imageUri).toBeUndefined();
+  });
+
+  it("marks preview-only media as partial while keeping the preview image", () => {
+    const snapshot = normalizeWalletGallerySnapshotResponse(
+      buildBackendSnapshot({
+        assets: [
+          {
+            ...buildBackendSnapshot().assets[0],
+            media: {
+              image: null,
+              image_preview: "https://media.6529.io/previews/1.png",
+              thumbnail: null,
+              animation: null,
+              animation_preview: null,
+              mime_type: "image/png",
+            },
+          },
+        ],
+      }),
+      REQUESTED_SOURCES
+    );
+
+    expect(snapshot.assets[0]?.mediaState).toBe("partial");
+    expect(snapshot.assets[0]?.imageUri).toBe(
+      "https://media.6529.io/previews/1.png"
+    );
+  });
+
+  it("surfaces backend exclusion flags and the excluded_assets list separately", () => {
+    const snapshot = normalizeWalletGallerySnapshotResponse(
+      buildBackendSnapshot({
+        excluded_assets: [
+          {
+            contract: "0x0000000000000000000000000000000000dead",
+            token_id: 99,
+            owner_wallet: "0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+            reason: "asset_excluded",
+          },
+        ],
+      }),
+      REQUESTED_SOURCES
+    );
+
+    expect(snapshot.excludedAssets).toEqual([
+      {
+        contract: "0x0000000000000000000000000000000000dead",
+        tokenId: "99",
+        owner: "0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+        reason: "asset_excluded",
+      },
+    ]);
+  });
+
+  it("derives collections by grouping assets on collection_key when the backend has no collections list", () => {
+    const snapshot = normalizeWalletGallerySnapshotResponse(
+      buildBackendSnapshot({
+        assets: [
+          buildBackendSnapshot().assets[0],
+          {
+            ...buildBackendSnapshot().assets[0],
+            token_id: 2,
+            name: "The Memes #2",
+          },
+        ],
+      }),
+      REQUESTED_SOURCES
+    );
+
+    expect(snapshot.collections).toEqual([
+      expect.objectContaining({
+        id: "MEMES",
+        name: "The Memes by 6529",
+        assetIds: [
+          "0x33fd426905f149f8376e227d0c9d3340aad17af1:1:0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+          "0x33fd426905f149f8376e227d0c9d3340aad17af1:2:0xf58fe66af1a8c792cd64d8d706eddabadfcb2fd0",
+        ],
+      }),
+    ]);
+  });
+
+  it("maps totals and flags a truncated warning when the backend truncates results", () => {
+    const snapshot = normalizeWalletGallerySnapshotResponse(
+      buildBackendSnapshot({
+        totals: {
+          requested_wallets: 1,
+          resolved_wallets: 1,
+          unresolved_wallets: 0,
+          indexed_assets: 500,
+          visible_assets: 200,
+          excluded_assets: 0,
+          spam_assets: 0,
+          truncated: true,
+        },
+      }),
+      REQUESTED_SOURCES
+    );
+
+    expect(snapshot.totals).toEqual({
+      requestedWallets: 1,
+      resolvedWallets: 1,
+      unresolvedWallets: 0,
+      indexedAssets: 500,
+      visibleAssets: 200,
+      excludedAssets: 0,
+      spamAssets: 0,
+      truncated: true,
+    });
+    expect(snapshot.warnings).toEqual(["backend_snapshot_truncated"]);
+  });
+
+  it("flags an unresolved-wallets warning when some inputs could not be resolved", () => {
+    const snapshot = normalizeWalletGallerySnapshotResponse(
+      buildBackendSnapshot({
+        totals: {
+          requested_wallets: 2,
+          resolved_wallets: 1,
+          unresolved_wallets: 1,
+          indexed_assets: 1,
+          visible_assets: 1,
+          excluded_assets: 0,
+          spam_assets: 0,
+          truncated: false,
+        },
+      }),
+      REQUESTED_SOURCES
+    );
+
+    expect(snapshot.warnings).toEqual(["backend_snapshot_unresolved_wallets"]);
+  });
+
+  it("falls back to the requested wallet sources when the backend cannot resolve any wallet", () => {
+    const snapshot = normalizeWalletGallerySnapshotResponse(
+      buildBackendSnapshot({
+        wallets: [
+          {
+            input: "not-a-wallet",
+            address: null,
+            ens: null,
+            display: null,
+            status: "unresolved",
+            reason: "unresolvable_input",
+          },
+        ],
+      }),
+      REQUESTED_SOURCES
+    );
+
+    expect(snapshot.wallets).toEqual(REQUESTED_SOURCES);
+  });
+});

--- a/components/profile-cms-builder/ProfileCmsBuilder.tsx
+++ b/components/profile-cms-builder/ProfileCmsBuilder.tsx
@@ -323,7 +323,9 @@ export default function ProfileCmsBuilder({
       ) {
         return;
       }
-      if (result.ok && result.draftId) {
+      // A rejected server validation (ok: false) can still return a
+      // persisted draft id in its validation target — keep it either way.
+      if (result.draftId) {
         setDraftId(result.draftId);
       }
       setActionResult(result);
@@ -1694,16 +1696,30 @@ function PublishStatePanel({
       {actionResult ? (
         <div
           className={`tw-mt-4 tw-border tw-border-solid tw-p-3 tw-text-sm ${
-            actionResult.ok && actionResult.code !== "server_validation_invalid"
+            actionResult.ok
               ? "tw-border-green tw-bg-green/10 tw-text-green"
               : "tw-text-primary-200 tw-border-primary-400 tw-bg-primary-500/10"
           }`}
         >
           <p>{getActionResultMessage(locale, actionResult.code)}</p>
           {actionResult.ok ? null : (
-            <p className="tw-mt-2 tw-font-mono tw-text-xs">
-              {actionResult.expectedEndpoint}
-            </p>
+            <>
+              <p className="tw-mt-2 tw-font-mono tw-text-xs">
+                {actionResult.expectedEndpoint}
+              </p>
+              {actionResult.serverIssues?.length ? (
+                <ul className="tw-mt-2 tw-flex tw-flex-col tw-gap-1">
+                  {actionResult.serverIssues.map((issue) => (
+                    <li
+                      className="tw-font-mono tw-text-xs"
+                      key={`${issue.code}-${issue.path}`}
+                    >
+                      {issue.severity} · {issue.code} · {issue.path}
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </>
           )}
         </div>
       ) : (
@@ -1753,11 +1769,11 @@ function DraftsPanel({
           onClick={onRequestDrafts}
         />
       </div>
-      {!builderApiEnabled ? (
+      {builderApiEnabled ? null : (
         <p className="tw-mt-3 tw-text-sm tw-leading-6 tw-text-iron-400">
           {t(locale, "profileCms.builder.api.disabled")}
         </p>
-      ) : null}
+      )}
       {builderApiEnabled && !canUseBuilderApi ? (
         <p className="tw-mt-3 tw-text-sm tw-leading-6 tw-text-iron-400">
           {t(locale, "profileCms.builder.api.profileNotAuthorized")}

--- a/components/profile-cms-builder/ProfileCmsBuilder.tsx
+++ b/components/profile-cms-builder/ProfileCmsBuilder.tsx
@@ -9,6 +9,7 @@ import {
   ProfileCmsAgentPanel,
   downloadJsonFile,
 } from "@/components/profile-cms-builder/ProfileCmsAgentPanel";
+import { isProfileCmsBuilderApiEnabledEnv } from "@/config/profileCmsBuilderEnv";
 import { formatInteger } from "@/i18n/format";
 import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
@@ -17,6 +18,8 @@ import {
   createCmsBuilderSourcePacket,
 } from "@/lib/profile-cms/builder/agent";
 import {
+  getProfileCmsPackageById,
+  listProfileCmsPackagesForProfile,
   PROFILE_CMS_BUILDER_PACKAGES_ENDPOINT,
   PROFILE_CMS_BUILDER_PUBLISH_ENDPOINT,
   PROFILE_CMS_BUILDER_VALIDATE_ENDPOINT,
@@ -25,8 +28,10 @@ import {
   type ProfileCmsBuilderAction,
   type ProfileCmsBuilderActionCode,
   type ProfileCmsBuilderActionResult,
+  type ProfileCmsPackageRecord,
 } from "@/lib/profile-cms/builder/api";
 import {
+  WALLET_GALLERY_BACKEND_WARNING_CODES,
   WALLET_GALLERY_FIXTURE_WARNING_CODES,
   parseWalletGallerySources,
   type WalletGalleryBuilderState,
@@ -53,6 +58,7 @@ import { resolveCmsUri } from "@/lib/profile-cms/runtime/uri";
 
 type BuilderTab = "editor" | "preview" | "json" | "agent";
 type GallerySnapshotStatus = "idle" | "loading" | "ready" | "error";
+type DraftsListStatus = "idle" | "loading" | "ready" | "error";
 
 const BLOCK_OPTIONS: ReadonlyArray<{
   readonly kind: CmsBuilderBlockKind;
@@ -92,8 +98,13 @@ export default function ProfileCmsBuilder({
   const [gallerySnapshotStatus, setGallerySnapshotStatus] =
     useState<GallerySnapshotStatus>("idle");
   const [gallerySnapshotError, setGallerySnapshotError] = useState("");
+  const [draftsStatus, setDraftsStatus] = useState<DraftsListStatus>("idle");
+  const [drafts, setDrafts] = useState<readonly ProfileCmsPackageRecord[]>([]);
+  const [loadingDraftId, setLoadingDraftId] = useState<string | null>(null);
+  const [draftLoadFailed, setDraftLoadFailed] = useState(false);
   const actionRequestIdRef = useRef(0);
   const gallerySnapshotRequestIdRef = useRef(0);
+  const draftsRequestIdRef = useRef(0);
   const stateVersionRef = useRef(0);
   const { activeProfileProxy, connectedProfile } = useAuth();
 
@@ -206,7 +217,6 @@ export default function ProfileCmsBuilder({
     try {
       const snapshot = await requestProfileCmsGallerySnapshot({
         handle: state.handle,
-        profileId: canUseBuilderApi ? profileId : undefined,
         sources: parsed.sources,
       });
       if (requestId !== gallerySnapshotRequestIdRef.current) {
@@ -334,6 +344,55 @@ export default function ProfileCmsBuilder({
       if (actionRequestId === actionRequestIdRef.current) {
         setIsSubmitting(false);
       }
+    }
+  };
+
+  const builderApiEnabled = isProfileCmsBuilderApiEnabledEnv();
+
+  const loadDrafts = async () => {
+    if (!canUseBuilderApi || !profileId || !builderApiEnabled) {
+      return;
+    }
+
+    const requestId = draftsRequestIdRef.current + 1;
+    draftsRequestIdRef.current = requestId;
+    setDraftsStatus("loading");
+    setDraftLoadFailed(false);
+
+    try {
+      const records = await listProfileCmsPackagesForProfile(profileId);
+      if (requestId !== draftsRequestIdRef.current) {
+        return;
+      }
+      setDrafts(records);
+      setDraftsStatus("ready");
+    } catch {
+      if (requestId !== draftsRequestIdRef.current) {
+        return;
+      }
+      setDraftsStatus("error");
+    }
+  };
+
+  const loadDraft = async (record: ProfileCmsPackageRecord) => {
+    if (!canUseBuilderApi || !builderApiEnabled || loadingDraftId) {
+      return;
+    }
+
+    setLoadingDraftId(record.id);
+    setDraftLoadFailed(false);
+    try {
+      // Refetch by id so the editor always loads the freshest stored
+      // package, validated against the local V1 schema by the adapter.
+      const loaded = await getProfileCmsPackageById(record.id);
+      setState(createBuilderStateFromPackage(loaded.cmsPackage));
+      setDraftId(loaded.id);
+      clearActionResult();
+      setActiveTab("editor");
+    } catch {
+      setDraftLoadFailed(true);
+    } finally {
+      setLoadingDraftId(null);
     }
   };
 
@@ -480,6 +539,17 @@ export default function ProfileCmsBuilder({
             locale={locale}
             packageHash={validation.cmsPackage.integrity.package_hash}
             payloadHash={validation.cmsPackage.integrity.payload_hash}
+          />
+          <DraftsPanel
+            builderApiEnabled={builderApiEnabled}
+            canUseBuilderApi={canUseBuilderApi}
+            drafts={drafts}
+            loadFailed={draftLoadFailed}
+            loadingDraftId={loadingDraftId}
+            locale={locale}
+            onLoadDraft={(record) => void loadDraft(record)}
+            onRequestDrafts={() => void loadDrafts()}
+            status={draftsStatus}
           />
         </aside>
       </div>
@@ -910,6 +980,13 @@ function formatGallerySnapshotWarning(
         locale,
         "profileCms.builder.gallery.snapshot.warning.partialMedia"
       );
+    case WALLET_GALLERY_BACKEND_WARNING_CODES.unresolvedWallets:
+      return t(
+        locale,
+        "profileCms.builder.gallery.snapshot.warning.unresolvedWallets"
+      );
+    case WALLET_GALLERY_BACKEND_WARNING_CODES.truncated:
+      return t(locale, "profileCms.builder.gallery.snapshot.warning.truncated");
     default:
       return warning;
   }
@@ -1617,7 +1694,7 @@ function PublishStatePanel({
       {actionResult ? (
         <div
           className={`tw-mt-4 tw-border tw-border-solid tw-p-3 tw-text-sm ${
-            actionResult.ok
+            actionResult.ok && actionResult.code !== "server_validation_invalid"
               ? "tw-border-green tw-bg-green/10 tw-text-green"
               : "tw-text-primary-200 tw-border-primary-400 tw-bg-primary-500/10"
           }`}
@@ -1634,6 +1711,111 @@ function PublishStatePanel({
           {t(locale, "profileCms.builder.publishState.pending")}
         </p>
       )}
+    </section>
+  );
+}
+
+function DraftsPanel({
+  builderApiEnabled,
+  canUseBuilderApi,
+  drafts,
+  loadFailed,
+  loadingDraftId,
+  locale,
+  onLoadDraft,
+  onRequestDrafts,
+  status,
+}: {
+  readonly builderApiEnabled: boolean;
+  readonly canUseBuilderApi: boolean;
+  readonly drafts: readonly ProfileCmsPackageRecord[];
+  readonly loadFailed: boolean;
+  readonly loadingDraftId: string | null;
+  readonly locale: SupportedLocale;
+  readonly onLoadDraft: (record: ProfileCmsPackageRecord) => void;
+  readonly onRequestDrafts: () => void;
+  readonly status: "idle" | "loading" | "ready" | "error";
+}) {
+  const canRequest = canUseBuilderApi && builderApiEnabled;
+  return (
+    <section className="tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-900 tw-p-4">
+      <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
+        <h2 className="tw-text-base tw-font-semibold tw-text-white">
+          {t(locale, "profileCms.builder.drafts.title")}
+        </h2>
+        <BuilderActionButton
+          disabled={!canRequest || status === "loading"}
+          label={
+            status === "loading"
+              ? t(locale, "profileCms.builder.drafts.loading")
+              : t(locale, "profileCms.builder.drafts.refresh")
+          }
+          onClick={onRequestDrafts}
+        />
+      </div>
+      {!builderApiEnabled ? (
+        <p className="tw-mt-3 tw-text-sm tw-leading-6 tw-text-iron-400">
+          {t(locale, "profileCms.builder.api.disabled")}
+        </p>
+      ) : null}
+      {builderApiEnabled && !canUseBuilderApi ? (
+        <p className="tw-mt-3 tw-text-sm tw-leading-6 tw-text-iron-400">
+          {t(locale, "profileCms.builder.api.profileNotAuthorized")}
+        </p>
+      ) : null}
+      {canRequest && status === "error" ? (
+        <p
+          className="tw-mt-3 tw-border tw-border-solid tw-border-red tw-bg-red/10 tw-p-3 tw-text-sm tw-text-red"
+          role="alert"
+        >
+          {t(locale, "profileCms.builder.drafts.failed")}
+        </p>
+      ) : null}
+      {canRequest && loadFailed ? (
+        <p
+          className="tw-mt-3 tw-border tw-border-solid tw-border-red tw-bg-red/10 tw-p-3 tw-text-sm tw-text-red"
+          role="alert"
+        >
+          {t(locale, "profileCms.builder.drafts.loadFailed")}
+        </p>
+      ) : null}
+      {canRequest && status === "ready" && !drafts.length ? (
+        <p className="tw-mt-3 tw-text-sm tw-leading-6 tw-text-iron-400">
+          {t(locale, "profileCms.builder.drafts.empty")}
+        </p>
+      ) : null}
+      {drafts.length ? (
+        <ul className="tw-mt-3 tw-flex tw-flex-col tw-gap-2">
+          {drafts.map((draft) => (
+            <li
+              className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2 tw-border tw-border-solid tw-border-iron-700 tw-bg-black tw-p-3"
+              key={draft.id}
+            >
+              <div className="tw-min-w-0">
+                <p className="tw-truncate tw-text-sm tw-font-semibold tw-text-white">
+                  {t(locale, "profileCms.builder.drafts.version", {
+                    version: formatInteger(locale, draft.version),
+                  })}{" "}
+                  · {t(locale, getDraftStatusLabelKey(draft.status))}
+                </p>
+                <p className="tw-mt-1 tw-truncate tw-font-mono tw-text-xs tw-text-iron-500">
+                  {draft.packageHash}
+                </p>
+              </div>
+              <button
+                className="tw-min-h-9 tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-px-3 tw-text-sm tw-text-iron-100 hover:tw-border-primary-400 disabled:tw-cursor-not-allowed disabled:tw-opacity-50"
+                disabled={!canRequest || !!loadingDraftId}
+                onClick={() => onLoadDraft(draft)}
+                type="button"
+              >
+                {loadingDraftId === draft.id
+                  ? t(locale, "profileCms.builder.drafts.loading")
+                  : t(locale, "profileCms.builder.drafts.load")}
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
     </section>
   );
 }
@@ -1657,6 +1839,8 @@ function getActionResultMessage(
       return t(locale, "profileCms.builder.api.failed");
     case "server_validation_completed":
       return t(locale, "profileCms.builder.api.serverValidationCompleted");
+    case "server_validation_invalid":
+      return t(locale, "profileCms.builder.api.serverValidationInvalid");
     case "draft_saved":
       return t(locale, "profileCms.builder.api.draftSaved");
   }
@@ -1686,6 +1870,27 @@ function getBlockLabelKey(
     BLOCK_OPTIONS.find((option) => option.kind === kind)?.labelKey ??
     "profileCms.builder.block.heading"
   );
+}
+
+function getDraftStatusLabelKey(
+  status: ProfileCmsPackageRecord["status"]
+): Parameters<typeof t>[1] {
+  switch (status) {
+    case "draft":
+      return "profileCms.builder.drafts.status.draft";
+    case "validating":
+      return "profileCms.builder.drafts.status.validating";
+    case "published":
+      return "profileCms.builder.drafts.status.published";
+    case "failed":
+      return "profileCms.builder.drafts.status.failed";
+    case "archived":
+      return "profileCms.builder.drafts.status.archived";
+    case "superseded":
+      return "profileCms.builder.drafts.status.superseded";
+    default:
+      return "profileCms.builder.drafts.status.draft";
+  }
 }
 
 function getValidationSeverityKey(

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -1215,6 +1215,10 @@ export const EN_US_MESSAGES = {
     "Fixture snapshot used until the gallery backend snapshot endpoint is enabled.",
   "profileCms.builder.gallery.snapshot.warning.partialMedia":
     "Some media may be pending or unavailable in the reviewed snapshot.",
+  "profileCms.builder.gallery.snapshot.warning.unresolvedWallets":
+    "Some wallet entries could not be resolved and are not part of this snapshot.",
+  "profileCms.builder.gallery.snapshot.warning.truncated":
+    "The snapshot hit the asset limit, so some indexed works are not shown.",
   "profileCms.builder.gallery.review.title": "Snapshot review",
   "profileCms.builder.gallery.review.description":
     "Review the frozen wallet snapshot before saving the generated gallery package.",
@@ -1385,7 +1389,24 @@ export const EN_US_MESSAGES = {
     "Publishing needs the signed decentralized storage flow and is not enabled in this MVP.",
   "profileCms.builder.api.serverValidationCompleted":
     "Server validation completed.",
+  "profileCms.builder.api.serverValidationInvalid":
+    "Server validation found blocking issues in this package.",
   "profileCms.builder.api.draftSaved": "Draft saved.",
+  "profileCms.builder.drafts.title": "Saved drafts",
+  "profileCms.builder.drafts.refresh": "Refresh drafts",
+  "profileCms.builder.drafts.loading": "Loading...",
+  "profileCms.builder.drafts.failed": "Could not load saved drafts.",
+  "profileCms.builder.drafts.empty": "No saved drafts yet.",
+  "profileCms.builder.drafts.version": "Version {version}",
+  "profileCms.builder.drafts.load": "Load",
+  "profileCms.builder.drafts.status.draft": "Draft",
+  "profileCms.builder.drafts.status.validating": "Validating",
+  "profileCms.builder.drafts.status.published": "Published",
+  "profileCms.builder.drafts.status.failed": "Failed",
+  "profileCms.builder.drafts.status.archived": "Archived",
+  "profileCms.builder.drafts.status.superseded": "Superseded",
+  "profileCms.builder.drafts.loadFailed":
+    "This draft could not be loaded into the editor.",
   ...USER_COLLECTED_STATS_MESSAGES,
   ...USER_COLLECTED_STATS_DETAILS_MESSAGES,
   ...USER_COLLECTED_STATS_BOOST_MESSAGES,

--- a/lib/profile-cms/builder/api.ts
+++ b/lib/profile-cms/builder/api.ts
@@ -1,22 +1,36 @@
 import { isProfileCmsBuilderApiEnabledEnv } from "@/config/profileCmsBuilderEnv";
+import type { ApiProfileCmsValidationResult } from "@/generated/models/ApiProfileCmsValidationResult";
+import type { ApiProfileCmsWalletGallerySnapshot } from "@/generated/models/ApiProfileCmsWalletGallerySnapshot";
 import {
   createMockWalletGallerySnapshot,
   type WalletGallerySnapshot,
-  type WalletGallerySnapshotAsset,
-  type WalletGallerySnapshotCollection,
-  type WalletGallerySnapshotSource,
   type WalletGallerySource,
 } from "@/lib/profile-cms/builder/gallery";
+import { normalizeWalletGallerySnapshotResponse } from "@/lib/profile-cms/builder/gallery-normalize";
+import {
+  normalizeLoadedProfileCmsPackageRecord,
+  normalizeProfileCmsPackageRecord,
+  type LoadedProfileCmsPackageRecord,
+  type ProfileCmsPackageRecord,
+  type ProfileCmsPackageWire,
+} from "@/lib/profile-cms/builder/package-normalize";
 import type { CmsPackageV1 } from "@/lib/profile-cms/protocol/v1";
-import { commonApiPost } from "@/services/api/common-api";
+import { commonApiFetch, commonApiPost } from "@/services/api/common-api";
 
+// Real backend contract (see D:\repos\6529seize-backend
+// src/api-serverless/src/generated/routes/openapi-generated.routes.ts and
+// src/api-serverless/src/profile-cms/*.handlers.ts). Publish stays hard
+// blocked client-side below regardless of what the backend exposes.
 export const PROFILE_CMS_GALLERY_SNAPSHOT_ENDPOINT =
-  "profile-cms/gallery/snapshots";
+  "profile-cms/wallet-gallery/snapshot";
 export const PROFILE_CMS_BUILDER_PACKAGES_ENDPOINT = "profile-cms/packages";
 export const PROFILE_CMS_BUILDER_VALIDATE_ENDPOINT =
   "profile-cms/packages/validate";
 export const PROFILE_CMS_BUILDER_PUBLISH_ENDPOINT =
   "profile-cms/packages/{id}/publish";
+const PROFILE_CMS_BUILDER_PACKAGE_BY_ID_ENDPOINT = "profile-cms/packages/{id}";
+const PROFILE_CMS_BUILDER_PROFILE_PACKAGES_ENDPOINT =
+  "profile-cms/profiles/{profile_id}/packages";
 
 export type ProfileCmsBuilderAction = "save_draft" | "validate" | "publish";
 export type ProfileCmsBuilderActionCode =
@@ -27,6 +41,7 @@ export type ProfileCmsBuilderActionCode =
   | "publish_requires_signed_storage"
   | "request_failed"
   | "server_validation_completed"
+  | "server_validation_invalid"
   | "draft_saved";
 
 export type ProfileCmsBuilderActionResult =
@@ -44,49 +59,7 @@ export type ProfileCmsBuilderActionResult =
       readonly expectedEndpoint: string;
     };
 
-type BuilderActionResponse = {
-  readonly draft_id?: string | undefined;
-  readonly package_hash?: string | undefined;
-  readonly message?: string | undefined;
-};
-
-type GallerySnapshotResponse = {
-  readonly snapshot_id?: string | undefined;
-  readonly source?: string | undefined;
-  readonly wallets?: readonly {
-    readonly kind?: "address" | "ens" | undefined;
-    readonly input?: string | undefined;
-    readonly normalized?: string | undefined;
-  }[];
-  readonly captured_at?: string | undefined;
-  readonly block_number?: number | undefined;
-  readonly assets?: readonly {
-    readonly id?: string | undefined;
-    readonly title?: string | undefined;
-    readonly collection_id?: string | undefined;
-    readonly collection_name?: string | undefined;
-    readonly contract?: string | undefined;
-    readonly token_id?: string | undefined;
-    readonly chain_id?: number | undefined;
-    readonly owner?: string | undefined;
-    readonly image_uri?: string | undefined;
-    readonly mime_type?: string | undefined;
-    readonly width?: number | undefined;
-    readonly height?: number | undefined;
-    readonly metadata_uri?: string | undefined;
-    readonly media_state?: "ready" | "partial" | "missing" | undefined;
-    readonly alt_text?: string | undefined;
-  }[];
-  readonly collections?: readonly {
-    readonly id?: string | undefined;
-    readonly name?: string | undefined;
-    readonly slug?: string | undefined;
-    readonly contract?: string | undefined;
-    readonly chain_id?: number | undefined;
-    readonly asset_ids?: readonly string[] | undefined;
-  }[];
-  readonly warnings?: readonly string[] | undefined;
-};
+export type { ProfileCmsPackageRecord } from "@/lib/profile-cms/builder/package-normalize";
 
 export async function runProfileCmsBuilderAction({
   action,
@@ -138,19 +111,20 @@ export async function runProfileCmsBuilderAction({
   return {
     ok: true,
     action,
-    code: getSuccessCode(action),
-    ...(response.draft_id ? { draftId: response.draft_id } : {}),
-    ...(response.package_hash ? { packageHash: response.package_hash } : {}),
+    code:
+      response.serverValid === false
+        ? "server_validation_invalid"
+        : getSuccessCode(action),
+    ...(response.draftId ? { draftId: response.draftId } : {}),
+    ...(response.packageHash ? { packageHash: response.packageHash } : {}),
   };
 }
 
 export async function requestProfileCmsGallerySnapshot({
   handle,
-  profileId,
   sources,
 }: {
   readonly handle: string;
-  readonly profileId?: string | undefined;
   readonly sources: readonly WalletGallerySource[];
 }): Promise<WalletGallerySnapshot> {
   if (!isProfileCmsBuilderApiEnabledEnv()) {
@@ -158,29 +132,60 @@ export async function requestProfileCmsGallerySnapshot({
   }
 
   const response = await commonApiPost<
-    {
-      readonly profile_id?: string | undefined;
-      readonly wallets: readonly {
-        readonly kind: WalletGallerySource["kind"];
-        readonly input: string;
-        readonly normalized: string;
-      }[];
-    },
-    GallerySnapshotResponse
+    { readonly wallets: readonly string[] },
+    ApiProfileCmsWalletGallerySnapshot
   >({
     endpoint: PROFILE_CMS_GALLERY_SNAPSHOT_ENDPOINT,
     body: {
-      ...(profileId ? { profile_id: profileId } : {}),
-      wallets: sources.map((source) => ({
-        kind: source.kind,
-        input: source.input,
-        normalized: source.normalized,
-      })),
+      wallets: sources.map((source) => source.normalized),
     },
     errorMode: "structured",
   });
 
-  return normalizeGallerySnapshotResponse(response, sources);
+  return normalizeWalletGallerySnapshotResponse(response, sources);
+}
+
+/**
+ * List saved drafts (and any published/archived versions) for a profile.
+ * Backing endpoint: `GET profile-cms/profiles/:profile_id/packages`.
+ */
+export async function listProfileCmsPackagesForProfile(
+  profileId: string
+): Promise<readonly ProfileCmsPackageRecord[]> {
+  assertProfileCmsBuilderApiEnabled();
+  const response = await commonApiFetch<readonly ProfileCmsPackageWire[]>({
+    endpoint: PROFILE_CMS_BUILDER_PROFILE_PACKAGES_ENDPOINT.replace(
+      "{profile_id}",
+      encodeURIComponent(profileId)
+    ),
+  });
+
+  return response.map(normalizeProfileCmsPackageRecord);
+}
+
+/**
+ * Load a single saved draft/package by id, including its CMS package payload
+ * (validated against the local V1 schema before it can enter editor state).
+ * Backing endpoint: `GET profile-cms/packages/:id`.
+ */
+export async function getProfileCmsPackageById(
+  id: string
+): Promise<LoadedProfileCmsPackageRecord> {
+  assertProfileCmsBuilderApiEnabled();
+  const response = await commonApiFetch<ProfileCmsPackageWire>({
+    endpoint: PROFILE_CMS_BUILDER_PACKAGE_BY_ID_ENDPOINT.replace(
+      "{id}",
+      encodeURIComponent(id)
+    ),
+  });
+
+  return normalizeLoadedProfileCmsPackageRecord(response);
+}
+
+function assertProfileCmsBuilderApiEnabled(): void {
+  if (!isProfileCmsBuilderApiEnabledEnv()) {
+    throw new Error("profile_cms_builder_api_disabled");
+  }
 }
 
 function getEndpoint({
@@ -205,6 +210,12 @@ function getEndpoint({
   }
 }
 
+type BuilderActionResponse = {
+  readonly draftId?: string | undefined;
+  readonly packageHash?: string | undefined;
+  readonly serverValid?: boolean | undefined;
+};
+
 async function postBuilderAction({
   action,
   cmsPackage,
@@ -217,24 +228,29 @@ async function postBuilderAction({
   readonly profileId?: string | undefined;
 }): Promise<BuilderActionResponse> {
   switch (action) {
-    case "save_draft":
-      return await commonApiPost<
+    case "save_draft": {
+      const response = await commonApiPost<
         { readonly cms_package: CmsPackageV1; readonly profile_id: string },
-        BuilderActionResponse
+        ProfileCmsPackageWire
       >({
         endpoint,
         body: { profile_id: profileId ?? "", cms_package: cmsPackage },
         errorMode: "structured",
       });
-    case "validate":
-      return await commonApiPost<
+      return {
+        draftId: response.id,
+        packageHash: response.package_hash,
+      };
+    }
+    case "validate": {
+      const response = await commonApiPost<
         {
           readonly allow_fixture_signatures: boolean;
           readonly allow_fixture_storage: boolean;
           readonly cms_package: CmsPackageV1;
           readonly enforce_hashes: boolean;
         },
-        BuilderActionResponse
+        ApiProfileCmsValidationResult
       >({
         endpoint,
         body: {
@@ -245,6 +261,12 @@ async function postBuilderAction({
         },
         errorMode: "structured",
       });
+      return {
+        draftId: response.target?.draft_id,
+        packageHash: response.target?.package_hash,
+        serverValid: response.valid,
+      };
+    }
     case "publish":
       throw new Error("unsupported_publish_action");
   }
@@ -261,152 +283,4 @@ function getSuccessCode(
     case "publish":
       return "publish_requires_signed_storage";
   }
-}
-
-function normalizeGallerySnapshotResponse(
-  response: GallerySnapshotResponse,
-  requestedSources: readonly WalletGallerySource[]
-): WalletGallerySnapshot {
-  const wallets = normalizeWallets(response.wallets, requestedSources);
-  const assets = normalizeSnapshotAssets(response.assets);
-  const collections = normalizeSnapshotCollections(
-    response.collections,
-    assets
-  );
-  const source = normalizeGallerySnapshotSource(response.source);
-
-  return {
-    snapshotId: response.snapshot_id ?? `${source}-${Date.now()}`,
-    source,
-    wallets,
-    capturedAt: response.captured_at ?? new Date().toISOString(),
-    ...(response.block_number !== undefined
-      ? { blockNumber: response.block_number }
-      : {}),
-    assets,
-    collections,
-    warnings: response.warnings ?? [],
-  };
-}
-
-function normalizeGallerySnapshotSource(
-  source: GallerySnapshotResponse["source"]
-): WalletGallerySnapshotSource {
-  return source === "fixture" ? "fixture" : "backend";
-}
-
-function normalizeWallets(
-  wallets: GallerySnapshotResponse["wallets"],
-  fallback: readonly WalletGallerySource[]
-): readonly WalletGallerySource[] {
-  const normalized = wallets
-    ?.map((wallet): WalletGallerySource | null => {
-      if (!wallet.kind || !wallet.normalized) {
-        return null;
-      }
-
-      return {
-        kind: wallet.kind,
-        input: wallet.input ?? wallet.normalized,
-        normalized: wallet.normalized,
-      };
-    })
-    .filter((wallet): wallet is WalletGallerySource => !!wallet);
-
-  return normalized?.length ? normalized : fallback;
-}
-
-function normalizeSnapshotAssets(
-  assets: GallerySnapshotResponse["assets"]
-): readonly WalletGallerySnapshotAsset[] {
-  return (
-    assets
-      ?.map((asset): WalletGallerySnapshotAsset | null => {
-        if (
-          !asset.id ||
-          !asset.title ||
-          !asset.collection_id ||
-          !asset.collection_name ||
-          !asset.contract ||
-          !asset.token_id ||
-          !asset.owner
-        ) {
-          return null;
-        }
-
-        return {
-          id: asset.id,
-          title: asset.title,
-          collectionId: asset.collection_id,
-          collectionName: asset.collection_name,
-          contract: asset.contract,
-          tokenId: asset.token_id,
-          chainId: asset.chain_id ?? 1,
-          owner: asset.owner,
-          ...(asset.image_uri ? { imageUri: asset.image_uri } : {}),
-          ...(asset.mime_type ? { mimeType: asset.mime_type } : {}),
-          ...(asset.width ? { width: asset.width } : {}),
-          ...(asset.height ? { height: asset.height } : {}),
-          ...(asset.metadata_uri ? { metadataUri: asset.metadata_uri } : {}),
-          mediaState:
-            asset.media_state ?? (asset.image_uri ? "ready" : "partial"),
-          altText: asset.alt_text ?? asset.title,
-        };
-      })
-      .filter((asset): asset is WalletGallerySnapshotAsset => !!asset) ?? []
-  );
-}
-
-function normalizeSnapshotCollections(
-  collections: GallerySnapshotResponse["collections"],
-  assets: readonly WalletGallerySnapshotAsset[]
-): readonly WalletGallerySnapshotCollection[] {
-  const normalized =
-    collections
-      ?.map((collection): WalletGallerySnapshotCollection | null => {
-        if (
-          !collection.id ||
-          !collection.name ||
-          !collection.slug ||
-          !collection.contract
-        ) {
-          return null;
-        }
-
-        return {
-          id: collection.id,
-          name: collection.name,
-          slug: collection.slug,
-          contract: collection.contract,
-          chainId: collection.chain_id ?? 1,
-          assetIds: collection.asset_ids ?? [],
-        };
-      })
-      .filter(
-        (collection): collection is WalletGallerySnapshotCollection =>
-          !!collection
-      ) ?? [];
-
-  if (normalized.length) {
-    return normalized;
-  }
-
-  const byCollection = new Map<string, WalletGallerySnapshotAsset[]>();
-  assets.forEach((asset) => {
-    const current = byCollection.get(asset.collectionId) ?? [];
-    byCollection.set(asset.collectionId, [...current, asset]);
-  });
-
-  return [...byCollection.entries()].map(([collectionId, collectionAssets]) => {
-    const firstAsset = collectionAssets[0];
-    return {
-      id: collectionId,
-      name: firstAsset?.collectionName ?? "Collection",
-      slug: collectionId.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
-      contract:
-        firstAsset?.contract ?? "0x0000000000000000000000000000000000000000",
-      chainId: firstAsset?.chainId ?? 1,
-      assetIds: collectionAssets.map((asset) => asset.id),
-    };
-  });
 }

--- a/lib/profile-cms/builder/api.ts
+++ b/lib/profile-cms/builder/api.ts
@@ -1,4 +1,5 @@
 import { isProfileCmsBuilderApiEnabledEnv } from "@/config/profileCmsBuilderEnv";
+import type { ApiProfileCmsValidationIssue } from "@/generated/models/ApiProfileCmsValidationIssue";
 import type { ApiProfileCmsValidationResult } from "@/generated/models/ApiProfileCmsValidationResult";
 import type { ApiProfileCmsWalletGallerySnapshot } from "@/generated/models/ApiProfileCmsWalletGallerySnapshot";
 import {
@@ -57,6 +58,14 @@ export type ProfileCmsBuilderActionResult =
       readonly action: ProfileCmsBuilderAction;
       readonly code: ProfileCmsBuilderActionCode;
       readonly expectedEndpoint: string;
+      // A rejected server validation is a completed request whose outcome is
+      // "not valid": the server can still return the validation target (and,
+      // if it persisted one, a draft id) plus the blocking issues to display.
+      readonly draftId?: string | undefined;
+      readonly packageHash?: string | undefined;
+      readonly serverIssues?:
+        | readonly ApiProfileCmsValidationIssue[]
+        | undefined;
     };
 
 export type { ProfileCmsPackageRecord } from "@/lib/profile-cms/builder/package-normalize";
@@ -108,13 +117,22 @@ export async function runProfileCmsBuilderAction({
     profileId,
   });
 
+  if (response.serverValid === false) {
+    return {
+      ok: false,
+      action,
+      code: "server_validation_invalid",
+      expectedEndpoint: endpoint,
+      ...(response.draftId ? { draftId: response.draftId } : {}),
+      ...(response.packageHash ? { packageHash: response.packageHash } : {}),
+      ...(response.issues?.length ? { serverIssues: response.issues } : {}),
+    };
+  }
+
   return {
     ok: true,
     action,
-    code:
-      response.serverValid === false
-        ? "server_validation_invalid"
-        : getSuccessCode(action),
+    code: getSuccessCode(action),
     ...(response.draftId ? { draftId: response.draftId } : {}),
     ...(response.packageHash ? { packageHash: response.packageHash } : {}),
   };
@@ -214,6 +232,7 @@ type BuilderActionResponse = {
   readonly draftId?: string | undefined;
   readonly packageHash?: string | undefined;
   readonly serverValid?: boolean | undefined;
+  readonly issues?: readonly ApiProfileCmsValidationIssue[] | undefined;
 };
 
 async function postBuilderAction({
@@ -265,6 +284,7 @@ async function postBuilderAction({
         draftId: response.target?.draft_id,
         packageHash: response.target?.package_hash,
         serverValid: response.valid,
+        issues: response.issues,
       };
     }
     case "publish":

--- a/lib/profile-cms/builder/gallery-normalize.ts
+++ b/lib/profile-cms/builder/gallery-normalize.ts
@@ -75,6 +75,12 @@ function normalizeWallets(
       if (!normalizedValue) {
         return null;
       }
+      // A resolved ENS input carries both `ens` and `address`. It is mapped
+      // as kind "address" with normalized=address on purpose: package
+      // generation picks profile.primary_wallet from the first
+      // kind==="address" source (gallery.ts getPrimaryAddress), and the
+      // review UI only renders wallet counts — the original ENS string stays
+      // available on `input` if a display name is ever needed.
       return {
         kind: wallet.ens && !wallet.address ? "ens" : "address",
         input: wallet.input,

--- a/lib/profile-cms/builder/gallery-normalize.ts
+++ b/lib/profile-cms/builder/gallery-normalize.ts
@@ -1,0 +1,209 @@
+// Maps the real backend wallet-gallery snapshot response
+// (POST profile-cms/wallet-gallery/snapshot, snake_case, see
+// D:\repos\6529seize-backend
+// src/api-serverless/src/profile-cms/wallet-gallery.api.service.ts and the
+// generated ApiProfileCmsWalletGallery* models) into the frontend builder's
+// existing camelCase WalletGallerySnapshot review model. The wallet parser
+// and curation UI (gallery.ts / ProfileCmsBuilder.tsx) are unchanged; only
+// this response-mapping layer is new.
+import type { ApiProfileCmsWalletGalleryAsset } from "@/generated/models/ApiProfileCmsWalletGalleryAsset";
+import type { ApiProfileCmsWalletGalleryExcludedAsset } from "@/generated/models/ApiProfileCmsWalletGalleryExcludedAsset";
+import type { ApiProfileCmsWalletGallerySnapshot } from "@/generated/models/ApiProfileCmsWalletGallerySnapshot";
+import type { ApiProfileCmsWalletGalleryWallet } from "@/generated/models/ApiProfileCmsWalletGalleryWallet";
+import {
+  WALLET_GALLERY_BACKEND_WARNING_CODES,
+  type WalletGallerySnapshot,
+  type WalletGallerySnapshotAsset,
+  type WalletGallerySnapshotCollection,
+  type WalletGallerySnapshotExcludedAsset,
+  type WalletGallerySnapshotTotals,
+  type WalletGallerySource,
+} from "@/lib/profile-cms/builder/gallery";
+import { slugifyBuilderId, toNullableString } from "./normalize";
+
+const DEFAULT_CHAIN_ID = 1;
+
+export function normalizeWalletGallerySnapshotResponse(
+  response: ApiProfileCmsWalletGallerySnapshot,
+  requestedSources: readonly WalletGallerySource[]
+): WalletGallerySnapshot {
+  const wallets = normalizeWallets(response.wallets, requestedSources);
+  const assets = normalizeAssets(response.assets);
+  const collections = deriveCollectionsFromAssets(assets);
+  const excludedAssets = normalizeExcludedAssets(response.excluded_assets);
+  const totals = normalizeTotals(response);
+
+  return {
+    snapshotId: `backend-${response.generated_at}`,
+    source: "backend",
+    wallets,
+    capturedAt: new Date(response.generated_at).toISOString(),
+    ...(response.block_reference
+      ? { blockNumber: response.block_reference }
+      : {}),
+    assets,
+    collections,
+    excludedAssets,
+    totals,
+    warnings: getWarnings(totals),
+  };
+}
+
+function getWarnings(
+  totals: WalletGallerySnapshotTotals | undefined
+): string[] {
+  if (!totals) {
+    return [];
+  }
+  const warnings: string[] = [];
+  if (totals.unresolvedWallets > 0) {
+    warnings.push(WALLET_GALLERY_BACKEND_WARNING_CODES.unresolvedWallets);
+  }
+  if (totals.truncated) {
+    warnings.push(WALLET_GALLERY_BACKEND_WARNING_CODES.truncated);
+  }
+  return warnings;
+}
+
+function normalizeWallets(
+  wallets: readonly ApiProfileCmsWalletGalleryWallet[] | undefined,
+  fallback: readonly WalletGallerySource[]
+): readonly WalletGallerySource[] {
+  const normalized = (wallets ?? [])
+    .map((wallet): WalletGallerySource | null => {
+      const normalizedValue = wallet.address ?? wallet.ens;
+      if (!normalizedValue) {
+        return null;
+      }
+      return {
+        kind: wallet.ens && !wallet.address ? "ens" : "address",
+        input: wallet.input,
+        normalized: normalizedValue,
+      };
+    })
+    .filter((wallet): wallet is WalletGallerySource => !!wallet);
+
+  return normalized.length ? normalized : fallback;
+}
+
+function normalizeAssets(
+  assets: readonly ApiProfileCmsWalletGalleryAsset[] | undefined
+): readonly WalletGallerySnapshotAsset[] {
+  return (assets ?? []).map(toSnapshotAsset);
+}
+
+function toSnapshotAsset(
+  asset: ApiProfileCmsWalletGalleryAsset
+): WalletGallerySnapshotAsset {
+  const tokenId = String(asset.token_id);
+  const fullImage = toNullableString(asset.media.image ?? undefined);
+  const imageUri =
+    fullImage ??
+    toNullableString(
+      asset.media.image_preview ?? asset.media.thumbnail ?? undefined
+    );
+  const mimeType = toNullableString(asset.media.mime_type ?? undefined);
+  const title =
+    toNullableString(asset.name) ?? `${asset.collection} #${tokenId}`;
+
+  return {
+    // Owner-scoped key: the same ERC1155 token can be indexed once per owned
+    // wallet, and curation ids must stay unique within the snapshot.
+    id: getAssetKey(asset.contract, tokenId, asset.owner_wallet),
+    title,
+    collectionId: asset.collection_key,
+    collectionName: asset.collection,
+    contract: asset.contract,
+    tokenId,
+    chainId: DEFAULT_CHAIN_ID,
+    owner: asset.owner_wallet,
+    ...(imageUri ? { imageUri } : {}),
+    ...(mimeType ? { mimeType } : {}),
+    mediaState: getMediaState(asset, fullImage, imageUri),
+    altText: title,
+    flags: {
+      spam: asset.flags.spam,
+      excluded: asset.flags.excluded,
+      ...(asset.flags.exclusion_reason
+        ? { reason: asset.flags.exclusion_reason }
+        : {}),
+    },
+  };
+}
+
+function getMediaState(
+  asset: ApiProfileCmsWalletGalleryAsset,
+  fullImage: string | undefined,
+  imageUri: string | undefined
+): WalletGallerySnapshotAsset["mediaState"] {
+  if (fullImage) {
+    return "ready";
+  }
+  const hasOtherMedia =
+    !!imageUri ||
+    !!toNullableString(
+      asset.media.animation ?? asset.media.animation_preview ?? undefined
+    );
+  return hasOtherMedia ? "partial" : "missing";
+}
+
+function deriveCollectionsFromAssets(
+  assets: readonly WalletGallerySnapshotAsset[]
+): readonly WalletGallerySnapshotCollection[] {
+  const byCollection = new Map<string, WalletGallerySnapshotAsset[]>();
+  assets.forEach((asset) => {
+    const current = byCollection.get(asset.collectionId) ?? [];
+    byCollection.set(asset.collectionId, [...current, asset]);
+  });
+
+  return [...byCollection.entries()].map(([collectionId, collectionAssets]) => {
+    const firstAsset = collectionAssets[0];
+    return {
+      id: collectionId,
+      name: firstAsset?.collectionName ?? collectionId,
+      slug: slugifyBuilderId(collectionId),
+      contract:
+        firstAsset?.contract ?? "0x0000000000000000000000000000000000000000",
+      chainId: firstAsset?.chainId ?? DEFAULT_CHAIN_ID,
+      assetIds: collectionAssets.map((asset) => asset.id),
+    };
+  });
+}
+
+function normalizeExcludedAssets(
+  excludedAssets: readonly ApiProfileCmsWalletGalleryExcludedAsset[] | undefined
+): readonly WalletGallerySnapshotExcludedAsset[] {
+  return (excludedAssets ?? []).map((excluded) => ({
+    contract: excluded.contract,
+    tokenId: String(excluded.token_id),
+    owner: excluded.owner_wallet,
+    reason: excluded.reason,
+  }));
+}
+
+function normalizeTotals(
+  response: ApiProfileCmsWalletGallerySnapshot
+): WalletGallerySnapshotTotals | undefined {
+  const totals = response.totals;
+  if (!totals) {
+    return undefined;
+  }
+  return {
+    requestedWallets: totals.requested_wallets,
+    resolvedWallets: totals.resolved_wallets,
+    unresolvedWallets: totals.unresolved_wallets,
+    indexedAssets: totals.indexed_assets,
+    visibleAssets: totals.visible_assets,
+    excludedAssets: totals.excluded_assets,
+    spamAssets: totals.spam_assets,
+    truncated: totals.truncated,
+  };
+}
+
+function getAssetKey(
+  contract: string,
+  tokenId: string,
+  ownerWallet: string
+): string {
+  return `${contract.toLowerCase()}:${tokenId}:${ownerWallet.toLowerCase()}`;
+}

--- a/lib/profile-cms/builder/gallery.ts
+++ b/lib/profile-cms/builder/gallery.ts
@@ -1,4 +1,5 @@
 import { detectEnsTarget } from "@/lib/ens/detect";
+import { slugifyBuilderId } from "@/lib/profile-cms/builder/normalize";
 import {
   CMS_CANONICALIZATION,
   CMS_HASH_ALGORITHM,
@@ -32,6 +33,12 @@ type WalletGalleryInputResult =
       readonly errors: readonly string[];
     };
 
+export type WalletGallerySnapshotAssetFlags = {
+  readonly spam: boolean;
+  readonly excluded: boolean;
+  readonly reason?: string | undefined;
+};
+
 export type WalletGallerySnapshotAsset = {
   readonly id: string;
   readonly title: string;
@@ -48,6 +55,13 @@ export type WalletGallerySnapshotAsset = {
   readonly metadataUri?: string | undefined;
   readonly mediaState: "ready" | "partial" | "missing";
   readonly altText: string;
+  /**
+   * Curation flags. Mirrors the backend's per-asset `flags` (spam/excluded
+   * with an optional reason) so the review UI can eventually surface backend
+   * exclusions, even though the wallet-gallery snapshot endpoint already
+   * removes excluded assets into `excludedAssets` before this array is built.
+   */
+  readonly flags: WalletGallerySnapshotAssetFlags;
 };
 
 export type WalletGallerySnapshotCollection = {
@@ -57,6 +71,24 @@ export type WalletGallerySnapshotCollection = {
   readonly contract: string;
   readonly chainId: number;
   readonly assetIds: readonly string[];
+};
+
+export type WalletGallerySnapshotExcludedAsset = {
+  readonly contract: string;
+  readonly tokenId: string;
+  readonly owner: string;
+  readonly reason: string;
+};
+
+export type WalletGallerySnapshotTotals = {
+  readonly requestedWallets: number;
+  readonly resolvedWallets: number;
+  readonly unresolvedWallets: number;
+  readonly indexedAssets: number;
+  readonly visibleAssets: number;
+  readonly excludedAssets: number;
+  readonly spamAssets: number;
+  readonly truncated: boolean;
 };
 
 export type WalletGallerySnapshotSource = "backend" | "fixture";
@@ -69,6 +101,8 @@ export type WalletGallerySnapshot = {
   readonly blockNumber?: number | undefined;
   readonly assets: readonly WalletGallerySnapshotAsset[];
   readonly collections: readonly WalletGallerySnapshotCollection[];
+  readonly excludedAssets: readonly WalletGallerySnapshotExcludedAsset[];
+  readonly totals?: WalletGallerySnapshotTotals | undefined;
   readonly warnings: readonly string[];
 };
 
@@ -97,6 +131,14 @@ type WalletGalleryPackageOptions = {
 export const WALLET_GALLERY_FIXTURE_WARNING_CODES = {
   backendDisabled: "fixture_snapshot_backend_disabled",
   partialMedia: "fixture_snapshot_partial_media",
+} as const;
+
+// Frontend-authored warning codes derived from the real backend
+// wallet-gallery snapshot totals (unresolved wallet inputs, truncated asset
+// list). Rendered through profileCms.builder.gallery.snapshot.warning.* keys.
+export const WALLET_GALLERY_BACKEND_WARNING_CODES = {
+  unresolvedWallets: "backend_snapshot_unresolved_wallets",
+  truncated: "backend_snapshot_truncated",
 } as const;
 
 const FIXTURE_ZERO_HASH =
@@ -195,6 +237,7 @@ export function createMockWalletGallerySnapshot({
       metadataUri: "ipfs://bafyfixturegallery/metadata/1.json",
       mediaState: "ready",
       altText: "The Memes by 6529 card number 1",
+      flags: { spam: false, excluded: false },
     },
     {
       id: "work-memes-2",
@@ -212,6 +255,7 @@ export function createMockWalletGallerySnapshot({
       metadataUri: "ipfs://bafyfixturegallery/metadata/2.json",
       mediaState: "ready",
       altText: "The Memes by 6529 card number 2",
+      flags: { spam: false, excluded: false },
     },
     {
       id: "work-memes-partial",
@@ -225,6 +269,7 @@ export function createMockWalletGallerySnapshot({
       metadataUri: "ipfs://bafyfixturegallery/metadata/404.json",
       mediaState: "partial",
       altText: "NFT metadata was found but preview media is pending",
+      flags: { spam: false, excluded: false },
     },
   ];
 
@@ -237,6 +282,7 @@ export function createMockWalletGallerySnapshot({
     capturedAt,
     blockNumber: 22000000,
     assets,
+    excludedAssets: [],
     collections: [
       {
         id: "collection-the-memes",
@@ -727,28 +773,7 @@ function getNftPageId(assetId: string, index: number): string {
   return `page-nft-${slugify(assetId) || index + 1}`;
 }
 
-function slugify(value: string): string {
-  const normalized = value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-");
-  return trimHyphenEdges(normalized).slice(0, 80) || "item";
-}
-
-function trimHyphenEdges(value: string): string {
-  let start = 0;
-  let end = value.length;
-
-  while (start < end && value[start] === "-") {
-    start += 1;
-  }
-
-  while (end > start && value[end - 1] === "-") {
-    end -= 1;
-  }
-
-  return value.slice(start, end);
-}
+const slugify = slugifyBuilderId;
 
 function normalizeHandle(value: string): string {
   const normalized = value

--- a/lib/profile-cms/builder/normalize.ts
+++ b/lib/profile-cms/builder/normalize.ts
@@ -1,0 +1,33 @@
+// Shared snake_case (backend) -> camelCase (frontend builder) normalization
+// helpers. Centralized here so gallery.ts, package.ts, and api.ts do not
+// duplicate the same small string/slug/id transforms (Sonar duplication
+// budget is tight for this lane).
+
+export function slugifyBuilderId(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-");
+  return trimHyphenEdges(normalized).slice(0, 80) || "item";
+}
+
+function trimHyphenEdges(value: string): string {
+  let start = 0;
+  let end = value.length;
+
+  while (start < end && value[start] === "-") {
+    start += 1;
+  }
+
+  while (end > start && value[end - 1] === "-") {
+    end -= 1;
+  }
+
+  return value.slice(start, end);
+}
+
+export function toNullableString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+}

--- a/lib/profile-cms/builder/package-normalize.ts
+++ b/lib/profile-cms/builder/package-normalize.ts
@@ -1,0 +1,79 @@
+// Maps the real backend ApiProfileCmsPackage record (snake_case, see the
+// backend repo's src/api-serverless/src/profile-cms/profile-cms.handlers.ts
+// and src/api-serverless/src/generated/models/ApiProfileCmsPackage.ts) into a
+// small camelCase record the builder drafts list/load UI can render, without
+// requiring every consumer to know the wire field names.
+import type { ApiProfileCmsPackage } from "@/generated/models/ApiProfileCmsPackage";
+import {
+  validateCmsPackageV1,
+  type CmsPackageV1,
+} from "@/lib/profile-cms/protocol/v1";
+
+// The OpenAPI generator aliases the on-wire `package` field to `_package` in
+// the generated client class; plain JSON responses keep the original
+// `package` key, so the adapter reads the wire shape directly.
+export type ProfileCmsPackageWire = Omit<ApiProfileCmsPackage, "_package"> & {
+  readonly package: unknown;
+};
+
+type ProfileCmsPackageStatus = `${ApiProfileCmsPackage["status"]}`;
+
+export type ProfileCmsPackageRecord = {
+  readonly id: string;
+  readonly profileId: string;
+  readonly profileHandle: string;
+  readonly packageId: string;
+  readonly version: number;
+  readonly status: ProfileCmsPackageStatus;
+  readonly packageHash: string;
+  readonly payloadHash: string;
+  readonly updatedAt: string;
+  readonly createdAt: string;
+  readonly publishedAt?: string | undefined;
+};
+
+export type LoadedProfileCmsPackageRecord = ProfileCmsPackageRecord & {
+  readonly cmsPackage: CmsPackageV1;
+};
+
+export function normalizeProfileCmsPackageRecord(
+  record: ProfileCmsPackageWire
+): ProfileCmsPackageRecord {
+  return {
+    id: record.id,
+    profileId: record.profile_id,
+    profileHandle: record.profile_handle,
+    packageId: record.package_id,
+    version: record.version,
+    status: record.status,
+    packageHash: record.package_hash,
+    payloadHash: record.payload_hash,
+    updatedAt: new Date(record.updated_at).toISOString(),
+    createdAt: new Date(record.created_at).toISOString(),
+    ...(record.published_at === undefined
+      ? {}
+      : { publishedAt: new Date(record.published_at).toISOString() }),
+  };
+}
+
+// Hashes are not re-enforced here: a stored draft may predate local edits and
+// the builder recomputes hashes before every save/validate anyway. Structural
+// V1 validation still rejects malformed stored payloads before they can crash
+// the editor state import.
+export function normalizeLoadedProfileCmsPackageRecord(
+  record: ProfileCmsPackageWire
+): LoadedProfileCmsPackageRecord {
+  const validation = validateCmsPackageV1(record.package, {
+    allowFixtureSignatures: true,
+    allowFixtureStorage: true,
+    enforceHashes: false,
+  });
+  if (!validation.valid) {
+    throw new Error("invalid_profile_cms_package");
+  }
+
+  return {
+    ...normalizeProfileCmsPackageRecord(record),
+    cmsPackage: record.package as CmsPackageV1,
+  };
+}

--- a/ops/workstreams/profile-native-cms-roadmap/builder-mvp-integration-assumptions.md
+++ b/ops/workstreams/profile-native-cms-roadmap/builder-mvp-integration-assumptions.md
@@ -1,6 +1,8 @@
 # Builder MVP Integration Assumptions
 
-Last updated: 2026-06-18.
+Last updated: 2026-07-05 (aligned to the real backend contract that landed on
+`6529seize-backend` main; the "expected" endpoint shapes below were replaced
+with the actual generated `ApiProfileCms*` models).
 
 ## Scope
 
@@ -45,31 +47,42 @@ canonicalization semantics.
   chain/contract/token data and point room placements at the existing NFT detail
   convention when that data is available.
 
-## Expected Backend Write API
+## Backend Write API (real contract)
 
-The frontend adapter is localized under `lib/profile-cms/builder/api.ts`.
-Backend models can replace that boundary later.
+The frontend adapter is localized under `lib/profile-cms/builder/api.ts` and
+now targets the real backend routes. Response models are the generated
+`ApiProfileCms*` OpenAPI models (already present in the frontend
+`generated/models/` output).
 
-Expected endpoints:
+Real endpoints used by the builder:
 
 ```ts
 POST /api/profile-cms/packages
 body: { profile_id: string, cms_package: CmsPackageV1 }
-returns: { draft_id: string, package_hash: string, message?: string }
+returns: ApiProfileCmsPackage
+  // { id, package, profile_id, profile_handle, package_id, version,
+  //   status, package_hash, payload_hash, updated_at, created_at,
+  //   published_at? } — epoch-millis timestamps, snake_case keys
 
 POST /api/profile-cms/packages/validate
 body: {
   cms_package: CmsPackageV1,
-  allow_fixture_signatures: boolean,
-  allow_fixture_storage: boolean,
-  enforce_hashes: boolean
+  allow_fixture_signatures?: boolean,
+  allow_fixture_storage?: boolean,
+  enforce_hashes?: boolean
 }
-returns: { draft_id?: string, package_hash: string, message?: string }
+returns: ApiProfileCmsValidationResult
+  // { schema, valid, checked_at, issues[], target?{package_hash, draft_id} }
+
+GET /api/profile-cms/packages/{id}
+returns: ApiProfileCmsPackage
+
+GET /api/profile-cms/profiles/{profile_id}/packages
+returns: ApiProfileCmsPackage[]
 
 POST /api/profile-cms/packages/{id}/publish
-body: signed decentralized publish request fields, storage receipts, package
-      hash, payload hash, and profile authority proof (exact BE model pending)
-returns: { package_hash: string, message?: string }
+// Exists on the backend, but the frontend MVP keeps publish hard-blocked
+// until the signed decentralized storage flow is wired end to end.
 ```
 
 Frontend endpoint constants:
@@ -77,10 +90,13 @@ Frontend endpoint constants:
 - `PROFILE_CMS_BUILDER_PACKAGES_ENDPOINT = "profile-cms/packages"`
 - `PROFILE_CMS_BUILDER_VALIDATE_ENDPOINT =
   "profile-cms/packages/validate"`
+- `PROFILE_CMS_BUILDER_PACKAGE_BY_ID_ENDPOINT = "profile-cms/packages/{id}"`
+- `PROFILE_CMS_BUILDER_PROFILE_PACKAGES_ENDPOINT =
+  "profile-cms/profiles/{profile_id}/packages"`
 - `PROFILE_CMS_BUILDER_PUBLISH_ENDPOINT =
   "profile-cms/packages/{id}/publish"`
 - `PROFILE_CMS_GALLERY_SNAPSHOT_ENDPOINT =
-  "profile-cms/gallery/snapshots"`
+  "profile-cms/wallet-gallery/snapshot"`
 
 ## Wallet Gallery Snapshot And Generator Contract
 
@@ -88,47 +104,57 @@ The frontend gallery builder shell requests a reviewed wallet snapshot through
 `lib/profile-cms/builder/api.ts` and keeps the package-generation fallback under
 `lib/profile-cms/builder/gallery.ts` deliberately temporary.
 
-Expected snapshot endpoint:
+Real snapshot endpoint (see `ApiProfileCmsWalletGallerySnapshot` and
+`ProfileCmsWalletGalleryApiService#createSnapshot` in the backend):
 
 ```ts
-POST /api/profile-cms/gallery/snapshots
+POST /api/profile-cms/wallet-gallery/snapshot
 body: {
-  profile_id?: string,
-  wallets: Array<{
-    kind: "address" | "ens",
-    input: string,
-    normalized: string
-  }>
+  wallets: string[],                 // addresses or ENS names, 1-25
+  exclude_contracts?: string[],
+  exclude_assets?: Array<{ contract: string, token_id: number }>,
+  include_spam?: boolean,
+  max_assets?: number                // default 200, max 500
 }
 returns: {
-  snapshot_id: string,
-  source: "backend" | "fixture" | string,
-  wallets: Array<{ kind: "address" | "ens", input: string, normalized: string }>,
-  captured_at: string,
-  block_number?: number,
+  generated_at: number,              // epoch millis
+  source: "indexed_ownership",
+  block_reference: number,
+  wallets: Array<{
+    input: string, address: string | null, ens: string | null,
+    display: string | null, status: "resolved" | "unresolved",
+    reason: string | null
+  }>,
   assets: Array<{
-    id: string,
-    title: string,
-    collection_id: string,
-    collection_name: string,
-    contract: string,
-    token_id: string,
-    owner: string,
-    image_uri?: string,
-    media_state: "ready" | "partial" | "missing",
-    metadata_uri?: string,
-    permalink?: string
+    contract: string, token_id: number, balance: number,
+    owner_wallet: string, owner_display: string | null,
+    collection: string, collection_key: "MEMES" | "MEMELAB" | "GRADIENTS" | "NEXTGEN",
+    name: string, description: string | null, artist: string | null,
+    artist_seize_handle: string | null, token_type: string | null,
+    media: {
+      image: string | null, image_preview: string | null,
+      thumbnail: string | null, animation: string | null,
+      animation_preview: string | null, mime_type: string | null
+    },
+    metadata: unknown,
+    flags: { spam: boolean, excluded: boolean, exclusion_reason: string | null }
   }>,
-  collections: Array<{
-    id: string,
-    name: string,
-    contract?: string,
-    description?: string,
-    asset_count: number
+  excluded_assets: Array<{
+    contract: string, token_id: number, owner_wallet: string, reason: string
   }>,
-  warnings?: string[]
+  totals: {
+    requested_wallets: number, resolved_wallets: number,
+    unresolved_wallets: number, indexed_assets: number,
+    visible_assets: number, excluded_assets: number,
+    spam_assets: number, truncated: boolean
+  }
 }
 ```
+
+The adapter maps this into the existing frontend `WalletGallerySnapshot`
+review model in `lib/profile-cms/builder/gallery-normalize.ts` (collections
+are derived by grouping assets on `collection_key`; unresolved wallets and
+truncation surface as review warnings).
 
 The backend Phase 5 deterministic wallet-snapshot -> CMS V1 package generator
 is the durable source of truth for generated packages. Until that generator is


### PR DESCRIPTION
## Issue
- The Profile CMS builder's API adapter (`lib/profile-cms/builder/api.ts`) was written against an assumed backend contract before the real backend landed. The real endpoints and response shapes (generated `ApiProfileCms*` models) differ: the wallet gallery snapshot endpoint moved and returns a completely different shape, and draft save/validate return full package/validation-result models instead of the assumed `{draft_id, package_hash}` stub. Saved drafts also had no way to be listed or loaded back.

## Fix
- Re-point the adapter at the real routes and translate the real snake_case wire shapes into the existing frontend models at the adapter boundary, so the wallet parser, curation UI, and editor state flow stay unchanged. Wire the full draft lifecycle (save / server-validate / get-by-id / list-for-profile) and add a minimal saved-drafts panel so drafts are recoverable. Publish remains hard-blocked.

## Changes
- Wallet gallery snapshot: `POST profile-cms/gallery/snapshots` (assumed) is now `POST profile-cms/wallet-gallery/snapshot` with body `{ wallets: string[] }`. New `lib/profile-cms/builder/gallery-normalize.ts` maps the real response (`generated_at` epoch millis, `source: "indexed_ownership"`, `block_reference`, resolved/unresolved `wallets`, assets with `media`/`flags`, `excluded_assets`, `totals`) into the existing `WalletGallerySnapshot` review model: collections derived by grouping on `collection_key`, media state ready/partial/missing from `media.image`/previews/animations, owner-scoped asset ids (same ERC1155 token can be indexed once per owned wallet), unresolved-wallet and truncation warnings surfaced through review warning codes. Fixture fallback when the builder API flag is disabled is preserved.
- Draft lifecycle: save draft (`POST profile-cms/packages`) and server validate (`POST profile-cms/packages/validate`) now parse the real `ApiProfileCmsPackage` / `ApiProfileCmsValidationResult` responses; `GET profile-cms/packages/:id` and `GET profile-cms/profiles/:profile_id/packages` are wired via `lib/profile-cms/builder/package-normalize.ts` (the on-wire `package` key is read directly since the generated client aliases it to `_package`). Loaded packages are validated against the local V1 schema before entering editor state.
- Builder UI: new "Saved drafts" panel (refresh + per-draft load) in `components/profile-cms-builder/ProfileCmsBuilder.tsx`; reads are gated behind the builder API flag and the connected-profile owner check, load failures and invalid server validation results are surfaced honestly instead of pretending success.
- Publish: the existing client-side hard block is untouched (verified by tests).
- i18n: en-US keys only, for the drafts panel, the invalid-server-validation message, and the two new snapshot warnings. Other locales intentionally fall back to en-US per the existing builder locale policy (separate lane).
- Docs: `ops/workstreams/profile-native-cms-roadmap/builder-mvp-integration-assumptions.md` updated from "expected" to the real contract.

## Validation
- `jest __tests__/lib/profile-cms/builder __tests__/components/profile-cms-builder`: 6 suites, 59 tests, all passing, including new adapter response-mapping tests with realistic backend-shaped snake_case fixtures and a drafts list/load component flow.
- `tsc --noEmit -p tsconfig.typecheck.json`: clean.
- ESLint on changed + new files (`--max-warnings=0`): clean.
- `knip`: no unused exports.
- Not tested: live requests against a deployed backend (the builder API feature flag is off in all environments; the contract was verified against the backend handlers, API service, and generated OpenAPI models on backend main).

## Risk
- Level: Low
- Why: the touched surface is the hidden, feature-flagged builder route; with the flag off the fixture path is unchanged. Publish remains blocked, so no write path to production content changes.
- Rollback: revert this commit; no migrations or config changes.

## Review Notes
- The generated `ApiProfileCmsPackage` client model aliases the wire `package` field to `_package`; the adapter defines a `ProfileCmsPackageWire` type reading the raw `package` key on purpose — see the comment in `package-normalize.ts`.
- `createBuilderStateFromPackage` still imports every loaded draft as the homepage template; loading a wallet-gallery draft re-edits it as homepage blocks. Known MVP limitation, follow-up candidate for the builder lane.
- Snapshot asset ids are owner-scoped (`contract:token:owner`) to keep curation ids unique when the same token is held by multiple connected wallets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)