### PR TITLE
Stabilize staging E2E read-only checks

### DIFF
--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -168,7 +168,14 @@ jobs:
             pack_artifacts="$artifact_root/$pack_slug"
             pack_log="$pack_artifacts/output.log"
             mkdir -p "$pack_artifacts"
-            rm -rf test-results playwright-report
+            if ! rm -rf test-results playwright-report; then
+              failed=1
+              echo "::error::Failed to clean previous Playwright output for $pack"
+              {
+                echo "- :warning: \`$pack\` cleanup failed before execution"
+                echo "  - Artifacts: \`$pack_artifacts/\`"
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
 
             if ./bin/6529 run "$pack" 2>&1 | tee "$pack_log"; then
               {
@@ -193,7 +200,14 @@ jobs:
 
             for path in test-results playwright-report; do
               if [ -e "$path" ]; then
-                cp -R "$path" "$pack_artifacts/"
+                if ! cp -R "$path" "$pack_artifacts/"; then
+                  failed=1
+                  echo "::error::Failed to preserve $path for $pack"
+                  {
+                    echo "- :warning: \`$pack\` artifact copy failed for \`$path\`"
+                    echo "  - Artifacts: \`$pack_artifacts/\`"
+                  } >> "$GITHUB_STEP_SUMMARY"
+                fi
               fi
             done
           done

--- a/.github/workflows/staging-e2e.yml
+++ b/.github/workflows/staging-e2e.yml
@@ -4,13 +4,35 @@ on:
   workflow_run:
     workflows: ["Web Deploy - STAGING"]
     types: [completed]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      pack:
+        description: Staging E2E pack to run
+        type: choice
+        required: true
+        default: all
+        options:
+          - all
+          - smoke
+          - core
+          - social-readonly
+          - public-groups-tools-readonly
+          - delegation-readonly
+          - collections-readonly
+          - admin-guards-readonly
+          - public-content-readonly
+          - profile-deep-links-readonly
+          - search-waves-readonly
+          - media-readonly
+          - network-open-data-readonly
 
 permissions:
   contents: read
 
 concurrency:
   group: staging-e2e
+  # Staging is a single mutable environment. Cancel superseded runs so an
+  # older deployed SHA does not keep testing after a newer staging deploy lands.
   cancel-in-progress: true
 
 jobs:
@@ -32,6 +54,7 @@ jobs:
     timeout-minutes: 90
     env:
       PLAYWRIGHT_STAGING_ACCESS_CODE: ${{ secrets.PLAYWRIGHT_STAGING_ACCESS_CODE }}
+      SELECTED_PACK: ${{ github.event.inputs.pack || 'all' }}
     steps:
       # workflow_run: the exact SHA the staging deploy shipped. Manual
       # dispatch falls back to the branch tip, which may differ from what is
@@ -88,27 +111,91 @@ jobs:
             test:e2e:staging:media-readonly
             test:e2e:staging:network-open-data-readonly
           )
+          selected_pack="${SELECTED_PACK:-all}"
+          case "$selected_pack" in
+            all)
+              ;;
+            smoke)
+              packs=(test:e2e:staging:smoke)
+              ;;
+            core)
+              packs=(test:e2e:staging)
+              ;;
+            social-readonly)
+              packs=(test:e2e:staging:social-readonly)
+              ;;
+            public-groups-tools-readonly)
+              packs=(test:e2e:staging:public-groups-tools-readonly)
+              ;;
+            delegation-readonly)
+              packs=(test:e2e:staging:delegation-readonly)
+              ;;
+            collections-readonly)
+              packs=(test:e2e:staging:collections-readonly)
+              ;;
+            admin-guards-readonly)
+              packs=(test:e2e:staging:admin-guards-readonly)
+              ;;
+            public-content-readonly)
+              packs=(test:e2e:staging:public-content-readonly)
+              ;;
+            profile-deep-links-readonly)
+              packs=(test:e2e:staging:profile-deep-links-readonly)
+              ;;
+            search-waves-readonly)
+              packs=(test:e2e:staging:search-waves-readonly)
+              ;;
+            media-readonly)
+              packs=(test:e2e:staging:media-readonly)
+              ;;
+            network-open-data-readonly)
+              packs=(test:e2e:staging:network-open-data-readonly)
+              ;;
+            *)
+              echo "::error::Unsupported staging E2E pack: $selected_pack"
+              exit 1
+              ;;
+          esac
+
+          artifact_root="staging-e2e-artifacts"
+          rm -rf "$artifact_root"
+          mkdir -p "$artifact_root"
           failed=0
           echo "## Staging E2E packs" >> "$GITHUB_STEP_SUMMARY"
