### PR TITLE
Filter MetaMask route parameterization noise

### DIFF
--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -532,17 +532,15 @@ describe("sentry-client-filters", () => {
         url: "/waves/fb539d2d-5efd-4cde-b6f0-b639a5659ff9",
         transaction: "/waves/:wave",
       },
-      breadcrumbs: {
-        values: [
-          {
-            category: "navigation",
-            data: {
-              from: "/anon93",
-              to: "/waves/fb539d2d-5efd-4cde-b6f0-b639a5659ff9",
-            },
+      breadcrumbs: [
+        {
+          category: "navigation",
+          data: {
+            from: "/anon93",
+            to: "/waves/fb539d2d-5efd-4cde-b6f0-b639a5659ff9",
           },
-        ],
-      },
+        },
+      ],
       ...overrides,
     });
 
@@ -3077,6 +3075,48 @@ describe("sentry-client-filters", () => {
       },
       contexts: {},
       tags: {},
+      breadcrumbs: [],
+    });
+
+    // Act
+    const result = shouldFilterSentryRouteParameterizationError(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter WKWebView route parameterization errors without MetaMaskMobile evidence", () => {
+    // Arrange
+    const event =
+      createObservedMetaMaskMobileWkWebViewWaveRouteParameterizationEvent({
+        request: {
+          url: "https://6529.io/waves/fb539d2d-5efd-4cde-b6f0-b639a5659ff9",
+          headers: {
+            "User-Agent":
+              "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.7 Mobile/15E148 Safari/604.1",
+          },
+        },
+      });
+
+    // Act
+    const result = shouldFilterSentryRouteParameterizationError(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter MetaMaskMobile route parameterization errors without route evidence", () => {
+    // Arrange
+    const event = createSentryRouteParameterizationEvent({
+      transaction: undefined,
+      request: {
+        headers: {
+          "User-Agent": metaMaskMobileWebViewUserAgent,
+        },
+      },
+      contexts: {},
+      tags: {},
+      breadcrumbs: [],
     });
 
     // Act

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -82,6 +82,8 @@ describe("sentry-client-filters", () => {
     "Converting circular structure to JSON --> starting at object with constructor 'HTMLMetaElement' | property '__reactFiber$nkfb4ziusym' -> object with constructor 'ry' --- property 'stateNode' closes the circle";
   const metaMaskMobileWebViewUserAgent =
     "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 WebView MetaMaskMobile";
+  const metaMaskMobileUserAgent =
+    "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.7 Mobile/15E148 Safari/604.1 MetaMaskMobile";
   const wasmCspUnsafeEvalMessage = [
     "Aborted(CompileError: WebAssembly.instantiate(): Compiling or instantiating",
     "WebAssembly module violates the following Content Security policy directive",
@@ -501,6 +503,42 @@ describe("sentry-client-filters", () => {
                   function: "n",
                 },
               ],
+            },
+          },
+        ],
+      },
+      ...overrides,
+    });
+
+  const createObservedMetaMaskMobileWkWebViewWaveRouteParameterizationEvent = (
+    overrides: TestSentryClientEventOverrides = {}
+  ): TestSentryClientEvent =>
+    createSentryRouteParameterizationEvent({
+      transaction: "/waves/:wave",
+      request: {
+        url: "https://6529.io/waves/fb539d2d-5efd-4cde-b6f0-b639a5659ff9",
+        headers: {
+          "User-Agent": metaMaskMobileUserAgent,
+        },
+      },
+      contexts: {
+        browser: {
+          name: "Mobile Safari UI/WKWebView",
+        },
+      },
+      tags: {
+        browser: "Mobile Safari UI/WKWebView",
+        "browser.name": "Mobile Safari UI/WKWebView",
+        url: "/waves/fb539d2d-5efd-4cde-b6f0-b639a5659ff9",
+        transaction: "/waves/:wave",
+      },
+      breadcrumbs: {
+        values: [
+          {
+            category: "navigation",
+            data: {
+              from: "/anon93",
+              to: "/waves/fb539d2d-5efd-4cde-b6f0-b639a5659ff9",
             },
           },
         ],
@@ -2765,6 +2803,18 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
+  it("filters observed MetaMaskMobile WKWebView wave route parameterization cyclic JSON errors", () => {
+    // Arrange
+    const event =
+      createObservedMetaMaskMobileWkWebViewWaveRouteParameterizationEvent();
+
+    // Act
+    const result = shouldFilterSentryRouteParameterizationError(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
   it("filters Sentry route parameterization errors with the Sentry parameterization frame outside route bounds", () => {
     // Arrange
     const event = createObservedSentryRouteParameterizationEvent();
@@ -3007,6 +3057,26 @@ describe("sentry-client-filters", () => {
         browser: "Mobile Safari",
         "browser.name": "Mobile Safari",
       },
+    });
+
+    // Act
+    const result = shouldFilterSentryRouteParameterizationError(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter MetaMaskMobile route parameterization errors without WKWebView evidence", () => {
+    // Arrange
+    const event = createSentryRouteParameterizationEvent({
+      request: {
+        url: "https://6529.io/waves/fb539d2d-5efd-4cde-b6f0-b639a5659ff9",
+        headers: {
+          "User-Agent": metaMaskMobileUserAgent,
+        },
+      },
+      contexts: {},
+      tags: {},
     });
 
     // Act

--- a/utils/sentry-client-filters/errors.ts
+++ b/utils/sentry-client-filters/errors.ts
@@ -200,21 +200,18 @@ export function hasMetaMaskMobileWebViewContext(
   event: SentryClientEvent
 ): boolean {
   const contextValues = getRouteParameterizationContextValues(event);
-  if (
-    contextValues.some((value) =>
+  const userAgentValues = getRouteParameterizationUserAgentValues(event);
+  const values = [...contextValues, ...userAgentValues];
+
+  return (
+    values.some((value) =>
       matchesContextToken(value, metaMaskMobileContextTokens)
     ) &&
-    contextValues.some((value) =>
-      matchesContextToken(value, mobileSafariWebViewContextTokens)
+    values.some(
+      (value) =>
+        matchesContextToken(value, mobileSafariWebViewContextTokens) ||
+        matchesContextToken(value, webViewUserAgentTokens)
     )
-  ) {
-    return true;
-  }
-
-  return getRouteParameterizationUserAgentValues(event).some(
-    (value) =>
-      matchesContextToken(value, metaMaskMobileContextTokens) &&
-      matchesContextToken(value, webViewUserAgentTokens)
   );
 }
 


### PR DESCRIPTION
## Issue
- Sentry issue 6529-FRONTEND-CP is high-volume noise from Sentry route parameterization in MetaMask Mobile WKWebView.
- The production event splits evidence across fields: WKWebView appears in browser context/tags, while MetaMaskMobile appears in the request user-agent.

## Fix
- Combine route-parameterization context/tag evidence with request/runtime user-agent evidence before requiring both MetaMaskMobile and WKWebView signals.
- Keep the existing safeguards for exact error message, Sentry browser API mechanism, known route evidence, native JSON.stringify frame, and no app-owned frames.

## Changes
- Updated the MetaMaskMobile WKWebView context check used by the Sentry route-parameterization filter.
- Added a regression fixture for the observed /anon93 -> /waves/... event shape.
- Added a guard test proving MetaMaskMobile without WKWebView evidence is still kept.

## Validation
- `git diff --check`
- `./bin/6529 run test:no-coverage -- __tests__/utils/sentry-client-filters.test.ts`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`

## Risk
- Level: Low
- Why: This is limited to client-side Sentry event filtering and keeps existing app-owned-frame and route/mechanism guards.
- Rollback: Revert this commit to restore the previous filter behavior.

## Review Notes
- Please focus on whether the combined evidence matching still avoids filtering app-owned cyclic JSON errors or generic browser cyclic JSON errors.