### PR TITLE
Add mobile wave swipe-back navigation

### DIFF
--- a/__tests__/components/brain/BrainMobile.test.tsx
+++ b/__tests__/components/brain/BrainMobile.test.tsx
@@ -38,6 +38,26 @@ jest.mock("@/hooks/useDeviceInfo", () => ({
   default: () => ({ isApp }),
 }));
 
+let mockActiveWaveId: string | null = null;
+const mockSetActiveWave = jest.fn();
+const mockRequestMainWavesList = jest.fn(() => jest.fn());
+jest.mock("@/contexts/wave/MyStreamContext", () => ({
+  useMyStreamOptional: () => ({
+    activeWave: {
+      id: mockActiveWaveId,
+      set: mockSetActiveWave,
+    },
+    requestMainWavesList: mockRequestMainWavesList,
+  }),
+}));
+
+const mockClearLastVisited = jest.fn();
+jest.mock("@/components/navigation/ViewContext", () => ({
+  useViewContext: () => ({
+    clearLastVisited: mockClearLastVisited,
+  }),
+}));
+
 let dropData: any = null;
 let waveData: any = null;
 let mockIsCompleted = false;
@@ -290,6 +310,10 @@ describe("BrainMobile", () => {
     dropData = null;
     waveData = null;
     isApp = true;
+    mockActiveWaveId = null;
+    mockSetActiveWave.mockClear();
+    mockRequestMainWavesList.mockClear();
+    mockClearLastVisited.mockClear();
     mockIsCompleted = false;
     mockFirstDecisionDone = true;
     mockOutcomesVisible = true;
@@ -379,6 +403,61 @@ describe("BrainMobile", () => {
       wave: waveData,
     });
   });
+
+  it("returns from an app wave detail to the waves list on edge swipe", async () => {
+    mockPathname = "/waves/1";
+    mockActiveWaveId = "1";
+    waveData = createWave(false);
+
+    render(<BrainMobile>child</BrainMobile>);
+
+    const waveContent = await screen.findByText("child");
+    fireEvent.touchStart(waveContent, {
+      touches: [{ clientX: 10, clientY: 100 }],
+    });
+    fireEvent.touchMove(waveContent, {
+      touches: [{ clientX: 60, clientY: 104 }],
+    });
+    fireEvent.touchEnd(waveContent, {
+      changedTouches: [{ clientX: 100, clientY: 106 }],
+    });
+
+    expect(mockRequestMainWavesList).toHaveBeenCalledTimes(1);
+    expect(mockClearLastVisited).toHaveBeenCalledWith("wave");
+    expect(mockSetActiveWave).toHaveBeenCalledWith(null, {
+      isDirectMessage: false,
+    });
+  });
+
+  it.each([
+    { app: false, pathname: "/waves/1", query: "" },
+    { app: true, pathname: "/messages/1", query: "" },
+    { app: true, pathname: "/waves/1", query: "drop=drop-1" },
+    { app: true, pathname: "/waves/1", query: "create=wave" },
+  ])(
+    "does not enable wave-list swipe for app=$app path=$pathname query=$query",
+    async ({ app, pathname, query }) => {
+      isApp = app;
+      mockPathname = pathname;
+      mockSearchParams = new URLSearchParams(query);
+      mockActiveWaveId = "1";
+      waveData = createWave(pathname.startsWith("/messages/"));
+
+      render(<BrainMobile>child</BrainMobile>);
+
+      const waveContent = await screen.findByText("child");
+      fireEvent.touchStart(waveContent, {
+        touches: [{ clientX: 10, clientY: 100 }],
+      });
+      fireEvent.touchEnd(waveContent, {
+        changedTouches: [{ clientX: 100, clientY: 100 }],
+      });
+
+      expect(mockRequestMainWavesList).not.toHaveBeenCalled();
+      expect(mockClearLastVisited).not.toHaveBeenCalled();
+      expect(mockSetActiveWave).not.toHaveBeenCalled();
+    }
+  );
 
   it("keeps My Votes unavailable for guests on memes waves", async () => {
     mockSearchParams.set("wave", "1");

--- a/__tests__/components/brain/BrainMobile.test.tsx
+++ b/__tests__/components/brain/BrainMobile.test.tsx
@@ -429,6 +429,31 @@ describe("BrainMobile", () => {
     });
   });
 
