### PR TITLE
Remove native border from profile curation switch controls

### DIFF
--- a/__tests__/components/user/waves/UserPageProfileWaveShared.test.tsx
+++ b/__tests__/components/user/waves/UserPageProfileWaveShared.test.tsx
@@ -48,6 +48,7 @@ describe("OfficialWaveSummary", () => {
       name: "Profile wave switch controls",
     });
 
+    expect(controls).toHaveClass("tw-border-0", "tw-p-0");
     expect(
       within(controls).getByRole("button", { name: "Switch wave" })
     ).toBeInTheDocument();

--- a/components/user/waves/UserPageProfileWaveShared.tsx
+++ b/components/user/waves/UserPageProfileWaveShared.tsx
@@ -227,7 +227,7 @@ export function OfficialWaveSummary({
               <span className="tw-text-xs sm:tw-text-sm">Add post</span>
             </button>
           )}
-          <fieldset className="tw-no-scrollbar tw-col-span-full tw-row-start-3 tw-mt-2 tw-w-full tw-overflow-x-auto lg:tw-mt-0 lg:tw-w-auto lg:tw-overflow-visible">
+          <fieldset className="tw-no-scrollbar tw-col-span-full tw-row-start-3 tw-mx-0 tw-mb-0 tw-mt-2 tw-w-full tw-min-w-0 tw-overflow-x-auto tw-border-0 tw-p-0 lg:tw-mt-0 lg:tw-w-auto lg:tw-overflow-visible">
             <legend className="tw-sr-only">Profile wave switch controls</legend>
             <div className="tw-flex tw-w-max tw-items-center tw-gap-2 lg:tw-w-auto lg:tw-justify-end">
               <div className="tw-flex tw-w-auto tw-flex-shrink-0 tw-items-center tw-gap-0.5 tw-rounded-lg tw-border tw-border-solid tw-border-white/10 tw-bg-white/5 tw-p-0.5 tw-shadow-[0_12px_30px_rgba(0,0,0,0.18)]">


### PR DESCRIPTION
## Issue
- The profile Curation owner controls ("Switch wave", "Switch curation", and "Unset") were surrounded by an unintended square white frame.

## Fix
- Reset the browser-native fieldset border, padding, margin, and minimum-width chrome.
- Preserve the semantic fieldset/legend grouping, the intended rounded segmented-control surface, and existing focus outlines.

## Changes
- Added scoped Tailwind reset utilities to the profile wave switch-controls fieldset.
- Added a regression assertion for the fieldset border and padding reset.

## Validation
- `6529 run test __tests__/components/user/waves/UserPageProfileWaveShared.test.tsx --runInBand` — 3 tests passed.
- `6529 run lint:changed` — passed.
- `6529 run typecheck:changed` — passed.
- `6529 run check:changed` — passed.
- `6529 run react-doctor:diff` — 100/100 on the touched files before commit.
- Browser review at mobile and desktop widths confirmed the native border/padding reset and no page-level horizontal overflow.
- Manually exercised by the requester with the frontend running against the staging API.

## Risk
- Level: Low
- Why: Styling-only, frontend-local reset on one existing semantic fieldset; no API, data, routing, dependency, or backend changes.
- Rollback: Revert the single commit to restore the previous browser-native fieldset styling.

## Review Notes
- The inner subtle rounded control-group border remains intentional; only the outer native fieldset frame is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the profile-wave controls layout by removing unnecessary spacing, borders, and minimum-width constraints.
  * Prevented unwanted scrollbar display within the controls area.

* **Tests**
  * Added coverage confirming the controls group uses the updated border and padding styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->