### PR TITLE
[codex] Add active drop subscriptions report

### DIFF
--- a/__tests__/app/tools/subscriptions-report.test.tsx
+++ b/__tests__/app/tools/subscriptions-report.test.tsx
@@ -226,6 +226,85 @@ describe("Subscriptions report page", () => {
     });
   });
 
+  it("keeps active and past drops when upcoming counts fail", async () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    isMintingToday.mockReturnValue(true);
+    commonApiFetch.mockImplementation((opts: any) => {
+      if (opts?.endpoint === "subscriptions/redeemed-memes-counts") {
+        return Promise.resolve({
+          count: 2,
+          page: 1,
+          next: null,
+          data: [
+            {
+              contract: "0xmemes",
+              token_id: 700,
+              count: 4,
+              name: "Active Meme",
+              image_url: "https://images.test/active.png",
+              mint_date: new Date().toISOString(),
+              szn: 15,
+            },
+            {
+              contract: "0xmemes",
+              token_id: 699,
+              count: 9,
+              name: "Past Meme",
+              image_url: "https://images.test/past.png",
+              mint_date: "2026-01-01T00:00:00.000Z",
+              szn: 14,
+            },
+          ],
+        });
+      }
+
+      if (opts?.endpoint === "subscriptions/memes/700/count") {
+        return Promise.resolve({
+          contract: "0xmemes",
+          token_id: 700,
+          count: 11,
+        });
+      }
+
+      if (
+        opts?.endpoint === "subscriptions/upcoming-memes-counts?card_count=2"
+      ) {
+        return Promise.reject(new Error("Upcoming unavailable"));
+      }
+
+      if (opts?.endpoint === "new_memes_seasons") {
+        return Promise.resolve([]);
+      }
+
+      return Promise.resolve([]);
+    });
+
+    render(
+      <AuthContext.Provider value={{ setToast } as any}>
+        <CookieConsentProvider>
+          <Page />
+        </CookieConsentProvider>
+      </AuthContext.Provider>
+    );
+
+    const activeDrop = await screen.findByTestId(
+      "subscriptions-report-active-drop"
+    );
+    expect(activeDrop).toHaveTextContent("#700 - Active Meme");
+    expect(activeDrop).toHaveTextContent("11");
+
+    const pastDrops = screen.getByTestId("subscriptions-report-past-drops");
+    expect(within(pastDrops).getByText("#699 - Past Meme")).toBeInTheDocument();
+    expect(within(pastDrops).queryByText("#700 - Active Meme")).toBeNull();
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to fetch upcoming subscriptions:",
+      expect.any(Error)
+    );
+  });
+
   it("downloads redeemed meme counts csv for all seasons by default", async () => {
     const user = userEvent.setup();
 

--- a/__tests__/app/tools/subscriptions-report.test.tsx
+++ b/__tests__/app/tools/subscriptions-report.test.tsx
@@ -1,7 +1,7 @@
 import Page, { generateMetadata } from "@/app/tools/subscriptions-report/page";
 import { AuthContext } from "@/components/auth/Auth";
 import { CookieConsentProvider } from "@/components/cookies/CookieConsentContext";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
@@ -18,8 +18,15 @@ jest.mock("@/services/auth/auth.utils", () => ({
   getAuthJwt: () => "jwtToken",
 }));
 
+jest.mock("@/components/about/AboutSubscriptionsProfileButton", () => ({
+  __esModule: true,
+  default: () => <button type="button">Manage</button>,
+}));
+
 jest.mock("@/components/meme-calendar/meme-calendar.helpers", () => ({
   __esModule: true,
+  displayedSeasonNumberFromIndex: jest.fn((index: number) => index + 1),
+  formatFullDate: jest.fn(() => "Jan 1, 2026"),
   getCardsRemainingUntilEndOf: jest.fn(() => 2),
   getUpcomingMintsAcrossSeasons: jest.fn(() => []),
   isMintingToday: jest.fn(() => false),
@@ -54,7 +61,32 @@ jest.mock("@/services/api/common-api", () => ({
 const { commonApiFetch } = require("@/services/api/common-api");
 const {
   getCardsRemainingUntilEndOf,
+  isMintingToday,
 } = require("@/components/meme-calendar/meme-calendar.helpers");
+
+const mockDefaultCommonApiFetch = (opts: any) => {
+  if (opts?.endpoint === "subscriptions/redeemed-memes-counts") {
+    return Promise.resolve({
+      count: 0,
+      page: 1,
+      next: null,
+      data: [],
+    });
+  }
+  if (opts?.endpoint === "new_memes_seasons") {
+    return Promise.resolve([
+      {
+        id: 14,
+        display: "SZN 14",
+      },
+      {
+        id: 15,
+        display: "SZN 15",
+      },
+    ]);
+  }
+  return Promise.resolve([]);
+};
 
 // Mock TitleContext
 jest.mock("@/contexts/TitleContext", () => ({
@@ -77,6 +109,9 @@ describe("Subscriptions report page", () => {
   beforeEach(() => {
     jest.restoreAllMocks();
     jest.clearAllMocks();
+    commonApiFetch.mockImplementation(mockDefaultCommonApiFetch);
+    getCardsRemainingUntilEndOf.mockReturnValue(2);
+    isMintingToday.mockReturnValue(false);
     mockDownload.mockClear();
     mockUseDownloader.mockReturnValue({
       download: mockDownload,
@@ -113,6 +148,81 @@ describe("Subscriptions report page", () => {
       expect(commonApiFetch).toHaveBeenCalledWith({
         endpoint: "new_memes_seasons",
       });
+    });
+  });
+
+  it("moves a mint-day redeemed card into the active drop section", async () => {
+    isMintingToday.mockReturnValue(true);
+    commonApiFetch.mockImplementation((opts: any) => {
+      if (opts?.endpoint === "subscriptions/redeemed-memes-counts") {
+        return Promise.resolve({
+          count: 2,
+          page: 1,
+          next: null,
+          data: [
+            {
+              contract: "0xmemes",
+              token_id: 700,
+              count: 4,
+              name: "Active Meme",
+              image_url: "https://images.test/active.png",
+              mint_date: new Date().toISOString(),
+              szn: 15,
+            },
+            {
+              contract: "0xmemes",
+              token_id: 699,
+              count: 9,
+              name: "Past Meme",
+              image_url: "https://images.test/past.png",
+              mint_date: "2026-01-01T00:00:00.000Z",
+              szn: 14,
+            },
+          ],
+        });
+      }
+
+      if (opts?.endpoint === "subscriptions/memes/700/count") {
+        return Promise.resolve({
+          contract: "0xmemes",
+          token_id: 700,
+          count: 11,
+        });
+      }
+
+      if (opts?.endpoint === "new_memes_seasons") {
+        return Promise.resolve([]);
+      }
+
+      return Promise.resolve([]);
+    });
+
+    render(
+      <AuthContext.Provider value={{ setToast } as any}>
+        <CookieConsentProvider>
+          <Page />
+        </CookieConsentProvider>
+      </AuthContext.Provider>
+    );
+
+    const activeDrop = await screen.findByTestId(
+      "subscriptions-report-active-drop"
+    );
+    expect(activeDrop).toHaveTextContent("#700 - Active Meme");
+    expect(activeDrop).toHaveTextContent("Projected");
+    expect(activeDrop).toHaveTextContent("Actual");
+    expect(activeDrop).toHaveTextContent("11");
+    expect(activeDrop).toHaveTextContent("4");
+
+    const pastDrops = screen.getByTestId("subscriptions-report-past-drops");
+    expect(within(pastDrops).queryByText("#700 - Active Meme")).toBeNull();
+    expect(within(pastDrops).getByText("#699 - Past Meme")).toBeInTheDocument();
+
+    expect(commonApiFetch).toHaveBeenCalledWith({
+      endpoint: "subscriptions/memes/700/count",
+    });
+    expect(commonApiFetch).toHaveBeenCalledWith({
+      endpoint: "subscriptions/upcoming-memes-counts?card_count=2",
     });
   });
 

--- a/__tests__/components/about/AboutSubscriptions.test.tsx
+++ b/__tests__/components/about/AboutSubscriptions.test.tsx
@@ -6,4 +6,13 @@ describe('AboutSubscriptions', () => {
     render(<AboutSubscriptions />);
     expect(screen.getByRole('heading', { name: /Subscription/ })).toBeInTheDocument();
   });
+
+  it('links to the subscriptions report', () => {
+    render(<AboutSubscriptions />);
+
+    expect(screen.getByRole('link', { name: 'Subscriptions Report' })).toHaveAttribute(
+      'href',
+      '/tools/subscriptions-report'
+    );
+  });
 });

--- a/__tests__/components/about/AboutSubscriptions.test.tsx
+++ b/__tests__/components/about/AboutSubscriptions.test.tsx
@@ -1,18 +1,22 @@
-import { render, screen } from '@testing-library/react';
-import AboutSubscriptions from '@/components/about/AboutSubscriptions';
+import { render, screen } from "@testing-library/react";
+import AboutSubscriptions from "@/components/about/AboutSubscriptions";
 
-describe('AboutSubscriptions', () => {
-  it('renders heading', () => {
+describe("AboutSubscriptions", () => {
+  it("renders heading", () => {
     render(<AboutSubscriptions />);
-    expect(screen.getByRole('heading', { name: /Subscription/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /Subscription/ })
+    ).toBeInTheDocument();
   });
 
-  it('links to the subscriptions report', () => {
+  it("links to the subscriptions report", () => {
     render(<AboutSubscriptions />);
 
-    expect(screen.getByRole('link', { name: 'Subscriptions Report' })).toHaveAttribute(
-      'href',
-      '/tools/subscriptions-report'
-    );
+    const reportLink = screen.getByRole("link", {
+      name: "Subscriptions Report",
+    });
+    expect(reportLink).toHaveAttribute("href", "/tools/subscriptions-report");
+    expect(reportLink).toHaveClass("tw-text-primary-300");
+    expect(reportLink).not.toHaveClass("tw-underline");
   });
 });

--- a/components/about/AboutSubscriptions.tsx
+++ b/components/about/AboutSubscriptions.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 import {
   AboutCol as Col,
   AboutContainer as Container,
@@ -60,6 +62,16 @@ export default function AboutSubscriptions() {
                   who choose to use them
                 </li>
               </ul>
+            </li>
+            <li className="tw-mt-2">
+              You can monitor aggregate projected and redeemed subscription
+              counts in the{" "}
+              <Link
+                href="/tools/subscriptions-report"
+                className="tw-font-semibold tw-text-primary-300 tw-underline tw-decoration-primary-300/50 tw-underline-offset-4 tw-transition-colors hover:tw-text-primary-200 hover:tw-decoration-primary-200"
+              >
+                Subscriptions Report
+              </Link>
             </li>
           </ul>
         </Col>

--- a/components/about/AboutSubscriptions.tsx
+++ b/components/about/AboutSubscriptions.tsx
@@ -68,7 +68,7 @@ export default function AboutSubscriptions() {
               counts in the{" "}
               <Link
                 href="/tools/subscriptions-report"
-                className="tw-font-semibold tw-text-primary-300 tw-underline tw-decoration-primary-300/50 tw-underline-offset-4 tw-transition-colors hover:tw-text-primary-200 hover:tw-decoration-primary-200"
+                className="hover:tw-text-primary-200 tw-font-semibold tw-text-primary-300 tw-transition-colors"
               >
                 Subscriptions Report
               </Link>

--- a/components/subscriptions-report/SubscriptionsReport.tsx
+++ b/components/subscriptions-report/SubscriptionsReport.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import styles from "./SubscriptionsReport.module.css";
+import AboutSubscriptionsProfileButton from "@/components/about/AboutSubscriptionsProfileButton";
 import { useAuth } from "@/components/auth/Auth";
-import { useCookieConsent } from "@/components/cookies/CookieConsentContext";
 import CircleLoader, {
   CircleLoaderSize,
 } from "@/components/distribution-plan-tool/common/CircleLoader";
 import { publicEnv } from "@/config/env";
-import { shouldHideSubscriptions } from "@/components/user/layout/userPageVisibility";
 import type { MemeSeason } from "@/entities/ISeason";
 import type { SeasonMintRow } from "@/components/meme-calendar/meme-calendar.helpers";
 import {
@@ -23,28 +22,60 @@ import ShowMoreButton from "@/components/show-more-button/ShowMoreButton";
 import type { RedeemedSubscriptionCounts } from "@/generated/models/RedeemedSubscriptionCounts";
 import type { SubscriptionCounts } from "@/generated/models/SubscriptionCounts";
 import { Time } from "@/helpers/time";
-import useCapacitor from "@/hooks/useCapacitor";
 import { commonApiFetch } from "@/services/api/common-api";
 import { getAuthJwt, getStagingAuth } from "@/services/auth/auth.utils";
 import { sanitizeErrorForUser } from "@/utils/error-sanitizer";
 import Image from "next/image";
 import Link from "next/link";
 import useDownloader from "@/hooks/useDownloader";
+import {
+  ArrowDownTrayIcon,
+  ChevronDownIcon,
+} from "@heroicons/react/24/outline";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 const PAGE_SIZE = 10;
+const UPCOMING_PAGE_SIZE = 5;
+
+function isRedeemedDropFromToday(drop: RedeemedSubscriptionCounts): boolean {
+  return (
+    Time.fromString(drop.mint_date).toIsoDateString() ===
+    Time.now().toIsoDateString()
+  );
+}
+
+function getActiveRedeemedDrop(
+  drops: RedeemedSubscriptionCounts[],
+  mintingToday: boolean
+): RedeemedSubscriptionCounts | null {
+  if (!mintingToday) {
+    return null;
+  }
+
+  return drops.find(isRedeemedDropFromToday) ?? null;
+}
+
+function withoutTokenId<T extends { token_id: number }>(
+  drops: T[],
+  tokenId: number | null
+): T[] {
+  if (tokenId === null) {
+    return drops;
+  }
+
+  return drops.filter((drop) => drop.token_id !== tokenId);
+}
+
+function formatSubscriptionCount(count: number): string {
+  return count > 0 ? count.toLocaleString() : "0";
+}
 
 export default function SubscriptionsReportComponent() {
-  const capacitor = useCapacitor();
-  const { country } = useCookieConsent();
-  const { connectedProfile, setToast } = useAuth();
-  const hideSubscriptions = shouldHideSubscriptions({
-    capacitorIsIos: capacitor.isIos,
-    country,
-  });
+  const { setToast } = useAuth();
   const pastDropsTarget = useRef<HTMLDivElement>(null);
   const upcomingToggleRef = useRef<HTMLDivElement>(null);
   const upcomingTableTopRef = useRef<HTMLDivElement>(null);
+  const activeTokenIdRef = useRef<number | null>(null);
 
   const [upcomingLoading, setUpcomingLoading] = useState(true);
   const [upcomingCounts, setUpcomingCounts] = useState<SubscriptionCounts[]>(
@@ -55,9 +86,12 @@ export default function SubscriptionsReportComponent() {
   const [redeemedCounts, setRedeemedCounts] = useState<
     RedeemedSubscriptionCounts[]
   >([]);
+  const [activeDrop, setActiveDrop] =
+    useState<RedeemedSubscriptionCounts | null>(null);
+  const [activeProjectedCount, setActiveProjectedCount] =
+    useState<SubscriptionCounts | null>(null);
   const [totalRedeemed, setTotalRedeemed] = useState(0);
   const [redeemedPage, setRedeemedPage] = useState<number>(1);
-  const UPCOMING_PAGE_SIZE = 5;
   const [upcomingVisible, setUpcomingVisible] = useState(UPCOMING_PAGE_SIZE);
   const [animateFromIndex, setAnimateFromIndex] = useState<number | null>(null);
   const firstNewRowRef = useRef<HTMLTableRowElement>(null);
@@ -98,6 +132,12 @@ export default function SubscriptionsReportComponent() {
     });
   }
 
+  async function fetchProjectedCount(tokenId: number) {
+    return await commonApiFetch<SubscriptionCounts>({
+      endpoint: `subscriptions/memes/${tokenId}/count`,
+    });
+  }
+
   async function fetchSeasons() {
     return await commonApiFetch<MemeSeason[]>({
       endpoint: "new_memes_seasons",
@@ -109,20 +149,40 @@ export default function SubscriptionsReportComponent() {
       try {
         let remainingCountForSeason = getCardsRemainingUntilEndOf("szn");
         const redeemed = await fetchRedeemedCounts(1);
-        if (isMintingToday()) {
-          const latestDrop = redeemed.data[0];
-          if (latestDrop?.mint_date) {
-            const mintDate = Time.fromString(latestDrop.mint_date);
-            if (mintDate.toIsoDateString() !== Time.now().toIsoDateString()) {
-              remainingCountForSeason += 1;
-            }
-          }
-        }
-        const upcoming = await fetchUpcomingCounts(remainingCountForSeason);
+        const mintingToday = isMintingToday();
+        const activeRedeemedDrop = getActiveRedeemedDrop(
+          redeemed.data,
+          mintingToday
+        );
+        activeTokenIdRef.current = activeRedeemedDrop?.token_id ?? null;
 
-        setRedeemedCounts(redeemed.data);
+        if (mintingToday && !activeRedeemedDrop) {
+          remainingCountForSeason += 1;
+        }
+        const [upcoming, projectedCount] = await Promise.all([
+          fetchUpcomingCounts(remainingCountForSeason),
+          activeRedeemedDrop
+            ? fetchProjectedCount(activeRedeemedDrop.token_id).catch(
+                (error: unknown) => {
+                  console.error(
+                    "Failed to fetch active drop projected subscriptions:",
+                    error
+                  );
+                  return null;
+                }
+              )
+            : Promise.resolve(null),
+        ]);
+
+        setActiveDrop(activeRedeemedDrop);
+        setActiveProjectedCount(projectedCount);
+        setRedeemedCounts(
+          withoutTokenId(redeemed.data, activeRedeemedDrop?.token_id ?? null)
+        );
         setTotalRedeemed(redeemed.count);
-        setUpcomingCounts(upcoming);
+        setUpcomingCounts(
+          withoutTokenId(upcoming, activeRedeemedDrop?.token_id ?? null)
+        );
       } finally {
         setRedeemedLoading(false);
         setUpcomingLoading(false);
@@ -155,7 +215,9 @@ export default function SubscriptionsReportComponent() {
       setRedeemedLoading(true);
       try {
         const redeemed = await fetchRedeemedCounts(redeemedPage);
-        setRedeemedCounts(redeemed.data);
+        setRedeemedCounts(
+          withoutTokenId(redeemed.data, activeTokenIdRef.current)
+        );
         setTotalRedeemed(redeemed.count);
       } finally {
         setRedeemedLoading(false);
@@ -248,17 +310,7 @@ export default function SubscriptionsReportComponent() {
         <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between">
           <h1>Subscriptions Report</h1>
           <div className="tw-flex tw-items-center tw-gap-3">
-            {connectedProfile && !hideSubscriptions && (
-              <Link
-                href={`/${connectedProfile.normalised_handle}/subscriptions`}
-                className="tw-no-underline"
-                aria-label="Learn more about The Memes subscriptions"
-              >
-                <button className="tw-rounded-lg tw-border-0 tw-bg-primary-500 tw-p-2 tw-ring-1 tw-ring-inset tw-transition tw-duration-300 tw-ease-out hover:tw-bg-primary-600">
-                  My Subscriptions
-                </button>
-              </Link>
-            )}
+            <AboutSubscriptionsProfileButton />
             <Link
               href="/about/subscriptions"
               className="decoration-hover-underline"
@@ -269,6 +321,49 @@ export default function SubscriptionsReportComponent() {
           </div>
         </div>
       </div>
+      {activeDrop && (
+        <>
+          <div className="tw-pt-3">
+            <div className="tw-flex tw-items-center tw-gap-3">
+              <span className="tw-text-lg tw-font-bold tw-no-underline">
+                Active Drop
+              </span>
+            </div>
+          </div>
+          <div
+            className="tw-pt-3"
+            data-testid="subscriptions-report-active-drop"
+          >
+            <table className="tw-w-full tw-border-separate tw-border-spacing-0 tw-overflow-hidden tw-rounded-xl tw-border tw-border-primary-400/40 tw-bg-iron-900">
+              <caption className="tw-sr-only">
+                Table listing the active meme card projected and actual
+                subscription counts
+              </caption>
+              <thead>
+                <tr className="tw-bg-primary-500/10 tw-text-left tw-text-sm tw-uppercase tw-tracking-wider tw-text-gray-300">
+                  <th className="tw-w-1/2 tw-border-b tw-border-primary-400/30 tw-px-6 tw-py-3 tw-font-semibold">
+                    Meme Card
+                  </th>
+                  <th className="tw-w-1/4 tw-border-b tw-border-primary-400/30 tw-px-6 tw-py-3 tw-text-center tw-font-semibold">
+                    Projected
+                  </th>
+                  <th className="tw-w-1/4 tw-border-b tw-border-primary-400/30 tw-px-6 tw-py-3 tw-text-center tw-font-semibold">
+                    Actual
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="tw-bg-iron-800 hover:tw-bg-iron-700">
+                  <ActiveSubscriptionDetails
+                    count={activeDrop}
+                    projectedCount={activeProjectedCount}
+                  />
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
       <div ref={upcomingTableTopRef} />
       <div className="tw-pt-3">
         <div className="tw-flex tw-items-center tw-gap-3">
@@ -365,7 +460,7 @@ export default function SubscriptionsReportComponent() {
           )}
         </div>
       </div>
-      <div className="tw-pt-5">
+      <div ref={pastDropsTarget} className="tw-pt-5">
         <div className="tw-flex tw-items-center tw-gap-3">
           <span className="tw-text-lg tw-font-bold tw-no-underline">
             Past Drops
@@ -432,18 +527,18 @@ export default function SubscriptionsReportComponent() {
       {shouldShowDownloadSection && (
         <div className="tw-pt-5">
           <div>
-            <div className="tw-rounded-xl tw-border tw-border-iron-700 tw-bg-iron-900 tw-p-5">
-              <div className="tw-flex tw-flex-col tw-gap-3 lg:tw-flex-row lg:tw-items-center lg:tw-justify-between">
-                <h2 className="tw-mb-0 tw-text-base tw-font-semibold tw-text-white">
+            <div className="tw-rounded-xl tw-border tw-border-iron-700 tw-bg-iron-900/95 tw-p-4 tw-shadow-sm md:tw-p-5">
+              <div className="tw-flex tw-flex-col tw-gap-4 lg:tw-flex-row lg:tw-items-center lg:tw-justify-between">
+                <h2 className="tw-mb-0 tw-text-base tw-font-semibold tw-leading-6 tw-text-white md:tw-text-lg">
                   Redeemed Subscriptions Report
                 </h2>
-                <div className="tw-flex tw-w-full tw-flex-col tw-gap-3 sm:tw-flex-row sm:tw-items-center lg:tw-w-auto lg:tw-shrink-0">
+                <div className="tw-flex tw-w-full tw-flex-col tw-gap-3 sm:tw-flex-row sm:tw-items-stretch lg:tw-w-auto lg:tw-shrink-0">
                   {availableSeasons.length > 0 && (
-                    <div className="tw-mb-0 tw-min-w-[180px]">
+                    <div className="tw-relative tw-mb-0 tw-min-w-[190px] sm:tw-w-52">
                       <select
                         id="redeemed-meme-subscription-season"
                         aria-label="Redeemed meme subscription counts season"
-                        className={`tw-h-9 tw-rounded-lg tw-border-0 tw-bg-iron-800 tw-px-3 tw-text-sm tw-text-iron-50 tw-ring-1 tw-ring-inset tw-ring-iron-700 tw-transition tw-duration-300 focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-primary-400 ${isDownloadingCsv ? "tw-pointer-events-none tw-opacity-50" : ""}`}
+                        className={`tw-h-11 tw-w-full tw-appearance-none tw-rounded-lg tw-border-0 tw-bg-iron-800 tw-py-0 tw-pl-4 tw-pr-11 tw-text-sm tw-font-medium tw-text-iron-50 tw-ring-1 tw-ring-inset tw-ring-iron-700 tw-transition tw-duration-300 focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-primary-400 ${isDownloadingCsv ? "tw-pointer-events-none tw-opacity-50" : ""}`}
                         value={selectedSeasonId}
                         onChange={(e) => {
                           setSelectedSeasonId(e.currentTarget.value);
@@ -456,13 +551,17 @@ export default function SubscriptionsReportComponent() {
                           </option>
                         ))}
                       </select>
+                      <ChevronDownIcon
+                        className="tw-pointer-events-none tw-absolute tw-right-3.5 tw-top-1/2 tw-size-4 -tw-translate-y-1/2 tw-text-iron-300"
+                        aria-hidden="true"
+                      />
                     </div>
                   )}
                   <button
                     type="button"
                     onClick={onDownloadCsv}
                     disabled={isDownloadingCsv}
-                    className="tw-flex tw-h-9 tw-min-w-[180px] tw-items-center tw-justify-center tw-gap-2 tw-whitespace-nowrap tw-rounded-lg tw-border-0 tw-bg-primary-500 tw-px-5 tw-text-sm tw-font-semibold tw-text-white tw-transition tw-duration-300 tw-ease-out hover:tw-bg-primary-600 disabled:tw-cursor-not-allowed disabled:tw-opacity-60"
+                    className="tw-flex tw-h-11 tw-min-w-[190px] tw-items-center tw-justify-center tw-gap-2 tw-whitespace-nowrap tw-rounded-lg tw-border-0 tw-bg-primary-500 tw-px-5 tw-text-sm tw-font-semibold tw-text-white tw-transition tw-duration-300 tw-ease-out hover:tw-bg-primary-600 focus:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-primary-300 focus-visible:tw-ring-offset-2 focus-visible:tw-ring-offset-black disabled:tw-cursor-not-allowed disabled:tw-opacity-60 sm:tw-w-52"
                   >
                     {isDownloadingCsv ? (
                       <>
@@ -490,7 +589,13 @@ export default function SubscriptionsReportComponent() {
                         Downloading
                       </>
                     ) : (
-                      "Download"
+                      <>
+                        <ArrowDownTrayIcon
+                          className="tw-size-4"
+                          aria-hidden="true"
+                        />
+                        Download
+                      </>
                     )}
                   </button>
                 </div>
@@ -509,6 +614,78 @@ function getRedeemedCsvFilename(season: MemeSeason | null): string {
   }
 
   return "redeemed-meme-subscription-counts-all-seasons.csv";
+}
+
+function MemeCardDetails(
+  props: Readonly<{
+    count: RedeemedSubscriptionCounts;
+  }>
+) {
+  const dateTime = Time.fromString(props.count.mint_date);
+  return (
+    <td className="tw-border-t tw-border-iron-700 tw-px-6 tw-py-4 tw-align-middle tw-text-white">
+      <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-3">
+        <div className="tw-flex tw-h-[50px] tw-w-[50px] tw-shrink-0 tw-items-center tw-justify-center">
+          <Image
+            unoptimized
+            src={props.count.image_url}
+            alt={props.count.name || "Meme card"}
+            width={0}
+            height={0}
+            className="tw-h-auto tw-max-h-full tw-w-auto tw-max-w-full tw-rounded-sm"
+          />
+        </div>
+        <div className="tw-flex tw-flex-col">
+          <Link
+            href={`/the-memes/${props.count.token_id}`}
+            className="decoration-hover-underline tw-text-white"
+            aria-label={`View The Memes card #${props.count.token_id} - ${props.count.name}`}
+          >
+            #{props.count.token_id} - {props.count.name}
+          </Link>
+          <span className="tw-text-sm tw-text-gray-400">
+            SZN {props.count.szn}
+            {" / "}
+            {formatFullDate(dateTime.toDate())}
+          </span>
+        </div>
+      </div>
+    </td>
+  );
+}
+
+function SubscriptionCountCell(
+  props: Readonly<{
+    children: string;
+  }>
+) {
+  return (
+    <td className="tw-border-t tw-border-iron-700 tw-px-6 tw-py-4 tw-text-center tw-align-middle tw-text-white">
+      {props.children}
+    </td>
+  );
+}
+
+function ActiveSubscriptionDetails(
+  props: Readonly<{
+    count: RedeemedSubscriptionCounts;
+    projectedCount: SubscriptionCounts | null;
+  }>
+) {
+  const projected =
+    props.projectedCount?.token_id === props.count.token_id
+      ? formatSubscriptionCount(props.projectedCount.count)
+      : "Unavailable";
+
+  return (
+    <>
+      <MemeCardDetails count={props.count} />
+      <SubscriptionCountCell>{projected}</SubscriptionCountCell>
+      <SubscriptionCountCell>
+        {formatSubscriptionCount(props.count.count)}
+      </SubscriptionCountCell>
+    </>
+  );
 }
 
 function SubscriptionDayDetails(
@@ -530,7 +707,7 @@ function SubscriptionDayDetails(
         </div>
       </td>
       <td className="tw-border-t tw-border-iron-700 tw-px-6 tw-py-4 tw-text-center tw-align-middle tw-text-white">
-        {props.count.count > 0 ? props.count.count.toLocaleString() : "0"}
+        {formatSubscriptionCount(props.count.count)}
       </td>
     </>
   );
@@ -541,40 +718,12 @@ function RedeemedSubscriptionDetails(
     count: RedeemedSubscriptionCounts;
   }>
 ) {
-  const dateTime = Time.fromString(props.count.mint_date);
   return (
     <>
-      <td className="tw-border-t tw-border-iron-700 tw-px-6 tw-py-4 tw-align-middle tw-text-white">
-        <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-3">
-          <div className="tw-flex tw-h-[50px] tw-w-[50px] tw-shrink-0 tw-items-center tw-justify-center">
-            <Image
-              unoptimized
-              src={props.count.image_url}
-              alt={props.count.name || "Meme card"}
-              width={0}
-              height={0}
-              className="tw-h-auto tw-max-h-full tw-w-auto tw-max-w-full tw-rounded-sm"
-            />
-          </div>
-          <div className="tw-flex tw-flex-col">
-            <Link
-              href={`/the-memes/${props.count.token_id}`}
-              className="decoration-hover-underline tw-text-white"
-              aria-label={`View The Memes card #${props.count.token_id} - ${props.count.name}`}
-            >
-              #{props.count.token_id} - {props.count.name}
-            </Link>
-            <span className="tw-text-sm tw-text-gray-400">
-              SZN {props.count.szn}
-              {" / "}
-              {formatFullDate(dateTime.toDate())}
-            </span>
-          </div>
-        </div>
-      </td>
-      <td className="tw-border-t tw-border-iron-700 tw-px-6 tw-py-4 tw-text-center tw-align-middle tw-text-white">
-        {props.count.count > 0 ? props.count.count.toLocaleString() : "0"}
-      </td>
+      <MemeCardDetails count={props.count} />
+      <SubscriptionCountCell>
+        {formatSubscriptionCount(props.count.count)}
+      </SubscriptionCountCell>
     </>
   );
 }

--- a/components/subscriptions-report/SubscriptionsReport.tsx
+++ b/components/subscriptions-report/SubscriptionsReport.tsx
@@ -70,6 +70,17 @@ function formatSubscriptionCount(count: number): string {
   return count > 0 ? count.toLocaleString() : "0";
 }
 
+function getDisplayedRedeemedTotal(
+  totalRedeemed: number,
+  activeTokenId: number | null
+): number {
+  if (activeTokenId === null) {
+    return totalRedeemed;
+  }
+
+  return Math.max(totalRedeemed - 1, 0);
+}
+
 export default function SubscriptionsReportComponent() {
   const { setToast } = useAuth();
   const pastDropsTarget = useRef<HTMLDivElement>(null);
@@ -146,21 +157,44 @@ export default function SubscriptionsReportComponent() {
 
   useEffect(() => {
     const fetchData = async () => {
-      try {
-        let remainingCountForSeason = getCardsRemainingUntilEndOf("szn");
-        const redeemed = await fetchRedeemedCounts(1);
-        const mintingToday = isMintingToday();
-        const activeRedeemedDrop = getActiveRedeemedDrop(
-          redeemed.data,
-          mintingToday
-        );
-        activeTokenIdRef.current = activeRedeemedDrop?.token_id ?? null;
+      const mintingToday = isMintingToday();
+      let remainingCountForSeason = getCardsRemainingUntilEndOf("szn");
+      let activeRedeemedDrop: RedeemedSubscriptionCounts | null = null;
 
-        if (mintingToday && !activeRedeemedDrop) {
-          remainingCountForSeason += 1;
-        }
+      try {
+        const redeemed = await fetchRedeemedCounts(1);
+        activeRedeemedDrop = getActiveRedeemedDrop(redeemed.data, mintingToday);
+        activeTokenIdRef.current = activeRedeemedDrop?.token_id ?? null;
+        setActiveDrop(activeRedeemedDrop);
+        setRedeemedCounts(
+          withoutTokenId(redeemed.data, activeRedeemedDrop?.token_id ?? null)
+        );
+        setTotalRedeemed(
+          getDisplayedRedeemedTotal(
+            redeemed.count,
+            activeRedeemedDrop?.token_id ?? null
+          )
+        );
+      } catch (error) {
+        console.error("Failed to fetch redeemed subscriptions:", error);
+        activeTokenIdRef.current = null;
+        setActiveDrop(null);
+        setRedeemedCounts([]);
+        setTotalRedeemed(0);
+      }
+
+      if (mintingToday && !activeRedeemedDrop) {
+        remainingCountForSeason += 1;
+      }
+
+      try {
         const [upcoming, projectedCount] = await Promise.all([
-          fetchUpcomingCounts(remainingCountForSeason),
+          fetchUpcomingCounts(remainingCountForSeason).catch(
+            (error: unknown) => {
+              console.error("Failed to fetch upcoming subscriptions:", error);
+              return [];
+            }
+          ),
           activeRedeemedDrop
             ? fetchProjectedCount(activeRedeemedDrop.token_id).catch(
                 (error: unknown) => {
@@ -174,15 +208,14 @@ export default function SubscriptionsReportComponent() {
             : Promise.resolve(null),
         ]);
 
-        setActiveDrop(activeRedeemedDrop);
         setActiveProjectedCount(projectedCount);
-        setRedeemedCounts(
-          withoutTokenId(redeemed.data, activeRedeemedDrop?.token_id ?? null)
-        );
-        setTotalRedeemed(redeemed.count);
         setUpcomingCounts(
           withoutTokenId(upcoming, activeRedeemedDrop?.token_id ?? null)
         );
+      } catch (error) {
+        console.error("Failed to fetch subscription counts:", error);
+        setActiveProjectedCount(null);
+        setUpcomingCounts([]);
       } finally {
         setRedeemedLoading(false);
         setUpcomingLoading(false);
@@ -218,7 +251,9 @@ export default function SubscriptionsReportComponent() {
         setRedeemedCounts(
           withoutTokenId(redeemed.data, activeTokenIdRef.current)
         );
-        setTotalRedeemed(redeemed.count);
+        setTotalRedeemed(
+          getDisplayedRedeemedTotal(redeemed.count, activeTokenIdRef.current)
+        );
       } finally {
         setRedeemedLoading(false);
       }
@@ -529,7 +564,7 @@ export default function SubscriptionsReportComponent() {
           <div>
             <div className="tw-rounded-xl tw-border tw-border-iron-700 tw-bg-iron-900/95 tw-p-4 tw-shadow-sm md:tw-p-5">
               <div className="tw-flex tw-flex-col tw-gap-4 lg:tw-flex-row lg:tw-items-center lg:tw-justify-between">
-                <h2 className="tw-mb-0 tw-text-base tw-font-semibold tw-leading-6 tw-text-white md:tw-text-lg">
+                <h2 className="tw-m-0 tw-flex tw-min-h-11 tw-items-center tw-text-base tw-font-semibold tw-leading-6 tw-text-white md:tw-text-lg">
                   Redeemed Subscriptions Report
                 </h2>
                 <div className="tw-flex tw-w-full tw-flex-col tw-gap-3 sm:tw-flex-row sm:tw-items-stretch lg:tw-w-auto lg:tw-shrink-0">

--- a/ops/docs/api-tool/README.md
+++ b/ops/docs/api-tool/README.md
@@ -11,8 +11,8 @@ private `/tools/6529bot/admin` operator page.
 - `/tools/block-finder`: estimate the closest block for a timestamp, or find
   block numbers that include selected sequences across a configurable window
   (`1 minute` to `2 days`).
-- `/tools/subscriptions-report`: read-only aggregate counts for upcoming and
-  redeemed The Memes subscriptions.
+- `/tools/subscriptions-report`: read-only aggregate counts for active,
+  upcoming, and redeemed The Memes subscriptions.
 - `/tools/app-wallets*`: create, import, and manage app-local wallets when
   runtime app-wallet support is available (supported native app environments).
 - `/tools/6529bot/admin`: private operator dashboard for central

--- a/ops/docs/api-tool/feature-memes-subscriptions-report.md
+++ b/ops/docs/api-tool/feature-memes-subscriptions-report.md
@@ -5,9 +5,13 @@
 `/tools/subscriptions-report` is a read-only report for aggregate The Memes
 subscription counts.
 
-- `Upcoming Drops`: aggregate counts for upcoming cards.
+- `Active Drop`: shown on mint days after the current card has redeemed data;
+  compares projected subscriptions with actual redeemed subscriptions and keeps
+  the card out of the other sections.
+- `Upcoming Drops`: aggregate projected counts for upcoming cards.
 - `Past Drops`: aggregate redeemed counts for minted cards.
-- Header actions: `My Subscriptions` (conditional) and `Learn More`.
+- Header actions: `Manage` / `Connect to Subscribe` (same profile-subscription
+  navigation as `/about/subscriptions`) and `Learn More`.
 
 ## Location in the Site
 
@@ -23,26 +27,36 @@ subscription counts.
 - Open from `About -> Data & Developer Tools` (when visible in current nav).
 - Open `/tools/subscriptions-report` directly (route always loads).
 - Use header actions:
-  - `My Subscriptions` -> `/{your-handle}/subscriptions` (when shown)
+  - `Manage` -> authenticates and opens `/{your-handle}/subscriptions`
+  - `Connect to Subscribe` -> starts wallet connection, then opens profile
+    subscriptions after authentication
   - `Learn More` -> `/about/subscriptions`
 
 ## User Journey
 
 1. Open `/tools/subscriptions-report`.
 2. Wait for initial load to finish.
-3. Review `Upcoming Drops` and optionally expand with `Show More`.
-4. Review `Past Drops` rows (thumbnail, token link, season/date, count).
-5. Use past pagination when total redeemed count is above 20.
-6. Use header actions (`My Subscriptions`, `Learn More`) as needed.
+3. When present, review `Active Drop` for the current card thumbnail, link,
+   season/date, projected subscriptions, and actual redeemed subscriptions.
+4. Review `Upcoming Drops` and optionally expand with `Show More`.
+5. Review `Past Drops` rows (thumbnail, token link, season/date, count).
+6. Use past pagination when total redeemed count is above 10.
+7. Use header actions (`Manage` / `Connect to Subscribe`, `Learn More`) as
+   needed.
 
 ## Data and Rendering Rules
 
 - Initial load fetches past page `1` first, then fetches upcoming counts.
 - Upcoming endpoint: `subscriptions/upcoming-memes-counts?card_count=<count>`.
-- Past endpoint: `subscriptions/redeemed-memes-counts?page_size=20&page=<page>`.
-- Past page size is fixed at `20`.
+- Active projected endpoint:
+  `subscriptions/memes/{token_id}/count`.
+- Past endpoint: `subscriptions/redeemed-memes-counts?page_size=10&page=<page>`.
+- Past page size is fixed at `10`.
 - Upcoming labels use mint-calendar ordering and `SZN <number> / <date>`.
-- Upcoming table shows first `10` rows until expanded.
+- Upcoming table shows first `5` rows until expanded.
+- When today's card appears in the redeemed response on a mint day, that token
+  is rendered only in `Active Drop`; it is filtered out of both upcoming and
+  past tables.
 - Past rows include image thumbnail and token link to `/the-memes/{token_id}`.
 
 ## Visibility and State Rules
@@ -50,10 +64,15 @@ subscription counts.
 - The route itself is not geo-blocked.
 - On iOS outside the US, this route is hidden from web sidebar and search.
 - Native app drawer uses the same `Subscriptions Report` label when visible.
-- `My Subscriptions` is hidden when no profile is connected.
-- On iOS, `My Subscriptions` is shown only when country is `US`.
-- `Show More` / `Show Less` appears only when upcoming rows are greater than 10.
-- Past pagination appears only when redeemed total count is greater than 20.
+- The profile-subscription action is hidden when subscription controls are
+  geo/platform hidden.
+- `Manage` appears when the connected authenticated profile can open profile
+  subscriptions directly.
+- `Connect to Subscribe` appears when a profile route is not available yet and
+  starts the same connection/authentication handoff used on
+  `/about/subscriptions`.
+- `Show More` / `Show Less` appears only when upcoming rows are greater than 5.
+- Past pagination appears only when redeemed total count is greater than 10.
 - Empty sections render `No Subscriptions Found`.
 
 ## Loading, Failure, and Recovery
@@ -73,7 +92,8 @@ subscription counts.
 
 - This page does not edit subscriptions.
 - Counts are aggregate totals, not wallet-specific allocations.
-- `My Subscriptions` is a shortcut into profile subscriptions routes.
+- `Manage` / `Connect to Subscribe` is a shortcut into profile subscriptions
+  routes and authentication.
 - `/open-data/meme-subscriptions` is a dataset-download list, not this live
   aggregate report.
 

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -2703,16 +2703,18 @@
         "minting",
         "airdrop",
         "balance",
+        "report",
         "top",
         "up"
       ],
       "facts": [
         "The Memes subscriptions are an optional way to mint Meme Cards remotely, with potential gas savings or set-and-forget minting.",
         "Subscriptions are not a mintpass and do not create extra allowlist access.",
-        "Users manage their subscription mode, balance, airdrop address, top-ups, upcoming drops, and history under their profile Subscriptions tab."
+        "Users manage their subscription mode, balance, airdrop address, top-ups, upcoming drops, and history under their profile Subscriptions tab.",
+        "The About Subscriptions overview links to the Subscriptions Report for aggregate projected and redeemed subscription counts."
       ],
       "canonical_path": "/about/subscriptions",
-      "related_paths": ["/{user}/subscriptions"],
+      "related_paths": ["/{user}/subscriptions", "/tools/subscriptions-report"],
       "tags": ["subscriptions", "memes", "glossary"],
       "source_refs": [
         "ops/docs/open-data/feature-meme-subscriptions.md",

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -2828,16 +2828,20 @@
       "keywords": [
         "subscriptions",
         "report",
+        "active",
         "upcoming",
         "redeemed",
+        "projected",
+        "actual",
         "download",
         "csv",
         "season"
       ],
       "facts": [
-        "The Subscriptions Report shows upcoming and redeemed Meme Card subscription counts.",
+        "The Subscriptions Report shows active, upcoming, and redeemed Meme Card subscription counts.",
+        "On a mint day, the Active Drop section compares projected subscriptions with actual redeemed subscriptions and keeps that card out of Upcoming Drops and Past Drops.",
         "It includes download actions for redeemed subscription count reports.",
-        "It links users to their own Subscriptions tab when a connected profile is available."
+        "Its Manage or Connect to Subscribe action uses the same profile-subscriptions navigation and authentication handoff as the About Subscriptions page."
       ],
       "canonical_path": "/tools/subscriptions-report",
       "related_paths": ["/about/subscriptions"],

--- a/pr-reports/3133.md
+++ b/pr-reports/3133.md
@@ -11,19 +11,20 @@ The Memes subscriptions report now separates the current mint-day card into an `
 - Added Active Drop rendering for today's redeemed Meme Card, including projected and actual count columns.
 - Reused the About Subscriptions profile action so Manage and Connect to Subscribe follow the same connection, authentication, and redirect behavior.
 - Polished the redeemed CSV report panel with aligned controls, a custom season selector chevron, and an icon-supported download action.
+- Added an About Subscriptions overview link to the Subscriptions Report.
 - Updated route docs and help index records for the new active/projected/actual behavior.
 
 ## Frontend Impact
-- Routes/views: `/tools/subscriptions-report`.
-- Components: `components/subscriptions-report/SubscriptionsReport.tsx`.
+- Routes/views: `/tools/subscriptions-report`, `/about/subscriptions`.
+- Components: `components/subscriptions-report/SubscriptionsReport.tsx`, `components/about/AboutSubscriptions.tsx`.
 - Generated API/client: Not affected.
-- User-visible behavior: mint-day redeemed cards appear in Active Drop instead of Past Drops, and active rows compare projected subscriptions with actual redeemed subscriptions.
+- User-visible behavior: mint-day redeemed cards appear in Active Drop instead of Past Drops, active rows compare projected subscriptions with actual redeemed subscriptions, and the About Subscriptions overview links to the report.
 
 ## Config / Env
 None.
 
 ## Release Notes
-Subscriptions Report now has a mint-day Active Drop section with projected and actual subscription counts side by side. The profile action matches the About Subscriptions Manage / Connect flow, and the redeemed report download controls are visually tightened.
+Subscriptions Report now has a mint-day Active Drop section with projected and actual subscription counts side by side. The profile action matches the About Subscriptions Manage / Connect flow, the redeemed report download controls are visually tightened, and About Subscriptions links to the report.
 
 ## Risks / Follow-Ups
 None.

--- a/pr-reports/3133.md
+++ b/pr-reports/3133.md
@@ -1,0 +1,29 @@
+# PR Report: Active drop subscriptions report
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/3133
+Branch: codex/subscriptions-report-active-drop -> main
+Related PRs: None
+
+## Summary
+The Memes subscriptions report now separates the current mint-day card into an `Active Drop` section when today's redeemed data exists. The active row shows the card media and metadata, the projected subscription count, and the actual redeemed count, while the same token is excluded from Upcoming Drops and Past Drops.
+
+## What Changed
+- Added Active Drop rendering for today's redeemed Meme Card, including projected and actual count columns.
+- Reused the About Subscriptions profile action so Manage and Connect to Subscribe follow the same connection, authentication, and redirect behavior.
+- Polished the redeemed CSV report panel with aligned controls, a custom season selector chevron, and an icon-supported download action.
+- Updated route docs and help index records for the new active/projected/actual behavior.
+
+## Frontend Impact
+- Routes/views: `/tools/subscriptions-report`.
+- Components: `components/subscriptions-report/SubscriptionsReport.tsx`.
+- Generated API/client: Not affected.
+- User-visible behavior: mint-day redeemed cards appear in Active Drop instead of Past Drops, and active rows compare projected subscriptions with actual redeemed subscriptions.
+
+## Config / Env
+None.
+
+## Release Notes
+Subscriptions Report now has a mint-day Active Drop section with projected and actual subscription counts side by side. The profile action matches the About Subscriptions Manage / Connect flow, and the redeemed report download controls are visually tightened.
+
+## Risks / Follow-Ups
+None.

--- a/pr-reports/3133.md
+++ b/pr-reports/3133.md
@@ -12,19 +12,20 @@ The Memes subscriptions report now separates the current mint-day card into an `
 - Reused the About Subscriptions profile action so Manage and Connect to Subscribe follow the same connection, authentication, and redirect behavior.
 - Polished the redeemed CSV report panel with aligned controls, a custom season selector chevron, and an icon-supported download action.
 - Added an About Subscriptions overview link to the Subscriptions Report.
+- Kept active/past drop data available if upcoming counts fail and aligned Past Drops pagination totals with active-drop filtering.
 - Updated route docs and help index records for the new active/projected/actual behavior.
 
 ## Frontend Impact
 - Routes/views: `/tools/subscriptions-report`, `/about/subscriptions`.
 - Components: `components/subscriptions-report/SubscriptionsReport.tsx`, `components/about/AboutSubscriptions.tsx`.
 - Generated API/client: Not affected.
-- User-visible behavior: mint-day redeemed cards appear in Active Drop instead of Past Drops, active rows compare projected subscriptions with actual redeemed subscriptions, and the About Subscriptions overview links to the report.
+- User-visible behavior: mint-day redeemed cards appear in Active Drop instead of Past Drops, active rows compare projected subscriptions with actual redeemed subscriptions, the About Subscriptions overview links to the report, and Past Drops pagination counts match the filtered list.
 
 ## Config / Env
 None.
 
 ## Release Notes
-Subscriptions Report now has a mint-day Active Drop section with projected and actual subscription counts side by side. The profile action matches the About Subscriptions Manage / Connect flow, the redeemed report download controls are visually tightened, and About Subscriptions links to the report.
+Subscriptions Report now has a mint-day Active Drop section with projected and actual subscription counts side by side. The profile action matches the About Subscriptions Manage / Connect flow, the redeemed report download controls are visually tightened, and About Subscriptions links to the report without an underline.
 
 ## Risks / Follow-Ups
 None.

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -2703,16 +2703,18 @@
         "minting",
         "airdrop",
         "balance",
+        "report",
         "top",
         "up"
       ],
       "facts": [
         "The Memes subscriptions are an optional way to mint Meme Cards remotely, with potential gas savings or set-and-forget minting.",
         "Subscriptions are not a mintpass and do not create extra allowlist access.",
-        "Users manage their subscription mode, balance, airdrop address, top-ups, upcoming drops, and history under their profile Subscriptions tab."
+        "Users manage their subscription mode, balance, airdrop address, top-ups, upcoming drops, and history under their profile Subscriptions tab.",
+        "The About Subscriptions overview links to the Subscriptions Report for aggregate projected and redeemed subscription counts."
       ],
       "canonical_path": "/about/subscriptions",
-      "related_paths": ["/{user}/subscriptions"],
+      "related_paths": ["/{user}/subscriptions", "/tools/subscriptions-report"],
       "tags": ["subscriptions", "memes", "glossary"],
       "source_refs": [
         "ops/docs/open-data/feature-meme-subscriptions.md",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -2828,16 +2828,20 @@
       "keywords": [
         "subscriptions",
         "report",
+        "active",
         "upcoming",
         "redeemed",
+        "projected",
+        "actual",
         "download",
         "csv",
         "season"
       ],
       "facts": [
-        "The Subscriptions Report shows upcoming and redeemed Meme Card subscription counts.",
+        "The Subscriptions Report shows active, upcoming, and redeemed Meme Card subscription counts.",
+        "On a mint day, the Active Drop section compares projected subscriptions with actual redeemed subscriptions and keeps that card out of Upcoming Drops and Past Drops.",
         "It includes download actions for redeemed subscription count reports.",
-        "It links users to their own Subscriptions tab when a connected profile is available."
+        "Its Manage or Connect to Subscribe action uses the same profile-subscriptions navigation and authentication handoff as the About Subscriptions page."
       ],
       "canonical_path": "/tools/subscriptions-report",
       "related_paths": ["/about/subscriptions"],


### PR DESCRIPTION
## Issue
- On mint days, a newly dropped Meme Card immediately appeared under Past Drops, which switched the report from projected subscription counts to redeemed actuals without a current-drop distinction.
- The subscriptions report CTA and redeemed CSV panel needed to match the About Subscriptions experience more closely.

## Fix
- Add an Active Drop section for today's redeemed card, combining the existing redeemed actual count with the public projected count from `subscriptions/memes/{token_id}/count`.
- Reuse the About Subscriptions profile CTA so Manage / Connect to Subscribe follows the same connection, authentication, and redirect behavior.
- Polish the redeemed report download panel with aligned controls, a custom season-select chevron, and an icon-supported Download button.

## Changes
- Filters the active token out of both Upcoming Drops and Past Drops when today's redeemed card is present.
- Keeps Upcoming Drops on future projected counts, with active projection fetched from the homepage-used token count endpoint.
- Refactors shared card row rendering for active and past rows.
- Updates the subscriptions report docs and help index records.
- Extends the route test to cover Active Drop projected vs actual counts and filtering.

## Validation
- `./bin/6529 run test -- __tests__/app/tools/subscriptions-report.test.tsx`
- `./bin/6529 run check:changed`
- `./bin/6529 run help-index:sync`
- `./bin/6529 run react-doctor:diff` scanned the changed files before the formatting amend; the final committed tree had no uncommitted source diff for React Doctor to rescan.

## Risk
- Level: Low
- Why: Frontend-only report/UI change using existing endpoints and existing profile-subscriptions navigation.
- Rollback: Revert this PR to restore the previous upcoming/past-only report behavior.

## Review Notes
- Please focus on the mint-day split: today's redeemed card should appear only in Active Drop, with projected and actual counts side by side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new **Subscriptions Report** link in About Subscriptions.
  * Introduced an **Active Drop** section in the subscriptions report with projected vs. actual counts for mint-day activity.
  * Improved report actions with clearer **Manage** / **Connect to Subscribe** navigation.

* **Bug Fixes**
  * Prevented the active drop card from also appearing in **Upcoming** or **Past** lists.
  * Refined report pagination and count display for more accurate subscription totals.

* **Documentation**
  * Updated help content to describe the new report sections and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->