### PR TITLE
Make Device Farm pools a deliberate representative device mix

### DIFF
--- a/ops/docs/developer/device-farm-qa.md
+++ b/ops/docs/developer/device-farm-qa.md
@@ -71,11 +71,27 @@ stable; unmetered slots ($250/device/month) only pay off past ~25 runs/week.
    bash ops/scripts/devicefarm-bootstrap.sh
    ```
 
-   Defaults: project `6529-mobile-qa`, pools `android-phones-smoke` (max 2,
-   Android 13+ highly-available public phones) and `ios-phones-web-smoke`
-   (max 1, iOS 16+). Override names via env vars and mirror them in repository
-   variables `DEVICEFARM_PROJECT_NAME`, `DEVICEFARM_ANDROID_POOL_NAME`,
+   Defaults: project `6529-mobile-qa`, pools `android-phones-smoke` (max 3)
+   and `ios-phones-web-smoke` (max 2). The script is idempotent and
+   *converging*: re-running it updates existing pools to the rules in the
+   script, so pool composition is version-controlled here. Override names via
+   env vars and mirror them in repository variables
+   `DEVICEFARM_PROJECT_NAME`, `DEVICEFARM_ANDROID_POOL_NAME`,
    `DEVICEFARM_IOS_POOL_NAME` (the workflow resolves resources by name).
+
+   Pool composition is a deliberate representative mix, not "any available
+   phone" (an open rule tends to hand out two near-identical Pixels):
+
+   | Pool | Devices | Why |
+   | --- | --- | --- |
+   | `android-phones-smoke` | Samsung Galaxy S24, Google Pixel 8, Samsung Galaxy A15 | One UI flagship (dominant real-world OEM skin), stock Android, and the mid-range/low-perf class that is the most common Android tier globally. |
+   | `ios-phones-web-smoke` | iPhone 16, iPhone SE (2022) | Current mainstream iOS, plus the 4.7" small screen on the oldest supported Safari — the viewport that makes the horizontal-overflow check earn its keep. |
+
+   Model rules pick whichever of the named devices are highly available at
+   scheduling time (a busy model just shrinks that run's coverage). Recheck
+   the model list against the fleet (`aws devicefarm list-devices`) roughly
+   yearly, and calibrate against real visitor device analytics (CloudWatch
+   RUM / Mixpanel user agents) when adjusting.
 
 2. **CI IAM principal** — create a dedicated IAM user (or role) for the
    workflow with this policy (Device Farm resources exist only in us-west-2):

--- a/ops/scripts/devicefarm-bootstrap.sh
+++ b/ops/scripts/devicefarm-bootstrap.sh
@@ -37,7 +37,8 @@ echo "  project ARN: ${project_arn}"
 ensure_pool() {
   local name="$1"
   local max_devices="$2"
-  local rules="$3"
+  local description="$3"
+  local rules="$4"
   local arn
 
   arn="$(aws devicefarm list-device-pools --region "$REGION" \
@@ -48,36 +49,50 @@ ensure_pool() {
     arn="$(aws devicefarm create-device-pool --region "$REGION" \
       --project-arn "$project_arn" \
       --name "$name" \
-      --description "Managed by ops/scripts/devicefarm-bootstrap.sh" \
+      --description "$description" \
       --max-devices "$max_devices" \
       --rules "$rules" \
       --query 'devicePool.arn' --output text)"
   else
-    echo "Device pool already exists: ${name}"
+    echo "Updating device pool: ${name} (max ${max_devices} devices)"
+    aws devicefarm update-device-pool --region "$REGION" \
+      --arn "$arn" \
+      --description "$description" \
+      --max-devices "$max_devices" \
+      --rules "$rules" \
+      --query 'devicePool.arn' --output text > /dev/null
   fi
   echo "  pool ARN: ${arn}"
 }
 
-# Highly-available public Android phones on OS 13+ (native + web packs).
+# Representative Android mix rather than "any available phone": a Samsung
+# One UI flagship (the dominant real-world OEM skin), a stock-Android Pixel,
+# and a mid-range A-series (the most common device class globally, lower
+# perf tier). Whichever of the three are highly available get picked, up to
+# the pool max. Model names must match the Device Farm public fleet exactly
+# (`aws devicefarm list-devices`).
 ANDROID_RULES='[
-  {"attribute":"PLATFORM","operator":"EQUALS","value":"\"ANDROID\""},
-  {"attribute":"FORM_FACTOR","operator":"EQUALS","value":"\"PHONE\""},
-  {"attribute":"OS_VERSION","operator":"GREATER_THAN_OR_EQUALS","value":"\"13\""},
+  {"attribute":"MODEL","operator":"IN","value":"[\"Samsung Galaxy S24\",\"Google Pixel 8\",\"Samsung Galaxy A15\"]"},
   {"attribute":"AVAILABILITY","operator":"EQUALS","value":"\"HIGHLY_AVAILABLE\""},
   {"attribute":"FLEET_TYPE","operator":"EQUALS","value":"\"PUBLIC\""}
 ]'
 
-# Highly-available public iPhones on iOS 16+ (mobile web Safari pack).
+# Representative iOS mix: the current mainstream iPhone plus the small-screen
+# SE on the oldest supported Safari — the 4.7" viewport is what makes the
+# horizontal-overflow check meaningful.
 IOS_RULES='[
-  {"attribute":"PLATFORM","operator":"EQUALS","value":"\"IOS\""},
-  {"attribute":"FORM_FACTOR","operator":"EQUALS","value":"\"PHONE\""},
+  {"attribute":"MODEL","operator":"IN","value":"[\"Apple iPhone 16\",\"Apple iPhone SE (2022)\"]"},
   {"attribute":"OS_VERSION","operator":"GREATER_THAN_OR_EQUALS","value":"\"16\""},
   {"attribute":"AVAILABILITY","operator":"EQUALS","value":"\"HIGHLY_AVAILABLE\""},
   {"attribute":"FLEET_TYPE","operator":"EQUALS","value":"\"PUBLIC\""}
 ]'
 
-ensure_pool "$ANDROID_POOL_NAME" 2 "$ANDROID_RULES"
-ensure_pool "$IOS_POOL_NAME" 1 "$IOS_RULES"
+ensure_pool "$ANDROID_POOL_NAME" 3 \
+  "Representative Android mix: One UI flagship + stock Pixel + mid-range A-series" \
+  "$ANDROID_RULES"
+ensure_pool "$IOS_POOL_NAME" 2 \
+  "Representative iOS mix: current mainstream + small-screen/oldest-Safari SE" \
+  "$IOS_RULES"
 
 cat <<SUMMARY
 


### PR DESCRIPTION
The bootstrap pools used open availability rules ("any highly-available Android 13+ phone"), which in practice selected two near-identical Pixels — no Samsung/One UI coverage (the dominant real-world Android), no mid-range tier, no small-screen iPhone.

Pools are now curated model mixes (live pools already updated to match):

| Pool | Devices | Why |
| --- | --- | --- |
| `android-phones-smoke` (max 3) | Samsung Galaxy S24, Google Pixel 8, Samsung Galaxy A15 | One UI flagship / stock Android / mid-range class |
| `ios-phones-web-smoke` (max 2) | iPhone 16, iPhone SE (2022) | current mainstream / 4.7" small screen on oldest supported Safari |

`ensure_pool()` now **converges** existing pools via `update-device-pool` instead of skipping them, so pool composition is version-controlled in the script. Docs record the rationale, fleet-recheck cadence, and a note to calibrate against real visitor device analytics (RUM/Mixpanel).

Cost impact: +2 devices per weekly run ≈ +$2–4/week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)