### PR TITLE
CI: run agent-files drift suite on PRs that touch the help corpus or committed artifacts

### DIFF
--- a/.github/workflows/app-pr-ci.yml
+++ b/.github/workflows/app-pr-ci.yml
@@ -31,6 +31,7 @@ jobs:
       playwright_critical_shell_required: ${{ steps.plan_outputs.outputs.playwright_critical_shell_required }}
       dependency_governance_required: ${{ steps.plan_outputs.outputs.dependency_governance_required }}
       reviewbot_contract_required: ${{ steps.plan_outputs.outputs.reviewbot_contract_required }}
+      agent_files_sync_required: ${{ steps.plan_outputs.outputs.agent_files_sync_required }}
 
     steps:
       - name: Checkout code
@@ -226,6 +227,13 @@ jobs:
       - name: Verify reviewbot contract
         if: needs.plan.outputs.reviewbot_contract_required == 'true'
         run: ./bin/6529 run test:no-coverage -- __tests__/scripts/testing-strategy.test.ts
+
+      # jest --findRelatedTests follows the module import graph, so it cannot
+      # see this suite's fs reads of the help corpus and committed artifacts.
+      # The plan requests it by path whenever those files change.
+      - name: Verify agent files sync
+        if: needs.plan.outputs.agent_files_sync_required == 'true'
+        run: ./bin/6529 run test:no-coverage -- __tests__/scripts/sync-agent-files.test.ts
 
       - name: Lint changed source
         if: needs.plan.outputs.lint_changed_required == 'true'

--- a/__tests__/scripts/sync-agent-files.test.ts
+++ b/__tests__/scripts/sync-agent-files.test.ts
@@ -208,6 +208,9 @@ describe("sync-agent-files", () => {
         path.join(repoRoot, "public/help-index.json"),
         "utf8"
       );
+      // scripts/sync-help-index.cjs publishes the corpus as a byte-for-byte
+      // copy, normalizing only a missing trailing newline. If the publish
+      // step ever reserializes instead, update this assertion with it.
       expect(published).toBe(source.endsWith("\n") ? source : `${source}\n`);
     });
   });

--- a/__tests__/scripts/sync-agent-files.test.ts
+++ b/__tests__/scripts/sync-agent-files.test.ts
@@ -198,6 +198,20 @@ describe("sync-agent-files", () => {
     });
   });
 
