### PR TITLE
Reconcile stale reaction canonical updates

### DIFF
--- a/__tests__/utils/monitoring/dropReactionMonitoring.test.ts
+++ b/__tests__/utils/monitoring/dropReactionMonitoring.test.ts
@@ -419,15 +419,15 @@ describe("dropReactionMonitoring", () => {
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });
 
-  it("captures reconciliation mismatch after the guard window", () => {
+  it("suppresses stale canonical refetches inside the successful reaction window", () => {
     const mutation = beginReactionMutation({
       dropId: "drop-4",
       waveId: "wave-1",
-      source: "chip",
-      action: "replace",
-      previousReaction: ":wave:",
-      intendedReaction: ":smile:",
-      optimisticReaction: ":smile:",
+      source: "quick-react",
+      action: "add",
+      previousReaction: null,
+      intendedReaction: ":joy:",
+      optimisticReaction: ":joy:",
       profileId: "profile-1",
       websocketStatus: WebSocketStatus.CONNECTED,
     });
@@ -441,10 +441,62 @@ describe("dropReactionMonitoring", () => {
     recordReactionRequestSucceeded(mutation);
     expect(mutation.apiFailedAt).toBeNull();
 
-    dateNowSpy.mockReturnValue(17_000);
+    dateNowSpy.mockReturnValue(57_000);
     const result = recordReactionRealtimeReconciliation({
       drop: {
         id: "drop-4",
+        wave: { id: "wave-1" },
+        context_profile_context: {
+          reaction: null,
+        } as any,
+      },
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+
+    expect(result).toEqual({
+      shouldApplyCanonicalDrop: false,
+      expectedReaction: ":joy:",
+      serverReaction: null,
+      supersededByMutationId: mutation.mutationId,
+    });
+    expect(addBreadcrumbMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "reaction.realtime_superseded",
+        data: expect.objectContaining({
+          expected_reaction: ":joy:",
+          time_since_api_success_ms: 55_900,
+          reconciliation_window_ms: 120_000,
+        }),
+      })
+    );
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it("captures reconciliation mismatch after the successful reaction window", () => {
+    const mutation = beginReactionMutation({
+      dropId: "drop-4-expired",
+      waveId: "wave-1",
+      source: "chip",
+      action: "replace",
+      previousReaction: ":wave:",
+      intendedReaction: ":smile:",
+      optimisticReaction: ":smile:",
+      profileId: "profile-1",
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+
+    recordReactionRequestSent(mutation, {
+      endpoint: "drops/drop-4-expired/reaction",
+      method: "POST",
+    });
+
+    dateNowSpy.mockReturnValue(1_100);
+    recordReactionRequestSucceeded(mutation);
+
+    dateNowSpy.mockReturnValue(130_000);
+    const result = recordReactionRealtimeReconciliation({
+      drop: {
+        id: "drop-4-expired",
         wave: { id: "wave-1" },
         context_profile_context: {
           reaction: ":wave:",
@@ -463,6 +515,8 @@ describe("dropReactionMonitoring", () => {
         message: "reaction.optimistic_reverted",
         data: expect.objectContaining({
           server_reaction: ":wave:",
+          time_since_api_success_ms: 128_900,
+          reconciliation_window_ms: 120_000,
         }),
       })
     );

--- a/__tests__/utils/monitoring/dropReactionMonitoring.test.ts
+++ b/__tests__/utils/monitoring/dropReactionMonitoring.test.ts
@@ -573,6 +573,64 @@ describe("dropReactionMonitoring", () => {
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });
 
+  it("clears the realtime guard after canonical state matches intent", () => {
+    const mutation = beginReactionMutation({
+      dropId: "drop-5b",
+      waveId: "wave-1",
+      source: "chip",
+      action: "add",
+      previousReaction: null,
+      intendedReaction: ":smile:",
+      optimisticReaction: ":smile:",
+      profileId: "profile-1",
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+
+    recordReactionRequestSent(mutation, {
+      endpoint: "drops/drop-5b/reaction",
+      method: "POST",
+    });
+
+    dateNowSpy.mockReturnValue(1_100);
+    recordReactionRequestSucceeded(mutation);
+
+    dateNowSpy.mockReturnValue(1_300);
+    recordReactionRealtimeReconciliation({
+      drop: {
+        id: "drop-5b",
+        wave: { id: "wave-1" },
+        context_profile_context: {
+          reaction: ":smile:",
+        } as any,
+      },
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+
+    dateNowSpy.mockReturnValue(1_500);
+    const result = recordReactionRealtimeReconciliation({
+      drop: {
+        id: "drop-5b",
+        wave: { id: "wave-1" },
+        context_profile_context: {
+          reaction: ":wave:",
+        } as any,
+      },
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+
+    expect(result).toEqual({
+      shouldApplyCanonicalDrop: true,
+      expectedReaction: null,
+      serverReaction: ":wave:",
+    });
+    expect(addBreadcrumbMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "reaction.realtime_superseded",
+      })
+    );
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
   it("resets the per-drop sequence when the last tracked mutation ages out", () => {
     const firstMutation = beginReactionMutation({
       dropId: "drop-6",

--- a/utils/monitoring/dropReactionMonitoring.ts
+++ b/utils/monitoring/dropReactionMonitoring.ts
@@ -5,7 +5,8 @@ import { extractRetryAfterMs } from "@/helpers/reactions/reactionRateLimit";
 import { WebSocketStatus } from "@/services/websocket/WebSocketTypes";
 import * as Sentry from "@sentry/nextjs";
 
-const RECONCILIATION_WINDOW_MS = 15_000;
+const PENDING_RECONCILIATION_WINDOW_MS = 15_000;
+const SUCCESSFUL_RECONCILIATION_WINDOW_MS = 2 * 60_000;
 const DEDUPE_WINDOW_MS = 60_000;
 const MUTATION_RETENTION_MS = 5 * 60_000;
 const REACTION_FEATURE = "drop-reaction";
@@ -566,6 +567,52 @@ export function recordReactionRollbackApplied(
   addReactionBreadcrumb("reaction.rollback_applied", context);
 }
 
+function captureReactionOptimisticReverted(params: {
+  readonly context: ReactionMutationContext;
+  readonly serverReaction: string | null;
+  readonly websocketStatus: WebSocketStatus | undefined;
+  readonly timeSinceMutationMs: number;
+  readonly timeSinceApiSuccessMs: number | null;
+  readonly reconciliationWindowMs: number;
+}): void {
+  captureReactionEvent({
+    error: new Error(
+      "Reaction optimistic state disagreed with canonical state"
+    ),
+    level: "warning",
+    fingerprint: [REACTION_FEATURE, ANOMALY_OPTIMISTIC_REVERTED],
+    tags: {
+      feature: REACTION_FEATURE,
+      operation: REACTION_ANOMALY_OPERATION,
+      anomaly_kind: ANOMALY_OPTIMISTIC_REVERTED,
+      source: params.context.source,
+      action: params.context.action,
+    },
+    extra: {
+      mutation_id: params.context.mutationId,
+      drop_mutation_seq: params.context.dropMutationSeq,
+      drop_id: params.context.dropId,
+      wave_id: params.context.waveId,
+      previous_reaction: params.context.previousReaction,
+      intended_reaction: params.context.intendedReaction,
+      optimistic_reaction: params.context.optimisticReaction,
+      server_reaction: params.serverReaction ?? undefined,
+      profile_id: params.context.profileId ?? undefined,
+      pathname: params.context.pathname ?? undefined,
+      visibility_state: params.context.visibilityState ?? undefined,
+      online: params.context.online ?? undefined,
+      websocket_status: params.websocketStatus ?? undefined,
+      endpoint: params.context.endpoint ?? undefined,
+      method: params.context.method ?? undefined,
+      reconciled_from: "ws_refetch",
+      time_since_mutation_ms: params.timeSinceMutationMs,
+      time_since_api_success_ms: params.timeSinceApiSuccessMs ?? undefined,
+      reconciliation_window_ms: params.reconciliationWindowMs,
+      anomaly_kind: ANOMALY_OPTIMISTIC_REVERTED,
+    },
+  });
+}
+
 export function recordReactionRealtimeReconciliation(params: {
   drop: Pick<ApiDrop, "id"> & {
     readonly wave: Pick<ApiDrop["wave"], "id">;
@@ -599,6 +646,14 @@ export function recordReactionRealtimeReconciliation(params: {
 
   const expectedReaction = context.intendedReaction;
   const timeSinceMutationMs = now - context.startedAt;
+  const timeSinceApiSuccessMs =
+    context.apiSucceededAt === null ? null : now - context.apiSucceededAt;
+  const timeSinceReconciliationStartMs =
+    timeSinceApiSuccessMs ?? timeSinceMutationMs;
+  const reconciliationWindowMs =
+    context.apiSucceededAt === null
+      ? PENDING_RECONCILIATION_WINDOW_MS
+      : SUCCESSFUL_RECONCILIATION_WINDOW_MS;
   const websocketStatus =
     toWebsocketStatus(params.websocketStatus) ?? undefined;
   const resultBase = {
@@ -620,7 +675,7 @@ export function recordReactionRealtimeReconciliation(params: {
     };
   }
 
-  if (timeSinceMutationMs <= RECONCILIATION_WINDOW_MS) {
+  if (timeSinceReconciliationStartMs <= reconciliationWindowMs) {
     addReactionBreadcrumb(
       "reaction.realtime_superseded",
       context,
@@ -630,6 +685,8 @@ export function recordReactionRealtimeReconciliation(params: {
         server_reaction: serverReaction ?? undefined,
         superseded_by_mutation_id: context.mutationId,
         time_since_mutation_ms: timeSinceMutationMs,
+        time_since_api_success_ms: timeSinceApiSuccessMs ?? undefined,
+        reconciliation_window_ms: reconciliationWindowMs,
         websocket_status: websocketStatus,
       },
       "warning"
@@ -656,6 +713,8 @@ export function recordReactionRealtimeReconciliation(params: {
       reconciled_from: "ws_refetch",
       server_reaction: serverReaction ?? undefined,
       time_since_mutation_ms: timeSinceMutationMs,
+      time_since_api_success_ms: timeSinceApiSuccessMs ?? undefined,
+      reconciliation_window_ms: reconciliationWindowMs,
       websocket_status: websocketStatus,
     },
     "warning"
@@ -678,42 +737,13 @@ export function recordReactionRealtimeReconciliation(params: {
     };
   }
 
-  captureReactionEvent({
-    error: new Error(
-      "Reaction optimistic state disagreed with canonical state"
-    ),
-    level: "warning",
-    fingerprint: [REACTION_FEATURE, ANOMALY_OPTIMISTIC_REVERTED],
-    tags: {
-      feature: REACTION_FEATURE,
-      operation: REACTION_ANOMALY_OPERATION,
-      anomaly_kind: ANOMALY_OPTIMISTIC_REVERTED,
-      source: context.source,
-      action: context.action,
-    },
-    extra: {
-      mutation_id: context.mutationId,
-      drop_mutation_seq: context.dropMutationSeq,
-      drop_id: context.dropId,
-      wave_id: context.waveId,
-      previous_reaction: context.previousReaction,
-      intended_reaction: context.intendedReaction,
-      optimistic_reaction: context.optimisticReaction,
-      server_reaction: serverReaction ?? undefined,
-      profile_id: context.profileId ?? undefined,
-      pathname: context.pathname ?? undefined,
-      visibility_state: context.visibilityState ?? undefined,
-      online: context.online ?? undefined,
-      websocket_status:
-        toWebsocketStatus(params.websocketStatus) ??
-        context.websocketStatus ??
-        undefined,
-      endpoint: context.endpoint ?? undefined,
-      method: context.method ?? undefined,
-      reconciled_from: "ws_refetch",
-      time_since_mutation_ms: timeSinceMutationMs,
-      anomaly_kind: ANOMALY_OPTIMISTIC_REVERTED,
-    },
+  captureReactionOptimisticReverted({
+    context,
+    serverReaction,
+    websocketStatus: websocketStatus ?? context.websocketStatus ?? undefined,
+    timeSinceMutationMs,
+    timeSinceApiSuccessMs,
+    reconciliationWindowMs,
   });
 
   clearActiveIntentForContext(context);

--- a/utils/monitoring/dropReactionMonitoring.ts
+++ b/utils/monitoring/dropReactionMonitoring.ts
@@ -669,6 +669,7 @@ export function recordReactionRealtimeReconciliation(params: {
       time_since_mutation_ms: timeSinceMutationMs,
       websocket_status: websocketStatus,
     });
+    clearActiveIntentForContext(context);
     return {
       ...resultBase,
       shouldApplyCanonicalDrop: true,


### PR DESCRIPTION
## Issue
- Sentry issue `6529-FRONTEND-AG` reported `Reaction optimistic state disagreed with canonical state` for successful drop reaction mutations.
- The latest inspected event showed a successful quick reaction add where the canonical refetch still reported no user reaction about 56 seconds after the request.

## Fix
- Keep the short 15 second reconciliation window for pending or unsucceeded reaction mutations.
- Add a longer 2 minute reconciliation window after the reaction API request succeeds, so stale websocket/refetch data does not immediately overwrite the successful optimistic state.
- Clear the active optimistic guard once canonical realtime state matches the intended reaction, so later cross-tab/device canonical changes are not suppressed.

## Changes
- Split pending vs successful reaction reconciliation windows in `utils/monitoring/dropReactionMonitoring.ts`.
- Add `time_since_api_success_ms` and `reconciliation_window_ms` to reaction reconciliation breadcrumbs/Sentry extras.
- Extract the optimistic-reverted Sentry event construction to keep the reconciliation function within tight lint limits.
- Add targeted tests for the observed stale successful refetch case, the post-window warning case, and the post-reconciliation guard clear case.

## Validation
- `PATH=/opt/homebrew/bin:$PATH ./bin/6529 run test -- __tests__/utils/monitoring/dropReactionMonitoring.test.ts`
- `PATH=/opt/homebrew/bin:$PATH ./bin/6529 run lint:changed`
- `PATH=/opt/homebrew/bin:$PATH ./bin/6529 run typecheck:changed`
- Commit hooks ran `format:uncommitted` and `lint:uncommitted:tight` successfully.

## Risk
- Level: Low
- Why: scoped to reaction monitoring/reconciliation timing; no API shape, generated files, routes, or UI layout changes.
- Rollback: revert this PR to restore the previous 15 second reconciliation behavior.

## Review Notes
- Please focus on whether 2 minutes is the right post-success reconciliation window and whether the added Sentry metadata is enough to tune this further.
