### PR TITLE
Read use-case lock multicall envelopes via .result, honoring status

### DIFF
--- a/__tests__/components/delegation/CollectionDelegation.utils.test.ts
+++ b/__tests__/components/delegation/CollectionDelegation.utils.test.ts
@@ -3,6 +3,7 @@ import {
   getDelegationsFromData,
   getParams,
   getReadParams,
+  readMulticallBoolean,
 } from "@/components/delegation/CollectionDelegation.utils";
 import {
   CONSOLIDATION_USE_CASE,
@@ -93,5 +94,42 @@ describe("CollectionDelegation utility functions", () => {
     expect(primary?.wallets[0].expiry).toBe("active - non-expiring");
     expect(subDelegation?.wallets[0].expiry).toBe("active - non-expiring");
     expect(consolidation?.wallets[0].expiry).toBe("active - non-expiring");
+  });
+});
+
+describe("readMulticallBoolean", () => {
+  it("reads true only from a successful envelope with result true", () => {
+    const data = [
+      { status: "success" as const, result: true },
+      { status: "success" as const, result: false },
+    ];
+    expect(readMulticallBoolean(data, 0)).toBe(true);
+    expect(readMulticallBoolean(data, 1)).toBe(false);
+  });
+
+  it("treats failed entries as false regardless of result", () => {
+    const data = [
+      { status: "failure" as const, result: undefined },
+      { status: "failure" as const, result: true },
+    ];
+    expect(readMulticallBoolean(data, 0)).toBe(false);
+    expect(readMulticallBoolean(data, 1)).toBe(false);
+  });
+
+  it("treats missing entries and missing data as false", () => {
+    expect(readMulticallBoolean(undefined, 0)).toBe(false);
+    expect(readMulticallBoolean([], 3)).toBe(false);
+    expect(readMulticallBoolean([undefined], 0)).toBe(false);
+  });
+
+  it("does not treat truthy non-boolean results as locked", () => {
+    const data = [
+      { status: "success" as const, result: {} },
+      { status: "success" as const, result: 1 },
+      { status: "success" as const, result: "true" },
+    ];
+    expect(readMulticallBoolean(data, 0)).toBe(false);
+    expect(readMulticallBoolean(data, 1)).toBe(false);
+    expect(readMulticallBoolean(data, 2)).toBe(false);
   });
 });

