### PR TITLE
Preserve parenthesized ordered list markers

### DIFF
--- a/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
+++ b/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
@@ -7,8 +7,10 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import DropPartMarkdown from "@/components/drops/view/part/DropPartMarkdown";
 import { DropImageGalleryProvider } from "@/components/drops/view/part/DropImageGalleryProvider";
 import { buildDropImageGalleryItems } from "@/components/drops/view/part/dropImageGallery";
-import { PARENTHESIZED_ORDERED_LIST_CLASS_NAME } from "@/components/drops/view/part/dropPartMarkdown/orderedListDelimiter";
 import { ApiDropGroupMention } from "@/generated/models/ApiDropGroupMention";
+
+const PARENTHESIZED_ORDERED_LIST_CLASS_NAME =
+  "drop-markdown-ordered-list-paren";
 
 class MockIntersectionObserver {
   observe = jest.fn();

--- a/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
+++ b/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
@@ -7,6 +7,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import DropPartMarkdown from "@/components/drops/view/part/DropPartMarkdown";
 import { DropImageGalleryProvider } from "@/components/drops/view/part/DropImageGalleryProvider";
 import { buildDropImageGalleryItems } from "@/components/drops/view/part/dropImageGallery";
+import { PARENTHESIZED_ORDERED_LIST_CLASS_NAME } from "@/components/drops/view/part/dropPartMarkdown/orderedListDelimiter";
 import { ApiDropGroupMention } from "@/generated/models/ApiDropGroupMention";
 
 class MockIntersectionObserver {
@@ -1253,6 +1254,56 @@ describe("DropPartMarkdown", () => {
     expect(paragraphs[0]).toHaveTextContent("see deep sea");
     expect(anchor).toHaveAttribute("href", previewUrl);
     expect(anchor.closest("p")).toBe(paragraphs[0]);
+  });
+
+  it("preserves a parenthesized ordered-list marker", () => {
+    const { container } = render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        mentionedWaves={[]}
+        referencedNfts={[]}
+        partContent="1) What"
+        onQuoteClick={jest.fn()}
+      />
+    );
+
+    const list = container.querySelector("ol");
+    expect(list).toHaveClass(PARENTHESIZED_ORDERED_LIST_CLASS_NAME);
+    expect(screen.getByRole("listitem")).toHaveTextContent("What");
+  });
+
+  it("keeps period-delimited ordered lists on the default marker style", () => {
+    const { container } = render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        mentionedWaves={[]}
+        referencedNfts={[]}
+        partContent="1. What"
+        onQuoteClick={jest.fn()}
+      />
+    );
+
+    expect(container.querySelector("ol")).not.toHaveClass(
+      PARENTHESIZED_ORDERED_LIST_CLASS_NAME
+    );
+  });
+
+  it("preserves non-one numbering only on parenthesized ordered lists", () => {
+    const { container } = render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        mentionedWaves={[]}
+        referencedNfts={[]}
+        partContent={"3) Three\n4) Four\n\n1. One"}
+        onQuoteClick={jest.fn()}
+      />
+    );
+
+    const lists = container.querySelectorAll("ol");
+    expect(lists).toHaveLength(2);
+    expect(lists[0]).toHaveClass(PARENTHESIZED_ORDERED_LIST_CLASS_NAME);
+    expect(lists[0]).toHaveAttribute("start", "3");
+    expect(lists[1]).not.toHaveClass(PARENTHESIZED_ORDERED_LIST_CLASS_NAME);
   });
 
   it("renders separate paragraphs for blank-line content with tight spacing", () => {

--- a/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
+++ b/__tests__/components/drops/view/part/DropPartMarkdown.test.tsx
@@ -1306,6 +1306,23 @@ describe("DropPartMarkdown", () => {
     expect(lists[1]).not.toHaveClass(PARENTHESIZED_ORDERED_LIST_CLASS_NAME);
   });
 
+  it("preserves parenthesized markers on nested ordered lists", () => {
+    const { container } = render(
+      <DropPartMarkdown
+        mentionedUsers={[]}
+        mentionedWaves={[]}
+        referencedNfts={[]}
+        partContent={"1) Parent\n   1) Child\n   2) Nested"}
+        onQuoteClick={jest.fn()}
+      />
+    );
+
+    const lists = container.querySelectorAll("ol");
+    expect(lists).toHaveLength(2);
+    expect(lists[0]).toHaveClass(PARENTHESIZED_ORDERED_LIST_CLASS_NAME);
+    expect(lists[1]).toHaveClass(PARENTHESIZED_ORDERED_LIST_CLASS_NAME);
+  });
+
   it("renders separate paragraphs for blank-line content with tight spacing", () => {
     render(
       <DropPartMarkdown

--- a/components/drops/view/part/DropPartMarkdown.tsx
+++ b/components/drops/view/part/DropPartMarkdown.tsx
@@ -17,10 +17,7 @@ import Markdown, {
   type ExtraProps,
 } from "react-markdown";
 import rehypeExternalLinks from "rehype-external-links";
-import rehypeSanitize, {
-  defaultSchema,
-  type Options as RehypeSanitizeOptions,
-} from "rehype-sanitize";
+import rehypeSanitize from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 import { useQueryClient } from "@tanstack/react-query";
 import type { PluggableList } from "unified";
@@ -48,37 +45,12 @@ import {
   DEFAULT_MAX_EMBED_DEPTH,
 } from "./dropPartMarkdown/linkHandlers";
 import { isSafeMarkdownImageSrc } from "./dropPartMarkdown/linkUtils";
-import {
-  PARENTHESIZED_ORDERED_LIST_CLASS_NAME,
-  remarkPreserveOrderedListDelimiter,
-} from "./dropPartMarkdown/orderedListDelimiter";
+import { rehypePreserveOrderedListDelimiter } from "./dropPartMarkdown/orderedListDelimiter";
 
 const BreakComponent = () => <br />;
 
 const EMPTY_MENTIONED_GROUPS: ApiDropGroupMention[] = [];
 const EMOJI_SHORTCODE_REGEX = /:\w+:/;
-const DROP_MARKDOWN_ORDERED_LIST_ATTRIBUTES = (
-  defaultSchema.attributes?.["ol"] ?? []
-).map((attribute) =>
-  Array.isArray(attribute) && attribute[0] === "className"
-    ? ([
-        ...attribute,
-        PARENTHESIZED_ORDERED_LIST_CLASS_NAME,
-      ] as typeof attribute)
-    : attribute
-);
-const DROP_MARKDOWN_SANITIZE_SCHEMA = {
-  attributes: {
-    ...(defaultSchema.attributes ?? {}),
-    ol: DROP_MARKDOWN_ORDERED_LIST_ATTRIBUTES,
-  },
-  protocols: {
-    cite: ["http", "https"],
-    href: ["http", "https", "irc", "ircs", "mailto", "xmpp"],
-    longDesc: ["http", "https"],
-    src: ["http", "https", "data"],
-  },
-} satisfies RehypeSanitizeOptions;
 
 const mergeClassNames = (...classes: Array<string | undefined>): string =>
   classes.filter(Boolean).join(" ");
@@ -417,15 +389,50 @@ function DropPartMarkdown({
           protocols: ["http", "https"],
         },
       ],
-      [rehypeSanitize, DROP_MARKDOWN_SANITIZE_SCHEMA],
+      [
+        rehypeSanitize,
+        {
+          allowedTags: [
+            "p",
+            "br",
+            "strong",
+            "em",
+            "a",
+            "code",
+            "pre",
+            "blockquote",
+            "h1",
+            "h2",
+            "h3",
+            "h4",
+            "h5",
+            "h6",
+            "ul",
+            "ol",
+            "li",
+            "img",
+          ],
+          allowedAttributes: {
+            a: ["href", "title"],
+            img: ["src", "alt", "title"],
+            code: ["className"],
+            pre: ["className"],
+          },
+          protocols: {
+            cite: ["http", "https"],
+            href: ["http", "https", "irc", "ircs", "mailto", "xmpp"],
+            longDesc: ["http", "https"],
+            src: ["http", "https", "data"],
+          },
+        },
+      ],
+      // This trusted plugin only adds one static renderer-owned class.
+      rehypePreserveOrderedListDelimiter,
     ],
     []
   );
 
-  const remarkPlugins = useMemo<PluggableList>(
-    () => [remarkGfm, remarkPreserveOrderedListDelimiter],
-    []
-  );
+  const remarkPlugins = useMemo<PluggableList>(() => [remarkGfm], []);
 
   const markdownComponents = useMemo<Components>(
     () =>

--- a/components/drops/view/part/DropPartMarkdown.tsx
+++ b/components/drops/view/part/DropPartMarkdown.tsx
@@ -17,7 +17,10 @@ import Markdown, {
   type ExtraProps,
 } from "react-markdown";
 import rehypeExternalLinks from "rehype-external-links";
-import rehypeSanitize from "rehype-sanitize";
+import rehypeSanitize, {
+  defaultSchema,
+  type Options as RehypeSanitizeOptions,
+} from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 import { useQueryClient } from "@tanstack/react-query";
 import type { PluggableList } from "unified";
@@ -45,11 +48,37 @@ import {
   DEFAULT_MAX_EMBED_DEPTH,
 } from "./dropPartMarkdown/linkHandlers";
 import { isSafeMarkdownImageSrc } from "./dropPartMarkdown/linkUtils";
+import {
+  PARENTHESIZED_ORDERED_LIST_CLASS_NAME,
+  remarkPreserveOrderedListDelimiter,
+} from "./dropPartMarkdown/orderedListDelimiter";
 
 const BreakComponent = () => <br />;
 
 const EMPTY_MENTIONED_GROUPS: ApiDropGroupMention[] = [];
 const EMOJI_SHORTCODE_REGEX = /:\w+:/;
+const DROP_MARKDOWN_ORDERED_LIST_ATTRIBUTES = (
+  defaultSchema.attributes?.["ol"] ?? []
+).map((attribute) =>
+  Array.isArray(attribute) && attribute[0] === "className"
+    ? ([
+        ...attribute,
+        PARENTHESIZED_ORDERED_LIST_CLASS_NAME,
+      ] as typeof attribute)
+    : attribute
+);
+const DROP_MARKDOWN_SANITIZE_SCHEMA = {
+  attributes: {
+    ...(defaultSchema.attributes ?? {}),
+    ol: DROP_MARKDOWN_ORDERED_LIST_ATTRIBUTES,
+  },
+  protocols: {
+    cite: ["http", "https"],
+    href: ["http", "https", "irc", "ircs", "mailto", "xmpp"],
+    longDesc: ["http", "https"],
+    src: ["http", "https", "data"],
+  },
+} satisfies RehypeSanitizeOptions;
 
 const mergeClassNames = (...classes: Array<string | undefined>): string =>
   classes.filter(Boolean).join(" ");
@@ -388,48 +417,15 @@ function DropPartMarkdown({
           protocols: ["http", "https"],
         },
       ],
-      [
-        rehypeSanitize,
-        {
-          allowedTags: [
-            "p",
-            "br",
-            "strong",
-            "em",
-            "a",
-            "code",
-            "pre",
-            "blockquote",
-            "h1",
-            "h2",
-            "h3",
-            "h4",
-            "h5",
-            "h6",
-            "ul",
-            "ol",
-            "li",
-            "img",
-          ],
-          allowedAttributes: {
-            a: ["href", "title"],
-            img: ["src", "alt", "title"],
-            code: ["className"],
-            pre: ["className"],
-          },
-          protocols: {
-            cite: ["http", "https"],
-            href: ["http", "https", "irc", "ircs", "mailto", "xmpp"],
-            longDesc: ["http", "https"],
-            src: ["http", "https", "data"],
-          },
-        },
-      ],
+      [rehypeSanitize, DROP_MARKDOWN_SANITIZE_SCHEMA],
     ],
     []
   );
 
-  const remarkPlugins = useMemo<PluggableList>(() => [remarkGfm], []);
+  const remarkPlugins = useMemo<PluggableList>(
+    () => [remarkGfm, remarkPreserveOrderedListDelimiter],
+    []
+  );
 
   const markdownComponents = useMemo<Components>(
     () =>

--- a/components/drops/view/part/dropPartMarkdown/orderedListDelimiter.ts
+++ b/components/drops/view/part/dropPartMarkdown/orderedListDelimiter.ts
@@ -1,0 +1,76 @@
+import type { Plugin } from "unified";
+
+export const PARENTHESIZED_ORDERED_LIST_CLASS_NAME =
+  "drop-markdown-ordered-list-paren";
+
+const ORDERED_LIST_MARKER_PATTERN = /^[\t ]*\d{1,9}([.)])(?:[\t ]+|$)/;
+
+interface MarkdownAstNode {
+  readonly type?: unknown;
+  readonly ordered?: unknown;
+  readonly position?: {
+    readonly start?: {
+      readonly offset?: number | undefined;
+    };
+  };
+  data?: {
+    hProperties?: Record<string, unknown> | undefined;
+  };
+  readonly children?: readonly MarkdownAstNode[] | undefined;
+}
+
+const normalizeClassNames = (className: unknown): string[] => {
+  if (typeof className === "string") {
+    return className.split(/\s+/).filter(Boolean);
+  }
+
+  if (!Array.isArray(className)) {
+    return [];
+  }
+
+  return className.filter(
+    (value: unknown): value is string => typeof value === "string"
+  );
+};
+
+const addParenthesizedListClass = (node: MarkdownAstNode): void => {
+  const hProperties = node.data?.hProperties ?? {};
+  const classNames = normalizeClassNames(hProperties["className"]);
+
+  if (!classNames.includes(PARENTHESIZED_ORDERED_LIST_CLASS_NAME)) {
+    classNames.push(PARENTHESIZED_ORDERED_LIST_CLASS_NAME);
+  }
+
+  node.data = {
+    ...node.data,
+    hProperties: {
+      ...hProperties,
+      className: classNames,
+    },
+  };
+};
+
+const preserveOrderedListDelimiter = (
+  node: MarkdownAstNode,
+  source: string
+): void => {
+  if (node.type === "list" && node.ordered === true) {
+    const offset = node.position?.start?.offset;
+    if (typeof offset === "number") {
+      const marker = ORDERED_LIST_MARKER_PATTERN.exec(source.slice(offset));
+      if (marker?.[1] === ")") {
+        addParenthesizedListClass(node);
+      }
+    }
+  }
+
+  node.children?.forEach((child) => {
+    preserveOrderedListDelimiter(child, source);
+  });
+};
+
+export const remarkPreserveOrderedListDelimiter: Plugin = () => {
+  return (tree, file) => {
+    preserveOrderedListDelimiter(tree as MarkdownAstNode, String(file.value));
+  };
+};

--- a/components/drops/view/part/dropPartMarkdown/orderedListDelimiter.ts
+++ b/components/drops/view/part/dropPartMarkdown/orderedListDelimiter.ts
@@ -5,18 +5,16 @@ export const PARENTHESIZED_ORDERED_LIST_CLASS_NAME =
 
 const ORDERED_LIST_MARKER_PATTERN = /^[\t ]*\d{1,9}([.)])(?:[\t ]+|$)/;
 
-interface MarkdownAstNode {
+interface MarkdownHastNode {
   readonly type?: unknown;
-  readonly ordered?: unknown;
+  readonly tagName?: unknown;
   readonly position?: {
     readonly start?: {
       readonly offset?: number | undefined;
     };
   };
-  data?: {
-    hProperties?: Record<string, unknown> | undefined;
-  };
-  readonly children?: readonly MarkdownAstNode[] | undefined;
+  properties?: Record<string, unknown> | undefined;
+  readonly children?: readonly MarkdownHastNode[] | undefined;
 }
 
 const normalizeClassNames = (className: unknown): string[] => {
@@ -33,28 +31,25 @@ const normalizeClassNames = (className: unknown): string[] => {
   );
 };
 
-const addParenthesizedListClass = (node: MarkdownAstNode): void => {
-  const hProperties = node.data?.hProperties ?? {};
-  const classNames = normalizeClassNames(hProperties["className"]);
+const addParenthesizedListClass = (node: MarkdownHastNode): void => {
+  const properties = node.properties ?? {};
+  const classNames = normalizeClassNames(properties["className"]);
 
   if (!classNames.includes(PARENTHESIZED_ORDERED_LIST_CLASS_NAME)) {
     classNames.push(PARENTHESIZED_ORDERED_LIST_CLASS_NAME);
   }
 
-  node.data = {
-    ...node.data,
-    hProperties: {
-      ...hProperties,
-      className: classNames,
-    },
+  node.properties = {
+    ...properties,
+    className: classNames,
   };
 };
 
 const preserveOrderedListDelimiter = (
-  node: MarkdownAstNode,
+  node: MarkdownHastNode,
   source: string
 ): void => {
-  if (node.type === "list" && node.ordered === true) {
+  if (node.type === "element" && node.tagName === "ol") {
     const offset = node.position?.start?.offset;
     if (typeof offset === "number") {
       const marker = ORDERED_LIST_MARKER_PATTERN.exec(source.slice(offset));
@@ -69,8 +64,8 @@ const preserveOrderedListDelimiter = (
   });
 };
 
-export const remarkPreserveOrderedListDelimiter: Plugin = () => {
+export const rehypePreserveOrderedListDelimiter: Plugin = () => {
   return (tree, file) => {
-    preserveOrderedListDelimiter(tree as MarkdownAstNode, String(file.value));
+    preserveOrderedListDelimiter(tree as MarkdownHastNode, String(file.value));
   };
 };

--- a/components/drops/view/part/dropPartMarkdown/orderedListDelimiter.ts
+++ b/components/drops/view/part/dropPartMarkdown/orderedListDelimiter.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from "unified";
 
-export const PARENTHESIZED_ORDERED_LIST_CLASS_NAME =
+const PARENTHESIZED_ORDERED_LIST_CLASS_NAME =
   "drop-markdown-ordered-list-paren";
 
 const ORDERED_LIST_MARKER_PATTERN = /^[\t ]*\d{1,9}([.)])(?:[\t ]+|$)/;

--- a/ops/docs/waves/drop-actions/feature-content-display.md
+++ b/ops/docs/waves/drop-actions/feature-content-display.md
@@ -35,6 +35,8 @@ Multipart drops ("storms") stay in one card while users switch parts.
 ## Common Scenarios
 
 - Full markdown body renders inline, including headings, lists, quotes, and code.
+- Ordered lists accept both `1.` and `1)` markers and keep the chosen delimiter
+  when rendered.
 - Code blocks use syntax highlighting when available.
 - Paragraphs split by a single blank line render as separate paragraphs with
   tight spacing.

--- a/ops/help/help-index.json
+++ b/ops/help/help-index.json
@@ -4446,11 +4446,29 @@
       "id": "waves.drop.content-display",
       "kind": "ui_affordance",
       "title": "Wave drop content display",
-      "aliases": ["drop content", "read drop", "drop display", "drop media"],
-      "keywords": ["waves", "drop", "content", "display", "media", "text"],
+      "aliases": [
+        "drop content",
+        "read drop",
+        "drop display",
+        "drop media",
+        "ordered list",
+        "numbered list"
+      ],
+      "keywords": [
+        "waves",
+        "drop",
+        "content",
+        "display",
+        "media",
+        "text",
+        "markdown",
+        "list",
+        "numbered"
+      ],
       "facts": [
         "Wave drop content display docs explain how posted drop content is rendered.",
         "Content display is separate from composer submission behavior.",
+        "Ordered lists accept both 1. and 1) markers and preserve the chosen delimiter when rendered.",
         "Media, quote links, replies, and selection copy have additional drop-action records."
       ],
       "canonical_path": "/waves",

--- a/public/help-index.json
+++ b/public/help-index.json
@@ -4446,11 +4446,29 @@
       "id": "waves.drop.content-display",
       "kind": "ui_affordance",
       "title": "Wave drop content display",
-      "aliases": ["drop content", "read drop", "drop display", "drop media"],
-      "keywords": ["waves", "drop", "content", "display", "media", "text"],
+      "aliases": [
+        "drop content",
+        "read drop",
+        "drop display",
+        "drop media",
+        "ordered list",
+        "numbered list"
+      ],
+      "keywords": [
+        "waves",
+        "drop",
+        "content",
+        "display",
+        "media",
+        "text",
+        "markdown",
+        "list",
+        "numbered"
+      ],
       "facts": [
         "Wave drop content display docs explain how posted drop content is rendered.",
         "Content display is separate from composer submission behavior.",
+        "Ordered lists accept both 1. and 1) markers and preserve the chosen delimiter when rendered.",
         "Media, quote links, replies, and selection copy have additional drop-action records."
       ],
       "canonical_path": "/waves",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,6 +4,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.drop-markdown-ordered-list-paren > li::marker {
+  content: counter(list-item) ") ";
+}
+
 @layer components {
   .layout-root {
     min-height: 100dvh;


### PR DESCRIPTION
## Issue
- Tech Feedback drop #1181639 reports that a message typed as `1) What` renders as `1. What`.
- CommonMark correctly parses both delimiters as ordered lists, but the browser's default marker style discards the source delimiter and always displays a period.

## Fix
- Preserve semantic `<ol>/<li>` output while detecting whether each ordered list used a parenthesized source marker.
- After untrusted Markdown has passed through the existing sanitizer unchanged, add one static renderer-owned class to parenthesized ordered lists and render that class with a matching `)` marker.

## Changes
- Add a small post-sanitize rehype transformer that detects ordered-list delimiters from source positions.
- Keep the existing sanitizer configuration unchanged and limit the transformer to one static class on `<ol>` elements.
- Add focused coverage for `1)`, `1.`, non-one starting values, and nested parenthesized lists.
- Document the supported delimiters and update the frontend Help Bot corpus and published artifact.

## Validation
- `./bin/6529 run test --testPathPatterns=__tests__/components/drops/view/part/DropPartMarkdown.test.tsx` — 49/49 passed.
- Tight ESLint on the three changed TypeScript/React files — passed.
- Full TypeScript check with `tsc --noEmit -p tsconfig.typecheck.json --incremental false` — passed.
- Help-index and agent-file sync commands — passed with no generated drift.
- Docs link validation — 277 Markdown files passed.
- React Doctor against `origin/main` — 99/100; only pre-existing warnings in test mocks, no production-code finding.
- Staging-backed browser QA — posted mixed `1)`, `1.`, and `3)` lists; verified marker classes and semantic numbering after the post-sanitize change.

## Risk
- Level: Low
- Why: The change is isolated to the shared Markdown renderer, leaves sanitization unchanged, and only adds styling for ordered lists that the parser already recognizes as parenthesized.
- Rollback: Revert the two PR commits to restore the browser-default period marker for all ordered lists.

## Review Notes
- Please focus on source-position handling for nested/indented lists and the ordering of the trusted transformer after sanitization.
- The implementation intentionally keeps native ordered-list semantics rather than converting lists back to plain text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ordered Markdown lists now support both period (`1.`) and parenthesis (`1)`) markers.
  * Rendered lists preserve the delimiter used in the original content, including nested lists.

* **Documentation**
  * Updated content-display guidance and help search terms to document the supported ordered-list formats.

* **Style**
  * Added visual styling for parenthesis-delimited ordered-list markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->