### PR TITLE
Filter injected keplr wallet collisions

### DIFF
--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -201,6 +201,30 @@ describe("sentry-client-filters", () => {
     ...overrides,
   });
 
+  const createInjectedKeplrWalletCollisionEvent = (
+    overrides: TestSentryClientEventOverrides = {}
+  ): TestSentryClientEvent => ({
+    transaction: "/waves",
+    exception: {
+      values: [
+        {
+          type: "TypeError",
+          value:
+            "Cannot assign to read only property 'keplr' of object '#<Window>'",
+          stacktrace: {
+            frames: [
+              {
+                filename: "app:///inject-runtime.js",
+                abs_path: "app:///inject-runtime.js",
+              },
+            ],
+          },
+        },
+      ],
+    },
+    ...overrides,
+  });
+
   const createCoinbaseWalletLinkWebSocketEvent = (
     overrides: TestSentryClientEventOverrides = {}
   ): TestSentryClientEvent => ({
@@ -3279,6 +3303,17 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
+  it("filters injected keplr read-only collisions from inject-runtime stacks", () => {
+    // Arrange
+    const event = createInjectedKeplrWalletCollisionEvent();
+
+    // Act
+    const result = shouldFilterInjectedWalletCollision(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
   it("filters Coinbase WalletLink websocket 1006 close errors", () => {
     // Arrange
     const event = createCoinbaseWalletLinkWebSocketEvent();
@@ -4281,6 +4316,39 @@ describe("sentry-client-filters", () => {
                 {
                   filename: "https://example.com/app.js",
                   abs_path: "https://example.com/app.js",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterInjectedWalletCollision(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter keplr read-only collisions with app-owned source frames", () => {
+    // Arrange
+    const event = createInjectedKeplrWalletCollisionEvent({
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value:
+              "Cannot assign to read only property 'keplr' of object '#<Window>'",
+            stacktrace: {
+              frames: [
+                {
+                  filename: "app:///inject-runtime.js",
+                  abs_path: "app:///inject-runtime.js",
+                },
+                {
+                  filename: "app:///utils/wallets/install-keplr.ts",
+                  abs_path: "app:///utils/wallets/install-keplr.ts",
                 },
               ],
             },

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -3325,6 +3325,36 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
+  it("filters Coinbase WalletLink websocket 1006 close errors without a detail suffix", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1006",
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "node_modules/.pnpm/@coinbase+wallet-sdk@3.9.3/node_modules/@coinbase/wallet-sdk/dist/relay/walletlink/connection/WalletLinkWebSocket.js",
+                  abs_path:
+                    "node_modules/.pnpm/@coinbase+wallet-sdk@3.9.3/node_modules/@coinbase/wallet-sdk/dist/relay/walletlink/connection/WalletLinkWebSocket.js",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
   it("filters Coinbase WalletLink websocket 1006 close errors from pnpm virtual-store paths", () => {
     // Arrange
     const event = createCoinbaseWalletLinkWebSocketEvent({

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -4364,6 +4364,35 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(false);
   });
 
+  it("does not filter keplr read-only collisions with mixed app-owned and injected frame paths", () => {
+    // Arrange
+    const event = createInjectedKeplrWalletCollisionEvent({
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value:
+              "Cannot assign to read only property 'keplr' of object '#<Window>'",
+            stacktrace: {
+              frames: [
+                {
+                  filename: "app:///utils/wallets/install-keplr.ts",
+                  abs_path: "app:///inject-runtime.js",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterInjectedWalletCollision(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
   it("does not filter unrelated app URI injected errors", () => {
     // Arrange
     const event = createInjectedWalletCollisionEvent({

--- a/utils/sentry-client-filters/app-frame-utils.ts
+++ b/utils/sentry-client-filters/app-frame-utils.ts
@@ -164,7 +164,7 @@ export function isInjectedOrThirdPartyWalletExtensionPath(
   );
 }
 
-export function hasInjectedWalletCollisionAppUriStackValue(
+function hasInjectedWalletCollisionAppUriStackValue(
   value: string | undefined
 ): boolean {
   const normalizedValue = value?.toLowerCase();

--- a/utils/sentry-client-filters/constants.ts
+++ b/utils/sentry-client-filters/constants.ts
@@ -11,6 +11,7 @@ const injectedAppUriPath = "app:///injected/injected.js";
 export const injectedWalletCollisionAppUriPaths = [
   injectedAppUriPath,
   "app:///requestProvider.js",
+  "app:///inject-runtime.js",
 ];
 export const walletCollisionPatterns = [
   "tronlinkparams",
@@ -18,6 +19,8 @@ export const walletCollisionPatterns = [
   "cannot assign to read only property 'ethereum'",
   'cannot assign to read only property "ethereum"',
   "cannot redefine property: ethereum",
+  "cannot assign to read only property 'keplr'",
+  'cannot assign to read only property "keplr"',
 ];
 export const coinbaseWalletSdkPathTokens = [
   "@coinbase/wallet-sdk",

--- a/utils/sentry-client-filters/wallets.ts
+++ b/utils/sentry-client-filters/wallets.ts
@@ -373,6 +373,19 @@ function hasInjectedOrThirdPartyWalletCollisionStack(
   return frames.every(hasInjectedOrThirdPartyWalletCollisionFrame);
 }
 
+function hasAppOwnedInjectedWalletCollisionEvidence(
+  event: SentryClientEvent,
+  frames: SentryStackFrame[] | undefined,
+  hint?: SentryEventHint
+): boolean {
+  return (
+    hasAppOwnedNonExtensionSignature(frames, hint) ||
+    hasAppOwnedSourceFrame(frames) ||
+    hasAppOwnedSourceStackValue(getHintExceptionStack(hint)) ||
+    hasAppOwnedSourceStackValue(getSerializedExceptionStack(event))
+  );
+}
+
 function hasWalletCollisionSignature(
   event: SentryClientEvent,
   hint?: SentryEventHint
@@ -751,7 +764,7 @@ export function shouldFilterInjectedWalletCollision(
     return false;
   }
 
-  if (hasAppOwnedNonExtensionSignature(frames, hint)) {
+  if (hasAppOwnedInjectedWalletCollisionEvidence(event, frames, hint)) {
     return false;
   }
 

--- a/utils/sentry-client-filters/wallets.ts
+++ b/utils/sentry-client-filters/wallets.ts
@@ -54,10 +54,7 @@ import {
   hasAppOwnedSourceFrame,
   hasAppOwnedSourceStackValue,
   hasAppOwnedStackPath,
-  hasInjectedAppUriFrame,
-  hasInjectedWalletCollisionAppUriStackValue,
   hasLikelyAppOwnedFrame,
-  hasOnlyAppUriFrames,
   hasOnlyInjectedProviderProxyFrames,
   isInjectedOrThirdPartyWalletExtensionPath,
 } from "./app-frame-utils";
@@ -347,18 +344,25 @@ export function matchesWalletCollisionPattern(value: string): boolean {
   );
 }
 
-function hasInjectedAppUriSignature(
+function hasInjectedOrThirdPartyWalletCollisionFrame(
+  frame: SentryStackFrame
+): boolean {
+  if (hasAppOwnedSourceFrame([frame])) {
+    return false;
+  }
+
+  return [frame.filename, frame.abs_path].some(
+    (value) =>
+      typeof value === "string" &&
+      isInjectedOrThirdPartyWalletExtensionPath(value)
+  );
+}
+
+function hasInjectedOrThirdPartyWalletCollisionStack(
   frames: SentryStackFrame[] | undefined,
   hint?: SentryEventHint
 ): boolean {
-  const hasOnlyInjectedFrames =
-    hasOnlyAppUriFrames(frames) && hasInjectedAppUriFrame(frames);
-  if (hasOnlyInjectedFrames) {
-    return true;
-  }
-
-  const stack = getHintExceptionStack(hint);
-  if (!hasInjectedWalletCollisionAppUriStackValue(stack)) {
+  if (!hasInjectedOrThirdPartyWalletExtensionSignature(frames, hint)) {
     return false;
   }
 
@@ -366,19 +370,7 @@ function hasInjectedAppUriSignature(
     return true;
   }
 
-  return hasOnlyAppUriFrames(frames);
-}
-
-function hasAppOwnedInjectedWalletCollisionEvidence(
-  event: SentryClientEvent,
-  frames: SentryStackFrame[] | undefined,
-  hint?: SentryEventHint
-): boolean {
-  return (
-    hasAppOwnedSourceFrame(frames) ||
-    hasAppOwnedSourceStackValue(getHintExceptionStack(hint)) ||
-    hasAppOwnedSourceStackValue(getSerializedExceptionStack(event))
-  );
+  return frames.every(hasInjectedOrThirdPartyWalletCollisionFrame);
 }
 
 function hasWalletCollisionSignature(
@@ -755,13 +747,13 @@ export function shouldFilterInjectedWalletCollision(
   }
 
   const frames = event.exception?.values?.[0]?.stacktrace?.frames;
-  if (hasAppOwnedInjectedWalletCollisionEvidence(event, frames, hint)) {
+  if (!hasWalletCollisionSignature(event, hint)) {
     return false;
   }
 
-  if (!hasInjectedAppUriSignature(frames, hint)) {
+  if (hasAppOwnedNonExtensionSignature(frames, hint)) {
     return false;
   }
 
-  return hasWalletCollisionSignature(event, hint);
+  return hasInjectedOrThirdPartyWalletCollisionStack(frames, hint);
 }


### PR DESCRIPTION
## Issue
- Sentry issue 6529-FRONTEND-E8 reports `Cannot assign to read only property 'keplr' of object '#<Window>'` from injected wallet runtime code on `/waves`.
- The existing injected-wallet collision filter covered similar `ethereum` collisions but did not cover the observed `keplr` shape or `app:///inject-runtime.js` frames.

## Fix
- Add `keplr` read-only wallet collision message patterns.
- Treat `app:///inject-runtime.js` as an injected wallet runtime path.
- Keep wallet-collision filtering narrow: the event is dropped only when the wallet-collision message and injected/third-party stack evidence are present, and app-owned source evidence is absent.
- Preserve app-owned wallet-global assignment visibility, including source-mapped frames that carry both app-owned and injected-runtime paths.

## Changes
- Added focused regression coverage for the production `keplr` injected runtime stack.
- Added negative tests for app-owned source frames, serialized app-owned stacks, and mixed same-frame source/runtime paths.
- Added Coinbase websocket 1006 exact-message coverage for the bare `websocket error 1006` branch raised during review.
- Made the injected wallet stack helper module-local to satisfy the installed-app Knip check.

## Validation
- `SEIZE_SECURE_INSTALL=1 ./bin/6529 run test -- __tests__/utils/sentry-client-filters.test.ts` passed with 177 tests.
- `SEIZE_SECURE_INSTALL=1 ./bin/6529 run lint:changed` passed.
- `SEIZE_SECURE_INSTALL=1 ./bin/6529 run typecheck:changed` passed for 12 changed TypeScript files.
- `SEIZE_SECURE_INSTALL=1 ./bin/6529 run deadcode:knip` was run locally; the PR-specific unused export was fixed, while the local full run still reports existing repo baseline unused script entries outside this PR.
- Latest GitHub PR check rollup is passing, including Installed app checks, Debt Ratchet, CodeQL, DCO, SonarCloud, Snyk, CodeRabbit status, and push secret scan.

## Risk
- Level: Low
- Why: change is limited to client-side Sentry event filtering and unit tests.
- Rollback: revert this PR to restore the previous filter behavior.

## Review Notes
- 6529bot follow-up review reports no new findings after the mixed-frame, Coinbase exact-message, and helper-export fixes.
- CodeRabbit status is green, but its comment says the textual review is currently rate-limited.
- Please focus on whether the injected/runtime path check remains narrow enough to keep app-owned wallet-global assignment bugs visible.