### PR TITLE
Add distribution link for upcoming meme cards

### DIFF
--- a/components/distribution/Distribution.tsx
+++ b/components/distribution/Distribution.tsx
@@ -498,19 +498,19 @@ export default function DistributionPage(props: Readonly<Props>) {
             <Image
               unoptimized
               loading="eager"
-              width={72}
-              height={72}
-              className="tw-h-12 tw-w-auto tw-flex-shrink-0 sm:tw-h-14"
+              width={96}
+              height={96}
+              className="tw-h-20 tw-w-auto tw-flex-shrink-0"
               src="/SummerGlasses.svg"
               alt=""
               aria-hidden="true"
             />
             <div className="tw-min-w-0 tw-text-left tw-text-sm tw-font-medium tw-leading-6 tw-text-white sm:tw-text-base sm:tw-leading-7">
-              <p className="tw-mb-0">{t(locale, "distribution.empty.soon")}</p>
-              <p className="tw-mb-0">
+              <p className="tw-m-0">{t(locale, "distribution.empty.soon")}</p>
+              <p className="tw-m-0">
                 {t(locale, "distribution.empty.checkBack")}
               </p>
-              <p className="tw-mb-0">
+              <p className="tw-m-0">
                 <span>{t(locale, "distribution.empty.dropUpdates")}</span>{" "}
                 <a
                   href="https://x.com/6529Collections"

--- a/components/distribution/Distribution.tsx
+++ b/components/distribution/Distribution.tsx
@@ -128,12 +128,14 @@ export default function DistributionPage(props: Readonly<Props>) {
             distributionPhotosUrl
           );
           setDistributionPhotos(photos);
+          setActiveDistributionPhotoIndex(0);
         } catch (error) {
           console.error(
             `Failed to fetch distribution photos for NFT ${nftId}`,
             error
           );
           setDistributionPhotos([]);
+          setActiveDistributionPhotoIndex(0);
         } finally {
           fetchDistribution();
         }
@@ -154,10 +156,6 @@ export default function DistributionPage(props: Readonly<Props>) {
       fetchDistribution();
     }
   }, [pageProps]);