+          echo "Selected pack: \`$selected_pack\`" >> "$GITHUB_STEP_SUMMARY"
           for pack in "${packs[@]}"; do
-            log="$(mktemp)"
-            if ./bin/6529 run "$pack" 2>&1 | tee "$log"; then
-              echo "- :white_check_mark: \`$pack\`" >> "$GITHUB_STEP_SUMMARY"
+            pack_slug="${pack//:/-}"
+            pack_artifacts="$artifact_root/$pack_slug"
+            pack_log="$pack_artifacts/output.log"
+            mkdir -p "$pack_artifacts"
+            rm -rf test-results playwright-report
+
+            if ./bin/6529 run "$pack" 2>&1 | tee "$pack_log"; then
+              {
+                echo "- :white_check_mark: \`$pack\`"
+                echo "  - Artifacts: \`$pack_artifacts/\`"
+              } >> "$GITHUB_STEP_SUMMARY"
             else
               failed=1
               {
                 echo "- :x: \`$pack\`"
+                echo "  - Artifacts: \`$pack_artifacts/\`"
                 echo ""
                 echo "<details><summary>Last 25 log lines for \`$pack\`</summary>"
                 echo ""
                 echo '```'
-                tail -25 "$log"
+                tail -25 "$pack_log"
                 echo '```'
                 echo ""
                 echo "</details>"
               } >> "$GITHUB_STEP_SUMMARY"
             fi
-            rm -f "$log"
+
+            for path in test-results playwright-report; do
+              if [ -e "$path" ]; then
+                cp -R "$path" "$pack_artifacts/"
+              fi
+            done
           done
           exit "$failed"
 
@@ -117,8 +204,6 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: staging-e2e-artifacts
-          path: |
-            test-results/
-            playwright-report/
+          path: staging-e2e-artifacts/
           retention-days: 7
           if-no-files-found: ignore

--- a/tests/content/public-content-readonly.spec.ts
+++ b/tests/content/public-content-readonly.spec.ts
@@ -88,8 +88,7 @@ const CONTENT_ROUTES: RouteExpectation[] = [
   },
   {
     path: "/author/ladysabrina/",
-    text: /ladysabrina/i,
-    links: ["/blog/from-fibonacci-to-fidenza/"],
+    text: "Sabrina Khan",
   },
 ];
 

--- a/tests/public-groups-tools/public-groups-tools-readonly.spec.ts
+++ b/tests/public-groups-tools/public-groups-tools-readonly.spec.ts
@@ -132,9 +132,9 @@ test.describe("Public groups, tools, and calendar read-only coverage @surface @m
       { timeout: 30000 }
     );
     await openGroupFilters(page);
-    await expect(
-      page.getByLabel(/^(By )?Group [Nn]ame$/).first()
-    ).toBeVisible({ timeout: 30000 });
+    await expect(page.getByLabel(/^(By )?Group [Nn]ame$/).first()).toBeVisible({
+      timeout: 30000,
+    });
     const groupsResponse = await groupsResponsePromise;
     const groupsPayload = (await groupsResponse.json()) as
       | { readonly id?: string; readonly name?: string }[]
