### PR TITLE
Clarify wave invite notifications

### DIFF
--- a/__tests__/components/brain/notifications/NotificationWaveCreated.test.tsx
+++ b/__tests__/components/brain/notifications/NotificationWaveCreated.test.tsx
@@ -9,7 +9,11 @@ jest.mock(
   "@/components/brain/notifications/wave-created/NotificationWaveFollowBtn",
   () => ({
     __esModule: true,
-    default: () => <div data-testid="wave-follow" />,
+    default: (props: { followLabel?: string; followingLabel?: string }) => (
+      <div data-testid="wave-follow">
+        {props.followLabel}/{props.followingLabel}
+      </div>
+    ),
   })
 );
 jest.mock("@/hooks/useDeviceInfo", () => ({
@@ -18,7 +22,11 @@ jest.mock("@/hooks/useDeviceInfo", () => ({
 }));
 jest.mock("@/components/brain/notifications/NotificationsFollowBtn", () => ({
   __esModule: true,
-  default: () => <div data-testid="follow-btn" />,
+  default: (props: { followLabel?: string; followingLabel?: string }) => (
+    <div data-testid="follow-btn">
+      {props.followLabel}/{props.followingLabel}
+    </div>
+  ),
 }));
 jest.mock("@/helpers/image.helpers", () => ({
   getScaledImageUri: () => "/scaled.jpg",
@@ -51,10 +59,42 @@ it("renders wave data and links", () => {
     "href",
     "/waves/1"
   );
-  expect(screen.getByTestId("wave-follow")).toBeInTheDocument();
-  expect(screen.getByTestId("follow-btn")).toBeInTheDocument();
+  expect(
+    screen.getByText("created a wave you can access:")
+  ).toBeInTheDocument();
+  expect(screen.getByTestId("wave-follow")).toHaveTextContent(
+    "Join wave/Joined"
+  );
+  expect(screen.getByTestId("follow-btn")).toHaveTextContent(
+    "Follow creator/Following creator"
+  );
   const img = screen.getByRole("img");
   expect(img.getAttribute("src")).toContain("scaled.jpg");
+});
+
+it("renders direct message wave notifications with DM copy and action", () => {
+  render(
+    <NotificationWaveCreated
+      notification={{
+        ...notification,
+        related_wave: {
+          ...notification.related_wave,
+          is_dm_wave: true,
+        },
+      }}
+    />
+  );
+
+  expect(screen.getByText("started a DM with you:")).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: "Wave 1" })).toHaveAttribute(
+    "href",
+    "/messages/1"
+  );
+  expect(screen.getByRole("link", { name: "Open DM" })).toHaveAttribute(
+    "href",
+    "/messages/1"
+  );
+  expect(screen.queryByTestId("wave-follow")).toBeNull();
 });
 
 it("renders fallback wave text without a link when wave id is missing", () => {

--- a/__tests__/components/waves/create-wave/groups/CreateWaveInlineGroupIdentities.test.tsx
+++ b/__tests__/components/waves/create-wave/groups/CreateWaveInlineGroupIdentities.test.tsx
@@ -219,8 +219,8 @@ describe("CreateWaveInlineGroupIdentities", () => {
       ],
     });
 
-    expect(
-      screen.getByText(/You are not included in this group/)
-    ).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(
+      /You are not included in this group/
+    );
   });
 });

--- a/__tests__/components/waves/create-wave/groups/CreateWaveInlineGroupIdentities.test.tsx
+++ b/__tests__/components/waves/create-wave/groups/CreateWaveInlineGroupIdentities.test.tsx
@@ -200,4 +200,27 @@ describe("CreateWaveInlineGroupIdentities", () => {
       screen.queryByRole("switch", { name: "Include me" })
     ).not.toBeInTheDocument();
   });
+
+  it("warns when the connected creator is excluded from an identity group", () => {
+    renderWithProfile({
+      identities: [
+        {
+          profile_id: "profile-1",
+          handle: "alpha",
+          normalised_handle: "alpha",
+          primary_wallet: "0xPRIMARY",
+          display: "Alpha",
+          tdh: 0,
+          level: 0,
+          cic_rating: 0,
+          wallet: "0xAAA1",
+          pfp: null,
+        },
+      ],
+    });
+
+    expect(
+      screen.getByText(/You are not included in this group/)
+    ).toBeInTheDocument();
+  });
 });

--- a/components/brain/notifications/NotificationsFollowBtn.tsx
+++ b/components/brain/notifications/NotificationsFollowBtn.tsx
@@ -15,6 +15,8 @@ import {
   commonApiDeleteWithBody,
   commonApiPost,
 } from "@/services/api/common-api";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import { useMutation } from "@tanstack/react-query";
 import type { FC } from "react";
 import { useContext, useState } from "react";
