### PR TITLE
Tighten debt ratchet reporting

### DIFF
--- a/.github/workflows/debt-ratchet.yml
+++ b/.github/workflows/debt-ratchet.yml
@@ -52,6 +52,8 @@ jobs:
       - name: Assert npm lockfile is absent
         run: ./bin/6529 guard:no-package-lock
 
+      # The AST-based any_casts scanner uses the repo-pinned TypeScript parser,
+      # so this standalone required check installs dependencies before running.
       - name: Install dependencies
         env:
           SFW_BIN: ${{ steps.socket_firewall.outputs.firewall-path-binary }}

--- a/.github/workflows/debt-ratchet.yml
+++ b/.github/workflows/debt-ratchet.yml
@@ -2,9 +2,9 @@ name: Debt Ratchet
 
 # Structural-debt gate: fails any PR that raises a debt counter above the
 # checked-in baseline (scripts/debt-ratchet-baseline.json). Runs on every PR
-# so it can serve as a required status check; it is dependency-free and does
-# not install node_modules. See scripts/debt-ratchet.cjs for the metrics and
-# the one-command baseline update (`node scripts/debt-ratchet.cjs --update`).
+# so it can serve as a required status check. See scripts/debt-ratchet.cjs for
+# the metrics and the one-command baseline update
+# (`node scripts/debt-ratchet.cjs --update`).
 
 on:
   pull_request:
@@ -22,7 +22,7 @@ jobs:
   debt-ratchet:
     name: Debt ratchet
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       contents: read
 
@@ -32,13 +32,30 @@ jobs:
         with:
           persist-credentials: false
 
-      # No dependency install and no package-manager cache by design: the
-      # ratchet script is dependency-free Node, which keeps this required
-      # check fast (<1 min) on a bare checkout. Do not add `cache: pnpm`.
       - name: Install Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
+
+      - name: Activate pinned pnpm
+        run: |
+          corepack enable pnpm
+          corepack prepare "$(node -p 'require("./package.json").packageManager')" --activate
+          pnpm --version
+
+      - name: Install Socket Firewall
+        id: socket_firewall
+        uses: SocketDev/action@2d3f25590c6ed6ba11a9a14c064d962a3a04698f # v1.3.1
+        with:
+          mode: firewall
+
+      - name: Assert npm lockfile is absent
+        run: ./bin/6529 guard:no-package-lock
+
+      - name: Install dependencies
+        env:
+          SFW_BIN: ${{ steps.socket_firewall.outputs.firewall-path-binary }}
+        run: ./bin/6529 install:frozen
 
       - name: Check debt counters against baseline
         run: node scripts/debt-ratchet.cjs

--- a/.github/workflows/debt-ratchet.yml
+++ b/.github/workflows/debt-ratchet.yml
@@ -36,8 +36,6 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
-          cache: "pnpm"
-          cache-dependency-path: pnpm-lock.yaml
 
       - name: Activate pinned pnpm
         run: |

--- a/.github/workflows/debt-ratchet.yml
+++ b/.github/workflows/debt-ratchet.yml
@@ -36,6 +36,8 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Activate pinned pnpm
         run: |

