### PR TITLE
Exclude locale dictionaries from Sonar copy-paste detection

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,4 +6,7 @@ sonar.organization=6529-collections
 # analysis signal, and their parameterized asset-chrome invocations trip the
 # new-code duplication gate.
 sonar.exclusions=**/__tests__/**,**/e2e/**,scripts/**,**/__mocks__/**,content/delegation/**,public/delegation-content/**,app/museum/**,app/om/**,app/blog/**,app/about/media/**,app/about/press/**,app/capital/**,app/education/**,app/news/**
-sonar.cpd.exclusions=ops/scripts/build-delegation-docs-content.mjs
+# Locale dictionaries are inherently repetitive (identical key scaffolding
+# across languages); exclude them from copy-paste detection only, keeping
+# full code analysis (e.g. unused-import detection) active.
+sonar.cpd.exclusions=ops/scripts/build-delegation-docs-content.mjs,i18n/messages/**


### PR DESCRIPTION
One-line analysis-scope change: add `i18n/messages/**` to `sonar.cpd.exclusions`.

**Why**: locale dictionaries share identical key scaffolding across languages; adding the same keys to 4 locale files trips the ≤3% new-code duplication gate (PR #3092 measured 99.2%). This mirrors the existing static-content exclusions in the same file, but narrower: CPD only — unused-import and all other code analysis stays active for these files (it recently caught a real dropped-namespace regression there).

**Why a standalone PR**: SonarCloud automatic analysis reads scope settings from the default branch, so the exclusion must land on main before dependent PRs (#3092) can pass their gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)