### PR TITLE
Guard Capacitor orientation updates

### DIFF
--- a/__tests__/hooks/useCapacitor.test.ts
+++ b/__tests__/hooks/useCapacitor.test.ts
@@ -65,4 +65,26 @@ describe("useCapacitor", () => {
     });
     expect(result.current.isActive).toBe(true);
   });
+
+  it("ignores repeated orientationchange events with the same orientation", async () => {
+    const renderSpy = jest.fn();
+    const { result } = renderHook(() => {
+      renderSpy();
+      return useCapacitor();
+    });
+
+    await waitFor(() => {
+      expect(result.current.orientation).toBe(0); // PORTRAIT
+    });
+
+    const renderCountAfterInitialSync = renderSpy.mock.calls.length;
+
+    act(() => {
+      window.dispatchEvent(new Event("orientationchange"));
+      window.dispatchEvent(new Event("orientationchange"));
+    });
+
+    expect(result.current.orientation).toBe(0); // PORTRAIT
+    expect(renderSpy).toHaveBeenCalledTimes(renderCountAfterInitialSync);
+  });
 });

--- a/hooks/useCapacitor.ts
+++ b/hooks/useCapacitor.ts
@@ -62,10 +62,14 @@ const useCapacitor = () => {
       window.matchMedia("(orientation: portrait)").matches;
 
     const handleOrientationChange = () => {
-      setOrientation(
-        isPortrait()
-          ? CapacitorOrientationType.PORTRAIT
-          : CapacitorOrientationType.LANDSCAPE
+      const nextOrientation = isPortrait()
+        ? CapacitorOrientationType.PORTRAIT
+        : CapacitorOrientationType.LANDSCAPE;
+
+      setOrientation((currentOrientation) =>
+        currentOrientation === nextOrientation
+          ? currentOrientation
+          : nextOrientation
       );
     };
 


### PR DESCRIPTION
## Issue
- Sentry issue 6529-FRONTEND-E6 reports React maximum update depth errors from Capacitor orientation handling on iOS WKWebView under `/waves`.

## Fix
- Guard the orientation state update so repeated same-orientation events keep the current state instead of scheduling redundant updates.

## Changes
- Compute `nextOrientation` once in `useCapacitor`.
- Use a functional orientation setter that returns the previous value when unchanged.
- Add hook regression coverage for repeated same-orientation `orientationchange` events.

## Validation
- `git diff --check`
- `./bin/6529 run test:no-coverage -- __tests__/hooks/useCapacitor.test.ts`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed` (completed; script reported no changed TypeScript files to typecheck)
- `./bin/6529 run typecheck:ci`
- `./bin/6529 run react-doctor:diff`

## Risk
- Level: Low
- Why: Change is scoped to Capacitor orientation state handling and focused hook coverage.
- Rollback: Revert this PR.

## Review Notes
- Please focus on whether preserving the existing `orientationchange` listener with a guarded setter is sufficient for the iOS WKWebView loop observed in Sentry.
