### PR TITLE
[codex] Sync agent glossary artifact

### DIFF
--- a/public/glossary.json
+++ b/public/glossary.json
@@ -661,7 +661,7 @@
         "The Memes subscriptions are an optional way to mint Meme Cards remotely, with potential gas savings or set-and-forget minting.",
         "Subscriptions are not a mintpass and do not create extra allowlist access.",
         "Users manage their subscription mode, balance, airdrop address, top-ups, upcoming drops, and history under their profile Subscriptions tab.",
-        "The About Subscriptions overview links to the Subscriptions Report for aggregate projected and redeemed subscription counts."
+        "The About Subscriptions overview links to the Subscriptions Report for aggregate subscribed and redeemed subscription counts."
       ],
       "canonical_path": "/about/subscriptions",
       "related_paths": [


### PR DESCRIPTION
## Summary
- Regenerate `public/glossary.json` so it matches the current help corpus wording for Subscriptions Report counts.
- Fix the stale committed artifact that caused `__tests__/scripts/sync-agent-files.test.ts` to fail in Coverage Floor.

## Root Cause
Commit `f01b9e3f6` updated `ops/help/help-index.json` and `public/help-index.json` from "projected" to "subscribed" wording, but `public/glossary.json` was not regenerated.

## Validation
- `./bin/6529 run agent-files:sync`
- Generated agent files to a temp directory and confirmed `public/glossary.json` and `public/llms.txt` match the generated output.
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated glossary content for subscription reporting to clarify that the “About Subscriptions” overview links to aggregate subscribed and redeemed subscription counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->