### PR TITLE
Fix pnpm test script swallowing appended jest test-path patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,7 +237,10 @@ Prefer focused checks first. Escalate based on blast radius.
 - Broader changed-file validation: `6529 run check:changed`.
 - React, Next.js, JSX, TSX, hooks, routing, or UI state: also run
   `6529 run react-doctor:diff` when available.
-- Unit/integration behavior: targeted `6529 run test -- <pattern>`.
+- Unit/integration behavior: targeted `6529 run test <pattern>` (append flags
+  like `--testPathPatterns=<regex>` or `--cacheDirectory=<dir>` directly; do
+  not insert a `--` separator — jest reads everything after `--` as a
+  test-path pattern, so flags placed there are misread).
 - Playwright/user flows: `6529 run test:e2e` or a targeted Playwright run. The
   Playwright config starts `./bin/6529 run dev` on port `3001`.
 - Build-time, generated models, Next config, env/runtime config, proxy, routing,

--- a/__tests__/scripts/lint-package-json.test.ts
+++ b/__tests__/scripts/lint-package-json.test.ts
@@ -3,7 +3,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-const SCRIPT_PATH = path.join(process.cwd(), "scripts", "lint-package-json.cjs");
+const SCRIPT_PATH = path.join(
+  process.cwd(),
+  "scripts",
+  "lint-package-json.cjs"
+);
 
 const BASE_PACKAGE_JSON = {
   name: "fixture",
@@ -18,7 +22,10 @@ const runLint = (packageJson?: object) => {
   const env = { ...process.env };
   delete env["LINT_PACKAGE_JSON_PATH"];
   if (!packageJson) {
-    return spawnSync(process.execPath, [SCRIPT_PATH], { encoding: "utf8", env });
+    return spawnSync(process.execPath, [SCRIPT_PATH], {
+      encoding: "utf8",
+      env,
+    });
   }
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lint-package-json-"));
   const packageJsonPath = path.join(dir, "package.json");
@@ -67,9 +74,9 @@ describe("lint-package-json trailing jest array options", () => {
   });
 
   it("fails dashed aliases and bare array flags", () => {
-    expect(runLint(withTestScript("jest --coverage-reporters=none")).status).toBe(
-      1
-    );
+    expect(
+      runLint(withTestScript("jest --coverage-reporters=none")).status
+    ).toBe(1);
     expect(runLint(withTestScript("jest --reporters")).status).toBe(1);
   });
 
@@ -82,9 +89,9 @@ describe("lint-package-json trailing jest array options", () => {
   });
 
   it("passes non-array trailing flags and positional endings", () => {
-    expect(runLint(withTestScript("jest --silent --coverage=false")).status).toBe(
-      0
-    );
+    expect(
+      runLint(withTestScript("jest --silent --coverage=false")).status
+    ).toBe(0);
     expect(runLint(withTestScript("jest __tests__/scripts")).status).toBe(0);
   });
 

--- a/__tests__/scripts/lint-package-json.test.ts
+++ b/__tests__/scripts/lint-package-json.test.ts
@@ -1,0 +1,106 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const SCRIPT_PATH = path.join(process.cwd(), "scripts", "lint-package-json.cjs");
+
+const BASE_PACKAGE_JSON = {
+  name: "fixture",
+  dependencies: { left: "1.0.0" },
+  devDependencies: { right: "2.0.0" },
+  scripts: {
+    test: "node scripts/require-6529-command.cjs && cross-env NODE_ENV=test jest --coverageReporters=none --silent --verbose=false",
+  },
+};
+
+const runLint = (packageJson?: object) => {
+  const env = { ...process.env };
+  delete env["LINT_PACKAGE_JSON_PATH"];
+  if (!packageJson) {
+    return spawnSync(process.execPath, [SCRIPT_PATH], { encoding: "utf8", env });
+  }
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lint-package-json-"));
+  const packageJsonPath = path.join(dir, "package.json");
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
+  try {
+    return spawnSync(process.execPath, [SCRIPT_PATH], {
+      encoding: "utf8",
+      env: { ...env, LINT_PACKAGE_JSON_PATH: packageJsonPath },
+    });
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+};
+
+const withTestScript = (test: string) => ({
+  ...BASE_PACKAGE_JSON,
+  scripts: { test },
+});
+
+describe("lint-package-json dependency pinning", () => {
+  it("passes pinned versions", () => {
+    expect(runLint(BASE_PACKAGE_JSON).status).toBe(0);
+  });
+
+  it("fails caret and tilde ranges", () => {
+    const result = runLint({
+      ...BASE_PACKAGE_JSON,
+      dependencies: { left: "^1.0.0" },
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("dependencies.left -> ^1.0.0");
+  });
+});
+
+describe("lint-package-json trailing jest array options", () => {
+  it("fails a jest script ending with an array-type option", () => {
+    const result = runLint(
+      withTestScript(
+        "cross-env NODE_ENV=test jest --silent --verbose=false --coverageReporters=none"
+      )
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "scripts.test ends with --coverageReporters=none"
+    );
+  });
+
+  it("fails dashed aliases and bare array flags", () => {
+    expect(runLint(withTestScript("jest --coverage-reporters=none")).status).toBe(
+      1
+    );
+    expect(runLint(withTestScript("jest --reporters")).status).toBe(1);
+  });
+
+  it("passes when the array option is not the final token", () => {
+    expect(
+      runLint(
+        withTestScript("jest --coverageReporters=none --silent --verbose=false")
+      ).status
+    ).toBe(0);
+  });
+
+  it("passes non-array trailing flags and positional endings", () => {
+    expect(runLint(withTestScript("jest --silent --coverage=false")).status).toBe(
+      0
+    );
+    expect(runLint(withTestScript("jest __tests__/scripts")).status).toBe(0);
+  });
+
+  it("ignores scripts whose final command is not jest", () => {
+    expect(
+      runLint(
+        withTestScript(
+          "jest --json --coverageReporters=none ; pnpm run test-extract-failed-names"
+        )
+      ).status
+    ).toBe(0);
+  });
+
+  it("accepts the repository package.json", () => {
+    const result = runLint();
+    expect(result.stderr).toBe("");
+    expect(result.status).toBe(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "postbuild": "node scripts/require-6529-command.cjs && next-sitemap --config next-sitemap.build.cjs",
     "start": "node scripts/require-6529-command.cjs && node scripts/start-next.cjs",
     "start:standalone": "node scripts/require-6529-command.cjs && node scripts/start-standalone.cjs",
-    "test": "node scripts/require-6529-command.cjs && cross-env NODE_ENV=test jest --silent --verbose=false --coverageReporters=none",
+    "test": "node scripts/require-6529-command.cjs && cross-env NODE_ENV=test jest --coverageReporters=none --silent --verbose=false",
     "test:no-coverage": "node scripts/require-6529-command.cjs && cross-env NODE_ENV=test jest --silent --verbose=false --coverage=false",
     "test-json": "node scripts/require-6529-command.cjs && cross-env NODE_ENV=test jest --silent --json --outputFile=test-results/jest-results.json --coverage=false --forceExit ; pnpm run test-extract-failed-names",
     "test-json-changed": "node scripts/require-6529-command.cjs && cross-env NODE_ENV=test jest --silent --json --outputFile=test-results/jest-results.json --changedSince=main --coverage=false --forceExit ; pnpm run test-extract-failed-names",

--- a/scripts/lint-package-json.cjs
+++ b/scripts/lint-package-json.cjs
@@ -3,7 +3,8 @@
 const { readFileSync } = require("node:fs");
 const { resolve } = require("node:path");
 
-const packageJsonPath = resolve(__dirname, "..", "package.json");
+const packageJsonPath =
+  process.env["LINT_PACKAGE_JSON_PATH"] || resolve(__dirname, "..", "package.json");
 let packageJson;
 
 try {
@@ -29,10 +30,90 @@ for (const field of dependencyFields) {
   }
 }
 
+// Array-type options of the pinned jest-cli (30.4.2). yargs lets an array
+// option keep absorbing the positionals that follow it — even when written as
+// `--flag=value` — so a script whose FINAL token is one of these swallows any
+// test-path pattern the caller appends (`6529 run test "MyComponent"`), runs
+// the full suite instead, then crashes resolving the pattern as a module.
+const jestArrayOptions = new Set([
+  "coveragePathIgnorePatterns",
+  "coverageReporters",
+  "ignoreProjects",
+  "moduleDirectories",
+  "moduleFileExtensions",
+  "modulePathIgnorePatterns",
+  "modulePaths",
+  "projects",
+  "reporters",
+  "roots",
+  "selectProjects",
+  "setupFiles",
+  "setupFilesAfterEnv",
+  "snapshotSerializers",
+  "testMatch",
+  "testPathIgnorePatterns",
+  "testPathPatterns",
+  "testRegex",
+  "transformIgnorePatterns",
+  "unmockedModulePathPatterns",
+  "watchPathIgnorePatterns",
+]);
+
+const camelize = (flagName) =>
+  flagName.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+
+// pnpm appends caller arguments to the END of the script line, so only the
+// last shell command can receive them, and only jest invocations are at risk.
+const trailingJestArrayOption = (script) => {
+  const segments = script.split(/&&|\|\||;/);
+  const tokens = segments[segments.length - 1].trim().split(/\s+/).filter(Boolean);
+  const invokesJest = tokens.some(
+    (token) => token === "jest" || /[\\/]jest(\.[cm]?js)?$/.test(token)
+  );
+  if (!invokesJest) {
+    return null;
+  }
+  const lastToken = tokens[tokens.length - 1];
+  const flagMatch = /^--([^=]+)/.exec(lastToken);
+  if (!flagMatch) {
+    return null;
+  }
+  return jestArrayOptions.has(camelize(flagMatch[1])) ? lastToken : null;
+};
+
+const invalidScripts = [];
+
+for (const [name, script] of Object.entries(packageJson.scripts ?? {})) {
+  if (typeof script !== "string") {
+    continue;
+  }
+
+  const offendingToken = trailingJestArrayOption(script);
+  if (offendingToken) {
+    invalidScripts.push(`scripts.${name} ends with ${offendingToken}`);
+  }
+}
+
+let failed = false;
+
 if (invalidEntries.length > 0) {
+  failed = true;
   console.error("package.json must pin dependency versions exactly.");
   for (const entry of invalidEntries) {
     console.error(`- ${entry}`);
   }
+}
+
+if (invalidScripts.length > 0) {
+  failed = true;
+  console.error(
+    "package.json scripts must not end a jest invocation with an array-type jest option; reorder the flags so appended positionals stay test-path patterns."
+  );
+  for (const entry of invalidScripts) {
+    console.error(`- ${entry}`);
+  }
+}
+
+if (failed) {
   process.exit(1);
 }

--- a/scripts/lint-package-json.cjs
+++ b/scripts/lint-package-json.cjs
@@ -4,14 +4,17 @@ const { readFileSync } = require("node:fs");
 const { resolve } = require("node:path");
 
 const packageJsonPath =
-  process.env["LINT_PACKAGE_JSON_PATH"] || resolve(__dirname, "..", "package.json");
+  process.env["LINT_PACKAGE_JSON_PATH"] ||
+  resolve(__dirname, "..", "package.json");
 let packageJson;
 
 try {
   packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
 } catch (error) {
   const message = error instanceof Error ? error.message : String(error);
-  console.error(`Failed to read or parse package.json at ${packageJsonPath}: ${message}`);
+  console.error(
+    `Failed to read or parse package.json at ${packageJsonPath}: ${message}`
+  );
   process.exit(1);
 }
 const dependencyFields = ["dependencies", "devDependencies"];
@@ -66,7 +69,10 @@ const camelize = (flagName) =>
 // last shell command can receive them, and only jest invocations are at risk.
 const trailingJestArrayOption = (script) => {
   const segments = script.split(/&&|\|\||;/);
-  const tokens = segments[segments.length - 1].trim().split(/\s+/).filter(Boolean);
+  const tokens = segments[segments.length - 1]
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
   const invokesJest = tokens.some(
     (token) => token === "jest" || /[\\/]jest(\.[cm]?js)?$/.test(token)
   );


### PR DESCRIPTION
## Issue
- The `test` script ended with the array-type jest option `--coverageReporters=none`. yargs array options keep absorbing the positionals that follow them — even in `--flag=value` form — so an appended test-path pattern (`6529 run test "MyComponent"`) was swallowed into `coverageReporters` instead of selecting suites: jest ran the full ~1,968-suite battery (~4–6 min) and then crashed `require()`ing the pattern as a coverage-reporter module (`Cannot find module 'MyComponent'`).
- This contaminated a large batch of agent test runs during the 2026-07-06 i18n campaign (see the campaign run-log incident audit) and an earlier agent-files resync session.

## Fix
- Reorder the script so the jest invocation ends with a boolean flag: `jest --coverageReporters=none --silent --verbose=false`. Trailing positionals parse as test-path patterns again, and appended flags are honored. No-argument behavior is unchanged.

## Changes
- `package.json`: flag reorder in the `test` script only.
- `scripts/lint-package-json.cjs`: new rule — fail if any script's final shell command is a jest invocation ending in an array-type jest option (option list pinned from the installed jest-cli 30.4.2; dashed aliases normalized). This linter already gates app-pr-ci, dependency-governance, and the prod deploy workflow, so the hazard cannot be reintroduced silently. The package.json path is now overridable via `LINT_PACKAGE_JSON_PATH` so the linter is testable against fixtures.
- `__tests__/scripts/lint-package-json.test.ts`: new suite (8 tests) covering the existing version-pinning rule and the new trailing-flag rule, including a regression pin that the repository package.json stays clean.
- `AGENTS.md` validation matrix: targeted-test guidance now uses the positional form and warns that flags after a `--` separator are misread (pnpm forwards `--` to jest, and jest reads everything after it as a test-path pattern).

## Audit of other jest entry points
- `test:no-coverage` ends with boolean `--coverage=false` — safe.
- `test-json` / `test-json-changed` end in a follow-up command (`pnpm run test-extract-failed-names`), so appended args never reach jest.
- CI workflows pass positional file lists after boolean `--passWithNoTests` / `--findRelatedTests`, and coverage-floor.yml appends nothing after its jest command — safe by construction.

## Validation
Run from a sibling worktree of this branch (jest cannot match tests under dot-directory checkouts):
- `6529 run test "lint-package-json"` → 1 suite selected, 8/8 pass (pre-fix this form ran the full suite, then crashed).
- `6529 run test "lint-package-json" --cacheDirectory=tmp/jest-verify` → 1 suite, flag honored (cache dir created).
- `6529 run test --testPathPatterns="lint-package-json" --cacheDirectory=tmp/jest-verify` → 1 suite (Jest 30 plural flag form keeps working).
- `6529 run test -- "lint-package-json"` → 1 suite; `6529 run test -- --listTests` → `Pattern: --listTests - 0 matches`, confirming the documented `--` misread.
- No-arg selection unchanged: `--listTests` matches 1,972 test files.
- CI parity: `jest --listTests --findRelatedTests <changed files>` → exactly the new suite.
- `node scripts/lint-package-json.cjs` passes the repo file and fails a fixture carrying the old script line; prettier --check clean on the four changed files.
- Typecheck: the only errors are 5 pre-existing ones in `components/waves/CreateDropGifPicker.tsx` caused by `@giphy/react-components` (added to main this morning) being absent from the local install used for verification — unrelated to this diff; CI typechecks against a fresh install.

## Risk
- Level: Low
- Why: no app code touched; jest flag order is semantically irrelevant to jest itself (no-arg selection verified identical); the new lint rule fires only on the exact hazard shape and passes the current repo file.
- Rollback: revert the commit; no data or deploy impact.

## Review Notes
- The array-option list in the linter is extracted from the installed jest-cli 30.4.2 bundle (`type: 'array'` options). `collectCoverageFrom` is string-type in Jest 30 and deliberately absent.
- The i18n integration branch still carries the old script line together with the old linter (a consistent pair), and its package.json edits don't touch the `test` line — its pre-PR rebase onto main picks both changes up without conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)