### PR TITLE
Filter extension content-script messaging errors

### DIFF
--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -5227,6 +5227,46 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
+  it("filters the observed Sentry 6V content-script messaging failure", () => {
+    // Arrange
+    const event: TestSentryClientEvent = {
+      transaction: "/waves/:wave",
+      tags: {
+        browser: "Chrome 147.0.0",
+        environment: "production",
+      },
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: extensionMessagingConnectionFailureMessage,
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename: "app:///content-scripts/content.js",
+                  function: "R",
+                  in_app: true,
+                  lineno: 1,
+                  colno: 14440,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    // Act
+    const result = shouldFilterBrowserExtensionMessagingConnectionError(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
   it("filters extension messaging failures from browser extension frames", () => {
     // Arrange
     const event = createBrowserExtensionMessagingConnectionEvent({
@@ -5269,15 +5309,44 @@ describe("sentry-client-filters", () => {
             stacktrace: {
               frames: [
                 {
-                  filename: "app:///injectedScript.bundle.js",
-                  abs_path: "app:///injectedScript.bundle.js",
-                  function: "n",
+                  filename: "app:///content-scripts/content.js",
+                  function: "R",
+                  in_app: true,
                 },
                 {
                   filename:
                     "webpack-internal:///(app-pages-browser)/./utils/browser-extension.ts",
                   abs_path:
                     "webpack-internal:///(app-pages-browser)/./utils/browser-extension.ts",
+                  function: "sendBrowserExtensionMessage",
+                  in_app: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    // Act
+    const result = shouldFilterBrowserExtensionMessagingConnectionError(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("does not filter unobserved content-script-like app paths", () => {
+    // Arrange
+    const event = createBrowserExtensionMessagingConnectionEvent({
+      exception: {
+        values: [
+          {
+            type: "Error",
+            value: extensionMessagingConnectionFailureMessage,
+            stacktrace: {
+              frames: [
+                {
+                  filename: "app:///content-scripts/application.js",
                   function: "sendBrowserExtensionMessage",
                   in_app: true,
                 },

--- a/utils/sentry-client-filters/constants.ts
+++ b/utils/sentry-client-filters/constants.ts
@@ -214,6 +214,9 @@ export const walletConnectStaleSessionFunctions = new Set([
 ]);
 export const extensionMessagingConnectionFailureMessage =
   "Could not establish connection. Receiving end does not exist.";
+export const extensionMessagingContentScriptPaths = new Set([
+  "app:///content-scripts/content.js",
+]);
 export const injectedScriptBundlePathToken = "injectedscript.bundle.js";
 export const URL_IS_FIRST_PARTY_KEY = "url.is_first_party";
 export const URL_IS_FIRST_PARTY_API_KEY = "url.is_first_party_api";

--- a/utils/sentry-client-filters/extension-messaging.ts
+++ b/utils/sentry-client-filters/extension-messaging.ts
@@ -1,6 +1,7 @@
 import {
   browserExtensionUrlPrefixes,
   extensionMessagingConnectionFailureMessage,
+  extensionMessagingContentScriptPaths,
   injectedScriptBundlePathToken,
 } from "./constants";
 import type {
@@ -19,6 +20,7 @@ function isExtensionMessagingInjectedPath(value: string): boolean {
   const normalizedValue = value.toLowerCase();
   return (
     normalizedValue.includes(injectedScriptBundlePathToken) ||
+    extensionMessagingContentScriptPaths.has(normalizedValue) ||
     browserExtensionUrlPrefixes.some((prefix) =>
       normalizedValue.startsWith(prefix)
     )

--- a/utils/sentry-client-filters/types.ts
+++ b/utils/sentry-client-filters/types.ts
@@ -3,6 +3,8 @@ export type SentryStackFrame = {
   abs_path?: string | undefined;
   function?: string | undefined;
   in_app?: boolean | undefined;
+  lineno?: number | undefined;
+  colno?: number | undefined;
 };
 
 export type SentryTransactionSpan = {


### PR DESCRIPTION
## Issue
- Sentry issue `6529-FRONTEND-6V` reports `Could not establish connection. Receiving end does not exist.` from the single frame `app:///content-scripts/content.js`.
- The existing extension-messaging filter recognizes extension URL schemes and `injectedScript.bundle.js`, but not this observed content-script path.

## Fix
- Treat the exact observed content-script path as extension-owned evidence only for this exact messaging error.
- Preserve the existing app-owned source guard so the same message remains visible when application frames, original stacks, or serialized stacks point to app code.

## Changes
- Add an exact allowlist entry for `app:///content-scripts/content.js`.
- Reproduce the production exception mechanism, function, in-app flag, and line/column shape in a focused regression test.
- Add negative coverage for mixed app-owned messaging frames and unobserved content-script-like paths.
- Extend the local Sentry frame test type with line and column fields used by the production-shaped fixture.

## Validation
- `./bin/6529 run test:no-coverage --testPathPatterns=__tests__/utils/sentry-client-filters.test.ts --runInBand` (207 tests passed)
- `./bin/6529 run lint:changed`
- `./bin/6529 run typecheck:changed`
- `./bin/6529 run typecheck:ci`
- Focused Prettier check for the four changed files
- `git diff --check`

## Risk
- Level: Low
- Why: the new match is restricted by the existing exact error-message check, an exact observed path, extension-only frames, and the absence of app-owned source evidence.
- Rollback: revert the single commit to restore the previous filter behavior.

## Review Notes
- Please focus on whether the exact path allowlist and app-owned evidence guard preserve same-message application failures.
- This filters known browser-extension noise; it does not fix the extension's missing receiving endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of browser extension messaging failures so recognized content-script errors are filtered more reliably.
  - Reduced incorrect error filtering by ensuring only observed, supported content-script paths are matched.
  - Expanded validation coverage for extension-related error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->