+  it("enables wave-list swipe when the active wave comes from the URL", async () => {
+    mockPathname = "/waves/1";
+    mockActiveWaveId = null;
+    waveData = createWave(false);
+
+    render(<BrainMobile>child</BrainMobile>);
+
+    const waveContent = await screen.findByText("child");
+    fireEvent.touchStart(waveContent, {
+      touches: [{ clientX: 10, clientY: 100 }],
+    });
+    fireEvent.touchMove(waveContent, {
+      touches: [{ clientX: 60, clientY: 104 }],
+    });
+    fireEvent.touchEnd(waveContent, {
+      changedTouches: [{ clientX: 100, clientY: 106 }],
+    });
+
+    expect(mockRequestMainWavesList).toHaveBeenCalledTimes(1);
+    expect(mockClearLastVisited).toHaveBeenCalledWith("wave");
+    expect(mockSetActiveWave).toHaveBeenCalledWith(null, {
+      isDirectMessage: false,
+    });
+  });
+
   it.each([
     { app: false, pathname: "/waves/1", query: "" },
     { app: true, pathname: "/messages/1", query: "" },

--- a/__tests__/components/brain/mobile/useWaveListSwipeBack.test.tsx
+++ b/__tests__/components/brain/mobile/useWaveListSwipeBack.test.tsx
@@ -96,8 +96,30 @@ describe("useWaveListSwipeBack", () => {
     fireEvent.touchMove(target, { touches: [touch(18, 125)] });
     fireEvent.touchEnd(target, { changedTouches: [touch(120, 130)] });
 
-    expect(onIntentStart).toHaveBeenCalledTimes(1);
+    expect(onIntentStart).not.toHaveBeenCalled();
     expect(onSwipeBack).not.toHaveBeenCalled();
+  });
+
+  it("does not start intent for a left-edge tap", () => {
+    renderHarness();
+    const target = screen.getByTestId("plain-target");
+
+    fireEvent.touchStart(target, { touches: [touch(10, 100)] });
+    fireEvent.touchEnd(target, { changedTouches: [touch(10, 100)] });
+
+    expect(onIntentStart).not.toHaveBeenCalled();
+    expect(onSwipeBack).not.toHaveBeenCalled();
+  });
+
+  it("starts intent once after horizontal movement is confirmed", () => {
+    renderHarness();
+    const target = screen.getByTestId("plain-target");
+
+    fireEvent.touchStart(target, { touches: [touch(10, 100)] });
+    fireEvent.touchMove(target, { touches: [touch(24, 102)] });
+    fireEvent.touchMove(target, { touches: [touch(60, 104)] });
+
+    expect(onIntentStart).toHaveBeenCalledTimes(1);
   });
 
   it("does not commit a short, leftward, or cancelled gesture", () => {

--- a/__tests__/components/brain/mobile/useWaveListSwipeBack.test.tsx
+++ b/__tests__/components/brain/mobile/useWaveListSwipeBack.test.tsx
@@ -1,0 +1,146 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useWaveListSwipeBack } from "@/components/brain/mobile/useWaveListSwipeBack";
+
+const touch = (clientX: number, clientY: number) => ({ clientX, clientY });
+
+function SwipeHarness({
+  enabled = true,
+  onIntentStart,
+  onSwipeBack,
+}: {
+  readonly enabled?: boolean | undefined;
+  readonly onIntentStart: () => void;
+  readonly onSwipeBack: () => void;
+}) {
+  const handlers = useWaveListSwipeBack({
+    enabled,
+    onIntentStart,
+    onSwipeBack,
+  });
+
+  return (
+    <div data-testid="surface" {...handlers}>
+      <div data-testid="plain-target" />
+      <input
+        data-testid="slider-target"
+        type="range"
+        min={0}
+        max={100}
+        defaultValue={50}
+      />
+      <div data-testid="horizontal-scroller" style={{ overflowX: "auto" }}>
+        <div data-testid="horizontal-child" />
+      </div>
+    </div>
+  );
+}
+
+describe("useWaveListSwipeBack", () => {
+  const onIntentStart = jest.fn();
+  const onSwipeBack = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const renderHarness = (enabled = true) =>
+    render(
+      <SwipeHarness
+        enabled={enabled}
+        onIntentStart={onIntentStart}
+        onSwipeBack={onSwipeBack}
+      />
+    );
+
+  it("commits a horizontally dominant right swipe from the left edge", () => {
+    renderHarness();
+    const target = screen.getByTestId("plain-target");
+
+    fireEvent.touchStart(target, { touches: [touch(10, 100)] });
+    fireEvent.touchMove(target, { touches: [touch(55, 104)] });
+    fireEvent.touchEnd(target, { changedTouches: [touch(100, 106)] });
+
+    expect(onIntentStart).toHaveBeenCalledTimes(1);
+    expect(onSwipeBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores gestures that start outside the edge or are disabled", () => {
+    const { rerender } = renderHarness();
+    const target = screen.getByTestId("plain-target");
+
+    fireEvent.touchStart(target, { touches: [touch(40, 100)] });
+    fireEvent.touchEnd(target, { changedTouches: [touch(140, 100)] });
+
+    rerender(
+      <SwipeHarness
+        enabled={false}
+        onIntentStart={onIntentStart}
+        onSwipeBack={onSwipeBack}
+      />
+    );
+    const disabledTarget = screen.getByTestId("plain-target");
+    fireEvent.touchStart(disabledTarget, { touches: [touch(10, 100)] });
+    fireEvent.touchEnd(disabledTarget, {
+      changedTouches: [touch(110, 100)],
+    });
+
+    expect(onIntentStart).not.toHaveBeenCalled();
+    expect(onSwipeBack).not.toHaveBeenCalled();
+  });
+
+  it("cancels when vertical movement wins the gesture", () => {
+    renderHarness();
+    const target = screen.getByTestId("plain-target");
+
+    fireEvent.touchStart(target, { touches: [touch(10, 100)] });
+    fireEvent.touchMove(target, { touches: [touch(18, 125)] });
+    fireEvent.touchEnd(target, { changedTouches: [touch(120, 130)] });
+
+    expect(onIntentStart).toHaveBeenCalledTimes(1);
+    expect(onSwipeBack).not.toHaveBeenCalled();
+  });
+
+  it("does not commit a short, leftward, or cancelled gesture", () => {
+    renderHarness();
+    const target = screen.getByTestId("plain-target");
+
+    fireEvent.touchStart(target, { touches: [touch(10, 100)] });
+    fireEvent.touchEnd(target, { changedTouches: [touch(70, 100)] });
+
+    fireEvent.touchStart(target, { touches: [touch(10, 100)] });
+    fireEvent.touchMove(target, { touches: [touch(-5, 100)] });
+    fireEvent.touchEnd(target, { changedTouches: [touch(110, 100)] });
+
+    fireEvent.touchStart(target, { touches: [touch(10, 100)] });
+    fireEvent.touchCancel(target);
+    fireEvent.touchEnd(target, { changedTouches: [touch(110, 100)] });
+
+    expect(onSwipeBack).not.toHaveBeenCalled();
+  });
+
+  it("ignores multi-touch and interactive horizontal targets", () => {
+    renderHarness();
+    const surface = screen.getByTestId("surface");
+    const plainTarget = screen.getByTestId("plain-target");
+    const sliderTarget = screen.getByTestId("slider-target");
+    const horizontalScroller = screen.getByTestId("horizontal-scroller");
+    const horizontalChild = screen.getByTestId("horizontal-child");
+    Object.defineProperties(horizontalScroller, {
+      clientWidth: { configurable: true, value: 100 },
+      scrollWidth: { configurable: true, value: 200 },
+    });
+
+    fireEvent.touchStart(plainTarget, {
+      touches: [touch(10, 100), touch(12, 102)],
+    });
+    fireEvent.touchEnd(surface, { changedTouches: [touch(110, 100)] });
+
+    for (const target of [sliderTarget, horizontalChild]) {
+      fireEvent.touchStart(target, { touches: [touch(10, 100)] });
+      fireEvent.touchEnd(target, { changedTouches: [touch(110, 100)] });
+    }
+
+    expect(onIntentStart).not.toHaveBeenCalled();
+    expect(onSwipeBack).not.toHaveBeenCalled();
+  });
+});

--- a/components/brain/BrainMobile.tsx
+++ b/components/brain/BrainMobile.tsx
@@ -33,6 +33,7 @@ import {
 import { markDropCloseNavigation } from "@/helpers/drop-close-navigation.helpers";
 import CreateWaveModal from "@/components/waves/create-wave/CreateWaveModal";
 import CreateDirectMessageModal from "@/components/waves/create-dm/CreateDirectMessageModal";
+import { useExitActiveWave } from "@/components/navigation/useExitActiveWave";
 import { useAuth } from "@/components/auth/Auth";
 import { useMyStreamOptional } from "@/contexts/wave/MyStreamContext";
 import { useClosingDropId } from "@/hooks/useClosingDropId";
@@ -45,6 +46,7 @@ import {
   fetchDropByIdBatched,
   getDropQueryKey,
 } from "@/services/api/drop-api";
+import { useWaveListSwipeBack } from "./mobile/useWaveListSwipeBack";
 
 interface Props {
   readonly children: ReactNode;
@@ -65,6 +67,8 @@ const BrainMobileContent: React.FC<Props> = ({ children }) => {
     () => false
   );
   const myStream = useMyStreamOptional();
+  const requestMainWavesList = myStream?.requestMainWavesList;
+  const exitActiveWave = useExitActiveWave();
 
   const dropId = searchParams.get("drop") ?? undefined;
   const { effectiveDropId, beginClosingDrop } = useClosingDropId(dropId);
@@ -157,6 +161,23 @@ const BrainMobileContent: React.FC<Props> = ({ children }) => {
     drop.id.toLowerCase() === effectiveDropId.toLowerCase();
 
   const hasWave = Boolean(waveId);
+  const canSwipeBackToWaves =
+    isApp &&
+    hasWave &&
+    pathname.startsWith("/waves/") &&
+    dropId === undefined &&
+    searchParams.get("create") === null;
+  const handleSwipeBackIntent = useCallback(() => {
+    requestMainWavesList?.();
+  }, [requestMainWavesList]);
+  const handleSwipeBackToWaves = useCallback(() => {
+    exitActiveWave(false);
+  }, [exitActiveWave]);
+  const swipeBackHandlers = useWaveListSwipeBack({
+    enabled: canSwipeBackToWaves,
+    onIntentStart: handleSwipeBackIntent,
+    onSwipeBack: handleSwipeBackToWaves,
+  });
 
   const closeCreateOverlay = useCallback(() => {
     const params = new URLSearchParams(searchParams.toString() || "");
@@ -237,6 +258,7 @@ const BrainMobileContent: React.FC<Props> = ({ children }) => {
         <AnimatePresence mode="wait">
           <m.div
             key={activeView}
+            {...swipeBackHandlers}
             initial={{ opacity: 0, x: 20 }}
             animate={{ opacity: 1, x: 0 }}
             exit={{ opacity: 0, x: -20 }}

--- a/components/brain/mobile/useWaveListSwipeBack.ts
+++ b/components/brain/mobile/useWaveListSwipeBack.ts
@@ -1,0 +1,181 @@
+"use client";
+
+import type { HTMLAttributes, TouchEvent } from "react";
+import { useCallback, useMemo, useRef } from "react";
+
+const SWIPE_EDGE_WIDTH_PX = 32;
+const SWIPE_COMMIT_DISTANCE_PX = 80;
+const SWIPE_AXIS_LOCK_DISTANCE_PX = 12;
+const SWIPE_HORIZONTAL_DOMINANCE_RATIO = 1.5;
+
+const SWIPE_BACK_IGNORE_SELECTOR = [
+  "input",
+  "textarea",
+  "select",
+  "video",
+  "audio",
+  "canvas",
+  "[contenteditable='true']",
+  "[role='slider']",
+  "[data-wave-swipe-back-ignore='true']",
+  ".swiper",
+].join(",");
+
+type SwipeBackHandlers = Pick<
+  HTMLAttributes<HTMLDivElement>,
+  "onTouchStart" | "onTouchMove" | "onTouchEnd" | "onTouchCancel"
+>;
+
+interface UseWaveListSwipeBackArgs {
+  readonly enabled: boolean;
+  readonly onIntentStart?: (() => void) | undefined;
+  readonly onSwipeBack: () => void;
+}
+
+interface SwipeGesture {
+  readonly startX: number;
+  readonly startY: number;
+  currentX: number;
+  currentY: number;
+}
+
+const isHorizontallyScrollable = (element: HTMLElement): boolean => {
+  if (element.scrollWidth <= element.clientWidth) {
+    return false;
+  }
+
+  const overflowX =
+    element.style.overflowX || globalThis.getComputedStyle(element).overflowX;
+  return overflowX === "auto" || overflowX === "scroll";
+};
+
+const shouldIgnoreSwipeTarget = ({
+  boundary,
+  target,
+}: {
+  readonly boundary: EventTarget;
+  readonly target: EventTarget;
+}): boolean => {
+  if (!(boundary instanceof HTMLElement) || !(target instanceof Element)) {
+    return true;
+  }
+
+  if (target.closest(SWIPE_BACK_IGNORE_SELECTOR)) {
+    return true;
+  }
+
+  let element = target instanceof HTMLElement ? target : target.parentElement;
+  while (element && element !== boundary) {
+    if (isHorizontallyScrollable(element)) {
+      return true;
+    }
+    element = element.parentElement;
+  }
+
+  return false;
+};
+
+export function useWaveListSwipeBack({
+  enabled,
+  onIntentStart,
+  onSwipeBack,
+}: UseWaveListSwipeBackArgs): SwipeBackHandlers {
+  const gestureRef = useRef<SwipeGesture | null>(null);
+
+  const resetGesture = useCallback(() => {
+    gestureRef.current = null;
+  }, []);
+
+  const handleTouchStart = useCallback(
+    (event: TouchEvent<HTMLDivElement>) => {
+      resetGesture();
+
+      if (!enabled || event.touches.length !== 1) {
+        return;
+      }
+
+      const touch = event.touches[0];
+      if (
+        !touch ||
+        touch.clientX > SWIPE_EDGE_WIDTH_PX ||
+        shouldIgnoreSwipeTarget({
+          boundary: event.currentTarget,
+          target: event.target,
+        })
+      ) {
+        return;
+      }
+
+      gestureRef.current = {
+        startX: touch.clientX,
+        startY: touch.clientY,
+        currentX: touch.clientX,
+        currentY: touch.clientY,
+      };
+      onIntentStart?.();
+    },
+    [enabled, onIntentStart, resetGesture]
+  );
+
+  const handleTouchMove = useCallback(
+    (event: TouchEvent<HTMLDivElement>) => {
+      const gesture = gestureRef.current;
+      const touch = event.touches[0];
+      if (!gesture || event.touches.length !== 1 || !touch) {
+        resetGesture();
+        return;
+      }
+
+      gesture.currentX = touch.clientX;
+      gesture.currentY = touch.clientY;
+
+      const deltaX = gesture.currentX - gesture.startX;
+      const deltaY = gesture.currentY - gesture.startY;
+      const absoluteDeltaX = Math.abs(deltaX);
+      const absoluteDeltaY = Math.abs(deltaY);
+
+      if (
+        (deltaX < 0 && absoluteDeltaX >= SWIPE_AXIS_LOCK_DISTANCE_PX) ||
+        (absoluteDeltaY >= SWIPE_AXIS_LOCK_DISTANCE_PX &&
+          absoluteDeltaY > absoluteDeltaX)
+      ) {
+        resetGesture();
+      }
+    },
+    [resetGesture]
+  );
+
+  const handleTouchEnd = useCallback(
+    (event: TouchEvent<HTMLDivElement>) => {
+      const gesture = gestureRef.current;
+      if (!gesture) {
+        return;
+      }
+
+      const touch = event.changedTouches[0];
+      const endX = touch?.clientX ?? gesture.currentX;
+      const endY = touch?.clientY ?? gesture.currentY;
+      const deltaX = endX - gesture.startX;
+      const absoluteDeltaY = Math.abs(endY - gesture.startY);
+      resetGesture();
+
+      if (
+        deltaX >= SWIPE_COMMIT_DISTANCE_PX &&
+        deltaX >= absoluteDeltaY * SWIPE_HORIZONTAL_DOMINANCE_RATIO
+      ) {
+        onSwipeBack();
+      }
+    },
+    [onSwipeBack, resetGesture]
+  );
+
+  return useMemo(
+    () => ({
+      onTouchStart: handleTouchStart,
+      onTouchMove: handleTouchMove,
+      onTouchEnd: handleTouchEnd,
+      onTouchCancel: resetGesture,
+    }),
+    [handleTouchEnd, handleTouchMove, handleTouchStart, resetGesture]
+  );
+}

--- a/components/brain/mobile/useWaveListSwipeBack.ts
+++ b/components/brain/mobile/useWaveListSwipeBack.ts
@@ -37,6 +37,7 @@ interface SwipeGesture {
   readonly startY: number;
   currentX: number;
   currentY: number;
+  intentStarted: boolean;
 }
 
 const isHorizontallyScrollable = (element: HTMLElement): boolean => {
@@ -111,10 +112,10 @@ export function useWaveListSwipeBack({
         startY: touch.clientY,
         currentX: touch.clientX,
         currentY: touch.clientY,
+        intentStarted: false,
       };
-      onIntentStart?.();
     },
-    [enabled, onIntentStart, resetGesture]
+    [enabled, resetGesture]
   );
 
   const handleTouchMove = useCallback(
@@ -140,9 +141,19 @@ export function useWaveListSwipeBack({
           absoluteDeltaY > absoluteDeltaX)
       ) {
         resetGesture();
+        return;
+      }
+
+      if (
+        !gesture.intentStarted &&
+        deltaX >= SWIPE_AXIS_LOCK_DISTANCE_PX &&
+        deltaX >= absoluteDeltaY * SWIPE_HORIZONTAL_DOMINANCE_RATIO
+      ) {
+        gesture.intentStarted = true;
+        onIntentStart?.();
       }
     },
-    [resetGesture]
+    [onIntentStart, resetGesture]
   );
 
   const handleTouchEnd = useCallback(

--- a/components/navigation/BackButton.tsx
+++ b/components/navigation/BackButton.tsx
@@ -15,9 +15,9 @@ import {
   getWaveHomeRoute,
 } from "@/helpers/navigation.helpers";
 import { markDropCloseNavigation } from "@/helpers/drop-close-navigation.helpers";
-import { useViewContext } from "./ViewContext";
 import { useNavigationHistoryContext } from "@/contexts/NavigationHistoryContext";
 import { useClosingDropId } from "@/hooks/useClosingDropId";
+import { useExitActiveWave } from "./useExitActiveWave";
 
 export default function BackButton() {
   const router = useRouter();
@@ -27,7 +27,7 @@ export default function BackButton() {
   const [loading, setLoading] = useState(false);
   const { isApp } = useDeviceInfo();
   const myStream = useMyStreamOptional();
-  const { clearLastVisited } = useViewContext();
+  const exitActiveWave = useExitActiveWave();
   const { goBack } = useNavigationHistoryContext();
 
   const waveId =
@@ -100,8 +100,7 @@ export default function BackButton() {
 
     // Inside a wave → go back to wave list
     if (waveId) {
-      clearLastVisited(isDm ? "dm" : "wave");
-      myStream?.activeWave.set(null, { isDirectMessage: isDm });
+      exitActiveWave(isDm);
       return;
     }
 

--- a/components/navigation/useExitActiveWave.ts
+++ b/components/navigation/useExitActiveWave.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useCallback } from "react";
+import { useMyStreamOptional } from "@/contexts/wave/MyStreamContext";
+import { useViewContext } from "./ViewContext";
+
+export function useExitActiveWave() {
+  const myStream = useMyStreamOptional();
+  const { clearLastVisited } = useViewContext();
+  const setActiveWave = myStream?.activeWave.set;
+
+  return useCallback(
+    (isDirectMessage: boolean) => {
+      clearLastVisited(isDirectMessage ? "dm" : "wave");
+      setActiveWave?.(null, { isDirectMessage });
+    },
+    [clearLastVisited, setActiveWave]
+  );
+}

--- a/ops/docs/navigation/feature-back-button.md
+++ b/ops/docs/navigation/feature-back-button.md
@@ -3,7 +3,9 @@
 ## Overview
 
 In the app layout, header `Back` is context-aware. It appears only in supported
-contexts, then runs route rules before history.
+contexts, then runs route rules before history. Standard wave detail views also
+support a right swipe from the left edge of the main content as a shortcut back
+to the Waves list.
 
 ## Location in the Site
 
@@ -16,6 +18,8 @@ contexts, then runs route rules before history.
 ## Entry Points
 
 - Open a wave or DM thread.
+- In the native app, open a standard wave at `/waves/{waveId}` and start a
+  right swipe from the left edge of the main content.
 - Open a route with `?drop={dropId}`.
 - Open `/waves/create` or `/messages/create`.
 - Open a profile route after moving from another app route.
@@ -26,7 +30,8 @@ contexts, then runs route rules before history.
    - active wave context exists,
    - route is `/waves/create` or `/messages/create`,
    - route is a profile page and in-app history can go back.
-2. User taps `Back`.
+2. User taps `Back`. In a native-app standard wave, the user can instead swipe
+   right from the left edge of the main content.
 3. The app applies the first match in this order:
    - `/waves/create` -> replace to `/waves`
    - `/messages/create` -> replace to `/messages`
@@ -42,12 +47,19 @@ contexts, then runs route rules before history.
   to the matching list route.
 - Close focused drop: if `?drop=` exists, `Back` removes only `drop`.
 - Leave thread: `Back` clears active thread state and returns to section root.
+- Leave a standard wave in the native app: an edge swipe right clears the
+  active wave and returns to `/waves`, using the same state reset as `Back`.
 - Return from profile: if in-app history has a valid target, `Back` returns to
   it.
 
 ## Edge Cases
 
 - Repeat taps are ignored while fallback loading is active.
+- Edge swipe applies only to native-app `/waves/{waveId}` views. It does not run
+  on web, direct messages, list/create routes, or while a focused drop or create
+  overlay is active.
+- Vertical gestures and touches that begin on sliders, editors, media controls,
+  or horizontally scrollable content do not trigger Back.
 - Profile routes hide `Back` when there is no valid in-app target (for example
   direct entry or same-profile-only browsing).
 - If active wave metadata is missing, the app clears wave state and routes to
@@ -56,6 +68,8 @@ contexts, then runs route rules before history.
 ## Failure and Recovery
 
 - If `Back` is missing, use menu or bottom navigation to return to section root.
+- If the edge gesture is unavailable or does not complete, use the visible
+  app-header `Back` control.
 - If no valid history target exists, navigate directly to `/waves`,
   `/messages`, or another root route from navigation controls.
 - If a route transition stalls, refresh the current route and retry.
@@ -64,6 +78,8 @@ contexts, then runs route rules before history.
 
 - This behavior is app-layout only.
 - `Back` is context-aware, not a strict browser-back wrapper.
+- Edge swipe is an optional shortcut and never replaces the visible `Back`
+  control.
 - Leaving a thread with `Back` clears last-visited thread memory for that
   section.
 - Loading spinner appears only during history fallback.

--- a/ops/docs/waves/sidebars/feature-wave-list-navigation.md
+++ b/ops/docs/waves/sidebars/feature-wave-list-navigation.md
@@ -14,6 +14,8 @@ Wave and DM rows in the left list control which thread is open.
 - The expanded web Waves panel header includes a secondary `Discover Waves`
   link to `/discover`.
 - Browser back/forward keeps the active row and URL in sync.
+- In the native app, swipe right from the left edge of a standard wave detail
+  view to return to the Waves list.
 
 ## Location in the Site
 
@@ -28,6 +30,8 @@ Wave and DM rows in the left list control which thread is open.
 - From the expanded web Waves panel header, open `Discover Waves` for the
   `/discover` route.
 - Select an inactive wave or DM row from the list by clicking the row body.
+- In the native app, open a standard wave and swipe right from the left edge of
+  the main content.
 - Use browser back/forward after navigating between rows.
 
 ## User Journey
@@ -37,7 +41,9 @@ Wave and DM rows in the left list control which thread is open.
 3. The app updates the active highlight and URL together.
 4. Select the active row body again to clear selection and return to section
    home.
-5. Use browser back/forward to revisit row selections while keeping the list
+5. In the native app, an edge swipe right from a standard wave also clears the
+   active wave and restores the Waves list at its saved scroll position.
+6. Use browser back/forward to revisit row selections while keeping the list
    and URL in sync.
 
 ## Common Scenarios
@@ -45,6 +51,7 @@ Wave and DM rows in the left list control which thread is open.
 - Wave rows open `/waves/{waveId}`.
 - Direct-message rows open `/messages/{waveId}`.
 - Active-row re-click returns to `/waves` or `/messages`.
+- Native-app edge swipe from `/waves/{waveId}` returns to `/waves`.
 - Inside the `/waves` or `/messages` shell, row changes update URL/history in
   place and keep row highlight aligned.
 - On signed-out desktop web `/waves`, clearing the active row returns to
@@ -63,6 +70,12 @@ Wave and DM rows in the left list control which thread is open.
   idle desktop rows do not reserve the hidden pin width.
 - Non-touch devices can prefetch an inactive row on hover.
 - Touch devices do not use hover prefetch.
+- Edge-swipe navigation applies only to native-app standard wave details. It is
+  disabled on web, direct messages, list routes, create overlays, and focused
+  drop views.
+- The gesture starts from the left edge and ignores sliders, editors, media
+  controls, and horizontally scrollable content so those interactions keep
+  their normal touch behavior.
 - Browser-default behavior is kept for modified clicks such as Cmd/Ctrl-click,
   Shift/Alt-click, middle-click, and right-click/context menu.
 
@@ -76,6 +89,8 @@ Wave and DM rows in the left list control which thread is open.
 ## Limitations / Notes
 
 - This page owns row selection/navigation only.
+- The visible app-header `Back` control remains available as the non-gesture
+  way to return to the Waves list.
 - Row metadata (`Last drop`, badges, tooltips) is owned by the row-metadata
   page.
 - Pin and mute controls are owned by their sidebar control pages.

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -3344,11 +3344,28 @@
       "id": "navigation.back-button",
       "kind": "ui_affordance",
       "title": "Back button behavior",
-      "aliases": ["back button", "go back", "return", "previous page"],
-      "keywords": ["back", "button", "navigation", "history", "return"],
+      "aliases": [
+        "back button",
+        "go back",
+        "return",
+        "previous page",
+        "swipe back",
+        "swipe right"
+      ],
+      "keywords": [
+        "back",
+        "button",
+        "navigation",
+        "history",
+        "return",
+        "swipe",
+        "gesture",
+        "mobile"
+      ],
       "facts": [
         "Back button behavior is documented as shared navigation behavior.",
         "It depends on route history and app shell context.",
+        "In the native app, swiping right from the left edge of a standard wave detail returns to the Waves list; the shortcut is disabled for direct messages and focused drop or create overlays.",
         "Use it when users ask why a back control returns to a prior app surface."
       ],
       "canonical_path": "/waves",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -3344,11 +3344,28 @@
       "id": "navigation.back-button",
       "kind": "ui_affordance",
       "title": "Back button behavior",
-      "aliases": ["back button", "go back", "return", "previous page"],
-      "keywords": ["back", "button", "navigation", "history", "return"],
+      "aliases": [
+        "back button",
+        "go back",
+        "return",
+        "previous page",
+        "swipe back",
+        "swipe right"
+      ],
+      "keywords": [
+        "back",
+        "button",
+        "navigation",
+        "history",
+        "return",
+        "swipe",
+        "gesture",
+        "mobile"
+      ],
       "facts": [
         "Back button behavior is documented as shared navigation behavior.",
         "It depends on route history and app shell context.",
+        "In the native app, swiping right from the left edge of a standard wave detail returns to the Waves list; the shortcut is disabled for direct messages and focused drop or create overlays.",
         "Use it when users ask why a back control returns to a prior app surface."
       ],
       "canonical_path": "/waves",


### PR DESCRIPTION
## Issue

In the native mobile app, opening a wave detail replaces the Waves list surface, but users cannot use the familiar edge-swipe gesture to return to the list.

## Fix

Add a native-app-only right swipe from the left edge of standard `/waves/{waveId}` views. A completed horizontal gesture exits the active wave through the same state-reset path as the visible Back button.

## Changes

- Add a focused edge-swipe hook with distance, direction, and axis guards.
- Ignore gestures started on form controls, editors, media, sliders, Swiper content, and horizontally scrollable regions.
- Disable the gesture on web, direct messages, focused drops, and create overlays.
- Prewarm the main Waves list only after horizontal swipe intent is confirmed.
- Share active-wave exit behavior between the gesture and Back button.
- Add unit/integration coverage and update navigation docs plus the help index.

## Validation

- `./bin/6529 run test:no-coverage __tests__/components/brain/mobile/useWaveListSwipeBack.test.tsx __tests__/components/brain/BrainMobile.test.tsx __tests__/components/navigation/BackButton.test.tsx --runInBand` — 34 tests passed.
- `./bin/6529 run lint:changed` — passed.
- `./bin/6529 run typecheck:changed` — passed for 4 changed TypeScript files.
- `./bin/6529 run help-index:sync` — passed; source and published help indexes match.
- Documentation link validation and `git diff --check` — passed.
- React Doctor branch scan: 98/100. Its one error and one warning are unchanged `BackButton` baseline lines outside this patch.
- GitHub current-head checks — DCO, debt ratchet, secret scan, Snyk, CodeQL, SonarCloud, CodeRabbit, production build, related Jest, and both Playwright packs passed.

## Risk

- Level: Low.
- Why: The gesture is attached only to the native wave-detail content boundary and leaves the existing visible Back control intact.
- Rollback: Revert the two feature commits to restore the previous Back-button-only behavior.

## Review Notes

Please focus on gesture-conflict exclusions and the native-app route gates. The change intentionally does not enable swipe-back for DMs, focused drops, create overlays, or web. The follow-up commit addresses review feedback by delaying list prewarming until horizontal intent is confirmed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added right-edge swipe navigation in the native app to return from standard wave details to the Waves list.
  * Preserved the active wave and view state behavior when leaving a wave.
  * Swipe navigation avoids interfering with sliders, editors, media controls, and horizontally scrollable content.
  * The existing Back button remains available as an alternative.

* **Documentation**
  * Updated navigation, wave-list, and help documentation with swipe-back behavior and limitations.

* **Tests**
  * Added comprehensive coverage for valid, invalid, canceled, and conflicting swipe gestures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->