### PR TITLE
Resync glossary.json with the help corpus

### DIFF
--- a/public/glossary.json
+++ b/public/glossary.json
@@ -660,11 +660,13 @@
       "facts": [
         "The Memes subscriptions are an optional way to mint Meme Cards remotely, with potential gas savings or set-and-forget minting.",
         "Subscriptions are not a mintpass and do not create extra allowlist access.",
-        "Users manage their subscription mode, balance, airdrop address, top-ups, upcoming drops, and history under their profile Subscriptions tab."
+        "Users manage their subscription mode, balance, airdrop address, top-ups, upcoming drops, and history under their profile Subscriptions tab.",
+        "The About Subscriptions overview links to the Subscriptions Report for aggregate projected and redeemed subscription counts."
       ],
       "canonical_path": "/about/subscriptions",
       "related_paths": [
-        "/{user}/subscriptions"
+        "/{user}/subscriptions",
+        "/tools/subscriptions-report"
       ],
       "tags": [
         "subscriptions",


### PR DESCRIPTION
## What

Reruns `./bin/6529 run agent-files:sync` on main. Only `public/glossary.json` changes (+4/-2): the `subscriptions.overview` glossary term picks up the Subscriptions Report fact and the `/tools/subscriptions-report` related path that #3133 added to `ops/help/help-index.json`.

## Why

`__tests__/scripts/sync-agent-files.test.ts` fails on current main (000852152): the artifacts regenerated from the help corpus no longer match the committed `public/` files. Root cause: #3132 merged main mid-branch (bringing in #3133's subscriptions-report corpus records) and regenerated `llms.txt` + `help-index.json` but not `glossary.json`.

PR CI didn't catch it because "Installed app checks" selects suites via `jest --findRelatedTests` over changed files, which follows the module graph and can't trace this test's `fs.readFileSync` of the corpus/artifacts — so corpus edits never select the drift test.

## Verification

- Full jest run on clean main at 000852152: `sync-agent-files.test.ts` fails with exactly this glossary diff (plus one unrelated `NotificationsContext.test.tsx` flake that passes on rerun).
- After regeneration: `sync-agent-files.test.ts` passes (12 tests). `help-index:sync` was also rerun and produced no diff — `public/help-index.json` and `public/llms.txt` were already in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the glossary entry for “The Memes subscriptions” with clearer guidance.
  * Added a note that the About Subscriptions overview links to the Subscriptions Report.
  * Expanded related links to include the Subscriptions Report page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->