### PR TITLE
Add external API auth guide

### DIFF
--- a/app/about/tech/wallet-authentication/page.tsx
+++ b/app/about/tech/wallet-authentication/page.tsx
@@ -35,11 +35,11 @@ export default function WalletAuthenticationPage() {
       <Container fluid className="tw-pt-4">
         <Row>
           <Col>
-            <Container className="tw-pt-2">
+            <Container fluid className="tw-pt-2">
               <Row>
                 <Col>
                   <AboutContentsDropdown currentSection={AboutSection.TECH} />
-                  <article className="tw-w-full tw-text-iron-200">
+                  <article className="tw-w-full tw-text-iron-50">
                     <Link
                       href="/about/tech"
                       className="hover:tw-text-primary-200 tw-mb-5 tw-inline-flex tw-text-sm tw-font-semibold tw-text-primary-300 tw-no-underline"
@@ -50,19 +50,19 @@ export default function WalletAuthenticationPage() {
                       )}
                     </Link>
 
-                    <header className="tw-max-w-4xl tw-pb-4">
-                      <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-400">
+                    <header className="tw-w-full tw-pb-4">
+                      <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-50">
                         {t(WALLET_AUTH_LOCALE, "about.tech.walletAuth.eyebrow")}
                       </p>
                       <h1 className="tw-mb-4 tw-text-3xl tw-font-semibold tw-leading-tight tw-text-iron-50 md:tw-text-4xl">
                         {t(WALLET_AUTH_LOCALE, "about.tech.walletAuth.title")}
                       </h1>
-                      <p className="tw-mb-0 tw-text-base tw-leading-7 tw-text-iron-300">
+                      <p className="tw-mb-0 tw-text-base tw-leading-7 tw-text-iron-50">
                         {t(WALLET_AUTH_LOCALE, "about.tech.walletAuth.lead")}
                       </p>
                     </header>
 
-                    <div className="tw-flex tw-max-w-4xl tw-flex-col tw-gap-8 tw-text-base tw-leading-7 tw-text-iron-300">
+                    <div className="tw-flex tw-w-full tw-flex-col tw-gap-8 tw-text-base tw-leading-7 tw-text-iron-50">
                       <section aria-labelledby="what-is-changing-heading">
                         <h2
                           id="what-is-changing-heading"

--- a/app/about/tech/wallet-authentication/page.tsx
+++ b/app/about/tech/wallet-authentication/page.tsx
@@ -12,6 +12,7 @@ import { DEFAULT_LOCALE } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
 import styles from "@/styles/Home.module.css";
 import { AboutSection } from "@/types/enums";
