### PR TITLE
Fix Capacitor orientation mount updates

### DIFF
--- a/__tests__/hooks/useCapacitor.test.ts
+++ b/__tests__/hooks/useCapacitor.test.ts
@@ -87,4 +87,25 @@ describe("useCapacitor", () => {
     expect(result.current.orientation).toBe(0); // PORTRAIT
     expect(renderSpy).toHaveBeenCalledTimes(renderCountAfterInitialSync);
   });
+
+  it("initializes landscape orientation without a mount-time orientation update", async () => {
+    (window.matchMedia as jest.Mock).mockReturnValue({
+      matches: false,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+    });
+
+    const renderSpy = jest.fn();
+    const { result } = renderHook(() => {
+      renderSpy();
+      return useCapacitor();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isIos).toBe(true);
+    });
+
+    expect(result.current.orientation).toBe(1); // LANDSCAPE
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/hooks/useCapacitor.ts
+++ b/hooks/useCapacitor.ts
@@ -9,6 +9,22 @@ enum CapacitorOrientationType {
   LANDSCAPE,
 }
 
+function getCurrentOrientation(
+  isCapacitor: boolean
+): CapacitorOrientationType {
+  if (
+    !isCapacitor ||
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return CapacitorOrientationType.PORTRAIT;
+  }
+
+  return window.matchMedia("(orientation: portrait)").matches
+    ? CapacitorOrientationType.PORTRAIT
+    : CapacitorOrientationType.LANDSCAPE;
+}
+
 const useCapacitor = () => {
   const isCapacitor = Capacitor.isNativePlatform();
   const platform = Capacitor.getPlatform();
@@ -51,20 +67,15 @@ const useCapacitor = () => {
     };
   }, [isCapacitor]);
 
-  const [orientation, setOrientation] = useState<CapacitorOrientationType>(
-    CapacitorOrientationType.PORTRAIT
+  const [orientation, setOrientation] = useState<CapacitorOrientationType>(() =>
+    getCurrentOrientation(isCapacitor)
   );
 
   useEffect(() => {
     if (!isCapacitor) return;
 
-    const isPortrait = () =>
-      window.matchMedia("(orientation: portrait)").matches;
-
     const handleOrientationChange = () => {
-      const nextOrientation = isPortrait()
-        ? CapacitorOrientationType.PORTRAIT
-        : CapacitorOrientationType.LANDSCAPE;
+      const nextOrientation = getCurrentOrientation(isCapacitor);
 
       setOrientation((currentOrientation) =>
         currentOrientation === nextOrientation
@@ -72,8 +83,6 @@ const useCapacitor = () => {
           : nextOrientation
       );
     };
-
-    handleOrientationChange();
 
     window.addEventListener("orientationchange", handleOrientationChange);
 


### PR DESCRIPTION
## Issue
- Fixes Sentry issue `6529-FRONTEND-E6`: `Maximum update depth exceeded` on `/waves` in iOS WKWebView.
- The latest event showed React error #185 from the Capacitor orientation mount effect after many `useCapacitor` consumers were active on the page.

## Fix
- Initialize native orientation from `matchMedia` before the mount effect subscribes to `orientationchange`.
- Remove the immediate mount-effect orientation sync so many hook instances do not all schedule passive-effect state updates at once.
- Keep the existing equality guard for real `orientationchange` events.

## Changes
- Added a guarded `getCurrentOrientation()` helper in `useCapacitor`.
- Changed the orientation state initializer to read the current native orientation lazily.
- Added a regression test for initial landscape orientation without a mount-time rerender.

## Validation
- `./bin/6529 run test -- __tests__/hooks/useCapacitor.test.ts`
- `./bin/6529 exec eslint --no-warn-ignored --max-warnings=0 hooks/useCapacitor.ts __tests__/hooks/useCapacitor.test.ts`
- `./bin/6529 run typecheck:ci`
- `./bin/6529 exec react-doctor . --project 6529seize --verbose --offline --diff=origin/main`
- `git diff --check origin/main...HEAD`

## Risk
- Level: Low
- Why: Scoped to the Capacitor hook orientation path; app-state listener behavior is unchanged.
- Rollback: Revert this commit to restore the previous mount-effect orientation sync.

## Review Notes
- Focus on whether skipping the immediate mount-effect orientation sync is acceptable now that initial orientation is read before subscribing.