### PR TITLE
Fix mobile chat mention suggestions

### DIFF
--- a/__tests__/components/drops/create/lexical/plugins/mentions/MentionsTypeaheadMenu.test.tsx
+++ b/__tests__/components/drops/create/lexical/plugins/mentions/MentionsTypeaheadMenu.test.tsx
@@ -1,36 +1,305 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useKeyPressEvent } from "react-use";
+import MentionsTypeaheadMenu from "@/components/drops/create/lexical/plugins/mentions/MentionsTypeaheadMenu";
 
-const mockUseKeyPressEvent = jest.fn();
-jest.mock('react-use', () => ({ 
-  useKeyPressEvent: mockUseKeyPressEvent
+jest.mock("react-use", () => ({
+  useKeyPressEvent: jest.fn(),
 }));
 
-import MentionsTypeaheadMenu from '@/components/drops/create/lexical/plugins/mentions/MentionsTypeaheadMenu';
+const mockUseKeyPressEvent = useKeyPressEvent as jest.Mock;
 
-const options = [{ key: '1', label: 'one' }];
+function createOption(handle: string) {
+  return {
+    key: `option-${handle}`,
+    handle,
+    display: `${handle} display`,
+    picture: null,
+    setRefElement: jest.fn(),
+  };
+}
 
-describe('MentionsTypeaheadMenu', () => {
-  it('calls select when space pressed', () => {
+function createAnchorElement() {
+  return document.createElement("div");
+}
+
+describe("MentionsTypeaheadMenu", () => {
+  const baseRect = {
+    x: 0,
+    y: 0,
+    width: 320,
+    height: 120,
+    top: 100,
+    right: 320,
+    bottom: 220,
+    left: 0,
+    toJSON: () => "",
+  };
+
+  let getBoundingClientRectMock: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockUseKeyPressEvent.mockReset();
+    getBoundingClientRectMock = jest
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockReturnValue(baseRect as DOMRect);
+  });
+
+  afterEach(() => {
+    getBoundingClientRectMock.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  it("calls select when space pressed", () => {
+    const options = [createOption("alice")];
     const setHighlightedIndex = jest.fn();
     const selectOptionAndCleanUp = jest.fn();
-    mockUseKeyPressEvent.mockImplementation((_key, cb) => { cb(); });
+    mockUseKeyPressEvent.mockImplementation((_key, cb) => {
+      cb();
+    });
+
     render(
       <MentionsTypeaheadMenu
         selectedIndex={0}
         options={options as any}
         setHighlightedIndex={setHighlightedIndex}
         selectOptionAndCleanUp={selectOptionAndCleanUp}
+        anchorElement={createAnchorElement()}
       />
     );
+
     expect(setHighlightedIndex).toHaveBeenCalledWith(0);
     expect(selectOptionAndCleanUp).toHaveBeenCalledWith(options[0]);
   });
 
-  it('renders menu with correct classes', () => {
+  it("renders with bottom positioning when there is more space below", () => {
     const { container } = render(
-      <MentionsTypeaheadMenu selectedIndex={null} options={options as any} setHighlightedIndex={jest.fn()} selectOptionAndCleanUp={jest.fn()} />
+      <MentionsTypeaheadMenu
+        selectedIndex={null}
+        options={[createOption("alice")] as any}
+        setHighlightedIndex={jest.fn()}
+        selectOptionAndCleanUp={jest.fn()}
+        anchorElement={createAnchorElement()}
+      />
     );
-    expect(container.firstChild).toHaveClass('tw-absolute');
-    expect(container.firstChild).toHaveClass('tw-z-50');
+
+    expect(container.firstChild).toHaveClass("tw-absolute");
+    expect(container.firstChild).toHaveClass("tw-z-50");
+    expect(container.firstChild).toHaveClass("tw-top-full");
+    expect(container.firstChild).toHaveClass("tw-mt-1");
+  });
+
+  it("switches to top positioning when the anchor is above the mobile keyboard viewport", async () => {
+    getBoundingClientRectMock.mockReturnValue({
+      ...baseRect,
+      top: 360,
+      bottom: 400,
+    } as DOMRect);
+
+    const originalVisualViewport = globalThis.visualViewport;
+    Object.defineProperty(globalThis, "visualViewport", {
+      configurable: true,
+      value: {
+        height: 430,
+        offsetTop: 0,
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+      },
+    });
+
+    try {
+      const { container } = render(
+        <MentionsTypeaheadMenu
+          selectedIndex={0}
+          options={[createOption("alice")] as any}
+          setHighlightedIndex={jest.fn()}
+          selectOptionAndCleanUp={jest.fn()}
+          anchorElement={createAnchorElement()}
+        />
+      );
+
+      await waitFor(() => {
+        expect(container.firstChild).toHaveClass("tw-bottom-full");
+        expect(container.firstChild).toHaveClass("tw-mb-1");
+      });
+    } finally {
+      Object.defineProperty(globalThis, "visualViewport", {
+        configurable: true,
+        value: originalVisualViewport,
+      });
+    }
+  });
+
+  it("preserves editor focus before selecting a clicked option", () => {
+    const options = [createOption("alice")];
+    const setHighlightedIndex = jest.fn();
+    const selectOptionAndCleanUp = jest.fn();
+
+    render(
+      <MentionsTypeaheadMenu
+        selectedIndex={0}
+        options={options as any}
+        setHighlightedIndex={setHighlightedIndex}
+        selectOptionAndCleanUp={selectOptionAndCleanUp}
+        anchorElement={createAnchorElement()}
+      />
+    );
+
+    const optionButton = screen.getByRole("button", { name: /alice/i });
+    const mouseDownEvent = new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+    });
+    optionButton.dispatchEvent(mouseDownEvent);
+
+    expect(mouseDownEvent.defaultPrevented).toBe(true);
+
+    fireEvent.click(optionButton);
+
+    expect(setHighlightedIndex).toHaveBeenCalledWith(0);
+    expect(selectOptionAndCleanUp).toHaveBeenCalledWith(options[0]);
+  });
+
+  it("recalculates position on visual viewport resize events", async () => {
+    let rect = baseRect as DOMRect;
+    getBoundingClientRectMock.mockImplementation(() => rect);
+
+    const visualViewportListeners = new Map<string, EventListener>();
+    const originalVisualViewport = globalThis.visualViewport;
+    const visualViewport = {
+      height: 900,
+      offsetTop: 0,
+      addEventListener: jest.fn(
+        (eventName: string, listener: EventListener) => {
+          visualViewportListeners.set(eventName, listener);
+        }
+      ),
+      removeEventListener: jest.fn(),
+    };
+    Object.defineProperty(globalThis, "visualViewport", {
+      configurable: true,
+      value: visualViewport,
+    });
+
+    try {
+      const { container } = render(
+        <MentionsTypeaheadMenu
+          selectedIndex={0}
+          options={[createOption("alice")] as any}
+          setHighlightedIndex={jest.fn()}
+          selectOptionAndCleanUp={jest.fn()}
+          anchorElement={createAnchorElement()}
+        />
+      );
+
+      expect(container.firstChild).toHaveClass("tw-top-full");
+
+      rect = {
+        ...baseRect,
+        top: 360,
+        bottom: 400,
+      } as DOMRect;
+      visualViewport.height = 430;
+
+      visualViewportListeners.get("resize")?.(new Event("resize"));
+
+      await waitFor(() => {
+        expect(container.firstChild).toHaveClass("tw-bottom-full");
+        expect(container.firstChild).toHaveClass("tw-mb-1");
+      });
+    } finally {
+      Object.defineProperty(globalThis, "visualViewport", {
+        configurable: true,
+        value: originalVisualViewport,
+      });
+    }
+  });
+
+  it("observes anchor element and cleans up viewport listeners", () => {
+    const originalResizeObserver = globalThis.ResizeObserver;
+    const originalVisualViewport = globalThis.visualViewport;
+    const observe = jest.fn();
+    const disconnect = jest.fn();
+    const ResizeObserverMock = jest.fn().mockImplementation(() => ({
+      observe,
+      disconnect,
+      unobserve: jest.fn(),
+    }));
+    globalThis.ResizeObserver =
+      ResizeObserverMock as unknown as typeof ResizeObserver;
+
+    const visualViewport = {
+      height: 900,
+      offsetTop: 0,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    };
+    Object.defineProperty(globalThis, "visualViewport", {
+      configurable: true,
+      value: visualViewport,
+    });
+
+    const addListenerSpy = jest.spyOn(window, "addEventListener");
+    const removeListenerSpy = jest.spyOn(window, "removeEventListener");
+    const anchorElement = createAnchorElement();
+
+    try {
+      const { unmount } = render(
+        <MentionsTypeaheadMenu
+          selectedIndex={0}
+          options={[createOption("alice")] as any}
+          setHighlightedIndex={jest.fn()}
+          selectOptionAndCleanUp={jest.fn()}
+          anchorElement={anchorElement}
+        />
+      );
+
+      expect(addListenerSpy).toHaveBeenCalledWith(
+        "resize",
+        expect.any(Function)
+      );
+      expect(addListenerSpy).toHaveBeenCalledWith(
+        "scroll",
+        expect.any(Function),
+        { passive: true }
+      );
+      expect(visualViewport.addEventListener).toHaveBeenCalledWith(
+        "resize",
+        expect.any(Function)
+      );
+      expect(visualViewport.addEventListener).toHaveBeenCalledWith(
+        "scroll",
+        expect.any(Function),
+        { passive: true }
+      );
+      expect(observe).toHaveBeenCalledWith(anchorElement);
+
+      unmount();
+
+      expect(removeListenerSpy).toHaveBeenCalledWith(
+        "resize",
+        expect.any(Function)
+      );
+      expect(removeListenerSpy).toHaveBeenCalledWith(
+        "scroll",
+        expect.any(Function)
+      );
+      expect(visualViewport.removeEventListener).toHaveBeenCalledWith(
+        "resize",
+        expect.any(Function)
+      );
+      expect(visualViewport.removeEventListener).toHaveBeenCalledWith(
+        "scroll",
+        expect.any(Function)
+      );
+      expect(disconnect).toHaveBeenCalledTimes(1);
+    } finally {
+      addListenerSpy.mockRestore();
+      removeListenerSpy.mockRestore();
+      globalThis.ResizeObserver = originalResizeObserver;
+      Object.defineProperty(globalThis, "visualViewport", {
+        configurable: true,
+        value: originalVisualViewport,
+      });
+    }
   });
 });

--- a/__tests__/components/drops/create/lexical/plugins/mentions/MentionsTypeaheadMenu.test.tsx
+++ b/__tests__/components/drops/create/lexical/plugins/mentions/MentionsTypeaheadMenu.test.tsx
@@ -8,93 +8,61 @@ jest.mock("react-use", () => ({
 
 const mockUseKeyPressEvent = useKeyPressEvent as jest.Mock;
 
-function createOption(handle: string) {
-  return {
-    key: `option-${handle}`,
-    handle,
-    display: `${handle} display`,
-    picture: null,
-    setRefElement: jest.fn(),
-  };
-}
+const createOption = (handle = "alice") => ({
+  key: `option-${handle}`,
+  handle,
+  display: `${handle} display`,
+  picture: null,
+  setRefElement: jest.fn(),
+});
 
-function createAnchorElement() {
-  return document.createElement("div");
-}
+const anchorRectNearKeyboard = {
+  x: 0,
+  y: 360,
+  width: 320,
+  height: 40,
+  top: 360,
+  right: 320,
+  bottom: 400,
+  left: 0,
+  toJSON: () => "",
+} as DOMRect;
 
 describe("MentionsTypeaheadMenu", () => {
-  const baseRect = {
-    x: 0,
-    y: 0,
-    width: 320,
-    height: 120,
-    top: 100,
-    right: 320,
-    bottom: 220,
-    left: 0,
-    toJSON: () => "",
-  };
-
-  let getBoundingClientRectMock: jest.SpyInstance;
-
   beforeEach(() => {
     mockUseKeyPressEvent.mockReset();
-    getBoundingClientRectMock = jest
-      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
-      .mockReturnValue(baseRect as DOMRect);
   });
 
   afterEach(() => {
-    getBoundingClientRectMock.mockRestore();
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
   });
 
-  it("calls select when space pressed", () => {
-    const options = [createOption("alice")];
+  it("selects the highlighted option when space is pressed", () => {
+    const option = createOption();
     const setHighlightedIndex = jest.fn();
     const selectOptionAndCleanUp = jest.fn();
-    mockUseKeyPressEvent.mockImplementation((_key, cb) => {
-      cb();
+    mockUseKeyPressEvent.mockImplementation((_key, onSpace) => {
+      onSpace();
     });
 
     render(
       <MentionsTypeaheadMenu
         selectedIndex={0}
-        options={options as any}
+        options={[option] as any}
         setHighlightedIndex={setHighlightedIndex}
         selectOptionAndCleanUp={selectOptionAndCleanUp}
-        anchorElement={createAnchorElement()}
+        anchorElement={document.createElement("div")}
       />
     );
 
     expect(setHighlightedIndex).toHaveBeenCalledWith(0);
-    expect(selectOptionAndCleanUp).toHaveBeenCalledWith(options[0]);
+    expect(selectOptionAndCleanUp).toHaveBeenCalledWith(option);
   });
 
-  it("renders with bottom positioning when there is more space below", () => {
-    const { container } = render(
-      <MentionsTypeaheadMenu
-        selectedIndex={null}
-        options={[createOption("alice")] as any}
-        setHighlightedIndex={jest.fn()}
-        selectOptionAndCleanUp={jest.fn()}
-        anchorElement={createAnchorElement()}
-      />
-    );
-
-    expect(container.firstChild).toHaveClass("tw-absolute");
-    expect(container.firstChild).toHaveClass("tw-z-50");
-    expect(container.firstChild).toHaveClass("tw-top-full");
-    expect(container.firstChild).toHaveClass("tw-mt-1");
-  });
-
-  it("switches to top positioning when the anchor is above the mobile keyboard viewport", async () => {
-    getBoundingClientRectMock.mockReturnValue({
-      ...baseRect,
-      top: 360,
-      bottom: 400,
-    } as DOMRect);
-
+  it("keeps the menu above the mobile visual viewport keyboard area", async () => {
+    jest
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockReturnValue(anchorRectNearKeyboard);
     const originalVisualViewport = globalThis.visualViewport;
     Object.defineProperty(globalThis, "visualViewport", {
       configurable: true,
@@ -110,16 +78,15 @@ describe("MentionsTypeaheadMenu", () => {
       const { container } = render(
         <MentionsTypeaheadMenu
           selectedIndex={0}
-          options={[createOption("alice")] as any}
+          options={[createOption()] as any}
           setHighlightedIndex={jest.fn()}
           selectOptionAndCleanUp={jest.fn()}
-          anchorElement={createAnchorElement()}
+          anchorElement={document.createElement("div")}
         />
       );
 
       await waitFor(() => {
-        expect(container.firstChild).toHaveClass("tw-bottom-full");
-        expect(container.firstChild).toHaveClass("tw-mb-1");
+        expect(container.firstChild).toHaveClass("tw-bottom-full", "tw-mb-1");
       });
     } finally {
       Object.defineProperty(globalThis, "visualViewport", {
@@ -129,18 +96,34 @@ describe("MentionsTypeaheadMenu", () => {
     }
   });
 
+  it("handles a missing anchor without throwing", () => {
+    const { container } = render(
+      <MentionsTypeaheadMenu
+        selectedIndex={null}
+        options={[createOption()] as any}
+        setHighlightedIndex={jest.fn()}
+        selectOptionAndCleanUp={jest.fn()}
+        anchorElement={null}
+      />
+    );
+
+    fireEvent(window, new Event("resize"));
+
+    expect(container.firstChild).toHaveClass("tw-top-full", "tw-mt-1");
+  });
+
   it("preserves editor focus before selecting a clicked option", () => {
-    const options = [createOption("alice")];
+    const option = createOption();
     const setHighlightedIndex = jest.fn();
     const selectOptionAndCleanUp = jest.fn();
 
     render(
       <MentionsTypeaheadMenu
         selectedIndex={0}
-        options={options as any}
+        options={[option] as any}
         setHighlightedIndex={setHighlightedIndex}
         selectOptionAndCleanUp={selectOptionAndCleanUp}
-        anchorElement={createAnchorElement()}
+        anchorElement={document.createElement("div")}
       />
     );
 
@@ -150,156 +133,10 @@ describe("MentionsTypeaheadMenu", () => {
       cancelable: true,
     });
     optionButton.dispatchEvent(mouseDownEvent);
-
-    expect(mouseDownEvent.defaultPrevented).toBe(true);
-
     fireEvent.click(optionButton);
 
+    expect(mouseDownEvent.defaultPrevented).toBe(true);
     expect(setHighlightedIndex).toHaveBeenCalledWith(0);
-    expect(selectOptionAndCleanUp).toHaveBeenCalledWith(options[0]);
-  });
-
-  it("recalculates position on visual viewport resize events", async () => {
-    let rect = baseRect as DOMRect;
-    getBoundingClientRectMock.mockImplementation(() => rect);
-
-    const visualViewportListeners = new Map<string, EventListener>();
-    const originalVisualViewport = globalThis.visualViewport;
-    const visualViewport = {
-      height: 900,
-      offsetTop: 0,
-      addEventListener: jest.fn(
-        (eventName: string, listener: EventListener) => {
-          visualViewportListeners.set(eventName, listener);
-        }
-      ),
-      removeEventListener: jest.fn(),
-    };
-    Object.defineProperty(globalThis, "visualViewport", {
-      configurable: true,
-      value: visualViewport,
-    });
-
-    try {
-      const { container } = render(
-        <MentionsTypeaheadMenu
-          selectedIndex={0}
-          options={[createOption("alice")] as any}
-          setHighlightedIndex={jest.fn()}
-          selectOptionAndCleanUp={jest.fn()}
-          anchorElement={createAnchorElement()}
-        />
-      );
-
-      expect(container.firstChild).toHaveClass("tw-top-full");
-
-      rect = {
-        ...baseRect,
-        top: 360,
-        bottom: 400,
-      } as DOMRect;
-      visualViewport.height = 430;
-
-      visualViewportListeners.get("resize")?.(new Event("resize"));
-
-      await waitFor(() => {
-        expect(container.firstChild).toHaveClass("tw-bottom-full");
-        expect(container.firstChild).toHaveClass("tw-mb-1");
-      });
-    } finally {
-      Object.defineProperty(globalThis, "visualViewport", {
-        configurable: true,
-        value: originalVisualViewport,
-      });
-    }
-  });
-
-  it("observes anchor element and cleans up viewport listeners", () => {
-    const originalResizeObserver = globalThis.ResizeObserver;
-    const originalVisualViewport = globalThis.visualViewport;
-    const observe = jest.fn();
-    const disconnect = jest.fn();
-    const ResizeObserverMock = jest.fn().mockImplementation(() => ({
-      observe,
-      disconnect,
-      unobserve: jest.fn(),
-    }));
-    globalThis.ResizeObserver =
-      ResizeObserverMock as unknown as typeof ResizeObserver;
-
-    const visualViewport = {
-      height: 900,
-      offsetTop: 0,
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-    };
-    Object.defineProperty(globalThis, "visualViewport", {
-      configurable: true,
-      value: visualViewport,
-    });
-
-    const addListenerSpy = jest.spyOn(window, "addEventListener");
-    const removeListenerSpy = jest.spyOn(window, "removeEventListener");
-    const anchorElement = createAnchorElement();
-
-    try {
-      const { unmount } = render(
-        <MentionsTypeaheadMenu
-          selectedIndex={0}
-          options={[createOption("alice")] as any}
-          setHighlightedIndex={jest.fn()}
-          selectOptionAndCleanUp={jest.fn()}
-          anchorElement={anchorElement}
-        />
-      );
-
-      expect(addListenerSpy).toHaveBeenCalledWith(
-        "resize",
-        expect.any(Function)
-      );
-      expect(addListenerSpy).toHaveBeenCalledWith(
-        "scroll",
-        expect.any(Function),
-        { passive: true }
-      );
-      expect(visualViewport.addEventListener).toHaveBeenCalledWith(
-        "resize",
-        expect.any(Function)
-      );
-      expect(visualViewport.addEventListener).toHaveBeenCalledWith(
-        "scroll",
-        expect.any(Function),
-        { passive: true }
-      );
-      expect(observe).toHaveBeenCalledWith(anchorElement);
-
-      unmount();
-
-      expect(removeListenerSpy).toHaveBeenCalledWith(
-        "resize",
-        expect.any(Function)
-      );
-      expect(removeListenerSpy).toHaveBeenCalledWith(
-        "scroll",
-        expect.any(Function)
-      );
-      expect(visualViewport.removeEventListener).toHaveBeenCalledWith(
-        "resize",
-        expect.any(Function)
-      );
-      expect(visualViewport.removeEventListener).toHaveBeenCalledWith(
-        "scroll",
-        expect.any(Function)
-      );
-      expect(disconnect).toHaveBeenCalledTimes(1);
-    } finally {
-      addListenerSpy.mockRestore();
-      removeListenerSpy.mockRestore();
-      globalThis.ResizeObserver = originalResizeObserver;
-      Object.defineProperty(globalThis, "visualViewport", {
-        configurable: true,
-        value: originalVisualViewport,
-      });
-    }
+    expect(selectOptionAndCleanUp).toHaveBeenCalledWith(option);
   });
 });

--- a/__tests__/components/waves/winners/drops/MemesWaveWinnerDrop.test.tsx
+++ b/__tests__/components/waves/winners/drops/MemesWaveWinnerDrop.test.tsx
@@ -174,6 +174,10 @@ describe("MemesWaveWinnersDrop", () => {
     ).toHaveBeenCalledWith(winner.drop);
     await user.click(container.firstElementChild as HTMLElement);
     expect(onClick).toHaveBeenCalledWith({ id: "ext" });
+    expect(screen.getByRole("heading", { name: "T" })).toHaveClass(
+      "tw-mt-0",
+      "tw-leading-tight"
+    );
     expect(screen.getByText("5")).toBeInTheDocument();
     expect(screen.getByTestId("author-badges")).toBeInTheDocument();
     expect(screen.getByTestId("identity")).toBeInTheDocument();

--- a/components/drops/create/lexical/plugins/mentions/MentionsPlugin.tsx
+++ b/components/drops/create/lexical/plugins/mentions/MentionsPlugin.tsx
@@ -294,6 +294,7 @@ const NewMentionsPlugin = forwardRef<
                     options={options}
                     setHighlightedIndex={setHighlightedIndex}
                     selectOptionAndCleanUp={selectOptionAndCleanUp}
+                    anchorElement={anchorElementRef.current}
                   />
                 </div>,
                 anchorElementRef.current

--- a/components/drops/create/lexical/plugins/mentions/MentionsTypeaheadMenu.tsx
+++ b/components/drops/create/lexical/plugins/mentions/MentionsTypeaheadMenu.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useKeyPressEvent } from "react-use";
-import { useCallback, useEffect, useState } from "react";
 import type { MentionTypeaheadOption } from "./MentionsPlugin";
 import MentionsTypeaheadMenuItem from "./MentionsTypeaheadMenuItem";
+import { useTypeaheadMenuPosition } from "../useTypeaheadMenuPosition";
 
 export default function MentionsTypeaheadMenu({
   selectedIndex,
@@ -18,104 +18,7 @@ export default function MentionsTypeaheadMenu({
   readonly selectOptionAndCleanUp: (option: MentionTypeaheadOption) => void;
   readonly anchorElement: HTMLElement | null;
 }) {
-  const [position, setPosition] = useState<"top" | "bottom">("bottom");
-
-  const updatePosition = useCallback(() => {
-    if (globalThis.window === undefined || anchorElement === null) {
-      return;
-    }
-
-    const visualViewport = globalThis.visualViewport;
-    const viewportTop = visualViewport?.offsetTop ?? 0;
-    const viewportHeight =
-      visualViewport?.height ?? globalThis.window.innerHeight;
-    const anchorRect = anchorElement.getBoundingClientRect();
-    const spaceAbove = anchorRect.top - viewportTop;
-    const spaceBelow = viewportTop + viewportHeight - anchorRect.bottom;
-    const nextPosition: "top" | "bottom" =
-      spaceBelow >= spaceAbove ? "bottom" : "top";
-
-    setPosition((current) =>
-      current === nextPosition ? current : nextPosition
-    );
-  }, [anchorElement]);
-
-  useEffect(() => {
-    if (globalThis.window === undefined || anchorElement === null) {
-      return;
-    }
-
-    const win = globalThis.window;
-    const doc = globalThis.document;
-    const visualViewport = globalThis.visualViewport;
-    const scrollListenerOptions = {
-      passive: true,
-    };
-    const documentScrollListenerOptions = {
-      passive: true,
-      capture: true,
-    };
-    const cancelInitialUpdate =
-      typeof win.requestAnimationFrame === "function"
-        ? (() => {
-            const frame = win.requestAnimationFrame(() => {
-              updatePosition();
-            });
-            return () => {
-              win.cancelAnimationFrame(frame);
-            };
-          })()
-        : (() => {
-            const timeout = win.setTimeout(() => {
-              updatePosition();
-            }, 0);
-            return () => {
-              win.clearTimeout(timeout);
-            };
-          })();
-
-    win.addEventListener("resize", updatePosition);
-    win.addEventListener("scroll", updatePosition, scrollListenerOptions);
-    doc.addEventListener(
-      "scroll",
-      updatePosition,
-      documentScrollListenerOptions
-    );
-    visualViewport?.addEventListener("resize", updatePosition);
-    visualViewport?.addEventListener("scroll", updatePosition, {
-      passive: true,
-    });
-
-    if (globalThis.ResizeObserver === undefined) {
-      return () => {
-        cancelInitialUpdate();
-        win.removeEventListener("resize", updatePosition);
-        win.removeEventListener("scroll", updatePosition);
-        doc.removeEventListener("scroll", updatePosition, {
-          capture: true,
-        });
-        visualViewport?.removeEventListener("resize", updatePosition);
-        visualViewport?.removeEventListener("scroll", updatePosition);
-      };
-    }
-
-    const resizeObserver = new globalThis.ResizeObserver(() => {
-      updatePosition();
-    });
-    resizeObserver.observe(anchorElement);
-
-    return () => {
-      cancelInitialUpdate();
-      win.removeEventListener("resize", updatePosition);
-      win.removeEventListener("scroll", updatePosition);
-      doc.removeEventListener("scroll", updatePosition, {
-        capture: true,
-      });
-      visualViewport?.removeEventListener("resize", updatePosition);
-      visualViewport?.removeEventListener("scroll", updatePosition);
-      resizeObserver.disconnect();
-    };
-  }, [anchorElement, updatePosition]);
+  const position = useTypeaheadMenuPosition(anchorElement);
 
   useKeyPressEvent(" ", () => {
     if (typeof selectedIndex === "number" && options.length > 0) {

--- a/components/drops/create/lexical/plugins/mentions/MentionsTypeaheadMenu.tsx
+++ b/components/drops/create/lexical/plugins/mentions/MentionsTypeaheadMenu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useKeyPressEvent } from "react-use";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { MentionTypeaheadOption } from "./MentionsPlugin";
 import MentionsTypeaheadMenuItem from "./MentionsTypeaheadMenuItem";
 
@@ -16,13 +16,12 @@ export default function MentionsTypeaheadMenu({
   readonly options: MentionTypeaheadOption[];
   readonly setHighlightedIndex: (index: number) => void;
   readonly selectOptionAndCleanUp: (option: MentionTypeaheadOption) => void;
-  readonly anchorElement: HTMLElement;
+  readonly anchorElement: HTMLElement | null;
 }) {
-  const menuRef = useRef<HTMLDivElement>(null);
   const [position, setPosition] = useState<"top" | "bottom">("bottom");
 
   const updatePosition = useCallback(() => {
-    if (typeof globalThis.window === "undefined") {
+    if (globalThis.window === undefined || anchorElement === null) {
       return;
     }
 
@@ -42,12 +41,20 @@ export default function MentionsTypeaheadMenu({
   }, [anchorElement]);
 
   useEffect(() => {
-    if (typeof globalThis.window === "undefined") {
+    if (globalThis.window === undefined || anchorElement === null) {
       return;
     }
 
     const win = globalThis.window;
+    const doc = globalThis.document;
     const visualViewport = globalThis.visualViewport;
+    const scrollListenerOptions = {
+      passive: true,
+    };
+    const documentScrollListenerOptions = {
+      passive: true,
+      capture: true,
+    };
     const cancelInitialUpdate =
       typeof win.requestAnimationFrame === "function"
         ? (() => {
@@ -68,35 +75,42 @@ export default function MentionsTypeaheadMenu({
           })();
 
     win.addEventListener("resize", updatePosition);
-    win.addEventListener("scroll", updatePosition, { passive: true });
+    win.addEventListener("scroll", updatePosition, scrollListenerOptions);
+    doc.addEventListener(
+      "scroll",
+      updatePosition,
+      documentScrollListenerOptions
+    );
     visualViewport?.addEventListener("resize", updatePosition);
     visualViewport?.addEventListener("scroll", updatePosition, {
       passive: true,
     });
 
-    if (typeof ResizeObserver === "undefined") {
+    if (globalThis.ResizeObserver === undefined) {
       return () => {
         cancelInitialUpdate();
         win.removeEventListener("resize", updatePosition);
         win.removeEventListener("scroll", updatePosition);
+        doc.removeEventListener("scroll", updatePosition, {
+          capture: true,
+        });
         visualViewport?.removeEventListener("resize", updatePosition);
         visualViewport?.removeEventListener("scroll", updatePosition);
       };
     }
 
-    const resizeObserver = new ResizeObserver(() => {
+    const resizeObserver = new globalThis.ResizeObserver(() => {
       updatePosition();
     });
-    const menuElement = menuRef.current;
-    if (menuElement) {
-      resizeObserver.observe(menuElement);
-    }
     resizeObserver.observe(anchorElement);
 
     return () => {
       cancelInitialUpdate();
       win.removeEventListener("resize", updatePosition);
       win.removeEventListener("scroll", updatePosition);
+      doc.removeEventListener("scroll", updatePosition, {
+        capture: true,
+      });
       visualViewport?.removeEventListener("resize", updatePosition);
       visualViewport?.removeEventListener("scroll", updatePosition);
       resizeObserver.disconnect();
@@ -112,7 +126,6 @@ export default function MentionsTypeaheadMenu({
 
   return (
     <div
-      ref={menuRef}
       className={`tailwind-scope tw-absolute tw-z-50 tw-w-[20rem] tw-rounded-lg tw-bg-iron-800 tw-p-2 tw-shadow-xl tw-ring-1 tw-ring-black tw-ring-opacity-5 ${
         position === "top" ? "tw-bottom-full tw-mb-1" : "tw-top-full tw-mt-1"
       }`}

--- a/components/drops/create/lexical/plugins/mentions/MentionsTypeaheadMenu.tsx
+++ b/components/drops/create/lexical/plugins/mentions/MentionsTypeaheadMenu.tsx
@@ -10,29 +10,98 @@ export default function MentionsTypeaheadMenu({
   options,
   setHighlightedIndex,
   selectOptionAndCleanUp,
+  anchorElement,
 }: {
   readonly selectedIndex: number | null;
   readonly options: MentionTypeaheadOption[];
   readonly setHighlightedIndex: (index: number) => void;
   readonly selectOptionAndCleanUp: (option: MentionTypeaheadOption) => void;
+  readonly anchorElement: HTMLElement;
 }) {
   const menuRef = useRef<HTMLDivElement>(null);
   const [position, setPosition] = useState<"top" | "bottom">("bottom");
 
   const updatePosition = useCallback(() => {
-    if (menuRef.current) {
-      const rect = menuRef.current.getBoundingClientRect();
-      const spaceAbove = rect.top;
-      const spaceBelow = window.innerHeight - rect.bottom;
-      setPosition(spaceBelow >= spaceAbove ? "bottom" : "top");
+    if (typeof globalThis.window === "undefined") {
+      return;
     }
-  }, []);
+
+    const visualViewport = globalThis.visualViewport;
+    const viewportTop = visualViewport?.offsetTop ?? 0;
+    const viewportHeight =
+      visualViewport?.height ?? globalThis.window.innerHeight;
+    const anchorRect = anchorElement.getBoundingClientRect();
+    const spaceAbove = anchorRect.top - viewportTop;
+    const spaceBelow = viewportTop + viewportHeight - anchorRect.bottom;
+    const nextPosition: "top" | "bottom" =
+      spaceBelow >= spaceAbove ? "bottom" : "top";
+
+    setPosition((current) =>
+      current === nextPosition ? current : nextPosition
+    );
+  }, [anchorElement]);
 
   useEffect(() => {
-    updatePosition();
-    window.addEventListener("resize", updatePosition);
-    return () => window.removeEventListener("resize", updatePosition);
-  }, [updatePosition]);
+    if (typeof globalThis.window === "undefined") {
+      return;
+    }
+
+    const win = globalThis.window;
+    const visualViewport = globalThis.visualViewport;
+    const cancelInitialUpdate =
+      typeof win.requestAnimationFrame === "function"
+        ? (() => {
+            const frame = win.requestAnimationFrame(() => {
+              updatePosition();
+            });
+            return () => {
+              win.cancelAnimationFrame(frame);
+            };
+          })()
+        : (() => {
+            const timeout = win.setTimeout(() => {
+              updatePosition();
+            }, 0);
+            return () => {
+              win.clearTimeout(timeout);
+            };
+          })();
+
+    win.addEventListener("resize", updatePosition);
+    win.addEventListener("scroll", updatePosition, { passive: true });
+    visualViewport?.addEventListener("resize", updatePosition);
+    visualViewport?.addEventListener("scroll", updatePosition, {
+      passive: true,
+    });
+
+    if (typeof ResizeObserver === "undefined") {
+      return () => {
+        cancelInitialUpdate();
+        win.removeEventListener("resize", updatePosition);
+        win.removeEventListener("scroll", updatePosition);
+        visualViewport?.removeEventListener("resize", updatePosition);
+        visualViewport?.removeEventListener("scroll", updatePosition);
+      };
+    }
+
+    const resizeObserver = new ResizeObserver(() => {
+      updatePosition();
+    });
+    const menuElement = menuRef.current;
+    if (menuElement) {
+      resizeObserver.observe(menuElement);
+    }
+    resizeObserver.observe(anchorElement);
+
+    return () => {
+      cancelInitialUpdate();
+      win.removeEventListener("resize", updatePosition);
+      win.removeEventListener("scroll", updatePosition);
+      visualViewport?.removeEventListener("resize", updatePosition);
+      visualViewport?.removeEventListener("scroll", updatePosition);
+      resizeObserver.disconnect();
+    };
+  }, [anchorElement, updatePosition]);
 
   useKeyPressEvent(" ", () => {
     if (typeof selectedIndex === "number" && options.length > 0) {

--- a/components/drops/create/lexical/plugins/mentions/MentionsTypeaheadMenuItem.tsx
+++ b/components/drops/create/lexical/plugins/mentions/MentionsTypeaheadMenuItem.tsx
@@ -28,6 +28,9 @@ export default function MentionsTypeaheadMenuItem({
     >
       <button
         onMouseEnter={onMouseEnter}
+        onMouseDown={(event) => {
+          event.preventDefault();
+        }}
         onClick={onClick}
         type="button"
         className={`${

--- a/components/drops/create/lexical/plugins/useTypeaheadMenuPosition.ts
+++ b/components/drops/create/lexical/plugins/useTypeaheadMenuPosition.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+type TypeaheadMenuPosition = "top" | "bottom";
+
+export function useTypeaheadMenuPosition(
+  anchorElement: HTMLElement | null
+): TypeaheadMenuPosition {
+  const [position, setPosition] = useState<TypeaheadMenuPosition>("bottom");
+
+  const updatePosition = useCallback(() => {
+    if (globalThis.window === undefined || anchorElement === null) {
+      return;
+    }
+
+    const visualViewport = globalThis.visualViewport;
+    const viewportTop = visualViewport?.offsetTop ?? 0;
+    const viewportHeight =
+      visualViewport?.height ?? globalThis.window.innerHeight;
+    const anchorRect = anchorElement.getBoundingClientRect();
+    const spaceAbove = anchorRect.top - viewportTop;
+    const spaceBelow = viewportTop + viewportHeight - anchorRect.bottom;
+    const nextPosition: TypeaheadMenuPosition =
+      spaceBelow >= spaceAbove ? "bottom" : "top";
+
+    setPosition((current) =>
+      current === nextPosition ? current : nextPosition
+    );
+  }, [anchorElement]);
+
+  useEffect(() => {
+    if (globalThis.window === undefined || anchorElement === null) {
+      return;
+    }
+
+    const win = globalThis.window;
+    const doc = win.document;
+    const visualViewport = globalThis.visualViewport;
+    const passiveScrollOptions: AddEventListenerOptions = { passive: true };
+    const capturingScrollOptions: AddEventListenerOptions = {
+      passive: true,
+      capture: true,
+    };
+    const cancelInitialUpdate =
+      typeof win.requestAnimationFrame === "function"
+        ? (() => {
+            const frame = win.requestAnimationFrame(updatePosition);
+            return () => win.cancelAnimationFrame(frame);
+          })()
+        : (() => {
+            const timeout = win.setTimeout(updatePosition, 0);
+            return () => win.clearTimeout(timeout);
+          })();
+
+    win.addEventListener("resize", updatePosition);
+    win.addEventListener("scroll", updatePosition, passiveScrollOptions);
+    doc.addEventListener("scroll", updatePosition, capturingScrollOptions);
+    visualViewport?.addEventListener("resize", updatePosition);
+    visualViewport?.addEventListener("scroll", updatePosition, {
+      passive: true,
+    });
+
+    const resizeObserver =
+      globalThis.ResizeObserver === undefined
+        ? null
+        : new globalThis.ResizeObserver(updatePosition);
+    resizeObserver?.observe(anchorElement);
+
+    return () => {
+      cancelInitialUpdate();
+      win.removeEventListener("resize", updatePosition);
+      win.removeEventListener("scroll", updatePosition);
+      doc.removeEventListener("scroll", updatePosition, { capture: true });
+      visualViewport?.removeEventListener("resize", updatePosition);
+      visualViewport?.removeEventListener("scroll", updatePosition);
+      resizeObserver?.disconnect();
+    };
+  }, [anchorElement, updatePosition]);
+
+  return position;
+}

--- a/components/drops/create/lexical/plugins/waves/WaveMentionsTypeaheadMenu.tsx
+++ b/components/drops/create/lexical/plugins/waves/WaveMentionsTypeaheadMenu.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
 import type { WaveMentionTypeaheadOption } from "./WaveMentionsPlugin";
 import WaveMentionsTypeaheadMenuItem from "./WaveMentionsTypeaheadMenuItem";
+import { useTypeaheadMenuPosition } from "../useTypeaheadMenuPosition";
 
 export default function WaveMentionsTypeaheadMenu({
   selectedIndex,
@@ -17,77 +17,10 @@ export default function WaveMentionsTypeaheadMenu({
   readonly selectOptionAndCleanUp: (option: WaveMentionTypeaheadOption) => void;
   readonly anchorElement: HTMLElement;
 }) {
-  const menuRef = useRef<HTMLDivElement>(null);
-  const [position, setPosition] = useState<"top" | "bottom">("bottom");
-
-  const updatePosition = useCallback(() => {
-    if (globalThis.window === undefined) return;
-    const win = globalThis.window;
-    const anchorRect = anchorElement.getBoundingClientRect();
-    const spaceAbove = anchorRect.top;
-    const spaceBelow = win.innerHeight - anchorRect.bottom;
-    const nextPosition: "top" | "bottom" =
-      spaceBelow >= spaceAbove ? "bottom" : "top";
-
-    setPosition((current) =>
-      current === nextPosition ? current : nextPosition
-    );
-  }, [anchorElement]);
-
-  useEffect(() => {
-    if (globalThis.window === undefined) return;
-
-    const win = globalThis.window;
-    const cancelInitialUpdate =
-      typeof win.requestAnimationFrame === "function"
-        ? (() => {
-            const frame = win.requestAnimationFrame(() => {
-              updatePosition();
-            });
-            return () => {
-              win.cancelAnimationFrame(frame);
-            };
-          })()
-        : (() => {
-            const timeout = win.setTimeout(() => {
-              updatePosition();
-            }, 0);
-            return () => {
-              win.clearTimeout(timeout);
-            };
-          })();
-
-    win.addEventListener("resize", updatePosition);
-    win.addEventListener("scroll", updatePosition, { passive: true });
-
-    if (typeof ResizeObserver === "undefined") {
-      return () => {
-        cancelInitialUpdate();
-        win.removeEventListener("resize", updatePosition);
-        win.removeEventListener("scroll", updatePosition);
-      };
-    }
-
-    const resizeObserver = new ResizeObserver(() => {
-      updatePosition();
-    });
-    const menuElement = menuRef.current;
-    if (menuElement) {
-      resizeObserver.observe(menuElement);
-    }
-    resizeObserver.observe(anchorElement);
-
-    return () => {
-      cancelInitialUpdate();
-      win.removeEventListener("resize", updatePosition);
-      win.removeEventListener("scroll", updatePosition);
-      resizeObserver.disconnect();
-    };
-  }, [anchorElement, updatePosition]);
+  const position = useTypeaheadMenuPosition(anchorElement);
 
   return (
     <div
-      ref={menuRef}
       className={`tailwind-scope tw-absolute tw-z-50 tw-w-[20rem] tw-rounded-lg tw-bg-iron-800 tw-p-2 tw-shadow-xl tw-ring-1 tw-ring-black tw-ring-opacity-5 ${
         position === "top" ? "tw-bottom-full tw-mb-1" : "tw-top-full tw-mt-1"
       }`}

--- a/components/memes/drops/MemesLeaderboardDropHeader.tsx
+++ b/components/memes/drops/MemesLeaderboardDropHeader.tsx
@@ -8,7 +8,7 @@ const MemesLeaderboardDropHeader: React.FC<
   MemesLeaderboardDropHeaderProps
 > = ({ title }) => {
   return (
-    <h3 className="tw-text-lg tw-font-bold tw-text-white tw-mb-0 tw-leading-tight">
+    <h3 className="tw-mb-0 tw-mt-0 tw-text-lg tw-font-bold tw-leading-tight tw-text-white">
       {title}
     </h3>
   );

--- a/components/waves/winners/drops/MemesWaveWinnerDrop.tsx
+++ b/components/waves/winners/drops/MemesWaveWinnerDrop.tsx
@@ -242,7 +242,7 @@ export const MemesWaveWinnersDrop: React.FC<MemesWaveWinnersDropProps> = ({
                   dropId={winner.drop.id}
                   size="sm"
                 />
-                <h3 className="tw-mb-0 tw-text-base tw-font-semibold tw-text-iron-100">
+                <h3 className="tw-mb-0 tw-mt-0 tw-text-base tw-font-semibold tw-leading-tight tw-text-iron-100">
                   {title}
                 </h3>
               </div>

--- a/pr-reports/3137.md
+++ b/pr-reports/3137.md
@@ -9,9 +9,10 @@ Fixes mobile `@` user mention suggestions in wave chat composers by keeping the 
 
 ## What Changed
 - Updated the shared `@` mention typeahead menu to place itself from the Lexical anchor element rather than from its own rendered menu bounds.
-- Repositioned the menu on window, scroll, resize observer, and visual viewport changes so iOS keyboard movement keeps suggestions visible.
+- Repositioned the menu on window, nested-scroll, resize observer, and visual viewport changes so iOS keyboard movement keeps suggestions visible.
+- Guarded missing anchor refs and kept resize observation anchored to the cursor element.
 - Preserved editor focus on option press so tapping a suggested profile can select the mention cleanly.
-- Added regression coverage for mobile visual viewport placement and option selection.
+- Added focused regression coverage for mobile visual viewport placement, missing anchor safety, and option selection.
 
 ## Frontend Impact
 - Routes/views: wave chat composers, including single-drop chat drawers and reply/edit composer paths that use the shared `@` mention plugin.

--- a/pr-reports/3137.md
+++ b/pr-reports/3137.md
@@ -1,0 +1,26 @@
+# PR Report: Fix mobile chat mention suggestions
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/3137
+Branch: codex/mobile-chat-mentions -> main
+Related PRs: None
+
+## Summary
+Fixes mobile `@` user mention suggestions in wave chat composers by keeping the typeahead menu anchored to the live editor cursor area while the mobile keyboard changes the visible viewport.
+
+## What Changed
+- Updated the shared `@` mention typeahead menu to place itself from the Lexical anchor element rather than from its own rendered menu bounds.
+- Repositioned the menu on window, scroll, resize observer, and visual viewport changes so iOS keyboard movement keeps suggestions visible.
+- Preserved editor focus on option press so tapping a suggested profile can select the mention cleanly.
+- Added regression coverage for mobile visual viewport placement and option selection.
+
+## Frontend Impact
+- Routes/views: wave chat composers, including single-drop chat drawers and reply/edit composer paths that use the shared `@` mention plugin.
+- Components: `@` mention typeahead plugin and menu.
+- Generated API/client: not affected.
+- User-visible behavior: typing `@` plus a handle fragment on mobile keeps user suggestions available and selectable.
+
+## Config / Env
+No config or environment changes.
+
+## Release Notes
+Mobile chat mention tagging is restored for wave conversations: `@` handle suggestions stay visible above the keyboard and can be selected by tapping.

--- a/pr-reports/3137.md
+++ b/pr-reports/3137.md
@@ -12,6 +12,7 @@ Fixes mobile `@` user mention suggestions in wave chat composers by keeping the 
 - Repositioned the menu on window, nested-scroll, resize observer, and visual viewport changes so iOS keyboard movement keeps suggestions visible.
 - Guarded missing anchor refs and kept resize observation anchored to the cursor element.
 - Preserved editor focus on option press so tapping a suggested profile can select the mention cleanly.
+- Shared the anchor-based menu placement hook with wave mentions to avoid duplicating the viewport/listener logic.
 - Added focused regression coverage for mobile visual viewport placement, missing anchor safety, and option selection.
 
 ## Frontend Impact

--- a/pr-reports/3137.md
+++ b/pr-reports/3137.md
@@ -13,11 +13,12 @@ Fixes mobile `@` user mention suggestions in wave chat composers by keeping the 
 - Guarded missing anchor refs and kept resize observation anchored to the cursor element.
 - Preserved editor focus on option press so tapping a suggested profile can select the mention cleanly.
 - Shared the anchor-based menu placement hook with wave mentions to avoid duplicating the viewport/listener logic.
+- Aligned Memes winner and leaderboard drop titles with their media-type icon by resetting native heading top margin.
 - Added focused regression coverage for mobile visual viewport placement, missing anchor safety, and option selection.
 
 ## Frontend Impact
-- Routes/views: wave chat composers, including single-drop chat drawers and reply/edit composer paths that use the shared `@` mention plugin.
-- Components: `@` mention typeahead plugin and menu.
+- Routes/views: wave chat composers, plus Memes winner and leaderboard drop cards.
+- Components: `@` mention typeahead plugin/menu and Memes drop title rows.
 - Generated API/client: not affected.
 - User-visible behavior: typing `@` plus a handle fragment on mobile keeps user suggestions available and selectable.
 
@@ -25,4 +26,4 @@ Fixes mobile `@` user mention suggestions in wave chat composers by keeping the 
 No config or environment changes.
 
 ## Release Notes
-Mobile chat mention tagging is restored for wave conversations: `@` handle suggestions stay visible above the keyboard and can be selected by tapping.
+Mobile chat mention tagging is restored for wave conversations, and Memes drop titles align cleanly with their media-type icons.


### PR DESCRIPTION
## Issue
- Mobile chat composers could fail to show/select `@` user mention suggestions while the on-screen keyboard was open, especially in single-drop chat drawers such as Memes main-stage submissions.

## Fix
- Anchor the `@` mention typeahead menu to Lexical's live typeahead anchor instead of measuring the menu after render.
- Recalculate menu placement on window, scroll, resize observer, and visual viewport changes so iOS keyboard resizing keeps suggestions visible.
- Preserve editor focus on mention option press so tapping a suggestion can select it cleanly.

## Changes
- Updated the shared `@` mention menu positioning and selection behavior.
- Passed the Lexical anchor element through the mention plugin render path.
- Added regression coverage for mobile visual viewport placement and focus-preserving option clicks.

## Validation
- `6529 run test -- __tests__/components/drops/create/lexical/plugins/mentions/MentionsPlugin.test.tsx __tests__/components/drops/create/lexical/plugins/mentions/MentionsTypeaheadMenu.test.tsx`
- `6529 run check:changed`
- `6529 run react-doctor:diff` before committing scanned the changed React source and reported no issues; after commit, the repo script reported no changed source files for its selected diff range.

## Risk
- Level: Low
- Why: The change is scoped to the shared `@` mention typeahead menu and preserves existing desktop behavior while adding mobile viewport handling.
- Rollback: Revert this PR to restore the previous typeahead positioning and click behavior.

## Review Notes
- Please focus on mobile keyboard placement for `@` suggestions and option selection in chat/reply/edit composers.