### PR TITLE
Harden Device Farm web smoke against Safari navigation races

### DIFF
--- a/tests/device-farm/lib/driver.cjs
+++ b/tests/device-farm/lib/driver.cjs
@@ -127,6 +127,42 @@ async function waitForDocumentReady(driver, timeout) {
   );
 }
 
+/**
+ * Navigate and wait until the browser is really on the requested page with
+ * rendered content. Safari's WebDriver `url()` can return before navigation
+ * starts (observed on Device Farm iPhones: the previous page's readyState
+ * satisfies a naive readiness check), so this waits for the expected pathname
+ * and a non-empty body rather than trusting the first readyState=complete.
+ */
+async function openPage(driver, pageUrl, timeout) {
+  const expectedPath = new URL(pageUrl).pathname.replace(/\/$/, "") || "/";
+  await driver.url(pageUrl);
+  await driver.waitUntil(
+    async () => {
+      const pathname = await driver.execute(() =>
+        window.location.pathname.replace(/\/$/, "")
+      );
+      return (pathname || "/") === expectedPath;
+    },
+    {
+      timeout,
+      interval: 2000,
+      timeoutMsg: `browser never navigated to ${expectedPath}`,
+    }
+  );
+  await waitForDocumentReady(driver, timeout);
+  await driver.waitUntil(
+    async () =>
+      (await driver.execute(() => (document.body.innerText || "").trim()))
+        .length > 0,
+    {
+      timeout,
+      interval: 2000,
+      timeoutMsg: `${expectedPath} never rendered visible body content`,
+    }
+  );
+}
+
 async function waitForWebviewContext(driver, timeout) {
   let webviewContext;
   await driver.waitUntil(
@@ -169,6 +205,7 @@ module.exports = {
   DEEP_LINK_SCHEME,
   assertNoCrashMarkers,
   isIos,
+  openPage,
   saveScreenshot,
   startNativeAndroidSession,
   startWebSession,

--- a/tests/device-farm/specs/web.smoke.spec.cjs
+++ b/tests/device-farm/specs/web.smoke.spec.cjs
@@ -11,10 +11,10 @@
 const assert = require("node:assert");
 const {
   assertNoCrashMarkers,
+  openPage,
   saveScreenshot,
   startWebSession,
   targetUrl,
-  waitForDocumentReady,
 } = require("../lib/driver.cjs");
 
 const PAGE_LOAD_TIMEOUT_MS = 90000;
@@ -46,15 +46,14 @@ describe("6529 mobile web smoke (real device)", function () {
 
   for (const page of PAGES) {
     it(`renders ${page.path} without crashing`, async function () {
-      await driver.url(new URL(page.path, targetUrl()).toString());
-      await waitForDocumentReady(driver, PAGE_LOAD_TIMEOUT_MS);
+      await openPage(
+        driver,
+        new URL(page.path, targetUrl()).toString(),
+        PAGE_LOAD_TIMEOUT_MS
+      );
 
       const bodyText = await driver.execute(() => document.body.innerText || "");
       assertNoCrashMarkers(assert, bodyText, page.path);
-      assert.ok(
-        bodyText.trim().length > 0,
-        `${page.path} rendered an empty body`
-      );
       if (page.expectBodyText) {
         assert.ok(
           bodyText.toLowerCase().includes(page.expectBodyText),
@@ -66,13 +65,17 @@ describe("6529 mobile web smoke (real device)", function () {
   }
 
   it("serves the 6529 app shell on the home page", async function () {
-    await driver.url(targetUrl());
-    await waitForDocumentReady(driver, PAGE_LOAD_TIMEOUT_MS);
+    await openPage(driver, targetUrl(), PAGE_LOAD_TIMEOUT_MS);
 
-    const title = await driver.getTitle();
-    assert.ok(
-      title.toLowerCase().includes("6529"),
-      `home page title "${title}" does not mention 6529`
+    // The home page's own title mentions 6529; give SPA title effects a
+    // moment to settle instead of asserting the first paint.
+    await driver.waitUntil(
+      async () => (await driver.getTitle()).toLowerCase().includes("6529"),
+      {
+        timeout: 30000,
+        interval: 2000,
+        timeoutMsg: "home page title never mentioned 6529",
+      }
     );
 
     const hasNavigationChrome = await driver.execute(() =>
@@ -82,8 +85,7 @@ describe("6529 mobile web smoke (real device)", function () {
   });
 
   it("keeps the mobile viewport free of horizontal overflow", async function () {
-    await driver.url(targetUrl());
-    await waitForDocumentReady(driver, PAGE_LOAD_TIMEOUT_MS);
+    await openPage(driver, targetUrl(), PAGE_LOAD_TIMEOUT_MS);
 
     const overflowPx = await driver.execute(
       () =>


### PR DESCRIPTION
Follow-up to #3091/#3102 from the second live Device Farm run ([28749127496](https://github.com/6529-Collections/6529seize-frontend/actions/runs/28749127496)):

- **Android Chrome (real Galaxy-class device): PASSED 5/5** — the pack is fully working end-to-end on Android.
- **iOS Safari (real iPhone 15, iOS 18): 2/5** — root cause is a Safari WebDriver navigation race, not the site: `url()` returns before navigation starts, so the previous page's `readyState=complete` satisfied the naive wait and assertions ran against the old/blank page (the home-shell test literally saw `/the-memes`' title; two pages asserted an "empty body" mid-navigation).

Fix: new `openPage()` helper waits for the expected `location.pathname`, then `readyState=complete`, then non-empty `document.body.innerText` before any assertion; the home title check now polls for the title to settle. Test-code only — no workflow, IAM, or runtime changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page loading checks to reduce flaky mobile web smoke test behavior and better wait for visible content before continuing.
  * Made page title verification more reliable on the home page by waiting for the expected title text to appear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->