-
-  useEffect(() => {
-    setActiveDistributionPhotoIndex(0);
-  }, [distributionPhotos]);
 
   function goToPreviousDistributionPhoto() {
     setActiveDistributionPhotoIndex((activeIndex) =>
@@ -492,33 +490,44 @@ export default function DistributionPage(props: Readonly<Props>) {
       <div>
         {nftId && (
           <div className="tw-w-full">
-            <UpcomingMemePage id={nftId} />
+            <UpcomingMemePage
+              id={nftId}
+              locale={locale}
+              showDistributionLink={false}
+            />
           </div>
         )}
-        <div className="tw-w-full">
-          <Image
-            unoptimized
-            loading="eager"
-            width={0}
-            height={0}
-            style={{ height: "auto", width: "100px" }}
-            src="/SummerGlasses.svg"
-            alt=""
-            aria-hidden="true"
-          />{" "}
-          {t(locale, "distribution.empty.soon")}
-        </div>
-        <div className="tw-flex tw-w-full tw-flex-wrap tw-gap-x-1">
-          <span>{t(locale, "distribution.empty.checkBack")}</span>
-          <span>{t(locale, "distribution.empty.dropUpdates")}</span>
-          <a
-            href="https://x.com/6529Collections"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label={t(locale, "distribution.empty.xLink.ariaLabel")}
-          >
-            &#64;6529Collections
-          </a>
+        <div className="tw-flex tw-w-full tw-justify-center tw-pt-8">
+          <div className="tw-flex tw-max-w-full tw-items-center tw-gap-4 sm:tw-gap-5">
+            <Image
+              unoptimized
+              loading="eager"
+              width={112}
+              height={112}
+              className="tw-h-20 tw-w-auto tw-flex-shrink-0 sm:tw-h-24"
+              src="/SummerGlasses.svg"
+              alt=""
+              aria-hidden="true"
+            />
+            <div className="tw-min-w-0 tw-text-left tw-text-base tw-font-medium tw-leading-7 tw-text-white sm:tw-text-xl sm:tw-leading-8">
+              <p className="tw-mb-0">{t(locale, "distribution.empty.soon")}</p>
+              <p className="tw-mb-0">
+                {t(locale, "distribution.empty.checkBack")}
+              </p>
+              <p className="tw-mb-0">
+                <span>{t(locale, "distribution.empty.dropUpdates")}</span>{" "}
+                <a
+                  href="https://x.com/6529Collections"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={t(locale, "distribution.empty.xLink.ariaLabel")}
+                  className="tw-text-white tw-underline tw-underline-offset-2 tw-transition-colors hover:tw-text-iron-300 focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400"
+                >
+                  &#64;6529Collections
+                </a>
+              </p>
+            </div>
+          </div>
         </div>
       </div>
     );

--- a/components/distribution/Distribution.tsx
+++ b/components/distribution/Distribution.tsx
@@ -490,26 +490,22 @@ export default function DistributionPage(props: Readonly<Props>) {
       <div>
         {nftId && (
           <div className="tw-w-full">
-            <UpcomingMemePage
-              id={nftId}
-              locale={locale}
-              showDistributionLink={false}
-            />
+            <UpcomingMemePage id={nftId} locale={locale} />
           </div>
         )}
         <div className="tw-flex tw-w-full tw-justify-center tw-pt-8">
-          <div className="tw-flex tw-max-w-full tw-items-center tw-gap-4 sm:tw-gap-5">
+          <div className="tw-flex tw-max-w-full tw-items-center tw-gap-3 sm:tw-gap-4">
             <Image
               unoptimized
               loading="eager"
-              width={112}
-              height={112}
-              className="tw-h-20 tw-w-auto tw-flex-shrink-0 sm:tw-h-24"
+              width={72}
+              height={72}
+              className="tw-h-12 tw-w-auto tw-flex-shrink-0 sm:tw-h-14"
               src="/SummerGlasses.svg"
               alt=""
               aria-hidden="true"
             />
-            <div className="tw-min-w-0 tw-text-left tw-text-base tw-font-medium tw-leading-7 tw-text-white sm:tw-text-xl sm:tw-leading-8">
+            <div className="tw-min-w-0 tw-text-left tw-text-sm tw-font-medium tw-leading-6 tw-text-white sm:tw-text-base sm:tw-leading-7">
               <p className="tw-mb-0">{t(locale, "distribution.empty.soon")}</p>
               <p className="tw-mb-0">
                 {t(locale, "distribution.empty.checkBack")}

--- a/components/the-memes/MemePage.tsx
+++ b/components/the-memes/MemePage.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { AuthContext } from "@/components/auth/Auth";
+import { getDistributionDetailHref } from "@/components/distribution/distributionRouteParams";
 import CommonTabs from "@/components/utils/select/tabs/CommonTabs";
 import { ArrowLeftIcon } from "@heroicons/react/20/solid";
+import { ArrowUpRightIcon } from "@heroicons/react/24/outline";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -130,6 +132,33 @@ function MemePageTabButton({
     >
       {title}
     </button>
+  );
+}
+
+function UpcomingMemeDistributionHeaderLink({
+  id,
+  locale,
+}: {
+  readonly id: number;
+  readonly locale: SupportedLocale;
+}) {
+  return (
+    <Link
+      href={getDistributionDetailHref({
+        basePath: "/the-memes",
+        id,
+        locale,
+      })}
+      className="tw-ml-auto tw-inline-flex tw-shrink-0 tw-items-center tw-gap-1.5 tw-rounded-md tw-bg-iron-900 tw-px-3 tw-py-1.5 tw-text-xs tw-font-semibold tw-leading-5 tw-text-iron-100 tw-no-underline tw-transition-colors hover:tw-bg-iron-800 hover:tw-text-white focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 sm:tw-text-sm"
+    >
+      <span className="tw-whitespace-nowrap">
+        {t(locale, "distribution.planLink")}
+      </span>
+      <ArrowUpRightIcon
+        aria-hidden="true"
+        className="tw-h-4 tw-w-4 tw-flex-shrink-0 tw-text-iron-400"
+      />
+    </Link>
   );
 }
 
@@ -575,13 +604,16 @@ export default function MemePage({ nftId }: { readonly nftId: string }) {
   const isLastCard = nftMeta?.collection_size === nft?.id;
   const isLoadingNft = !nft && !nftNotFound;
   const nftYear = nft === undefined ? null : getMemeYearFromMintNumber(nft.id);
+  const numericNftId = Number(nftId);
+  const showUpcomingDistributionLink =
+    nftNotFound && Number.isInteger(numericNftId) && numericNftId > 0;
 
   return (
     <div className="tailwind-scope tw-min-h-[calc(100vh-100px)] tw-border tw-border-y-0 tw-border-l-0 tw-border-solid tw-border-iron-800 tw-bg-[#0D0D0F] tw-pb-5 tw-text-white">
       <div className="tw-px-4 tw-py-4 md:tw-px-6 md:tw-pb-10 lg:tw-px-8">
         <header className="tw-pb-8">
           <div className="tw-flex tw-flex-col tw-gap-4">
-            <div className="tw-flex tw-items-center tw-justify-between tw-gap-x-4 tw-gap-y-2 md:tw-justify-start">
+            <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-x-4 tw-gap-y-2 md:tw-justify-start">
               <div className="tw-mb-0 tw-flex tw-items-center">
                 <Link
                   href={getTheMemesRouteHrefWithLocale({
@@ -598,6 +630,12 @@ export default function MemePage({ nftId }: { readonly nftId: string }) {
                   {t(locale, "theMemes.title")}
                 </Link>
               </div>
+              {showUpcomingDistributionLink && (
+                <UpcomingMemeDistributionHeaderLink
+                  id={numericNftId}
+                  locale={locale}
+                />
+              )}
               {nftMeta && nft && (
                 <div className="tw-ml-auto tw-flex tw-min-w-0 tw-items-center md:tw-ml-0">
                   <MemeCalendarPeriods

--- a/components/the-memes/MemePage.tsx
+++ b/components/the-memes/MemePage.tsx
@@ -671,7 +671,7 @@ export default function MemePage({ nftId }: { readonly nftId: string }) {
             {printContent()}
           </>
         )}
-        {nftNotFound && <UpcomingMemePage id={nftId} />}
+        {nftNotFound && <UpcomingMemePage id={nftId} locale={locale} />}
       </div>
     </div>
   );

--- a/components/the-memes/UpcomingMemePage.tsx
+++ b/components/the-memes/UpcomingMemePage.tsx
@@ -1,14 +1,61 @@
 import { MemeCalendarOverviewNextMint } from "@/components/meme-calendar/MemeCalendarOverview";
+import { getDistributionDetailHref } from "@/components/distribution/distributionRouteParams";
 import LatestDropNextMintSubscribe from "@/components/home/now-minting/LatestDropNextMintSubscribe";
 import NotFound from "@/components/not-found/NotFound";
+import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
+import { t } from "@/i18n/messages";
+import { ArrowUpRightIcon } from "@heroicons/react/24/outline";
+import Link from "next/link";
 
-export default function UpcomingMemePage({ id }: { readonly id: string }) {
+function UpcomingMemeDistributionLink({
+  id,
+  locale,
+}: {
+  readonly id: number;
+  readonly locale: SupportedLocale;
+}) {
+  return (
+    <div className="tw-flex tw-w-full tw-justify-end">
+      <Link
+        href={getDistributionDetailHref({
+          basePath: "/the-memes",
+          id,
+          locale,
+        })}
+        className="tw-inline-flex tw-w-full tw-items-center tw-justify-center tw-gap-2 tw-rounded-lg tw-bg-iron-900 tw-px-5 tw-py-3 tw-text-base tw-font-semibold tw-leading-6 tw-text-iron-100 tw-no-underline tw-transition-colors hover:tw-bg-iron-800 hover:tw-text-white focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 sm:tw-w-auto"
+      >
+        <span>{t(locale, "distribution.planLink")}</span>
+        <ArrowUpRightIcon
+          aria-hidden="true"
+          className="-tw-mr-1 tw-h-5 tw-w-5 tw-flex-shrink-0 tw-text-iron-400"
+        />
+      </Link>
+    </div>
+  );
+}
+
+export default function UpcomingMemePage({
+  id,
+  locale = DEFAULT_LOCALE,
+  showDistributionLink = true,
+}: {
+  readonly id: string;
+  readonly locale?: SupportedLocale;
+  readonly showDistributionLink?: boolean;
+}) {
   const numId = Number(id);
-  if (Number.isInteger(numId)) {
+  if (Number.isInteger(numId) && numId > 0) {
     return (
       <div className="tw-mt-6 tw-flex tw-w-full tw-flex-col tw-gap-4">
         <LatestDropNextMintSubscribe tokenId={numId} />
-        <MemeCalendarOverviewNextMint displayTz="local" id={numId} />
+        {showDistributionLink && (
+          <UpcomingMemeDistributionLink id={numId} locale={locale} />
+        )}
+        <MemeCalendarOverviewNextMint
+          displayTz="local"
+          id={numId}
+          locale={locale}
+        />
       </div>
     );
   }

--- a/components/the-memes/UpcomingMemePage.tsx
+++ b/components/the-memes/UpcomingMemePage.tsx
@@ -1,56 +1,20 @@
 import { MemeCalendarOverviewNextMint } from "@/components/meme-calendar/MemeCalendarOverview";
-import { getDistributionDetailHref } from "@/components/distribution/distributionRouteParams";
 import LatestDropNextMintSubscribe from "@/components/home/now-minting/LatestDropNextMintSubscribe";
 import NotFound from "@/components/not-found/NotFound";
 import { DEFAULT_LOCALE, type SupportedLocale } from "@/i18n/locales";
-import { t } from "@/i18n/messages";
-import { ArrowUpRightIcon } from "@heroicons/react/24/outline";
-import Link from "next/link";
-
-function UpcomingMemeDistributionLink({
-  id,
-  locale,
-}: {
-  readonly id: number;
-  readonly locale: SupportedLocale;
-}) {
-  return (
-    <div className="tw-flex tw-w-full tw-justify-end">
-      <Link
-        href={getDistributionDetailHref({
-          basePath: "/the-memes",
-          id,
-          locale,
-        })}
-        className="tw-inline-flex tw-w-full tw-items-center tw-justify-center tw-gap-2 tw-rounded-lg tw-bg-iron-900 tw-px-5 tw-py-3 tw-text-base tw-font-semibold tw-leading-6 tw-text-iron-100 tw-no-underline tw-transition-colors hover:tw-bg-iron-800 hover:tw-text-white focus-visible:tw-outline focus-visible:tw-outline-2 focus-visible:tw-outline-offset-2 focus-visible:tw-outline-primary-400 sm:tw-w-auto"
-      >
-        <span>{t(locale, "distribution.planLink")}</span>
-        <ArrowUpRightIcon
-          aria-hidden="true"
-          className="-tw-mr-1 tw-h-5 tw-w-5 tw-flex-shrink-0 tw-text-iron-400"
-        />
-      </Link>
-    </div>
-  );
-}
 
 export default function UpcomingMemePage({
   id,
   locale = DEFAULT_LOCALE,
-  showDistributionLink = true,
 }: {
   readonly id: string;
   readonly locale?: SupportedLocale;
-  readonly showDistributionLink?: boolean;
 }) {
   const numId = Number(id);
   if (Number.isInteger(numId)) {
     return (
       <div className="tw-mt-6 tw-flex tw-w-full tw-flex-col tw-gap-4">
         <LatestDropNextMintSubscribe tokenId={numId} />
-        {showDistributionLink && numId > 0 && (
-          <UpcomingMemeDistributionLink id={numId} locale={locale} />
-        )}
         <MemeCalendarOverviewNextMint
           displayTz="local"
           id={numId}

--- a/components/the-memes/UpcomingMemePage.tsx
+++ b/components/the-memes/UpcomingMemePage.tsx
@@ -44,11 +44,11 @@ export default function UpcomingMemePage({
   readonly showDistributionLink?: boolean;
 }) {
   const numId = Number(id);
-  if (Number.isInteger(numId) && numId > 0) {
+  if (Number.isInteger(numId)) {
     return (
       <div className="tw-mt-6 tw-flex tw-w-full tw-flex-col tw-gap-4">
         <LatestDropNextMintSubscribe tokenId={numId} />
-        {showDistributionLink && (
+        {showDistributionLink && numId > 0 && (
           <UpcomingMemeDistributionLink id={numId} locale={locale} />
         )}
         <MemeCalendarOverviewNextMint

--- a/ops/docs/media/flow-media-discovery-and-actions.md
+++ b/ops/docs/media/flow-media-discovery-and-actions.md
@@ -87,8 +87,8 @@ This flow covers cross-route media tasks:
 - `/the-memes/{id}` ignores unsupported `focus` values and falls back to
   `Live`.
 - Upcoming numeric `/the-memes/{id}` routes can show the next-mint fallback
-  panel instead of full card data. Positive ids also show a `Distribution Plan`
-  link to `/the-memes/{id}/distribution`.
+  panel instead of full card data. Positive ids also show a header-row
+  `Distribution Plan` link to `/the-memes/{id}/distribution`.
 - `/the-memes/{id}/distribution` with no published distribution shows
   next-mint fallback plus the centered `The Distribution Plan will be made
   available soon!` message.

--- a/ops/docs/media/flow-media-discovery-and-actions.md
+++ b/ops/docs/media/flow-media-discovery-and-actions.md
@@ -86,10 +86,12 @@ This flow covers cross-route media tasks:
   `Mint on 6529.io`.
 - `/the-memes/{id}` ignores unsupported `focus` values and falls back to
   `Live`.
-- Upcoming numeric `/the-memes/{id}` routes can show the next-mint fallback
-  panel instead of full card data.
+- Upcoming positive numeric `/the-memes/{id}` routes can show the next-mint
+  fallback panel instead of full card data, including a `Distribution Plan`
+  link to `/the-memes/{id}/distribution`.
 - `/the-memes/{id}/distribution` with no published distribution shows
-  next-mint fallback plus `The Distribution Plan will be made available soon!`.
+  next-mint fallback plus the centered `The Distribution Plan will be made
+  available soon!` message.
 - Invalid or non-positive distribution IDs show the `DISTRIBUTION` not-found
   view.
 - `/rememes` keeps only `meme_id` in the URL. Sort, token type, and page reset

--- a/ops/docs/media/flow-media-discovery-and-actions.md
+++ b/ops/docs/media/flow-media-discovery-and-actions.md
@@ -86,8 +86,8 @@ This flow covers cross-route media tasks:
   `Mint on 6529.io`.
 - `/the-memes/{id}` ignores unsupported `focus` values and falls back to
   `Live`.
-- Upcoming positive numeric `/the-memes/{id}` routes can show the next-mint
-  fallback panel instead of full card data, including a `Distribution Plan`
+- Upcoming numeric `/the-memes/{id}` routes can show the next-mint fallback
+  panel instead of full card data. Positive ids also show a `Distribution Plan`
   link to `/the-memes/{id}/distribution`.
 - `/the-memes/{id}/distribution` with no published distribution shows
   next-mint fallback plus the centered `The Distribution Plan will be made

--- a/ops/docs/media/memes/feature-minting-calendar.md
+++ b/ops/docs/media/memes/feature-minting-calendar.md
@@ -18,8 +18,8 @@ distribution routes.
 - Full route: `/meme-calendar`
 - Navigation path: `Network -> Memes Calendar` in desktop and small-screen
   sidebars.
-- Shared fallback panel on `/the-memes/{id}` when `{id}` is an integer but no
-  published card data resolves.
+- Shared fallback panel on `/the-memes/{id}` when `{id}` is a positive integer
+  but no published card data resolves.
 - Shared fallback panel on `/the-memes/{id}/distribution` when `{id}` is a
   valid positive integer and distribution data is still empty/unpublished.
 
@@ -27,7 +27,7 @@ distribution routes.
 
 - Open `Network -> Memes Calendar`.
 - Open `/meme-calendar` directly.
-- Open an unresolved integer `/the-memes/{id}` route.
+- Open an unresolved positive integer `/the-memes/{id}` route.
 - Open a valid positive integer `/the-memes/{id}/distribution` route before
   distribution rows are available.
 
@@ -54,7 +54,8 @@ distribution routes.
 7. Open mint-day cells to view details, export links, and any override note.
 8. On fallback routes, the compact panel auto-selects the URL id and stays
    local-time read-only (no timezone toggle, no `Next Mint` button, no `Meme #`
-   input, no upcoming table).
+   input, no upcoming table). On unresolved `/the-memes/{id}` pages, use
+   `Distribution Plan` to open `/the-memes/{id}/distribution`.
 
 ## Common Scenarios
 
@@ -63,9 +64,9 @@ distribution routes.
 - Export any upcoming mint to calendar from the top panel or day tooltip.
 - Compare `Local` vs `UTC` renderings for cross-time-zone coordination.
 - Open unresolved future card URLs and still see timing details in the fallback
-  panel.
+  panel, plus a `Distribution Plan` link for that card.
 - Open early distribution URLs and still see the same fallback timing panel
-  above the "Distribution Plan will be made available soon!" message.
+  above the centered "Distribution Plan will be made available soon!" message.
 - Query `/api/meme-calendar/{id}` for a mint timeline summary.
 
 ## Edge Cases
@@ -87,8 +88,9 @@ distribution routes.
 - Invalid or non-positive top-panel/calendar `Meme #` input is ignored.
 - `/the-memes/{id}` behavior:
   - Non-integer ids show `MEME` not-found.
-  - Integer ids that do not resolve (including `0` or negative integers) show
-    the fallback panel.
+  - Non-positive integer ids show `MEME` not-found.
+  - Positive integer ids that do not resolve show the fallback panel with a
+    `Distribution Plan` link.
 - `/the-memes/{id}/distribution` behavior:
   - Non-positive or non-integer ids show `DISTRIBUTION` not-found.
 - `/about/memes-calendar` is unsupported; use `/meme-calendar`.

--- a/ops/docs/media/memes/feature-minting-calendar.md
+++ b/ops/docs/media/memes/feature-minting-calendar.md
@@ -18,8 +18,8 @@ distribution routes.
 - Full route: `/meme-calendar`
 - Navigation path: `Network -> Memes Calendar` in desktop and small-screen
   sidebars.
-- Shared fallback panel on `/the-memes/{id}` when `{id}` is a positive integer
-  but no published card data resolves.
+- Shared fallback panel on `/the-memes/{id}` when `{id}` is an integer but no
+  published card data resolves.
 - Shared fallback panel on `/the-memes/{id}/distribution` when `{id}` is a
   valid positive integer and distribution data is still empty/unpublished.
 
@@ -27,7 +27,7 @@ distribution routes.
 
 - Open `Network -> Memes Calendar`.
 - Open `/meme-calendar` directly.
-- Open an unresolved positive integer `/the-memes/{id}` route.
+- Open an unresolved integer `/the-memes/{id}` route.
 - Open a valid positive integer `/the-memes/{id}/distribution` route before
   distribution rows are available.
 
@@ -54,8 +54,8 @@ distribution routes.
 7. Open mint-day cells to view details, export links, and any override note.
 8. On fallback routes, the compact panel auto-selects the URL id and stays
    local-time read-only (no timezone toggle, no `Next Mint` button, no `Meme #`
-   input, no upcoming table). On unresolved `/the-memes/{id}` pages, use
-   `Distribution Plan` to open `/the-memes/{id}/distribution`.
+   input, no upcoming table). On unresolved positive `/the-memes/{id}` pages,
+   use `Distribution Plan` to open `/the-memes/{id}/distribution`.
 
 ## Common Scenarios
 
@@ -64,7 +64,7 @@ distribution routes.
 - Export any upcoming mint to calendar from the top panel or day tooltip.
 - Compare `Local` vs `UTC` renderings for cross-time-zone coordination.
 - Open unresolved future card URLs and still see timing details in the fallback
-  panel, plus a `Distribution Plan` link for that card.
+  panel; positive ids also show a `Distribution Plan` link for that card.
 - Open early distribution URLs and still see the same fallback timing panel
   above the centered "Distribution Plan will be made available soon!" message.
 - Query `/api/meme-calendar/{id}` for a mint timeline summary.
@@ -88,9 +88,9 @@ distribution routes.
 - Invalid or non-positive top-panel/calendar `Meme #` input is ignored.
 - `/the-memes/{id}` behavior:
   - Non-integer ids show `MEME` not-found.
-  - Non-positive integer ids show `MEME` not-found.
-  - Positive integer ids that do not resolve show the fallback panel with a
-    `Distribution Plan` link.
+  - Integer ids that do not resolve show the fallback panel.
+  - Positive integer ids that do not resolve also show a `Distribution Plan`
+    link.
 - `/the-memes/{id}/distribution` behavior:
   - Non-positive or non-integer ids show `DISTRIBUTION` not-found.
 - `/about/memes-calendar` is unsupported; use `/meme-calendar`.

--- a/ops/docs/media/memes/feature-minting-calendar.md
+++ b/ops/docs/media/memes/feature-minting-calendar.md
@@ -55,7 +55,8 @@ distribution routes.
 8. On fallback routes, the compact panel auto-selects the URL id and stays
    local-time read-only (no timezone toggle, no `Next Mint` button, no `Meme #`
    input, no upcoming table). On unresolved positive `/the-memes/{id}` pages,
-   use `Distribution Plan` to open `/the-memes/{id}/distribution`.
+   use the header-row `Distribution Plan` link to open
+   `/the-memes/{id}/distribution`.
 
 ## Common Scenarios
 
@@ -64,7 +65,8 @@ distribution routes.
 - Export any upcoming mint to calendar from the top panel or day tooltip.
 - Compare `Local` vs `UTC` renderings for cross-time-zone coordination.
 - Open unresolved future card URLs and still see timing details in the fallback
-  panel; positive ids also show a `Distribution Plan` link for that card.
+  panel; positive ids also show a header-row `Distribution Plan` link for that
+  card.
 - Open early distribution URLs and still see the same fallback timing panel
   above the centered "Distribution Plan will be made available soon!" message.
 - Query `/api/meme-calendar/{id}` for a mint timeline summary.
@@ -89,8 +91,8 @@ distribution routes.
 - `/the-memes/{id}` behavior:
   - Non-integer ids show `MEME` not-found.
   - Integer ids that do not resolve show the fallback panel.
-  - Positive integer ids that do not resolve also show a `Distribution Plan`
-    link.
+  - Positive integer ids that do not resolve also show a header-row
+    `Distribution Plan` link.
 - `/the-memes/{id}/distribution` behavior:
   - Non-positive or non-integer ids show `DISTRIBUTION` not-found.
 - `/about/memes-calendar` is unsupported; use `/meme-calendar`.

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -4901,7 +4901,7 @@
         "Individual Meme Card pages live at /the-memes/{id}.",
         "Use /the-memes/{id} for a specific Meme Card number such as Meme #1 or The Memes #1.",
         "Meme Card preview/data surfaces expose fields such as edition size, TDH rate, season, mint date, and supply when available.",
-        "Upcoming unresolved Meme Card pages show mint timing, subscription awareness, and a Distribution Plan link for that card.",
+        "Upcoming unresolved Meme Card pages show mint timing and subscription awareness; positive card ids also show a Distribution Plan link for that card.",
         "The backend public data catalog can answer public aggregate or specific Meme Card lookup questions for TDH/HODL rate, edition size, and supply.",
         "Card tabs and focus links are documented for deep-linking into card page sections.",
         "Distribution details for a Meme Card use /the-memes/{id}/distribution."

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -4901,7 +4901,7 @@
         "Individual Meme Card pages live at /the-memes/{id}.",
         "Use /the-memes/{id} for a specific Meme Card number such as Meme #1 or The Memes #1.",
         "Meme Card preview/data surfaces expose fields such as edition size, TDH rate, season, mint date, and supply when available.",
-        "Upcoming unresolved Meme Card pages show mint timing and subscription awareness for that card.",
+        "Upcoming unresolved Meme Card pages show mint timing, subscription awareness, and a Distribution Plan link for that card.",
         "The backend public data catalog can answer public aggregate or specific Meme Card lookup questions for TDH/HODL rate, edition size, and supply.",
         "Card tabs and focus links are documented for deep-linking into card page sections.",
         "Distribution details for a Meme Card use /the-memes/{id}/distribution."
@@ -4929,6 +4929,7 @@
       "keywords": ["memes", "distribution", "card", "holders", "route"],
       "facts": [
         "Meme Card distribution pages live at /the-memes/{id}/distribution.",
+        "Unpublished Meme Card distribution pages can show the upcoming mint panel plus a centered message that the Distribution Plan will be made available soon.",
         "Use distribution routes when users ask where card distribution details are shown.",
         "Meme Lab cards have a separate distribution route under /meme-lab/{id}/distribution."
       ],

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -4901,7 +4901,7 @@
         "Individual Meme Card pages live at /the-memes/{id}.",
         "Use /the-memes/{id} for a specific Meme Card number such as Meme #1 or The Memes #1.",
         "Meme Card preview/data surfaces expose fields such as edition size, TDH rate, season, mint date, and supply when available.",
-        "Upcoming unresolved Meme Card pages show mint timing, subscription awareness, and a Distribution Plan link for that card.",
+        "Upcoming unresolved Meme Card pages show mint timing and subscription awareness; positive card ids also show a Distribution Plan link for that card.",
         "The backend public data catalog can answer public aggregate or specific Meme Card lookup questions for TDH/HODL rate, edition size, and supply.",
         "Card tabs and focus links are documented for deep-linking into card page sections.",
         "Distribution details for a Meme Card use /the-memes/{id}/distribution."

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -4901,7 +4901,7 @@
         "Individual Meme Card pages live at /the-memes/{id}.",
         "Use /the-memes/{id} for a specific Meme Card number such as Meme #1 or The Memes #1.",
         "Meme Card preview/data surfaces expose fields such as edition size, TDH rate, season, mint date, and supply when available.",
-        "Upcoming unresolved Meme Card pages show mint timing and subscription awareness for that card.",
+        "Upcoming unresolved Meme Card pages show mint timing, subscription awareness, and a Distribution Plan link for that card.",
         "The backend public data catalog can answer public aggregate or specific Meme Card lookup questions for TDH/HODL rate, edition size, and supply.",
         "Card tabs and focus links are documented for deep-linking into card page sections.",
         "Distribution details for a Meme Card use /the-memes/{id}/distribution."
@@ -4929,6 +4929,7 @@
       "keywords": ["memes", "distribution", "card", "holders", "route"],
       "facts": [
         "Meme Card distribution pages live at /the-memes/{id}/distribution.",
+        "Unpublished Meme Card distribution pages can show the upcoming mint panel plus a centered message that the Distribution Plan will be made available soon.",
         "Use distribution routes when users ask where card distribution details are shown.",
         "Meme Lab cards have a separate distribution route under /meme-lab/{id}/distribution."
       ],


### PR DESCRIPTION
## Issue
- Upcoming unresolved Meme Card pages show subscription and mint calendar context, but there is no direct path to that card's distribution route.
- Unpublished distribution pages show the available-soon copy in a layout that reads left-heavy and cramped.

## Fix
- Add a responsive `Distribution Plan` link to unresolved positive `/the-memes/{id}` pages, routing to `/the-memes/{id}/distribution`.
- Keep that link hidden when the same upcoming mint panel is reused inside the distribution empty state, avoiding a self-link.

## Changes
- Center the unpublished distribution empty-state block with one `SummerGlasses.svg` image beside three rows of text and the existing `@6529Collections` link.
- Pass locale through the upcoming meme fallback so the distribution route link preserves locale query behavior.
- Update media docs and help-index records for the new control and empty-state behavior.
- Move the distribution photo carousel index reset into the photo-load path while touching the distribution component.

## Validation
- Local changed-file lint, typecheck, quality, and React Doctor checks passed.
- Browser visual QA was not run because this task did not authorize starting a local dev server.

## Risk
- Level: Low
- Why: UI-only route/link/layout change with docs/help updates; no API or data-shape changes.
- Rollback: Revert this PR to restore the previous upcoming fallback and empty-state layout.

## Review Notes
- Please focus on responsive placement of the new button and the centered unpublished-distribution message.