+  describe("published help-index.json", () => {
+    it("matches the corpus (run `6529 run help-index:sync` after editing it)", () => {
+      const source = fs.readFileSync(
+        path.join(repoRoot, "ops/help/help-index.json"),
+        "utf8"
+      );
+      const published = fs.readFileSync(
+        path.join(repoRoot, "public/help-index.json"),
+        "utf8"
+      );
+      expect(published).toBe(source.endsWith("\n") ? source : `${source}\n`);
+    });
+  });
+
   describe("robots.txt agent discovery block", () => {
     it("appends the block after the generated directives", () => {
       const generated =

--- a/__tests__/scripts/testing-strategy.test.ts
+++ b/__tests__/scripts/testing-strategy.test.ts
@@ -392,10 +392,20 @@ describe("testing strategy CI plan", () => {
     expect(plan.checks.install.required).toBe(true);
   });
 
-  it("verifies agent files sync when a generator script changes", () => {
-    const plan = createCiPlan(["scripts/sync-help-index.cjs"]);
+  it.each([
+    "ops/help/llms.txt.template",
+    "public/glossary.json",
+    "public/help-index.json",
+    "public/robots.txt",
+    "scripts/sync-agent-files.cjs",
+    "scripts/sync-help-index.cjs",
+    "next-sitemap.config.ts",
+    "__tests__/scripts/sync-agent-files.test.ts",
+  ])("verifies agent files sync when %s changes", (file) => {
+    const plan = createCiPlan([file]);
 
     expect(plan.checks.agent_files_sync.required).toBe(true);
+    expect(plan.checks.install.required).toBe(true);
   });
 
   it("keeps corpus docs in the fast lane without agent files sync", () => {

--- a/__tests__/scripts/testing-strategy.test.ts
+++ b/__tests__/scripts/testing-strategy.test.ts
@@ -376,6 +376,34 @@ describe("testing strategy CI plan", () => {
 
     expect(plan.checks.reviewbot_contract.required).toBe(true);
   });
+
+  it("verifies agent files sync when the help corpus changes", () => {
+    const plan = createCiPlan(["ops/help/help-index.json"]);
+
+    expect(plan.checks.agent_files_sync.required).toBe(true);
+    expect(plan.checks.install.required).toBe(true);
+  });
+
+  it("verifies agent files sync when only committed artifacts change", () => {
+    const plan = createCiPlan(["public/llms.txt"]);
+
+    expect(plan.risk.computed_floor).toBe(1);
+    expect(plan.checks.agent_files_sync.required).toBe(true);
+    expect(plan.checks.install.required).toBe(true);
+  });
+
+  it("verifies agent files sync when a generator script changes", () => {
+    const plan = createCiPlan(["scripts/sync-help-index.cjs"]);
+
+    expect(plan.checks.agent_files_sync.required).toBe(true);
+  });
+
+  it("keeps corpus docs in the fast lane without agent files sync", () => {
+    const plan = createCiPlan(["ops/help/README.md"]);
+
+    expect(plan.checks.agent_files_sync.required).toBe(false);
+    expect(plan.checks.install.required).toBe(false);
+  });
 });
 
 describe("testing strategy CI security checks", () => {

--- a/ops/help/README.md
+++ b/ops/help/README.md
@@ -29,11 +29,19 @@ Each record should be short, factual, and linkable:
   whose canonical or related paths resolve to WordPress-migrated `page.tsx`
   files, or whose `source_refs` point at those files.
 
-Run this after editing:
+Run both sync steps after editing:
 
 ```bash
 ./bin/6529 run help-index:sync
+./bin/6529 run agent-files:sync
 ```
 
-The sync step validates record shape, required V1 records, source refs, and
-internal route paths, then writes `public/help-index.json`.
+`help-index:sync` validates record shape, required V1 records, source refs, and
+internal route paths, then writes `public/help-index.json`. `agent-files:sync`
+regenerates `public/glossary.json` and `public/llms.txt` from the corpus and
+`ops/help/llms.txt.template`.
+
+Commit the regenerated `public/` artifacts with the corpus change. PR CI runs
+`__tests__/scripts/sync-agent-files.test.ts` (the "Verify agent files sync"
+step) whenever these files change and fails if the committed artifacts drift
+from the corpus.

--- a/ops/scripts/testing-strategy.cjs
+++ b/ops/scripts/testing-strategy.cjs
@@ -214,6 +214,21 @@ const REVIEWBOT_CONTRACT_FILES = new Set([
   "ops/scripts/testing-strategy.cjs",
   "__tests__/scripts/testing-strategy.test.ts",
 ]);
+// Corpus, committed artifacts, and generators verified by
+// __tests__/scripts/sync-agent-files.test.ts. That suite reads these files
+// with fs, so jest --findRelatedTests cannot trace them through the module
+// graph; the plan must request the suite explicitly whenever they change.
+const AGENT_FILES_SYNC_FILES = new Set([
+  "public/glossary.json",
+  "public/help-index.json",
+  "public/llms.txt",
+  "public/robots.txt",
+  "scripts/sync-agent-files.cjs",
+  "scripts/sync-help-index.cjs",
+  "next-sitemap.config.ts",
+  "__tests__/scripts/sync-agent-files.test.ts",
+]);
+const AGENT_FILES_CORPUS_PREFIX = "ops/help/";
 const SOURCE_CODE_EXTENSIONS = new Set([
   ".js",
   ".jsx",
@@ -546,6 +561,19 @@ function isReviewbotContractFile(filePath) {
   return REVIEWBOT_CONTRACT_FILES.has(normalizePath(filePath));
 }
 
+function isAgentFilesSyncFile(filePath) {
+  const normalized = normalizePath(filePath);
+  if (AGENT_FILES_SYNC_FILES.has(normalized)) {
+    return true;
+  }
+  // Any corpus file except its docs; new templates or data files under
+  // ops/help/ must keep the committed artifacts in sync too.
+  return (
+    normalized.startsWith(AGENT_FILES_CORPUS_PREFIX) &&
+    !normalized.endsWith(".md")
+  );
+}
+
 function isBuildSensitiveFile(filePath) {
   const normalized = normalizePath(filePath);
   return (
@@ -592,6 +620,7 @@ function createCiPlan(files, options = {}) {
     isPlaywrightOrTestSupportFile
   );
   const hasReviewbotContract = normalizedFiles.some(isReviewbotContractFile);
+  const hasAgentFilesSync = normalizedFiles.some(isAgentFilesSyncFile);
   const hasBuildSensitive = normalizedFiles.some(isBuildSensitiveFile);
   const hasDeletedRuntimeSource = normalizedFiles.some(
     (file) =>
@@ -608,7 +637,8 @@ function createCiPlan(files, options = {}) {
     hasPackageGovernance ||
     hasPlaywrightOrTests ||
     hasRuntimeEvidenceNeed ||
-    hasBuildSensitive;
+    hasBuildSensitive ||
+    hasAgentFilesSync;
 
   return {
     schema_version: CI_PLAN_SCHEMA_VERSION,
@@ -642,6 +672,12 @@ function createCiPlan(files, options = {}) {
         hasReviewbotContract
           ? "Reviewbot config, manifest schema, or strategy tooling changed and must preserve existing lanes."
           : "No reviewbot contract files changed."
+      ),
+      agent_files_sync: check(
+        hasAgentFilesSync,
+        hasAgentFilesSync
+          ? "Help corpus, committed agent artifacts, or their generators changed; committed artifacts must match `6529 run help-index:sync` and `6529 run agent-files:sync` output."
+          : "No help corpus or agent artifact files changed."
       ),
       install: check(
         needsInstall,


### PR DESCRIPTION
## Problem

`__tests__/scripts/sync-agent-files.test.ts` verifies that the committed agent artifacts (`public/glossary.json`, `public/llms.txt`, `public/robots.txt`) match what `6529 run agent-files:sync` generates from `ops/help/help-index.json` + `ops/help/llms.txt.template`. But PR CI selects Jest suites with `jest --findRelatedTests`, which follows the **module import graph** — it cannot trace this suite's `fs.readFileSync` of those data files. Two concrete holes:

1. **Corpus edits** (`ops/help/*.json|.template`): the file list feeding `--findRelatedTests` is also restricted to `*.js/jsx/ts/tsx`, so these files never even enter it. A corpus PR that skipped the sync merged green and broke main's full suite (#3132, hotfixed by #3139 on 2026-07-06).
2. **Artifact-only edits** (`public/llms.txt` etc.): worse — these classify as level-1 `presentational-assets`, `install_required` comes out false, and the **entire Installed app checks job is skipped**, so no step-level fix alone could catch a hand-edited or stale artifact.

Because of hole 2, the fix lives in the CI plan (the same place the workflow already computes its changed-file gates), not in a bash diff inside the jest step.

## Fix

Same mechanism as the existing `reviewbot_contract` check + "Verify reviewbot contract" step:

- **`ops/scripts/testing-strategy.cjs`**: new `agent_files_sync` plan check. Fires when the diff touches `ops/help/**` (except `*.md`), the committed artifacts (`public/glossary.json`, `public/llms.txt`, `public/help-index.json`, `public/robots.txt`), the generators (`scripts/sync-agent-files.cjs`, `scripts/sync-help-index.cjs`, `next-sitemap.config.ts` — the robots block lives there), or the suite itself. It also forces `install` on so artifact-only PRs no longer skip the job. Plan changed-file lists come from `git diff --diff-filter=ACMRD`, so **deletions** of an artifact trigger the check too.
- **`.github/workflows/app-pr-ci.yml`**: expose `agent_files_sync_required` and add a "Verify agent files sync" step running `./bin/6529 run test:no-coverage -- __tests__/scripts/sync-agent-files.test.ts` (~36s standalone), mirroring the reviewbot contract step.
- **`__tests__/scripts/sync-agent-files.test.ts`**: `scripts/sync-help-index.cjs` had the same fs-read blindspot with **no drift test at all** (it's a run-on-load script with no exports). The suite now also asserts `public/help-index.json` matches the corpus byte-for-byte (mirroring the script's trailing-newline behavior), so the new CI step covers that artifact too.
- **`__tests__/scripts/testing-strategy.test.ts`**: four new plan cases — corpus change fires the check + install; artifact-only change fires both despite staying risk level 1; generator script change fires it; `ops/help/README.md` stays in the docs fast lane.
- **`ops/help/README.md`**: previously told corpus editors to run only `help-index:sync` — exactly the #3132 trap. Now documents both sync commands and the CI enforcement.

## Verification

- Both suites pass locally: 51/51 (includes the 5 new tests).
- Workflow YAML parses; eslint clean on `testing-strategy.cjs`.
- This PR itself modifies `ops/scripts/testing-strategy.cjs` and the suite, so both the reviewbot-contract step and the new agent-files step should fire on this very PR — check the run for "Verify agent files sync".

## Known limits

- The related-jest step's `*.js/ts/...` pathspec still can't see `.cjs`/data files generally; this PR fixes the agent-files instance via the plan rather than reworking that step.
- `prebuild` regenerates the artifacts at build time, so production output was never stale — the failure mode was main's full suite going red after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CI checks to detect when help-related published files are out of sync with their source content.
  * Expanded the contributor guidance to include regenerating and committing the updated published help artifacts.

* **Bug Fixes**
  * Improved CI planning so relevant help-content changes now trigger the correct validation steps.
  * Added test coverage for the published help index and sync requirements to catch drift earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->