### PR TITLE
Anchor .claude gitignore entry so knip is trustworthy in nested agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,11 @@ eslint-rule-summary.csv
 .cursor
 .cursorignore
 CLAUDE.md
-.claude
+# Anchored on purpose: an unanchored `.claude` becomes a `**/.claude/**` ignore
+# inside knip, which silently drops every entry file knip resolves to an
+# absolute path when the checkout itself lives under .claude/worktrees/<wt>
+# (agent worktrees) — producing ~23 false unused-file/export findings.
+/.claude/
 .codex
 .gemini
 .windsurfrules

--- a/ops/workstreams/repo-health-2026-07/run-log.md
+++ b/ops/workstreams/repo-health-2026-07/run-log.md
@@ -79,7 +79,7 @@
       lost their plugin-entry "ignore exports" exemption, so
       `includeEntryExports: true` surfaced their 16 `module.exports`
       members as UNUSED EXPORT. Fix: anchor the line to `/.claude/`
-      (with an explanatory comment) — knip then derives `.claude/**`,
+      (PR #3121, with an explanatory comment) — knip then derives `.claude/**`,
       which matches neither absolute paths nor anything outside a
       top-level `.claude/`. Verified clean (exit 0, zero findings) in
       both the nested worktree and the short-path control at the same

--- a/ops/workstreams/repo-health-2026-07/run-log.md
+++ b/ops/workstreams/repo-health-2026-07/run-log.md
@@ -60,6 +60,37 @@
     `.claude/worktrees/`; identical content knips clean from a
     short-path worktree or the main checkout — treat knip failures under
     `.claude/worktrees/` as suspect before chasing them.
+    - SOLVED 2026-07-05 (root cause via `knip --debug` A/B at e70de6a90,
+      nested worktree vs `D:\wt-knipctl` short-path control, identical
+      junctioned node_modules). Mechanism: the root `.gitignore` had an
+      unanchored `.claude` line; knip converts every root-gitignore rule
+      into picomatch ignores (`.claude` → `**/.claude` + `**/.claude/**`)
+      and hands them to fast-glob with `absolute: true`. Entries that
+      plugins resolve to absolute-path patterns — everything referenced
+      as `node <file>` from package.json scripts and from
+      `.github/workflows/*.yml` (github-actions plugin), plus
+      workflow-launched Playwright specs — are then matched against
+      their full absolute path, and under
+      `.claude/worktrees/<wt>` every one of them contains a `.claude`
+      segment, so fast-glob drops them. 28 files fell out of the graph
+      (3954 → 3926 analyzed): the 7 unreferenced-elsewhere scripts
+      became UNUSED FILE, 21 `tests/**` drops were masked by
+      `ignoreFiles`, and coverage-floor/debt-ratchet/dependency-risk-gate
+      lost their plugin-entry "ignore exports" exemption, so
+      `includeEntryExports: true` surfaced their 16 `module.exports`
+      members as UNUSED EXPORT. Fix: anchor the line to `/.claude/`
+      (with an explanatory comment) — knip then derives `.claude/**`,
+      which matches neither absolute paths nor anything outside a
+      top-level `.claude/`. Verified clean (exit 0, zero findings) in
+      both the nested worktree and the short-path control at the same
+      commit; `git check-ignore` confirms `.claude/` at the repo root is
+      still ignored. Caveats: checkouts of commits predating the fix
+      still show the false findings, and the same class of bug fires for
+      any unanchored root-gitignore token that equals a path segment of
+      the checkout's own location (e.g. a worktree under a dir named
+      `logs` or `tasks`). Side-finding, not fixed: knip's `getGitDir()`
+      does `join(cwd, <absolute gitdir>)`, so `.git/info/exclude` is
+      never honored in linked worktrees (harmless for us).
   - Nested bare-`pnpm` hops (`check:changed`, `predev`) execute in
     whichever checkout's `bin/` is on PATH (`bin/pnpm.cmd` does
     `cd /d "%~dp0.."`), so from a secondary worktree they silently run


### PR DESCRIPTION
## Problem

Running `knip` (directly or via `quality.js`) from a git worktree nested under `.claude/worktrees/<wt>` produced **23 false findings** that do not appear when the identical commit runs from a short-path worktree (`D:\wt-*`) or the primary checkout:

- **7 false UNUSED FILE**: `ops/scripts/cli-args.cjs`, `deployment-bus.cjs`, `native-surface-evidence.cjs`, `publish-delegation-docs-content.mjs`, `testing-strategy.cjs`, `verify-deployment-version.cjs`, `standalone/standalone-memes-mint/scripts/export-mint-page.cjs`
- **16 false UNUSED EXPORT** rows across `scripts/dependency-risk-gate.cjs` (9), `scripts/debt-ratchet.cjs` (5), `scripts/coverage-floor.cjs` (2)

Both environments used a junctioned `node_modules`, so the junction was ruled out; the nested path was the variable. This poisoned knip results for every repo-health campaign agent working in `.claude/worktrees`.

## Root cause (found via `knip --debug` A/B at e70de6a90)

1. The root `.gitignore` had an **unanchored `.claude` line**. knip converts root-gitignore rules into picomatch ignores: `.claude` → `**/.claude` + `**/.claude/**`.
2. knip resolves entries discovered from package.json scripts and `.github/workflows/*.yml` (`node <file>` references, workflow-launched Playwright specs) to **absolute paths**, and passes them as fast-glob patterns together with those ignores and `absolute: true`.
3. fast-glob matches the ignores against the **full absolute path** of such entries. Under `.claude/worktrees/<wt>` every absolute path contains a `.claude` segment, so **all 28 plugin-resolved entries were silently dropped** (analyzed files: 3954 → 3926; the same glob call kept its relative-pattern entries, which is why the damage was selective).
4. Cascade: the 7 scripts have no other references → UNUSED FILE. The 21 dropped `tests/**` specs are masked by `ignoreFiles`. The three gate scripts stay in the project via the `scripts/**` config entry but lose their **plugin-entry "ignore exports" exemption**, so `includeEntryExports: true` reports their 16 `module.exports` members.

Short-path worktrees have no `.claude` path segment, hence clean results — the classic "works from over here" trap.

## Fix

Anchor the line to `/.claude/` (with a comment in `.gitignore` warning against reverting). knip then derives `.claude` + `.claude/**`, which match neither absolute paths nor anything outside a top-level `.claude/` directory. git semantics are preserved where it matters: `git check-ignore` confirms `.claude/` at the repo root (worktrees dir, local agent settings) is still ignored; the only behavior change is that a `.claude` directory nested in a subfolder would no longer be ignored (none exist).

Also extends the `ops/workstreams/repo-health-2026-07/run-log.md` knip note with the root cause, and records the remaining class risk: any unanchored root-gitignore token that equals a path segment of the checkout location (e.g. `logs`, `tasks/`) can reproduce this.

## Verification

- Nested worktree (`.claude/worktrees/hopeful-lewin-c6dee7`, e70de6a90): before — exit 1, 7 unused files + 16 export rows; after — **exit 0, zero findings**.
- Short-path control (`D:\wt-knipctl`, same commit, same junction, same edit): **exit 0, zero findings** before and after (no regression).
- `git check-ignore -v .claude/foo` → still ignored by the new anchored line; `node_modules` junction still ignored; `git status` shows no new untracked noise.

Known limitation: checkouts of commits predating this fix still show the false findings. Side-finding (not fixed here, harmless for us): knip's `getGitDir()` joins absolute `gitdir:` pointers onto cwd, so `.git/info/exclude` is never honored in any linked worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)