### PR TITLE
Filter requestProvider wallet collisions

### DIFF
--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -3930,6 +3930,117 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
+  it("filters observed injected wallet collisions from requestProvider app URI frames", () => {
+    // Arrange
+    const event = createInjectedWalletCollisionEvent({
+      transaction: "/waves",
+      request: {
+        url: "https://6529.io/waves",
+      },
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value:
+              "Cannot set property ethereum of #<Window> which has only a getter",
+            stacktrace: {
+              frames: [
+                {
+                  filename: "app:///requestProvider.js:2:584019",
+                  abs_path: "app:///requestProvider.js:2:584019",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      breadcrumbs: {
+        values: [],
+      },
+    });
+
+    // Act
+    const result = shouldFilterInjectedWalletCollision(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("does not filter wallet collisions when app-owned source frames are present", () => {
+    // Arrange
+    const event = createInjectedWalletCollisionEvent({
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value:
+              "Cannot set property ethereum of #<Window> which has only a getter",
+            stacktrace: {
+              frames: [
+                {
+                  filename: "app:///requestProvider.js",
+                  abs_path: "app:///requestProvider.js",
+                },
+                {
+                  filename: "app:///services/auth/wallet-provider.ts",
+                  abs_path: "app:///services/auth/wallet-provider.ts",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      breadcrumbs: {
+        values: [],
+      },
+    });
+
+    // Act
+    const result = shouldFilterInjectedWalletCollision(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter wallet collisions when serialized stack is app-owned", () => {
+    // Arrange
+    const event = createInjectedWalletCollisionEvent({
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value:
+              "Cannot set property ethereum of #<Window> which has only a getter",
+            stacktrace: {
+              frames: [
+                {
+                  filename: "app:///requestProvider.js",
+                  abs_path: "app:///requestProvider.js",
+                },
+              ],
+            },
+          },
+        ],
+      },
+      breadcrumbs: {
+        values: [],
+      },
+      extra: {
+        __serialized__: {
+          stack:
+            "TypeError: Cannot set property ethereum of #<Window> which has only a getter\n    at installProvider (app:///services/auth/wallet-provider.ts:12:3)",
+        },
+      },
+    });
+
+    // Act
+    const result = shouldFilterInjectedWalletCollision(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
   it("filters MetaMask mobile update-url circular React meta element errors", () => {
     // Arrange
     const event = createMetaMaskUpdateUrlCircularEvent();

--- a/utils/sentry-client-filters/app-frame-utils.ts
+++ b/utils/sentry-client-filters/app-frame-utils.ts
@@ -5,7 +5,7 @@ import {
   browserExtensionUrlPrefixes,
   gifPickerReactPackageToken,
   gifPickerTenorManagerPathToken,
-  injectedAppUriPath,
+  injectedWalletCollisionAppUriPaths,
   injectedProviderProxyPath,
   injectedWasmCspAppUriPath,
   injectedWasmCspCollapsedPath,
@@ -82,9 +82,7 @@ function isAppUriFrame(frame: SentryStackFrame): boolean {
 }
 
 function isInjectedAppUriFrame(frame: SentryStackFrame): boolean {
-  return [frame.filename, frame.abs_path].some(
-    (path) => typeof path === "string" && path.includes(injectedAppUriPath)
-  );
+  return getFramePaths(frame).some(hasInjectedWalletCollisionAppUriStackValue);
 }
 
 function isInjectedProviderProxyFrame(frame: SentryStackFrame): boolean {
@@ -153,7 +151,7 @@ export function isInjectedOrThirdPartyWalletExtensionPath(
 ): boolean {
   const normalizedValue = value.toLowerCase();
   if (
-    normalizedValue.includes(injectedAppUriPath) ||
+    hasInjectedWalletCollisionAppUriStackValue(normalizedValue) ||
     normalizedValue.includes("app:///page.js")
   ) {
     return true;
@@ -163,6 +161,18 @@ export function isInjectedOrThirdPartyWalletExtensionPath(
     browserExtensionUrlPrefixes.some((prefix) =>
       normalizedValue.includes(prefix)
     ) && normalizedValue.includes("/page.js")
+  );
+}
+
+export function hasInjectedWalletCollisionAppUriStackValue(
+  value: string | undefined
+): boolean {
+  const normalizedValue = value?.toLowerCase();
+  return (
+    !!normalizedValue &&
+    injectedWalletCollisionAppUriPaths.some((path) =>
+      normalizedValue.includes(path.toLowerCase())
+    )
   );
 }
 

--- a/utils/sentry-client-filters/constants.ts
+++ b/utils/sentry-client-filters/constants.ts
@@ -8,6 +8,10 @@ export const filenameExceptions = [
 export const injectedWasmCspAppUriPath = "app:///inject.js";
 export const injectedWasmCspCollapsedPath = "///inject.js";
 export const injectedAppUriPath = "app:///injected/injected.js";
+export const injectedWalletCollisionAppUriPaths = [
+  injectedAppUriPath,
+  "app:///requestProvider.js",
+];
 export const walletCollisionPatterns = [
   "tronlinkparams",
   "cannot set property ethereum of #<window> which has only a getter",

--- a/utils/sentry-client-filters/constants.ts
+++ b/utils/sentry-client-filters/constants.ts
@@ -7,7 +7,7 @@ export const filenameExceptions = [
 ];
 export const injectedWasmCspAppUriPath = "app:///inject.js";
 export const injectedWasmCspCollapsedPath = "///inject.js";
-export const injectedAppUriPath = "app:///injected/injected.js";
+const injectedAppUriPath = "app:///injected/injected.js";
 export const injectedWalletCollisionAppUriPaths = [
   injectedAppUriPath,
   "app:///requestProvider.js",

--- a/utils/sentry-client-filters/wallets.ts
+++ b/utils/sentry-client-filters/wallets.ts
@@ -5,7 +5,6 @@ import {
   coinbaseWalletLinkWebSocketCloseFunction,
   coinbaseWalletLinkWebSocketFile,
   coinbaseWalletSdkPathTokens,
-  injectedAppUriPath,
   injectedProviderProxyStartsWithMessage,
   jsonStringifyFunction,
   metaMaskMobileUpdateUrlFunction,
@@ -55,6 +54,7 @@ import {
   hasAppOwnedSourceStackValue,
   hasAppOwnedStackPath,
   hasInjectedAppUriFrame,
+  hasInjectedWalletCollisionAppUriStackValue,
   hasLikelyAppOwnedFrame,
   hasOnlyAppUriFrames,
   hasOnlyInjectedProviderProxyFrames,
@@ -349,7 +349,7 @@ function hasInjectedAppUriSignature(
   }
 
   const stack = getHintExceptionStack(hint);
-  if (!stack.includes(injectedAppUriPath)) {
+  if (!hasInjectedWalletCollisionAppUriStackValue(stack)) {
     return false;
   }
 
@@ -358,6 +358,18 @@ function hasInjectedAppUriSignature(
   }
 
   return hasOnlyAppUriFrames(frames);
+}
+
+function hasAppOwnedInjectedWalletCollisionEvidence(
+  event: SentryClientEvent,
+  frames: SentryStackFrame[] | undefined,
+  hint?: SentryEventHint
+): boolean {
+  return (
+    hasAppOwnedSourceFrame(frames) ||
+    hasAppOwnedSourceStackValue(getHintExceptionStack(hint)) ||
+    hasAppOwnedSourceStackValue(getSerializedExceptionStack(event))
+  );
 }
 
 function hasWalletCollisionSignature(
@@ -731,6 +743,10 @@ export function shouldFilterInjectedWalletCollision(
   }
 
   const frames = event.exception?.values?.[0]?.stacktrace?.frames;
+  if (hasAppOwnedInjectedWalletCollisionEvidence(event, frames, hint)) {
+    return false;
+  }
+
   if (!hasInjectedAppUriSignature(frames, hint)) {
     return false;
   }


### PR DESCRIPTION
## Issue
- Sentry issue 6529-FRONTEND-60 reports injected wallet collision noise from production when a wallet script tries to assign read-only `window.ethereum`.
- The existing filter knew the error message but did not recognize the production `app:///requestProvider.js` injected path shape.

## Fix
- Treat `app:///requestProvider.js` as an injected wallet collision source path alongside the existing injected wallet path.
- Keep collision events visible when app-owned source frames or serialized app-owned stacks are present.

## Changes
- Added a shared injected wallet collision path list.
- Reused that path list for app-frame classification and wallet collision stack matching.
- Added production-shape tests for `app:///requestProvider.js:2:584019` and app-owned evidence guardrails.

## Validation
- `./bin/6529 run test -- __tests__/utils/sentry-client-filters.test.ts`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`

## Risk
- Level: Low
- Why: Scoped to Sentry client-side filtering for known injected wallet collision signatures; app-owned source evidence still prevents filtering.
- Rollback: Revert this PR to restore the prior path-matching behavior.

## Review Notes
- Please focus on whether `requestProvider.js` is narrow enough as injected-wallet evidence and whether the app-owned stack guard preserves first-party wallet-provider errors.