### PR TITLE
Pin Device Farm pools to exact devices and raise Safari webview timeout

### DIFF
--- a/ops/docs/developer/device-farm-qa.md
+++ b/ops/docs/developer/device-farm-qa.md
@@ -71,27 +71,30 @@ stable; unmetered slots ($250/device/month) only pay off past ~25 runs/week.
    bash ops/scripts/devicefarm-bootstrap.sh
    ```
 
-   Defaults: project `6529-mobile-qa`, pools `android-phones-smoke` (max 3)
-   and `ios-phones-web-smoke` (max 2). The script is idempotent and
-   *converging*: re-running it updates existing pools to the rules in the
-   script, so pool composition is version-controlled here. Override names via
-   env vars and mirror them in repository variables
-   `DEVICEFARM_PROJECT_NAME`, `DEVICEFARM_ANDROID_POOL_NAME`,
-   `DEVICEFARM_IOS_POOL_NAME` (the workflow resolves resources by name).
+   Defaults: project `6529-mobile-qa`, pools `android-phones-smoke` and
+   `ios-phones-web-smoke`. The script is idempotent and *converging*:
+   re-running it updates existing pools to the rules in the script, so pool
+   composition is version-controlled here. Override names via env vars and
+   mirror them in repository variables `DEVICEFARM_PROJECT_NAME`,
+   `DEVICEFARM_ANDROID_POOL_NAME`, `DEVICEFARM_IOS_POOL_NAME` (the workflow
+   resolves resources by name).
 
-   Pool composition is a deliberate representative mix, not "any available
-   phone" (an open rule tends to hand out two near-identical Pixels):
+   Pool composition is a deliberate representative set, ARN-pinned to exact
+   device+OS combinations. (Open availability rules handed out two
+   near-identical Pixels; `MODEL IN` rules select the same model on multiple
+   OS versions — both observed live.)
 
    | Pool | Devices | Why |
    | --- | --- | --- |
-   | `android-phones-smoke` | Samsung Galaxy S24, Google Pixel 8, Samsung Galaxy A15 | One UI flagship (dominant real-world OEM skin), stock Android, and the mid-range/low-perf class that is the most common Android tier globally. |
-   | `ios-phones-web-smoke` | iPhone 16, iPhone SE (2022) | Current mainstream iOS, plus the 4.7" small screen on the oldest supported Safari — the viewport that makes the horizontal-overflow check earn its keep. |
+   | `android-phones-smoke` | Samsung Galaxy S24 (Android 14), Google Pixel 8 (Android 15), Samsung Galaxy A15 (Android 14) | One UI flagship (dominant real-world OEM skin), stock Android, and the mid-range/low-perf class that is the most common Android tier globally. |
+   | `ios-phones-web-smoke` | iPhone 16 (iOS 18.6.2), iPhone SE 2022 (iOS 16.4) | Current mainstream iOS, plus the 4.7" small screen on the oldest supported Safari — the viewport that makes the horizontal-overflow check earn its keep. |
 
-   Model rules pick whichever of the named devices are highly available at
-   scheduling time (a busy model just shrinks that run's coverage). Recheck
-   the model list against the fleet (`aws devicefarm list-devices`) roughly
-   yearly, and calibrate against real visitor device analytics (CloudWatch
-   RUM / Mixpanel user agents) when adjusting.
+   ARN-pinned (static) pools queue for a busy device instead of silently
+   substituting another. If a pinned device is retired from the public fleet,
+   re-resolve its ARN per the comment in the bootstrap script. Recheck the
+   set against the fleet (`aws devicefarm list-devices`) roughly yearly, and
+   calibrate against real visitor device analytics (CloudWatch RUM / Mixpanel
+   user agents) when adjusting.
 
 2. **CI IAM principal** — create a dedicated IAM user (or role) for the
    workflow with this policy (Device Farm resources exist only in us-west-2):

--- a/ops/scripts/devicefarm-bootstrap.sh
+++ b/ops/scripts/devicefarm-bootstrap.sh
@@ -34,64 +34,63 @@ else
 fi
 echo "  project ARN: ${project_arn}"
 
+# Pools are STATIC (ARN-pinned, one exact device+OS each): a MODEL IN rule
+# happily selects the same model on two OS versions and squeezes out the rest
+# (observed live: two Pixel 8s / two iPhone 16s). Static pools take no
+# --max-devices parameter.
 ensure_pool() {
   local name="$1"
-  local max_devices="$2"
-  local description="$3"
-  local rules="$4"
+  local description="$2"
+  local rules="$3"
   local arn
 
   arn="$(aws devicefarm list-device-pools --region "$REGION" \
     --arn "$project_arn" --type PRIVATE \
     --query "devicePools[?name=='${name}'].arn | [0]" --output text)"
   if [[ -z "$arn" || "$arn" == "None" ]]; then
-    echo "Creating device pool: ${name} (max ${max_devices} devices)"
+    echo "Creating device pool: ${name}"
     arn="$(aws devicefarm create-device-pool --region "$REGION" \
       --project-arn "$project_arn" \
       --name "$name" \
       --description "$description" \
-      --max-devices "$max_devices" \
       --rules "$rules" \
       --query 'devicePool.arn' --output text)"
   else
-    echo "Updating device pool: ${name} (max ${max_devices} devices)"
+    echo "Updating device pool: ${name}"
     aws devicefarm update-device-pool --region "$REGION" \
       --arn "$arn" \
       --description "$description" \
-      --max-devices "$max_devices" \
+      --clear-max-devices \
       --rules "$rules" \
       --query 'devicePool.arn' --output text > /dev/null
   fi
   echo "  pool ARN: ${arn}"
 }
 
-# Representative Android mix rather than "any available phone": a Samsung
+# Representative Android devices rather than "any available phone": a Samsung
 # One UI flagship (the dominant real-world OEM skin), a stock-Android Pixel,
-# and a mid-range A-series (the most common device class globally, lower
-# perf tier). Whichever of the three are highly available get picked, up to
-# the pool max. Model names must match the Device Farm public fleet exactly
-# (`aws devicefarm list-devices`).
-ANDROID_RULES='[
-  {"attribute":"MODEL","operator":"IN","value":"[\"Samsung Galaxy S24\",\"Google Pixel 8\",\"Samsung Galaxy A15\"]"},
-  {"attribute":"AVAILABILITY","operator":"EQUALS","value":"\"HIGHLY_AVAILABLE\""},
-  {"attribute":"FLEET_TYPE","operator":"EQUALS","value":"\"PUBLIC\""}
-]'
+# and a mid-range A-series (the most common device class globally, lower perf
+# tier). Device ARNs are public-fleet identifiers (account-independent); a
+# busy device makes the run queue for it rather than dropping coverage. If a
+# device is retired from the fleet, re-resolve with:
+#   aws devicefarm list-devices --region us-west-2 \
+#     --query "devices[?model=='<model>'].{os:os,arn:arn}"
+# Galaxy S24 / Android 14, Pixel 8 / Android 15, Galaxy A15 / Android 14.
+# (The value must stay single-line: it is a JSON-encoded array inside a JSON
+# string, and raw newlines inside a JSON string are invalid.)
+ANDROID_RULES='[{"attribute":"ARN","operator":"IN","value":"[\"arn:aws:devicefarm:us-west-2::device:E0BD1EDDDF1B4E1A8FF5668759831BD6\",\"arn:aws:devicefarm:us-west-2::device:DE5BD47FF3BD42C3A14BF7A6EFB1BFE7\",\"arn:aws:devicefarm:us-west-2::device:9B74AD95597D4BF39827A4EAD83B9F6D\"]"}]'
 
-# Representative iOS mix: the current mainstream iPhone plus the small-screen
-# SE on the oldest supported Safari — the 4.7" viewport is what makes the
-# horizontal-overflow check meaningful.
-IOS_RULES='[
-  {"attribute":"MODEL","operator":"IN","value":"[\"Apple iPhone 16\",\"Apple iPhone SE (2022)\"]"},
-  {"attribute":"OS_VERSION","operator":"GREATER_THAN_OR_EQUALS","value":"\"16\""},
-  {"attribute":"AVAILABILITY","operator":"EQUALS","value":"\"HIGHLY_AVAILABLE\""},
-  {"attribute":"FLEET_TYPE","operator":"EQUALS","value":"\"PUBLIC\""}
-]'
+# Representative iOS devices: the current mainstream iPhone plus the
+# small-screen SE on the oldest supported Safari — the 4.7" viewport is what
+# makes the horizontal-overflow check meaningful.
+# iPhone 16 / iOS 18.6.2, iPhone SE 2022 / iOS 16.4.
+IOS_RULES='[{"attribute":"ARN","operator":"IN","value":"[\"arn:aws:devicefarm:us-west-2::device:3D8FC46FCD034EF8B617E538C1651422\",\"arn:aws:devicefarm:us-west-2::device:9769808870C54DD798C7985DA7515A05\"]"}]'
 
-ensure_pool "$ANDROID_POOL_NAME" 3 \
-  "Representative Android mix: One UI flagship + stock Pixel + mid-range A-series" \
+ensure_pool "$ANDROID_POOL_NAME" \
+  "Pinned representative Android devices: Galaxy S24 (14), Pixel 8 (15), Galaxy A15 (14)" \
   "$ANDROID_RULES"
-ensure_pool "$IOS_POOL_NAME" 2 \
-  "Representative iOS mix: current mainstream + small-screen/oldest-Safari SE" \
+ensure_pool "$IOS_POOL_NAME" \
+  "Pinned representative iOS devices: iPhone 16 (18.6.2), iPhone SE 2022 (16.4)" \
   "$IOS_RULES"
 
 cat <<SUMMARY

--- a/tests/device-farm/lib/driver.cjs
+++ b/tests/device-farm/lib/driver.cjs
@@ -91,6 +91,11 @@ async function startWebSession() {
   if (isIos()) {
     capabilities.browserName = "Safari";
     capabilities["appium:automationName"] = "XCUITest";
+    // Safari's remote debugger can take longer than the 5s driver default to
+    // expose the page (session creation failed on a Device Farm iPhone 16 /
+    // iOS 18.6.2 with "remote debugger did not return any connected web
+    // applications after ~5s").
+    capabilities["appium:webviewConnectTimeout"] = 30000;
     const derivedDataPath = env("DEVICEFARM_APPIUM_WDA_DERIVED_DATA_PATH");
     if (derivedDataPath) {
       capabilities["appium:derivedDataPath"] = derivedDataPath;


### PR DESCRIPTION
Follow-up to #3119 from the pool-verification run ([28757299717](https://github.com/6529-Collections/6529seize-frontend/actions/runs/28757299717)):

- **`MODEL IN` doesn't dedupe by model** — the run got two Pixel 8s (OS 14+15) and two iPhone 16s (18.0+18.6.2), squeezing out the Galaxy A15 and iPhone SE. Pools are now **static (ARN-pinned)** to exact device+OS combos: Galaxy S24 (14) + Pixel 8 (15) + Galaxy A15 (14); iPhone 16 (18.6.2) + iPhone SE 2022 (16.4). Static pools queue for a busy device instead of substituting, and take no `max-devices`. Bootstrap script updated (and re-run against the live project — pools already converged).
- **Safari session startup on iOS 18.6.2** failed with "remote debugger did not return any connected web applications after ~5s" — the driver's default `webviewConnectTimeout`. iOS web capabilities now allow 30s.

The passing devices from run 28757299717 (S24, two Pixel 8s, iPhone 16/18.0) all passed their tests — these fixes are about pool composition and session startup, not test logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)