### PR TITLE
Add session refresh rate limit backoff

### DIFF
--- a/__tests__/components/react-query-wrapper/utils/query-utils.test.ts
+++ b/__tests__/components/react-query-wrapper/utils/query-utils.test.ts
@@ -1,5 +1,7 @@
 import {
+  getDefaultQueryRetry,
   getWaveDropsInitialLimit,
+  isRateLimitQueryError,
   WAVE_DROPS_NATIVE_INITIAL_PARAMS,
   WAVE_DROPS_PARAMS,
 } from "@/components/react-query-wrapper/utils/query-utils";
@@ -16,5 +18,32 @@ describe("wave drop query params", () => {
     expect(WAVE_DROPS_NATIVE_INITIAL_PARAMS.limit).toBeLessThan(
       WAVE_DROPS_PARAMS.limit
     );
+  });
+});
+
+describe("default query retry policy", () => {
+  it("does not retry rate limit responses", () => {
+    const onRetryStopped = jest.fn();
+    const retryPolicy = getDefaultQueryRetry(onRetryStopped);
+
+    expect(retryPolicy.retry(0, { status: 429 })).toBe(false);
+
+    expect(onRetryStopped).toHaveBeenCalledTimes(1);
+  });
+
+  it("detects rate limits on nested response statuses", () => {
+    expect(isRateLimitQueryError({ response: { status: 429 } })).toBe(true);
+    expect(isRateLimitQueryError({ cause: { status: 429 } })).toBe(true);
+    expect(isRateLimitQueryError({ status: 500 })).toBe(false);
+  });
+
+  it("keeps retrying non-rate-limit failures until the default retry count", () => {
+    const onRetryStopped = jest.fn();
+    const retryPolicy = getDefaultQueryRetry(onRetryStopped);
+
+    expect(retryPolicy.retry(2, { status: 500 })).toBe(true);
+    expect(retryPolicy.retry(3, { status: 500 })).toBe(false);
+
+    expect(onRetryStopped).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/components/react-query-wrapper/utils/query-utils.test.ts
+++ b/__tests__/components/react-query-wrapper/utils/query-utils.test.ts
@@ -24,7 +24,7 @@ describe("wave drop query params", () => {
 describe("default query retry policy", () => {
   it("does not retry rate limit responses", () => {
     const onRetryStopped = jest.fn();
-    const retryPolicy = getDefaultQueryRetry(onRetryStopped);
+    const retryPolicy = getDefaultQueryRetry<unknown>(onRetryStopped);
 
     expect(retryPolicy.retry(0, { status: 429 })).toBe(false);
 
@@ -39,7 +39,7 @@ describe("default query retry policy", () => {
 
   it("keeps retrying non-rate-limit failures until the default retry count", () => {
     const onRetryStopped = jest.fn();
-    const retryPolicy = getDefaultQueryRetry(onRetryStopped);
+    const retryPolicy = getDefaultQueryRetry<unknown>(onRetryStopped);
 
     expect(retryPolicy.retry(2, { status: 500 })).toBe(true);
     expect(retryPolicy.retry(3, { status: 500 })).toBe(false);

--- a/__tests__/services/auth/session-v2.utils.test.ts
+++ b/__tests__/services/auth/session-v2.utils.test.ts
@@ -605,6 +605,62 @@ describe("session-v2.utils", () => {
     }
   });
 
+  it("short-circuits refresh retries for sixty seconds while rate limited", async () => {
+    jest.useFakeTimers();
+    const rateLimitError = Object.assign(new Error("Rate limit exceeded"), {
+      status: 429,
+      response: { status: 429 },
+    });
+    const sessionResponse = {
+      client_type: "web",
+      address: "0xabc",
+      role: null,
+      access_token: "access-token",
+      access_token_expires_at: "2026-06-10T00:00:00.000Z",
+    };
+    (commonApiPost as jest.Mock)
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValueOnce(sessionResponse);
+
+    try {
+      await expect(refreshSessionV2({ address: "0xabc" })).rejects.toBe(
+        rateLimitError
+      );
+      await expect(refreshSessionV2({ address: "0xABC" })).resolves.toBeNull();
+
+      await jest.advanceTimersByTimeAsync(59_000);
+      await expect(refreshSessionV2({ address: "0xABC" })).resolves.toBeNull();
+      expect(commonApiPost).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(1_000);
+      await expect(refreshSessionV2({ address: "0xABC" })).resolves.toBe(
+        sessionResponse
+      );
+
+      expect(commonApiPost).toHaveBeenCalledTimes(2);
+      expect(getTelemetryOutcomes(getSessionRefreshInfoTelemetry())).toEqual([
+        "started",
+        "cooldown_used_rate_limit",
+        "cooldown_used_rate_limit",
+        "started",
+        "success",
+      ]);
+      expect(getSessionRefreshWarnTelemetry()).toEqual([
+        expect.objectContaining({
+          client_type: "web",
+          auth_refresh_outcome: "backend_error",
+          outcome: "backend_error",
+          status_code: 429,
+          duration_bucket_ms: expect.any(String),
+        }),
+      ]);
+      expectNoSensitiveRefreshTelemetry(getSessionRefreshInfoTelemetry());
+      expectNoSensitiveRefreshTelemetry(getSessionRefreshWarnTelemetry());
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it("counts aborted refreshes without logging them as failures", async () => {
     const abortController = new AbortController();
     abortController.abort();

--- a/__tests__/services/auth/session-v2.utils.test.ts
+++ b/__tests__/services/auth/session-v2.utils.test.ts
@@ -609,7 +609,12 @@ describe("session-v2.utils", () => {
     jest.useFakeTimers();
     const rateLimitError = Object.assign(new Error("Rate limit exceeded"), {
       status: 429,
-      response: { status: 429 },
+      response: {
+        status: 429,
+        headers: new Headers({
+          "Retry-After": "1",
+        }),
+      },
     });
     const sessionResponse = {
       client_type: "web",

--- a/__tests__/services/auth/session-v2.utils.test.ts
+++ b/__tests__/services/auth/session-v2.utils.test.ts
@@ -514,13 +514,22 @@ describe("session-v2.utils", () => {
     expectNoSensitiveRefreshTelemetry(getSessionRefreshInfoTelemetry());
   });
 
-  it("blocks invalid web session refreshes until auth state changes", async () => {
+  it("blocks invalid web session refreshes until persisted auth clears the block", async () => {
     jest.useFakeTimers();
     const unauthorizedError = Object.assign(new Error("Unauthorized"), {
       status: 401,
       response: { status: 401 },
     });
-    (commonApiPost as jest.Mock).mockRejectedValueOnce(unauthorizedError);
+    const sessionResponse = {
+      client_type: "web",
+      address: "0xabc",
+      role: null,
+      access_token: "access-token",
+      access_token_expires_at: "2026-06-10T00:00:00.000Z",
+    };
+    (commonApiPost as jest.Mock)
+      .mockRejectedValueOnce(unauthorizedError)
+      .mockResolvedValueOnce(sessionResponse);
 
     try {
       await expect(refreshSessionV2({ address: "0xabc" })).resolves.toBeNull();
@@ -528,13 +537,21 @@ describe("session-v2.utils", () => {
 
       await jest.advanceTimersByTimeAsync(5 * 60 * 1000);
       await expect(refreshSessionV2({ address: "0xABC" })).resolves.toBeNull();
-
       expect(commonApiPost).toHaveBeenCalledTimes(1);
+
+      await expect(persistSessionResponse(sessionResponse)).resolves.toBe(true);
+      await expect(refreshSessionV2({ address: "0xABC" })).resolves.toBe(
+        sessionResponse
+      );
+      expect(commonApiPost).toHaveBeenCalledTimes(2);
+
       expect(getTelemetryOutcomes(getSessionRefreshInfoTelemetry())).toEqual([
         "started",
         "unauthorized",
         "cooldown_used_empty",
         "cooldown_used_empty",
+        "started",
+        "success",
       ]);
       expectNoSensitiveRefreshTelemetry(getSessionRefreshInfoTelemetry());
     } finally {

--- a/__tests__/services/auth/session-v2.utils.test.ts
+++ b/__tests__/services/auth/session-v2.utils.test.ts
@@ -514,23 +514,32 @@ describe("session-v2.utils", () => {
     expectNoSensitiveRefreshTelemetry(getSessionRefreshInfoTelemetry());
   });
 
-  it("cooldowns failed web refreshes for the same session context", async () => {
+  it("blocks invalid web session refreshes until auth state changes", async () => {
+    jest.useFakeTimers();
     const unauthorizedError = Object.assign(new Error("Unauthorized"), {
       status: 401,
       response: { status: 401 },
     });
     (commonApiPost as jest.Mock).mockRejectedValueOnce(unauthorizedError);
 
-    await expect(refreshSessionV2({ address: "0xabc" })).resolves.toBeNull();
-    await expect(refreshSessionV2({ address: "0xABC" })).resolves.toBeNull();
+    try {
+      await expect(refreshSessionV2({ address: "0xabc" })).resolves.toBeNull();
+      await expect(refreshSessionV2({ address: "0xABC" })).resolves.toBeNull();
 
-    expect(commonApiPost).toHaveBeenCalledTimes(1);
-    expect(getTelemetryOutcomes(getSessionRefreshInfoTelemetry())).toEqual([
-      "started",
-      "unauthorized",
-      "cooldown_used_empty",
-    ]);
-    expectNoSensitiveRefreshTelemetry(getSessionRefreshInfoTelemetry());
+      await jest.advanceTimersByTimeAsync(5 * 60 * 1000);
+      await expect(refreshSessionV2({ address: "0xABC" })).resolves.toBeNull();
+
+      expect(commonApiPost).toHaveBeenCalledTimes(1);
+      expect(getTelemetryOutcomes(getSessionRefreshInfoTelemetry())).toEqual([
+        "started",
+        "unauthorized",
+        "cooldown_used_empty",
+        "cooldown_used_empty",
+      ]);
+      expectNoSensitiveRefreshTelemetry(getSessionRefreshInfoTelemetry());
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it("clears a failed refresh cooldown after successful auth persistence", async () => {

--- a/components/react-query-wrapper/utils/query-utils.ts
+++ b/components/react-query-wrapper/utils/query-utils.ts
@@ -33,21 +33,6 @@ export const WAVE_LOGS_PARAMS = {
   limit: 20,
 };
 
-export const getDefaultQueryRetry = (errorCallback?: () => void) => {
-  return {
-    retry: (failureCount: number) => {
-      if (failureCount >= 3) {
-        errorCallback?.();
-        return false;
-      }
-      return true;
-    },
-    retryDelay: (failureCount: number) => {
-      return failureCount * 1000;
-    },
-  };
-};
-
 type QueryErrorWithStatus = {
   readonly status?: unknown;
   readonly response?: {
@@ -70,6 +55,29 @@ const getQueryErrorStatus = (error: unknown): number | null => {
     statusError.cause?.status;
 
   return typeof status === "number" ? status : null;
+};
+
+export const isRateLimitQueryError = (error: unknown): boolean => {
+  return getQueryErrorStatus(error) === 429;
+};
+
+export const getDefaultQueryRetry = (errorCallback?: () => void) => {
+  return {
+    retry: (failureCount: number, error: unknown) => {
+      if (isRateLimitQueryError(error)) {
+        errorCallback?.();
+        return false;
+      }
+      if (failureCount >= 3) {
+        errorCallback?.();
+        return false;
+      }
+      return true;
+    },
+    retryDelay: (failureCount: number) => {
+      return failureCount * 1000;
+    },
+  };
 };
 
 export const isUnauthorizedQueryError = (error: unknown): boolean => {

--- a/components/react-query-wrapper/utils/query-utils.ts
+++ b/components/react-query-wrapper/utils/query-utils.ts
@@ -61,9 +61,16 @@ export const isRateLimitQueryError = (error: unknown): boolean => {
   return getQueryErrorStatus(error) === 429;
 };
 
-export const getDefaultQueryRetry = (errorCallback?: () => void) => {
+type DefaultQueryRetryPolicy<TError> = {
+  readonly retry: (failureCount: number, error: TError) => boolean;
+  readonly retryDelay: (failureCount: number) => number;
+};
+
+export const getDefaultQueryRetry = <TError = Error>(
+  errorCallback?: () => void
+): DefaultQueryRetryPolicy<TError> => {
   return {
-    retry: (failureCount: number, error: unknown) => {
+    retry: (failureCount: number, error: TError) => {
       if (isRateLimitQueryError(error)) {
         errorCallback?.();
         return false;

--- a/hooks/useConnectedAccountsUnreadNotifications.ts
+++ b/hooks/useConnectedAccountsUnreadNotifications.ts
@@ -3,7 +3,10 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
-import { isUnauthorizedQueryError } from "@/components/react-query-wrapper/utils/query-utils";
+import {
+  isRateLimitQueryError,
+  isUnauthorizedQueryError,
+} from "@/components/react-query-wrapper/utils/query-utils";
 import type { ApiNotificationsResponseV2 } from "@/generated/models/ApiNotificationsResponseV2";
 import {
   isAuthJwtUsable,
@@ -254,6 +257,9 @@ export function useConnectedAccountsUnreadNotifications(
         return false;
       }
       if (isUnauthorizedQueryError(error)) {
+        return false;
+      }
+      if (isRateLimitQueryError(error)) {
         return false;
       }
 

--- a/hooks/useUnreadNotifications.ts
+++ b/hooks/useUnreadNotifications.ts
@@ -6,7 +6,10 @@ import type { ApiNotificationsResponseV2 } from "@/generated/models/ApiNotificat
 import { commonApiFetch } from "@/services/api/common-api";
 import useCapacitor from "./useCapacitor";
 import { QueryKey } from "@/components/react-query-wrapper/ReactQueryWrapper";
-import { isUnauthorizedQueryError } from "@/components/react-query-wrapper/utils/query-utils";
+import {
+  isRateLimitQueryError,
+  isUnauthorizedQueryError,
+} from "@/components/react-query-wrapper/utils/query-utils";
 import { getAuthJwt, isAuthJwtUsable } from "@/services/auth/auth.utils";
 import { getAuthTokenFingerprint } from "@/services/auth/auth-token-fingerprint";
 
@@ -115,6 +118,9 @@ export function useUnreadNotifications(
         return false;
       }
       if (isUnauthorizedQueryError(error)) {
+        return false;
+      }
+      if (isRateLimitQueryError(error)) {
         return false;
       }
 

--- a/services/auth/session-refresh-rate-limit.utils.ts
+++ b/services/auth/session-refresh-rate-limit.utils.ts
@@ -1,6 +1,6 @@
-const SESSION_REFRESH_EMPTY_FAILURE_COOLDOWN_MS = 2000;
 const SESSION_REFRESH_RETRY_COOLDOWN_MS = 250;
 const SESSION_REFRESH_RATE_LIMIT_COOLDOWN_MS = 60 * 1000;
+const SESSION_REFRESH_INVALID_SESSION_COOLDOWN_MS = Number.POSITIVE_INFINITY;
 
 export type SessionRefreshFailureCooldownType =
   | "empty"
@@ -37,7 +37,7 @@ export function getSessionRefreshFailureCooldownMs(
   }
 
   if (type === "empty") {
-    return SESSION_REFRESH_EMPTY_FAILURE_COOLDOWN_MS;
+    return SESSION_REFRESH_INVALID_SESSION_COOLDOWN_MS;
   }
 
   if (type === "rate_limit") {

--- a/services/auth/session-refresh-rate-limit.utils.ts
+++ b/services/auth/session-refresh-rate-limit.utils.ts
@@ -1,0 +1,88 @@
+const SESSION_REFRESH_EMPTY_FAILURE_COOLDOWN_MS = 2000;
+const SESSION_REFRESH_RETRY_COOLDOWN_MS = 250;
+const SESSION_REFRESH_RATE_LIMIT_COOLDOWN_MS = 60 * 1000;
+
+export type SessionRefreshFailureCooldownType =
+  | "empty"
+  | "retry"
+  | "rate_limit";
+
+type ApiStatusError = {
+  readonly status?: unknown;
+  readonly headers?: {
+    get(name: string): string | null;
+  };
+  readonly response?: {
+    readonly status?: unknown;
+    readonly headers?: {
+      get(name: string): string | null;
+    };
+  };
+};
+
+function getApiErrorStatus(error: unknown): number | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+
+  const statusError = error as ApiStatusError;
+  const status = statusError.status ?? statusError.response?.status;
+  return typeof status === "number" && Number.isInteger(status) ? status : null;
+}
+
+export function isRateLimitError(error: unknown): boolean {
+  return getApiErrorStatus(error) === 429;
+}
+
+export function getSessionRefreshFailureCooldownMs(
+  type: SessionRefreshFailureCooldownType,
+  cooldownMsOverride?: number
+): number {
+  if (cooldownMsOverride !== undefined) {
+    return cooldownMsOverride;
+  }
+
+  if (type === "empty") {
+    return SESSION_REFRESH_EMPTY_FAILURE_COOLDOWN_MS;
+  }
+
+  if (type === "rate_limit") {
+    return SESSION_REFRESH_RATE_LIMIT_COOLDOWN_MS;
+  }
+
+  return SESSION_REFRESH_RETRY_COOLDOWN_MS;
+}
+
+function getRetryAfterHeader(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+
+  const statusError = error as ApiStatusError;
+  return (
+    statusError.response?.headers?.get("Retry-After") ??
+    statusError.response?.headers?.get("retry-after") ??
+    statusError.headers?.get("Retry-After") ??
+    statusError.headers?.get("retry-after") ??
+    null
+  );
+}
+
+export function getRateLimitCooldownMs(error: unknown): number {
+  const retryAfter = getRetryAfterHeader(error);
+  if (!retryAfter) {
+    return SESSION_REFRESH_RATE_LIMIT_COOLDOWN_MS;
+  }
+
+  const retryAfterSeconds = Number(retryAfter);
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
+    return Math.max(1000, retryAfterSeconds * 1000);
+  }
+
+  const retryAfterDateMs = Date.parse(retryAfter);
+  if (Number.isFinite(retryAfterDateMs)) {
+    return Math.max(1000, retryAfterDateMs - Date.now());
+  }
+
+  return SESSION_REFRESH_RATE_LIMIT_COOLDOWN_MS;
+}

--- a/services/auth/session-refresh-rate-limit.utils.ts
+++ b/services/auth/session-refresh-rate-limit.utils.ts
@@ -9,14 +9,8 @@ export type SessionRefreshFailureCooldownType =
 
 type ApiStatusError = {
   readonly status?: unknown;
-  readonly headers?: {
-    get(name: string): string | null;
-  };
   readonly response?: {
     readonly status?: unknown;
-    readonly headers?: {
-      get(name: string): string | null;
-    };
   };
 };
 
@@ -53,36 +47,6 @@ export function getSessionRefreshFailureCooldownMs(
   return SESSION_REFRESH_RETRY_COOLDOWN_MS;
 }
 
-function getRetryAfterHeader(error: unknown): string | null {
-  if (typeof error !== "object" || error === null) {
-    return null;
-  }
-
-  const statusError = error as ApiStatusError;
-  return (
-    statusError.response?.headers?.get("Retry-After") ??
-    statusError.response?.headers?.get("retry-after") ??
-    statusError.headers?.get("Retry-After") ??
-    statusError.headers?.get("retry-after") ??
-    null
-  );
-}
-
-export function getRateLimitCooldownMs(error: unknown): number {
-  const retryAfter = getRetryAfterHeader(error);
-  if (!retryAfter) {
-    return SESSION_REFRESH_RATE_LIMIT_COOLDOWN_MS;
-  }
-
-  const retryAfterSeconds = Number(retryAfter);
-  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
-    return Math.max(1000, retryAfterSeconds * 1000);
-  }
-
-  const retryAfterDateMs = Date.parse(retryAfter);
-  if (Number.isFinite(retryAfterDateMs)) {
-    return Math.max(1000, retryAfterDateMs - Date.now());
-  }
-
+export function getRateLimitCooldownMs(): number {
   return SESSION_REFRESH_RATE_LIMIT_COOLDOWN_MS;
 }

--- a/services/auth/session-refresh-rate-limit.utils.ts
+++ b/services/auth/session-refresh-rate-limit.utils.ts
@@ -1,5 +1,6 @@
 const SESSION_REFRESH_RETRY_COOLDOWN_MS = 250;
 const SESSION_REFRESH_RATE_LIMIT_COOLDOWN_MS = 60 * 1000;
+// Invalid sessions require user action; successful auth persistence clears this block.
 const SESSION_REFRESH_INVALID_SESSION_COOLDOWN_MS = Number.POSITIVE_INFINITY;
 
 export type SessionRefreshFailureCooldownType =

--- a/services/auth/session-refresh-telemetry.utils.ts
+++ b/services/auth/session-refresh-telemetry.utils.ts
@@ -10,6 +10,7 @@ type SessionRefreshTelemetryOutcome =
   | "network_error"
   | "backend_error"
   | "cooldown_used_empty"
+  | "cooldown_used_rate_limit"
   | "cooldown_used_retry"
   | "deduped_in_flight";
 type SessionRefreshTelemetryAttrs = {

--- a/services/auth/session-v2.utils.ts
+++ b/services/auth/session-v2.utils.ts
@@ -539,7 +539,7 @@ export async function refreshSessionV2({
         rememberSessionRefreshFailure(
           key,
           "rate_limit",
-          getRateLimitCooldownMs(error)
+          getRateLimitCooldownMs()
         );
         return;
       }

--- a/services/auth/session-v2.utils.ts
+++ b/services/auth/session-v2.utils.ts
@@ -15,6 +15,12 @@ import {
   recordSessionRefreshOutcome,
   withSessionRefreshAbortTelemetry,
 } from "./session-refresh-telemetry.utils";
+import {
+  getRateLimitCooldownMs,
+  getSessionRefreshFailureCooldownMs,
+  isRateLimitError,
+  type SessionRefreshFailureCooldownType,
+} from "./session-refresh-rate-limit.utils";
 
 type AuthSessionClientType = "web" | "native" | "desktop";
 type RefreshTokenSessionClientType = Exclude<AuthSessionClientType, "web">;
@@ -47,15 +53,7 @@ interface SessionNativeResponse {
 
 type SessionLoginResponse = SessionWebResponse | SessionNativeResponse;
 type SessionRefreshResponse = SessionWebResponse | SessionNativeResponse;
-type SessionRefreshFailureCooldown =
-  | {
-      readonly type: "empty";
-      readonly expiresAtMs: number;
-    }
-  | {
-      readonly type: "retry";
-      readonly expiresAtMs: number;
-    };
+type SessionRefreshFailureCooldown = { readonly type: SessionRefreshFailureCooldownType; readonly expiresAtMs: number };
 type SessionRefreshInFlight = {
   readonly controller: AbortController;
   readonly promise: Promise<SessionRefreshResponse | null>;
@@ -94,8 +92,6 @@ interface NativeConnectionShareSourceProof {
   readonly native_refresh_token: string;
 }
 
-const SESSION_REFRESH_EMPTY_FAILURE_COOLDOWN_MS = 2000;
-const SESSION_REFRESH_RETRY_COOLDOWN_MS = 250;
 const sessionRefreshInFlight = new Map<string, SessionRefreshInFlight>();
 const sessionRefreshFailureCooldowns = new Map<
   string,
@@ -144,15 +140,14 @@ function getActiveFailureCooldown(
 
 function rememberSessionRefreshFailure(
   key: string,
-  type: SessionRefreshFailureCooldown["type"]
+  type: SessionRefreshFailureCooldownType,
+  cooldownMsOverride?: number
 ): void {
   sessionRefreshFailureCooldowns.set(key, {
     type,
     expiresAtMs:
       Date.now() +
-      (type === "empty"
-        ? SESSION_REFRESH_EMPTY_FAILURE_COOLDOWN_MS
-        : SESSION_REFRESH_RETRY_COOLDOWN_MS),
+      getSessionRefreshFailureCooldownMs(type, cooldownMsOverride),
   });
 }
 
@@ -467,10 +462,13 @@ export async function refreshSessionV2({
   const key = getSessionRefreshKey({ address, clientType });
   const cooldown = getActiveFailureCooldown(key);
 
-  if (cooldown?.type === "empty") {
+  if (cooldown?.type === "empty" || cooldown?.type === "rate_limit") {
     recordSessionRefreshOutcome({
       clientType,
-      outcome: "cooldown_used_empty",
+      outcome:
+        cooldown.type === "empty"
+          ? "cooldown_used_empty"
+          : "cooldown_used_rate_limit",
     });
     return null;
   }
@@ -535,6 +533,14 @@ export async function refreshSessionV2({
       rememberSessionRefreshFailure(key, "empty");
     } catch (error: unknown) {
       if (isAbortError(error)) {
+        return;
+      }
+      if (isRateLimitError(error)) {
+        rememberSessionRefreshFailure(
+          key,
+          "rate_limit",
+          getRateLimitCooldownMs(error)
+        );
         return;
       }
       rememberSessionRefreshFailure(key, "retry");


### PR DESCRIPTION
## Issue
- Browser clients can repeatedly retry `auth/session-refresh` after API/WAF `429` responses, which can amplify rate-limit incidents and push shared IPs deeper into WAF blocking.
- Several API polling queries also kept using the default retry policy for `429` responses.

## Fix
- Add a dedicated session-refresh rate-limit cooldown for structured `429` errors.
- Use `Retry-After` when present, with a 60-second fallback for WAF/no-header responses.
- Short-circuit subsequent refresh attempts during that cooldown without issuing another network request.

## Changes
- Added a `rate_limit` session refresh cooldown type and telemetry outcome.
- Stopped shared React Query retry behavior on `429` responses.
- Stopped unread-notification polling retries on `429`, including connected-account polling.
- Added focused unit coverage for session-refresh 429 cooldown behavior and query retry behavior.

## Validation
- `./bin/6529 run test --runInBand --forceExit --testPathPatterns=__tests__/services/auth/session-v2.utils.test.ts --testPathPatterns=__tests__/components/react-query-wrapper/utils/query-utils.test.ts`
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`

## Risk
- Level: Low
- Why: scoped client-side retry/backoff behavior; no API shape, generated model, config, or deployment changes.
- Rollback: revert this PR to restore the previous retry behavior.

## Review Notes
- Please focus on whether returning `null` during an active session-refresh rate-limit cooldown is the right auth behavior versus surfacing a distinct refresh outcome to callers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate-limit awareness across retry and session refresh flows, so 429 responses now stop retrying and trigger a cooldown.
  * Expanded telemetry to record when a cooldown is used after a rate-limit event.

* **Bug Fixes**
  * Prevented repeated refresh attempts during active cooldowns.
  * Improved retry handling so non-rate-limit failures still retry up to the standard limit, with callbacks firing as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->