### PR TITLE
Fix reaction reconciliation lifecycle

### DIFF
--- a/__tests__/utils/monitoring/dropReactionMonitoring.test.ts
+++ b/__tests__/utils/monitoring/dropReactionMonitoring.test.ts
@@ -526,15 +526,15 @@ describe("dropReactionMonitoring", () => {
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });
 
-  it("captures reconciliation mismatch after the guard window", () => {
+  it("captures the production-shaped slow reconciliation mismatch", () => {
     const mutation = beginReactionMutation({
       dropId: "drop-4",
       waveId: "wave-1",
-      source: "chip",
-      action: "replace",
-      previousReaction: ":wave:",
-      intendedReaction: ":smile:",
-      optimisticReaction: ":smile:",
+      source: "quick-react",
+      action: "add",
+      previousReaction: null,
+      intendedReaction: ":joy:",
+      optimisticReaction: ":joy:",
       profileId: "profile-1",
       websocketStatus: WebSocketStatus.CONNECTED,
     });
@@ -548,13 +548,13 @@ describe("dropReactionMonitoring", () => {
     recordReactionRequestSucceeded(mutation);
     expect(mutation.apiFailedAt).toBeNull();
 
-    dateNowSpy.mockReturnValue(17_000);
+    dateNowSpy.mockReturnValue(218_657);
     const result = recordReactionRealtimeReconciliation({
       drop: {
         id: "drop-4",
         wave: { id: "wave-1" },
         context_profile_context: {
-          reaction: ":wave:",
+          reaction: null,
         } as any,
       },
       websocketStatus: WebSocketStatus.CONNECTED,
@@ -562,14 +562,14 @@ describe("dropReactionMonitoring", () => {
 
     expect(result).toEqual({
       shouldApplyCanonicalDrop: true,
-      expectedReaction: ":smile:",
-      serverReaction: ":wave:",
+      expectedReaction: ":joy:",
+      serverReaction: null,
     });
     expect(addBreadcrumbMock).toHaveBeenCalledWith(
       expect.objectContaining({
         message: "reaction.optimistic_reverted",
         data: expect.objectContaining({
-          server_reaction: ":wave:",
+          time_since_mutation_ms: 217_657,
         }),
       })
     );
@@ -623,6 +623,61 @@ describe("dropReactionMonitoring", () => {
         message: "reaction.realtime_reconciled",
       })
     );
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it("does not attribute a later canonical change to a reconciled mutation", () => {
+    const mutation = beginReactionMutation({
+      dropId: "drop-5-reconciled",
+      waveId: "wave-1",
+      source: "quick-react",
+      action: "add",
+      previousReaction: null,
+      intendedReaction: ":joy:",
+      optimisticReaction: ":joy:",
+      profileId: "profile-1",
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+
+    recordReactionRequestSent(mutation, {
+      endpoint: "drops/drop-5-reconciled/reaction",
+      method: "POST",
+    });
+
+    dateNowSpy.mockReturnValue(1_100);
+    recordReactionRequestSucceeded(mutation);
+
+    dateNowSpy.mockReturnValue(1_300);
+    recordReactionRealtimeReconciliation({
+      drop: {
+        id: "drop-5-reconciled",
+        wave: { id: "wave-1" },
+        context_profile_context: {
+          reaction: ":joy:",
+        } as any,
+      },
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+
+    addBreadcrumbMock.mockClear();
+    dateNowSpy.mockReturnValue(218_657);
+    const result = recordReactionRealtimeReconciliation({
+      drop: {
+        id: "drop-5-reconciled",
+        wave: { id: "wave-1" },
+        context_profile_context: {
+          reaction: null,
+        } as any,
+      },
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+
+    expect(result).toEqual({
+      shouldApplyCanonicalDrop: true,
+      expectedReaction: null,
+      serverReaction: null,
+    });
+    expect(addBreadcrumbMock).not.toHaveBeenCalled();
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });
 

--- a/__tests__/utils/monitoring/dropReactionMonitoring.test.ts
+++ b/__tests__/utils/monitoring/dropReactionMonitoring.test.ts
@@ -681,6 +681,81 @@ describe("dropReactionMonitoring", () => {
     expect(captureExceptionMock).not.toHaveBeenCalled();
   });
 
+  it("keeps the realtime guard until the matching request succeeds", () => {
+    const mutation = beginReactionMutation({
+      dropId: "drop-5-pending",
+      waveId: "wave-1",
+      source: "quick-react",
+      action: "add",
+      previousReaction: null,
+      intendedReaction: ":joy:",
+      optimisticReaction: ":joy:",
+      profileId: "profile-1",
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+
+    recordReactionRequestSent(mutation, {
+      endpoint: "drops/drop-5-pending/reaction",
+      method: "POST",
+    });
+
+    dateNowSpy.mockReturnValue(1_200);
+    recordReactionRealtimeReconciliation({
+      drop: {
+        id: "drop-5-pending",
+        wave: { id: "wave-1" },
+        context_profile_context: {
+          reaction: ":joy:",
+        } as any,
+      },
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+
+    dateNowSpy.mockReturnValue(1_300);
+    const staleResult = recordReactionRealtimeReconciliation({
+      drop: {
+        id: "drop-5-pending",
+        wave: { id: "wave-1" },
+        context_profile_context: {
+          reaction: null,
+        } as any,
+      },
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+
+    expect(staleResult).toEqual({
+      shouldApplyCanonicalDrop: false,
+      expectedReaction: ":joy:",
+      serverReaction: null,
+      supersededByMutationId: mutation.mutationId,
+    });
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+
+    dateNowSpy.mockReturnValue(1_400);
+    recordReactionRequestSucceeded(mutation);
+
+    addBreadcrumbMock.mockClear();
+    dateNowSpy.mockReturnValue(1_500);
+    const laterResult = recordReactionRealtimeReconciliation({
+      drop: {
+        id: "drop-5-pending",
+        wave: { id: "wave-1" },
+        context_profile_context: {
+          reaction: null,
+        } as any,
+      },
+      websocketStatus: WebSocketStatus.CONNECTED,
+    });
+
+    expect(laterResult).toEqual({
+      shouldApplyCanonicalDrop: true,
+      expectedReaction: null,
+      serverReaction: null,
+    });
+    expect(addBreadcrumbMock).not.toHaveBeenCalled();
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
   it("resets the per-drop sequence when the last tracked mutation ages out", () => {
     const firstMutation = beginReactionMutation({
       dropId: "drop-6",

--- a/utils/monitoring/dropReactionMonitoring.ts
+++ b/utils/monitoring/dropReactionMonitoring.ts
@@ -655,6 +655,7 @@ export function recordReactionRealtimeReconciliation(params: {
       time_since_mutation_ms: timeSinceMutationMs,
       websocket_status: websocketStatus,
     });
+    clearActiveIntentForContext(context);
     return {
       ...resultBase,
       shouldApplyCanonicalDrop: true,

--- a/utils/monitoring/dropReactionMonitoring.ts
+++ b/utils/monitoring/dropReactionMonitoring.ts
@@ -484,6 +484,10 @@ export function recordReactionRequestSucceeded(
     latency_ms: now - (context.requestSentAt ?? context.startedAt),
   });
 
+  if (result.isLatestMutation && context.realtimeReconciledAt !== null) {
+    clearActiveIntentForContext(context);
+  }
+
   return result;
 }
 
@@ -655,7 +659,9 @@ export function recordReactionRealtimeReconciliation(params: {
       time_since_mutation_ms: timeSinceMutationMs,
       websocket_status: websocketStatus,
     });
-    clearActiveIntentForContext(context);
+    if (context.apiSucceededAt !== null) {
+      clearActiveIntentForContext(context);
+    }
     return {
       ...resultBase,
       shouldApplyCanonicalDrop: true,


### PR DESCRIPTION
## Issue
- Sentry issue 6529-FRONTEND-AG reports successful optimistic reaction mutations as reverted when a later canonical refetch disagrees.
- The monitor kept a mutation active for five minutes even after an independent canonical refetch had already confirmed the intended reaction, so later canonical changes could be misattributed to a completed mutation.

## Fix
- Complete the active reaction intent only after both the HTTP mutation succeeds and canonical state confirms the intended reaction, regardless of which arrives first.
- Keep the guard active while HTTP is pending so out-of-order canonical refetches remain suppressed inside the existing reconciliation window.
- Keep canonical server updates authoritative and preserve warning capture when the first settled canonical reconciliation genuinely disagrees.

## Changes
- End the reaction monitoring lifecycle after canonical confirmation and request success.
- Add production-shaped coverage for a quick-react `:joy:` add that still disagrees after 217,657 ms.
- Add ordering coverage for a canonical match followed by a later canonical `null`.
- Add pending-request ordering coverage for a matching refetch, an older stale refetch, and subsequent HTTP success.

## Validation
- `./bin/6529 run test __tests__/utils/monitoring/dropReactionMonitoring.test.ts` — 18 tests passed.
- `./bin/6529 run lint:changed` — passed.
- `./bin/6529 run typecheck:changed` — passed for the changed TypeScript source.
- `./bin/6529 run react-doctor:diff` — 100/100, no issues.
- `git diff --check` — passed.

## Risk
- Level: Low.
- Why: monitoring lifecycle bookkeeping plus focused ordering coverage; canonical state application semantics are unchanged outside the existing in-flight guard.
- Rollback: revert the commits to restore the previous five-minute active-intent behavior.

## Review Notes
- Please verify the two-condition lifecycle: canonical confirmation and HTTP success can arrive in either order, while stale canonical refetches remain guarded until the request settles.
- This does not add a time-based noise filter: the production-shaped slow mismatch continues to capture the warning.