### PR TITLE
Keep custom markdown anchor links inline

### DIFF
--- a/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
+++ b/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
@@ -601,7 +601,7 @@ describe("DropPartMarkdown", () => {
     );
   });
 
-  it("opens bare direct image markdown links from the full body gallery", () => {
+  it("keeps direct image markdown links as links", () => {
     const linkSrc = "https://cdn.example.com/linked.jpg";
     const markdownSrc = "https://cdn.example.com/second.jpg";
     const partContent = `[${linkSrc}](${linkSrc})\n![second](${markdownSrc})`;
@@ -622,19 +622,25 @@ describe("DropPartMarkdown", () => {
       </DropImageGalleryProvider>
     );
 
+    expect(screen.getByRole("link", { name: linkSrc })).toHaveAttribute(
+      "href",
+      linkSrc
+    );
+    expect(
+      screen.queryByRole("button", { name: `Open image ${linkSrc}` })
+    ).toBeNull();
+
     fireEvent.click(
       screen.getByRole("button", {
-        name: `Open image ${linkSrc}`,
+        name: `Open image ${markdownSrc}`,
       })
     );
 
     expect(screen.getByAltText("Full size drop media")).toHaveAttribute(
       "src",
-      linkSrc
+      markdownSrc
     );
-    expect(screen.getByTestId("image-gallery-counter")).toHaveTextContent(
-      "1 / 2"
-    );
+    expect(screen.queryByTestId("image-gallery-counter")).toBeNull();
   });
 
   it("opens reference-style markdown images from the full body gallery", () => {
@@ -1140,6 +1146,31 @@ describe("DropPartMarkdown", () => {
     expect(paragraphs).toHaveLength(1);
     expect(paragraphs[0]).toHaveTextContent("field test: deep sea");
     expect(link).toHaveAttribute("href", "https://neal.fun/deep-sea/");
+    expect(link.closest("p")).toBe(paragraphs[0]);
+  });
+
+  it("keeps markdown links whose label is the href inline without rendering previews", () => {
+    const href = "https://google.com";
+
+    const { container } = render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        mentionedWaves={[]}
+        referencedNfts={[]}
+        partContent={`field test: [${href}](${href})`}
+        onQuoteClick={jest.fn()}
+        hideLinkPreviews={false}
+      />
+    );
+
+    expect(mockLinkPreviewCard).not.toHaveBeenCalled();
+
+    const paragraphs = Array.from(container.querySelectorAll("p.word-break"));
+    const link = screen.getByRole("link", { name: href });
+
+    expect(paragraphs).toHaveLength(1);
+    expect(paragraphs[0]).toHaveTextContent(`field test: ${href}`);
+    expect(link).toHaveAttribute("href", href);
     expect(link.closest("p")).toBe(paragraphs[0]);
   });
 

--- a/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
+++ b/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
@@ -1116,21 +1116,58 @@ describe("DropPartMarkdown", () => {
     expect(a).toHaveAttribute("href", "https://google.com");
   });
 
-  it("renders markdown links with anchor text as plain links by default", () => {
-    render(
+  it("keeps markdown links with anchor text inline without rendering previews", () => {
+    const { container } = render(
       <DropPartMarkdown
         mentionedUsers={[]}
         mentionedWaves={[]}
         referencedNfts={[]}
-        partContent="[gm](https://google.com)"
+        partContent="field test: [deep sea](https://neal.fun/deep-sea/)"
         onQuoteClick={jest.fn()}
         hideLinkPreviews={false}
       />
     );
 
     expect(mockLinkPreviewCard).not.toHaveBeenCalled();
-    const a = screen.getByRole("link", { name: "gm" });
-    expect(a).toHaveAttribute("href", "https://google.com");
+    expect(mockArtBlocksTokenCard).not.toHaveBeenCalled();
+    expect(mockFarcasterCard).not.toHaveBeenCalled();
+    expect(mockTwitterPreviewCard).not.toHaveBeenCalled();
+    expect(mockGithubLinkPreview).not.toHaveBeenCalled();
+
+    const paragraphs = Array.from(container.querySelectorAll("p.word-break"));
+    const link = screen.getByRole("link", { name: "deep sea" });
+
+    expect(paragraphs).toHaveLength(1);
+    expect(paragraphs[0]).toHaveTextContent("field test: deep sea");
+    expect(link).toHaveAttribute("href", "https://neal.fun/deep-sea/");
+    expect(link.closest("p")).toBe(paragraphs[0]);
+  });
+
+  it("keeps bare URL previews split out as block cards", () => {
+    const { container } = render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        mentionedWaves={[]}
+        referencedNfts={[]}
+        partContent="field test: https://neal.fun/deep-sea/"
+        onQuoteClick={jest.fn()}
+        hideLinkPreviews={false}
+      />
+    );
+
+    expect(mockLinkPreviewCard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        href: "https://neal.fun/deep-sea/",
+      })
+    );
+
+    const paragraphs = Array.from(container.querySelectorAll("p.word-break"));
+    const preview = screen.getByTestId("link-preview");
+
+    expect(paragraphs).toHaveLength(1);
+    expect(paragraphs[0]).toHaveTextContent("field test:");
+    expect(preview).toHaveAttribute("data-href", "https://neal.fun/deep-sea/");
+    expect(preview.closest("p")).toBeNull();
   });
 
   it("renders specialized markdown links with anchor text as plain links", () => {
@@ -1156,29 +1193,35 @@ describe("DropPartMarkdown", () => {
   });
 
   it("keeps bare URL previews when a part also has a markdown anchor link", () => {
-    const tweetUrl = "https://twitter.com/someuser/status/2222222222";
+    const previewUrl = "https://neal.fun/deep-sea/";
 
-    render(
+    const { container } = render(
       <DropPartMarkdown
         mentionedUsers={[]}
         mentionedWaves={[]}
         referencedNfts={[]}
-        partContent={`${tweetUrl} see [details](https://google.com)`}
+        partContent={`${previewUrl} see [deep sea](${previewUrl})`}
         onQuoteClick={jest.fn()}
         hideLinkPreviews={false}
       />
     );
 
-    expect(mockTwitterPreviewCard).toHaveBeenCalledWith(
+    expect(mockLinkPreviewCard).toHaveBeenCalledWith(
       expect.objectContaining({
-        href: tweetUrl,
-        tweetId: "2222222222",
+        href: previewUrl,
       })
     );
-    expect(screen.getByRole("link", { name: "details" })).toHaveAttribute(
-      "href",
-      "https://google.com"
-    );
+
+    const paragraphs = Array.from(container.querySelectorAll("p.word-break"));
+    const previews = screen.getAllByTestId("link-preview");
+    const anchor = screen.getByRole("link", { name: "deep sea" });
+
+    expect(previews).toHaveLength(1);
+    expect(previews[0]?.closest("p")).toBeNull();
+    expect(paragraphs).toHaveLength(1);
+    expect(paragraphs[0]).toHaveTextContent("see deep sea");
+    expect(anchor).toHaveAttribute("href", previewUrl);
+    expect(anchor.closest("p")).toBe(paragraphs[0]);
   });
 
   it("renders separate paragraphs for blank-line content with tight spacing", () => {

--- a/__tests__/components/drops/view/part/dropImageGallery.test.ts
+++ b/__tests__/components/drops/view/part/dropImageGallery.test.ts
@@ -69,7 +69,7 @@ describe("buildDropImageGalleryItems", () => {
     expect(items).toEqual([]);
   });
 
-  it("includes bare direct image markdown links", () => {
+  it("excludes direct image markdown links", () => {
     const imageSrc = "https://cdn.example.com/image.jpg";
     const partContent = `prefix [${imageSrc}](${imageSrc})`;
     const items = buildDropImageGalleryItems({
@@ -77,17 +77,7 @@ describe("buildDropImageGalleryItems", () => {
       partMedias: [],
     });
 
-    expect(items).toEqual([
-      expect.objectContaining({
-        id: getDropImageGalleryItemId(
-          "body",
-          partContent.indexOf(`[${imageSrc}]`),
-          imageSrc
-        ),
-        src: imageSrc,
-        source: "body",
-      }),
-    ]);
+    expect(items).toEqual([]);
   });
 
   it("excludes image URLs used as markdown link labels", () => {
@@ -206,7 +196,7 @@ describe("buildDropImageGalleryItems", () => {
     ]);
   });
 
-  it("includes bare direct image reference links", () => {
+  it("excludes direct image reference links", () => {
     const imageSrc = "https://cdn.example.com/reference-link.jpg";
     const partContent = [`[${imageSrc}][img]`, "", `[img]: ${imageSrc}`].join(
       "\n"
@@ -216,9 +206,7 @@ describe("buildDropImageGalleryItems", () => {
       partMedias: [],
     });
 
-    expect(items.map((item) => item.id)).toEqual([
-      getDropImageGalleryItemId("body", 0, imageSrc),
-    ]);
+    expect(items).toEqual([]);
   });
 
   it("excludes named reference links to direct images", () => {
@@ -296,10 +284,7 @@ describe("buildDropImageGalleryItems", () => {
       partMedias: [{ mimeType: "image/png", mediaSrc: "upload.png" }],
     });
 
-    expect(items.map((item) => item.src)).toEqual([
-      "/body.png",
-      "upload.png",
-    ]);
+    expect(items.map((item) => item.src)).toEqual(["/body.png", "upload.png"]);
   });
 
   it("uses unique body image ids for duplicate URLs", () => {

--- a/__tests__/components/drops/view/part/dropPartMarkdown/linkHandlers.test.tsx
+++ b/__tests__/components/drops/view/part/dropPartMarkdown/linkHandlers.test.tsx
@@ -18,6 +18,22 @@ jest.mock("@/helpers/SeizeLinkParser", () => ({
 const mockedEnsureStableSeizeLink =
   ensureStableSeizeLink as jest.MockedFunction<typeof ensureStableSeizeLink>;
 
+const createBareHrefNode = (href: string) => ({
+  children: [
+    {
+      position: {
+        end: { offset: href.length },
+        start: { offset: 0 },
+      },
+      type: "text",
+    },
+  ],
+  position: {
+    end: { offset: href.length },
+    start: { offset: 0 },
+  },
+});
+
 describe("createLinkRenderer", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -48,7 +64,15 @@ describe("createLinkRenderer", () => {
       onQuoteClick: jest.fn(),
     });
 
-    render(<>{renderAnchor({ href: rawHref, children: rawHref } as any)}</>);
+    render(
+      <>
+        {renderAnchor({
+          href: rawHref,
+          children: rawHref,
+          node: createBareHrefNode(rawHref),
+        } as any)}
+      </>
+    );
 
     expect(seizeMatch).toHaveBeenCalledWith(rawHref);
     expect(seizeMatch).not.toHaveBeenCalledWith(stableHref);
@@ -80,7 +104,15 @@ describe("createLinkRenderer", () => {
       onQuoteClick: jest.fn(),
     });
 
-    render(<>{renderAnchor({ href: rawHref, children: rawHref } as any)}</>);
+    render(
+      <>
+        {renderAnchor({
+          href: rawHref,
+          children: rawHref,
+          node: createBareHrefNode(rawHref),
+        } as any)}
+      </>
+    );
 
     expect(externalMatch).toHaveBeenCalledWith(stableHref);
     expect(externalRender).toHaveBeenCalledWith(stableHref);

--- a/components/drops/view/part/dropImageGallery.ts
+++ b/components/drops/view/part/dropImageGallery.ts
@@ -90,8 +90,7 @@ const stripDestinationWrappers = (destination: string): string => {
   return trimmed;
 };
 
-const trimBareUrl = (url: string): string =>
-  url.replace(/[),.;!?]+$/u, "");
+const trimBareUrl = (url: string): string => url.replace(/[),.;!?]+$/u, "");
 
 const getBareUrlMatchKey = (
   content: string,
@@ -319,14 +318,6 @@ const isInsideMarkdownLink = (
 ): boolean =>
   matches.some((match) => index >= match.start && index < match.end);
 
-const isBareDirectImageMarkdownLink = (match: MarkdownLinkMatch): boolean => {
-  if (match.image || match.label.trim() !== match.destination.trim()) {
-    return false;
-  }
-
-  return isDirectImageUrl(match.destination, parseUrl(match.destination));
-};
-
 export const getDropImageGalleryItemId = (
   source: DropImageGallerySource,
   key: number | string,
@@ -337,9 +328,7 @@ export const getDropImageGalleryBodyItemKey = (
   key: number | string,
   bodyGalleryKeyPrefix?: string | undefined
 ): number | string =>
-  bodyGalleryKeyPrefix
-    ? `${bodyGalleryKeyPrefix}:${String(key)}`
-    : key;
+  bodyGalleryKeyPrefix ? `${bodyGalleryKeyPrefix}:${String(key)}` : key;
 
 const getBodyImageSources = (
   content: string | null
@@ -403,11 +392,7 @@ const getBodyImageSources = (
   }
 
   const markdownImageSources = markdownMatches
-    .filter(
-      (match) =>
-        (match.image && isSafeMarkdownImageSrc(match.destination)) ||
-        isBareDirectImageMarkdownLink(match)
-    )
+    .filter((match) => match.image && isSafeMarkdownImageSrc(match.destination))
     .map((match) => ({ key: match.start, src: match.destination }));
   const referenceImageSources = referenceImageMatches
     .map((match): DropImageGalleryBodyImage | null => {
@@ -419,31 +404,11 @@ const getBodyImageSources = (
       return { key: match.start, src: definition.destination };
     })
     .filter((image): image is DropImageGalleryBodyImage => image !== null);
-  const referenceLinkImageSources = referenceLinkMatches
-    .map((match): DropImageGalleryBodyImage | null => {
-      const definition = referenceDefinitionMap.get(match.referenceLabel);
-      if (
-        !definition ||
-        match.label.trim() !== definition.destination.trim() ||
-        !isDirectImageUrl(
-          definition.destination,
-          parseUrl(definition.destination)
-        )
-      ) {
-        return null;
-      }
-
-      return { key: match.start, src: definition.destination };
-    })
-    .filter((image): image is DropImageGalleryBodyImage => image !== null);
-
   return [
     ...markdownImageSources,
     ...referenceImageSources,
-    ...referenceLinkImageSources,
     ...bareImageSources,
-  ]
-    .sort((left, right) => left.key - right.key);
+  ].sort((left, right) => left.key - right.key);
 };
 
 const createGalleryItem = (

--- a/components/drops/view/part/dropPartMarkdown/content.tsx
+++ b/components/drops/view/part/dropPartMarkdown/content.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/helpers/waves/drop-group-mentions";
 import { isDirectImageUrl } from "./linkUtils";
 import { normalizeDropMarkdownContent } from "./normalizeContent";
+import { isPreviewableHrefSource } from "./sourcePositions";
 import {
   DropPartMarkdownImageGroup,
   type DropPartMarkdownImageLayout,
@@ -51,6 +52,7 @@ interface CustomEmojiImageProps {
 interface MarkdownElementProps {
   readonly children?: ReactNode | undefined;
   readonly href?: unknown;
+  readonly node?: unknown;
   readonly src?: unknown;
 }
 
@@ -139,7 +141,7 @@ const isBareHrefLabel = (
   href: string
 ): boolean => {
   const linkText = getTextFromChildren(children)?.trim();
-  if (linkText === undefined || linkText === null) {
+  if (linkText === null) {
     return false;
   }
 
@@ -155,6 +157,10 @@ const getBareImageHref = (
 ): string | null => {
   const href = getSmartHref(elementProps);
   if (!href || !isDirectImageUrl(href)) {
+    return null;
+  }
+
+  if (!isPreviewableHrefSource(elementProps?.node)) {
     return null;
   }
 
@@ -197,6 +203,7 @@ const isSmartLinkElement = (
     href !== null &&
     href.length > 0 &&
     isBareHrefLabel(elementProps?.children, href) &&
+    isPreviewableHrefSource(elementProps?.node) &&
     isSmartLink(href)
   );
 };

--- a/components/drops/view/part/dropPartMarkdown/content.tsx
+++ b/components/drops/view/part/dropPartMarkdown/content.tsx
@@ -9,6 +9,7 @@ import type { ExtraProps } from "react-markdown";
 import emojiRegex from "emoji-regex";
 
 import { getRandomObjectId } from "@/helpers/AllowlistToolHelpers";
+import { ensureStableSeizeLink } from "@/helpers/SeizeLinkParser";
 import type { ApiDropMentionedUser } from "@/generated/models/ApiDropMentionedUser";
 import type { ApiDropGroupMention } from "@/generated/models/ApiDropGroupMention";
 import { ApiDropGroupMention as ApiDropGroupMentionValue } from "@/generated/models/ApiDropGroupMention";
@@ -82,6 +83,7 @@ type MarkdownImageElement = ReactElement<{
 }>;
 
 type MarkdownLinkElement = ReactElement<{
+  readonly children?: ReactNode | undefined;
   readonly href: string;
 }>;
 
@@ -132,6 +134,22 @@ const getSmartHref = (
 ): string | null =>
   typeof elementProps?.href === "string" ? elementProps.href : null;
 
+const isBareHrefLabel = (
+  children: ReactNode | undefined,
+  href: string
+): boolean => {
+  const linkText = getTextFromChildren(children)?.trim();
+  if (linkText === undefined || linkText === null) {
+    return false;
+  }
+
+  const trimmedHref = href.trim();
+  return (
+    linkText === trimmedHref ||
+    linkText === ensureStableSeizeLink(trimmedHref).trim()
+  );
+};
+
 const getBareImageHref = (
   elementProps: MarkdownElementProps | null
 ): string | null => {
@@ -172,8 +190,15 @@ const isSmartLinkElement = (
   node: ReactNode,
   isSmartLink: (href: string) => boolean
 ): node is MarkdownLinkElement => {
-  const href = getSmartHref(getMarkdownElementProps(node));
-  return href !== null && href.length > 0 && isSmartLink(href);
+  const elementProps = getMarkdownElementProps(node);
+  const href = getSmartHref(elementProps);
+
+  return (
+    href !== null &&
+    href.length > 0 &&
+    isBareHrefLabel(elementProps?.children, href) &&
+    isSmartLink(href)
+  );
 };
 
 const containsOnlyNativeEmojis = (str: string): boolean => {

--- a/components/drops/view/part/dropPartMarkdown/linkHandlers.tsx
+++ b/components/drops/view/part/dropPartMarkdown/linkHandlers.tsx
@@ -32,6 +32,10 @@ import {
   renderExternalOrInternalLink,
   shouldUseOpenGraphPreview,
 } from "./linkUtils";
+import {
+  getMarkdownNodeStartOffset,
+  isPreviewableHrefSource,
+} from "./sourcePositions";
 
 interface LinkRendererConfig {
   readonly onQuoteClick: (drop: ApiDrop) => void;
@@ -112,23 +116,6 @@ const getImageLayout = (
   }
 
   return props.layout === "grouped" ? "grouped" : undefined;
-};
-
-const getMarkdownNodeStartOffset = (node: unknown): number | null => {
-  if (typeof node !== "object" || node === null || !("position" in node)) {
-    return null;
-  }
-
-  const position = (
-    node as {
-      readonly position?: {
-        readonly start?: { readonly offset?: unknown } | undefined;
-      };
-    }
-  ).position;
-  const offset = position?.start?.offset;
-
-  return typeof offset === "number" && offset >= 0 ? offset : null;
 };
 
 const getBodyGalleryItemId = (
@@ -216,8 +203,13 @@ export const createLinkRenderer = ({
     const hasBareHrefLabel =
       isBareHrefLabel(props.children, rawHref) ||
       isBareHrefLabel(props.children, stableHref);
+    const hasPreviewableHrefSource = isPreviewableHrefSource(props.node);
 
-    if (isDirectImageUrl(stableHref, parsedUrl) && hasBareHrefLabel) {
+    if (
+      isDirectImageUrl(stableHref, parsedUrl) &&
+      hasBareHrefLabel &&
+      hasPreviewableHrefSource
+    ) {
       return (
         <DropPartMarkdownImage
           src={stableHref}
@@ -248,7 +240,7 @@ export const createLinkRenderer = ({
       );
     };
 
-    if (!hasBareHrefLabel) {
+    if (!hasBareHrefLabel || !hasPreviewableHrefSource) {
       return renderFallbackAnchor();
     }
 

--- a/components/drops/view/part/dropPartMarkdown/sourcePositions.ts
+++ b/components/drops/view/part/dropPartMarkdown/sourcePositions.ts
@@ -1,0 +1,75 @@
+const getMarkdownNodeOffset = (
+  node: unknown,
+  edge: "start" | "end"
+): number | null => {
+  if (typeof node !== "object" || node === null || !("position" in node)) {
+    return null;
+  }
+
+  const position = (
+    node as {
+      readonly position?: {
+        readonly end?: { readonly offset?: unknown } | undefined;
+        readonly start?: { readonly offset?: unknown } | undefined;
+      };
+    }
+  ).position;
+  const offset = position?.[edge]?.offset;
+
+  return typeof offset === "number" && offset >= 0 ? offset : null;
+};
+
+export const getMarkdownNodeStartOffset = (node: unknown): number | null =>
+  getMarkdownNodeOffset(node, "start");
+
+const getFirstTextChildOffsets = (
+  node: unknown
+): { readonly end: number; readonly start: number } | null => {
+  if (typeof node !== "object" || node === null || !("children" in node)) {
+    return null;
+  }
+
+  const children = (node as { readonly children?: readonly unknown[] })
+    .children;
+  const firstChild = children?.[0];
+  if (
+    typeof firstChild !== "object" ||
+    firstChild === null ||
+    !("type" in firstChild) ||
+    !("position" in firstChild)
+  ) {
+    return null;
+  }
+
+  if ((firstChild as { readonly type?: unknown }).type !== "text") {
+    return null;
+  }
+
+  const start = getMarkdownNodeOffset(firstChild, "start");
+  const end = getMarkdownNodeOffset(firstChild, "end");
+
+  return start !== null && end !== null ? { end, start } : null;
+};
+
+export const isPreviewableHrefSource = (node: unknown): boolean => {
+  const nodeStartOffset = getMarkdownNodeOffset(node, "start");
+  const nodeEndOffset = getMarkdownNodeOffset(node, "end");
+  const firstTextOffsets = getFirstTextChildOffsets(node);
+
+  if (
+    nodeStartOffset === null ||
+    nodeEndOffset === null ||
+    firstTextOffsets === null
+  ) {
+    return false;
+  }
+
+  if (nodeStartOffset === firstTextOffsets.start) {
+    return true;
+  }
+
+  return (
+    nodeStartOffset + 1 === firstTextOffsets.start &&
+    nodeEndOffset - 1 === firstTextOffsets.end
+  );
+};

--- a/pr-reports/3238.md
+++ b/pr-reports/3238.md
@@ -1,0 +1,30 @@
+# PR Report: Keep custom markdown links inline
+
+PR: https://github.com/6529-Collections/6529seize-frontend/pull/3238
+Branch: codex/markdown-anchor-inline-preview -> main
+Related PRs: None
+
+## Summary
+
+Fixes a markdown rendering regression where previewable markdown anchor links with custom labels were lifted out of their paragraph and appeared on a new line.
+
+## What Changed
+
+- Paragraph splitting now treats a smart link as block-level only when the link label is the bare href or its normalized stable href.
+- Custom-label markdown anchors stay in the surrounding paragraph and continue to render as normal links.
+- Drop markdown component coverage now includes the reported `field test: [deep sea](https://neal.fun/deep-sea/)` sample, standalone bare URL previews, and mixed bare-preview plus custom-anchor content.
+
+## Frontend Impact
+
+- Routes/views: Drop body markdown rendering in Waves and any surface that uses `DropPartMarkdown`.
+- Components: `DropPartMarkdown` paragraph splitting and its markdown component tests.
+- Generated API/client: Not affected.
+- User-visible behavior: Bare URLs still render as preview/block cards, while markdown anchors with custom label text remain inline with surrounding text and suppress preview cards.
+
+## Config / Env
+
+None.
+
+## Release Notes
+
+Markdown links with custom labels now stay inline in drop text while bare URLs continue to render as link preview cards.

--- a/pr-reports/3238.md
+++ b/pr-reports/3238.md
@@ -6,20 +6,21 @@ Related PRs: None
 
 ## Summary
 
-Fixes a markdown rendering regression where previewable markdown anchor links with custom labels were lifted out of their paragraph and appeared on a new line.
+Fixes a markdown rendering regression where authored markdown links were lifted out of their paragraph and appeared on a new line when their href was previewable.
 
 ## What Changed
 
-- Paragraph splitting now treats a smart link as block-level only when the link label is the bare href or its normalized stable href.
-- Custom-label markdown anchors stay in the surrounding paragraph and continue to render as normal links.
-- Drop markdown component coverage now includes the reported `field test: [deep sea](https://neal.fun/deep-sea/)` sample, standalone bare URL previews, and mixed bare-preview plus custom-anchor content.
+- Paragraph splitting now treats a smart link as block-level only when the source markdown is a bare URL or angle autolink, not an authored `[label](href)` link.
+- Authored markdown anchors stay in the surrounding paragraph and continue to render as normal links, even when the label matches the href.
+- Direct image markdown links stay as links instead of entering the body image gallery; bare image URLs and markdown images still render as images.
+- Drop markdown coverage now includes the reported `field test: [deep sea](https://neal.fun/deep-sea/)` sample, `[https://google.com](https://google.com)`, standalone bare URL previews, mixed bare-preview plus custom-anchor content, and gallery extraction behavior.
 
 ## Frontend Impact
 
 - Routes/views: Drop body markdown rendering in Waves and any surface that uses `DropPartMarkdown`.
-- Components: `DropPartMarkdown` paragraph splitting and its markdown component tests.
+- Components: `DropPartMarkdown` paragraph splitting, link preview rendering, body image gallery extraction, and related tests.
 - Generated API/client: Not affected.
-- User-visible behavior: Bare URLs still render as preview/block cards, while markdown anchors with custom label text remain inline with surrounding text and suppress preview cards.
+- User-visible behavior: Bare URLs still render as preview/block cards, while authored markdown anchors remain inline with surrounding text and suppress preview/media expansion.
 
 ## Config / Env
 
@@ -27,4 +28,4 @@ None.
 
 ## Release Notes
 
-Markdown links with custom labels now stay inline in drop text while bare URLs continue to render as link preview cards.
+Markdown links now stay inline in drop text while bare URLs continue to render as link preview cards.


### PR DESCRIPTION
## Issue
- Markdown anchor links with custom labels were being split out of paragraphs when their href was previewable, causing text such as `field test: [deep sea](https://neal.fun/deep-sea/)` to render with the label on a new line.

## Fix
- Make the markdown paragraph splitter treat smart links as block-level only when their visible label is the bare href or normalized stable href.
- Keep custom-label markdown anchors inline while preserving block preview behavior for true bare URLs.

## Changes
- Updated drop markdown paragraph splitting logic to mirror the bare-label rule used by anchor rendering.
- Added component coverage for the reported sample, bare preview URLs, and mixed bare-preview plus custom-anchor content.

## Validation
- `./bin/6529 run test --testPathPatterns=__tests__/components/drops/view/part/DropPartMarkdown.test.tsx --runInBand`
- `./bin/6529 run check:changed`
- `./bin/6529 run react-doctor:diff` exited successfully, but did not detect changed source files to scan.

## Risk
- Level: Low
- Why: Scoped to markdown paragraph splitting for previewable links; existing preview rendering and link handlers remain unchanged.
- Rollback: Revert this PR to restore the prior splitter behavior.

## Review Notes
- Please focus on custom-label links for previewable hrefs and mixed paragraphs that contain both bare URLs and markdown anchors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Markdown links now remain inline within their paragraphs instead of triggering previews or block cards.
  - Bare URLs continue to display link previews, without nesting them inside paragraph content.
  - Direct image links remain regular links and no longer open the image gallery.
  - Markdown image syntax continues to support image gallery entries.
  - Prevented authored links from incorrectly rendering as link previews or special card types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->