### PR TITLE
Polish Subscription Minting information cards

### DIFF
--- a/components/about/About.tsx
+++ b/components/about/About.tsx
@@ -53,7 +53,7 @@ export default function About({ section }: { readonly section: AboutSection }) {
           <AboutContentsDropdown
             className={
               section === AboutSection.SUBSCRIPTIONS
-                ? "max-sm:!tw-top-2 max-sm:-tw-mt-14 max-sm:tw-mb-0 max-sm:tw-py-1"
+                ? "max-md:!tw-top-0 max-sm:-tw-mt-14 max-sm:tw-mb-0 max-sm:tw-py-1"
                 : undefined
             }
             currentSection={section}

--- a/components/about/AboutSubscriptions.tsx
+++ b/components/about/AboutSubscriptions.tsx
@@ -47,7 +47,7 @@ const OVERVIEW_BENEFITS: readonly OverviewBenefit[] = [
   {
     icon: faEarthAmericas,
     iconClassName: "tw-text-[#8f5cff]",
-    iconWrapperClassName: "tw-bg-[#7000ff]/10",
+    iconWrapperClassName: "tw-bg-[#7000ff]/20",
     messageKey: "about.subscriptions.overview.awayFromComputer",
   },
   {
@@ -162,7 +162,7 @@ function Overview({ locale }: { readonly locale: SupportedLocale }) {
         <OverviewRule
           title={m(locale, "about.subscriptions.overview.notMintpass.title")}
         >
-          <ul className="tw-m-0 tw-space-y-2 tw-pl-5 tw-text-base tw-leading-7 tw-text-iron-300 marker:tw-text-primary-300 sm:tw-space-y-3">
+          <ul className="tw-m-0 tw-space-y-2 tw-pl-5 tw-text-sm tw-leading-6 tw-text-iron-400 marker:tw-text-iron-600">
             <li>
               {m(locale, "about.subscriptions.overview.notMintpass.choice")}
             </li>
@@ -184,7 +184,7 @@ function Overview({ locale }: { readonly locale: SupportedLocale }) {
         <OverviewRule
           title={m(locale, "about.subscriptions.overview.regularMinting.title")}
         >
-          <ul className="tw-m-0 tw-space-y-2 tw-pl-5 tw-text-base tw-leading-7 tw-text-iron-300 marker:tw-text-primary-300 sm:tw-space-y-3">
+          <ul className="tw-m-0 tw-space-y-2 tw-pl-5 tw-text-sm tw-leading-6 tw-text-iron-400 marker:tw-text-iron-600">
             <li>
               {m(locale, "about.subscriptions.overview.regularMinting.normal")}
             </li>
@@ -209,11 +209,11 @@ function OverviewRule({
   readonly title: string;
 }) {
   return (
-    <div className={`${SUBSCRIPTIONS_PANEL_CLASS} tw-p-4 sm:tw-p-8`}>
-      <h3 className="tw-m-0 tw-text-base tw-font-medium tw-text-iron-100 sm:tw-text-lg">
+    <div className={`${SUBSCRIPTIONS_PANEL_CLASS} tw-p-4 sm:tw-p-6`}>
+      <h3 className="tw-m-0 tw-text-base tw-font-medium tw-leading-6 tw-text-iron-100">
         {title}
       </h3>
-      <div className="tw-mt-4 sm:tw-mt-5">{children}</div>
+      <div className="tw-mt-3">{children}</div>
     </div>
   );
 }

--- a/components/about/AboutSubscriptionsReference.tsx
+++ b/components/about/AboutSubscriptionsReference.tsx
@@ -383,7 +383,7 @@ function RemoteMinting({ locale }: { readonly locale: SupportedLocale }) {
       className="tw-border-0 tw-border-t tw-border-solid tw-border-white/5 tw-px-1 tw-py-6 sm:tw-px-2 sm:tw-py-10"
     >
       <div className="tw-flex tw-items-center tw-gap-3 sm:tw-gap-4">
-        <span className="tw-flex tw-size-10 tw-items-center tw-justify-center tw-rounded-full tw-bg-[#7000ff]/10 tw-text-lg tw-text-[#8f5cff] sm:tw-size-12 sm:tw-text-xl">
+        <span className="tw-flex tw-size-10 tw-items-center tw-justify-center tw-rounded-full tw-bg-[#7000ff]/20 tw-text-lg tw-text-[#8f5cff] sm:tw-size-12 sm:tw-text-xl">
           <FontAwesomeIcon aria-hidden="true" icon={faEarthAmericas} />
         </span>
         <h2


### PR DESCRIPTION
## Issue
- The two Overview information panels were visually louder and roomier than the benefit cards above them.
- The Remote Minting accent circle was difficult to distinguish on the black page background.
- The About navigation retained a 64px sticky offset at tablet-sized mobile breakpoints.

## Fix
- Align the informational list typography with the established benefit-card body style, strengthen the purple accent perceptually, and remove the sub-desktop sticky offset for this page.

## Changes
- Use 14px/24px `iron-400` list text with muted markers in both informational panels.
- Reduce the panels' desktop padding and heading spacing.
- Increase the repeated Remote Minting icon background from 10% to 20% purple.
- Keep the Subscription Minting contents navigation at the top across the full sub-desktop range.

## Validation
- `./bin/6529 run react-doctor:diff` — 100/100, no issues.
- `./bin/6529 run test --testPathPatterns=__tests__/components/about/AboutSubscriptions.test.tsx --runInBand` — 4 tests passed.
- `./bin/6529 run check:changed` — changed-file typecheck and lint passed; the final repository-wide Knip scan reports existing unused operational scripts/exports outside this diff.
- Browser review at 1280px, 700px, and 390px: no horizontal overflow; sticky wrapper measured at `top: 0` at both tested sub-desktop widths.
- Contrast checks: information text is 6.48:1 on its panel; the purple icon is 4.75:1 on its accent circle.

## Risk
- Level: Low
- Why: Tailwind-only presentation changes in the Subscription Minting page; no data, auth, minting, or navigation behavior changes.
- Rollback: Revert the single commit.

## Review Notes
- Please focus on the Overview hierarchy, the Remote Minting accent visibility, and the sticky dropdown at widths below 768px.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive positioning for the subscriptions section on smaller and medium-sized screens.
  * Refined subscription overview spacing, typography, bullet styling, and panel layout for better readability.
  * Increased visual emphasis for remote minting and Earth-related benefit icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->