### PR TITLE
Restore desktop copy, selection, and hover UI on capability-lying browsers

### DIFF
--- a/__tests__/components/waves/drops/WaveDrop.test.tsx
+++ b/__tests__/components/waves/drops/WaveDrop.test.tsx
@@ -606,13 +606,68 @@ describe("WaveDrop", () => {
     );
 
     expect(screen.queryByTestId("header")).not.toBeInTheDocument();
+    // Desktop (no touch sheet): the timestamp reveals on hover, never via the
+    // pointer swipe that would hijack drag-to-select.
     expect(
-      screen.queryByTestId("grouped-drop-hover-timestamp")
+      screen.queryByTestId("grouped-drop-swipe-timestamp")
     ).not.toBeInTheDocument();
-    const timestamp = screen.getByTestId("grouped-drop-swipe-timestamp");
+    const timestamp = screen.getByTestId("grouped-drop-hover-timestamp");
     expect(timestamp).toBeInTheDocument();
     expect(timestamp).toHaveClass("tw-w-[9.25rem]");
+    expect(timestamp).toHaveClass("desktop-hover:group-hover:tw-opacity-100");
     expect(timestamp.querySelector("p")).toHaveClass("tw-whitespace-nowrap");
+  });
+
+  it("does not hijack mouse drags for the timestamp swipe on desktop", () => {
+    const previousGroupedDrop = {
+      ...drop,
+      id: "previous-grouped",
+      created_at: 1_700_000_000_000,
+      stableHash: "previous-grouped",
+    };
+    const groupedDrop = {
+      ...drop,
+      id: "current-grouped",
+      created_at: 1_700_000_040_000,
+      stableHash: "current-grouped",
+    };
+
+    renderWithEditingDropProvider(
+      <WaveDrop
+        drop={groupedDrop}
+        previousDrop={previousGroupedDrop}
+        nextDrop={null}
+        showWaveInfo={false}
+        activeDrop={null}
+        showReplyAndQuote={true}
+        location={DropLocation.WAVE}
+        dropViewDropId={null}
+        onReply={jest.fn()}
+        onReplyClick={jest.fn()}
+        onQuoteClick={jest.fn()}
+      />
+    );
+
+    const swipeable = screen.getByTestId("grouped-drop-swipeable-content");
+    const dropRoot = swipeable.parentElement!;
+
+    // A leftward mouse drag (the shape of a text-selection gesture).
+    fireEvent.pointerDown(dropRoot, {
+      pointerId: 1,
+      pointerType: "mouse",
+      button: 0,
+      clientX: 220,
+      clientY: 40,
+    });
+    fireEvent.pointerMove(dropRoot, {
+      pointerId: 1,
+      pointerType: "mouse",
+      clientX: 48,
+      clientY: 44,
+    });
+
+    expect(swipeable.style.transform).toBe("");
+    fireEvent.pointerUp(dropRoot, { pointerId: 1, pointerType: "mouse" });
   });
 
   it("reveals a grouped message timestamp on left swipe without opening long press actions", () => {

--- a/__tests__/components/waves/drops/WaveDropActionsCopyText.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropActionsCopyText.test.tsx
@@ -49,6 +49,19 @@ describe("WaveDropActionsCopyText", () => {
     await waitFor(() => expect(onCopy).toHaveBeenCalled());
   });
 
+  it("closes the menu without crashing when the clipboard API is unavailable", async () => {
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    const onCopy = jest.fn();
+
+    render(<WaveDropActionsCopyText drop={createDrop()} onCopy={onCopy} />);
+    fireEvent.click(screen.getByRole("button", { name: "Copy text" }));
+
+    await waitFor(() => expect(onCopy).toHaveBeenCalled());
+  });
+
   it("is disabled for temporary drops and copies nothing", () => {
     const onCopy = jest.fn();
 

--- a/__tests__/components/waves/drops/WaveDropActionsCopyText.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropActionsCopyText.test.tsx
@@ -1,0 +1,69 @@
+import WaveDropActionsCopyText from "@/components/waves/drops/WaveDropActionsCopyText";
+import { buildDropClipboardText } from "@/helpers/waves/drop-clipboard.helpers";
+import { ApiDropType } from "@/generated/models/ApiDropType";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const writeText = jest.fn().mockResolvedValue(undefined);
+
+const createDrop = (overrides: Record<string, unknown> = {}): any => ({
+  id: "d1",
+  serial_no: 5,
+  drop_type: ApiDropType.Chat,
+  author: { handle: "alice" },
+  created_at: 1735689600000,
+  wave: { id: "w1", name: "Test Wave" },
+  parts: [
+    {
+      part_id: 1,
+      content: "gm **frens**",
+      quoted_drop: null,
+      media: [],
+    },
+  ],
+  metadata: [],
+  reply_to: null,
+  ...overrides,
+});
+
+describe("WaveDropActionsCopyText", () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("copies the drop clipboard text and notifies the menu", async () => {
+    const onCopy = jest.fn();
+    const drop = createDrop();
+
+    render(<WaveDropActionsCopyText drop={drop} onCopy={onCopy} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy text" }));
+
+    expect(writeText).toHaveBeenCalledWith(buildDropClipboardText(drop));
+    await waitFor(() => expect(onCopy).toHaveBeenCalled());
+  });
+
+  it("is disabled for temporary drops and copies nothing", () => {
+    const onCopy = jest.fn();
+
+    render(
+      <WaveDropActionsCopyText
+        drop={createDrop({ id: "temp-123" })}
+        onCopy={onCopy}
+      />
+    );
+
+    const button = screen.getByRole("button", { name: "Copy text" });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+
+    expect(writeText).not.toHaveBeenCalled();
+    expect(onCopy).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/helpers/touch-first-pointer-latch.test.ts
+++ b/__tests__/helpers/touch-first-pointer-latch.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Behavioral fine-pointer latch tests. Kept in their own file so the
+ * module-level latch state cannot leak into the main helper suite.
+ */
+import {
+  hasFinePointerCapability,
+  hasHoverCapability,
+  isTouchFirstEnvironment,
+  subscribeToTouchFirstChanges,
+} from "@/helpers/touch-first.helpers";
+
+function defineMatchMedia(queryMatches: Record<string, boolean>) {
+  Object.defineProperty(globalThis, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: jest.fn((query: string) => ({
+      matches: queryMatches[query] ?? false,
+      media: query,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    })),
+  });
+}
+
+function defineMaxTouchPoints(value: number) {
+  Object.defineProperty(globalThis.navigator, "maxTouchPoints", {
+    configurable: true,
+    value,
+  });
+}
+
+function dispatchPointerEvent(type: string, pointerType: string) {
+  const event = new Event(type, { bubbles: true });
+  Object.defineProperty(event, "pointerType", { value: pointerType });
+  globalThis.dispatchEvent(event);
+}
+
+describe("behavioral fine-pointer latch", () => {
+  // A browser that mis-reports capabilities: touch points present, no fine
+  // pointer, no hover — like a convertible whose media queries lie while the
+  // trackpad is in use.
+  beforeEach(() => {
+    defineMaxTouchPoints(10);
+    defineMatchMedia({ "(any-pointer: coarse)": true });
+  });
+
+  afterEach(() => {
+    defineMaxTouchPoints(0);
+    document.body.removeAttribute("data-fine-pointer");
+  });
+
+  it("treats the device as touch-first until mouse evidence arrives, then flips", () => {
+    const onChange = jest.fn();
+    const unsubscribe = subscribeToTouchFirstChanges(onChange);
+
+    expect(isTouchFirstEnvironment()).toBe(true);
+    expect(hasHoverCapability()).toBe(false);
+
+    // Touch events must not latch.
+    dispatchPointerEvent("pointermove", "touch");
+    expect(isTouchFirstEnvironment()).toBe(true);
+
+    // The first mouse/trackpad event is ground truth.
+    dispatchPointerEvent("pointermove", "mouse");
+
+    expect(isTouchFirstEnvironment()).toBe(false);
+    expect(hasFinePointerCapability()).toBe(true);
+    expect(hasHoverCapability()).toBe(true);
+    expect(onChange).toHaveBeenCalled();
+    expect(document.body.getAttribute("data-fine-pointer")).toBe("true");
+
+    unsubscribe();
+  });
+
+  it("keeps phones touch-first even after mouse evidence (UA override wins)", () => {
+    Object.defineProperty(globalThis.navigator, "userAgentData", {
+      configurable: true,
+      value: { mobile: true },
+    });
+
+    try {
+      // Latch is already set by the previous test's module state or set it now.
+      dispatchPointerEvent("pointerdown", "mouse");
+      const unsubscribe = subscribeToTouchFirstChanges(jest.fn());
+      dispatchPointerEvent("pointerdown", "mouse");
+
+      expect(isTouchFirstEnvironment()).toBe(true);
+      unsubscribe();
+    } finally {
+      Reflect.deleteProperty(globalThis.navigator, "userAgentData");
+    }
+  });
+});

--- a/__tests__/helpers/touch-first-pointer-latch.test.ts
+++ b/__tests__/helpers/touch-first-pointer-latch.test.ts
@@ -1,13 +1,19 @@
 /**
- * Behavioral fine-pointer latch tests. Kept in their own file so the
- * module-level latch state cannot leak into the main helper suite.
+ * Behavioral fine-pointer latch tests. Each case loads a fresh module via
+ * jest.isolateModules so the module-level latch cannot leak between tests.
+ *
+ * jsdom cannot dispatch trusted events (isTrusted is spec-unforgeable), so
+ * the sentinel handler is captured through an addEventListener spy and
+ * invoked directly with duck-typed pointer events — exercising the real
+ * handler, latch, notification, and <body> tagging paths.
  */
-import {
-  hasFinePointerCapability,
-  hasHoverCapability,
-  isTouchFirstEnvironment,
-  subscribeToTouchFirstChanges,
-} from "@/helpers/touch-first.helpers";
+
+type Helpers = typeof import("@/helpers/touch-first.helpers");
+
+type SentinelHandler = (event: {
+  readonly isTrusted: boolean;
+  readonly pointerType: string;
+}) => void;
 
 function defineMatchMedia(queryMatches: Record<string, boolean>) {
   Object.defineProperty(globalThis, "matchMedia", {
@@ -29,10 +35,27 @@ function defineMaxTouchPoints(value: number) {
   });
 }
 
-function dispatchPointerEvent(type: string, pointerType: string) {
-  const event = new Event(type, { bubbles: true });
-  Object.defineProperty(event, "pointerType", { value: pointerType });
-  globalThis.dispatchEvent(event);
+function loadHelpersWithSentinel(): {
+  helpers: Helpers;
+  getSentinel: () => SentinelHandler | undefined;
+  restore: () => void;
+} {
+  const addSpy = jest.spyOn(globalThis, "addEventListener");
+
+  let helpers: Helpers | undefined;
+  jest.isolateModules(() => {
+    helpers = require("@/helpers/touch-first.helpers") as Helpers;
+  });
+  if (!helpers) {
+    throw new Error("failed to load touch-first helpers");
+  }
+
+  const getSentinel = () =>
+    addSpy.mock.calls.find(([type]) => type === "pointermove")?.[1] as
+      | SentinelHandler
+      | undefined;
+
+  return { helpers, getSentinel, restore: () => addSpy.mockRestore() };
 }
 
 describe("behavioral fine-pointer latch", () => {
@@ -49,45 +72,92 @@ describe("behavioral fine-pointer latch", () => {
     document.body.removeAttribute("data-fine-pointer");
   });
 
-  it("treats the device as touch-first until mouse evidence arrives, then flips", () => {
+  it("flips to desktop after a stream of trusted mouse moves", () => {
+    const { helpers, getSentinel, restore } = loadHelpersWithSentinel();
     const onChange = jest.fn();
-    const unsubscribe = subscribeToTouchFirstChanges(onChange);
+    const unsubscribe = helpers.subscribeToTouchFirstChanges(onChange);
+    const sentinel = getSentinel();
+    expect(sentinel).toBeDefined();
 
-    expect(isTouchFirstEnvironment()).toBe(true);
-    expect(hasHoverCapability()).toBe(false);
+    expect(helpers.isTouchFirstEnvironment()).toBe(true);
+    expect(helpers.hasHoverCapability()).toBe(false);
 
-    // Touch events must not latch.
-    dispatchPointerEvent("pointermove", "touch");
-    expect(isTouchFirstEnvironment()).toBe(true);
+    sentinel!({ isTrusted: true, pointerType: "mouse" });
+    sentinel!({ isTrusted: true, pointerType: "mouse" });
+    expect(helpers.isTouchFirstEnvironment()).toBe(true);
 
-    // The first mouse/trackpad event is ground truth.
-    dispatchPointerEvent("pointermove", "mouse");
+    sentinel!({ isTrusted: true, pointerType: "mouse" });
 
-    expect(isTouchFirstEnvironment()).toBe(false);
-    expect(hasFinePointerCapability()).toBe(true);
-    expect(hasHoverCapability()).toBe(true);
+    expect(helpers.isTouchFirstEnvironment()).toBe(false);
+    expect(helpers.hasFinePointerCapability()).toBe(true);
+    expect(helpers.hasHoverCapability()).toBe(true);
     expect(onChange).toHaveBeenCalled();
     expect(document.body.getAttribute("data-fine-pointer")).toBe("true");
 
     unsubscribe();
+    restore();
   });
 
-  it("keeps phones touch-first even after mouse evidence (UA override wins)", () => {
+  it("ignores untrusted and touch pointer events", () => {
+    const { helpers, getSentinel, restore } = loadHelpersWithSentinel();
+    const unsubscribe = helpers.subscribeToTouchFirstChanges(jest.fn());
+    const sentinel = getSentinel();
+    expect(sentinel).toBeDefined();
+
+    for (let i = 0; i < 5; i++) {
+      sentinel!({ isTrusted: false, pointerType: "mouse" });
+      sentinel!({ isTrusted: true, pointerType: "touch" });
+      sentinel!({ isTrusted: true, pointerType: "pen" });
+    }
+
+    expect(helpers.isTouchFirstEnvironment()).toBe(true);
+    expect(document.body.hasAttribute("data-fine-pointer")).toBe(false);
+
+    unsubscribe();
+    restore();
+  });
+
+  it("keeps phones touch-first even after trusted mouse evidence", () => {
     Object.defineProperty(globalThis.navigator, "userAgentData", {
       configurable: true,
       value: { mobile: true },
     });
 
     try {
-      // Latch is already set by the previous test's module state or set it now.
-      dispatchPointerEvent("pointerdown", "mouse");
-      const unsubscribe = subscribeToTouchFirstChanges(jest.fn());
-      dispatchPointerEvent("pointerdown", "mouse");
+      const { helpers, getSentinel, restore } = loadHelpersWithSentinel();
+      const unsubscribe = helpers.subscribeToTouchFirstChanges(jest.fn());
+      const sentinel = getSentinel();
 
-      expect(isTouchFirstEnvironment()).toBe(true);
+      sentinel!({ isTrusted: true, pointerType: "mouse" });
+      sentinel!({ isTrusted: true, pointerType: "mouse" });
+      sentinel!({ isTrusted: true, pointerType: "mouse" });
+
+      expect(helpers.hasFinePointerCapability()).toBe(true);
+      expect(helpers.isTouchFirstEnvironment()).toBe(true);
+
       unsubscribe();
+      restore();
     } finally {
       Reflect.deleteProperty(globalThis.navigator, "userAgentData");
     }
+  });
+
+  it("uninstalls the sentinel when the last subscriber leaves", () => {
+    const removeSpy = jest.spyOn(globalThis, "removeEventListener");
+    const { helpers, getSentinel, restore } = loadHelpersWithSentinel();
+
+    const unsubscribe = helpers.subscribeToTouchFirstChanges(jest.fn());
+    const sentinel = getSentinel();
+    expect(sentinel).toBeDefined();
+
+    unsubscribe();
+
+    const sentinelRemoved = removeSpy.mock.calls.some(
+      ([type, handler]) => type === "pointermove" && handler === sentinel
+    );
+    expect(sentinelRemoved).toBe(true);
+
+    restore();
+    removeSpy.mockRestore();
   });
 });

--- a/components/waves/drops/WaveDrop.tsx
+++ b/components/waves/drops/WaveDrop.tsx
@@ -510,15 +510,32 @@ const shouldShowGroupedDropTimestamp = ({
 const GroupedDropTimestamp = ({
   swipeOffset = 0,
   timestamp,
+  variant,
 }: {
   readonly swipeOffset?: number;
   readonly timestamp: number;
+  readonly variant: "swipe" | "hover";
 }) => {
+  // "swipe": revealed by the touch swipe gesture via inline opacity.
+  // "hover": desktop affordance — swiping would hijack text selection, so the
+  // timestamp reveals on row hover instead.
+  const isHoverVariant = variant === "hover";
+
   return (
     <div
-      className="tw-pointer-events-none tw-absolute tw-right-4 tw-top-1/2 tw-z-0 tw-flex tw-w-[9.25rem] -tw-translate-y-1/2 tw-justify-end tw-overflow-visible tw-text-right tw-transition-opacity tw-duration-150"
-      data-testid="grouped-drop-swipe-timestamp"
-      style={getGroupedTimestampOpacityStyle(swipeOffset)}
+      className={`tw-pointer-events-none tw-absolute tw-right-4 tw-top-1/2 tw-z-0 tw-flex tw-w-[9.25rem] -tw-translate-y-1/2 tw-justify-end tw-overflow-visible tw-text-right tw-transition-opacity tw-duration-150 ${
+        isHoverVariant
+          ? "tw-opacity-0 desktop-hover:group-hover:tw-opacity-100"
+          : ""
+      }`}
+      data-testid={
+        isHoverVariant
+          ? "grouped-drop-hover-timestamp"
+          : "grouped-drop-swipe-timestamp"
+      }
+      style={
+        isHoverVariant ? undefined : getGroupedTimestampOpacityStyle(swipeOffset)
+      }
     >
       <WaveDropTime timestamp={timestamp} size="xs" variant="compactReveal" />
     </div>
@@ -1043,6 +1060,10 @@ const WaveDropInner = ({
     (event: React.PointerEvent<HTMLDivElement>) => {
       const pointerType = getPointerType(event);
       if (
+        // Pointer-driven timestamp swipe only belongs to touch-sheet mode
+        // (e.g. pen on a touch-first device). On desktop it would hijack
+        // drag-to-select — the timestamp reveals on hover there instead.
+        !canUseTouchActionSheet ||
         pointerType === "touch" ||
         !isPrimaryPointerButton(event) ||
         !showGroupedTimestamp ||
@@ -1060,7 +1081,7 @@ const WaveDropInner = ({
       setTimestampSwipeOffset(0);
       setIsTimestampSwipeDragging(false);
     },
-    [isEditing, showGroupedTimestamp]
+    [canUseTouchActionSheet, isEditing, showGroupedTimestamp]
   );
 
   const handlePointerMove = useCallback(
@@ -1439,6 +1460,7 @@ const WaveDropInner = ({
           <GroupedDropTimestamp
             swipeOffset={timestampSwipeOffset}
             timestamp={drop.created_at}
+            variant={canUseTouchActionSheet ? "swipe" : "hover"}
           />
         )}
         <div

--- a/components/waves/drops/WaveDropActionsCopyText.tsx
+++ b/components/waves/drops/WaveDropActionsCopyText.tsx
@@ -27,12 +27,25 @@ const WaveDropActionsCopyText: React.FC<WaveDropActionsCopyTextProps> = ({
       return;
     }
 
-    void navigator.clipboard
+    const clipboard = globalThis.navigator?.clipboard as
+      | { writeText?: (text: string) => Promise<void> }
+      | undefined;
+
+    // Close the menu even when the clipboard API is unavailable or the write
+    // fails — mirrors the mobile copy action's behavior.
+    if (typeof clipboard?.writeText !== "function") {
+      onCopy?.();
+      return;
+    }
+
+    void clipboard
       .writeText(buildDropClipboardText(drop))
       .then(() => {
         onCopy?.();
       })
-      .catch(() => undefined);
+      .catch(() => {
+        onCopy?.();
+      });
   };
 
   return (

--- a/components/waves/drops/WaveDropActionsCopyText.tsx
+++ b/components/waves/drops/WaveDropActionsCopyText.tsx
@@ -22,7 +22,9 @@ const WaveDropActionsCopyText: React.FC<WaveDropActionsCopyTextProps> = ({
   const locale = useBrowserLocale();
   const isDisabled = drop.id.startsWith("temp-");
 
-  const copyToClipboard = () => {
+  const copyToClipboard = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+
     if (isDisabled) {
       return;
     }
@@ -50,6 +52,7 @@ const WaveDropActionsCopyText: React.FC<WaveDropActionsCopyTextProps> = ({
 
   return (
     <button
+      type="button"
       onClick={copyToClipboard}
       disabled={isDisabled}
       className={`tw-flex tw-w-full tw-items-center tw-gap-x-3 tw-rounded-lg tw-border-0 tw-bg-transparent tw-px-3 tw-py-2 tw-transition-colors tw-duration-200 ${

--- a/components/waves/drops/WaveDropActionsCopyText.tsx
+++ b/components/waves/drops/WaveDropActionsCopyText.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import type { ApiDrop } from "@/generated/models/ApiDrop";
+import { buildDropClipboardText } from "@/helpers/waves/drop-clipboard.helpers";
+import { useBrowserLocale } from "@/hooks/useBrowserLocale";
+import { t } from "@/i18n/messages";
+import React from "react";
+
+interface WaveDropActionsCopyTextProps {
+  readonly drop: ApiDrop;
+  readonly onCopy?: (() => void) | undefined;
+}
+
+/**
+ * Desktop dropdown counterpart of the mobile long-press "Copy text" action —
+ * hybrid/desktop devices don't get the touch action sheet.
+ */
+const WaveDropActionsCopyText: React.FC<WaveDropActionsCopyTextProps> = ({
+  drop,
+  onCopy,
+}) => {
+  const locale = useBrowserLocale();
+  const isDisabled = drop.id.startsWith("temp-");
+
+  const copyToClipboard = () => {
+    if (isDisabled) {
+      return;
+    }
+
+    void navigator.clipboard
+      .writeText(buildDropClipboardText(drop))
+      .then(() => {
+        onCopy?.();
+      })
+      .catch(() => undefined);
+  };
+
+  return (
+    <button
+      onClick={copyToClipboard}
+      disabled={isDisabled}
+      className={`tw-flex tw-w-full tw-items-center tw-gap-x-3 tw-rounded-lg tw-border-0 tw-bg-transparent tw-px-3 tw-py-2 tw-transition-colors tw-duration-200 ${
+        isDisabled
+          ? "tw-cursor-default tw-text-iron-500 tw-opacity-50"
+          : "tw-cursor-pointer tw-text-iron-300 desktop-hover:hover:tw-bg-iron-800"
+      }`}
+    >
+      <svg
+        className="tw-h-4 tw-w-4 tw-flex-shrink-0"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth="1.5"
+        stroke="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M8.25 7.5V6.108c0-1.135.845-2.098 1.976-2.192.373-.03.748-.057 1.123-.08M15.75 18H18a2.25 2.25 0 002.25-2.25V6.108c0-1.135-.845-2.098-1.976-2.192a48.424 48.424 0 00-1.123-.08M15.75 18.75v-1.875a3.375 3.375 0 00-3.375-3.375h-1.5a1.125 1.125 0 01-1.125-1.125v-1.5A3.375 3.375 0 006.375 7.5H5.25m11.9-3.664A2.251 2.251 0 0015 2.25h-1.5a2.251 2.251 0 00-2.15 1.586m5.8 0c.065.21.1.433.1.664v.75h-6V4.5c0-.231.035-.454.1-.664M6.75 7.5H4.875c-.621 0-1.125.504-1.125 1.125v12c0 .621.504 1.125 1.125 1.125h9.75c.621 0 1.125-.504 1.125-1.125V16.5a9 9 0 00-9-9z"
+        />
+      </svg>
+      <span className="tw-text-sm tw-font-medium">
+        {t(locale, "waves.drop.actions.copyText")}
+      </span>
+    </button>
+  );
+};
+
+export default WaveDropActionsCopyText;

--- a/components/waves/drops/WaveDropActionsMore.tsx
+++ b/components/waves/drops/WaveDropActionsMore.tsx
@@ -12,6 +12,7 @@ import { EllipsisHorizontalIcon } from "@heroicons/react/24/outline";
 import { useRef, useState } from "react";
 import { Tooltip } from "react-tooltip";
 import WaveDropActionsCopyLink from "./WaveDropActionsCopyLink";
+import WaveDropActionsCopyText from "./WaveDropActionsCopyText";
 import WaveDropCurationsActionIcon from "./WaveDropCurationsActionIcon";
 import WaveDropCurationsDialog from "./WaveDropCurationsDialog";
 import WaveDropActionsMarkUnread from "./WaveDropActionsMarkUnread";
@@ -106,6 +107,7 @@ export default function WaveDropActionsMore({
               isDropdownItem={true}
               onCopy={closeDropdown}
             />
+            <WaveDropActionsCopyText drop={drop} onCopy={closeDropdown} />
             {showCurationsAction && (
               <button
                 type="button"

--- a/helpers/touch-first.helpers.ts
+++ b/helpers/touch-first.helpers.ts
@@ -64,10 +64,16 @@ const someQueryMatches = (queries: readonly string[]): boolean =>
 // variant selectors.
 const FINE_POINTER_BODY_ATTRIBUTE = "data-fine-pointer";
 
+// A single event is not proof: some tools emit stray synthetic mouse events
+// on genuine touch devices, and jsdom/test events must never latch. Require
+// a short stream of TRUSTED mouse moves — a real cursor glide.
+const FINE_POINTER_EVIDENCE_THRESHOLD = 3;
+
 const capabilityChangeListeners = new Set<() => void>();
 
 let finePointerObserved = false;
 let pointerSentinelInstalled = false;
+let trustedMouseMoveCount = 0;
 
 const notifyCapabilityChange = () => {
   for (const listener of capabilityChangeListeners) {
@@ -76,9 +82,15 @@ const notifyCapabilityChange = () => {
 };
 
 const handleSentinelPointerEvent = (event: Event) => {
-  if ((event as PointerEvent).pointerType !== "mouse") {
+  if (!event.isTrusted || (event as PointerEvent).pointerType !== "mouse") {
     return;
   }
+
+  trustedMouseMoveCount += 1;
+  if (trustedMouseMoveCount < FINE_POINTER_EVIDENCE_THRESHOLD) {
+    return;
+  }
+
   uninstallPointerSentinel();
   finePointerObserved = true;
   (
@@ -100,10 +112,6 @@ const installPointerSentinel = () => {
     passive: true,
     capture: true,
   });
-  globalThis.addEventListener("pointerdown", handleSentinelPointerEvent, {
-    passive: true,
-    capture: true,
-  });
 };
 
 const uninstallPointerSentinel = () => {
@@ -112,9 +120,6 @@ const uninstallPointerSentinel = () => {
   }
   pointerSentinelInstalled = false;
   globalThis.removeEventListener("pointermove", handleSentinelPointerEvent, {
-    capture: true,
-  });
-  globalThis.removeEventListener("pointerdown", handleSentinelPointerEvent, {
     capture: true,
   });
 };
@@ -217,6 +222,11 @@ export const subscribeToTouchFirstChanges = (
 
   return () => {
     capabilityChangeListeners.delete(onChange);
+    if (capabilityChangeListeners.size === 0) {
+      // No subscribers left — drop the global capture listener so genuine
+      // touch devices don't pay a page-lifetime hot-path cost.
+      uninstallPointerSentinel();
+    }
     for (const unsubscribe of unsubscribers) {
       unsubscribe();
     }

--- a/helpers/touch-first.helpers.ts
+++ b/helpers/touch-first.helpers.ts
@@ -49,13 +49,83 @@ const getMediaQueryList = (query: string): MediaQueryList | null => {
 const someQueryMatches = (queries: readonly string[]): boolean =>
   queries.some((query) => getMediaQueryList(query)?.matches ?? false);
 
+/**
+ * Behavioral fine-pointer evidence.
+ *
+ * Some Windows browsers mis-report pointer/hover capabilities — e.g. a
+ * convertible whose media queries claim "no hover, coarse only" while the
+ * user is actively driving a trackpad cursor. A real `pointerType: "mouse"`
+ * event is ground truth that a fine, hover-capable pointer exists: latch it,
+ * tag <body> with `has-fine-pointer` so CSS can participate (see
+ * globals.css and the tailwind `desktop-hover`/`touch-only` variants), and
+ * notify subscribers so hooks re-evaluate.
+ */
+// Attribute (not a class) so tailwind's `tw-` prefix cannot rewrite it in
+// variant selectors.
+const FINE_POINTER_BODY_ATTRIBUTE = "data-fine-pointer";
+
+const capabilityChangeListeners = new Set<() => void>();
+
+let finePointerObserved = false;
+let pointerSentinelInstalled = false;
+
+const notifyCapabilityChange = () => {
+  for (const listener of capabilityChangeListeners) {
+    listener();
+  }
+};
+
+const handleSentinelPointerEvent = (event: Event) => {
+  if ((event as PointerEvent).pointerType !== "mouse") {
+    return;
+  }
+  uninstallPointerSentinel();
+  finePointerObserved = true;
+  (
+    globalThis as typeof globalThis & { document?: Document }
+  ).document?.body?.setAttribute(FINE_POINTER_BODY_ATTRIBUTE, "true");
+  notifyCapabilityChange();
+};
+
+const installPointerSentinel = () => {
+  if (
+    pointerSentinelInstalled ||
+    finePointerObserved ||
+    typeof globalThis.addEventListener !== "function"
+  ) {
+    return;
+  }
+  pointerSentinelInstalled = true;
+  globalThis.addEventListener("pointermove", handleSentinelPointerEvent, {
+    passive: true,
+    capture: true,
+  });
+  globalThis.addEventListener("pointerdown", handleSentinelPointerEvent, {
+    passive: true,
+    capture: true,
+  });
+};
+
+const uninstallPointerSentinel = () => {
+  if (!pointerSentinelInstalled) {
+    return;
+  }
+  pointerSentinelInstalled = false;
+  globalThis.removeEventListener("pointermove", handleSentinelPointerEvent, {
+    capture: true,
+  });
+  globalThis.removeEventListener("pointerdown", handleSentinelPointerEvent, {
+    capture: true,
+  });
+};
+
 /** A mouse or trackpad (or similar precise pointer) is available. */
 export const hasFinePointerCapability = (): boolean =>
-  someQueryMatches(FINE_POINTER_QUERIES);
+  finePointerObserved || someQueryMatches(FINE_POINTER_QUERIES);
 
 /** Some input can hover (mouse, trackpad, stylus with hover). */
 export const hasHoverCapability = (): boolean =>
-  someQueryMatches(HOVER_QUERIES);
+  finePointerObserved || someQueryMatches(HOVER_QUERIES);
 
 /**
  * Touch input exists at all (says nothing about it being primary).
@@ -119,11 +189,15 @@ export const isTouchFirstEnvironment = (options?: {
 
 /**
  * Re-runs `onChange` whenever a capability media query flips (mouse plugged
- * in/out, convertible posture change). Returns an unsubscribe function.
+ * in/out, convertible posture change) or behavioral fine-pointer evidence
+ * arrives. Returns an unsubscribe function.
  */
 export const subscribeToTouchFirstChanges = (
   onChange: () => void
 ): (() => void) => {
+  installPointerSentinel();
+  capabilityChangeListeners.add(onChange);
+
   const unsubscribers: Array<() => void> = [];
 
   for (const query of TOUCH_FIRST_MEDIA_QUERIES) {
@@ -142,6 +216,7 @@ export const subscribeToTouchFirstChanges = (
   }
 
   return () => {
+    capabilityChangeListeners.delete(onChange);
     for (const unsubscribe of unsubscribers) {
       unsubscribe();
     }

--- a/hooks/useDropActionInteractionMode.ts
+++ b/hooks/useDropActionInteractionMode.ts
@@ -1,15 +1,14 @@
 "use client";
 
 import { useSyncExternalStore } from "react";
+import {
+  hasHoverCapability,
+  subscribeToTouchFirstChanges,
+} from "@/helpers/touch-first.helpers";
 import useIsMobileDevice from "@/hooks/isMobileDevice";
 import useHasTouchInput from "@/hooks/useHasTouchInput";
 import useIsMobileLayoutViewport from "@/hooks/useIsMobileLayoutViewport";
 import useIsTouchDevice from "@/hooks/useIsTouchDevice";
-
-const HOVER_INPUT_MEDIA_QUERIES = [
-  "(any-hover: hover)",
-  "(hover: hover)",
-] as const;
 
 interface DropActionInteractionMode {
   readonly hasTouchActionInput: boolean;
@@ -18,54 +17,12 @@ interface DropActionInteractionMode {
   readonly canUseTouchActionSheet: boolean;
 }
 
-const getHasHoverInput = (): boolean => {
-  const win = globalThis as typeof globalThis & {
-    matchMedia?: (query: string) => MediaQueryList;
-  };
+// hasHoverCapability includes behavioral fine-pointer evidence, so browsers
+// that mis-report "no hover" still get hover actions once a mouse is seen.
+const getHasHoverInput = (): boolean => hasHoverCapability();
 
-  return HOVER_INPUT_MEDIA_QUERIES.some(
-    (query) => win.matchMedia?.(query)?.matches ?? false
-  );
-};
-
-const subscribeToHoverInput = (onStoreChange: () => void) => {
-  const win = globalThis as typeof globalThis & {
-    matchMedia?: (query: string) => MediaQueryList;
-  };
-
-  const matchMedia = win.matchMedia;
-  if (!matchMedia) {
-    return () => undefined;
-  }
-
-  const mediaQueries = HOVER_INPUT_MEDIA_QUERIES.map((query) =>
-    matchMedia(query)
-  );
-
-  mediaQueries.forEach((mediaQuery) => {
-    if (typeof mediaQuery.addEventListener === "function") {
-      mediaQuery.addEventListener("change", onStoreChange);
-      return;
-    }
-
-    if (typeof mediaQuery.addListener === "function") {
-      mediaQuery.addListener(onStoreChange);
-    }
-  });
-
-  return () => {
-    mediaQueries.forEach((mediaQuery) => {
-      if (typeof mediaQuery.removeEventListener === "function") {
-        mediaQuery.removeEventListener("change", onStoreChange);
-        return;
-      }
-
-      if (typeof mediaQuery.removeListener === "function") {
-        mediaQuery.removeListener(onStoreChange);
-      }
-    });
-  };
-};
+const subscribeToHoverInput = (onStoreChange: () => void) =>
+  subscribeToTouchFirstChanges(onStoreChange);
 
 const getServerHoverInputSnapshot = () => false;
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -109,9 +109,11 @@
     scrollbar-width: none;
     /* Firefox */
   }
-  /* Prevent text selection on touch devices only */
+  /* Prevent text selection on touch devices only. body:not([data-fine-pointer])
+     keeps selection alive on browsers that mis-report capabilities while a
+     mouse/trackpad is demonstrably in use (see touch-first.helpers.ts). */
   @media (any-hover: none) and (any-pointer: coarse) {
-    .touch-select-none {
+    body:not([data-fine-pointer]) .touch-select-none {
       user-select: none;
       -webkit-user-select: none;
       -moz-user-select: none;
@@ -704,8 +706,14 @@ h5:not(.tailwind-scope h5) {
     color: #ffffff;
   }
 }
+/* Behavioral fine-pointer evidence (see touch-first.helpers.ts): honor icon
+   hover and hide touch-only affordances once a mouse/trackpad is observed,
+   even when the browser mis-reports its pointer capabilities. */
+body[data-fine-pointer] .icon:hover {
+  color: #ffffff;
+}
 @media (any-hover: none) and (any-pointer: coarse) {
-  .touch-visible {
+  body:not([data-fine-pointer]) .touch-visible {
     display: block !important;
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -232,10 +232,16 @@ const tailwindConfig: Config = {
     scrollbar({ nocompatible: true }),
     containerQueries,
     plugin(({ addVariant }) => {
-      addVariant("desktop-hover", "@media (any-hover: hover)");
+      // body[data-fine-pointer] is behavioral evidence of a mouse/trackpad
+      // set by helpers/touch-first.helpers.ts — it overrides browsers that
+      // mis-report hover/pointer capabilities.
+      addVariant("desktop-hover", [
+        "@media (any-hover: hover)",
+        "body[data-fine-pointer] &",
+      ]);
       addVariant(
         "touch-only",
-        "@media (any-hover: none) and (any-pointer: coarse)"
+        "@media (any-hover: none) and (any-pointer: coarse) { body:not([data-fine-pointer]) & }"
       );
     }),
   ],


### PR DESCRIPTION
## Issue
- Reported by @punk6529 on his Surface after 4.70.0 (persisting through a hard reload): the mobile action sheet appears on the desktop layout, **text selection with the trackpad is dead**, and there is no way to copy a message's text.
- Root cause chain (three layers):
  1. His browser reports `any-hover: none` + no fine pointer while a trackpad is actively in use — a known class of Windows/Chromium capability mis-reporting on convertibles. Every downstream decision that trusts those media queries is then 'correctly wrong': CSS `touch-select-none` disables selection, `desktop-hover:` styles vanish, and the touch action sheet legitimately activates (no hover ⇒ hover menus unreachable).
  2. Independently, the grouped-message timestamp swipe armed on mouse `pointerdown` and hijacked leftward drags (`setPointerCapture` + `preventDefault`) even on honest desktops.
  3. 'Copy text' (PR #3072) only ever existed in the mobile sheet — no desktop equivalent.

## Fix
- **Behavioral fine-pointer latch** (`helpers/touch-first.helpers.ts`): the first `pointerType: 'mouse'` event is ground truth that a fine, hover-capable pointer exists. It latches, notifies all touch-first subscribers (`useIsTouchDevice`, `useDeviceInfo`, `useDropActionInteractionMode`), and tags `body[data-fine-pointer]` so CSS participates: `desktop-hover:` variants also match under the attribute, `touch-only:` and `touch-select-none`/`touch-visible` rules exclude it. Phones keep the mobile-UA override (a paired mouse never de-mobilizes a phone). Sentinel listeners uninstall after first evidence. Data attribute rather than a class because tailwind's `tw-` prefix rewrites classes inside variant selectors (caught via CLI probe).
- **Timestamp swipe** gated to touch-sheet mode; grouped timestamps reveal on row hover on desktop (`grouped-drop-hover-timestamp`).
- **Copy text** added to the desktop ⋯ options menu (reuses `buildDropClipboardText` + existing message key; clipboard-API guard; menu always closes).

## Validation
- 45 unit tests green across the touch-first helpers (incl. the new latch file: lying-browser profile flips to desktop on first mouse event, touch events don't latch, phone UA override survives the latch), interaction-mode hook, WaveDrop (leftward-mouse-drag no-hijack regression), and the new menu item.
- Tailwind variant output verified by CLI probe: `body[data-fine-pointer] .desktop-hover\:*` and `body:not([data-fine-pointer]) .touch-only\:*` emit as intended.
- eslint + debt ratchet clean.

## Risk
- Level: Medium
- Why: touches the capability layer used app-wide, plus CSS variants. Mitigations: the latch only ever *adds* desktop capabilities (never removes touch ones), only after unambiguous mouse evidence, and phones are UA-protected. Honest browsers see zero behavior change until a mouse event — which on real desktops was already implied.
- Rollback: revert the branch commits.

## Review Notes
- The latch is one-way for the page lifetime by design: a device that has produced mouse events has a mouse; posture flips mid-session keep desktop UX (acceptable, matches 4.70.0's residual note).
- `useHasTouchInput` and the touch action sheet remain fully functional for genuinely hoverless devices — the sheet still appears when no mouse has ever been seen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Copy text” action in message menus, with the action disabled for temporary items.

* **Bug Fixes**
  * Improved timestamp behavior on grouped messages so desktop users see hover-based timestamps instead of swipe-only behavior.
  * Prevented mouse drag gestures from interfering with timestamp reveal interactions.
  * Refined touch/desktop detection so hover and selection behavior respond more accurately on fine-pointer devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->