### PR TITLE
Persist the fine-pointer latch so lying browsers boot into desktop mode

### DIFF
--- a/__tests__/helpers/touch-first-pointer-latch.test.ts
+++ b/__tests__/helpers/touch-first-pointer-latch.test.ts
@@ -70,6 +70,36 @@ describe("behavioral fine-pointer latch", () => {
   afterEach(() => {
     defineMaxTouchPoints(0);
     document.body.removeAttribute("data-fine-pointer");
+    localStorage.removeItem("6529-fine-pointer");
+  });
+
+  it("hydrates the latch from a previous session at module load", () => {
+    localStorage.setItem("6529-fine-pointer", "1");
+
+    const { helpers, restore } = loadHelpersWithSentinel();
+
+    // Desktop from the very first read — no events required, no flicker.
+    expect(helpers.hasFinePointerCapability()).toBe(true);
+    expect(helpers.hasHoverCapability()).toBe(true);
+    expect(helpers.isTouchFirstEnvironment()).toBe(false);
+    expect(document.body.getAttribute("data-fine-pointer")).toBe("true");
+
+    restore();
+  });
+
+  it("persists the latch for future sessions", () => {
+    const { helpers, getSentinel, restore } = loadHelpersWithSentinel();
+    const unsubscribe = helpers.subscribeToTouchFirstChanges(jest.fn());
+    const sentinel = getSentinel();
+
+    sentinel!({ isTrusted: true, pointerType: "mouse" });
+    sentinel!({ isTrusted: true, pointerType: "mouse" });
+    sentinel!({ isTrusted: true, pointerType: "mouse" });
+
+    expect(localStorage.getItem("6529-fine-pointer")).toBe("1");
+
+    unsubscribe();
+    restore();
   });
 
   it("flips to desktop after a stream of trusted mouse moves", () => {

--- a/__tests__/helpers/touch-first-pointer-latch.test.ts
+++ b/__tests__/helpers/touch-first-pointer-latch.test.ts
@@ -88,6 +88,27 @@ describe("behavioral fine-pointer latch", () => {
     restore();
   });
 
+  it("ignores a stored latch on mobile user agents (synced/inherited flags)", () => {
+    localStorage.setItem("6529-fine-pointer", "1");
+    Object.defineProperty(globalThis.navigator, "userAgentData", {
+      configurable: true,
+      value: { mobile: true },
+    });
+
+    try {
+      const { helpers, restore } = loadHelpersWithSentinel();
+
+      expect(helpers.isTouchFirstEnvironment()).toBe(true);
+      expect(helpers.hasFinePointerCapability()).toBe(false);
+      expect(helpers.hasHoverCapability()).toBe(false);
+      expect(document.body.hasAttribute("data-fine-pointer")).toBe(false);
+
+      restore();
+    } finally {
+      Reflect.deleteProperty(globalThis.navigator, "userAgentData");
+    }
+  });
+
   it("persists the latch for future sessions", () => {
     const { helpers, getSentinel, restore } = loadHelpersWithSentinel();
     const unsubscribe = helpers.subscribeToTouchFirstChanges(jest.fn());

--- a/helpers/touch-first.helpers.ts
+++ b/helpers/touch-first.helpers.ts
@@ -138,15 +138,6 @@ const persistFinePointer = () => {
   }
 };
 
-// Hydrate the latch from a previous session at module load so the very first
-// client render is already in desktop mode on machines with mouse history.
-// Only guarded evidence is ever persisted (see the guards below), so a
-// stored flag always represents a genuine cursor glide.
-if (readPersistedFinePointer()) {
-  finePointerObserved = true;
-  tagBodyWithFinePointer();
-}
-
 const discountTouchDerivedEvidence = () => {
   lastTrustedTouchAt = Date.now();
   trustedMouseEvidenceCount = 0;
@@ -275,6 +266,17 @@ const isMobileUserAgent = (): boolean => {
   }
   return MOBILE_USER_AGENT_REGEX.test(nav.userAgent);
 };
+
+// Hydrate the latch from a previous session at module load so the very first
+// client render is already in desktop mode on machines with mouse history.
+// The write path only ever stores guarded evidence, but a stored flag can
+// travel (profile import/sync, older builds, tampering) — so hydration also
+// defers to the phone override: a mobile UA never boots into desktop mode
+// from storage.
+if (!isMobileUserAgent() && readPersistedFinePointer()) {
+  finePointerObserved = true;
+  tagBodyWithFinePointer();
+}
 
 /**
  * True only for devices whose primary interaction is touch (phones/tablets).

--- a/helpers/touch-first.helpers.ts
+++ b/helpers/touch-first.helpers.ts
@@ -64,6 +64,12 @@ const someQueryMatches = (queries: readonly string[]): boolean =>
 // variant selectors.
 const FINE_POINTER_BODY_ATTRIBUTE = "data-fine-pointer";
 
+// Once a machine has proven it has a mouse, remember it: without persistence
+// every page load on a capability-lying browser starts in touch mode and
+// visibly flips to desktop on the first cursor glide (mobile buttons flash
+// and disappear, and clicks land in a dead transitional window).
+const FINE_POINTER_STORAGE_KEY = "6529-fine-pointer";
+
 // A single event is not proof: some tools emit stray synthetic mouse events
 // on genuine touch devices, and jsdom/test events must never latch. Require
 // a short stream of TRUSTED mouse moves — a real cursor glide.
@@ -81,6 +87,41 @@ const notifyCapabilityChange = () => {
   }
 };
 
+const tagBodyWithFinePointer = () => {
+  (
+    globalThis as typeof globalThis & { document?: Document }
+  ).document?.body?.setAttribute(FINE_POINTER_BODY_ATTRIBUTE, "true");
+};
+
+const readPersistedFinePointer = (): boolean => {
+  try {
+    return (
+      (
+        globalThis as typeof globalThis & { localStorage?: Storage }
+      ).localStorage?.getItem(FINE_POINTER_STORAGE_KEY) === "1"
+    );
+  } catch {
+    return false;
+  }
+};
+
+const persistFinePointer = () => {
+  try {
+    (
+      globalThis as typeof globalThis & { localStorage?: Storage }
+    ).localStorage?.setItem(FINE_POINTER_STORAGE_KEY, "1");
+  } catch {
+    // Storage may be unavailable (private mode, blocked) — session-only latch.
+  }
+};
+
+// Hydrate the latch from a previous session at module load so the very first
+// client render is already in desktop mode on machines with mouse history.
+if (readPersistedFinePointer()) {
+  finePointerObserved = true;
+  tagBodyWithFinePointer();
+}
+
 const handleSentinelPointerEvent = (event: Event) => {
   if (!event.isTrusted || (event as PointerEvent).pointerType !== "mouse") {
     return;
@@ -93,9 +134,8 @@ const handleSentinelPointerEvent = (event: Event) => {
 
   uninstallPointerSentinel();
   finePointerObserved = true;
-  (
-    globalThis as typeof globalThis & { document?: Document }
-  ).document?.body?.setAttribute(FINE_POINTER_BODY_ATTRIBUTE, "true");
+  tagBodyWithFinePointer();
+  persistFinePointer();
   notifyCapabilityChange();
 };
 


### PR DESCRIPTION
## Issue
- Reported by @punk6529 on production after 4.71.x: the mobile drop-actions (⋮) button appears on wave load and then disappears, and there is a window where clicking a post does nothing ('no way to reply by clicking a post').
- Root cause: on capability-lying browsers (his Brave reports `any-pointer: fine=false, any-hover=false` while a trackpad is in use), every page load starts in touch mode; the behavioral latch (PR #3099) then flips the UI to desktop on the first cursor glide. The flip is the flicker, and clicks during the transition land in the dead zone. Reproduced exactly on the composer sandbox with a `hasTouch` context: pre-mouse `Open drop actions` buttons: 2 → post-latch: 0; post-latch hover shows Reply/More actions correctly.

## Fix
- Persist mouse evidence in `localStorage` (`6529-fine-pointer`). The helper hydrates the latch at module load — before the first client render — so machines with mouse history boot directly into desktop mode: no touch-mode first paint, no flip, no dead window.
- First-ever visit on a lying browser still transitions once (nothing can prevent that without truthful capability reporting); storage-blocked contexts degrade to the previous session-only latch.
- Genuine touch devices are untouched: they never latch, so nothing is ever stored.

## Validation
- 22 tests green across the touch-first helper suites, including new cases: hydration from a stored flag at module load (desktop from first read, body attribute set, zero events) and persistence after the trusted-mouse-stream latch.
- Sandbox reproduction of the user's symptoms on current main documented above; the fix removes the transitional state for all loads after the first.

## Risk
- Level: Low
- Why: additive persistence for an existing latch; single storage key; failure modes degrade to current behavior.
- Rollback: revert the commit (users' stored flags become inert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)