### PR TITLE
[codex] Fix messages create DM modal ownership

### DIFF
--- a/__tests__/components/MessagesLayout.test.tsx
+++ b/__tests__/components/MessagesLayout.test.tsx
@@ -3,7 +3,12 @@ import { render, screen } from "@testing-library/react";
 import React from "react";
 
 const mockUseAuthenticatedContent = jest.fn();
+const mockUseCreateModalState = jest.fn();
 const mockUseDeviceInfo = jest.fn();
+const mockCreateDirectMessageModal = jest.fn(
+  ({ isOpen }: { readonly isOpen: boolean }) =>
+    isOpen ? <div data-testid="create-dm-modal" /> : null
+);
 
 jest.mock("@/hooks/useAuthenticatedContent", () => ({
   useAuthenticatedContent: () => mockUseAuthenticatedContent(),
@@ -12,6 +17,17 @@ jest.mock("@/hooks/useAuthenticatedContent", () => ({
 jest.mock("@/hooks/useDeviceInfo", () => ({
   __esModule: true,
   default: () => mockUseDeviceInfo(),
+}));
+
+jest.mock("@/hooks/useCreateModalState", () => ({
+  __esModule: true,
+  default: () => mockUseCreateModalState(),
+}));
+
+jest.mock("@/components/waves/create-dm/CreateDirectMessageModal", () => ({
+  __esModule: true,
+  default: (props: { readonly isOpen: boolean }) =>
+    mockCreateDirectMessageModal(props),
 }));
 
 jest.mock("@/components/messages/MessagesDesktop", () => ({
@@ -56,12 +72,20 @@ describe("MessagesLayout", () => {
   beforeEach(() => {
     mockUseAuthenticatedContent.mockReturnValue({
       contentState: "not-authenticated",
+      connectedProfile: null,
+    });
+    mockUseCreateModalState.mockReturnValue({
+      close: jest.fn(),
+      isDirectMessageModalOpen: false,
     });
     mockUseDeviceInfo.mockReturnValue({ isApp: false, isMobileDevice: false });
   });
 
   it("renders messages content only when ready", () => {
-    mockUseAuthenticatedContent.mockReturnValue({ contentState: "ready" });
+    mockUseAuthenticatedContent.mockReturnValue({
+      connectedProfile: null,
+      contentState: "ready",
+    });
 
     render(
       <MessagesLayout>
@@ -74,8 +98,36 @@ describe("MessagesLayout", () => {
     expect(screen.queryByTestId("connect-wallet")).not.toBeInTheDocument();
   });
 
+  it("owns the desktop create-direct-message modal from the layout", () => {
+    const close = jest.fn();
+    const connectedProfile = { handle: "seize", primary_wallet: "0x1" };
+    mockUseAuthenticatedContent.mockReturnValue({
+      connectedProfile,
+      contentState: "ready",
+    });
+    mockUseCreateModalState.mockReturnValue({
+      close,
+      isDirectMessageModalOpen: true,
+    });
+
+    render(
+      <MessagesLayout>
+        <div data-testid="message-content">DM content</div>
+      </MessagesLayout>
+    );
+
+    expect(screen.getByTestId("create-dm-modal")).toBeInTheDocument();
+    expect(mockCreateDirectMessageModal).toHaveBeenCalledTimes(1);
+    expect(mockCreateDirectMessageModal).toHaveBeenCalledWith({
+      isOpen: true,
+      onClose: close,
+      profile: connectedProfile,
+    });
+  });
+
   it("keeps messages content gated when profile setup is needed", () => {
     mockUseAuthenticatedContent.mockReturnValue({
+      connectedProfile: null,
       contentState: "needs-profile",
     });
 

--- a/components/brain/left-sidebar/web/WebDirectMessagesList.tsx
+++ b/components/brain/left-sidebar/web/WebDirectMessagesList.tsx
@@ -14,7 +14,6 @@ import { useSeizeConnectContext } from "../../../auth/SeizeConnectContext";
 import HeaderUserConnect from "../../../header/user/HeaderUserConnect";
 import UserSetUpProfileCta from "../../../user/utils/set-up-profile/UserSetUpProfileCta";
 import PrimaryButton from "../../../utils/button/PrimaryButton";
-import CreateDirectMessageModal from "../../../waves/create-dm/CreateDirectMessageModal";
 import UnifiedWavesListEmpty from "../waves/UnifiedWavesListEmpty";
 import { UnifiedWavesListLoader } from "../waves/UnifiedWavesListLoader";
 import WebUnifiedWavesListWaves from "./WebUnifiedWavesListWaves";
@@ -30,8 +29,7 @@ const WebDirectMessagesList: React.FC<WebDirectMessagesListProps> = ({
 }) => {
   const { hasValidWalletAuth } = useSeizeConnectContext();
   const { connectedProfile } = useContext(AuthContext);
-  const { isDirectMessageModalOpen, openDirectMessage, close, isApp } =
-    useCreateModalState();
+  const { openDirectMessage, isApp } = useCreateModalState();
   const isTouchDevice = useIsTouchDevice();
 
   const shouldRenderCreateDirectMessage = !isApp;
@@ -207,11 +205,6 @@ const WebDirectMessagesList: React.FC<WebDirectMessagesListProps> = ({
         />
       )}
 
-      <CreateDirectMessageModal
-        isOpen={isDirectMessageModalOpen}
-        onClose={close}
-        profile={connectedProfile}
-      />
     </div>
   );
 };

--- a/components/messages/MessagesView.tsx
+++ b/components/messages/MessagesView.tsx
@@ -57,11 +57,9 @@ const MessagesView: React.FC = () => {
   }
 
   return (
-    <>
-      <BrainContent activeDrop={null} onCancelReplyQuote={() => {}}>
-        {content}
-      </BrainContent>
-    </>
+    <BrainContent activeDrop={null} onCancelReplyQuote={() => {}}>
+      {content}
+    </BrainContent>
   );
 };
 

--- a/components/messages/MessagesView.tsx
+++ b/components/messages/MessagesView.tsx
@@ -7,19 +7,16 @@ import BrainContent from "../brain/content/BrainContent";
 import PrimaryButton from "../utils/button/PrimaryButton";
 import { faPaperPlane } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import CreateDirectMessageModal from "../waves/create-dm/CreateDirectMessageModal";
-import { useAuth } from "../auth/Auth";
 import useDeviceInfo from "../../hooks/useDeviceInfo";
 import useCreateModalState from "@/hooks/useCreateModalState";
 import { getActiveWaveIdFromUrl } from "@/helpers/navigation.helpers";
 
 const MessagesView: React.FC = () => {
+  // react-doctor-disable-next-line react-doctor/nextjs-no-use-search-params-without-suspense covered by app/messages page Suspense wrapper
   const searchParams = useSearchParams();
   const pathname = usePathname();
-  const { connectedProfile } = useAuth();
   const { isApp } = useDeviceInfo();
-  const { isDirectMessageModalOpen, openDirectMessage, close } =
-    useCreateModalState();
+  const { openDirectMessage } = useCreateModalState();
 
   const serialisedWaveId = getActiveWaveIdFromUrl({ pathname, searchParams });
 
@@ -64,14 +61,6 @@ const MessagesView: React.FC = () => {
       <BrainContent activeDrop={null} onCancelReplyQuote={() => {}}>
         {content}
       </BrainContent>
-
-      {connectedProfile && (
-        <CreateDirectMessageModal
-          isOpen={isDirectMessageModalOpen}
-          onClose={close}
-          profile={connectedProfile}
-        />
-      )}
     </>
   );
 };

--- a/components/messages/layout/MessagesLayout.tsx
+++ b/components/messages/layout/MessagesLayout.tsx
@@ -8,11 +8,14 @@ import MessagesMobile from "../MessagesMobile";
 import useDeviceInfo from "../../../hooks/useDeviceInfo";
 import ConnectWallet from "../../common/ConnectWallet";
 import { useAuthenticatedContent } from "../../../hooks/useAuthenticatedContent";
+import useCreateModalState from "@/hooks/useCreateModalState";
+import CreateDirectMessageModal from "@/components/waves/create-dm/CreateDirectMessageModal";
 
 // Main layout content that uses the Layout context
 function MessagesLayoutContent({ children }: { readonly children: ReactNode }) {
-  const { contentState } = useAuthenticatedContent();
+  const { contentState, connectedProfile } = useAuthenticatedContent();
   const { isApp } = useDeviceInfo();
+  const { isDirectMessageModalOpen, close } = useCreateModalState();
 
   const containerClassName =
     "tw-relative tw-flex tw-flex-col tw-flex-1 tailwind-scope";
@@ -79,6 +82,13 @@ function MessagesLayoutContent({ children }: { readonly children: ReactNode }) {
   return (
     <div className="tailwind-scope tw-flex tw-flex-col tw-bg-black">
       {content}
+      {contentState === "ready" && !isApp && connectedProfile && (
+        <CreateDirectMessageModal
+          isOpen={isDirectMessageModalOpen}
+          onClose={close}
+          profile={connectedProfile}
+        />
+      )}
     </div>
   );
 }

--- a/pr-reports/3130.md
+++ b/pr-reports/3130.md
@@ -1,0 +1,25 @@
+# PR Report: Fix messages create DM modal ownership
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/3130
+Branch: codex/dm-modal-identity-click -> main
+Related PRs: None
+
+## Summary
+Fixes the desktop `/messages?create=dm` flow so the new direct-message modal is interactive when opened from URL state or create controls. The messages layout now owns one desktop create-DM modal, while the sidebar and placeholder controls only launch the shared URL mode.
+
+## What Changed
+- Moved desktop create-DM modal ownership to `MessagesLayout`.
+- Removed duplicate URL-driven create-DM modal instances from `MessagesView` and `WebDirectMessagesList`.
+- Added focused coverage for layout-level modal ownership.
+
+## Frontend Impact
+- Routes/views: `/messages` and `/messages/{waveId}` desktop create-DM URL mode.
+- Components: messages layout, messages placeholder view, web direct messages sidebar.
+- Generated API/client: Not affected.
+- User-visible behavior: identity search, close button, backdrop close, and Escape close remain usable in the desktop create-DM modal.
+
+## Config / Env
+None.
+
+## Release Notes
+Desktop direct-message creation from `/messages?create=dm` no longer opens a non-interactive modal.


### PR DESCRIPTION
## Issue
- Opening `/messages?create=dm` on desktop could render the new direct-message modal in a non-interactive state.
- Root cause: the messages main view and the web messages sidebar both mounted the URL-driven create-DM modal. Each modal inerted the other portal, leaving the visible dialog unable to accept clicks or close normally.

## Fix
- Move desktop URL-driven create-DM modal ownership to `MessagesLayout` so `/messages` pages mount one modal owner.
- Keep the messages placeholder and sidebar create buttons as launchers that update `create=dm`.
- Leave app-mode create handling untouched, since app mode already uses `/messages/create` / mobile overlay behavior.

## Changes
- Added one layout-level `CreateDirectMessageModal` owner for authenticated desktop messages pages.
- Removed duplicate modal instances from `MessagesView` and `WebDirectMessagesList`.
- Added a focused `MessagesLayout` test covering single layout modal ownership.

## Validation
- `./bin/6529 run test -- __tests__/components/MessagesLayout.test.tsx`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff`

## Risk
- Level: Low
- Why: the change narrows modal ownership without changing the DM creation form or API calls.
- Rollback: revert this PR to restore the previous per-component modal ownership.

## Review Notes
- Please focus on `/messages?create=dm` desktop behavior: the identity input, close button, backdrop close, and Escape close should all be interactive with only one modal mounted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the desktop “create direct message” flow so it opens as a fully interactive modal instead of a non-interactive one.
  * Direct message creation now behaves consistently on desktop, with closing via the close button, backdrop, or Escape key still working.
* **Tests**
  * Added coverage for the direct message modal behavior to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->