### PR TITLE
Read profile CMS env flags exclusively via publicEnv

### DIFF
--- a/__tests__/app/profile-cms-builder-route.test.tsx
+++ b/__tests__/app/profile-cms-builder-route.test.tsx
@@ -1,8 +1,14 @@
 import { render, screen } from "@testing-library/react";
 
 import ProfileCmsBuilderPage from "@/app/[user]/cms/builder/page";
+import { publicEnv } from "@/config/env";
 import { getAppCommonHeaders } from "@/helpers/server.app.helpers";
 import { getUserProfile } from "@/helpers/server.helpers";
+
+jest.mock("@/config/env", () => {
+  const actual = jest.requireActual("@/config/env");
+  return { ...actual, publicEnv: { ...actual.publicEnv } };
+});
 
 jest.mock("@/components/profile-cms-builder/ProfileCmsBuilder", () => ({
   __esModule: true,
@@ -41,8 +47,8 @@ const getUserProfileMock = getUserProfile as jest.Mock;
 describe("profile CMS builder route", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    delete process.env["PROFILE_CMS_BUILDER_ENABLED"];
-    delete process.env["NEXT_PUBLIC_PROFILE_CMS_BUILDER_ENABLED"];
+    delete publicEnv.PROFILE_CMS_BUILDER_ENABLED;
+    delete publicEnv.NEXT_PUBLIC_PROFILE_CMS_BUILDER_ENABLED;
     getAppCommonHeadersMock.mockResolvedValue({});
     getUserProfileMock.mockResolvedValue({
       id: "profile-punk6529",
@@ -59,7 +65,7 @@ describe("profile CMS builder route", () => {
   });
 
   it("renders the builder for a profile handle when enabled", async () => {
-    process.env["PROFILE_CMS_BUILDER_ENABLED"] = "true";
+    publicEnv.PROFILE_CMS_BUILDER_ENABLED = "true";
 
     const page = await ProfileCmsBuilderPage({
       params: Promise.resolve({ user: "punk6529" }),
@@ -76,7 +82,7 @@ describe("profile CMS builder route", () => {
   });
 
   it("returns not found when the profile lookup fails", async () => {
-    process.env["PROFILE_CMS_BUILDER_ENABLED"] = "true";
+    publicEnv.PROFILE_CMS_BUILDER_ENABLED = "true";
     getUserProfileMock.mockRejectedValueOnce(new Error("not found"));
 
     await expect(
@@ -87,7 +93,7 @@ describe("profile CMS builder route", () => {
   });
 
   it("returns not found when the profile lookup has no profile id", async () => {
-    process.env["PROFILE_CMS_BUILDER_ENABLED"] = "true";
+    publicEnv.PROFILE_CMS_BUILDER_ENABLED = "true";
     getUserProfileMock.mockResolvedValueOnce({ handle: "punk6529" });
 
     await expect(

--- a/__tests__/components/profile-cms-builder/ProfileCmsBuilder.test.tsx
+++ b/__tests__/components/profile-cms-builder/ProfileCmsBuilder.test.tsx
@@ -11,7 +11,13 @@ import type { ReactNode } from "react";
 
 import { useAuth } from "@/components/auth/Auth";
 import ProfileCmsBuilder from "@/components/profile-cms-builder/ProfileCmsBuilder";
+import { publicEnv } from "@/config/env";
 import { commonApiPost } from "@/services/api/common-api";
+
+jest.mock("@/config/env", () => {
+  const actual = jest.requireActual("@/config/env");
+  return { ...actual, publicEnv: { ...actual.publicEnv } };
+});
 
 jest.mock("@/components/auth/Auth", () => ({
   useAuth: jest.fn(),
@@ -74,8 +80,8 @@ describe("ProfileCmsBuilder", () => {
       configurable: true,
       value: revokeObjectUrlMock,
     });
-    delete process.env["PROFILE_CMS_BUILDER_API_ENABLED"];
-    delete process.env["NEXT_PUBLIC_PROFILE_CMS_BUILDER_API_ENABLED"];
+    delete publicEnv.PROFILE_CMS_BUILDER_API_ENABLED;
+    delete publicEnv.NEXT_PUBLIC_PROFILE_CMS_BUILDER_API_ENABLED;
     useAuthMock.mockReturnValue({
       activeProfileProxy: null,
       connectedProfile: null,
@@ -277,7 +283,7 @@ describe("ProfileCmsBuilder", () => {
 
   it("does not turn agent patch import into backend authority", async () => {
     const user = userEvent.setup();
-    process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
+    publicEnv.PROFILE_CMS_BUILDER_API_ENABLED = "true";
     useAuthMock.mockReturnValue({
       activeProfileProxy: null,
       connectedProfile: { id: "profile-other" },
@@ -353,7 +359,7 @@ describe("ProfileCmsBuilder", () => {
 
   it("blocks draft saves unless the connected profile owns the target", async () => {
     const user = userEvent.setup();
-    process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
+    publicEnv.PROFILE_CMS_BUILDER_API_ENABLED = "true";
     useAuthMock.mockReturnValue({
       activeProfileProxy: null,
       connectedProfile: { id: "profile-other" },
@@ -379,7 +385,7 @@ describe("ProfileCmsBuilder", () => {
 
   it("blocks server validation unless the connected profile owns the target", async () => {
     const user = userEvent.setup();
-    process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
+    publicEnv.PROFILE_CMS_BUILDER_API_ENABLED = "true";
     useAuthMock.mockReturnValue({
       activeProfileProxy: null,
       connectedProfile: { id: "profile-other" },
@@ -482,7 +488,7 @@ describe("ProfileCmsBuilder", () => {
 
   it("does not show a stale save result after edits during the request", async () => {
     const user = userEvent.setup();
-    process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
+    publicEnv.PROFILE_CMS_BUILDER_API_ENABLED = "true";
     useAuthMock.mockReturnValue({
       activeProfileProxy: null,
       connectedProfile: { id: "profile-punk6529" },

--- a/__tests__/lib/profile-cms/builder/api.test.ts
+++ b/__tests__/lib/profile-cms/builder/api.test.ts
@@ -1,9 +1,15 @@
+import { publicEnv } from "@/config/env";
 import {
   PROFILE_CMS_GALLERY_SNAPSHOT_ENDPOINT,
   requestProfileCmsGallerySnapshot,
 } from "@/lib/profile-cms/builder/api";
 import { parseWalletGallerySources } from "@/lib/profile-cms/builder/gallery";
 import { commonApiPost } from "@/services/api/common-api";
+
+jest.mock("@/config/env", () => {
+  const actual = jest.requireActual("@/config/env");
+  return { ...actual, publicEnv: { ...actual.publicEnv } };
+});
 
 jest.mock("@/services/api/common-api", () => ({
   commonApiPost: jest.fn(),
@@ -14,8 +20,8 @@ const commonApiPostMock = commonApiPost as jest.Mock;
 describe("profile CMS builder API adapter", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    delete process.env["PROFILE_CMS_BUILDER_API_ENABLED"];
-    delete process.env["NEXT_PUBLIC_PROFILE_CMS_BUILDER_API_ENABLED"];
+    delete publicEnv.PROFILE_CMS_BUILDER_API_ENABLED;
+    delete publicEnv.NEXT_PUBLIC_PROFILE_CMS_BUILDER_API_ENABLED;
   });
 
   it("uses the fixture snapshot fallback while backend gallery API is disabled", async () => {
@@ -35,7 +41,7 @@ describe("profile CMS builder API adapter", () => {
   });
 
   it("posts the expected backend snapshot contract when the API is enabled", async () => {
-    process.env["PROFILE_CMS_BUILDER_API_ENABLED"] = "true";
+    publicEnv.PROFILE_CMS_BUILDER_API_ENABLED = "true";
     const sources = parseWalletGallerySources("punk6529.eth").sources;
     commonApiPostMock.mockResolvedValue({
       snapshot_id: "snapshot-1",

--- a/__tests__/lib/profile-cms/runtime/fetcher.test.ts
+++ b/__tests__/lib/profile-cms/runtime/fetcher.test.ts
@@ -1,4 +1,5 @@
 import minimalPackage from "@/ops/workstreams/profile-native-cms-roadmap/phase-1/fixtures/valid/minimal-profile-homepage.package.json";
+import { publicEnv } from "@/config/env";
 import type { CmsPackageV1 } from "@/lib/profile-cms/protocol/v1";
 import { withComputedCmsHashes } from "@/lib/profile-cms/protocol/v1";
 import { commonApiFetch } from "@/services/api/common-api";
@@ -8,6 +9,11 @@ import {
   fetchProfileCmsPrimarySite,
   normalizePrimarySiteResponse,
 } from "@/lib/profile-cms/runtime/fetcher";
+
+jest.mock("@/config/env", () => {
+  const actual = jest.requireActual("@/config/env");
+  return { ...actual, publicEnv: { ...actual.publicEnv } };
+});
 
 jest.mock("@/services/api/common-api", () => ({
   commonApiFetch: jest.fn(),
@@ -61,8 +67,8 @@ describe("profile CMS primary-site fetcher", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     clearProfileCmsRuntimeCacheForTests();
-    delete process.env["PROFILE_CMS_RUNTIME_FIXTURE_PRIMARY"];
-    delete process.env["PROFILE_CMS_RUNTIME_ENABLED"];
+    delete publicEnv.PROFILE_CMS_RUNTIME_FIXTURE_PRIMARY;
+    delete publicEnv.PROFILE_CMS_RUNTIME_ENABLED;
   });
 
   it("documents the canonical primary endpoint", () => {
@@ -164,7 +170,7 @@ describe("profile CMS primary-site fetcher", () => {
   });
 
   it("uses the dev fixture only when explicitly enabled and the API is unavailable", async () => {
-    process.env["PROFILE_CMS_RUNTIME_FIXTURE_PRIMARY"] = "true";
+    publicEnv.PROFILE_CMS_RUNTIME_FIXTURE_PRIMARY = "true";
     commonApiFetchMock.mockRejectedValueOnce(new Error("ECONNREFUSED"));
 
     const site = await fetchProfileCmsPrimarySite({

--- a/config/env.schema.ts
+++ b/config/env.schema.ts
@@ -118,6 +118,8 @@ export const publicEnvSchema = z.object({
   NEXT_PUBLIC_FEATURE_AB_CARD: z.string().optional(),
   PROFILE_CMS_BUILDER_API_ENABLED: z.string().optional(),
   PROFILE_CMS_BUILDER_ENABLED: z.string().optional(),
+  PROFILE_CMS_RUNTIME_ENABLED: z.string().optional(),
+  PROFILE_CMS_RUNTIME_FIXTURE_PRIMARY: z.string().optional(),
   NEXT_PUBLIC_VITE_FEATURE_AB_CARD: z.string().optional(),
   VITE_FEATURE_AB_CARD: z.string().optional(),
 

--- a/config/profileCmsBuilderEnv.ts
+++ b/config/profileCmsBuilderEnv.ts
@@ -1,27 +1,20 @@
 import { publicEnv } from "@/config/env";
 
 export function isProfileCmsBuilderEnabledEnv(): boolean {
-  return getBooleanEnv("PROFILE_CMS_BUILDER_ENABLED", [
-    process.env["PROFILE_CMS_BUILDER_ENABLED"],
-    process.env["NEXT_PUBLIC_PROFILE_CMS_BUILDER_ENABLED"],
+  return getBooleanEnv([
     publicEnv.NEXT_PUBLIC_PROFILE_CMS_BUILDER_ENABLED,
     publicEnv.PROFILE_CMS_BUILDER_ENABLED,
   ]);
 }
 
 export function isProfileCmsBuilderApiEnabledEnv(): boolean {
-  return getBooleanEnv("PROFILE_CMS_BUILDER_API_ENABLED", [
-    process.env["PROFILE_CMS_BUILDER_API_ENABLED"],
-    process.env["NEXT_PUBLIC_PROFILE_CMS_BUILDER_API_ENABLED"],
+  return getBooleanEnv([
     publicEnv.NEXT_PUBLIC_PROFILE_CMS_BUILDER_API_ENABLED,
     publicEnv.PROFILE_CMS_BUILDER_API_ENABLED,
   ]);
 }
 
-function getBooleanEnv(
-  _name: string,
-  values: ReadonlyArray<string | undefined>
-): boolean {
+function getBooleanEnv(values: ReadonlyArray<string | undefined>): boolean {
   return values.some((value) => {
     if (value === undefined) {
       return false;

--- a/config/profileCmsRuntimeEnv.ts
+++ b/config/profileCmsRuntimeEnv.ts
@@ -1,10 +1,19 @@
+import { getNodeEnv, publicEnv } from "@/config/env";
+
+/**
+ * These flags resolve from the build-time-baked `publicEnv` (PUBLIC_RUNTIME),
+ * mirroring the sibling PROFILE_CMS_BUILDER_* flags. Their values are fixed at
+ * build/deploy time, not read live per request — setting the underlying env
+ * var on an already-built server has no effect. There is no per-request
+ * runtime toggle for these flags by design.
+ */
 export function isProfileCmsRuntimeEnabledEnv(): boolean {
-  return process.env["PROFILE_CMS_RUNTIME_ENABLED"] !== "false";
+  return publicEnv.PROFILE_CMS_RUNTIME_ENABLED !== "false";
 }
 
 export function shouldUseProfileCmsRuntimeFixturePrimaryEnv(): boolean {
   return (
-    process.env.NODE_ENV !== "production" &&
-    process.env["PROFILE_CMS_RUNTIME_FIXTURE_PRIMARY"] === "true"
+    getNodeEnv() !== "production" &&
+    publicEnv.PROFILE_CMS_RUNTIME_FIXTURE_PRIMARY === "true"
   );
 }


### PR DESCRIPTION
## What

`config/profileCmsBuilderEnv.ts` and `config/profileCmsRuntimeEnv.ts` read `process.env` directly. The `no-restricted-syntax` rule in `eslint.config.mjs` bans `process.env` member access for `**/*.{ts,tsx}`. This PR routes every flag read through the schema-validated `publicEnv` (from `@/config/env`), matching the pattern used elsewhere for public flags — no `process.env` fallback.

## Why it was never caught (correction to the original premise)

The violation was assumed dormant because `lint:changed` only scopes to files changed since `main`. The real reason is stronger: **`baseGlobalIgnores` in `eslint.config.mjs` excludes `config/**` from eslint entirely**, so the rule could never fire on these files — not merely "unchanged since the rule landed." Chronology confirms it: rule added 2025-10-28, `config/**` ignore added 2026-01-06, these files landed 2026-06-17 already ignored. A "full eslint pass" over them is vacuously green (`--no-warn-ignored` skips ignored files silently).

I verified the honest way, forcing the full rule set with `--no-ignore`:
- **before:** 7 `no-restricted-syntax` errors across the two files
- **after:** 0 errors

The broader gap (all of `config/**` and `__tests__/**` invisible to eslint) is out of scope here and tracked separately.

## Changes

- **`config/profileCmsBuilderEnv.ts`** — both builder flags now read only `publicEnv.NEXT_PUBLIC_PROFILE_CMS_BUILDER_*` / `publicEnv.PROFILE_CMS_BUILDER_*`; dropped the four `process.env` reads and the now-unused `_name` arg to the boolean helper.
- **`config/profileCmsRuntimeEnv.ts`** — runtime flags read via `publicEnv`; the non-production guard uses the existing `getNodeEnv()` helper instead of `process.env.NODE_ENV`.
- **`config/env.schema.ts`** — added `PROFILE_CMS_RUNTIME_ENABLED` and `PROFILE_CMS_RUNTIME_FIXTURE_PRIMARY` to `publicEnvSchema` (the four builder keys already existed; the two runtime keys did not). `next.config.ts` bakes every schema key from `process.env` into `PUBLIC_RUNTIME`, so the env vars keep working in dev and deploys with no extra plumbing.
- **4 test suites** (`profile-cms-builder-route`, `profile-cms/builder/api`, `ProfileCmsBuilder`, `profile-cms/runtime/fetcher`) — these toggled flags by mutating `process.env` at call time, which only worked because the modules read it lazily; that path no longer exists. Switched to the repo-standard approach: `jest.mock("@/config/env")` returning a mutable copy of the real `publicEnv`, with each set/delete translated one-for-one. Assertions are unchanged.

## Behavioral note

`PROFILE_CMS_RUNTIME_ENABLED` was previously read live from the server process env per request; it is now baked at build time like every other `publicEnv` flag. This is inherent to the publicEnv-only design and consistent with the other CMS flags. Nothing sets it in deployed environments today (dark launch), so there is no runtime change in practice.

## Verification

- `eslint --no-ignore` on both config files: 7 errors → 0
- jest: 6 profile-CMS suites green (route, builder api, ProfileCmsBuilder, runtime fetcher, profile-cms-route, env.base-endpoint) — 64 tests
- `tsc --noEmit -p tsconfig.typecheck.json`: clean
- prettier: clean
- Re-verified after rebasing onto current `main` (which includes the Profile CMS file-splits and the `TENOR_API_KEY`→`GIPHY_API_KEY` schema rename)

cc @prxt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new CMS runtime configuration options, including enabling the runtime and selecting a primary fixture in non-production environments.
* **Bug Fixes**
  * Improved how feature flags are read so CMS builder and runtime behavior now follows the app’s shared configuration consistently.
  * Updated test coverage to verify enabled/disabled CMS builder and runtime flows using the same configuration source as the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->