### PR TITLE
Filter injected /metrics network noise

### DIFF
--- a/__tests__/utils/sentry-client-filters.test.ts
+++ b/__tests__/utils/sentry-client-filters.test.ts
@@ -898,6 +898,96 @@ describe("sentry-client-filters", () => {
     ...overrides,
   });
 
+  const observedFrameAntNetworkFrames: SentryStackFrame[] = [
+    {
+      filename: "app:///frame_ant/frame_ant.js",
+      abs_path: "app:///frame_ant/frame_ant.js",
+      function: "o",
+      in_app: true,
+    },
+    {
+      filename: "app:///frame_ant/frame_ant.js",
+      abs_path: "app:///frame_ant/frame_ant.js",
+      function: "window.fetch",
+      in_app: true,
+    },
+    {
+      filename:
+        "node_modules/.pnpm/@sentry+core@10.45.0/node_modules/@sentry/core/src/instrument/fetch.ts",
+      function: "<anonymous>",
+      in_app: false,
+    },
+    {
+      filename:
+        "node_modules/.pnpm/aws-rum-web@1.25.0/node_modules/aws-rum-web/dist/es/sessions/VirtualPageLoadTimer.js",
+      function: "i.fetch",
+      in_app: false,
+    },
+    {
+      filename:
+        "node_modules/.pnpm/aws-rum-web@1.25.0/node_modules/aws-rum-web/dist/es/sessions/VirtualPageLoadTimer.js",
+      function: "<anonymous>",
+      in_app: false,
+    },
+    {
+      filename:
+        "node_modules/.pnpm/aws-rum-web@1.25.0/node_modules/aws-rum-web/dist/es/plugins/event-plugins/FetchPlugin.js",
+      function: "n.fetch",
+      in_app: false,
+    },
+    {
+      filename:
+        "node_modules/.pnpm/aws-rum-web@1.25.0/node_modules/aws-rum-web/dist/es/plugins/event-plugins/FetchPlugin.js",
+      function: "<anonymous>",
+      in_app: false,
+    },
+    {
+      filename: "<anonymous>",
+      function: "_t",
+      in_app: false,
+    },
+    {
+      filename: "<anonymous>",
+      function: "<anonymous>",
+      in_app: false,
+    },
+  ];
+
+  const createObservedFrameAntNetworkException = (
+    value: string = coinbaseMetricsNetworkMessage,
+    frames: SentryStackFrame[] = observedFrameAntNetworkFrames
+  ): NonNullable<TestSentryClientEvent["exception"]> => ({
+    values: [
+      {
+        type: "TypeError",
+        value,
+        mechanism: {
+          type: "auto.browser.global_handlers.onunhandledrejection",
+          handled: false,
+        },
+        stacktrace: {
+          frames,
+        },
+      },
+    ],
+  });
+
+  const createObservedFrameAntMetricsNetworkErrorEvent = (
+    overrides: TestSentryClientEventOverrides = {}
+  ): TestSentryClientEvent => ({
+    event_id: "frame-ant-metrics-network-error",
+    transaction: "/:user",
+    exception: createObservedFrameAntNetworkException(),
+    tags: {
+      environment: "production",
+      errorType: "network",
+      handled: "no",
+      transaction: "/:user",
+      url: "/example",
+    },
+    ...overrides,
+  });
+
   const createWalletConnectStaleSessionTopicEvent = (
     overrides: TestSentryClientEventOverrides = {}
   ): TestSentryClientEvent => ({
@@ -1614,6 +1704,38 @@ describe("sentry-client-filters", () => {
     expect(result).toBe(true);
   });
 
+  it("filters the observed frame_ant metrics network error", () => {
+    const result = shouldFilterThirdPartyTelemetryNetworkError(
+      createObservedFrameAntMetricsNetworkErrorEvent()
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("preserves frame_ant network errors for other targets", () => {
+    const result = shouldFilterThirdPartyTelemetryNetworkError(
+      createObservedFrameAntMetricsNetworkErrorEvent({
+        exception: createObservedFrameAntNetworkException(
+          "Network request failed. Please check your connection and try again. (/messages)"
+        ),
+      })
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("preserves non-network metrics messages from frame_ant", () => {
+    const result = shouldFilterThirdPartyTelemetryNetworkError(
+      createObservedFrameAntMetricsNetworkErrorEvent({
+        exception: createObservedFrameAntNetworkException(
+          "Telemetry request rejected. (/metrics)"
+        ),
+      })
+    );
+
+    expect(result).toBe(false);
+  });
+
   it("does not filter first-party spans", () => {
     const result = shouldFilterThirdPartyTelemetrySpan(
       buildSpan({
@@ -1653,6 +1775,49 @@ describe("sentry-client-filters", () => {
             },
           ],
         },
+      })
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("preserves the observed frame_ant metrics error with an app-owned frame", () => {
+    const result = shouldFilterThirdPartyTelemetryNetworkError(
+      createObservedFrameAntMetricsNetworkErrorEvent({
+        exception: createObservedFrameAntNetworkException(
+          coinbaseMetricsNetworkMessage,
+          [
+            ...observedFrameAntNetworkFrames,
+            {
+              filename: "services/api/common-api.ts",
+              abs_path: "services/api/common-api.ts",
+              function: "fetchUrl",
+              in_app: true,
+            },
+          ]
+        ),
+      })
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("preserves the same metrics message for a matching first-party failure", () => {
+    const result = shouldFilterThirdPartyTelemetryNetworkError(
+      createObservedFrameAntMetricsNetworkErrorEvent({
+        breadcrumbs: [
+          {
+            type: "http",
+            category: "fetch",
+            level: "error",
+            data: {
+              url: "https://api.6529.io/metrics",
+              status_code: 0,
+              "url.is_first_party": true,
+              "url.is_first_party_api": true,
+            },
+          },
+        ],
       })
     );
 

--- a/utils/sentry-client-filters/network.ts
+++ b/utils/sentry-client-filters/network.ts
@@ -15,6 +15,7 @@ import type {
   NetworkTargetCandidate,
   SentryBreadcrumb,
   SentryClientEvent,
+  SentryStackFrame,
   SentryTransactionSpan,
 } from "./types";
 import {
@@ -25,6 +26,7 @@ import {
   getBooleanValue,
   getBreadcrumbValues,
   getEventMessage,
+  getFramePaths,
   getNumericValue,
   getRequestPathname,
   getSerializedExceptionStack,
@@ -39,6 +41,8 @@ import {
   parseAbsoluteRequestUrl,
   uniqueStrings,
 } from "./value-utils";
+
+const injectedFrameAntFramePath = "app:///frame_ant/frame_ant.js";
 
 function isFirstPartyApiTarget(candidate: NetworkTargetCandidate): boolean {
   if (candidate.isFirstPartyApi === true) {
@@ -694,11 +698,56 @@ function hasThirdPartyTelemetryNetworkMessageTarget(
   );
 }
 
+function isInjectedFrameAntFrame(frame: SentryStackFrame): boolean {
+  return getFramePaths(frame).some(
+    (path) => path.trim().toLowerCase() === injectedFrameAntFramePath
+  );
+}
+
+function isFirstPartyNetworkTarget(candidate: NetworkTargetCandidate): boolean {
+  if (candidate.isFirstParty === true) {
+    return true;
+  }
+
+  const absoluteUrl = parseAbsoluteRequestUrl(candidate.url);
+  return absoluteUrl !== null && isFirstPartyHost(absoluteUrl.hostname);
+}
+
+function hasMatchingFirstPartyNetworkFailure(
+  event: SentryClientEvent
+): boolean {
+  const messageTargets = getMessageTargetCandidates(event);
+
+  return getHttpBreadcrumbs(event).some((breadcrumb) => {
+    if (getBreadcrumbFailureKind(breadcrumb) === null) {
+      return false;
+    }
+
+    const breadcrumbTarget = getBreadcrumbTargetCandidate(breadcrumb);
+    if (!breadcrumbTarget || !isFirstPartyNetworkTarget(breadcrumbTarget)) {
+      return false;
+    }
+
+    const breadcrumbPath = getRequestPathname(breadcrumbTarget.url);
+    return (
+      breadcrumbPath !== null &&
+      messageTargets.some(
+        (messageTarget) =>
+          getRequestPathname(messageTarget.url) === breadcrumbPath
+      )
+    );
+  });
+}
+
 function hasAppOwnedNetworkErrorEvidence(event: SentryClientEvent): boolean {
   const frames = event.exception?.values?.[0]?.stacktrace?.frames;
+  const framesWithoutInjectedFrameAnt = frames?.filter(
+    (frame) => !isInjectedFrameAntFrame(frame)
+  );
   return (
-    hasLikelyAppOwnedFrame(frames) ||
-    hasAppOwnedSourceStackValue(getSerializedExceptionStack(event))
+    hasLikelyAppOwnedFrame(framesWithoutInjectedFrameAnt) ||
+    hasAppOwnedSourceStackValue(getSerializedExceptionStack(event)) ||
+    hasMatchingFirstPartyNetworkFailure(event)
   );
 }
 


### PR DESCRIPTION
## Issue
- Sentry issue `6529-FRONTEND-2Y` continues to capture an injected third-party `/metrics` network rejection.
- The production stack includes AWS RUM and Sentry fetch wrappers plus `app:///frame_ant/frame_ant.js`, with no 6529-owned source frame.
- The existing telemetry filter incorrectly treats every `app:///` frame as app-owned, so the injected frame prevents suppression.

## Fix
- Exclude only the exact observed `frame_ant` path when evaluating whether a `/metrics` network error has app-owned stack evidence.
- Preserve the event whenever another app-owned frame remains or a failed first-party 6529 breadcrumb matches the same request path.

## Changes
- Add filter-local recognition for the exact injected `app:///frame_ant/frame_ant.js` frame.
- Add a matching first-party failure safeguard for ambiguous bare `/metrics` messages.
- Reproduce the observed production event shape in focused unit coverage.
- Cover non-`/metrics` network errors, non-network `/metrics` messages, app-owned stacks, and first-party 6529 failures.

## Validation
- `./bin/6529 run test:no-coverage __tests__/utils/sentry-client-filters.test.ts --runInBand` — 210 tests passed.
- `./bin/6529 run lint:changed` — passed.
- `./bin/6529 run lint:changed:tight` — passed.
- `./bin/6529 run typecheck:changed` — passed.
- `./bin/6529 exec prettier --check utils/sentry-client-filters/network.ts __tests__/utils/sentry-client-filters.test.ts` — passed.
- Full no-emit TypeScript check — passed.

## Risk
- Level: Low.
- Why: The change is limited to one existing Sentry client filter and exact event-shape regression tests. It does not broaden the accepted target beyond the existing exact `/metrics` path.
- Rollback: Revert the commit to restore the previous filter behavior.

## Review Notes
- Please focus on the exact `frame_ant` path match and the matching-path requirement for first-party failed breadcrumbs.
- The filter intentionally fails open if the injected script changes its filename, preserving unknown errors rather than silently dropping them.
- This filters the known Sentry noise; it does not prevent the third-party script from issuing the request.