### PR TITLE
Reveal drop hover actions from pointer events, not CSS :hover

### DIFF
--- a/__tests__/components/waves/drops/WaveDrop.test.tsx
+++ b/__tests__/components/waves/drops/WaveDrop.test.tsx
@@ -796,6 +796,63 @@ describe("WaveDrop", () => {
     );
   });
 
+  it("reveals desktop actions from mouse pointer events without CSS :hover", () => {
+    // Capability-lying browsers never activate :hover although mouse pointer
+    // events flow — the row's pointerenter must force the action bar visible.
+    isMobileMock.mockReturnValue(false);
+    hasTouchInputMock.mockReturnValue(true);
+    isTouchDeviceMock.mockReturnValue(false);
+    setHoverSupport(true);
+    setViewportWidth(1440);
+
+    renderWithEditingDropProvider(
+      <WaveDrop
+        drop={drop}
+        previousDrop={null}
+        nextDrop={null}
+        showWaveInfo={false}
+        activeDrop={null}
+        showReplyAndQuote={true}
+        location={DropLocation.WAVE}
+        dropViewDropId={null}
+        onReply={jest.fn()}
+        onQuote={jest.fn()}
+        onReplyClick={jest.fn()}
+        onQuoteClick={jest.fn()}
+      />
+    );
+
+    expect(getLastMockProps(mockWaveDropActions)).toEqual(
+      expect.objectContaining({ forceVisible: false })
+    );
+
+    const dropRoot = screen.getByTestId("content").closest(
+      "[data-wave-drop-id]"
+    )!;
+    // React synthesizes onPointerEnter/Leave from pointerover/pointerout.
+    fireEvent.pointerOver(dropRoot, { pointerType: "mouse" });
+    expect(getLastMockProps(mockWaveDropActions)).toEqual(
+      expect.objectContaining({ forceVisible: true })
+    );
+
+    fireEvent.pointerOut(dropRoot, {
+      pointerType: "mouse",
+      relatedTarget: document.body,
+    });
+    expect(getLastMockProps(mockWaveDropActions)).toEqual(
+      expect.objectContaining({ forceVisible: false })
+    );
+
+    // Touch enter must not force the desktop reveal. jsdom drops pointerType
+    // from event init, so define it explicitly on a hand-built event.
+    const touchOver = new Event("pointerover", { bubbles: true });
+    Object.defineProperty(touchOver, "pointerType", { value: "touch" });
+    dropRoot.dispatchEvent(touchOver);
+    expect(getLastMockProps(mockWaveDropActions)).toEqual(
+      expect.objectContaining({ forceVisible: false })
+    );
+  });
+
   it("omits group mention metadata from edit update requests", () => {
     isMobileMock.mockReturnValue(false);
     mockEditMentionedGroups = [ApiDropGroupMention.All];

--- a/__tests__/components/waves/drops/WaveDropActions.test.tsx
+++ b/__tests__/components/waves/drops/WaveDropActions.test.tsx
@@ -109,6 +109,39 @@ describe("WaveDropActions", () => {
     );
   });
 
+  it("forces visibility from the row's pointer-driven hover", () => {
+    const { container } = render(
+      <WaveDropActions
+        drop={baseDrop}
+        activePartIndex={0}
+        onReply={() => {}}
+        forceVisible={true}
+      />
+    );
+
+    expect(container.firstElementChild).toHaveClass(
+      "tw-pointer-events-auto",
+      "tw-opacity-100"
+    );
+  });
+
+  it("keeps link-card suppression above the pointer-driven hover", () => {
+    const { container } = render(
+      <WaveDropActions
+        drop={baseDrop}
+        activePartIndex={0}
+        onReply={() => {}}
+        suppressed={true}
+        forceVisible={true}
+      />
+    );
+
+    expect(container.firstElementChild).toHaveClass(
+      "tw-pointer-events-none",
+      "tw-opacity-0"
+    );
+  });
+
   it("renders the voting control for regular drops", () => {
     render(
       <WaveDropActions drop={baseDrop} activePartIndex={0} onReply={() => {}} />

--- a/components/waves/drops/WaveDrop.tsx
+++ b/components/waves/drops/WaveDrop.tsx
@@ -511,10 +511,13 @@ const GroupedDropTimestamp = ({
   swipeOffset = 0,
   timestamp,
   variant,
+  forceVisible = false,
 }: {
   readonly swipeOffset?: number;
   readonly timestamp: number;
   readonly variant: "swipe" | "hover";
+  /** Pointer-driven row hover for browsers whose CSS :hover never fires. */
+  readonly forceVisible?: boolean;
 }) => {
   // "swipe": revealed by the touch swipe gesture via inline opacity.
   // "hover": desktop affordance — swiping would hijack text selection, so the
@@ -534,7 +537,11 @@ const GroupedDropTimestamp = ({
           : "grouped-drop-swipe-timestamp"
       }
       style={
-        isHoverVariant ? undefined : getGroupedTimestampOpacityStyle(swipeOffset)
+        isHoverVariant
+          ? forceVisible
+            ? { opacity: 1 }
+            : undefined
+          : getGroupedTimestampOpacityStyle(swipeOffset)
       }
     >
       <WaveDropTime timestamp={timestamp} size="xs" variant="compactReveal" />
@@ -645,6 +652,7 @@ const getContentBlock = ({
   embedDepth,
   maxEmbedDepth,
   groupedTimestampSwipeOffset,
+  isRowPointerHovered,
 }: {
   readonly shouldShowReplyHeader: boolean;
   readonly onReplyClick: (serialNo: number) => void;
@@ -689,6 +697,7 @@ const getContentBlock = ({
   readonly embedDepth?: number | undefined;
   readonly maxEmbedDepth?: number | undefined;
   readonly groupedTimestampSwipeOffset: number;
+  readonly isRowPointerHovered: boolean;
 }): React.ReactNode => (
   <>
     {shouldShowReplyHeader && replyTo && (
@@ -776,6 +785,7 @@ const getContentBlock = ({
           onReply={handleOnReply}
           onEdit={handleOnEdit}
           suppressed={hasActiveLinkCardActions}
+          forceVisible={isRowPointerHovered}
           style={getGroupedTimestampActionStyle(groupedTimestampSwipeOffset)}
         />
       )}
@@ -883,6 +893,35 @@ const WaveDropInner = ({
     useDropActionInteractionMode();
   const mobileMenu = useWaveDropMobileMenu();
   const allowLongPress = showInteractions && canUseTouchActionSheet;
+  // Pointer-driven row hover: some browsers (capability-lying convertibles)
+  // never activate CSS :hover although mouse pointer events flow, leaving the
+  // group-hover action reveal invisible. Track the cursor with pointer events
+  // instead; CSS :hover stays as the no-JS fallback. pointerover/out (with a
+  // containment check) rather than enter/leave so child crossings are cheap
+  // no-op state writes and jsdom can exercise the path.
+  const [isRowPointerHovered, setIsRowPointerHovered] = useState(false);
+  const handleRowPointerOver = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (getPointerType(event) === "mouse" && canUseDesktopHoverActions) {
+        setIsRowPointerHovered(true);
+      }
+    },
+    [canUseDesktopHoverActions]
+  );
+  const handleRowPointerOut = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (
+        getPointerType(event) === "mouse" &&
+        !(
+          event.relatedTarget instanceof Node &&
+          event.currentTarget.contains(event.relatedTarget)
+        )
+      ) {
+        setIsRowPointerHovered(false);
+      }
+    },
+    []
+  );
   const compact = useCompactMode();
   const hasActiveLinkCardActions = activeLinkCardActionIds.length > 0;
 
@@ -1397,6 +1436,7 @@ const WaveDropInner = ({
     embedDepth,
     maxEmbedDepth,
     groupedTimestampSwipeOffset: timestampSwipeOffset,
+    isRowPointerHovered,
   });
 
   const contentOffsetClass = inlineAuthorOnDesktop
@@ -1454,6 +1494,8 @@ const WaveDropInner = ({
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerEnd}
         onPointerCancel={handlePointerEnd}
+        onPointerOver={handleRowPointerOver}
+        onPointerOut={handleRowPointerOut}
         onClickCapture={handleClickCapture}
       >
         {showGroupedTimestamp && (
@@ -1461,6 +1503,7 @@ const WaveDropInner = ({
             swipeOffset={timestampSwipeOffset}
             timestamp={drop.created_at}
             variant={canUseTouchActionSheet ? "swipe" : "hover"}
+            forceVisible={isRowPointerHovered}
           />
         )}
         <div

--- a/components/waves/drops/WaveDropActions.tsx
+++ b/components/waves/drops/WaveDropActions.tsx
@@ -23,6 +23,14 @@ interface WaveDropActionsProps {
   readonly onReply: () => void;
   readonly onEdit?: (() => void) | undefined;
   readonly suppressed?: boolean | undefined;
+  /**
+   * Pointer-driven reveal from the drop row. Browsers that internally
+   * classify all input as touch never activate CSS :hover, so the
+   * group-hover reveal stays invisible even while a real cursor (delivering
+   * pointer events) is on the row. The row tracks pointerenter/leave and
+   * forces visibility here; CSS :hover remains as the no-JS fallback.
+   */
+  readonly forceVisible?: boolean | undefined;
   readonly style?: CSSProperties | undefined;
 }
 
@@ -33,6 +41,7 @@ export default function WaveDropActions({
   onReply,
   onEdit,
   suppressed = false,
+  forceVisible = false,
   style,
 }: WaveDropActionsProps) {
   const { isMemesWave } = useSeizeSettings();
@@ -55,6 +64,8 @@ export default function WaveDropActions({
     visibilityClasses = "tw-pointer-events-auto tw-opacity-100";
   } else if (suppressed) {
     visibilityClasses = "tw-pointer-events-none tw-opacity-0";
+  } else if (forceVisible) {
+    visibilityClasses = "tw-pointer-events-auto tw-opacity-100";
   }
 
   return (


### PR DESCRIPTION
## Issue
- Reported by @punk6529 after 4.71.5: on his Surface/Brave, desktop mode is now stable (latch + persistence working — the ⋮ flashed exactly once and the flag stored), but **hovering a message reveals nothing** — no Reply, no ⋯ — so there is still no reply path.
- Root cause: the desktop action bar renders correctly but reveals via `desktop-hover:group-hover:` CSS. On his browser, the same internal input classification that mis-reports `matchMedia` capabilities also **never activates CSS `:hover`**, although mouse pointer events flow normally (selection and the latch both work off them). Verified: the hydrated desktop mode renders the bar (sandbox: Reply/More visible under Playwright, where `:hover` works) and prod CSS contains both reveal arms — the failure is `:hover` activation itself, which no CSS can fix.

## Fix
- The drop row tracks the cursor with `pointerover`/`pointerout` (mouse-type only, containment check on out so child crossings are no-ops) and passes `forceVisible` to `WaveDropActions` and the grouped hover-timestamp. Pointer events are ground truth on these browsers; CSS `:hover` remains the no-JS fallback for everyone else.
- Precedence preserved: open dropdown > link-card suppression > pointer hover > CSS hover.
- `pointerType` uses the file's existing `getPointerType` default (missing → mouse), consistent with the swipe handlers.

## Validation
- 33 tests green across WaveDrop / WaveDropActions / DropMobileMenuHandler, including new cases: pointerover(mouse) forces the bar visible, pointerout clears it, touch pointerover never reveals, suppression outranks the pointer reveal.
- eslint + debt ratchet clean.

## Risk
- Level: Low-Medium
- Why: adds two pointer handlers per drop row and one boolean state; honest desktops behave identically (JS reveal coincides with CSS reveal).
- Rollback: revert the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)