### PR TITLE
Reduce duplicate notification requests

### DIFF
--- a/__tests__/components/react-query-wrapper/ReactQueryWrapper.test.tsx
+++ b/__tests__/components/react-query-wrapper/ReactQueryWrapper.test.tsx
@@ -169,13 +169,13 @@ describe("ReactQueryWrapper context", () => {
     });
   });
 
-  it("invalidateNotifications invalidates notification queries", () => {
+  it("invalidateNotifications leaves other connected accounts cached", () => {
     const { client, ctx } = createTestSetup();
     act(() => ctx.invalidateNotifications());
     expect(client.invalidateQueries).toHaveBeenCalledWith({
       queryKey: [QueryKey.IDENTITY_NOTIFICATIONS],
     });
-    expect(client.invalidateQueries).toHaveBeenCalledWith({
+    expect(client.invalidateQueries).not.toHaveBeenCalledWith({
       queryKey: [QueryKey.CONNECTED_ACCOUNT_UNREAD_NOTIFICATIONS],
     });
     expect(client.invalidateQueries).toHaveBeenCalledWith({

--- a/__tests__/helpers/stream.helpers.notifications.test.ts
+++ b/__tests__/helpers/stream.helpers.notifications.test.ts
@@ -1,3 +1,4 @@
+import { QueryKey } from '@/components/react-query-wrapper/ReactQueryWrapper';
 import { prefetchAuthenticatedNotifications } from '@/helpers/stream.helpers';
 
 jest.mock('jwt-decode', () => ({ jwtDecode: () => ({ sub: 'wallet' }) }));
@@ -11,6 +12,14 @@ describe('prefetchAuthenticatedNotifications', () => {
     const queryClient = createClient();
     await prefetchAuthenticatedNotifications({ queryClient: queryClient as any, headers: { Authorization: 'Bearer t' }, context: {} as any });
     expect(queryClient.prefetchInfiniteQuery).toHaveBeenCalledTimes(3);
+    expect(queryClient.prefetchInfiniteQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: [
+          QueryKey.IDENTITY_NOTIFICATIONS,
+          { identity: 'alice', limit: '30', cause: null, version: 'v2' },
+        ],
+      })
+    );
   });
 
   it('skips when no auth header', async () => {

--- a/components/react-query-wrapper/ReactQueryWrapper.tsx
+++ b/components/react-query-wrapper/ReactQueryWrapper.tsx
@@ -1112,14 +1112,11 @@ const createReactQueryContextValue = (
   };
 
   const invalidateNotifications = () => {
+    // Notification read mutations use the active account's JWT. Other connected
+    // accounts keep their cached unread counts and continue their normal polling.
     queryClient
       .invalidateQueries({
         queryKey: [QueryKey.IDENTITY_NOTIFICATIONS],
-      })
-      .catch(() => undefined);
-    queryClient
-      .invalidateQueries({
-        queryKey: [QueryKey.CONNECTED_ACCOUNT_UNREAD_NOTIFICATIONS],
       })
       .catch(() => undefined);
     invalidateWavesV2();

--- a/helpers/stream.helpers.ts
+++ b/helpers/stream.helpers.ts
@@ -288,11 +288,11 @@ const prefetchAuthenticatedNotificationsItems = async ({
   await queryClient.prefetchInfiniteQuery({
     queryKey: [
       QueryKey.IDENTITY_NOTIFICATIONS,
-      { identity: handle, limit: "10", cause: null, version: "v2" },
+      { identity: handle, limit: "30", cause: null, version: "v2" },
     ],
     queryFn: async ({ pageParam }: { pageParam: number | null }) => {
       return await fetchNotificationsV2({
-        limit: "10",
+        limit: "30",
         pageParam,
         headers,
       });


### PR DESCRIPTION
## Issue
- Sentry issue `6529-FRONTEND-EF` reports an N+1 API call pattern on `/notifications`.
- Marking the active account's notifications as read also invalidated the aggregate query for every other connected account, causing an unnecessary concurrent `v2/notifications?limit=1` fan-out.
- The server prefetched 10 notifications while the client queried 30, so React Query hydration could not reuse the server result.

## Fix
- Keep connected-account unread counts cached when a read mutation only affects the active account.
- Match the server notification prefetch size and query key to the client's 30-item query.

## Changes
- Narrow `invalidateNotifications` to active identity notification queries.
- Preserve the normal polling cadence for other connected accounts.
- Align the authenticated SSR prefetch key and request size with the client infinite query.
- Add regression coverage for both cache invalidation scope and the hydration query key.

## Validation
- `git diff --check`
- Focused Jest execution was attempted, but this isolated worktree has no installed `node_modules` and stopped before Jest with `cross-env: command not found`.
- Pull request CI is the executable validation gate for this branch.

## Risk
- Level: Low
- Why: The change only narrows a cache invalidation that cannot affect non-active JWTs and aligns an existing prefetch with the existing client page size. Cursor pagination, retry behavior, auth guards, proxy guards, and infinite scrolling are unchanged.
- Rollback: Revert the commit to restore the previous invalidation scope and 10-item server prefetch.

## Review Notes
- Verify that active-account unread state still refreshes through `IDENTITY_NOTIFICATIONS`.
- Verify that non-active connected accounts continue updating through their existing 15-second polling query.
- Verify that the server and client notification query keys remain identical for hydration.