### PR TITLE
Suppress stale drop reaction not-found warnings

### DIFF
--- a/__tests__/utils/monitoring/dropReactionMonitoring.test.ts
+++ b/__tests__/utils/monitoring/dropReactionMonitoring.test.ts
@@ -214,6 +214,113 @@ describe("dropReactionMonitoring", () => {
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });
 
+  it("breadcrumbs stale drop-not-found reaction failures without capturing an exception", () => {
+    const mutation = beginReactionMutation({
+      dropId: "drop-stale",
+      waveId: "wave-1",
+      source: "quick-react",
+      action: "add",
+      previousReaction: null,
+      intendedReaction: ":smile:",
+      optimisticReaction: ":smile:",
+      profileId: "profile-1",
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+
+    recordReactionRequestSent(mutation, {
+      endpoint: "drops/drop-stale/reaction",
+      method: "POST",
+    });
+
+    const error = Object.assign(new Error("Drop drop-stale not found"), {
+      status: 404,
+      response: {
+        status: 404,
+      },
+    });
+
+    dateNowSpy.mockReturnValue(1_200);
+    const result = recordReactionRequestFailed(mutation, error);
+
+    expect(result).toEqual({
+      isLatestMutation: true,
+      supersededByMutationId: null,
+    });
+    expect(addBreadcrumbMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "reaction.request_failed",
+        data: expect.objectContaining({
+          status_code: 404,
+          error_kind: "endpoint-contract",
+          error_message: "Drop drop-stale not found",
+        }),
+      })
+    );
+    expect(addBreadcrumbMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "reaction.stale_drop_not_found",
+        data: expect.objectContaining({
+          status_code: 404,
+          error_kind: "endpoint-contract",
+          error_message: "Drop drop-stale not found",
+          captured: false,
+        }),
+      })
+    );
+    expect(withScopeMock).not.toHaveBeenCalled();
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+
+    dateNowSpy.mockReturnValue(20_000);
+    expect(
+      recordReactionRealtimeReconciliation({
+        drop: {
+          id: "drop-stale",
+          wave: { id: "wave-1" },
+          context_profile_context: {
+            reaction: null,
+          } as any,
+        },
+        websocketStatus: WebSocketStatus.CONNECTED,
+      })
+    ).toEqual({
+      shouldApplyCanonicalDrop: true,
+      expectedReaction: null,
+      serverReaction: null,
+    });
+  });
+
+  it("captures non-matching endpoint-contract reaction failures", () => {
+    const mutation = beginReactionMutation({
+      dropId: "drop-contract",
+      waveId: "wave-1",
+      source: "quick-react",
+      action: "add",
+      previousReaction: null,
+      intendedReaction: ":smile:",
+      optimisticReaction: ":smile:",
+      profileId: "profile-1",
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+
+    recordReactionRequestSent(mutation, {
+      endpoint: "drops/drop-contract/reaction",
+      method: "POST",
+    });
+
+    const error = Object.assign(new Error("Reaction endpoint not found"), {
+      status: 404,
+      response: {
+        status: 404,
+      },
+    });
+
+    dateNowSpy.mockReturnValue(1_200);
+    recordReactionRequestFailed(mutation, error);
+
+    expect(withScopeMock).toHaveBeenCalled();
+    expect(captureExceptionMock).toHaveBeenCalledWith(error);
+  });
+
   it("breadcrumbs an older success as superseded without capturing an issue", () => {
     const olderMutation = beginReactionMutation({
       dropId: "drop-3",

--- a/utils/monitoring/dropReactionMonitoring.ts
+++ b/utils/monitoring/dropReactionMonitoring.ts
@@ -310,6 +310,8 @@ function isExpectedStaleDropNotFoundError({
   readonly errorMessage: string;
   readonly statusCode: number | null;
 }): boolean {
+  // Intentionally exact: if the backend changes this stale-drop 404 shape,
+  // capture resumes so we can re-evaluate the contract.
   return (
     statusCode === 404 &&
     context.endpoint === `drops/${context.dropId}/reaction` &&
@@ -533,7 +535,7 @@ export function recordReactionRequestFailed(
       "reaction.stale_drop_not_found",
       context,
       {
-        status_code: statusCode,
+        status_code: statusCode ?? undefined,
         latency_ms: latencyMs,
         error_kind: errorKind,
         error_message: errorMessage,

--- a/utils/monitoring/dropReactionMonitoring.ts
+++ b/utils/monitoring/dropReactionMonitoring.ts
@@ -301,6 +301,22 @@ function classifyReactionError(error: unknown): {
   return { statusCode, errorKind: "server" };
 }
 
+function isExpectedStaleDropNotFoundError({
+  context,
+  errorMessage,
+  statusCode,
+}: {
+  readonly context: ReactionMutationContext;
+  readonly errorMessage: string;
+  readonly statusCode: number | null;
+}): boolean {
+  return (
+    statusCode === 404 &&
+    context.endpoint === `drops/${context.dropId}/reaction` &&
+    errorMessage === `Drop ${context.dropId} not found`
+  );
+}
+
 function captureReactionEvent({
   error,
   level,
@@ -502,6 +518,29 @@ export function recordReactionRequestFailed(
   }
 
   if (errorKind === "rate-limit") {
+    clearActiveIntentForContext(context);
+    return result;
+  }
+
+  if (
+    isExpectedStaleDropNotFoundError({
+      context,
+      errorMessage,
+      statusCode,
+    })
+  ) {
+    addReactionBreadcrumb(
+      "reaction.stale_drop_not_found",
+      context,
+      {
+        status_code: statusCode,
+        latency_ms: latencyMs,
+        error_kind: errorKind,
+        error_message: errorMessage,
+        captured: false,
+      },
+      "warning"
+    );
     clearActiveIntentForContext(context);
     return result;
   }


### PR DESCRIPTION
## Issue
- Fixes Sentry issue 6529-FRONTEND-AK.
- Production showed handled warning events for drop reaction requests where the API returned `404` with `Drop <id> not found` from `/waves` reaction flows.
- Recent events were latest reaction mutations with rollback/canonical-refresh handling already in place, so the remaining problem was noisy Sentry capture for an expected stale-data race.

## Fix
- Suppress Sentry exception capture only for the exact stale reaction condition: HTTP 404, reaction endpoint for the same drop, and message `Drop <dropId> not found`.
- Keep request-failure breadcrumbs and clear the active reaction intent so rollback, canonical refresh, and later realtime reconciliation continue to behave correctly.
- Leave non-matching endpoint-contract failures captured so real API contract issues still surface.

## Changes
- Added a narrow stale-drop-not-found predicate in `utils/monitoring/dropReactionMonitoring.ts`.
- Added monitoring tests for the suppressed stale-drop path and for a non-matching 404 that still captures.

## Validation
- `6529 run test -- __tests__/utils/monitoring/dropReactionMonitoring.test.ts`
- `6529 run lint:changed`
- `6529 run typecheck:changed` reported no changed TypeScript files to typecheck
- `6529 run react-doctor:diff`
- `6529 run typecheck:ci`
- `git diff --check`

## Risk
- Level: Low
- Why: The change only suppresses Sentry capture for an exact reaction 404 shape already handled by the UI flow; it does not change the API request, rollback, toast, or canonical refresh path.
- Rollback: Revert this commit to restore capture of stale reaction 404s.

## Review Notes
- Please focus on the suppression predicate narrowness. Non-matching 404 endpoint-contract failures remain captured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of reaction requests that fail with a 404 “Drop not found” response.
  * Added a specific stale-state breadcrumb and avoided unnecessary error capture for this expected case.
  * Preserved normal error reporting for other 404 reaction failures.
  * Realtime reconciliation now better recognizes stale reaction states and applies the canonical drop when appropriate.

* **Tests**
  * Expanded coverage for both stale drop-not-found and non-matching endpoint failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->