### PR TITLE
Fix chat-wave legacy-link crash: restore useSearchParams in useActiveWaveManager

### DIFF
--- a/__tests__/contexts/wave/hooks/useActiveWaveManager.test.tsx
+++ b/__tests__/contexts/wave/hooks/useActiveWaveManager.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useActiveWaveManager } from "@/contexts/wave/hooks/useActiveWaveManager";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 
 jest.mock("@/hooks/useDeviceInfo", () => ({
   __esModule: true,
@@ -18,22 +18,10 @@ jest.mock("next/navigation", () => ({
     replace: jest.fn(),
   })),
   usePathname: jest.fn(),
+  useSearchParams: jest.fn(),
 }));
 
 describe("useActiveWaveManager", () => {
-  const originalPushState = globalThis.history.pushState;
-  const originalReplaceState = globalThis.history.replaceState;
-
-  afterEach(() => {
-    globalThis.history.pushState = originalPushState;
-    globalThis.history.replaceState = originalReplaceState;
-    delete (
-      globalThis.window as Window & {
-        __locationStatePatch?: unknown;
-      }
-    ).__locationStatePatch;
-  });
-
   beforeEach(() => {
     jest.restoreAllMocks();
     globalThis.history.replaceState(null, "", "http://localhost/");
@@ -42,6 +30,7 @@ describe("useActiveWaveManager", () => {
   it("reads wave from pathname and updates via setActiveWave", async () => {
     globalThis.history.replaceState(null, "", "http://localhost/waves/abc");
     (usePathname as jest.Mock).mockReturnValue("/waves/abc");
+    (useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams({}));
 
     const pushStateSpy = jest.spyOn(globalThis.history, "pushState");
     const replaceStateSpy = jest.spyOn(globalThis.history, "replaceState");
@@ -57,6 +46,7 @@ describe("useActiveWaveManager", () => {
 
     globalThis.history.replaceState(null, "", "http://localhost/waves/def");
     (usePathname as jest.Mock).mockReturnValue("/waves/def");
+    (useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams({}));
     rerender();
     await waitFor(() => expect(result.current.activeWaveId).toBe("def"));
 
@@ -67,27 +57,10 @@ describe("useActiveWaveManager", () => {
     expect(pushStateSpy).toHaveBeenLastCalledWith(null, "", "/waves");
   });
 
-  it("updates active wave when query params change through pushState", async () => {
-    globalThis.history.replaceState(
-      null,
-      "",
-      "http://localhost/messages?wave=wave-1"
-    );
-    (usePathname as jest.Mock).mockReturnValue("/messages");
-
-    const { result } = renderHook(() => useActiveWaveManager());
-    await waitFor(() => expect(result.current.activeWaveId).toBe("wave-1"));
-
-    act(() => {
-      globalThis.history.pushState(null, "", "/messages?wave=wave-2");
-    });
-
-    await waitFor(() => expect(result.current.activeWaveId).toBe("wave-2"));
-  });
-
   it("includes serialNo when provided via options", async () => {
     globalThis.history.replaceState(null, "", "http://localhost/waves");
     (usePathname as jest.Mock).mockReturnValue("/waves");
+    (useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams({}));
 
     const pushStateSpy = jest.spyOn(globalThis.history, "pushState");
 
@@ -106,6 +79,7 @@ describe("useActiveWaveManager", () => {
   it("includes serialNo as string in URL", async () => {
     globalThis.history.replaceState(null, "", "http://localhost/waves");
     (usePathname as jest.Mock).mockReturnValue("/waves");
+    (useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams({}));
 
     const pushStateSpy = jest.spyOn(globalThis.history, "pushState");
 
@@ -119,39 +93,5 @@ describe("useActiveWaveManager", () => {
       "",
       "/waves/wave-xyz?serialNo=99"
     );
-  });
-
-  it("preserves history patches installed after subscription cleanup", () => {
-    globalThis.history.replaceState(
-      null,
-      "",
-      "http://localhost/messages?wave=wave-1"
-    );
-    (usePathname as jest.Mock).mockReturnValue("/messages");
-
-    const { unmount } = renderHook(() => useActiveWaveManager());
-    const activeWaveManagerPushState = globalThis.history.pushState;
-    const activeWaveManagerReplaceState = globalThis.history.replaceState;
-
-    const laterPushState = function laterPushState(
-      this: History,
-      ...args: Parameters<History["pushState"]>
-    ) {
-      return activeWaveManagerPushState.apply(this, args);
-    } as History["pushState"];
-    const laterReplaceState = function laterReplaceState(
-      this: History,
-      ...args: Parameters<History["replaceState"]>
-    ) {
-      return activeWaveManagerReplaceState.apply(this, args);
-    } as History["replaceState"];
-
-    globalThis.history.pushState = laterPushState;
-    globalThis.history.replaceState = laterReplaceState;
-
-    unmount();
-
-    expect(globalThis.history.pushState).toBe(laterPushState);
-    expect(globalThis.history.replaceState).toBe(laterReplaceState);
   });
 });

--- a/contexts/wave/hooks/useActiveWaveManager.ts
+++ b/contexts/wave/hooks/useActiveWaveManager.ts
@@ -7,27 +7,14 @@ import {
 } from "@/helpers/navigation.helpers";
 import { useClientNavigation } from "@/hooks/useClientNavigation";
 import useDeviceInfo from "@/hooks/useDeviceInfo";
-import { usePathname } from "next/navigation";
-import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { useCallback, useMemo } from "react";
 
 interface WaveNavigationOptions {
   isDirectMessage?: boolean | undefined;
   serialNo?: number | string | null | undefined;
   divider?: number | null | undefined;
 }
-
-const LOCATION_STATE_CHANGE_EVENT = "6529-location-state-change";
-type LocationStatePatch = {
-  subscribers: number;
-  originalPushState: History["pushState"];
-  originalReplaceState: History["replaceState"];
-  patchedPushState: History["pushState"];
-  patchedReplaceState: History["replaceState"];
-};
-
-type LocationStatePatchedWindow = Window & {
-  __locationStatePatch?: LocationStatePatch | undefined;
-};
 
 const getWaveFromWindow = (): string | null => {
   if (typeof window === "undefined") return null;
@@ -37,88 +24,6 @@ const getWaveFromWindow = (): string | null => {
     pathname: url.pathname,
     searchParams: url.searchParams,
   });
-};
-
-const getLocationSearch = (): string => globalThis.window?.location.search ?? "";
-
-const ensureLocationStateEvents = (
-  browserWindow: Window
-): (() => void) => {
-  const patchedWindow = browserWindow as LocationStatePatchedWindow;
-  let patch = patchedWindow.__locationStatePatch;
-  if (!patch) {
-    const originalPushState = browserWindow.history.pushState;
-    const originalReplaceState = browserWindow.history.replaceState;
-    const patchedPushState = function patchedPushState(
-      this: History,
-      ...args: Parameters<History["pushState"]>
-    ) {
-      const result = originalPushState.apply(this, args);
-      browserWindow.dispatchEvent(new Event(LOCATION_STATE_CHANGE_EVENT));
-      return result;
-    } as History["pushState"];
-    const patchedReplaceState = function patchedReplaceState(
-      this: History,
-      ...args: Parameters<History["replaceState"]>
-    ) {
-      const result = originalReplaceState.apply(this, args);
-      browserWindow.dispatchEvent(new Event(LOCATION_STATE_CHANGE_EVENT));
-      return result;
-    } as History["replaceState"];
-
-    patch = {
-      subscribers: 0,
-      originalPushState,
-      originalReplaceState,
-      patchedPushState,
-      patchedReplaceState,
-    };
-    patchedWindow.__locationStatePatch = patch;
-
-    browserWindow.history.pushState = patchedPushState;
-    browserWindow.history.replaceState = patchedReplaceState;
-  }
-
-  patch.subscribers += 1;
-
-  return () => {
-    const patch = patchedWindow.__locationStatePatch;
-    if (!patch) {
-      return;
-    }
-
-    patch.subscribers -= 1;
-    if (patch.subscribers > 0) {
-      return;
-    }
-
-    if (browserWindow.history.pushState === patch.patchedPushState) {
-      browserWindow.history.pushState = patch.originalPushState;
-    }
-    if (browserWindow.history.replaceState === patch.patchedReplaceState) {
-      browserWindow.history.replaceState = patch.originalReplaceState;
-    }
-    delete patchedWindow.__locationStatePatch;
-  };
-};
-
-const subscribeLocationSearch = (onStoreChange: () => void): (() => void) => {
-  const browserWindow = globalThis.window;
-  if (browserWindow === undefined) {
-    return () => undefined;
-  }
-
-  const cleanupLocationStateEvents = ensureLocationStateEvents(browserWindow);
-  browserWindow.addEventListener("popstate", onStoreChange);
-  browserWindow.addEventListener(LOCATION_STATE_CHANGE_EVENT, onStoreChange);
-  return () => {
-    browserWindow.removeEventListener("popstate", onStoreChange);
-    browserWindow.removeEventListener(
-      LOCATION_STATE_CHANGE_EVENT,
-      onStoreChange
-    );
-    cleanupLocationStateEvents();
-  };
 };
 
 const getRouteContext = (): { isOnWaves: boolean; isOnMessages: boolean } => {
@@ -135,12 +40,7 @@ const getRouteContext = (): { isOnWaves: boolean; isOnMessages: boolean } => {
 
 export function useActiveWaveManager() {
   const pathname = usePathname();
-  const search = useSyncExternalStore(
-    subscribeLocationSearch,
-    getLocationSearch,
-    () => ""
-  );
-  const searchParams = useMemo(() => new URLSearchParams(search), [search]);
+  const searchParams = useSearchParams();
   const { isApp } = useDeviceInfo();
 
   const waveFromLocation = useMemo(


### PR DESCRIPTION
## Incident (second regression from today's deploys)

Following a stale legacy link `6529.io/waves?wave=<id>` into a **chat-type wave** (reproduced with Announcements, `da16201a`) crashes to the "This page couldn't load" error boundary on **all viewports**, ~0.9s after load — React #310 "Rendered more hooks than during the previous render", thrown at **Next's app Router's own `useMemo`** (identified by extracting the minified frame `I` from the production chunk: it's the Router — `useActionQueue`/`canonicalUrl` internals). Direct `/waves/<id>` loads (with or without `serialNo`), the waves list, and in-app clicks are all unaffected. Published as a known issue in the 4.76.1 release notes; this PR is the promised fix.

Distinct from the #3170 crash reverted in #3184 — that one hit the spec-covered regular-wave flow; this one only triggers on the server-`redirect()` soft-nav into chat waves, which the staging E2E spec misses because its wave discovery draws from the regular-waves list region.

## Attribution (production-build bisect)

Local production builds + an 4-8-run crash probe per sha (the crash is timing-flaky; single runs lie). Shas that contain #3170 got its revert overlaid (`git revert --no-commit -m 1 f5577ca87`) so the two same-symptom bugs don't confound:

| sha (+overlay where applicable) | contains | result |
|---|---|---|
| `61a3691f1` (pre-window base) | — | clean 4/4 |
| `f4f98b34f` | ...through #3174 | clean 4/4 |
| `663887b91` | + #3171, #3175 | clean 4/4 |
| `8aa1d8453` | + #3143, #3179, #3176, **#3173** | **crash 4/4** |
| prod `499f3977c` | everything | crash 5/5 |

#3143/#3179/#3176 are non-runtime (CI, package.json script, ops tooling) — **#3173 is the only runtime change in the guilty range**.

## Mechanism and fix

#3173 replaced `useSearchParams` in `useActiveWaveManager` with a `useSyncExternalStore` over **monkey-patched `history.pushState`/`replaceState`**. Next's Router calls those methods during its own render/commit work — e.g. reconciling the `redirect()` target from `app/waves/page.tsx`'s legacy-link handler — and the store's snapshot/notification interplay re-enters React mid-render, corrupting the Router's hook bookkeeping.

Two fixes were tested against production builds:

- **Deferring the patched dispatch to a coalesced macrotask: still crashes 4/4.** The re-entrancy isn't only the synchronous event — React's own render-phase store-consistency check over the changing `location.search` snapshot appears sufficient to trigger it.
- **Restoring the `useSearchParams` implementation (this PR): 0/8 crash runs**, plus 6/6 clean on an earlier equivalent build. Restores the exact pre-#3173 file and test (the `hasActiveWaveDropTarget` API from #3168 is retained — it predates #3173). Net −160 lines; everything else in #3173 (wallet startup gate, navigation history, i18n) is untouched.

Unit suite passes (3/3). If the `useSearchParams`→store swap in #3173 was motivated by the Suspense/CSR-bailout lint rule, that need should be re-approached with a Suspense boundary rather than history patching — happy to help design it (cc @simo6529).

## Post-merge plan

Deploy train immediately after merge (staging → E2E → prod), verify the repro is clean against production, then a follow-up release note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the app responds to changes in the page URL, making active wave state update more reliably.
  * Preserved existing URL-based wave behavior, including handling of serial numbers, while simplifying navigation tracking.
* **Tests**
  * Updated automated coverage to match the new URL handling behavior and remove outdated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->