--- a/__tests__/scripts/debt-ratchet.test.ts
+++ b/__tests__/scripts/debt-ratchet.test.ts
@@ -5,11 +5,13 @@ import path from "node:path";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const {
+  countAnyCasts,
   countImportStatements,
   countLines,
   countMatches,
   isWordPressMigratedSource,
 } = require(path.join(process.cwd(), "scripts", "debt-ratchet.cjs")) as {
+  countAnyCasts: (content: string, filePath?: string) => number;
   countImportStatements: (content: string, packages: string[]) => number;
   countLines: (content: string) => number;
   countMatches: (content: string, pattern: RegExp) => number;
@@ -30,14 +32,20 @@ describe("debt-ratchet counting helpers", () => {
       "const a: any = 1;",
       "const b = value as any;",
       "const c: any[] = [];",
+      "function f(input: any): any { return input; }",
+      "type Shape = { field: any; generic: Record<string, any> };",
       "const inner: Record<string, any> = {}; // generic arg is not counted",
+      "type Alias = any; // type aliases are outside this metric",
+      'const text = "value as any";',
+      "// value as any",
+      "<span>connect deeply to an audience as powerfully as",
+      "any great art can.</span>",
       "const many = anything; // not a match",
       "function f(x: number): number { return x; }",
     ].join("\n");
-    // ": any" direct annotations and "as any" casts count; an "any" buried in
-    // a generic argument list (Record<string, any>) does not carry a ": any"
-    // or "as any" token, so it is intentionally outside this metric.
-    expect(countMatches(content, /:\s*any\b|\bas\s+any\b/g)).toBe(3);
+    // Direct annotations and casts count. Strings, comments, JSX prose, type
+    // aliases, and generic arguments stay outside this metric.
+    expect(countAnyCasts(content, "Sample.tsx")).toBe(6);
   });
 
   it("counts TODO markers without matching longer words", () => {
@@ -102,6 +110,10 @@ describe("debt-ratchet check mode", () => {
     writeFixture(
       "components/Sample.tsx",
       'const a: any = 1;\n// TODO tidy\nimport { useSelector } from "react-redux";\n'
+    );
+    writeFixture(
+      "components/Article.tsx",
+      "<span>connect deeply to an audience as powerfully as\nany great art can.</span>\n"
     );
     writeFixture(
       "components/__tests__/Ignored.test.tsx",
@@ -224,6 +236,19 @@ describe("debt-ratchet check mode", () => {
     writeFixture(
       "components/Large.tsx",
       "export const line = 1;\n".repeat(810)
+    );
+
+    expect(runRatchet(root, ["--update"]).status).toBe(0);
+    const check = runRatchet(root);
+    expect(check.status).toBe(0);
+    expect(check.stdout).toMatch(
+      /^oversized_files\s+baseline\s+2 actual\s+2\s+ok$/m
+    );
+    expect(check.stdout).toMatch(
+      /^\s+app_source\s+baseline\s+1 actual\s+1\s+ok$/m
+    );
+    expect(check.stdout).toMatch(
+      /^\s+wp_migrated\s+baseline\s+1 actual\s+1\s+ok$/m
     );
 
     const unfiltered = runRatchet(root, ["--details", "oversized_files"]);

--- a/__tests__/scripts/debt-ratchet.test.ts
+++ b/__tests__/scripts/debt-ratchet.test.ts
@@ -32,6 +32,9 @@ describe("debt-ratchet counting helpers", () => {
       "const a: any = 1;",
       "const b = value as any;",
       "const c: any[] = [];",
+      "const d: readonly any[] = [];",
+      "let parenthesized: (any);",
+      "let union: string | any;",
       "function f(input: any): any { return input; }",
       "type Shape = { field: any; generic: Record<string, any> };",
       "const inner: Record<string, any> = {}; // generic arg is not counted",
@@ -45,7 +48,17 @@ describe("debt-ratchet counting helpers", () => {
     ].join("\n");
     // Direct annotations and casts count. Strings, comments, JSX prose, type
     // aliases, and generic arguments stay outside this metric.
-    expect(countAnyCasts(content, "Sample.tsx")).toBe(6);
+    expect(countAnyCasts(content, "Sample.tsx")).toBe(9);
+  });
+
+  it("counts TypeScript angle-bracket any assertions", () => {
+    expect(countAnyCasts("const value = <any>input;\n", "Sample.ts")).toBe(1);
+  });
+
+  it("throws on invalid TSX syntax instead of undercounting", () => {
+    expect(() =>
+      countAnyCasts("const value = <any>input;\n", "Sample.tsx")
+    ).toThrow(/Unable to parse Sample\.tsx while counting any_casts/);
   });
 
   it("counts TODO markers without matching longer words", () => {

--- a/__tests__/scripts/debt-ratchet.test.ts
+++ b/__tests__/scripts/debt-ratchet.test.ts
@@ -257,12 +257,9 @@ describe("debt-ratchet check mode", () => {
     expect(check.stdout).toMatch(
       /^oversized_files\s+baseline\s+2 actual\s+2\s+ok$/m
     );
-    expect(check.stdout).toMatch(
-      /^\s+app_source\s+baseline\s+1 actual\s+1\s+ok$/m
-    );
-    expect(check.stdout).toMatch(
-      /^\s+wp_migrated\s+baseline\s+1 actual\s+1\s+ok$/m
-    );
+    expect(check.stdout).toMatch(/^\s+breakdown:$/m);
+    expect(check.stdout).toMatch(/^\s+app_source\s+baseline\s+1 actual\s+1$/m);
+    expect(check.stdout).toMatch(/^\s+wp_migrated\s+baseline\s+1 actual\s+1$/m);
 
     const unfiltered = runRatchet(root, ["--details", "oversized_files"]);
     expect(unfiltered.status).toBe(0);

--- a/__tests__/wagmiConfig/wagmiAppWalletConnector.test.ts
+++ b/__tests__/wagmiConfig/wagmiAppWalletConnector.test.ts
@@ -263,6 +263,39 @@ describe("wagmiAppWalletConnector", () => {
   });
 
   describe("connect", () => {
+    it("returns address accounts by default", async () => {
+      mockRequestPasswordModal.mockResolvedValue("validpass123");
+      mockDecryptData
+        .mockResolvedValueOnce(mockAppWallet.address)
+        .mockResolvedValueOnce("valid_private_key");
+      mockAreEqualAddresses.mockReturnValue(true);
+
+      await expect(connectorInstance.connect({ chainId: 1 })).resolves.toEqual({
+        accounts: [mockAppWallet.address],
+        chainId: 1,
+      });
+    });
+
+    it("returns capability account objects when requested", async () => {
+      mockRequestPasswordModal.mockResolvedValue("validpass123");
+      mockDecryptData
+        .mockResolvedValueOnce(mockAppWallet.address)
+        .mockResolvedValueOnce("valid_private_key");
+      mockAreEqualAddresses.mockReturnValue(true);
+
+      await expect(
+        connectorInstance.connect({ chainId: 1, withCapabilities: true })
+      ).resolves.toEqual({
+        accounts: [
+          {
+            address: mockAppWallet.address,
+            capabilities: {},
+          },
+        ],
+        chainId: 1,
+      });
+    });
+
     it("throws error for unsupported chainId", async () => {
       const unsupportedChainId = 999;
 

--- a/ops/workstreams/repo-health-2026-07/any-exceptions.md
+++ b/ops/workstreams/repo-health-2026-07/any-exceptions.md
@@ -1,23 +1,17 @@
 # `any` exceptions ledger
 
-Sites that keep `: any` / `as any` deliberately, with one-line justifications.
-Everything not listed here is expected to stay at zero; the debt-ratchet
-baseline (`scripts/debt-ratchet-baseline.json`, metric `any_casts`) is the
-enforcement backstop.
+Sites that keep direct `: any` / `as any` deliberately, with one-line
+justifications. Everything not listed here is expected to stay at zero; the
+debt-ratchet baseline (`scripts/debt-ratchet-baseline.json`, metric
+`any_casts`) is the enforcement backstop.
 
-Current floor: `any_casts` = 4 (3 permanent + 1 scan false positive).
+Current floor: `any_casts` = 0.
 
-## Permanent exceptions
+## Current exceptions
 
-| Site | Count | Justification |
-| --- | --- | --- |
-| `wagmiConfig/wagmiAppWalletConnector.ts` | 3 | wagmi `createConnector`'s `connect()` return type is conditional on the `withCapabilities` parameter; expressing it without `any` requires `as unknown as` double-casts that add no safety. Runtime shape matches the wagmi v2 connector contract. |
-
-## Scan false positives (not `any` usages)
-
-| Site | Count | Explanation |
-| --- | --- | --- |
-| `app/blog/disney-deekay-their-secret-to-animation/page.tsx` | 1 | The ratchet's textual `\bas\s+any\b` matches the prose "…as powerfully as any great art can" inside JSX copy. No TypeScript cast exists in the file; editorial copy is not changed to satisfy a counter. |
+| Site | Count | Justification           |
+| ---- | ----- | ----------------------- |
+| None | 0     | Keep the floor at zero. |
 
 ## Resolved deferrals (history)
 
@@ -30,12 +24,19 @@ Current floor: `any_casts` = 4 (3 permanent + 1 scan false positive).
   underlying `.result` misread is tracked in issue #3078.
 - `src/types/window.d.ts`: removed with the layout workstream's `src/`
   fold (resolved 2026-07-05).
+- `wagmiConfig/wagmiAppWalletConnector.ts` (3 sites): replaced with a named
+  wagmi connector return type and one targeted assertion at the
+  `withCapabilities` conditional-generic boundary.
+- `app/blog/disney-deekay-their-secret-to-animation/page.tsx` (1 site): removed
+  as a scanner false positive by switching `any_casts` from textual matching to
+  TypeScript AST matching.
 
 ## Known scanner blind spot (for future calibration)
 
-The ratchet regex counts `: any` and `as any` only; generic type arguments
-like `useState<any>()` are invisible to it. A handful of such generics
-remain in `components/delegation/CollectionDelegation.tsx`
+The ratchet counts direct `: any`-style annotations and `as any`/`<any>`
+assertions only; generic type arguments like `useState<any>()` are invisible to
+it. A handful of such generics remain in
+`components/delegation/CollectionDelegation.tsx`
 (`revokeDelegationParams`, `batchRevokeDelegationParams`, three
 `useState<any[]>` key arrays). They are outside the metric and were left
 untouched by the typing wave; tighten them opportunistically when that

--- a/ops/workstreams/repo-health-2026-07/any-exceptions.md
+++ b/ops/workstreams/repo-health-2026-07/any-exceptions.md
@@ -33,9 +33,11 @@ Current floor: `any_casts` = 0.
 
 ## Known scanner blind spot (for future calibration)
 
-The ratchet counts direct `: any`-style annotations and `as any`/`<any>`
-assertions only; generic type arguments like `useState<any>()` are invisible to
-it. A handful of such generics remain in
+The ratchet counts direct `: any`-style annotations, `as any` assertions, and
+valid TypeScript `<any>` assertions only; generic type arguments like
+`useState<any>()` are invisible to it. Invalid TSX angle-bracket assertion
+syntax fails parsing instead of silently undercounting. A handful of such
+generics remain in
 `components/delegation/CollectionDelegation.tsx`
 (`revokeDelegationParams`, `batchRevokeDelegationParams`, three
 `useState<any[]>` key arrays). They are outside the metric and were left

--- a/scripts/debt-ratchet-baseline.json
+++ b/scripts/debt-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "max_source_file_lines": 800,
   "counts": {
-    "any_casts": 4,
+    "any_casts": 0,
     "todo_comments": 0,
     "oversized_files": 76,
     "bootstrap_imports": 0,

--- a/scripts/debt-ratchet.cjs
+++ b/scripts/debt-ratchet.cjs
@@ -458,7 +458,7 @@ function countOversizedGroups(files, wordpressMigratedFiles) {
   };
 }
 
-function buildOversizedGroupRows(baseline, actuals) {
+function buildOversizedBreakdownRows(baseline, actuals) {
   const baselineGroups = countOversizedGroups(
     baseline.oversized_file_allowlist ?? [],
     actuals.wordpressMigratedFiles
@@ -470,19 +470,34 @@ function buildOversizedGroupRows(baseline, actuals) {
 
   return [
     {
-      metric: "  app_source",
-      baseline: baselineGroups.app,
-      actual: actualGroups.app,
-      status: baselineGroups.app === actualGroups.app ? "ok" : "info",
+      metric: "  breakdown:",
+      kind: "label",
     },
     {
-      metric: "  wp_migrated",
+      metric: "    app_source",
+      baseline: baselineGroups.app,
+      actual: actualGroups.app,
+    },
+    {
+      metric: "    wp_migrated",
       baseline: baselineGroups.wordpress,
       actual: actualGroups.wordpress,
-      status:
-        baselineGroups.wordpress === actualGroups.wordpress ? "ok" : "info",
     },
   ];
+}
+
+function formatReportRow(row) {
+  if (row.kind === "label") return row.metric;
+
+  const countColumns =
+    `${row.metric.padEnd(20)} baseline ${String(row.baseline).padStart(5)} ` +
+    `actual ${String(row.actual).padStart(5)}`;
+  return row.status ? `${countColumns}  ${row.status}` : countColumns;
+}
+
+function formatSummaryRow(row) {
+  if (row.kind === "label") return `| ${row.metric.trim()} | | | |`;
+  return `| ${row.metric} | ${row.baseline} | ${row.actual} | ${row.status ?? ""} |`;
 }
 
 function runCheck() {
@@ -543,15 +558,12 @@ function runCheck() {
 
   console.log("Debt ratchet report");
   console.log("===================");
-  const oversizedGroupRows = buildOversizedGroupRows(baseline, actuals);
+  const oversizedBreakdownRows = buildOversizedBreakdownRows(baseline, actuals);
   const reportRows = rows.flatMap((row) =>
-    row.metric === "oversized_files" ? [row, ...oversizedGroupRows] : [row]
+    row.metric === "oversized_files" ? [row, ...oversizedBreakdownRows] : [row]
   );
   for (const row of reportRows) {
-    console.log(
-      `${row.metric.padEnd(20)} baseline ${String(row.baseline).padStart(5)} ` +
-        `actual ${String(row.actual).padStart(5)}  ${row.status}`
-    );
+    console.log(formatReportRow(row));
   }
 
   for (const warning of warnings) {
@@ -568,10 +580,7 @@ function runCheck() {
     "",
     "| Metric | Baseline | Actual | Status |",
     "| --- | ---: | ---: | --- |",
-    ...reportRows.map(
-      (row) =>
-        `| ${row.metric} | ${row.baseline} | ${row.actual} | ${row.status} |`
-    ),
+    ...reportRows.map(formatSummaryRow),
     ...(failures.length > 0
       ? ["", "**Failures**", ...failures.map((failure) => `- ${failure}`)]
       : []),

--- a/scripts/debt-ratchet.cjs
+++ b/scripts/debt-ratchet.cjs
@@ -22,12 +22,13 @@
 //
 // Counting semantics (deliberate trade-offs):
 //   - The `any_casts` metric is syntax-aware and counts direct `: any`-style
-//     annotations plus `as any`/`<any>` assertions. Generic type arguments such
-//     as `Record<string, any>` remain outside this metric for continuity with
-//     the original ratchet scope.
-//   - TODO/FIXME/HACK regexes match inside strings, comments, and JSDoc. Counts
-//     are symmetric between baseline and actuals, so the ratchet still moves in
-//     the right direction; do not read them as exact.
+//     annotations plus `as any` and valid TypeScript `<any>` assertions. Invalid
+//     TSX angle-bracket syntax fails parsing instead of silently undercounting.
+//     Generic type arguments such as `Record<string, any>` remain outside this
+//     metric for continuity with the original ratchet scope.
+//   - Task-marker regexes match inside strings, comments, and JSDoc. Counts are
+//     symmetric between baseline and actuals, so the ratchet still moves in the
+//     right direction; do not read them as exact.
 //   - The oversized grandfather list keys on exact relative paths. Renaming
 //     or moving a grandfathered file makes it count as a NEW oversized file
 //     (fail-closed); run `--update` in the same PR to re-grandfather the new
@@ -199,8 +200,77 @@ function scriptKindForPath(filePath) {
   return ts.ScriptKind.TS;
 }
 
-function typeTextStartsWithAny(typeNode, sourceFile) {
-  return /^any\b/.test(typeNode.getText(sourceFile).trim());
+function formatParseDiagnostic(diagnostic, sourceFile, filePath) {
+  const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, " ");
+  const position = diagnostic.start ?? 0;
+  const { line, character } =
+    sourceFile.getLineAndCharacterOfPosition(position);
+  return `${filePath}:${line + 1}:${character + 1}: ${message}`;
+}
+
+function hasDirectAnyType(typeNode) {
+  if (typeNode.kind === ts.SyntaxKind.AnyKeyword) return true;
+
+  if (ts.isParenthesizedTypeNode(typeNode)) {
+    return hasDirectAnyType(typeNode.type);
+  }
+
+  if (ts.isArrayTypeNode(typeNode)) {
+    return hasDirectAnyType(typeNode.elementType);
+  }
+
+  if (ts.isTypeOperatorNode(typeNode)) {
+    return (
+      typeNode.operator === ts.SyntaxKind.ReadonlyKeyword &&
+      hasDirectAnyType(typeNode.type)
+    );
+  }
+
+  if (ts.isUnionTypeNode(typeNode) || ts.isIntersectionTypeNode(typeNode)) {
+    return typeNode.types.some(hasDirectAnyType);
+  }
+
+  if (ts.isTupleTypeNode(typeNode)) {
+    return typeNode.elements.some(hasDirectAnyType);
+  }
+
+  if (ts.isRestTypeNode(typeNode)) {
+    return hasDirectAnyType(typeNode.type);
+  }
+
+  if (ts.isNamedTupleMember(typeNode)) {
+    return hasDirectAnyType(typeNode.type);
+  }
+
+  return false;
+}
+
+function getCountedTypeNode(node) {
+  if (ts.isAsExpression(node) || ts.isTypeAssertionExpression(node)) {
+    return node.type;
+  }
+
+  if (
+    ts.isVariableDeclaration(node) ||
+    ts.isParameter(node) ||
+    ts.isPropertyDeclaration(node) ||
+    ts.isPropertySignature(node) ||
+    ts.isMethodDeclaration(node) ||
+    ts.isMethodSignature(node) ||
+    ts.isFunctionDeclaration(node) ||
+    ts.isFunctionExpression(node) ||
+    ts.isArrowFunction(node) ||
+    ts.isGetAccessorDeclaration(node) ||
+    ts.isSetAccessorDeclaration(node) ||
+    ts.isCallSignatureDeclaration(node) ||
+    ts.isConstructSignatureDeclaration(node) ||
+    ts.isIndexSignatureDeclaration(node) ||
+    ts.isMappedTypeNode(node)
+  ) {
+    return node.type;
+  }
+
+  return undefined;
 }
 
 function countAnyCasts(content, filePath = "source.ts") {
@@ -212,36 +282,23 @@ function countAnyCasts(content, filePath = "source.ts") {
     scriptKindForPath(filePath)
   );
 
+  if (sourceFile.parseDiagnostics.length > 0) {
+    throw new Error(
+      `Unable to parse ${filePath} while counting any_casts: ` +
+        formatParseDiagnostic(
+          sourceFile.parseDiagnostics[0],
+          sourceFile,
+          filePath
+        )
+    );
+  }
+
   let count = 0;
 
-  const countDirectAnyType = (typeNode) => {
-    if (typeTextStartsWithAny(typeNode, sourceFile)) {
-      count += 1;
-    }
-  };
-
   const visit = (node) => {
-    if (ts.isAsExpression(node) || ts.isTypeAssertionExpression(node)) {
-      countDirectAnyType(node.type);
-    } else if (
-      (ts.isVariableDeclaration(node) ||
-        ts.isParameter(node) ||
-        ts.isPropertyDeclaration(node) ||
-        ts.isPropertySignature(node) ||
-        ts.isMethodDeclaration(node) ||
-        ts.isMethodSignature(node) ||
-        ts.isFunctionDeclaration(node) ||
-        ts.isFunctionExpression(node) ||
-        ts.isArrowFunction(node) ||
-        ts.isGetAccessorDeclaration(node) ||
-        ts.isSetAccessorDeclaration(node) ||
-        ts.isCallSignatureDeclaration(node) ||
-        ts.isConstructSignatureDeclaration(node) ||
-        ts.isIndexSignatureDeclaration(node) ||
-        ts.isMappedTypeNode(node)) &&
-      node.type
-    ) {
-      countDirectAnyType(node.type);
+    const typeNode = getCountedTypeNode(node);
+    if (typeNode && hasDirectAnyType(typeNode)) {
+      count += 1;
     }
 
     ts.forEachChild(node, visit);
@@ -416,13 +473,14 @@ function buildOversizedGroupRows(baseline, actuals) {
       metric: "  app_source",
       baseline: baselineGroups.app,
       actual: actualGroups.app,
-      status: getCountStatus(baselineGroups.app, actualGroups.app),
+      status: baselineGroups.app === actualGroups.app ? "ok" : "info",
     },
     {
       metric: "  wp_migrated",
       baseline: baselineGroups.wordpress,
       actual: actualGroups.wordpress,
-      status: getCountStatus(baselineGroups.wordpress, actualGroups.wordpress),
+      status:
+        baselineGroups.wordpress === actualGroups.wordpress ? "ok" : "info",
     },
   ];
 }

--- a/scripts/debt-ratchet.cjs
+++ b/scripts/debt-ratchet.cjs
@@ -21,20 +21,21 @@
 //     the baseline in the same PR with `--update` so the improvement sticks.
 //
 // Counting semantics (deliberate trade-offs):
-//   - Metrics are textual heuristics, not AST analysis: the `any` and
-//     TODO/FIXME/HACK regexes also match inside strings, comments, and JSDoc.
-//     Counts are symmetric between baseline and actuals, so the ratchet
-//     still moves in the right direction; do not read them as exact.
+//   - The `any_casts` metric is syntax-aware and counts direct `: any`-style
+//     annotations plus `as any`/`<any>` assertions. Generic type arguments such
+//     as `Record<string, any>` remain outside this metric for continuity with
+//     the original ratchet scope.
+//   - TODO/FIXME/HACK regexes match inside strings, comments, and JSDoc. Counts
+//     are symmetric between baseline and actuals, so the ratchet still moves in
+//     the right direction; do not read them as exact.
 //   - The oversized grandfather list keys on exact relative paths. Renaming
 //     or moving a grandfathered file makes it count as a NEW oversized file
 //     (fail-closed); run `--update` in the same PR to re-grandfather the new
 //     path, or use the move as the moment to split the file.
 //
-// The script is dependency-free on purpose so CI can run it on a bare
-// checkout without installing node_modules.
-
 const fs = require("node:fs");
 const path = require("node:path");
+const ts = require("typescript");
 
 // DEBT_RATCHET_ROOT is a test seam; production runs use the repo root.
 const REPO_ROOT = process.env["DEBT_RATCHET_ROOT"]
@@ -188,6 +189,68 @@ function countImportStatements(content, packageNames) {
   return count;
 }
 
+function scriptKindForPath(filePath) {
+  const extension = path.extname(filePath);
+  if (extension === ".tsx") return ts.ScriptKind.TSX;
+  if (extension === ".jsx") return ts.ScriptKind.JSX;
+  if (extension === ".js" || extension === ".cjs" || extension === ".mjs") {
+    return ts.ScriptKind.JS;
+  }
+  return ts.ScriptKind.TS;
+}
+
+function typeTextStartsWithAny(typeNode, sourceFile) {
+  return /^any\b/.test(typeNode.getText(sourceFile).trim());
+}
+
+function countAnyCasts(content, filePath = "source.ts") {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKindForPath(filePath)
+  );
+
+  let count = 0;
+
+  const countDirectAnyType = (typeNode) => {
+    if (typeTextStartsWithAny(typeNode, sourceFile)) {
+      count += 1;
+    }
+  };
+
+  const visit = (node) => {
+    if (ts.isAsExpression(node) || ts.isTypeAssertionExpression(node)) {
+      countDirectAnyType(node.type);
+    } else if (
+      (ts.isVariableDeclaration(node) ||
+        ts.isParameter(node) ||
+        ts.isPropertyDeclaration(node) ||
+        ts.isPropertySignature(node) ||
+        ts.isMethodDeclaration(node) ||
+        ts.isMethodSignature(node) ||
+        ts.isFunctionDeclaration(node) ||
+        ts.isFunctionExpression(node) ||
+        ts.isArrowFunction(node) ||
+        ts.isGetAccessorDeclaration(node) ||
+        ts.isSetAccessorDeclaration(node) ||
+        ts.isCallSignatureDeclaration(node) ||
+        ts.isConstructSignatureDeclaration(node) ||
+        ts.isIndexSignatureDeclaration(node) ||
+        ts.isMappedTypeNode(node)) &&
+      node.type
+    ) {
+      countDirectAnyType(node.type);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return count;
+}
+
 function countLines(content) {
   if (content.length === 0) return 0;
   let newlines = 0;
@@ -248,7 +311,7 @@ function computeActuals() {
     if (!isCode) continue;
 
     if (TYPESCRIPT_EXTENSIONS.has(extension)) {
-      const anyCount = countMatches(content, /:\s*any\b|\bas\s+any\b/g);
+      const anyCount = countAnyCasts(content, relativePath);
       if (anyCount > 0) perFile.any_casts.set(relativePath, anyCount);
     }
 
@@ -321,6 +384,49 @@ function appendStepSummary(lines) {
   fs.appendFileSync(summaryPath, `${lines.join("\n")}\n`);
 }
 
+function getCountStatus(baselineCount, actualCount) {
+  if (actualCount > baselineCount) return "RISE";
+  if (actualCount < baselineCount) return "stale baseline";
+  return "ok";
+}
+
+function countOversizedGroups(files, wordpressMigratedFiles) {
+  let wordpress = 0;
+  for (const file of files) {
+    if (wordpressMigratedFiles.has(file)) wordpress += 1;
+  }
+  return {
+    app: files.length - wordpress,
+    wordpress,
+  };
+}
+
+function buildOversizedGroupRows(baseline, actuals) {
+  const baselineGroups = countOversizedGroups(
+    baseline.oversized_file_allowlist ?? [],
+    actuals.wordpressMigratedFiles
+  );
+  const actualGroups = countOversizedGroups(
+    actuals.oversizedFiles,
+    actuals.wordpressMigratedFiles
+  );
+
+  return [
+    {
+      metric: "  app_source",
+      baseline: baselineGroups.app,
+      actual: actualGroups.app,
+      status: getCountStatus(baselineGroups.app, actualGroups.app),
+    },
+    {
+      metric: "  wp_migrated",
+      baseline: baselineGroups.wordpress,
+      actual: actualGroups.wordpress,
+      status: getCountStatus(baselineGroups.wordpress, actualGroups.wordpress),
+    },
+  ];
+}
+
 function runCheck() {
   const baseline = readBaseline();
   const actuals = computeActuals();
@@ -338,15 +444,13 @@ function runCheck() {
       continue;
     }
 
-    let status = "ok";
-    if (actualCount > baselineCount) {
-      status = "RISE";
+    const status = getCountStatus(baselineCount, actualCount);
+    if (status === "RISE") {
       failures.push(
         `${metric} rose from ${baselineCount} to ${actualCount} ` +
           `(${definition.description}). ${definition.hint}`
       );
-    } else if (actualCount < baselineCount) {
-      status = "stale baseline";
+    } else if (status === "stale baseline") {
       warnings.push(
         `${metric} dropped from ${baselineCount} to ${actualCount}. ` +
           "Lock in the improvement: run `node scripts/debt-ratchet.cjs --update` " +
@@ -381,7 +485,11 @@ function runCheck() {
 
   console.log("Debt ratchet report");
   console.log("===================");
-  for (const row of rows) {
+  const oversizedGroupRows = buildOversizedGroupRows(baseline, actuals);
+  const reportRows = rows.flatMap((row) =>
+    row.metric === "oversized_files" ? [row, ...oversizedGroupRows] : [row]
+  );
+  for (const row of reportRows) {
     console.log(
       `${row.metric.padEnd(20)} baseline ${String(row.baseline).padStart(5)} ` +
         `actual ${String(row.actual).padStart(5)}  ${row.status}`
@@ -402,7 +510,7 @@ function runCheck() {
     "",
     "| Metric | Baseline | Actual | Status |",
     "| --- | ---: | ---: | --- |",
-    ...rows.map(
+    ...reportRows.map(
       (row) =>
         `| ${row.metric} | ${row.baseline} | ${row.actual} | ${row.status} |`
     ),
@@ -510,6 +618,7 @@ module.exports = {
   MAX_SOURCE_FILE_LINES,
   SCAN_DIRS,
   countImportStatements,
+  countAnyCasts,
   countLines,
   countMatches,
   isWordPressMigratedSource,

--- a/scripts/debt-ratchet.cjs
+++ b/scripts/debt-ratchet.cjs
@@ -190,22 +190,88 @@ function countImportStatements(content, packageNames) {
   return count;
 }
 
-function scriptKindForPath(filePath) {
-  const extension = path.extname(filePath);
-  if (extension === ".tsx") return ts.ScriptKind.TSX;
-  if (extension === ".jsx") return ts.ScriptKind.JSX;
-  if (extension === ".js" || extension === ".cjs" || extension === ".mjs") {
-    return ts.ScriptKind.JS;
-  }
-  return ts.ScriptKind.TS;
-}
-
 function formatParseDiagnostic(diagnostic, sourceFile, filePath) {
   const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, " ");
   const position = diagnostic.start ?? 0;
   const { line, character } =
     sourceFile.getLineAndCharacterOfPosition(position);
   return `${filePath}:${line + 1}:${character + 1}: ${message}`;
+}
+
+function normalizeProgramFilePath(filePath) {
+  return path.normalize(filePath);
+}
+
+function createAnyCastProgram(files) {
+  const compilerOptions = {
+    allowJs: true,
+    checkJs: false,
+    jsx: ts.JsxEmit.Preserve,
+    noLib: true,
+    noResolve: true,
+    target: ts.ScriptTarget.Latest,
+  };
+  const fileContents = new Map(
+    files.map(({ filePath, content }) => [
+      normalizeProgramFilePath(filePath),
+      content,
+    ])
+  );
+  const compilerHost = ts.createCompilerHost(compilerOptions, true);
+  const sourceFiles = new Map();
+  const isTargetFile = (requestedFilePath) =>
+    fileContents.has(normalizeProgramFilePath(requestedFilePath));
+  const defaultFileExists = compilerHost.fileExists.bind(compilerHost);
+  const defaultReadFile = compilerHost.readFile.bind(compilerHost);
+
+  compilerHost.fileExists = (requestedFilePath) =>
+    isTargetFile(requestedFilePath) || defaultFileExists(requestedFilePath);
+  compilerHost.readFile = (requestedFilePath) =>
+    isTargetFile(requestedFilePath)
+      ? fileContents.get(normalizeProgramFilePath(requestedFilePath))
+      : defaultReadFile(requestedFilePath);
+
+  const program = ts.createProgram(
+    files.map(({ filePath }) => filePath),
+    compilerOptions,
+    compilerHost
+  );
+  const programSourceFiles = program.getSourceFiles();
+
+  for (const { filePath } of files) {
+    const normalizedFilePath = normalizeProgramFilePath(filePath);
+    const sourceFile =
+      program.getSourceFile(filePath) ??
+      programSourceFiles.find(
+        (candidate) =>
+          normalizeProgramFilePath(candidate.fileName) === normalizedFilePath
+      );
+
+    if (!sourceFile) {
+      throw new Error(
+        `Unable to parse ${filePath} while counting any_casts: source file was not created`
+      );
+    }
+
+    sourceFiles.set(normalizedFilePath, sourceFile);
+  }
+
+  return { program, sourceFiles };
+}
+
+function getAnyCastSourceFile(sourceFiles, filePath) {
+  return sourceFiles.get(normalizeProgramFilePath(filePath));
+}
+
+function throwOnSyntacticDiagnostics(program, sourceFile, filePath) {
+  const syntacticDiagnostics = program.getSyntacticDiagnostics(sourceFile);
+
+  if (syntacticDiagnostics.length > 0) {
+    throw new Error(
+      `Unable to parse ${filePath} while counting any_casts: ` +
+        formatParseDiagnostic(syntacticDiagnostics[0], sourceFile, filePath)
+    );
+  }
 }
 
 function hasDirectAnyType(typeNode) {
@@ -273,26 +339,7 @@ function getCountedTypeNode(node) {
   return undefined;
 }
 
-function countAnyCasts(content, filePath = "source.ts") {
-  const sourceFile = ts.createSourceFile(
-    filePath,
-    content,
-    ts.ScriptTarget.Latest,
-    true,
-    scriptKindForPath(filePath)
-  );
-
-  if (sourceFile.parseDiagnostics.length > 0) {
-    throw new Error(
-      `Unable to parse ${filePath} while counting any_casts: ` +
-        formatParseDiagnostic(
-          sourceFile.parseDiagnostics[0],
-          sourceFile,
-          filePath
-        )
-    );
-  }
-
+function countAnyCastsInSourceFile(sourceFile) {
   let count = 0;
 
   const visit = (node) => {
@@ -306,6 +353,15 @@ function countAnyCasts(content, filePath = "source.ts") {
 
   visit(sourceFile);
   return count;
+}
+
+function countAnyCasts(content, filePath = "source.ts") {
+  const { program, sourceFiles } = createAnyCastProgram([
+    { filePath, content },
+  ]);
+  const sourceFile = getAnyCastSourceFile(sourceFiles, filePath);
+  throwOnSyntacticDiagnostics(program, sourceFile, filePath);
+  return countAnyCastsInSourceFile(sourceFile);
 }
 
 function countLines(content) {
@@ -340,6 +396,7 @@ function computeActuals() {
   };
   const oversizedFiles = [];
   const wordpressMigratedFiles = new Set();
+  const anyCastInputs = [];
 
   for (const relativePath of listSourceFiles()) {
     const extension = path.extname(relativePath);
@@ -368,8 +425,7 @@ function computeActuals() {
     if (!isCode) continue;
 
     if (TYPESCRIPT_EXTENSIONS.has(extension)) {
-      const anyCount = countAnyCasts(content, relativePath);
-      if (anyCount > 0) perFile.any_casts.set(relativePath, anyCount);
+      anyCastInputs.push({ filePath: relativePath, content });
     }
 
     const reduxCount = countImportStatements(content, [
@@ -382,6 +438,21 @@ function computeActuals() {
     if (countLines(content) > MAX_SOURCE_FILE_LINES) {
       oversizedFiles.push(relativePath);
     }
+  }
+
+  const anyCastProgram = createAnyCastProgram(anyCastInputs);
+  for (const { filePath: relativePath } of anyCastInputs) {
+    const sourceFile = getAnyCastSourceFile(
+      anyCastProgram.sourceFiles,
+      relativePath
+    );
+    throwOnSyntacticDiagnostics(
+      anyCastProgram.program,
+      sourceFile,
+      relativePath
+    );
+    const anyCount = countAnyCastsInSourceFile(sourceFile);
+    if (anyCount > 0) perFile.any_casts.set(relativePath, anyCount);
   }
 
   const sum = (map) => [...map.values()].reduce((total, n) => total + n, 0);

--- a/wagmiConfig/wagmiAppWalletConnector.ts
+++ b/wagmiConfig/wagmiAppWalletConnector.ts
@@ -17,6 +17,18 @@ interface CreateAppWalletConnectorOptions {
   appWallet: AppWallet;
 }
 
+type AppWalletAccountWithCapabilities = {
+  address: Address;
+  capabilities: Record<string, unknown>;
+};
+
+type AppWalletConnectResult<withCapabilities extends boolean> = {
+  accounts: withCapabilities extends true
+    ? readonly AppWalletAccountWithCapabilities[]
+    : readonly Address[];
+  chainId: number;
+};
+
 export function createAppWalletConnector(
   chains: Chain[],
   options: CreateAppWalletConnectorOptions,
@@ -184,15 +196,7 @@ export function createAppWalletConnector(
       chainId?: number | undefined;
       isReconnecting?: boolean | undefined;
       withCapabilities?: boolean | withCapabilities | undefined;
-    }): Promise<{
-      accounts: withCapabilities extends true
-        ? readonly {
-            address: `0x${string}`;
-            capabilities: Record<string, unknown>;
-          }[]
-        : readonly `0x${string}`[];
-      chainId: number;
-    }> {
+    }): Promise<AppWalletConnectResult<withCapabilities>> {
       const maybeChainId = opts?.chainId;
       const chainId = maybeChainId ?? chains[0]?.id;
 
@@ -223,7 +227,8 @@ export function createAppWalletConnector(
         );
       }
 
-      const client = await getOrCreateClient(chainId!);
+      const connectedChainId = chainId!;
+      const client = await getOrCreateClient(connectedChainId);
       if (!client.account?.address) {
         throw new Error("No valid local account found after decryption.");
       }
@@ -238,35 +243,33 @@ export function createAppWalletConnector(
       }
 
       // Keep internal state up to date
-      currentChainId = chainId!;
+      currentChainId = connectedChainId;
 
       // Emit connect event (addresses only)
       emitter.emit("connect", {
         accounts: [client.account.address],
-        chainId: chainId!,
+        chainId: connectedChainId,
       });
 
-      if (opts?.withCapabilities) {
-        const accountsWithCaps = (
-          [client.account.address] as readonly `0x${string}`[]
-        ).map((address) => ({
-          address,
-          capabilities: {} as Record<string, unknown>,
-        })) as unknown as readonly {
-          address: `0x${string}`;
-          capabilities: Record<string, unknown>;
-        }[];
+      const result = opts?.withCapabilities
+        ? {
+            accounts: [
+              {
+                address: client.account.address,
+                capabilities: {},
+              },
+            ] satisfies readonly AppWalletAccountWithCapabilities[],
+            chainId: connectedChainId,
+          }
+        : {
+            accounts: [client.account.address] satisfies readonly Address[],
+            chainId: connectedChainId,
+          };
 
-        return {
-          accounts: accountsWithCaps as any,
-          chainId,
-        } as any;
-      }
-
-      return {
-        accounts: [client.account.address] as readonly `0x${string}`[],
-        chainId,
-      } as any;
+      // TypeScript cannot narrow wagmi's generic `withCapabilities` parameter
+      // from the runtime option; this assertion is limited to the two account
+      // shapes constructed above from the validated wallet client.
+      return result as unknown as AppWalletConnectResult<withCapabilities>;
     },
 
     async disconnect() {


### PR DESCRIPTION
## Issue
- The `any_casts` debt ratchet used textual matching, so prose like `as ... any` could be counted as TypeScript debt.
- The normal debt ratchet report also showed only the combined `oversized_files` total, while the details command can now distinguish WordPress-migrated files.

## Fix
- Count `any_casts` with TypeScript syntax parsing for direct `: any`-style annotations, `as any` assertions, and valid TypeScript `<any>` assertions, while keeping generic type arguments outside the existing metric scope.
- Fail loudly on TypeScript parse diagnostics during `any_casts` scanning instead of silently undercounting malformed source.
- Show `oversized_files` as the single checked ratchet row, followed by a `breakdown:` block for `app_source` and `wp_migrated` count-only subrows.
- Replace the app-wallet connector's `as any` returns with a named wagmi connector return type and one localized `unknown` assertion at the `withCapabilities` conditional-generic boundary.

## Changes
- Lowers the `any_casts` baseline from 4 to 0.
- Keeps `--details oversized_files --ignore-wp-migrated` behavior intact.
- Updates the debt ratchet workflow to install dependencies so the repo-pinned TypeScript parser is available in CI.
- Adds scanner regression coverage for `readonly any[]`, parenthesized direct `any`, unions containing direct `any`, TypeScript `<any>` assertions, and invalid TSX angle-bracket syntax.
- Adds connector tests for default `connect()` address-array returns and `withCapabilities` account-object returns.
- Updates the any-exceptions ledger to show no current `any_casts` exceptions and document the TS/TSX angle-bracket boundary.

## Validation
- `node scripts/debt-ratchet.cjs`
- `node scripts/debt-ratchet.cjs --details any_casts`
- `node scripts/debt-ratchet.cjs --details oversized_files --ignore-wp-migrated`
- `6529 run test -- __tests__/scripts/debt-ratchet.test.ts __tests__/wagmiConfig/wagmiAppWalletConnector.test.ts --runInBand`
- `6529 exec eslint --config eslint.config.diff.mjs --no-warn-ignored --max-warnings=0 .github/workflows/debt-ratchet.yml scripts/debt-ratchet.cjs __tests__/scripts/debt-ratchet.test.ts __tests__/wagmiConfig/wagmiAppWalletConnector.test.ts wagmiConfig/wagmiAppWalletConnector.ts`
- `6529 run typecheck`
- `git diff --check`

## Risk
- Level: Medium
- Why: touches a required CI workflow and the custom wagmi app-wallet connector typing boundary.
- Rollback: revert this PR to restore the previous textual scanner, combined oversized report, and connector casts.

## Review Notes
- The dependency install in the debt-ratchet workflow is intentional because the AST scanner uses the repo-pinned TypeScript parser.
- CodeRabbit's pnpm-cache nitpick was intentionally reverted because `actions/setup-node` resolves pnpm caching before the later Corepack activation in this standalone workflow.
- The CodeRabbit `countAnyCasts` expectation comment was based on the pre-follow-up scanner shape and is no longer valid; the broadened scanner behavior is covered by passing tests.
- Please look closely at the `withCapabilities` return shape in `wagmiAppWalletConnector.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debt-ratchet checks to better detect real TypeScript `any` usage and avoid false positives from prose or comments.
  * Expanded debt-ratchet reporting so oversized-file results now show clearer breakdowns.
  * Updated wallet connection behavior to return more complete connection details, including optional capability data when requested.
  * Increased workflow timeout to reduce premature check failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->