### PR TITLE
Fix staging search checks

### DIFF
--- a/tests/social/search-waves-readonly.spec.ts
+++ b/tests/social/search-waves-readonly.spec.ts
@@ -189,7 +189,7 @@ async function firstVisible(locator: Locator) {
 
 async function openHeaderSearch(page: Page) {
   const searchButton = await firstVisible(
-    page.getByRole("button", { exact: true, name: "Search" })
+    page.getByRole("button", { name: /^Search(?: 6529)?$/ })
   );
   await searchButton.click();
   const searchInput = page.locator("#header-search-input");
@@ -365,7 +365,7 @@ test.describe("Search and wave-detail read-only coverage @surface @medium @large
 
     await searchInput.fill(GLOBAL_SEARCH_QUERY);
     const waveScoreResult = page
-      .getByRole("link", { name: GLOBAL_SEARCH_RESULT })
+      .getByRole("option", { name: GLOBAL_SEARCH_RESULT })
       .first();
     await expect(waveScoreResult).toBeVisible({
       timeout: NAVIGATION_TIMEOUT_MS,
@@ -380,7 +380,7 @@ test.describe("Search and wave-detail read-only coverage @surface @medium @large
     await expect(reopenedInput).toBeVisible();
     await reopenedInput.fill(GLOBAL_SEARCH_QUERY);
     await page
-      .getByRole("link", { name: GLOBAL_SEARCH_RESULT })
+      .getByRole("option", { name: GLOBAL_SEARCH_RESULT })
       .first()
       .click();
 

--- a/tests/surfaces/core-surfaces.spec.ts
+++ b/tests/surfaces/core-surfaces.spec.ts
@@ -38,7 +38,7 @@ async function openWaveScoreFromSearch(page: Page, searchButton: Locator) {
   const searchInput = page.locator("#header-search-input");
   await expect(searchInput).toBeVisible();
   await searchInput.fill("wave score");
-  const result = page.getByRole("link", { name: WAVE_SCORE_RESULT }).first();
+  const result = page.getByRole("option", { name: WAVE_SCORE_RESULT }).first();
   await expect(result).toBeVisible();
   await result.click();
   await expectWaveScorePage(page);


### PR DESCRIPTION
## Issue
- The full Staging E2E suite fails after the global search redesign even though the Wave Score result is visibly present and navigable.
- The assertions still target the previous link role and one mobile helper requires the previous exact “Search” button name.

## Fix
- Align the read-only staging checks with the current accessible search semantics instead of changing working application behavior.

## Changes
- Locate global search results by their current option role.
- Accept the intentional desktop/mobile search labels “Search” and “Search 6529”.

## Validation
- Focused Playwright run: 4 passed, 2 project-gated skips across desktop and mobile Chromium.
- Tight uncommitted lint passed.
- Changed-file typecheck passed.
- Diff check passed.

## Risk
- Level: Low
- Why: Test-only locator alignment; no production application code changes.
- Rollback: Revert the single commit if search semantics change again.

## Review Notes
- Staging artifacts show “Wave Score — About • Network & Reputation” present as an option. The failure is assertion drift, not a missing user-facing result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated search-related test coverage to support optional branding in the header search button.
  * Improved validation of Wave Score search suggestions by targeting search result options.
  * Applied the updated result selection checks across global search and surface navigation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->