### PR TITLE
Catch generic-argument any in the debt ratchet; type the delegation stragglers

### DIFF
--- a/__tests__/scripts/debt-ratchet.test.ts
+++ b/__tests__/scripts/debt-ratchet.test.ts
@@ -4,13 +4,13 @@ import os from "node:os";
 import path from "node:path";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const { countImportStatements, countLines, countMatches } = require(
-  path.join(process.cwd(), "scripts", "debt-ratchet.cjs")
-) as {
-  countImportStatements: (content: string, packages: string[]) => number;
-  countLines: (content: string) => number;
-  countMatches: (content: string, pattern: RegExp) => number;
-};
+const { ANY_CASTS_PATTERN, countImportStatements, countLines, countMatches } =
+  require(path.join(process.cwd(), "scripts", "debt-ratchet.cjs")) as {
+    ANY_CASTS_PATTERN: RegExp;
+    countImportStatements: (content: string, packages: string[]) => number;
+    countLines: (content: string) => number;
+    countMatches: (content: string, pattern: RegExp) => number;
+  };
 
 const SCRIPT_PATH = path.join(process.cwd(), "scripts", "debt-ratchet.cjs");
 
@@ -26,14 +26,38 @@ describe("debt-ratchet counting helpers", () => {
       "const a: any = 1;",
       "const b = value as any;",
       "const c: any[] = [];",
-      "const inner: Record<string, any> = {}; // generic arg is not counted",
       "const many = anything; // not a match",
       "function f(x: number): number { return x; }",
     ].join("\n");
-    // ": any" direct annotations and "as any" casts count; an "any" buried in
-    // a generic argument list (Record<string, any>) does not carry a ": any"
-    // or "as any" token, so it is intentionally outside this metric.
-    expect(countMatches(content, /:\s*any\b|\bas\s+any\b/g)).toBe(3);
+    expect(countMatches(content, ANY_CASTS_PATTERN)).toBe(3);
+  });
+
+  it("counts any used as a generic type argument", () => {
+    const content = [
+      "const a = useState<any>();",
+      "const b = useState<any[]>([]);",
+      "const c: Record<string, any> = {};", // ": Record" is not ": any"
+      "const d = new Map<any, string>();",
+      "const e = new Map<string, any>();",
+      "const f = fetchJson<any>(url);",
+      "type G = Promise<any> | undefined;",
+      "type H = Wrapped< any >;", // whitespace inside the generic
+      "const both = new Map<any, any>();", // two arguments, two matches
+    ].join("\n");
+    expect(countMatches(content, ANY_CASTS_PATTERN)).toBe(10);
+  });
+
+  it("does not count prose or identifiers that merely contain any", () => {
+    const content = [
+      "// smaller than any of the configured values",
+      "// applies to, any websites hosted at sub-domains",
+      "// placeholder form: <any-string>",
+      "const cmp = a < anyLimit && b > anyFloor;",
+      "const word = many < anyone.count;",
+      'const text = "pick any, or all, of the options";',
+      "type Tuple = [unknown, string];",
+    ].join("\n");
+    expect(countMatches(content, ANY_CASTS_PATTERN)).toBe(0);
   });
 
   it("counts TODO markers without matching longer words", () => {

--- a/components/delegation/collection-delegation/CollectionDelegationSections.tsx
+++ b/components/delegation/collection-delegation/CollectionDelegationSections.tsx
@@ -52,12 +52,12 @@ export function CollectionDelegationSections(
   const { subDelegationOriginalDelegator } = props;
   const { outgoingDelegations, incomingDelegations } = reads;
 
-  const [delegationKeys, setDelegationKeys] = useState<any[]>([]);
+  const [delegationKeys, setDelegationKeys] = useState<string[]>([]);
   const [delegationKeysChanged, setDelegationKeysChanged] = useState(false);
-  const [subDelegationKeys, setSubDelegationKeys] = useState<any[]>([]);
+  const [subDelegationKeys, setSubDelegationKeys] = useState<string[]>([]);
   const [subDelegationKeysChanged, setSubDelegationKeysChanged] =
     useState(false);
-  const [consolidationKeys, setConsolidationKeys] = useState<any[]>([]);
+  const [consolidationKeys, setConsolidationKeys] = useState<string[]>([]);
   const [consolidationKeysChanged, setConsolidationKeysChanged] =
     useState(false);
 

--- a/components/delegation/collection-delegation/useDelegationRevocation.ts
+++ b/components/delegation/collection-delegation/useDelegationRevocation.ts
@@ -15,6 +15,25 @@ import {
 } from "./collection-delegation-helpers";
 
 /**
+ * A queued `revokeDelegationAddress` write; `loading` flips once the
+ * write has been handed to the wallet.
+ */
+export interface RevokeDelegationRequest {
+  readonly collection: string;
+  readonly address: string;
+  readonly use_case: number;
+  readonly loading?: boolean;
+}
+
+/** A queued `batchRevocations` write over parallel arrays. */
+export interface BatchRevokeDelegationRequest {
+  readonly collections: string[];
+  readonly addresses: string[];
+  readonly use_cases: number[];
+  readonly loading?: boolean;
+}
+
+/**
  * Revocation writes for the collection-delegation screen: single revocation,
  * batch revocation, and the bulk-selection state feeding the batch call.
  * Setting the corresponding params state triggers the contract write.
@@ -26,9 +45,11 @@ export function useDelegationRevocation(options: {
 
   const [bulkRevocations, setBulkRevocations] = useState<Revocation[]>([]);
 
-  const [revokeDelegationParams, setRevokeDelegationParams] = useState<any>();
+  const [revokeDelegationParams, setRevokeDelegationParams] = useState<
+    RevokeDelegationRequest | undefined
+  >();
   const [batchRevokeDelegationParams, setBatchRevokeDelegationParams] =
-    useState<any>();
+    useState<BatchRevokeDelegationRequest | undefined>();
 
   const contractWriteRevoke = useWriteContract();
 

--- a/ops/workstreams/repo-health-2026-07/any-exceptions.md
+++ b/ops/workstreams/repo-health-2026-07/any-exceptions.md
@@ -1,11 +1,14 @@
 # `any` exceptions ledger
 
-Sites that keep `: any` / `as any` deliberately, with one-line justifications.
-Everything not listed here is expected to stay at zero; the debt-ratchet
-baseline (`scripts/debt-ratchet-baseline.json`, metric `any_casts`) is the
+Sites that keep `: any` / `as any` / generic-argument `any` deliberately,
+with one-line justifications. Everything not listed here is expected to
+stay at zero; the debt-ratchet baseline
+(`scripts/debt-ratchet-baseline.json`, metric `any_casts`) is the
 enforcement backstop.
 
-Current floor: `any_casts` = 4 (3 permanent + 1 scan false positive).
+Current floor: `any_casts` = 27 (3 permanent + 1 scan false positive + 23
+generic-argument sites newly visible to the extended scanner; burn-down
+inventory below).
 
 ## Permanent exceptions
 
@@ -19,26 +22,54 @@ Current floor: `any_casts` = 4 (3 permanent + 1 scan false positive).
 | --- | --- | --- |
 | `app/blog/disney-deekay-their-secret-to-animation/page.tsx` | 1 | The ratchet's textual `\bas\s+any\b` matches the prose "…as powerfully as any great art can" inside JSX copy. No TypeScript cast exists in the file; editorial copy is not changed to satisfy a counter. |
 
+## Generic-argument burn-down inventory (fixable, not exceptions)
+
+Made visible by the 2026-07 scanner extension (the `any_casts` regex now
+also matches generic type arguments such as `useState<any>()` and
+`Record<string, any>`). These 23 sites predate the extension; the ratchet
+stops new ones, and these should be typed by whichever thread next owns
+each area:
+
+| Area | Count | Shape |
+| --- | --- | --- |
+| `app/api/pepe/resolve/route.ts` | 6 | `fetchJson<any>` / `tokenscanJson<any>` responses |
+| `components/drops/view/item/rate/give/clap/DropListItemRateGiveClap.tsx` | 5 | `useState<any>` mo-js animation handles |
+| `components/waves/drop/SingleWaveDropTraits.tsx` | 4 | `Record<keyof TraitsData, any>` write casts |
+| `components/allowlist-tool/allowlist-tool.types.ts` | 1 | `params: Record<string, any>` |
+| `components/drops/view/item/content/media/MediaDisplayGLB.tsx` | 1 | `useRef<any>` model ref |
+| `components/nextGen/admin/NextGenAdminUploadAL.tsx` | 1 | `useState<any>` allowlist file |
+| `components/nextGen/collections/collectionParts/hooks/useSlideshowAutoplay.ts` | 1 | `useState<any>` swiper instance |
+| `components/react-query-wrapper/ReactQueryWrapper.tsx` | 1 | `Record<string, any>` in a values type |
+| `components/rememes/alchemy-sdk-types.ts` | 1 | `metadata: Record<string, any>` |
+| `components/user/identity/statements/consolidated-addresses/UserPageIdentityStatementsConsolidatedAddressesItem.tsx` | 1 | `useState<any>` status message |
+| `components/waves/memes/traits/schema.ts` | 1 | `Record<string, any>` initial values |
+
 ## Resolved deferrals (history)
 
 - `components/delegation/**` (60 sites): typed directly by the Thread G
   any-tail wave (2026-07-05, three PRs: write-config path, form-component
   clones, read path) once Thread C's styling verification showed no
-  delegation rewrite was coming. One behavior-preserving double cast
-  (`as unknown as boolean`, counts as zero `any`) remains in
-  `CollectionDelegation.tsx` over the multicall envelope comparison whose
-  underlying `.result` misread is tracked in issue #3078.
+  delegation rewrite was coming. The behavior-preserving
+  `as unknown as boolean` double cast over the multicall envelope
+  comparison was removed by the issue #3078 fix once the envelope read
+  became honest.
+- `components/delegation/**` generic arguments (5 sites:
+  `revokeDelegationParams`, `batchRevokeDelegationParams`, three
+  disclosure-key `useState<any[]>` arrays): typed by the
+  CollectionDelegation split thread in the same PR that extended the
+  scanner (2026-07-05); the delegation area now counts zero.
 - `src/types/window.d.ts`: removed with the layout workstream's `src/`
   fold (resolved 2026-07-05).
 
-## Known scanner blind spot (for future calibration)
+## Scanner coverage notes (for future calibration)
 
-The ratchet regex counts `: any` and `as any` only; generic type arguments
-like `useState<any>()` are invisible to it. A handful of such generics
-remain in `components/delegation/CollectionDelegation.tsx`
-(`revokeDelegationParams`, `batchRevokeDelegationParams`, three
-`useState<any[]>` key arrays). They are outside the metric and were left
-untouched by the typing wave; tighten them opportunistically when that
-file is next split (Thread D owns the split).
+The 2026-07 extension added generic-argument detection: `any` delimited by
+`<` or `,` before and `,`/`>`/`[`/`)`/`|`/`&` after. Remaining known blind
+spot, kept deliberately until a real instance appears: `any` as a tuple
+member (`[any, string]`) — tuple brackets are also markdown-link and
+comparison syntax, so matching them textually would trade a currently
+non-existent miss for real false positives. Pattern and rationale live in
+`scripts/debt-ratchet.cjs` (`ANY_CASTS_PATTERN`), pinned by
+`__tests__/scripts/debt-ratchet.test.ts`.
 
 Counts and per-file locations: `node scripts/debt-ratchet.cjs --details any_casts`.

--- a/ops/workstreams/repo-health-2026-07/run-log.md
+++ b/ops/workstreams/repo-health-2026-07/run-log.md
@@ -1,5 +1,49 @@
 # Run Log
 
+## 2026-07-05 (Thread H — CollectionDelegation split + #3078 + generic-any scanner)
+
+- Three-PR stacked series, all requiring human review by prxt (live wallet
+  UI; no agent merges): #3106 -> #3107 -> the scanner PR carrying this
+  entry.
+- PR #3106 (split): CollectionDelegation.tsx (2,033 lines) decomposed
+  behavior-preserving into 10 single-concern modules under
+  `components/delegation/collection-delegation/` + a 387-line composition
+  shell at the old path (public interface unchanged). Wagmi hook call
+  order preserved exactly — existing suites mock wagmi by call sequence.
+  The #3078 envelope bug and the `useState<any>` sites moved byte-for-byte
+  by design. `oversized_files` 89 -> 88. Validation: full Jest
+  1,968/11,117, delegation-readonly e2e 30/30 (desktop+mobile), browser
+  walk of 7 /delegation routes + interactive wallet-checker lookup
+  (punk6529.eth) — 200/0 overflow/0 errors everywhere, react-doctor
+  98/100.
+- PR #3107 (fix #3078): use-case lock UI read multicall envelopes as
+  booleans; now reads `.result` honoring `status` via new
+  `readMulticallBoolean` (failure/missing = unlocked, never locked).
+  Beyond the issue's four sites, the write arg was also envelope-derived:
+  `setCollectionUsecaseLock` always submitted lock=false once statuses
+  loaded (the UI could never lock). Before/after screenshots from a
+  local-only fixture harness are embedded in the PR; unit + component
+  suites pin labels, asterisks, toast titles, and exact write args
+  (incl. failure envelopes). react-doctor 100/100 on the diff.
+- Bug found while fixing, filed NOT fixed (different class, same flow):
+  #3108 — special use cases 997/998/999 map to lockUseCaseIndex 16/17/18
+  but the multicall arrays put them at 17/18/19, so their post-selection
+  button state/write args/toast read the wrong entry ("#undefined -
+  undefined" titles for 998/999). Masked until #3107 lands.
+- PR 3 (this entry): ratchet `any_casts` regex extended to catch
+  generic-argument `any` (`useState<any>`, `Record<string, any>`; pattern
+  exported as ANY_CASTS_PATTERN, jest-pinned incl. prose non-matches).
+  The five delegation `useState<any>` stragglers typed
+  (RevokeDelegationRequest/BatchRevokeDelegationRequest + string[] keys);
+  delegation area now counts zero. Baseline 4 -> 27: the 23 newly visible
+  pre-existing sites across 11 non-delegation files are inventoried in
+  any-exceptions.md as owned burn-down backlog, not exceptions.
+- Environment notes for other threads: fresh-worktree `run dev`/e2e needs
+  `./bin/6529 run build:env-schema` once (next.config.compiled.js
+  requires the generated env schema; the predev hop does not cover the
+  Playwright webServer path). `gh` cannot attach images to PRs — push
+  PNGs to a gist via git and embed the raw URLs.
+
 ## 2026-07-05 (Thread F — collection surfaces quality pass)
 
 - Phase 1 (overflow): root cause pinned with production evidence — the

--- a/scripts/debt-ratchet-baseline.json
+++ b/scripts/debt-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "max_source_file_lines": 800,
   "counts": {
-    "any_casts": 4,
+    "any_casts": 27,
     "todo_comments": 0,
     "oversized_files": 88,
     "bootstrap_imports": 0,

--- a/scripts/debt-ratchet.cjs
+++ b/scripts/debt-ratchet.cjs
@@ -83,10 +83,20 @@ const CODE_EXTENSIONS = new Set([
 const TYPESCRIPT_EXTENSIONS = new Set([".ts", ".tsx", ".cts", ".mts"]);
 const STYLE_EXTENSIONS = new Set([".css", ".scss"]);
 
+// Matches explicit `: any` annotations, `as any` casts, and `any` used as a
+// generic type argument (`useState<any>`, `Record<string, any>`, `<any[]>`,
+// `Map<any, T>`). The generic-argument alternation requires a `<` or `,`
+// before `any` and a `,`/`>`/`[`/`)`/`|`/`&` after it, so prose such as
+// "as powerful as any art", ", any websites", or placeholder text like
+// `<any-string>` never matches. Known blind spot kept deliberately: `any`
+// as a tuple member (`[any, string]`) has no such delimiters; extend the
+// pattern when a real one appears.
+const ANY_CASTS_PATTERN = /:\s*any\b|\bas\s+any\b|[<,]\s*any\b(?=\s*[,>[)|&])/g;
+
 const METRIC_DEFINITIONS = {
   any_casts: {
     description:
-      "`: any` and `as any` occurrences in TypeScript source (tests excluded)",
+      "`: any`, `as any`, and generic-argument `any` occurrences in TypeScript source (tests excluded)",
     hint: "Replace `any` with a real type or `unknown` plus narrowing.",
   },
   todo_comments: {
@@ -224,7 +234,7 @@ function computeActuals() {
     if (!isCode) continue;
 
     if (TYPESCRIPT_EXTENSIONS.has(extension)) {
-      const anyCount = countMatches(content, /:\s*any\b|\bas\s+any\b/g);
+      const anyCount = countMatches(content, ANY_CASTS_PATTERN);
       if (anyCount > 0) perFile.any_casts.set(relativePath, anyCount);
     }
 
@@ -465,6 +475,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  ANY_CASTS_PATTERN,
   MAX_SOURCE_FILE_LINES,
   SCAN_DIRS,
   countImportStatements,


### PR DESCRIPTION
## Issue

Repo-health campaign, dead-patterns tail: the debt ratchet's `any_casts` regex counted only `: any` and `as any`, so generic type arguments (`useState<any>()`, `Record<string, any>`, `<any[]>`) were invisible — the blind spot recorded in `ops/workstreams/repo-health-2026-07/any-exceptions.md` after the Thread G typing wave. Five such sites lived in the delegation modules split by #3106.

Third PR of the CollectionDelegation series (#3106 split -> #3107 envelope fix -> this). Base is `fix/delegation-lock-envelopes`; it retargets as the stack merges.

## Fix

1. **Scanner**: `ANY_CASTS_PATTERN` in `scripts/debt-ratchet.cjs` now also matches `any` as a generic type argument — delimited by `<` or `,` before and `,` `>` `[` `)` `|` `&` after. The delimiter requirements were calibrated against the repo so prose ("as powerful as any art", ", any websites"), placeholders (`<any-string>`), and identifiers (`anyLimit`) never match. The pattern is exported and pinned by new jest cases: a 10-match generic fixture (incl. `Map<any, any>` counting twice and whitespace inside the generic) and a 0-match prose/identifier fixture. Documented remaining blind spot: tuple-member `any` (`[any, string]`) — no current instances, and matching brackets textually would trade a non-existent miss for real false positives (markdown links in comments, comparisons).
2. **Delegation stragglers**: the five `useState<any>` sites the split carried verbatim are typed — `RevokeDelegationRequest` / `BatchRevokeDelegationRequest` for the queued revocation writes in `useDelegationRevocation.ts` (the `loading` flip is part of the shape), and `string[]` for the three disclosure-key arrays in `CollectionDelegationSections.tsx`. The delegation area now counts zero.
3. **Baseline** refreshed in the same change: `any_casts` 4 -> 27. The 23 newly visible sites are pre-existing generic-argument usages across 11 non-delegation files (pepe resolve route, clap animation handles, wave traits casts, and 8 single-site files). They are inventoried per-file in the exceptions ledger as owned burn-down backlog — deliberately NOT typed here (each sits in an area this series has not studied; typing them blind in a stack that must stay reviewable would be scope creep). The ratchet blocks new ones from now on.
4. The thread's run-log entry for the whole series rides along.

## Validation

- New + existing debt-ratchet jest suite green (the old "generic arg is not counted" assertion now asserts the opposite, via the exported pattern rather than a duplicated literal).
- `node scripts/debt-ratchet.cjs` passes against the refreshed baseline; `--details any_casts` shows zero delegation entries.
- `tsc --noEmit -p tsconfig.typecheck.json` clean; ESLint `--max-warnings=0` clean; focused delegation + ratchet suites 19/89 green; full Jest green on the stack (1,969 suites / 11,127 tests).

## Risk

- Level: Low
- Why: scanner + typing-only changes; no runtime behavior change (the revocation-params typing is structural on state that already carried exactly these shapes). The baseline rise is definitional (same debt, better instrument), not a regression.
- Rollback: revert; baseline and ledger revert with it.

## Review Notes

- The regex is the load-bearing piece: see the fixture tests for exactly what it does and does not match. If you know a legitimate `any`-adjacent pattern in this repo it would false-positive on, that is the review comment I want.
- `any_casts` 4 -> 27 in the baseline is intentional and documented in the ledger; the alternative (fixing 23 sites across 11 unfamiliar files in this PR) was rejected as unreviewable scope creep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
