### PR TITLE
Protect notification keyboard behavior from regressions

### DIFF
--- a/__tests__/components/brain/content/BrainContent.test.tsx
+++ b/__tests__/components/brain/content/BrainContent.test.tsx
@@ -1,9 +1,36 @@
 import { render, screen, fireEvent } from "@testing-library/react";
+import type { ReactNode, Ref } from "react";
 import BrainContent from "@/components/brain/content/BrainContent";
 import { ActiveDropAction } from "@/types/dropInteractionTypes";
 
 let mockIsApp = false;
 let mockIsKeyboardVisible = false;
+
+jest.mock("framer-motion", () => {
+  const React = jest.requireActual("react");
+  const MotionDiv = React.forwardRef(
+    (
+      { initial, animate, exit, transition, ...props }: Record<string, unknown>,
+      ref: Ref<HTMLDivElement>
+    ) =>
+      React.createElement("div", {
+        ...props,
+        ref,
+        "data-motion-initial": JSON.stringify(initial),
+        "data-motion-animate": JSON.stringify(animate),
+        "data-motion-exit": JSON.stringify(exit),
+        "data-motion-transition": JSON.stringify(transition),
+      })
+  );
+
+  return {
+    AnimatePresence: ({ children }: { children: ReactNode }) => children,
+    LazyMotion: ({ children }: { children: ReactNode }) => children,
+    domAnimation: {},
+    m: { div: MotionDiv },
+    useReducedMotion: () => false,
+  };
+});
 
 jest.mock("@/hooks/useDeviceInfo", () => ({
   __esModule: true,
@@ -96,6 +123,18 @@ describe("BrainContent", () => {
     expect(composer?.style.transitionProperty).toBe("bottom");
     expect(composer?.style.transitionDuration).toBe(
       "var(--native-keyboard-layout-transition-duration, 0ms)"
+    );
+    expect(composer).toHaveAttribute(
+      "data-motion-initial",
+      JSON.stringify({ opacity: 1, y: "0%" })
+    );
+    expect(composer).toHaveAttribute(
+      "data-motion-exit",
+      JSON.stringify({ opacity: 1, y: "0%" })
+    );
+    expect(composer).toHaveAttribute(
+      "data-motion-transition",
+      JSON.stringify({ duration: 0, ease: "easeOut" })
     );
   });
 

--- a/__tests__/components/brain/my-stream/layout/LayoutContext.test.tsx
+++ b/__tests__/components/brain/my-stream/layout/LayoutContext.test.tsx
@@ -265,10 +265,10 @@ describe("LayoutProvider", () => {
     const notifications = screen.getByTestId("notifications-view");
 
     expect(notifications.style.height).toContain(
-      "var(--native-keyboard-inset-bottom, 0px)"
+      "- var(--native-keyboard-inset-bottom, 0px)"
     );
     expect(notifications.style.maxHeight).toContain(
-      "var(--native-keyboard-inset-bottom, 0px)"
+      "- var(--native-keyboard-inset-bottom, 0px)"
     );
     expect(notifications.style.transition).toBe(
       "height var(--native-keyboard-layout-transition-duration, 0ms) ease-out, max-height var(--native-keyboard-layout-transition-duration, 0ms) ease-out"


### PR DESCRIPTION
## Issue

Follow-up to #3239. The native notification keyboard fix is merged, but final review identified two gaps in its regression coverage: the tests did not prove that the extra Framer Motion slide stays disabled in the app, or that the keyboard inset is specifically subtracted from the notification viewport.

## Fix

Tighten the existing native and web regression tests without changing runtime behavior.

## Notable changes

- Assert that the native reply composer starts and exits at its final position with a zero-duration Framer transition.
- Assert that notification height and max-height subtract the shared native keyboard inset.
- Keep the existing native keyboard CSS and responsive-web fallback assertions.

## Validation

- `./bin/6529 run test --runInBand --runTestsByPath __tests__/components/brain/content/BrainContent.test.tsx __tests__/components/brain/my-stream/layout/LayoutContext.test.tsx`
- `./bin/6529 run lint:uncommitted:tight`
- `git diff --check origin/main...HEAD`

## Risk

Tests only. No production code or user-facing behavior changes.

## Review notes

This PR contains the final CodeRabbit test-quality follow-up from #3239, which was merged while that feedback was being addressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for composer motion attributes and animation settings.
  * Updated layout tests to reflect the current keyboard inset CSS calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->