@@ -34,8 +36,8 @@ interface NotificationsFollowBtnProps {
 const NotificationsFollowBtn: FC<NotificationsFollowBtnProps> = ({
   profile,
   size = UserFollowBtnSize.MEDIUM,
-  followLabel = "Follow",
-  followingLabel = "Following",
+  followLabel = t(DEFAULT_LOCALE, "notifications.followButton.follow"),
+  followingLabel = t(DEFAULT_LOCALE, "notifications.followButton.following"),
 }) => {
   const { onIdentityFollowChange } = useContext(ReactQueryWrapperContext);
   const { setToast, requestAuth } = useAuth();
@@ -107,8 +109,14 @@ const NotificationsFollowBtn: FC<NotificationsFollowBtnProps> = ({
     if (!handle) {
       setToast({
         type: "error",
-        title: "Couldn't follow this profile.",
-        description: "This profile is missing a handle.",
+        title: t(
+          DEFAULT_LOCALE,
+          "notifications.followButton.error.missingHandleTitle"
+        ),
+        description: t(
+          DEFAULT_LOCALE,
+          "notifications.followButton.error.missingHandleDescription"
+        ),
       });
       return;
     }

--- a/components/brain/notifications/NotificationsFollowBtn.tsx
+++ b/components/brain/notifications/NotificationsFollowBtn.tsx
@@ -27,26 +27,34 @@ import {
 interface NotificationsFollowBtnProps {
   readonly profile: ApiProfileMin;
   readonly size?: UserFollowBtnSize | undefined;
+  readonly followLabel?: string | undefined;
+  readonly followingLabel?: string | undefined;
 }
 
 const NotificationsFollowBtn: FC<NotificationsFollowBtnProps> = ({
   profile,
   size = UserFollowBtnSize.MEDIUM,
+  followLabel = "Follow",
+  followingLabel = "Following",
 }) => {
   const { onIdentityFollowChange } = useContext(ReactQueryWrapperContext);
   const { setToast, requestAuth } = useAuth();
   const [mutating, setMutating] = useState<boolean>(false);
 
+  const handle = profile.handle?.trim();
   const following = profile.subscribed_actions.length > 0;
-  const label = following ? "Following" : "Follow";
+  const label = following ? followingLabel : followLabel;
 
   const followMutation = useMutation({
     mutationFn: async () => {
+      if (!handle) {
+        throw new Error("Missing profile handle.");
+      }
       await commonApiPost<
         ApiIdentitySubscriptionActions,
         ApiIdentitySubscriptionActions
       >({
-        endpoint: `identities/${profile.handle}/subscriptions`,
+        endpoint: `identities/${handle}/subscriptions`,
         body: DEFAULT_SUBSCRIPTION_BODY,
       });
     },
@@ -68,11 +76,14 @@ const NotificationsFollowBtn: FC<NotificationsFollowBtnProps> = ({
 
   const unFollowMutation = useMutation({
     mutationFn: async () => {
+      if (!handle) {
+        throw new Error("Missing profile handle.");
+      }
       await commonApiDeleteWithBody<
         ApiIdentitySubscriptionActions,
         ApiIdentitySubscriptionActions
       >({
-        endpoint: `identities/${profile.handle}/subscriptions`,
+        endpoint: `identities/${handle}/subscriptions`,
         body: DEFAULT_SUBSCRIPTION_BODY,
       });
     },
@@ -93,6 +104,14 @@ const NotificationsFollowBtn: FC<NotificationsFollowBtnProps> = ({
   });
 
   const onFollow = async (): Promise<void> => {
+    if (!handle) {
+      setToast({
+        type: "error",
+        title: "Couldn't follow this profile.",
+        description: "This profile is missing a handle.",
+      });
+      return;
+    }
     setMutating(true);
     const { success } = await requestAuth();
     if (!success) {
@@ -118,13 +137,12 @@ const NotificationsFollowBtn: FC<NotificationsFollowBtnProps> = ({
             : "tw-bg-primary-500 tw-text-white tw-ring-primary-500 hover:tw-bg-primary-600 hover:tw-ring-primary-600"
         } tw-flex tw-cursor-pointer tw-items-center tw-rounded-lg tw-border-0 tw-font-semibold tw-ring-1 tw-ring-inset tw-transition tw-duration-300 tw-ease-out`}
       >
-        {mutating ? (
-          <CircleLoader size={FOLLOW_BTN_LOADER_SIZES[size]} />
-        ) : following ? (
-          <FollowBtnCheckIcon />
-        ) : (
-          <FollowBtnPlusIcon size={size} />
-        )}
+        {(() => {
+          if (mutating)
+            return <CircleLoader size={FOLLOW_BTN_LOADER_SIZES[size]} />;
+          if (following) return <FollowBtnCheckIcon />;
+          return <FollowBtnPlusIcon size={size} />;
+        })()}
         <span>{label}</span>
       </button>
     </div>

--- a/components/brain/notifications/wave-created/NotificationWaveCreated.tsx
+++ b/components/brain/notifications/wave-created/NotificationWaveCreated.tsx
@@ -8,6 +8,8 @@ import {
 } from "@/components/user/utils/UserFollowBtn";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
 import { getWaveRoute } from "@/helpers/navigation.helpers";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import NotificationHeader from "../subcomponents/NotificationHeader";
 import NotificationTimestamp from "../subcomponents/NotificationTimestamp";
 import NotificationWaveFollowBtn from "./NotificationWaveFollowBtn";
@@ -31,8 +33,8 @@ export default function NotificationWaveCreated({
     : null;
   const waveName = wave?.name ?? waveId ?? "Unknown wave";
   const notificationCopy = isDirectMessage
-    ? "started a DM with you:"
-    : "created a wave you can access:";
+    ? t(DEFAULT_LOCALE, "notifications.waveCreated.dmCopy")
+    : t(DEFAULT_LOCALE, "notifications.waveCreated.normalCopy");
   let waveAction: ReactNode = null;
   if (isDirectMessage && waveHref) {
     waveAction = (
@@ -40,7 +42,7 @@ export default function NotificationWaveCreated({
         href={waveHref}
         className={`${FOLLOW_BTN_BUTTON_CLASSES[UserFollowBtnSize.SMALL]} tw-flex tw-cursor-pointer tw-items-center tw-rounded-lg tw-border-0 tw-bg-primary-500 tw-font-semibold tw-text-white tw-no-underline tw-ring-1 tw-ring-inset tw-ring-primary-500 tw-transition tw-duration-300 tw-ease-out hover:tw-bg-primary-600 hover:tw-text-white hover:tw-ring-primary-600`}
       >
-        Open DM
+        {t(DEFAULT_LOCALE, "notifications.waveCreated.openDm")}
       </Link>
     );
   } else if (wave) {
@@ -48,8 +50,11 @@ export default function NotificationWaveCreated({
       <NotificationWaveFollowBtn
         wave={wave}
         size={UserFollowBtnSize.SMALL}
-        followLabel="Join wave"
-        followingLabel="Joined"
+        followLabel={t(DEFAULT_LOCALE, "notifications.waveCreated.joinWave")}
+        followingLabel={t(
+          DEFAULT_LOCALE,
+          "notifications.waveCreated.joinedWave"
+        )}
       />
     );
   }
@@ -64,8 +69,14 @@ export default function NotificationWaveCreated({
             <NotificationsFollowBtn
               profile={notification.related_identity}
               size={UserFollowBtnSize.SMALL}
-              followLabel="Follow creator"
-              followingLabel="Following creator"
+              followLabel={t(
+                DEFAULT_LOCALE,
+                "notifications.waveCreated.followCreator"
+              )}
+              followingLabel={t(
+                DEFAULT_LOCALE,
+                "notifications.waveCreated.followingCreator"
+              )}
             />
           </div>
         }

--- a/components/brain/notifications/wave-created/NotificationWaveCreated.tsx
+++ b/components/brain/notifications/wave-created/NotificationWaveCreated.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
+import type { ReactNode } from "react";
 import type { INotificationWaveCreated } from "@/types/feed.types";
 import NotificationsFollowBtn from "../NotificationsFollowBtn";
-import { UserFollowBtnSize } from "@/components/user/utils/UserFollowBtn";
+import {
+  FOLLOW_BTN_BUTTON_CLASSES,
+  UserFollowBtnSize,
+} from "@/components/user/utils/UserFollowBtn";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
 import { getWaveRoute } from "@/helpers/navigation.helpers";
 import NotificationHeader from "../subcomponents/NotificationHeader";
@@ -17,40 +21,61 @@ export default function NotificationWaveCreated({
   const wave = notification.related_wave;
   const contextWaveId = notification.additional_context.wave_id || undefined;
   const waveId = wave?.id ?? contextWaveId;
-  const invitationHref = waveId
+  const isDirectMessage = wave?.is_direct_message ?? wave?.is_dm_wave ?? false;
+  const waveHref = waveId
     ? getWaveRoute({
         waveId,
-        isDirectMessage: wave?.is_direct_message ?? wave?.is_dm_wave ?? false,
+        isDirectMessage,
         isApp,
       })
     : null;
   const waveName = wave?.name ?? waveId ?? "Unknown wave";
+  const notificationCopy = isDirectMessage
+    ? "started a DM with you:"
+    : "created a wave you can access:";
+  let waveAction: ReactNode = null;
+  if (isDirectMessage && waveHref) {
+    waveAction = (
+      <Link
+        href={waveHref}
+        className={`${FOLLOW_BTN_BUTTON_CLASSES[UserFollowBtnSize.SMALL]} tw-flex tw-cursor-pointer tw-items-center tw-rounded-lg tw-border-0 tw-bg-primary-500 tw-font-semibold tw-text-white tw-no-underline tw-ring-1 tw-ring-inset tw-ring-primary-500 tw-transition tw-duration-300 tw-ease-out hover:tw-bg-primary-600 hover:tw-text-white hover:tw-ring-primary-600`}
+      >
+        Open DM
+      </Link>
+    );
+  } else if (wave) {
+    waveAction = (
+      <NotificationWaveFollowBtn
+        wave={wave}
+        size={UserFollowBtnSize.SMALL}
+        followLabel="Join wave"
+        followingLabel="Joined"
+      />
+    );
+  }
 
   return (
     <div className="tw-w-full">
       <NotificationHeader
         author={notification.related_identity}
         actions={
-          <div className="tw-flex tw-items-center tw-gap-x-2">
-            {wave && (
-              <NotificationWaveFollowBtn
-                wave={wave}
-                size={UserFollowBtnSize.SMALL}
-              />
-            )}
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-end tw-gap-2">
+            {waveAction}
             <NotificationsFollowBtn
               profile={notification.related_identity}
               size={UserFollowBtnSize.SMALL}
+              followLabel="Follow creator"
+              followingLabel="Following creator"
             />
           </div>
         }
       >
         <span className="tw-text-sm tw-font-normal tw-text-iron-400">
-          invited you to a wave:
+          {notificationCopy}
         </span>
-        {invitationHref ? (
+        {waveHref ? (
           <Link
-            href={invitationHref}
+            href={waveHref}
             className="tw-text-sm tw-font-medium tw-text-primary-400 tw-no-underline hover:tw-text-primary-300"
           >
             {waveName}

--- a/components/brain/notifications/wave-created/NotificationWaveFollowBtn.tsx
+++ b/components/brain/notifications/wave-created/NotificationWaveFollowBtn.tsx
@@ -12,6 +12,8 @@ import {
 import type { ApiWaveSubscriptionActions } from "@/generated/models/ApiWaveSubscriptionActions";
 import type { ApiWaveOverview } from "@/generated/models/ApiWaveOverview";
 import { getToastErrorDetails } from "@/helpers/toast.helpers";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import {
   commonApiDeleteWithBody,
   commonApiPost,
@@ -26,8 +28,8 @@ import {
 export default function NotificationWaveFollowBtn({
   wave,
   size = UserFollowBtnSize.SMALL,
-  followLabel = "Join",
-  followingLabel = "Joined",
+  followLabel = t(DEFAULT_LOCALE, "notifications.waveFollowButton.join"),
+  followingLabel = t(DEFAULT_LOCALE, "notifications.waveFollowButton.joined"),
 }: {
   readonly wave: ApiWaveOverview;
   readonly size?: UserFollowBtnSize | undefined;

--- a/components/brain/notifications/wave-created/NotificationWaveFollowBtn.tsx
+++ b/components/brain/notifications/wave-created/NotificationWaveFollowBtn.tsx
@@ -26,9 +26,13 @@ import {
 export default function NotificationWaveFollowBtn({
   wave,
   size = UserFollowBtnSize.SMALL,
+  followLabel = "Join",
+  followingLabel = "Joined",
 }: {
   readonly wave: ApiWaveOverview;
   readonly size?: UserFollowBtnSize | undefined;
+  readonly followLabel?: string | undefined;
+  readonly followingLabel?: string | undefined;
 }) {
   const { setToast, requestAuth } = useAuth();
   const { onWaveFollowChange } = useContext(ReactQueryWrapperContext);
@@ -121,7 +125,7 @@ export default function NotificationWaveFollowBtn({
     await followMutation.mutateAsync();
   };
 
-  const label = following ? "Joined" : "Join";
+  const label = following ? followingLabel : followLabel;
   const icon = (() => {
     if (mutating) {
       return <CircleLoader size={FOLLOW_BTN_LOADER_SIZES[size]} />;

--- a/components/waves/create-wave/groups/CreateWaveGroups.tsx
+++ b/components/waves/create-wave/groups/CreateWaveGroups.tsx
@@ -2,6 +2,8 @@ import type { ApiGroupFull } from "@/generated/models/ApiGroupFull";
 import type { ApiWaveType } from "@/generated/models/ApiWaveType";
 import type { ApiCreateGroup } from "@/generated/models/ApiCreateGroup";
 import { CREATE_WAVE_GROUPS } from "@/helpers/waves/waves.constants";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 import type {
   CreateWaveGroupConfigType,
   WaveGroupsConfig,
@@ -42,8 +44,9 @@ export default function CreateWaveGroups({
   return (
     <div className="tw-flex tw-flex-col tw-gap-y-6">
       <p className="tw-mb-0 tw-text-sm tw-font-normal tw-leading-relaxed tw-text-iron-400">
-        The Who can view group controls who can access this wave. Followers of
-        you who can view the wave may get a notification when it is created.
+        {t(DEFAULT_LOCALE, "waves.create.groups.accessHelper", {
+          viewGroupName: "Who can view",
+        })}
       </p>
       {CREATE_WAVE_GROUPS[waveType].map((groupType) => (
         <CreateWaveGroup
@@ -63,8 +66,15 @@ export default function CreateWaveGroups({
       ))}
       {isRestrictedGroup && (
         <CreateWaveWarning
-          title="Warning: Limited Access"
-          description='This wave is configured with restricted access. It can only be viewed by members of the "Who can view" group and managed by members of the "Admin" group. If you are not in a group that can view it, you will not be able to access this wave.'
+          title={t(DEFAULT_LOCALE, "waves.create.groups.limitedAccessTitle")}
+          description={t(
+            DEFAULT_LOCALE,
+            "waves.create.groups.limitedAccessDescription",
+            {
+              viewGroupName: "Who can view",
+              adminGroupName: "Admin",
+            }
+          )}
         />
       )}
     </div>

--- a/components/waves/create-wave/groups/CreateWaveGroups.tsx
+++ b/components/waves/create-wave/groups/CreateWaveGroups.tsx
@@ -41,6 +41,10 @@ export default function CreateWaveGroups({
 
   return (
     <div className="tw-flex tw-flex-col tw-gap-y-6">
+      <p className="tw-mb-0 tw-text-sm tw-font-normal tw-leading-relaxed tw-text-iron-400">
+        The Who can view group controls who can access this wave. Followers of
+        you who can view the wave may get a notification when it is created.
+      </p>
       {CREATE_WAVE_GROUPS[waveType].map((groupType) => (
         <CreateWaveGroup
           key={groupType}
@@ -60,10 +64,7 @@ export default function CreateWaveGroups({
       {isRestrictedGroup && (
         <CreateWaveWarning
           title="Warning: Limited Access"
-          description=' This wave is configured with restricted access. It can only be viewed
-        and managed by the members of the "Who can view" and
-        "Admin" groups. If you are not a member of either of these
-        groups, you will not be able to access this wave.'
+          description='This wave is configured with restricted access. It can only be viewed by members of the "Who can view" group and managed by members of the "Admin" group. If you are not in a group that can view it, you will not be able to access this wave.'
         />
       )}
     </div>

--- a/components/waves/create-wave/groups/CreateWaveInlineGroupIdentities.tsx
+++ b/components/waves/create-wave/groups/CreateWaveInlineGroupIdentities.tsx
@@ -139,9 +139,14 @@ export default function CreateWaveInlineGroupIdentities({
         />
       )}
       {showCurrentUserExcludedWarning && (
-        <p className="tw-mb-0 tw-rounded-lg tw-border tw-border-solid tw-border-[#fef08a]/20 tw-bg-[#fef08a]/10 tw-px-3 tw-py-2 tw-text-xs tw-font-medium tw-leading-relaxed tw-text-[#fef08a]">
-          You are not included in this group. If it controls who can view the
-          wave, you may not be able to access the wave after creating it.
+        <p
+          role="status"
+          aria-live="polite"
+          className="tw-mb-0 tw-rounded-lg tw-border tw-border-solid tw-border-[#fef08a]/20 tw-bg-[#fef08a]/10 tw-px-3 tw-py-2 tw-text-xs tw-font-medium tw-leading-relaxed tw-text-[#fef08a]"
+        >
+          Warning: You are not included in this group. If it controls who can
+          view the wave, you may not be able to access the wave after creating
+          it.
         </p>
       )}
     </div>

--- a/components/waves/create-wave/groups/CreateWaveInlineGroupIdentities.tsx
+++ b/components/waves/create-wave/groups/CreateWaveInlineGroupIdentities.tsx
@@ -6,6 +6,8 @@ import GroupCreateIdentitySelectedItems from "@/components/groups/page/create/co
 import GroupCreateIdentitiesSearch from "@/components/groups/page/create/config/identities/select/GroupCreateIdentitiesSearch";
 import type { GroupCreateIdentitiesSearchResultsLayout } from "@/components/groups/page/create/config/identities/select/GroupCreateIdentitiesSearchItems";
 import { areEqualAddresses } from "@/helpers/Helpers";
+import { DEFAULT_LOCALE } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
 
 export default function CreateWaveInlineGroupIdentities({
   identities,
@@ -42,7 +44,7 @@ export default function CreateWaveInlineGroupIdentities({
     );
   const identitiesHelperText =
     identities.length === 0
-      ? "Add identities one by one to build this access group."
+      ? t(DEFAULT_LOCALE, "waves.create.groups.inlineIdentities.emptyHelper")
       : null;
   const showHelperRow = !!identitiesHelperText || !!currentUserIdentity;
   const showCurrentUserExcludedWarning =
@@ -144,9 +146,10 @@ export default function CreateWaveInlineGroupIdentities({
           aria-live="polite"
           className="tw-mb-0 tw-rounded-lg tw-border tw-border-solid tw-border-[#fef08a]/20 tw-bg-[#fef08a]/10 tw-px-3 tw-py-2 tw-text-xs tw-font-medium tw-leading-relaxed tw-text-[#fef08a]"
         >
-          Warning: You are not included in this group. If it controls who can
-          view the wave, you may not be able to access the wave after creating
-          it.
+          {t(
+            DEFAULT_LOCALE,
+            "waves.create.groups.inlineIdentities.creatorExcludedWarning"
+          )}
         </p>
       )}
     </div>

--- a/components/waves/create-wave/groups/CreateWaveInlineGroupIdentities.tsx
+++ b/components/waves/create-wave/groups/CreateWaveInlineGroupIdentities.tsx
@@ -42,9 +42,11 @@ export default function CreateWaveInlineGroupIdentities({
     );
   const identitiesHelperText =
     identities.length === 0
-      ? "Add identities one by one to create a group."
+      ? "Add identities one by one to build this access group."
       : null;
   const showHelperRow = !!identitiesHelperText || !!currentUserIdentity;
+  const showCurrentUserExcludedWarning =
+    identities.length > 0 && !!currentUserIdentity && !isCurrentUserSelected;
 
   const onCurrentUserToggle = (checked: boolean) => {
     if (!currentUserIdentity) {
@@ -135,6 +137,12 @@ export default function CreateWaveInlineGroupIdentities({
           onRemove={onRemove}
           variant="inline"
         />
+      )}
+      {showCurrentUserExcludedWarning && (
+        <p className="tw-mb-0 tw-rounded-lg tw-border tw-border-solid tw-border-[#fef08a]/20 tw-bg-[#fef08a]/10 tw-px-3 tw-py-2 tw-text-xs tw-font-medium tw-leading-relaxed tw-text-[#fef08a]">
+          You are not included in this group. If it controls who can view the
+          wave, you may not be able to access the wave after creating it.
+        </p>
       )}
     </div>
   );

--- a/i18n/messages/en-US.ts
+++ b/i18n/messages/en-US.ts
@@ -532,10 +532,53 @@ const QUICK_DM_MESSAGES = objectMessages("quickDm", {
   chatLoadError: "Unable to load this conversation.",
 } as const);
 
+const NOTIFICATIONS_FOLLOW_BUTTON_MESSAGES = objectMessages(
+  "notifications.followButton",
+  {
+    follow: "Follow",
+    following: "Following",
+    "error.missingHandleTitle": "Couldn't follow this profile.",
+    "error.missingHandleDescription": "This profile is missing a handle.",
+  } as const
+);
+
+const NOTIFICATIONS_WAVE_CREATED_MESSAGES = objectMessages(
+  "notifications.waveCreated",
+  {
+    normalCopy: "created a wave you can access:",
+    dmCopy: "started a DM with you:",
+    openDm: "Open DM",
+    joinWave: "Join wave",
+    joinedWave: "Joined",
+    followCreator: "Follow creator",
+    followingCreator: "Following creator",
+  } as const
+);
+
+const NOTIFICATIONS_WAVE_FOLLOW_BUTTON_MESSAGES = objectMessages(
+  "notifications.waveFollowButton",
+  {
+    join: "Join",
+    joined: "Joined",
+  } as const
+);
+
 const WAVE_HEADER_MESSAGES = objectMessages("waves.header", {
   createdLabel: "Created {relativeTime} · {date}",
   "postsCount.one": "{count} Post",
   "postsCount.other": "{count} Posts",
+} as const);
+
+const WAVE_CREATE_GROUPS_MESSAGES = objectMessages("waves.create.groups", {
+  accessHelper:
+    "The {viewGroupName} group controls who can access this wave. Your followers who can view the wave may be notified when it is created.",
+  limitedAccessTitle: "Warning: Limited Access",
+  limitedAccessDescription:
+    'This wave is configured with restricted access. It can only be viewed by members of the "{viewGroupName}" group and managed by members of the "{adminGroupName}" group. If you are not in a group that can view it, you will not be able to access this wave.',
+  "inlineIdentities.emptyHelper":
+    "Add identities one by one to build this access group.",
+  "inlineIdentities.creatorExcludedWarning":
+    "Warning: You are not included in this group. If it controls who can view the wave, you may not be able to access the wave after creating it.",
 } as const);
 
 const WAVE_CHAT_MESSAGES = objectMessages("waves.chat", {
@@ -1452,10 +1495,14 @@ export const EN_US_MESSAGES = {
   ...FOLLOWERS_MESSAGES,
   ...WAVES_SIDEBAR_MESSAGES,
   ...QUICK_DM_MESSAGES,
+  ...NOTIFICATIONS_FOLLOW_BUTTON_MESSAGES,
+  ...NOTIFICATIONS_WAVE_CREATED_MESSAGES,
+  ...NOTIFICATIONS_WAVE_FOLLOW_BUTTON_MESSAGES,
   ...WAVE_CHAT_MESSAGES,
   ...WAVE_LOADING_MESSAGES,
   ...WAVE_GIF_PICKER_MESSAGES,
   ...WAVE_HEADER_MESSAGES,
+  ...WAVE_CREATE_GROUPS_MESSAGES,
   ...WAVE_EXPLORE_CARD_MESSAGES,
   ...WAVE_SCORE_SUMMARY_MESSAGES,
   ...WAVE_SCORE_DETAILS_MESSAGES,

--- a/ops/docs/notifications/feature-notifications-feed.md
+++ b/ops/docs/notifications/feature-notifications-feed.md
@@ -51,7 +51,8 @@ with cause filters, grouped reactions, and inline drop previews.
   - `Replies`: reply notifications.
   - `Identity`: new followers and REP/NIC updates.
   - `Reactions`: voted, reacted, and boosted drop notifications.
-  - `Invites`: wave invite notifications.
+  - `Invites`: wave-created notifications, including standard waves the user
+    can access and direct-message waves started with the user.
 
 ## Row and Action Behavior
 
@@ -64,7 +65,10 @@ with cause filters, grouped reactions, and inline drop previews.
 - Priority alerts show `sent a priority alert 🚨` as:
   - header-only rows (no related drop), or
   - header plus first related drop preview.
-- Invite rows can include both identity follow and wave follow controls.
+- Standard wave-created rows say the creator made a wave the user can access
+  and can include `Join wave` plus `Follow creator` controls.
+- Direct-message wave-created rows say the creator started a DM with the user
+  and expose `Open DM` instead of the wave join control.
 - Unknown causes render a generic row (formatted cause/context) instead of
   failing feed render.
 

--- a/ops/docs/waves/create/feature-groups-step.md
+++ b/ops/docs/waves/create/feature-groups-step.md
@@ -28,6 +28,9 @@ This step is user-reachable for `Chat`, `Rank`, and `Approve`.
 
 ## What You Configure
 
+- Helper copy clarifies that `Who can view` controls who can access the wave,
+  and that followers who can view the wave may get a notification when it is
+  created.
 - `Chat` rows: `Who can view`, `Who can chat`, `Admin`
 - `Rank` and `Approve` rows: `Who can view`, `Who can drop`, `Who can vote`,
   `Who can chat`, `Admin`
@@ -56,11 +59,15 @@ This step is user-reachable for `Chat`, `Rank`, and `Approve`.
   selected until the row is explicitly cleared or a new group is picked.
 - Clear control (`x`) resets the row to its default scope.
 - Helper text under each row shows `Current group: <group-or-scope>`.
+- Inline identity groups use access-group wording and warn when the connected
+  creator is excluded, because excluding yourself from a `Who can view` group
+  can prevent you from opening the created wave.
 
 ## Warnings and State Changes
 
 - If both `Who can view` and `Admin` are set to explicit groups, `Warning:
-  Limited Access` appears.
+  Limited Access` appears and clarifies that the view group controls access
+  while the admin group controls management.
 - On `Rank` and `Approve`, turning `Enable chat` off disables editing for
   `Who can chat`.
 - `Allow admins to delete posts` does not show extra helper text when enabled.

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -1645,6 +1645,8 @@
       ],
       "facts": [
         "The wave creation flow starts with Overview and then configures groups, description, and additional steps depending on wave type.",
+        "In the Groups step, Who can view controls wave access; followers who can view the wave may get a notification when it is created.",
+        "Inline identity groups warn when the connected creator is excluded, because excluding yourself from a view group can prevent you from opening the created wave.",
         "All wave types include a Rules step; Rank and Approve waves also include Dates, Drops, Voting, and Outcomes steps.",
         "The Rules step previews automatic rules generated from wave setup and lets creators add optional custom creator rules.",
         "The docs for wave creation live under ops/docs/waves/create; on web, use /waves?create=wave to open create-wave mode."
@@ -3419,6 +3421,8 @@
         "The notifications feed lives at /notifications.",
         "It supports feed filters, row actions, read state, paging, and navigation to related app content.",
         "Cause filters include Mentions, Replies, Identity, Reactions, and Invites.",
+        "The Invites filter includes wave-created notifications: standard waves the user can access and direct-message waves started with the user.",
+        "Standard wave-created rows can offer Join wave and Follow creator controls; direct-message wave-created rows offer Open DM instead of joining the wave.",
         "The Reactions filter includes voted, reacted, and boosted drop notifications; the Identity filter includes new follows and REP/NIC updates.",
         "Notification rows may be missing or stale if loading, permissions, or realtime connectivity are disrupted."
       ],

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -1645,6 +1645,8 @@
       ],
       "facts": [
         "The wave creation flow starts with Overview and then configures groups, description, and additional steps depending on wave type.",
+        "In the Groups step, Who can view controls wave access; followers who can view the wave may get a notification when it is created.",
+        "Inline identity groups warn when the connected creator is excluded, because excluding yourself from a view group can prevent you from opening the created wave.",
         "All wave types include a Rules step; Rank and Approve waves also include Dates, Drops, Voting, and Outcomes steps.",
         "The Rules step previews automatic rules generated from wave setup and lets creators add optional custom creator rules.",
         "The docs for wave creation live under ops/docs/waves/create; on web, use /waves?create=wave to open create-wave mode."
@@ -3419,6 +3421,8 @@
         "The notifications feed lives at /notifications.",
         "It supports feed filters, row actions, read state, paging, and navigation to related app content.",
         "Cause filters include Mentions, Replies, Identity, Reactions, and Invites.",
+        "The Invites filter includes wave-created notifications: standard waves the user can access and direct-message waves started with the user.",
+        "Standard wave-created rows can offer Join wave and Follow creator controls; direct-message wave-created rows offer Open DM instead of joining the wave.",
         "The Reactions filter includes voted, reacted, and boosted drop notifications; the Identity filter includes new follows and REP/NIC updates.",
         "Notification rows may be missing or stale if loading, permissions, or realtime connectivity are disrupted."
       ],

--- a/tests/auth/notifications-sandbox.spec.ts
+++ b/tests/auth/notifications-sandbox.spec.ts
@@ -43,9 +43,15 @@ test.describe("Notifications local sandbox @auth @medium @local-only", () => {
     await expect(page.getByText("mentioned you")).toHaveCount(0);
 
     await page.getByRole("button", { name: "Invites", exact: true }).click();
-    await expect(page.getByText("invited you to a wave:")).toBeVisible({
+    await expect(page.getByText("created a wave you can access:")).toBeVisible({
       timeout: LOCAL_SANDBOX_NAVIGATION_TIMEOUT_MS,
     });
+    await expect(
+      page.getByRole("button", { name: "Join wave", exact: true }).first()
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Follow creator", exact: true }).first()
+    ).toBeVisible();
     await expect(
       page.getByRole("link", { name: "Sandbox Notifications Wave" }).first()
     ).toHaveAttribute("href", "/waves/00000000-0000-4000-8000-000000000533");


### PR DESCRIPTION
## Issue
Wave-created notifications used invite wording for all wave types, which made normal accessible waves look like direct manual invites and made DM waves indistinct.

## Fix
- Split normal wave-created copy from DM wave-created copy.
- Label normal wave actions as `Join wave` / `Joined` and DM actions as `Open DM`.
- Label the creator follow action as `Follow creator` / `Following creator` in this notification context.
- Clarify restricted wave access copy in the group setup UI and docs/help corpus.
- Add focused tests for notification copy/actions and restricted group creator inclusion warning.

## Validation
- `git diff --check`
- `./bin/6529 run lint:changed`
- `./bin/6529 run lint:uncommitted:tight`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run react-doctor:diff`
- `./bin/6529 run test -- __tests__/components/brain/notifications/NotificationWaveCreated.test.tsx __tests__/components/waves/create-wave/groups/CreateWaveInlineGroupIdentities.test.tsx --runInBand`
- Browser QA against staging-backed local app: normal wave notification from followed creator with manual access group, normal wave notification from followed creator with chosen existing group, existing DM notification copy/action, mobile notification rendering.

## Risk
Low. This changes frontend copy, scoped action labels, docs/help text, and tests. Backend notification eligibility is unchanged.

## Review Notes
A fresh DM notification was not created during QA because the tested accounts already had an existing DM wave; backend behavior reuses that DM and does not send a new notification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications now distinguish between standard waves and direct messages, with clearer actions like **Join wave**, **Follow creator**, and **Open DM**.
  * Create-wave screens now show a warning when the current user isn’t included in the selected access group.

* **Bug Fixes**
  * Improved notification and follow button behavior for missing or trimmed profile handles.
  * Updated visible help text and warning copy for clearer access and notification guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->