### PR TITLE
Fix Windows Node 24 spawn of .cmd shims in quality.js and dev-open.cjs

### DIFF
--- a/ops/workstreams/repo-health-2026-07/run-log.md
+++ b/ops/workstreams/repo-health-2026-07/run-log.md
@@ -49,15 +49,37 @@
 - App-wide follow-up flagged (out of scope, evidence attached): every
   `useSetTitle` suffix app-wide is silently lost to streamed metadata
   since the Next 16 upgrade — spawned as a separate task for scoping.
-- Environment notes for other threads: `quality.js --changed` fails on
-  Windows Node 24 (spawnSync of .cmd without shell) — run
-  `format:changed`/`lint:changed`/`typecheck:changed` directly; in fresh
-  worktrees use `./bin/6529 env prod` (then verify with `env status` —
-  the switcher comments out non-matching managed keys but only appends
-  missing ones, so a local-target `.env` can end up with no active
-  API/WS endpoint) instead of relying on shell-var overrides reaching
-  the client env bake; dev servers watched by piped `head`/`tail` die on
-  SIGPIPE once the pipe closes — redirect to a file instead.
+- Environment notes for other threads:
+  - `quality.js --changed` failed on Windows Node 24 (spawnSync of .cmd
+    without shell) — fixed in PR #3100 (`quality.js`/`dev-open.cjs` now
+    run `.cmd` shims through a shell; `dev:open` also needed `run dev`
+    instead of bare `dev`). Until a checkout has the fix, run
+    `format:changed`/`lint:changed`/`typecheck:changed` directly.
+  - knip reports ~23 false unused-file/export findings (`ops/scripts/*`
+    files, gate-script exports) when run from a worktree nested under
+    `.claude/worktrees/`; identical content knips clean from a
+    short-path worktree or the main checkout — treat knip failures under
+    `.claude/worktrees/` as suspect before chasing them.
+  - Nested bare-`pnpm` hops (`check:changed`, `predev`) execute in
+    whichever checkout's `bin/` is on PATH (`bin/pnpm.cmd` does
+    `cd /d "%~dp0.."`), so from a secondary worktree they silently run
+    against the main checkout — strip the other checkout's `bin` from
+    PATH when verifying.
+  - A stale local `main` ref inflates the `:changed` sets until
+    `lint:changed` overflows the Windows command-line length limit
+    ("The command line is too long", xargs exit 123).
+  - Turbopack refuses a junctioned `node_modules` ("symlink points out
+    of the filesystem root") — use `USE_TURBO=false` in junction-based
+    scratch worktrees.
+  - In fresh worktrees use `./bin/6529 env prod` (then verify with
+    `env status` — the switcher comments out non-matching managed keys
+    but only appends missing ones, so a local-target `.env` can end up
+    with no active API/WS endpoint) instead of relying on shell-var
+    overrides reaching the client env bake; `.env.sample` placeholders
+    also fail schema validation (`IPFS_GATEWAY_ENDPOINT` URL,
+    positive-number vars) — seed from a known-good `.env` instead.
+  - Dev servers watched by piped `head`/`tail` die on SIGPIPE once the
+    pipe closes — redirect to a file instead.
 
 ## 2026-07-05 (Thread D — one layout)
 

--- a/scripts/dev-open.cjs
+++ b/scripts/dev-open.cjs
@@ -14,14 +14,24 @@ function getOpenModule() {
   return openModulePromise;
 }
 
-const repoCommand =
-  process.platform === "win32"
-    ? path.join(process.cwd(), "bin", "6529.cmd")
-    : "./bin/6529";
+const isWindows = process.platform === "win32";
+const repoCommand = isWindows
+  ? path.join(process.cwd(), "bin", "6529.cmd")
+  : "./bin/6529";
 
-const proc = spawn(repoCommand, ["dev"], {
-  stdio: ["inherit", "pipe", "inherit"],
-});
+// Node refuses to spawn .cmd files without a shell (CVE-2024-27980), and
+// combining shell:true with an args array is deprecated (DEP0190), so the
+// Windows invocation is one static command line with the shim path quoted.
+// bin/6529 only accepts package.json scripts through `run`, so this must
+// spawn `run dev`, not bare `dev`.
+const proc = spawn(
+  isWindows ? `"${repoCommand}" run dev` : repoCommand,
+  isWindows ? [] : ["run", "dev"],
+  {
+    stdio: ["inherit", "pipe", "inherit"],
+    shell: isWindows,
+  }
+);
 
 proc.on("error", (error) => {
   console.error("Failed to start dev server:", error);

--- a/scripts/quality.js
+++ b/scripts/quality.js
@@ -20,12 +20,23 @@ const enableCoderabbit = args.has("--coderabbit");
 const changedMode = args.has("--changed");
 
 const runCommand = ({ command, args = [], inheritOutput = false }) => {
+  // Node refuses to spawn .cmd/.bat files without a shell (CVE-2024-27980),
+  // and combining shell:true with an args array is deprecated (DEP0190), so
+  // shim invocations collapse into one command line. Safe here: every token
+  // is a static string, and the quoted shim path survives a repo path with
+  // spaces under cmd.exe.
+  const useShell = /\.(cmd|bat)$/i.test(command);
   // Sonar hotspot accepted: this is a trusted local developer script.
-  const result = spawnSync(command, args, {
-    encoding: "utf8",
-    cwd: repoRoot,
-    stdio: inheritOutput ? "inherit" : ["ignore", "pipe", "pipe"],
-  });
+  const result = spawnSync(
+    useShell ? [`"${command}"`, ...args].join(" ") : command,
+    useShell ? [] : args,
+    {
+      encoding: "utf8",
+      cwd: repoRoot,
+      stdio: inheritOutput ? "inherit" : ["ignore", "pipe", "pipe"],
+      shell: useShell,
+    }
+  );
 
   if (result.error) {
     throw result.error;


### PR DESCRIPTION
## Problem

Node's CVE-2024-27980 hardening makes `spawnSync`/`spawn` of `.cmd`/`.bat` files fail with `EINVAL` unless a shell is used. On Windows (Node 24):

- `scripts/quality.js` spawns `bin/6529.cmd` (format/lint/typecheck/knip stages) and `coderabbit.cmd` without a shell, so `6529 run quality:changed` / `quality` / `check` / `check:changed` die at the first stage with `ERROR: Format changed files failed.` — the EINVAL is swallowed by the stage wrapper. Documented as a Thread F environment blocker in `ops/workstreams/repo-health-2026-07/run-log.md`.
- `scripts/dev-open.cjs` has the same spawn bug — and additionally has passed bare `dev` to `bin/6529` since both were introduced in #2207. The shim rejects bare `dev` ("Use \`6529 run dev\`"), so `dev:open` has never worked on any platform.

## Fix

- `quality.js#runCommand`: when the target is a `.cmd`/`.bat` shim, collapse the invocation into a single quoted command line run with `shell: true`. The single-string form avoids Node 24's DEP0190 deprecation (shell + args array); the quoting keeps repo paths containing spaces working under `cmd.exe /d /s /c`. Every token is a static string, so there is no injection surface. Non-shim targets (`git`) spawn exactly as before, shell-less.
- `dev-open.cjs`: same shell treatment, plus spawn `run dev` instead of bare `dev`.

This matches the pattern already used in `scripts/run-secure-pnpm.cjs` and `scripts/react-doctor-diff.cjs` (`shell: process.platform === "win32"`).

## Audit of the other scripts/*.js|cjs

Swept for `spawn`/`spawnSync`/`exec*`: every other call site targets `git` / `process.execPath` (`.exe` — unaffected by the hardening) or already passes `shell` on Windows (`run-secure-pnpm.cjs`, `react-doctor-diff.cjs`). No other fixes needed.

## Verification (Windows Server 2025, Node v24.16.0)

- Before: `./bin/6529 run quality:changed` → `ERROR: Format changed files failed.`; isolated repro: `spawnSync("bin\6529.cmd", ...)` → `error.code === "EINVAL"`.
- After, from a clean short-path worktree at this commit:
  - `./bin/6529 run quality:changed` → exit 0 (format:changed, lint:changed, typecheck:changed, repo-wide knip all execute through the shim; knip JSON captured and parsed).
  - `./bin/6529 run check:changed` → exit 0.
  - `./bin/6529 run dev:open` → Next.js 16.2.6 boots to `✓ Ready`; dev-open's stdout URL scraping and exit propagation work.
  - No DEP0190 warnings.
- POSIX behavior unchanged: commands never end in `.cmd`/`.bat` there, so `shell` stays false and args pass as an array exactly as before.

Unrelated Windows/worktree environment quirks hit during verification (knip false positives under `.claude/worktrees`-nested worktrees; nested bare-`pnpm` hops pinned to whichever checkout's `bin/` is on PATH) are recorded in the campaign run-log in this PR's follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)