@@ -150,16 +150,16 @@ test.describe("Public groups, tools, and calendar read-only coverage @surface @m
 
     // Deep-link the group: the URL param hydrates the active-group state.
     await gotoReady(page, `/network?group=${groupId}`);
-    await expect(page).toHaveURL((url) =>
-      url.searchParams.get("group") === groupId
+    await expect(page).toHaveURL(
+      (url) => url.searchParams.get("group") === groupId
     );
     await openGroupFilters(page);
 
     // The active-group block is required: "Members:" in the desktop sidebar,
     // "Active filter" in the mobile sheet.
-    await expect(
-      page.getByText(/Members:|Active filter/).first()
-    ).toBeVisible({ timeout: 30000 });
+    await expect(page.getByText(/Members:|Active filter/).first()).toBeVisible({
+      timeout: 30000,
+    });
 
     // Clearing the group exercises the state transition back to null and
     // must drop the URL param.
@@ -205,21 +205,17 @@ test.describe("Public groups, tools, and calendar read-only coverage @surface @m
     const pastDrops = page.getByTestId("subscriptions-report-past-drops");
     await expectAnyVisible(
       [
-        upcomingDrops.getByText(
-          "Table listing upcoming meme card subscriptions"
-        ),
-        upcomingDrops.getByText("No Subscriptions Found"),
+        upcomingDrops.getByRole("link", { name: /^View The Memes card #/ }),
+        upcomingDrops.getByText("No Subscriptions Found", { exact: true }),
       ],
-      "upcoming subscriptions table or empty state"
+      "upcoming subscription rows or empty state"
     );
     await expectAnyVisible(
       [
-        pastDrops.getByText(
-          "Table listing past meme card subscription redemptions"
-        ),
-        pastDrops.getByText("No Subscriptions Found"),
+        pastDrops.getByRole("link", { name: /^View The Memes card #/ }),
+        pastDrops.getByText("No Subscriptions Found", { exact: true }),
       ],
-      "past subscriptions table or empty state"
+      "past subscription rows or empty state"
     );
     await expect(
       page.getByRole("button", { name: /^Download$/ })

--- a/tests/social/search-waves-readonly.spec.ts
+++ b/tests/social/search-waves-readonly.spec.ts
@@ -420,15 +420,23 @@ test.describe("Search and wave-detail read-only coverage @surface @medium @large
           url.searchParams.get("wave") === expectedQueryWaveId)
     );
     await expect(searchInput).toHaveAttribute("placeholder", "Search messages");
-    await expect(page.getByText(/Type at least 2 characters/)).toBeVisible();
+    const minimumQueryMessage = page
+      .locator("#wave-drops-search-idle-status")
+      .getByText("Type at least 2 characters to search this wave.", {
+        exact: true,
+      });
+    await expect(minimumQueryMessage).toBeVisible();
 
     await searchInput.fill("x");
-    await expect(page.getByText(/Type at least 2 characters/)).toBeVisible();
+    await expect(minimumQueryMessage).toBeVisible();
 
     await searchInput.fill(UNMATCHABLE_WAVE_QUERY);
-    await expect(page.getByText("No matches found.")).toBeVisible({
-      timeout: NAVIGATION_TIMEOUT_MS,
-    });
+    await expect(searchInput).toHaveValue(UNMATCHABLE_WAVE_QUERY);
+    await expect(
+      page
+        .locator("#wave-drops-search-empty-status")
+        .getByText("No messages found", { exact: true })
+    ).toBeVisible({ timeout: NAVIGATION_TIMEOUT_MS });
 
     await page.getByRole("button", { name: "Clear search" }).click();
     await expect(searchInput).toHaveValue("");


### PR DESCRIPTION
## Summary
- Stabilize the failing read-only assertions for the subscriptions report, migrated Sabrina author page, and wave-search modal against deterministic UI states.
- Keep staging supersession cancellation and exact deployed-ref checkout intact while adding an allowlisted manual pack selector.
- Preserve each pack's Playwright output and log under a separate artifact folder so future failures expose the right screenshots/report instead of only the final pack.

## Root causes
- The workflow loop overwrote `test-results/` and `playwright-report/` on every pack, so uploaded artifacts only showed the last pack.
- The subscriptions report test expected stale table-label copy instead of the rendered rows or empty state.
- The `/author/ladysabrina/` fixture expected the old handle/link assumptions; the migrated page renders Sabrina Khan archive content without that link.
- The wave-search test used broad text locators that matched both screen-reader and visible helper copy, then expected header-search empty-state copy instead of the wave modal's empty status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manual staging end-to-end test execution with a selectable `pack` input (including an “all” option).
  * Improved organization of per-pack logs, reports, and uploaded artifacts.
* **Tests**
  * Strengthened read-only UI assertions across content, public groups, subscriptions, and wave message search.
  * Updated checks for exact empty-state text, idle/empty search status elements, filters, and link accessible names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->