### PR TITLE
Filter injected WebAssembly CSP sibling frames

### DIFF
--- a/__tests__/instrumentation-client.test.ts
+++ b/__tests__/instrumentation-client.test.ts
@@ -42,6 +42,15 @@ describe("instrumentation-client", () => {
     "Content Security Policy directive: \"script-src 'self' 'unsafe-inline'\".).",
     "Build with -sASSERTIONS for more info.",
   ].join(" ");
+  const observedSentryE7WasmCspUnsafeEvalMessage = [
+    "Aborted(CompileError: WebAssembly.instantiate(): Refused to compile or instantiate",
+    "WebAssembly module because 'unsafe-eval' is not an allowed source of script in the",
+    "following Content Security Policy directive: \"script-src 'self' 'unsafe-inline'",
+    "https://dnclu2fna0b2b.cloudfront.net https://www.google-analytics.com",
+    "https://www.googletagmanager.com",
+    'https://dataplane.rum.us-east-1.amazonaws.com\").',
+    "Build with -sASSERTIONS for more info.",
+  ].join(" ");
   const observedWasmModuleCspUnsafeEvalMessage =
     "CompileError: WebAssembly.Module(): Compiling or instantiating WebAssembly module violates CSP because unsafe-eval is not allowed";
   const anonymousUnsafeEvalCspMessage =
@@ -351,14 +360,28 @@ describe("instrumentation-client", () => {
   it("drops observed Sentry E7 WebAssembly CSP unsafe-eval errors from injected static chunks", () => {
     const beforeSend = loadBeforeSend();
     const event = {
-      transaction: "/waves",
+      transaction: "/the-memes/:id",
       exception: {
         values: [
           {
             type: "RuntimeError",
-            value: wasmCspUnsafeEvalMessage,
+            value: observedSentryE7WasmCspUnsafeEvalMessage,
+            mechanism: {
+              type: "auto.browser.global_handlers.onunhandledrejection",
+              handled: false,
+            },
             stacktrace: {
               frames: [
+                {
+                  filename: "app:///chunks/utils-DNoBWR8F.js",
+                  abs_path: "app:///chunks/utils-DNoBWR8F.js",
+                  in_app: true,
+                },
+                {
+                  filename: "app:///chunks/utils-DNoBWR8F.js",
+                  abs_path: "app:///chunks/utils-DNoBWR8F.js",
+                  in_app: true,
+                },
                 {
                   filename: "app:///chunks/utils-DNoBWR8F.js",
                   abs_path: "app:///chunks/utils-DNoBWR8F.js",
@@ -372,8 +395,8 @@ describe("instrumentation-client", () => {
       },
       tags: {
         environment: "production",
-        transaction: "/waves",
-        url: "/waves",
+        transaction: "/the-memes/:id",
+        url: "/the-memes/447",
       },
     };
 

--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -100,6 +100,15 @@ describe("sentry-client-filters", () => {
     "Content Security Policy directive: \"script-src 'self' 'unsafe-inline'\".).",
     "Build with -sASSERTIONS for more info.",
   ].join(" ");
+  const observedSentryE7WasmCspUnsafeEvalMessage = [
+    "Aborted(CompileError: WebAssembly.instantiate(): Refused to compile or instantiate",
+    "WebAssembly module because 'unsafe-eval' is not an allowed source of script in the",
+    "following Content Security Policy directive: \"script-src 'self' 'unsafe-inline'",
+    "https://dnclu2fna0b2b.cloudfront.net https://www.google-analytics.com",
+    "https://www.googletagmanager.com",
+    'https://dataplane.rum.us-east-1.amazonaws.com\").',
+    "Build with -sASSERTIONS for more info.",
+  ].join(" ");
   const observedWasmModuleCspUnsafeEvalMessage =
     "CompileError: WebAssembly.Module(): Compiling or instantiating WebAssembly module violates CSP because unsafe-eval is not allowed";
   const anonymousUnsafeEvalCspMessage =
@@ -485,14 +494,28 @@ describe("sentry-client-filters", () => {
   const createObservedSentryE7WasmCspUnsafeEvalEvent = (
     overrides: TestSentryClientEventOverrides = {}
   ): TestSentryClientEvent => ({
-    transaction: "/waves",
+    transaction: "/the-memes/:id",
     exception: {
       values: [
         {
           type: "RuntimeError",
-          value: wasmCspUnsafeEvalMessage,
+          value: observedSentryE7WasmCspUnsafeEvalMessage,
+          mechanism: {
+            type: "auto.browser.global_handlers.onunhandledrejection",
+            handled: false,
+          },
           stacktrace: {
             frames: [
+              {
+                filename: "app:///chunks/utils-DNoBWR8F.js",
+                abs_path: "app:///chunks/utils-DNoBWR8F.js",
+                in_app: true,
+              },
+              {
+                filename: "app:///chunks/utils-DNoBWR8F.js",
+                abs_path: "app:///chunks/utils-DNoBWR8F.js",
+                in_app: true,
+              },
               {
                 filename: "app:///chunks/utils-DNoBWR8F.js",
                 abs_path: "app:///chunks/utils-DNoBWR8F.js",
@@ -506,8 +529,8 @@ describe("sentry-client-filters", () => {
     },
     contexts: {
       browser: {
-        name: "Chrome",
-        version: "150",
+        name: "Edge",
+        version: "125.0.0",
       },
       os: {
         name: "Windows",
@@ -515,8 +538,8 @@ describe("sentry-client-filters", () => {
     },
     tags: {
       environment: "production",
-      transaction: "/waves",
-      url: "/waves",
+      transaction: "/the-memes/:id",
+      url: "/the-memes/447",
     },
     ...overrides,
   });

--- a/utils/sentry-client-filters/app-frame-utils.ts
+++ b/utils/sentry-client-filters/app-frame-utils.ts
@@ -131,6 +131,26 @@ function isInjectedWasmCspStaticChunkFramePath(
   );
 }
 
+function hasOnlyInjectedWasmCspStaticChunkFrames(
+  frames: SentryStackFrame[]
+): boolean {
+  const markerFrame = frames.find(isInjectedWasmCspStaticChunkFrame);
+  if (!markerFrame) {
+    return false;
+  }
+
+  const markerPaths = new Set(
+    getFramePaths(markerFrame)
+      .map((path) => path.trim())
+      .filter((path) => injectedWasmCspStaticChunkPathPattern.test(path))
+  );
+
+  return frames.every((frame) => {
+    const paths = getFramePaths(frame).map((path) => path.trim());
+    return paths.length > 0 && paths.every((path) => markerPaths.has(path));
+  });
+}
+
 function hasAppOwnedWasmCspFramePath(frame: SentryStackFrame): boolean {
   return getFramePaths(frame).some(
     (path) =>
@@ -252,6 +272,10 @@ export function hasInjectedWasmCspFrameSignature(
 ): boolean {
   if (!Array.isArray(frames) || frames.length === 0) {
     return false;
+  }
+
+  if (hasOnlyInjectedWasmCspStaticChunkFrames(frames)) {
+    return true;
   }
 
   if (frames.some(isAppOwnedWasmCspFrame)) {


### PR DESCRIPTION
## Issue
- Sentry issue `6529-FRONTEND-E7` continues to report a known injected `WebAssembly.instantiate` CSP rejection even though the existing filter covers a simplified single-frame fixture.
- The production CSP is behaving correctly and must remain unchanged.

## Fix
- Recognize the exact multi-frame production signature only when the stack contains the known `k` marker and every frame resolves to the same observed hashed `utils-*.js` chunk.
- Continue sending any event with an application source frame, a different marker, or a non-CSP message.

## Changes
- Add a stack-level injected WASM chunk classifier for unnamed sibling frames.
- Replace the simplified E7 fixtures with the observed Edge/Windows unhandled-rejection shape and exact message.
- Keep `securityHeaders` and the `unsafe-eval` policy unchanged.

## Validation
- `./bin/6529 run test __tests__/utils/sentry-client-filters.test.ts __tests__/instrumentation-client.test.ts --runInBand` — 263 tests passed.
- `./bin/6529 run lint:changed` — passed.
- `./bin/6529 run typecheck:changed` — passed.
- `git diff --check origin/main...HEAD` — passed.

## Risk
- Level: Low.
- Why: The change affects only client-side Sentry filtering and requires an exact message plus a narrow stack signature.
- Rollback: Revert the commit to restore the prior fail-open behavior.

## Review Notes
- Please focus on the stack-level matching boundary: all frames must share the marker chunk path, and the existing app-owned-frame protections remain in place.