--- a/__tests__/components/delegation/CollectionDelegationLocks.test.tsx
+++ b/__tests__/components/delegation/CollectionDelegationLocks.test.tsx
@@ -1,0 +1,254 @@
+jest.mock("react", () => {
+  const actual = jest.requireActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    useEffectEvent: (fn: (...args: unknown[]) => unknown) =>
+      actual.useCallback(fn, []),
+  };
+});
+
+import CollectionDelegationComponent from "@/components/delegation/CollectionDelegation";
+import { ALL_USE_CASES } from "@/components/delegation/delegation-constants";
+import { DELEGATION_ALL_ADDRESS } from "@/constants/constants";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useReadContract, useReadContracts, useWriteContract } from "wagmi";
+
+jest.mock("wagmi", () => ({
+  useReadContract: jest.fn(),
+  useReadContracts: jest.fn(),
+  useWriteContract: jest.fn(),
+  useEnsName: jest.fn().mockReturnValue({ data: undefined }),
+  useWaitForTransactionReceipt: jest.fn().mockReturnValue({
+    isLoading: false,
+    isSuccess: false,
+    isError: false,
+    error: undefined,
+  }),
+  useChainId: jest.fn().mockReturnValue(1),
+}));
+
+jest.mock("@/components/auth/SeizeConnectContext", () => ({
+  useSeizeConnectContext: () => ({ address: "0x0", isConnected: true }),
+}));
+
+const mockUseReadContract = useReadContract as jest.Mock;
+const mockUseReadContracts = useReadContracts as jest.Mock;
+const mockUseWriteContract = useWriteContract as jest.Mock;
+const mockWriteContract = jest.fn();
+
+type Envelope = { status: "success" | "failure"; result?: unknown };
+
+interface LockReadParams {
+  contracts?: { functionName?: string; args?: unknown[] }[];
+}
+
+// getParams appends the primary/sub-delegation/consolidation trio after the
+// provided use cases, so the use-case lock multicall has three extra entries.
+const LOCK_MULTICALL_SIZE = ALL_USE_CASES.length + 3;
+
+function buildEnvelopes(overrides: Record<number, Envelope>): Envelope[] {
+  const envelopes: Envelope[] = Array.from(
+    { length: LOCK_MULTICALL_SIZE },
+    () => ({ status: "success", result: false })
+  );
+  for (const [index, envelope] of Object.entries(overrides)) {
+    envelopes[Number(index)] = envelope;
+  }
+  return envelopes;
+}
+
+describe("CollectionDelegation use-case lock UI (issue #3078)", () => {
+  const collection = {
+    title: "Test Collection",
+    display: "Test",
+    contract: "0x1",
+    preview: "",
+  };
+  const setSection = jest.fn();
+
+  function mockLockReads(options: {
+    statuses: Envelope[];
+    global: Envelope[];
+  }) {
+    mockUseReadContracts.mockImplementation((params?: LockReadParams) => {
+      const first = params?.contracts?.[0];
+      if (first?.functionName !== "retrieveCollectionUseCaseLockStatus") {
+        return { data: undefined, refetch: jest.fn() };
+      }
+      return {
+        data:
+          first.args?.[0] === DELEGATION_ALL_ADDRESS
+            ? options.global
+            : options.statuses,
+        refetch: jest.fn(),
+      };
+    });
+  }
+
+  function renderComponent() {
+    return render(
+      <CollectionDelegationComponent
+        collection={collection}
+        setSection={setSection}
+      />
+    );
+  }
+
+  function selectUseCase(value: number) {
+    fireEvent.change(screen.getByLabelText("Lock or unlock use case"), {
+      target: { value: String(value) },
+    });
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseReadContract.mockReturnValue({});
+    mockUseReadContracts.mockReturnValue({
+      data: undefined,
+      refetch: jest.fn(),
+    });
+    mockUseWriteContract.mockReturnValue({
+      writeContract: mockWriteContract,
+      reset: jest.fn(),
+      data: undefined,
+      error: undefined,
+    });
+  });
+
+  it("labels use cases from decoded results instead of envelope truthiness", () => {
+    mockLockReads({
+      // Index 1 = use case #2 (locked), index 2 = use case #3 (unlocked),
+      // index 3 = use case #4 (failed read).
+      statuses: buildEnvelopes({
+        1: { status: "success", result: true },
+        3: { status: "failure", result: undefined },
+      }),
+      global: buildEnvelopes({}),
+    });
+
+    renderComponent();
+
+    expect(
+      screen.getByRole("option", { name: "#2 - Minting / Allowlist - LOCKED" })
+    ).toBeInTheDocument();
+    // With the envelope bug every option rendered LOCKED once data arrived;
+    // a decoded false must now render UNLOCKED.
+    expect(
+      screen.getByRole("option", { name: "#3 - Airdrops - UNLOCKED" })
+    ).toBeInTheDocument();
+    // A failed multicall entry reads as unknown -> UNLOCKED, not LOCKED.
+    expect(
+      screen.getByRole("option", {
+        name: "#4 - Voting / Governance - UNLOCKED",
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("marks globally locked use cases with LOCKED and an asterisk", () => {
+    mockLockReads({
+      statuses: buildEnvelopes({}),
+      // Index 4 = use case #5 locked at the all-collections scope.
+      global: buildEnvelopes({ 4: { status: "success", result: true } }),
+    });
+
+    renderComponent();
+
+    expect(
+      screen.getByRole("option", { name: "#5 - Avatar Display - LOCKED *" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", {
+        name: "#2 - Minting / Allowlist - UNLOCKED",
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("locks an unlocked use case with a Locking toast and lock=true args", () => {
+    mockLockReads({
+      statuses: buildEnvelopes({}),
+      global: buildEnvelopes({}),
+    });
+
+    renderComponent();
+    selectUseCase(3);
+
+    const button = screen.getByRole("button", { name: /Lock Use Case/ });
+    fireEvent.click(button);
+
+    expect(mockWriteContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: "setCollectionUsecaseLock",
+        args: [collection.contract, 3, true],
+      })
+    );
+    expect(
+      screen.getByText("Locking Wallet on Use Case #3 - Airdrops")
+    ).toBeInTheDocument();
+  });
+
+  it("unlocks a locked use case with an Unlocking toast and lock=false args", () => {
+    mockLockReads({
+      statuses: buildEnvelopes({ 1: { status: "success", result: true } }),
+      global: buildEnvelopes({}),
+    });
+
+    renderComponent();
+    selectUseCase(2);
+
+    const button = screen.getByRole("button", { name: /Unlock Use Case/ });
+    fireEvent.click(button);
+
+    expect(mockWriteContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: "setCollectionUsecaseLock",
+        args: [collection.contract, 2, false],
+      })
+    );
+    expect(
+      screen.getByText("Unlocking Wallet on Use Case #2 - Minting / Allowlist")
+    ).toBeInTheDocument();
+  });
+
+  it("points at All Collections instead of the lock button when globally locked", () => {
+    mockLockReads({
+      statuses: buildEnvelopes({}),
+      global: buildEnvelopes({ 4: { status: "success", result: true } }),
+    });
+
+    renderComponent();
+    selectUseCase(5);
+
+    expect(
+      screen.queryByRole("button", { name: /Lock Use Case|Unlock Use Case/ })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/Unlock use case in/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "All Collections" })
+    ).toBeInTheDocument();
+  });
+
+  it("still shows the lock button while global statuses are absent", () => {
+    // Simulate the all-collections page shape: the global multicall gets
+    // empty params and never produces data.
+    mockUseReadContracts.mockImplementation((params?: LockReadParams) => {
+      const first = params?.contracts?.[0];
+      if (first?.functionName !== "retrieveCollectionUseCaseLockStatus") {
+        return { data: undefined, refetch: jest.fn() };
+      }
+      return {
+        data:
+          first.args?.[0] === DELEGATION_ALL_ADDRESS
+            ? undefined
+            : buildEnvelopes({}),
+        refetch: jest.fn(),
+      };
+    });
+
+    renderComponent();
+    selectUseCase(3);
+
+    expect(
+      screen.getByRole("button", { name: /Lock Use Case/ })
+    ).toBeInTheDocument();
+  });
+});

--- a/components/delegation/CollectionDelegation.utils.ts
+++ b/components/delegation/CollectionDelegation.utils.ts
@@ -47,6 +47,30 @@ type DelegationsResultTuple = readonly [
   readonly (number | bigint)[],
 ];
 
+/**
+ * One entry of a wagmi `useReadContracts` (multicall) result. With the
+ * default `allowFailure: true`, `data[i]` is this envelope object — the
+ * decoded value lives at `.result` and is only meaningful when `status`
+ * is `"success"`.
+ */
+export interface MulticallEnvelope {
+  readonly status: "success" | "failure";
+  readonly result?: unknown;
+}
+
+/**
+ * Reads one decoded boolean out of a multicall result. Failed or missing
+ * entries read as `false`, so lock UI treats an unknown status as
+ * unlocked instead of locked.
+ */
+export function readMulticallBoolean(
+  data: readonly (MulticallEnvelope | undefined)[] | undefined,
+  index: number
+): boolean {
+  const entry = data?.[index];
+  return entry?.status === "success" && entry.result === true;
+}
+
 function formatExpiry(myDate: number) {
   const date = new Date(myDate * 1000);
   const year = date.getUTCFullYear();

--- a/components/delegation/collection-delegation/CollectionDelegationLocks.tsx
+++ b/components/delegation/collection-delegation/CollectionDelegationLocks.tsx
@@ -27,6 +27,7 @@ import {
   PRIMARY_ADDRESS_USE_CASE,
   SUB_DELEGATION_USE_CASE,
 } from "../delegation-constants";
+import { readMulticallBoolean } from "../CollectionDelegation.utils";
 import type { DelegationToastState } from "../DelegationToast";
 import { LOCK_SELECT_CLASS } from "./collection-delegation-helpers";
 import type { CollectionLocks } from "./useCollectionLocks";
@@ -64,6 +65,18 @@ export function CollectionDelegationLocks(
 ) {
   const { collection, locks, chainsMatch, getSwitchToMessage } = props;
   const { showDelegationToast } = props;
+
+  // Multicall entries are envelopes ({ status, result }), not decoded
+  // booleans — read them through readMulticallBoolean so a failed or
+  // missing entry counts as unlocked (issue #3078).
+  const selectedUseCaseLocked = readMulticallBoolean(
+    locks.useCaseLockStatuses.data,
+    locks.lockUseCaseIndex
+  );
+  const selectedUseCaseLockedGlobally = readMulticallBoolean(
+    locks.useCaseLockStatusesGlobal.data,
+    locks.lockUseCaseIndex
+  );
 
   return (
     <div className="tw-w-full tw-p-0">
@@ -167,14 +180,14 @@ export function CollectionDelegationLocks(
             </option>
             {ALL_USE_CASES.map((uc, index) => {
               if (uc.use_case === 1) return null;
-              const asteriskDisplay = locks.useCaseLockStatusesGlobal.data?.[
+              const lockedGlobally = readMulticallBoolean(
+                locks.useCaseLockStatusesGlobal.data,
                 index
-              ]
-                ? ` *`
-                : ``;
+              );
+              const asteriskDisplay = lockedGlobally ? ` *` : ``;
               const lockDisplay =
-                locks.useCaseLockStatuses.data?.[index] ||
-                locks.useCaseLockStatusesGlobal.data?.[index] ||
+                readMulticallBoolean(locks.useCaseLockStatuses.data, index) ||
+                lockedGlobally ||
                 locks.collectionLockRead.data
                   ? ` - LOCKED${asteriskDisplay}`
                   : ` - UNLOCKED`;
@@ -192,22 +205,13 @@ export function CollectionDelegationLocks(
         </div>
         {locks.lockUseCaseValue != 0 && (
           <div className="tw-flex tw-w-full tw-items-center tw-px-3 tw-pb-2 tw-pt-2 md:tw-w-2/3">
-            {!locks.useCaseLockStatusesGlobal.data ||
-            (locks.useCaseLockStatusesGlobal?.data &&
-              // Double cast preserves the existing comparison against the
-              // multicall envelope object (issue #3078 tracks reading
-              // `.result` here); typing it honestly would change behavior.
-              (locks.useCaseLockStatusesGlobal?.data[
-                locks.lockUseCaseIndex
-              ] as unknown as boolean) === false) ? (
+            {!selectedUseCaseLockedGlobally ? (
               <button
                 className={`${styles["lockUseCaseBtn"]}`}
                 onClick={() => {
                   const useCase = DELEGATION_USE_CASES[locks.lockUseCaseIndex];
                   const title = `${
-                    locks.useCaseLockStatuses?.data?.[locks.lockUseCaseIndex]
-                      ? "Unlocking"
-                      : "Locking"
+                    selectedUseCaseLocked ? "Unlocking" : "Locking"
                   } Wallet on Use Case #${useCase?.use_case} - ${
                     useCase?.display
                   }`;
@@ -222,9 +226,7 @@ export function CollectionDelegationLocks(
                       args: [
                         collection.contract,
                         locks.lockUseCaseValue,
-                        !locks.useCaseLockStatuses.data?.[
-                          locks.lockUseCaseIndex
-                        ],
+                        !selectedUseCaseLocked,
                       ],
                       functionName: "setCollectionUsecaseLock",
                     });
@@ -235,17 +237,10 @@ export function CollectionDelegationLocks(
                 }}
               >
                 <FontAwesomeIcon
-                  icon={
-                    locks.useCaseLockStatuses.data?.[locks.lockUseCaseIndex]
-                      ? faLock
-                      : faLockOpen
-                  }
+                  icon={selectedUseCaseLocked ? faLock : faLockOpen}
                   className={styles["buttonIcon"]}
                 />
-                {locks.useCaseLockStatuses.data?.[locks.lockUseCaseIndex]
-                  ? "Unlock"
-                  : "Lock"}{" "}
-                Use Case
+                {selectedUseCaseLocked ? "Unlock" : "Lock"} Use Case
                 {(locks.useCaseLockWrite.isPending ||
                   locks.waitUseCaseLockWrite.isLoading) && <Spinner />}
               </button>


### PR DESCRIPTION
## Issue

Fixes #3078. The use-case lock UI in the collection-delegation screen read wagmi `useReadContracts` (multicall) results as booleans. With the default `allowFailure: true`, `data[i]` is an envelope object `{ error?, result?, status }` — always truthy once data loads — so the UI was systematically wrong:

- every use case rendered ` - LOCKED` plus the global `*` marker once statuses loaded
- the lock/unlock branch compared the envelope with `false` (a branch that can never be true for an object), so the "Unlock use case in All Collections" note replaced the Lock/Unlock button for every use case
- the in-flight toast title always said "Unlocking"
- most seriously: the write argument `!useCaseLockStatuses.data?.[i]` negated a truthy envelope, so `setCollectionUsecaseLock` was always submitted with `lock=false` once statuses loaded — the button could never actually lock a use case

This PR intentionally changes visible behavior; the preceding split PR (#3106) preserved the bug byte-for-byte to keep that diff mechanical. Base is `refactor/collection-delegation-split`; it retargets to `main` when #3106 merges.

## Fix

New `readMulticallBoolean(data, index)` helper in `CollectionDelegation.utils.ts` reads `data[index].result` and honors `status`: an entry only counts as locked when `status === "success"` and `result === true`. Failed or missing entries read as unlocked (unknown), never locked. All seven use-case lock sites in `CollectionDelegationLocks.tsx` now go through it (option labels, asterisk, button-vs-note branch, toast title, button icon/label, and the write argument). The collection-level single reads (`useReadContract`) already returned decoded booleans and are unchanged.

## Before / after

Rendered by feeding the Locks view fixed multicall envelopes (fixtures: use case #2 locked for this collection, #4 failed read, #5 locked at the all-collections scope; everything else decoded unlocked) via a local-only harness page on a dev server against the public API. Same fixtures, both commits:

**Before (split PR code, bug preserved)** — every option LOCKED with asterisk, note shown instead of the button for all three selections:

![before](https://gist.githubusercontent.com/punk6529/a8d1b469f5572ce6fd3c419e5f4f3e9a/raw/lock-evidence-before.png)

**After (this PR)** — labels come from decoded results; the failed read counts as unlocked; the Lock/Unlock button appears with correct label/icon; the All-Collections note appears only for the genuinely globally locked use case:

![after](https://gist.githubusercontent.com/punk6529/a8d1b469f5572ce6fd3c419e5f4f3e9a/raw/lock-evidence-after.png)

| Surface | Before (envelope truthiness) | After (decoded result) |
| --- | --- | --- |
| Option label, decoded false | `#3 - Airdrops - LOCKED *` | `#3 - Airdrops - UNLOCKED` |
| Option label, decoded true (this collection) | `#2 - Minting / Allowlist - LOCKED *` | `#2 - Minting / Allowlist - LOCKED` |
| Option label, failed multicall entry | `#4 - Voting / Governance - LOCKED *` | `#4 - Voting / Governance - UNLOCKED` |
| Option label, locked globally | `#5 - Avatar Display - LOCKED *` | `#5 - Avatar Display - LOCKED *` (unchanged, now for the right reason) |
| Selected use case, not locked globally | note "Unlock use case in All Collections" (button unreachable) | `Lock Use Case` / `Unlock Use Case` button per decoded state |
| Toast while writing | always "Unlocking Wallet on Use Case ..." | "Locking"/"Unlocking" per decoded state |
| `setCollectionUsecaseLock` args | always `lock=false` once data loaded | `lock=true` when locking, `lock=false` when unlocking |

## Changes

- `components/delegation/CollectionDelegation.utils.ts`: `MulticallEnvelope` type + `readMulticallBoolean` helper (documented failure semantics).
- `components/delegation/collection-delegation/CollectionDelegationLocks.tsx`: the seven envelope sites now use the helper via two named locals (`selectedUseCaseLocked`, `selectedUseCaseLockedGlobally`) and a per-option `lockedGlobally`; the dead `as unknown as boolean` cast and its bug-preservation comment are gone.
- Tests: `readMulticallBoolean` unit tests (success true/false, failure, missing entries, non-boolean results) and a new `CollectionDelegationLocks.test.tsx` suite pinning option labels, asterisks, toast titles, write args, and the globally-locked note branch against envelope fixtures including failure statuses.

## Validation

- Full Jest suite green: 1,969 suites / 11,127 tests (10 new).
- `tsc --noEmit -p tsconfig.typecheck.json` clean; ESLint `--max-warnings=0` clean; Prettier applied.
- react-doctor on the PR diff: 100/100, no issues.
- Local delegation-readonly Playwright pack against the public API: 30/30 passed.
- Debt ratchet unchanged (`any_casts` 4, the removed double cast was not ratchet-visible).
- Before/after harness run documented above (the harness page itself is local-only and not part of the diff).

Not tested: an on-chain `setCollectionUsecaseLock` transaction (needs a funded wallet and changes chain state). The write-arg correction is pinned by unit tests asserting the exact `writeContract` args instead. Residual risk: the lock write path sees only mock traffic before a human verifies it on-chain — flagged in Review Notes.

## Risk

- Level: Medium-High (wallet write path semantics)
- Why: changes what the lock UI shows and, critically, the boolean submitted to `setCollectionUsecaseLock`. The old behavior could only ever unlock; the new behavior locks/unlocks per decoded on-chain state. Blast radius is confined to the Locks section of `/delegation/[collection]`.
- Rollback: single revert restores the (buggy but known) previous behavior; no data or schema impact.

## Review Notes

- Please scrutinize the lock=true/false write-arg change (`args: [collection, useCase, !selectedUseCaseLocked]`) — it is the one site where wrong logic writes chain state. The unit test "locks an unlocked use case ... lock=true args" pins it.
- A separate pre-existing bug is deliberately NOT fixed here: the special use cases (997/998/999) map to `lockUseCaseIndex` 16/17/18 while the multicall arrays put them at 17/18/19, so their post-selection button state/title read the wrong entry. Filed separately (see the issue linked in the PR conversation) to keep this diff single-concern.
- The `status === "success" && result === true` strictness means a temporarily failing multicall entry shows UNLOCKED rather than an error state. That matches the pre-existing UI vocabulary (there is no error state in this select) and fails toward the less alarming label; flagging in case product prefers an explicit unknown state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
