### PR TITLE
Accept the static mint page title in staging/production E2E on no-mint days

### DIFF
--- a/tests/media/media-mint-detail-readonly.spec.ts
+++ b/tests/media/media-mint-detail-readonly.spec.ts
@@ -113,7 +113,11 @@ test.describe("Media, mint, and detail read-only coverage @surface @medium @larg
   test("renders The Memes mint page read-only", async ({ page }) => {
     await gotoReady(page, "/the-memes/mint");
 
-    await expect(page).toHaveTitle(/^Mint #\d+ \| [^|]+ \| The Memes$/);
+    // The numbered "Mint #<id> | <name> | The Memes" title comes from the
+    // client TitleContext and only sticks while a mint is live; outside mint
+    // windows (Memes mint Mon/Wed/Fri) deployed envs settle on the static
+    // generateMetadata title "Mint | The Memes", so accept both.
+    await expect(page).toHaveTitle(/^Mint(?: #\d+ \| [^|]+)? \| The Memes$/);
     await expect(page.getByText("Retrieving Mint information")).toBeHidden({
       timeout: 15000,
     });


### PR DESCRIPTION
## Problem

`tests/media/media-mint-detail-readonly.spec.ts` › "renders The Memes mint page read-only" requires the page title to match `/^Mint #\d+ \| [^|]+ \| The Memes$/`. That numbered title is set client-side via TitleContext; the route's `generateMetadata` title is the static `Mint | The Memes`. In deployed environments the streamed metadata replaces the client-set title, and outside mint windows (Memes mint Mon/Wed/Fri) nothing re-asserts it, so the document durably shows `Mint | The Memes` and the assertion fails deterministically on first attempt.

Evidence from staging run [28744182752](https://github.com/6529-Collections/6529seize-frontend/actions/runs/28744182752) (Saturday 2026-07-05):

- desktop: fail, fail, pass on retry #2 — `14 × unexpected value "Mint | The Memes"`
- mobile: fail, pass on retry #1

The retries only pass when a poll happens to catch the short window where the client title is live, so on no-mint days the test burns retries at best and fails the pack at worst.

## Fix

Accept both title forms with one pattern:

```
/^Mint(?: #\d+ \| [^|]+)? \| The Memes$/
```

No other assertions changed — `memes_latest` returns the latest card even on no-mint days (id 517 today), so the page still renders the full read-only mint UI (Distribution Plan, Edition Size, Minting Approach, Mint Price, Status) and those assertions already pass in both states. Malformed titles (e.g. `404 | PAGE NOT FOUND`, `Mint #517 | The Memes` with a missing name) are still rejected.

Branching the assertions on "is a mint active" was considered and rejected: the observable title does not reliably encode mint state (both forms appear transiently in both states), and a day-of-week branch would duplicate the mint calendar in the test.

PR #3089 (metadata/client title alignment) does not touch `/the-memes/mint`, so the static title remains the durable deployed title for this route after it lands; this pattern stays correct.

## Verification (run today, a no-mint Saturday — the exact failing condition)

- Full media pack vs staging.6529.io: 8 passed, 2 skipped (production-only fixture)
- Mint test only, `--repeat-each=3`, desktop+mobile, 0 retries: 6/6 vs staging.6529.io, 6/6 vs 6529.io
- Prettier clean; eslint ignores spec files by config

## Known issue (separate)

The same staging run also has 5 hard failures in `tests/collections/nextgen-collections-readonly.spec.ts` (desktop horizontal-overflow: offending `div.-tw-mx-3 tw-flex tw-flex-wrap` at width 1223 vs viewport 1280, 11px over). That is a distinct layout issue this PR does not address, so the staging-e2e workflow needs that fixed too before it goes fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)