### PR TITLE
Make notification replies follow the mobile keyboard

### DIFF
--- a/__tests__/components/brain/content/BrainContent.test.tsx
+++ b/__tests__/components/brain/content/BrainContent.test.tsx
@@ -1,45 +1,127 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import BrainContent from '@/components/brain/content/BrainContent';
-import { ActiveDropAction } from '@/types/dropInteractionTypes';
+import { render, screen, fireEvent } from "@testing-library/react";
+import BrainContent from "@/components/brain/content/BrainContent";
+import { ActiveDropAction } from "@/types/dropInteractionTypes";
 
-jest.mock('@/components/brain/content/input/BrainContentInput', () => ({
+let mockIsApp = false;
+let mockIsKeyboardVisible = false;
+
+jest.mock("@/hooks/useDeviceInfo", () => ({
+  __esModule: true,
+  default: () => ({ isApp: mockIsApp }),
+}));
+
+jest.mock("@/hooks/useNativeKeyboard", () => ({
+  useNativeKeyboard: () => ({ isVisible: mockIsKeyboardVisible }),
+}));
+
+jest.mock("@/components/brain/my-stream/layout/LayoutContext", () => ({
+  useLayout: () => ({ spaces: { mobileNavSpace: 72 } }),
+}));
+
+jest.mock("@/components/brain/content/input/BrainContentInput", () => ({
   __esModule: true,
   default: ({ activeDrop, onCancelReplyQuote }: any) => (
     <div data-testid="input">
-      {activeDrop?.id ?? 'no-drop'}
+      {activeDrop?.id ?? "no-drop"}
       <button onClick={onCancelReplyQuote}>cancel</button>
     </div>
   ),
 }));
 
-describe('BrainContent', () => {
-  it('renders children without the old pinned waves slot', () => {
+describe("BrainContent", () => {
+  beforeEach(() => {
+    mockIsApp = false;
+    mockIsKeyboardVisible = false;
+  });
+
+  it("renders children without the old pinned waves slot", () => {
     render(
       <BrainContent activeDrop={null} onCancelReplyQuote={jest.fn()}>
         child
       </BrainContent>
     );
-    expect(screen.getByText('child')).toBeInTheDocument();
-    expect(screen.queryByTestId('pinned')).toBeNull();
+    expect(screen.getByText("child")).toBeInTheDocument();
+    expect(screen.queryByTestId("pinned")).toBeNull();
   });
 
-  it('passes props to BrainContentInput', () => {
+  it("passes props to BrainContentInput", () => {
     const onCancel = jest.fn();
     render(
       <BrainContent
-        activeDrop={{
-          id: 'x',
-          action: ActiveDropAction.REPLY,
-          drop: { id: 'x', wave: { id: 'w' } } as any,
-          partId: 0,
-        } as any}
+        activeDrop={
+          {
+            id: "x",
+            action: ActiveDropAction.REPLY,
+            drop: { id: "x", wave: { id: "w" } } as any,
+            partId: 0,
+          } as any
+        }
         onCancelReplyQuote={onCancel}
       >
         child
       </BrainContent>
     );
-    expect(screen.getByTestId('input')).toHaveTextContent('x');
-    fireEvent.click(screen.getByText('cancel'));
+    expect(screen.getByTestId("input")).toHaveTextContent("x");
+    fireEvent.click(screen.getByText("cancel"));
     expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("positions the native composer from the shared keyboard inset", () => {
+    mockIsApp = true;
+    mockIsKeyboardVisible = true;
+
+    render(
+      <BrainContent
+        activeDrop={
+          {
+            id: "x",
+            action: ActiveDropAction.REPLY,
+            drop: { id: "x", wave: { id: "w" } } as any,
+            partId: 0,
+          } as any
+        }
+        onCancelReplyQuote={jest.fn()}
+      >
+        child
+      </BrainContent>
+    );
+
+    const composer = screen.getByTestId("input").parentElement;
+
+    expect(composer).not.toBeNull();
+    expect(composer).toHaveClass("tw-fixed");
+    expect(composer?.style.bottom).toBe(
+      "calc(var(--native-keyboard-inset-bottom, 0px) + 0px)"
+    );
+    expect(composer?.style.transitionProperty).toBe("bottom");
+    expect(composer?.style.transitionDuration).toBe(
+      "var(--native-keyboard-layout-transition-duration, 0ms)"
+    );
+  });
+
+  it("keeps the web composer on its existing positioning path", () => {
+    render(
+      <BrainContent
+        activeDrop={
+          {
+            id: "x",
+            action: ActiveDropAction.REPLY,
+            drop: { id: "x", wave: { id: "w" } } as any,
+            partId: 0,
+          } as any
+        }
+        onCancelReplyQuote={jest.fn()}
+      >
+        child
+      </BrainContent>
+    );
+
+    const composer = screen.getByTestId("input").parentElement;
+
+    expect(composer).not.toBeNull();
+    expect(composer).toHaveClass("tw-absolute", "tw-bottom-0");
+    expect(composer?.style.bottom).toBe("");
+    expect(composer?.style.transitionProperty).toBe("");
+    expect(composer?.style.transitionDuration).toBe("");
   });
 });

--- a/__tests__/components/brain/my-stream/layout/LayoutContext.test.tsx
+++ b/__tests__/components/brain/my-stream/layout/LayoutContext.test.tsx
@@ -107,6 +107,14 @@ function FallbackStyleComponent() {
   );
 }
 
+function NotificationsStyleComponent() {
+  const { notificationsViewStyle } = useLayout();
+
+  return (
+    <div data-testid="notifications-view" style={notificationsViewStyle} />
+  );
+}
+
 describe("LayoutProvider", () => {
   it("provides viewport-sized fallback styles before measurement completes", () => {
     const originalRequestAnimationFrame = global.requestAnimationFrame;
@@ -243,5 +251,45 @@ describe("LayoutProvider", () => {
       expect(content.style.maxHeight).toContain("- 100px");
     });
     expect(content.style.maxHeight).not.toContain("- 80px");
+  });
+
+  it("subtracts the shared keyboard inset from native notifications", () => {
+    mockCapacitorValues = { isCapacitor: true, isAndroid: false, isIos: true };
+
+    render(
+      <LayoutProvider>
+        <NotificationsStyleComponent />
+      </LayoutProvider>
+    );
+
+    const notifications = screen.getByTestId("notifications-view");
+
+    expect(notifications.style.height).toContain(
+      "var(--native-keyboard-inset-bottom, 0px)"
+    );
+    expect(notifications.style.maxHeight).toContain(
+      "var(--native-keyboard-inset-bottom, 0px)"
+    );
+    expect(notifications.style.transition).toBe(
+      "height var(--native-keyboard-layout-transition-duration, 0ms) ease-out, max-height var(--native-keyboard-layout-transition-duration, 0ms) ease-out"
+    );
+  });
+
+  it("keeps responsive web notifications free of native keyboard styles", () => {
+    render(
+      <LayoutProvider>
+        <NotificationsStyleComponent />
+      </LayoutProvider>
+    );
+
+    const notifications = screen.getByTestId("notifications-view");
+
+    expect(notifications.style.height).not.toContain(
+      "--native-keyboard-inset-bottom"
+    );
+    expect(notifications.style.maxHeight).not.toContain(
+      "--native-keyboard-inset-bottom"
+    );
+    expect(notifications.style.transition).toBe("");
   });
 });

--- a/components/brain/content/BrainContent.tsx
+++ b/components/brain/content/BrainContent.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import React, { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useState,
+} from "react";
 import {
   AnimatePresence,
   LazyMotion,
@@ -27,6 +32,9 @@ interface BrainContentProps {
 
 // Reserve the compact one-line composer height before ResizeObserver runs.
 const MIN_REPLY_COMPOSER_RESERVE_PX = 104;
+const NATIVE_KEYBOARD_INSET = "var(--native-keyboard-inset-bottom, 0px)";
+const NATIVE_KEYBOARD_LAYOUT_TRANSITION_DURATION =
+  "var(--native-keyboard-layout-transition-duration, 0ms)";
 
 const BrainContent: React.FC<BrainContentProps> = ({
   children,
@@ -50,20 +58,29 @@ const BrainContent: React.FC<BrainContentProps> = ({
   const composerPositionClassName = isApp
     ? "tw-fixed tw-inset-x-0"
     : "tw-absolute tw-inset-x-0 tw-bottom-0";
-  const composerMotionInitial = shouldReduceMotion
-    ? { opacity: 1, y: "0%" }
-    : { opacity: 1, y: "100%" };
+  const shouldAnimateComposerEntrance = !isApp && !shouldReduceMotion;
+  const composerMotionInitial = shouldAnimateComposerEntrance
+    ? { opacity: 1, y: "100%" }
+    : { opacity: 1, y: "0%" };
   const composerMotionAnimate = { opacity: 1, y: "0%" };
-  const composerMotionExit = shouldReduceMotion
-    ? { opacity: 1, y: "0%" }
-    : { opacity: 1, y: "100%" };
+  const composerMotionExit = shouldAnimateComposerEntrance
+    ? { opacity: 1, y: "100%" }
+    : { opacity: 1, y: "0%" };
   const containerStyle: BrainContentStyle = {
     "--brain-content-composer-reserve": `${composerReserve}px`,
   };
   const composerMotionTransition = {
-    duration: shouldReduceMotion ? 0 : 0.32,
+    duration: shouldAnimateComposerEntrance ? 0.32 : 0,
     ease: "easeOut",
   };
+  const composerStyle = isApp
+    ? {
+        bottom: `calc(${NATIVE_KEYBOARD_INSET} + ${composerBottomOffset}px)`,
+        transitionProperty: "bottom",
+        transitionDuration: NATIVE_KEYBOARD_LAYOUT_TRANSITION_DURATION,
+        transitionTimingFunction: "ease-out",
+      }
+    : undefined;
   const handleComposerRef = useCallback((node: HTMLDivElement | null) => {
     setComposerElement(node);
     if (!node) {
@@ -113,7 +130,7 @@ const BrainContent: React.FC<BrainContentProps> = ({
             <m.div
               ref={handleComposerRef}
               className={`${composerPositionClassName} tw-z-[80] tw-transform-gpu tw-bg-black tw-px-2 tw-will-change-transform sm:tw-px-4 md:tw-px-6 lg:tw-px-0`}
-              {...(isApp ? { style: { bottom: composerBottomOffset } } : {})}
+              {...(composerStyle ? { style: composerStyle } : {})}
               initial={composerMotionInitial}
               animate={composerMotionAnimate}
               exit={composerMotionExit}

--- a/components/brain/my-stream/layout/LayoutContext.tsx
+++ b/components/brain/my-stream/layout/LayoutContext.tsx
@@ -397,8 +397,19 @@ export const LayoutProvider: React.FC<{ children: ReactNode }> = ({
   }, [navAdjustedSpaces]);
 
   const notificationsViewStyle = useMemo<React.CSSProperties>(() => {
-    return calculateHeightStyle({ ...navAdjustedSpaces, mobileNavSpace: 0 }, 0);
-  }, [navAdjustedSpaces]);
+    const style = calculateHeightStyle(
+      { ...navAdjustedSpaces, mobileNavSpace: 0 },
+      isCapacitor ? NATIVE_KEYBOARD_INSET : 0
+    );
+
+    if (isCapacitor) {
+      return {
+        ...style,
+        transition: `height ${NATIVE_KEYBOARD_LAYOUT_TRANSITION_DURATION} ease-out, max-height ${NATIVE_KEYBOARD_LAYOUT_TRANSITION_DURATION} ease-out`,
+      };
+    }
+    return style;
+  }, [navAdjustedSpaces, isCapacitor]);
 
   const myStreamFeedStyle = useMemo<React.CSSProperties>(() => {
     return calculateHeightStyle(navAdjustedSpaces, 0);


### PR DESCRIPTION
## Issue
- In the native mobile Notifications view, opening Reply raised the keyboard while leaving the fixed composer underneath it. The notification list also reacted separately, producing a partial layout shift instead of one coordinated movement.

## Fix
- Reuse the native keyboard inset and transition timing already used by wave chat for both the Notifications viewport and its fixed reply composer.
- Keep desktop and responsive web behavior unchanged.

## Changes
- Dock the native notification reply composer to the animated keyboard inset.
- Resize the Notifications viewport with the same inset so the list and composer move together.
- Disable the separate composer entrance slide in native app mode so it does not compete with the keyboard animation.

## Validation
- Verified in a native iOS test build against the branch dev server: notification reply keyboard open and close behavior.
- Confirmed the existing wave chat keyboard behavior remains intact.
- `6529 run lint:changed`
- `6529 run typecheck:changed`
- React Doctor inspected the uncommitted React diff; the only diagnostic came from an unrelated existing effect in a comment-only file, which was removed from the final diff.

## Risk
- Level: Medium
- Why: Changes native keyboard layout for the Notifications reply surface, while leaving desktop and responsive web paths unchanged.
- Rollback: Revert the single commit to restore the previous fixed composer and viewport sizing.

## Review Notes
- Focus on native keyboard open/close timing, composer positioning, notification scroll preservation, and the boundary between native and web motion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved composer positioning and animation when the native keyboard is visible.
  - Adjusted composer entrance/exit behavior to better respect app context and reduced-motion preferences.
  - Updated the notifications view sizing to account for native keyboard insets on mobile.
  - Added animated height/max-height transitions for notifications during keyboard-related layout changes.
- **Tests**
  - Expanded BrainContent tests to verify native vs web composer styling and transitions.
  - Added LayoutContext tests to validate notifications view keyboard inset and transition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->