### PR TITLE
Disable create drop retries

### DIFF
--- a/components/waves/CreateDrop.tsx
+++ b/components/waves/CreateDrop.tsx
@@ -526,8 +526,7 @@ export default function CreateDrop({
       });
       body.onError?.(error);
     },
-    retry: (failureCount) => failureCount < 3,
-    retryDelay: (failureCount) => failureCount * 1000,
+    retry: false,
   });
 
   // Use refs to avoid stale closures - fixes the stream unmounting issue


### PR DESCRIPTION
## Issue
- Chat drop creation uses a non-idempotent `POST /drops` request.
- If the backend commits a drop and the response later fails or times out, the current React Query retry policy can replay the create request and produce duplicate real drops.

## Fix
- Disable React Query retries for the create-drop mutation.
- Keep the existing optimistic insert, success reconciliation, and error cleanup behavior unchanged.

## Changes
- Replaces the custom three-attempt retry policy for create-drop with `retry: false`.

## Validation
- Ran `git diff --check`.
- Reviewed the scoped diff.
- Did not run lint/typecheck/react-doctor because the local instruction policy requires explicit confirmation before project verification commands.

## Risk
- Level: Low
- Why: One mutation option changes; failed create attempts now surface the existing error toast instead of being replayed automatically.
- Rollback: Revert the commit to restore the prior retry behavior.

## Review Notes
- This is a frontend mitigation. The durable fix is backend idempotency for drop creation, such as a client-generated idempotency key stored with a uniqueness constraint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed drop submissions now stop immediately instead of retrying multiple times.
  * Error handling will surface issues faster, making failures easier to detect and respond to.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->