### PR TITLE
Align debt ratchet report columns

### DIFF
--- a/__tests__/scripts/debt-ratchet.test.ts
+++ b/__tests__/scripts/debt-ratchet.test.ts
@@ -177,6 +177,17 @@ describe("debt-ratchet check mode", () => {
     const check = runRatchet(root);
     expect(check.status).toBe(0);
     expect(check.stdout).toContain("Debt ratchet passed.");
+
+    const reportLines = check.stdout.split("\n");
+    const anyCastsLine = reportLines.find((line) =>
+      line.startsWith("any_casts")
+    );
+    const legacyWordPressLine = reportLines.find((line) =>
+      line.startsWith("legacy_wordpress_runtime")
+    );
+    expect(anyCastsLine?.indexOf("baseline")).toBe(
+      legacyWordPressLine?.indexOf("baseline")
+    );
   });
 
   it("fails when a count rises above the baseline", () => {
@@ -293,11 +304,15 @@ describe("debt-ratchet check mode", () => {
     const check = runRatchet(root);
     expect(check.status).toBe(0);
     expect(check.stdout).toMatch(
-      /^oversized_files\s+baseline\s+2 actual\s+2\s+ok$/m
+      /^oversized_files\s+baseline\s+2\s+actual\s+2\s+ok$/m
     );
     expect(check.stdout).toMatch(/^\s+breakdown:$/m);
-    expect(check.stdout).toMatch(/^\s+app_source\s+baseline\s+1 actual\s+1$/m);
-    expect(check.stdout).toMatch(/^\s+wp_migrated\s+baseline\s+1 actual\s+1$/m);
+    expect(check.stdout).toMatch(
+      /^\s+app_source\s+baseline\s+1\s+actual\s+1$/m
+    );
+    expect(check.stdout).toMatch(
+      /^\s+wp_migrated\s+baseline\s+1\s+actual\s+1$/m
+    );
 
     const unfiltered = runRatchet(root, ["--details", "oversized_files"]);
     expect(unfiltered.status).toBe(0);

--- a/__tests__/scripts/debt-ratchet.test.ts
+++ b/__tests__/scripts/debt-ratchet.test.ts
@@ -185,6 +185,8 @@ describe("debt-ratchet check mode", () => {
     const legacyWordPressLine = reportLines.find((line) =>
       line.startsWith("legacy_wordpress_runtime")
     );
+    expect(anyCastsLine).toBeDefined();
+    expect(legacyWordPressLine).toBeDefined();
     expect(anyCastsLine?.indexOf("baseline")).toBe(
       legacyWordPressLine?.indexOf("baseline")
     );
@@ -268,9 +270,7 @@ describe("debt-ratchet check mode", () => {
 
     const check = runRatchet(root);
     expect(check.status).toBe(1);
-    expect(check.stderr).toContain(
-      "legacy_wordpress_runtime rose from 0 to 1"
-    );
+    expect(check.stderr).toContain("legacy_wordpress_runtime rose from 0 to 1");
   });
 
   it("prints per-file counts from --details", () => {

--- a/scripts/debt-ratchet.cjs
+++ b/scripts/debt-ratchet.cjs
@@ -581,12 +581,13 @@ function buildOversizedBreakdownRows(baseline, actuals) {
 
 function getReportColumnWidths(rows) {
   const dataRows = rows.filter((row) => row.kind !== "label");
+  const maxWidth = (selectValue) =>
+    Math.max(1, ...dataRows.map((row) => String(selectValue(row)).length));
+
   return {
-    metric: Math.max(...dataRows.map((row) => row.metric.length)),
-    baseline: Math.max(
-      ...dataRows.map((row) => String(row.baseline).length)
-    ),
-    actual: Math.max(...dataRows.map((row) => String(row.actual).length)),
+    metric: maxWidth((row) => row.metric),
+    baseline: maxWidth((row) => row.baseline),
+    actual: maxWidth((row) => row.actual),
   };
 }
 

--- a/scripts/debt-ratchet.cjs
+++ b/scripts/debt-ratchet.cjs
@@ -579,12 +579,24 @@ function buildOversizedBreakdownRows(baseline, actuals) {
   ];
 }
 
-function formatReportRow(row) {
+function getReportColumnWidths(rows) {
+  const dataRows = rows.filter((row) => row.kind !== "label");
+  return {
+    metric: Math.max(...dataRows.map((row) => row.metric.length)),
+    baseline: Math.max(
+      ...dataRows.map((row) => String(row.baseline).length)
+    ),
+    actual: Math.max(...dataRows.map((row) => String(row.actual).length)),
+  };
+}
+
+function formatReportRow(row, widths) {
   if (row.kind === "label") return row.metric;
 
   const countColumns =
-    `${row.metric.padEnd(20)} baseline ${String(row.baseline).padStart(5)} ` +
-    `actual ${String(row.actual).padStart(5)}`;
+    `${row.metric.padEnd(widths.metric)}  ` +
+    `baseline ${String(row.baseline).padStart(widths.baseline)}  ` +
+    `actual ${String(row.actual).padStart(widths.actual)}`;
   return row.status ? `${countColumns}  ${row.status}` : countColumns;
 }
 
@@ -655,8 +667,9 @@ function runCheck() {
   const reportRows = rows.flatMap((row) =>
     row.metric === "oversized_files" ? [row, ...oversizedBreakdownRows] : [row]
   );
+  const reportColumnWidths = getReportColumnWidths(reportRows);
   for (const row of reportRows) {
-    console.log(formatReportRow(row));
+    console.log(formatReportRow(row, reportColumnWidths));
   }
 
   for (const warning of warnings) {


### PR DESCRIPTION
## Issue
- The debt ratchet CLI report used a fixed-width metric column, so longer metric names such as `legacy_wordpress_runtime` pushed the `baseline` and `actual` columns out of alignment.

## Fix
- Compute report column widths from the rows being printed, then use those widths when formatting the terminal report.

## Changes
- Align the metric, baseline value, and actual value columns in `scripts/debt-ratchet.cjs`.
- Keep label rows such as `breakdown:` visually simple while aligning their child rows with the rest of the report.
- Add test coverage that verifies long metric names keep the `baseline` column aligned and update existing oversized-file breakdown expectations for the spacing change.

## Validation
- `./bin/6529 run debt:ratchet`
- `./bin/6529 run test --testPathPatterns=__tests__/scripts/debt-ratchet.test.ts`
- `./bin/6529 run check:changed`
- `git diff --check`

## Risk
- Level: Low
- Why: This only changes CLI/report formatting and related tests; ratchet counting and pass/fail behavior are unchanged.
- Rollback: Revert this PR to restore the previous fixed-width formatter.

## Review Notes
- Please focus on whether the terminal output remains readable for both normal metric rows and the `oversized_files` breakdown rows.