+import clsx from "clsx";
 
 const WALLET_AUTH_LOCALE = DEFAULT_LOCALE;
 const WALLET_AUTH_TITLE = t(
@@ -30,7 +31,7 @@ export const metadata: Metadata = getAppMetadata({
 
 export default function WalletAuthenticationPage() {
   return (
-    <main className={`${styles["main"]} tailwind-scope`}>
+    <main className={clsx(styles["main"], "tailwind-scope")}>
       <Container fluid className="tw-pt-4">
         <Row>
           <Col>
@@ -184,6 +185,33 @@ export default function WalletAuthenticationPage() {
                             )}
                           </li>
                         </ul>
+                      </section>
+
+                      <section aria-labelledby="api-builders-heading">
+                        <h2
+                          id="api-builders-heading"
+                          className="tw-mb-3 tw-text-2xl tw-font-semibold tw-text-iron-50"
+                        >
+                          {t(
+                            WALLET_AUTH_LOCALE,
+                            "about.tech.walletAuth.builders.title"
+                          )}
+                        </h2>
+                        <p className="tw-mb-3">
+                          {t(
+                            WALLET_AUTH_LOCALE,
+                            "about.tech.walletAuth.builders.body"
+                          )}
+                        </p>
+                        <Link
+                          href="/tools/api/authentication"
+                          className="hover:tw-text-primary-200 tw-font-semibold tw-text-primary-300 tw-no-underline"
+                        >
+                          {t(
+                            WALLET_AUTH_LOCALE,
+                            "about.tech.walletAuth.builders.link"
+                          )}
+                        </Link>
                       </section>
                     </div>
                   </article>

--- a/app/tools/api/authentication/page.tsx
+++ b/app/tools/api/authentication/page.tsx
@@ -13,13 +13,12 @@ import {
 } from "@/components/about/AboutLayout";
 
 const API_REFERENCE_URL = "https://api.6529.io/docs/";
-const FLOW_CODE_PLACEHOLDER = "__API_AUTH_FLOW_CODE__";
 
 const inlineCodeClass =
   "tw-rounded tw-bg-iron-900 tw-px-1.5 tw-py-0.5 tw-text-sm tw-text-iron-100";
-const sectionClass = "tw-max-w-4xl tw-text-base tw-leading-7 tw-text-iron-50";
+const sectionClass = "tw-w-full tw-text-base tw-leading-7 tw-text-iron-50";
 const exampleSectionClass =
-  "tw-max-w-5xl tw-text-base tw-leading-7 tw-text-iron-50";
+  "tw-w-full tw-text-base tw-leading-7 tw-text-iron-50";
 const sectionHeadingClass =
   "tw-mb-3 tw-text-2xl tw-font-semibold tw-text-iron-50";
 
@@ -53,23 +52,8 @@ function ApiAuthSection({
   );
 }
 
-function AuthFlowStep({
-  code,
-  message,
-}: Readonly<{
-  code: string;
-  message: string;
-}>) {
-  const [beforeCode = "", afterCode = ""] =
-    message.split(FLOW_CODE_PLACEHOLDER);
-
-  return (
-    <li>
-      {beforeCode}
-      <code className={inlineCodeClass}>{code}</code>
-      {afterCode}
-    </li>
-  );
+function InlineCode({ children }: Readonly<{ children: ReactNode }>) {
+  return <code className={inlineCodeClass}>{children}</code>;
 }
 
 const apiAuthGuideCopy = {
@@ -79,31 +63,16 @@ const apiAuthGuideCopy = {
   backToApi: "Back to API",
   eyebrow: "API Authentication",
   title: "External Client Authentication",
-  lead:
-    "Use session-v2 wallet authentication when building scripts, services, and other external clients against the 6529 API.",
+  lead: "Use session-v2 wallet authentication when building scripts, services, and other external clients against the 6529 API.",
   overviewTitle: "What to use",
-  overviewPreferred:
-    "New external clients should authenticate through session-v2 endpoints. The standard external-client mode is client_type=native, even when the client is a command-line script or backend service controlled by the wallet owner.",
   overviewLegacy:
     "The older nonce, login, and redeem-refresh-token endpoints remain compatibility endpoints for older clients. New integrations should not start on those legacy endpoints.",
   flowTitle: "Login flow",
-  flowNonce: `Request a signable message with signer_address, client_type=native, and chain_id=1 from ${FLOW_CODE_PLACEHOLDER}.`,
-  flowSign: `Sign the returned message exactly as returned in ${FLOW_CODE_PLACEHOLDER}.`,
-  flowLogin: `Send client_type, client_address, client_signature, server_signature, and optional role to ${FLOW_CODE_PLACEHOLDER}.`,
-  flowBearer: `Use the returned access token on protected API calls as ${FLOW_CODE_PLACEHOLDER}.`,
   refreshTitle: "Refresh and logout",
-  refreshLogin:
-    "Native/script login returns an access_token for bearer auth plus a native_refresh_token and refresh_token_expires_at for long-running clients.",
-  refreshRotate:
-    "Refresh through POST /api/auth/session-refresh with client_type=native, client_address, and the current native_refresh_token. A successful refresh rotates the native refresh token, so replace the stored token with the new one immediately.",
-  refreshLogout:
-    "Logout through POST /api/auth/session-logout with client_type=native, client_address, the current native_refresh_token, and all_sessions=false unless you intend to revoke every session for that wallet.",
   browserTitle: "Browser clients",
   browserNote:
     "This guide is for external clients. First-party browser sessions also use session-v2, but browser refresh state is handled with backend-owned HttpOnly cookies, credentials-included requests, and origin checks. Follow the app implementation rather than adapting the native/script examples directly for browser sessions.",
   securityTitle: "Security rules",
-  securitySignable:
-    "Sign only signable_message exactly as returned. Do not trim, normalize, rebuild, JSON-stringify, or sign a nonce field.",
   securitySecrets:
     "Do not log private keys, access tokens, refresh tokens, signatures, or raw authentication responses. Store refresh tokens in a secret store appropriate for the client environment.",
   securityStatus:
@@ -213,7 +182,7 @@ export async function logoutNativeSession({ address, nativeRefreshToken }) {
 export default function ApiAuthenticationPage() {
   return (
     <main className={clsx(styles["main"], "tailwind-scope")}>
-      <Container className={ABOUT_TEXT_PAGE_CONTAINER_CLASS}>
+      <Container fluid className={ABOUT_TEXT_PAGE_CONTAINER_CLASS}>
         <Row>
           <Col>
             <Link
@@ -222,7 +191,7 @@ export default function ApiAuthenticationPage() {
             >
               {apiAuthGuideCopy.backToApi}
             </Link>
-            <header className="tw-max-w-4xl">
+            <header className="tw-w-full">
               <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-50">
                 {apiAuthGuideCopy.eyebrow}
               </p>
@@ -240,7 +209,13 @@ export default function ApiAuthenticationPage() {
           headingId="api-auth-overview-heading"
           title={apiAuthGuideCopy.overviewTitle}
         >
-          <p className="tw-mb-3">{apiAuthGuideCopy.overviewPreferred}</p>
+          <p className="tw-mb-3">
+            New external clients should authenticate through session-v2
+            endpoints. The standard external-client mode is{" "}
+            <InlineCode>client_type=native</InlineCode>, even when the client is
+            a command-line script or backend service controlled by the wallet
+            owner.
+          </p>
           <p className="tw-mb-0">{apiAuthGuideCopy.overviewLegacy}</p>
         </ApiAuthSection>
 
@@ -249,22 +224,30 @@ export default function ApiAuthenticationPage() {
           title={apiAuthGuideCopy.flowTitle}
         >
           <ol className="tw-grid tw-gap-3 tw-pl-5">
-            <AuthFlowStep
-              message={apiAuthGuideCopy.flowNonce}
-              code="GET /api/auth/session-nonce"
-            />
-            <AuthFlowStep
-              message={apiAuthGuideCopy.flowSign}
-              code="signable_message"
-            />
-            <AuthFlowStep
-              message={apiAuthGuideCopy.flowLogin}
-              code="POST /api/auth/session-login"
-            />
-            <AuthFlowStep
-              message={apiAuthGuideCopy.flowBearer}
-              code="Authorization: Bearer <access_token>"
-            />
+            <li>
+              Request a signable message with{" "}
+              <InlineCode>signer_address</InlineCode>,{" "}
+              <InlineCode>client_type=native</InlineCode>, and{" "}
+              <InlineCode>chain_id=1</InlineCode> from{" "}
+              <InlineCode>GET /api/auth/session-nonce</InlineCode>.
+            </li>
+            <li>
+              Sign the returned message exactly as returned in{" "}
+              <InlineCode>signable_message</InlineCode>.
+            </li>
+            <li>
+              Send <InlineCode>client_type</InlineCode>,{" "}
+              <InlineCode>client_address</InlineCode>,{" "}
+              <InlineCode>client_signature</InlineCode>,{" "}
+              <InlineCode>server_signature</InlineCode>, and optional{" "}
+              <InlineCode>role</InlineCode> to{" "}
+              <InlineCode>POST /api/auth/session-login</InlineCode>.
+            </li>
+            <li>
+              Use the returned <InlineCode>access_token</InlineCode> on
+              protected API calls as{" "}
+              <InlineCode>Authorization: Bearer {"<access_token>"}</InlineCode>.
+            </li>
           </ol>
         </ApiAuthSection>
 
@@ -272,9 +255,30 @@ export default function ApiAuthenticationPage() {
           headingId="api-auth-refresh-heading"
           title={apiAuthGuideCopy.refreshTitle}
         >
-          <p className="tw-mb-3">{apiAuthGuideCopy.refreshLogin}</p>
-          <p className="tw-mb-3">{apiAuthGuideCopy.refreshRotate}</p>
-          <p className="tw-mb-0">{apiAuthGuideCopy.refreshLogout}</p>
+          <p className="tw-mb-3">
+            Native/script login returns an <InlineCode>access_token</InlineCode>{" "}
+            for bearer auth plus a <InlineCode>native_refresh_token</InlineCode>{" "}
+            and <InlineCode>refresh_token_expires_at</InlineCode> for
+            long-running clients.
+          </p>
+          <p className="tw-mb-3">
+            Refresh through{" "}
+            <InlineCode>POST /api/auth/session-refresh</InlineCode> with{" "}
+            <InlineCode>client_type=native</InlineCode>,{" "}
+            <InlineCode>client_address</InlineCode>, and the current{" "}
+            <InlineCode>native_refresh_token</InlineCode>. A successful refresh
+            rotates the native refresh token, so replace the stored token with
+            the new one immediately.
+          </p>
+          <p className="tw-mb-0">
+            Logout through{" "}
+            <InlineCode>POST /api/auth/session-logout</InlineCode> with{" "}
+            <InlineCode>client_type=native</InlineCode>,{" "}
+            <InlineCode>client_address</InlineCode>, the current{" "}
+            <InlineCode>native_refresh_token</InlineCode>, and{" "}
+            <InlineCode>all_sessions=false</InlineCode> unless you intend to
+            revoke every session for that wallet.
+          </p>
         </ApiAuthSection>
 
         <ApiAuthSection
@@ -289,7 +293,11 @@ export default function ApiAuthenticationPage() {
           title={apiAuthGuideCopy.securityTitle}
         >
           <ul className="tw-mb-0 tw-grid tw-gap-3 tw-pl-5">
-            <li>{apiAuthGuideCopy.securitySignable}</li>
+            <li>
+              Sign only <InlineCode>signable_message</InlineCode> exactly as
+              returned. Do not trim, normalize, rebuild, JSON-stringify, or sign
+              a <InlineCode>nonce</InlineCode> field.
+            </li>
             <li>{apiAuthGuideCopy.securitySecrets}</li>
             <li>{apiAuthGuideCopy.securityStatus}</li>
           </ul>
@@ -308,7 +316,7 @@ export default function ApiAuthenticationPage() {
           <Col>
             <nav
               aria-label={apiAuthGuideCopy.relatedAriaLabel}
-              className="tw-flex tw-max-w-4xl tw-flex-wrap tw-gap-4 tw-text-sm"
+              className="tw-flex tw-w-full tw-flex-wrap tw-gap-4 tw-text-sm"
             >
               <Link
                 href="/tools/api"

--- a/app/tools/api/authentication/page.tsx
+++ b/app/tools/api/authentication/page.tsx
@@ -8,6 +8,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import {
+  ABOUT_TEXT_PAGE_CONTAINER_CLASS,
   AboutCol as Col,
   AboutContainer as Container,
   AboutRow as Row,
@@ -18,13 +19,11 @@ const API_REFERENCE_URL = "https://api.6529.io/docs/";
 
 const inlineCodeClass =
   "tw-rounded tw-bg-iron-900 tw-px-1.5 tw-py-0.5 tw-text-sm tw-text-iron-100";
-const pageContainerClass =
-  "tw-px-5 tw-pb-4 tw-pt-4 tw-text-white sm:tw-px-6 lg:tw-px-8";
-const sectionClass = "tw-max-w-4xl tw-text-base tw-leading-7 tw-text-white";
+const sectionClass = "tw-max-w-4xl tw-text-base tw-leading-7 tw-text-iron-50";
 const exampleSectionClass =
-  "tw-max-w-5xl tw-text-base tw-leading-7 tw-text-white";
+  "tw-max-w-5xl tw-text-base tw-leading-7 tw-text-iron-50";
 const sectionHeadingClass =
-  "tw-mb-3 tw-text-2xl tw-font-semibold tw-text-white";
+  "tw-mb-3 tw-text-2xl tw-font-semibold tw-text-iron-50";
 
 type ApiAuthSectionProps = Readonly<{
   children: ReactNode;
@@ -72,16 +71,14 @@ function AuthFlowStep({
   );
 }
 
-const nodeJsLoginExample = `import { Wallet } from "ethers";
+const nodeJsSessionExample = `import { Wallet } from "ethers";
 import fetch from "node-fetch";
 
 const API_BASE = "https://api.6529.io/api";
 
 async function assertOk(response, label) {
   if (!response.ok) {
-    throw new Error(
-      \`\${label} failed: \${response.status} \${response.statusText} - \${await response.text()}\`
-    );
+    throw new Error(\`\${label} failed with HTTP \${response.status}\`);
   }
 }
 
@@ -128,18 +125,6 @@ export async function loginAndFetchFeed() {
     session,
     feed: await feedResp.json(),
   };
-}`;
-
-const nodeJsRefreshExample = `import fetch from "node-fetch";
-
-const API_BASE = "https://api.6529.io/api";
-
-async function assertOk(response, label) {
-  if (!response.ok) {
-    throw new Error(
-      \`\${label} failed: \${response.status} \${response.statusText} - \${await response.text()}\`
-    );
-  }
 }
 
 export async function refreshNativeSession({ address, nativeRefreshToken }) {
@@ -183,7 +168,7 @@ export async function logoutNativeSession({ address, nativeRefreshToken }) {
 export default function ApiAuthenticationPage() {
   return (
     <main className={clsx(styles["main"], "tailwind-scope")}>
-      <Container className={pageContainerClass}>
+      <Container className={ABOUT_TEXT_PAGE_CONTAINER_CLASS}>
         <Row>
           <Col>
             <Link
@@ -193,13 +178,13 @@ export default function ApiAuthenticationPage() {
               {t(API_AUTH_LOCALE, "tools.api.authGuide.backToApi")}
             </Link>
             <header className="tw-max-w-4xl">
-              <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-white">
+              <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-50">
                 {t(API_AUTH_LOCALE, "tools.api.authGuide.eyebrow")}
               </p>
-              <h1 className="tw-mb-4 tw-text-3xl tw-font-semibold tw-leading-tight tw-text-white md:tw-text-4xl">
+              <h1 className="tw-mb-4 tw-text-3xl tw-font-semibold tw-leading-tight tw-text-iron-50 md:tw-text-4xl">
                 {t(API_AUTH_LOCALE, "tools.api.authGuide.title")}
               </h1>
-              <p className="tw-mb-0 tw-text-base tw-leading-7 tw-text-white">
+              <p className="tw-mb-0 tw-text-base tw-leading-7 tw-text-iron-50">
                 {t(API_AUTH_LOCALE, "tools.api.authGuide.lead")}
               </p>
             </header>
@@ -291,11 +276,7 @@ export default function ApiAuthenticationPage() {
           <p className="tw-mb-3">
             {t(API_AUTH_LOCALE, "tools.api.authGuide.examples.login")}
           </p>
-          <CodeExample code={nodeJsLoginExample} />
-          <p className="tw-mb-3 tw-mt-6">
-            {t(API_AUTH_LOCALE, "tools.api.authGuide.examples.refresh")}
-          </p>
-          <CodeExample code={nodeJsRefreshExample} />
+          <CodeExample code={nodeJsSessionExample} />
         </ApiAuthSection>
 
         <Row className="tw-pt-6">

--- a/app/tools/api/authentication/page.tsx
+++ b/app/tools/api/authentication/page.tsx
@@ -1,0 +1,354 @@
+import CodeExample from "@/components/code-example/CodeExample";
+import { getAppMetadata } from "@/components/providers/metadata";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
+import styles from "@/styles/Home.module.css";
+import clsx from "clsx";
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  AboutCol as Col,
+  AboutContainer as Container,
+  AboutRow as Row,
+} from "@/components/about/AboutLayout";
+
+const API_AUTH_LOCALE = DEFAULT_LOCALE;
+const API_REFERENCE_URL = "https://api.6529.io/docs/";
+
+const inlineCodeClass =
+  "tw-rounded tw-bg-iron-900 tw-px-1.5 tw-py-0.5 tw-text-sm tw-text-iron-100";
+
+const nodeJsLoginExample = `import { Wallet } from "ethers";
+import fetch from "node-fetch";
+
+const API_BASE = "https://api.6529.io/api";
+
+async function assertOk(response, label) {
+  if (!response.ok) {
+    throw new Error(
+      \`\${label} failed: \${response.status} \${response.statusText} - \${await response.text()}\`
+    );
+  }
+}
+
+export async function loginAndFetchFeed() {
+  const clientAddress = "0x...";
+  const clientPrivateKey = "0x..."; // Never hardcode private keys in production.
+  const wallet = new Wallet(clientPrivateKey);
+
+  const nonceResp = await fetch(
+    \`\${API_BASE}/auth/session-nonce?signer_address=\${clientAddress}&client_type=native&chain_id=1\`,
+    { headers: { accept: "application/json" } }
+  );
+  await assertOk(nonceResp, "session nonce");
+
+  const { signable_message, server_signature } = await nonceResp.json();
+  const clientSignature = await wallet.signMessage(signable_message);
+
+  const loginResp = await fetch(\`\${API_BASE}/auth/session-login\`, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      client_type: "native",
+      client_address: clientAddress,
+      client_signature: clientSignature,
+      server_signature,
+    }),
+  });
+  await assertOk(loginResp, "session login");
+
+  const session = await loginResp.json();
+
+  const feedResp = await fetch(\`\${API_BASE}/feed\`, {
+    headers: {
+      accept: "application/json",
+      authorization: \`Bearer \${session.access_token}\`,
+    },
+  });
+  await assertOk(feedResp, "feed");
+
+  return {
+    session,
+    feed: await feedResp.json(),
+  };
+}`;
+
+const nodeJsRefreshExample = `import fetch from "node-fetch";
+
+const API_BASE = "https://api.6529.io/api";
+
+async function assertOk(response, label) {
+  if (!response.ok) {
+    throw new Error(
+      \`\${label} failed: \${response.status} \${response.statusText} - \${await response.text()}\`
+    );
+  }
+}
+
+export async function refreshNativeSession({ address, nativeRefreshToken }) {
+  const response = await fetch(\`\${API_BASE}/auth/session-refresh\`, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      client_type: "native",
+      client_address: address,
+      native_refresh_token: nativeRefreshToken,
+    }),
+  });
+  await assertOk(response, "session refresh");
+
+  const refreshedSession = await response.json();
+
+  // Store refreshedSession.native_refresh_token over the previous refresh token.
+  return refreshedSession;
+}
+
+export async function logoutNativeSession({ address, nativeRefreshToken }) {
+  const response = await fetch(\`\${API_BASE}/auth/session-logout\`, {
+    method: "POST",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      client_type: "native",
+      client_address: address,
+      native_refresh_token: nativeRefreshToken,
+      all_sessions: false,
+    }),
+  });
+  await assertOk(response, "session logout");
+}`;
+
+export default function ApiAuthenticationPage() {
+  return (
+    <main className={clsx(styles["main"], "tailwind-scope")}>
+      <Container className="tw-pb-4 tw-pt-4">
+        <Row>
+          <Col>
+            <Link
+              href="/tools/api"
+              className="hover:tw-text-primary-200 tw-mb-5 tw-inline-flex tw-text-sm tw-font-semibold tw-text-primary-300 tw-no-underline"
+            >
+              {t(API_AUTH_LOCALE, "tools.api.authGuide.backToApi")}
+            </Link>
+            <header className="tw-max-w-4xl">
+              <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-400">
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.eyebrow")}
+              </p>
+              <h1 className="tw-mb-4 tw-text-3xl tw-font-semibold tw-leading-tight tw-text-iron-50 md:tw-text-4xl">
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.title")}
+              </h1>
+              <p className="tw-mb-0 tw-text-base tw-leading-7 tw-text-iron-300">
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.lead")}
+              </p>
+            </header>
+          </Col>
+        </Row>
+
+        <Row className="tw-pt-6">
+          <Col>
+            <section
+              className="tw-max-w-4xl tw-text-base tw-leading-7 tw-text-iron-300"
+              aria-labelledby="api-auth-overview-heading"
+            >
+              <h2
+                id="api-auth-overview-heading"
+                className="tw-mb-3 tw-text-2xl tw-font-semibold tw-text-iron-50"
+              >
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.overview.title")}
+              </h2>
+              <p className="tw-mb-3">
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.overview.preferred")}
+              </p>
+              <p className="tw-mb-0">
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.overview.legacy")}
+              </p>
+            </section>
+          </Col>
+        </Row>
+
+        <Row className="tw-pt-6">
+          <Col>
+            <section
+              className="tw-max-w-4xl tw-text-base tw-leading-7 tw-text-iron-300"
+              aria-labelledby="api-auth-flow-heading"
+            >
+              <h2
+                id="api-auth-flow-heading"
+                className="tw-mb-3 tw-text-2xl tw-font-semibold tw-text-iron-50"
+              >
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.flow.title")}
+              </h2>
+              <ol className="tw-grid tw-gap-3 tw-pl-5">
+                <li>
+                  {t(API_AUTH_LOCALE, "tools.api.authGuide.flow.nonce")}{" "}
+                  <code className={inlineCodeClass}>
+                    GET /api/auth/session-nonce
+                  </code>
+                  .
+                </li>
+                <li>
+                  {t(API_AUTH_LOCALE, "tools.api.authGuide.flow.sign")}{" "}
+                  <code className={inlineCodeClass}>signable_message</code>.
+                </li>
+                <li>
+                  {t(API_AUTH_LOCALE, "tools.api.authGuide.flow.login")}{" "}
+                  <code className={inlineCodeClass}>
+                    POST /api/auth/session-login
+                  </code>
+                  .
+                </li>
+                <li>
+                  {t(API_AUTH_LOCALE, "tools.api.authGuide.flow.bearer")}{" "}
+                  <code className={inlineCodeClass}>
+                    Authorization: Bearer &lt;access_token&gt;
+                  </code>
+                  .
+                </li>
+              </ol>
+            </section>
+          </Col>
+        </Row>
+
+        <Row className="tw-pt-6">
+          <Col>
+            <section
+              className="tw-max-w-4xl tw-text-base tw-leading-7 tw-text-iron-300"
+              aria-labelledby="api-auth-refresh-heading"
+            >
+              <h2
+                id="api-auth-refresh-heading"
+                className="tw-mb-3 tw-text-2xl tw-font-semibold tw-text-iron-50"
+              >
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.refresh.title")}
+              </h2>
+              <p className="tw-mb-3">
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.refresh.login")}
+              </p>
+              <p className="tw-mb-3">
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.refresh.rotate")}
+              </p>
+              <p className="tw-mb-0">
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.refresh.logout")}
+              </p>
+            </section>
+          </Col>
+        </Row>
+
+        <Row className="tw-pt-6">
+          <Col>
+            <section
+              className="tw-max-w-4xl tw-text-base tw-leading-7 tw-text-iron-300"
+              aria-labelledby="api-auth-browser-heading"
+            >
+              <h2
+                id="api-auth-browser-heading"
+                className="tw-mb-3 tw-text-2xl tw-font-semibold tw-text-iron-50"
+              >
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.browser.title")}
+              </h2>
+              <p className="tw-mb-0">
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.browser.note")}
+              </p>
+            </section>
+          </Col>
+        </Row>
+
+        <Row className="tw-pt-6">
+          <Col>
+            <section
+              className="tw-max-w-4xl tw-text-base tw-leading-7 tw-text-iron-300"
+              aria-labelledby="api-auth-security-heading"
+            >
+              <h2
+                id="api-auth-security-heading"
+                className="tw-mb-3 tw-text-2xl tw-font-semibold tw-text-iron-50"
+              >
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.security.title")}
+              </h2>
+              <ul className="tw-mb-0 tw-grid tw-gap-3 tw-pl-5">
+                <li>
+                  {t(API_AUTH_LOCALE, "tools.api.authGuide.security.signable")}
+                </li>
+                <li>
+                  {t(API_AUTH_LOCALE, "tools.api.authGuide.security.secrets")}
+                </li>
+                <li>
+                  {t(API_AUTH_LOCALE, "tools.api.authGuide.security.status")}
+                </li>
+              </ul>
+            </section>
+          </Col>
+        </Row>
+
+        <Row className="tw-pt-6">
+          <Col>
+            <section
+              className="tw-max-w-5xl tw-text-base tw-leading-7 tw-text-iron-300"
+              aria-labelledby="api-auth-examples-heading"
+            >
+              <h2
+                id="api-auth-examples-heading"
+                className="tw-mb-3 tw-text-2xl tw-font-semibold tw-text-iron-50"
+              >
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.examples.title")}
+              </h2>
+              <p className="tw-mb-3">
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.examples.login")}
+              </p>
+              <CodeExample code={nodeJsLoginExample} />
+              <p className="tw-mb-3 tw-mt-6">
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.examples.refresh")}
+              </p>
+              <CodeExample code={nodeJsRefreshExample} />
+            </section>
+          </Col>
+        </Row>
+
+        <Row className="tw-pt-6">
+          <Col>
+            <nav
+              aria-label={t(
+                API_AUTH_LOCALE,
+                "tools.api.authGuide.related.ariaLabel"
+              )}
+              className="tw-flex tw-max-w-4xl tw-flex-wrap tw-gap-4 tw-text-sm"
+            >
+              <Link
+                href="/tools/api"
+                className="hover:tw-text-primary-200 tw-font-semibold tw-text-primary-300 tw-no-underline"
+              >
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.related.api")}
+              </Link>
+              <a
+                href={API_REFERENCE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:tw-text-primary-200 tw-font-semibold tw-text-primary-300 tw-no-underline"
+              >
+                {t(API_AUTH_LOCALE, "tools.api.authGuide.related.reference")}
+              </a>
+            </nav>
+          </Col>
+        </Row>
+      </Container>
+    </main>
+  );
+}
+
+export function generateMetadata(): Metadata {
+  return getAppMetadata({
+    title: t(API_AUTH_LOCALE, "tools.api.authGuide.metadata.title"),
+    description: t(
+      API_AUTH_LOCALE,
+      "tools.api.authGuide.metadata.description"
+    ),
+  });
+}

--- a/app/tools/api/authentication/page.tsx
+++ b/app/tools/api/authentication/page.tsx
@@ -1,11 +1,12 @@
 import CodeExample from "@/components/code-example/CodeExample";
 import { getAppMetadata } from "@/components/providers/metadata";
 import { DEFAULT_LOCALE } from "@/i18n/locales";
-import { t } from "@/i18n/messages";
+import { t, type MessageKey } from "@/i18n/messages";
 import styles from "@/styles/Home.module.css";
 import clsx from "clsx";
 import type { Metadata } from "next";
 import Link from "next/link";
+import type { ReactNode } from "react";
 import {
   AboutCol as Col,
   AboutContainer as Container,
@@ -17,6 +18,59 @@ const API_REFERENCE_URL = "https://api.6529.io/docs/";
 
 const inlineCodeClass =
   "tw-rounded tw-bg-iron-900 tw-px-1.5 tw-py-0.5 tw-text-sm tw-text-iron-100";
+const pageContainerClass =
+  "tw-px-5 tw-pb-4 tw-pt-4 tw-text-white sm:tw-px-6 lg:tw-px-8";
+const sectionClass = "tw-max-w-4xl tw-text-base tw-leading-7 tw-text-white";
+const exampleSectionClass =
+  "tw-max-w-5xl tw-text-base tw-leading-7 tw-text-white";
+const sectionHeadingClass =
+  "tw-mb-3 tw-text-2xl tw-font-semibold tw-text-white";
+
+type ApiAuthSectionProps = Readonly<{
+  children: ReactNode;
+  headingId: string;
+  titleKey: MessageKey;
+  wide?: boolean;
+}>;
+
+function ApiAuthSection({
+  children,
+  headingId,
+  titleKey,
+  wide = false,
+}: ApiAuthSectionProps) {
+  return (
+    <Row className="tw-pt-6">
+      <Col>
+        <section
+          className={wide ? exampleSectionClass : sectionClass}
+          aria-labelledby={headingId}
+        >
+          <h2 id={headingId} className={sectionHeadingClass}>
+            {t(API_AUTH_LOCALE, titleKey)}
+          </h2>
+          {children}
+        </section>
+      </Col>
+    </Row>
+  );
+}
+
+function AuthFlowStep({
+  code,
+  messageKey,
+}: Readonly<{
+  code: string;
+  messageKey: MessageKey;
+}>) {
+  return (
+    <li className="tw-flex tw-flex-wrap tw-items-baseline tw-gap-x-1">
+      <span>{t(API_AUTH_LOCALE, messageKey)}</span>
+      <code className={inlineCodeClass}>{code}</code>
+      <span>.</span>
+    </li>
+  );
+}
 
 const nodeJsLoginExample = `import { Wallet } from "ethers";
 import fetch from "node-fetch";
@@ -129,7 +183,7 @@ export async function logoutNativeSession({ address, nativeRefreshToken }) {
 export default function ApiAuthenticationPage() {
   return (
     <main className={clsx(styles["main"], "tailwind-scope")}>
-      <Container className="tw-pb-4 tw-pt-4">
+      <Container className={pageContainerClass}>
         <Row>
           <Col>
             <Link
@@ -139,178 +193,110 @@ export default function ApiAuthenticationPage() {
               {t(API_AUTH_LOCALE, "tools.api.authGuide.backToApi")}
             </Link>
             <header className="tw-max-w-4xl">
-              <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-400">
+              <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-white">
                 {t(API_AUTH_LOCALE, "tools.api.authGuide.eyebrow")}
               </p>
-              <h1 className="tw-mb-4 tw-text-3xl tw-font-semibold tw-leading-tight tw-text-iron-50 md:tw-text-4xl">
+              <h1 className="tw-mb-4 tw-text-3xl tw-font-semibold tw-leading-tight tw-text-white md:tw-text-4xl">
                 {t(API_AUTH_LOCALE, "tools.api.authGuide.title")}
               </h1>
-              <p className="tw-mb-0 tw-text-base tw-leading-7 tw-text-iron-300">
+              <p className="tw-mb-0 tw-text-base tw-leading-7 tw-text-white">
                 {t(API_AUTH_LOCALE, "tools.api.authGuide.lead")}
               </p>
             </header>
           </Col>
         </Row>
 
-        <Row className="tw-pt-6">
-          <Col>
-            <section
-              className="tw-max-w-4xl tw-text-base tw-leading-7 tw-text-iron-300"
-              aria-labelledby="api-auth-overview-heading"
-            >
-              <h2
-                id="api-auth-overview-heading"
-                className="tw-mb-3 tw-text-2xl tw-font-semibold tw-text-iron-50"
-              >
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.overview.title")}
-              </h2>
-              <p className="tw-mb-3">
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.overview.preferred")}
-              </p>
-              <p className="tw-mb-0">
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.overview.legacy")}
-              </p>
-            </section>
-          </Col>
-        </Row>
+        <ApiAuthSection
+          headingId="api-auth-overview-heading"
+          titleKey="tools.api.authGuide.overview.title"
+        >
+          <p className="tw-mb-3">
+            {t(API_AUTH_LOCALE, "tools.api.authGuide.overview.preferred")}
+          </p>
+          <p className="tw-mb-0">
+            {t(API_AUTH_LOCALE, "tools.api.authGuide.overview.legacy")}
+          </p>
+        </ApiAuthSection>
 
-        <Row className="tw-pt-6">
-          <Col>
-            <section
-              className="tw-max-w-4xl tw-text-base tw-leading-7 tw-text-iron-300"
-              aria-labelledby="api-auth-flow-heading"
-            >
-              <h2
-                id="api-auth-flow-heading"
-                className="tw-mb-3 tw-text-2xl tw-font-semibold tw-text-iron-50"
-              >
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.flow.title")}
-              </h2>
-              <ol className="tw-grid tw-gap-3 tw-pl-5">
-                <li>
-                  {t(API_AUTH_LOCALE, "tools.api.authGuide.flow.nonce")}{" "}
-                  <code className={inlineCodeClass}>
-                    GET /api/auth/session-nonce
-                  </code>
-                  .
-                </li>
-                <li>
-                  {t(API_AUTH_LOCALE, "tools.api.authGuide.flow.sign")}{" "}
-                  <code className={inlineCodeClass}>signable_message</code>.
-                </li>
-                <li>
-                  {t(API_AUTH_LOCALE, "tools.api.authGuide.flow.login")}{" "}
-                  <code className={inlineCodeClass}>
-                    POST /api/auth/session-login
-                  </code>
-                  .
-                </li>
-                <li>
-                  {t(API_AUTH_LOCALE, "tools.api.authGuide.flow.bearer")}{" "}
-                  <code className={inlineCodeClass}>
-                    Authorization: Bearer &lt;access_token&gt;
-                  </code>
-                  .
-                </li>
-              </ol>
-            </section>
-          </Col>
-        </Row>
+        <ApiAuthSection
+          headingId="api-auth-flow-heading"
+          titleKey="tools.api.authGuide.flow.title"
+        >
+          <ol className="tw-grid tw-gap-3 tw-pl-5">
+            <AuthFlowStep
+              messageKey="tools.api.authGuide.flow.nonce"
+              code="GET /api/auth/session-nonce"
+            />
+            <AuthFlowStep
+              messageKey="tools.api.authGuide.flow.sign"
+              code="signable_message"
+            />
+            <AuthFlowStep
+              messageKey="tools.api.authGuide.flow.login"
+              code="POST /api/auth/session-login"
+            />
+            <AuthFlowStep
+              messageKey="tools.api.authGuide.flow.bearer"
+              code="Authorization: Bearer <access_token>"
+            />
+          </ol>
+        </ApiAuthSection>
 
-        <Row className="tw-pt-6">
-          <Col>
-            <section
-              className="tw-max-w-4xl tw-text-base tw-leading-7 tw-text-iron-300"
-              aria-labelledby="api-auth-refresh-heading"
-            >
-              <h2
-                id="api-auth-refresh-heading"
-                className="tw-mb-3 tw-text-2xl tw-font-semibold tw-text-iron-50"
-              >
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.refresh.title")}
-              </h2>
-              <p className="tw-mb-3">
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.refresh.login")}
-              </p>
-              <p className="tw-mb-3">
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.refresh.rotate")}
-              </p>
-              <p className="tw-mb-0">
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.refresh.logout")}
-              </p>
-            </section>
-          </Col>
-        </Row>
+        <ApiAuthSection
+          headingId="api-auth-refresh-heading"
+          titleKey="tools.api.authGuide.refresh.title"
+        >
+          <p className="tw-mb-3">
+            {t(API_AUTH_LOCALE, "tools.api.authGuide.refresh.login")}
+          </p>
+          <p className="tw-mb-3">
+            {t(API_AUTH_LOCALE, "tools.api.authGuide.refresh.rotate")}
+          </p>
+          <p className="tw-mb-0">
+            {t(API_AUTH_LOCALE, "tools.api.authGuide.refresh.logout")}
+          </p>
+        </ApiAuthSection>
 
-        <Row className="tw-pt-6">
-          <Col>
-            <section
-              className="tw-max-w-4xl tw-text-base tw-leading-7 tw-text-iron-300"
-              aria-labelledby="api-auth-browser-heading"
-            >
-              <h2
-                id="api-auth-browser-heading"
-                className="tw-mb-3 tw-text-2xl tw-font-semibold tw-text-iron-50"
-              >
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.browser.title")}
-              </h2>
-              <p className="tw-mb-0">
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.browser.note")}
-              </p>
-            </section>
-          </Col>
-        </Row>
+        <ApiAuthSection
+          headingId="api-auth-browser-heading"
+          titleKey="tools.api.authGuide.browser.title"
+        >
+          <p className="tw-mb-0">
+            {t(API_AUTH_LOCALE, "tools.api.authGuide.browser.note")}
+          </p>
+        </ApiAuthSection>
 
-        <Row className="tw-pt-6">
-          <Col>
-            <section
-              className="tw-max-w-4xl tw-text-base tw-leading-7 tw-text-iron-300"
-              aria-labelledby="api-auth-security-heading"
-            >
-              <h2
-                id="api-auth-security-heading"
-                className="tw-mb-3 tw-text-2xl tw-font-semibold tw-text-iron-50"
-              >
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.security.title")}
-              </h2>
-              <ul className="tw-mb-0 tw-grid tw-gap-3 tw-pl-5">
-                <li>
-                  {t(API_AUTH_LOCALE, "tools.api.authGuide.security.signable")}
-                </li>
-                <li>
-                  {t(API_AUTH_LOCALE, "tools.api.authGuide.security.secrets")}
-                </li>
-                <li>
-                  {t(API_AUTH_LOCALE, "tools.api.authGuide.security.status")}
-                </li>
-              </ul>
-            </section>
-          </Col>
-        </Row>
+        <ApiAuthSection
+          headingId="api-auth-security-heading"
+          titleKey="tools.api.authGuide.security.title"
+        >
+          <ul className="tw-mb-0 tw-grid tw-gap-3 tw-pl-5">
+            <li>
+              {t(API_AUTH_LOCALE, "tools.api.authGuide.security.signable")}
+            </li>
+            <li>
+              {t(API_AUTH_LOCALE, "tools.api.authGuide.security.secrets")}
+            </li>
+            <li>
+              {t(API_AUTH_LOCALE, "tools.api.authGuide.security.status")}
+            </li>
+          </ul>
+        </ApiAuthSection>
 
-        <Row className="tw-pt-6">
-          <Col>
-            <section
-              className="tw-max-w-5xl tw-text-base tw-leading-7 tw-text-iron-300"
-              aria-labelledby="api-auth-examples-heading"
-            >
-              <h2
-                id="api-auth-examples-heading"
-                className="tw-mb-3 tw-text-2xl tw-font-semibold tw-text-iron-50"
-              >
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.examples.title")}
-              </h2>
-              <p className="tw-mb-3">
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.examples.login")}
-              </p>
-              <CodeExample code={nodeJsLoginExample} />
-              <p className="tw-mb-3 tw-mt-6">
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.examples.refresh")}
-              </p>
-              <CodeExample code={nodeJsRefreshExample} />
-            </section>
-          </Col>
-        </Row>
+        <ApiAuthSection
+          headingId="api-auth-examples-heading"
+          titleKey="tools.api.authGuide.examples.title"
+          wide
+        >
+          <p className="tw-mb-3">
+            {t(API_AUTH_LOCALE, "tools.api.authGuide.examples.login")}
+          </p>
+          <CodeExample code={nodeJsLoginExample} />
+          <p className="tw-mb-3 tw-mt-6">
+            {t(API_AUTH_LOCALE, "tools.api.authGuide.examples.refresh")}
+          </p>
+          <CodeExample code={nodeJsRefreshExample} />
+        </ApiAuthSection>
 
         <Row className="tw-pt-6">
           <Col>

--- a/app/tools/api/authentication/page.tsx
+++ b/app/tools/api/authentication/page.tsx
@@ -16,6 +16,7 @@ import {
 
 const API_AUTH_LOCALE = DEFAULT_LOCALE;
 const API_REFERENCE_URL = "https://api.6529.io/docs/";
+const FLOW_CODE_PLACEHOLDER = "__API_AUTH_FLOW_CODE__";
 
 const inlineCodeClass =
   "tw-rounded tw-bg-iron-900 tw-px-1.5 tw-py-0.5 tw-text-sm tw-text-iron-100";
@@ -62,11 +63,17 @@ function AuthFlowStep({
   code: string;
   messageKey: MessageKey;
 }>) {
+  const message = t(API_AUTH_LOCALE, messageKey, {
+    code: FLOW_CODE_PLACEHOLDER,
+  });
+  const [beforeCode = "", afterCode = ""] =
+    message.split(FLOW_CODE_PLACEHOLDER);
+
   return (
-    <li className="tw-flex tw-flex-wrap tw-items-baseline tw-gap-x-1">
-      <span>{t(API_AUTH_LOCALE, messageKey)}</span>
+    <li>
+      {beforeCode}
       <code className={inlineCodeClass}>{code}</code>
-      <span>.</span>
+      {afterCode}
     </li>
   );
 }

--- a/app/tools/api/authentication/page.tsx
+++ b/app/tools/api/authentication/page.tsx
@@ -1,7 +1,5 @@
 import CodeExample from "@/components/code-example/CodeExample";
 import { getAppMetadata } from "@/components/providers/metadata";
-import { DEFAULT_LOCALE } from "@/i18n/locales";
-import { t, type MessageKey } from "@/i18n/messages";
 import styles from "@/styles/Home.module.css";
 import clsx from "clsx";
 import type { Metadata } from "next";
@@ -14,7 +12,6 @@ import {
   AboutRow as Row,
 } from "@/components/about/AboutLayout";
 
-const API_AUTH_LOCALE = DEFAULT_LOCALE;
 const API_REFERENCE_URL = "https://api.6529.io/docs/";
 const FLOW_CODE_PLACEHOLDER = "__API_AUTH_FLOW_CODE__";
 
@@ -29,14 +26,14 @@ const sectionHeadingClass =
 type ApiAuthSectionProps = Readonly<{
   children: ReactNode;
   headingId: string;
-  titleKey: MessageKey;
+  title: string;
   wide?: boolean;
 }>;
 
 function ApiAuthSection({
   children,
   headingId,
-  titleKey,
+  title,
   wide = false,
 }: ApiAuthSectionProps) {
   return (
@@ -47,7 +44,7 @@ function ApiAuthSection({
           aria-labelledby={headingId}
         >
           <h2 id={headingId} className={sectionHeadingClass}>
-            {t(API_AUTH_LOCALE, titleKey)}
+            {title}
           </h2>
           {children}
         </section>
@@ -58,14 +55,11 @@ function ApiAuthSection({
 
 function AuthFlowStep({
   code,
-  messageKey,
+  message,
 }: Readonly<{
   code: string;
-  messageKey: MessageKey;
+  message: string;
 }>) {
-  const message = t(API_AUTH_LOCALE, messageKey, {
-    code: FLOW_CODE_PLACEHOLDER,
-  });
   const [beforeCode = "", afterCode = ""] =
     message.split(FLOW_CODE_PLACEHOLDER);
 
@@ -77,6 +71,50 @@ function AuthFlowStep({
     </li>
   );
 }
+
+const apiAuthGuideCopy = {
+  metadataTitle: "API Authentication",
+  metadataDescription:
+    "External-client session-v2 wallet authentication for the 6529 API.",
+  backToApi: "Back to API",
+  eyebrow: "API Authentication",
+  title: "External Client Authentication",
+  lead:
+    "Use session-v2 wallet authentication when building scripts, services, and other external clients against the 6529 API.",
+  overviewTitle: "What to use",
+  overviewPreferred:
+    "New external clients should authenticate through session-v2 endpoints. The standard external-client mode is client_type=native, even when the client is a command-line script or backend service controlled by the wallet owner.",
+  overviewLegacy:
+    "The older nonce, login, and redeem-refresh-token endpoints remain compatibility endpoints for older clients. New integrations should not start on those legacy endpoints.",
+  flowTitle: "Login flow",
+  flowNonce: `Request a signable message with signer_address, client_type=native, and chain_id=1 from ${FLOW_CODE_PLACEHOLDER}.`,
+  flowSign: `Sign the returned message exactly as returned in ${FLOW_CODE_PLACEHOLDER}.`,
+  flowLogin: `Send client_type, client_address, client_signature, server_signature, and optional role to ${FLOW_CODE_PLACEHOLDER}.`,
+  flowBearer: `Use the returned access token on protected API calls as ${FLOW_CODE_PLACEHOLDER}.`,
+  refreshTitle: "Refresh and logout",
+  refreshLogin:
+    "Native/script login returns an access_token for bearer auth plus a native_refresh_token and refresh_token_expires_at for long-running clients.",
+  refreshRotate:
+    "Refresh through POST /api/auth/session-refresh with client_type=native, client_address, and the current native_refresh_token. A successful refresh rotates the native refresh token, so replace the stored token with the new one immediately.",
+  refreshLogout:
+    "Logout through POST /api/auth/session-logout with client_type=native, client_address, the current native_refresh_token, and all_sessions=false unless you intend to revoke every session for that wallet.",
+  browserTitle: "Browser clients",
+  browserNote:
+    "This guide is for external clients. First-party browser sessions also use session-v2, but browser refresh state is handled with backend-owned HttpOnly cookies, credentials-included requests, and origin checks. Follow the app implementation rather than adapting the native/script examples directly for browser sessions.",
+  securityTitle: "Security rules",
+  securitySignable:
+    "Sign only signable_message exactly as returned. Do not trim, normalize, rebuild, JSON-stringify, or sign a nonce field.",
+  securitySecrets:
+    "Do not log private keys, access tokens, refresh tokens, signatures, or raw authentication responses. Store refresh tokens in a secret store appropriate for the client environment.",
+  securityStatus:
+    "Check response status codes before trusting JSON payloads, and treat authentication errors as requiring a fresh wallet signature or a clean re-login.",
+  examplesTitle: "Node.js examples",
+  examplesLogin:
+    "This example requests a native session-v2 challenge, signs it, calls a protected endpoint with bearer auth, refreshes the session, and logs out.",
+  relatedAriaLabel: "Related API authentication links",
+  relatedApi: "API overview",
+  relatedReference: "Full API reference",
+} as const;
 
 const nodeJsSessionExample = `import { Wallet } from "ethers";
 import fetch from "node-fetch";
@@ -182,17 +220,17 @@ export default function ApiAuthenticationPage() {
               href="/tools/api"
               className="hover:tw-text-primary-200 tw-mb-5 tw-inline-flex tw-text-sm tw-font-semibold tw-text-primary-300 tw-no-underline"
             >
-              {t(API_AUTH_LOCALE, "tools.api.authGuide.backToApi")}
+              {apiAuthGuideCopy.backToApi}
             </Link>
             <header className="tw-max-w-4xl">
               <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-50">
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.eyebrow")}
+                {apiAuthGuideCopy.eyebrow}
               </p>
               <h1 className="tw-mb-4 tw-text-3xl tw-font-semibold tw-leading-tight tw-text-iron-50 md:tw-text-4xl">
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.title")}
+                {apiAuthGuideCopy.title}
               </h1>
               <p className="tw-mb-0 tw-text-base tw-leading-7 tw-text-iron-50">
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.lead")}
+                {apiAuthGuideCopy.lead}
               </p>
             </header>
           </Col>
@@ -200,35 +238,31 @@ export default function ApiAuthenticationPage() {
 
         <ApiAuthSection
           headingId="api-auth-overview-heading"
-          titleKey="tools.api.authGuide.overview.title"
+          title={apiAuthGuideCopy.overviewTitle}
         >
-          <p className="tw-mb-3">
-            {t(API_AUTH_LOCALE, "tools.api.authGuide.overview.preferred")}
-          </p>
-          <p className="tw-mb-0">
-            {t(API_AUTH_LOCALE, "tools.api.authGuide.overview.legacy")}
-          </p>
+          <p className="tw-mb-3">{apiAuthGuideCopy.overviewPreferred}</p>
+          <p className="tw-mb-0">{apiAuthGuideCopy.overviewLegacy}</p>
         </ApiAuthSection>
 
         <ApiAuthSection
           headingId="api-auth-flow-heading"
-          titleKey="tools.api.authGuide.flow.title"
+          title={apiAuthGuideCopy.flowTitle}
         >
           <ol className="tw-grid tw-gap-3 tw-pl-5">
             <AuthFlowStep
-              messageKey="tools.api.authGuide.flow.nonce"
+              message={apiAuthGuideCopy.flowNonce}
               code="GET /api/auth/session-nonce"
             />
             <AuthFlowStep
-              messageKey="tools.api.authGuide.flow.sign"
+              message={apiAuthGuideCopy.flowSign}
               code="signable_message"
             />
             <AuthFlowStep
-              messageKey="tools.api.authGuide.flow.login"
+              message={apiAuthGuideCopy.flowLogin}
               code="POST /api/auth/session-login"
             />
             <AuthFlowStep
-              messageKey="tools.api.authGuide.flow.bearer"
+              message={apiAuthGuideCopy.flowBearer}
               code="Authorization: Bearer <access_token>"
             />
           </ol>
@@ -236,70 +270,51 @@ export default function ApiAuthenticationPage() {
 
         <ApiAuthSection
           headingId="api-auth-refresh-heading"
-          titleKey="tools.api.authGuide.refresh.title"
+          title={apiAuthGuideCopy.refreshTitle}
         >
-          <p className="tw-mb-3">
-            {t(API_AUTH_LOCALE, "tools.api.authGuide.refresh.login")}
-          </p>
-          <p className="tw-mb-3">
-            {t(API_AUTH_LOCALE, "tools.api.authGuide.refresh.rotate")}
-          </p>
-          <p className="tw-mb-0">
-            {t(API_AUTH_LOCALE, "tools.api.authGuide.refresh.logout")}
-          </p>
+          <p className="tw-mb-3">{apiAuthGuideCopy.refreshLogin}</p>
+          <p className="tw-mb-3">{apiAuthGuideCopy.refreshRotate}</p>
+          <p className="tw-mb-0">{apiAuthGuideCopy.refreshLogout}</p>
         </ApiAuthSection>
 
         <ApiAuthSection
           headingId="api-auth-browser-heading"
-          titleKey="tools.api.authGuide.browser.title"
+          title={apiAuthGuideCopy.browserTitle}
         >
-          <p className="tw-mb-0">
-            {t(API_AUTH_LOCALE, "tools.api.authGuide.browser.note")}
-          </p>
+          <p className="tw-mb-0">{apiAuthGuideCopy.browserNote}</p>
         </ApiAuthSection>
 
         <ApiAuthSection
           headingId="api-auth-security-heading"
-          titleKey="tools.api.authGuide.security.title"
+          title={apiAuthGuideCopy.securityTitle}
         >
           <ul className="tw-mb-0 tw-grid tw-gap-3 tw-pl-5">
-            <li>
-              {t(API_AUTH_LOCALE, "tools.api.authGuide.security.signable")}
-            </li>
-            <li>
-              {t(API_AUTH_LOCALE, "tools.api.authGuide.security.secrets")}
-            </li>
-            <li>
-              {t(API_AUTH_LOCALE, "tools.api.authGuide.security.status")}
-            </li>
+            <li>{apiAuthGuideCopy.securitySignable}</li>
+            <li>{apiAuthGuideCopy.securitySecrets}</li>
+            <li>{apiAuthGuideCopy.securityStatus}</li>
           </ul>
         </ApiAuthSection>
 
         <ApiAuthSection
           headingId="api-auth-examples-heading"
-          titleKey="tools.api.authGuide.examples.title"
+          title={apiAuthGuideCopy.examplesTitle}
           wide
         >
-          <p className="tw-mb-3">
-            {t(API_AUTH_LOCALE, "tools.api.authGuide.examples.login")}
-          </p>
+          <p className="tw-mb-3">{apiAuthGuideCopy.examplesLogin}</p>
           <CodeExample code={nodeJsSessionExample} />
         </ApiAuthSection>
 
         <Row className="tw-pt-6">
           <Col>
             <nav
-              aria-label={t(
-                API_AUTH_LOCALE,
-                "tools.api.authGuide.related.ariaLabel"
-              )}
+              aria-label={apiAuthGuideCopy.relatedAriaLabel}
               className="tw-flex tw-max-w-4xl tw-flex-wrap tw-gap-4 tw-text-sm"
             >
               <Link
                 href="/tools/api"
                 className="hover:tw-text-primary-200 tw-font-semibold tw-text-primary-300 tw-no-underline"
               >
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.related.api")}
+                {apiAuthGuideCopy.relatedApi}
               </Link>
               <a
                 href={API_REFERENCE_URL}
@@ -307,7 +322,7 @@ export default function ApiAuthenticationPage() {
                 rel="noopener noreferrer"
                 className="hover:tw-text-primary-200 tw-font-semibold tw-text-primary-300 tw-no-underline"
               >
-                {t(API_AUTH_LOCALE, "tools.api.authGuide.related.reference")}
+                {apiAuthGuideCopy.relatedReference}
               </a>
             </nav>
           </Col>
@@ -319,10 +334,7 @@ export default function ApiAuthenticationPage() {
 
 export function generateMetadata(): Metadata {
   return getAppMetadata({
-    title: t(API_AUTH_LOCALE, "tools.api.authGuide.metadata.title"),
-    description: t(
-      API_AUTH_LOCALE,
-      "tools.api.authGuide.metadata.description"
-    ),
+    title: apiAuthGuideCopy.metadataTitle,
+    description: apiAuthGuideCopy.metadataDescription,
   });
 }

--- a/app/tools/api/page.tsx
+++ b/app/tools/api/page.tsx
@@ -3,7 +3,9 @@ import { getAppMetadata } from "@/components/providers/metadata";
 import { DEFAULT_LOCALE } from "@/i18n/locales";
 import { t } from "@/i18n/messages";
 import styles from "@/styles/Home.module.css";
+import clsx from "clsx";
 import type { Metadata } from "next";
+import Link from "next/link";
 import {
   AboutCol as Col,
   AboutContainer as Container,
@@ -11,9 +13,9 @@ import {
 } from "@/components/about/AboutLayout";
 
 const API_PAGE_LOCALE = DEFAULT_LOCALE;
+const API_AUTHENTICATION_PATH = "/tools/api/authentication";
 
-export default function AboutApi() {
-  const nodeJsAuthExample = `import { Wallet } from 'ethers';
+const nodeJsAuthExample = `import { Wallet } from 'ethers';
 import fetch from 'node-fetch';
 
 export async function loginAndFetchFeed() {
@@ -23,7 +25,7 @@ export async function loginAndFetchFeed() {
   // Rebuild wallet from private key
   const wallet = new Wallet(clientPrivateKey);
 
-  // 1. Get the session-v2 signable message from the server
+  // 1. Get the native/script session-v2 signable message from the server
   const nonceResp = await fetch(
     \`https://api.6529.io/api/auth/session-nonce?signer_address=\${clientAddress}&client_type=native&chain_id=1\`,
     {
@@ -70,7 +72,7 @@ export async function loginAndFetchFeed() {
   console.log('Feed:', feed);
 }`;
 
-  const nodeJsMediaDropExample = `import fetch from "node-fetch";
+const nodeJsMediaDropExample = `import fetch from "node-fetch";
 import {readFile} from "fs/promises";
 import {extname} from "path";
 import mime from "mime-types";
@@ -243,8 +245,10 @@ run().catch((err) => {
     console.error("Error:", err);
     process.exit(1);
 });`;
+
+export default function AboutApi() {
   return (
-    <main className={`${styles["main"]} tailwind-scope`}>
+    <main className={clsx(styles["main"], "tailwind-scope")}>
       <Container className="tw-pb-4 tw-pt-4">
         <Row>
           <Col>
@@ -288,6 +292,31 @@ run().catch((err) => {
               ℹ️ Some routes are still undocumented. We plan to expand the
               documentation over time.
             </div>
+          </Col>
+        </Row>
+
+        <Row className="tw-pt-2">
+          <Col>
+            <section
+              aria-labelledby="api-authentication-guide-heading"
+              className="tw-mb-4 tw-rounded tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-950/50 tw-p-4"
+            >
+              <h2
+                id="api-authentication-guide-heading"
+                className="tw-mb-2 tw-text-lg tw-font-bold tw-text-iron-50"
+              >
+                {t(API_PAGE_LOCALE, "tools.api.authCallout.title")}
+              </h2>
+              <p className="tw-mb-3">
+                {t(API_PAGE_LOCALE, "tools.api.authCallout.description")}
+              </p>
+              <Link
+                href={API_AUTHENTICATION_PATH}
+                className="hover:tw-text-primary-200 tw-font-semibold tw-text-primary-300 tw-no-underline"
+              >
+                {t(API_PAGE_LOCALE, "tools.api.authCallout.link")}
+              </Link>
+            </section>
           </Col>
         </Row>
 
@@ -359,6 +388,15 @@ run().catch((err) => {
             <p>
               {t(API_PAGE_LOCALE, "tools.api.authentication.basedOnSignatures")}
             </p>
+            <p>
+              {t(API_PAGE_LOCALE, "tools.api.authentication.externalNote")}{" "}
+              <Link
+                href={API_AUTHENTICATION_PATH}
+                className="hover:tw-text-primary-200 tw-font-semibold tw-text-primary-300 tw-no-underline"
+              >
+                {t(API_PAGE_LOCALE, "tools.api.authentication.fullGuideLink")}
+              </Link>
+            </p>
 
             <p>{t(API_PAGE_LOCALE, "tools.api.authentication.flowIntro")}</p>
 
@@ -408,7 +446,7 @@ run().catch((err) => {
                 previous steps and keep the ETags from responses
               </li>
               <li>
-                When all parts have finished uploading, complete the upload bt
+                When all parts have finished uploading, complete the upload by
                 supplying the ETags to our API
               </li>
               <li>
@@ -426,6 +464,6 @@ run().catch((err) => {
   );
 }
 
-export async function generateMetadata(): Promise<Metadata> {
+export function generateMetadata(): Metadata {
   return getAppMetadata({ title: "API", description: "API" });
 }

--- a/app/tools/api/page.tsx
+++ b/app/tools/api/page.tsx
@@ -7,6 +7,7 @@ import clsx from "clsx";
 import type { Metadata } from "next";
 import Link from "next/link";
 import {
+  ABOUT_TEXT_PAGE_CONTAINER_CLASS,
   AboutCol as Col,
   AboutContainer as Container,
   AboutRow as Row,
@@ -14,65 +15,6 @@ import {
 
 const API_PAGE_LOCALE = DEFAULT_LOCALE;
 const API_AUTHENTICATION_PATH = "/tools/api/authentication";
-const pageContainerClass =
-  "tw-px-5 tw-pb-4 tw-pt-4 tw-text-white sm:tw-px-6 lg:tw-px-8";
-
-const nodeJsAuthExample = `import { Wallet } from 'ethers';
-import fetch from 'node-fetch';
-
-export async function loginAndFetchFeed() {
-  const clientAddress = '0x...';
-  const clientPrivateKey = '0x...'; // ⚠️ Do not hardcode private keys in production!
-
-  // Rebuild wallet from private key
-  const wallet = new Wallet(clientPrivateKey);
-
-  // 1. Get the native/script session-v2 signable message from the server
-  const nonceResp = await fetch(
-    \`https://api.6529.io/api/auth/session-nonce?signer_address=\${clientAddress}&client_type=native&chain_id=1\`,
-    {
-      headers: { accept: 'application/json' },
-      method: 'GET'
-    }
-  );
-
-  const { signable_message, server_signature } = await nonceResp.json();
-
-  // 2. Sign signable_message exactly as returned
-  const clientSignature = await wallet.signMessage(signable_message);
-
-  // 3. Send the signed message back to the session-v2 login endpoint
-  const loginResp = await fetch(
-    'https://api.6529.io/api/auth/session-login',
-    {
-      headers: {
-        accept: 'application/json',
-        'content-type': 'application/json'
-      },
-      method: 'POST',
-      body: JSON.stringify({
-        client_type: 'native',
-        client_address: clientAddress,
-        client_signature: clientSignature,
-        server_signature
-      })
-    }
-  );
-
-  const { access_token } = await loginResp.json();
-
-  // 4. Fetch feed with the received authorization token
-  const feedResp = await fetch('https://api.6529.io/api/feed', {
-    headers: {
-      accept: 'application/json',
-      authorization: \`Bearer \${access_token}\`
-    },
-    method: 'GET'
-  });
-
-  const feed = await feedResp.json();
-  console.log('Feed:', feed);
-}`;
 
 const nodeJsMediaDropExample = `import fetch from "node-fetch";
 import {readFile} from "fs/promises";
@@ -251,7 +193,7 @@ run().catch((err) => {
 export default function AboutApi() {
   return (
     <main className={clsx(styles["main"], "tailwind-scope")}>
-      <Container className={pageContainerClass}>
+      <Container className={ABOUT_TEXT_PAGE_CONTAINER_CLASS}>
         <Row>
           <Col>
             <h1>6529.io API</h1>
@@ -419,9 +361,6 @@ export default function AboutApi() {
                 {t(API_PAGE_LOCALE, "tools.api.authentication.receiveToken")}
               </li>
             </ol>
-            <p>{t(API_PAGE_LOCALE, "tools.api.authentication.nodeExample")}</p>
-
-            <CodeExample code={nodeJsAuthExample} />
           </Col>
         </Row>
         <Row className="tw-pt-2">

--- a/app/tools/api/page.tsx
+++ b/app/tools/api/page.tsx
@@ -193,7 +193,7 @@ run().catch((err) => {
 export default function AboutApi() {
   return (
     <main className={clsx(styles["main"], "tailwind-scope")}>
-      <Container className={ABOUT_TEXT_PAGE_CONTAINER_CLASS}>
+      <Container fluid className={ABOUT_TEXT_PAGE_CONTAINER_CLASS}>
         <Row>
           <Col>
             <h1>6529.io API</h1>

--- a/app/tools/api/page.tsx
+++ b/app/tools/api/page.tsx
@@ -14,6 +14,8 @@ import {
 
 const API_PAGE_LOCALE = DEFAULT_LOCALE;
 const API_AUTHENTICATION_PATH = "/tools/api/authentication";
+const pageContainerClass =
+  "tw-px-5 tw-pb-4 tw-pt-4 tw-text-white sm:tw-px-6 lg:tw-px-8";
 
 const nodeJsAuthExample = `import { Wallet } from 'ethers';
 import fetch from 'node-fetch';
@@ -249,7 +251,7 @@ run().catch((err) => {
 export default function AboutApi() {
   return (
     <main className={clsx(styles["main"], "tailwind-scope")}>
-      <Container className="tw-pb-4 tw-pt-4">
+      <Container className={pageContainerClass}>
         <Row>
           <Col>
             <h1>6529.io API</h1>

--- a/components/about/About.tsx
+++ b/components/about/About.tsx
@@ -43,7 +43,7 @@ export default function About({ section }: { readonly section: AboutSection }) {
   );
 
   return (
-    <Container className="tw-pt-2">
+    <Container fluid={section === AboutSection.TECH} className="tw-pt-2">
       <Row>
         <Col>
           <AboutContentsDropdown

--- a/components/about/AboutLayout.tsx
+++ b/components/about/AboutLayout.tsx
@@ -3,6 +3,9 @@ import type { HTMLAttributes, TableHTMLAttributes } from "react";
 
 import styles from "./AboutLayout.module.css";
 
+export const ABOUT_TEXT_PAGE_CONTAINER_CLASS =
+  "tw-px-5 tw-pb-4 tw-pt-4 tw-text-iron-50 sm:tw-px-6 lg:tw-px-8";
+
 type AboutContainerProps = HTMLAttributes<HTMLDivElement> & {
   readonly fluid?: boolean;
 };

--- a/components/about/tech/AboutTech.tsx
+++ b/components/about/tech/AboutTech.tsx
@@ -15,15 +15,15 @@ export default function AboutTech() {
   const locale = DEFAULT_LOCALE;
 
   return (
-    <div className="tw-flex tw-flex-col tw-gap-10 tw-px-4 tw-text-iron-200 sm:tw-px-6 lg:tw-px-8">
+    <div className="tw-flex tw-w-full tw-flex-col tw-gap-10 tw-px-4 tw-text-iron-50 sm:tw-px-6 lg:tw-px-8">
       <section className="tw-pb-2">
-        <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-400">
+        <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-50">
           About / Tech
         </p>
         <h1 className="tw-mb-4 tw-text-3xl tw-font-semibold tw-leading-tight tw-text-iron-50 md:tw-text-4xl">
           Tech Updates
         </h1>
-        <div className="tw-flex tw-max-w-4xl tw-flex-col tw-gap-5 tw-text-base tw-leading-7 tw-text-iron-300">
+        <div className="tw-flex tw-w-full tw-flex-col tw-gap-5 tw-text-base tw-leading-7 tw-text-iron-50">
           <p className="tw-mb-0">
             This is a current casual area for longer 6529 tech updates: repo
             work, bot notes, release context, and build reports that are too
@@ -50,7 +50,7 @@ export default function AboutTech() {
         </div>
       </section>
 
-      <section className="tw-max-w-6xl" aria-labelledby="tech-notes-heading">
+      <section className="tw-w-full" aria-labelledby="tech-notes-heading">
         <h2
           id="tech-notes-heading"
           className="tw-mb-5 tw-text-2xl tw-font-semibold tw-text-iron-50"
@@ -65,23 +65,23 @@ export default function AboutTech() {
             "about.tech.notes.walletAuthentication.ariaLabel"
           )}
         >
-          <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-400">
+          <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-50">
             Auth changes
           </p>
           <h3 className="tw-mb-2 tw-text-xl tw-font-semibold tw-leading-snug tw-text-iron-50">
             Wallet authentication upgrade
           </h3>
-          <p className="tw-mb-0 tw-max-w-3xl tw-text-sm tw-leading-6 tw-text-iron-300">
+          <p className="tw-mb-0 tw-text-sm tw-leading-6 tw-text-iron-50">
             What is changing with the new secure session, why users may be asked
             to upgrade, and what to expect during rollout.
           </p>
         </Link>
       </section>
 
-      <section className="tw-max-w-6xl" aria-labelledby="tech-reports-heading">
+      <section className="tw-w-full" aria-labelledby="tech-reports-heading">
         <div className="tw-mb-5 tw-flex tw-flex-col tw-gap-2 sm:tw-flex-row sm:tw-items-end sm:tw-justify-between">
           <div>
-            <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-400">
+            <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-50">
               Index
             </p>
             <h2
@@ -107,7 +107,7 @@ export default function AboutTech() {
               <li key={report.slug}>
                 <div className="tw-grid tw-gap-0 md:tw-grid-cols-[minmax(0,1fr)_12rem]">
                   <div className="tw-p-5">
-                    <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-400">
+                    <p className="tw-mb-2 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-50">
                       {report.dateLabel}
                     </p>
                     <h3 className="tw-mb-2 tw-text-xl tw-font-semibold tw-leading-snug tw-text-iron-50">
@@ -118,7 +118,7 @@ export default function AboutTech() {
                         {report.title}
                       </Link>
                     </h3>
-                    <p className="tw-mb-0 tw-max-w-3xl tw-text-sm tw-leading-6 tw-text-iron-300">
+                    <p className="tw-mb-0 tw-text-sm tw-leading-6 tw-text-iron-50">
                       {report.description}
                     </p>
                   </div>
@@ -126,7 +126,7 @@ export default function AboutTech() {
                     <p className="tw-mb-1 tw-text-3xl tw-font-semibold tw-leading-none tw-text-iron-50">
                       {formatInteger(locale, getTechReportTotal(report))}
                     </p>
-                    <p className="tw-mb-0 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-400">
+                    <p className="tw-mb-0 tw-text-xs tw-font-semibold tw-uppercase tw-leading-4 tw-text-iron-50">
                       {t(locale, "about.tech.index.prsCovered")}
                     </p>
                   </div>

--- a/components/code-example/CodeExample.tsx
+++ b/components/code-example/CodeExample.tsx
@@ -3,7 +3,7 @@
 import hljs from "highlight.js/lib/core";
 import javascript from "highlight.js/lib/languages/javascript";
 import "highlight.js/styles/vs2015.css";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { Tooltip } from "react-tooltip";
 
 interface CodeExampleProps {
@@ -13,6 +13,8 @@ interface CodeExampleProps {
 export default function CodeExample({ code }: CodeExampleProps) {
   const [copied, setCopied] = useState(false);
   const codeRef = useRef<HTMLElement>(null);
+  const reactId = useId();
+  const tooltipId = `copy-code-tooltip-${reactId.replace(/:/g, "")}`;
 
   useEffect(() => {
     hljs.registerLanguage("javascript", javascript);
@@ -29,40 +31,30 @@ export default function CodeExample({ code }: CodeExampleProps) {
   };
 
   return (
-    <div className="position-relative">
+    <div className="tw-relative">
       <pre
-        className="p-3 rounded"
-        style={{
-          backgroundColor: "rgb(26, 26, 26)",
-          border: "1px solid rgb(44, 44, 44)",
-          overflow: "auto",
-        }}>
+        className="tw-mb-4 tw-overflow-auto tw-rounded tw-border tw-border-solid tw-border-iron-800 tw-bg-iron-950 tw-p-3 tw-pr-20"
+      >
         <code ref={codeRef} className="language-javascript">
           {code}
         </code>
       </pre>
       <button
-        className="tw-absolute tw-rounded tw-px-2 tw-py-1"
-        style={{
-          top: "8px",
-          right: "8px",
-          backgroundColor: "rgba(68, 68, 68, 0.8)",
-          border: "1px solid rgb(88, 88, 88)",
-          color: "white",
-          fontSize: "0.75rem",
-        }}
+        className="tw-absolute tw-right-2 tw-top-2 tw-rounded tw-border tw-border-solid tw-border-iron-700 tw-bg-iron-800/90 tw-px-2 tw-py-1 tw-text-xs tw-font-semibold tw-text-iron-50 tw-shadow-sm hover:tw-bg-iron-700 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-primary-400"
         onClick={copyToClipboard}
-        data-tooltip-id="copy-code-tooltip">
+        data-tooltip-id={tooltipId}
+      >
         {copied ? "Copied!" : "Copy"}
       </button>
       <Tooltip
-        id="copy-code-tooltip"
+        id={tooltipId}
         place="top"
         style={{
           backgroundColor: "#1F2937",
           color: "white",
           padding: "4px 8px",
-        }}>
+        }}
+      >
         <span className="tw-text-xs">{copied ? "Copied!" : "Copy code"}</span>
       </Tooltip>
     </div>

--- a/components/code-example/CodeExample.tsx
+++ b/components/code-example/CodeExample.tsx
@@ -14,7 +14,7 @@ export default function CodeExample({ code }: CodeExampleProps) {
   const [copied, setCopied] = useState(false);
   const codeRef = useRef<HTMLElement>(null);
   const reactId = useId();
-  const tooltipId = `copy-code-tooltip-${reactId.replace(/:/g, "")}`;
+  const tooltipId = `copy-code-tooltip-${reactId.replaceAll(":", "")}`;
 
   useEffect(() => {
     hljs.registerLanguage("javascript", javascript);

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -733,6 +733,10 @@ const ABOUT_TECH_MESSAGES = objectMessages("about.tech", {
   "walletAuth.same.assets": "You do not need to move tokens or assets.",
   "walletAuth.same.desktop":
     "The 6529 Desktop app continues using the existing connection flow during this rollout.",
+  "walletAuth.builders.title": "Building with the API",
+  "walletAuth.builders.body":
+    "External clients should use the session-v2 API authentication guide instead of the user upgrade notes on this page.",
+  "walletAuth.builders.link": "Open API authentication guide",
 } as const);
 
 const ATTACHMENT_MESSAGES = namespaceMessages("attachment", [
@@ -869,9 +873,17 @@ export const EN_US_MESSAGES = {
   "headerWaveLinkAction.feedback.shared": "Link shared",
   "headerWaveLinkAction.feedback.copied": "Link copied",
   "acceptConnection.incoming.profileStats": "TDH: {tdh} · Level: {level}",
-  "tools.api.authentication.title": "Authentication",
+  "tools.api.authCallout.title": "V2 API authentication",
+  "tools.api.authCallout.description":
+    "New external clients should use session-v2 wallet authentication: request a signable message, sign it exactly, exchange the signature for an access token, then send that token as bearer auth.",
+  "tools.api.authCallout.link": "Read the full external-client auth guide",
+  "tools.api.authentication.title": "Authentication quickstart",
   "tools.api.authentication.basedOnSignatures":
-    "Authentication is based on Ethereum signatures.",
+    "Authentication is based on Ethereum signatures. For scripts and other external clients, request a native session-v2 challenge.",
+  "tools.api.authentication.externalNote":
+    "This example shows the short native/script flow for external API clients.",
+  "tools.api.authentication.fullGuideLink":
+    "Use the full guide for refresh, logout, and security notes.",
   "tools.api.authentication.flowIntro": "The flow works as follows:",
   "tools.api.authentication.requestSessionMessage":
     "Request a session-v2 signable message for the wallet you want to authenticate.",
@@ -883,6 +895,53 @@ export const EN_US_MESSAGES = {
     "Receive a JWT bearer token, which you can include in headers of subsequent requests.",
   "tools.api.authentication.nodeExample":
     "Here's a full example in Node.js using ethers and node-fetch:",
+  "tools.api.authGuide.metadata.title": "API Authentication",
+  "tools.api.authGuide.metadata.description":
+    "External-client session-v2 wallet authentication for the 6529 API.",
+  "tools.api.authGuide.backToApi": "Back to API",
+  "tools.api.authGuide.eyebrow": "API Authentication",
+  "tools.api.authGuide.title": "External Client Authentication",
+  "tools.api.authGuide.lead":
+    "Use session-v2 wallet authentication when building scripts, services, and other external clients against the 6529 API.",
+  "tools.api.authGuide.overview.title": "What to use",
+  "tools.api.authGuide.overview.preferred":
+    "New external clients should authenticate through session-v2 endpoints. The standard external-client mode is client_type=native, even when the client is a command-line script or backend service controlled by the wallet owner.",
+  "tools.api.authGuide.overview.legacy":
+    "The older nonce, login, and redeem-refresh-token endpoints remain compatibility endpoints for older clients. New integrations should not start on those legacy endpoints.",
+  "tools.api.authGuide.flow.title": "Login flow",
+  "tools.api.authGuide.flow.nonce":
+    "Request a signable message with signer_address, client_type=native, and chain_id=1 from",
+  "tools.api.authGuide.flow.sign":
+    "Sign the returned message exactly as returned in",
+  "tools.api.authGuide.flow.login":
+    "Send client_type, client_address, client_signature, server_signature, and optional role to",
+  "tools.api.authGuide.flow.bearer":
+    "Use the returned access token on protected API calls as",
+  "tools.api.authGuide.refresh.title": "Refresh and logout",
+  "tools.api.authGuide.refresh.login":
+    "Native/script login returns an access_token for bearer auth plus a native_refresh_token and refresh_token_expires_at for long-running clients.",
+  "tools.api.authGuide.refresh.rotate":
+    "Refresh through POST /api/auth/session-refresh with client_type=native, client_address, and the current native_refresh_token. A successful refresh rotates the native refresh token, so replace the stored token with the new one immediately.",
+  "tools.api.authGuide.refresh.logout":
+    "Logout through POST /api/auth/session-logout with client_type=native, client_address, the current native_refresh_token, and all_sessions=false unless you intend to revoke every session for that wallet.",
+  "tools.api.authGuide.browser.title": "Browser clients",
+  "tools.api.authGuide.browser.note":
+    "This guide is for external clients. First-party browser sessions also use session-v2, but browser refresh state is handled with backend-owned HttpOnly cookies, credentials-included requests, and origin checks. Follow the app implementation rather than adapting the native/script examples directly for browser sessions.",
+  "tools.api.authGuide.security.title": "Security rules",
+  "tools.api.authGuide.security.signable":
+    "Sign only signable_message exactly as returned. Do not trim, normalize, rebuild, JSON-stringify, or sign a nonce field.",
+  "tools.api.authGuide.security.secrets":
+    "Do not log private keys, access tokens, refresh tokens, signatures, or raw authentication responses. Store refresh tokens in a secret store appropriate for the client environment.",
+  "tools.api.authGuide.security.status":
+    "Check response status codes before trusting JSON payloads, and treat authentication errors as requiring a fresh wallet signature or a clean re-login.",
+  "tools.api.authGuide.examples.title": "Node.js examples",
+  "tools.api.authGuide.examples.login":
+    "This example requests a native session-v2 challenge, signs it, logs in, and calls a protected endpoint with bearer auth.",
+  "tools.api.authGuide.examples.refresh":
+    "This example refreshes and logs out a native/script session. Persist the rotated native_refresh_token after every successful refresh.",
+  "tools.api.authGuide.related.ariaLabel": "Related API authentication links",
+  "tools.api.authGuide.related.api": "API overview",
+  "tools.api.authGuide.related.reference": "Full API reference",
   "home.boostedDrop.anonymousAuthor": "Anonymous",
   "home.boostedDrop.badge": "Boosted drop",
   "home.boostedDrop.boost": "Boost",

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -893,8 +893,6 @@ export const EN_US_MESSAGES = {
     "Send the signature back to the server.",
   "tools.api.authentication.receiveToken":
     "Receive a JWT bearer token, which you can include in headers of subsequent requests.",
-  "tools.api.authentication.nodeExample":
-    "Here's a full example in Node.js using ethers and node-fetch:",
   "tools.api.authGuide.metadata.title": "API Authentication",
   "tools.api.authGuide.metadata.description":
     "External-client session-v2 wallet authentication for the 6529 API.",
@@ -910,13 +908,13 @@ export const EN_US_MESSAGES = {
     "The older nonce, login, and redeem-refresh-token endpoints remain compatibility endpoints for older clients. New integrations should not start on those legacy endpoints.",
   "tools.api.authGuide.flow.title": "Login flow",
   "tools.api.authGuide.flow.nonce":
-    "Request a signable message with signer_address, client_type=native, and chain_id=1 from",
+    "Request a signable message with signer_address, client_type=native, and chain_id=1 from {code}.",
   "tools.api.authGuide.flow.sign":
-    "Sign the returned message exactly as returned in",
+    "Sign the returned message exactly as returned in {code}.",
   "tools.api.authGuide.flow.login":
-    "Send client_type, client_address, client_signature, server_signature, and optional role to",
+    "Send client_type, client_address, client_signature, server_signature, and optional role to {code}.",
   "tools.api.authGuide.flow.bearer":
-    "Use the returned access token on protected API calls as",
+    "Use the returned access token on protected API calls as {code}.",
   "tools.api.authGuide.refresh.title": "Refresh and logout",
   "tools.api.authGuide.refresh.login":
     "Native/script login returns an access_token for bearer auth plus a native_refresh_token and refresh_token_expires_at for long-running clients.",
@@ -937,8 +935,6 @@ export const EN_US_MESSAGES = {
   "tools.api.authGuide.examples.title": "Node.js examples",
   "tools.api.authGuide.examples.login":
     "This example requests a native session-v2 challenge, signs it, calls a protected endpoint with bearer auth, refreshes the session, and logs out.",
-  "tools.api.authGuide.examples.refresh":
-    "This example refreshes and logs out a native/script session. Persist the rotated native_refresh_token after every successful refresh.",
   "tools.api.authGuide.related.ariaLabel": "Related API authentication links",
   "tools.api.authGuide.related.api": "API overview",
   "tools.api.authGuide.related.reference": "Full API reference",

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -893,51 +893,6 @@ export const EN_US_MESSAGES = {
     "Send the signature back to the server.",
   "tools.api.authentication.receiveToken":
     "Receive a JWT bearer token, which you can include in headers of subsequent requests.",
-  "tools.api.authGuide.metadata.title": "API Authentication",
-  "tools.api.authGuide.metadata.description":
-    "External-client session-v2 wallet authentication for the 6529 API.",
-  "tools.api.authGuide.backToApi": "Back to API",
-  "tools.api.authGuide.eyebrow": "API Authentication",
-  "tools.api.authGuide.title": "External Client Authentication",
-  "tools.api.authGuide.lead":
-    "Use session-v2 wallet authentication when building scripts, services, and other external clients against the 6529 API.",
-  "tools.api.authGuide.overview.title": "What to use",
-  "tools.api.authGuide.overview.preferred":
-    "New external clients should authenticate through session-v2 endpoints. The standard external-client mode is client_type=native, even when the client is a command-line script or backend service controlled by the wallet owner.",
-  "tools.api.authGuide.overview.legacy":
-    "The older nonce, login, and redeem-refresh-token endpoints remain compatibility endpoints for older clients. New integrations should not start on those legacy endpoints.",
-  "tools.api.authGuide.flow.title": "Login flow",
-  "tools.api.authGuide.flow.nonce":
-    "Request a signable message with signer_address, client_type=native, and chain_id=1 from {code}.",
-  "tools.api.authGuide.flow.sign":
-    "Sign the returned message exactly as returned in {code}.",
-  "tools.api.authGuide.flow.login":
-    "Send client_type, client_address, client_signature, server_signature, and optional role to {code}.",
-  "tools.api.authGuide.flow.bearer":
-    "Use the returned access token on protected API calls as {code}.",
-  "tools.api.authGuide.refresh.title": "Refresh and logout",
-  "tools.api.authGuide.refresh.login":
-    "Native/script login returns an access_token for bearer auth plus a native_refresh_token and refresh_token_expires_at for long-running clients.",
-  "tools.api.authGuide.refresh.rotate":
-    "Refresh through POST /api/auth/session-refresh with client_type=native, client_address, and the current native_refresh_token. A successful refresh rotates the native refresh token, so replace the stored token with the new one immediately.",
-  "tools.api.authGuide.refresh.logout":
-    "Logout through POST /api/auth/session-logout with client_type=native, client_address, the current native_refresh_token, and all_sessions=false unless you intend to revoke every session for that wallet.",
-  "tools.api.authGuide.browser.title": "Browser clients",
-  "tools.api.authGuide.browser.note":
-    "This guide is for external clients. First-party browser sessions also use session-v2, but browser refresh state is handled with backend-owned HttpOnly cookies, credentials-included requests, and origin checks. Follow the app implementation rather than adapting the native/script examples directly for browser sessions.",
-  "tools.api.authGuide.security.title": "Security rules",
-  "tools.api.authGuide.security.signable":
-    "Sign only signable_message exactly as returned. Do not trim, normalize, rebuild, JSON-stringify, or sign a nonce field.",
-  "tools.api.authGuide.security.secrets":
-    "Do not log private keys, access tokens, refresh tokens, signatures, or raw authentication responses. Store refresh tokens in a secret store appropriate for the client environment.",
-  "tools.api.authGuide.security.status":
-    "Check response status codes before trusting JSON payloads, and treat authentication errors as requiring a fresh wallet signature or a clean re-login.",
-  "tools.api.authGuide.examples.title": "Node.js examples",
-  "tools.api.authGuide.examples.login":
-    "This example requests a native session-v2 challenge, signs it, calls a protected endpoint with bearer auth, refreshes the session, and logs out.",
-  "tools.api.authGuide.related.ariaLabel": "Related API authentication links",
-  "tools.api.authGuide.related.api": "API overview",
-  "tools.api.authGuide.related.reference": "Full API reference",
   "home.boostedDrop.anonymousAuthor": "Anonymous",
   "home.boostedDrop.badge": "Boosted drop",
   "home.boostedDrop.boost": "Boost",

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -873,7 +873,7 @@ export const EN_US_MESSAGES = {
   "headerWaveLinkAction.feedback.shared": "Link shared",
   "headerWaveLinkAction.feedback.copied": "Link copied",
   "acceptConnection.incoming.profileStats": "TDH: {tdh} · Level: {level}",
-  "tools.api.authCallout.title": "V2 API authentication",
+  "tools.api.authCallout.title": "v2 API authentication",
   "tools.api.authCallout.description":
     "New external clients should use session-v2 wallet authentication: request a signable message, sign it exactly, exchange the signature for an access token, then send that token as bearer auth.",
   "tools.api.authCallout.link": "Read the full external-client auth guide",

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -936,7 +936,7 @@ export const EN_US_MESSAGES = {
     "Check response status codes before trusting JSON payloads, and treat authentication errors as requiring a fresh wallet signature or a clean re-login.",
   "tools.api.authGuide.examples.title": "Node.js examples",
   "tools.api.authGuide.examples.login":
-    "This example requests a native session-v2 challenge, signs it, logs in, and calls a protected endpoint with bearer auth.",
+    "This example requests a native session-v2 challenge, signs it, calls a protected endpoint with bearer auth, refreshes the session, and logs out.",
   "tools.api.authGuide.examples.refresh":
     "This example refreshes and logs out a native/script session. Persist the rotated native_refresh_token after every successful refresh.",
   "tools.api.authGuide.related.ariaLabel": "Related API authentication links",

--- a/ops/docs/api-tool/README.md
+++ b/ops/docs/api-tool/README.md
@@ -46,6 +46,18 @@ private `/tools/6529bot/admin` operator page.
 - `/tools/app-wallets/{appWalletAddress}`
 - `/tools/6529bot/admin`
 
+## Localization Notes
+
+- `/tools/api/authentication` and the new authentication quickstart copy on
+  `/tools/api` use `en-US` source messages with non-source locales falling back
+  through the shared `t()` helper.
+- `/tools/api` still has legacy hardcoded en-US copy in the Introduction, Key
+  terminology, and Creating drops with embedded media sections. Current
+  fallback behavior is direct hardcoded en-US rendering. Owner: frontend docs
+  and i18n migration. Remediation path: move the remaining `/tools/api` section
+  headings, body copy, list items, and metadata into `i18n/messages/en-US.ts`
+  during the broader API page localization pass.
+
 ## Navigation and Visibility
 
 - Web sidebar paths:

--- a/ops/docs/api-tool/README.md
+++ b/ops/docs/api-tool/README.md
@@ -48,15 +48,15 @@ private `/tools/6529bot/admin` operator page.
 
 ## Localization Notes
 
-- `/tools/api/authentication` and the new authentication quickstart copy on
-  `/tools/api` use `en-US` source messages with non-source locales falling back
-  through the shared `t()` helper.
-- `/tools/api` still has legacy hardcoded en-US copy in the Introduction, Key
+- The new authentication quickstart copy on `/tools/api` uses `en-US` source
+  messages with non-source locales falling back through the shared `t()` helper.
+- `/tools/api/authentication` uses route-local static en-US copy, and
+  `/tools/api` still has legacy hardcoded en-US copy in the Introduction, Key
   terminology, and Creating drops with embedded media sections. Current
-  fallback behavior is direct hardcoded en-US rendering. Owner: frontend docs
-  and i18n migration. Remediation path: move the remaining `/tools/api` section
-  headings, body copy, list items, and metadata into `i18n/messages/en-US.ts`
-  during the broader API page localization pass.
+  fallback behavior is direct en-US rendering. Owner: frontend docs and i18n
+  migration. Remediation path: move the API guide and remaining `/tools/api`
+  section headings, body copy, list items, and metadata into the shared message
+  system during the broader API page localization pass.
 
 ## Navigation and Visibility
 

--- a/ops/docs/api-tool/README.md
+++ b/ops/docs/api-tool/README.md
@@ -6,8 +6,10 @@ private `/tools/6529bot/admin` operator page.
 ## Overview
 
 - `/tools`: direct secondary landing page for grouped tool navigation.
-- `/tools/api`: static guide for API authentication and multipart media-drop
-  requests.
+- `/tools/api`: static guide for API terminology, authentication quickstart,
+  and multipart media-drop requests.
+- `/tools/api/authentication`: external-client session-v2 API authentication
+  guide.
 - `/tools/block-finder`: estimate the closest block for a timestamp, or find
   block numbers that include selected sequences across a configurable window
   (`1 minute` to `2 days`).
@@ -21,19 +23,22 @@ private `/tools/6529bot/admin` operator page.
 ## Read Order
 
 1. Start with `Tools Index` for the grouped direct `/tools` landing page.
-2. Read `API Authentication and Media Drop Flow` for API auth, multipart
-   upload, and drop creation examples.
-3. Read `Block Finder` for timestamp lookup, include-sequence windows, and
+2. Read `API Authentication` for the full external-client session-v2 auth
+   guide.
+3. Read `API Authentication and Media Drop Flow` for the `/tools/api`
+   quickstart, multipart upload, and drop creation examples.
+4. Read `Block Finder` for timestamp lookup, include-sequence windows, and
    result detail actions.
-4. Read `Memes Subscriptions Report` for aggregate subscription reporting.
-5. Read `App Wallets Management` for native app-wallet setup, recovery, and
+5. Read `Memes Subscriptions Report` for aggregate subscription reporting.
+6. Read `App Wallets Management` for native app-wallet setup, recovery, and
    unsupported-state behavior.
-6. Read `6529bot Admin` for the private bot operator route and auth boundary.
+7. Read `6529bot Admin` for the private bot operator route and auth boundary.
 
 ## Route Coverage
 
 - `/tools`
 - `/tools/api`
+- `/tools/api/authentication`
 - `/tools/block-finder`
 - `/tools/subscriptions-report`
 - `/tools/app-wallets`
@@ -71,11 +76,12 @@ private `/tools/6529bot/admin` operator page.
 ## Features
 
 1. [Tools Index](feature-tools-index.md)
-2. [API Authentication and Media Drop Flow](feature-api-authentication-and-media-drop-flow.md)
-3. [Block Finder](feature-block-finder.md)
-4. [Memes Subscriptions Report](feature-memes-subscriptions-report.md)
-5. [App Wallets Management](feature-app-wallets.md)
-6. [6529bot Admin](feature-6529bot-admin.md)
+2. [API Authentication](feature-api-authentication.md)
+3. [API Authentication and Media Drop Flow](feature-api-authentication-and-media-drop-flow.md)
+4. [Block Finder](feature-block-finder.md)
+5. [Memes Subscriptions Report](feature-memes-subscriptions-report.md)
+6. [App Wallets Management](feature-app-wallets.md)
+7. [6529bot Admin](feature-6529bot-admin.md)
 
 ## Flows
 

--- a/ops/docs/api-tool/feature-api-authentication-and-media-drop-flow.md
+++ b/ops/docs/api-tool/feature-api-authentication-and-media-drop-flow.md
@@ -4,7 +4,9 @@
 
 `/tools/api` is a read-only guide for the 6529 REST API.
 
-- It explains wallet-signature authentication (`session-nonce -> sign -> session-login -> access_token`).
+- It links to the full external-client API authentication guide.
+- It explains the short native/script wallet-signature authentication
+  quickstart (`session-nonce -> sign -> session-login -> access_token`).
 - It shows a multipart media upload flow and drop creation flow.
 - It defines key API terms used in routes and payloads.
 - It links to the full external API reference: `https://api.6529.io/docs/`.
@@ -20,6 +22,8 @@
 
 - Open `API` from Tools navigation.
 - Open `/tools/api` directly.
+- Open `/tools/api/authentication` from the authentication callout or
+  quickstart link when you need refresh, logout, and security notes.
 - Open `API` from the site footer.
 
 ## User Journey
@@ -27,27 +31,31 @@
 1. Open `/tools/api`.
 2. Review the introduction and terminology to confirm the page covers the
    intended auth or media-upload task.
-3. Read the wallet-signature authentication example and copy the snippet when
-   needed.
-4. Read the multipart media-upload and drop-creation example and copy the
+3. Open the full API authentication guide if you need more than the quickstart.
+4. Read the wallet-signature authentication example and copy the snippet when
    snippet when needed.
-5. Use the current contract highlights to spot recent payload/schema additions.
-6. Follow the external API docs for endpoint-level details beyond the examples
+5. Read the multipart media-upload and drop-creation example and copy the
+   snippet when needed.
+6. Use the current contract highlights to spot recent payload/schema additions.
+7. Follow the external API docs for endpoint-level details beyond the examples
    shown on this page.
 
 ## Page Structure and Behavior
 
 - The page is static content. It does not execute API calls.
-- It has four sections: `Introduction`, `Key terminology`, `Authentication`,
-  and `Creating drops with embedded media`.
+- It has a v2 auth callout plus sections for `Introduction`, `Key terminology`,
+  `Authentication quickstart`, and `Creating drops with embedded media`.
 - It includes two Node.js snippets:
-  - auth and bearer-token usage
+  - native/script session-v2 auth and bearer-token usage
   - multipart upload and drop creation
 - Each snippet has a `Copy` button with temporary `Copied!` feedback.
 - The introduction includes an inline note that some routes are still
   undocumented.
 
-## Authentication Example Flow
+## Authentication Quickstart Flow
+
+The `/tools/api` example is intentionally short and external-client oriented.
+The fuller guide lives at `/tools/api/authentication`.
 
 1. Request a native session nonce:
    - `GET https://api.6529.io/api/auth/session-nonce?signer_address=<address>&client_type=native&chain_id=1`
@@ -130,7 +138,9 @@
 
 ## Common Scenarios
 
-- Review the auth snippet before building a wallet-signature login flow.
+- Open the API authentication guide before building or maintaining an external
+  wallet-signature login flow.
+- Review the quickstart snippet when you only need the basic bearer-token flow.
 - Copy the multipart example while wiring media upload and drop creation in a
   Node.js script.
 - Check the current contract highlights when generated clients or API payloads
@@ -162,6 +172,8 @@
 
 - Examples are Node.js-oriented and include placeholders (`0x...`, private key,
   `TARGET_WAVE_ID_GOES_HERE`).
+- The auth example is for external native/script clients. First-party browser
+  session internals are not covered by the quickstart.
 - The media snippet uses `node-fetch`, `fs/promises`, `path`, and
   `mime-types`.
 - Some API routes are still undocumented; use the external API docs for broader
@@ -170,6 +182,7 @@
 ## Related Pages
 
 - [API Tool Index](README.md)
+- [API Authentication](feature-api-authentication.md)
 - [Block Finder](feature-block-finder.md)
 - [Memes Subscriptions Report](feature-memes-subscriptions-report.md)
 - [Sidebar Navigation](../navigation/feature-sidebar-navigation.md)

--- a/ops/docs/api-tool/feature-api-authentication-and-media-drop-flow.md
+++ b/ops/docs/api-tool/feature-api-authentication-and-media-drop-flow.md
@@ -32,8 +32,7 @@
 2. Review the introduction and terminology to confirm the page covers the
    intended auth or media-upload task.
 3. Open the full API authentication guide if you need more than the quickstart.
-4. Read the wallet-signature authentication example and copy the snippet when
-   snippet when needed.
+4. Review the wallet-signature authentication quickstart when needed.
 5. Read the multipart media-upload and drop-creation example and copy the
    snippet when needed.
 6. Use the current contract highlights to spot recent payload/schema additions.
@@ -45,10 +44,8 @@
 - The page is static content. It does not execute API calls.
 - It has a v2 auth callout plus sections for `Introduction`, `Key terminology`,
   `Authentication quickstart`, and `Creating drops with embedded media`.
-- It includes two Node.js snippets:
-  - native/script session-v2 auth and bearer-token usage
-  - multipart upload and drop creation
-- Each snippet has a `Copy` button with temporary `Copied!` feedback.
+- It includes a Node.js multipart upload and drop creation snippet.
+- The snippet has a `Copy` button with temporary `Copied!` feedback.
 - The introduction includes an inline note that some routes are still
   undocumented.
 
@@ -140,7 +137,7 @@ The fuller guide lives at `/tools/api/authentication`.
 
 - Open the API authentication guide before building or maintaining an external
   wallet-signature login flow.
-- Review the quickstart snippet when you only need the basic bearer-token flow.
+- Review the quickstart flow when you only need the basic bearer-token steps.
 - Copy the multipart example while wiring media upload and drop creation in a
   Node.js script.
 - Check the current contract highlights when generated clients or API payloads

--- a/ops/docs/api-tool/feature-api-authentication.md
+++ b/ops/docs/api-tool/feature-api-authentication.md
@@ -1,0 +1,154 @@
+# API Authentication
+
+## Overview
+
+`/tools/api/authentication` is the external-client authentication guide for the
+6529 REST API.
+
+- It explains session-v2 wallet authentication for scripts, services, and other
+  external clients.
+- It documents the native/script flow:
+  `session-nonce -> sign -> session-login -> bearer access_token`.
+- It covers refresh and logout for long-running native/script clients.
+- It names legacy auth endpoints as compatibility endpoints, not the preferred
+  path for new integrations.
+- It intentionally avoids first-party app flows that are not useful for normal
+  external API clients.
+
+## Location in the Site
+
+- Route: `/tools/api/authentication`
+- Parent route: `/tools/api`
+- Linked from `/tools/api`
+- Linked from `/about/tech/wallet-authentication` for builders
+
+## Entry Points
+
+- Open the `V2 API authentication` callout on `/tools/api`.
+- Open the full-guide link in the `/tools/api` authentication quickstart.
+- Open the builder-facing link on `/about/tech/wallet-authentication`.
+- Open `/tools/api/authentication` directly.
+
+## User Journey
+
+1. Open `/tools/api/authentication`.
+2. Confirm that new external clients should use session-v2 auth and
+   `client_type=native`.
+3. Follow the login flow:
+   `GET /api/auth/session-nonce`, sign `signable_message`, then
+   `POST /api/auth/session-login`.
+4. Use the returned `access_token` as
+   `Authorization: Bearer <access_token>`.
+5. For long-running clients, store the returned `native_refresh_token` securely.
+6. Refresh through `POST /api/auth/session-refresh` and replace the stored
+   native refresh token after every successful refresh.
+7. Logout through `POST /api/auth/session-logout` when the client should revoke
+   the current native/script session.
+8. Follow the full API reference for endpoint-level request and response
+   schemas beyond the examples on the page.
+
+## Page Structure and Behavior
+
+- The page is static content. It does not execute API calls.
+- It has sections for:
+  - what auth flow to use
+  - login flow
+  - refresh and logout
+  - browser-client caveat
+  - security rules
+  - Node.js login, refresh, and logout examples
+  - related links
+- It includes two copyable Node.js snippets:
+  - login and bearer-token usage
+  - native/script refresh and logout
+
+## External Client Login Flow
+
+1. Request a native session nonce:
+   - `GET https://api.6529.io/api/auth/session-nonce?signer_address=<address>&client_type=native&chain_id=1`
+2. Read `signable_message` and `server_signature`.
+3. Sign `signable_message` exactly with the wallet that owns
+   `signer_address`.
+4. Login:
+   - `POST https://api.6529.io/api/auth/session-login`
+   - Body: `client_type`, `client_address`, `client_signature`,
+     `server_signature`, and optional `role`.
+5. Use `access_token` for protected API calls.
+
+### Refresh and Logout
+
+- Native/script login returns `native_refresh_token` and
+  `refresh_token_expires_at`.
+- Refresh sends `client_type=native`, `client_address`, and the current
+  `native_refresh_token` to `POST /api/auth/session-refresh`.
+- A successful refresh rotates the native refresh token. Clients must persist
+  the new token and stop using the old one.
+- Logout sends `client_type=native`, `client_address`, the current
+  `native_refresh_token`, and `all_sessions=false` to
+  `POST /api/auth/session-logout`.
+- Use `all_sessions=true` only when the user intends to revoke every session for
+  that wallet.
+
+## Security Notes
+
+- Sign only `signable_message` exactly as returned.
+- Do not trim, normalize, rebuild, JSON-stringify, or sign a `nonce` field.
+- Do not log private keys, access tokens, refresh tokens, signatures, or raw
+  authentication responses.
+- Store refresh tokens in an environment-appropriate secret store.
+- Check response status before trusting response JSON.
+- Treat authentication errors as requiring a clean refresh, new signature, or
+  re-login.
+
+## Legacy Compatibility
+
+The older `GET /api/auth/nonce`, `POST /api/auth/login`, and
+`POST /api/auth/redeem-refresh-token` endpoints remain compatibility endpoints
+for older clients. New external integrations should start on session-v2
+endpoints instead.
+
+## Common Scenarios
+
+- Build a command-line script that signs with a wallet and calls protected API
+  endpoints.
+- Maintain a service that needs to refresh an API session without asking the
+  wallet owner to sign on every run.
+- Confirm whether an older integration should move away from legacy nonce/login
+  endpoints.
+- Review security constraints before storing bearer and refresh credentials.
+
+## Edge Cases
+
+- The page does not confirm live API health, account permissions, or wallet
+  ownership.
+- The page does not include a browser-auth implementation. First-party browser
+  sessions use HttpOnly cookies, credentialed requests, and origin checks.
+- A role can be sent during login only when the backend recognizes that wallet
+  as authorized for the requested profile role.
+- Refresh can fail if the refresh token is expired, already rotated, revoked,
+  mismatched to the wallet address, or otherwise invalid.
+
+## Failure and Recovery
+
+- If nonce creation fails, retry after checking API availability and request
+  parameters.
+- If the user rejects signing, stop and ask them to retry the login flow.
+- If login fails after signing, request a fresh session nonce before retrying.
+- If refresh fails, discard the stale refresh token and perform a fresh login.
+- If logout succeeds, remove local bearer and refresh credentials for that
+  session.
+
+## Limitations / Notes
+
+- Examples are Node.js-oriented and use `client_type=native`.
+- The examples include placeholders for wallet address and private key handling.
+- Production clients should use wallet and secret-management practices suitable
+  for their environment.
+- Use the external API reference for complete endpoint schemas.
+
+## Related Pages
+
+- [API Tool Index](README.md)
+- [API Authentication and Media Drop Flow](feature-api-authentication-and-media-drop-flow.md)
+- [Sidebar Navigation](../navigation/feature-sidebar-navigation.md)
+- [Docs Home](../README.md)

--- a/ops/docs/api-tool/feature-api-authentication.md
+++ b/ops/docs/api-tool/feature-api-authentication.md
@@ -56,11 +56,10 @@
   - refresh and logout
   - browser-client caveat
   - security rules
-  - Node.js login, refresh, and logout examples
+  - Node.js login, refresh, and logout example
   - related links
-- It includes two copyable Node.js snippets:
-  - login and bearer-token usage
-  - native/script refresh and logout
+- It includes one copyable Node.js session snippet covering login,
+  bearer-token usage, refresh, and logout.
 
 ## External Client Login Flow
 

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -546,7 +546,11 @@
         "The page links active technical notes such as the wallet authentication upgrade and indexes longer tech reports."
       ],
       "canonical_path": "/about/tech",
-      "related_paths": ["/about/tech/wallet-authentication", "/about/faq"],
+      "related_paths": [
+        "/about/tech/wallet-authentication",
+        "/tools/api/authentication",
+        "/about/faq"
+      ],
       "tags": ["about", "tech", "reports"],
       "source_refs": ["components/about/tech/AboutTech.tsx"]
     },
@@ -5385,6 +5389,43 @@
       "source_refs": ["app/emma/page.tsx", "app/emma/plans/page.tsx"]
     },
     {
+      "id": "tools.api-authentication",
+      "kind": "workflow",
+      "title": "API authentication for external clients",
+      "aliases": [
+        "api authentication",
+        "external api auth",
+        "session v2 auth",
+        "wallet api auth",
+        "bearer token api"
+      ],
+      "keywords": [
+        "api",
+        "authentication",
+        "session",
+        "v2",
+        "wallet",
+        "nonce",
+        "bearer",
+        "refresh"
+      ],
+      "facts": [
+        "The external-client API authentication guide lives at /tools/api/authentication.",
+        "New external clients should use session-v2 wallet authentication with client_type=native.",
+        "The flow is session-nonce, sign signable_message exactly, session-login, then Authorization: Bearer <access_token>.",
+        "Long-running external clients can use session-refresh and session-logout with the current native_refresh_token."
+      ],
+      "canonical_path": "/tools/api/authentication",
+      "related_paths": ["/tools/api", "/about/tech/wallet-authentication"],
+      "tags": ["tools", "api", "authentication"],
+      "source_refs": [
+        "app/tools/api/authentication/page.tsx",
+        "app/tools/api/page.tsx",
+        "app/about/tech/wallet-authentication/page.tsx",
+        "ops/docs/api-tool/feature-api-authentication.md"
+      ]
+    },
+    {
       "id": "tools.api-auth-media-drop",
       "kind": "workflow",
       "title": "API authentication and media drop flow",
@@ -5404,14 +5445,17 @@
       ],
       "facts": [
         "The API tool page lives at /tools/api.",
-        "API authentication and media-drop example flows are documented in the API tool docs.",
+        "The full external-client API authentication guide lives at /tools/api/authentication.",
+        "The API tool page includes a native/script authentication quickstart and media-drop example flow.",
         "This is separate from regular wave composer posting."
       ],
       "canonical_path": "/tools/api",
-      "related_paths": ["/tools/6529bot/admin"],
+      "related_paths": ["/tools/api/authentication", "/tools/6529bot/admin"],
       "tags": ["tools", "api"],
       "source_refs": [
         "app/tools/api/page.tsx",
+        "app/tools/api/authentication/page.tsx",
+        "ops/docs/api-tool/feature-api-authentication.md",
         "ops/docs/api-tool/feature-api-authentication-and-media-drop-flow.md"
       ]
     },

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -5412,7 +5412,7 @@
       "facts": [
         "The external-client API authentication guide lives at /tools/api/authentication.",
         "New external clients should use session-v2 wallet authentication with client_type=native.",
-        "The flow is session-nonce, sign signable_message exactly, session-login, then Authorization: Bearer <access_token>.",
+        "The flow is session-nonce, sign signable_message exactly, submit client_address, client_signature, and server_signature to session-login, then Authorization: Bearer <access_token>.",
         "Long-running external clients can use session-refresh and session-logout with the current native_refresh_token."
       ],
       "canonical_path": "/tools/api/authentication",

--- a/pr-reports/3132.md
+++ b/pr-reports/3132.md
@@ -1,0 +1,39 @@
+# PR Report: Add external API auth guide
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/3132
+Branch: codex/api-v2-auth-docs -> main
+Related PRs: None
+
+## Summary
+
+Adds a dedicated external-client API authentication guide for session-v2 wallet
+auth and keeps `/tools/api` as the concise API overview and quickstart page.
+
+## What Changed
+
+- Added `/tools/api/authentication` for external-client session-v2 login,
+  bearer-token usage, refresh/logout, and security notes.
+- Clarified `/tools/api` authentication as a native/script quickstart and linked
+  to the full guide.
+- Added a builder-facing link from `/about/tech/wallet-authentication`.
+- Updated API Tool docs and the help-index source/published artifact.
+
+## Frontend Impact
+
+- Routes/views: `/tools/api`, `/tools/api/authentication`,
+  `/about/tech/wallet-authentication`.
+- Components: static App Router pages using existing About layout and
+  `CodeExample`.
+- Generated API/client: not affected.
+- User-visible behavior: API builders have a clearer v2 auth reference focused
+  on external clients.
+
+## Config / Env
+
+None.
+
+## Release Notes
+
+External API builders can now open `/tools/api/authentication` for the preferred
+session-v2 auth flow. The existing `/tools/api` page remains the API overview
+and media-drop quickstart.

--- a/pr-reports/3132.md
+++ b/pr-reports/3132.md
@@ -16,6 +16,8 @@ auth and keeps `/tools/api` as the concise API overview and quickstart page.
 - Clarified `/tools/api` authentication as a native/script quickstart and linked
   to the full guide.
 - Added a builder-facing link from `/about/tech/wallet-authentication`.
+- Adjusted the API guide pages so body copy renders white with slightly wider
+  horizontal gutters.
 - Updated API Tool docs and the help-index source/published artifact.
 
 ## Frontend Impact

--- a/pr-reports/3132.md
+++ b/pr-reports/3132.md
@@ -16,8 +16,12 @@ auth and keeps `/tools/api` as the concise API overview and quickstart page.
 - Clarified `/tools/api` authentication as a native/script quickstart and linked
   to the full guide.
 - Added a builder-facing link from `/about/tech/wallet-authentication`.
-- Adjusted the API guide pages so body copy renders white with slightly wider
-  horizontal gutters.
+- Adjusted the API guide pages so body copy renders near-white with slightly
+  wider horizontal gutters.
+- Centralized the shared API page gutter/text class, kept the bright copy on
+  the `iron-50` design token, and removed the duplicate auth code sample from
+  `/tools/api` in favor of the full guide example.
+- Fixed review feedback in API docs and help-index flow facts.
 - Updated API Tool docs and the help-index source/published artifact.
 
 ## Frontend Impact

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -546,7 +546,11 @@
         "The page links active technical notes such as the wallet authentication upgrade and indexes longer tech reports."
       ],
       "canonical_path": "/about/tech",
-      "related_paths": ["/about/tech/wallet-authentication", "/about/faq"],
+      "related_paths": [
+        "/about/tech/wallet-authentication",
+        "/tools/api/authentication",
+        "/about/faq"
+      ],
       "tags": ["about", "tech", "reports"],
       "source_refs": ["components/about/tech/AboutTech.tsx"]
     },
@@ -5385,6 +5389,43 @@
       "source_refs": ["app/emma/page.tsx", "app/emma/plans/page.tsx"]
     },
     {
+      "id": "tools.api-authentication",
+      "kind": "workflow",
+      "title": "API authentication for external clients",
+      "aliases": [
+        "api authentication",
+        "external api auth",
+        "session v2 auth",
+        "wallet api auth",
+        "bearer token api"
+      ],
+      "keywords": [
+        "api",
+        "authentication",
+        "session",
+        "v2",
+        "wallet",
+        "nonce",
+        "bearer",
+        "refresh"
+      ],
+      "facts": [
+        "The external-client API authentication guide lives at /tools/api/authentication.",
+        "New external clients should use session-v2 wallet authentication with client_type=native.",
+        "The flow is session-nonce, sign signable_message exactly, session-login, then Authorization: Bearer <access_token>.",
+        "Long-running external clients can use session-refresh and session-logout with the current native_refresh_token."
+      ],
+      "canonical_path": "/tools/api/authentication",
+      "related_paths": ["/tools/api", "/about/tech/wallet-authentication"],
+      "tags": ["tools", "api", "authentication"],
+      "source_refs": [
+        "app/tools/api/authentication/page.tsx",
+        "app/tools/api/page.tsx",
+        "app/about/tech/wallet-authentication/page.tsx",
+        "ops/docs/api-tool/feature-api-authentication.md"
+      ]
+    },
+    {
       "id": "tools.api-auth-media-drop",
       "kind": "workflow",
       "title": "API authentication and media drop flow",
@@ -5404,14 +5445,17 @@
       ],
       "facts": [
         "The API tool page lives at /tools/api.",
-        "API authentication and media-drop example flows are documented in the API tool docs.",
+        "The full external-client API authentication guide lives at /tools/api/authentication.",
+        "The API tool page includes a native/script authentication quickstart and media-drop example flow.",
         "This is separate from regular wave composer posting."
       ],
       "canonical_path": "/tools/api",
-      "related_paths": ["/tools/6529bot/admin"],
+      "related_paths": ["/tools/api/authentication", "/tools/6529bot/admin"],
       "tags": ["tools", "api"],
       "source_refs": [
         "app/tools/api/page.tsx",
+        "app/tools/api/authentication/page.tsx",
+        "ops/docs/api-tool/feature-api-authentication.md",
         "ops/docs/api-tool/feature-api-authentication-and-media-drop-flow.md"
       ]
     },

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -5412,7 +5412,7 @@
       "facts": [
         "The external-client API authentication guide lives at /tools/api/authentication.",
         "New external clients should use session-v2 wallet authentication with client_type=native.",
-        "The flow is session-nonce, sign signable_message exactly, session-login, then Authorization: Bearer <access_token>.",
+        "The flow is session-nonce, sign signable_message exactly, submit client_address, client_signature, and server_signature to session-login, then Authorization: Bearer <access_token>.",
         "Long-running external clients can use session-refresh and session-logout with the current native_refresh_token."
       ],
       "canonical_path": "/tools/api/authentication",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -7,7 +7,7 @@ Site data such as TDH, REP, and Wave activity changes continuously. Fetch the fi
 ## Machine-readable files
 
 - [llms.txt](https://6529.io/llms.txt): this file — the stable entry point.
-- [help-index.json](https://6529.io/help-index.json): 188 curated records covering routes, workflows, UI affordances, business rules, and glossary terms. Each record has an id, title, aliases, facts, and a canonical_path that is validated against the app's real routes at build time. This is the primary reference for answering questions about 6529.io.
+- [help-index.json](https://6529.io/help-index.json): 189 curated records covering routes, workflows, UI affordances, business rules, and glossary terms. Each record has an id, title, aliases, facts, and a canonical_path that is validated against the app's real routes at build time. This is the primary reference for answering questions about 6529.io.
 - [glossary.json](https://6529.io/glossary.json): 27 term definitions (TDH, xTDH, REP, NIC, Waves, Drops, Groups, Subscriptions, and more) projected from the same help corpus. Each term carries its help-index record id, definition facts, and canonical page path.
 - [sitemap.xml](https://6529.io/sitemap.xml): the crawlable page list, regenerated on every deploy.
 - [robots.txt](https://6529.io/robots.txt): standard crawler directives; it also references the files above.

--- a/tests/network-open-data/network-open-data-api-readonly.spec.ts
+++ b/tests/network-open-data/network-open-data-api-readonly.spec.ts
@@ -158,7 +158,7 @@ test.describe("Network, Open Data, and public API read-only coverage @surface @m
     for (const section of [
       "Introduction",
       "Key terminology",
-      "Authentication",
+      "Authentication quickstart",
       "Creating drops with embedded media",
     ]) {
       await expect(page.getByText(section, { exact: true })).toBeVisible();


### PR DESCRIPTION
## Summary
Adds a dedicated external-client API authentication guide at `/tools/api/authentication` and turns `/tools/api` into a clearer quickstart/linking surface for session-v2 wallet auth.

## Notable changes
- Adds `/tools/api/authentication` with native/script session-v2 login, bearer-token use, refresh/logout, and security notes.
- Clarifies the existing `/tools/api` authentication section as a native/script quickstart and links to the full guide.
- Adds a builder-facing link from `/about/tech/wallet-authentication`.
- Updates API Tool docs and help-index/public help-index records.

## Validation
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run lint:diff`
- `./bin/6529 exec react-doctor . --project 6529seize --verbose --offline --diff=main`
- `python3 ops/skills/commit-docs-updater/scripts/validate_docs_links.py`
- `git diff --check main...HEAD`

Per request, I am not waiting for CI before staging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API authentication guide for external clients, covering login, token refresh, logout, and security tips.
  * Added clear navigation from the main API page and wallet authentication page to the full guide.

* **Documentation**
  * Updated API help content and index entries so the authentication flow is easier to find and follow.
  * Clarified the API quickstart and related guidance for builders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->