### PR TITLE
Retry swallowed Safari navigations in the Device Farm web smoke

### DIFF
--- a/tests/device-farm/lib/driver.cjs
+++ b/tests/device-farm/lib/driver.cjs
@@ -136,20 +136,30 @@ async function waitForDocumentReady(driver, timeout) {
  */
 async function openPage(driver, pageUrl, timeout) {
   const expectedPath = new URL(pageUrl).pathname.replace(/\/$/, "") || "/";
+  const onExpectedPath = async () => {
+    const pathname = await driver.execute(() =>
+      window.location.pathname.replace(/\/$/, "")
+    );
+    return (pathname || "/") === expectedPath;
+  };
+  // Safari on real devices occasionally swallows a navigation command
+  // outright (observed on Device Farm iPhones), so re-issue url() once if the
+  // pathname has not changed within half the budget.
   await driver.url(pageUrl);
-  await driver.waitUntil(
-    async () => {
-      const pathname = await driver.execute(() =>
-        window.location.pathname.replace(/\/$/, "")
-      );
-      return (pathname || "/") === expectedPath;
-    },
-    {
-      timeout,
+  try {
+    await driver.waitUntil(onExpectedPath, {
+      timeout: Math.floor(timeout / 2),
       interval: 2000,
-      timeoutMsg: `browser never navigated to ${expectedPath}`,
-    }
-  );
+    });
+  } catch {
+    console.warn(`navigation to ${expectedPath} did not start; retrying url()`);
+    await driver.url(pageUrl);
+    await driver.waitUntil(onExpectedPath, {
+      timeout: Math.floor(timeout / 2),
+      interval: 2000,
+      timeoutMsg: `browser never navigated to ${expectedPath} (after retry)`,
+    });
+  }
   await waitForDocumentReady(driver, timeout);
   await driver.waitUntil(
     async () =>

--- a/tests/device-farm/package.json
+++ b/tests/device-farm/package.json
@@ -5,8 +5,8 @@
   "description": "Appium smoke suites executed on AWS Device Farm real devices. Packaged via npm pack (bundleDependencies) and uploaded by .github/workflows/device-farm-qa.yml; not part of the pnpm workspace.",
   "scripts": {
     "test": "npm run test:web",
-    "test:web": "mocha specs/web.smoke.spec.cjs --timeout 900000 --reporter spec",
-    "test:native": "mocha specs/native-android.smoke.spec.cjs --timeout 900000 --reporter spec"
+    "test:web": "mocha specs/web.smoke.spec.cjs --timeout 900000 --retries 1 --reporter spec",
+    "test:native": "mocha specs/native-android.smoke.spec.cjs --timeout 900000 --retries 1 --reporter spec"
   },
   "dependencies": {
     "mocha": "^11.1.0",


### PR DESCRIPTION
Follow-up to #3105 from the third live run ([28750633242](https://github.com/6529-Collections/6529seize-frontend/actions/runs/28750633242)): Android Chrome passed again (2nd consecutive), and the Safari navigation-race fix brought iOS from 2/5 to 4/5 on a real iPhone 15. The one remaining failure was Safari silently swallowing a single `url()` navigation (`/network` never started within 90s).

- `openPage()` now re-issues the navigation once if `location.pathname` hasn't changed within half the budget.
- Both device suites run with `--retries 1` — they are read-only by design, so retries are side-effect free (matches the deploy-6529 flaky-signal policy of one evidenced rerun).

Test-code only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)