### PR TITLE
Fix GitHub blob DM previews

### DIFF
--- a/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
+++ b/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
@@ -140,10 +140,26 @@ const mockTwitterPreviewCard = jest.fn(({ href, tweetId }: any) => (
   />
 ));
 
+const mockGithubLinkPreview = jest.fn(({ href }: any) => (
+  <div data-testid="github-link-preview" data-href={href} />
+));
+
 jest.mock("@/components/waves/LinkPreviewCard", () => ({
   __esModule: true,
   default: (props: any) => mockLinkPreviewCard(props),
 }));
+
+jest.mock("@/components/waves/github/GithubLinkPreview", () => {
+  const actual = jest.requireActual(
+    "@/components/waves/github/GithubLinkPreview"
+  );
+
+  return {
+    __esModule: true,
+    ...actual,
+    default: (props: any) => mockGithubLinkPreview(props),
+  };
+});
 
 jest.mock("@/components/waves/ArtBlocksTokenCard", () => ({
   __esModule: true,
@@ -182,6 +198,7 @@ beforeEach(() => {
   mockArtBlocksTokenCard.mockClear();
   mockFarcasterCard.mockClear();
   mockTwitterPreviewCard.mockClear();
+  mockGithubLinkPreview.mockClear();
 });
 
 describe("DropPartMarkdown", () => {
@@ -487,6 +504,30 @@ describe("DropPartMarkdown", () => {
     expect(group).not.toBeNull();
     expect(group?.querySelectorAll("img")).toHaveLength(2);
     expect(group?.querySelector(".tw-mt-2")).toBeNull();
+  });
+
+  it("routes GitHub blob image URLs through GitHub preview instead of direct image rendering", () => {
+    const href =
+      "https://github.com/david-6529/self-custody-education/blob/main/output/craig-self-custody-comic/pages/page-01.png";
+
+    render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        mentionedWaves={[]}
+        referencedNfts={[]}
+        partContent={href}
+        onQuoteClick={jest.fn()}
+      />
+    );
+
+    expect(mockGithubLinkPreview).toHaveBeenCalledWith(
+      expect.objectContaining({ href })
+    );
+    expect(screen.getByTestId("github-link-preview")).toHaveAttribute(
+      "data-href",
+      href
+    );
+    expect(screen.queryByRole("img", { name: "Drop media" })).toBeNull();
   });
 
   it("opens duplicate body markdown image URLs at the clicked item", () => {

--- a/__tests__/components/drops/view/part/dropPartMarkdown/linkUtils.test.ts
+++ b/__tests__/components/drops/view/part/dropPartMarkdown/linkUtils.test.ts
@@ -1,4 +1,7 @@
-import { shouldUseOpenGraphPreview } from "@/components/drops/view/part/dropPartMarkdown/linkUtils";
+import {
+  isDirectImageUrl,
+  shouldUseOpenGraphPreview,
+} from "@/components/drops/view/part/dropPartMarkdown/linkUtils";
 
 jest.mock("@/lib/ens/detect", () => ({
   isLikelyEnsTarget: jest.fn(() => false),
@@ -53,5 +56,23 @@ describe("shouldUseOpenGraphPreview", () => {
     expect(
       shouldUseOpenGraphPreview("https://www.youtube.com/channel/UC123456789")
     ).toBe(false);
+  });
+});
+
+describe("isDirectImageUrl", () => {
+  it("does not treat GitHub blob image pages as direct image files", () => {
+    expect(
+      isDirectImageUrl(
+        "https://github.com/david-6529/self-custody-education/blob/main/output/craig-self-custody-comic/pages/page-01.png"
+      )
+    ).toBe(false);
+  });
+
+  it("still treats raw GitHub image URLs as direct image files", () => {
+    expect(
+      isDirectImageUrl(
+        "https://raw.githubusercontent.com/david-6529/self-custody-education/main/output/craig-self-custody-comic/pages/page-01.png"
+      )
+    ).toBe(true);
   });
 });

--- a/components/drops/view/part/dropPartMarkdown/linkUtils.tsx
+++ b/components/drops/view/part/dropPartMarkdown/linkUtils.tsx
@@ -68,6 +68,16 @@ const isSafeMarkdownImageSrc = (href: string): boolean => {
   return protocol === "http:" || protocol === "https:";
 };
 
+const isGithubBlobUrl = (url: URL): boolean => {
+  const hostname = url.hostname.replace(/^www\./i, "").toLowerCase();
+  if (hostname !== "github.com") {
+    return false;
+  }
+
+  const [, , kindSegment] = url.pathname.split("/").filter(Boolean);
+  return kindSegment === "blob";
+};
+
 const isDirectImageUrl = (href: string, parsedUrl?: URL | null): boolean => {
   const url = parsedUrl ?? parseUrl(href);
   if (!url) {
@@ -76,6 +86,10 @@ const isDirectImageUrl = (href: string, parsedUrl?: URL | null): boolean => {
 
   const protocol = url.protocol.toLowerCase();
   if (protocol !== "http:" && protocol !== "https:") {
+    return false;
+  }
+
+  if (isGithubBlobUrl(url)) {
     return false;
   }
 
@@ -141,7 +155,8 @@ const renderExternalOrInternalLink = (
   props: AnchorHTMLAttributes<HTMLAnchorElement> & ExtraProps
 ) => {
   const baseEndpoint = publicEnv.BASE_ENDPOINT || "";
-  const isExternalLink = baseEndpoint && !href.startsWith(baseEndpoint);
+  const hasBaseEndpoint = baseEndpoint.length > 0;
+  const isExternalLink = hasBaseEndpoint && !href.startsWith(baseEndpoint);
   const { onClick, ...restProps } = props;
   const anchorProps: AnchorHTMLAttributes<HTMLAnchorElement> & ExtraProps = {
     ...restProps,
@@ -151,7 +166,7 @@ const renderExternalOrInternalLink = (
   if (isExternalLink) {
     anchorProps.rel = "noopener noreferrer nofollow";
     anchorProps.target = "_blank";
-  } else if (baseEndpoint) {
+  } else if (hasBaseEndpoint) {
     anchorProps.href = href.replace(baseEndpoint, "");
   }
 


### PR DESCRIPTION
## Issue
- GitHub blob URLs that point at image files were rendered in DMs as direct media because their path ended with an image extension.
- GitHub blob pages return HTML, not image bytes, so the message displayed poorly instead of using the richer GitHub preview path.

## Fix
- Treat `github.com/.../blob/...` URLs as non-direct image URLs so they fall through to the existing GitHub link preview handler.
- Keep raw GitHub image URLs, such as `raw.githubusercontent.com/...png`, eligible for direct image rendering.

## Changes
- Added GitHub blob detection in markdown link utilities.
- Added unit coverage for GitHub blob image URLs versus raw GitHub image URLs.
- Added a markdown rendering regression test for the reported DM URL to ensure it routes to `GithubLinkPreview` and not `Drop media`.

## Validation
- `./bin/6529 run test -- __tests__/components/drops/view/part/dropPartMarkdown/linkUtils.test.ts __tests__/components/drops/view/part/DropPartMarkdown.test.tsx`
- `./bin/6529 run lint:diff`
- `./bin/6529 run react-doctor:diff` passed with existing test-mock warnings only.
- `./bin/6529 run typecheck:ci`
- `./bin/6529 run build`
- Browser QA against a local staging-backed app: sent the reported URL in a DM between 6529 agent accounts, verified sender and recipient render the GitHub file preview with no `Drop media` image and no broken image text. The preview API returned `github.file` metadata with `mimeType: image/png`.

## Risk
- Level: Low
- Why: scoped to markdown direct-image detection for GitHub blob URLs; existing GitHub preview and raw image paths remain unchanged.
- Rollback: revert the helper/test commit to restore prior image-extension behavior.

## Review Notes
- Please focus on URL classification order in the markdown rendering path and whether any other GitHub URL shapes should bypass direct media detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub image links that point to a repository page now open in the GitHub preview experience instead of being treated as direct images.
  * Improved handling of image links so only true direct image URLs are displayed as images.
  * Internal and external link handling for markdown content was refined to make link behavior more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->