### PR TITLE
[codex] Sync agent glossary artifact

### DIFF
--- a/public/glossary.json
+++ b/public/glossary.json
@@ -660,11 +660,13 @@
       "facts": [
         "The Memes subscriptions are an optional way to mint Meme Cards remotely, with potential gas savings or set-and-forget minting.",
         "Subscriptions are not a mintpass and do not create extra allowlist access.",
-        "Users manage their subscription mode, balance, airdrop address, top-ups, upcoming drops, and history under their profile Subscriptions tab."
+        "Users manage their subscription mode, balance, airdrop address, top-ups, upcoming drops, and history under their profile Subscriptions tab.",
+        "The About Subscriptions overview links to the Subscriptions Report for aggregate projected and redeemed subscription counts."
       ],
       "canonical_path": "/about/subscriptions",
       "related_paths": [
-        "/{user}/subscriptions"
+        "/{user}/subscriptions",
+        "/tools/subscriptions-report"
       ],
       "tags": [
         "subscriptions",


### PR DESCRIPTION
## Issue
- The post-merge Coverage Floor workflow is failing because `public/glossary.json` drifted from `ops/help/help-index.json` after the About Subscriptions corpus change.

## Fix
- Regenerated the public agent glossary artifact so the committed output matches the help corpus.

## Changes
- Updated `public/glossary.json` with the Subscriptions Report fact and related route for About Subscriptions.

## Validation
- `./bin/6529 run agent-files:sync`
- `./bin/6529 run test -- __tests__/scripts/sync-agent-files.test.ts`
- Remote CI was not awaited by request.

## Risk
- Level: Low
- Why: Generated public agent artifact only; no runtime UI or API behavior changes.
- Rollback: Revert this single generated artifact commit.

## Review Notes
- Focus on confirming the glossary artifact matches the existing help corpus change.