### PR TITLE
Align collections/network pack titles with post-reassert reality

### DIFF
--- a/tests/collections/nextgen-collections-readonly.spec.ts
+++ b/tests/collections/nextgen-collections-readonly.spec.ts
@@ -155,9 +155,7 @@ test.describe("NextGen and collections read-only coverage @surface @medium @larg
     await expect(
       page.getByRole("heading", { level: 1, name: "Collections" })
     ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Status: ALL" })
-    ).toBeVisible();
+    await expect(page.getByLabel("Status:")).toBeVisible();
     await expectCardsOrEmpty(
       page,
       page.locator('main a[href*="/nextgen/collection/"]'),
@@ -225,7 +223,8 @@ test.describe("NextGen and collections read-only coverage @surface @medium @larg
   }, testInfo) => {
     await gotoReady(page, "/the-memes");
 
-    await expect(page).toHaveTitle("The Memes");
+    // Client titles win since the title-reassert fix (#3077): suffixed form.
+    await expect(page).toHaveTitle("The Memes | Collections");
     await expectCollectionTitle(page, testInfo.project.name, "The Memes");
     await expect(
       page.getByRole("region", { name: "Meme sorting" })
@@ -242,7 +241,8 @@ test.describe("NextGen and collections read-only coverage @surface @medium @larg
   }, testInfo) => {
     await gotoReady(page, "/meme-lab");
 
-    await expect(page).toHaveTitle("Meme Lab");
+    // Client titles win since the title-reassert fix (#3077): suffixed form.
+    await expect(page).toHaveTitle("Meme Lab | Collections");
     await expectCollectionTitle(page, testInfo.project.name, "Meme Lab");
     await expect(
       page.getByRole("region", { name: "Meme Lab sorting" })

--- a/tests/network-open-data/network-open-data-api-readonly.spec.ts
+++ b/tests/network-open-data/network-open-data-api-readonly.spec.ts
@@ -127,7 +127,9 @@ test.describe("Network, Open Data, and public API read-only coverage @surface @m
         url.searchParams.get("page") === "1"
     );
 
-    await expect(page).toHaveTitle("Network Metrics | Open Data");
+    // Client title wins since the title-reassert fix (#3077); the page's
+    // client title carries the historical "Consolidated" qualifier (#3081).
+    await expect(page).toHaveTitle("Consolidated Network Metrics | Open Data");
     await expect(
       page.getByRole("heading", {
         level: 1,


### PR DESCRIPTION
Production runs the title-reassert fix (#3077), so client titles now win on deployed environments — the packs' four stale expectations (bare 'The Memes'/'Meme Lab', non-Consolidated Network Metrics, and one Bootstrap-era 'Status: ALL' button locator) made both packs red against a correct build. Aligned to shipped reality and verified against live production: collections 10/10, network 7/7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)