### PR TITLE
Make mobile chat follow the keyboard smoothly

### DIFF
--- a/__tests__/hooks/useNativeKeyboard.test.ts
+++ b/__tests__/hooks/useNativeKeyboard.test.ts
@@ -106,6 +106,12 @@ describe("useNativeKeyboard", () => {
     expect(result.current.isVisible).toBe(true);
     expect(result.current.keyboardHeight).toBe(320);
     expect(result.current.phase).toBe("showing");
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--native-keyboard-inset-bottom"
+      )
+    ).toBe("320px");
+    expect(document.documentElement.dataset.nativeKeyboardVisible).toBe("true");
 
     act(() => {
       listeners["keyboardDidShow"]?.({ keyboardHeight: 336 });
@@ -114,6 +120,57 @@ describe("useNativeKeyboard", () => {
     expect(result.current.isVisible).toBe(true);
     expect(result.current.keyboardHeight).toBe(336);
     expect(result.current.phase).toBe("visible");
+  });
+
+  it("publishes only the keyboard inset not already removed by layout viewport resize", async () => {
+    const originalInnerHeight = globalThis.innerHeight;
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+    Object.defineProperty(globalThis, "innerHeight", {
+      configurable: true,
+      value: 800,
+    });
+    window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    };
+    window.cancelAnimationFrame = jest.fn();
+
+    try {
+      await renderNativeKeyboardHook();
+
+      act(() => {
+        listeners["keyboardWillShow"]?.({ keyboardHeight: 320 });
+      });
+
+      expect(
+        document.documentElement.style.getPropertyValue(
+          "--native-keyboard-inset-bottom"
+        )
+      ).toBe("320px");
+
+      Object.defineProperty(globalThis, "innerHeight", {
+        configurable: true,
+        value: 600,
+      });
+
+      act(() => {
+        globalThis.dispatchEvent(new Event("resize"));
+      });
+
+      expect(
+        document.documentElement.style.getPropertyValue(
+          "--native-keyboard-inset-bottom"
+        )
+      ).toBe("120px");
+    } finally {
+      Object.defineProperty(globalThis, "innerHeight", {
+        configurable: true,
+        value: originalInnerHeight,
+      });
+      window.requestAnimationFrame = originalRequestAnimationFrame;
+      window.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
   });
 
   it("updates immediately on iOS keyboard will-hide and reconciles on did-hide", async () => {
@@ -129,9 +186,15 @@ describe("useNativeKeyboard", () => {
       listeners["keyboardWillHide"]?.();
     });
 
-    expect(result.current.isVisible).toBe(false);
+    expect(result.current.isVisible).toBe(true);
     expect(result.current.keyboardHeight).toBe(0);
     expect(result.current.phase).toBe("hiding");
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--native-keyboard-inset-bottom"
+      )
+    ).toBe("0px");
+    expect(document.documentElement.dataset.nativeKeyboardVisible).toBe("true");
 
     act(() => {
       listeners["keyboardDidHide"]?.();
@@ -140,6 +203,9 @@ describe("useNativeKeyboard", () => {
     expect(result.current.isVisible).toBe(false);
     expect(result.current.keyboardHeight).toBe(0);
     expect(result.current.phase).toBe("hidden");
+    expect(document.documentElement.dataset.nativeKeyboardVisible).toBe(
+      undefined
+    );
   });
 
   it("supports Android without iOS accessory bar calls", async () => {

--- a/__tests__/hooks/useNativeKeyboard.test.ts
+++ b/__tests__/hooks/useNativeKeyboard.test.ts
@@ -123,6 +123,7 @@ describe("useNativeKeyboard", () => {
   });
 
   it("publishes only the keyboard inset not already removed by layout viewport resize", async () => {
+    mockGetPlatform.mockReturnValue("android");
     const originalInnerHeight = globalThis.innerHeight;
     const originalRequestAnimationFrame = window.requestAnimationFrame;
     const originalCancelAnimationFrame = window.cancelAnimationFrame;
@@ -163,6 +164,52 @@ describe("useNativeKeyboard", () => {
           "--native-keyboard-inset-bottom"
         )
       ).toBe("120px");
+    } finally {
+      Object.defineProperty(globalThis, "innerHeight", {
+        configurable: true,
+        value: originalInnerHeight,
+      });
+      window.requestAnimationFrame = originalRequestAnimationFrame;
+      window.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+  });
+
+  it("keeps the native iOS inset authoritative while the keyboard opens", async () => {
+    const originalInnerHeight = globalThis.innerHeight;
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+    Object.defineProperty(globalThis, "innerHeight", {
+      configurable: true,
+      value: 800,
+    });
+    window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    };
+    window.cancelAnimationFrame = jest.fn();
+
+    try {
+      const { result } = await renderNativeKeyboardHook();
+
+      act(() => {
+        listeners["keyboardWillShow"]?.({ keyboardHeight: 320 });
+      });
+
+      Object.defineProperty(globalThis, "innerHeight", {
+        configurable: true,
+        value: 600,
+      });
+
+      act(() => {
+        globalThis.dispatchEvent(new Event("resize"));
+      });
+
+      expect(result.current.phase).toBe("showing");
+      expect(
+        document.documentElement.style.getPropertyValue(
+          "--native-keyboard-inset-bottom"
+        )
+      ).toBe("320px");
     } finally {
       Object.defineProperty(globalThis, "innerHeight", {
         configurable: true,

--- a/components/brain/my-stream/MyStreamWaveChat.tsx
+++ b/components/brain/my-stream/MyStreamWaveChat.tsx
@@ -116,6 +116,8 @@ interface WaveLeaderboardCurationDropModalProps {
 }
 
 const MAX_UNSUPPORTED_FILE_NAMES_IN_TOAST = 3;
+const NATIVE_KEYBOARD_COMPOSER_BOTTOM_PADDING =
+  "var(--native-keyboard-composer-bottom-padding, max(env(safe-area-inset-bottom,0px), 0.5rem))";
 const noop = () => {};
 
 const WaveGallery = dynamic<WaveGalleryProps>(
@@ -308,6 +310,18 @@ const MyStreamWaveChat: React.FC<MyStreamWaveChatProps> = ({
 
     return `${baseStyles} ${heightClass}`;
   }, []);
+  const composerContainerClassName = isApp
+    ? "tw-mt-auto tw-bg-iron-950"
+    : "tw-mt-auto tw-bg-iron-950 tw-pb-[max(env(safe-area-inset-bottom,0px),0.5rem)] lg:tw-pb-0";
+  const composerContainerStyle = useMemo<React.CSSProperties | undefined>(
+    () =>
+      isApp
+        ? {
+            paddingBottom: NATIVE_KEYBOARD_COMPOSER_BOTTOM_PADDING,
+          }
+        : undefined,
+    [isApp]
+  );
 
   const onReply = (drop: ApiDrop, partId: number) => {
     setActiveDropForWave({
@@ -552,7 +566,10 @@ const MyStreamWaveChat: React.FC<MyStreamWaveChatProps> = ({
           isVotingControlsLocked={isVotingControlsLocked}
         />
         {!(isApp && editingDropId) && (
-          <div className="tw-mt-auto tw-bg-iron-950 tw-pb-[max(env(safe-area-inset-bottom,0px),0.5rem)] lg:tw-pb-0">
+          <div
+            className={composerContainerClassName}
+            style={composerContainerStyle}
+          >
             <CreateDropWaveWrapper>
               <PrivilegedDropCreator
                 activeDrop={activeDrop}

--- a/components/brain/my-stream/layout/LayoutContext.tsx
+++ b/components/brain/my-stream/layout/LayoutContext.tsx
@@ -49,13 +49,20 @@ const spacesAreEqual = (a: LayoutSpaces, b: LayoutSpaces) =>
   a.contentSpace === b.contentSpace &&
   a.measurementsComplete === b.measurementsComplete;
 
+const NATIVE_KEYBOARD_INSET = "var(--native-keyboard-inset-bottom, 0px)";
+const NATIVE_KEYBOARD_LAYOUT_TRANSITION_DURATION =
+  "var(--native-keyboard-layout-transition-duration, 0ms)";
+
+const formatCssLength = (value: number | string): string =>
+  typeof value === "number" ? `${value}px` : value;
+
 // Helper function to calculate height style
 const calculateHeightStyle = (
   spaces: LayoutSpaces,
-  capacitorSpace: number // Accept specific space value
+  bottomInset: number | string
 ): React.CSSProperties => {
   // Use dynamic viewport height to avoid extra space on mobile browsers
-  const heightCalc = `calc(100dvh - ${spaces.headerSpace}px - ${spaces.pinnedSpace}px - ${spaces.tabsSpace}px - ${spaces.spacerSpace}px - ${spaces.mobileTabsSpace}px - ${spaces.mobileNavSpace}px - ${capacitorSpace}px)`;
+  const heightCalc = `calc(100dvh - ${spaces.headerSpace}px - ${spaces.pinnedSpace}px - ${spaces.tabsSpace}px - ${spaces.spacerSpace}px - ${spaces.mobileTabsSpace}px - ${spaces.mobileNavSpace}px - ${formatCssLength(bottomInset)})`;
   return {
     height: heightCalc,
     maxHeight: heightCalc,
@@ -213,7 +220,7 @@ const LayoutContext = createContext<LayoutContextType>({
 export const LayoutProvider: React.FC<{ children: ReactNode }> = ({
   children,
 }) => {
-  const { isAndroid } = useCapacitor();
+  const { isCapacitor } = useCapacitor();
   const { isVisible: isKeyboardVisible } = useNativeKeyboard();
 
   // Internal ref storage (source of truth)
@@ -351,16 +358,19 @@ export const LayoutProvider: React.FC<{ children: ReactNode }> = ({
   }, [spaces, isNavHiddenForKeyboard]);
 
   const waveViewStyle = useMemo<React.CSSProperties>(() => {
-    const style = calculateHeightStyle(navAdjustedSpaces, 0);
+    const style = calculateHeightStyle(
+      navAdjustedSpaces,
+      isCapacitor ? NATIVE_KEYBOARD_INSET : 0
+    );
 
-    if (isAndroid) {
+    if (isCapacitor) {
       return {
         ...style,
-        transition: "height 75ms ease-out, max-height 75ms ease-out",
+        transition: `height ${NATIVE_KEYBOARD_LAYOUT_TRANSITION_DURATION} ease-out, max-height ${NATIVE_KEYBOARD_LAYOUT_TRANSITION_DURATION} ease-out`,
       };
     }
     return style;
-  }, [navAdjustedSpaces, isAndroid]);
+  }, [navAdjustedSpaces, isCapacitor]);
 
   const leaderboardViewStyle = useMemo<React.CSSProperties>(() => {
     return calculateHeightStyle(navAdjustedSpaces, 0);

--- a/components/providers/CapacitorSetup.tsx
+++ b/components/providers/CapacitorSetup.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import useCapacitor from "@/hooks/useCapacitor";
+import { Capacitor } from "@capacitor/core";
+import { Keyboard, KeyboardResize } from "@capacitor/keyboard";
 import { useEffect, useRef } from "react";
 
 export default function CapacitorSetup() {
-  const { isCapacitor } = useCapacitor();
+  const { isCapacitor, isIos } = useCapacitor();
   const originalViewport = useRef<string | null>(null);
 
   useEffect(() => {
@@ -44,6 +46,25 @@ export default function CapacitorSetup() {
       }
     };
   }, [isCapacitor]);
+
+  useEffect(() => {
+    if (!isCapacitor || !isIos || !Capacitor.isPluginAvailable("Keyboard")) {
+      return;
+    }
+
+    // The iOS plugin's native resize is delayed until after the keyboard
+    // animation; the app drives the chat inset itself for synchronized motion.
+    void (async () => {
+      try {
+        await Keyboard.setResizeMode({ mode: KeyboardResize.None });
+      } catch (error: unknown) {
+        console.error(
+          "[Capacitor Setup] Error setting keyboard resize mode:",
+          error
+        );
+      }
+    })();
+  }, [isCapacitor, isIos]);
 
   return null;
 }

--- a/components/waves/drop/SingleWaveDropChat.tsx
+++ b/components/waves/drop/SingleWaveDropChat.tsx
@@ -77,14 +77,20 @@ export const SingleWaveDropChat: React.FC<SingleWaveDropChatProps> = ({
   };
 
   React.useEffect(() => {
+    // Preserve the existing runtime fallback for partial wave payloads.
+    const eligibilityWave = wave as Partial<
+      Pick<ApiWave, "chat" | "participation" | "voting" | "wave">
+    >;
+
     updateEligibility(wave.id, {
       authenticated_user_eligible_to_chat:
-        wave.chat.authenticated_user_eligible,
+        eligibilityWave.chat?.authenticated_user_eligible ?? false,
       authenticated_user_eligible_to_vote:
-        wave.voting.authenticated_user_eligible,
+        eligibilityWave.voting?.authenticated_user_eligible ?? false,
       authenticated_user_eligible_to_participate:
-        wave.participation.authenticated_user_eligible,
-      authenticated_user_admin: wave.wave.authenticated_user_eligible_for_admin,
+        eligibilityWave.participation?.authenticated_user_eligible ?? false,
+      authenticated_user_admin:
+        eligibilityWave.wave?.authenticated_user_eligible_for_admin ?? false,
     });
   }, [updateEligibility, wave]);
 

--- a/components/waves/drop/SingleWaveDropChat.tsx
+++ b/components/waves/drop/SingleWaveDropChat.tsx
@@ -35,17 +35,21 @@ export const SingleWaveDropChat: React.FC<SingleWaveDropChatProps> = ({
   isVotingControlsLocked = false,
 }) => {
   const { isApp } = useDeviceInfo();
-  const { isVisible: isKeyboardVisible } = useNativeKeyboard();
+  const nativeKeyboard = useNativeKeyboard();
   const { updateEligibility } = useWaveEligibility();
+  const isKeyboardOccupyingViewport =
+    nativeKeyboard.isVisible ||
+    nativeKeyboard.phase === "hiding" ||
+    nativeKeyboard.keyboardHeight > 0;
 
   // Drop safe-area padding as soon as the native keyboard starts moving.
   const inputContainerStyle = useMemo(() => {
     return {
-      paddingBottom: isKeyboardVisible
+      paddingBottom: isKeyboardOccupyingViewport
         ? "0px"
         : "calc(env(safe-area-inset-bottom))",
     };
-  }, [isKeyboardVisible]);
+  }, [isKeyboardOccupyingViewport]);
 
   const [activeDrop, setActiveDrop] = useState<ActiveDropState | null>({
     action: ActiveDropAction.REPLY,
@@ -75,13 +79,12 @@ export const SingleWaveDropChat: React.FC<SingleWaveDropChatProps> = ({
   React.useEffect(() => {
     updateEligibility(wave.id, {
       authenticated_user_eligible_to_chat:
-        wave.chat?.authenticated_user_eligible ?? false,
+        wave.chat.authenticated_user_eligible,
       authenticated_user_eligible_to_vote:
-        wave.voting?.authenticated_user_eligible ?? false,
+        wave.voting.authenticated_user_eligible,
       authenticated_user_eligible_to_participate:
-        wave.participation?.authenticated_user_eligible ?? false,
-      authenticated_user_admin:
-        wave.wave?.authenticated_user_eligible_for_admin ?? false,
+        wave.participation.authenticated_user_eligible,
+      authenticated_user_admin: wave.wave.authenticated_user_eligible_for_admin,
     });
   }, [updateEligibility, wave]);
 

--- a/hooks/useNativeKeyboard.ts
+++ b/hooks/useNativeKeyboard.ts
@@ -36,6 +36,7 @@ let browserFallbackTeardown: (() => void) | null = null;
 let hiddenFallbackTimeout: ReturnType<typeof setTimeout> | null = null;
 let keyboardClosedViewportHeight = 0;
 let keyboardClosedLayoutViewportHeight = 0;
+let nativeKeyboardLifecycleActive = false;
 
 const KEYBOARD_INSET_CSS_VARIABLE = "--native-keyboard-inset-bottom";
 const KEYBOARD_LAYOUT_TRANSITION_DURATION_CSS_VARIABLE =
@@ -131,7 +132,7 @@ function normalizeKeyboardHeight(height: number | null | undefined): number {
 }
 
 function applyKeyboardLayoutVariables(
-  state: Pick<NativeKeyboardState, "keyboardHeight" | "phase">,
+  state: Pick<NativeKeyboardState, "keyboardHeight" | "phase" | "isAndroid">,
   transitionMs: number
 ): void {
   const documentRef = (globalThis as Partial<{ readonly document: Document }>)
@@ -142,7 +143,7 @@ function applyKeyboardLayoutVariables(
   }
 
   const keyboardHeight = normalizeKeyboardHeight(state.keyboardHeight);
-  const keyboardInset = getKeyboardLayoutInset(keyboardHeight);
+  const keyboardInset = getKeyboardLayoutInset(keyboardHeight, state.isAndroid);
   const isKeyboardActive = keyboardHeight > 0 || state.phase !== "hidden";
   documentElement.style.setProperty(
     KEYBOARD_INSET_CSS_VARIABLE,
@@ -212,7 +213,14 @@ function getLayoutViewportShrinkHeight(): number {
   return Math.max(0, keyboardClosedLayoutViewportHeight - layoutViewportHeight);
 }
 
-function getKeyboardLayoutInset(keyboardHeight: number): number {
+function getKeyboardLayoutInset(
+  keyboardHeight: number,
+  isAndroid: boolean
+): number {
+  if (!isAndroid) {
+    return normalizeKeyboardHeight(keyboardHeight);
+  }
+
   // Android WebViews can shrink the layout viewport themselves. Only publish
   // the keyboard overlap that has not already been removed from 100dvh.
   return normalizeKeyboardHeight(
@@ -253,15 +261,18 @@ function getViewportKeyboardHeight(): number {
 
   const visualViewportShrinkHeight =
     keyboardClosedViewportHeight > 0
-      ? keyboardClosedViewportHeight - visualViewportHeight
+      ? keyboardClosedViewportHeight -
+        visualViewport.offsetTop -
+        visualViewportHeight
       : 0;
   const windowHeight = typeof window !== "undefined" ? window.innerHeight : 0;
   const viewportBottomOverlap =
     windowHeight > 0
       ? windowHeight - visualViewport.offsetTop - visualViewportHeight
       : 0;
-  const unappliedViewportShrinkHeight =
-    visualViewportShrinkHeight - getLayoutViewportShrinkHeight();
+  const unappliedViewportShrinkHeight = currentState.isAndroid
+    ? visualViewportShrinkHeight - getLayoutViewportShrinkHeight()
+    : visualViewportShrinkHeight;
 
   // Use the closed-viewport shrink when available, but keep bottom overlap as
   // the first-focus/offsetTop fallback for WebViews that do not expose a stable
@@ -296,6 +307,7 @@ function hasEditableFocus(): boolean {
 
 function markKeyboardHiddenFromFallback(): void {
   clearHiddenFallbackTimeout();
+  nativeKeyboardLifecycleActive = false;
 
   if (!currentState.isVisible) {
     rememberKeyboardClosedViewportHeight();
@@ -311,6 +323,16 @@ function markKeyboardHiddenFromFallback(): void {
 }
 
 function syncKeyboardVisibilityFromViewport(): void {
+  // Native iOS will-events provide the final geometry before animation starts.
+  // Intermediate viewport frames must not replace that animation target.
+  if (
+    currentState.isIos &&
+    nativeKeyboardLifecycleActive &&
+    (currentState.phase === "showing" || currentState.phase === "hiding")
+  ) {
+    return;
+  }
+
   const viewportHeight = getViewportHeight();
   if (viewportHeight <= 0) {
     return;
@@ -462,6 +484,7 @@ async function removeListenerHandles(
 
 function teardownKeyboardListeners(): void {
   listenerSetupToken += 1;
+  nativeKeyboardLifecycleActive = false;
   browserFallbackTeardown?.();
 
   if (listenerHandles.length === 0) {
@@ -518,6 +541,7 @@ function ensureKeyboardListeners(): void {
       const handles = await Promise.all([
         Keyboard.addListener("keyboardWillShow", (info) => {
           const keyboardHeight = getKeyboardHeight(info);
+          nativeKeyboardLifecycleActive = keyboardHeight > 0;
           setKeyboardState(
             {
               isVisible: keyboardHeight > 0,
@@ -529,6 +553,7 @@ function ensureKeyboardListeners(): void {
         }),
         Keyboard.addListener("keyboardDidShow", (info) => {
           const keyboardHeight = getKeyboardHeight(info);
+          nativeKeyboardLifecycleActive = keyboardHeight > 0;
           setKeyboardState({
             isVisible: keyboardHeight > 0,
             keyboardHeight,
@@ -538,6 +563,7 @@ function ensureKeyboardListeners(): void {
         Keyboard.addListener("keyboardWillHide", () => {
           const wasKeyboardActive =
             currentState.isVisible || currentState.keyboardHeight > 0;
+          nativeKeyboardLifecycleActive = wasKeyboardActive;
           // willHide starts the native dismissal animation; target zero inset
           // now so the app layout travels down with the keyboard instead of
           // waiting for didHide.
@@ -551,6 +577,7 @@ function ensureKeyboardListeners(): void {
           );
         }),
         Keyboard.addListener("keyboardDidHide", () => {
+          nativeKeyboardLifecycleActive = false;
           setKeyboardState({
             isVisible: false,
             keyboardHeight: 0,
@@ -621,5 +648,6 @@ export function __resetNativeKeyboardForTests(): void {
   listenerSetupToken = 0;
   keyboardClosedViewportHeight = 0;
   keyboardClosedLayoutViewportHeight = 0;
+  nativeKeyboardLifecycleActive = false;
   resetKeyboardLayoutVariables();
 }

--- a/hooks/useNativeKeyboard.ts
+++ b/hooks/useNativeKeyboard.ts
@@ -263,6 +263,9 @@ function getViewportKeyboardHeight(): number {
   const unappliedViewportShrinkHeight =
     visualViewportShrinkHeight - getLayoutViewportShrinkHeight();
 
+  // Use the closed-viewport shrink when available, but keep bottom overlap as
+  // the first-focus/offsetTop fallback for WebViews that do not expose a stable
+  // pre-keyboard baseline.
   return normalizeKeyboardHeight(
     Math.max(unappliedViewportShrinkHeight, viewportBottomOverlap)
   );
@@ -535,6 +538,9 @@ function ensureKeyboardListeners(): void {
         Keyboard.addListener("keyboardWillHide", () => {
           const wasKeyboardActive =
             currentState.isVisible || currentState.keyboardHeight > 0;
+          // willHide starts the native dismissal animation; target zero inset
+          // now so the app layout travels down with the keyboard instead of
+          // waiting for didHide.
           setKeyboardState(
             {
               isVisible: wasKeyboardActive,

--- a/hooks/useNativeKeyboard.ts
+++ b/hooks/useNativeKeyboard.ts
@@ -35,7 +35,13 @@ let listenerSetupToken = 0;
 let browserFallbackTeardown: (() => void) | null = null;
 let hiddenFallbackTimeout: ReturnType<typeof setTimeout> | null = null;
 let keyboardClosedViewportHeight = 0;
+let keyboardClosedLayoutViewportHeight = 0;
 
+const KEYBOARD_INSET_CSS_VARIABLE = "--native-keyboard-inset-bottom";
+const KEYBOARD_LAYOUT_TRANSITION_DURATION_CSS_VARIABLE =
+  "--native-keyboard-layout-transition-duration";
+const KEYBOARD_EVENT_LAYOUT_TRANSITION_MS = 250;
+const VIEWPORT_KEYBOARD_HEIGHT_TOLERANCE_PX = 8;
 const VIEWPORT_KEYBOARD_CLOSED_TOLERANCE_PX = 24;
 const FOCUSOUT_KEYBOARD_HIDE_FALLBACK_MS = 180;
 
@@ -96,13 +102,17 @@ function setKeyboardState(
   keyboardState: Pick<
     NativeKeyboardState,
     "isVisible" | "keyboardHeight" | "phase"
-  >
+  >,
+  options: { readonly transitionMs?: number | undefined } = {}
 ): void {
-  emitState({
+  const nextState = {
     ...currentState,
     ...readPlatformState(),
     ...keyboardState,
-  });
+  };
+
+  applyKeyboardLayoutVariables(nextState, options.transitionMs ?? 0);
+  emitState(nextState);
 }
 
 function clearHiddenFallbackTimeout(): void {
@@ -112,6 +122,46 @@ function clearHiddenFallbackTimeout(): void {
 
   clearTimeout(hiddenFallbackTimeout);
   hiddenFallbackTimeout = null;
+}
+
+function normalizeKeyboardHeight(height: number | null | undefined): number {
+  return typeof height === "number" && Number.isFinite(height) && height > 0
+    ? Math.round(height)
+    : 0;
+}
+
+function applyKeyboardLayoutVariables(
+  state: Pick<NativeKeyboardState, "keyboardHeight" | "phase">,
+  transitionMs: number
+): void {
+  const documentRef = (globalThis as Partial<{ readonly document: Document }>)
+    .document;
+  const documentElement = documentRef?.documentElement;
+  if (documentElement === undefined) {
+    return;
+  }
+
+  const keyboardHeight = normalizeKeyboardHeight(state.keyboardHeight);
+  const keyboardInset = getKeyboardLayoutInset(keyboardHeight);
+  const isKeyboardActive = keyboardHeight > 0 || state.phase !== "hidden";
+  documentElement.style.setProperty(
+    KEYBOARD_INSET_CSS_VARIABLE,
+    `${keyboardInset}px`
+  );
+  documentElement.style.setProperty(
+    KEYBOARD_LAYOUT_TRANSITION_DURATION_CSS_VARIABLE,
+    `${Math.max(0, transitionMs)}ms`
+  );
+
+  if (isKeyboardActive) {
+    documentElement.dataset["nativeKeyboardVisible"] = "true";
+  } else {
+    delete documentElement.dataset["nativeKeyboardVisible"];
+  }
+}
+
+function resetKeyboardLayoutVariables(): void {
+  applyKeyboardLayoutVariables(defaultState, 0);
 }
 
 function getViewportHeight(): number {
@@ -138,13 +188,84 @@ function getViewportHeight(): number {
     : 0;
 }
 
+function getLayoutViewportHeight(): number {
+  const windowHeight = typeof window !== "undefined" ? window.innerHeight : 0;
+  if (
+    typeof windowHeight === "number" &&
+    Number.isFinite(windowHeight) &&
+    windowHeight > 0
+  ) {
+    return windowHeight;
+  }
+
+  return typeof document !== "undefined"
+    ? document.documentElement.clientHeight
+    : 0;
+}
+
+function getLayoutViewportShrinkHeight(): number {
+  const layoutViewportHeight = getLayoutViewportHeight();
+  if (keyboardClosedLayoutViewportHeight <= 0 || layoutViewportHeight <= 0) {
+    return 0;
+  }
+
+  return Math.max(0, keyboardClosedLayoutViewportHeight - layoutViewportHeight);
+}
+
+function getKeyboardLayoutInset(keyboardHeight: number): number {
+  // Android WebViews can shrink the layout viewport themselves. Only publish
+  // the keyboard overlap that has not already been removed from 100dvh.
+  return normalizeKeyboardHeight(
+    Math.max(0, keyboardHeight - getLayoutViewportShrinkHeight())
+  );
+}
+
 function rememberKeyboardClosedViewportHeight(): number {
   const viewportHeight = getViewportHeight();
   if (viewportHeight > 0) {
     keyboardClosedViewportHeight = viewportHeight;
   }
 
+  const layoutViewportHeight = getLayoutViewportHeight();
+  if (layoutViewportHeight > 0) {
+    keyboardClosedLayoutViewportHeight = layoutViewportHeight;
+  }
+
   return viewportHeight;
+}
+
+function getViewportKeyboardHeight(): number {
+  const visualViewport = (
+    globalThis as Partial<{ readonly visualViewport: VisualViewport }>
+  ).visualViewport;
+  if (visualViewport === undefined) {
+    return 0;
+  }
+
+  const visualViewportHeight = visualViewport.height;
+  if (
+    typeof visualViewportHeight !== "number" ||
+    !Number.isFinite(visualViewportHeight) ||
+    visualViewportHeight <= 0
+  ) {
+    return 0;
+  }
+
+  const visualViewportShrinkHeight =
+    keyboardClosedViewportHeight > 0
+      ? keyboardClosedViewportHeight - visualViewportHeight
+      : 0;
+  const windowHeight = typeof window !== "undefined" ? window.innerHeight : 0;
+  const viewportBottomOverlap =
+    windowHeight > 0
+      ? windowHeight - visualViewport.offsetTop - visualViewportHeight
+      : 0;
+  const unappliedViewportShrinkHeight =
+    visualViewportShrinkHeight - getLayoutViewportShrinkHeight();
+
+  return normalizeKeyboardHeight(
+    Math.max(unappliedViewportShrinkHeight, viewportBottomOverlap)
+  );
 }
 
 function isEditableElement(element: Element | null): boolean {
@@ -192,6 +313,21 @@ function syncKeyboardVisibilityFromViewport(): void {
     return;
   }
 
+  const viewportKeyboardHeight = getViewportKeyboardHeight();
+  if (viewportKeyboardHeight > VIEWPORT_KEYBOARD_HEIGHT_TOLERANCE_PX) {
+    clearHiddenFallbackTimeout();
+    setKeyboardState({
+      isVisible: true,
+      keyboardHeight: viewportKeyboardHeight,
+      phase: currentState.phase === "hidden" ? "showing" : currentState.phase,
+    });
+    return;
+  }
+
+  if (currentState.isVisible || currentState.phase !== "hidden") {
+    applyKeyboardLayoutVariables(currentState, 0);
+  }
+
   if (!currentState.isVisible) {
     rememberKeyboardClosedViewportHeight();
     return;
@@ -236,29 +372,43 @@ function setupBrowserKeyboardFallbackListeners(): void {
   }
 
   rememberKeyboardClosedViewportHeight();
+  let viewportAnimationFrame: number | null = null;
 
   const handleFocusIn = () => {
     clearHiddenFallbackTimeout();
+    if (!currentState.isVisible) {
+      rememberKeyboardClosedViewportHeight();
+    }
   };
   const handleFocusOut = () => {
     scheduleFocusoutKeyboardHideFallback();
   };
   const handleViewportChange = () => {
-    syncKeyboardVisibilityFromViewport();
+    if (viewportAnimationFrame !== null) {
+      return;
+    }
+
+    viewportAnimationFrame = windowRef.requestAnimationFrame(() => {
+      viewportAnimationFrame = null;
+      syncKeyboardVisibilityFromViewport();
+    });
   };
   const handleVisibilityChange = () => {
     if (documentRef.visibilityState === "hidden") {
       markKeyboardHiddenFromFallback();
+      return;
     }
+
+    handleViewportChange();
   };
 
   documentRef.addEventListener("focusin", handleFocusIn, true);
   documentRef.addEventListener("focusout", handleFocusOut, true);
-  documentRef.addEventListener(
-    "visibilitychange",
-    handleVisibilityChange
-  );
+  documentRef.addEventListener("visibilitychange", handleVisibilityChange);
   windowRef.addEventListener("resize", handleViewportChange, {
+    passive: true,
+  });
+  windowRef.addEventListener("orientationchange", handleViewportChange, {
     passive: true,
   });
   globalThis.visualViewport?.addEventListener("resize", handleViewportChange, {
@@ -270,10 +420,15 @@ function setupBrowserKeyboardFallbackListeners(): void {
 
   browserFallbackTeardown = () => {
     clearHiddenFallbackTimeout();
+    if (viewportAnimationFrame !== null) {
+      windowRef.cancelAnimationFrame(viewportAnimationFrame);
+      viewportAnimationFrame = null;
+    }
     documentRef.removeEventListener("focusin", handleFocusIn, true);
     documentRef.removeEventListener("focusout", handleFocusOut, true);
     documentRef.removeEventListener("visibilitychange", handleVisibilityChange);
     windowRef.removeEventListener("resize", handleViewportChange);
+    windowRef.removeEventListener("orientationchange", handleViewportChange);
     globalThis.visualViewport?.removeEventListener(
       "resize",
       handleViewportChange
@@ -287,12 +442,7 @@ function setupBrowserKeyboardFallbackListeners(): void {
 }
 
 function getKeyboardHeight(info?: { keyboardHeight?: number | null }): number {
-  const height = info?.keyboardHeight;
-
-  // Keep missing heights as 0 for now; current consumers only key off visibility.
-  return typeof height === "number" && Number.isFinite(height) && height > 0
-    ? height
-    : 0;
+  return normalizeKeyboardHeight(info?.keyboardHeight);
 }
 
 async function removeListenerHandles(
@@ -364,25 +514,35 @@ function ensureKeyboardListeners(): void {
 
       const handles = await Promise.all([
         Keyboard.addListener("keyboardWillShow", (info) => {
-          setKeyboardState({
-            isVisible: true,
-            keyboardHeight: getKeyboardHeight(info),
-            phase: "showing",
-          });
+          const keyboardHeight = getKeyboardHeight(info);
+          setKeyboardState(
+            {
+              isVisible: keyboardHeight > 0,
+              keyboardHeight,
+              phase: keyboardHeight > 0 ? "showing" : "hidden",
+            },
+            { transitionMs: KEYBOARD_EVENT_LAYOUT_TRANSITION_MS }
+          );
         }),
         Keyboard.addListener("keyboardDidShow", (info) => {
+          const keyboardHeight = getKeyboardHeight(info);
           setKeyboardState({
-            isVisible: true,
-            keyboardHeight: getKeyboardHeight(info),
-            phase: "visible",
+            isVisible: keyboardHeight > 0,
+            keyboardHeight,
+            phase: keyboardHeight > 0 ? "visible" : "hidden",
           });
         }),
         Keyboard.addListener("keyboardWillHide", () => {
-          setKeyboardState({
-            isVisible: false,
-            keyboardHeight: 0,
-            phase: "hiding",
-          });
+          const wasKeyboardActive =
+            currentState.isVisible || currentState.keyboardHeight > 0;
+          setKeyboardState(
+            {
+              isVisible: wasKeyboardActive,
+              keyboardHeight: 0,
+              phase: wasKeyboardActive ? "hiding" : "hidden",
+            },
+            { transitionMs: KEYBOARD_EVENT_LAYOUT_TRANSITION_MS }
+          );
         }),
         Keyboard.addListener("keyboardDidHide", () => {
           setKeyboardState({
@@ -454,4 +614,6 @@ export function __resetNativeKeyboardForTests(): void {
   listenerSetupPromise = null;
   listenerSetupToken = 0;
   keyboardClosedViewportHeight = 0;
+  keyboardClosedLayoutViewportHeight = 0;
+  resetKeyboardLayoutVariables();
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -64,8 +64,17 @@
   /* Android keyboard height adjustments */
   :root {
     --android-keyboard-height: 0px;
+    --native-keyboard-inset-bottom: 0px;
+    --native-keyboard-layout-transition-duration: 0ms;
+    --native-keyboard-composer-bottom-padding: max(
+      env(safe-area-inset-bottom, 0px),
+      0.5rem
+    );
     --pull-to-refresh-fixed-overlay-offset: 0px;
     --pull-to-refresh-fixed-overlay-transition-duration: 0ms;
+  }
+  :root[data-native-keyboard-visible="true"] {
+    --native-keyboard-composer-bottom-padding: 0px;
   }
   [data-pull-to-refresh-transform-root="true"]
     [data-pull-to-refresh-fixed-overlay="true"] {


### PR DESCRIPTION
## Issue
- In the native Capacitor app, the wave chat composer lagged behind the iOS/Android keyboard animation, producing a visible second layout jump when the keyboard opened or closed.

## Fix
- Move native chat layout off delayed iOS WebView keyboard resizing and onto an app-owned keyboard inset that updates at keyboard event time.
- Apply that inset to the wave chat viewport height and composer safe-area padding so the message list and composer move as one unit with the keyboard.
- Avoid double-shrinking on Android by subtracting any layout viewport resize the WebView has already applied.

## Changes
- Set iOS Capacitor keyboard resize mode to `none` during native app setup.
- Extend `useNativeKeyboard` to publish CSS variables for keyboard inset, transition timing, and active keyboard state.
- Use the keyboard inset in the wave chat layout and native-app composer padding.
- Keep single-drop chat safe-area padding collapsed while the keyboard is hiding.
- Add focused hook coverage for keyboard CSS state and Android-style viewport shrink behavior.

## Validation
- `6529 run test --testPathPatterns=__tests__/hooks/useNativeKeyboard.test.ts --cacheDirectory=/private/tmp/jest-cache-native-keyboard`
- `6529 run lint:changed`
- `6529 run typecheck:changed`
- `6529 run check:changed`
- `6529 run react-doctor:diff` scanned the uncommitted source diff before commit and reported only existing/non-blocking warnings; after commit the script skipped because its diff base matched `HEAD`.

## Risk
- Level: Medium
- Why: Native keyboard handling affects a high-frequency mobile chat interaction across iOS and Android.
- Rollback: Revert this PR to return to the previous Capacitor/WebView resize behavior.

## Review Notes
- Please focus on native keyboard open/close, rapid focus/blur, rotation, safe-area devices, hardware keyboards, emoji picker interactions, multi-line composer growth, and preserving the reversed chat scroller’s newest-message position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved native keyboard handling on iOS and Android to keep layout/viewport sizing in sync.
  - Avoided incorrect keyboard inset re-application during viewport resize.
  - Preserved the correct composer/safe-area spacing across keyboard opening, hiding, and dismissal.
- **Enhancements**
  - Added smoother height and inset transitions tied to native keyboard resize behavior.
  - Improved orientation-change and resize reconciliation for more stable wave view sizing.
  - Updated keyboard resize mode when running on iOS via Capacitor when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->