### PR TITLE
[codex] Normalize wave reaction emoji line height

### DIFF
--- a/components/waves/drops/WaveDropReactions.tsx
+++ b/components/waves/drops/WaveDropReactions.tsx
@@ -523,12 +523,12 @@ function WaveDropReaction({
     if (native) {
       return {
         emojiNode: (
-          <span className="tw-flex tw-items-center tw-justify-center tw-text-[1rem]">
+          <span className="tw-inline-flex tw-size-5 tw-items-center tw-justify-center tw-text-base tw-leading-none">
             {native.skins[0]?.native}
           </span>
         ),
         emojiNodeTooltip: (
-          <span className="tw-flex tw-items-center tw-justify-center tw-text-2xl">
+          <span className="tw-inline-flex tw-size-8 tw-items-center tw-justify-center tw-text-2xl tw-leading-none">
             {native.skins[0]?.native}
           </span>
         ),
@@ -806,7 +806,7 @@ function WaveDropReaction({
           </div>
           <span
             className={clsx(
-              "tw-min-w-[2ch] tw-text-xs tw-font-normal",
+              "tw-min-w-[2ch] tw-text-xs tw-font-normal tw-leading-none",
               animationStyle
             )}
           >


### PR DESCRIPTION
## Issue
- Native emoji reactions can look vertically off on mobile because the emoji glyph is rendered through system text metrics while custom emoji reactions render as fixed image boxes.

## Fix
- Give native reaction emojis a fixed inline-flex box with `leading-none` so the chip centers a deterministic emoji line box instead of an unconstrained text line box.

## Changes
- Normalized native reaction emoji sizing for reaction chips and tooltips.
- Added `leading-none` to the reaction count so the chip contents align from tighter line boxes.
- Left custom emoji image rendering unchanged.

## Validation
- `6529 run check:changed` passed.
- `6529 run react-doctor:diff` was attempted, but the diff scanner reported no changed source files in this worktree.

## Risk
- Level: Low
- Why: narrow Tailwind class-only change in the existing reaction component.
- Rollback: revert this commit to restore the prior reaction chip classes.

## Review Notes
- Please sanity-check mobile native emoji reaction alignment; custom emoji rendering should be unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the display of native emoji reactions for more consistent sizing and vertical alignment.
  * Improved the alignment of reaction counts to make the reaction row look cleaner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->