### PR TITLE
Fix Device Farm test-spec host tokens and document live-run gotchas

### DIFF
--- a/ops/docs/developer/device-farm-qa.md
+++ b/ops/docs/developer/device-farm-qa.md
@@ -93,6 +93,7 @@ stable; unmetered slots ($250/device/month) only pay off past ~25 runs/week.
            "devicefarm:ListUploads",
            "devicefarm:CreateUpload",
            "devicefarm:GetUpload",
+           "devicefarm:DeleteUpload",
            "devicefarm:ScheduleRun",
            "devicefarm:GetRun",
            "devicefarm:StopRun",
@@ -120,6 +121,27 @@ stable; unmetered slots ($250/device/month) only pay off past ~25 runs/week.
 
    Until the secrets exist, every job in the workflow skips with a `::notice`
    and the scheduled run stays green — provisioning can land after the code.
+
+4. **Actions allowlist** — this repository runs the "allow selected actions"
+   policy (GitHub-owned + Marketplace-verified + explicit patterns). The
+   workflow's SHA-pinned third-party actions must appear as exact patterns in
+   the allowlist or every run ends in `startup_failure` with zero jobs:
+
+   ```
+   aws-actions/aws-devicefarm-mobile-device-testing@<pinned SHA>
+   sarisia/actions-status-discord@<pinned SHA>
+   ```
+
+   (Both are in place as of 2026-07-05; re-add the new SHA whenever the pin is
+   bumped. Note the policy/CodeQL tension: CodeQL requires SHA pins while the
+   allowlist previously only allowed `sarisia/actions-status-discord@v1`.)
+
+### Test spec gotcha
+
+The AWS docs render test-host selectors as `{{amazon_linux_2}}` — that is doc
+templating, not syntax. Device Farm rejects the braces with
+`TEST_SPEC_INVALID_YAML_FILE`; test spec files must use the bare tokens
+(`android_test_host: amazon_linux_2`, `ios_test_host: macos_sequoia`).
 
 ## Reading results
 

--- a/tests/device-farm/testspecs/native-android.yml
+++ b/tests/device-farm/testspecs/native-android.yml
@@ -5,7 +5,7 @@
 # https://docs.aws.amazon.com/devicefarm/latest/developerguide/custom-test-environment-test-spec.html
 version: 0.1
 
-android_test_host: {{amazon_linux_2}}
+android_test_host: amazon_linux_2
 
 phases:
   install:

--- a/tests/device-farm/testspecs/web-android.yml
+++ b/tests/device-farm/testspecs/web-android.yml
@@ -4,7 +4,7 @@
 # https://docs.aws.amazon.com/devicefarm/latest/developerguide/custom-test-environment-test-spec.html
 version: 0.1
 
-android_test_host: {{amazon_linux_2}}
+android_test_host: amazon_linux_2
 
 phases:
   install:

--- a/tests/device-farm/testspecs/web-ios.yml
+++ b/tests/device-farm/testspecs/web-ios.yml
@@ -5,7 +5,7 @@
 # https://docs.aws.amazon.com/devicefarm/latest/developerguide/custom-test-environment-test-spec.html
 version: 0.1
 
-ios_test_host: {{macos_sequoia}}
+ios_test_host: macos_sequoia
 
 phases:
   install:


### PR DESCRIPTION
Follow-up to #3091 from the first live Device Farm run ([28747773193](https://github.com/6529-Collections/6529seize-frontend/actions/runs/28747773193)):

- **Test specs**: Device Farm rejects `{{amazon_linux_2}}`-style host selectors with `TEST_SPEC_INVALID_YAML_FILE` — the braces in AWS's docs are their doc templating, not syntax. All three specs now use bare tokens (`android_test_host: amazon_linux_2`, `ios_test_host: macos_sequoia`) and are YAML-validated.
- **IAM**: the action's post-run cleanup calls `devicefarm:DeleteUpload`; added to the documented policy. Already applied to the live `devicefarm-ci` user.
- **Docs**: recorded the repo Actions-allowlist requirement (SHA-pinned third-party actions need exact-SHA patterns or runs end in `startup_failure`; allowlist updated 2026-07-05) and the test-spec brace gotcha.

Everything else in the first run worked: pack planning, npm-pack bundling, name-based project/pool lookup, test package upload, and the native pack's self-skip notice (MOBILE_REPO_TOKEN pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)