### PR TITLE
Filter Coinbase WalletLink 1006 noise

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -490,6 +490,40 @@ describe("instrumentation-client", () => {
     expect(result).toBeNull();
   });
 
+  it("drops production Coinbase WalletLink websocket 1006 frames marked in_app", () => {
+    const beforeSend = loadBeforeSend();
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "webpack://_n_e/./node_modules/@coinbase/wallet-sdk/dist/relay/walletlink/connection/WalletLinkWebSocket.js",
+                  abs_path:
+                    "webpack://_n_e/./node_modules/@coinbase/wallet-sdk/dist/relay/walletlink/connection/WalletLinkWebSocket.js",
+                  function: "webSocket.onclose",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result).toBeNull();
+  });
+
   it("drops exact Talisman onboarding errors from extension page.js frames", () => {
     const beforeSend = loadBeforeSend();
     const event = {

--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -616,6 +616,39 @@ describe("instrumentation-client", () => {
     expect(result).toBeNull();
   });
 
+  it("drops raw AppKit Coinbase websocket 1006 frames marked in_app", () => {
+    const beforeSend = loadBeforeSend();
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "Error: websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "https://dnclu2fna0b2b.cloudfront.net/_next/static/chunks/app/layout-123.js",
+                  function: "e",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      breadcrumbs: createAppKitCoinbaseBreadcrumbs(),
+    };
+
+    const result = beforeSend(event);
+
+    expect(result).toBeNull();
+  });
+
   it("keeps exact Talisman onboarding errors with app-owned frames", () => {
     const beforeSend = loadBeforeSend();
     const event = {

--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -711,6 +711,38 @@ describe("instrumentation-client", () => {
     expect(result).not.toBeNull();
   });
 
+  it("keeps raw Next static in_app websocket 1006 close errors without third-party wallet evidence", () => {
+    const beforeSend = loadBeforeSend();
+    const event = {
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "https://dnclu2fna0b2b.cloudfront.net/_next/static/chunks/app/services-websocket-provider-123.js",
+                  function: "webSocket.onclose",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    const result = beforeSend(event);
+
+    expect(result).not.toBeNull();
+  });
+
   it("drops Sentry route parameterization cyclic JSON errors", () => {
     const beforeSend = loadBeforeSend();
     const event = createSentryRouteParameterizationEvent();

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -108,6 +108,31 @@ describe("sentry-client-filters", () => {
   const extensionMessagingConnectionFailureMessage =
     "Could not establish connection. Receiving end does not exist.";
 
+  describe("first-party static frame paths", () => {
+    it("keeps the Next static path token stable", () => {
+      expect(__testing.nextStaticFramePathToken).toBe("/_next/static/");
+    });
+
+    it("classifies hosted and app Next static paths as first-party", () => {
+      expect(
+        __testing.isFirstPartyFramePath(
+          "https://host.example/_next/static/chunk.js"
+        )
+      ).toBe(true);
+      expect(
+        __testing.isFirstPartyFramePath("app:///_next/static/chunks/app.js")
+      ).toBe(true);
+    });
+
+    it("does not classify partial third-party Next static tokens as first-party", () => {
+      expect(
+        __testing.isFirstPartyFramePath(
+          "https://cdn.example/assets_next/static/chunk.js"
+        )
+      ).toBe(false);
+    });
+  });
+
   const buildSpan = (
     overrides: TestSentryTransactionSpanOverrides = {}
   ): SentryTransactionSpan => ({

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -3270,7 +3270,7 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
-  it("filters pre-symbolication Coinbase WalletLink websocket 1006 close errors marked in_app by Sentry", () => {
+  it("filters pre-symbolication Coinbase WalletLink websocket 1006 close errors marked in_app by Sentry when AppKit breadcrumbs tie it to Coinbase", () => {
     // Arrange
     const event = createCoinbaseWalletLinkWebSocketEvent({
       exception: {
@@ -3295,6 +3295,7 @@ describe("sentry-client-filters", () => {
           },
         ],
       },
+      breadcrumbs: createAppKitCoinbaseBreadcrumbs(),
     });
 
     // Act
@@ -3617,6 +3618,40 @@ describe("sentry-client-filters", () => {
         ],
       },
       breadcrumbs: createAppKitCoinbaseBreadcrumbs(),
+    });
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter raw Next static in_app websocket 1006 close errors without third-party wallet evidence", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "https://dnclu2fna0b2b.cloudfront.net/_next/static/chunks/app/services-websocket-provider-123.js",
+                  function: "webSocket.onclose",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
     });
 
     // Act

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -3420,6 +3420,41 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
+  it("filters raw AppKit Coinbase websocket 1006 unhandled rejections marked in_app by Sentry", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "Error: websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "https://dnclu2fna0b2b.cloudfront.net/_next/static/chunks/app/layout-123.js",
+                  function: "e",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      breadcrumbs: createAppKitCoinbaseBreadcrumbs(),
+    });
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
   it("filters Coinbase WalletLink websocket 1006 errors from serialized raw stacks", () => {
     // Arrange
     const event = createCoinbaseWalletLinkWebSocketEvent({

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -108,31 +108,6 @@ describe("sentry-client-filters", () => {
   const extensionMessagingConnectionFailureMessage =
     "Could not establish connection. Receiving end does not exist.";
 
-  describe("first-party static frame paths", () => {
-    it("keeps the Next static path token stable", () => {
-      expect(__testing.nextStaticFramePathToken).toBe("/_next/static/");
-    });
-
-    it("classifies hosted and app Next static paths as first-party", () => {
-      expect(
-        __testing.isFirstPartyFramePath(
-          "https://host.example/_next/static/chunk.js"
-        )
-      ).toBe(true);
-      expect(
-        __testing.isFirstPartyFramePath("app:///_next/static/chunks/app.js")
-      ).toBe(true);
-    });
-
-    it("does not classify partial third-party Next static tokens as first-party", () => {
-      expect(
-        __testing.isFirstPartyFramePath(
-          "https://cdn.example/assets_next/static/chunk.js"
-        )
-      ).toBe(false);
-    });
-  });
-
   const buildSpan = (
     overrides: TestSentryTransactionSpanOverrides = {}
   ): SentryTransactionSpan => ({
@@ -822,6 +797,31 @@ describe("sentry-client-filters", () => {
 
   afterEach(() => {
     setNavigatorUserAgent(originalNavigatorUserAgent);
+  });
+
+  describe("first-party static frame paths", () => {
+    it("keeps the Next static path token stable", () => {
+      expect(__testing.nextStaticFramePathToken).toBe("/_next/static/");
+    });
+
+    it("classifies hosted and app Next static paths as first-party", () => {
+      expect(
+        __testing.isFirstPartyFramePath(
+          "https://host.example/_next/static/chunk.js"
+        )
+      ).toBe(true);
+      expect(
+        __testing.isFirstPartyFramePath("app:///_next/static/chunks/app.js")
+      ).toBe(true);
+    });
+
+    it("does not classify partial third-party Next static tokens as first-party", () => {
+      expect(
+        __testing.isFirstPartyFramePath(
+          "https://cdn.example/assets_next/static/chunk.js"
+        )
+      ).toBe(false);
+    });
   });
 
   const createReactDomInsertBeforeEvent = (

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -3173,6 +3173,42 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
+  it("filters production Coinbase WalletLink websocket 1006 frames marked in_app by Sentry", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "webpack://_n_e/./node_modules/@coinbase/wallet-sdk/dist/relay/walletlink/connection/WalletLinkWebSocket.js",
+                  abs_path:
+                    "webpack://_n_e/./node_modules/@coinbase/wallet-sdk/dist/relay/walletlink/connection/WalletLinkWebSocket.js",
+                  function: "webSocket.onclose",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
   it("filters Coinbase WalletLink websocket 1006 close errors from pnpm virtual-store paths", () => {
     // Arrange
     const event = createCoinbaseWalletLinkWebSocketEvent({
@@ -3219,6 +3255,40 @@ describe("sentry-client-filters", () => {
                   filename:
                     "https://dnclu2fna0b2b.cloudfront.net/_next/static/chunks/app/layout-123.js",
                   function: "webSocket.onclose",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterCoinbaseWalletLinkWebSocket1006(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("filters pre-symbolication Coinbase WalletLink websocket 1006 close errors marked in_app by Sentry", () => {
+    // Arrange
+    const event = createCoinbaseWalletLinkWebSocketEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: "websocket error 1006:",
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "https://dnclu2fna0b2b.cloudfront.net/_next/static/chunks/app/layout-123.js",
+                  function: "webSocket.onclose",
+                  in_app: true,
                 },
               ],
             },

--- a/utils/sentry-client-filters/app-frame-utils.ts
+++ b/utils/sentry-client-filters/app-frame-utils.ts
@@ -9,6 +9,7 @@ import {
   injectedProviderProxyPath,
   injectedWasmCspAppUriPath,
   injectedWasmCspCollapsedPath,
+  nextStaticFramePathToken,
   NEXT_STATIC_CHUNK_FRAME_PATTERNS,
   REACT_DOM_INSERT_BEFORE_RUNTIME_FUNCTIONS,
   REACT_DOM_RUNTIME_FRAME_PATTERNS,
@@ -129,7 +130,7 @@ function isFirstPartyFramePath(path: string): boolean {
     return true;
   }
 
-  if (normalizedPath.includes("/_next/static/")) {
+  if (normalizedPath.includes(nextStaticFramePathToken)) {
     return true;
   }
 

--- a/utils/sentry-client-filters/app-frame-utils.ts
+++ b/utils/sentry-client-filters/app-frame-utils.ts
@@ -117,7 +117,7 @@ function isInjectedWasmCspFrame(frame: SentryStackFrame): boolean {
   return getFramePaths(frame).some(isInjectedWasmCspFramePath);
 }
 
-function isFirstPartyFramePath(path: string): boolean {
+export function isFirstPartyFramePath(path: string): boolean {
   const normalizedPath = path.trim();
   if (!normalizedPath) {
     return false;

--- a/utils/sentry-client-filters/constants.ts
+++ b/utils/sentry-client-filters/constants.ts
@@ -23,8 +23,7 @@ export const coinbaseWalletLinkWebSocketFile = "WalletLinkWebSocket.js";
 export const coinbaseWalletLinkWebSocketCloseFunction = "webSocket.onclose";
 export const browserUnhandledRejectionMechanism =
   "auto.browser.global_handlers.onunhandledrejection";
-export const coinbaseWalletLinkWebSocket1006Pattern =
-  /^websocket error 1006(?::.*)?$/i;
+export const coinbaseWalletLinkWebSocket1006Message = "websocket error 1006";
 export const walletWebSocketBreadcrumbAppKitTokens = [
   "appkit",
   "reown",
@@ -87,9 +86,10 @@ export const browserExtensionUrlPrefixes = [
   "moz-extension://",
   "safari-web-extension://",
 ];
+export const nextStaticFramePathToken = "/_next/static/";
 const appOwnedFrameBasePathTokens = [
   "webpack-internal:///(app-",
-  "/_next/static/",
+  nextStaticFramePathToken,
 ];
 export const appOwnedFramePathTokens = [
   ...appOwnedFrameBasePathTokens,
@@ -101,7 +101,7 @@ export const rabbyMobileStackPatterns = ["rabbymobile", "userrejectedrequest"];
 export const appOwnedStackPatterns = [
   "webpack-internal:///(app-pages-browser)",
   "webpack://_n_e/./",
-  "/_next/static/",
+  nextStaticFramePathToken,
   "https://6529.io/",
   "https://www.6529.io/",
   "https://staging.6529.io/",
@@ -132,8 +132,8 @@ export const REACT_DOM_RUNTIME_FRAME_PATTERNS = [
   "react-dom-client.production.js",
 ];
 export const NEXT_STATIC_CHUNK_FRAME_PATTERNS = [
-  "/_next/static/chunks/",
-  "/_next/static/webpack/",
+  `${nextStaticFramePathToken}chunks/`,
+  `${nextStaticFramePathToken}webpack/`,
 ];
 export const REACT_DOM_INSERT_BEFORE_RUNTIME_FUNCTIONS = new Set([
   "insertOrAppendPlacementNode",

--- a/utils/sentry-client-filters/testing.ts
+++ b/utils/sentry-client-filters/testing.ts
@@ -20,8 +20,8 @@ import {
   hasCoinbaseWalletLinkWebSocketFrame,
   isCoinbaseWalletLinkWebSocket1006Message,
   isCoinbaseWalletLinkWebSocketPath,
-  matchesWalletCollisionPattern,
-} from "./wallets";
+} from "./walletlink-websocket";
+import { matchesWalletCollisionPattern } from "./wallets";
 
 export const __testing = {
   filenameExceptions,

--- a/utils/sentry-client-filters/testing.ts
+++ b/utils/sentry-client-filters/testing.ts
@@ -2,12 +2,17 @@ import {
   filenameExceptions,
   gifPickerTenorUndefinedTagsMessage,
   noisyThirdPartyTelemetryTargets,
+  nextStaticFramePathToken,
   REACT_DOM_INSERT_BEFORE_NOT_FOUND_ERROR_MESSAGE,
   REACT_DOM_REMOVE_CHILD_NOT_FOUND_ERROR_MESSAGE,
   sentryRouteParameterizationMechanismType,
   sentryRouteParameterizationMessage,
 } from "./constants";
-import { hasInjectedAppUriFrame, hasOnlyAppUriFrames } from "./app-frame-utils";
+import {
+  hasInjectedAppUriFrame,
+  hasOnlyAppUriFrames,
+  isFirstPartyFramePath,
+} from "./app-frame-utils";
 import {
   hasMetaMaskMobileWebViewContext,
   hasRouteParameterizationRouteEvidence,
@@ -30,6 +35,8 @@ export const __testing = {
   isTwitterBrowser,
   matchesWalletCollisionPattern,
   noisyThirdPartyTelemetryTargets,
+  nextStaticFramePathToken,
+  isFirstPartyFramePath,
   REACT_DOM_INSERT_BEFORE_NOT_FOUND_ERROR_MESSAGE,
   gifPickerTenorUndefinedTagsMessage,
   REACT_DOM_REMOVE_CHILD_NOT_FOUND_ERROR_MESSAGE,

--- a/utils/sentry-client-filters/walletlink-websocket.ts
+++ b/utils/sentry-client-filters/walletlink-websocket.ts
@@ -1,0 +1,257 @@
+import {
+  browserUnhandledRejectionMechanism,
+  coinbaseWalletLinkWebSocketCloseFunction,
+  coinbaseWalletLinkWebSocketFile,
+  coinbaseWalletLinkWebSocket1006MessagePrefix,
+  coinbaseWalletSdkPathTokens,
+  nextStaticFramePathToken,
+  walletWebSocketBreadcrumbAppKitTokens,
+  walletWebSocketBreadcrumbConnectorTokens,
+} from "./constants";
+import {
+  hasAppOwnedSourceFrame,
+  hasAppOwnedSourceStackValue,
+} from "./app-frame-utils";
+import type {
+  SentryClientEvent,
+  SentryEventHint,
+  SentryExceptionValue,
+  SentryStackFrame,
+} from "./types";
+import {
+  getBreadcrumbValues,
+  getHintExceptionStack,
+  getSerializedExceptionStack,
+  isRecord,
+  normalizeErrorPrefix,
+} from "./value-utils";
+
+export function isCoinbaseWalletLinkWebSocket1006Message(
+  value: string
+): boolean {
+  const normalized = normalizeErrorPrefix(value).toLowerCase();
+  return (
+    normalized === coinbaseWalletLinkWebSocket1006MessagePrefix ||
+    normalized.startsWith(`${coinbaseWalletLinkWebSocket1006MessagePrefix}:`)
+  );
+}
+
+export function isCoinbaseWalletLinkWebSocketPath(
+  path: string | undefined
+): boolean {
+  return (
+    typeof path === "string" &&
+    path.includes(coinbaseWalletLinkWebSocketFile) &&
+    coinbaseWalletSdkPathTokens.some((token) => path.includes(token))
+  );
+}
+
+function isCoinbaseWalletLinkWebSocketFrame(frame: SentryStackFrame): boolean {
+  return [frame.filename, frame.abs_path].some(
+    isCoinbaseWalletLinkWebSocketPath
+  );
+}
+
+export function hasCoinbaseWalletLinkWebSocketFrame(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  return (
+    Array.isArray(frames) && frames.some(isCoinbaseWalletLinkWebSocketFrame)
+  );
+}
+
+function isCoinbaseWalletLinkWebSocketCloseFrame(
+  frame: SentryStackFrame
+): boolean {
+  return frame.function === coinbaseWalletLinkWebSocketCloseFunction;
+}
+
+export function hasCoinbaseWalletLinkWebSocketCloseFunction(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  return (
+    Array.isArray(frames) &&
+    frames.some(isCoinbaseWalletLinkWebSocketCloseFrame)
+  );
+}
+
+function isRawNextStaticFrame(frame: SentryStackFrame): boolean {
+  return [frame.filename, frame.abs_path].some(
+    (path) =>
+      typeof path === "string" && path.includes(nextStaticFramePathToken)
+  );
+}
+
+export function hasRawNextStaticInAppFrame(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  return (
+    Array.isArray(frames) &&
+    frames.some((frame) => frame.in_app === true && isRawNextStaticFrame(frame))
+  );
+}
+
+function hasAppOwnedWalletLinkWebSocketInAppFrame(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  return (
+    Array.isArray(frames) &&
+    frames.some(
+      (frame) =>
+        frame.in_app === true &&
+        !isCoinbaseWalletLinkWebSocketFrame(frame) &&
+        !isCoinbaseWalletLinkWebSocketCloseFrame(frame) &&
+        !isRawNextStaticFrame(frame)
+    )
+  );
+}
+
+export function hasCoinbaseWalletLinkWebSocketStack(
+  hint?: SentryEventHint
+): boolean {
+  const stack = getHintExceptionStack(hint);
+  return (
+    stack.includes(coinbaseWalletLinkWebSocketFile) &&
+    coinbaseWalletSdkPathTokens.some((token) => stack.includes(token))
+  );
+}
+
+export function hasCoinbaseWalletLinkWebSocketCloseStack(
+  hint?: SentryEventHint
+): boolean {
+  return getHintExceptionStack(hint).includes(
+    coinbaseWalletLinkWebSocketCloseFunction
+  );
+}
+
+export function hasCoinbaseWalletLinkWebSocketSerializedStack(
+  event: SentryClientEvent
+): boolean {
+  const stack = getSerializedExceptionStack(event);
+  return (
+    stack.includes(coinbaseWalletLinkWebSocketFile) &&
+    coinbaseWalletSdkPathTokens.some((token) => stack.includes(token))
+  );
+}
+
+function hasCoinbaseWalletLinkWebSocketSerializedCloseStack(
+  event: SentryClientEvent
+): boolean {
+  return getSerializedExceptionStack(event).includes(
+    coinbaseWalletLinkWebSocketCloseFunction
+  );
+}
+
+function addBreadcrumbSignatureValues(
+  value: unknown,
+  values: string[],
+  depth: number
+): void {
+  if (depth > 4) {
+    return;
+  }
+
+  if (typeof value === "string") {
+    values.push(value);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) =>
+      addBreadcrumbSignatureValues(item, values, depth + 1)
+    );
+    return;
+  }
+
+  if (!isRecord(value)) {
+    return;
+  }
+
+  Object.entries(value).forEach(([key, item]) => {
+    if (item === true) {
+      values.push(key);
+    }
+    addBreadcrumbSignatureValues(item, values, depth + 1);
+  });
+}
+
+function getBreadcrumbSignatureText(event: SentryClientEvent): string {
+  const values: string[] = [];
+  getBreadcrumbValues(event).forEach((breadcrumb) => {
+    addBreadcrumbSignatureValues(
+      [breadcrumb.category, breadcrumb.message, breadcrumb.data],
+      values,
+      0
+    );
+  });
+
+  return values.join("\n").toLowerCase();
+}
+
+export function hasThirdPartyWalletAppKitBreadcrumbSignature(
+  event: SentryClientEvent
+): boolean {
+  const text = getBreadcrumbSignatureText(event);
+  if (!text) {
+    return false;
+  }
+
+  const hasAppKitToken = walletWebSocketBreadcrumbAppKitTokens.some((token) =>
+    text.includes(token)
+  );
+  const hasConnectorToken = walletWebSocketBreadcrumbConnectorTokens.some(
+    (token) => text.includes(token)
+  );
+
+  return hasAppKitToken && hasConnectorToken;
+}
+
+export function hasWalletLinkWebSocketUnhandledRejectionSignature(
+  value: SentryExceptionValue | undefined,
+  event: SentryClientEvent,
+  hint?: SentryEventHint
+): boolean {
+  return (
+    value?.mechanism?.type === browserUnhandledRejectionMechanism &&
+    value.mechanism.handled === false &&
+    (hasCoinbaseWalletLinkWebSocketCloseFunction(value.stacktrace?.frames) ||
+      hasCoinbaseWalletLinkWebSocketCloseStack(hint) ||
+      hasCoinbaseWalletLinkWebSocketSerializedCloseStack(event))
+  );
+}
+
+export function hasBrowserUnhandledRejectionMechanism(
+  value: SentryExceptionValue | undefined
+): boolean {
+  return (
+    value?.mechanism?.type === browserUnhandledRejectionMechanism &&
+    value.mechanism.handled === false
+  );
+}
+
+export function hasAppOwnedWalletLinkWebSocket1006Evidence(
+  event: SentryClientEvent,
+  value: SentryExceptionValue | undefined,
+  hint?: SentryEventHint
+): boolean {
+  const frames = value?.stacktrace?.frames;
+  return (
+    hasAppOwnedSourceFrame(frames) ||
+    hasAppOwnedWalletLinkWebSocketInAppFrame(frames) ||
+    hasAppOwnedSourceStackValue(getHintExceptionStack(hint)) ||
+    hasAppOwnedSourceStackValue(getSerializedExceptionStack(event))
+  );
+}
+
+export function hasThirdPartyWalletLinkWebSocket1006Evidence(
+  event: SentryClientEvent,
+  value: SentryExceptionValue | undefined,
+  hint?: SentryEventHint
+): boolean {
+  return (
+    hasCoinbaseWalletLinkWebSocketFrame(value?.stacktrace?.frames) ||
+    hasCoinbaseWalletLinkWebSocketStack(hint) ||
+    hasCoinbaseWalletLinkWebSocketSerializedStack(event) ||
+    hasThirdPartyWalletAppKitBreadcrumbSignature(event)
+  );
+}

--- a/utils/sentry-client-filters/wallets.ts
+++ b/utils/sentry-client-filters/wallets.ts
@@ -1,7 +1,7 @@
 import {
   browserUnhandledRejectionMechanism,
   circularReactMetaElementMessagePatterns,
-  coinbaseWalletLinkWebSocket1006Pattern,
+  coinbaseWalletLinkWebSocket1006Message,
   coinbaseWalletLinkWebSocketCloseFunction,
   coinbaseWalletLinkWebSocketFile,
   coinbaseWalletSdkPathTokens,
@@ -9,6 +9,7 @@ import {
   injectedProviderProxyStartsWithMessage,
   jsonStringifyFunction,
   metaMaskMobileUpdateUrlFunction,
+  nextStaticFramePathToken,
   objectCapturedPromiseRejectionMessage,
   providerDisconnectedCode,
   providerDisconnectedMessage,
@@ -95,8 +96,10 @@ function hasAppOwnedStackEvidence(
 export function isCoinbaseWalletLinkWebSocket1006Message(
   value: string
 ): boolean {
-  return coinbaseWalletLinkWebSocket1006Pattern.test(
-    normalizeErrorPrefix(value)
+  const normalized = normalizeErrorPrefix(value).toLowerCase();
+  return (
+    normalized === coinbaseWalletLinkWebSocket1006Message ||
+    normalized.startsWith(`${coinbaseWalletLinkWebSocket1006Message}:`)
   );
 }
 
@@ -110,31 +113,17 @@ export function isCoinbaseWalletLinkWebSocketPath(
   );
 }
 
+function isCoinbaseWalletLinkWebSocketFrame(frame: SentryStackFrame): boolean {
+  return [frame.filename, frame.abs_path].some(
+    isCoinbaseWalletLinkWebSocketPath
+  );
+}
+
 export function hasCoinbaseWalletLinkWebSocketFrame(
   frames: SentryStackFrame[] | undefined
 ): boolean {
   return (
-    Array.isArray(frames) &&
-    frames.some((frame) =>
-      [frame.filename, frame.abs_path].some(isCoinbaseWalletLinkWebSocketPath)
-    )
-  );
-}
-
-export function hasCoinbaseWalletLinkWebSocketCloseFunction(
-  frames: SentryStackFrame[] | undefined
-): boolean {
-  return (
-    Array.isArray(frames) &&
-    frames.some(
-      (frame) => frame.function === coinbaseWalletLinkWebSocketCloseFunction
-    )
-  );
-}
-
-function isCoinbaseWalletLinkWebSocketFrame(frame: SentryStackFrame): boolean {
-  return [frame.filename, frame.abs_path].some(
-    isCoinbaseWalletLinkWebSocketPath
+    Array.isArray(frames) && frames.some(isCoinbaseWalletLinkWebSocketFrame)
   );
 }
 
@@ -144,9 +133,28 @@ function isCoinbaseWalletLinkWebSocketCloseFrame(
   return frame.function === coinbaseWalletLinkWebSocketCloseFunction;
 }
 
+export function hasCoinbaseWalletLinkWebSocketCloseFunction(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  return (
+    Array.isArray(frames) &&
+    frames.some(isCoinbaseWalletLinkWebSocketCloseFrame)
+  );
+}
+
 function isRawNextStaticFrame(frame: SentryStackFrame): boolean {
   return [frame.filename, frame.abs_path].some(
-    (path) => typeof path === "string" && path.includes("/_next/static/")
+    (path) =>
+      typeof path === "string" && path.includes(nextStaticFramePathToken)
+  );
+}
+
+function hasRawNextStaticInAppFrame(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  return (
+    Array.isArray(frames) &&
+    frames.some((frame) => frame.in_app === true && isRawNextStaticFrame(frame))
   );
 }
 
@@ -662,6 +670,9 @@ export function shouldFilterCoinbaseWalletLinkWebSocket1006(
     value,
     hint
   );
+  const hasAmbiguousRawInAppFrame = hasRawNextStaticInAppFrame(
+    value?.stacktrace?.frames
+  );
   if (hasAppOwnedEvidence) {
     return false;
   }
@@ -676,7 +687,10 @@ export function shouldFilterCoinbaseWalletLinkWebSocket1006(
   }
 
   if (hasWalletLinkWebSocketUnhandledRejectionSignature(value, event, hint)) {
-    return true;
+    return (
+      !hasAmbiguousRawInAppFrame ||
+      hasThirdPartyWalletAppKitBreadcrumbSignature(event)
+    );
   }
 
   return (

--- a/utils/sentry-client-filters/wallets.ts
+++ b/utils/sentry-client-filters/wallets.ts
@@ -1,14 +1,8 @@
 import {
-  browserUnhandledRejectionMechanism,
   circularReactMetaElementMessagePatterns,
-  coinbaseWalletLinkWebSocketCloseFunction,
-  coinbaseWalletLinkWebSocketFile,
-  coinbaseWalletLinkWebSocket1006MessagePrefix,
-  coinbaseWalletSdkPathTokens,
   injectedProviderProxyStartsWithMessage,
   jsonStringifyFunction,
   metaMaskMobileUpdateUrlFunction,
-  nextStaticFramePathToken,
   objectCapturedPromiseRejectionMessage,
   providerDisconnectedCode,
   providerDisconnectedMessage,
@@ -22,8 +16,6 @@ import {
   walletCollisionPatterns,
   walletConnectStaleSessionFunctions,
   walletConnectStaleSessionTopicPrefix,
-  walletWebSocketBreadcrumbAppKitTokens,
-  walletWebSocketBreadcrumbConnectorTokens,
 } from "./constants";
 import type {
   SentryClientEvent,
@@ -33,7 +25,6 @@ import type {
 } from "./types";
 import {
   getBreadcrumbMessages,
-  getBreadcrumbValues,
   getContextString,
   getEventMessage,
   getHintExceptionMessage,
@@ -45,7 +36,6 @@ import {
   getSerializedObjectRejection,
   getStringValue,
   isObjectCapturedPromiseRejectionMessage,
-  isRecord,
   normalizeErrorPrefix,
 } from "./value-utils";
 import {
@@ -61,6 +51,18 @@ import {
   hasOnlyInjectedProviderProxyFrames,
   isInjectedOrThirdPartyWalletExtensionPath,
 } from "./app-frame-utils";
+import {
+  hasAppOwnedWalletLinkWebSocket1006Evidence,
+  hasBrowserUnhandledRejectionMechanism,
+  hasCoinbaseWalletLinkWebSocketFrame,
+  hasCoinbaseWalletLinkWebSocketSerializedStack,
+  hasCoinbaseWalletLinkWebSocketStack,
+  hasRawNextStaticInAppFrame,
+  hasThirdPartyWalletAppKitBreadcrumbSignature,
+  hasThirdPartyWalletLinkWebSocket1006Evidence,
+  hasWalletLinkWebSocketUnhandledRejectionSignature,
+  isCoinbaseWalletLinkWebSocket1006Message,
+} from "./walletlink-websocket";
 
 function matchesStackPattern(
   value: string | undefined,
@@ -97,234 +99,6 @@ function hasAppOwnedStackEvidence(
     hasLikelyAppOwnedFrame(frames) ||
     hasAppOwnedStackPath(serializedStack) ||
     hasAppOwnedStackPath(getHintExceptionStack(hint))
-  );
-}
-
-export function isCoinbaseWalletLinkWebSocket1006Message(
-  value: string
-): boolean {
-  const normalized = normalizeErrorPrefix(value).toLowerCase();
-  return (
-    normalized === coinbaseWalletLinkWebSocket1006MessagePrefix ||
-    normalized.startsWith(`${coinbaseWalletLinkWebSocket1006MessagePrefix}:`)
-  );
-}
-
-export function isCoinbaseWalletLinkWebSocketPath(
-  path: string | undefined
-): boolean {
-  return (
-    typeof path === "string" &&
-    path.includes(coinbaseWalletLinkWebSocketFile) &&
-    coinbaseWalletSdkPathTokens.some((token) => path.includes(token))
-  );
-}
-
-function isCoinbaseWalletLinkWebSocketFrame(frame: SentryStackFrame): boolean {
-  return [frame.filename, frame.abs_path].some(
-    isCoinbaseWalletLinkWebSocketPath
-  );
-}
-
-export function hasCoinbaseWalletLinkWebSocketFrame(
-  frames: SentryStackFrame[] | undefined
-): boolean {
-  return (
-    Array.isArray(frames) && frames.some(isCoinbaseWalletLinkWebSocketFrame)
-  );
-}
-
-function isCoinbaseWalletLinkWebSocketCloseFrame(
-  frame: SentryStackFrame
-): boolean {
-  return frame.function === coinbaseWalletLinkWebSocketCloseFunction;
-}
-
-export function hasCoinbaseWalletLinkWebSocketCloseFunction(
-  frames: SentryStackFrame[] | undefined
-): boolean {
-  return (
-    Array.isArray(frames) &&
-    frames.some(isCoinbaseWalletLinkWebSocketCloseFrame)
-  );
-}
-
-function isRawNextStaticFrame(frame: SentryStackFrame): boolean {
-  return [frame.filename, frame.abs_path].some(
-    (path) =>
-      typeof path === "string" && path.includes(nextStaticFramePathToken)
-  );
-}
-
-function hasRawNextStaticInAppFrame(
-  frames: SentryStackFrame[] | undefined
-): boolean {
-  return (
-    Array.isArray(frames) &&
-    frames.some((frame) => frame.in_app === true && isRawNextStaticFrame(frame))
-  );
-}
-
-function hasAppOwnedWalletLinkWebSocketInAppFrame(
-  frames: SentryStackFrame[] | undefined
-): boolean {
-  return (
-    Array.isArray(frames) &&
-    frames.some(
-      (frame) =>
-        frame.in_app === true &&
-        !isCoinbaseWalletLinkWebSocketFrame(frame) &&
-        !isCoinbaseWalletLinkWebSocketCloseFrame(frame) &&
-        !isRawNextStaticFrame(frame)
-    )
-  );
-}
-
-function hasCoinbaseWalletLinkWebSocketStack(hint?: SentryEventHint): boolean {
-  const stack = getHintExceptionStack(hint);
-  return (
-    stack.includes(coinbaseWalletLinkWebSocketFile) &&
-    coinbaseWalletSdkPathTokens.some((token) => stack.includes(token))
-  );
-}
-
-export function hasCoinbaseWalletLinkWebSocketCloseStack(
-  hint?: SentryEventHint
-): boolean {
-  return getHintExceptionStack(hint).includes(
-    coinbaseWalletLinkWebSocketCloseFunction
-  );
-}
-
-function hasCoinbaseWalletLinkWebSocketSerializedStack(
-  event: SentryClientEvent
-): boolean {
-  const stack = getSerializedExceptionStack(event);
-  return (
-    stack.includes(coinbaseWalletLinkWebSocketFile) &&
-    coinbaseWalletSdkPathTokens.some((token) => stack.includes(token))
-  );
-}
-
-function hasCoinbaseWalletLinkWebSocketSerializedCloseStack(
-  event: SentryClientEvent
-): boolean {
-  return getSerializedExceptionStack(event).includes(
-    coinbaseWalletLinkWebSocketCloseFunction
-  );
-}
-
-function addBreadcrumbSignatureValues(
-  value: unknown,
-  values: string[],
-  depth: number
-): void {
-  if (depth > 4) {
-    return;
-  }
-
-  if (typeof value === "string") {
-    values.push(value);
-    return;
-  }
-
-  if (Array.isArray(value)) {
-    value.forEach((item) =>
-      addBreadcrumbSignatureValues(item, values, depth + 1)
-    );
-    return;
-  }
-
-  if (!isRecord(value)) {
-    return;
-  }
-
-  Object.entries(value).forEach(([key, item]) => {
-    if (item === true) {
-      values.push(key);
-    }
-    addBreadcrumbSignatureValues(item, values, depth + 1);
-  });
-}
-
-function getBreadcrumbSignatureText(event: SentryClientEvent): string {
-  const values: string[] = [];
-  getBreadcrumbValues(event).forEach((breadcrumb) => {
-    addBreadcrumbSignatureValues(
-      [breadcrumb.category, breadcrumb.message, breadcrumb.data],
-      values,
-      0
-    );
-  });
-
-  return values.join("\n").toLowerCase();
-}
-
-function hasThirdPartyWalletAppKitBreadcrumbSignature(
-  event: SentryClientEvent
-): boolean {
-  const text = getBreadcrumbSignatureText(event);
-  if (!text) {
-    return false;
-  }
-
-  const hasAppKitToken = walletWebSocketBreadcrumbAppKitTokens.some((token) =>
-    text.includes(token)
-  );
-  const hasConnectorToken = walletWebSocketBreadcrumbConnectorTokens.some(
-    (token) => text.includes(token)
-  );
-
-  return hasAppKitToken && hasConnectorToken;
-}
-
-function hasWalletLinkWebSocketUnhandledRejectionSignature(
-  value: SentryExceptionValue | undefined,
-  event: SentryClientEvent,
-  hint?: SentryEventHint
-): boolean {
-  return (
-    value?.mechanism?.type === browserUnhandledRejectionMechanism &&
-    value.mechanism.handled === false &&
-    (hasCoinbaseWalletLinkWebSocketCloseFunction(value.stacktrace?.frames) ||
-      hasCoinbaseWalletLinkWebSocketCloseStack(hint) ||
-      hasCoinbaseWalletLinkWebSocketSerializedCloseStack(event))
-  );
-}
-
-function hasBrowserUnhandledRejectionMechanism(
-  value: SentryExceptionValue | undefined
-): boolean {
-  return (
-    value?.mechanism?.type === browserUnhandledRejectionMechanism &&
-    value.mechanism.handled === false
-  );
-}
-
-function hasAppOwnedWalletLinkWebSocket1006Evidence(
-  event: SentryClientEvent,
-  value: SentryExceptionValue | undefined,
-  hint?: SentryEventHint
-): boolean {
-  const frames = value?.stacktrace?.frames;
-  return (
-    hasAppOwnedSourceFrame(frames) ||
-    hasAppOwnedWalletLinkWebSocketInAppFrame(frames) ||
-    hasAppOwnedSourceStackValue(getHintExceptionStack(hint)) ||
-    hasAppOwnedSourceStackValue(getSerializedExceptionStack(event))
-  );
-}
-
-function hasThirdPartyWalletLinkWebSocket1006Evidence(
-  event: SentryClientEvent,
-  value: SentryExceptionValue | undefined,
-  hint?: SentryEventHint
-): boolean {
-  return (
-    hasCoinbaseWalletLinkWebSocketFrame(value?.stacktrace?.frames) ||
-    hasCoinbaseWalletLinkWebSocketStack(hint) ||
-    hasCoinbaseWalletLinkWebSocketSerializedStack(event) ||
-    hasThirdPartyWalletAppKitBreadcrumbSignature(event)
   );
 }
 

--- a/utils/sentry-client-filters/wallets.ts
+++ b/utils/sentry-client-filters/wallets.ts
@@ -49,7 +49,6 @@ import {
 } from "./value-utils";
 import {
   getStackSignatureValues,
-  hasAppOwnedFrame,
   hasAppOwnedNonExtensionSignature,
   hasAppOwnedSourceFrame,
   hasAppOwnedSourceStackValue,
@@ -129,6 +128,32 @@ export function hasCoinbaseWalletLinkWebSocketCloseFunction(
     Array.isArray(frames) &&
     frames.some(
       (frame) => frame.function === coinbaseWalletLinkWebSocketCloseFunction
+    )
+  );
+}
+
+function isCoinbaseWalletLinkWebSocketFrame(frame: SentryStackFrame): boolean {
+  return [frame.filename, frame.abs_path].some(
+    isCoinbaseWalletLinkWebSocketPath
+  );
+}
+
+function isCoinbaseWalletLinkWebSocketCloseFrame(
+  frame: SentryStackFrame
+): boolean {
+  return frame.function === coinbaseWalletLinkWebSocketCloseFunction;
+}
+
+function hasAppOwnedWalletLinkWebSocketInAppFrame(
+  frames: SentryStackFrame[] | undefined
+): boolean {
+  return (
+    Array.isArray(frames) &&
+    frames.some(
+      (frame) =>
+        frame.in_app === true &&
+        !isCoinbaseWalletLinkWebSocketFrame(frame) &&
+        !isCoinbaseWalletLinkWebSocketCloseFrame(frame)
     )
   );
 }
@@ -261,8 +286,8 @@ function hasAppOwnedWalletLinkWebSocket1006Evidence(
 ): boolean {
   const frames = value?.stacktrace?.frames;
   return (
-    hasAppOwnedFrame(frames) ||
     hasAppOwnedSourceFrame(frames) ||
+    hasAppOwnedWalletLinkWebSocketInAppFrame(frames) ||
     hasAppOwnedSourceStackValue(getHintExceptionStack(hint)) ||
     hasAppOwnedSourceStackValue(getSerializedExceptionStack(event))
   );
@@ -643,16 +668,12 @@ export function shouldFilterCoinbaseWalletLinkWebSocket1006(
     return true;
   }
 
-  if (
-    hasWalletLinkWebSocketUnhandledRejectionSignature(value, event, hint) &&
-    !hasAppOwnedEvidence
-  ) {
+  if (hasWalletLinkWebSocketUnhandledRejectionSignature(value, event, hint)) {
     return true;
   }
 
   return (
     hasBrowserUnhandledRejectionMechanism(value) &&
-    !hasAppOwnedEvidence &&
     hasThirdPartyWalletLinkWebSocket1006Evidence(event, value, hint)
   );
 }

--- a/utils/sentry-client-filters/wallets.ts
+++ b/utils/sentry-client-filters/wallets.ts
@@ -20,7 +20,6 @@ import {
 import type {
   SentryClientEvent,
   SentryEventHint,
-  SentryExceptionValue,
   SentryStackFrame,
 } from "./types";
 import {

--- a/utils/sentry-client-filters/wallets.ts
+++ b/utils/sentry-client-filters/wallets.ts
@@ -144,6 +144,12 @@ function isCoinbaseWalletLinkWebSocketCloseFrame(
   return frame.function === coinbaseWalletLinkWebSocketCloseFunction;
 }
 
+function isRawNextStaticFrame(frame: SentryStackFrame): boolean {
+  return [frame.filename, frame.abs_path].some(
+    (path) => typeof path === "string" && path.includes("/_next/static/")
+  );
+}
+
 function hasAppOwnedWalletLinkWebSocketInAppFrame(
   frames: SentryStackFrame[] | undefined
 ): boolean {
@@ -153,7 +159,8 @@ function hasAppOwnedWalletLinkWebSocketInAppFrame(
       (frame) =>
         frame.in_app === true &&
         !isCoinbaseWalletLinkWebSocketFrame(frame) &&
-        !isCoinbaseWalletLinkWebSocketCloseFrame(frame)
+        !isCoinbaseWalletLinkWebSocketCloseFrame(frame) &&
+        !isRawNextStaticFrame(frame)
     )
   );
 }


### PR DESCRIPTION
## Issue
- Sentry issue 6529-FRONTEND-N still receives `websocket error 1006:` events from Coinbase WalletLink.
- The filter could treat vendor WalletLink frames as app-owned when Sentry marks them `in_app: true`, so wallet noise survived.

## Fix
- Narrow the app-owned evidence check for the Coinbase WalletLink 1006 filter.
- Coinbase WalletLink source frames and WalletLink close-handler frames no longer count as first-party solely because of `in_app: true`.
- Real app-owned websocket evidence still keeps first-party websocket errors.

## Changes
- Added WalletLink frame helpers to distinguish Coinbase vendor frames from app-owned frames.
- Kept source-frame and serialized/original app-stack checks as the guard against hiding first-party websocket failures.
- Added production-shape tests for WalletLink frames marked `in_app: true`.

## Validation
- `git diff --check`
- `6529 run test:no-coverage -- __tests__/utils/sentry-client-filters.test.ts __tests__/instrumentation-client.test.ts`
- `6529 run lint:uncommitted:tight`
- `6529 run lint:changed`
- `6529 run typecheck:changed`

## Risk
- Level: Low
- Why: client-side Sentry filtering only; the filter remains scoped to Coinbase WalletLink websocket 1006 signatures and keeps first-party websocket evidence.
- Rollback: revert this PR to restore the previous filtering behavior.

## Review Notes
- Please focus on whether the `in_app` narrowing still preserves first-party websocket errors while dropping Coinbase WalletLink noise.