### PR TITLE
[codex] Raise mobile mention typeahead layer

### DIFF
--- a/__tests__/components/drops/create/lexical/plugins/mentions/MentionsPlugin.test.tsx
+++ b/__tests__/components/drops/create/lexical/plugins/mentions/MentionsPlugin.test.tsx
@@ -86,6 +86,32 @@ describe("MentionsPlugin", () => {
     expect(close).toHaveBeenCalled();
   });
 
+  it("renders the menu wrapper on the raised typeahead layer", () => {
+    (useIdentitiesSearch as jest.Mock).mockReturnValue({
+      identities: [{ id: "1", handle: "alice", display: "Alice", pfp: null }],
+    });
+
+    render(
+      <NewMentionsPlugin waveId="w1" onSelect={jest.fn()} ref={createRef()} />
+    );
+
+    const portal = capturedProps.menuRenderFn(
+      { current: document.createElement("div") },
+      {
+        selectedIndex: null,
+        selectOptionAndCleanUp: jest.fn(),
+        setHighlightedIndex: jest.fn(),
+      }
+    ) as React.ReactPortal | null;
+    const wrapper = portal?.children;
+
+    expect(React.isValidElement<{ className: string }>(wrapper)).toBe(true);
+    if (!React.isValidElement<{ className: string }>(wrapper)) {
+      throw new Error("Expected mention typeahead menu wrapper element");
+    }
+    expect(wrapper.props.className).toContain("tw-z-[1020]");
+  });
+
   it("adds @all option for admins and emits group mention", () => {
     (useIdentitiesSearch as jest.Mock).mockReturnValue({
       identities: [],

--- a/__tests__/components/drops/create/lexical/plugins/mentions/MentionsPlugin.test.tsx
+++ b/__tests__/components/drops/create/lexical/plugins/mentions/MentionsPlugin.test.tsx
@@ -53,6 +53,7 @@ describe("MentionsPlugin", () => {
     render(<NewMentionsPlugin waveId="w1" onSelect={jest.fn()} ref={ref} />);
     expect(capturedProps.options).toHaveLength(1);
     expect(capturedProps.options[0]).toBeInstanceOf(MentionTypeaheadOption);
+    expect(capturedProps.anchorClassName).toBe("tailwind-scope tw-z-[1020]");
 
     act(() => {
       capturedProps.onOpen();

--- a/components/drops/create/lexical/plugins/mentions/MentionsPlugin.tsx
+++ b/components/drops/create/lexical/plugins/mentions/MentionsPlugin.tsx
@@ -91,6 +91,7 @@ const AtSignMentionsRegexAliasRegex = new RegExp(
 
 // At most, 5 suggestions are shown in the popup.
 const SUGGESTION_LIST_LENGTH_LIMIT = 5;
+// Keep mentions above single-drop mobile chat menus/dialogs while below global modal layers.
 const TYPEAHEAD_ANCHOR_CLASS_NAME = "tailwind-scope tw-z-[1020]";
 const TYPEAHEAD_MENU_WRAPPER_CLASS_NAME =
   "tw-absolute -tw-top-12 tw-left-0 tw-z-[1020]";

--- a/components/drops/create/lexical/plugins/mentions/MentionsPlugin.tsx
+++ b/components/drops/create/lexical/plugins/mentions/MentionsPlugin.tsx
@@ -91,6 +91,9 @@ const AtSignMentionsRegexAliasRegex = new RegExp(
 
 // At most, 5 suggestions are shown in the popup.
 const SUGGESTION_LIST_LENGTH_LIMIT = 5;
+const TYPEAHEAD_ANCHOR_CLASS_NAME = "tailwind-scope tw-z-[1020]";
+const TYPEAHEAD_MENU_WRAPPER_CLASS_NAME =
+  "tw-absolute -tw-top-12 tw-left-0 tw-z-[1020]";
 
 function checkForAtSignMentions(
   text: string,
@@ -282,13 +285,14 @@ const NewMentionsPlugin = forwardRef<
         options={options}
         onOpen={() => setIsOpen(true)}
         onClose={() => setIsOpen(false)}
+        anchorClassName={TYPEAHEAD_ANCHOR_CLASS_NAME}
         menuRenderFn={(
           anchorElementRef,
           { selectedIndex, selectOptionAndCleanUp, setHighlightedIndex }
         ) => {
           return anchorElementRef.current && options.length
             ? ReactDOM.createPortal(
-                <div className="tw-absolute -tw-top-12 tw-left-0 tw-z-[1000]">
+                <div className={TYPEAHEAD_MENU_WRAPPER_CLASS_NAME}>
                   <MentionsTypeaheadMenu
                     selectedIndex={selectedIndex}
                     options={options}


### PR DESCRIPTION
## Summary
- Raise the Lexical mention typeahead anchor above the mobile chat/composer overlay stack.
- Keep the inner mention menu wrapper on the same z-index layer.
- Add a focused regression assertion that the plugin passes the high-z anchor class into Lexical.

## Root Cause
The prior fix made the mention menu keyboard-aware, but Lexical still appends its typeahead anchor to `document.body` without a z-index. On the single-drop mobile chat surface, the chat/composer layers can sit above that body-level anchor, so suggestions can be computed but not visible/selectable on mobile.

## Validation
- `./bin/6529 run test -- __tests__/components/drops/create/lexical/plugins/mentions/MentionsPlugin.test.tsx`
- `./bin/6529 run check:changed`

React Doctor was invoked with `./bin/6529 run react-doctor:diff`, but it skipped with no changed source files detected for this follow-up branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the mentions dropdown/typeahead layering and positioning so it reliably appears above surrounding interface elements.
  * Updated the typeahead anchor and menu wrapper styling to use a higher z-index for correct on-screen stacking.
* **Tests**
  * Strengthened mentions plugin tests to verify the exact anchor class styling and to confirm the menu wrapper renders on the raised typeahead layer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->