### PR TITLE
Filter Sentry route parameterization cyclic JSON noise

### DIFF
--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -822,76 +822,81 @@ describe("sentry-client-filters", () => {
       ...overrides,
     });
 
-  const createObservedSentryCpNotificationsEvent =
-    (): TestSentryClientEvent => ({
-      transaction: "/notifications",
-      exception: {
-        values: [
-          {
-            type: "TypeError",
-            value: __testing.sentryRouteParameterizationMessage,
-            mechanism: {
-              type: __testing.sentryRouteParameterizationMechanismType,
-              handled: false,
-            },
-            stacktrace: {
-              frames: [
-                {
-                  filename:
-                    "node_modules/.pnpm/@sentry+nextjs@10.45.0_@opentelemetry+context-async-hooks@2.7.1_@opentelemetry+api@1.9._9f030f10fd79c9d796c635bb51c5a1cc/node_modules/@sentry/nextjs/src/client/routing/parameterization.ts",
-                  function: "n",
-                  in_app: true,
-                  lineno: 94,
-                  colno: 19,
-                  context_line: "  routeResultCache.clear();",
-                },
-                {
-                  filename: "[native code]",
-                  function: "stringify",
-                  in_app: false,
-                },
-              ],
-            },
+  const observedSentryCpNotificationsFrames: SentryStackFrame[] = [
+    {
+      filename:
+        "node_modules/.pnpm/@sentry+nextjs@10.45.0_@opentelemetry+context-async-hooks@2.7.1_@opentelemetry+api@1.9._9f030f10fd79c9d796c635bb51c5a1cc/node_modules/@sentry/nextjs/src/client/routing/parameterization.ts",
+      function: "n",
+      in_app: true,
+      lineno: 94,
+      colno: 19,
+      context_line: "  routeResultCache.clear();",
+    },
+    {
+      filename: "[native code]",
+      function: "stringify",
+      in_app: false,
+    },
+  ];
+
+  const createObservedSentryCpNotificationsEvent = (
+    overrides: TestSentryClientEventOverrides = {},
+    frames: SentryStackFrame[] = observedSentryCpNotificationsFrames
+  ): TestSentryClientEvent => ({
+    transaction: "/notifications",
+    exception: {
+      values: [
+        {
+          type: "TypeError",
+          value: __testing.sentryRouteParameterizationMessage,
+          mechanism: {
+            type: __testing.sentryRouteParameterizationMechanismType,
+            handled: false,
           },
-        ],
-      },
-      contexts: {
-        browser: {
-          browser: "Mobile Safari UI/WKWebView",
-          name: "Mobile Safari UI/WKWebView",
+          stacktrace: {
+            frames,
+          },
         },
-        device: {
-          family: "iPhone",
-          model: "iPhone",
-          brand: "Apple",
-        },
-        os: {
-          os: "iOS 18.7",
-          name: "iOS",
-          version: "18.7",
-        },
-      },
-      extra: {
-        arguments: [],
-      },
-      tags: {
+      ],
+    },
+    contexts: {
+      browser: {
         browser: "Mobile Safari UI/WKWebView",
-        "browser.name": "Mobile Safari UI/WKWebView",
-        device: "iPhone",
-        "device.family": "iPhone",
-        environment: "production",
-        handled: "no",
-        interface_type: "exception",
-        level: "error",
-        mechanism: __testing.sentryRouteParameterizationMechanismType,
-        os: "iOS 18.7",
-        "os.name": "iOS",
-        release: "c7d1ee2cdf4f09d9e5c88dddf342fdbd145ad093",
-        transaction: "/notifications",
-        turbopack: "True",
-        url: "/notifications",
+        name: "Mobile Safari UI/WKWebView",
       },
-    });
+      device: {
+        family: "iPhone",
+        model: "iPhone",
+        brand: "Apple",
+      },
+      os: {
+        os: "iOS 18.7",
+        name: "iOS",
+        version: "18.7",
+      },
+    },
+    extra: {
+      arguments: [],
+    },
+    tags: {
+      browser: "Mobile Safari UI/WKWebView",
+      "browser.name": "Mobile Safari UI/WKWebView",
+      device: "iPhone",
+      "device.family": "iPhone",
+      environment: "production",
+      handled: "no",
+      interface_type: "exception",
+      level: "error",
+      mechanism: __testing.sentryRouteParameterizationMechanismType,
+      os: "iOS 18.7",
+      "os.name": "iOS",
+      release: "c7d1ee2cdf4f09d9e5c88dddf342fdbd145ad093",
+      transaction: "/notifications",
+      turbopack: "True",
+      url: "/notifications",
+    },
+    ...overrides,
+  });
 
   const createRabbyMobileUserRejectedRequestEvent = (
     overrides: TestSentryClientEventOverrides = {}
@@ -3366,6 +3371,39 @@ describe("sentry-client-filters", () => {
   it("filters the observed Sentry CP notifications event when the SDK frame is marked in-app", () => {
     // Arrange
     const event = createObservedSentryCpNotificationsEvent();
+
+    // Act
+    const result = shouldFilterSentryRouteParameterizationError(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("preserves the observed Sentry CP event when a real app-owned frame is present", () => {
+    // Arrange
+    const event = createObservedSentryCpNotificationsEvent({}, [
+      ...observedSentryCpNotificationsFrames,
+      {
+        filename: "services/api/common-api.ts",
+        abs_path: "services/api/common-api.ts",
+        function: "fetchUrl",
+        in_app: true,
+      },
+    ]);
+
+    // Act
+    const result = shouldFilterSentryRouteParameterizationError(event);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("filters the observed Sentry CP event when native stringify is marked in-app", () => {
+    // Arrange
+    const frames = observedSentryCpNotificationsFrames.map((frame) =>
+      frame.function === "stringify" ? { ...frame, in_app: true } : frame
+    );
+    const event = createObservedSentryCpNotificationsEvent({}, frames);
 
     // Act
     const result = shouldFilterSentryRouteParameterizationError(event);

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -799,6 +799,77 @@ describe("sentry-client-filters", () => {
       ...overrides,
     });
 
+  const createObservedSentryCpNotificationsEvent =
+    (): TestSentryClientEvent => ({
+      transaction: "/notifications",
+      exception: {
+        values: [
+          {
+            type: "TypeError",
+            value: __testing.sentryRouteParameterizationMessage,
+            mechanism: {
+              type: __testing.sentryRouteParameterizationMechanismType,
+              handled: false,
+            },
+            stacktrace: {
+              frames: [
+                {
+                  filename:
+                    "node_modules/.pnpm/@sentry+nextjs@10.45.0_@opentelemetry+context-async-hooks@2.7.1_@opentelemetry+api@1.9._9f030f10fd79c9d796c635bb51c5a1cc/node_modules/@sentry/nextjs/src/client/routing/parameterization.ts",
+                  function: "n",
+                  in_app: true,
+                  lineno: 94,
+                  colno: 19,
+                  context_line: "  routeResultCache.clear();",
+                },
+                {
+                  filename: "[native code]",
+                  function: "stringify",
+                  in_app: false,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      contexts: {
+        browser: {
+          browser: "Mobile Safari UI/WKWebView",
+          name: "Mobile Safari UI/WKWebView",
+        },
+        device: {
+          family: "iPhone",
+          model: "iPhone",
+          brand: "Apple",
+        },
+        os: {
+          os: "iOS 18.7",
+          name: "iOS",
+          version: "18.7",
+        },
+      },
+      extra: {
+        arguments: [],
+      },
+      tags: {
+        browser: "Mobile Safari UI/WKWebView",
+        "browser.name": "Mobile Safari UI/WKWebView",
+        device: "iPhone",
+        "device.family": "iPhone",
+        environment: "production",
+        handled: "no",
+        interface_type: "exception",
+        level: "error",
+        mechanism: __testing.sentryRouteParameterizationMechanismType,
+        os: "iOS 18.7",
+        "os.name": "iOS",
+        release: "c7d1ee2cdf4f09d9e5c88dddf342fdbd145ad093",
+        transaction: "/notifications",
+        turbopack: "True",
+        url: "/notifications",
+      },
+    });
+
   const createRabbyMobileUserRejectedRequestEvent = (
     overrides: TestSentryClientEventOverrides = {}
   ): TestSentryClientEvent =>
@@ -3096,6 +3167,17 @@ describe("sentry-client-filters", () => {
   it("filters observed iOS WKWebView wave route parameterization cyclic JSON errors without app context", () => {
     // Arrange
     const event = createObservedIosWkWebViewWaveRouteParameterizationEvent();
+
+    // Act
+    const result = shouldFilterSentryRouteParameterizationError(event);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("filters the observed Sentry CP notifications event when the SDK frame is marked in-app", () => {
+    // Arrange
+    const event = createObservedSentryCpNotificationsEvent();
 
     // Act
     const result = shouldFilterSentryRouteParameterizationError(event);

--- a/utils/sentry-client-filters/app-frame-utils.ts
+++ b/utils/sentry-client-filters/app-frame-utils.ts
@@ -349,14 +349,18 @@ function isSentryRouteParameterizationPath(path: string): boolean {
   );
 }
 
+export function isSentryRouteParameterizationFrame(
+  frame: SentryStackFrame
+): boolean {
+  return getFramePaths(frame).some(isSentryRouteParameterizationPath);
+}
+
 export function hasSentryRouteParameterizationFrame(
   frames: SentryStackFrame[] | undefined
 ): boolean {
   return (
     Array.isArray(frames) &&
-    frames.some((frame) =>
-      getFramePaths(frame).some(isSentryRouteParameterizationPath)
-    )
+    frames.some(isSentryRouteParameterizationFrame)
   );
 }
 

--- a/utils/sentry-client-filters/errors.ts
+++ b/utils/sentry-client-filters/errors.ts
@@ -55,6 +55,7 @@ import {
   hasOnlyAppUriFrames,
   hasReactDomNotFoundErrorSignature,
   hasSentryRouteParameterizationFrame,
+  isSentryRouteParameterizationFrame,
 } from "./app-frame-utils";
 
 const sentryBrowserPathTokens = ["@sentry/browser", "@sentry+browser"];
@@ -463,7 +464,7 @@ export function shouldFilterSentryRouteParameterizationError(
 
   const frames = value.stacktrace?.frames;
   const framesWithoutSentryRouteParameterization = frames?.filter(
-    (frame) => !hasSentryRouteParameterizationFrame([frame])
+    (frame) => !isSentryRouteParameterizationFrame(frame)
   );
   if (
     hasLikelyAppOwnedFrame(framesWithoutSentryRouteParameterization) ||

--- a/utils/sentry-client-filters/errors.ts
+++ b/utils/sentry-client-filters/errors.ts
@@ -462,7 +462,13 @@ export function shouldFilterSentryRouteParameterizationError(
   }
 
   const frames = value.stacktrace?.frames;
-  if (hasLikelyAppOwnedFrame(frames) || !hasNativeJsonStringifyFrame(frames)) {
+  const framesWithoutSentryRouteParameterization = frames?.filter(
+    (frame) => !hasSentryRouteParameterizationFrame([frame])
+  );
+  if (
+    hasLikelyAppOwnedFrame(framesWithoutSentryRouteParameterization) ||
+    !hasNativeJsonStringifyFrame(frames)
+  ) {
     return false;
   }
 

--- a/utils/sentry-client-filters/types.ts
+++ b/utils/sentry-client-filters/types.ts
@@ -3,6 +3,9 @@ export type SentryStackFrame = {
   abs_path?: string | undefined;
   function?: string | undefined;
   in_app?: boolean | undefined;
+  lineno?: number | undefined;
+  colno?: number | undefined;
+  context_line?: string | undefined;
 };
 
 export type SentryTransactionSpan = {


### PR DESCRIPTION
## Issue
- Sentry issue `6529-FRONTEND-CP` continues to receive the known Next.js SDK route-parameterization cyclic JSON error in iOS WKWebView.
- The existing filter matches the error signature, but rejects the event early because Sentry's own parameterization frame can be classified as application-owned.

## Fix
- Exclude only the exact `@sentry/nextjs` route-parameterization frame from app-frame detection.
- Continue reporting generic cyclic JSON failures and any event with another application-owned frame.

## Changes
- Update the route-parameterization predicate to evaluate app ownership after removing exact SDK parameterization frames.
- Add the observed `/notifications` production event shape, including frame metadata and Mobile Safari WKWebView context, as a regression fixture.
- Model the observed line, column, and context-line frame fields in the local Sentry event type.

## Validation
- `./bin/6529 run test:no-coverage --testPathPatterns='(__tests__/utils/sentry-client-filters|__tests__/instrumentation-client)\.test\.ts$' --runInBand` — 2 suites and 262 tests passed.
- `./bin/6529 run lint:changed` — passed.
- `./bin/6529 run lint:changed:tight` — passed.
- `./bin/6529 run typecheck:changed` — passed for the changed TypeScript files.
- `git diff --check` — passed.

## Risk
- Level: Low
- Why: The change remains gated by the exact error type, message, mechanism, native stringify frame, Sentry package path, and iOS WKWebView context.
- Rollback: Revert the commit to restore the previous filter behavior.

## Review Notes
- Please focus on the SDK-frame exclusion and the tests that preserve generic cyclic JSON errors and real app-owned frames.
- This filters the known SDK exception before transport; it does not prevent the SDK from throwing it.