### PR TITLE
Profile CMS publish flow with EIP-712 signing

### DIFF
--- a/__tests__/components/profile-cms-builder/ProfileCmsBuilder.test.tsx
+++ b/__tests__/components/profile-cms-builder/ProfileCmsBuilder.test.tsx
@@ -26,6 +26,16 @@ jest.mock("@/services/api/common-api", () => ({
   commonApiPost: jest.fn(),
 }));
 
+jest.mock("@/hooks/profile-cms/useProfileCmsPublishSign", () => ({
+  useProfileCmsPublishSign: () => ({
+    signTypedData: jest.fn(async () => ({ ok: true, signature: "0xsig" })),
+    chainId: 1,
+    signerAddress: "0x1111111111111111111111111111111111111111",
+    isConnected: true,
+    isSafe: false,
+  }),
+}));
+
 jest.mock("next/link", () => ({
   __esModule: true,
   default: ({
@@ -653,8 +663,7 @@ describe("ProfileCmsBuilder", () => {
     expect(screen.queryByText("draft-1")).not.toBeInTheDocument();
   });
 
-  it("keeps production publish disabled until the signed storage flow exists", async () => {
-    const user = userEvent.setup();
+  it("exposes the signed-storage publish panel for the connected owner", async () => {
     useAuthMock.mockReturnValue({
       activeProfileProxy: null,
       connectedProfile: { id: "profile-punk6529" },
@@ -667,20 +676,18 @@ describe("ProfileCmsBuilder", () => {
       />
     );
 
-    await user.click(screen.getByRole("button", { name: "Publish" }));
-
+    // The publish flow now lives in its own panel with visible step progress,
+    // not a header button that fakes a production publish.
     expect(
-      screen.getByText(
-        "Publishing needs the signed decentralized storage flow and is not enabled in this MVP."
-      )
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("profile-cms/packages/:id/publish")
-    ).toBeInTheDocument();
+      screen.getByRole("button", { name: "Publish website" })
+    ).toBeEnabled();
+    expect(screen.getByText("Save and validate draft")).toBeInTheDocument();
+    expect(screen.getByText("Upload to storage")).toBeInTheDocument();
+    expect(screen.getByText("Sign with wallet")).toBeInTheDocument();
+    expect(screen.getByText("Publish primary pointer")).toBeInTheDocument();
   });
 
-  it("blocks publish unless the connected profile owns the target", async () => {
-    const user = userEvent.setup();
+  it("disables publish unless the connected profile owns the target", async () => {
     useAuthMock.mockReturnValue({
       activeProfileProxy: null,
       connectedProfile: { id: "profile-other" },
@@ -694,16 +701,9 @@ describe("ProfileCmsBuilder", () => {
       />
     );
 
-    await user.click(screen.getByRole("button", { name: "Publish" }));
-
     expect(
-      screen.getByText(
-        "Connect as this profile before using backend builder actions."
-      )
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText("profile-cms/packages/:id/publish")
-    ).toBeInTheDocument();
+      screen.getByRole("button", { name: "Publish website" })
+    ).toBeDisabled();
   });
 
   it("adds a 3D room primitive and previews it through the CMS renderer", async () => {

--- a/__tests__/components/profile-cms-builder/ProfileCmsPublishPanel.test.tsx
+++ b/__tests__/components/profile-cms-builder/ProfileCmsPublishPanel.test.tsx
@@ -1,0 +1,211 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import ProfileCmsPublishPanel from "@/components/profile-cms-builder/ProfileCmsPublishPanel";
+import { useProfileCmsPublishSign } from "@/hooks/profile-cms/useProfileCmsPublishSign";
+import {
+  prepareProfileCmsPublish,
+  signAndPublishProfileCms,
+  type ProfileCmsPublishContext,
+} from "@/lib/profile-cms/builder/publish";
+import {
+  buildCmsPackageCandidate,
+  createDefaultCmsBuilderState,
+} from "@/lib/profile-cms/builder/package";
+
+jest.mock("@/hooks/profile-cms/useProfileCmsPublishSign", () => ({
+  useProfileCmsPublishSign: jest.fn(),
+}));
+
+jest.mock("@/lib/profile-cms/builder/publish", () => {
+  const actual = jest.requireActual("@/lib/profile-cms/builder/publish");
+  return {
+    ...actual,
+    prepareProfileCmsPublish: jest.fn(),
+    signAndPublishProfileCms: jest.fn(),
+  };
+});
+
+const useSignMock = useProfileCmsPublishSign as jest.Mock;
+const prepareMock = prepareProfileCmsPublish as jest.Mock;
+const signPublishMock = signAndPublishProfileCms as jest.Mock;
+
+const cmsPackage = buildCmsPackageCandidate(
+  createDefaultCmsBuilderState("punk6529")
+);
+
+const context: ProfileCmsPublishContext = {
+  draftId: "draft-1",
+  profileId: "profile-1",
+  handle: "punk6529",
+  packageId: "pkg-punk6529-builder-mvp",
+  version: 1,
+  payloadHash: "sha256:aa",
+  packageHash: "sha256:bb",
+  primaryPath: "/punk6529/index.html",
+  receipt: {
+    provider: "arweave",
+    uri: "ar://tx",
+    content_hash: "sha256:bb",
+    canonical: true,
+    recorded_at: "2026-07-05T00:00:00.000Z",
+  },
+};
+
+const renderPanel = (
+  overrides: Partial<React.ComponentProps<typeof ProfileCmsPublishPanel>> = {}
+) =>
+  render(
+    <ProfileCmsPublishPanel
+      canPublish
+      canUseBuilderApi
+      cmsPackage={cmsPackage}
+      profileId="profile-1"
+      {...overrides}
+    />
+  );
+
+describe("ProfileCmsPublishPanel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useSignMock.mockReturnValue({
+      signTypedData: jest.fn(async () => ({ ok: true, signature: "0xsig" })),
+      chainId: 1,
+      signerAddress: "0xowner",
+      isConnected: true,
+      isSafe: false,
+    });
+  });
+
+  it("renders the four publish steps", () => {
+    renderPanel();
+    expect(screen.getByText("Save and validate draft")).toBeInTheDocument();
+    expect(screen.getByText("Upload to storage")).toBeInTheDocument();
+    expect(screen.getByText("Sign with wallet")).toBeInTheDocument();
+    expect(screen.getByText("Publish primary pointer")).toBeInTheDocument();
+  });
+
+  it("shows the published URL as a link on success", async () => {
+    const user = userEvent.setup();
+    prepareMock.mockResolvedValue({ ok: true, context });
+    signPublishMock.mockResolvedValue({
+      ok: true,
+      published: { profileHandle: "punk6529" },
+      publishedUrl: "https://6529.io/punk6529/index.html",
+    });
+    const onPublished = jest.fn();
+    renderPanel({ onPublished });
+
+    await user.click(screen.getByRole("button", { name: "Publish website" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", {
+          name: "https://6529.io/punk6529/index.html",
+        })
+      ).toHaveAttribute("href", "https://6529.io/punk6529/index.html");
+    });
+    expect(onPublished).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a validation failure without uploading or signing", async () => {
+    const user = userEvent.setup();
+    prepareMock.mockResolvedValue({
+      ok: false,
+      step: "validate",
+      code: "server_validation_invalid",
+      message: "invalid",
+    });
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: "Publish website" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Server validation found blocking issues. Fix them, then publish again."
+        )
+      ).toBeInTheDocument();
+    });
+    expect(signPublishMock).not.toHaveBeenCalled();
+  });
+
+  it("offers a re-sign action after a deadline expiry and retries the tail only", async () => {
+    const user = userEvent.setup();
+    prepareMock.mockResolvedValue({ ok: true, context });
+    signPublishMock
+      .mockResolvedValueOnce({
+        ok: false,
+        step: "sign",
+        code: "deadline_expired",
+        message: "expired",
+        context,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        published: { profileHandle: "punk6529" },
+        publishedUrl: "https://6529.io/punk6529/index.html",
+      });
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: "Publish website" }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Sign again" })
+      ).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Sign again" }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("link", {
+          name: "https://6529.io/punk6529/index.html",
+        })
+      ).toBeInTheDocument();
+    });
+
+    // The retry re-runs only sign+publish, never re-preparing (no re-upload).
+    expect(prepareMock).toHaveBeenCalledTimes(1);
+    expect(signPublishMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("disables publishing when the package is not valid", () => {
+    renderPanel({ canPublish: false });
+    expect(
+      screen.getByRole("button", { name: "Publish website" })
+    ).toBeDisabled();
+  });
+
+  it("shows a Safe notice for smart-contract wallets", () => {
+    useSignMock.mockReturnValue({
+      signTypedData: jest.fn(),
+      chainId: 1,
+      signerAddress: "0xsafe",
+      isConnected: true,
+      isSafe: true,
+    });
+    renderPanel();
+    expect(
+      screen.getByText(/Safe \/ smart-contract wallet detected/)
+    ).toBeInTheDocument();
+  });
+
+  it("prompts to connect a wallet when none is connected", () => {
+    useSignMock.mockReturnValue({
+      signTypedData: jest.fn(),
+      chainId: 1,
+      signerAddress: undefined,
+      isConnected: false,
+      isSafe: false,
+    });
+    renderPanel();
+    expect(
+      screen.getByRole("button", { name: "Publish website" })
+    ).toBeDisabled();
+    expect(
+      screen.getByText(
+        "Connect the wallet linked to this profile to sign the publish."
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/profile-cms-builder/ProfileCmsVersionHistoryPanel.test.tsx
+++ b/__tests__/components/profile-cms-builder/ProfileCmsVersionHistoryPanel.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import ProfileCmsVersionHistoryPanel from "@/components/profile-cms-builder/ProfileCmsVersionHistoryPanel";
+import {
+  listProfileCmsPackagesForProfile,
+  rollbackProfileCmsPackage,
+  type ProfileCmsPackageRecord,
+} from "@/lib/profile-cms/builder/api";
+
+jest.mock("@/lib/profile-cms/builder/api", () => ({
+  listProfileCmsPackagesForProfile: jest.fn(),
+  rollbackProfileCmsPackage: jest.fn(),
+}));
+
+const listMock = listProfileCmsPackagesForProfile as jest.Mock;
+const rollbackMock = rollbackProfileCmsPackage as jest.Mock;
+
+const record = (
+  overrides: Partial<ProfileCmsPackageRecord>
+): ProfileCmsPackageRecord => ({
+  id: "pkg-1",
+  profileId: "profile-1",
+  profileHandle: "punk6529",
+  packageId: "pkg-punk6529-builder-mvp",
+  version: 1,
+  status: "published",
+  packageHash: "sha256:aa",
+  payloadHash: "sha256:bb",
+  updatedAt: "2026-07-05T00:00:00.000Z",
+  createdAt: "2026-07-05T00:00:00.000Z",
+  ...overrides,
+});
+
+const renderPanel = (
+  overrides: Partial<
+    React.ComponentProps<typeof ProfileCmsVersionHistoryPanel>
+  > = {}
+) =>
+  render(
+    <ProfileCmsVersionHistoryPanel
+      builderApiEnabled
+      canUseBuilderApi
+      profileId="profile-1"
+      {...overrides}
+    />
+  );
+
+describe("ProfileCmsVersionHistoryPanel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("lists packages with status and marks the primary", async () => {
+    const user = userEvent.setup();
+    listMock.mockResolvedValue([
+      record({ id: "pkg-2", version: 2, status: "published" }),
+      record({ id: "pkg-1", version: 1, status: "superseded" }),
+    ]);
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Version 2/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Version 2/).textContent).toContain("Primary");
+    expect(screen.getByText(/Version 1/).textContent).toContain("Superseded");
+  });
+
+  it("rolls a previous version back after confirmation", async () => {
+    const user = userEvent.setup();
+    listMock.mockResolvedValue([
+      record({ id: "pkg-2", version: 2, status: "published" }),
+      record({
+        id: "pkg-1",
+        version: 1,
+        status: "superseded",
+        packageId: "pkg-punk6529-builder-mvp",
+      }),
+    ]);
+    rollbackMock.mockResolvedValue(
+      record({ id: "pkg-1", status: "published" })
+    );
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+    await waitFor(() => screen.getByText(/Version 1/));
+
+    // Only the non-primary published/superseded version offers rollback.
+    await user.click(screen.getByRole("button", { name: "Make primary" }));
+    expect(
+      screen.getByRole("alertdialog", { name: "Confirm rollback" })
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Roll back" }));
+
+    await waitFor(() => {
+      expect(rollbackMock).toHaveBeenCalledWith("pkg-1", {
+        expected_current_package_id: "pkg-punk6529-builder-mvp",
+        expected_current_package_hash: "sha256:aa",
+      });
+    });
+  });
+
+  it("cancels the rollback confirmation without calling the API", async () => {
+    const user = userEvent.setup();
+    listMock.mockResolvedValue([
+      record({ id: "pkg-2", version: 2, status: "published" }),
+      record({ id: "pkg-1", version: 1, status: "superseded" }),
+    ]);
+    renderPanel();
+
+    await user.click(screen.getByRole("button", { name: "Refresh" }));
+    await waitFor(() => screen.getByText(/Version 1/));
+    await user.click(screen.getByRole("button", { name: "Make primary" }));
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(
+      screen.queryByRole("alertdialog", { name: "Confirm rollback" })
+    ).not.toBeInTheDocument();
+    expect(rollbackMock).not.toHaveBeenCalled();
+  });
+
+  it("shows an unavailable notice when the caller cannot use the builder API", () => {
+    renderPanel({ canUseBuilderApi: false });
+    expect(
+      screen.getByText(
+        "Connect as this profile owner to view published versions."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("refreshes when the publish refresh token increments", async () => {
+    listMock.mockResolvedValue([record({ id: "pkg-1", version: 1 })]);
+    const { rerender } = renderPanel({ refreshToken: 0 });
+    expect(listMock).not.toHaveBeenCalled();
+
+    rerender(
+      <ProfileCmsVersionHistoryPanel
+        builderApiEnabled
+        canUseBuilderApi
+        profileId="profile-1"
+        refreshToken={1}
+      />
+    );
+
+    await waitFor(() => {
+      expect(listMock).toHaveBeenCalledWith("profile-1");
+    });
+  });
+});

--- a/__tests__/hooks/profile-cms/useProfileCmsPublishSign.test.ts
+++ b/__tests__/hooks/profile-cms/useProfileCmsPublishSign.test.ts
@@ -1,0 +1,114 @@
+import { renderHook } from "@testing-library/react";
+import { useChainId, useSignTypedData } from "wagmi";
+
+import { useSeizeConnectContext } from "@/components/auth/SeizeConnectContext";
+import { useProfileCmsPublishSign } from "@/hooks/profile-cms/useProfileCmsPublishSign";
+import {
+  buildProfileCmsPublishTypedData,
+  type ProfileCmsPublishContext,
+} from "@/lib/profile-cms/builder/publish";
+
+jest.mock("wagmi", () => ({
+  useChainId: jest.fn(),
+  useSignTypedData: jest.fn(),
+}));
+
+jest.mock("@/components/auth/SeizeConnectContext", () => ({
+  useSeizeConnectContext: jest.fn(),
+}));
+
+const useChainIdMock = useChainId as jest.Mock;
+const useSignTypedDataMock = useSignTypedData as jest.Mock;
+const useSeizeConnectContextMock = useSeizeConnectContext as jest.Mock;
+
+const context: ProfileCmsPublishContext = {
+  draftId: "draft-1",
+  profileId: "profile-1",
+  handle: "punk6529",
+  packageId: "pkg-punk6529-builder-mvp",
+  version: 3,
+  payloadHash: "sha256:aa",
+  packageHash: "sha256:bb",
+  primaryPath: "/punk6529/index.html",
+  receipt: {
+    provider: "arweave",
+    uri: "ar://tx",
+    content_hash: "sha256:bb",
+    canonical: true,
+    recorded_at: "2026-07-05T00:00:00.000Z",
+  },
+};
+
+const typedData = buildProfileCmsPublishTypedData({
+  context,
+  chainId: 1,
+  deadline: 1_792_345_678_000,
+});
+
+describe("useProfileCmsPublishSign", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useChainIdMock.mockReturnValue(1);
+    useSeizeConnectContextMock.mockReturnValue({
+      address: "0xowner",
+      isConnected: true,
+      isSafeWallet: false,
+    });
+  });
+
+  it("converts uint256 fields to bigint before signing and returns the signature", async () => {
+    const signTypedDataAsync = jest.fn(async () => "0xsignature");
+    useSignTypedDataMock.mockReturnValue({ signTypedDataAsync });
+
+    const { result } = renderHook(() => useProfileCmsPublishSign());
+    const signed = await result.current.signTypedData(typedData);
+
+    expect(signed).toEqual({ ok: true, signature: "0xsignature" });
+    const call = signTypedDataAsync.mock.calls[0][0];
+    expect(call.message.version).toBe(3n);
+    expect(call.message.deadline).toBe(1_792_345_678_000n);
+    expect(call.domain.verifyingContract).toBeUndefined();
+    expect(result.current.chainId).toBe(1);
+    expect(result.current.signerAddress).toBe("0xowner");
+    expect(result.current.isSafe).toBe(false);
+  });
+
+  it("reports a user rejection distinctly", async () => {
+    const rejection = Object.assign(new Error("denied"), {
+      name: "UserRejectedRequestError",
+    });
+    const signTypedDataAsync = jest.fn(async () => {
+      throw rejection;
+    });
+    useSignTypedDataMock.mockReturnValue({ signTypedDataAsync });
+
+    const { result } = renderHook(() => useProfileCmsPublishSign());
+    const signed = await result.current.signTypedData(typedData);
+
+    expect(signed).toEqual({ ok: false, rejected: true });
+  });
+
+  it("reports a non-rejection signing failure as not-rejected", async () => {
+    const signTypedDataAsync = jest.fn(async () => {
+      throw new Error("provider offline");
+    });
+    useSignTypedDataMock.mockReturnValue({ signTypedDataAsync });
+
+    const { result } = renderHook(() => useProfileCmsPublishSign());
+    const signed = await result.current.signTypedData(typedData);
+
+    expect(signed).toEqual({ ok: false, rejected: false });
+  });
+
+  it("passes through Safe detection from the connect context", () => {
+    useSeizeConnectContextMock.mockReturnValue({
+      address: "0xsafe",
+      isConnected: true,
+      isSafeWallet: true,
+    });
+    useSignTypedDataMock.mockReturnValue({ signTypedDataAsync: jest.fn() });
+
+    const { result } = renderHook(() => useProfileCmsPublishSign());
+    expect(result.current.isSafe).toBe(true);
+  });
+});

--- a/__tests__/lib/profile-cms/builder/api.test.ts
+++ b/__tests__/lib/profile-cms/builder/api.test.ts
@@ -294,24 +294,36 @@ describe("profile CMS builder API adapter", () => {
       );
     });
 
-    it("keeps publish hard-blocked regardless of the API-enabled flag", async () => {
+    it("surfaces the server-assigned version and payload hash from a saved draft", async () => {
       process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
       const state = createDefaultCmsBuilderState("punk6529");
       const { cmsPackage } = validateCmsBuilderState(state);
+      commonApiPostMock.mockResolvedValue({
+        id: "draft-123",
+        profile_id: "profile-punk6529",
+        profile_handle: "punk6529",
+        package_id: "pkg-punk6529-builder-mvp",
+        version: 4,
+        status: "draft",
+        package_hash: cmsPackage.integrity.package_hash,
+        payload_hash: cmsPackage.integrity.payload_hash,
+        updated_at: 1750204800000,
+        created_at: 1750204800000,
+      });
 
       const result = await runProfileCmsBuilderAction({
-        action: "publish",
+        action: "save_draft",
         cmsPackage,
-        draftId: "draft-123",
         profileId: "profile-punk6529",
       });
 
-      expect(commonApiPostMock).not.toHaveBeenCalled();
       expect(result).toEqual(
         expect.objectContaining({
-          ok: false,
-          code: "publish_requires_signed_storage",
-          expectedEndpoint: "profile-cms/packages/draft-123/publish",
+          ok: true,
+          code: "draft_saved",
+          draftId: "draft-123",
+          version: 4,
+          payloadHash: cmsPackage.integrity.payload_hash,
         })
       );
     });

--- a/__tests__/lib/profile-cms/builder/publish.test.ts
+++ b/__tests__/lib/profile-cms/builder/publish.test.ts
@@ -1,0 +1,446 @@
+import { ethers } from "ethers";
+import { hashTypedData } from "viem";
+
+import {
+  runProfileCmsBuilderAction,
+  uploadProfileCmsPackageStorage,
+  publishProfileCmsPackage,
+  type ProfileCmsStorageReceipt,
+} from "@/lib/profile-cms/builder/api";
+import {
+  buildProfileCmsPublishTypedData,
+  getProfileCmsPublishedUrl,
+  runProfileCmsPublish,
+  signAndPublishProfileCms,
+  PROFILE_CMS_PUBLISH_DEADLINE_MS,
+  PROFILE_CMS_PUBLISH_DOMAIN_NAME,
+  PROFILE_CMS_PUBLISH_DOMAIN_VERSION,
+  type ProfileCmsPublishContext,
+  type ProfileCmsSignTypedData,
+} from "@/lib/profile-cms/builder/publish";
+import { createDefaultCmsBuilderState } from "@/lib/profile-cms/builder/package";
+import { validateCmsBuilderState } from "@/lib/profile-cms/builder/package";
+
+jest.mock("@/lib/profile-cms/builder/api", () => ({
+  runProfileCmsBuilderAction: jest.fn(),
+  uploadProfileCmsPackageStorage: jest.fn(),
+  publishProfileCmsPackage: jest.fn(),
+}));
+
+const runActionMock = runProfileCmsBuilderAction as jest.Mock;
+const uploadMock = uploadProfileCmsPackageStorage as jest.Mock;
+const publishMock = publishProfileCmsPackage as jest.Mock;
+
+const RECEIPT: ProfileCmsStorageReceipt = {
+  provider: "arweave",
+  uri: "ar://tx-abc",
+  content_hash: `sha256:${"2".repeat(64)}`,
+  provider_content_id: "tx-abc",
+  canonical: true,
+  recorded_at: "2026-07-05T00:00:00.000Z",
+};
+
+const buildPackage = () => {
+  const state = createDefaultCmsBuilderState("punk6529");
+  return validateCmsBuilderState(state).cmsPackage;
+};
+
+const okSign =
+  (signature = `0x${"a".repeat(130)}`): ProfileCmsSignTypedData =>
+  async () => ({ ok: true, signature });
+
+const publishedRecord = {
+  id: "draft-1",
+  profileId: "profile-1",
+  profileHandle: "punk6529",
+  packageId: "pkg-punk6529-builder-mvp",
+  version: 1,
+  status: "published" as const,
+  packageHash: `sha256:${"2".repeat(64)}`,
+  payloadHash: `sha256:${"1".repeat(64)}`,
+  updatedAt: "2026-07-05T00:00:00.000Z",
+  createdAt: "2026-07-05T00:00:00.000Z",
+  publishedAt: "2026-07-05T00:00:00.000Z",
+};
+
+const mockSaveOk = () =>
+  runActionMock.mockImplementation(async ({ action }) => {
+    if (action === "save_draft") {
+      return {
+        ok: true,
+        action: "save_draft",
+        code: "draft_saved",
+        draftId: "draft-1",
+        version: 1,
+        packageHash: `sha256:${"2".repeat(64)}`,
+        payloadHash: `sha256:${"1".repeat(64)}`,
+      };
+    }
+    return {
+      ok: true,
+      action: "validate",
+      code: "server_validation_completed",
+      packageHash: `sha256:${"2".repeat(64)}`,
+    };
+  });
+
+describe("profile CMS publish orchestration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("typed data construction", () => {
+    it("matches the backend EIP-712 domain and type field order/values", () => {
+      // Backend fixture from
+      // 6529seize-backend/src/profile-cms/profile-cms-signing.test.ts
+      const context: ProfileCmsPublishContext = {
+        draftId: "draft-1",
+        profileId: "profile-1",
+        handle: "punk6529bot",
+        packageId: "profile-native-home",
+        version: 1,
+        payloadHash: `sha256:${"1".repeat(64)}`,
+        packageHash: `sha256:${"2".repeat(64)}`,
+        primaryPath: "/punk6529bot/index.html",
+        receipt: {
+          provider: "ipfs",
+          uri: "ipfs://bafybeigdyrztmrgfydgytzqojqfaytmqmvqwxqk66xcs4i6hj5yq",
+          content_hash: `sha256:${"2".repeat(64)}`,
+          canonical: true,
+          recorded_at: "2026-07-05T00:00:00.000Z",
+        },
+      };
+      const typedData = buildProfileCmsPublishTypedData({
+        context,
+        chainId: 1,
+        deadline: 1792345678000,
+      });
+
+      expect(typedData.domain).toEqual({
+        name: PROFILE_CMS_PUBLISH_DOMAIN_NAME,
+        version: PROFILE_CMS_PUBLISH_DOMAIN_VERSION,
+        chainId: 1,
+      });
+      expect(typedData.types.ProfileCmsPublish.map((f) => f.name)).toEqual([
+        "action",
+        "profileId",
+        "handle",
+        "packageId",
+        "version",
+        "draftId",
+        "payloadHash",
+        "packageHash",
+        "primaryPath",
+        "storageProvider",
+        "storageUri",
+        "storageContentHash",
+        "deadline",
+      ]);
+
+      // Replicate the backend fixture's expected typed-data hash exactly, using
+      // both ethers (backend uses ethers.TypedDataEncoder.hash) and viem.
+      const expectedHash =
+        "0x1fe21ab2829931ed7cd8777ad1ead3300701b7e8d5dcc2e56de8be396e3b0372";
+      expect(
+        ethers.TypedDataEncoder.hash(
+          typedData.domain,
+          typedData.types,
+          typedData.message
+        )
+      ).toBe(expectedHash);
+      expect(
+        hashTypedData({
+          domain: typedData.domain,
+          types: typedData.types,
+          primaryType: "ProfileCmsPublish",
+          message: {
+            ...typedData.message,
+            version: BigInt(typedData.message.version),
+            deadline: BigInt(typedData.message.deadline),
+          },
+        })
+      ).toBe(expectedHash);
+    });
+
+    it("adds verifyingContract to the domain only when provided", () => {
+      const context: ProfileCmsPublishContext = {
+        draftId: "d",
+        profileId: "p",
+        handle: "h",
+        packageId: "pkg",
+        version: 2,
+        payloadHash: "sha256:aa",
+        packageHash: "sha256:bb",
+        primaryPath: "/h/index.html",
+        receipt: RECEIPT,
+      };
+      const withContract = buildProfileCmsPublishTypedData({
+        context,
+        chainId: 1,
+        deadline: 1,
+        verifyingContract: "0x0000000000000000000000000000000000000001",
+      });
+      expect(withContract.domain.verifyingContract).toBe(
+        "0x0000000000000000000000000000000000000001"
+      );
+      const withoutContract = buildProfileCmsPublishTypedData({
+        context,
+        chainId: 1,
+        deadline: 1,
+      });
+      expect(withoutContract.domain.verifyingContract).toBeUndefined();
+    });
+  });
+
+  describe("happy path", () => {
+    it("sequences save -> validate -> upload -> sign -> publish and returns the URL", async () => {
+      mockSaveOk();
+      uploadMock.mockResolvedValue(RECEIPT);
+      publishMock.mockResolvedValue(publishedRecord);
+      const signTypedData = jest.fn(okSign());
+
+      const result = await runProfileCmsPublish({
+        cmsPackage: buildPackage(),
+        profileId: "profile-1",
+        chainId: 1,
+        signerAddress: "0xabc",
+        signTypedData,
+        now: () => 1_000_000,
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.publishedUrl).toBe("https://6529.io/punk6529/index.html");
+      }
+      // Ordering: save + validate before upload before publish.
+      expect(runActionMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ action: "save_draft" })
+      );
+      expect(runActionMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ action: "validate" })
+      );
+      expect(uploadMock).toHaveBeenCalledWith("draft-1");
+      expect(signTypedData).toHaveBeenCalledTimes(1);
+      // Publish carries the signature, chain id, deadline and expected hashes.
+      const publishArgs = publishMock.mock.calls[0];
+      expect(publishArgs[0]).toBe("draft-1");
+      expect(publishArgs[1]).toEqual(
+        expect.objectContaining({
+          signer_address: "0xabc",
+          chain_id: 1,
+          deadline: 1_000_000 + PROFILE_CMS_PUBLISH_DEADLINE_MS,
+          expected_package_hash: `sha256:${"2".repeat(64)}`,
+          expected_payload_hash: `sha256:${"1".repeat(64)}`,
+        })
+      );
+      expect(publishArgs[1]).not.toHaveProperty("is_safe_signature");
+    });
+
+    it("sets is_safe_signature for Safe wallets", async () => {
+      mockSaveOk();
+      uploadMock.mockResolvedValue(RECEIPT);
+      publishMock.mockResolvedValue(publishedRecord);
+
+      await runProfileCmsPublish({
+        cmsPackage: buildPackage(),
+        profileId: "profile-1",
+        chainId: 1,
+        signerAddress: "0xsafe",
+        signTypedData: okSign(),
+        isSafe: true,
+      });
+
+      expect(publishMock.mock.calls[0][1]).toEqual(
+        expect.objectContaining({ is_safe_signature: true })
+      );
+    });
+  });
+
+  describe("failure branches", () => {
+    it("aborts before upload when server validation is invalid", async () => {
+      runActionMock.mockImplementation(async ({ action }) => {
+        if (action === "save_draft") {
+          return {
+            ok: true,
+            action: "save_draft",
+            code: "draft_saved",
+            draftId: "draft-1",
+            version: 1,
+          };
+        }
+        return {
+          ok: false,
+          action: "validate",
+          code: "server_validation_invalid",
+          expectedEndpoint: "profile-cms/packages/validate",
+        };
+      });
+
+      const result = await runProfileCmsPublish({
+        cmsPackage: buildPackage(),
+        profileId: "profile-1",
+        chainId: 1,
+        signerAddress: "0xabc",
+        signTypedData: okSign(),
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe("server_validation_invalid");
+        expect(result.step).toBe("validate");
+      }
+      expect(uploadMock).not.toHaveBeenCalled();
+      expect(publishMock).not.toHaveBeenCalled();
+    });
+
+    it("reports an upload failure and does not sign", async () => {
+      mockSaveOk();
+      uploadMock.mockRejectedValue(new Error("bad key"));
+      const signTypedData = jest.fn(okSign());
+
+      const result = await runProfileCmsPublish({
+        cmsPackage: buildPackage(),
+        profileId: "profile-1",
+        chainId: 1,
+        signerAddress: "0xabc",
+        signTypedData,
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe("upload_failed");
+        expect(result.step).toBe("upload");
+      }
+      expect(signTypedData).not.toHaveBeenCalled();
+      expect(publishMock).not.toHaveBeenCalled();
+    });
+
+    it("reports a signature rejection and does not publish, keeping the context", async () => {
+      mockSaveOk();
+      uploadMock.mockResolvedValue(RECEIPT);
+      const signTypedData: ProfileCmsSignTypedData = async () => ({
+        ok: false,
+        rejected: true,
+      });
+
+      const result = await runProfileCmsPublish({
+        cmsPackage: buildPackage(),
+        profileId: "profile-1",
+        chainId: 1,
+        signerAddress: "0xabc",
+        signTypedData,
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe("signature_rejected");
+        expect(result.step).toBe("sign");
+        expect(result.context).toBeDefined();
+      }
+      expect(publishMock).not.toHaveBeenCalled();
+    });
+
+    it("maps a publish 4xx into a publish_failed result", async () => {
+      mockSaveOk();
+      uploadMock.mockResolvedValue(RECEIPT);
+      const error = Object.assign(new Error("wrong owner"), { status: 403 });
+      publishMock.mockRejectedValue(error);
+
+      const result = await runProfileCmsPublish({
+        cmsPackage: buildPackage(),
+        profileId: "profile-1",
+        chainId: 1,
+        signerAddress: "0xabc",
+        signTypedData: okSign(),
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe("publish_failed");
+        expect(result.step).toBe("publish");
+      }
+    });
+
+    it("detects a deadline-expiry 400 and allows re-signing with a fresh deadline", async () => {
+      const context: ProfileCmsPublishContext = {
+        draftId: "draft-1",
+        profileId: "profile-1",
+        handle: "punk6529",
+        packageId: "pkg-punk6529-builder-mvp",
+        version: 1,
+        payloadHash: `sha256:${"1".repeat(64)}`,
+        packageHash: `sha256:${"2".repeat(64)}`,
+        primaryPath: "/punk6529/index.html",
+        receipt: RECEIPT,
+      };
+      const deadlineError = Object.assign(
+        new Error("publish deadline is in the past"),
+        { status: 400 }
+      );
+      publishMock.mockRejectedValueOnce(deadlineError);
+
+      const first = await signAndPublishProfileCms({
+        context,
+        chainId: 1,
+        signerAddress: "0xabc",
+        signTypedData: okSign(),
+        now: () => 1_000,
+      });
+      expect(first.ok).toBe(false);
+      if (!first.ok) {
+        expect(first.code).toBe("deadline_expired");
+        expect(first.context).toBeDefined();
+      }
+
+      // Re-sign with a fresh (later) deadline and succeed.
+      publishMock.mockResolvedValueOnce(publishedRecord);
+      const second = await signAndPublishProfileCms({
+        context,
+        chainId: 1,
+        signerAddress: "0xabc",
+        signTypedData: okSign(),
+        now: () => 2_000_000,
+      });
+      expect(second.ok).toBe(true);
+      expect(publishMock.mock.calls[1][1].deadline).toBe(
+        2_000_000 + PROFILE_CMS_PUBLISH_DEADLINE_MS
+      );
+    });
+
+    it("reports save failure before validating", async () => {
+      runActionMock.mockResolvedValue({
+        ok: false,
+        action: "save_draft",
+        code: "request_failed",
+        expectedEndpoint: "profile-cms/packages",
+      });
+
+      const result = await runProfileCmsPublish({
+        cmsPackage: buildPackage(),
+        profileId: "profile-1",
+        chainId: 1,
+        signerAddress: "0xabc",
+        signTypedData: okSign(),
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.code).toBe("save_failed");
+      }
+      expect(uploadMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("published url", () => {
+    it("builds the canonical /{handle}/index.html url", () => {
+      expect(getProfileCmsPublishedUrl("punk6529")).toBe(
+        "https://6529.io/punk6529/index.html"
+      );
+      expect(
+        getProfileCmsPublishedUrl("punk6529", "https://staging.6529.io")
+      ).toBe("https://staging.6529.io/punk6529/index.html");
+    });
+  });
+});

--- a/components/profile-cms-builder/ProfileCmsBuilder.tsx
+++ b/components/profile-cms-builder/ProfileCmsBuilder.tsx
@@ -9,6 +9,8 @@ import {
   ProfileCmsAgentPanel,
   downloadJsonFile,
 } from "@/components/profile-cms-builder/ProfileCmsAgentPanel";
+import ProfileCmsPublishPanel from "@/components/profile-cms-builder/ProfileCmsPublishPanel";
+import ProfileCmsVersionHistoryPanel from "@/components/profile-cms-builder/ProfileCmsVersionHistoryPanel";
 import { isProfileCmsBuilderApiEnabledEnv } from "@/config/profileCmsBuilderEnv";
 import { formatInteger } from "@/i18n/format";
 import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
@@ -21,7 +23,6 @@ import {
   getProfileCmsPackageById,
   listProfileCmsPackagesForProfile,
   PROFILE_CMS_BUILDER_PACKAGES_ENDPOINT,
-  PROFILE_CMS_BUILDER_PUBLISH_ENDPOINT,
   PROFILE_CMS_BUILDER_VALIDATE_ENDPOINT,
   requestProfileCmsGallerySnapshot,
   runProfileCmsBuilderAction,
@@ -102,6 +103,7 @@ export default function ProfileCmsBuilder({
   const [drafts, setDrafts] = useState<readonly ProfileCmsPackageRecord[]>([]);
   const [loadingDraftId, setLoadingDraftId] = useState<string | null>(null);
   const [draftLoadFailed, setDraftLoadFailed] = useState(false);
+  const [publishRefreshToken, setPublishRefreshToken] = useState(0);
   const actionRequestIdRef = useRef(0);
   const gallerySnapshotRequestIdRef = useRef(0);
   const draftsRequestIdRef = useRef(0);
@@ -299,7 +301,7 @@ export default function ProfileCmsBuilder({
       setActionResult({
         ok: false,
         action,
-        expectedEndpoint: getExpectedBuilderEndpoint(action, draftId),
+        expectedEndpoint: getExpectedBuilderEndpoint(action),
         code: "profile_not_authorized",
       });
       return;
@@ -314,7 +316,6 @@ export default function ProfileCmsBuilder({
       const result = await runProfileCmsBuilderAction({
         action,
         cmsPackage: validation.cmsPackage,
-        draftId,
         profileId: canUseBuilderApi ? profileId : undefined,
       });
       if (
@@ -420,12 +421,6 @@ export default function ProfileCmsBuilder({
               disabled={isSubmitting}
               label={t(locale, "profileCms.builder.cta.serverValidate")}
               onClick={() => void runAction("validate")}
-            />
-            <BuilderActionButton
-              disabled={isSubmitting || !validation.result.valid}
-              label={t(locale, "profileCms.builder.cta.publish")}
-              onClick={() => void runAction("publish")}
-              variant="primary"
             />
           </div>
         </div>
@@ -541,6 +536,21 @@ export default function ProfileCmsBuilder({
             locale={locale}
             packageHash={validation.cmsPackage.integrity.package_hash}
             payloadHash={validation.cmsPackage.integrity.payload_hash}
+          />
+          <ProfileCmsPublishPanel
+            canPublish={validation.result.valid}
+            canUseBuilderApi={canUseBuilderApi}
+            cmsPackage={validation.cmsPackage}
+            locale={locale}
+            onPublished={() => setPublishRefreshToken((token) => token + 1)}
+            profileId={profileId}
+          />
+          <ProfileCmsVersionHistoryPanel
+            builderApiEnabled={builderApiEnabled}
+            canUseBuilderApi={canUseBuilderApi}
+            locale={locale}
+            profileId={profileId}
+            refreshToken={publishRefreshToken}
           />
           <DraftsPanel
             builderApiEnabled={builderApiEnabled}
@@ -1849,8 +1859,6 @@ function getActionResultMessage(
       return t(locale, "profileCms.builder.api.missingProfileId");
     case "profile_not_authorized":
       return t(locale, "profileCms.builder.api.profileNotAuthorized");
-    case "publish_requires_signed_storage":
-      return t(locale, "profileCms.builder.api.publishRequiresSignedStorage");
     case "request_failed":
       return t(locale, "profileCms.builder.api.failed");
     case "server_validation_completed":
@@ -1862,20 +1870,12 @@ function getActionResultMessage(
   }
 }
 
-function getExpectedBuilderEndpoint(
-  action: ProfileCmsBuilderAction,
-  draftId: string | undefined
-): string {
+function getExpectedBuilderEndpoint(action: ProfileCmsBuilderAction): string {
   switch (action) {
     case "save_draft":
       return PROFILE_CMS_BUILDER_PACKAGES_ENDPOINT;
     case "validate":
       return PROFILE_CMS_BUILDER_VALIDATE_ENDPOINT;
-    case "publish":
-      return PROFILE_CMS_BUILDER_PUBLISH_ENDPOINT.replace(
-        "{id}",
-        draftId ? encodeURIComponent(draftId) : ":id"
-      );
   }
 }
 

--- a/components/profile-cms-builder/ProfileCmsPublishPanel.tsx
+++ b/components/profile-cms-builder/ProfileCmsPublishPanel.tsx
@@ -1,0 +1,403 @@
+"use client";
+
+import { useState } from "react";
+
+import { t } from "@/i18n/messages";
+import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+import { useProfileCmsPublishSign } from "@/hooks/profile-cms/useProfileCmsPublishSign";
+import {
+  prepareProfileCmsPublish,
+  signAndPublishProfileCms,
+  type ProfileCmsPublishContext,
+  type ProfileCmsPublishResult,
+  type ProfileCmsPublishStep,
+} from "@/lib/profile-cms/builder/publish";
+import type { CmsPackageV1 } from "@/lib/profile-cms/protocol/v1";
+
+type StepStatus = "idle" | "active" | "done" | "error";
+
+const PUBLISH_STEPS: readonly ProfileCmsPublishStep[] = [
+  "validate",
+  "upload",
+  "sign",
+  "publish",
+];
+
+export type ProfileCmsPublishPanelProps = {
+  readonly cmsPackage: CmsPackageV1;
+  readonly profileId: string | undefined;
+  readonly canUseBuilderApi: boolean;
+  readonly canPublish: boolean;
+  readonly locale?: SupportedLocale | undefined;
+  readonly onPublished?: (() => void) | undefined;
+};
+
+type PublishState = {
+  readonly running: boolean;
+  readonly result: ProfileCmsPublishResult | null;
+  readonly context: ProfileCmsPublishContext | null;
+  // Highest step index that has succeeded (validate=0 ... publish=3).
+  readonly reachedStep: number;
+};
+
+const INITIAL_STATE: PublishState = {
+  running: false,
+  result: null,
+  context: null,
+  reachedStep: -1,
+};
+
+export default function ProfileCmsPublishPanel({
+  cmsPackage,
+  profileId,
+  canUseBuilderApi,
+  canPublish,
+  locale = DEFAULT_LOCALE,
+  onPublished,
+}: ProfileCmsPublishPanelProps) {
+  const { signTypedData, chainId, signerAddress, isConnected, isSafe } =
+    useProfileCmsPublishSign();
+  const [state, setState] = useState<PublishState>(INITIAL_STATE);
+
+  const disabled =
+    state.running ||
+    !canUseBuilderApi ||
+    !canPublish ||
+    !profileId ||
+    !isConnected ||
+    !signerAddress;
+
+  const runFullPublish = async () => {
+    if (!profileId || !signerAddress) {
+      return;
+    }
+    setState({ ...INITIAL_STATE, running: true });
+
+    const prepared = await prepareProfileCmsPublish({
+      cmsPackage,
+      profileId,
+      chainId,
+      signerAddress,
+      signTypedData,
+      isSafe,
+    });
+    if (!prepared.ok) {
+      setState({
+        running: false,
+        result: prepared,
+        context: prepared.context ?? null,
+        reachedStep: getReachedStepFromFailure(prepared.step, false),
+      });
+      return;
+    }
+
+    const result = await signAndPublishProfileCms({
+      context: prepared.context,
+      chainId,
+      signerAddress,
+      signTypedData,
+      isSafe,
+    });
+    finishAttempt(result, prepared.context);
+  };
+
+  // Retry the sign + publish tail with a fresh deadline, reusing the receipt.
+  const retrySignAndPublish = async () => {
+    if (!state.context || !signerAddress) {
+      return;
+    }
+    setState((current) => ({ ...current, running: true, result: null }));
+    const result = await signAndPublishProfileCms({
+      context: state.context,
+      chainId,
+      signerAddress,
+      signTypedData,
+      isSafe,
+    });
+    finishAttempt(result, state.context);
+  };
+
+  const finishAttempt = (
+    result: ProfileCmsPublishResult,
+    context: ProfileCmsPublishContext
+  ) => {
+    if (result.ok) {
+      setState({
+        running: false,
+        result,
+        context,
+        reachedStep: PUBLISH_STEPS.length,
+      });
+      onPublished?.();
+      return;
+    }
+    setState({
+      running: false,
+      result,
+      context: result.context ?? context,
+      reachedStep: getReachedStepFromFailure(result.step, true),
+    });
+  };
+
+  const stepStatuses = getStepStatuses(state);
+
+  return (
+    <section className="tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-900 tw-p-4">
+      <h2 className="tw-text-base tw-font-semibold tw-text-white">
+        {t(locale, "profileCms.builder.publish.title")}
+      </h2>
+      <p className="tw-mt-1 tw-text-sm tw-leading-6 tw-text-iron-400">
+        {t(locale, "profileCms.builder.publish.description")}
+      </p>
+
+      <ol className="tw-mt-4 tw-flex tw-flex-col tw-gap-2">
+        {PUBLISH_STEPS.map((step, index) => (
+          <PublishStepRow
+            key={step}
+            index={index}
+            label={t(locale, getStepLabelKey(step))}
+            status={stepStatuses[index] ?? "idle"}
+          />
+        ))}
+      </ol>
+
+      {isSafe ? (
+        <p className="tw-text-primary-200 tw-mt-3 tw-border tw-border-solid tw-border-primary-400 tw-bg-primary-500/10 tw-p-3 tw-text-xs tw-leading-5">
+          {t(locale, "profileCms.builder.publish.safeNotice")}
+        </p>
+      ) : null}
+
+      <div className="tw-mt-4 tw-flex tw-flex-wrap tw-gap-2">
+        <button
+          className="tw-min-h-10 tw-border tw-border-solid tw-border-primary-400 tw-bg-primary-500 tw-px-3 tw-text-sm tw-font-semibold tw-text-white disabled:tw-cursor-not-allowed disabled:tw-opacity-50"
+          disabled={disabled}
+          onClick={() => void runFullPublish()}
+          type="button"
+        >
+          {state.running
+            ? t(locale, "profileCms.builder.publish.publishing")
+            : t(locale, "profileCms.builder.publish.publish")}
+        </button>
+        {canRetrySignTail(state) ? (
+          <button
+            className="tw-min-h-10 tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-px-3 tw-text-sm tw-font-semibold tw-text-iron-100 hover:tw-border-primary-400 disabled:tw-cursor-not-allowed disabled:tw-opacity-50"
+            disabled={state.running}
+            onClick={() => void retrySignAndPublish()}
+            type="button"
+          >
+            {isDeadlineExpired(state)
+              ? t(locale, "profileCms.builder.publish.reSign")
+              : t(locale, "profileCms.builder.publish.retry")}
+          </button>
+        ) : null}
+      </div>
+
+      {!isConnected ? (
+        <p className="tw-mt-3 tw-text-sm tw-leading-6 tw-text-iron-400">
+          {t(locale, "profileCms.builder.publish.walletRequired")}
+        </p>
+      ) : null}
+
+      <PublishResultBanner locale={locale} result={state.result} />
+    </section>
+  );
+}
+
+function PublishResultBanner({
+  locale,
+  result,
+}: {
+  readonly locale: SupportedLocale;
+  readonly result: ProfileCmsPublishResult | null;
+}) {
+  if (!result) {
+    return null;
+  }
+
+  if (result.ok) {
+    return (
+      <div
+        className="tw-mt-4 tw-border tw-border-solid tw-border-green tw-bg-green/10 tw-p-3 tw-text-sm tw-text-green"
+        role="status"
+      >
+        <p className="tw-font-semibold">
+          {t(locale, "profileCms.builder.publish.success")}
+        </p>
+        <a
+          className="tw-mt-2 tw-inline-block tw-break-all tw-font-mono tw-text-xs tw-text-green tw-underline"
+          href={result.publishedUrl}
+          rel="noreferrer"
+          target="_blank"
+        >
+          {result.publishedUrl}
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="tw-mt-4 tw-border tw-border-solid tw-border-red tw-bg-red/10 tw-p-3 tw-text-sm tw-text-red"
+      role="alert"
+    >
+      <p className="tw-font-semibold">
+        {t(locale, getPublishErrorKey(result.code))}
+      </p>
+      <p className="tw-mt-1 tw-break-words tw-text-xs tw-leading-5">
+        {result.message}
+      </p>
+    </div>
+  );
+}
+
+function PublishStepRow({
+  index,
+  label,
+  status,
+}: {
+  readonly index: number;
+  readonly label: string;
+  readonly status: StepStatus;
+}) {
+  return (
+    <li className="tw-flex tw-items-center tw-gap-3">
+      <span
+        aria-hidden="true"
+        className={`tw-flex tw-h-6 tw-w-6 tw-flex-none tw-items-center tw-justify-center tw-border tw-border-solid tw-text-xs tw-font-semibold ${getStepBadgeClass(
+          status
+        )}`}
+      >
+        {getStepGlyph(status, index)}
+      </span>
+      <span className={`tw-text-sm ${getStepLabelClass(status)}`}>{label}</span>
+    </li>
+  );
+}
+
+function getStepStatuses(state: PublishState): readonly StepStatus[] {
+  const errorIndex =
+    state.result && !state.result.ok
+      ? PUBLISH_STEPS.indexOf(state.result.step)
+      : -1;
+
+  return PUBLISH_STEPS.map((_, index) => {
+    if (index === errorIndex) {
+      return "error";
+    }
+    if (index <= state.reachedStep) {
+      return "done";
+    }
+    if (state.running && index === state.reachedStep + 1) {
+      return "active";
+    }
+    return "idle";
+  });
+}
+
+function getReachedStepFromFailure(
+  step: ProfileCmsPublishStep,
+  hasContext: boolean
+): number {
+  // On failure, all steps strictly before the failed one succeeded. When the
+  // sign/publish tail fails after a successful upload, mark upload as done.
+  const failedIndex = PUBLISH_STEPS.indexOf(step);
+  if (hasContext) {
+    return Math.max(failedIndex - 1, PUBLISH_STEPS.indexOf("upload"));
+  }
+  return failedIndex - 1;
+}
+
+function canRetrySignTail(state: PublishState): boolean {
+  return (
+    !state.running &&
+    state.context !== null &&
+    state.result !== null &&
+    !state.result.ok
+  );
+}
+
+function isDeadlineExpired(state: PublishState): boolean {
+  return (
+    state.result !== null &&
+    !state.result.ok &&
+    state.result.code === "deadline_expired"
+  );
+}
+
+function getStepBadgeClass(status: StepStatus): string {
+  switch (status) {
+    case "done":
+      return "tw-border-green tw-bg-green/10 tw-text-green";
+    case "active":
+      return "tw-border-primary-400 tw-bg-primary-500/10 tw-text-primary-200";
+    case "error":
+      return "tw-border-red tw-bg-red/10 tw-text-red";
+    case "idle":
+      return "tw-border-iron-700 tw-bg-black tw-text-iron-500";
+  }
+}
+
+function getStepLabelClass(status: StepStatus): string {
+  switch (status) {
+    case "done":
+      return "tw-text-iron-100";
+    case "active":
+      return "tw-text-white tw-font-semibold";
+    case "error":
+      return "tw-text-red";
+    case "idle":
+      return "tw-text-iron-500";
+  }
+}
+
+function getStepGlyph(status: StepStatus, index: number): string {
+  switch (status) {
+    case "done":
+      return "✓";
+    case "error":
+      return "!";
+    case "active":
+    case "idle":
+      return String(index + 1);
+  }
+}
+
+function getStepLabelKey(
+  step: ProfileCmsPublishStep
+): Parameters<typeof t>[1] {
+  switch (step) {
+    case "validate":
+      return "profileCms.builder.publish.step.validate";
+    case "upload":
+      return "profileCms.builder.publish.step.upload";
+    case "sign":
+      return "profileCms.builder.publish.step.sign";
+    case "publish":
+      return "profileCms.builder.publish.step.publish";
+  }
+}
+
+function getPublishErrorKey(
+  code: Extract<ProfileCmsPublishResult, { ok: false }>["code"]
+): Parameters<typeof t>[1] {
+  switch (code) {
+    case "server_validation_invalid":
+      return "profileCms.builder.publish.error.validationInvalid";
+    case "save_failed":
+      return "profileCms.builder.publish.error.saveFailed";
+    case "validate_failed":
+      return "profileCms.builder.publish.error.validateFailed";
+    case "upload_failed":
+      return "profileCms.builder.publish.error.uploadFailed";
+    case "signature_rejected":
+      return "profileCms.builder.publish.error.signatureRejected";
+    case "signature_failed":
+      return "profileCms.builder.publish.error.signatureFailed";
+    case "deadline_expired":
+      return "profileCms.builder.publish.error.deadlineExpired";
+    case "publish_conflict":
+      return "profileCms.builder.publish.error.publishConflict";
+    case "publish_failed":
+      return "profileCms.builder.publish.error.publishFailed";
+  }
+}

--- a/components/profile-cms-builder/ProfileCmsPublishPanel.tsx
+++ b/components/profile-cms-builder/ProfileCmsPublishPanel.tsx
@@ -23,7 +23,7 @@ const PUBLISH_STEPS: readonly ProfileCmsPublishStep[] = [
   "publish",
 ];
 
-export type ProfileCmsPublishPanelProps = {
+type ProfileCmsPublishPanelProps = {
   readonly cmsPackage: CmsPackageV1;
   readonly profileId: string | undefined;
   readonly canUseBuilderApi: boolean;
@@ -362,9 +362,7 @@ function getStepGlyph(status: StepStatus, index: number): string {
   }
 }
 
-function getStepLabelKey(
-  step: ProfileCmsPublishStep
-): Parameters<typeof t>[1] {
+function getStepLabelKey(step: ProfileCmsPublishStep): Parameters<typeof t>[1] {
   switch (step) {
     case "validate":
       return "profileCms.builder.publish.step.validate";

--- a/components/profile-cms-builder/ProfileCmsVersionHistoryPanel.tsx
+++ b/components/profile-cms-builder/ProfileCmsVersionHistoryPanel.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { formatInteger } from "@/i18n/format";
+import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
+import {
+  listProfileCmsPackagesForProfile,
+  rollbackProfileCmsPackage,
+  type ProfileCmsPackageRecord,
+} from "@/lib/profile-cms/builder/api";
+
+type ListStatus = "idle" | "loading" | "ready" | "error";
+type RollbackStatus = "idle" | "working" | "error" | "done";
+
+type ProfileCmsVersionHistoryPanelProps = {
+  readonly profileId: string | undefined;
+  readonly canUseBuilderApi: boolean;
+  readonly builderApiEnabled: boolean;
+  readonly locale?: SupportedLocale | undefined;
+  // Bumped by the parent after a successful publish so the list refreshes.
+  readonly refreshToken?: number | undefined;
+};
+
+export default function ProfileCmsVersionHistoryPanel({
+  profileId,
+  canUseBuilderApi,
+  builderApiEnabled,
+  locale = DEFAULT_LOCALE,
+  refreshToken = 0,
+}: ProfileCmsVersionHistoryPanelProps) {
+  const [status, setStatus] = useState<ListStatus>("idle");
+  const [packages, setPackages] = useState<readonly ProfileCmsPackageRecord[]>(
+    []
+  );
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [rollbackStatus, setRollbackStatus] = useState<RollbackStatus>("idle");
+  const [rollbackError, setRollbackError] = useState("");
+  const requestIdRef = useRef(0);
+
+  const canRequest = canUseBuilderApi && builderApiEnabled && !!profileId;
+
+  const loadPackages = useCallback(async () => {
+    if (!profileId || !canRequest) {
+      return;
+    }
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    setStatus("loading");
+    try {
+      const records = await listProfileCmsPackagesForProfile(profileId);
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+      setPackages(records);
+      setStatus("ready");
+    } catch {
+      if (requestId !== requestIdRef.current) {
+        return;
+      }
+      setStatus("error");
+    }
+  }, [canRequest, profileId]);
+
+  useEffect(() => {
+    if (refreshToken > 0 && canRequest) {
+      void loadPackages();
+    }
+  }, [refreshToken, canRequest, loadPackages]);
+
+  const primary = packages.find((record) => record.status === "published");
+  const rollbackTargets = packages.filter(
+    (record) =>
+      (record.status === "published" || record.status === "superseded") &&
+      record.id !== primary?.id
+  );
+
+  const confirmRollback = async (target: ProfileCmsPackageRecord) => {
+    if (!primary) {
+      return;
+    }
+    setRollbackStatus("working");
+    setRollbackError("");
+    try {
+      await rollbackProfileCmsPackage(target.id, {
+        expected_current_package_id: primary.packageId,
+        expected_current_package_hash: primary.packageHash,
+      });
+      setConfirmingId(null);
+      setRollbackStatus("done");
+      await loadPackages();
+    } catch (error) {
+      setRollbackStatus("error");
+      setRollbackError(getErrorMessage(error));
+    }
+  };
+
+  return (
+    <section className="tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-900 tw-p-4">
+      <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
+        <h2 className="tw-text-base tw-font-semibold tw-text-white">
+          {t(locale, "profileCms.builder.history.title")}
+        </h2>
+        <button
+          className="tw-min-h-10 tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-px-3 tw-text-sm tw-font-semibold tw-text-iron-100 hover:tw-border-primary-400 disabled:tw-cursor-not-allowed disabled:tw-opacity-50"
+          disabled={!canRequest || status === "loading"}
+          onClick={() => void loadPackages()}
+          type="button"
+        >
+          {status === "loading"
+            ? t(locale, "profileCms.builder.history.loading")
+            : t(locale, "profileCms.builder.history.refresh")}
+        </button>
+      </div>
+
+      {!canRequest ? (
+        <p className="tw-mt-3 tw-text-sm tw-leading-6 tw-text-iron-400">
+          {t(locale, "profileCms.builder.history.unavailable")}
+        </p>
+      ) : null}
+
+      {canRequest && status === "error" ? (
+        <p
+          className="tw-mt-3 tw-border tw-border-solid tw-border-red tw-bg-red/10 tw-p-3 tw-text-sm tw-text-red"
+          role="alert"
+        >
+          {t(locale, "profileCms.builder.history.failed")}
+        </p>
+      ) : null}
+
+      {canRequest && status === "ready" && !packages.length ? (
+        <p className="tw-mt-3 tw-text-sm tw-leading-6 tw-text-iron-400">
+          {t(locale, "profileCms.builder.history.empty")}
+        </p>
+      ) : null}
+
+      {packages.length ? (
+        <ul className="tw-mt-3 tw-flex tw-flex-col tw-gap-2">
+          {packages.map((record) => {
+            const isPrimary = record.id === primary?.id;
+            const canRollback = rollbackTargets.some(
+              (target) => target.id === record.id
+            );
+            return (
+              <li
+                className="tw-flex tw-flex-col tw-gap-2 tw-border tw-border-solid tw-border-iron-700 tw-bg-black tw-p-3"
+                key={record.id}
+              >
+                <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2">
+                  <div className="tw-min-w-0">
+                    <p className="tw-truncate tw-text-sm tw-font-semibold tw-text-white">
+                      {t(locale, "profileCms.builder.history.version", {
+                        version: formatInteger(locale, record.version),
+                      })}{" "}
+                      · {t(locale, getStatusLabelKey(record.status))}
+                      {isPrimary
+                        ? ` · ${t(locale, "profileCms.builder.history.primary")}`
+                        : ""}
+                    </p>
+                    <p className="tw-mt-1 tw-truncate tw-font-mono tw-text-xs tw-text-iron-500">
+                      {record.packageHash}
+                    </p>
+                  </div>
+                  {canRollback ? (
+                    <button
+                      className="tw-min-h-9 tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-px-3 tw-text-sm tw-text-iron-100 hover:tw-border-primary-400 disabled:tw-cursor-not-allowed disabled:tw-opacity-50"
+                      disabled={rollbackStatus === "working"}
+                      onClick={() => setConfirmingId(record.id)}
+                      type="button"
+                    >
+                      {t(locale, "profileCms.builder.history.rollback")}
+                    </button>
+                  ) : null}
+                </div>
+
+                {confirmingId === record.id ? (
+                  <div
+                    className="tw-border tw-border-solid tw-border-primary-400 tw-bg-primary-500/10 tw-p-3"
+                    role="alertdialog"
+                    aria-label={t(
+                      locale,
+                      "profileCms.builder.history.confirm.title"
+                    )}
+                  >
+                    <p className="tw-text-sm tw-leading-6 tw-text-iron-100">
+                      {t(locale, "profileCms.builder.history.confirm.body", {
+                        version: formatInteger(locale, record.version),
+                      })}
+                    </p>
+                    <div className="tw-mt-3 tw-flex tw-flex-wrap tw-gap-2">
+                      <button
+                        className="tw-min-h-9 tw-border tw-border-solid tw-border-primary-400 tw-bg-primary-500 tw-px-3 tw-text-sm tw-font-semibold tw-text-white disabled:tw-cursor-not-allowed disabled:tw-opacity-50"
+                        disabled={rollbackStatus === "working"}
+                        onClick={() => void confirmRollback(record)}
+                        type="button"
+                      >
+                        {rollbackStatus === "working"
+                          ? t(
+                              locale,
+                              "profileCms.builder.history.confirm.working"
+                            )
+                          : t(
+                              locale,
+                              "profileCms.builder.history.confirm.confirm"
+                            )}
+                      </button>
+                      <button
+                        className="tw-min-h-9 tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-950 tw-px-3 tw-text-sm tw-text-iron-100 hover:tw-border-primary-400 disabled:tw-cursor-not-allowed disabled:tw-opacity-50"
+                        disabled={rollbackStatus === "working"}
+                        onClick={() => setConfirmingId(null)}
+                        type="button"
+                      >
+                        {t(locale, "profileCms.builder.history.confirm.cancel")}
+                      </button>
+                    </div>
+                    {rollbackStatus === "error" ? (
+                      <p
+                        className="tw-mt-2 tw-break-words tw-text-xs tw-leading-5 tw-text-red"
+                        role="alert"
+                      >
+                        {rollbackError ||
+                          t(
+                            locale,
+                            "profileCms.builder.history.rollbackFailed"
+                          )}
+                      </p>
+                    ) : null}
+                  </div>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </section>
+  );
+}
+
+function getStatusLabelKey(
+  status: ProfileCmsPackageRecord["status"]
+): Parameters<typeof t>[1] {
+  switch (status) {
+    case "draft":
+      return "profileCms.builder.drafts.status.draft";
+    case "validating":
+      return "profileCms.builder.drafts.status.validating";
+    case "published":
+      return "profileCms.builder.drafts.status.published";
+    case "failed":
+      return "profileCms.builder.drafts.status.failed";
+    case "archived":
+      return "profileCms.builder.drafts.status.archived";
+    case "superseded":
+      return "profileCms.builder.drafts.status.superseded";
+    default:
+      return "profileCms.builder.drafts.status.draft";
+  }
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") {
+      return message;
+    }
+  }
+  return "";
+}

--- a/hooks/profile-cms/useProfileCmsPublishSign.ts
+++ b/hooks/profile-cms/useProfileCmsPublishSign.ts
@@ -11,7 +11,7 @@ import type {
   ProfileCmsSignTypedDataResult,
 } from "@/lib/profile-cms/builder/publish";
 
-export type ProfileCmsPublishSigner = {
+type ProfileCmsPublishSigner = {
   readonly signTypedData: ProfileCmsSignTypedData;
   readonly chainId: number;
   readonly signerAddress: string | undefined;
@@ -57,11 +57,28 @@ export function useProfileCmsPublishSign(): ProfileCmsPublishSigner {
       typedData: ProfileCmsPublishTypedData
     ): Promise<ProfileCmsSignTypedDataResult> => {
       try {
+        // viem encodes EIP-712 uint256 fields as bigint and addresses as
+        // `0x`-prefixed hex; ethers on the backend encodes the same numeric
+        // values from plain numbers, so the signable hash is identical.
+        const { message, domain } = typedData;
         const signature = await signTypedDataAsync({
-          domain: typedData.domain,
+          domain: {
+            name: domain.name,
+            version: domain.version,
+            chainId: domain.chainId,
+            ...(domain.verifyingContract
+              ? {
+                  verifyingContract: domain.verifyingContract as `0x${string}`,
+                }
+              : {}),
+          },
           types: typedData.types,
           primaryType: typedData.primaryType,
-          message: typedData.message,
+          message: {
+            ...message,
+            version: BigInt(message.version),
+            deadline: BigInt(message.deadline),
+          },
         });
         return { ok: true, signature };
       } catch (error) {

--- a/hooks/profile-cms/useProfileCmsPublishSign.ts
+++ b/hooks/profile-cms/useProfileCmsPublishSign.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useCallback } from "react";
+import { useChainId, useSignTypedData } from "wagmi";
+import { UserRejectedRequestError } from "viem";
+
+import { useSeizeConnectContext } from "@/components/auth/SeizeConnectContext";
+import type {
+  ProfileCmsPublishTypedData,
+  ProfileCmsSignTypedData,
+  ProfileCmsSignTypedDataResult,
+} from "@/lib/profile-cms/builder/publish";
+
+export type ProfileCmsPublishSigner = {
+  readonly signTypedData: ProfileCmsSignTypedData;
+  readonly chainId: number;
+  readonly signerAddress: string | undefined;
+  readonly isConnected: boolean;
+  readonly isSafe: boolean;
+};
+
+const isUserRejectedSigningError = (error: unknown): boolean => {
+  try {
+    if (error instanceof UserRejectedRequestError) {
+      return true;
+    }
+  } catch {
+    // Fall through to shape-based checks for cross-realm wallet errors.
+  }
+
+  if (error === null || error === undefined || typeof error !== "object") {
+    return false;
+  }
+
+  const errorObject = error as Record<string, unknown>;
+  return (
+    errorObject["name"] === "UserRejectedRequestError" ||
+    errorObject["code"] === 4001 ||
+    errorObject["code"] === "4001"
+  );
+};
+
+/**
+ * Wallet signer for the Profile CMS publish EIP-712 typed data. Wraps wagmi's
+ * useSignTypedData so the orchestration in lib/profile-cms/builder/publish.ts
+ * stays wallet-agnostic and unit-testable. Reports Safe/contract wallets via
+ * the existing SeizeConnect Safe detection so the publish request can set
+ * is_safe_signature and, when known, verifyingContract.
+ */
+export function useProfileCmsPublishSign(): ProfileCmsPublishSigner {
+  const chainId = useChainId();
+  const { signTypedDataAsync } = useSignTypedData();
+  const { address, isConnected, isSafeWallet } = useSeizeConnectContext();
+
+  const signTypedData = useCallback<ProfileCmsSignTypedData>(
+    async (
+      typedData: ProfileCmsPublishTypedData
+    ): Promise<ProfileCmsSignTypedDataResult> => {
+      try {
+        const signature = await signTypedDataAsync({
+          domain: typedData.domain,
+          types: typedData.types,
+          primaryType: typedData.primaryType,
+          message: typedData.message,
+        });
+        return { ok: true, signature };
+      } catch (error) {
+        return { ok: false, rejected: isUserRejectedSigningError(error) };
+      }
+    },
+    [signTypedDataAsync]
+  );
+
+  return {
+    signTypedData,
+    chainId,
+    signerAddress: address,
+    isConnected,
+    isSafe: isSafeWallet,
+  };
+}

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -1407,6 +1407,58 @@ export const EN_US_MESSAGES = {
   "profileCms.builder.drafts.status.superseded": "Superseded",
   "profileCms.builder.drafts.loadFailed":
     "This draft could not be loaded into the editor.",
+  "profileCms.builder.publish.title": "Publish",
+  "profileCms.builder.publish.description":
+    "Save, validate, upload to decentralized storage, sign with your wallet, then publish this package as your primary profile website.",
+  "profileCms.builder.publish.publish": "Publish website",
+  "profileCms.builder.publish.publishing": "Publishing...",
+  "profileCms.builder.publish.retry": "Retry",
+  "profileCms.builder.publish.reSign": "Sign again",
+  "profileCms.builder.publish.walletRequired":
+    "Connect the wallet linked to this profile to sign the publish.",
+  "profileCms.builder.publish.safeNotice":
+    "Safe / smart-contract wallet detected. Publishing requests an EIP-1271 signature; if your Safe cannot complete it, publish from the profile's EOA wallet instead.",
+  "profileCms.builder.publish.success":
+    "Published. Your profile website is now live at:",
+  "profileCms.builder.publish.step.validate": "Save and validate draft",
+  "profileCms.builder.publish.step.upload": "Upload to storage",
+  "profileCms.builder.publish.step.sign": "Sign with wallet",
+  "profileCms.builder.publish.step.publish": "Publish primary pointer",
+  "profileCms.builder.publish.error.validationInvalid":
+    "Server validation found blocking issues. Fix them, then publish again.",
+  "profileCms.builder.publish.error.saveFailed":
+    "Could not save the draft before publishing.",
+  "profileCms.builder.publish.error.validateFailed":
+    "The server validation request failed.",
+  "profileCms.builder.publish.error.uploadFailed":
+    "Uploading the package to decentralized storage failed.",
+  "profileCms.builder.publish.error.signatureRejected":
+    "The signature request was canceled in your wallet.",
+  "profileCms.builder.publish.error.signatureFailed":
+    "Wallet signing failed. Check your wallet and try again.",
+  "profileCms.builder.publish.error.deadlineExpired":
+    "The signature deadline expired before publishing. Sign again to continue.",
+  "profileCms.builder.publish.error.publishConflict":
+    "The draft changed on the server since it was signed. Retry to re-sign and publish.",
+  "profileCms.builder.publish.error.publishFailed":
+    "Publishing failed. Please try again.",
+  "profileCms.builder.history.title": "Version history",
+  "profileCms.builder.history.refresh": "Refresh",
+  "profileCms.builder.history.loading": "Loading...",
+  "profileCms.builder.history.unavailable":
+    "Connect as this profile owner to view published versions.",
+  "profileCms.builder.history.failed": "Could not load version history.",
+  "profileCms.builder.history.empty": "No published versions yet.",
+  "profileCms.builder.history.version": "Version {version}",
+  "profileCms.builder.history.primary": "Primary",
+  "profileCms.builder.history.rollback": "Make primary",
+  "profileCms.builder.history.rollbackFailed": "Rollback failed.",
+  "profileCms.builder.history.confirm.title": "Confirm rollback",
+  "profileCms.builder.history.confirm.body":
+    "Point your primary profile website back to version {version}? This replaces the currently published version.",
+  "profileCms.builder.history.confirm.confirm": "Roll back",
+  "profileCms.builder.history.confirm.working": "Rolling back...",
+  "profileCms.builder.history.confirm.cancel": "Cancel",
   ...USER_COLLECTED_STATS_MESSAGES,
   ...USER_COLLECTED_STATS_DETAILS_MESSAGES,
   ...USER_COLLECTED_STATS_BOOST_MESSAGES,

--- a/lib/profile-cms/builder/api.ts
+++ b/lib/profile-cms/builder/api.ts
@@ -19,8 +19,9 @@ import { commonApiFetch, commonApiPost } from "@/services/api/common-api";
 
 // Real backend contract (see D:\repos\6529seize-backend
 // src/api-serverless/src/generated/routes/openapi-generated.routes.ts and
-// src/api-serverless/src/profile-cms/*.handlers.ts). Publish stays hard
-// blocked client-side below regardless of what the backend exposes.
+// src/api-serverless/src/profile-cms/*.handlers.ts). Publish is now wired to
+// the real signed-storage flow via the orchestration in
+// lib/profile-cms/builder/publish.ts.
 export const PROFILE_CMS_GALLERY_SNAPSHOT_ENDPOINT =
   "profile-cms/wallet-gallery/snapshot";
 export const PROFILE_CMS_BUILDER_PACKAGES_ENDPOINT = "profile-cms/packages";
@@ -28,17 +29,20 @@ export const PROFILE_CMS_BUILDER_VALIDATE_ENDPOINT =
   "profile-cms/packages/validate";
 export const PROFILE_CMS_BUILDER_PUBLISH_ENDPOINT =
   "profile-cms/packages/{id}/publish";
+export const PROFILE_CMS_BUILDER_STORAGE_UPLOAD_ENDPOINT =
+  "profile-cms/packages/{id}/storage/upload";
+export const PROFILE_CMS_BUILDER_ROLLBACK_ENDPOINT =
+  "profile-cms/packages/{id}/rollback";
 const PROFILE_CMS_BUILDER_PACKAGE_BY_ID_ENDPOINT = "profile-cms/packages/{id}";
 const PROFILE_CMS_BUILDER_PROFILE_PACKAGES_ENDPOINT =
   "profile-cms/profiles/{profile_id}/packages";
 
-export type ProfileCmsBuilderAction = "save_draft" | "validate" | "publish";
+export type ProfileCmsBuilderAction = "save_draft" | "validate";
 export type ProfileCmsBuilderActionCode =
   | "api_disabled"
   | "missing_draft_id"
   | "missing_profile_id"
   | "profile_not_authorized"
-  | "publish_requires_signed_storage"
   | "request_failed"
   | "server_validation_completed"
   | "server_validation_invalid"
@@ -51,6 +55,8 @@ export type ProfileCmsBuilderActionResult =
       readonly code: ProfileCmsBuilderActionCode;
       readonly draftId?: string | undefined;
       readonly packageHash?: string | undefined;
+      readonly payloadHash?: string | undefined;
+      readonly version?: number | undefined;
     }
   | {
       readonly ok: false;
@@ -61,27 +67,57 @@ export type ProfileCmsBuilderActionResult =
 
 export type { ProfileCmsPackageRecord } from "@/lib/profile-cms/builder/package-normalize";
 
+/**
+ * Canonical storage receipt returned by the storage-upload endpoint, mirroring
+ * the backend `CmsStorageReceiptV1` / `ApiProfileCmsStorageReceipt` shape (see
+ * 6529seize-backend PR #1713, branch codex/cms-arweave-storage-upload). The
+ * frontend has no generated model for this yet, so the shape is pinned here.
+ */
+export type ProfileCmsStorageReceipt = {
+  readonly provider: "ipfs" | "arweave" | "s3" | "fixture";
+  readonly uri: string;
+  readonly content_hash: string;
+  readonly provider_content_id?: string | undefined;
+  readonly pinned?: boolean | undefined;
+  readonly canonical: boolean;
+  readonly recorded_at: string;
+};
+
+/**
+ * Publish request body. Mirrors the generated
+ * `ApiPublishProfileCmsPackageRequest` model and the backend Joi
+ * `PublishBodySchema`. `verifying_contract` is only set for Safe/EIP-1271.
+ */
+export type ProfileCmsPublishRequest = {
+  readonly expected_package_hash?: string | undefined;
+  readonly expected_payload_hash?: string | undefined;
+  readonly signer_address: string;
+  readonly signature: string;
+  readonly chain_id: number;
+  readonly deadline: number;
+  readonly is_safe_signature?: boolean | undefined;
+  readonly verifying_contract?: string | null | undefined;
+};
+
+/**
+ * Rollback request body. Mirrors `ApiRollbackProfileCmsPackageRequest` and the
+ * backend Joi `RollbackBodySchema`.
+ */
+export type ProfileCmsRollbackRequest = {
+  readonly expected_current_package_id: string;
+  readonly expected_current_package_hash?: string | undefined;
+};
+
 export async function runProfileCmsBuilderAction({
   action,
   cmsPackage,
-  draftId,
   profileId,
 }: {
   readonly action: ProfileCmsBuilderAction;
   readonly cmsPackage: CmsPackageV1;
-  readonly draftId?: string | undefined;
   readonly profileId?: string | undefined;
 }): Promise<ProfileCmsBuilderActionResult> {
-  const endpoint = getEndpoint({ action, draftId });
-
-  if (action === "publish") {
-    return {
-      ok: false,
-      action,
-      expectedEndpoint: endpoint,
-      code: "publish_requires_signed_storage",
-    };
-  }
+  const endpoint = getEndpoint({ action });
 
   if (!isProfileCmsBuilderApiEnabledEnv()) {
     return {
@@ -117,7 +153,83 @@ export async function runProfileCmsBuilderAction({
         : getSuccessCode(action),
     ...(response.draftId ? { draftId: response.draftId } : {}),
     ...(response.packageHash ? { packageHash: response.packageHash } : {}),
+    ...(response.payloadHash ? { payloadHash: response.payloadHash } : {}),
+    ...(response.version === undefined ? {} : { version: response.version }),
   };
+}
+
+/**
+ * Upload the canonical package JSON to decentralized storage and return the
+ * persisted canonical receipt. Backing endpoint:
+ * `POST profile-cms/packages/:id/storage/upload` (no request body). The backend
+ * writes the receipt into the stored draft's `storage` array; callers must not
+ * fabricate receipts client-side.
+ */
+export async function uploadProfileCmsPackageStorage(
+  id: string
+): Promise<ProfileCmsStorageReceipt> {
+  assertProfileCmsBuilderApiEnabled();
+  const response = await commonApiPost<
+    Record<string, never>,
+    { readonly receipt: ProfileCmsStorageReceipt }
+  >({
+    endpoint: PROFILE_CMS_BUILDER_STORAGE_UPLOAD_ENDPOINT.replace(
+      "{id}",
+      encodeURIComponent(id)
+    ),
+    body: {},
+    errorMode: "structured",
+  });
+
+  return response.receipt;
+}
+
+/**
+ * Publish a saved draft as the primary CMS package after wallet signing.
+ * Backing endpoint: `POST profile-cms/packages/:id/publish`.
+ */
+export async function publishProfileCmsPackage(
+  id: string,
+  request: ProfileCmsPublishRequest
+): Promise<ProfileCmsPackageRecord> {
+  assertProfileCmsBuilderApiEnabled();
+  const response = await commonApiPost<
+    ProfileCmsPublishRequest,
+    ProfileCmsPackageWire
+  >({
+    endpoint: PROFILE_CMS_BUILDER_PUBLISH_ENDPOINT.replace(
+      "{id}",
+      encodeURIComponent(id)
+    ),
+    body: request,
+    errorMode: "structured",
+  });
+
+  return normalizeProfileCmsPackageRecord(response);
+}
+
+/**
+ * Roll the primary pointer back to a previously published version.
+ * Backing endpoint: `POST profile-cms/packages/:id/rollback`.
+ */
+export async function rollbackProfileCmsPackage(
+  id: string,
+  request: ProfileCmsRollbackRequest
+): Promise<ProfileCmsPackageRecord> {
+  assertProfileCmsBuilderApiEnabled();
+  const response = await commonApiPost<
+    ProfileCmsRollbackRequest,
+    ProfileCmsPackageWire
+  >({
+    endpoint: PROFILE_CMS_BUILDER_ROLLBACK_ENDPOINT.replace(
+      "{id}",
+      encodeURIComponent(id)
+    ),
+    body: request,
+    errorMode: "structured",
+  });
+
+  return normalizeProfileCmsPackageRecord(response);
 }
 
 export async function requestProfileCmsGallerySnapshot({
@@ -190,30 +302,23 @@ function assertProfileCmsBuilderApiEnabled(): void {
 
 function getEndpoint({
   action,
-  draftId,
 }: {
   readonly action: ProfileCmsBuilderAction;
-  readonly draftId?: string | undefined;
 }): string {
   switch (action) {
     case "save_draft":
       return PROFILE_CMS_BUILDER_PACKAGES_ENDPOINT;
     case "validate":
       return PROFILE_CMS_BUILDER_VALIDATE_ENDPOINT;
-    case "publish":
-      return draftId
-        ? PROFILE_CMS_BUILDER_PUBLISH_ENDPOINT.replace(
-            "{id}",
-            encodeURIComponent(draftId)
-          )
-        : PROFILE_CMS_BUILDER_PUBLISH_ENDPOINT.replace("{id}", ":id");
   }
 }
 
 type BuilderActionResponse = {
   readonly draftId?: string | undefined;
   readonly packageHash?: string | undefined;
+  readonly payloadHash?: string | undefined;
   readonly serverValid?: boolean | undefined;
+  readonly version?: number | undefined;
 };
 
 async function postBuilderAction({
@@ -240,6 +345,8 @@ async function postBuilderAction({
       return {
         draftId: response.id,
         packageHash: response.package_hash,
+        payloadHash: response.payload_hash,
+        version: response.version,
       };
     }
     case "validate": {
@@ -267,8 +374,6 @@ async function postBuilderAction({
         serverValid: response.valid,
       };
     }
-    case "publish":
-      throw new Error("unsupported_publish_action");
   }
 }
 
@@ -280,7 +385,5 @@ function getSuccessCode(
       return "draft_saved";
     case "validate":
       return "server_validation_completed";
-    case "publish":
-      return "publish_requires_signed_storage";
   }
 }

--- a/lib/profile-cms/builder/api.ts
+++ b/lib/profile-cms/builder/api.ts
@@ -28,11 +28,11 @@ export const PROFILE_CMS_GALLERY_SNAPSHOT_ENDPOINT =
 export const PROFILE_CMS_BUILDER_PACKAGES_ENDPOINT = "profile-cms/packages";
 export const PROFILE_CMS_BUILDER_VALIDATE_ENDPOINT =
   "profile-cms/packages/validate";
-export const PROFILE_CMS_BUILDER_PUBLISH_ENDPOINT =
+const PROFILE_CMS_BUILDER_PUBLISH_ENDPOINT =
   "profile-cms/packages/{id}/publish";
-export const PROFILE_CMS_BUILDER_STORAGE_UPLOAD_ENDPOINT =
+const PROFILE_CMS_BUILDER_STORAGE_UPLOAD_ENDPOINT =
   "profile-cms/packages/{id}/storage/upload";
-export const PROFILE_CMS_BUILDER_ROLLBACK_ENDPOINT =
+const PROFILE_CMS_BUILDER_ROLLBACK_ENDPOINT =
   "profile-cms/packages/{id}/rollback";
 const PROFILE_CMS_BUILDER_PACKAGE_BY_ID_ENDPOINT = "profile-cms/packages/{id}";
 const PROFILE_CMS_BUILDER_PROFILE_PACKAGES_ENDPOINT =
@@ -112,7 +112,7 @@ export type ProfileCmsPublishRequest = {
  * Rollback request body. Mirrors `ApiRollbackProfileCmsPackageRequest` and the
  * backend Joi `RollbackBodySchema`.
  */
-export type ProfileCmsRollbackRequest = {
+type ProfileCmsRollbackRequest = {
   readonly expected_current_package_id: string;
   readonly expected_current_package_hash?: string | undefined;
 };

--- a/lib/profile-cms/builder/publish.ts
+++ b/lib/profile-cms/builder/publish.ts
@@ -81,13 +81,9 @@ export type ProfileCmsPublishTypedData = {
   readonly message: ProfileCmsPublishMessage;
 };
 
-export type ProfileCmsPublishStep =
-  | "validate"
-  | "upload"
-  | "sign"
-  | "publish";
+export type ProfileCmsPublishStep = "validate" | "upload" | "sign" | "publish";
 
-export type ProfileCmsPublishErrorCode =
+type ProfileCmsPublishErrorCode =
   | "server_validation_invalid"
   | "save_failed"
   | "validate_failed"
@@ -142,7 +138,7 @@ export type ProfileCmsSignTypedData = (
   typedData: ProfileCmsPublishTypedData
 ) => Promise<ProfileCmsSignTypedDataResult>;
 
-export type RunProfileCmsPublishInput = {
+type RunProfileCmsPublishInput = {
   readonly cmsPackage: CmsPackageV1;
   readonly profileId: string;
   readonly chainId: number;
@@ -211,7 +207,10 @@ export function getProfileCmsPublishedUrl(
  */
 export async function prepareProfileCmsPublish(
   input: RunProfileCmsPublishInput
-): Promise<ProfileCmsPublishFailure | { readonly ok: true; readonly context: ProfileCmsPublishContext }> {
+): Promise<
+  | ProfileCmsPublishFailure
+  | { readonly ok: true; readonly context: ProfileCmsPublishContext }
+> {
   const { cmsPackage, profileId } = input;
 
   const saved = await runProfileCmsBuilderAction({
@@ -235,19 +234,22 @@ export async function prepareProfileCmsPublish(
     profileId,
   });
   if (!validated.ok) {
+    // A rejected server validation is a completed request whose outcome is
+    // "not valid" — abort before upload and surface it as a validation
+    // failure, distinct from a transport error.
+    if (validated.code === "server_validation_invalid") {
+      return {
+        ok: false,
+        step: "validate",
+        code: "server_validation_invalid",
+        message: "Server rejected the package as invalid.",
+      };
+    }
     return {
       ok: false,
       step: "validate",
       code: "validate_failed",
       message: "Server validation request failed.",
-    };
-  }
-  if (validated.code === "server_validation_invalid") {
-    return {
-      ok: false,
-      step: "validate",
-      code: "server_validation_invalid",
-      message: "Server rejected the package as invalid.",
     };
   }
 
@@ -403,10 +405,12 @@ export async function runProfileCmsPublish(
     chainId: input.chainId,
     signerAddress: input.signerAddress,
     signTypedData: input.signTypedData,
-    isSafe: input.isSafe,
-    verifyingContract: input.verifyingContract,
-    now: input.now,
-    baseUrl: input.baseUrl,
+    ...(input.isSafe === undefined ? {} : { isSafe: input.isSafe }),
+    ...(input.verifyingContract === undefined
+      ? {}
+      : { verifyingContract: input.verifyingContract }),
+    ...(input.now === undefined ? {} : { now: input.now }),
+    ...(input.baseUrl === undefined ? {} : { baseUrl: input.baseUrl }),
   });
 }
 

--- a/lib/profile-cms/builder/publish.ts
+++ b/lib/profile-cms/builder/publish.ts
@@ -1,0 +1,447 @@
+// Profile CMS publish orchestration.
+//
+// Sequences the full signed-storage publish flow end to end:
+//   1. save draft   -> get server-authoritative id/version/hashes
+//   2. validate     -> server must report the package valid
+//   3. storage      -> upload canonical JSON, get the persisted receipt
+//   4. sign         -> build EIP-712 typed data and request a wallet signature
+//   5. publish      -> POST the signature + chain metadata
+//
+// The typed data is constructed field-for-field to match the backend domain and
+// `ProfileCmsPublish` type in
+// 6529seize-backend/src/profile-cms/profile-cms-signing.ts. All hashes, handle,
+// version, package id and draft id come from server responses (never fabricated
+// client-side); the storage receipt comes from the backend upload endpoint.
+import type { CmsPackageV1 } from "@/lib/profile-cms/protocol/v1";
+import {
+  publishProfileCmsPackage,
+  runProfileCmsBuilderAction,
+  uploadProfileCmsPackageStorage,
+  type ProfileCmsPackageRecord,
+  type ProfileCmsPublishRequest,
+  type ProfileCmsStorageReceipt,
+} from "@/lib/profile-cms/builder/api";
+
+// EIP-712 domain — must match PROFILE_CMS_PUBLISH_EIP712_DOMAIN_NAME/VERSION.
+export const PROFILE_CMS_PUBLISH_DOMAIN_NAME = "6529 Profile CMS";
+export const PROFILE_CMS_PUBLISH_DOMAIN_VERSION = "1";
+export const PROFILE_CMS_PUBLISH_PRIMARY_TYPE = "ProfileCmsPublish";
+
+// Deadline window: the backend rejects deadlines more than 15 minutes ahead
+// (PROFILE_CMS_PUBLISH_MAX_DEADLINE_MS). Sign for 10 minutes, comfortably under.
+export const PROFILE_CMS_PUBLISH_DEADLINE_MS = 10 * 60 * 1000;
+
+// EIP-712 type definition — field order and types must match
+// PROFILE_CMS_PUBLISH_EIP712_TYPES exactly.
+export const PROFILE_CMS_PUBLISH_EIP712_TYPES = {
+  ProfileCmsPublish: [
+    { name: "action", type: "string" },
+    { name: "profileId", type: "string" },
+    { name: "handle", type: "string" },
+    { name: "packageId", type: "string" },
+    { name: "version", type: "uint256" },
+    { name: "draftId", type: "string" },
+    { name: "payloadHash", type: "string" },
+    { name: "packageHash", type: "string" },
+    { name: "primaryPath", type: "string" },
+    { name: "storageProvider", type: "string" },
+    { name: "storageUri", type: "string" },
+    { name: "storageContentHash", type: "string" },
+    { name: "deadline", type: "uint256" },
+  ],
+} as const;
+
+export type ProfileCmsPublishDomain = {
+  readonly name: string;
+  readonly version: string;
+  readonly chainId: number;
+  readonly verifyingContract?: string | undefined;
+};
+
+export type ProfileCmsPublishMessage = {
+  readonly action: "publish";
+  readonly profileId: string;
+  readonly handle: string;
+  readonly packageId: string;
+  readonly version: number;
+  readonly draftId: string;
+  readonly payloadHash: string;
+  readonly packageHash: string;
+  readonly primaryPath: string;
+  readonly storageProvider: string;
+  readonly storageUri: string;
+  readonly storageContentHash: string;
+  readonly deadline: number;
+};
+
+export type ProfileCmsPublishTypedData = {
+  readonly domain: ProfileCmsPublishDomain;
+  readonly types: typeof PROFILE_CMS_PUBLISH_EIP712_TYPES;
+  readonly primaryType: typeof PROFILE_CMS_PUBLISH_PRIMARY_TYPE;
+  readonly message: ProfileCmsPublishMessage;
+};
+
+export type ProfileCmsPublishStep =
+  | "validate"
+  | "upload"
+  | "sign"
+  | "publish";
+
+export type ProfileCmsPublishErrorCode =
+  | "server_validation_invalid"
+  | "save_failed"
+  | "validate_failed"
+  | "upload_failed"
+  | "signature_rejected"
+  | "signature_failed"
+  | "deadline_expired"
+  | "publish_conflict"
+  | "publish_failed";
+
+/**
+ * Context prepared once (save + validate + upload) and reused across
+ * sign/publish attempts so a deadline-expiry retry only re-signs and re-posts.
+ */
+export type ProfileCmsPublishContext = {
+  readonly draftId: string;
+  readonly profileId: string;
+  readonly handle: string;
+  readonly packageId: string;
+  readonly version: number;
+  readonly payloadHash: string;
+  readonly packageHash: string;
+  readonly primaryPath: string;
+  readonly receipt: ProfileCmsStorageReceipt;
+};
+
+export type ProfileCmsPublishSuccess = {
+  readonly ok: true;
+  readonly published: ProfileCmsPackageRecord;
+  readonly publishedUrl: string;
+};
+
+export type ProfileCmsPublishFailure = {
+  readonly ok: false;
+  readonly step: ProfileCmsPublishStep;
+  readonly code: ProfileCmsPublishErrorCode;
+  readonly message: string;
+  // Present once save+validate+upload have succeeded, so the caller can retry
+  // just the sign/publish tail (e.g. after a deadline_expired rejection).
+  readonly context?: ProfileCmsPublishContext | undefined;
+};
+
+export type ProfileCmsPublishResult =
+  | ProfileCmsPublishSuccess
+  | ProfileCmsPublishFailure;
+
+export type ProfileCmsSignTypedDataResult =
+  | { readonly ok: true; readonly signature: string }
+  | { readonly ok: false; readonly rejected: boolean };
+
+export type ProfileCmsSignTypedData = (
+  typedData: ProfileCmsPublishTypedData
+) => Promise<ProfileCmsSignTypedDataResult>;
+
+export type RunProfileCmsPublishInput = {
+  readonly cmsPackage: CmsPackageV1;
+  readonly profileId: string;
+  readonly chainId: number;
+  readonly signerAddress: string;
+  readonly signTypedData: ProfileCmsSignTypedData;
+  readonly isSafe?: boolean | undefined;
+  readonly verifyingContract?: string | null | undefined;
+  readonly now?: () => number;
+  readonly baseUrl?: string | undefined;
+};
+
+const DEFAULT_PUBLISHED_BASE_URL = "https://6529.io";
+
+/**
+ * Build the EIP-712 typed data for a publish. Pure and deterministic given the
+ * context + signing metadata; exported for direct unit testing against the
+ * backend fixture.
+ */
+export function buildProfileCmsPublishTypedData(params: {
+  readonly context: ProfileCmsPublishContext;
+  readonly chainId: number;
+  readonly deadline: number;
+  readonly verifyingContract?: string | null | undefined;
+}): ProfileCmsPublishTypedData {
+  const { context, chainId, deadline, verifyingContract } = params;
+  const domain: ProfileCmsPublishDomain = {
+    name: PROFILE_CMS_PUBLISH_DOMAIN_NAME,
+    version: PROFILE_CMS_PUBLISH_DOMAIN_VERSION,
+    chainId,
+    ...(verifyingContract ? { verifyingContract } : {}),
+  };
+  const message: ProfileCmsPublishMessage = {
+    action: "publish",
+    profileId: context.profileId,
+    handle: context.handle,
+    packageId: context.packageId,
+    version: context.version,
+    draftId: context.draftId,
+    payloadHash: context.payloadHash,
+    packageHash: context.packageHash,
+    primaryPath: context.primaryPath,
+    storageProvider: context.receipt.provider,
+    storageUri: context.receipt.uri,
+    storageContentHash: context.receipt.content_hash,
+    deadline,
+  };
+  return {
+    domain,
+    types: PROFILE_CMS_PUBLISH_EIP712_TYPES,
+    primaryType: PROFILE_CMS_PUBLISH_PRIMARY_TYPE,
+    message,
+  };
+}
+
+export function getProfileCmsPublishedUrl(
+  handle: string,
+  baseUrl: string = DEFAULT_PUBLISHED_BASE_URL
+): string {
+  return `${baseUrl}/${handle}/index.html`;
+}
+
+/**
+ * Prepare the publish context: save the draft, server-validate, and upload to
+ * storage. Returns a reusable context on success so the sign/publish tail can
+ * be retried without re-uploading.
+ */
+export async function prepareProfileCmsPublish(
+  input: RunProfileCmsPublishInput
+): Promise<ProfileCmsPublishFailure | { readonly ok: true; readonly context: ProfileCmsPublishContext }> {
+  const { cmsPackage, profileId } = input;
+
+  const saved = await runProfileCmsBuilderAction({
+    action: "save_draft",
+    cmsPackage,
+    profileId,
+  });
+  if (!saved.ok || !saved.draftId) {
+    return {
+      ok: false,
+      step: "validate",
+      code: "save_failed",
+      message: "Could not save the draft before publishing.",
+    };
+  }
+  const draftId = saved.draftId;
+
+  const validated = await runProfileCmsBuilderAction({
+    action: "validate",
+    cmsPackage,
+    profileId,
+  });
+  if (!validated.ok) {
+    return {
+      ok: false,
+      step: "validate",
+      code: "validate_failed",
+      message: "Server validation request failed.",
+    };
+  }
+  if (validated.code === "server_validation_invalid") {
+    return {
+      ok: false,
+      step: "validate",
+      code: "server_validation_invalid",
+      message: "Server rejected the package as invalid.",
+    };
+  }
+
+  let receipt: ProfileCmsStorageReceipt;
+  try {
+    receipt = await uploadProfileCmsPackageStorage(draftId);
+  } catch (error) {
+    return {
+      ok: false,
+      step: "upload",
+      code: "upload_failed",
+      message: getErrorMessage(error, "Storage upload failed."),
+    };
+  }
+
+  const context: ProfileCmsPublishContext = {
+    draftId,
+    profileId,
+    handle: cmsPackage.profile.handle,
+    packageId: cmsPackage.package_id,
+    version: saved.version ?? 1,
+    payloadHash: saved.payloadHash ?? cmsPackage.integrity.payload_hash,
+    packageHash: saved.packageHash ?? cmsPackage.integrity.package_hash,
+    primaryPath: `/${cmsPackage.profile.handle}/index.html`,
+    receipt,
+  };
+
+  return { ok: true, context };
+}
+
+/**
+ * Sign + publish given a prepared context. Reusable for the deadline-expiry
+ * retry path (re-sign with a fresh deadline, then re-post).
+ */
+export async function signAndPublishProfileCms(params: {
+  readonly context: ProfileCmsPublishContext;
+  readonly chainId: number;
+  readonly signerAddress: string;
+  readonly signTypedData: ProfileCmsSignTypedData;
+  readonly isSafe?: boolean | undefined;
+  readonly verifyingContract?: string | null | undefined;
+  readonly now?: () => number;
+  readonly baseUrl?: string | undefined;
+}): Promise<ProfileCmsPublishResult> {
+  const {
+    context,
+    chainId,
+    signerAddress,
+    signTypedData,
+    isSafe,
+    verifyingContract,
+    now = Date.now,
+    baseUrl,
+  } = params;
+
+  const deadline = now() + PROFILE_CMS_PUBLISH_DEADLINE_MS;
+  const typedData = buildProfileCmsPublishTypedData({
+    context,
+    chainId,
+    deadline,
+    verifyingContract,
+  });
+
+  let signatureResult: ProfileCmsSignTypedDataResult;
+  try {
+    signatureResult = await signTypedData(typedData);
+  } catch (error) {
+    return {
+      ok: false,
+      step: "sign",
+      code: "signature_failed",
+      message: getErrorMessage(error, "Wallet signing failed."),
+      context,
+    };
+  }
+  if (!signatureResult.ok) {
+    return {
+      ok: false,
+      step: "sign",
+      code: signatureResult.rejected
+        ? "signature_rejected"
+        : "signature_failed",
+      message: signatureResult.rejected
+        ? "The signature request was canceled in your wallet."
+        : "Wallet signing failed.",
+      context,
+    };
+  }
+
+  const request: ProfileCmsPublishRequest = {
+    signer_address: signerAddress,
+    signature: signatureResult.signature,
+    chain_id: chainId,
+    deadline,
+    expected_package_hash: context.packageHash,
+    expected_payload_hash: context.payloadHash,
+    ...(isSafe ? { is_safe_signature: true } : {}),
+    ...(verifyingContract ? { verifying_contract: verifyingContract } : {}),
+  };
+
+  try {
+    const published = await publishProfileCmsPackage(context.draftId, request);
+    return {
+      ok: true,
+      published,
+      publishedUrl: getProfileCmsPublishedUrl(published.profileHandle, baseUrl),
+    };
+  } catch (error) {
+    const status = getErrorStatus(error);
+    if (isDeadlineError(error, status)) {
+      return {
+        ok: false,
+        step: "sign",
+        code: "deadline_expired",
+        message:
+          "The signature deadline expired before publishing. Please sign again.",
+        context,
+      };
+    }
+    if (status === 409) {
+      return {
+        ok: false,
+        step: "publish",
+        code: "publish_conflict",
+        message:
+          "The draft changed on the server since it was signed. Please retry.",
+        context,
+      };
+    }
+    return {
+      ok: false,
+      step: "publish",
+      code: "publish_failed",
+      message: getErrorMessage(error, "Publishing failed."),
+      context,
+    };
+  }
+}
+
+/**
+ * Full publish flow: prepare (save + validate + upload), then sign + publish.
+ */
+export async function runProfileCmsPublish(
+  input: RunProfileCmsPublishInput
+): Promise<ProfileCmsPublishResult> {
+  const prepared = await prepareProfileCmsPublish(input);
+  if (!prepared.ok) {
+    return prepared;
+  }
+
+  return signAndPublishProfileCms({
+    context: prepared.context,
+    chainId: input.chainId,
+    signerAddress: input.signerAddress,
+    signTypedData: input.signTypedData,
+    isSafe: input.isSafe,
+    verifyingContract: input.verifyingContract,
+    now: input.now,
+    baseUrl: input.baseUrl,
+  });
+}
+
+function getErrorStatus(error: unknown): number | undefined {
+  if (error && typeof error === "object" && "status" in error) {
+    const status = (error as { status?: unknown }).status;
+    if (typeof status === "number") {
+      return status;
+    }
+  }
+  return undefined;
+}
+
+function isDeadlineError(error: unknown, status: number | undefined): boolean {
+  if (status !== 400) {
+    return false;
+  }
+  const message = getRawErrorMessage(error).toLowerCase();
+  return message.includes("deadline");
+}
+
+function getRawErrorMessage(error: unknown): string {
+  if (error && typeof error === "object" && "message" in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") {
+      return message;
+    }
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return "";
+}
+
+function getErrorMessage(error: unknown, fallback: string): string {
+  const message = getRawErrorMessage(error);
+  return message.length > 0 ? message : fallback;
+}


### PR DESCRIPTION
> Stacked on `codex/cms-builder-api-alignment` (PR #3093). Base will be retargeted to `main` after #3093 merges. Review only the commits unique to this branch.

## Issue
The Profile CMS builder could save and server-validate drafts, but publish was hard-blocked client-side (`publish_requires_signed_storage`). The flagship launch flow — save → validate → decentralized-storage upload → wallet signature → publish, plus primary-pointer rollback — was not wired to the real backend contract.

## Fix
Replace the client-side publish hard-block with the real signed-storage flow and build the EIP-712 typed data field-for-field against the backend signing contract (`src/profile-cms/profile-cms-signing.ts`), so signatures verify server-side for both EOA and Safe/EIP-1271 signers.

## Changes
- **Adapter** (`lib/profile-cms/builder/api.ts`): add `uploadProfileCmsPackageStorage(id)`, `publishProfileCmsPackage(id, request)`, and `rollbackProfileCmsPackage(id, request)`; surface the server-assigned `version`/`payload_hash` from `save_draft`; remove the `publish_requires_signed_storage` block. Owner-gating and flag-gating are unchanged from save/validate.
- **Orchestration** (`lib/profile-cms/builder/publish.ts`): sequences save → validate → upload → sign → publish. Splits into `prepareProfileCmsPublish` (save+validate+upload → reusable context) and `signAndPublishProfileCms` (sign+publish), so a deadline-expiry retry re-signs with a fresh deadline without re-uploading. Builds the EIP-712 domain (`6529 Profile CMS`, v1, chainId from wallet) and `ProfileCmsPublish` message with the exact backend field order/types. Deadline = now + 10 min (under the 15-min backend cap).
- **Signing hook** (`hooks/profile-cms/useProfileCmsPublishSign.ts`): wraps wagmi `useSignTypedData`, converts `uint256` fields (`version`, `deadline`) to `bigint` for viem, and reports Safe wallets via the existing `SeizeConnect` `isSafeWallet` detection (sets `is_safe_signature`).
- **UI**: `ProfileCmsPublishPanel` (four-step progress with per-step success/error, retry-from-failed-step, re-sign on deadline expiry, and the published `/{handle}/index.html` URL as a link) and `ProfileCmsVersionHistoryPanel` (lists packages, shows status/primary, rolls the primary pointer back to a prior PUBLISHED/SUPERSEDED version behind a confirmation dialog). Both wired into `ProfileCmsBuilder`; the header publish button is replaced by the dedicated panel.
- **i18n**: `en-US` keys for all new strings (other locales fall back per the locale lane).

## Typed-data construction notes
- Domain and type match the backend exactly. A unit test replicates the backend fixture message from `profile-cms-signing.test.ts` and asserts the EIP-712 hash equals `0x1fe21ab2829931ed7cd8777ad1ead3300701b7e8d5dcc2e56de8be396e3b0372` via **both** `ethers.TypedDataEncoder.hash` (what the backend uses) and viem `hashTypedData` — confirming the `number`→`bigint` conversion is hash-equivalent.
- `verifyingContract` is added to the domain only when supplied.
- `primaryPath` is `/{handle}/index.html`; hashes/version/handle/packageId/draftId come from server responses, never fabricated client-side. Storage `provider`/`uri`/`content_hash` come from the backend upload receipt.

## Safe-wallet handling
Safe/smart-contract wallets are detected via the existing `SeizeConnect` `isSafeWallet` helper; publish sets `is_safe_signature: true` so the backend uses EIP-1271 verification. `verifyingContract` is not supplied (the backend supports EIP-1271 against the base domain), and a UI notice tells Safe users to fall back to the profile's EOA if their Safe cannot complete the EIP-1271 signature. The EOA path is fully implemented and tested.

## Validation
- `tsc --noEmit` (typecheck config): clean.
- `eslint --max-warnings=0` on all changed files: clean.
- `prettier --check`: clean.
- `knip`: no unused exports/types for the new files.
- Jest (run from the worktree with `NODE_PATH` pointed at the pnpm `@babel/runtime` store, per the known non-hoisted-deps gotcha): 58 tests across 6 suites pass — orchestration sequencing (happy path, validation-failure-aborts-before-upload, upload failure, signature rejection, publish 4xx, deadline regeneration), typed-data hash equivalence, signing-hook bigint/rejection handling, and both panels' UI states + rollback confirmation.
- Not exercised against a live backend or a real Safe wallet in this lane (backend storage endpoint PR #1713 still in bot review); the receipt shape is pinned to that branch head.

## Risk
- Level: Low
- Why: entirely behind the existing `PROFILE_CMS_BUILDER_ENABLED` / `PROFILE_CMS_BUILDER_API_ENABLED` flags and owner-gated; no changes to protocol, hashing, or canonicalization. New surface is additive.
- Rollback: revert this PR; the builder returns to save/validate-only.

## Review Notes
- Confirm the EIP-712 field order/values still match the backend `ProfileCmsPublish` type if that contract changes.
- The storage-receipt type is pinned locally (`ProfileCmsStorageReceipt`) mirroring backend PR #1713 (`codex/cms-arweave-storage-upload`); swap to the generated model once it lands in `generated/models`.
- Safe/EIP-1271 path is best-effort (detection + `is_safe_signature`) and untested against a live Safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
